### PR TITLE
Allow loadout items to have custom setup procs

### DIFF
--- a/code/datums/underwear/underwear.dm
+++ b/code/datums/underwear/underwear.dm
@@ -60,7 +60,7 @@ datum/category_group/underwear/dd_SortValue()
 /datum/category_item/underwear/proc/is_default(var/gender)
 	return is_default
 
-/datum/category_item/underwear/proc/create_underwear(var/list/metadata)
+/datum/category_item/underwear/proc/create_underwear(var/mob/user, var/list/metadata)
 	if(!underwear_type)
 		return
 
@@ -71,5 +71,5 @@ datum/category_group/underwear/dd_SortValue()
 	UW.icon_state = icon_state
 
 	for(var/datum/gear_tweak/gt in tweaks)
-		gt.tweak_item(UW, metadata && metadata["[gt]"] ? metadata["[gt]"] : gt.get_default())
+		gt.tweak_item(user, UW, metadata && metadata["[gt]"] ? metadata["[gt]"] : gt.get_default())
 	return UW

--- a/code/game/objects/structures/under_wardrobe.dm
+++ b/code/game/objects/structures/under_wardrobe.dm
@@ -102,7 +102,7 @@
 			return
 		LAZYSET(amount_of_underwear_by_id_card, id, ++current_quota)
 
-		var/obj/UW = UWI.create_underwear(metadata_list)
+		var/obj/UW = UWI.create_underwear(H, metadata_list)
 		UW.forceMove(loc)
 		H.put_in_hands(UW)
 

--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -10,7 +10,7 @@
 /datum/gear_tweak/proc/tweak_gear_data(var/metadata, var/datum/gear_data)
 	return
 
-/datum/gear_tweak/proc/tweak_item(var/obj/item/I, var/metadata)
+/datum/gear_tweak/proc/tweak_item(var/user, var/obj/item/I, var/metadata)
 	return
 
 /datum/gear_tweak/proc/tweak_description(var/description, var/metadata)
@@ -38,7 +38,7 @@
 		return input(user, "Choose a color.", title, metadata) as null|anything in valid_colors
 	return input(user, "Choose a color.", title, metadata) as color|null
 
-/datum/gear_tweak/color/tweak_item(var/obj/item/I, var/metadata)
+/datum/gear_tweak/color/tweak_item(var/user, var/obj/item/I, var/metadata)
 	if(valid_colors && !(metadata in valid_colors))
 		return
 	I.color = sanitize_hexcolor(metadata, I.color)
@@ -126,7 +126,7 @@
 		else
 			return metadata
 
-/datum/gear_tweak/contents/tweak_item(var/obj/item/I, var/list/metadata)
+/datum/gear_tweak/contents/tweak_item(var/owner, var/obj/item/I, var/list/metadata)
 	if(length(metadata) != length(valid_contents))
 		return
 	for(var/i = 1 to valid_contents.len)
@@ -166,7 +166,7 @@
 	if(!.)
 		return metadata
 
-/datum/gear_tweak/reagents/tweak_item(var/obj/item/I, var/list/metadata)
+/datum/gear_tweak/reagents/tweak_item(var/user, var/obj/item/I, var/list/metadata)
 	if(metadata == "None")
 		return
 	var/reagent
@@ -176,6 +176,23 @@
 		reagent = valid_reagents[metadata]
 	if(reagent)
 		return I.reagents.add_reagent(reagent, REAGENTS_FREE_SPACE(I.reagents))
+
+/*
+* Custom Setup
+*/
+/datum/gear_tweak/custom_setup
+	var/custom_setup_proc
+
+/datum/gear_tweak/custom_setup/New(custom_setup_proc)
+	src.custom_setup_proc = custom_setup_proc
+	..()
+
+/datum/gear_tweak/custom_setup/tweak_item(var/user, var/item)
+	call(item, custom_setup_proc)(user)
+
+/*
+* Tablet Stuff
+*/
 
 /datum/gear_tweak/tablet
 	var/list/ValidProcessors = list(/obj/item/stock_parts/computer/processor_unit/small)
@@ -322,7 +339,7 @@
 	for(var/i in 1 to TWEAKABLE_COMPUTER_PART_SLOTS)
 		. += 1
 
-/datum/gear_tweak/tablet/tweak_item(var/obj/item/modular_computer/tablet/I, var/list/metadata)
+/datum/gear_tweak/tablet/tweak_item(var/user, var/obj/item/modular_computer/tablet/I, var/list/metadata)
 	if(length(metadata) < TWEAKABLE_COMPUTER_PART_SLOTS)
 		return
 	var/datum/extension/assembly/modular_computer/assembly = get_extension(I, /datum/extension/assembly)

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -241,7 +241,9 @@ var/list/gear_datums = list()
 		if(ticked)
 			entry += "<tr><td colspan=3>"
 			for(var/datum/gear_tweak/tweak in G.gear_tweaks)
-				entry += " <a href='?src=\ref[src];gear=\ref[G];tweak=\ref[tweak]'>[tweak.get_contents(get_tweak_metadata(G, tweak))]</a>"
+				var/contents = tweak.get_contents(get_tweak_metadata(G, tweak))
+				if(contents)
+					entry += " <a href='?src=\ref[src];gear=\ref[G];tweak=\ref[tweak]'>[contents]</a>"
 			entry += "</td></tr>"
 		if(!hide_unavailable_gear || allowed || ticked)
 			. += entry
@@ -388,22 +390,22 @@ var/list/gear_datums = list()
 	src.path = path
 	src.location = location
 
-/datum/gear/proc/spawn_item(var/location, var/metadata)
+/datum/gear/proc/spawn_item(user, location, metadata)
 	var/datum/gear_data/gd = new(path, location)
 	for(var/datum/gear_tweak/gt in gear_tweaks)
 		gt.tweak_gear_data(metadata && metadata["[gt]"], gd)
 	var/item = new gd.path(gd.location)
 	for(var/datum/gear_tweak/gt in gear_tweaks)
-		gt.tweak_item(item, metadata && metadata["[gt]"])
+		gt.tweak_item(user, item, metadata && metadata["[gt]"])
 	return item
 
 /datum/gear/proc/spawn_on_mob(var/mob/living/carbon/human/H, var/metadata)
-	var/obj/item/item = spawn_item(H, metadata)
+	var/obj/item/item = spawn_item(H, H, metadata)
 	if(H.equip_to_slot_if_possible(item, slot, del_on_fail = 1, force = 1))
 		. = item
 
 /datum/gear/proc/spawn_in_storage_or_drop(var/mob/living/carbon/human/H, var/metadata)
-	var/obj/item/item = spawn_item(H, metadata)
+	var/obj/item/item = spawn_item(H, H, metadata)
 	item.add_fingerprint(H)
 
 	var/atom/placed_in = H.equip_to_storage(item)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -235,7 +235,7 @@ datum/preferences
 			var/underwear_item_name = all_underwear[underwear_category_name]
 			var/datum/category_item/underwear/UWD = underwear_category.items_by_name[underwear_item_name]
 			var/metadata = all_underwear_metadata[underwear_category_name]
-			var/obj/item/underwear/UW = UWD.create_underwear(metadata)
+			var/obj/item/underwear/UW = UWD.create_underwear(character, metadata)
 			if(UW)
 				UW.ForceEquipUnderwear(character, FALSE)
 		else

--- a/code/unit_tests/loadout_tests.dm
+++ b/code/unit_tests/loadout_tests.dm
@@ -102,3 +102,23 @@ datum/unit_test/loadout_test_gear_path_tweaks_shall_have_unique_keys/start_test(
 /proc/type_has_valid_icon_state(var/atom/type)
 	var/atom/A = type
 	return (initial(A.icon_state) in icon_states(initial(A.icon)))
+
+
+datum/unit_test/loadout_custom_setup_tweaks_shall_have_valid_procs
+	name = "LOADOUT: Custom setup tweaks shall have valid procs"
+
+datum/unit_test/loadout_custom_setup_tweaks_shall_have_valid_procs/start_test()
+	for(var/gear_name in gear_datums)
+		var/datum/gear/G = gear_datums[gear_name]
+		var/datum/instance
+		var/mob/user
+		for(var/datum/gear_tweak/custom_setup/cs in G.gear_tweaks)
+			instance = instance || new G.path()
+			user = user || new()
+			cs.tweak_item(user, instance)
+
+		QDEL_NULL(instance)
+		QDEL_NULL(user)
+
+	pass("Succesfully called all custom setup procs without runtimes")
+	return  1


### PR DESCRIPTION
Which do not have to rely on being in the right place at the right time
Intended as a better solution for things like https://github.com/Baystation12/Baystation12/pull/28675 which just hope that they happen to be in the inventory of the owning mob