### PR TITLE
Attempting to simplify fluid<->reagent code for turf-based fluids later.

### DIFF
--- a/code/game/atoms_fluids.dm
+++ b/code/game/atoms_fluids.dm
@@ -2,6 +2,7 @@
 	return
 
 /atom/proc/fluid_act(var/datum/reagents/fluids)
+	fluids.touch(src)
 	if(reagents && fluids.total_volume >= FLUID_SHALLOW && ATOM_IS_OPEN_CONTAINER(src))
 		reagents.trans_to_holder(fluids, reagents.total_volume)
 		fluids.trans_to_holder(reagents, min(fluids.total_volume, reagents.maximum_volume))

--- a/code/game/objects/effects/fluids.dm
+++ b/code/game/objects/effects/fluids.dm
@@ -96,7 +96,7 @@
 	if(!isturf(loc))
 		return
 
-	reagents.touch_turf(loc)
+	loc.fluid_act(reagents)
 	var/pushing = (world.time >= next_fluid_act && reagents.total_volume > FLUID_SHALLOW && last_flow_strength >= 10)
 	for(var/thing in loc.contents)
 		if(thing == src)

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -189,7 +189,9 @@
 	//TODO: DEFERRED Consider checking to make sure tank pressure is high enough before doing this...
 	//Transfer 5% of current tank air contents to turf
 	var/datum/gas_mixture/air_transfer = tank.remove_air_ratio(0.02*(throw_amount/100))
-	target.add_fluid(air_transfer.get_by_flag(XGM_GAS_FUEL), /decl/material/liquid/fuel)
+	var/obj/effect/fluid/F = locate() in target
+	if(!F) F = new(target)
+	F.reagents.add_reagent(/decl/material/liquid/fuel, air_transfer.get_by_flag(XGM_GAS_FUEL))
 	air_transfer.remove_by_flag(XGM_GAS_FUEL, 0)
 	target.assume_air(air_transfer)
 	//Burn it based on transfered gas

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -196,8 +196,3 @@
 
 /obj/get_mass()
 	return min(2**(w_class-1), 100)
-
-/obj/fluid_act(var/datum/reagents/fluids)
-	fluids.touch_obj(src)
-	if(fluids.total_volume > 0)
-		..()

--- a/code/game/objects/structures/fishtanks.dm
+++ b/code/game/objects/structures/fishtanks.dm
@@ -89,9 +89,9 @@ GLOBAL_LIST_INIT(fishtank_cache, new)
 	. = ..()
 	if(reagents && reagents.total_volume)
 		var/turf/T = get_turf(src)
-		if(T)
-			T.add_fluid(reagents.total_volume * TANK_WATER_MULTIPLIER)
-		reagents.clear_reagents()
+		var/obj/effect/fluid/F = locate() in T
+		if(!F) F = new(T)
+		reagents.trans_to_holder(F.reagents, reagents.total_volume)
 
 GLOBAL_LIST_INIT(aquarium_states_and_layers, list(
 	"b" = FLY_LAYER - 0.02,

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -75,8 +75,9 @@
 				playsound(T, pick(SSfluids.gurgles), 50, 1)
 			var/obj/effect/fluid/F = locate() in T
 			var/adding = min(flood_amt-F?.reagents.total_volume, rand(30,50)*clogged)
-			if(adding)
-				T.add_fluid(adding, /decl/material/liquid/water)
+			if(adding > 0)
+				if(!F) F = new(T)
+				F.reagents.add_reagent(/decl/material/liquid/water, adding)
 
 /obj/structure/hygiene/proc/drain()
 	if(!can_drain) return
@@ -235,7 +236,7 @@
 
 /obj/structure/hygiene/shower/Initialize()
 	. = ..()
-	create_reagents(50)
+	create_reagents(5)
 
 /obj/structure/hygiene/shower/Destroy()
 	QDEL_NULL(sound_token)

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -9,17 +9,6 @@
 				break
 	return fluid_can_pass
 
-/turf/proc/add_reagents_as_fluid(var/datum/reagents/mixture)
-	for(var/rtype in mixture?.reagent_volumes)
-		add_fluid(mixture.reagent_volumes[rtype], rtype)
-	qdel(mixture)
-
-/turf/proc/add_fluid(var/amount, var/fluid = /decl/material/liquid/water)
-	if(!flooded)
-		var/obj/effect/fluid/F = locate() in src
-		if(!F) F = new(src)
-		F.reagents.add_reagent(fluid, amount)
-
 /turf/proc/remove_fluid(var/amount = 0)
 	var/obj/effect/fluid/F = locate() in src
 	if(F)

--- a/code/modules/ZAS/Zone.dm
+++ b/code/modules/ZAS/Zone.dm
@@ -195,7 +195,9 @@ Class Procs:
 				if(condense_amt < 1)
 					break
 				air.adjust_gas(g, -condense_amt)
-				flooding.add_fluid(condense_amt * REAGENT_UNITS_PER_GAS_MOLE, g)
+				var/obj/effect/fluid/F = locate() in flooding
+				if(!F) F = new(flooding)
+				F.reagents.add_reagent(g, condense_amt * REAGENT_UNITS_PER_GAS_MOLE)
 				CHECK_TICK
 	condensing = FALSE
 

--- a/code/modules/admin/verbs/fluids.dm
+++ b/code/modules/admin/verbs/fluids.dm
@@ -18,8 +18,9 @@
 		return
 	var/turf/flooding = get_turf(user)
 	for(var/thing in RANGE_TURFS(flooding, spawn_range))
-		var/turf/T = thing
-		T.add_fluid(reagent_amount, reagent_type)
+		var/obj/effect/fluid/F = locate() in thing
+		if(!F) F = new(thing)
+		F.reagents.add_reagent(reagent_type, reagent_amount)
 
 /datum/admins/proc/jump_to_fluid_source()
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1049,11 +1049,6 @@
 /mob/proc/check_has_eyes()
 	return TRUE
 
-/mob/fluid_act(var/datum/reagents/fluids)
-	wash_mob(src)
-	fluids.touch_mob(src)
-	..()
-
 /mob/proc/handle_pre_transformation()
 	return
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -393,7 +393,9 @@ GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
 		return
 	var/datum/reagents/R = new /datum/reagents(amount * multiplier, GLOB.temp_reagents_holder)
 	. = trans_to_holder(R, amount, multiplier, copy, 1)
-	target.add_reagents_as_fluid(R)
+	var/obj/effect/fluid/F = locate() in target
+	if(!F) F = new(target)
+	trans_to_holder(F.reagents, amount, multiplier, copy)
 
 /datum/reagents/proc/trans_to_obj(var/obj/target, var/amount = 1, var/multiplier = 1, var/copy = 0) // Objects may or may not; if they do, it's probably a beaker or something and we need to transfer properly; otherwise, just touch.
 	if(!target || !target.simulated)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -25,10 +25,7 @@
 /obj/structure/reagent_dispensers/proc/leak()
 	var/turf/T = get_turf(src)
 	if(reagents && T)
-		var/datum/reagents/leaked = new(FLUID_PUDDLE, GLOB.temp_reagents_holder)
-		reagents.trans_to_holder(leaked, FLUID_PUDDLE)
-		T.add_reagents_as_fluid(leaked)
-		qdel(leaked)
+		reagents.trans_to_turf(T, FLUID_PUDDLE)
 
 /obj/structure/reagent_dispensers/Move()
 	. = ..()
@@ -89,8 +86,9 @@
 	if(reagents?.total_volume)
 		var/turf/T = get_turf(src)
 		if(T)
-			for(var/r in reagents.reagent_volumes)
-				T.add_fluid(REAGENT_VOLUME(reagents, r), r)
+			var/obj/effect/fluid/F = locate() in T
+			if(!F) F = new(T)
+			reagents.trans_to_holder(F.reagents, reagents.total_volume)
 	. = ..()
 
 /obj/structure/reagent_dispensers/explosion_act(severity)

--- a/code/modules/species/outsider/starlight.dm
+++ b/code/modules/species/outsider/starlight.dm
@@ -83,7 +83,9 @@
 /datum/species/starlight/starborn/handle_death(var/mob/living/carbon/human/H)
 	..()
 	var/turf/T = get_turf(H)
-	T.add_fluid(20, /decl/material/liquid/fuel)
+	var/obj/effect/fluid/F = locate() in T
+	if(!F) F = new(T)
+	F.reagents.add_reagent(/decl/material/liquid/fuel, 20)
 	T.hotspot_expose(FLAMMABLE_GAS_MINIMUM_BURN_TEMPERATURE)
 
 /datum/species/starlight/blueforged


### PR DESCRIPTION
Infinite water bug was not fixed, this is a rather more drastic but effective solution (ha).
Probably breaks mob washing from flows but I don't really care about that right now since this is making it impossible to interact with water without causing an infinite flood.

Current plan is to make fluid overlays a visual thing only and have turfs handle flooding with their own reagents - this standardizes the fluid procs to reagent transfer to make that easier when I get to it.