### PR TITLE
Makes APC visuals actually care about broken components

### DIFF
--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -429,9 +429,9 @@ Class Procs:
 	if(. && !CanFluidPass())
 		fluid_update()
 
-/obj/machinery/get_cell()
+/obj/machinery/get_cell(var/functional_only = TRUE)
 	var/obj/item/stock_parts/power/battery/battery = get_component_of_type(/obj/item/stock_parts/power/battery)
-	if(battery)
+	if(battery && (!functional_only || battery.is_functional()))
 		return battery.get_cell()
 
 /obj/machinery/building_cost()

--- a/code/game/machinery/_machines_base/machinery_damage.dm
+++ b/code/game/machinery/_machines_base/machinery_damage.dm
@@ -53,7 +53,9 @@
 
 /obj/machinery/proc/on_component_failure(var/obj/item/stock_parts/component)
 	RefreshParts()
-	power_change()
+	update_icon()
+	if(istype(component, /obj/item/stock_parts/power))
+		power_change()
 
 /obj/machinery/emp_act(severity)
 	if(use_power && stat == 0)


### PR DESCRIPTION
Not drawing screen overlay / light if screen is broken
Not  reporting power from cell if cell component is broken
Properly reporting no terminal connection in UI if component is broken

Turned out the actual meat of interactions already worked fine, just all UI / visuals didn't care.
 
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->

## Changelog
:cl:
tweak: APCs now don't draw screen overlay / glow if screen component is destroyed
tweak: APCs now don't report cell power in UI etc if battery backup is destroyed
tweak: APCs now show that external power is not coming in if terminal component is destroyed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
