### PR TITLE
Gas mixers will now function with empty inputs, if they are told to ignore that input

### DIFF
--- a/code/modules/atmospherics/components/omni_devices/mixer.dm
+++ b/code/modules/atmospherics/components/omni_devices/mixer.dm
@@ -109,6 +109,8 @@
 	var/transfer_moles_max = INFINITY
 
 	for (var/datum/omni_port/P in inputs)
+		if(!P.concentration)
+			continue
 		transfer_moles += (set_flow_rate*P.concentration/P.air.volume)*P.air.total_moles
 		transfer_moles_max = min(transfer_moles_max, calculate_transfer_moles(P.air, output.air, delta, (output && output.network && output.network.volume) ? output.network.volume : 0))
 	transfer_moles = between(0, transfer_moles, transfer_moles_max)


### PR DESCRIPTION
Current situation:
- If you have a gas mixer with two inputs.
- Input 1 is empty, input 2 has a gas.
- Input 1 concentration is 0%, input 2 is 100%

-> The mixer will not operate because of zero gas on the 'unused' input 1.

This is because `transfer_moles_max` becomes zero, and then on line 136:
`transfer_moles = between(0, transfer_moles, transfer_moles_max)` 
is
`transfer_moles = between(0, transfer_moles, 0)` 
which is always zero.

This PR makes the mixer ignore inputs with concentration set to zero when it processes. So in the above scenario it will pump input 2 to 100% of its ability, only caring about input 2 pressure and output pressure.