### PR TITLE
Some OS/net refactors/fixes

### DIFF
--- a/code/__defines/computers.dm
+++ b/code/__defines/computers.dm
@@ -6,9 +6,7 @@
 #define NETWORK_ALL_FEATURES		(NETWORK_SOFTWAREDOWNLOAD|NETWORK_COMMUNICATION|NETWORK_SYSTEMCONTROL)
 
 // Transfer speeds, used when downloading/uploading a file/program.
-#define NETWORK_SPEED_LOWSIGNAL 0.5	// GQ/s transfer speed when the device is wirelessly connected and on Low signal
-#define NETWORK_SPEED_HIGHSIGNAL 1	// GQ/s transfer speed when the device is wirelessly connected and on High signal
-#define NETWORK_SPEED_ETHERNET 2		// GQ/s transfer speed when the device is using wired connection
+#define NETWORK_SPEED_BASE  1/NETWORK_BASE_BROADCAST_STRENGTH	// GQ/s transfer speed, multiplied by signal power
 #define NETWORK_SPEED_DISK 	10		// GQ/s transfer speed when the device is transferring between hard drives
 
 // Network mainframe roles

--- a/code/game/machinery/_machines_base/stock_parts/network_lock.dm
+++ b/code/game/machinery/_machines_base/stock_parts/network_lock.dm
@@ -11,7 +11,7 @@
 	var/list/grants = list()						// List of grants required to operate the device.
 	var/emagged										// Whether or not this has been emagged.
 	var/error
-	var/signal_strength = NETWORK_SPEED_LOWSIGNAL	// How good the wireless capabilities are of this card.
+	var/signal_strength = NETWORK_CONNECTION_WIRELESS	// How good the wireless capabilities are of this card.
 	var/interact_sounds = list("keyboard", "keystroke")
 	var/interact_sound_volume = 40
 

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -17,14 +17,12 @@
 	var/program_menu_icon = "newwin"				// Icon to use for program's link in main menu
 	var/requires_network = 0						// Set to 1 for program to require nonstop network connection to run. If network connection is lost program crashes.
 	var/requires_network_feature = 0				// Optional, if above is set to 1 checks for specific function of network (currently NETWORK_SOFTWAREDOWNLOAD, NETWORK_PEERTOPEER, NETWORK_SYSTEMCONTROL and NETWORK_COMMUNICATION)
-	var/network_status = 1							// network status, updated every tick by computer running this program. Don't use this for checks if network works, computers do that. Use this for calculations, etc.
 	var/usage_flags = PROGRAM_ALL & ~PROGRAM_PDA	// Bitflags (PROGRAM_CONSOLE, PROGRAM_LAPTOP, PROGRAM_TABLET, PROGRAM_PDA combination) or PROGRAM_ALL
 	var/network_destination = null					// Optional string that describes what network server/system this program connects to. Used in default logging.
 	var/available_on_network = 1						// Whether the program can be downloaded from network. Set to 0 to disable.
 	var/available_on_syndinet = 0					// Whether the program can be downloaded from SyndiNet (accessible via emagging the computer). Set to 1 to enable.
 	var/computer_emagged = 0						// Set to 1 if computer that's running us was emagged. Computer updates this every Process() tick
 	var/ui_header = null							// Example: "something.gif" - a header image that will be rendered in computer's UI when this program is running at background. Images are taken from /nano/images/status_icons. Be careful not to use too large images!
-	var/network_speed = 0								// GQ/s - current network connectivity transfer rate
 	var/operator_skill = SKILL_MIN                  // Holder for skill value of current/recent operator for programs that tick.
 
 /datum/computer_file/program/Destroy()
@@ -80,18 +78,7 @@
 
 // Called by Process() on device that runs us, once every tick.
 /datum/computer_file/program/proc/process_tick()
-	update_netspeed()
 	return 1
-
-/datum/computer_file/program/proc/update_netspeed()
-	network_speed = 0
-	switch(network_status)
-		if(1)
-			network_speed = NETWORK_SPEED_LOWSIGNAL
-		if(2)
-			network_speed = NETWORK_SPEED_HIGHSIGNAL
-		if(3)
-			network_speed = NETWORK_SPEED_ETHERNET
 
 // Check if the user can run program. Only humans can operate computer. Automatically called in run_program()
 // User has to wear their ID or have it inhand for ID Scan to work.

--- a/code/modules/modular_computers/file_system/programs/generic/email_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/email_client.dm
@@ -46,7 +46,7 @@
 	var/datum/nano_module/program/email_client/NME = NM
 	if(!istype(NME))
 		return
-	NME.relayed_process(network_speed)
+	NME.relayed_process(computer.get_network_status())
 
 	var/check_count = NME.check_for_new_messages()
 	if(check_count)

--- a/code/modules/modular_computers/file_system/programs/generic/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/file_browser.dm
@@ -14,7 +14,7 @@
 	var/error
 	var/list/file_sources = list(
 		/datum/file_storage/disk,
-		/datum/file_storage/disk_removable,
+		/datum/file_storage/disk/removable,
 		/datum/file_storage/network
 	)
 	var/datum/file_storage/current_filesource = /datum/file_storage/disk

--- a/code/modules/modular_computers/ntos/components.dm
+++ b/code/modules/modular_computers/ntos/components.dm
@@ -29,20 +29,12 @@
 /datum/extension/interactive/ntos/proc/get_network_status(var/specific_action = 0)
 	var/obj/item/stock_parts/computer/network_card/network_card = get_component(PART_NETWORK)
 	if(network_card)
-		return network_card.get_signal(specific_action)
+		var/signal_power_level = NETWORK_SPEED_BASE * network_card.get_signal(specific_action)
+		if(signal_power_level > 0)
+			signal_power_level = round(Clamp(signal_power_level, 1, 3))
+		return signal_power_level
 	else
 		return 0
-
-/datum/extension/interactive/ntos/proc/get_network_speed(var/specific_action = 0)
-	switch(get_network_status(NETWORK_SOFTWAREDOWNLOAD))
-		if(0)
-			return 0
-		if(1)
-			return NETWORK_SPEED_LOWSIGNAL
-		if(2)
-			return NETWORK_SPEED_HIGHSIGNAL
-		if(3)
-			return NETWORK_SPEED_ETHERNET
 
 /datum/extension/interactive/ntos/proc/get_inserted_id()
 	var/obj/item/stock_parts/computer/card_slot/card_slot = get_component(PART_CARD)

--- a/code/modules/modular_computers/ntos/files.dm
+++ b/code/modules/modular_computers/ntos/files.dm
@@ -182,7 +182,7 @@
 /datum/file_storage/network/get_transfer_speed()
 	if(check_errors())
 		return 0
-	return os.get_network_speed()
+	return os.get_network_status()
 
 /*
  * Special subclass for network machines specifically.
@@ -223,12 +223,15 @@
 	name = "Local Storage"
 	var/disk_type = PART_HDD
 
+/datum/file_storage/disk/proc/get_disk()
+	return os.get_component(PART_HDD)
+
 /datum/file_storage/disk/check_errors()
 	. = ..()
 	if(.)
 		return
-	var/obj/item/stock_parts/computer/hard_drive/HDD = os.get_component(disk_type)
-	if(!HDD)
+	var/obj/item/stock_parts/computer/hard_drive/HDD = get_disk()
+	if(!istype(HDD))
 		return "HARDWARE ERROR: No compatible device found"
 	if(!HDD.check_functionality())
 		return "NETWORK ERROR: [HDD] is non-operational"
@@ -236,78 +239,51 @@
 /datum/file_storage/disk/get_all_files()
 	if(check_errors())
 		return FALSE
-	return os.get_all_files(os.get_component(disk_type))
+	return os.get_all_files(get_disk())
 
 /datum/file_storage/disk/get_file(filename)
 	if(check_errors())
 		return FALSE
-	return os.get_file(filename, os.get_component(disk_type))
+	return os.get_file(filename, get_disk())
 
 /datum/file_storage/disk/store_file(datum/computer_file/F)
 	if(check_errors())
 		return FALSE
-	return os.store_file(F, os.get_component(disk_type))
+	return os.store_file(F, get_disk())
 
 /datum/file_storage/disk/save_file(filename, new_data)
 	if(check_errors())
 		return FALSE
-	return os.save_file(filename, new_data, os.get_component(disk_type))
+	return os.save_file(filename, new_data, get_disk())
 
 /datum/file_storage/disk/delete_file(filename)
 	if(check_errors())
 		return FALSE
-	return os.delete_file(filename, os.get_component(disk_type))
+	return os.delete_file(filename, get_disk())
 
-/datum/file_storage/network/get_transfer_speed()
+/datum/file_storage/disk/get_transfer_speed()
 	if(check_errors())
 		return 0
 	return NETWORK_SPEED_DISK
 
 // Storing files on a removable disk.
-/datum/file_storage/disk_removable
+/datum/file_storage/disk/removable
 	name = "Disk Drive"
 
-/datum/file_storage/disk_removable/check_errors()
+/datum/file_storage/disk/removable/get_disk()
+	var/obj/item/stock_parts/computer/drive_slot/drive_slot = os.get_component(PART_D_SLOT)
+	return drive_slot.stored_drive
+
+/datum/file_storage/disk/removable/check_errors()
 	. = ..()
 	if(.)
 		return
 	var/obj/item/stock_parts/computer/drive_slot/drive_slot = os.get_component(PART_D_SLOT)
-	if(!drive_slot)
-		return "HARDWARE ERROR: No compatible device found"
 	if(!drive_slot.check_functionality())
 		return "HARDWARE ERROR: [drive_slot] is non-operational"
 	if(!istype(drive_slot.stored_drive))
 		return "HARDWARE ERROR: No portable drive inserted."
 
-/datum/file_storage/disk_removable/get_all_files()
-	if(check_errors())
-		return FALSE
-	var/obj/item/stock_parts/computer/drive_slot/drive_slot = os.get_component(PART_D_SLOT)
-	return os.get_all_files(drive_slot.stored_drive)
-
-/datum/file_storage/disk_removable/get_file(filename)
-	if(check_errors())
-		return FALSE
-	var/obj/item/stock_parts/computer/drive_slot/drive_slot = os.get_component(PART_D_SLOT)
-	return os.get_file(filename, drive_slot.stored_drive)
-
-/datum/file_storage/disk_removable/store_file(datum/computer_file/F)
-	if(check_errors())
-		return FALSE
-	var/obj/item/stock_parts/computer/drive_slot/drive_slot = os.get_component(PART_D_SLOT)
-	return os.store_file(F, drive_slot.stored_drive)
-
-/datum/file_storage/disk_removable/save_file(filename, new_data)
-	if(check_errors())
-		return FALSE
-	var/obj/item/stock_parts/computer/drive_slot/drive_slot = os.get_component(PART_D_SLOT)
-	return os.save_file(filename, new_data, drive_slot.stored_drive)
-
-/datum/file_storage/disk_removable/delete_file(filename)
-	if(check_errors())
-		return FALSE
-	var/obj/item/stock_parts/computer/drive_slot/drive_slot = os.get_component(PART_D_SLOT)
-	return os.delete_file(filename, drive_slot.stored_drive)
 
 // Datum tracking progress between of file transfer between two file streams
 /datum/file_transfer


### PR DESCRIPTION
Gives it proc for acquiring disk that is override by removable disk one.

Fixes ntos net status proc

Also fixes network transfer speed configuration.
It used to be 0-3 value, now it's signal power in around 0-100 range I think.
Speed now sorta mirrors old setup, by getting divided by base broadcasting strength.
Removed bunch of unneeded procs and vars and defines
Repaths disk drive filestream handler to child of disk one
Fixes network status tray icon not appearing also.