### PR TITLE
Fixes to mixers and outlet injectors.

### DIFF
--- a/code/modules/atmospherics/atmos_primitives.dm
+++ b/code/modules/atmospherics/atmos_primitives.dm
@@ -336,12 +336,12 @@
 	var/total_input_moles = 0		//for flow rate calculation
 	var/list/source_specific_power = list()
 	for (var/datum/gas_mixture/source in mix_sources)
-		if (source.total_moles < MINIMUM_MOLES_TO_FILTER)
-			return -1	//either mix at the set ratios or mix no gas at all
-
 		var/mix_ratio = mix_sources[source]
 		if (!mix_ratio)
 			continue	//this gas is not being mixed in
+		if (source.total_moles < MINIMUM_MOLES_TO_FILTER)
+			return -1	//either mix at the set ratios or mix no gas at all
+
 
 		//mixing rate is limited by the source with the least amount of available gas
 		var/this_mixing_moles = source.total_moles/mix_ratio

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -58,10 +58,7 @@
 	//Give it a small reservoir for injecting. Also allows it to have a higher flow rate limit than vent pumps, to differentiate injectors a bit more.
 	air_contents.volume = ATMOS_DEFAULT_VOLUME_PUMP + 500	
 
-/obj/machinery/atmospherics/unary/outlet_injector/on_update_icon()	
-	if (!node)
-		update_use_power(POWER_USE_OFF)
-
+/obj/machinery/atmospherics/unary/outlet_injector/on_update_icon()
 	if(stat & NOPOWER)
 		icon_state = "off"
 	else
@@ -92,7 +89,7 @@
 	if((. = ..()))
 		return
 	if(href_list["toggle_power"])
-		use_power = update_use_power(!use_power)
+		update_use_power(!use_power)
 		queue_icon_update()
 		to_chat(user, "<span class='notice'>The multitool emits a short beep confirming the change.</span>")
 		return TOPIC_REFRESH


### PR DESCRIPTION
- Mixers properly handle 0/100% mixing input configurations
- Outlet injector multitool interaction now actually works
- Outlet injectors no longer turn off if the atmos device they are connected to is removed. As their mapping makes them hard to interact with (within tanks) I feel this is desirable.

Let's say this closes #8, just so future issues are more specific.