### PR TITLE
Fixes accessories using onmobicon getting colorized by parent

### DIFF
--- a/code/game/objects/items/item_icon_experimental.dm
+++ b/code/game/objects/items/item_icon_experimental.dm
@@ -36,6 +36,7 @@
 	var/bodytype = lowertext(user_mob?.get_bodytype() || BODYTYPE_HUMANOID)
 	var/image/I = image(get_icon_for_bodytype(bodytype), "[bodytype]-[slot]")
 	I.color = color
+	I.appearance_flags = RESET_COLOR
 	. = apply_offsets(user_mob, I, slot)
 	. = apply_overlays(user_mob, bodytype, I, slot)
 


### PR DESCRIPTION
Since it was skipping the usual generation, it didn't have the flag set.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->