### PR TITLE
Ghosts can't detach IVs anymore.

### DIFF
--- a/code/game/objects/structures/iv_drip.dm
+++ b/code/game/objects/structures/iv_drip.dm
@@ -143,8 +143,8 @@
 	if(!attached)
 		return
 		
-	if(!usr.Adjacent(attached))
-		to_chat(usr, "<span class='warning'>You are too far away from the [attached]!</span>")
+	if(!CanPhysicallyInteractWith(usr, src))
+		to_chat(usr, SPAN_NOTICE("You're in no condition to do that!"))
 		return
 		
 	if(!usr.skill_check(SKILL_MEDICAL, SKILL_BASIC))


### PR DESCRIPTION
Prevents ghosts from using the detach IV verb.