### PR TITLE
Makes turfs respect attack_hand and attackby returns

### DIFF
--- a/code/game/gamemodes/cult/cultify/de-cultify.dm
+++ b/code/game/gamemodes/cult/cultify/de-cultify.dm
@@ -2,5 +2,5 @@
 	if(istype(I, /obj/item/nullrod))
 		user.visible_message("<span class='notice'>\The [user] touches \the [src] with \the [I], and it shifts.</span>", "<span class='notice'>You touch \the [src] with \the [I], and it shifts.</span>")
 		ChangeTurf(/turf/unsimulated/wall)
-		return
-	..()
+		return TRUE
+	return ..()

--- a/code/game/gamemodes/endgame/supermatter_cascade/cascade_blob.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/cascade_blob.dm
@@ -74,6 +74,7 @@
 	playsound(src, 'sound/effects/supermatter.ogg', 50, 1)
 
 	Consume(user)
+	return TRUE
 
 /turf/unsimulated/wall/supermatter/attackby(obj/item/W, mob/living/user)
 	user.visible_message("<span class=\"warning\">\The [user] touches \a [W] to \the [src] as a silence fills the room...</span>",\
@@ -84,6 +85,7 @@
 
 	user.drop_from_inventory(W)
 	Consume(W)
+	return TRUE
 
 #define MayConsume(A) (istype(A) && A.simulated && !isobserver(A))
 

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -158,7 +158,7 @@
 	if(isCoil(thing) && can_build_cable(user))
 		var/obj/item/stack/cable_coil/coil = thing
 		coil.turf_place(src, user)
-		return
+		return TRUE
 	return ..()
 
 /turf/simulated/Initialize()

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -3,7 +3,7 @@
 		var/mob/living/carbon/human/H = user
 		var/obj/item/hand = H.hand ? H.organs_by_name[BP_L_HAND] : H.organs_by_name[BP_R_HAND]
 		if(hand && try_graffiti(H, hand))
-			return
+			return TRUE
 	. = ..()
 	
 /turf/simulated/floor/attackby(var/obj/item/C, var/mob/user)
@@ -15,7 +15,7 @@
 		return ..(C, user)
 
 	if(!(isScrewdriver(C) && flooring && (flooring.flags & TURF_REMOVE_SCREWDRIVER)) && try_graffiti(user, C))
-		return
+		return TRUE
 
 	if(flooring)
 		if(isCrowbar(C))
@@ -31,33 +31,33 @@
 			else
 				return
 			playsound(src, 'sound/items/Crowbar.ogg', 80, 1)
-			return
+			return TRUE
 		else if(isScrewdriver(C) && (flooring.flags & TURF_REMOVE_SCREWDRIVER))
 			if(broken || burnt)
 				return
 			to_chat(user, "<span class='notice'>You unscrew and remove the [flooring.descriptor].</span>")
 			make_plating(1)
 			playsound(src, 'sound/items/Screwdriver.ogg', 80, 1)
-			return
+			return TRUE
 		else if(isWrench(C) && (flooring.flags & TURF_REMOVE_WRENCH))
 			to_chat(user, "<span class='notice'>You unwrench and remove the [flooring.descriptor].</span>")
 			make_plating(1)
 			playsound(src, 'sound/items/Ratchet.ogg', 80, 1)
-			return
+			return TRUE
 		else if(istype(C, /obj/item/shovel) && (flooring.flags & TURF_REMOVE_SHOVEL))
 			to_chat(user, "<span class='notice'>You shovel off the [flooring.descriptor].</span>")
 			make_plating(1)
 			playsound(src, 'sound/items/Deconstruct.ogg', 80, 1)
-			return
+			return TRUE
 		else if(isCoil(C))
 			to_chat(user, "<span class='warning'>You must remove the [flooring.descriptor] first.</span>")
-			return
+			return TRUE
 	else
 
 		if(istype(C, /obj/item/stack))
 			if(broken || burnt)
 				to_chat(user, "<span class='warning'>This section is too damaged to support anything. Use a welder to fix the damage.</span>")
-				return
+				return TRUE
 			//first check, catwalk? Else let flooring do its thing
 			if(locate(/obj/structure/catwalk, src))
 				return
@@ -66,6 +66,7 @@
 				if (R.use(2))
 					playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 					new /obj/structure/catwalk(src)
+					return TRUE
 				return
 			var/obj/item/stack/S = C
 			var/decl/flooring/use_flooring
@@ -82,21 +83,22 @@
 			// Do we have enough?
 			if(use_flooring.build_cost && S.get_amount() < use_flooring.build_cost)
 				to_chat(user, "<span class='warning'>You require at least [use_flooring.build_cost] [S.name] to complete the [use_flooring.descriptor].</span>")
-				return
+				return TRUE
 			// Stay still and focus...
 			if(use_flooring.build_time && !do_after(user, use_flooring.build_time, src))
-				return
+				return TRUE
 			if(flooring || !S || !user || !use_flooring)
-				return
+				return TRUE
 			if(S.use(use_flooring.build_cost))
 				set_flooring(use_flooring)
 				playsound(src, 'sound/items/Deconstruct.ogg', 80, 1)
-				return
+			return TRUE
 		// Repairs and Deconstruction.
 		else if(isCrowbar(C))
 			if(broken || burnt)
 				playsound(src, 'sound/items/Crowbar.ogg', 80, 1)
 				visible_message("<span class='notice'>[user] has begun prying off the damaged plating.</span>")
+				. = TRUE
 				var/turf/T = GetBelow(src)
 				if(T)
 					T.visible_message("<span class='warning'>The ceiling above looks as if it's being pried off.</span>")
@@ -108,8 +110,6 @@
 					playsound(src, 'sound/items/Deconstruct.ogg', 80, 1)
 					if(T)
 						T.visible_message("<span class='danger'>The ceiling above has been pried off!</span>")
-			else
-				return
 			return
 		else if(isWelder(C))
 			var/obj/item/weldingtool/welder = C
@@ -121,24 +121,27 @@
 						icon_state = "plating"
 						burnt = null
 						broken = null
-					return
+						return TRUE
 				else
 					if(welder.remove_fuel(0, user))
 						playsound(src, 'sound/items/Welder.ogg', 80, 1)
 						visible_message("<span class='notice'>[user] has started melting the plating's reinforcements!</span>")
+						. = TRUE
 						if(do_after(user, 5 SECONDS) && welder.isOn() && welder_melt())
 							visible_message("<span class='warning'>[user] has melted the plating's reinforcements! It should be possible to pry it off.</span>")
 							playsound(src, 'sound/items/Welder.ogg', 80, 1)
-					return
+				return
 		else if(istype(C, /obj/item/gun/energy/plasmacutter) && (is_plating()) && !broken && !burnt)
 			var/obj/item/gun/energy/plasmacutter/cutter = C
 			if(!cutter.slice(user))
 				return ..()
 			playsound(src, 'sound/items/Welder.ogg', 80, 1)
 			visible_message("<span class='notice'>[user] has started slicing through the plating's reinforcements!</span>")
+			. = TRUE
 			if(do_after(user, 3 SECONDS) && welder_melt())
 				visible_message("<span class='warning'>[user] has sliced through the plating's reinforcements! It should be possible to pry it off.</span>")
 				playsound(src, 'sound/items/Welder.ogg', 80, 1)
+			return
 
 	return ..()
 

--- a/code/game/turfs/simulated/floor_static.dm
+++ b/code/game/turfs/simulated/floor_static.dm
@@ -31,7 +31,7 @@
 /turf/simulated/floor/fixed/alium/attackby(var/obj/item/C, var/mob/user)
 	if(isCrowbar(C))
 		to_chat(user, "<span class='notice'>There aren't any openings big enough to pry it away...</span>")
-		return
+		return TRUE
 	return ..()
 
 /turf/simulated/floor/fixed/alium/Initialize()

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -79,7 +79,7 @@
 			to_chat(user, "<span class='notice'>Constructing support lattice ...</span>")
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 			ReplaceWithLattice(R.material.type)
-		return
+			return TRUE
 
 	if (istype(C, /obj/item/stack/tile/floor))
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
@@ -90,10 +90,9 @@
 			qdel(L)
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 			ChangeTurf(/turf/simulated/floor/airless, keep_air = TRUE)
-			return
 		else
 			to_chat(user, "<span class='warning'>The plating is going to need some support.</span>")
-	return
+		return TRUE
 
 
 // Ported from unstable r355

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -100,9 +100,7 @@
 			return 0
 		do_pull_click(user, src)
 
-	.=handle_hand_interception(user)
-	if (!.)
-		return 1
+	. = handle_hand_interception(user)
 
 /turf/proc/handle_hand_interception(var/mob/user)
 	var/datum/extension/turf_hand/THE
@@ -118,11 +116,12 @@
 	if(Adjacent(user))
 		attack_hand(user)
 
-turf/attackby(obj/item/W, mob/user)
+/turf/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/storage))
 		var/obj/item/storage/S = W
 		if(S.use_to_pickup && S.collection_mode)
 			S.gather_all(src, user)
+		return TRUE
 	return ..()
 
 /turf/Enter(atom/movable/mover, atom/forget)

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -160,19 +160,19 @@ var/list/mining_floors = list()
 		geologic_data.UpdateNearbyArtifactInfo(src)
 		var/obj/item/core_sampler/C = W
 		C.sample_item(src, user)
-		return
+		return TRUE
 
 	if (istype(W, /obj/item/depth_scanner))
 		var/obj/item/depth_scanner/C = W
 		C.scan_atom(user, src)
-		return
+		return TRUE
 
 	if (istype(W, /obj/item/measuring_tape))
 		var/obj/item/measuring_tape/P = W
 		user.visible_message("<span class='notice'>\The [user] extends [P] towards [src].</span>","<span class='notice'>You extend [P] towards [src].</span>")
 		if(do_after(user,10, src))
 			to_chat(user, "<span class='notice'>\The [src] has been excavated to a depth of [excavation_level]cm.</span>")
-		return
+		return TRUE
 
 	if (istype(W, /obj/item/pickaxe))
 		if(!istype(user.loc, /turf))
@@ -184,6 +184,7 @@ var/list/mining_floors = list()
 		last_act = world.time
 
 		playsound(user, P.drill_sound, 20, 1)
+		. = TRUE
 
 		var/newDepth = excavation_level + P.excavation_amount // Used commonly below
 		//handle any archaeological finds we might uncover
@@ -471,7 +472,7 @@ var/list/mining_floors = list()
 	if(valid_tool)
 		if (dug)
 			to_chat(user, "<span class='warning'>This area has already been dug</span>")
-			return
+			return TRUE
 
 		var/turf/T = user.loc
 		if (!(istype(T)))
@@ -479,6 +480,7 @@ var/list/mining_floors = list()
 
 		to_chat(user, "<span class='warning'>You start digging.</span>")
 		playsound(user.loc, 'sound/effects/rustle1.ogg', 50, 1)
+		. = TRUE
 
 		if(!do_after(user,40, src)) return
 
@@ -489,18 +491,15 @@ var/list/mining_floors = list()
 		var/obj/item/storage/ore/S = W
 		if(S.collection_mode)
 			for(var/obj/item/ore/O in contents)
-				O.attackby(W,user)
-				return
+				return O.attackby(W,user)
 	else if(istype(W,/obj/item/storage/bag/fossils))
 		var/obj/item/storage/bag/fossils/S = W
 		if(S.collection_mode)
 			for(var/obj/item/fossil/F in contents)
-				F.attackby(W,user)
-				return
+				return F.attackby(W,user)
 
 	else
-		..(W,user)
-	return
+		return ..(W,user)
 
 /turf/simulated/floor/asteroid/proc/gets_dug()
 

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -79,6 +79,7 @@
 			to_chat(user, SPAN_NOTICE("You lay down the support lattice."))
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 			new /obj/structure/lattice(locate(src.x, src.y, src.z), R.material.type)
+			return TRUE
 		return
 
 	if (istype(C, /obj/item/stack/tile))
@@ -96,15 +97,15 @@
 			qdel(L)
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 			ChangeTurf(/turf/simulated/floor/airless)
-			return
 		else
 			to_chat(user, SPAN_WARNING("The plating is going to need some support."))
+		return TRUE
 
 	//To lay cable.
 	if(isCoil(C))
 		var/obj/item/stack/cable_coil/coil = C
 		coil.turf_place(src, user)
-		return
+		return TRUE
 
 	for(var/atom/movable/M in below)
 		if(M.movable_flags & MOVABLE_FLAG_Z_INTERACT)

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -183,19 +183,3 @@
 /atom/movable/openspace/overlay/proc/owning_turf_changed()
 	if (!destruction_timer)
 		destruction_timer = addtimer(CALLBACK(src, /datum/.proc/qdel_self), 10 SECONDS, TIMER_STOPPABLE)
-
-// This one's a little different because it's mimicing a turf.
-/atom/movable/openspace/turf_overlay
-	plane = OPENTURF_MAX_PLANE
-
-/atom/movable/openspace/turf_overlay/attackby(obj/item/W, mob/user)
-	loc.attackby(W, user)
-
-/atom/movable/openspace/turf_overlay/attack_hand(mob/user)
-	loc.attack_hand(user)
-
-/atom/movable/openspace/turf_overlay/attack_generic(mob/user)
-	loc.attack_generic(user)
-
-/atom/movable/openspace/turf_overlay/examine(mob/examiner)
-	loc.examine(examiner)

--- a/code/modules/multiz/zmimic/mimic_turf.dm
+++ b/code/modules/multiz/zmimic/mimic_turf.dm
@@ -79,10 +79,10 @@
 	plane = OPENTURF_MAX_PLANE
 
 /atom/movable/openspace/turf_overlay/attackby(obj/item/W, mob/user)
-	loc.attackby(W, user)
+	return loc.attackby(W, user)
 
 /atom/movable/openspace/turf_overlay/attack_hand(mob/user)
-	loc.attack_hand(user)
+	return loc.attack_hand(user)
 
 /atom/movable/openspace/turf_overlay/attack_generic(mob/user)
 	loc.attack_generic(user)

--- a/code/modules/overmap/exoplanets/turfs.dm
+++ b/code/modules/overmap/exoplanets/turfs.dm
@@ -29,6 +29,7 @@
 /turf/simulated/floor/exoplanet/attackby(obj/item/C, mob/user)
 	if(diggable && istype(C,/obj/item/shovel))
 		visible_message("<span class='notice'>\The [user] starts digging \the [src]</span>")
+		. = TRUE
 		if(do_after(user, 50))
 			to_chat(user,"<span class='notice'>You dig a deep pit.</span>")
 			new /obj/structure/pit(src)
@@ -40,8 +41,9 @@
 		if(T.use(1))
 			playsound(src, 'sound/items/Deconstruct.ogg', 80, 1)
 			ChangeTurf(/turf/simulated/floor, FALSE, FALSE, TRUE)
+		. = TRUE
 	else
-		..()
+		return ..()
 
 /turf/simulated/floor/exoplanet/ex_act(severity)
 	switch(severity)
@@ -97,6 +99,7 @@
 	if (reagent_type && istype(RG) && ATOM_IS_OPEN_CONTAINER(RG) && RG.reagents)
 		RG.reagents.add_reagent(reagent_type, min(RG.volume - RG.reagents.total_volume, RG.amount_per_transfer_from_this))
 		user.visible_message("<span class='notice'>[user] fills \the [RG] from \the [src].</span>","<span class='notice'>You fill \the [RG] from \the [src].</span>")
+		. = TRUE
 	else
 		return ..()
 


### PR DESCRIPTION
Player-facing changes:
- Attacking a wall with a weapon which doesn't do damage won't attack the wall with an empty hand as an alternative (tool interactions, etc, unaffected). In particular, this removes a lot of "You push the X, but it won't budge" messages in that case.
- Attacking a wall with a weapon which does do damage while on help intent won't do damage to the wall.

Closes #92

Generally you should return TRUE in attackby or attack_hand if the action has resolved, i.e. you've affected the game state in some way. Some stuff does, in fact, check this.