### PR TITLE
Autopsy tweaks and refactor

### DIFF
--- a/code/datums/supplypacks/medical.dm
+++ b/code/datums/supplypacks/medical.dm
@@ -232,7 +232,7 @@
 	contains = list(/obj/item/folder/white,
 					/obj/item/camera,
 					/obj/item/camera_film = 2,
-					/obj/item/autopsy_scanner,
+					/obj/item/scanner/autopsy,
 					/obj/item/scalpel,
 					/obj/item/storage/box/masks,
 					/obj/item/storage/box/gloves,

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -178,22 +178,8 @@
 				qdel(src)
 
 /obj/item/examine(mob/user, distance)
-	var/size
-	switch(src.w_class)
-		if(ITEM_SIZE_TINY)
-			size = "tiny"
-		if(ITEM_SIZE_SMALL)
-			size = "small"
-		if(ITEM_SIZE_NORMAL)
-			size = "normal-sized"
-		if(ITEM_SIZE_LARGE)
-			size = "large"
-		if(ITEM_SIZE_HUGE)
-			size = "bulky"
-		if(ITEM_SIZE_HUGE + 1 to INFINITY)
-			size = "huge"
 	var/desc_comp = "" //For "description composite"
-	desc_comp += "It is a [size] item."
+	desc_comp += "It is a [w_class_description()] item."
 
 	var/list/available_recipes = list()
 	for(var/decl/crafting_stage/initial_stage in SSfabrication.find_crafting_recipes(type))
@@ -953,3 +939,31 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 /obj/item/proc/is_special_cutting_tool(var/high_power)
 	return FALSE
+
+/obj/item/proc/w_class_description()
+	switch(w_class)
+		if(ITEM_SIZE_TINY)
+			return "tiny"
+		if(ITEM_SIZE_SMALL)
+			return "small"
+		if(ITEM_SIZE_NORMAL)
+			return "normal-sized"
+		if(ITEM_SIZE_LARGE)
+			return "large"
+		if(ITEM_SIZE_HUGE)
+			return "bulky"
+		if(ITEM_SIZE_HUGE + 1 to INFINITY)
+			return "huge"
+
+/obj/item/proc/get_autopsy_descriptors()
+	var/list/descriptors = list()
+	descriptors += w_class_description()
+	if(sharp)
+		descriptors += "sharp"
+	if(edge)
+		descriptors += "edged"
+	if(force >= 10 && !sharp && !edge)
+		descriptors += "heavy"
+	if(material)
+		descriptors += "made of [material.display_name]"
+	return descriptors

--- a/code/game/objects/items/devices/scanners/_scanner.dm
+++ b/code/game/objects/items/devices/scanners/_scanner.dm
@@ -84,6 +84,7 @@
 	if(!scan_data)
 		to_chat(user, "There is no scan data to print.")
 		return
+	playsound(loc, "sound/machines/dotprinter.ogg", 20, 1)
 	var/obj/item/paper/P = new(get_turf(src), scan_data, "paper - [scan_title]")
 	if(printout_color)
 		P.color = printout_color

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -19,6 +19,10 @@
 	stacktype = /obj/item/stack/material/rods
 	material = MAT_STEEL
 
+/obj/item/stack/material/rods/get_autopsy_descriptors()
+	. = ..()
+	. += "narrow"
+
 /obj/item/stack/material/rods/ten
 	amount = 10
 

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -1,8 +1,7 @@
 
 //moved these here from code/defines/obj/weapon.dm
 //please preference put stuff where it's easy to find - C
-
-/obj/item/autopsy_scanner
+/obj/item/scanner/autopsy
 	name = "autopsy scanner"
 	desc = "Used to gather information on wounds."
 	icon = 'icons/obj/surgery.dmi'
@@ -10,186 +9,116 @@
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	w_class = ITEM_SIZE_SMALL
 	origin_tech = "{'" + TECH_MATERIAL + "':1,'" + TECH_BIO + "':1}"
-	var/list/datum/autopsy_data_scanner/wdata = list()
+	var/list/weapon_data = list()
 	var/list/chemtraces = list()
-	var/target_name = null
-	var/timeofdeath = null
+	var/target_name
+	var/timeofdeath
 
-/datum/autopsy_data_scanner
-	var/weapon = null // this is the DEFINITE weapon type that was used
-	var/list/organs_scanned = list() // this maps a number of scanned organs to
-									 // the wounds to those organs with this data's weapon type
-	var/organ_names = ""
+/obj/item/scanner/autopsy/is_valid_scan_target(atom/O)
+	return ishuman(O) || istype(O, /obj/item/organ/external)
+
+/obj/item/scanner/autopsy/do_surgery(mob/living/carbon/M, mob/living/user, fuckup_prob)
+	if(istype(M))
+		scan(M,user)
+
+/obj/item/scanner/autopsy/scan(atom/A, mob/user)
+	if(ishuman(A))
+		var/mob/living/carbon/human/M = A
+		set_target(M, user)
+		timeofdeath = M.timeofdeath
+		var/obj/item/organ/external/S = M.get_organ(user.zone_sel.selecting)
+		if(!S)
+			visible_message(SPAN_WARNING("[src] states, 'The targeted bodypart is missing.'"))
+			return
+		if(!S.how_open())
+			visible_message(SPAN_WARNING("[src] states, 'The access incision is missing.'"))
+			return
+
+		add_data(S)
+		for(var/T in M.chem_doses)
+			var/datum/reagent/R = T
+			chemtraces |= initial(R.name)
+
+	else if(istype(A, /obj/item/organ/external))
+		set_target(A, user)
+		add_data(A)
+	
+	scan_title = "Autopsy Report ([target_name])" 
+	scan_data = get_formatted_data()
+	playsound(src, 'sound/effects/fastbeep.ogg', 10)
+
+/obj/item/scanner/autopsy/proc/add_data(var/obj/item/organ/external/O)
+	if(!O.autopsy_data.len) return
+
+	for(var/V in O.autopsy_data)
+		var/datum/autopsy_data/W = O.autopsy_data[V]
+		if(!weapon_data[V])
+			weapon_data[V] = list("data" = W.copy(), "organs" = list(O.name))
+		else
+			var/datum/autopsy_data/data = weapon_data[V]["data"]
+			data.merge_with(W)
+			var/list/organs = weapon_data[V]["organs"]
+			organs |= O.name
+
+/obj/item/scanner/autopsy/proc/get_formatted_data()
+	var/list/scan_data = list("Subject: [target_name]")
+
+	if(timeofdeath)
+		scan_data += "<b>Time of death:</b> [worldtime2stationtime(timeofdeath)]<br>"
+
+	var/n = 1
+	for(var/weapon in weapon_data)
+		var/list/organs = weapon_data[weapon]["organs"]
+		var/datum/autopsy_data/data = weapon_data[weapon]["data"]
+		scan_data += "<b>Weapon #[n++]:</b> [data.weapon]"
+		if(data.hits)
+			var/damage_desc
+			switch(data.damage)
+				if(0)
+					damage_desc = "Unknown"
+				if(1 to 5)
+					damage_desc = "<font color='green'>negligible</font>"
+				if(5 to 15)
+					damage_desc = "<font color='green'>light</font>"
+				if(15 to 30)
+					damage_desc = "<font color='orange'>moderate</font>"
+				if(30 to 1000)
+					damage_desc = "<font color='red'>severe</font>"
+			scan_data += "<b>Severity:</b> [damage_desc]"
+			scan_data += "<b>Hits by weapon:</b> [data.hits]"
+		scan_data += "<b>Approximate time of wound infliction:</b> [worldtime2stationtime(data.time_inflicted)]"
+		scan_data += "<b>Affected limbs:</b> [english_list(organs)]"
+		scan_data += ""
+
+	if(chemtraces.len)
+		scan_data += "<b>Trace Chemicals:</b>"
+		for(var/chemID in chemtraces)
+			scan_data += chemID
+	return jointext(scan_data, "<br>")
+
+/obj/item/scanner/autopsy/proc/set_target(atom/new_target, user)
+	if(target_name != new_target.name)
+		target_name = new_target.name
+		weapon_data.Cut()
+		chemtraces.Cut()
+		timeofdeath = null
+		to_chat(user, SPAN_NOTICE("A new patient has been registered. Purging data for previous patient."))
 
 /datum/autopsy_data
 	var/weapon = null
-	var/pretend_weapon = null
 	var/damage = 0
 	var/hits = 0
 	var/time_inflicted = 0
 
 /datum/autopsy_data/proc/copy()
-		var/datum/autopsy_data/W = new()
-		W.weapon = weapon
-		W.pretend_weapon = pretend_weapon
-		W.damage = damage
-		W.hits = hits
-		W.time_inflicted = time_inflicted
-		return W
+	var/datum/autopsy_data/W = new()
+	W.weapon = weapon
+	W.damage = damage
+	W.hits = hits
+	W.time_inflicted = time_inflicted
+	return W
 
-/obj/item/autopsy_scanner/proc/add_data(var/obj/item/organ/external/O)
-	if(!O.autopsy_data.len) return
-
-	for(var/V in O.autopsy_data)
-		var/datum/autopsy_data/W = O.autopsy_data[V]
-
-		if(!W.pretend_weapon)
-			// the more hits, the more likely it is that we get the right weapon type
-			if(prob(50 + W.hits * 10 + W.damage))
-				W.pretend_weapon = W.weapon
-			else
-				W.pretend_weapon = pick("mechanical toolbox", "wirecutters", "revolver", "crowbar", "fire extinguisher", "tomato soup", "oxygen tank", "emergency oxygen tank", "laser", "bullet")
-
-
-		var/datum/autopsy_data_scanner/D = wdata[V]
-		if(!D)
-			D = new()
-			D.weapon = W.weapon
-			wdata[V] = D
-
-		if(!D.organs_scanned[O.name])
-			if(D.organ_names == "")
-				D.organ_names = O.name
-			else
-				D.organ_names += ", [O.name]"
-
-		qdel(D.organs_scanned[O.name])
-		D.organs_scanned[O.name] = W.copy()
-
-/obj/item/autopsy_scanner/verb/print_data()
-	set category = "Object"
-	set src in view(usr, 1)
-	set name = "Print Data"
-	if(usr.stat || !(istype(usr,/mob/living/carbon/human)))
-		to_chat(usr, "No.")
-		return
-
-	var/scan_data = ""
-
-	if(timeofdeath)
-		scan_data += "<b>Time of death:</b> [worldtime2stationtime(timeofdeath)]<br><br>"
-
-	var/n = 1
-	for(var/wdata_idx in wdata)
-		var/datum/autopsy_data_scanner/D = wdata[wdata_idx]
-		var/total_hits = 0
-		var/total_score = 0
-		var/list/weapon_chances = list() // maps weapon names to a score
-		var/age = 0
-
-		for(var/wound_idx in D.organs_scanned)
-			var/datum/autopsy_data/W = D.organs_scanned[wound_idx]
-			total_hits += W.hits
-
-			var/wname = W.pretend_weapon
-
-			if(wname in weapon_chances) weapon_chances[wname] += W.damage
-			else weapon_chances[wname] = max(W.damage, 1)
-			total_score+=W.damage
-
-
-			var/wound_age = W.time_inflicted
-			age = max(age, wound_age)
-
-		var/damage_desc
-
-		var/damaging_weapon = (total_score != 0)
-
-		// total score happens to be the total damage
-		switch(total_score)
-			if(0)
-				damage_desc = "Unknown"
-			if(1 to 5)
-				damage_desc = "<font color='green'>negligible</font>"
-			if(5 to 15)
-				damage_desc = "<font color='green'>light</font>"
-			if(15 to 30)
-				damage_desc = "<font color='orange'>moderate</font>"
-			if(30 to 1000)
-				damage_desc = "<font color='red'>severe</font>"
-
-		if(!total_score) total_score = D.organs_scanned.len
-
-		scan_data += "<b>Weapon #[n]</b><br>"
-		if(damaging_weapon)
-			scan_data += "Severity: [damage_desc]<br>"
-			scan_data += "Hits by weapon: [total_hits]<br>"
-		scan_data += "Approximate time of wound infliction: [worldtime2stationtime(age)]<br>"
-		scan_data += "Affected limbs: [D.organ_names]<br>"
-		scan_data += "Possible weapons:<br>"
-		for(var/weapon_name in weapon_chances)
-			scan_data += "\t[100*weapon_chances[weapon_name]/total_score]% [weapon_name]<br>"
-
-		scan_data += "<br>"
-
-		n++
-
-	if(chemtraces.len)
-		scan_data += "<b>Trace Chemicals: </b><br>"
-		for(var/chemID in chemtraces)
-			scan_data += chemID
-			scan_data += "<br>"
-
-	for(var/mob/O in viewers(usr))
-		O.show_message("<span class='notice'>\The [src] rattles and prints out a sheet of paper.</span>", 1)
-
-	sleep(10)
-
-	var/obj/item/paper/P = new(usr.loc, "<tt>[scan_data]</tt>", "Autopsy Data ([target_name])")
-	if(istype(usr,/mob/living/carbon))
-		// place the item in the usr's hand if possible
-		usr.put_in_hands(P)
-
-/obj/item/autopsy_scanner/do_surgery(mob/living/carbon/human/M, mob/living/user)
-	if(!istype(M))
-		return 0
-
-	set_target(M, user)
-
-	timeofdeath = M.timeofdeath
-
-	var/obj/item/organ/external/S = M.get_organ(user.zone_sel.selecting)
-	if(!S)
-		to_chat(usr, "<span class='warning'>You can't scan this body part.</span>")
-		return
-	if(!S.how_open())
-		to_chat(usr, "<span class='warning'>You have to cut [S] open first!</span>")
-		return
-	M.visible_message("<span class='notice'>\The [user] scans the wounds on [M]'s [S.name] with [src]</span>")
-
-	add_data(S)
-	for(var/T in M.chem_doses)
-		var/datum/reagent/R = T
-		chemtraces |= initial(R.name)
-
-	return 1
-
-/obj/item/autopsy_scanner/proc/set_target(atom/new_target, user)
-	if(target_name != new_target.name)
-		target_name = new_target.name
-		wdata.Cut()
-		chemtraces.Cut()
-		timeofdeath = null
-		to_chat(user, "<span class='notice'>A new patient has been registered. Purging data for previous patient.</span>")
-
-/obj/item/autopsy_scanner/afterattack(obj/item/organ/external/target, mob/user, proximity_flag, click_parameters)
-	if(!proximity_flag)
-		return
-	if(!istype(target))
-		return
-	
-	set_target(target, user)
-	add_data(target)
-
-/obj/item/autopsy_scanner/attack_self(mob/user)
-	print_data(user)
+/datum/autopsy_data/proc/merge_with(var/datum/autopsy_data/other)
+	damage += other.damage
+	hits += other.hits
+	time_inflicted = max(time_inflicted, other.time_inflicted)

--- a/code/game/objects/items/weapons/cane.dm
+++ b/code/game/objects/items/weapons/cane.dm
@@ -12,6 +12,10 @@
 	attack_verb = list("bludgeoned", "whacked", "disciplined", "thrashed")
 	base_parry_chance = 30
 
+/obj/item/cane/get_autopsy_descriptors()
+	. = ..()
+	. += "narrow"
+
 /obj/item/cane/concealed
 	var/concealed_blade
 

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -52,6 +52,10 @@
 	applies_material_colour = FALSE
 	w_class = ITEM_SIZE_NORMAL
 
+/obj/item/material/knife/table/primitive/get_autopsy_descriptors()
+	. = ..()
+	. += "serrated"
+
 //kitchen knives
 /obj/item/material/knife/kitchen
 	name = "kitchen knife"
@@ -81,6 +85,10 @@
 	material_force_multiplier = 0.2
 	w_class = ITEM_SIZE_SMALL
 
+/obj/item/material/knife/combat/get_autopsy_descriptors()
+	. = ..()
+	. += "serrated"
+
 //random stuff
 /obj/item/material/knife/hook
 	name = "meat hook"
@@ -96,6 +104,10 @@
 	icon_state = "render"
 	applies_material_colour = FALSE
 	applies_material_name = FALSE
+
+/obj/item/material/knife/ritual/get_autopsy_descriptors()
+	. = ..()
+	. += "curved"
 
 //Utility knives
 /obj/item/material/knife/utility

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -11,6 +11,11 @@
 	armor_penetration = 50
 	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_NO_BLOOD
 
+/obj/item/melee/energy/get_autopsy_descriptors()
+	. = ..()
+	if(active)
+		. += "made of pure energy"
+
 /obj/item/melee/energy/can_embed()
 	return FALSE
 	

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -140,6 +140,10 @@
 	sharp = 1
 	edge = 1
 
+/obj/item/circular_saw/get_autopsy_descriptors()
+	. = ..()
+	. += "serrated"
+
 //misc, formerly from code/defines/weapons.dm
 /obj/item/bonegel
 	name = "bone gel"

--- a/code/game/objects/items/weapons/tools/crowbar.dm
+++ b/code/game/objects/items/weapons/tools/crowbar.dm
@@ -17,6 +17,10 @@
 	center_of_mass = @"{'x':16,'y':20}"
 	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked")
 
+/obj/item/crowbar/get_autopsy_descriptors()
+	. = ..()
+	. += "narrow"
+
 /obj/item/crowbar/red
 	icon_state = "red_crowbar"
 	item_state = "crowbar_red"

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -299,6 +299,11 @@
 	else
 		return ..()
 
+/obj/item/weldingtool/get_autopsy_descriptors()
+	if(isOn())
+		return list("jet of flame")
+	return ..()
+
 /obj/item/weldingtool/mini
 	tank = /obj/item/welder_tank/mini
 

--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -193,8 +193,12 @@ atom/proc/add_fibers(mob/living/carbon/human/M)
 		return 1 //I'll admit I am just imitating examine.dm
 
 
+	if(istype(A, /obj/item) && skill_check(SKILL_FORENSICS, SKILL_ADEPT) && get_dist(src, A) <= 1)
+		var/obj/item/I = A
+		to_chat(src, SPAN_INFO("As a murder weapon, it's [english_list(I.get_autopsy_descriptors())]."))
+
 	//Detective is on the case
-	if(get_skill_value(SKILL_FORENSICS) >= SKILL_EXPERT && get_dist(src, A) <= (get_skill_value(SKILL_FORENSICS) - SKILL_ADEPT))
+	if(skill_check(SKILL_FORENSICS, SKILL_EXPERT) && get_dist(src, A) <= (get_skill_value(SKILL_FORENSICS) - SKILL_ADEPT))
 		var/clue
 		if(LAZYLEN(A.suit_fibers))
 			to_chat(src, "<span class='notice'>You notice some fibers embedded in \the [A].</span>")
@@ -206,7 +210,7 @@ atom/proc/add_fibers(mob/living/carbon/human/M)
 			to_chat(src, "<span class='notice'>You notice a faint acrid smell coming from \the [A].</span>")
 			clue = 1
 		//Noticing wiped blood is a bit harder
-		if((get_skill_value(SKILL_FORENSICS) >= SKILL_PROF) && LAZYLEN(A.blood_DNA))
+		if(skill_check(SKILL_FORENSICS, SKILL_PROF) && LAZYLEN(A.blood_DNA))
 			to_chat(src, "<span class='warning'>You notice faint blood traces on \The [A].</span>")
 			clue = 1
 		if(clue && has_client_color(/datum/client_color/noir))

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
@@ -20,7 +20,7 @@
 		/obj/item/borg/sight/hud/sec,
 		/obj/item/taperoll/police,
 		/obj/item/scalpel/laser1,
-		/obj/item/autopsy_scanner,
+		/obj/item/scanner/autopsy,
 		/obj/item/chems/spray/luminol,
 		/obj/item/uv_light,
 		/obj/item/crowbar

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1368,11 +1368,17 @@ obj/item/organ/external/proc/remove_clamps()
 
 //Adds autopsy data for used_weapon.
 /obj/item/organ/external/proc/add_autopsy_data(var/used_weapon, var/damage)
-	var/datum/autopsy_data/W = autopsy_data[used_weapon]
+	var/key = used_weapon
+	var/data = used_weapon
+	if(istype(used_weapon, /obj/item))
+		var/obj/item/I = used_weapon
+		key = I.name
+		data = english_list(I.get_autopsy_descriptors())
+	var/datum/autopsy_data/W = autopsy_data[key]
 	if(!W)
 		W = new()
-		W.weapon = used_weapon
-		autopsy_data[used_weapon] = W
+		W.weapon = data
+		autopsy_data[key] = W
 
 	W.hits += 1
 	W.damage += damage

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -30,7 +30,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 			owner.visible_message("<span class='warning'>\The [owner]'s crystalline [name] shines with absorbed energy!</span>")
 
 	if(used_weapon)
-		add_autopsy_data("[used_weapon]", brute + burn)
+		add_autopsy_data(used_weapon, brute + burn)
 
 	var/spillover = 0
 	var/pure_brute = brute

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -19,6 +19,9 @@
 /obj/item/ammo_casing/Initialize()
 	if(ispath(projectile_type))
 		BB = new projectile_type(src)
+		if(caliber && istype(BB, /obj/item/projectile/bullet))
+			var/obj/item/projectile/bullet/B = BB
+			B.caliber = caliber
 	if(randpixel)
 		pixel_x = rand(-randpixel, randpixel)
 		pixel_y = rand(-randpixel, randpixel)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -511,3 +511,6 @@
 		SP.SetName((name != "shrapnel")? "[name] shrapnel" : "shrapnel")
 		SP.desc += " It looks like it was fired from [shot_from]."
 		return SP
+	
+/obj/item/projectile/get_autopsy_descriptors()
+	return list(name)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -9,12 +9,18 @@
 	embed = 1
 	penetration_modifier = 1.0
 	var/mob_passthrough_check = 0
+	var/caliber
 
 	muzzle_type = /obj/effect/projectile/bullet/muzzle
 	miss_sounds = list('sound/weapons/guns/miss1.ogg','sound/weapons/guns/miss2.ogg','sound/weapons/guns/miss3.ogg','sound/weapons/guns/miss4.ogg')
 	ricochet_sounds = list('sound/weapons/guns/ricochet1.ogg', 'sound/weapons/guns/ricochet2.ogg',
 							'sound/weapons/guns/ricochet3.ogg', 'sound/weapons/guns/ricochet4.ogg')
 	impact_sounds = list(BULLET_IMPACT_MEAT = SOUNDS_BULLET_MEAT, BULLET_IMPACT_METAL = SOUNDS_BULLET_METAL)
+
+/obj/item/projectile/bullet/get_autopsy_descriptors()
+	. = ..()
+	if(caliber)
+		. += "matching caliber [caliber]"
 
 /obj/item/projectile/bullet/on_hit(var/atom/target, var/blocked = 0)
 	if (..(target, blocked))

--- a/code/modules/xenoarcheaology/artifacts/standalone/replicator.dm
+++ b/code/modules/xenoarcheaology/artifacts/standalone/replicator.dm
@@ -38,7 +38,7 @@
 	/obj/item/radio,
 	/obj/item/radio/headset,
 	/obj/item/radio/beacon,
-	/obj/item/autopsy_scanner,
+	/obj/item/scanner/autopsy,
 	/obj/item/bikehorn,
 	/obj/item/bonesetter,
 	/obj/item/material/knife/kitchen/cleaver,


### PR DESCRIPTION
Weapons are now noted in autopsy data using their generic descriptors. Base ones are size, sharp/edge, material, with few objects here and there adding their own or overriding existing.

Repathed autopsy scanner under generic scanner path so it can store / print scans in same way.

Also added sounds to scanners printing


![image](https://user-images.githubusercontent.com/1300258/78513340-e141d880-77bb-11ea-872b-534cdcb7056a.png)
![image](https://user-images.githubusercontent.com/1300258/78513359-06cee200-77bc-11ea-9dd6-d36d6d6ac65e.png)
