### PR TITLE
Planets generate landing areas BEFORE placing ruins

### DIFF
--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -22,6 +22,8 @@
 	var/y_size
 
 	var/landmark_type = /obj/effect/shuttle_landmark/automatic
+	var/shuttle_size = 20  		 //'diameter' of expected shuttle in turfs
+	var/landing_points_to_place  // number of landing points to place, calculated dynamically based on planet size
 
 	var/list/rock_colors = list(COLOR_ASTEROID_ROCK)
 	var/list/plant_colors = list("RANDOM")
@@ -83,6 +85,7 @@
 	y_origin = TRANSITIONEDGE + 1
 	x_size = maxx - 2 * (TRANSITIONEDGE + 1)
 	y_size = maxy - 2 * (TRANSITIONEDGE + 1)
+	landing_points_to_place = min(round(0.1 * (x_size * y_size) / (shuttle_size * shuttle_size)), 3)
 	planetary_area = new planetary_area()
 	var/themes_num = min(length(possible_themes), rand(1, max_themes))
 	for(var/i = 1 to themes_num)
@@ -97,10 +100,10 @@
 		T.adjust_atmosphere(src)
 	generate_flora()
 	generate_map()
+	generate_landing(2)
 	generate_features()
 	for(var/datum/exoplanet_theme/T in themes)
 		T.after_map_generation(src)
-	generate_landing(2)
 	generate_daycycle()
 	generate_planet_image()
 	START_PROCESSING(SSobj, src)
@@ -187,18 +190,21 @@
 		daycycle = rand(10 MINUTES, 40 MINUTES)
 
 //Tries to generate num landmarks, but avoids repeats.
-/obj/effect/overmap/visitable/sector/exoplanet/proc/generate_landing(num = 1)
+/obj/effect/overmap/visitable/sector/exoplanet/proc/generate_landing()
 	var/places = list()
-	var/attempts = 10*num
-	var/new_type = /obj/effect/shuttle_landmark/automatic
-	while(num)
+	var/attempts = 10*landing_points_to_place
+	var/border_padding = shuttle_size / 2 + 3
+
+	while(landing_points_to_place)
 		attempts--
-		var/turf/T = locate(rand(20, maxx-20), rand(20, maxy - 10),map_z[map_z.len])
+		var/turf/T = locate(rand(x_origin + border_padding, x_origin + x_size - border_padding), rand(y_origin + border_padding, y_origin + y_size - border_padding), map_z[1])
+
 		if(!T || (T in places)) // Two landmarks on one turf is forbidden as the landmark code doesn't work with it.
 			continue
+
 		if(attempts >= 0) // While we have the patience, try to find better spawn points. If out of patience, put them down wherever, so long as there are no repeats.
 			var/valid = 1
-			var/list/block_to_check = block(locate(T.x - 10, T.y - 10, T.z), locate(T.x + 10, T.y + 10, T.z))
+			var/list/block_to_check = block(locate(T.x - shuttle_size / 2, T.y - shuttle_size / 2, T.z), locate(T.x + shuttle_size / 2, T.y + shuttle_size / 2, T.z))
 			for(var/turf/check in block_to_check)
 				if(!istype(get_area(check), /area/exoplanet) || check.turf_flags & TURF_FLAG_NORUINS)
 					valid = 0
@@ -206,15 +212,13 @@
 			if(attempts >= 10)
 				if(check_collision(T.loc, block_to_check)) //While we have lots of patience, ensure landability
 					valid = 0
-			else //Running out of patience, but would rather not clear ruins, so switch to clearing landmarks and bypass landability check
-				new_type = /obj/effect/shuttle_landmark/automatic/clearing
 
 			if(!valid)
 				continue
 
-		num--
+		landing_points_to_place--
 		places += T
-		new new_type(T)
+		new /obj/effect/shuttle_landmark/automatic/clearing(T)
 
 /obj/effect/overmap/visitable/sector/exoplanet/get_scan_data(mob/user)
 	. = ..()

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -128,6 +128,7 @@
 	for(var/turf/T in range(radius, src))
 		if(T.density)
 			T.ChangeTurf(get_base_turf_by_area(T))
+		T.turf_flags |= TURF_FLAG_NORUINS
 
 //Used for custom landing locations. Self deletes after a shuttle leaves.
 /obj/effect/shuttle_landmark/temporary


### PR DESCRIPTION
Prevents the often seen case of auto-clearing landmarks chomping out most of the walls of a ruin.
Now autoclear landmarks set their affected turfs to NO RUINS

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->