### PR TITLE
Fixes grass not appearing on exoplanets and tweaks its density

### DIFF
--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/turf/exterior/barren.dmi'
 	footstep_type = /decl/footsteps/asteroid
 	icon_state = "0"
+	layer = PLATING_LAYER
 	var/diggable = 1
 	var/dirt_color = "#7c5e42"
 	var/possible_states = 0

--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -24,7 +24,7 @@ var/list/floor_decals = list()
 
 	if(supplied_dir) set_dir(supplied_dir)
 	var/turf/T = get_turf(src)
-	if(istype(T, /turf/simulated/floor) || istype(T, /turf/unsimulated/floor))
+	if(istype(T))
 		layer = T.is_plating() ? DECAL_PLATING_LAYER : DECAL_LAYER
 		var/cache_key = "[alpha]-[color]-[dir]-[icon_state]-[plane]-[layer]-[detail_overlay]-[detail_color]"
 		if(!floor_decals[cache_key])

--- a/code/modules/overmap/exoplanets/planet_types/desert.dm
+++ b/code/modules/overmap/exoplanets/planet_types/desert.dm
@@ -47,6 +47,7 @@
 	land_type = /turf/exterior/sand
 
 	flora_prob = 5
+	grass_prob = 2
 	large_flora_prob = 0
 
 /datum/random_map/noise/exoplanet/desert/get_additional_spawns(var/value, var/turf/T)

--- a/code/modules/overmap/exoplanets/planet_types/grass.dm
+++ b/code/modules/overmap/exoplanets/planet_types/grass.dm
@@ -65,4 +65,5 @@
 	water_type = /turf/exterior/water
 
 	flora_prob = 10
+	grass_prob = 50
 	large_flora_prob = 30

--- a/code/modules/overmap/exoplanets/planet_types/volcanic.dm
+++ b/code/modules/overmap/exoplanets/planet_types/volcanic.dm
@@ -54,6 +54,7 @@
 
 	fauna_prob = 1
 	flora_prob = 3
+	grass_prob = 0
 	large_flora_prob = 0
 
 //Squashing most of 1 tile lava puddles

--- a/code/modules/overmap/exoplanets/random_map.dm
+++ b/code/modules/overmap/exoplanets/random_map.dm
@@ -14,6 +14,7 @@
 	var/large_flora_prob = 30
 	var/flora_prob = 10
 	var/fauna_prob = 2
+	var/grass_prob
 	var/megafauna_spawn_prob = 0.5 //chance that a given fauna mob will instead be a megafauna
 
 	var/list/plantcolors = list("RANDOM")
@@ -23,6 +24,7 @@
 	target_turf_type = world.turf
 	water_level = rand(water_level_min,water_level_max)
 	//automagically adjust probs for bigger maps to help with lag
+	if(isnull(grass_prob)) grass_prob = flora_prob * 2
 	var/size_mod = intended_x / tlx * intended_y / tly
 	flora_prob *= size_mod
 	large_flora_prob *= size_mod
@@ -53,12 +55,12 @@
 			if(prob(fauna_prob))
 				spawn_fauna(T)
 		if(5 to 6)
-			if(flora_prob > 5 && prob(flora_prob * 5))
+			if(grass_prob > 10 && prob(grass_prob))
 				spawn_grass(T)
 			if(prob(flora_prob/3))
 				spawn_flora(T)
 		if(7 to 9)
-			if(flora_prob > 1 && prob(flora_prob * 10))
+			if(grass_prob > 1 && prob(grass_prob * 3))
 				spawn_grass(T)
 			if(prob(flora_prob))
 				spawn_flora(T)


### PR DESCRIPTION
Issue was twofold:
- decals had typechecks which prevented them from applying on external turfs
- external turfs didn't layer on plating layer (despite claiming to be plating)

Also decloupled random grass prob from flora prob, and made it not scale with planet size, so now deserts and volcanic worlds aren't too lush.