### PR TITLE
Swapping github_token for password to see if CL build will run.

### DIFF
--- a/.github/workflows/changelog_generation.yml
+++ b/.github/workflows/changelog_generation.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Push
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          password: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
I have no idea if this will work, a lot of the workflow docs seem to assume you're using GITHUB_TOKEN, which we aren't.