### PR TITLE
Add better lighting to example map

### DIFF
--- a/maps/example/example-1.dmm
+++ b/maps/example/example-1.dmm
@@ -9,22 +9,17 @@
 /turf/simulated/floor/tiled,
 /area/constructionsite)
 "d" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/spot,
 /turf/simulated/floor/tiled,
 /area/constructionsite)
 "e" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/constructionsite)
+/obj/machinery/light/spot,
+/turf/simulated/floor/plating,
+/area/shuttle/escape)
 "f" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+/obj/machinery/light/spot{
+	icon_state = "tube_map";
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/constructionsite)
@@ -60,7 +55,10 @@
 /turf/simulated/floor/tiled,
 /area/constructionsite)
 "k" = (
-/obj/machinery/light,
+/obj/machinery/light/spot{
+	icon_state = "tube_map";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/constructionsite)
 "l" = (
@@ -172,9 +170,12 @@
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "C" = (
-/obj/machinery/light,
-/turf/simulated/floor/plating,
-/area/shuttle/escape)
+/obj/machinery/light/spot{
+	icon_state = "tube_map";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/constructionsite)
 "D" = (
 /obj/machinery/door/airlock/external/bolted{
 	id_tag = "example_shuttle_port_hatch"
@@ -710,7 +711,7 @@ a
 y
 A
 B
-C
+e
 y
 a
 a
@@ -875,13 +876,13 @@ b
 c
 c
 c
-e
+k
 c
 c
 u
 c
 c
-e
+k
 h
 i
 j
@@ -974,19 +975,19 @@ a
 Z
 Z
 b
+f
+l
+l
+l
+c
+c
+c
+c
+c
+t
+t
+t
 d
-l
-l
-l
-c
-c
-c
-c
-c
-t
-t
-t
-k
 b
 Z
 Z
@@ -1178,7 +1179,7 @@ a
 Z
 Z
 b
-d
+f
 c
 c
 c
@@ -1190,7 +1191,7 @@ c
 c
 c
 X
-k
+d
 b
 Z
 Z
@@ -1283,13 +1284,13 @@ b
 c
 c
 v
-f
+C
 c
 n
 c
 q
 c
-f
+C
 c
 c
 c

--- a/maps/example/example-2.dmm
+++ b/maps/example/example-2.dmm
@@ -30,13 +30,14 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "ag" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes,
 /obj/item/storage/box/freezer,
+/obj/machinery/light/spot{
+	icon_state = "tube_map";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "ah" = (
@@ -56,10 +57,11 @@
 /turf/simulated/open,
 /area/medical/surgery)
 "ak" = (
-/obj/machinery/light{
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/machinery/light/spot{
+	icon_state = "tube_map";
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "al" = (
@@ -84,8 +86,8 @@
 /obj/structure/table/glass,
 /obj/item/chems/dropper,
 /obj/item/stack/nanopaste,
-/obj/machinery/light{
-	icon_state = "tube1";
+/obj/machinery/light/spot{
+	icon_state = "tube_map";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -157,8 +159,8 @@
 /area/medical/surgery)
 "ay" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
-/obj/machinery/light{
-	icon_state = "tube1";
+/obj/machinery/light/spot{
+	icon_state = "tube_map";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -280,19 +282,19 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "aP" = (
-/obj/machinery/light{
-	icon_state = "tube1";
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/machinery/light/spot{
+	icon_state = "tube_map";
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "aQ" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
+/obj/machinery/light/spot,
 /obj/effect/floor_decal/corner/blue/diagonal,
+/obj/machinery/fabricator/protolathe{
+	initial_id_tag = "research"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "aR" = (
@@ -326,7 +328,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "aU" = (
-/obj/machinery/light,
+/obj/machinery/light/spot,
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
@@ -347,14 +349,6 @@
 "aX" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/machinery/destructive_analyzer{
-	initial_id_tag = "research"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"aY" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/blue/diagonal,
-/obj/machinery/fabricator/protolathe{
 	initial_id_tag = "research"
 	},
 /turf/simulated/floor/tiled/white,
@@ -1119,7 +1113,7 @@ aN
 aN
 aN
 aN
-aY
+aQ
 ac
 aa
 aa
@@ -1422,8 +1416,8 @@ aI
 aN
 aM
 aN
-aQ
 aN
+ay
 aN
 aN
 ac

--- a/maps/example/example-3.dmm
+++ b/maps/example/example-3.dmm
@@ -16,10 +16,11 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/fsmaint2)
 "e" = (
-/obj/machinery/light{
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/machinery/light/spot{
+	icon_state = "tube_map";
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled,
 /area/maintenance/fsmaint2)
 "f" = (
@@ -41,11 +42,11 @@
 /turf/space,
 /area/space)
 "j" = (
-/obj/machinery/light{
-	icon_state = "tube1";
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/machinery/light/spot{
+	icon_state = "tube_map";
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled,
 /area/maintenance/fsmaint2)
 "k" = (
@@ -65,8 +66,7 @@
 /turf/simulated/floor,
 /area/maintenance/fsmaint2)
 "n" = (
-/obj/machinery/door/airlock/external/bolted{
-	},
+/obj/machinery/door/airlock/external/bolted,
 /turf/simulated/floor,
 /area/maintenance/fsmaint2)
 "o" = (
@@ -76,15 +76,15 @@
 /area/maintenance/fsmaint2)
 "p" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
-/obj/machinery/light{
-	icon_state = "tube1";
+/obj/machinery/light/spot{
+	icon_state = "tube_map";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/fsmaint2)
 "q" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	 icon_state = "intact";
+	icon_state = "intact";
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
@@ -92,7 +92,7 @@
 /area/maintenance/fsmaint2)
 "r" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	 icon_state = "intact";
+	icon_state = "intact";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
@@ -100,7 +100,7 @@
 /area/maintenance/fsmaint2)
 "s" = (
 /obj/machinery/atmospherics/portables_connector{
-	 icon_state = "map_connector";
+	icon_state = "map_connector";
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/air,
@@ -109,7 +109,7 @@
 /area/maintenance/fsmaint2)
 "t" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	 icon_state = "intact";
+	icon_state = "intact";
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
@@ -117,7 +117,7 @@
 /area/maintenance/fsmaint2)
 "u" = (
 /obj/machinery/atmospherics/portables_connector{
-	 icon_state = "map_connector";
+	icon_state = "map_connector";
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
@@ -133,17 +133,14 @@
 /area/maintenance/fsmaint2)
 "w" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	 icon_state = "map_scrubber_on";
+	icon_state = "map_scrubber_on";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled,
 /area/maintenance/fsmaint2)
 "x" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
+/obj/machinery/light/spot,
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled,
 /area/maintenance/fsmaint2)
@@ -174,11 +171,6 @@
 "A" = (
 /obj/structure/cable,
 /obj/machinery/power/debug_items/infinite_generator,
-/obj/effect/floor_decal/corner/blue/diagonal,
-/turf/simulated/floor/tiled,
-/area/maintenance/fsmaint2)
-"B" = (
-/obj/machinery/light,
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled,
 /area/maintenance/fsmaint2)
@@ -920,7 +912,7 @@ d
 d
 d
 d
-B
+x
 c
 a
 a
@@ -1124,7 +1116,7 @@ d
 d
 d
 d
-B
+x
 c
 a
 a
@@ -1223,8 +1215,8 @@ s
 d
 u
 d
-x
 d
+p
 d
 d
 c


### PR DESCRIPTION
Just replaces all the standard tube lights on example with spotlights.

![](https://i.imgur.com/18BJHha.png)
