### PR TITLE
Swapped to a browser based chat instead of an output panel based chat.

### DIFF
--- a/code/_chat.dm
+++ b/code/_chat.dm
@@ -1,0 +1,110 @@
+/proc/generate_asset_name(file)
+	return "asset.[md5(fcopy_rsc(file))]"
+	
+/proc/icon2html(thing, target, icon_state, dir, frame = 1, moving = FALSE, realsize = FALSE, class = null)
+	if (!thing)
+		return
+
+	var/key
+	var/icon/I = thing
+	if (!target)
+		return
+	if (target == world)
+		target = GLOB.clients
+
+	var/list/targets
+	if (!islist(target))
+		targets = list(target)
+	else
+		targets = target
+		if (!targets.len)
+			return
+	if (!isicon(I))
+		if (isfile(thing)) //special snowflake
+			var/name = "[generate_asset_name(thing)].png"
+			register_asset(name, thing)
+			for (var/thing2 in targets)
+				send_asset(thing2, key, FALSE)
+			return "<img class='icon icon-misc [class]' src=\"[url_encode(name)]\">"
+		var/atom/A = thing
+		if (isnull(dir))
+			dir = A.dir
+		if (isnull(icon_state))
+			icon_state = A.icon_state
+		I = A.icon
+		if(istype(thing, /mob/living/carbon/human)) // Shitty workaround for a BYOND issue.
+			var/icon/temp = I
+			I = icon()
+			I.Insert(temp, dir = SOUTH)
+			dir = SOUTH
+	else
+		if (isnull(dir))
+			dir = SOUTH
+		if (isnull(icon_state))
+			icon_state = ""
+
+	I = icon(I, icon_state, dir, frame, moving)
+
+	key = "[generate_asset_name(I)].png"
+	register_asset(key, I)
+	for (var/thing2 in targets)
+		send_asset(thing2, key, FALSE)
+
+	if(realsize)
+		return "<img class='icon icon-[icon_state] [class]' style='width:[I.Width()]px;height:[I.Height()]px;min-height:[I.Height()]px' src=\"[url_encode(key)]\">"
+	return "<img class='icon icon-[icon_state] [class]' src=\"[url_encode(key)]\">"
+
+
+/proc/to_world(message)
+	for(var/client/C in GLOB.clients)
+		to_chat(C, message)
+
+/atom
+	var/last_chat_message
+	var/last_chat_message_count = 0
+
+/client/New()
+	..()
+	src << output( \
+{"
+[script]
+<script type='text/javascript'>
+
+	function replace(msg, count) {
+		var replacing = document.getElementById('chatOutput').innerHTML;
+		var replacingIndex = replacing.lastIndexOf('<BR>');
+		if(replacingIndex >= 0)
+		{
+			msg += ' <sup><span class=\\'notice\\'><i>x ' + count + '</i></span></sup>';
+			document.getElementById('chatOutput').innerHTML = replacing.substring(0, replacingIndex);
+		}
+		append(msg)
+	}
+
+	function append(msg)
+	{
+		document.getElementById('chatOutput').innerHTML += '<br>' + msg;
+		var scrollingElement = (document.scrollingElement || document.body);
+		scrollingElement.scrollTop = scrollingElement.scrollHeight;
+	}
+
+	</script>
+
+	<div id='chatOutput'></div>
+	"}, "outputwindow.output");
+
+/proc/to_chat(var/atom/target, var/message)
+	if(!message)
+		return
+	if(istype(target, /client))
+		var/client/C = target
+		target = C.mob
+	if(istype(target))
+		var/func = "append"
+		if(isnull(target.last_chat_message) || message != target.last_chat_message)
+			target.last_chat_message_count = 0
+		else
+			func = "replace"
+		target.last_chat_message_count++
+		target << output(list2params(list(message, target.last_chat_message_count)), "outputwindow.output:[func]")
+		target.last_chat_message = message

--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -167,7 +167,7 @@ mob
 
 		Output_Icon()
 			set name = "2. Output Icon"
-			to_chat(src, "Icon is: [html_icon(getFlatIcon(src))]")
+			to_chat(src, "Icon is: [icon2html(getFlatIcon(src))]")
 
 		Label_Icon()
 			set name = "3. Label Icon"

--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -352,7 +352,7 @@ proc/TextPreview(var/string,var/len=40)
 /proc/create_text_tag(var/tagname, var/tagdesc = tagname, var/client/C = null)
 	if(!(C && C.get_preference_value(/datum/client_preference/chat_tags) == GLOB.PREF_SHOW))
 		return tagdesc
-	return "<IMG src='\ref['./icons/chattags.dmi']' class='text_tag' iconstate='[tagname]'" + (tagdesc ? " alt='[tagdesc]'" : "") + ">"
+	return icon2html(icon('./icons/chattags.dmi', tagname), world, realsize=TRUE, class="text_tag")
 
 /proc/contains_az09(var/input)
 	for(var/i=1, i<=length(input), i++)

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -97,8 +97,6 @@
 
 #define random_id(key,min_id,max_id) uniqueness_repository.Generate(/datum/uniqueness_generator/id_random, key, min_id, max_id)
 
-#define to_chat(target, message)                            target << (message)
-#define to_world(message)                                   world << (message)
 #define to_world_log(message)                               world.log << (message)
 #define sound_to(target, sound)                             target << (sound)
 #define to_file(file_entry, source_var)                     file_entry << (source_var)
@@ -108,9 +106,6 @@
 #define show_image(target, image)                           target << (image)
 #define send_rsc(target, rsc_content, rsc_name)             target << browse_rsc(rsc_content, rsc_name)
 #define open_link(target, url)             target << link(url)
-
-/proc/html_icon(var/thing) // Proc instead of macro to avoid precompiler problems. 
-	. = "\icon[thing]"
 
 #define MAP_IMAGE_PATH "nano/images/[GLOB.using_map.path]/"
 

--- a/code/controllers/subsystems/zcopy.dm
+++ b/code/controllers/subsystems/zcopy.dm
@@ -316,14 +316,14 @@ SUBSYSTEM_DEF(zcopy)
 		if (istype(A, /atom/movable/openspace/overlay))
 			var/atom/movable/openspace/overlay/OO = A
 			var/atom/movable/AA = OO.associated_atom
-			out += "<li>[html_icon(A)] plane [A.plane], layer [A.layer], depth [OO.depth], associated Z-level [AA.z] - [OO.type] copying [AA] ([AA.type], eventually [OO.mimiced_type])</li>"
+			out += "<li>[icon2html(A, usr)] plane [A.plane], layer [A.layer], depth [OO.depth], associated Z-level [AA.z] - [OO.type] copying [AA] ([AA.type], eventually [OO.mimiced_type])</li>"
 		else if (isturf(A))
 			if (A == T)
-				out += "<li>[html_icon(A)] plane [A.plane], layer [A.layer], depth [A:z_depth], Z-level [A.z] - [A] ([A.type]) - <font color='green'>SELF</font></li>"
+				out += "<li>[icon2html(A, usr)] plane [A.plane], layer [A.layer], depth [A:z_depth], Z-level [A.z] - [A] ([A.type]) - <font color='green'>SELF</font></li>"
 			else	// foreign turfs - not visible here, but good for figuring out layering
-				out += "<li>[html_icon(A)] plane [A.plane], layer [A.layer], depth [A:z_depth], Z-level [A.z] - [A] ([A.type]) - <font color='red'>FOREIGN</font></li>"
+				out += "<li>[icon2html(A, usr)] plane [A.plane], layer [A.layer], depth [A:z_depth], Z-level [A.z] - [A] ([A.type]) - <font color='red'>FOREIGN</font></li>"
 		else
-			out += "<li>[html_icon(A)] plane [A.plane], layer [A.layer], Z-level [A.z] - [A] ([A.type])</li>"
+			out += "<li>[icon2html(A, usr)] plane [A.plane], layer [A.layer], Z-level [A.z] - [A] ([A.type])</li>"
 
 	out += "</ul>"
 

--- a/code/datums/communication/pray.dm
+++ b/code/datums/communication/pray.dm
@@ -12,9 +12,9 @@
 		if(!M.client)
 			continue
 		if(M.client.holder && M.client.get_preference_value(/datum/client_preference/staff/show_chat_prayers) == GLOB.PREF_SHOW)
-			receive_communication(communicator, M, "\[<A HREF='?_src_=holder;adminspawnprayreward=\ref[communicator]'>SC</a>\] \[<A HREF='?_src_=holder;narrateto=\ref[communicator]'>DN</a>\]<span class='notice'>[html_icon(cross)] <b><font color=purple>PRAY: </font>[key_name(communicator, 1)]: </b>[message]</span>")
+			receive_communication(communicator, M, "\[<A HREF='?_src_=holder;adminspawnprayreward=\ref[communicator]'>SC</a>\] \[<A HREF='?_src_=holder;narrateto=\ref[communicator]'>DN</a>\]<span class='notice'>[icon2html(cross, M)] <b><font color=purple>PRAY: </font>[key_name(communicator, 1)]: </b>[message]</span>")
 		else if(communicator == M) //Give it to ourselves
-			receive_communication(communicator, M, "<span class='notice'>[html_icon(cross)] <b>You send the prayer, \"[message]\" out into the heavens.</b></span>")
+			receive_communication(communicator, M, "<span class='notice'>[icon2html(cross, M)] <b>You send the prayer, \"[message]\" out into the heavens.</b></span>")
 
 /decl/communication_channel/pray/receive_communication(var/mob/communicator, var/mob/receiver, var/message)
 	..()

--- a/code/datums/uplink/badassery.dm
+++ b/code/datums/uplink/badassery.dm
@@ -95,5 +95,4 @@
 	if(!icon)
 		var/obj/structure/largecrate/C = /obj/structure/largecrate
 		icon = image(initial(C.icon), initial(C.icon_state))
-
-	return html_icon(icon)
+	return icon2html(icon, world)

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -146,7 +146,7 @@ datum/uplink_item/dd_SortValue()
 
 /datum/uplink_item/item/log_icon()
 	var/obj/I = path
-	return html_icon(I)
+	return icon2html(I, world)
 
 /****************
 * Support procs *

--- a/code/datums/wires/camera.dm
+++ b/code/datums/wires/camera.dm
@@ -67,7 +67,7 @@ var/const/CAMERA_WIRE_NOTHING2 = 32
 			C.light_disabled = !C.light_disabled
 
 		if(CAMERA_WIRE_ALARM)
-			C.visible_message("[html_icon(C)] *beep*", "[html_icon(C)] *beep*")
+			C.visible_message("[icon2html(C, viewers(get_turf(holder)))] *beep*", "[icon2html(C, viewers(get_turf(holder)))] *beep*")
 	return
 
 /datum/wires/camera/proc/CanDeconstruct()

--- a/code/datums/wires/particle_accelerator.dm
+++ b/code/datums/wires/particle_accelerator.dm
@@ -34,7 +34,7 @@ var/const/PARTICLE_LIMIT_POWER_WIRE = 8 // Determines how strong the PA can be.
 			C.interface_control = !C.interface_control
 
 		if(PARTICLE_LIMIT_POWER_WIRE)
-			C.visible_message("[html_icon(C)]<b>[C]</b> makes a large whirring noise.")
+			C.visible_message("[icon2html(C, viewers(get_turf(holder)))]<b>[C]</b> makes a large whirring noise.")
 
 /datum/wires/particle_acc/control_box/UpdateCut(var/index, var/mended)
 	var/obj/machinery/particle_accelerator/control_box/C = holder

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -253,7 +253,7 @@ its easier to just keep the beam vertical.
 			f_name = "a "
 		f_name += "<font color ='[blood_color]'>stained</font> [name][infix]!"
 
-	to_chat(user, "[html_icon(src)] That's [f_name] [suffix]")
+	to_chat(user, "[icon2html(src, user)] That's [f_name] [suffix]")
 	to_chat(user, desc)
 	return TRUE
 

--- a/code/game/gamemodes/godmode/god_pylon.dm
+++ b/code/game/gamemodes/godmode/god_pylon.dm
@@ -65,9 +65,9 @@
 			if(P == src || linked_god.pylon == P)
 				continue
 			P.audible_message("<b>\The [P]</b> resonates, \"[text]\"")
-	to_chat(linked_god, "[html_icon(src)] <span class='game say'><span class='name'>[M]</span> (<A href='?src=\ref[linked_god];jump=\ref[src];'>P</A>) [verb], [linked_god.pylon == src ? "<b>" : ""]<span class='message'><span class='body'>\"[text]\"</span></span>[linked_god.pylon == src ? "</b>" : ""]</span>")
+	to_chat(linked_god, "[icon2html(src, linked_god)] <span class='game say'><span class='name'>[M]</span> (<A href='?src=\ref[linked_god];jump=\ref[src];'>P</A>) [verb], [linked_god.pylon == src ? "<b>" : ""]<span class='message'><span class='body'>\"[text]\"</span></span>[linked_god.pylon == src ? "</b>" : ""]</span>")
 	if(linked_god.minions.len)
 		for(var/minion in linked_god.minions)
 			var/datum/mind/mind = minion
 			if(mind.current && mind.current.eyeobj) //If it is currently having a vision of some sort
-				to_chat(mind.current,"[html_icon(src)] <span class='game say'><span class='name'>[M]</span> (<A href='?src=\ref[src];vision_jump=\ref[src];'>J</A>) [verb], <span class='message'<span class='body'>\"[text]\"</span></span>")
+				to_chat(mind.current,"[icon2html(src, mind.current)] <span class='game say'><span class='name'>[M]</span> (<A href='?src=\ref[src];vision_jump=\ref[src];'>J</A>) [verb], <span class='message'<span class='body'>\"[text]\"</span></span>")

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -311,7 +311,7 @@ Class Procs:
 	set_broken(!!missing, MACHINE_BROKEN_NO_PARTS)
 
 /obj/machinery/proc/state(var/msg)
-	audible_message(SPAN_NOTICE("[html_icon(src)] [msg]"), null, 2)
+	audible_message(SPAN_NOTICE("[icon2html(src, hearers(get_turf(src)))] [msg]"), null, 2)
 
 /obj/machinery/proc/ping(text=null)
 	if (!text)

--- a/code/game/machinery/bodyscanner_console.dm
+++ b/code/game/machinery/bodyscanner_console.dm
@@ -90,10 +90,10 @@
 /obj/machinery/body_scanconsole/OnTopic(mob/user, href_list)
 	if(href_list["scan"])
 		if (!connected.occupant)
-			to_chat(user, "[html_icon(src)]<span class='warning'>The body scanner is empty.</span>")
+			to_chat(user, "[icon2html(src, user)]<span class='warning'>The body scanner is empty.</span>")
 			return TOPIC_REFRESH
 		if (!istype(connected.occupant))
-			to_chat(user, "[html_icon(src)]<span class='warning'>The body scanner cannot scan that lifeform.</span>")
+			to_chat(user, "[icon2html(src, user)]<span class='warning'>The body scanner cannot scan that lifeform.</span>")
 			return TOPIC_REFRESH
 		data["printEnabled"] = TRUE
 		data["eraseEnabled"] = TRUE
@@ -110,7 +110,7 @@
 
 	if (href_list["print"])
 		if (!data["scan"])
-			to_chat(user, "[html_icon(src)]<span class='warning'>Error: No scan stored.</span>")
+			to_chat(user, "[icon2html(src, user)]<span class='warning'>Error: No scan stored.</span>")
 			return TOPIC_REFRESH
 		var/list/scan = data["scan"]
 		new /obj/item/paper/bodyscan(loc, "Printout error.", "Body scan report - [stored_scan_subject]", scan.Copy())
@@ -118,7 +118,7 @@
 
 	if(href_list["push"])		
 		if(!connected_displays.len && !FindDisplays())
-			to_chat(user, "[html_icon(src)]<span class='warning'>Error: No configured displays detected.</span>")
+			to_chat(user, "[icon2html(src, user)]<span class='warning'>Error: No configured displays detected.</span>")
 			return TOPIC_REFRESH
 		for(var/obj/machinery/body_scan_display/D in connected_displays)
 			D.add_new_scan(data["scan"])

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -336,7 +336,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 		end_call()
 	if (caller_id&&sourcepad)
 		if(caller_id.loc!=sourcepad.loc)
-			sourcepad.to_chat(caller_id, "Severing connection to distant holopad.")
+			to_chat(sourcepad.caller_id, "Severing connection to distant holopad.")
 			end_call()
 			audible_message("The connection has been terminated by the caller.")
 	return 1

--- a/code/game/machinery/kitchen/icecream.dm
+++ b/code/game/machinery/kitchen/icecream.dm
@@ -110,7 +110,7 @@
 		var/obj/item/chems/food/snacks/icecream/I = O
 		if(!I.ice_creamed)
 			if(product_types[dispense_flavour] > 0)
-				src.visible_message("[html_icon(src)] <span class='info'>[user] scoops delicious [flavour_name] icecream into [I].</span>")
+				src.visible_message("[icon2html(src, viewers(get_turf(src)))] <span class='info'>[user] scoops delicious [flavour_name] icecream into [I].</span>")
 				product_types[dispense_flavour] -= 1
 				I.add_ice_cream(flavour_name)
 			//	if(beaker)

--- a/code/game/machinery/message_server.dm
+++ b/code/game/machinery/message_server.dm
@@ -102,12 +102,12 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 				Console.icon_state = "req_comp[priority]"
 			if(priority > 1)
 				playsound(Console.loc, 'sound/machines/chime.ogg', 80, 1)
-				Console.audible_message("[html_icon(Console)]<span class='warning'>\The [Console] announces: 'High priority message received from [sender]!'</span>", hearing_distance = 8)
+				Console.audible_message("[icon2html(Console, hearers(get_turf(Console)))]<span class='warning'>\The [Console] announces: 'High priority message received from [sender]!'</span>", hearing_distance = 8)
 				Console.message_log += "<FONT color='red'>High Priority message from <A href='?src=\ref[Console];write=[sender]'>[sender]</A></FONT><BR>[authmsg]"
 			else
 				if(!Console.silent)
 					playsound(Console.loc, 'sound/machines/twobeep.ogg', 50, 1)
-					Console.audible_message("[html_icon(Console)]<span class='notice'>\The [Console] announces: 'Message received from [sender].'</span>", hearing_distance = 5)
+					Console.audible_message("[icon2html(Console, hearers(get_turf(Console)))]<span class='notice'>\The [Console] announces: 'Message received from [sender].'</span>", hearing_distance = 5)
 				Console.message_log += "<B>Message from <A href='?src=\ref[Console];write=[sender]'>[sender]</A></B><BR>[authmsg]"
 			Console.set_light(0.3, 0.1, 2)
 

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -159,7 +159,7 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 				screen = RCS_SENTPASS
 				message_log += "<B>Message sent to [recipient]</B><BR>[message]"
 		else
-			audible_message("[html_icon(src)] *The Requests Console beeps: 'NOTICE: No server detected!'", null, 4)
+			audible_message("[icon2html(src, hearers(get_turf(src)))] *The Requests Console beeps: 'NOTICE: No server detected!'", null, 4)
 		return TOPIC_REFRESH
 
 	//Handle screen switching

--- a/code/game/machinery/vending/_vending.dm
+++ b/code/game/machinery/vending/_vending.dm
@@ -203,7 +203,7 @@
 	if(currently_vending.price > cashmoney.absolute_worth)
 		// This is not a status display message, since it's something the character
 		// themselves is meant to see BEFORE putting the money in
-		to_chat(usr, "[html_icon(cashmoney)] <span class='warning'>That is not enough money.</span>")
+		to_chat(usr, "[icon2html(cashmoney, usr)] <span class='warning'>That is not enough money.</span>")
 		return 0
 	visible_message("<span class='info'>\The [usr] inserts some cash into \the [src].</span>")
 	cashmoney.adjust_worth(-(currently_vending.price))

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -21,8 +21,7 @@
 	if(triggered) return
 
 	if(istype(M, /mob/living/carbon/human))
-		for(var/mob/O in viewers(world.view, src.loc))
-			to_chat(O, "<span class='warning'>\The [M] triggered the [html_icon(src)] [src]</span>")
+		visible_message(SPAN_DANGER("\The [M] triggered [icon2html(src, viewers(get_turf(src)))] \the [src]!"))
 		triggered = 1
 		call(src,triggerproc)(M)
 

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -891,11 +891,11 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 		return user_human.species.get_offset_overlay_image(spritesheet, mob_icon, mob_state, color, use_slot)
 	return overlay_image(mob_icon, mob_state, color, RESET_COLOR)
 
-/obj/item/proc/get_examine_line()
+/obj/item/proc/get_examine_line(var/mob/user)
 	if(blood_color)
-		. = SPAN_WARNING("[html_icon(src)] [gender==PLURAL?"some":"a"] <font color='[blood_color]'>stained</font> [src]")
+		. = SPAN_WARNING("[icon2html(src, user)] [gender==PLURAL?"some":"a"] <font color='[blood_color]'>stained</font> [src]")
 	else
-		. = "[html_icon(src)] \a [src]"
+		. = "[icon2html(src, user)] \a [src]"
 	var/ID = GetIdCard()
 	if(ID)
 		. += "  <a href='?src=\ref[ID];look_at_id=1'>\[Look at ID\]</a>"

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -54,7 +54,7 @@
 	else
 		STOP_PROCESSING(SSobj, src)
 	update_icon()
-	to_chat(user, "<span class='notice'>[html_icon(src)] You switch [scanning ? "on" : "off"] [src].</span>")
+	to_chat(user, "<span class='notice'>[icon2html(src, user)] You switch [scanning ? "on" : "off"] [src].</span>")
 
 /obj/item/geiger/on_update_icon()
 	if(!scanning)

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -18,7 +18,7 @@
 	)
 
 /obj/item/gps/attack_self(var/mob/user)
-	to_chat(user, "<span class='notice'>[html_icon(src)] \The [src] flashes <i>[get_coordinates()]</i>.</span>")
+	to_chat(user, "<span class='notice'>[icon2html(src, user)] \The [src] flashes <i>[get_coordinates()]</i>.</span>")
 
 /obj/item/gps/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/devices/hacktool.dm
+++ b/code/game/objects/items/devices/hacktool.dm
@@ -44,7 +44,7 @@
 		to_chat(user, "<span class='warning'>You are already hacking!</span>")
 		return 1
 	if(!is_type_in_list(target, supported_types))
-		to_chat(user, "[html_icon(src)] <span class='warning'>Unable to hack this target.</span>")
+		to_chat(user, "[icon2html(src, user)] <span class='warning'>Unable to hack this target.</span>")
 		return 0
 	var/found = known_targets.Find(target)
 	if(found)

--- a/code/game/objects/items/devices/scanners/mining.dm
+++ b/code/game/objects/items/devices/scanners/mining.dm
@@ -30,7 +30,7 @@
 		scan_data = scan_results[1]
 	else
 		scan_data += "<hr>[scan_results[1]]"
-	to_chat(user, "[html_icon(src)] <span class='notice'>\The [src] displays a readout.</span>")
+	to_chat(user, "[icon2html(src, user)] <span class='notice'>\The [src] displays a readout.</span>")
 	to_chat(user, scan_results[1])
 
 	if(scan_results[2])

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -302,8 +302,9 @@ var/const/NO_EMAG_ACT = -50
 	return jointext(dat,null)
 
 /obj/item/card/id/attack_self(mob/user)
-	user.visible_message("\The [user] shows you: [html_icon(src)] [src.name]. The assignment on the card: [src.assignment]",\
-		"You flash your ID card: [html_icon(src)] [src.name]. The assignment on the card: [src.assignment]")
+	var/viewing = viewers(get_turf(src))
+	user.visible_message("\The [user] shows you: [icon2html(src, viewing)] [src.name]. The assignment on the card: [src.assignment]",\
+		"You flash your ID card: [icon2html(src, viewing)] [src.name]. The assignment on the card: [src.assignment]")
 
 	src.add_fingerprint(user)
 	return
@@ -319,7 +320,7 @@ var/const/NO_EMAG_ACT = -50
 	set category = "Object"
 	set src in usr
 
-	to_chat(usr, "[html_icon(src)] [name]: The current assignment on the card is [assignment].")
+	to_chat(usr, "[icon2html(src, usr)] [name]: The current assignment on the card is [assignment].")
 	to_chat(usr, "The blood type on the card is [blood_type].")
 	to_chat(usr, "The DNA hash on the card is [dna_hash].")
 	to_chat(usr, "The fingerprint hash on the card is [fingerprint_hash].")

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -56,7 +56,7 @@
 /obj/item/extinguisher/examine(mob/user, distance)
 	. = ..()
 	if(distance <= 0)
-		to_chat(user, "[html_icon(src)] [name] contains [reagents.total_volume] units of water!")
+		to_chat(user, "[icon2html(src, user)] [name] contains [reagents.total_volume] units of water!")
 
 /obj/item/extinguisher/attack_self(mob/user)
 	safety = !safety

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -456,7 +456,7 @@ var/list/global/tank_gauge_cache = list()
 				return
 			T.assume_air(air_contents)
 			playsound(get_turf(src), 'sound/weapons/gunshot/shotgun.ogg', 20, 1)
-			visible_message("[html_icon(src)] <span class='danger'>\The [src] flies apart!</span>", "<span class='warning'>You hear a bang!</span>")
+			visible_message("[icon2html(src, viewers(get_turf(src)))] <span class='danger'>\The [src] flies apart!</span>", "<span class='warning'>You hear a bang!</span>")
 			T.hotspot_expose(air_contents.temperature, 70, 1)
 
 			var/strength = 1+((pressure-TANK_LEAK_PRESSURE)/TANK_FRAGMENT_SCALE)
@@ -487,7 +487,7 @@ var/list/global/tank_gauge_cache = list()
 
 			T.assume_air(leaked_gas)
 			if(!leaking)
-				visible_message("[html_icon(src)] <span class='warning'>\The [src] relief valve flips open with a hiss!</span>", "You hear hissing.")
+				visible_message("[icon2html(src, viewers(get_turf(src)))] <span class='warning'>\The [src] relief valve flips open with a hiss!</span>", "You hear hissing.")
 				playsound(loc, 'sound/effects/spray.ogg', 10, 1, -3)
 				leaking = 1
 				#ifdef FIREDBG

--- a/code/game/objects/items/weapons/weldbackpack.dm
+++ b/code/game/objects/items/weapons/weldbackpack.dm
@@ -80,7 +80,7 @@
 
 /obj/item/weldpack/examine(mob/user)
 	. = ..()
-	to_chat(user, "[html_icon(src)] [reagents.total_volume] unit\s of fuel left!")
+	to_chat(user, "[icon2html(src, user)] [reagents.total_volume] unit\s of fuel left!")
 
 	if(welder)
 		to_chat(user, "\The [welder] is attached.")

--- a/code/game/objects/structures/ironing_board.dm
+++ b/code/game/objects/structures/ironing_board.dm
@@ -45,7 +45,7 @@
 /obj/structure/bed/roller/ironingboard/examine(mob/user)
 	. = ..()
 	if(cloth)
-		to_chat(user, "<span class='notice'>\The [html_icon(cloth)] [cloth] lies on it.</span>")
+		to_chat(user, "<span class='notice'>\The [icon2html(cloth, user)] [cloth] lies on it.</span>")
 
 /obj/structure/bed/roller/ironingboard/on_update_icon()
 	if(density)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -22,8 +22,7 @@
 /obj/structure/janitorialcart/examine(mob/user, distance)
 	. = ..()
 	if(distance <= 1)
-		to_chat(user, "[src] [html_icon(src)] contains [reagents.total_volume] unit\s of liquid!")
-
+		to_chat(user, "[src] [icon2html(src, user)] contains [reagents.total_volume] unit\s of liquid!")
 
 /obj/structure/janitorialcart/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/storage/bag/trash) && !mybag)
@@ -185,7 +184,7 @@
 	if(distance > 1)
 		return
 
-	to_chat(user, "[html_icon(src)] This [callme] contains [reagents.total_volume] unit\s of water!")
+	to_chat(user, "[icon2html(src, user)] This [callme] contains [reagents.total_volume] unit\s of water!")
 	if(mybag)
 		to_chat(user, "\A [mybag] is hanging on the [callme].")
 

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -16,7 +16,7 @@
 /obj/structure/mopbucket/examine(mob/user, distance)
 	. = ..()
 	if(distance <= 1)
-		to_chat(user, "[src] [html_icon(src)] contains [reagents.total_volume] unit\s of water!")
+		to_chat(user, "[src] [icon2html(src, user)] contains [reagents.total_volume] unit\s of water!")
 
 /obj/structure/mopbucket/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/mop))

--- a/code/game/objects/structures/skele_stand.dm
+++ b/code/game/objects/structures/skele_stand.dm
@@ -41,7 +41,7 @@
 		var/list/swagnames = list()
 		for(var/slot in swag)
 			var/obj/item/clothing/C = swag[slot]
-			swagnames += C.get_examine_line()
+			swagnames += C.get_examine_line(user)
 		to_chat(user,"[gender == MALE ? "He" : "She"] is wearing [english_list(swagnames)].")
 
 /obj/structure/skele_stand/attackby(obj/item/W, mob/user)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -458,7 +458,7 @@ var/world_topic_spam_protect_time = world.timeofday
 
 	if(config.server)	//if you set a server location in config.txt, it sends you there instead of trying to reconnect to the same world address. -- NeoFite
 		for(var/client/C in GLOB.clients)
-			to_chat(C, link("byond://[config.server]"))
+			open_link(C, "byond://[config.server]")
 
 	if(config.wait_for_sigusr1_reboot && reason != 3)
 		text2file("foo", "reboot_called")

--- a/code/modules/admin/verbs/massmodvar.dm
+++ b/code/modules/admin/verbs/massmodvar.dm
@@ -72,7 +72,7 @@
 
 	else if(isicon(var_value))
 		to_chat(usr, "Variable appears to be <b>ICON</b>.")
-		var_value = "[html_icon(var_value)]"
+		var_value = "[icon2html(var_value, usr)]"
 		default = "icon"
 
 	else if(istype(var_value,/atom) || istype(var_value,/datum))

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -170,7 +170,7 @@
 
 	else if(isicon(variable))
 		to_chat(usr, "Variable appears to be <b>ICON</b>.")
-		variable = "[html_icon(variable)]"
+		variable = "[icon2html(variable, usr)]"
 		default = "icon"
 
 	else if(istype(variable,/atom) || istype(variable,/datum))
@@ -347,7 +347,7 @@
 
 			else if(isicon(var_value))
 				to_chat(usr, "Variable appears to be <b>ICON</b>.")
-				var_value = "[html_icon(var_value)]"
+				var_value = "[icon2html(var_value, usr)]"
 				class = "icon"
 
 			else if(istype(var_value,/atom) || istype(var_value,/datum))
@@ -402,7 +402,7 @@
 
 		else if(isicon(var_value))
 			to_chat(usr, "Variable appears to be <b>ICON</b>.")
-			var_value = "[html_icon(var_value)]"
+			var_value = "[icon2html(var_value, usr)]"
 			default = "icon"
 
 		else if(istype(var_value,/atom) || istype(var_value,/datum))

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -169,7 +169,7 @@
 	process_activation(var/obj/D, var/normal = 1, var/special = 1)
 		if(!D)	return 0
 		if(!secured)
-			visible_message("[html_icon(src)] *beep* *beep*", "*beep* *beep*")
+			visible_message("[icon2html(src, viewers(get_turf(src)))] *beep* *beep*", "*beep* *beep*")
 		if((normal) && (a_right) && (a_left))
 			if(a_right != D)
 				a_right.pulsed(0)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -107,7 +107,7 @@
 
 	pulse(0)
 	if(!holder)
-		visible_message("[html_icon(src)] *beep* *beep*")
+		visible_message("[icon2html(src, viewers(get_turf(src)))] *beep* *beep*")
 	cooldown = 2
 	spawn(10)
 		process_cooldown()

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -53,12 +53,10 @@
 
 /obj/item/assembly/prox_sensor/sense()
 	var/turf/mainloc = get_turf(src)
-//		if(scanning && cooldown <= 0)
-//			mainloc.visible_message("[html_icon(src)] *boop* *boop*", "*boop* *boop*")
 	if((!holder && !secured)||(!scanning)||(cooldown > 0))	return 0
 	pulse(0)
 	if(!holder)
-		mainloc.visible_message("[html_icon(src)] *beep* *beep*", "*beep* *beep*")
+		mainloc.visible_message("[icon2html(src, viewers(get_turf(src)))] *beep* *beep*", "*beep* *beep*")
 	cooldown = 2
 	spawn(10)
 		process_cooldown()

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -129,7 +129,7 @@
 	if(!(src.wires & WIRE_RADIO_RECEIVE))	return 0
 	pulse(1)
 	if(!holder)
-		audible_message(SPAN_NOTICE("[html_icon(src)] *beep* *beep*"), null, 3)
+		audible_message(SPAN_NOTICE("[icon2html(src, hearers(get_turf(src)))] *beep* *beep*"), null, 3)
 
 /obj/item/assembly/signaler/proc/set_frequency(new_frequency)
 	set waitfor = 0

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -43,7 +43,7 @@
 	if(!secured)	return 0
 	pulse(0)
 	if(!holder)
-		visible_message("[html_icon(src)] *beep* *beep*", "*beep* *beep*")
+		visible_message("[icon2html(src, viewers(get_turf(src)))] *beep* *beep*", "*beep* *beep*")
 	cooldown = 2
 	spawn(10)
 		process_cooldown()

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -24,7 +24,7 @@
 		recorded = msg
 		listening = 0
 		var/turf/T = get_turf(src)	//otherwise it won't work in hand
-		T.visible_message("[html_icon(src)] beeps, \"Activation message is '[recorded]'.\"")
+		T.visible_message("[icon2html(src, viewers(get_turf(src)))] beeps, \"Activation message is '[recorded]'.\"")
 	else
 		if(findtext(msg, recorded))
 			pulse(0)
@@ -34,7 +34,7 @@
 		if(!holder)
 			listening = !listening
 			var/turf/T = get_turf(src)
-			T.visible_message("[html_icon(src)] beeps, \"[listening ? "Now" : "No longer"] recording input.\"")
+			T.visible_message("[icon2html(src, viewers(get_turf(src)))] beeps, \"[listening ? "Now" : "No longer"] recording input.\"")
 
 
 /obj/item/assembly/voice/attack_self(mob/user)

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -144,12 +144,12 @@
 		else
 			icon = initial(icon)
 
-/obj/item/clothing/get_examine_line()
+/obj/item/clothing/get_examine_line(var/mob/user)
 	. = ..()
 	var/list/ties = list()
 	for(var/obj/item/clothing/accessory/accessory in accessories)
 		if(accessory.high_visibility)
-			ties += "\a [accessory.get_examine_line()]"
+			ties += "\a [accessory.get_examine_line(user)]"
 	if(ties.len)
 		.+= " with [english_list(ties)] attached"
 	if(accessories.len > ties.len)
@@ -170,14 +170,14 @@
 			if(length(accessories) && can_see)
 				var/list/ties = list()
 				for(var/accessory in accessories)
-					ties += "[html_icon(accessory)] \a [accessory]"
+					ties += "[icon2html(accessory, user)] \a [accessory]"
 				to_chat(user, "Attached to \the [src] are [english_list(ties)].")
 			return TOPIC_HANDLED
 		if(href_list["list_armor_damage"] && can_see)
 			var/datum/extension/armor/ablative/armor_datum = get_extension(src, /datum/extension/armor)
 			if(istype(armor_datum))
 				var/list/damages = armor_datum.get_visible_damage()
-				to_chat(user, "\The [src] [html_icon(src)] has some damage:")
+				to_chat(user, "\The [src] [icon2html(src, user)] has some damage:")
 				for(var/key in damages)
 					to_chat(user, "<li><b>[capitalize(damages[key])]</b> damage to the <b>[key]</b> armor.")
 			return TOPIC_HANDLED

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -71,7 +71,7 @@
 /obj/item/clothing/examine(mob/user)
 	. = ..()
 	for(var/obj/item/clothing/accessory/A in accessories)
-		to_chat(user, "[html_icon(A)] \A [A] is attached to it.")
+		to_chat(user, "[icon2html(A)] \A [A] is attached to it.")
 	switch(ironed_state)
 		if(WRINKLES_WRINKLY)
 			to_chat(user, "<span class='bad'>It's wrinkly.</span>")

--- a/code/modules/clothing/rings/material.dm
+++ b/code/modules/clothing/rings/material.dm
@@ -29,7 +29,7 @@
 				user.examinate(src)
 				return TOPIC_HANDLED
 
-/obj/item/clothing/ring/material/get_examine_line()
+/obj/item/clothing/ring/material/get_examine_line(var/mob/user)
 	. = ..()
 	. += " <a href='?src=\ref[src];examine=1'>\[View\]</a>"
 

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -112,7 +112,7 @@
 		for(var/obj/item/piece in list(helmet,gloves,chest,boots))
 			if(!piece || piece.loc != wearer)
 				continue
-			to_chat(user, "[html_icon(piece)] \The [piece] [piece.gender == PLURAL ? "are" : "is"] deployed.")
+			to_chat(user, "[icon2html(piece, user)] \The [piece] [piece.gender == PLURAL ? "are" : "is"] deployed.")
 
 	if(src.loc == user)
 		to_chat(user, "The access panel is [locked? "locked" : "unlocked"].")

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -23,7 +23,7 @@
 
 /obj/item/clothing/accessory/badge/proc/set_desc(var/mob/living/carbon/human/H)
 
-/obj/item/clothing/accessory/badge/get_examine_line()
+/obj/item/clothing/accessory/badge/get_examine_line(var/mob/user)
 	. = ..()
 	. += "  <a href='?src=\ref[src];look_at_me=1'>\[View\]</a>"
 

--- a/code/modules/economy/cael/ATM.dm
+++ b/code/modules/economy/cael/ATM.dm
@@ -75,14 +75,14 @@
 
 		//display a message to the user
 		var/response = pick("Initiating withdraw. Have a nice day!", "CRITICAL ERROR: Activating cash chamber panic siphon.","PIN Code accepted! Emptying account balance.", "Jackpot!")
-		to_chat(user, "[html_icon(src)] <span class='warning'>[src] beeps: \"[response]\"</span>")
+		to_chat(user, "[icon2html(src, user)] <span class='warning'>[src] beeps: \"[response]\"</span>")
 		return 1
 
 /obj/machinery/atm/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/card))
 		if(emagged > 0)
 			//prevent inserting id into an emagged ATM
-			to_chat(user, "[html_icon(src)] <span class='warning'>CARD READER ERROR. This system has been compromised!</span>")
+			to_chat(user, "[icon2html(src, user)] <span class='warning'>CARD READER ERROR. This system has been compromised!</span>")
 			return
 		if(stat & NOPOWER)
 			to_chat(user, "You try to insert your card into [src], but nothing happens.")
@@ -121,7 +121,7 @@
 /obj/machinery/atm/interact(mob/user)
 
 	if(istype(user, /mob/living/silicon))
-		to_chat(user, "[html_icon(src)] <span class='warning'>Artificial unit recognized. Artificial units do not currently receive monetary compensation, as per system banking regulation #1005.</span>")
+		to_chat(user, "[icon2html(src, user)] <span class='warning'>Artificial unit recognized. Artificial units do not currently receive monetary compensation, as per system banking regulation #1005.</span>")
 		return
 
 	if(get_dist(src,user) <= 1)
@@ -255,12 +255,12 @@
 						var/transfer_purpose = href_list["purpose"]
 						var/datum/money_account/target_account = get_account(target_account_number)
 						if(target_account && authenticated_account.transfer(target_account, transfer_amount, transfer_purpose))
-							to_chat(usr, "[html_icon(src)]<span class='info'>Funds transfer successful.</span>")
+							to_chat(usr, "[icon2html(src, usr)]<span class='info'>Funds transfer successful.</span>")
 						else
-							to_chat(usr, "[html_icon(src)]<span class='warning'>Funds transfer failed.</span>")
+							to_chat(usr, "[icon2html(src, usr)]<span class='warning'>Funds transfer failed.</span>")
 
 					else
-						to_chat(usr, "[html_icon(src)]<span class='warning'>You don't have enough funds to do that!</span>")
+						to_chat(usr, "[icon2html(src, usr)]<span class='warning'>You don't have enough funds to do that!</span>")
 			if("view_screen")
 				view_screen = text2num(href_list["view_screen"])
 			if("change_security_level")
@@ -308,11 +308,11 @@
 								if(failed_account)
 									failed_account.log_msg("Unauthorized login attempt", machine_id)
 							else
-								to_chat(usr, "[html_icon(src)] <span class='warning'>Incorrect pin/account combination entered, [max_pin_attempts - number_incorrect_tries] attempts remaining.</span>")
+								to_chat(usr, "[icon2html(src, usr)] <span class='warning'>Incorrect pin/account combination entered, [max_pin_attempts - number_incorrect_tries] attempts remaining.</span>")
 								previous_account_number = tried_account_num
 								playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 1)
 						else
-							to_chat(usr, "[html_icon(src)] <span class='warning'>Unable to log in to account, additional information may be required.</span>")
+							to_chat(usr, "[icon2html(src, usr)] <span class='warning'>Unable to log in to account, additional information may be required.</span>")
 							number_incorrect_tries = 0
 					else
 						playsound(src, 'sound/machines/twobeep.ogg', 50, 1)
@@ -322,7 +322,7 @@
 						//create a transaction log entry
 						authenticated_account.log_msg("Remote terminal access", machine_id)
 
-						to_chat(usr, "[html_icon(src)] <span class='info'>Access granted. Welcome user '[authenticated_account.owner_name].'</span>")
+						to_chat(usr, "[icon2html(src, usr)] <span class='info'>Access granted. Welcome user '[authenticated_account.owner_name].'</span>")
 
 					previous_account_number = tried_account_num
 			if("e_withdrawal")
@@ -343,7 +343,7 @@
 						E.creator = authenticated_account.owner_name
 						usr.put_in_hands(E)
 					else
-						to_chat(usr, "[html_icon(src)]<span class='warning'>You don't have enough funds to do that!</span>")
+						to_chat(usr, "[icon2html(src, usr)]<span class='warning'>You don't have enough funds to do that!</span>")
 			if("withdrawal")
 				var/amount = max(text2num(href_list["funds_amount"]),0)
 				amount = round(amount, 0.01)
@@ -357,7 +357,7 @@
 						cash.adjust_worth(amount)
 						usr.put_in_hands(src)
 					else
-						to_chat(usr, "[html_icon(src)]<span class='warning'>You don't have enough funds to do that!</span>")
+						to_chat(usr, "[icon2html(src, usr)]<span class='warning'>You don't have enough funds to do that!</span>")
 			if("balance_statement")
 				if(authenticated_account)
 					var/obj/item/paper/R = new(src.loc)
@@ -429,7 +429,7 @@
 				if(!held_card)
 					//this might happen if the user had the browser window open when somebody emagged it
 					if(emagged > 0)
-						to_chat(usr, "[html_icon(src)] <span class='warning'>The ATM card reader rejected your ID because this machine has been sabotaged!</span>")
+						to_chat(usr, "[icon2html(src, usr)] <span class='warning'>The ATM card reader rejected your ID because this machine has been sabotaged!</span>")
 					else
 						var/obj/item/I = usr.get_active_hand()
 						if (istype(I, /obj/item/card/id))

--- a/code/modules/economy/cael/EFTPOS.dm
+++ b/code/modules/economy/cael/EFTPOS.dm
@@ -108,7 +108,7 @@
 		if(linked_account)
 			scan_card(I, O)
 		else
-			to_chat(usr, "[html_icon(src)]<span class='warning'>Unable to connect to linked account.</span>")
+			to_chat(usr, "[icon2html(src, usr)]<span class='warning'>Unable to connect to linked account.</span>")
 	else if (istype(O, /obj/item/charge_stick))
 		var/obj/item/charge_stick/E = O
 		if (linked_account)
@@ -120,14 +120,14 @@
 					if(linked_account.deposit(transaction_amount, purpose, machine_id))
 						E.adjust_worth(-(transaction_amount))
 						playsound(src, 'sound/machines/chime.ogg', 50, 1)
-						visible_message("[html_icon(src)] \The [src] chimes.")
+						visible_message("[icon2html(src, viewers(get_turf(src)))] \The [src] chimes.")
 						transaction_paid = 1
 					else
-						to_chat(usr, "[html_icon(src)]<span class='warning'>Transaction failed! Please try again.</span>")
+						to_chat(usr, "[icon2html(src, usr)]<span class='warning'>Transaction failed! Please try again.</span>")
 				else
-					to_chat(usr, "[html_icon(src)]<span class='warning'>\The [O] doesn't have that much money!</span>")
+					to_chat(usr, "[icon2html(src, usr)]<span class='warning'>\The [O] doesn't have that much money!</span>")
 		else
-			to_chat(usr, "[html_icon(src)]<span class='warning'>EFTPOS is not connected to an account.</span>")
+			to_chat(usr, "[icon2html(src, usr)]<span class='warning'>EFTPOS is not connected to an account.</span>")
 
 	else
 		..()
@@ -145,14 +145,14 @@
 						alert("That is not a valid code!")
 					print_reference()
 				else
-					to_chat(usr, "[html_icon(src)]<span class='warning'>Incorrect code entered.</span>")
+					to_chat(usr, "[icon2html(src, usr)]<span class='warning'>Incorrect code entered.</span>")
 			if("change_id")
 				var/attempt_code = text2num(input("Re-enter the current EFTPOS access code", "Confirm EFTPOS code"))
 				if(attempt_code == access_code)
 					eftpos_name = sanitize(input("Enter a new terminal ID for this device", "Enter new EFTPOS ID"), MAX_NAME_LEN) + " EFTPOS scanner"
 					print_reference()
 				else
-					to_chat(usr, "[html_icon(src)]<span class='warning'>Incorrect code entered.</span>")
+					to_chat(usr, "[icon2html(src, usr)]<span class='warning'>Incorrect code entered.</span>")
 			if("link_account")
 				var/attempt_account_num = input("Enter account number to pay EFTPOS charges into", "New account number") as num
 				var/attempt_pin = input("Enter pin code", "Account pin") as num
@@ -160,9 +160,9 @@
 				if(linked_account)
 					if(linked_account.suspended)
 						linked_account = null
-						to_chat(usr, "[html_icon(src)]<span class='warning'>Account has been suspended.</span>")
+						to_chat(usr, "[icon2html(src, usr)]<span class='warning'>Account has been suspended.</span>")
 				else
-					to_chat(usr, "[html_icon(src)]<span class='warning'>Account not found.</span>")
+					to_chat(usr, "[icon2html(src, usr)]<span class='warning'>Account not found.</span>")
 			if("trans_purpose")
 				var/choice = sanitize(input("Enter reason for EFTPOS transaction", "Transaction purpose"))
 				if(choice) transaction_purpose = choice
@@ -185,14 +185,14 @@
 				else if(linked_account)
 					transaction_locked = 1
 				else
-					to_chat(usr, "[html_icon(src)]<span class='warning'>No account connected to send transactions to.</span>")
+					to_chat(usr, "[icon2html(src, usr)]<span class='warning'>No account connected to send transactions to.</span>")
 			if("scan_card")
 				if(linked_account)
 					var/obj/item/I = usr.get_active_hand()
 					if (istype(I, /obj/item/card))
 						scan_card(I)
 				else
-					to_chat(usr, "[html_icon(src)]<span class='warning'>Unable to link accounts.</span>")
+					to_chat(usr, "[icon2html(src, usr)]<span class='warning'>Unable to link accounts.</span>")
 			if("reset")
 				//reset the access code - requires HoP/captain access
 				var/obj/item/I = usr.get_active_hand()
@@ -200,10 +200,10 @@
 					var/obj/item/card/id/C = I
 					if((access_cent_captain in C.access) || (access_hop in C.access) || (access_captain in C.access))
 						access_code = 0
-						to_chat(usr, "[html_icon(src)]<span class='info'>Access code reset to 0.</span>")
+						to_chat(usr, "[icon2html(src, usr)]<span class='info'>Access code reset to 0.</span>")
 				else if (istype(I, /obj/item/card/emag))
 					access_code = 0
-					to_chat(usr, "[html_icon(src)]<span class='info'>Access code reset to 0.</span>")
+					to_chat(usr, "[icon2html(src, usr)]<span class='info'>Access code reset to 0.</span>")
 
 	src.attack_self(usr)
 
@@ -227,26 +227,26 @@
 						//transfer the money
 						if(D.transfer(linked_account, transaction_amount, "[transaction_purpose] (via [eftpos_name]/[machine_id])"))
 							playsound(src, 'sound/machines/chime.ogg', 50, 1)
-							src.visible_message("[html_icon(src)] \The [src] chimes.")
+							src.visible_message("[icon2html(src, usr)] \The [src] chimes.")
 							transaction_paid = 1
 						else
-							to_chat(usr, "[html_icon(src)]<span class='warning'>Transaction failed! Please try again.</span>")
+							to_chat(usr, "[icon2html(src, usr)]<span class='warning'>Transaction failed! Please try again.</span>")
 					else
-						to_chat(usr, "[html_icon(src)]<span class='warning'>Unable to access account. Check security settings and try again.</span>")
+						to_chat(usr, "[icon2html(src, usr)]<span class='warning'>Unable to access account. Check security settings and try again.</span>")
 				else
-					to_chat(usr, "[html_icon(src)]<span class='warning'>Connected account has been suspended.</span>")
+					to_chat(usr, "[icon2html(src, usr)]<span class='warning'>Connected account has been suspended.</span>")
 			else
-				to_chat(usr, "[html_icon(src)]<span class='warning'>EFTPOS is not connected to an account.</span>")
+				to_chat(usr, "[icon2html(src, usr)]<span class='warning'>EFTPOS is not connected to an account.</span>")
 	else if (istype(I, /obj/item/card/emag))
 		if(transaction_locked)
 			if(transaction_paid)
-				to_chat(usr, "[html_icon(src)]<span class='info'>You stealthily swipe \the [I] through \the [src].</span>")
+				to_chat(usr, "[icon2html(src, usr)]<span class='info'>You stealthily swipe \the [I] through \the [src].</span>")
 				transaction_locked = 0
 				transaction_paid = 0
 			else
 				usr.visible_message("<span class='info'>\The [usr] swipes a card through \the [src].</span>")
 				playsound(src, 'sound/machines/chime.ogg', 50, 1)
-				src.visible_message("[html_icon(src)] \The [src] chimes.")
+				src.visible_message("[icon2html(src, usr)] \The [src] chimes.")
 				transaction_paid = 1
 
 	//emag?

--- a/code/modules/economy/worth_cash.dm
+++ b/code/modules/economy/worth_cash.dm
@@ -229,20 +229,20 @@
 			to_chat(user, SPAN_WARNING("Cannot transfer funds from a locked [W]."))
 			return TRUE
 		if(sender.currency != currency)
-			to_chat(user, SPAN_WARNING("[html_icon(src)] [src] chirps, \"Mismatched currency detected. Unable to transfer.\""))
+			to_chat(user, SPAN_WARNING("[icon2html(src, user)] [src] chirps, \"Mismatched currency detected. Unable to transfer.\""))
 			return TRUE
 		var/amount = input(user, "How much of [sender.loaded_worth] do you want to transfer?", "[sender] transfer", "0") as null|num
 		if(!amount)
 			return TRUE
 		if(amount < 0 || amount > sender.loaded_worth)
-			to_chat(user, SPAN_NOTICE("[html_icon(src)] [src] chirps, \"Enter a valid number between 1 and [sender.loaded_worth] to transfer.\""))
+			to_chat(user, SPAN_NOTICE("[icon2html(src, user)] [src] chirps, \"Enter a valid number between 1 and [sender.loaded_worth] to transfer.\""))
 			return TRUE
 		sender.loaded_worth -= amount
 		loaded_worth += amount
 		sender.update_icon()
 		update_icon()
 		var/decl/currency/cur = decls_repository.get_decl(currency)
-		to_chat(user, SPAN_NOTICE("[html_icon(src)] [src] chirps, \"Completed transfer of [amount] [cur.name].\""))
+		to_chat(user, SPAN_NOTICE("[icon2html(src, user)] [src] chirps, \"Completed transfer of [amount] [cur.name].\""))
 		return TRUE
 	
 	if(lock.attackby(W, user))

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -54,15 +54,15 @@
 	active = 0
 	if(failed_task)
 		failed_task = 0
-		visible_message("[html_icon(src)] [src] pings unhappily, flashing a red warning light.")
+		visible_message("[icon2html(src, viewers(get_turf(src)))] [src] pings unhappily, flashing a red warning light.")
 	else
-		visible_message("[html_icon(src)] [src] pings happily.")
+		visible_message("[icon2html(src, viewers(get_turf(src)))] [src] pings happily.")
 
 	if(eject_disk)
 		eject_disk = 0
 		if(loaded_disk)
 			loaded_disk.dropInto(loc)
-			visible_message("[html_icon(src)] [src] beeps and spits out [loaded_disk].")
+			visible_message("[icon2html(src, viewers(get_turf(src)))] [src] beeps and spits out [loaded_disk].")
 			loaded_disk = null
 
 /obj/machinery/botany/attackby(obj/item/W, mob/user)
@@ -173,14 +173,14 @@
 			SSplants.seeds[seed.seed.name] = seed.seed
 
 		seed.update_seed()
-		visible_message("[html_icon(src)] [src] beeps and spits out [seed].")
+		visible_message("[icon2html(src, viewers(get_turf(src)))] [src] beeps and spits out [seed].")
 
 		seed = null
 
 	if(href_list["eject_disk"])
 		if(!loaded_disk) return
 		loaded_disk.dropInto(loc)
-		visible_message("[html_icon(src)] [src] beeps and spits out [loaded_disk].")
+		visible_message("[icon2html(src, viewers(get_turf(src)))] [src] beeps and spits out [loaded_disk].")
 		loaded_disk = null
 
 	usr.set_machine(src)

--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -48,7 +48,7 @@
 	var/list/nearby_things = range(0, get_turf(src))
 	for(var/mob/M in nearby_things)
 		var/obj/O = assembly ? assembly : src
-		to_chat(M, "<span class='notice'>[html_icon(O)] [stuff_to_display]</span>")
+		to_chat(M, "<span class='notice'>[icon2html(O)] [stuff_to_display]</span>")
 
 /obj/item/integrated_circuit/output/screen/large
 	name = "large screen"
@@ -60,7 +60,7 @@
 /obj/item/integrated_circuit/output/screen/large/do_work()
 	..()
 	var/obj/O = assembly ? get_turf(assembly) : loc
-	O.visible_message("<span class='notice'>[html_icon(O)]  [stuff_to_display]</span>")
+	O.visible_message("<span class='notice'>[icon2html(O)]  [stuff_to_display]</span>")
 
 /obj/item/integrated_circuit/output/light
 	name = "light"

--- a/code/modules/mob/living/bot/remotebot.dm
+++ b/code/modules/mob/living/bot/remotebot.dm
@@ -22,7 +22,7 @@
 /mob/living/bot/remotebot/examine(mob/user)
 	. = ..()
 	if(holding)
-		to_chat(user, "<span class='notice'>It is holding \the [html_icon(holding)] [holding].</span>")
+		to_chat(user, "<span class='notice'>It is holding \the [icon2html(holding, user)] [holding].</span>")
 
 /mob/living/bot/remotebot/explode()
 	on = 0

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -32,14 +32,14 @@
 	if(distance > 3)
 		skipears = 1
 
-	var/list/msg = list("<span class='info'>*---------*\nThis is ")
+	var/list/msg = list("<span class='info'>*---------*<BR>This is ")
 
 	var/datum/gender/T = gender_datums[get_gender()]
 	if(skipjumpsuit && skipface) //big suits/masks/helmets make it hard to tell their gender
 		T = gender_datums[PLURAL]
 	else
 		if(icon)
-			msg += "[html_icon(icon)] " //fucking BYOND: this should stop dreamseeker crashing if we -somehow- examine somebody before their icon is generated
+			msg += "[icon2html(icon, user)] " //fucking BYOND: this should stop dreamseeker crashing if we -somehow- examine somebody before their icon is generated
 
 	if(!T)
 		// Just in case someone VVs the gender to something strange. It'll runtime anyway when it hits usages, better to CRASH() now with a helpful message.
@@ -58,91 +58,91 @@
 
 	var/extra_species_text = species.get_additional_examine_text(src)
 	if(extra_species_text)
-		msg += "[extra_species_text]<br>"
+		msg += "[extra_species_text]<BR>"
 
-	msg += "<br>"
+	msg += "<BR>"
 
 	//uniform
 	if(w_uniform && !skipjumpsuit)
-		msg += "[T.He] [T.is] wearing [w_uniform.get_examine_line()].\n"
+		msg += "[T.He] [T.is] wearing [w_uniform.get_examine_line(user)].<BR>"
 
 	//head
 	if(head)
-		msg += "[T.He] [T.is] wearing [head.get_examine_line()] on [T.his] head.\n"
+		msg += "[T.He] [T.is] wearing [head.get_examine_line(user)] on [T.his] head.<BR>"
 
 	//suit/armour
 	if(wear_suit)
-		msg += "[T.He] [T.is] wearing [wear_suit.get_examine_line()].\n"
+		msg += "[T.He] [T.is] wearing [wear_suit.get_examine_line(user)].<BR>"
 		//suit/armour storage
 		if(s_store && !skipsuitstorage)
-			msg += "[T.He] [T.is] carrying [s_store.get_examine_line()] on [T.his] [wear_suit.name].\n"
+			msg += "[T.He] [T.is] carrying [s_store.get_examine_line(user)] on [T.his] [wear_suit.name].<BR>"
 
 	//back
 	if(back)
-		msg += "[T.He] [T.has] [back.get_examine_line()] on [T.his] back.\n"
+		msg += "[T.He] [T.has] [back.get_examine_line(user)] on [T.his] back.<BR>"
 
 	//held items
 	for(var/bp in held_item_slots)
 		var/datum/inventory_slot/inv_slot = LAZYACCESS(held_item_slots, bp)
 		var/obj/item/organ/external/E = organs_by_name[bp]
 		if(inv_slot?.holding)
-			msg += "[T.He] [T.is] holding [inv_slot.holding.get_examine_line()] in [T.his] [E.name].\n"
+			msg += "[T.He] [T.is] holding [inv_slot.holding.get_examine_line()] in [T.his] [E.name].<BR>"
 
 	//gloves
 	if(gloves && !skipgloves)
-		msg += "[T.He] [T.has] [gloves.get_examine_line()] on [T.his] hands.\n"
+		msg += "[T.He] [T.has] [gloves.get_examine_line(user)] on [T.his] hands.<BR>"
 	else if(blood_DNA)
-		msg += "<span class='warning'>[T.He] [T.has] [(hand_blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained hands!</span>\n"
+		msg += "<span class='warning'>[T.He] [T.has] [(hand_blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained hands!</span><BR>"
 
 	//belt
 	if(belt)
-		msg += "[T.He] [T.has] [belt.get_examine_line()] about [T.his] waist.\n"
+		msg += "[T.He] [T.has] [belt.get_examine_line(user)] about [T.his] waist.<BR>"
 
 	//shoes
 	if(shoes && !skipshoes)
-		msg += "[T.He] [T.is] wearing [shoes.get_examine_line()] on [T.his] feet.\n"
+		msg += "[T.He] [T.is] wearing [shoes.get_examine_line(user)] on [T.his] feet.<BR>"
 	else if(feet_blood_DNA)
-		msg += "<span class='warning'>[T.He] [T.has] [(feet_blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained feet!</span>\n"
+		msg += "<span class='warning'>[T.He] [T.has] [(feet_blood_color != SYNTH_BLOOD_COLOUR) ? "blood" : "oil"]-stained feet!</span><BR>"
 
 	//mask
 	if(wear_mask && !skipmask)
-		msg += "[T.He] [T.has] [wear_mask.get_examine_line()] on [T.his] face.\n"
+		msg += "[T.He] [T.has] [wear_mask.get_examine_line(user)] on [T.his] face.<BR>"
 
 	//eyes
 	if(glasses && !skipeyes)
-		msg += "[T.He] [T.has] [glasses.get_examine_line()] covering [T.his] eyes.\n"
+		msg += "[T.He] [T.has] [glasses.get_examine_line(user)] covering [T.his] eyes.<BR>"
 
 	//left ear
 	if(l_ear && !skipears)
-		msg += "[T.He] [T.has] [l_ear.get_examine_line()] on [T.his] left ear.\n"
+		msg += "[T.He] [T.has] [l_ear.get_examine_line(user)] on [T.his] left ear.<BR>"
 
 	//right ear
 	if(r_ear && !skipears)
-		msg += "[T.He] [T.has] [r_ear.get_examine_line()] on [T.his] right ear.\n"
+		msg += "[T.He] [T.has] [r_ear.get_examine_line(user)] on [T.his] right ear.<BR>"
 
 	//ID
 	if(wear_id)
-		msg += "[T.He] [T.is] wearing [wear_id.get_examine_line()].\n"
+		msg += "[T.He] [T.is] wearing [wear_id.get_examine_line(user)].<BR>"
 
 	//handcuffed?
 	if(handcuffed)
 		if(istype(handcuffed, /obj/item/handcuffs/cable))
-			msg += "<span class='warning'>[T.He] [T.is] [html_icon(handcuffed)] restrained with cable!</span>\n"
+			msg += "<span class='warning'>[T.He] [T.is] [icon2html(handcuffed, user)] restrained with cable!</span><BR>"
 		else
-			msg += "<span class='warning'>[T.He] [T.is] [html_icon(handcuffed)] handcuffed!</span>\n"
+			msg += "<span class='warning'>[T.He] [T.is] [icon2html(handcuffed, user)] handcuffed!</span><BR>"
 
 	//buckled
 	if(buckled)
-		msg += "<span class='warning'>[T.He] [T.is] [html_icon(buckled)] buckled to [buckled]!</span>\n"
+		msg += "<span class='warning'>[T.He] [T.is] [icon2html(buckled, user)] buckled to [buckled]!</span><BR>"
 
 	//Jitters
 	if(is_jittery)
 		if(jitteriness >= 300)
-			msg += "<span class='warning'><B>[T.He] [T.is] convulsing violently!</B></span>\n"
+			msg += "<span class='warning'><B>[T.He] [T.is] convulsing violently!</B></span><BR>"
 		else if(jitteriness >= 200)
-			msg += "<span class='warning'>[T.He] [T.is] extremely jittery.</span>\n"
+			msg += "<span class='warning'>[T.He] [T.is] extremely jittery.</span><BR>"
 		else if(jitteriness >= 100)
-			msg += "<span class='warning'>[T.He] [T.is] twitching ever so slightly.</span>\n"
+			msg += "<span class='warning'>[T.He] [T.is] twitching ever so slightly.</span><BR>"
 
 	//Disfigured face
 	if(!skipface) //Disfigurement only matters for the head currently.
@@ -151,21 +151,21 @@
 			if(E.species) //Check to make sure we have a species
 				msg += E.species.disfigure_msg(src)
 			else //Just in case they lack a species for whatever reason.
-				msg += "<span class='warning'>[T.His] face is horribly mangled!</span>\n"
+				msg += "<span class='warning'>[T.His] face is horribly mangled!</span><BR>"
 
 	//splints
 	for(var/organ in list(BP_L_LEG, BP_R_LEG, BP_L_ARM, BP_R_ARM))
 		var/obj/item/organ/external/o = get_organ(organ)
 		if(o && o.splinted && o.splinted.loc == o)
-			msg += "<span class='warning'>[T.He] [T.has] \a [o.splinted] on [T.his] [o.name]!</span>\n"
+			msg += "<span class='warning'>[T.He] [T.has] \a [o.splinted] on [T.his] [o.name]!</span><BR>"
 
 	if(mSmallsize in mutations)
-		msg += "[T.He] [T.is] small halfling!\n"
+		msg += "[T.He] [T.is] small halfling!<BR>"
 
 	if (src.stat)
-		msg += "<span class='warning'>[T.He] [T.is]n't responding to anything around [T.him] and seems to be unconscious.</span>\n"
+		msg += "<span class='warning'>[T.He] [T.is]n't responding to anything around [T.him] and seems to be unconscious.</span><BR>"
 		if((stat == DEAD || is_asystole() || src.losebreath) && distance <= 3)
-			msg += "<span class='warning'>[T.He] [T.does] not appear to be breathing.</span>\n"
+			msg += "<span class='warning'>[T.He] [T.does] not appear to be breathing.</span><BR>"
 		if(ishuman(user) && !user.incapacitated() && Adjacent(user))
 			spawn(0)
 				user.visible_message("<b>\The [user]</b> checks \the [src]'s pulse.", "You check \the [src]'s pulse.")
@@ -176,28 +176,28 @@
 						to_chat(user, "<span class='deadsay'>[T.He] [T.has] a pulse!</span>")
 
 	if(fire_stacks > 0)
-		msg += "[T.He] is covered in flammable liquid!\n"
+		msg += "[T.He] is covered in flammable liquid!<BR>"
 	else if(fire_stacks < 0)
-		msg += "[T.He] [T.is] soaking wet.\n"
+		msg += "[T.He] [T.is] soaking wet.<BR>"
 
 	if(on_fire)
-		msg += "<span class='warning'>[T.He] [T.is] on fire!.</span>\n"
+		msg += "<span class='warning'>[T.He] [T.is] on fire!.</span><BR>"
 
 	var/ssd_msg = species.get_ssd(src)
 	if(ssd_msg && (!should_have_organ(BP_BRAIN) || has_brain()) && stat != DEAD)
 		if(!key)
-			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg]. It doesn't look like [T.he] [T.is] waking up anytime soon.</span>\n"
+			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg]. It doesn't look like [T.he] [T.is] waking up anytime soon.</span><BR>"
 		else if(!client)
-			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg].</span>\n"
+			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg].</span><BR>"
 
 	var/obj/item/organ/external/head/H = organs_by_name[BP_HEAD]
 	if(istype(H) && H.forehead_graffiti && H.graffiti_style)
-		msg += "<span class='notice'>[T.He] [T.has] \"[H.forehead_graffiti]\" written on [T.his] [H.name] in [H.graffiti_style]!</span>\n"
+		msg += "<span class='notice'>[T.He] [T.has] \"[H.forehead_graffiti]\" written on [T.his] [H.name] in [H.graffiti_style]!</span><BR>"
 
 	if(became_younger)
-		msg += "[T.He] looks a lot younger than you remember.\n"
+		msg += "[T.He] looks a lot younger than you remember.<BR>"
 	if(became_older)
-		msg += "[T.He] looks a lot older than you remember.\n"
+		msg += "[T.He] looks a lot older than you remember.<BR>"
 
 	var/list/wound_flavor_text = list()
 	var/applying_pressure = ""
@@ -211,13 +211,13 @@
 		var/obj/item/organ/external/E = organs_by_name[organ_tag]
 
 		if(!E)
-			wound_flavor_text[organ_descriptor] = "<b>[T.He] [T.is] missing [T.his] [organ_descriptor].</b>\n"
+			wound_flavor_text[organ_descriptor] = "<b>[T.He] [T.is] missing [T.his] [organ_descriptor].</b><BR>"
 			continue
 
 		wound_flavor_text[E.name] = ""
 
 		if(E.applied_pressure == src)
-			applying_pressure = "<span class='info'>[T.He] [T.is] applying pressure to [T.his] [E.name].</span><br>"
+			applying_pressure = "<span class='info'>[T.He] [T.is] applying pressure to [T.his] [E.name].</span><BR>"
 
 		var/obj/item/clothing/hidden
 		var/list/clothing_items = list(head, wear_mask, wear_suit, w_uniform, gloves, shoes)
@@ -233,20 +233,20 @@
 				hidden_bleeders[hidden] += E.name
 		else
 			if(E.is_stump())
-				wound_flavor_text[E.name] += "<b>[T.He] [T.has] a stump where [T.his] [organ_descriptor] should be.</b>\n"
+				wound_flavor_text[E.name] += "<b>[T.He] [T.has] a stump where [T.his] [organ_descriptor] should be.</b><BR>"
 				if(LAZYLEN(E.wounds) && E.parent)
-					wound_flavor_text[E.name] += "[T.He] [T.has] [E.get_wounds_desc()] on [T.his] [E.parent.name].<br>"
+					wound_flavor_text[E.name] += "[T.He] [T.has] [E.get_wounds_desc()] on [T.his] [E.parent.name].<BR>"
 			else
 				if(!is_synth && BP_IS_PROSTHETIC(E) && (E.parent && !BP_IS_PROSTHETIC(E.parent) && !BP_IS_ASSISTED(E.parent)))
-					wound_flavor_text[E.name] = "[T.He] [T.has] a [E.name].\n"
+					wound_flavor_text[E.name] = "[T.He] [T.has] a [E.name].<BR>"
 				var/wounddesc = E.get_wounds_desc()
 				if(wounddesc != "nothing")
-					wound_flavor_text[E.name] += "[T.He] [T.has] [wounddesc] on [T.his] [E.name].<br>"
+					wound_flavor_text[E.name] += "[T.He] [T.has] [wounddesc] on [T.his] [E.name].<BR>"
 		if(!hidden || distance <=1)
 			if(E.dislocated > 0)
-				wound_flavor_text[E.name] += "[T.His] [E.joint] is dislocated!<br>"
+				wound_flavor_text[E.name] += "[T.His] [E.joint] is dislocated!<BR>"
 			if(((E.status & ORGAN_BROKEN) && E.brute_dam > E.min_broken_damage) || (E.status & ORGAN_MUTATED))
-				wound_flavor_text[E.name] += "[T.His] [E.name] is dented and swollen!<br>"
+				wound_flavor_text[E.name] += "[T.His] [E.name] is dented and swollen!<BR>"
 
 		for(var/datum/wound/wound in E.wounds)
 			var/list/embedlist = wound.embedded_objects
@@ -259,9 +259,9 @@
 					else if(!parsedembed.Find("multiple [embedded.name]"))
 						parsedembed.Remove(embedded.name)
 						parsedembed.Add("multiple "+embedded.name)
-				wound_flavor_text["[E.name]"] += "The [wound.desc] on [T.his] [E.name] has \a [english_list(parsedembed, and_text = " and \a ", comma_text = ", \a ")] sticking out of it!<br>"
+				wound_flavor_text["[E.name]"] += "The [wound.desc] on [T.his] [E.name] has \a [english_list(parsedembed, and_text = " and \a ", comma_text = ", \a ")] sticking out of it!<BR>"
 	for(var/hidden in hidden_bleeders)
-		wound_flavor_text[hidden] = "[T.He] [T.has] blood soaking through [hidden] around [T.his] [english_list(hidden_bleeders[hidden])]!<br>"
+		wound_flavor_text[hidden] = "[T.He] [T.has] blood soaking through [hidden] around [T.his] [english_list(hidden_bleeders[hidden])]!<BR>"
 
 	msg += "<span class='warning'>"
 	for(var/limb in wound_flavor_text)
@@ -271,9 +271,9 @@
 	for(var/obj/implant in get_visible_implants(0))
 		if(implant in shown_objects)
 			continue
-		msg += "<span class='danger'>[src] [T.has] \a [implant.name] sticking out of [T.his] flesh!</span>\n"
+		msg += "<span class='danger'>[src] [T.has] \a [implant.name] sticking out of [T.his] flesh!</span><BR>"
 	if(digitalcamo)
-		msg += "[T.He] [T.is] repulsively uncanny!\n"
+		msg += "[T.He] [T.is] repulsively uncanny!<BR>"
 
 	if(hasHUD(user, HUD_SECURITY))
 		var/perpname = "wot"
@@ -292,8 +292,8 @@
 				if(R)
 					criminal = R.get_criminalStatus()
 
-				msg += "<span class = 'deptradio'>Criminal status:</span> <a href='?src=\ref[src];criminal=1'>\[[criminal]\]</a>\n"
-				msg += "<span class = 'deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=`'>\[View\]</a>\n"
+				msg += "<span class = 'deptradio'>Criminal status:</span> <a href='?src=\ref[src];criminal=1'>\[[criminal]\]</a><BR>"
+				msg += "<span class = 'deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=`'>\[View\]</a><BR>"
 
 	if(hasHUD(user, HUD_MEDICAL))
 		var/perpname = "wot"
@@ -311,28 +311,28 @@
 			if(R)
 				medical = R.get_status()
 
-			msg += "<span class = 'deptradio'>Physical status:</span> <a href='?src=\ref[src];medical=1'>\[[medical]\]</a>\n"
-			msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=`'>\[View\]</a>\n"
+			msg += "<span class = 'deptradio'>Physical status:</span> <a href='?src=\ref[src];medical=1'>\[[medical]\]</a><BR>"
+			msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=`'>\[View\]</a><BR>"
 
 
-	if(print_flavor_text()) msg += "[print_flavor_text()]\n"
+	if(print_flavor_text()) msg += "[print_flavor_text()]<BR>"
 
 	if(mind && user.mind && name == real_name)
 		var/list/relations = matchmaker.get_relationships_between(user.mind, mind, TRUE)
 		if(length(relations))
-			msg += "<br><span class='notice'>You know them. <a href='byond://?src=\ref[src];show_relations=1'>More...</a></span><br>"
+			msg += "<BR><span class='notice'>You know them. <a href='byond://?src=\ref[src];show_relations=1'>More...</a></span><BR>"
 
-	msg += "*---------*</span><br>"
+	msg += "*---------*</span><BR>"
 	msg += applying_pressure
 
 	if (pose)
 		if( findtext(pose,".",length(pose)) == 0 && findtext(pose,"!",length(pose)) == 0 && findtext(pose,"?",length(pose)) == 0 )
 			pose = addtext(pose,".") //Makes sure all emotes end with a period.
-		msg += "[T.He] [pose]\n"
+		msg += "[T.He] [pose]<BR>"
 
 	var/show_descs = show_descriptors_to(user)
 	if(show_descs)
-		msg += "<span class='notice'>[jointext(show_descs, "<br>")]</span>"
+		msg += "<span class='notice'>[jointext(show_descs, "<BR>")]</span>"
 	to_chat(user, jointext(msg, null))
 
 //Helper procedure. Called by /mob/living/carbon/human/examine() and /mob/living/carbon/human/Topic() to determine HUD access to security and medical records.
@@ -384,34 +384,34 @@
 	HTML += "<body>"
 	HTML += "<tt><center>"
 	HTML += "<b>Update Flavour Text</b> <hr />"
-	HTML += "<br></center>"
+	HTML += "<BR></center>"
 	HTML += "<a href='byond://?src=\ref[src];flavor_change=general'>General:</a> "
 	HTML += TextPreview(flavor_texts["general"])
-	HTML += "<br>"
+	HTML += "<BR>"
 	HTML += "<a href='byond://?src=\ref[src];flavor_change=head'>Head:</a> "
 	HTML += TextPreview(flavor_texts["head"])
-	HTML += "<br>"
+	HTML += "<BR>"
 	HTML += "<a href='byond://?src=\ref[src];flavor_change=face'>Face:</a> "
 	HTML += TextPreview(flavor_texts["face"])
-	HTML += "<br>"
+	HTML += "<BR>"
 	HTML += "<a href='byond://?src=\ref[src];flavor_change=eyes'>Eyes:</a> "
 	HTML += TextPreview(flavor_texts["eyes"])
-	HTML += "<br>"
+	HTML += "<BR>"
 	HTML += "<a href='byond://?src=\ref[src];flavor_change=torso'>Body:</a> "
 	HTML += TextPreview(flavor_texts["torso"])
-	HTML += "<br>"
+	HTML += "<BR>"
 	HTML += "<a href='byond://?src=\ref[src];flavor_change=arms'>Arms:</a> "
 	HTML += TextPreview(flavor_texts["arms"])
-	HTML += "<br>"
+	HTML += "<BR>"
 	HTML += "<a href='byond://?src=\ref[src];flavor_change=hands'>Hands:</a> "
 	HTML += TextPreview(flavor_texts["hands"])
-	HTML += "<br>"
+	HTML += "<BR>"
 	HTML += "<a href='byond://?src=\ref[src];flavor_change=legs'>Legs:</a> "
 	HTML += TextPreview(flavor_texts["legs"])
-	HTML += "<br>"
+	HTML += "<BR>"
 	HTML += "<a href='byond://?src=\ref[src];flavor_change=feet'>Feet:</a> "
 	HTML += TextPreview(flavor_texts["feet"])
-	HTML += "<br>"
+	HTML += "<BR>"
 	HTML += "<hr />"
 	HTML +="<a href='?src=\ref[src];flavor_change=done'>\[Done\]</a>"
 	HTML += "<tt>"

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -73,7 +73,7 @@
 
 /mob/living/simple_animal/construct/examine(mob/user)
 	. = ..(user)
-	var/msg = "<span cass='info'>*---------*\nThis is [html_icon(src)] \a <EM>[src]</EM>!\n"
+	var/msg = "<span cass='info'>*---------*\nThis is [icon2html(src, user)] \a <EM>[src]</EM>!\n"
 	if (src.health < src.maxHealth)
 		msg += "<span class='warning'>"
 		if (src.health >= src.maxHealth/2)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -100,7 +100,7 @@
 	if( ishuman(AM) )
 		if(!stat)
 			var/mob/M = AM
-			to_chat(M, "<span class='warning'>[html_icon(src)] Squeek!</span>")
+			to_chat(M, "<span class='warning'>[icon2html(src, M)] Squeek!</span>")
 			sound_to(M, 'sound/effects/mousesqueek.ogg')
 	..()
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -68,10 +68,10 @@
 /mob/living/simple_animal/hostile/retaliate/malf_drone/proc/Haywire()
 	if(prob(disabled ? 0 : 1) && malfunctioning)
 		if(hostile_drone)
-			src.visible_message("<span class='notice'>[html_icon(src)] [src] retracts several targetting vanes, and dulls it's running lights.</span>")
+			src.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] [src] retracts several targetting vanes, and dulls it's running lights.</span>")
 			hostile_drone = 0
 		else
-			src.visible_message("<span class='warning'>[html_icon(src)] [src] suddenly lights up, and additional targetting vanes slide into place.</span>")
+			src.visible_message("<span class='warning'>[icon2html(src, viewers(get_turf(src)))] [src] suddenly lights up, and additional targetting vanes slide into place.</span>")
 			hostile_drone = 1
 
 /mob/living/simple_animal/hostile/retaliate/malf_drone/ListTargets()
@@ -98,7 +98,7 @@
 
 	//repair a bit of damage
 	if(prob(1))
-		src.visible_message("<span class='warning'>[html_icon(src)] [src] shudders and shakes as some of it's damaged systems come back online.</span>")
+		src.visible_message("<span class='warning'>[icon2html(src, viewers(get_turf(src)))] [src] shudders and shakes as some of it's damaged systems come back online.</span>")
 		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 		s.set_up(3, 1, src)
 		s.start()
@@ -131,17 +131,17 @@
 		exploding = 0
 		if(!disabled)
 			if(prob(50))
-				src.visible_message("<span class='notice'>[html_icon(src)] [src] suddenly shuts down!</span>")
+				src.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] [src] suddenly shuts down!</span>")
 			else
-				src.visible_message("<span class='notice'>[html_icon(src)] [src] suddenly lies still and quiet.</span>")
+				src.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] [src] suddenly lies still and quiet.</span>")
 			disabled = rand(150, 600)
 			walk(src,0)
 
 	if(exploding && prob(20))
 		if(prob(50))
-			src.visible_message("<span class='warning'>[html_icon(src)] [src] begins to spark and shake violenty!</span>")
+			src.visible_message("<span class='warning'>[icon2html(src, viewers(get_turf(src)))] [src] begins to spark and shake violenty!</span>")
 		else
-			src.visible_message("<span class='warning'>[html_icon(src)] [src] sparks and shakes like it's about to explode!</span>")
+			src.visible_message("<span class='warning'>[icon2html(src, viewers(get_turf(src)))] [src] sparks and shakes like it's about to explode!</span>")
 		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 		s.set_up(3, 1, src)
 		s.start()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -414,7 +414,7 @@ var/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HURT)
 	var/turf/sourceturf = get_turf(broadcast_source)
 	for(var/mob/M in targets)
 		if(!sourceturf || (get_z(M) in GetConnectedZlevels(sourceturf.z)))
-			M.show_message("<span class='info'>[html_icon(icon)] [message]</span>", 1)
+			M.show_message("<span class='info'>[icon2html(icon, M)] [message]</span>", 1)
 
 /proc/mobs_in_area(var/area/A)
 	var/list/mobs = new

--- a/code/modules/organs/internal/posibrain.dm
+++ b/code/modules/organs/internal/posibrain.dm
@@ -87,7 +87,7 @@
 /obj/item/organ/internal/posibrain/examine(mob/user)
 	. = ..()
 
-	var/msg = "<span class='info'>*---------*</span>\nThis is [html_icon(src)] \a <EM>[src]</EM>!\n[desc]\n"
+	var/msg = "<span class='info'>*---------*</span>\nThis is [icon2html(src, user)] \a <EM>[src]</EM>!\n[desc]\n"
 
 	if(shackle)	msg += "<span class='warning'>It is clamped in a set of metal straps with a complex digital lock.</span>\n"
 

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -59,7 +59,7 @@ var/global/list/rad_collectors = list()
 			if(last_rads > max_rads)
 				if(world.time > end_time)
 					end_time = world.time + alert_delay
-					visible_message("[html_icon(src)] \the [src] beeps loudly as the radiation reaches dangerous levels, indicating imminent damage.")
+					visible_message("[icon2html(src, viewers(get_turf(src)))] \the [src] beeps loudly as the radiation reaches dangerous levels, indicating imminent damage.")
 					playsound(src, 'sound/effects/screech.ogg', 100, 1, 1)
 			receive_pulse(12.5*(last_rads/max_rads)/(0.3+(last_rads/max_rads)))
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -105,7 +105,7 @@ GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
 
 			if(my_atom)
 				if(replace_message)
-					my_atom.visible_message("<span class='notice'>[html_icon(my_atom)] [replace_message]</span>")
+					my_atom.visible_message("<span class='notice'>[icon2html(my_atom, viewers(get_turf(my_atom)))] [replace_message]</span>")
 				if(replace_sound)
 					playsound(my_atom, replace_sound, 80, 1)
 

--- a/code/modules/reagents/reactions/_reaction.dm
+++ b/code/modules/reagents/reactions/_reaction.dm
@@ -74,9 +74,9 @@
 	if(mix_message && container && !ismob(container))
 		var/turf/T = get_turf(container)
 		if(istype(T))
-			T.visible_message(SPAN_NOTICE("[html_icon(container)] [mix_message]"))
+			T.visible_message(SPAN_NOTICE("[icon2html(container, viewers(get_turf(container)))] [mix_message]"))
 		else
-			container.visible_message(SPAN_NOTICE("[html_icon(container)] [mix_message]"))
+			container.visible_message(SPAN_NOTICE("[icon2html(container, viewers(get_turf(container)))] [mix_message]"))
 		if(reaction_sound)
 			playsound(T || container, reaction_sound, 80, 1)
 

--- a/code/modules/reagents/reactions/reaction_slimes.dm
+++ b/code/modules/reagents/reactions/reaction_slimes.dm
@@ -16,7 +16,7 @@
 	var/obj/item/slime_extract/T = holder.my_atom
 	T.Uses--
 	if(T.Uses <= 0)
-		T.visible_message("[html_icon(T)]<span class='notice'>\The [T]'s power is consumed in the reaction.</span>")
+		T.visible_message("[icon2html(T)]<span class='notice'>\The [T]'s power is consumed in the reaction.</span>")
 		T.SetName("used slime extract")
 		T.desc = "This extract has been used up."
 

--- a/code/modules/reagents/storage/pill_foil.dm
+++ b/code/modules/reagents/storage/pill_foil.dm
@@ -65,4 +65,4 @@
 	. = ..()
 	to_chat(user, SPAN_NOTICE("It has the following pills in it:"))
 	for(var/obj/item/chems/pill/C in pill_positions)
-		to_chat(user, SPAN_NOTICE("[html_icon(C)] [C.name]"))
+		to_chat(user, SPAN_NOTICE("[icon2html(C)] [C.name]"))

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -282,7 +282,7 @@ var/list/all_conveyor_switches = list()
 			found = 1
 			break
 	if(!found)
-		to_chat(user, "[html_icon(src)]<span class=notice>The conveyor switch did not detect any linked conveyor belts in range.</span>")
+		to_chat(user, "[icon2html(src, user)]<span class=notice>The conveyor switch did not detect any linked conveyor belts in range.</span>")
 		return
 	var/obj/machinery/conveyor_switch/NC = new /obj/machinery/conveyor_switch(A, id_tag)
 	transfer_fingerprints_to(NC)
@@ -301,7 +301,7 @@ var/list/all_conveyor_switches = list()
 			found = 1
 			break
 	if(!found)
-		to_chat(user, "[html_icon(src)]<span class=notice>The conveyor switch did not detect any linked conveyor belts in range.</span>")
+		to_chat(user, "[icon2html(src, user)]<span class=notice>The conveyor switch did not detect any linked conveyor belts in range.</span>")
 		return
 	var/obj/machinery/conveyor_switch/oneway/NC = new /obj/machinery/conveyor_switch/oneway(A, id_tag)
 	transfer_fingerprints_to(NC)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -513,7 +513,7 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 			found = 1
 			break
 	if(!found)
-		to_chat(user, "[html_icon(src)]<span class=notice>\The [src] is not linked to any junctions!</span>")
+		to_chat(user, "[icon2html(src, user)]<span class=notice>\The [src] is not linked to any junctions!</span>")
 		return
 	var/obj/machinery/disposal_switch/NC = new/obj/machinery/disposal_switch(A, id_tag)
 	transfer_fingerprints_to(NC)

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -246,14 +246,14 @@
 		return TRUE
 
 	if (src.active)
-		user.visible_message("<span class='notice'>[html_icon(src)] [user] deactivated the shield generator.</span>", \
-			"<span class='notice'>[html_icon(src)] You deactivate the shield generator.</span>", \
+		user.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] [user] deactivated the shield generator.</span>", \
+			"<span class='notice'>[icon2html(src, user)] You deactivate the shield generator.</span>", \
 			"You hear heavy droning fade out.")
 		src.shields_down()
 	else
 		if(anchored)
-			user.visible_message("<span class='notice'>[html_icon(src)] [user] activated the shield generator.</span>", \
-				"<span class='notice'>[html_icon(src)] You activate the shield generator.</span>", \
+			user.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] [user] activated the shield generator.</span>", \
+				"<span class='notice'>[icon2html(src, user)] You activate the shield generator.</span>", \
 				"You hear heavy droning.")
 			src.shields_up()
 		else

--- a/code/modules/xenoarcheaology/artifacts/effects/_effect.dm
+++ b/code/modules/xenoarcheaology/artifacts/effects/_effect.dm
@@ -55,7 +55,7 @@
 		var/atom/toplevelholder = holder
 		while(!istype(toplevelholder.loc, /turf))
 			toplevelholder = toplevelholder.loc
-		toplevelholder.visible_message("<span class='warning'>[html_icon(toplevelholder)] [toplevelholder] [display_msg]</span>")
+		toplevelholder.visible_message("<span class='warning'>[icon2html(toplevelholder, viewers(get_turf(toplevelholder)))] [toplevelholder] [display_msg]</span>")
 
 /datum/artifact_effect/proc/DoEffectTouch(var/mob/user)
 /datum/artifact_effect/proc/DoEffectAura(var/atom/holder)

--- a/code/modules/xenoarcheaology/artifacts/standalone/autocloner.dm
+++ b/code/modules/xenoarcheaology/artifacts/standalone/autocloner.dm
@@ -44,17 +44,17 @@
 		if(!previous_power_state)
 			previous_power_state = 1
 			icon_state = "cellold1"
-			src.visible_message("<span class='notice'>[html_icon(src)] [src] suddenly comes to life!</span>")
+			src.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] [src] suddenly comes to life!</span>")
 
 		//slowly grow a mob
 		if(prob(5))
-			src.visible_message("<span class='notice'>[html_icon(src)] [src] [pick("gloops","glugs","whirrs","whooshes","hisses","purrs","hums","gushes")].</span>")
+			src.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] [src] [pick("gloops","glugs","whirrs","whooshes","hisses","purrs","hums","gushes")].</span>")
 
 		//if we've finished growing...
 		if(time_spent_spawning >= time_per_spawn)
 			time_spent_spawning = 0
 			update_use_power(POWER_USE_IDLE)
-			src.visible_message("<span class='notice'>[html_icon(src)] [src] pings!</span>")
+			src.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] [src] pings!</span>")
 			icon_state = "cellold1"
 			desc = "It's full of a bubbling viscous liquid, and is lit by a mysterious glow."
 			if(spawn_type)
@@ -75,7 +75,7 @@
 		if(previous_power_state)
 			previous_power_state = 0
 			icon_state = "cellold0"
-			src.visible_message("<span class='notice'>[html_icon(src)] [src] suddenly shuts down.</span>")
+			src.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] [src] suddenly shuts down.</span>")
 
 		//cloned mob slowly breaks down
 		time_spent_spawning = max(time_spent_spawning + last_process - world.time, 0)

--- a/code/modules/xenoarcheaology/artifacts/standalone/replicator.dm
+++ b/code/modules/xenoarcheaology/artifacts/standalone/replicator.dm
@@ -74,7 +74,7 @@
 		viables.Remove(type)
 		construction[button_desc] = type
 
-	fail_message = "<span class='notice'>[html_icon(src)] a [pick("loud","soft","sinister","eery","triumphant","depressing","cheerful","angry")] \
+	fail_message = "<span class='notice'>a [pick("loud","soft","sinister","eery","triumphant","depressing","cheerful","angry")] \
 		[pick("horn","beep","bing","bleep","blat","honk","hrumph","ding")] sounds and a \
 		[pick("yellow","purple","green","blue","red","orange","white")] \
 		[pick("light","dial","meter","window","protrusion","knob","antenna","swirly thing")] \
@@ -86,7 +86,7 @@
 	if(spawning_types.len)
 		spawn_progress_time += world.time - last_process_time
 		if(spawn_progress_time > max_spawn_time)
-			src.visible_message("<span class='notice'>[html_icon(src)] [src] pings!</span>")
+			src.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] [src] pings!</span>")
 
 			var/obj/source_material = pop(stored_materials)
 			var/spawn_type = pop(spawning_types)
@@ -108,7 +108,7 @@
 				icon_state = "borgcharger0(old)"
 
 		else if(prob(5))
-			src.visible_message("<span class='notice'>[html_icon(src)] [src] [pick("clicks","whizzes","whirrs","whooshes","clanks","clongs","clonks","bangs")].</span>")
+			src.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] [src] [pick("clicks","whizzes","whirrs","whooshes","clanks","clongs","clonks","bangs")].</span>")
 
 	last_process_time = world.time
 
@@ -136,15 +136,15 @@
 		if(index > 0 && index <= construction.len)
 			if(stored_materials.len > spawning_types.len)
 				if(spawning_types.len)
-					src.visible_message("<span class='notice'>[html_icon(src)] a [pick("light","dial","display","meter","pad")] on [src]'s front [pick("blinks","flashes")] [pick("red","yellow","blue","orange","purple","green","white")].</span>")
+					src.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] a [pick("light","dial","display","meter","pad")] on [src]'s front [pick("blinks","flashes")] [pick("red","yellow","blue","orange","purple","green","white")].</span>")
 				else
-					src.visible_message("<span class='notice'>[html_icon(src)] [src]'s front compartment slides shut.</span>")
+					src.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] [src]'s front compartment slides shut.</span>")
 
 				spawning_types.Add(construction[construction[index]])
 				spawn_progress_time = 0
 				icon_state = "borgcharger1(old)"
 			else
-				src.visible_message(fail_message)
+				src.visible_message("[icon2html(src, viewers(get_turf(src)))] [fail_message]")
 		. = TOPIC_REFRESH
 
 /obj/machinery/replicator/get_artifact_scan_data()

--- a/code/modules/xenoarcheaology/finds/find_types/statuette.dm
+++ b/code/modules/xenoarcheaology/finds/find_types/statuette.dm
@@ -77,7 +77,7 @@
 
 	if(charges >= 0.1)
 		if(prob(5))
-			src.visible_message("<span class='warning'>[html_icon(src)] [src]'s eyes glow ruby red for a moment!</span>")
+			src.visible_message("<span class='warning'>[icon2html(src, viewers(get_turf(src)))] [src]'s eyes glow ruby red for a moment!</span>")
 			charges -= 0.1
 
 	//check on our shadow wights

--- a/code/modules/xenoarcheaology/finds/talking.dm
+++ b/code/modules/xenoarcheaology/finds/talking.dm
@@ -51,7 +51,7 @@
 		var/list/options = list("[holder_atom] seems to be listening intently to [source]...",\
 			"[holder_atom] seems to be focusing on [source]...",\
 			"[holder_atom] seems to turn it's attention to [source]...")
-		holder_atom.loc.visible_message("<span class='notice'>[html_icon(holder_atom)] [pick(options)]</span>")
+		holder_atom.loc.visible_message("<span class='notice'>[icon2html(holder_atom, viewers(get_turf(holder_atom)))] [pick(options)]</span>")
 
 	if(prob(20))
 		spawn(2)
@@ -115,5 +115,5 @@
 			listening|=M
 
 	for(var/mob/M in listening)
-		to_chat(M, "[html_icon(holder_atom)] <b>[holder_atom]</b> reverberates, <span class='notice'>\"[msg]\"</span>")
+		to_chat(M, "[icon2html(holder_atom, M)] <b>[holder_atom]</b> reverberates, <span class='notice'>\"[msg]\"</span>")
 	last_talk_time = world.time

--- a/code/modules/xenoarcheaology/machinery/geosample_scanner.dm
+++ b/code/modules/xenoarcheaology/machinery/geosample_scanner.dm
@@ -227,16 +227,16 @@
 			//emergency stop if seal integrity reaches 0
 			if(scanner_seal_integrity <= 0 || (scanner_temperature >= 1273 && !rad_shield))
 				stop_scanning()
-				src.visible_message("<span class='notice'>[html_icon(src)] buzzes unhappily. It has failed mid-scan!</span>", 2)
+				src.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] buzzes unhappily. It has failed mid-scan!</span>", 2)
 
 			if(prob(5))
-				src.visible_message("<span class='notice'>[html_icon(src)] [pick("whirrs","chuffs","clicks")][pick(" excitedly"," energetically"," busily")].</span>", 2)
+				src.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] [pick("whirrs","chuffs","clicks")][pick(" excitedly"," energetically"," busily")].</span>", 2)
 	else
 		//gradually cool down over time
 		if(scanner_temperature > 0)
 			scanner_temperature = max(scanner_temperature - 5 - 10 * rand(), 0)
 		if(prob(0.75))
-			src.visible_message("<span class='notice'>[html_icon(src)] [pick("plinks","hisses")][pick(" quietly"," softly"," sadly"," plaintively")].</span>", 2)
+			src.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] [pick("plinks","hisses")][pick(" quietly"," softly"," sadly"," plaintively")].</span>", 2)
 	last_process_worldtime = world.time
 
 /obj/machinery/radiocarbon_spectrometer/proc/stop_scanning()
@@ -254,7 +254,7 @@
 		used_coolant = 0
 
 /obj/machinery/radiocarbon_spectrometer/proc/complete_scan()
-	src.visible_message("<span class='notice'>[html_icon(src)] makes an insistent chime.</span>", 2)
+	src.visible_message("<span class='notice'>[icon2html(src, viewers(get_turf(src)))] makes an insistent chime.</span>", 2)
 
 	if(scanned_item)
 		last_scan_data = get_scan_data()

--- a/code/modules/xenoarcheaology/machinery/suspension_generator.dm
+++ b/code/modules/xenoarcheaology/machinery/suspension_generator.dm
@@ -80,7 +80,7 @@
 /obj/machinery/suspension_gen/proc/activate()
 	var/turf/T = get_turf(get_step(src,dir))
 	suspension_field = new(T)
-	visible_message(SPAN_NOTICE("[html_icon(src)] [src] activates with a low hum."))
+	visible_message(SPAN_NOTICE("[icon2html(src, viewers(get_turf(src)))] [src] activates with a low hum."))
 	update_icon()
 	update_use_power(POWER_USE_ACTIVE)
 

--- a/code/modules/xenoarcheaology/tools/ano_device_battery.dm
+++ b/code/modules/xenoarcheaology/tools/ano_device_battery.dm
@@ -81,7 +81,8 @@
 
 /obj/item/anodevice/Process()
 	if(!activated || !inserted_battery || !inserted_battery.battery_effect || !inserted_battery.stored_charge)
-		visible_message("<span class='notice'>[html_icon(src)] [src] buzzes.</span>", "<span class='notice'>[html_icon(src)] You hear something buzz.</span>")
+		var/viewing = viewers(get_turf(src))
+		visible_message("<span class='notice'>[icon2html(src, viewing)] [src] buzzes.</span>", "<span class='notice'>[icon2html(src, viewing)] You hear something buzz.</span>")
 		shutdown_emission()
 		return
 
@@ -108,11 +109,13 @@
 	if(inserted_battery.battery_effect)
 		inserted_battery.battery_effect.process()
 	else //ran out of charge
-		visible_message("<span class='notice'>[html_icon(src)] [src] buzzes.</span>", "<span class='notice'>[html_icon(src)] You hear something buzz.</span>")
+		var/viewing = viewers(get_turf(src))
+		visible_message("<span class='notice'>[icon2html(src, viewing)] [src] buzzes.</span>", "<span class='notice'>[icon2html(src, viewing)] You hear something buzz.</span>")
 		shutdown_emission()
 
 	if(current_tick >= duration)
-		visible_message("<span class='notice'>[html_icon(src)] [src] chimes.</span>", "<span class='notice'>[html_icon(src)] You hear something chime.</span>")
+		var/viewing = viewers(get_turf(src))
+		visible_message("<span class='notice'>[icon2html(src, viewing)] [src] chimes.</span>", "<span class='notice'>[icon2html(src, viewing)] You hear something chime.</span>")
 		shutdown_emission()
 
 /obj/item/anodevice/proc/start_emission()
@@ -150,7 +153,8 @@
 		. = TOPIC_REFRESH
 	else if(href_list["startup"])
 		if(inserted_battery && inserted_battery.battery_effect && (inserted_battery.stored_charge > 0) )
-			visible_message("<span class='notice'>[html_icon(src)] [src] whirrs.</span>", "<span class='notice'>[html_icon(src)] You hear something whirr.</span>")
+			var/viewing = viewers(get_turf(src))
+			visible_message("<span class='notice'>[icon2html(src, viewing)] [src] whirrs.</span>", "<span class='notice'>[icon2html(src, viewing)] You hear something whirr.</span>")
 			start_emission()
 			. = TOPIC_REFRESH
 	else if(href_list["shutdown"])

--- a/code/modules/xenoarcheaology/tools/depth_scanner.dm
+++ b/code/modules/xenoarcheaology/tools/depth_scanner.dm
@@ -47,7 +47,7 @@
 
 			positive_locations.Add(D)
 
-			to_chat(user, "<span class='notice'>[html_icon(src)] [src] pings.</span>")
+			to_chat(user, "<span class='notice'>[icon2html(src, user)] [src] pings.</span>")
 
 	else if(istype(A, /obj/structure/boulder))
 		var/obj/structure/boulder/B = A
@@ -65,7 +65,7 @@
 
 			positive_locations.Add(D)
 
-			to_chat(user, "<span class='notice'>[html_icon(src)] [src] pings [pick("madly","wildly","excitedly","crazily")]!</span>")
+			to_chat(user, "<span class='notice'>[icon2html(src, user)] [src] pings [pick("madly","wildly","excitedly","crazily")]!</span>")
 
 /obj/item/depth_scanner/attack_self(var/mob/living/user)
 	interact(user)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -988,7 +988,6 @@ window "mainwindow"
 		size = 999x999
 		anchor1 = none
 		anchor2 = none
-		background-color = none
 		is-visible = false
 		saved-params = ""
 
@@ -1027,7 +1026,6 @@ window "mapwindow"
 		is-visible = false
 		is-disabled = true
 		saved-params = ""
-		auto-format = false
 
 window "outputwindow"
 	elem "outputwindow"
@@ -1036,6 +1034,7 @@ window "outputwindow"
 		size = 640x480
 		anchor1 = none
 		anchor2 = none
+		background-color = none
 		saved-params = "pos;size;is-minimized;is-maximized"
 		titlebar = false
 		statusbar = false
@@ -1043,22 +1042,22 @@ window "outputwindow"
 		can-minimize = false
 		can-resize = false
 		is-pane = true
+		outer-size = 654x494
 	elem "output"
-		type = OUTPUT
+		type = BROWSER
 		pos = 0,0
 		size = 640x480
 		anchor1 = 0,0
 		anchor2 = 100,100
-		is-default = true
-		saved-params = "max-lines"
-		style = ".system {color:#ff0000;}"
-		max-lines = 0
+		background-color = none
+		saved-params = ""
 	elem "saybutton_alt"
 		type = BUTTON
 		pos = 519,460
 		size = 40x20
 		anchor1 = 100,100
 		anchor2 = none
+		background-color = none
 		is-visible = false
 		is-disabled = true
 		saved-params = "is-checked"
@@ -1083,6 +1082,7 @@ window "outputwindow"
 		size = 80x20
 		anchor1 = 100,100
 		anchor2 = none
+		background-color = none
 		is-visible = false
 		is-disabled = true
 		saved-params = ""

--- a/mods/dionaea/mob/_nymph.dm
+++ b/mods/dionaea/mob/_nymph.dm
@@ -91,10 +91,10 @@
 /mob/living/carbon/alien/diona/examine(mob/user)
 	. = ..()
 	if(holding_item)
-		to_chat(user, SPAN_NOTICE("It is holding [html_icon(holding_item)] \a [holding_item]."))
+		to_chat(user, SPAN_NOTICE("It is holding [icon2html(holding_item, user)] \a [holding_item]."))
 	var/datum/extension/hattable/hattable = get_extension(src, /datum/extension/hattable)
 	if(hattable?.hat)
-		to_chat(user, SPAN_NOTICE("It is wearing [html_icon(hattable.hat)] \a [hattable.hat]."))
+		to_chat(user, SPAN_NOTICE("It is wearing [icon2html(hattable.hat, user)] \a [hattable.hat]."))
 
 /mob/living/carbon/alien/diona/has_dexterity()
 	return FALSE

--- a/mods/psionics/system/psionics/events/mini_spasm.dm
+++ b/mods/psionics/system/psionics/events/mini_spasm.dm
@@ -42,12 +42,12 @@
 			victim.disabilities |= pick(disabilities)
 
 	if(victim.psi)
-		to_chat(victim, SPAN_DANGER("A hauntingly familiar sound hisses from [html_icon(source)] \the [source], and your vision flickers!"))
+		to_chat(victim, SPAN_DANGER("A hauntingly familiar sound hisses from [icon2html(source, victim)] \the [source], and your vision flickers!"))
 		victim.psi.backblast(rand(5,15))
 		victim.Paralyse(5)
 		victim.make_jittery(100)
 	else
-		to_chat(victim, SPAN_DANGER("An indescribable, brain-tearing sound hisses from [html_icon(source)] \the [source], and you collapse in a seizure!"))
+		to_chat(victim, SPAN_DANGER("An indescribable, brain-tearing sound hisses from [icon2html(source, victim)] \the [source], and you collapse in a seizure!"))
 		victim.seizure()
 		var/new_latencies = rand(2,4)
 		var/list/faculties = list(PSI_COERCION, PSI_REDACTION, PSI_ENERGISTICS, PSI_PSYCHOKINESIS)

--- a/nebula.dme
+++ b/nebula.dme
@@ -10,6 +10,7 @@
 #define DEBUG
 // END_PREFERENCES
 // BEGIN_INCLUDE
+#include "code\_chat.dm"
 #include "code\_macros.dm"
 #include "code\client_macros.dm"
 #include "code\hub.dm"


### PR DESCRIPTION
Highly WIP, figured I'd open it for input.

Swaps the `output` to a `browser`, with accompanying code to support icons and newlines being sent to the client. Also bundles a small JS feature to collapse identical lines of text into each other. This is similar to Goonchat/Vuechat but relies on no other libraries and has like 1% the features.

I copypasted `icon2html()` and accompanying procs from Snapshot/quardbreak's Goonchat port on Bay.

![image](https://user-images.githubusercontent.com/2468979/89261919-37dbf800-d672-11ea-92b3-2ac5fbf6f879.png)

**TODO:**
- [x] Basic conversion.
- [ ] Fix up CSS so text isn't so huge.
- [ ] Add a darkmode and a way to specify CSS in the client prefs.
- [ ] Check if there's some way to automatically update the broken-link icons in the chat when an asset is sent but before the next message arrives.
- [ ] Find a less inefficient way of appending to the buffer than `innerHTML +=`
- [ ] Add a pause button.
- [ ] Add a ping indicator.