### PR TITLE
Outlet injectors to radio components.

### DIFF
--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -156,14 +156,14 @@ obj/machinery/computer/air_control/Destroy()
 		refreshing_input = TRUE
 		input_flow_setting = input("What would you like to set the rate limit to?", "Set Volume", input_flow_setting) as num|null
 		input_flow_setting = between(0, input_flow_setting, ATMOS_DEFAULT_VOLUME_PUMP+500)
-		signal.data = list ("tag" = input_tag, "set_volume_rate" = "[input_flow_setting]")
+		signal.data = list ("tag" = input_tag, "set_volume_rate" = input_flow_setting)
 		. = 1
 
 	if(href_list["in_set_max"])
 		input_info = null
 		refreshing_input = TRUE
 		input_flow_setting = ATMOS_DEFAULT_VOLUME_PUMP+500
-		signal.data = list ("tag" = input_tag, "set_volume_rate" = "[input_flow_setting]")
+		signal.data = list ("tag" = input_tag, "set_volume_rate" = input_flow_setting)
 		. = 1
 
 	if(href_list["out_refresh_status"])

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -188,30 +188,6 @@ Buildable meters
 		"You hear ratchet.")
 	qdel(src)	// remove the pipe item
 
-/obj/item/pipe/injector
-	name = "Injector"
-	desc = "Passively injects air into its surroundings. Has a valve attached to it that can control flow rate."
-	connect_types =  CONNECT_TYPE_REGULAR|CONNECT_TYPE_FUEL
-	icon = 	'icons/atmos/injector.dmi'
-	icon_state = "map_injector"
-	constructed_path = /obj/machinery/atmospherics/unary/outlet_injector
-	pipe_class = PIPE_CLASS_UNARY
-
-	var/frequency
-	var/id
-
-/obj/item/pipe/injector/Initialize(mapload, obj/machinery/atmospherics/P)
-	. = ..(mapload)
-	var/obj/machinery/atmospherics/unary/outlet_injector/I = P
-	if(!I)
-		return
-	frequency = I.frequency
-	id = I.id
-	set_dir(I.dir)
-	name = I.name
-	desc = I.desc
-	connect_types = I.connect_types
-
 /obj/item/machine_chassis
 	var/build_type
 

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -1082,9 +1082,7 @@
 /area/map_template/merc_shuttle/rear)
 "bN" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
-	frequency = 1441;
-	id = "fuel_in";
-	id_tag = null;
+	id_tag = "fuel_in";
 	use_power = 0
 	},
 /obj/machinery/sparker{

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -4632,8 +4632,7 @@
 	icon_state = "map_injector";
 	dir = 8;
 	use_power = 1;
-	frequency = 1441;
-	id = "n2_in"
+	id_tag = "n2_in"
 	},
 /mob/living/simple_animal/hostile/carp,
 /turf/simulated/floor/reinforced/airless,
@@ -4935,9 +4934,8 @@
 	},
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
-	frequency = 1441;
 	icon_state = "map_injector";
-	id = "n2_in";
+	id_tag = "n2_in";
 	use_power = 1
 	},
 /obj/effect/floor_decal/corner/white/diagonal,
@@ -5834,8 +5832,7 @@
 	icon_state = "map_injector";
 	dir = 8;
 	use_power = 1;
-	frequency = 1441;
-	id = "n2_in"
+	id_tag = "n2_in"
 	},
 /turf/simulated/floor/airless,
 /area/ship/scrap/maintenance/atmos)

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -2648,9 +2648,8 @@
 "iH" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
-	frequency = 1441;
 	icon_state = "map_injector";
-	id = "d_air_in";
+	id_tag = "d_air_in";
 	use_power = 1
 	},
 /turf/simulated/floor/reinforced/airmix,
@@ -2746,9 +2745,8 @@
 "iU" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
-	frequency = 1441;
 	icon_state = "map_injector";
-	id = "d_o2_in";
+	id_tag = "d_o2_in";
 	use_power = 1
 	},
 /turf/simulated/floor/reinforced/oxygen,
@@ -2895,9 +2893,8 @@
 "jr" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
-	frequency = 1441;
 	icon_state = "map_injector";
-	id = "d_n2_in";
+	id_tag = "d_n2_in";
 	use_power = 1
 	},
 /turf/simulated/floor/reinforced/nitrogen,

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -1414,9 +1414,8 @@
 "dA" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
-	frequency = 1441;
 	icon_state = "map_injector";
-	id = "n2_in";
+	id_tag = "n2_in";
 	use_power = 1
 	},
 /turf/simulated/floor/airless,

--- a/maps/away/icarus/icarus-1.dmm
+++ b/maps/away/icarus/icarus-1.dmm
@@ -2274,9 +2274,8 @@
 "hp" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
-	frequency = 1441;
 	icon_state = "map_injector";
-	id = "h2_in";
+	id_tag = "h2_in";
 	pixel_y = 1;
 	use_power = 1
 	},
@@ -2377,9 +2376,8 @@
 "hC" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
-	frequency = 1441;
 	icon_state = "map_injector";
-	id = "h2_in";
+	id_tag = "h2_in";
 	pixel_y = 1;
 	use_power = 1
 	},

--- a/maps/away/magshield/magshield.dmm
+++ b/maps/away/magshield/magshield.dmm
@@ -1054,9 +1054,8 @@
 "cG" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
-	frequency = 1441;
 	icon_state = "map_injector";
-	id = "n2o_in";
+	id_tag = "n2o_in";
 	pixel_y = 1;
 	use_power = 1
 	},
@@ -2396,9 +2395,8 @@
 "fX" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
-	frequency = 1441;
 	icon_state = "map_injector";
-	id = "d_n2_in";
+	id_tag = "d_n2_in";
 	use_power = 1
 	},
 /turf/simulated/floor/airless,

--- a/maps/away/unishi/unishi-1.dmm
+++ b/maps/away/unishi/unishi-1.dmm
@@ -511,11 +511,10 @@
 /turf/simulated/floor,
 /area/unishi/engineroom)
 "bt" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
+/obj/machinery/atmospherics/unary/outlet_injector/engine{
 	dir = 1;
-	frequency = 1438;
 	icon_state = "map_injector";
-	id = "unishi_fuel_in";
+	id_tag = "unishi_fuel_in";
 	use_power = 1
 	},
 /turf/simulated/floor,

--- a/maps/away/unishi/unishi-2.dmm
+++ b/maps/away/unishi/unishi-2.dmm
@@ -2854,11 +2854,10 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
 	},
-/obj/machinery/atmospherics/unary/outlet_injector{
+/obj/machinery/atmospherics/unary/outlet_injector/engine{
 	dir = 1;
-	frequency = 1438;
 	icon_state = "map_injector";
-	id = "unishi_cooling_in";
+	id_tag = "unishi_cooling_in";
 	name = "Coolant Injector";
 	pixel_y = 1;
 	power_rating = 30000;

--- a/maps/bearcat/bearcat-2.dmm
+++ b/maps/bearcat/bearcat-2.dmm
@@ -3535,8 +3535,7 @@
 	icon_state = "map_injector";
 	dir = 8;
 	use_power = 1;
-	frequency = 1441;
-	id = "n2_in"
+	id_tag = "n2_in"
 	},
 /turf/simulated/floor/reinforced/oxygen,
 /area/ship/bearcat/maintenance/atmos)
@@ -3829,9 +3828,8 @@
 	},
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
-	frequency = 1441;
 	icon_state = "map_injector";
-	id = "n2_in";
+	id_tag = "n2_in";
 	use_power = 1
 	},
 /obj/effect/floor_decal/corner/white/diagonal,
@@ -4110,8 +4108,7 @@
 	icon_state = "map_injector";
 	dir = 8;
 	use_power = 1;
-	frequency = 1441;
-	id = "n2_in"
+	id_tag = "n2_in"
 	},
 /turf/simulated/floor/reinforced/nitrogen,
 /area/ship/bearcat/maintenance/atmos)

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -1017,8 +1017,7 @@
 "ce" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/machinery/atmospherics/unary/outlet_injector{
-	frequency = 1441;
-	id = "cn2n"
+	id_tag = "cn2n"
 	},
 /turf/simulated/floor/reinforced/nitrogen,
 /area/map_template/colony/atmospherics)
@@ -1280,8 +1279,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/unary/outlet_injector{
-	frequency = 1441;
-	id = "co2n"
+	id_tag = "co2n"
 	},
 /turf/simulated/floor/reinforced/oxygen,
 /area/map_template/colony/atmospherics)
@@ -1297,8 +1295,7 @@
 	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/unary/outlet_injector{
-	frequency = 1441;
-	id = "cco2n"
+	id_tag = "cco2n"
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/map_template/colony/atmospherics)
@@ -6375,8 +6372,7 @@
 	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/unary/outlet_injector{
-	frequency = 1441;
-	id = "cn2n"
+	id_tag = "cn2n"
 	},
 /turf/simulated/floor/reinforced/nitrogen,
 /area/map_template/colony/atmospherics)


### PR DESCRIPTION
Need to test at least the build code.

Suggested map migration procedure for downstreams: run the following regex search-replace over all .dmm files:
```
(/obj/machinery/atmospherics/unary/outlet_injector\{\n(?:\t.*\n)*\tid)( =) -> $1_tag$2
(/obj/machinery/atmospherics/unary/outlet_injector\{(?:\n\t.*)*)(;)?\n\tfrequency = 1441(;)? -> $1$3
(/obj/machinery/atmospherics/unary/outlet_injector)(\{(?:\n\t.*)*)(;)?\n\tfrequency = 1438(;)? -> $1/engine$2$4
```
Then search `/obj/machinery/atmospherics/unary/outlet_injector\{\n(\t.*\n)*\tfrequency =`. If any hits are found, either make a subtype (similar to the energy one) with that frequency, or take the `id_tag` var, search it, and replace the frequencies of any attached machines with `1441` (making sure that machines with frequencies set by subtype are handled properly).