### PR TITLE
Fixes Z copying floor decals

### DIFF
--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -197,14 +197,6 @@ What is the naming convention for planes or layers?
 /atom
 	plane = DEFAULT_PLANE
 
-/image/proc/plating_decal_layerise()
-	plane = DEFAULT_PLANE
-	layer = DECAL_PLATING_LAYER
-
-/image/proc/turf_decal_layerise()
-	plane =  DEFAULT_PLANE
-	layer = DECAL_LAYER
-
 /atom/proc/hud_layerise()
 	plane = HUD_PLANE
 	layer = HUD_ITEM_LAYER

--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -80,7 +80,6 @@ var/list/flooring_cache = list()
 /turf/simulated/floor/proc/get_flooring_overlay(var/cache_key, var/icon_base, var/icon_dir = 0, var/external = FALSE)
 	if(!flooring_cache[cache_key])
 		var/image/I = image(icon = flooring.icon, icon_state = icon_base, dir = icon_dir)
-		I.turf_decal_layerise()
 
 		//External overlays will be offset out of this tile
 		if (external)
@@ -103,7 +102,7 @@ var/list/flooring_cache = list()
 		var/image/I = image(icon = 'icons/turf/flooring/damage.dmi', icon_state = cache_key)
 		if(blend)
 			I.blend_mode = blend
-		I.turf_decal_layerise()
+		I.layer = DECAL_LAYER
 		flooring_cache[cache_key] = I
 	return flooring_cache[cache_key]
 

--- a/code/game/turfs/simulated/wall_natural.dm
+++ b/code/game/turfs/simulated/wall_natural.dm
@@ -121,7 +121,7 @@ var/list/natural_walls = list()
 			M.Scale(-1,1)
 			ore_overlay.transform = M
 		ore_overlay.color = reinf_material.color
-		ore_overlay.turf_decal_layerise()
+		ore_overlay.layer = DECAL_LAYER
 
 /turf/simulated/wall/natural/on_update_icon()
 	. = ..()

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -118,12 +118,12 @@ var/list/mining_floors = list()
 
 		if(istype(get_step(src, step_overlays[direction]), /turf/space))
 			var/image/aster_edge = image('icons/turf/flooring/asteroid.dmi', "asteroid_edges", dir = step_overlays[direction])
-			aster_edge.turf_decal_layerise()
+			aster_edge.layer = DECAL_LAYER
 			overlays += aster_edge
 
 	if(overlay_detail)
 		var/image/floor_decal = image(icon = 'icons/turf/flooring/decals.dmi', icon_state = overlay_detail)
-		floor_decal.turf_decal_layerise()
+		floor_decal.layer = DECAL_LAYER
 		overlays |= floor_decal
 
 	if(update_neighbors)

--- a/code/modules/overmap/exoplanets/turfs.dm
+++ b/code/modules/overmap/exoplanets/turfs.dm
@@ -62,7 +62,7 @@
 		var/turf/turf_to_check = get_step(src,direction)
 		if(!istype(turf_to_check, type))
 			var/image/rock_side = image(icon, "edge[pick(0,1,2)]", dir = turn(direction, 180))
-			rock_side.plating_decal_layerise()
+			rock_side.layer = DECAL_PLATING_LAYER
 			switch(direction)
 				if(NORTH)
 					rock_side.pixel_y += world.icon_size


### PR DESCRIPTION
Fixes decals from /turf/simulated/floor
Removes /image/proc/plating_decal_layerise() and /image/proc/turf_decal_layerise()
Replaces instances of them with assignments to the layer 
Current issue:
![image](https://cdn.discordapp.com/attachments/678826323728400394/732124697592070204/SadZcopy.png)
Fixed:
![image](https://user-images.githubusercontent.com/12163281/87870552-16db8d80-c977-11ea-89fd-088b3b05f513.png)
