### PR TITLE
Makes lighting bi-directional

### DIFF
--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -212,6 +212,19 @@
 
 #define LUM_FALLOFF(C, T)(CLAMP01(-((((C.x - T.x) ** 2 +(C.y - T.y) ** 2) ** 0.5 - light_outer_range) / max(light_outer_range - light_inner_range, 1))) ** light_falloff_curve)
 
+#define STEP_LUM(T)\
+	if(!T.lighting_corners_initialised)						\
+		{ T.generate_missing_corners(); }					\
+															\
+	for(var/datum/lighting_corner/C in T.get_corners())		\
+		{ if(C.update_gen == update_gen) { continue; }		\
+		C.update_gen = update_gen;							\
+		C.affecting += src;									\
+		if(!C.active) {effect_str[C] = 0; continue; }		\
+		APPLY_CORNER(C)										\
+		LAZYADD(T.affecting_lights, src)					\
+		affecting_turfs += T;}
+
 
 /datum/light_source/proc/apply_lum()
 	var/static/update_gen = 1
@@ -223,29 +236,21 @@
 	applied_lum_b = lum_b
 
 	FOR_DVIEW(var/turf/T, light_outer_range, source_turf, INVISIBILITY_LIGHTING)
-		check_t:
-		if(!T.lighting_corners_initialised)
-			T.generate_missing_corners()
+		STEP_LUM(T)
 
-		for(var/datum/lighting_corner/C in T.get_corners())
-			if(C.update_gen == update_gen)
-				continue
-
-			C.update_gen = update_gen
-			C.affecting += src
-
-			if(!C.active)
-				effect_str[C] = 0
-				continue
-
-			APPLY_CORNER(C)
-
-		LAZYADD(T.affecting_lights, src)
-		affecting_turfs += T
-
-		if (T.z_flags & ZM_ALLOW_LIGHTING)
-			T = T.below
-			goto check_t
+		// If this turf allows lighting to pass through, crawl
+		// downwards adding the light to the tile below.
+		var/turf/z_turf = T
+		while(z_turf?.z_flags & ZM_ALLOW_LIGHTING)
+			STEP_LUM(z_turf.below)
+			z_turf = z_turf.below
+		
+		// Similar to previous, but if the tile allows light
+		// to pass through, add light to US.
+		z_turf = T.above
+		while(z_turf?.z_flags & ZM_ALLOW_LIGHTING)
+			STEP_LUM(z_turf)
+			z_turf = z_turf.above
 
 	END_FOR_DVIEW
 

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -37,7 +37,7 @@ exactly 137 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 19 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
-exactly 1 "goto uses" 'goto '
+exactly 0 "goto uses" 'goto '
 exactly 6 "atom/New uses" '^/(obj|atom|area|mob|turf).*/New\('
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong


### PR DESCRIPTION
Accidentally deleted branch, recreated
Makes lights bi-directional, removing last goto in process.
Uses an ugly macro due to this being very hot code.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->