### PR TITLE
Fixes assembly devices failing to draw from battery.

### DIFF
--- a/code/datums/extensions/assembly/assembly_power.dm
+++ b/code/datums/extensions/assembly/assembly_power.dm
@@ -10,8 +10,7 @@
 /datum/extension/assembly/proc/battery_power(var/power_usage = 0)
 	apc_powered = FALSE
 	for(var/obj/item/stock_parts/computer/battery_module/battery_module in parts)
-		if(battery_module.check_functionality() && battery_module.battery.charge >= power_usage)
-			battery_module.battery.use(power_usage * CELLRATE)
+		if(battery_module.check_functionality() && battery_module.battery.checked_use(power_usage * CELLRATE))
 			return TRUE
 
 // Tries to use power from APC, if present.

--- a/code/modules/modular_computers/computers/modular_computer/assembly_computer.dm
+++ b/code/modules/modular_computers/computers/modular_computer/assembly_computer.dm
@@ -57,8 +57,7 @@
 	var/datum/extension/interactive/ntos/os = get_extension(holder, /datum/extension/interactive/ntos)
 	if(os)
 		os.event_powerfailure()
-	shutdown_device()
-	return ..()
+	. = ..()
 
 /datum/extension/assembly/modular_computer/turn_on(var/mob/user)
 	if(bsod)


### PR DESCRIPTION
This should fix PDAs failing when in space or in an area with no APC.