### PR TITLE
Fixed html usage in floating chat

### DIFF
--- a/code/modules/mob/floating_message.dm
+++ b/code/modules/mob/floating_message.dm
@@ -7,6 +7,13 @@ var/list/floating_chat_colors = list()
 /atom/movable/proc/animate_chat(message, decl/language/language, small, list/show_to, duration)
 	set waitfor = FALSE
 
+	// Get rid of any URL schemes that might cause BYOND to automatically wrap something in an anchor tag
+	var/static/regex/url_scheme = new(@"[A-Za-z][A-Za-z0-9+-\.]*:\/\/", "g")
+	message = replacetext(message, url_scheme, "")
+
+	var/static/regex/html_metachars = new(@"&[A-Za-z]{1,7};", "g")
+	message = replacetext(message, html_metachars, "")
+
 	var/style	//additional style params for the message
 	var/fontsize = 6
 	if(small)


### PR DESCRIPTION
I used tgstation's method with regex because sanitize and sanitizeSafe doesn't work here.