### PR TITLE
Moves Fabrication SS init up in order

### DIFF
--- a/code/controllers/subsystems/initialization/fabrication.dm
+++ b/code/controllers/subsystems/initialization/fabrication.dm
@@ -1,7 +1,7 @@
 SUBSYSTEM_DEF(fabrication)
 	name = "Fabrication"
 	flags = SS_NO_FIRE
-	init_order = SS_INIT_MISC_LATE
+	init_order = SS_INIT_MISC
 
 	var/list/all_recipes =                 list()
 	var/list/locked_recipes =              list()


### PR DESCRIPTION
Roundstart lathes started with no recipies becaue fabrication is inited way too late for them to get the initial ones.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->