### PR TITLE
Basic functionality of breath-holding

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -11,6 +11,9 @@
 	var/datum/reagents/metabolism/touching = null
 	var/losebreath = 0 //if we failed to breathe last tick
 
+	var/datum/gas_mixture/breath = null
+	var/last_breath_tick = 0
+
 	var/coughedtime = null
 	var/ignore_rads = FALSE
 	var/cpr_time = 1.0

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -11,6 +11,20 @@
 			visible_message(SPAN_NOTICE("\The [src] [species.sniff_message_3p]."), SPAN_NOTICE(species.sniff_message_1p))
 		LAZYCLEARLIST(smell_cooldown)
 
+/mob/living/carbon/human/verb/hold_breath()
+	set name = "Hold Breath"
+	set desc = "Hold your breath, or stop holding your breath."
+	set category = "IC"
+	set src = usr
+	if(stat == CONSCIOUS)
+		if(!holding_breath)
+			visible_message(SPAN_WARNING("\The [src] starts holding their breath!"), SPAN_WARNING("You start holding your breath!"))
+			holding_breath = 1
+		else
+			visible_message(SPAN_NOTICE("\The [src] starts breathing again."), SPAN_NOTICE("You stop holding your breath."))
+			holding_breath = (holding_breath >= 2 ? 3 : 0)
+		breathe()
+
 /mob/living/carbon/human/proc/tie_hair()
 	set name = "Tie Hair"
 	set desc = "Style your hair."

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -753,7 +753,7 @@ default behaviour is:
 	return TRUE
 
 /mob/living/handle_drowning()
-	if(!can_drown() || !loc.is_flooded(lying))
+	if(!can_drown() || !loc.is_flooded(lying) || holding_breath)
 		return FALSE
 	if(prob(5))
 		var/obj/effect/fluid/F = locate() in loc

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -36,6 +36,7 @@
 	var/fire_stacks
 
 	var/failed_last_breath = 0 //This is used to determine if the mob failed a breath. If they did fail a brath, they will attempt to breathe each tick, otherwise just once per 4 ticks.
+	var/holding_breath = 0 //Used for when the mob is trying to hold their breath. 1 means they need to get a breath, 2 means they're currently holding their breath, 3 means they're going to release their held breath.
 	var/possession_candidate // Can be possessed by ghosts if unplayed.
 
 	var/eye_blind = null	//Carbon


### PR DESCRIPTION
Adds the basic functionality of breath-holding. Currently, a human can hold their breath until they pass out in about 4 minutes and cause significant brain damage to themself.