### PR TITLE
Adds internal storage to exosuits

### DIFF
--- a/code/modules/mechs/components/_components.dm
+++ b/code/modules/mechs/components/_components.dm
@@ -92,7 +92,16 @@
 /obj/item/mech_component/attackby(var/obj/item/thing, var/mob/user)
 	if(isScrewdriver(thing))
 		if(contents.len)
-			var/obj/item/removed = pick(contents)
+			//Filter non movables
+			var/list/valid_contents = list()
+			for(var/atom/movable/A in contents)
+				if(!A.anchored)
+					valid_contents += A
+			if(!valid_contents.len)
+				return
+			var/obj/item/removed = pick(valid_contents)
+			if(!(removed in contents))
+				return
 			user.visible_message(SPAN_NOTICE("\The [user] removes \the [removed] from \the [src]."))
 			removed.forceMove(user.loc)
 			playsound(user.loc, 'sound/effects/pop.ogg', 50, 0)

--- a/code/modules/mechs/components/body.dm
+++ b/code/modules/mechs/components/body.dm
@@ -1,3 +1,22 @@
+/obj/item/storage/mech
+	w_class = ITEM_SIZE_NO_CONTAINER
+	max_w_class = ITEM_SIZE_LARGE
+	storage_slots = 4
+	use_sound = 'sound/effects/storage/toolbox.ogg'
+	anchored = 1
+
+/obj/item/mech_component/chassis/Adjacent(var/atom/neighbor, var/recurse = 1) //For interaction purposes we consider body to be adjacent to whatever holder mob is adjacent
+	var/mob/living/exosuit/E = loc
+	if(istype(E))
+		. = E.Adjacent(neighbor, recurse)
+	return . || ..()
+
+/obj/item/storage/mech/Adjacent(var/atom/neighbor, var/recurse = 1) //in order to properly retrieve items
+	var/obj/item/mech_component/chassis/C = loc
+	if(istype(C))
+		. = C.Adjacent(neighbor, recurse-1)
+	return . || ..()
+
 /obj/item/mech_component/chassis
 	name = "body"
 	icon_state = "loader_body"
@@ -10,6 +29,7 @@
 	var/obj/item/robot_parts/robot_component/diagnosis_unit/diagnostics
 	var/obj/item/robot_parts/robot_component/armour/exosuit/m_armour
 	var/obj/machinery/portable_atmospherics/canister/air_supply
+	var/obj/item/storage/mech/storage_compartment
 	var/datum/gas_mixture/cockpit
 	var/transparent_cabin = FALSE
 	var/hide_pilot =        FALSE
@@ -37,6 +57,7 @@
 	QDEL_NULL(diagnostics)
 	QDEL_NULL(m_armour)
 	QDEL_NULL(air_supply)
+	QDEL_NULL(storage_compartment)
 	. = ..()
 
 /obj/item/mech_component/chassis/update_components()
@@ -44,6 +65,7 @@
 	cell =        locate() in src
 	m_armour =    locate() in src
 	air_supply =  locate() in src
+	storage_compartment = locate() in src
 
 /obj/item/mech_component/chassis/show_missing_parts(var/mob/user)
 	if(!cell)
@@ -61,6 +83,7 @@
 		if(air)
 			cockpit.equalize(air)
 	air_supply = new /obj/machinery/portable_atmospherics/canister/air(src)
+	storage_compartment = new(src)
 
 /obj/item/mech_component/chassis/proc/update_air(var/take_from_supply)
 
@@ -112,7 +135,9 @@
 
 /obj/item/mech_component/chassis/MouseDrop_T(atom/dropping, mob/user)
 	var/obj/machinery/portable_atmospherics/canister/C = dropping
-	if(istype(C) && do_after(user, 5, src))
+	if(istype(C) && !C.anchored && do_after(user, 5, src))
+		if(C.anchored)
+			return
 		to_chat(user, SPAN_NOTICE("You install the canister in the [src]."))
 		if(air_supply)
 			air_supply.forceMove(get_turf(src))
@@ -120,5 +145,11 @@
 		C.forceMove(src)
 		update_components()
 	else . = ..()
+
+obj/item/mech_component/chassis/MouseDrop(atom/over)
+	if(CanMouseDrop(over))
+		if(storage_compartment)
+			return storage_compartment.MouseDrop(over)
+
 
 

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -17,6 +17,11 @@
 		body.MouseDrop_T(dropping, user)
 	else . = ..()
 
+/mob/living/exosuit/MouseDrop(mob/living/carbon/human/over_object) //going from assumption none of previous options are relevant to exosuit
+	if(body)
+		if(!body.MouseDrop(over_object))
+			return ..()
+	
 /mob/living/exosuit/RelayMouseDrag(src_object, over_object, src_location, over_location, src_control, over_control, params, var/mob/user)
 	if(user && (user in pilots) && user.loc == src)
 		return OnMouseDrag(src_object, over_object, src_location, over_location, src_control, over_control, params, user)


### PR DESCRIPTION
🆑CrimsonShrike
rscadd: Exosuits now have a storage compartment to keep emergency supplies or personal belongings. Click drag exosuit onto you to open it.
/🆑

The idea is to have a place to put flares, toolboxes etc. Is more QOL than anything as players can just carry a dufflebag inside anyway.