### PR TITLE
Prevent overloading /New()

### DIFF
--- a/code/datums/repositories/decls.dm
+++ b/code/datums/repositories/decls.dm
@@ -43,6 +43,9 @@
 		. = get_decls(subtypesof(decl_prototype))
 		fetched_decl_subtypes[decl_prototype] = .
 
+/decl/proc/New()
+	SHOULD_NOT_OVERRIDE(TRUE)
+
 /decl/proc/Initialize()
 	SHOULD_CALL_PARENT(TRUE)
 	return

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -15,6 +15,7 @@
 	var/climb_speed_mult = 1
 
 /atom/New(loc, ...)
+	SHOULD_NOT_OVERRIDE(TRUE)
 	//atom creation method that preloads variables at creation
 	if(GLOB.use_preloader && (src.type == GLOB._preloader.target_path))//in case the instanciated atom is creating other atoms in New()
 		GLOB._preloader.load(src)


### PR DESCRIPTION
Unless it's a straight /datum/ subtype

Awaiting linter errors