### PR TITLE
Allow to override target turf and floor type for mountains and exopla…

### DIFF
--- a/code/modules/overmap/exoplanets/planet_themes/mountains.dm
+++ b/code/modules/overmap/exoplanets/planet_themes/mountains.dm
@@ -17,13 +17,17 @@
 	descriptor = "space mountains"
 	wall_type =  /turf/simulated/wall/natural
 	cell_threshold = 6
+	target_turf_type = null
+	floor_type = null
 	var/rock_color
 
 /datum/random_map/automata/cave_system/mountains/New(var/seed, var/tx, var/ty, var/tz, var/tlx, var/tly, var/do_not_apply, var/do_not_announce, var/never_be_priority = 0, var/used_area, var/_rock_color)
 	if(_rock_color)
 		rock_color = _rock_color
-	target_turf_type = world.turf
-	floor_type = world.turf
+	if(target_turf_type == null)
+		target_turf_type = world.turf
+	if(floor_type == null)
+		floor_type = world.turf
 	..()
 
 /datum/random_map/automata/cave_system/mountains/get_additional_spawns(value, var/turf/simulated/wall/natural/T)

--- a/code/modules/overmap/exoplanets/random_map.dm
+++ b/code/modules/overmap/exoplanets/random_map.dm
@@ -2,6 +2,7 @@
 /datum/random_map/noise/exoplanet
 	descriptor = "exoplanet"
 	smoothing_iterations = 1
+	target_turf_type = null
 
 	var/water_level
 	var/water_level_min = 0
@@ -23,7 +24,8 @@
 	var/list/grass_cache
 
 /datum/random_map/noise/exoplanet/New(var/seed, var/tx, var/ty, var/tz, var/tlx, var/tly, var/do_not_apply, var/do_not_announce, var/never_be_priority = 0, var/used_area, var/list/_plant_colors)
-	target_turf_type = world.turf
+	if(target_turf_type == null)
+		target_turf_type = world.turf
 	water_level = rand(water_level_min,water_level_max)
 	//automagically adjust probs for bigger maps to help with lag
 	if(isnull(grass_prob)) grass_prob = flora_prob * 2


### PR DESCRIPTION
…nets noise

Found out what I can't fill my map with unsimulated mask to perform planet generation. So... I did this to able override.
This removes hard type set and allow to set custom target. @comma, you probably want to discuss this with me.
