### PR TITLE
Converts unarmed attacks to decls, adds per-species natural attack tracking.

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -32,8 +32,8 @@
 	var/showed_msg = FALSE
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		var/datum/unarmed_attack/attack = H.get_unarmed_attack(src)
-		if(attack)
+		var/decl/natural_attack/attack = H.get_unarmed_attack(src)
+		if(istype(attack))
 			attack.show_attack(H, src, H.zone_sel.selecting, 1)
 			showed_msg = TRUE
 	if(!showed_msg)

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -143,9 +143,8 @@
 	var/mob/living/carbon/human/attacker = G.assailant
 	var/mob/living/carbon/human/target = G.affecting
 
-	var/datum/unarmed_attack/attack = attacker.get_unarmed_attack(target, BP_EYES)
-
-	if(!attack)
+	var/decl/natural_attack/attack = attacker.get_unarmed_attack(target, BP_EYES)
+	if(!istype(attack))
 		return
 	for(var/obj/item/protection in list(target.head, target.wear_mask, target.glasses))
 		if(protection && (protection.body_parts_covered & EYES))

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -98,7 +98,7 @@
 
 	var/stance_damage = 0 //Whether this mob's ability to stand has been affected
 
-	var/datum/unarmed_attack/default_attack	//default unarmed attack
+	var/decl/natural_attack/default_attack	//default unarmed attack
 
 	var/obj/machinery/machine_visual //machine that is currently applying visual effects to this mob. Only used for camera monitors currently.
 	var/shock_stage

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -1,7 +1,7 @@
 var/global/list/sparring_attack_cache = list()
 
 //Species unarmed attacks
-/datum/unarmed_attack
+/decl/natural_attack
 	var/attack_verb = list("attacks")	// Empty hand hurt intent verb.
 	var/attack_noun = list("fist")
 	var/damage = 0						// Extra empty hand attack damage.
@@ -11,27 +11,22 @@ var/global/list/sparring_attack_cache = list()
 	var/sharp = 0
 	var/edge = 0
 	var/delay = 0
-
 	var/deal_halloss
-	var/sparring_variant_type = /datum/unarmed_attack/light_strike
-
+	var/sparring_variant_type = /decl/natural_attack/light_strike
 	var/eye_attack_text
 	var/eye_attack_text_victim
-
 	var/attack_name = "fist"
+	var/list/usable_with_limbs = list(BP_L_HAND, BP_R_HAND)
 
-/datum/unarmed_attack/proc/get_damage_type()
+/decl/natural_attack/proc/get_damage_type()
 	if(deal_halloss)
 		return PAIN
 	return BRUTE
 
-/datum/unarmed_attack/proc/get_sparring_variant()
-	if(sparring_variant_type)
-		if(!sparring_attack_cache[sparring_variant_type])
-			sparring_attack_cache[sparring_variant_type] = new sparring_variant_type()
-		return sparring_attack_cache[sparring_variant_type]
+/decl/natural_attack/proc/get_sparring_variant()
+	return sparring_variant_type && decls_repository.get_decl(sparring_variant_type)
 
-/datum/unarmed_attack/proc/is_usable(var/mob/living/carbon/human/user, var/mob/target, var/zone)
+/decl/natural_attack/proc/is_usable(var/mob/living/carbon/human/user, var/mob/target, var/zone)
 	if(user.restrained())
 		return 0
 
@@ -46,10 +41,10 @@ var/global/list/sparring_attack_cache = list()
 
 	return 0
 
-/datum/unarmed_attack/proc/get_unarmed_damage()
+/decl/natural_attack/proc/get_unarmed_damage()
 	return damage
 
-/datum/unarmed_attack/proc/apply_effects(var/mob/living/carbon/human/user,var/mob/living/carbon/human/target,var/attack_damage,var/zone)
+/decl/natural_attack/proc/apply_effects(var/mob/living/carbon/human/user,var/mob/living/carbon/human/target,var/attack_damage,var/zone)
 
 	if(target.stat == DEAD)
 		return
@@ -101,7 +96,7 @@ var/global/list/sparring_attack_cache = list()
 	if(istype(C) && prob(10))
 		C.leave_evidence(user)
 
-/datum/unarmed_attack/proc/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
+/decl/natural_attack/proc/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
 	var/msg = "\The [user] [pick(attack_verb)] \the [target]"
 	var/obj/item/organ/external/affecting = istype(target) && zone && target.get_organ(zone)
 	if(affecting)
@@ -112,7 +107,7 @@ var/global/list/sparring_attack_cache = list()
 		user.visible_message(SPAN_DANGER("[msg]!"))
 		playsound(user.loc, attack_sound, 25, 1, -1)
 
-/datum/unarmed_attack/proc/handle_eye_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target)
+/decl/natural_attack/proc/handle_eye_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target)
 	var/obj/item/organ/internal/eyes/eyes = target.internal_organs_by_name[BP_EYES]
 	if(eyes)
 		eyes.take_internal_damage(rand(3,4), 1)
@@ -122,10 +117,10 @@ var/global/list/sparring_attack_cache = list()
 		return
 	user.visible_message("<span class='danger'>[user] attempts to press \his [eye_attack_text] into [target]'s eyes, but they don't have any!</span>")
 
-/datum/unarmed_attack/proc/damage_flags()
+/decl/natural_attack/proc/damage_flags()
 	return (src.sharp? DAM_SHARP : 0)|(src.edge? DAM_EDGE : 0)
 
-/datum/unarmed_attack/bite
+/decl/natural_attack/bite
 	attack_verb = list("bit")
 	attack_sound = 'sound/weapons/bite.ogg'
 	shredding = 0
@@ -133,13 +128,14 @@ var/global/list/sparring_attack_cache = list()
 	sharp = 0
 	edge = 0
 	attack_name = "bite"
+	usable_with_limbs = list(BP_HEAD)
 
-/datum/unarmed_attack/bite/sharp
+/decl/natural_attack/bite/sharp
 	attack_verb = list("bit", "chomped")
 	sharp = 1
 	edge = 1
 
-/datum/unarmed_attack/bite/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone)
+/decl/natural_attack/bite/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone)
 
 	if(istype(user.wear_mask, /obj/item/clothing/mask/muzzle))
 		return 0
@@ -150,7 +146,7 @@ var/global/list/sparring_attack_cache = list()
 		return 0 //how do you bite yourself in the head?
 	return 1
 
-/datum/unarmed_attack/punch
+/decl/natural_attack/punch
 	attack_verb = list("punched")
 	attack_noun = list("fist")
 	eye_attack_text = "fingers"
@@ -158,7 +154,7 @@ var/global/list/sparring_attack_cache = list()
 	damage = 0
 	attack_name = "punch"
 
-/datum/unarmed_attack/punch/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
+/decl/natural_attack/punch/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
 
 	var/obj/item/organ/external/affecting = istype(target) && zone && target.get_organ(zone)
 	if(!affecting)
@@ -202,14 +198,15 @@ var/global/list/sparring_attack_cache = list()
 	else
 		user.visible_message("<span class='danger'>[user] [pick("punched", "threw a punch at", "struck", "slammed their [pick(attack_noun)] into")] [target]'s [organ]!</span>") //why do we have a separate set of verbs for lying targets?
 
-/datum/unarmed_attack/kick
+/decl/natural_attack/kick
 	attack_verb = list("kicked", "kicked", "kicked", "kneed")
 	attack_noun = list("kick", "kick", "kick", "knee strike")
 	attack_sound = "swing_hit"
 	damage = 0
 	attack_name = "kick"
+	usable_with_limbs = list(BP_L_FOOT, BP_R_FOOT)
 
-/datum/unarmed_attack/kick/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone)
+/decl/natural_attack/kick/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone)
 	if(!(zone in list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT, BP_GROIN)))
 		return 0
 
@@ -223,13 +220,13 @@ var/global/list/sparring_attack_cache = list()
 
 	return 0
 
-/datum/unarmed_attack/kick/get_unarmed_damage(var/mob/living/carbon/human/user)
+/decl/natural_attack/kick/get_unarmed_damage(var/mob/living/carbon/human/user)
 	var/obj/item/clothing/shoes = user.shoes
 	if(!istype(shoes))
 		return damage
 	return damage + (shoes ? shoes.force : 0)
 
-/datum/unarmed_attack/kick/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
+/decl/natural_attack/kick/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
 
 	var/obj/item/organ/external/affecting = istype(target) && zone && target.get_organ(zone)
 	if(!affecting)
@@ -242,14 +239,15 @@ var/global/list/sparring_attack_cache = list()
 		if(3 to 4)	user.visible_message("<span class='danger'>[user] [pick(attack_verb)] [target] in \his [organ]!</span>")
 		if(5)		user.visible_message("<span class='danger'>[user] landed a strong [pick(attack_noun)] against [target]'s [organ]!</span>")
 
-/datum/unarmed_attack/stomp
+/decl/natural_attack/stomp
 	attack_verb = list("stomped on")
 	attack_noun = list("stomp")
 	attack_sound = "swing_hit"
 	damage = 0
 	attack_name = "stomp"
+	usable_with_limbs = list(BP_L_FOOT, BP_R_FOOT)
 
-/datum/unarmed_attack/stomp/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone)
+/decl/natural_attack/stomp/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone)
 	if(!istype(target))
 		return 0
 
@@ -266,11 +264,11 @@ var/global/list/sparring_attack_cache = list()
 
 		return 0
 
-/datum/unarmed_attack/stomp/get_unarmed_damage(var/mob/living/carbon/human/user)
+/decl/natural_attack/stomp/get_unarmed_damage(var/mob/living/carbon/human/user)
 	var/obj/item/clothing/shoes = user.shoes
 	return damage + (shoes ? shoes.force : 0)
 
-/datum/unarmed_attack/stomp/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
+/decl/natural_attack/stomp/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
 
 	var/obj/item/organ/external/affecting = istype(target) && zone && target.get_organ(zone)
 	if(!affecting)
@@ -291,7 +289,7 @@ var/global/list/sparring_attack_cache = list()
 				"<span class='danger'>[user] stomped down hard onto [target]'s [organ][pick("", "with their [shoe_text]")]!</span>",
 				"<span class='danger'>[user] slammed \his [shoe_text] down onto [target]'s [organ]!</span>"))
 
-/datum/unarmed_attack/light_strike
+/decl/natural_attack/light_strike
 	deal_halloss = 3
 	attack_noun = list("tap","light strike")
 	attack_verb = list("tapped", "lightly struck")
@@ -301,3 +299,4 @@ var/global/list/sparring_attack_cache = list()
 	sharp = 0
 	edge = 0
 	attack_name = "light hit"
+	usable_with_limbs = list(BP_L_HAND, BP_R_HAND, BP_L_FOOT, BP_R_FOOT)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -257,12 +257,13 @@
 		if(I_HURT)
 			var/dealt_damage = harm_intent_damage
 			var/harm_verb = response_harm
-			if(ishuman(M) && M.species)
-				var/datum/unarmed_attack/attack = M.get_unarmed_attack(src)
-				dealt_damage = attack.damage <= dealt_damage ? dealt_damage : attack.damage
-				harm_verb = pick(attack.attack_verb)
-				if(attack.sharp || attack.edge)
-					adjustBleedTicks(dealt_damage)
+			if(ishuman(M))
+				var/decl/natural_attack/attack = M.get_unarmed_attack(src)
+				if(istype(attack))
+					dealt_damage = attack.damage <= dealt_damage ? dealt_damage : attack.damage
+					harm_verb = pick(attack.attack_verb)
+					if(attack.sharp || attack.edge)
+						adjustBleedTicks(dealt_damage)
 
 			adjustBruteLoss(dealt_damage)
 			M.visible_message("<span class='warning'>[M] [harm_verb] \the [src]!</span>")

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -71,6 +71,9 @@
 	var/hatch_state = 0
 	var/stage = 0
 	var/cavity = 0
+
+	var/list/unarmed_attacks
+
 	var/atom/movable/applied_pressure
 	var/atom/movable/splinted
 
@@ -100,8 +103,12 @@
 		replaced(owner)
 		sync_colour_to_human(owner)
 	get_icon()
-
 	slowdown = species.get_slowdown(owner)
+	if(species)
+		for(var/attack_type in species.unarmed_attacks)
+			var/decl/natural_attack/attack = decls_repository.get_decl(attack_type)
+			if(istype(attack) && (organ_tag in attack.usable_with_limbs))
+				LAZYADD(unarmed_attacks, attack_type)
 
 /obj/item/organ/external/Destroy()
 

--- a/code/modules/species/outsider/shadow.dm
+++ b/code/modules/species/outsider/shadow.dm
@@ -9,7 +9,7 @@
 	bone_material = null
 	skin_material = null
 
-	unarmed_attacks = list(/datum/unarmed_attack/claws/strong, /datum/unarmed_attack/bite/sharp)
+	unarmed_attacks = list(/decl/natural_attack/claws/strong, /decl/natural_attack/bite/sharp)
 	darksight_range = 8
 	darksight_tint = DARKTINT_GOOD
 	siemens_coefficient = 0

--- a/code/modules/species/outsider/starlight.dm
+++ b/code/modules/species/outsider/starlight.dm
@@ -46,7 +46,7 @@
 	blood_color = "#ffff00"
 	flesh_color = "#ffff00"
 
-	unarmed_attacks = list(/datum/unarmed_attack/punch/starborn)
+	unarmed_attacks = list(/decl/natural_attack/punch/starborn)
 
 	cold_discomfort_level = 300
 	cold_discomfort_strings = list("You feel your fire dying out...",

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -74,8 +74,8 @@
 	// Combat vars.
 	var/total_health = 200                   // Point at which the mob will enter crit.
 	var/list/unarmed_attacks = list(           // Possible unarmed attacks that the mob will use in combat,
-		/datum/unarmed_attack,
-		/datum/unarmed_attack/bite
+		/decl/natural_attack,
+		/decl/natural_attack/bite
 		)
 
 	var/list/natural_armour_values            // Armour values used if naked.
@@ -324,11 +324,6 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 	if(!breathing_organ && has_organ[BP_LUNGS])
 		breathing_organ = BP_LUNGS
 
-	var/list/unarmed_types = unarmed_attacks.Copy()
-	unarmed_attacks = list()
-	for(var/u_type in unarmed_types)
-		unarmed_attacks += new u_type()
-
 	// Modify organ lists if necessary.
 	if(islist(override_organ_types))
 		for(var/ltag in override_organ_types)
@@ -505,12 +500,12 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 	if(!ignore_antag && H.mind && !player_is_antag(H.mind))
 		return 0
 
-	for(var/datum/unarmed_attack/attack in unarmed_attacks)
-		if(!attack.is_usable(H))
+	for(var/attack_type in unarmed_attacks)
+		var/decl/natural_attack/attack = decls_repository.get_decl(attack_type)
+		if(!istype(attack) || !attack.is_usable(H))
 			continue
 		if(attack.shredding)
 			return 1
-
 	return 0
 
 // Called in life() when the mob has no client.

--- a/code/modules/species/species_attack.dm
+++ b/code/modules/species/species_attack.dm
@@ -1,4 +1,4 @@
-/datum/unarmed_attack/bite/sharp //eye teeth
+/decl/natural_attack/bite/sharp //eye teeth
 	attack_verb = list("bit", "chomped on")
 	attack_sound = 'sound/weapons/bite.ogg'
 	shredding = 0
@@ -6,14 +6,15 @@
 	edge = 1
 	attack_name = "sharp bite"
 
-/datum/unarmed_attack/diona
+/decl/natural_attack/diona
 	attack_verb = list("lashed", "bludgeoned")
 	attack_noun = list("tendril")
 	eye_attack_text = "a tendril"
 	eye_attack_text_victim = "a tendril"
 	attack_name = "tendrils"
+	usable_with_limbs = list(BP_L_HAND, BP_R_HAND, BP_L_FOOT, BP_R_FOOT)
 
-/datum/unarmed_attack/claws
+/decl/natural_attack/claws
 	attack_verb = list("scratched", "clawed", "slashed")
 	attack_noun = list("claws")
 	eye_attack_text = "claws"
@@ -23,12 +24,13 @@
 	sharp = 1
 	edge = 1
 	attack_name = "claws"
+	usable_with_limbs = list(BP_L_HAND, BP_R_HAND)
 	var/blocked_by_gloves = TRUE
 
-/datum/unarmed_attack/claws/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone)
+/decl/natural_attack/claws/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone)
 	return (!user.gloves || !blocked_by_gloves)
 
-/datum/unarmed_attack/claws/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
+/decl/natural_attack/claws/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
 	var/obj/item/organ/external/affecting = istype(target) && zone && target.get_organ(zone)
 	if(!affecting)
 		return ..()
@@ -65,39 +67,40 @@
 						))
 				if(5)		user.visible_message("<span class='danger'>[user] tears \his [pick(attack_noun)] [pick("deep into", "into", "across")] [target]'s [affecting.name]!</span>")
 
-/datum/unarmed_attack/claws/strong
+/decl/natural_attack/claws/strong
 	attack_verb = list("slashed")
 	damage = 5
 	shredding = 1
 	attack_name = "strong claws"
 
-/datum/unarmed_attack/claws/strong/gloves
+/decl/natural_attack/claws/strong/gloves
 	blocked_by_gloves = FALSE
 
-/datum/unarmed_attack/bite/strong
+/decl/natural_attack/bite/strong
 	attack_verb = list("mauled")
 	damage = 8
 	shredding = 1
 	attack_name = "strong bite"
 
-/datum/unarmed_attack/slime_glomp
+/decl/natural_attack/slime_glomp
 	attack_verb = list("glomped")
 	attack_noun = list("body")
 	damage = 2
 	attack_name = "glomp"
+	usable_with_limbs = list(BP_CHEST, BP_GROIN)
 
-/datum/unarmed_attack/slime_glomp/apply_effects(var/mob/living/carbon/human/user,var/mob/living/carbon/human/target,var/armour,var/attack_damage,var/zone)
+/decl/natural_attack/slime_glomp/apply_effects(var/mob/living/carbon/human/user,var/mob/living/carbon/human/target,var/armour,var/attack_damage,var/zone)
 	..()
 	user.apply_stored_shock_to(target)
 
-/datum/unarmed_attack/stomp/weak
+/decl/natural_attack/stomp/weak
 	attack_verb = list("jumped on")
 	attack_name = "weak stomp"
 
-/datum/unarmed_attack/stomp/weak/get_unarmed_damage()
+/decl/natural_attack/stomp/weak/get_unarmed_damage()
 	return damage
 
-/datum/unarmed_attack/stomp/weak/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
+/decl/natural_attack/stomp/weak/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
 	var/obj/item/organ/external/affecting = istype(target) && zone && target.get_organ(zone)
 	if(affecting)
 		user.visible_message(SPAN_WARNING("\The [user] jumped up and down on \the [target]'s [affecting.name]!"))
@@ -105,12 +108,13 @@
 		user.visible_message(SPAN_WARNING("\The [user] jumped up and down on \the [target]!"))
 	playsound(user.loc, attack_sound, 25, 1, -1)
 
-/datum/unarmed_attack/tail
+/decl/natural_attack/tail
 	attack_verb = list ("bludgeoned", "lashed", "smacked", "whapped")
 	attack_noun = list ("tail")
 	attack_name = "tail swipe"
+	usable_with_limbs = list(BP_GROIN)
 
-/datum/unarmed_attack/tail/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone) //ensures that you can't tail someone in the skull
+/decl/natural_attack/tail/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone) //ensures that you can't tail someone in the skull
 
 	if(!(zone in list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT, BP_GROIN)))
 
@@ -131,7 +135,7 @@
 
 	return 0
 
-/datum/unarmed_attack/tail/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
+/decl/natural_attack/tail/show_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone, var/attack_damage)
 
 	var/obj/item/organ/external/affecting = istype(target) && zone && target.get_organ(zone)
 	if(!affecting)
@@ -148,7 +152,7 @@
 
 		if(8)		user.visible_message("<span class='danger'>[user] landed a heavy blow with their [pick(attack_noun)] against [target]'s [organ]!</span>")
 
-/datum/unarmed_attack/nabber
+/decl/natural_attack/nabber
 	attack_verb = list("mauled", "slashed", "struck", "pierced")
 	attack_noun = list("forelimb")
 	damage = 8
@@ -159,25 +163,26 @@
 	eye_attack_text = "a forelimb"
 	eye_attack_text_victim = "a forelimb"
 	attack_name = "forelimb slash"
+	usable_with_limbs = list(BP_L_HAND, BP_R_HAND)
 
-/datum/unarmed_attack/punch/weak
+/decl/natural_attack/punch/weak
 	attack_verb = list("swiped", "smacked", "smecked")
 	attack_name = "smek"
 
-/datum/unarmed_attack/punch/starborn
+/decl/natural_attack/punch/starborn
 	attack_verb = list("scorched", "burned", "fried")
 	shredding = 1
 	attack_name = "starborn strike"
 
-/datum/unarmed_attack/punch/starborn/get_damage_type()
+/decl/natural_attack/punch/starborn/get_damage_type()
 	return BURN
 
-/datum/unarmed_attack/bite/venom
+/decl/natural_attack/bite/venom
 	attack_verb = list("bit", "sank their fangs into")
 	attack_sound = 'sound/weapons/bite.ogg'
 	damage = 5
 	delay = 120
 	attack_name = "venomous bite"
 
-/datum/unarmed_attack/bite/venom/get_damage_type()
+/decl/natural_attack/bite/venom/get_damage_type()
 	return TOX

--- a/code/modules/species/station/golem.dm
+++ b/code/modules/species/station/golem.dm
@@ -6,7 +6,7 @@
 	deform = 'icons/mob/human_races/species/golem/body.dmi'
 	husk_icon = 'icons/mob/human_races/species/golem/husk.dmi'
 
-	unarmed_attacks = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch)
+	unarmed_attacks = list(/decl/natural_attack/stomp, /decl/natural_attack/kick, /decl/natural_attack/punch)
 	species_flags = SPECIES_FLAG_NO_PAIN | SPECIES_FLAG_NO_SCAN | SPECIES_FLAG_NO_POISON
 	spawn_flags = SPECIES_IS_RESTRICTED
 	siemens_coefficient = 0

--- a/code/modules/species/station/monkey.dm
+++ b/code/modules/species/station/monkey.dm
@@ -22,7 +22,7 @@
 	death_message = "lets out a faint chimper as it collapses and stops moving..."
 	tail = "chimptail"
 
-	unarmed_attacks = list(/datum/unarmed_attack/bite, /datum/unarmed_attack/claws, /datum/unarmed_attack/punch)
+	unarmed_attacks = list(/decl/natural_attack/bite, /decl/natural_attack/claws, /decl/natural_attack/punch)
 	inherent_verbs = list(/mob/living/proc/ventcrawl)
 	hud_type = /datum/hud_data/monkey
 	meat_type = /obj/item/chems/food/snacks/meat/monkey

--- a/code/modules/species/station/station.dm
+++ b/code/modules/species/station/station.dm
@@ -2,7 +2,7 @@
 	name = SPECIES_HUMAN
 	name_plural = "Humans"
 	primitive_form = SPECIES_MONKEY
-	unarmed_attacks = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch, /datum/unarmed_attack/bite)
+	unarmed_attacks = list(/decl/natural_attack/stomp, /decl/natural_attack/kick, /decl/natural_attack/punch, /decl/natural_attack/bite)
 	description = "Humans are so big, and strong, and smart, and rich sometimes. Oooooh."
 	min_age = 17
 	max_age = 100


### PR DESCRIPTION
This was sorta kinda in previously, not sure where it went.
Re-implements https://github.com/NebulaSS13/NebulaFeatureRequests/issues/6.
- Unarmed attacks are now properly singletons and are passed around and tracked as types except when needed for actual processing.
- The state of your bodyparts and the associated species will determine which unarmed attacks you have available.