### PR TITLE
Human mobs should not take their IDs from mobs they are holding

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -222,11 +222,12 @@
 /mob/living/bot/GetIdCard()
 	return botcard
 
-/mob/living/carbon/human/GetIdCard()
+// Gets the ID card of a mob, but will not check types in the exceptions list
+/mob/living/carbon/human/GetIdCard(exceptions = list())
 	var/list/id_cards = get_held_items()
 	LAZYDISTINCTADD(id_cards, wear_id)
 	for(var/obj/item/I in id_cards)
-		if(istype(I, /obj/item/holder))
+		if(is_type_in_list(I, exceptions))
 			continue
 		var/obj/item/card/id = I ? I.GetIdCard() : null
 		if(istype(id))

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -226,6 +226,8 @@
 	var/list/id_cards = get_held_items()
 	LAZYDISTINCTADD(id_cards, wear_id)
 	for(var/obj/item/I in id_cards)
+		if(istype(I, /obj/item/holder))
+			continue
 		var/obj/item/card/id = I ? I.GetIdCard() : null
 		if(istype(id))
 			return id

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -223,7 +223,7 @@
 	return botcard
 
 // Gets the ID card of a mob, but will not check types in the exceptions list
-/mob/living/carbon/human/GetIdCard(exceptions = list())
+/mob/living/carbon/human/GetIdCard(exceptions = null)
 	var/list/id_cards = get_held_items()
 	LAZYDISTINCTADD(id_cards, wear_id)
 	for(var/obj/item/I in id_cards)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -265,7 +265,7 @@
 //gets name from ID or ID inside PDA or PDA itself
 //Useful when player do something with computers
 /mob/living/carbon/human/proc/get_authentification_name(var/if_no_id = "Unknown")
-	var/obj/item/card/id/id = GetIdCard()
+	var/obj/item/card/id/id = GetIdCard(exceptions = list(/obj/item/holder))
 	if(istype(id))
 		return id.registered_name
 	else

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -265,7 +265,7 @@
 //gets name from ID or ID inside PDA or PDA itself
 //Useful when player do something with computers
 /mob/living/carbon/human/proc/get_authentification_name(var/if_no_id = "Unknown")
-	var/obj/item/card/id/id = GetIdCard(exceptions = list(/obj/item/holder))
+	var/obj/item/card/id/id = GetIdCard()
 	if(istype(id))
 		return id.registered_name
 	else
@@ -296,7 +296,7 @@
 //Useful when player is being seen by other mobs
 /mob/living/carbon/human/proc/get_id_name(var/if_no_id = "Unknown")
 	. = if_no_id
-	var/obj/item/card/id/I = GetIdCard()
+	var/obj/item/card/id/I = GetIdCard(exceptions = list(/obj/item/holder))
 	if(istype(I))
 		return I.registered_name
 


### PR DESCRIPTION
:cl:
bugfix: You will no longer use the IDs of mobs you are holding for your name, when you have no ID showing yourself. You can still use the held mob's ID for access.
/:cl:

Fixes #801