### PR TITLE
Lets you have planets bigger than the world

### DIFF
--- a/maps/bearcat/bearcat_define.dm
+++ b/maps/bearcat/bearcat_define.dm
@@ -16,10 +16,11 @@
 	evac_controller_type = /datum/evacuation_controller/lifepods
 	lobby_screens = list('maps/bearcat/lobby/bloodmoney.png','maps/bearcat/lobby/vapormoney.png')
 
+	planet_size = list(129,129)
 	allowed_spawns = list("Cryogenic Storage")
 	default_spawn = "Cryogenic Storage"
 	use_overmap = 1
-	num_exoplanets = 3
+	num_exoplanets = 2
 	welcome_sound = 'sound/effects/cowboysting.ogg'
 
 	emergency_shuttle_leaving_dock = "Attention all hands: the escape pods have been launched, maintaining burn for %ETA%."

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -100,7 +100,9 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	var/id_hud_icons = 'icons/mob/hud.dmi' // Used by the ID HUD (primarily sechud) overlay.
 
 	var/num_exoplanets = 0
-	var/list/planet_size  //dimensions of planet zlevel, defaults to world size. Due to how maps are generated, must be (2^n+1) e.g. 17,33,65,129 etc. Map will just round up to those if set to anything other.
+	//dimensions of planet zlevels, defaults to world size if smaller, INCREASES world size if larger. 
+	//Due to how maps are generated, must be (2^n+1) e.g. 17,33,65,129 etc. Map will just round up to those if set to anything other.
+	var/list/planet_size = list()
 	var/away_site_budget = 0
 
 	var/list/loadout_blacklist	//list of types of loadout items that will not be pickable
@@ -219,7 +221,11 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 /datum/map/proc/build_exoplanets()
 	if(!use_overmap)
 		return
-
+	if(LAZYLEN(planet_size))
+		if(world.maxx < planet_size[1])
+			world.maxx = planet_size[1]
+		if(world.maxy < planet_size[2])
+			world.maxy = planet_size[2]
 	for(var/i = 0, i < num_exoplanets, i++)
 		var/exoplanet_type = pick(subtypesof(/obj/effect/overmap/visitable/sector/exoplanet))
 		INCREMENT_WORLD_Z_SIZE


### PR DESCRIPTION
Planet size can now be set higher than maxx/y and will increase wolrd size accordingly.
Used that on bearcat because its size made it very painful to test planetgen since things get very awkward in such squashed space.
Cut number of planets to 2 to keep more or less same init time.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->