### PR TITLE
Ports panic bunker function from Hestia

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -236,6 +236,9 @@ var/list/gamemode_cache = list()
 	var/max_acts_per_interval = 140 //Number of actions per interval permitted for spam protection.
 	var/act_interval = 0.1 SECONDS //Interval for spam prevention.
 
+	var/panic_bunker = FALSE //is the panic bunker enabled?
+	var/panic_bunker_message = "Sorry! The panic bunker is enabled. Please head to our Discord or forum to get yourself added to the panic bunker bypass."
+
 	var/lock_client_view_x
 	var/lock_client_view_y
 	var/max_client_view_x
@@ -773,6 +776,11 @@ var/list/gamemode_cache = list()
 					config.max_acts_per_interval = text2num(value)
 				if ("act_interval")
 					config.act_interval = text2num(value) SECONDS
+
+				if("panic_bunker")
+					config.panic_bunker = TRUE
+				if("panic_bunker_message")
+					config.panic_bunker_message = value
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -158,7 +158,10 @@ var/list/admin_verbs_server = list(
 	/datum/admins/proc/toggle_aliens,
 	/datum/admins/proc/toggle_space_ninja,
 	/client/proc/toggle_random_events,
-	/client/proc/nanomapgen_DumpImage
+	/client/proc/nanomapgen_DumpImage,
+	/datum/admins/proc/panicbunker,
+	/datum/admins/proc/addbunkerbypass,
+	/datum/admins/proc/revokebunkerbypass
 	)
 var/list/admin_verbs_debug = list(
 	/datum/admins/proc/jump_to_fluid_source,
@@ -293,7 +296,10 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/enable_debug_verbs,
 	/client/proc/roll_dices,
 	/proc/possess,
-	/proc/release
+	/proc/release,
+	/datum/admins/proc/panicbunker,
+	/datum/admins/proc/addbunkerbypass,
+	/datum/admins/proc/revokebunkerbypass
 	)
 var/list/admin_verbs_mod = list(
 	/client/proc/cmd_admin_pm_context,	// right-click adminPM interface,

--- a/code/modules/admin/panicbunker.dm
+++ b/code/modules/admin/panicbunker.dm
@@ -1,0 +1,37 @@
+var/list/panic_bunker_bypass = list()
+
+/datum/admins/proc/panicbunker()
+	set category = "Server"
+	set name = "Toggle Panic Bunker"
+
+	if(!check_rights(R_SERVER))
+		return
+
+	config.panic_bunker = !config.panic_bunker
+
+	log_and_message_admins("[key_name(usr)] has toggled the Panic Bunker, it is now [(config.panic_bunker ? "on" : "off")]")
+	if (config.panic_bunker && (!dbcon || !dbcon.IsConnected()))
+		message_admins("The SQL database is not connected, player age cannot be checked and the panic bunker will not function until the database connection is restored.")
+
+/datum/admins/proc/addbunkerbypass(ckeytobypass as text)
+	set category = "Server"
+	set name = "Add Panic Bunker Bypass"
+	set desc = "Allows a given ckey to connect despite the panic bunker for a given round."
+
+	if(!check_rights(R_SERVER))
+		return
+
+	global.panic_bunker_bypass |= ckey(ckeytobypass)
+
+	log_admin("[key_name(usr)] has added [ckeytobypass] to the current round's bunker bypass list.")
+	message_admins("[key_name_admin(usr)] has added [ckeytobypass] to the current round's bunker bypass list.")
+
+/datum/admins/proc/revokebunkerbypass(ckeytobypass in global.panic_bunker_bypass)
+	set category = "Server"
+	set name = "Revoke Panic Bunker Bypass"
+	set desc = "Revoke's a ckey's permission to bypass the panic bunker for a given round."
+
+	global.panic_bunker_bypass -= ckey(ckeytobypass)
+
+	log_admin("[key_name(usr)] has removed [ckeytobypass] from the current round's bunker bypass list.")
+	message_admins("[key_name_admin(usr)] has removed [ckeytobypass] from the current round's bunker bypass list.")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -325,6 +325,13 @@
 	var/sql_computerid = sql_sanitize_text(src.computer_id)
 	var/sql_admin_rank = sql_sanitize_text(admin_rank)
 
+	if ((player_age <= 0) && !(ckey in global.panic_bunker_bypass)) //first connection
+		if (config.panic_bunker && !holder && !deadmin_holder)
+			log_adminwarn("Failed Login: [key] - New account attempting to connect during panic bunker")
+			message_admins("<span class='adminnotice'>Failed Login: [key] - New account attempting to connect during panic bunker</span>")
+			to_chat(src, config.panic_bunker_message)
+			qdel(src)
+			return 0
 
 	if(sql_id)
 		//Player already identified previously, we need to just update the 'lastseen', 'ip' and 'computer_id' variables

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -426,6 +426,12 @@ RADIATION_LOWER_LIMIT 0.15
 ## Uncomment this to modify the number of actions permitted per interval before being kicked for spam.
 #MAX_ACTS_PER_INTERVAL 140
 
+## Is the panic bunker currently on by default.
+#PANIC_BUNKER
+
+## A message when user did not pass the panic bunker.
+#PANIC_BUNKER_MESSAGE Sorry! The panic bunker is enabled. Please head to our Discord or forum to get yourself added to the panic bunker bypass.
+
 ##Clients will be unable to connect unless their version is equal to or higher than this (a number, e.g. 511)
 #MINIMUM_BYOND_VERSION
 

--- a/nebula.dme
+++ b/nebula.dme
@@ -1319,6 +1319,7 @@
 #include "code\modules\admin\IsBanned.dm"
 #include "code\modules\admin\map_capture.dm"
 #include "code\modules\admin\NewBan.dm"
+#include "code\modules\admin\panicbunker.dm"
 #include "code\modules\admin\persistence.dm"
 #include "code\modules\admin\player_notes.dm"
 #include "code\modules\admin\player_panel.dm"


### PR DESCRIPTION

Adds the panic bunker from Hestia. It lack of SSbabysit which I personally don't like, so I ported only PB since it will be useful for hi-pop servers.

## Changelog
:cl:
rscadd: Added the panic bunker support from Hestia repository. By default, it turned off and can be toggled on in config or manually for a round.
admin: Admins can control the panic bunker state and add/revoke bypass in Server section with R_SERVER flag.
/:cl:
