### PR TITLE
Shuttle landing overhaul

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -48,6 +48,7 @@
 #define SHUTTLE_IDLE      0
 #define SHUTTLE_WARMUP    1
 #define SHUTTLE_INTRANSIT 2
+#define SHUTTLE_FREEFALL  3
 
 // Autodock shuttle processing status.
 #define IDLE_STATE   0

--- a/code/controllers/subsystems/shuttle.dm
+++ b/code/controllers/subsystems/shuttle.dm
@@ -148,3 +148,8 @@ SUBSYSTEM_DEF(shuttle)
 
 /datum/controller/subsystem/shuttle/stat_entry()
 	..("Shuttles:[shuttles.len], Ships:[ships.len], L:[registered_shuttle_landmarks.len][overmap_halted ? ", HALT" : ""]")
+
+/datum/controller/subsystem/shuttle/proc/get_ship_by_shuttle(var/datum/shuttle/S)
+	for(var/obj/effect/overmap/visitable/ship/landable/ship in ships)
+		if(ship.shuttle == S.name)
+			return ship

--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -71,6 +71,10 @@
 	var/list/possible_features = list()
 	var/list/spawned_features
 
+	//Details regarding flight characteristics of the planet.
+	var/planet_radius
+	var/gravity
+
 	var/habitability_class	// if it's above bad, atmosphere will be adjusted to be better for humans (no extreme temps / oxygen to breathe)
 
 /obj/effect/overmap/visitable/sector/exoplanet/Initialize(mapload, z_level)
@@ -92,6 +96,11 @@
 		themes += new T
 		possible_themes -= T
 	name = "[generate_planet_name()], \a [name]"
+
+	if(!planet_radius)
+		planet_radius = rand(0.5, 2.5)
+	if(!gravity)
+		gravity = planet_radius * rand(3, 5) + 2
 
 	generate_habitability()
 	generate_atmosphere()

--- a/code/modules/overmap/overmap_object.dm
+++ b/code/modules/overmap/overmap_object.dm
@@ -30,6 +30,9 @@
 
 	if(requires_contact)
 		invisibility = INVISIBILITY_OVERMAP // Effects that require identification have their images cast to the client via sensors.
+
+	if(!color) // color is required. choose a random one if none chosen.
+		color = get_random_colour()
 	update_icon()
 
 /obj/effect/overmap/Crossed(var/obj/effect/overmap/visitable/other)

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -101,6 +101,9 @@
 /obj/effect/overmap/visitable/proc/generate_skybox()
 	return
 
+/obj/effect/overmap/visitable/proc/is_planet()
+	return istype(src, /obj/effect/overmap/visitable/sector/exoplanet)
+
 /obj/effect/overmap/visitable/sector
 	name = "generic sector"
 	desc = "Sector with some stuff in it."

--- a/code/modules/overmap/ships/computers/shuttle.dm
+++ b/code/modules/overmap/ships/computers/shuttle.dm
@@ -11,22 +11,26 @@
 /obj/machinery/computer/shuttle_control/explore/get_ui_data(var/datum/shuttle/autodock/overmap/shuttle)
 	. = ..()
 	if(istype(shuttle))
-		var/total_gas = 0
-		for(var/obj/structure/fuel_port/FP in shuttle.fuel_ports) //loop through fuel ports
-			var/obj/item/tank/fuel_tank = locate() in FP
-			if(fuel_tank)
-				total_gas += fuel_tank.air_contents.total_moles
+		var/delta_v
+		var/delta_v_budget
+
+		var/obj/effect/overmap/visitable/ship/ship = SSshuttle.get_ship_by_shuttle(shuttle)
+		if(istype(ship))
+			delta_v = ship.get_delta_v()
+			delta_v_budget = ship.get_delta_v_budget(shuttle.next_location)
 
 		var/fuel_span = "good"
-		if(total_gas < shuttle.fuel_consumption * 2)
+		if(delta_v < delta_v_budget * 1.4)
 			fuel_span = "bad"
 
 		. += list(
 			"destination_name" = shuttle.get_destination_name(),
 			"can_pick" = shuttle.moving_status == SHUTTLE_IDLE,
-			"fuel_usage" = shuttle.fuel_consumption * 100,
-			"remaining_fuel" = round(total_gas, 0.01) * 100,
-			"fuel_span" = fuel_span
+			"delta_v_budget" = delta_v_budget,
+			"delta_v" = delta_v,
+			"total_delta_v" = delta_v * 10,
+			"fuel_span" = fuel_span,
+			"is_ship" = istype(ship)
 		)
 
 /obj/machinery/computer/shuttle_control/explore/handle_topic_href(var/datum/shuttle/autodock/overmap/shuttle, var/list/href_list, var/mob/user)

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -231,7 +231,8 @@ var/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 	if (world.time < last_burn + burn_delay)
 		return 0
 	for(var/datum/extension/ship_engine/E in engines)
-		. |= E.can_burn()
+		if(E.can_burn())
+			return TRUE // If even one engine can burn, we can burn.
 
 //deciseconds to next step
 /obj/effect/overmap/visitable/ship/proc/ETA()

--- a/code/modules/shuttles/shuttle_autodock.dm
+++ b/code/modules/shuttles/shuttle_autodock.dm
@@ -145,6 +145,9 @@
 /datum/shuttle/autodock/proc/can_cancel()
 	return (moving_status == SHUTTLE_WARMUP || process_state == WAIT_LAUNCH || process_state == FORCE_LAUNCH)
 
+/datum/shuttle/autodock/proc/can_resume()
+	return (moving_status == SHUTTLE_FREEFALL && next_location.is_valid(src))
+
 /*
 	"Public" procs
 */

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -49,6 +49,7 @@
 		"can_launch" = shuttle.can_launch(),
 		"can_cancel" = shuttle.can_cancel(),
 		"can_force" = shuttle.can_force(),
+		"can_resume" = shuttle.can_resume(),
 		"docking_codes" = shuttle.docking_codes
 	)
 
@@ -99,7 +100,7 @@
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, ui_template, "[shuttle_tag] Shuttle Control", 470, 450)
+		ui = new(user, src, ui_key, ui_template, "[shuttle_tag] Shuttle Control", 470, 500)
 		ui.set_initial_data(data)
 		ui.open()
 		ui.set_auto_update(1)

--- a/maps/antag_spawn/mercenary/mercenary.dm
+++ b/maps/antag_spawn/mercenary/mercenary.dm
@@ -38,7 +38,6 @@
 	ceiling_type = /turf/simulated/floor/shuttle_ceiling/merc
 	warmup_time = 5
 	range = 1
-	fuel_consumption = 7
 	skill_needed = SKILL_BASIC
 
 /turf/simulated/floor/shuttle_ceiling/merc

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -1686,9 +1686,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_shuttle/rear)
 "cH" = (
-/obj/structure/fuel_port{
-	pixel_x = -32
-	},
 /obj/machinery/atmospherics/valve/shutoff{
 	level = 2
 	},
@@ -1707,9 +1704,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_shuttle/rear)
 "cJ" = (
-/obj/structure/fuel_port{
-	pixel_x = 32
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 2;
 	icon_state = "warning"

--- a/maps/away/blueriver/blueriver-2.dmm
+++ b/maps/away/blueriver/blueriver-2.dmm
@@ -584,7 +584,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/bluespaceriver/ship)
 "bP" = (
-/obj/structure/fuel_port,
 /turf/simulated/wall/titanium,
 /area/bluespaceriver/ship)
 "bQ" = (

--- a/maps/away/casino/casino.dm
+++ b/maps/away/casino/casino.dm
@@ -67,7 +67,6 @@
 	shuttle_area = /area/casino/casino_cutter
 	current_location = "nav_casino_hangar"
 	landmark_transition = "nav_casino_transit"
-	fuel_consumption = 0.5//it's small
 	range = 1
 	defer_initialisation = TRUE
 

--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -1233,7 +1233,6 @@
 	},
 /area/casino/casino_cutter)
 "dq" = (
-/obj/structure/fuel_port,
 /turf/simulated/shuttle/wall{
 	dir = 8;
 	icon_state = "swall"

--- a/maps/bearcat/bearcat-1.dmm
+++ b/maps/bearcat/bearcat-1.dmm
@@ -374,6 +374,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/ship/bearcat/cargo/lower)
+"be" = (
+/obj/machinery/network/relay{
+	initial_network_id = "bearnet"
+	},
+/turf/simulated/floor/tiled,
+/area/ship/bearcat/broken1)
 "bf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -2345,12 +2351,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/bearcat/escape_port)
-"jw" = (
-/obj/machinery/network/relay{
-	initial_network_id = "bearnet"
-	},
-/turf/simulated/floor/tiled,
-/area/ship/bearcat/broken1)
 "jD" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
@@ -5614,7 +5614,7 @@ cs
 cs
 cQ
 da
-jw
+be
 ob
 pb
 WZ

--- a/maps/bearcat/bearcat-2.dmm
+++ b/maps/bearcat/bearcat-2.dmm
@@ -3,9 +3,7 @@
 /turf/space,
 /area/space)
 "ab" = (
-/obj/structure/shuttle/engine/propulsion/burst/left{
-	dir = 1
-	},
+/obj/machinery/shipsensors/weak,
 /turf/simulated/floor/airless,
 /area/ship/bearcat/shuttle/outgoing)
 "ac" = (
@@ -42,19 +40,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/bearcat/maintenance/atmos)
-"ae" = (
-/obj/structure/cable{
-	icon_state = "4-9"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
-	},
-/obj/machinery/network/acl{
-	initial_network_id = "bearnet"
-	},
-/turf/simulated/floor/carpet/blue,
-/area/ship/bearcat/command/captain)
 "aj" = (
 /obj/effect/landmark/map_data{
 	height = 2
@@ -79,6 +64,12 @@
 /area/ship/bearcat/shuttle/outgoing)
 "aw" = (
 /turf/simulated/wall/r_wall/prepainted,
+/area/ship/bearcat/comms)
+"aD" = (
+/obj/machinery/network/mainframe{
+	initial_network_id = "bearnet"
+	},
+/turf/simulated/floor/bluegrid,
 /area/ship/bearcat/comms)
 "aE" = (
 /turf/simulated/floor/bluegrid,
@@ -222,7 +213,24 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/bearcat/maintenance/atmos)
-"bg" = (
+"be" = (
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/obj/machinery/network/acl{
+	initial_network_id = "bearnet"
+	},
+/turf/simulated/floor/carpet/blue,
+/area/ship/bearcat/command/captain)
+"bh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/ship/bearcat/shuttle/outgoing)
+"bi" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/walllocker/emerglocker/north,
 /obj/machinery/floodlight,
@@ -230,14 +238,6 @@
 	icon_state = "handrail";
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/ship/bearcat/shuttle/outgoing)
-"bh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/ship/bearcat/shuttle/outgoing)
-"bi" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/ship/bearcat/shuttle/outgoing)
 "bm" = (
@@ -659,10 +659,25 @@
 	icon_state = "handrail";
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	icon_state = "intact";
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/ship/bearcat/shuttle/outgoing)
 "cq" = (
-/obj/structure/closet/crate/freezer/rations,
+/obj/machinery/power/port_gen/pacman/super{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1;
+	d2 = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	icon_state = "intact";
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/ship/bearcat/shuttle/outgoing)
 "cs" = (
@@ -712,14 +727,13 @@
 /turf/simulated/floor/plating,
 /area/ship/bearcat/shuttle/outgoing)
 "cA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/ship/bearcat/shuttle/outgoing)
@@ -727,9 +741,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/ship/bearcat/shuttle/outgoing)
 "cC" = (
@@ -760,11 +772,28 @@
 	dir = 1;
 	level = 2
 	},
+/obj/structure/window/reinforced{
+	dir = 2;
+	health = 1e+007
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	icon_state = "intact";
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/ship/bearcat/shuttle/outgoing)
 "cI" = (
-/obj/structure/cable,
-/obj/machinery/power/port_gen/pacman/super,
+/obj/structure/window/reinforced{
+	dir = 2;
+	health = 1e+007
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	icon_state = "map";
+	dir = 4
+	},
+/obj/machinery/computer/ship/engines{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/ship/bearcat/shuttle/outgoing)
 "cJ" = (
@@ -2794,7 +2823,9 @@
 /turf/simulated/floor/plating,
 /area/ship/bearcat/hidden)
 "hb" = (
-/obj/structure/shuttle/engine/propulsion/burst/left,
+/obj/machinery/atmospherics/unary/tank/carbon_dioxide{
+	dir = 1
+	},
 /turf/simulated/floor/airless,
 /area/ship/bearcat/shuttle/outgoing)
 "hc" = (
@@ -4651,7 +4682,6 @@
 /turf/simulated/floor/plating,
 /area/ship/bearcat/maintenance/engine/aft)
 "lx" = (
-/obj/structure/shuttle/engine/propulsion/burst/right,
 /turf/simulated/floor/airless,
 /area/ship/bearcat/shuttle/outgoing)
 "mb" = (
@@ -4680,6 +4710,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/bearcat/maintenance/engine/aft)
+"mz" = (
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled,
+/area/ship/bearcat/shuttle/outgoing)
 "mX" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/prepainted,
@@ -4742,12 +4780,6 @@
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/prepainted,
 /area/ship/bearcat/crew/cryo)
-"nu" = (
-/obj/structure/shuttle/engine/propulsion/burst/right{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/ship/bearcat/shuttle/outgoing)
 "nL" = (
 /turf/simulated/floor/airless,
 /area/space)
@@ -4885,6 +4917,21 @@
 /obj/structure/handrai,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/bearcat/maintenance/engineering)
+"pZ" = (
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = 0
+	},
+/obj/machinery/computer/ship/sensors{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/ship/bearcat/shuttle/outgoing)
 "qb" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -5020,6 +5067,13 @@
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
 /area/ship/bearcat/maintenance/atmos)
+"rJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/simulated/wall/titanium,
+/area/ship/bearcat/shuttle/outgoing)
 "rQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
@@ -5265,6 +5319,10 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	icon_state = "intact";
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/ship/bearcat/shuttle/outgoing)
 "we" = (
@@ -5421,13 +5479,18 @@
 /turf/simulated/floor/tiled,
 /area/ship/bearcat/crew/saloon)
 "Ah" = (
-/obj/structure/table/standard,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+/obj/machinery/computer/ship/helm,
+/obj/effect/overmap/visitable/ship/landable/outgoing,
+/turf/simulated/floor/tiled,
+/area/ship/bearcat/shuttle/outgoing)
+"An" = (
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = 22
 	},
-/obj/item/deck/tarot,
-/obj/machinery/cell_charger,
+/obj/machinery/computer/ship/navigation{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/ship/bearcat/shuttle/outgoing)
 "AB" = (
@@ -5716,6 +5779,20 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/ship/bearcat/comms)
+"FO" = (
+/obj/structure/table/standard,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 1
+	},
+/obj/item/deck/tarot,
+/obj/machinery/cell_charger,
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/ship/bearcat/shuttle/outgoing)
 "FS" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -5770,6 +5847,17 @@
 /obj/machinery/door/airlock/hatch/autoname/engineering,
 /turf/simulated/floor/plating,
 /area/ship/bearcat/maintenance/engine/starboard)
+"Gn" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/obj/item/radio,
+/obj/item/spaceflare,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/ship/bearcat/shuttle/outgoing)
 "Gv" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5807,6 +5895,10 @@
 /obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/tiled/white,
 /area/ship/bearcat/crew/medbay)
+"Hf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/wall/titanium,
+/area/ship/bearcat/shuttle/outgoing)
 "HO" = (
 /obj/structure/handrai{
 	icon_state = "handrail";
@@ -5904,6 +5996,13 @@
 /obj/random/drinkbottle,
 /turf/simulated/floor/tiled,
 /area/ship/bearcat/crew/kitchen)
+"Je" = (
+/obj/machinery/atmospherics/unary/engine{
+	icon_state = "nozzle";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/ship/bearcat/shuttle/outgoing)
 "Jg" = (
 /obj/effect/paint/red,
 /turf/simulated/wall/r_wall/hull,
@@ -6033,10 +6132,6 @@
 	dir = 2;
 	level = 2
 	},
-/obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 10
-	},
 /obj/machinery/alarm{
 	dir = 4;
 	icon_state = "alarm0";
@@ -6103,14 +6198,6 @@
 /obj/structure/bed/chair/comfy/brown{
 	icon_state = "comfychair_preview";
 	dir = 1
-	},
-/obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
@@ -6309,6 +6396,14 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/bearcat/crew/hallway/port)
+"Pm" = (
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/ship/bearcat/shuttle/outgoing)
 "PA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6438,14 +6533,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/bearcat/maintenance/engine/port)
-"Sb" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/ship/bearcat/shuttle/outgoing)
 "Sc" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/floor_decal/corner/blue{
@@ -6490,26 +6577,6 @@
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/prepainted,
 /area/ship/bearcat/command/captain)
-"Tb" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate,
-/obj/item/radio,
-/obj/item/spaceflare,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10;
-	icon_state = "intact"
-	},
-/obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/ship/bearcat/shuttle/outgoing)
 "Tc" = (
 /obj/structure/closet/crate,
 /obj/random/loot,
@@ -6545,8 +6612,15 @@
 /area/ship/bearcat/crew/saloon)
 "Ub" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/storage/backpack/dufflebag,
-/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/structure/closet/crate/uranium,
+/obj/structure/handrai{
+	icon_state = "handrail";
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/ship/bearcat/shuttle/outgoing)
 "Uc" = (
@@ -6593,12 +6667,6 @@
 /obj/effect/paint/brown,
 /turf/simulated/wall/prepainted,
 /area/ship/bearcat/crew/toilets)
-"Uo" = (
-/obj/machinery/network/mainframe{
-	initial_network_id = "bearnet"
-	},
-/turf/simulated/floor/bluegrid,
-/area/ship/bearcat/comms)
 "Vb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -8938,9 +9006,9 @@ aL
 aL
 aL
 aL
-aL
-aL
-aL
+rJ
+Hf
+Hf
 hb
 aa
 aa
@@ -9013,8 +9081,8 @@ aa
 at
 at
 aL
+FO
 aL
-bg
 bi
 Vb
 bx
@@ -9095,8 +9163,8 @@ aa
 at
 Ah
 Lb
+Pm
 Gv
-bh
 bh
 bp
 aL
@@ -9105,7 +9173,7 @@ aL
 cq
 cA
 cH
-aL
+Je
 aa
 aa
 aa
@@ -9177,9 +9245,9 @@ aa
 at
 ob
 Mb
+mz
 Nb
-Sb
-bi
+Gn
 bq
 at
 Zb
@@ -9187,7 +9255,7 @@ cd
 wc
 cB
 cI
-aL
+Je
 aa
 aa
 aa
@@ -9258,9 +9326,9 @@ aa
 aa
 at
 xb
+An
+pZ
 aL
-aL
-Tb
 Ub
 Wb
 Nb
@@ -9340,7 +9408,7 @@ aa
 aa
 aa
 zb
-nu
+aL
 aL
 aL
 at
@@ -9749,7 +9817,7 @@ Ls
 oK
 aw
 aw
-Uo
+aD
 aP
 ba
 oK
@@ -10325,7 +10393,7 @@ ar
 Wp
 aI
 aV
-ae
+be
 eq
 aa
 bA

--- a/maps/bearcat/bearcat_overmap.dm
+++ b/maps/bearcat/bearcat_overmap.dm
@@ -11,3 +11,7 @@
 	initial_restricted_waypoints = list(
 		"Exploration Pod" = list("nav_bearcat_starboard_dock_pod"), //pod can only dock starboard-side, b/c there's only one door.
 	)
+
+/obj/effect/overmap/visitable/ship/landable/outgoing
+	shuttle = "Exploration Shuttle"
+	

--- a/maps/random_ruins/exoplanet_ruins/marooned/marooned.dmm
+++ b/maps/random_ruins/exoplanet_ruins/marooned/marooned.dmm
@@ -277,7 +277,6 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/map_template/marooned)
 "aP" = (
-/obj/structure/fuel_port,
 /obj/effect/paint/black,
 /turf/simulated/wall/ocp_wall,
 /area/map_template/marooned)

--- a/nano/templates/shuttle_control_console_exploration.tmpl
+++ b/nano/templates/shuttle_control_console_exploration.tmpl
@@ -58,25 +58,37 @@
 	</div>
 	<span class="average">{{:data.destination_name}}</span>
 	<div class="item">
-		{{:helper.link('Choose Destination', 'arrowreturn-1-s', {'pick' : '1'}, data.can_pick ? null : 'disabled' , null)}}
+		{{:helper.link('Choose Destination', 'arrowreturn-1-s', {'pick' : '1'}, data.can_pick && !data.can_resume ? null : 'disabled' , null)}}
 	</div>
 	<div class="item">
-		{{:helper.link('Manual Landing', 'arrowthickstop-1-s', {'manual_landing' : '1'})}}
+		{{:helper.link('Manual Landing', 'arrowthickstop-1-s', {'manual_landing' : '1'}, data.can_resume ? 'disabled' : null)}}
 	</div>
 </div>
-{{if data.fuel_usage}}
+{{if data.is_ship}}
 	<div class="item" style="padding-top: 10px">
-		<div class="itemLabel">
-			Est. Delta-V Budget:
+		<div class="item">
+			<div class="itemLabel">
+				Est. Delta-V Budget:
+			</div>
+			<div class="itemContent">
+				<span class='{{:data.fuel_span}}'>{{:data.delta_v_budget}} Km/s</span>
+			</div>
 		</div>
-		<div class="itemContent">
-			<span class='{{:data.fuel_span}}'>{{:data.remaining_fuel}} m/s</span>
+		<div class="item">
+			<div class="itemLabel">
+				Avg. Delta-V Per Maneuver:
+			</div>
+			<div class="itemContent">
+				{{:data.delta_v}} Km/s
+			</div>
 		</div>
-		<div class="itemLabel">
-			Avg. Delta-V Per Maneuver:
-		</div>
-		<div class="itemContent">
-			 {{:data.fuel_usage}} m/s
+		<div class="item">
+			<div class="itemLabel">
+				Total Delta-V:
+			</div>
+			<div class="itemContent">
+				{{:data.total_delta_v}}
+			</div>
 		</div>
 	</div>
 {{/if}}
@@ -87,6 +99,7 @@
 			{{:helper.link('Launch Shuttle', 'arrowthickstop-1-e', {'move' : '1'}, data.can_launch ? null : 'disabled' , null)}}
 			{{:helper.link('Cancel Launch', 'cancel', {'cancel' : '1'}, data.can_cancel ? null : 'disabled' , null)}}
 			{{:helper.link('Force Launch', 'alert', {'force' : '1'}, data.can_force ? null : 'disabled' , data.can_force ? 'redButton' : null)}}
+			{{:helper.link('Resume Launch', 'arrowthickstop-1-e', {'resume': '1'}, data.can_resume ? null : 'disabled')}}
 		</div>
 	</div>
 </div>

--- a/nebula.dme
+++ b/nebula.dme
@@ -13,7 +13,6 @@
 #include "code\_macros.dm"
 #include "code\client_macros.dm"
 #include "code\hub.dm"
-#include "code\stylesheet.dm"
 #include "code\world.dm"
 #include "code\__datastructures\globals.dm"
 #include "code\__datastructures\priority_queue.dm"


### PR DESCRIPTION
Shuttle landing now calculates delta_v for maneuvers and burns, requiring the ship to perform the burn in order to land.

It supports doing up to six maneuvers in order to try and reach its goal delta_v.

This replaces fuel ports entirely. Make believe ships that still require landing can use the fake bluespace thrusters.