### PR TITLE
Makes concrete walls break down to local base turf

### DIFF
--- a/code/game/turfs/simulated/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types.dm
@@ -141,6 +141,9 @@
 /turf/simulated/wall/voxshuttle/attackby()
 	return
 
+/turf/simulated/wall/concrete
+	floor_type = null
+
 /turf/simulated/wall/concrete/Initialize(var/ml)
 	. = ..(ml,MAT_CONCRETE)
 

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -196,7 +196,7 @@
 	reinf_material = null
 	update_connections(1)
 
-	ChangeTurf(floor_type)
+	ChangeTurf(floor_type || get_base_turf_by_area(src))
 
 /turf/simulated/wall/ex_act(severity)
 	switch(severity)

--- a/code/modules/overmap/exoplanets/planet_types/garbage.dm
+++ b/code/modules/overmap/exoplanets/planet_types/garbage.dm
@@ -218,6 +218,7 @@
 //Artifact containment lab
 /turf/simulated/wall/containment
 	paint_color = COLOR_GRAY20
+	floor_type = /turf/simulated/floor/fixed/alium/airless
 
 /turf/simulated/wall/containment/Initialize(var/ml)
 	. = ..(ml, MAT_CONCRETE, MAT_ALIENALLOY)


### PR DESCRIPTION
Special alium lab walls break down to alium plating
Makes it so if floor type for wall is null, it gets base turf for its loc instead.
