### PR TITLE
Makes default bashing only occur on non-help intents.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -34,11 +34,15 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	return
 
 /atom/movable/attackby(obj/item/W, mob/user)
-	bash(W,user)
+	return bash(W,user)
 
 /atom/movable/proc/bash(obj/item/W, mob/user)
-	if(!(W.item_flags & ITEM_FLAG_NO_BLUDGEON))
-		visible_message("<span class='danger'>[src] has been hit by [user] with [W].</span>")
+	if(isliving(user) && user.a_intent == I_HELP)
+		return FALSE
+	if(W.item_flags & ITEM_FLAG_NO_BLUDGEON)
+		return FALSE
+	visible_message("<span class='danger'>[src] has been hit by [user] with [W].</span>")
+	return TRUE
 
 /mob/living/attackby(obj/item/I, mob/user)
 	if(!ismob(user))


### PR DESCRIPTION
I feel this is better design, and it makes developing interaction code better as it's more reasonable to call parent in attackby now.