### PR TITLE
centralizing get_processing_power variable

### DIFF
--- a/code/modules/modular_computers/file_system/programs/antagonist/access_decrypter.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/access_decrypter.dm
@@ -105,8 +105,7 @@
 
 /datum/computer_file/program/access_decrypter/proc/get_speed()
 	var/skill_speed_modifier = 1 + (operator_skill - SKILL_ADEPT)/(SKILL_MAX - SKILL_MIN)
-	var/obj/item/stock_parts/computer/processor_unit/CPU = computer.get_component(PART_CPU)
-	return CPU?.processing_power * skill_speed_modifier
+	return computer.get_processing_power() * skill_speed_modifier
 
 /datum/nano_module/program/access_decrypter
 	name = "Access Database Decrypter"

--- a/code/modules/modular_computers/file_system/programs/generic/folding.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/folding.dm
@@ -55,8 +55,7 @@ GLOBAL_LIST_INIT(science_strings, list(
 			to_chat(usr, SPAN_WARNING("Unable to locate ID card for transaction."))
 			return TOPIC_HANDLED
 		var/datum/money_account/account = get_account(I.associated_account_number)
-		var/obj/item/stock_parts/computer/processor_unit/processor = computer.get_component(PART_CPU)
-		var/earned = current_interval * (SCIENCE_MONEY_PER_MINUTE * processor.processing_power)
+		var/earned = current_interval * (SCIENCE_MONEY_PER_MINUTE * computer.get_processing_power())
 		account.deposit(earned, "Completed FOLDING@SPACE project.")
 		to_chat(usr, SPAN_NOTICE("Transferred [earned] to your account."))
 		started_on = 0

--- a/code/modules/modular_computers/ntos/ntos.dm
+++ b/code/modules/modular_computers/ntos/ntos.dm
@@ -194,3 +194,7 @@
 
 /datum/extension/interactive/ntos/proc/emagged()
 	return FALSE
+
+/datum/extension/interactive/ntos/proc/get_processing_power()
+	var/obj/item/stock_parts/computer/processor_unit/CPU = get_component(PART_CPU)
+	return CPU?.processing_power


### PR DESCRIPTION
really simple change. processors are critical components, moved the processing_power accessor to a proc on the computer itself for null safety & add a good place for a hook if I ever decide to add some logic to fuck with this like overclocking or botnets.