### PR TITLE
Added MMO-style protection areas.

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -75,10 +75,11 @@
 #define DEFAULT_JOB_TYPE /datum/job/assistant
 
 //Area flags, possibly more to come
-#define AREA_FLAG_RAD_SHIELDED      1 // shielded from radiation, clearly
-#define AREA_FLAG_EXTERNAL          2 // External as in exposed to space, not outside in a nice, green, forest
-#define AREA_FLAG_ION_SHIELDED      4 // shielded from ionospheric anomalies
-#define AREA_FLAG_IS_NOT_PERSISTENT 8 // SSpersistence will not track values from this area.
+#define AREA_FLAG_RAD_SHIELDED      1 	// shielded from radiation, clearly
+#define AREA_FLAG_EXTERNAL          2 	// External as in exposed to space, not outside in a nice, green, forest
+#define AREA_FLAG_ION_SHIELDED      4 	// shielded from ionospheric anomalies
+#define AREA_FLAG_IS_NOT_PERSISTENT 8 	// SSpersistence will not track values from this area.
+#define AREA_FLAG_PROTECTED			16	// Machines, turfs, and walls are protected in this area.
 
 //Map template flags
 #define TEMPLATE_FLAG_ALLOW_DUPLICATES 1 // Lets multiple copies of the template to be spawned

--- a/code/_helpers/protection.dm
+++ b/code/_helpers/protection.dm
@@ -1,0 +1,14 @@
+/atom/proc/isProtected(var/mob/user)
+	var/area/A
+	if(istype(src, /turf))
+		A = get_area(src)
+	else
+		A = get_area(loc)
+		
+	var/protected = A.area_flags & AREA_FLAG_PROTECTED
+	if(!protected)
+		return FALSE
+	if(!user)
+		return TRUE
+	// Check permission whitelists for this user.
+	return TRUE // TODO: actually implement.

--- a/code/game/machinery/_machines_base/machine_construction/default.dm
+++ b/code/game/machinery/_machines_base/machine_construction/default.dm
@@ -64,6 +64,9 @@
 	if((. = ..()))
 		return
 	if(isCrowbar(I))
+		if(machine.isProtected(user))
+			to_chat(user, SPAN_NOTICE("This machine is protected by a safe-zone."))
+			return
 		TRANSFER_STATE(down_state)
 		playsound(get_turf(machine), 'sound/items/Crowbar.ogg', 50, 1)
 		machine.visible_message(SPAN_NOTICE("\The [user] deconstructs \the [machine]."))

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -158,6 +158,10 @@
 	if (href_list["make"])
 		if (src.get_amount() < 1) qdel(src) //Never should happen
 
+		if(usr.loc.isProtected(usr))
+			to_chat(usr, SPAN_WARNING("This area is protected and cannot be built in."))
+			return
+
 		var/list/recipes_list = recipes
 		if (href_list["sublist"])
 			var/datum/stack_recipe_list/srl = recipes_list[text2num(href_list["sublist"])]

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -17,6 +17,9 @@
 	if(!(isScrewdriver(C) && flooring && (flooring.flags & TURF_REMOVE_SCREWDRIVER)) && try_graffiti(user, C))
 		return TRUE
 
+	if(isProtected(user))
+		return
+
 	if(flooring)
 		if(isCrowbar(C) && user.a_intent != I_HURT)
 			if(broken || burnt)

--- a/code/game/turfs/simulated/floor_damage.dm
+++ b/code/game/turfs/simulated/floor_damage.dm
@@ -7,6 +7,8 @@
 	break_tile()
 
 /turf/simulated/floor/proc/break_tile()
+	if(isProtected())
+		return
 	if(!flooring || !(flooring.flags & TURF_CAN_BREAK) || !isnull(broken))
 		return
 	if(flooring.has_damage_range)
@@ -17,6 +19,8 @@
 	update_icon()
 
 /turf/simulated/floor/proc/burn_tile(var/exposed_temperature)
+	if(isProtected())
+		return
 	if(!flooring || !(flooring.flags & TURF_CAN_BURN) || !isnull(burnt))
 		return
 	if(flooring.has_burn_range)

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -170,6 +170,10 @@
 				take_damage(-damage)
 		return TRUE
 
+	if(isProtected(user))
+		to_chat(user, SPAN_WARNING("This cannot be deconstructed while in a safe-zone."))
+		return
+
 	// Basic dismantling.
 	if(isnull(construction_stage) || !reinf_material)
 

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -146,11 +146,15 @@
 			visible_message(SPAN_DANGER("\The [src] spontaneously combusts!"))
 
 /turf/simulated/wall/proc/take_damage(dam)
+	if(isProtected())
+		return
 	if(dam)
 		damage = max(0, damage + dam)
 		update_damage()
 
 /turf/simulated/wall/proc/update_damage()
+	if(isProtected())
+		return
 	var/cap = material.integrity
 	if(reinf_material)
 		cap += reinf_material.integrity
@@ -223,6 +227,8 @@
 		new/obj/effect/overlay/wallrot(src)
 
 /turf/simulated/wall/proc/can_melt()
+	if(isProtected())
+		return 0
 	if(material.flags & MAT_FLAG_UNMELTABLE)
 		return 0
 	return 1
@@ -236,6 +242,8 @@
 	return total_radiation
 
 /turf/simulated/wall/proc/burn(temperature)
+	if(isProtected())
+		return
 	if(material.combustion_effect(src, temperature, 0.7))
 		spawn(2)
 			for(var/turf/simulated/wall/W in range(3,src))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -91,6 +91,9 @@
 /turf/attack_hand(mob/user)
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 
+	if(isProtected(user))
+		return 0
+
 	if(user.restrained())
 		return 0
 

--- a/code/modules/materials/_stack_recipe.dm
+++ b/code/modules/materials/_stack_recipe.dm
@@ -65,13 +65,17 @@
 	return O
 
 /datum/stack_recipe/proc/can_make(mob/user)
+	if(user.loc.isProtected(user))
+		to_chat(user, SPAN_WARNING("This area is protected and cannot be built in."))
+		return FALSE
+
 	if (one_per_turf && (locate(result_type) in user.loc))
-		to_chat(user, "<span class='warning'>There is another [display_name()] here!</span>")
+		to_chat(user, SPAN_WARNING("There is another [display_name()] here!"))
 		return FALSE
 
 	var/turf/T = get_turf(user.loc)
 	if (on_floor && !T.is_floor())
-		to_chat(user, "<span class='warning'>\The [display_name()] must be constructed on the floor!</span>")
+		to_chat(user, SPAN_WARNING("\The [display_name()] must be constructed on the floor!"))
 		return FALSE
 
 	return TRUE

--- a/nebula.dme
+++ b/nebula.dme
@@ -117,6 +117,7 @@
 #include "code\_helpers\medical_scans.dm"
 #include "code\_helpers\mobs.dm"
 #include "code\_helpers\names.dm"
+#include "code\_helpers\protection.dm"
 #include "code\_helpers\sanitize_values.dm"
 #include "code\_helpers\spawn_sync.dm"
 #include "code\_helpers\storage.dm"


### PR DESCRIPTION
* Walls cannot be constructed/deconstructed in /area/protected where safe_zone is true
* Same for walls
* Same for anything made from a stack out of hand.
* Same for floors.
* Walls, floors, etc are all immune to damage. Machines cannot be deconstructed.

Anti-griefing tool. Could be used for timeout zones or something on a round-based server.