### PR TITLE
Fire Equipment tweaks & fixes

### DIFF
--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -222,7 +222,7 @@
 	name = "Gear - Firefighting equipment"
 	contains = list(/obj/item/clothing/suit/fire/firefighter,
 			/obj/item/clothing/mask/gas,
-			/obj/item/tank/oxygen/red,
+			/obj/item/tank/emergency/oxygen/double/red,
 			/obj/item/extinguisher,
 			/obj/item/clothing/head/hardhat/red)
 	cost = 20

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -906,7 +906,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 /obj/item/proc/has_embedded()
 	return
 
-/obj/item/proc/get_pressure_weakness(pressure)
+/obj/item/proc/get_pressure_weakness(pressure,zone)
 	. = 1
 	if(pressure > ONE_ATMOSPHERE)
 		if(max_pressure_protection != null)

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -247,7 +247,7 @@
 		/obj/item/extinguisher,
 		/obj/item/clothing/gloves/fire,
 		/obj/item/clothing/accessory/fire_overpants,
-		/obj/item/tank/oxygen/red,
+		/obj/item/tank/emergency/oxygen/double/red,
 		/obj/item/clothing/head/hardhat/firefighter,
 		/obj/item/extinguisher
 	)

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -23,11 +23,6 @@
 	desc = "A tank of oxygen. This one is yellow."
 	icon_state = "oxygen_f"
 
-/obj/item/tank/oxygen/red
-	name = "self contained breathing apparatus"
-	desc = "A self contained breathing apparatus, well known as SCBA. Generally filled with oxygen."
-	icon_state = "oxygen_fr"
-
 /*
  * Anesthetic
  */
@@ -108,6 +103,12 @@
 	gauge_icon = "indicator_emergency_double"
 	volume = 90
 	w_class = ITEM_SIZE_NORMAL
+
+/obj/item/tank/emergency/oxygen/double/red	//firefighting tank, fits on belt, back or suitslot
+	name = "self contained breathing apparatus"
+	desc = "A self contained breathing apparatus, well known as SCBA. Generally filled with oxygen."
+	icon_state = "oxygen_fr"
+	slot_flags = SLOT_BELT | SLOT_BACK
 
 /obj/item/tank/emergency/nitrogen
 	name = "emergency nitrogen tank"

--- a/code/game/objects/items/weapons/tools/crowbar.dm
+++ b/code/game/objects/items/weapons/tools/crowbar.dm
@@ -53,12 +53,29 @@
 	icon = 'icons/obj/items/tool/forcing_tool.dmi'
 	icon_state = "emergency_forcing_tool"
 	item_state = "emergency_forcing_tool"
-	force = 10
+	force = 12
 	throwforce = 6
 	throw_range = 5
-	w_class = ITEM_SIZE_SMALL
+	sharp = 1
+	edge = 1
+	w_class = ITEM_SIZE_NORMAL
 	material = MAT_STEEL
 	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked", "attacked", "slashed", "torn", "ripped", "cut")
+
+/obj/item/crowbar/emergency_forcing_tool/resolve_attackby(atom/A)//extra dmg against glass, it's an emergency forcing tool, it's gotta be good at something
+	if(istype(A, /obj/structure/window))
+		force = initial(force) * 2
+	else
+		force = initial(force)
+	. = ..()
+
+/obj/item/crowbar/emergency_forcing_tool/iscrowbar()//go ham
+	if(ismob(loc))
+		var/mob/M = loc
+		if(M.a_intent && M.a_intent == I_HURT)
+			return FALSE
+
+	return TRUE
 
 /obj/item/crowbar/prybar/cheap
 	name = "discount pry bar"

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -514,7 +514,7 @@
 /obj/random/tank/spawn_choices()
 	return list(/obj/item/tank/oxygen = 5,
 				/obj/item/tank/oxygen/yellow = 4,
-				/obj/item/tank/oxygen/red = 4,
+				/obj/item/tank/emergency/oxygen/double/red = 4,
 				/obj/item/tank/air = 3,
 				/obj/item/tank/emergency/oxygen = 4,
 				/obj/item/tank/emergency/oxygen/engi = 3,

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -55,7 +55,7 @@
 		/obj/item/clothing/suit/fire/firefighter,
 		/obj/item/clothing/mask/gas,
 		/obj/item/flashlight,
-		/obj/item/tank/oxygen/red,
+		/obj/item/tank/emergency/oxygen/double/red,
 		/obj/item/extinguisher,
 		/obj/item/clothing/head/hardhat/firefighter/Chief)
 

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -179,3 +179,8 @@
 		for(var/key in damages)
 			to_chat(user, "<li><b>[capitalize(damages[key])]</b> damage to the <b>[key]</b> armor.")
 		return TOPIC_HANDLED
+
+/obj/item/clothing/get_pressure_weakness(pressure,zone)
+	. = ..()
+	for(var/obj/item/clothing/accessory/A in accessories)
+		. = min(., A.get_pressure_weakness(pressure,zone))

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -18,20 +18,24 @@
 		slot_r_hand_str = "fire_suit",
 	)
 	w_class = ITEM_SIZE_LARGE//large item
+	flags_inv = HIDETAIL
+
+	body_parts_covered = UPPER_TORSO | LOWER_TORSO| ARMS
+	armor = list(laser = ARMOR_LASER_MINOR, energy = ARMOR_ENERGY_MINOR, bomb = ARMOR_BOMB_MINOR)
+	allowed = list(/obj/item/flashlight,/obj/item/tank/emergency,/obj/item/extinguisher,/obj/item/crowbar/emergency_forcing_tool,/obj/item/clothing/head/hardhat)
+	
 	gas_transfer_coefficient = 0.90
 	permeability_coefficient = 0.50
-	armor = list(melee = 0, bullet = 0, laser = 10, energy = 10, bomb = 15, bio = 0, rad = 0)
-	body_parts_covered = UPPER_TORSO | ARMS
-	allowed = list(/obj/item/flashlight,/obj/item/tank/emergency,/obj/item/extinguisher,/obj/item/crowbar/emergency_forcing_tool)
-	flags_inv = HIDETAIL
-	max_pressure_protection = FIRESUIT_MAX_PRESSURE
+
 	heat_protection = UPPER_TORSO | LOWER_TORSO | ARMS
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	cold_protection = UPPER_TORSO | LOWER_TORSO | ARMS
+
+	max_pressure_protection = FIRESUIT_MAX_PRESSURE
+	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/suit/fire/Initialize()
 	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 0.4
+	slowdown_per_slot[slot_wear_suit] = 0.5
 
 /obj/item/clothing/suit/fire/firefighter
 	icon_state = "firesuit"
@@ -39,21 +43,6 @@
 		slot_l_hand_str = "firefighter",
 		slot_r_hand_str = "firefighter",
 	)
-
-
-/obj/item/clothing/suit/fire/heavy
-	name = "firesuit"
-	desc = "A suit that protects against extreme fire and heat."
-	//icon_state = "thermal"
-	item_state_slots = list(
-		slot_l_hand_str = "ro_suit",
-		slot_r_hand_str = "ro_suit",
-	)
-	w_class = ITEM_SIZE_HUGE//bulky item
-
-/obj/item/clothing/suit/fire/heavy/Initialize()
-	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 0.6
 
 /*
  * Bomb protection

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -97,6 +97,11 @@
 		return	//we aren't an object on the ground so don't call parent
 	..()
 
+/obj/item/clothing/accessory/get_pressure_weakness(pressure,zone)
+	if(body_parts_covered & zone)
+		return ..()
+	return 1
+
 //Necklaces
 /obj/item/clothing/accessory/necklace
 	name = "necklace"

--- a/code/modules/clothing/under/accessories/clothing.dm
+++ b/code/modules/clothing/under/accessories/clothing.dm
@@ -277,16 +277,16 @@
 	icon_state = "fire_overpants"
 	gas_transfer_coefficient = 0.90
 	permeability_coefficient = 0.50
-	body_parts_covered = LEG_LEFT | LEG_RIGHT | LOWER_TORSO
-	cold_protection = LOWER_TORSO | LEG_LEFT | LEG_RIGHT
-	heat_protection = LOWER_TORSO | LEG_LEFT | LEG_RIGHT
+
+	armor = list(laser = ARMOR_LASER_MINOR, energy = ARMOR_ENERGY_MINOR, bomb = ARMOR_BOMB_MINOR)
+	body_parts_covered = LOWER_TORSO | LEGS
+	slowdown = 0.5
+
+	heat_protection = LOWER_TORSO | LEGS
+	cold_protection = LOWER_TORSO | LEGS
+
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	max_pressure_protection = FIRESUIT_MAX_PRESSURE
-	armor = list(melee = 0, bullet = 0, laser = 10, energy = 10, bomb = 10, bio = 0, rad = 0)
-
-/obj/item/clothing/accessory/fire_overpants/Initialize()
-	. = ..()
-	slowdown_per_slot[slot_wear_suit] = 0.2
 
 /obj/item/clothing/accessory/space_adapted/venter
 	name = "venter assembly"

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -147,7 +147,7 @@
 		var/list/covers = get_covering_equipped_items(zone)
 		var/zone_exposure = 1
 		for(var/obj/item/clothing/C in covers)
-			zone_exposure = min(zone_exposure, C.get_pressure_weakness(pressure))
+			zone_exposure = min(zone_exposure, C.get_pressure_weakness(pressure,zone))
 		if(zone_exposure >= 1)
 			return 1
 		pressure_adjustment_coefficient = max(pressure_adjustment_coefficient, zone_exposure)

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -284,7 +284,7 @@
 /obj/item/stock_parts/circuitboard/unary_atmos/cooler,
 /obj/item/stock_parts/circuitboard/unary_atmos/heater,
 /obj/item/stock_parts/circuitboard/oxyregenerator,
-/obj/item/tank/oxygen/red,
+/obj/item/tank/emergency/oxygen/double/red,
 /obj/structure/cable,
 /obj/item/stack/material/uranium/ten,
 /obj/item/stack/material/uranium/ten,


### PR DESCRIPTION
Small QOL tweaks and fixes to firefighting equipment

Made atmospheric pressure account for clothing accessory; fire overpants works again
Firefighting tank is now a double extended oxygen tank, to fit on the firesuit's equipment slot,
Firesuit can now carry it's helmet on the equipment slot
Made the emergency forcing tool deal extra dmg against glass
Re balance slowdown and item sizes and dmg of firefighting equipment

Fixed up the pressure code thanks to @CrimsonShrike