### PR TITLE
Prevents fake connection spam from crashing the server 

### DIFF
--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -1,32 +1,51 @@
 //Blocks an attempt to connect before even creating our client datum thing.
-world/IsBanned(key,address,computer_id)
-	if(ckey(key) in admin_datums)
+/world/IsBanned(key, address, computer_id, type)
+	var/static/key_cache = list()
+	if(type == "world")
+		return ..()
+
+	if(key_cache[key] >= world.time)
+		return list("reason"="concurrent connection attempts", "desc"="You are attempting to connect too fast. Try again.")
+	key_cache[key] = world.time + 10 //This proc shouldn't be runtiming. But if it does, then the expiry time will cover it to ensure genuine connection attempts don't get trapped in limbo.
+
+	var/ckeytext = ckey(key)
+
+	if(ckeytext in admin_datums)
+		key_cache[key] = 0
 		return ..()
 
 	//Guest Checking
 	if(!config.guests_allowed && IsGuestKey(key))
 		log_access("Failed Login: [key] - Guests not allowed")
 		message_admins("<span class='notice'>Failed Login: [key] - Guests not allowed</span>")
+		key_cache[key] = 0
 		return list("reason"="guest", "desc"="\nReason: Guests not allowed. Please sign in with a byond account.")
+
+	var/client/C = GLOB.ckey_directory[ckeytext]
+	//If this isn't here, then topic call spam will result in all clients getting kicked with a connecting too fast error.
+	if (C && ckeytext == C.ckey && address == C.address && computer_id == C.computer_id)
+		key_cache[key] = 0
+		return
 
 	if(config.ban_legacy_system)
 
 		//Ban Checking
-		. = CheckBan( ckey(key), computer_id, address )
+		. = CheckBan(ckeytext, computer_id, address)
 		if(.)
 			log_access("Failed Login: [key] [computer_id] [address] - Banned [.["reason"]]")
 			message_admins("<span class='notice'>Failed Login: [key] id:[computer_id] ip:[address] - Banned [.["reason"]]</span>")
+			key_cache[key] = 0
 			return .
 
+		key_cache[key] = 0
 		return ..()	//default pager ban stuff
 
 	else
 
-		var/ckeytext = ckey(key)
-
 		if(!establish_db_connection())
 			error("Ban database connection failure. Key [ckeytext] not checked")
 			log_misc("Ban database connection failure. Key [ckeytext] not checked")
+			key_cache[key] = 0
 			return
 
 		var/failedcid = 1
@@ -63,10 +82,12 @@ world/IsBanned(key,address,computer_id)
 
 			var/desc = "\nReason: You, or another user of this computer or connection ([pckey]) is banned from playing here. The ban reason is:\n[reason]\nThis ban was applied by [ackey] on [bantime], [expires]"
 
+			key_cache[key] = 0
 			return list("reason"="[bantype]", "desc"="[desc]")
 
 		if (failedcid)
 			message_admins("[key] has logged in with a blank computer id in the ban check.")
 		if (failedip)
 			message_admins("[key] has logged in with a blank ip in the ban check.")
+		key_cache[key] = 0
 		return ..()	//default pager ban stuff

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -10,7 +10,7 @@
 
 	var/ckeytext = ckey(key)
 
-	if(ckeytext in admin_datums)
+	if(admin_datums[ckeytext])
 		key_cache[key] = 0
 		return ..()
 

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -4,9 +4,9 @@
 	if(type == "world")
 		return ..()
 
-	if(key_cache[key] >= world.time)
+	if(key_cache[key] >= REALTIMEOFDAY)
 		return list("reason"="concurrent connection attempts", "desc"="You are attempting to connect too fast. Try again.")
-	key_cache[key] = world.time + 10 //This proc shouldn't be runtiming. But if it does, then the expiry time will cover it to ensure genuine connection attempts don't get trapped in limbo.
+	key_cache[key] = REALTIMEOFDAY + 10 //This proc shouldn't be runtiming. But if it does, then the expiry time will cover it to ensure genuine connection attempts don't get trapped in limbo.
 
 	var/ckeytext = ckey(key)
 


### PR DESCRIPTION
This PR patches one of several major DoS vectors that were exploited during the first few weeks of January of this year. Spamming connection packets on a server that has the DB enabled without proper mitigations such as what's contained in this PR results in the server eventually crashing due to the sheer amount of DB queries that can be generated in a single tick without this. Since there's a few mainstream servers that still don't have this patched, I won't be detailing reproduction steps for crashing servers with the exploit in question.

This PR is based off of the following TGStation PRs: tgstation/tgstation#48529 and tgstation/tgstation#48583