### PR TITLE
Fixes the mining processor.

### DIFF
--- a/code/modules/mining/machinery/mineral_processor.dm
+++ b/code/modules/mining/machinery/mineral_processor.dm
@@ -19,9 +19,9 @@
 /obj/machinery/mineral/processing_unit/Initialize()
 	ores_processing = list()
 	ores_stored = list()
-	for(var/orename in SSmaterials.processable_ores)
-		ores_processing[orename] = 0
-		ores_stored[orename] = 0
+	for(var/orepath in SSmaterials.processable_ores)
+		ores_processing[orepath] = 0
+		ores_stored[orepath] = 0
 	. = ..()
 
 /obj/machinery/mineral/processing_unit/Process()
@@ -158,7 +158,7 @@
 			if("Smelting")    choice = ORE_SMELT
 			if("Compressing") choice = ORE_COMPRESS
 			if("Alloying")    choice = ORE_ALLOY
-		ores_processing[href_list["toggle_smelting"]] = choice
+		ores_processing[text2path(href_list["toggle_smelting"])] = choice
 		. = TRUE
 	else if(href_list["toggle_power"])
 		active = !active

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -34,7 +34,7 @@ exactly 1 "world<< uses" 'world<<|world[[:space:]]<<'
 exactly 1 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
 exactly 142 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
-exactly 19 "text2path uses" 'text2path'
+exactly 20 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto uses" 'goto '
 exactly 6 "atom/New uses" '^/(obj|atom|area|mob|turf).*/New\('

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -34,7 +34,7 @@ exactly 1 "world<< uses" 'world<<|world[[:space:]]<<'
 exactly 1 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
 exactly 142 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
-exactly 20 "text2path uses" 'text2path'
+exactly 19 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto uses" 'goto '
 exactly 6 "atom/New uses" '^/(obj|atom|area|mob|turf).*/New\('


### PR DESCRIPTION
Mining processor would previously make duplicate entries due to lacking a text2path. It would create a duplicate entry for `"/decl/material/solid/mineral/hematite"` in addition to the actual entry for `/decl/material/solid/mineral/hematite`.
Fun fact: `new "/decl/material/solid/mineral/hematite"()` apparently works, meaning it created a whole new decl, which is how it was able to get info like the proper `solid_name`.

I'll change check-paths.sh soon, I swear.