### PR TITLE
Minor grab refactor.

### DIFF
--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -213,13 +213,15 @@
 	var/turf/old_turf = get_turf(mob)
 	step(mob, direction)
 
-	// Something with dragging things
-	var/extra_delay = HandleGrabs(direction, old_turf)
+	if(isturf(mob.loc))
+		for(var/atom/movable/M in mob.ret_grab())
+			if(M != src && M.loc != mob.loc && !M.anchored && get_dist(old_turf, M) <= 1)
+				step(M, get_dir(M.loc, old_turf))
+		for(var/obj/item/grab/G in mob.get_active_grabs())
+			G.adjust_position()
 
 	if(QDELETED(mob)) // No idea why, but this was causing null check runtimes on live.
 		return
-
-	mob.ExtraMoveCooldown(extra_delay)
 
 	for (var/obj/item/grab/G in mob)
 		if (G.assailant_reverse_facing())
@@ -276,21 +278,6 @@
 			mod *= 0.8
 
 	return config.minimum_sprint_cost + (config.skill_sprint_cost_range * mod)
-
-/datum/movement_handler/mob/movement/proc/HandleGrabs(var/direction, var/old_turf)
-	. = 0
-	// TODO: Look into making grabs use movement events instead, this is a mess.
-	for(var/obj/item/grab/G in mob?.get_active_grabs())
-		if(G.assailant == G.affecting)
-			return
-		if(G.affecting.anchored)
-			return
-		. = max(., G.grab_slowdown())
-		if(isturf(mob.loc) && mob.loc != old_turf)
-			for(var/atom/movable/M in (mob.ret_grab()-mob))
-				if(isturf(M.loc) && M.loc != mob.loc && get_dist(old_turf, M) <= 1)
-					step(M, get_dir(M.loc, old_turf))
-		G.adjust_position()
 
 // Misc. helpers
 /mob/proc/MayEnterTurf(var/turf/T)

--- a/code/modules/mob/living/carbon/human/human_grabs.dm
+++ b/code/modules/mob/living/carbon/human/human_grabs.dm
@@ -8,11 +8,15 @@
 		if(!istype(organ))
 			to_chat(grabber, SPAN_WARNING("\The [src] is missing that body part!"))
 			return FALSE
-		if(grabber == src && istype(organ))
+		if(grabber == src)
+			var/using_slot = get_active_held_item_slot()
+			if(!using_slot)
+				to_chat(src, SPAN_WARNING("You cannot grab yourself without a usable hand!"))
+				return FALSE
 			var/list/bad_parts = list(organ.organ_tag) | organ.parent_organ
 			for(var/obj/item/organ/external/child in organ.children)
 				bad_parts |= child.organ_tag
-			if(organ && (organ.organ_tag in bad_parts))
+			if(using_slot in bad_parts)
 				to_chat(src, SPAN_WARNING("You can't grab your own [organ.name] with itself!"))
 				return FALSE
 		if(pull_damage())

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -188,34 +188,24 @@
 			return M
 	return 0
 
+#define ENCUMBERANCE_MOVEMENT_MOD 0.35
 /mob/proc/movement_delay()
 	. = 0
 	if(istype(loc, /turf))
 		var/turf/T = loc
 		. += T.movement_delay
-
 	if (drowsyness > 0)
 		. += 6
 	if(lying) //Crawling, it's slower
 		. += (8 + ((weakened * 3) + (confused * 2)))
-	. += move_intent.move_delay
-	. += encumbrance() * (0.5 + 1.5 * (SKILL_MAX - get_skill_value(SKILL_HAULING))/(SKILL_MAX - SKILL_MIN)) //Varies between 0.5 and 2, depending on skill
+	. += move_intent.move_delay + (ENCUMBERANCE_MOVEMENT_MOD * encumbrance())
+#undef ENCUMBERANCE_MOVEMENT_MOD
 
-#define ENCUMBERANCE_MOD 0.5
 /mob/proc/encumbrance()
 	for(var/obj/item/grab/G in get_active_grabs())
-		var/atom/movable/pulling = G.affecting
-		if(istype(pulling, /obj))
-			var/obj/O = pulling
-			. += between(0, O.w_class, ITEM_SIZE_GARGANTUAN) / 5
-		else if(istype(pulling, /mob))
-			var/mob/M = pulling
-			. += max(0, M.mob_size) / MOB_SIZE_MEDIUM
-		else
-			. += 1
+		. = max(., G.grab_slowdown())
 	. *= (0.8 ** size_strength_mod())
-	. *= ENCUMBERANCE_MOD
-#undef ENCUMBERANCE_MOD
+	. *= (0.5 + 1.5 * (SKILL_MAX - get_skill_value(SKILL_HAULING))/(SKILL_MAX - SKILL_MIN))
 
 //Determines mob size/strength effects for slowdown purposes. Standard is 0; can be pos/neg.
 /mob/proc/size_strength_mod()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -201,6 +201,7 @@
 	. += move_intent.move_delay
 	. += encumbrance() * (0.5 + 1.5 * (SKILL_MAX - get_skill_value(SKILL_HAULING))/(SKILL_MAX - SKILL_MIN)) //Varies between 0.5 and 2, depending on skill
 
+#define ENCUMBERANCE_MOD 0.5
 /mob/proc/encumbrance()
 	for(var/obj/item/grab/G in get_active_grabs())
 		var/atom/movable/pulling = G.affecting
@@ -213,6 +214,8 @@
 		else
 			. += 1
 	. *= (0.8 ** size_strength_mod())
+	. *= ENCUMBERANCE_MOD
+#undef ENCUMBERANCE_MOD
 
 //Determines mob size/strength effects for slowdown purposes. Standard is 0; can be pos/neg.
 /mob/proc/size_strength_mod()


### PR DESCRIPTION
- Allows you to grab yourself again.
- Refactors grab encumberance handling and properly factors grabs into move delay only once.
- Overall reduces the movement impact of encumberance.