### PR TITLE
Adjusts some colors on exoplanets

### DIFF
--- a/code/game/turfs/exterior/exterior_concrete.dm
+++ b/code/game/turfs/exterior/exterior_concrete.dm
@@ -45,4 +45,4 @@ var/exterior_broken_states = icon_states('icons/turf/exterior/broken.dmi')
 
 /turf/exterior/concrete/reinforced/road
 	name = "asphalt"
-	color = COLOR_GRAY20
+	color = COLOR_GRAY40

--- a/code/modules/overmap/exoplanets/planet_types/desert.dm
+++ b/code/modules/overmap/exoplanets/planet_types/desert.dm
@@ -4,7 +4,7 @@
 	color = "#a08444"
 	planetary_area = /area/exoplanet/desert
 	rock_colors = list(COLOR_BEIGE, COLOR_PALE_YELLOW, COLOR_GRAY80, COLOR_BROWN)
-	plant_colors = list("#efdd6f","#7b4a12","#e49135","#ba6222","#5c755e","#420d22")
+	plant_colors = list("#efdd6f","#7b4a12","#e49135","#ba6222","#5c755e","#701732")
 	map_generators = list(/datum/random_map/noise/exoplanet/desert, /datum/random_map/noise/ore/rich)
 	surface_color = "#d6cca4"
 	water_color = null

--- a/code/modules/overmap/exoplanets/planet_types/grass.dm
+++ b/code/modules/overmap/exoplanets/planet_types/grass.dm
@@ -4,7 +4,7 @@
 	color = "#407c40"
 	planetary_area = /area/exoplanet/grass
 	rock_colors = list(COLOR_ASTEROID_ROCK, COLOR_GRAY80, COLOR_BROWN)
-	plant_colors = list("#0e1e14","#1a3e38","#5a7467","#9eab88","#6e7248", "RANDOM")
+	plant_colors = list("#215a00","#195a47","#5a7467","#9eab88","#6e7248", "RANDOM")
 	map_generators = list(/datum/random_map/noise/exoplanet/grass)
 	flora_diversity = 6
 	fauna_types = list(/mob/living/simple_animal/yithian, /mob/living/simple_animal/tindalos, /mob/living/simple_animal/hostile/retaliate/jelly)

--- a/code/modules/overmap/exoplanets/planet_types/volcanic.dm
+++ b/code/modules/overmap/exoplanets/planet_types/volcanic.dm
@@ -4,7 +4,7 @@
 	color = "#9c2020"
 	planetary_area = /area/exoplanet/volcanic
 	rock_colors = list(COLOR_DARK_GRAY)
-	plant_colors = list("#a23c05","#3f1f0d","#662929","#ba6222","#7a5b3a","#120309")
+	plant_colors = list("#a23c05","#3f1f0d","#662929","#ba6222","#7a5b3a","#471429")
 	max_themes = 1
 	possible_themes = list(
 		/datum/exoplanet_theme = 100,


### PR DESCRIPTION
Roads are made less dark (were nearly pitch black with new sprites)
Some desert and volcanic plant colors were made bit brighter cause thye resulted in black blobs of plants.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->