### PR TITLE
Removes the old feedback database, swaps feedback credentials to use non-feedback credentials.

### DIFF
--- a/code/_global_vars/configuration.dm
+++ b/code/_global_vars/configuration.dm
@@ -15,9 +15,7 @@ var/gravity_is_on = 1
 
 // Database connections. A connection is established on world creation.
 // Ideally, the connection dies when the server restarts (After feedback logging.).
-var/DBConnection/dbcon     = new() // Feedback    database (New database)
-var/DBConnection/dbcon_old = new() // /tg/station database (Old database) -- see the files in the SQL folder for information on what goes where.
-
+var/DBConnection/dbcon // General-purpose record database.
 
 // For FTP requests. (i.e. downloading runtime logs.)
 // However it'd be ok to use for accessing attack logs and such too, which are even laggier.

--- a/code/_global_vars/sensitive.dm
+++ b/code/_global_vars/sensitive.dm
@@ -6,8 +6,3 @@ GLOBAL_REAL_VAR(sqlport)      = "3306"
 GLOBAL_REAL_VAR(sqldb)        = "tgstation"
 GLOBAL_REAL_VAR(sqllogin)     = "root"
 GLOBAL_REAL_VAR(sqlpass)      = ""
-
-// Feedback gathering sql connection
-GLOBAL_REAL_VAR(sqlfdbkdb)    = "test"
-GLOBAL_REAL_VAR(sqlfdbklogin) = "root"
-GLOBAL_REAL_VAR(sqlfdbkpass)  = ""

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -890,12 +890,6 @@ var/list/gamemode_cache = list()
 				sqllogin = value
 			if ("password")
 				sqlpass = value
-			if ("feedback_database")
-				sqlfdbkdb = value
-			if ("feedback_login")
-				sqlfdbklogin = value
-			if ("feedback_password")
-				sqlfdbkpass = value
 			else
 				log_misc("Unknown setting in configuration: '[name]'")
 

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -34,10 +34,11 @@ var/list/whitelist = list()
 	else
 		alien_whitelist = splittext(text, "\n")
 		return 1
+
 /proc/load_alienwhitelistSQL()
-	var/DBQuery/query = dbcon_old.NewQuery("SELECT * FROM `whitelist`")
+	var/DBQuery/query = dbcon.NewQuery("SELECT * FROM `whitelist`")
 	if(!query.Execute())
-		to_world_log(dbcon_old.ErrorMsg())
+		to_world_log(dbcon.ErrorMsg())
 		return 0
 	else
 		while(query.NextRow())

--- a/code/modules/admin/view_variables/view_variables_global.dm
+++ b/code/modules/admin/view_variables/view_variables_global.dm
@@ -35,23 +35,21 @@
 	return vars
 
 /decl/global_vars/VV_hidden()
-	return list("forumsqladdress",
-				"forumsqldb",
-				"forumsqllogin",
-				"forumsqlpass",
-				"forumsqlport",
-				"sqladdress",
-				"sqldb",
-				"sqlfdbkdb",
-				"sqlfdbklogin",
-				"sqlfdbkpass",
-				"sqllogin",
-				"sqlpass",
-				"sqlport",
-				"comms_password",
-				"ban_comms_password",
-				"login_export_addr"
-			)
+	return list(
+		"forumsqladdress",
+		"forumsqldb",
+		"forumsqllogin",
+		"forumsqlpass",
+		"forumsqlport",
+		"sqladdress",
+		"sqldb",
+		"sqllogin",
+		"sqlpass",
+		"sqlport",
+		"comms_password",
+		"ban_comms_password",
+		"login_export_addr"
+	)
 
 /client/proc/debug_global_variables()
 	set category = "Debug"

--- a/config/example/dbconfig.txt
+++ b/config/example/dbconfig.txt
@@ -18,8 +18,3 @@ LOGIN mylogin
 
 # Password used to access the database
 PASSWORD mypassword
-
-# The following information is for feedback tracking via the blackbox server
-FEEDBACK_DATABASE test
-FEEDBACK_LOGIN mylogin
-FEEDBACK_PASSWORD mypassword

--- a/config/example/dbconfig_docker.txt
+++ b/config/example/dbconfig_docker.txt
@@ -17,11 +17,6 @@ LOGIN gamelord
 # Password used to access the database
 PASSWORD gamelord
 
-# The following information is for feedback tracking via the blackbox server
-FEEDBACK_DATABASE gamelord
-FEEDBACK_LOGIN gamelord
-FEEDBACK_PASSWORD gamelord
-
 # Track population and death statistics
 # Comment this out to disable
 ENABLE_STAT_TRACKING


### PR DESCRIPTION
The whitelist table has already been migrated so the old DB is literally useless. Brought to our attention by someone trying to set it up and being very confused by the duplicate logins.