### PR TITLE
Lowers default area security.

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -75,10 +75,9 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	has_gravity = 0
 	area_flags = AREA_FLAG_EXTERNAL | AREA_FLAG_IS_NOT_PERSISTENT
 	ambience = list('sound/ambience/ambispace1.ogg','sound/ambience/ambispace2.ogg','sound/ambience/ambispace3.ogg','sound/ambience/ambispace4.ogg','sound/ambience/ambispace5.ogg')
-	secure = FALSE
 	show_starlight = TRUE
 
-area/space/atmosalert()
+/area/space/atmosalert()
 	return
 
 /area/space/fire_alert()
@@ -132,6 +131,7 @@ area/space/atmosalert()
 
 /area/security
 	req_access = list(access_sec_doors)
+	secure = TRUE
 
 /area/security/brig
 	name = "\improper Security - Brig"

--- a/code/game/area/area_access.dm
+++ b/code/game/area/area_access.dm
@@ -1,6 +1,6 @@
 /area
 	var/list/req_access = list()
-	var/secure = TRUE    // unsecure areas will have doors between them use access diff; secure ones use union.
+	var/secure = FALSE    // unsecure areas will have doors between them use access diff; secure ones use union.
 
 // Given two areas, find the minimal req_access needed such that (return value) + (area access) >= (other area access) and vice versa
 /proc/req_access_diff(area/first, area/second)


### PR DESCRIPTION
Not sure if this is desirable, but may be the better default setting. The current one is a bit bay-centric.

To explain what it does: if you have a door wholly contained in a `secure` area, it will require the area's access to be opened. If it's not in a `secure` area, it will require no access (assuming that you already satisfied the area's access requirements by virtue of you being in the area).

Likewise, if you have a door between two areas, if at least one of them is `secure`, then you'll need to meet all the access requirements of both areas to open it. If neither is `secure`, it will instead compute the access requirements that one area has but the other does not, and only check those.