### PR TITLE
Machinery explosion act tweaks

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -29,11 +29,6 @@
 	. = ..()
 	to_chat(user, SPAN_NOTICE("The neural suppressors are switched [suppressing ? "on" : "off"]."))
 
-/obj/machinery/optable/explosion_act(severity)
-	. = ..()
-	if(. && !QDELETED(src) && (severity == 1 || prob(100 - (25 * severity))))
-		physically_destroyed(src)
-
 /obj/machinery/optable/attackby(var/obj/item/O, var/mob/user)
 	if (istype(O, /obj/item/grab))
 		var/obj/item/grab/G = O

--- a/code/game/machinery/_machines_base/machinery_damage.dm
+++ b/code/game/machinery/_machines_base/machinery_damage.dm
@@ -65,7 +65,11 @@
 /obj/machinery/explosion_act(severity)
 	..()
 	if(!QDELETED(src))
-		take_damage(100/severity, BRUTE, TRUE)
+		if((severity == 1 || (severity == 2 && prob(25))))
+			physically_destroyed()
+			qdel(src)
+		else
+			take_damage(100/severity, BRUTE, TRUE)
 
 /obj/machinery/bullet_act(obj/item/projectile/P, def_zone)
 	. = ..()

--- a/code/game/machinery/bodyscanner.dm
+++ b/code/game/machinery/bodyscanner.dm
@@ -115,11 +115,6 @@
 	if(!user_can_move_target_inside(target, user))
 		return
 
-/obj/machinery/bodyscanner/explosion_act(severity)
-	. = ..()
-	if(. && !QDELETED(src) && prob(severity == 1 ? 100 : (100 - (25 * severity))))
-		physically_destroyed(src)
-
 /obj/machinery/bodyscanner/Destroy()
 	if(occupant)
 		occupant.dropInto(loc)

--- a/code/game/machinery/bodyscanner_console.dm
+++ b/code/game/machinery/bodyscanner_console.dm
@@ -24,11 +24,6 @@
 	else
 		icon_state = initial(icon_state)
 
-/obj/machinery/body_scanconsole/explosion_act(severity)
-	. = ..()
-	if(. && !QDELETED(src) && (severity == 1 || (severity == 2 && prob(50))))
-		qdel(src)
-
 /obj/machinery/body_scanconsole/proc/FindScanner()
 	for(var/D in GLOB.cardinal)
 		src.connected = locate(/obj/machinery/bodyscanner, get_step(src, D))

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -33,15 +33,6 @@
 	if(prob(20/severity)) set_broken(TRUE)
 	..()
 
-/obj/machinery/computer/explosion_act(severity)
-	..()
-	if(!QDELETED(src))
-		if(severity == 1 || (severity == 2 && prob(25)))
-			qdel(src)
-		else if(prob(100 - (severity * 25)))
-			verbs.Cut()
-			set_broken(TRUE)
-
 /obj/machinery/computer/on_update_icon()
 
 	cut_overlays()

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -379,11 +379,6 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	active_power_usage = 100
 
 //Destruction procs.
-/obj/machinery/hologram/explosion_act(severity)
-	. = ..()
-	if(. && !QDELETED(src) && (severity == 1 || (severity == 2 && prob(50)) || (severity == 3 && prob(5))))
-		physically_destroyed(src)
-
 /obj/machinery/hologram/holopad/Destroy()
 	for (var/mob/living/master in masters)
 		clear_holo(master)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -129,13 +129,10 @@
 	else ..()
 
 /obj/machinery/photocopier/explosion_act(severity)
-	. = ..()
-	if(.)
-		if(severity == 1 || (severity == 2 && prob(50)))
-			physically_destroyed()
-		else if((severity == 2 || prob(50)) && toner)
-			new /obj/effect/decal/cleanable/blood/oil(get_turf(src))
-			toner = 0
+	..()
+	if(!QDELETED(src) && (severity == 2 || prob(50)) && toner)
+		new /obj/effect/decal/cleanable/blood/oil(get_turf(src))
+		toner = 0
 
 /obj/machinery/photocopier/proc/copy(var/obj/item/paper/copy, var/need_toner=1)
 	var/obj/item/paper/c = new copy.type(loc, copy.text, copy.name, copy.metadata )

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -34,11 +34,6 @@
 /obj/machinery/chem_master/proc/get_remaining_volume()
 	return Clamp(reagent_limit - reagents.total_volume, 0, reagent_limit)
 
-/obj/machinery/chem_master/explosion_act(severity)
-	. = ..()
-	if(. && (severity == 1) || (severity == 2 && prob(50)))
-		physically_destroyed()
-
 /obj/machinery/chem_master/attackby(var/obj/item/B, var/mob/user)
 
 	if(istype(B, /obj/item/chems/glass))


### PR DESCRIPTION
Moved a bunch of cookie cutter explosion acts up into base proc
Machines now can actually be fully destroyed by explosions

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->

## Changelog
:cl:
experiment: Machines can actually be destroyed fully by strong explosions again (not just component damage)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
