### PR TITLE
Add maximum atom content configuration.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -89,6 +89,8 @@ var/list/gamemode_cache = list()
 	var/guests_allowed = 1
 	var/debugparanoid = 0
 
+	var/atom_content_limit = 0
+
 	var/serverurl
 	var/server
 	var/banappeals
@@ -318,6 +320,9 @@ var/list/gamemode_cache = list()
 
 				if ("debug_paranoid")
 					config.debugparanoid = 1
+
+				if ("atom_content_limit")
+					config.atom_content_limit = text2num(value)
 
 				if ("log_admin")
 					config.log_admin = 1

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -165,8 +165,27 @@
 			found += A.search_contents_for(path,filter_path)
 	return found
 
-
-
+/*
+ * Recursively searches all atom contents (including contents contents and so on.)
+ * 
+ * ARGS: paths (array) - only count atoms of one the provided paths.
+ * RETURNS: A number of all contents found.
+*/
+/atom/proc/get_all_contents_count(var/paths)
+	var/count = 0
+	for(var/atom/A in src.contents)
+		if(paths)
+			var/found = FALSE
+			for(var/path in paths)
+				if(istype(A, path))
+					found = TRUE
+					break
+			if(!found)
+				continue
+		count++
+		if(A.contents.len)
+			count += A.get_all_contents_count()
+	return count
 
 /*
 Beam code by Gunbuddy

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -181,14 +181,16 @@ var/list/slot_equipment_priority = list( \
 			qdel(grab)
 			. = TRUE
 		return
+	if(!is_space_available(get_active_hand(), Target ? get_turf(Target) : get_turf(loc)))
+		return
+	return hand ? drop_l_hand(Target) : drop_r_hand(Target)
 
-	var/obj/item/W = hand ? l_hand : r_hand
-	if(W && config.atom_content_limit)
-		var/turf/T = Target ? get_turf(Target) : get_turf(loc)
-		if(T.get_all_contents_count(list(/obj/structure, /obj/item)) >= config.atom_content_limit)
+/mob/proc/is_space_available(var/obj/item/W, var/atom/target)
+	if(W && target && config.atom_content_limit)
+		if(target.get_all_contents_count(list(/obj/structure, /obj/item)) >= config.atom_content_limit)
 			to_chat(src, SPAN_WARNING("There is no room to put that there."))
 			return 0
-	return hand ? drop_l_hand(Target) : drop_r_hand(Target)
+	return 1
 
 /*
 	Removes the object from any slots the mob might have, calling the appropriate icon update proc.
@@ -243,11 +245,8 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/unEquip(obj/item/I, var/atom/target)
 	if(!canUnEquip(I))
 		return
-	if(I && config.atom_content_limit && target)
-		var/turf/T = get_turf(target)
-		if(T.get_all_contents_count(list(/obj/structure, /obj/item)) >= config.atom_content_limit)
-			to_chat(src, SPAN_WARNING("There is no room to put that there."))
-			return 0
+	if(target && !is_space_available(I, get_turf(target)))
+		return
 	drop_from_inventory(I, target)
 	return 1
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -181,6 +181,13 @@ var/list/slot_equipment_priority = list( \
 			qdel(grab)
 			. = TRUE
 		return
+
+	var/obj/item/W = hand ? l_hand : r_hand
+	if(W && config.atom_content_limit)
+		var/turf/T = Target ? get_turf(Target) : get_turf(loc)
+		if(T.get_all_contents_count(list(/obj/structure, /obj/item)) >= config.atom_content_limit)
+			to_chat(src, SPAN_WARNING("There is no room to put that there."))
+			return 0
 	return hand ? drop_l_hand(Target) : drop_r_hand(Target)
 
 /*
@@ -236,6 +243,11 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/unEquip(obj/item/I, var/atom/target)
 	if(!canUnEquip(I))
 		return
+	if(I && config.atom_content_limit && target)
+		var/turf/T = get_turf(target)
+		if(T.get_all_contents_count(list(/obj/structure, /obj/item)) >= config.atom_content_limit)
+			to_chat(src, SPAN_WARNING("There is no room to put that there."))
+			return 0
 	drop_from_inventory(I, target)
 	return 1
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -268,9 +268,8 @@
 
 	if(!item) return
 
-	if(config.atom_content_limit && get_turf(target).get_all_contents_count(list(/obj)) >= config.atom_content_limit)
-		to_chat(src, SPAN_WARNING("There is no room to throw that there."))
-		return // No room.
+	if(!is_space_available(item, get_turf(target)))
+		return
 
 	var/throw_range = item.throw_range
 	var/itemsize

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -268,6 +268,10 @@
 
 	if(!item) return
 
+	if(config.atom_content_limit && get_turf(target).get_all_contents_count(list(/obj)) >= config.atom_content_limit)
+		to_chat(src, SPAN_WARNING("There is no room to throw that there."))
+		return // No room.
+
 	var/throw_range = item.throw_range
 	var/itemsize
 	if (istype(item, /obj/item/grab))

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -160,6 +160,13 @@ VOTE_AUTOGAMEMODE_TIMELEFT 160
 ## players' votes default to "No vote" (otherwise,  default to "No change")
 DEFAULT_NO_VOTE
 
+## Set a limit to the number of /obj contents an atom can have.
+## Strict Values: <100
+## Moderate Values: <250
+## Generous Values: <500
+## Default: Disabled
+##ATOM_CONTENT_LIMIT 250
+
 ## Allow ghosts to see antagonist through AntagHUD
 ALLOW_ANTAG_HUD
 


### PR DESCRIPTION
* Adds a configuration variable for limiting the maximum number of /obj that can be in a single turf (recursively).
* Default value is unlimited.
* Turfs that have reached the configured variable limit will not allow new items to be dropped or thrown in that turf.
* Further improvements could be made like limiting conveyors, or teleporters with the same limit.

* For persistence, this discourages hoarding behaviour on single turfs in a user friendly way. (And allows a much tighter limit.)
* Other servers may wish to use the limit for performance reasons.