### PR TITLE
Silicon NTOS

### DIFF
--- a/code/_onclick/hud/ai.dm
+++ b/code/_onclick/hud/ai.dm
@@ -57,9 +57,9 @@
 			ui_ai_crew_manifest,
 			"Show Crew Manifest",
 			"manifest",
-			/mob/living/silicon/proc/open_subsystem,
+			/mob/living/silicon/ai/proc/run_program,
 			null,
-			list(/datum/computer_file/program/crew_manifest)
+			list("crewmanifest")
 			)
 
 	adding += new /obj/screen/ai_button(null,
@@ -122,7 +122,9 @@
 			ui_ai_crew_mon,
 			"Crew Monitor",
 			"crew_monitor",
-			/mob/living/silicon/ai/proc/show_crew_monitor
+			/mob/living/silicon/ai/proc/run_program,
+			null,
+			list("sensormonitor")
 			)
 
 	adding += new /obj/screen/ai_button(null,
@@ -162,10 +164,9 @@
 
 	adding += new /obj/screen/ai_button(null,
 			ui_ai_crew_rec,
-			"Crew Records",
+			"Inbuilt Computer",
 			"ai_crew_rec",
-			/mob/living/silicon/ai/proc/show_crew_records
+			/mob/living/silicon/ai/proc/access_computer
 			)
-
 	A.client.screen = list()
 	A.client.screen.Add(adding)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -28,10 +28,11 @@ var/list/ai_verbs_default = list(
 	/mob/living/silicon/ai/proc/ai_take_image,
 	/mob/living/silicon/ai/proc/change_floor,
 	/mob/living/silicon/ai/proc/show_crew_monitor,
-	/mob/living/silicon/ai/proc/show_crew_records,
+	/mob/living/silicon/ai/proc/access_computer,
 	/mob/living/silicon/ai/proc/ai_power_override,
 	/mob/living/silicon/ai/proc/ai_shutdown,
-	/mob/living/silicon/ai/proc/ai_reset_radio_keys
+	/mob/living/silicon/ai/proc/ai_reset_radio_keys,
+	/mob/living/silicon/ai/proc/run_program
 )
 
 //Not sure why this is necessary...
@@ -204,6 +205,7 @@ var/list/ai_verbs_default = list(
 	job = "AI"
 	setup_icon()
 	eyeobj.possess(src)
+	CreateModularRecord(src, /datum/computer_file/report/crew_record/synth)
 
 /mob/living/silicon/ai/Destroy()
 	for(var/robot in connected_robots)
@@ -617,6 +619,21 @@ var/list/ai_verbs_default = list(
 			user.visible_message("<span class='notice'>\The [user] finishes fastening down \the [src]!</span>")
 			anchored = 1
 			return
+	else if(isCrowbar(W) && user.a_intent != I_HURT)
+		if(!length(stock_parts))
+			to_chat(user, SPAN_WARNING("No parts left to remove"))
+			return
+		var/obj/item/stock_parts/remove = input(user, "Which component do you want to pry out?", "Remove Component") as null|anything in stock_parts
+		if(!remove || !(remove in stock_parts))
+			return
+		stock_parts -= remove
+		to_chat(user, SPAN_NOTICE("You remove \the [remove]."))
+		remove.forceMove(loc)
+	else if(istype(W, /obj/item/stock_parts) && user.unEquip(W))
+		W.forceMove(src)
+		stock_parts += W
+		to_chat(usr, "<span class='notice'>You install the [W.name].</span>")
+		return
 	else
 		return ..()
 
@@ -746,10 +763,31 @@ var/list/ai_verbs_default = list(
 	set category = "Silicon Commands"
 	set name = "Show Crew Lifesigns Monitor"
 
-	open_subsystem(/datum/nano_module/crew_monitor)
+	run_program("sensormonitor")
 
-/mob/living/silicon/ai/proc/show_crew_records()
+/mob/living/silicon/ai/proc/access_computer()
 	set category = "Silicon Commands"
-	set name = "Show Crew Records"
+	set name = "Boot NTOS Device"
 
-	open_subsystem(/datum/nano_module/records)
+	if(incapacitated())
+		to_chat(src, SPAN_WARNING("You are in no state to do that right now."))
+		return
+
+	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
+	if(!istype(os))
+		to_chat(src, SPAN_WARNING("You seem to be lacking an NTOS capable device!"))
+		return
+	
+	if(!os.on)
+		os.system_boot()
+	os.ui_interact(src)
+
+/mob/living/silicon/ai/proc/run_program(var/filename)
+	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
+	if(!istype(os))
+		to_chat(src, SPAN_WARNING("You seem to be lacking an NTOS capable device!"))
+		return
+	if(!os.on)
+		os.system_boot()
+	if(os.run_program(filename))
+		os.ui_interact(src)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -61,6 +61,7 @@ var/list/mob_hat_cache = list()
 	var/hat_y_offset = -13
 
 	holder_type = /obj/item/holder/drone
+	starting_stock_parts = list()
 
 /mob/living/silicon/robot/drone/Initialize()
 	. = ..()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -34,6 +34,13 @@
 
 	var/list/access_rights
 	var/obj/item/card/id/idcard = /obj/item/card/id/synthetic
+	// Various machinery stock parts used by stuff like NTOS (should be merged with above at some point)
+	var/list/stock_parts = list()
+	var/list/starting_stock_parts = list(
+		/obj/item/stock_parts/computer/processor_unit,
+		/obj/item/stock_parts/computer/hard_drive/silicon,
+		/obj/item/stock_parts/computer/network_card
+	)
 
 	#define SEC_HUD 1 //Security HUD mode
 	#define MED_HUD 2 //Medical HUD mode
@@ -46,6 +53,9 @@
 		silicon_radio = new silicon_radio(src)
 	if(silicon_camera)
 		silicon_camera = new silicon_camera(src)
+	for(var/T in starting_stock_parts)
+		stock_parts += new T(src)
+	set_extension(src, /datum/extension/interactive/ntos/silicon)
 
 	add_language(/decl/language/human/common)
 	default_language = /decl/language/human/common

--- a/code/modules/mob/living/silicon/subsystems.dm
+++ b/code/modules/mob/living/silicon/subsystems.dm
@@ -2,9 +2,7 @@
 	var/list/silicon_subsystems_by_name = list()
 	var/list/silicon_subsystems = list(
 		/datum/nano_module/alarm_monitor/all,
-		/datum/nano_module/law_manager,
-		/datum/nano_module/email_client,
-		/datum/nano_module/crew_manifest
+		/datum/nano_module/law_manager
 	)
 
 /mob/living/silicon/ai/Initialize()
@@ -17,8 +15,7 @@
 
 /mob/living/silicon/robot/syndicate
 	silicon_subsystems = list(
-		/datum/nano_module/law_manager,
-		/datum/nano_module/email_client
+		/datum/nano_module/law_manager
 	)
 
 /mob/living/silicon/Destroy()

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -94,7 +94,7 @@
 			for(var/obj/effect/landmark/start/sloc in landmarks_list)
 				if (sloc.name == "AI")
 					loc_landmark = sloc
-		O.forceMove(loc_landmark.loc)
+		O.forceMove(loc_landmark ? loc_landmark.loc : get_turf(src))
 		O.on_mob_init()
 
 	O.add_ai_verbs()

--- a/code/modules/modular_computers/NTNet/NTNet.dm
+++ b/code/modules/modular_computers/NTNet/NTNet.dm
@@ -233,7 +233,7 @@ var/global/datum/ntnet/ntnet_global = new()
 		user.StoreMemory("Your email account address has been changed to [new_login].", /decl/memory_options/system)
 	if(issilicon(user))
 		var/mob/living/silicon/S = user
-		var/datum/nano_module/email_client/my_client = S.get_subsystem_from_path(/datum/nano_module/email_client)
+		var/datum/nano_module/program/email_client/my_client = S.get_subsystem_from_path(/datum/nano_module/program/email_client)
 		if(my_client)
 			my_client.stored_login = new_login
 
@@ -258,7 +258,7 @@ var/global/datum/ntnet/ntnet_global = new()
 			user.StoreMemory("Your email account address is [EA.login] and the password is [EA.password].", /decl/memory_options/system)
 		if(issilicon(user))
 			var/mob/living/silicon/S = user
-			var/datum/nano_module/email_client/my_client = S.get_subsystem_from_path(/datum/nano_module/email_client)
+			var/datum/nano_module/program/email_client/my_client = S.get_subsystem_from_path(/datum/nano_module/program/email_client)
 			if(my_client)
 				my_client.stored_login = EA.login
 				my_client.stored_password = EA.password

--- a/code/modules/modular_computers/NTNet/emails/email_account.dm
+++ b/code/modules/modular_computers/NTNet/emails/email_account.dm
@@ -70,7 +70,7 @@
 		spam.Add(received_message)
 	else
 		inbox.Add(received_message)
-		for(var/datum/nano_module/email_client/ec in connected_clients)
+		for(var/datum/nano_module/program/email_client/ec in connected_clients)
 			ec.mail_received(received_message)
 
 	return 1

--- a/code/modules/modular_computers/file_system/manifest.dm
+++ b/code/modules/modular_computers/file_system/manifest.dm
@@ -7,27 +7,10 @@
 		dept_data += list(list("names" = list(), "header" = dept.title, "ref" = dept.reference))
 	
 	
-	/*var/list/dept_data = list(
-		list("names" = list(), "header" = "Heads of Staff", "flag" = COM),
-		list("names" = list(), "header" = "Command Support", "flag" = SPT),
-		list("names" = list(), "header" = "Research", "flag" = SCI),
-		list("names" = list(), "header" = "Security", "flag" = SEC),
-		list("names" = list(), "header" = "Medical", "flag" = MED),
-		list("names" = list(), "header" = "Engineering", "flag" = ENG),
-		list("names" = list(), "header" = "Supply", "flag" = SUP),
-		list("names" = list(), "header" = "Exploration", "flag" = EXP),
-		list("names" = list(), "header" = "Service", "flag" = SRV),
-		list("names" = list(), "header" = "Civilian", "flag" = CIV),
-		list("names" = list(), "header" = "Miscellaneous", "flag" = MSC),
-		list("names" = list(), "header" = "Silicon")
-	)*/
 	var/list/misc //Special departments for easier access
-	var/list/bot
 	for(var/list/department in dept_data)
 		if(department["ref"] == "misc")
 			misc = department["names"]
-		if(isnull(department["ref"]))
-			bot = department["names"]
 
 	var/list/isactive = new()
 	var/list/mil_ranks = list() // HTML to prepend to name
@@ -77,17 +60,6 @@
 					found_place = 1
 		if(!found_place)
 			misc[name] = rank
-
-	// Synthetics don't have actual records, so we will pull them from here.
-	for(var/mob/living/silicon/ai/ai in SSmobs.mob_list)
-		bot[ai.name] = "Artificial Intelligence"
-
-	for(var/mob/living/silicon/robot/robot in SSmobs.mob_list)
-		// No combat/syndicate cyborgs, no drones.
-		if(robot.module && robot.module.hide_on_manifest)
-			continue
-
-		bot[robot.name] = "[robot.modtype] [robot.braintype]"
 
 	for(var/list/department in dept_data)
 		var/list/names = department["names"]

--- a/code/modules/modular_computers/file_system/programs/generic/crew_manifest.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/crew_manifest.dm
@@ -7,14 +7,14 @@
 	size = 4
 	requires_ntnet = 1
 	available_on_ntnet = 1
-	nanomodule_path = /datum/nano_module/crew_manifest
+	nanomodule_path = /datum/nano_module/program/crew_manifest
 	usage_flags = PROGRAM_ALL
 	category = PROG_OFFICE
 
-/datum/nano_module/crew_manifest
+/datum/nano_module/program/crew_manifest
 	name = "Crew Manifest"
 
-/datum/nano_module/crew_manifest/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, state = GLOB.default_state)
+/datum/nano_module/program/crew_manifest/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, state = GLOB.default_state)
 	var/list/data = host.initial_data()
 
 	data["crew_manifest"] = html_crew_manifest(TRUE)

--- a/code/modules/modular_computers/file_system/programs/generic/email_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/email_client.dm
@@ -13,12 +13,12 @@
 	usage_flags = PROGRAM_ALL
 	category = PROG_OFFICE
 
-	nanomodule_path = /datum/nano_module/email_client
+	nanomodule_path = /datum/nano_module/program/email_client
 
 // Persistency. Unless you log out, or unless your password changes, this will pre-fill the login data when restarting the program
 /datum/computer_file/program/email_client/on_shutdown()
 	if(NM)
-		var/datum/nano_module/email_client/NME = NM
+		var/datum/nano_module/program/email_client/NME = NM
 		if(NME.current_account)
 			stored_login = NME.stored_login
 			stored_password = NME.stored_password
@@ -32,7 +32,7 @@
 	. = ..()
 
 	if(NM)
-		var/datum/nano_module/email_client/NME = NM
+		var/datum/nano_module/program/email_client/NME = NM
 		NME.stored_login = stored_login
 		NME.stored_password = stored_password
 		NME.log_in()
@@ -44,7 +44,7 @@
 
 /datum/computer_file/program/email_client/process_tick()
 	..()
-	var/datum/nano_module/email_client/NME = NM
+	var/datum/nano_module/program/email_client/NME = NM
 	if(!istype(NME))
 		return
 	NME.relayed_process(ntnet_speed)
@@ -57,7 +57,7 @@
 	else
 		ui_header = "ntnrc_idle.gif"
 
-/datum/nano_module/email_client/
+/datum/nano_module/program/email_client/
 	name = "Email Client"
 	var/stored_login = ""
 	var/stored_password = ""
@@ -81,15 +81,10 @@
 	var/datum/computer_file/data/email_account/current_account = null
 	var/datum/computer_file/data/email_message/current_message = null
 
-/datum/nano_module/email_client/proc/get_functional_drive()
-	var/datum/extension/interactive/ntos/os = get_extension(nano_host(), /datum/extension/interactive/ntos)
-	var/obj/item/stock_parts/computer/hard_drive/drive = os && os.get_component(/obj/item/stock_parts/computer/hard_drive)
-	if(!drive || !drive.check_functionality())
-		error = "Error uploading file. Are you using a functional and NTOSv2-compliant device?"
-		return
-	return drive
+/datum/nano_module/program/email_client/proc/get_functional_drive()
+	return program.computer.get_component(/obj/item/stock_parts/computer/hard_drive)
 
-/datum/nano_module/email_client/proc/mail_received(var/datum/computer_file/data/email_message/received_message)
+/datum/nano_module/program/email_client/proc/mail_received(var/datum/computer_file/data/email_message/received_message)
 	var/mob/living/L = get_holder_of_type(host, /mob/living)
 	if(L)
 		var/list/msg = list()
@@ -102,11 +97,11 @@
 		msg += "*--*"
 		to_chat(L, jointext(msg, null))
 
-/datum/nano_module/email_client/Destroy()
+/datum/nano_module/program/email_client/Destroy()
 	log_out()
 	. = ..()
 
-/datum/nano_module/email_client/proc/log_in()
+/datum/nano_module/program/email_client/proc/log_in()
 	var/list/id_login
 	var/atom/movable/A = nano_host()
 	var/obj/item/card/id/id = A.GetIdCard()
@@ -151,7 +146,7 @@
 
 // Returns 0 if no new messages were received, 1 if there is an unread message but notification has already been sent.
 // and 2 if there is a new message that appeared in this tick (and therefore notification should be sent by the program).
-/datum/nano_module/email_client/proc/check_for_new_messages(var/messages_read = FALSE)
+/datum/nano_module/program/email_client/proc/check_for_new_messages(var/messages_read = FALSE)
 	if(!current_account)
 		return 0
 
@@ -169,7 +164,7 @@
 		read_message_count = allmails.len
 
 
-/datum/nano_module/email_client/proc/log_out()
+/datum/nano_module/program/email_client/proc/log_out()
 	if(current_account)
 		current_account.connected_clients -= src
 	current_account = null
@@ -178,7 +173,7 @@
 	last_message_count = 0
 	read_message_count = 0
 
-/datum/nano_module/email_client/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = GLOB.default_state)
+/datum/nano_module/program/email_client/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = GLOB.default_state)
 	var/list/data = host.initial_data()
 
 	// Password has been changed by other client connected to this email account
@@ -275,7 +270,7 @@
 		ui.set_initial_data(data)
 		ui.open()
 
-/datum/nano_module/email_client/proc/find_message_by_fuid(var/fuid)
+/datum/nano_module/program/email_client/proc/find_message_by_fuid(var/fuid)
 	if(!istype(current_account))
 		return
 
@@ -287,7 +282,7 @@
 		if(message.uid == fuid)
 			return message
 
-/datum/nano_module/email_client/proc/clear_message()
+/datum/nano_module/program/email_client/proc/clear_message()
 	new_message = FALSE
 	msg_title = ""
 	msg_body = ""
@@ -295,7 +290,7 @@
 	msg_attachment = null
 	current_message = null
 
-/datum/nano_module/email_client/proc/relayed_process(var/netspeed)
+/datum/nano_module/program/email_client/proc/relayed_process(var/netspeed)
 	download_speed = netspeed
 	if(!downloading)
 		return
@@ -316,7 +311,7 @@
 	return 1
 
 
-/datum/nano_module/email_client/Topic(href, href_list)
+/datum/nano_module/program/email_client/Topic(href, href_list)
 	if(..())
 		return 1
 	var/mob/living/user = usr

--- a/code/modules/modular_computers/file_system/programs/generic/records.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/records.dm
@@ -7,16 +7,19 @@
 	size = 14
 	requires_ntnet = 1
 	available_on_ntnet = 1
-	nanomodule_path = /datum/nano_module/records
+	nanomodule_path = /datum/nano_module/program/records
 	usage_flags = PROGRAM_ALL
 	category = PROG_OFFICE
 
-/datum/nano_module/records
+/datum/nano_module/program/records
 	name = "Crew Records"
 	var/datum/computer_file/report/crew_record/active_record
 	var/message = null
 
-/datum/nano_module/records/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, state = GLOB.default_state)
+/datum/nano_module/program/records/proc/get_records()
+	return GLOB.all_crew_records
+
+/datum/nano_module/program/records/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, state = GLOB.default_state)
 	var/list/data = host.initial_data()
 	var/list/user_access = get_record_access(user)
 
@@ -29,7 +32,8 @@
 	else
 		var/list/all_records = list()
 
-		for(var/datum/computer_file/report/crew_record/R in GLOB.all_crew_records)
+		data["show_milrank"] = (GLOB.using_map.flags & MAP_HAS_BRANCH)
+		for(var/datum/computer_file/report/crew_record/R in get_records())
 			all_records.Add(list(list(
 				"name" = R.get_name(),
 				"rank" = R.get_job(),
@@ -49,7 +53,7 @@
 		ui.open()
 
 
-/datum/nano_module/records/proc/get_record_access(var/mob/user)
+/datum/nano_module/program/records/proc/get_record_access(var/mob/user)
 	var/list/user_access = using_access || user.GetAccess()
 
 	var/obj/PC = nano_host()
@@ -60,7 +64,7 @@
 
 	return user_access
 
-/datum/nano_module/records/proc/edit_field(var/mob/user, var/field_ID)
+/datum/nano_module/program/records/proc/edit_field(var/mob/user, var/field_ID)
 	var/datum/computer_file/report/crew_record/R = active_record
 	if(!R)
 		return
@@ -72,7 +76,7 @@
 		return
 	F.ask_value(user)
 
-/datum/nano_module/records/Topic(href, href_list)
+/datum/nano_module/program/records/Topic(href, href_list)
 	if(..())
 		return 1
 	if(href_list["clear_active"])
@@ -83,7 +87,7 @@
 		return 1
 	if(href_list["set_active"])
 		var/ID = text2num(href_list["set_active"])
-		for(var/datum/computer_file/report/crew_record/R in GLOB.all_crew_records)
+		for(var/datum/computer_file/report/crew_record/R in get_records())
 			if(R.uid == ID)
 				active_record = R
 				break
@@ -105,7 +109,7 @@
 		var/search = sanitize(input("Enter the value for search for.") as null|text)
 		if(!search)
 			return
-		for(var/datum/computer_file/report/crew_record/R in GLOB.all_crew_records)
+		for(var/datum/computer_file/report/crew_record/R in get_records())
 			var/datum/report_field/field = R.field_from_name(field_name)
 			if(findtext(lowertext(field.get_value()), lowertext(search)))
 				active_record = R
@@ -130,7 +134,7 @@
 		edit_field(usr, text2num(href_list["edit_field"]))
 		return 1
 
-/datum/nano_module/records/proc/get_photo(var/mob/user)
+/datum/nano_module/program/records/proc/get_photo(var/mob/user)
 	if(istype(user.get_active_hand(), /obj/item/photo))
 		var/obj/item/photo/photo = user.get_active_hand()
 		return photo.img

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -16,6 +16,7 @@ GLOBAL_VAR_INIT(arrest_security_status, "Arrest")
 
 /datum/computer_file/report/crew_record/New()
 	..()
+	filename = "record[random_id(type, 100,999)]"
 	load_from_mob(null)
 
 /datum/computer_file/report/crew_record/Destroy()
@@ -119,10 +120,39 @@ GLOBAL_VAR_INIT(arrest_security_status, "Arrest")
 	// Antag record
 	set_antagRecord(H && H.exploit_record && !jobban_isbanned(H, "Records") ? html_decode(H.exploit_record) : "")
 
+// Cut down version for silicons
+/datum/computer_file/report/crew_record/synth/load_from_mob(var/mob/living/silicon/S)
+	if(istype(S))
+		photo_front = getFlatIcon(S, SOUTH, always_use_defdir = 1)
+		photo_side = getFlatIcon(S, WEST, always_use_defdir = 1)
+
+	// Generic record
+	set_name(S ? S.real_name : "Unset")
+	set_formal_name(S ? S.real_name : "Unset")
+	set_sex("Unset")
+	set_status(GLOB.default_physical_status)
+	var/silicon_type = "Synthetic Lifeform"
+	var/robojob = GetAssignment(S)
+	if(istype(S, /mob/living/silicon/robot))
+		var/mob/living/silicon/robot/R = S
+		silicon_type = R.braintype
+		if(R.module)
+			robojob = "[R.module.display_name] [silicon_type]"
+	if(istype(S, /mob/living/silicon/ai))
+		silicon_type = "AI"
+		robojob = "Artificial Intelligence"
+	set_job(S ? robojob : "Unset")
+	set_species(silicon_type)
+
+	set_implants("Robotic body")
+
+	// Security record
+	set_criminalStatus(GLOB.default_security_status)
+
 // Global methods
 // Used by character creation to create a record for new arrivals.
-/proc/CreateModularRecord(var/mob/living/carbon/human/H)
-	var/datum/computer_file/report/crew_record/CR = new/datum/computer_file/report/crew_record()
+/proc/CreateModularRecord(var/mob/living/H, record_type = /datum/computer_file/report/crew_record)
+	var/datum/computer_file/report/crew_record/CR = new record_type()
 	GLOB.all_crew_records.Add(CR)
 	CR.load_from_mob(H)
 	return CR

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -176,3 +176,11 @@
 /obj/item/stock_parts/computer/hard_drive/Initialize()
 	. = ..()
 	install_default_programs()
+
+// Preset for borgs and AIs
+/obj/item/stock_parts/computer/hard_drive/silicon/install_default_programs()
+	..()
+	store_file(new/datum/computer_file/program/records())
+	store_file(new/datum/computer_file/program/crew_manifest())
+	store_file(new/datum/computer_file/program/email_client())
+	store_file(new/datum/computer_file/program/suit_sensors())

--- a/code/modules/modular_computers/ntos/subtypes/silicon.dm
+++ b/code/modules/modular_computers/ntos/subtypes/silicon.dm
@@ -1,0 +1,41 @@
+/datum/extension/interactive/ntos/silicon
+	expected_type = /mob/living/silicon
+
+/datum/extension/interactive/ntos/silicon/update_host_icon()
+	return
+
+/datum/extension/interactive/ntos/silicon/get_hardware_flag()
+	return PROGRAM_CONSOLE
+
+/datum/extension/interactive/ntos/silicon/get_component(var/part_type)
+	var/mob/living/silicon/M = holder
+	return locate(part_type) in M.stock_parts
+
+/datum/extension/interactive/ntos/silicon/get_all_components()
+	var/mob/living/silicon/M = holder
+	return M.stock_parts.Copy()
+
+/datum/extension/interactive/ntos/silicon/emagged()
+	var/mob/living/silicon/robot/R = holder
+	if(istype(R))
+		return R.emagged
+	return FALSE
+
+/datum/extension/interactive/ntos/silicon/host_status()
+	var/mob/living/silicon/M = holder
+	return !M.stat
+
+// Hack to make status bar work
+
+/mob/living/silicon/initial_data()
+	. = ..()
+	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
+	if(os)
+		. += os.get_header_data()
+
+/mob/living/silicon/check_eye()
+	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
+	if(os)
+		return os.check_eye()
+	else 
+		return ..()

--- a/nano/templates/crew_records.tmpl
+++ b/nano/templates/crew_records.tmpl
@@ -50,11 +50,16 @@
 <br><br>
 <h2>Available records:</h2>
 <table style="width:100%">
-<tr><td style="width:40%">Name<th>Position<th>Rank
+<tr><td style="width:40%">Name<th>Position
+{{if data.show_milrank}}
+	<th>Rank
+{{/if}}
 {{for data.all_records}}
 	<tr class="candystripe"><td>{{:helper.link(value.name, '', {'set_active' : value.id})}}
 	<td>{{:value.rank}}
-	<td>{{:value.milrank}}
+	{{if data.show_milrank}}
+		<td>{{:value.milrank}}
+	{{/if}}
 {{/for}}
 </table>
 {{/if}}

--- a/nebula.dme
+++ b/nebula.dme
@@ -2380,6 +2380,7 @@
 #include "code\modules\modular_computers\ntos\visuals.dm"
 #include "code\modules\modular_computers\ntos\subtypes\console.dm"
 #include "code\modules\modular_computers\ntos\subtypes\device.dm"
+#include "code\modules\modular_computers\ntos\subtypes\silicon.dm"
 #include "code\modules\modular_computers\terminal\terminal.dm"
 #include "code\modules\modular_computers\terminal\terminal_commands.dm"
 #include "code\modules\modular_computers\terminal\terminal_remote.dm"


### PR DESCRIPTION
Needed for ntnet kill PR to work properly since that makes a lot of 'subsystems' unusable without a computer.
Gives synths crew records. AIs get them on spawn (after namepick), borgs get them after they pick a module. This is needed for manifest generation to work withotu special cases for synths
You can now install/remove stock parts into borgs and AIs, currently only used by NTOS. It's done by crowbar (same as components for robots).
Also fixes AIize verb failing if it finds no landmark to move you to.
