### PR TITLE
Moved req_access on machines to initial_access /w network lock auto-c…

### DIFF
--- a/code/game/machinery/_machines_base/machine_construction/_construction.dm
+++ b/code/game/machinery/_machines_base/machine_construction/_construction.dm
@@ -18,6 +18,10 @@
 
 // Return a change state define or a fail message to block transition.
 /obj/machinery/proc/cannot_transition_to(var/state_path, var/mob/user)
+	if(ispath(state_path, /decl/machine_construction/default/deconstructed))
+		var/obj/item/stock_parts/network_lock/lock = get_component_of_type(/obj/item/stock_parts/network_lock)
+		if(istype(lock) && !allowed(user)) // Only check if we have a network_lock.
+			return MCS_BLOCK
 	return MCS_CHANGE
 
 /decl/machine_construction

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -245,7 +245,7 @@ Class Procs:
 
 /obj/machinery/proc/get_tool_manipulation_info()
 	return construct_state?.mechanics_info()
-	
+
 ////////////////////////////////////////////////////////////////////////////////////////////
 
 /obj/machinery/attack_ai(mob/user)
@@ -262,7 +262,7 @@ Class Procs:
 /obj/machinery/attack_ghost(mob/user)
 	interface_interact(user)
 
-// If you don't call parent in this proc, you must make all appropriate checks yourself. 
+// If you don't call parent in this proc, you must make all appropriate checks yourself.
 // If you do, you must respect the return value.
 /obj/machinery/attack_hand(mob/user)
 	if((. = ..())) // Buckling, climbers; unlikely to return true.
@@ -453,6 +453,5 @@ Class Procs:
 
 /obj/machinery/get_req_access()
 	. = ..() || list()
-	var/obj/item/stock_parts/network_lock/lock = get_component_of_type(/obj/item/stock_parts/network_lock)
-	if(lock)
-		. = . | lock.get_req_access()
+	for(var/obj/item/stock_parts/network_lock/lock in get_all_components_of_type(/obj/item/stock_parts/network_lock))
+		.+= lock.get_req_access()

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -116,6 +116,8 @@ Class Procs:
 	var/list/processing_parts // Component parts queued for processing by the machine. Expected type: /obj/item/stock_parts
 	var/processing_flags         // What is being processed
 
+	var/list/initial_access		// Used to setup network locks on machinery at populate_parts.
+
 /obj/machinery/Initialize(mapload, d=0, populate_parts = TRUE)
 	. = ..()
 	if(d)

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -30,9 +30,10 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 				for(var/type in req_components)
 					uncreated_component_parts[type] += (req_components[type] || 1)
 		if(initial_access && length(initial_access) > 0)
-			// Auto-create a network lock.
-			var/obj/item/stock_parts/network_lock/lock = install_component(/obj/item/stock_parts/network_lock/buildable, refresh_parts = FALSE)
-			lock.grants = initial_access
+			for(var/access_list in initial_access)
+				// Each part is an AND component.
+				var/obj/item/stock_parts/network_lock/lock = install_component(/obj/item/stock_parts/network_lock/buildable, refresh_parts = FALSE)
+				lock.grants = access_list
 
 	// Create the parts we are supposed to have. If not full_populate, this is only hard-baked parts, and more will be added later.
 	for(var/component_path in uncreated_component_parts)
@@ -308,6 +309,9 @@ Standard helpers for users interacting with machinery parts.
 	for(var/path in types_of_component(/obj/item/stock_parts))
 		var/obj/item/stock_parts/part = path
 		if(!(initial(part.part_flags) & PART_FLAG_HAND_REMOVE))
+			continue
+		var/obj/item/stock_parts/network_lock/lock = part
+		if(istype(lock) && !allowed(user))
 			continue
 		if(components_are_accessible(path))
 			removable_parts[initial(part.name)] = path

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -29,6 +29,10 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 				LAZYINITLIST(uncreated_component_parts)
 				for(var/type in req_components)
 					uncreated_component_parts[type] += (req_components[type] || 1)
+		if(initial_access && length(initial_access) > 0)
+			// Auto-create a network lock.
+			var/obj/item/stock_parts/network_lock/lock = install_component(/obj/item/stock_parts/network_lock, refresh_parts = FALSE)
+			lock.grants = initial_access
 
 	// Create the parts we are supposed to have. If not full_populate, this is only hard-baked parts, and more will be added later.
 	for(var/component_path in uncreated_component_parts)

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -31,7 +31,7 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 					uncreated_component_parts[type] += (req_components[type] || 1)
 		if(initial_access && length(initial_access) > 0)
 			// Auto-create a network lock.
-			var/obj/item/stock_parts/network_lock/lock = install_component(/obj/item/stock_parts/network_lock, refresh_parts = FALSE)
+			var/obj/item/stock_parts/network_lock/lock = install_component(/obj/item/stock_parts/network_lock/buildable, refresh_parts = FALSE)
 			lock.grants = initial_access
 
 	// Create the parts we are supposed to have. If not full_populate, this is only hard-baked parts, and more will be added later.

--- a/code/game/machinery/_machines_base/stock_parts/network_lock.dm
+++ b/code/game/machinery/_machines_base/stock_parts/network_lock.dm
@@ -41,7 +41,7 @@
 	var/list/resulting_grants = list()
 	for(var/grant_data in grants)
 		var/datum/computer_file/data/grant_record/grant = access_controller.get_grant(grant_data)
-		if(!grant)
+		if(!istype(grant))
 			continue // couldn't find.
 		resulting_grants |= uppertext("[D.network_id].[grant_data]")
 

--- a/code/game/machinery/ai_slipper.dm
+++ b/code/game/machinery/ai_slipper.dm
@@ -11,7 +11,7 @@
 	var/cooldown_time = 0
 	var/cooldown_timeleft = 0
 	var/cooldown_on = 0
-	req_access = list(access_ai_upload)
+	initial_access = list(access_ai_upload)
 
 /obj/machinery/ai_slipper/on_update_icon()
 	if (stat & NOPOWER || stat & BROKEN)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -56,7 +56,7 @@
 	idle_power_usage = 80
 	active_power_usage = 1000 //For heating/cooling rooms. 1000 joules equates to about 1 degree every 2 seconds for a single tile of air.
 	power_channel = ENVIRON
-	req_access = list(list(access_atmospherics, access_engine_equip))
+	initial_access = list(list(access_atmospherics, access_engine_equip))
 	clicksound = "button"
 	clickvol = 30
 
@@ -124,7 +124,7 @@
 	breach_detection = 0
 
 /obj/machinery/alarm/server/Initialize()
-	req_access = list(access_rd, access_atmospherics, access_engine_equip)
+	initial_access = list(access_rd, access_atmospherics, access_engine_equip)
 	TLV["temperature"] =	list(T0C-26, T0C, T0C+30, T0C+40) // K
 	target_temperature = T0C+10
 	. = ..()

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -56,7 +56,7 @@
 	idle_power_usage = 80
 	active_power_usage = 1000 //For heating/cooling rooms. 1000 joules equates to about 1 degree every 2 seconds for a single tile of air.
 	power_channel = ENVIRON
-	initial_access = list(access_atmospherics, access_engine_equip)
+	initial_access = list(list(access_atmospherics, access_engine_equip))
 	clicksound = "button"
 	clickvol = 30
 
@@ -124,7 +124,7 @@
 	breach_detection = 0
 
 /obj/machinery/alarm/server/Initialize()
-	initial_access = list(access_rd, access_atmospherics, access_engine_equip)
+	initial_access = list(list(access_rd, access_atmospherics, access_engine_equip))
 	TLV["temperature"] =	list(T0C-26, T0C, T0C+30, T0C+40) // K
 	target_temperature = T0C+10
 	. = ..()

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -56,7 +56,7 @@
 	idle_power_usage = 80
 	active_power_usage = 1000 //For heating/cooling rooms. 1000 joules equates to about 1 degree every 2 seconds for a single tile of air.
 	power_channel = ENVIRON
-	initial_access = list(list(access_atmospherics, access_engine_equip))
+	initial_access = list(access_atmospherics, access_engine_equip)
 	clicksound = "button"
 	clickvol = 30
 

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -10,7 +10,7 @@
 	light_color = "#00b000"
 	density = 1
 	anchored = 1.0
-	req_access = list(access_ce)
+	initial_access = list(access_ce)
 	var/list/monitored_alarm_ids = null
 	var/datum/nano_module/atmos_control/atmos_control
 	base_type = /obj/machinery/computer/atmoscontrol

--- a/code/game/machinery/computer/prisoner.dm
+++ b/code/game/machinery/computer/prisoner.dm
@@ -6,7 +6,7 @@
 	icon_keyboard = "security_key"
 	icon_screen = "explosive"
 	light_color = "#a91515"
-	req_access = list(access_armory)
+	initial_access = list(access_armory)
 	var/id = 0.0
 	var/temp = null
 	var/status = 0

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -5,7 +5,7 @@
 	icon_keyboard = "mining_key"
 	icon_screen = "robot"
 	light_color = "#a97faa"
-	req_access = list(access_robotics)
+	initial_access = list(access_robotics)
 
 /obj/machinery/computer/robotics/interface_interact(mob/user)
 	ui_interact(user)

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -3,7 +3,7 @@
 	name = "deployable"
 	desc = "Deployable."
 	icon = 'icons/obj/objects.dmi'
-	req_access = list(access_security)//I'm changing this until these are properly tested./N
+	initial_access = list(access_security)
 
 /obj/machinery/deployable/barrier
 	name = "deployable barrier"
@@ -15,7 +15,6 @@
 	var/health = 100.0
 	var/maxhealth = 100.0
 	var/locked = 0.0
-//	req_access = list(access_maint_tunnels)
 
 /obj/machinery/deployable/barrier/Initialize()
 	. = ..()

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -18,7 +18,7 @@
 	icon = 'icons/obj/status_display.dmi'
 	icon_state = "frame"
 	desc = "A remote control for a door."
-	req_access = list(access_brig)
+	initial_access = list(access_brig)
 	anchored = 1.0    		// can't pick it up
 	density = 0       		// can walk through it.
 	var/id = null     		// id of door it controls.

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -15,7 +15,7 @@
 	var/panel_file = 'icons/obj/doors/hazard/panel.dmi'
 	var/welded_file = 'icons/obj/doors/hazard/welded.dmi'
 	icon_state = "open"
-	req_access = list(list(access_atmospherics, access_engine_equip))
+	initial_access = list(list(access_atmospherics, access_engine_equip))
 	autoset_access = FALSE
 	opacity = 0
 	density = 0

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -15,7 +15,7 @@
 	var/panel_file = 'icons/obj/doors/hazard/panel.dmi'
 	var/welded_file = 'icons/obj/doors/hazard/welded.dmi'
 	icon_state = "open"
-	initial_access = list(access_atmospherics, access_engine_equip)
+	initial_access = list(list(access_atmospherics, access_engine_equip))
 	autoset_access = FALSE
 	opacity = 0
 	density = 0

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -15,7 +15,7 @@
 	var/panel_file = 'icons/obj/doors/hazard/panel.dmi'
 	var/welded_file = 'icons/obj/doors/hazard/welded.dmi'
 	icon_state = "open"
-	initial_access = list(list(access_atmospherics, access_engine_equip))
+	initial_access = list(access_atmospherics, access_engine_equip)
 	autoset_access = FALSE
 	opacity = 0
 	density = 0

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -6,7 +6,7 @@
 	icon_state = "grinder"
 	density = 1
 	anchored = 1
-	req_access = list(access_kitchen,access_morgue)
+	initial_access = list(access_kitchen,access_morgue)
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -6,7 +6,7 @@
 	icon_state = "grinder"
 	density = 1
 	anchored = 1
-	initial_access = list(access_kitchen,access_morgue)
+	initial_access = list(list(access_kitchen, access_morgue))
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -67,7 +67,7 @@
 	name = "\improper Slime Extract Storage"
 	desc = "A refrigerated storage unit for slime extracts."
 	icon_contents = "slime"
-	req_access = list(access_research)
+	initial_access = list(access_research)
 
 /obj/machinery/smartfridge/secure/extract/accept_check(var/obj/item/O)
 	if(istype(O,/obj/item/slime_extract))
@@ -78,7 +78,7 @@
 	name = "\improper Refrigerated Medicine Storage"
 	desc = "A refrigerated storage unit for storing medicine and chemicals."
 	icon_contents = "chem"
-	req_access = list(list(access_medical,access_chemistry))
+	initial_access = list(access_medical,access_chemistry)
 
 /obj/machinery/smartfridge/secure/medbay/accept_check(var/obj/item/O)
 	if(istype(O,/obj/item/chems/glass/))

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -78,7 +78,7 @@
 	name = "\improper Refrigerated Medicine Storage"
 	desc = "A refrigerated storage unit for storing medicine and chemicals."
 	icon_contents = "chem"
-	initial_access = list(access_medical,access_chemistry)
+	initial_access = list(list(access_medical, access_chemistry))
 
 /obj/machinery/smartfridge/secure/medbay/accept_check(var/obj/item/O)
 	if(istype(O,/obj/item/chems/glass/))

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -14,7 +14,7 @@ var/global/list/navbeacons = list()
 	var/location = ""	// location response text
 	var/list/codes = list()		// assoc. list of transponder codes
 
-	req_access = list(access_engine)
+	initial_access = list(access_engine)
 
 /obj/machinery/navbeacon/Initialize()
 	. = ..()

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -59,7 +59,7 @@
 	var/wrenching = 0
 	var/last_target			//last target fired at, prevents turrets from erratically firing at all valid targets in range
 
-	req_access = list(list(access_security, access_bridge))
+	initial_access = list(list(access_security, access_bridge))
 
 /obj/machinery/porta_turret/crescent
 	enabled = 0
@@ -70,7 +70,7 @@
 	check_records = 1
 	check_weapons = 1
 	check_anomalies = 1
-	req_access = list(access_cent_specops)
+	initial_access = list(access_cent_specops)
 
 /obj/machinery/porta_turret/stationary
 	ailock = 1

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -59,7 +59,7 @@
 	var/wrenching = 0
 	var/last_target			//last target fired at, prevents turrets from erratically firing at all valid targets in range
 
-	initial_access = list(access_security, access_bridge)
+	initial_access = list(list(access_security, access_bridge))
 
 /obj/machinery/porta_turret/crescent
 	enabled = 0

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -59,7 +59,7 @@
 	var/wrenching = 0
 	var/last_target			//last target fired at, prevents turrets from erratically firing at all valid targets in range
 
-	initial_access = list(list(access_security, access_bridge))
+	initial_access = list(access_security, access_bridge)
 
 /obj/machinery/porta_turret/crescent
 	enabled = 0

--- a/code/game/machinery/suit_cycler.dm
+++ b/code/game/machinery/suit_cycler.dm
@@ -8,7 +8,7 @@
 	icon = 'icons/obj/suitstorage.dmi'
 	icon_state = "close"
 
-	initial_access = list(access_captain, access_bridge)
+	initial_access = list(list(access_captain, access_bridge))
 
 	var/active = 0          // PLEASE HOLD.
 	var/safeties = 1        // The cycler won't start with a living thing inside it unless safeties are off.

--- a/code/game/machinery/suit_cycler.dm
+++ b/code/game/machinery/suit_cycler.dm
@@ -8,7 +8,7 @@
 	icon = 'icons/obj/suitstorage.dmi'
 	icon_state = "close"
 
-	req_access = list(access_captain, access_bridge)
+	initial_access = list(access_captain, access_bridge)
 
 	var/active = 0          // PLEASE HOLD.
 	var/safeties = 1        // The cycler won't start with a living thing inside it unless safeties are off.

--- a/code/game/machinery/suit_cycler_units.dm
+++ b/code/game/machinery/suit_cycler_units.dm
@@ -1,7 +1,7 @@
 /obj/machinery/suit_cycler/engineering
 	name = "Engineering suit cycler"
 	model_text = "Engineering"
-	req_access = list(access_construction)
+	initial_access = list(access_construction)
 	available_modifications = list(/decl/item_modifier/space_suit/engineering, /decl/item_modifier/space_suit/atmos)
 
 /obj/machinery/suit_cycler/engineering/alt
@@ -14,19 +14,19 @@
 /obj/machinery/suit_cycler/mining
 	name = "Mining suit cycler"
 	model_text = "Mining"
-	req_access = list(access_mining)
+	initial_access = list(access_mining)
 	available_modifications = list(/decl/item_modifier/space_suit/mining)
 
 /obj/machinery/suit_cycler/science
 	name = "Excavation suit cycler"
 	model_text = "Excavation"
-	req_access = list(access_xenoarch)
+	initial_access = list(access_xenoarch)
 	available_modifications = list(/decl/item_modifier/space_suit/science)
 
 /obj/machinery/suit_cycler/security
 	name = "Security suit cycler"
 	model_text = "Security"
-	req_access = list(access_security)
+	initial_access = list(access_security)
 	available_modifications = list(/decl/item_modifier/space_suit/security, /decl/item_modifier/space_suit/security/alt)
 
 /obj/machinery/suit_cycler/security/alt
@@ -36,7 +36,7 @@
 /obj/machinery/suit_cycler/medical
 	name = "Medical suit cycler"
 	model_text = "Medical"
-	req_access = list(access_medical)
+	initial_access = list(access_medical)
 	available_modifications = list(/decl/item_modifier/space_suit/medical)
 
 /obj/machinery/suit_cycler/medical/alt
@@ -46,7 +46,7 @@
 /obj/machinery/suit_cycler/syndicate
 	name = "Nonstandard suit cycler"
 	model_text = "Nonstandard"
-	req_access = list(access_syndicate)
+	initial_access = list(access_syndicate)
 	available_modifications = list(/decl/item_modifier/space_suit/mercenary)
 	can_repair = 1
 	buildable = FALSE
@@ -54,5 +54,5 @@
 /obj/machinery/suit_cycler/pilot
 	name = "Pilot suit cycler"
 	model_text = "Pilot"
-	req_access = list(access_mining_office)
+	initial_access = list(access_mining_office)
 	available_modifications = list(/decl/item_modifier/space_suit/pilot)

--- a/code/game/machinery/telecomms/logbrowser.dm
+++ b/code/game/machinery/telecomms/logbrowser.dm
@@ -16,7 +16,7 @@
 
 	var/universal_translate = 0 // set to 1 if it can translate nonhuman speech
 
-	req_access = list(access_tcomsat)
+	initial_access = list(access_tcomsat)
 
 /obj/machinery/computer/telecomms/server/interface_interact(mob/user)
 	interact(user)

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -27,7 +27,7 @@
 	var/check_synth = 0 	//if active, will shoot at anything not an AI or cyborg
 	var/ailock = 0 	//Silicons cannot use this
 
-	req_access = list(access_ai_upload)
+	initial_access = list(access_ai_upload)
 
 /obj/machinery/turretid/stun
 	enabled = 1

--- a/code/game/machinery/vending/engineering.dm
+++ b/code/game/machinery/vending/engineering.dm
@@ -61,7 +61,7 @@
 	markup = 0
 	vend_delay = 21
 	base_type = /obj/machinery/vending/engivend
-	initial_access = list(access_atmospherics, access_engine_equip)
+	initial_access = list(list(access_atmospherics, access_engine_equip))
 	products = list(
 		/obj/item/clothing/glasses/meson = 2,
 		/obj/item/multitool = 4,
@@ -84,7 +84,7 @@
 	icon_vend = "engi-vend"
 	base_type = /obj/machinery/vending/engineering
 	markup = 0
-	initial_access = list(access_atmospherics, access_engine_equip)
+	initial_access = list(list(access_atmospherics, access_engine_equip))
 	products = list(
 		/obj/item/storage/belt/utility = 4,
 		/obj/item/clothing/glasses/meson = 4,

--- a/code/game/machinery/vending/engineering.dm
+++ b/code/game/machinery/vending/engineering.dm
@@ -61,7 +61,7 @@
 	markup = 0
 	vend_delay = 21
 	base_type = /obj/machinery/vending/engivend
-	req_access = list(list(access_atmospherics,access_engine_equip))
+	initial_access = list(access_atmospherics, access_engine_equip)
 	products = list(
 		/obj/item/clothing/glasses/meson = 2,
 		/obj/item/multitool = 4,
@@ -84,7 +84,7 @@
 	icon_vend = "engi-vend"
 	base_type = /obj/machinery/vending/engineering
 	markup = 0
-	req_access = list(list(access_atmospherics,access_engine_equip))
+	initial_access = list(access_atmospherics, access_engine_equip)
 	products = list(
 		/obj/item/storage/belt/utility = 4,
 		/obj/item/clothing/glasses/meson = 4,
@@ -117,7 +117,7 @@
 	icon_state = "robotics"
 	icon_deny = "robotics-deny"
 	icon_vend = "robotics-vend"
-	req_access = list(access_robotics)
+	initial_access = list(access_robotics)
 	base_type = /obj/machinery/vending/robotics
 	products = list(
 		/obj/item/stack/cable_coil = 4,

--- a/code/game/machinery/vending/food.dm
+++ b/code/game/machinery/vending/food.dm
@@ -175,7 +175,7 @@
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 	product_slogans = "I hope nobody asks me for a bloody cup o' tea...;Alcohol is humanity's friend. Would you abandon a friend?;Quite delighted to serve you!;Is nobody thirsty on this station?"
 	product_ads = "Drink up!;Booze is good for you!;Alcohol is humanity's best friend.;Quite delighted to serve you!;Care for a nice, cold beer?;Nothing cures you like booze!;Have a sip!;Have a drink!;Have a beer!;Beer is good for you!;Only the finest alcohol!;Best quality booze since 2053!;Award-winning wine!;Maximum alcohol!;Man loves beer.;A toast for progress!"
-	req_access = list(access_bar)
+	initial_access = list(access_bar)
 	base_type = /obj/machinery/vending/boozeomat
 
 

--- a/code/game/machinery/vending/medical.dm
+++ b/code/game/machinery/vending/medical.dm
@@ -8,7 +8,7 @@
 	vend_delay = 18
 	base_type = /obj/machinery/vending/medical
 	product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;Natural chemicals!;This stuff saves lives.;Don't you want some?;Ping!"
-	req_access = list(access_medical_equip)
+	initial_access = list(access_medical_equip)
 	products = list(
 		/obj/item/chems/glass/bottle/antitoxin = 4,
 		/obj/item/chems/glass/bottle/adrenaline = 4,

--- a/code/game/machinery/vending/security.dm
+++ b/code/game/machinery/vending/security.dm
@@ -8,7 +8,7 @@
 	icon_vend = "sec-vend"
 	vend_delay = 14
 	base_type = /obj/machinery/vending/security
-	req_access = list(access_security)
+	initial_access = list(access_security)
 	products = list(
 		/obj/item/handcuffs = 8,
 		/obj/item/grenade/flashbang = 4,

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -420,7 +420,7 @@
 	desc = "Burn baby burn!"
 	icon = 'icons/obj/power.dmi'
 	icon_state = "crema_switch"
-	req_access = list(access_crematorium)
+	initial_access = list(access_crematorium)
 	id_tag = 1
 
 /obj/machinery/button/crematorium/on_update_icon()

--- a/code/modules/modular_computers/networking/machinery/acl.dm
+++ b/code/modules/modular_computers/networking/machinery/acl.dm
@@ -12,18 +12,80 @@
 	var/datum/file_storage/network/file_source = /datum/file_storage/network/machine
 	var/editing_user	// Numerical user ID of the user being editing on this device.
 	var/list/initial_grants = list(
-		DEPT_COMMAND,
-		DEPT_CIVILIAN,
-		DEPT_ENGINEERING,
-		DEPT_EXPLORATION,
-		DEPT_MEDICAL,
-		DEPT_MISC,
-		DEPT_SCIENCE,
-		DEPT_SECURITY,
-		DEPT_SERVICE,
-		DEPT_SUPPORT,
-		DEPT_SUPPLY
+		access_security,
+		access_brig,
+		access_armory,
+		access_forensics_lockers,
+		access_medical,
+		access_morgue,
+		access_tox,
+		access_tox_storage,
+		access_engine,
+		access_engine_equip,
+		access_maint_tunnels,
+		access_external_airlocks,
+		access_emergency_storage,
+		access_change_ids,
+		access_ai_upload,
+		access_teleporter,
+		access_eva,
+		access_bridge,
+		access_captain,
+		access_all_personal_lockers,
+		access_chapel_office,
+		access_tech_storage,
+		access_atmospherics,
+		access_bar,
+		access_janitor,
+		access_crematorium,
+		access_kitchen,
+		access_robotics,
+		access_rd,
+		access_cargo,
+		access_construction,
+		access_chemistry,
+		access_cargo_bot,
+		access_hydroponics,
+		access_manufacturing,
+		access_library,
+		access_lawyer,
+		access_virology,
+		access_cmo,
+		access_qm,
+		access_network,
+		access_surgery,
+		access_research,
+		access_mining,
+		access_mining_office,
+		access_mailsorting,
+		access_heads_vault,
+		access_mining_station,
+		access_xenobiology,
+		access_ce,
+		access_hop,
+		access_hos,
+		access_RC_announce,
+		access_keycard_auth,
+		access_tcomsat,
+		access_gateway,
+		access_sec_doors,
+		access_psychiatrist,
+		access_xenoarch,
+		access_medical_equip,
+		access_heads
 	)
+
+/obj/machinery/network/acl/merchant
+	initial_grants = list(
+		access_crate_cash,
+		access_merchant
+	)
+
+/obj/machinery/network/acl/antag
+	initial_grants = list(
+		access_syndicate
+	)
+
 
 /obj/machinery/network/acl/Initialize()
 	. = ..()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -87,7 +87,7 @@
 	power_channel = LOCAL      // Do not manipulate this; you don't want to power the APC off itself.
 	interact_offline = TRUE    // Can use UI even if unpowered
 
-	req_access = list(access_engine_equip)
+	initial_access = list(access_engine_equip)
 	clicksound = "switch"
 	layer = ABOVE_WINDOW_LAYER
 	var/needs_powerdown_sound

--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -4,7 +4,7 @@
 	icon_state = "injector0"
 	density = 1
 	anchored = 0
-	req_access = list(access_engine)
+	initial_access = list(access_engine)
 	idle_power_usage = 10
 	active_power_usage = 500
 	construct_state = /decl/machine_construction/default/panel_closed

--- a/code/modules/power/fusion/gyrotron/gyrotron.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/machines/power/fusion.dmi'
 	desc = "It is a heavy duty industrial gyrotron suited for powering fusion reactors."
 	icon_state = "emitter-off"
-	req_access = list(access_engine)
+	initial_access = list(access_engine)
 	use_power = POWER_USE_IDLE
 	active_power_usage = GYRO_POWER
 

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -8,7 +8,7 @@ var/global/list/rad_collectors = list()
 	icon_state = "ca"
 	anchored = 0
 	density = 1
-	req_access = list(access_engine_equip)
+	initial_access = list(access_engine_equip)
 	var/obj/item/tank/phoron/P = null
 
 	var/health = 100

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -7,7 +7,7 @@
 	icon_state = "emitter"
 	anchored = 0
 	density = 1
-	req_access = list(access_engine_equip)
+	initial_access = list(access_engine_equip)
 	active_power_usage = 100 KILOWATTS
 
 	var/efficiency = 0.3	// Energy efficiency. 30% at this time, so 100kW load means 30kW laser pulses.

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -123,7 +123,7 @@
 	density = 1
 	opacity = 0
 	anchored = 0
-	req_access = list(access_engine)
+	initial_access = list(access_engine)
 	var/const/max_health = 100
 	var/health = max_health
 	var/active = 0

--- a/code/modules/shieldgen/shieldwallgen.dm
+++ b/code/modules/shieldgen/shieldwallgen.dm
@@ -6,7 +6,7 @@
 	icon_state = "Shield_Gen"
 	anchored = 0
 	density = 1
-	initial_access = list(access_engine_equip,access_research)
+	initial_access = list(list(access_engine_equip, access_research))
 	var/active = 0
 	var/power = 0
 	var/locked = 1

--- a/code/modules/shieldgen/shieldwallgen.dm
+++ b/code/modules/shieldgen/shieldwallgen.dm
@@ -6,7 +6,7 @@
 	icon_state = "Shield_Gen"
 	anchored = 0
 	density = 1
-	req_access = list(list(access_engine_equip,access_research))
+	initial_access = list(access_engine_equip,access_research)
 	var/active = 0
 	var/power = 0
 	var/locked = 1

--- a/code/modules/shuttles/antagonist.dm
+++ b/code/modules/shuttles/antagonist.dm
@@ -1,20 +1,20 @@
 /obj/machinery/computer/shuttle_control/multi/vox
 	name = "skipjack control console"
-	req_access = list(access_syndicate)
+	initial_access = list(access_syndicate)
 	shuttle_tag = "Skipjack"
 
 /obj/machinery/computer/shuttle_control/multi/syndicate
 	name = "mercenary shuttle control console"
-	req_access = list(access_syndicate)
+	initial_access = list(access_syndicate)
 	shuttle_tag = "Mercenary"
 
 /obj/machinery/computer/shuttle_control/multi/rescue
 	name = "rescue shuttle control console"
-	req_access = list(access_cent_specops)
+	initial_access = list(access_cent_specops)
 	shuttle_tag = "Rescue"
 
 /obj/machinery/computer/shuttle_control/multi/ninja
 	name = "stealth shuttle control console"
-	req_access = list(access_syndicate)
+	initial_access = list(access_syndicate)
 	shuttle_tag = "Ninja"
 

--- a/code/modules/shuttles/departmental.dm
+++ b/code/modules/shuttles/departmental.dm
@@ -14,5 +14,5 @@
 	name = "merchant shuttle control console"
 	icon_keyboard = "power_key"
 	icon_screen = "shuttle"
-	req_access = list(access_merchant)
+	initial_access = list(access_merchant)
 	shuttle_tag = "Merchant"

--- a/code/modules/shuttles/shuttle_specops.dm
+++ b/code/modules/shuttles/shuttle_specops.dm
@@ -1,7 +1,7 @@
 /obj/machinery/computer/shuttle_control/specops
 	name = "special operations shuttle console"
 	shuttle_tag = "Special Operations"
-	req_access = list(access_cent_specops)
+	initial_access = list(access_cent_specops)
 
 /obj/machinery/computer/shuttle_control/specops/attack_ai(user)
 	to_chat(user, "<span class='warning'>Access Denied.</span>")

--- a/maps/antag_spawn/ert/ert_base.dmm
+++ b/maps/antag_spawn/ert/ert_base.dmm
@@ -2688,7 +2688,7 @@
 	id_tag = "rescue_shuttle";
 	pixel_x = -8;
 	pixel_y = 25;
-	req_access = list()
+	initial_access = list()
 	},
 /obj/machinery/light{
 	dir = 4
@@ -2903,7 +2903,7 @@
 	name = "interior access button";
 	pixel_x = 25;
 	pixel_y = 25;
-	req_access = list("ACCESS_CENT_SPECOPS")
+	initial_access = list("ACCESS_CENT_SPECOPS")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/rescue_base/start)
@@ -3067,7 +3067,7 @@
 	name = "Emergency NanoMed";
 	pixel_x = 28;
 	pixel_y = 0;
-	req_access = newlist()
+	initial_access = newlist()
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/rescue_base/start)

--- a/mods/psionics/machines/psimonitor.dm
+++ b/mods/psionics/machines/psimonitor.dm
@@ -6,7 +6,7 @@
 	anchored = TRUE
 	density = TRUE
 	opacity = FALSE
-	req_access = list(list(access_psychiatrist, access_captain, access_cmo, access_hos))
+	initial_access = list(access_psychiatrist, access_captain, access_cmo, access_hos)
 
 	var/list/psi_violations = list()
 	var/show_violations = FALSE

--- a/mods/psionics/machines/psimonitor.dm
+++ b/mods/psionics/machines/psimonitor.dm
@@ -6,7 +6,7 @@
 	anchored = TRUE
 	density = TRUE
 	opacity = FALSE
-	initial_access = list(access_psychiatrist, access_captain, access_cmo, access_hos)
+	initial_access = list(list(access_psychiatrist, access_captain, access_cmo, access_hos))
 
 	var/list/psi_violations = list()
 	var/show_violations = FALSE


### PR DESCRIPTION
Moved req_access on machines to initial_access /w network lock auto-creation.

This prevents scenarios where machines created in play by manually building them have permissions that prevent their creator from accessing the machine.

This also converts all machines to using the network authorization system. The network ACL auto-create grant list has been expanded to correlate with this change.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->