### PR TITLE
Pipe Fabricator Fixes and Adjustments

### DIFF
--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -48,9 +48,9 @@
 
 	frame_type = /obj/item/pipe
 	construct_state = /decl/machine_construction/default/panel_closed/item_chassis
-	base_type = /obj/machinery/atmospherics/unary/vent_pump/buildable
+	base_type = /obj/machinery/atmospherics/unary/outlet_injector/buildable
 
-/obj/machinery/atmospherics/unary/vent_pump/buildable
+/obj/machinery/atmospherics/unary/outlet_injector/buildable
 	uncreated_component_parts = null
 
 /obj/machinery/atmospherics/unary/outlet_injector/Initialize()

--- a/code/modules/fabrication/designs/pipe/device_pipe_datums.dm
+++ b/code/modules/fabrication/designs/pipe/device_pipe_datums.dm
@@ -9,6 +9,7 @@
 	build_icon_state = "connector"
 	constructed_path = /obj/machinery/atmospherics/portables_connector
 	pipe_class = PIPE_CLASS_UNARY
+	rotate_class = PIPE_ROTATE_STANDARD
 
 /datum/fabricator_recipe/pipe/device/adapter
 	name = "universal pipe adapter"

--- a/code/modules/fabrication/designs/pipe/pipe_datums.dm
+++ b/code/modules/fabrication/designs/pipe/pipe_datums.dm
@@ -18,6 +18,7 @@
 	build_icon_state = "manifold"
 	constructed_path = /obj/machinery/atmospherics/pipe/manifold/hidden
 	pipe_class = PIPE_CLASS_TRINARY
+	rotate_class = PIPE_ROTATE_STANDARD
 
 /datum/fabricator_recipe/pipe/manifold4w
 	name = "four-way pipe manifold fitting"
@@ -70,6 +71,7 @@
 	build_icon_state = "manifold"
 	constructed_path = /obj/machinery/atmospherics/pipe/manifold/hidden/supply
 	pipe_class = PIPE_CLASS_TRINARY
+	rotate_class = PIPE_ROTATE_STANDARD
 
 /datum/fabricator_recipe/pipe/supply/manifold4w
 	name = "four-way supply pipe manifold fitting"
@@ -122,6 +124,7 @@
 	build_icon_state = "manifold"
 	constructed_path = /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers
 	pipe_class = PIPE_CLASS_TRINARY
+	rotate_class = PIPE_ROTATE_STANDARD
 
 /datum/fabricator_recipe/pipe/scrubber/manifold4w
 	name = "four-way scrubber pipe manifold fitting"
@@ -173,6 +176,7 @@
 	build_icon_state = "manifold"
 	constructed_path = /obj/machinery/atmospherics/pipe/manifold/hidden/fuel
 	pipe_class = PIPE_CLASS_TRINARY
+	rotate_class = PIPE_ROTATE_STANDARD
 
 /datum/fabricator_recipe/pipe/fuel/manifold4w
 	name = "four-way supply pipe manifold fitting"
@@ -204,6 +208,7 @@
 /datum/fabricator_recipe/pipe/he
 	category = "Heat Exchange Pipes"
 	colorable = FALSE
+	pipe_color = null
 	connect_types = CONNECT_TYPE_HE
 	constructed_path = /obj/machinery/atmospherics/pipe/simple/heat_exchanging
 	pipe_class = PIPE_CLASS_BINARY
@@ -227,6 +232,7 @@
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_HE
 	build_icon_state = "junction"
 	constructed_path = /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction
+	rotate_class = PIPE_ROTATE_STANDARD
 
 /datum/fabricator_recipe/pipe/he/exchanger
 	name = "heat exchanger"
@@ -235,6 +241,7 @@
 	build_icon_state = "heunary"
 	constructed_path = /obj/machinery/atmospherics/unary/heat_exchanger
 	pipe_class = PIPE_CLASS_UNARY
+	rotate_class = PIPE_ROTATE_STANDARD
 
 //Cleanup
 #undef PIPE_STRAIGHT

--- a/code/modules/fabrication/fabricator_intake.dm
+++ b/code/modules/fabrication/fabricator_intake.dm
@@ -139,8 +139,3 @@
 		return TRUE
 	interact(user)
 	return TRUE
-
-#undef SUBSTANCE_TAKEN_FULL
-#undef SUBSTANCE_TAKEN_NONE
-#undef SUBSTANCE_TAKEN_SOME
-#undef SUBSTANCE_TAKEN_ALL

--- a/code/modules/fabrication/fabricator_pipe.dm
+++ b/code/modules/fabrication/fabricator_pipe.dm
@@ -27,6 +27,12 @@
 	if(anchored)
 		update_use_power(POWER_USE_IDLE)
 
+/obj/machinery/fabricator/pipe/take_materials(var/obj/item/thing, var/mob/user)
+	. = ..()
+	// Pipe objects do not contain matter, and will not provide a refund on materials used to make them, but can be recycled to prevent clutter.
+	if(istype(thing, /obj/item/pipe) && (. == SUBSTANCE_TAKEN_NONE))
+		return SUBSTANCE_TAKEN_ALL
+	
 /obj/machinery/fabricator/pipe/do_build(var/datum/fabricator_recipe/recipe, var/amount)
 	. = recipe.build(get_turf(src), amount, pipe_colors[selected_color])
 	use_power_oneoff(500 * amount)


### PR DESCRIPTION
Fixes pipe fabricator bugs with Heat Exchange pipes not being visible after wrenching down and many devices and pipes not being able to be properly rotated in hand until they were wrenched and unwrenched.

You can now recycle subtypes of /obj/item/pipe in the Fabricator. This does not return any of the matter used for things such as devices, but it should prevent clutter from building up.