### PR TITLE
Tradeship map expansion.

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -228,6 +228,24 @@
 				/obj/item/chems/syringe/drugs = 1,
 				/obj/item/chems/food/snacks/egg/lizard = 3)
 
+/obj/random/drinkingglass
+	name = "random drinking glass" 
+	desc = "This is a random drinking glass."
+	icon = 'icons/obj/drink_glasses/square.dmi'
+	icon_state = "square"
+
+/obj/random/drinkingglass/spawn_choices()
+	return list(
+		/obj/item/chems/food/drinks/glass2/square,
+		/obj/item/chems/food/drinks/glass2/rocks,
+		/obj/item/chems/food/drinks/glass2/shake,
+		/obj/item/chems/food/drinks/glass2/cocktail,
+		/obj/item/chems/food/drinks/glass2/shot,
+		/obj/item/chems/food/drinks/glass2/pint,
+		/obj/item/chems/food/drinks/glass2/mug,
+		/obj/item/chems/food/drinks/glass2/wine
+	)
+
 /obj/random/drinkbottle
 	name = "random drink"
 	desc = "This is a random drink."

--- a/code/modules/mining/machinery/mineral_stacker.dm
+++ b/code/modules/mining/machinery/mineral_stacker.dm
@@ -1,5 +1,6 @@
 /obj/machinery/mineral/stacking_machine
 	name = "stacking machine"
+	icon_state = "stacker"
 	console = /obj/machinery/computer/mining
 	input_turf =  EAST
 	output_turf = WEST

--- a/code/modules/reagents/reagent_containers/drinkingglass/glass_boxes.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/glass_boxes.dm
@@ -2,7 +2,6 @@
 	name = "glassware box"
 	desc = "A box of assorted glassware"
 	can_hold = list(/obj/item/chems/food/drinks/glass2)
-
 	startswith = list(
 		/obj/item/chems/food/drinks/glass2/square,
 		/obj/item/chems/food/drinks/glass2/rocks,

--- a/maps/tradeship/tradeship-0.dmm
+++ b/maps/tradeship/tradeship-0.dmm
@@ -32,35 +32,7 @@
 "ai" = (
 /turf/simulated/floor/airless,
 /area/space)
-"aj" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
-	},
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor,
-/area/ship/trade/loading_bay)
 "ak" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/light/small{
-	icon_state = "bulb_map";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/ship/trade/fore_port_underside_maint)
-"am" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/ship/trade/fore_port_underside_maint)
 "an" = (
@@ -84,28 +56,26 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/loading_bay)
 "ap" = (
-/obj/machinery/door/airlock/hatch/autoname/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/autoset,
-/turf/simulated/floor/plating,
-/area/ship/trade/disused)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor,
+/area/ship/trade/undercomms)
 "aq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/beige{
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster{
 	pixel_y = -30
 	},
@@ -165,20 +135,14 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/trade/loading_bay)
 "ax" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/item/stool/padded,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-8";
+	pixel_y = 0
 	},
-/obj/item/stool/padded,
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/ship/trade/disused)
 "ay" = (
@@ -193,16 +157,18 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/trade/loading_bay)
 "az" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-8";
+	pixel_y = 0
 	},
-/obj/item/stool/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/ship/trade/disused)
 "aA" = (
@@ -388,129 +354,39 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ship/trade/loading_bay)
-"aS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
-/area/ship/trade/disused)
 "aT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 8
 	},
 /obj/machinery/light_switch{
 	pixel_y = -20
 	},
-/turf/simulated/floor,
-/area/ship/trade/disused)
-"aU" = (
-/obj/machinery/door/airlock/hatch/autoname/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/autoset,
-/turf/simulated/floor/plating,
-/area/ship/trade/disused)
-"aV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
-/area/ship/trade/fore_port_underside_maint)
-"aY" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id_tag = "trash_sort"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/ship/trade/loading_bay)
+/turf/simulated/floor/tiled,
+/area/ship/trade/disused)
 "ba" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor,
 /area/ship/trade/fore_port_underside_maint)
 "bb" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	icon_state = "warningcorner";
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
-	},
 /turf/simulated/floor,
 /area/ship/trade/loading_bay)
-"bc" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/ship/trade/loading_bay)
-"bd" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/bed/roller/ironingboard,
-/turf/simulated/floor,
-/area/ship/trade/fore_port_underside_maint)
-"be" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/ship/trade/fore_starboard_underside_maint)
-"bf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/random/trash,
-/obj/structure/mattress,
-/turf/simulated/floor,
-/area/ship/trade/fore_port_underside_maint)
 "bg" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -537,25 +413,18 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/loading_bay)
 "bh" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 6
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 1
 	},
-/obj/machinery/light_switch{
-	pixel_x = 20
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/loading_bay)
@@ -567,10 +436,6 @@
 	d2 = 2;
 	icon_state = "1-2";
 	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
@@ -599,30 +464,11 @@
 /obj/item/trash/mollusc_shell/clam,
 /turf/simulated/floor,
 /area/ship/trade/disused)
-"bm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/light/small{
-	icon_state = "bulb_map";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/ship/trade/fore_starboard_underside_maint)
 "bn" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/effect/wallframe_spawn/reinforced,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
-/area/ship/trade/fore_starboard_underside_maint)
+/area/ship/trade/livestock)
 "bo" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8;
@@ -631,23 +477,8 @@
 /turf/simulated/floor,
 /area/ship/trade/fore_port_underside_maint)
 "bp" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4;
-	level = 2
-	},
-/turf/simulated/floor,
-/area/ship/trade/fore_starboard_underside_maint)
-"bq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor,
-/area/ship/trade/fore_starboard_underside_maint)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/trade/livestock)
 "br" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -666,56 +497,18 @@
 /turf/simulated/floor/tiled,
 /area/ship/trade/loading_bay)
 "bs" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
-	},
+/obj/item/hatchet,
 /turf/simulated/floor,
 /area/ship/trade/aft_port_underside_maint)
-"bt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/ship/trade/fore_starboard_underside_maint)
 "bu" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment/bent{
-	icon_state = "pipe-c";
+/obj/machinery/door/window,
+/obj/machinery/door/window{
+	icon_state = "right";
 	dir = 1
 	},
-/obj/machinery/honey_extractor,
-/turf/simulated/floor,
-/area/ship/trade/fore_starboard_underside_maint)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/trade/livestock)
 "bv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -725,31 +518,25 @@
 	icon_state = "corner_white";
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
-/area/ship/trade/loading_bay)
-"bx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/closet/crate/hydroponics/beekeeping,
-/turf/simulated/floor,
-/area/ship/trade/fore_starboard_underside_maint)
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/ship/trade/loading_bay)
 "by" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/random/trash,
 /turf/simulated/floor,
 /area/ship/trade/fore_port_underside_maint)
 "bz" = (
@@ -776,6 +563,10 @@
 /obj/effect/floor_decal/corner/beige{
 	icon_state = "corner_white";
 	dir = 10
+	},
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/ship/trade/loading_bay)
@@ -847,33 +638,11 @@
 /turf/simulated/floor/tiled,
 /area/ship/trade/loading_bay)
 "bH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/ship/trade/fore_port_underside_maint)
-"bI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/ship/trade/fore_starboard_underside_maint)
 "bJ" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -987,9 +756,6 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/loading_bay)
 "bS" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -999,11 +765,7 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/ship/trade/aft_starboard_underside_maint)
 "bT" = (
@@ -1135,18 +897,9 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/loading_bay)
 "ca" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/random/drinkbottle,
 /turf/simulated/floor,
 /area/ship/trade/aft_starboard_underside_maint)
 "cb" = (
@@ -1155,6 +908,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/closet/crate/hydroponics/beekeeping,
 /turf/simulated/floor,
 /area/ship/trade/aft_port_underside_maint)
 "cc" = (
@@ -1174,6 +928,10 @@
 	},
 /turf/simulated/floor,
 /area/ship/trade/loading_bay)
+"cr" = (
+/obj/item/minihoe,
+/turf/simulated/floor,
+/area/ship/trade/aft_starboard_underside_maint)
 "cI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1197,6 +955,18 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/loading_bay)
+"cQ" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/undercomms)
 "cX" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -1220,6 +990,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ship/trade/disused)
+"dN" = (
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/obj/item/minihoe,
+/turf/simulated/floor,
+/area/ship/trade/aft_port_underside_maint)
 "en" = (
 /turf/simulated/floor/wood/walnut,
 /area/ship/trade/disused)
@@ -1236,6 +1011,40 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ship/trade/loading_bay)
+"fe" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/door/airlock/hatch/autoname/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/ship/trade/undercomms)
+"fp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	icon_state = "bulb_map";
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/ship/trade/fore_port_underside_maint)
 "fq" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1316,6 +1125,9 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/ship/trade/loading_bay)
+"hF" = (
+/turf/simulated/floor,
+/area/ship/trade/aft_starboard_underside_maint)
 "hZ" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -1323,24 +1135,7 @@
 	},
 /turf/simulated/floor,
 /area/ship/trade/loading_bay)
-"iq" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 2
-	},
-/obj/random/trash,
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/ship/trade/loading_bay)
-"iD" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/suit/rubber,
-/turf/simulated/floor,
-/area/ship/trade/loading_bay)
-"iH" = (
+"ic" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -1350,11 +1145,29 @@
 	name = "External Blast Doors";
 	opacity = 0
 	},
-/obj/structure/disposalpipe/segment{
+/turf/simulated/floor/plating,
+/area/ship/trade/livestock)
+"iy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/ship/trade/fore_starboard_underside_maint)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/ship/trade/disused)
+"iD" = (
+/obj/structure/closet/crate,
+/obj/item/clothing/suit/rubber,
+/turf/simulated/floor,
+/area/ship/trade/loading_bay)
 "iY" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -1363,6 +1176,16 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/ship/trade/disused)
+"jk" = (
+/obj/item/mollusc/barnacle{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/turf/simulated/floor/airless,
+/area/ship/trade/livestock)
+"jT" = (
+/turf/simulated/floor/airless,
+/area/ship/trade/livestock)
 "kO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1383,6 +1206,23 @@
 /turf/simulated/floor,
 /area/ship/trade/loading_bay)
 "lg" = (
+/obj/item/stool/bar/padded,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/ship/trade/disused)
+"ls" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -1394,14 +1234,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/item/stool/bar/padded,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled,
-/area/ship/trade/disused)
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/simulated/floor,
+/area/ship/trade/aft_port_underside_maint)
 "lv" = (
-/obj/effect/paint/brown,
-/turf/simulated/wall/r_wall/hull,
-/area/ship/trade/fore_starboard_underside_maint)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/bluegrid,
+/area/ship/trade/undercomms)
 "lA" = (
 /turf/simulated/wall,
 /area/ship/trade/disused)
@@ -1416,7 +1255,7 @@
 	},
 /turf/simulated/floor,
 /area/ship/trade/loading_bay)
-"oo" = (
+"ne" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -1426,7 +1265,43 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor,
+/area/ship/trade/fore_port_underside_maint)
+"nz" = (
+/obj/machinery/door/blast/regular{
+	density = 1;
+	dir = 4;
+	icon_state = "pdoor1";
+	id_tag = "xenovent";
+	name = "Specimen Consignment Shutter";
+	opacity = 1
+	},
+/turf/simulated/floor,
+/area/ship/trade/livestock)
+"nE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/random/trash,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor,
+/area/ship/trade/fore_port_underside_maint)
+"oo" = (
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/simulated/floor,
 /area/ship/trade/aft_starboard_underside_maint)
+"or" = (
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/simulated/floor,
+/area/ship/trade/aft_port_underside_maint)
 "os" = (
 /obj/structure/lattice,
 /obj/item/mollusc/barnacle{
@@ -1440,6 +1315,10 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/ship/trade/disused)
 "oO" = (
@@ -1451,6 +1330,10 @@
 /obj/random/tool,
 /turf/simulated/floor,
 /area/ship/trade/aft_starboard_underside_maint)
+"oP" = (
+/obj/effect/paint/brown,
+/turf/simulated/wall,
+/area/ship/trade/livestock)
 "oU" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -1482,6 +1365,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/ship/trade/loading_bay)
+"pG" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	icon_state = "map-supply";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/ship/trade/disused)
 "pU" = (
 /obj/structure/window/basic,
 /obj/structure/curtain/open/bed{
@@ -1491,10 +1384,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/loading_bay)
+"qt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled,
+/area/ship/trade/disused)
 "qK" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/trade/loading_bay)
+"qQ" = (
+/obj/machinery/network/relay{
+	initial_network_id = "tradenet"
+	},
+/turf/simulated/floor/bluegrid,
+/area/ship/trade/undercomms)
 "rp" = (
 /obj/effect/floor_decal/corner/beige,
 /obj/effect/floor_decal/corner/beige{
@@ -1515,51 +1418,78 @@
 /obj/structure/bed/chair/padded/beige,
 /turf/simulated/floor/carpet/red,
 /area/ship/trade/disused)
-"sX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/ship/trade/fore_starboard_underside_maint)
-"ty" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
+"rv" = (
 /obj/item/radio/intercom{
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
 /area/ship/trade/loading_bay)
-"tD" = (
+"rI" = (
+/obj/structure/table/standard,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/syringes,
+/obj/item/scalpel,
+/obj/item/storage/box/monkeycubes,
+/obj/item/circular_saw,
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/livestock)
+"sO" = (
+/turf/simulated/floor,
+/area/ship/trade/loading_bay)
+"sX" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/autoset,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
+/area/ship/trade/livestock)
+"tD" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
 /area/ship/trade/loading_bay)
 "tM" = (
-/obj/structure/disposalpipe/trunk{
+/obj/effect/wallframe_spawn/reinforced,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/disposal/deliveryChute{
-	dir = 8;
-	icon_state = "intake";
-	name = "disposals ejection chute"
-	},
-/obj/structure/sign/warning/deathsposal{
-	pixel_y = -32
-	},
-/turf/simulated/floor,
-/area/ship/trade/loading_bay)
+/turf/simulated/floor/plating,
+/area/ship/trade/livestock)
 "ug" = (
 /obj/effect/floor_decal/corner/beige{
 	icon_state = "corner_white";
@@ -1569,6 +1499,10 @@
 /area/ship/trade/loading_bay)
 "un" = (
 /obj/structure/janitorialcart,
+/obj/item/storage/box/water{
+	pixel_x = -10;
+	pixel_y = -5
+	},
 /turf/simulated/floor,
 /area/ship/trade/aft_port_underside_maint)
 "ux" = (
@@ -1587,18 +1521,13 @@
 	},
 /turf/simulated/floor,
 /area/ship/trade/fore_port_underside_maint)
+"vn" = (
+/obj/structure/extinguisher_cabinet,
+/turf/simulated/wall,
+/area/ship/trade/undercomms)
 "vP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment/bent,
-/turf/simulated/floor,
-/area/ship/trade/fore_starboard_underside_maint)
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/livestock)
 "ws" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -1611,6 +1540,37 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/aft_starboard_underside_maint)
+"wG" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/ship/trade/loading_bay)
+"wP" = (
+/obj/structure/disposalpipe/trunk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/disposal,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/livestock)
 "xc" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall,
@@ -1624,17 +1584,29 @@
 	},
 /turf/simulated/floor,
 /area/ship/trade/fore_port_underside_maint)
+"xy" = (
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/ship/trade/aft_port_underside_maint)
 "xF" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/ship/trade/loading_bay)
 "xP" = (
-/obj/effect/paint/brown,
-/turf/simulated/wall,
-/area/ship/trade/fore_starboard_underside_maint)
-"xV" = (
-/turf/simulated/floor,
-/area/ship/trade/fore_starboard_underside_maint)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/livestock)
 "xZ" = (
 /obj/machinery/power/apc{
 	dir = 2;
@@ -1663,6 +1635,30 @@
 /obj/item/caution,
 /turf/simulated/floor,
 /area/ship/trade/aft_port_underside_maint)
+"yr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/ship/trade/disused)
 "yE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1683,6 +1679,14 @@
 "yQ" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/loading_bay)
+"yT" = (
+/obj/machinery/honey_extractor,
+/obj/item/seeds/tomatoseed,
+/turf/simulated/floor,
+/area/ship/trade/aft_port_underside_maint)
+"zb" = (
+/turf/simulated/wall,
+/area/ship/trade/livestock)
 "zi" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -1694,48 +1698,54 @@
 "zw" = (
 /turf/simulated/floor/carpet/green,
 /area/ship/trade/disused)
+"AG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24
+	},
+/obj/structure/hygiene/sink/kitchen{
+	dir = 4;
+	icon_state = "sink_alt";
+	pixel_x = -22
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/livestock)
 "AO" = (
 /obj/structure/hygiene/drain,
 /mob/living/simple_animal/mouse,
 /turf/simulated/floor,
 /area/ship/trade/aft_starboard_underside_maint)
-"AY" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/ship/trade/loading_bay)
+"AZ" = (
+/obj/machinery/smartfridge/secure/extract,
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/livestock)
 "Bm" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/trade/fore_port_underside_maint)
-"Cj" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"Cg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/machinery/light,
-/obj/item/storage/box/water{
-	pixel_x = -10;
-	pixel_y = -5
+/obj/random/trash,
+/obj/structure/mattress,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
 /turf/simulated/floor,
-/area/ship/trade/fore_starboard_underside_maint)
-"Da" = (
+/area/ship/trade/fore_port_underside_maint)
+"Ck" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -1755,6 +1765,45 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/loading_bay)
+"DT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/trade/undercomms)
+"DV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled,
+/area/ship/trade/disused)
+"Ff" = (
+/obj/structure/flora/pottedplant/bamboo,
+/turf/simulated/floor/carpet/red,
+/area/ship/trade/disused)
+"Ft" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor,
+/area/ship/trade/undercomms)
 "FD" = (
 /obj/item/mollusc/barnacle{
 	pixel_x = -5;
@@ -1762,16 +1811,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/space)
-"FT" = (
-/obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/ship/trade/disused)
 "Gb" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
@@ -1788,44 +1827,38 @@
 /turf/simulated/floor,
 /area/ship/trade/aft_starboard_underside_maint)
 "GH" = (
-/obj/machinery/door/airlock/hatch/autoname/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/ship/trade/fore_starboard_underside_maint)
-"GP" = (
-/turf/simulated/floor/carpet/green,
-/area/ship/trade/disused)
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/livestock)
 "GQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor,
-/area/ship/trade/fore_starboard_underside_maint)
+/mob/living/carbon/slime,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/trade/livestock)
 "Hk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+/obj/item/radio/intercom{
+	pixel_y = 24
 	},
-/obj/item/trash/mollusc_shell/barnacle,
-/turf/simulated/floor,
-/area/ship/trade/fore_starboard_underside_maint)
+/obj/machinery/optable,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/livestock)
+"HG" = (
+/obj/effect/decal/cleanable/generic,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/bluegrid,
+/area/ship/trade/undercomms)
 "HS" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -1835,7 +1868,33 @@
 	dir = 4
 	},
 /turf/simulated/floor/airless,
-/area/space)
+/area/ship/trade/livestock)
+"If" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/ship/trade/fore_port_underside_maint)
+"Iu" = (
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled,
+/area/ship/trade/disused)
+"Iv" = (
+/obj/effect/paint/brown,
+/turf/simulated/wall/r_wall/hull,
+/area/ship/trade/livestock)
 "IG" = (
 /obj/structure/bed/chair/comfy/green{
 	dir = 1
@@ -1855,6 +1914,17 @@
 /obj/structure/stairs/west,
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/loading_bay)
+"IQ" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/deliveryChute{
+	dir = 8;
+	icon_state = "intake";
+	name = "disposals ejection chute"
+	},
+/turf/simulated/floor,
+/area/ship/trade/loading_bay)
 "Jz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1865,6 +1935,30 @@
 "JI" = (
 /turf/simulated/floor/tiled,
 /area/ship/trade/loading_bay)
+"JQ" = (
+/turf/simulated/wall,
+/area/ship/trade/undercomms)
+"Ky" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/ship/trade/loading_bay)
+"KO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/ship/trade/aft_starboard_underside_maint)
 "KZ" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1873,6 +1967,40 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/ship/trade/loading_bay)
+"Lm" = (
+/obj/effect/paint/brown,
+/turf/simulated/wall/r_wall/hull,
+/area/ship/trade/undercomms)
+"Lx" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	icon_state = "apc0";
+	name = "south bump";
+	pixel_x = 24;
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1;
+	d2 = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/livestock)
+"Lz" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/livestock)
 "LB" = (
 /obj/structure/lattice,
 /obj/structure/bed,
@@ -1880,33 +2008,79 @@
 /obj/structure/curtain/open/bed,
 /turf/simulated/floor/wood/walnut,
 /area/ship/trade/disused)
+"LH" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/bed/roller/ironingboard,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor,
+/area/ship/trade/fore_port_underside_maint)
 "LI" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/ship/trade/fore_starboard_underside_maint)
-"LO" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 5
+/obj/machinery/button/blast_door{
+	id_tag = "xenovent";
+	name = "vent control";
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/livestock)
+"LO" = (
+/obj/structure/sign/warning/deathsposal{
+	dir = 1;
+	pixel_y = 32
 	},
 /turf/simulated/floor,
 /area/ship/trade/loading_bay)
 "Mb" = (
-/turf/simulated/wall,
-/area/ship/trade/fore_starboard_underside_maint)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/trade/undercomms)
 "Ms" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	icon_state = "pipe-c";
+	dir = 2
 	},
-/turf/simulated/wall,
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/livestock)
+"MI" = (
+/obj/machinery/light_switch{
+	pixel_x = 20
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
 /area/ship/trade/loading_bay)
 "MK" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1922,28 +2096,50 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/loading_bay)
-"MX" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
+"MY" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8;
+	level = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/livestock)
+"Nq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
-/area/ship/trade/fore_starboard_underside_maint)
+/area/ship/trade/fore_port_underside_maint)
 "NR" = (
 /obj/structure/mattress,
 /obj/item/trash/mollusc_shell,
 /turf/simulated/floor,
 /area/ship/trade/fore_port_underside_maint)
+"Pa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor,
+/area/ship/trade/disused)
 "PF" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled,
 /area/ship/trade/loading_bay)
 "PZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -1991,8 +2187,15 @@
 	icon_state = "";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor,
 /area/ship/trade/loading_bay)
+"QQ" = (
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/ship/trade/aft_starboard_underside_maint)
 "QW" = (
 /obj/item/stack/tile/floor{
 	amount = 5
@@ -2002,35 +2205,24 @@
 /obj/item/stool/padded,
 /turf/simulated/floor,
 /area/ship/trade/disused)
-"Rr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/ship/trade/fore_starboard_underside_maint)
-"RT" = (
-/obj/machinery/door/airlock/hatch/autoname/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+"Ss" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/turf/simulated/floor/plating,
-/area/ship/trade/aft_starboard_underside_maint)
-"Sm" = (
-/turf/simulated/floor/tiled/steel_grid,
-/area/ship/trade/loading_bay)
+/turf/simulated/floor,
+/area/ship/trade/fore_port_underside_maint)
 "SC" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
@@ -2065,6 +2257,10 @@
 /obj/structure/flora/pottedplant/bamboo,
 /turf/simulated/floor,
 /area/ship/trade/disused)
+"TA" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/trade/livestock)
 "Ua" = (
 /obj/structure/bed/chair/wood/walnut,
 /turf/simulated/floor/carpet/red,
@@ -2076,25 +2272,6 @@
 "Ux" = (
 /turf/simulated/floor/carpet/red,
 /area/ship/trade/disused)
-"UF" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/structure/table/standard,
-/obj/item/seeds/tobaccoseed,
-/obj/item/seeds/tomatoseed,
-/obj/item/hatchet,
-/obj/item/chems/glass/bottle/eznutrient,
-/obj/item/chems/glass/bottle/eznutrient,
-/obj/item/minihoe,
-/turf/simulated/floor,
-/area/ship/trade/fore_starboard_underside_maint)
 "UI" = (
 /obj/structure/disposaloutlet{
 	icon_state = "outlet";
@@ -2125,36 +2302,45 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/aft_port_underside_maint)
-"XU" = (
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 2
-	},
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/ship/trade/loading_bay)
-"Yc" = (
-/obj/effect/paint/brown,
-/turf/simulated/wall,
-/area/ship/trade/aft_starboard_underside_maint)
-"Yd" = (
-/obj/random/trash,
-/turf/simulated/floor,
-/area/ship/trade/loading_bay)
-"YH" = (
+"XL" = (
+/obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/autoset,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/disused)
+"Yc" = (
+/obj/effect/paint/brown,
+/turf/simulated/wall,
+/area/ship/trade/aft_starboard_underside_maint)
+"Yd" = (
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/ship/trade/livestock)
+"Yh" = (
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light/small{
+	icon_state = "bulb_map";
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 2;
+	level = 2
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/trade/undercomms)
+"YH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/structure/closet/crate,
 /obj/item/clothing/accessory/medal/gold,
@@ -2162,6 +2348,18 @@
 /obj/random_multi/single_item/captains_spare_id,
 /turf/simulated/floor,
 /area/ship/trade/aft_starboard_underside_maint)
+"YL" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/obj/item/chems/glass/bottle/eznutrient,
+/obj/item/chems/glass/bottle/eznutrient,
+/obj/item/seeds/tomatoseed,
+/obj/item/seeds/tomatoseed,
+/obj/structure/table/standard,
+/turf/simulated/floor,
+/area/ship/trade/aft_port_underside_maint)
 "YW" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -2171,6 +2369,10 @@
 /obj/random/single/textbook,
 /turf/simulated/floor,
 /area/ship/trade/loading_bay)
+"YZ" = (
+/obj/structure/hygiene/sink/puddle,
+/turf/simulated/floor,
+/area/ship/trade/aft_starboard_underside_maint)
 "Zz" = (
 /obj/machinery/power/apc{
 	dir = 2;
@@ -2189,17 +2391,13 @@
 /turf/simulated/floor,
 /area/ship/trade/aft_starboard_underside_maint)
 "ZA" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
+/obj/structure/disposaloutlet,
+/obj/structure/disposalpipe/trunk{
+	icon_state = "pipe-t";
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/ship/trade/fore_starboard_underside_maint)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/trade/livestock)
 "ZB" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -2212,9 +2410,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/fore_port_underside_maint)
-"ZL" = (
-/turf/simulated/floor/wood/walnut,
-/area/ship/trade/disused)
 "ZR" = (
 /obj/structure/window/basic,
 /obj/structure/curtain/open/bed,
@@ -4554,7 +4749,7 @@ aa
 aa
 aa
 aa
-aa
+as
 aa
 aa
 aa
@@ -4635,26 +4830,26 @@ aa
 aa
 aa
 aa
-aa
-aa
+as
+as
+as
 as
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+as
+Gb
+Bm
+ai
+ai
+ai
+FD
+Bm
+xc
+as
+as
+as
+as
+as
 aa
 as
 aa
@@ -4718,26 +4913,26 @@ aa
 aa
 aa
 aa
-as
-as
-as
-as
-aa
-as
+oX
+Gb
+Gb
+Gb
+ZB
+Gb
 Gb
 Bm
-ai
-ai
-ai
-FD
+Bm
+ZB
+ZB
+Bm
 Bm
 xc
-as
-as
-as
-as
-as
-aa
+xc
+xc
+xc
+xc
+xc
+xc
 as
 as
 aa
@@ -4798,27 +4993,27 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-oX
+SC
+SC
+SC
 Gb
-Gb
-ZB
-Gb
-Gb
-Bm
-Bm
-ZB
-ZB
-Bm
-Bm
-xc
-xc
-xc
-xc
-xc
-xc
+fp
+ne
+ne
+ne
+ne
+fq
+Ss
+LH
+Cg
+nE
+fq
+kO
+kO
+kO
+bX
+YL
+bJ
 xc
 ar
 aa
@@ -4880,28 +5075,28 @@ aa
 aa
 aa
 aa
-aa
 SC
-SC
-SC
-Gb
+Ff
+Ux
+Xe
+Nq
 ak
-aV
-aV
-aV
+ak
+ak
+ak
 ba
 bH
-bd
-bf
+bH
+Ck
 by
-fq
-kO
-kO
-kO
-bX
+ba
+or
+xy
+dN
+yE
 bs
-bJ
-xc
+yT
+XK
 ar
 aa
 aa
@@ -4962,12 +5157,12 @@ aa
 aa
 aa
 aa
-aa
 SC
 Qh
 IG
 Xe
-am
+If
+ak
 yO
 hg
 yO
@@ -4980,7 +5175,7 @@ yO
 yO
 yO
 yO
-yE
+ls
 Xo
 un
 XK
@@ -5044,12 +5239,12 @@ aa
 aa
 aa
 aa
-aa
 fY
 LB
 hf
 Xe
-Da
+Nq
+ak
 xF
 af
 UI
@@ -5126,12 +5321,12 @@ aa
 aa
 aa
 aa
-aa
 ux
 lA
 ad
 lA
-ap
+XL
+lA
 yO
 ag
 hZ
@@ -5208,11 +5403,11 @@ aa
 aa
 aa
 aa
-aa
 SC
 SS
 iY
 cX
+yr
 aq
 yO
 cc
@@ -5290,19 +5485,19 @@ aa
 aa
 aa
 aa
-aa
 fY
 en
 ae
-ZL
+en
+DV
 ax
 pU
 zi
 lB
-XU
-JI
-JI
-JI
+sO
+sO
+sO
+sO
 Qy
 ao
 yO
@@ -5372,24 +5567,24 @@ aa
 aa
 aa
 aa
-aa
 fY
 rt
 hc
 bk
+pG
 az
 eu
 cd
 kS
-aj
-JI
-JI
-JI
-JI
+sO
+sO
+sO
+sO
+sO
 bL
 II
 bz
-Sm
+yQ
 bO
 au
 ay
@@ -5454,24 +5649,24 @@ aa
 aa
 aa
 aa
-aa
 fY
 Ua
 fV
 bl
-aS
+Pa
+iy
 ZR
 cd
-kS
-iq
-JI
-JI
-JI
-JI
+hZ
+sO
+sO
+sO
+sO
+sO
 bL
 yQ
 bz
-Sm
+yQ
 bP
 av
 aD
@@ -5536,20 +5731,20 @@ aa
 aa
 aa
 aa
-aa
 fY
 en
-ZL
+en
 QW
+qt
 lg
 eu
-cd
+iD
 pg
-XU
-JI
-JI
-JI
-JI
+sO
+sO
+sO
+sO
+sO
 bg
 JI
 aI
@@ -5618,20 +5813,20 @@ aa
 aa
 aa
 aa
-aa
 SC
 rp
+Iu
 oG
-FT
+qt
 aT
 yO
 LO
-aY
+YW
 bb
 PF
-AY
-bc
-ty
+PF
+PF
+PF
 bh
 bi
 br
@@ -5700,22 +5895,22 @@ aa
 aa
 aa
 aa
-aa
 ux
 lA
 Ug
-lA
-aU
-yO
-iD
-YW
-yO
+JQ
+JQ
+fe
+JQ
+sO
+IQ
+sO
 tD
-yO
-yO
-yO
-yO
-yO
+wG
+Ky
+rv
+Ky
+MI
 bv
 yO
 yO
@@ -5782,22 +5977,22 @@ aa
 aa
 aa
 aa
-aa
 fY
 gf
-GP
+zw
+JQ
 Mb
-be
-xF
+ap
+JQ
 Yd
 tM
-yO
+zb
 sX
-MX
-MX
-MX
-UF
-yO
+zb
+zb
+zb
+zb
+zb
 bB
 SE
 bS
@@ -5864,22 +6059,22 @@ aa
 aa
 aa
 aa
-aa
 SC
 zw
 Ux
-Mb
-Rr
-yO
-yO
+JQ
+Yh
+Ft
+vn
+rI
 Ms
-yO
+AG
 LI
-bn
+zb
 bp
-xV
-Cj
-yO
+bp
+bp
+zb
 yO
 yO
 YH
@@ -5946,29 +6141,29 @@ aa
 aa
 aa
 aa
-aa
 SC
-SC
-SC
+zw
+Ux
+JQ
 lv
-bm
-bq
+DT
+JQ
 Hk
 vP
 GH
-bt
+MY
 bu
-bx
+bp
 GQ
-bI
-RT
+bp
+zb
 oo
-oo
+cr
 ca
-oO
-bK
-Yc
-ar
+hF
+YZ
+ws
+ai
 aa
 aa
 aa
@@ -6028,27 +6223,27 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-lv
-lv
+SC
+SC
+SC
+Lm
+qQ
+HG
+JQ
+AZ
+Lx
+xP
+wP
+bn
 ZA
-lv
-lv
-xP
-xP
-iH
-ZA
-xP
-xP
-Yc
-Yc
-Yc
-Yc
-Yc
-Yc
+bp
+TA
+zb
+oo
+QQ
+KO
+oO
+bK
 Yc
 ar
 aa
@@ -6112,27 +6307,27 @@ aa
 aa
 aa
 aa
-as
-as
-as
-as
-as
-as
-lv
-xP
-ai
-HS
-FD
-ai
-xP
+aa
+Lm
+Lm
+cQ
+Lm
+ic
+Iv
+Lz
+oP
+oP
+nz
+nz
+nz
+oP
 Yc
-as
-as
-aa
-aa
-as
-as
-as
+Yc
+Yc
+Yc
+Yc
+Yc
+ar
 aa
 aa
 aa
@@ -6193,27 +6388,27 @@ aa
 aa
 aa
 aa
+as
+as
+as
+as
 aa
-aa
+as
+as
+Iv
+HS
+oP
+oP
+jk
+jT
+jk
+oP
+as
 as
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+as
+as
 as
 aa
 aa
@@ -6276,6 +6471,7 @@ aa
 aa
 aa
 aa
+as
 aa
 aa
 aa
@@ -6295,8 +6491,7 @@ aa
 aa
 aa
 aa
-aa
-aa
+as
 aa
 aa
 aa

--- a/maps/tradeship/tradeship-1.dmm
+++ b/maps/tradeship/tradeship-1.dmm
@@ -190,15 +190,15 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/trade/escape_port)
 "aF" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 5
 	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/atmospherics/portables_connector{
-	icon_state = "map_connector";
-	dir = 4
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 9
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled,
 /area/ship/trade/cargo/lower)
 "aG" = (
 /obj/machinery/door/airlock/external/bolted{
@@ -264,10 +264,10 @@
 /area/ship/trade/escape_star)
 "aO" = (
 /turf/simulated/wall,
-/area/ship/trade/maintenance/robot)
+/area/ship/trade/artifact_storage)
 "aP" = (
 /turf/simulated/wall/r_wall,
-/area/ship/trade/maintenance/robot)
+/area/ship/trade/artifact_storage)
 "aR" = (
 /obj/structure/handrai{
 	icon_state = "handrail";
@@ -293,10 +293,10 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 9
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
 "aU" = (
@@ -327,44 +327,33 @@
 /turf/simulated/wall/r_wall,
 /area/ship/trade/crew/dorms1)
 "aZ" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/firealarm{
-	pixel_y = 18
-	},
-/obj/machinery/recharge_station,
-/turf/simulated/floor/plating,
-/area/ship/trade/maintenance/robot)
-"ba" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/alarm{
-	pixel_y = 17
+	pixel_y = 24
 	},
-/obj/effect/landmark/start{
-	name = "Robot"
+/obj/structure/table/standard,
+/obj/machinery/button/blast_door{
+	id_tag = "anomvent";
+	name = "emergency vent control"
 	},
-/turf/simulated/floor/plating,
-/area/ship/trade/maintenance/robot)
-"bb" = (
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/artifact_storage)
+"ba" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/light_switch{
+	pixel_w = 0;
+	pixel_x = 24;
+	pixel_z = 0
+	},
+/obj/machinery/power/apc{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "0-2";
 	pixel_y = 1;
 	d2 = 2
 	},
-/obj/machinery/light_switch{
-	pixel_x = 24
-	},
-/obj/machinery/power/apc{
-	dir = 1
-	},
-/obj/machinery/cryopod/robot,
-/obj/effect/landmark{
-	name = "JoinLateCyborg"
-	},
-/turf/simulated/floor/plating,
-/area/ship/trade/maintenance/robot)
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/artifact_storage)
 "bc" = (
 /obj/machinery/light{
 	dir = 8
@@ -450,21 +439,20 @@
 /turf/simulated/floor/tiled/monotile,
 /area/ship/trade/cargo/lower)
 "bi" = (
-/obj/machinery/light{
-	icon_state = "bulb1";
-	dir = 4
-	},
-/obj/structure/ladder,
-/obj/effect/decal/cleanable/cobweb,
 /obj/structure/sign/deck/second{
 	pixel_x = -32
 	},
+/obj/structure/ladder,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
 	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/structure/disposalpipe/up,
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/lower)
 "bj" = (
@@ -503,40 +491,24 @@
 /turf/simulated/floor/lino,
 /area/ship/trade/crew/dorms1)
 "bm" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/ship/trade/maintenance/robot)
-"bn" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/door/window{
+	icon_state = "left";
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/ship/trade/maintenance/robot)
+/turf/simulated/floor/reinforced,
+/area/ship/trade/artifact_storage)
+"bn" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	level = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/artifact_storage)
 "bo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/light/small{
-	flickering = 1
-	},
-/turf/simulated/floor/plating,
-/area/ship/trade/maintenance/robot)
-"bp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -544,27 +516,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/computer/cryopod{
-	pixel_y = -27
-	},
-/turf/simulated/floor/plating,
-/area/ship/trade/maintenance/robot)
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/artifact_storage)
 "br" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/structure/lattice,
 /obj/structure/disposalpipe/down,
 /turf/simulated/open,
@@ -645,7 +599,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/disposalpipe/up,
+/obj/structure/disposalpipe/segment{
+	icon_state = "pipe-c";
+	dir = 2
+	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/lower)
 "bB" = (
@@ -690,16 +647,7 @@
 /turf/simulated/floor/plating,
 /area/ship/trade/crew/dorms1)
 "bI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/ship/trade/maintenance/lower)
 "bJ" = (
@@ -859,32 +807,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/monotile,
 /area/ship/trade/cargo/lower)
-"bZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/structure/cable{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/ship/trade/maintenance/lower)
 "ca" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
@@ -1078,10 +1000,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
-"cz" = (
-/obj/effect/paint/brown,
-/turf/simulated/wall/r_wall,
-/area/space)
 "cC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -1361,6 +1279,12 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
 "dk" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/maintenance/lower)
+"dl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -1370,22 +1294,8 @@
 	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/ship/trade/maintenance/lower)
-"dl" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
-	},
-/obj/machinery/power/apc{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/ship/trade/drunk_tank)
 "dm" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/structure/cable{
@@ -1431,15 +1341,10 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/science)
 "ds" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+/obj/structure/disposalpipe/segment/bent{
+	icon_state = "pipe-c";
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -1558,21 +1463,23 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/lower)
-"dI" = (
-/obj/machinery/door_timer/cell_1{
-	name = "Drunk Tank";
-	pixel_x = 1;
-	pixel_y = -29;
-	id = "tank"
-	},
-/turf/simulated/floor/plating,
-/area/ship/trade/drunk_tank)
 "dJ" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/ship/trade/drunk_tank)
+"dK" = (
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/light_switch{
+	pixel_w = -23
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/science)
 "dL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -1592,31 +1499,21 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/science)
 "dP" = (
-/obj/effect/decal/cleanable/spiderling_remains,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment/bent{
-	icon_state = "pipe-c";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/plating,
 /area/ship/trade/maintenance/lower)
 "dR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1656,8 +1553,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/power/apc,
-/turf/simulated/floor/plating,
+/obj/machinery/power/apc{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
 /area/ship/trade/maintenance/lower)
 "dT" = (
 /obj/machinery/light{
@@ -1695,7 +1594,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/ship/trade/maintenance/lower)
 "dV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1712,7 +1611,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/ship/trade/maintenance/lower)
 "dW" = (
 /obj/structure/cable{
@@ -1735,19 +1634,16 @@
 /area/ship/trade/maintenance/lower)
 "dY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment/bent{
-	icon_state = "pipe-c";
-	dir = 8
+/obj/structure/cable{
+	icon_state = "5-8"
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/lower)
@@ -1757,21 +1653,6 @@
 "eb" = (
 /turf/simulated/wall/r_wall,
 /area/ship/trade/maintenance/storage)
-"ec" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/trade/maintenance/techstorage)
 "ed" = (
 /turf/simulated/wall/r_wall,
 /area/ship/trade/maintenance/eva)
@@ -1780,16 +1661,6 @@
 /area/ship/trade/maintenance/eva)
 "ef" = (
 /turf/simulated/wall/r_wall,
-/area/ship/trade/maintenance/techstorage)
-"ek" = (
-/obj/structure/closet/crate/plastic,
-/obj/item/storage/ore,
-/obj/item/pickaxe,
-/obj/item/stack/flag/yellow,
-/obj/item/storage/box/glowsticks,
-/obj/item/scanner/mining,
-/obj/item/floor_painter,
-/turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/techstorage)
 "em" = (
 /obj/machinery/light{
@@ -1835,6 +1706,11 @@
 /obj/item/clothing/mask/breath,
 /obj/item/tank/jetpack/oxygen,
 /obj/item/clothing/mask/breath,
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_z = 21;
+	pixel_w = 33
+	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/eva)
 "eq" = (
@@ -1924,7 +1800,7 @@
 	},
 /obj/machinery/door/airlock/hatch/autoname/engineering,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/trade/maintenance/storage)
+/area/ship/trade/maintenance/techstorage)
 "ez" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2090,53 +1966,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/techstorage)
-"eK" = (
-/obj/item/stock_parts/console_screen,
-/obj/item/stock_parts/console_screen,
-/obj/item/stock_parts/console_screen,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/micro_laser/ultra,
-/obj/structure/table/rack,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/trade/maintenance/techstorage)
-"eL" = (
-/obj/structure/table/rack,
-/obj/item/stock_parts/circuitboard/pacman/super/potato,
-/obj/item/stack/material/glass/reinforced_borosilicate/ten,
-/obj/item/stack/material/ocp/ten,
-/obj/item/stock_parts/circuitboard/unary_atmos/engine,
-/obj/item/stock_parts/circuitboard/unary_atmos/engine,
-/obj/item/stock_parts/circuitboard/unary_atmos/engine,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/trade/maintenance/techstorage)
 "eN" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/techstorage)
-"eP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start{
-	name = "Junior Engineer"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/trade/maintenance/storage)
 "eQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2184,24 +2016,20 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/eva)
 "eV" = (
-/obj/structure/table/standard,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/storage/box/lights/bulbs,
-/obj/item/storage/box/lights/mixed,
-/obj/item/taperoll/engineering,
-/obj/item/tape_roll,
+/obj/effect/landmark/start{
+	name = "Robot"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/techstorage)
 "eW" = (
-/obj/structure/table/standard,
-/obj/item/inflatable_dispenser,
-/obj/item/radio,
-/obj/item/radio,
-/obj/machinery/light,
-/obj/item/radio,
+/obj/machinery/computer/cryopod{
+	pixel_x = 32
+	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/trade/maintenance/storage)
+/area/ship/trade/maintenance/techstorage)
 "eY" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -2230,6 +2058,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/storage)
+"fa" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/drunk_tank)
 "fb" = (
 /obj/machinery/light,
 /obj/machinery/suit_cycler/tradeship,
@@ -2328,13 +2160,32 @@
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/eva)
 "he" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	icon_state = "conveyor0";
-	id_tag = "con"
-	},
-/turf/simulated/floor/tiled/steel_grid,
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
 /area/ship/trade/cargo/lower)
+"hf" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/ship/trade/maintenance/lower)
+"hn" = (
+/obj/effect/paint/brown,
+/turf/simulated/wall/r_wall,
+/area/ship/trade/maintenance/eva)
 "hp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/westleft,
@@ -2364,6 +2215,36 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/monotile,
 /area/ship/trade/cargo/lower)
+"it" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment/bent{
+	icon_state = "pipe-c";
+	dir = 4
+	},
+/obj/structure/sign/science_1{
+	pixel_x = -30
+	},
+/turf/simulated/floor/tiled,
+/area/ship/trade/maintenance/lower)
+"iH" = (
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 5;
+	pixel_y = -7
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/head/welding,
+/obj/item/scanner/gas,
+/obj/structure/table/rack,
+/obj/item/inflatable_dispenser,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/trade/maintenance/techstorage)
 "iW" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
@@ -2402,14 +2283,6 @@
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
 /area/ship/trade/crew/dorms1)
-"jH" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/tiled/white,
-/area/ship/trade/science)
 "jM" = (
 /obj/machinery/light{
 	icon_state = "bulb1";
@@ -2441,6 +2314,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/ship/trade/maintenance/lower)
+"kr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/drunk_tank)
 "kP" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
@@ -2462,32 +2339,42 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/science)
+"lg" = (
+/obj/structure/closet/crate/plastic,
+/obj/item/storage/ore,
+/obj/item/pickaxe,
+/obj/item/stack/flag/yellow,
+/obj/item/storage/box/glowsticks,
+/obj/item/scanner/mining,
+/obj/item/floor_painter,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/trade/maintenance/techstorage)
+"lw" = (
+/obj/machinery/conveyor_switch{
+	id_tag = "con";
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled,
+/area/ship/trade/cargo/lower)
 "lD" = (
-/obj/effect/paint/brown,
-/turf/simulated/wall/r_wall/hull,
-/area/ship/trade/maintenance/robot)
+/turf/simulated/floor/reinforced,
+/area/ship/trade/artifact_storage)
 "lE" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
 /area/ship/trade/cargo/lower)
+"lJ" = (
+/obj/machinery/door/airlock/hatch/autoname/general,
+/turf/simulated/floor/plating,
+/area/ship/trade/maintenance/lower)
 "lK" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
-"lO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/sign/science_1{
-	pixel_x = -30
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/ship/trade/maintenance/lower)
 "lZ" = (
 /turf/simulated/open,
 /area/ship/trade/cargo/lower)
@@ -2510,6 +2397,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ship/trade/cargo/lower)
+"my" = (
+/obj/machinery/cryopod/robot,
+/obj/effect/landmark{
+	name = "JoinLateCyborg"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/trade/maintenance/techstorage)
+"mN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/trade/maintenance/techstorage)
 "nb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -2532,6 +2435,18 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/trade/escape_star)
+"ni" = (
+/obj/structure/table/rack,
+/obj/item/stock_parts/circuitboard/pacman/super/potato,
+/obj/item/stack/material/glass/reinforced_borosilicate/ten,
+/obj/item/stack/material/ocp/ten,
+/obj/item/stock_parts/circuitboard/unary_atmos/engine,
+/obj/item/stock_parts/circuitboard/unary_atmos/engine,
+/obj/item/stock_parts/circuitboard/unary_atmos/engine,
+/obj/item/storage/box/lights/mixed,
+/obj/item/storage/box/lights/bulbs,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/trade/maintenance/techstorage)
 "nn" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -2547,30 +2462,26 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/techstorage)
-"ob" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/light_switch{
-	pixel_w = -23
-	},
+"nG" = (
+/obj/machinery/artifact_scanpad,
 /turf/simulated/floor/tiled/white,
-/area/ship/trade/science)
+/area/ship/trade/artifact_storage)
 "pn" = (
-/obj/item/tape_roll,
-/obj/item/stack/material/plasteel/fifty,
-/obj/item/stack/material/rods/fifty,
-/obj/item/stack/material/steel/fifty,
-/obj/item/stack/material/plastic/fifty,
-/obj/item/stack/material/steel/fifty,
-/obj/structure/closet/crate,
-/obj/item/stack/material/glass/fifty,
-/obj/item/stack/material/glass/fifty,
-/obj/item/stack/material/glass/reinforced/fifty,
-/obj/item/clothing/head/welding,
-/obj/item/stack/material/cardboard/fifty,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/landmark/start{
+	name = "Junior Engineer"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/techstorage)
 "pr" = (
@@ -2599,6 +2510,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/trade/escape_star)
+"qf" = (
+/obj/machinery/door/blast/regular{
+	density = 1;
+	icon_state = "pdoor1";
+	id_tag = "anomvent";
+	name = "Emergency Vent";
+	opacity = 1
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/artifact_storage)
 "ql" = (
 /obj/structure/handrai{
 	icon_state = "handrail";
@@ -2606,6 +2527,12 @@
 	},
 /turf/space,
 /area/space)
+"qF" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/trade/artifact_storage)
 "rb" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -2632,6 +2559,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ship/trade/cargo/lower)
+"rN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/ship/trade/maintenance/lower)
 "rP" = (
 /obj/structure/handrai{
 	icon_state = "handrail";
@@ -2639,6 +2573,9 @@
 	},
 /turf/space,
 /area/space)
+"rW" = (
+/turf/simulated/wall,
+/area/ship/trade/maintenance/lower)
 "sb" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/structure/cable{
@@ -2669,29 +2606,35 @@
 "sB" = (
 /turf/simulated/wall/r_wall,
 /area/ship/trade/science/fabricaton)
+"sM" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/science/fabricaton)
 "sY" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
 /area/ship/trade/escape_port)
-"tb" = (
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 5;
-	pixel_y = -7
+"ts" = (
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1;
+	d2 = 2
 	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/head/welding,
-/obj/item/scanner/gas,
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/trade/maintenance/techstorage)
-"tf" = (
-/obj/effect/paint/brown,
-/turf/simulated/wall/r_wall/hull,
-/area/ship/trade/science/fabricaton)
+/obj/machinery/power/apc{
+	dir = 1
+	},
+/obj/item/stool/padded,
+/turf/simulated/floor/plating,
+/area/ship/trade/drunk_tank)
 "tz" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/conveyor{
+	dir = 2;
+	icon_state = "conveyor0";
+	id_tag = "con"
+	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/plating,
 /area/ship/trade/cargo/lower)
 "tE" = (
 /obj/machinery/door/airlock/hatch/autoname/engineering,
@@ -2762,6 +2705,32 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/ship/trade/maintenance/lower)
+"uz" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/ship/trade/maintenance/lower)
+"uX" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/maintenance/lower)
 "uY" = (
 /obj/structure/closet/wardrobe/mixed,
 /obj/item/storage/backpack/dufflebag,
@@ -2804,14 +2773,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/airless,
 /area/ship/trade/crew/dorms1)
-"vz" = (
-/obj/machinery/conveyor_switch{
-	id_tag = "con";
-	pixel_x = 10;
-	pixel_y = 10
-	},
-/turf/simulated/floor/tiled,
-/area/ship/trade/cargo/lower)
 "vW" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
@@ -2827,6 +2788,20 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/ship/trade/escape_star)
+"wl" = (
+/obj/item/stock_parts/circuitboard/pacman,
+/obj/item/stock_parts/circuitboard/recharge_station,
+/obj/item/stock_parts/circuitboard/shield_generator,
+/obj/structure/table/rack,
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/trade/maintenance/techstorage)
 "wI" = (
 /obj/structure/bed/padded,
 /obj/machinery/light/small{
@@ -2870,6 +2845,31 @@
 	},
 /turf/simulated/floor/lino,
 /area/ship/trade/crew/dorms1)
+"yF" = (
+/obj/effect/paint/brown,
+/turf/simulated/wall,
+/area/ship/trade/maintenance/techstorage)
+"yL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1;
+	d2 = 2
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/ship/trade/maintenance/lower)
 "zb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2886,12 +2886,15 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/autoname/science,
 /turf/simulated/floor/plating,
-/area/ship/trade/maintenance/robot)
+/area/ship/trade/artifact_storage)
 "Ab" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/ship/trade/cargo/lower)
+"AM" = (
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/drunk_tank)
 "Bb" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2919,7 +2922,7 @@
 	id_tag = "con";
 	movedir = 6
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/plating,
 /area/ship/trade/cargo/lower)
 "BO" = (
 /obj/structure/bed/padded,
@@ -2943,6 +2946,8 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
+/obj/machinery/fabricator/industrial,
+/obj/item/stack/material/osmium/ten,
 /turf/simulated/floor/tiled,
 /area/ship/trade/cargo/lower)
 "CN" = (
@@ -2973,52 +2978,51 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/ship/trade/cargo/lower)
-"Dl" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/airless,
-/area/ship/trade/maintenance/robot)
 "DQ" = (
 /obj/machinery/door/airlock/hatch/autoname/engineering,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/ship/trade/maintenance/eva)
+"DV" = (
+/obj/machinery/door_timer/cell_1{
+	name = "Drunk Tank";
+	pixel_x = 1;
+	pixel_y = -29;
+	id = "tank"
+	},
+/obj/item/stool/padded,
+/turf/simulated/floor/plating,
+/area/ship/trade/drunk_tank)
 "DX" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
 /area/ship/trade/drunk_tank)
-"Eb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+"Ei" = (
+/turf/simulated/floor/airless,
+/area/space)
+"En" = (
+/obj/item/stool/padded,
+/turf/simulated/floor/plating,
+/area/ship/trade/drunk_tank)
+"EB" = (
+/obj/machinery/light{
+	icon_state = "bulb1";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/cobweb,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = -22
+/obj/structure/cable{
+	icon_state = "1-8";
+	d1 = 1;
+	d2 = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/plating,
 /area/ship/trade/maintenance/lower)
-"Ei" = (
-/turf/simulated/floor/airless,
-/area/space)
-"Fb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/trade/science/fabricaton)
 "Fw" = (
 /obj/item/stool/padded,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3082,6 +3086,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ship/trade/cargo/lower)
+"HY" = (
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/fabricator/protolathe{
+	initial_id_tag = "tradeship_rnd"
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/science/fabricaton)
 "Ib" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/holostool,
@@ -3104,11 +3121,15 @@
 /area/ship/trade/science/fabricaton)
 "IU" = (
 /obj/machinery/conveyor{
-	dir = 10;
-	icon_state = "conveyor1";
+	dir = 4;
+	icon_state = "conveyor0";
 	id_tag = "con"
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/obj/machinery/mineral/processing_unit{
+	input_turf = 1;
+	output_turf = 2
+	},
+/turf/simulated/floor/plating,
 /area/ship/trade/cargo/lower)
 "Jb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3127,6 +3148,16 @@
 /obj/machinery/door/airlock/hatch/autoname/science,
 /turf/simulated/floor/plating,
 /area/ship/trade/science/fabricaton)
+"Jl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/maintenance/lower)
 "Jr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -3136,13 +3167,9 @@
 /area/ship/trade/science/fabricaton)
 "Js" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/mining/drill,
+/obj/machinery/mining/brace,
 /turf/simulated/floor/tiled/monotile,
 /area/ship/trade/cargo/lower)
-"Jv" = (
-/obj/effect/paint/brown,
-/turf/simulated/wall/r_wall/hull,
-/area/space)
 "JM" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -3165,6 +3192,20 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/ship/trade/crew/dorms2)
+"La" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment/bent{
+	icon_state = "pipe-c";
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/maintenance/lower)
 "Lb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -3182,6 +3223,14 @@
 /obj/item/stool/padded,
 /turf/simulated/floor/tiled,
 /area/ship/trade/cargo/lower)
+"LE" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/trade/maintenance/techstorage)
 "Mb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3196,16 +3245,22 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/lower)
+"Ml" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled,
+/area/ship/trade/maintenance/lower)
 "Mx" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/trade/escape_port)
-"MK" = (
-/obj/item/mollusc/barnacle{
-	pixel_w = 18
-	},
-/turf/space,
-/area/space)
 "Nb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/department/security{
@@ -3221,6 +3276,13 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/science)
+"NM" = (
+/obj/effect/floor_decal/industrial/loading{
+	icon_state = "loadingarea";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/ship/trade/cargo/lower)
 "Ob" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3238,6 +3300,9 @@
 /obj/machinery/door/airlock/hatch/autoname/science,
 /turf/simulated/floor/plating,
 /area/ship/trade/science)
+"On" = (
+/turf/simulated/floor/tiled,
+/area/ship/trade/maintenance/lower)
 "Pb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3257,6 +3322,48 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/drunk_tank)
+"Py" = (
+/obj/effect/decal/cleanable/spiderling_remains,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment/bent{
+	icon_state = "pipe-c";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/maintenance/lower)
+"PJ" = (
+/obj/structure/curtain/open/bed,
+/obj/structure/bed/padded,
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/item/bedsheet/red,
+/obj/random_multi/single_item/captains_spare_id,
+/obj/effect/landmark/start{
+	name = "Head Engineer"
+	},
+/obj/item/stack/material/osmium/ten,
+/turf/simulated/floor/lino,
+/area/ship/trade/crew/dorms2)
 "Qb" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/door/firedoor,
@@ -3276,16 +3383,38 @@
 /mob/living/simple_animal/cat/fluff/ran,
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/science/fabricaton)
-"Qi" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = -22
+"Qg" = (
+/obj/effect/paint/brown,
+/obj/structure/sign/warning/caution,
+/turf/simulated/wall/r_wall,
+/area/ship/trade/artifact_storage)
+"QK" = (
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/micro_laser/ultra,
+/obj/structure/table/rack,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
 	},
-/obj/machinery/fabricator/protolathe{
-	initial_id_tag = "tradeship_rnd"
+/obj/structure/cable,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
 	},
+/obj/item/flashlight,
+/obj/item/flashlight,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/trade/maintenance/techstorage)
+"QV" = (
+/obj/machinery/artifact_analyser,
 /turf/simulated/floor/tiled/white,
-/area/ship/trade/science/fabricaton)
+/area/ship/trade/artifact_storage)
 "Rb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3301,10 +3430,7 @@
 /area/ship/trade/cargo/lower)
 "Rl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/processing_unit{
-	input_turf = 1;
-	output_turf = 2
-	},
+/obj/machinery/mineral/stacking_machine,
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
 "Rs" = (
@@ -3333,6 +3459,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/trade/drunk_tank)
+"Sc" = (
+/obj/machinery/conveyor{
+	dir = 10;
+	icon_state = "conveyor1";
+	id_tag = "con"
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/cargo/lower)
 "Sm" = (
 /obj/effect/floor_decal/corner/beige{
 	icon_state = "corner_white";
@@ -3355,6 +3489,14 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
+"Sx" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	icon_state = "conveyor0";
+	id_tag = "con"
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/cargo/lower)
 "Tb" = (
 /obj/machinery/light,
 /obj/machinery/botany/extractor,
@@ -3366,6 +3508,22 @@
 	},
 /turf/simulated/floor/airless,
 /area/space)
+"TC" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/trade/maintenance/techstorage)
+"TZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/ship/trade/maintenance/lower)
 "Ub" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3386,12 +3544,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/lower)
-"Ud" = (
-/obj/item/mollusc/barnacle{
-	pixel_z = 19
+"UX" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/plating,
+/area/ship/trade/drunk_tank)
+"Va" = (
+/obj/effect/paint/brown,
+/turf/simulated/wall/r_wall,
+/area/ship/trade/artifact_storage)
 "Vb" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3400,12 +3567,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "5-8"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/lower)
@@ -3413,10 +3583,41 @@
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
 /area/ship/trade/crew/dorms2)
-"VM" = (
-/obj/effect/paint/brown,
-/turf/simulated/wall,
-/area/ship/trade/maintenance/robot)
+"Vm" = (
+/obj/item/tape_roll,
+/obj/item/stack/material/plasteel/fifty,
+/obj/item/stack/material/rods/fifty,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/plastic/fifty,
+/obj/item/stack/material/steel/fifty,
+/obj/structure/closet/crate,
+/obj/item/stack/material/glass/fifty,
+/obj/item/stack/material/glass/fifty,
+/obj/item/stack/material/glass/reinforced/fifty,
+/obj/item/clothing/head/welding,
+/obj/item/stack/material/cardboard/fifty,
+/obj/item/tape_roll,
+/obj/item/taperoll/engineering,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/trade/maintenance/techstorage)
+"VX" = (
+/turf/simulated/floor/plating,
+/area/ship/trade/maintenance/lower)
+"Wi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled,
+/area/ship/trade/maintenance/lower)
 "Wm" = (
 /obj/machinery/network/relay{
 	initial_network_id = "tradenet"
@@ -3426,36 +3627,12 @@
 "WT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/computer/mining{
-	density = 0;
-	pixel_w = 32;
-	pixel_z = 0
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
 "WZ" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/trade/science)
-"Xb" = (
-/obj/item/stock_parts/circuitboard/pacman,
-/obj/item/stock_parts/circuitboard/recharge_station,
-/obj/item/stock_parts/circuitboard/shield_generator,
-/obj/structure/table/rack,
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/trade/maintenance/techstorage)
 "XF" = (
 /obj/structure/handrai{
 	icon_state = "handrail";
@@ -3475,6 +3652,12 @@
 /obj/item/stock_parts/circuitboard/unary_atmos/heater,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/techstorage)
+"YH" = (
+/turf/simulated/floor/airless,
+/area/ship/trade/maintenance/eva)
+"Za" = (
+/turf/simulated/floor/plating,
+/area/ship/trade/drunk_tank)
 "Zb" = (
 /obj/item/storage/toolbox/electrical,
 /obj/item/storage/toolbox/electrical{
@@ -3496,9 +3679,9 @@
 /area/ship/trade/maintenance/techstorage)
 "Zd" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/mining/brace,
 /obj/random/accessory,
 /obj/random/accessory,
+/obj/machinery/mining/drill,
 /turf/simulated/floor/tiled/monotile,
 /area/ship/trade/cargo/lower)
 "Zs" = (
@@ -3507,6 +3690,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/science/fabricaton)
+"Zv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/trade/maintenance/storage)
 "ZJ" = (
 /turf/simulated/wall,
 /area/ship/trade/escape_star)
@@ -5764,26 +5957,26 @@ aa
 aa
 aa
 aa
-aa
-aa
-MK
-aa
-aa
-aa
-aa
 XF
-aa
-aa
-aa
-aa
-MK
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+sY
+sY
+sY
+Va
+Qg
+qf
+Qg
+ca
+ca
+ca
+cr
+cr
+cP
+cZ
+cZ
+cZ
+iW
+WZ
+XF
 aa
 aa
 aa
@@ -5846,29 +6039,29 @@ aa
 aa
 aa
 aa
-XF
 sY
-sY
-sY
+Mx
+ah
+ah
+aP
 lD
 lD
-Dl
-tf
-ca
-ca
-cr
-cr
+lD
+sB
+HY
+Rs
+Nc
+Ic
 cP
-cZ
-cZ
-WZ
-iW
-WZ
-XF
-Jv
-Jv
-aa
-aa
+da
+NL
+NL
+dK
+yF
+rv
+rv
+rv
+rv
 aa
 aa
 aa
@@ -5929,29 +6122,29 @@ aa
 aa
 aa
 sY
-Mx
+sY
 ah
-ah
-VM
-aO
+fs
+aP
+qF
 bm
+qF
 sB
-Qi
-Rs
-Nc
-Ic
-cP
-da
-NL
-ob
-jH
-WZ
-cz
+sM
+Fw
+cs
+Jr
+JM
+fL
+fL
+fL
+fL
+yF
 se
 se
-Jv
-aa
-aa
+se
+se
+se
 aa
 aa
 aa
@@ -6010,31 +6203,31 @@ aa
 aa
 aa
 aa
-sY
-sY
-ah
-fs
-aO
+Ei
+ai
+ar
+cb
+aP
 aZ
 bn
-ce
-Fb
-Fw
-cs
-Jr
+QV
 JM
-fL
-fL
-fL
-fL
-WZ
-Xb
+cc
+Zs
+ub
+cJ
+JM
+db
+dq
+dD
+Tb
+dZ
+wl
+LE
 nz
 eJ
+ef
 se
-aa
-aa
-aa
 aa
 aa
 aa
@@ -6095,28 +6288,28 @@ aa
 Ei
 ai
 ar
-cb
-aP
+aC
+aO
 ba
 bo
+nG
 ce
-cc
-Zs
-ub
-cJ
+cd
+Qc
+cu
+vb
 ce
-db
-dq
-dD
-Tb
-cS
+lb
+dr
+dE
+dO
+dZ
 Yb
 et
-eK
+mN
+QK
 ef
 rv
-aa
-aa
 aa
 aa
 aa
@@ -6177,29 +6370,29 @@ aa
 Ei
 ai
 ar
-aC
+jb
+aP
 aO
-bb
-bp
+zb
+aO
 ce
-cd
-Qc
-cu
-vb
 ce
-lb
-dr
-dE
-dO
+hp
+Jb
+ce
+ce
+dd
+Ob
 cS
+nn
+dZ
 rb
 eu
-eL
+eN
+ni
 ef
 rv
 fX
-aa
-aa
 aa
 aa
 aa
@@ -6258,29 +6451,29 @@ aa
 aa
 Ei
 ai
-ar
-jb
-aP
-aO
-zb
-ce
-ce
-hp
-Jb
-ce
-ce
-dd
-Ob
-cS
-nn
-cS
-Wm
-eu
+as
+aE
+sb
+bc
+hf
+Ml
+Wi
+it
+TZ
+uz
+uo
+cf
+uw
+kb
+Py
+Jl
+tE
+uj
 pn
+eN
+Vm
 ef
 rv
-aa
-aa
 aa
 aa
 aa
@@ -6337,32 +6530,32 @@ aa
 aa
 aa
 aa
-aa
-Ei
-ai
-as
-aE
-sb
-bc
+ql
+sY
+sY
+ah
+ah
+ah
+On
 br
 bI
-Eb
+bI
 ds
-kb
-lO
-uo
-cf
-kb
-uw
+On
+On
+lJ
+VX
+VX
+On
 dP
-tE
-uj
-ec
-tb
-ef
+VX
+dZ
+Wm
+ew
+eN
+iH
 se
 rv
-aa
 aa
 aa
 aa
@@ -6417,10 +6610,10 @@ aa
 aa
 aa
 aa
-ql
 pr
 pr
-pr
+al
+al
 al
 al
 al
@@ -6437,14 +6630,14 @@ ao
 Ab
 ao
 Ub
+rW
 dZ
 Zb
 ew
-eN
 eV
+TC
 ef
 rv
-aa
 aa
 aa
 aa
@@ -6499,10 +6692,10 @@ aa
 aa
 aa
 aa
-pr
-pr
-al
-al
+ad
+aj
+au
+aG
 aF
 js
 Cr
@@ -6519,14 +6712,14 @@ df
 dt
 Qb
 dR
+On
 dZ
-ek
+lg
 ew
-eN
 eW
+my
 ef
 rv
-aa
 aa
 aa
 aa
@@ -6581,13 +6774,13 @@ aa
 aa
 aa
 aa
-ad
-aj
-au
-aG
+ae
+ak
+av
+aH
 aS
 du
-aU
+NM
 Js
 gb
 bu
@@ -6601,14 +6794,14 @@ mb
 lK
 ao
 dS
-eb
-eb
+On
+ef
+ef
 ey
-eb
-eb
-eb
-vW
-aa
+ef
+ef
+ef
+rv
 aa
 aa
 aa
@@ -6663,10 +6856,10 @@ aa
 aa
 aa
 aa
-ae
-ak
-av
-aH
+pr
+lE
+al
+al
 aT
 aU
 du
@@ -6683,14 +6876,14 @@ dh
 dv
 ao
 dT
+On
 eb
 em
 ez
-eP
+Zv
 eY
 eb
 vW
-aa
 aa
 aa
 aa
@@ -6745,11 +6938,11 @@ aa
 aa
 aa
 aa
-pr
-lE
-al
-al
-vz
+xj
+Sc
+Sx
+jM
+CN
 rB
 du
 aU
@@ -6765,6 +6958,7 @@ ao
 lZ
 ao
 dU
+VX
 eb
 en
 eA
@@ -6772,7 +6966,6 @@ eQ
 eZ
 eb
 vW
-aa
 aa
 aa
 aa
@@ -6830,8 +7023,8 @@ aa
 xj
 IU
 he
-jM
-CN
+xj
+lw
 aU
 Lx
 Zd
@@ -6847,6 +7040,7 @@ di
 hI
 ao
 dV
+On
 ed
 ee
 gc
@@ -6854,7 +7048,6 @@ ee
 ee
 ee
 Gd
-aa
 aa
 aa
 aa
@@ -6929,6 +7122,7 @@ dj
 dw
 Rb
 dW
+On
 DQ
 eo
 eC
@@ -6936,7 +7130,6 @@ eR
 hc
 ee
 Gd
-aa
 aa
 aa
 aa
@@ -7011,6 +7204,7 @@ ao
 Ab
 ao
 Vb
+rW
 ed
 ep
 eD
@@ -7018,7 +7212,6 @@ eS
 fb
 ed
 Gd
-aa
 aa
 aa
 aa
@@ -7075,24 +7268,25 @@ aa
 aa
 aa
 aa
-aa
-Ei
-ap
-ay
-aK
-wb
+ql
+gX
+gX
+ZJ
+ZJ
+ZJ
 bi
-bz
-bP
-bZ
-cl
-cC
-bP
-Mb
+rN
+VX
+On
+On
+VX
+VX
+lJ
 dk
-cC
-dH
+On
+On
 dY
+VX
 ee
 eq
 eE
@@ -7101,7 +7295,6 @@ fc
 ed
 Gd
 fX
-aa
 aa
 aa
 aa
@@ -7161,28 +7354,28 @@ aa
 Ei
 ap
 ay
-nb
-aX
-aX
-Bb
-aX
-cm
-cm
-Kb
-cm
-cm
+aK
+wb
+EB
+bz
+bP
+yL
+cl
+cC
+bP
+Mb
 dl
-Pb
-dI
-DX
-uh
+cC
+dH
+La
+uX
+ee
 uh
 eF
 ee
 ee
 ed
 Gd
-aa
 aa
 aa
 aa
@@ -7243,27 +7436,27 @@ aa
 Ei
 ap
 ay
-aM
+nb
 aX
-bj
-bB
-bQ
+aX
+Bb
+aX
 cm
-cn
-cE
-cM
 cm
-dm
-dy
-dJ
-DX
-rP
+Kb
+cm
+cm
+ts
+Pb
+Za
+En
+DV
+hn
 uh
 eG
 uh
 Gd
 Gd
-aa
 aa
 aa
 aa
@@ -7322,30 +7515,30 @@ aa
 aa
 aa
 aa
-Tp
+Ei
 ap
-az
-qb
+ay
+aM
 aX
-yb
-bC
-Db
+bj
+bB
+bQ
 cm
-Ib
-cF
-Lb
+cn
+cE
+cM
 cm
-Nb
-dz
-Sb
+dm
+dy
+UX
+dJ
 DX
-Ud
+uh
 er
 eH
 er
 aa
 rP
-aa
 aa
 aa
 aa
@@ -7404,28 +7597,28 @@ aa
 aa
 aa
 aa
-gX
-gX
-ZJ
-uY
-aY
-bl
-bD
-bS
+Tp
+ap
+az
+qb
+aX
+yb
+bC
+Db
 cm
-cp
-ZY
-cO
+Ib
+cF
+Lb
 cm
-do
-dA
-dL
+Nb
+dz
+AM
+Sb
 DX
-aa
+YH
 er
 eI
 er
-aa
 aa
 aa
 aa
@@ -7487,23 +7680,23 @@ aa
 aa
 aa
 gX
-aq
-aA
-aA
-kP
+gX
+ZJ
+uY
 aY
-bE
-aX
-cq
+bl
+bD
+bS
+cm
 cp
-cG
+ZY
 cO
-xa
-wI
-dB
-BO
+cm
+do
+dA
+kr
+dL
 DX
-aa
 aa
 aa
 aa
@@ -7568,24 +7761,24 @@ aa
 aa
 aa
 aa
-rP
 gX
-gX
-gX
-jD
-jD
-vw
-jD
-Vc
+aq
+aA
+aA
+kP
+aY
+bE
+aX
 cq
-cH
+cp
+cG
+PJ
 xa
-cq
-Cd
-sh
+wI
+dB
+fa
+BO
 DX
-DX
-aa
 aa
 aa
 aa
@@ -7650,24 +7843,24 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 rP
-aa
-aa
-aa
-rP
-aa
-aa
-aa
-aa
-aa
-aa
+gX
+gX
+gX
+jD
+jD
+vw
+jD
+Vc
+cq
+cH
+xa
+cq
+Cd
+sh
+sh
+DX
+DX
 aa
 aa
 aa
@@ -7739,11 +7932,11 @@ aa
 aa
 aa
 aa
+rP
 aa
 aa
 aa
-aa
-aa
+rP
 aa
 aa
 aa

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -43,16 +43,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/atmos)
 "ae" = (
-/obj/structure/cable{
-	icon_state = "4-9"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
-	},
-/obj/machinery/network/acl{
-	initial_network_id = "tradenet"
-	},
 /turf/simulated/floor/carpet/blue,
 /area/ship/trade/command/captain)
 "af" = (
@@ -65,10 +55,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/ship/trade/command/captain)
-"ak" = (
-/obj/effect/overmap/visitable/ship/tradeship,
-/turf/space,
-/area/space)
 "ar" = (
 /obj/machinery/door/blast/regular,
 /turf/simulated/floor/plating,
@@ -84,6 +70,13 @@
 "aw" = (
 /turf/simulated/wall/r_wall,
 /area/ship/trade/command/fmate)
+"aB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset,
+/obj/random/voidsuit,
+/obj/random/voidhelmet,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/maintenance/hallway)
 "aJ" = (
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -125,21 +118,23 @@
 /area/ship/trade/command/fmate)
 "aS" = (
 /obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/ship/trade/command/hallway)
 "aU" = (
 /obj/structure/cable{
@@ -176,32 +171,18 @@
 	},
 /turf/simulated/floor/carpet,
 /area/ship/trade/command/fmate)
-"bb" = (
-/obj/machinery/light,
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/obj/machinery/computer/modular/preset/engineering{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/trade/command/bridge)
 "bc" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/ship/trade/command/hallway)
 "bd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
@@ -252,40 +233,13 @@
 /turf/simulated/floor/tiled,
 /area/ship/trade/shuttle/outgoing)
 "bv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/ship/trade/dock)
-"bw" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Docking Area APC"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_w = 27
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/ship/trade/dock)
@@ -320,16 +274,12 @@
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -35
 	},
-/obj/machinery/computer/shuttle_control/explore/tradeship,
 /turf/simulated/floor/tiled/monotile,
 /area/ship/trade/dock)
 "bC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -339,45 +289,28 @@
 /turf/simulated/floor/tiled/monotile,
 /area/ship/trade/dock)
 "bD" = (
-/obj/machinery/door/airlock/hatch/autoname/general,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/ship/trade/dock)
-"bE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/ship/trade/dock)
 "bF" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -385,36 +318,39 @@
 	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/random/maintenance,
 /turf/simulated/floor/tiled/monotile,
 /area/ship/trade/dock)
 "bG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/ship/trade/dock)
 "bH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 35
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals6,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8;
+	level = 2
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/ship/trade/dock)
+"bM" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/maintenance/hallway)
 "bQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10;
@@ -429,18 +365,30 @@
 /turf/simulated/floor/tiled/monotile,
 /area/ship/trade/dock)
 "bT" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plating,
+/area/ship/trade/command/bridge)
+"bU" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/ship/trade/dock)
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/shieldbay)
 "bW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
@@ -573,63 +521,23 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/ship/trade/dock)
-"cg" = (
-/obj/machinery/atmospherics/portables_connector{
-	icon_state = "map_connector";
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/plating,
-/area/ship/trade/dock)
-"ch" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6,
-/turf/simulated/floor/tiled/monotile,
-/area/ship/trade/dock)
 "cj" = (
+/obj/machinery/computer/ship/helm,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/hatch/autoname/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/ship/trade/dock)
+/turf/simulated/floor/bluegrid,
+/area/ship/trade/command/bridge)
 "cl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	icon_state = "intact";
 	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/ship/trade/dock)
-"cm" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/plating,
 /area/ship/trade/dock)
 "cp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -664,15 +572,21 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/ship/trade/dock)
 "cw" = (
+/obj/structure/bed/chair/comfy/teal{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Captain"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/ship/trade/dock)
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/command/bridge)
 "cy" = (
 /obj/structure/lattice,
 /turf/space,
@@ -752,10 +666,6 @@
 /obj/machinery/power/port_gen/pacman/super,
 /turf/simulated/floor/plating,
 /area/ship/trade/shuttle/outgoing)
-"cJ" = (
-/obj/effect/paint/brown,
-/turf/simulated/wall/r_wall,
-/area/ship/trade/crew/saloon)
 "cK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -766,7 +676,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/ship/trade/crew/saloon)
+/area/ship/trade/command/bridge)
 "cL" = (
 /obj/random/maintenance,
 /turf/simulated/floor/tiled/techmaint,
@@ -775,14 +685,19 @@
 /turf/simulated/wall,
 /area/ship/trade/crew/saloon)
 "cO" = (
-/obj/machinery/vending/snack{
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Crew Areas APC"
 	},
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -24
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
 	},
+/obj/structure/table/standard,
+/obj/item/deck/tarot,
+/obj/item/synthesized_instrument/guitar,
+/obj/random/drinkbottle,
+/obj/item/chems/food/drinks/bottle/limejuice,
 /turf/simulated/floor/tiled,
 /area/ship/trade/crew/saloon)
 "cQ" = (
@@ -801,13 +716,25 @@
 /turf/simulated/floor/tiled,
 /area/ship/trade/crew/saloon)
 "cS" = (
-/obj/machinery/vending/coffee{
-	dir = 8
-	},
 /obj/effect/floor_decal/corner/beige{
 	icon_state = "corner_white";
 	dir = 6
 	},
+/obj/structure/table/standard,
+/obj/random/drinkbottle,
+/obj/random/drinkbottle,
+/obj/random/drinkbottle,
+/obj/random/drinkbottle,
+/obj/random/drinkbottle,
+/obj/item/chems/food/drinks/shaker,
+/obj/item/chems/food/drinks/bottle/orangejuice,
+/obj/random/drinkingglass,
+/obj/random/drinkingglass,
+/obj/random/drinkingglass,
+/obj/random/drinkingglass,
+/obj/random/drinkingglass,
+/obj/random/drinkbottle,
+/obj/random/drinkbottle,
 /turf/simulated/floor/tiled,
 /area/ship/trade/crew/saloon)
 "cT" = (
@@ -846,11 +773,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/stool/padded,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/item/synthesized_instrument/guitar,
+/obj/structure/bed/chair/wood,
 /turf/simulated/floor/tiled,
 /area/ship/trade/crew/saloon)
 "da" = (
@@ -872,6 +798,11 @@
 	},
 /obj/item/trash/tray,
 /obj/item/circular_saw,
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/obj/random/drinkbottle,
+/obj/random/drinkbottle,
 /turf/simulated/floor/tiled,
 /area/ship/trade/crew/saloon)
 "dc" = (
@@ -945,20 +876,24 @@
 "dk" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "dl" = (
 /obj/effect/floor_decal/corner/beige{
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/structure/handrai{
 	icon_state = "handrail";
 	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled,
 /area/ship/trade/crew/saloon)
@@ -969,6 +904,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ship/trade/crew/saloon)
+"dn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/command/bridge)
 "dp" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/door/firedoor,
@@ -1331,10 +1281,6 @@
 /turf/simulated/floor/tiled/freezer,
 /area/ship/trade/crew/toilets)
 "dO" = (
-/obj/machinery/light{
-	icon_state = "bulb1";
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	icon_state = "conpipe-c";
@@ -1358,16 +1304,14 @@
 /area/ship/trade/crew/saloon)
 "dQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/vending/cigarette{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/beige{
 	icon_state = "corner_white";
 	dir = 9
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal,
 /turf/simulated/floor/tiled,
 /area/ship/trade/crew/saloon)
 "dS" = (
@@ -1375,9 +1319,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1395,10 +1336,6 @@
 /turf/simulated/floor/tiled,
 /area/ship/trade/crew/saloon)
 "dV" = (
-/obj/machinery/light{
-	icon_state = "bulb1";
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1437,9 +1374,6 @@
 "ea" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/closet/walllocker/emerglocker/east,
-/obj/machinery/light_switch{
-	pixel_x = -25
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -1448,7 +1382,7 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/plating,
 /area/ship/trade/crew/hallway/port)
 "eb" = (
 /turf/simulated/wall,
@@ -1471,9 +1405,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/sign/deck/first{
-	pixel_x = 32
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -1485,14 +1416,6 @@
 "ee" = (
 /turf/simulated/wall,
 /area/ship/trade/crew/medbay)
-"ef" = (
-/obj/machinery/door/window/southright,
-/obj/structure/table/marble,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled{
-	icon_state = "white"
-	},
-/area/ship/trade/crew/medbay/chemistry)
 "eh" = (
 /turf/simulated/wall/natural,
 /area/space)
@@ -1527,18 +1450,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/cargo)
-"eq" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
-	},
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/ship/trade/command/captain)
 "er" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1619,10 +1530,6 @@
 /area/ship/trade/crew/kitchen)
 "eC" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	icon_state = "bulb1";
-	dir = 8
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -1631,10 +1538,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/sign/directions/engineering{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/plating,
 /area/ship/trade/crew/hallway/port)
 "eD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1707,10 +1611,14 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/structure/sign/redcross{
-	pixel_w = 32
+/obj/structure/lattice,
+/obj/structure/cable{
+	d1 = 32;
+	d2 = 1;
+	icon_state = "32-1"
 	},
-/turf/simulated/floor/plating,
+/obj/structure/disposalpipe/down,
+/turf/simulated/open,
 /area/ship/trade/crew/hallway/starboard)
 "eL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1839,7 +1747,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/plating,
 /area/ship/trade/crew/hallway/port)
 "eU" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
@@ -1868,7 +1776,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/structure/disposalpipe/down,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/ship/trade/crew/hallway/starboard)
 "fb" = (
@@ -2117,6 +2025,14 @@
 /obj/item/scanner/health,
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/crew/medbay)
+"fx" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/ship/trade/garden)
 "fz" = (
 /obj/machinery/light{
 	icon_state = "bulb1";
@@ -2166,15 +2082,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/trade/maintenance/engine/port)
-"fD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/structure/lattice,
-/obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 4
-	},
-/turf/space,
-/area/space)
 "fE" = (
 /turf/simulated/wall,
 /area/ship/trade/crew/wash)
@@ -2197,15 +2104,6 @@
 	},
 /turf/simulated/open,
 /area/ship/trade/cargo)
-"fM" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 8
-	},
-/turf/space,
-/area/space)
 "fN" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall,
@@ -2507,10 +2405,6 @@
 /turf/simulated/floor/tiled/freezer,
 /area/ship/trade/crew/wash)
 "gr" = (
-/obj/machinery/light{
-	icon_state = "bulb1";
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
@@ -2555,10 +2449,6 @@
 	d2 = 2;
 	icon_state = "1-2";
 	pixel_y = 0
-	},
-/obj/machinery/light{
-	icon_state = "bulb1";
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
@@ -2676,7 +2566,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/plating,
 /area/ship/trade/crew/hallway/port)
 "gM" = (
 /obj/structure/catwalk,
@@ -2781,6 +2671,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/power)
+"hf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/ship/trade/garden)
 "hi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -2831,15 +2725,15 @@
 	},
 /area/ship/trade/hidden)
 "hl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/item/cash/c1000,
 /obj/random/coin,
 /obj/structure/closet/crate,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/ship/trade/hidden)
 "hm" = (
@@ -2870,13 +2764,15 @@
 	icon_state = "intact";
 	dir = 5
 	},
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -24
-	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
+"hs" = (
+/obj/machinery/light{
+	icon_state = "bulb1";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/crew/hallway/starboard)
 "ht" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3032,12 +2928,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/structure/sign/directions/medical{
-	dir = 1;
-	icon_state = "direction_med";
-	pixel_x = 30;
-	pixel_z = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	icon_state = "intact";
 	dir = 9
@@ -3057,23 +2947,20 @@
 /obj/machinery/power/apc{
 	name = "Medical Bay APC"
 	},
-/obj/structure/cable{
-	d2 = 6;
-	icon_state = "0-6"
-	},
 /obj/item/storage/backpack/dufflebag/syndie,
 /obj/machinery/alarm{
 	dir = 4;
 	icon_state = "alarm0";
 	pixel_x = -24
 	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1;
+	d2 = 2
+	},
 /turf/simulated/floor/plating,
 /area/ship/trade/hidden)
 "hB" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
-	},
 /obj/item/disk/design_disk,
 /obj/item/disk/tech_disk,
 /obj/item/disk/tech_disk,
@@ -3106,12 +2993,6 @@
 /area/ship/trade/maintenance/engineering)
 "hJ" = (
 /turf/simulated/wall,
-/area/ship/trade/maintenance/power)
-"hK" = (
-/obj/structure/cable{
-	icon_state = "2-9"
-	},
-/turf/simulated/wall/r_wall,
 /area/ship/trade/maintenance/power)
 "hL" = (
 /turf/simulated/wall/r_wall,
@@ -3471,6 +3352,9 @@
 /obj/effect/fluid_mapped/fuel,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/engineering)
+"in" = (
+/turf/simulated/floor/plating,
+/area/ship/trade/crew/hallway/port)
 "io" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3739,6 +3623,11 @@
 	},
 /turf/simulated/floor/reinforced/airmix,
 /area/ship/trade/maintenance/atmos)
+"iN" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/maintenance/hallway)
 "iQ" = (
 /turf/simulated/wall/r_wall,
 /area/ship/trade/maintenance/engine/aft)
@@ -3861,12 +3750,10 @@
 /turf/simulated/floor/reinforced/airmix,
 /area/ship/trade/maintenance/atmos)
 "jb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
 	},
+/obj/machinery/media/jukebox/old,
 /turf/simulated/floor/tiled,
 /area/ship/trade/crew/saloon)
 "jc" = (
@@ -4548,6 +4435,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/engine/aft)
+"kC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/airless,
+/area/ship/trade/maintenance/engine/starboard)
 "kD" = (
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/industrial/warning,
@@ -4600,21 +4491,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/engine/aft)
-"lb" = (
-/obj/machinery/light,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24;
-	pixel_y = 0
-	},
-/obj/machinery/computer/modular/preset/cardslot/command{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/trade/command/bridge)
+"kR" = (
+/obj/effect/paint/brown,
+/turf/simulated/wall/r_wall/hull,
+/area/space)
 "lc" = (
 /obj/machinery/button/access/exterior{
 	id_tag = "tradeship_dock_port";
@@ -4653,6 +4533,12 @@
 /obj/structure/shuttle/engine/propulsion/burst/right,
 /turf/simulated/floor/airless,
 /area/ship/trade/shuttle/outgoing)
+"lZ" = (
+/obj/structure/sign/redcross{
+	pixel_w = 32
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/crew/hallway/starboard)
 "mb" = (
 /turf/simulated/wall/r_wall,
 /area/ship/trade/garden)
@@ -4677,6 +4563,27 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/engine/aft)
+"me" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/plating,
+/area/ship/trade/maintenance/hallway)
+"ml" = (
+/obj/structure/table/standard,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/random/powercell,
+/obj/random/powercell,
+/turf/simulated/floor/plating,
+/area/ship/trade/shieldbay)
 "mt" = (
 /obj/item/roller,
 /obj/structure/hygiene/sink{
@@ -4693,6 +4600,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/engine/aft)
+"mz" = (
+/obj/machinery/door/airlock/hatch/autoname/general,
+/turf/simulated/floor/plating,
+/area/ship/trade/crew/hallway/port)
 "mX" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
@@ -4761,6 +4672,13 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/trade/shuttle/outgoing)
+"nv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/ship/trade/dock)
 "nH" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -4774,9 +4692,10 @@
 /obj/item/chems/glass/rag,
 /turf/simulated/floor/tiled,
 /area/ship/trade/crew/kitchen)
-"nL" = (
-/turf/simulated/floor/airless,
-/area/space)
+"nR" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/shieldbay)
 "nU" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
@@ -4832,6 +4751,28 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/trade/dock)
+"oi" = (
+/obj/machinery/vending/snack{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/port)
+"ok" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/shieldbay)
 "om" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
@@ -4847,6 +4788,21 @@
 /obj/item/chems/glass/rag,
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/crew/medbay)
+"op" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/shieldbay)
 "or" = (
 /obj/structure/lattice,
 /turf/simulated/floor/airless,
@@ -4890,10 +4846,63 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/ship/trade/dock)
+"pe" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/structure/handrai{
+	icon_state = "handrail";
+	dir = 8
+	},
+/turf/space,
+/area/ship/trade/maintenance/engine/starboard)
 "pn" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
 /area/ship/trade/maintenance/engine/port)
+"pp" = (
+/obj/machinery/door/airlock/hatch/autoname/general,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/maintenance/hallway)
+"pt" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/port)
+"pu" = (
+/obj/machinery/computer/ship/engines,
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/command/bridge)
+"pG" = (
+/obj/structure/closet/crate/uranium,
+/turf/simulated/floor/plating,
+/area/ship/trade/shieldbay)
+"pI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Docking Area APC"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/ship/trade/dock)
 "pT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4953,8 +4962,29 @@
 	icon_state = "bulb_map";
 	dir = 4
 	},
+/obj/machinery/computer/shuttle_control/explore/tradeship,
 /turf/simulated/floor/tiled/monotile,
 /area/ship/trade/dock)
+"qd" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/shieldbay)
+"qg" = (
+/obj/random/drinkbottle,
+/obj/random/drinkbottle,
+/turf/simulated/floor/plating,
+/area/ship/trade/hidden)
+"qp" = (
+/obj/machinery/vending/cola{
+	icon_state = "Cola_Machine";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/port)
 "qE" = (
 /obj/machinery/atmospherics/omni/mixer{
 	active_power_usage = 7500;
@@ -4977,19 +5007,20 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/computer/modular/preset/merchant,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/cargo)
-"qS" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
+"qR" = (
+/obj/structure/sign/directions/engineering{
+	pixel_x = -32
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/light{
+	icon_state = "bulb1";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "qT" = (
 /obj/machinery/door/blast/regular{
@@ -4997,18 +5028,18 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/trade/command/fmate)
-"ra" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
+"qZ" = (
+/obj/structure/closet/radiation,
 /turf/simulated/floor/plating,
-/area/ship/trade/command/bridge)
+/area/ship/trade/shieldbay)
+"ra" = (
+/obj/structure/closet/emcloset,
+/obj/random/voidsuit,
+/obj/random/voidsuit,
+/obj/random/voidhelmet,
+/obj/random/voidhelmet,
+/turf/simulated/floor/plating,
+/area/ship/trade/shieldbay)
 "rb" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -5022,18 +5053,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/garden)
-"rc" = (
-/obj/structure/closet/walllocker/emerglocker/south,
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4;
-	level = 2
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/ship/trade/dock)
 "rp" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -5062,22 +5081,46 @@
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
 /area/ship/trade/maintenance/atmos)
-"rQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
+"rH" = (
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/command/bridge)
+"rI" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_w = 1
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/newscaster{
+	pixel_x = 30
+	},
+/turf/simulated/floor/tiled/dark,
 /area/ship/trade/command/bridge)
 "rR" = (
 /obj/item/flashlight,
 /turf/simulated/floor/wood/yew,
 /area/ship/trade/unused)
+"rT" = (
+/obj/machinery/computer/modular/preset/engineering,
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/command/bridge)
 "sb" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 1
@@ -5093,26 +5136,10 @@
 /obj/item/plantspray/pests,
 /turf/simulated/floor/tiled,
 /area/ship/trade/garden)
-"sc" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/ladder,
-/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/structure/cable{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/ship/trade/dock)
+"se" = (
+/obj/effect/paint/brown,
+/turf/simulated/wall/r_wall,
+/area/ship/trade/shieldbay)
 "sf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	icon_state = "intact";
@@ -5154,17 +5181,8 @@
 /turf/simulated/wall/r_wall,
 /area/ship/trade/hidden)
 "sM" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
-	},
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/space)
+/turf/simulated/wall/r_wall,
+/area/ship/trade/shieldbay)
 "sS" = (
 /turf/simulated/floor/plating,
 /area/ship/trade/hidden)
@@ -5174,10 +5192,6 @@
 /area/ship/trade/garden)
 "tc" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -5207,6 +5221,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/engine/aft)
+"tV" = (
+/turf/space,
+/area/ship/trade/command/fmate)
 "tW" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -5229,6 +5246,10 @@
 	dir = 1;
 	pixel_y = -30
 	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/ship/trade/dock)
 "ul" = (
@@ -5242,6 +5263,18 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/trade/crew/medbay/chemistry)
+"uP" = (
+/obj/structure/handrai{
+	icon_state = "handrail";
+	dir = 4
+	},
+/obj/structure/handrai{
+	icon_state = "handrail";
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/ship/trade/command/captain)
 "vb" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -5267,19 +5300,40 @@
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/atmospherics/portables_connector{
+	icon_state = "map_connector";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/ship/trade/dock)
 "vj" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
 /area/ship/trade/crew/toilets)
-"vu" = (
-/obj/machinery/computer/ship/sensors,
-/obj/machinery/light_switch{
-	pixel_x = 28
+"vt" = (
+/obj/item/radio,
+/obj/structure/cable{
+	icon_state = "4-9"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/trade/command/bridge)
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	icon_state = "intact";
+	dir = 6
+	},
+/turf/simulated/floor/airless,
+/area/ship/trade/maintenance/engine/starboard)
+"vF" = (
+/obj/structure/closet/walllocker/emerglocker/south,
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	level = 2
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/ship/trade/command/hallway)
 "vL" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -5415,20 +5469,20 @@
 /turf/simulated/floor/plating,
 /area/ship/trade/shuttle/outgoing)
 "xc" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Crew Areas APC"
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/structure/bed/chair,
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/ship/trade/crew/saloon)
+"xl" = (
+/obj/effect/paint/brown,
+/turf/simulated/wall/r_wall,
+/area/ship/trade/command/hallway)
 "xn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5439,6 +5493,27 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/engine/aft)
+"xB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/maintenance/hallway)
+"xG" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "xL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	icon_state = "intact";
@@ -5453,6 +5528,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/engine/aft)
+"xO" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/shieldbay)
 "xS" = (
 /turf/simulated/floor/carpet,
 /area/ship/trade/command/fmate)
@@ -5462,14 +5547,6 @@
 	},
 /turf/space,
 /area/space)
-"xZ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4;
-	level = 2
-	},
-/obj/machinery/computer/ship/engines,
-/turf/simulated/floor/tiled/dark,
-/area/ship/trade/command/bridge)
 "yb" = (
 /turf/simulated/floor/tiled,
 /area/ship/trade/garden)
@@ -5481,11 +5558,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/crew/medbay/chemistry)
-"yg" = (
-/obj/machinery/computer/ship/helm,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/bluegrid,
-/area/ship/trade/command/bridge)
+"yh" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	level = 2
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/shieldbay)
+"yt" = (
+/obj/effect/paint/brown,
+/turf/simulated/wall/r_wall/hull,
+/area/ship/trade/shieldbay)
 "yA" = (
 /obj/structure/closet,
 /obj/random/clothing,
@@ -5496,6 +5579,13 @@
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/tiled/freezer,
 /area/ship/trade/crew/wash)
+"yF" = (
+/obj/machinery/vending/cigarette{
+	icon_state = "cigs";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/starboard)
 "zb" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 8;
@@ -5525,6 +5615,10 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/ship/trade/crew/toilets)
+"zi" = (
+/obj/random/maintenance,
+/turf/simulated/floor/tiled/monotile,
+/area/ship/trade/dock)
 "zs" = (
 /obj/machinery/shipsensors,
 /turf/simulated/floor/airless,
@@ -5558,10 +5652,7 @@
 	dir = 1;
 	pixel_y = -30
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled,
 /area/ship/trade/crew/saloon)
 "Ah" = (
@@ -5574,6 +5665,32 @@
 /obj/machinery/cell_charger,
 /turf/simulated/floor/tiled,
 /area/ship/trade/shuttle/outgoing)
+"Ai" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/command/bridge)
+"As" = (
+/obj/machinery/power/smes/buildable/max_cap_in_out,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/shieldbay)
 "AB" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -5589,6 +5706,27 @@
 /obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/trade/crew/wash)
+"AQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/crew/hallway/port)
 "Bb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5596,15 +5734,21 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/door/airlock/hatch/autoname/command,
-/turf/simulated/floor/tiled/dark,
-/area/ship/trade/command/captain)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/random/maintenance,
+/turf/simulated/floor/tiled/monotile,
+/area/ship/trade/command/hallway)
 "Bc" = (
 /obj/structure/table/standard,
 /obj/machinery/reagentgrinder/juicer,
@@ -5625,11 +5769,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/hatch/autoname/command,
-/turf/simulated/floor/tiled/dark,
-/area/ship/trade/dock)
+/turf/simulated/floor/tiled/steel_ridged,
+/area/ship/trade/command/hallway)
 "Bx" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
@@ -5643,6 +5787,10 @@
 /obj/item/clamp,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/atmos)
+"BP" = (
+/obj/random/maintenance,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/shieldbay)
 "BZ" = (
 /obj/structure/table/marble,
 /obj/machinery/door/window/brigdoor/southright,
@@ -5693,20 +5841,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ship/trade/crew/kitchen)
-"Cq" = (
-/obj/structure/table/standard,
-/obj/machinery/button/blast_door{
-	id_tag = "scraplock";
-	name = "External Lockdown"
-	},
-/obj/random_multi/single_item/captains_spare_id,
-/obj/item/documents/tradehouse/account,
-/obj/item/documents/tradehouse/personnel,
-/obj/machinery/newscaster{
-	pixel_x = 30
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/trade/command/bridge)
 "CD" = (
 /obj/effect/paint/red,
 /turf/simulated/wall/r_wall/hull,
@@ -5719,8 +5853,26 @@
 	name = "Sensor Shroud"
 	},
 /obj/item/radio,
+/obj/random/drinkbottle,
 /turf/simulated/floor/tiled/dark,
 /area/ship/trade/command/bridge)
+"CP" = (
+/obj/machinery/door/airlock/hatch/autoname/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/ship/trade/command/fmate)
 "Db" = (
 /obj/effect/floor_decal/corner/white{
 	icon_state = "corner_white";
@@ -5768,19 +5920,17 @@
 /obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/trade/crew/kitchen)
-"DL" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	dir = 8
+"DE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/structure/cable{
-	d2 = 6;
-	icon_state = "0-6"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/trade/command/bridge)
+/turf/simulated/floor/tiled/monotile,
+/area/ship/trade/dock)
 "DO" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
@@ -5830,9 +5980,6 @@
 /obj/random/hat,
 /obj/random/hat,
 /obj/random/masks,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/power/apc{
 	dir = 8
 	},
@@ -5853,43 +6000,65 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/crew/medbay)
-"EA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/ship/trade/dock)
-"EQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
+"Ey" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/hatch/autoname/command,
-/turf/simulated/floor/tiled/dark,
-/area/ship/trade/command/fmate)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/starboard)
+"EA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/ship/trade/dock)
+"EN" = (
+/obj/machinery/door/airlock/hatch/autoname/general,
+/turf/simulated/floor/plating,
+/area/ship/trade/crew/hallway/starboard)
+"EQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/ship/trade/command/hallway)
+"ER" = (
+/obj/machinery/network/acl{
+	initial_network_id = "tradenet"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/trade/command/captain)
 "Fc" = (
 /obj/machinery/light{
 	icon_state = "bulb1";
@@ -5902,10 +6071,32 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/cargo)
+"Fl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/maintenance/hallway)
 "Fm" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/trade/hidden)
+"Fv" = (
+/obj/machinery/door/window/southright,
+/obj/structure/table/marble,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled{
+	icon_state = "white"
+	},
+/area/ship/trade/crew/medbay)
 "FD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
@@ -5919,28 +6110,27 @@
 /turf/simulated/floor/plating,
 /area/ship/trade/command/fmate)
 "FS" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
+/obj/structure/table/standard,
+/obj/machinery/button/blast_door{
 	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
+	name = "External Lockdown"
+	},
+/obj/random_multi/single_item/captains_spare_id,
+/obj/item/documents/tradehouse/account,
+/obj/item/documents/tradehouse/personnel,
+/obj/machinery/light_switch{
+	pixel_x = 28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/command/bridge)
+"FT" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24
 	},
 /turf/simulated/floor/plating,
-/area/ship/trade/dock)
-"FV" = (
-/obj/item/radio,
-/obj/structure/cable{
-	icon_state = "4-9"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact";
-	dir = 6
-	},
-/turf/simulated/floor/airless,
-/area/space)
+/area/ship/trade/maintenance/hallway)
 "FW" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
@@ -5975,16 +6165,57 @@
 /obj/machinery/door/airlock/hatch/autoname/engineering,
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/engine/starboard)
+"Gj" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/hidden)
 "Gv" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/ship/trade/shuttle/outgoing)
+"Gw" = (
+/obj/machinery/computer/ship/sensors,
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/command/bridge)
+"GA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/shieldbay)
 "GF" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
 /area/ship/trade/maintenance/atmos)
+"GJ" = (
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/shieldbay)
+"GN" = (
+/obj/structure/sign/directions/medical{
+	dir = 1;
+	icon_state = "direction_med";
+	pixel_x = 30;
+	pixel_z = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/maintenance/hallway)
+"GT" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/shieldbay)
 "Hb" = (
 /obj/effect/floor_decal/corner/blue,
 /obj/effect/floor_decal/corner/yellow{
@@ -6010,11 +6241,34 @@
 /obj/structure/curtain/open/privacy,
 /obj/structure/bed/padded,
 /obj/item/clothing/accessory/stethoscope,
+/obj/random/drinkbottle,
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/crew/medbay)
+"Hp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/crew/hallway/port)
 "Hs" = (
 /turf/simulated/floor/wood/yew,
 /area/ship/trade/unused)
+"HA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall,
+/area/ship/trade/maintenance/power)
 "HF" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -6033,21 +6287,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/power)
-"HO" = (
-/obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 4
-	},
-/obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 8
-	},
-/turf/space,
-/area/space)
+"HJ" = (
+/obj/machinery/door/airlock/hatch/autoname/general,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/port)
 "HR" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
 /area/ship/trade/maintenance/atmos)
+"HT" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/maintenance/hallway)
 "Ib" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	icon_state = "intact";
@@ -6092,10 +6342,54 @@
 	},
 /turf/space,
 /area/space)
+"Iw" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/crew/hallway/port)
+"Iy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/port)
 "IA" = (
 /obj/effect/paint/red,
 /turf/simulated/wall/r_wall/hull,
 /area/ship/trade/maintenance/engine/aft)
+"IC" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/crew/hallway/starboard)
+"IJ" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/port_gen/pacman/super,
+/turf/simulated/floor/plating,
+/area/ship/trade/shieldbay)
+"IM" = (
+/turf/simulated/floor/airless,
+/area/ship/trade/command/captain)
 "Jb" = (
 /obj/structure/table/standard,
 /obj/machinery/cell_charger,
@@ -6134,18 +6428,14 @@
 /turf/simulated/wall/r_wall/hull,
 /area/ship/trade/maintenance/engine/port)
 "Jh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/trade/command/hallway)
 "Jk" = (
 /obj/structure/bed/chair/office/dark,
@@ -6168,18 +6458,13 @@
 	icon_state = "bulb1";
 	dir = 4
 	},
-/obj/structure/closet/emcloset,
 /obj/structure/sign/deck/first{
 	pixel_x = 32
 	},
-/obj/random/voidhelmet,
-/obj/random/voidsuit,
 /obj/structure/handrai{
 	icon_state = "handrail";
 	dir = 8
 	},
-/obj/random/voidhelmet,
-/obj/random/voidsuit,
 /turf/simulated/floor/tiled,
 /area/ship/trade/crew/saloon)
 "Jp" = (
@@ -6208,15 +6493,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/power)
+"JN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/airless,
+/area/ship/trade/maintenance/engine/port)
 "JR" = (
 /obj/effect/floor_decal/corner/beige{
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/obj/machinery/media/jukebox/old,
+/obj/structure/closet/emcloset,
+/obj/random/voidsuit,
+/obj/random/voidsuit,
+/obj/random/voidhelmet,
+/obj/random/voidhelmet,
 /turf/simulated/floor/tiled,
 /area/ship/trade/crew/saloon)
 "JX" = (
@@ -6247,11 +6537,6 @@
 /area/ship/trade/maintenance/power)
 "Kc" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -24
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24;
@@ -6264,11 +6549,56 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/turf/simulated/floor/plating,
+/area/ship/trade/crew/hallway/port)
+"Kd" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/structure/table/standard,
+/obj/machinery/cell_charger,
+/turf/simulated/floor/plating,
+/area/ship/trade/shieldbay)
+"Kj" = (
+/obj/machinery/door/airlock/hatch/autoname/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/ship/trade/command/captain)
+"Kl" = (
+/obj/machinery/light_switch{
+	pixel_x = -25
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "Kw" = (
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/crew/medbay)
+"KB" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/cargo)
 "KI" = (
 /obj/machinery/light_switch{
 	pixel_x = -25
@@ -6313,6 +6643,14 @@
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
 /area/ship/trade/crew/medbay)
+"KZ" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/crew/hallway/starboard)
 "Lb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 2;
@@ -6333,17 +6671,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/cable{
-	d1 = 32;
-	d2 = 1;
-	icon_state = "32-1"
-	},
-/obj/structure/lattice,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
@@ -6357,12 +6684,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/open,
+/turf/simulated/floor/plating,
 /area/ship/trade/crew/hallway/starboard)
-"Ln" = (
-/obj/effect/paint/brown,
-/turf/simulated/wall/r_wall/hull,
-/area/ship/trade/command/bridge)
+"Lm" = (
+/obj/machinery/power/shield_generator,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/shieldbay)
 "Ls" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
@@ -6374,21 +6705,16 @@
 	},
 /turf/space,
 /area/space)
+"LC" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/starboard)
 "LP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/engine/aft)
-"LY" = (
-/obj/item/screwdriver,
-/obj/structure/cable{
-	icon_state = "5-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	icon_state = "intact";
-	dir = 10
-	},
-/turf/simulated/floor/airless,
-/area/space)
 "Mb" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
@@ -6434,6 +6760,10 @@
 /obj/machinery/door/airlock/hatch/autoname/engineering,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/ship/trade/maintenance/atmos)
+"Mv" = (
+/obj/machinery/door/airlock/hatch/autoname/general,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/starboard)
 "Mw" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
@@ -6453,6 +6783,30 @@
 /obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/trade/unused)
+"MG" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	level = 2
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/command/bridge)
+"MO" = (
+/obj/machinery/light,
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/command/bridge)
+"MX" = (
+/obj/machinery/light{
+	icon_state = "bulb1";
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/crew/hallway/port)
 "Nb" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/firedoor,
@@ -6487,6 +6841,42 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/ship/trade/crew/wash)
+"Np" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Captain";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/structure/closet/emcloset,
+/obj/random/voidsuit,
+/obj/random/voidhelmet,
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/command/bridge)
+"Nq" = (
+/turf/simulated/floor/tiled/monotile,
+/area/ship/trade/command/hallway)
+"Nx" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/port)
+"NF" = (
+/obj/item/screwdriver,
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/simulated/floor/airless,
+/area/ship/trade/maintenance/engine/port)
 "NI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	icon_state = "intact";
@@ -6495,17 +6885,6 @@
 /obj/structure/bookcase/skill_books/random,
 /turf/simulated/floor/wood/yew,
 /area/ship/trade/unused)
-"NN" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Captain";
-	pixel_x = 32
-	},
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/trade/command/bridge)
 "Ob" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -6538,37 +6917,22 @@
 /turf/simulated/floor/wood/yew,
 /area/ship/trade/unused)
 "Og" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Bridge APC"
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/ship/trade/command/hallway)
-"Oi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/airless,
-/area/space)
-"Oq" = (
-/obj/structure/bed/chair/comfy/teal{
-	dir = 1
-	},
-/obj/effect/landmark/start{
-	name = "Captain"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/ship/trade/command/bridge)
 "Os" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel,
@@ -6582,11 +6946,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/engine/aft)
-"OI" = (
-/obj/structure/lattice,
-/obj/structure/handrai,
-/turf/space,
-/area/space)
 "OP" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -6597,6 +6956,40 @@
 /obj/machinery/reagent_temperature/cooler,
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/crew/medbay/chemistry)
+"OS" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/ladder,
+/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/supply{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/machinery/atm{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/ship/trade/command/hallway)
+"Pa" = (
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/apc{
+	dir = 8
+	},
+/obj/structure/table/standard,
+/turf/simulated/floor/plating,
+/area/ship/trade/shieldbay)
 "Pb" = (
 /obj/item/gun/projectile/shotgun/pump{
 	desc = "When words don't strike hard enough.";
@@ -6619,21 +7012,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/plating,
 /area/ship/trade/crew/hallway/port)
-"PA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "2-9"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/trade/command/bridge)
+"Pp" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/ship/trade/command/captain)
 "PE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -6647,6 +7032,10 @@
 /obj/machinery/door/airlock/hatch/autoname/engineering,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/ship/trade/maintenance/engineering)
+"PF" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plating,
+/area/ship/trade/shieldbay)
 "PH" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -6681,11 +7070,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24;
-	pixel_y = 0
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -6707,6 +7091,22 @@
 	},
 /turf/space,
 /area/space)
+"Qu" = (
+/obj/machinery/portable_atmospherics/canister/hydrogen,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/shieldbay)
+"Qw" = (
+/obj/machinery/door/airlock/hatch/autoname/general,
+/turf/simulated/floor/plating,
+/area/ship/trade/maintenance/hallway)
+"Qz" = (
+/obj/machinery/computer/modular/preset/cardslot/command,
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/command/bridge)
 "QH" = (
 /obj/structure/table/standard,
 /obj/structure/cable,
@@ -6732,6 +7132,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/engine/aft)
+"QW" = (
+/obj/machinery/light,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/maintenance/hallway)
 "Rb" = (
 /obj/structure/table/woodentable,
 /obj/structure/cable{
@@ -6761,6 +7170,16 @@
 	},
 /turf/simulated/floor/wood/yew,
 /area/ship/trade/unused)
+"Rq" = (
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/turf/simulated/floor/carpet/blue,
+/area/ship/trade/command/captain)
 "Rv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start{
@@ -6772,8 +7191,6 @@
 /area/ship/trade/cargo)
 "RL" = (
 /obj/structure/closet/walllocker/emerglocker/north,
-/obj/structure/bed/chair/wood,
-/obj/item/deck/tarot,
 /obj/structure/handrai,
 /turf/simulated/floor/tiled,
 /area/ship/trade/crew/saloon)
@@ -6810,6 +7227,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ship/trade/garden)
+"Sg" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/shieldbay)
 "Si" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -6821,10 +7242,71 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/trade/crew/toilets)
+"Sr" = (
+/turf/simulated/floor/plating,
+/area/ship/trade/maintenance/hallway)
 "SC" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
 /area/ship/trade/command/captain)
+"SG" = (
+/turf/space,
+/area/ship/trade/command/captain)
+"SI" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/obj/structure/sign{
+	icon_state = "radiation";
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/tiled/monotile,
+/area/ship/trade/command/hallway)
+"SL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/ship/trade/crew/hallway/starboard)
+"SQ" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 1
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Docking Area APC"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_w = 27
+	},
+/obj/structure/sign{
+	icon_state = "radiation";
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/ship/trade/command/hallway)
 "Tb" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate,
@@ -6846,19 +7328,41 @@
 /turf/simulated/floor/plating,
 /area/ship/trade/shuttle/outgoing)
 "Tl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/hatch/autoname/command,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/trade/command/bridge)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/hatch/autoname/command,
+/obj/structure/sign{
+	icon_state = "radiation";
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/shieldbay)
+"Tp" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/obj/random/maintenance,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/shieldbay)
 "Tt" = (
-/obj/effect/paint/brown,
-/turf/simulated/wall,
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
 /area/ship/trade/crew/saloon)
 "TB" = (
 /obj/machinery/atmospherics/valve/open{
@@ -6884,6 +7388,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/engine/aft)
+"TM" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/command/bridge)
+"TR" = (
+/obj/structure/sign/deck/first{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/starboard)
 "Ub" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/storage/backpack/dufflebag,
@@ -6916,12 +7432,27 @@
 /obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/trade/crew/toilets)
-"Uo" = (
-/obj/machinery/network/relay{
-	initial_network_id = "tradenet"
+"UB" = (
+/obj/machinery/light,
+/obj/machinery/newscaster{
+	pixel_y = -32
 	},
-/turf/simulated/floor/bluegrid,
-/area/ship/trade/comms)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/command/bridge)
+"UD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/structure/lattice,
+/obj/structure/handrai{
+	icon_state = "handrail";
+	dir = 4
+	},
+/turf/space,
+/area/ship/trade/maintenance/engine/port)
 "UP" = (
 /obj/machinery/door/blast/regular{
 	id_tag = "scram"
@@ -6934,6 +7465,10 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/trade/maintenance/engine/aft)
+"UV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/monotile,
+/area/ship/trade/dock)
 "Vb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -6963,6 +7498,16 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled,
 /area/ship/trade/garden)
+"Vd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/ship/trade/command/fmate)
+"VK" = (
+/obj/machinery/network/relay{
+	initial_network_id = "tradenet"
+	},
+/turf/simulated/floor/bluegrid,
+/area/ship/trade/command/fmate)
 "VL" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel,
 /obj/machinery/fusion_fuel_injector/mapped{
@@ -6976,6 +7521,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/engine/aft)
+"VX" = (
+/obj/machinery/vending/coffee{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/starboard)
 "Wb" = (
 /obj/effect/floor_decal/corner/beige{
 	icon_state = "corner_white";
@@ -6997,7 +7548,6 @@
 /turf/simulated/floor/tiled,
 /area/ship/trade/shuttle/outgoing)
 "Wc" = (
-/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -7013,10 +7563,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
@@ -7091,25 +7637,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/trade/maintenance/atmos)
-"Xl" = (
-/obj/machinery/atm{
-	pixel_y = 25
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -24
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6,
-/turf/simulated/floor/tiled/monotile,
-/area/ship/trade/dock)
-"Xu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/trade/command/bridge)
+"Xz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/trade/maintenance/hallway)
 "XR" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -7165,22 +7696,30 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/engineering)
+"Yt" = (
+/obj/structure/handrai{
+	icon_state = "handrail";
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "YE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/hologram/holopad/longrange,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/trade/command/bridge)
 "YN" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
-	},
 /turf/simulated/floor/plating,
 /area/ship/trade/crew/hallway/starboard)
 "YS" = (
@@ -7236,6 +7775,18 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/trade/maintenance/power)
+"Zg" = (
+/obj/structure/handrai{
+	icon_state = "handrail";
+	dir = 4
+	},
+/obj/structure/handrai{
+	icon_state = "handrail";
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/ship/trade/command/fmate)
 "Zv" = (
 /obj/structure/lattice,
 /obj/structure/handrai{
@@ -9010,88 +9561,6 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
-(23,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 xX
 aa
 aa
@@ -9131,7 +9600,7 @@ aa
 aa
 aa
 "}
-(24,1,1) = {"
+(23,1,1) = {"
 aa
 aa
 aa
@@ -9213,7 +9682,7 @@ aa
 aa
 aa
 "}
-(25,1,1) = {"
+(24,1,1) = {"
 aa
 aa
 aa
@@ -9295,6 +9764,88 @@ aa
 aa
 aa
 "}
+(25,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eh
+ex
+ex
+fg
+fB
+RW
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
 (26,1,1) = {"
 aa
 aa
@@ -9335,11 +9886,11 @@ aa
 aa
 aa
 aa
-eh
+aa
 ex
 ex
-fg
-fB
+fh
+fC
 RW
 aa
 aa
@@ -9418,12 +9969,13 @@ aa
 aa
 aa
 aa
+cy
 ex
+mc
 ex
-fh
-fC
-RW
-aa
+fQ
+gl
+cy
 aa
 aa
 aa
@@ -9440,7 +9992,6 @@ jB
 jB
 jB
 kq
-aa
 aa
 aa
 aa
@@ -9495,23 +10046,24 @@ aL
 aa
 aa
 aa
+Lx
 aa
+xX
 aa
-aa
-aa
-aa
+Lx
 cy
-ex
-mc
-ex
-fQ
-gl
 cy
+NF
+UD
+JN
+gm
+cy
+Lx
 aa
 aa
 aa
 aa
-aa
+kR
 GF
 GF
 GF
@@ -9521,7 +10073,6 @@ GF
 rx
 GF
 rx
-aa
 aa
 aa
 aa
@@ -9576,24 +10127,25 @@ cI
 aL
 aa
 aa
-aa
-Lx
-aa
-xX
-aa
-Lx
-cy
-cy
-LY
-fD
-Oi
-gm
-cy
-Lx
-aa
-aa
-aa
-GF
+YS
+vj
+Si
+vj
+Cd
+dY
+ey
+Ue
+Dq
+AH
+fT
+gn
+AH
+mX
+mX
+rb
+mX
+mX
+HR
 GF
 hD
 hD
@@ -9606,7 +10158,6 @@ GF
 GF
 GF
 jB
-aa
 aa
 aa
 aa
@@ -9657,24 +10208,25 @@ cC
 aL
 aL
 aa
-aa
-YS
 vj
-Si
-vj
-Cd
-dY
-ey
-Ue
+Ui
+cT
+dt
+cU
 Dq
-AH
-fT
-gn
-AH
-mX
-mX
-rb
-mX
+Bc
+nH
+eP
+fk
+fE
+fU
+go
+yA
+nb
+Sc
+sb
+hf
+Wf
 HR
 hD
 hD
@@ -9688,7 +10240,6 @@ hD
 hD
 GF
 kq
-aa
 aa
 aa
 aa
@@ -9740,24 +10291,25 @@ aL
 lx
 aa
 vj
-Ui
-cT
-dt
 cU
-Dq
-Bc
-nH
-eP
-fk
+dh
+du
+zc
+dZ
+nW
+ez
+Co
+Jp
 fE
-fU
-go
-yA
+wU
+vS
+gA
 nb
-Sc
-sb
-Wf
-HR
+sY
+WO
+yb
+Uc
+hD
 Ab
 ib
 is
@@ -9770,7 +10322,6 @@ kd
 hD
 GF
 GF
-aa
 aa
 aa
 aa
@@ -9804,7 +10355,7 @@ aa
 aa
 aa
 aa
-aa
+Lx
 aa
 aa
 aa
@@ -9821,25 +10372,26 @@ aa
 aa
 aa
 aa
-vj
-cU
-dh
-du
-zc
+Si
+cV
+di
+dv
+dM
 dZ
-nW
-ez
-Co
-Jp
+Cc
+eA
+eQ
+Jc
 fE
-wU
-vS
-gA
+Mc
+gp
+gB
 nb
-sY
+pb
 WO
-Uc
-hD
+yb
+yb
+Mp
 Xc
 ic
 it
@@ -9853,7 +10405,6 @@ hD
 hD
 GF
 jB
-aa
 aa
 aa
 aa
@@ -9885,43 +10436,44 @@ aa
 aa
 aa
 aa
-aa
-ak
-aa
-aa
-aa
-aa
-xX
-aa
+tV
+Ls
+Ls
+oK
+Ls
+tW
+Ls
+Ls
 aa
 nZ
 Mw
 nc
 bA
-Lx
-aa
-aa
-aa
-aa
-Si
-cV
-di
-dv
-dM
+Yt
+cy
+cy
+cy
+cy
+YS
+cU
+nd
+dw
+dN
 dZ
-Cc
-eA
-eQ
-Jc
+Dc
+eB
+eR
+fm
 fE
-Mc
-gp
-gB
-nb
-pb
-WO
-yb
-Mp
+Nc
+gq
+gC
+mb
+qb
+vb
+fx
+Vc
+hF
 hO
 id
 iu
@@ -9935,7 +10487,6 @@ BD
 hD
 GF
 kq
-aa
 aa
 aa
 aa
@@ -9967,42 +10518,43 @@ aa
 aa
 aa
 aa
-Lx
-aa
-aa
 Ls
-Ls
-tW
-Ls
-Ls
-aa
+oK
+aw
+aw
+aw
+rp
+aw
+oK
+cy
 nZ
 bm
 oc
 cf
 ct
-OI
-cy
-cy
-cy
+xG
+xG
+xG
+xG
 YS
 cU
-nd
-dw
-dN
+cT
+dx
+cT
 dZ
-Dc
-eB
-eR
-fm
+dZ
+dZ
+eS
+dZ
 fE
-Nc
-gq
-gC
+fX
+fE
+fE
 mb
-qb
-vb
-Vc
+mb
+wb
+nb
+nb
 hF
 hP
 ie
@@ -10017,7 +10569,6 @@ ks
 hD
 GF
 jB
-aa
 aa
 aa
 aa
@@ -10047,44 +10598,45 @@ aa
 aa
 aa
 aa
-aa
-aa
-Ls
-Ls
-Ls
-oK
-aw
-rp
-aw
-oK
 cy
+cy
+Zg
+qT
+zs
+FD
+VK
+aP
+ba
+aw
+oK
 Mw
 bm
 pc
-cg
+cf
 Mw
-qS
-qS
-qS
-qS
-YS
-cU
-cT
-dx
-cT
-dZ
-dZ
-dZ
-eS
-dZ
-fE
-fX
-fE
-fE
-mb
-mb
-wb
-nb
+oi
+qp
+cE
+cE
+in
+cE
+mz
+Hp
+MX
+Kl
+in
+qR
+Iy
+HJ
+pt
+AQ
+MX
+Iw
+in
+Qw
+Fl
+FT
+Sr
 hF
 hQ
 if
@@ -10113,7 +10665,6 @@ aa
 aa
 aa
 aa
-aa
 "}
 (36,1,1) = {"
 aa
@@ -10129,25 +10680,25 @@ aa
 aa
 aa
 aa
-aa
-aa
-Ls
-oK
-aw
-aw
-Uo
-aP
-ba
-aw
+yt
 sM
-bm
+sM
+se
+se
+sM
+xS
+xS
+xS
+Jk
+BZ
+UV
 bB
 bQ
-ch
+cl
 cu
 cE
 cE
-cE
+Nx
 cE
 cE
 cW
@@ -10167,6 +10718,7 @@ gL
 gU
 hi
 hr
+Xz
 hF
 wG
 WE
@@ -10195,7 +10747,6 @@ aa
 aa
 aa
 aa
-aa
 "}
 (37,1,1) = {"
 aa
@@ -10210,27 +10761,27 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-HO
-qT
-zs
-FD
-xS
-xS
-xS
-Jk
-BZ
-tg
+yt
+sM
+sM
+pG
+qZ
+Pa
+sM
+Eb
+aQ
+Vd
+Ob
+oK
+zi
 bC
 qc
 uc
-Mw
-qS
-qS
-qS
-cJ
+DO
+KP
+KP
+DO
+DO
 Tt
 cN
 cN
@@ -10249,6 +10800,7 @@ eb
 eb
 eb
 Wc
+QW
 hG
 Yc
 ih
@@ -10277,7 +10829,6 @@ aa
 aa
 aa
 aa
-aa
 "}
 (38,1,1) = {"
 aa
@@ -10292,33 +10843,33 @@ aa
 aa
 aa
 aa
-ra
-KP
-Ln
-Ln
-DO
-DO
-aw
-Eb
-aQ
-Ob
+yt
+sM
+IJ
+nR
+BP
+qd
+sM
 oK
-Mw
-Mw
+CP
+aw
+aw
+oK
+UV
 bD
-bm
-Mw
-Mw
-aa
-aa
-aa
-cJ
+DO
+DO
+DO
+rT
+rH
+Np
+DO
 cO
 JR
 dl
 dA
 dQ
-eb
+KB
 Ec
 eD
 eV
@@ -10331,6 +10882,7 @@ fZ
 fZ
 eb
 ht
+bM
 hH
 hS
 ii
@@ -10359,7 +10911,6 @@ aa
 aa
 aa
 aa
-aa
 "}
 (39,1,1) = {"
 aa
@@ -10373,28 +10924,28 @@ aa
 aa
 aa
 aa
-aa
-rQ
+yt
+sM
+sM
+xO
+GT
+yh
+Tp
+sM
+SI
+EQ
+Nq
+vF
+xl
+tg
+bD
+KP
 Ig
 CG
-xZ
-DL
-bb
-aw
-aw
-EQ
-aw
-aw
-bm
-Xl
-bE
-rc
-Mw
-FS
-FS
-FS
-FS
-cJ
+pu
+MG
+MO
+DO
 xc
 cY
 MB
@@ -10413,6 +10964,7 @@ fZ
 fZ
 eb
 hu
+HT
 hG
 pT
 ij
@@ -10441,7 +10993,6 @@ aa
 aa
 aa
 aa
-aa
 "}
 (40,1,1) = {"
 aa
@@ -10455,13 +11006,13 @@ aa
 aa
 aa
 aa
-aa
-rQ
-yg
-Oq
-Xu
-YE
-PA
+yt
+sM
+sM
+As
+GA
+op
+ok
 Tl
 Og
 aS
@@ -10473,9 +11024,9 @@ bF
 bT
 cj
 cw
-cw
-cw
-cw
+Ai
+YE
+dn
 cK
 cQ
 cZ
@@ -10495,6 +11046,7 @@ fZ
 gV
 eU
 hv
+me
 PE
 hU
 ik
@@ -10523,7 +11075,6 @@ aa
 aa
 aa
 aa
-aa
 "}
 (41,1,1) = {"
 aa
@@ -10537,28 +11088,28 @@ aa
 aa
 aa
 aa
-aa
-rQ
-Qb
-Cq
-vu
-NN
-lb
-as
-as
+yt
+sM
+sM
+Lm
+GT
+bU
+Sg
+sM
+SQ
 Bb
-as
-as
-bm
-bw
+Jh
+OS
+xl
+pI
 EA
-sc
-Mw
+KP
+Qb
 FS
-FS
-FS
-FS
-cJ
+Gw
+TM
+UB
+DO
 RL
 da
 dm
@@ -10567,8 +11118,8 @@ Ac
 eb
 qO
 XR
-eV
 fr
+eV
 fJ
 fZ
 fZ
@@ -10577,6 +11128,7 @@ fZ
 gW
 eb
 hw
+Xz
 hG
 hV
 il
@@ -10605,7 +11157,6 @@ aa
 aa
 aa
 aa
-aa
 "}
 (42,1,1) = {"
 aa
@@ -10620,33 +11171,33 @@ aa
 aa
 aa
 aa
-ra
-KP
-Ln
-Ln
-DO
-DO
-as
-vP
-aU
-Pb
+yt
+sM
+PF
+BP
+GJ
+Qu
+sM
 SC
-Mw
-Mw
-bD
-bm
-Mw
-Mw
-aa
-aa
-aa
-cJ
+Kj
+as
+as
+SC
+tg
+DE
+DO
+DO
+DO
+Qz
+rH
+rI
+DO
 cS
 db
 Jn
 dE
 dU
-eb
+KB
 Rv
 eH
 eV
@@ -10659,6 +11210,7 @@ gM
 eV
 eb
 hx
+Xz
 hG
 hW
 il
@@ -10687,7 +11239,6 @@ aa
 aa
 aa
 aa
-aa
 "}
 (43,1,1) = {"
 aa
@@ -10702,27 +11253,27 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-HO
-nL
-ar
-Wp
-af
-aV
+yt
+sM
+sM
+ml
+ra
+Kd
+sM
+vP
+aU
 ae
-eq
-aa
-bA
+Pb
+SC
+tg
 bG
 tc
 vc
-Mw
-YN
-YN
-YN
-cJ
+DO
+KP
+KP
+DO
+DO
 Tt
 cN
 cN
@@ -10741,6 +11292,7 @@ gN
 eb
 eb
 hy
+iN
 hG
 hX
 im
@@ -10769,7 +11321,6 @@ aa
 aa
 aa
 aa
-aa
 "}
 (44,1,1) = {"
 aa
@@ -10785,27 +11336,27 @@ aa
 aa
 aa
 aa
-aa
-aa
-wP
-wP
-SC
-as
-aJ
-aW
-Rb
-SC
-aa
-bA
+yt
+sM
+sM
+se
+se
+sM
+af
+aV
+Rq
+ER
+Pp
+zi
 bH
 bW
-cl
+nv
 cu
 cG
 cG
-cG
+LC
 cL
-cG
+YN
 dc
 dp
 dF
@@ -10823,6 +11374,7 @@ gO
 gY
 hj
 hz
+Sr
 hJ
 hJ
 KO
@@ -10851,7 +11403,6 @@ aa
 aa
 aa
 aa
-aa
 "}
 (45,1,1) = {"
 aa
@@ -10867,44 +11418,45 @@ aa
 aa
 aa
 aa
-aa
-aa
-wP
-wP
-wP
-SC
-as
-zO
-as
-SC
 cy
+cy
+uP
+IM
+ar
+Wp
+aJ
+aW
+Rb
+SC
+SC
 Mw
 bm
 bX
-cm
+cf
 Mw
+VX
+yF
 YN
 YN
+cG
+cG
+Mv
+SL
+hs
+TR
 YN
-YN
-Mo
-dd
-de
-dG
-de
-ee
-ee
-ee
-fb
-ee
-ee
-ee
-gc
-gu
-gu
-gP
-hk
-gP
+lZ
+SL
+EN
+KZ
+hs
+Ey
+IC
+cG
+pp
+xB
+GN
+aB
 hJ
 Zc
 io
@@ -10920,7 +11472,6 @@ or
 IA
 IA
 hR
-aa
 aa
 aa
 aa
@@ -10951,42 +11502,43 @@ aa
 aa
 aa
 aa
-Is
-aa
-aa
 wP
 wP
-PU
-wP
-wP
-aa
+SC
+as
+as
+zO
+as
+SC
+cy
 nZ
 bm
 bY
 cf
 ct
-OI
-cy
-cy
-cy
-Ce
+xG
+xG
+xG
+xG
+Mo
+dd
 de
-yc
-dH
-dW
+dG
+de
 ee
-es
-Ic
-fc
-fu
-QH
 ee
-gd
-gv
-Rc
-gQ
-hl
-hA
+ee
+fb
+ee
+ee
+ee
+gc
+gu
+gu
+gP
+hk
+gP
+gP
 hJ
 Jb
 ip
@@ -10998,7 +11550,6 @@ jP
 kc
 hL
 Bx
-aa
 aa
 aa
 aa
@@ -11033,43 +11584,44 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+SG
+wP
+wP
+SC
+wP
+PU
+wP
+wP
 aa
 nZ
 Mw
 bZ
 bA
 Zv
-aa
-aa
-aa
-aa
-ul
-df
-dr
-dI
-dX
-ef
-Kw
-eL
-fd
-Kw
-oo
-ev
-ge
-gw
-Dl
+cy
+cy
+cy
+cy
+Ce
+de
+yc
+dH
+dW
+de
+es
+Ic
+fc
+fu
+QH
+ee
+gd
+gv
+Rc
 gQ
-hm
-hB
-hK
+hl
+Gj
+hA
+HA
 Kb
 iq
 Za
@@ -11080,7 +11632,6 @@ hL
 hL
 Jr
 Bx
-aa
 aa
 aa
 aa
@@ -11116,7 +11667,7 @@ aa
 aa
 aa
 aa
-aa
+Is
 aa
 aa
 aa
@@ -11133,24 +11684,25 @@ aa
 aa
 aa
 aa
-om
-de
-ds
-dJ
-OP
-ee
-mt
+ul
+df
+dr
+dI
+dX
+Fv
 Kw
-Et
-fV
-Im
-ee
-NI
-rR
-Hs
+eL
+fd
+Kw
+oo
+ev
+ge
+gw
+Dl
 gQ
+hm
 sS
-sS
+hB
 hL
 hL
 hL
@@ -11161,7 +11713,6 @@ hL
 hL
 hL
 Jr
-aa
 aa
 aa
 aa
@@ -11216,24 +11767,25 @@ aa
 aa
 aa
 om
-nj
-dd
-dK
-dd
-KR
-Hc
-eM
-fe
-fo
-fw
+de
+ds
+dJ
+OP
 ee
-Oc
-gx
-gI
+mt
+Kw
+Et
+fV
+Im
+ee
+NI
+rR
+Hs
 gQ
-FW
-hC
-sI
+sS
+sS
+qg
+gP
 Bx
 Bx
 PH
@@ -11242,7 +11794,6 @@ Bx
 Bx
 Bx
 Bx
-aa
 aa
 aa
 aa
@@ -11297,32 +11848,32 @@ aa
 aa
 aa
 aa
-aa
 om
-om
-ul
-om
-on
+nj
+dd
+dK
+dd
 KR
-KR
-ff
-KR
-KR
-KR
-gy
-gg
-MD
+Hc
+eM
+fe
+fo
+fw
+ee
+Oc
+gx
+gI
+gQ
+FW
+sS
+hC
 sI
-sI
-sI
-Fm
 Is
 aa
 aa
 aa
 aa
 Is
-aa
 aa
 aa
 aa
@@ -11380,6 +11931,88 @@ aa
 aa
 aa
 aa
+om
+om
+ul
+om
+on
+KR
+KR
+ff
+KR
+KR
+KR
+gy
+gg
+MD
+sI
+sI
+sI
+sI
+Fm
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(52,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 Is
 aa
@@ -11388,9 +12021,9 @@ aa
 Is
 cy
 cy
-FV
-fM
-Oi
+vt
+pe
+kC
 gz
 cy
 Zv
@@ -11427,7 +12060,7 @@ aa
 aa
 aa
 "}
-(52,1,1) = {"
+(53,1,1) = {"
 aa
 aa
 aa
@@ -11509,7 +12142,7 @@ aa
 aa
 aa
 "}
-(53,1,1) = {"
+(54,1,1) = {"
 aa
 aa
 aa
@@ -11591,7 +12224,7 @@ aa
 aa
 aa
 "}
-(54,1,1) = {"
+(55,1,1) = {"
 aa
 aa
 aa
@@ -11673,7 +12306,7 @@ aa
 aa
 aa
 "}
-(55,1,1) = {"
+(56,1,1) = {"
 aa
 aa
 aa
@@ -11755,7 +12388,7 @@ aa
 aa
 aa
 "}
-(56,1,1) = {"
+(57,1,1) = {"
 aa
 aa
 aa
@@ -11837,88 +12470,6 @@ aa
 aa
 aa
 "}
-(57,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-wL
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
 (58,1,1) = {"
 aa
 aa
@@ -11962,7 +12513,7 @@ aa
 aa
 aa
 aa
-aa
+wL
 aa
 aa
 aa

--- a/maps/tradeship/tradeship-3.dmm
+++ b/maps/tradeship/tradeship-3.dmm
@@ -348,6 +348,26 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/open,
 /area/ship/trade/maintenance/solars)
+"hJ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/bridge_unused)
 "iz" = (
 /obj/structure/cable/yellow{
 	icon_state = "5-10"
@@ -412,9 +432,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/solars)
-"kL" = (
-/turf/simulated/floor/tiled/dark,
-/area/ship/trade/command/bridge_upper)
 "ma" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -431,6 +448,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/trade/maintenance/solars)
+"mn" = (
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/bridge_unused)
 "mV" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-9"
@@ -497,6 +517,17 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/ship/trade/bridge_unused)
+"pt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/ship/trade/command/bridge_upper)
 "pC" = (
 /obj/item/wrench,
 /obj/structure/handrai{
@@ -742,6 +773,20 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/trade/bridge_unused)
+"Dg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/trade/bridge_unused)
 "Dl" = (
 /obj/item/mollusc/barnacle{
 	pixel_x = 0
@@ -855,20 +900,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/open,
 /area/ship/trade/maintenance/solars)
-"Jm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/trade/command/bridge_upper)
 "Jo" = (
 /obj/machinery/message_server,
 /turf/simulated/floor/bluegrid,
@@ -954,30 +985,6 @@
 	},
 /turf/simulated/open,
 /area/ship/trade/maintenance/solars)
-"MD" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/ship/trade/command/bridge_upper)
-"Nc" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
-	},
-/turf/simulated/floor/airless,
-/area/ship/trade/command/bridge_upper)
 "NY" = (
 /obj/item/mollusc/barnacle{
 	pixel_w = 16
@@ -1085,26 +1092,6 @@
 "Su" = (
 /turf/simulated/floor/bluegrid,
 /area/ship/trade/comms)
-"SC" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/trade/command/bridge_upper)
 "SO" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -1299,7 +1286,8 @@
 /obj/machinery/light_switch{
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/lattice,
+/turf/simulated/open,
 /area/ship/trade/command/bridge_upper)
 "ZU" = (
 /obj/machinery/alarm{
@@ -3646,22 +3634,22 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ax
-aa
 ax
-aa
-aa
-aa
-aa
-aa
-ac
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ax
 ax
 ax
@@ -4034,17 +4022,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
 Ob
 Ob
 QK
 Ob
 ax
-aa
+ax
+ax
+ax
+ax
+ax
+ax
 ax
 ax
 ax
@@ -4115,18 +4103,18 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-ax
-ax
 Ob
 jz
 jz
 aN
 jz
 Ob
-ac
+ax
+ax
+ax
+ax
+ax
+ax
 ax
 ax
 ax
@@ -4154,11 +4142,11 @@ aV
 vi
 ax
 ax
-aV
-au
-au
-aV
 ax
+aV
+au
+au
+aV
 ax
 ax
 ax
@@ -4197,18 +4185,18 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-ax
-ax
 Ob
 jz
 ds
 Jo
 ZU
 Ob
-ac
+ax
+ax
+ax
+ax
+ax
+ax
 ax
 ax
 ax
@@ -4236,12 +4224,12 @@ aV
 aV
 aV
 ax
+ax
 aV
 bf
 ak
 aV
 aH
-ax
 ax
 ax
 ax
@@ -4279,18 +4267,18 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-ax
 Ob
 jz
 Tx
 Su
 Su
 Dr
-ac
+ax
+ax
+ax
+ax
+ax
+ax
 ax
 ax
 ax
@@ -4318,11 +4306,11 @@ FY
 Pg
 aV
 ax
+ax
 aV
 aB
 as
 aV
-ax
 ax
 ax
 ax
@@ -4361,11 +4349,6 @@ aa
 aa
 aa
 aa
-ax
-ax
-ax
-ax
-ax
 Ob
 jz
 ZD
@@ -4375,12 +4358,17 @@ Ob
 tJ
 tJ
 SQ
+SQ
 tJ
 tJ
 ax
-aa
-aa
-aa
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ax
 ax
 ax
@@ -4401,10 +4389,10 @@ Fe
 aV
 aV
 aV
+aV
 aL
 av
 aV
-ax
 ax
 ax
 ax
@@ -4443,11 +4431,6 @@ aa
 aa
 ac
 ac
-ax
-ax
-ax
-ax
-ax
 Ob
 jz
 jz
@@ -4457,8 +4440,13 @@ jz
 Xb
 RZ
 HN
+PZ
 bE
 SQ
+ax
+ax
+ax
+ax
 ax
 ax
 ax
@@ -4481,12 +4469,12 @@ GP
 GP
 Al
 XQ
+aR
 UY
 aR
 ah
 ap
 aV
-ax
 ax
 ax
 ax
@@ -4525,22 +4513,22 @@ aa
 aa
 aa
 aa
-ax
-ax
-ax
-ax
-ax
-Nc
-MD
-kL
-SC
-Jm
+Db
+jv
+mn
+hJ
+Dg
 KK
 YA
 rl
 fi
 PZ
+PZ
 PJ
+ax
+ax
+ax
+ax
 ax
 ax
 ax
@@ -4564,12 +4552,12 @@ GP
 zh
 vC
 qw
+ao
 oE
 BD
 We
 aV
 aH
-ax
 ax
 ax
 ax
@@ -4607,11 +4595,6 @@ aa
 aa
 aa
 ac
-ax
-ax
-ax
-ax
-ax
 zY
 ne
 ne
@@ -4621,8 +4604,13 @@ ne
 Xb
 wc
 nZ
+pt
 ZT
 SQ
+ax
+ax
+ax
+ax
 ax
 ax
 ax
@@ -4647,10 +4635,10 @@ UT
 aV
 aV
 aV
+aV
 au
 au
 aV
-ax
 ax
 ax
 ax
@@ -4689,11 +4677,6 @@ aa
 aa
 aa
 aa
-ax
-ax
-ax
-ax
-ax
 zY
 ne
 oq
@@ -4703,12 +4686,17 @@ zY
 tJ
 tJ
 SQ
+SQ
 tJ
 tJ
 ax
-aa
-aa
-aa
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 ax
 ax
 ax
@@ -4727,12 +4715,12 @@ aS
 Mk
 Ko
 aV
+aa
 ax
 ax
 ax
 ax
 mW
-ax
 ax
 ax
 ax
@@ -4771,18 +4759,18 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-ax
 zY
 ne
 wq
 zn
 KS
 oY
-aa
+ax
+ax
+ax
+ax
+ax
+ax
 ax
 ax
 ax
@@ -4853,18 +4841,18 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-ax
-ax
 zY
 cB
 cO
 XF
 XF
 zY
-ac
+ax
+ax
+ax
+ax
+ax
+ax
 ax
 ax
 ax
@@ -4935,18 +4923,18 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-ax
-ax
 zY
 ne
 ne
 jv
 cB
 zY
-ac
+ax
+ax
+ax
+ax
+ax
+ax
 ax
 ax
 ax
@@ -5018,17 +5006,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
 zY
 zY
 Db
 zY
 ax
-aa
+ax
+ax
+ax
+ax
+ax
+ax
 ax
 ax
 ax
@@ -5067,9 +5055,9 @@ ax
 ax
 ax
 ax
+ax
+ax
 ac
-ac
-aa
 aa
 aa
 aa
@@ -5149,9 +5137,9 @@ ax
 ax
 ax
 ax
+ax
+ax
 ac
-aa
-aa
 aa
 aa
 aa
@@ -5230,9 +5218,9 @@ ax
 ax
 ax
 ax
-aa
-aa
-aa
+ax
+ax
+ax
 aa
 aa
 aa
@@ -5311,10 +5299,10 @@ ax
 ax
 Dl
 ax
-aa
-aa
-aa
-aa
+ax
+ax
+ax
+ax
 aa
 aa
 aa
@@ -5385,17 +5373,17 @@ ax
 ax
 ax
 ax
-ac
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 aa
 aa
 aa
@@ -5450,34 +5438,34 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 ax
-aa
 ax
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 aa
 aa
 aa
@@ -5549,15 +5537,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
 aa
 aa
 aa

--- a/maps/tradeship/tradeship_areas.dm
+++ b/maps/tradeship/tradeship_areas.dm
@@ -72,6 +72,11 @@
 	name = "\improper Underside - Fore Port Maintenance"
 	icon_state = "green"
 
+/area/ship/trade/livestock
+	name = "\improper Underside - Livestock Handling"
+	icon_state = "red"
+	req_access = list(access_xenobiology)
+
 /area/ship/trade/fore_starboard_underside_maint
 	name = "\improper Underside - Fore Starboard Maintenance"
 	icon_state = "locker"
@@ -79,6 +84,10 @@
 /area/ship/trade/disused
 	name = "\improper Underside - Disused"
 	icon_state = "yellow"
+
+/area/ship/trade/undercomms
+	name = "\improper Underside - Communications Relay"
+	icon_state = "blue"
 
 /area/ship/trade/garden
 	name = "\improper Garden"
@@ -193,6 +202,11 @@
 	icon_state = "heads_hop"
 	req_access = list(access_hop)
 
+/area/ship/trade/shieldbay
+	name = "\improper Auxillary Shield Bay"
+	icon_state = "engine"
+	req_access = list(access_engine_equip)
+
 /area/ship/trade/command/bridge_upper
 	name = "\improper Upper Bridge"
 	icon_state = "blue"
@@ -219,9 +233,10 @@
 	icon_state = "SolarcontrolA"
 	req_access = list(access_engine)
 
-/area/ship/trade/maintenance/robot
-	name = "\improper Robot Storage"
+/area/ship/trade/artifact_storage
+	name = "\improper Artifact Storage"
 	icon_state = "ai_cyborg"
+	req_access = list(access_xenoarch)
 
 /area/ship/trade/drunk_tank
 	name = "Drunk Tank"

--- a/maps/tradeship/tradeship_unit_testing.dm
+++ b/maps/tradeship/tradeship_unit_testing.dm
@@ -13,7 +13,6 @@
 		/area/ship/trade/crew/hallway/starboard = NO_SCRUBBER|NO_VENT,
 		/area/ship/trade/maintenance/hallway = NO_SCRUBBER|NO_VENT,
 		/area/ship/trade/maintenance/lower = NO_SCRUBBER|NO_VENT,
-		/area/ship/trade/command/hallway = NO_SCRUBBER|NO_VENT,
 		/area/ship/trade/escape_port = NO_SCRUBBER|NO_VENT,
 		/area/ship/trade/escape_star = NO_SCRUBBER|NO_VENT,
 		/area/ship/trade/shuttle/outgoing = NO_SCRUBBER,


### PR DESCRIPTION
- Expands most hallways by 1 tile.
- Adds xenoarch and xenobio rooms. 
- Adds an industrial fabricator and small amount of osmium to the cargo deck.
- Moves the bridge into the center of the ship.
- Furnishes the saloon.
- Adds a shield bay and aux generator to the area the bridge used to be.
- Moves robot storage down to tool storage, as is proper.
- Adds a network relay to the bottom deck (https://github.com/ScavStation/ScavStation/issues/511).
- Tweaks light switch placement in tool storage (https://github.com/NebulaSS13/Nebula/issues/615).