### PR TITLE
Fixes planet landing

### DIFF
--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -1,8 +1,6 @@
 /obj/effect/overmap/visitable/sector/exoplanet
 	name = "exoplanet"
-	icon = 'icons/obj/overmap64.dmi'
-	bound_height = 64
-	bound_width = 64
+	icon = 'icons/obj/overmap.dmi'
 	icon_state = "globe"
 	sector_flags = OVERMAP_SECTOR_KNOWN
 	free_landing = TRUE

--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -37,15 +37,7 @@
 	if(moving_status == SHUTTLE_INTRANSIT)
 		return FALSE //already going somewhere, current_location may be an intransit location instead of in a sector
 
-	//ensures that distances are calculated correctly when dealing with multi-tile sectors
-	var/atom/movable/current_sector = waypoint_sector(current_location)
-	var/atom/movable/next_sector = waypoint_sector(next_location)
-	for(var/turf/current_loc_turf in (current_sector.locs))
-		for(var/turf/next_loc_turf in (next_sector.locs))
-			if(get_dist(current_loc_turf, next_loc_turf) <= range)
-				return TRUE
-
-	return FALSE
+	return get_dist(waypoint_sector(current_location), waypoint_sector(next_location)) <= range
 
 /datum/shuttle/autodock/overmap/can_launch()
 	return ..() && can_go()


### PR DESCRIPTION
Fixes #632 by reverting planets back to the normal one tile sector size. Also fixes the associated sky-box bug. Leaves the .dmi file for the large planet in case someone feels like re-adding it or using it for non-visitable sector icons.