### PR TITLE
Shuttle Landing Adjustments

### DIFF
--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -135,13 +135,15 @@
 				transport_turf_contents(source, target)
 	//change the old turfs
 	for(var/turf/source in translation)
-		source.ChangeTurf(base_turf ? base_turf : get_base_turf_by_area(source), 1, 1)
+		var/old_turf = source.prev_type || base_turf || get_base_turf_by_area(source)
+		source.ChangeTurf(old_turf)
 
 //Transports a turf from a source turf to a target turf, moving all of the turf's contents and making the target a copy of the source.
 /proc/transport_turf_contents(turf/source, turf/target)
-
+	var/target_type = target.type
 	var/turf/new_turf = target.ChangeTurf(source.type, 1, 1)
 	new_turf.transport_properties_from(source)
+	new_turf.prev_type = target_type
 
 	for(var/obj/O in source)
 		if(O.simulated)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -35,6 +35,8 @@
 
 	var/tmp/changing_turf
 
+	var/prev_type // Previous type of the turf, prior to turf translation.
+
 /turf/Initialize(mapload, ...)
 	. = ..()
 	if(dynamic_lighting)

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -40,6 +40,7 @@
 	var/old_corners = corners
 	var/old_ao_neighbors = ao_neighbors
 	var/old_above = above
+	var/old_prev_type = prev_type
 
 //	log_debug("Replacing [src.type] with [N]")
 
@@ -57,6 +58,7 @@
 	var/turf/simulated/W = new N(src)
 
 	above = old_above
+	prev_type = old_prev_type
 
 	if (permit_ao)
 		regenerate_ao()

--- a/code/modules/mob/observer/eye/landing_eye.dm
+++ b/code/modules/mob/observer/eye/landing_eye.dm
@@ -1,4 +1,4 @@
-#define LANDING_VIEW 12
+#define LANDING_VIEW 25
 
 /mob/observer/eye/landing
 	name = "Landing Eye"
@@ -53,25 +53,15 @@
 		. = TRUE
 
 		if(!T || !T.loc || !origin || !origin.loc)
-			img.icon_state = "red"
 			. = FALSE
-			continue
-		if((T.x < TRANSITIONEDGE || T.x > world.maxx - TRANSITIONEDGE) || (T.y < TRANSITIONEDGE || T.y > world.maxy - TRANSITIONEDGE))
-			img.icon_state = "red"
+		else if((T.x < TRANSITIONEDGE || T.x > world.maxx - TRANSITIONEDGE) || (T.y < TRANSITIONEDGE || T.y > world.maxy - TRANSITIONEDGE))
 			. = FALSE // Cannot land past the normal world boundaries.
-			continue
-		if(!istype(T, origin))
-			img.icon_state = "red"
-			. = FALSE // Cannot land on two different types of turfs.
-			continue
-		if(check_collision(origin.loc, list(T))) // Checking for density or multi-area overlap.
-			img.icon_state = "red"
+		else if(check_collision(origin.loc, list(T))) // Checking for density or multi-area overlap.
 			. = FALSE
-			continue
-		if(!istype(A, /area/space) && !istype(A, /area/exoplanet)) // Can only land in space or outside.
-			img.icon_state = "red"
+		else if(!istype(A, /area/space) && !istype(A, /area/exoplanet)) // Can only land in space or outside.
 			. = FALSE
-			continue
+		if(!.)
+			img.icon_state = "red" // Visual indicator the spot is invalid.
 
 /mob/observer/eye/landing/possess(var/mob/user)
 	. = ..()

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -17,7 +17,7 @@
 	//when the shuttle leaves this landmark, it will leave behind the base area
 	//also used to determine if the shuttle can arrive here without obstruction
 	var/area/base_area
-	//Will also leave this type of turf behind if set.
+	//Will also leave this type of turf behind if set, if the turfs do not have prev_type set.
 	var/turf/base_turf
 	//Name of the shuttle, null for generic waypoint
 	var/shuttle_restricted


### PR DESCRIPTION
Makes some adjustments to shuttle landing and turf translation for ease of use and code cleanliness.
* Manual Shuttle Landing now only requires expert rather than professional skill in piloting.
* Turf translation now keeps track of the previous turf type, so shuttles will now leave behind whatever they landed on rather than relying on the landmarks base_turf alone.
* Manual landing now allows landing across multiple types of turf, provided they are not dense.
* Increased the view range of shuttle landing to 25.
* Cleans up the check_landing proc as suggested by Loaf when this feature was first implemented.