### PR TITLE
Adds adminverb to spawn a stack of any material

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -205,7 +205,8 @@ var/list/admin_verbs_debug = list(
 	/client/proc/visualpower_remove,
 	/client/proc/ping_webhook,
 	/client/proc/reload_webhooks,
-	/datum/admins/proc/check_unconverted_single_icon_items
+	/datum/admins/proc/check_unconverted_single_icon_items,
+	/client/proc/spawn_material
 	)
 
 var/list/admin_verbs_paranoid_debug = list(

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -481,3 +481,14 @@
 
 	images -= powernet_markers
 	QDEL_NULL_LIST(powernet_markers)
+
+/client/proc/spawn_material()
+	set category = "Debug"
+	set name = "Spawn Material Stack"
+	if(!check_rights(R_DEBUG)) return
+
+	var/material = input("Select material to spawn") as null|anything in SSmaterials.materials_by_name
+	if(!material)
+		return
+	var/material/M = SSmaterials.get_material_datum(material)
+	new M.stack_type(get_turf(mob), 50, M)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->