### PR TITLE
Apcs to construct states.

### DIFF
--- a/code/datums/trading/goods.dm
+++ b/code/datums/trading/goods.dm
@@ -84,7 +84,6 @@
 								/obj/item/cell/high                               = TRADER_THIS_TYPE,
 								/obj/item/cell/super                              = TRADER_THIS_TYPE,
 								/obj/item/cell/hyper                              = TRADER_THIS_TYPE,
-								/obj/item/module                                  = TRADER_SUBTYPES_ONLY,
 								/obj/item/tracker_electronics                     = TRADER_THIS_TYPE)
 
 

--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -21,7 +21,7 @@
 
 /datum/wires/apc/CanUse(var/mob/living/L)
 	var/obj/machinery/power/apc/A = holder
-	if(!A.panel_open && !(A.stat & BROKEN))
+	if(istype(A.construct_state, /decl/machine_construction/wall_frame/panel_closed/hackable/hacking) && !(A.stat & BROKEN))
 		return 1
 	return 0
 

--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -21,7 +21,7 @@
 
 /datum/wires/apc/CanUse(var/mob/living/L)
 	var/obj/machinery/power/apc/A = holder
-	if(A.wiresexposed && !(A.stat & BROKEN))
+	if(!A.panel_open && !(A.stat & BROKEN))
 		return 1
 	return 0
 

--- a/code/game/machinery/_machines_base/machine_construction/_construction.dm
+++ b/code/game/machinery/_machines_base/machine_construction/_construction.dm
@@ -24,6 +24,7 @@
 	var/needs_board  // Type of circuitboard expected, if any. Used in unit testing.
 	var/cannot_print // If false, unit testing will attempt to guarantee that the machine is buildable in-round. This inverts that behavior.
 	var/visible_components = TRUE // Whether user can see installed components on examine
+	var/locked = FALSE // Affects how the access lock views the machine.
 
 // Run on unit testing. Should return a fail message or null.
 /decl/machine_construction/proc/fail_unit_test(obj/machinery/machine)

--- a/code/game/machinery/_machines_base/machine_construction/default.dm
+++ b/code/game/machinery/_machines_base/machine_construction/default.dm
@@ -11,6 +11,7 @@
 /decl/machine_construction/default/panel_closed
 	down_state = /decl/machine_construction/default/panel_open
 	visible_components = FALSE
+	locked = TRUE
 
 /decl/machine_construction/default/panel_closed/state_is_valid(obj/machinery/machine)
 	return !machine.panel_open

--- a/code/game/machinery/_machines_base/machine_construction/tcomms.dm
+++ b/code/game/machinery/_machines_base/machine_construction/tcomms.dm
@@ -3,8 +3,9 @@
 /decl/machine_construction/tcomms
 	needs_board = "machine"
 
-/decl/machine_construction/tcomms/panel_closed/
+/decl/machine_construction/tcomms/panel_closed
 	visible_components = FALSE
+	locked = TRUE
 
 /decl/machine_construction/tcomms/panel_closed/state_is_valid(obj/machinery/machine)
 	return !machine.panel_open

--- a/code/game/machinery/_machines_base/machine_construction/wall_frame.dm
+++ b/code/game/machinery/_machines_base/machine_construction/wall_frame.dm
@@ -12,6 +12,7 @@
 
 /decl/machine_construction/wall_frame/panel_closed
 	visible_components = FALSE
+	locked = TRUE
 
 /decl/machine_construction/wall_frame/panel_closed/state_is_valid(obj/machinery/machine)
 	return !machine.panel_open

--- a/code/game/machinery/_machines_base/machine_construction/wall_frame.dm
+++ b/code/game/machinery/_machines_base/machine_construction/wall_frame.dm
@@ -28,19 +28,21 @@
 /decl/machine_construction/wall_frame/panel_closed/attackby(obj/item/I, mob/user, obj/machinery/machine)
 	if((. = ..()))
 		return
-	if(isScrewdriver(I))
-		TRANSFER_STATE(open_state)
-		playsound(get_turf(machine), 'sound/items/Screwdriver.ogg', 50, 1)
-		machine.panel_open = TRUE
-		to_chat(user, SPAN_NOTICE("You open the maintenance hatch of \the [machine], exposing the wiring."))
-		machine.queue_icon_update()
-		return
 	if(istype(I, /obj/item/storage/part_replacer))
 		var/obj/item/storage/part_replacer/replacer = I
 		if(replacer.remote_interaction)
 			machine.part_replacement(user, replacer)
 		machine.display_parts(user)
 		return TRUE
+	return down_interaction(I, user, machine)
+
+/decl/machine_construction/wall_frame/panel_closed/proc/down_interaction(obj/item/I, mob/user, obj/machinery/machine)
+	if(isScrewdriver(I))
+		TRANSFER_STATE(open_state)
+		playsound(get_turf(machine), 'sound/items/Screwdriver.ogg', 50, 1)
+		machine.panel_open = TRUE
+		to_chat(user, SPAN_NOTICE("You open the maintenance hatch of \the [machine], exposing the wiring."))
+		machine.queue_icon_update()
 
 /decl/machine_construction/wall_frame/panel_closed/mechanics_info()
 	. = list()
@@ -78,12 +80,7 @@
 		machine.queue_icon_update()
 		return
 
-	if(isScrewdriver(I))
-		TRANSFER_STATE(active_state)
-		playsound(get_turf(machine), 'sound/items/Screwdriver.ogg', 50, 1)
-		machine.panel_open = FALSE
-		to_chat(user, SPAN_NOTICE("You close the maintenance hatch of \the [machine]."))
-		machine.queue_icon_update()
+	if((. = up_interaction(I, user, machine)))
 		return
 
 	if(istype(I, /obj/item/storage/part_replacer))
@@ -95,7 +92,13 @@
 	if(istype(I))
 		return machine.part_insertion(user, I)
 
-// Wires removed
+/decl/machine_construction/wall_frame/panel_open/proc/up_interaction(obj/item/I, mob/user, obj/machinery/machine)
+	if(isScrewdriver(I))
+		TRANSFER_STATE(active_state)
+		playsound(get_turf(machine), 'sound/items/Screwdriver.ogg', 50, 1)
+		machine.panel_open = FALSE
+		to_chat(user, SPAN_NOTICE("You close the maintenance hatch of \the [machine]."))
+		machine.queue_icon_update()
 
 /decl/machine_construction/wall_frame/panel_open/mechanics_info()
 	. = list()
@@ -105,6 +108,7 @@
 	. += "Remove installed parts with a wrench."
 	. += "Use a wirecutter to disconnect the wires and expose the circuit board."
 
+// Wires removed
 
 /decl/machine_construction/wall_frame/no_wires
 

--- a/code/game/machinery/_machines_base/machine_construction/wall_frame_hackable.dm
+++ b/code/game/machinery/_machines_base/machine_construction/wall_frame_hackable.dm
@@ -1,0 +1,81 @@
+// Wall frame with an extra state accessible from the closed one via screwdriver, with custom interactions available for that state. Uses crowbar for the usual down state instead.
+
+/decl/machine_construction/wall_frame/panel_closed/hackable
+	active_state = /decl/machine_construction/wall_frame/panel_closed/hackable
+	open_state = /decl/machine_construction/wall_frame/panel_open/hackable
+	diconnected_state = /decl/machine_construction/wall_frame/no_wires/hackable
+	bottom_state = /decl/machine_construction/wall_frame/no_circuit/hackable
+	newly_built_state = /decl/machine_construction/wall_frame/no_circuit/hackable
+
+/decl/machine_construction/wall_frame/panel_open/hackable
+	active_state = /decl/machine_construction/wall_frame/panel_closed/hackable
+	open_state = /decl/machine_construction/wall_frame/panel_open/hackable
+	diconnected_state = /decl/machine_construction/wall_frame/no_wires/hackable
+	bottom_state = /decl/machine_construction/wall_frame/no_circuit/hackable
+	newly_built_state = /decl/machine_construction/wall_frame/no_circuit/hackable
+
+/decl/machine_construction/wall_frame/no_wires/hackable
+	active_state = /decl/machine_construction/wall_frame/panel_closed/hackable
+	open_state = /decl/machine_construction/wall_frame/panel_open/hackable
+	diconnected_state = /decl/machine_construction/wall_frame/no_wires/hackable
+	bottom_state = /decl/machine_construction/wall_frame/no_circuit/hackable
+	newly_built_state = /decl/machine_construction/wall_frame/no_circuit/hackable
+
+/decl/machine_construction/wall_frame/no_circuit/hackable
+	active_state = /decl/machine_construction/wall_frame/panel_closed/hackable
+	open_state = /decl/machine_construction/wall_frame/panel_open/hackable
+	diconnected_state = /decl/machine_construction/wall_frame/no_wires/hackable
+	bottom_state = /decl/machine_construction/wall_frame/no_circuit/hackable
+	newly_built_state = /decl/machine_construction/wall_frame/no_circuit/hackable
+
+/decl/machine_construction/wall_frame/panel_closed/hackable/down_interaction(obj/item/I, mob/user, obj/machinery/machine)
+	if(isScrewdriver(I))
+		TRANSFER_STATE(/decl/machine_construction/wall_frame/panel_closed/hackable/hacking)
+		playsound(get_turf(machine), 'sound/items/Screwdriver.ogg', 50, 1)
+		to_chat(user, SPAN_NOTICE("You release some of the logic wiring on \the [machine]. The cover panel remains closed."))
+		machine.queue_icon_update()
+		return
+	if(isCrowbar(I))
+		TRANSFER_STATE(open_state)
+		playsound(get_turf(machine), 'sound/items/Crowbar.ogg', 50, 1)
+		machine.panel_open = TRUE
+		to_chat(user, SPAN_NOTICE("You open the main cover panel on \the [machine], exposing the internals."))
+		machine.queue_icon_update()
+
+/decl/machine_construction/wall_frame/panel_closed/hackable/mechanics_info()
+	. = list()
+	. += "Use a screwdriver to open a small hatch and expose some logic wires."
+	. += "Use a crowbar to pry open the main cover."
+	. += "Use a parts replacer to view installed parts."
+
+/decl/machine_construction/wall_frame/panel_closed/hackable/hacking/down_interaction(obj/item/I, mob/user, obj/machinery/machine)
+	if(isScrewdriver(I))
+		TRANSFER_STATE(active_state)
+		playsound(get_turf(machine), 'sound/items/Screwdriver.ogg', 50, 1)
+		to_chat(user, SPAN_NOTICE("You tuck the exposed wiring back into \the [machine] and screw the hatch back into place."))
+		machine.queue_icon_update()
+		return
+	if(isCrowbar(I))
+		to_chat(user, SPAN_NOTICE("The exposed wires block you from prying open the main hatch. Tuck them back in first."))
+		return TRUE
+
+/decl/machine_construction/wall_frame/panel_closed/hackable/hacking/mechanics_info()
+	. = list()
+	. += "Use a screwdriver close the hatch and tuck the exposed wires back in."
+	. += "Use a parts replacer to view installed parts."
+
+/decl/machine_construction/wall_frame/panel_open/hackable/up_interaction(obj/item/I, mob/user, obj/machinery/machine)
+	if(isCrowbar(I))
+		TRANSFER_STATE(active_state)
+		playsound(get_turf(machine), 'sound/items/Crowbar.ogg', 50, 1)
+		machine.panel_open = FALSE
+		to_chat(user, SPAN_NOTICE("You push the main cover panel back into place on \the [machine]."))
+		machine.queue_icon_update()
+
+/decl/machine_construction/wall_frame/panel_open/hackable/mechanics_info()
+	. = list()
+	. += "Use a crowbar to close the main cover."
+	. += "Use a parts replacer to upgrade some parts."
+	. += "Insert a new part to install it."
+	. += "Remove installed parts with a wrench."
+	. += "Use a wirecutter to disconnect the wires and expose the circuit board."

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -215,7 +215,7 @@ Class Procs:
 	return TRUE
 
 /obj/machinery/CanUseTopicPhysical(var/mob/user)
-	if(stat & BROKEN)
+	if((stat & BROKEN) && (reason_broken & MACHINE_BROKEN_GENERIC))
 		return STATUS_CLOSE
 
 	return GLOB.physical_state.can_use_topic(nano_host(), user)
@@ -437,3 +437,8 @@ Class Procs:
 		var/list/part_costs = part.building_cost()
 		for(var/key in part_costs)
 			.[key] += part_costs[key] * component_types[path]
+
+/obj/machinery/emag_act(remaining_charges, mob/user, emag_source)
+	. = ..()
+	for(var/obj/item/stock_parts/access_lock/lock in get_all_components_of_type(/obj/item/stock_parts/access_lock))
+		. = max(., lock.emag_act())

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -212,6 +212,8 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 
 // Use to block interactivity if panel is not open, etc.
 /obj/machinery/proc/components_are_accessible(var/path)
+	if(ispath(path, /obj/item/stock_parts/access_lock))
+		return TRUE
 	return panel_open
 
 // Installation. Returns number of such components which can be inserted, or 0.

--- a/code/game/machinery/_machines_base/stock_parts/access_lock.dm
+++ b/code/game/machinery/_machines_base/stock_parts/access_lock.dm
@@ -1,0 +1,77 @@
+/obj/item/stock_parts/access_lock
+	name = "access_lock"
+	desc = "An id-based access lock preventing tampering with a machine's hardware."
+	icon_state = "scan_module"
+	part_flags = PART_FLAG_QDEL | PART_FLAG_NODAMAGE
+	req_access = list(access_engine_equip) // set req_access on this to impose access requirements.
+	var/locked = FALSE
+
+/obj/machinery/cannot_transition_to(state_path, mob/user)
+	var/decl/machine_construction/state = decls_repository.get_decl(state_path)
+	if(state && !state.locked && construct_state && construct_state.locked) // we're locked, we're becoming unlocked
+		for(var/obj/item/stock_parts/access_lock/lock in get_all_components_of_type(/obj/item/stock_parts/access_lock))
+			if(lock.locked && !lock.check_access(user))
+				return SPAN_WARNING("\The [lock] flashes red! You lack the access to unlock this.")
+	return ..()
+
+/obj/item/stock_parts/access_lock/on_install(obj/machinery/machine)
+	. = ..()
+	locked = TRUE
+
+/obj/item/stock_parts/access_lock/on_uninstall(obj/machinery/machine)
+	. = ..()
+	locked = FALSE
+
+/obj/item/stock_parts/access_lock/on_fail(obj/machinery/machine, damtype)
+	. = ..()
+	locked = FALSE
+
+/obj/item/stock_parts/access_lock/examine(mob/user)
+	. = ..()
+	if(locked)
+		to_chat(user, "The lock is engaged.")
+
+/obj/item/stock_parts/access_lock/attackby(obj/item/W, mob/user)
+	var/obj/machinery/machine = loc
+	if(istype(machine))
+		if(check_access(W))
+			locked = !locked
+			visible_message(SPAN_NOTICE("\The [src] beeps and flashes green twice: it is now [locked ? "" : "un"]locked."))
+			return TRUE
+		return
+
+	if(isMultitool(W)) // This is a non-machine interaction only; doing this within a machine will likely lead to interaction clashes.
+		var/list/accesses = user.GetAccess()
+		if(!LAZYLEN(accesses))
+			return
+		var/list/choices = list()
+		for(var/key in accesses)
+			choices[get_access_desc(key)] = key
+		choices["No Access"] = "No Access"
+		var/default = length(req_access) ? req_access[1] : null
+		var/selected_desc = input(user, "Select the access you would like \the [src] to use:", "Access Modification", default) as null|anything in choices
+		. = TRUE
+		if(!CanPhysicallyInteract(user))
+			return
+		if(!selected_desc)
+			return
+		if(selected_desc == "No Access")
+			req_access.Cut()
+			return
+		if(!(choices[selected_desc] in user.GetAccess()))
+			return
+		req_access = list(choices[selected_desc])
+		return
+
+	return ..()
+
+/obj/item/stock_parts/access_lock/buildable
+	part_flags = PART_FLAG_HAND_REMOVE
+	matter = list(MAT_STEEL = 400, MAT_GLASS = 200)
+
+/decl/stock_part_preset/access_lock
+	expected_part_type = /obj/item/stock_parts/access_lock
+	var/list/req_access = list()
+
+/decl/stock_part_preset/access_lock/do_apply(obj/machinery/machine, obj/item/stock_parts/access_lock/part)
+	part.req_access = req_access.Copy()

--- a/code/game/machinery/_machines_base/stock_parts/access_lock.dm
+++ b/code/game/machinery/_machines_base/stock_parts/access_lock.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/access_lock
-	name = "access_lock"
+	name = "access lock"
 	desc = "An id-based access lock preventing tampering with a machine's hardware."
 	icon_state = "scan_module"
 	part_flags = PART_FLAG_QDEL | PART_FLAG_NODAMAGE
@@ -54,8 +54,6 @@
 
 	if(isMultitool(W)) // This is a non-machine interaction only; doing this within a machine will likely lead to interaction clashes.
 		var/list/accesses = user.GetAccess()
-		if(!LAZYLEN(accesses))
-			return
 		var/list/choices = list()
 		for(var/key in accesses)
 			choices[get_access_desc(key)] = key

--- a/code/game/machinery/_machines_base/stock_parts/power/battery.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/battery.dm
@@ -27,6 +27,16 @@
 		remove_cell()
 	..()
 
+/obj/item/stock_parts/power/battery/take_damage(amount, damtype)
+	. = ..()
+	switch(damtype)
+		if(ELECTROCUTE)
+			if(prob(50) && cell && health < initial(health)/2)
+				cell.emp_act(3)
+		if(BRUTE)
+			if(prob(20) && cell && health < initial(health)/2)
+				cell.ex_act(3)
+
 // None of these helpers actually change the cell's loc. They only manage internal references and state.
 /obj/item/stock_parts/power/battery/proc/add_cell(var/obj/machinery/machine, var/obj/item/cell/new_cell)
 	if(cell)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1149,7 +1149,7 @@
 	vend_delay = 21
 	base_type = /obj/machinery/vending/engivend
 	req_access = list(list(access_atmospherics,access_engine_equip))
-	products = list(/obj/item/clothing/glasses/meson = 2,/obj/item/multitool = 4,/obj/item/geiger = 4,/obj/item/airlock_electronics = 10,/obj/item/module/power_control = 10,/obj/item/stock_parts/circuitboard/air_alarm = 10,/obj/item/cell = 10,/obj/item/clamp = 10)
+	products = list(/obj/item/clothing/glasses/meson = 2,/obj/item/multitool = 4,/obj/item/geiger = 4,/obj/item/airlock_electronics = 10,/obj/item/stock_parts/circuitboard/apc = 10,/obj/item/stock_parts/circuitboard/air_alarm = 10,/obj/item/cell = 10,/obj/item/clamp = 10)
 	contraband = list(/obj/item/cell/high = 3)
 	premium = list(/obj/item/storage/belt/utility = 3)
 

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -14,6 +14,7 @@
 	if(fully_construct)
 		var/obj/machinery/machine = new build_machine_type
 		var/list/cost = machine.building_cost()
+		qdel(machine) // It's likely queued for processing; it won't delete automatically.
 		for(var/key in cost)
 			.[key] += cost[key]
 

--- a/code/game/objects/alien_props.dm
+++ b/code/game/objects/alien_props.dm
@@ -24,8 +24,10 @@
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "ano10"
 	update_state = 0 //Don't pixelshift us on wall
-	cell_type = /obj/item/cell/alien
 	autoname = 0
+	uncreated_component_parts = list(
+		/obj/item/cell/alien
+	)
 	
 /obj/machinery/power/apc/alien/on_update_icon()
 	check_updates()

--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -6,12 +6,8 @@
 	icon = 'icons/obj/apc_repair.dmi'
 	icon_state = "apc_frame"
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
-
-/obj/item/frame/apc/attackby(obj/item/W, mob/user)
-	..()
-	if(isWrench(W))
-		new /obj/item/stack/material/steel( get_turf(src.loc), 2 )
-		qdel(src)
+	build_machine_type = /obj/machinery/power/apc/buildable
+	reverse = TRUE
 
 /obj/item/frame/apc/try_build(turf/on_wall)
 	var/area/A = get_area(src)

--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -27,3 +27,4 @@
 	fully_construct = TRUE
 	name = "APC kit"
 	desc = "An all-in-one APC kit, comes preassembled."
+	build_machine_type = /obj/machinery/power/apc

--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -14,16 +14,7 @@
 		qdel(src)
 
 /obj/item/frame/apc/try_build(turf/on_wall)
-	if (get_dist(on_wall,usr)>1)
-		return
-	var/ndir = get_dir(usr,on_wall)
-	if (!(ndir in GLOB.cardinal))
-		return
-	var/turf/loc = get_turf(usr)
-	var/area/A = loc.loc
-	if (!istype(loc, /turf/simulated/floor))
-		to_chat(usr, "<span class='warning'>APC cannot be placed on this spot.</span>")
-		return
+	var/area/A = get_area(src)
 	if (A.requires_power == 0 || istype(A, /area/space))
 		to_chat(usr, "<span class='warning'>APC cannot be placed in this area.</span>")
 		return
@@ -34,10 +25,9 @@
 		if (T.master)
 			to_chat(usr, "<span class='warning'>There is another network terminal here.</span>")
 			return
-		else
-			var/obj/item/stack/cable_coil/C = new /obj/item/stack/cable_coil(loc)
-			C.amount = 10
-			to_chat(usr, "You cut the cables and disassemble the unused power terminal.")
-			qdel(T)
-	new /obj/machinery/power/apc(loc, ndir, TRUE, 1)
-	qdel(src)
+	return ..()
+
+/obj/item/frame/apc/kit
+	fully_construct = TRUE
+	name = "APC kit"
+	desc = "An all-in-one APC kit, comes preassembled."

--- a/code/game/objects/items/weapons/circuitboards/wall.dm
+++ b/code/game/objects/items/weapons/circuitboards/wall.dm
@@ -28,3 +28,23 @@
 		/obj/item/stock_parts/keyboard = 1,
 		/obj/item/stock_parts/power/apc/buildable = 1
 	)
+
+/obj/item/stock_parts/circuitboard/apc
+	name = T_BOARD("area power controller")
+	desc = "Heavy-duty switching circuits for power control."
+	icon = 'icons/obj/module.dmi'
+	icon_state = "power_mod"
+	item_state = "electronic"
+	matter = list(MAT_STEEL = 50, MAT_GLASS = 50)
+	w_class = ITEM_SIZE_SMALL
+	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	build_path = /obj/machinery/power/apc/buildable
+	board_type = "wall"
+	origin_tech = "{'" + TECH_DATA + "':1,'" + TECH_ENGINEERING + "':1}"
+	req_components = list()
+	additional_spawn_components = list(
+		/obj/item/stock_parts/console_screen = 1,
+		/obj/item/stock_parts/keyboard = 1,
+		/obj/item/stock_parts/power/battery/buildable = 1,
+		/obj/item/stock_parts/power/terminal/buildable = 1,
+	)

--- a/code/game/objects/items/weapons/circuitboards/wall.dm
+++ b/code/game/objects/items/weapons/circuitboards/wall.dm
@@ -47,5 +47,5 @@
 		/obj/item/stock_parts/keyboard = 1,
 		/obj/item/stock_parts/power/battery/buildable = 1,
 		/obj/item/stock_parts/power/terminal/buildable = 1,
-		/obj/item/stock_parts/access_lock = 1
+		/obj/item/stock_parts/access_lock/buildable = 1
 	)

--- a/code/game/objects/items/weapons/circuitboards/wall.dm
+++ b/code/game/objects/items/weapons/circuitboards/wall.dm
@@ -47,4 +47,5 @@
 		/obj/item/stock_parts/keyboard = 1,
 		/obj/item/stock_parts/power/battery/buildable = 1,
 		/obj/item/stock_parts/power/terminal/buildable = 1,
+		/obj/item/stock_parts/access_lock = 1
 	)

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -33,7 +33,7 @@
 	return list(
 		/obj/item/clothing/gloves/insulated = 3,
 		/obj/item/storage/toolbox/electrical = 3,
-		/obj/item/module/power_control = 3,
+		/obj/item/stock_parts/circuitboard/apc = 3,
 		/obj/item/multitool = 3
 	)
 

--- a/code/modules/fabrication/designs/general/designs_devices_components.dm
+++ b/code/modules/fabrication/designs/general/designs_devices_components.dm
@@ -36,6 +36,9 @@
 /datum/fabricator_recipe/device_component/terminal
 	path = /obj/item/stock_parts/power/terminal/buildable
 
+/datum/fabricator_recipe/device_component/access_lock
+	path = /obj/item/stock_parts/access_lock/buildable
+
 /datum/fabricator_recipe/device_component/igniter
 	path = /obj/item/assembly/igniter
 

--- a/code/modules/fabrication/designs/general/designs_engineering.dm
+++ b/code/modules/fabrication/designs/general/designs_engineering.dm
@@ -21,7 +21,10 @@
 	path = /obj/item/frame/light/nav
 
 /datum/fabricator_recipe/engineering/powermodule
-	path = /obj/item/module/power_control
+	path = /obj/item/stock_parts/circuitboard/apc
+
+/datum/fabricator_recipe/engineering/powermodule_kit
+	path = /obj/item/frame/apc/kit
 
 /datum/fabricator_recipe/engineering/rcd_ammo
 	path = /obj/item/rcd_ammo

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -13,7 +13,6 @@
 		/obj/item/cell,
 		/obj/item/airlock_electronics,
 		/obj/item/tracker_electronics,
-		/obj/item/module/power_control,
 		/obj/item/stock_parts,
 		/obj/item/frame,
 		/obj/item/camera_assembly,

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -46,31 +46,34 @@
 	lighting = 0
 	equipment = 0
 	environ = 0
-	locked = 0
-	coverlocked = 0
+	locked = FALSE
 
 /obj/machinery/power/apc/critical
 	is_critical = 1
 
 /obj/machinery/power/apc/high
-	cell_type = /obj/item/cell/high
+	uncreated_component_parts = list(
+		/obj/item/cell/high
+	)
 
 /obj/machinery/power/apc/high/inactive
-	cell_type = /obj/item/cell/high
 	lighting = 0
 	equipment = 0
 	environ = 0
-	locked = 0
-	coverlocked = 0
+	locked = FALSE
 
 /obj/machinery/power/apc/super
-	cell_type = /obj/item/cell/super
+	uncreated_component_parts = list(
+		/obj/item/cell/super
+	)
 
 /obj/machinery/power/apc/super/critical
 	is_critical = 1
 
 /obj/machinery/power/apc/hyper
-	cell_type = /obj/item/cell/hyper
+	uncreated_component_parts = list(
+		/obj/item/cell/hyper
+	)
 
 // Main APC code
 /obj/machinery/power/apc
@@ -83,19 +86,13 @@
 	use_power = POWER_USE_IDLE // Has custom handling here.
 	power_channel = LOCAL      // Do not manipulate this; you don't want to power the APC off itself.
 	interact_offline = TRUE    // Can use UI even if unpowered
-	uncreated_component_parts = list(
-		/obj/item/stock_parts/power/terminal,
-		/obj/item/stock_parts/power/apc,
-		/obj/item/stock_parts/power/battery
-		)
+
 	req_access = list(access_engine_equip)
 	clicksound = "switch"
 	layer = ABOVE_WINDOW_LAYER
 	var/needs_powerdown_sound
 	var/area/area
 	var/areastring = null
-	var/cell_type = /obj/item/cell/apc
-	var/opened = 0 //0=closed, 1=opened, 2=cover removed
 	var/shorted = 0
 	var/lighting = POWERCHAN_ON_AUTO
 	var/equipment = POWERCHAN_ON_AUTO
@@ -103,8 +100,6 @@
 	var/operating = 1       // Bool for main toggle.
 	var/charging = 0        // Whether or not it's charging. 0 - not charging but not full, 1 - charging, 2 - full
 	var/chargemode = 1      // Whether charging is toggled on or off.
-	var/locked = 1
-	var/coverlocked = 1     // Whether you can crowbar off the cover or need to swipe ID first.
 	var/aidisabled = 0
 	var/lastused_light = 0    // Internal stuff for UI and bookkeeping; can read off values but don't modify.
 	var/lastused_equip = 0
@@ -113,11 +108,8 @@
 	var/lastused_total = 0
 	var/main_status = 0     // UI var for whether we are getting external power. 0 = no external power at all, 1 = some, but not enough, 2 = getting enough.
 	var/mob/living/silicon/ai/hacker = null // Malfunction var. If set AI hacked the APC and has full control.
-	var/wiresexposed = 0 // whether you can access the wires for hacking or not.
 	powernet = 0		 // set so that APCs aren't found as powernet nodes //Hackish, Horrible, was like this before I changed it :(
-	var/debug= 0         // Legacy debug toggle, left in for admin use.
 	var/autoflag= 0		 // 0 = off, 1= eqp and lights off, 2 = eqp off, 3 = all on.
-	var/has_electronics = 0 // 0 - none, 1 - plugged in, 2 - secured by screwdriver
 	var/beenhit = 0 // used for counting how many times it has been hit, used for Aliens at the moment
 	var/longtermpower = 10  // Counter to smooth out power state changes; do not modify.
 	wires = /datum/wires/apc
@@ -135,11 +127,19 @@
 	var/global/list/status_overlays_lighting
 	var/global/list/status_overlays_environ
 	var/autoname = 1
+	var/cover_removed = FALSE           // Cover is gone; can't close it anymore.
+	var/locked = TRUE                   // This is the interface, not the hardware.
 
-/obj/machinery/power/apc/updateDialog()
-	if (stat & (BROKEN|MAINT))
-		return
-	..()
+	base_type = /obj/machinery/power/apc/buildable
+	stat_immune = 0
+	frame_type = /obj/item/frame/apc
+	construct_state = /decl/machine_construction/wall_frame/panel_closed
+	uncreated_component_parts = list(
+		/obj/item/cell/apc
+	)
+
+/obj/machinery/power/apc/buildable
+	uncreated_component_parts = null
 
 /obj/machinery/power/apc/connect_to_network()
 	//Override because the APC does not directly connect to the network; it goes through a terminal.
@@ -162,12 +162,7 @@
 
 	return amount - use_power_oneoff(amount, LOCAL)
 
-/obj/machinery/power/apc/Initialize(mapload, var/ndir, var/populate_parts = TRUE, var/building=0)
-	// offset 22 pixels in direction of dir
-	// this allows the APC to be embedded in a wall, yet still inside an area
-	if (building)
-		set_dir(ndir)
-
+/obj/machinery/power/apc/Initialize(mapload, var/ndir, var/populate_parts = TRUE)
 	if(areastring)
 		area = get_area_name(areastring)
 	else
@@ -180,12 +175,10 @@
 
 	. = ..()
 
-	if (building==0)
+	if (populate_parts)
 		init_round_start()
 	else
-		opened = 1
 		operating = 0
-		stat |= MAINT
 		queue_icon_update()
 
 	if(operating)
@@ -218,13 +211,8 @@
 	playsound(src, 'sound/machines/apc_nopower.ogg', 75, 0)
 
 /obj/machinery/power/apc/proc/init_round_start()
-	has_electronics = 2 //installed and secured
-
-	var/obj/item/stock_parts/power/battery/bat = get_component_of_type(/obj/item/stock_parts/power/battery)
-	bat.add_cell(src, new cell_type(bat))
 	var/obj/item/stock_parts/power/terminal/term = get_component_of_type(/obj/item/stock_parts/power/terminal)
-	term.make_terminal(src)
-
+	term.make_terminal(src) // intentional crash if there is no terminal
 	queue_icon_update()
 
 /obj/machinery/power/apc/proc/terminal()
@@ -238,24 +226,12 @@
 			to_chat(user, "Looks broken.")
 			return
 		var/terminal = terminal()
-		if(opened)
-			if(has_electronics && terminal)
-				to_chat(user, "The cover is [opened==2?"removed":"open"] and the power cell is [ get_cell() ? "installed" : "missing"].")
-			else if (!has_electronics && terminal)
-				to_chat(user, "There are some wires but no any electronics.")
-			else if (has_electronics && !terminal)
-				to_chat(user, "Electronics installed but not wired.")
-			else /* if (!has_electronics && !terminal) */
-				to_chat(user, "There is no electronics nor connected wires.")
-
+		to_chat(user, "\The [src] is [terminal ? "" : "not "]connected to external power.")
+		if(!panel_open)
+			to_chat(user, "The cover is closed.")
 		else
-			if (stat & MAINT)
-				to_chat(user, "The cover is closed. Something wrong with it: it doesn't work.")
-			else if (hacker && !hacker.hacked_apcs_hidden)
-				to_chat(user, "The cover is locked.")
-			else
-				to_chat(user, "The cover is closed.")
-
+			to_chat(user, "The cover is [cover_removed ? "removed" : "open"] and the power cell is [ get_cell() ? "installed" : "missing"].")
+//  Broken/missing board should be shown by parent.
 
 // update the APC icon to show the three base states
 // also add overlays for indicator lights
@@ -328,8 +304,6 @@
 			icon_state = "apc-b"
 		else if(update_state & UPDATE_BLUESCREEN)
 			icon_state = "apcemag"
-		else if(update_state & UPDATE_WIREEXP)
-			icon_state = "apcewires"
 
 	if(!(update_state & UPDATE_ALLGOOD))
 		if(overlays.len)
@@ -379,15 +353,13 @@
 		update_state |= UPDATE_BROKE
 	if(stat & MAINT)
 		update_state |= UPDATE_MAINT
-	if(opened)
-		if(opened==1)
+	if(panel_open)
+		if(!cover_removed)
 			update_state |= UPDATE_OPENED1
-		if(opened==2)
+		else
 			update_state |= UPDATE_OPENED2
 	else if(emagged || (hacker && !hacker.hacked_apcs_hidden) || failure_timer)
 		update_state |= UPDATE_BLUESCREEN
-	else if(wiresexposed)
-		update_state |= UPDATE_WIREEXP
 	if(update_state <= 1)
 		update_state |= UPDATE_ALLGOOD
 
@@ -420,250 +392,50 @@
 		results += 2
 	return results
 
-/obj/machinery/power/apc/components_are_accessible(var/path)
-	. = opened
-	if(ispath(path, /obj/item/stock_parts/power/terminal))
-		. = min(., (has_electronics != 2))
+/obj/machinery/power/apc/cannot_transition_to(state_path, mob/user)
+	if(ispath(state_path, /decl/machine_construction/wall_frame/panel_closed) && cover_removed)
+		return SPAN_NOTICE("You cannot close the cover: it was completely removed!")
+	. = ..()	
 
-//attack with an item - open/close cover, insert cell, or (un)lock interface
+/obj/machinery/power/apc/proc/force_open_panel(mob/user)
+	var/decl/machine_construction/wall_frame/panel_closed/closed_state = construct_state
+	if(!istype(closed_state))
+		return MCS_CONTINUE
+	var/list/locks = get_all_components_of_type(/obj/item/stock_parts/access_lock)
+	for(var/obj/item/stock_parts/access_lock/lock in locks)
+		lock.locked = FALSE
+	. = closed_state.try_change_state(src, closed_state.open_state, user)
+	if(. != MCS_CHANGE)
+		return
+	panel_open = TRUE
+	queue_icon_update()
 
 /obj/machinery/power/apc/attackby(obj/item/W, mob/user)
-	if (istype(user, /mob/living/silicon) && get_dist(src,user)>1)
-		return attack_robot(user)
-	if(istype(W, /obj/item/inducer))
-		return FALSE // inducer.dm afterattack handles this
+	if (!panel_open && (isMultitool(W) || isWirecutter(W) || istype(W, /obj/item/assembly/signaler)))
+		return wires.Interact(user)
+	return ..()
 
-	if(isCrowbar(W))
-		if(opened) // Closes or removes board.
-			if (has_electronics == 1)
-				if (terminal())
-					to_chat(user, SPAN_WARNING("Disconnect the wires first."))
-					return TRUE
-				playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
-				to_chat(user, "You are trying to remove the power control board...")//lpeters - fixed grammar issues
-
-				if(do_after(user, 50, src) && opened && (has_electronics == 1) && !terminal()) // redo all checks.
-					has_electronics = 0
-					if ((stat & BROKEN))
-						user.visible_message(\
-							SPAN_WARNING("\The [user] has broken the power control board inside \the [src]!"),\
-							SPAN_NOTICE("You break the charred power control board and remove the remains."),\
-							"You hear a crack!")
-					else
-						user.visible_message(\
-							SPAN_WARNING("\The [user] has removed the power control board from \the [src]!"),\
-							SPAN_NOTICE("You remove the power control board."))
-						new /obj/item/module/power_control(loc)
-				return TRUE
-
-			else if (opened != 2) //cover isn't removed
-				opened = 0 // Closes panel.
-				user.visible_message(SPAN_NOTICE("\The [user] pries the cover shut on \the [src]."), SPAN_NOTICE("You pry the cover shut."))
-				update_icon()
-				return TRUE
-
-		if((stat & BROKEN) || (hacker && !hacker.hacked_apcs_hidden))
-			to_chat(user, SPAN_WARNING("The cover appears broken or stuck."))
-			return TRUE
-		if(coverlocked && !(stat & MAINT))
-			to_chat(user, SPAN_WARNING("The cover is locked and cannot be opened."))
-			return TRUE
-		opened = 1
-		user.visible_message(SPAN_NOTICE("\The [user] pries the cover open on \the [src]."), SPAN_NOTICE("You pry the cover open."))
-		update_icon()
-		return TRUE
-
-	// Exposes wires for hacking and attaches/detaches the circuit.
-	if(isScrewdriver(W))
-		if(opened)
-			if (get_cell())
-				to_chat(user, SPAN_WARNING("Either close the cover or remove the cell first."))
-				return TRUE
-			switch(has_electronics)
-				if(1)
-					if(!terminal())
-						to_chat(user, SPAN_WARNING("You must attach a wire connection first!"))
-						return TRUE
-					has_electronics = 2
-					stat &= ~MAINT
-					playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-					to_chat(user, "You screw the circuit electronics into place.")
-					update_icon()
-				if(2)
-					has_electronics = 1
-					stat |= MAINT
-					playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-					to_chat(user, "You unfasten the electronics.")
-					update_icon()
-				if(0)
-					to_chat(user, SPAN_WARNING("There is no power control board to secure!"))
-			return TRUE
-		// Otherwise, if not opened, expose the wires.
-		wiresexposed = !wiresexposed
-		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"]")
-		update_icon()
-		return TRUE
-
-	// trying to unlock the interface with an ID card
-	if (istype(W, /obj/item/card/id)||istype(W, /obj/item/modular_computer))
-		if(emagged)
-			to_chat(user, "The interface is broken.")
-		else if(opened)
-			to_chat(user, "You must close the cover to swipe an ID card.")
-		else if(wiresexposed)
-			to_chat(user, "You must close the panel")
-		else if(stat & (BROKEN|MAINT))
-			to_chat(user, "Nothing happens.")
-		else if(hacker && !hacker.hacked_apcs_hidden)
-			to_chat(user, "<span class='warning'>Access denied.</span>")
-		else
-			if(has_access(req_access, user.GetAccess()) && !isWireCut(APC_WIRE_IDSCAN))
-				locked = !locked
-				to_chat(user, "You [ locked ? "lock" : "unlock"] the APC interface.")
-				update_icon()
-			else
-				to_chat(user, SPAN_WARNING("Access denied."))
-		return TRUE
-
-	// Inserting board.
-	if(istype(W, /obj/item/module/power_control))
-		if(stat & BROKEN)
-			to_chat(user, SPAN_WARNING("You cannot put the board inside, the frame is damaged."))
-			return TRUE
-		if(!opened)
-			to_chat(user, SPAN_WARNING("You must first open the cover."))
-			return TRUE
-		if(has_electronics != 0)
-			to_chat(user, SPAN_WARNING("There is already a power control board inside."))
-			return TRUE
-		user.visible_message(SPAN_WARNING("\The [user] inserts the power control board into \the [src]."), \
-							"You start to insert the power control board into the frame...")
-		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-		if(do_after(user, 10, src) && has_electronics == 0 && opened && !(stat & BROKEN))
-			has_electronics = 1
-			reboot() //completely new electronics
-			to_chat(user, SPAN_NOTICE("You place the power control board inside the frame."))
-			qdel(W)
-
-	// Deconstruction
-	if(isWelder(W))
-		if(!opened)
-			to_chat(user, SPAN_WARNING("You must first open the cover."))
-			return TRUE
-		if(has_electronics != 0)
-			to_chat(user, SPAN_WARNING("You must first remove the power control board inside."))
-			return TRUE
-		if(terminal())
-			to_chat(user, SPAN_WARNING("The wire connection is in the way."))
-			return TRUE
-		var/obj/item/weldingtool/WT = W
-		if (WT.get_fuel() < 3)
-			to_chat(user, SPAN_WARNING("You need more welding fuel to complete this task."))
-			return
-		user.visible_message(SPAN_WARNING("\The [user] begins to weld \the [src]."), \
-							"You start welding the APC frame...", \
-							"You hear welding.")
-		playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
-		if(do_after(user, 50, src) && opened && has_electronics == 0 && !terminal())
-			if(!WT.remove_fuel(3, user))
-				return TRUE
-			if (emagged || (stat & BROKEN) || opened==2)
-				new /obj/item/stack/material/steel(loc)
-				user.visible_message(\
-					SPAN_WARNING("\The [src] has been cut apart by \the [user] with \the [WT]."),\
-					SPAN_NOTICE("You disassembled the broken APC frame."),\
-					"You hear welding.")
-			else
-				new /obj/item/frame/apc(loc)
-				user.visible_message(\
-					SPAN_WARNING("\The [src] has been cut from the wall by \the [user] with \the [WT]."),\
-					SPAN_NOTICE("You cut the APC frame from the wall."),\
-					"You hear welding.")
-			qdel(src)
-			return TRUE
-
-	// Panel and frame repair.
-	if (istype(W, /obj/item/frame/apc))
-		if(!opened)
-			to_chat(user, SPAN_WARNING("You must first open the cover."))
-			return TRUE
-		if(emagged)
-			emagged = 0
-			if(opened==2)
-				opened = 1
-			user.visible_message(\
-				"<span class='warning'>[user.name] has replaced the damaged APC frontal panel with a new one.</span>",\
-				"<span class='notice'>You replace the damaged APC frontal panel with a new one.</span>")
-			qdel(W)
-			update_icon()
-			return TRUE
-
-		if((stat & BROKEN) || (hacker && !hacker.hacked_apcs_hidden))
-			if (has_electronics)
-				to_chat(user, "<span class='warning'>You cannot repair this APC until you remove the electronics still inside.</span>")
-				return TRUE
-
-			user.visible_message("<span class='warning'>[user.name] replaces the damaged APC frame with a new one.</span>",\
-								"You begin to replace the damaged APC frame...")
-			if(do_after(user, 50, src) && opened && !has_electronics && ((stat & BROKEN) || (hacker && !hacker.hacked_apcs_hidden)))
-				user.visible_message(\
-					"<span class='notice'>[user.name] has replaced the damaged APC frame with new one.</span>",\
-					"You replace the damaged APC frame with new one.")
-				qdel(W)
-				set_broken(FALSE)
-				// Malf AI, removes the APC from AI's hacked APCs list.
-				if(hacker && hacker.hacked_apcs && (src in hacker.hacked_apcs))
-					hacker.hacked_apcs -= src
-					hacker = null
-				if (opened==2)
-					opened = 1
-				queue_icon_update()
-
-	if((. = ..())) // Further interactions are low priority attack stuff.
+/obj/machinery/power/apc/bash(obj/item/W, mob/user)
+	if (!(user.a_intent == I_HURT) || (W.item_flags & ITEM_FLAG_NO_BLUDGEON))
 		return
 
-	if (((stat & BROKEN) || (hacker && !hacker.hacked_apcs_hidden)) \
-			&& !opened \
-			&& W.force >= 5 \
-			&& W.w_class >= ITEM_SIZE_NORMAL \
-			&& prob(20) )
-		opened = 2
-		user.visible_message("<span class='danger'>The APC cover was knocked down with the [W.name] by [user.name]!</span>", \
-			"<span class='danger'>You knock down the APC cover with your [W.name]!</span>", \
-			"You hear a bang")
-		update_icon()
-	else
-		if (istype(user, /mob/living/silicon))
-			return attack_robot(user)
-		if (!opened && wiresexposed && (isMultitool(W) || isWirecutter(W) || istype(W, /obj/item/assembly/signaler)))
-			return wires.Interact(user)
-
-		user.visible_message("<span class='danger'>The [src.name] has been hit with the [W.name] by [user.name]!</span>", \
-			"<span class='danger'>You hit the [src.name] with your [W.name]!</span>", \
-			"You hear a bang")
-		if(W.force >= 5 && W.w_class >= ITEM_SIZE_NORMAL && prob(W.force))
-			var/roulette = rand(1,100)
-			switch(roulette)
-				if(1 to 10)
-					locked = FALSE
-					to_chat(user, "<span class='notice'>You manage to disable the lock on \the [src]!</span>")
-				if(50 to 70)
-					to_chat(user, "<span class='notice'>You manage to bash the lid open!</span>")
-					opened = 1
-				if(90 to 100)
-					to_chat(user, "<span class='warning'>There's a nasty sound and \the [src] goes cold...</span>")
-					set_broken(TRUE)
-			queue_icon_update()
-	playsound(get_turf(src), 'sound/weapons/smash.ogg', 75, 1)
+	if(!panel_open && W.force >= 5 && W.w_class >= ITEM_SIZE_NORMAL)
+		if (((stat & BROKEN) || (hacker && !hacker.hacked_apcs_hidden))	&& prob(20))
+			playsound(get_turf(src), 'sound/weapons/smash.ogg', 75, 1)
+			if(force_open_panel(user) == MCS_CHANGE)
+				cover_removed = TRUE
+				user.visible_message("<span class='danger'>The APC cover was knocked down with the [W.name] by [user.name]!</span>", \
+					"<span class='danger'>You knock down the APC cover with your [W.name]!</span>", \
+					"You hear a bang")
+			return TRUE
+	return ..()
 
 // attack with hand - remove cell (if cover open) or interact with the APC
 
 /obj/machinery/power/apc/emag_act(var/remaining_charges, var/mob/user)
 	if (!(emagged || (hacker && !hacker.hacked_apcs_hidden)))		// trying to unlock with an emag card
-		if(opened)
+		if(panel_open)
 			to_chat(user, "You must close the cover to swipe an ID card.")
-		else if(wiresexposed)
-			to_chat(user, "You must close the panel first")
 		else if(stat & (BROKEN|MAINT))
 			to_chat(user, "Nothing happens.")
 		else
@@ -675,6 +447,8 @@
 					locked = 0
 					to_chat(user, "<span class='notice'>You emag the APC interface.</span>")
 					update_icon()
+				else if(prob(50))
+					return max(..(), 1) // might unlock the panel lock instead.
 				else
 					to_chat(user, "<span class='warning'>You fail to [ locked ? "unlock" : "lock"] the APC interface.</span>")
 				return 1
@@ -692,13 +466,7 @@
 			playsound(src.loc, 'sound/weapons/slash.ogg', 100, 1)
 
 			var/allcut = wires.IsAllCut()
-
-			if(beenhit >= pick(3, 4) && wiresexposed != 1)
-				wiresexposed = 1
-				src.update_icon()
-				src.visible_message("<span class='warning'>\The The [src]'s cover flies open, exposing the wires!</span>")
-
-			else if(wiresexposed == 1 && allcut == 0)
+			if(beenhit >= pick(3, 4) && allcut == 0)
 				wires.CutAll()
 				src.update_icon()
 				src.visible_message("<span class='warning'>\The [src]'s wires are shredded!</span>")
@@ -714,6 +482,11 @@
 	if(!user)
 		return
 	var/obj/item/cell/cell = get_cell()
+	var/coverlocked = FALSE
+	for(var/obj/item/stock_parts/access_lock/lock in get_all_components_of_type(/obj/item/stock_parts/access_lock))
+		if(lock.locked)
+			coverlocked = TRUE
+			break
 
 	var/list/data = list(
 		"pChan_Off" = POWERCHAN_OFF,
@@ -721,7 +494,7 @@
 		"pChan_Off_A" = POWERCHAN_OFF_AUTO,
 		"pChan_On" = POWERCHAN_ON,
 		"pChan_On_A" = POWERCHAN_ON_AUTO,
-		"locked" = (locked && !emagged) ? 1 : 0,
+		"locked" = locked,
 		"isOperating" = operating,
 		"externalPower" = main_status,
 		"powerCellStatus" = cell ? cell.percent() : null,
@@ -834,60 +607,68 @@
 		to_chat(user, "<span class='warning'>You must have free hands to use [src].</span>")
 		. = min(., STATUS_UPDATE)
 
-/obj/machinery/power/apc/Topic(href, href_list)
-	if(..())
-		return 1
+/obj/machinery/power/apc/OnTopic(mob/user, list/href_list, state)
+	if(href_list["toggleaccess"])
+		if(emagged || (stat & (BROKEN|MAINT)) || (hacker && !hacker.hacked_apcs_hidden))
+			to_chat(user, "The APC does not respond to the command.")
+		else
+			locked = !locked
+			update_icon()
+		return TOPIC_REFRESH
 
-	if(!istype(usr, /mob/living/silicon) && (locked && !emagged))
-		// Shouldn't happen, this is here to prevent href exploits
-		to_chat(usr, "You must unlock the panel to use this!")
-		return 1
+	if(locked)
+		return TOPIC_REFRESH
 
-	if (href_list["lock"])
-		coverlocked = !coverlocked
+	if(href_list["lock"])
+		var/coverlocked = FALSE
+		var/list/locks = get_all_components_of_type(/obj/item/stock_parts/access_lock)
+		for(var/obj/item/stock_parts/access_lock/lock in locks)
+			if(lock.locked)
+				coverlocked = TRUE
+				break
+		for(var/obj/item/stock_parts/access_lock/lock in locks)
+			lock.locked = !coverlocked
+		return TOPIC_REFRESH
 
-	else if( href_list["reboot"] )
+	if(href_list["reboot"] )
 		failure_timer = 0
 		update_icon()
 		update()
+		return TOPIC_REFRESH
 
-	else if (href_list["breaker"])
+	if(href_list["breaker"])
 		toggle_breaker()
+		return TOPIC_REFRESH
 
-	else if (href_list["cmode"])
+	if(href_list["cmode"])
 		set_chargemode(!chargemode)
 		if(!chargemode)
 			charging = 0
 			update_icon()
+		return TOPIC_REFRESH
 
-	else if (href_list["eqp"])
+	if(href_list["eqp"])
 		var/val = text2num(href_list["eqp"])
 		equipment = setsubsystem(val)
 		force_update_channels()
+		return TOPIC_REFRESH
 
-	else if (href_list["lgt"])
+	if(href_list["lgt"])
 		var/val = text2num(href_list["lgt"])
 		lighting = setsubsystem(val)
 		force_update_channels()
+		return TOPIC_REFRESH
 
-	else if (href_list["env"])
+	if(href_list["env"])
 		var/val = text2num(href_list["env"])
 		environ = setsubsystem(val)
 		force_update_channels()
+		return TOPIC_REFRESH
 
-	else if (href_list["overload"])
-		if(istype(usr, /mob/living/silicon))
-			src.overload_lighting()
-
-	else if (href_list["toggleaccess"])
-		if(istype(usr, /mob/living/silicon))
-			if(emagged || (stat & (BROKEN|MAINT)))
-				to_chat(usr, "The APC does not respond to the command.")
-			else
-				locked = !locked
-				update_icon()
-
-	return 0
+	if(href_list["overload"])
+		if(istype(user, /mob/living/silicon))
+			overload_lighting()
+		return TOPIC_REFRESH
 
 /obj/machinery/power/apc/proc/force_update_channels()
 	autoflag = -1 // This clears state, forcing a full recalculation
@@ -953,9 +734,6 @@
 		charging = 0
 	else
 		..() // Actual processing happens in here.
-
-		if(debug)
-			log_debug("Status: [main_status] - Excess: [excess] - Last Equip: [lastused_equip] - Last Light: [lastused_light] - Longterm: [longtermpower]")
 
 		//update state
 		var/obj/item/stock_parts/power/battery/power = get_component_of_type(/obj/item/stock_parts/power/battery)
@@ -1045,54 +823,27 @@ obj/machinery/power/apc/proc/autoset(var/cur_state, var/on)
 /obj/machinery/power/apc/emp_act(severity)
 	if(emp_hardened)
 		return
-	var/obj/item/cell/cell = get_cell()
 	// Fail for 8-12 minutes (divided by severity)
 	// Division by 2 is required, because machinery ticks are every two seconds. Without it we would fail for 16-24 minutes.
 	if(is_critical)
 		// Critical APCs are considered EMP shielded and will be offline only for about half minute. Prevents AIs being one-shot disabled by EMP strike.
 		// Critical APCs are also more resilient to cell corruption/power drain.
 		energy_fail(rand(240, 360) / severity / CRITICAL_APC_EMP_PROTECTION)
-		if(cell)
-			cell.emp_act(severity+2)
 	else
 		// Regular APCs fail for normal time.
 		energy_fail(rand(240, 360) / severity)
-		if(cell)
-			cell.emp_act(severity+1)
-
-	update_icon()
+	queue_icon_update()
 	..()
 
-/obj/machinery/power/apc/ex_act(severity)
-	var/obj/item/cell/C = get_cell()
-	switch(severity)
-		if(1.0)
-			qdel(src)
-			if (C)
-				C.ex_act(1.0) // more lags woohoo
-			return
-		if(2.0)
-			if (prob(50))
-				set_broken(TRUE)
-				if (C && prob(50))
-					C.ex_act(2.0)
-		if(3.0)
-			if (prob(25))
-				set_broken(TRUE)
-				if (C && prob(25))
-					C.ex_act(3.0)
-
-/obj/machinery/power/apc/set_broken(new_state)
-	if(!new_state || (stat & BROKEN))
-		return ..()
-	visible_message("<span class='notice'>[src]'s screen flickers with warnings briefly!</span>")
-	power_alarm.triggerAlarm(loc, src)
-	spawn(rand(2,5))
-		..()
-		visible_message("<span class='notice'>[src]'s screen suddenly explodes in rain of sparks and small debris!</span>")
-		operating = 0
-		update()
-	return TRUE
+/obj/machinery/power/apc/on_component_failure(obj/item/stock_parts/component)
+	var/was_broken = stat & BROKEN
+	. = ..()
+	if(!was_broken && (stat & BROKEN))
+		visible_message("<span class='notice'>[src]'s screen flickers with warnings briefly!</span>")
+		power_alarm.triggerAlarm(loc, src)
+		spawn(rand(2,5))
+			operating = 0
+			update()
 
 /obj/machinery/power/apc/proc/reboot()
 	//reset various counters so that process() will start fresh
@@ -1151,16 +902,6 @@ obj/machinery/power/apc/proc/autoset(var/cur_state, var/on)
 	locked = 1
 	update_icon()
 	return 1
-
-/obj/item/module/power_control
-	name = "power control module"
-	desc = "Heavy-duty switching circuits for power control."
-	icon = 'icons/obj/module.dmi'
-	icon_state = "power_mod"
-	item_state = "electronic"
-	matter = list(MAT_STEEL = 50, MAT_GLASS = 50)
-	w_class = ITEM_SIZE_SMALL
-	obj_flags = OBJ_FLAG_CONDUCTIBLE
 
 /obj/machinery/power/apc/malf_upgrade(var/mob/living/silicon/ai/user)
 	..()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -169,6 +169,8 @@
 		var/area/A = get_area(src)
 		//if area isn't specified use current
 		area = A
+	if(!area)
+		return ..() // Spawned in nullspace means it's a test entity or prototype.
 	if(autoname)
 		SetName("\improper [area.name] APC")
 	area.apc = src
@@ -186,12 +188,13 @@
 	power_change()
 
 /obj/machinery/power/apc/Destroy()
-	src.update()
-	area.apc = null
-	area.power_light = 0
-	area.power_equip = 0
-	area.power_environ = 0
-	area.power_change()
+	if(area)
+		update()
+		area.apc = null
+		area.power_light = 0
+		area.power_equip = 0
+		area.power_environ = 0
+		area.power_change()
 
 	// Malf AI, removes the APC from AI's hacked APCs list.
 	if((hacker) && (hacker.hacked_apcs) && (src in hacker.hacked_apcs))
@@ -694,6 +697,8 @@
 	if(autoflag)
 		return lastused_total // If not, we need to do something more sophisticated: compute how much power we would need in order to come back online.
 	. = 0
+	if(!area)
+		return
 	if(autoset(lighting, 2) >= POWERCHAN_ON)
 		. += area.usage(LIGHT)
 	if(autoset(equipment, 2) >= POWERCHAN_ON)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -133,7 +133,7 @@
 	base_type = /obj/machinery/power/apc/buildable
 	stat_immune = 0
 	frame_type = /obj/item/frame/apc
-	construct_state = /decl/machine_construction/wall_frame/panel_closed
+	construct_state = /decl/machine_construction/wall_frame/panel_closed/hackable
 	uncreated_component_parts = list(
 		/obj/item/cell/apc
 	)
@@ -304,6 +304,8 @@
 			icon_state = "apc-b"
 		else if(update_state & UPDATE_BLUESCREEN)
 			icon_state = "apcemag"
+		else if(update_state & UPDATE_WIREEXP)
+			icon_state = "apcewires"
 
 	if(!(update_state & UPDATE_ALLGOOD))
 		if(overlays.len)
@@ -360,6 +362,8 @@
 			update_state |= UPDATE_OPENED2
 	else if(emagged || (hacker && !hacker.hacked_apcs_hidden) || failure_timer)
 		update_state |= UPDATE_BLUESCREEN
+	else if(istype(construct_state, /decl/machine_construction/wall_frame/panel_closed/hackable/hacking))
+		update_state |= UPDATE_WIREEXP
 	if(update_state <= 1)
 		update_state |= UPDATE_ALLGOOD
 
@@ -392,6 +396,12 @@
 		results += 2
 	return results
 
+/obj/machinery/power/apc/set_broken(new_state, cause)
+	. = ..()
+	if(. && (stat & BROKEN))
+		operating = 0
+		update()
+
 /obj/machinery/power/apc/cannot_transition_to(state_path, mob/user)
 	if(ispath(state_path, /decl/machine_construction/wall_frame/panel_closed) && cover_removed)
 		return SPAN_NOTICE("You cannot close the cover: it was completely removed!")
@@ -411,7 +421,7 @@
 	queue_icon_update()
 
 /obj/machinery/power/apc/attackby(obj/item/W, mob/user)
-	if (!panel_open && (isMultitool(W) || isWirecutter(W) || istype(W, /obj/item/assembly/signaler)))
+	if (istype(construct_state, /decl/machine_construction/wall_frame/panel_closed/hackable/hacking) && (isMultitool(W) || isWirecutter(W) || istype(W, /obj/item/assembly/signaler)))
 		return wires.Interact(user)
 	return ..()
 

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -513,8 +513,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/derelict{
-	cell_type = /obj/item/cell;
+/obj/machinery/power/apc/derelict/full{
 	dir = 4;
 	name = "Captain's Quarters APC"
 	},
@@ -2782,8 +2781,7 @@
 "eO" = (
 /obj/structure/table/standard,
 /obj/structure/cable,
-/obj/machinery/power/apc/derelict{
-	cell_type = /obj/item/cell;
+/obj/machinery/power/apc/derelict/full{
 	name = "Medical Bay APC"
 	},
 /obj/machinery/light_switch{
@@ -3543,8 +3541,7 @@
 /turf/simulated/floor/usedup,
 /area/ship/scrap/unused)
 "gc" = (
-/obj/machinery/power/apc/derelict{
-	cell_type = /obj/item/cell;
+/obj/machinery/power/apc/derelict/full{
 	name = "Medical Bay APC"
 	},
 /obj/structure/cable,
@@ -5913,8 +5910,7 @@
 /turf/simulated/floor/tiled/airless,
 /area/ship/scrap/maintenance/atmos)
 "PP" = (
-/obj/machinery/power/apc/derelict{
-	cell_type = /obj/item/cell;
+/obj/machinery/power/apc/derelict/full{
 	name = "Medical Bay APC"
 	},
 /obj/structure/cable{

--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -84,12 +84,18 @@
 	base_turf = /turf/simulated/floor
 
 /obj/machinery/power/apc/derelict
-	cell_type = /obj/item/cell/crap/empty
 	lighting = 0
 	equipment = 0
 	environ = 0
 	locked = 0
-	coverlocked = 0
+	uncreated_component_parts = list(
+		/obj/item/cell/crap/empty
+	)
+
+/obj/machinery/power/apc/derelict/full
+	uncreated_component_parts = list(
+		/obj/item/cell/crap
+	)
 
 /obj/machinery/door/airlock/autoname/command
 	door_color = COLOR_COMMAND_BLUE

--- a/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
@@ -255,7 +255,7 @@
 /obj/item/frame/apc,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cell/crap/empty,
-/obj/item/module/power_control,
+/obj/item/stock_parts/circuitboard/apc,
 /turf/simulated/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aI" = (

--- a/nano/templates/apc.tmpl
+++ b/nano/templates/apc.tmpl
@@ -7,21 +7,13 @@
 </div>
 {{else}}
 <div class='notice'>
-	{{if data.siliconUser}}
-		<div class="itemContentSmall">
-			Interface Lock:
-		</div>
-		<div class="itemContentFull">
-			{{:helper.link('Engaged', 'locked', {'toggleaccess' : 1}, data.locked ? 'selected' : null)}}{{:helper.link('Disengaged', 'unlocked', {'toggleaccess' : 1}, data.malfStatus >= 2 ? 'linkOff' : (data.locked ? null : 'selected'))}}
-		</div>
-		<div class="clearBoth"></div>
-	{{else}}
-		{{if data.locked}}
-			Swipe an ID card to unlock this interface
-		{{else}}
-			Swipe an ID card to lock this interface
-		{{/if}}
-	{{/if}}
+	<div class="itemContentSmall">
+		Interface Lock:
+	</div>
+	<div class="itemContentFull">
+		{{:helper.link('Engaged', 'locked', {'toggleaccess' : 1}, data.locked ? 'selected' : null)}}{{:helper.link('Disengaged', 'unlocked', {'toggleaccess' : 1}, data.malfStatus >= 2 ? 'linkOff' : (data.locked ? null : 'selected'))}}
+	</div>
+	<div class="clearBoth"></div>
 </div>
 
 <div style="min-width: 480px">

--- a/nebula.dme
+++ b/nebula.dme
@@ -720,6 +720,7 @@
 #include "code\game\machinery\_machines_base\machine_construction\item_chassis.dm"
 #include "code\game\machinery\_machines_base\machine_construction\tcomms.dm"
 #include "code\game\machinery\_machines_base\machine_construction\wall_frame.dm"
+#include "code\game\machinery\_machines_base\machine_construction\wall_frame_hackable.dm"
 #include "code\game\machinery\_machines_base\machine_construction\wall_frame_simple.dm"
 #include "code\game\machinery\_machines_base\stock_parts\_stock_parts.dm"
 #include "code\game\machinery\_machines_base\stock_parts\access_lock.dm"

--- a/nebula.dme
+++ b/nebula.dme
@@ -722,6 +722,7 @@
 #include "code\game\machinery\_machines_base\machine_construction\wall_frame.dm"
 #include "code\game\machinery\_machines_base\machine_construction\wall_frame_simple.dm"
 #include "code\game\machinery\_machines_base\stock_parts\_stock_parts.dm"
+#include "code\game\machinery\_machines_base\stock_parts\access_lock.dm"
 #include "code\game\machinery\_machines_base\stock_parts\building_material.dm"
 #include "code\game\machinery\_machines_base\stock_parts\legacy_parts.dm"
 #include "code\game\machinery\_machines_base\stock_parts\shielding.dm"


### PR DESCRIPTION
Migration procedure: replace `/obj/item/module/power_control` with `/obj/item/stock_parts/circuitboard/apc`. If maps still have removed vars set, remove them (you can do more sophisticated stuff, but it's unlikely to be worth it).