### PR TITLE
Passive gates to radio components.

### DIFF
--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -166,7 +166,7 @@
 	return machine.volume_rate
 
 /decl/public_access/public_variable/volume_rate/write_var(obj/machinery/atmospherics/unary/outlet_injector/machine, new_value)
-	new_value = sanitize_integer(new_value, 0, machine.air_contents.volume, machine.volume_rate)
+	new_value = Clamp(new_value, 0, machine.air_contents.volume)
 	. = ..()
 	if(.)
 		machine.volume_rate = new_value

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -36,7 +36,7 @@ exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 26 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto uses" 'goto '
-exactly 468 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 466 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 6 "atom/New uses" '^/(obj|atom|area|mob|turf).*/New\('
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 


### PR DESCRIPTION
They usually aren't mapped in a way that uses radio, so this isn't a major change.

Suggested map migration procedure: your map is unlikely to need migration. To see if it does, search
```
/obj/machinery/atmospherics/binary/passive_gate.*\{\n(?:\t.*\n)*\t(?:id|frequency) =
```
If you do get any hits, you will need to replace `id` with `id_tag`, remove the frequency var, and change the typepath of the instance to something like
```
/obj/machinery/atmospherics/binary/passive_gate/radio_enabled
	uncreated_component_parts = list(
		/obj/item/stock_parts/radio/receiver/buildable,
		/obj/item/stock_parts/radio/transmitter/on_event/buildable,
	)
```
After that, you should look up what machine the passive gate is talking to, and ensure it is still able to communicate (default settings are `PUMP_FREQ` and `ATMOS_FILTER_ATMOSIA`; you may also have to check individual keys to make sure everything is still valid). The most likely other device to communicate with passive gates is the button, and these settings will probably work with buttons.