### PR TITLE
Antagonist selection for mixed modes is more likely to be successful.

### DIFF
--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -216,12 +216,6 @@ Checks if a list has the same entries and values as an element of big.
 	for(var/e in L)
 		. += L[e]
 
-// Return a list of the keys in an assoc list
-/proc/list_keys(var/list/L)
-	. = list()
-	for(var/e in L)
-		. += e
-
 //Mergesort: divides up the list into halves to begin the sort
 /proc/sortKey(var/list/client/L, var/order = 1)
 	if(isnull(L) || L.len < 2)

--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -216,6 +216,12 @@ Checks if a list has the same entries and values as an element of big.
 	for(var/e in L)
 		. += L[e]
 
+// Return a list of the keys in an assoc list
+/proc/list_keys(var/list/L)
+	. = list()
+	for(var/e in L)
+		. += e
+
 //Mergesort: divides up the list into halves to begin the sort
 /proc/sortKey(var/list/client/L, var/order = 1)
 	if(isnull(L) || L.len < 2)

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -198,10 +198,9 @@
 	if(!candidates.len)
 		return 0
 
-	//Grab candidates randomly until we have enough.
+	//Grab candidates until we have enough.
 	while(candidates.len && pending_antagonists.len < spawn_target)
-		var/datum/mind/player = pick(candidates)
-		candidates -= player
+		var/datum/mind/player = popleft(candidates)
 		draft_antagonist(player)
 
 	return 1

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -212,7 +212,9 @@ var/global/list/additional_antag_types = list()
 			antag_templates_by_initial_spawn_req[antag] = antag.initial_spawn_req
 
 		sortTim(antag_templates_by_initial_spawn_req, /proc/cmp_numeric_asc, TRUE)
-		antag_templates = list_keys(antag_templates_by_initial_spawn_req)
+		antag_templates = list()
+		for(var/template in antag_templates_by_initial_spawn_req)
+			antag_templates += template
 
 		var/list/valid_templates_per_candidate = list() // number of roles each candidate can satisfy
 		for(var/candidate in all_candidates)
@@ -220,9 +222,12 @@ var/global/list/additional_antag_types = list()
 
 		valid_templates_per_candidate = shuffle(valid_templates_per_candidate) // shuffle before sorting so that candidates with the same number of templates will be in random order
 		sortTim(valid_templates_per_candidate, /proc/cmp_numeric_asc, TRUE)
+		var/list/sorted_candidates = list()
+		for(var/sorted_candidate in valid_templates_per_candidate)
+			sorted_candidates += sorted_candidate
 
 		for(var/datum/antagonist/antag in antag_templates)
-			antag.candidates = list_keys(valid_templates_per_candidate) & antag.candidates // orders antag.candidates by valid_templates_per_candidate
+			antag.candidates = sorted_candidates & antag.candidates // orders antag.candidates by sorted_candidates
 
 		var/datum/antagonist/last_template = antag_templates[antag_templates.len]
 		last_template.candidates = shuffle(last_template.candidates) // last template to be considered can have its candidates in any order

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -201,9 +201,37 @@ var/global/list/additional_antag_types = list()
 		antag.update_current_antag_max(src)
 		antag.build_candidate_list(src) //compile a list of all eligible candidates
 
+	if(length(antag_templates) > 1) // If we have multiple templates to satisfy, we must pick candidates who satisfy fewer templates first, and fill the template with fewest candidates first
+		var/list/template_candidates = list()
+		var/list/all_candidates = list() // All candidates for every template, may contain duplicates
+		var/list/antag_templates_by_initial_spawn_req = list()
+
+		for(var/datum/antagonist/antag in antag_templates)
+			template_candidates[antag.id] = length(antag.candidates)
+			all_candidates += antag.candidates
+			antag_templates_by_initial_spawn_req[antag] = antag.initial_spawn_req
+
+		sortTim(antag_templates_by_initial_spawn_req, /proc/cmp_numeric_asc, TRUE)
+		antag_templates = list_keys(antag_templates_by_initial_spawn_req)
+
+		var/list/valid_templates_per_candidate = list() // number of roles each candidate can satisfy
+		for(var/candidate in all_candidates)
+			valid_templates_per_candidate[candidate]++
+
+		valid_templates_per_candidate = shuffle(valid_templates_per_candidate) // shuffle before sorting so that candidates with the same number of templates will be in random order
+		sortTim(valid_templates_per_candidate, /proc/cmp_numeric_asc, TRUE)
+
+		for(var/datum/antagonist/antag in antag_templates)
+			antag.candidates = list_keys(valid_templates_per_candidate) & antag.candidates // orders antag.candidates by valid_templates_per_candidate
+
+		var/datum/antagonist/last_template = antag_templates[antag_templates.len]
+		last_template.candidates = shuffle(last_template.candidates) // last template to be considered can have its candidates in any order
+
+	for(var/datum/antagonist/antag in antag_templates)
 		//antag roles that replace jobs need to be assigned before the job controller hands out jobs.
 		if(antag.flags & ANTAG_OVERRIDE_JOB)
 			antag.attempt_spawn() //select antags to be spawned
+		antag.candidates = shuffle(antag.candidates) // makes selection past initial_spawn_req fairer
 
 ///post_setup()
 /datum/game_mode/proc/post_setup()


### PR DESCRIPTION
_Originally PR'd for Aurora [here](https://github.com/Aurorastation/Aurora.3/pull/9583) plus some further bugfix/adjustment PRs._

Adjusts antagonist selection for mixed modes, performing some sorting so that the mixed mode is more likely to be successfully started. This has proven important on Aurora where we have many popular mixed modes, and it was common for mode selection to be restarted despite having appropriate candidates.

* Candidates with fewer eligible modes are selected preferentially for that mode, leaving more eligible players for the other modes.
* Candidates are assigned to the mode that requires fewest players, first.
* Selection is still made as random as possible within these limits.