### PR TITLE
Added istype() to wall material procs.

### DIFF
--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -51,10 +51,10 @@
 	update_material()
 
 /turf/simulated/wall/proc/get_wall_icon()
-	. = material?.icon_base || 'icons/turf/walls/solid.dmi'
+	. = (istype(material) && material.icon_base) || 'icons/turf/walls/solid.dmi'
 
 /turf/simulated/wall/proc/apply_reinf_overlay()
-	. = !!reinf_material
+	. = istype(reinf_material)
 
 /turf/simulated/wall/on_update_icon()
 


### PR DESCRIPTION
Until we can guarantee stuff like away site loading isn't going to mess with walls prior to proper init, this will have to do.