### PR TITLE
Fixes all stock parts not having health

### DIFF
--- a/code/game/machinery/_machines_base/stock_parts/_stock_parts.dm
+++ b/code/game/machinery/_machines_base/stock_parts/_stock_parts.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/obj/items/stock_parts/stock_parts.dmi'
 	randpixel = 5
 	w_class = ITEM_SIZE_SMALL
+	material = MAT_STEEL
 	var/part_flags = PART_FLAG_LAZY_INIT | PART_FLAG_HAND_REMOVE
 	var/rating = 1
 	var/status = 0             // Flags using PART_STAT defines.


### PR DESCRIPTION
I removed var override for their health value since I thought they defaulted to steel and that literally broke them
Now they default to steel material.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->