### PR TITLE
Generalize fabricators output direction

### DIFF
--- a/code/modules/fabrication/_fabricator.dm
+++ b/code/modules/fabrication/_fabricator.dm
@@ -51,6 +51,8 @@
 	var/datum/sound_token/sound_token
 	var/fabricator_sound = 'sound/machines/fabricator_loop.ogg'
 
+	var/output_dir
+
 /obj/machinery/fabricator/Destroy()
 	QDEL_NULL(currently_building)
 	QDEL_NULL_LIST(queued_orders)

--- a/code/modules/fabrication/fabricator_build.dm
+++ b/code/modules/fabrication/fabricator_build.dm
@@ -16,6 +16,9 @@
 
 /obj/machinery/fabricator/proc/do_build(var/datum/fabricator_recipe/recipe, var/amount)
 	. = recipe.build(get_turf(src), amount)
+	if(output_dir)
+		for(var/atom/movable/product in .)
+			step(product, output_dir)
 
 /obj/machinery/fabricator/proc/start_building()
 	if(!(fab_status_flags & FAB_BUSY) && is_functioning())

--- a/code/modules/fabrication/fabricator_industrial.dm
+++ b/code/modules/fabrication/fabricator_industrial.dm
@@ -20,8 +20,4 @@
 		MAT_URANIUM =   SHEET_MATERIAL_AMOUNT * 100,
 		MAT_DIAMOND =   SHEET_MATERIAL_AMOUNT * 100
 	)
-
-/obj/machinery/fabricator/industrial/do_build(var/datum/fabricator_recipe/recipe, var/amount)
-	. = ..()
-	for(var/atom/movable/product in .)
-		step(product, EAST)
+	output_dir = EAST


### PR DESCRIPTION
So we can make directional subtypes without overriding proc. Useful when we need output something on conveyors.