### PR TITLE
Makes lights use construct decls.

### DIFF
--- a/code/game/machinery/_machines_base/machine_construction/wall_frame_simple.dm
+++ b/code/game/machinery/_machines_base/machine_construction/wall_frame_simple.dm
@@ -1,0 +1,50 @@
+// Similar to the wall frame setup, but does not require circuit boards.
+
+/decl/machine_construction/wall_frame/panel_closed/simple
+	needs_board = null
+	active_state = /decl/machine_construction/wall_frame/panel_closed/simple
+	open_state = /decl/machine_construction/wall_frame/panel_open/simple
+	diconnected_state = /decl/machine_construction/wall_frame/no_wires/simple
+	bottom_state = /decl/machine_construction/default/deconstructed
+	newly_built_state = /decl/machine_construction/wall_frame/no_wires/simple
+
+/decl/machine_construction/wall_frame/panel_closed/simple/state_is_valid(obj/machinery/machine)
+	return !machine.panel_open
+
+/decl/machine_construction/wall_frame/panel_open/simple
+	needs_board = null
+	active_state = /decl/machine_construction/wall_frame/panel_closed/simple
+	open_state = /decl/machine_construction/wall_frame/panel_open/simple
+	diconnected_state = /decl/machine_construction/wall_frame/no_wires/simple
+	bottom_state = /decl/machine_construction/default/deconstructed
+	newly_built_state = /decl/machine_construction/wall_frame/no_wires/simple
+
+/decl/machine_construction/wall_frame/panel_open/simple/state_is_valid(obj/machinery/machine)
+	return machine.panel_open
+
+/decl/machine_construction/wall_frame/panel_open/simple/mechanics_info()
+	. = list()
+	. += "Use a screwdriver to close the panel."
+	. += "Use a parts replacer to upgrade some parts."
+	. += "Insert a new part to install it."
+	. += "Remove installed parts with a wrench."
+	. += "Use a wirecutter to disconnect the wires and expose the frame."
+
+/decl/machine_construction/wall_frame/no_wires/simple
+	needs_board = null
+	active_state = /decl/machine_construction/wall_frame/panel_closed/simple
+	open_state = /decl/machine_construction/wall_frame/panel_open/simple
+	diconnected_state = /decl/machine_construction/wall_frame/no_wires/simple
+	bottom_state = /decl/machine_construction/default/deconstructed
+	newly_built_state = /decl/machine_construction/wall_frame/no_wires/simple
+
+/decl/machine_construction/wall_frame/no_wires/simple/state_is_valid(obj/machinery/machine)
+	return machine.panel_open
+
+/decl/machine_construction/wall_frame/no_wires/simple/mechanics_info()
+	. = list()
+	. += "Add wires to hook up the machine."
+	. += "Use a parts replacer to upgrade some parts."
+	. += "Insert a new part to install it."
+	. += "Remove installed parts with a wrench."
+	. += "Use a crowbar to pry the frame off the wall."

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -84,11 +84,23 @@
 	desc = "Used for building lights."
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "tube-construct-item"
-	build_machine_type = /obj/machinery/light_construct
+	build_machine_type = /obj/machinery/light/buildable
 	reverse = 1
 
 /obj/item/frame/light/small
 	name = "small light fixture frame"
 	icon_state = "bulb-construct-item"
 	matter = list(MAT_STEEL = 2000)
-	build_machine_type = /obj/machinery/light_construct/small
+	build_machine_type = /obj/machinery/light/small/buildable
+
+/obj/item/frame/light/spot
+	name = "spotlight fixture frame"
+	icon_state = "tube-construct-item"
+	matter = list(MAT_STEEL = 4000, MAT_PLASTIC = 2000)
+	build_machine_type = /obj/machinery/light/spot/buildable
+
+/obj/item/frame/light/nav
+	name = "navigation light fixture frame"
+	icon_state = "tube-construct-item"
+	matter = list(MAT_STEEL = 4000, MAT_PLASTIC = 2000)
+	build_machine_type = /obj/machinery/light/navigation/buildable

--- a/code/modules/fabrication/designs/general/designs_engineering.dm
+++ b/code/modules/fabrication/designs/general/designs_engineering.dm
@@ -14,6 +14,12 @@
 /datum/fabricator_recipe/engineering/firealarm_kit
 	path = /obj/item/frame/fire_alarm/kit
 
+/datum/fabricator_recipe/engineering/spotlight
+	path = /obj/item/frame/light/spot
+
+/datum/fabricator_recipe/engineering/navlight
+	path = /obj/item/frame/light/nav
+
 /datum/fabricator_recipe/engineering/powermodule
 	path = /obj/item/module/power_control
 

--- a/maps/away/bearcat/bearcat-1.dmm
+++ b/maps/away/bearcat/bearcat-1.dmm
@@ -982,10 +982,7 @@
 /area/ship/scrap/broken2)
 "bX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/light_construct/small{
-	icon_state = "bulb-construct-stage1";
-	dir = 1
-	},
+/obj/item/frame/light/small,
 /turf/simulated/floor/usedup,
 /area/ship/scrap/broken2)
 "bY" = (

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -2301,9 +2301,7 @@
 	},
 /area/constructionsite/atmospherics)
 "hu" = (
-/obj/machinery/light_construct{
-	dir = 1
-	},
+/obj/item/frame/light,
 /turf/simulated/floor/airless,
 /area/constructionsite/medical)
 "hv" = (

--- a/maps/away/lost_supply_base/lost_supply_base.dmm
+++ b/maps/away/lost_supply_base/lost_supply_base.dmm
@@ -288,9 +288,7 @@
 /turf/simulated/floor/airless,
 /area/lost_supply_base)
 "aH" = (
-/obj/machinery/light_construct{
-	dir = 1
-	},
+/obj/item/frame/light,
 /turf/simulated/floor/airless,
 /area/lost_supply_base)
 "aI" = (
@@ -1100,9 +1098,7 @@
 /turf/space,
 /area/lost_supply_base/common)
 "cN" = (
-/obj/machinery/light_construct{
-	dir = 8
-	},
+/obj/item/frame/light,
 /turf/simulated/floor/airless,
 /area/lost_supply_base)
 "cO" = (
@@ -1122,9 +1118,7 @@
 /turf/simulated/wall,
 /area/lost_supply_base)
 "cR" = (
-/obj/machinery/light_construct{
-	dir = 8
-	},
+/obj/item/frame/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -1255,7 +1249,7 @@
 /turf/simulated/floor/airless,
 /area/lost_supply_base)
 "dl" = (
-/obj/machinery/light_construct,
+/obj/item/frame/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/airless,
 /area/lost_supply_base)

--- a/maps/away/magshield/magshield.dmm
+++ b/maps/away/magshield/magshield.dmm
@@ -2005,7 +2005,7 @@
 /turf/simulated/floor/airless,
 /area/magshield/north)
 "eO" = (
-/obj/machinery/light_construct/small,
+/obj/item/frame/light/small,
 /turf/simulated/floor/airless,
 /area/magshield/north)
 "eP" = (
@@ -2216,9 +2216,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/obj/machinery/light_construct{
-	dir = 8
-	},
+/obj/item/frame/light,
 /turf/simulated/floor/airless,
 /area/magshield/east)
 "fy" = (
@@ -2228,9 +2226,7 @@
 /turf/simulated/floor/airless,
 /area/magshield/east)
 "fz" = (
-/obj/machinery/light_construct{
-	dir = 4
-	},
+/obj/item/frame/light,
 /turf/simulated/floor/airless,
 /area/magshield/east)
 "fA" = (
@@ -2240,9 +2236,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/magshield/west)
 "fC" = (
-/obj/machinery/light_construct{
-	dir = 1
-	},
+/obj/item/frame/light,
 /turf/simulated/floor/tiled/dark,
 /area/magshield/west)
 "fD" = (
@@ -2262,9 +2256,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/magshield/west)
 "fF" = (
-/obj/machinery/light_construct{
-	dir = 1
-	},
+/obj/item/frame/light,
 /turf/simulated/floor/tiled,
 /area/magshield/west)
 "fG" = (
@@ -2493,9 +2485,7 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/machinery/light_construct{
-	dir = 8
-	},
+/obj/item/frame/light,
 /turf/simulated/floor/tiled,
 /area/magshield/west)
 "gn" = (
@@ -2554,9 +2544,7 @@
 /turf/simulated/floor/carpet/blue,
 /area/magshield/west)
 "gx" = (
-/obj/machinery/light_construct{
-	dir = 8
-	},
+/obj/item/frame/light,
 /turf/simulated/floor/airless,
 /area/magshield/east)
 "gy" = (
@@ -2856,9 +2844,7 @@
 /turf/simulated/floor/tiled,
 /area/magshield/west)
 "ho" = (
-/obj/machinery/light_construct{
-	dir = 8
-	},
+/obj/item/frame/light,
 /turf/simulated/floor/tiled/white,
 /area/magshield/west)
 "hp" = (
@@ -3016,9 +3002,7 @@
 /area/magshield/east)
 "hQ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light_construct{
-	dir = 4
-	},
+/obj/item/frame/light,
 /turf/simulated/floor/airless,
 /area/magshield/east)
 "hR" = (
@@ -3212,9 +3196,7 @@
 /turf/simulated/floor/airless,
 /area/magshield/east)
 "io" = (
-/obj/machinery/light_construct{
-	dir = 8
-	},
+/obj/item/frame/light,
 /turf/simulated/floor/tiled,
 /area/magshield/west)
 "ip" = (
@@ -3283,9 +3265,7 @@
 /turf/simulated/floor/tiled/white,
 /area/magshield/south)
 "iz" = (
-/obj/machinery/light_construct{
-	dir = 1
-	},
+/obj/item/frame/light,
 /turf/simulated/floor/tiled/white,
 /area/magshield/south)
 "iA" = (
@@ -3325,7 +3305,7 @@
 /turf/simulated/floor/tiled/white,
 /area/magshield/south)
 "iG" = (
-/obj/machinery/light_construct,
+/obj/item/frame/light,
 /turf/simulated/floor/tiled,
 /area/magshield/west)
 "iH" = (
@@ -3434,9 +3414,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light_construct{
-	dir = 4
-	},
+/obj/item/frame/light,
 /turf/simulated/floor/tiled,
 /area/magshield/south)
 "iW" = (
@@ -3936,9 +3914,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light_construct{
-	dir = 8
-	},
+/obj/item/frame/light,
 /turf/simulated/floor/tiled,
 /area/magshield/south)
 "ku" = (
@@ -4273,9 +4249,7 @@
 /turf/simulated/floor/tiled,
 /area/magshield/south)
 "lr" = (
-/obj/machinery/light_construct{
-	dir = 8
-	},
+/obj/item/frame/light,
 /turf/simulated/floor/tiled,
 /area/magshield/south)
 "ls" = (

--- a/maps/bearcat/bearcat-1.dmm
+++ b/maps/bearcat/bearcat-1.dmm
@@ -880,10 +880,7 @@
 /area/ship/bearcat/escape_port)
 "cc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/light_construct/small{
-	icon_state = "bulb-construct-stage1";
-	dir = 1
-	},
+/obj/item/frame/light/small,
 /turf/simulated/floor/plating,
 /area/ship/bearcat/broken2)
 "cd" = (

--- a/nebula.dme
+++ b/nebula.dme
@@ -726,6 +726,7 @@
 #include "code\game\machinery\_machines_base\machine_construction\item_chassis.dm"
 #include "code\game\machinery\_machines_base\machine_construction\tcomms.dm"
 #include "code\game\machinery\_machines_base\machine_construction\wall_frame.dm"
+#include "code\game\machinery\_machines_base\machine_construction\wall_frame_simple.dm"
 #include "code\game\machinery\_machines_base\stock_parts\_stock_parts.dm"
 #include "code\game\machinery\_machines_base\stock_parts\building_material.dm"
 #include "code\game\machinery\_machines_base\stock_parts\legacy_parts.dm"


### PR DESCRIPTION
Removes the intermediate frame machine as well.

The map fixes are really crude; I'm replacing deconstructed lights with light frames, basically. If that's undesirable, I can do something more sophisticated.

Note that lights require APC components, but light frames won't come with them. I can make them come with them, so long as light frames are moved to autolathe from stack recipes.