### PR TITLE
Initializes human colour vars to black to prevent some icon runtimes.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -3,10 +3,10 @@
 	var/h_style = "Bald"
 	var/f_style = "Shaved"
 
-	var/hair_colour
-	var/facial_hair_colour
-	var/skin_colour
-	var/eye_colour
+	var/hair_colour =        COLOR_BLACK
+	var/facial_hair_colour = COLOR_BLACK
+	var/skin_colour =        COLOR_BLACK
+	var/eye_colour =         COLOR_BLACK
 
 	var/skin_tone = 0  //Skin tone
 	var/skin_base = "" //Skin base

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -72,7 +72,7 @@
 	if(owner.chem_effects[CE_GLOWINGEYES])
 		eye_colour = "#75bdd6" // blue glow, hardcoded for now.
 	else
-		eye_colour = owner.eye_colour || COLOR_BLACK
+		eye_colour = owner.eye_colour
 
 /obj/item/organ/internal/eyes/take_internal_damage(amount, var/silent=0)
 	var/oldbroken = is_broken()


### PR DESCRIPTION
Starlight reported a 'bad icon' runtime with Resomi tails due to these vars initializing to null.