### PR TITLE
Adds floating chat messages

### DIFF
--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -242,6 +242,11 @@ var/list/_client_preferences_by_type
 	key = "EXAMINE_MESSAGES"
 	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
 
+/datum/client_preference/floating_messages
+	description ="Floating chat messages"
+	key = "FLOATING_CHAT"
+	options = list(GLOB.PREF_HIDE, GLOB.PREF_SHOW)
+
 /********************
 * General Staff Preferences *
 ********************/

--- a/code/modules/mob/floating_message.dm
+++ b/code/modules/mob/floating_message.dm
@@ -1,0 +1,63 @@
+// Thanks to Burger from Burgerstation for the foundation for this
+var/list/floating_chat_colors = list()
+
+/atom/movable
+	var/list/stored_chat_text
+
+/atom/movable/proc/animate_chat(message, decl/language/language, small, list/show_to, duration)
+	set waitfor = FALSE
+	
+	var/style	//additional style params for the message
+	var/fontsize = 6
+	if(small)
+		fontsize = 5
+	var/limit = 50
+	if(copytext(message, length(message) - 1) == "!!")
+		fontsize = 8
+		limit = 30
+		style += "font-weight: bold;"
+
+	if(length(message) > limit)
+		message = "[copytext(message, 1, limit)]..."
+
+	if(!floating_chat_colors[name])
+		floating_chat_colors[name] = get_random_colour(0,160,230)
+	style += "color: [floating_chat_colors[name]];"
+
+	// create 2 messages, one that appears if you know the language, and one that appears when you don't know the language
+	var/image/understood = generate_floating_text(src, capitalize(message), style, fontsize, duration, show_to)
+	var/image/gibberish = language ? generate_floating_text(src, language.scramble(message), style, fontsize, duration, show_to) : understood
+
+	for(var/client/C in show_to)
+		if(!C.mob.is_deaf() && C.get_preference_value(/datum/client_preference/floating_messages) == GLOB.PREF_SHOW)
+			if(C.mob.say_understands(null, language))
+				C.images += understood
+			else
+				C.images += gibberish
+
+/proc/generate_floating_text(atom/movable/holder, message, style, size, duration, show_to)	
+	var/image/I = image(null, holder)
+	I.layer=FLY_LAYER
+	I.alpha = 0
+	I.maptext_width = 80
+	I.maptext_height = 64
+	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+	I.plane = EFFECTS_ABOVE_LIGHTING_PLANE
+	I.pixel_x = -round(I.maptext_width/2) + 16
+
+	style = "font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: [size]px; [style]"
+	I.maptext = "<center><span style=\"[style]\">[message]</span></center>"
+	animate(I, 1, alpha = 255, pixel_y = 16)
+	
+	for(var/image/old in holder.stored_chat_text)
+		animate(old, 2, pixel_y = old.pixel_y + 8)
+	LAZYADD(holder.stored_chat_text, I)
+	
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/remove_floating_text, holder, I), duration)
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/remove_images_from_clients, I, show_to), duration + 2)
+
+	return I
+
+/proc/remove_floating_text(atom/movable/holder, image/I)
+	animate(I, 2, pixel_y = I.pixel_y + 10, alpha = 0)
+	LAZYREMOVE(holder.stored_chat_text, I)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -313,6 +313,7 @@ proc/get_radio_key_from_channel(var/channel)
 					O.hear_talk(src, stars(message), verb, speaking)
 
 	INVOKE_ASYNC(GLOBAL_PROC, .proc/animate_speech_bubble, speech_bubble, speech_bubble_recipients, 30)
+	INVOKE_ASYNC(src, /atom/movable/proc/animate_chat, message, speaking, italics, speech_bubble_recipients, 30)
 
 	if(whispering)
 		log_whisper("[name]/[key] : [message]")

--- a/nebula.dme
+++ b/nebula.dme
@@ -1944,6 +1944,7 @@
 #include "code\modules\mining\machinery\mineral_unloader.dm"
 #include "code\modules\mob\animations.dm"
 #include "code\modules\mob\death.dm"
+#include "code\modules\mob\floating_message.dm"
 #include "code\modules\mob\gender.dm"
 #include "code\modules\mob\hear_say.dm"
 #include "code\modules\mob\holder.dm"


### PR DESCRIPTION
AKA runescape chat
Stolen from beestation PR which is stolen from goon (in a license friendly way)
https://github.com/BeeStation/BeeStation-Hornet/pull/1603

Differencies to bee PR include name=color setup, and some code reshuffling to reduce copypaste.
It's shown if you have preference enabled, defaults to off

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->