### PR TITLE
Z-Sound - Adds the ability for sound to propagate across multiple connected z-levels

### DIFF
--- a/code/__defines/sound.dm
+++ b/code/__defines/sound.dm
@@ -35,3 +35,29 @@
 #define SMALL_SOFTFLOOR ROOM
 #define ASTEROID CAVE
 #define SPACE UNDERWATER
+
+//Defines for echo list index positions.
+//ECHO_DIRECT and ECHO_ROOM are the only two that actually appear to do anything, and represent the dry and wet channels of the environment effects, respectively.
+//The rest of the defines are there primarily for the sake of completeness. It might be worth testing on EAX-enabled hardware, and on future BYOND versions (I've tested with 511, 512, and 513)
+#define ECHO_DIRECT 1
+#define ECHO_DIRECTHF 2
+#define ECHO_ROOM 3
+#define ECHO_ROOMHF 4
+#define ECHO_OBSTRUCTION 5
+#define ECHO_OBSTRUCTIONLFRATIO 6
+#define ECHO_OCCLUSION 7
+#define ECHO_OCCLUSIONLFRATIO 8
+#define ECHO_OCCLUSIONROOMRATIO 9
+#define ECHO_OCCLUSIONDIRECTRATIO 10
+#define ECHO_EXCLUSION 11
+#define ECHO_EXCLUSIONLFRATIO 12
+#define ECHO_OUTSIDEVOLUMEHF 13
+#define ECHO_DOPPLERFACTOR 14
+#define ECHO_ROLLOFFFACTOR 15
+#define ECHO_ROOMROLLOFFFACTOR 16
+#define ECHO_AIRABSORPTIONFACTOR 17
+#define ECHO_FLAGS 18
+
+//Defines for controlling how zsound sounds.
+#define ZSOUND_DRYLOSS_PER_Z -2000 //Affects what happens to the dry channel as the sound travels through z-levels
+#define ZSOUND_DISTANCE_PER_Z 2 //Affects the distance added to the sound per z-level travelled

--- a/code/_global_vars/sound.dm
+++ b/code/_global_vars/sound.dm
@@ -110,4 +110,4 @@ GLOBAL_LIST_INIT(glasscrack_sound,\
 		'sound/effects/glass_crack4.ogg'))
 
 //This is a global list in interest of optimization; list init is expensive enough for this to be worth doing, even with playsound() not being very hot.
-GLOBAL_LIST_INIT(echo_list, list(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null))
+GLOBAL_LIST_INIT(echo_list, new(18))

--- a/code/_global_vars/sound.dm
+++ b/code/_global_vars/sound.dm
@@ -108,6 +108,3 @@ GLOBAL_LIST_INIT(glasscrack_sound,\
 		'sound/effects/glass_crack2.ogg',\
 		'sound/effects/glass_crack3.ogg',\
 		'sound/effects/glass_crack4.ogg'))
-
-//This is a global list in interest of optimization; list init is expensive enough for this to be worth doing, even with playsound() not being very hot.
-GLOBAL_LIST_INIT(echo_list, new(18))

--- a/code/_global_vars/sound.dm
+++ b/code/_global_vars/sound.dm
@@ -108,3 +108,6 @@ GLOBAL_LIST_INIT(glasscrack_sound,\
 		'sound/effects/glass_crack2.ogg',\
 		'sound/effects/glass_crack3.ogg',\
 		'sound/effects/glass_crack4.ogg'))
+
+//This is a global list in interest of optimization; list init is expensive enough for this to be worth doing, even with playsound() not being very hot.
+GLOBAL_LIST_INIT(echo_list, list(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null))

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -121,9 +121,10 @@ var/const/FALLOFF_SOUNDS = 0.5
 			var/area/A = get_area(src)
 			S.environment = A.sound_env
 
-	GLOB.echo_list[ECHO_DIRECT] = envdry
-	GLOB.echo_list[ECHO_ROOM] = envwet
-	S.echo = GLOB.echo_list
+	var/list/echo_list = new(18)
+	echo_list[ECHO_DIRECT] = envdry
+	echo_list[ECHO_ROOM] = envwet
+	S.echo = echo_list
 
 	sound_to(src, S)
 


### PR DESCRIPTION
This more or less does exactly what the title suggests it does on the tin. [A short demo showing this in action can be found here.](https://streamable.com/etrrr)

This effect can be tweaked via the ZSOUND_DRYLOSS_PER_Z and ZSOUND_DISTANCE_PER_Z defines in `code/__defines/sound.dm`. The former affects how muffled a sound gets the further the distance between z-levels, and the latter affects how much physical distance gets added per z-level. The defaults are tweaked to make quieter sounds nearly inaudible, while still allowing beefier sounds (such as gunshots and melee attacks) to reverberate throughout the ship/station/etc.

Sound behavior can also be modified via new args on playsound and playsound_local. For the former, the args are zrange (affects how many z-levels up and down it can travel, default is 2), override_env (disables zsound's effects for better manual control over sounds), envdry (affects the dry channel (ECHO_DIRECT) of the environmental effects, this is what zsound adjusts to give that muffled effect), envwet (affects the wet channel (ECHO_ROOM) of the environmental effects). For the latter, the args added are override_env, envdry, and envwet.

This also adds new defines for all of the variables modifiable via the echo list. I have done some testing, and it seems the only two args that do anything are ECHO_DIRECT and ECHO_ROOM, though I have included defines for all echo list index positions for the sake of completeness.

Potential future improvements include disabling or reducing the muffle effect if either the source or target of a given sound can see each other from an openspace, though the implementation has been kept relatively simple for now.