### PR TITLE
Fixes global sounds getting 0 volume if they have no source turf

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -80,7 +80,8 @@ var/const/FALLOFF_SOUNDS = 0.5
 			S.frequency = get_rand_frequency()
 
 	var/turf/T = get_turf(src)
-	S.volume = adjust_volume_for_hearer(S.volume, turf_source, src)
+	if(!is_global)
+		S.volume = adjust_volume_for_hearer(S.volume, turf_source, src)
 	// 3D sounds, the technology is here!
 
 	if(isturf(turf_source))


### PR DESCRIPTION
Having no source turf is perfectly legal, but the proc that adjsuted volume based on atmos etc set volume to 0 if it couldn't find one.
Broke important things like forensic examine clue sounds.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->