### PR TITLE
Adds ship encounters

### DIFF
--- a/code/__defines/shuttle.dm
+++ b/code/__defines/shuttle.dm
@@ -4,10 +4,12 @@
 #define SHUTTLE_FLAGS_ZERO_G  4
 #define SHUTTLE_FLAGS_ALL (~SHUTTLE_FLAGS_NONE)
 
-#define SLANDMARK_FLAG_AUTOSET 1    // If set, will set base area and turf type to same as where it was spawned at
-#define SLANDMARK_FLAG_ZERO_G  2    // Zero-G shuttles moved here will lose gravity unless the area has ambient gravity.
+#define SLANDMARK_FLAG_AUTOSET      1 // If set, will set base area and turf type to same as where it was spawned at.
+#define SLANDMARK_FLAG_ZERO_G       2 // Zero-G shuttles moved here will lose gravity unless the area has ambient gravity.
+#define SLANDMARK_FLAG_DISCONNECTED 4 // Landable ships that land here will be forceably removed if the sector moves out of range.
 
 //Overmap landable shuttles
-#define SHIP_STATUS_LANDED   1
-#define SHIP_STATUS_TRANSIT  2
-#define SHIP_STATUS_OVERMAP  3
+#define SHIP_STATUS_LANDED    1
+#define SHIP_STATUS_TRANSIT   2
+#define SHIP_STATUS_OVERMAP   3
+#define SHIP_STATUS_ENCOUNTER 4

--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -129,9 +129,10 @@
 		if(target)
 			if(base_area)
 				ChangeArea(target, get_area(source))
+				transport_turf_contents(source, target)
 				ChangeArea(source, base_area)
-			transport_turf_contents(source, target)
-
+			else
+				transport_turf_contents(source, target)
 	//change the old turfs
 	for(var/turf/source in translation)
 		source.ChangeTurf(base_turf ? base_turf : get_base_turf_by_area(source), 1, 1)

--- a/code/modules/overmap/contacts/_contacts.dm
+++ b/code/modules/overmap/contacts/_contacts.dm
@@ -32,7 +32,7 @@
 
 /datum/overmap_contact/proc/update_marker_icon(var/range = 0)
 	marker.icon_state = effect.icon_state
-
+	marker.dir = effect.dir
 	marker.overlays.Cut()
 
 	if(check_effect_shield())

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -156,6 +156,32 @@
 	destination.shuttle_arrived(src)
 	return TRUE
 
+// Attempts to force move the shuttle with minimal checks.
+// In ideal use, none of the checks fail and this is a standard move to location while overriding any movement time or fuel checks.
+// Anything in the arrival area will be destroyed with no warning. Use sparingly.
+/datum/shuttle/proc/attempt_force_move(var/obj/effect/shuttle_landmark/destination)
+	if(current_location == destination)
+		log_error("Error when attempting to force move a shuttle: Attempted to move [src] to its current location [destination].")
+		return FALSE
+	if(destination.shuttle_restricted != name)
+		log_error("Error when attempting to force move a shuttle: Destination location not restricted for [src]'s use.")
+		return FALSE
+	
+	testing("Force moving [src] to [destination]. Areas are [english_list(shuttle_area)]")
+	var/list/translation = list()
+
+	for(var/area/A in shuttle_area)
+		testing("Moving [A]")
+		translation += get_turf_translation(get_turf(current_location), get_turf(destination), A.contents)
+	var/obj/effect/shuttle_landmark/old_location = current_location
+	GLOB.shuttle_pre_move_event.raise_event(src, old_location, destination)
+	shuttle_moved(destination, translation)
+	GLOB.shuttle_moved_event.raise_event(src, old_location, destination)
+	if(istype(old_location))
+		old_location.shuttle_departed(src)
+	destination.shuttle_arrived(src)
+	return TRUE
+
 //just moves the shuttle from A to B, if it can be moved
 //A note to anyone overriding move in a subtype. shuttle_moved() must absolutely not, under any circumstances, fail to move the shuttle.
 //If you want to conditionally cancel shuttle launches, that logic must go in short_jump(), long_jump() or attempt_move()


### PR DESCRIPTION
A simple implementation of ship encounters to make interaction between overmap ships more interesting. Landable ships that fly into a landmark flagged as disconnected no longer leave the overmap, and will be forceably removed from the landmark and back into space if they move out of range of the sector. Currently only applies to landable ships visitor landmarks.

Additionally moves a couple lines around in shuttle's turf translation in order to prevent machines inside of shuttles from briefly losing power when their area is removed, although this means there will briefly be a copy of the shuttle area elsewhere before translation. Also fixes a small bug where the direction of overmap effects wasn't updated properly by scanners, although this can be moved to another PR if necessary.