### PR TITLE
Makes airlocks waitfor TRUE on closing again.

### DIFF
--- a/code/game/machinery/doors/_door.dm
+++ b/code/game/machinery/doors/_door.dm
@@ -402,7 +402,6 @@
 	return world.time + (normalspeed ? 150 : 5)
 
 /obj/machinery/door/proc/close(var/forced = 0)
-	set waitfor = FALSE
 	if(!can_close(forced))
 		return
 	operating = 1

--- a/code/game/machinery/doors/_door.dm
+++ b/code/game/machinery/doors/_door.dm
@@ -110,7 +110,7 @@
 	if(close_door_at && world.time >= close_door_at)
 		if(autoclose)
 			close_door_at = next_close_time()
-			close()
+			INVOKE_ASYNC(src, /obj/machinery/door/proc/close)
 		else
 			close_door_at = 0
 


### PR DESCRIPTION
Making the `close` proc async breaks stuff which is supposed to wait for it to complete (e.g. airlock controllers, which send sequential sets of instructions for the door to execute). Making it async when specifically called from `Process`, on the other hand, is fine.