### PR TITLE
Sleeper rework.

### DIFF
--- a/code/content_packages/ascent/machines/ship_machines.dm
+++ b/code/content_packages/ascent/machines/ship_machines.dm
@@ -66,6 +66,12 @@ MANTIDIFY(/obj/machinery/door/airlock/external/bolted, "mantid airlock", "door")
 	construct_state = /decl/machine_construction/default/no_deconstruct
 	base_type = /obj/machinery/bodyscanner
 
+MANTIDIFY(/obj/item/chems/chem_disp_cartridge, "canister", "chemical storage")
+/obj/item/chems/chem_disp_cartridge/ascent/crystal
+	spawn_reagent = /datum/reagent/crystal
+/obj/item/chems/chem_disp_cartridge/ascent/bromide
+	spawn_reagent = /datum/reagent/toxin/bromide
+
 /obj/machinery/sleeper/ascent
 	name = "mantid sleeper"
 	desc = "Some kind of strange alien sleeper technology."
@@ -75,8 +81,8 @@ MANTIDIFY(/obj/machinery/door/airlock/external/bolted, "mantid airlock", "door")
 
 /obj/machinery/sleeper/ascent/Initialize(mapload, d, populate_parts)
 	. = ..()
-	base_chemicals["Crystalizing Agent"] = /datum/reagent/crystal
-	base_chemicals["Bromide"] = /datum/reagent/toxin/bromide
+	add_reagent_canister(null, new /obj/item/chems/chem_disp_cartridge/ascent/crystal()) 
+	add_reagent_canister(null, new /obj/item/chems/chem_disp_cartridge/ascent/bromide())
 
 /obj/machinery/fabricator/ascent
 	name = "\improper Ascent nanofabricator"

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -264,6 +264,25 @@
 			print_reagent_default_message = FALSE
 			. += "<span class='scan_warning'>Warning: Unknown substance[(unknown>1)?"s":""] detected in subject's blood.</span>"
 
+	if(H.touching.total_volume)
+		var/unknown = 0
+		var/reagentdata[0]
+		for(var/A in H.touching.reagent_list)
+			var/datum/reagent/R = A
+			if(R.scannable)
+				print_reagent_default_message = FALSE
+				reagentdata[R.type] = "<span class='scan_notice'>[round(H.reagents.get_reagent_amount(R.type), 1)]u [R.name]</span>"
+			else
+				unknown++
+		if(reagentdata.len)
+			print_reagent_default_message = FALSE
+			. += "<span class='scan_notice'>Beneficial reagents detected on subject's body:</span>"
+			for(var/d in reagentdata)
+				. += reagentdata[d]
+		if(unknown)
+			print_reagent_default_message = FALSE
+			. += "<span class='scan_warning'>Warning: Unknown substance[(unknown>1)?"s":""] detected on subject's body.</span>"
+
 	var/datum/reagents/ingested = H.get_ingested_reagents()
 	if(ingested && ingested.total_volume)
 		var/unknown = 0

--- a/code/modules/mechs/equipment/medical.dm
+++ b/code/modules/mechs/equipment/medical.dm
@@ -52,10 +52,17 @@
 	anchored = 0
 	idle_power_usage = 0
 	active_power_usage = 0 //It'd be hard to handle, so for now all power is consumed by mech sleeper object
-	synth_modifier = 0
 	stasis_power = 0
 	interact_offline = TRUE
 	stat_immune = NOPOWER
+
+/obj/machinery/sleeper/mounted/standard/Initialize(mapload, d, populate_parts)
+	. = ..()
+	add_reagent_canister(null, new /obj/item/chems/chem_disp_cartridge/adrenaline()) 
+	add_reagent_canister(null, new /obj/item/chems/chem_disp_cartridge/sedatives())
+	add_reagent_canister(null, new /obj/item/chems/chem_disp_cartridge/painkillers())
+	add_reagent_canister(null, new /obj/item/chems/chem_disp_cartridge/antitoxins())
+	add_reagent_canister(null, new /obj/item/chems/chem_disp_cartridge/oxy_meds())
 
 /obj/machinery/sleeper/mounted/ui_interact(var/mob/user, var/ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = GLOB.mech_state)
 	. = ..()

--- a/code/modules/reagents/dispenser/cartridge.dm
+++ b/code/modules/reagents/dispenser/cartridge.dm
@@ -1,5 +1,5 @@
 /obj/item/chems/chem_disp_cartridge
-	name = "chemical dispenser cartridge"
+	name = "cartridge"
 	desc = "This goes in a chemical dispenser."
 	icon_state = "cartridge"
 

--- a/maps/antag_spawn/ert/ert_base.dmm
+++ b/maps/antag_spawn/ert/ert_base.dmm
@@ -3288,7 +3288,7 @@
 /turf/simulated/floor/tiled/white,
 /area/map_template/rescue_base/start)
 "gF" = (
-/obj/machinery/sleeper{
+/obj/machinery/sleeper/standard{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -870,7 +870,7 @@
 /turf/simulated/floor/tiled/white,
 /area/map_template/merc_shuttle)
 "bv" = (
-/obj/machinery/sleeper{
+/obj/machinery/sleeper/standard{
 	dir = 1
 	},
 /obj/structure/window/reinforced/crescent{

--- a/maps/antag_spawn/ninja/ninja_base.dmm
+++ b/maps/antag_spawn/ninja/ninja_base.dmm
@@ -495,7 +495,7 @@
 /area/map_template/ninja_dojo/dojo)
 "bf" = (
 /obj/effect/floor_decal/spline/fancy/wood,
-/obj/machinery/sleeper{
+/obj/machinery/sleeper/standard{
 	dir = 4
 	},
 /turf/unsimulated/floor{
@@ -1374,7 +1374,7 @@
 	},
 /area/map_template/ninja_dojo/start)
 "cS" = (
-/obj/machinery/sleeper{
+/obj/machinery/sleeper/standard{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/grey,

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -2078,7 +2078,7 @@
 /turf/simulated/floor/usedup,
 /area/ship/scrap/crew/hallway/starboard)
 "dO" = (
-/obj/machinery/sleeper,
+/obj/machinery/sleeper/standard,
 /obj/structure/sign/warning/nosmoking_2{
 	pixel_y = 28
 	},

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -65,7 +65,7 @@
 /turf/simulated/floor/tiled,
 /area/derelict/ship)
 "ah" = (
-/obj/machinery/sleeper,
+/obj/machinery/sleeper/standard,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -2278,7 +2278,7 @@
 /turf/simulated/wall,
 /area/constructionsite/medical)
 "ho" = (
-/obj/machinery/sleeper,
+/obj/machinery/sleeper/standard,
 /turf/simulated/floor/tiled/white/airless,
 /area/constructionsite/medical)
 "hp" = (

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -4204,7 +4204,7 @@
 /turf/simulated/wall/r_wall,
 /area/errant_pisces/cryo)
 "kk" = (
-/obj/machinery/sleeper{
+/obj/machinery/sleeper/standard{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -4282,7 +4282,7 @@
 /turf/simulated/floor/tiled,
 /area/errant_pisces/cryo)
 "kr" = (
-/obj/machinery/sleeper{
+/obj/machinery/sleeper/standard{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,

--- a/maps/bearcat/bearcat-2.dmm
+++ b/maps/bearcat/bearcat-2.dmm
@@ -1577,7 +1577,7 @@
 /turf/simulated/floor/plating,
 /area/ship/bearcat/crew/hallway/starboard)
 "es" = (
-/obj/machinery/sleeper,
+/obj/machinery/sleeper/standard,
 /obj/structure/sign/warning/nosmoking_2{
 	pixel_y = 28
 	},

--- a/maps/example/example-2.dmm
+++ b/maps/example/example-2.dmm
@@ -108,7 +108,7 @@
 /area/medical/surgery)
 "r" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
-/obj/machinery/sleeper{
+/obj/machinery/sleeper/standard{
 	icon_state = "sleeper_0";
 	dir = 8
 	},

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -233,7 +233,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "aB" = (
-/obj/machinery/sleeper{
+/obj/machinery/sleeper/standard{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
@@ -257,7 +257,7 @@
 /turf/simulated/wall,
 /area/map_template/crashed_pod)
 "aE" = (
-/obj/machinery/sleeper{
+/obj/machinery/sleeper/standard{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/blue,

--- a/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
@@ -431,7 +431,7 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/map_template/oldpod)
 "aZ" = (
-/obj/machinery/sleeper{
+/obj/machinery/sleeper/standard{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -493,7 +493,7 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/map_template/oldpod)
 "bg" = (
-/obj/machinery/sleeper{
+/obj/machinery/sleeper/standard{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -2580,7 +2580,7 @@
 /turf/simulated/floor/carpet,
 /area/map_template/colony/dorms)
 "eY" = (
-/obj/machinery/sleeper{
+/obj/machinery/sleeper/standard{
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{

--- a/nano/templates/sleeper.tmpl
+++ b/nano/templates/sleeper.tmpl
@@ -22,6 +22,8 @@
 				<div class="itemContent">
 				{{:helper.link(data.pump ? "Stomach pump active" : "Stomach pump inactive", null, {'pump' : !data.pump})}}
 				</div>
+			{{else}}
+				There are a few buttons here, but the labels don't make any sense to you.
 			{{/if}}
 			<div class="itemContent">
 				{{:helper.link("Eject occupant", null, {'eject' : 0})}}
@@ -37,22 +39,33 @@
 			Stasis setting:
 		</div>
 		<div class="itemContent">
-			{{:helper.link("Off", null,  {'stasis' : 1}, null, data.stasis == 1 ? 'yellowButton' : null)}}
-			{{:helper.link("2x", null,  {'stasis' : 2}, null, data.stasis == 2 ? 'yellowButton' : null)}}
-			{{:helper.link("5x", null,  {'stasis' : 5}, null, data.stasis == 5 ? 'yellowButton' : null)}}
-			{{:helper.link("10x", null,  {'stasis' : 10}, null, data.stasis == 10 ? 'yellowButton' : null)}}
+			{{:helper.link("Off", null, {'stasis' : 1},  null, data.stasis == 1  ? 'yellowButton' : null)}}
+			{{:helper.link("2x",  null, {'stasis' : 2},  null, data.stasis == 2  ? 'yellowButton' : null)}}
+			{{:helper.link("5x",  null, {'stasis' : 5},  null, data.stasis == 5  ? 'yellowButton' : null)}}
+			{{:helper.link("10x", null, {'stasis' : 10}, null, data.stasis == 10 ? 'yellowButton' : null)}}
 		</div>
 	</div>
 	<div class="item">
 	{{for data.reagents}}
 		<div class="itemLabel">
-		{{:value.name}}
+			{{:value.name}} ({{:value.amount}}u)
 		</div>
 		<div class="itemContent">
-			{{if data.occupant}}Occupant: {{:value.amount}} units{{/if}}
-			{{:helper.link('Inject 5', null, {'chemical' : value.name, 'amount' : 5}, data.occupant ? null : 'disabled')}}{{:helper.link('Inject 10', null, {'chemical' : value.name, 'amount' : 10}, data.occupant ? null : 'disabled')}}
+			{{:helper.link('Inject 5',  null, {'chemical' : value.id, 'amount' : 5},  data.occupant ? null : 'disabled')}}
+			{{:helper.link('Inject 10', null, {'chemical' : value.id, 'amount' : 10}, data.occupant ? null : 'disabled')}}
+			{{:helper.link('Spray 5',   null, {'chemical' : value.id, 'amount' : 5,   'contact_chem' : 1}, data.occupant ? null : 'disabled')}}
+			{{:helper.link('Spray 10',  null, {'chemical' : value.id, 'amount' : 10,  'contact_chem' : 1}, data.occupant ? null : 'disabled')}}
+			{{:helper.link('Eject Canister', null, {'chemical' : value.id, 'eject_canister' : 1}, null)}}
 		</div>
 	{{/for}}
+	{{if data.empty_canisters > 0}}
+		<div class="itemLabel">
+			{{:data.empty_canisters}} empty canisters
+		</div>
+		<div class="itemContent">
+			{{:helper.link('Eject', null, {'eject_empties' : 1}, null)}}
+		</div>
+	{{/if}}
 	</div>
 	{{if data.beaker != -1}}
 		<div class="item">


### PR DESCRIPTION
https://user-images.githubusercontent.com/2468979/77420373-075f9400-6e1e-11ea-959b-33f3eee66975.png
https://user-images.githubusercontent.com/2468979/77420674-97054280-6e1e-11ea-953c-35ab295a7ded.png

- Sleepers can now be loaded/unloaded with reagent canisters. This replaces the magic chemical synthesis.
- Sleepers can now spray contact reagents as well as inject them.
- Emagging a sleeper now allows you to insert dangerous reagents into the sleeper injector.
- Sleepers now use the old cryotube icon.
- Medical scan data now includes contact reagents.
