### PR TITLE
Rearranges planetary atmos generation

### DIFF
--- a/code/modules/overmap/exoplanets/exoplanet_atmosphere.dm
+++ b/code/modules/overmap/exoplanets/exoplanet_atmosphere.dm
@@ -1,50 +1,94 @@
-
-
 /obj/effect/overmap/visitable/sector/exoplanet/proc/generate_atmosphere()
 	atmosphere = new
+	var/target_temp = get_target_temperature()
+
+	//Make sure temperature can't damage people on casual planets
+	if(habitability_class <= HABITABILITY_OKAY)
+		var/decl/species/S = get_species_by_key(GLOB.using_map.default_species)
+		target_temp = Clamp(target_temp, S.cold_level_1 + rand(1,5), S.heat_level_1 - rand(1,5))
+
+	atmosphere.temperature = target_temp
+
+	//Skip fun gas gen for perfect terran worlds
 	if(habitability_class == HABITABILITY_IDEAL)
-		atmosphere.adjust_gas(/decl/material/gas/oxygen, MOLES_O2STANDARD, 0)
+		atmosphere.adjust_gas(/decl/material/gas/oxygen, MOLES_O2STANDARD)
 		atmosphere.adjust_gas(/decl/material/gas/nitrogen, MOLES_N2STANDARD)
-	else //let the fuckery commence
-		var/list/newgases = subtypesof(/decl/material/gas)
-		newgases = newgases.Copy() // So we don't mutate the global list.
-		if(prob(50)) //alium gas should be slightly less common than mundane shit
-			newgases -= /decl/material/gas/alien
-		newgases -= /decl/material/liquid/water
+		return
+	
+	var/total_moles = MOLES_CELLSTANDARD
+	
+	//Add the non-negotiable gasses
+	var/badflag = 0
+	var/gas_list = get_mandatory_gasses()
+	for(var/g in gas_list)
+		total_moles = max(0, total_moles - gas_list[g])
+		var/decl/material/mat = decls_repository.get_decl(g)
+		if(mat.gas_flags & XGM_GAS_OXIDIZER)
+			badflag |= XGM_GAS_FUEL
+		if(mat.gas_flags & XGM_GAS_FUEL)
+			badflag |= XGM_GAS_OXIDIZER
 
-		var/total_moles = MOLES_CELLSTANDARD * rand(80,120)/100
-		var/badflag = 0
+	//Breathable planet
+	if(habitability_class == HABITABILITY_OKAY)
+		badflag |= XGM_GAS_CONTAMINANT
 
-		//Breathable planet
-		if(habitability_class == HABITABILITY_OKAY)
-			atmosphere.gas[/decl/material/gas/oxygen] += MOLES_O2STANDARD
-			total_moles -= MOLES_O2STANDARD
-			badflag = XGM_GAS_FUEL|XGM_GAS_CONTAMINANT
+	var/list/newgases = subtypesof(/decl/material/gas)
+	if(prob(50)) //alium gas should be slightly less common than mundane shit
+		newgases -= /decl/material/gas/alien
 
-		var/gasnum = rand(1,4)
-		var/i = 1
-		var/sanity = prob(99.9)
-		while(i <= gasnum && total_moles && newgases.len)
-			if(badflag && sanity)
-				for(var/g in newgases)
-					var/decl/material/mat = decls_repository.get_decl(g)
-					if(mat.gas_flags & badflag)
-						newgases -= g
-			var/ng = pick_n_take(newgases)	//pick a gas
-			var/decl/material/mat = decls_repository.get_decl(ng)
-			if(sanity) //make sure atmosphere is not flammable... always
-				if(mat.gas_flags & XGM_GAS_OXIDIZER)
-					badflag |= XGM_GAS_FUEL
-				if(mat.gas_flags & XGM_GAS_FUEL)
-					badflag |= XGM_GAS_OXIDIZER
-				sanity = 0
+	// Prune gases that won't stay gaseous
+	for(var/g in newgases)
+		var/decl/material/mat = decls_repository.get_decl(g)
+		if(mat.gas_flags & badflag)
+			newgases -= g
+		if(mat.gas_condensation_point && mat.gas_condensation_point <= atmosphere.temperature)
+			newgases -= g
+		if(mat.boiling_point && mat.boiling_point >= atmosphere.temperature)
+			newgases -= g
 
-			var/part = total_moles * rand(3,80)/100 //allocate percentage to it
-			if(i == gasnum || !newgases.len) //if it's last gas, let it have all remaining moles
-				part = total_moles
-			atmosphere.gas[ng] += part
-			total_moles = max(total_moles - part, 0)
-			i++
+	var/gasnum = rand(1,4)
+	var/i = 1
+	while(i <= gasnum && total_moles && newgases.len)
+		if(badflag)
+			for(var/g in newgases)
+				var/decl/material/mat = decls_repository.get_decl(g)
+				if(mat.gas_flags & badflag)
+					newgases -= g
+		var/ng = pick_n_take(newgases)	//pick a gas
+
+		// Make sure atmosphere is not flammable
+		var/decl/material/mat = decls_repository.get_decl(ng)
+		if(mat.gas_flags & XGM_GAS_OXIDIZER)
+			badflag |= XGM_GAS_FUEL
+		if(mat.gas_flags & XGM_GAS_FUEL)
+			badflag |= XGM_GAS_OXIDIZER
+
+		var/part = total_moles * rand(20,80)/100 //allocate percentage to it
+		if(i == gasnum || !newgases.len) //if it's last gas, let it have all remaining moles
+			part = total_moles
+		gas_list[ng] += part
+		total_moles = max(total_moles - part, 0)
+		i++
+
+	// Add all gasses, adjusted for target temperature and pressure
+	var/target_pressure = get_target_pressure()
+	var/target_moles = target_pressure * CELL_VOLUME / (atmosphere.temperature * R_IDEAL_GAS_EQUATION)
+	for(var/g in gas_list)
+		var/adjusted_moles = gas_list[g] * target_moles / MOLES_CELLSTANDARD
+		atmosphere.adjust_gas(g, adjusted_moles, 0)
+	atmosphere.update_values()
+
+//List of gases that will be always present. Amounts are given assuming total of MOLES_CELLSTANDARD in atmosphere
+/obj/effect/overmap/visitable/sector/exoplanet/proc/get_mandatory_gasses()
+	if(habitability_class == HABITABILITY_OKAY)
+		return list(/decl/material/gas/oxygen = MOLES_O2STANDARD)
+	return list()
+
+/obj/effect/overmap/visitable/sector/exoplanet/proc/get_target_temperature()
+	return T20C + rand(-5,5)
+
+/obj/effect/overmap/visitable/sector/exoplanet/proc/get_target_pressure()
+	return ONE_ATMOSPHERE * rand(8, 12)/10
 
 /obj/effect/overmap/visitable/sector/exoplanet/proc/generate_habitability()
 	var/roll = rand(1,100)

--- a/code/modules/overmap/exoplanets/exoplanet_flora.dm
+++ b/code/modules/overmap/exoplanets/exoplanet_flora.dm
@@ -44,7 +44,7 @@
 	S.set_trait(TRAIT_HIGHKPA_TOLERANCE,   atmosphere.return_pressure() + rand(5,50),500,110)
 	if(S.exude_gasses)
 		S.exude_gasses -= badgas
-	if(atmosphere)
+	if(atmosphere && length(atmosphere.gas))
 		if(S.consume_gasses)
 			S.consume_gasses = list(pick(atmosphere.gas)) // ensure that if the plant consumes a gas, the atmosphere will have it
 		for(var/g in atmosphere.gas)

--- a/code/modules/overmap/exoplanets/planet_types/barren.dm
+++ b/code/modules/overmap/exoplanets/planet_types/barren.dm
@@ -16,13 +16,12 @@
 	if(prob(10))
 		flora_diversity = 1
 	..()
-	
+
+/obj/effect/overmap/visitable/sector/exoplanet/barren/get_target_pressure()
+	return ONE_ATMOSPHERE * 0.05
+
 /obj/effect/overmap/visitable/sector/exoplanet/barren/generate_habitability()
 	habitability_class =  HABITABILITY_BAD
-
-/obj/effect/overmap/visitable/sector/exoplanet/barren/generate_atmosphere()
-	..()
-	atmosphere.remove_ratio(0.9)
 
 /datum/random_map/noise/exoplanet/barren
 	descriptor = "barren exoplanet"

--- a/code/modules/overmap/exoplanets/planet_types/chlorine.dm
+++ b/code/modules/overmap/exoplanets/planet_types/chlorine.dm
@@ -27,12 +27,11 @@
 		lightlevel = 0.1
 	..()
 
-/obj/effect/overmap/visitable/sector/exoplanet/chlorine/generate_atmosphere()
-	..()
-	if(atmosphere)
-		atmosphere.adjust_gas(/decl/material/gas/chlorine, MOLES_O2STANDARD)
-		atmosphere.temperature = T100C - rand(0, 100)
-		atmosphere.update_values()
+/obj/effect/overmap/visitable/sector/exoplanet/chlorine/get_target_temperature()
+	return T0C - rand(0, 100)
+
+/obj/effect/overmap/visitable/sector/exoplanet/chlorine/get_mandatory_gasses()
+	return list(/decl/material/gas/chlorine = MOLES_O2STANDARD)
 
 /datum/random_map/noise/exoplanet/chlorine
 	descriptor = "chlorine exoplanet"

--- a/code/modules/overmap/exoplanets/planet_types/desert.dm
+++ b/code/modules/overmap/exoplanets/planet_types/desert.dm
@@ -18,15 +18,8 @@
 		lightlevel = rand(5,10)/10	//deserts are usually :lit:
 	..()
 
-/obj/effect/overmap/visitable/sector/exoplanet/desert/generate_atmosphere()
-	..()
-	if(atmosphere)
-		var/limit = 1000
-		if(habitability_class <= HABITABILITY_OKAY)
-			var/decl/species/human/H = /decl/species/human
-			limit = initial(H.heat_level_1) - rand(1,10)
-		atmosphere.temperature = min(T20C + rand(20, 100), limit)
-		atmosphere.update_values()
+/obj/effect/overmap/visitable/sector/exoplanet/desert/get_target_temperature()
+	return T20C + rand(20, 100)
 
 /obj/effect/overmap/visitable/sector/exoplanet/desert/adapt_seed(var/datum/seed/S)
 	..()

--- a/code/modules/overmap/exoplanets/planet_types/grass.dm
+++ b/code/modules/overmap/exoplanets/planet_types/grass.dm
@@ -15,11 +15,8 @@
 		lightlevel = rand(1,7)/10	//give a chance of twilight jungle
 	..()
 
-/obj/effect/overmap/visitable/sector/exoplanet/grass/generate_atmosphere()
-	..()
-	if(atmosphere)
-		atmosphere.temperature = T20C + rand(10, 30)
-		atmosphere.update_values()
+/obj/effect/overmap/visitable/sector/exoplanet/grass/get_target_temperature()
+	return T20C + rand(10, 30)
 
 /obj/effect/overmap/visitable/sector/exoplanet/grass/get_surface_color()
 	return grass_color

--- a/code/modules/overmap/exoplanets/planet_types/shrouded.dm
+++ b/code/modules/overmap/exoplanets/planet_types/shrouded.dm
@@ -16,11 +16,8 @@
 					   /mob/living/simple_animal/hostile/retaliate/beast/shantak/alt,
 					   /mob/living/simple_animal/hostile/leech)
 
-/obj/effect/overmap/visitable/sector/exoplanet/shrouded/generate_atmosphere()
-	..()
-	if(atmosphere)
-		atmosphere.temperature = T20C - rand(10, 20)
-		atmosphere.update_values()
+/obj/effect/overmap/visitable/sector/exoplanet/shrouded/get_target_temperature()
+	return T20C - rand(10, 20)
 
 /obj/effect/overmap/visitable/sector/exoplanet/shrouded/get_atmosphere_color()
 	return COLOR_BLACK

--- a/code/modules/overmap/exoplanets/planet_types/snow.dm
+++ b/code/modules/overmap/exoplanets/planet_types/snow.dm
@@ -15,22 +15,15 @@
 	fauna_types = list(/mob/living/simple_animal/hostile/retaliate/beast/samak, /mob/living/simple_animal/hostile/retaliate/beast/diyaab, /mob/living/simple_animal/hostile/retaliate/beast/shantak)
 	megafauna_types = list(/mob/living/simple_animal/hostile/retaliate/giant_crab)
 
+/obj/effect/overmap/visitable/sector/exoplanet/snow/get_target_temperature()
+	return T0C - rand(10, 100)
+
 /datum/random_map/automata/cave_system/mountains/snow
 	iterations = 2
 	descriptor = "ice mountains"
 	wall_type =  /turf/simulated/wall/natural/ice
 	mineral_turf = /turf/simulated/wall/natural/random/ice
 	rock_color = COLOR_CYAN_BLUE
-
-/obj/effect/overmap/visitable/sector/exoplanet/snow/generate_atmosphere()
-	..()
-	if(atmosphere)
-		var/limit = 0
-		if(habitability_class <= HABITABILITY_OKAY)
-			var/decl/species/human/H = /decl/species/human
-			limit = initial(H.cold_level_1) + rand(1,10)
-		atmosphere.temperature = max(T0C - rand(10, 100), limit)
-		atmosphere.update_values()
 
 /datum/random_map/noise/exoplanet/snow
 	descriptor = "snow exoplanet"

--- a/code/modules/overmap/exoplanets/planet_types/volcanic.dm
+++ b/code/modules/overmap/exoplanets/planet_types/volcanic.dm
@@ -29,11 +29,8 @@
 /obj/effect/overmap/visitable/sector/exoplanet/volcanic/generate_habitability()
 	habitability_class =  HABITABILITY_BAD
 
-/obj/effect/overmap/visitable/sector/exoplanet/volcanic/generate_atmosphere()
-	..()
-	if(atmosphere)
-		atmosphere.temperature = T20C + rand(220, 800)
-		atmosphere.update_values()
+/obj/effect/overmap/visitable/sector/exoplanet/volcanic/get_target_temperature()
+	return T20C + rand(220, 800)
 
 /obj/effect/overmap/visitable/sector/exoplanet/volcanic/adapt_seed(var/datum/seed/S)
 	..()


### PR DESCRIPTION
Now we always know temperature /before/ we pick gasses.
Makes sure that nothing's going to condense etc.
Moves some things into overridable procs - temperature generation, list of mandatory gases, desired pressure.
Another unrelated change - chlorine planets are now cold rather than boiling hot. Was weird how chlorine puddles were a thing waaay above boiling point.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->