### PR TITLE
Tickchecks zone rebuilds.

### DIFF
--- a/code/modules/ZAS/Zone.dm
+++ b/code/modules/ZAS/Zone.dm
@@ -127,6 +127,7 @@ Class Procs:
 	#endif
 
 /zone/proc/rebuild()
+	set waitfor = 0
 	if(invalid) return //Short circuit for explosions where rebuild is called many times over.
 	c_invalidate()
 	for(var/turf/simulated/T in contents)
@@ -134,6 +135,7 @@ Class Procs:
 		//T.dbg(invalid_zone)
 		T.needs_air_update = 0 //Reset the marker so that it will be added to the list.
 		SSair.mark_for_update(T)
+		CHECK_TICK
 
 /zone/proc/add_tile_air(datum/gas_mixture/tile_air)
 	//air.volume += CELL_VOLUME


### PR DESCRIPTION
This is implemented on Aurora but was missing from Bay.