### PR TITLE
Removes a master item from casino

### DIFF
--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -3110,7 +3110,7 @@
 /obj/structure/bed/chair/comfy/red{
 	dir = 4
 	},
-/obj/item/material/knife,
+/obj/item/material/knife/combat,
 /turf/simulated/floor/carpet,
 /area/casino/casino_mainfloor)
 "iq" = (


### PR DESCRIPTION
This item is not supposed to be mapped, per its in-game description.

~Note the casino doesn't currently compile but that wasn't me.~
Just kidding it's in the unit tests