### PR TITLE
Makes fabricators queue for initial recipies

### DIFF
--- a/code/modules/fabrication/_fabricator.dm
+++ b/code/modules/fabrication/_fabricator.dm
@@ -44,7 +44,7 @@
 	var/build_time_multiplier = 1
 	var/global/list/stored_substances_to_names = list()
 
-	var/list/design_cache
+	var/list/design_cache = list()
 	var/list/installed_designs
 
 	var/sound_id
@@ -96,9 +96,7 @@
 				var/decl/material/reg = mat
 				stored_substances_to_names[mat] = lowertext(initial(reg.name))
 
-	var/list/base_designs = SSfabrication.get_initial_recipes(fabricator_class)
-	design_cache = islist(base_designs) ? base_designs.Copy() : list() // Don't want to mutate the subsystem cache.
-	refresh_design_cache()
+	SSfabrication.init_fabricator(src)
 
 /obj/machinery/fabricator/proc/refresh_design_cache(var/list/known_tech)
 	if(length(installed_designs))


### PR DESCRIPTION
Adds list on fabSS to hold fabs that need their stuff inited, does that after recipies are in.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->