### PR TITLE
Fixes

### DIFF
--- a/code/_global_vars/lists/objects.dm
+++ b/code/_global_vars/lists/objects.dm
@@ -24,3 +24,5 @@ GLOBAL_LIST_INIT(alphabet_no_vowels, list("b","c","d","f","g","h","j","k","l","m
 GLOBAL_LIST_INIT(full_alphabet, list("a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x","y","z"))
 
 GLOBAL_LIST_EMPTY(meteor_list)
+
+var/list/is_currently_exploding = list()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -66,6 +66,7 @@
 	return
 
 /atom/Destroy()
+	global.is_currently_exploding -= src
 	QDEL_NULL(reagents)
 	. = ..()
 
@@ -311,11 +312,14 @@ its easier to just keep the beam vertical.
 
 /atom/proc/explosion_act(var/severity)
 	SHOULD_CALL_PARENT(TRUE)
-	. = (severity <= 3)
-	if(.)
-		for(var/atom/movable/AM in contents)
-			AM.explosion_act(severity++)
-		try_detonate_reagents(severity)
+	if(!global.is_currently_exploding[src])
+		global.is_currently_exploding[src] = TRUE
+		. = (severity <= 3)
+		if(.)
+			for(var/atom/movable/AM in contents)
+				AM.explosion_act(severity++)
+			try_detonate_reagents(severity)
+		global.is_currently_exploding -= src
 
 /atom/proc/emag_act(var/remaining_charges, var/mob/user, var/emag_source)
 	return NO_EMAG_ACT

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -11,8 +11,6 @@
 	var/toggle = 1
 	movable_flags = MOVABLE_FLAG_PROXMOVE
 
-/obj/item/transfer_valve/proc/process_activation(var/obj/item/D)
-
 /obj/item/transfer_valve/IsAssemblyHolder()
 	return 1
 
@@ -122,7 +120,7 @@
 			attached_device.attack_self(usr)
 	return 1 // Returning 1 sends an update to attached UIs
 
-/obj/item/transfer_valve/process_activation(var/obj/item/D)
+/obj/item/transfer_valve/proc/process_activation(var/obj/item/D)
 	if(toggle)
 		toggle = 0
 		toggle_valve()

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -1,5 +1,22 @@
 #define TANK_IDEAL_PRESSURE 1015 //Arbitrary.
 
+var/tank_bomb_severity = 1
+#define TANK_BOMB_DVSTN_FACTOR (0.15 * global.tank_bomb_severity)
+#define TANK_BOMB_HEAVY_FACTOR (0.35 * global.tank_bomb_severity)
+#define TANK_BOMB_LIGHT_FACTOR (0.80 * global.tank_bomb_severity)
+#define TANK_BOMB_FLASH_FACTOR (1.25 * global.tank_bomb_severity)
+#define MAX_TANK_BOMB_SEVERITY 20
+
+/client/proc/verb_adjust_tank_bomb_severity()
+	set name = "Adjust Tank Bomb Severity"
+	set category = "Debug"
+
+	if(check_rights(R_DEBUG))
+		var/next_input = input("Enter a new bomb severity between 1 and [MAX_TANK_BOMB_SEVERITY].", "Tank Bomb Severity", global.tank_bomb_severity) as num|null
+		if(isnum(next_input))
+			global.tank_bomb_severity = Clamp(next_input, 0, MAX_TANK_BOMB_SEVERITY)
+			log_and_message_admins("[key_name_admin(mob)] has set the tank bomb severity value to [global.tank_bomb_severity].", mob)
+
 var/list/global/tank_gauge_cache = list()
 
 /obj/item/tank
@@ -410,10 +427,10 @@ var/list/global/tank_gauge_cache = list()
 			T.assume_air(air_contents)
 			explosion(
 				get_turf(loc),
-				round(min(BOMBCAP_DVSTN_RADIUS, ((mult)*strength)*0.15)),
-				round(min(BOMBCAP_HEAVY_RADIUS, ((mult)*strength)*0.35)),
-				round(min(BOMBCAP_LIGHT_RADIUS, ((mult)*strength)*0.80)),
-				round(min(BOMBCAP_FLASH_RADIUS, ((mult)*strength)*1.20)),
+				round(min(BOMBCAP_DVSTN_RADIUS, ((mult) * strength) * TANK_BOMB_DVSTN_FACTOR)),
+				round(min(BOMBCAP_HEAVY_RADIUS, ((mult) * strength) * TANK_BOMB_HEAVY_FACTOR)),
+				round(min(BOMBCAP_LIGHT_RADIUS, ((mult) * strength) * TANK_BOMB_LIGHT_FACTOR)),
+				round(min(BOMBCAP_FLASH_RADIUS, ((mult) * strength) * TANK_BOMB_FLASH_FACTOR)),
 				)
 
 			var/num_fragments = round(rand(8,10) * sqrt(strength * mult))
@@ -592,3 +609,8 @@ var/list/global/tank_gauge_cache = list()
 	name = "large metal fragment"
 	damage = 17
 
+#undef TANK_BOMB_DVSTN_FACTOR
+#undef TANK_BOMB_HEAVY_FACTOR
+#undef TANK_BOMB_LIGHT_FACTOR
+#undef TANK_BOMB_FLASH_FACTOR
+#undef MAX_TANK_BOMB_SEVERITY

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -206,7 +206,8 @@ var/list/admin_verbs_debug = list(
 	/client/proc/ping_webhook,
 	/client/proc/reload_webhooks,
 	/datum/admins/proc/check_unconverted_single_icon_items,
-	/client/proc/spawn_material
+	/client/proc/spawn_material,
+	/client/proc/verb_adjust_tank_bomb_severity
 	)
 
 var/list/admin_verbs_paranoid_debug = list(

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -7,7 +7,7 @@ Specifically made to do radiation burns.
 /mob/living/carbon/apply_radiation(damage)
 	..()
 	if(!isSynthetic() && !ignore_rads)
-		damage = 0.25 * damage * species.get_radiation_mod(src)
+		damage = 0.25 * damage * (species ? species.get_radiation_mod(src) : 1)
 		adjustFireLoss(damage)
 		updatehealth()
 	return TRUE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -573,10 +573,9 @@
 	var/total_protection = flash_protection
 	if(species.has_organ[species.vision_organ])
 		var/obj/item/organ/internal/eyes/I = internal_organs_by_name[species.vision_organ]
-		if(!I.is_usable())
+		if(!I?.is_usable())
 			return FLASH_PROTECTION_MAJOR
-		else
-			total_protection = I.get_total_protection(flash_protection)
+		total_protection = I.get_total_protection(flash_protection)
 	else // They can't be flashed if they don't have eyes.
 		return FLASH_PROTECTION_MAJOR
 	return total_protection

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -322,15 +322,13 @@ meteor_act
 			else if(shield_check)
 				return
 
-		if(!zone)
-			visible_message("<span class='notice'>\The [O] misses [src] narrowly!</span>")
+		var/obj/item/organ/external/affecting = (zone && get_organ(zone))
+		if(!affecting)
+			visible_message(SPAN_NOTICE("\The [O] misses \the [src] narrowly!"))
 			return
 
-		var/obj/item/organ/external/affecting = get_organ(zone)
-		var/hit_area = affecting.name
 		var/datum/wound/created_wound
-
-		src.visible_message("<span class='warning'>\The [src] has been hit in the [hit_area] by \the [O].</span>")
+		visible_message(SPAN_DANGER("\The [src] has been hit in \the [affecting.name] by \the [O]."))
 		created_wound = apply_damage(throw_damage, dtype, zone, O.damage_flags(), O, O.armor_penetration)
 
 		if(TT.thrower)

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -116,11 +116,14 @@
 	addtimer(CALLBACK(src, /atom/movable/proc/fall_callback, below), 0)
 
 /atom/movable/proc/fall_callback(var/turf/below)
-	var/mob/M = src
-	var/is_client_moving = (ismob(M) && M.moving)
-	if(is_client_moving) M.moving = 1
-	handle_fall(below)
-	if(is_client_moving) M.moving = 0
+	if(!QDELETED(src))
+		handle_fall(below)
+
+/mob/fall_callback(var/turf/below)
+	var/was_moving = moving
+	..()
+	if(was_moving)
+		moving = FALSE
 
 //For children to override
 /atom/movable/proc/can_fall(var/anchor_bypass = FALSE, var/turf/location_override = loc)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -280,11 +280,12 @@ var/list/organ_cache = list()
 	if(!BP_IS_PROSTHETIC(src) && species && reagents?.total_volume < 5)
 		owner.vessel.trans_to(src, 5 - reagents.total_volume, 1, 1)
 
-	if(owner && vital)
+	if(vital)
 		if(user)
 			admin_attack_log(user, owner, "Removed a vital organ ([src]).", "Had a vital organ ([src]) removed.", "removed a vital organ ([src]) from")
 		owner.death()
-
+	screen_loc = null
+	owner.client?.screen -= src
 	owner = null
 
 /obj/item/organ/proc/replaced(var/mob/living/carbon/human/target, var/obj/item/organ/external/affected)


### PR DESCRIPTION
- Fixes species runtime in carbon radiation code.
- Adds a verb for adjusting tank bomb severity at runtime, which somehow fixes tank bombs to work properly.
- Adds a global list for preventing recursive `explosion_act` loops.
- Should fix #3.
- Fixes several runtimes observed during bomb testing.