### PR TITLE
Atmos control restriction

### DIFF
--- a/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
@@ -32,7 +32,8 @@
 		SKILL_COMPUTER            = SKILL_EXPERT,
 		SKILL_FORENSICS           = SKILL_PROF,
 		SKILL_WEAPONS             = SKILL_EXPERT,
-		SKILL_CONSTRUCTION        = SKILL_ADEPT
+		SKILL_CONSTRUCTION        = SKILL_ADEPT,
+		SKILL_ANATOMY             = SKILL_ADEPT
 	)
 
 /obj/item/robot_module/flying/forensics/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)

--- a/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
@@ -56,6 +56,9 @@
 
 	// TODO: Move these to a cache, similar to cameras
 	for(var/obj/machinery/alarm/alarm in (monitored_alarms.len ? monitored_alarms : SSmachines.machinery))
+		var/turf/Z = get_host_z()
+		if (!Z || !AreConnectedZLevels(Z, alarm.z))
+			continue
 		var/danger_level = max(alarm.danger_level, alarm.alarm_area.atmosalm)
 		if(danger_level == 2)
 			alarmsAlert[++alarmsAlert.len] = list("name" = sanitize(alarm.name), "ref"= "\ref[alarm]", "danger" = danger_level)
@@ -63,10 +66,10 @@
 			alarmsDanger[++alarmsDanger.len] = list("name" = sanitize(alarm.name), "ref"= "\ref[alarm]", "danger" = danger_level)
 		else
 			alarms[++alarms.len] = list("name" = sanitize(alarm.name), "ref"= "\ref[alarm]", "danger" = danger_level)
-	
-	data["alarms"] = alarms
-	data["alarmsAlert"] = alarmsAlert
-	data["alarmsDanger"] = alarmsDanger
+
+	data["alarms"] = sortByKey(alarms, "name")
+	data["alarmsAlert"] = sortByKey(alarmsAlert, "name")
+	data["alarmsDanger"] = sortByKey(alarmsDanger, "name")
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)


### PR DESCRIPTION
:cl:
tweak: Atmosphere Control software now only displays alarms from connected z-levels.
tweak: Atmosphere Control software now displays alarms in alphabetical order.
/:cl: