### PR TITLE
Refactoring extinguisher and balloon refilling.

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -50,7 +50,7 @@
 
 #define REAGENT_LIST(R) (R.reagents?.get_reagents() || "No reagent holder")
 
-#define REAGENTS_FREE_SPACE(R) (R.maximum_volume - R.total_volume)
+#define REAGENTS_FREE_SPACE(R) (R?.maximum_volume - R?.total_volume)
 #define REAGENT_VOLUME(REAGENT_HOLDER, REAGENT_TYPE) (REAGENT_HOLDER?.reagent_volumes && REAGENT_HOLDER.reagent_volumes[REAGENT_TYPE])
 #define REAGENT_DATA(REAGENT_HOLDER, REAGENT_TYPE)   (REAGENT_HOLDER?.reagent_data    && REAGENT_HOLDER.reagent_data[REAGENT_TYPE])
 

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -978,3 +978,26 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 /obj/item/proc/attack_message_name()
 	return "\a [src]"
+
+/obj/item/proc/fill_from_pressurized_fluid_source(obj/structure/source, mob/user)
+	if(!istype(source) || !source.is_pressurized_fluid_source())
+		return FALSE
+	var/free_space =  Floor(REAGENTS_FREE_SPACE(reagents))
+	if(free_space <= 0)
+		to_chat(user, SPAN_WARNING("\The [src] is full!"))
+		return TRUE
+	if(istype(source, /obj/structure/reagent_dispensers))
+		free_space = min(free_space, source.reagents?.total_volume)
+		if(free_space <= 0)
+			to_chat(user, SPAN_WARNING("There is not enough fluid in \the [source] to fill \the [src]."))
+			return TRUE
+	if(free_space > 0)
+		if(istype(source, /obj/structure/reagent_dispensers/watertank))
+			source.reagents.trans_to_obj(src, free_space)
+		else
+			reagents.add_reagent(/decl/material/liquid/water, free_space)
+		if(reagents && reagents.total_volume >= reagents.maximum_volume)
+			to_chat(user, SPAN_NOTICE("You fill \the [src] with [free_space] unit\s from \the [source]."))
+			reagents.touch(src)
+			return TRUE
+	return FALSE

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -39,22 +39,20 @@
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "waterballoon-e"
 	item_state = "balloon-empty"
+	force = 0
 
 /obj/item/toy/water_balloon/Initialize()
 	. = ..()
 	create_reagents(10)
+	item_flags |= ITEM_FLAG_NO_BLUDGEON
 
-/obj/item/toy/water_balloon/attack(mob/living/carbon/human/M, mob/user)
-	return
+/obj/item/toy/water_balloon/resolve_attackby(obj/structure/O, mob/user, click_params)
+	. = (istype(O) && fill_from_pressurized_fluid_source(O, user)) || ..()
 
-/obj/item/toy/water_balloon/afterattack(atom/A, mob/user, proximity)
-	if(!proximity) return
-	if (istype(A, /obj/structure/reagent_dispensers/watertank) && get_dist(src,A) <= 1)
-		A.reagents.trans_to_obj(src, 10)
-		to_chat(user, "<span class='notice'>You fill the balloon with the contents of [A].</span>")
-		src.desc = "A translucent balloon with some form of liquid sloshing around in it."
-		src.update_icon()
-	return
+/obj/item/toy/water_balloon/fill_from_pressurized_fluid_source(obj/source, mob/user)
+	. = ..()
+	desc = . ? "A translucent balloon with some form of liquid sloshing around in it." : initial(desc)
+	update_icon()
 
 /obj/item/toy/water_balloon/attackby(obj/O, mob/user)
 	if(istype(O, /obj/item/chems/glass))

--- a/code/game/objects/structures/__structure.dm
+++ b/code/game/objects/structures/__structure.dm
@@ -97,6 +97,9 @@
 	set waitfor = FALSE
 	return FALSE
 
+/obj/structure/proc/is_pressurized_fluid_source()
+	return FALSE
+
 /obj/structure/proc/take_damage(var/damage)
 	if(health == -1) // This object does not take damage.
 		return

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -383,6 +383,9 @@
 	anchored = 1
 	var/busy = 0 	//Something's being washed at the moment
 
+/obj/structure/hygiene/sink/is_pressurized_fluid_source()
+	return TRUE
+
 /obj/structure/hygiene/sink/MouseDrop_T(var/obj/item/thing, var/mob/user)
 	..()
 	if(!istype(thing) || !ATOM_IS_OPEN_CONTAINER(thing))
@@ -499,6 +502,9 @@
 	name = "puddle"
 	icon_state = "puddle"
 	clogged = -1 // how do you clog a puddle
+
+/obj/structure/hygiene/sink/puddle/is_pressurized_fluid_source()
+	return FALSE
 
 /obj/structure/hygiene/sink/puddle/attack_hand(var/mob/M)
 	icon_state = "puddle-splash"

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -22,6 +22,9 @@
 		var/reagent_ratio = initial_reagent_types[reagent_type]
 		reagents.add_reagent(reagent_type, reagent_ratio * initial_capacity)
 
+/obj/structure/reagent_dispensers/is_pressurized_fluid_source()
+	return TRUE
+
 /obj/structure/reagent_dispensers/proc/leak()
 	var/turf/T = get_turf(src)
 	if(reagents && T)


### PR DESCRIPTION
Water balloons and extinguishers now share code for refilling from tanks and sinks (or any pressurized fluid source).
You can fill extinguishers from fuel tanks but it seems to produce tiny puddles that won't ignite, not really a significant bug since it won't do any cooling or extinguishing.

Alternative to #927.