### PR TITLE
Fixes #861

### DIFF
--- a/code/modules/overmap/_defines.dm
+++ b/code/modules/overmap/_defines.dm
@@ -17,7 +17,6 @@ var/global/list/map_sectors = list()
 
 /turf/unsimulated/map/edge
 	opacity = 1
-	density = 1
 
 /turf/unsimulated/map/Initialize(var/ml)
 	. = ..(ml)

--- a/code/modules/overmap/overmap_object.dm
+++ b/code/modules/overmap/overmap_object.dm
@@ -64,16 +64,16 @@
 	var/nx = x
 	var/ny = y
 	var/low_edge = 1
-	var/high_edge = GLOB.using_map.overmap_size - 1
+	var/high_edge = GLOB.using_map.overmap_size
 
 	if((dir & WEST) && x == low_edge)
-		nx = high_edge
+		nx = high_edge - 1
 	else if((dir & EAST) && x == high_edge)
-		nx = low_edge
+		nx = low_edge + 1
 	if((dir & SOUTH)  && y == low_edge)
-		ny = high_edge
+		ny = high_edge - 1
 	else if((dir & NORTH) && y == high_edge)
-		ny = low_edge
+		ny = low_edge + 1
 	if((x == nx) && (y == ny))
 		return //we're not flying off anywhere
 


### PR DESCRIPTION
Now ship briefly moves to the edge turfs (which are non dense on both sides) to wrap around to the turf next to the edge.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->