### PR TITLE
Added a cocktail system to replace cocktail reagents.

### DIFF
--- a/code/_helpers/cmp.dm
+++ b/code/_helpers/cmp.dm
@@ -87,3 +87,6 @@
 
 /proc/cmp_currency_denomination_des(var/datum/denomination/A, var/datum/denomination/B)
 	. = B.marked_value - A.marked_value
+
+/proc/cmp_cocktail_des(var/decl/cocktail/A, var/decl/cocktail/B)
+	. = B.mix_priority() - A.mix_priority()

--- a/code/_helpers/names.dm
+++ b/code/_helpers/names.dm
@@ -186,7 +186,7 @@ var/syndicate_code_response//Code response for traitors.
 
 	var/safety[] = list(1,2,3)//Tells the proc which options to remove later on.
 	var/nouns[] = list("love","hate","anger","peace","pride","sympathy","bravery","loyalty","honesty","integrity","compassion","charity","success","courage","deceit","skill","beauty","brilliance","pain","misery","beliefs","dreams","justice","truth","faith","liberty","knowledge","thought","information","culture","trust","dedication","progress","education","hospitality","leisure","trouble","friendships", "relaxation")
-	var/drinks[] = list("vodka and tonic","gin fizz","bahama mama","manhattan","black Russian","whiskey soda","long island tea","margarita","Irish coffee"," manly dwarf","Irish cream","doctor's delight","Beepksy Smash","tequilla sunrise","brave bull","gargle blaster","bloody mary","whiskey cola","white Russian","vodka martini","martini","Cuba libre","kahlua","vodka","wine","moonshine")
+	var/drinks[] = list("vodka and tonic","gin fizz","bahama mama","manhattan","black Russian","whiskey soda","long island tea","margarita","Irish coffee"," manly dwarf","Irish cream","doctor's delight","Beepsky Smash","tequilla sunrise","brave bull","gargle blaster","bloody mary","whiskey cola","white Russian","vodka martini","martini","Cuba libre","kahlua","vodka","wine","moonshine")
 	var/locations[] = length(stationlocs) ? stationlocs : drinks//if null, defaults to drinks instead.
 
 	var/maxwords = words//Extra var to check for duplicates.

--- a/code/controllers/subsystems/initialization/codex.dm
+++ b/code/controllers/subsystems/initialization/codex.dm
@@ -8,6 +8,7 @@ SUBSYSTEM_DEF(codex)
 	var/list/entries_by_string = list()
 	var/list/index_file =        list()
 	var/list/search_cache =      list()
+	var/list/categories =        list()
 
 /datum/controller/subsystem/codex/Initialize()
 	// Codex link syntax is such: 
@@ -26,13 +27,12 @@ SUBSYSTEM_DEF(codex)
 				add_entry_by_string(associated_string, centry)
 			if(centry.display_name)
 				add_entry_by_string(centry.display_name, centry)
-			centry.update_links()
 
 	// Create categorized entries.
 	for(var/ctype in subtypesof(/datum/codex_category))
 		var/datum/codex_category/cat = new ctype
+		categories[ctype] = cat
 		cat.Initialize()
-		qdel(cat)
 
 	// Create the index file for later use.
 	for(var/thing in SScodex.entries_by_path)
@@ -79,6 +79,10 @@ SUBSYSTEM_DEF(codex)
 		var/datum/browser/popup = new(presenting_to, "codex\ref[entry]", "Codex", nheight=425)
 		popup.set_content(parse_links(entry.get_text(presenting_to), presenting_to))
 		popup.open()
+
+/datum/controller/subsystem/codex/proc/get_guide(var/category)
+	var/datum/codex_category/cat = categories[category]
+	. = cat?.guide_html
 
 /datum/controller/subsystem/codex/proc/retrieve_entries_for_string(var/searching)
 

--- a/code/game/machinery/kitchen/icecream.dm
+++ b/code/game/machinery/kitchen/icecream.dm
@@ -33,7 +33,7 @@
 		if(ICECREAM_STRAWBERRY)
 			return list(/decl/reagent/drink/milk, /decl/reagent/drink/ice, /decl/reagent/drink/juice/berry)
 		if(ICECREAM_BLUE)
-			return list(/decl/reagent/drink/milk, /decl/reagent/drink/ice, /decl/reagent/ethanol/singulo)
+			return list(/decl/reagent/drink/milk, /decl/reagent/drink/ice, /decl/reagent/ethanol/bluecuracao)
 		if(ICECREAM_CHERRY)
 			return list(/decl/reagent/drink/milk, /decl/reagent/drink/ice, /decl/reagent/nutriment/cherryjelly)
 		if(ICECREAM_BANANA)
@@ -87,7 +87,7 @@
 	dat += "<b>Vanilla icecream:</b> <a href='?src=\ref[src];select=[ICECREAM_VANILLA]'><b>Select</b></a> <a href='?src=\ref[src];make=[ICECREAM_VANILLA];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[ICECREAM_VANILLA];amount=5'><b>x5</b></a> [product_types[ICECREAM_VANILLA]] scoops left. (Ingredients: milk, ice)<br>"
 	dat += "<b>Strawberry icecream:</b> <a href='?src=\ref[src];select=[ICECREAM_STRAWBERRY]'><b>Select</b></a> <a href='?src=\ref[src];make=[ICECREAM_STRAWBERRY];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[ICECREAM_STRAWBERRY];amount=5'><b>x5</b></a> [product_types[ICECREAM_STRAWBERRY]] dollops left. (Ingredients: milk, ice, berry juice)<br>"
 	dat += "<b>Chocolate icecream:</b> <a href='?src=\ref[src];select=[ICECREAM_CHOCOLATE]'><b>Select</b></a> <a href='?src=\ref[src];make=[ICECREAM_CHOCOLATE];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[ICECREAM_CHOCOLATE];amount=5'><b>x5</b></a> [product_types[ICECREAM_CHOCOLATE]] dollops left. (Ingredients: milk, ice, coco powder)<br>"
-	dat += "<b>Blue icecream:</b> <a href='?src=\ref[src];select=[ICECREAM_BLUE]'><b>Select</b></a> <a href='?src=\ref[src];make=[ICECREAM_BLUE];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[ICECREAM_BLUE];amount=5'><b>x5</b></a> [product_types[ICECREAM_BLUE]] dollops left. (Ingredients: milk, ice, singulo)<br>"
+	dat += "<b>Blue icecream:</b> <a href='?src=\ref[src];select=[ICECREAM_BLUE]'><b>Select</b></a> <a href='?src=\ref[src];make=[ICECREAM_BLUE];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[ICECREAM_BLUE];amount=5'><b>x5</b></a> [product_types[ICECREAM_BLUE]] dollops left. (Ingredients: milk, ice, blue curacao)<br>"
 	dat += "<b>Cherry icecream:</b> <a href='?src=\ref[src];select=[ICECREAM_CHERRY]'><b>Select</b></a> <a href='?src=\ref[src];make=[ICECREAM_CHERRY];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[ICECREAM_CHERRY];amount=5'><b>x5</b></a> [product_types[ICECREAM_CHERRY]] dollops left. (Ingredients: milk, ice, cherry jelly)<br>"
 	dat += "<b>Banana icecream:</b> <a href='?src=\ref[src];select=[ICECREAM_BANANA]'><b>Select</b></a> <a href='?src=\ref[src];make=[ICECREAM_BANANA];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[ICECREAM_BANANA];amount=5'><b>x5</b></a> [product_types[ICECREAM_BANANA]] dollops left. (Ingredients: milk, ice, banana)<br></div>"
 	dat += "<br><b>CONES</b><br><div class='statusDisplay'>"

--- a/code/game/machinery/vending/food.dm
+++ b/code/game/machinery/vending/food.dm
@@ -140,7 +140,6 @@
 		/obj/item/chems/food/drinks/bottle/melonliquor = 5,
 		/obj/item/chems/food/drinks/bottle/bluecuracao = 5,
 		/obj/item/chems/food/drinks/bottle/absinthe = 5,
-		/obj/item/chems/food/drinks/bottle/bottleofnothing =5,
 		/obj/item/chems/food/drinks/bottle/champagne = 5,
 		/obj/item/chems/food/drinks/bottle/herbal = 5,
 		/obj/item/chems/food/drinks/bottle/small/beer = 15,

--- a/code/game/objects/items/books/manuals/manuals.dm
+++ b/code/game/objects/items/books/manuals/manuals.dm
@@ -4,6 +4,8 @@
 	author = "Victoria Ponsonby"
 	title = "Chef Recipes"
 
+/obj/item/book/manual/chef_recipes/Initialize()
+	. = ..()
 	dat = {"<html>
 				<head>
 				<style>
@@ -17,52 +19,19 @@
 				</style>
 				</head>
 				<body>
-
-				<h1>Food for Dummies</h1>
-				Here is a guide on basic food recipes and also how to not poison your customers accidentally.
-
-				<h3>Basics:</h3>
-				Knead an egg and some flour along with some water to make dough. Bake that to make a bun or flatten and cut it.
-
-				<h3>Burger:</h3>
-				Put a bun and some meat into the microwave and turn it on. Then wait.
-
-				<h3>Bread:</h3>
-				Put some dough and an egg into the microwave and then wait.
-
-				<h3>Waffles:</h3>
-				Add two lumps of dough and 10 units of sugar to the microwave and then wait.
-
-				<h3>Popcorn:</h3>
-				Add 1 corn to the microwave and wait.
-
-				<h3>Meat Steak:</h3>
-				Put a slice of meat, 1 unit of salt, and 1 unit of pepper into the microwave and wait.
-
-				<h3>Meat Pie:</h3>
-				Put a flattened piece of dough and some meat into the microwave and wait.
-
-				<h3>Boiled Spaghetti:</h3>
-				Put the spaghetti (processed flour) and 5 units of water into the microwave and wait.
-
-				<h3>Donuts:</h3>
-				Add some dough and 5 units of sugar to the microwave and wait.
-
-				<h3>Fries:</h3>
-				Add one potato to the processor, then bake them in the microwave.
-
-
+				[SScodex.get_guide(/datum/codex_category/recipes)]
 				</body>
 			</html>
 			"}
-
 
 /obj/item/book/manual/barman_recipes
-	name = "Barman Recipes"
+	name = "Mixology 101"
 	icon_state = "barbook"
 	author = "Sir John Rose"
-	title = "Barman Recipes"
+	title = "Mixology 101"
 
+/obj/item/book/manual/barman_recipes/Initialize()
+	. = ..()
 	dat = {"<html>
 				<head>
 				<style>
@@ -76,42 +45,12 @@
 				</style>
 				</head>
 				<body>
-
-				<h1>Drinks for Dummies</h1>
-				Here's a guide for some basic drinks.
-
-				<h3>Black Russian:</h3>
-				Mix vodka and Kahlua into a glass.
-
-				<h3>Cafe Latte:</h3>
-				Mix milk and coffee into a glass.
-
-				<h3>Classic Martini:</h3>
-				Mix vermouth and gin into a glass.
-
-				<h3>Gin Tonic:</h3>
-				Mix gin and tonic into a glass.
-
-				<h3>Grog:</h3>
-				Mix rum and water into a glass.
-
-				<h3>Irish Cream:</h3>
-				Mix cream and whiskey into a glass.
-
-				<h3>The Manly Dorf:</h3>
-				Mix ale and beer into a glass.
-
-				<h3>Mead:</h3>
-				Mix enzyme, water, and sugar into a glass.
-
-				<h3>Screwdriver:</h3>
-				Mix vodka and orange juice into a glass.
-
+				[SScodex.get_guide(/datum/codex_category/cocktails)]
 				</body>
 			</html>
 			"}
 
-
+SScuis
 /obj/item/book/manual/detective
 	name = "The Film Noir: Proper Procedures for Investigations"
 	icon_state ="bookDetective"

--- a/code/game/objects/items/books/manuals/manuals.dm
+++ b/code/game/objects/items/books/manuals/manuals.dm
@@ -50,7 +50,6 @@
 			</html>
 			"}
 
-SScuis
 /obj/item/book/manual/detective
 	name = "The Film Noir: Proper Procedures for Investigations"
 	icon_state ="bookDetective"

--- a/code/modules/codex/categories/_category.dm
+++ b/code/modules/codex/categories/_category.dm
@@ -2,10 +2,14 @@
 	var/name = "Generic Category"
 	var/desc = "Some description for category's codex entry"
 	var/list/items = list()
+
+	var/guide_name
 	var/guide_html
+	var/list/guide_strings
 
 //Children should call ..() at the end after filling the items list
 /datum/codex_category/proc/Initialize()
+
 	if(items.len)
 		var/datum/codex_entry/entry = new(_display_name = "[name] (category)")
 		entry.lore_text = desc + "<hr>"
@@ -13,5 +17,16 @@
 		for(var/item in items)
 			links+= "<l>[item]</l>"
 		entry.lore_text += jointext(links, "<br>")
+		if(guide_name && guide_html)
+			entry.mechanics_text("This category has <span codexlink='[guide_name]]'>an associated guide</span>.")
 		SScodex.add_entry_by_string(lowertext(entry.display_name), entry)
-	build_guide()
+
+	if(guide_html)
+		if(guide_name)
+			LAZYDISTINCTADD(guide_strings, lowertext(guide_name))
+		var/datum/codex_entry/entry = new(      \
+			_display_name = "Guide to [capitalize(guide_name || name)]",  \
+			_associated_strings = guide_strings \
+			)
+		entry.mechanics_text = guide_html
+		SScodex.add_entry_by_string(lowertext(entry.display_name), entry)

--- a/code/modules/codex/categories/_category.dm
+++ b/code/modules/codex/categories/_category.dm
@@ -2,6 +2,7 @@
 	var/name = "Generic Category"
 	var/desc = "Some description for category's codex entry"
 	var/list/items = list()
+	var/guide_html
 
 //Children should call ..() at the end after filling the items list
 /datum/codex_category/proc/Initialize()
@@ -13,4 +14,4 @@
 			links+= "<l>[item]</l>"
 		entry.lore_text += jointext(links, "<br>")
 		SScodex.add_entry_by_string(lowertext(entry.display_name), entry)
-
+	build_guide()

--- a/code/modules/codex/categories/_category.dm
+++ b/code/modules/codex/categories/_category.dm
@@ -18,7 +18,7 @@
 			links+= "<l>[item]</l>"
 		entry.lore_text += jointext(links, "<br>")
 		if(guide_name && guide_html)
-			entry.mechanics_text("This category has <span codexlink='[guide_name]]'>an associated guide</span>.")
+			entry.mechanics_text = "This category has <span codexlink='[guide_name]]'>an associated guide</span>."
 		SScodex.add_entry_by_string(lowertext(entry.display_name), entry)
 
 	if(guide_html)

--- a/code/modules/codex/categories/_category.dm
+++ b/code/modules/codex/categories/_category.dm
@@ -18,7 +18,7 @@
 			links+= "<l>[item]</l>"
 		entry.lore_text += jointext(links, "<br>")
 		if(guide_name && guide_html)
-			entry.mechanics_text = "This category has <span codexlink='[guide_name]]'>an associated guide</span>."
+			entry.mechanics_text = "This category has <span codexlink='Guide to [capitalize(guide_name || name)]'>an associated guide</span>."
 		SScodex.add_entry_by_string(lowertext(entry.display_name), entry)
 
 	if(guide_html)

--- a/code/modules/codex/categories/category_cocktails.dm
+++ b/code/modules/codex/categories/category_cocktails.dm
@@ -1,0 +1,41 @@
+/datum/codex_category/cocktails
+	name = "Cocktails"
+	desc = "Various mixes of drinks, alcoholic and otherwise, that can be made by a skilled bartender."
+
+/datum/codex_category/cocktails/Initialize()
+
+	var/list/entries_to_register = list()
+	var/list/cocktails = decls_repository.get_decls_of_subtype(/decl/cocktail)
+	guide_html = "<h1>Mixology 101</h1>Here's a guide for mixing decent cocktails."
+	for(var/ctype in cocktails)
+		var/decl/cocktail/cocktail = cocktails[ctype]
+		if(cocktail.hidden_from_codex)
+			continue
+
+		var/mechanics_text = "Cocktails will change the name of bartending glasses when mixed properly.<br><br>"
+		mechanics_text += "This cocktail is mixed with the following ingredients:<br>"        
+		var/list/ingredients = list()
+		for(var/rtype in cocktail.ratios)
+			// If anyone can think of a good way to find the lowest common
+			// divisor of these part values and make it a bit neater, please
+			// feel free to change this block to use it.
+			var/decl/reagent/mixer = decls_repository.get_decl(rtype) 
+			var/ingredient = "[cocktail.ratios[rtype] >= 0.1 ? "[ceil(cocktail.ratios[rtype] * 10)] part\s" : "a dash of"] [mixer.name]"
+			ingredients += ingredient
+		
+		guide_html += "<h3>[capitalize(cocktail.name)]</h3>Mix [english_list(ingredients)] in a glass."
+		mechanics_text += "<ul><li>[jointext(ingredients, "</li><li>")]</li></ul>"
+
+		entries_to_register += new /datum/codex_entry(         \
+		 _display_name =       "[cocktail.name] (cocktail)",   \
+		 _associated_strings = list(lowertext(cocktail.name)), \
+		 _lore_text =          cocktail.description,           \
+		 _mechanics_text =     mechanics_text,                 \
+		)
+
+	for(var/datum/codex_entry/entry in entries_to_register)
+		entry.update_links()
+		SScodex.add_entry_by_string(entry.display_name, entry)
+		items += entry.display_name
+
+	..()

--- a/code/modules/codex/categories/category_cocktails.dm
+++ b/code/modules/codex/categories/category_cocktails.dm
@@ -1,6 +1,8 @@
 /datum/codex_category/cocktails
 	name = "Cocktails"
 	desc = "Various mixes of drinks, alcoholic and otherwise, that can be made by a skilled bartender."
+	guide_name = "Bartending"
+	guide_strings = list("bartender", "cocktails", "bartending")
 
 /datum/codex_category/cocktails/Initialize()
 
@@ -34,7 +36,6 @@
 		)
 
 	for(var/datum/codex_entry/entry in entries_to_register)
-		entry.update_links()
 		SScodex.add_entry_by_string(entry.display_name, entry)
 		items += entry.display_name
 

--- a/code/modules/codex/categories/category_cultures.dm
+++ b/code/modules/codex/categories/category_cultures.dm
@@ -9,7 +9,6 @@
 		if(!culture.hidden_from_codex)
 			var/datum/codex_entry/entry = new(_display_name = "[culture.name] ([lowertext(culture.desc_type)])")
 			entry.lore_text = culture.description
-			entry.update_links()
 			SScodex.add_entry_by_string(culture.name, entry)
 			items += culture.name
 	..()

--- a/code/modules/codex/categories/category_materials.dm
+++ b/code/modules/codex/categories/category_materials.dm
@@ -99,7 +99,6 @@
 				material_info += "It can be used to pad furniture."
 
 			entry.mechanics_text = jointext(material_info,"<br>")
-			entry.update_links()
 			SScodex.add_entry_by_string(entry.display_name, entry)
 			items += entry.display_name
 	..()

--- a/code/modules/codex/categories/category_reagents.dm
+++ b/code/modules/codex/categories/category_reagents.dm
@@ -84,7 +84,6 @@
 		entries_to_register += entry
 
 	for(var/datum/codex_entry/entry in entries_to_register)
-		entry.update_links()
 		SScodex.add_entry_by_string(entry.display_name, entry)
 		items += entry.display_name
 

--- a/code/modules/codex/categories/category_recipes.dm
+++ b/code/modules/codex/categories/category_recipes.dm
@@ -1,6 +1,8 @@
 /datum/codex_category/recipes
 	name = "Recipes"
 	desc = "Recipes for a variety of different kinds of foods and condiments."
+	guide_name = "Cooking"
+	guide_strings = list("chef", "cooking", "recipes")
 
 /datum/codex_category/recipes/Initialize()
 
@@ -110,7 +112,7 @@
 		)
 
 	for(var/datum/codex_entry/entry in entries_to_register)
-		entry.update_links()
 		SScodex.add_entry_by_string(entry.display_name, entry)
 		items += entry.display_name
+
 	..()

--- a/code/modules/codex/categories/category_recipes.dm
+++ b/code/modules/codex/categories/category_recipes.dm
@@ -6,6 +6,18 @@
 
 	var/list/entries_to_register = list()
 
+	guide_html = {"
+		<h1>Chef recipes</h1>
+		Here is a guide on food recipes and also how to not poison your customers accidentally.
+
+		<h3>Basics:</h3>
+		<ul>
+		<li>Mix an egg and some flour along with some water to make dough.</li>
+		<li>Bake that to make a bun or flatten and cut it.</li>
+		<li>Cup up a meat slab with a sharp knife to make cutlets.</li>
+		<li>Mix flour and protein (ground meat) to make meatballs.</li>
+		</ul>"}
+
 	for(var/reactiontype in subtypesof(/datum/chemical_reaction/recipe))
 		var/datum/chemical_reaction/recipe/food = SSchemistry.chemical_reactions[reactiontype]
 		if(!food || !food.name || food.hidden_from_codex)
@@ -69,24 +81,25 @@
 		var/mechanics_text = ""
 		if(recipe.mechanics_text)
 			mechanics_text = "[recipe.mechanics_text]<br><br>"
-		mechanics_text += "This recipe requires the following ingredients:<br><ul>"
+		mechanics_text += "This recipe requires the following ingredients:<br>"
+		var/list/ingredients = list()
 		for(var/thing in recipe.reagents)
 			var/decl/reagent/thing_reagent = thing
-			mechanics_text += "<li>[recipe.reagents[thing]]u [initial(thing_reagent.name)]</li>"
+			ingredients += "[recipe.reagents[thing]]u [initial(thing_reagent.name)]"
 		for(var/thing in recipe.items)
 			var/atom/thing_atom = thing
-			mechanics_text += "<li>\a [initial(thing_atom.name)]</li>"
+			ingredients += "\a [initial(thing_atom.name)]"
 		for(var/thing in recipe.fruit)
-			mechanics_text += "<li>[recipe.fruit[thing]] [thing]\s</li>"
-		mechanics_text += "</ul>"
+			ingredients += "[recipe.fruit[thing]] [thing]\s"
+		mechanics_text += "<ul><li>[jointext(ingredients, "</li><li>")]</li></ul>"
 		var/atom/recipe_product = recipe.result
 		mechanics_text += "<br>This recipe takes [ceil(recipe.time/10)] second\s to cook in a microwave and creates \a [initial(recipe_product.name)]."
 		var/lore_text = recipe.lore_text
 		if(!lore_text)
 			lore_text = initial(recipe_product.desc)
-		var/recipe_name = recipe.display_name
-		if(!recipe_name)
-			recipe_name = sanitize(initial(recipe_product.name))
+
+		var/recipe_name = recipe.display_name || sanitize(initial(recipe_product.name))
+		guide_html += "<h3>[capitalize(recipe_name)]</h3>Place [english_list(ingredients)] into a microwave for [ceil(recipe.time/10)] second\s."
 
 		entries_to_register += new /datum/codex_entry(             \
 		 _display_name =       "[recipe_name] (microwave recipe)", \

--- a/code/modules/codex/categories/category_species.dm
+++ b/code/modules/codex/categories/category_species.dm
@@ -9,7 +9,6 @@
 			var/datum/codex_entry/entry = new(_display_name = "[species.name] (species)")
 			entry.lore_text = species.codex_description
 			entry.mechanics_text = species.ooc_codex_information
-			entry.update_links()
 			SScodex.add_entry_by_string(entry.display_name, entry)
 			SScodex.add_entry_by_string(species.name, entry)
 			items += entry.display_name

--- a/code/modules/codex/entries/_codex_entry.dm
+++ b/code/modules/codex/entries/_codex_entry.dm
@@ -9,9 +9,6 @@
 /datum/codex_entry/dd_SortValue()
 	return display_name
 
-/datum/codex_entry/proc/update_links()
-	return
-
 /datum/codex_entry/New(var/_display_name, var/list/_associated_paths, var/list/_associated_strings, var/_lore_text, var/_mechanics_text, var/_antag_text)
 
 	if(_display_name)       display_name =       _display_name

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -226,7 +226,10 @@
 	seed_name = "bluespace tomato"
 	display_name = "bluespace tomato plant"
 	mutants = null
-	chems = list(/decl/reagent/nutriment = list(1,20), /decl/reagent/ethanol/singulo = list(10,5))
+	chems = list(
+		/decl/reagent/nutriment = list(1,20), 
+		/decl/reagent/ethanol/bluecuracao = list(10,5)
+	)
 
 /datum/seed/tomato/blue/teleport/New()
 	..()

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -62,7 +62,7 @@
 		/decl/reagent/drink/milk =                     0.1,
 		/decl/reagent/ethanol/beer =                   0.25,
 		/decl/reagent/phosphorus =                     0.1,
-		/decl/reagent/nutriment/sugar =                          0.1,
+		/decl/reagent/nutriment/sugar =                0.1,
 		/decl/reagent/drink/sodawater =                0.1,
 		/decl/reagent/ammonia =                        1,
 		/decl/reagent/nutriment =                      1,

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -122,7 +122,6 @@
 			new/obj/item/clothing/head/beret(src)
 			new/obj/item/clothing/accessory/suspenders(src)
 			new/obj/item/pen/crayon/mime(src)
-			new/obj/item/chems/food/drinks/bottle/bottleofnothing(src)
 		if(96)
 			new/obj/item/vampiric(src)
 		if(97)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -13,7 +13,7 @@
 	var/alpha = 255
 	var/flags = 0
 	var/hidden_from_codex
-
+	var/cocktail_ingredient
 	var/glass_icon = DRINK_ICON_DEFAULT
 	var/glass_name = "something"
 	var/glass_desc = "It's a glass of... what, exactly?"
@@ -47,6 +47,15 @@
 	var/scent_intensity = /decl/scent_intensity/normal
 	var/scent_descriptor = SCENT_DESC_SMELL
 	var/scent_range = 1
+
+/decl/reagent/Initialize()
+	. = ..()
+	var/list/cocktails = decls_repository.get_decls_of_subtype(/decl/cocktail)
+	for(var/ctype in cocktails)
+		var/decl/cocktail/cocktail = cocktails[ctype]
+		if(type in cocktail.ratios)
+			cocktail_ingredient = TRUE
+			break
 
 /decl/reagent/proc/on_leaving_metabolism(var/mob/parent, var/metabolism_class)
 	return
@@ -138,5 +147,11 @@
 
 /decl/reagent/proc/build_presentation_name_from_reagents(var/obj/item/prop, var/supplied)
 	. = supplied
+
+	if(cocktail_ingredient)
+		for(var/decl/cocktail/cocktail in SSchemistry.get_cocktails_by_primary_ingredient(type))
+			if(cocktail.matches(prop))
+				return cocktail.get_presentation_name(prop)
+
 	if(prop.reagents.has_reagent(/decl/reagent/drink/ice))
 		. = "iced [.]"

--- a/code/modules/reagents/chems/chems_blood.dm
+++ b/code/modules/reagents/chems/chems_blood.dm
@@ -1,5 +1,5 @@
 /decl/reagent/blood
-	name = "Blood"
+	name = "blood"
 	description = "A red (or blue) liquid commonly found inside animals, most of whom are pretty insistent about it being left where you found it."
 	metabolism = REM * 5
 	color = "#c80000"

--- a/code/modules/reagents/chems/chems_cleaner.dm
+++ b/code/modules/reagents/chems/chems_cleaner.dm
@@ -1,4 +1,3 @@
-
 /decl/reagent/cleaner
 	name = "spray cleaner"
 	description = "A compound used to clean things. Now with 50% more sodium hypochlorite!"

--- a/code/modules/reagents/chems/chems_drinks.dm
+++ b/code/modules/reagents/chems/chems_drinks.dm
@@ -645,32 +645,6 @@
 	glass_name = "pumpkin spice syrup"
 	glass_desc = "Thick spiced pumpkin syrup used to flavor drinks."
 
-// Non-Alcoholic Drinks
-/decl/reagent/drink/fools_gold
-	name = "Fool's Gold"
-	description = "A non-alcoholic beverage typically served as an alternative to whiskey."
-	taste_description = "watered down whiskey"
-	color = "#e78108"
-	glass_name = "fools gold"
-	glass_desc = "A non-alcoholic beverage typically served as an alternative to whiskey."
-
-/decl/reagent/drink/snowball
-	name = "Snowball"
-	description = "A cold pick-me-up frequently drunk in scientific outposts and academic fields."
-	taste_description = "intellectual thought and brain-freeze"
-	color = "#eeecea"
-	adj_temp = -5
-	glass_name = "snowball"
-	glass_desc = "A cold pick-me-up frequently drunk in scientific outposts and academic fields."
-
-/decl/reagent/drink/browndwarf
-	name = "Brown Dwarf"
-	description = "A large gas body made of chocolate that has failed to sustain nuclear fusion."
-	taste_description = "dark chocolatey matter"
-	color = "#44371f"
-	glass_name = "brown dwarf"
-	glass_desc = "A large gas body made of chocolate that has failed to sustain nuclear fusion."
-
 /decl/reagent/drink/gingerbeer
 	name = "ginger beer"
 	description = "A hearty, non-alcoholic beverage brewed from ginger."

--- a/code/modules/reagents/chems/chems_drinks.dm
+++ b/code/modules/reagents/chems/chems_drinks.dm
@@ -516,14 +516,6 @@
 	..()
 	M.bodytemperature += 10 * TEMPERATURE_DAMAGE_COEFFICIENT
 
-/decl/reagent/drink/nothing
-	name = "nothing"
-	description = "Absolutely nothing."
-	taste_description = "nothing"
-
-	glass_name = "nothing"
-	glass_desc = "Absolutely nothing."
-
 /decl/reagent/drink/tea/build_presentation_name_from_reagents(var/obj/item/prop, var/supplied)
 	. = supplied || glass_name
 	if(prop.reagents.has_reagent(/decl/reagent/nutriment/sugar) || prop.reagents.has_reagent(/decl/reagent/nutriment/honey))

--- a/code/modules/reagents/chems/chems_drinks.dm
+++ b/code/modules/reagents/chems/chems_drinks.dm
@@ -403,20 +403,6 @@
 	glass_name = "milkshake"
 	glass_desc = "Glorious brainfreezing mixture."
 
-/decl/reagent/drink/rewriter
-	name = "Rewriter"
-	description = "The secret of the sanctuary of the Libarian..."
-	taste_description = "a bad night out"
-	color = "#485000"
-	adj_temp = -5
-
-	glass_name = "Rewriter"
-	glass_desc = "The secret of the sanctuary of the Libarian..."
-
-/decl/reagent/drink/rewriter/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	..()
-	M.make_jittery(5)
-
 /decl/reagent/drink/mutagencola
 	name = "mutagen cola"
 	description = "The energy of a radioactive isotope in beverage form."
@@ -503,26 +489,6 @@
 	glass_name = "lemon lime soda"
 	glass_desc = "A tangy substance made of 0.5% natural citrus!"
 	glass_special = list(DRINK_FIZZ)
-
-/decl/reagent/drink/doctor_delight
-	name = "The Doctor's Delight"
-	description = "Tasty drink that keeps you healthy and doctors bored.  Just the way they like it."
-	taste_description = "homely fruit"
-	color = "#ff8cff"
-	nutrition = 1
-
-	glass_name = "The Doctor's Delight"
-	glass_desc = "A healthy mixture of juices, guaranteed to keep you healthy until the next exile decides to put a few new holes in you."
-
-/decl/reagent/drink/doctor_delight/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	..()
-	M.adjustOxyLoss(-4 * removed)
-	M.heal_organ_damage(2 * removed, 2 * removed)
-	M.adjustToxLoss(-2 * removed)
-	if(M.dizziness)
-		M.dizziness = max(0, M.dizziness - 15)
-	if(M.confused)
-		M.confused = max(0, M.confused - 5)
 
 /decl/reagent/drink/dry_ramen
 	name = "dry ramen"

--- a/code/modules/reagents/chems/chems_ethanol.dm
+++ b/code/modules/reagents/chems/chems_ethanol.dm
@@ -117,7 +117,7 @@
 	M.jitteriness = max(M.jitteriness - 3, 0)
 
 /decl/reagent/ethanol/bluecuracao
-	name = "blue Curacao"
+	name = "blue curacao"
 	description = "Exotically blue, fruity drink, distilled from oranges."
 	taste_description = "oranges"
 	taste_mult = 1.1
@@ -299,323 +299,6 @@
 	glass_name = "herbal liquor"
 	glass_desc = "It's definitely green. Or is it yellow?"
 
-// Cocktails
-/decl/reagent/ethanol/acid_spit
-	name = "Acid Spit"
-	description = "A drink for the daring, can be deadly if incorrectly prepared!"
-	taste_description = "stomach acid"
-	color = "#365000"
-	strength = 30
-
-	glass_name = "Acid Spit"
-	glass_desc = "A drink from the company archives. Made from live aliens."
-
-/decl/reagent/ethanol/alliescocktail
-	name = "Allies cocktail"
-	description = "A drink made from your allies, not as sweet as when made from your enemies."
-	taste_description = "bitter yet free"
-	color = "#d8ac45"
-	strength = 25
-
-	glass_name = "Allies cocktail"
-	glass_desc = "A drink made from your allies."
-
-/decl/reagent/ethanol/aloe
-	name = "Aloe"
-	description = "So very, very, very good."
-	taste_description = "sweet 'n creamy"
-	color = "#b7ea75"
-	strength = 15
-
-	glass_name = "Aloe"
-	glass_desc = "Very, very, very good."
-
-/decl/reagent/ethanol/amasec
-	name = "Amasec"
-	description = "Official drink of the Gun Club!"
-	taste_description = "dark and metallic"
-	color = "#ff975d"
-	strength = 25
-
-	glass_name = "Amasec"
-	glass_desc = "Always handy before COMBAT!!!"
-
-/decl/reagent/ethanol/andalusia
-	name = "Andalusia"
-	description = "A nice, strangely named drink."
-	taste_description = "lemons"
-	color = "#f4ea4a"
-	strength = 15
-
-	glass_name = "Andalusia"
-	glass_desc = "A nice, strange named drink."
-
-/decl/reagent/ethanol/antifreeze
-	name = "Anti-freeze"
-	description = "Ultimate refreshment."
-	taste_description = "Jack Frost's piss"
-	color = "#56deea"
-	strength = 12
-	adj_temp = 20
-	targ_temp = 330
-
-	glass_name = "Anti-freeze"
-	glass_desc = "The ultimate refreshment."
-
-/decl/reagent/ethanol/atomicbomb
-	name = "Atomic Bomb"
-	description = "Nuclear proliferation never tasted so good."
-	taste_description = "da bomb"
-	color = "#666300"
-	strength = 10
-	druggy = 50
-
-	glass_name = "Atomic Bomb"
-	glass_desc = "We cannot take legal responsibility for your actions after imbibing."
-
-/decl/reagent/ethanol/coffee/b52
-	name = "B-52"
-	description = "Coffee, Irish Cream, and cognac. You will get bombed."
-	taste_description = "angry and irish"
-	taste_mult = 1.3
-	color = "#997650"
-	strength = 12
-
-	glass_name = "B-52"
-	glass_desc = "Kahlua, Irish cream, and congac. You will get bombed."
-
-/decl/reagent/ethanol/bahama_mama
-	name = "Bahama Mama"
-	description = "Tropical cocktail."
-	taste_description = "lime and orange"
-	color = "#ff7f3b"
-	strength = 25
-
-	glass_name = "Bahama Mama"
-	glass_desc = "Tropical cocktail"
-
-/decl/reagent/ethanol/bananahonk
-	name = "Banana Mama"
-	description = "A drink from Clown Heaven."
-	taste_description = "a bad joke"
-	nutriment_factor = 1
-	color = "#ffff91"
-	strength = 12
-
-	glass_name = "Banana Honk"
-	glass_desc = "A drink from Banana Heaven."
-
-/decl/reagent/ethanol/barefoot
-	name = "Barefoot"
-	description = "Barefoot and pregnant"
-	taste_description = "creamy berries"
-	color = "#ffcdea"
-	strength = 30
-
-	glass_name = "Barefoot"
-	glass_desc = "Barefoot and pregnant"
-
-/decl/reagent/ethanol/beepsky_smash
-	name = "Beepsky Smash"
-	description = "Deny drinking this and prepare for THE LAW."
-	taste_description = "JUSTICE"
-	taste_mult = 2
-	color = "#404040"
-	strength = 12
-
-	glass_name = "Beepsky Smash"
-	glass_desc = "Heavy, hot and strong. Just like the Iron fist of the LAW."
-
-/decl/reagent/ethanol/beepsky_smash/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	..()
-	M.Stun(2)
-
-/decl/reagent/ethanol/bilk
-	name = "bilk"
-	description = "This appears to be beer mixed with milk. Disgusting."
-	taste_description = "desperation and lactate"
-	color = "#895c4c"
-	strength = 50
-	nutriment_factor = 2
-
-	glass_name = "bilk"
-	glass_desc = "A brew of milk and beer. For those alcoholics who fear osteoporosis."
-
-/decl/reagent/ethanol/black_russian
-	name = "Black Russian"
-	description = "For the lactose-intolerant. Still as classy as a White Russian."
-	taste_description = "bitterness"
-	color = "#360000"
-	strength = 15
-
-	glass_name = "Black Russian"
-	glass_desc = "For the lactose-intolerant. Still as classy as a White Russian."
-
-/decl/reagent/ethanol/bloody_mary
-	name = "Bloody Mary"
-	description = "A strange yet pleasurable mixture made of vodka, tomato and lime juice. Or at least you THINK the red stuff is tomato juice."
-	taste_description = "tomatoes with a hint of lime"
-	color = "#b40000"
-	strength = 15
-
-	glass_name = "Bloody Mary"
-	glass_desc = "Tomato juice, mixed with Vodka and a lil' bit of lime. Tastes like liquid murder."
-
-/decl/reagent/ethanol/booger
-	name = "Booger"
-	description = "Ewww..."
-	taste_description = "sweet 'n creamy"
-	color = "#8cff8c"
-	strength = 30
-
-	glass_name = "Booger"
-	glass_desc = "Ewww..."
-
-/decl/reagent/ethanol/coffee/brave_bull
-	name = "Brave Bull"
-	description = "It's just as effective as Dutch-Courage!"
-	taste_description = "alcoholic bravery"
-	taste_mult = 1.1
-	color = "#4c3100"
-	strength = 15
-
-	glass_name = "Brave Bull"
-	glass_desc = "Tequilla and coffee liquor, brought together in a mouthwatering mixture. Drink up."
-
-/decl/reagent/ethanol/changelingsting
-	name = "Changeling Sting"
-	description = "You take a tiny sip and feel a burning sensation..."
-	taste_description = "your brain coming out your nose"
-	color = "#2e6671"
-	strength = 10
-
-	glass_name = "Changeling Sting"
-	glass_desc = "A stingy drink."
-
-/decl/reagent/ethanol/martini
-	name = "classic martini"
-	description = "Vermouth with Gin. Not quite how 007 enjoyed it, but still delicious."
-	taste_description = "dry class"
-	color = "#0064c8"
-	strength = 25
-
-	glass_name = "classic martini"
-	glass_desc = "Damn, the bartender even stirred it, not shook it."
-
-/decl/reagent/ethanol/cuba_libre
-	name = "Cuba Libre"
-	description = "Rum, mixed with cola. Viva la revolucion."
-	taste_description = "cola"
-	color = "#3e1b00"
-	strength = 30
-
-	glass_name = "Cuba Libre"
-	glass_desc = "A classic mix of rum and cola."
-
-/decl/reagent/ethanol/demonsblood
-	name = "Demons Blood"
-	description = "AHHHH!!!!"
-	taste_description = "sweet tasting iron"
-	taste_mult = 1.5
-	color = "#820000"
-	strength = 15
-
-	glass_name = "Demons' Blood"
-	glass_desc = "Just looking at this thing makes the hair at the back of your neck stand up."
-
-/decl/reagent/ethanol/devilskiss
-	name = "Devils Kiss"
-	description = "Creepy time!"
-	taste_description = "bitter iron"
-	color = "#a68310"
-	strength = 15
-
-	glass_name = "Devil's Kiss"
-	glass_desc = "Creepy time!"
-
-/decl/reagent/ethanol/driestmartini
-	name = "driest martini"
-	description = "Only for the experienced. You think you see sand floating in the glass."
-	taste_description = "a beach"
-	nutriment_factor = 1
-	color = "#2e6671"
-	strength = 12
-
-	glass_name = "driest martini"
-	glass_desc = "Only for the experienced. You think you see sand floating in the glass."
-
-/decl/reagent/ethanol/ginfizz
-	name = "gin fizz"
-	description = "Refreshingly lemony, deliciously dry."
-	taste_description = "dry, tart lemons"
-	color = "#ffffae"
-	strength = 30
-
-	glass_name = "gin fizz"
-	glass_desc = "Refreshingly lemony, deliciously dry."
-
-/decl/reagent/ethanol/grog
-	name = "grog"
-	description = "Watered-down rum, pirate approved!"
-	taste_description = "a poor excuse for alcohol"
-	color = "#ffbb00"
-	strength = 100
-
-	glass_name = "grog"
-	glass_desc = "A fine and cepa drink for Space."
-
-/decl/reagent/ethanol/erikasurprise
-	name = "Erika Surprise"
-	description = "The surprise is, it's green!"
-	taste_description = "tartness and bananas"
-	color = "#2e6671"
-	strength = 15
-
-	glass_name = "Erika Surprise"
-	glass_desc = "The surprise is, it's green!"
-
-/decl/reagent/ethanol/livergeist
-	name = "The Livergeist"
-	description = "Looking at this beverage, you can faintly hear your liver swear it'll come back to haunt you."
-	taste_description = "your liver being ripped out of your body, but in the best, most delicious meaning of those words."
-	taste_mult = 5
-	color = "#7f00ff"
-	strength = 10
-	glass_name = "The Livergeist"
-	glass_desc = "Looking at this beverage, you can faintly hear your liver swear it'll come back to haunt you."
-
-/decl/reagent/ethanol/gintonic
-	name = "gin and tonic"
-	description = "An all time classic, mild cocktail."
-	taste_description = "mild tartness" //???
-	color = "#0064c8"
-	strength = 50
-
-	glass_name = "gin and tonic"
-	glass_desc = "A mild but still great cocktail. Drink up, like a true Englishman."
-
-/decl/reagent/ethanol/goldschlager
-	name = "cinnamon schnapps"
-	description = "100 proof cinnamon schnapps, made for alcoholic teen girls on spring break."
-	taste_description = "burning cinnamon"
-	taste_mult = 1.3
-	color = "#f4e46d"
-	strength = 15
-
-	glass_name = "Goldschlager"
-	glass_desc = "100 proof that teen girls will drink anything with gold in it."
-
-/decl/reagent/ethanol/hippies_delight
-	name = "Hippies' Delight"
-	description = "You just don't get it maaaan."
-	taste_description = "giving peace a chance"
-	color = "#ff88ff"
-	strength = 15
-	druggy = 50
-
-	glass_name = "Hippie's Delight"
-	glass_desc = "A drink enjoyed by people during the 1960's."
-
 /decl/reagent/ethanol/hooch
 	name = "hooch"
 	description = "Either someone's failure at cocktail making or attempt in alchohol production. In any case, do you really want to drink that?"
@@ -627,86 +310,15 @@
 	glass_name = "Hooch"
 	glass_desc = "You've really hit rock bottom now... your liver packed its bags and left last night."
 
-/decl/reagent/ethanol/irishslammer
-	name = "Irish Slammer"
-	description = "Mmm, tastes like chocolate cake..."
-	taste_description = "delicious anger"
-	color = "#2e6671"
-	strength = 15
-
-	glass_name = "Irish slammer"
-	glass_desc = "An Irish slammer, mixed with cream, whiskey, and ale."
-
-/decl/reagent/ethanol/coffee/irishcoffee
-	name = "Irish coffee"
-	description = "Coffee, and alcohol. More fun than a Mimosa to drink in the morning."
-	taste_description = "giving up on the day"
-	color = "#4c3100"
-	strength = 15
-
-	glass_name = "Irish coffee"
-	glass_desc = "Coffee and alcohol. More fun than a Mimosa to drink in the morning."
-
 /decl/reagent/ethanol/irish_cream
 	name = "Irish cream"
-	description = "Whiskey-imbued cream, what else would you expect from the Irish."
+	description = "Whiskey-imbued cream."
 	taste_description = "creamy alcohol"
 	color = "#dddd9a"
 	strength = 25
 
 	glass_name = "Irish cream"
-	glass_desc = "It's cream, mixed with whiskey. What else would you expect from the Irish?"
-
-/decl/reagent/ethanol/longislandicedtea
-	name = "Long Island Iced Tea"
-	description = "The liquor cabinet, brought together in a delicious mix. Intended for middle-aged alcoholic women only."
-	taste_description = "a mixture of cola and alcohol"
-	color = "#895b1f"
-	strength = 12
-
-	glass_name = "Long Island iced tea"
-	glass_desc = "The liquor cabinet, brought together in a delicious mix. Intended for middle-aged alcoholic women only."
-
-/decl/reagent/ethanol/manhattan
-	name = "Manhattan"
-	description = "The Detective's undercover drink of choice. He never could stomach gin..."
-	taste_description = "mild dryness"
-	color = "#c13600"
-	strength = 15
-
-	glass_name = "Manhattan"
-	glass_desc = "The Detective's undercover drink of choice. He never could stomach gin..."
-
-/decl/reagent/ethanol/manhattan_proj
-	name = "Manhattan Project"
-	description = "A scientist's drink of choice, for pondering ways to blow stuff up."
-	taste_description = "death, the destroyer of worlds"
-	color = "#c15d00"
-	strength = 10
-	druggy = 30
-
-	glass_name = "Manhattan Project"
-	glass_desc = "A scientist's drink of choice, for pondering ways to blow stuff up."
-
-/decl/reagent/ethanol/manly_dorf
-	name = "Manly Dorf"
-	description = "Beer and Ale, brought together in a delicious mix. Intended for true men only."
-	taste_description = "hair on your chest and your chin"
-	color = "#4c3100"
-	strength = 25
-
-	glass_name = "Manly Dorf"
-	glass_desc = "A manly concotion made from Ale and Beer. Intended for true men only."
-
-/decl/reagent/ethanol/margarita
-	name = "margarita"
-	description = "On the rocks with salt on the rim. Arriba~!"
-	taste_description = "dry and salty"
-	color = "#8cff8c"
-	strength = 15
-
-	glass_name = "margarita"
-	glass_desc = "On the rocks with salt on the rim. Arriba~!"
+	glass_desc = "It's cream, mixed with whiskey."
 
 /decl/reagent/ethanol/mead
 	name = "mead"
@@ -730,33 +342,6 @@
 	glass_name = "moonshine"
 	glass_desc = "You've really hit rock bottom now... your liver packed its bags and left last night."
 
-/decl/reagent/ethanol/neurotoxin
-	name = "Neurotoxin"
-	description = "A strong neurotoxin that puts the subject into a death-like state."
-	taste_description = "a numbing sensation"
-	color = "#2e2e61"
-	strength = 10
-
-	glass_name = "Neurotoxin"
-	glass_desc = "A drink that is guaranteed to knock you silly."
-	glass_icon = DRINK_ICON_NOISY
-	glass_special = list("neuroright")
-
-/decl/reagent/ethanol/neurotoxin/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	..()
-	M.Weaken(3)
-	M.add_chemical_effect(CE_PULSE, -1)
-
-/decl/reagent/ethanol/patron
-	name = "Patron"
-	description = "Tequila with silver in it, a favorite of alcoholic women in the club scene."
-	taste_description = "metallic and expensive"
-	color = "#585840"
-	strength = 30
-
-	glass_name = "Patron"
-	glass_desc = "Drinking patron in the bar, with all the subpar ladies."
-
 /decl/reagent/ethanol/pwine
 	name = "poison wine"
 	description = "Is this even wine? Toxic! Hallucinogenic! Probably consumed in boatloads by your superiors!"
@@ -765,7 +350,6 @@
 	strength = 10
 	druggy = 50
 	halluci = 10
-
 	glass_name = "???"
 	glass_desc = "A black ichor with an oily purple sheer on top. Are you sure you should drink this?"
 
@@ -781,186 +365,6 @@
 				L.take_internal_damage(10 * removed, 0)
 			else
 				L.take_internal_damage(100, 0)
-
-/decl/reagent/ethanol/red_mead
-	name = "red mead"
-	description = "The true Viking's drink! Even though it has a strange red color."
-	taste_description = "sweet and salty alcohol"
-	color = "#c73c00"
-	strength = 30
-
-	glass_name = "red mead"
-	glass_desc = "A true Viking's beverage, though its color is strange."
-
-/decl/reagent/ethanol/sbiten
-	name = "sbiten"
-	description = "A spicy mead! Might be a little hot for the little guys!"
-	taste_description = "hot and spice"
-	color = "#ffa371"
-	strength = 15
-	adj_temp = 50
-	targ_temp = 360
-
-	glass_name = "Sbiten"
-	glass_desc = "A spicy mix of Mead and Spice. Very hot."
-
-/decl/reagent/ethanol/screwdrivercocktail
-	name = "Screwdriver"
-	description = "Vodka, mixed with plain ol' orange juice. The result is surprisingly delicious."
-	taste_description = "oranges"
-	color = "#a68310"
-	strength = 15
-
-	glass_name = "Screwdriver"
-	glass_desc = "A simple, yet superb mixture of Vodka and orange juice. Just the thing for the tired engineer."
-
-/decl/reagent/ethanol/ships_surgeon
-	name = "Ship's Surgeon"
-	description = "Rum and Dr. Gibb. Served ice cold, like the scalpel."
-	taste_description = "black comedy"
-	color = "#524d0f"
-	strength = 15
-
-	glass_name = "ship's surgeon"
-	glass_desc = "Rum qualified for surgical practice by Dr. Gibb. Smooth and steady."
-
-/decl/reagent/ethanol/silencer
-	name = "Silencer"
-	description = "A drink from Mime Heaven."
-	taste_description = "a pencil eraser"
-	taste_mult = 1.2
-	nutriment_factor = 1
-	color = "#ffffff"
-	strength = 12
-
-	glass_name = "Silencer"
-	glass_desc = "A drink from mime Heaven."
-
-/decl/reagent/ethanol/singulo
-	name = "Singulo"
-	description = "A blue-space beverage!"
-	taste_description = "concentrated matter"
-	color = "#2e6671"
-	strength = 10
-
-	glass_name = "Singulo"
-	glass_desc = "A blue-space beverage."
-
-/decl/reagent/ethanol/snowwhite
-	name = "Snow White"
-	description = "A cold refreshment"
-	taste_description = "refreshing cold"
-	color = "#ffffff"
-	strength = 30
-
-	glass_name = "Snow White"
-	glass_desc = "A cold refreshment."
-
-/decl/reagent/ethanol/suidream
-	name = "Sui Dream"
-	description = "Comprised of: White soda, blue curacao, melon liquor."
-	taste_description = "fruit"
-	color = "#00a86b"
-	strength = 100
-
-	glass_name = "Sui Dream"
-	glass_desc = "A froofy, fruity, and sweet mixed drink. Understanding the name only brings shame."
-
-/decl/reagent/ethanol/syndicatebomb
-	name = "Syndicate Bomb"
-	description = "Tastes like terrorism!"
-	taste_description = "purified antagonism"
-	color = "#2e6671"
-	strength = 10
-
-	glass_name = "Syndicate Bomb"
-	glass_desc = "Tastes like terrorism!"
-
-/decl/reagent/ethanol/tequilla_sunrise
-	name = "Tequila Sunrise"
-	description = "Tequila and orange juice. Much like a Screwdriver, only Mexican~"
-	taste_description = "oranges"
-	color = "#ffe48c"
-	strength = 25
-
-	glass_name = "Tequilla Sunrise"
-	glass_desc = "Oh great, now you feel nostalgic about sunrises back on Terra..."
-
-/decl/reagent/ethanol/threemileisland
-	name = "Three Mile Island Iced Tea"
-	description = "Made for a woman, strong enough for a man."
-	taste_description = "dry"
-	color = "#666340"
-	strength = 10
-	druggy = 50
-
-	glass_name = "Three Mile Island iced tea"
-	glass_desc = "A glass of this is sure to prevent a meltdown."
-
-/decl/reagent/ethanol/toxins_special
-	name = "Toxins Special"
-	description = "This thing is ON FIRE! CALL THE DAMN SHUTTLE!"
-	taste_description = "spicy toxins"
-	color = "#7f00ff"
-	strength = 10
-	adj_temp = 15
-	targ_temp = 330
-
-	glass_name = "Toxins Special"
-	glass_desc = "Whoah, this thing is on FIRE"
-
-/decl/reagent/ethanol/vodkamartini
-	name = "vodka martini"
-	description = "Vodka with Gin. Not quite how 007 enjoyed it, but still delicious."
-	taste_description = "shaken, not stirred"
-	color = "#0064c8"
-	strength = 12
-
-	glass_name = "vodka martini"
-	glass_desc ="A bastardisation of the classic martini. Still great."
-
-
-/decl/reagent/ethanol/vodkatonic
-	name = "vodka and tonic"
-	description = "For when a gin and tonic isn't russian enough."
-	taste_description = "tart bitterness"
-	color = "#0064c8" // rgb: 0, 100, 200
-	strength = 15
-
-	glass_name = "vodka and tonic"
-	glass_desc = "For when a gin and tonic isn't Russian enough."
-
-
-/decl/reagent/ethanol/white_russian
-	name = "White Russian"
-	description = "That's just, like, your opinion, man..."
-	taste_description = "bitter cream"
-	color = "#a68340"
-	strength = 15
-
-	glass_name = "White Russian"
-	glass_desc = "A very nice looking drink. But that's just, like, your opinion, man."
-
-
-/decl/reagent/ethanol/whiskey_cola
-	name = "whiskey cola"
-	description = "Whiskey, mixed with cola. Surprisingly refreshing."
-	taste_description = "cola"
-	color = "#3e1b00"
-	strength = 25
-
-	glass_name = "whiskey cola"
-	glass_desc = "An innocent-looking mixture of cola and Whiskey. Delicious."
-
-
-/decl/reagent/ethanol/whiskeysoda
-	name = "whiskey soda"
-	description = "For the more refined griffon."
-	color = "#eab300"
-	strength = 15
-
-	glass_name = "whiskey soda"
-	glass_desc = "Ultimate refreshment."
 
 /decl/reagent/ethanol/aged_whiskey // I have no idea what this is and where it comes from.  //It comes from Dinnlan now 
 	name = "aged whiskey"
@@ -981,16 +385,6 @@
 	glass_name = "apple cider"
 	glass_desc = "A refreshing glass of apple cider."
 
-/decl/reagent/ethanol/arak
-	name = "Arak"
-	description = "An unsweetened aniseed and grape mixture."
-	taste_description = "oil and licorice"
-	color = "#f7f6e0"
-	strength = 20
-
-	glass_name = "arak"
-	glass_desc = "An unsweetened mixture of aniseed and grape."
-
 /decl/reagent/ethanol/champagne
 	name = "champagne"
 	description = "Smooth sparkling wine, produced in the same region of France as it has for centuries."
@@ -1001,16 +395,6 @@
 	glass_name = "champagne"
 	glass_desc = "Smooth sparkling wine, produced in the same region of France as it has for centuries."
 
-/decl/reagent/ethanol/sawbonesdismay
-	name = "Sawbones' Dismay"
-	description = "The Tradehouse Surgeon general doesn't recommend mixing stimulants and depressants, but who listens to those warnings, anyhow?"
-	taste_description = "a pick-me-up and put-me-down"
-	color = "#996862"
-	strength = 10
-
-	glass_name = "Sawbones' Dismay"
-	glass_desc = "The Tradehouse Surgeon general doesn't recommend mixing stimulants and depressants, but who listens to those warnings, anyhow?"
-
 /decl/reagent/ethanol/jagermeister
 	name = "Jagermeister"
 	description = "A special blend of alcohol, herbs, and spices. It has remained a popular Earther drink."
@@ -1019,7 +403,7 @@
 	strength = 20
 
 	glass_name = "jagermeister"
-	glass_desc = "A special blend of alcohol, herbs, and spaces. It has remained a popular Earther drink."
+	glass_desc = "A special blend of alcohol, herbs, and spices. It has remained a popular Earther drink."
 
 /decl/reagent/ethanol/kvass
 	name = "kvass"
@@ -1030,12 +414,3 @@
 
 	glass_name = "kvass"
 	glass_desc = "An alcoholic drink commonly made from bread."
-
-/decl/reagent/ethanol/vodkacola
-	name = "vodka cola"
-	description = "A refreshing mix of vodka and cola."
-	taste_description = "vodka and cola"
-	color = "#474238"
-	strength = 15
-	glass_name = "vodka cola"
-	glass_desc = "A refreshing mix of vodka and cola."

--- a/code/modules/reagents/cocktails.dm
+++ b/code/modules/reagents/cocktails.dm
@@ -512,3 +512,28 @@
 		/decl/reagent/ethanol/vodka = 0.7,
 		/decl/reagent/gold
 	)
+
+/decl/cocktail/browndwarf
+	name = "Brown Dwarf"
+	description = "A foamy chocolate beverage that has failed to sustain nuclear fusion."
+	ratios = list(
+		/decl/reagent/drink/hot_coco =   0.4, 
+		/decl/reagent/drink/citrussoda = 0.3
+	)
+
+/decl/cocktail/snowball
+	name = "Snowball"
+	description = "A cold pick-me-up frequently drunk in scientific outposts and academic offices."
+	ratios = list(
+		/decl/reagent/drink/ice =              0.3,
+		/decl/reagent/drink/coffee =           0.2,
+		/decl/reagent/drink/juice/watermelon = 0.2
+	)
+
+/decl/cocktail/fools_gold
+	name = "Fool's Gold"
+	description = "Watered-down whiskey. Essentially grog, but without the pirates."
+	ratios = list(
+		/decl/reagent/water =           0.5,
+		/decl/reagent/ethanol/whiskey = 0.2
+	)

--- a/code/modules/reagents/cocktails.dm
+++ b/code/modules/reagents/cocktails.dm
@@ -1,0 +1,478 @@
+// This is a system used to change the name and description of a glass of
+// alcohol if it meets certain minimum proportions of ingredients. It 
+// replaces the previous system, which used chemical reactions.
+
+/decl/cocktail
+	var/name                   // Cocktail name, applied to the glass.
+	var/description            // Cocktail description, applied to the glass.
+	var/list/ratios            // Associative list of reagents to a minimum percentage of mix (<1).
+	                           // Reagents with no assoc value will count as valid for any amount (even 0.001u)
+	var/order_specific = FALSE // If set, cocktail will fail if ingredients were added out of ratio order.
+	var/hidden_from_codex      // Doesn't generate a codex entry.
+
+// Shoot for total ratios of about 70% (0.7) for any cocktail that doesn't need 
+// to be super precise - this will leave room in a mix for people to spike your 
+// drink or to be comfortably over or under their proportions without having to 
+// be frustratingly picky with measurements.
+
+/decl/cocktail/proc/get_presentation_name(var/obj/item/prop)
+	. = name
+	if(prop?.reagents?.has_reagent(/decl/reagent/drink/ice) && !(/decl/reagent/drink/ice in ratios))
+		. = "[name], on the rocks"
+
+/decl/cocktail/proc/mix_priority()
+	. = length(ratios)
+
+/decl/cocktail/proc/matches(var/obj/item/prop)
+	if(length(ratios) > length(prop.reagents.reagent_volumes))
+		return FALSE
+	var/list/check_ratios
+	var/i = 0
+	for(var/rtype in ratios)
+		i++
+		if(!prop.reagents.has_reagent(rtype) || (order_specific && prop.reagents.reagent_volumes[i] != rtype))
+			return FALSE
+		if(isnum(ratios[rtype]))
+			LAZYSET(check_ratios, rtype, ratios[rtype])
+	var/effective_volume = prop.reagents.total_volume - REAGENT_VOLUME(prop.reagents, /decl/reagent/drink/ice)
+	for(var/rtype in check_ratios)
+		if((REAGENT_VOLUME(prop.reagents, rtype) / effective_volume) < check_ratios[rtype])
+			return FALSE
+	return TRUE
+
+/decl/cocktail/grog
+	name = "grog"
+	ratios = list(
+		/decl/reagent/water =       0.5,
+		/decl/reagent/ethanol/rum = 0.2
+	)
+
+/decl/cocktail/screwdriver
+	name = "screwdriver"
+	description = "A classic mixture of vodka and orange juice. Just the thing for the tired engineer."
+	ratios = list(
+		/decl/reagent/drink/juice/orange = 0.6,
+		/decl/reagent/ethanol/vodka =      0.1
+	)
+
+/decl/cocktail/tequilla_sunrise
+	name = "tequilla sunrise"
+	description = "A simple cocktail of tequilla and orange juice. Much like a Screwdriver, only Mexican."
+	ratios = list(
+		/decl/reagent/drink/juice/orange = 0.6,
+		/decl/reagent/ethanol/tequilla =   0.1
+	)
+
+/decl/cocktail/classic_martini
+	name = "martini"
+	description = "Vermouth with gin. The classiest of all cocktails."
+	ratios = list(
+		/decl/reagent/ethanol/gin =      0.4,
+		/decl/reagent/ethanol/vermouth = 0.3
+	)
+
+/decl/cocktail/vodka_martini
+	name = "vodka martini" 
+	ratios = list(
+		/decl/reagent/ethanol/vodka =    0.4,
+		/decl/reagent/ethanol/vermouth = 0.3
+	)
+
+/decl/cocktail/allies_cocktail
+	name = "Allies Cocktail"
+	description = "A drink made from your allies, not as sweet as when made from your enemies."
+	ratios = list(
+		/decl/reagent/ethanol/vermouth = 0.3,
+		/decl/reagent/ethanol/vodka =    0.1,
+		/decl/reagent/ethanol/gin =      0.3
+	)
+
+/decl/cocktail/bilk
+	name = "bilk"
+	ratios = list(
+		/decl/reagent/ethanol/beer = 0.35,
+		/decl/reagent/drink/milk =   0.35
+	)
+
+/decl/cocktail/gin_and_tonic
+	name = "gin and tonic"
+	ratios = list(
+		/decl/reagent/drink/tonic = 0.4,
+		/decl/reagent/ethanol/gin = 0.3
+	)
+
+/decl/cocktail/cuba_libre
+	name = "Cuba Libre"
+	ratios = list(
+		/decl/reagent/ethanol/rum = 0.2,
+		/decl/reagent/drink/cola =  0.5
+	)
+
+/decl/cocktail/black_russian
+	name = "Black Russian"
+	ratios = list(
+		/decl/reagent/ethanol/vodka =         0.4,
+		/decl/reagent/ethanol/coffee/kahlua = 0.2
+	)
+
+/decl/cocktail/white_russian
+	name = "White Russian"
+	ratios = list(
+		/decl/reagent/ethanol/vodka =         0.3,
+		/decl/reagent/ethanol/coffee/kahlua = 0.15,
+		/decl/reagent/drink/milk/cream =      0.15
+	)
+
+/decl/cocktail/whiskey_cola
+	name = "whiskey cola"
+	ratios = list(
+		/decl/reagent/ethanol/whiskey = 0.2,
+		/decl/reagent/drink/cola =      0.5
+	)
+
+/decl/cocktail/bloody_mary
+	name = "Bloody Mary"
+	ratios = list(
+		/decl/reagent/drink/juice/tomato = 0.4,
+		/decl/reagent/ethanol/vodka =      0.15, 
+		/decl/reagent/drink/juice/lime =   0.15
+	)
+
+/decl/cocktail/livergeist
+	name = "The Livergeist"
+	ratios = list(
+		/decl/reagent/ethanol/vodka =        0.1,
+		/decl/reagent/ethanol/gin =          0.1,
+		/decl/reagent/ethanol/aged_whiskey = 0.1,
+		/decl/reagent/ethanol/cognac =       0.1,
+		/decl/reagent/drink/juice/lime =     0.1
+	)
+
+/decl/cocktail/brave_bull
+	name = "Brave Bull"
+	ratios = list(
+		/decl/reagent/ethanol/tequilla =      0.45,
+		/decl/reagent/ethanol/coffee/kahlua = 0.25
+	)
+
+/decl/cocktail/phoron_special
+	name = "Toxins Special"
+	ratios = list(
+		/decl/reagent/ethanol/rum = 0.35,
+		/decl/reagent/ethanol/vermouth = 0.35,
+		/decl/reagent/toxin/phoron
+	)
+
+/decl/cocktail/beepsky_smash
+	name = "Beepsky Smash"
+	ratios = list(
+		/decl/reagent/ethanol/whiskey =  0.4,
+		/decl/reagent/drink/juice/lime = 0.2, 
+		/decl/reagent/iron =             0.1
+	)
+
+/decl/cocktail/doctor_delight
+	name = "Doctor's Delight"
+	ratios = list(
+		/decl/reagent/regenerator =        0.3,
+		/decl/reagent/drink/juice/lime =   0.1, 
+		/decl/reagent/drink/juice/tomato = 0.1, 
+		/decl/reagent/drink/juice/orange = 0.1, 
+		/decl/reagent/drink/milk/cream =   0.1
+	)
+
+/decl/cocktail/manly_dorf
+	name = "The Manly Dorf"
+	ratios = list(
+		/decl/reagent/ethanol/ale =  0.35,
+		/decl/reagent/ethanol/beer = 0.35
+	)
+
+/decl/cocktail/irish_coffee
+	name = "Irish coffee"
+	ratios = list(
+		/decl/reagent/drink/coffee =        0.5,
+		/decl/reagent/ethanol/irish_cream = 0.2
+	)
+
+/decl/cocktail/b52
+	name = "B-52"
+	ratios = list(
+		/decl/reagent/ethanol/cognac =        0.3,
+		/decl/reagent/ethanol/irish_cream =   0.2,
+		/decl/reagent/ethanol/coffee/kahlua = 0.2
+	)
+
+/decl/cocktail/atomicbomb
+	name = "Atomic Bomb"
+	ratios = list(
+		/decl/reagent/ethanol/cognac =        0.3,
+		/decl/reagent/ethanol/irish_cream =   0.2,
+		/decl/reagent/ethanol/coffee/kahlua = 0.2,
+		/decl/reagent/uranium
+	)
+
+/decl/cocktail/margarita
+	name = "margarita"
+	ratios = list(
+		/decl/reagent/ethanol/tequilla = 0.35,
+		/decl/reagent/drink/juice/lime = 0.35
+	)
+
+/decl/cocktail/longislandicedtea
+	name = "Long Island Iced Tea"
+	ratios = list(
+		/decl/reagent/drink/cola =       0.2,
+		/decl/reagent/ethanol/rum =      0.1,
+		/decl/reagent/ethanol/vodka =    0.1, 
+		/decl/reagent/ethanol/gin =      0.1, 
+		/decl/reagent/ethanol/tequilla = 0.1	
+	)
+
+/decl/cocktail/threemileisland
+	name = "Three Mile Island Iced Tea"
+	ratios = list(
+		/decl/reagent/drink/cola =       0.2,
+		/decl/reagent/ethanol/rum =      0.1,
+		/decl/reagent/ethanol/vodka =    0.1, 
+		/decl/reagent/ethanol/gin =      0.1, 
+		/decl/reagent/ethanol/tequilla = 0.1,
+		/decl/reagent/uranium
+	)
+
+/decl/cocktail/whiskeysoda
+	name = "whiskey soda"
+	ratios = list(
+		/decl/reagent/ethanol/whiskey = 0.25,
+		/decl/reagent/drink/sodawater = 0.45
+	)
+
+/decl/cocktail/manhattan
+	name = "Manhattan"
+	ratios = list(
+		/decl/reagent/ethanol/whiskey =  0.45,
+		/decl/reagent/ethanol/vermouth = 0.25
+	)
+
+/decl/cocktail/manhattan_proj
+	name = "Manhattan Project"
+	ratios = list(
+		/decl/reagent/ethanol/whiskey =  0.45,
+		/decl/reagent/ethanol/vermouth = 0.25,
+		/decl/reagent/uranium
+	)
+
+/decl/cocktail/vodka_tonic
+	name = "vodka and tonic"
+	ratios = list(
+		/decl/reagent/ethanol/vodka = 0.2,
+		/decl/reagent/drink/tonic =   0.5
+	)
+
+/decl/cocktail/gin_fizz
+	name = "gin fizz"
+	ratios = list(
+		/decl/reagent/ethanol/gin =      0.3,
+		/decl/reagent/drink/sodawater =  0.2, 
+		/decl/reagent/drink/juice/lime = 0.2
+	)
+
+/decl/cocktail/bahama_mama
+	name = "Bahama Mama"
+	ratios = list(
+		/decl/reagent/ethanol/rum =        0.2,
+		/decl/reagent/drink/juice/orange = 0.2,
+		/decl/reagent/drink/juice/lime =   0.2,
+		/decl/reagent/drink/grenadine =    0.1
+	)
+
+/decl/cocktail/singulo
+	name = "Singulo"
+	ratios = list(
+		/decl/reagent/ethanol/vodka = 0.35,
+		/decl/reagent/ethanol/wine =  0.35,
+		/decl/reagent/radium
+	)
+
+/decl/cocktail/demonsblood
+	name = "Demon's Blood"
+	ratios = list(
+		/decl/reagent/ethanol/rum =      0.2,
+		/decl/reagent/drink/citrussoda = 0.2,
+		/decl/reagent/blood =            0.1,
+		/decl/reagent/drink/cherrycola = 0.2
+	)
+
+/decl/cocktail/booger
+	name = "Booger"
+	ratios = list(
+		/decl/reagent/drink/milk/cream =       0.2,
+		/decl/reagent/drink/juice/banana =     0.15, 
+		/decl/reagent/ethanol/rum =            0.2,
+		/decl/reagent/drink/juice/watermelon = 0.15
+	)
+
+/decl/cocktail/antifreeze
+	name = "Anti-freeze"
+	ratios = list(
+		/decl/reagent/ethanol/vodka =    0.3,
+		/decl/reagent/drink/milk/cream = 0.2, 
+		/decl/reagent/drink/ice =        0.2
+	)
+
+/decl/cocktail/barefoot
+	name = "Barefoot"
+	ratios = list(
+		/decl/reagent/ethanol/vermouth =  0.4,
+		/decl/reagent/drink/juice/berry = 0.2, 
+		/decl/reagent/drink/milk/cream =  0.1
+	)
+
+/decl/cocktail/sbiten
+	name = "sbiten"
+	ratios = list(
+		/decl/reagent/ethanol/mead = 0.6,
+		/decl/reagent/capsaicin =    0.1
+	)
+
+/decl/cocktail/red_mead
+	name = "red mead"
+	ratios = list(
+		/decl/reagent/ethanol/mead = 0.6,
+		/decl/reagent/blood =        0.1
+	)
+
+/decl/cocktail/acidspit
+	name = "Acid Spit"
+	ratios = list(
+		/decl/reagent/ethanol/wine = 0.7,
+		/decl/reagent/acid
+	)
+
+/decl/cocktail/changelingsting
+	name = "Changeling Sting"
+	ratios = list(
+		/decl/reagent/ethanol/vodka =      0.4,
+		/decl/reagent/drink/juice/lime =   0.1, 
+		/decl/reagent/drink/juice/lemon =  0.1,
+		/decl/reagent/drink/juice/orange = 0.1
+	)
+
+/decl/cocktail/neurotoxin
+	name = "Neurotoxin"
+	ratios = list(
+		/decl/reagent/ethanol/vodka =        0.1,
+		/decl/reagent/ethanol/gin =          0.1,
+		/decl/reagent/ethanol/aged_whiskey = 0.1,
+		/decl/reagent/ethanol/cognac =       0.1,
+		/decl/reagent/drink/juice/lime =     0.1,
+		/decl/reagent/sedatives =            0.1
+	)
+
+/decl/cocktail/snowwhite
+	name = "Snow White"
+	ratios = list(
+		/decl/reagent/ethanol/beer =     0.4,
+		/decl/reagent/drink/lemon_lime = 0.3
+	)
+
+/decl/cocktail/irishslammer
+	name = "Irish Slammer"
+	ratios = list(
+		/decl/reagent/ethanol/ale =         0.5,
+		/decl/reagent/ethanol/whiskey =     0.1,
+		/decl/reagent/ethanol/irish_cream = 0.1
+	)
+
+/decl/cocktail/syndicatebomb
+	name = "Syndicate Bomb"
+	ratios = list(
+		/decl/reagent/ethanol/whiskey = 0.2,
+		/decl/reagent/ethanol/beer =    0.2,
+		/decl/reagent/drink/cola =      0.3
+	)
+
+/decl/cocktail/devilskiss
+	name = "Devil's Kiss"
+	ratios = list(
+		/decl/reagent/ethanol/rum =           0.4,
+		/decl/reagent/blood =                 0.1, 
+		/decl/reagent/ethanol/coffee/kahlua = 0.2
+	)
+
+/decl/cocktail/hippiesdelight
+	name = "Hippy's Delight"
+	ratios = list(
+		/decl/reagent/ethanol/vodka =        0.1,
+		/decl/reagent/ethanol/gin =          0.1,
+		/decl/reagent/ethanol/aged_whiskey = 0.1,
+		/decl/reagent/ethanol/cognac =       0.1,
+		/decl/reagent/drink/juice/lime =     0.1,
+		/decl/reagent/psychotropics =        0.2
+	)
+
+/decl/cocktail/bananahonk
+	name = "Banana Honk"
+	ratios = list(
+		/decl/reagent/drink/juice/banana = 0.4,
+		/decl/reagent/drink/milk/cream =   0.2, 
+		/decl/reagent/nutriment/sugar =    0.1
+	)
+
+/decl/cocktail/silencer
+	name = "Silencer"
+	ratios = list(
+		/decl/reagent/drink/nothing =    0.3,
+		/decl/reagent/drink/milk/cream = 0.3,
+		/decl/reagent/nutriment/sugar =  0.1
+	)
+
+/decl/cocktail/driestmartini
+	name = "driest martini"
+	ratios = list(
+		/decl/reagent/ethanol/gin =   0.4,
+		/decl/reagent/drink/nothing = 0.3
+	)
+
+/decl/cocktail/ships_surgeon
+	name = "Ship's Surgeon"
+	ratios = list(
+		/decl/reagent/drink/cherrycola = 0.5,
+		/decl/reagent/ethanol/rum =      0.2
+	)
+
+/decl/cocktail/vodkacola
+	name = "vodka cola"
+	ratios = list(
+		/decl/reagent/ethanol/vodka = 0.5,
+		/decl/reagent/drink/cola =    0.2
+	)
+
+/decl/cocktail/sawbonesdismay
+	name = "Sawbones' Dismay"
+	ratios = list(
+		/decl/reagent/ethanol/jagermeister = 0.35,
+		/decl/reagent/drink/beastenergy =    0.35
+	)
+
+/decl/cocktail/patron
+	name = "Patron"
+	ratios = list(
+		/decl/reagent/ethanol/tequilla = 0.7,
+		/decl/reagent/silver
+	)
+
+/decl/cocktail/rewriter
+	name = "Rewriter"
+	ratios = list(
+		/decl/reagent/drink/coffee =     0.35,
+		/decl/reagent/drink/citrussoda = 0.35
+	)
+
+// TODO: add schnapps
+/decl/cocktail/goldschlager
+	name = "Goldschlager"
+	ratios = list(
+		/decl/reagent/ethanol/vodka = 0.7,
+		/decl/reagent/gold
+	)

--- a/code/modules/reagents/cocktails.dm
+++ b/code/modules/reagents/cocktails.dm
@@ -34,7 +34,9 @@
 			return FALSE
 		if(isnum(ratios[rtype]))
 			LAZYSET(check_ratios, rtype, ratios[rtype])
-	var/effective_volume = prop.reagents.total_volume - REAGENT_VOLUME(prop.reagents, /decl/reagent/drink/ice)
+	var/effective_volume = prop.reagents.total_volume
+	if(!(/decl/reagent/drink/ice in ratios))
+		effective_volume -= REAGENT_VOLUME(prop.reagents, /decl/reagent/drink/ice)
 	for(var/rtype in check_ratios)
 		if((REAGENT_VOLUME(prop.reagents, rtype) / effective_volume) < check_ratios[rtype])
 			return FALSE

--- a/code/modules/reagents/cocktails.dm
+++ b/code/modules/reagents/cocktails.dm
@@ -44,6 +44,7 @@
 
 /decl/cocktail/grog
 	name = "grog"
+	description = "Watered-down rum. Pirate approved!"
 	ratios = list(
 		/decl/reagent/water =       0.5,
 		/decl/reagent/ethanol/rum = 0.2
@@ -59,7 +60,7 @@
 
 /decl/cocktail/tequilla_sunrise
 	name = "tequilla sunrise"
-	description = "A simple cocktail of tequilla and orange juice. Much like a Screwdriver, only Mexican."
+	description = "A simple cocktail of tequilla and orange juice. Much like a screwdriver."
 	ratios = list(
 		/decl/reagent/drink/juice/orange = 0.6,
 		/decl/reagent/ethanol/tequilla =   0.1
@@ -74,7 +75,8 @@
 	)
 
 /decl/cocktail/vodka_martini
-	name = "vodka martini" 
+	name = "vodka martini"
+	description = "A bastardisation of the classic martini. Still great."
 	ratios = list(
 		/decl/reagent/ethanol/vodka =    0.4,
 		/decl/reagent/ethanol/vermouth = 0.3
@@ -91,6 +93,7 @@
 
 /decl/cocktail/bilk
 	name = "bilk"
+	description =  "A foul brew of milk and beer. For alcoholics who fear osteoporosis."
 	ratios = list(
 		/decl/reagent/ethanol/beer = 0.35,
 		/decl/reagent/drink/milk =   0.35
@@ -98,6 +101,7 @@
 
 /decl/cocktail/gin_and_tonic
 	name = "gin and tonic"
+	description = "A mild cocktail, widely considered an all-time classic."
 	ratios = list(
 		/decl/reagent/drink/tonic = 0.4,
 		/decl/reagent/ethanol/gin = 0.3
@@ -105,20 +109,23 @@
 
 /decl/cocktail/cuba_libre
 	name = "Cuba Libre"
+	description = "A classic mix of rum and cola."
 	ratios = list(
 		/decl/reagent/ethanol/rum = 0.2,
 		/decl/reagent/drink/cola =  0.5
 	)
 
 /decl/cocktail/black_russian
-	name = "Black Russian"
+	name = "black Russian"
+	description = "Similar to a white Russian, but fit for the lactose-intolerant."
 	ratios = list(
 		/decl/reagent/ethanol/vodka =         0.4,
 		/decl/reagent/ethanol/coffee/kahlua = 0.2
 	)
 
 /decl/cocktail/white_russian
-	name = "White Russian"
+	name = "white Russian"
+	description = "A straightforward cocktail of coffee liqueur and vodka. Popular in a lot of places, but that's just, like, an opinion, man."
 	ratios = list(
 		/decl/reagent/ethanol/vodka =         0.3,
 		/decl/reagent/ethanol/coffee/kahlua = 0.15,
@@ -127,6 +134,7 @@
 
 /decl/cocktail/whiskey_cola
 	name = "whiskey cola"
+	description = "Whiskey mixed with cola. Quite refreshing."
 	ratios = list(
 		/decl/reagent/ethanol/whiskey = 0.2,
 		/decl/reagent/drink/cola =      0.5
@@ -134,6 +142,7 @@
 
 /decl/cocktail/bloody_mary
 	name = "Bloody Mary"
+	description = "A cocktail of vodka, tomato and lime juice. Celery stalk optional."
 	ratios = list(
 		/decl/reagent/drink/juice/tomato = 0.4,
 		/decl/reagent/ethanol/vodka =      0.15, 
@@ -142,6 +151,7 @@
 
 /decl/cocktail/livergeist
 	name = "The Livergeist"
+	description = "A cocktail pioneered by a small cabal with a vendetta against the liver. Drink very carefully."
 	ratios = list(
 		/decl/reagent/ethanol/vodka =        0.1,
 		/decl/reagent/ethanol/gin =          0.1,
@@ -152,6 +162,7 @@
 
 /decl/cocktail/brave_bull
 	name = "Brave Bull"
+	description = "A strong cocktail of tequila and coffee liquor."
 	ratios = list(
 		/decl/reagent/ethanol/tequilla =      0.45,
 		/decl/reagent/ethanol/coffee/kahlua = 0.25
@@ -159,6 +170,7 @@
 
 /decl/cocktail/phoron_special
 	name = "Toxins Special"
+	description = "Raise a glass to the bomb technicians of yesteryear, wherever their ashes now reside."
 	ratios = list(
 		/decl/reagent/ethanol/rum = 0.35,
 		/decl/reagent/ethanol/vermouth = 0.35,
@@ -167,6 +179,7 @@
 
 /decl/cocktail/beepsky_smash
 	name = "Beepsky Smash"
+	description = "A cocktail originating with stationside security forces. Rumoured to take the edge off being stunned with your own baton."
 	ratios = list(
 		/decl/reagent/ethanol/whiskey =  0.4,
 		/decl/reagent/drink/juice/lime = 0.2, 
@@ -175,6 +188,7 @@
 
 /decl/cocktail/doctor_delight
 	name = "Doctor's Delight"
+	description = "A healthy mixture of juices and medication, guaranteed to keep you healthy until the next maintenance goblin decides to put a few new holes in you."
 	ratios = list(
 		/decl/reagent/regenerator =        0.3,
 		/decl/reagent/drink/juice/lime =   0.1, 
@@ -185,6 +199,7 @@
 
 /decl/cocktail/manly_dorf
 	name = "The Manly Dorf"
+	description = "A cocktail of old that claims to be for manly men, but is mostly for people who can't tell beer and ale apart."
 	ratios = list(
 		/decl/reagent/ethanol/ale =  0.35,
 		/decl/reagent/ethanol/beer = 0.35
@@ -192,6 +207,7 @@
 
 /decl/cocktail/irish_coffee
 	name = "Irish coffee"
+	description = "A cocktail of coffee, whiskey and cream, just the thing to kick you awake while also dulling the pain of existence."
 	ratios = list(
 		/decl/reagent/drink/coffee =        0.5,
 		/decl/reagent/ethanol/irish_cream = 0.2
@@ -199,6 +215,7 @@
 
 /decl/cocktail/b52
 	name = "B-52"
+	description = "A semi-modern spin on an Irish coffee, featuring a dash of cognac. It will get you bombed."
 	ratios = list(
 		/decl/reagent/ethanol/cognac =        0.3,
 		/decl/reagent/ethanol/irish_cream =   0.2,
@@ -207,6 +224,7 @@
 
 /decl/cocktail/atomicbomb
 	name = "Atomic Bomb"
+	description = "A radioactive take on a B-52, popularized by asteroid miners with prosthetic organs and something to prove."
 	ratios = list(
 		/decl/reagent/ethanol/cognac =        0.3,
 		/decl/reagent/ethanol/irish_cream =   0.2,
@@ -216,6 +234,7 @@
 
 /decl/cocktail/margarita
 	name = "margarita"
+	description = "A classic cocktail of antiquity."
 	ratios = list(
 		/decl/reagent/ethanol/tequilla = 0.35,
 		/decl/reagent/drink/juice/lime = 0.35
@@ -223,6 +242,7 @@
 
 /decl/cocktail/longislandicedtea
 	name = "Long Island Iced Tea"
+	description = "Most of the liquor cabinet, brought together in a delicious mix. Designed for middle-aged alcoholics."
 	ratios = list(
 		/decl/reagent/drink/cola =       0.2,
 		/decl/reagent/ethanol/rum =      0.1,
@@ -233,6 +253,7 @@
 
 /decl/cocktail/threemileisland
 	name = "Three Mile Island Iced Tea"
+	description = "Much like the Atomic Bomb, this cocktail was adapted by asteroid miners who couldn't enjoy a drink without a dose of radiation poisoning."
 	ratios = list(
 		/decl/reagent/drink/cola =       0.2,
 		/decl/reagent/ethanol/rum =      0.1,
@@ -244,6 +265,7 @@
 
 /decl/cocktail/whiskeysoda
 	name = "whiskey soda"
+	description = "A simple cocktail, considered to be cultured and refined."
 	ratios = list(
 		/decl/reagent/ethanol/whiskey = 0.25,
 		/decl/reagent/drink/sodawater = 0.45
@@ -251,6 +273,7 @@
 
 /decl/cocktail/manhattan
 	name = "Manhattan"
+	description = "Another classic cocktail of antiquity. Popular with private investigators."
 	ratios = list(
 		/decl/reagent/ethanol/whiskey =  0.45,
 		/decl/reagent/ethanol/vermouth = 0.25
@@ -258,6 +281,7 @@
 
 /decl/cocktail/manhattan_proj
 	name = "Manhattan Project"
+	description = "A classic cocktail with a spicy twist, pioneered by a robot detective."
 	ratios = list(
 		/decl/reagent/ethanol/whiskey =  0.45,
 		/decl/reagent/ethanol/vermouth = 0.25,
@@ -266,6 +290,7 @@
 
 /decl/cocktail/vodka_tonic
 	name = "vodka and tonic"
+	description = "A simple, refreshing cocktail with a kick to it."
 	ratios = list(
 		/decl/reagent/ethanol/vodka = 0.2,
 		/decl/reagent/drink/tonic =   0.5
@@ -273,6 +298,7 @@
 
 /decl/cocktail/gin_fizz
 	name = "gin fizz"
+	description = "A dry, refreshing cocktail with a tang of lime."
 	ratios = list(
 		/decl/reagent/ethanol/gin =      0.3,
 		/decl/reagent/drink/sodawater =  0.2, 
@@ -281,6 +307,7 @@
 
 /decl/cocktail/bahama_mama
 	name = "Bahama Mama"
+	description = "A sweet tropical cocktail that is deceptively strong."
 	ratios = list(
 		/decl/reagent/ethanol/rum =        0.2,
 		/decl/reagent/drink/juice/orange = 0.2,
@@ -290,6 +317,7 @@
 
 /decl/cocktail/singulo
 	name = "Singulo"
+	description = "Traditionally thrown together from maintenance stills and used to treat singularity exposure in engineers who forgot their meson goggles."
 	ratios = list(
 		/decl/reagent/ethanol/vodka = 0.35,
 		/decl/reagent/ethanol/wine =  0.35,
@@ -298,6 +326,7 @@
 
 /decl/cocktail/demonsblood
 	name = "Demon's Blood"
+	description = "A ghoulish cocktail that originated as a practical joke in a fringe habitat."
 	ratios = list(
 		/decl/reagent/ethanol/rum =      0.2,
 		/decl/reagent/drink/citrussoda = 0.2,
@@ -307,6 +336,7 @@
 
 /decl/cocktail/booger
 	name = "Booger"
+	description = "A thick and creamy cocktail."
 	ratios = list(
 		/decl/reagent/drink/milk/cream =       0.2,
 		/decl/reagent/drink/juice/banana =     0.15, 
@@ -316,6 +346,7 @@
 
 /decl/cocktail/antifreeze
 	name = "Anti-freeze"
+	description = "A chilled cocktail invented and popularized by corona miners."
 	ratios = list(
 		/decl/reagent/ethanol/vodka =    0.3,
 		/decl/reagent/drink/milk/cream = 0.2, 
@@ -324,6 +355,7 @@
 
 /decl/cocktail/barefoot
 	name = "Barefoot"
+	description = "A smooth cocktail that will take your mind off the broken glass you stepped on."
 	ratios = list(
 		/decl/reagent/ethanol/vermouth =  0.4,
 		/decl/reagent/drink/juice/berry = 0.2, 
@@ -332,6 +364,7 @@
 
 /decl/cocktail/sbiten
 	name = "sbiten"
+	description = "A form of spiced mead that will bring tears to the eyes of the most hardened drinker."
 	ratios = list(
 		/decl/reagent/ethanol/mead = 0.6,
 		/decl/reagent/capsaicin =    0.1
@@ -339,6 +372,7 @@
 
 /decl/cocktail/red_mead
 	name = "red mead"
+	description = "Supposedly a traditional drink amongst mercenary groups prior to dangerous missions."
 	ratios = list(
 		/decl/reagent/ethanol/mead = 0.6,
 		/decl/reagent/blood =        0.1
@@ -346,6 +380,7 @@
 
 /decl/cocktail/acidspit
 	name = "Acid Spit"
+	description = "A cocktail inspired by monsters of legend, popular with college students daring their friends to drink one."
 	ratios = list(
 		/decl/reagent/ethanol/wine = 0.7,
 		/decl/reagent/acid
@@ -353,6 +388,7 @@
 
 /decl/cocktail/changelingsting
 	name = "Changeling Sting"
+	description = "A deceptively simple cocktail with a complex flavour profile. Rumours of causing paralysis and voice loss are common but unsubstantiated."
 	ratios = list(
 		/decl/reagent/ethanol/vodka =      0.4,
 		/decl/reagent/drink/juice/lime =   0.1, 
@@ -362,6 +398,7 @@
 
 /decl/cocktail/neurotoxin
 	name = "Neurotoxin"
+	description = "A cocktail primarily intended for people with a grudge against their own brain."
 	ratios = list(
 		/decl/reagent/ethanol/vodka =        0.1,
 		/decl/reagent/ethanol/gin =          0.1,
@@ -373,6 +410,7 @@
 
 /decl/cocktail/snowwhite
 	name = "Snow White"
+	description = "A tangy, fizzy twist on beer."
 	ratios = list(
 		/decl/reagent/ethanol/beer =     0.4,
 		/decl/reagent/drink/lemon_lime = 0.3
@@ -380,6 +418,7 @@
 
 /decl/cocktail/irishslammer
 	name = "Irish Slammer"
+	description = "A rich cocktail of whiskey, stout and cream that was performed using a shot glass before glass-interleaving technology was lost."
 	ratios = list(
 		/decl/reagent/ethanol/ale =         0.5,
 		/decl/reagent/ethanol/whiskey =     0.1,
@@ -388,6 +427,7 @@
 
 /decl/cocktail/syndicatebomb
 	name = "Syndicate Bomb"
+	description = "A murky cocktail reputed to have originated in criminal circles. It will definitely get you bombed."
 	ratios = list(
 		/decl/reagent/ethanol/whiskey = 0.2,
 		/decl/reagent/ethanol/beer =    0.2,
@@ -396,6 +436,7 @@
 
 /decl/cocktail/devilskiss
 	name = "Devil's Kiss"
+	description = "A ghoulish cocktail popular in some of the weirder dive bars on the system fringe."
 	ratios = list(
 		/decl/reagent/ethanol/rum =           0.4,
 		/decl/reagent/blood =                 0.1, 
@@ -404,6 +445,7 @@
 
 /decl/cocktail/hippiesdelight
 	name = "Hippy's Delight"
+	description = "A complex cocktail that just might open your third eye."
 	ratios = list(
 		/decl/reagent/ethanol/vodka =        0.1,
 		/decl/reagent/ethanol/gin =          0.1,
@@ -415,6 +457,7 @@
 
 /decl/cocktail/bananahonk
 	name = "Banana Honk"
+	description = "A virgin cocktail intended for the class clown. If someone orders you one of these, it is probably an insult."
 	ratios = list(
 		/decl/reagent/drink/juice/banana = 0.4,
 		/decl/reagent/drink/milk/cream =   0.2, 
@@ -423,6 +466,7 @@
 
 /decl/cocktail/silencer
 	name = "Silencer"
+	description = "A very non-alcoholic cocktail - sort of a mocktail, really."
 	ratios = list(
 		/decl/reagent/drink/nothing =    0.3,
 		/decl/reagent/drink/milk/cream = 0.3,
@@ -431,6 +475,7 @@
 
 /decl/cocktail/driestmartini
 	name = "driest martini"
+	description = "If the dryness of a martini is proportionate to classiness, drinking this will turn you into Old Money."
 	ratios = list(
 		/decl/reagent/ethanol/gin =   0.4,
 		/decl/reagent/drink/nothing = 0.3
@@ -438,6 +483,7 @@
 
 /decl/cocktail/ships_surgeon
 	name = "Ship's Surgeon"
+	description = "A smooth, steady cocktail supposedly ordered by sawbones and surgeons of legend."
 	ratios = list(
 		/decl/reagent/drink/cherrycola = 0.5,
 		/decl/reagent/ethanol/rum =      0.2
@@ -445,6 +491,7 @@
 
 /decl/cocktail/vodkacola
 	name = "vodka cola"
+	description = "A simple mix of cola and vodka, combining sweetness, fizz and a kick in the teeth."
 	ratios = list(
 		/decl/reagent/ethanol/vodka = 0.5,
 		/decl/reagent/drink/cola =    0.2
@@ -452,6 +499,7 @@
 
 /decl/cocktail/sawbonesdismay
 	name = "Sawbones' Dismay"
+	description = "Legally, we are required to inform you that drinking this cocktail may invalidate your health insurance."
 	ratios = list(
 		/decl/reagent/ethanol/jagermeister = 0.35,
 		/decl/reagent/drink/beastenergy =    0.35
@@ -459,6 +507,7 @@
 
 /decl/cocktail/patron
 	name = "Patron"
+	description = "Tequila mixed with flaked silver, for those with moderate expensive tastes."
 	ratios = list(
 		/decl/reagent/ethanol/tequilla = 0.7,
 		/decl/reagent/silver
@@ -466,6 +515,7 @@
 
 /decl/cocktail/rewriter
 	name = "Rewriter"
+	description = "A sickly concotion that college students and academics swear by for getting you through an all-nighter or six."
 	ratios = list(
 		/decl/reagent/drink/coffee =     0.35,
 		/decl/reagent/drink/citrussoda = 0.35
@@ -474,6 +524,7 @@
 // TODO: add schnapps
 /decl/cocktail/goldschlager
 	name = "Goldschlager"
+	description = "Schnapps mixed with flaked gold, for those with very expensive tastes."
 	ratios = list(
 		/decl/reagent/ethanol/vodka = 0.7,
 		/decl/reagent/gold

--- a/code/modules/reagents/cocktails.dm
+++ b/code/modules/reagents/cocktails.dm
@@ -464,23 +464,6 @@
 		/decl/reagent/nutriment/sugar =    0.1
 	)
 
-/decl/cocktail/silencer
-	name = "Silencer"
-	description = "A very non-alcoholic cocktail - sort of a mocktail, really."
-	ratios = list(
-		/decl/reagent/drink/nothing =    0.3,
-		/decl/reagent/drink/milk/cream = 0.3,
-		/decl/reagent/nutriment/sugar =  0.1
-	)
-
-/decl/cocktail/driestmartini
-	name = "driest martini"
-	description = "If the dryness of a martini is proportionate to classiness, drinking this will turn you into Old Money."
-	ratios = list(
-		/decl/reagent/ethanol/gin =   0.4,
-		/decl/reagent/drink/nothing = 0.3
-	)
-
 /decl/cocktail/ships_surgeon
 	name = "Ship's Surgeon"
 	description = "A smooth, steady cocktail supposedly ordered by sawbones and surgeons of legend."

--- a/code/modules/reagents/reactions/reaction_alcohol.dm
+++ b/code/modules/reagents/reactions/reaction_alcohol.dm
@@ -1,24 +1,3 @@
-/datum/chemical_reaction/recipe/goldschlager
-	name = "Goldschlager"
-	result = /decl/reagent/ethanol/goldschlager
-	required_reagents = list(/decl/reagent/ethanol/vodka = 10, /decl/reagent/gold = 1)
-	result_amount = 10
-	mix_message = "The gold flakes and settles in the vodka."
-
-/datum/chemical_reaction/recipe/patron
-	name = "Patron"
-	result = /decl/reagent/ethanol/patron
-	required_reagents = list(/decl/reagent/ethanol/tequilla = 10, /decl/reagent/silver = 1)
-	result_amount = 10
-	mix_message = "The silver flakes and settles in the tequila."
-
-/datum/chemical_reaction/recipe/bilk
-	name = "Bilk"
-	result = /decl/reagent/ethanol/bilk
-	required_reagents = list(/decl/reagent/drink/milk = 1, /decl/reagent/ethanol/beer = 1)
-	result_amount = 2
-	mix_message = "The solution takes on an unpleasant, thick, brown appearance."
-
 /datum/chemical_reaction/recipe/moonshine
 	name = "Moonshine"
 	result = /decl/reagent/ethanol/moonshine
@@ -66,8 +45,8 @@
 	result_amount = 10
 	mix_message = "The solution roils as it rapidly ferments into a shockingly blue liquor."
 
-/datum/chemical_reaction/recipe/spacebeer
-	name = "Space Beer"
+/datum/chemical_reaction/recipe/beer
+	name = "Beer"
 	result = /decl/reagent/ethanol/beer
 	required_reagents = list(/decl/reagent/nutriment/cornoil = 10)
 	catalysts = list(/decl/reagent/enzyme = 5)
@@ -75,7 +54,7 @@
 	mix_message = "The solution roils as it rapidly ferments into a foaming amber liquid."
 
 /datum/chemical_reaction/recipe/vodka
-	name = "Vodka"
+	name = "Potato Vodka"
 	result = /decl/reagent/ethanol/vodka
 	required_reagents = list(/decl/reagent/drink/juice/potato = 10)
 	catalysts = list(/decl/reagent/enzyme = 5)
@@ -83,7 +62,7 @@
 	mix_message = "The solution roils as it rapidly ferments into a crystal clear liquid."
 
 /datum/chemical_reaction/recipe/vodka2
-	name = "Vodka"
+	name = "Turnip Vodka"
 	result = /decl/reagent/ethanol/vodka
 	required_reagents = list(/decl/reagent/drink/juice/turnip = 10)
 	catalysts = list(/decl/reagent/enzyme = 5)
@@ -106,100 +85,10 @@
 	result_amount = 5
 	mix_message = "The solution roils as it rapidly ferments into a rich brown liquid."
 
-/datum/chemical_reaction/recipe/gin_tonic
-	name = "Gin and Tonic"
-	result = /decl/reagent/ethanol/gintonic
-	required_reagents = list(/decl/reagent/ethanol/gin = 2, /decl/reagent/drink/tonic = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/cuba_libre
-	name = "Cuba Libre"
-	result = /decl/reagent/ethanol/cuba_libre
-	required_reagents = list(/decl/reagent/ethanol/rum = 2, /decl/reagent/drink/cola = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/martini
-	name = "Classic Martini"
-	result = /decl/reagent/ethanol/martini
-	required_reagents = list(/decl/reagent/ethanol/gin = 2, /decl/reagent/ethanol/vermouth = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/vodkamartini
-	name = "Vodka Martini"
-	result = /decl/reagent/ethanol/vodkamartini
-	required_reagents = list(/decl/reagent/ethanol/vodka = 2, /decl/reagent/ethanol/vermouth = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/white_russian
-	name = "White Russian"
-	result = /decl/reagent/ethanol/white_russian
-	required_reagents = list(/decl/reagent/ethanol/black_russian = 2, /decl/reagent/drink/milk/cream = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/whiskey_cola
-	name = "Whiskey Cola"
-	result = /decl/reagent/ethanol/whiskey_cola
-	required_reagents = list(/decl/reagent/ethanol/whiskey = 2, /decl/reagent/drink/cola = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/screwdriver
-	name = "Screwdriver"
-	result = /decl/reagent/ethanol/screwdrivercocktail
-	required_reagents = list(/decl/reagent/ethanol/vodka = 2, /decl/reagent/drink/juice/orange = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/bloody_mary
-	name = "Bloody Mary"
-	result = /decl/reagent/ethanol/bloody_mary
-	required_reagents = list(/decl/reagent/ethanol/vodka = 2, /decl/reagent/drink/juice/tomato = 3, /decl/reagent/drink/juice/lime = 1)
-	result_amount = 6
-
-/datum/chemical_reaction/recipe/livergeist
-	name = "The Livergeist"
-	result = /decl/reagent/ethanol/livergeist
-	required_reagents = list(/decl/reagent/ethanol/vodka = 2, /decl/reagent/ethanol/gin = 1, /decl/reagent/ethanol/aged_whiskey = 1, /decl/reagent/ethanol/cognac = 1, /decl/reagent/drink/juice/lime = 1)
-	result_amount = 6
-
-/datum/chemical_reaction/recipe/brave_bull
-	name = "Brave Bull"
-	result = /decl/reagent/ethanol/coffee/brave_bull
-	required_reagents = list(/decl/reagent/ethanol/tequilla = 2, /decl/reagent/ethanol/coffee/kahlua = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/tequilla_sunrise
-	name = "Tequilla Sunrise"
-	result = /decl/reagent/ethanol/tequilla_sunrise
-	required_reagents = list(/decl/reagent/ethanol/tequilla = 2, /decl/reagent/drink/juice/orange = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/phoron_special
-	name = "Toxins Special"
-	result = /decl/reagent/ethanol/toxins_special
-	required_reagents = list(/decl/reagent/ethanol/rum = 2, /decl/reagent/ethanol/vermouth = 2, /decl/reagent/toxin/phoron = 2)
-	result_amount = 6
-
-/datum/chemical_reaction/recipe/beepsky_smash
-	name = "Beepksy Smash"
-	result = /decl/reagent/ethanol/beepsky_smash
-	required_reagents = list(/decl/reagent/drink/juice/lime = 1, /decl/reagent/ethanol/whiskey = 1, /decl/reagent/iron = 1)
-	result_amount = 2
-
-/datum/chemical_reaction/recipe/doctor_delight
-	name = "The Doctor's Delight"
-	result = /decl/reagent/drink/doctor_delight
-	required_reagents = list(/decl/reagent/drink/juice/lime = 1, /decl/reagent/drink/juice/tomato = 1, /decl/reagent/drink/juice/orange = 1, /decl/reagent/drink/milk/cream = 2, /decl/reagent/regenerator = 1)
-	result_amount = 6
-
 /datum/chemical_reaction/recipe/irish_cream
 	name = "Irish Cream"
 	result = /decl/reagent/ethanol/irish_cream
 	required_reagents = list(/decl/reagent/ethanol/whiskey = 2, /decl/reagent/drink/milk/cream = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/manly_dorf
-	name = "The Manly Dorf"
-	result = /decl/reagent/ethanol/manly_dorf
-	required_reagents = list (/decl/reagent/ethanol/beer = 1, /decl/reagent/ethanol/ale = 2)
 	result_amount = 3
 
 /datum/chemical_reaction/recipe/hooch
@@ -210,239 +99,11 @@
 	maximum_temperature = (30 CELSIUS) + 100
 	result_amount = 3
 
-/datum/chemical_reaction/recipe/irish_coffee
-	name = "Irish Coffee"
-	result = /decl/reagent/ethanol/coffee/irishcoffee
-	required_reagents = list(/decl/reagent/ethanol/irish_cream = 1, /decl/reagent/drink/coffee = 1)
-	result_amount = 2
-
-/datum/chemical_reaction/recipe/b52
-	name = "B-52"
-	result = /decl/reagent/ethanol/coffee/b52
-	required_reagents = list(/decl/reagent/ethanol/irish_cream = 1, /decl/reagent/ethanol/coffee/kahlua = 1, /decl/reagent/ethanol/cognac = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/atomicbomb
-	name = "Atomic Bomb"
-	result = /decl/reagent/ethanol/atomicbomb
-	required_reagents = list(/decl/reagent/ethanol/coffee/b52 = 10, /decl/reagent/uranium = 1)
-	result_amount = 10
-
-/datum/chemical_reaction/recipe/margarita
-	name = "Margarita"
-	result = /decl/reagent/ethanol/margarita
-	required_reagents = list(/decl/reagent/ethanol/tequilla = 2, /decl/reagent/drink/juice/lime = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/longislandicedtea
-	name = "Long Island Iced Tea"
-	result = /decl/reagent/ethanol/longislandicedtea
-	required_reagents = list(/decl/reagent/ethanol/vodka = 1, /decl/reagent/ethanol/gin = 1, /decl/reagent/ethanol/tequilla = 1, /decl/reagent/ethanol/cuba_libre = 3)
-	result_amount = 6
-
-/datum/chemical_reaction/recipe/threemileisland
-	name = "Three Mile Island Iced Tea"
-	result = /decl/reagent/ethanol/threemileisland
-	required_reagents = list(/decl/reagent/ethanol/longislandicedtea = 10, /decl/reagent/uranium = 1)
-	result_amount = 10
-
-/datum/chemical_reaction/recipe/whiskeysoda
-	name = "Whiskey Soda"
-	result = /decl/reagent/ethanol/whiskeysoda
-	required_reagents = list(/decl/reagent/ethanol/whiskey = 2, /decl/reagent/drink/sodawater = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/black_russian
-	name = "Black Russian"
-	result = /decl/reagent/ethanol/black_russian
-	required_reagents = list(/decl/reagent/ethanol/vodka = 2, /decl/reagent/ethanol/coffee/kahlua = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/manhattan
-	name = "Manhattan"
-	result = /decl/reagent/ethanol/manhattan
-	required_reagents = list(/decl/reagent/ethanol/whiskey = 2, /decl/reagent/ethanol/vermouth = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/manhattan_proj
-	name = "Manhattan Project"
-	result = /decl/reagent/ethanol/manhattan_proj
-	required_reagents = list(/decl/reagent/ethanol/manhattan = 10, /decl/reagent/uranium = 1)
-	result_amount = 10
-
-/datum/chemical_reaction/recipe/vodka_tonic
-	name = "Vodka and Tonic"
-	result = /decl/reagent/ethanol/vodkatonic
-	required_reagents = list(/decl/reagent/ethanol/vodka = 2, /decl/reagent/drink/tonic = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/gin_fizz
-	name = "Gin Fizz"
-	result = /decl/reagent/ethanol/ginfizz
-	required_reagents = list(/decl/reagent/ethanol/gin = 1, /decl/reagent/drink/sodawater = 1, /decl/reagent/drink/juice/lime = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/bahama_mama
-	name = "Bahama Mama"
-	result = /decl/reagent/ethanol/bahama_mama
-	required_reagents = list(/decl/reagent/ethanol/rum = 2, /decl/reagent/drink/juice/orange = 2, /decl/reagent/drink/juice/lime = 1, /decl/reagent/drink/ice = 1)
-	result_amount = 6
-
-/datum/chemical_reaction/recipe/singulo
-	name = "Singulo"
-	result = /decl/reagent/ethanol/singulo
-	required_reagents = list(/decl/reagent/ethanol/vodka = 5, /decl/reagent/radium = 1, /decl/reagent/ethanol/wine = 5)
-	result_amount = 10
-
-/datum/chemical_reaction/recipe/alliescocktail
-	name = "Allies Cocktail"
-	result = /decl/reagent/ethanol/alliescocktail
-	required_reagents = list(/decl/reagent/ethanol/vodkamartini = 1, /decl/reagent/ethanol/martini = 1)
-	result_amount = 2
-
-/datum/chemical_reaction/recipe/demonsblood
-	name = "Demon's Blood"
-	result = /decl/reagent/ethanol/demonsblood
-	required_reagents = list(/decl/reagent/ethanol/rum = 3, /decl/reagent/drink/citrussoda = 1, /decl/reagent/blood = 1, /decl/reagent/drink/cherrycola = 1)
-	result_amount = 6
-
-/datum/chemical_reaction/recipe/booger
-	name = "Booger"
-	result = /decl/reagent/ethanol/booger
-	required_reagents = list(/decl/reagent/drink/milk/cream = 2, /decl/reagent/drink/juice/banana = 1, /decl/reagent/ethanol/rum = 1, /decl/reagent/drink/juice/watermelon = 1)
-	result_amount = 5
-	mix_message = "The solution thickens unpleasantly."
-
-/datum/chemical_reaction/recipe/antifreeze
-	name = "Anti-freeze"
-	result = /decl/reagent/ethanol/antifreeze
-	required_reagents = list(/decl/reagent/ethanol/vodka = 1, /decl/reagent/drink/milk/cream = 1, /decl/reagent/drink/ice = 1)
-	minimum_temperature = (0 CELSIUS) - 100
-	maximum_temperature = 0 CELSIUS
-	result_amount = 3
-	mix_message = "The solution thickens sluggishly."
-
-/datum/chemical_reaction/recipe/barefoot
-	name = "Barefoot"
-	result = /decl/reagent/ethanol/barefoot
-	required_reagents = list(/decl/reagent/drink/juice/berry = 1, /decl/reagent/drink/milk/cream = 1, /decl/reagent/ethanol/vermouth = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/sbiten
-	name = "Sbiten"
-	result = /decl/reagent/ethanol/sbiten
-	required_reagents = list(/decl/reagent/ethanol/mead = 10, /decl/reagent/capsaicin = 1)
-	result_amount = 10
-
-/datum/chemical_reaction/recipe/red_mead
-	name = "Red Mead"
-	result = /decl/reagent/ethanol/red_mead
-	required_reagents = list(/decl/reagent/blood = 1, /decl/reagent/ethanol/mead = 1)
-	result_amount = 2
-
 /datum/chemical_reaction/recipe/mead
 	name = "Mead"
 	result = /decl/reagent/ethanol/mead
 	required_reagents = list(/decl/reagent/nutriment/honey = 1, /decl/reagent/water = 1)
 	catalysts = list(/decl/reagent/enzyme = 5)
-	result_amount = 2
-
-/datum/chemical_reaction/recipe/grog
-	name = "Grog"
-	result = /decl/reagent/ethanol/grog
-	required_reagents = list(/decl/reagent/ethanol/rum = 1, /decl/reagent/water = 1)
-	result_amount = 2
-
-/datum/chemical_reaction/recipe/acidspit
-	name = "Acid Spit"
-	result = /decl/reagent/ethanol/acid_spit
-	required_reagents = list(/decl/reagent/acid = 1, /decl/reagent/ethanol/wine = 5)
-	result_amount = 6
-	mix_message = "The solution curdles into an unpleasant, slimy liquid."
-
-/datum/chemical_reaction/recipe/amasec
-	name = "Amasec"
-	result = /decl/reagent/ethanol/amasec
-	required_reagents = list(/decl/reagent/iron = 1, /decl/reagent/ethanol/wine = 5, /decl/reagent/ethanol/vodka = 5)
-	result_amount = 10
-
-/datum/chemical_reaction/recipe/changelingsting
-	name = "Changeling Sting"
-	result = /decl/reagent/ethanol/changelingsting
-	required_reagents = list(/decl/reagent/ethanol/screwdrivercocktail = 1, /decl/reagent/drink/juice/lime = 1, /decl/reagent/drink/juice/lemon = 1)
-	result_amount = 3
-	mix_message = "The solution begins to shift and change colour."
-
-/datum/chemical_reaction/recipe/aloe
-	name = "Aloe"
-	result = /decl/reagent/ethanol/aloe
-	required_reagents = list(/decl/reagent/drink/milk/cream = 1, /decl/reagent/ethanol/aged_whiskey = 1, /decl/reagent/drink/juice/watermelon = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/andalusia
-	name = "Andalusia"
-	result = /decl/reagent/ethanol/andalusia
-	required_reagents = list(/decl/reagent/ethanol/rum = 1, /decl/reagent/ethanol/whiskey = 1, /decl/reagent/drink/juice/lemon = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/neurotoxin
-	name = "Neurotoxin"
-	result = /decl/reagent/ethanol/neurotoxin
-	required_reagents = list(/decl/reagent/ethanol/livergeist = 1, /decl/reagent/sedatives = 1)
-	result_amount = 2
-
-/datum/chemical_reaction/recipe/snowwhite
-	name = "Snow White"
-	result = /decl/reagent/ethanol/snowwhite
-	required_reagents = list(/decl/reagent/ethanol/beer = 1, /decl/reagent/drink/lemon_lime = 1)
-	result_amount = 2
-
-/datum/chemical_reaction/recipe/irishslammer
-	name = "Irish Slammer"
-	result = /decl/reagent/ethanol/irishslammer
-	required_reagents = list(/decl/reagent/ethanol/ale = 1, /decl/reagent/ethanol/irish_cream = 1)
-	result_amount = 2
-
-/datum/chemical_reaction/recipe/syndicatebomb
-	name = "Syndicate Bomb"
-	result = /decl/reagent/ethanol/syndicatebomb
-	required_reagents = list(/decl/reagent/ethanol/beer = 1, /decl/reagent/ethanol/whiskey_cola = 1)
-	result_amount = 2
-
-/datum/chemical_reaction/recipe/erikasurprise
-	name = "Erika Surprise"
-	result = /decl/reagent/ethanol/erikasurprise
-	required_reagents = list(/decl/reagent/ethanol/ale = 2, /decl/reagent/drink/juice/lime = 1, /decl/reagent/ethanol/whiskey = 1, /decl/reagent/drink/juice/banana = 1, /decl/reagent/drink/ice = 1)
-	result_amount = 6
-
-/datum/chemical_reaction/recipe/devilskiss
-	name = "Devils Kiss"
-	result = /decl/reagent/ethanol/devilskiss
-	required_reagents = list(/decl/reagent/blood = 1, /decl/reagent/ethanol/coffee/kahlua = 1, /decl/reagent/ethanol/rum = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/hippiesdelight
-	name = "Hippies Delight"
-	result = /decl/reagent/ethanol/hippies_delight
-	required_reagents = list(/decl/reagent/psychotropics = 1, /decl/reagent/ethanol/livergeist = 1)
-	result_amount = 2
-
-/datum/chemical_reaction/recipe/bananahonk
-	name = "Banana Honk"
-	result = /decl/reagent/ethanol/bananahonk
-	required_reagents = list(/decl/reagent/drink/juice/banana = 1, /decl/reagent/drink/milk/cream = 1, /decl/reagent/nutriment/sugar = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/silencer
-	name = "Silencer"
-	result = /decl/reagent/ethanol/silencer
-	required_reagents = list(/decl/reagent/drink/nothing = 1, /decl/reagent/drink/milk/cream = 1, /decl/reagent/nutriment/sugar = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/driestmartini
-	name = "Driest Martini"
-	result = /decl/reagent/ethanol/driestmartini
-	required_reagents = list(/decl/reagent/drink/nothing = 1, /decl/reagent/ethanol/gin = 1)
 	result_amount = 2
 
 /datum/chemical_reaction/recipe/rum
@@ -453,12 +114,6 @@
 	result_amount = 2
 	mix_message = "The solution roils as it rapidly ferments into a red-brown liquid."
 
-/datum/chemical_reaction/recipe/ships_surgeon
-	name = "Ship's Surgeon"
-	result = /decl/reagent/ethanol/ships_surgeon
-	required_reagents = list(/decl/reagent/ethanol/rum = 1, /decl/reagent/drink/cherrycola = 2, /decl/reagent/drink/ice = 1)
-	result_amount = 4
-
 /datum/chemical_reaction/recipe/applecider
 	name = "Apple Cider"
 	result = /decl/reagent/ethanol/applecider
@@ -466,44 +121,9 @@
 	catalysts = list(/decl/reagent/nutriment = 5)
 	result_amount = 3
 
-/datum/chemical_reaction/recipe/vodkacola
-	name = "Vodka Cola"
-	result = /decl/reagent/ethanol/vodkacola
-	required_reagents = list(/decl/reagent/drink/cola = 1, /decl/reagent/ethanol/vodka = 2)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/arak
-	name = "Arak"
-	result = /decl/reagent/ethanol/arak
-	required_reagents = list(/decl/reagent/ethanol/absinthe = 2, /decl/reagent/drink/juice/grape = 1)
-	catalysts = list(/decl/reagent/nutriment)
-	result_amount = 3
-	minimum_temperature = (0 CELSIUS) - 100
-	maximum_temperature = 0 CELSIUS
-	mix_message = "The aniseed ferments into a translucent white mixture"
-
-/datum/chemical_reaction/recipe/sawbonesdismay
-	name = "Sawbones' Dismay"
-	result = /decl/reagent/ethanol/sawbonesdismay
-	required_reagents = list(/decl/reagent/drink/beastenergy = 1, /decl/reagent/ethanol/jagermeister = 2)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/jagermeister
-	name = "Jagermeister"
-	result = /decl/reagent/ethanol/jagermeister
-	required_reagents = list(/decl/reagent/ethanol/herbal = 2, /decl/reagent/water = 1)
-	catalysts = list(/decl/reagent/drink/syrup/mint)
-	result_amount = 3
-
 /datum/chemical_reaction/recipe/kvass
 	name = "Kvass"
 	result = /decl/reagent/ethanol/kvass
 	required_reagents = list(/decl/reagent/nutriment/sugar = 1, /decl/reagent/ethanol/beer = 1)
 	catalysts = list(/decl/reagent/enzyme = 5)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/suidream
-	name = "Sui Dream"
-	result = /decl/reagent/ethanol/suidream
-	required_reagents = list(/decl/reagent/drink/lemonade = 1, /decl/reagent/ethanol/bluecuracao = 1, /decl/reagent/ethanol/melonliquor = 1)
 	result_amount = 3

--- a/code/modules/reagents/reactions/reaction_drinks.dm
+++ b/code/modules/reagents/reactions/reaction_drinks.dm
@@ -43,30 +43,6 @@
 	mix_message = "The solution thickens into a creamy brown beverage."
 	maximum_temperature = 70 CELSIUS
 
-/datum/chemical_reaction/recipe/fools_gold
-	name = "Fools Gold"
-	result = /decl/reagent/drink/fools_gold
-	required_reagents = list(/decl/reagent/water = 2, /decl/reagent/ethanol/whiskey = 1)
-	result_amount = 3
-
-/datum/chemical_reaction/recipe/snowball
-	name = "Snowball"
-	result = /decl/reagent/drink/snowball
-	required_reagents = list(/decl/reagent/drink/ice = 2, /decl/reagent/drink/coffee = 1, /decl/reagent/drink/juice/watermelon = 1)
-	result_amount = 4
-	minimum_temperature = (0 CELSIUS) - 100
-	maximum_temperature = 0 CELSIUS
-	mix_message = "The solution turns pure white."
-
-/datum/chemical_reaction/recipe/browndwarf
-	name = "Brown Dwarf"
-	result = /decl/reagent/drink/browndwarf
-	required_reagents = list(/decl/reagent/drink/hot_coco = 2, /decl/reagent/drink/citrussoda = 1)
-	result_amount = 3
-	minimum_temperature = 70 CELSIUS
-	maximum_temperature = (70 CELSIUS) + 100
-	mix_message = "The chocolate puffs up into a semi-solid state"
-
 /datum/chemical_reaction/recipe/kefir
 	name = "Kefir"
 	result = /decl/reagent/drink/kefir

--- a/code/modules/reagents/reactions/reaction_drinks.dm
+++ b/code/modules/reagents/reactions/reaction_drinks.dm
@@ -43,12 +43,6 @@
 	mix_message = "The solution thickens into a creamy brown beverage."
 	maximum_temperature = 70 CELSIUS
 
-/datum/chemical_reaction/recipe/nothing
-	name = "Nothing"
-	result = /decl/reagent/drink/nothing
-	required_reagents = list(/decl/reagent/drink/milk/cream = 1, /decl/reagent/nutriment/sugar = 1, /decl/reagent/water= 1)
-	result_amount = 3
-
 /datum/chemical_reaction/recipe/fools_gold
 	name = "Fools Gold"
 	result = /decl/reagent/drink/fools_gold

--- a/code/modules/reagents/reactions/reaction_drinks.dm
+++ b/code/modules/reagents/reactions/reaction_drinks.dm
@@ -35,12 +35,6 @@
 	required_reagents = list(/decl/reagent/drink/milk/cream = 1, /decl/reagent/drink/ice = 2, /decl/reagent/drink/milk = 2)
 	result_amount = 5
 
-/datum/chemical_reaction/recipe/rewriter
-	name = "Rewriter"
-	result = /decl/reagent/drink/rewriter
-	required_reagents = list(/decl/reagent/drink/citrussoda = 1, /decl/reagent/drink/coffee = 1)
-	result_amount = 2
-
 /datum/chemical_reaction/recipe/chocolate_milk
 	name = "Chocolate Milk"
 	result = /decl/reagent/drink/milk/chocolate

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -279,16 +279,6 @@
 	. = ..()
 	reagents.add_reagent(/decl/reagent/ethanol/tequilla, 100)
 
-/obj/item/chems/food/drinks/bottle/bottleofnothing
-	name = "Bottle of Nothing"
-	desc = "A bottle filled with nothing."
-	icon_state = "bottleofnothing"
-	center_of_mass = @"{'x':17,'y':5}"
-
-/obj/item/chems/food/drinks/bottle/bottleofnothing/Initialize()
-	. = ..()
-	reagents.add_reagent(/decl/reagent/drink/nothing, 100)
-
 /obj/item/chems/food/drinks/bottle/patron
 	name = "Wrapp Artiste Patron"
 	desc = "Silver laced tequilla, served in space night clubs across the galaxy."

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -297,7 +297,8 @@
 
 /obj/item/chems/food/drinks/bottle/patron/Initialize()
 	. = ..()
-	reagents.add_reagent(/decl/reagent/ethanol/patron, 100)
+	reagents.add_reagent(/decl/reagent/ethanol/tequilla, 95)
+	reagents.add_reagent(/decl/reagent/silver, 5)
 
 /obj/item/chems/food/drinks/bottle/rum
 	name = "Captain Pete's Cuban Spiced Rum"
@@ -347,7 +348,8 @@
 
 /obj/item/chems/food/drinks/bottle/goldschlager/Initialize()
 	. = ..()
-	reagents.add_reagent(/decl/reagent/ethanol/goldschlager, 100)
+	reagents.add_reagent(/decl/reagent/ethanol/vodka, 95)
+	reagents.add_reagent(/decl/reagent/gold, 5)
 
 /obj/item/chems/food/drinks/bottle/cognac
 	name = "Chateau De Baton Premium Cognac"

--- a/code/modules/reagents/reagent_containers/food/lunch.dm
+++ b/code/modules/reagents/reagent_containers/food/lunch.dm
@@ -59,7 +59,6 @@ var/list/lunchables_drinks_ = list(
 // This default list is a bit different, it contains items we don't want
 var/list/lunchables_drink_reagents_ = list(
 											/decl/reagent/drink/nothing,
-											/decl/reagent/drink/doctor_delight,
 											/decl/reagent/drink/dry_ramen,
 											/decl/reagent/drink/hell_ramen,
 											/decl/reagent/drink/hot_ramen,
@@ -68,18 +67,10 @@ var/list/lunchables_drink_reagents_ = list(
 
 // This default list is a bit different, it contains items we don't want
 var/list/lunchables_ethanol_reagents_ = list(
-												/decl/reagent/ethanol/acid_spit,
-												/decl/reagent/ethanol/atomicbomb,
-												/decl/reagent/ethanol/beepsky_smash,
 												/decl/reagent/ethanol/coffee,
-												/decl/reagent/ethanol/hippies_delight,
 												/decl/reagent/ethanol/hooch,
 												/decl/reagent/ethanol/thirteenloko,
-												/decl/reagent/ethanol/manhattan_proj,
-												/decl/reagent/ethanol/neurotoxin,
-												/decl/reagent/ethanol/pwine,
-												/decl/reagent/ethanol/threemileisland,
-												/decl/reagent/ethanol/toxins_special
+												/decl/reagent/ethanol/pwine
 											)
 
 /proc/lunchables_lunches()

--- a/code/modules/reagents/reagent_containers/food/lunch.dm
+++ b/code/modules/reagents/reagent_containers/food/lunch.dm
@@ -58,7 +58,6 @@ var/list/lunchables_drinks_ = list(
 
 // This default list is a bit different, it contains items we don't want
 var/list/lunchables_drink_reagents_ = list(
-											/decl/reagent/drink/nothing,
 											/decl/reagent/drink/dry_ramen,
 											/decl/reagent/drink/hell_ramen,
 											/decl/reagent/drink/hot_ramen,

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -251,9 +251,7 @@
 	bitesize = 3
 /obj/item/chems/food/snacks/aesirsalad/Initialize()
 	.=..()
-	reagents.add_reagent(/decl/reagent/drink/doctor_delight, 8)
 	reagents.add_reagent(/decl/reagent/regenerator, 8)
-
 
 /obj/item/chems/food/snacks/egg
 	name = "egg"
@@ -514,7 +512,11 @@
 	name = "\improper Sin-pocket"
 	desc = "The food of choice for the veteran. Do <b>NOT</b> overconsume."
 	filling_color = "#6d6d00"
-	heated_reagents = list(/decl/reagent/drink/doctor_delight = 5, /decl/reagent/amphetamines = 0.75, /decl/reagent/stimulants = 0.25)
+	heated_reagents = list(
+		/decl/reagent/regenerator = 5, 
+		/decl/reagent/amphetamines = 0.75, 
+		/decl/reagent/stimulants = 0.25
+	)
 	var/has_been_heated = 0 // Unlike the warm var, this checks if the one-time self-heating operation has been used.
 
 /obj/item/chems/food/snacks/donkpocket/sinpocket/attack_self(mob/user)
@@ -3235,7 +3237,6 @@
 	.=..()
 	reagents.add_reagent(/decl/reagent/nutriment/sugar, 4)
 
-
 /obj/item/chems/food/snacks/cheesiehonkers
 	name = "cheese puffs"
 	icon_state = "cheesie_honkers"
@@ -3260,7 +3261,7 @@
 
 /obj/item/chems/food/snacks/syndicake/Initialize()
 	.=..()
-	reagents.add_reagent(/decl/reagent/drink/doctor_delight, 5)
+	reagents.add_reagent(/decl/reagent/regenerator, 5)
 
 //terran delights
 
@@ -3289,7 +3290,7 @@
 /obj/item/chems/food/snacks/squid
 	name = "\improper Calamari Crisps"
 	icon_state = "squid"
-	desc = "Space squid tentacles, Carefully removed (from the squid) then dried into strips of delicious rubbery goodness!"
+	desc = "Space cepholapod tentacles, carefully removed from the squid then dried into strips of delicious rubbery goodness!"
 	trash = /obj/item/trash/squid
 	filling_color = "#c0a9d7"
 	center_of_mass = @"{'x':15,'y':9}"

--- a/maps/antag_spawn/wizard/wizard_base.dmm
+++ b/maps/antag_spawn/wizard/wizard_base.dmm
@@ -270,7 +270,6 @@
 /area/map_template/wizard_station)
 "aL" = (
 /obj/structure/closet,
-/obj/item/chems/food/drinks/bottle/bottleofnothing,
 /obj/item/chems/food/drinks/bottle/pwine,
 /obj/item/chems/food/drinks/bottle/agedwhiskey,
 /obj/item/chems/food/drinks/bottle/cognac,

--- a/nebula.dme
+++ b/nebula.dme
@@ -2730,6 +2730,7 @@
 #include "code\modules\reagents\Chemistry-Machinery.dm"
 #include "code\modules\reagents\Chemistry-Metabolism.dm"
 #include "code\modules\reagents\Chemistry-Reagents.dm"
+#include "code\modules\reagents\cocktails.dm"
 #include "code\modules\reagents\reagent_containers.dm"
 #include "code\modules\reagents\reagent_dispenser.dm"
 #include "code\modules\reagents\chems\chems_acid.dm"

--- a/nebula.dme
+++ b/nebula.dme
@@ -1616,6 +1616,7 @@
 #include "code\modules\codex\codex_implant.dm"
 #include "code\modules\codex\codex_mob.dm"
 #include "code\modules\codex\categories\_category.dm"
+#include "code\modules\codex\categories\category_cocktails.dm"
 #include "code\modules\codex\categories\category_cultures.dm"
 #include "code\modules\codex\categories\category_fusion_reaction.dm"
 #include "code\modules\codex\categories\category_gases.dm"


### PR DESCRIPTION
- Cuts out a lot of reagents and reactions purely used for cosmetic drinks.
- Removes a few /tg/ cocktails that are just references, or aren't cocktails (Sui Dream, Arak).
- Adds a cocktail system that changes the properties of the vessel based on the contents.
- This is prep for unifying materials and reagents as I really don't want to have to convert fifty or sixty fluff reagents when their main purpose is visual.
- Removes the Nothing reagent and associated drinks. Was discussed on Discord, it's a meme mime reagent.

**TODO**
- [x] Add ratio checking for cocktails instead of just presence.
- [x] Set ratios on cocktails.
- [x] Convert remaining cocktail reagents.
- [x] Remove primary reagent check, make the recipe tree commutative.
- [x] Remove remaining cocktail reagents.
- [x] Add codex page and adjust other codex page.
- [x] Readd and update cocktail descriptions.
- ~~Add reagent layering for cocktails.~~ This can be a future PR.