### PR TITLE
Allows underpants to be offset per-species.

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -56,6 +56,11 @@
 #define slot_s_store_str     "slot_s_store"
 #define slot_in_backpack_str "slot_s_store"
 
+// Defined here for consistency, not actually used for slots, just for species clothing offsets.
+#define slot_undershirt_str  "slot_undershirt"
+#define slot_underpants_str  "slot_underpants"
+#define slot_socks_str       "slot_socks"
+
 // Bodypart coverage bitflags.
 #define SLOT_UPPER_BODY  BITFLAG(0)
 #define SLOT_LOWER_BODY  BITFLAG(1)

--- a/code/modules/clothing/underwear/base.dm
+++ b/code/modules/clothing/underwear/base.dm
@@ -2,6 +2,7 @@
 	w_class = ITEM_SIZE_TINY
 	var/required_slot_flags
 	var/required_free_body_parts
+	var/slot_offset_str
 
 /obj/item/underwear/afterattack(var/atom/target, var/mob/user, var/proximity)
 	if(!proximity)
@@ -109,12 +110,16 @@
 
 /obj/item/underwear/socks
 	required_free_body_parts = SLOT_FEET
+	slot_offset_str = slot_socks_str
 
 /obj/item/underwear/top
 	required_free_body_parts = SLOT_UPPER_BODY
+	slot_offset_str = slot_undershirt_str
 
 /obj/item/underwear/bottom
 	required_free_body_parts = SLOT_FEET|SLOT_LEGS|SLOT_LOWER_BODY
+	slot_offset_str = slot_underpants_str
 
 /obj/item/underwear/undershirt
 	required_free_body_parts = SLOT_UPPER_BODY
+	slot_offset_str = slot_undershirt_str

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -387,11 +387,13 @@ var/global/list/damage_icon_parts = list()
 		var/obj/item/underwear/UW = entry
 		if (!UW || !UW.icon) // Avoid runtimes for nude underwear types
 			continue
-
-		var/image/I = image(icon = UW.icon, icon_state = UW.icon_state)
-		I.appearance_flags = RESET_COLOR
-		I.color = UW.color
-
+		var/image/I
+		if(UW.slot_offset_str && LAZYACCESS(species.equip_adjust, UW.slot_offset_str))
+			I = species.get_offset_overlay_image(FALSE, UW.icon, UW.icon_state, UW.color, UW.slot_offset_str)
+		else
+			I = image(icon = UW.icon, icon_state = UW.icon_state)
+			I.color = UW.color
+		I.appearance_flags |= RESET_COLOR
 		overlays_standing[HO_UNDERWEAR_LAYER] += I
 
 	if(update_icons)


### PR DESCRIPTION
Working on some smaller-than-human mobs and undies keep appearing halfway up their body/undershirts appear over their heads. This allows it to be specified like other equipment offsets.