### PR TITLE
Adds Discord button

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -94,6 +94,7 @@ var/list/gamemode_cache = list()
 	var/banappeals
 	var/wikiurl
 	var/forumurl
+	var/discordurl
 	var/githuburl
 	var/issuereporturl
 
@@ -433,6 +434,9 @@ var/list/gamemode_cache = list()
 
 				if ("forumurl")
 					config.forumurl = value
+
+				if ("discordurl")
+					config.discordurl = value
 
 				if ("githuburl")
 					config.githuburl = value

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -192,6 +192,9 @@ GUEST_BAN
 ## forum address
 # FORUMURL http://example.com
 
+## discord server permanent invite address
+# DISCORDURL https://discord.gg/example
+
 ## Wiki address
 # WIKIURL http://example.com
 

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -3,48 +3,60 @@
 	set name = "Wiki"
 	set desc = "Visit the wiki."
 	set hidden = 1
-	if( config.wikiurl )
+	if(config.wikiurl)
 		if(alert("This will open the wiki in your browser. Are you sure?",,"Yes","No")=="No")
 			return
 		send_link(src, config.wikiurl)
 	else
-		to_chat(src, "<span class='warning'>The wiki URL is not set in the server configuration.</span>")
+		to_chat(src, SPAN_WARNING("The wiki URL is not set in the server configuration."))
 	return
 
 /client/verb/github()
 	set name = "GitHub"
 	set desc = "Visit the GitHub repository."
 	set hidden = 1
-	if( config.githuburl )
+	if(config.githuburl)
 		if(alert("This will open GitHub in your browser. Are you sure?",,"Yes","No")=="No")
 			return
 		send_link(src, config.githuburl)
 	else
-		to_chat(src, "<span class='warning'>The github URL is not set in the server configuration.</span>")
+		to_chat(src, SPAN_WARNING("The github URL is not set in the server configuration."))
 	return
 
 /client/verb/bugreport()
 	set name = "Bug Report"
 	set desc = "Visit the GitHub repository to report an issue or bug."
 	set hidden = 1
-	if( config.issuereporturl )
+	if(config.issuereporturl)
 		if(alert("This will open GitHub in your browser. Are you sure?",,"Yes","No")=="No")
 			return
 		send_link(src, config.issuereporturl)
 	else
-		to_chat(src, "<span class='warning'>The issue report URL is not set in the server configuration.</span>")
+		to_chat(src, SPAN_WARNING("The issue report URL is not set in the server configuration."))
 	return
 
 /client/verb/forum()
 	set name = "Forum"
 	set desc = "Visit the forum."
 	set hidden = 1
-	if( config.forumurl )
+	if(config.forumurl)
 		if(alert("This will open the forum in your browser. Are you sure?",,"Yes","No")=="No")
 			return
 		send_link(src, config.forumurl)
 	else
-		to_chat(src, "<span class='warning'>The forum URL is not set in the server configuration.</span>")
+		to_chat(src, SPAN_WARNING("The forum URL is not set in the server configuration."))
+	return
+
+/client/verb/discord()
+	set name = "Discord"
+	set desc = "Visit the Discord server."
+	set hidden = 1
+	if(config.discordurl)
+		if(alert("This will open the Discord invition link in your browser. Are you sure?",,"Yes","No")=="No")
+			return
+		send_link(src, config.discordurl)
+	else
+		to_chat(src, SPAN_WARNING("The Discord server URL is not set in the server configuration."))
 	return
 
 #define RULES_FILE "config/rules.html"


### PR DESCRIPTION
Adds the Discord server button for general use. Can be helpful for downstream servers which use only discord server as replacement for forum. Here probably should be a special button for it, but I'll add it later.