### PR TITLE
Adds material sheet vendomat

### DIFF
--- a/code/game/machinery/vending/engineering.dm
+++ b/code/game/machinery/vending/engineering.dm
@@ -132,3 +132,29 @@
 		/obj/item/crowbar = 2
 	)
 	contraband = list(/obj/item/flash = 2)
+
+/obj/machinery/vending/materials
+	name = "MatterVend"
+	desc = "Provides access to baryonic matter in easy to handle sheet form."
+	icon_state = "engivend"
+	icon_deny = "engivend-deny"
+	icon_vend = "engivend-vend"
+	markup = 0
+	vend_delay = 21
+	base_type = /obj/machinery/vending/materials
+	products = list(
+		/obj/item/stack/material/steel/fifty = 3,
+		/obj/item/stack/material/plastic/fifty = 4,
+		/obj/item/stack/material/aluminium/fifty = 3,
+		/obj/item/stack/material/plasteel/ten = 4,
+		/obj/item/stack/material/glass/fifty = 4
+	)
+	contraband = list(/obj/item/stack/material/ocp/ten = 3)
+
+/obj/machinery/vending/materials/build_inventory()
+	..()
+	for(var/datum/stored_items/vending_products/P in product_records)
+		if(ispath(P.item_path, /obj/item/stack/material))
+			var/obj/item/stack/material/S = P.item_path
+			var/material/sheet_material = SSmaterials.get_material_datum(initial(S.material))
+			P.item_name = "[sheet_material.display_name] [sheet_material.sheet_plural_name] ([initial(S.amount)]x)"

--- a/maps/bearcat/bearcat-1.dmm
+++ b/maps/bearcat/bearcat-1.dmm
@@ -1855,10 +1855,14 @@
 /turf/simulated/floor/plating,
 /area/ship/bearcat/maintenance/eva)
 "es" = (
+/obj/machinery/vending/engineering{
+	icon_state = "engi";
+	dir = 4
+	},
 /obj/machinery/light/small{
+	icon_state = "bulb1";
 	dir = 8
 	},
-/obj/machinery/vending/engineering,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/bearcat/maintenance/techstorage)
 "et" = (
@@ -2015,10 +2019,6 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/ship/bearcat/maintenance/eva)
 "eG" = (
-/obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
-	},
 /obj/machinery/airlock_sensor{
 	id_tag = "eva_sensor";
 	pixel_y = 40
@@ -2040,6 +2040,10 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 2;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/bearcat/maintenance/eva)
@@ -2067,14 +2071,10 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/ship/bearcat/maintenance/eva)
 "eJ" = (
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/capacitor/adv,
-/obj/item/stock_parts/scanning_module,
-/obj/item/stock_parts/scanning_module,
-/obj/item/stock_parts/scanning_module,
-/obj/item/stock_parts/scanning_module/adv,
-/obj/structure/table/rack,
+/obj/machinery/vending/materials{
+	icon_state = "engivend";
+	dir = 4
+	},
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
 	dir = 10
@@ -2219,15 +2219,8 @@
 /area/ship/bearcat/maintenance/storage)
 "eX" = (
 /obj/item/tape_roll,
-/obj/item/stack/material/plasteel/fifty,
 /obj/item/stack/material/rods/fifty,
-/obj/item/stack/material/steel/fifty,
-/obj/item/stack/material/plastic/fifty,
-/obj/item/stack/material/steel/fifty,
 /obj/structure/closet/crate,
-/obj/item/stack/material/glass/fifty,
-/obj/item/stack/material/glass/fifty,
-/obj/item/stack/material/glass/reinforced/fifty,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/bearcat/maintenance/storage)
 "eY" = (


### PR DESCRIPTION
Anticipating more material usage in future, it helps to make sure players always have all the kinds they need at start, so this is an easier way of ensuring that compared to mapping sheets.

Also mapped it on bearcat