### PR TITLE
Implements species exertion (Bay port).

### DIFF
--- a/code/modules/emotes/definitions/exertion.dm
+++ b/code/modules/emotes/definitions/exertion.dm
@@ -1,0 +1,40 @@
+/decl/emote/exertion/biological
+	key = "esweat"
+	emote_range = 4
+	emote_message_1p = "You are sweating heavily."
+	emote_message_3p = "USER is sweating heavily."
+
+/decl/emote/exertion/biological/check_user(mob/living/user)
+	if(istype(user) && !user.isSynthetic())
+		return ..()
+	return FALSE
+
+/decl/emote/exertion/biological/breath
+	key = "ebreath"
+	emote_message_1p = "You feel out of breath."
+	emote_message_3p = "USER looks out of breath."
+
+/decl/emote/exertion/biological/pant
+	key = "epant"
+	emote_range = 3
+	message_type = AUDIBLE_MESSAGE
+	emote_message_1p = "You pant to catch your breath."
+	emote_message_3p = "USER pants for air."
+	emote_message_impaired = "You can see USER breathing heavily."
+
+/decl/emote/exertion/synthetic
+	key = "ewhine"
+	emote_range = 3
+	message_type = AUDIBLE_MESSAGE
+	emote_message_1p = "You overstress your actuators."
+	emote_message_3p = "USER's actuators whine with strain."
+
+/decl/emote/exertion/synthetic/check_user(mob/living/user)
+	if(istype(user) && user.isSynthetic())
+		return ..()
+	return FALSE
+
+/decl/emote/exertion/synthetic/creak
+	key = "ecreak"
+	emote_message_1p = "Your chassis stress indicators spike."
+	emote_message_3p = "USER's joints creak with stress."

--- a/code/modules/emotes/emote_define.dm
+++ b/code/modules/emotes/emote_define.dm
@@ -24,7 +24,7 @@
 	var/check_restraints               // Can this emote be used while restrained?
 	var/check_range                    // falsy, or a range outside which the emote will not work
 	var/conscious = TRUE               // Do we need to be awake to emote this?
-	var/emote_range                    // falsy, or a range outside which the emote is not shown
+	var/emote_range = 0                // If >0, restricts emote visibility to viewers within range.
 
 /decl/emote/proc/get_emote_message_1p(var/atom/user, var/atom/target, var/extra_params)
 	if(target)
@@ -100,6 +100,10 @@
 		use_radio_message = replacetext(use_radio_message, "USER_SELF", user_gender.self)
 		use_radio_message = replacetext(use_radio_message, "USER", "<b>\the [user]</b>")
 
+	var/use_range = emote_range
+	if (!use_range)
+		use_range = world.view
+
 	if(ismob(user))
 		var/mob/M = user
 		if(message_type == AUDIBLE_MESSAGE)
@@ -109,9 +113,9 @@
 					M.visible_message(message = "[user] opens their mouth silently!", self_message = "You cannot say anything!", blind_message = emote_message_impaired, checkghosts = /datum/client_preference/ghost_sight)
 					return
 				else
-					M.audible_message(message = use_3p, self_message = use_1p, deaf_message = emote_message_impaired, checkghosts = /datum/client_preference/ghost_sight, radio_message = use_radio_message)
+					M.audible_message(message = use_3p, self_message = use_1p, deaf_message = emote_message_impaired, hearing_distance = use_range, checkghosts = /datum/client_preference/ghost_sight, radio_message = use_radio_message)
 		else
-			M.visible_message(message = use_3p, self_message = use_1p, blind_message = emote_message_impaired, checkghosts = /datum/client_preference/ghost_sight)
+			M.visible_message(message = use_3p, self_message = use_1p, blind_message = emote_message_impaired, range = use_range, checkghosts = /datum/client_preference/ghost_sight)
 
 	do_extra(user, target)
 	do_sound(user)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -133,25 +133,12 @@
 /mob/living/carbon/human/Move()
 	. = ..()
 	if(.) //We moved
-		handle_exertion()
+		species.handle_exertion(src)
 		handle_leg_damage()
 
 		if(client)
 			var/turf/B = GetAbove(src)
 			up_hint.icon_state = "uphint[(B ? B.is_open() : 0)]"
-
-/mob/living/carbon/human/proc/handle_exertion()
-	if(isSynthetic())
-		return
-	var/lac_chance =  10 * encumbrance()
-	if(lac_chance && prob(skill_fail_chance(SKILL_HAULING, lac_chance)))
-		make_reagent(1, /decl/material/liquid/lactate)
-		adjust_hydration(-DEFAULT_THIRST_FACTOR)
-		switch(rand(1,20))
-			if(1)
-				visible_message("<span class='notice'>\The [src] is sweating heavily!</span>", "<span class='notice'>You are sweating heavily!</span>")
-			if(2)
-				visible_message("<span class='notice'>\The [src] looks out of breath!</span>", "<span class='notice'>You are out of breath!</span>")
 
 /mob/living/carbon/human/proc/handle_leg_damage()
 	if(!can_feel_pain())

--- a/code/modules/species/outsider/random.dm
+++ b/code/modules/species/outsider/random.dm
@@ -18,6 +18,16 @@
 		TAG_CULTURE = CULTURE_ALIUM
 	)
 
+	exertion_effect_chance = 10
+	exertion_hydration_scale = 1
+	exertion_reagent_scale = 5
+	exertion_reagent_path = /decl/material/liquid/lactate
+	exertion_emotes_biological = list(
+		/decl/emote/exertion/biological,
+		/decl/emote/exertion/biological/breath,
+		/decl/emote/exertion/biological/pant
+	)
+
 /decl/species/alium/New()
 	//Coloring
 	blood_color = RANDOM_RGB

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -274,6 +274,14 @@
 
 	var/datum/ai/ai						// Type abused. Define with path and will automagically create. Determines behaviour for clientless mobs. This will override mob AIs.
 
+	var/exertion_effect_chance = 0
+	var/exertion_hydration_scale = 0
+	var/exertion_nutrition_scale = 0
+	var/exertion_charge_scale = 0
+	var/exertion_reagent_scale = 0
+	var/exertion_reagent_path = null
+	var/list/exertion_emotes_biological = null
+	var/list/exertion_emotes_synthetic = null
 /*
 These are all the things that can be adjusted for equipping stuff and
 each one can be in the NORTH, SOUTH, EAST, and WEST direction. Specify
@@ -844,3 +852,27 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 			// This assumes that if a pain-level has been defined it also has a list of emotes to go with it
 			var/decl/emote/E = decls_repository.get_decl(pick(pain_emotes))
 			return E.key
+
+/decl/species/proc/handle_exertion(mob/living/carbon/human/H)
+	if (!exertion_effect_chance)
+		return
+	var/chance = exertion_effect_chance * H.encumbrance()
+	if (chance && prob(H.skill_fail_chance(SKILL_HAULING, chance)))
+		var/synthetic = H.isSynthetic()
+		if (synthetic)
+			if (exertion_charge_scale)
+				var/obj/item/organ/internal/cell/cell = locate() in H.internal_organs
+				if (cell)
+					cell.use(cell.get_power_drain() * exertion_charge_scale)
+		else
+			if (exertion_hydration_scale)
+				H.adjust_hydration(-DEFAULT_THIRST_FACTOR * exertion_hydration_scale)
+			if (exertion_nutrition_scale)
+				H.adjust_nutrition(-DEFAULT_HUNGER_FACTOR * exertion_nutrition_scale)
+			if (exertion_reagent_scale && !isnull(exertion_reagent_path))
+				H.make_reagent(REM * exertion_reagent_scale, exertion_reagent_path)
+		if (prob(10))
+			var/list/active_emotes = synthetic ? exertion_emotes_synthetic : exertion_emotes_biological
+			if(length(active_emotes))
+				var/decl/emote/exertion_emote = decls_repository.get_decl(pick(active_emotes))
+				exertion_emote.do_emote(H)

--- a/code/modules/species/station/station.dm
+++ b/code/modules/species/station/station.dm
@@ -25,6 +25,21 @@
 		)
 	)
 
+	exertion_effect_chance = 10
+	exertion_hydration_scale = 1
+	exertion_charge_scale = 1
+	exertion_reagent_scale = 5
+	exertion_reagent_path = /decl/material/liquid/lactate
+	exertion_emotes_biological = list(
+		/decl/emote/exertion/biological,
+		/decl/emote/exertion/biological/breath,
+		/decl/emote/exertion/biological/pant
+	)
+	exertion_emotes_synthetic = list(
+		/decl/emote/exertion/synthetic,
+		/decl/emote/exertion/synthetic/creak
+	)
+
 /decl/species/human/get_root_species_name(var/mob/living/carbon/human/H)
 	return SPECIES_HUMAN
 

--- a/mods/utility_frames/species.dm
+++ b/mods/utility_frames/species.dm
@@ -51,6 +51,13 @@
 		BP_EYES = /obj/item/organ/internal/eyes/robot
 	)
 
+	exertion_effect_chance = 10
+	exertion_charge_scale = 1
+	exertion_emotes_synthetic = list(
+		/decl/emote/exertion/synthetic,
+		/decl/emote/exertion/synthetic/creak
+	)
+
 /decl/species/utility_frame/post_organ_rejuvenate(obj/item/organ/org, mob/living/carbon/human/H)
 	var/obj/item/organ/external/E = org
 	if(istype(E) && !BP_IS_PROSTHETIC(E))

--- a/nebula.dme
+++ b/nebula.dme
@@ -1767,6 +1767,7 @@
 #include "code\modules\emotes\definitions\_mob.dm"
 #include "code\modules\emotes\definitions\_species.dm"
 #include "code\modules\emotes\definitions\audible.dm"
+#include "code\modules\emotes\definitions\exertion.dm"
 #include "code\modules\emotes\definitions\human.dm"
 #include "code\modules\emotes\definitions\slime.dm"
 #include "code\modules\emotes\definitions\synthetics.dm"


### PR DESCRIPTION
Ports Spook's species-level exertion emote and reagent PR. Allows you to configure response to exertion per-species instead of at the `/mob/living/carbon/human` level.