### PR TITLE
Sort suit sensors in alphabetical order

### DIFF
--- a/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
+++ b/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
@@ -60,6 +60,7 @@
 	if(network)
 		for(var/z_level in GetConnectedZlevels(network.get_router_z()))
 			data["crewmembers"] += crew_repository.health_data(z_level)
+	data["crewmembers"] = sortByKey(data["crewmembers"], "name")
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)


### PR DESCRIPTION
No more determining the deck of people not set to tracking.

:cl:
tweak: Crew Monitor now sorts properly by name instead of by deck.
/:cl: