### PR TITLE
[halp] Added toggle-able default and lighting plane masters.

### DIFF
--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -59,7 +59,6 @@ What is the naming convention for planes or layers?
 
 	FLOAT_PLANE = -32767
 */
-
 #define CLICKCATCHER_PLANE -100
 
 #define SPACE_PLANE               -99
@@ -72,10 +71,8 @@ What is the naming convention for planes or layers?
 	#define DUST_LAYER                   2
 
 // Openspace uses planes -80 through -70.
-
-#define OVER_OPENSPACE_PLANE        -3
-
-#define DEFAULT_PLANE                   0
+#define DEFAULT_PLANE                0
+	#define DEFAULT_LAYER               0
 	#define PLATING_LAYER               1
 	//ABOVE PLATING
 	#define HOLOMAP_LAYER               1.01
@@ -215,22 +212,24 @@ What is the naming convention for planes or layers?
 /*
   PLANE MASTERS
 */
-
 /obj/screen/plane_master
-	appearance_flags = PLANE_MASTER
-	screen_loc = "CENTER,CENTER"
-	globalscreen = 1
+	screen_loc = "LEFT+1,BOTTOM+1"
+	appearance_flags =  PLANE_MASTER
+	var/default_layer = DEFAULT_LAYER
+	var/default_plane = DEFAULT_PLANE
 
-/obj/screen/plane_master/ghost_master
-	plane = OBSERVER_PLANE
+/obj/screen/plane_master/Initialize()
+	. = ..()
+	name = ""
+	verbs.Cut()
+	reset_plane_and_layer()
 
-/obj/screen/plane_master/ghost_dummy
-	// this avoids a bug which means plane masters which have nothing to control get angry and mess with the other plane masters out of spite
-	alpha = 0
-	appearance_flags = 0
-	plane = OBSERVER_PLANE
+/obj/screen/plane_master/hud_layerise()
+	reset_plane_and_layer()
 
-GLOBAL_LIST_INIT(ghost_master, list(
-	new /obj/screen/plane_master/ghost_master(),
-	new /obj/screen/plane_master/ghost_dummy()
-))
+/obj/screen/plane_master/reset_plane_and_layer()
+	layer = default_layer
+	plane = default_plane
+
+/obj/screen/plane_master/hide(var/hide)
+	alpha = hide ? 0 : initial(alpha)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -206,7 +206,8 @@ var/list/admin_verbs_debug = list(
 	/client/proc/ping_webhook,
 	/client/proc/reload_webhooks,
 	/datum/admins/proc/check_unconverted_single_icon_items,
-	/client/proc/spawn_material
+	/client/proc/spawn_material,
+	/client/proc/toggle_default_planes
 	)
 
 var/list/admin_verbs_paranoid_debug = list(

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -591,3 +591,17 @@ client/verb/character_setup()
 			break
 	winset(src, "menu.icon[set_initial_window_size]", "is-checked=true")
 	SetWindowIconSize(set_initial_window_size)
+
+/client
+	var/mundane_planes_hidden = FALSE
+
+/client/proc/toggle_default_planes()
+	set name = "Toggle Default Planes"
+	set category = "Debug"
+
+	mundane_planes_hidden = !mundane_planes_hidden
+	mob.lighting_plane_master?.hide(mundane_planes_hidden)
+	mob.l_general.alpha = mundane_planes_hidden ? 0 : initial(mob.l_general.alpha)
+	for(var/obj/screen/plane_master/pmaster in mob.mundane_plane_masters)
+		pmaster.hide(mundane_planes_hidden)
+	to_chat(mob, SPAN_NOTICE("You are [mundane_planes_hidden ? "no longer" : "now"] viewing mundane plane masters (space, objs, lighting, z-mimic, etc)."))

--- a/code/modules/lighting/lighting_planemaster.dm
+++ b/code/modules/lighting/lighting_planemaster.dm
@@ -1,7 +1,6 @@
-/obj/lighting_plane
-	screen_loc = "LEFT+1,BOTTOM+1"
+/obj/screen/plane_master/light
 	plane = LIGHTING_PLANE
-
+	default_plane = LIGHTING_PLANE
 	blend_mode = BLEND_MULTIPLY
 	appearance_flags = PLANE_MASTER | NO_CLIENT_COLOR
 	// use 20% ambient lighting; be sure to add full alpha
@@ -40,9 +39,9 @@
 	color = new_colour
 
 /mob
-	var/obj/lighting_plane/l_plane
+	// Plane master and backdrop for lighting.
+	var/obj/screen/plane_master/light/lighting_plane_master
 	var/obj/lighting_general/l_general
-
 
 /mob/proc/change_light_colour(var/new_colour)
 	if(l_general)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -182,7 +182,8 @@
 	else if(!client.adminobs)
 		reset_view(null)
 
-/mob/living/proc/update_sight()
+/mob/living/update_sight()
+	..()
 	set_sight(0)
 	set_see_in_dark(0)
 	if(stat == DEAD || (eyeobj && !eyeobj.living_eye))

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -56,6 +56,39 @@
 /mob
 	var/client/my_client // Need to keep track of this ourselves, since by the time Logout() is called the client has already been nulled
 
+// A list of planes that make up the "real world".
+// Space and co are not included because they break.
+// Plane masters are really finnicky!
+var/list/mundane_environment_planes = list(
+	DEFAULT_PLANE,
+	EFFECTS_ABOVE_LIGHTING_PLANE,
+	FULLSCREEN_PLANE
+)
+
+/mob/proc/rebuild_plane_masters()
+
+	lighting_plane_master = lighting_plane_master || new
+	l_general = l_general || new
+
+	if(!length(mundane_plane_masters) < length(global.mundane_environment_planes) + OPENTURF_MAX_DEPTH + 1)
+		mundane_plane_masters = list()
+
+		for(var/i = 0 to OPENTURF_MAX_DEPTH)
+			var/obj/screen/plane_master/zmimic_master = new
+			zmimic_master.default_plane = OPENTURF_MAX_PLANE - i
+			zmimic_master.plane = zmimic_master.default_plane
+			mundane_plane_masters += zmimic_master
+
+		for(var/otherplane in global.mundane_environment_planes)
+			var/obj/screen/plane_master/pmaster = new
+			pmaster.default_plane = otherplane
+			pmaster.plane = pmaster.default_plane
+			mundane_plane_masters += pmaster
+
+	client.screen += lighting_plane_master
+	client.screen += l_general
+	client.screen += mundane_plane_masters
+
 /mob/Login()
 
 	GLOB.player_list |= src
@@ -84,11 +117,7 @@
 	if(eyeobj)
 		eyeobj.possess(src)
 
-	l_plane = new()
-	l_general = new()
-	client.screen += l_plane
-	client.screen += l_general
-
+	rebuild_plane_masters()
 	refresh_client_images()
 	reload_fullscreen() // Reload any fullscreen overlays this mob has.
 	add_click_catcher()

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -4,9 +4,13 @@
 	log_access("Logout: [key_name(src)]")
 	if(my_client)
 		my_client.screen -= l_general
-		my_client.screen -= l_plane
+		my_client.screen -= lighting_plane_master
+		my_client.screen -= mundane_plane_masters
+
 	QDEL_NULL(l_general)
-	QDEL_NULL(l_plane)
+	QDEL_NULL(lighting_plane_master)
+	QDEL_NULL_LIST(mundane_plane_masters)
+
 	hide_client_images()
 	..()
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -44,6 +44,7 @@
 	gun_setting_icon = null
 	ability_master = null
 	zone_sel = null
+	mundane_plane_masters = null
 
 /mob/Initialize()
 	. = ..()
@@ -53,6 +54,9 @@
 	if(ispath(move_intent))
 		move_intent = decls_repository.get_decl(move_intent)
 	START_PROCESSING(SSmobs, src)
+
+/mob/verb/fix_planes()
+	client?.screen |= mundane_plane_masters
 
 /mob/proc/show_message(msg, type, alt, alt_type)//Message, type of message (1 or 2), alternative message, alt message type (1 or 2)
 	if(!client)	return
@@ -1058,3 +1062,6 @@
 
 /mob/get_mass()
 	return mob_size
+
+/mob/proc/update_sight()
+	return

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -186,3 +186,6 @@
 	var/list/additional_vision_handlers = list() //Basically a list of atoms from which additional vision data is retrieved
 
 	var/list/progressbars = null //for stacking do_after bars
+
+	// Plane masters for handling the default plane and multiz.
+	var/list/mundane_plane_masters

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -27,7 +27,6 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 	var/admin_ghosted = 0
 	var/anonsay = 0
 	var/ghostvision = 1 //is the ghost able to see things humans can't?
-	var/seedarkness = 1
 
 	var/obj/item/multitool/ghost_multitool
 	var/list/hud_images // A list of hud images
@@ -482,18 +481,21 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set desc = "Toggles your ability to see things only ghosts can see, like other ghosts"
 	set category = "Ghost"
 	ghostvision = !(ghostvision)
-	updateghostsight()
+	update_sight()
 	to_chat(src, "You [(ghostvision?"now":"no longer")] have ghost vision.")
+
+/mob/observer/ghost
+	var/darkness_hidden = FALSE
 
 /mob/observer/ghost/verb/toggle_darkness()
 	set name = "Toggle Darkness"
 	set category = "Ghost"
-	seedarkness = !(seedarkness)
-	updateghostsight()
-	to_chat(src, "You [(seedarkness?"now":"no longer")] see darkness.")
+	darkness_hidden = !darkness_hidden
+	update_sight()
+	to_chat(src, "You [!darkness_hidden ? "now" : "no longer"] see darkness.")
 
-/mob/observer/ghost/proc/updateghostsight()
-	if (!seedarkness)
+/mob/observer/ghost/update_sight()
+	if(darkness_hidden)
 		set_see_invisible(SEE_INVISIBLE_NOLIGHTING)
 	else
 		set_see_invisible(ghostvision ? SEE_INVISIBLE_OBSERVER : SEE_INVISIBLE_LIVING)
@@ -504,11 +506,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return
 	client.images -= ghost_sightless_images
 	client.images -= ghost_darkness_images
-	if(!seedarkness)
+	if(darkness_hidden)
 		client.images |= ghost_sightless_images
 		if(ghostvision)
 			client.images |= ghost_darkness_images
-	else if(seedarkness && !ghostvision)
+	else if(!darkness_hidden && !ghostvision)
 		client.images |= ghost_sightless_images
 	client.images -= ghost_image //remove ourself
 


### PR DESCRIPTION
Need help with this.
- ~~At some point lighting became completely fucked despite not really changing it very much and I cannot for the life of me work out why or how.~~
- ~~Toggling darkness sets the alpha of both the lighting plane master and the darkness layer to 0, but this does not actually disables shadows, just makes them darker.~~
- ~~Space is perma-white.~~ 
- Adding plane masters for the skybox, dust and space planes causes space to be perma-white.
- The plane master objects block all clicks and prevent you from interacting with anything if they are in the client screen list.
Pls.