### PR TITLE
Creates network extension before rest of machine init

### DIFF
--- a/code/modules/modular_computers/networking/machinery/_network_machine.dm
+++ b/code/modules/modular_computers/networking/machinery/_network_machine.dm
@@ -16,8 +16,8 @@
 	var/runtimeload // Use this for calling an even later lateload.
 
 /obj/machinery/network/Initialize()
-	. = ..()
 	set_extension(src, network_device_type, initial_network_id, initial_network_key, NETWORK_CONNECTION_WIRED, !lateload)
+	. = ..()
 	if(lateload)
 		return INITIALIZE_HINT_LATELOAD
 


### PR DESCRIPTION
Prevents runtime when power components starts inititing and jigging power.
Extension itself doesn't really care about components etc so should be okay

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->