### PR TITLE
Moves light switching to lateload

### DIFF
--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -28,18 +28,19 @@
 	on = TRUE
 
 /obj/machinery/light_switch/Initialize()
-	. = ..()
+	..()
 	if(other_area)
-		src.connected_area = locate(other_area)
+		connected_area = locate(other_area)
 	else
-		src.connected_area = get_area(src)
+		connected_area = get_area(src)
 
-	if(!connected_area)
-		return // Test instance spawned in nullspace
-	if(name == initial(name))
+	if(connected_area && name == initial(name))
 		SetName("light switch ([connected_area.name])")
+	return INITIALIZE_HINT_LATELOAD
 
-	connected_area.set_lightswitch(on)
+/obj/machinery/light_switch/LateInitialize()
+	. = ..()
+	connected_area?.set_lightswitch(on)
 	update_icon()
 
 /obj/machinery/light_switch/on_update_icon()


### PR DESCRIPTION
So it doesn't fuck with power changes in area too early on

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->