### PR TITLE
Geological sampling small cleanup

### DIFF
--- a/code/controllers/subsystems/xenoarch.dm
+++ b/code/controllers/subsystems/xenoarch.dm
@@ -29,9 +29,6 @@ SUBSYSTEM_DEF(xenoarch)
 		if(!M.density)
 			continue
 
-		if(isnull(M.geologic_data))
-			M.geologic_data = new /datum/geosample(M)
-
 		if(!prob(XENOARCH_SPAWN_CHANCE))
 			continue
 

--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -57,6 +57,9 @@
 	"You hear a rustle as someone puts something into a plastic bag.")
 	if(!user.skill_check(SKILL_FORENSICS, SKILL_BASIC))
 		I.add_fingerprint(user)
+	store_item(I)
+
+/obj/item/evidencebag/proc/store_item(obj/item/I)
 	I.forceMove(src)
 	stored_item = I
 	w_class = I.w_class

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -159,7 +159,6 @@ var/list/mining_floors = list()
 		return
 
 	if (istype(W, /obj/item/core_sampler))
-		geologic_data.UpdateNearbyArtifactInfo(src)
 		var/obj/item/core_sampler/C = W
 		C.sample_item(src, user)
 		return TRUE
@@ -276,11 +275,16 @@ var/list/mining_floors = list()
 			while(next_rock > 50)
 				next_rock -= 50
 				var/obj/item/ore/O = new(src)
-				geologic_data.UpdateNearbyArtifactInfo(src)
-				O.geologic_data = geologic_data
+				O.geologic_data = get_geodata()
 
 	else
 		return ..()
+
+/turf/simulated/mineral/proc/get_geodata()
+	if(!geologic_data)
+		geologic_data = new /datum/geosample(src)
+	geologic_data.UpdateNearbyArtifactInfo(src)
+	return geologic_data
 
 /turf/simulated/mineral/proc/clear_ore_effects()
 	overlays -= ore_overlay
@@ -292,9 +296,8 @@ var/list/mining_floors = list()
 
 	clear_ore_effects()
 	var/obj/item/ore/O = new(src, mineral.type)
-	if(geologic_data && istype(O))
-		geologic_data.UpdateNearbyArtifactInfo(src)
-		O.geologic_data = geologic_data
+	if(istype(O))
+		O.geologic_data = get_geodata()
 	return O
 
 /turf/simulated/mineral/proc/GetDrilled(var/artifact_fail = 0)
@@ -347,8 +350,7 @@ var/list/mining_floors = list()
 		new find(src)
 	else
 		var/obj/item/ore/strangerock/rock = new(src, F.find_type)
-		geologic_data.UpdateNearbyArtifactInfo(src)
-		rock.geologic_data = geologic_data
+		rock.geologic_data = get_geodata()
 
 	finds.Remove(F)
 

--- a/code/modules/xenoarcheaology/boulder.dm
+++ b/code/modules/xenoarcheaology/boulder.dm
@@ -7,7 +7,7 @@
 	opacity = 1
 	anchored = 1
 	var/excavation_level = 0
-	var/datum/geosample/geological_data
+	var/datum/geosample/geologic_data
 	var/datum/artifact_find/artifact_find
 	var/last_act = 0
 
@@ -17,14 +17,14 @@
 	excavation_level = rand(5, 50)
 
 /obj/structure/boulder/Destroy()
-	QDEL_NULL(geological_data)
+	QDEL_NULL(geologic_data)
 	QDEL_NULL(artifact_find)
 	..()
 
 /obj/structure/boulder/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/core_sampler))
-		src.geological_data.artifact_distance = rand(-100,100) / 100
-		src.geological_data.artifact_id = artifact_find.artifact_id
+		src.geologic_data.artifact_distance = rand(-100,100) / 100
+		src.geologic_data.artifact_id = artifact_find.artifact_id
 
 		var/obj/item/core_sampler/C = I
 		C.sample_item(src, user)

--- a/code/modules/xenoarcheaology/tools/geosample_scanner.dm
+++ b/code/modules/xenoarcheaology/tools/geosample_scanner.dm
@@ -280,8 +280,8 @@
 
 		if(/obj/item/rocksliver)
 			var/obj/item/rocksliver/O = scanned_item
-			if(O.geological_data)
-				G = O.geological_data
+			if(O.geologic_data)
+				G = O.geologic_data
 
 		if(/obj/item/archaeological_find)
 			data += " - Mundane object (archaic xenos origins)<br>"


### PR DESCRIPTION
Made geodata lazy-init on mineral turfs instead of xenoarch controller spawning a datum for each turf in the world on init.
Renamed all occurances of geological to geologic (in regards to geosamples) because searching was hell.
Removed limited sample bags thing from sampler, it was only complicating code and why was it even a thing.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->