### PR TITLE
mob_can_equip() cleanup pass. Fixes issues with gloves/magboots.

### DIFF
--- a/code/game/objects/items/devices/auto_cpr.dm
+++ b/code/game/objects/items/devices/auto_cpr.dm
@@ -11,12 +11,8 @@
 
 /obj/item/auto_cpr/mob_can_equip(mob/living/carbon/human/H, slot, disable_warning = 0, force = 0)
 	. = ..()
-	if(force || !istype(H) || slot != slot_wear_suit_str)
-		return
-	if(H.species.get_bodytype() != BODYTYPE_HUMANOID) //non-humanoids btfo
-		return
-	else
-		return FALSE
+	if(. && slot == slot_wear_suit_str)
+		. = H.species.get_bodytype() == BODYTYPE_HUMANOID
 
 /obj/item/auto_cpr/attack(mob/living/carbon/human/M, mob/living/user, var/target_zone)
 	if(istype(M) && user.a_intent == I_HELP)

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -17,7 +17,7 @@
 	return		//make sure this is never picked up
 
 /obj/item/storage/internal/mob_can_equip()
-	return 0	//make sure this is never picked up
+	return FALSE //make sure this is never picked up
 
 //Helper procs to cleanly implement internal storages - storage items that provide inventory slots for other items.
 //These procs are completely optional, it is up to the master item to decide when it's storage get's opened by calling open()

--- a/code/modules/clothing/masks/monitor.dm
+++ b/code/modules/clothing/masks/monitor.dm
@@ -76,12 +76,11 @@
 
 /obj/item/clothing/mask/monitor/mob_can_equip(var/mob/living/carbon/human/user, var/slot)
 	. = ..()
-	if(. && istype(user))
+	if(. && (slot == slot_head_str || slot == slot_wear_mask_str))
 		var/obj/item/organ/external/E = user.organs_by_name[BP_HEAD]
-		if(istype(E) && BP_IS_PROSTHETIC(E))
-			return TRUE
-		to_chat(user, SPAN_WARNING("You must have a synthetic head to install this upgrade."))
-	return FALSE
+		if(!istype(E) || !BP_IS_PROSTHETIC(E))
+			to_chat(user, SPAN_WARNING("You must have a robotic head to install this upgrade."))
+			return FALSE
 
 /obj/item/clothing/mask/monitor/attack_self(mob/user)
 	set_monitor_state()

--- a/code/modules/clothing/rings/_ring.dm
+++ b/code/modules/clothing/rings/_ring.dm
@@ -5,4 +5,4 @@
 	icon_state = ICON_STATE_WORLD
 	slot_flags = SLOT_HANDS
 	gender = NEUTER
-	var/undergloves = 1
+	var/can_fit_under_gloves = TRUE

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -12,15 +12,16 @@
 	permeability_coefficient = 0.50
 	force = 2
 	blood_overlay_type = "shoeblood"
-	var/overshoes = 0
+	material = /decl/material/solid/leather
+	origin_tech = "{'materials':1,'engineering':1}"
+
+	var/can_fit_under_magboots = TRUE
 	var/can_add_cuffs = TRUE
 	var/obj/item/handcuffs/attached_cuffs = null
 	var/can_add_hidden_item = TRUE
 	var/hidden_item_max_w_class = ITEM_SIZE_SMALL
 	var/obj/item/hidden_item = null
 	var/shine = -1 // if material should apply shine overlay. Set to -1 for it to not do that
-	material = /decl/material/solid/leather
-	origin_tech = "{'materials':1,'engineering':1}"
 
 /obj/item/clothing/shoes/Destroy()
 	. = ..()


### PR DESCRIPTION
Gloves and magboots should stop complaining about not being equippable to your inhands now.
This boilerplate really needs to be generalized to /clothing level or something, or ideally replaced with some kind of inventory slot stacking mechanic.