### PR TITLE
Stock parts health

### DIFF
--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -387,8 +387,8 @@ Class Procs:
 		var/line = "<span class='notice'>	[C.name]</span>"
 		if(!C.health)
 			line = "<span class='warning'>	[C.name] (destroyed)</span>"
-		else if(C.health < initial(C.health))
-			line = "<span class='warning'>	[C.name] (damaged)</span>"
+		else if(C.health < 0.75 * C.max_health)
+			line = "<span class='notice'>	[C.name] (damaged)</span>"
 		to_chat(user, line)
 	for(var/path in uncreated_component_parts)
 		var/obj/item/thing = path

--- a/code/game/machinery/_machines_base/stock_parts/_stock_parts.dm
+++ b/code/game/machinery/_machines_base/stock_parts/_stock_parts.dm
@@ -8,7 +8,6 @@
 	var/rating = 1
 	var/status = 0             // Flags using PART_STAT defines.
 	var/base_type              // Type representing parent of category for replacer usage.
-	health = 50
 
 /obj/item/stock_parts/attack_hand(mob/user)
 	if(istype(loc, /obj/machinery))
@@ -85,10 +84,14 @@
 
 /obj/item/stock_parts/proc/is_functional()
 	return health > 0
-	
+
 /obj/item/stock_parts/examine(mob/user)
 	. = ..()
 	if(!is_functional())
 		to_chat(user, SPAN_WARNING("It is completely broken."))
-	else if(health < initial(health))
+	else if(health < 0.5 * max_health)
+		to_chat(user, SPAN_WARNING("It is heavily damaged."))
+	else if(health < 0.75 * max_health)
 		to_chat(user, SPAN_NOTICE("It is showing signs of damage."))
+	else if(health < max_health)
+		to_chat(user, SPAN_NOTICE("It is showing some wear and tear."))

--- a/code/game/machinery/_machines_base/stock_parts/shielding.dm
+++ b/code/game/machinery/_machines_base/stock_parts/shielding.dm
@@ -2,7 +2,7 @@
 //Components that soak damage before it reaches other components.
 /obj/item/stock_parts/shielding
 	base_type = /obj/item/stock_parts/shielding
-	health = 80
+	material_health_multiplier = 0.4
 	var/list/protection_types	//types of damage it will soak
 
 /obj/item/stock_parts/shielding/electric

--- a/code/game/machinery/doors/braces.dm
+++ b/code/game/machinery/doors/braces.dm
@@ -20,8 +20,7 @@
 	material = MAT_STEEL
 	matter = list(MAT_GLASS = MATTER_AMOUNT_REINFORCEMENT)
 
-	var/cur_health
-	var/max_health = 450
+	material_health_multiplier = 0.6
 	var/obj/machinery/door/airlock/airlock = null
 	var/obj/item/airlock_electronics/brace/electronics
 
@@ -55,7 +54,7 @@
 
 /obj/item/airlock_brace/Initialize()
 	. = ..()
-	cur_health = max_health
+	health = max_health
 	electronics = new/obj/item/airlock_electronics/brace(src)
 	update_access()
 
@@ -103,21 +102,21 @@
 
 	if(isWelder(W))
 		var/obj/item/weldingtool/C = W
-		if(cur_health == max_health)
+		if(health == max_health)
 			to_chat(user, "\The [src] does not require repairs.")
 			return
 		if(C.remove_fuel(0,user))
 			playsound(src, 'sound/items/Welder.ogg', 100, 1)
-			cur_health = min(cur_health + rand(80,120), max_health)
-			if(cur_health == max_health)
+			health = min(health + rand(20,30), max_health)
+			if(health == max_health)
 				to_chat(user, "You repair some dents on \the [src]. It is in perfect condition now.")
 			else
 				to_chat(user, "You repair some dents on \the [src].")
 
 
 /obj/item/airlock_brace/proc/take_damage(var/amount)
-	cur_health = between(0, cur_health - amount, max_health)
-	if(!cur_health)
+	health = between(0, health - amount, max_health)
+	if(!health)
 		if(airlock)
 			airlock.visible_message("<span class='danger'>\The [src] breaks off of \the [airlock]!</span>")
 		unlock_brace(null)
@@ -141,7 +140,7 @@
 /obj/item/airlock_brace/proc/health_percentage()
 	if(!max_health)
 		return 0
-	return (cur_health / max_health) * 100
+	return (health / max_health) * 100
 
 /obj/item/airlock_brace/proc/update_access()
 	if(!electronics)

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -8,6 +8,8 @@
 	var/randpixel = 6
 	var/r_speed = 1.0
 	var/health = null
+	var/max_health
+	var/material_health_multiplier = 0.2
 	var/burn_point = null
 	var/burning = null
 	var/hitsound = "swing_hit"

--- a/code/game/objects/item_materials.dm
+++ b/code/game/objects/item_materials.dm
@@ -61,7 +61,8 @@
 	if(new_material)
 		material = SSmaterials.get_material_datum(new_material)
 	if(istype(material))
-		health = round(material.integrity/5)
+		health = round(material_health_multiplier * material.integrity)
+		max_health = health
 		if(material.products_need_process())
 			START_PROCESSING(SSobj, src)
 		if(material.conductive)


### PR DESCRIPTION
Added max_health var to track how damaged things are, since initial(health) is meaningless with material based health.
Added multiplier for how much of material's integrity is translated into health. Default is mimicing same values it had.

Added bit more gradation to damage descriptors when examining stock parts.
Shielding components have twice the health.
Made armor component requrie plasteel (also means it gets more health)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->