### PR TITLE
Towards constructable airlocks

### DIFF
--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -135,7 +135,6 @@ var/const/BUTTON_FREQ       = 1301 // Used by generic buttons controlling stuff
 var/const/BLAST_DOORS_FREQ  = 1303 // Used by blast doors, buttons controlling them, and mass drivers.
 var/const/AIRLOCK_FREQ      = 1305 // Used by airlocks and buttons controlling them.
 var/const/SHUTTLE_AIR_FREQ  = 1331 // Used by shuttles and shuttle-related atmos systems.
-var/const/AIRLOCK_AIR_FREQ  = 1379 // Used by some airlocks for atmos devices.
 var/const/EXTERNAL_AIR_FREQ = 1380 // Used by some external airlocks.
 
 var/list/radiochannels = list(

--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -135,7 +135,7 @@ var/const/BUTTON_FREQ       = 1301 // Used by generic buttons controlling stuff
 var/const/BLAST_DOORS_FREQ  = 1303 // Used by blast doors, buttons controlling them, and mass drivers.
 var/const/AIRLOCK_FREQ      = 1305 // Used by airlocks and buttons controlling them.
 var/const/SHUTTLE_AIR_FREQ  = 1331 // Used by shuttles and shuttle-related atmos systems.
-var/const/EXTERNAL_AIR_FREQ = 1380 // Used by some external airlocks.
+var/const/EXTERNAL_AIR_FREQ = 1381 // Used by some external airlocks.
 
 var/list/radiochannels = list(
 	"Common"		= PUB_FREQ,

--- a/code/datums/extensions/multitool/multitool.dm
+++ b/code/datums/extensions/multitool/multitool.dm
@@ -9,7 +9,7 @@
 
 	var/html = get_interact_window(M, user)
 	if(html)
-		var/datum/browser/popup = new(usr, "multitool", "Multitool Menu", window_x, window_y)
+		var/datum/browser/popup = new(user, "multitool", "Multitool Menu", window_x, window_y)
 		popup.set_content(html)
 		popup.set_title_image(user.browse_rsc_icon(M.icon, M.icon_state))
 		popup.open()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -29,6 +29,7 @@ var/list/airlock_overlays = list()
 	var/main_power_lost_until = 0	 	//World time when main power is restored.
 	var/backup_power_lost_until = -1	//World time when backup power is restored.
 	var/next_beep_at = 0				//World time when we may next beep due to doors being blocked by mobs
+	var/shockedby = list()              //Some sort of admin logging var
 	var/spawnPowerRestoreRunning = 0
 	var/welded = null
 	var/locked = FALSE
@@ -92,12 +93,6 @@ var/list/airlock_overlays = list()
 		/obj/item/stock_parts/radio/receiver,
 		/obj/item/stock_parts/power/apc
 	)
-	// To be fleshed out and moved to parent door, but staying minimal for now.
-	public_methods = list(
-		/decl/public_access/public_method/toggle_door,
-		/decl/public_access/public_method/airlock_toggle_bolts
-	)
-	stock_part_presets = list(/decl/stock_part_preset/radio/receiver/airlock = 1)
 
 /obj/machinery/door/airlock/attack_generic(var/mob/user, var/damage)
 	if(stat & (BROKEN|NOPOWER))
@@ -1126,17 +1121,3 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/proc/stripe_airlock(var/paint_color)
 	stripe_color = paint_color
 	update_icon()
-
-// Public access
-
-/decl/public_access/public_method/airlock_toggle_bolts
-	name = "toggle bolts"
-	desc = "Toggles whether the airlock is bolted or not, if possible."
-	call_proc = /obj/machinery/door/airlock/proc/toggle_lock
-
-/decl/stock_part_preset/radio/receiver/airlock
-	frequency = AIRLOCK_FREQ
-	receive_and_call = list(
-		"toggle_door" = /decl/public_access/public_method/toggle_door,
-		"toggle_bolts" = /decl/public_access/public_method/airlock_toggle_bolts
-	)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -91,6 +91,7 @@ var/list/airlock_overlays = list()
 
 	uncreated_component_parts = list(
 		/obj/item/stock_parts/radio/receiver,
+		/obj/item/stock_parts/radio/transmitter/on_event,
 		/obj/item/stock_parts/power/apc
 	)
 

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -26,9 +26,9 @@
 	receive_and_call = list(
 		"toggle_door" = /decl/public_access/public_method/toggle_door,
 		"toggle_bolts" = /decl/public_access/public_method/airlock_toggle_bolts,
+		"unlock" = /decl/public_access/public_method/airlock_unlock,
 		"open" = /decl/public_access/public_method/open_door,
 		"close" = /decl/public_access/public_method/close_door,
-		"unlock" = /decl/public_access/public_method/airlock_unlock,
 		"lock" = /decl/public_access/public_method/airlock_lock,
 		"status" = /decl/public_access/public_method/toggle_input_toggle
 	)
@@ -133,7 +133,7 @@
 
 		if(abs(pressure - new_pressure) > 0.001 || pressure == null)
 			var/decl/public_access/public_variable/airlock_pressure/pressure_var = decls_repository.get_decl(/decl/public_access/public_variable/airlock_pressure)
-			pressure_var.write_var(src, pressure)
+			pressure_var.write_var(src, new_pressure)
 
 			var/new_alert = (pressure < ONE_ATMOSPHERE*0.8)
 			if(new_alert != alert)

--- a/code/game/machinery/doors/airlock_interactions.dm
+++ b/code/game/machinery/doors/airlock_interactions.dm
@@ -13,9 +13,6 @@
 /obj/structure/window/blocks_airlock()
 	return 0
 
-/obj/machinery/mech_sensor/blocks_airlock()
-	return 0
-
 /obj/effect/energy_field/blocks_airlock()
 	return 0
 

--- a/code/game/machinery/doors/airlock_subtypes.dm
+++ b/code/game/machinery/doors/airlock_subtypes.dm
@@ -166,7 +166,7 @@
 	locked = TRUE
 
 /obj/machinery/door/airlock/external/bolted/cycling
-	frequency = 1379
+	frequency = 1380
 
 /obj/machinery/door/airlock/external/bolted_open
 	density = FALSE
@@ -183,7 +183,7 @@
 	locked = TRUE
 
 /obj/machinery/door/airlock/external/glass/bolted/cycling
-	frequency = 1379
+	frequency = 1380
 
 /obj/machinery/door/airlock/external/glass/bolted_open
 	density = FALSE

--- a/code/game/machinery/doors/airlock_subtypes.dm
+++ b/code/game/machinery/doors/airlock_subtypes.dm
@@ -87,6 +87,10 @@
 /obj/machinery/door/airlock/glass/virology
 	door_color = COLOR_WHITE
 	stripe_color = COLOR_GREEN
+	stock_part_presets = list(
+		/decl/stock_part_preset/radio/receiver/airlock/external_air = 1,
+		/decl/stock_part_preset/radio/event_transmitter/airlock/external_air = 1
+	)
 
 /obj/machinery/door/airlock/glass/mining
 	door_color = COLOR_PALE_ORANGE
@@ -136,6 +140,10 @@
 	assembly_type = /obj/structure/door_assembly/door_assembly_ext
 	door_color = COLOR_NT_RED
 	paintable = AIRLOCK_PAINTABLE
+	stock_part_presets = list(
+		/decl/stock_part_preset/radio/receiver/airlock/external_air = 1,
+		/decl/stock_part_preset/radio/event_transmitter/airlock/external_air = 1
+	)
 
 /obj/machinery/door/airlock/external/inherit_access_from_area()
 	..()
@@ -144,7 +152,6 @@
 
 /obj/machinery/door/airlock/external/escapepod
 	name = "Escape Pod"
-	frequency =  1380
 	locked = TRUE
 
 /obj/machinery/door/airlock/external/escapepod/attackby(obj/item/C, mob/user)
@@ -162,11 +169,14 @@
 				return
 	..()
 
+/obj/machinery/door/airlock/external/shuttle
+	stock_part_presets = list(
+		/decl/stock_part_preset/radio/receiver/airlock/shuttle = 1,
+		/decl/stock_part_preset/radio/event_transmitter/airlock/shuttle = 1
+	)
+
 /obj/machinery/door/airlock/external/bolted
 	locked = TRUE
-
-/obj/machinery/door/airlock/external/bolted/cycling
-	frequency = 1380
 
 /obj/machinery/door/airlock/external/bolted_open
 	density = FALSE
@@ -181,9 +191,6 @@
 
 /obj/machinery/door/airlock/external/glass/bolted
 	locked = TRUE
-
-/obj/machinery/door/airlock/external/glass/bolted/cycling
-	frequency = 1380
 
 /obj/machinery/door/airlock/external/glass/bolted_open
 	density = FALSE

--- a/code/game/machinery/embedded_controller/airlock_controllers.dm
+++ b/code/game/machinery/embedded_controller/airlock_controllers.dm
@@ -2,6 +2,7 @@
 /obj/machinery/embedded_controller/radio/airlock
 	// Setup parameters only
 	program = /datum/computer/file/embedded_program/airlock
+	base_type = /obj/machinery/embedded_controller/radio/airlock/airlock_controller
 	var/tag_exterior_door
 	var/tag_interior_door
 	var/tag_airpump

--- a/code/game/machinery/embedded_controller/airlock_controllers.dm
+++ b/code/game/machinery/embedded_controller/airlock_controllers.dm
@@ -8,8 +8,6 @@
 	var/tag_chamber_sensor
 	var/tag_exterior_sensor
 	var/tag_interior_sensor
-	var/tag_airlock_mech_sensor
-	var/tag_shuttle_mech_sensor
 	var/tag_secure = 0
 	var/tag_air_alarm
 	var/list/dummy_terminals = list()

--- a/code/game/machinery/embedded_controller/airlock_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/airlock_docking_controller.dm
@@ -95,14 +95,12 @@
 
 //we are docked, open the doors or whatever.
 /datum/computer/file/embedded_program/docking/airlock/finish_docking()
-	airlock_program.enable_mech_regulators()
 	airlock_program.open_doors()
 
 //tell the docking port to start getting ready for undocking - e.g. close those doors.
 /datum/computer/file/embedded_program/docking/airlock/prepare_for_undocking()
 	airlock_program.stop_cycling()
 	airlock_program.close_doors()
-	airlock_program.disable_mech_regulators()
 
 //are we ready for undocking?
 /datum/computer/file/embedded_program/docking/airlock/ready_for_undocking()
@@ -124,12 +122,6 @@
 /datum/computer/file/embedded_program/airlock/docking/receive_user_command(command)
 	if (master_prog.undocked() || master_prog.override_enabled)	//only allow the port to be used as an airlock if nothing is docked here or the override is enabled
 		return ..(command)
-
-/datum/computer/file/embedded_program/airlock/docking/proc/enable_mech_regulators()
-	enable_mech_regulation()
-
-/datum/computer/file/embedded_program/airlock/docking/proc/disable_mech_regulators()
-	disable_mech_regulation()
 
 /datum/computer/file/embedded_program/airlock/docking/proc/open_doors()
 	toggleDoor(memory["interior_status"], tag_interior_door, memory["secure"], "open")

--- a/code/game/machinery/embedded_controller/airlock_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/airlock_docking_controller.dm
@@ -4,6 +4,7 @@
 	program = /datum/computer/file/embedded_program/docking/airlock
 	var/display_name			//how would it show up on docking monitoring program, area name + coordinates if unset
 	tag_secure = 1
+	base_type = /obj/machinery/embedded_controller/radio/airlock/docking_port
 
 /obj/machinery/embedded_controller/radio/airlock/docking_port/Initialize()
 	. = ..()
@@ -80,6 +81,11 @@
 	. = ..()
 	if(istype(airlock_program))
 		. |= airlock_program.get_receive_filters()
+
+/datum/computer/file/embedded_program/docking/airlock/reset_id_tags(base_tag)
+	. = ..()
+	if(!. && istype(airlock_program))
+		return airlock_program.reset_id_tags(base_tag)
 
 /datum/computer/file/embedded_program/docking/airlock/receive_signal(datum/signal/signal, receive_method, receive_param)
 	airlock_program.receive_signal(signal, receive_method, receive_param)	//pass along to subprograms

--- a/code/game/machinery/embedded_controller/airlock_program.dm
+++ b/code/game/machinery/embedded_controller/airlock_program.dm
@@ -18,8 +18,6 @@
 	var/tag_chamber_sensor
 	var/tag_exterior_sensor
 	var/tag_interior_sensor
-	var/tag_airlock_mech_sensor
-	var/tag_shuttle_mech_sensor
 
 	var/state = STATE_IDLE
 	var/target_state = TARGET_NONE
@@ -55,8 +53,6 @@
 		tag_chamber_sensor = controller.tag_chamber_sensor? controller.tag_chamber_sensor : "[id_tag]_sensor"
 		tag_exterior_sensor = controller.tag_exterior_sensor || "[id_tag]_exterior_sensor"
 		tag_interior_sensor = controller.tag_interior_sensor || "[id_tag]_interior_sensor"
-		tag_airlock_mech_sensor = controller.tag_airlock_mech_sensor? controller.tag_airlock_mech_sensor : "[id_tag]_airlock_mech"
-		tag_shuttle_mech_sensor = controller.tag_shuttle_mech_sensor? controller.tag_shuttle_mech_sensor : "[id_tag]_shuttle_mech"
 		tag_air_alarm = controller.tag_air_alarm || "[id_tag]_alarm"
 		memory["secure"] = controller.tag_secure
 
@@ -362,20 +358,6 @@
 		if(TARGET_INOPEN)
 			toggleDoor(memory["exterior_status"], tag_exterior_door, memory["secure"], "close")
 			toggleDoor(memory["interior_status"], tag_interior_door, memory["secure"], "open")
-
-datum/computer/file/embedded_program/airlock/proc/signal_mech_sensor(var/command, var/sensor)
-	var/datum/signal/signal = new
-	signal.data["tag"] = sensor
-	signal.data["command"] = command
-	post_signal(signal, tag)
-
-/datum/computer/file/embedded_program/airlock/proc/enable_mech_regulation()
-	signal_mech_sensor("enable", tag_shuttle_mech_sensor)
-	signal_mech_sensor("enable", tag_airlock_mech_sensor)
-
-/datum/computer/file/embedded_program/airlock/proc/disable_mech_regulation()
-	signal_mech_sensor("disable", tag_shuttle_mech_sensor)
-	signal_mech_sensor("disable", tag_airlock_mech_sensor)
 
 /*----------------------------------------------------------
 toggleDoor()

--- a/code/game/machinery/embedded_controller/airlock_program.dm
+++ b/code/game/machinery/embedded_controller/airlock_program.dm
@@ -174,7 +174,6 @@
 		if("purge")
 			memory["purge"] = !memory["purge"]
 			if(memory["purge"])
-				close_doors()
 				state = STATE_PREPARE
 				target_state = TARGET_NONE
 
@@ -201,9 +200,6 @@
 					memory["target_pressure"] = memory["internal_sensor_pressure"]
 				if(TARGET_OUTOPEN)
 					memory["target_pressure"] = memory["external_sensor_pressure"]
-
-			//lock down the airlock before activating pumps
-			close_doors()
 
 			state = STATE_PREPARE
 		else
@@ -250,6 +246,8 @@
 						memory["purge"] = 1 // should always purge first if using external air, chamber pressure should never be higher than target pressure here
 
 				memory["target_pressure"] = target_pressure
+			else
+				close_doors()
 
 		if(STATE_PRESSURIZE)
 			if(memory["chamber_sensor_pressure"] >= memory["target_pressure"] - SENSOR_TOLERANCE)

--- a/code/game/machinery/embedded_controller/airlock_program.dm
+++ b/code/game/machinery/embedded_controller/airlock_program.dm
@@ -29,8 +29,6 @@
 	var/tag_air_alarm
 
 /datum/computer/file/embedded_program/airlock/New(var/obj/machinery/embedded_controller/M)
-	..(M)
-
 	memory["chamber_sensor_pressure"] = ONE_ATMOSPHERE
 	memory["external_sensor_pressure"] = 0					//assume vacuum for simple airlock controller
 	memory["internal_sensor_pressure"] = ONE_ATMOSPHERE
@@ -40,10 +38,11 @@
 	memory["target_pressure"] = ONE_ATMOSPHERE
 	memory["purge"] = 0
 	memory["secure"] = 0
-	if (istype(master, /obj/machinery/embedded_controller/radio/airlock))
-		var/obj/machinery/embedded_controller/radio/airlock/controller = master
+	if (istype(M, /obj/machinery/embedded_controller/radio/airlock))
+		var/obj/machinery/embedded_controller/radio/airlock/controller = M
 		memory["secure"] = controller.tag_secure
 		cycle_to_external_air = controller.cycle_to_external_air
+	..(M)
 
 #define SET_AIRLOCK_TAG(FROM_CONTROLLER, FROM_SRC) (base_tag ? FROM_SRC : (FROM_CONTROLLER || FROM_SRC))
 
@@ -65,6 +64,8 @@
 		spawn(10)
 			signalDoor(tag_exterior_door)		//signals connected doors to update their status
 			signalDoor(tag_interior_door)
+
+#undef SET_AIRLOCK_TAG
 
 /datum/computer/file/embedded_program/airlock/get_receive_filters(for_ui = FALSE)
 	. = list(

--- a/code/game/machinery/embedded_controller/docking_program.dm
+++ b/code/game/machinery/embedded_controller/docking_program.dm
@@ -55,7 +55,6 @@
 	var/dock_state = STATE_UNDOCKED
 	var/control_mode = MODE_NONE
 	var/response_sent = 0		//so we don't spam confirmation messages
-	var/resend_counter = 0		//for periodically resending confirmation messages in case they are missed
 
 	var/override_enabled = 0	//when enabled, do not open/close doors or cycle airlocks and wait for the player to do it manually
 	var/received_confirm = 0	//for undocking, whether the server has recieved a confirmation from the client
@@ -189,13 +188,6 @@
 						finish_undocking()
 					reset()		//server is done undocking!
 
-	if (response_sent || resend_counter > 0)
-		resend_counter++
-
-	if (resend_counter >= MESSAGE_RESEND_TIME || (dock_state != STATE_DOCKING && dock_state != STATE_UNDOCKING))
-		response_sent = 0
-		resend_counter = 0
-
 	//handle invalid states
 	if (control_mode == MODE_NONE && dock_state != STATE_UNDOCKED)
 		if (tag_target)
@@ -294,7 +286,7 @@
 	var/datum/signal/signal = new
 	signal.data["tag"] = id_tag
 	signal.data["dock_status"] = get_docking_status()
-	post_signal(signal, tag)
+	post_signal(signal, id_tag)
 
 //this is mostly for NanoUI
 /datum/computer/file/embedded_program/docking/proc/get_docking_status()

--- a/code/game/machinery/embedded_controller/docking_program.dm
+++ b/code/game/machinery/embedded_controller/docking_program.dm
@@ -62,8 +62,11 @@
 	var/docking_codes			//would only allow docking when receiving signal with these, if set
 	var/display_name			//how would it show up on docking monitoring program, area name + coordinates if unset
 
-/datum/computer/file/embedded_program/docking/New(var/obj/machinery/embedded_controller/M)
-	..()
+/datum/computer/file/embedded_program/docking/reset_id_tags(base_tag)
+	if(SSshuttle.docking_registry[base_tag])
+		return SPAN_WARNING("The tag [base_tag] is already registered and cannot be used.")
+	SSshuttle.docking_registry -= id_tag
+	. = ..()
 	if(id_tag)
 		if(SSshuttle.docking_registry[id_tag])
 			crash_with("Docking controller tag [id_tag] had multiple associated programs.")
@@ -88,7 +91,7 @@
 		return TRUE
 
 /datum/computer/file/embedded_program/docking/get_receive_filters()
-	return list(id_tag)
+	return list("[id_tag]" = "primary controller")
 
 /datum/computer/file/embedded_program/docking/receive_signal(datum/signal/signal, receive_method, receive_param)
 	var/receive_tag = signal.data["tag"]		//for docking signals, this is the sender id

--- a/code/game/machinery/embedded_controller/docking_program_multi.dm
+++ b/code/game/machinery/embedded_controller/docking_program_multi.dm
@@ -11,11 +11,13 @@
 	var/list/children_ready
 	var/list/children_override
 
-/datum/computer/file/embedded_program/docking/multi/New(var/obj/machinery/embedded_controller/M)
-	..(M)
+/datum/computer/file/embedded_program/docking/multi/reset_id_tags(base_tag)
+	. = ..()
 
-	if (istype(M,/obj/machinery/embedded_controller/radio/docking_port_multi))	//if our parent controller is the right type, then we can auto-init stuff at construction
-		var/obj/machinery/embedded_controller/radio/docking_port_multi/controller = M
+	children_tags = null
+
+	if (istype(master,/obj/machinery/embedded_controller/radio/docking_port_multi))	//if our parent controller is the right type, then we can auto-init stuff at construction
+		var/obj/machinery/embedded_controller/radio/docking_port_multi/controller = master
 		//parse child_tags_txt and create child tags
 		children_tags = splittext(controller.child_tags_txt, ";")
 

--- a/code/game/machinery/embedded_controller/docking_program_multi.dm
+++ b/code/game/machinery/embedded_controller/docking_program_multi.dm
@@ -174,11 +174,9 @@
 			if (!override_enabled)
 				stop_cycling()
 				close_doors()
-				disable_mech_regulation()
 
 		if ("finish_docking")
 			if (!override_enabled)
-				enable_mech_regulation()
 				open_doors()
 
 		if ("finish_undocking")

--- a/code/game/machinery/embedded_controller/embedded_controller_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_controller_base.dm
@@ -83,12 +83,16 @@ obj/machinery/embedded_controller/radio/Destroy()
 		else
 			overlays += image(icon, "screen_fill")
 
+#define AIRLOCK_CONTROL_RANGE 22
+
 /obj/machinery/embedded_controller/radio/post_signal(datum/signal/signal, var/radio_filter = null)
 	signal.transmission_method = TRANSMISSION_RADIO
 	if(radio_connection)
 		return radio_connection.post_signal(src, signal, radio_filter, AIRLOCK_CONTROL_RANGE)
 	else
 		qdel(signal)
+
+#undef AIRLOCK_CONTROL_RANGE
 
 /obj/machinery/embedded_controller/radio/proc/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)

--- a/code/game/machinery/embedded_controller/embedded_controller_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_controller_base.dm
@@ -130,9 +130,10 @@ obj/machinery/embedded_controller/radio/Destroy()
 		for(var/tag in tags)
 			. += "<tr>"
 			. += "<td>[tags[tag]]</td>"
-			. += "<td>tag</td>"
+			. += "<td>[tag]</td>"
 			. += "</tr>"
 		. += "</table>"
+	. = JOINTEXT(.)
 
 /datum/extension/interactive/multitool/embedded_controller/on_topic(href, href_list, user)
 	var/obj/machinery/embedded_controller/radio/controller = holder

--- a/code/game/machinery/embedded_controller/embedded_controller_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_controller_base.dm
@@ -49,12 +49,19 @@
 	power_channel = ENVIRON
 	density = 0
 	unacidable = 1
-	var/frequency = 1380
+	var/frequency = EXTERNAL_AIR_FREQ
 	var/datum/radio_frequency/radio_connection
+
+	uncreated_component_parts = null
+	construct_state = /decl/machine_construction/wall_frame/panel_closed
+	frame_type = /obj/item/frame/button/airlock_controller
+	base_type = /obj/machinery/embedded_controller/radio/simple_docking_controller
+	stat_immune = 0
 
 /obj/machinery/embedded_controller/radio/Initialize()
 	. = ..()
 	set_frequency(frequency)
+	set_extension(src, /datum/extension/interactive/multitool/embedded_controller)
 
 obj/machinery/embedded_controller/radio/Destroy()
 	if(radio_controller)
@@ -100,3 +107,49 @@ obj/machinery/embedded_controller/radio/Destroy()
 	var/list/filters = program?.get_receive_filters()
 	for(var/filter in filters)
 		radio_connection = radio_controller.add_object(src, frequency, filter)
+
+// resets all id_tags (including in programs) based on the given tag.
+/obj/machinery/embedded_controller/radio/proc/reset_id_tags(base_tag)
+	id_tag = base_tag
+	if(program)
+		program.reset_id_tags(base_tag)
+
+/datum/extension/interactive/multitool/embedded_controller/get_interact_window(var/obj/item/multitool/M, var/mob/user)
+	var/obj/machinery/embedded_controller/radio/controller = holder
+	if(!istype(holder))
+		return
+	. = list()
+	. += "ID tag: <a href='?src=\ref[src];set_tag=1'>[controller.id_tag]</a><br>"
+	. += "Frequency: <a href='?src=\ref[src];set_freq=1'>[controller.frequency]</a><br>"
+	. += "Likely tags used by controller:<br>"
+	var/list/tags = controller.program?.get_receive_filters(TRUE)
+	if(!length(tags))
+		. += "None."
+	else
+		. += "<table>"
+		for(var/tag in tags)
+			. += "<tr>"
+			. += "<td>[tags[tag]]</td>"
+			. += "<td>tag</td>"
+			. += "</tr>"
+		. += "</table>"
+
+/datum/extension/interactive/multitool/embedded_controller/on_topic(href, href_list, user)
+	var/obj/machinery/embedded_controller/radio/controller = holder
+	if(href_list["set_tag"])
+		var/new_tag = input(user, "Enter a new tag to use. Warning: this will reset all tags used by this machine, not just the main one!", "Tag Selection", controller.id_tag) as text|null
+		if(extension_status(user) != STATUS_INTERACTIVE)
+			return MT_NOACTION
+		sanitize(new_tag)
+		if(new_tag)
+			controller.reset_id_tags(new_tag)
+			controller.set_frequency(controller.frequency)
+			return MT_REFRESH
+
+	if(href_list["set_freq"])
+		var/new_frequency = input(user, "Enter a new frequency to use.", "frequency Selection", controller.frequency) as num|null
+		if(!new_frequency || (extension_status(user) != STATUS_INTERACTIVE))
+			return MT_NOACTION
+		new_frequency = sanitize_frequency(new_frequency, RADIO_LOW_FREQ, RADIO_HIGH_FREQ)
+		controller.set_frequency(new_frequency)
+		return MT_REFRESH

--- a/code/game/machinery/embedded_controller/embedded_controller_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_controller_base.dm
@@ -49,7 +49,7 @@
 	power_channel = ENVIRON
 	density = 0
 	unacidable = 1
-	var/frequency = 1379
+	var/frequency = 1380
 	var/datum/radio_frequency/radio_connection
 
 /obj/machinery/embedded_controller/radio/Initialize()

--- a/code/game/machinery/embedded_controller/embedded_program_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_program_base.dm
@@ -5,11 +5,9 @@
 	var/id_tag
 
 /datum/computer/file/embedded_program/New(var/obj/machinery/embedded_controller/M)
-	master = M
-	if (istype(M, /obj/machinery/embedded_controller/radio))
-		var/obj/machinery/embedded_controller/R = M
-		id_tag = R.id_tag
 	..()
+	master = M
+	reset_id_tags()
 
 /datum/computer/file/embedded_program/Destroy()
 	if(master)
@@ -21,7 +19,7 @@
 	return FALSE
 
 // Returns all filters on which you want to receive signals
-/datum/computer/file/embedded_program/proc/get_receive_filters()
+/datum/computer/file/embedded_program/proc/get_receive_filters(var/for_ui = FALSE)
 
 /datum/computer/file/embedded_program/proc/receive_signal(datum/signal/signal, receive_method, receive_param)
 	return
@@ -34,3 +32,6 @@
 		master.post_signal(signal, comm_line)
 	else
 		qdel(signal)
+
+/datum/computer/file/embedded_program/proc/reset_id_tags(base_tag)
+	id_tag = base_tag || master.id_tag

--- a/code/game/machinery/embedded_controller/simple_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/simple_docking_controller.dm
@@ -31,16 +31,19 @@
 	..(M)
 	memory["door_status"] = list(state = "closed", lock = "locked")		//assume closed and locked in case the doors dont report in
 
-	if (istype(M, /obj/machinery/embedded_controller/radio/simple_docking_controller))
-		var/obj/machinery/embedded_controller/radio/simple_docking_controller/controller = M
+/datum/computer/file/embedded_program/docking/simple/reset_id_tags(base_tag)
+	. = ..()
+	if (istype(master, /obj/machinery/embedded_controller/radio/simple_docking_controller))
+		var/obj/machinery/embedded_controller/radio/simple_docking_controller/controller = master
 
-		tag_door = controller.tag_door? controller.tag_door : "[id_tag]_hatch"
+		tag_door = (!base_tag && controller.tag_door) || "[id_tag]_hatch"
 
 		spawn(10)
 			signalDoor()		//signals connected doors to update their status
 
 /datum/computer/file/embedded_program/docking/simple/get_receive_filters()
-	return ..() + tag_door
+	. = ..()
+	.[tag_door] = "doors"
 
 /datum/computer/file/embedded_program/docking/simple/receive_signal(datum/signal/signal, receive_method, receive_param)
 	var/receive_tag = signal.data["tag"]

--- a/code/game/machinery/embedded_controller/simple_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/simple_docking_controller.dm
@@ -37,7 +37,7 @@
 		tag_door = controller.tag_door? controller.tag_door : "[id_tag]_hatch"
 
 		spawn(10)
-			signal_door("update")		//signals connected doors to update their status
+			signalDoor()		//signals connected doors to update their status
 
 /datum/computer/file/embedded_program/docking/simple/get_receive_filters()
 	return ..() + tag_door
@@ -58,10 +58,7 @@
 	switch(command)
 		if("force_door")
 			if (override_enabled)
-				if(memory["door_status"]["state"] == "open")
-					close_door()
-				else
-					open_door()
+				toggleDoor(memory["door_status"], tag_door, TRUE, "toggle")
 		if("toggle_override")
 			if (override_enabled)
 				disable_override()
@@ -69,30 +66,6 @@
 				enable_override()
 		else
 			. = FALSE
-
-/datum/computer/file/embedded_program/docking/simple/proc/signal_door(var/command)
-	var/datum/signal/signal = new
-	signal.data["tag"] = tag_door
-	signal.data["command"] = command
-	post_signal(signal, tag_door)
-
-///datum/computer/file/embedded_program/docking/simple/proc/signal_mech_sensor(var/command)
-//	signal_door(command)
-//	return
-
-/datum/computer/file/embedded_program/docking/simple/proc/open_door()
-	if(memory["door_status"]["state"] == "closed")
-		//signal_mech_sensor("enable")
-		signal_door("secure_open")
-	else if(memory["door_status"]["lock"] == "unlocked")
-		signal_door("lock")
-
-/datum/computer/file/embedded_program/docking/simple/proc/close_door()
-	if(memory["door_status"]["state"] == "open")
-		signal_door("secure_close")
-		//signal_mech_sensor("disable")
-	else if(memory["door_status"]["lock"] == "unlocked")
-		signal_door("lock")
 
 //tell the docking port to start getting ready for docking - e.g. pressurize
 /datum/computer/file/embedded_program/docking/simple/prepare_for_docking()
@@ -104,11 +77,11 @@
 
 //we are docked, open the doors or whatever.
 /datum/computer/file/embedded_program/docking/simple/finish_docking()
-	open_door()
+	toggleDoor(memory["door_status"], tag_door, TRUE, "open")
 
 //tell the docking port to start getting ready for undocking - e.g. close those doors.
 /datum/computer/file/embedded_program/docking/simple/prepare_for_undocking()
-	close_door()
+	toggleDoor(memory["door_status"], tag_door, TRUE, "close")
 
 //are we ready for undocking?
 /datum/computer/file/embedded_program/docking/simple/ready_for_undocking()

--- a/code/game/machinery/embedded_controller/tin_can.dm
+++ b/code/game/machinery/embedded_controller/tin_can.dm
@@ -12,8 +12,10 @@
 #define STATE_SEALED   3
 
 /obj/machinery/embedded_controller/radio/airlock/tin_can
+	name = "non-cycling shuttle airlock controller"
 	program = /datum/computer/file/embedded_program/airlock/tin_can
 	cycle_to_external_air = TRUE // Some kind of legacy var needed for proper init
+	base_type = /obj/machinery/embedded_controller/radio/airlock/tin_can
 
 /obj/machinery/embedded_controller/radio/airlock/tin_can/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/nanoui/master_ui = null, datum/topic_state/state = GLOB.default_state)
 	var/list/data = list()

--- a/code/game/machinery/embedded_controller/tin_can.dm
+++ b/code/game/machinery/embedded_controller/tin_can.dm
@@ -46,8 +46,7 @@
 	switch(command)
 		if("toggle_door_safety")
 			door_safety = !door_safety
-			if(!door_safety)
-				signalDoor(tag_exterior_door, "unlock")
+			toggleDoor(memory["exterior_status"], tag_exterior_door, door_safety)
 		if("evacuate_atmos")
 			if(state == STATE_EVACUATE)
 				return
@@ -74,11 +73,8 @@
 
 /datum/computer/file/embedded_program/airlock/tin_can/process()
 	if(door_safety)
-		var/safe_to_open = safe_to_open()
-		if(safe_to_open && memory["exterior_status"]["lock"] == "locked")
-			signalDoor(tag_exterior_door, "unlock")
-		else if(!safe_to_open && memory["exterior_status"]["lock"] == "unlocked")
-			signalDoor(tag_exterior_door, "secure_close") // close and lock
+		var/safe_to_open = safe_to_open() // If safe, unlock; if not, close and lock
+		toggleDoor(memory["exterior_status"], tag_exterior_door, !safe_to_open, !safe_to_open ? "close" : null)
 
 /datum/computer/file/embedded_program/airlock/tin_can/proc/safe_to_open()
 	. = TRUE

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -201,3 +201,10 @@
 /obj/item/frame/stock_offset/newscaster/kit
 	name = "newscaster kit"
 	fully_construct = TRUE
+
+/obj/item/frame/button/airlock_sensor
+	icon = 'icons/obj/airlock_machines.dmi'
+	icon_state = "airlock_sensor_off"
+	name = "airlock sensor"
+	desc = "An airlock sensor frame."
+	build_machine_type = /obj/machinery/airlock_sensor/buildable

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -208,3 +208,26 @@
 	name = "airlock sensor"
 	desc = "An airlock sensor frame."
 	build_machine_type = /obj/machinery/airlock_sensor/buildable
+
+/obj/item/frame/button/airlock_controller
+	icon = 'icons/obj/airlock_machines.dmi'
+	icon_state = "airlock_control_off"
+	name = "airlock controller frame"
+	desc = "Used to build airlock controllers. Use a multitool on the circuit to determine which type you want, and then hit this with the the circuit."
+	build_machine_type = null
+
+/obj/item/frame/button/airlock_controller/try_build(turf/on_wall, click_params)
+	if(!build_machine_type)
+		to_chat(usr, SPAN_WARNING("First hit this with a circuitboard to configure it!"))
+		return
+	return ..()
+
+/obj/item/frame/button/airlock_controller/attackby(obj/item/W, mob/user)
+	if(istype(W, /obj/item/stock_parts/circuitboard))
+		var/obj/item/stock_parts/circuitboard/board = W
+		if(ispath(board.build_path, /obj/machinery/embedded_controller/radio))
+			build_machine_type = board.build_path
+			to_chat(user, SPAN_NOTICE("You configure \the [src] using \the [W]."))
+			return TRUE
+	. = ..()
+	

--- a/code/game/objects/items/weapons/circuitboards/wall.dm
+++ b/code/game/objects/items/weapons/circuitboards/wall.dm
@@ -69,3 +69,24 @@
 /obj/item/stock_parts/circuitboard/requests_console/newscaster
 	name = T_BOARD("newscaster")
 	build_path = /obj/machinery/newscaster
+
+/obj/item/stock_parts/circuitboard/airlock_controller
+	name = T_BOARD("airlock controller")
+	build_path = /obj/machinery/embedded_controller/radio/simple_docking_controller
+	board_type = "wall"
+	origin_tech = "{'" + TECH_DATA + "':3,'" + TECH_ENGINEERING + "':3}"
+	req_components = list()
+	additional_spawn_components = list(
+		/obj/item/stock_parts/console_screen = 1,
+		/obj/item/stock_parts/keyboard = 1,
+		/obj/item/stock_parts/power/apc/buildable = 1,
+	)
+	buildtype_select = TRUE
+
+/obj/item/stock_parts/circuitboard/airlock_controller/get_buildable_types()
+	. = list()
+	for(var/path in typesof(/obj/machinery/embedded_controller/radio))
+		var/obj/machinery/embedded_controller/radio/controller = path
+		var/base_type = initial(controller.base_type) || path
+		. |= base_type
+	

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -35,7 +35,7 @@
 	)
 	public_methods = list(
 		/decl/public_access/public_method/toggle_unlocked,
-		/decl/public_access/public_method/refresh	
+		/decl/public_access/public_method/toggle_input_toggle	
 	) // Does come with suggested stock configurations, though.
 	stock_part_presets = list(
 		/decl/stock_part_preset/radio/receiver/passive_gate = 1,
@@ -280,7 +280,7 @@
 	frequency = PUMP_FREQ
 	receive_and_call = list(
 		"power_toggle" = /decl/public_access/public_method/toggle_unlocked,
-		"status" = /decl/public_access/public_method/refresh
+		"status" = /decl/public_access/public_method/toggle_input_toggle
 	)
 	receive_and_write = list(
 		"set_power" = /decl/public_access/public_variable/passive_gate_unlocked,

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -45,7 +45,7 @@ Thus, the two variables affect pump operation are set in New():
 	)
 	public_methods = list(
 		/decl/public_access/public_method/toggle_power,
-		/decl/public_access/public_method/refresh
+		/decl/public_access/public_method/toggle_input_toggle
 	)
 	stock_part_presets = list(
 		/decl/stock_part_preset/radio/receiver/pump = 1,
@@ -212,7 +212,7 @@ Thus, the two variables affect pump operation are set in New():
 	frequency = PUMP_FREQ
 	receive_and_call = list(
 		"power_toggle" = /decl/public_access/public_method/toggle_power,
-		"status" = /decl/public_access/public_method/refresh
+		"status" = /decl/public_access/public_method/toggle_input_toggle
 	)
 	receive_and_write = list(
 		"set_power" = /decl/public_access/public_variable/use_power,

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -39,7 +39,7 @@
 	public_methods = list(
 		/decl/public_access/public_method/toggle_power,
 		/decl/public_access/public_method/inject,
-		/decl/public_access/public_method/refresh
+		/decl/public_access/public_method/toggle_input_toggle
 	)
 	stock_part_presets = list(
 		/decl/stock_part_preset/radio/receiver/outlet_injector = 1,
@@ -187,7 +187,7 @@
 		"power_toggle" = /decl/public_access/public_method/toggle_power,
 		"valve_toggle" = /decl/public_access/public_method/toggle_power,
 		"inject" = /decl/public_access/public_method/inject,
-		"status" = /decl/public_access/public_method/refresh
+		"status" = /decl/public_access/public_method/toggle_input_toggle
 	) // power_toggle and valve_toggle are used by different senders
 	receive_and_write = list(
 		"set_power" = /decl/public_access/public_variable/use_power,

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -520,21 +520,6 @@
 		/decl/stock_part_preset/radio/event_transmitter/vent_pump/shuttle/aux = 1
 	)
 
-/decl/stock_part_preset/radio/receiver/vent_pump/airlock
-	frequency = AIRLOCK_AIR_FREQ
-	filter = null
-
-/decl/stock_part_preset/radio/event_transmitter/vent_pump/airlock
-	frequency = AIRLOCK_AIR_FREQ
-	filter = null
-
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock
-	controlled = FALSE
-	stock_part_presets = list(
-		/decl/stock_part_preset/radio/receiver/vent_pump/airlock = 1,
-		/decl/stock_part_preset/radio/event_transmitter/vent_pump/airlock = 1
-	)
-
 /decl/stock_part_preset/radio/receiver/vent_pump/engine
 	frequency = ATMOS_ENGINE_FREQ
 	filter = null

--- a/code/modules/fabrication/designs/general/designs_engineering.dm
+++ b/code/modules/fabrication/designs/general/designs_engineering.dm
@@ -32,6 +32,9 @@
 /datum/fabricator_recipe/engineering/button_frame
 	path = /obj/item/frame/button
 
+/datum/fabricator_recipe/engineering/airlock_sensor
+	path = /obj/item/frame/button/airlock_sensor
+
 /datum/fabricator_recipe/engineering/powermodule
 	path = /obj/item/stock_parts/circuitboard/apc
 

--- a/code/modules/fabrication/designs/general/designs_engineering.dm
+++ b/code/modules/fabrication/designs/general/designs_engineering.dm
@@ -35,6 +35,9 @@
 /datum/fabricator_recipe/engineering/airlock_sensor
 	path = /obj/item/frame/button/airlock_sensor
 
+/datum/fabricator_recipe/engineering/airlock_controller
+	path = /obj/item/stock_parts/circuitboard/airlock_controller
+
 /datum/fabricator_recipe/engineering/powermodule
 	path = /obj/item/stock_parts/circuitboard/apc
 

--- a/code/modules/shuttles/escape_pods.dm
+++ b/code/modules/shuttles/escape_pods.dm
@@ -164,11 +164,15 @@ var/list/escape_pods_by_name = list()
 /datum/computer/file/embedded_program/docking/simple/escape_pod
 	var/tag_pump
 
-/datum/computer/file/embedded_program/docking/simple/escape_pod/New(var/obj/machinery/embedded_controller/M)
-	..(M)
-	if (istype(M, /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod))
-		var/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod/controller = M
-		tag_pump = controller.tag_pump ? controller.tag_pump : "[id_tag]_pump"
+/datum/computer/file/embedded_program/docking/simple/escape_pod/reset_id_tags(base_tag)
+	. = ..()
+	if (istype(master, /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod))
+		var/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod/controller = master
+		tag_pump = (!base_tag && controller.tag_pump) || "[id_tag]_pump"
+
+/datum/computer/file/embedded_program/docking/simple/escape_pod/get_receive_filters()
+	. = ..()
+	.[tag_pump] = "main pumps"
 
 /datum/computer/file/embedded_program/docking/simple/escape_pod/finish_undocking()
 	. = ..()

--- a/code/modules/shuttles/escape_pods.dm
+++ b/code/modules/shuttles/escape_pods.dm
@@ -134,7 +134,7 @@ var/list/escape_pods_by_name = list()
 /datum/computer/file/embedded_program/docking/simple/escape_pod_berth/proc/arm()
 	if(!armed)
 		armed = 1
-		open_door()
+		toggleDoor(memory["door_status"], tag_door, TRUE, "open")
 
 
 /datum/computer/file/embedded_program/docking/simple/escape_pod_berth/receive_user_command(command)
@@ -145,7 +145,7 @@ var/list/escape_pods_by_name = list()
 /datum/computer/file/embedded_program/docking/simple/escape_pod_berth/process()
 	..()
 	if (eject_time && world.time >= eject_time && !closing)
-		close_door()
+		toggleDoor(memory["door_status"], tag_door, TRUE, "close")
 		closing = 1
 
 /datum/computer/file/embedded_program/docking/simple/escape_pod_berth/prepare_for_docking()

--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -40,12 +40,12 @@
 
 /datum/turbolift/proc/open_doors(var/datum/turbolift_floor/use_floor = current_floor)
 	for(var/obj/machinery/door/airlock/door in (use_floor ? (doors + use_floor.doors) : doors))
-		door.command("open")
+		door.open()
 	return
 
 /datum/turbolift/proc/close_doors(var/datum/turbolift_floor/use_floor = current_floor)
 	for(var/obj/machinery/door/airlock/door in (use_floor ? (doors + use_floor.doors) : doors))
-		door.command("close")
+		door.close()
 	return
 
 #define LIFT_MOVING    1

--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -40,13 +40,11 @@
 
 /datum/turbolift/proc/open_doors(var/datum/turbolift_floor/use_floor = current_floor)
 	for(var/obj/machinery/door/airlock/door in (use_floor ? (doors + use_floor.doors) : doors))
-		door.open()
-	return
+		INVOKE_ASYNC(door, /obj/machinery/door/proc/open)
 
 /datum/turbolift/proc/close_doors(var/datum/turbolift_floor/use_floor = current_floor)
 	for(var/obj/machinery/door/airlock/door in (use_floor ? (doors + use_floor.doors) : doors))
-		door.close()
-	return
+		INVOKE_ASYNC(door, /obj/machinery/door/proc/close)
 
 #define LIFT_MOVING    1
 #define LIFT_WAITING_A 2

--- a/code/modules/turbolift/turbolift_door.dm
+++ b/code/modules/turbolift/turbolift_door.dm
@@ -45,6 +45,5 @@
 					LM.gib()
 			else // the mob is too big to just move, so we need to give up what we're doing
 				audible_message("\The [src]'s motors grind as they quickly reverse direction, unable to safely close.")
-				cur_command = null // the door will just keep trying otherwise
 				return 0
 	return ..()

--- a/maps/antag_spawn/ert/ert_base.dmm
+++ b/maps/antag_spawn/ert/ert_base.dmm
@@ -2947,10 +2947,8 @@
 /area/map_template/rescue_base/start)
 "fH" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1331;
-	master_tag = "rescue_shuttle";
+/obj/machinery/button/access/shuttle/interior{
+	id_tag = "rescue_shuttle";
 	name = "interior access button";
 	pixel_x = 25;
 	pixel_y = 25;

--- a/maps/antag_spawn/ert/ert_base.dmm
+++ b/maps/antag_spawn/ert/ert_base.dmm
@@ -2705,8 +2705,7 @@
 	dir = 4;
 	id_tag = "rescue_shuttle_pump"
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
+/obj/machinery/airlock_sensor/shuttle{
 	id_tag = "rescue_shuttle_sensor";
 	pixel_x = 8;
 	pixel_y = 25

--- a/maps/antag_spawn/ert/ert_base.dmm
+++ b/maps/antag_spawn/ert/ert_base.dmm
@@ -1880,8 +1880,7 @@
 /turf/unsimulated/wall,
 /area/map_template/rescue_base/base)
 "dC" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1331;
+/obj/machinery/door/airlock/external/shuttle{
 	id_tag = "rescue_base_hatch";
 	name = "Landing Pad"
 	},
@@ -1998,8 +1997,7 @@
 /area/map_template/rescue_base/base)
 "dQ" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/door/airlock/external{
-	frequency = 1331;
+/obj/machinery/door/airlock/external/shuttle{
 	id_tag = "rescue_base_hatch"
 	},
 /turf/unsimulated/floor{
@@ -2664,9 +2662,8 @@
 /turf/simulated/floor/plating,
 /area/map_template/rescue_base/start)
 "eX" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/shuttle{
 	density = 1;
-	frequency = 1331;
 	id_tag = "rescue_shuttle_outer";
 	name = "Ship External Access"
 	},
@@ -2886,8 +2883,7 @@
 /area/map_template/rescue_base/start)
 "fA" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/door/airlock/external{
-	frequency = 1331;
+/obj/machinery/door/airlock/external/shuttle{
 	id_tag = "rescue_shuttle_inner";
 	name = "Ship External Access"
 	},

--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -1083,8 +1083,7 @@
 /turf/simulated/floor/plating,
 /area/map_template/skipjack_station/start)
 "cC" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
+/obj/machinery/airlock_sensor/shuttle{
 	id_tag = "vox_west_sensor";
 	pixel_x = 25
 	},
@@ -1106,7 +1105,6 @@
 "cG" = (
 /obj/random/trash,
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "skipjack_shuttle_sensor";
 	pixel_x = 8;
 	pixel_y = 25

--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -974,7 +974,6 @@
 /area/map_template/syndicate_mothership/raider_base)
 "co" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
-	frequency = 1380;
 	id_tag = "skipjack_base";
 	pixel_x = -25;
 	pixel_y = -5
@@ -1192,7 +1191,6 @@
 "cP" = (
 /obj/machinery/light/small,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 1380;
 	id_tag = "skipjack_shuttle";
 	pixel_x = -25;
 	pixel_y = 8;

--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -1019,7 +1019,6 @@
 /area/map_template/syndicate_mothership/raider_base)
 "cu" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "skipjack_base_hatch"
 	},
 /turf/unsimulated/floor{
@@ -1035,8 +1034,7 @@
 /turf/simulated/wall/voxshuttle,
 /area/map_template/skipjack_station/start)
 "cx" = (
-/obj/machinery/door/airlock/hatch{
-	frequency = 1331;
+/obj/machinery/door/airlock/external{
 	icon_state = "door_closed";
 	id_tag = "vox_northwest_lock";
 	locked = 0
@@ -1067,7 +1065,6 @@
 "cA" = (
 /obj/machinery/door/airlock/external{
 	density = 1;
-	frequency = 1380;
 	id_tag = "skipjack_shuttle_outer";
 	name = "Ship External Access"
 	},
@@ -1219,8 +1216,7 @@
 /turf/simulated/wall/voxshuttle,
 /area/map_template/skipjack_station/start)
 "cS" = (
-/obj/machinery/door/airlock/hatch{
-	frequency = 1331;
+/obj/machinery/door/airlock/external{
 	icon_state = "door_closed";
 	id_tag = "vox_southwest_lock";
 	locked = 0
@@ -1255,7 +1251,6 @@
 "cY" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "skipjack_shuttle_inner";
 	name = "Ship External Access"
 	},

--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -1045,10 +1045,8 @@
 /turf/simulated/floor/plating,
 /area/map_template/skipjack_station/start)
 "cy" = (
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1331;
-	master_tag = "vox_west_control";
+/obj/machinery/button/access/shuttle/exterior{
+	id_tag = "vox_west_control";
 	req_access = list("ACCESS_SYNDICATE")
 	},
 /obj/effect/paint/black,
@@ -1267,10 +1265,8 @@
 /area/map_template/skipjack_station/start)
 "cZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1331;
-	master_tag = "vox_west_control";
+/obj/machinery/button/access/shuttle/interior{
+	id_tag = "vox_west_control";
 	pixel_x = -22;
 	req_access = list("ACCESS_SYNDICATE")
 	},
@@ -1383,10 +1379,8 @@
 /area/map_template/skipjack_station/start)
 "dk" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1380;
-	master_tag = "skipjack_shuttle";
+/obj/machinery/button/access/interior{
+	id_tag = "skipjack_shuttle";
 	name = "interior access button";
 	pixel_x = 25;
 	pixel_y = 25;

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -1038,7 +1038,6 @@
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	cycle_to_external_air = 1;
 	dir = 1;
-	frequency = 1380;
 	id_tag = "merc_shuttle";
 	pixel_x = 0;
 	pixel_y = -25;

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -2000,9 +2000,8 @@
 /obj/machinery/pointdefense{
 	initial_id_tag = "merc_pd"
 	},
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1380;
-	master_tag = "merc_shuttle";
+/obj/machinery/button/access/exterior{;
+	id_tag = "merc_shuttle";
 	pixel_x = 37;
 	pixel_y = -32;
 	req_access = list("ACCESS_SYNDICATE")

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -1994,7 +1994,7 @@
 /obj/machinery/pointdefense{
 	initial_id_tag = "merc_pd"
 	},
-/obj/machinery/button/access/exterior{;
+/obj/machinery/button/access/exterior{
 	id_tag = "merc_shuttle";
 	pixel_x = 37;
 	pixel_y = -32;

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -687,7 +687,6 @@
 	id_tag = "merc_shuttle_pump"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "merc_shuttle_sensor";
 	pixel_x = 0;
 	pixel_y = 25
@@ -1984,8 +1983,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "merc_shuttle_pump_out_external"
 	},
-/obj/machinery/airlock_sensor/airlock_exterior{
-	frequency = 1380;
+/obj/machinery/airlock_sensor{
 	id_tag = "merc_shuttle_exterior_sensor";
 	pixel_x = 0;
 	pixel_y = -28

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -810,7 +810,6 @@
 /area/map_template/merc_shuttle)
 "bp" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "merc_shuttle_inner";
 	name = "Ship External Access"
 	},
@@ -836,7 +835,6 @@
 /obj/machinery/door/airlock/external{
 	density = 1;
 	dir = 2;
-	frequency = 1380;
 	id_tag = "merc_shuttle_outer";
 	name = "Ship External Access"
 	},
@@ -969,7 +967,6 @@
 /obj/machinery/door/airlock/external{
 	density = 1;
 	dir = 4;
-	frequency = 1380;
 	id_tag = "merc_shuttle_outer";
 	name = "Ship External Access"
 	},

--- a/maps/antag_spawn/ninja/ninja_base.dmm
+++ b/maps/antag_spawn/ninja/ninja_base.dmm
@@ -1355,9 +1355,8 @@
 	},
 /area/map_template/ninja_dojo/start)
 "cR" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/shuttle{
 	density = 1;
-	frequency = 1331;
 	id_tag = "ninja_shuttle_outer";
 	name = "Ship External Access"
 	},
@@ -1411,8 +1410,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
-	frequency = 1331;
+/obj/machinery/door/airlock/external/shuttle{
 	id_tag = "ninja_shuttle_inner";
 	name = "Ship External Access"
 	},

--- a/maps/antag_spawn/ninja/ninja_base.dmm
+++ b/maps/antag_spawn/ninja/ninja_base.dmm
@@ -1422,8 +1422,7 @@
 	},
 /area/map_template/ninja_dojo/start)
 "cW" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
+/obj/machinery/airlock_sensor/shuttle{
 	id_tag = "ninja_shuttle_sensor";
 	pixel_x = 8;
 	pixel_y = -25

--- a/maps/antag_spawn/ninja/ninja_base.dmm
+++ b/maps/antag_spawn/ninja/ninja_base.dmm
@@ -1395,10 +1395,8 @@
 	dir = 5;
 	icon_state = "intact"
 	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1331;
-	master_tag = "ninja_shuttle";
+/obj/machinery/button/access/shuttle/interior{
+	id_tag = "ninja_shuttle";
 	name = "interior access button";
 	pixel_x = 25;
 	pixel_y = 25;

--- a/maps/away/bearcat/bearcat-1.dmm
+++ b/maps/away/bearcat/bearcat-1.dmm
@@ -19,14 +19,14 @@
 /turf/simulated/floor/usedup,
 /area/space)
 "ad" = (
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "cargo_out"
 	},
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/usedup,
 /area/ship/scrap/cargo/lower)
 "ae" = (
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "cargo_out"
 	},
 /obj/machinery/button/access/exterior{
@@ -243,14 +243,14 @@
 /turf/simulated/floor/tiled/usedup,
 /area/ship/scrap/cargo/lower)
 "aD" = (
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "cargo_in"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/usedup,
 /area/ship/scrap/cargo/lower)
 "aE" = (
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "cargo_in"
 	},
 /obj/machinery/button/access/interior{
@@ -2417,7 +2417,7 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "eva_in"
 	},
 /obj/machinery/button/access/interior{
@@ -2476,7 +2476,7 @@
 /turf/simulated/floor/usedup,
 /area/ship/scrap/maintenance/eva)
 "eD" = (
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "eva_out"
 	},
 /obj/machinery/button/access/exterior{

--- a/maps/away/bearcat/bearcat-1.dmm
+++ b/maps/away/bearcat/bearcat-1.dmm
@@ -29,8 +29,8 @@
 /obj/machinery/door/airlock/external/bolted/cycling{
 	id_tag = "cargo_out"
 	},
-/obj/machinery/access_button/airlock_exterior{
-	master_tag = "cargo";
+/obj/machinery/button/access/exterior{
+	id_tag = "cargo";
 	pixel_x = 18;
 	pixel_y = 17
 	},
@@ -57,13 +57,13 @@
 /turf/simulated/floor/airless,
 /area/ship/scrap/escape_port)
 "aj" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "cargo_pump"
 	},
 /turf/simulated/floor/usedup,
 /area/ship/scrap/cargo/lower)
 "ak" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "cargo_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
@@ -253,8 +253,8 @@
 /obj/machinery/door/airlock/external/bolted/cycling{
 	id_tag = "cargo_in"
 	},
-/obj/machinery/access_button/airlock_interior{
-	master_tag = "cargo";
+/obj/machinery/button/access/interior{
+	id_tag = "cargo";
 	pixel_x = 20;
 	pixel_y = -12
 	},
@@ -2420,8 +2420,8 @@
 /obj/machinery/door/airlock/external/bolted/cycling{
 	id_tag = "eva_in"
 	},
-/obj/machinery/access_button/airlock_interior{
-	master_tag = "eva";
+/obj/machinery/button/access/interior{
+	id_tag = "eva";
 	pixel_x = -12;
 	pixel_y = 20
 	},
@@ -2465,7 +2465,7 @@
 /turf/simulated/floor/usedup,
 /area/ship/scrap/maintenance/eva)
 "eC" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 8;
 	id_tag = "eva_pump"
 	},
@@ -2479,8 +2479,8 @@
 /obj/machinery/door/airlock/external/bolted/cycling{
 	id_tag = "eva_out"
 	},
-/obj/machinery/access_button/airlock_exterior{
-	master_tag = "eva";
+/obj/machinery/button/access/exterior{
+	id_tag = "eva";
 	pixel_x = 18;
 	pixel_y = -18
 	},

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -732,7 +732,7 @@
 	pixel_x = -18;
 	pixel_y = 20
 	},
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "dock_port_out"
 	},
 /obj/machinery/shield_diffuser,
@@ -802,7 +802,7 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "dock_port_in"
 	},
 /obj/structure/cable{
@@ -923,7 +923,7 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "dock_star_in"
 	},
 /obj/structure/cable{
@@ -981,7 +981,7 @@
 	pixel_x = 18;
 	pixel_y = 20
 	},
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "dock_star_out"
 	},
 /obj/machinery/shield_diffuser,

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -727,8 +727,8 @@
 /turf/simulated/floor/tiled/usedup,
 /area/ship/scrap/dock)
 "bu" = (
-/obj/machinery/access_button/airlock_exterior{
-	master_tag = "bearcat_dock_port";
+/obj/machinery/button/access/exterior{
+	id_tag = "bearcat_dock_port";
 	pixel_x = -18;
 	pixel_y = 20
 	},
@@ -745,7 +745,7 @@
 /turf/simulated/floor/tiled/usedup,
 /area/ship/scrap/dock)
 "bv" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 4;
 	id_tag = "dock_port_pump"
 	},
@@ -793,8 +793,8 @@
 	name = "External Blast Doors";
 	opacity = 0
 	},
-/obj/machinery/access_button/airlock_interior{
-	master_tag = "bearcat_dock_port";
+/obj/machinery/button/access/interior{
+	id_tag = "bearcat_dock_port";
 	pixel_x = 12;
 	pixel_y = 20
 	},
@@ -914,8 +914,8 @@
 	name = "External Blast Doors";
 	opacity = 0
 	},
-/obj/machinery/access_button/airlock_interior{
-	master_tag = "bearcat_starboard_dock";
+/obj/machinery/button/access/interior{
+	id_tag = "bearcat_starboard_dock";
 	pixel_x = -12;
 	pixel_y = 20
 	},
@@ -963,7 +963,7 @@
 /turf/simulated/floor/tiled/usedup,
 /area/ship/scrap/dock)
 "bH" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 8;
 	id_tag = "dock_star_pump"
 	},
@@ -976,8 +976,8 @@
 /turf/simulated/floor/tiled/usedup,
 /area/ship/scrap/dock)
 "bI" = (
-/obj/machinery/access_button/airlock_exterior{
-	master_tag = "bearcat_starboard_dock";
+/obj/machinery/button/access/exterior{
+	id_tag = "bearcat_starboard_dock";
 	pixel_x = 18;
 	pixel_y = 20
 	},

--- a/maps/away/casino/casino.dm
+++ b/maps/away/casino/casino.dm
@@ -35,7 +35,7 @@
 	apc_test_exempt_areas = list(
 		/area/casino/casino_hangar = NO_SCRUBBER,
 		/area/casino/casino_cutter = NO_SCRUBBER|NO_VENT,
-		/area/casino/casino_solar_control = NO_SCRUBBER,
+		/area/casino/casino_solar_control = NO_SCRUBBER|NO_VENT,
 		/area/casino/casino_maintenance = NO_SCRUBBER|NO_VENT
 	)
 

--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -220,7 +220,6 @@
 	dir = 9
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "casino_dock_sensor";
 	pixel_x = -30;
 	pixel_y = -8
@@ -2517,7 +2516,6 @@
 	tag_interior_door = "casino_solar_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "casino_solar_sensor";
 	pixel_x = 24;
 	pixel_y = 12

--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -193,7 +193,6 @@
 /area/casino/casino_maintenance)
 "aD" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "door_closed";
 	id_tag = "casino_dock_outer";
 	locked = 0;
@@ -289,7 +288,6 @@
 "aU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "door_closed";
 	id_tag = "casino_dock_inner";
 	locked = 0;
@@ -2491,7 +2489,6 @@
 /area/space)
 "gy" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "casino_solar_outer";
 	locked = 1;
@@ -2594,7 +2591,6 @@
 /area/space)
 "gL" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "casino_solar_inner";
 	locked = 1;
@@ -4977,7 +4973,6 @@
 /area/casino/casino_bow)
 "na" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "escape_pod";
 	locked = 1;

--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -2481,10 +2481,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1439;
-	master_tag = "casino_solar_airlock";
+/obj/machinery/button/access/exterior{
+	id_tag = "casino_solar_airlock";
 	name = "exterior access button";
 	pixel_x = 28;
 	pixel_y = 24;
@@ -2494,9 +2492,9 @@
 /area/space)
 "gy" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1379;
+	frequency = 1380;
 	icon_state = "door_locked";
-	id_tag = "solar_casino_outer";
+	id_tag = "casino_solar_outer";
 	locked = 1;
 	name = "External Access"
 	},
@@ -2509,7 +2507,7 @@
 /area/casino/casino_solar_control)
 "gz" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "casino_solar_airlock";
 	pixel_x = 24;
 	req_access = newlist();
@@ -2519,7 +2517,7 @@
 	tag_interior_door = "casino_solar_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "casino_solar_sensor";
 	pixel_x = 24;
 	pixel_y = 12
@@ -2534,7 +2532,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 2;
 	id_tag = "casino_solar_pump"
 	},
@@ -2598,9 +2596,9 @@
 /area/space)
 "gL" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
+	frequency = 1380;
 	icon_state = "door_locked";
-	id_tag = "solar_casino_inner";
+	id_tag = "casino_solar_inner";
 	locked = 1;
 	name = "External Access"
 	},
@@ -2653,10 +2651,8 @@
 	dir = 8;
 	icon_state = "map"
 	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1439;
-	master_tag = "casino_solar_airlock";
+/obj/machinery/button/access/interior{
+	id_tag = "casino_solar_airlock";
 	name = "interior access button";
 	pixel_x = 24;
 	pixel_y = 24;

--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -350,7 +350,6 @@
 /area/space)
 "bc" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 1380;
 	id_tag = "casino_dock_airlock";
 	pixel_x = -24;
 	pixel_y = 6;
@@ -1329,7 +1328,6 @@
 /obj/machinery/door/window,
 /obj/item/key,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 1380;
 	pixel_y = 25
 	},
 /turf/simulated/floor/shuttle/yellow,
@@ -2503,7 +2501,6 @@
 /area/casino/casino_solar_control)
 "gz" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "casino_solar_airlock";
 	pixel_x = 24;
 	req_access = newlist();
@@ -5053,7 +5050,6 @@
 	pixel_y = 0
 	},
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod{
-	frequency = 1380;
 	id_tag = "Casino_escape_pod_3";
 	name = "Casino escape pod Three controller";
 	pixel_x = 24;
@@ -5069,7 +5065,6 @@
 	pixel_y = 0
 	},
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod{
-	frequency = 1380;
 	id_tag = "Casino_escape_pod_2";
 	name = "Casino escape pod Two controller";
 	pixel_x = 24;
@@ -5085,7 +5080,6 @@
 	pixel_y = 0
 	},
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod{
-	frequency = 1380;
 	id_tag = "Casino_escape_pod_1";
 	name = "Casino escape pod One controller";
 	pixel_x = 24;

--- a/maps/away/casino/casino_areas.dm
+++ b/maps/away/casino/casino_areas.dm
@@ -1,7 +1,7 @@
-area/casino
+/area/casino
 	icon = 'maps/away/casino/casino_sprites.dmi'
 
-area/casino/casino_mainfloor
+/area/casino/casino_mainfloor
 	name = "\improper Casino Hall"
 	icon_state = "main_area"
 

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -1619,7 +1619,6 @@
 "fb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/blue,
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "constructionsite_sensor";
 	pixel_x = 0;
 	pixel_y = -25

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -1538,7 +1538,6 @@
 /area/constructionsite/hallway/fore)
 "eR" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "constructionsite_outer";
 	locked = 1
@@ -1557,7 +1556,6 @@
 /area/constructionsite/teleporter)
 "eU" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "constructionsite_inner";
 	locked = 1
@@ -1635,7 +1633,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "constructionsite_inner";
 	locked = 1

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -1471,8 +1471,8 @@
 /turf/simulated/wall,
 /area/constructionsite/hallway/fore)
 "eH" = (
-/obj/machinery/access_button/airlock_exterior{
-	master_tag = "constructionsite_airlock";
+/obj/machinery/button/access/exterior{
+	id_tag = "constructionsite_airlock";
 	pixel_x = 20;
 	pixel_y = 0;
 	req_access = newlist()
@@ -1483,8 +1483,8 @@
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
 	},
-/obj/machinery/access_button/airlock_interior{
-	master_tag = "constructionsite_airlock";
+/obj/machinery/button/access/interior{
+	id_tag = "constructionsite_airlock";
 	pixel_x = -20;
 	pixel_y = 0;
 	req_access = newlist()
@@ -1538,7 +1538,7 @@
 /area/constructionsite/hallway/fore)
 "eR" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1379;
+	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "constructionsite_outer";
 	locked = 1
@@ -1546,7 +1546,7 @@
 /turf/simulated/floor,
 /area/constructionsite/teleporter)
 "eS" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "constructionsite_vent"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -1557,7 +1557,7 @@
 /area/constructionsite/teleporter)
 "eU" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1379;
+	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "constructionsite_inner";
 	locked = 1
@@ -1600,7 +1600,7 @@
 	},
 /obj/machinery/light/small,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
+	frequency = 1380;
 	id_tag = "constructionsite_airlock";
 	pixel_x = 0;
 	pixel_y = -25;
@@ -1619,7 +1619,7 @@
 "fb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/blue,
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
+	frequency = 1380;
 	id_tag = "constructionsite_sensor";
 	pixel_x = 0;
 	pixel_y = -25
@@ -1636,7 +1636,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	frequency = 1379;
+	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "constructionsite_inner";
 	locked = 1
@@ -3636,7 +3636,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/constructionsite/teleporter)
 "ob" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "constructionsite_vent"
 	},
 /obj/effect/floor_decal/industrial/warning{

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -1598,7 +1598,6 @@
 	},
 /obj/machinery/light/small,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "constructionsite_airlock";
 	pixel_x = 0;
 	pixel_y = -25;

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -1721,7 +1721,6 @@
 	pixel_y = 25
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "Harpoon_solar_starboard_airlock";
 	pixel_x = 25;
 	tag_airpump = "Harpoon_solar_starboard_pump";
@@ -1900,7 +1899,6 @@
 	id_tag = "Harpoon_solar_port_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "Harpoon_solar_port_airlock";
 	pixel_x = -25;
 	tag_airpump = "Harpoon_solar_port_pump";
@@ -4506,7 +4504,6 @@
 "lc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "Harpoon_ls_airlock";
 	pixel_x = 25;
 	pixel_y = 0;
@@ -4845,7 +4842,6 @@
 	id_tag = "Harpoon_sci_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "Harpoon_sci_airlock";
 	pixel_x = 0;
 	pixel_y = -25;
@@ -5300,7 +5296,6 @@
 	id_tag = "Harpoon_dock1_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "Harpoon_dock1_airlock";
 	pixel_x = 0;
 	pixel_y = -25;
@@ -5930,7 +5925,6 @@
 	id_tag = "Harpoon_dock2_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "Harpoon_dock2_airlock";
 	pixel_x = 0;
 	pixel_y = -25;
@@ -6845,7 +6839,6 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "Harpoon_fish_airlock";
 	pixel_x = 0;
 	pixel_y = -25;

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -1689,16 +1689,15 @@
 	icon_state = "pdoor0";
 	id_tag = "Harpoon_perimeter_blast"
 	},
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1011;
-	master_tag = "Harpoon_solar_starboard_airlock";
+/obj/machinery/button/access/exterior{
+	id_tag = "Harpoon_solar_starboard_airlock";
 	pixel_y = 20
 	},
 /turf/simulated/floor/airless,
 /area/errant_pisces/solar_starboard)
 "eg" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1011;
+	frequency = 1380;
 	id_tag = "Harpoon_solar_starboard_outer"
 	},
 /obj/structure/cable/yellow{
@@ -1715,14 +1714,16 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	id_tag = "Harpoon_solar_starboard_pump"
+	},
 /obj/machinery/airlock_sensor{
-	frequency = 1011;
+	frequency = 1380;
 	id_tag = "Harpoon_solar_starboard_sensor";
 	pixel_y = 25
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1011;
+	frequency = 1380;
 	id_tag = "Harpoon_solar_starboard_airlock";
 	pixel_x = 25;
 	tag_airpump = "Harpoon_solar_starboard_pump";
@@ -1897,11 +1898,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "Harpoon_solar_port_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_solar_port_airlock";
 	pixel_x = -25;
 	tag_airpump = "Harpoon_solar_port_pump";
@@ -1910,7 +1911,7 @@
 	tag_interior_door = "Harpoon_solar_port_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_solar_port_sensor";
 	pixel_y = 25
 	},
@@ -1919,7 +1920,7 @@
 /area/errant_pisces/solar_port)
 "eC" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_solar_port_outer"
 	},
 /obj/structure/cable/yellow{
@@ -1941,9 +1942,8 @@
 	icon_state = "pdoor0";
 	id_tag = "Harpoon_perimeter_blast"
 	},
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1439;
-	master_tag = "Harpoon_solar_port_airlock";
+/obj/machinery/button/access/exterior{
+	id_tag = "Harpoon_solar_port_airlock";
 	pixel_y = 20
 	},
 /turf/simulated/floor/airless,
@@ -1996,7 +1996,7 @@
 /area/space)
 "eH" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1011;
+	frequency = 1380;
 	id_tag = "Harpoon_solar_starboard_inner"
 	},
 /obj/structure/cable/yellow{
@@ -2145,7 +2145,7 @@
 /area/errant_pisces/head_m)
 "eV" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_solar_port_inner"
 	},
 /obj/structure/cable/yellow{
@@ -2167,9 +2167,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/access_button/airlock_interior{
-	frequency = 1011;
-	master_tag = "Harpoon_solar_starboard_airlock";
+/obj/machinery/button/access/interior{
+	id_tag = "Harpoon_solar_starboard_airlock";
 	pixel_x = -25;
 	pixel_y = 25
 	},
@@ -2317,9 +2316,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/access_button/airlock_interior{
-	frequency = 1439;
-	master_tag = "Harpoon_solar_port_airlock";
+/obj/machinery/button/access/interior{
+	id_tag = "Harpoon_solar_port_airlock";
 	pixel_x = 25;
 	pixel_y = 25
 	},
@@ -3941,9 +3939,8 @@
 /turf/space,
 /area/errant_pisces/live_storage)
 "jy" = (
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1439;
-	master_tag = "Harpoon_ls_airlock";
+/obj/machinery/button/access/exterior{
+	id_tag = "Harpoon_ls_airlock";
 	pixel_x = -25;
 	pixel_y = 0
 	},
@@ -4070,7 +4067,7 @@
 /area/errant_pisces/dorms)
 "jQ" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_ls_outer"
 	},
 /obj/machinery/door/firedoor,
@@ -4138,14 +4135,14 @@
 /turf/simulated/floor/tiled,
 /area/errant_pisces/cryo)
 "ka" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "Harpoon_ls_pump"
 	},
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_ls_sensor";
 	pixel_x = -25;
 	pixel_y = 0
@@ -4295,7 +4292,7 @@
 /area/errant_pisces/prod_storage)
 "ku" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_ls_inner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4518,7 +4515,7 @@
 "lc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_ls_airlock";
 	pixel_x = 25;
 	pixel_y = 0;
@@ -4836,16 +4833,15 @@
 /area/errant_pisces/live_storage)
 "mb" = (
 /obj/structure/lattice,
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1439;
-	master_tag = "Harpoon_sci_airlock";
+/obj/machinery/button/access/exterior{
+	id_tag = "Harpoon_sci_airlock";
 	pixel_y = -20
 	},
 /turf/space,
 /area/errant_pisces/science_wing)
 "mc" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_sci_outer"
 	},
 /turf/simulated/floor/plating,
@@ -4854,12 +4850,12 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 4;
 	id_tag = "Harpoon_sci_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_sci_airlock";
 	pixel_x = 0;
 	pixel_y = -25;
@@ -4869,7 +4865,7 @@
 	tag_interior_door = "Harpoon_sci_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_sci_sensor";
 	pixel_y = 25
 	},
@@ -4877,7 +4873,7 @@
 /area/errant_pisces/science_wing)
 "me" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_sci_inner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4889,9 +4885,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/access_button/airlock_interior{
-	frequency = 1439;
-	master_tag = "Harpoon_sci_airlock";
+/obj/machinery/button/access/interior{
+	id_tag = "Harpoon_sci_airlock";
 	pixel_x = -25;
 	pixel_y = -25
 	},
@@ -5291,9 +5286,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/access_button/airlock_interior{
-	frequency = 1439;
-	master_tag = "Harpoon_dock1_airlock";
+/obj/machinery/button/access/interior{
+	id_tag = "Harpoon_dock1_airlock";
 	pixel_x = 0;
 	pixel_y = 25
 	},
@@ -5301,7 +5295,7 @@
 /area/errant_pisces/aft_hallway)
 "nf" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_dock1_inner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5314,12 +5308,12 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 8;
 	id_tag = "Harpoon_dock1_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_dock1_airlock";
 	pixel_x = 0;
 	pixel_y = -25;
@@ -5329,7 +5323,7 @@
 	tag_interior_door = "Harpoon_dock1_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_dock1_sensor";
 	pixel_y = 25
 	},
@@ -5337,7 +5331,7 @@
 /area/errant_pisces/aft_hallway)
 "nh" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_dock1_outer"
 	},
 /obj/machinery/door/blast/regular/open{
@@ -5349,9 +5343,8 @@
 /turf/simulated/floor/plating,
 /area/errant_pisces/aft_hallway)
 "ni" = (
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1439;
-	master_tag = "Harpoon_dock1_airlock";
+/obj/machinery/button/access/exterior{
+	id_tag = "Harpoon_dock1_airlock";
 	pixel_x = -25;
 	pixel_y = -25
 	},
@@ -5926,9 +5919,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/access_button/airlock_interior{
-	frequency = 1439;
-	master_tag = "Harpoon_dock2_airlock";
+/obj/machinery/button/access/interior{
+	id_tag = "Harpoon_dock2_airlock";
 	pixel_x = 0;
 	pixel_y = -25
 	},
@@ -5936,7 +5928,7 @@
 /area/errant_pisces/aft_hallway)
 "ol" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_dock2_inner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5949,12 +5941,12 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 8;
-	id_tag = "Harpoon_dock2_airlock"
+	id_tag = "Harpoon_dock2_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_dock2_airlock";
 	pixel_x = 0;
 	pixel_y = -25;
@@ -5964,7 +5956,7 @@
 	tag_interior_door = "Harpoon_dock2_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_dock2_sensor";
 	pixel_y = 25
 	},
@@ -5972,7 +5964,7 @@
 /area/errant_pisces/aft_hallway)
 "on" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_dock2_outer"
 	},
 /obj/machinery/door/blast/regular/open{
@@ -5984,9 +5976,8 @@
 /turf/simulated/floor/plating,
 /area/errant_pisces/aft_hallway)
 "oo" = (
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1439;
-	master_tag = "Harpoon_dock2_airlock";
+/obj/machinery/button/access/exterior{
+	id_tag = "Harpoon_dock2_airlock";
 	pixel_x = -25;
 	pixel_y = -25
 	},
@@ -6845,9 +6836,8 @@
 /area/errant_pisces/fishing_wing)
 "qP" = (
 /obj/effect/decal/cleanable/blood,
-/obj/machinery/access_button/airlock_interior{
-	frequency = 1439;
-	master_tag = "Harpoon_fish_airlock";
+/obj/machinery/button/access/interior{
+	id_tag = "Harpoon_fish_airlock";
 	pixel_x = 25;
 	pixel_y = -25
 	},
@@ -6858,7 +6848,7 @@
 /area/errant_pisces/fishing_wing)
 "qQ" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_fish_inner"
 	},
 /obj/machinery/door/firedoor,
@@ -6874,7 +6864,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_fish_airlock";
 	pixel_x = 0;
 	pixel_y = -25;
@@ -6884,11 +6874,11 @@
 	tag_interior_door = "Harpoon_fish_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_fish_sensor";
 	pixel_y = 25
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 8;
 	id_tag = "Harpoon_fish_pump"
 	},
@@ -6896,7 +6886,7 @@
 /area/errant_pisces/fishing_wing)
 "qS" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "Harpoon_fish_outer"
 	},
 /obj/machinery/door/blast/regular/open{
@@ -6909,9 +6899,8 @@
 /area/space)
 "qT" = (
 /obj/structure/net,
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1439;
-	master_tag = "Harpoon_dock2_airlock";
+/obj/machinery/button/access/exterior{
+	id_tag = "Harpoon_dock2_airlock";
 	pixel_x = -25;
 	pixel_y = -25
 	},

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -1697,7 +1697,6 @@
 /area/errant_pisces/solar_starboard)
 "eg" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "Harpoon_solar_starboard_outer"
 	},
 /obj/structure/cable/yellow{
@@ -1918,7 +1917,6 @@
 /area/errant_pisces/solar_port)
 "eC" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "Harpoon_solar_port_outer"
 	},
 /obj/structure/cable/yellow{
@@ -1994,7 +1992,6 @@
 /area/space)
 "eH" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "Harpoon_solar_starboard_inner"
 	},
 /obj/structure/cable/yellow{
@@ -2143,7 +2140,6 @@
 /area/errant_pisces/head_m)
 "eV" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "Harpoon_solar_port_inner"
 	},
 /obj/structure/cable/yellow{
@@ -4065,7 +4061,6 @@
 /area/errant_pisces/dorms)
 "jQ" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "Harpoon_ls_outer"
 	},
 /obj/machinery/door/firedoor,
@@ -4289,7 +4284,6 @@
 /area/errant_pisces/prod_storage)
 "ku" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "Harpoon_ls_inner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4838,7 +4832,6 @@
 /area/errant_pisces/science_wing)
 "mc" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "Harpoon_sci_outer"
 	},
 /turf/simulated/floor/plating,
@@ -4869,7 +4862,6 @@
 /area/errant_pisces/science_wing)
 "me" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "Harpoon_sci_inner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5291,7 +5283,6 @@
 /area/errant_pisces/aft_hallway)
 "nf" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "Harpoon_dock1_inner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5326,7 +5317,6 @@
 /area/errant_pisces/aft_hallway)
 "nh" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "Harpoon_dock1_outer"
 	},
 /obj/machinery/door/blast/regular/open{
@@ -5923,7 +5913,6 @@
 /area/errant_pisces/aft_hallway)
 "ol" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "Harpoon_dock2_inner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5958,7 +5947,6 @@
 /area/errant_pisces/aft_hallway)
 "on" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "Harpoon_dock2_outer"
 	},
 /obj/machinery/door/blast/regular/open{
@@ -6842,7 +6830,6 @@
 /area/errant_pisces/fishing_wing)
 "qQ" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "Harpoon_fish_inner"
 	},
 /obj/machinery/door/firedoor,
@@ -6879,7 +6866,6 @@
 /area/errant_pisces/fishing_wing)
 "qS" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "Harpoon_fish_outer"
 	},
 /obj/machinery/door/blast/regular/open{

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -1718,7 +1718,6 @@
 	id_tag = "Harpoon_solar_starboard_pump"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "Harpoon_solar_starboard_sensor";
 	pixel_y = 25
 	},
@@ -1911,7 +1910,6 @@
 	tag_interior_door = "Harpoon_solar_port_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "Harpoon_solar_port_sensor";
 	pixel_y = 25
 	},
@@ -4142,7 +4140,6 @@
 	dir = 4
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "Harpoon_ls_sensor";
 	pixel_x = -25;
 	pixel_y = 0
@@ -4865,7 +4862,6 @@
 	tag_interior_door = "Harpoon_sci_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "Harpoon_sci_sensor";
 	pixel_y = 25
 	},
@@ -5323,7 +5319,6 @@
 	tag_interior_door = "Harpoon_dock1_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "Harpoon_dock1_sensor";
 	pixel_y = 25
 	},
@@ -5956,7 +5951,6 @@
 	tag_interior_door = "Harpoon_dock2_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "Harpoon_dock2_sensor";
 	pixel_y = 25
 	},
@@ -6874,7 +6868,6 @@
 	tag_interior_door = "Harpoon_fish_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "Harpoon_fish_sensor";
 	pixel_y = 25
 	},

--- a/maps/away/lost_supply_base/lost_supply_base.dmm
+++ b/maps/away/lost_supply_base/lost_supply_base.dmm
@@ -204,7 +204,7 @@
 /area/lost_supply_base/solar)
 "ay" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1379;
+	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "solar_outer";
 	locked = 1;
@@ -220,7 +220,7 @@
 /area/lost_supply_base/solar)
 "az" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
+	frequency = 1380;
 	id_tag = "solar_starboard_airlock";
 	pixel_x = 24;
 	req_access = newlist();
@@ -229,12 +229,12 @@
 	tag_exterior_door = "solar_starboard_outer";
 	tag_interior_door = "solar_starboard_inner"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 2;
 	id_tag = "solar_starboard_pump"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
+	frequency = 1380;
 	id_tag = "solar_starboard_sensor";
 	pixel_x = 24;
 	pixel_y = 12
@@ -255,7 +255,7 @@
 /area/lost_supply_base)
 "aB" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1379;
+	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "solar_inner";
 	locked = 1;
@@ -339,10 +339,8 @@
 	dir = 8;
 	icon_state = "map"
 	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "solar_starboard_airlock";
+/obj/machinery/button/access/interior{
+	id_tag = "solar_starboard_airlock";
 	name = "interior access button";
 	pixel_x = 24;
 	pixel_y = 24;
@@ -605,10 +603,8 @@
 /area/lost_supply_base)
 "bs" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "solar_starboard_airlock";
+/obj/machinery/button/access/interior{
+	id_tag = "solar_starboard_airlock";
 	name = "interior access button";
 	pixel_x = -24;
 	pixel_y = 24;
@@ -748,7 +744,7 @@
 /area/lost_supply_base/office)
 "bJ" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
+	frequency = 1380;
 	id_tag = "solar_starboard_airlock";
 	pixel_x = 24;
 	req_access = newlist();
@@ -758,7 +754,7 @@
 	tag_interior_door = "solar_starboard_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
+	frequency = 1380;
 	id_tag = "solar_starboard_sensor";
 	pixel_x = 24;
 	pixel_y = 12
@@ -2143,7 +2139,7 @@
 	icon_state = "intact"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1379;
+	frequency = 1380;
 	id_tag = "solar_starboard_airlock";
 	pixel_x = 24;
 	req_access = newlist();
@@ -2153,7 +2149,7 @@
 	tag_interior_door = "solar_starboard_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
+	frequency = 1380;
 	id_tag = "solar_starboard_sensor";
 	pixel_x = 24;
 	pixel_y = 12

--- a/maps/away/lost_supply_base/lost_supply_base.dmm
+++ b/maps/away/lost_supply_base/lost_supply_base.dmm
@@ -219,7 +219,6 @@
 /area/lost_supply_base/solar)
 "az" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "solar_starboard_airlock";
 	pixel_x = 24;
 	req_access = newlist();
@@ -740,7 +739,6 @@
 /area/lost_supply_base/office)
 "bJ" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "solar_starboard_airlock";
 	pixel_x = 24;
 	req_access = newlist();
@@ -2133,7 +2131,6 @@
 	icon_state = "intact"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "solar_starboard_airlock";
 	pixel_x = 24;
 	req_access = newlist();

--- a/maps/away/lost_supply_base/lost_supply_base.dmm
+++ b/maps/away/lost_supply_base/lost_supply_base.dmm
@@ -588,7 +588,6 @@
 /area/lost_supply_base)
 "br" = (
 /obj/machinery/door/airlock/external{
-	glass = 1380;
 	icon_state = "door_locked";
 	id_tag = "centcom_shuttle_bay_door";
 	locked = 1;

--- a/maps/away/lost_supply_base/lost_supply_base.dmm
+++ b/maps/away/lost_supply_base/lost_supply_base.dmm
@@ -204,7 +204,6 @@
 /area/lost_supply_base/solar)
 "ay" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "solar_outer";
 	locked = 1;
@@ -254,7 +253,6 @@
 /area/lost_supply_base)
 "aB" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "solar_inner";
 	locked = 1;
@@ -591,7 +589,6 @@
 /area/lost_supply_base)
 "br" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	glass = 1380;
 	icon_state = "door_locked";
 	id_tag = "centcom_shuttle_bay_door";
@@ -1362,7 +1359,6 @@
 /area/lost_supply_base/common)
 "dE" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "centcom_shuttle_hatch";
 	locked = 1;

--- a/maps/away/lost_supply_base/lost_supply_base.dmm
+++ b/maps/away/lost_supply_base/lost_supply_base.dmm
@@ -234,7 +234,6 @@
 	id_tag = "solar_starboard_pump"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "solar_starboard_sensor";
 	pixel_x = 24;
 	pixel_y = 12
@@ -754,7 +753,6 @@
 	tag_interior_door = "solar_starboard_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "solar_starboard_sensor";
 	pixel_x = 24;
 	pixel_y = 12
@@ -2149,7 +2147,6 @@
 	tag_interior_door = "solar_starboard_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "solar_starboard_sensor";
 	pixel_x = 24;
 	pixel_y = 12

--- a/maps/away/magshield/magshield.dmm
+++ b/maps/away/magshield/magshield.dmm
@@ -164,7 +164,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/access_button{
+/obj/machinery/button/access{
 	pixel_x = -25;
 	pixel_y = -25
 	},
@@ -1926,7 +1926,7 @@
 /turf/simulated/floor/airless,
 /area/magshield/north)
 "eG" = (
-/obj/machinery/access_button{
+/obj/machinery/button/access{
 	pixel_x = -25;
 	pixel_y = 25
 	},
@@ -2029,7 +2029,7 @@
 "eT" = (
 /obj/machinery/door/airlock/external/bolted_open,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/access_button{
+/obj/machinery/button/access{
 	pixel_x = -25;
 	pixel_y = 25
 	},
@@ -2205,7 +2205,7 @@
 /turf/simulated/floor/tiled,
 /area/magshield/west)
 "fw" = (
-/obj/machinery/access_button{
+/obj/machinery/button/access{
 	pixel_x = -25;
 	pixel_y = 25
 	},
@@ -2805,7 +2805,7 @@
 /turf/space,
 /area/magshield/east)
 "hj" = (
-/obj/machinery/access_button{
+/obj/machinery/button/access{
 	pixel_x = -25;
 	pixel_y = -25
 	},

--- a/maps/away/mining/mining-asteroid.dmm
+++ b/maps/away/mining/mining-asteroid.dmm
@@ -239,8 +239,8 @@
 /turf/simulated/floor/asteroid,
 /area/mine/explored)
 "jb" = (
-/obj/machinery/access_button/airlock_exterior{
-	master_tag = "lp_north_airlock";
+/obj/machinery/button/access/exterior{
+	id_tag = "lp_north_airlock";
 	name = "exterior access button";
 	pixel_y = -24
 	},
@@ -248,7 +248,7 @@
 /area/mine/explored)
 "kb" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1379;
+	frequency = 1380;
 	icon_state = "closed";
 	id_tag = "lp_north_outer";
 	locked = 1
@@ -267,7 +267,7 @@
 /turf/simulated/floor/airless,
 /area/djstation)
 "mb" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "lp_north_pump"
 	},
 /turf/simulated/floor/airless,
@@ -282,7 +282,7 @@
 /area/djstation)
 "ob" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1379;
+	frequency = 1380;
 	icon_state = "closed";
 	id_tag = "lp_north_inner";
 	locked = 1
@@ -292,7 +292,7 @@
 /area/djstation)
 "pb" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1379;
+	frequency = 1380;
 	icon_state = "closed";
 	id_tag = "lp_north_inner";
 	locked = 1
@@ -315,8 +315,8 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/machinery/access_button/airlock_interior{
-	master_tag = "lp_north_airlock";
+/obj/machinery/button/access/interior{
+	id_tag = "lp_north_airlock";
 	name = "interior access button";
 	pixel_y = 24
 	},
@@ -330,10 +330,8 @@
 /turf/simulated/floor/airless,
 /area/djstation)
 "ub" = (
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "lp_east_airlock";
+/obj/machinery/button/access/interior{
+	id_tag = "lp_east_airlock";
 	name = "interior access button";
 	pixel_x = 24;
 	pixel_y = 0;
@@ -342,10 +340,8 @@
 /turf/simulated/floor/tiled/airless,
 /area/djstation)
 "vb" = (
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1379;
-	master_tag = "lp_east_airlock";
+/obj/machinery/button/access/exterior{
+	id_tag = "lp_east_airlock";
 	name = "exterior access button";
 	pixel_x = -24;
 	pixel_y = 0;
@@ -355,7 +351,7 @@
 /area/mine/explored)
 "wb" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1379;
+	frequency = 1380;
 	icon_state = "closed";
 	id_tag = "lp_east_inner";
 	locked = 1
@@ -365,7 +361,7 @@
 "xb" = (
 /obj/random/trash,
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
+	frequency = 1380;
 	id_tag = "lp_east_sensor";
 	pixel_x = 0;
 	pixel_y = 24
@@ -387,7 +383,7 @@
 /area/djstation)
 "zb" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1379;
+	frequency = 1380;
 	icon_state = "closed";
 	id_tag = "lp_east_outer";
 	locked = 1
@@ -403,7 +399,7 @@
 /area/djstation)
 "Bb" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1379;
+	frequency = 1380;
 	icon_state = "closed";
 	id_tag = "lp_east_inner";
 	locked = 1
@@ -415,7 +411,7 @@
 /turf/simulated/floor/airless,
 /area/djstation)
 "Cb" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 8;
 	id_tag = "lp_east_pump"
 	},

--- a/maps/away/mining/mining-asteroid.dmm
+++ b/maps/away/mining/mining-asteroid.dmm
@@ -248,7 +248,6 @@
 /area/mine/explored)
 "kb" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "closed";
 	id_tag = "lp_north_outer";
 	locked = 1
@@ -281,7 +280,6 @@
 /area/djstation)
 "ob" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "closed";
 	id_tag = "lp_north_inner";
 	locked = 1
@@ -291,7 +289,6 @@
 /area/djstation)
 "pb" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "closed";
 	id_tag = "lp_north_inner";
 	locked = 1
@@ -350,7 +347,6 @@
 /area/mine/explored)
 "wb" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "closed";
 	id_tag = "lp_east_inner";
 	locked = 1
@@ -381,7 +377,6 @@
 /area/djstation)
 "zb" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "closed";
 	id_tag = "lp_east_outer";
 	locked = 1
@@ -397,7 +392,6 @@
 /area/djstation)
 "Bb" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "closed";
 	id_tag = "lp_east_inner";
 	locked = 1

--- a/maps/away/mining/mining-asteroid.dmm
+++ b/maps/away/mining/mining-asteroid.dmm
@@ -275,7 +275,6 @@
 "nb" = (
 /obj/machinery/airlock_sensor{
 	id_tag = "lp_north_sensor";
-	master_tag = "lp_north_airlock";
 	pixel_x = 24
 	},
 /turf/simulated/floor/airless,
@@ -361,7 +360,6 @@
 "xb" = (
 /obj/random/trash,
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "lp_east_sensor";
 	pixel_x = 0;
 	pixel_y = 24

--- a/maps/away/slavers/slavers_base.dmm
+++ b/maps/away/slavers/slavers_base.dmm
@@ -4301,7 +4301,7 @@
 /turf/simulated/floor/airless/ceiling,
 /area/slavers_base/maint)
 "kU" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 1;
 	id_tag = "solar_port_pump"
 	},

--- a/maps/away/smugglers/smugglers.dm
+++ b/maps/away/smugglers/smugglers.dm
@@ -21,7 +21,7 @@
 	generate_mining_by_z = 1
 	area_usage_test_exempted_root_areas = list(/area/smugglers)
 	apc_test_exempt_areas = list(
-		/area/smugglers/base = NO_SCRUBBER,
+		/area/smugglers/base = NO_SCRUBBER|NO_VENT,
 		/area/smugglers/dorms = NO_SCRUBBER|NO_VENT,
 		/area/smugglers/office = NO_SCRUBBER|NO_VENT
 	)

--- a/maps/away/smugglers/smugglers.dmm
+++ b/maps/away/smugglers/smugglers.dmm
@@ -52,8 +52,7 @@
 /area/smugglers/base)
 "am" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
-	master_tag = "asteroid_base_dock_airlock";
+	id_tag = "asteroid_base_dock_airlock";
 	pixel_x = 25
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -293,8 +292,7 @@
 	icon_state = "beartrap1"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
-	master_tag = "asteroid_base_east_airlock";
+	id_tag = "asteroid_base_east_airlock";
 	pixel_y = -25
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{

--- a/maps/away/smugglers/smugglers.dmm
+++ b/maps/away/smugglers/smugglers.dmm
@@ -274,7 +274,6 @@
 /area/smugglers/base)
 "aI" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "asteroid_base_east_inner";
 	locked = 1;
@@ -304,7 +303,6 @@
 /area/smugglers/base)
 "aK" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "asteroid_base_east_outer";
 	locked = 1

--- a/maps/away/smugglers/smugglers.dmm
+++ b/maps/away/smugglers/smugglers.dmm
@@ -108,7 +108,6 @@
 "av" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "asteroid_base_dock_airlock";
 	name = "Dock Airlock Controller";
 	pixel_x = -25;
@@ -253,7 +252,6 @@
 /area/smugglers/base)
 "aH" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "asteroid_base_east_airlock";
 	pixel_y = 25;
 	tag_airpump = "asteroid_base_east_pump";

--- a/maps/away/smugglers/smugglers.dmm
+++ b/maps/away/smugglers/smugglers.dmm
@@ -21,7 +21,6 @@
 /area/smugglers/base)
 "ag" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
 	icon_state = "door_closed";
 	locked = 0
 	},
@@ -53,11 +52,11 @@
 /area/smugglers/base)
 "am" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1439;
+	frequency = 1380;
 	master_tag = "asteroid_base_dock_airlock";
 	pixel_x = 25
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 2;
 	id_tag = "asteroid_base_dock_pump"
 	},
@@ -84,7 +83,6 @@
 /area/space)
 "aq" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
 	icon_state = "door_closed";
 	locked = 0;
 	name = "Internal Airlock"
@@ -111,7 +109,7 @@
 "av" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "asteroid_base_dock_airlock";
 	name = "Dock Airlock Controller";
 	pixel_x = -25;
@@ -119,10 +117,8 @@
 	tag_exterior_door = "asteroid_base_dock_outer";
 	tag_interior_door = "asteroid_base_dock_inner"
 	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1439;
-	master_tag = "asteroid_base_dock_airlock";
+/obj/machinery/button/access/interior{
+	id_tag = "asteroid_base_dock_airlock";
 	name = "interior access button";
 	pixel_x = 28;
 	pixel_y = 24;
@@ -258,19 +254,15 @@
 /area/smugglers/base)
 "aH" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "asteroid_base_east_airlock";
 	pixel_y = 25;
 	tag_airpump = "asteroid_base_east_pump";
 	tag_exterior_door = "asteroid_base_east_outer";
-	tag_exterior_sensor = null;
-	tag_interior_door = "asteroid_base_east_inner";
-	tag_interior_sensor = null
+	tag_interior_door = "asteroid_base_east_inner"
 	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1439;
-	master_tag = "asteroid_base_east_airlock";
+/obj/machinery/button/access/interior{
+	id_tag = "asteroid_base_east_airlock";
 	name = "interior access button";
 	pixel_x = -28;
 	pixel_y = 24;
@@ -283,7 +275,7 @@
 /area/smugglers/base)
 "aI" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
+	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "asteroid_base_east_inner";
 	locked = 1;
@@ -301,11 +293,11 @@
 	icon_state = "beartrap1"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1439;
+	frequency = 1380;
 	master_tag = "asteroid_base_east_airlock";
 	pixel_y = -25
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 8;
 	id_tag = "asteroid_base_east_pump"
 	},
@@ -314,7 +306,7 @@
 /area/smugglers/base)
 "aK" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
+	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "asteroid_base_east_outer";
 	locked = 1
@@ -322,9 +314,8 @@
 /turf/simulated/floor,
 /area/smugglers/base)
 "aL" = (
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1439;
-	master_tag = "asteroid_base_east_airlock";
+/obj/machinery/button/access/exterior{
+	id_tag = "asteroid_base_east_airlock";
 	name = "exterior access button";
 	pixel_x = -25;
 	pixel_y = 25

--- a/maps/away/unishi/unishi-1.dmm
+++ b/maps/away/unishi/unishi-1.dmm
@@ -253,7 +253,7 @@
 /turf/simulated/floor,
 /area/unishi/engineering)
 "aL" = (
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	dir = 4;
 	id_tag = "unishi_inner"
 	},
@@ -268,7 +268,7 @@
 /turf/simulated/floor,
 /area/unishi/engineering)
 "aN" = (
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	dir = 4;
 	id_tag = "unishi_outer"
 	},

--- a/maps/away/unishi/unishi-1.dmm
+++ b/maps/away/unishi/unishi-1.dmm
@@ -261,7 +261,7 @@
 /turf/simulated/floor,
 /area/unishi/engineering)
 "aM" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 8;
 	id_tag = "unishi_vent"
 	},
@@ -357,8 +357,8 @@
 /turf/simulated/wall/r_wall,
 /area/unishi/engineroom)
 "aX" = (
-/obj/machinery/access_button/airlock_interior{
-	master_tag = "unishi";
+/obj/machinery/button/access/interior{
+	id_tag = "unishi";
 	pixel_x = 28
 	},
 /turf/simulated/floor,
@@ -368,8 +368,8 @@
 /turf/simulated/wall/titanium,
 /area/unishi/engineering)
 "aZ" = (
-/obj/machinery/access_button/airlock_exterior{
-	master_tag = "unishi";
+/obj/machinery/button/access/exterior{
+	id_tag = "unishi";
 	pixel_x = -28
 	},
 /turf/space,

--- a/maps/away/yacht/yacht.dmm
+++ b/maps/away/yacht/yacht.dmm
@@ -1329,7 +1329,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "yacht_airlock";
 	pixel_y = 24;
 	tag_airpump = "yacht_pump";

--- a/maps/away/yacht/yacht.dmm
+++ b/maps/away/yacht/yacht.dmm
@@ -1317,7 +1317,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1380;
 	id_tag = "yacht_outer"
 	},
 /turf/simulated/floor/airless,
@@ -1360,7 +1359,6 @@
 	icon_state = "intact"
 	},
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1380;
 	id_tag = "yacht_inner"
 	},
 /turf/simulated/floor/plating,

--- a/maps/away/yacht/yacht.dmm
+++ b/maps/away/yacht/yacht.dmm
@@ -1343,7 +1343,6 @@
 	id_tag = "yacht_pump"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "yacht_sensor";
 	pixel_y = -24
 	},

--- a/maps/away/yacht/yacht.dmm
+++ b/maps/away/yacht/yacht.dmm
@@ -1257,9 +1257,8 @@
 /turf/simulated/floor/wood/walnut,
 /area/yacht/living)
 "fb" = (
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1439;
-	master_tag = "yacht_airlock";
+/obj/machinery/button/access/exterior{
+	id_tag = "yacht_airlock";
 	pixel_x = 24
 	},
 /turf/space,
@@ -1272,9 +1271,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/constructable_frame/computerframe,
-/obj/machinery/access_button/airlock_interior{
-	frequency = 1439;
-	master_tag = "yacht_airlock";
+/obj/machinery/button/access/interior{
+	id_tag = "yacht_airlock";
 	pixel_x = -24
 	},
 /turf/simulated/floor/plating,
@@ -1319,7 +1317,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "yacht_outer"
 	},
 /turf/simulated/floor/airless,
@@ -1332,7 +1330,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "yacht_airlock";
 	pixel_y = 24;
 	tag_airpump = "yacht_pump";
@@ -1340,12 +1338,12 @@
 	tag_exterior_door = "yacht_outer";
 	tag_interior_door = "yacht_inner"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 4;
 	id_tag = "yacht_pump"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "yacht_sensor";
 	pixel_y = -24
 	},
@@ -1363,7 +1361,7 @@
 	icon_state = "intact"
 	},
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "yacht_inner"
 	},
 /turf/simulated/floor/plating,

--- a/maps/bearcat/bearcat-1.dmm
+++ b/maps/bearcat/bearcat-1.dmm
@@ -7,14 +7,14 @@
 /turf/space,
 /area/space)
 "ad" = (
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "cargo_out"
 	},
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/plating,
 /area/ship/bearcat/cargo/lower)
 "ae" = (
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "cargo_out"
 	},
 /obj/machinery/button/access/exterior{
@@ -195,14 +195,14 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/bearcat/cargo/lower)
 "aG" = (
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "cargo_in"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
 /area/ship/bearcat/cargo/lower)
 "aH" = (
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "cargo_in"
 	},
 /obj/machinery/button/access/interior{
@@ -1997,7 +1997,7 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "eva_in"
 	},
 /obj/machinery/button/access/interior{
@@ -2056,7 +2056,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/bearcat/maintenance/eva)
 "eI" = (
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "eva_out"
 	},
 /obj/machinery/button/access/exterior{

--- a/maps/bearcat/bearcat-1.dmm
+++ b/maps/bearcat/bearcat-1.dmm
@@ -17,8 +17,8 @@
 /obj/machinery/door/airlock/external/bolted/cycling{
 	id_tag = "cargo_out"
 	},
-/obj/machinery/access_button/airlock_exterior{
-	master_tag = "cargo";
+/obj/machinery/button/access/exterior{
+	id_tag = "cargo";
 	pixel_x = 18;
 	pixel_y = 17
 	},
@@ -33,13 +33,13 @@
 /turf/simulated/floor/plating,
 /area/ship/bearcat/escape_port)
 "aj" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "cargo_pump"
 	},
 /turf/simulated/floor/plating,
 /area/ship/bearcat/cargo/lower)
 "ak" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "cargo_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
@@ -205,8 +205,8 @@
 /obj/machinery/door/airlock/external/bolted/cycling{
 	id_tag = "cargo_in"
 	},
-/obj/machinery/access_button/airlock_interior{
-	master_tag = "cargo";
+/obj/machinery/button/access/interior{
+	id_tag = "cargo";
 	pixel_x = 20;
 	pixel_y = -12
 	},
@@ -2000,8 +2000,8 @@
 /obj/machinery/door/airlock/external/bolted/cycling{
 	id_tag = "eva_in"
 	},
-/obj/machinery/access_button/airlock_interior{
-	master_tag = "eva";
+/obj/machinery/button/access/interior{
+	id_tag = "eva";
 	pixel_x = -12;
 	pixel_y = 20
 	},
@@ -2045,7 +2045,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/bearcat/maintenance/eva)
 "eH" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 8;
 	id_tag = "eva_pump"
 	},
@@ -2059,8 +2059,8 @@
 /obj/machinery/door/airlock/external/bolted/cycling{
 	id_tag = "eva_out"
 	},
-/obj/machinery/access_button/airlock_exterior{
-	master_tag = "eva";
+/obj/machinery/button/access/exterior{
+	id_tag = "eva";
 	pixel_x = 18;
 	pixel_y = -18
 	},

--- a/maps/bearcat/bearcat-2.dmm
+++ b/maps/bearcat/bearcat-2.dmm
@@ -10,7 +10,6 @@
 /area/ship/bearcat/shuttle/outgoing)
 "ac" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "bearcat_shuttle_sensor";
 	pixel_y = -24
 	},
@@ -4789,7 +4788,6 @@
 	dir = 1
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "dock_port_sensor";
 	pixel_y = 36
 	},

--- a/maps/bearcat/bearcat-2.dmm
+++ b/maps/bearcat/bearcat-2.dmm
@@ -475,8 +475,8 @@
 	name = "External Blast Doors";
 	opacity = 0
 	},
-/obj/machinery/access_button/airlock_interior{
-	master_tag = "bearcat_starboard_dock";
+/obj/machinery/button/access/interior{
+	id_tag = "bearcat_starboard_dock";
 	pixel_x = -12;
 	pixel_y = 20
 	},
@@ -524,7 +524,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/bearcat/dock)
 "bZ" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 8;
 	id_tag = "dock_star_pump"
 	},
@@ -537,8 +537,8 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/bearcat/dock)
 "ca" = (
-/obj/machinery/access_button/airlock_exterior{
-	master_tag = "bearcat_starboard_dock";
+/obj/machinery/button/access/exterior{
+	id_tag = "bearcat_starboard_dock";
 	pixel_x = 18;
 	pixel_y = 20
 	},
@@ -3857,9 +3857,8 @@
 	frequency = 1380;
 	id_tag = "bearcat_shuttle_out"
 	},
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1380;
-	master_tag = "bearcat_shuttle";
+/obj/machinery/button/access/exterior{
+	id_tag = "bearcat_shuttle";
 	pixel_x = 18;
 	pixel_y = -20
 	},
@@ -4635,9 +4634,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/bearcat/command/bridge)
 "lc" = (
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1380;
-	master_tag = "bearcat_dock_port";
+/obj/machinery/button/access/exterior{
+	id_tag = "bearcat_dock_port";
 	pixel_x = -18;
 	pixel_y = 20
 	},
@@ -4851,9 +4849,8 @@
 	name = "External Blast Doors";
 	opacity = 0
 	},
-/obj/machinery/access_button/airlock_interior{
-	frequency = 1380;
-	master_tag = "bearcat_dock_port";
+/obj/machinery/button/access/interior{
+	id_tag = "bearcat_dock_port";
 	pixel_x = 12;
 	pixel_y = 20
 	},
@@ -6766,9 +6763,8 @@
 /obj/structure/cable{
 	icon_state = "4-10"
 	},
-/obj/machinery/access_button/airlock_interior{
-	frequency = 1380;
-	master_tag = "bearcat_shuttle";
+/obj/machinery/button/access/interior{
+	id_tag = "bearcat_shuttle";
 	pixel_x = -12;
 	pixel_y = 20
 	},

--- a/maps/bearcat/bearcat-2.dmm
+++ b/maps/bearcat/bearcat-2.dmm
@@ -4790,7 +4790,6 @@
 	pixel_y = 36
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 1380;
 	id_tag = "bearcat_dock_port";
 	pixel_y = 25;
 	tag_airpump = "dock_port_pump";
@@ -6821,7 +6820,6 @@
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	cycle_to_external_air = 1;
-	frequency = 1380;
 	id_tag = "bearcat_shuttle";
 	pixel_x = 0;
 	pixel_y = -24;

--- a/maps/bearcat/bearcat-2.dmm
+++ b/maps/bearcat/bearcat-2.dmm
@@ -483,7 +483,7 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "dock_star_in"
 	},
 /obj/structure/cable{
@@ -541,7 +541,7 @@
 	pixel_x = 18;
 	pixel_y = 20
 	},
-/obj/machinery/door/airlock/external/bolted/cycling{
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "dock_star_out"
 	},
 /obj/machinery/shield_diffuser,
@@ -3852,8 +3852,7 @@
 /turf/simulated/floor/tiled,
 /area/ship/bearcat/crew/saloon)
 "jc" = (
-/obj/machinery/door/airlock/external/bolted/cycling{
-	frequency = 1380;
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "bearcat_shuttle_out"
 	},
 /obj/machinery/button/access/exterior{
@@ -4638,8 +4637,7 @@
 	pixel_x = -18;
 	pixel_y = 20
 	},
-/obj/machinery/door/airlock/external/bolted/cycling{
-	frequency = 1380;
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "dock_port_out"
 	},
 /obj/machinery/shield_diffuser,
@@ -4856,8 +4854,7 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/obj/machinery/door/airlock/external/bolted/cycling{
-	frequency = 1380;
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "dock_port_in"
 	},
 /obj/structure/cable{
@@ -6754,8 +6751,7 @@
 /turf/simulated/open,
 /area/ship/bearcat/cargo)
 "Yb" = (
-/obj/machinery/door/airlock/external/bolted/cycling{
-	frequency = 1380;
+/obj/machinery/door/airlock/external/bolted{
 	id_tag = "bearcat_shuttle_in"
 	},
 /obj/structure/cable{

--- a/maps/example/example-1.dmm
+++ b/maps/example/example-1.dmm
@@ -177,14 +177,14 @@
 /area/shuttle/escape)
 "D" = (
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1379;
+	frequency = 1380;
 	id_tag = "example_shuttle_port_hatch"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "E" = (
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1379;
+	frequency = 1380;
 	id_tag = "example_shuttle_starboard_hatch"
 	},
 /turf/simulated/floor/plating,
@@ -199,7 +199,7 @@
 /area/constructionsite)
 "G" = (
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1379;
+	frequency = 1380;
 	id_tag = "lower_level_dock_hatch"
 	},
 /turf/simulated/floor,

--- a/maps/example/example-1.dmm
+++ b/maps/example/example-1.dmm
@@ -177,14 +177,12 @@
 /area/shuttle/escape)
 "D" = (
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1380;
 	id_tag = "example_shuttle_port_hatch"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "E" = (
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1380;
 	id_tag = "example_shuttle_starboard_hatch"
 	},
 /turf/simulated/floor/plating,
@@ -199,7 +197,6 @@
 /area/constructionsite)
 "G" = (
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1380;
 	id_tag = "lower_level_dock_hatch"
 	},
 /turf/simulated/floor,

--- a/maps/example/example-3.dmm
+++ b/maps/example/example-3.dmm
@@ -66,7 +66,7 @@
 /area/maintenance/fsmaint2)
 "n" = (
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1379
+	frequency = 1380
 	},
 /turf/simulated/floor,
 /area/maintenance/fsmaint2)

--- a/maps/example/example-3.dmm
+++ b/maps/example/example-3.dmm
@@ -66,7 +66,6 @@
 /area/maintenance/fsmaint2)
 "n" = (
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1380
 	},
 /turf/simulated/floor,
 /area/maintenance/fsmaint2)

--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
@@ -1872,10 +1872,8 @@
 	icon_state = "warning";
 	dir = 4
 	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1380;
-	master_tag = "solars_airlock";
+/obj/machinery/button/access/interior{
+	id_tag = "solars_airlock";
 	name = "interior access button";
 	pixel_x = 24;
 	pixel_y = -24
@@ -1981,10 +1979,8 @@
 	icon_state = "warning";
 	dir = 8
 	},
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1380;
-	master_tag = "solars_airlock";
+/obj/machinery/button/access/exterior{
+	id_tag = "solars_airlock";
 	name = "exterior access button";
 	pixel_x = -24;
 	pixel_y = 24
@@ -2600,10 +2596,8 @@
 	dir = 8
 	},
 /obj/structure/catwalk,
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1380;
-	master_tag = "hydrodock_airlock";
+/obj/machinery/button/access/interior{
+	id_tag = "hydrodock_airlock";
 	name = "interior access button";
 	pixel_x = -24;
 	pixel_y = 0;
@@ -3001,10 +2995,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/hydrobase/station/dockport)
 "gL" = (
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1380;
-	master_tag = "hydrodock_airlock";
+/obj/machinery/button/access/exterior{
+	id_tag = "hydrodock_airlock";
 	name = "exterior access button";
 	pixel_x = 24;
 	pixel_y = 24;

--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
@@ -1919,7 +1919,6 @@
 	dir = 8
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "solars_airlock";
 	name = "EVA Airlock Console";
 	pixel_y = -24;
@@ -2904,7 +2903,6 @@
 	id_tag = "hydrodock_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "hydrodock_airlock";
 	name = "Shipping Airlock Console";
 	pixel_x = 24;

--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
@@ -1951,7 +1951,6 @@
 	dir = 4
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "solars_sensor";
 	pixel_x = 0;
 	pixel_y = 25
@@ -2822,7 +2821,6 @@
 	dir = 1
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "hydrodock_sensor";
 	pixel_x = 0;
 	pixel_y = 25

--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
@@ -1896,7 +1896,6 @@
 	icon_state = "intact"
 	},
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "solars_inner";
 	locked = 1;
@@ -1964,7 +1963,6 @@
 /area/map_template/hydrobase/station/solarlock)
 "eH" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "solars_outer";
 	locked = 1;
@@ -2766,7 +2764,6 @@
 "go" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "hydrodock_inner";
 	locked = 1;
@@ -2984,7 +2981,6 @@
 /area/map_template/hydrobase/station/dockport)
 "gK" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "hydrodock_outer";
 	locked = 1;

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -6410,7 +6410,6 @@
 /area/map_template/colony/mineralprocessing)
 "lh" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "playablecolonymain_exterior_door";
 	locked = 1
 	},
@@ -7007,7 +7006,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "playablecolonymain_interior_door"
 	},
 /obj/effect/decal/cleanable/dirt,

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -6686,7 +6686,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	cycle_to_external_air = 1;
-	frequency = 1380;
 	id_tag = "playablecolonymain";
 	pixel_y = 28;
 	tag_airpump = "playablecolonymain_pump";

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -3799,7 +3799,7 @@
 /area/map_template/colony/airlock)
 "gR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 2;
 	id_tag = "playablecolonymain_pump_out_external";
 	
@@ -6410,7 +6410,7 @@
 /area/map_template/colony/mineralprocessing)
 "lh" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "playablecolonymain_exterior_door";
 	locked = 1
 	},
@@ -6687,7 +6687,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	cycle_to_external_air = 1;
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "playablecolonymain";
 	pixel_y = 28;
 	tag_airpump = "playablecolonymain_pump";
@@ -6697,7 +6697,7 @@
 	tag_interior_door = "playablecolonymain_interior_door";
 	tag_interior_sensor = "playablecolonymain_sensor_interior"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 2;
 	id_tag = "playablecolonymain_pump";
 	power_rating = 25000;
@@ -6723,7 +6723,7 @@
 /area/map_template/colony/atmospherics)
 "lM" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "playablecolonymain_sensor_chamber";
 	pixel_x = 22
 	},
@@ -6731,7 +6731,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 2;
 	id_tag = "playablecolonymain_pump";
 	power_rating = 25000;
@@ -6776,9 +6776,8 @@
 "lQ" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/atmospherics/portables_connector,
-/obj/machinery/access_button/airlock_interior{
-	frequency = 1439;
-	master_tag = "playablecolonymain";
+/obj/machinery/button/access/interior{
+	id_tag = "playablecolonymain";
 	pixel_x = -22;
 	pixel_y = 5
 	},
@@ -6787,7 +6786,7 @@
 	dir = 5
 	},
 /obj/machinery/airlock_sensor/airlock_interior{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "playablecolonymain_sensor_interior";
 	pixel_x = -22
 	},
@@ -6912,13 +6911,12 @@
 /area/map_template/colony/mineralprocessing)
 "ma" = (
 /obj/machinery/airlock_sensor/airlock_exterior{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "playablecolonymain_sensor_external";
 	pixel_x = 22
 	},
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1439;
-	master_tag = "playablecolonymain";
+/obj/machinery/button/access/exterior{
+	id_tag = "playablecolonymain";
 	pixel_x = 19;
 	pixel_y = 5
 	},
@@ -7012,7 +7010,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "playablecolonymain_interior_door"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -8008,7 +8006,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 8;
 	id_tag = "playablecolonymain_pump_out_internal";
 	power_rating = 25000;
@@ -8075,7 +8073,7 @@
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 1;
 	id_tag = "playablecolonymain_pump";
 	power_rating = 25000;
@@ -8101,7 +8099,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 1;
 	id_tag = "playablecolonymain_pump";
 	power_rating = 25000;
@@ -8512,7 +8510,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 8;
 	id_tag = "playablecolonymain_pump_out_internal";
 	power_rating = 25000;

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -6723,7 +6723,6 @@
 /area/map_template/colony/atmospherics)
 "lM" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "playablecolonymain_sensor_chamber";
 	pixel_x = 22
 	},
@@ -6785,8 +6784,7 @@
 	icon_state = "corner_white";
 	dir = 5
 	},
-/obj/machinery/airlock_sensor/airlock_interior{
-	frequency = 1380;
+/obj/machinery/airlock_sensor{
 	id_tag = "playablecolonymain_sensor_interior";
 	pixel_x = -22
 	},
@@ -6910,8 +6908,7 @@
 /turf/simulated/floor/exoplanet/concrete,
 /area/map_template/colony/mineralprocessing)
 "ma" = (
-/obj/machinery/airlock_sensor/airlock_exterior{
-	frequency = 1380;
+/obj/machinery/airlock_sensor{
 	id_tag = "playablecolonymain_sensor_external";
 	pixel_x = 22
 	},

--- a/mods/ascent/away_sites/ascent/ascent-1.dmm
+++ b/mods/ascent/away_sites/ascent/ascent-1.dmm
@@ -839,8 +839,8 @@
 /area/ship/ascent/habitation)
 "cn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on/ascent,
-/obj/machinery/access_button/airlock_interior{
-	master_tag = "ascent_seedship_fore_dock_controller";
+/obj/machinery/button/access/interior{
+	id_tag = "ascent_seedship_fore_dock_controller";
 	pixel_x = -4;
 	pixel_y = 24
 	},
@@ -1388,10 +1388,8 @@
 	id_tag = "ascent_seedship_fore_external"
 	},
 /obj/effect/catwalk_plated/ascent,
-/obj/machinery/access_button/airlock_interior{
-	command = "cycle_exterior";
-	frequency = 1331;
-	master_tag = "ascent_seedship_fore_dock_controller";
+/obj/machinery/button/access/shuttle/exterior{
+	id_tag = "ascent_seedship_fore_dock_controller";
 	pixel_x = -4;
 	pixel_y = 24
 	},
@@ -1502,7 +1500,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/machinery/access_button/airlock_interior,
+/obj/machinery/button/access/interior,
 /turf/simulated/floor/ascent,
 /area/ship/ascent/habitation)
 "dQ" = (
@@ -1574,10 +1572,8 @@
 	},
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/light/ascent,
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1331;
-	master_tag = "ascent_starboard";
+/obj/machinery/button/access/shuttle/interior{
+	id_tag = "ascent_starboard";
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -3467,10 +3463,8 @@
 	},
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/atmospherics/pipe/manifold/hidden/black,
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1331;
-	master_tag = "ascent_starboard";
+/obj/machinery/button/access/shuttle/exterior{
+	id_tag = "ascent_starboard";
 	pixel_x = -24;
 	pixel_y = 0
 	},
@@ -3596,9 +3590,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/access_button/airlock_interior{
-	frequency = 1331;
-	master_tag = "ascent_port_shuttle_dock";
+/obj/machinery/button/access/shuttle/interior{;
+	id_tag = "ascent_port_shuttle_dock";
 	pixel_x = 4;
 	pixel_y = 24
 	},
@@ -4137,9 +4130,8 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/wing_port)
 "jM" = (
-/obj/machinery/access_button/airlock_interior{
-	command = "cycle_exterior";
-	master_tag = "ascent_port_shuttle_dock";
+/obj/machinery/button/access/exterior/airlock_interior{
+	id_tag = "ascent_port_shuttle_dock";
 	pixel_x = 24
 	},
 /obj/effect/catwalk_plated/ascent,

--- a/mods/ascent/away_sites/ascent/ascent-1.dmm
+++ b/mods/ascent/away_sites/ascent/ascent-1.dmm
@@ -1541,8 +1541,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
+/obj/machinery/airlock_sensor/shuttle{
 	id_tag = "ascent_port_dock_sensor";
 	pixel_x = -8;
 	pixel_y = 24
@@ -1850,8 +1849,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
 	id_tag = "ascent_seedship_fore_pumps"
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
+/obj/machinery/airlock_sensor/shuttle{
 	id_tag = "ascent_seedship_fore_dock_sensor";
 	pixel_y = 24
 	},
@@ -2073,8 +2071,7 @@
 /turf/simulated/floor/ascent,
 /area/ship/ascent/shuttle_starboard)
 "fa" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
+/obj/machinery/airlock_sensor/shuttle{
 	id_tag = "ascent_starboard_sensor";
 	pixel_x = -24;
 	pixel_y = 0
@@ -2202,8 +2199,7 @@
 	tag_exterior_door = "ascent_port_outer";
 	tag_interior_door = "ascent_port_inner"
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
+/obj/machinery/airlock_sensor/shuttle{
 	id_tag = "ascent_port_sensor";
 	pixel_x = 24;
 	pixel_y = -12
@@ -3956,8 +3952,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
+/obj/machinery/airlock_sensor/shuttle{
 	id_tag = "ascent_shuttle_starboard_interior_sensor";
 	pixel_x = -8;
 	pixel_y = -24
@@ -4196,8 +4191,7 @@
 	dir = 8;
 	id_tag = "ascent_starboard_pump_out_external"
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1331;
+/obj/machinery/airlock_sensor/shuttle{
 	id_tag = "ascent_starboard_sensor_external";
 	pixel_x = -24;
 	pixel_y = 0

--- a/mods/ascent/away_sites/ascent/ascent-1.dmm
+++ b/mods/ascent/away_sites/ascent/ascent-1.dmm
@@ -47,7 +47,6 @@
 	},
 /obj/machinery/door/airlock/external/bolted/ascent{
 	airlock_type = "Internal";
-	frequency = 1331;
 	id_tag = "ascent_starboard_inner"
 	},
 /turf/simulated/floor/ascent,
@@ -394,7 +393,6 @@
 "bq" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
 	airlock_type = "Internal";
-	frequency = 1331;
 	id_tag = "ascent_dock_starboard_internal"
 	},
 /obj/structure/cable/cyan{
@@ -740,7 +738,6 @@
 "ce" = (
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1331;
 	id_tag = "ascent_port_dock_inner"
 	},
 /turf/simulated/floor/ascent,
@@ -1384,7 +1381,6 @@
 /area/ship/ascent/fore_starboard_prow)
 "dD" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1331;
 	id_tag = "ascent_seedship_fore_external"
 	},
 /obj/effect/catwalk_plated/ascent,
@@ -1551,7 +1547,6 @@
 /area/ship/ascent/wing_port)
 "dX" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1331;
 	id_tag = "ascent_port_dock_inner"
 	},
 /obj/structure/cable/cyan{
@@ -1776,7 +1771,6 @@
 /area/ship/ascent/fore_hallway)
 "er" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1331;
 	id_tag = "ascent_seedship_fore_internal"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1873,7 +1867,6 @@
 /obj/effect/shuttle_landmark/ascent_seedship/start,
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1331;
 	id_tag = "ascent_port_dock_outer"
 	},
 /turf/simulated/floor/ascent,
@@ -1995,7 +1988,6 @@
 /area/ship/ascent/engineering)
 "eF" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1331;
 	id_tag = "ascent_port_dock_outer"
 	},
 /obj/effect/catwalk_plated/ascent,
@@ -2017,7 +2009,6 @@
 "eO" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
 	airlock_type = "Internal";
-	frequency = 1331;
 	id_tag = "ascent_starboard_inner"
 	},
 /obj/effect/catwalk_plated/ascent,
@@ -2036,7 +2027,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/machinery/door/airlock/external/bolted/ascent{
 	airlock_type = "Internal";
-	frequency = 1331;
 	id_tag = "ascent_starboard_inner"
 	},
 /turf/simulated/floor/ascent,
@@ -2108,7 +2098,6 @@
 /area/ship/ascent/shuttle_starboard)
 "fe" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1331;
 	id_tag = "ascent_port_outer"
 	},
 /obj/structure/cable/cyan{
@@ -2696,7 +2685,6 @@
 /area/ship/ascent/fore_hallway)
 "gs" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1331;
 	id_tag = "ascent_port_inner"
 	},
 /obj/effect/catwalk_plated/ascent,
@@ -3454,7 +3442,6 @@
 /area/ship/ascent/shuttle_starboard)
 "ie" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1331;
 	id_tag = "ascent_starboard_outer"
 	},
 /obj/effect/catwalk_plated/ascent,
@@ -3571,7 +3558,6 @@
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1331;
 	id_tag = "ascent_starboard_outer"
 	},
 /turf/simulated/floor/ascent,
@@ -3653,7 +3639,6 @@
 /area/ship/ascent/shuttle_port)
 "iE" = (
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1331;
 	id_tag = "ascent_dock_starboard_external"
 	},
 /obj/effect/catwalk_plated/ascent,
@@ -3668,7 +3653,6 @@
 /obj/effect/catwalk_plated/ascent,
 /obj/effect/shuttle_landmark/ascent_seedship/start/two,
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1331;
 	id_tag = "ascent_dock_starboard_external"
 	},
 /turf/simulated/floor/ascent,
@@ -3736,7 +3720,6 @@
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/door/airlock/external/bolted/ascent{
 	airlock_type = "Internal";
-	frequency = 1331;
 	id_tag = "ascent_dock_starboard_internal"
 	},
 /turf/simulated/floor/ascent,
@@ -4131,7 +4114,6 @@
 	},
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1331;
 	id_tag = "ascent_port_outer"
 	},
 /turf/simulated/floor/ascent,
@@ -4394,7 +4376,6 @@
 "pE" = (
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1331;
 	id_tag = "ascent_port_inner"
 	},
 /turf/simulated/floor/ascent,
@@ -5187,7 +5168,6 @@
 /obj/effect/catwalk_plated/ascent,
 /obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /obj/machinery/door/airlock/external/bolted/ascent{
-	frequency = 1331;
 	id_tag = "ascent_starboard_outer"
 	},
 /turf/simulated/floor/ascent,

--- a/mods/ascent/away_sites/ascent/ascent-1.dmm
+++ b/mods/ascent/away_sites/ascent/ascent-1.dmm
@@ -3572,7 +3572,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/button/access/shuttle/interior{;
+/obj/machinery/button/access/shuttle/interior{
 	id_tag = "ascent_port_shuttle_dock";
 	pixel_x = 4;
 	pixel_y = 24

--- a/mods/ascent/machines/ship_machines.dm
+++ b/mods/ascent/machines/ship_machines.dm
@@ -122,6 +122,10 @@ MANTIDIFY(/obj/item/chems/chem_disp_cartridge, "canister", "chemical storage")
 /obj/machinery/door/airlock/external/bolted/ascent
 	door_color = COLOR_PURPLE
 	stripe_color = COLOR_GRAY40
+	stock_part_presets = list(
+		/decl/stock_part_preset/radio/receiver/airlock/shuttle = 1,
+		/decl/stock_part_preset/radio/event_transmitter/airlock/shuttle = 1
+	)
 
 /obj/machinery/power/apc/hyper/ascent/north
 	name = "north bump"

--- a/mods/corporate/away_sites/lar_maria/lar_maria-1.dmm
+++ b/mods/corporate/away_sites/lar_maria/lar_maria-1.dmm
@@ -2011,7 +2011,6 @@
 	dir = 8
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "ZHPsec_access_airlock";
 	pixel_x = 0;
 	pixel_y = 0;
@@ -2754,7 +2753,6 @@
 	dir = 4
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "ZHPvirology_access_airlock";
 	pixel_x = 0;
 	pixel_y = 25;
@@ -3636,7 +3634,6 @@
 "iB" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "ZHPCells_airlock";
 	pixel_x = 0;
 	pixel_y = 0;

--- a/mods/corporate/away_sites/lar_maria/lar_maria-1.dmm
+++ b/mods/corporate/away_sites/lar_maria/lar_maria-1.dmm
@@ -2912,9 +2912,7 @@
 "gR" = (
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "ZHPvirology_access_airlock_sensor";
-	master_tag = "ZHPvirology_access_airlock";
 	pixel_x = 25;
 	pixel_y = 0
 	},

--- a/mods/corporate/away_sites/lar_maria/lar_maria-1.dmm
+++ b/mods/corporate/away_sites/lar_maria/lar_maria-1.dmm
@@ -2739,7 +2739,7 @@
 /area/lar_maria/vir_hallway)
 "gw" = (
 /obj/machinery/door/airlock/virology{
-	frequency = 1039;
+	frequency = 1380;
 	id_tag = "ZHPvirology_access_airlock_inner"
 	},
 /obj/machinery/door/blast/regular/open{
@@ -2759,7 +2759,7 @@
 	dir = 4
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1039;
+	frequency = 1380;
 	id_tag = "ZHPvirology_access_airlock";
 	pixel_x = 0;
 	pixel_y = 25;
@@ -2875,9 +2875,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/access_button/airlock_interior{
-	frequency = 1039;
-	master_tag = "ZHPvirology_access_airlock";
+/obj/machinery/button/access/interior{
+	id_tag = "ZHPvirology_access_airlock";
 	pixel_x = 0;
 	pixel_y = -25
 	},
@@ -2885,7 +2884,7 @@
 /area/lar_maria/vir_hallway)
 "gP" = (
 /obj/machinery/door/airlock/virology{
-	frequency = 1039;
+	frequency = 1380;
 	id_tag = "ZHPvirology_access_airlock_inner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2913,7 +2912,7 @@
 "gR" = (
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/airlock_sensor{
-	frequency = 1039;
+	frequency = 1380;
 	id_tag = "ZHPvirology_access_airlock_sensor";
 	master_tag = "ZHPvirology_access_airlock";
 	pixel_x = 25;
@@ -2958,7 +2957,7 @@
 /area/lar_maria/vir_access)
 "gY" = (
 /obj/machinery/door/airlock/virology{
-	frequency = 1039;
+	frequency = 1380;
 	id_tag = "ZHPvirology_access_airlock_outer"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2967,7 +2966,7 @@
 /area/lar_maria/vir_access)
 "gZ" = (
 /obj/machinery/door/airlock/virology{
-	frequency = 1039;
+	frequency = 1380;
 	id_tag = "ZHPvirology_access_airlock_outer"
 	},
 /turf/simulated/floor/tiled,
@@ -3068,9 +3067,8 @@
 /obj/structure/sign/warning/biohazard{
 	pixel_x = 32
 	},
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1039;
-	master_tag = "ZHPvirology_access_airlock";
+/obj/machinery/button/access/exterior{
+	id_tag = "ZHPvirology_access_airlock";
 	pixel_x = 25;
 	pixel_y = 15
 	},
@@ -3648,7 +3646,7 @@
 "iB" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "ZHPCells_airlock";
 	pixel_x = 0;
 	pixel_y = 0;
@@ -3749,7 +3747,7 @@
 /area/lar_maria/sec_wing)
 "iN" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "ZHPCells_airlock_inner"
 	},
 /obj/machinery/door/firedoor,
@@ -3762,7 +3760,7 @@
 /turf/simulated/floor/plating,
 /area/lar_maria/cells)
 "iO" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 1;
 	id_tag = "ZHPCells_airlock_pump"
 	},
@@ -3770,7 +3768,7 @@
 /area/lar_maria/cells)
 "iP" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "ZHPCells_airlock_outer"
 	},
 /obj/machinery/door/firedoor,

--- a/mods/corporate/away_sites/lar_maria/lar_maria-1.dmm
+++ b/mods/corporate/away_sites/lar_maria/lar_maria-1.dmm
@@ -1197,7 +1197,6 @@
 "de" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
-	frequency = 1041;
 	id_tag = "ZHPcells_access_airlock_outer"
 	},
 /obj/machinery/door/blast/regular/open{
@@ -1378,7 +1377,6 @@
 /area/lar_maria/cells)
 "dA" = (
 /obj/machinery/door/airlock/security{
-	frequency = 1041;
 	id_tag = "ZHPcells_access_airlock_outer"
 	},
 /obj/machinery/door/firedoor,
@@ -1662,7 +1660,7 @@
 "eu" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1041;
+	frequency = 1305;
 	id_tag = "ZHPcells_access_airlock";
 	pixel_x = 0;
 	pixel_y = 0;
@@ -2013,7 +2011,7 @@
 	dir = 8
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1043;
+	frequency = 1380;
 	id_tag = "ZHPsec_access_airlock";
 	pixel_x = 0;
 	pixel_y = 0;
@@ -2510,7 +2508,6 @@
 /area/lar_maria/sec_wing)
 "fX" = (
 /obj/machinery/door/airlock/virology{
-	frequency = 1043;
 	id_tag = "ZHPsec__access_airlock_inner"
 	},
 /obj/machinery/door/firedoor,
@@ -2553,7 +2550,6 @@
 /area/lar_maria/sec_wing)
 "fZ" = (
 /obj/machinery/door/airlock/virology{
-	frequency = 1043;
 	id_tag = "ZHPsec__access_airlock_outer"
 	},
 /obj/machinery/door/firedoor,
@@ -2739,7 +2735,6 @@
 /area/lar_maria/vir_hallway)
 "gw" = (
 /obj/machinery/door/airlock/virology{
-	frequency = 1380;
 	id_tag = "ZHPvirology_access_airlock_inner"
 	},
 /obj/machinery/door/blast/regular/open{
@@ -2884,7 +2879,6 @@
 /area/lar_maria/vir_hallway)
 "gP" = (
 /obj/machinery/door/airlock/virology{
-	frequency = 1380;
 	id_tag = "ZHPvirology_access_airlock_inner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2955,7 +2949,6 @@
 /area/lar_maria/vir_access)
 "gY" = (
 /obj/machinery/door/airlock/virology{
-	frequency = 1380;
 	id_tag = "ZHPvirology_access_airlock_outer"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2964,7 +2957,6 @@
 /area/lar_maria/vir_access)
 "gZ" = (
 /obj/machinery/door/airlock/virology{
-	frequency = 1380;
 	id_tag = "ZHPvirology_access_airlock_outer"
 	},
 /turf/simulated/floor/tiled,
@@ -3745,7 +3737,6 @@
 /area/lar_maria/sec_wing)
 "iN" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "ZHPCells_airlock_inner"
 	},
 /obj/machinery/door/firedoor,
@@ -3766,7 +3757,6 @@
 /area/lar_maria/cells)
 "iP" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
 	id_tag = "ZHPCells_airlock_outer"
 	},
 /obj/machinery/door/firedoor,

--- a/mods/corporate/away_sites/lar_maria/lar_maria-2.dmm
+++ b/mods/corporate/away_sites/lar_maria/lar_maria-2.dmm
@@ -269,7 +269,6 @@
 "aF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1380;
 	id_tag = "ZHPWestSolar_outer"
 	},
 /obj/structure/cable/yellow{
@@ -307,7 +306,6 @@
 "aH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1380;
 	id_tag = "ZHPWestSolar_inner"
 	},
 /obj/structure/cable/yellow{
@@ -367,7 +365,6 @@
 "aL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1380;
 	id_tag = "ZHPEastSolar_inner"
 	},
 /obj/structure/cable/yellow{
@@ -407,7 +404,6 @@
 "aN" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1380;
 	id_tag = "ZHPEastSolar_outer"
 	},
 /obj/structure/cable/yellow{
@@ -3349,7 +3345,6 @@
 /area/lar_maria/hallway)
 "ji" = (
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1380;
 	id_tag = "ZHPDock_airlock_inner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3357,7 +3352,6 @@
 /area/lar_maria/hallway)
 "jj" = (
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1380;
 	id_tag = "ZHPDock_airlock_inner"
 	},
 /obj/machinery/door/firedoor,
@@ -3392,7 +3386,6 @@
 /area/lar_maria/hallway)
 "jo" = (
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1380;
 	id_tag = "ZHPDock_airlock_outer"
 	},
 /turf/simulated/floor/plating,

--- a/mods/corporate/away_sites/lar_maria/lar_maria-2.dmm
+++ b/mods/corporate/away_sites/lar_maria/lar_maria-2.dmm
@@ -290,9 +290,7 @@
 	id_tag = "ZHPWestSolar_pump"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "ZHPWestSolar_sensor";
-	master_tag = "ZHPWestSolar";
 	pixel_y = 25
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -401,9 +399,7 @@
 	tag_interior_door = "ZHPEastSolar_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "ZHPEastSolar_sensor";
-	master_tag = "ZHPWestSolar";
 	pixel_y = 25
 	},
 /turf/simulated/floor/plating,
@@ -3388,9 +3384,7 @@
 /area/lar_maria/hallway)
 "jn" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
 	id_tag = "ZHPDock_airlock_sensor";
-	master_tag = "ZHPWestSolar";
 	pixel_x = 25;
 	pixel_y = 0
 	},

--- a/mods/corporate/away_sites/lar_maria/lar_maria-2.dmm
+++ b/mods/corporate/away_sites/lar_maria/lar_maria-2.dmm
@@ -293,7 +293,6 @@
 	pixel_y = 25
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "ZHPWestSolar";
 	pixel_y = -25;
 	tag_airpump = "ZHPWestSolar_pump";
@@ -387,7 +386,6 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1380;
 	id_tag = "ZHPEastSolar";
 	pixel_y = -25;
 	tag_airpump = "ZHPEastSolar_pump";

--- a/mods/corporate/away_sites/lar_maria/lar_maria-2.dmm
+++ b/mods/corporate/away_sites/lar_maria/lar_maria-2.dmm
@@ -259,9 +259,8 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1439;
-	master_tag = "ZHPWestSolar";
+/obj/machinery/button/access/exterior{
+	id_tag = "ZHPWestSolar";
 	pixel_x = 25;
 	pixel_y = 25
 	},
@@ -270,7 +269,7 @@
 "aF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "ZHPWestSolar_outer"
 	},
 /obj/structure/cable/yellow{
@@ -286,18 +285,18 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 4;
 	id_tag = "ZHPWestSolar_pump"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "ZHPWestSolar_sensor";
 	master_tag = "ZHPWestSolar";
 	pixel_y = 25
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "ZHPWestSolar";
 	pixel_y = -25;
 	tag_airpump = "ZHPWestSolar_pump";
@@ -310,7 +309,7 @@
 "aH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "ZHPWestSolar_inner"
 	},
 /obj/structure/cable/yellow{
@@ -335,9 +334,8 @@
 	icon_state = "warning";
 	dir = 8
 	},
-/obj/machinery/access_button/airlock_interior{
-	frequency = 1439;
-	master_tag = "ZHPWestSolar";
+/obj/machinery/button/access/interior{
+	id_tag = "ZHPWestSolar";
 	pixel_x = -25;
 	pixel_y = 25
 	},
@@ -361,9 +359,8 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
-/obj/machinery/access_button/airlock_interior{
-	frequency = 1303;
-	master_tag = "ZHPEastSolar";
+/obj/machinery/button/access/interior{
+	id_tag = "ZHPEastSolar";
 	pixel_x = 25;
 	pixel_y = 25
 	},
@@ -372,7 +369,7 @@
 "aL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "ZHPEastSolar_inner"
 	},
 /obj/structure/cable/yellow{
@@ -389,13 +386,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 8;
 	id_tag = "ZHPEastSolar_pump"
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "ZHPEastSolar";
 	pixel_y = -25;
 	tag_airpump = "ZHPEastSolar_pump";
@@ -404,7 +401,7 @@
 	tag_interior_door = "ZHPEastSolar_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "ZHPEastSolar_sensor";
 	master_tag = "ZHPWestSolar";
 	pixel_y = 25
@@ -414,7 +411,7 @@
 "aN" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "ZHPEastSolar_outer"
 	},
 /obj/structure/cable/yellow{
@@ -442,9 +439,8 @@
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/blood,
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1439;
-	master_tag = "ZHPEastSolar";
+/obj/machinery/button/access/exterior{
+	id_tag = "ZHPEastSolar";
 	pixel_x = -25;
 	pixel_y = 25
 	},
@@ -3348,9 +3344,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/machinery/access_button/airlock_interior{
-	frequency = 1439;
-	master_tag = "ZHPDock_airlock";
+/obj/machinery/button/access/interior{
+	id_tag = "ZHPDock_airlock";
 	pixel_x = 25;
 	pixel_y = -25
 	},
@@ -3358,7 +3353,7 @@
 /area/lar_maria/hallway)
 "ji" = (
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "ZHPDock_airlock_inner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3366,7 +3361,7 @@
 /area/lar_maria/hallway)
 "jj" = (
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "ZHPDock_airlock_inner"
 	},
 /obj/machinery/door/firedoor,
@@ -3378,32 +3373,22 @@
 /turf/simulated/floor/reinforced,
 /area/space)
 "jl" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 1;
 	id_tag = "ZHPDock_airlock_pump"
 	},
 /turf/simulated/floor/plating,
 /area/lar_maria/hallway)
 "jm" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 1;
 	id_tag = "ZHPDock_airlock_pump"
-	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1037;
-	id_tag = "ZHPCells_airlock";
-	pixel_x = 25;
-	pixel_y = 0;
-	tag_airpump = "ZHPCells_airlock_pump";
-	tag_chamber_sensor = null;
-	tag_exterior_door = "ZHPCells_airlock_outer";
-	tag_interior_door = "ZHPCells_airlock_inner"
 	},
 /turf/simulated/floor/plating,
 /area/lar_maria/hallway)
 "jn" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "ZHPDock_airlock_sensor";
 	master_tag = "ZHPWestSolar";
 	pixel_x = 25;
@@ -3413,7 +3398,7 @@
 /area/lar_maria/hallway)
 "jo" = (
 /obj/machinery/door/airlock/external/bolted{
-	frequency = 1439;
+	frequency = 1380;
 	id_tag = "ZHPDock_airlock_outer"
 	},
 /turf/simulated/floor/plating,
@@ -3426,9 +3411,8 @@
 /turf/simulated/floor/plating,
 /area/space)
 "jr" = (
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1039;
-	master_tag = "ZHPvirology_access_airlock";
+/obj/machinery/button/access/exterior{
+	id_tag = "ZHPvirology_access_airlock";
 	pixel_x = 25;
 	pixel_y = 15
 	},

--- a/mods/government/away_sites/icarus/icarus-2.dmm
+++ b/mods/government/away_sites/icarus/icarus-2.dmm
@@ -1535,7 +1535,7 @@
 /turf/simulated/floor/plating,
 /area/icarus/vessel)
 "eO" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 4;
 	id_tag = "bridgeport_pump"
 	},


### PR DESCRIPTION
Makes various airlock equipment pieces use radio parts. makes them all constructable (except for doors, which will probably be a separate PR). Needs testing; just opening for CI.

Worth mentioning that this removes some functionality from doors; they used to queue up their last-received command if unpowered, in some cases, and then run it when they become powered. They no longer do this.

Suggested map migration procedure:

- Find-replace 1380 by 1381 everywhere.
- Start by converting the frequency of every airlock you are using to either EXTERNAL_AIR_FREQ (1381) or SHUTTLE_AIR_FREQ (1331). While for most you can do this by search-replacing the numbers in the map, note that for specifically 1439 you will also need to look up the vent pumps corresponding to the airlock and change their type path (either to /external_air or to /shuttle).

- run the following search-replace:
```
/obj/machinery/access_button -> /obj/machinery/button/access
/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock -> /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air
(/obj/machinery/button/access.*\n(\t.*\n)*\t)master_tag -> $1id_tag
(/obj/machinery/button/access)(.*\{(?:\n\t.*)*)(;)?\n\tfrequency = 1331(;)? -> $1/shuttle$2$3
(/obj/machinery/button/access)(.*\{(?:\n\t.*)*)(;)?\n\tfrequency = 1381(;)? -> $1$2$3
(/obj/machinery/button/access(?:/shuttle)?)(.*\{)((?:\n\t.*)*)(;)?\n\tcommand = "cycle_interior"(;)? -> $1/interior$2$3
(/obj/machinery/button/access(?:/shuttle)?)(.*\{)((?:\n\t.*)*)(;)?\n\tcommand = "cycle_exterior"(;)? -> $1/exterior$2$3
(button/access/(?:shuttle/)?)airlock_((?:ex|in)terior) -> $1$2
```
- Search for `(/obj/machinery/button/access.*\n(\t.*\n)*\t)master_tag`. Remove if id_tag is also present; replace with `id_tag` otherwise.
- Run the following search-replace:
```
(/obj/machinery/airlock_sensor).+(\{) -> $1$2
(/obj/machinery/airlock_sensor)(.*\{(?:\n\t.*)*)(;)?\n\tfrequency = 1331(;)? -> $1/shuttle$2$3
(/obj/machinery/airlock_sensor)(.*\{(?:\n\t.*)*)(;)?\n\tfrequency = 1381(;)? -> $1$2$3

(/obj/machinery/door/airlock/external(?:/bolted)?)/cycling -> $1
(/obj/machinery/door/airlock/virology)(\{(?:\n\t.*)*)(;)?\n\tfrequency = 1381(;)? -> $1$2$3
(/obj/machinery/door/airlock/external(?:/bolted)?)(\{(?:\n\t.*)*)(;)?\n\tfrequency = 1381(;)? -> $1$2$3
(/obj/machinery/door/airlock/external)(\{(?:\n\t.*)*)(;)?\n\tfrequency = 1331(;)? -> $1/shuttle$2$3
```
- Note that airlocks often contain mapping errors, so you may need to do further manual changes.