### PR TITLE
Random small forensics additions

### DIFF
--- a/code/datums/extensions/holster/holster.dm
+++ b/code/datums/extensions/holster/holster.dm
@@ -48,6 +48,7 @@
 		holstered = I
 		storage.handle_item_insertion(holstered, 1)
 		holstered.add_fingerprint(user)
+		holstered.add_fibers(atom_holder)
 		storage.w_class = max(storage.w_class, holstered.w_class)
 		user.visible_message("<span class='notice'>\The [user] holsters \the [holstered].</span>", "<span class='notice'>You holster \the [holstered].</span>")
 		atom_holder.SetName("occupied [initial(atom_holder.name)]")

--- a/code/game/machinery/doors/_door.dm
+++ b/code/game/machinery/doors/_door.dm
@@ -317,9 +317,11 @@
 		to_chat(user, "\The [src] looks seriously damaged!")
 	else if(src.health < src.maxhealth * 3/4)
 		to_chat(user, "\The [src] shows signs of damage!")
+	else if(src.health < src.maxhealth && get_dist(src, user) <= 1)
+		to_chat(user, "\The [src] has some minor scuffing.")
 
 	var/mob/living/carbon/human/H = user
-	if (emagged && istype(H) && H.skill_check(SKILL_COMPUTER, SKILL_ADEPT))
+	if (emagged && istype(H) && (H.skill_check(SKILL_COMPUTER, SKILL_ADEPT) || H.skill_check(SKILL_ELECTRICAL, SKILL_ADEPT)))
 		to_chat(user, SPAN_WARNING("\The [src]'s control panel looks fried."))
 
 /obj/machinery/door/set_broken(new_state, cause)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -766,6 +766,9 @@ About the new airlock wires panel:
 		return wires.Interact(user)
 
 	else if(isCrowbar(C) && !welded && !repairing)
+		// Add some minor damage as evidence of forcing.
+		if(health >= maxhealth)
+			take_damage(1)
 		if(arePowerSystemsOn())
 			to_chat(user, SPAN_WARNING("The airlock's motors resist your efforts to force it."))
 		else if(locked)

--- a/code/modules/detectivework/evidence/fibers.dm
+++ b/code/modules/detectivework/evidence/fibers.dm
@@ -2,14 +2,22 @@
 	name = "fibers and microparticles"
 	remove_on_transfer = TRUE
 
-/datum/forensics/fibers/add_from_atom(mob/living/carbon/human/M)
-	if(!istype(M))
+/datum/forensics/fibers/add_from_atom(atom/movable/AM)
+	if(!AM)
 		return
-	var/covered = 0
-	for(var/obj/item/clothing/C in list(M.wear_suit, M.gloves, M.w_uniform))
-		if(prob(15) && (C.body_parts_covered & ~covered))
-			add_data(C.get_fibers())
-		covered |= C.body_parts_covered
+	var/list/sources
+	if(istype(AM, /obj/item/clothing/))
+		LAZYADD(sources, AM)
+	else if(ishuman(AM))
+		var/mob/living/carbon/human/M = AM
+		var/covered = 0
+		for(var/obj/item/clothing/C in list(M.wear_suit, M.gloves, M.w_uniform))
+			if(prob(15) && (C.body_parts_covered & ~covered))
+				LAZYADD(sources, C)
+			covered |= C.body_parts_covered
+
+	for(var/obj/item/clothing/C in sources)
+		add_data(C.get_fibers())
 
 /datum/forensics/fibers/spot_message(mob/detective, atom/location)
 	to_chat(detective, SPAN_NOTICE("You notice some fibers embedded in \the [location]."))

--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -34,6 +34,12 @@
 	add_hiddenprint(M)
 	return 1
 
+/atom/proc/add_fibers(obj/item/clothing/source)
+	if(!istype(source) || (source.item_flags & ITEM_FLAG_NO_PRINT))
+		return
+	var/datum/extension/forensic_evidence/forensics = get_or_create_extension(src, /datum/extension/forensic_evidence)
+	forensics.add_from_atom(/datum/forensics/fibers, source)
+
 /atom/proc/transfer_fingerprints_to(var/atom/A)
 	var/datum/extension/forensic_evidence/forensics = get_extension(src, /datum/extension/forensic_evidence)
 	if(!forensics)


### PR DESCRIPTION
Holstering a thing now puts holster's fibers on it. Restructured fibers proc to work both with mob and item as sources.
Emagged airlocks can now be spotted with either IT or Electician skill, not just IT.
Crowbarred airlocks leave minor (1) damage. Such damage can only be seen when examining door up close.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->

## Changelog
:cl:
tweak: Holsters now leave their fibers on things put inside.
tweak: Crowbarring doors now leaves scuffing on them, visible when examined up close. Can be repaired as any other damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
