### PR TITLE
Add configuring readout threshholds in supermatter monitoring

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -116,6 +116,11 @@ var/list/restricted_camera_networks = list(NETWORK_ERT, NETWORK_MERCENARY, NETWO
 #define SUPERMATTER_EMERGENCY 5		// Integrity < 25%
 #define SUPERMATTER_DELAMINATING 6	// Pretty obvious.
 
+#define SUPERMATTER_DATA_EER         "Relative EER"
+#define SUPERMATTER_DATA_TEMPERATURE "Temperature"
+#define SUPERMATTER_DATA_PRESSURE    "Pressure"
+#define SUPERMATTER_DATA_EPR         "Chamber EPR"
+
 // Scrubber modes
 #define SCRUBBER_SIPHON   "siphon"
 #define SCRUBBER_SCRUB    "scrub"

--- a/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
@@ -1,3 +1,7 @@
+#define SM_MONITOR_SCREEN_MAIN        "main"
+#define SM_MONITOR_SCREEN_THRESHHOLDS "threshholds"
+
+
 /datum/computer_file/program/supermatter_monitor
 	filename = "supmon"
 	filedesc = "Supermatter Monitoring"
@@ -27,6 +31,7 @@
 	name = "Supermatter monitor"
 	var/list/supermatters
 	var/obj/machinery/power/supermatter/active = null		// Currently selected supermatter crystal.
+	var/screen = SM_MONITOR_SCREEN_MAIN // Which screen the monitor is currently on
 
 /datum/nano_module/program/supermatter_monitor/Destroy()
 	. = ..()
@@ -58,6 +63,7 @@
 
 	if(!(active in supermatters))
 		active = null
+		screen = initial(screen)
 
 /datum/nano_module/program/supermatter_monitor/proc/get_status()
 	. = SUPERMATTER_INACTIVE
@@ -69,6 +75,26 @@
 		. = max(., S.get_status())
 	if(needs_refresh)
 		refresh()
+
+/datum/nano_module/program/supermatter_monitor/proc/get_threshhold_color(threshhold, value)
+	for (var/entry in active.threshholds)
+		if (entry["name"] != threshhold)
+			continue
+		if (entry["min_h"] >= 0 && value <= entry["min_h"])
+			return "bad"
+		if (entry["min_l"] >= 0 && value <= entry["min_l"])
+			return "average"
+		if (entry["max_h"] >= 0 && value >= entry["max_h"])
+			return "bad"
+		if (entry["max_l"] >= 0 && value >= entry["max_l"])
+			return "average"
+	return "good"
+
+/datum/nano_module/program/supermatter_monitor/proc/set_threshhold_value(threshhold, category, value)
+	for (var/entry in active.threshholds)
+		if (entry["name"] != threshhold)
+			continue
+		entry[category] = value
 
 /datum/nano_module/program/supermatter_monitor/proc/process_data_output(skill, value)
 	switch(skill)
@@ -87,23 +113,35 @@
 
 	if(active && !can_read(active))
 		active = null
+		screen = initial(screen)
 
 	if(istype(active))
 		var/turf/T = get_turf(active)
 		if(!T)
 			active = null
+			screen = initial(screen)
 			return
 		var/datum/gas_mixture/air = T.return_air()
 		if(!istype(air))
 			active = null
+			screen = initial(screen)
 			return
 
+		var/ambient_pressure = air.return_pressure()
+		var/epr = active.get_epr()
+
 		data["active"] = 1
+		data["screen"] = screen
+		data["threshholds"] = active.threshholds
 		data["SM_integrity"] = min(process_data_output(engine_skill, active.get_integrity()), 100)
 		data["SM_power"] = process_data_output(engine_skill, active.power)
+		data["SM_power_label"] = get_threshhold_color(SUPERMATTER_DATA_EER, active.power)
 		data["SM_ambienttemp"] = process_data_output(engine_skill, air.temperature)
-		data["SM_ambientpressure"] = process_data_output(engine_skill, air.return_pressure())
-		data["SM_EPR"] = process_data_output(engine_skill, active.get_epr())
+		data["SM_ambienttemp_label"] = get_threshhold_color(SUPERMATTER_DATA_TEMPERATURE, air.temperature)
+		data["SM_ambientpressure"] = process_data_output(engine_skill, ambient_pressure)
+		data["SM_ambientpressure_label"] = get_threshhold_color(SUPERMATTER_DATA_PRESSURE, ambient_pressure)
+		data["SM_EPR"] = process_data_output(engine_skill, epr)
+		data["SM_EPR_label"] = get_threshhold_color(SUPERMATTER_DATA_EPR, epr)
 		if(air.total_moles)
 			data["SM_gas_O2"] = round(100*air.gas[MAT_OXYGEN]/air.total_moles,0.01)
 			data["SM_gas_CO2"] = round(100*air.gas[MAT_CO2]/air.total_moles,0.01)
@@ -128,7 +166,7 @@
 			if(!can_read(S))
 				needs_refresh = TRUE
 				continue
-			
+
 			SMS.Add(list(list(
 			"area_name" = A.name,
 			"integrity" = process_data_output(engine_skill, S.get_integrity()),
@@ -153,9 +191,21 @@
 		return 1
 	if( href_list["clear"] )
 		active = null
+		screen = initial(screen)
 		return 1
 	if( href_list["refresh"] )
 		refresh()
+		return 1
+	if (href_list["screen_threshholds"])
+		screen = SM_MONITOR_SCREEN_THRESHHOLDS
+		return 1
+	if (href_list["screen_main"])
+		screen = SM_MONITOR_SCREEN_MAIN
+		return 1
+	if (href_list["set_threshhold"])
+		var/new_value = input(usr, "Select a new threshhold, or set to -1 to disable:", "Threshhold", href_list["value"]) as null|num
+		if (new_value != null)
+			set_threshhold_value(href_list["threshhold"], href_list["category"], new_value)
 		return 1
 	if( href_list["set"] )
 		var/newuid = text2num(href_list["set"])

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -104,6 +104,13 @@
 	var/aw_delam = FALSE
 	var/aw_EPR = FALSE
 
+	var/list/threshholds = list( // List of lists defining the amber/red labeling threshholds in readouts. Numbers are minminum red and amber and maximum amber and red, in that order
+		list("name" = SUPERMATTER_DATA_EER,         "min_h" = -1, "min_l" = -1,  "max_l" = 150,  "max_h" = 300),
+		list("name" = SUPERMATTER_DATA_TEMPERATURE, "min_h" = -1, "min_l" = -1,  "max_l" = 4000, "max_h" = 5000),
+		list("name" = SUPERMATTER_DATA_PRESSURE,    "min_h" = -1, "min_l" = -1,  "max_l" = 5000, "max_h" = 10000),
+		list("name" = SUPERMATTER_DATA_EPR,         "min_h" = -1, "min_l" = 1.0, "max_l" = 2.5,  "max_h" = 4.0)
+	)
+
 /obj/machinery/power/supermatter/Initialize()
 	. = ..()
 	uid = gl_uid++

--- a/nano/templates/supermatter_monitor.tmpl
+++ b/nano/templates/supermatter_monitor.tmpl
@@ -1,5 +1,7 @@
 {{if data.active}}
-	{{:helper.link('Back to Menu', null, {'clear' : 1})}}<br>
+	{{:helper.link('Back to List', null, {'clear' : 1})}}
+	{{if data.screen == "main"}}
+		{{:helper.link('Configure', null, {'screen_threshholds' : 1})}}<br>
 		<div class="item">
 			<div class="itemLabel">
 				Core Integrity:
@@ -11,52 +13,26 @@
 				Relative EER:
 			</div>
 			<div class="itemContent">
-				{{if data.SM_power > 300}}
-					<span class='bad'>{{:data.SM_power}} MeV/cm3</span>
-				{{else data.SM_power > 150}}
-					<span class='average'>{{:data.SM_power}} MeV/cm3</span>
-				{{else}}
-					<span class='good'>{{:data.SM_power}} MeV/cm3</span>
-				{{/if}}
+				<span class='{{:data.SM_power_label}}'>{{:data.SM_power}} MeV/cm3</span>
 			</div>
 			<div class="itemLabel">
 				Temperature:
 			</div>
 			<div class="itemContent">
-				{{if data.SM_ambienttemp > 5000}}
-					<span class='bad'>{{:data.SM_ambienttemp}} K</span>
-				{{else data.SM_ambienttemp > 4000}}
-					<span class='average'>{{:data.SM_ambienttemp}} K</span>
-				{{else}}
-					<span class='good'>{{:data.SM_ambienttemp}} K</span>
-				{{/if}}
-			</div>		
+				<span class='{{:data.SM_ambienttemp_label}}'>{{:data.SM_ambienttemp}} K</span>
+			</div>
 			<div class="itemLabel">
 				Pressure:
 			</div>
 			<div class="itemContent">
-				{{if data.SM_ambientpressure > 10000}}
-					<span class='bad'>{{:data.SM_ambientpressure}} kPa</span>
-				{{else data.SM_ambientpressure > 5000}}
-					<span class='average'>{{:data.SM_ambientpressure}} kPa</span>
-				{{else}}
-					<span class='good'>{{:data.SM_ambientpressure}} kPa</span>
-				{{/if}}
+				<span class='{{:data.SM_ambientpressure_label}}'>{{:data.SM_ambientpressure}} kPa</span>
 			</div>
 			<div class="itemLabel">
 				Chamber EPR:
 			</div>
 			<div class="itemContent">
-				{{if data.SM_EPR > 4}}
-					<span class='bad'>{{:data.SM_EPR}}</span>
-				{{else data.SM_EPR > 2.5}}
-					<span class='average'>{{:data.SM_EPR}}</span>
-				{{else data.SM_EPR < 1}}
-					<span class='average'>{{:data.SM_EPR}}</span>
-				{{else}}
-					<span class='good'>{{:data.SM_EPR}}</span>
-				{{/if}}
-			</div>		
+				<span class='{{:data.SM_EPR_label}}'>{{:data.SM_EPR}}</span>
+			</div>
 		</div>
 		<hr><br
 		<div class="item">
@@ -70,7 +46,7 @@
 					</div>
 					<div class="itemContent">
 						{{:data.SM_gas_O2}} %
-					</div>	
+					</div>
 					<div class="itemLabel">
 						CO2:
 					</div>
@@ -102,8 +78,30 @@
 						{{:data.SM_gas_N2O}} %
 					</div>
 				</div>
-			</div>			
+			</div>
 		</div>
+	{{else data.screen == "threshholds"}}
+		{{:helper.link('Monitor', null, {'screen_main' : 1})}}<br>
+		<table class="fixed">
+			<tr>
+				<th>Threshholds</th>
+				<td><span class='bad'>min2</span></td>
+				<td><span class='average'>min1</span></td>
+				<td><span class='average'>max1</span></td>
+				<td><span class='bad'>max2</span></td>
+			</tr>
+
+			{{for data.threshholds}}
+				<tr>
+					<th>{{:value.name}}</th>
+					<td>{{:helper.link(value.min_h >= 0 ? value.min_h : "Off", null, {'set_threshhold' : 1, 'threshhold' : value.name, 'category' : 'min_h', 'value' : value.min_h})}}</td>
+					<td>{{:helper.link(value.min_l >= 0 ? value.min_l : "Off", null, {'set_threshhold' : 1, 'threshhold' : value.name, 'category' : 'min_l', 'value' : value.min_l})}}</td>
+					<td>{{:helper.link(value.max_l >= 0 ? value.max_l : "Off", null, {'set_threshhold' : 1, 'threshhold' : value.name, 'category' : 'max_l', 'value' : value.max_l})}}</td>
+					<td>{{:helper.link(value.max_h >= 0 ? value.max_h : "Off", null, {'set_threshhold' : 1, 'threshhold' : value.name, 'category' : 'max_h', 'value' : value.max_h})}}</td>
+				</tr>
+			{{/for}}
+		</table>
+	{{/if}}
 {{else}}
 	{{:helper.link('Refresh', null, {'refresh' : 1})}}<br>
 	{{for data.supermatters}}
@@ -125,7 +123,7 @@
 			</div>
 			<div class="itemContent">
 				{{:helper.link('View Details', null, {'set' : value.uid})}}
-			</div>			
-		</div>	
+			</div>
+		</div>
 	{{/for}}
 {{/if}}


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Supermatter reading thresholds (The point at which the numbers turn yellow and red) can now be configured. The configuration is stored per supermatter crystal and syncs between all programs/subsystems looking at that supermatter. This applies to EER, Temperature, Pressure, and EPR readings. Does not apply to integrity, icon state, or the delamination radio broadcast.
/:cl:

![vlc_Tvi9DfvTP5](https://user-images.githubusercontent.com/11140088/86952721-42a17c80-c108-11ea-8667-2e2140a43454.png)
