### PR TITLE
Bunch of aimless cooldown / medical system tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -905,30 +905,27 @@
 			eye_blurry = max(2, eye_blurry)
 			stuttering = max(stuttering, 5)
 
-	if(shock_stage == 40)
-		custom_pain("[pick("The pain is excruciating", "Please, just end the pain", "Your whole body is going numb")]!", 40, nohalloss = TRUE)
 	if (shock_stage >= 60)
 		if(shock_stage == 60) visible_message("<b>[src]</b>'s body becomes limp.")
 		if (prob(2))
 			custom_pain("[pick("The pain is excruciating", "Please, just end the pain", "Your whole body is going numb")]!", shock_stage, nohalloss = TRUE)
-			Weaken(10)
+			Weaken(3)
 
 	if(shock_stage >= 80)
 		if (prob(5))
 			custom_pain("[pick("The pain is excruciating", "Please, just end the pain", "Your whole body is going numb")]!", shock_stage, nohalloss = TRUE)
-			Weaken(20)
+			Weaken(5)
 
 	if(shock_stage >= 120)
-		if (prob(2))
+		if(!paralysis && prob(2))
 			custom_pain("[pick("You black out", "You feel like you could die any moment now", "You're about to lose consciousness")]!", shock_stage, nohalloss = TRUE)
 			Paralyse(5)
 
 	if(shock_stage == 150)
 		visible_message("<b>[src]</b> can no longer stand, collapsing!")
-		Weaken(20)
 
 	if(shock_stage >= 150)
-		Weaken(20)
+		Weaken(5)
 
 /*
 	Called by life(), instead of having the individual hud items update icons each tick and check for status changes

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -286,6 +286,9 @@ proc/blood_splatter(var/target, var/source, var/large, var/spray_dir)
 				pulse_mod *= 1.25
 	blood_volume *= pulse_mod
 
+	if(lying)
+		blood_volume *= 1.25
+
 	var/min_efficiency = recent_pump ? 0.5 : 0.3
 	blood_volume *= max(min_efficiency, (1-(heart.damage / heart.max_damage)))
 

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -105,7 +105,7 @@
 			else
 				to_chat(owner, "<span class='danger'>You're having trouble getting enough [breath_type]!</span>")
 
-			owner.losebreath = max(round(damage / 2), owner.losebreath)
+			owner.losebreath = max(3, owner.losebreath)
 
 /obj/item/organ/internal/lungs/proc/rupture()
 	var/obj/item/organ/external/parent = owner.get_organ(parent_organ)

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -153,7 +153,10 @@
 	safe_pressure_min *= 1 + rand(1,4) * damage/max_damage
 
 	if(!forced && owner.chem_effects[CE_BREATHLOSS] && !owner.chem_effects[CE_STABLE]) //opiates are bad mmkay
-		safe_pressure_min *= 1 + rand(1,4) * owner.chem_effects[CE_BREATHLOSS]
+		safe_pressure_min *= 1 + owner.chem_effects[CE_BREATHLOSS]
+	
+	if(owner.lying)
+		safe_pressure_min *= 0.8
 
 	var/failed_inhale = 0
 	var/failed_exhale = 0

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -47,7 +47,7 @@ mob/living/carbon/proc/custom_pain(var/message, var/power, var/force, var/obj/it
 			var/decl/emote/use_emote = usable_emotes[force_emote]
 			if(!(use_emote.message_type == AUDIBLE_MESSAGE && silent))
 				emote(force_emote)
-	next_pain_time = world.time + (100-power)
+	next_pain_time = world.time + max(30 SECONDS - power, 10 SECONDS)
 
 /mob/living/carbon/human/proc/handle_pain()
 	if(stat)


### PR DESCRIPTION
Commits have nitty gritty in descs

- Shock stage caused weakening is now /way/ shorter, from 10-20 life ticks to 3-5. Paralysis is only applied if you're not already paralysed, like brain does it for bloodloss, so it doesn't stack potentially.
- Random damaged lung gasping doesn't require 30-70 seconds to clear up, which made bruised lungs deadlier than intended
- Gives some bonuses to blood circulation and required oxygen if you're lying down.
- Pain messages are now at 30s cooldown, lowered by pain power to minimum of 10s. Only applies to same message, different pains will be shown at their leisure.