### PR TITLE
Makes area ambience use ambience channel

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -277,7 +277,7 @@ var/list/mob/living/forced_ambiance_list = new
 		forced_ambiance_list += L
 		L.playsound_local(T,sound(pick(forced_ambience), repeat = 1, wait = 0, volume = 25, channel = GLOB.lobby_sound_channel))
 	if(ambience.len && prob(5) && (world.time >= L.client.played + 3 MINUTES))
-		L.playsound_local(T, sound(pick(ambience), repeat = 0, wait = 0, volume = 15, channel = GLOB.lobby_sound_channel))
+		L.playsound_local(T, sound(pick(ambience), repeat = 0, wait = 0, volume = 15, channel = GLOB.ambience_sound_channel))
 		L.client.played = world.time
 
 /area/proc/clear_ambience(var/mob/living/L)

--- a/code/modules/overmap/exoplanets/planet_types/grass.dm
+++ b/code/modules/overmap/exoplanets/planet_types/grass.dm
@@ -51,12 +51,7 @@
 /area/exoplanet/grass
 	base_turf = /turf/exterior/wildgrass
 	ambience = list('sound/effects/wind/wind_2_1.ogg','sound/effects/wind/wind_2_2.ogg','sound/effects/wind/wind_3_1.ogg','sound/effects/wind/wind_4_1.ogg','sound/ambience/eeriejungle2.ogg','sound/ambience/eeriejungle1.ogg')
-
-/area/exoplanet/grass/play_ambience(var/mob/living/L)
-	..()
-	if(!L.ear_deaf && L.client && !L.client.ambience_playing)
-		L.client.ambience_playing = 1
-		L.playsound_local(get_turf(L),sound('sound/ambience/jungle.ogg', repeat = 1, wait = 0, volume = 25, channel = GLOB.ambience_sound_channel))
+	forced_ambience = list('sound/ambience/jungle.ogg')
 
 /datum/random_map/noise/exoplanet/grass
 	descriptor = "grass exoplanet"


### PR DESCRIPTION
Also now that force ambience and ambience are on different channels, moves jungle planet's ambience loop to force ambience instead of a weird hack.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->