### PR TITLE
Fix midnight rollovers not rolling over

### DIFF
--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -106,7 +106,8 @@ GLOBAL_VAR_INIT(midnight_rollovers, 0)
 GLOBAL_VAR_INIT(rollovercheck_last_timeofday, 0)
 /proc/update_midnight_rollover()
 	if (world.timeofday < GLOB.rollovercheck_last_timeofday) //TIME IS GOING BACKWARDS!
-		return GLOB.midnight_rollovers++
+		GLOB.midnight_rollovers += 1
+	GLOB.rollovercheck_last_timeofday = world.timeofday
 	return GLOB.midnight_rollovers
 
 //Increases delay as the server gets more overloaded,


### PR DESCRIPTION
Fixes REALTIMEOFDAY not rolling over the first time it's called after midnight.