### PR TITLE
stoplag() update

### DIFF
--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -87,16 +87,22 @@ GLOBAL_VAR_INIT(rollovercheck_last_timeofday, 0)
 
 //Increases delay as the server gets more overloaded,
 //as sleeps aren't cheap and sleeping only to wake up and sleep again is wasteful
-#define DELTA_CALC max(((max(world.tick_usage, world.cpu) / 100) * max(Master.sleep_delta,1)), 1)
+#define DELTA_CALC max(((max(world.tick_usage, world.cpu) / 100) * max(Master.sleep_delta-1,1)), 1)
 
-/proc/stoplag()
-	if (!Master || !(GAME_STATE & RUNLEVELS_DEFAULT))
+/proc/stoplag(initial_delay)
+	// If we're initializing, our tick limit might be over 100 (testing config), but stoplag() penalizes procs that go over.
+	// 	Unfortunately, this penalty slows down init a *lot*. So, we disable it during boot and lobby, when relatively few things should be calling this.
+	if (!Master || Master.current_runlevel < 3)
 		sleep(world.tick_lag)
 		return 1
+
+	if (!initial_delay)
+		initial_delay = world.tick_lag
+
 	. = 0
-	var/i = 1
+	var/i = DS2TICKS(initial_delay)
 	do
-		. += round(i*DELTA_CALC)
+		. += CEILING(i*DELTA_CALC, 1)
 		sleep(i*world.tick_lag*DELTA_CALC)
 		i *= 2
 	while (world.tick_usage > min(TICK_LIMIT_TO_RUN, Master.current_ticklimit))


### PR DESCRIPTION
The ver of stoplag on Neb was a bit out of date and lacked the `initial_delay` param, which a recent TG-port seems to be assuming already exists.

This allows `stoplag()` to be used similarly to sleep; it'll sleep at least that duration, but may sleep longer if there's not much tick left or the server is overloaded.