### PR TITLE
Changes spawn() count check from exactly to less than.

### DIFF
--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -37,7 +37,6 @@ exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 20 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto uses" 'goto '
-exactly 417 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 6 "atom/New uses" '^/(obj|atom|area|mob|turf).*/New\('
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong


### PR DESCRIPTION
The only time this comes up is when people are removing spawn and it decides to conflict or start failing random PRs post-merge. We can check for spawn use in review, we don't need to make builds fail because they removed one.