### PR TITLE
Removing sort_string and id from research datums.

### DIFF
--- a/code/modules/power/fusion/fusion_circuits.dm
+++ b/code/modules/power/fusion/fusion_circuits.dm
@@ -75,42 +75,34 @@
 
 /datum/design/circuit/fusion
 	name = "fusion core control console"
-	id = "fusion_core_control"
 	build_path = /obj/item/stock_parts/circuitboard/fusion/core_control
 	req_tech = list(TECH_POWER = 3, TECH_ENGINEERING = 3, TECH_MATERIAL = 3)
 
 /datum/design/circuit/fusion/fuel_compressor
 	name = "fusion fuel compressor"
-	id = "fusion_fuel_compressor"
 	build_path = /obj/item/stock_parts/circuitboard/fusion_fuel_compressor
 
 /datum/design/circuit/fusion/fuel_control
 	name = "fusion fuel control console"
-	id = "fusion_fuel_control"
 	build_path = /obj/item/stock_parts/circuitboard/fusion_fuel_control
 
 /datum/design/circuit/fusion/gyrotron_control
 	name = "gyrotron control console"
-	id = "gyrotron_control"
 	build_path = /obj/item/stock_parts/circuitboard/gyrotron_control
 
 /datum/design/circuit/fusion/core
 	name = "fusion core"
-	id = "fusion_core"
 	build_path = /obj/item/stock_parts/circuitboard/fusion_core
 
 /datum/design/circuit/fusion/injector
 	name = "fusion fuel injector"
-	id = "fusion_injector"
 	build_path = /obj/item/stock_parts/circuitboard/fusion_injector
 
 /datum/design/circuit/fusion/kinetic_harvester
 	name = "fusion toroid kinetic harvester"
-	id = "fusion_kinetic_harvester"
 	build_path = /obj/item/stock_parts/circuitboard/kinetic_harvester
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4, TECH_MATERIAL = 4)
 
 /datum/design/circuit/fusion/gyrotron
 	name = "gyrotron"
-	id = "gyrotron"
 	build_path = /obj/item/stock_parts/circuitboard/gyrotron

--- a/code/modules/power/fusion/fusion_circuits.dm
+++ b/code/modules/power/fusion/fusion_circuits.dm
@@ -77,48 +77,40 @@
 	name = "fusion core control console"
 	id = "fusion_core_control"
 	build_path = /obj/item/stock_parts/circuitboard/fusion/core_control
-	sort_string = "LAAAD"
 	req_tech = list(TECH_POWER = 3, TECH_ENGINEERING = 3, TECH_MATERIAL = 3)
 
 /datum/design/circuit/fusion/fuel_compressor
 	name = "fusion fuel compressor"
 	id = "fusion_fuel_compressor"
 	build_path = /obj/item/stock_parts/circuitboard/fusion_fuel_compressor
-	sort_string = "LAAAE"
 
 /datum/design/circuit/fusion/fuel_control
 	name = "fusion fuel control console"
 	id = "fusion_fuel_control"
 	build_path = /obj/item/stock_parts/circuitboard/fusion_fuel_control
-	sort_string = "LAAAF"
 
 /datum/design/circuit/fusion/gyrotron_control
 	name = "gyrotron control console"
 	id = "gyrotron_control"
 	build_path = /obj/item/stock_parts/circuitboard/gyrotron_control
-	sort_string = "LAAAG"
 
 /datum/design/circuit/fusion/core
 	name = "fusion core"
 	id = "fusion_core"
 	build_path = /obj/item/stock_parts/circuitboard/fusion_core
-	sort_string = "LAAAH"
 
 /datum/design/circuit/fusion/injector
 	name = "fusion fuel injector"
 	id = "fusion_injector"
 	build_path = /obj/item/stock_parts/circuitboard/fusion_injector
-	sort_string = "LAAAI"
 
 /datum/design/circuit/fusion/kinetic_harvester
 	name = "fusion toroid kinetic harvester"
 	id = "fusion_kinetic_harvester"
 	build_path = /obj/item/stock_parts/circuitboard/kinetic_harvester
-	sort_string = "LAAAJ"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4, TECH_MATERIAL = 4)
 
 /datum/design/circuit/fusion/gyrotron
 	name = "gyrotron"
 	id = "gyrotron"
 	build_path = /obj/item/stock_parts/circuitboard/gyrotron
-	sort_string = "LAAAK"

--- a/code/modules/research/designs/_designs.dm
+++ b/code/modules/research/designs/_designs.dm
@@ -22,7 +22,6 @@ other types of metals and chemistry for reagents).
 	var/name = "design"         //Name of the created object. If null it will be 'guessed' from build_path if possible.
 	var/desc                    //Description of the created object. If null it will use group_desc and name where applicable.
 	var/item_name               //An item name before it is modified by various name-modifying procs
-	var/id = "id"               //ID of the created object for easy refernece. Alphanumeric, lower-case, no symbols.
 	var/build_type              //Flag as to what kind machine the design is built in. See defines.
 	var/build_path              //The path of the object that gets created.
 	var/time = 10               //How many ticks it requires to build

--- a/code/modules/research/designs/_designs.dm
+++ b/code/modules/research/designs/_designs.dm
@@ -18,19 +18,18 @@ other types of metals and chemistry for reagents).
 */
 //Note: More then one of these can be added to a design.
 
-/datum/design						//Datum for object designs, used in construction
-	var/name = null					//Name of the created object. If null it will be 'guessed' from build_path if possible.
-	var/desc = null					//Description of the created object. If null it will use group_desc and name where applicable.
-	var/item_name = null			//An item name before it is modified by various name-modifying procs
-	var/id = "id"					//ID of the created object for easy refernece. Alphanumeric, lower-case, no symbols.
-	var/list/req_tech = list()		//IDs of that techs the object originated from and the minimum level requirements.
-	var/build_type = null			//Flag as to what kind machine the design is built in. See defines.
-	var/list/materials = list()		//List of materials. Format: "id" = amount.
-	var/list/chemicals = list()		//List of chemicals.
-	var/build_path = null			//The path of the object that gets created.
-	var/time = 10					//How many ticks it requires to build
-	var/category = null 			//Primarily used for Mech Fabricators, but can be used for anything.
-	var/sort_string = "ZZZZZ"		//Sorting order
+/datum/design                   //Datum for object designs, used in construction
+	var/name = "design"         //Name of the created object. If null it will be 'guessed' from build_path if possible.
+	var/desc                    //Description of the created object. If null it will use group_desc and name where applicable.
+	var/item_name               //An item name before it is modified by various name-modifying procs
+	var/id = "id"               //ID of the created object for easy refernece. Alphanumeric, lower-case, no symbols.
+	var/build_type              //Flag as to what kind machine the design is built in. See defines.
+	var/build_path              //The path of the object that gets created.
+	var/time = 10               //How many ticks it requires to build
+	var/category                //Primarily used for Mech Fabricators, but can be used for anything.
+	var/list/req_tech = list()  //IDs of that techs the object originated from and the minimum level requirements.
+	var/list/materials = list() //List of materials. Format: "id" = amount.
+	var/list/chemicals = list() //List of chemicals.
 
 /datum/design/New()
 	..()

--- a/code/modules/research/designs/design_aimodule.dm
+++ b/code/modules/research/designs/design_aimodule.dm
@@ -13,63 +13,54 @@
 	id = "safeguard"
 	req_tech = list(TECH_DATA = 3, TECH_MATERIAL = 4)
 	build_path = /obj/item/aiModule/safeguard
-	sort_string = "XABAA"
 
 /datum/design/aimodule/onehuman
 	name = "OneCrewMember"
 	id = "onehuman"
 	req_tech = list(TECH_DATA = 4, TECH_MATERIAL = 6)
 	build_path = /obj/item/aiModule/oneHuman
-	sort_string = "XABAB"
 
 /datum/design/aimodule/protectstation
 	name = "ProtectInstallation"
 	id = "protectstation"
 	req_tech = list(TECH_DATA = 3, TECH_MATERIAL = 6)
 	build_path = /obj/item/aiModule/protectStation
-	sort_string = "XABAC"
 
 /datum/design/aimodule/notele
 	name = "TeleporterOffline"
 	id = "notele"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/aiModule/teleporterOffline
-	sort_string = "XABAD"
 
 /datum/design/aimodule/quarantine
 	name = "Quarantine"
 	id = "quarantine"
 	req_tech = list(TECH_DATA = 3, TECH_BIO = 2, TECH_MATERIAL = 4)
 	build_path = /obj/item/aiModule/quarantine
-	sort_string = "XABAE"
 
 /datum/design/aimodule/oxygen
 	name = "OxygenIsToxicToHumans"
 	id = "oxygen"
 	req_tech = list(TECH_DATA = 3, TECH_BIO = 2, TECH_MATERIAL = 4)
 	build_path = /obj/item/aiModule/oxygen
-	sort_string = "XABAF"
 
 /datum/design/aimodule/freeform
 	name = "Freeform"
 	id = "freeform"
 	req_tech = list(TECH_DATA = 4, TECH_MATERIAL = 4)
 	build_path = /obj/item/aiModule/freeform
-	sort_string = "XABAG"
 
 /datum/design/aimodule/reset
 	name = "Reset"
 	id = "reset"
 	req_tech = list(TECH_DATA = 3, TECH_MATERIAL = 6)
 	build_path = /obj/item/aiModule/reset
-	sort_string = "XAAAA"
 
 /datum/design/aimodule/purge
 	name = "Purge"
 	id = "purge"
 	req_tech = list(TECH_DATA = 4, TECH_MATERIAL = 6)
 	build_path = /obj/item/aiModule/purge
-	sort_string = "XAAAB"
 
 // Core modules
 /datum/design/aimodule/core
@@ -85,23 +76,19 @@
 	name = "Freeform"
 	id = "freeformcore"
 	build_path = /obj/item/aiModule/freeformcore
-	sort_string = "XACAA"
 
 /datum/design/aimodule/core/asimov
 	name = "Asimov"
 	id = "asimov"
 	build_path = /obj/item/aiModule/asimov
-	sort_string = "XACAB"
 
 /datum/design/aimodule/core/paladin
 	name = "P.A.L.A.D.I.N."
 	id = "paladin"
 	build_path = /obj/item/aiModule/paladin
-	sort_string = "XACAC"
 
 /datum/design/aimodule/core/tyrant
 	name = "T.Y.R.A.N.T."
 	id = "tyrant"
 	req_tech = list(TECH_DATA = 4, TECH_ESOTERIC = 2, TECH_MATERIAL = 6)
 	build_path = /obj/item/aiModule/tyrant
-	sort_string = "XACAD"

--- a/code/modules/research/designs/design_aimodule.dm
+++ b/code/modules/research/designs/design_aimodule.dm
@@ -10,55 +10,46 @@
 
 /datum/design/aimodule/safeguard
 	name = "Safeguard"
-	id = "safeguard"
 	req_tech = list(TECH_DATA = 3, TECH_MATERIAL = 4)
 	build_path = /obj/item/aiModule/safeguard
 
 /datum/design/aimodule/onehuman
 	name = "OneCrewMember"
-	id = "onehuman"
 	req_tech = list(TECH_DATA = 4, TECH_MATERIAL = 6)
 	build_path = /obj/item/aiModule/oneHuman
 
 /datum/design/aimodule/protectstation
 	name = "ProtectInstallation"
-	id = "protectstation"
 	req_tech = list(TECH_DATA = 3, TECH_MATERIAL = 6)
 	build_path = /obj/item/aiModule/protectStation
 
 /datum/design/aimodule/notele
 	name = "TeleporterOffline"
-	id = "notele"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/aiModule/teleporterOffline
 
 /datum/design/aimodule/quarantine
 	name = "Quarantine"
-	id = "quarantine"
 	req_tech = list(TECH_DATA = 3, TECH_BIO = 2, TECH_MATERIAL = 4)
 	build_path = /obj/item/aiModule/quarantine
 
 /datum/design/aimodule/oxygen
 	name = "OxygenIsToxicToHumans"
-	id = "oxygen"
 	req_tech = list(TECH_DATA = 3, TECH_BIO = 2, TECH_MATERIAL = 4)
 	build_path = /obj/item/aiModule/oxygen
 
 /datum/design/aimodule/freeform
 	name = "Freeform"
-	id = "freeform"
 	req_tech = list(TECH_DATA = 4, TECH_MATERIAL = 4)
 	build_path = /obj/item/aiModule/freeform
 
 /datum/design/aimodule/reset
 	name = "Reset"
-	id = "reset"
 	req_tech = list(TECH_DATA = 3, TECH_MATERIAL = 6)
 	build_path = /obj/item/aiModule/reset
 
 /datum/design/aimodule/purge
 	name = "Purge"
-	id = "purge"
 	req_tech = list(TECH_DATA = 4, TECH_MATERIAL = 6)
 	build_path = /obj/item/aiModule/purge
 
@@ -74,21 +65,17 @@
 
 /datum/design/aimodule/core/freeformcore
 	name = "Freeform"
-	id = "freeformcore"
 	build_path = /obj/item/aiModule/freeformcore
 
 /datum/design/aimodule/core/asimov
 	name = "Asimov"
-	id = "asimov"
 	build_path = /obj/item/aiModule/asimov
 
 /datum/design/aimodule/core/paladin
 	name = "P.A.L.A.D.I.N."
-	id = "paladin"
 	build_path = /obj/item/aiModule/paladin
 
 /datum/design/aimodule/core/tyrant
 	name = "T.Y.R.A.N.T."
-	id = "tyrant"
 	req_tech = list(TECH_DATA = 4, TECH_ESOTERIC = 2, TECH_MATERIAL = 6)
 	build_path = /obj/item/aiModule/tyrant

--- a/code/modules/research/designs/designs_beaker.dm
+++ b/code/modules/research/designs/designs_beaker.dm
@@ -4,7 +4,6 @@
 /datum/design/item/beaker/noreact
 	name = "cryostasis"
 	desc = "A cryostasis beaker that allows for chemical storage without reactions. Can hold up to 50 units."
-	id = "splitbeaker"
 	req_tech = list(TECH_MATERIAL = 2)
 	materials = list(MAT_STEEL = 3000)
 	build_path = /obj/item/chems/glass/beaker/noreact
@@ -12,7 +11,6 @@
 /datum/design/item/beaker/bluespace
 	name = TECH_BLUESPACE
 	desc = "A bluespace beaker, which uses experimental technology to prevent its contents from reacting. Can hold up to 300 units."
-	id = "bluespacebeaker"
 	req_tech = list(TECH_BLUESPACE = 2, TECH_MATERIAL = 6)
 	materials = list(MAT_STEEL = 3000, MAT_PHORON = 3000, MAT_DIAMOND = 500)
 	build_path = /obj/item/chems/glass/beaker/bluespace

--- a/code/modules/research/designs/designs_beaker.dm
+++ b/code/modules/research/designs/designs_beaker.dm
@@ -8,7 +8,6 @@
 	req_tech = list(TECH_MATERIAL = 2)
 	materials = list(MAT_STEEL = 3000)
 	build_path = /obj/item/chems/glass/beaker/noreact
-	sort_string = "MCAAA"
 
 /datum/design/item/beaker/bluespace
 	name = TECH_BLUESPACE
@@ -17,4 +16,3 @@
 	req_tech = list(TECH_BLUESPACE = 2, TECH_MATERIAL = 6)
 	materials = list(MAT_STEEL = 3000, MAT_PHORON = 3000, MAT_DIAMOND = 500)
 	build_path = /obj/item/chems/glass/beaker/bluespace
-	sort_string = "MCAAB"

--- a/code/modules/research/designs/designs_biostorage.dm
+++ b/code/modules/research/designs/designs_biostorage.dm
@@ -10,7 +10,6 @@
 	materials = list(MAT_STEEL = 1000, MAT_GLASS = 500)
 	build_path = /obj/item/mmi
 	category = "Misc"
-	sort_string = "VACCA"
 
 /datum/design/item/biostorage/mmi_radio
 	name = "radio-enabled man-machine interface"
@@ -20,4 +19,3 @@
 	materials = list(MAT_ALUMINIUM = 1200, MAT_GLASS = 500)
 	build_path = /obj/item/mmi/radio_enabled
 	category = "Misc"
-	sort_string = "VACCB"

--- a/code/modules/research/designs/designs_biostorage.dm
+++ b/code/modules/research/designs/designs_biostorage.dm
@@ -4,7 +4,6 @@
 
 /datum/design/item/biostorage/mmi
 	name = "man-machine interface"
-	id = "mmi"
 	req_tech = list(TECH_DATA = 2, TECH_BIO = 3)
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_STEEL = 1000, MAT_GLASS = 500)
@@ -13,7 +12,6 @@
 
 /datum/design/item/biostorage/mmi_radio
 	name = "radio-enabled man-machine interface"
-	id = "mmi_radio"
 	req_tech = list(TECH_DATA = 2, TECH_BIO = 4)
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_ALUMINIUM = 1200, MAT_GLASS = 500)

--- a/code/modules/research/designs/designs_bluespace.dm
+++ b/code/modules/research/designs/designs_bluespace.dm
@@ -8,7 +8,6 @@
 	req_tech = list(TECH_BLUESPACE = 1)
 	materials = list (MAT_ALUMINIUM = 20, MAT_GLASS = 10)
 	build_path = /obj/item/radio/beacon
-	sort_string = "VADAA"
 
 /datum/design/item/bluespace/gps
 	name = "triangulating device"
@@ -17,7 +16,6 @@
 	req_tech = list(TECH_MATERIAL = 2, TECH_DATA = 2, TECH_BLUESPACE = 2)
 	materials = list(MAT_ALUMINIUM = 250, MAT_STEEL = 250, MAT_GLASS = 50)
 	build_path = /obj/item/gps
-	sort_string = "VADAB"
 
 /datum/design/item/bluespace/beacon_locator
 	name = "beacon tracking pinpointer"
@@ -26,7 +24,6 @@
 	req_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 2, TECH_BLUESPACE = 3)
 	materials = list(MAT_ALUMINIUM = 1000, MAT_GLASS = 500)
 	build_path = /obj/item/pinpointer/radio
-	sort_string = "VADAC"
 
 /datum/design/item/bluespace/ano_scanner
 	name = "Alden-Saraspova counter"
@@ -35,7 +32,6 @@
 	req_tech = list(TECH_BLUESPACE = 3, TECH_MAGNET = 3)
 	materials = list(MAT_STEEL = 5000, MAT_ALUMINIUM = 5000, MAT_GLASS = 5000)
 	build_path = /obj/item/ano_scanner
-	sort_string = "VAEAA"
 
 /datum/design/item/bluespace/bag_holding
 	name = "bag of holding"
@@ -44,7 +40,6 @@
 	req_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 6)
 	materials = list(MAT_GOLD = 3000, MAT_DIAMOND = 1500, MAT_URANIUM = 250, MAT_PLASTIC = 250)
 	build_path = /obj/item/storage/backpack/holding
-	sort_string = "VAFAA"
 
 /datum/design/item/dufflebag_holding
 	name = "dufflebag of holding"
@@ -53,4 +48,3 @@
 	req_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 6)
 	materials = list(MAT_GOLD = 3000, MAT_DIAMOND = 1500, MAT_URANIUM = 250, MAT_PLASTIC = 250)
 	build_path = /obj/item/storage/backpack/holding/duffle
-	sort_string = "VAFAB"

--- a/code/modules/research/designs/designs_bluespace.dm
+++ b/code/modules/research/designs/designs_bluespace.dm
@@ -4,7 +4,6 @@
 
 /datum/design/item/bluespace/beacon
 	name = "tracking beacon"
-	id = "beacon"
 	req_tech = list(TECH_BLUESPACE = 1)
 	materials = list (MAT_ALUMINIUM = 20, MAT_GLASS = 10)
 	build_path = /obj/item/radio/beacon
@@ -12,7 +11,6 @@
 /datum/design/item/bluespace/gps
 	name = "triangulating device"
 	desc = "Triangulates approximate co-ordinates using a nearby satellite network."
-	id = "gps"
 	req_tech = list(TECH_MATERIAL = 2, TECH_DATA = 2, TECH_BLUESPACE = 2)
 	materials = list(MAT_ALUMINIUM = 250, MAT_STEEL = 250, MAT_GLASS = 50)
 	build_path = /obj/item/gps
@@ -20,14 +18,12 @@
 /datum/design/item/bluespace/beacon_locator
 	name = "beacon tracking pinpointer"
 	desc = "Used to scan and locate signals on a particular frequency."
-	id = "beacon_locator"
 	req_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 2, TECH_BLUESPACE = 3)
 	materials = list(MAT_ALUMINIUM = 1000, MAT_GLASS = 500)
 	build_path = /obj/item/pinpointer/radio
 
 /datum/design/item/bluespace/ano_scanner
 	name = "Alden-Saraspova counter"
-	id = "ano_scanner"
 	desc = "Aids in triangulation of exotic particles."
 	req_tech = list(TECH_BLUESPACE = 3, TECH_MAGNET = 3)
 	materials = list(MAT_STEEL = 5000, MAT_ALUMINIUM = 5000, MAT_GLASS = 5000)
@@ -36,7 +32,6 @@
 /datum/design/item/bluespace/bag_holding
 	name = "bag of holding"
 	desc = "Using localized pockets of bluespace this bag prototype offers incredible storage capacity with the contents weighting nothing. It's a shame the bag itself is pretty heavy."
-	id = "bag_holding"
 	req_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 6)
 	materials = list(MAT_GOLD = 3000, MAT_DIAMOND = 1500, MAT_URANIUM = 250, MAT_PLASTIC = 250)
 	build_path = /obj/item/storage/backpack/holding
@@ -44,7 +39,6 @@
 /datum/design/item/dufflebag_holding
 	name = "dufflebag of holding"
 	desc = "A variation of the popular Bag of Holding, the dufflebag of holding is, functionally, identical to the bag of holding, but comes in an easier to carry form."
-	id = "dufflebag_holding"
 	req_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 6)
 	materials = list(MAT_GOLD = 3000, MAT_DIAMOND = 1500, MAT_URANIUM = 250, MAT_PLASTIC = 250)
 	build_path = /obj/item/storage/backpack/holding/duffle

--- a/code/modules/research/designs/designs_circuits.dm
+++ b/code/modules/research/designs/designs_circuits.dm
@@ -22,512 +22,425 @@
 
 /datum/design/circuit/arcademachine
 	name = "battle arcade machine"
-	id = "arcademachine"
 	req_tech = list(TECH_DATA = 1)
 	build_path = /obj/item/stock_parts/circuitboard/arcade/battle
 
 /datum/design/circuit/oriontrail
 	name = "orion trail arcade machine"
-	id = "oriontrail"
 	req_tech = list(TECH_DATA = 1)
 	build_path = /obj/item/stock_parts/circuitboard/arcade/orion_trail
 
 /datum/design/circuit/prisonmanage
 	name = "prisoner management console"
-	id = "prisonmanage"
 	build_path = /obj/item/stock_parts/circuitboard/prisoner
 
 /datum/design/circuit/operating
 	name = "patient monitoring console"
-	id = "operating"
 	build_path = /obj/item/stock_parts/circuitboard/operating
 
 /datum/design/circuit/optable
 	name = "operating table"
-	id = "optable"
 	req_tech = list(TECH_ENGINEERING = 1, TECH_BIO = 3, TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/optable
 
 /datum/design/circuit/bodyscanner
 	name = "body scanner"
-	id = "bodyscanner"
 	req_tech = list(TECH_ENGINEERING = 2, TECH_BIO = 4, TECH_DATA = 4)
 	build_path = /obj/item/stock_parts/circuitboard/bodyscanner
 
 /datum/design/circuit/body_scanconsole
 	name = "body scanner console"
-	id = "bodyscannerconsole"
 	req_tech = list(TECH_ENGINEERING = 2, TECH_BIO = 4, TECH_DATA = 4)
 	build_path = /obj/item/stock_parts/circuitboard/body_scanconsole
 
 /datum/design/circuit/sleeper
 	name = "sleeper"
-	id = "sleeper"
 	req_tech = list(TECH_ENGINEERING = 3, TECH_BIO = 5, TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/sleeper
 
 /datum/design/circuit/crewconsole
 	name = "crew monitoring console"
-	id = "crewconsole"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 2, TECH_BIO = 2)
 	build_path = /obj/item/stock_parts/circuitboard/crew
 
 /datum/design/circuit/body_scan_display
 	name = "body scanner display"
-	id = "bodyscannerdisplay"
 	req_tech = list(TECH_BIO = 2, TECH_DATA = 2)
 	build_path = /obj/item/stock_parts/circuitboard/body_scanconsole/display
 
 /datum/design/circuit/bioprinter
 	name = "bioprinter"
-	id = "bioprinter"
 	req_tech = list(TECH_ENGINEERING = 1, TECH_BIO = 3, TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/bioprinter
 
 /datum/design/circuit/roboprinter
 	name = "prosthetic organ fabricator"
-	id = "roboprinter"
 	req_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/roboprinter
 
 /datum/design/circuit/teleconsole
 	name = "teleporter control console"
-	id = "teleconsole"
 	req_tech = list(TECH_DATA = 3, TECH_BLUESPACE = 5)
 	build_path = /obj/item/stock_parts/circuitboard/teleporter
 
 /datum/design/circuit/robocontrol
 	name = "robotics control console"
-	id = "robocontrol"
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/stock_parts/circuitboard/robotics
 
 /datum/design/circuit/rdconsole
 	name = "R&D control console"
-	id = "rdconsole"
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/stock_parts/circuitboard/rdconsole
 
 /datum/design/circuit/comm_monitor
 	name = "telecommunications monitoring console"
-	id = "comm_monitor"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/comm_monitor
 
 /datum/design/circuit/comm_server
 	name = "telecommunications server monitoring console"
-	id = "comm_server"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/comm_server
 
 /datum/design/circuit/message_monitor
 	name = "messaging monitor console"
-	id = "message_monitor"
 	req_tech = list(TECH_DATA = 5)
 	build_path = /obj/item/stock_parts/circuitboard/message_monitor
 
 /datum/design/circuit/guestpass
 	name = "guest pass terminal"
-	id = "guestpass"
 	build_path = /obj/item/stock_parts/circuitboard/guestpass
 
 /datum/design/circuit/accounts
 	name = "account database terminal"
-	id = "accounts"
 	build_path = /obj/item/stock_parts/circuitboard/account_database
 
 /datum/design/circuit/holo
 	name = "holodeck control console"
-	id = "holo"
 	build_path = /obj/item/stock_parts/circuitboard/holodeckcontrol
 	req_tech = list(TECH_DATA = 2, TECH_BLUESPACE = 2)
 
 /datum/design/circuit/aiupload
 	name = "AI upload console"
-	id = "aiupload"
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/stock_parts/circuitboard/aiupload
 
 /datum/design/circuit/borgupload
 	name = "cyborg upload console"
-	id = "borgupload"
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/stock_parts/circuitboard/borgupload
 
 /datum/design/circuit/cryopodcontrol
 	name = "cryogenic oversight console"
-	id = "cryo_console"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/cryopodcontrol
 
 /datum/design/circuit/robot_storage
 	name = "robotic storage control"
-	id = "cryo_console_borg"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/robotstoragecontrol
 
 /datum/design/circuit/destructive_analyzer
 	name = "destructive analyzer"
-	id = "destructive_analyzer"
 	req_tech = list(TECH_DATA = 2, TECH_MAGNET = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/destructive_analyzer
 
 /datum/design/circuit/protolathe
 	name = "protolathe"
-	id = "protolathe"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/protolathe
 
 /datum/design/circuit/circuit_imprinter
 	name = "circuit imprinter"
-	id = "circuit_imprinter"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/circuit_imprinter
 
 /datum/design/circuit/autolathe
 	name = "autolathe board"
-	id = "autolathe"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/autolathe
 
 /datum/design/circuit/replicator
 	name = "replicator board"
-	id = "replicator"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 3, TECH_BIO = 3)
 	build_path = /obj/item/stock_parts/circuitboard/replicator
 
 /datum/design/circuit/microlathe
 	name = "microlathe board"
-	id = "microlathe"
 	req_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/autolathe/micro
 
 /datum/design/circuit/autobinder
 	name = "autobinder board"
-	id = "autobinder"
 	req_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/autolathe/book
 
 /datum/design/circuit/mining_console
 	name = "mining console board"
-	id = "mining_console"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/mineral_processing
 
 /datum/design/circuit/mining_processor
 	name = "mining processor board"
-	id = "mining_processor"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/mining_processor
 
 /datum/design/circuit/mining_unloader
 	name = "ore unloader board"
-	id = "mining_unloader"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/mining_unloader
 
 /datum/design/circuit/mining_stacker
 	name = "sheet stacker board"
-	id = "mining_stacker"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/mining_stacker
 
 /datum/design/circuit/suspension_gen
 	name = "suspension generator"
-	id = "suspension_gen"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3, TECH_MAGNET = 4)
 	build_path = /obj/item/stock_parts/circuitboard/suspension_gen
 
 /datum/design/circuit/rdservercontrol
 	name = "R&D server control console"
-	id = "rdservercontrol"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/rdservercontrol
 
 /datum/design/circuit/rdserver
 	name = "R&D server"
-	id = "rdserver"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/rdserver
 
 /datum/design/circuit/mechfab
 	name = "exosuit fabricator"
-	id = "mechfab"
 	req_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 3)
 	build_path = /obj/item/stock_parts/circuitboard/mechfab
 
 /datum/design/circuit/mech_recharger
 	name = "mech recharger"
-	id = "mech_recharger"
 	req_tech = list(TECH_DATA = 2, TECH_POWER = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/mech_recharger
 
 /datum/design/circuit/recharge_station
 	name = "cyborg recharge station"
-	id = "recharge_station"
 	req_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/recharge_station
 
 /datum/design/circuit/atmosalerts
 	name = "atmosphere alert console"
-	id = "atmosalerts"
 	build_path = /obj/item/stock_parts/circuitboard/atmos_alert
 
 /datum/design/circuit/air_management
 	name = "atmosphere monitoring console"
-	id = "air_management"
 	build_path = /obj/item/stock_parts/circuitboard/air_management
 
 /datum/design/circuit/rcon_console
 	name = "RCON remote control console"
-	id = "rcon_console"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3, TECH_POWER = 5)
 	build_path = /obj/item/stock_parts/circuitboard/rcon_console
 
 /datum/design/circuit/dronecontrol
 	name = "drone control console"
-	id = "dronecontrol"
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/stock_parts/circuitboard/drone_control
 
 /datum/design/circuit/powermonitor
 	name = "power monitoring console"
-	id = "powermonitor"
 	build_path = /obj/item/stock_parts/circuitboard/powermonitor
 
 /datum/design/circuit/solarcontrol
 	name = "solar control console"
-	id = "solarcontrol"
 	build_path = /obj/item/stock_parts/circuitboard/solar_control
 
 /datum/design/circuit/supermatter_control
 	name = "core monitoring console"
-	id = "supermatter_control"
 	build_path = /obj/item/stock_parts/circuitboard/air_management/supermatter_core
 
 /datum/design/circuit/injector
 	name = "injector control console"
-	id = "injector"
 	build_path = /obj/item/stock_parts/circuitboard/air_management/injector_control
 
 /datum/design/circuit/pacman
 	name = "PACMAN-type generator"
-	id = "pacman"
 	req_tech = list(TECH_DATA = 3, TECH_PHORON = 3, TECH_POWER = 3, TECH_ENGINEERING = 3)
 	build_path = /obj/item/stock_parts/circuitboard/pacman
 
 /datum/design/circuit/superpacman
 	name = "SUPERPACMAN-type generator"
-	id = "superpacman"
 	req_tech = list(TECH_DATA = 3, TECH_POWER = 4, TECH_ENGINEERING = 4)
 	build_path = /obj/item/stock_parts/circuitboard/pacman/super
 
 /datum/design/circuit/mrspacman
 	name = "MRSPACMAN-type generator"
-	id = "mrspacman"
 	req_tech = list(TECH_DATA = 3, TECH_POWER = 5, TECH_ENGINEERING = 5)
 	build_path = /obj/item/stock_parts/circuitboard/pacman/mrs
 
 /datum/design/circuit/pacmanpotato
 	name = "PTTO-3 nuclear generator"
-	id = "pacmanpotato"
 	req_tech = list(TECH_DATA = 3, TECH_POWER = 5, TECH_ENGINEERING = 4, TECH_ESOTERIC = 4)
 	build_path = /obj/item/stock_parts/circuitboard/pacman/super/potato
 
 /datum/design/circuit/batteryrack
 	name = "cell rack PSU"
-	id = "batteryrack"
 	req_tech = list(TECH_POWER = 3, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/batteryrack
 
 /datum/design/circuit/smes_cell
 	name = "'SMES' superconductive magnetic energy storage"
 	desc = "Allows for the construction of circuit boards used to build a SMES."
-	id = "smes_cell"
 	req_tech = list(TECH_POWER = 7, TECH_ENGINEERING = 5)
 	build_path = /obj/item/stock_parts/circuitboard/smes
 
 /datum/design/circuit/alerts
 	name = "alerts console"
-	id = "alerts"
 	build_path = /obj/item/stock_parts/circuitboard/stationalert
 
 /datum/design/circuit/gas_heater
 	name = "gas heating system"
-	id = "gasheater"
 	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/unary_atmos/heater
 
 /datum/design/circuit/gas_cooler
 	name = "gas cooling system"
-	id = "gascooler"
 	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/unary_atmos/cooler
 
 /datum/design/circuit/oxyregenerator
 	name = "oxygen regenerator"
-	id = "oxyregen"
 	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/oxyregenerator
 
 /datum/design/circuit/reagent_heater
 	name = "chemical heating system"
-	id = "chemheater"
 	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/reagent_heater
 
 /datum/design/circuit/reagent_cooler
 	name = "chemical cooling system"
-	id = "chemcooler"
 	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/reagent_heater/cooler
 
 /datum/design/circuit/atmos_control
 	name = "atmospherics control console"
-	id = "atmos_control"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 3)
 	build_path = /obj/item/stock_parts/circuitboard/atmoscontrol
 
 /datum/design/circuit/pipe_dispenser
 	name = "pipe dispenser"
-	id = "pipe_dispenser"
 	req_tech = list(TECH_ENGINEERING = 6, TECH_MATERIAL = 5)
 	build_path = /obj/item/stock_parts/circuitboard/pipedispensor
 
 /datum/design/circuit/pipe_dispenser/disposal
 	name = "disposal pipe dispenser"
-	id = "pipe_disposal"
 	build_path = /obj/item/stock_parts/circuitboard/pipedispensor/disposal
 
 /datum/design/circuit/secure_airlock
 	name = "secure airlock electronics"
 	desc =  "Allows for the construction of a tamper-resistant airlock electronics."
-	id = "securedoor"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/airlock_electronics/secure
 
 /datum/design/circuit/portable_scrubber
 	name = "portable scrubber"
-	id = "portascrubber"
 	req_tech = list(TECH_ENGINEERING = 4, TECH_POWER = 4)
 	build_path = /obj/item/stock_parts/circuitboard/portable_scrubber
 
 /datum/design/circuit/portable_pump
 	name = "portable pump"
-	id = "portapump"
 	req_tech = list(TECH_ENGINEERING = 4, TECH_POWER = 4)
 	build_path = /obj/item/stock_parts/circuitboard/portable_scrubber/pump
 
 /datum/design/circuit/portable_scrubber_huge
 	name = "large portable scrubber"
-	id = "portascrubberhuge"
 	req_tech = list(TECH_ENGINEERING = 5, TECH_POWER = 5, TECH_MATERIAL = 5)
 	build_path = /obj/item/stock_parts/circuitboard/portable_scrubber/huge
 
 /datum/design/circuit/portable_scrubber_stat
 	name = "large stationary portable scrubber"
-	id = "portascrubberstat"
 	req_tech = list(TECH_ENGINEERING = 5, TECH_POWER = 5, TECH_MATERIAL = 5)
 	build_path = /obj/item/stock_parts/circuitboard/portable_scrubber/huge/stationary
 
 /datum/design/circuit/thruster
 	name = "gas thruster"
-	id = "thruster"
 	req_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/unary_atmos/engine
 
 /datum/design/circuit/helms
 	name = "helm control console"
-	id = "helms"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3)
 	build_path = /obj/item/stock_parts/circuitboard/helm
 
 /datum/design/circuit/nav
 	name = "navigation control console"
-	id = "nav"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/nav
 
 /datum/design/circuit/nav/tele
 	name = "navigation telescreen"
-	id = "nav_tele"
 	build_path = /obj/item/stock_parts/circuitboard/nav/tele
 
 /datum/design/circuit/sensors
 	name = "ship sensor control console"
-	id = "sensors"
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/stock_parts/circuitboard/sensors
 
 /datum/design/circuit/engine
 	name = "ship engine control console"
-	id = "shipengine"
 	req_tech = list(TECH_DATA = 2, TECH_POWER = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/engine
 
 /datum/design/circuit/shuttle
 	name = "basic shuttle console"
-	id = "shuttle"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/shuttle_console
 
 /datum/design/circuit/shuttle_long
 	name = "long range shuttle console"
-	id = "shuttle_long"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/shuttle_console/explore
 
 /datum/design/circuit/biogenerator
 	name = "biogenerator"
-	id = "biogenerator"
 	req_tech = list(TECH_DATA = 2)
 	build_path = /obj/item/stock_parts/circuitboard/biogenerator
 
 /datum/design/circuit/hydro_tray
 	name = "hydroponics tray"
-	id = "hydrotray"
 	req_tech = list(TECH_BIO = 3, TECH_MATERIAL = 2, TECH_DATA = 1)
 	build_path = /obj/item/stock_parts/circuitboard/tray
 
 /datum/design/circuit/miningdrill
 	name = "mining drill head"
-	id = "mining drill head"
 	req_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/miningdrill
 
 /datum/design/circuit/miningdrillbrace
 	name = "mining drill brace"
-	id = "mining drill brace"
 	req_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/miningdrillbrace
 
 /datum/design/circuit/floodlight
 	name = "emergency floodlight"
-	id = "floodlight"
 	req_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/floodlight
 
 /datum/design/circuit/disperserfront
 	name = "obstruction field disperser beam generator"
-	id = "disperserfront"
 	req_tech = list(TECH_ENGINEERING = 2, TECH_COMBAT = 2, TECH_BLUESPACE = 2)
 	build_path = /obj/item/stock_parts/circuitboard/disperserfront
 
 /datum/design/circuit/dispersermiddle
 	name = "obstruction field disperser fusor"
-	id = "dispersermiddle"
 	req_tech = list(TECH_ENGINEERING = 2, TECH_COMBAT = 2, TECH_BLUESPACE = 2)
 	build_path = /obj/item/stock_parts/circuitboard/dispersermiddle
 
 /datum/design/circuit/disperserback
 	name = "obstruction field disperser material deconstructor"
-	id = "bsaback"
 	req_tech = list(TECH_ENGINEERING = 2, TECH_COMBAT = 2, TECH_BLUESPACE = 2)
 	build_path = /obj/item/stock_parts/circuitboard/disperserback
 
 /datum/design/circuit/disperser_console
 	name = "obstruction field disperser control console"
-	id = "disperser_console"
 	req_tech = list(TECH_DATA = 2, TECH_COMBAT = 5, TECH_BLUESPACE = 5)
 	build_path = /obj/item/stock_parts/circuitboard/disperser
 
@@ -541,145 +454,121 @@
 
 /datum/design/circuit/tcom/server
 	name = "server mainframe"
-	id = "tcom-server"
 	build_path = /obj/item/stock_parts/circuitboard/telecomms/server
 
 /datum/design/circuit/tcom/processor
 	name = "processor unit"
-	id = "tcom-processor"
 	build_path = /obj/item/stock_parts/circuitboard/telecomms/processor
 
 /datum/design/circuit/tcom/bus
 	name = "bus mainframe"
-	id = "tcom-bus"
 	build_path = /obj/item/stock_parts/circuitboard/telecomms/bus
 
 /datum/design/circuit/tcom/hub
 	name = "hub mainframe"
-	id = "tcom-hub"
 	build_path = /obj/item/stock_parts/circuitboard/telecomms/hub
 
 /datum/design/circuit/tcom/broadcaster
 	name = "subspace broadcaster"
-	id = "tcom-broadcaster"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4, TECH_BLUESPACE = 2)
 	build_path = /obj/item/stock_parts/circuitboard/telecomms/broadcaster
 
 /datum/design/circuit/tcom/receiver
 	name = "subspace receiver"
-	id = "tcom-receiver"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3, TECH_BLUESPACE = 2)
 	build_path = /obj/item/stock_parts/circuitboard/telecomms/receiver
 
 /datum/design/circuit/bluespace_relay
 	name = "bluespace relay"
-	id = "bluespacerelay"
 	req_tech = list(TECH_DATA = 5, TECH_BLUESPACE = 5, TECH_PHORON = 5)
 	build_path = /obj/item/stock_parts/circuitboard/bluespacerelay
 
 /datum/design/circuit/shield_generator
 	name = "Shield Generator"
 	desc = "Allows for the construction of a shield generator circuit board."
-	id = "shield_generator"
 	req_tech = list(TECH_MAGNET = 3, TECH_POWER = 4)
 	build_path = /obj/item/stock_parts/circuitboard/shield_generator
 
 /datum/design/circuit/shield_diffuser
 	name = "Shield Diffuser"
 	desc = "Allows for the construction of a shield generator circuit board."
-	id = "shield_diffuser"
 	req_tech = list(TECH_MAGNET = 3, TECH_POWER = 4)
 	build_path = /obj/item/stock_parts/circuitboard/shield_diffuser
 
 /datum/design/circuit/pointdefense
 	name = "Point defense battery"
 	desc = "Allows for the construction of a point defense battery circuit board."
-	id = "pointdefense"
 	req_tech = list(TECH_COMBAT = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/pointdefense
 
 /datum/design/circuit/pointdefense_control
 	name = "Fire Assist Mainframe"
 	desc = "Allows for the construction of a fire assist mainframe circuit board."
-	id = "pointdefense_control"
 	req_tech = list(TECH_COMBAT = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/pointdefense_control
 
 /datum/design/circuit/ntnet_relay
 	name = "NTNet Quantum Relay"
-	id = "ntnet_relay"
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/stock_parts/circuitboard/ntnet_relay
 
 /datum/design/circuit/washer
 	name = "washing machine"
-	id = "washer"
 	req_tech = list(TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/washer
 
 /datum/design/circuit/microwave
 	name = "microwave"
-	id = "microwave"
 	req_tech = list(TECH_BIO = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/microwave
 
 /datum/design/circuit/gibber
 	name = "meat gibber"
-	id = "gibber"
 	req_tech = list(TECH_BIO = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/gibber
 
 /datum/design/circuit/cooker
 	name = "kitchen appliance (assorted)"
 	desc = "Allows for the construction of an interchangable cooking appliance circuit board. Use a multitool to select appliance."
-	id = "cooker"
 	req_tech = list(TECH_BIO = 1, TECH_MATERIAL = 1)
 	build_path = /obj/item/stock_parts/circuitboard/cooker
 
 /datum/design/circuit/honey_extractor
 	name = "honey extractor"
-	id = "honey_extractor"
 	req_tech = list(TECH_BIO = 2, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/honey
 
 /datum/design/circuit/seed_extractor
 	name = "seed extractor"
-	id = "seed_extractor"
 	req_tech = list(TECH_BIO = 2, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/honey/seed
 
 /datum/design/circuit/vending
 	name = "vending machine"
-	id = "vending"
 	req_tech = list(TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/vending
 
 /datum/design/circuit/aicore
 	name = "AI core"
-	id = "aicore"
 	req_tech = list(TECH_DATA = 4, TECH_BIO = 3)
 	build_path = /obj/item/stock_parts/circuitboard/aicore
 
 /datum/design/circuit/ionengine
 	name = "ion propulsion system"
-	id = "ionengine"
 	req_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 6)
 	materials = list(MAT_GOLD = 250, MAT_DIAMOND = 250, MAT_URANIUM = 250, MAT_PLASTIC = 1000, MAT_ALUMINIUM = 1000)
 	build_path = /obj/item/stock_parts/circuitboard/engine/ion
 
 /datum/design/circuit/vitals
 	name = "vitals monitor"
-	id = "vitals"
 	req_tech = list(TECH_BIO = 2, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/vitals_monitor
 
 /datum/design/circuit/modular_computer
 	name = "general-purpose computer"
-	id = "pc_motherboard"
 	req_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/modular_computer
 
 /datum/design/circuit/shipsensors
 	name = "ship sensors"
-	id = "shipsensors"
 	build_path = /obj/item/stock_parts/circuitboard/shipsensors

--- a/code/modules/research/designs/designs_circuits.dm
+++ b/code/modules/research/designs/designs_circuits.dm
@@ -25,375 +25,320 @@
 	id = "arcademachine"
 	req_tech = list(TECH_DATA = 1)
 	build_path = /obj/item/stock_parts/circuitboard/arcade/battle
-	sort_string = "MAAAA"
 
 /datum/design/circuit/oriontrail
 	name = "orion trail arcade machine"
 	id = "oriontrail"
 	req_tech = list(TECH_DATA = 1)
 	build_path = /obj/item/stock_parts/circuitboard/arcade/orion_trail
-	sort_string = "MABAA"
 
 /datum/design/circuit/prisonmanage
 	name = "prisoner management console"
 	id = "prisonmanage"
 	build_path = /obj/item/stock_parts/circuitboard/prisoner
-	sort_string = "DACAA"
 
 /datum/design/circuit/operating
 	name = "patient monitoring console"
 	id = "operating"
 	build_path = /obj/item/stock_parts/circuitboard/operating
-	sort_string = "FACAA"
 
 /datum/design/circuit/optable
 	name = "operating table"
 	id = "optable"
 	req_tech = list(TECH_ENGINEERING = 1, TECH_BIO = 3, TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/optable
-	sort_string = "FACAB"
 
 /datum/design/circuit/bodyscanner
 	name = "body scanner"
 	id = "bodyscanner"
 	req_tech = list(TECH_ENGINEERING = 2, TECH_BIO = 4, TECH_DATA = 4)
 	build_path = /obj/item/stock_parts/circuitboard/bodyscanner
-	sort_string = "FACAC"
 
 /datum/design/circuit/body_scanconsole
 	name = "body scanner console"
 	id = "bodyscannerconsole"
 	req_tech = list(TECH_ENGINEERING = 2, TECH_BIO = 4, TECH_DATA = 4)
 	build_path = /obj/item/stock_parts/circuitboard/body_scanconsole
-	sort_string = "FACAD"
 
 /datum/design/circuit/sleeper
 	name = "sleeper"
 	id = "sleeper"
 	req_tech = list(TECH_ENGINEERING = 3, TECH_BIO = 5, TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/sleeper
-	sort_string = "FACAE"
 
 /datum/design/circuit/crewconsole
 	name = "crew monitoring console"
 	id = "crewconsole"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 2, TECH_BIO = 2)
 	build_path = /obj/item/stock_parts/circuitboard/crew
-	sort_string = "FAGAI"
 
 /datum/design/circuit/body_scan_display
 	name = "body scanner display"
 	id = "bodyscannerdisplay"
 	req_tech = list(TECH_BIO = 2, TECH_DATA = 2)
 	build_path = /obj/item/stock_parts/circuitboard/body_scanconsole/display
-	sort_string = "FACAJ"
 
 /datum/design/circuit/bioprinter
 	name = "bioprinter"
 	id = "bioprinter"
 	req_tech = list(TECH_ENGINEERING = 1, TECH_BIO = 3, TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/bioprinter
-	sort_string = "FAGAK"
 
 /datum/design/circuit/roboprinter
 	name = "prosthetic organ fabricator"
 	id = "roboprinter"
 	req_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/roboprinter
-	sort_string = "FAGAM"
 
 /datum/design/circuit/teleconsole
 	name = "teleporter control console"
 	id = "teleconsole"
 	req_tech = list(TECH_DATA = 3, TECH_BLUESPACE = 5)
 	build_path = /obj/item/stock_parts/circuitboard/teleporter
-	sort_string = "HAAAA"
 
 /datum/design/circuit/robocontrol
 	name = "robotics control console"
 	id = "robocontrol"
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/stock_parts/circuitboard/robotics
-	sort_string = "HAAAB"
 
 /datum/design/circuit/rdconsole
 	name = "R&D control console"
 	id = "rdconsole"
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/stock_parts/circuitboard/rdconsole
-	sort_string = "HAAAE"
 
 /datum/design/circuit/comm_monitor
 	name = "telecommunications monitoring console"
 	id = "comm_monitor"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/comm_monitor
-	sort_string = "HAACA"
 
 /datum/design/circuit/comm_server
 	name = "telecommunications server monitoring console"
 	id = "comm_server"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/comm_server
-	sort_string = "HAACB"
 
 /datum/design/circuit/message_monitor
 	name = "messaging monitor console"
 	id = "message_monitor"
 	req_tech = list(TECH_DATA = 5)
 	build_path = /obj/item/stock_parts/circuitboard/message_monitor
-	sort_string = "HAACD"
 
 /datum/design/circuit/guestpass
 	name = "guest pass terminal"
 	id = "guestpass"
 	build_path = /obj/item/stock_parts/circuitboard/guestpass
-	sort_string = "HAACE"
 
 /datum/design/circuit/accounts
 	name = "account database terminal"
 	id = "accounts"
 	build_path = /obj/item/stock_parts/circuitboard/account_database
-	sort_string = "HAACF"
 
 /datum/design/circuit/holo
 	name = "holodeck control console"
 	id = "holo"
 	build_path = /obj/item/stock_parts/circuitboard/holodeckcontrol
 	req_tech = list(TECH_DATA = 2, TECH_BLUESPACE = 2)
-	sort_string = "HAACG"
 
 /datum/design/circuit/aiupload
 	name = "AI upload console"
 	id = "aiupload"
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/stock_parts/circuitboard/aiupload
-	sort_string = "HAABA"
 
 /datum/design/circuit/borgupload
 	name = "cyborg upload console"
 	id = "borgupload"
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/stock_parts/circuitboard/borgupload
-	sort_string = "HAABB"
 
 /datum/design/circuit/cryopodcontrol
 	name = "cryogenic oversight console"
 	id = "cryo_console"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/cryopodcontrol
-	sort_string = "HAABC"
 
 /datum/design/circuit/robot_storage
 	name = "robotic storage control"
 	id = "cryo_console_borg"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/robotstoragecontrol
-	sort_string = "HAABD"
 
 /datum/design/circuit/destructive_analyzer
 	name = "destructive analyzer"
 	id = "destructive_analyzer"
 	req_tech = list(TECH_DATA = 2, TECH_MAGNET = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/destructive_analyzer
-	sort_string = "HABAA"
 
 /datum/design/circuit/protolathe
 	name = "protolathe"
 	id = "protolathe"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/protolathe
-	sort_string = "HABAB"
 
 /datum/design/circuit/circuit_imprinter
 	name = "circuit imprinter"
 	id = "circuit_imprinter"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/circuit_imprinter
-	sort_string = "HABAC"
 
 /datum/design/circuit/autolathe
 	name = "autolathe board"
 	id = "autolathe"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/autolathe
-	sort_string = "HABAD"
 
 /datum/design/circuit/replicator
 	name = "replicator board"
 	id = "replicator"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 3, TECH_BIO = 3)
 	build_path = /obj/item/stock_parts/circuitboard/replicator
-	sort_string = "HABAE"
 
 /datum/design/circuit/microlathe
 	name = "microlathe board"
 	id = "microlathe"
 	req_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/autolathe/micro
-	sort_string = "HABAF"
 
 /datum/design/circuit/autobinder
 	name = "autobinder board"
 	id = "autobinder"
 	req_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/autolathe/book
-	sort_string = "HABAG"
 
 /datum/design/circuit/mining_console
 	name = "mining console board"
 	id = "mining_console"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/mineral_processing
-	sort_string = "HABAH"
 
 /datum/design/circuit/mining_processor
 	name = "mining processor board"
 	id = "mining_processor"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/mining_processor
-	sort_string = "HABAI"
 
 /datum/design/circuit/mining_unloader
 	name = "ore unloader board"
 	id = "mining_unloader"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/mining_unloader
-	sort_string = "HABAJ"
 
 /datum/design/circuit/mining_stacker
 	name = "sheet stacker board"
 	id = "mining_stacker"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/mining_stacker
-	sort_string = "HABAK"
 
 /datum/design/circuit/suspension_gen
 	name = "suspension generator"
 	id = "suspension_gen"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3, TECH_MAGNET = 4)
 	build_path = /obj/item/stock_parts/circuitboard/suspension_gen
-	sort_string = "HABAL"
 
 /datum/design/circuit/rdservercontrol
 	name = "R&D server control console"
 	id = "rdservercontrol"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/rdservercontrol
-	sort_string = "HABBA"
 
 /datum/design/circuit/rdserver
 	name = "R&D server"
 	id = "rdserver"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/rdserver
-	sort_string = "HABBB"
 
 /datum/design/circuit/mechfab
 	name = "exosuit fabricator"
 	id = "mechfab"
 	req_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 3)
 	build_path = /obj/item/stock_parts/circuitboard/mechfab
-	sort_string = "HABAE"
 
 /datum/design/circuit/mech_recharger
 	name = "mech recharger"
 	id = "mech_recharger"
 	req_tech = list(TECH_DATA = 2, TECH_POWER = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/mech_recharger
-	sort_string = "HACAA"
 
 /datum/design/circuit/recharge_station
 	name = "cyborg recharge station"
 	id = "recharge_station"
 	req_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/recharge_station
-	sort_string = "HACAC"
 
 /datum/design/circuit/atmosalerts
 	name = "atmosphere alert console"
 	id = "atmosalerts"
 	build_path = /obj/item/stock_parts/circuitboard/atmos_alert
-	sort_string = "JAAAA"
 
 /datum/design/circuit/air_management
 	name = "atmosphere monitoring console"
 	id = "air_management"
 	build_path = /obj/item/stock_parts/circuitboard/air_management
-	sort_string = "JAAAB"
 
 /datum/design/circuit/rcon_console
 	name = "RCON remote control console"
 	id = "rcon_console"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3, TECH_POWER = 5)
 	build_path = /obj/item/stock_parts/circuitboard/rcon_console
-	sort_string = "JAAAC"
 
 /datum/design/circuit/dronecontrol
 	name = "drone control console"
 	id = "dronecontrol"
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/stock_parts/circuitboard/drone_control
-	sort_string = "JAAAD"
 
 /datum/design/circuit/powermonitor
 	name = "power monitoring console"
 	id = "powermonitor"
 	build_path = /obj/item/stock_parts/circuitboard/powermonitor
-	sort_string = "JAAAE"
 
 /datum/design/circuit/solarcontrol
 	name = "solar control console"
 	id = "solarcontrol"
 	build_path = /obj/item/stock_parts/circuitboard/solar_control
-	sort_string = "JAAAF"
 
 /datum/design/circuit/supermatter_control
 	name = "core monitoring console"
 	id = "supermatter_control"
 	build_path = /obj/item/stock_parts/circuitboard/air_management/supermatter_core
-	sort_string = "JAAAG"
 
 /datum/design/circuit/injector
 	name = "injector control console"
 	id = "injector"
 	build_path = /obj/item/stock_parts/circuitboard/air_management/injector_control
-	sort_string = "JAAAH"
 
 /datum/design/circuit/pacman
 	name = "PACMAN-type generator"
 	id = "pacman"
 	req_tech = list(TECH_DATA = 3, TECH_PHORON = 3, TECH_POWER = 3, TECH_ENGINEERING = 3)
 	build_path = /obj/item/stock_parts/circuitboard/pacman
-	sort_string = "JBAAA"
 
 /datum/design/circuit/superpacman
 	name = "SUPERPACMAN-type generator"
 	id = "superpacman"
 	req_tech = list(TECH_DATA = 3, TECH_POWER = 4, TECH_ENGINEERING = 4)
 	build_path = /obj/item/stock_parts/circuitboard/pacman/super
-	sort_string = "JBAAB"
 
 /datum/design/circuit/mrspacman
 	name = "MRSPACMAN-type generator"
 	id = "mrspacman"
 	req_tech = list(TECH_DATA = 3, TECH_POWER = 5, TECH_ENGINEERING = 5)
 	build_path = /obj/item/stock_parts/circuitboard/pacman/mrs
-	sort_string = "JBAAC"
 
 /datum/design/circuit/pacmanpotato
 	name = "PTTO-3 nuclear generator"
 	id = "pacmanpotato"
 	req_tech = list(TECH_DATA = 3, TECH_POWER = 5, TECH_ENGINEERING = 4, TECH_ESOTERIC = 4)
 	build_path = /obj/item/stock_parts/circuitboard/pacman/super/potato
-	sort_string = "JBAAD"
 
 /datum/design/circuit/batteryrack
 	name = "cell rack PSU"
 	id = "batteryrack"
 	req_tech = list(TECH_POWER = 3, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/batteryrack
-	sort_string = "JBABA"
 
 /datum/design/circuit/smes_cell
 	name = "'SMES' superconductive magnetic energy storage"
@@ -401,68 +346,58 @@
 	id = "smes_cell"
 	req_tech = list(TECH_POWER = 7, TECH_ENGINEERING = 5)
 	build_path = /obj/item/stock_parts/circuitboard/smes
-	sort_string = "JBABB"
 
 /datum/design/circuit/alerts
 	name = "alerts console"
 	id = "alerts"
 	build_path = /obj/item/stock_parts/circuitboard/stationalert
-	sort_string = "JBACA"
 
 /datum/design/circuit/gas_heater
 	name = "gas heating system"
 	id = "gasheater"
 	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/unary_atmos/heater
-	sort_string = "JCAAA"
 
 /datum/design/circuit/gas_cooler
 	name = "gas cooling system"
 	id = "gascooler"
 	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/unary_atmos/cooler
-	sort_string = "JCAAB"
 
 /datum/design/circuit/oxyregenerator
 	name = "oxygen regenerator"
 	id = "oxyregen"
 	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/oxyregenerator
-	sort_string = "JCAAC"
 
 /datum/design/circuit/reagent_heater
 	name = "chemical heating system"
 	id = "chemheater"
 	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/reagent_heater
-	sort_string = "JCAAD"
 
 /datum/design/circuit/reagent_cooler
 	name = "chemical cooling system"
 	id = "chemcooler"
 	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/reagent_heater/cooler
-	sort_string = "JCAAE"
 
 /datum/design/circuit/atmos_control
 	name = "atmospherics control console"
 	id = "atmos_control"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 3)
 	build_path = /obj/item/stock_parts/circuitboard/atmoscontrol
-	sort_string = "JCAAF"
 
 /datum/design/circuit/pipe_dispenser
 	name = "pipe dispenser"
 	id = "pipe_dispenser"
 	req_tech = list(TECH_ENGINEERING = 6, TECH_MATERIAL = 5)
 	build_path = /obj/item/stock_parts/circuitboard/pipedispensor
-	sort_string = "JCAAG"
 
 /datum/design/circuit/pipe_dispenser/disposal
 	name = "disposal pipe dispenser"
 	id = "pipe_disposal"
 	build_path = /obj/item/stock_parts/circuitboard/pipedispensor/disposal
-	sort_string = "JCAAH"
 
 /datum/design/circuit/secure_airlock
 	name = "secure airlock electronics"
@@ -470,153 +405,131 @@
 	id = "securedoor"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/airlock_electronics/secure
-	sort_string = "JDAAA"
 
 /datum/design/circuit/portable_scrubber
 	name = "portable scrubber"
 	id = "portascrubber"
 	req_tech = list(TECH_ENGINEERING = 4, TECH_POWER = 4)
 	build_path = /obj/item/stock_parts/circuitboard/portable_scrubber
-	sort_string = "JEAAA"
 
 /datum/design/circuit/portable_pump
 	name = "portable pump"
 	id = "portapump"
 	req_tech = list(TECH_ENGINEERING = 4, TECH_POWER = 4)
 	build_path = /obj/item/stock_parts/circuitboard/portable_scrubber/pump
-	sort_string = "JEAAB"
 
 /datum/design/circuit/portable_scrubber_huge
 	name = "large portable scrubber"
 	id = "portascrubberhuge"
 	req_tech = list(TECH_ENGINEERING = 5, TECH_POWER = 5, TECH_MATERIAL = 5)
 	build_path = /obj/item/stock_parts/circuitboard/portable_scrubber/huge
-	sort_string = "JEAAC"
 
 /datum/design/circuit/portable_scrubber_stat
 	name = "large stationary portable scrubber"
 	id = "portascrubberstat"
 	req_tech = list(TECH_ENGINEERING = 5, TECH_POWER = 5, TECH_MATERIAL = 5)
 	build_path = /obj/item/stock_parts/circuitboard/portable_scrubber/huge/stationary
-	sort_string = "JEAAD"
 
 /datum/design/circuit/thruster
 	name = "gas thruster"
 	id = "thruster"
 	req_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/unary_atmos/engine
-	sort_string = "JFAAA"
 
 /datum/design/circuit/helms
 	name = "helm control console"
 	id = "helms"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3)
 	build_path = /obj/item/stock_parts/circuitboard/helm
-	sort_string = "JFAAB"
 
 /datum/design/circuit/nav
 	name = "navigation control console"
 	id = "nav"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/nav
-	sort_string = "JFAAC"
 
 /datum/design/circuit/nav/tele
 	name = "navigation telescreen"
 	id = "nav_tele"
 	build_path = /obj/item/stock_parts/circuitboard/nav/tele
-	sort_string = "JFAAD"
 
 /datum/design/circuit/sensors
 	name = "ship sensor control console"
 	id = "sensors"
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/stock_parts/circuitboard/sensors
-	sort_string = "JFAAE"
 
 /datum/design/circuit/engine
 	name = "ship engine control console"
 	id = "shipengine"
 	req_tech = list(TECH_DATA = 2, TECH_POWER = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/engine
-	sort_string = "JFAAF"
 
 /datum/design/circuit/shuttle
 	name = "basic shuttle console"
 	id = "shuttle"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/shuttle_console
-	sort_string = "JFAAG"
 
 /datum/design/circuit/shuttle_long
 	name = "long range shuttle console"
 	id = "shuttle_long"
 	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/stock_parts/circuitboard/shuttle_console/explore
-	sort_string = "JFAAH"
 
 /datum/design/circuit/biogenerator
 	name = "biogenerator"
 	id = "biogenerator"
 	req_tech = list(TECH_DATA = 2)
 	build_path = /obj/item/stock_parts/circuitboard/biogenerator
-	sort_string = "KBAAA"
 
 /datum/design/circuit/hydro_tray
 	name = "hydroponics tray"
 	id = "hydrotray"
 	req_tech = list(TECH_BIO = 3, TECH_MATERIAL = 2, TECH_DATA = 1)
 	build_path = /obj/item/stock_parts/circuitboard/tray
-	sort_string = "KBAAB"
 
 /datum/design/circuit/miningdrill
 	name = "mining drill head"
 	id = "mining drill head"
 	req_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/miningdrill
-	sort_string = "KCAAA"
 
 /datum/design/circuit/miningdrillbrace
 	name = "mining drill brace"
 	id = "mining drill brace"
 	req_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/miningdrillbrace
-	sort_string = "KCAAB"
 
 /datum/design/circuit/floodlight
 	name = "emergency floodlight"
 	id = "floodlight"
 	req_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/floodlight
-	sort_string = "KCAAC"
 
 /datum/design/circuit/disperserfront
 	name = "obstruction field disperser beam generator"
 	id = "disperserfront"
 	req_tech = list(TECH_ENGINEERING = 2, TECH_COMBAT = 2, TECH_BLUESPACE = 2)
 	build_path = /obj/item/stock_parts/circuitboard/disperserfront
-	sort_string = "KCAAD"
 
 /datum/design/circuit/dispersermiddle
 	name = "obstruction field disperser fusor"
 	id = "dispersermiddle"
 	req_tech = list(TECH_ENGINEERING = 2, TECH_COMBAT = 2, TECH_BLUESPACE = 2)
 	build_path = /obj/item/stock_parts/circuitboard/dispersermiddle
-	sort_string = "KCAAE"
 
 /datum/design/circuit/disperserback
 	name = "obstruction field disperser material deconstructor"
 	id = "bsaback"
 	req_tech = list(TECH_ENGINEERING = 2, TECH_COMBAT = 2, TECH_BLUESPACE = 2)
 	build_path = /obj/item/stock_parts/circuitboard/disperserback
-	sort_string = "KCAAF"
 
 /datum/design/circuit/disperser_console
 	name = "obstruction field disperser control console"
 	id = "disperser_console"
 	req_tech = list(TECH_DATA = 2, TECH_COMBAT = 5, TECH_BLUESPACE = 5)
 	build_path = /obj/item/stock_parts/circuitboard/disperser
-	sort_string = "KCAAG"
 
 /datum/design/circuit/tcom
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4)
@@ -630,46 +543,39 @@
 	name = "server mainframe"
 	id = "tcom-server"
 	build_path = /obj/item/stock_parts/circuitboard/telecomms/server
-	sort_string = "PAAAA"
 
 /datum/design/circuit/tcom/processor
 	name = "processor unit"
 	id = "tcom-processor"
 	build_path = /obj/item/stock_parts/circuitboard/telecomms/processor
-	sort_string = "PAAAB"
 
 /datum/design/circuit/tcom/bus
 	name = "bus mainframe"
 	id = "tcom-bus"
 	build_path = /obj/item/stock_parts/circuitboard/telecomms/bus
-	sort_string = "PAAAC"
 
 /datum/design/circuit/tcom/hub
 	name = "hub mainframe"
 	id = "tcom-hub"
 	build_path = /obj/item/stock_parts/circuitboard/telecomms/hub
-	sort_string = "PAAAD"
 
 /datum/design/circuit/tcom/broadcaster
 	name = "subspace broadcaster"
 	id = "tcom-broadcaster"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4, TECH_BLUESPACE = 2)
 	build_path = /obj/item/stock_parts/circuitboard/telecomms/broadcaster
-	sort_string = "PAAAF"
 
 /datum/design/circuit/tcom/receiver
 	name = "subspace receiver"
 	id = "tcom-receiver"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3, TECH_BLUESPACE = 2)
 	build_path = /obj/item/stock_parts/circuitboard/telecomms/receiver
-	sort_string = "PAAAG"
 
 /datum/design/circuit/bluespace_relay
 	name = "bluespace relay"
 	id = "bluespacerelay"
 	req_tech = list(TECH_DATA = 5, TECH_BLUESPACE = 5, TECH_PHORON = 5)
 	build_path = /obj/item/stock_parts/circuitboard/bluespacerelay
-	sort_string = "PAAAH"
 
 /datum/design/circuit/shield_generator
 	name = "Shield Generator"
@@ -677,7 +583,6 @@
 	id = "shield_generator"
 	req_tech = list(TECH_MAGNET = 3, TECH_POWER = 4)
 	build_path = /obj/item/stock_parts/circuitboard/shield_generator
-	sort_string = "VAAAC"
 
 /datum/design/circuit/shield_diffuser
 	name = "Shield Diffuser"
@@ -685,7 +590,6 @@
 	id = "shield_diffuser"
 	req_tech = list(TECH_MAGNET = 3, TECH_POWER = 4)
 	build_path = /obj/item/stock_parts/circuitboard/shield_diffuser
-	sort_string = "VAAAB"
 
 /datum/design/circuit/pointdefense
 	name = "Point defense battery"
@@ -693,7 +597,6 @@
 	id = "pointdefense"
 	req_tech = list(TECH_COMBAT = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/pointdefense
-	sort_string = "VAAAC"
 
 /datum/design/circuit/pointdefense_control
 	name = "Fire Assist Mainframe"
@@ -701,35 +604,30 @@
 	id = "pointdefense_control"
 	req_tech = list(TECH_COMBAT = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/pointdefense_control
-	sort_string = "VAAAD"
 
 /datum/design/circuit/ntnet_relay
 	name = "NTNet Quantum Relay"
 	id = "ntnet_relay"
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/stock_parts/circuitboard/ntnet_relay
-	sort_string = "WAAAA"
 
 /datum/design/circuit/washer
 	name = "washing machine"
 	id = "washer"
 	req_tech = list(TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/washer
-	sort_string = "WAAAS"
 
 /datum/design/circuit/microwave
 	name = "microwave"
 	id = "microwave"
 	req_tech = list(TECH_BIO = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/microwave
-	sort_string = "WAAAT"
 
 /datum/design/circuit/gibber
 	name = "meat gibber"
 	id = "gibber"
 	req_tech = list(TECH_BIO = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/gibber
-	sort_string = "WAAAU"
 
 /datum/design/circuit/cooker
 	name = "kitchen appliance (assorted)"
@@ -737,35 +635,30 @@
 	id = "cooker"
 	req_tech = list(TECH_BIO = 1, TECH_MATERIAL = 1)
 	build_path = /obj/item/stock_parts/circuitboard/cooker
-	sort_string = "WAAAV"
 
 /datum/design/circuit/honey_extractor
 	name = "honey extractor"
 	id = "honey_extractor"
 	req_tech = list(TECH_BIO = 2, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/honey
-	sort_string = "WAAAW"
 
 /datum/design/circuit/seed_extractor
 	name = "seed extractor"
 	id = "seed_extractor"
 	req_tech = list(TECH_BIO = 2, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/honey/seed
-	sort_string = "WAAAX"
 
 /datum/design/circuit/vending
 	name = "vending machine"
 	id = "vending"
 	req_tech = list(TECH_ENGINEERING = 2)
 	build_path = /obj/item/stock_parts/circuitboard/vending
-	sort_string = "WAABA"
 
 /datum/design/circuit/aicore
 	name = "AI core"
 	id = "aicore"
 	req_tech = list(TECH_DATA = 4, TECH_BIO = 3)
 	build_path = /obj/item/stock_parts/circuitboard/aicore
-	sort_string = "XAAAA"
 
 /datum/design/circuit/ionengine
 	name = "ion propulsion system"
@@ -773,24 +666,20 @@
 	req_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 6)
 	materials = list(MAT_GOLD = 250, MAT_DIAMOND = 250, MAT_URANIUM = 250, MAT_PLASTIC = 1000, MAT_ALUMINIUM = 1000)
 	build_path = /obj/item/stock_parts/circuitboard/engine/ion
-	sort_string = "XAAAB"
 
 /datum/design/circuit/vitals
 	name = "vitals monitor"
 	id = "vitals"
 	req_tech = list(TECH_BIO = 2, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/vitals_monitor
-	sort_string = "XAAAD"
 
 /datum/design/circuit/modular_computer
 	name = "general-purpose computer"
 	id = "pc_motherboard"
 	req_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 1)
 	build_path = /obj/item/stock_parts/circuitboard/modular_computer
-	sort_string = "XAAAD"
 
 /datum/design/circuit/shipsensors
 	name = "ship sensors"
 	id = "shipsensors"
 	build_path = /obj/item/stock_parts/circuitboard/shipsensors
-	sort_string = "XAAAE"

--- a/code/modules/research/designs/designs_disk.dm
+++ b/code/modules/research/designs/designs_disk.dm
@@ -9,7 +9,6 @@
 	id = "design_disk"
 	req_tech = list(TECH_DATA = 1)
 	build_path = /obj/item/disk/design_disk
-	sort_string = "AAAAA"
 
 /datum/design/item/disk/tech
 	name = "technology data"
@@ -17,4 +16,3 @@
 	id = "tech_disk"
 	req_tech = list(TECH_DATA = 1)
 	build_path = /obj/item/disk/tech_disk
-	sort_string = "AAAAB"

--- a/code/modules/research/designs/designs_disk.dm
+++ b/code/modules/research/designs/designs_disk.dm
@@ -6,13 +6,11 @@
 /datum/design/item/disk/design
 	name = "research design"
 	desc = "Produce additional disks for storing device designs."
-	id = "design_disk"
 	req_tech = list(TECH_DATA = 1)
 	build_path = /obj/item/disk/design_disk
 
 /datum/design/item/disk/tech
 	name = "technology data"
 	desc = "Produce additional disks for storing technology data."
-	id = "tech_disk"
 	req_tech = list(TECH_DATA = 1)
 	build_path = /obj/item/disk/tech_disk

--- a/code/modules/research/designs/designs_exosuits.dm
+++ b/code/modules/research/designs/designs_exosuits.dm
@@ -8,32 +8,27 @@
 	id = "mech_software_engineering"
 	req_tech = list(TECH_DATA = 1)
 	build_path = /obj/item/circuitboard/exosystem/engineering
-	sort_string = "NAAAA"
 
 /datum/design/circuit/exosuit/utility
 	name = "utility system control"
 	id = "mech_software_utility"
 	req_tech = list(TECH_DATA = 1)
 	build_path = /obj/item/circuitboard/exosystem/utility
-	sort_string = "NAAAB"
 
 /datum/design/circuit/exosuit/medical
 	name = "medical system control"
 	id = "mech_software_medical"
 	req_tech = list(TECH_DATA = 3,TECH_BIO = 2)
 	build_path = /obj/item/circuitboard/exosystem/medical
-	sort_string = "NAABA"
 
 /datum/design/circuit/exosuit/weapons
 	name = "basic weapon control"
 	id = "mech_software_weapons"
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/circuitboard/exosystem/weapons
-	sort_string = "NAACA"
 
 /datum/design/circuit/exosuit/advweapons
 	name = "advanced weapon control"
 	id = "mech_software_advweapons"
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/circuitboard/exosystem/advweapons
-	sort_string = "NAACB"

--- a/code/modules/research/designs/designs_exosuits.dm
+++ b/code/modules/research/designs/designs_exosuits.dm
@@ -5,30 +5,25 @@
 
 /datum/design/circuit/exosuit/engineering
 	name = "engineering system control"
-	id = "mech_software_engineering"
 	req_tech = list(TECH_DATA = 1)
 	build_path = /obj/item/circuitboard/exosystem/engineering
 
 /datum/design/circuit/exosuit/utility
 	name = "utility system control"
-	id = "mech_software_utility"
 	req_tech = list(TECH_DATA = 1)
 	build_path = /obj/item/circuitboard/exosystem/utility
 
 /datum/design/circuit/exosuit/medical
 	name = "medical system control"
-	id = "mech_software_medical"
 	req_tech = list(TECH_DATA = 3,TECH_BIO = 2)
 	build_path = /obj/item/circuitboard/exosystem/medical
 
 /datum/design/circuit/exosuit/weapons
 	name = "basic weapon control"
-	id = "mech_software_weapons"
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/circuitboard/exosystem/weapons
 
 /datum/design/circuit/exosuit/advweapons
 	name = "advanced weapon control"
-	id = "mech_software_advweapons"
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/circuitboard/exosystem/advweapons

--- a/code/modules/research/designs/designs_hud_optical.dm
+++ b/code/modules/research/designs/designs_hud_optical.dm
@@ -10,19 +10,16 @@
 
 /datum/design/item/hud/health
 	name = "health scanner"
-	id = "health_hud"
 	req_tech = list(TECH_BIO = 2, TECH_MAGNET = 3)
 	build_path = /obj/item/clothing/glasses/hud/health
 
 /datum/design/item/hud/security
 	name = "security records"
-	id = "security_hud"
 	req_tech = list(TECH_MAGNET = 3, TECH_COMBAT = 2)
 	build_path = /obj/item/clothing/glasses/hud/security
 
 /datum/design/item/hud/janitor
 	name = "filth scanner"
-	id = "janitor_hud"
 	req_tech = list(TECH_BIO = 1, TECH_MAGNET = 3)
 	build_path = /obj/item/clothing/glasses/hud/janitor
 
@@ -34,19 +31,16 @@
 /datum/design/item/optical/mesons
 	name = "mesons"
 	desc = "Using the meson-scanning technology those glasses allow you to see through walls, floor or anything else."
-	id = "mesons"
 	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/clothing/glasses/meson
 
 /datum/design/item/optical/material
 	name = "material"
-	id = "mesons_material"
 	req_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 3)
 	build_path = /obj/item/clothing/glasses/material
 
 /datum/design/item/optical/tactical
 	name = "tactical"
-	id = "tactical_goggles"
 	req_tech = list(TECH_MAGNET = 3, TECH_COMBAT = 5)
 	materials = list(MAT_STEEL = 50, MAT_GLASS = 50, MAT_SILVER = 50, MAT_GOLD = 50)
 	build_path = /obj/item/clothing/glasses/tacgoggles

--- a/code/modules/research/designs/designs_hud_optical.dm
+++ b/code/modules/research/designs/designs_hud_optical.dm
@@ -13,21 +13,18 @@
 	id = "health_hud"
 	req_tech = list(TECH_BIO = 2, TECH_MAGNET = 3)
 	build_path = /obj/item/clothing/glasses/hud/health
-	sort_string = "GAAAA"
 
 /datum/design/item/hud/security
 	name = "security records"
 	id = "security_hud"
 	req_tech = list(TECH_MAGNET = 3, TECH_COMBAT = 2)
 	build_path = /obj/item/clothing/glasses/hud/security
-	sort_string = "GAAAB"
 
 /datum/design/item/hud/janitor
 	name = "filth scanner"
 	id = "janitor_hud"
 	req_tech = list(TECH_BIO = 1, TECH_MAGNET = 3)
 	build_path = /obj/item/clothing/glasses/hud/janitor
-	sort_string = "GAAAC"
 
 /datum/design/item/optical/AssembleDesignName()
 	..()
@@ -40,14 +37,12 @@
 	id = "mesons"
 	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
 	build_path = /obj/item/clothing/glasses/meson
-	sort_string = "GBAAA"
 
 /datum/design/item/optical/material
 	name = "material"
 	id = "mesons_material"
 	req_tech = list(TECH_MAGNET = 3, TECH_ENGINEERING = 3)
 	build_path = /obj/item/clothing/glasses/material
-	sort_string = "GAAAB"
 
 /datum/design/item/optical/tactical
 	name = "tactical"
@@ -55,4 +50,3 @@
 	req_tech = list(TECH_MAGNET = 3, TECH_COMBAT = 5)
 	materials = list(MAT_STEEL = 50, MAT_GLASS = 50, MAT_SILVER = 50, MAT_GOLD = 50)
 	build_path = /obj/item/clothing/glasses/tacgoggles
-	sort_string = "GAAAC"

--- a/code/modules/research/designs/designs_implant.dm
+++ b/code/modules/research/designs/designs_implant.dm
@@ -10,46 +10,39 @@
 	id = "implant_chem"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3)
 	build_path = /obj/item/implantcase/chem
-	sort_string = "MFAAA"
 
 /datum/design/item/implant/death_alarm
 	name = "death alarm"
 	id = "implant_death"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_DATA = 2)
 	build_path = /obj/item/implantcase/death_alarm
-	sort_string = "MFAAB"
 
 /datum/design/item/implant/tracking
 	name = "tracking"
 	id = "implant_tracking"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_BLUESPACE = 3)
 	build_path = /obj/item/implantcase/tracking
-	sort_string = "MFAAC"
 
 /datum/design/item/implant/imprinting
 	name = "imprinting"
 	id = "implant_imprinting"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_DATA = 4)
 	build_path = /obj/item/implantcase/imprinting
-	sort_string = "MFAAD"
 
 /datum/design/item/implant/adrenaline
 	name = "adrenaline"
 	id = "implant_adrenaline"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_ESOTERIC = 3)
 	build_path = /obj/item/implantcase/adrenalin
-	sort_string = "MFAAE"
 
 /datum/design/item/implant/freedom
 	name = "freedom"
 	id = "implant_free"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_ESOTERIC = 3)
 	build_path = /obj/item/implantcase/freedom
-	sort_string = "MFAAF"
 
 /datum/design/item/implant/explosive
 	name = "explosive"
 	id = "implant_explosive"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_ESOTERIC = 4)
 	build_path = /obj/item/implantcase/explosive
-	sort_string = "MFAAG"

--- a/code/modules/research/designs/designs_implant.dm
+++ b/code/modules/research/designs/designs_implant.dm
@@ -7,42 +7,35 @@
 
 /datum/design/item/implant/chemical
 	name = "chemical"
-	id = "implant_chem"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3)
 	build_path = /obj/item/implantcase/chem
 
 /datum/design/item/implant/death_alarm
 	name = "death alarm"
-	id = "implant_death"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_DATA = 2)
 	build_path = /obj/item/implantcase/death_alarm
 
 /datum/design/item/implant/tracking
 	name = "tracking"
-	id = "implant_tracking"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_BLUESPACE = 3)
 	build_path = /obj/item/implantcase/tracking
 
 /datum/design/item/implant/imprinting
 	name = "imprinting"
-	id = "implant_imprinting"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_DATA = 4)
 	build_path = /obj/item/implantcase/imprinting
 
 /datum/design/item/implant/adrenaline
 	name = "adrenaline"
-	id = "implant_adrenaline"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_ESOTERIC = 3)
 	build_path = /obj/item/implantcase/adrenalin
 
 /datum/design/item/implant/freedom
 	name = "freedom"
-	id = "implant_free"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_ESOTERIC = 3)
 	build_path = /obj/item/implantcase/freedom
 
 /datum/design/item/implant/explosive
 	name = "explosive"
-	id = "implant_explosive"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_ESOTERIC = 4)
 	build_path = /obj/item/implantcase/explosive

--- a/code/modules/research/designs/designs_mechfab.dm
+++ b/code/modules/research/designs/designs_mechfab.dm
@@ -15,56 +15,48 @@
 
 /datum/design/item/mechfab/robot/exoskeleton_ground
 	name = "Robot frame, standard"
-	id = "robot_exoskeleton"
 	build_path = /obj/item/robot_parts/robot_suit
 	time = 50
 	materials = list(MAT_STEEL = 50000)
 
 /datum/design/item/mechfab/robot/exoskeleton_flying
 	name = "Robot frame, hover"
-	id = "robot_exoskeleton_hover"
 	build_path = /obj/item/robot_parts/robot_suit/flyer
 	time = 50
 	materials = list(MAT_STEEL = 50000)
 
 /datum/design/item/mechfab/robot/torso
 	name = "Robot torso"
-	id = "robot_torso"
 	build_path = /obj/item/robot_parts/chest
 	time = 35
 	materials = list(MAT_STEEL = 40000)
 
 /datum/design/item/mechfab/robot/head
 	name = "Robot head"
-	id = "robot_head"
 	build_path = /obj/item/robot_parts/head
 	time = 35
 	materials = list(MAT_STEEL = 25000)
 
 /datum/design/item/mechfab/robot/l_arm
 	name = "Robot left arm"
-	id = "robot_l_arm"
 	build_path = /obj/item/robot_parts/l_arm
 	time = 20
 	materials = list(MAT_STEEL = 18000)
 
 /datum/design/item/mechfab/robot/r_arm
 	name = "Robot right arm"
-	id = "robot_r_arm"
 	build_path = /obj/item/robot_parts/r_arm
 	time = 20
 	materials = list(MAT_STEEL = 18000)
 
 /datum/design/item/mechfab/robot/l_leg
 	name = "Robot left leg"
-	id = "robot_l_leg"
 	build_path = /obj/item/robot_parts/l_leg
 	time = 20
 	materials = list(MAT_STEEL = 15000)
 
 /datum/design/item/mechfab/robot/r_leg
 	name = "Robot right leg"
-	id = "robot_r_leg"
 	build_path = /obj/item/robot_parts/r_leg
 	time = 20
 	materials = list(MAT_STEEL = 15000)
@@ -75,37 +67,30 @@
 
 /datum/design/item/mechfab/robot/component/binary_communication_device
 	name = "Binary communication device"
-	id = "binary_communication_device"
 	build_path = /obj/item/robot_parts/robot_component/binary_communication_device
 
 /datum/design/item/mechfab/robot/component/radio
 	name = "Radio"
-	id = "radio"
 	build_path = /obj/item/robot_parts/robot_component/radio
 
 /datum/design/item/mechfab/robot/component/actuator
 	name = "Actuator"
-	id = "actuator"
 	build_path = /obj/item/robot_parts/robot_component/actuator
 
 /datum/design/item/mechfab/robot/component/diagnosis_unit
 	name = "Diagnosis unit"
-	id = "diagnosis_unit"
 	build_path = /obj/item/robot_parts/robot_component/diagnosis_unit
 
 /datum/design/item/mechfab/robot/component/camera
 	name = "Camera"
-	id = "camera"
 	build_path = /obj/item/robot_parts/robot_component/camera
 
 /datum/design/item/mechfab/robot/component/armour
 	name = "Armour plating"
-	id = "armour"
 	build_path = /obj/item/robot_parts/robot_component/armour
 
 /datum/design/item/mechfab/robot/component/armour/light
 	name = "Light-weight armour plating"
-	id = "light_armour"
 	build_path = /obj/item/robot_parts/robot_component/armour/light
 	// Half the armor, half the cost
 	time = 10
@@ -113,7 +98,6 @@
 
 /datum/design/item/mechfab/exosuit
 	name = "exosuit frame"
-	id = "mech_frame"
 	build_path = /obj/structure/heavy_vehicle_frame
 	time = 70
 	materials = list(MAT_STEEL = 20000)
@@ -121,14 +105,12 @@
 
 /datum/design/item/mechfab/exosuit/basic_armour
 	name = "basic exosuit armour"
-	id = "mech_armour_basic"
 	build_path = /obj/item/robot_parts/robot_component/armour/exosuit
 	time = 30
 	materials = list(MAT_STEEL = 7500)
 
 /datum/design/item/mechfab/exosuit/radproof_armour
 	name = "radiation-proof exosuit armour"
-	id = "mech_armour_radproof"
 	build_path = /obj/item/robot_parts/robot_component/armour/exosuit/radproof
 	time = 50
 	req_tech = list(TECH_MATERIAL = 2)
@@ -136,7 +118,6 @@
 
 /datum/design/item/mechfab/exosuit/em_armour
 	name = "EM-shielded exosuit armour"
-	id = "mech_armour_em"
 	build_path = /obj/item/robot_parts/robot_component/armour/exosuit/em
 	time = 50
 	req_tech = list(TECH_MATERIAL = 2)
@@ -144,7 +125,6 @@
 
 /datum/design/item/mechfab/exosuit/combat_armour
 	name = "Combat exosuit armour"
-	id = "mech_armour_combat"
 	build_path = /obj/item/robot_parts/robot_component/armour/exosuit/combat
 	time = 50
 	req_tech = list(TECH_MATERIAL = 4)
@@ -152,14 +132,12 @@
 
 /datum/design/item/mechfab/exosuit/control_module
 	name = "exosuit control module"
-	id = "mech_control_module"
 	build_path = /obj/item/mech_component/control_module
 	time = 15
 	materials = list(MAT_STEEL = 5000)
 
 /datum/design/item/mechfab/exosuit/combat_head
 	name = "combat exosuit sensors"
-	id = "combat_head"
 	time = 30
 	materials = list(MAT_STEEL = 10000)
 	build_path = /obj/item/mech_component/sensors/combat
@@ -167,7 +145,6 @@
 
 /datum/design/item/mechfab/exosuit/combat_torso
 	name = "combat exosuit chassis"
-	id = "combat_body"
 	time = 60
 	materials = list(MAT_STEEL = 45000)
 	build_path = /obj/item/mech_component/chassis/combat
@@ -175,7 +152,6 @@
 
 /datum/design/item/mechfab/exosuit/combat_arms
 	name = "combat exosuit manipulators"
-	id = "combat_arms"
 	time = 30
 	materials = list(MAT_STEEL = 15000)
 	build_path = /obj/item/mech_component/manipulators/combat
@@ -183,7 +159,6 @@
 
 /datum/design/item/mechfab/exosuit/combat_legs
 	name = "combat exosuit motivators"
-	id = "combat_legs"
 	time = 30
 	materials = list(MAT_STEEL = 15000)
 	build_path = /obj/item/mech_component/propulsion/combat
@@ -191,35 +166,30 @@
 
 /datum/design/item/mechfab/exosuit/powerloader_head
 	name = "power loader sensors"
-	id = "powerloader_head"
 	build_path = /obj/item/mech_component/sensors/powerloader
 	time = 15
 	materials = list(MAT_STEEL = 5000)
 
 /datum/design/item/mechfab/exosuit/powerloader_torso
 	name = "power loader chassis"
-	id = "powerloader_body"
 	build_path = /obj/item/mech_component/chassis/powerloader
 	time = 50
 	materials = list(MAT_STEEL = 20000)
 
 /datum/design/item/mechfab/exosuit/powerloader_arms
 	name = "power loader manipulators"
-	id = "powerloader_arms"
 	build_path = /obj/item/mech_component/manipulators/powerloader
 	time = 30
 	materials = list(MAT_STEEL = 6000)
 
 /datum/design/item/mechfab/exosuit/powerloader_legs
 	name = "power loader motivators"
-	id = "powerloader_legs"
 	build_path = /obj/item/mech_component/propulsion/powerloader
 	time = 30
 	materials = list(MAT_STEEL = 6000)
 
 /datum/design/item/mechfab/exosuit/light_head
 	name = "light exosuit sensors"
-	id = "light_head"
 	time = 20
 	materials = list(MAT_STEEL = 8000)
 	build_path = /obj/item/mech_component/sensors/light
@@ -227,7 +197,6 @@
 
 /datum/design/item/mechfab/exosuit/light_torso
 	name = "light exosuit chassis"
-	id = "light_body"
 	time = 40
 	materials = list(MAT_STEEL = 30000)
 	build_path = /obj/item/mech_component/chassis/light
@@ -235,7 +204,6 @@
 
 /datum/design/item/mechfab/exosuit/light_arms
 	name = "light exosuit manipulators"
-	id = "light_arms"
 	time = 20
 	materials = list(MAT_STEEL = 10000)
 	build_path = /obj/item/mech_component/manipulators/light
@@ -243,7 +211,6 @@
 
 /datum/design/item/mechfab/exosuit/light_legs
 	name = "light exosuit motivators"
-	id = "light_legs"
 	time = 25
 	materials = list(MAT_STEEL = 10000)
 	build_path = /obj/item/mech_component/propulsion/light
@@ -251,7 +218,6 @@
 
 /datum/design/item/mechfab/exosuit/heavy_head
 	name = "heavy exosuit sensors"
-	id = "heavy_head"
 	time = 35
 	materials = list(MAT_STEEL = 16000)
 	build_path = /obj/item/mech_component/sensors/heavy
@@ -259,28 +225,24 @@
 
 /datum/design/item/mechfab/exosuit/heavy_torso
 	name = "heavy exosuit chassis"
-	id = "heavy_body"
 	time = 75
 	materials = list(MAT_STEEL = 70000, MAT_URANIUM = 10000)
 	build_path = /obj/item/mech_component/chassis/heavy
 
 /datum/design/item/mechfab/exosuit/heavy_arms
 	name = "heavy exosuit manipulators"
-	id = "heavy_arms"
 	time = 35
 	materials = list(MAT_STEEL = 20000)
 	build_path = /obj/item/mech_component/manipulators/heavy
 
 /datum/design/item/mechfab/exosuit/heavy_legs
 	name = "heavy exosuit motivators"
-	id = "heavy_legs"
 	time = 35
 	materials = list(MAT_STEEL = 20000)
 	build_path = /obj/item/mech_component/propulsion/heavy
 
 /datum/design/item/mechfab/exosuit/spider
 	name = "quadruped motivators"
-	id = "quad_legs"
 	time = 20
 	materials = list(MAT_STEEL = 12000)
 	build_path = /obj/item/mech_component/propulsion/spider
@@ -288,7 +250,6 @@
 
 /datum/design/item/mechfab/exosuit/track
 	name = "armored treads"
-	id = "treads"
 	time = 35
 	materials = list(MAT_STEEL = 25000)
 	build_path = /obj/item/mech_component/propulsion/tracks
@@ -296,7 +257,6 @@
 
 /datum/design/item/mechfab/exosuit/sphere_torso
 	name = "spherical chassis"
-	id = "sphere_body"
 	build_path = /obj/item/mech_component/chassis/pod
 	time = 50
 	materials = list(MAT_STEEL = 18000)
@@ -310,60 +270,51 @@
 /datum/design/item/robot_upgrade/rename
 	name = "Rename module"
 	desc = "Used to rename a cyborg."
-	id = "borg_rename_module"
 	build_path = /obj/item/borg/upgrade/rename
 
 /datum/design/item/robot_upgrade/reset
 	name = "Reset module"
 	desc = "Used to reset a cyborg's module. Destroys any other upgrades applied to the robot."
-	id = "borg_reset_module"
 	build_path = /obj/item/borg/upgrade/reset
 
 /datum/design/item/robot_upgrade/floodlight
 	name = "Floodlight module"
 	desc = "Used to boost cyborg's integrated light intensity."
-	id = "borg_floodlight_module"
 	build_path = /obj/item/borg/upgrade/floodlight
 
 /datum/design/item/robot_upgrade/restart
 	name = "Emergency restart module"
 	desc = "Used to force a restart of a disabled-but-repaired robot, bringing it back online."
-	id = "borg_restart_module"
 	materials = list(MAT_STEEL = 60000, MAT_GLASS = 5000)
 	build_path = /obj/item/borg/upgrade/restart
 
 /datum/design/item/robot_upgrade/vtec
 	name = "VTEC module"
 	desc = "Used to kick in a robot's VTEC systems, increasing their speed."
-	id = "borg_vtec_module"
 	materials = list(MAT_STEEL = 80000, MAT_GLASS = 6000, MAT_GOLD = 5000)
 	build_path = /obj/item/borg/upgrade/vtec
 
 /datum/design/item/robot_upgrade/weaponcooler
 	name = "Rapid weapon cooling module"
 	desc = "Used to cool a mounted energy gun, increasing the potential current in it and thus its recharge rate."
-	id = "borg_taser_module"
 	materials = list(MAT_STEEL = 80000, MAT_GLASS = 6000, MAT_GOLD = 2000, MAT_DIAMOND = 500)
 	build_path = /obj/item/borg/upgrade/weaponcooler
 
 /datum/design/item/robot_upgrade/jetpack
 	name = "Jetpack module"
 	desc = "A carbon dioxide jetpack suitable for low-gravity mining operations."
-	id = "borg_jetpack_module"
 	materials = list(MAT_STEEL = 10000, MAT_PHORON = 15000, MAT_URANIUM = 20000)
 	build_path = /obj/item/borg/upgrade/jetpack
 
 /datum/design/item/robot_upgrade/rcd
 	name = "RCD module"
 	desc = "A rapid construction device module for use during construction operations."
-	id = "borg_rcd_module"
 	materials = list(MAT_STEEL = 25000, MAT_PHORON = 10000, MAT_GOLD = 1000, MAT_SILVER = 1000)
 	build_path = /obj/item/borg/upgrade/rcd
 
 /datum/design/item/robot_upgrade/syndicate
 	name = "Illegal upgrade"
 	desc = "Allows for the construction of lethal upgrades for cyborgs."
-	id = "borg_syndicate_module"
 	req_tech = list(TECH_COMBAT = 4, TECH_ESOTERIC = 3)
 	materials = list(MAT_STEEL = 10000, MAT_GLASS = 15000, MAT_DIAMOND = 10000)
 	build_path = /obj/item/borg/upgrade/syndicate
@@ -380,47 +331,39 @@
 
 /datum/design/item/exosuit/hydraulic_clamp
 	name = "hydraulic clamp"
-	id = "hydraulic_clamp"
 	build_path = /obj/item/mech_equipment/clamp
 
 /datum/design/item/exosuit/gravity_catapult
 	name = "gravity catapult"
-	id = "gravity_catapult"
 	build_path = /obj/item/mech_equipment/catapult
 
 /datum/design/item/exosuit/drill
 	name = "drill"
-	id = "mech_drill"
 	build_path = /obj/item/mech_equipment/drill
 
 /datum/design/item/exosuit/taser
 	name = "mounted electrolaser"
-	id = "mech_taser"
 	req_tech = list(TECH_COMBAT = 1)
 	build_path = /obj/item/mech_equipment/mounted_system/taser
 
 /datum/design/item/exosuit/weapon/plasma
 	name = "mounted plasma cutter"
-	id = "mech_plasma"
 	materials = list(MAT_STEEL = 20000)
 	req_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
 	build_path = /obj/item/mech_equipment/mounted_system/taser/plasma
 
 /datum/design/item/exosuit/weapon/ion
 	name = "mounted ion rifle"
-	id = "mech_ion"
 	req_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 4)
 	build_path = /obj/item/mech_equipment/mounted_system/taser/ion
 
 /datum/design/item/exosuit/weapon/laser
 	name = "mounted laser gun"
-	id = "mech_laser"
 	req_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 4)
 	build_path = /obj/item/mech_equipment/mounted_system/taser/laser
 
 /datum/design/item/exosuit/rcd
 	name = "RCD"
-	id = "mech_rcd"
 	time = 90
 	materials = list(MAT_STEEL = 30000, MAT_PHORON = 25000, MAT_SILVER = 15000, MAT_GOLD = 15000)
 	req_tech = list(TECH_MATERIAL = 4, TECH_BLUESPACE = 3, TECH_MAGNET = 4, TECH_POWER = 4, TECH_ENGINEERING = 4)
@@ -428,23 +371,19 @@
 
 /datum/design/item/exosuit/floodlight
 	name = "floodlight"
-	id = "mech_floodlight"
 	req_tech = list(TECH_ENGINEERING = 1)
 	build_path = /obj/item/mech_equipment/light
 
 /datum/design/item/exosuit/sleeper
 	name = "mounted sleeper"
-	id   = "mech_sleeper"
 	build_path = /obj/item/mech_equipment/sleeper
 
 /datum/design/item/exosuit/extinguisher
 	name = "mounted extinguisher"
-	id   = "mech_extinguisher"
 	build_path = /obj/item/mech_equipment/mounted_system/extinguisher
 
 /datum/design/item/exosuit/mechshields
 	name = "energy shield drone"
-	id = "mech_shield"
 	time = 90
 	materials = list(MAT_STEEL = 20000, MAT_SILVER = 12000, MAT_GOLD = 12000)
 	req_tech = list(TECH_MATERIAL = 4, TECH_MAGNET = 4, TECH_POWER = 4, TECH_COMBAT = 2)
@@ -453,7 +392,6 @@
 
 /datum/design/item/synthetic_flash
 	name = "Synthetic flash"
-	id = "sflash"
 	req_tech = list(TECH_MAGNET = 3, TECH_COMBAT = 2)
 	build_type = MECHFAB
 	materials = list(MAT_STEEL = 750, MAT_GLASS = 750)
@@ -469,74 +407,63 @@
 	build_path = /obj/item/organ/internal/augment/active/simple/armblade
 	materials = list(MAT_STEEL = 4000, MAT_GLASS = 750)
 	req_tech = list(TECH_MAGNET = 3, TECH_COMBAT = 2, TECH_MATERIAL = 4, TECH_BIO = 3)
-	id = "augment_blade"
 
 /datum/design/item/mechfab/augment/armblade/wolverine
 	name = "Cyberclaws"
 	build_path = /obj/item/organ/internal/augment/active/simple/wolverine
 	materials = list(MAT_STEEL = 6000, MAT_DIAMOND = 250)
 	req_tech = list(TECH_MAGNET = 3, TECH_COMBAT = 4, TECH_MATERIAL = 4, TECH_BIO = 3)
-	id = "augment_wolverine"
 
 /datum/design/item/mechfab/augment/engineering
 	name = "Engineering toolset"
 	build_path = /obj/item/organ/internal/augment/active/polytool/engineer
 	materials = list(MAT_STEEL = 3000, MAT_GLASS = 1000)
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 4, TECH_BIO = 2)
-	id = "augment_toolset_engineering"
 
 /datum/design/item/mechfab/augment/surgery
 	name = "Surgical toolset"
 	build_path = /obj/item/organ/internal/augment/active/polytool/surgical
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 2000)
 	req_tech = list(TECH_BIO = 4, TECH_MATERIAL = 4)
-	id = "augment_toolset_surgery"
 
 /datum/design/item/mechfab/augment/reflex
 	name = "Synapse interceptors"
 	build_path = /obj/item/organ/internal/augment/boost/reflex
 	materials = list(MAT_STEEL = 750, MAT_GLASS = 750, MAT_SILVER = 100)
 	req_tech = list(TECH_MATERIAL = 5, TECH_COMBAT = 4, TECH_BIO = 4, TECH_MAGNET = 5)
-	id = "augment_booster_reflex"
 
 /datum/design/item/mechfab/augment/shooting
 	name = "Gunnery booster"
 	build_path = /obj/item/organ/internal/augment/boost/shooting
 	materials = list(MAT_STEEL = 750, MAT_GLASS = 750, MAT_SILVER = 100)
 	req_tech = list(TECH_MATERIAL = 5, TECH_COMBAT = 5, TECH_BIO = 4)
-	id = "augment_booster_gunnery"
 
 /datum/design/item/mechfab/augment/muscle
 	name = "Mechanical muscles"
 	build_path = /obj/item/organ/internal/augment/boost/muscle
 	materials = list(MAT_STEEL = 5000, MAT_GLASS = 1000)
 	req_tech = list(TECH_MATERIAL = 3, TECH_BIO = 4)
-	id = "augment_booster_muscles"
 
 /datum/design/item/mechfab/augment/armor
 	name = "Subdermal armor"
 	build_path = /obj/item/organ/internal/augment/armor
 	materials = list(MAT_STEEL = 10000, MAT_GLASS = 750)
 	req_tech = list(TECH_MATERIAL = 5, TECH_COMBAT = 4, TECH_BIO = 4)
-	id = "augment_armor"
 
 /datum/design/item/mechfab/augment/nanounit
 	name = "Nanite MCU"
 	build_path = /obj/item/organ/internal/augment/active/nanounit
 	materials = list(MAT_STEEL = 5000, MAT_GLASS = 1000, MAT_GOLD = 100, MAT_URANIUM = 500)
 	req_tech = list(TECH_MATERIAL = 5, TECH_COMBAT = 5, TECH_BIO = 5, TECH_ENGINEERING = 5)
-	id = "augment_nanounit"
 
 /datum/design/item/mechfab/augment/circuit
 	name = "Integrated circuit frame"
 	build_path = /obj/item/organ/internal/augment/active/simple/circuit
 	materials = list(MAT_STEEL = 3000)
-	id = "augment_circuitry"
 
 /datum/design/item/mechfab/rig/zero
 	category = "Hardsuits"
 	name = "Null suit control module"
 	build_path = /obj/item/rig/zero
 	materials = list(MAT_STEEL = 30000, MAT_GLASS = 5000, MAT_SILVER = 1000)
-	id = "null _suit"
 	time = 120

--- a/code/modules/research/designs/designs_medical.dm
+++ b/code/modules/research/designs/designs_medical.dm
@@ -7,52 +7,44 @@
 
 /datum/design/item/medical/slime_scanner
 	desc = "Multipurpose organic life scanner."
-	id = "slime_scanner"
 	req_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
 	materials = list(MAT_STEEL = 200, MAT_GLASS = 100, MAT_PLASTIC = 150)
 	build_path = /obj/item/scanner/xenobio
 
 /datum/design/item/medical/robot_scanner
 	desc = "A hand-held scanner able to diagnose robotic injuries."
-	id = "robot_scanner"
 	req_tech = list(TECH_MAGNET = 3, TECH_BIO = 2, TECH_ENGINEERING = 3)
 	materials = list(MAT_STEEL = 500, MAT_GLASS = 200, MAT_PLASTIC = 150)
 	build_path = /obj/item/robotanalyzer
 
 /datum/design/item/medical/mass_spectrometer
 	desc = "A device for analyzing chemicals in blood."
-	id = "mass_spectrometer"
 	req_tech = list(TECH_BIO = 2, TECH_MAGNET = 2)
 	build_path = /obj/item/scanner/spectrometer
 
 /datum/design/item/medical/adv_mass_spectrometer
 	desc = "A device for analyzing chemicals in blood and their quantities."
-	id = "adv_mass_spectrometer"
 	req_tech = list(TECH_BIO = 2, TECH_MAGNET = 4)
 	build_path = /obj/item/scanner/spectrometer/adv
 
 /datum/design/item/medical/reagent_scanner
 	desc = "A device for identifying chemicals."
-	id = "reagent_scanner"
 	req_tech = list(TECH_BIO = 2, TECH_MAGNET = 2)
 	build_path = /obj/item/scanner/reagent
 
 /datum/design/item/medical/adv_reagent_scanner
 	desc = "A device for identifying chemicals and their proportions."
-	id = "adv_reagent_scanner"
 	req_tech = list(TECH_BIO = 2, TECH_MAGNET = 4)
 	build_path = /obj/item/scanner/reagent/adv
 
 /datum/design/item/medical/nanopaste
 	desc = "A tube of paste containing swarms of repair nanites. Very effective in repairing robotic machinery."
-	id = "nanopaste"
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
 	materials = list(MAT_STEEL = 7000, MAT_GLASS = 7000)
 	build_path = /obj/item/stack/nanopaste
 
 /datum/design/item/medical/hypospray
 	desc = "A sterile, air-needle autoinjector for rapid administration of drugs"
-	id = "hypospray"
 	req_tech = list(TECH_MATERIAL = 4, TECH_BIO = 5)
 	materials = list(MAT_STEEL = 8000, MAT_GLASS = 8000, MAT_SILVER = 2000)
 	build_path = /obj/item/chems/hypospray/vial
@@ -60,7 +52,6 @@
 /datum/design/item/medical/cryobag
 	desc = "A folded, reusable bag designed to prevent additional damage to an occupant, especially useful if short on time or in \
 	a hostile enviroment."
-	id = "cryobag"
 	req_tech = list(TECH_MATERIAL = 6, TECH_BIO = 6)
 	materials = list(MAT_PLASTIC = 15000, MAT_GLASS = 15000, MAT_SILVER = 5000, MAT_GOLD = 1000)
 	build_path = /obj/item/bodybag/cryobag

--- a/code/modules/research/designs/designs_medical.dm
+++ b/code/modules/research/designs/designs_medical.dm
@@ -11,7 +11,6 @@
 	req_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
 	materials = list(MAT_STEEL = 200, MAT_GLASS = 100, MAT_PLASTIC = 150)
 	build_path = /obj/item/scanner/xenobio
-	sort_string = "MACFA"
 
 /datum/design/item/medical/robot_scanner
 	desc = "A hand-held scanner able to diagnose robotic injuries."
@@ -19,35 +18,30 @@
 	req_tech = list(TECH_MAGNET = 3, TECH_BIO = 2, TECH_ENGINEERING = 3)
 	materials = list(MAT_STEEL = 500, MAT_GLASS = 200, MAT_PLASTIC = 150)
 	build_path = /obj/item/robotanalyzer
-	sort_string = "MACFB"
 
 /datum/design/item/medical/mass_spectrometer
 	desc = "A device for analyzing chemicals in blood."
 	id = "mass_spectrometer"
 	req_tech = list(TECH_BIO = 2, TECH_MAGNET = 2)
 	build_path = /obj/item/scanner/spectrometer
-	sort_string = "MACAA"
 
 /datum/design/item/medical/adv_mass_spectrometer
 	desc = "A device for analyzing chemicals in blood and their quantities."
 	id = "adv_mass_spectrometer"
 	req_tech = list(TECH_BIO = 2, TECH_MAGNET = 4)
 	build_path = /obj/item/scanner/spectrometer/adv
-	sort_string = "MACAB"
 
 /datum/design/item/medical/reagent_scanner
 	desc = "A device for identifying chemicals."
 	id = "reagent_scanner"
 	req_tech = list(TECH_BIO = 2, TECH_MAGNET = 2)
 	build_path = /obj/item/scanner/reagent
-	sort_string = "MACBA"
 
 /datum/design/item/medical/adv_reagent_scanner
 	desc = "A device for identifying chemicals and their proportions."
 	id = "adv_reagent_scanner"
 	req_tech = list(TECH_BIO = 2, TECH_MAGNET = 4)
 	build_path = /obj/item/scanner/reagent/adv
-	sort_string = "MACBB"
 
 /datum/design/item/medical/nanopaste
 	desc = "A tube of paste containing swarms of repair nanites. Very effective in repairing robotic machinery."
@@ -55,7 +49,6 @@
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
 	materials = list(MAT_STEEL = 7000, MAT_GLASS = 7000)
 	build_path = /obj/item/stack/nanopaste
-	sort_string = "MADAA"
 
 /datum/design/item/medical/hypospray
 	desc = "A sterile, air-needle autoinjector for rapid administration of drugs"
@@ -63,7 +56,6 @@
 	req_tech = list(TECH_MATERIAL = 4, TECH_BIO = 5)
 	materials = list(MAT_STEEL = 8000, MAT_GLASS = 8000, MAT_SILVER = 2000)
 	build_path = /obj/item/chems/hypospray/vial
-	sort_string = "MAEAA"
 
 /datum/design/item/medical/cryobag
 	desc = "A folded, reusable bag designed to prevent additional damage to an occupant, especially useful if short on time or in \
@@ -72,4 +64,3 @@
 	req_tech = list(TECH_MATERIAL = 6, TECH_BIO = 6)
 	materials = list(MAT_PLASTIC = 15000, MAT_GLASS = 15000, MAT_SILVER = 5000, MAT_GOLD = 1000)
 	build_path = /obj/item/bodybag/cryobag
-	sort_string = "MAFAA"

--- a/code/modules/research/designs/designs_mining.dm
+++ b/code/modules/research/designs/designs_mining.dm
@@ -7,35 +7,30 @@
 	req_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2, TECH_ENGINEERING = 2)
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 500, MAT_SILVER = 500)
 	build_path = /obj/item/pickaxe/jackhammer
-	sort_string = "KAAAA"
 
 /datum/design/item/mining/drill
 	id = "drill"
 	req_tech = list(TECH_MATERIAL = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
 	materials = list(MAT_STEEL = 6000, MAT_GLASS = 1000) //expensive, but no need for miners.
 	build_path = /obj/item/pickaxe/drill
-	sort_string = "KAAAB"
 
 /datum/design/item/mining/plasmacutter
 	id = "plasmacutter"
 	req_tech = list(TECH_MATERIAL = 4, TECH_PHORON = 3, TECH_ENGINEERING = 3)
 	materials = list(MAT_STEEL = 1500, MAT_GLASS = 500, MAT_GOLD = 500, MAT_PHORON = 500)
 	build_path = /obj/item/gun/energy/plasmacutter
-	sort_string = "KAAAC"
 
 /datum/design/item/mining/pick_diamond
 	id = "pick_diamond"
 	req_tech = list(TECH_MATERIAL = 6)
 	materials = list(MAT_DIAMOND = 3000)
 	build_path = /obj/item/pickaxe/diamond
-	sort_string = "KAAAD"
 
 /datum/design/item/mining/drill_diamond
 	id = "drill_diamond"
 	req_tech = list(TECH_MATERIAL = 6, TECH_POWER = 4, TECH_ENGINEERING = 4)
 	materials = list(MAT_STEEL = 3000, MAT_GLASS = 1000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/pickaxe/diamonddrill
-	sort_string = "KAAAE"
 
 /datum/design/item/mining/depth_scanner
 	desc = "Used to check spatial depth and density of rock outcroppings."
@@ -43,4 +38,3 @@
 	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2, TECH_BLUESPACE = 2)
 	materials = list(MAT_STEEL = 1000, MAT_GLASS = 500, MAT_ALUMINIUM = 150)
 	build_path = /obj/item/depth_scanner
-	sort_string = "KAAAF"

--- a/code/modules/research/designs/designs_mining.dm
+++ b/code/modules/research/designs/designs_mining.dm
@@ -3,38 +3,32 @@
 	name = "Mining equipment design ([item_name])"
 
 /datum/design/item/mining/jackhammer
-	id = "jackhammer"
 	req_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2, TECH_ENGINEERING = 2)
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 500, MAT_SILVER = 500)
 	build_path = /obj/item/pickaxe/jackhammer
 
 /datum/design/item/mining/drill
-	id = "drill"
 	req_tech = list(TECH_MATERIAL = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
 	materials = list(MAT_STEEL = 6000, MAT_GLASS = 1000) //expensive, but no need for miners.
 	build_path = /obj/item/pickaxe/drill
 
 /datum/design/item/mining/plasmacutter
-	id = "plasmacutter"
 	req_tech = list(TECH_MATERIAL = 4, TECH_PHORON = 3, TECH_ENGINEERING = 3)
 	materials = list(MAT_STEEL = 1500, MAT_GLASS = 500, MAT_GOLD = 500, MAT_PHORON = 500)
 	build_path = /obj/item/gun/energy/plasmacutter
 
 /datum/design/item/mining/pick_diamond
-	id = "pick_diamond"
 	req_tech = list(TECH_MATERIAL = 6)
 	materials = list(MAT_DIAMOND = 3000)
 	build_path = /obj/item/pickaxe/diamond
 
 /datum/design/item/mining/drill_diamond
-	id = "drill_diamond"
 	req_tech = list(TECH_MATERIAL = 6, TECH_POWER = 4, TECH_ENGINEERING = 4)
 	materials = list(MAT_STEEL = 3000, MAT_GLASS = 1000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/pickaxe/diamonddrill
 
 /datum/design/item/mining/depth_scanner
 	desc = "Used to check spatial depth and density of rock outcroppings."
-	id = "depth_scanner"
 	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2, TECH_BLUESPACE = 2)
 	materials = list(MAT_STEEL = 1000, MAT_GLASS = 500, MAT_ALUMINIUM = 150)
 	build_path = /obj/item/depth_scanner

--- a/code/modules/research/designs/designs_modular_computer.dm
+++ b/code/modules/research/designs/designs_modular_computer.dm
@@ -10,7 +10,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 400, MAT_GLASS = 100)
 	build_path = /obj/item/stock_parts/computer/hard_drive/
-	sort_string = "VBAAA"
 
 /datum/design/item/modularcomponent/disk/advanced
 	name = "advanced hard drive"
@@ -19,7 +18,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 800, MAT_GLASS = 200)
 	build_path = /obj/item/stock_parts/computer/hard_drive/advanced
-	sort_string = "VBAAB"
 
 /datum/design/item/modularcomponent/disk/super
 	name = "super hard drive"
@@ -28,7 +26,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 1600, MAT_GLASS = 400)
 	build_path = /obj/item/stock_parts/computer/hard_drive/super
-	sort_string = "VBAAC"
 
 /datum/design/item/modularcomponent/disk/cluster
 	name = "cluster hard drive"
@@ -37,7 +34,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 3200, MAT_GLASS = 800)
 	build_path = /obj/item/stock_parts/computer/hard_drive/cluster
-	sort_string = "VBAAD"
 
 /datum/design/item/modularcomponent/disk/micro
 	name = "micro hard drive"
@@ -46,7 +42,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 400, MAT_GLASS = 100)
 	build_path = /obj/item/stock_parts/computer/hard_drive/micro
-	sort_string = "VBAAE"
 
 /datum/design/item/modularcomponent/disk/small
 	name = "small hard drive"
@@ -55,7 +50,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 800, MAT_GLASS = 200)
 	build_path = /obj/item/stock_parts/computer/hard_drive/small
-	sort_string = "VBAAF"
 
 // Network cards
 /datum/design/item/modularcomponent/netcard/AssembleDesignName()
@@ -70,7 +64,6 @@
 	materials = list(MAT_STEEL = 250, MAT_GLASS = 100)
 	chemicals = list(/datum/reagent/acid = 20)
 	build_path = /obj/item/stock_parts/computer/network_card
-	sort_string = "VBABA"
 
 /datum/design/item/modularcomponent/netcard/advanced
 	name = "advanced network card"
@@ -80,7 +73,6 @@
 	materials = list(MAT_STEEL = 500, MAT_GLASS = 200)
 	chemicals = list(/datum/reagent/acid = 20)
 	build_path = /obj/item/stock_parts/computer/network_card/advanced
-	sort_string = "VBABB"
 
 /datum/design/item/modularcomponent/netcard/wired
 	name = "wired network card"
@@ -90,7 +82,6 @@
 	materials = list(MAT_STEEL = 2500, MAT_GLASS = 400)
 	chemicals = list(/datum/reagent/acid = 20)
 	build_path = /obj/item/stock_parts/computer/network_card/wired
-	sort_string = "VBABC"
 
 // Data crystals (USB flash drives)
 /datum/design/item/modularcomponent/portabledrive/AssembleDesignName()
@@ -105,7 +96,6 @@
 	materials = list(MAT_GLASS = 800)
 	chemicals = list(/datum/reagent/acid = 20)
 	build_path = /obj/item/stock_parts/computer/hard_drive/portable
-	sort_string = "VBACA"
 
 /datum/design/item/modularcomponent/portabledrive/advanced
 	name = "advanced data crystal"
@@ -115,7 +105,6 @@
 	materials = list(MAT_GLASS = 1600)
 	chemicals = list(/datum/reagent/acid = 20)
 	build_path = /obj/item/stock_parts/computer/hard_drive/portable/advanced
-	sort_string = "VBACB"
 
 /datum/design/item/modularcomponent/portabledrive/super
 	name = "super data crystal"
@@ -125,7 +114,6 @@
 	materials = list(MAT_GLASS = 3200)
 	chemicals = list(/datum/reagent/acid = 20)
 	build_path = /obj/item/stock_parts/computer/hard_drive/portable/super
-	sort_string = "VBACC"
 
 // Card slot
 /datum/design/item/modularcomponent/accessory/AssembleDesignName()
@@ -139,7 +127,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 600)
 	build_path = /obj/item/stock_parts/computer/card_slot
-	sort_string = "VBADA"
 
 // Card Broadcaster
 /datum/design/item/modularcomponent/accessory/cardbroadcaster
@@ -149,7 +136,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 600)
 	build_path = /obj/item/stock_parts/computer/card_slot/broadcaster
-	sort_string = "VBADB"
 
 // inteliCard Slot
 /datum/design/item/modularcomponent/accessory/aislot
@@ -160,7 +146,6 @@
 	materials = list(MAT_STEEL = 2000)
 	chemicals = list(/datum/reagent/acid = 20)
 	build_path = /obj/item/stock_parts/computer/ai_slot
-	sort_string = "VBADC"
 
 // Nano printer
 /datum/design/item/modularcomponent/accessory/nanoprinter
@@ -170,7 +155,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 600)
 	build_path = /obj/item/stock_parts/computer/nano_printer
-	sort_string = "VBADD"
 
 // Tesla Link
 /datum/design/item/modularcomponent/accessory/teslalink
@@ -180,7 +164,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 2000)
 	build_path = /obj/item/stock_parts/computer/tesla_link
-	sort_string = "VBADE"
 
 //Scanners
 /datum/design/item/modularcomponent/accessory/reagent_scanner
@@ -190,7 +173,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 600, MAT_GLASS = 200)
 	build_path = /obj/item/stock_parts/computer/scanner/reagent
-	sort_string = "VBADF"
 
 /datum/design/item/modularcomponent/accessory/paper_scanner
 	name = "paper scanner module"
@@ -199,7 +181,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 600, MAT_GLASS = 200)
 	build_path = /obj/item/stock_parts/computer/scanner/paper
-	sort_string = "VBADG"
 
 /datum/design/item/modularcomponent/accessory/atmos_scanner
 	name = "atmospheric scanner module"
@@ -208,7 +189,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 600, MAT_GLASS = 200)
 	build_path = /obj/item/stock_parts/computer/scanner/atmos
-	sort_string = "VBADH"
 
 /datum/design/item/modularcomponent/accessory/medical_scanner
 	name = "medical scanner module"
@@ -217,7 +197,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 600, MAT_GLASS = 200)
 	build_path = /obj/item/stock_parts/computer/scanner/medical
-	sort_string = "VBADI"
 
 // Batteries
 /datum/design/item/modularcomponent/battery/AssembleDesignName()
@@ -231,7 +210,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 400)
 	build_path = /obj/item/stock_parts/computer/battery_module
-	sort_string = "VBAEA"
 
 /datum/design/item/modularcomponent/battery/advanced
 	name = "advanced battery module"
@@ -240,7 +218,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 800)
 	build_path = /obj/item/stock_parts/computer/battery_module/advanced
-	sort_string = "VBAEB"
 
 /datum/design/item/modularcomponent/battery/super
 	name = "super battery module"
@@ -249,7 +226,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 1600)
 	build_path = /obj/item/stock_parts/computer/battery_module/super
-	sort_string = "VBAEC"
 
 /datum/design/item/modularcomponent/battery/ultra
 	name = "ultra battery module"
@@ -258,7 +234,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 3200)
 	build_path = /obj/item/stock_parts/computer/battery_module/ultra
-	sort_string = "VBAED"
 
 /datum/design/item/modularcomponent/battery/nano
 	name = "nano battery module"
@@ -267,7 +242,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 200)
 	build_path = /obj/item/stock_parts/computer/battery_module/nano
-	sort_string = "VBAEE"
 
 /datum/design/item/modularcomponent/battery/micro
 	name = "micro battery module"
@@ -276,7 +250,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 400)
 	build_path = /obj/item/stock_parts/computer/battery_module/micro
-	sort_string = "VBAEF"
 
 // Processor unit
 /datum/design/item/modularcomponent/cpu/AssembleDesignName()
@@ -291,7 +264,6 @@
 	materials = list(MAT_STEEL = 1600)
 	chemicals = list(/datum/reagent/acid = 20)
 	build_path = /obj/item/stock_parts/computer/processor_unit
-	sort_string = "VBAFA"
 
 /datum/design/item/modularcomponent/cpu/small
 	name = "computer microprocessor unit"
@@ -301,7 +273,6 @@
 	materials = list(MAT_STEEL = 800)
 	chemicals = list(/datum/reagent/acid = 20)
 	build_path = /obj/item/stock_parts/computer/processor_unit/small
-	sort_string = "VBAFB"
 
 /datum/design/item/modularcomponent/cpu/photonic
 	name = "computer photonic processor unit"
@@ -311,7 +282,6 @@
 	materials = list(MAT_STEEL = 6400, glass = 2000)
 	chemicals = list(/datum/reagent/acid = 40)
 	build_path = /obj/item/stock_parts/computer/processor_unit/photonic
-	sort_string = "VBAFC"
 
 /datum/design/item/modularcomponent/cpu/photonic/small
 	name = "computer photonic microprocessor unit"
@@ -321,4 +291,3 @@
 	materials = list(MAT_STEEL = 3200, glass = 1000)
 	chemicals = list(/datum/reagent/acid = 20)
 	build_path = /obj/item/stock_parts/computer/processor_unit/photonic/small
-	sort_string = "VBAFD"

--- a/code/modules/research/designs/designs_modular_computer.dm
+++ b/code/modules/research/designs/designs_modular_computer.dm
@@ -5,7 +5,6 @@
 
 /datum/design/item/modularcomponent/disk/normal
 	name = "basic hard drive"
-	id = "hdd_basic"
 	req_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 400, MAT_GLASS = 100)
@@ -13,7 +12,6 @@
 
 /datum/design/item/modularcomponent/disk/advanced
 	name = "advanced hard drive"
-	id = "hdd_advanced"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 800, MAT_GLASS = 200)
@@ -21,7 +19,6 @@
 
 /datum/design/item/modularcomponent/disk/super
 	name = "super hard drive"
-	id = "hdd_super"
 	req_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 1600, MAT_GLASS = 400)
@@ -29,7 +26,6 @@
 
 /datum/design/item/modularcomponent/disk/cluster
 	name = "cluster hard drive"
-	id = "hdd_cluster"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 3200, MAT_GLASS = 800)
@@ -37,7 +33,6 @@
 
 /datum/design/item/modularcomponent/disk/micro
 	name = "micro hard drive"
-	id = "hdd_micro"
 	req_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 400, MAT_GLASS = 100)
@@ -45,7 +40,6 @@
 
 /datum/design/item/modularcomponent/disk/small
 	name = "small hard drive"
-	id = "hdd_small"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 800, MAT_GLASS = 200)
@@ -58,7 +52,6 @@
 
 /datum/design/item/modularcomponent/netcard/basic
 	name = "basic network card"
-	id = "netcard_basic"
 	req_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
 	build_type = IMPRINTER
 	materials = list(MAT_STEEL = 250, MAT_GLASS = 100)
@@ -67,7 +60,6 @@
 
 /datum/design/item/modularcomponent/netcard/advanced
 	name = "advanced network card"
-	id = "netcard_advanced"
 	req_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_STEEL = 500, MAT_GLASS = 200)
@@ -76,7 +68,6 @@
 
 /datum/design/item/modularcomponent/netcard/wired
 	name = "wired network card"
-	id = "netcard_wired"
 	req_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_STEEL = 2500, MAT_GLASS = 400)
@@ -90,7 +81,6 @@
 
 /datum/design/item/modularcomponent/portabledrive/basic
 	name = "basic data crystal"
-	id = "portadrive_basic"
 	req_tech = list(TECH_DATA = 1)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 800)
@@ -99,7 +89,6 @@
 
 /datum/design/item/modularcomponent/portabledrive/advanced
 	name = "advanced data crystal"
-	id = "portadrive_advanced"
 	req_tech = list(TECH_DATA = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1600)
@@ -108,7 +97,6 @@
 
 /datum/design/item/modularcomponent/portabledrive/super
 	name = "super data crystal"
-	id = "portadrive_super"
 	req_tech = list(TECH_DATA = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 3200)
@@ -122,7 +110,6 @@
 
 /datum/design/item/modularcomponent/accessory/cardslot
 	name = "RFID card slot"
-	id = "cardslot"
 	req_tech = list(TECH_DATA = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 600)
@@ -131,7 +118,6 @@
 // Card Broadcaster
 /datum/design/item/modularcomponent/accessory/cardbroadcaster
 	name = "RFID card broadcaster"
-	id = "cardbroadcaster"
 	req_tech = list(TECH_DATA = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 600)
@@ -140,7 +126,6 @@
 // inteliCard Slot
 /datum/design/item/modularcomponent/accessory/aislot
 	name = "inteliCard slot"
-	id = "aislot"
 	req_tech = list(TECH_POWER = 2, TECH_DATA = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_STEEL = 2000)
@@ -150,7 +135,6 @@
 // Nano printer
 /datum/design/item/modularcomponent/accessory/nanoprinter
 	name = "nano printer"
-	id = "nanoprinter"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 600)
@@ -159,7 +143,6 @@
 // Tesla Link
 /datum/design/item/modularcomponent/accessory/teslalink
 	name = "tesla link"
-	id = "teslalink"
 	req_tech = list(TECH_DATA = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 2000)
@@ -168,7 +151,6 @@
 //Scanners
 /datum/design/item/modularcomponent/accessory/reagent_scanner
 	name = "reagent scanner module"
-	id = "scan_reagent"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2, TECH_BIO = 2, TECH_MAGNET = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 600, MAT_GLASS = 200)
@@ -176,7 +158,6 @@
 
 /datum/design/item/modularcomponent/accessory/paper_scanner
 	name = "paper scanner module"
-	id = "scan_paper"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 600, MAT_GLASS = 200)
@@ -184,7 +165,6 @@
 
 /datum/design/item/modularcomponent/accessory/atmos_scanner
 	name = "atmospheric scanner module"
-	id = "scan_atmos"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2, TECH_MAGNET = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 600, MAT_GLASS = 200)
@@ -192,7 +172,6 @@
 
 /datum/design/item/modularcomponent/accessory/medical_scanner
 	name = "medical scanner module"
-	id = "scan_medical"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2, TECH_MAGNET = 2, TECH_BIO = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 600, MAT_GLASS = 200)
@@ -205,7 +184,6 @@
 
 /datum/design/item/modularcomponent/battery/normal
 	name = "standard battery module"
-	id = "bat_normal"
 	req_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 1)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 400)
@@ -213,7 +191,6 @@
 
 /datum/design/item/modularcomponent/battery/advanced
 	name = "advanced battery module"
-	id = "bat_advanced"
 	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 800)
@@ -221,7 +198,6 @@
 
 /datum/design/item/modularcomponent/battery/super
 	name = "super battery module"
-	id = "bat_super"
 	req_tech = list(TECH_POWER = 3, TECH_ENGINEERING = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 1600)
@@ -229,7 +205,6 @@
 
 /datum/design/item/modularcomponent/battery/ultra
 	name = "ultra battery module"
-	id = "bat_ultra"
 	req_tech = list(TECH_POWER = 5, TECH_ENGINEERING = 4)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 3200)
@@ -237,7 +212,6 @@
 
 /datum/design/item/modularcomponent/battery/nano
 	name = "nano battery module"
-	id = "bat_nano"
 	req_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 1)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 200)
@@ -245,7 +219,6 @@
 
 /datum/design/item/modularcomponent/battery/micro
 	name = "micro battery module"
-	id = "bat_micro"
 	req_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_STEEL = 400)
@@ -258,7 +231,6 @@
 
 /datum/design/item/modularcomponent/cpu/
 	name = "computer processor unit"
-	id = "cpu_normal"
 	req_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_STEEL = 1600)
@@ -267,7 +239,6 @@
 
 /datum/design/item/modularcomponent/cpu/small
 	name = "computer microprocessor unit"
-	id = "cpu_small"
 	req_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_STEEL = 800)
@@ -276,7 +247,6 @@
 
 /datum/design/item/modularcomponent/cpu/photonic
 	name = "computer photonic processor unit"
-	id = "pcpu_normal"
 	req_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_STEEL = 6400, glass = 2000)
@@ -285,7 +255,6 @@
 
 /datum/design/item/modularcomponent/cpu/photonic/small
 	name = "computer photonic microprocessor unit"
-	id = "pcpu_small"
 	req_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_STEEL = 3200, glass = 1000)

--- a/code/modules/research/designs/designs_organs.dm
+++ b/code/modules/research/designs/designs_organs.dm
@@ -12,7 +12,6 @@
 /datum/design/item/mechfab/prosthetic_organ/stomach
 	name = "stomach"
 	desc = "A prosthetic stomach."
-	id = "prostheticstomach"
 	req_tech = list(TECH_MATERIAL = 2)
 	materials = list(MAT_STEEL = 3000)
 	build_path = /obj/item/organ/internal/stomach
@@ -20,7 +19,6 @@
 /datum/design/item/mechfab/prosthetic_organ/heart
 	name = "heart"
 	desc = "A prosthetic heart."
-	id = "prostheticheart"
 	req_tech = list(TECH_MATERIAL = 2)
 	materials = list(MAT_STEEL = 3000)
 	build_path = /obj/item/organ/internal/heart
@@ -28,7 +26,6 @@
 /datum/design/item/mechfab/prosthetic_organ/liver
 	name = "liver"
 	desc = "A prosthetic liver."
-	id = "prostheticliver"
 	req_tech = list(TECH_MATERIAL = 2)
 	materials = list(MAT_STEEL = 3000)
 	build_path = /obj/item/organ/internal/liver
@@ -36,7 +33,6 @@
 /datum/design/item/mechfab/prosthetic_organ/kidneys
 	name = "kidneys"
 	desc = "A prosthetic pair of kidneys."
-	id = "prosthetickidneys"
 	req_tech = list(TECH_MATERIAL = 2)
 	materials = list(MAT_STEEL = 3000)
 	build_path = /obj/item/organ/internal/kidneys
@@ -44,7 +40,6 @@
 /datum/design/item/mechfab/prosthetic_organ/lungs
 	name = "lungs"
 	desc = "A prosthetic pair of lungs."
-	id = "prostheticlungs"
 	req_tech = list(TECH_MATERIAL = 2)
 	materials = list(MAT_STEEL = 3000)
 	build_path = /obj/item/organ/internal/lungs
@@ -52,7 +47,6 @@
 /datum/design/item/mechfab/prosthetic_organ/eyes
 	name = "eyes"
 	desc = "A prosthetic pair of eyes."
-	id = "prostheticeyes"
 	req_tech = list(TECH_MATERIAL = 2)
 	materials = list(MAT_STEEL = 3000)
 	build_path = /obj/item/organ/internal/eyes

--- a/code/modules/research/designs/designs_powercell.dm
+++ b/code/modules/research/designs/designs_powercell.dm
@@ -24,21 +24,18 @@
 	id = "basic_cell"
 	req_tech = list(TECH_POWER = 1)
 	build_path = /obj/item/cell
-	sort_string = "DAAAA"
 
 /datum/design/item/powercell/high
 	name = "high-capacity"
 	id = "high_cell"
 	req_tech = list(TECH_POWER = 2)
 	build_path = /obj/item/cell/high
-	sort_string = "DAAAB"
 
 /datum/design/item/powercell/super
 	name = "super-capacity"
 	id = "super_cell"
 	req_tech = list(TECH_POWER = 3, TECH_MATERIAL = 2)
 	build_path = /obj/item/cell/super
-	sort_string = "DAAAC"
 
 /datum/design/item/powercell/hyper
 	name = "hyper-capacity"
@@ -46,7 +43,6 @@
 	req_tech = list(TECH_POWER = 5, TECH_MATERIAL = 4)
 	materials = list(MAT_STEEL = 400, MAT_GOLD = 150, MAT_SILVER = 150, MAT_GLASS = 70, MAT_ALUMINIUM = 25)
 	build_path = /obj/item/cell/hyper
-	sort_string = "DAAAD"
 
 /datum/design/item/powercell/device/standard
 	name = "basic"
@@ -54,7 +50,6 @@
 	req_tech = list(TECH_POWER = 1)
 	materials = list(MAT_STEEL = 70, MAT_GLASS = 5)
 	build_path = /obj/item/cell/device/standard
-	sort_string = "DAAAE"
 
 /datum/design/item/powercell/device/high
 	name = "high-capacity"
@@ -63,4 +58,3 @@
 	req_tech = list(TECH_POWER = 2)
 	materials = list(MAT_STEEL = 70, MAT_GLASS = 6)
 	build_path = /obj/item/cell/device/high
-	sort_string = "DAAAF"

--- a/code/modules/research/designs/designs_powercell.dm
+++ b/code/modules/research/designs/designs_powercell.dm
@@ -21,32 +21,27 @@
 
 /datum/design/item/powercell/basic
 	name = "basic"
-	id = "basic_cell"
 	req_tech = list(TECH_POWER = 1)
 	build_path = /obj/item/cell
 
 /datum/design/item/powercell/high
 	name = "high-capacity"
-	id = "high_cell"
 	req_tech = list(TECH_POWER = 2)
 	build_path = /obj/item/cell/high
 
 /datum/design/item/powercell/super
 	name = "super-capacity"
-	id = "super_cell"
 	req_tech = list(TECH_POWER = 3, TECH_MATERIAL = 2)
 	build_path = /obj/item/cell/super
 
 /datum/design/item/powercell/hyper
 	name = "hyper-capacity"
-	id = "hyper_cell"
 	req_tech = list(TECH_POWER = 5, TECH_MATERIAL = 4)
 	materials = list(MAT_STEEL = 400, MAT_GOLD = 150, MAT_SILVER = 150, MAT_GLASS = 70, MAT_ALUMINIUM = 25)
 	build_path = /obj/item/cell/hyper
 
 /datum/design/item/powercell/device/standard
 	name = "basic"
-	id = "device_cell_standard"
 	req_tech = list(TECH_POWER = 1)
 	materials = list(MAT_STEEL = 70, MAT_GLASS = 5)
 	build_path = /obj/item/cell/device/standard
@@ -54,7 +49,6 @@
 /datum/design/item/powercell/device/high
 	name = "high-capacity"
 	build_type = PROTOLATHE | MECHFAB
-	id = "device_cell_high"
 	req_tech = list(TECH_POWER = 2)
 	materials = list(MAT_STEEL = 70, MAT_GLASS = 6)
 	build_path = /obj/item/cell/device/high

--- a/code/modules/research/designs/designs_rig_modules.dm
+++ b/code/modules/research/designs/designs_rig_modules.dm
@@ -6,7 +6,6 @@
 /datum/design/item/rig/meson
 	name = "Meson Scanner"
 	desc = "A layered, translucent visor system for a RIG."
-	id = "rig_meson"
 	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 5)
 	materials = list(MAT_STEEL = 100, MAT_GLASS = 200, MAT_PLASTIC = 300)
 	build_path = /obj/item/rig_module/vision/meson
@@ -14,7 +13,6 @@
 /datum/design/item/rig/medhud
 	name = "Medical HUD"
 	desc = "A simple medical status indicator for a RIG."
-	id = "rig_medhud"
 	req_tech = list(TECH_MAGNET = 3, TECH_BIO = 2, TECH_ENGINEERING = 5)
 	materials = list(MAT_STEEL = 100, MAT_GLASS = 200,  MAT_PLASTIC = 300)
 	build_path = /obj/item/rig_module/vision/medhud
@@ -22,7 +20,6 @@
 /datum/design/item/rig/sechud
 	name = "Security HUD"
 	desc = "A simple security status indicator for a RIG."
-	id = "rig_sechud"
 	req_tech = list(TECH_MAGNET = 3, TECH_BIO = 2, TECH_ENGINEERING = 5)
 	materials = list(MAT_STEEL = 100, MAT_GLASS = 200,  MAT_PLASTIC = 300)
 	build_path = /obj/item/rig_module/vision/sechud
@@ -30,7 +27,6 @@
 /datum/design/item/rig/nvg
 	name = "Night Vision"
 	desc = "A night vision module, mountable on a RIG."
-	id = "rig_nvg"
 	req_tech = list(TECH_MAGNET = 6, TECH_ENGINEERING = 6)
 	materials = list(MAT_PLASTIC = 500, MAT_STEEL = 300, MAT_GLASS = 200, MAT_URANIUM = 200)
 	build_path = /obj/item/rig_module/vision/nvg
@@ -38,7 +34,6 @@
 /datum/design/item/rig/healthscanner
 	name = "Medical Scanner"
 	desc = "A device able to distinguish vital signs of the subject, mountable on a RIG."
-	id = "rig_healthscanner"
 	req_tech = list(TECH_MAGNET = 3, TECH_BIO = 3, TECH_ENGINEERING = 5)
 	materials = list(MAT_PLASTIC = 1000, MAT_STEEL = 700, MAT_GLASS = 500)
 	build_path = /obj/item/rig_module/device/healthscanner
@@ -46,7 +41,6 @@
 /datum/design/item/rig/drill
 	name = "Mining Drill"
 	desc = "A diamond mining drill, mountable on a RIG."
-	id = "rig_drill"
 	req_tech = list(TECH_MATERIAL = 6, TECH_POWER = 4, TECH_ENGINEERING = 6)
 	materials = list(MAT_STEEL = 3500, MAT_GLASS = 1500, MAT_DIAMOND = 2000, MAT_PLASTIC = 1000)
 	build_path = /obj/item/rig_module/device/drill
@@ -54,7 +48,6 @@
 /datum/design/item/rig/plasmacutter
 	name = "Plasma Cutter"
 	desc = "A rock cutter that projects bursts of hot plasma, mountable on a RIG."
-	id = "rig_plasmacutter"
 	req_tech = list(TECH_MATERIAL = 4, TECH_PHORON = 3, TECH_ENGINEERING = 6, TECH_COMBAT = 4)
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 1000, MAT_PLASTIC = 1000, MAT_GOLD = 700, MAT_PHORON = 500)
 	build_path = /obj/item/rig_module/mounted/plasmacutter
@@ -62,7 +55,6 @@
 /datum/design/item/rig/orescanner
 	name = "Ore Scanner"
 	desc = "A sonar system for detecting large masses of ore, mountable on a RIG."
-	id = "rig_orescanner"
 	req_tech = list(TECH_MATERIAL = 4, TECH_MAGNET = 4, TECH_ENGINEERING = 6)
 	materials = list(MAT_PLASTIC = 1000, MAT_STEEL = 800, MAT_GLASS = 500)
 	build_path = /obj/item/rig_module/device/orescanner
@@ -70,7 +62,6 @@
 /datum/design/item/rig/anomaly_scanner
 	name = "Anomaly Scanner"
 	desc = "An exotic particle detector commonly used by xenoarchaeologists, mountable on a RIG."
-	id = "rig_anomaly_scanner"
 	req_tech = list(TECH_BLUESPACE = 4, TECH_MAGNET = 4, TECH_ENGINEERING = 6)
 	materials = list(MAT_PLASTIC = 1000, MAT_STEEL = 800, MAT_GLASS = 500)
 	build_path = /obj/item/rig_module/device/anomaly_scanner
@@ -78,7 +69,6 @@
 /datum/design/item/rig/rcd
 	name = "RCD"
 	desc = "A Rapid Construction Device, mountable on a RIG."
-	id = "rig_rcd"
 	req_tech = list(TECH_MATERIAL = 6, TECH_MAGNET = 5, TECH_ENGINEERING = 7)
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 1000, MAT_PLASTIC = 1000,MAT_GOLD = 700, MAT_SILVER = 700)
 	build_path = /obj/item/rig_module/device/rcd
@@ -86,7 +76,6 @@
 /datum/design/item/rig/jets
 	name = "Maneuvering Jets"
 	desc = "A compact gas thruster system, mountable on a RIG."
-	id = "rig_jets"
 	req_tech = list(TECH_MATERIAL = 6,  TECH_ENGINEERING = 7)
 	materials = list(MAT_STEEL = 3000, MAT_PLASTIC = 2000, MAT_GLASS = 1000)
 	build_path = /obj/item/rig_module/maneuvering_jets
@@ -95,7 +84,6 @@
 /datum/design/item/rig/decompiler
 	name = "Matter Decompiler"
 	desc = "A drone matter decompiler reconfigured to be mounted onto a RIG."
-	id = "rig_decompiler"
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 5)
 	materials = list(MAT_STEEL = 3000, MAT_PLASTIC = 2000, MAT_GLASS = 1000)
 	build_path = /obj/item/rig_module/device/decompiler
@@ -103,7 +91,6 @@
 /datum/design/item/rig/powersink
 	name = "Power Sink"
 	desc = "A RIG module that allows the user to recharge their RIG's power cell without removing it."
-	id = "rig_powersink"
 	req_tech = list(TECH_POWER = 6, TECH_ENGINEERING = 6)
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 2000, MAT_GOLD = 1000, MAT_PLASTIC = 1000)
 	build_path = /obj/item/rig_module/power_sink
@@ -111,7 +98,6 @@
 /datum/design/item/rig/ai_container
 	name = "IIS"
 	desc = "An integrated intelligence system module suitable for most RIGs."
-	id = "rig_ai_container"
 	req_tech = list(TECH_DATA = 6, TECH_MATERIAL = 5, TECH_ENGINEERING = 6)
 	materials = list(MAT_STEEL = 1000, MAT_GLASS = 1000, MAT_PLASTIC = 1000, MAT_GOLD = 500)
 	build_path = /obj/item/rig_module/ai_container
@@ -119,7 +105,6 @@
 /datum/design/item/rig/flash
 	name = "Flash"
 	desc = "A normal flash, mountable on a RIG."
-	id = "rig_flash"
 	req_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 3, TECH_ENGINEERING = 5)
 	materials = list(MAT_PLASTIC = 1500, MAT_STEEL = 1000, MAT_GLASS = 500)
 	build_path = /obj/item/rig_module/device/flash
@@ -127,7 +112,6 @@
 /datum/design/item/rig/taser
 	name = "Electrolaser"
 	desc = "An electrolaser, mountable on a RIG."
-	id = "rig_taser"
 	req_tech = list(TECH_POWER = 5, TECH_COMBAT = 5, TECH_ENGINEERING = 6)
 	materials = list(MAT_STEEL = 4000, MAT_PLASTIC = 2500, MAT_GLASS = 2000, MAT_GOLD = 1000)
 	build_path = /obj/item/rig_module/mounted/taser
@@ -135,7 +119,6 @@
 /datum/design/item/rig/egun
 	name = "Energy Gun"
 	desc = "An energy gun, mountable on a RIG."
-	id = "rig_egun"
 	req_tech = list(TECH_POWER = 6, TECH_COMBAT = 6, TECH_ENGINEERING = 6)
 	materials = list(MAT_STEEL = 6000, MAT_GLASS = 3000, MAT_PLASTIC = 2500, MAT_GOLD = 2000, MAT_SILVER = 1000)
 	build_path = /obj/item/rig_module/mounted/egun
@@ -143,7 +126,6 @@
 /datum/design/item/rig/enet
 	name = "Energy Net"
 	desc = "An advanced energy-patterning projector used to capture targets, mountable on a RIG."
-	id = "rig_enet"
 	req_tech = list(TECH_MATERIAL = 5, TECH_POWER = 6, TECH_MAGNET = 5, TECH_ESOTERIC = 4, TECH_ENGINEERING = 6)
 	materials = list(MAT_STEEL = 6000, MAT_GLASS = 3000, MAT_DIAMOND = 2000, MAT_PLASTIC = 2000)
 	build_path = /obj/item/rig_module/fabricator/energy_net
@@ -151,7 +133,6 @@
 /datum/design/item/rig/stealth
 	name = "Active Camouflage"
 	desc = "An integrated active camouflage system, mountable on a RIG."
-	id = "rig_stealth"
 	req_tech = list(TECH_MATERIAL = 5, TECH_POWER = 6, TECH_MAGNET = 6, TECH_ESOTERIC = 6, TECH_ENGINEERING = 7)
 	materials = list(MAT_STEEL = 6000, MAT_GLASS = 3000, MAT_DIAMOND = 2000, MAT_SILVER = 2000, MAT_URANIUM = 2000, MAT_GOLD = 2000, MAT_PLASTIC = 2000)
 	build_path = /obj/item/rig_module/stealth_field
@@ -159,7 +140,6 @@
 /datum/design/item/rig/cooling_unit
 	name = "Cooling Unit"
 	desc = "A suit cooling unit, mountable on a RIG."
-	id = "rig_cooler"
 	req_tech = list(TECH_MATERIAL = 2, TECH_MAGNET = 2, TECH_ENGINEERING = 5)
 	materials = list(MAT_STEEL = 3000, MAT_GLASS = 3500, MAT_PLASTIC = 2000)
 	build_path = /obj/item/rig_module/cooling_unit
@@ -167,7 +147,6 @@
 /datum/design/item/integrated_printer
 	name = "Integrated Circuit Printer"
 	desc = "This machine provides all the necessary things for circuitry."
-	id = "icprinter"
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 1)
 	materials = list(MAT_STEEL = 10000, MAT_GLASS = 5000)
 	build_path = /obj/item/integrated_circuit_printer
@@ -175,7 +154,6 @@
 /datum/design/item/integrated_printer_upgrade_advanced
 	name = "Integrated Circuit Printer Upgrade Disk"
 	desc = "This disk allows for integrated circuit printers to print advanced circuitry designs."
-	id = "icupgradv"
 	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3)
 	materials = list(MAT_STEEL = 10000, MAT_GLASS = 10000)
 	build_path = /obj/item/disk/integrated_circuit/upgrade/advanced
@@ -183,7 +161,6 @@
 /datum/design/item/integrated_printer_upgrade_clone
 	name = "Integrated Circuit Printer Clone Disk"
 	desc = "This disk allows for integrated circuit printers to copy and clone designs instantaneously."
-	id = "icupclo"
 	req_tech = list(TECH_DATA = 3, TECH_MATERIAL = 5)
 	materials = list(MAT_STEEL = 10000, MAT_GLASS = 10000)
 	build_path = /obj/item/disk/integrated_circuit/upgrade/clone

--- a/code/modules/research/designs/designs_rig_modules.dm
+++ b/code/modules/research/designs/designs_rig_modules.dm
@@ -10,7 +10,6 @@
 	req_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 5)
 	materials = list(MAT_STEEL = 100, MAT_GLASS = 200, MAT_PLASTIC = 300)
 	build_path = /obj/item/rig_module/vision/meson
-	sort_string = "WCAAA"
 
 /datum/design/item/rig/medhud
 	name = "Medical HUD"
@@ -19,7 +18,6 @@
 	req_tech = list(TECH_MAGNET = 3, TECH_BIO = 2, TECH_ENGINEERING = 5)
 	materials = list(MAT_STEEL = 100, MAT_GLASS = 200,  MAT_PLASTIC = 300)
 	build_path = /obj/item/rig_module/vision/medhud
-	sort_string = "WCAAB"
 
 /datum/design/item/rig/sechud
 	name = "Security HUD"
@@ -28,7 +26,6 @@
 	req_tech = list(TECH_MAGNET = 3, TECH_BIO = 2, TECH_ENGINEERING = 5)
 	materials = list(MAT_STEEL = 100, MAT_GLASS = 200,  MAT_PLASTIC = 300)
 	build_path = /obj/item/rig_module/vision/sechud
-	sort_string = "WCAAC"
 
 /datum/design/item/rig/nvg
 	name = "Night Vision"
@@ -37,7 +34,6 @@
 	req_tech = list(TECH_MAGNET = 6, TECH_ENGINEERING = 6)
 	materials = list(MAT_PLASTIC = 500, MAT_STEEL = 300, MAT_GLASS = 200, MAT_URANIUM = 200)
 	build_path = /obj/item/rig_module/vision/nvg
-	sort_string = "WCAAD"
 
 /datum/design/item/rig/healthscanner
 	name = "Medical Scanner"
@@ -46,7 +42,6 @@
 	req_tech = list(TECH_MAGNET = 3, TECH_BIO = 3, TECH_ENGINEERING = 5)
 	materials = list(MAT_PLASTIC = 1000, MAT_STEEL = 700, MAT_GLASS = 500)
 	build_path = /obj/item/rig_module/device/healthscanner
-	sort_string = "WCBAA"
 
 /datum/design/item/rig/drill
 	name = "Mining Drill"
@@ -55,7 +50,6 @@
 	req_tech = list(TECH_MATERIAL = 6, TECH_POWER = 4, TECH_ENGINEERING = 6)
 	materials = list(MAT_STEEL = 3500, MAT_GLASS = 1500, MAT_DIAMOND = 2000, MAT_PLASTIC = 1000)
 	build_path = /obj/item/rig_module/device/drill
-	sort_string = "WCCAA"
 
 /datum/design/item/rig/plasmacutter
 	name = "Plasma Cutter"
@@ -64,7 +58,6 @@
 	req_tech = list(TECH_MATERIAL = 4, TECH_PHORON = 3, TECH_ENGINEERING = 6, TECH_COMBAT = 4)
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 1000, MAT_PLASTIC = 1000, MAT_GOLD = 700, MAT_PHORON = 500)
 	build_path = /obj/item/rig_module/mounted/plasmacutter
-	sort_string = "VCCAB"
 
 /datum/design/item/rig/orescanner
 	name = "Ore Scanner"
@@ -73,7 +66,6 @@
 	req_tech = list(TECH_MATERIAL = 4, TECH_MAGNET = 4, TECH_ENGINEERING = 6)
 	materials = list(MAT_PLASTIC = 1000, MAT_STEEL = 800, MAT_GLASS = 500)
 	build_path = /obj/item/rig_module/device/orescanner
-	sort_string = "WCDAA"
 
 /datum/design/item/rig/anomaly_scanner
 	name = "Anomaly Scanner"
@@ -82,7 +74,6 @@
 	req_tech = list(TECH_BLUESPACE = 4, TECH_MAGNET = 4, TECH_ENGINEERING = 6)
 	materials = list(MAT_PLASTIC = 1000, MAT_STEEL = 800, MAT_GLASS = 500)
 	build_path = /obj/item/rig_module/device/anomaly_scanner
-	sort_string = "WCDAB"
 
 /datum/design/item/rig/rcd
 	name = "RCD"
@@ -91,7 +82,6 @@
 	req_tech = list(TECH_MATERIAL = 6, TECH_MAGNET = 5, TECH_ENGINEERING = 7)
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 1000, MAT_PLASTIC = 1000,MAT_GOLD = 700, MAT_SILVER = 700)
 	build_path = /obj/item/rig_module/device/rcd
-	sort_string = "WCEAA"
 
 /datum/design/item/rig/jets
 	name = "Maneuvering Jets"
@@ -100,7 +90,6 @@
 	req_tech = list(TECH_MATERIAL = 6,  TECH_ENGINEERING = 7)
 	materials = list(MAT_STEEL = 3000, MAT_PLASTIC = 2000, MAT_GLASS = 1000)
 	build_path = /obj/item/rig_module/maneuvering_jets
-	sort_string = "WCFAA"
 
 //I think this is like a janitor thing but seems like it could be useful for engis
 /datum/design/item/rig/decompiler
@@ -110,7 +99,6 @@
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 5)
 	materials = list(MAT_STEEL = 3000, MAT_PLASTIC = 2000, MAT_GLASS = 1000)
 	build_path = /obj/item/rig_module/device/decompiler
-	sort_string = "WCGAA"
 
 /datum/design/item/rig/powersink
 	name = "Power Sink"
@@ -119,7 +107,6 @@
 	req_tech = list(TECH_POWER = 6, TECH_ENGINEERING = 6)
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 2000, MAT_GOLD = 1000, MAT_PLASTIC = 1000)
 	build_path = /obj/item/rig_module/power_sink
-	sort_string = "WCHAA"
 
 /datum/design/item/rig/ai_container
 	name = "IIS"
@@ -128,7 +115,6 @@
 	req_tech = list(TECH_DATA = 6, TECH_MATERIAL = 5, TECH_ENGINEERING = 6)
 	materials = list(MAT_STEEL = 1000, MAT_GLASS = 1000, MAT_PLASTIC = 1000, MAT_GOLD = 500)
 	build_path = /obj/item/rig_module/ai_container
-	sort_string = "WCIAA"
 
 /datum/design/item/rig/flash
 	name = "Flash"
@@ -137,7 +123,6 @@
 	req_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 3, TECH_ENGINEERING = 5)
 	materials = list(MAT_PLASTIC = 1500, MAT_STEEL = 1000, MAT_GLASS = 500)
 	build_path = /obj/item/rig_module/device/flash
-	sort_string = "WCJAA"
 
 /datum/design/item/rig/taser
 	name = "Electrolaser"
@@ -146,7 +131,6 @@
 	req_tech = list(TECH_POWER = 5, TECH_COMBAT = 5, TECH_ENGINEERING = 6)
 	materials = list(MAT_STEEL = 4000, MAT_PLASTIC = 2500, MAT_GLASS = 2000, MAT_GOLD = 1000)
 	build_path = /obj/item/rig_module/mounted/taser
-	sort_string = "WCKAA"
 
 /datum/design/item/rig/egun
 	name = "Energy Gun"
@@ -155,7 +139,6 @@
 	req_tech = list(TECH_POWER = 6, TECH_COMBAT = 6, TECH_ENGINEERING = 6)
 	materials = list(MAT_STEEL = 6000, MAT_GLASS = 3000, MAT_PLASTIC = 2500, MAT_GOLD = 2000, MAT_SILVER = 1000)
 	build_path = /obj/item/rig_module/mounted/egun
-	sort_string = "WCKAB"
 
 /datum/design/item/rig/enet
 	name = "Energy Net"
@@ -164,7 +147,6 @@
 	req_tech = list(TECH_MATERIAL = 5, TECH_POWER = 6, TECH_MAGNET = 5, TECH_ESOTERIC = 4, TECH_ENGINEERING = 6)
 	materials = list(MAT_STEEL = 6000, MAT_GLASS = 3000, MAT_DIAMOND = 2000, MAT_PLASTIC = 2000)
 	build_path = /obj/item/rig_module/fabricator/energy_net
-	sort_string = "WCKAC"
 
 /datum/design/item/rig/stealth
 	name = "Active Camouflage"
@@ -173,7 +155,6 @@
 	req_tech = list(TECH_MATERIAL = 5, TECH_POWER = 6, TECH_MAGNET = 6, TECH_ESOTERIC = 6, TECH_ENGINEERING = 7)
 	materials = list(MAT_STEEL = 6000, MAT_GLASS = 3000, MAT_DIAMOND = 2000, MAT_SILVER = 2000, MAT_URANIUM = 2000, MAT_GOLD = 2000, MAT_PLASTIC = 2000)
 	build_path = /obj/item/rig_module/stealth_field
-	sort_string = "WCLAA"
 
 /datum/design/item/rig/cooling_unit
 	name = "Cooling Unit"
@@ -182,7 +163,6 @@
 	req_tech = list(TECH_MATERIAL = 2, TECH_MAGNET = 2, TECH_ENGINEERING = 5)
 	materials = list(MAT_STEEL = 3000, MAT_GLASS = 3500, MAT_PLASTIC = 2000)
 	build_path = /obj/item/rig_module/cooling_unit
-	sort_string = "WCLAB"
 
 /datum/design/item/integrated_printer
 	name = "Integrated Circuit Printer"
@@ -191,7 +171,6 @@
 	req_tech = list(TECH_MATERIAL = 2, TECH_ENGINEERING = 1)
 	materials = list(MAT_STEEL = 10000, MAT_GLASS = 5000)
 	build_path = /obj/item/integrated_circuit_printer
-	sort_string = "WCLAC"
 
 /datum/design/item/integrated_printer_upgrade_advanced
 	name = "Integrated Circuit Printer Upgrade Disk"
@@ -200,7 +179,6 @@
 	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3)
 	materials = list(MAT_STEEL = 10000, MAT_GLASS = 10000)
 	build_path = /obj/item/disk/integrated_circuit/upgrade/advanced
-	sort_string = "WCLAD"
 
 /datum/design/item/integrated_printer_upgrade_clone
 	name = "Integrated Circuit Printer Clone Disk"
@@ -209,4 +187,3 @@
 	req_tech = list(TECH_DATA = 3, TECH_MATERIAL = 5)
 	materials = list(MAT_STEEL = 10000, MAT_GLASS = 10000)
 	build_path = /obj/item/disk/integrated_circuit/upgrade/clone
-	sort_string = "WCLAE"

--- a/code/modules/research/designs/designs_singletons.dm
+++ b/code/modules/research/designs/designs_singletons.dm
@@ -5,7 +5,6 @@
 /datum/design/item/encryptionkey/binary
 	name = "binary"
 	desc = "Allows for deciphering the binary channel on-the-fly."
-	id = "binaryencrypt"
 	req_tech = list(TECH_ESOTERIC = 2)
 	materials = list(MAT_STEEL = 300, MAT_GLASS = 300)
 	build_path = /obj/item/encryptionkey/binary
@@ -17,7 +16,6 @@
 /datum/design/item/camouflage/chameleon
 	name = "holographic equipment kit"
 	desc = "A kit of dangerous, high-tech equipment with changeable looks."
-	id = "chameleon"
 	req_tech = list(TECH_ESOTERIC = 2)
 	materials = list(MAT_STEEL = 500, MAT_ALUMINIUM = 500, MAT_PLASTIC = 500)
 	build_path = /obj/item/storage/backpack/chameleon/sydie_kit
@@ -25,7 +23,6 @@
 /datum/design/item/advmop
 	name = "Advanced Mop"
 	desc = "An upgraded mop with a large internal capacity for holding water or other cleaning chemicals."
-	id = "advmop"
 	req_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 4, TECH_POWER = 3)
 	materials = list(MAT_ALUMINIUM = 2500, MAT_STEEL = 500, MAT_PLASTIC = 200)
 	build_path = /obj/item/mop/advanced
@@ -33,7 +30,6 @@
 /datum/design/blutrash
 	name = "Trashbag of Holding"
 	desc = "An advanced trash bag with bluespace properties; capable of holding a plethora of garbage."
-	id = "blutrash"
 	req_tech = list(TECH_BLUESPACE = 5, TECH_MATERIALS = 6)
 	materials = list(MAT_PLASTIC = 5000, MAT_GOLD = 1500, MAT_URANIUM = 250, MAT_PHORON = 1500)
 	build_path = /obj/item/storage/bag/trash/bluespace
@@ -41,7 +37,6 @@
 /datum/design/item/holosign
 	name = "Holographic Sign Projector"
 	desc = "A holograpic projector used to project various warning signs."
-	id = "holosign"
 	req_tech = list(TECH_ENGINEERING = 5, TECH_BLUESPACE = 4, TECH_POWER = 4)
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 1000)
 	build_path = /obj/item/holosign_creator
@@ -49,7 +44,6 @@
 /datum/design/item/party
 	name = "Uncertified module: PRTY"
 	desc = "Schematics for a robotic module, scraped from seedy parts of the net. Who knows what it does."
-	id = "borg_party_module"
 	req_tech = list(TECH_DATA = 2, TECH_ESOTERIC = 2)
 	build_type = MECHFAB
 	materials = list(MAT_STEEL = 7500, MAT_ALUMINIUM = 5000, MAT_DIAMOND = 2000)

--- a/code/modules/research/designs/designs_singletons.dm
+++ b/code/modules/research/designs/designs_singletons.dm
@@ -9,7 +9,6 @@
 	req_tech = list(TECH_ESOTERIC = 2)
 	materials = list(MAT_STEEL = 300, MAT_GLASS = 300)
 	build_path = /obj/item/encryptionkey/binary
-	sort_string = "VASAA"
 
 /datum/design/item/camouflage/AssembleDesignName()
 	..()
@@ -22,7 +21,6 @@
 	req_tech = list(TECH_ESOTERIC = 2)
 	materials = list(MAT_STEEL = 500, MAT_ALUMINIUM = 500, MAT_PLASTIC = 500)
 	build_path = /obj/item/storage/backpack/chameleon/sydie_kit
-	sort_string = "VASBA"
 
 /datum/design/item/advmop
 	name = "Advanced Mop"

--- a/code/modules/research/designs/designs_smes_coil.dm
+++ b/code/modules/research/designs/designs_smes_coil.dm
@@ -11,18 +11,15 @@
 	id = "smes_coil_standard"
 	req_tech = list(TECH_MATERIAL = 7, TECH_POWER = 7, TECH_ENGINEERING = 5)
 	build_path = /obj/item/stock_parts/smes_coil
-	sort_string = "VAXAA"
 
 /datum/design/item/smes_coil/super_capacity
 	name = "capacitance"
 	id = "smes_coil_super_capacity"
 	req_tech = list(TECH_MATERIAL = 7, TECH_POWER = 8, TECH_ENGINEERING = 6)
 	build_path = /obj/item/stock_parts/smes_coil/super_capacity
-	sort_string = "VAXAB"
 
 /datum/design/item/smes_coil/super_io
 	name = "transmission"
 	id = "smes_coil_super_io"
 	req_tech = list(TECH_MATERIAL = 7, TECH_POWER = 8, TECH_ENGINEERING = 6)
 	build_path = /obj/item/stock_parts/smes_coil/super_io
-	sort_string = "VAXAC"

--- a/code/modules/research/designs/designs_smes_coil.dm
+++ b/code/modules/research/designs/designs_smes_coil.dm
@@ -8,18 +8,15 @@
 
 /datum/design/item/smes_coil/standard
 	name = "standard"
-	id = "smes_coil_standard"
 	req_tech = list(TECH_MATERIAL = 7, TECH_POWER = 7, TECH_ENGINEERING = 5)
 	build_path = /obj/item/stock_parts/smes_coil
 
 /datum/design/item/smes_coil/super_capacity
 	name = "capacitance"
-	id = "smes_coil_super_capacity"
 	req_tech = list(TECH_MATERIAL = 7, TECH_POWER = 8, TECH_ENGINEERING = 6)
 	build_path = /obj/item/stock_parts/smes_coil/super_capacity
 
 /datum/design/item/smes_coil/super_io
 	name = "transmission"
-	id = "smes_coil_super_io"
 	req_tech = list(TECH_MATERIAL = 7, TECH_POWER = 8, TECH_ENGINEERING = 6)
 	build_path = /obj/item/stock_parts/smes_coil/super_io

--- a/code/modules/research/designs/designs_stock_part.dm
+++ b/code/modules/research/designs/designs_stock_part.dm
@@ -10,91 +10,76 @@
 		desc = "A stock part used in the construction of various devices."
 
 /datum/design/item/stock_part/basic_capacitor
-	id = "basic_capacitor"
 	req_tech = list(TECH_POWER = 1)
 	materials = list(MAT_STEEL = 50, MAT_GLASS = 50)
 	build_path = /obj/item/stock_parts/capacitor
 
 /datum/design/item/stock_part/adv_capacitor
-	id = "adv_capacitor"
 	req_tech = list(TECH_POWER = 3)
 	materials = list(MAT_STEEL = 50, MAT_GLASS = 50)
 	build_path = /obj/item/stock_parts/capacitor/adv
 
 /datum/design/item/stock_part/super_capacitor
-	id = "super_capacitor"
 	req_tech = list(TECH_POWER = 5, TECH_MATERIAL = 4)
 	materials = list(MAT_STEEL = 50, MAT_GLASS = 50, MAT_GOLD = 20)
 	build_path = /obj/item/stock_parts/capacitor/super
 
 /datum/design/item/stock_part/micro_mani
-	id = "micro_mani"
 	req_tech = list(TECH_MATERIAL = 1, TECH_DATA = 1)
 	materials = list(MAT_STEEL = 30)
 	build_path = /obj/item/stock_parts/manipulator
 
 /datum/design/item/stock_part/nano_mani
-	id = "nano_mani"
 	req_tech = list(TECH_MATERIAL = 3, TECH_DATA = 2)
 	materials = list(MAT_STEEL = 30)
 	build_path = /obj/item/stock_parts/manipulator/nano
 
 /datum/design/item/stock_part/pico_mani
-	id = "pico_mani"
 	req_tech = list(TECH_MATERIAL = 5, TECH_DATA = 2)
 	materials = list(MAT_STEEL = 30)
 	build_path = /obj/item/stock_parts/manipulator/pico
 
 /datum/design/item/stock_part/basic_matter_bin
-	id = "basic_matter_bin"
 	req_tech = list(TECH_MATERIAL = 1)
 	materials = list(MAT_STEEL = 80)
 	build_path = /obj/item/stock_parts/matter_bin
 
 /datum/design/item/stock_part/adv_matter_bin
-	id = "adv_matter_bin"
 	req_tech = list(TECH_MATERIAL = 3)
 	materials = list(MAT_STEEL = 80)
 	build_path = /obj/item/stock_parts/matter_bin/adv
 
 /datum/design/item/stock_part/super_matter_bin
-	id = "super_matter_bin"
 	req_tech = list(TECH_MATERIAL = 5)
 	materials = list(MAT_STEEL = 80)
 	build_path = /obj/item/stock_parts/matter_bin/super
 
 /datum/design/item/stock_part/basic_micro_laser
-	id = "basic_micro_laser"
 	req_tech = list(TECH_MAGNET = 1)
 	materials = list(MAT_STEEL = 10, MAT_GLASS = 20)
 	build_path = /obj/item/stock_parts/micro_laser
 
 /datum/design/item/stock_part/high_micro_laser
-	id = "high_micro_laser"
 	req_tech = list(TECH_MAGNET = 3)
 	materials = list(MAT_STEEL = 10, MAT_GLASS = 20)
 	build_path = /obj/item/stock_parts/micro_laser/high
 
 /datum/design/item/stock_part/ultra_micro_laser
-	id = "ultra_micro_laser"
 	req_tech = list(TECH_MAGNET = 5, TECH_MATERIAL = 5)
 	materials = list(MAT_STEEL = 10, MAT_GLASS = 20, MAT_URANIUM = 10)
 	build_path = /obj/item/stock_parts/micro_laser/ultra
 
 /datum/design/item/stock_part/basic_sensor
-	id = "basic_sensor"
 	req_tech = list(TECH_MAGNET = 1)
 	materials = list(MAT_STEEL = 50, MAT_GLASS = 20)
 	build_path = /obj/item/stock_parts/scanning_module
 
 /datum/design/item/stock_part/adv_sensor
-	id = "adv_sensor"
 	req_tech = list(TECH_MAGNET = 3)
 	materials = list(MAT_STEEL = 50, MAT_GLASS = 20)
 	build_path = /obj/item/stock_parts/scanning_module/adv
 
 /datum/design/item/stock_part/phasic_sensor
-	id = "phasic_sensor"
 	req_tech = list(TECH_MAGNET = 5, TECH_MATERIAL = 3)
 	materials = list(MAT_STEEL = 50, MAT_GLASS = 20, MAT_SILVER = 10)
 	build_path = /obj/item/stock_parts/scanning_module/phasic
@@ -102,7 +87,6 @@
 /datum/design/item/stock_part/RPED
 	name = "Rapid Part Exchange Device"
 	desc = "Special mechanical module made to store, sort, and apply standard machine parts."
-	id = "rped"
 	req_tech = list(TECH_ENGINEERING = 3, TECH_MATERIAL = 3)
 	materials = list(MAT_STEEL = 15000, MAT_GLASS = 5000)
 	build_path = /obj/item/storage/part_replacer
@@ -110,49 +94,41 @@
 /datum/design/item/stock_part/RPED_BS
 	name = "bluespace Rapid Part Exchange Device"
 	desc = "Powered by bluespace technology, this RPED variant can upgrade buildings from a distance, without needing to remove the panel first."
-	id = "rped_bs"
 	req_tech = list(TECH_ENGINEERING = 5, TECH_MATERIAL = 5, TECH_BLUESPACE = 4)
 	materials = list(MATERIAL_STEEL = 20000, MATERIAL_GLASS = 5000, MATERIAL_SILVER = 2000)
 	build_path = /obj/item/storage/part_replacer/bluespace
 
 /datum/design/item/stock_part/subspace_ansible
-	id = "s-ansible"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
 	materials = list(MAT_STEEL = 80, MAT_SILVER = 20)
 	build_path = /obj/item/stock_parts/subspace/ansible
 
 /datum/design/item/stock_part/hyperwave_filter
-	id = "s-filter"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 3)
 	materials = list(MAT_STEEL = 40, MAT_SILVER = 10)
 	build_path = /obj/item/stock_parts/subspace/filter
 
 /datum/design/item/stock_part/subspace_amplifier
-	id = "s-amplifier"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
 	materials = list(MAT_STEEL = 10, MAT_GOLD = 30, MAT_URANIUM = 15)
 	build_path = /obj/item/stock_parts/subspace/amplifier
 
 /datum/design/item/stock_part/subspace_treatment
-	id = "s-treatment"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 2, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
 	materials = list(MAT_STEEL = 10, MAT_SILVER = 20)
 	build_path = /obj/item/stock_parts/subspace/treatment
 
 /datum/design/item/stock_part/subspace_analyzer
-	id = "s-analyzer"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
 	materials = list(MAT_STEEL = 10, MAT_GOLD = 15)
 	build_path = /obj/item/stock_parts/subspace/analyzer
 
 /datum/design/item/stock_part/subspace_crystal
-	id = "s-crystal"
 	req_tech = list(TECH_MAGNET = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
 	materials = list(MAT_GLASS = 1000, MAT_SILVER = 20, MAT_GOLD = 20)
 	build_path = /obj/item/stock_parts/subspace/crystal
 
 /datum/design/item/stock_part/subspace_transmitter
-	id = "s-transmitter"
 	req_tech = list(TECH_MAGNET = 5, TECH_MATERIAL = 5, TECH_BLUESPACE = 3)
 	materials = list(MAT_GLASS = 100, MAT_SILVER = 10, MAT_URANIUM = 15)
 	build_path = /obj/item/stock_parts/subspace/transmitter

--- a/code/modules/research/designs/designs_stock_part.dm
+++ b/code/modules/research/designs/designs_stock_part.dm
@@ -14,105 +14,90 @@
 	req_tech = list(TECH_POWER = 1)
 	materials = list(MAT_STEEL = 50, MAT_GLASS = 50)
 	build_path = /obj/item/stock_parts/capacitor
-	sort_string = "CAAAA"
 
 /datum/design/item/stock_part/adv_capacitor
 	id = "adv_capacitor"
 	req_tech = list(TECH_POWER = 3)
 	materials = list(MAT_STEEL = 50, MAT_GLASS = 50)
 	build_path = /obj/item/stock_parts/capacitor/adv
-	sort_string = "CAAAB"
 
 /datum/design/item/stock_part/super_capacitor
 	id = "super_capacitor"
 	req_tech = list(TECH_POWER = 5, TECH_MATERIAL = 4)
 	materials = list(MAT_STEEL = 50, MAT_GLASS = 50, MAT_GOLD = 20)
 	build_path = /obj/item/stock_parts/capacitor/super
-	sort_string = "CAAAC"
 
 /datum/design/item/stock_part/micro_mani
 	id = "micro_mani"
 	req_tech = list(TECH_MATERIAL = 1, TECH_DATA = 1)
 	materials = list(MAT_STEEL = 30)
 	build_path = /obj/item/stock_parts/manipulator
-	sort_string = "CAABA"
 
 /datum/design/item/stock_part/nano_mani
 	id = "nano_mani"
 	req_tech = list(TECH_MATERIAL = 3, TECH_DATA = 2)
 	materials = list(MAT_STEEL = 30)
 	build_path = /obj/item/stock_parts/manipulator/nano
-	sort_string = "CAABB"
 
 /datum/design/item/stock_part/pico_mani
 	id = "pico_mani"
 	req_tech = list(TECH_MATERIAL = 5, TECH_DATA = 2)
 	materials = list(MAT_STEEL = 30)
 	build_path = /obj/item/stock_parts/manipulator/pico
-	sort_string = "CAABC"
 
 /datum/design/item/stock_part/basic_matter_bin
 	id = "basic_matter_bin"
 	req_tech = list(TECH_MATERIAL = 1)
 	materials = list(MAT_STEEL = 80)
 	build_path = /obj/item/stock_parts/matter_bin
-	sort_string = "CAACA"
 
 /datum/design/item/stock_part/adv_matter_bin
 	id = "adv_matter_bin"
 	req_tech = list(TECH_MATERIAL = 3)
 	materials = list(MAT_STEEL = 80)
 	build_path = /obj/item/stock_parts/matter_bin/adv
-	sort_string = "CAACB"
 
 /datum/design/item/stock_part/super_matter_bin
 	id = "super_matter_bin"
 	req_tech = list(TECH_MATERIAL = 5)
 	materials = list(MAT_STEEL = 80)
 	build_path = /obj/item/stock_parts/matter_bin/super
-	sort_string = "CAACC"
 
 /datum/design/item/stock_part/basic_micro_laser
 	id = "basic_micro_laser"
 	req_tech = list(TECH_MAGNET = 1)
 	materials = list(MAT_STEEL = 10, MAT_GLASS = 20)
 	build_path = /obj/item/stock_parts/micro_laser
-	sort_string = "CAADA"
 
 /datum/design/item/stock_part/high_micro_laser
 	id = "high_micro_laser"
 	req_tech = list(TECH_MAGNET = 3)
 	materials = list(MAT_STEEL = 10, MAT_GLASS = 20)
 	build_path = /obj/item/stock_parts/micro_laser/high
-	sort_string = "CAADB"
 
 /datum/design/item/stock_part/ultra_micro_laser
 	id = "ultra_micro_laser"
 	req_tech = list(TECH_MAGNET = 5, TECH_MATERIAL = 5)
 	materials = list(MAT_STEEL = 10, MAT_GLASS = 20, MAT_URANIUM = 10)
 	build_path = /obj/item/stock_parts/micro_laser/ultra
-	sort_string = "CAADC"
 
 /datum/design/item/stock_part/basic_sensor
 	id = "basic_sensor"
 	req_tech = list(TECH_MAGNET = 1)
 	materials = list(MAT_STEEL = 50, MAT_GLASS = 20)
 	build_path = /obj/item/stock_parts/scanning_module
-	sort_string = "CAAEA"
 
 /datum/design/item/stock_part/adv_sensor
 	id = "adv_sensor"
 	req_tech = list(TECH_MAGNET = 3)
 	materials = list(MAT_STEEL = 50, MAT_GLASS = 20)
 	build_path = /obj/item/stock_parts/scanning_module/adv
-	sort_string = "CAAEB"
 
 /datum/design/item/stock_part/phasic_sensor
 	id = "phasic_sensor"
 	req_tech = list(TECH_MAGNET = 5, TECH_MATERIAL = 3)
 	materials = list(MAT_STEEL = 50, MAT_GLASS = 20, MAT_SILVER = 10)
 	build_path = /obj/item/stock_parts/scanning_module/phasic
-	sort_string = "CAAEC"
 
 /datum/design/item/stock_part/RPED
 	name = "Rapid Part Exchange Device"
@@ -121,7 +106,6 @@
 	req_tech = list(TECH_ENGINEERING = 3, TECH_MATERIAL = 3)
 	materials = list(MAT_STEEL = 15000, MAT_GLASS = 5000)
 	build_path = /obj/item/storage/part_replacer
-	sort_string = "CBAAA"
 
 /datum/design/item/stock_part/RPED_BS
 	name = "bluespace Rapid Part Exchange Device"
@@ -130,53 +114,45 @@
 	req_tech = list(TECH_ENGINEERING = 5, TECH_MATERIAL = 5, TECH_BLUESPACE = 4)
 	materials = list(MATERIAL_STEEL = 20000, MATERIAL_GLASS = 5000, MATERIAL_SILVER = 2000)
 	build_path = /obj/item/storage/part_replacer/bluespace
-	sort_string = "CBAAB"
 
 /datum/design/item/stock_part/subspace_ansible
 	id = "s-ansible"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
 	materials = list(MAT_STEEL = 80, MAT_SILVER = 20)
 	build_path = /obj/item/stock_parts/subspace/ansible
-	sort_string = "UAAAA"
 
 /datum/design/item/stock_part/hyperwave_filter
 	id = "s-filter"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 3)
 	materials = list(MAT_STEEL = 40, MAT_SILVER = 10)
 	build_path = /obj/item/stock_parts/subspace/filter
-	sort_string = "UAAAB"
 
 /datum/design/item/stock_part/subspace_amplifier
 	id = "s-amplifier"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
 	materials = list(MAT_STEEL = 10, MAT_GOLD = 30, MAT_URANIUM = 15)
 	build_path = /obj/item/stock_parts/subspace/amplifier
-	sort_string = "UAAAC"
 
 /datum/design/item/stock_part/subspace_treatment
 	id = "s-treatment"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 2, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
 	materials = list(MAT_STEEL = 10, MAT_SILVER = 20)
 	build_path = /obj/item/stock_parts/subspace/treatment
-	sort_string = "UAAAD"
 
 /datum/design/item/stock_part/subspace_analyzer
 	id = "s-analyzer"
 	req_tech = list(TECH_DATA = 3, TECH_MAGNET = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
 	materials = list(MAT_STEEL = 10, MAT_GOLD = 15)
 	build_path = /obj/item/stock_parts/subspace/analyzer
-	sort_string = "UAAAE"
 
 /datum/design/item/stock_part/subspace_crystal
 	id = "s-crystal"
 	req_tech = list(TECH_MAGNET = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
 	materials = list(MAT_GLASS = 1000, MAT_SILVER = 20, MAT_GOLD = 20)
 	build_path = /obj/item/stock_parts/subspace/crystal
-	sort_string = "UAAAF"
 
 /datum/design/item/stock_part/subspace_transmitter
 	id = "s-transmitter"
 	req_tech = list(TECH_MAGNET = 5, TECH_MATERIAL = 5, TECH_BLUESPACE = 3)
 	materials = list(MAT_GLASS = 100, MAT_SILVER = 10, MAT_URANIUM = 15)
 	build_path = /obj/item/stock_parts/subspace/transmitter
-	sort_string = "UAAAG"

--- a/code/modules/research/designs/designs_surgery.dm
+++ b/code/modules/research/designs/designs_surgery.dm
@@ -9,7 +9,6 @@
 	req_tech = list(TECH_BIO = 2, TECH_MATERIAL = 2, TECH_MAGNET = 2)
 	materials = list(MAT_STEEL = 12500, MAT_GLASS = 7500)
 	build_path = /obj/item/scalpel/laser1
-	sort_string = "MBEAA"
 
 /datum/design/item/surgery/scalpel_laser2
 	name = "Improved Laser Scalpel"
@@ -18,7 +17,6 @@
 	req_tech = list(TECH_BIO = 3, TECH_MATERIAL = 4, TECH_MAGNET = 4)
 	materials = list(MAT_STEEL = 12500, MAT_GLASS = 7500, MAT_SILVER = 2500)
 	build_path = /obj/item/scalpel/laser2
-	sort_string = "MBEAB"
 
 /datum/design/item/surgery/scalpel_laser3
 	name = "Advanced Laser Scalpel"
@@ -27,7 +25,6 @@
 	req_tech = list(TECH_BIO = 4, TECH_MATERIAL = 6, TECH_MAGNET = 5)
 	materials = list(MAT_STEEL = 12500, MAT_GLASS = 7500, MAT_SILVER = 2000, MAT_GOLD = 1500)
 	build_path = /obj/item/scalpel/laser3
-	sort_string = "MBEAC"
 
 /datum/design/item/surgery/scalpel_manager
 	name = "Incision Management System"
@@ -36,4 +33,3 @@
 	req_tech = list(TECH_BIO = 4, TECH_MATERIAL = 7, TECH_MAGNET = 5, TECH_DATA = 4)
 	materials = list (MAT_STEEL = 12500, MAT_GLASS = 7500, MAT_SILVER = 1500, MAT_GOLD = 1500, MAT_DIAMOND = 750)
 	build_path = /obj/item/scalpel/manager
-	sort_string = "MBEAD"

--- a/code/modules/research/designs/designs_surgery.dm
+++ b/code/modules/research/designs/designs_surgery.dm
@@ -5,7 +5,6 @@
 /datum/design/item/surgery/scalpel_laser1
 	name = "Basic Laser Scalpel"
 	desc = "A scalpel augmented with a directed laser, for more precise cutting without blood entering the field. This one looks basic and could be improved."
-	id = "scalpel_laser1"
 	req_tech = list(TECH_BIO = 2, TECH_MATERIAL = 2, TECH_MAGNET = 2)
 	materials = list(MAT_STEEL = 12500, MAT_GLASS = 7500)
 	build_path = /obj/item/scalpel/laser1
@@ -13,7 +12,6 @@
 /datum/design/item/surgery/scalpel_laser2
 	name = "Improved Laser Scalpel"
 	desc = "A scalpel augmented with a directed laser, for more precise cutting without blood entering the field. This one looks somewhat advanced."
-	id = "scalpel_laser2"
 	req_tech = list(TECH_BIO = 3, TECH_MATERIAL = 4, TECH_MAGNET = 4)
 	materials = list(MAT_STEEL = 12500, MAT_GLASS = 7500, MAT_SILVER = 2500)
 	build_path = /obj/item/scalpel/laser2
@@ -21,7 +19,6 @@
 /datum/design/item/surgery/scalpel_laser3
 	name = "Advanced Laser Scalpel"
 	desc = "A scalpel augmented with a directed laser, for more precise cutting without blood entering the field. This one looks to be the pinnacle of precision energy cutlery!"
-	id = "scalpel_laser3"
 	req_tech = list(TECH_BIO = 4, TECH_MATERIAL = 6, TECH_MAGNET = 5)
 	materials = list(MAT_STEEL = 12500, MAT_GLASS = 7500, MAT_SILVER = 2000, MAT_GOLD = 1500)
 	build_path = /obj/item/scalpel/laser3
@@ -29,7 +26,6 @@
 /datum/design/item/surgery/scalpel_manager
 	name = "Incision Management System"
 	desc = "A true extension of the surgeon's body, this marvel instantly and completely prepares an incision allowing for the immediate commencement of therapeutic steps."
-	id = "scalpel_manager"
 	req_tech = list(TECH_BIO = 4, TECH_MATERIAL = 7, TECH_MAGNET = 5, TECH_DATA = 4)
 	materials = list (MAT_STEEL = 12500, MAT_GLASS = 7500, MAT_SILVER = 1500, MAT_GOLD = 1500, MAT_DIAMOND = 750)
 	build_path = /obj/item/scalpel/manager

--- a/code/modules/research/designs/designs_synthstorage.dm
+++ b/code/modules/research/designs/designs_synthstorage.dm
@@ -5,7 +5,6 @@
 /datum/design/item/synthstorage/paicard
 	name = "pAI"
 	desc = "Personal Artificial Intelligence device."
-	id = "paicard"
 	req_tech = list(TECH_DATA = 2)
 	materials = list(MAT_GLASS = 500, MAT_STEEL = 500)
 	build_path = /obj/item/paicard
@@ -13,14 +12,12 @@
 /datum/design/item/synthstorage/intelicard
 	name = "inteliCard"
 	desc = "AI preservation and transportation system."
-	id = "intelicard"
 	req_tech = list(TECH_DATA = 4, TECH_MATERIAL = 4)
 	materials = list(MAT_GLASS = 1000, MAT_GOLD = 200)
 	build_path = /obj/item/aicard
 
 /datum/design/item/synthstorage/posibrain
 	name = "Positronic brain"
-	id = "posibrain"
 	req_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 6, TECH_BLUESPACE = 2, TECH_DATA = 4)
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 1000, MAT_SILVER = 1000, MAT_GOLD = 500, MAT_PHORON = 500, MAT_DIAMOND = 100)

--- a/code/modules/research/designs/designs_synthstorage.dm
+++ b/code/modules/research/designs/designs_synthstorage.dm
@@ -9,7 +9,6 @@
 	req_tech = list(TECH_DATA = 2)
 	materials = list(MAT_GLASS = 500, MAT_STEEL = 500)
 	build_path = /obj/item/paicard
-	sort_string = "VABAI"
 
 /datum/design/item/synthstorage/intelicard
 	name = "inteliCard"
@@ -18,7 +17,6 @@
 	req_tech = list(TECH_DATA = 4, TECH_MATERIAL = 4)
 	materials = list(MAT_GLASS = 1000, MAT_GOLD = 200)
 	build_path = /obj/item/aicard
-	sort_string = "VACAA"
 
 /datum/design/item/synthstorage/posibrain
 	name = "Positronic brain"
@@ -28,4 +26,3 @@
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 1000, MAT_SILVER = 1000, MAT_GOLD = 500, MAT_PHORON = 500, MAT_DIAMOND = 100)
 	build_path = /obj/item/organ/internal/posibrain
 	category = "Misc"
-	sort_string = "VACAB"

--- a/code/modules/research/designs/designs_syringe.dm
+++ b/code/modules/research/designs/designs_syringe.dm
@@ -4,7 +4,6 @@
 /datum/design/item/syringe/noreactsyringe
 	name = "Cryo Syringe"
 	desc = "An advanced syringe that stops reagents inside from reacting. It can hold up to 20 units."
-	id = "noreactsyringe"
 	req_tech = list(TECH_BIO = 4, TECH_MATERIAL = 4)
 	materials = list(MAT_GLASS = 2000, MAT_GOLD = 1000, MAT_PLASTIC = 500)
 	build_path = /obj/item/chems/syringe/noreact
@@ -12,7 +11,6 @@
 /datum/design/item/syringe/bluespacesyringe
 	name = "Bluespace Syringe"
 	desc = "An advanced syringe that can hold 60 units of chemicals"
-	id = "bluespacesyringe"
 	req_tech = list(TECH_BIO = 3, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
 	materials = list(MAT_GLASS = 2000, MAT_PHORON = 1000, MAT_DIAMOND = 1000)
 	build_path = /obj/item/chems/syringe/bluespace

--- a/code/modules/research/designs/designs_syringe.dm
+++ b/code/modules/research/designs/designs_syringe.dm
@@ -8,7 +8,6 @@
 	req_tech = list(TECH_BIO = 4, TECH_MATERIAL = 4)
 	materials = list(MAT_GLASS = 2000, MAT_GOLD = 1000, MAT_PLASTIC = 500)
 	build_path = /obj/item/chems/syringe/noreact
-	sort_string = "MCAAC"
 
 /datum/design/item/syringe/bluespacesyringe
 	name = "Bluespace Syringe"
@@ -17,4 +16,3 @@
 	req_tech = list(TECH_BIO = 3, TECH_MATERIAL = 4, TECH_BLUESPACE = 2)
 	materials = list(MAT_GLASS = 2000, MAT_PHORON = 1000, MAT_DIAMOND = 1000)
 	build_path = /obj/item/chems/syringe/bluespace
-	sort_string = "MCAAD"

--- a/code/modules/research/designs/designs_tool.dm
+++ b/code/modules/research/designs/designs_tool.dm
@@ -5,7 +5,6 @@
 /datum/design/item/tool/light_replacer
 	name = "light replacer"
 	desc = "A device to automatically replace lights. Refill with working lightbulbs."
-	id = "light_replacer"
 	req_tech = list(TECH_MAGNET = 3, TECH_MATERIAL = 4)
 	materials = list(MAT_STEEL = 1500, MAT_SILVER = 150, MAT_GLASS = 3000)
 	build_path = /obj/item/lightreplacer
@@ -13,7 +12,6 @@
 /datum/design/item/tool/airlock_brace
 	name = "airlock brace"
 	desc = "Special door attachment that can be used to provide extra security."
-	id = "brace"
 	req_tech = list(TECH_ENGINEERING = 3, TECH_MATERIAL = 2)
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 50)
 	build_path = /obj/item/airlock_brace
@@ -21,7 +19,6 @@
 /datum/design/item/tool/brace_jack
 	name = "maintenance jack"
 	desc = "A special maintenance tool that can be used to remove airlock braces."
-	id = "bracejack"
 	req_tech = list(TECH_ENGINEERING = 3, TECH_MATERIAL = 2)
 	materials = list(MAT_STEEL = 120)
 	build_path = /obj/item/crowbar/brace_jack
@@ -29,7 +26,6 @@
 /datum/design/item/tool/clamp
 	name = "stasis clamp"
 	desc = "A magnetic clamp which can halt the flow of gas in a pipe, via a localised stasis field."
-	id = "stasis_clamp"
 	req_tech = list(TECH_ENGINEERING = 4, TECH_MAGNET = 4)
 	materials = list(MAT_STEEL = 500, MAT_GLASS = 500)
 	build_path = /obj/item/clamp
@@ -37,7 +33,6 @@
 /datum/design/item/tool/inducer
 	name = "inducer"
 	desc = "An electromagnetic inducer that can transfer power from one cell into another."
-	id = "inducer"
 	req_tech = list(TECH_POWER = 6, TECH_ENGINEERING = 4)
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 100)
 	build_path = /obj/item/inducer
@@ -45,7 +40,6 @@
 /datum/design/item/tool/price_scanner
 	name = "price scanner"
 	desc = "Using an up-to-date database of various costs and prices, this device estimates the market price of an item up to 0.001% accuracy."
-	id = "price_scanner"
 	req_tech = list(TECH_MATERIAL = 6, TECH_MAGNET = 4)
 	materials = list(MAT_STEEL = 3000, MAT_GLASS = 3000, MAT_SILVER = 250)
 	build_path = /obj/item/scanner/price
@@ -53,7 +47,6 @@
 /datum/design/item/tool/experimental_welder
 	name = "experimental welding tool"
 	desc = "This welding tool feels heavier in your possession than is normal. There appears to be no external fuel port."
-	id = "experimental_welder"
 	req_tech = list(TECH_ENGINEERING = 5, TECH_PHORON = 4)
 	materials = list(MAT_STEEL = 120, MAT_GLASS = 50)
 	build_path = /obj/item/weldingtool/experimental
@@ -61,7 +54,6 @@
 /datum/design/item/tool/shield_diffuser
 	name = "portable shield diffuser"
 	desc = "A small handheld device designed to disrupt energy barriers."
-	id = "portable_shield_diffuser"
 	req_tech = list(TECH_MAGNET = 5, TECH_POWER = 5, TECH_ESOTERIC = 2)
 	materials = list(MAT_STEEL = 5000, MAT_GLASS = 5000, MAT_GOLD = 2000, MAT_SILVER = 2000)
 	build_path = /obj/item/shield_diffuser
@@ -69,7 +61,6 @@
 /datum/design/item/tool/rpd
 	name = "rapid piping device"
 	desc = "A compacted and complicated device, that relies on compressed matter to dispense piping on the move."
-	id = "rpd"
 	req_tech = list(TECH_ENGINEERING = 6, TECH_MATERIAL = 6)
 	materials = list(MAT_STEEL = 15000, MAT_GLASS = 10000, MAT_SILVER = 2000)
 	build_path = /obj/item/rpd
@@ -77,7 +68,6 @@
 /datum/design/item/tool/oxycandle
 	name = "oxycandle"
 	desc = "a device which, via a chemical reaction, can pressurise small areas."
-	id="oxycandle"
 	req_tech = list(TECH_ENGINEERING = 2)
 	materials = list(MAT_STEEL = 3000)
 	chemicals = list(/datum/reagent/sodiumchloride = 20, /datum/reagent/acetone = 20)

--- a/code/modules/research/designs/designs_tool.dm
+++ b/code/modules/research/designs/designs_tool.dm
@@ -9,7 +9,6 @@
 	req_tech = list(TECH_MAGNET = 3, TECH_MATERIAL = 4)
 	materials = list(MAT_STEEL = 1500, MAT_SILVER = 150, MAT_GLASS = 3000)
 	build_path = /obj/item/lightreplacer
-	sort_string = "VAGAB"
 
 /datum/design/item/tool/airlock_brace
 	name = "airlock brace"
@@ -18,7 +17,6 @@
 	req_tech = list(TECH_ENGINEERING = 3, TECH_MATERIAL = 2)
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 50)
 	build_path = /obj/item/airlock_brace
-	sort_string = "VAGAC"
 
 /datum/design/item/tool/brace_jack
 	name = "maintenance jack"
@@ -27,7 +25,6 @@
 	req_tech = list(TECH_ENGINEERING = 3, TECH_MATERIAL = 2)
 	materials = list(MAT_STEEL = 120)
 	build_path = /obj/item/crowbar/brace_jack
-	sort_string = "VAGAD"
 
 /datum/design/item/tool/clamp
 	name = "stasis clamp"
@@ -36,7 +33,6 @@
 	req_tech = list(TECH_ENGINEERING = 4, TECH_MAGNET = 4)
 	materials = list(MAT_STEEL = 500, MAT_GLASS = 500)
 	build_path = /obj/item/clamp
-	sort_string = "VAGAE"
 
 /datum/design/item/tool/inducer
 	name = "inducer"
@@ -53,7 +49,6 @@
 	req_tech = list(TECH_MATERIAL = 6, TECH_MAGNET = 4)
 	materials = list(MAT_STEEL = 3000, MAT_GLASS = 3000, MAT_SILVER = 250)
 	build_path = /obj/item/scanner/price
-	sort_string = "VAGAF"
 
 /datum/design/item/tool/experimental_welder
 	name = "experimental welding tool"
@@ -62,7 +57,6 @@
 	req_tech = list(TECH_ENGINEERING = 5, TECH_PHORON = 4)
 	materials = list(MAT_STEEL = 120, MAT_GLASS = 50)
 	build_path = /obj/item/weldingtool/experimental
-	sort_string = "VAGAG"
 
 /datum/design/item/tool/shield_diffuser
 	name = "portable shield diffuser"
@@ -71,7 +65,6 @@
 	req_tech = list(TECH_MAGNET = 5, TECH_POWER = 5, TECH_ESOTERIC = 2)
 	materials = list(MAT_STEEL = 5000, MAT_GLASS = 5000, MAT_GOLD = 2000, MAT_SILVER = 2000)
 	build_path = /obj/item/shield_diffuser
-	sort_string = "VAGAH"
 
 /datum/design/item/tool/rpd
 	name = "rapid piping device"
@@ -80,7 +73,6 @@
 	req_tech = list(TECH_ENGINEERING = 6, TECH_MATERIAL = 6)
 	materials = list(MAT_STEEL = 15000, MAT_GLASS = 10000, MAT_SILVER = 2000)
 	build_path = /obj/item/rpd
-	sort_string = "VAGAI"
 
 /datum/design/item/tool/oxycandle
 	name = "oxycandle"
@@ -90,4 +82,3 @@
 	materials = list(MAT_STEEL = 3000)
 	chemicals = list(/datum/reagent/sodiumchloride = 20, /datum/reagent/acetone = 20)
 	build_path = /obj/item/oxycandle
-	sort_string = "VAGAJ"

--- a/code/modules/research/designs/designs_weapon.dm
+++ b/code/modules/research/designs/designs_weapon.dm
@@ -11,123 +11,103 @@
 
 /datum/design/item/weapon/chemsprayer
 	desc = "An advanced chem spraying device."
-	id = "chemsprayer"
 	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_BIO = 2)
 	materials = list(MAT_STEEL = 5000, MAT_GLASS = 1000)
 	build_path = /obj/item/chems/spray/chemsprayer
 
 /datum/design/item/weapon/rapidsyringe
-	id = "rapidsyringe"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_BIO = 2)
 	materials = list(MAT_STEEL = 5000, MAT_GLASS = 1000)
 	build_path = /obj/item/gun/launcher/syringe/rapid
 
 /datum/design/item/weapon/temp_gun
 	desc = "A gun that shoots high-powered glass-encased energy temperature bullets."
-	id = "temp_gun"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 4, TECH_POWER = 3, TECH_MAGNET = 2)
 	materials = list(MAT_STEEL = 5000, MAT_GLASS = 500, MAT_SILVER = 3000)
 	build_path = /obj/item/gun/energy/temperature
 
 /datum/design/item/weapon/large_grenade
-	id = "large_Grenade"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2)
 	materials = list(MAT_STEEL = 3000)
 	build_path = /obj/item/grenade/chem_grenade/large
 
 /datum/design/item/weapon/anti_photon
-	id = "anti_photon"
 	req_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 4)
 	materials = list(MAT_STEEL = 3000, MAT_GLASS = 1000, MAT_DIAMOND = 1000)
 	build_path = /obj/item/grenade/anti_photon
 
 /datum/design/item/weapon/flora_gun
-	id = "flora_gun"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_POWER = 3)
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 500, MAT_URANIUM = 500)
 	build_path = /obj/item/gun/energy/floragun
 
 /datum/design/item/weapon/advancedflash
-	id = "advancedflash"
 	req_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 2)
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 2000, MAT_SILVER = 500)
 	build_path = /obj/item/flash/advanced
 
 /datum/design/item/weapon/stunrevolver
-	id = "stunrevolver"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_POWER = 2)
 	materials = list(MAT_STEEL = 4000)
 	build_path = /obj/item/gun/energy/stunrevolver
 
 /datum/design/item/weapon/stunrifle
-	id = "stun_rifle"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
 	materials = list(MAT_STEEL = 4000, MAT_GLASS = 1000, MAT_SILVER = 500)
 	build_path = /obj/item/gun/energy/stunrevolver/rifle
 
 /datum/design/item/weapon/confuseray
-	id = "confuseray"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_POWER = 3)
 	materials = list(MAT_STEEL = 3000, MAT_GLASS = 1000)
 	build_path = /obj/item/gun/energy/confuseray
 
 /datum/design/item/weapon/nuclear_gun
-	id = "nuclear_gun"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 5, TECH_POWER = 3)
 	materials = list(MAT_STEEL = 5000, MAT_GLASS = 1000, MAT_URANIUM = 500)
 	build_path = /obj/item/gun/energy/gun/nuclear
 
 /datum/design/item/weapon/lasercannon
 	desc = "The lasing medium of this prototype is enclosed in a tube lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core."
-	id = "lasercannon"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
 	materials = list(MAT_STEEL = 10000, MAT_GLASS = 1000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/gun/energy/lasercannon
 
 /datum/design/item/weapon/xraypistol
-	id = "xraypistol"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_MAGNET = 2, TECH_ESOTERIC = 2)
 	materials = list(MAT_STEEL = 4000, MAT_GLASS = 500, MAT_URANIUM = 500)
 	build_path = /obj/item/gun/energy/xray/pistol
 
 /datum/design/item/weapon/xrayrifle
-	id = "xrayrifle"
 	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 3, TECH_MAGNET = 2, TECH_ESOTERIC = 2)
 	materials = list(MAT_STEEL = 5000, MAT_GLASS = 1000, MAT_URANIUM = 1000)
 	build_path = /obj/item/gun/energy/xray
 
 /datum/design/item/weapon/grenadelauncher
-	id = "grenadelauncher"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
 	materials = list(MAT_STEEL = 5000, MAT_GLASS = 1000)
 	build_path = /obj/item/gun/launcher/grenade
 
 /datum/design/item/weapon/flechette
-	id = "flechette"
 	req_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 4, TECH_MAGNET = 4)
 	materials = list(MAT_STEEL = 8000, MAT_GOLD = 4000, MAT_SILVER = 4000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/gun/magnetic/railgun/flechette
 
 /datum/design/item/weapon/phoronpistol
-	id = "ppistol"
 	req_tech = list(TECH_COMBAT = 5, TECH_PHORON = 4)
 	materials = list(MAT_STEEL = 5000, MAT_GLASS = 1000, MAT_PHORON = 3000)
 	build_path = /obj/item/gun/energy/toxgun
 
 /datum/design/item/weapon/decloner
-	id = "decloner"
 	req_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 7, TECH_BIO = 5, TECH_POWER = 6)
 	materials = list(MAT_GOLD = 5000, MAT_URANIUM = 10000)
 	build_path = /obj/item/gun/energy/decloner
 
 /datum/design/item/weapon/wt550
-	id = "wt550"
 	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	materials = list(MAT_STEEL = 8000, MAT_SILVER = 3000, MAT_DIAMOND = 1500)
 	build_path = /obj/item/gun/projectile/automatic/smg
 
 /datum/design/item/weapon/bullpup
-	id = "bullpup"
 	req_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 3)
 	materials = list(MAT_STEEL = 10000, MAT_SILVER = 5000, MAT_DIAMOND = 3000)
 	build_path = /obj/item/gun/projectile/automatic/assault_rifle
@@ -137,7 +117,6 @@
 	name = "Ammunition prototype ([item_name])"
 
 /datum/design/item/weapon/ammunition/ammo_small
-	id = "ammo_small"
 	desc = "A box of small pistol rounds."
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3)
 	materials = list(MAT_STEEL = 3750, MAT_SILVER = 100)
@@ -145,14 +124,12 @@
 
 /datum/design/item/weapon/ammunition/stunshell
 	desc = "A stunning shell for a shotgun."
-	id = "stunshell"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
 	materials = list(MAT_STEEL = 4000)
 	build_path = /obj/item/ammo_casing/shotgun/stunshell
 
 /datum/design/item/weapon/ammunition/ammo_emp_small
 	name = "haywire 7mm"
-	id = "ammo_emp_small"
 	desc = "A box of small pistol rounds with integrated EMP charges."
 	materials = list(MAT_STEEL = 2500, MAT_URANIUM = 750)
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
@@ -160,14 +137,12 @@
 
 /datum/design/item/weapon/ammunition/ammo_emp_pistol
 	name = "haywire 10mm"
-	id = "ammo_emp_pistol"
 	desc = "A box of pistol rounds fitted with integrated EMP charges."
 	materials = list(MAT_STEEL = 2500, MAT_URANIUM = 750)
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
 	build_path = /obj/item/ammo_magazine/box/emp/pistol
 
 /datum/design/item/weapon/ammunition/ammo_emp_slug
-	id = "ammo_emp_slug"
 	desc = "A shotgun slug with an integrated EMP charge."
 	materials = list(MAT_STEEL = 3000, MAT_URANIUM = 1000)
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3)

--- a/code/modules/research/designs/designs_weapon.dm
+++ b/code/modules/research/designs/designs_weapon.dm
@@ -15,14 +15,12 @@
 	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_BIO = 2)
 	materials = list(MAT_STEEL = 5000, MAT_GLASS = 1000)
 	build_path = /obj/item/chems/spray/chemsprayer
-	sort_string = "TAAAA"
 
 /datum/design/item/weapon/rapidsyringe
 	id = "rapidsyringe"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_BIO = 2)
 	materials = list(MAT_STEEL = 5000, MAT_GLASS = 1000)
 	build_path = /obj/item/gun/launcher/syringe/rapid
-	sort_string = "TAAAB"
 
 /datum/design/item/weapon/temp_gun
 	desc = "A gun that shoots high-powered glass-encased energy temperature bullets."
@@ -30,63 +28,54 @@
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 4, TECH_POWER = 3, TECH_MAGNET = 2)
 	materials = list(MAT_STEEL = 5000, MAT_GLASS = 500, MAT_SILVER = 3000)
 	build_path = /obj/item/gun/energy/temperature
-	sort_string = "TAAAC"
 
 /datum/design/item/weapon/large_grenade
 	id = "large_Grenade"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2)
 	materials = list(MAT_STEEL = 3000)
 	build_path = /obj/item/grenade/chem_grenade/large
-	sort_string = "TABAA"
 
 /datum/design/item/weapon/anti_photon
 	id = "anti_photon"
 	req_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 4)
 	materials = list(MAT_STEEL = 3000, MAT_GLASS = 1000, MAT_DIAMOND = 1000)
 	build_path = /obj/item/grenade/anti_photon
-	sort_string = "TABAB"
 
 /datum/design/item/weapon/flora_gun
 	id = "flora_gun"
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_POWER = 3)
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 500, MAT_URANIUM = 500)
 	build_path = /obj/item/gun/energy/floragun
-	sort_string = "TACAA"
 
 /datum/design/item/weapon/advancedflash
 	id = "advancedflash"
 	req_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 2)
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 2000, MAT_SILVER = 500)
 	build_path = /obj/item/flash/advanced
-	sort_string = "TADAA"
 
 /datum/design/item/weapon/stunrevolver
 	id = "stunrevolver"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_POWER = 2)
 	materials = list(MAT_STEEL = 4000)
 	build_path = /obj/item/gun/energy/stunrevolver
-	sort_string = "TADAB"
 
 /datum/design/item/weapon/stunrifle
 	id = "stun_rifle"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
 	materials = list(MAT_STEEL = 4000, MAT_GLASS = 1000, MAT_SILVER = 500)
 	build_path = /obj/item/gun/energy/stunrevolver/rifle
-	sort_string = "TADAC"
 
 /datum/design/item/weapon/confuseray
 	id = "confuseray"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_POWER = 3)
 	materials = list(MAT_STEEL = 3000, MAT_GLASS = 1000)
 	build_path = /obj/item/gun/energy/confuseray
-	sort_string = "TADAD"
 
 /datum/design/item/weapon/nuclear_gun
 	id = "nuclear_gun"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 5, TECH_POWER = 3)
 	materials = list(MAT_STEEL = 5000, MAT_GLASS = 1000, MAT_URANIUM = 500)
 	build_path = /obj/item/gun/energy/gun/nuclear
-	sort_string = "TAEAA"
 
 /datum/design/item/weapon/lasercannon
 	desc = "The lasing medium of this prototype is enclosed in a tube lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core."
@@ -94,63 +83,54 @@
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
 	materials = list(MAT_STEEL = 10000, MAT_GLASS = 1000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/gun/energy/lasercannon
-	sort_string = "TAEAB"
 
 /datum/design/item/weapon/xraypistol
 	id = "xraypistol"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_MAGNET = 2, TECH_ESOTERIC = 2)
 	materials = list(MAT_STEEL = 4000, MAT_GLASS = 500, MAT_URANIUM = 500)
 	build_path = /obj/item/gun/energy/xray/pistol
-	sort_string = "TAFAA"
 
 /datum/design/item/weapon/xrayrifle
 	id = "xrayrifle"
 	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 3, TECH_MAGNET = 2, TECH_ESOTERIC = 2)
 	materials = list(MAT_STEEL = 5000, MAT_GLASS = 1000, MAT_URANIUM = 1000)
 	build_path = /obj/item/gun/energy/xray
-	sort_string = "TAFAB"
 
 /datum/design/item/weapon/grenadelauncher
 	id = "grenadelauncher"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
 	materials = list(MAT_STEEL = 5000, MAT_GLASS = 1000)
 	build_path = /obj/item/gun/launcher/grenade
-	sort_string = "TAGAA"
 
 /datum/design/item/weapon/flechette
 	id = "flechette"
 	req_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 4, TECH_MAGNET = 4)
 	materials = list(MAT_STEEL = 8000, MAT_GOLD = 4000, MAT_SILVER = 4000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/gun/magnetic/railgun/flechette
-	sort_string = "TAHAA"
 
 /datum/design/item/weapon/phoronpistol
 	id = "ppistol"
 	req_tech = list(TECH_COMBAT = 5, TECH_PHORON = 4)
 	materials = list(MAT_STEEL = 5000, MAT_GLASS = 1000, MAT_PHORON = 3000)
 	build_path = /obj/item/gun/energy/toxgun
-	sort_string = "TAJAA"
 
 /datum/design/item/weapon/decloner
 	id = "decloner"
 	req_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 7, TECH_BIO = 5, TECH_POWER = 6)
 	materials = list(MAT_GOLD = 5000, MAT_URANIUM = 10000)
 	build_path = /obj/item/gun/energy/decloner
-	sort_string = "TAJAB"
 
 /datum/design/item/weapon/wt550
 	id = "wt550"
 	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	materials = list(MAT_STEEL = 8000, MAT_SILVER = 3000, MAT_DIAMOND = 1500)
 	build_path = /obj/item/gun/projectile/automatic/smg
-	sort_string = "TAPAA"
 
 /datum/design/item/weapon/bullpup
 	id = "bullpup"
 	req_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 3)
 	materials = list(MAT_STEEL = 10000, MAT_SILVER = 5000, MAT_DIAMOND = 3000)
 	build_path = /obj/item/gun/projectile/automatic/assault_rifle
-	sort_string = "TAPAC"
 
 /datum/design/item/weapon/ammunition/AssembleDesignName()
 	..()
@@ -162,7 +142,6 @@
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3)
 	materials = list(MAT_STEEL = 3750, MAT_SILVER = 100)
 	build_path = /obj/item/ammo_magazine/box/smallpistol
-	sort_string = "TBAAA"
 
 /datum/design/item/weapon/ammunition/stunshell
 	desc = "A stunning shell for a shotgun."
@@ -170,7 +149,6 @@
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
 	materials = list(MAT_STEEL = 4000)
 	build_path = /obj/item/ammo_casing/shotgun/stunshell
-	sort_string = "TBAAC"
 
 /datum/design/item/weapon/ammunition/ammo_emp_small
 	name = "haywire 7mm"
@@ -179,7 +157,6 @@
 	materials = list(MAT_STEEL = 2500, MAT_URANIUM = 750)
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
 	build_path = /obj/item/ammo_magazine/box/emp/smallpistol
-	sort_string = "TBAAD"
 
 /datum/design/item/weapon/ammunition/ammo_emp_pistol
 	name = "haywire 10mm"
@@ -188,7 +165,6 @@
 	materials = list(MAT_STEEL = 2500, MAT_URANIUM = 750)
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
 	build_path = /obj/item/ammo_magazine/box/emp/pistol
-	sort_string = "TBAAF"
 
 /datum/design/item/weapon/ammunition/ammo_emp_slug
 	id = "ammo_emp_slug"
@@ -196,4 +172,3 @@
 	materials = list(MAT_STEEL = 3000, MAT_URANIUM = 1000)
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3)
 	build_path = /obj/item/ammo_casing/shotgun/emp
-	sort_string = "TBAAG"

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -215,10 +215,10 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		if(!d_disk)
 			screen = 1
 			return
-		for(var/datum/design/D in files.known_designs)
-			if(href_list["copy_design_ID"] == D.id)
-				d_disk.blueprint = D
-				break
+
+		var/datum/design/locate_design = locate(href_list["copy_design_ID"])
+		if(istype(locate_design) && (locate_design in files.known_designs))
+			d_disk.blueprint = locate_design
 		screen = 1.4
 
 	else if(href_list["eject_item"]) //Eject the item inside the destructive analyzer.
@@ -290,24 +290,16 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	else if(href_list["build"]) //Causes the Protolathe to build something.
 		. = TOPIC_REFRESH
 		CHECK_LATHE
-		var/datum/design/being_built = null
-		for(var/datum/design/D in files.known_designs)
-			if(D.id == href_list["build"])
-				being_built = D
-				break
-		if(being_built)
+		var/datum/design/being_built = locate(href_list["build"])
+		if(istype(being_built) && (being_built in files.known_designs))
 			linked_lathe.addToQueue(being_built)
 		screen = 3.1
 
 	else if(href_list["imprint"]) //Causes the Circuit Imprinter to build something.
 		. = TOPIC_REFRESH
 		CHECK_IMPRINTER
-		var/datum/design/being_built = null
-		for(var/datum/design/D in files.known_designs)
-			if(D.id == href_list["imprint"])
-				being_built = D
-				break
-		if(being_built)
+		var/datum/design/being_built = locate(href_list["imprint"])
+		if(istype(being_built) && (being_built in files.known_designs))
 			linked_imprinter.addToQueue(being_built)
 		screen = 4.1
 
@@ -616,7 +608,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			for(var/datum/design/D in files.known_designs)
 				if(D.build_path)
 					dat += "<LI>[D.name] "
-					dat += "<A href='?src=\ref[src];copy_design=1;copy_design_ID=[D.id]'>\[copy to disk\]</A>"
+					dat += "<A href='?src=\ref[src];copy_design=1;copy_design_ID=\ref[D]'>\[copy to disk\]</A>"
 			dat += "</UL>"
 
 		if(1.6) //R&D console settings
@@ -709,7 +701,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				if(temp_dat)
 					temp_dat = " \[[copytext(temp_dat, 3)]\]"
 				if(linked_lathe.canBuild(D))
-					dat += "<LI><B><A href='?src=\ref[src];build=[D.id]'>[D.name]</A></B>[temp_dat]"
+					dat += "<LI><B><A href='?src=\ref[src];build=\ref[D]'>[D.name]</A></B>[temp_dat]"
 				else
 					dat += "<LI><B>[D.name]</B>[temp_dat]"
 			dat += "</UL>"
@@ -791,7 +783,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				if(temp_dat)
 					temp_dat = " \[[copytext(temp_dat,3)]\]"
 				if(linked_imprinter.canBuild(D))
-					dat += "<LI><B><A href='?src=\ref[src];imprint=[D.id]'>[D.name]</A></B>[temp_dat]"
+					dat += "<LI><B><A href='?src=\ref[src];imprint=\ref[D]'>[D.name]</A></B>[temp_dat]"
 				else
 					dat += "<LI><B>[D.name]</B>[temp_dat]"
 			dat += "</UL>"

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -91,16 +91,8 @@ research holder datum.
 	return
 
 /datum/research/proc/AddDesign2Known(var/datum/design/D)
-	if(!length(known_designs))
-		known_designs.Add(D)
-		return
-	for(var/i = 1 to known_designs.len)
-		var/datum/design/A = known_designs[i]
-		if(A.name != D.name && "[A.name]" > "[D.name]")
-			known_designs.Insert(i, D)
-			return
-	known_designs.Add(D)
-	return
+	if(!(D in known_designs))
+		ADD_SORTED(known_designs, D, /proc/cmp_name_asc)
 
 //Refreshes known_tech and known_designs list
 //Input/Output: n/a

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -91,14 +91,12 @@ research holder datum.
 	return
 
 /datum/research/proc/AddDesign2Known(var/datum/design/D)
-	if(!known_designs.len) // Special case
+	if(!length(known_designs))
 		known_designs.Add(D)
 		return
 	for(var/i = 1 to known_designs.len)
 		var/datum/design/A = known_designs[i]
-		if(A.id == D.id) // We are guaranteed to reach this if the ids are the same, because sort_string will also be the same
-			return
-		if(A.sort_string > D.sort_string)
+		if(A.name != D.name && "[A.name]" > "[D.name]")
 			known_designs.Insert(i, D)
 			return
 	known_designs.Add(D)

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -186,10 +186,9 @@
 	else if(href_list["reset_design"])
 		var/choice = alert(user, "Design Data Deletion", "Are you sure you want to delete this design? If you still have the prerequisites for the design, it'll reset to its base reliability. Data lost cannot be recovered.", "Continue", "Cancel")
 		if(choice == "Continue" && CanUseTopic(user, state))
-			for(var/datum/design/D in temp_server.files.known_designs)
-				if(D.id == href_list["reset_design"])
-					temp_server.files.known_designs -= D
-					break
+			var/datum/design/D = locate(href_list["reset_design"])
+			if(istype(D))
+				temp_server.files.known_designs -= D
 		temp_server.files.RefreshResearch()
 		. = TOPIC_REFRESH
 
@@ -244,7 +243,7 @@
 			dat += "Known Designs<BR>"
 			for(var/datum/design/D in temp_server.files.known_designs)
 				dat += "* [D.name] "
-				dat += "<A href='?src=\ref[src];reset_design=[D.id]'>(Delete)</A><BR>"
+				dat += "<A href='?src=\ref[src];reset_design=\ref[D]'>(Delete)</A><BR>"
 			dat += "<HR><A href='?src=\ref[src];main=1'>Main Menu</A>"
 
 		if(3) //Server Data Transfer

--- a/code/unit_tests/unique_tests.dm
+++ b/code/unit_tests/unique_tests.dm
@@ -25,25 +25,17 @@
 	name = "UNIQUENESS: Research Designs Shall Be Unique"
 
 /datum/unit_test/research_designs_shall_be_unique/start_test()
-	var/list/ids = list()
 	var/list/build_paths = list()
-
 	for(var/design_type in subtypesof(/datum/design))
 		var/datum/design/design = design_type
-		if(initial(design.id) == "id")
-			continue
-
-		group_by(ids, initial(design.id), design)
-		group_by(build_paths, initial(design.build_path), design)
-
-	var/number_of_issues = number_of_issues(ids, "IDs")
-	number_of_issues += number_of_issues(build_paths, "Build Paths")
-
+		var/build_path = initial(design.build_path)
+		if(build_path)
+			group_by(build_paths, build_path, design)
+	var/number_of_issues = number_of_issues(build_paths, "Build Paths")
 	if(number_of_issues)
 		fail("[number_of_issues] issues with research designs found.")
 	else
 		pass("All research designs are unique.")
-
 	return 1
 
 /datum/unit_test/player_preferences_shall_have_unique_key


### PR DESCRIPTION
Breaking changes from #116 out into a separate PR.

- Removed `sort_string` and made recipe sorting use `name`.
- Removed `id` and made the R&D interfaces use a reference to the datum instead.