### PR TITLE
Made hands act as items.

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -9,18 +9,14 @@
 	Otherwise pretty standard.
 */
 /mob/living/carbon/human/UnarmedAttack(var/atom/A, var/proximity)
-
 	if(!..())
 		return
-
-	// Special glove functions:
-	// If the gloves do anything, have them return 1 to stop
-	// normal attack_hand() here.
-	var/obj/item/clothing/gloves/G = gloves // not typecast specifically enough in defines
-	if(istype(G) && G.Touch(A,1))
+	var/obj/item/organ/external/limb = organs_by_name[hand ? BP_L_HAND : BP_R_HAND]
+	if(!limb || (istype(limb) && limb.is_stump()))
+		to_chat(src, SPAN_WARNING("You are missing your [hand ? "left" : "right"] hand!"))
 		return
-
-	A.attack_hand(src)
+	if(!limb.resolve_attackby(A, src, proximity) && A && limb)
+		limb.afterattack(A, src, 1)
 
 /atom/proc/attack_hand(mob/user)
 	. = FALSE

--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -148,6 +148,16 @@
 	arterial_bleed_severity = 0.5
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_GRASP | ORGAN_FLAG_FINGERPRINT | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK
 
+/obj/item/organ/external/hand/resolve_attackby(atom/A, mob/user, var/click_params)
+	if(owner == user && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(src in H.organs)
+			var/obj/item/clothing/gloves/G = H.gloves
+			if(istype(G) && G.Touch(A, 1))
+				return TRUE
+			return A.attack_hand(user)
+	. = ..()
+
 /obj/item/organ/external/hand/right
 	organ_tag = BP_R_HAND
 	name = "right hand"


### PR DESCRIPTION
This is sort of a weird idea. Essentially, when a human tries to do an unarmed click on someone, instead of just jumping to `attack_hand()` it now retrieves the associated organ and uses it as though attacking with it as an item. Hands have been changed to handle the checking and call `attack_hand()` in their `resolve_attackby()`. 

Upshots:
- Non-grasping or unwieldly limbs can now be handled by overriding the organ attackby (thinking mostly for Baxxid on Scav ie. https://github.com/ScavStation/ScavStation/issues/241).
- Augments could be checked for in the limb check rather than handled through hacking a tool item into the hand.
- Claws could be set up to handle engraving or damaging via harm intent rather than blocks of code in their associated interactions.
- Would make pizza hands more feasible in the future.

Opening as a draft to see thoughts and comments on it.