### PR TITLE
Removes defalut drop and pickup sound for all items

### DIFF
--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -100,9 +100,9 @@
 	///Sound used when equipping the item into a valid slot
 	var/equip_sound
 	///Sound uses when picking the item up (into your hands)
-	var/pickup_sound = 'sound/items/pickup/device.ogg'
+	var/pickup_sound
 	///Sound uses when dropping the item, or when its thrown.
-	var/drop_sound = 'sound/items/drop/device.ogg'
+	var/drop_sound
 
 /obj/item/create_matter()
 	..()


### PR DESCRIPTION
I can't figure why it plays sound after player spawn, so it would be better to remove default drop/pickup sounds for a time.