### PR TITLE
Improves blueprints

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -130,6 +130,7 @@
 	. = ..()
 
 /obj/machinery/alarm/Destroy()
+	GLOB.name_set_event.unregister(src, get_area(src), .proc/change_area_name)
 	unregister_radio(src, frequency)
 	return ..()
 
@@ -156,6 +157,7 @@
 		if(!env_info.important_gasses[g])
 			trace_gas += g
 
+	GLOB.name_set_event.register(alarm_area, src, .proc/change_area_name)
 	set_frequency(frequency)
 	update_icon()
 
@@ -775,6 +777,11 @@
 				to_chat(user, "<span class='warning'>Access denied.</span>")
 			return TRUE
 	return ..()
+
+/obj/machinery/alarm/proc/change_area_name(var/area/A, var/old_area_name, var/new_area_name)
+	if(A != get_area(src))
+		return
+	SetName(replacetext(name,old_area_name,new_area_name))
 
 /*
 FIRE ALARM

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -52,6 +52,7 @@
 	desc = "Blueprints of the [station_name()]. There is a \"Classified\" stamp and several coffee stains on it."
 	area_prefix = station_name()
 	valid_z_levels += GLOB.using_map.station_levels
+	return TRUE
 
 //For use on exoplanets
 /obj/item/blueprints/outpost

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -110,6 +110,7 @@
 	QDEL_NULL(sound_token)
 	var/area/A = get_area(src)
 	if(A)
+		GLOB.name_set_event.unregister(A, src, .proc/change_area_name)
 		A.air_vent_info -= id_tag
 		A.air_vent_names -= id_tag
 	. = ..()
@@ -251,7 +252,15 @@
 			var/new_name = "[A.name] Vent Pump #[A.air_vent_names.len+1]"
 			A.air_vent_names[id_tag] = new_name
 			SetName(new_name)
+			GLOB.name_set_event.register(A, src, .proc/change_area_name)
 	. = ..()
+
+/obj/machinery/atmospherics/unary/vent_pump/proc/change_area_name(var/area/A, var/old_area_name, var/new_area_name)
+	if(get_area(src) != A)
+		return
+	var/new_name = replacetext(A.air_vent_names[id_tag], old_area_name, new_area_name)
+	SetName(new_name)
+	A.air_vent_names[id_tag] = new_name
 
 /obj/machinery/atmospherics/unary/vent_pump/proc/purge()
 	pressure_checks &= ~PRESSURE_CHECK_EXTERNAL

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -65,6 +65,14 @@
 	air_contents.volume = ATMOS_DEFAULT_VOLUME_FILTER
 	icon = null
 
+/obj/machinery/atmospherics/unary/vent_scrubber/Destroy()
+	var/area/A = get_area(src)
+	if(A)
+		GLOB.name_set_event.unregister(A, src, .proc/change_area_name)
+		A.air_scrub_info -= id_tag
+		A.air_scrub_names -= id_tag
+	. = ..()
+
 /obj/machinery/atmospherics/unary/vent_scrubber/on_update_icon(var/safety = 0)
 	if(!check_icon_cache())
 		return
@@ -114,7 +122,15 @@
 		var/new_name = "[A.name] Vent Scrubber #[A.air_scrub_names.len+1]"
 		A.air_scrub_names[id_tag] = new_name
 		SetName(new_name)
+		GLOB.name_set_event.register(A, src, .proc/change_area_name)
 	. = ..()
+
+/obj/machinery/atmospherics/unary/vent_scrubber/proc/change_area_name(var/area/A, var/old_area_name, var/new_area_name)
+	if(get_area(src) != A)
+		return
+	var/new_name = replacetext(A.air_scrub_names[id_tag], old_area_name, new_area_name)
+	SetName(new_name)
+	A.air_scrub_names[id_tag] = new_name
 
 /obj/machinery/atmospherics/unary/vent_scrubber/RefreshParts()
 	. = ..()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -175,8 +175,10 @@
 		SetName("\improper [area.name] APC")
 	area.apc = src
 
-	. = ..()
+	GLOB.name_set_event.register(area, src, .proc/change_area_name)
 
+	. = ..()
+	
 	if (populate_parts)
 		init_round_start()
 	else
@@ -195,6 +197,8 @@
 		area.power_equip = 0
 		area.power_environ = 0
 		area.power_change()
+
+		GLOB.name_set_event.unregister(area, src, .proc/change_area_name)
 
 	// Malf AI, removes the APC from AI's hacked APCs list.
 	if((hacker) && (hacker.hacked_apcs) && (src in hacker.hacked_apcs))
@@ -885,6 +889,11 @@ obj/machinery/power/apc/proc/autoset(var/cur_state, var/on)
 	if(power)
 		power.can_charge = chargemode
 		power.charge_wait_counter = initial(power.charge_wait_counter)
+
+/obj/machinery/power/apc/proc/change_area_name(var/area/A, var/old_area_name, var/new_area_name)
+	if(A != get_area(src) || !autoname)
+		return
+	SetName(replacetext(name,old_area_name,new_area_name))
 
 // overload the lights in this APC area
 /obj/machinery/power/apc/proc/overload_lighting(var/chance = 100)


### PR DESCRIPTION
Addresses a few of the comments made on https://github.com/NebulaSS13/Nebula/pull/564, including cleaning up the machinery renaming code using event registration and using lazy lists on the blueprints eye. Also fixes a couple thing I missed regarding the selection image and using the blueprints on maps that do not use the overmap.