### PR TITLE
Makes door-turf unit test more flexible

### DIFF
--- a/code/modules/multiz/_stubs.dm
+++ b/code/modules/multiz/_stubs.dm
@@ -5,3 +5,5 @@
 
 	var/height = 1     ///< The number of Z-Levels in the map.
 	var/turf/edge_type ///< What the map edge should be formed with. (null = world.turf)
+
+	VAR_PROTECTED/UT_turf_exceptions_by_door_type // An associate list of door types/list of allowed turfs

--- a/code/modules/multiz/basic.dm
+++ b/code/modules/multiz/basic.dm
@@ -1,5 +1,8 @@
 // If you add a more comprehensive system, just untick this file.
-var/list/z_levels = list()// Each bit re... haha just kidding this is a list of bools now
+var/list/z_levels = list() // Each Z-level is associated with the relevant map data landmark
+
+/proc/get_map_data(z)
+	return z > 0 && z_levels.len >= z ? z_levels[z] : null
 
 // If the height is more than 1, we mark all contained levels as connected.
 // This is in New because it is an auxiliary effect specifically needed pre-init.
@@ -12,14 +15,16 @@ var/list/z_levels = list()// Each bit re... haha just kidding this is a list of 
 	for(var/i = (loc.z - height + 1) to (loc.z-1))
 		if (z_levels.len <i)
 			z_levels.len = i
-		z_levels[i] = TRUE
+		z_levels[i] = src
 
 	if (length(SSzcopy.zstack_maximums))
 		SSzcopy.calculate_zstack_limits()
 
-/obj/effect/landmark/map_data/Initialize()
-	..()
-	return INITIALIZE_HINT_QDEL
+/obj/effect/landmark/map_data/Destroy(forced)
+	if(forced)
+		new type(loc, height) // Will replace our references in z_levels
+		return ..()
+	return QDEL_HINT_LETMELIVE
 
 // Thankfully, no bitwise magic is needed here.
 /proc/GetAbove(var/atom/atom)

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -829,11 +829,16 @@ datum/unit_test/ladder_check/start_test()
 			bad_doors++
 			log_bad("Invalid door turf: [log_info_line(D.loc)]]")
 		else
+			var/list/turf_exceptions
+			var/obj/effect/landmark/map_data/MD = get_map_data(D.loc.z)
+			if(UNLINT(MD?.UT_turf_exceptions_by_door_type))
+				turf_exceptions = UNLINT(MD.UT_turf_exceptions_by_door_type[D.type])
+
 			var/is_bad_door = FALSE
-			for(var/L in D.locs)
-				if(istype(L, /turf/simulated/open) || isspaceturf(L))
+			for(var/turf/T in D.locs)
+				if((istype(T, /turf/simulated/open) || isspaceturf(T)) && !(T.type in turf_exceptions))
 					is_bad_door = TRUE
-					log_bad("Invalid door turf: [log_info_line(L)]]")
+					log_bad("Invalid door turf: [log_info_line(T)]]")
 			if(is_bad_door)
 				bad_doors++
 


### PR DESCRIPTION
Utilizes map data markers allow a per submap setup, instead of globally per map datum