### PR TITLE
Fixes weird bald 'gap' in planet generation

### DIFF
--- a/code/modules/overmap/exoplanets/planet_themes/mountains.dm
+++ b/code/modules/overmap/exoplanets/planet_themes/mountains.dm
@@ -5,7 +5,7 @@
 /datum/exoplanet_theme/mountains/before_map_generation(obj/effect/overmap/visitable/sector/exoplanet/E)
 	rock_color = pick(E.rock_colors)
 	for(var/zlevel in E.map_z)
-		new /datum/random_map/automata/cave_system/mountains(null,E.x_origin,E.y_origin,zlevel,E.x_size,E.y_size,0,1,1, E.planetary_area, rock_color)
+		new /datum/random_map/automata/cave_system/mountains(null,E.x_origin,E.y_origin,zlevel,E.x_origin+E.x_size,E.x_origin+E.y_size,0,1,1, E.planetary_area, rock_color)
 
 /datum/exoplanet_theme/mountains/get_planet_image_extra()
 	var/image/res = image('icons/skybox/planet.dmi', "mountains")

--- a/code/modules/overmap/exoplanets/planet_types/desert.dm
+++ b/code/modules/overmap/exoplanets/planet_types/desert.dm
@@ -51,8 +51,6 @@
 
 /datum/random_map/noise/exoplanet/desert/get_additional_spawns(var/value, var/turf/T)
 	..()
-	if(is_edge_turf(T))
-		return
 	var/v = noise2value(value)
 	if(v > 6)
 		T.icon_state = "desert[v-1]"

--- a/code/modules/overmap/exoplanets/random_map.dm
+++ b/code/modules/overmap/exoplanets/random_map.dm
@@ -36,9 +36,6 @@
 /datum/random_map/noise/exoplanet/proc/noise2value(var/value)
 	return min(9,max(0,round((value/cell_range)*10)))
 
-/datum/random_map/noise/exoplanet/proc/is_edge_turf(turf/T)
-	return T.x <= TRANSITIONEDGE || T.x >= (limit_x - TRANSITIONEDGE + 1) || T.y <= TRANSITIONEDGE || T.y >= (limit_y - TRANSITIONEDGE + 1)
-
 /datum/random_map/noise/exoplanet/get_map_char(var/value)
 	if(water_type && noise2value(value) < water_level)
 		return "~"
@@ -51,8 +48,6 @@
 		return land_type
 
 /datum/random_map/noise/exoplanet/get_additional_spawns(var/value, var/turf/T)
-	if(is_edge_turf(T))
-		return
 	if(T.is_wall())
 		return
 	var/parsed_value = noise2value(value)


### PR DESCRIPTION
Issue was twofold:
1. Mountains (cave automata maps) use x/y limit vars in different way, as global coordinates. Now appropriately global ones are passed.
2. Planet surface mapgen had checks to prevent placing grass and various stuff on the edge turfs. Now edge turfs are handled completely outside of random map gen, and all affected turfs are guaranteed to be non-edge. Removed the check, now goodies can be placed across entire map.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->