### PR TITLE
Attempting to fix chem grenades.

### DIFF
--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -134,11 +134,15 @@
 		icon_state = initial(icon_state) + (primed?"_primed":"_active")
 
 /obj/item/grenade/chem_grenade/detonate()
-	if(!stage || stage<2) return
+	set waitfor = 0
+	if(!stage || stage < 2) 
+		return
 
 	var/has_reagents = 0
 	for(var/obj/item/chems/glass/G in beakers)
-		if(G.reagents.total_volume) has_reagents = 1
+		if(G.reagents.total_volume) 
+			has_reagents = TRUE
+			break
 
 	active = 0
 	if(!has_reagents)
@@ -154,28 +158,36 @@
 		return
 
 	playsound(src.loc, 'sound/effects/bamf.ogg', 50, 1)
+	if(ismob(loc))
+		var/mob/M = loc
+		M.drop_from_inventory(src)
+		M.throw_mode_off()
 
 	for(var/obj/item/chems/glass/G in beakers)
 		G.reagents.trans_to_obj(src, G.reagents.total_volume)
 
-	if(src.reagents.total_volume) //The possible reactions didnt use up all reagents.
-		var/datum/effect/effect/system/steam_spread/steam = new /datum/effect/effect/system/steam_spread()
+	anchored = TRUE
+	set_invisibility(INVISIBILITY_MAXIMUM)
+
+	// Visual effect to show the grenade going off.
+	if(reagents.total_volume) 
+		var/datum/effect/effect/system/steam_spread/steam = new
 		steam.set_up(10, 0, get_turf(src))
 		steam.attach(src)
 		steam.start()
 
-		for(var/atom/A in view(affected_area, src.loc))
-			if( A == src ) continue
-			src.reagents.touch(A)
+ 	// Allow time for reactions to proc.
+	var/max_delays = 5
+	var/delays = 0
+	while(reagents.total_volume && delays <= max_delays)
+		delays++
+		sleep(SSmaterials.wait)
 
-	if(istype(loc, /mob/living/carbon))		//drop dat grenade if it goes off in your hand
-		var/mob/living/carbon/C = loc
-		C.drop_from_inventory(src)
-		C.throw_mode_off()
+	// The reactions didn't use up all reagents, dump them as a fluid.
+	if(reagents.total_volume)
+		reagents.trans_to(loc, reagents.total_volume)
 
-	set_invisibility(INVISIBILITY_MAXIMUM) //Why am i doing this?
-	spawn(50)		   //To make sure all reagents can work
-		qdel(src)	   //correctly before deleting the grenade.
+	qdel(src)
 
 /obj/item/grenade/chem_grenade/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -236,10 +236,9 @@
 	var/obj/item/chems/glass/beaker/B2 = new(src)
 
 	B1.reagents.add_reagent(/decl/material/solid/metal/aluminium, 15)
-	B1.reagents.add_reagent(/decl/material/liquid/fuel,20)
-	B2.reagents.add_reagent(/decl/material/solid/phoron, 15)
+	B1.reagents.add_reagent(/decl/material/liquid/fuel, 15)
+	B2.reagents.add_reagent(/decl/material/solid/metal/aluminium, 15)
 	B2.reagents.add_reagent(/decl/material/liquid/acid, 15)
-	B1.reagents.add_reagent(/decl/material/liquid/fuel,20)
 
 	detonator = new/obj/item/assembly_holder/timer_igniter(src)
 

--- a/code/modules/reagents/reactions/_reaction.dm
+++ b/code/modules/reagents/reactions/_reaction.dm
@@ -72,8 +72,12 @@
 /datum/chemical_reaction/proc/post_reaction(var/datum/reagents/holder)
 	var/atom/container = holder.my_atom
 	if(mix_message && container && !ismob(container))
-		container.visible_message("<span class='notice'>\icon[container] [mix_message]</span>")
-		playsound(container, reaction_sound, 80, 1)
+		var/turf/T = get_turf(container)
+		if(istype(T))
+			T.visible_message(SPAN_NOTICE("\icon[container] [mix_message]"))
+		else
+			container.visible_message(SPAN_NOTICE("\icon[container] [mix_message]"))
+		playsound(T || container, reaction_sound, 80, 1)
 
 //obtains any special data that will be provided to the reaction products
 //this is called just before reactants are removed.

--- a/code/modules/reagents/reactions/reaction_grenade_reaction.dm
+++ b/code/modules/reagents/reactions/reaction_grenade_reaction.dm
@@ -61,11 +61,11 @@
 	name = "Flash Fire"
 	lore_text = "This mixture causes an immediate flash fire."
 	required_reagents = list(
-		/decl/material/solid/metal/aluminium = 1, 
-		/decl/material/solid/phoron = 1, 
+		/decl/material/solid/metal/aluminium = 2,
+		/decl/material/liquid/fuel = 1,
 		/decl/material/liquid/acid = 1
 	)
-	result_amount = 1
+	result_amount = 10 // Sufficient to start a fire.
 	reaction_sound = 'sound/items/Welder.ogg'
 	mix_message = "The solution suddenly ignites!"
 
@@ -73,7 +73,7 @@
 	..()
 	var/turf/location = get_turf(holder.my_atom.loc)
 	if(istype(location))
-		location.assume_gas(/decl/material/solid/phoron, created_volume, FLAMMABLE_GAS_FLASHPOINT + 10)
+		location.assume_gas(/decl/material/gas/hydrogen, created_volume, FLAMMABLE_GAS_FLASHPOINT + 10)
 		var/datum/effect/effect/system/spark_spread/sparks = new
 		sparks.set_up(1, 1, location)
 		sparks.start()

--- a/code/modules/reagents/reactions/reaction_grenade_reaction.dm
+++ b/code/modules/reagents/reactions/reaction_grenade_reaction.dm
@@ -57,19 +57,26 @@
 	empulse(location, round(created_volume / 24), round(created_volume / 14), 1)
 	holder.clear_reagents()
 
-/datum/chemical_reaction/grenade_reaction/phlogiston
+/datum/chemical_reaction/grenade_reaction/flash_fire
 	name = "Flash Fire"
 	lore_text = "This mixture causes an immediate flash fire."
-	required_reagents = list(/decl/material/solid/metal/aluminium = 1, /decl/material/solid/phoron = 1, /decl/material/liquid/acid = 1 )
+	required_reagents = list(
+		/decl/material/solid/metal/aluminium = 1, 
+		/decl/material/solid/phoron = 1, 
+		/decl/material/liquid/acid = 1
+	)
 	result_amount = 1
-	mix_message = "The solution thickens and begins to bubble."
+	reaction_sound = 'sound/items/Welder.ogg'
+	mix_message = "The solution suddenly ignites!"
 
-/datum/chemical_reaction/grenade_reaction/phlogiston/on_reaction(var/datum/reagents/holder, var/created_volume, var/reaction_flags)
+/datum/chemical_reaction/grenade_reaction/flash_fire/on_reaction(var/datum/reagents/holder, var/created_volume, var/reaction_flags)
 	..()
 	var/turf/location = get_turf(holder.my_atom.loc)
-	for(var/turf/simulated/floor/target_tile in range(0,location))
-		target_tile.assume_gas(/decl/material/solid/phoron, created_volume, 400+T0C)
-		spawn (0) target_tile.hotspot_expose(700, 400)
+	if(istype(location))
+		location.assume_gas(/decl/material/solid/phoron, created_volume, FLAMMABLE_GAS_FLASHPOINT + 10)
+		var/datum/effect/effect/system/spark_spread/sparks = new
+		sparks.set_up(1, 1, location)
+		sparks.start()
 
 /datum/chemical_reaction/grenade_reaction/chemsmoke
 	name = "Chemical Smoke"


### PR DESCRIPTION
It looks like these were never updated for scheduler-managed reactions, and also never updated for fluids. So:
- Chem grenades no longer touch every turf in view with their reagents.
- Chem grenades will now delay up to 5 seconds to allow their contents to react.
- At the end of the five seconds, the grenade will dump any remaining reagents to the turf as a fluid.