### PR TITLE
Fixes generate_habitability

### DIFF
--- a/code/modules/overmap/exoplanets/planet_types/barren.dm
+++ b/code/modules/overmap/exoplanets/planet_types/barren.dm
@@ -18,7 +18,7 @@
 	..()
 	
 /obj/effect/overmap/visitable/sector/exoplanet/barren/generate_habitability()
-	return HABITABILITY_BAD
+	habitability_class =  HABITABILITY_BAD
 
 /obj/effect/overmap/visitable/sector/exoplanet/barren/generate_atmosphere()
 	..()

--- a/code/modules/overmap/exoplanets/planet_types/chlorine.dm
+++ b/code/modules/overmap/exoplanets/planet_types/chlorine.dm
@@ -15,7 +15,7 @@
 	megafauna_types = list(/mob/living/simple_animal/hostile/retaliate/jelly/mega)
 
 /obj/effect/overmap/visitable/sector/exoplanet/chlorine/generate_habitability()
-	return HABITABILITY_BAD
+	habitability_class =  HABITABILITY_BAD
 
 /obj/effect/overmap/visitable/sector/exoplanet/chlorine/get_atmosphere_color()
 	return "#e5f2bd"

--- a/code/modules/overmap/exoplanets/planet_types/volcanic.dm
+++ b/code/modules/overmap/exoplanets/planet_types/volcanic.dm
@@ -27,7 +27,7 @@
 	return COLOR_GRAY20
 
 /obj/effect/overmap/visitable/sector/exoplanet/volcanic/generate_habitability()
-	return HABITABILITY_BAD
+	habitability_class =  HABITABILITY_BAD
 
 /obj/effect/overmap/visitable/sector/exoplanet/volcanic/generate_atmosphere()
 	..()


### PR DESCRIPTION
Several exoplanet types didn't use generate_habitability() correctly. In the base implementation, habitability_class was assigned, but the children were instead just returning the value. 