### PR TITLE
Material armor

### DIFF
--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -49,6 +49,7 @@
 	var/slowdown_per_slot[slot_last] // How much clothing is slowing you down. This is an associative list: item slot - slowdown
 	var/slowdown_accessory // How much an accessory will slow you down when attached to a worn article of clothing.
 	var/canremove = 1 //Mostly for Ninja code at this point but basically will not allow the item to be removed if set to 0. /N
+	var/material_armor_multiplier  // if set, item will use material's armor values multiplied by this.
 	var/armor_type = /datum/extension/armor
 	var/list/armor
 	var/armor_degradation_speed //How fast armor will degrade, multiplier to blocked damage to get armor damage value.

--- a/code/game/objects/item_materials.dm
+++ b/code/game/objects/item_materials.dm
@@ -72,4 +72,11 @@
 		update_force()
 		if(applies_material_name)
 			SetName("[material.display_name] [initial(name)]")
+		if(material_armor_multiplier)
+			armor = material.get_armor(material_armor_multiplier)
+			armor_degradation_speed = material.armor_degradation_speed
+			if(length(armor))
+				set_extension(src, armor_type, armor, armor_degradation_speed)
+			else
+				remove_extension(src, armor_type)
 	queue_icon_update()

--- a/code/modules/clothing/shoes/craftable.dm
+++ b/code/modules/clothing/shoes/craftable.dm
@@ -10,6 +10,7 @@
 	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
 	heat_protection = FEET
 	max_heat_protection_temperature = SHOE_MAX_HEAT_PROTECTION_TEMPERATURE
+	material_armor_multiplier = 1
 
 /obj/item/clothing/shoes/craftable/boots
 	name = "boots"

--- a/code/modules/clothing/suits/crafted/_armour.dm
+++ b/code/modules/clothing/suits/crafted/_armour.dm
@@ -1,6 +1,3 @@
-#define CRAFTED_ARMOR_DIVISOR 2
-#define BASIC_ARMOUR_VALUES list(melee = ARMOR_MELEE_MAJOR, bullet = ARMOR_BALLISTIC_RESISTANT, laser = ARMOR_LASER_RIFLES, energy = ARMOR_ENERGY_STRONG, bomb = ARMOR_BOMB_RESISTANT,rad  = ARMOR_RAD_RESISTANT)
-
 // Other armour icons: soft_armour, medium_armour, heavy_armour
 /obj/item/clothing/suit/armor/crafted
 	name = "improvised armour"
@@ -9,15 +6,13 @@
 	applies_material_name = TRUE
 	icon_state = "improvised_armour"
 	material = MAT_STEEL
-	gender = PLURAL
-	armor = BASIC_ARMOUR_VALUES
 	armor_degradation_speed = 1
 	armor_type = /datum/extension/armor/ablative
+	material_armor_multiplier = 1
 
 /obj/item/clothing/suit/armor/crafted/set_material(new_material)
 	. = ..()
 	update_strings()
-	update_armour_values()
 
 /obj/item/clothing/suit/armor/crafted/proc/update_strings()
 	if(material)
@@ -26,29 +21,6 @@
 	else
 		name = initial(name)
 		desc = initial(desc)
-
-/obj/item/clothing/suit/armor/crafted/proc/update_armour_values()
-	armor = BASIC_ARMOUR_VALUES
-	armor_degradation_speed = initial(armor_degradation_speed)
-	if(material.is_brittle())
-		armor_degradation_speed = 10
-	else
-		armor_degradation_speed = max(0.1, 200-(material.integrity/200))
-	for(var/val in list("melee", "bullet", "bomb"))
-		if(armor[val])
-			armor[val] *= (material.hardness/100)
-	for(var/val in list("laser", "energy", "rad"))
-		if(armor[val])
-			armor[val] *= (material.reflectiveness/100)
-	var/set_armour
-	if(LAZYLEN(armor))
-		for(var/val in armor)
-			if(armor[val])
-				set_armour = TRUE
-				set_extension(src, armor_type, armor, armor_degradation_speed)
-				break
-	if(!set_armour)
-		remove_extension(src, armor_type)
 
 /obj/item/clothing/suit/armor/crafted/cardboard
 	material = MAT_CARDBOARD
@@ -62,6 +34,3 @@
 	material = MAT_GOLD
 /obj/item/clothing/suit/armor/crafted/supermatter
 	material = MAT_SUPERMATTER
-
-#undef CRAFTED_ARMOR_DIVISOR
-#undef BASIC_ARMOUR_VALUES

--- a/code/modules/clothing/under/accessories/cloaks.dm
+++ b/code/modules/clothing/under/accessories/cloaks.dm
@@ -138,6 +138,9 @@
 	material = MAT_LEATHER_GENERIC
 	applies_material_colour = TRUE
 	applies_material_name = TRUE
+	armor_type = /datum/extension/armor/ablative
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+	material_armor_multiplier = 0.5
 
 /obj/item/clothing/accessory/cloak/hide/set_material(var/new_material)
 	..()

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -160,6 +160,10 @@
 	var/gas_tile_overlay =       "generic"
 	var/gas_condensation_point = INFINITY
 
+	// Armor values generated from properties
+	var/list/basic_armor
+	var/armor_degradation_speed
+
 // Placeholders for light tiles and rglass.
 /material/proc/reinforce(var/mob/user, var/obj/item/stack/material/used_stack, var/obj/item/stack/material/target_stack)
 	if(!used_stack.can_use(1))
@@ -210,6 +214,7 @@
 		shard_icon = shard_type
 	if(!burn_armor)
 		burn_armor = brute_armor
+	generate_armor_values()
 
 // Return the matter comprising this material.
 /material/proc/get_matter()

--- a/code/modules/materials/definitions/materials_organic.dm
+++ b/code/modules/materials/definitions/materials_organic.dm
@@ -66,6 +66,8 @@
 	hidden_from_codex = TRUE
 	construction_difficulty = MAT_VALUE_NORMAL_DIY
 	reflectiveness = MAT_VALUE_DULL
+	hardness = MAT_VALUE_SOFT
+	weight = MAT_VALUE_EXTREMELY_LIGHT
 	wall_support_value = 0
 
 /material/cloth/yellow
@@ -121,6 +123,8 @@
 	stack_type = null
 	construction_difficulty = MAT_VALUE_NORMAL_DIY
 	reflectiveness = MAT_VALUE_DULL
+	hardness = MAT_VALUE_SOFT
+	weight = MAT_VALUE_EXTREMELY_LIGHT
 	wall_support_value = 0
 	hidden_from_codex = TRUE
 

--- a/code/modules/materials/material_armor.dm
+++ b/code/modules/materials/material_armor.dm
@@ -1,0 +1,40 @@
+#define BASIC_ARMOUR_VALUES list(melee = ARMOR_MELEE_MAJOR, bullet = ARMOR_BALLISTIC_RIFLE, laser = ARMOR_LASER_HEAVY, energy = ARMOR_ENERGY_STRONG, bomb = ARMOR_BOMB_RESISTANT,rad  = ARMOR_RAD_SHIELDED)
+
+/material/proc/generate_armor_values()
+	if(is_brittle())
+		armor_degradation_speed = 1
+	else
+		armor_degradation_speed = max(0.01, 0.5 * (200-integrity)/200)
+
+	var/list/armor = BASIC_ARMOUR_VALUES
+	for(var/val in list("melee", "bomb"))
+		armor[val] *= hardness / 100
+	armor["bomb"] *= weight / MAT_VALUE_NORMAL
+	armor["bullet"] *= (hardness / 100) ** 2
+	if(is_brittle())
+		armor["bullet"] *= 0.2
+	armor["laser"] *= (reflectiveness / 100) ** 2
+	armor["energy"] *= reflectiveness / 100
+	armor["rad"] *= (weight / 100) ** 2
+
+	//Sanitizing the list, rounding and discarding empty entries
+	for(var/val in armor)
+		armor[val] = round(armor[val], 3)
+		if(armor[val] < 1)
+			armor -= val
+
+	basic_armor = armor
+
+/material/proc/get_armor(coef=1)
+	if(!length(basic_armor))
+		return list()
+	var/list/armor = basic_armor.Copy()
+	if(coef == 1)
+		return armor
+	for(var/val in armor)
+		armor[val] = round(coef * armor[val], 3)
+		if(armor[val] < 1)
+			armor -= val
+	return armor
+
+#undef BASIC_ARMOUR_VALUES

--- a/nebula.dme
+++ b/nebula.dme
@@ -1913,6 +1913,7 @@
 #include "code\modules\maps\ruins.dm"
 #include "code\modules\materials\_materials.dm"
 #include "code\modules\materials\_stack_recipe.dm"
+#include "code\modules\materials\material_armor.dm"
 #include "code\modules\materials\material_recipes.dm"
 #include "code\modules\materials\material_sheets.dm"
 #include "code\modules\materials\material_synth.dm"


### PR DESCRIPTION
Materials now generate platonic 'armor values' based on their properties.
Items can opt to pull armor values from their material with a given multiplier to values (for things taht shouldn't be as protective as a suit of armor)
Makes crafted boots use it and cloaks (half armor).

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->