### PR TITLE
Makes unary atmo machines dump their content into air when deleting

### DIFF
--- a/code/modules/atmospherics/atmospherics.dm
+++ b/code/modules/atmospherics/atmospherics.dm
@@ -181,8 +181,3 @@ obj/machinery/atmospherics/proc/check_connect_types(obj/machinery/atmospherics/a
 		if(!do_after(user, unwrench_time, src))
 			return MCS_BLOCK
 	return ..()
-
-/obj/machinery/atmospherics/explosion_act(var/severity)
-	..()
-	if(!QDELETED(src) && (severity == 1 || (severity == 2 && prob(50))))
-		qdel(src)

--- a/code/modules/atmospherics/components/unary/unary_base.dm
+++ b/code/modules/atmospherics/components/unary/unary_base.dm
@@ -37,6 +37,16 @@
 
 	. = ..()
 
+/obj/machinery/atmospherics/unary/physically_destroyed()
+	if(loc && air_contents)
+		loc.assume_air(air_contents)
+	. = ..()	
+
+/obj/machinery/atmospherics/unary/dismantle()
+	if(loc && air_contents)
+		loc.assume_air(air_contents)
+	. = ..()	
+
 /obj/machinery/atmospherics/unary/atmos_init()
 	..()
 	if(node) return


### PR DESCRIPTION
Makes gas from tanks not disappear into thin air (heh heh)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->

## Changelog
:cl:
tweak: Gas tanks will now dump their content into air when destroyed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
