### PR TITLE
Split nonstandard limb mapping code out of hands PR.

### DIFF
--- a/code/__defines/inventory_sizes.dm
+++ b/code/__defines/inventory_sizes.dm
@@ -1,6 +1,21 @@
 // The below should be used to define an item's w_class variable.
 // Example: w_class = ITEM_SIZE_LARGE
 // This allows the addition of future w_classes without needing to change every file.
+
+/*
+	A note on w_classes - this is an attempt to describe the w_classes currently in use
+	with an attempt at providing examples of the kinds of things that fit each w_class
+
+	1 - tiny items - things like screwdrivers and pens, sheets of paper
+	2 - small items - things that can fit in a pocket
+	3 - normal items
+	4 - large items - the largest things you can fit in a backpack
+	5 - bulky items - backpacks are this size, for reference
+	6 - human sized objects
+	10 - things that are large enough to not realistically fit into a container (or should not be contained)
+	20 - things that take up an entire turf, like wall girders or door assemblies
+*/
+
 #define ITEM_SIZE_TINY           1
 #define ITEM_SIZE_SMALL          2
 #define ITEM_SIZE_NORMAL         3

--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -208,19 +208,21 @@
 
 // Storage
 
-/*
-	A note on w_classes - this is an attempt to describe the w_classes currently in use
-	with an attempt at providing examples of the kinds of things that fit each w_class
+// Limbs.
+#define BP_L_FOOT       "l_foot"
+#define BP_R_FOOT       "r_foot"
+#define BP_L_LEG        "l_leg"
+#define BP_R_LEG        "r_leg"
+#define BP_L_HAND       "l_hand"
+#define BP_R_HAND       "r_hand"
+#define BP_L_ARM        "l_arm"
+#define BP_R_ARM        "r_arm"
+#define BP_HEAD         "head"
+#define BP_CHEST        "chest"
+#define BP_GROIN        "groin"
 
-	1 - tiny items - things like screwdrivers and pens, sheets of paper
-	2 - small items - things that can fit in a pocket
-	3 - normal items
-	4 - large items - the largest things you can fit in a backpack
-	5 - bulky items - backpacks are this size, for reference
-	6 - human sized objects
-	7 - things that are large enough to contain humans, like closets, but smaller than entire turfs
-	8 - things that take up an entire turf, like wall girders or door assemblies
-*/
+var/list/all_limb_tags = list(BP_CHEST, BP_GROIN, BP_HEAD, BP_L_ARM, BP_R_ARM, BP_L_HAND, BP_R_HAND, BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT)
+var/list/all_limb_tags_by_depth = list(BP_HEAD, BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM, BP_L_FOOT, BP_R_FOOT, BP_L_LEG, BP_R_LEG, BP_GROIN, BP_CHEST)
 
 var/list/default_onmob_icons = list(
 		slot_l_hand_str = 'icons/mob/onmob/items/lefthand.dmi',

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -209,21 +209,6 @@
 #define AUGMENTATION_MECHANIC 1
 #define AUGMENTATION_ORGANIC  2
 
-// Limbs.
-#define BP_L_FOOT "l_foot"
-#define BP_R_FOOT "r_foot"
-#define BP_L_LEG  "l_leg"
-#define BP_R_LEG  "r_leg"
-#define BP_L_HAND "l_hand"
-#define BP_R_HAND "r_hand"
-#define BP_L_ARM  "l_arm"
-#define BP_R_ARM  "r_arm"
-#define BP_HEAD   "head"
-#define BP_CHEST  "chest"
-#define BP_GROIN  "groin"
-#define BP_ALL_LIMBS list(BP_CHEST, BP_GROIN, BP_HEAD, BP_L_ARM, BP_R_ARM, BP_L_HAND, BP_R_HAND, BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT)
-#define BP_BY_DEPTH list(BP_HEAD, BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM, BP_L_FOOT, BP_R_FOOT, BP_L_LEG, BP_R_LEG, BP_GROIN, BP_CHEST)
-
 // Prosthetic helpers.
 #define BP_IS_PROSTHETIC(org) (!QDELETED(org) && (org.status & ORGAN_PROSTHETIC))
 #define BP_IS_ASSISTED(org)   (!QDELETED(org) && (org.status & ORGAN_ASSISTED))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -569,11 +569,7 @@ its easier to just keep the beam vertical.
 				M.adjustBruteLoss(damage)
 				return
 
-			var/obj/item/organ/external/affecting
-			var/list/limbs = BP_ALL_LIMBS //sanity check, can otherwise be shortened to affecting = pick(BP_ALL_LIMBS)
-			if(limbs.len)
-				affecting = H.get_organ(pick(limbs))
-
+			var/obj/item/organ/external/affecting = pick(H.organs)
 			if(affecting)
 				to_chat(M, "<span class='danger'>You land heavily on your [affecting.name]!</span>")
 				affecting.take_external_damage(damage, 0)

--- a/code/game/objects/items/weapons/implants/implants/imprinting.dm
+++ b/code/game/objects/items/weapons/implants/implants/imprinting.dm
@@ -109,7 +109,7 @@
 		if(!B || H.isSynthetic())
 			to_chat(user, "<span class='warning'>\The [M] cannot be imprinted.</span>")
 			return FALSE
-		if(!(B.parent_organ == check_zone(target_zone)))
+		if(!(B.parent_organ == check_zone(target_zone, H)))
 			to_chat(user, "<span class='warning'>\The [src] must be implanted in [H.get_organ(B.parent_organ)].</span>")
 			return FALSE
 	return TRUE

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -105,7 +105,7 @@
 
 /obj/item/baton/throw_impact(atom/hit_atom, var/datum/thrownthing/TT)
 	if(istype(hit_atom,/mob/living))
-		apply_hit_effect(hit_atom, hit_zone = ran_zone(TT.target_zone, 30))//more likely to hit the zone you target!
+		apply_hit_effect(hit_atom, hit_zone = ran_zone(TT.target_zone, 30, hit_atom)) // more likely to hit the zone you target!
 	else
 		..()
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -264,8 +264,8 @@
 	if (!G.force_danger())
 		to_chat(G.assailant, SPAN_DANGER("You need a better grip to do that!"))
 		return TRUE
-	var/def_zone = ran_zone(BP_HEAD, 20)
 	var/mob/affecting_mob = G.get_affecting_mob()
+	var/def_zone = ran_zone(BP_HEAD, 20, affecting_mob)
 	if(!affecting_mob)
 		attackby(G.affecting, G.assailant)
 		return TRUE

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -523,7 +523,9 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		switch(new_state)
 			if("Normal")
 				if(limb == BP_CHEST)
-					for(var/other_limb in (BP_ALL_LIMBS - BP_CHEST))
+					for(var/other_limb in global.all_limb_tags)
+						if(other_limb == BP_CHEST)
+							continue
 						pref.organ_data[other_limb] = null
 						pref.rlimb_data[other_limb] = null
 						for(var/internal_organ in list(BP_HEART,BP_EYES,BP_LUNGS,BP_LIVER,BP_KIDNEYS,BP_STOMACH,BP_BRAIN))
@@ -571,7 +573,9 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 					pref.organ_data[third_limb] = null
 
 				if(limb == BP_CHEST)
-					for(var/other_limb in BP_ALL_LIMBS - BP_CHEST)
+					for(var/other_limb in global.all_limb_tags)
+						if(other_limb == BP_CHEST)
+							continue
 						pref.organ_data[other_limb] = "cyborg"
 						pref.rlimb_data[other_limb] = choice
 					if(!pref.organ_data[BP_BRAIN])

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -177,7 +177,7 @@ datum/preferences
 	character.f_style = f_style
 
 	// Replace any missing limbs.
-	for(var/name in BP_ALL_LIMBS)
+	for(var/name in global.all_limb_tags)
 		var/obj/item/organ/external/O = character.organs_by_name[name]
 		if(!O && organ_data[name] != "amputated")
 			var/list/organ_data = character.species.has_limbs[name]
@@ -186,7 +186,7 @@ datum/preferences
 			O = new limb_path(character)
 
 	// Destroy/cyborgize organs and limbs. The order is important for preserving low-level choices for robolimb sprites being overridden.
-	for(var/name in BP_BY_DEPTH)
+	for(var/name in global.all_limb_tags_by_depth)
 		var/status = organ_data[name]
 		var/obj/item/organ/external/O = character.organs_by_name[name]
 		if(!O)

--- a/code/modules/genetics/side_effects.dm
+++ b/code/modules/genetics/side_effects.dm
@@ -40,7 +40,7 @@
 
 /datum/genetics/side_effect/genetic_burn/finish(mob/living/carbon/human/H)
 	if(!H.reagents.has_reagent(/decl/material/liquid/oxy_meds))
-		for(var/organ_name in BP_ALL_LIMBS)
+		for(var/organ_name in global.all_limb_tags)
 			var/obj/item/organ/external/E = H.get_organ(organ_name)
 			E.take_external_damage(0, 5, 0)
 
@@ -55,10 +55,10 @@
 	H.visible_message("<B>\The [H]</B>'s limbs start shivering uncontrollably.")
 /datum/genetics/side_effect/bone_snap/finish(mob/living/carbon/human/H)
 	if(!H.reagents.has_reagent(/decl/material/liquid/brute_meds))
-		var/organ_name = pick(BP_ALL_LIMBS)
-		var/obj/item/organ/external/E = H.get_organ(organ_name)
-		E.take_external_damage(20, 0, 0)
-		E.fracture()
+		var/obj/item/organ/external/E = pick(H.organs)
+		if(E)
+			E.take_external_damage(20, 0, 0)
+			E.fracture()
 
 /datum/genetics/side_effect/confuse
 	name = "Confuse"

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -119,11 +119,8 @@
 			qdel(target)
 		return
 
-
-	if(!target_limb) target_limb = pick(BP_ALL_LIMBS)
-	var/obj/item/organ/external/affecting = target.get_organ(target_limb)
-
-	if((target.species && target.species.species_flags & (SPECIES_FLAG_NO_EMBED|SPECIES_FLAG_NO_MINOR_CUT)))
+	var/obj/item/organ/external/affecting = target_limb ? target.get_organ(target_limb) : pick(target.organs)
+	if(affecting?.species?.species_flags & (SPECIES_FLAG_NO_EMBED|SPECIES_FLAG_NO_MINOR_CUT))
 		to_chat(target, "<span class='danger'>\The [fruit]'s thorns scratch against the armour on your [affecting.name]!</span>")
 		return
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -323,7 +323,7 @@
 	return ..(shock_damage, source, base_siemens_coeff, def_zone)
 
 /mob/living/carbon/human/apply_shock(var/shock_damage, var/def_zone, var/base_siemens_coeff = 1.0)
-	var/obj/item/organ/external/initial_organ = get_organ(check_zone(def_zone))
+	var/obj/item/organ/external/initial_organ = get_organ(check_zone(def_zone, src))
 	if(!initial_organ)
 		initial_organ = pick(organs)
 
@@ -614,7 +614,7 @@
 
 	var/obj/item/organ/affecting = internal_organs_by_name[brain_tag]
 
-	target_zone = check_zone(target_zone)
+	target_zone = check_zone(target_zone, src)
 	if(!affecting || affecting.parent_organ != target_zone)
 		return 0
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -183,7 +183,7 @@
 					TODO: proc for melee combat miss chances depending on organ?
 				*/
 				if(prob(80))
-					hit_zone = ran_zone(hit_zone)
+					hit_zone = ran_zone(hit_zone, target = src)
 				if(prob(15) && hit_zone != BP_CHEST) // Missed!
 					if(!src.lying)
 						attack_message = "[H] attempted to strike [src], but missed!"

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -351,7 +351,7 @@ This function restores the subjects blood to max.
 This function restores all organs.
 */
 /mob/living/carbon/human/restore_all_organs(var/ignore_prosthetic_prefs)
-	for(var/bodypart in BP_BY_DEPTH)
+	for(var/bodypart in global.all_limb_tags_by_depth)
 		var/obj/item/organ/external/current_organ = organs_by_name[bodypart]
 		if(istype(current_organ))
 			current_organ.rejuvenate(ignore_prosthetic_prefs)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -367,7 +367,7 @@ This function restores all organs.
 	return
 
 /mob/living/carbon/human/get_organ(var/zone)
-	return organs_by_name[check_zone(zone)]
+	return organs_by_name[check_zone(zone, src, base_zone_only = TRUE)]
 
 /mob/living/carbon/human/apply_damage(var/damage = 0, var/damagetype = BRUTE, var/def_zone = null, var/damage_flags = 0, var/obj/used_weapon = null, var/armor_pen, var/silent = FALSE, var/obj/item/organ/external/given_organ = null)
 
@@ -388,8 +388,8 @@ This function restores all organs.
 						def_zone = zone
 						. = .() || .
 					return
-				def_zone = ran_zone(def_zone)
-			organ = get_organ(check_zone(def_zone))
+				def_zone = ran_zone(def_zone, target = src)
+			organ = get_organ(check_zone(def_zone, src))
 
 	//Handle other types of damage
 	if(!(damagetype in list(BRUTE, BURN, PAIN, CLONE)))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -9,7 +9,7 @@ meteor_act
 
 /mob/living/carbon/human/bullet_act(var/obj/item/projectile/P, var/def_zone)
 
-	def_zone = check_zone(def_zone)
+	def_zone = check_zone(def_zone, src)
 	if(!has_organ(def_zone))
 		return PROJECTILE_FORCE_MISS //if they don't have the organ in question then the projectile just passes by.
 
@@ -29,7 +29,7 @@ meteor_act
 	return blocked
 
 /mob/living/carbon/human/stun_effect_act(var/stun_amount, var/agony_amount, var/def_zone)
-	var/obj/item/organ/external/affected = get_organ(check_zone(def_zone))
+	var/obj/item/organ/external/affected = get_organ(def_zone)
 	if(!affected)
 		return
 
@@ -63,7 +63,7 @@ meteor_act
 	if(!def_zone)
 		def_zone = ran_zone()
 	if(!istype(def_zone))
-		def_zone = get_organ(check_zone(def_zone))
+		def_zone = get_organ(def_zone)
 	if(!def_zone)
 		return
 	var/list/protective_gear = list(head, wear_mask, wear_suit, w_uniform, gloves, shoes)
@@ -307,7 +307,7 @@ meteor_act
 
 		var/zone = BP_CHEST
 		if (TT.target_zone)
-			zone = check_zone(TT.target_zone)
+			zone = check_zone(TT.target_zone, src)
 		else
 			zone = ran_zone()	//Hits a random part of the body, -was already geared towards the chest
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -350,7 +350,7 @@ default behaviour is:
 	var/t = shooter.zone_sel?.selecting
 	if ((t in list( BP_EYES, BP_MOUTH )))
 		t = BP_HEAD
-	var/obj/item/organ/external/def_zone = ran_zone(t)
+	var/obj/item/organ/external/def_zone = ran_zone(t, target = src)
 	return def_zone
 
 

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -127,7 +127,7 @@
 	if(ishuman(target_mob))
 		var/mob/living/carbon/human/H = target_mob
 		var/dam_zone = pick(BP_CHEST, BP_L_HAND, BP_R_HAND, BP_L_LEG, BP_R_LEG)
-		var/obj/item/organ/external/affecting = H.get_organ(ran_zone(dam_zone))
+		var/obj/item/organ/external/affecting = H.get_organ(ran_zone(dam_zone, target = H))
 		H.apply_damage(damage, BRUTE, affecting, DAM_SHARP|DAM_EDGE) //TODO damage_flags var on simple_animals, maybe?
 		return H
 	else if(isliving(target_mob))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -110,22 +110,21 @@ var/list/global/organ_rel_size = list(
 	BP_R_FOOT = 10,
 )
 
-/proc/check_zone(zone)
-	if(!zone)	return BP_CHEST
-	switch(zone)
-		if(BP_EYES)
-			zone = BP_HEAD
-		if(BP_MOUTH)
-			zone = BP_HEAD
-	return zone
+/proc/check_zone(zone, mob/target, var/base_zone_only)
+	. = zone || BP_CHEST
+	if(. == BP_EYES || . == BP_MOUTH)
+		. = BP_HEAD
+	if(ishuman(target) && !base_zone_only)
+		var/mob/living/carbon/human/H = target
+		. = H.species.get_limb_from_zone(.)
 
 // Returns zone with a certain probability. If the probability fails, or no zone is specified, then a random body part is chosen.
 // Do not use this if someone is intentionally trying to hit a specific body part.
 // Use get_zone_with_miss_chance() for that.
-/proc/ran_zone(zone, probability)
-	if (zone)
-		zone = check_zone(zone)
-		if (prob(probability))
+/proc/ran_zone(zone, probability, target)
+	if(zone)
+		zone = check_zone(zone, target)
+		if(prob(probability))
 			return zone
 
 	var/ran_zone = zone
@@ -150,7 +149,7 @@ var/list/global/organ_rel_size = list(
 // May return null if missed
 // miss_chance_mod may be negative.
 /proc/get_zone_with_miss_chance(zone, var/mob/target, var/miss_chance_mod = 0, var/ranged_attack=0)
-	zone = check_zone(zone)
+	zone = check_zone(zone, target)
 
 	if(!ranged_attack)
 		// target isn't trying to fight

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -49,7 +49,7 @@
 		if(TT.speed >= 10 && isliving(hit_atom))
 			var/mob/living/L = hit_atom
 			//unfortuately we don't know where the dart will actually hit, since that's done by the parent.
-			if(L.can_inject(null, ran_zone(TT.target_zone, 30)) == CAN_INJECT && syringe.reagents)
+			if(L.can_inject(null, ran_zone(TT.target_zone, 30, L)) == CAN_INJECT && syringe.reagents)
 				var/reagent_log = syringe.reagents.get_reagents()
 				syringe.reagents.trans_to_mob(L, 15, CHEM_INJECT)
 				admin_inject_log(TT.thrower? TT.thrower : null, L, src, reagent_log, 15, violent=1)

--- a/code/modules/projectiles/projectile/pellets.dm
+++ b/code/modules/projectiles/projectile/pellets.dm
@@ -35,7 +35,7 @@
 		//pellet hits spread out across different zones, but 'aim at' the targeted zone with higher probability
 		//whether the pellet actually hits the def_zone or a different zone should still be determined by the parent using get_zone_with_miss_chance().
 		var/old_zone = def_zone
-		def_zone = ran_zone(def_zone, spread)
+		def_zone = ran_zone(def_zone, spread, target_mob)
 		if (..()) hits++
 		def_zone = old_zone //restore the original zone the projectile was aimed at
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -34,7 +34,7 @@
 	if (!istype(M))
 		return
 
-	var/allow = M.can_inject(user, check_zone(user.zone_sel.selecting))
+	var/allow = M.can_inject(user, check_zone(user.zone_sel.selecting, M))
 	if(!allow)
 		return
 

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -138,7 +138,7 @@
 					CRASH("[T] \[[T.type]\] was missing their dna datum!")
 				return
 
-			var/allow = T.can_inject(user, check_zone(user.zone_sel.selecting))
+			var/allow = T.can_inject(user, check_zone(user.zone_sel.selecting, T))
 			if(!allow)
 				return
 
@@ -157,7 +157,7 @@
 
 			if(prob(user.skill_fail_chance(SKILL_MEDICAL, 60, SKILL_BASIC)))
 				to_chat(user, "<span class='warning'>You miss the vein!</span>")
-				var/target_zone = check_zone(user.zone_sel.selecting)
+				var/target_zone = check_zone(user.zone_sel.selecting, T)
 				T.apply_damage(3, BRUTE, target_zone, damage_flags=DAM_SHARP)
 				return
 
@@ -227,7 +227,7 @@
 	if(!trackTarget)
 		trackTarget = target
 
-	var/allow = target.can_inject(user, check_zone(user.zone_sel.selecting))
+	var/allow = target.can_inject(user, check_zone(user.zone_sel.selecting, target))
 	if(!allow)
 		return
 
@@ -270,7 +270,7 @@
 
 		var/mob/living/carbon/human/H = target
 
-		var/target_zone = check_zone(user.zone_sel.selecting)
+		var/target_zone = check_zone(user.zone_sel.selecting, H)
 		var/obj/item/organ/external/affecting = H.get_organ(target_zone)
 
 		if (!affecting || affecting.is_stump())

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -197,6 +197,11 @@
 
 	var/list/skin_overlays = list()
 
+	// An associative list of target zones (ex. BP_CHEST, BP_MOUTH) mapped to all possible keys associated
+	// with the zone. Unused on vanilla Nebula at time of commit, will be used by hands and inventory 
+	// rewrite and for species with body layouts that do not map directly to the standard humanoid body.
+	var/list/limb_mapping 
+
 	var/list/has_limbs = list(
 		BP_CHEST =  list("path" = /obj/item/organ/external/chest),
 		BP_GROIN =  list("path" = /obj/item/organ/external/groin),
@@ -346,7 +351,7 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 		var/list/organ_data = has_limbs[limb_type]
 		var/obj/item/organ/limb_path = organ_data["path"]
 		organ_data["descriptor"] = initial(limb_path.name)
-
+	
 /datum/species/proc/equip_survival_gear(var/mob/living/carbon/human/H,var/extendedtank = 1)
 	if(istype(H.get_equipped_item(slot_back), /obj/item/storage/backpack))
 		if (extendedtank)	H.equip_to_slot_or_del(new /obj/item/storage/box/engineer(H.back), slot_in_backpack)
@@ -622,7 +627,7 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 
 	if(target.w_uniform)
 		target.w_uniform.add_fingerprint(attacker)
-	var/obj/item/organ/external/affecting = target.get_organ(ran_zone(attacker.zone_sel.selecting))
+	var/obj/item/organ/external/affecting = target.get_organ(ran_zone(attacker.zone_sel.selecting, target = target))
 
 	var/list/holding = list(target.get_active_hand() = 60, target.get_inactive_hand() = 30)
 

--- a/code/modules/species/species_getters.dm
+++ b/code/modules/species/species_getters.dm
@@ -107,3 +107,6 @@
 
 /datum/species/proc/get_root_species_name(var/mob/living/carbon/human/H)
 	return name
+
+/datum/species/proc/get_limb_from_zone(var/limb)
+	. = length(LAZYACCESS(limb_mapping, limb)) ? pick(limb_mapping[limb]) : limb

--- a/code/modules/surgery/_surgery.dm
+++ b/code/modules/surgery/_surgery.dm
@@ -266,7 +266,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 		. = TRUE
 
 	if(M == user)
-		var/hitzone = check_zone(user.zone_sel.selecting)
+		var/hitzone = check_zone(user.zone_sel.selecting, M)
 		var/list/badzones = list(BP_HEAD)
 		if(user.hand)
 			badzones += BP_L_ARM

--- a/code/modules/surgery/_surgery.dm
+++ b/code/modules/surgery/_surgery.dm
@@ -179,6 +179,13 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 
 	// Check for multi-surgery drifting.
 	var/zone = user.zone_sel.selecting
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(length(LAZYACCESS(H.species.limb_mapping, zone)) > 1)
+			zone = input("Which bodypart do you wish to operate on?", "Non-standard surgery") as null|anything in H.species.limb_mapping[zone]
+			if(!zone)
+				return FALSE
+
 	if(LAZYACCESS(M.surgeries_in_progress, zone))
 		to_chat(user, SPAN_WARNING("You can't operate on this area while surgery is already in progress."))
 		return TRUE


### PR DESCRIPTION
Tl;dr: `check_zone` and `ran_zone` now use a species-level limb mapping list when resolving a target zone to an organ, if a human mob is supplied as an argument. This will allow surgery and combat actions to hit nonstandard limbs (ie. limbs not on the target dolly). Nothing on Neb currently will use this, but it's needed for the multihands PR.