### PR TITLE
Adds water smoothing and coastal turfs to exoplanets

### DIFF
--- a/code/modules/overmap/exoplanets/planet_types/grass.dm
+++ b/code/modules/overmap/exoplanets/planet_types/grass.dm
@@ -60,9 +60,10 @@
 
 /datum/random_map/noise/exoplanet/grass
 	descriptor = "grass exoplanet"
-	smoothing_iterations = 2
 	land_type = /turf/exterior/wildgrass
 	water_type = /turf/exterior/water
+	coast_type = /turf/exterior/mud/dark
+	water_level_min = 3
 
 	flora_prob = 10
 	large_flora_prob = 30

--- a/code/modules/overmap/exoplanets/random_map.dm
+++ b/code/modules/overmap/exoplanets/random_map.dm
@@ -1,3 +1,4 @@
+#define  COAST_VALUE  cell_range + 1
 /datum/random_map/noise/exoplanet
 	descriptor = "exoplanet"
 	smoothing_iterations = 1
@@ -7,6 +8,7 @@
 	var/water_level_max = 5
 	var/land_type = /turf/simulated/floor
 	var/water_type
+	var/coast_type
 
 	//intended x*y size, used to adjust spawn probs
 	var/intended_x = 150
@@ -42,6 +44,8 @@
 	if(water_type && noise2value(value) < water_level)
 		return water_type
 	else
+		if(coast_type && value == COAST_VALUE)
+			return coast_type
 		return land_type
 
 /datum/random_map/noise/exoplanet/get_additional_spawns(var/value, var/turf/T)
@@ -97,3 +101,46 @@
 	if(locate(/obj/effect/floor_decal) in T)
 		return
 	new /obj/effect/floor_decal(T, null, null, get_grass_overlay())
+
+/datum/random_map/noise/exoplanet/cleanup()
+	..()
+	if(!water_type && !water_level)
+		return
+	for(var/x in 1 to limit_x - 1)
+		for(var/y in 1 to limit_y - 1)
+			if(noise2value(map[get_map_cell(x,y)]) < water_level)
+				smooth_water(x, y)
+			else
+				smooth_islands(x, y)
+
+//Remove one-tile puddles and place coastal turfs if set
+/datum/random_map/noise/exoplanet/proc/smooth_water(x, y)
+	var/list/coast = list()
+	var/list/water = list()
+	var/mapcell = get_map_cell(x,y)
+	for(var/dx in list(-1,0,1))
+		for(var/dy in list(-1,0,1))
+			var/tmp_cell = get_map_cell(x+dx,y+dy)
+			if(tmp_cell && tmp_cell != mapcell)
+				if(noise2value(map[tmp_cell]) < water_level)
+					water |= tmp_cell
+				else
+					coast |= tmp_cell
+	if(!length(water))
+		map[mapcell] = cell_range
+	else if (coast_type)
+		for(var/cell in coast)
+			map[cell] = COAST_VALUE
+
+//Remove one-tile 'islands' in water bodies
+/datum/random_map/noise/exoplanet/proc/smooth_islands(x, y)
+	var/list/buddies = list()
+	var/mapcell = get_map_cell(x,y)
+	for(var/dx in list(-1,0,1))
+		for(var/dy in list(-1,0,1))
+			var/tmp_cell = get_map_cell(x+dx,y+dy)
+			if(tmp_cell && tmp_cell != mapcell)
+				if(noise2value(map[tmp_cell]) >= water_level)
+					buddies |= tmp_cell
+	if(!length(buddies))
+		map[mapcell] = 0


### PR DESCRIPTION
Adds a second pass on generated maps to eliminate 1 tile water puddles and 1 tile islands inside water.
You can also set type of turf to be placed around bodies of water, currently used by grass planets.
![image](https://user-images.githubusercontent.com/1300258/104729793-02bbf180-574a-11eb-82ab-8a364156f242.png)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->