### PR TITLE
Removes redundant dots from fusion interfaces

### DIFF
--- a/nano/templates/fusion_core_control.tmpl
+++ b/nano/templates/fusion_core_control.tmpl
@@ -4,15 +4,15 @@
 	{{if value.field}}
 		<div class="item">
 			<div class="itemLabel">
-				Field generator
+				Field generator:
 			</div>
 			<div class="itemContent">
-				 Online.<br/>{{:helper.link('Shut down.', null, {'machine': value.ref, 'toggle_active': 1})}}
+				 Online<br/>{{:helper.link('Shut down', null, {'machine': value.ref, 'toggle_active': 1})}}
 			</div>
 		</div>
 		<div class="item">
 			<div class="itemLabel">
-				Power status
+				Power status:
 			</div>
 			<div class="itemContent">
 				{{:value.powerstatus}}
@@ -20,7 +20,7 @@
 		</div>
 		<div class="item">
 			<div class="itemLabel">
-				Field strength
+				Field strength:
 			</div>
 			<div class="itemContent">
 				{{:value.power}}<br/>{{:helper.link('-10', null, {'machine': value.ref, 'str': -100})}}{{:helper.link('-1', null, {'machine': value.ref, 'str': -10})}}{{:helper.link('-0.1', null, {'machine': value.ref, 'str': -1})}}{{:helper.link('+0.1', null, {'machine': value.ref, 'str': 1})}}{{:helper.link('+1', null, {'machine': value.ref, 'str': 10})}}{{:helper.link('+10', null, {'machine': value.ref, 'str': 100})}}
@@ -28,7 +28,7 @@
 		</div>
 		<div class="item">
 			<div class="itemLabel">
-				Size
+				Size:
 			</div>
 			<div class="itemContent">
 				{{:value.size}}
@@ -36,7 +36,7 @@
 		</div>
 		<div class="item">
 			<div class="itemLabel">
-				Instability
+				Instability:
 			</div>
 			<div class="itemContent">
 				{{:value.instability}}
@@ -44,7 +44,7 @@
 		</div>
 		<div class="item">
 			<div class="itemLabel">
-				Plasma temperature
+				Plasma temperature:
 			</div>
 			<div class="itemContent">
 				{{:value.temperature}}
@@ -52,7 +52,7 @@
 		</div>
 		<div class="item">
 			<div class="itemLabel">
-				Reactants
+				Reactants:
 			</div>
 			<div class="itemContent">
 				{{:value.fuel}}
@@ -61,10 +61,10 @@
 	{{else}}
 		<div class="item">
 			<div class="itemLabel">
-				Field generator
+				Field generator:
 			</div>
 			<div class="itemContent">
-				Offline.<br/>{{:helper.link('Start up.', null, {'machine': value.ref, 'toggle_active': 1})}}
+				Offline<br/>{{:helper.link('Start up', null, {'machine': value.ref, 'toggle_active': 1})}}
 			</div>
 		</div>
 	{{/if}}

--- a/nano/templates/fusion_gyrotron_control.tmpl
+++ b/nano/templates/fusion_gyrotron_control.tmpl
@@ -7,15 +7,15 @@
 		</div>
 		<div class="itemContent">
 			 {{if value.active}}
-				Online.<br/>{{:helper.link('Shut down.', null, {'machine': value.ref, 'toggle': 1})}}
+				Online<br/>{{:helper.link('Shut down', null, {'machine': value.ref, 'toggle': 1})}}
 			 {{else}}
-				Offline.<br/>{{:helper.link('Start up.', null, {'machine': value.ref, 'toggle': 1})}}
+				Offline<br/>{{:helper.link('Start up', null, {'machine': value.ref, 'toggle': 1})}}
 			 {{/if}}
 		</div>
 	</div>
 	<div class="item">
 		<div class="itemLabel">
-			Fire delay
+			Fire delay:
 		</div>
 		<div class="itemContent">
 			{{:helper.link(value.firedelay, null, {'machine': value.ref, 'modifyrate': 1})}}
@@ -23,7 +23,7 @@
 	</div>
 	<div class="item">
 		<div class="itemLabel">
-			Power output
+			Power output:
 		</div>
 		<div class="itemContent">
 			{{:helper.link(value.energy, null, {'machine': value.ref, 'modifypower': 1})}}

--- a/nano/templates/fusion_injector_control.tmpl
+++ b/nano/templates/fusion_injector_control.tmpl
@@ -11,19 +11,19 @@
 	<h3>{{:value.id}}</h3>
 	<div class="item">
 		<div class="itemLabel">
-			Status
+			Status:
 		</div>
 		<div class="itemContent">
 			 {{if value.injecting}}
-				Online.<br/>{{:helper.link('Shut down.', null, {'toggle_injecting': value.ref})}}
+				Online<br/>{{:helper.link('Shut down', null, {'toggle_injecting': value.ref})}}
 			 {{else}}
-				Offline.<br/>{{:helper.link('Start up.', null, {'toggle_injecting': value.ref})}}
+				Offline<br/>{{:helper.link('Start up', null, {'toggle_injecting': value.ref})}}
 			 {{/if}}
 		</div>
 	</div>
 	<div class="item">
 		<div class="itemLabel">
-			Injection rate
+			Injection rate:
 		</div>
 		<div class="itemContent">
 			{{:helper.link(value.injection_rate, null, {'machine': value.ref, 'injection_rate': 1})}}
@@ -31,7 +31,7 @@
 	</div>
 	<div class="item">
 		<div class="itemLabel">
-			Fuel material
+			Fuel material:
 		</div>
 		<div class="itemContent">
 			{{:value.fueltype}}
@@ -39,7 +39,7 @@
 	</div>
 	<div class="item">
 		<div class="itemLabel">
-			Fuel depletion
+			Fuel depletion:
 		</div>
 		<div class="itemContent">
 			{{:value.depletion}}

--- a/nano/templates/kinetic_harvester.tmpl
+++ b/nano/templates/kinetic_harvester.tmpl
@@ -1,8 +1,8 @@
 <h2>Fusion plant: {{:data.id}}</h2>
 {{if data.status}}
-	{{:helper.link('Online.', null, {'toggle_power': 1})}}
+	{{:helper.link('Online', null, {'toggle_power': 1})}}
 {{else}}
-	{{:helper.link('Offline.', null, {'toggle_power': 1})}}
+	{{:helper.link('Offline', null, {'toggle_power': 1})}}
 {{/if}}
 
 {{for data.materials}}
@@ -12,12 +12,12 @@
 		</div>
 		<div class="itemContent">
 			{{if value.harvest}}
-				{{:helper.link('Collecting.', null, {'toggle_harvest': value.material})}}
+				{{:helper.link('Collecting', null, {'toggle_harvest': value.material})}}
 			{{else}}
-				{{:helper.link('Not collecting.', null, {'toggle_harvest': value.material})}}
+				{{:helper.link('Not collecting', null, {'toggle_harvest': value.material})}}
 			{{/if}}
 			{{if value.amount > 0}}
-				{{:helper.link('Remove sheets.', null, {'remove_mat': value.material})}}
+				{{:helper.link('Remove sheets', null, {'remove_mat': value.material})}}
 			{{/if}}
 		</div>
 	</div>


### PR DESCRIPTION
They're ugly and looks bad on buttons.

Here's old vs new versions:
![image](https://user-images.githubusercontent.com/44920739/93688841-a6193480-fad1-11ea-8e46-aee4765cd3cb.png)![image](https://user-images.githubusercontent.com/44920739/93688851-b204f680-fad1-11ea-86b2-f51f0be539cc.png)

