### PR TITLE
Standardizing sheet values, fab efficiency and material units.

### DIFF
--- a/code/__defines/research.dm
+++ b/code/__defines/research.dm
@@ -1,4 +1,5 @@
 #define SHEET_MATERIAL_AMOUNT 2000
+#define SHEET_UNIT "<small>cm<sup>3</sup></small>"
 
 #define TECH_MATERIAL "materials"
 #define TECH_ENGINEERING "engineering"

--- a/code/modules/fabrication/_fabricator.dm
+++ b/code/modules/fabrication/_fabricator.dm
@@ -31,10 +31,10 @@
 	var/list/stored_material
 	var/list/storage_capacity
 	var/list/base_storage_capacity = list(
-		/material/steel =     25000,
-		/material/aluminium = 25000,
-		/material/glass =     12500,
-		/material/plastic =   12500
+		MAT_STEEL =     SHEET_MATERIAL_AMOUNT * 20,
+		MAT_ALUMINIUM = SHEET_MATERIAL_AMOUNT * 20,
+		MAT_GLASS =     SHEET_MATERIAL_AMOUNT * 10,
+		MAT_PLASTIC =   SHEET_MATERIAL_AMOUNT * 10
 	)
 
 	var/show_category = "All"
@@ -131,8 +131,8 @@
 		if(ispath(mat, /material))
 			var/mat_name = stored_substances_to_names[mat]
 			var/material/M = SSmaterials.get_material_datum(mat_name)
-			if(stored_material[mat] > M.units_per_sheet)
-				M.place_sheet(get_turf(src), round(stored_material[mat] / M.units_per_sheet), M.type)
+			if(stored_material[mat] > SHEET_MATERIAL_AMOUNT)
+				M.place_sheet(get_turf(src), round(stored_material[mat] / SHEET_MATERIAL_AMOUNT), M.type)
 	..()
 	return TRUE
 

--- a/code/modules/fabrication/fabricator_books.dm
+++ b/code/modules/fabrication/fabricator_books.dm
@@ -9,8 +9,8 @@
 	base_type = /obj/machinery/fabricator/book
 	fabricator_class = FABRICATOR_CLASS_BOOKS
 	base_storage_capacity = list(
-		/material/wood =      20000,
-		/material/plastic =   20000
+		MAT_WOOD =      SHEET_MATERIAL_AMOUNT * 20,
+		MAT_PLASTIC =   SHEET_MATERIAL_AMOUNT * 20
 	)
 	color_selectable = TRUE
 

--- a/code/modules/fabrication/fabricator_intake.dm
+++ b/code/modules/fabrication/fabricator_intake.dm
@@ -41,7 +41,7 @@
 		if(!mat_colour)
 			mat_colour = material_def.icon_colour
 		stored_material[material_def.type] += taking_material
-		stacks_used = max(stacks_used, ceil(taking_material/material_def.units_per_sheet))
+		stacks_used = max(stacks_used, ceil(taking_material/SHEET_MATERIAL_AMOUNT))
 		if(storage_capacity[material_def.type] == stored_material[material_def.type])
 			. = SUBSTANCE_TAKEN_FULL
 		else if(. != SUBSTANCE_TAKEN_FULL)

--- a/code/modules/fabrication/fabricator_microlathe.dm
+++ b/code/modules/fabrication/fabricator_microlathe.dm
@@ -9,9 +9,9 @@
 	base_type = /obj/machinery/fabricator/micro
 	fabricator_class = FABRICATOR_CLASS_MICRO
 	base_storage_capacity = list(
-		/material/aluminium = 5000,
-		/material/plastic =   5000,
-		/material/glass   = 5000
+		MAT_ALUMINIUM = SHEET_MATERIAL_AMOUNT * 5,
+		MAT_PLASTIC =   SHEET_MATERIAL_AMOUNT * 5,
+		MAT_GLASS   =   SHEET_MATERIAL_AMOUNT * 5
 	)
 
 //Subtype for mapping, starts preloaded with glass and set to print glasses
@@ -20,4 +20,4 @@
 
 /obj/machinery/fabricator/micro/bartender/Initialize()
 	. = ..()
-	stored_material[/material/glass] = base_storage_capacity[/material/glass]
+	stored_material[MAT_GLASS] = base_storage_capacity[MAT_GLASS]

--- a/code/modules/fabrication/fabricator_topic.dm
+++ b/code/modules/fabrication/fabricator_topic.dm
@@ -41,9 +41,9 @@
 		if(stored_substances_to_names[mat_path] == mat_name)
 			if(ispath(mat_path, /material))
 				var/material/mat = SSmaterials.get_material_datum(mat_path)
-				if(mat && stored_material[mat_path] > mat.units_per_sheet && mat.stack_type)
-					var/sheet_count = Floor(stored_material[mat_path]/mat.units_per_sheet)
-					stored_material[mat_path] -= sheet_count * mat.units_per_sheet
+				if(mat && stored_material[mat_path] > SHEET_MATERIAL_AMOUNT && mat.stack_type)
+					var/sheet_count = Floor(stored_material[mat_path]/SHEET_MATERIAL_AMOUNT)
+					stored_material[mat_path] -= sheet_count * SHEET_MATERIAL_AMOUNT
 					mat.place_sheet(get_turf(src), sheet_count)
 			else if(!isnull(stored_material[mat_path]))
 				stored_material[mat_path] = 0

--- a/code/modules/fabrication/fabricator_ui.dm
+++ b/code/modules/fabrication/fabricator_ui.dm
@@ -16,7 +16,7 @@
 			var/list/material_data = list()
 			var/mat_name = capitalize(stored_substances_to_names[material])
 			material_data["name"] =        mat_name
-			material_data["stored"] =      stored_material[material]
+			material_data["stored"] =      "[stored_material[material]][SHEET_UNIT]"
 			material_data["max"] =         storage_capacity[material]
 			material_data["eject_key"] =   stored_substances_to_names[material]
 			material_data["eject_label"] = ispath(material, /material) ? "Eject" : "Flush"
@@ -68,7 +68,7 @@
 						max_sheets = sheets
 					if(stored_material[material] < round(R.resources[material]*mat_efficiency))
 						build_option["unavailable"] = 1
-					material_components += "[round(R.resources[material] * mat_efficiency)] [stored_substances_to_names[material]]"
+					material_components += "[round(R.resources[material] * mat_efficiency)][SHEET_UNIT] [stored_substances_to_names[material]]"
 				build_option["cost"] = "[capitalize(jointext(material_components, ", "))]."
 			if(R.max_amount >= PRINT_MULTIPLIER_DIVISOR && max_sheets >= PRINT_MULTIPLIER_DIVISOR)
 				build_option["multiplier"] = list()

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -104,7 +104,6 @@
 	var/conductive = 1           // Objects with this var add CONDUCTS to flags on spawn.
 	var/luminescence
 	var/list/alloy_materials     // If set, material can be produced via alloying these materials in these amounts.
-	var/units_per_sheet = SHEET_MATERIAL_AMOUNT
 	var/wall_support_value = 30
 
 	// Placeholder vars for the time being, todo properly integrate windows/light tiles/rods.

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -10,7 +10,6 @@
 	icon = 'icons/obj/materials.dmi'
 
 	var/material/reinf_material
-	var/perunit = SHEET_MATERIAL_AMOUNT
 	var/material_flags = USE_MATERIAL_COLOR|USE_MATERIAL_SINGULAR_NAME|USE_MATERIAL_PLURAL_NAME
 	var/matter_multiplier = 1
 

--- a/code/modules/mining/machinery/mineral_processor.dm
+++ b/code/modules/mining/machinery/mineral_processor.dm
@@ -59,8 +59,8 @@
 				if(SSmaterials.alloy_components[metal])
 					attempt_to_alloy[metal] = TRUE
 				else
-					result = min(sheets_per_tick - sheets, Floor(ores_processing[metal] / M.units_per_sheet))
-					ores_processing[metal] -= result * M.units_per_sheet
+					result = min(sheets_per_tick - sheets, Floor(ores_processing[metal] / SHEET_MATERIAL_AMOUNT))
+					ores_processing[metal] -= result * SHEET_MATERIAL_AMOUNT
 					result = -(result)
 			else if(ore_mode == ORE_COMPRESS)
 				result = attempt_compression(M, sheets_per_tick - sheets)
@@ -101,8 +101,8 @@
 					break
 
 /obj/machinery/mineral/processing_unit/proc/attempt_smelt(var/material/metal, var/max_result)
-	. = Clamp(Floor(ores_stored[metal.type]/metal.units_per_sheet),1,max_result)
-	ores_stored[metal.type] -= . * metal.units_per_sheet
+	. = Clamp(Floor(ores_stored[metal.type]/SHEET_MATERIAL_AMOUNT),1,max_result)
+	ores_stored[metal.type] -= . * SHEET_MATERIAL_AMOUNT
 	var/material/M = SSmaterials.get_material_datum(metal.ore_smelts_to)
 	if(istype(M))
 		M.place_sheet(output_turf, .)
@@ -110,9 +110,9 @@
 		. = -(.)
 
 /obj/machinery/mineral/processing_unit/proc/attempt_compression(var/material/metal, var/max_result)
-	var/making = Clamp(Floor(ores_stored[metal.type]/metal.units_per_sheet),1,max_result)
+	var/making = Clamp(Floor(ores_stored[metal.type]/SHEET_MATERIAL_AMOUNT),1,max_result)
 	if(making >= 2)
-		ores_stored[metal.type] -= making * metal.units_per_sheet
+		ores_stored[metal.type] -= making * SHEET_MATERIAL_AMOUNT
 		. = Floor(making * 0.5)
 		var/material/M = SSmaterials.get_material_datum(metal.ore_compresses_to)
 		if(istype(M))
@@ -128,7 +128,7 @@
 	for(var/ore in ores_processing)
 		if(!ores_stored[ore] && !report_all_ores) continue
 		var/material/M = SSmaterials.get_material_datum(ore)
-		var/line = "[capitalize(M.display_name)]</td><td>[Floor(ores_stored[ore] / M.units_per_sheet)] ([ores_stored[ore]]u)"
+		var/line = "[capitalize(M.display_name)]</td><td>[Floor(ores_stored[ore] / SHEET_MATERIAL_AMOUNT)] ([ores_stored[ore]]u)"
 		var/status_string
 		if(ores_processing[ore])
 			switch(ores_processing[ore])

--- a/code/modules/power/fusion/fuel_assembly/fuel_assembly.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_assembly.dm
@@ -12,7 +12,7 @@
 
 /obj/item/fuel_assembly/Initialize(mapload, var/_material, var/_colour)
 	. = ..(mapload, _material)
-	initial_amount = material.units_per_sheet * 5 // Fuel compressor eats 5 sheets.
+	initial_amount = SHEET_MATERIAL_AMOUNT * 5 // Fuel compressor eats 5 sheets.
 	SetName("[material.use_name] fuel rod assembly")
 	desc = "A fuel rod for a fusion reactor. This one is made from [material.use_name]."
 	if(material.radioactivity)

--- a/code/modules/power/fusion/kinetic_harvester.dm
+++ b/code/modules/power/fusion/kinetic_harvester.dm
@@ -62,7 +62,7 @@
 	for(var/mat in stored)
 		var/material/material = SSmaterials.get_material_datum(mat)
 		if(material)
-			var/sheets = Floor(stored[mat]/(material.units_per_sheet * 1.5))
+			var/sheets = Floor(stored[mat]/(SHEET_MATERIAL_AMOUNT * 1.5))
 			data["materials"] += list(list("material" = mat, "rawamount" = stored[mat], "amount" = sheets, "harvest" = harvesting[mat]))
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
@@ -106,7 +106,7 @@
 		var/mat = href_list["remove_mat"]
 		var/material/material = SSmaterials.get_material_datum(mat)
 		if(material)
-			var/sheet_cost = (material.units_per_sheet * 1.5)
+			var/sheet_cost = (SHEET_MATERIAL_AMOUNT * 1.5)
 			var/sheets = Floor(stored[mat]/sheet_cost)
 			if(sheets > 0)
 				material.place_sheet(loc, sheets)

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -9,12 +9,12 @@
 	base_type = /obj/machinery/r_n_d/protolathe
 	construct_state = /decl/machine_construction/default/panel_closed
 
-	var/max_material_storage = 250000
+	var/max_material_storage = 100 * SHEET_MATERIAL_AMOUNT
 
 	var/list/datum/design/queue = list()
 	var/progress = 0
 
-	var/mat_efficiency = 1
+	var/mat_efficiency = 2
 	var/speed = 1
 
 /obj/machinery/r_n_d/protolathe/Initialize()
@@ -61,7 +61,7 @@
 	max_material_storage = 75000 * Clamp(total_component_rating_of_type(/obj/item/stock_parts/matter_bin), 0, 10)
 
 	T = Clamp(total_component_rating_of_type(/obj/item/stock_parts/manipulator), 0, 6)
-	mat_efficiency = 1 - (T - 2) / 8
+	mat_efficiency = Clamp(initial(mat_efficiency) - (T - 2) / 8, 1, 6)
 	speed = T / 2
 	..()
 
@@ -163,8 +163,4 @@
 		reagents.remove_reagent(C, D.chemicals[C] * mat_efficiency)
 
 	if(D.build_path)
-		var/obj/new_item = D.Fabricate(loc, src)
-		if(mat_efficiency != 1) // No matter out of nowhere
-			if(new_item.matter && new_item.matter.len > 0)
-				for(var/i in new_item.matter)
-					new_item.matter[i] = new_item.matter[i] * mat_efficiency
+		D.Fabricate(loc, src)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -694,7 +694,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "<A href='?src=\ref[src];menu=3.2'>Material Storage</A> || "
 			dat += "<A href='?src=\ref[src];menu=3.3'>Chemical Storage</A><HR>"
 			dat += "Protolathe Menu:<BR><BR>"
-			dat += "<B>Material Amount:</B> [linked_lathe.TotalMaterials()] cm<sup>3</sup> (MAX: [linked_lathe.max_material_storage])<BR>"
+			dat += "<B>Material Amount:</B> [linked_lathe.TotalMaterials()][SHEET_UNIT] (MAX: [linked_lathe.max_material_storage])<BR>"
 			dat += "<B>Chemical Volume:</B> [linked_lathe.reagents.total_volume] (MAX: [linked_lathe.reagents.maximum_volume])<HR>"
 			dat += "<UL>"
 			for(var/datum/design/D in files.known_designs)
@@ -723,7 +723,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			for(var/M in linked_lathe.materials)
 				var/material/mat = SSmaterials.get_material_datum(M)
 				var/amount = linked_lathe.materials[M]
-				dat += "<LI><B>[capitalize(mat.display_name)]</B>: [amount] cm<sup>3</sup>"
+				dat += "<LI><B>[capitalize(mat.display_name)]</B>: [amount][SHEET_UNIT]"
 				if(amount >= SHEET_MATERIAL_AMOUNT)
 					dat += " || Eject "
 					for (var/C in list(1, 3, 5, 10, 15, 20, 25, 30, 40))
@@ -776,7 +776,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "<A href='?src=\ref[src];menu=4.3'>Material Storage</A> || "
 			dat += "<A href='?src=\ref[src];menu=4.2'>Chemical Storage</A><HR>"
 			dat += "Circuit Imprinter Menu:<BR><BR>"
-			dat += "Material Amount: [linked_imprinter.TotalMaterials()] cm<sup>3</sup><BR>"
+			dat += "Material Amount: [linked_imprinter.TotalMaterials()][SHEET_UNIT]<BR>"
 			dat += "Chemical Volume: [linked_imprinter.reagents.total_volume]<HR>"
 			dat += "<UL>"
 			for(var/datum/design/D in files.known_designs)
@@ -815,7 +815,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			for(var/M in linked_imprinter.materials)
 				var/material/mat = SSmaterials.get_material_datum(M)
 				var/amount = linked_imprinter.materials[M]
-				dat += "<LI><B>[capitalize(mat.display_name)]</B>: [amount] cm<sup>3</sup>"
+				dat += "<LI><B>[capitalize(mat.display_name)]</B>: [amount][SHEET_UNIT]"
 				if(amount >= SHEET_MATERIAL_AMOUNT)
 					dat += " || Eject: "
 					for (var/C in list(1, 3, 5, 10, 15, 20, 25, 30, 40))

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -29,10 +29,10 @@ var/list/default_material_composition = list(MAT_STEEL = 0, MAT_ALUMINIUM = 0, M
 	if(!(material in materials))
 		return
 	var/material/mat = SSmaterials.get_material_datum(material)
-	var/eject = Clamp(round(materials[material] / mat.units_per_sheet), 0, amount)
+	var/eject = Clamp(round(materials[material] / SHEET_MATERIAL_AMOUNT), 0, amount)
 	if(eject > 0)
 		mat.place_sheet(loc, eject)
-		materials[material] -= eject * mat.units_per_sheet
+		materials[material] -= eject * SHEET_MATERIAL_AMOUNT
 
 /obj/machinery/r_n_d/proc/TotalMaterials()
 	for(var/f in materials)


### PR DESCRIPTION
- Robotics fab and protolathe now apply efficiency from a position of increased costs rather than diminished. This means by default recipes will be more expensive, getting closer to 1:1 with material costs as the machine is upgraded.
- `perunit` and `units_per_sheet` were not actually used and have been removed, replaced with `SHEET_MATERIAL_AMOUNT`.
- Max capacity for robotics fab and protolathe is now based on `SHEET_MATERIAL_AMOUNT`.

Still need to test this to ensure efficiency changes are working.