### PR TITLE
Port SpaceDrift SS

### DIFF
--- a/code/__defines/subsystem-priority.dm
+++ b/code/__defines/subsystem-priority.dm
@@ -15,7 +15,9 @@
 #define SS_PRIORITY_MOB            95  // Mob Life().
 #define SS_PRIORITY_MACHINERY      95  // Machinery + powernet ticks.
 #define SS_PRIORITY_AIR            80  // ZAS processing.
+#define SS_PRIORITY_THROWING       75  // Throwing calculation and constant checks
 #define SS_PRIORITY_CHEMISTRY      60  // Multi-tick chemical reactions.
+#define SS_PRIORITY_SPACEDRIFT     40  // Drifting things
 #define SS_PRIORITY_ALARM          20  // Alarm processing.
 #define SS_PRIORITY_EVENT          20  // Event processing and queue handling.
 #define SS_PRIORITY_SHUTTLE        20  // Shuttle movement.

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -115,6 +115,11 @@ proc/age2agedescription(age)
 	if(!user || !target)
 		return 0
 	var/user_loc = user.loc
+
+	var/drifting = 0
+	if(!user.Process_Spacemove(0) && user.inertia_dir)
+		drifting = 1
+
 	var/target_loc = target.loc
 
 	var/holding = user.get_active_hand()
@@ -135,7 +140,11 @@ proc/age2agedescription(age)
 		if(uninterruptible)
 			continue
 
-		if(QDELETED(user) || user.incapacitated(incapacitation_flags) || user.loc != user_loc)
+		if(drifting && !user.inertia_dir)
+			drifting = 0
+			user_loc = user.loc
+
+		if(QDELETED(user) || user.incapacitated(incapacitation_flags) || (!drifting && user.loc != user_loc))
 			. = 0
 			break
 
@@ -168,6 +177,10 @@ proc/age2agedescription(age)
 
 	var/atom/original_loc = user.loc
 
+	var/drifting = 0
+	if(!user.Process_Spacemove(0) && user.inertia_dir)
+		drifting = 1
+
 	var/holding = user.get_active_hand()
 
 	var/datum/progressbar/progbar
@@ -182,7 +195,11 @@ proc/age2agedescription(age)
 		if (progress)
 			progbar.update(world.time - starttime)
 
-		if(QDELETED(user) || user.incapacitated(incapacitation_flags) || (user.loc != original_loc && !can_move) || (same_direction && user.dir != original_dir))
+		if(drifting && !user.inertia_dir)
+			drifting = 0
+			original_loc = user.loc
+
+		if(QDELETED(user) || user.incapacitated(incapacitation_flags) || (!drifting && user.loc != original_loc && !can_move) || (same_direction && user.dir != original_dir))
 			. = 0
 			break
 

--- a/code/controllers/subsystems/fluids.dm
+++ b/code/controllers/subsystems/fluids.dm
@@ -97,7 +97,7 @@ var/datum/controller/subsystem/fluids/SSfluids
 
 		REMOVE_ACTIVE_FLUID(F) // This will be refreshed if our level changes at all in this iteration of the subsystem.
 		UPDATE_FLUID_BLOCKED_DIRS(T)
-		if(!(T.fluid_blocked_dirs & DOWN) && istype(T, /turf/simulated/open) && has_gravity(F))
+		if(!(T.fluid_blocked_dirs & DOWN) && T.is_open() && T.has_gravity())
 			var/turf/below = GetBelow(T)
 			if(below)
 				UPDATE_FLUID_BLOCKED_DIRS(below)

--- a/code/controllers/subsystems/spacedrift.dm
+++ b/code/controllers/subsystems/spacedrift.dm
@@ -1,0 +1,59 @@
+//ported from TG 30/03/2020
+SUBSYSTEM_DEF(spacedrift)
+	name = "Space Drift"
+//	priority = FIRE_PRIORITY_SPACEDRIFT	//fix this maybe?
+	wait = 5
+	flags = SS_NO_INIT|SS_KEEP_TIMING
+	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+
+	var/list/currentrun = list()
+	var/list/processing = list()
+
+/datum/controller/subsystem/spacedrift/stat_entry()
+	..("P:[processing.len]")
+
+
+/datum/controller/subsystem/spacedrift/fire(resumed = 0)
+	if (!resumed)
+		src.currentrun = processing.Copy()
+
+	//cache for sanic speed (lists are references anyways)
+	var/list/currentrun = src.currentrun
+
+	while (currentrun.len)
+		var/atom/movable/AM = currentrun[currentrun.len]
+		currentrun.len--
+		if (!AM)
+			processing -= AM
+			if (MC_TICK_CHECK)
+				return
+			continue
+
+		if (AM.inertia_next_move > world.time)
+			if (MC_TICK_CHECK)
+				return
+			continue
+
+		if (!AM.loc || AM.loc != AM.inertia_last_loc || AM.Process_Spacemove(0))
+			AM.inertia_dir = 0
+
+		if (!AM.inertia_dir)
+			AM.inertia_last_loc = null
+			processing -= AM
+			if (MC_TICK_CHECK)
+				return
+			continue
+
+		var/old_dir = AM.dir
+		var/old_loc = AM.loc
+		AM.inertia_moving = TRUE
+		step(AM, AM.inertia_dir)
+		AM.inertia_moving = FALSE
+		AM.inertia_next_move = world.time + AM.inertia_move_delay
+		if (AM.loc == old_loc)
+			AM.inertia_dir = 0
+
+		AM.set_dir(old_dir)
+		AM.inertia_last_loc = AM.loc
+		if (MC_TICK_CHECK)
+			return

--- a/code/controllers/subsystems/spacedrift.dm
+++ b/code/controllers/subsystems/spacedrift.dm
@@ -36,6 +36,8 @@ SUBSYSTEM_DEF(spacedrift)
 
 		if (!AM.loc || AM.loc != AM.inertia_last_loc || AM.Process_Spacemove(0))
 			AM.inertia_dir = 0
+		
+		AM.inertia_ignore = null
 
 		if (!AM.inertia_dir)
 			AM.inertia_last_loc = null

--- a/code/controllers/subsystems/spacedrift.dm
+++ b/code/controllers/subsystems/spacedrift.dm
@@ -1,7 +1,7 @@
 //ported from TG 30/03/2020
 SUBSYSTEM_DEF(spacedrift)
 	name = "Space Drift"
-//	priority = FIRE_PRIORITY_SPACEDRIFT	//fix this maybe?
+	priority = SS_PRIORITY_SPACEDRIFT
 	wait = 5
 	flags = SS_NO_INIT|SS_KEEP_TIMING
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME

--- a/code/controllers/subsystems/throwing.dm
+++ b/code/controllers/subsystems/throwing.dm
@@ -4,6 +4,7 @@
 
 SUBSYSTEM_DEF(throwing)
 	name = "Throwing"
+	priority = SS_PRIORITY_THROWING
 	wait = 1
 	flags = SS_NO_INIT|SS_KEEP_TIMING
 

--- a/code/controllers/subsystems/throwing.dm
+++ b/code/controllers/subsystems/throwing.dm
@@ -1,6 +1,5 @@
 //ported from TG 28/10/2019
 
-#define MAX_THROWING_DIST 1280 // 5 z-levels on default width
 #define MAX_TICKS_TO_MAKE_UP 3 //how many missed ticks will we attempt to make up for this run.
 
 SUBSYSTEM_DEF(throwing)
@@ -117,7 +116,6 @@ SUBSYSTEM_DEF(throwing)
 		finalize()
 		return
 
-	var/area/A = get_area(AM.loc)
 	var/atom/step
 
 	last_move = world.time
@@ -125,7 +123,7 @@ SUBSYSTEM_DEF(throwing)
 	//calculate how many tiles to move, making up for any missed ticks.
 	var/tilestomove = CEILING(min(((((world.time+world.tick_lag) - start_time + delayed_time) * speed) - (dist_travelled ? dist_travelled : -1)), speed*MAX_TICKS_TO_MAKE_UP) * (world.tick_lag * SSthrowing.wait), 1)
 	while (tilestomove-- > 0)
-		if ((dist_travelled >= maxrange || AM.loc == target_turf) && (A && A.has_gravity()))
+		if (dist_travelled >= maxrange || AM.loc == target_turf)
 			finalize()
 			return
 
@@ -150,18 +148,11 @@ SUBSYSTEM_DEF(throwing)
 		AM.Move(step, get_dir(AM, step))
 
 		if (!AM.throwing) // we hit something during our move
-			finalize(hit = TRUE)
 			return
 
 		dist_travelled++
 
-		if (dist_travelled > MAX_THROWING_DIST)
-			finalize()
-			return
-
-		A = get_area(AM.loc)
-
-/datum/thrownthing/proc/finalize(hit = FALSE, t_target=null)
+/datum/thrownthing/proc/finalize(hit = FALSE, t_target = null)
 	set waitfor = FALSE
 	//done throwing, either because it hit something or it finished moving
 	if(QDELETED(thrownthing))
@@ -176,6 +167,7 @@ SUBSYSTEM_DEF(throwing)
 				break
 		if (!hit)
 			thrownthing.throw_impact(get_turf(thrownthing), src)  // we haven't hit something yet and we still must, let's hit the ground.
+			thrownthing.space_drift(init_dir)
 
 	if(t_target)
 		thrownthing.throw_impact(t_target, src)

--- a/code/controllers/subsystems/throwing.dm
+++ b/code/controllers/subsystems/throwing.dm
@@ -177,10 +177,6 @@ SUBSYSTEM_DEF(throwing)
 		if (!hit)
 			thrownthing.throw_impact(get_turf(thrownthing), src)  // we haven't hit something yet and we still must, let's hit the ground.
 
-	if(ismob(thrownthing))
-		var/mob/M = thrownthing
-		M.inertia_dir = init_dir
-
 	if(t_target)
 		thrownthing.throw_impact(t_target, src)
 

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -80,7 +80,7 @@
 
 // Space movement
 /datum/movement_handler/mob/space/DoMove(var/direction, var/mob/mover)
-	if(!mob.check_solid_ground())
+	if(!mob.has_gravity())
 		var/allowmove = mob.Process_Spacemove(direction)
 		if(!allowmove)
 			return MOVEMENT_HANDLED
@@ -261,7 +261,7 @@
 /mob/living/carbon/human/get_stamina_used_per_step()
 	var/mod = (1-((get_skill_value(SKILL_HAULING) - SKILL_MIN)/(SKILL_MAX - SKILL_MIN)))
 	if(species && (species.species_flags & SPECIES_FLAG_LOW_GRAV_ADAPTED))
-		if(has_gravity(src))
+		if(has_gravity())
 			mod *= 1.2
 		else
 			mod *= 0.8

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -81,22 +81,11 @@
 // Space movement
 /datum/movement_handler/mob/space/DoMove(var/direction, var/mob/mover)
 	if(!mob.check_solid_ground())
-		var/allowmove = mob.Allow_Spacemove(0)
+		var/allowmove = mob.Process_Spacemove(direction)
 		if(!allowmove)
 			return MOVEMENT_HANDLED
 		else if(allowmove == -1 && mob.handle_spaceslipping()) //Check to see if we slipped
 			return MOVEMENT_HANDLED
-		else
-			mob.inertia_dir = 0 //If not then we can reset inertia and move
-
-/datum/movement_handler/mob/space/MayMove(var/mob/mover, var/is_external)
-	if(IS_NOT_SELF(mover) && is_external)
-		return MOVEMENT_PROCEED
-
-	if(!mob.check_solid_ground())
-		if(!mob.Allow_Spacemove(0))
-			return MOVEMENT_STOP
-	return MOVEMENT_PROCEED
 
 // Buckle movement
 /datum/movement_handler/mob/buckle_relay/DoMove(var/direction, var/mover)

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -78,14 +78,27 @@
 		return MOVEMENT_PROCEED
 	return (MOVEMENT_PROCEED|MOVEMENT_HANDLED)
 
+/datum/movement_handler/mob/space
+	var/allow_move
+
 // Space movement
 /datum/movement_handler/mob/space/DoMove(var/direction, var/mob/mover)
 	if(!mob.has_gravity())
-		var/allowmove = mob.Process_Spacemove(direction)
-		if(!allowmove)
+		if(!allow_move)
 			return MOVEMENT_HANDLED
-		else if(allowmove == -1 && mob.handle_spaceslipping()) //Check to see if we slipped
+		if(!mob.space_do_move(allow_move, direction))
 			return MOVEMENT_HANDLED
+
+/datum/movement_handler/mob/space/MayMove(var/mob/mover, var/is_external)
+	if(IS_NOT_SELF(mover) && is_external)
+		return MOVEMENT_PROCEED
+
+	if(!mob.has_gravity())
+		allow_move = mob.Process_Spacemove(1)
+		if(!allow_move)
+			return MOVEMENT_STOP
+
+	return MOVEMENT_PROCEED
 
 // Buckle movement
 /datum/movement_handler/mob/buckle_relay/DoMove(var/direction, var/mover)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -291,14 +291,31 @@ var/list/mob/living/forced_ambiance_list = new
 		for(var/obj/machinery/door/window/temp_windoor in src)
 			temp_windoor.open()
 
-/area/proc/has_gravity()
+/area/has_gravity()
 	return has_gravity
 
 /area/space/has_gravity()
 	return 0
 
-/proc/has_gravity(atom/AT)
-	var/area/A = get_area(AT)
+/atom/proc/has_gravity()
+	var/area/A = get_area(src)
+	if(A && A.has_gravity())
+		return 1
+	return 0
+
+/mob/has_gravity()
+	if(istype(loc, /turf/space))
+		return 0
+
+	if(!lastarea)
+		lastarea = get_area(src)
+	if(!lastarea || !lastarea.has_gravity())
+		return 0
+
+	return 1
+
+/turf/has_gravity()
+	var/area/A = loc
 	if(A && A.has_gravity())
 		return 1
 	return 0

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -297,10 +297,8 @@ var/list/mob/living/forced_ambiance_list = new
 /area/space/has_gravity()
 	return 0
 
-/proc/has_gravity(atom/AT, turf/T)
-	if(!T)
-		T = get_turf(AT)
-	var/area/A = get_area(T)
+/proc/has_gravity(atom/AT)
+	var/area/A = get_area(AT)
 	if(A && A.has_gravity())
 		return 1
 	return 0

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -304,9 +304,6 @@ var/list/mob/living/forced_ambiance_list = new
 	return 0
 
 /mob/has_gravity()
-	if(istype(loc, /turf/space))
-		return 0
-
 	if(!lastarea)
 		lastarea = get_area(src)
 	if(!lastarea || !lastarea.has_gravity())

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -44,7 +44,7 @@
 	if(!simulated)
 		return 1
 
-	if(has_gravity(src))
+	if(has_gravity())
 		return 1
 
 	if(length(grabbed_by))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -23,11 +23,13 @@
 	var/inertia_moving = 0
 	var/inertia_next_move = 0
 	var/inertia_move_delay = 5
+	var/atom/movable/inertia_ignore
 
 //call this proc to start space drifting
 /atom/movable/proc/space_drift(direction)//move this down
 	if(!loc || direction & (UP|DOWN) || Process_Spacemove(0))
 		inertia_dir = 0
+		inertia_ignore = null
 		return 0
 
 	inertia_dir = direction
@@ -77,7 +79,6 @@
 
 	else if(power > 0.5)	//knocks them back and changes their direction
 		step(src, direction)
-		space_drift(direction)
 
 	else if(power > 0.25)	//glancing change in direction
 		var/drift_dir
@@ -123,6 +124,9 @@
 /atom/movable/Bump(var/atom/A, yes)
 	if(!QDELETED(throwing))
 		throwing.hit_atom(A)
+
+	if(inertia_dir)
+		inertia_dir = 0
 
 	if (A && yes)
 		A.last_bumped = world.time

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -64,13 +64,16 @@
 
 	return 0
 
-/atom/movable/hitby(atom/movable/AM, var/datum/thrownthing/TT)
+/atom/movable/hitby(var/atom/movable/AM, var/datum/thrownthing/TT)
 	. = ..()
 	process_momentum(AM,TT)
 
-/atom/movable/proc/process_momentum(atom/movable/AM, var/datum/thrownthing/TT)
+/atom/movable/proc/process_momentum(var/atom/movable/AM, var/datum/thrownthing/TT, var/power)//physic isn't an exact science
 	if(anchored) return
-	var/power = (AM.get_mass()*TT.speed)/get_mass()
+	if(!power)
+		power = (AM.get_mass()*TT.speed)/(get_mass()*min(AM.throw_speed,2))
+		if(has_gravity())
+			power *= 0.5
 
 	var/direction = TT.init_dir
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -40,7 +40,7 @@
 	return 1
 
 //return 0 to space drift, 1 to stop, -1 for mobs to handle space slips
-/atom/movable/proc/Process_Spacemove(var/movement_dir)
+/atom/movable/proc/Process_Spacemove(var/allow_movement)
 	if(!simulated)
 		return 1
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -18,6 +18,50 @@
 	var/does_spin = TRUE // Does the atom spin when thrown (of course it does :P)
 	var/list/grabbed_by
 
+	var/inertia_dir = 0
+	var/atom/inertia_last_loc
+	var/inertia_moving = 0
+	var/inertia_next_move = 0
+	var/inertia_move_delay = 5
+
+//call this proc to start space drifting
+/atom/movable/proc/space_drift(direction)//move this down
+	if(!loc || direction & (UP|DOWN) || Process_Spacemove(0))
+		inertia_dir = 0
+		return 0
+
+	inertia_dir = direction
+	if(!direction)
+		return 1
+	inertia_last_loc = loc
+	SSspacedrift.processing[src] = src
+	return 1
+
+//return 0 to space drift, 1 to stop, -1 for mobs to handle space slips
+/atom/movable/proc/Process_Spacemove(var/movement_dir)
+	if(!simulated)
+		return 1
+
+	if(has_gravity(src))
+		return 1
+
+	if(length(grabbed_by))
+		return 1
+
+	if(throwing)
+		return 1
+
+	if(anchored)
+		return 1
+
+	if(!isturf(loc))
+		return 1
+
+	if(locate(/obj/structure/lattice) in range(1, get_turf(src))) //Not realistic but makes pushing things in space easier
+		return -1
+
+	return 0
+
 /atom/movable/Destroy()
 	. = ..()
 	if(!(atom_flags & ATOM_FLAG_INITIALIZED))

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -81,6 +81,8 @@ Class Procs:
 	icon = 'icons/obj/stationobjs.dmi'
 	w_class = ITEM_SIZE_STRUCTURE
 	layer = STRUCTURE_LAYER // Layer under items
+	throw_speed = 1
+	throw_range = 5
 
 	var/stat = 0
 	var/reason_broken = 0

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -125,8 +125,8 @@
 	master.disrupt()
 
 /obj/effect/dummy/chameleon/relaymove(var/mob/user, direction)
-	var/area/A = get_area(src)
-	if(!A || !A.has_gravity()) return //No magical space movement!
+	if(!has_gravity())
+		return //No magical space movement!
 
 	if(can_move)
 		can_move = 0

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -43,6 +43,17 @@
 	throwforce = round(0.25*material.get_edge_damage())
 	force = round(0.5*material.get_blunt_damage())
 
+/obj/item/stack/material/on_update_icon()
+	if(material_flags & USE_MATERIAL_COLOR)
+		color = material.icon_colour
+		alpha = 100 + max(1, amount/25)*(material.opacity * 255)
+	if(max_icon_state && amount > 0.5*max_amount)
+		icon_state = max_icon_state
+	else if(plural_icon_state && amount >= 2)
+		icon_state = plural_icon_state
+	else
+		icon_state = base_state
+
 /obj/item/stack/material/rods/attackby(obj/item/W, mob/user)
 	if(isWelder(W))
 		var/obj/item/weldingtool/WT = W

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -144,7 +144,6 @@
 
 		if((istype(usr.loc, /turf/space)) || (usr.lastarea.has_gravity == 0))
 			step(user, direction)
-			space_drift(direction)
 	else
 		return ..()
 	return

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -135,16 +135,16 @@
 
 		playsound(src.loc, 'sound/effects/extinguish.ogg', 75, 1, -3)
 
-		var/direction = get_dir(src,target)
+		var/direction = get_dir(target,src)
 
 		if(user.buckled && isobj(user.buckled))
-			addtimer(CALLBACK(src, .proc/propel_object, user.buckled, user, turn(direction,180)), 0)
+			addtimer(CALLBACK(src, .proc/propel_object, user.buckled, user, direction), 0)
 
 		addtimer(CALLBACK(src, .proc/do_spray, target), 0)
 
 		if((istype(usr.loc, /turf/space)) || (usr.lastarea.has_gravity == 0))
-			user.inertia_dir = get_dir(target, user)
-			step(user, user.inertia_dir)
+			step(user, direction)
+			space_drift(direction)
 	else
 		return ..()
 	return

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -142,7 +142,7 @@
 
 		addtimer(CALLBACK(src, .proc/do_spray, target), 0)
 
-		if((istype(usr.loc, /turf/space)) || (usr.lastarea.has_gravity == 0))
+		if(!user.check_space_footing())
 			step(user, direction)
 	else
 		return ..()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -193,3 +193,6 @@
 
 /obj/can_be_injected_by(var/atom/injector)
 	. = ATOM_IS_OPEN_CONTAINER(src) && ..()
+
+/obj/get_mass()
+	return w_class

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -195,4 +195,4 @@
 	. = ATOM_IS_OPEN_CONTAINER(src) && ..()
 
 /obj/get_mass()
-	return w_class
+	return min(2^(w_class-1), 100)

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -10,9 +10,10 @@
 	obj_flags = OBJ_FLAG_NOFALL
 	handle_generic_blending = TRUE
 	tool_interaction_flags = TOOL_INTERACTION_DECONSTRUCT
+	material = MAT_STEEL
 
 	var/hatch_open = FALSE
-	var/obj/item/stack/tile/mono/plated_tile
+	var/decl/flooring/tiling/plated_tile
 	var/list/connections
 	var/list/other_connections
 
@@ -27,6 +28,11 @@
 /obj/structure/catwalk/Initialize()
 	. = ..()
 	DELETE_IF_DUPLICATE_OF(/obj/structure/catwalk)
+
+	if(!istype(material))
+		return INITIALIZE_HINT_QDEL
+
+	return INITIALIZE_HINT_LATELOAD
 
 /obj/structure/catwalk/LateInitialize()
 	..()
@@ -62,13 +68,19 @@
 		I.color = plated_tile.color
 		overlays += I
 
+/obj/structure/catwalk/create_dismantled_products(var/turf/T)
+	new /obj/item/stack/material/rods(T, 2, material.type)
+	if(plated_tile)
+		var/plate_path = plated_tile.build_type
+		new plate_path(T)
+
 /obj/structure/catwalk/ex_act(severity)
 	switch(severity)
 		if(1)
-			new /obj/item/stack/material/rods(loc)
+			create_dismantled_products(get_turf(src))
 			qdel(src)
 		if(2)
-			new /obj/item/stack/material/rods(loc)
+			create_dismantled_products(get_turf(src))
 			qdel(src)
 
 /obj/structure/catwalk/attack_robot(var/mob/user)

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -80,11 +80,12 @@
 			return TRUE
 
 		var/obj/item/stack/material/rods/R = C
-		if(R.use(2))
-			src.alpha = 0
+		if(locate(/obj/structure/catwalk) in get_turf(src))
+			to_chat(user, SPAN_WARNING("There is already a catwalk here."))
+			return
+		else if(R.use(2))
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
-			new /obj/structure/catwalk(src.loc)
-			qdel(src)
+			new /obj/structure/catwalk(src.loc, R.material.type)
 			return
 		else
 			to_chat(user, SPAN_WARNING("You require at least two rods to complete the catwalk."))

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -122,10 +122,6 @@
 				for(var/i = 1 to slip_dist)
 					step(M, M.dir)
 					sleep(1)
-			else
-				M.inertia_dir = 0
-		else
-			M.inertia_dir = 0
 
 //returns 1 if made bloody, returns 0 otherwise
 /turf/simulated/add_blood(mob/living/carbon/human/M)

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -69,7 +69,7 @@
 				var/obj/item/stack/material/rods/R = C
 				if (R.use(2))
 					playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
-					new /obj/structure/catwalk(src)
+					new /obj/structure/catwalk(src, R.material.type)
 					return TRUE
 				return
 			var/obj/item/stack/S = C

--- a/code/game/turfs/simulated/footsteps.dm
+++ b/code/game/turfs/simulated/footsteps.dm
@@ -53,7 +53,7 @@
 		return
 
 	// don't need to step as often when you hop around
-	if((step_count % 3) && !has_gravity(src))
+	if((step_count % 3) && !has_gravity())
 		return
 
 	var/turf/simulated/T = get_turf(src)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -274,9 +274,12 @@ var/const/enterloopsanity = 100
 		if(isliving(AM))
 			var/mob/living/M = AM
 			M.turf_collision(src, TT.speed)
-		var/intial_dir = TT.init_dir
-		spawn(2)
-			step(AM, turn(intial_dir, 180))
+			if(M.pinned)
+				return
+		addtimer(CALLBACK(src, /turf/proc/bounce_off, AM, TT.init_dir), 2)
+
+/turf/proc/bounce_off(var/atom/movable/AM, var/direction)
+	step(AM, turn(direction, 180))
 
 /turf/proc/can_engrave()
 	return FALSE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -176,17 +176,6 @@ var/const/enterloopsanity = 100
 
 	var/atom/movable/A = atom
 
-	if(ismob(A))
-		var/mob/M = A
-		if(!M.check_solid_ground())
-			inertial_drift(M)
-			//we'll end up checking solid ground again but we still need to check the other things.
-			//Ususally most people aren't in space anyways so hopefully this is acceptable.
-			M.update_floating()
-		else
-			M.inertia_dir = 0
-			M.make_floating(0) //we know we're not on solid ground so skip the checks to save a bit of processing
-
 	var/objects = 0
 	if(A && (A.movable_flags & MOVABLE_FLAG_PROXMOVE))
 		for(var/atom/movable/thing in range(1))
@@ -207,20 +196,6 @@ var/const/enterloopsanity = 100
 
 /turf/proc/protects_atom(var/atom/A)
 	return FALSE
-
-/turf/proc/inertial_drift(atom/movable/A)
-	if(!(A.last_move))	return
-	if((istype(A, /mob/) && src.x > 2 && src.x < (world.maxx - 1) && src.y > 2 && src.y < (world.maxy-1)))
-		var/mob/M = A
-		if(M.Allow_Spacemove(1)) //if this mob can control their own movement in space then they shouldn't be drifting
-			M.inertia_dir  = 0
-			return
-		spawn(5)
-			if(M && !M.anchored && !LAZYLEN(M.grabbed_by) && M.loc == src)
-				if(!M.inertia_dir)
-					M.inertia_dir = M.last_move
-				step(M, M.inertia_dir)
-	return
 
 /turf/proc/levelupdate()
 	for(var/obj/O in src)

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -68,7 +68,7 @@ GLOBAL_LIST_INIT(carp_count,list())// a list of Z levels (string), associated wi
 			GLOB.destroyed_event.register(M,src,/datum/event/carp_migration/proc/reduce_carp_count)
 			LAZYADD(GLOB.carp_count["[Z]"], M)
 			spawned_carp ++
-			M.throw_at(get_random_edge_turf(GLOB.reverse_dir[dir],TRANSITIONEDGE + 2, Z), 5, speed, callback = CALLBACK(src,/datum/event/carp_migration/proc/check_gib,M))
+			M.throw_at(get_random_edge_turf(GLOB.reverse_dir[dir],TRANSITIONEDGE + 2, Z), 250, speed, callback = CALLBACK(src,/datum/event/carp_migration/proc/check_gib,M))
 		I++
 		if(no_show)
 			break

--- a/code/modules/mechs/mech_movement.dm
+++ b/code/modules/mechs/mech_movement.dm
@@ -95,15 +95,36 @@
 	expected_host_type = /mob/living/exosuit
 
 // Space movement
-/datum/movement_handler/mob/space/exosuit/DoMove(var/direction, var/mob/mover)
+/datum/movement_handler/mob/space/exosuit/MayMove(var/mob/mover, var/is_external)
+	if((mover != host) && is_external)
+		return MOVEMENT_PROCEED
+
 	if(!mob.has_gravity())
-		mob.anchored = FALSE
-		var/allowmove = mob.Process_Spacemove(direction)
-		if(!allowmove)
-			return MOVEMENT_HANDLED
-		else if(allowmove == -1 && mob.handle_spaceslipping()) //Check to see if we slipped
-			return MOVEMENT_HANDLED
-	else mob.anchored = TRUE
+		allow_move = mob.Process_Spacemove(1)
+		if(!allow_move)
+			return MOVEMENT_STOP
+
+	return MOVEMENT_PROCEED
+
+/mob/living/exosuit/Check_Shoegrip()//mechs are always magbooting
+	return TRUE
+
+/mob/living/exosuit/Process_Spacemove()
+	if(has_gravity() || throwing || !isturf(loc) || length(grabbed_by) || check_space_footing() || locate(/obj/structure/lattice) in range(1, get_turf(src)))
+		anchored = 1
+		return 1
+
+	anchored = 0
+	return 0
+
+/mob/living/exosuit/check_space_footing()//mechs can't push off things to move around in space, they stick to hull or float away
+	for(var/thing in trange(1,src))
+		var/turf/T = thing
+		if(T.density || T.is_wall() || T.is_floor())
+			return T
+
+/mob/living/exosuit/space_do_move()
+	return 1
 
 /mob/living/exosuit/lost_in_space()
 	for(var/atom/movable/AM in contents)

--- a/code/modules/mechs/mech_movement.dm
+++ b/code/modules/mechs/mech_movement.dm
@@ -99,23 +99,12 @@
 
 	if(!mob.check_solid_ground())
 		mob.anchored = FALSE
-		var/allowmove = mob.Allow_Spacemove(0)
+		var/allowmove = mob.Process_Spacemove(direction)
 		if(!allowmove)
 			return MOVEMENT_HANDLED
 		else if(allowmove == -1 && mob.handle_spaceslipping()) //Check to see if we slipped
 			return MOVEMENT_HANDLED
-		else
-			mob.inertia_dir = 0 //If not then we can reset inertia and move
 	else mob.anchored = TRUE
-
-/datum/movement_handler/mob/space/exosuit/MayMove(var/mob/mover, var/is_external)
-	if((mover != host) && is_external)
-		return MOVEMENT_PROCEED
-
-	if(!mob.check_solid_ground())
-		if(!mob.Allow_Spacemove(0))
-			return MOVEMENT_STOP
-	return MOVEMENT_PROCEED
 
 /mob/living/exosuit/lost_in_space()
 	for(var/atom/movable/AM in contents)

--- a/code/modules/mechs/mech_movement.dm
+++ b/code/modules/mechs/mech_movement.dm
@@ -96,8 +96,7 @@
 
 // Space movement
 /datum/movement_handler/mob/space/exosuit/DoMove(var/direction, var/mob/mover)
-
-	if(!mob.check_solid_ground())
+	if(!mob.has_gravity())
 		mob.anchored = FALSE
 		var/allowmove = mob.Process_Spacemove(direction)
 		if(!allowmove)

--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -79,11 +79,11 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 /mob/proc/update_floating()
 
-	if(anchored || buckled || check_solid_ground())
+	if(anchored || buckled || has_gravity())
 		make_floating(0)
 		return
 
-	if(Check_Shoegrip() && Check_Dense_Object())
+	if(check_space_footing())
 		make_floating(0)
 		return
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -314,8 +314,9 @@
 		src.lastarea = get_area(src.loc)
 	if((istype(src.loc, /turf/space)) || (src.lastarea.has_gravity == 0))
 		if(prob((itemsize * itemsize * 10) * MOB_SIZE_MEDIUM/src.mob_size))
-			src.inertia_dir = get_dir(target, src)
-			step(src, inertia_dir)
+			var/direction = get_dir(target, src)
+			step(src,direction)
+			space_drift(direction)
 
 	item.throw_at(target, throw_range, item.throw_speed * skill_mod, src)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -312,7 +312,7 @@
 
 	if(!src.lastarea)
 		src.lastarea = get_area(src.loc)
-	if((istype(src.loc, /turf/space)) || (src.lastarea.has_gravity == 0))
+	if(!check_space_footing())
 		if(prob((itemsize * itemsize * 10) * MOB_SIZE_MEDIUM/src.mob_size))
 			var/direction = get_dir(target, src)
 			step(src,direction)
@@ -363,8 +363,7 @@
 	..()
 
 /mob/living/carbon/slip(slipped_on, stun_duration = 8)
-	var/area/A = get_area(src)
-	if(!A.has_gravity())
+	if(!has_gravity())
 		return FALSE
 	if(buckled)
 		return FALSE

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -296,6 +296,7 @@ meteor_act
 					put_in_active_hand(O)
 					visible_message("<span class='warning'>[src] catches [O]!</span>")
 					throw_mode_off()
+					process_momentum(AM, TT)
 					return
 
 		var/dtype = O.damtype
@@ -352,29 +353,8 @@ meteor_act
 					affecting.embed(I, supplied_wound = created_wound)
 					I.has_embedded()
 
-		// Begin BS12 momentum-transfer code.
-		var/mass = 1.5
-		if(istype(O, /obj/item))
-			var/obj/item/I = O
-			mass = I.w_class/THROWNOBJ_KNOCKBACK_DIVISOR
-		var/momentum = TT.speed*mass
+		process_momentum(AM, TT)
 
-		if(momentum >= THROWNOBJ_KNOCKBACK_SPEED)
-			var/dir = TT.init_dir
-
-			visible_message("<span class='warning'>\The [src] staggers under the impact!</span>","<span class='warning'>You stagger under the impact!</span>")
-			src.throw_at(get_edge_target_turf(src,dir),1,momentum)
-
-			if(!O || !src) return
-
-			if(O.loc == src && O.sharp) //Projectile is embedded and suitable for pinning.
-				var/turf/T = near_wall(dir,2)
-
-				if(T)
-					src.forceMove(T)
-					visible_message("<span class='warning'>[src] is pinned to the wall by [O]!</span>","<span class='warning'>You are pinned to the wall by [O]!</span>")
-					src.anchored = 1
-					src.pinned += O
 	else
 		..()
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -71,11 +71,7 @@
 	. = ..()
 	. += species.strength
 
-/mob/living/carbon/human/Allow_Spacemove(var/check_drift = 0)
-	. = ..()
-	if(.)
-		return
-
+/mob/living/carbon/human/Process_Spacemove(var/movement_dir)
 	//Do we have a working jetpack?
 	var/obj/item/tank/jetpack/thrust
 	if(back)
@@ -87,15 +83,10 @@
 				thrust = module.jets
 				break
 
-	if(thrust && thrust.on)
-		if(prob(skill_fail_chance(SKILL_EVA, 10, SKILL_ADEPT)))
-			to_chat(src, "<span class='warning'>You fumble with [thrust] controls!</span>")
-			inertia_dir = pick(GLOB.cardinal)
-			return 0
+	if(thrust && thrust.on && (movement_dir || thrust.stabilization_on) && thrust.allow_thrust(0.01, src))
+		return 1
 
-		if(((!check_drift) || (check_drift && thrust.stabilization_on)) && (!lying) && (thrust.allow_thrust(0.01, src)))
-			inertia_dir = 0
-			return 1
+	. = ..()
 
 /mob/living/carbon/human/slip_chance(var/prob_slip = 5)
 	if(!..())

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -70,22 +70,38 @@
 	. = ..()
 	. += species.strength
 
-/mob/living/carbon/human/Process_Spacemove(var/movement_dir)
-	//Do we have a working jetpack?
-	var/obj/item/tank/jetpack/thrust
-	if(back)
-		if(istype(back,/obj/item/tank/jetpack))
-			thrust = back
-		else if(istype(back,/obj/item/rig))
-			var/obj/item/rig/rig = back
-			for(var/obj/item/rig_module/maneuvering_jets/module in rig.installed_modules)
-				thrust = module.jets
-				break
+/mob/living/carbon/human/Process_Spacemove(var/allow_movement)
+	var/obj/item/tank/jetpack/thrust = get_jetpack()
 
-	if(thrust && thrust.on && (movement_dir || thrust.stabilization_on) && thrust.allow_thrust(0.01, src))
+	if(thrust && thrust.on && (allow_movement || thrust.stabilization_on) && thrust.allow_thrust(0.01, src))
 		return 1
 
 	. = ..()
+
+
+/mob/living/carbon/human/space_do_move(var/allow_move, var/direction)
+	if(allow_move == 1)
+		var/obj/item/tank/jetpack/thrust = get_jetpack()
+		if(thrust && thrust.on && prob(skill_fail_chance(SKILL_EVA, 10, SKILL_ADEPT)))
+			to_chat(src, "<span class='warning'>You fumble with [thrust] controls!</span>")
+			if(prob(50))
+				thrust.toggle()
+			if(prob(50))
+				thrust.stabilization_on = 0
+			SetMoveCooldown(15)	//2 seconds of random rando panic drifting
+			step(src, pick(GLOB.alldirs))
+			return 0
+
+	. = ..()
+
+/mob/living/carbon/human/proc/get_jetpack()
+	if(back)
+		if(istype(back,/obj/item/tank/jetpack))
+			return back
+		else if(istype(back,/obj/item/rig))
+			var/obj/item/rig/rig = back
+			for(var/obj/item/rig_module/maneuvering_jets/module in rig.installed_modules)
+				return module.jets
 
 /mob/living/carbon/human/slip_chance(var/prob_slip = 5)
 	if(!..())

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -10,8 +10,7 @@
 
 	tally += species.handle_movement_delay_special(src)
 
-	var/area/a = get_area(src)
-	if(a && !a.has_gravity())
+	if(!has_gravity())
 		if(skill_check(SKILL_EVA, SKILL_PROF))
 			tally -= 2
 		tally -= 1

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -83,8 +83,7 @@
 		return
 
 	// Can't fall if nothing pulls you down
-	var/area/area = get_area(src)
-	if (!area || !area.has_gravity())
+	if(!has_gravity())
 		return
 
 	var/limb_pain

--- a/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
+++ b/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
@@ -148,9 +148,6 @@
 
 	..()
 
-/mob/living/carbon/slime/Allow_Spacemove()
-	return 1
-
 /mob/living/carbon/slime/Stat()
 	. = ..()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -845,8 +845,7 @@ default behaviour is:
 
 /mob/living/handle_grab_damage()
 	..()
-	var/area/A = get_area(src)
-	if(!A.has_gravity)
+	if(!has_gravity())
 		return
 	if(isturf(loc) && pull_damage() && prob(getBruteLoss() / 6))
 		blood_splatter(loc, src, large = TRUE)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -164,17 +164,20 @@
 
 	process_momentum(AM, TT)
 
-/mob/living/process_momentum(atom/movable/AM, var/datum/thrownthing/TT)
+/mob/living/process_momentum(var/atom/movable/AM, var/datum/thrownthing/TT, var/power)
 	if(anchored || buckled) return
-	var/power = (AM.get_mass()*TT.speed)/get_mass()
+	if(!power)
+		power = (AM.get_mass()*TT.speed)/(get_mass()*min(AM.throw_speed,2))
+		if(has_gravity() || check_space_footing())
+			power *= 0.5
 
 	if(power > 0.75)		//snowflake to enable being pinned to walls
 		var/direction = TT.init_dir
 		throw_at(get_edge_target_turf(src, direction), min((TT.maxrange - TT.dist_travelled) * power, 10), throw_speed * min(power, 1.5), callback = CALLBACK(src,/mob/living/proc/pin_to_wall,AM,direction))
 		visible_message(SPAN_DANGER("\The [src] staggers under the impact!"),SPAN_DANGER("You stagger under the impact!"))
 		return
-
-	. = ..()
+	else
+		. = ..(AM,TT,power)
 
 /mob/living/proc/pin_to_wall(var/obj/O, var/direction)
 	if(!istype(O) || O.loc != src || !O.can_embed())//Projectile is suitable for pinning.

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -159,32 +159,34 @@
 			if(assailant)
 				admin_attack_log(TT.thrower, src, "Threw \an [O] at the victim.", "Had \an [O] thrown at them.", "threw \an [O] at")
 
-		// Begin BS12 momentum-transfer code.
-		var/mass = 1.5
-		if(istype(O, /obj/item))
-			var/obj/item/I = O
-			mass = I.w_class/THROWNOBJ_KNOCKBACK_DIVISOR
-		var/momentum = TT.speed*mass
+		if(O.can_embed() && (throw_damage > 5*O.w_class)) //Handles embedding for non-humans and simple_animals.
+			embed(O)
 
-		if(momentum >= THROWNOBJ_KNOCKBACK_SPEED)
-			var/dir = TT.init_dir
+	process_momentum(AM, TT)
 
-			visible_message("<span class='warning'>\The [src] staggers under the impact!</span>","<span class='warning'>You stagger under the impact!</span>")
-			src.throw_at(get_edge_target_turf(src,dir),1,momentum)
+/mob/living/process_momentum(atom/movable/AM, var/datum/thrownthing/TT)
+	if(anchored || buckled) return
+	var/power = (AM.get_mass()*TT.speed)/get_mass()
 
-			if(!O || !src) return
+	if(power > 0.75)		//snowflake to enable being pinned to walls
+		var/direction = TT.init_dir
+		throw_at(get_edge_target_turf(src, direction), min((TT.maxrange - TT.dist_travelled) * power, 10), throw_speed * min(power, 1.5), callback = CALLBACK(src,/mob/living/proc/pin_to_wall,AM,direction))
+		visible_message(SPAN_DANGER("\The [src] staggers under the impact!"),SPAN_DANGER("You stagger under the impact!"))
+		return
 
-			if(O.can_embed()) //Projectile is suitable for pinning.
-				//Handles embedding for non-humans and simple_animals.
-				embed(O)
+	. = ..()
 
-				var/turf/T = near_wall(dir,2)
+/mob/living/proc/pin_to_wall(var/obj/O, var/direction)
+	if(!istype(O) || O.loc != src || !O.can_embed())//Projectile is suitable for pinning.
+		return
 
-				if(T)
-					forceMove(T)
-					visible_message("<span class='warning'>[src] is pinned to the wall by [O]!</span>","<span class='warning'>You are pinned to the wall by [O]!</span>")
-					src.anchored = 1
-					src.pinned += O
+	var/turf/T = near_wall(direction,2)
+
+	if(T)
+		forceMove(T)
+		visible_message(SPAN_DANGER("[src] is pinned to the wall by [O]!"),SPAN_DANGER("You are pinned to the wall by [O]!"))
+		src.anchored = 1
+		src.pinned += O
 
 /mob/living/proc/embed(var/obj/O, var/def_zone=null, var/datum/wound/supplied_wound)
 	O.forceMove(src)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -164,20 +164,22 @@
 
 	process_momentum(AM, TT)
 
-/mob/living/process_momentum(var/atom/movable/AM, var/datum/thrownthing/TT, var/power)
-	if(anchored || buckled) return
-	if(!power)
-		power = (AM.get_mass()*TT.speed)/(get_mass()*min(AM.throw_speed,2))
-		if(has_gravity() || check_space_footing())
-			power *= 0.5
+/mob/living/momentum_power(var/atom/movable/AM, var/datum/thrownthing/TT)
+	if(anchored || buckled)
+		return 0
 
-	if(power > 0.75)		//snowflake to enable being pinned to walls
+	. = (AM.get_mass()*TT.speed)/(get_mass()*min(AM.throw_speed,2))
+	if(has_gravity() || check_space_footing())
+		. *= 0.5
+
+/mob/living/momentum_do(var/power, var/datum/thrownthing/TT, var/atom/movable/AM)
+	if(power >= 0.75)		//snowflake to enable being pinned to walls
 		var/direction = TT.init_dir
 		throw_at(get_edge_target_turf(src, direction), min((TT.maxrange - TT.dist_travelled) * power, 10), throw_speed * min(power, 1.5), callback = CALLBACK(src,/mob/living/proc/pin_to_wall,AM,direction))
 		visible_message(SPAN_DANGER("\The [src] staggers under the impact!"),SPAN_DANGER("You stagger under the impact!"))
 		return
-	else
-		. = ..(AM,TT,power)
+
+	. = ..()
 
 /mob/living/proc/pin_to_wall(var/obj/O, var/direction)
 	if(!istype(O) || O.loc != src || !O.can_embed())//Projectile is suitable for pinning.

--- a/code/modules/mob/living/maneuvers/_maneuver.dm
+++ b/code/modules/mob/living/maneuvers/_maneuver.dm
@@ -12,7 +12,7 @@
 		if(!silent)
 			to_chat(user, SPAN_WARNING("You are buckled down and cannot maneuver!"))
 		return FALSE
-	if(!has_gravity(user))
+	if(!user.has_gravity())
 		if(!silent)
 			to_chat(user, SPAN_WARNING("You cannot maneuver in zero gravity!"))
 		return FALSE

--- a/code/modules/mob/living/silicon/robot/flying/flying.dm
+++ b/code/modules/mob/living/silicon/robot/flying/flying.dm
@@ -44,11 +44,11 @@
 	if(!QDELETED(src) && stat == DEAD)
 		stop_flying()
 
-/mob/living/silicon/robot/flying/Allow_Spacemove()
+/mob/living/silicon/robot/flying/Process_Spacemove()
 	return (pass_flags & PASS_FLAG_TABLE) || ..()
 
 /mob/living/silicon/robot/flying/can_fall(var/anchor_bypass = FALSE, var/turf/location_override = loc)
-	return !Allow_Spacemove()
+	return !Process_Spacemove()
 
 /mob/living/silicon/robot/flying/can_overcome_gravity()
-	return Allow_Spacemove()
+	return Process_Spacemove()

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -8,7 +8,7 @@
 		return 1
 	return 0
 
-/mob/living/silicon/robot/Allow_Spacemove()
+/mob/living/silicon/robot/Process_Spacemove()
 	if(module)
 		for(var/obj/item/tank/jetpack/J in module.equipment)
 			if(J && J.allow_thrust(0.01))

--- a/code/modules/mob/living/simple_animal/familiars/familiars.dm
+++ b/code/modules/mob/living/simple_animal/familiars/familiars.dm
@@ -66,7 +66,7 @@
 
 	wizardy_spells = list(/spell/aoe_turf/conjure/forcewall)
 
-/mob/living/simple_animal/familiar/pike/Allow_Spacemove(var/check_drift = 0)
+/mob/living/simple_animal/familiar/pike/Process_Spacemove()
 	return 1	//No drifting in space for space carp!	//original comments do not steal
 
 /mob/living/simple_animal/familiar/horror

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -57,7 +57,7 @@
 	icon_living = "[carp_color]"
 	icon_dead = "[carp_color]_dead"
 
-/mob/living/simple_animal/hostile/carp/Allow_Spacemove(var/check_drift = 0)
+/mob/living/simple_animal/hostile/carp/Process_Spacemove()
 	return 1	//No drifting in space for space carp!	//original comments do not steal
 
 /mob/living/simple_animal/hostile/carp/FindTarget()

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -34,7 +34,7 @@
 	skin_material = null
 	skin_amount =   0
 
-/mob/living/simple_animal/hostile/faithless/Allow_Spacemove(var/check_drift = 0)
+/mob/living/simple_animal/hostile/faithless/Process_Spacemove()
 	return 1
 
 /mob/living/simple_animal/hostile/faithless/FindTarget()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -62,7 +62,7 @@
 	ion_trail.set_up(src)
 	ion_trail.start()
 
-/mob/living/simple_animal/hostile/retaliate/malf_drone/Allow_Spacemove(var/check_drift = 0)
+/mob/living/simple_animal/hostile/retaliate/malf_drone/Process_Spacemove()
 	return 1
 
 /mob/living/simple_animal/hostile/retaliate/malf_drone/proc/Haywire()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
@@ -212,5 +212,5 @@
 	if(damtype != BRUTE)
 		special_attacks++
 	
-/mob/living/simple_animal/hostile/retaliate/goat/king/Allow_Spacemove(check_drift = 0)
+/mob/living/simple_animal/hostile/retaliate/goat/king/Process_Spacemove()
 	return 1

--- a/code/modules/mob/living/simple_animal/hostile/vagrant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vagrant.dm
@@ -35,7 +35,7 @@
 
 	bleed_colour = "#aad9de"
 
-/mob/living/simple_animal/hostile/vagrant/Allow_Spacemove(var/check_drift = 0)
+/mob/living/simple_animal/hostile/vagrant/Process_Spacemove()
 	return 1
 
 /mob/living/simple_animal/hostile/vagrant/bullet_act(var/obj/item/projectile/Proj)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1045,8 +1045,12 @@
 // mobs do not have mouths by default
 /mob/proc/check_has_mouth()
 	return FALSE
+
 /mob/proc/check_has_eyes()
 	return TRUE
 
 /mob/proc/handle_pre_transformation()
 	return
+
+/mob/get_mass()
+	return mob_size

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -128,8 +128,6 @@
 	var/obj/item/clothing/mask/wear_mask = null//Carbon
 	var/in_throw_mode = 0
 
-	var/inertia_dir = 0
-
 //	var/job = null//Living
 
 	var/can_pull_size = ITEM_SIZE_STRUCTURE // Maximum w_class the mob can pull.

--- a/code/modules/mob/mob_grabs.dm
+++ b/code/modules/mob/mob_grabs.dm
@@ -24,7 +24,6 @@
 		if((grabber.mob_size == mob_size) && grabber.can_pull_mobs == MOB_PULL_SMALLER)
 			to_chat(grabber, SPAN_WARNING("\The [src] is too large for you to move!"))
 			return FALSE
-		inertia_dir = 0
 
 /mob/proc/handle_grab_damage()
 	set waitfor = 0

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -140,7 +140,7 @@
 		if ((A != src.loc && A && A.z == src.z))
 			src.last_move = get_dir(A, src.loc)
 	
-	if (!inertia_moving && !(direct & (UP|DOWN)))
+	if(!inertia_moving)
 		inertia_next_move = world.time + inertia_move_delay
 		space_drift(direct)
 
@@ -172,13 +172,14 @@
 
 	for(var/thing in trange(1,src))//checks for walls or grav turf first
 		var/turf/T = thing
-		if(T.density || T.is_wall() || (T.is_floor() && (shoegrip || has_gravity(src))))
+		if(T.density || T.is_wall() || (T.is_floor() && (shoegrip || has_gravity(T))))
 			return T
 
+	var/obj/item/grab/G = locate() in src
 	for(var/A in orange(1, get_turf(src)))
 		if(istype(A,/atom/movable))
 			var/atom/movable/AM = A
-			if(AM == buckled)
+			if(AM == inertia_ignore || !AM.simulated || !AM.mouse_opacity || AM == buckled)	//mouse_opacity is hacky as hell, need better solution
 				continue
 			if(ismob(AM))
 				var/mob/M = AM
@@ -187,10 +188,8 @@
 			if(AM.density || !AM.CanPass(src))
 				if(AM.anchored)
 					return AM
-				if(AM == inertia_ignore)
+				if(G && AM == G.affecting)
 					continue
-				//if(pulling == AM) solve this
-				//	continue
 				. = AM
 
 //Checks if a mob has solid ground to stand on
@@ -234,7 +233,7 @@
 /mob/proc/handle_spaceslipping()
 	if(prob(skill_fail_chance(SKILL_EVA, slip_chance(10), SKILL_EXPERT)))
 		to_chat(src, "<span class='warning'>You slipped!</span>")
-		step(turn(last_move, pick(45,-45)))
+		step(src,turn(last_move, pick(45,-45)))
 		return 1
 	return 0
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -195,7 +195,7 @@
 			return T
 
 	var/obj/item/grab/G = locate() in src
-	for(var/A in orange(1, get_turf(src)))
+	for(var/A in range(1, get_turf(src)))
 		if(istype(A,/atom/movable))
 			var/atom/movable/AM = A
 			if(AM == inertia_ignore || !AM.simulated || !AM.mouse_opacity || AM == buckled)	//mouse_opacity is hacky as hell, need better solution

--- a/code/modules/mob/observer/observer.dm
+++ b/code/modules/mob/observer/observer.dm
@@ -78,7 +78,6 @@ mob/observer/check_airflow_movable()
 	var/turf/T = locate(new_x, new_y, z)
 	if(T)
 		forceMove(T)
-		inertia_dir = 0
 		throwing = null
 		to_chat(src, "<span class='notice'>You cannot move further in this direction.</span>")
 

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -100,8 +100,7 @@
 		return
 
 	// No gravity in space, apparently.
-	var/area/area = get_area(src)
-	if(!area.has_gravity())
+	if(!has_gravity())
 		return
 
 	if(throwing)
@@ -241,8 +240,7 @@
 	var/turf/T = get_turf(A)
 	var/turf/above = GetAbove(src)
 	if(above && T.Adjacent(bound_overlay) && above.CanZPass(src, UP)) //Certain structures will block passage from below, others not
-		var/area/location = get_area(loc)
-		if(location.has_gravity && !can_overcome_gravity())
+		if(loc.has_gravity() && !can_overcome_gravity())
 			return FALSE
 
 		visible_message("<span class='notice'>[src] starts climbing onto \the [A]!</span>", "<span class='notice'>You start climbing onto \the [A]!</span>")

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -68,7 +68,7 @@
 	return 0
 
 /mob/living/carbon/human/can_ztravel()
-	if(Allow_Spacemove())
+	if(Process_Spacemove())
 		return 1
 
 	if(Check_Shoegrip())	//scaling hull with magboots
@@ -77,7 +77,7 @@
 				return 1
 
 /mob/living/silicon/robot/can_ztravel()
-	if(Allow_Spacemove()) //Checks for active jetpack
+	if(Process_Spacemove()) //Checks for active jetpack
 		return 1
 
 	for(var/turf/simulated/T in trange(1,src)) //Robots get "magboots"

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -116,8 +116,7 @@
 /obj/structure/ladder/hitby(obj/item/I)
 	if(!target_down)
 		return
-	var/area/room = get_area(src)
-	if(!room.has_gravity())
+	if(!has_gravity())
 		return
 	var/atom/blocker
 	var/turf/landing = get_turf(target_down)

--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -52,7 +52,7 @@ proc/get_deepspace(x,y)
 	return isnull(client)
 
 /mob/living/carbon/human/lost_in_space()
-	return isnull(client) && !last_ckey && stat == DEAD
+	return isnull(client) && (!last_ckey || stat == DEAD)
 
 proc/overmap_spacetravel(var/turf/space/T, var/atom/movable/A)
 	if (!T || !A)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -58,6 +58,7 @@
 	var/fire_sound_text = "gunshot"
 	var/fire_anim = null
 	var/screen_shake = 0 //shouldn't be greater than 2 unless zoomed
+	var/space_recoil = 0 //knocks back in space
 	var/silenced = 0
 	var/accuracy = 0   //accuracy is measured in tiles. +1 accuracy means that everything is effectively one tile closer for the purpose of miss chance, -1 means the opposite. launchers are not supported, at the moment.
 	var/accuracy_power = 5  //increase of to-hit chance per 1 point of accuracy
@@ -231,7 +232,7 @@
 			process_point_blank(projectile, user, target)
 
 		if(process_projectile(projectile, user, target, user.zone_sel?.selecting, clickparams))
-			handle_post_fire(user, target, pointblank, reflex)
+			handle_post_fire(user, target, pointblank, reflex, projectile)
 			update_icon()
 
 		if(i < burst)
@@ -268,7 +269,7 @@
 	playsound(src.loc, 'sound/weapons/empty.ogg', 100, 1)
 
 //called after successfully firing
-/obj/item/gun/proc/handle_post_fire(mob/user, atom/target, var/pointblank=0, var/reflex=0)
+/obj/item/gun/proc/handle_post_fire(mob/user, atom/target, var/pointblank=0, var/reflex=0, var/obj/projectile)
 	if(fire_anim)
 		flick(fire_anim, src)
 
@@ -320,6 +321,13 @@
 			var/obj/item/rig/R = H.back
 			for(var/obj/item/rig_module/stealth_field/S in R.installed_modules)
 				S.deactivate()
+	
+	if(space_recoil)
+		if(!has_gravity(user) && !user.anchored)
+			var/old_dir = user.dir
+			user.inertia_ignore = projectile
+			step(user,get_dir(target,user))
+			user.set_dir(old_dir)
 
 	update_icon()
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -323,7 +323,7 @@
 				S.deactivate()
 	
 	if(space_recoil)
-		if(!has_gravity(user) && !user.anchored)
+		if(!user.check_space_footing())
 			var/old_dir = user.dir
 			user.inertia_ignore = projectile
 			step(user,get_dir(target,user))

--- a/code/modules/projectiles/guns/launcher.dm
+++ b/code/modules/projectiles/guns/launcher.dm
@@ -6,6 +6,8 @@
 	w_class = ITEM_SIZE_HUGE
 	obj_flags =  OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_BACK
+	screen_shake = 1
+	space_recoil = 1
 
 	var/release_force = 0
 	var/throw_distance = 10

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -7,6 +7,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	material = MAT_STEEL
 	screen_shake = 1
+	space_recoil = 1
 	combustion = 1
 
 	var/caliber = CALIBER_PISTOL		//determines which casings will fit

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -47,6 +47,7 @@
 	var/drowsy = 0
 	var/agony = 0
 	var/embed = 0 // whether or not the projectile can embed itself in the mob
+	var/space_knockback = 0	//whether or not it will knock things back in space
 	var/penetration_modifier = 0.2 //How much internal damage this projectile can deal, as a multiplier.
 
 	var/hitscan = 0		// whether the projectile should be hitscan
@@ -103,6 +104,11 @@
 		var/turf/T = get_turf(A)
 		if(T)
 			T.hotspot_expose(700, 5)
+
+	if(space_knockback && ismovable(A) && !has_gravity(A))
+		var/atom/movable/AM = A
+		if(!AM.anchored)
+			step(AM,get_dir(firer,AM))
 
 //Checks if the projectile is eligible for embedding. Not that it necessarily will.
 /obj/item/projectile/can_embed()
@@ -515,3 +521,6 @@
 	
 /obj/item/projectile/get_autopsy_descriptors()
 	return list(name)
+
+/obj/item/projectile/Process_Spacemove()
+	return TRUE	//Bullets don't drift in space

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -105,10 +105,16 @@
 		if(T)
 			T.hotspot_expose(700, 5)
 
-	if(space_knockback && ismovable(A) && !has_gravity(A))
+	if(space_knockback && ismovable(A))
 		var/atom/movable/AM = A
-		if(!AM.anchored)
+		if(!AM.anchored && !AM.has_gravity())
+			if(ismob(AM))
+				var/mob/M = AM
+				if(M.check_space_footing())
+					return
+			var/old_dir = AM.dir
 			step(AM,get_dir(firer,AM))
+			AM.set_dir(old_dir)
 
 //Checks if the projectile is eligible for embedding. Not that it necessarily will.
 /obj/item/projectile/can_embed()

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -7,6 +7,7 @@
 	damage_flags = DAM_BULLET | DAM_SHARP
 	nodamage = 0
 	embed = 1
+	space_knockback = 1
 	penetration_modifier = 1.0
 	var/mob_passthrough_check = 0
 	var/caliber

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -202,8 +202,7 @@
 		icon_state = "net_roll"
 
 /obj/item/stack/net/proc/attach_wall_check()//checks if wall can be attached to something vertical such as walls or another net-wall
-	var/area/A = get_area(src)
-	if (!A.has_gravity)
+	if (!has_gravity())
 		return 1
 	var/turf/T = get_turf(src)
 	for (var/turf/AT in T.CardinalTurfs(FALSE))

--- a/nebula.dme
+++ b/nebula.dme
@@ -208,6 +208,7 @@
 #include "code\controllers\subsystems\radiation.dm"
 #include "code\controllers\subsystems\shuttle.dm"
 #include "code\controllers\subsystems\skybox.dm"
+#include "code\controllers\subsystems\spacedrift.dm"
 #include "code\controllers\subsystems\statistics.dm"
 #include "code\controllers\subsystems\sun.dm"
 #include "code\controllers\subsystems\supply.dm"

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -37,7 +37,7 @@ exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 20 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto uses" 'goto '
-exactly 423 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 421 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 6 "atom/New uses" '^/(obj|atom|area|mob|turf).*/New\('
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong


### PR DESCRIPTION
Port and HEAVILY modify SpaceDrift SS from TG

This PR should hopefully greatly improve space combat for nebula.
I might've made more hot messy spaghetti than a soup kitchen, don't kill me

<details>
  <summary>Features: - Click to expand!</summary>

- Allows for objects to drift through space
- Allow for progress bars while spacedrifting
- Makes magboots effective at reducing a lot of space related movement
- Adds in fancy gun knock back recoil, and recoil for being shot
- Nothing will ever be thrown indefinitely through the void, spacedrift should take over.
- Improve throwing momentum, allow you to knock other things around with throws
- Fixes pinning mob to walls for crossbow and spear
- Fixed lost in space for carbon/human
- Reduces the usages of spawn, Yay!
- Reworked all spaceslips failure; using a jetpack with untrained EVA is now a high stress activity 
</details>

## Images + Gifs
[Space Gunplay](https://i.imgur.com/qxEzjMu.gif)

[Zero G Movement](https://gfycat.com/slowuntidyasianpiedstarling)

[Throwing Momentum](https://i.imgur.com/UQYAUJV.gif)

[Spacedrift not canceling progress bar](https://i.imgur.com/9JXgx9T.gif)