### PR TITLE
Adds a check for when network machine is bothered too early

### DIFF
--- a/code/modules/modular_computers/networking/machinery/_network_machine.dm
+++ b/code/modules/modular_computers/networking/machinery/_network_machine.dm
@@ -66,6 +66,8 @@
 
 /obj/machinery/network/proc/update_network_status()
 	var/datum/extension/network_device/D = get_extension(src, /datum/extension/network_device)
+	if(!D)
+		return
 	if(operable())
 		D.connect()
 	else


### PR DESCRIPTION
It seems that during init something can try to change its power state before it's inited properly and gets a network device extension.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->