### PR TITLE
Fixes a small null check in jobban code.

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -119,7 +119,7 @@ SUBSYSTEM_DEF(jobs)
 
 /datum/controller/subsystem/jobs/proc/guest_jobbans(var/job)
 	var/datum/job/j = get_by_title(job)
-	if (j.guestbanned)
+	if(istype(j) && j.guestbanned)
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
This is a bit of a bandaid. It seems like jobban checks are used for channels as well, so it tries to look up `guestbanned` on some jobs that don't exist.