### PR TITLE
Added primitive sound occlusion

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -73,6 +73,12 @@ var/const/FALLOFF_SOUNDS = 0.5
 
 		S.volume *= pressure_factor
 
+		if(istype(T,/turf/simulated) && istype(turf_source,/turf/simulated))
+			var/turf/simulated/sim_source = turf_source
+			var/turf/simulated/sim_destination = T
+			if(sim_destination.zone != sim_source.zone)
+				S.volume -= 30
+
 		if (S.volume <= 0)
 			return //no volume means no sound
 


### PR DESCRIPTION
If source and destination are not in same ZAS zone, sound volume is reduced by 30
Impelementing https://github.com/NebulaSS13/NebulaFeatureRequests/issues/16 partially

I couldn't get echo vars to do anything, and as far as I can see connections don't really happen unless there's gas work to be done so just same zone / different zone is enough for most cases.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->