### PR TITLE
Fixes all-terrain wheelchairs

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -27,6 +27,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define MOVABLE_FLAG_Z_INTERACT           0x0002 // Should attackby and attack_hand be relayed through ladders and open spaces?
 #define MOVABLE_FLAG_EFFECTMOVE           0x0004 // Is this an effect that should move?
 #define MOVABLE_FLAG_DEL_SHUTTLE          0x0008 // Shuttle transistion will delete this.
+#define MOVABLE_FLAG_NONDENSE_COLLISION   0x0010 // Used for non-dense movables that should be capable of colliding when attempting to move onto dense atoms
 
 #define OBJ_FLAG_ANCHORABLE               0x0001 // This object can be stuck in place with a tool
 #define OBJ_FLAG_CONDUCTIBLE              0x0002 // Conducts electricity. (metal etc.)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -239,4 +239,4 @@
 	. = ..()
 
 /atom/movable/CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-	. = ..() || (mover && !mover.density)
+	. = ..() || (mover && !(mover.movable_flags & MOVABLE_FLAG_NONDENSE_COLLISION) && !mover.density)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -106,3 +106,5 @@
 		add_fingerprint(user)
 	return M
 
+/obj/CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+	. = ..() || (buckled_mob == mover)

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -5,6 +5,7 @@
 	anchored = 0
 	buckle_movable = 1
 	movement_handlers = list(/datum/movement_handler/delay = list(2), /datum/movement_handler/move_relay_self)
+	movable_flags = MOVABLE_FLAG_NONDENSE_COLLISION
 	var/driving = 0
 	var/bloodiness
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -6,7 +6,7 @@
 		return TRUE // Doesn't necessarily mean the mob physically moved
 
 /mob/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	. = lying || ..()
+	. = lying || ..() || (mover == buckled)
 
 /mob/proc/SetMoveCooldown(var/timeout)
 	var/datum/movement_handler/mob/delay/delay = GetMovementHandler(/datum/movement_handler/mob/delay)


### PR DESCRIPTION
Fixes #235 
This PR does exactly as it suggests on the tin. It fixes the bug where wheelchairs are able to pass through machinery and other dense objects that don't override canpass(). This is done by introducing the `MOVABLE_FLAG_NONDENSE_COLLISION` movable flag (by default, non-dense movers can pass through all dense movables, such as machinery. this flag disables that behavior) and adding buckle checks to the canpass() procs of /mob and /obj (this prevents wheelchairs from colliding with the mob that's buckled to it and vice-versa).