### PR TITLE
Adds dry mud turfs to desert planets

### DIFF
--- a/code/game/turfs/exterior/exterior_mud.dm
+++ b/code/game/turfs/exterior/exterior_mud.dm
@@ -8,3 +8,9 @@
 /turf/exterior/mud/dark
 	icon = 'icons/turf/exterior/mud_dark.dmi'
 	icon_edge_layer = EXT_EDGE_MUD_DARK
+
+/turf/exterior/dry
+	name = "dry mud"
+	desc = "Should have stayed hydrated."
+	dirt_color = "#ae9e66"
+	icon = 'icons/turf/exterior/seafloor.dmi'

--- a/code/modules/overmap/exoplanets/planet_types/desert.dm
+++ b/code/modules/overmap/exoplanets/planet_types/desert.dm
@@ -51,6 +51,11 @@
 		if(prob(10))
 			new/obj/structure/quicksand(T)
 
+/datum/random_map/noise/exoplanet/desert/get_appropriate_path(var/value)
+	. = ..()
+	if(noise2value(value) > 6)
+		return /turf/exterior/dry
+
 /area/exoplanet/desert
 	ambience = list('sound/effects/wind/desert0.ogg','sound/effects/wind/desert1.ogg','sound/effects/wind/desert2.ogg','sound/effects/wind/desert3.ogg','sound/effects/wind/desert4.ogg','sound/effects/wind/desert5.ogg')
 	base_turf = /turf/exterior/sand


### PR DESCRIPTION
Previously darker sand icon states were used for that, but those are gone.
These turfs are where quicksands can spawn, so they gotta be visible as 'potentially dangerous to cross area'
![image](https://user-images.githubusercontent.com/1300258/104834966-5a766c00-58b4-11eb-897d-c47ae0f6f1f8.png)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->

## Changelog
:cl:
tweak: Desert planets now have 'dry mud' turfs in the areas where quicksands can spawn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
