### PR TITLE
Generalizes one tile smoothing from exoplanets to all noise maps

### DIFF
--- a/code/modules/overmap/exoplanets/random_map.dm
+++ b/code/modules/overmap/exoplanets/random_map.dm
@@ -2,7 +2,7 @@
 /datum/random_map/noise/exoplanet
 	descriptor = "exoplanet"
 	smoothing_iterations = 1
-	target_turf_type = null
+	smooth_single_tiles = 1
 
 	var/water_level
 	var/water_level_min = 0
@@ -108,43 +108,13 @@
 
 /datum/random_map/noise/exoplanet/cleanup()
 	..()
-	if(!water_type && !water_level)
+	if(!water_type || !water_level || !coast_type)
 		return
 	for(var/x in 1 to limit_x - 1)
 		for(var/y in 1 to limit_y - 1)
-			if(noise2value(map[get_map_cell(x,y)]) < water_level)
-				smooth_water(x, y)
-			else
-				smooth_islands(x, y)
-
-//Remove one-tile puddles and place coastal turfs if set
-/datum/random_map/noise/exoplanet/proc/smooth_water(x, y)
-	var/list/coast = list()
-	var/list/water = list()
-	var/mapcell = get_map_cell(x,y)
-	for(var/dx in list(-1,0,1))
-		for(var/dy in list(-1,0,1))
-			var/tmp_cell = get_map_cell(x+dx,y+dy)
-			if(tmp_cell && tmp_cell != mapcell)
-				if(noise2value(map[tmp_cell]) < water_level)
-					water |= tmp_cell
-				else
-					coast |= tmp_cell
-	if(!length(water))
-		map[mapcell] = cell_range
-	else if (coast_type)
-		for(var/cell in coast)
-			map[cell] = COAST_VALUE
-
-//Remove one-tile 'islands' in water bodies
-/datum/random_map/noise/exoplanet/proc/smooth_islands(x, y)
-	var/list/buddies = list()
-	var/mapcell = get_map_cell(x,y)
-	for(var/dx in list(-1,0,1))
-		for(var/dy in list(-1,0,1))
-			var/tmp_cell = get_map_cell(x+dx,y+dy)
-			if(tmp_cell && tmp_cell != mapcell)
-				if(noise2value(map[tmp_cell]) >= water_level)
-					buddies |= tmp_cell
-	if(!length(buddies))
-		map[mapcell] = 0
+			var/mapcell = get_map_cell(x,y)
+			if(noise2value(map[mapcell]) < water_level)
+				var/neighbors = get_neighbors(x, y, TRUE)
+				for(var/cell in neighbors)
+					if(noise2value(map[cell]) >= water_level)
+						map[cell] = COAST_VALUE		


### PR DESCRIPTION
If parameter is set, single tiles without buddies in orthogonal directions are going to get squashed.
I went for orthogonal because allowing diagonals leaves odd configurations that don't look nice.
