### PR TITLE
Inverts gas overlay check loop

### DIFF
--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -353,10 +353,9 @@
 //Two lists can be passed by reference if you need know specifically which graphics were added and removed.
 /datum/gas_mixture/proc/check_tile_graphic(list/graphic_add = null, list/graphic_remove = null)
 	for(var/obj/effect/gas_overlay/O in graphic)
-		var/material/mat = SSmaterials.get_material_datum(O.material.type)
-		if(gas[O.material.type] <= mat.gas_overlay_limit)
+		if(gas[O.material.type] <= O.material.gas_overlay_limit)
 			LAZYADD(graphic_remove, O)
-	for(var/g in SSmaterials.all_gasses)
+	for(var/g in gas)
 		//Overlay isn't applied for this gas, check if it's valid and needs to be added.
 		var/material/mat = SSmaterials.get_material_datum(g)
 		if(!isnull(mat.gas_overlay_limit) && gas[g] > mat.gas_overlay_limit)


### PR DESCRIPTION
Now it only loops over gases actually present, instead of looping over all possible gases and checking if they're present.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->