### PR TITLE
Removes forced initial 48x48 client size.

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -229,8 +229,6 @@
 	if(holder)
 		src.control_freak = 0 //Devs need 0 for profiler access
 
-	SetWindowIconSize(48)
-
 	//////////////
 	//DISCONNECT//
 	//////////////


### PR DESCRIPTION
This causes a desync between client skin settings (which box is ticked) and the actual client icon size.