### PR TITLE
Fixes some fun stuff found with automated properties

### DIFF
--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -89,8 +89,8 @@
 	var/applies_material_colour = FALSE        // Whether or not the material recolours this icon.
 	var/applies_material_name = FALSE          // If true, item becomes 'material item' ie. 'steel hatchet'.
 	var/max_force = 40	                       // any damage above this is added to armor penetration value
-	var/material_force_multiplier = 0.5	       // Multiplier to material's generic damage value for this specific type of weapon
-	var/thrown_material_force_multiplier = 0.5 // As above, but for throwing the weapon.
+	var/material_force_multiplier = 0.1	       // Multiplier to material's generic damage value for this specific type of weapon
+	var/thrown_material_force_multiplier = 0.1 // As above, but for throwing the weapon.
 	var/unbreakable = FALSE                    // Whether or not this weapon degrades.
 	var/anomaly_shielding					   // 0..1 value of how well it shields against xenoarch anomalies
 

--- a/code/modules/economy/worth_items.dm
+++ b/code/modules/economy/worth_items.dm
@@ -12,7 +12,7 @@
 	. = initial_value
 
 	if(force)
-		var/weapon_value = ((get_max_weapon_value() * 25) * max(1, max(sharp, edge)))
+		var/weapon_value = ((get_max_weapon_value() * 25) * (1 + max(sharp, edge)))
 		if(attack_cooldown <= FAST_WEAPON_COOLDOWN)
 			weapon_value *= 0.5
 		else if(attack_cooldown >= SLOW_WEAPON_COOLDOWN)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -166,7 +166,7 @@
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = @"[5,10,15,25,30,60,120]"
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	material_force_multiplier = 2.5
+	material_force_multiplier = 0.5
 
 /obj/item/chems/glass/beaker/bowl
 	name = "mixing bowl"


### PR DESCRIPTION
Large beakers are no longer the ultimate killer weapons, material force multiplier lowered to twice the usual beaker's
Some odd math fixed in item cost gen, sharpness/edge now actualy doubles force value.
Items force nerfed in general, base force multiplier was 0.5 which is what weapons like /claymores/ used. Made it 0.1

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->