### PR TITLE
Fixes #30.

### DIFF
--- a/code/modules/admin/buildmode/buttons.dm
+++ b/code/modules/admin/buildmode/buttons.dm
@@ -6,9 +6,9 @@
 	icon = 'icons/misc/buildmode.dmi'
 	var/datum/click_handler/build_mode/host
 
-/obj/effect/bmode/Initialize()
-	. = ..()
-	src.host = loc
+/obj/effect/bmode/Initialize(mapload, _host)
+	. = ..(mapload)
+	host = _host
 
 /obj/effect/bmode/Destroy()
 	host = null

--- a/code/modules/admin/buildmode/click_handler.dm
+++ b/code/modules/admin/buildmode/click_handler.dm
@@ -20,7 +20,7 @@
 
 	build_buttons = list()
 	for(var/button_type in subtypesof(/obj/effect/bmode))
-		var/obj/effect/bmode/build_button = new button_type(src)
+		var/obj/effect/bmode/build_button = new button_type(null, src)
 		build_buttons += build_button
 	StartTimer()
 	current_build_mode.Selected()


### PR DESCRIPTION
From an incorrect Initialize autoconvertion; if the first argument to `New` is not an atom, it will be lost.