### PR TITLE
Cleaning up accessory code and readding hiding on uniform rolldown.

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -258,9 +258,9 @@
 #define SPECIES_ALIEN            "Humanoid"
 #define SPECIES_GOLEM            "Golem"
 
-#define BODYTYPE_HUMANOID        "Humanoid Body"
-#define BODYTYPE_OTHER           "Alien Body"
-#define BODYTYPE_MONKEY          "Small Humanoid Body"
+#define BODYTYPE_HUMANOID        "humanoid body"
+#define BODYTYPE_OTHER           "alien body"
+#define BODYTYPE_MONKEY          "small humanoid body"
 
 #define SURGERY_CLOSED 0
 #define SURGERY_OPEN 1

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -64,16 +64,7 @@
 
 	var/use_alt_layer = FALSE // Use the slot's alternative layer when rendering on a mob
 
-	//** These specify item/icon overrides for _slots_
-	//** These specify item/icon overrides for _species_
-	/* Species-specific sprites, concept stolen from Paradise//vg/.
-	ex:
-	sprite_sheets = list(
-		SPECIES_FOO = 'icons/foo/onmob_foo.dmi'
-		)
-	If index term exists and icon_override is not set, this sprite sheet will be used.
-	*/
-	var/list/sprite_sheets = list()
+	var/list/sprite_sheets = list() // Assoc list of bodytype to icon override for on-mob icons when this item is held or worn.
 
 	// Material handling for material weapons (not used by default, unless material is supplied or set)
 	var/decl/material/material                      // Reference to material decl. If set to a string corresponding to a material ID, will init the item with that material.
@@ -824,7 +815,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	if(use_single_icon)
 		return experimental_mob_overlay(user_mob, slot, bodypart)
 
-	var/bodytype = "Default"
+	var/bodytype = BODYTYPE_HUMANOID
 	var/mob/living/carbon/human/user_human
 	if(ishuman(user_mob))
 		user_human = user_mob

--- a/code/game/objects/items/dog_tags.dm
+++ b/code/game/objects/items/dog_tags.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/clothing/accessories/jewelry/dogtags.dmi'
 	slot_flags = SLOT_FACE | SLOT_TIE
 	badge_string = null
+	hide_on_uniform_rolldown = FALSE
 
 	var/owner_rank
 	var/owner_name

--- a/code/game/objects/items/item_icon_experimental.dm
+++ b/code/game/objects/items/item_icon_experimental.dm
@@ -68,13 +68,16 @@ var/list/bodypart_to_slot_lookup_table = list(
 
 /obj/item/proc/experimental_mob_overlay(var/mob/user_mob, var/slot, var/bodypart)
 
-	var/bodytype = lowertext(user_mob?.get_bodytype())
+	var/bodytype = user_mob?.get_bodytype() || BODYTYPE_HUMANOID
 	var/useicon =  get_icon_for_bodytype(bodytype)
-	if(bodytype != BODYTYPE_HUMANOID && (!bodytype || !check_state_in_icon("[bodytype]-[slot]", useicon)))
-		bodytype = lowertext(BODYTYPE_HUMANOID)
-		useicon = get_icon_for_bodytype(bodytype)
+	if(bodytype != BODYTYPE_HUMANOID && !check_state_in_icon("[bodytype]-[slot]", useicon))
+		var/fallback = get_fallback_slot(slot)
+		if(fallback && fallback != slot && check_state_in_icon("[bodytype]-[fallback]", useicon))
+			slot = fallback
+		else
+			bodytype = BODYTYPE_HUMANOID
+			useicon = get_icon_for_bodytype(bodytype)
 
-	// See comment above.
 	var/use_state = "[bodytype]-[slot]"
 	if(!check_state_in_icon(use_state, useicon) && global.bodypart_to_slot_lookup_table[slot])
 		use_state = "[bodytype]-[global.bodypart_to_slot_lookup_table[slot]]"
@@ -98,7 +101,6 @@ var/list/bodypart_to_slot_lookup_table = list(
 	. = species && species.get_bodytype(src)
 
 /obj/item/proc/get_icon_for_bodytype(var/bodytype)
-	bodytype = lowertext(bodytype)
 	. = LAZYACCESS(sprite_sheets, bodytype) || icon
 
 /obj/item/proc/apply_overlays(var/mob/user_mob, var/bodytype, var/image/overlay, var/slot)
@@ -107,7 +109,7 @@ var/list/bodypart_to_slot_lookup_table = list(
 /obj/item/proc/apply_offsets(var/mob/user_mob, var/bodytype,  var/image/overlay, var/slot, var/bodypart)
 	if(ishuman(user_mob))
 		var/mob/living/carbon/human/H = user_mob
-		if(lowertext(H.species.get_bodytype(H)) != bodytype) 
+		if(H.species.get_bodytype(H) != bodytype) 
 			overlay = H.species.get_offset_overlay_image(FALSE, overlay.icon, overlay.icon_state, color, bodypart || slot)
 	. = overlay
 

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -67,21 +67,17 @@
 		if(blood_DNA && user_human.species.blood_mask)
 			var/image/bloodsies = overlay_image(user_human.species.blood_mask, blood_overlay_type, blood_color, RESET_COLOR)
 			bloodsies.appearance_flags |= NO_CLIENT_COLOR
-			ret.overlays	+= bloodsies
-
-	if(length(accessories))
-		for(var/obj/item/clothing/accessory/A in accessories)
-			ret.overlays += A.get_mob_overlay(user_mob, slot)
-
+			ret.overlays += bloodsies
 	if(markings_icon && markings_color)
 		ret.overlays += mutable_appearance(ret.icon, markings_icon, markings_color)
 	return ret
 
 /obj/item/clothing/apply_overlays(var/mob/user_mob, var/bodytype, var/image/overlay, var/slot)
 	var/image/ret = ..()
-	if(length(accessories))
+	if(ret && length(accessories))
 		for(var/obj/item/clothing/accessory/A in accessories)
-			ret.overlays += A.get_mob_overlay(user_mob, slot)
+			if(A.should_overlay())
+				ret.overlays += A.get_mob_overlay(user_mob, slot)
 
 	if(markings_icon && markings_color && check_state_in_icon("[ret.icon_state][markings_icon]", ret.icon))
 		ret.overlays += mutable_appearance(ret.icon, "[ret.icon_state][markings_icon]", markings_color)
@@ -89,10 +85,14 @@
 	return ret
 
 /obj/item/clothing/on_update_icon()
-	..()
+	cut_overlays()
 	if(markings_icon && markings_color)
-		overlays += mutable_appearance(icon, "[get_world_inventory_state()][markings_icon]", markings_color)
-		
+		add_overlay(mutable_appearance(icon, "[get_world_inventory_state()][markings_icon]", markings_color))
+	for(var/obj/item/clothing/accessory/accessory in accessories)
+		var/image/ret = accessory.get_inv_overlay()
+		if(ret)
+			add_overlay(ret)
+
 /obj/item/clothing/proc/change_smell(smell = SMELL_DEFAULT)
 	smell_state = smell
 

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -18,7 +18,6 @@
 	gender = copy.gender
 	if(copy.sprite_sheets)
 		sprite_sheets = copy.sprite_sheets.Copy()
-	//copying sprite_sheets_obj should be unnecessary as chameleon items are not refittable.
 
 	OnDisguise(copy, user)
 	qdel(copy)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -344,11 +344,6 @@
 		return
 
 	slot = copy.slot
-	has_suit = copy.has_suit
-	inv_overlay = copy.inv_overlay
-	mob_overlay = copy.mob_overlay
-	overlay_state = copy.overlay_state
-	on_rolled = copy.on_rolled
 	high_visibility = copy.high_visibility
 	return copy
 

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -96,11 +96,14 @@
  *  items on spawn
  */
 /obj/item/clothing/proc/attach_accessory(mob/user, obj/item/clothing/accessory/A)
+	if(A in accessories)
+		return
 	accessories += A
 	A.on_attached(src, user)
 	if(A.removable)
 		src.verbs |= /obj/item/clothing/proc/removetie_verb
 	update_accessory_slowdown()
+	update_icon()
 	update_clothing_icon()
 
 /obj/item/clothing/proc/remove_accessory(mob/user, obj/item/clothing/accessory/A)
@@ -110,6 +113,7 @@
 	A.on_removed(user)
 	accessories -= A
 	update_accessory_slowdown()
+	update_icon()
 	update_clothing_icon()
 
 /obj/item/clothing/proc/removetie_verb()

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -1,7 +1,6 @@
 /obj/item/clothing/gloves/color
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = ICON_STATE_WORLD
-	sprite_sheets = null
 
 /obj/item/clothing/gloves/color/white
 	color = COLOR_WHITE

--- a/code/modules/clothing/gloves/latex.dm
+++ b/code/modules/clothing/gloves/latex.dm
@@ -5,7 +5,6 @@
 	permeability_coefficient = 0.01
 	germ_level = 0
 	icon_state = ICON_STATE_WORLD
-	sprite_sheets = null
 	anomaly_shielding = 0.1
 	material = /decl/material/solid/plastic //todo: latex
 

--- a/code/modules/clothing/gloves/thick.dm
+++ b/code/modules/clothing/gloves/thick.dm
@@ -12,7 +12,6 @@
 	icon = 'icons/clothing/hands/gloves_thick.dmi'
 	icon_state = ICON_STATE_WORLD
 	force = 5
-	sprite_sheets = null
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT, 
 		bullet = ARMOR_BALLISTIC_PISTOL, 

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -25,9 +25,7 @@
 		if(!light_overlay_image)
 			if(ishuman(user_mob))
 				var/mob/living/carbon/human/user_human = user_mob
-				var/use_icon
-				if(sprite_sheets)
-					use_icon = sprite_sheets[user_human.species.get_bodytype(user_human)]
+				var/use_icon = LAZYACCESS(sprite_sheets, user_human.species.get_bodytype(user_human))
 				if(use_icon)
 					light_overlay_image = user_human.species.get_offset_overlay_image(TRUE, use_icon, "[light_overlay]", color, slot)
 				else

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -310,12 +310,12 @@
 							wearer.update_inv_head()
 							if(helmet)
 								helmet.update_light(wearer)
-
 					//sealed pieces become airtight, protecting against diseases
 					var/datum/extension/armor/rig/armor_datum = get_extension(piece, /datum/extension/armor)
 					if(istype(armor_datum))
 						armor_datum.sealed = !seal_target
 					playsound(src, 'sound/machines/suitstorage_lockdoor.ogg', 10, 0)
+					piece.update_icon()
 
 				else
 					failed_to_seal = 1
@@ -560,6 +560,9 @@
 		for(var/obj/item/rig_module/module in installed_modules)
 			if(module.suit_overlay)
 				chest.overlays += image("icon" = equipment_overlay_icon, "icon_state" = "[module.suit_overlay]", "dir" = SOUTH)
+
+	for(var/obj/item/thing in list(chest, boots, gloves, helmet))
+		thing.update_icon()
 
 	if(wearer)
 		wearer.update_inv_shoes()

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -147,8 +147,8 @@
 	offline_vision_restriction = TINT_HEAVY
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE // this is passed to the rig suit components when deployed, including the helmet.
 
-	chest = FALSE
 	boots = FALSE
+	chest = /obj/item/clothing/suit/space/rig/ce
 	helmet = /obj/item/clothing/head/helmet/space/rig/ce
 	gloves = /obj/item/clothing/gloves/rig/ce
 
@@ -169,6 +169,9 @@
 		/obj/item/rig_module/grenade_launcher/mfoam,
 		/obj/item/rig_module/cooling_unit
 		)
+
+/obj/item/clothing/suit/space/rig/ce
+	icon = 'icons/clothing/rigs/chests/chest_engineering.dmi'
 
 /obj/item/clothing/head/helmet/space/rig/ce
 	icon = 'icons/clothing/rigs/helmets/helmet_engineering.dmi'

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -43,9 +43,9 @@
 
 /obj/item/clothing/under/Initialize()
 	. = ..()
-	if(check_state_in_icon(lowertext("[BODYTYPE_HUMANOID]-[slot_w_uniform_str]-rolled"), icon))
+	if(check_state_in_icon("[BODYTYPE_HUMANOID]-[slot_w_uniform_str]-rolled", icon))
 		verbs |= /obj/item/clothing/under/proc/roll_down_clothes
-	if(check_state_in_icon(lowertext("[BODYTYPE_HUMANOID]-[slot_w_uniform_str]-sleeves"), icon))
+	if(check_state_in_icon("[BODYTYPE_HUMANOID]-[slot_w_uniform_str]-sleeves", icon))
 		verbs |= /obj/item/clothing/under/proc/roll_up_sleeves
 
 /obj/item/clothing/under/experimental_mob_overlay(mob/user_mob, slot, bodypart)

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -7,93 +7,35 @@
 	w_class = ITEM_SIZE_SMALL
 
 	var/slot = ACCESSORY_SLOT_DECOR
-	var/obj/item/clothing/has_suit = null		//the suit the tie may be attached to
-	var/image/inv_overlay = null	//overlay used when attached to clothing.
-	var/list/mob_overlay = list()
-	var/overlay_state = null
-	var/list/on_rolled = list()	//used when jumpsuit sleevels are rolled ("rolled" entry) or it's rolled down ("down"). Set to "none" to hide in those states.
 	var/high_visibility	//if it should appear on examine without detailed view
 	var/slowdown //used when an accessory is meant to slow the wearer down when attached to clothing
 	var/removable = TRUE
+	var/hide_on_uniform_rolldown = FALSE
+	var/hide_on_uniform_rollsleeves = FALSE
 
 /obj/item/clothing/accessory/Destroy()
 	on_removed()
 	return ..()
 
-/obj/item/clothing/accessory/proc/get_inv_overlay()
-	if(!inv_overlay)
-		if(use_single_icon)
-			inv_overlay = image(icon, "inventory")
-			inv_overlay.color = color
-		else
-			var/tmp_icon_state = overlay_state? overlay_state : icon_state
-			if(icon_override && ("[tmp_icon_state]_tie" in icon_states(icon_override)))
-				inv_overlay = image(icon = icon_override, icon_state = "[tmp_icon_state]_tie", dir = SOUTH)
-			else if("[tmp_icon_state]_tie" in icon_states(default_onmob_icons[slot_tie_str]))
-				inv_overlay = image(icon = global.default_onmob_icons[slot_tie_str], icon_state = "[tmp_icon_state]_tie", dir = SOUTH)
-			else
-				inv_overlay = image(icon = global.default_onmob_icons[slot_tie_str], icon_state = tmp_icon_state, dir = SOUTH)
-	inv_overlay.color = color
-	inv_overlay.appearance_flags = RESET_COLOR
-	return inv_overlay
-
 /obj/item/clothing/accessory/get_fallback_slot(var/slot)
 	if(slot != BP_L_HAND && slot != BP_R_HAND)
 		return slot_tie_str
 
-/obj/item/clothing/accessory/get_mob_overlay(mob/user_mob, slot, bodypart)
-	if(!istype(loc,/obj/item/clothing) || use_single_icon)	//don't need special handling if it's worn as normal item.
-		return ..()
-	var/bodytype = BODYTYPE_HUMANOID
-	if(ishuman(user_mob))
-		var/mob/living/carbon/human/user_human = user_mob
-		if(user_human.species.get_bodytype(user_human) in sprite_sheets)
-			bodytype = user_human.species.get_bodytype(user_human)
-
-		var/tmp_icon_state = overlay_state? overlay_state : icon_state
-
-		if(istype(loc,/obj/item/clothing/under))
-			var/obj/item/clothing/under/C = loc
-			if(on_rolled["down"] && C.rolled_down > 0)
-				tmp_icon_state = on_rolled["down"]
-			else if(on_rolled["rolled"] && C.rolled_sleeves > 0)
-				tmp_icon_state = on_rolled["rolled"]
-
-		var/do_species_offset = (lowertext(bodytype) != lowertext(user_human.species.get_bodytype(user_human)))
-		var/use_sprite_sheet = FALSE
-		if(sprite_sheets[bodytype])
-			use_sprite_sheet = sprite_sheets[bodytype]
-
-
-		if(icon_override && ("[tmp_icon_state]_mob" in icon_states(icon_override)))
-			return overlay_image(icon_override, "[tmp_icon_state]_mob", color, RESET_COLOR)
-		else if(do_species_offset)
-			user_human.species.get_offset_overlay_image(FALSE, use_sprite_sheet, tmp_icon_state, color, bodypart || slot)
-		else
-			return overlay_image(use_sprite_sheet, tmp_icon_state, color, RESET_COLOR)
-
-//when user attached an accessory to S
 /obj/item/clothing/accessory/proc/on_attached(var/obj/item/clothing/S, var/mob/user)
-	if(!istype(S))
-		return
-	has_suit = S
-	forceMove(has_suit)
-	has_suit.overlays += get_inv_overlay()
-
-	if(user)
-		to_chat(user, "<span class='notice'>You attach \the [src] to \the [has_suit].</span>")
-		src.add_fingerprint(user)
+	if(istype(S))
+		forceMove(S)
+		if(user)
+			to_chat(user, SPAN_NOTICE("You attach \the [src] to \the [S]."))
+			src.add_fingerprint(user)
 
 /obj/item/clothing/accessory/proc/on_removed(var/mob/user)
-	if(!has_suit)
-		return
-	has_suit.overlays -= get_inv_overlay()
-	has_suit = null
-	if(user)
-		usr.put_in_hands(src)
-		src.add_fingerprint(user)
-	else
-		dropInto(loc)
+	var/obj/item/clothing/suit = loc
+	if(istype(suit))
+		if(user)
+			usr.put_in_hands(src)
+			src.add_fingerprint(user)
+		else
+			dropInto(loc)
 
 //default attackby behaviour
 /obj/item/clothing/accessory/attackby(obj/item/I, mob/user)
@@ -101,14 +43,54 @@
 
 //default attack_hand behaviour
 /obj/item/clothing/accessory/attack_hand(mob/user)
-	if(has_suit)
-		return	//we aren't an object on the ground so don't call parent
+	var/obj/item/clothing/suit = loc
+	if(istype(suit))
+		return TRUE //we aren't an object on the ground so don't call parent
 	..()
 
 /obj/item/clothing/accessory/get_pressure_weakness(pressure,zone)
 	if(body_parts_covered & zone)
 		return ..()
 	return 1
+
+/obj/item/clothing/accessory/proc/should_overlay()
+	. = istype(loc, /obj/item/clothing)
+	if(. && istype(loc, /obj/item/clothing/under))
+		var/obj/item/clothing/under/uniform = loc
+		if(uniform.rolled_down && hide_on_uniform_rolldown)
+			return FALSE
+		if(uniform.rolled_sleeves && hide_on_uniform_rollsleeves)
+			return FALSE
+
+/obj/item/clothing/accessory/experimental_mob_overlay(mob/user_mob, slot, bodypart)
+	var/image/ret = ..()
+	if(ret && istype(loc, /obj/item/clothing/under))
+		var/new_state = ret.icon_state
+		var/obj/item/clothing/under/uniform = loc
+		if(uniform.rolled_down)
+			new_state = "[new_state]-rolled"
+		else if(uniform.rolled_sleeves)
+			new_state = "[new_state]-sleeves"
+		if(check_state_in_icon(ret.icon, new_state))
+			ret.icon_state = new_state
+	return ret
+
+/obj/item/clothing/accessory/proc/get_inv_overlay()
+	var/overlay_state = "[get_world_inventory_state()]-attached"
+	if(check_state_in_icon(overlay_state, icon))
+		var/image/I = image(icon, overlay_state)
+		I.appearance_flags |= RESET_COLOR
+		return I
+
+/obj/item/clothing/accessory/OnDisguise(obj/item/copy, mob/user)
+	. = ..()
+	if(istype(copy, /obj/item/clothing/accessory))
+		var/obj/item/clothing/accessory/tie = copy
+		hide_on_uniform_rolldown =    tie.hide_on_uniform_rolldown
+		hide_on_uniform_rollsleeves = tie.hide_on_uniform_rollsleeves
+	else
+		hide_on_uniform_rolldown =    initial(hide_on_uniform_rolldown)
+		hide_on_uniform_rollsleeves = initial(hide_on_uniform_rollsleeves)
 
 //Necklaces
 /obj/item/clothing/accessory/necklace

--- a/code/modules/clothing/under/accessories/accessory_toggleable.dm
+++ b/code/modules/clothing/under/accessories/accessory_toggleable.dm
@@ -13,12 +13,14 @@
 
 /obj/item/clothing/accessory/toggleable/on_attached(obj/item/clothing/under/S, mob/user)
 	..()
-	if(has_suit)
-		has_suit.verbs |= /obj/item/clothing/accessory/toggleable/verb/toggle
+	var/obj/item/clothing/suit = loc
+	if(istype(suit))
+		suit.verbs |= /obj/item/clothing/accessory/toggleable/verb/toggle
 
 /obj/item/clothing/accessory/toggleable/on_removed(mob/user)
-	if(has_suit)
-		has_suit.verbs -= /obj/item/clothing/accessory/toggleable/verb/toggle
+	var/obj/item/clothing/suit = loc
+	if(istype(suit))
+		suit.verbs -= /obj/item/clothing/accessory/toggleable/verb/toggle
 	..()
 
 /obj/item/clothing/accessory/toggleable/attack_self(mob/user)
@@ -105,14 +107,16 @@
 
 /obj/item/clothing/accessory/toggleable/flannel/on_attached(obj/item/clothing/under/S, mob/user)
 	..()
-	if(has_suit)
-		has_suit.verbs |= /obj/item/clothing/accessory/toggleable/flannel/verb/tuck
-		has_suit.verbs |= /obj/item/clothing/accessory/toggleable/flannel/verb/roll_up_sleeves
+	var/obj/item/clothing/suit = loc
+	if(istype(suit))
+		suit.verbs |= /obj/item/clothing/accessory/toggleable/flannel/verb/tuck
+		suit.verbs |= /obj/item/clothing/accessory/toggleable/flannel/verb/roll_up_sleeves
 
 /obj/item/clothing/accessory/toggleable/flannel/on_removed(mob/user)
-	if(has_suit)
-		has_suit.verbs -= /obj/item/clothing/accessory/toggleable/flannel/verb/tuck
-		has_suit.verbs -= /obj/item/clothing/accessory/toggleable/flannel/verb/roll_up_sleeves
+	var/obj/item/clothing/suit = loc
+	if(istype(suit))
+		suit.verbs -= /obj/item/clothing/accessory/toggleable/flannel/verb/tuck
+		suit.verbs -= /obj/item/clothing/accessory/toggleable/flannel/verb/roll_up_sleeves
 	..()
 
 /obj/item/clothing/accessory/toggleable/flannel/verb/roll_up_sleeves()

--- a/code/modules/clothing/under/accessories/armband.dm
+++ b/code/modules/clothing/under/accessories/armband.dm
@@ -4,7 +4,8 @@
 	icon = 'icons/clothing/accessories/armbands/armband_security.dmi'
 	slot = ACCESSORY_SLOT_ARMBAND
 	bodytype_restricted = null
-	on_rolled = list("down" = "none")
+	hide_on_uniform_rolldown = TRUE
+	hide_on_uniform_rollsleeves = TRUE
 
 /obj/item/clothing/accessory/armband/cargo
 	name = "cargo armband"

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -11,6 +11,7 @@
 	slot_flags = SLOT_LOWER_BODY | SLOT_TIE
 	slot = ACCESSORY_SLOT_INSIGNIA
 	high_visibility = 1
+	hide_on_uniform_rolldown = TRUE
 	var/badge_string = "Detective"
 	var/stored_name
 

--- a/code/modules/clothing/under/accessories/chaplaininsignia.dm
+++ b/code/modules/clothing/under/accessories/chaplaininsignia.dm
@@ -2,7 +2,7 @@
 	name = "chaplain insignia (christianity)"
 	desc = "An insignia worn by chaplains. The cross represents Christianity."
 	icon = 'icons/clothing/accessories/religious/icon_christianity.dmi'
-	on_rolled = list("down" = "none")
+	hide_on_uniform_rolldown = TRUE
 	slot = ACCESSORY_SLOT_INSIGNIA
 
 /obj/item/clothing/accessory/chaplaininsignia/judaism

--- a/code/modules/clothing/under/accessories/cloaks.dm
+++ b/code/modules/clothing/under/accessories/cloaks.dm
@@ -34,7 +34,7 @@
 		var/image/cloverlay
 
 		var/bodyicon = get_icon_for_bodytype(bodytype)
-		if(user_mob && bodytype != lowertext(user_mob.get_bodytype()))
+		if(user_mob && bodytype != user_mob.get_bodytype())
 			var/mob/living/carbon/human/H = user_mob
 			underlay =  H.species.get_offset_overlay_image(FALSE, bodyicon, "[bodytype]-underlay", color, slot)
 			cloverlay = H.species.get_offset_overlay_image(FALSE, bodyicon, "[bodytype]-overlay", color, slot)

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -34,22 +34,25 @@
 
 /obj/item/clothing/accessory/storage/holster/on_attached(obj/item/clothing/under/S, mob/user)
 	..()
-	has_suit.verbs += /atom/proc/holster_verb
+	var/obj/item/clothing/suit = loc
+	if(istype(suit))
+		suit.verbs += /atom/proc/holster_verb
 
 /obj/item/clothing/accessory/storage/holster/on_removed(mob/user)
-	if(has_suit)
+	var/obj/item/clothing/suit = loc
+	if(istype(suit))
 		var/remove_verb = TRUE
-		if(has_extension(has_suit, /datum/extension/holster))
+		if(has_extension(suit, /datum/extension/holster))
 			remove_verb = FALSE
 
-		for(var/obj/accessory in has_suit.accessories)
+		for(var/obj/accessory in suit.accessories)
 			if(accessory == src)
 				continue
 			if(has_extension(accessory, /datum/extension/holster))
 				remove_verb = FALSE
 
 		if(remove_verb)
-			has_suit.verbs -= /atom/proc/holster_verb
+			suit.verbs -= /atom/proc/holster_verb
 	..()
 
 /obj/item/clothing/accessory/storage/holster/armpit

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -5,7 +5,7 @@
 	slot = ACCESSORY_SLOT_UTILITY
 	w_class = ITEM_SIZE_NORMAL
 	high_visibility = 1
-	on_rolled = list("down" = "none")
+	hide_on_uniform_rolldown = TRUE
 	var/slots = 3
 	var/max_w_class = ITEM_SIZE_SMALL //pocket sized
 	var/obj/item/storage/internal/pockets/hold
@@ -18,7 +18,8 @@
 	hold = new/obj/item/storage/internal/pockets(src, slots, max_w_class)
 
 /obj/item/clothing/accessory/storage/attack_hand(mob/user)
-	if(has_suit && hold)	//if we are part of a suit
+	var/obj/item/clothing/suit = loc
+	if(istype(suit) && hold)	//if we are part of a suit
 		hold.open(user)
 		return
 
@@ -26,7 +27,8 @@
 		..(user)
 
 /obj/item/clothing/accessory/storage/MouseDrop(obj/over_object)
-	if(has_suit)
+	var/obj/item/clothing/suit = loc
+	if(istype(suit))
 		return
 
 	if(hold && hold.handle_mousedrop(usr, over_object))

--- a/code/modules/clothing/under/accessories/ties.dm
+++ b/code/modules/clothing/under/accessories/ties.dm
@@ -45,11 +45,14 @@
 
 /obj/item/clothing/accessory/bowtie/on_attached(obj/item/clothing/under/S, mob/user)
 	..()
-	has_suit.verbs += /obj/item/clothing/accessory/bowtie/verb/toggle
+	var/obj/item/clothing/suit = loc
+	if(istype(suit))
+		suit.verbs += /obj/item/clothing/accessory/bowtie/verb/toggle
 
 /obj/item/clothing/accessory/bowtie/on_removed(mob/user)
-	if(has_suit)
-		has_suit.verbs -= /obj/item/clothing/accessory/bowtie/verb/toggle
+	var/obj/item/clothing/suit = loc
+	if(istype(suit))
+		suit.verbs -= /obj/item/clothing/accessory/bowtie/verb/toggle
 	..()
 
 /obj/item/clothing/accessory/bowtie/verb/toggle()

--- a/mods/species/ascent/ascent.dm
+++ b/mods/species/ascent/ascent.dm
@@ -3,10 +3,10 @@
 #define SPECIES_MANTID_GYNE    "Kharmaan Gyne"
 #define SPECIES_MANTID_NYMPH   "Kharmaan Nymph"
 
-#define BODYTYPE_SNAKE "Snakelike Body"
-#define BODYTYPE_NYMPH	"Small Nymph Body"
-#define BODYTYPE_MANTID_SMALL "Small Mantid Body"
-#define BODYTYPE_MANTID_LARGE "Large Mantid Body"
+#define BODYTYPE_SNAKE "snakelike body"
+#define BODYTYPE_NYMPH	"small nymph body"
+#define BODYTYPE_MANTID_SMALL "small mantid body"
+#define BODYTYPE_MANTID_LARGE "large mantid body"
 
 #define CULTURE_ASCENT           "The Ascent"
 #define HOME_SYSTEM_KHARMAANI    "Core"

--- a/mods/species/neocorvids/_neocorvids.dm
+++ b/mods/species/neocorvids/_neocorvids.dm
@@ -1,5 +1,5 @@
 #define SPECIES_CORVID           "Neo-Corvid"
-#define BODYTYPE_CORVID          "Corvid Body"
+#define BODYTYPE_CORVID          "corvid body"
 #define IS_CORVID                "corvid"
 
 /decl/modpack/neocorvids


### PR DESCRIPTION
- You can now specify `humanoid body-slot_tie-rolled` and `humanoid body-slot_tie-sleeves` states for accessories to use when attached to a uniform.
- Accessories can be set to hide themselves when sleeves are rolled up or uniform is rolled down.
- You can now specify `world-attached` or `inv-attached` for an accessory to have a state to add to the holder item's icon.
- `sprite_sheets` now cooperate with fallback slots (for stuff like accessories).