### PR TITLE
Requires mob to be on same tile as rollerbed to buckle

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -250,7 +250,8 @@
 			attach_iv(buckled_mob, usr)
 		return
 	if(ishuman(over_object))
-		if(user_buckle_mob(over_object, usr))
+		var/mob/M = over_object
+		if(loc == M.loc && user_buckle_mob(M, usr))
 			attach_iv(buckled_mob, usr)
 			return
 	if(beaker)


### PR DESCRIPTION
Mostly to prevent annoying self-buckle when trying to fold it. How /do/ you even fold it again?..
Idea stolen from bay PR with same goal, but this version still lets you buckle self, just have to be on top of the roller.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->

## Changelog
:cl:
tweak: Need to be on same tile as rollerbed to buckle to it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
