### PR TITLE
Implements scaling glide_size, mostly for mobs and grabbed atoms.

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -324,3 +324,5 @@
 #define DEXTERITY_WEAPONS         5
 #define DEXTERITY_COMPLEX_TOOLS   6
 #define DEXTERITY_FULL            7
+
+#define GLIDE_SIZE_CONSTANT world.tick_lag

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -144,9 +144,11 @@
 
 /datum/movement_handler/mob/delay/proc/SetDelay(var/delay)
 	next_move = max(next_move, world.time + delay)
+	mob.glide_size = world.icon_size / max((delay-GLIDE_SIZE_CONSTANT), world.tick_lag) * world.tick_lag
 
 /datum/movement_handler/mob/delay/proc/AddDelay(var/delay)
 	next_move += max(0, delay)
+	mob.glide_size = world.icon_size / max((next_move-world.time)-GLIDE_SIZE_CONSTANT, world.tick_lag) * world.tick_lag
 
 // Stop effect
 /datum/movement_handler/mob/stop_effect/DoMove()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -131,6 +131,7 @@
 
 /atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, datum/callback/callback) //If this returns FALSE then callback will not be called.
 	. = TRUE
+	glide_size = world.icon_size / max((speed - GLIDE_SIZE_CONSTANT), world.tick_lag) * world.tick_lag
 	if (!target || speed <= 0 || QDELETED(src) || (target.z != src.z))
 		return FALSE
 

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -273,6 +273,7 @@
 	return current_grab.grab_slowdown
 
 /obj/item/grab/proc/assailant_moved()
+	affecting.glide_size = assailant.glide_size
 	current_grab.assailant_moved(src)
 
 /obj/item/grab/proc/restrains()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -132,6 +132,7 @@ default behaviour is:
 					for(var/obj/structure/window/win in get_step(AM,t))
 						now_pushing = 0
 						return
+				AM.glide_size = glide_size
 				step(AM, t)
 				if (istype(AM, /mob/living))
 					var/mob/living/tmob = AM


### PR DESCRIPTION
Smooths movement out based on expected move delays.