### PR TITLE
Fixes network bugs and adjusts program access

### DIFF
--- a/code/game/machinery/_machines_base/stock_parts/network_lock.dm
+++ b/code/game/machinery/_machines_base/stock_parts/network_lock.dm
@@ -83,15 +83,15 @@
 		return
 	data["connected"] = TRUE
 	data["default_state"] = auto_deny_all
-	var/list/grants = list()
+	var/list/grants_data = list()
 	if(!network.access_controller)
 		return
 	for(var/datum/computer_file/data/grant_record/GR in network.access_controller.get_all_grants())
-		grants.Add(list(list(
+		grants_data.Add(list(list(
 			"grant_name" = GR.stored_data,
 			"assigned" = (GR.stored_data in grants)
 		)))
-	data["grants"] = grants
+	data["grants"] = grants_data
 
 /obj/item/stock_parts/network_lock/OnTopic(mob/user, href_list, datum/topic_state/state)
 	. = ..()

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -462,6 +462,11 @@ var/const/NO_EMAG_ACT = -50
 		to_chat(usr, SPAN_WARNING("Pressing the synchronization button on the card causes a red LED to flash three times."))
 
 /obj/item/card/id/network/proc/refresh_access_record(var/datum/computer_network/network)
+	if(!network)
+		var/datum/extension/network_device/D = get_extension(src, /datum/extension/network_device)
+		network = D.get_network()
+	if(!network)
+		return
 	for(var/datum/extension/network_device/mainframe/mainframe in network.get_mainframes_by_role(MF_ROLE_CREW_RECORDS))
 		for(var/datum/computer_file/report/crew_record/ar in mainframe.get_all_files())
 			if(ar.user_id != user_id)

--- a/code/modules/merchant/merchant_programs.dm
+++ b/code/modules/merchant/merchant_programs.dm
@@ -7,7 +7,7 @@
 	nanomodule_path = /datum/nano_module/program/merchant
 	size = 12
 	usage_flags = PROGRAM_CONSOLE
-	required_access = access_merchant
+	required_access = list(access_merchant)
 	var/obj/machinery/merchant_pad/pad = null
 	var/current_merchant = 0
 	var/show_trades = 0

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -91,7 +91,7 @@
 		if(network)
 			var/datum/extension/network_device/acl/access_controller = network.access_controller
 			if(access_controller)
-				accesses_to_check = access_controller.get_program_access(src.type)
+				accesses_to_check = access_controller.get_program_access(filename)
 				if(!length(accesses_to_check))
 					accesses_to_check = list(required_access)
 				else if(accesses_to_check[1] == "NONE")

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -2,7 +2,7 @@
 /datum/computer_file/program
 	filetype = "PRG"
 	filename = "UnknownProgram"						// File name. FILE NAME MUST BE UNIQUE IF YOU WANT THE PROGRAM TO BE DOWNLOADABLE FROM NETWORK!
-	var/required_access = null						// List of required accesses to run/download the program.
+	var/list/required_access = list()					// List of required accesses to run/download the program.
 	var/requires_access_to_run = 1					// Whether the program checks for required_access when run.
 	var/requires_access_to_download = 1				// Whether the program checks for required_access when downloading.
 	var/datum/nano_module/NM = null					// If the program uses NanoModule, put it here and it will be automagically opened. Otherwise implement ui_interact.
@@ -86,19 +86,17 @@
 /datum/computer_file/program/proc/can_run(var/mob/living/user, var/loud = 0, var/list/accesses_to_check, var/datum/computer_network/network)
 	if(!requires_access_to_run)
 		return TRUE
-	// Defaults to network accecss, and then required_access
-	if(!length(accesses_to_check))
+	// Checks to see if network access is enabled, and then defaults to required_access if not.
+	if(!accesses_to_check)
 		if(network)
 			var/datum/extension/network_device/acl/access_controller = network.access_controller
-			if(access_controller)
+			if(access_controller && access_controller.program_control)
 				accesses_to_check = access_controller.get_program_access(filename)
-				if(!length(accesses_to_check))
-					accesses_to_check = list(required_access)
-				else if(accesses_to_check[1] == "NONE")
-					return TRUE
-		else
-			accesses_to_check = list(required_access)
-	if(!accesses_to_check[1]) // No required_access, allow it.
+	
+	if(!length(accesses_to_check))
+		accesses_to_check = required_access
+
+	if(!length(accesses_to_check)) // No required_access, allow it.
 		return TRUE
 
 	// Admin override - allows operation of any computer as aghosted admin, as if you had any required access.
@@ -111,14 +109,14 @@
 	var/obj/item/card/id/I = user.GetIdCard()
 	if(!I)
 		if(loud)
-			to_chat(user, "<span class='notice'>\The [computer] flashes an \"RFID Error - Unable to scan ID\" warning.</span>")
+			to_chat(user, SPAN_WARNING("The OS flashes an \"RFID Error - Unable to scan ID\" warning."))
 		return FALSE
 
 	for(var/access in I.access)
 		if(access in accesses_to_check)
 			return TRUE
 	if(loud)
-		to_chat(user, "<span class='notice'>\The [computer] flashes an \"Access Denied\" warning.</span>")
+		to_chat(user, SPAN_WARNING("The OS flashes an \"Access Denied\" warning."))
 		return FALSE
 
 // This attempts to retrieve header data for NanoUIs. If implementing completely new device of different type than existing ones

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -2,7 +2,7 @@
 /datum/computer_file/program
 	filetype = "PRG"
 	filename = "UnknownProgram"						// File name. FILE NAME MUST BE UNIQUE IF YOU WANT THE PROGRAM TO BE DOWNLOADABLE FROM NETWORK!
-	var/list/required_access = list()					// List of required accesses to run/download the program.
+	var/list/required_access = list()				// List of required accesses to run/download the program.
 	var/requires_access_to_run = 1					// Whether the program checks for required_access when run.
 	var/requires_access_to_download = 1				// Whether the program checks for required_access when downloading.
 	var/datum/nano_module/NM = null					// If the program uses NanoModule, put it here and it will be automagically opened. Otherwise implement ui_interact.
@@ -112,9 +112,8 @@
 			to_chat(user, SPAN_WARNING("The OS flashes an \"RFID Error - Unable to scan ID\" warning."))
 		return FALSE
 
-	for(var/access in I.access)
-		if(access in accesses_to_check)
-			return TRUE
+	if(has_access(accesses_to_check, I.access))
+		return TRUE
 	if(loud)
 		to_chat(user, SPAN_WARNING("The OS flashes an \"Access Denied\" warning."))
 		return FALSE

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -11,7 +11,7 @@
 	program_menu_icon = "flag"
 	nanomodule_path = /datum/nano_module/program/comm
 	extended_desc = "Used to command and control. Can relay long-range communications. This program can not be run on tablet computers."
-	required_access = access_bridge
+	required_access = list(access_bridge)
 	requires_network = 1
 	size = 12
 	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP
@@ -109,7 +109,7 @@
 
 /datum/nano_module/program/comm/proc/is_autenthicated(var/mob/user)
 	if(program)
-		return program.can_run(user)
+		return program.can_run(user, program.computer.get_network())
 	return 1
 
 /datum/nano_module/program/comm/proc/obtain_message_listener()

--- a/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
@@ -6,7 +6,7 @@
 	program_key_state = "atmos_key"
 	program_menu_icon = "shuffle"
 	extended_desc = "This program allows remote control of air alarms. This program can not be run on tablet computers."
-	required_access = access_atmospherics
+	required_access = list(access_atmospherics)
 	requires_network = 1
 	network_destination = "atmospheric control system"
 	requires_network_feature = NETWORK_SYSTEMCONTROL

--- a/code/modules/modular_computers/file_system/programs/engineering/power_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/power_monitor.dm
@@ -7,7 +7,7 @@
 	program_menu_icon = "battery-3"
 	extended_desc = "This program connects to sensors to provide information about electrical systems"
 	ui_header = "power_norm.gif"
-	required_access = access_engine
+	required_access = list(access_engine)
 	requires_network = 1
 	network_destination = "power monitoring system"
 	size = 9

--- a/code/modules/modular_computers/file_system/programs/engineering/rcon_console.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/rcon_console.dm
@@ -6,7 +6,7 @@
 	program_key_state = "rd_key"
 	program_menu_icon = "power"
 	extended_desc = "This program allows remote control of power distribution systems. This program can not be run on tablet computers."
-	required_access = access_engine
+	required_access = list(access_engine)
 	network_destination = "RCON remote control system"
 	requires_network_feature = NETWORK_SYSTEMCONTROL
 	usage_flags = PROGRAM_LAPTOP | PROGRAM_CONSOLE

--- a/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
@@ -11,7 +11,7 @@
 	program_menu_icon = "notice"
 	extended_desc = "This program connects to specially calibrated supermatter sensors to provide information on the status of supermatter-based engines."
 	ui_header = "smmon_0.gif"
-	required_access = access_engine
+	required_access = list(access_engine)
 	network_destination = "supermatter monitoring system"
 	size = 5
 	category = PROG_ENG

--- a/code/modules/modular_computers/file_system/programs/generic/deck_management.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/deck_management.dm
@@ -7,7 +7,7 @@
 	filename = "deckmngr"
 	filedesc = "Deck Management"
 	nanomodule_path = /datum/nano_module/deck_management
-	required_access = list(access_cargo, access_bridge)
+	required_access = list(list(access_cargo, access_bridge))
 	program_icon_state = "request"
 	program_key_state = "rd_key"
 	program_menu_icon = "clock"

--- a/code/modules/modular_computers/file_system/programs/generic/deck_management.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/deck_management.dm
@@ -7,6 +7,7 @@
 	filename = "deckmngr"
 	filedesc = "Deck Management"
 	nanomodule_path = /datum/nano_module/deck_management
+	required_access = list(access_cargo, access_bridge)
 	program_icon_state = "request"
 	program_key_state = "rd_key"
 	program_menu_icon = "clock"
@@ -25,8 +26,6 @@
 	var/datum/computer_file/report/selected_report   //A report being viewed/edited.
 	var/list/report_prototypes = list()              //Stores report prototypes to use for UI purposes.
 	var/datum/shuttle/prototype_shuttle              //The shuttle for which the prototypes were built (to avoid excessive prototype rebuilding)
-	//The default access needed to properly use. Should be set in map files.
-	var/default_access = list(access_cargo, access_bridge)  //The format is (needs one of list(these access constants or lists of access constants))
 
 /datum/nano_module/deck_management/New()
 	..()
@@ -45,7 +44,6 @@
 	var/logs = SSshuttle.shuttle_logs
 
 	data["prog_state"] = prog_state
-	data["default_access"] = get_default_access(user)
 
 	switch(prog_state)
 		if(DECK_HOME)
@@ -171,11 +169,6 @@
 			mission_data["queued"] = 1
 	return mission_data
 
-/datum/nano_module/deck_management/proc/get_default_access(mob/user)
-	for(var/access_pattern in default_access)
-		if(check_access(user, access_pattern))
-			return 1
-
 /datum/nano_module/deck_management/proc/get_shuttle_access(mob/user, datum/shuttle/shuttle)
 	return shuttle.logging_access ? (check_access(user, shuttle.logging_access) || check_access(user, access_bridge)) : 0
 
@@ -211,8 +204,6 @@
 	if(..())
 		return 1
 
-	if(!get_default_access(user))
-		return 1 //No program access if you don't have the right access.
 	if(text2num(href_list["warning"])) //Gives the user a chance to avoid losing unsaved reports.
 		if(alert(user, "Are you sure you want to do this? Data may be lost.",, "Yes.", "No.") == "No.")
 			return 1 //If yes, proceed to the actual action instead.

--- a/code/modules/modular_computers/file_system/programs/generic/docks.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/docks.dm
@@ -1,7 +1,7 @@
 /datum/computer_file/program/docking
 	filename = "docking"
 	filedesc = "Docking Control"
-	required_access = access_bridge
+	required_access = list(access_bridge)
 	nanomodule_path = /datum/nano_module/program/docking
 	program_icon_state = "supply"
 	program_key_state = "rd_key"

--- a/code/modules/modular_computers/file_system/programs/generic/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntdownloader.dm
@@ -42,7 +42,7 @@
 	source.server = net.find_file_location(filename, MF_ROLE_SOFTWARE)
 	if(source.check_errors() || destination.check_errors())
 		return 0
-	current_transfer = new(source, destination, PRG)
+	current_transfer = new(source, destination, PRG, TRUE)
 
 	ui_header = "downloader_running.gif"
 	generate_network_log("Downloading file [filename] from [source.server].")
@@ -77,11 +77,11 @@
 		if(QDELETED(current_transfer)) //either completely
 			downloaderror = "I/O ERROR: Unknown error during the file transfer."
 		else  //or during the saving at the destination
-			downloaderror = "I/O ERROR: Unable to store '[current_transfer.copying.filename]' at [current_transfer.copying_to]"
+			downloaderror = "I/O ERROR: Unable to store '[current_transfer.transferring.filename]' at [current_transfer.transfer_to]"
 			qdel(current_transfer)
 		current_transfer = null
 		ui_header = "downloader_finished.gif"
-	else if(!current_transfer.left_to_copy)  //done
+	else if(!current_transfer.left_to_transfer)  //done
 		QDEL_NULL(current_transfer)
 		ui_header = "downloader_finished.gif"
 	if(!current_transfer && downloads_queue.len > 0)
@@ -94,7 +94,7 @@
 	if(href_list["PRG_downloadfile"])
 		if(!current_transfer)
 			begin_file_download(href_list["PRG_downloadfile"])
-		else if(check_file_download(href_list["PRG_downloadfile"]) && !downloads_queue.Find(href_list["PRG_downloadfile"]) && current_transfer.copying.filename != href_list["PRG_downloadfile"])
+		else if(check_file_download(href_list["PRG_downloadfile"]) && !downloads_queue.Find(href_list["PRG_downloadfile"]) && current_transfer.transferring.filename != href_list["PRG_downloadfile"])
 			downloads_queue |= href_list["PRG_downloadfile"]
 		return 1
 	if(href_list["PRG_removequeued"])
@@ -123,7 +123,7 @@
 	if(prog.current_transfer) // Download running. Wait please..
 		data |= prog.current_transfer.get_ui_data()
 		data["downloadspeed"] = prog.current_transfer.get_transfer_speed()
-		var/datum/computer_file/program/P = prog.current_transfer.copying
+		var/datum/computer_file/program/P = prog.current_transfer.transferring
 		if(istype(P))
 			data["transfer_desc"] = P.extended_desc
 

--- a/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
@@ -87,7 +87,7 @@
 				channel = null
 			return 1
 		var/mob/living/user = usr
-		if(can_run(usr, 1, access_network))
+		if(can_run(usr, 1, list(access_network)))
 			if(channel)
 				var/response = alert(user, "Really engage admin-mode? You will be disconnected from your current channel!", "NTNRC Admin mode", "Yes", "No")
 				if(response == "Yes")

--- a/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
+++ b/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
@@ -7,7 +7,7 @@
 	program_key_state = "med_key"
 	program_menu_icon = "heart"
 	extended_desc = "This program connects to life signs monitoring system to provide basic information on crew health."
-	required_access = access_medical
+	required_access = list(access_medical)
 	network_destination = "crew lifesigns monitoring system"
 	size = 11
 	category = PROG_MONITOR

--- a/code/modules/modular_computers/file_system/programs/research/ai_restorer.dm
+++ b/code/modules/modular_computers/file_system/programs/research/ai_restorer.dm
@@ -6,7 +6,7 @@
 	program_menu_icon = "person"
 	extended_desc = "This program is capable of reconstructing damaged AI systems. It can also be used to upload basic laws to the AI. Requires direct AI connection via inteliCard slot."
 	size = 12
-	required_access = access_bridge
+	required_access = list(access_bridge)
 	requires_access_to_run = 0
 	available_on_network = 1
 	nanomodule_path = /datum/nano_module/program/computer_aidiag/

--- a/code/modules/modular_computers/file_system/programs/research/email_administration.dm
+++ b/code/modules/modular_computers/file_system/programs/research/email_administration.dm
@@ -9,7 +9,7 @@
 	requires_network = 1
 	available_on_network = 1
 	nanomodule_path = /datum/nano_module/program/email_administration
-	required_access = access_network
+	required_access = list(access_network)
 	category = PROG_ADMIN
 
 /datum/nano_module/program/email_administration

--- a/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
+++ b/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
@@ -10,7 +10,7 @@ GLOBAL_LIST(all_warrants)
 	program_menu_icon = "star"
 	requires_network = 1
 	available_on_network = 1
-	required_access = access_security
+	required_access = list(access_security)
 	nanomodule_path = /datum/nano_module/program/digitalwarrant/
 	category = PROG_SEC
 

--- a/code/modules/modular_computers/file_system/programs/security/forceauthorization.dm
+++ b/code/modules/modular_computers/file_system/programs/security/forceauthorization.dm
@@ -8,7 +8,7 @@
 	program_menu_icon = "locked"
 	requires_network = 1
 	available_on_network = 1
-	required_access = access_armory
+	required_access = list(access_armory)
 	nanomodule_path = /datum/nano_module/program/forceauthorization/
 	category = PROG_SEC
 

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -32,10 +32,10 @@ GLOBAL_VAR_INIT(arrest_security_status, "Arrest")
 	for(var/weakref/grant in grants)
 		var/datum/computer_file/data/grant_record/GR = grant.resolve()
 		if(!GR)
-			grants -= GR
+			grants -= grant
 			continue
 		if(GR.stored_data == grant_name)
-			grants -= GR
+			grants -= grant
 			return
 
 /datum/computer_file/report/crew_record/proc/calculate_size()

--- a/code/modules/modular_computers/networking/device_types/acl.dm
+++ b/code/modules/modular_computers/networking/device_types/acl.dm
@@ -1,6 +1,15 @@
 /datum/extension/network_device/acl
 	connection_type = NETWORK_CONNECTION_WIRED
 	var/list/administrators = list()	// A list of numerical user IDs of users that are administrators on a network.
+	var/list/program_access = list()	// List of lists containing perimitted accesses for programs.
+
+/datum/extension/network_device/acl/New()
+	. = ..()
+	for(var/prog_type in subtypesof(/datum/computer_file/program))
+		var/datum/computer_file/program/prog = prog_type
+		if(!initial(prog.available_on_network))
+			continue
+		program_access[prog_type] = list()
 
 /datum/extension/network_device/acl/proc/add_admin(var/user_id)
 	administrators |= user_id
@@ -23,3 +32,12 @@
 	for(var/datum/computer_file/data/grant_record/GR in grant_files)
 		grants |= GR
 	return grants
+
+/datum/extension/network_device/acl/proc/get_program_access(var/program_type)
+	if(!program_access[program_type])
+		return list()
+	if(!length(program_access[program_type]))
+		return list("NONE")
+	. = list()
+	for(var/access in program_access[program_type])
+		. += uppertext("[network_id].[access]")

--- a/code/modules/modular_computers/networking/device_types/acl.dm
+++ b/code/modules/modular_computers/networking/device_types/acl.dm
@@ -41,3 +41,5 @@
 	. = list()
 	for(var/access in program_access[program_name])
 		. += uppertext("[network_id].[access]")
+	
+	return list(.)

--- a/code/modules/modular_computers/networking/device_types/acl.dm
+++ b/code/modules/modular_computers/networking/device_types/acl.dm
@@ -1,6 +1,8 @@
 /datum/extension/network_device/acl
 	connection_type = NETWORK_CONNECTION_WIRED
 	var/list/administrators = list()	// A list of numerical user IDs of users that are administrators on a network.
+
+	var/program_control = FALSE			// Whether the ACL controls program access or not.
 	var/list/program_access = list()	// List of lists containing perimitted accesses for programs.
 
 /datum/extension/network_device/acl/New()
@@ -34,10 +36,8 @@
 	return grants
 
 /datum/extension/network_device/acl/proc/get_program_access(var/program_name)
-	if(!program_access[program_name])
-		return list()
 	if(!length(program_access[program_name]))
-		return list("NONE")
+		return list()
 	. = list()
 	for(var/access in program_access[program_name])
 		. += uppertext("[network_id].[access]")

--- a/code/modules/modular_computers/networking/device_types/acl.dm
+++ b/code/modules/modular_computers/networking/device_types/acl.dm
@@ -9,7 +9,7 @@
 		var/datum/computer_file/program/prog = prog_type
 		if(!initial(prog.available_on_network))
 			continue
-		program_access[prog_type] = list()
+		program_access[initial(prog.filename)] = list()
 
 /datum/extension/network_device/acl/proc/add_admin(var/user_id)
 	administrators |= user_id
@@ -33,11 +33,11 @@
 		grants |= GR
 	return grants
 
-/datum/extension/network_device/acl/proc/get_program_access(var/program_type)
-	if(!program_access[program_type])
+/datum/extension/network_device/acl/proc/get_program_access(var/program_name)
+	if(!program_access[program_name])
 		return list()
-	if(!length(program_access[program_type]))
+	if(!length(program_access[program_name]))
 		return list("NONE")
 	. = list()
-	for(var/access in program_access[program_type])
+	for(var/access in program_access[program_name])
 		. += uppertext("[network_id].[access]")

--- a/code/modules/modular_computers/networking/machinery/acl.dm
+++ b/code/modules/modular_computers/networking/machinery/acl.dm
@@ -113,16 +113,13 @@
 
 	if(href_list["clear_program_access"])
 		if(editing_program)
-			computer.program_access[editing_program] = list("NONE")
+			computer.program_access[editing_program] = list()
 		else
 			error = "ERROR: Program not found."
 		return TOPIC_REFRESH
 
-	if(href_list["remove_program_control"])
-		if(editing_program)
-			computer.program_access[editing_program] = list()
-		else
-			error = "ERROR: Program not found."
+	if(href_list["toggle_program_control"])
+		computer.program_control = !computer.program_control
 		return TOPIC_REFRESH
 
 	if(href_list["create_grant"])
@@ -232,8 +229,7 @@
 		.["program_name"] = editing_program
 		var/list/program_access = computer.program_access[editing_program]
 		var/list/grants[0]
-		.["cleared_control"] = length(program_access) ? (program_access[1] == "NONE") : 0
-		.["disabled_control"] = !length(program_access)
+		.["cleared_control"] = !length(program_access)
 		for(var/datum/computer_file/data/grant_record/GR in computer.get_all_grants())
 			grants.Add(list(list(
 				"grant_name" = GR.stored_data,
@@ -252,6 +248,7 @@
 			)))
 		.["users"] = users
 		var/list/programs[0]
+		.["program_control"] = computer.program_control
 		for(var/prog_name in computer.program_access)
 			programs.Add(list(list(
 				"name" = prog_name,

--- a/code/modules/modular_computers/networking/machinery/acl.dm
+++ b/code/modules/modular_computers/networking/machinery/acl.dm
@@ -13,7 +13,7 @@
 	// Datum file source for where grants/records are.
 	var/datum/file_storage/network/file_source = /datum/file_storage/network/machine
 	var/editing_user	// Numerical user ID of the user being editing on this device.
-	var/datum/computer_file/program/editing_program // Current type of program being edited.
+	var/editing_program // Name of current program being edited.
 	var/list/initial_grants  //defaults to all possible station accesses if left null
 
 /obj/machinery/network/acl/merchant
@@ -146,7 +146,7 @@
 		return TOPIC_REFRESH
 
 	if(href_list["view_program"])
-		var/prog = text2path(href_list["view_program"])
+		var/prog = href_list["view_program"]
 		var/list/programs = computer.program_access
 		if(!(prog in programs))
 			error = "ERROR: Program not found."
@@ -229,7 +229,7 @@
 			)))
 		.["grants"] = grants
 	else if(editing_program) // Editing program access.
-		.["program_name"] = initial(editing_program.filedesc)
+		.["program_name"] = editing_program
 		var/list/program_access = computer.program_access[editing_program]
 		var/list/grants[0]
 		.["cleared_control"] = length(program_access) ? (program_access[1] == "NONE") : 0
@@ -252,11 +252,10 @@
 			)))
 		.["users"] = users
 		var/list/programs[0]
-		for(var/prog_type in computer.program_access)
-			var/datum/computer_file/program/prog = prog_type
+		for(var/prog_name in computer.program_access)
 			programs.Add(list(list(
-				"name" = initial(prog.filedesc),
-				"type" = prog_type
+				"name" = prog_name,
+				"grants" = length(computer.program_access[prog_name])
 			)))
 		.["programs"] = programs
 

--- a/code/modules/modular_computers/networking/machinery/mainframe.dm
+++ b/code/modules/modular_computers/networking/machinery/mainframe.dm
@@ -47,9 +47,3 @@
 		var/datum/extension/network_device/mainframe/M = get_extension(src, /datum/extension/network_device)
 		M.toggle_role(href_list["toggle_role"])
 		return TOPIC_REFRESH
-	
-/obj/machinery/network/mainframe/on_update_icon()
-	if(operable())
-		icon_state = "blackbox"
-	else
-		icon_state = "blackbox_off"

--- a/code/modules/modular_computers/ntos/ntos.dm
+++ b/code/modules/modular_computers/ntos/ntos.dm
@@ -113,7 +113,7 @@
 	if(P in running_programs)
 		P.program_state = PROGRAM_STATE_ACTIVE
 		active_program = P
-	else if(P.can_run(user, 1))
+	else if(P.can_run(user, 1, null, get_network()))
 		P.on_startup(user, src)
 		active_program = P
 

--- a/code/modules/modular_computers/ntos/ntos.dm
+++ b/code/modules/modular_computers/ntos/ntos.dm
@@ -116,7 +116,8 @@
 	else if(P.can_run(user, 1, null, get_network()))
 		P.on_startup(user, src)
 		active_program = P
-
+	else
+		return
 	running_programs |= P
 	update_host_icon()
 	return 1

--- a/maps/tradeship/tradeship_overrides.dm
+++ b/maps/tradeship/tradeship_overrides.dm
@@ -1,5 +1,5 @@
 /datum/computer_file/program/merchant/tradeship
-	required_access = null
+	required_access = list()
 
 /obj/machinery/computer/modular/preset/merchant/tradeship
 	default_software = list(

--- a/nano/templates/deck_management.tmpl
+++ b/nano/templates/deck_management.tmpl
@@ -1,11 +1,3 @@
-<div class='notice'>
-	You 
-	{{if !data.default_access}}
-		do not 
-	{{/if}}
-	have program access.
-</div>
-{{if data.default_access}}<!--Suppressed indentation.-->
 {{if data.prog_state == 1}}<!--DECK_HOME-->
 	<h2>Shuttles:</h2>
 	{{for data.shuttles}}
@@ -278,5 +270,4 @@
 			</div>
 		</div>
 	{{/if}}
-{{/if}}
 {{/if}}

--- a/nano/templates/file_manager.tmpl
+++ b/nano/templates/file_manager.tmpl
@@ -51,7 +51,7 @@
 					{{:helper.link('DELETE', null, { "PRG_deletefile" : value.name }, value.undeletable ? 'disabled' : null)}}
 					{{:helper.link('RENAME', null, { "PRG_rename" : value.name }, value.undeletable ? 'disabled' : null)}}
 					{{:helper.link('CLONE', null, { "PRG_clone" : value.name }, value.undeletable ? 'disabled' : null)}}
-					{{:helper.link('COPY TO', null, { "PRG_copyto" : value.name }, value.undeletable ? 'disabled' : null)}}
+					{{:helper.link('TRANSFER TO', null, { "PRG_transferto" : value.name }, value.unsendable ? 'disabled' : null)}}
 			{{/for}}
 		</table>
 		{{if data.usbconnected}}

--- a/nano/templates/network_acl.tmpl
+++ b/nano/templates/network_acl.tmpl
@@ -62,6 +62,25 @@
 				{{/for}}
 			</table>
 			{{:helper.link('Back to menu', null, { "back" : 1 })}}
+		{{else data.editing_program}}
+			<h2>Editing Program: {{:data.program_name}}</h2>
+			<hr>
+			<table>
+				{{:helper.link('REMOVE ACCESS REQUIREMENT', null, { "clear_program_access" : 1}, data.cleared_control ? 'selected' : null)}}
+				{{:helper.link('DISABLE ACCESS CONTROL', null, { "remove_program_control" : 1}, data.disabled_control ? 'selected' : null)}}
+				<tr><th>Grant
+				<th>Operations
+				{{for data.grants}}
+					<tr><td>{{:value.grant_name}}
+					<td>
+						{{if value.assigned}}
+							{{:helper.link('REMOVE', null, { "remove_grant" : value.grant_name })}}
+						{{else}}
+							{{:helper.link('ASSIGN', null, { "assign_grant" : value.grant_name })}}
+						{{/if}}
+				{{/for}}
+			</table>
+			{{:helper.link('Back to menu', null, { "back" : 1 })}}
 		{{else}}
 			<h2>Available Users ({{:data.file_server}}):</h2>
 			<table>
@@ -76,6 +95,17 @@
 					<td>
 						{{:helper.link('VIEW', null, { "view_user" : value.user_id })}}
 				{{/for}}
+			</table>
+			<hr>
+			<h2>Available Programs:</h2>
+			<table>
+				<tr><th>Program
+				<th>Access
+			{{for data.programs}}
+				<tr><td>{{:value.name}}
+				<td>
+					{{:helper.link('EDIT', null, { "view_program" : value.type})}}
+			{{/for}}
 			</table>
 		{{/if}}
 	{{/if}}

--- a/nano/templates/network_acl.tmpl
+++ b/nano/templates/network_acl.tmpl
@@ -100,11 +100,13 @@
 			<h2>Available Programs:</h2>
 			<table>
 				<tr><th>Program
+				<th>Grants
 				<th>Access
 			{{for data.programs}}
 				<tr><td>{{:value.name}}
+				<td>{{:value.grants}}
 				<td>
-					{{:helper.link('EDIT', null, { "view_program" : value.type})}}
+					{{:helper.link('EDIT', null, { "view_program" : value.name})}}
 			{{/for}}
 			</table>
 		{{/if}}

--- a/nano/templates/network_acl.tmpl
+++ b/nano/templates/network_acl.tmpl
@@ -67,7 +67,6 @@
 			<hr>
 			<table>
 				{{:helper.link('REMOVE ACCESS REQUIREMENT', null, { "clear_program_access" : 1}, data.cleared_control ? 'selected' : null)}}
-				{{:helper.link('DISABLE ACCESS CONTROL', null, { "remove_program_control" : 1}, data.disabled_control ? 'selected' : null)}}
 				<tr><th>Grant
 				<th>Operations
 				{{for data.grants}}
@@ -98,17 +97,22 @@
 			</table>
 			<hr>
 			<h2>Available Programs:</h2>
-			<table>
-				<tr><th>Program
-				<th>Grants
-				<th>Access
-			{{for data.programs}}
-				<tr><td>{{:value.name}}
-				<td>{{:value.grants}}
-				<td>
-					{{:helper.link('EDIT', null, { "view_program" : value.name})}}
-			{{/for}}
-			</table>
+			{{if data.program_control}}
+				{{:helper.link('DISABLE PROGRAM ACCESS CONTROL', null, { "toggle_program_control" : 1})}}
+				<table>
+					<tr><th>Program
+					<th>Grants
+					<th>Access
+				{{for data.programs}}
+					<tr><td>{{:value.name}}
+					<td>{{:value.grants}}
+					<td>
+						{{:helper.link('EDIT', null, { "view_program" : value.name})}}
+				{{/for}}
+				</table>
+			{{else}}
+				{{:helper.link('ENABLE PROGRAM ACCESS CONTROL', null, { "toggle_program_control" : 1})}}
+			{{/if}}
 		{{/if}}
 	{{/if}}
 {{/if}}


### PR DESCRIPTION
Fixes a few bugs with networks and their related machinery, and adds an option for grant based program access
* Fixes mainframes going invisible after opening their panel once
* Fixes Network Locks not having their UI properly updated.
* Changes how the transfer files backend works. Now it by default transfers the file with an option for cloning the file instead. Beforehand it used store_file to add the datum to the file list of whatever was being copied to, without removing itself from the former location, which resulted in every program downloaded from a mainframe being one instance. This lead to issues like #1037, which is now fixed.
* Fixes a bug where running a program without proper access would break the computer until it was restarted.
* Added an option for program access to be determined by grants through the access controller. If/when full replacement of the access system with grants occurs, this should probably be reworked., but it works for now. 