### PR TITLE
Increases atom/movable glide_size to 8 from 4, to increase gameplay smoothiness.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1,7 +1,7 @@
 /atom/movable
 	layer = OBJ_LAYER
 	appearance_flags = TILE_BOUND
-	glide_size = 4
+	glide_size = 8
 	var/movable_flags
 	var/last_move = null
 	var/anchored = 0


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->
When a character walk he won't finish his glide animation before making another step "snapping" their sprite and the users camera several pixels away, for purposes of starting the next glide, which causes a feeling of lag, and that's not good

This bumps the glide_size to 8, which considerably helps the smoothness of stuff