### PR TITLE
Adds SScomputer_networks for queueing connecttions

### DIFF
--- a/code/__defines/subsystem-priority.dm
+++ b/code/__defines/subsystem-priority.dm
@@ -45,6 +45,7 @@
 #define SS_PRIORITY_CIRCUIT       30   // Processing Circuit's ticks and all that
 #define SS_PRIORITY_GRAPH         30   // Merging and splitting of graphs
 #define SS_PRIORITY_CHAR_SETUP    25   // Writes player preferences to savefiles.
+#define SS_PRIORITY_COMPUTER_NETS 25   // Handles computer network devices hookups
 #define SS_PRIORITY_GARBAGE       20   // Garbage collection.
 
 

--- a/code/controllers/subsystems/initialization/computer_networks.dm
+++ b/code/controllers/subsystems/initialization/computer_networks.dm
@@ -1,0 +1,36 @@
+SUBSYSTEM_DEF(networking)
+	name = "Computer Networks"
+	priority = SS_PRIORITY_COMPUTER_NETS
+	flags = SS_BACKGROUND | SS_NO_INIT
+	wait = 2 SECOND
+	runlevels = RUNLEVEL_INIT | RUNLEVELS_DEFAULT
+
+	var/list/networks = list()
+	var/list/connection_queue = list()
+	var/list/tmp_queue = list()
+
+/datum/controller/subsystem/networking/fire(resumed = FALSE)
+	if(!resumed)
+		tmp_queue = connection_queue.Copy()
+		connection_queue = list()
+	while(tmp_queue.len)
+		var/datum/extension/network_device/device = tmp_queue[tmp_queue.len]
+		tmp_queue.len--
+
+		if(!QDELETED(device))
+			var/connected
+			if(device.network_id)
+				connected = device.connect()
+			else
+				connected = device.connect_to_any()
+			if(!connected)
+				connection_queue += device
+
+		if(MC_TICK_CHECK)
+			return
+
+/datum/controller/subsystem/networking/stat_entry()
+	..("[length(networks)] network\s, [length(connection_queue)] connection\s queued")
+
+/datum/controller/subsystem/networking/proc/queue_connection(var/datum/extension/network_device/device)
+	connection_queue |= device

--- a/code/modules/modular_computers/networking/_network.dm
+++ b/code/modules/modular_computers/networking/_network.dm
@@ -1,5 +1,3 @@
-GLOBAL_LIST_EMPTY(computer_networks)
-
 /datum/computer_network
 	var/network_id
 	var/network_key
@@ -26,7 +24,7 @@ GLOBAL_LIST_EMPTY(computer_networks)
 	if(!new_id)
 		new_id = "network[random_id(type, 100,999)]"
 	network_id = new_id
-	GLOB.computer_networks[network_id] = src
+	SSnetworking.networks[network_id] = src
 
 /datum/computer_network/Destroy()
 	for(var/datum/extension/network_device/D in devices)
@@ -34,7 +32,7 @@ GLOBAL_LIST_EMPTY(computer_networks)
 	QDEL_NULL_LIST(chat_channels)
 	devices = null
 	mainframes = null
-	GLOB.computer_networks -= network_id
+	SSnetworking.networks -= network_id
 	. = ..()
 
 /datum/computer_network/proc/add_device(datum/extension/network_device/D)
@@ -144,10 +142,10 @@ GLOBAL_LIST_EMPTY(computer_networks)
 	for(var/datum/extension/network_device/D in devices)
 		if(D.network_id != new_id)
 			D.network_id = new_id
-	GLOB.computer_networks -= network_id
+	SSnetworking.networks -= network_id
 	add_log("Network ID was changed from '[network_id]' to '[new_id]'")
 	network_id = new_id
-	GLOB.computer_networks[network_id] = src
+	SSnetworking.networks[network_id] = src
 
 /datum/computer_network/proc/enable_network_feature(feature)
 	network_features_enabled |= feature
@@ -181,8 +179,8 @@ GLOBAL_LIST_EMPTY(computer_networks)
 
 // TODO: Some way to set what network it should be, based on map vars or overmap vars
 /proc/get_local_network_at(turf/T)
-	for(var/id in GLOB.computer_networks)
-		var/datum/computer_network/net = GLOB.computer_networks[id]
+	for(var/id in SSnetworking.networks)
+		var/datum/computer_network/net = SSnetworking.networks[id]
 		if(net.router && ARE_Z_CONNECTED(get_z(net.router.holder), get_z(T)))
 			return net
 

--- a/code/modules/modular_computers/networking/device_types/_network_device.dm
+++ b/code/modules/modular_computers/networking/device_types/_network_device.dm
@@ -18,29 +18,26 @@
 	var/obj/O = holder
 	network_tag = "[uppertext(replacetext(O.name, " ", "_"))]-[sequential_id(type)]"
 	if(autojoin)
-		if(network_id)
-			connect()
-		else
-			connect_to_any()
+		SSnetworking.queue_connection(src)
 	
 /datum/extension/network_device/Destroy()
 	disconnect()
 	. = ..()
 
 /datum/extension/network_device/proc/connect()
-	var/datum/computer_network/net = GLOB.computer_networks[network_id]
+	var/datum/computer_network/net = SSnetworking.networks[network_id]
 	if(!net)
 		return FALSE
 	return net.add_device(src)
 
 /datum/extension/network_device/proc/disconnect()
-	var/datum/computer_network/net = GLOB.computer_networks[network_id]
+	var/datum/computer_network/net = SSnetworking.networks[network_id]
 	if(!net)
 		return FALSE
 	return net.remove_device(src)
 
 /datum/extension/network_device/proc/check_connection(specific_action)
-	var/datum/computer_network/net = GLOB.computer_networks[network_id]
+	var/datum/computer_network/net = SSnetworking.networks[network_id]
 	if(!net)
 		return FALSE
 	if(!net.check_connection(src, specific_action) || !net.add_device(src))
@@ -61,8 +58,8 @@
 
 /datum/extension/network_device/proc/get_nearby_networks()
 	var/list/networks = list()
-	for(var/id in GLOB.computer_networks)
-		var/datum/computer_network/net = GLOB.computer_networks[id]
+	for(var/id in SSnetworking.networks)
+		var/datum/computer_network/net = SSnetworking.networks[id]
 		if(net.check_connection(src))
 			networks |= id
 	return networks
@@ -75,7 +72,7 @@
 
 /datum/extension/network_device/proc/get_network()
 	if(check_connection())
-		return GLOB.computer_networks[network_id]
+		return SSnetworking.networks[network_id]
 
 /datum/extension/network_device/proc/add_log(text)
 	var/datum/computer_network/net = get_network()
@@ -88,7 +85,7 @@
 	for(var/net in nets)
 		network_id = net
 		if(connect())
-			return
+			return TRUE
 
 /datum/extension/network_device/proc/can_interact(user)
 	return holder.CanUseTopic(user) == STATUS_INTERACTIVE

--- a/code/modules/modular_computers/networking/device_types/mainframe.dm
+++ b/code/modules/modular_computers/networking/device_types/mainframe.dm
@@ -14,7 +14,7 @@ GLOBAL_LIST_INIT(all_mainframe_roles, list(MF_ROLE_SOFTWARE, MF_ROLE_FILESERVER,
 	update_roles()
 
 /datum/extension/network_device/mainframe/proc/update_roles()
-	var/datum/computer_network/net = GLOB.computer_networks[network_id]
+	var/datum/computer_network/net = SSnetworking.networks[network_id]
 	if(!net)
 		return FALSE
 	if(!check_connection())

--- a/code/modules/modular_computers/networking/device_types/relay.dm
+++ b/code/modules/modular_computers/networking/device_types/relay.dm
@@ -5,10 +5,10 @@
 
 /datum/extension/network_device/broadcaster/relay/get_nearby_networks()
 	if(long_range)
-		return GLOB.computer_networks
+		return SSnetworking.networks
 	var/list/networks = list()
-	for(var/network_id in GLOB.computer_networks)
-		var/datum/computer_network/network = GLOB.computer_networks[network_id]
+	for(var/network_id in SSnetworking.networks)
+		var/datum/computer_network/network = SSnetworking.networks[network_id]
 		var/list/broadcasters = network.relays + network.router
 		for(var/datum/extension/network_device/D in broadcasters)
 			if(ARE_Z_CONNECTED(get_z(D.holder), get_z(holder)))
@@ -17,7 +17,7 @@
 	return networks
 
 /datum/extension/network_device/broadcaster/relay/connect()
-	var/datum/computer_network/net = GLOB.computer_networks[network_id]
+	var/datum/computer_network/net = SSnetworking.networks[network_id]
 	if(!net)
 		return FALSE
 	if(!long_range && !(network_id in get_nearby_networks()))

--- a/code/modules/modular_computers/networking/device_types/router.dm
+++ b/code/modules/modular_computers/networking/device_types/router.dm
@@ -7,28 +7,28 @@
 	broadcast()
 
 /datum/extension/network_device/broadcaster/router/proc/broadcast()
-	var/datum/computer_network/net = GLOB.computer_networks[network_id]
+	var/datum/computer_network/net = SSnetworking.networks[network_id]
 	if(!net)
 		net = new(network_id)
 	if(!net.router)
 		net.set_router(src)
 
 /datum/extension/network_device/broadcaster/router/proc/is_router()
-	var/datum/computer_network/net = GLOB.computer_networks[network_id]
+	var/datum/computer_network/net = SSnetworking.networks[network_id]
 	if(!net)
 		return FALSE
 	return (net.router == src)
 
 /datum/extension/network_device/broadcaster/router/set_new_id(new_id, user)
 	if(is_router())
-		var/datum/computer_network/net = GLOB.computer_networks[network_id]
+		var/datum/computer_network/net = SSnetworking.networks[network_id]
 		net.change_id(new_id)
 		to_chat(user, SPAN_NOTICE("Network '[network_id]' ID changed to '[new_id]'."))
 		network_id = new_id
 	else
 		network_id = new_id
 		broadcast()
-		var/datum/computer_network/net = GLOB.computer_networks[network_id]
+		var/datum/computer_network/net = SSnetworking.networks[network_id]
 		if(net.router == src)
 			to_chat(user, SPAN_NOTICE("Hosting the network '[network_id]'."))
 		else
@@ -36,7 +36,7 @@
 
 /datum/extension/network_device/broadcaster/router/set_new_key(new_key, user)
 	if(is_router())
-		var/datum/computer_network/net = GLOB.computer_networks[network_id]
+		var/datum/computer_network/net = SSnetworking.networks[network_id]
 		key = new_key
 		net.network_key = new_key
 		to_chat(user, SPAN_NOTICE("Network '[network_id]' key changed to '[new_key]'."))

--- a/code/modules/modular_computers/networking/machinery/_network_machine.dm
+++ b/code/modules/modular_computers/networking/machinery/_network_machine.dm
@@ -8,7 +8,6 @@
 
 	var/initial_network_id
 	var/initial_network_key
-	var/lateload
 	var/produces_heat = TRUE		// If true, produces and is affected by heat.
 	var/inefficiency = 0.12			// How much power is waste heat.
 	var/heat_threshold = 90 CELSIUS	// At what temperature the machine will lock up.
@@ -16,10 +15,8 @@
 	var/runtimeload // Use this for calling an even later lateload.
 
 /obj/machinery/network/Initialize()
-	set_extension(src, network_device_type, initial_network_id, initial_network_key, NETWORK_CONNECTION_WIRED, !lateload)
+	set_extension(src, network_device_type, initial_network_id, initial_network_key, NETWORK_CONNECTION_WIRED)
 	. = ..()
-	if(lateload)
-		return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/network/proc/is_overheated()
 	var/turf/simulated/L = loc

--- a/code/modules/modular_computers/networking/machinery/mainframe.dm
+++ b/code/modules/modular_computers/networking/machinery/mainframe.dm
@@ -4,7 +4,6 @@
 	icon_state = "server"
 	network_device_type =  /datum/extension/network_device/mainframe
 	main_template = "network_mainframe.tmpl"
-	lateload = TRUE
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
@@ -17,11 +16,10 @@
 		MF_ROLE_SOFTWARE
 		)
 
-/obj/machinery/network/mainframe/LateInitialize()
+/obj/machinery/network/mainframe/Initialize()
 	. = ..()
 	var/datum/extension/network_device/mainframe/M = get_extension(src, /datum/extension/network_device)
 	M.roles |= initial_roles
-	M.connect() || M.connect_to_any()
 
 /obj/machinery/network/mainframe/ui_data(mob/user, ui_key)
 	var/data = ..()

--- a/code/modules/modular_computers/networking/machinery/relay.dm
+++ b/code/modules/modular_computers/networking/machinery/relay.dm
@@ -8,21 +8,6 @@
 	base_type = /obj/machinery/network/relay
 	produces_heat = FALSE // for convenience
 
-/obj/machinery/network/relay/Initialize()
-	if(!initial_network_id)
-		initial_network_id = "network[random_id(type, 100, 999)]"
-	. = ..()
-
-/obj/machinery/network/relay/ui_data(mob/user, ui_key)
-	var/data = ..()
-	var/datum/extension/network_device/broadcaster/relay/R = get_extension(src, /datum/extension/network_device)
-	if(!istype(R))
-		return data
-	var/datum/computer_network/net = R.get_network()
-	if(net)
-		data["is_router"] = FALSE
-	return data
-
 /obj/machinery/network/relay/on_update_icon()
 	if(operable())
 		icon_state = panel_open ? "relay_o" : "relay"

--- a/nebula.dme
+++ b/nebula.dme
@@ -221,6 +221,7 @@
 #include "code\controllers\subsystems\zcopy.dm"
 #include "code\controllers\subsystems\initialization\character_setup.dm"
 #include "code\controllers\subsystems\initialization\codex.dm"
+#include "code\controllers\subsystems\initialization\computer_networks.dm"
 #include "code\controllers\subsystems\initialization\cuisine.dm"
 #include "code\controllers\subsystems\initialization\customitems.dm"
 #include "code\controllers\subsystems\initialization\fabrication.dm"


### PR DESCRIPTION
Final solution to the init racing we've been having with routers-relays-devices.
Now devices queue themselves in SS, and SS will try to hook them up with their desired network every once in a while.
Most of diff is just renaming of global list to ss network list
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->