### PR TITLE
fixing exploded assemblies

### DIFF
--- a/code/datums/extensions/assembly/assembly.dm
+++ b/code/datums/extensions/assembly/assembly.dm
@@ -79,7 +79,7 @@
 			return P
 
 /datum/extension/assembly/proc/get_all_components()
-	return parts.Copy()
+	return parts?.Copy()
 
 
 /datum/extension/assembly/proc/shutdown_device()


### PR DESCRIPTION
During explosions, get_all_components() sometimes gets called after parts is cleared out. Nullcheck safety.