### PR TITLE
Removing req_amount from crafting recipes for items and structures.

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -14,7 +14,7 @@
 	max_amount = 100
 	attack_verb = list("hit", "bludgeoned", "whacked")
 	lock_picking_level = 3
-	matter_multiplier = 0.5
+	matter_multiplier = 0.3
 	material_flags = USE_MATERIAL_COLOR
 	stacktype = /obj/item/stack/material/rods
 	material = MAT_STEEL

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -143,9 +143,9 @@
 			to_chat(user, "<span class='warning'>You waste some [name] and fail to build \the [recipe.display_name()]!</span>")
 			return
 		var/atom/O = recipe.spawn_result(user, user.loc, produced)
-		O.add_fingerprint(user)
-
-		user.put_in_hands(O)
+		if(!QDELETED(O)) // In case of stack merger.
+			O.add_fingerprint(user)
+			user.put_in_hands(O)
 
 /obj/item/stack/Topic(href, href_list)
 	..()

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -15,7 +15,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	max_amount = 100
 	icon = 'icons/obj/tiles.dmi'
-	matter_multiplier = 0.25
+	matter_multiplier = 0.15
 
 	force = 1
 	throwforce = 1

--- a/code/modules/materials/_stack_recipe.dm
+++ b/code/modules/materials/_stack_recipe.dm
@@ -29,8 +29,8 @@
 		req_amount = 0
 		var/list/materials = atom_info_repository.get_matter_for(result_type, use_material, res_amount)
 		for(var/mat in materials)
-			req_amount += materials[mat]
-		req_amount = Clamp(ceil((req_amount*CRAFTING_EXTRA_COST_FACTOR)/SHEET_MATERIAL_AMOUNT) * res_amount, 1, 50)
+			req_amount += round(materials[mat]/res_amount)
+		req_amount = Clamp(ceil(((req_amount*CRAFTING_EXTRA_COST_FACTOR)/SHEET_MATERIAL_AMOUNT) * res_amount), 1, 50)
 
 #undef CRAFTING_EXTRA_COST_FACTOR
 

--- a/code/modules/materials/_stack_recipe.dm
+++ b/code/modules/materials/_stack_recipe.dm
@@ -4,7 +4,7 @@
 /datum/stack_recipe
 	var/title = "ERROR"
 	var/result_type
-	var/req_amount = 1 // amount of material needed for this recipe
+	var/req_amount     // amount of material needed for this recipe
 	var/res_amount = 1 // amount of stuff that is produced in one batch (e.g. 4 for floor tiles)
 	var/max_res_amount = 1
 	var/time = 0

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -8,6 +8,7 @@
 	max_amount = 60
 	randpixel = 3
 	icon = 'icons/obj/materials.dmi'
+	matter = null
 
 	var/material/reinf_material
 	var/material_flags = USE_MATERIAL_COLOR|USE_MATERIAL_SINGULAR_NAME|USE_MATERIAL_PLURAL_NAME
@@ -43,21 +44,21 @@
 /obj/item/stack/material/get_codex_value()
 	return (material && !material.hidden_from_codex) ? "[lowertext(material.display_name)] (material)" : ..()
 
-/obj/item/stack/material/proc/set_amount(var/_amount)
-	amount = max(1, min(_amount, max_amount))
-	update_strings()
-
 /obj/item/stack/material/get_material()
 	return material
 
+/obj/item/stack/material/update_matter()
+	create_matter()
+
+/obj/item/stack/material/create_matter()
+	matter = list()
+	if(istype(material))
+		matter[material.type] = MATTER_AMOUNT_PRIMARY * get_matter_amount_modifier()
+	if(istype(reinf_material))
+		matter[reinf_material.type] = MATTER_AMOUNT_REINFORCEMENT * get_matter_amount_modifier()
+
 /obj/item/stack/material/proc/update_strings()
 	// Update from material datum.
-	var/matter_mod = get_matter_amount_modifier()
-	matter = list()
-	matter[material.type] = MATTER_AMOUNT_PRIMARY * matter_mod
-	if(reinf_material)
-		matter[reinf_material.type] = MATTER_AMOUNT_REINFORCEMENT * matter_mod
-
 	if(material_flags & USE_MATERIAL_SINGULAR_NAME)
 		singular_name = material.sheet_singular_name
 
@@ -79,7 +80,6 @@
 /obj/item/stack/material/use(var/used)
 	. = ..()
 	update_strings()
-	return
 
 /obj/item/stack/material/proc/is_same(obj/item/stack/material/M)
 	if(!istype(M))

--- a/code/modules/materials/recipes_furniture.dm
+++ b/code/modules/materials/recipes_furniture.dm
@@ -8,7 +8,6 @@
 /datum/stack_recipe/furniture/chair
 	title = "chair"
 	result_type = /obj/structure/bed/chair
-	req_amount = 5
 	time = 10
 	var/list/modifiers
 
@@ -34,7 +33,6 @@ PADDED_CHAIR(yellow)
 
 /datum/stack_recipe/furniture/chair/office
 	title = "office chair"
-	req_amount = 5
 
 /datum/stack_recipe/furniture/chair/office/display_name()
 	return modifiers ? jointext(modifiers + title, " ") : title // Bypass material
@@ -46,9 +44,6 @@ PADDED_CHAIR(yellow)
 /datum/stack_recipe/furniture/chair/office/dark
 	result_type = /obj/structure/bed/chair/office/dark
 	modifiers = list("dark")
-
-/datum/stack_recipe/furniture/chair/office/comfy
-	req_amount = 7
 
 #define COMFY_OFFICE_CHAIR(color) /datum/stack_recipe/furniture/chair/office/comfy/##color{\
 	result_type = /obj/structure/bed/chair/office/comfy/##color;\
@@ -67,7 +62,6 @@ COMFY_OFFICE_CHAIR(yellow)
 
 /datum/stack_recipe/furniture/chair/comfy
 	title = "comfy chair"
-	req_amount = 3
 
 #define COMFY_CHAIR(color) /datum/stack_recipe/furniture/chair/comfy/##color{\
 	result_type = /obj/structure/bed/chair/comfy/##color;\
@@ -86,7 +80,6 @@ COMFY_CHAIR(yellow)
 
 /datum/stack_recipe/furniture/chair/arm
 	title = "armchair"
-	req_amount = 4
 
 #define ARMCHAIR(color) /datum/stack_recipe/furniture/chair/arm/##color{\
 	result_type = /obj/structure/bed/chair/armchair/##color;\
@@ -104,7 +97,6 @@ ARMCHAIR(yellow)
 #undef ARMCHAIR
 
 /datum/stack_recipe/furniture/chair/wood
-	req_amount = 5
 
 /datum/stack_recipe/furniture/chair/wood/normal
 	result_type = /obj/structure/bed/chair/wood
@@ -116,55 +108,45 @@ ARMCHAIR(yellow)
 /datum/stack_recipe/furniture/door
 	title = "door"
 	result_type = /obj/structure/door
-	req_amount = 10
 	time = 50
 
 /datum/stack_recipe/furniture/barricade
 	title = "barricade"
 	result_type = /obj/structure/barricade
-	req_amount = 5
 	time = 50
 
 /datum/stack_recipe/furniture/stool
 	title = "stool"
 	result_type = /obj/item/stool
-	req_amount = 2
 
 /datum/stack_recipe/furniture/bar_stool
 	title = "bar stool"
 	result_type = /obj/item/stool/bar
-	req_amount = 2
 
 /datum/stack_recipe/furniture/bed
 	title = "bed"
 	result_type = /obj/structure/bed
-	req_amount = 5
 
 /datum/stack_recipe/furniture/pew
 	title = "pew, right"
 	result_type = /obj/structure/bed/chair/pew
-	req_amount = 5
 
 /datum/stack_recipe/furniture/pew_left
 	title = "pew, left"
 	result_type = /obj/structure/bed/chair/pew/left
-	req_amount = 5
 
 /datum/stack_recipe/furniture/table_frame
 	title = "table frame"
 	result_type = /obj/structure/table
-	req_amount = 5
 	time = 10
 
 /datum/stack_recipe/furniture/rack
 	title = "rack"
-	req_amount = 5
 	result_type = /obj/structure/table/rack
 
 /datum/stack_recipe/furniture/closet
 	title = "closet"
 	result_type = /obj/structure/closet
-	req_amount = 5
 	time = 15
 
 /datum/stack_recipe/furniture/canister
@@ -176,7 +158,6 @@ ARMCHAIR(yellow)
 /datum/stack_recipe/furniture/tank
 	title = "pressure tank"
 	result_type = /obj/item/pipe/tank
-	req_amount = 30
 	time = 20
 
 /datum/stack_recipe/furniture/computerframe
@@ -188,7 +169,6 @@ ARMCHAIR(yellow)
 /datum/stack_recipe/furniture/ladder
 	title = "ladder"
 	result_type = /obj/structure/ladder
-	req_amount = 5
 	time = 50
 	one_per_turf = TRUE
 	on_floor = FALSE
@@ -196,15 +176,12 @@ ARMCHAIR(yellow)
 /datum/stack_recipe/furniture/girder
 	title = "wall support"
 	result_type = /obj/structure/girder
-	req_amount = 5
 	time = 50
 
 /datum/stack_recipe/furniture/wall_frame
 	title = "low wall frame"
 	result_type = /obj/structure/wall_frame
-	req_amount = 3
 	time = 50
-	req_amount = 5
 
 /datum/stack_recipe/furniture/machine
 	title = "machine frame"
@@ -219,7 +196,6 @@ ARMCHAIR(yellow)
 	time = 25
 
 /datum/stack_recipe/furniture/door_assembly
-	req_amount = 4
 	time = 50
 
 /datum/stack_recipe/furniture/door_assembly/standard
@@ -249,7 +225,6 @@ ARMCHAIR(yellow)
 /datum/stack_recipe/furniture/crate
 	title = "crate"
 	result_type = /obj/structure/closet/crate
-	req_amount = 10
 	time = 50
 
 /datum/stack_recipe/furniture/crate/plastic
@@ -258,25 +233,21 @@ ARMCHAIR(yellow)
 /datum/stack_recipe/furniture/flaps
 	title = "flaps"
 	result_type = /obj/structure/plasticflaps
-	req_amount = 30
 	time = 50
 
 /datum/stack_recipe/furniture/coffin
 	title = "coffin"
 	result_type = /obj/structure/closet/coffin
-	req_amount = 5
 	time = 15
 
 /datum/stack_recipe/furniture/coffin/wooden
 	title = "coffin"
 	result_type = /obj/structure/closet/coffin/wooden
-	req_amount = 5
 	time = 15
 
 /datum/stack_recipe/furniture/bookcase
 	title = "book shelf"
 	result_type = /obj/structure/bookcase
-	req_amount = 5
 	time = 15
 
 /datum/stack_recipe/furniture/planting_bed
@@ -288,7 +259,6 @@ ARMCHAIR(yellow)
 /datum/stack_recipe/furniture/fullwindow
 	title = "full-tile window"
 	result_type = /obj/structure/window
-	req_amount = 4
 	time = 15
 	one_per_turf = 0
 
@@ -306,7 +276,6 @@ ARMCHAIR(yellow)
 /datum/stack_recipe/furniture/borderwindow
 	title = "border window"
 	result_type = /obj/structure/window
-	req_amount = 1
 	time = 5
 	one_per_turf = 0
 
@@ -324,7 +293,6 @@ ARMCHAIR(yellow)
 /datum/stack_recipe/furniture/windoor
 	title = "windoor assembly"
 	result_type = /obj/structure/windoor_assembly
-	req_amount = 1
 	time = 20
 	one_per_turf = 1
 

--- a/code/modules/materials/recipes_items.dm
+++ b/code/modules/materials/recipes_items.dm
@@ -3,32 +3,27 @@
 /datum/stack_recipe/baseball_bat
 	title = "baseball bat"
 	result_type = /obj/item/material/twohanded/baseballbat
-	req_amount = 10
 	time = 20
 	difficulty = 2
 
 /datum/stack_recipe/bell
 	title = "bell"
 	result_type = /obj/item/material/bell
-	req_amount = 5
 	time = 20
 
 /datum/stack_recipe/ashtray
 	title = "ashtray"
 	result_type = /obj/item/material/ashtray
-	req_amount = 2
 	one_per_turf = 1
 
 /datum/stack_recipe/improvised_armour
 	title = "improvised armour"
 	result_type = /obj/item/clothing/suit/armor/crafted
-	req_amount = 20
 	one_per_turf = 1
 
 /datum/stack_recipe/coin
 	title = "coin"
 	result_type = /obj/item/coin
-	req_amount = 2
 	one_per_turf = 1
 
 /datum/stack_recipe/ring
@@ -56,14 +51,12 @@
 /datum/stack_recipe/blade
 	title = "knife"
 	result_type = /obj/item/material/butterflyblade
-	req_amount = 6
 	time = 20
 	difficulty = 1
 
 /datum/stack_recipe/grip
 	title = "knife grip"
 	result_type = /obj/item/material/butterflyhandle
-	req_amount = 4
 	time = 20
 	on_floor = 1
 	difficulty = 1
@@ -76,7 +69,6 @@
 /datum/stack_recipe/cannon
 	title = "cannon frame"
 	result_type = /obj/item/cannonframe
-	req_amount = 10
 	time = 15
 	difficulty = 3
 
@@ -88,7 +80,6 @@
 /datum/stack_recipe/light
 	title = "light fixture frame"
 	result_type = /obj/item/frame/light
-	req_amount = 2
 	difficulty = 2
 
 /datum/stack_recipe/light_small
@@ -99,49 +90,41 @@
 /datum/stack_recipe/light_switch
 	title = "light switch frame"
 	result_type = /obj/item/frame/button/light_switch
-	req_amount = 1
 	difficulty = 2
 
 /datum/stack_recipe/light_switch/windowtint
 	title = "window tint switch frame"
 	result_type = /obj/item/frame/button/light_switch/windowtint
-	req_amount = 1
 	difficulty = 2
 
 /datum/stack_recipe/apc
 	title = "APC frame"
 	result_type = /obj/item/frame/apc
-	req_amount = 2
 	difficulty = 2
 
 /datum/stack_recipe/air_alarm
 	title = "air alarm frame"
 	result_type = /obj/item/frame/air_alarm
-	req_amount = 2
 	difficulty = 2
 
 /datum/stack_recipe/fire_alarm
 	title = "fire alarm frame"
 	result_type = /obj/item/frame/fire_alarm
-	req_amount = 2
 	difficulty = 2
 
 /datum/stack_recipe/computer/telescreen
 	title = "modular telescreen frame"
 	result_type = /obj/item/modular_computer/telescreen
-	req_amount = 10
 	difficulty = 2
 
 /datum/stack_recipe/computer/laptop
 	title = "modular laptop frame"
 	result_type = /obj/item/modular_computer/laptop
-	req_amount = 10
 	difficulty = 2
 
 /datum/stack_recipe/computer/tablet
 	title = "modular tablet frame"
 	result_type = /obj/item/modular_computer/tablet
-	req_amount = 5
 	difficulty = 2
 
 /datum/stack_recipe/hazard_cone
@@ -152,7 +135,6 @@
 /datum/stack_recipe/ivbag
 	title = "IV bag"
 	result_type = /obj/item/chems/ivbag
-	req_amount = 4
 	difficulty = 2
 
 /datum/stack_recipe/cartridge
@@ -170,12 +152,10 @@
 /datum/stack_recipe/cartridge/medium
 	result_type = /obj/item/chems/chem_disp_cartridge/medium
 	modifier = "medium"
-	req_amount = 3
 
 /datum/stack_recipe/cartridge/large
 	result_type = /obj/item/chems/chem_disp_cartridge
 	modifier = "large"
-	req_amount = 5
 
 /datum/stack_recipe/sandals
 	title = "sandals"
@@ -184,13 +164,11 @@
 /datum/stack_recipe/zipgunframe
 	title = "zip gun frame"
 	result_type = /obj/item/zipgunframe
-	req_amount = 5
 	difficulty = 3
 
 /datum/stack_recipe/coilgun
 	title = "coilgun stock"
 	result_type = /obj/item/coilgun_assembly
-	req_amount = 5
 	difficulty = 3
 
 /datum/stack_recipe/stick
@@ -201,14 +179,12 @@
 /datum/stack_recipe/crossbowframe
 	title = "crossbow frame"
 	result_type = /obj/item/crossbowframe
-	req_amount = 5
 	time = 25
 	difficulty = 3
 
 /datum/stack_recipe/beehive_assembly
 	title = "beehive assembly"
 	result_type = /obj/item/beehive_assembly
-	req_amount = 4
 
 /datum/stack_recipe/beehive_frame
 	title = "beehive frame"
@@ -217,7 +193,6 @@
 /datum/stack_recipe/cardborg_suit
 	title = "cardborg suit"
 	result_type = /obj/item/clothing/suit/cardborg
-	req_amount = 3
 	difficulty = 0
 
 /datum/stack_recipe/cardborg_helmet
@@ -233,29 +208,24 @@
 /datum/stack_recipe/clipboard
 	title = "clipboard"
 	result_type = /obj/item/material/clipboard
-	req_amount = 5
 
 /datum/stack_recipe/urn
 	title = "urn"
 	result_type = /obj/item/material/urn
-	req_amount = 5
 
 /datum/stack_recipe/drill_head
 	title = "drill head"
 	result_type = /obj/item/material/drill_head
-	req_amount = 3
 	difficulty = 0
 
 /datum/stack_recipe/cross
 	title = "cross"
 	result_type = /obj/item/material/cross
-	req_amount = 2
 	on_floor = 1
 
 /datum/stack_recipe/wooden_prosthetic
 	title = "left arm"
 	result_type = /obj/item/organ/external/arm/wooden
-	req_amount = 10
 	difficulty = 0
 
 /datum/stack_recipe/wooden_prosthetic/right_arm

--- a/code/modules/materials/recipes_storage.dm
+++ b/code/modules/materials/recipes_storage.dm
@@ -6,7 +6,6 @@
 /datum/stack_recipe/box/large
 	title = "large box"
 	result_type = /obj/item/storage/box/large
-	req_amount = 2
 
 /datum/stack_recipe/box/donut
 	title = "donut box"
@@ -35,7 +34,6 @@
 /datum/stack_recipe/bag
 	title = "bag"
 	result_type = /obj/item/storage/bag/plasticbag
-	req_amount = 3
 	on_floor = 1
 
 /datum/stack_recipe/folder

--- a/code/modules/materials/recipes_structures.dm
+++ b/code/modules/materials/recipes_structures.dm
@@ -2,7 +2,6 @@
 /datum/stack_recipe/butcher_hook
 	title = "meat hook"
 	result_type = /obj/structure/kitchenspike
-	req_amount = 10
 	time = 40
 	one_per_turf = 1
 	difficulty = 1
@@ -10,7 +9,6 @@
 /datum/stack_recipe/ai_core
 	title = "AI core"
 	result_type = /obj/structure/aicore
-	req_amount = 5
 	time = 50
 	one_per_turf = 1
 	difficulty = 2
@@ -18,7 +16,6 @@
 /datum/stack_recipe/railing
 	title = "railing"
 	result_type = /obj/structure/railing
-	req_amount = 5
 	time = 40
 	on_floor = 1
 	difficulty = 2
@@ -26,7 +23,6 @@
 /datum/stack_recipe/noticeboard
 	title = "noticeboard"
 	result_type = /obj/structure/noticeboard
-	req_amount = 10
 	time = 50
 	on_floor = 1
 	difficulty = 2


### PR DESCRIPTION
All the important parts of the original PR got split off into their own PRs so I'm going to use it for this small one. Removes preset amounts from item/structure recipes so they will autogenerate from matter.