### PR TITLE
Make planetary atmos scans allow atmos skill

### DIFF
--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -222,7 +222,7 @@
 	. = ..()
 	var/list/extra_data = list("<br>")
 	if(atmosphere)
-		if(user.skill_check(SKILL_SCIENCE, SKILL_EXPERT))
+		if(user.skill_check(SKILL_SCIENCE, SKILL_EXPERT) || user.skill_check(SKILL_ATMOS, SKILL_EXPERT))
 			var/list/gases = list()
 			for(var/g in atmosphere.gas)
 				if(atmosphere.gas[g] > atmosphere.total_moles * 0.05)
@@ -231,7 +231,7 @@
 			extra_data += "Atmosphere composition: [english_list(gases)]"
 			var/inaccuracy = rand(8,12)/10
 			extra_data += "Atmosphere pressure [atmosphere.return_pressure()*inaccuracy] kPa, temperature [atmosphere.temperature*inaccuracy] K"
-		else if(user.skill_check(SKILL_SCIENCE, SKILL_BASIC))
+		else if(user.skill_check(SKILL_SCIENCE, SKILL_BASIC) || user.skill_check(SKILL_ATMOS, SKILL_BASIC))
 			extra_data += "Atmosphere present"
 		extra_data += "<br>"
 


### PR DESCRIPTION
:cl:
tweak: Atmospheric readings when scanning planetoids is now reliant on atmospherics or science skill instead of only science skill (You only need one of the two).
/:cl: