### PR TITLE
alternate try at providing modularity to unique ids.

### DIFF
--- a/code/__defines/computers.dm
+++ b/code/__defines/computers.dm
@@ -1,5 +1,4 @@
-#define RANDBYTE  num2hex(rand(1,255))
-#define NETWORK_MAC   "[RANDBYTE]-[RANDBYTE]-[RANDBYTE]-[RANDBYTE]"
+#define NETWORK_MAC  uniqueness_repository.Generate(/datum/uniqueness_generator/hex)
 									// Network allowed actions
 #define NETWORK_SOFTWAREDOWNLOAD 	1 	// Downloads of software
 #define NETWORK_COMMUNICATION 		2	// Communication (messaging)

--- a/code/datums/repositories/unique.dm
+++ b/code/datums/repositories/unique.dm
@@ -1,3 +1,5 @@
+#define RANDBYTE  num2hex(rand(1,255))
+
 var/repository/unique/uniqueness_repository = new()
 
 /repository/unique
@@ -19,6 +21,9 @@ var/repository/unique/uniqueness_repository = new()
 
 /datum/uniqueness_generator/proc/Generate()
 	return
+
+/datum/uniqueness_generator/hex/Generate()
+	return "[RANDBYTE]-[RANDBYTE]-[RANDBYTE]-[RANDBYTE]"
 
 /datum/uniqueness_generator/id_sequential
 	var/list/ids_by_key

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -162,7 +162,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 	securityCaster = istype(get_area(src), /area/security)
 	allCasters += src
 	paper_remaining = 15            // Will probably change this to something better
-	unit_no = sequential_id("obj/machinery/newscaster")
+	unit_no = "[sequential_id("obj/machinery/newscaster")]"
 	queue_icon_update()
 
 /obj/machinery/newscaster/Destroy()

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -244,7 +244,7 @@
 
 /obj/machinery/atmospherics/unary/vent_pump/Initialize()
 	if (!id_tag)
-		id_tag = num2text(sequential_id("obj/machinery"))
+		id_tag = "[sequential_id("obj/machinery")]"
 	if(controlled)
 		var/area/A = get_area(src)
 		if(A && !A.air_vent_names[id_tag])

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -103,7 +103,7 @@
 
 /obj/machinery/atmospherics/unary/vent_scrubber/Initialize()
 	if (!id_tag)
-		id_tag = num2text(sequential_id("obj/machinery"))
+		id_tag = "[sequential_id("obj/machinery")]"
 	if(!scrubbing_gas)
 		scrubbing_gas = list()
 		for(var/g in SSmaterials.all_gasses)

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -67,7 +67,7 @@
 
 	update_growth_stages()
 
-	uid = sequential_id(/datum/seed/)
+	uid = "[sequential_id(/datum/seed/)]"
 
 /datum/seed/proc/get_trait(var/trait)
 	return traits["[trait]"]

--- a/code/modules/modular_computers/networking/device_types/_network_device.dm
+++ b/code/modules/modular_computers/networking/device_types/_network_device.dm
@@ -16,7 +16,7 @@
 		connection_type = c_type
 	address = uppertext(NETWORK_MAC)
 	var/obj/O = holder
-	network_tag = "[uppertext(replacetext(O.name, " ", "_"))]-[num2hex(sequential_id(type))]"
+	network_tag = "[uppertext(replacetext(O.name, " ", "_"))]-[sequential_id(type)]"
 	if(autojoin)
 		if(network_id)
 			connect()

--- a/code/modules/species/species_getters.dm
+++ b/code/modules/species/species_getters.dm
@@ -33,7 +33,7 @@
 
 /datum/species/proc/get_icon_cache_uid(var/mob/H)
 	if(!icon_cache_uid)
-		icon_cache_uid = sequential_id(/datum/species)
+		icon_cache_uid = "[sequential_id(/datum/species)]"
 	return icon_cache_uid
 
 /datum/species/proc/get_bodytype(var/mob/living/carbon/human/H)


### PR DESCRIPTION
lets modders or downstreams determine how things are generated by overriding uniqueness_generator. assumes all things returned will be strings.