### PR TITLE
Makes mobs resistant to negligible amounts of radiation

### DIFF
--- a/code/modules/radiation/radiation.dm
+++ b/code/modules/radiation/radiation.dm
@@ -63,7 +63,7 @@
 	return 1
 
 /mob/living/rad_act(var/severity)
-	if(severity)
+	if(severity > RAD_LEVEL_LOW)
 		src.apply_damage(severity, IRRADIATE, damage_flags = DAM_DISPERSED)
 		for(var/atom/I in src)
 			I.rad_act(severity)


### PR DESCRIPTION
> Mobs will only accumulate radiation when it is higher than RAD_LEVEL_LOW, which is the lowest define that is above 0.
This will prevent from mobs getting negligible radiation burns in areas that are deemed safe.
Green geiger readings used to imply no radiation damage, not sure if this was an oversight in one of the radiation overhauls.