### PR TITLE
Fixes rotation bug with mismatched icon sizes between mob icon and overlays

### DIFF
--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -227,7 +227,6 @@
 
 	var/sexybits_location	//organ tag where they are located if they can be kicked for increased pain
 
-	var/list/prone_overlay_offset = list(0, 0) // amount to shift overlays when lying
 	var/job_skill_buffs = list()				// A list containing jobs (/datum/job), with values the extra points that job recieves.
 
 	var/list/descriptors = list(


### PR DESCRIPTION
This is a port of [this bugfix](https://github.com/Baystation12/Baystation12/pull/27961) on Bay

Please check out [this post on that PR](https://github.com/Baystation12/Baystation12/pull/27961#issuecomment-577855426) for images of the effect.

I don't know if this affects the current downstream. But it may be helpful for future species.