### PR TITLE
Fixes #1093

### DIFF
--- a/code/game/machinery/_machines_base/stock_parts/_stock_parts.dm
+++ b/code/game/machinery/_machines_base/stock_parts/_stock_parts.dm
@@ -95,3 +95,11 @@
 		to_chat(user, SPAN_NOTICE("It is showing signs of damage."))
 	else if(health < max_health)
 		to_chat(user, SPAN_NOTICE("It is showing some wear and tear."))
+
+//Machines handle damaging for us, so don't do it twice
+/obj/item/stock_parts/explosion_act(severity)
+	var/obj/machinery/M = loc
+	if(istype(M) && (src in M.component_parts))
+		return
+	..()
+	


### PR DESCRIPTION
The issue was that explosion was propagated to contents, qdeling the circuitboard, which in turn broke machine construction's states assumption, so it threw a fit and refused to play along.
Made stock parts inside machinery just ignore that stuff, machinery handles damaging them (with shielding components etc)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->

## Changelog
:cl:
bugfix: APCs can be fixed again after explosions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
