### PR TITLE
Added a modpack testing map, removed modpacks from Example.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ jobs:
       env: TEST=MAP MAP_PATH=tradeship
     - name: "Map - Away Sites"
       env: TEST=MAP MAP_PATH=away_sites_testing
+    - name: "Map - Modpacks"
+      env: TEST=MAP MAP_PATH=modpack_testing
 
 cache:
   directories:

--- a/code/modules/client/preference_setup/loadout/lists/suits.dm
+++ b/code/modules/client/preference_setup/loadout/lists/suits.dm
@@ -77,8 +77,7 @@
 	.[/datum/gear_tweak/path/specified_types_list] |= list(
 		/obj/item/clothing/suit/storage/toggle/bomber,
 		/obj/item/clothing/suit/storage/leather_jacket,
-		/obj/item/clothing/suit/storage/toggle/brown_jacket,
-		/obj/item/clothing/suit/storage/mbill
+		/obj/item/clothing/suit/storage/toggle/brown_jacket
 	)
 
 /datum/gear/suit/wintercoat

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -1,3 +1,4 @@
+#include "../../../mods/corporate/_corporate.dme"
 #include "errant_pisces_areas.dm"
 
 /obj/effect/overmap/visitable/ship/errant_pisces

--- a/maps/example/example.dm
+++ b/maps/example/example.dm
@@ -1,14 +1,5 @@
 #if !defined(USING_MAP_DATUM)
 
-	#include "..\..\mods\misc\mundane.dm"
-	#include "..\..\mods\corporate\_corporate.dme"
-	#include "..\..\mods\government\_government.dme"
-	#include "..\..\mods\psionics\_psionics.dme"
-	#include "..\..\mods\borers\_borers.dme"
-	#include "..\..\mods\ascent\_ascent.dme"
-	#include "..\..\mods\modern_earth\_modern_earth.dme"
-	#include "..\..\mods\dionaea\_dionaea.dme"
-
 	#include "example_areas.dm"
 	#include "example_shuttles.dm"
 	#include "example_unit_testing.dm"

--- a/maps/modpack_testing/blank.dmm
+++ b/maps/modpack_testing/blank.dmm
@@ -1,0 +1,145 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/space,
+/area/space)
+"b" = (
+/turf/simulated/wall,
+/area/space)
+"c" = (
+/turf/simulated/floor/tiled,
+/area/space)
+"d" = (
+/obj/effect/landmark/test/safe_turf,
+/turf/simulated/floor/tiled,
+/area/space)
+"e" = (
+/obj/effect/landmark/start{
+	name = "JoinLate"
+	},
+/turf/simulated/floor/tiled,
+/area/space)
+"f" = (
+/obj/effect/landmark/test/space_turf,
+/turf/space,
+/area/space)
+
+(1,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+"}
+(2,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+a
+f
+a
+"}
+(3,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+"}
+(4,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+"}
+(5,1,1) = {"
+b
+b
+b
+b
+b
+b
+a
+a
+a
+a
+"}
+(6,1,1) = {"
+b
+c
+c
+c
+e
+b
+a
+a
+a
+a
+"}
+(7,1,1) = {"
+b
+c
+d
+c
+c
+b
+a
+a
+a
+a
+"}
+(8,1,1) = {"
+b
+c
+c
+c
+c
+b
+a
+a
+a
+a
+"}
+(9,1,1) = {"
+b
+c
+c
+c
+c
+b
+a
+a
+a
+a
+"}
+(10,1,1) = {"
+b
+b
+b
+b
+b
+b
+a
+a
+a
+a
+"}

--- a/maps/modpack_testing/modpack_testing.dm
+++ b/maps/modpack_testing/modpack_testing.dm
@@ -1,0 +1,21 @@
+#if !defined(USING_MAP_DATUM)
+
+	#include "modpack_testing_lobby.dm"
+	#include "blank.dmm"
+
+	#include "..\..\mods\misc\mundane.dm"
+	#include "..\..\mods\corporate\_corporate.dme"
+	#include "..\..\mods\government\_government.dme"
+	#include "..\..\mods\psionics\_psionics.dme"
+	#include "..\..\mods\borers\_borers.dme"
+	#include "..\..\mods\ascent\_ascent.dme"
+	#include "..\..\mods\modern_earth\_modern_earth.dme"
+	#include "..\..\mods\dionaea\_dionaea.dme"
+
+	#define USING_MAP_DATUM /datum/map/modpack_testing
+
+#elif !defined(MAP_OVERRIDE)
+
+	#warn A map has already been included, ignoring Modpack Testing
+
+#endif

--- a/maps/modpack_testing/modpack_testing_define.dm
+++ b/maps/modpack_testing/modpack_testing_define.dm
@@ -1,0 +1,8 @@
+/datum/map/modpack_testing
+	name = "Modpack Testing"
+	full_name = "Modpack Testing District"
+	path = "modpack_testing"
+	station_levels = list()
+	contact_levels = list()
+	player_levels = list()
+	allowed_spawns = list()

--- a/maps/modpack_testing/modpack_testing_lobby.dm
+++ b/maps/modpack_testing/modpack_testing_lobby.dm
@@ -1,0 +1,2 @@
+/datum/map/modpack_testing
+	lobby_tracks = list(/music_track/absconditus)

--- a/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dm
+++ b/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dm
@@ -1,3 +1,5 @@
+#include "../../../../mods/corporate/_corporate.dme"
+
 /datum/map_template/ruin/exoplanet/oldpod
 	name = "old pod"
 	id = "oldpod"

--- a/maps/tradeship/tradeship_define.dm
+++ b/maps/tradeship/tradeship_define.dm
@@ -17,7 +17,6 @@
 	company_name  = "Legit Cargo Ltd."
 	company_short = "LC"
 	overmap_event_areas = 11
-	default_law_type = /datum/ai_laws/corporate
 	lobby_screens = list('maps/tradeship/lobby/bloodmoney.png','maps/tradeship/lobby/vapormoney.png')
 	use_overmap = 1
 	num_exoplanets = 3

--- a/maps/tradeship/tradeship_jobs.dm
+++ b/maps/tradeship/tradeship_jobs.dm
@@ -1,4 +1,5 @@
 /datum/map/tradeship
+	default_law_type = /datum/ai_laws/corporate
 	default_assistant_title = "Deck Hand"
 	allowed_jobs = list(
 		/datum/job/tradeship_captain,

--- a/mods/corporate/datum/loadout.dm
+++ b/mods/corporate/datum/loadout.dm
@@ -95,3 +95,7 @@
 	display_name = "winter coat, DAIS"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/dais
 
+/datum/gear/suit/leather/get_gear_tweak_options()
+	. = ..()
+	LAZYINITLIST(.[/datum/gear_tweak/path/specified_types_list])
+	.[/datum/gear_tweak/path/specified_types_list] |= /obj/item/clothing/suit/storage/mbill

--- a/mods/government/away_sites/icarus/icarus.dm
+++ b/mods/government/away_sites/icarus/icarus.dm
@@ -1,4 +1,5 @@
 #include "../../_government.dme"
+#include "../../../corporate/_corporate.dme"
 #include "icarus_areas.dm"
 
 /obj/effect/overmap/visitable/sector/icarus

--- a/nebula.dme
+++ b/nebula.dme
@@ -3195,6 +3195,7 @@
 #include "maps\away\away_sites.dm"
 #include "maps\away_sites_testing\away_sites_testing_define.dm"
 #include "maps\example\example_define.dm"
+#include "maps\modpack_testing\modpack_testing_define.dm"
 #include "maps\random_ruins\exoplanet_ruins\exoplanet_ruins.dm"
 #include "maps\random_ruins\exoplanet_ruins\crashed_pod\crashed_pod.dm"
 #include "maps\random_ruins\exoplanet_ruins\datacapsule\datacapsule.dm"


### PR DESCRIPTION
- Example is now completely clear of modpacks and should be left that way to make sure the game actually compiles with none of them included.
- Modpack testing should have all modpacks included in it.