### PR TITLE
Fixes infinite recursion in fingerprint addition

### DIFF
--- a/code/modules/detectivework/evidence/_evidence_holder.dm
+++ b/code/modules/detectivework/evidence/_evidence_holder.dm
@@ -27,6 +27,6 @@
 
 /datum/extension/forensic_evidence/proc/add_from_atom(evidence_type, atom/A)
 	var/datum/forensics/temp = new evidence_type
-	temp.add_from_atom(A)
+	temp.add_from_atom(arglist(args.Copy(2)))
 	for(var/item in temp.data)
 		add_data(evidence_type, item)

--- a/code/modules/detectivework/evidence/fingerprints.dm
+++ b/code/modules/detectivework/evidence/fingerprints.dm
@@ -6,8 +6,8 @@
 	. = ..()
 	QDEL_NULL_LIST(data)
 
-/datum/forensics/fingerprints/add_from_atom(mob/M)
-	var/datum/fingerprint/F = new(M)
+/datum/forensics/fingerprints/add_from_atom(mob/M, ignore_gloves)
+	var/datum/fingerprint/F = new(M, ignore_gloves)
 	if(F.completeness > 0)
 		add_data(F)
 
@@ -54,14 +54,14 @@
 
 	//Using prints from severed hand items!
 	var/obj/item/organ/external/E = M.get_active_hand()
-	if(src != E && istype(E) && E.get_fingerprint())
+	if(istype(E) && E.get_fingerprint())
 		full_print = E.get_fingerprint()
 		ignore_gloves = 1
 
 	if(!ignore_gloves)
 		var/obj/item/cover = M.get_covering_equipped_item(M.hand ? HAND_LEFT : HAND_RIGHT)
 		if(cover)
-			cover.add_fingerprint(M)
+			cover.add_fingerprint(M, 1)
 			return
 
 	var/extra_crispy = 0

--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -28,7 +28,7 @@
 		return
 
 	var/datum/extension/forensic_evidence/forensics = get_or_create_extension(src, /datum/extension/forensic_evidence)
-	forensics.add_from_atom(/datum/forensics/fingerprints, M)
+	forensics.add_from_atom(/datum/forensics/fingerprints, M, ignoregloves)
 	forensics.add_from_atom(/datum/forensics/fibers, M)
 
 	add_hiddenprint(M)


### PR DESCRIPTION
It was checking for gloves, and if gloves existed it added print to gloves which was checking for gloves, and if gloves existed it added print to gloves which was checking for gloves, and if gloves existed it added print to gloves which was checking for gloves, and if gloves existed it added print to gloves which was checking for gloves, and if gloves existed it added print to gloves
So whole thing crashed silently, preventing any code after fingerprint adding from running.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->