### PR TITLE
Tweaks to examining message

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -310,14 +310,20 @@
 	face_atom(A)
 
 	if(!isghost(src))
-		if(A.loc != src || (A in get_held_items()))
+		if((A.loc != src || (A in get_held_items())))
+			var/look_target = "at \the [A]"
+			if(isobj(A.loc))
+				look_target = "inside \the [A.loc]"
+			if(A == src)
+				var/datum/gender/T = gender_datums[get_gender()]
+				look_target = "at [T.self]"
 			for(var/mob/M in viewers(4, src))
 				if(M == src)
 					continue
 				if(M.client && M.client.get_preference_value(/datum/client_preference/examine_messages) == GLOB.PREF_SHOW)
 					if(M.is_blind() || is_invisible_to(M))
 						continue
-					to_chat(M, "<span class='subtle'><b>\The [src]</b> looks at \the [A].</span>")
+					to_chat(M, "<span class='subtle'><b>\The [src]</b> looks [look_target].</span>")
 
 	var/distance = INFINITY
 	if(isghost(src) || stat == DEAD)


### PR DESCRIPTION
Now if mob is looking at something inside an object, only the object is specified, e.g. 'inside the backpack' rather than 'at the e-mag'
Also made looking at self message not list name twice cause it looks bit silly.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->