### PR TITLE
Minor unarmed attack refactor.

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -89,7 +89,10 @@
 /mob/living/carbon/attack_hand(var/mob/living/carbon/human/M)
 	if(istype(M))
 		var/obj/item/organ/external/temp = M.organs_by_name[M.get_active_held_item_slot()]
-		if(!temp || !temp.is_usable())
+		if(!temp)
+			to_chat(M, SPAN_WARNING("You don't have a usable limb!"))
+			return TRUE
+		if(!temp.is_usable())
 			to_chat(M, SPAN_WARNING("You can't use your [temp.name]."))
 			return TRUE
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -2,20 +2,21 @@
 	if(!hit_zone)
 		hit_zone = zone_sel.selecting
 	var/list/available_attacks = get_natural_attacks()
-	if(!default_attack || !default_attack.is_usable(src, target, hit_zone) || !(default_attack.type in available_attacks))
-		default_attack = null
+	var/decl/natural_attack/use_attack = default_attack
+	if(!use_attack || !use_attack.is_usable(src, target, hit_zone) || !(use_attack.type in available_attacks))
+		use_attack = null
 		var/list/other_attacks = list()
 		for(var/u_attack_type in available_attacks)
 			var/decl/natural_attack/u_attack = decls_repository.get_decl(u_attack_type)
 			if(!u_attack.is_usable(src, target, hit_zone))
 				continue
 			if(u_attack.is_starting_default)
-				default_attack = u_attack
+				use_attack = u_attack
 				break
 			other_attacks += u_attack
-		if(!default_attack && length(other_attacks))
-			default_attack = pick(other_attacks)
-	. = default_attack && default_attack.resolve_to_soft_variant(src)
+		if(!use_attack && length(other_attacks))
+			use_attack = pick(other_attacks)
+	. = use_attack?.resolve_to_soft_variant(src)
 
 /mob/living/carbon/human/proc/get_natural_attacks()
 	. = list()

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -26,15 +26,11 @@
 
 /mob/living/carbon/human/attack_hand(mob/living/carbon/M)
 
-	. = ..()
-	if(.)
-		return
-
 	remove_cloaking_source(species)
 
 	// Grabs are handled at a lower level.
 	if(istype(M) && M.a_intent == I_GRAB)
-		return 0
+		return ..()
 
 	// Should this all be in Touch()?
 	var/mob/living/carbon/human/H = M
@@ -230,6 +226,7 @@
 				admin_attack_log(M, src, "Disarmed their victim.", "Was disarmed.", "disarmed")
 				H.species.disarm_attackhand(H, src)
 				return TRUE
+	. = ..()
 
 /mob/living/carbon/human/proc/afterattack(atom/target, mob/living/user, inrange, params)
 	return

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -43,19 +43,12 @@ var/global/list/sparring_attack_cache = list()
 	return sparring_variant_type && decls_repository.get_decl(sparring_variant_type)
 
 /decl/natural_attack/proc/is_usable(var/mob/living/carbon/human/user, var/mob/target, var/zone)
-	if(user.restrained())
-		return 0
-
-	// Check if they have a functioning hand.
-	var/obj/item/organ/external/E = user.organs_by_name[BP_L_HAND]
-	if(E && !E.is_stump())
-		return 1
-
-	E = user.organs_by_name[BP_R_HAND]
-	if(E && !E.is_stump())
-		return 1
-
-	return 0
+	if(!user.restrained() && !user.incapacitated())
+		for(var/etype in usable_with_limbs)
+			var/obj/item/organ/external/E = user.organs_by_name[etype]
+			if(E && !E.is_stump())
+				return TRUE
+	return FALSE
 
 /decl/natural_attack/proc/get_unarmed_damage()
 	return damage
@@ -227,18 +220,9 @@ var/global/list/sparring_attack_cache = list()
 	sparring_variant_type = /decl/natural_attack/light_strike/kick
 
 /decl/natural_attack/kick/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone)
-	if(!(zone in list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT, BP_GROIN)))
-		return 0
-
-	var/obj/item/organ/external/E = user.organs_by_name[BP_L_FOOT]
-	if(E && !E.is_stump())
-		return 1
-
-	E = user.organs_by_name[BP_R_FOOT]
-	if(E && !E.is_stump())
-		return 1
-
-	return 0
+	if(zone == BP_HEAD || zone == BP_EYES || zone == BP_MOUTH)
+		zone = BP_CHEST
+	. = ..()
 
 /decl/natural_attack/kick/get_unarmed_damage(var/mob/living/carbon/human/user)
 	var/obj/item/clothing/shoes = user.shoes
@@ -329,3 +313,8 @@ var/global/list/sparring_attack_cache = list()
 	attack_name = "light kick"
 	attack_noun = list("foot")
 	usable_with_limbs = list(BP_L_FOOT, BP_R_FOOT)
+
+/decl/natural_attack/light_strike/kick/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone)
+	if(zone == BP_HEAD || zone == BP_EYES || zone == BP_MOUTH)
+		zone = BP_CHEST
+	. = ..()

--- a/code/modules/mob/living/inventory.dm
+++ b/code/modules/mob/living/inventory.dm
@@ -54,6 +54,9 @@
 
 /mob/living/get_active_held_item_slot()
 	. = held_item_slot_selected
+	if(. && !(. in held_item_slots))
+		held_item_slot_selected = null
+		. = null
 
 /mob/living/get_inactive_held_items()
 	for(var/bp in (held_item_slots - get_active_held_item_slot()))


### PR DESCRIPTION
- Default attack is no longer cleared if it isn't usable in one instance.
- Kicks cannot hit the head but are no longer restricted to the legs.
- Fixes #75.