### PR TITLE
Adds self-density-checking to /atom/movable/CanPass.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -329,4 +329,9 @@
 	. = ..()
 
 /atom/movable/CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-	. = ..() || (mover && !(mover.movable_flags & MOVABLE_FLAG_NONDENSE_COLLISION) && !mover.density)
+	. = ..()
+	if(. && mover)
+		if(!density && (mover.movable_flags & MOVABLE_FLAG_NONDENSE_COLLISION))
+			return FALSE
+		if(!mover.density && (movable_flags & MOVABLE_FLAG_NONDENSE_COLLISION))
+			return FALSE

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -395,7 +395,7 @@
 	icon_state = "intake"
 	base_type = /obj/machinery/disposal/deliveryChute/buildable
 	frame_type = /obj/structure/disposalconstruct/machine/chute
-
+	movable_flags = MOVABLE_FLAG_NONDENSE_COLLISION
 	var/c_mode = 0
 
 /obj/machinery/disposal/deliveryChute/buildable


### PR DESCRIPTION
This is failing unit tests and I am not sure why.
Fixes #148.

````
## UNIT_TEST ##: !!! FAILURE !!! [FOUNDATION: step() shall return true on success]: step() did not return true: Mob result: 1 - Obj result: 0.
````
I don't know why the CanPass change is causing this, if anyone can advise I'd appreciate it.