### PR TITLE
Fixes surgery hand bloodying

### DIFF
--- a/code/modules/surgery/_surgery.dm
+++ b/code/modules/surgery/_surgery.dm
@@ -112,9 +112,9 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 	if(ishuman(user) && prob(60))
 		var/mob/living/carbon/human/H = user
 		if (blood_level)
-			H.bloody_hands(target,0)
+			H.bloody_hands(target,2)
 		if (blood_level > 1)
-			H.bloody_body(target,0)
+			H.bloody_body(target,2)
 	if(shock_level)
 		target.shock_stage = max(target.shock_stage, shock_level)
 


### PR DESCRIPTION
It was bloodying hand with 0 amount, which dind't work so hot with coating system changes.

Fixes #1235

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->
