### PR TITLE
Removes runtime caused by null lists in english_lists

### DIFF
--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -11,7 +11,7 @@
 
 //Returns a list in plain english as a string
 /proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "," )
-	switch(input.len)
+	switch(length(input))
 		if(0) return nothing_text
 		if(1) return "[input[1]]"
 		if(2) return "[input[1]][and_text][input[2]]"


### PR DESCRIPTION
Null lists are common due to LAZYLIST usage
Dedicated to Alex6511