### PR TITLE
Reagent-driven fluids.

### DIFF
--- a/code/__defines/fluids.dm
+++ b/code/__defines/fluids.dm
@@ -13,15 +13,6 @@
 #define ADD_ACTIVE_FLUID(F)           SSfluids.active_fluids[F] = TRUE
 #define REMOVE_ACTIVE_FLUID(F)        SSfluids.active_fluids -= F
 
-// Expects /obj/effect/fluid for F, int for amt.
-#define LOSE_FLUID(F, AMT) \
-	F.fluid_amount = max(-1, F.fluid_amount - AMT); \
-	ADD_ACTIVE_FLUID(F);
-
-#define SET_FLUID_DEPTH(F, AMT) \
-	F.fluid_amount = min(FLUID_MAX_DEPTH, AMT); \
-	ADD_ACTIVE_FLUID(F);
-
 // Expects turf for T,
 #define UPDATE_FLUID_BLOCKED_DIRS(T) \
 	if(isnull(T.fluid_blocked_dirs)) {\

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -281,7 +281,7 @@ its easier to just keep the beam vertical.
 /atom/proc/on_update_icon()
 	return
 
-/atom/proc/ex_act()
+/atom/proc/ex_act(var/severity)
 	return
 
 /atom/proc/emag_act(var/remaining_charges, var/mob/user, var/emag_source)

--- a/code/game/atoms_fluids.dm
+++ b/code/game/atoms_fluids.dm
@@ -1,8 +1,10 @@
 /atom/proc/is_flooded(var/lying_mob, var/absolute)
 	return
 
-/atom/proc/water_act(var/depth)
-	clean_blood()
+/atom/proc/fluid_act(var/datum/reagents/fluids)
+	if(reagents && fluids.total_volume >= FLUID_SHALLOW && ATOM_IS_OPEN_CONTAINER(src))
+		reagents.trans_to_holder(fluids, reagents.total_volume)
+		fluids.trans_to_holder(reagents, min(fluids.total_volume, reagents.maximum_volume))
 
 /atom/proc/return_fluid()
 	return null

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -417,9 +417,9 @@ Class Procs:
 		to_chat(user, "\The [src] is missing [english_list(parts)], rendering it inoperable.")
 
 // This is really pretty crap and should be overridden for specific machines.
-/obj/machinery/water_act(var/depth)
+/obj/machinery/fluid_act(var/datum/reagents/fluids)
 	..()
-	if(!(stat & (NOPOWER|BROKEN)) && !waterproof && (depth > FLUID_DEEP))
+	if(!(stat & (NOPOWER|BROKEN)) && !waterproof && (fluids.total_volume > FLUID_DEEP))
 		ex_act(3)
 
 /obj/machinery/Move()

--- a/code/game/machinery/cracker.dm
+++ b/code/game/machinery/cracker.dm
@@ -51,8 +51,8 @@
 		if(istype(F))
 
 			// Drink more water!
-			var/consuming = min(F.fluid_amount, fluid_consumption_per_tick)
-			LOSE_FLUID(F, consuming)
+			var/consuming = min(F.reagents.total_volume, fluid_consumption_per_tick)
+			F.reagents.remove_any(consuming)
 			T.show_bubbles()
 
 			// Gas production.

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -34,10 +34,6 @@
 	SSpersistence.forget_value(src, /datum/persistent/filth)
 	. = ..()
 
-/obj/effect/decal/cleanable/water_act(var/depth)
-	..()
-	qdel(src)
-
 /obj/effect/decal/cleanable/clean_blood(var/ignore = 0)
 	if(!ignore)
 		qdel(src)
@@ -47,3 +43,7 @@
 /obj/effect/decal/cleanable/proc/set_cleanable_scent()
 	if(cleanable_scent)
 		set_extension(src, /datum/extension/scent/custom, cleanable_scent, scent_intensity, scent_descriptor, scent_range)
+
+/obj/effect/decal/cleanable/fluid_act(var/datum/reagents/fluid)
+	reagents?.trans_to(fluid, reagents.total_volume)
+	qdel(src)

--- a/code/game/objects/effects/fluids.dm
+++ b/code/game/objects/effects/fluids.dm
@@ -9,9 +9,9 @@
 	alpha = 0
 	color = COLOR_OCEAN
 
-	var/fluid_amount = 0
 	var/list/neighbors = list()
 	var/last_flow_strength = 0
+	var/next_fluid_act = 0
 
 /obj/effect/fluid/ex_act()
 	return
@@ -23,12 +23,21 @@
 	crash_with("A fluid overlay had Move() called!")
 	return FALSE
 
+/obj/effect/fluid/on_reagent_change()
+	. = ..()
+	ADD_ACTIVE_FLUID(src)
+	queue_icon_update()
+
 /obj/effect/fluid/Initialize()
+	START_PROCESSING(SSobj, src)
+	atom_flags |= ATOM_FLAG_OPEN_CONTAINER
+	create_reagents(FLUID_MAX_DEPTH)
 	. = ..()
 	var/turf/simulated/T = get_turf(src)
-	if(!istype(T) || T.flooded)
+	if(!isturf(T) || T.flooded)
 		return INITIALIZE_HINT_QDEL
-	T.unwet_floor(FALSE)
+	if(istype(T))
+		T.unwet_floor(FALSE)
 	for(var/checkdir in GLOB.cardinal)
 		var/obj/effect/fluid/F = locate() in get_step(src, checkdir)
 		if(F)
@@ -38,6 +47,7 @@
 	ADD_ACTIVE_FLUID(src)
 
 /obj/effect/fluid/Destroy()
+	STOP_PROCESSING(SSobj, src)
 	var/turf/simulated/T = loc
 	if(istype(T))
 		T.wet_floor()
@@ -49,27 +59,48 @@
 	REMOVE_ACTIVE_FLUID(src)
 	. = ..()
 
+/obj/effect/fluid/Process()
+	if(reagents.total_volume <= FLUID_EVAPORATION_POINT)
+		qdel(src)
+		return
+	if(world.time < next_fluid_act)
+		return
+	next_fluid_act = world.time + SSfluids.fluid_act_delay
+	if(prob(1))
+		playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
+	if(length(loc.contents) > 1 && reagents.total_volume > FLUID_SHALLOW)
+		for(var/thing in loc.contents)
+			if(thing == src)
+				continue
+			var/atom/movable/AM = thing
+			if(AM.simulated && !AM.waterproof)
+				AM.fluid_act(reagents)
+			if(last_flow_strength >= 10 && AM.is_fluid_pushable(last_flow_strength))
+				step(AM, dir)
+
 /obj/effect/fluid/on_update_icon()
 
 	overlays.Cut()
 
-	if(fluid_amount > FLUID_OVER_MOB_HEAD)
+	if(reagents.total_volume > FLUID_OVER_MOB_HEAD)
 		layer = DEEP_FLUID_LAYER
 	else
 		layer = SHALLOW_FLUID_LAYER
 
-	if(fluid_amount > FLUID_DEEP)
+	color = reagents.get_color()
+
+	if(reagents.total_volume > FLUID_DEEP)
 		alpha = FLUID_MAX_ALPHA
 	else
-		alpha = min(FLUID_MAX_ALPHA,max(FLUID_MIN_ALPHA,ceil(255*(fluid_amount/FLUID_DEEP))))
+		alpha = min(FLUID_MAX_ALPHA,max(FLUID_MIN_ALPHA,ceil(255*(reagents.total_volume/FLUID_DEEP))))
 
-	if(fluid_amount <= FLUID_EVAPORATION_POINT)
+	if(reagents.total_volume <= FLUID_EVAPORATION_POINT)
 		APPLY_FLUID_OVERLAY("shallow_still")
-	else if(fluid_amount > FLUID_EVAPORATION_POINT && fluid_amount < FLUID_SHALLOW)
+	else if(reagents.total_volume > FLUID_EVAPORATION_POINT && reagents.total_volume < FLUID_SHALLOW)
 		APPLY_FLUID_OVERLAY("mid_still")
-	else if(fluid_amount >= FLUID_SHALLOW && fluid_amount < (FLUID_DEEP*2))
+	else if(reagents.total_volume >= FLUID_SHALLOW && reagents.total_volume < (FLUID_DEEP*2))
 		APPLY_FLUID_OVERLAY("deep_still")
-	else if(fluid_amount >= (FLUID_DEEP*2))
+	else if(reagents.total_volume >= (FLUID_DEEP*2))
 		APPLY_FLUID_OVERLAY("ocean")
 
 // Map helper.
@@ -79,7 +110,8 @@
 	icon_state = "shallow_still"
 	color = COLOR_OCEAN
 
-	var/fluid_amount = FLUID_MAX_DEPTH
+	var/fluid_type = /decl/reagent/water
+	var/fluid_initial = FLUID_MAX_DEPTH
 
 /obj/effect/fluid_mapped/Initialize()
 	..()
@@ -87,7 +119,7 @@
 	if(istype(T))
 		var/obj/effect/fluid/F = locate() in T
 		if(!F) F = new(T)
-		SET_FLUID_DEPTH(F, fluid_amount)
+		F.reagents.add_reagent(fluid_type, fluid_initial)
 	return INITIALIZE_HINT_QDEL
 
 // Permaflood overlay.

--- a/code/game/objects/items/weapons/flame.dm
+++ b/code/game/objects/items/weapons/flame.dm
@@ -13,11 +13,10 @@
 	damtype = "brute"
 	STOP_PROCESSING(SSobj, src)
 
-/obj/item/flame/water_act(var/depth)
+/obj/item/flame/fluid_act(var/datum/reagents/fluids)
 	..()
 	if(!waterproof && lit)
-		if(submerged(depth))
-			extinguish(no_message = TRUE)
+		extinguish(no_message = TRUE)
 
 /proc/isflamesource(var/atom/A)
 	if(!istype(A))

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -31,13 +31,13 @@
 	if(istype(A, /turf))
 		var/turf/T = A
 		var/obj/effect/fluid/F = locate() in T
-		if(F && F.fluid_amount > 0)
-			if(F.fluid_amount > FLUID_SHALLOW)
+		if(F && F.reagents.total_volume > 0)
+			if(F.reagents.total_volume > FLUID_SHALLOW)
 				to_chat(user, SPAN_WARNING("There is too much water here to be mopped up."))
 			else
 				user.visible_message("<span class='notice'>\The [user] begins to mop up \the [T].</span>")
 				if(do_after(user, 40, T) && F && !QDELETED(F))
-					if(F.fluid_amount > FLUID_SHALLOW)
+					if(F.reagents.total_volume > FLUID_SHALLOW)
 						to_chat(user, SPAN_WARNING("There is too much water here to be mopped up."))
 					else
 						qdel(F)

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -122,7 +122,8 @@
 	else
 		..()
 
-/obj/item/weldingtool/water_act()
+/obj/item/weldingtool/fluid_act(var/datum/reagents/fluids)
+	..()
 	if(welding && !waterproof)
 		setWelding(0)
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -196,3 +196,8 @@
 
 /obj/get_mass()
 	return min(2^(w_class-1), 100)
+
+/obj/fluid_act(var/datum/reagents/fluids)
+	fluids.touch_obj(src)
+	if(fluids.total_volume > 0)
+		..()

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -68,14 +68,15 @@
 	if(flood_amt)
 		var/turf/T = loc
 		if(istype(T))
-			var/obj/effect/fluid/F = locate() in T
-			if(!F) F = new(loc)
 			T.show_bubbles()
 			if(world.time > next_gurgle)
 				visible_message("\The [src] gurgles and overflows!")
 				next_gurgle = world.time + 80
 				playsound(T, pick(SSfluids.gurgles), 50, 1)
-			SET_FLUID_DEPTH(F, min(F.fluid_amount + (rand(30,50)*clogged), flood_amt))
+			var/obj/effect/fluid/F = locate() in T
+			var/adding = min(flood_amt-F?.reagents.total_volume, rand(30,50)*clogged)
+			if(adding)
+				T.add_fluid(adding, /decl/reagent/water)
 
 /obj/structure/hygiene/proc/drain()
 	if(!can_drain) return

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -9,15 +9,16 @@
 				break
 	return fluid_can_pass
 
-/turf/proc/add_fluid(var/amount, var/fluid)
+/turf/proc/add_fluid(var/amount, var/fluid = /decl/reagent/water)
 	if(!flooded)
 		var/obj/effect/fluid/F = locate() in src
 		if(!F) F = new(src)
-		SET_FLUID_DEPTH(F, F.fluid_amount + amount)
+		F.reagents.add_reagent(fluid, amount)
 
 /turf/proc/remove_fluid(var/amount = 0)
 	var/obj/effect/fluid/F = locate() in src
-	if(F) LOSE_FLUID(F, amount)
+	if(F)
+		F.reagents.remove_any(amount)
 
 /turf/return_fluid()
 	return (locate(/obj/effect/fluid) in contents)
@@ -41,7 +42,7 @@
 		return FLUID_MAX_DEPTH
 	var/obj/effect/fluid/F = return_fluid()
 	if(istype(F))
-		return F.fluid_amount
+		return F.reagents.total_volume
 	var/obj/structure/glass_tank/aquarium = locate() in contents
 	if(aquarium && aquarium.reagents && aquarium.reagents.total_volume)
 		return aquarium.reagents.total_volume * TANK_WATER_MULTIPLIER

--- a/code/modules/admin/verbs/fluids.dm
+++ b/code/modules/admin/verbs/fluids.dm
@@ -1,14 +1,24 @@
 /datum/admins/proc/spawn_fluid_verb()
-	set name = "Spawn Water"
+	set name = "Spawn Fluid"
 	set desc = "Flood the turf you are standing on."
 	set category = "Debug"
 
-	if(!check_rights(R_SPAWN)) return
+	if(!check_rights(R_SPAWN)) 
+		return
+
 	var/mob/user = usr
-	if(istype(user) && user.client)
-		for(var/thing in trange(1, get_turf(user)))
-			var/turf/T = thing
-			T.add_fluid(2000, /decl/reagent/water)
+	if(!istype(user) || !user.client)
+		return
+	var/spawn_range = input("How wide a radius?", "Spawn Fluid", 0) as num|null
+	var/reagent_amount = input("How deep?", "Spawn Fluid", 1000) as num|null
+	if(!reagent_amount)
+		return
+	var/reagent_type = input("What kind of reagent?", "Spawn Fluid", /decl/reagent/water) as null|anything in subtypesof(/decl/reagent)
+	if(!reagent_type || !user || !check_rights(R_SPAWN))
+		return
+	for(var/thing in trange(spawn_range, get_turf(user)))
+		var/turf/T = thing
+		T.add_fluid(reagent_amount, reagent_type)
 
 /datum/admins/proc/jump_to_fluid_source()
 

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -77,11 +77,10 @@
 		M.update_inv_l_hand(0)
 		M.update_inv_r_hand(1)
 
-/obj/item/clothing/mask/smokable/water_act(var/depth)
+/obj/item/clothing/mask/smokable/fluid_act(var/datum/reagents/fluids)
 	..()
 	if(!waterproof && lit)
-		if(submerged(depth))
-			extinguish(no_message = TRUE)
+		extinguish(no_message = TRUE)
 
 /obj/item/clothing/mask/smokable/proc/light(var/flavor_text = "[usr] lights the [name].")
 	if(QDELETED(src))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -505,3 +505,10 @@
 
 /mob/living/carbon/has_dexterity(var/dex_level)
 	. = ..() && (species.get_manual_dexterity() >= dex_level)
+
+/mob/living/carbon/fluid_act(var/datum/reagents/fluids)
+	var/saturation =  min(fluids.total_volume, round(mob_size * 1.5 * reagent_permeability()) - touching.total_volume)
+	if(saturation > 0)
+		fluids.trans_to_holder(touching, saturation)
+	if(fluids.total_volume)
+		..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1723,9 +1723,9 @@
 			T.show_bubbles()
 	return breath
 
-/mob/living/carbon/human/water_act(var/depth)
-	species.water_act(src, depth)
-	..(depth)
+/mob/living/carbon/human/fluid_act(var/datum/reagents/fluids)
+	species.fluid_act(src, fluids)
+	..()
 
 /mob/living/carbon/human/proc/set_cultural_value(var/token, var/decl/cultural_info/_culture, var/defer_language_update)
 	if(!istype(_culture))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -767,14 +767,17 @@ default behaviour is:
 	T.show_bubbles()
 	return TRUE // Presumably chemical smoke can't be breathed while you're underwater.
 
-/mob/living/water_act(var/depth)
+/mob/fluid_act(var/datum/reagents/fluids)
 	..()
 	wash_mob(src)
+
+/mob/living/fluid_act(var/datum/reagents/fluids)
+	..()
 	for(var/thing in get_equipped_items(TRUE))
 		if(isnull(thing)) continue
 		var/atom/movable/A = thing
 		if(A.simulated && !A.waterproof)
-			A.water_act(depth)
+			A.fluid_act(fluids)
 
 /mob/living/proc/nervous_system_failure()
 	return FALSE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1049,6 +1049,10 @@
 /mob/proc/check_has_eyes()
 	return TRUE
 
+/mob/fluid_act(var/datum/reagents/fluids)
+	fluids.touch_mob(src)
+	..()
+
 /mob/proc/handle_pre_transformation()
 	return
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -7,6 +7,7 @@ GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
 	var/total_volume = 0
 	var/maximum_volume = 120
 	var/atom/my_atom
+	var/cached_color
 
 /datum/reagents/New(var/maximum_volume = 120, var/atom/my_atom)
 	if(!istype(my_atom))
@@ -31,6 +32,7 @@ GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
 	. = primary_reagent && decls_repository.get_decl(primary_reagent)
 
 /datum/reagents/proc/update_total() // Updates volume.
+	cached_color = null
 	total_volume = 0
 	primary_reagent = null
 	for(var/R in reagent_volumes)

--- a/code/modules/reagents/chems/chems_water.dm
+++ b/code/modules/reagents/chems/chems_water.dm
@@ -3,7 +3,7 @@
 /decl/reagent/water
 	name = "water"
 	description = "A ubiquitous chemical substance composed of hydrogen and oxygen."
-	color = "#0064c8"
+	color = COLOR_OCEAN
 	scannable = 1
 	metabolism = REM * 10
 	taste_description = "water"

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -212,7 +212,7 @@
 	else if((loc == user) && user.skill_check(SKILL_CHEMISTRY, SKILL_EXPERT))
 		to_chat(user, "<span class='notice'>Using your chemistry knowledge, you identify the following reagents in \the [src]: [reagents.get_reagents(!user.skill_check(SKILL_CHEMISTRY, SKILL_PROF), 5)].</span>")
 
-/obj/item/chems/ex_act(severity)
+/obj/item/chems/ex_act(var/severity)
 	if(reagents)
 		for(var/rtype in reagents.reagent_volumes)
 			var/decl/reagent/R = decls_repository.get_decl(rtype)

--- a/code/modules/species/species_helpers.dm
+++ b/code/modules/species/species_helpers.dm
@@ -36,12 +36,12 @@ var/list/stored_shock_by_ref = list()
 		return I
 	return overlay_image(mob_icon, mob_state, color, RESET_COLOR)
 
-/datum/species/proc/water_act(var/mob/living/carbon/human/H, var/depth)
-	if(!isnull(water_soothe_amount) && depth >= 40)
-		if(H.getHalLoss())
-			H.adjustHalLoss(-(water_soothe_amount))
-			if(prob(5))
-				to_chat(H, "<span class='notice'>The water ripples gently over your skin in a soothing balm.</span>")
+/datum/species/proc/fluid_act(var/mob/living/carbon/human/H, var/datum/reagents/fluids)
+	var/water = REAGENT_VOLUME(fluids, /decl/reagent/water)
+	if(water >= 40 && H.getHalLoss())
+		H.adjustHalLoss(-(water_soothe_amount))
+		if(prob(5))
+			to_chat(H, SPAN_NOTICE("The water ripples gently over your skin in a soothing balm."))
 
 /datum/species/proc/is_available_for_join()
 	if(!(spawn_flags & SPECIES_CAN_JOIN))


### PR DESCRIPTION
This is absurdly costly currently but is otherwise working pretty well.
- Fluids are now driven by a reagent holder in each overlay.
- Fluids will not spread on exoplanet turfs.
- `water_act()` is now `fluid_act()`.
- Fluid pushing and reagent transfer has been moved to `SSobjs`.
- Fluids will call `touch_obj()`, `touch_mob()` and transfer to `touching` in `fluid_act()`.