### PR TITLE
Applies workaround for instaghosting when joining as AI.

### DIFF
--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -72,7 +72,7 @@
 	if(mind)
 		mind.transfer_to(O)
 		O.mind.original = O
-	else
+	else if(O.key != key)
 		O.key = key
 
 	if(move)


### PR DESCRIPTION
This started happening with robits shortly after the Initialize() changes went in but I haven't been able to isolate a proper fix.