### PR TITLE
Block access to objects that are not on connected z-levels

### DIFF
--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -40,7 +40,8 @@ GLOBAL_DATUM_INIT(default_state, /datum/topic_state/default, new)
 	// Prevents the AI from using Topic on admin levels (by for example viewing through the court/thunderdome cameras)
 	// unless it's on the same level as the object it's interacting with.
 	var/turf/T = get_turf(src_object)
-	if(!T || !(z == T.z || (T.z in GLOB.using_map.player_levels)))
+	var/turf/A = get_turf(src)
+	if(!A || !T || !AreConnectedZLevels(A.z, T.z))
 		return STATUS_CLOSE
 
 	// If an object is in view then we can interact with it


### PR DESCRIPTION
Port of https://github.com/Baystation12/Baystation12/pull/28889 from BS12

:cl:
rscdel: AI can no longer access objects in a non-connected z-level, including shuttles at away sites. Distant holopads are still accessible.
/:cl: