### PR TITLE
Generalizing surgery to /mob/living.

### DIFF
--- a/code/_helpers/medical_scans.dm
+++ b/code/_helpers/medical_scans.dm
@@ -6,7 +6,7 @@
 	scan["time"] = stationtime2text()
 	var/brain_result
 	if(H.should_have_organ(BP_BRAIN))
-		var/obj/item/organ/internal/brain/brain = H.internal_organs_by_name[BP_BRAIN]
+		var/obj/item/organ/internal/brain/brain = H.get_internal_organ(BP_BRAIN)
 		if(!brain || H.stat == DEAD || (H.status_flags & FAKEDEATH))
 			brain_result = 0
 		else if(H.stat != DEAD)
@@ -17,7 +17,7 @@
 
 	var/pulse_result
 	if(H.should_have_organ(BP_HEART))
-		var/obj/item/organ/internal/heart/heart = H.internal_organs_by_name[BP_HEART]
+		var/obj/item/organ/internal/heart/heart = H.get_internal_organ(BP_HEART)
 		if(!heart)
 			pulse_result = 0
 		else if(BP_IS_PROSTHETIC(heart))

--- a/code/datums/repositories/crew/binary.dm
+++ b/code/datums/repositories/crew/binary.dm
@@ -2,7 +2,7 @@
 /crew_sensor_modifier/binary/process_crew_data(var/mob/living/carbon/human/H, var/obj/item/clothing/under/C, var/turf/pos, var/list/crew_data)
 	crew_data["alert"] = FALSE
 	if(!H.isSynthetic() && H.should_have_organ(BP_HEART))
-		var/obj/item/organ/internal/heart/O = H.internal_organs_by_name[BP_HEART]
+		var/obj/item/organ/internal/heart/O = H.get_internal_organ(BP_HEART)
 		if (!O || !BP_IS_PROSTHETIC(O)) // Don't make medical freak out over prosthetic hearts
 			var/pulse = H.pulse()
 			if(pulse == PULSE_NONE || pulse == PULSE_THREADY)
@@ -10,7 +10,7 @@
 		if(H.get_blood_oxygenation() < BLOOD_VOLUME_SAFE)
 			crew_data["alert"] = TRUE
 	if(H.isSynthetic())
-		var/obj/item/organ/internal/cell/cell = H.internal_organs_by_name[BP_CELL]
+		var/obj/item/organ/internal/cell/cell = H.get_internal_organ(BP_CELL)
 		if(!cell || cell.percent() < 10)
 			crew_data["alert"] = TRUE
 	return ..()

--- a/code/datums/repositories/crew/vital.dm
+++ b/code/datums/repositories/crew/vital.dm
@@ -4,7 +4,7 @@
 	crew_data["pulse"] = "N/A"
 	crew_data["pulse_span"] = "neutral"
 	if(!H.isSynthetic() && H.should_have_organ(BP_HEART))
-		var/obj/item/organ/internal/heart/O = H.internal_organs_by_name[BP_HEART]
+		var/obj/item/organ/internal/heart/O = H.get_internal_organ(BP_HEART)
 		if (!O || !BP_IS_PROSTHETIC(O)) // Don't make medical freak out over prosthetic hearts
 			crew_data["true_pulse"] = H.pulse()
 			crew_data["pulse"] = H.get_pulse(GETPULSE_TOOL)
@@ -24,7 +24,7 @@
 	crew_data["charge"] = "N/A"
 	crew_data["charge_span"] = "N/A"
 	if(H.isSynthetic())
-		var/obj/item/organ/internal/cell/cell = H.internal_organs_by_name[BP_CELL]
+		var/obj/item/organ/internal/cell/cell = H.get_internal_organ(BP_CELL)
 		if(cell)
 			crew_data["charge"] = cell.percent()
 			if(cell.percent() <= 10)

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -5,7 +5,7 @@ var/hadevent    = 0
 /proc/appendicitis()
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.living_mob_list_))
 		if(H.client && H.stat != DEAD)
-			var/obj/item/organ/internal/appendix/A = H.internal_organs_by_name[BP_APPENDIX]
+			var/obj/item/organ/internal/appendix/A = H.get_internal_organ(BP_APPENDIX)
 			if(!istype(A) || (A && A.inflamed))
 				continue
 			A.inflamed = 1

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -13,7 +13,7 @@
 	stat_immune = 0
 
 	var/suppressing = FALSE
-	var/mob/living/carbon/human/victim = null
+	var/mob/living/victim
 	var/strapped = 0.0
 	var/obj/machinery/computer/operating/computer = null
 
@@ -32,7 +32,7 @@
 /obj/machinery/optable/attackby(var/obj/item/O, var/mob/user)
 	if (istype(O, /obj/item/grab))
 		var/obj/item/grab/G = O
-		if(iscarbon(G.affecting) && check_table(G.affecting))
+		if(isliving(G.affecting) && check_table(G.affecting))
 			take_victim(G.affecting,usr)
 			qdel(O)
 			return
@@ -87,42 +87,41 @@
 	if(!victim || !victim.lying || victim.loc != loc)
 		suppressing = FALSE
 		victim = null
-		if(locate(/mob/living/carbon/human) in loc)
-			for(var/mob/living/carbon/human/H in loc)
-				if(H.lying)
-					victim = H
-					break
-	icon_state = (victim && victim.pulse()) ? "table2-active" : "table2-idle"
+		for(var/mob/living/carbon/human/H in loc)
+			if(H.lying)
+				victim = H
+				break
 	if(victim)
 		if(suppressing && victim.sleeping < 3)
 			victim.Sleeping(3 - victim.sleeping)
-		return 1
-	return 0
+	. = !!victim
+	update_icon()
+
+/obj/machinery/optable/on_update_icon()
+	icon_state = "table2-idle"
+	if(ishuman(victim))
+		var/mob/living/carbon/human/H = victim
+		if(H.pulse())
+			icon_state = "table2-active"
 
 /obj/machinery/optable/Process()
 	check_victim()
 
-/obj/machinery/optable/proc/take_victim(mob/living/carbon/C, mob/living/carbon/user)
-	if (C == user)
-		user.visible_message("[user] climbs on \the [src].","You climb on \the [src].")
+/obj/machinery/optable/proc/take_victim(mob/living/target, mob/living/user)
+	if (target == user)
+		user.visible_message( \
+		SPAN_NOTICE("\The [user] climbs on \the [src]."), \
+		SPAN_NOTICE("You climb on \the [src]."))
 	else
-		visible_message("<span class='notice'>\The [C] has been laid on \the [src] by [user].</span>")
-	if (C.client)
-		C.client.perspective = EYE_PERSPECTIVE
-		C.client.eye = src
-	C.resting = 1
-	C.dropInto(loc)
-	src.add_fingerprint(user)
-	if(ishuman(C))
-		var/mob/living/carbon/human/H = C
-		src.victim = H
-		icon_state = H.pulse() ? "table2-active" : "table2-idle"
-	else
-		icon_state = "table2-idle"
+		visible_message(SPAN_NOTICE("\The [target] has been laid on \the [src] by \the [user]."))
+	target.resting = 1
+	target.dropInto(loc)
+	add_fingerprint(user)
+	update_icon()
 
 /obj/machinery/optable/MouseDrop_T(mob/target, mob/user)
 	var/mob/living/M = user
-	if(user.stat || user.restrained() || !iscarbon(target) || !check_table(target))
+	if(user.stat || user.restrained() || !isliving(target) || !check_table(target))
 		return
 	if(istype(M))
 		take_victim(target,user)
@@ -135,7 +134,7 @@
 
 	take_victim(usr,usr)
 
-/obj/machinery/optable/proc/check_table(mob/living/carbon/patient)
+/obj/machinery/optable/proc/check_table(mob/living/patient)
 	check_victim()
 	if(src.victim && get_turf(victim) == get_turf(src) && victim.lying)
 		to_chat(usr, "<span class='warning'>\The [src] is already occupied!</span>")

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -76,7 +76,7 @@
 				flash_time = round(H.getFlashMod() * flash_time)
 				if(flash_time <= 0)
 					return
-				var/obj/item/organ/internal/eyes/E = H.internal_organs_by_name[H.species.vision_organ]
+				var/obj/item/organ/internal/eyes/E = H.get_internal_organ(H.species.vision_organ)
 				if(!E)
 					return
 				if(E.is_bruised() && prob(E.damage + 50))

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -78,7 +78,7 @@
 
 	if(ishuman(occupant))
 		var/mob/living/carbon/human/H = occupant
-		var/obj/item/organ/internal/cell/potato = H.internal_organs_by_name[BP_CELL]
+		var/obj/item/organ/internal/cell/potato = H.get_internal_organ(BP_CELL)
 		if(potato)
 			target = potato.cell
 		if((!target || target.percent() > 95) && istype(H.back,/obj/item/rig))
@@ -199,7 +199,7 @@
 		if(istype(H.back,/obj/item/rig))
 			var/obj/item/rig/R = H.back
 			return R.cell
-		return H.internal_organs_by_name["cell"]
+		return H.get_internal_organ(BP_CELL)
 	return 0
 
 /obj/machinery/recharge_station/proc/go_out()

--- a/code/game/machinery/vitals_monitor.dm
+++ b/code/game/machinery/vitals_monitor.dm
@@ -29,7 +29,7 @@
 		to_chat(user, SPAN_NOTICE("Pulse: [victim.get_pulse(GETPULSE_TOOL)]"))
 
 		var/brain_activity = "none"
-		var/obj/item/organ/internal/brain/brain = victim.internal_organs_by_name[BP_BRAIN]
+		var/obj/item/organ/internal/brain/brain = victim.get_internal_organ(BP_BRAIN)
 		if(istype(brain) && victim.stat != DEAD && !(victim.status_flags & FAKEDEATH))
 			if(user.skill_check(SKILL_MEDICAL, SKILL_BASIC))
 				switch(brain.get_current_damage_threshold())
@@ -44,7 +44,7 @@
 		to_chat(user, SPAN_NOTICE("Brain activity: [brain_activity]"))
 
 		var/breathing = "none"
-		var/obj/item/organ/internal/lungs/lungs = victim.internal_organs_by_name[BP_LUNGS]
+		var/obj/item/organ/internal/lungs/lungs = victim.get_internal_organ(BP_LUNGS)
 		if(istype(lungs) && !(victim.status_flags & FAKEDEATH))
 			if(lungs.breath_fail_ratio < 0.3)
 				breathing = "normal"
@@ -96,7 +96,7 @@
 			overlays += image(icon, icon_state = "pulse_thready")
 			overlays += image(icon, icon_state = "pulse_warning")
 
-	var/obj/item/organ/internal/brain/brain = victim.internal_organs_by_name[BP_BRAIN]
+	var/obj/item/organ/internal/brain/brain = victim.get_internal_organ(BP_BRAIN)
 	if(istype(brain) && victim.stat != DEAD && !(victim.status_flags & FAKEDEATH))
 		switch(brain.get_current_damage_threshold())
 			if(0 to 2)
@@ -109,7 +109,7 @@
 	else
 		overlays += image(icon, icon_state = "brain_warning")
 
-	var/obj/item/organ/internal/lungs/lungs = victim.internal_organs_by_name[BP_LUNGS]
+	var/obj/item/organ/internal/lungs/lungs = victim.get_internal_organ(BP_LUNGS)
 	if(istype(lungs) && !(victim.status_flags & FAKEDEATH))
 		if(lungs.breath_fail_ratio < 0.3)
 			overlays += image(icon, icon_state = "breathing_normal")

--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -58,7 +58,7 @@
 					low_nut_warning("head")
 
 		for(var/bpart in shuffle(H.internal_organs_by_name - BP_BRAIN))
-			var/obj/item/organ/internal/regen_organ = H.internal_organs_by_name[bpart]
+			var/obj/item/organ/internal/regen_organ = H.get_internal_organ(bpart)
 			if(BP_IS_PROSTHETIC(regen_organ))
 				continue
 			if(istype(regen_organ))

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -620,7 +620,7 @@ var/list/slot_flags_enumeration = list(
 
 	if(istype(H))
 
-		var/obj/item/organ/internal/eyes/eyes = H.internal_organs_by_name[BP_EYES]
+		var/obj/item/organ/internal/eyes/eyes = H.get_internal_organ(BP_EYES)
 
 		if(H != user)
 			for(var/mob/O in (viewers(M) - user - M))

--- a/code/game/objects/items/devices/auto_cpr.dm
+++ b/code/game/objects/items/devices/auto_cpr.dm
@@ -61,7 +61,7 @@
 			if(prob(5))
 				E.fracture()
 		else
-			var/obj/item/organ/internal/heart/heart = H.internal_organs_by_name[BP_HEART]
+			var/obj/item/organ/internal/heart/heart = H.get_internal_organ(BP_HEART)
 			if(heart)
 				heart.external_pump = list(world.time, 0.6)
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -83,7 +83,7 @@
 				to_chat(user, "<span class='warning'>You can't find anything on [H] to direct [src] into!</span>")
 				return
 
-			vision = H.internal_organs_by_name[H.species.vision_organ]
+			vision = H.get_internal_organ(H.species.vision_organ)
 			if(!vision)
 				vision = H.species.has_organ[H.species.vision_organ]
 				to_chat(user, "<span class='warning'>\The [H] is missing \his [initial(vision.name)]!</span>")

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -82,7 +82,7 @@
 	// Brain activity.
 	var/brain_result = "normal"
 	if(H.should_have_organ(BP_BRAIN))
-		var/obj/item/organ/internal/brain/brain = H.internal_organs_by_name[BP_BRAIN]
+		var/obj/item/organ/internal/brain/brain = H.get_internal_organ(BP_BRAIN)
 		if(!brain || H.stat == DEAD || (H.status_flags & FAKEDEATH))
 			brain_result = "<span class='scan_danger'>none, patient is braindead</span>"
 		else if(H.stat != DEAD)

--- a/code/game/objects/items/dog_tags.dm
+++ b/code/game/objects/items/dog_tags.dm
@@ -31,4 +31,4 @@
 
 	badge_string = pob
 
-	desc = "[initial(desc)]\nName: [H.real_name] ([H.get_species()])[H.char_branch ? "\nBranch: [H.char_branch.name]" : ""]\nReligion: [religion]\nBlood type: [H.b_type]"
+	desc = "[initial(desc)]\nName: [H.real_name] ([H.get_species_name()])[H.char_branch ? "\nBranch: [H.char_branch.name]" : ""]\nReligion: [religion]\nBlood type: [H.b_type]"

--- a/code/game/objects/items/passport.dm
+++ b/code/game/objects/items/passport.dm
@@ -23,7 +23,7 @@
 	else
 		fingerprint = "N/A"
 
-	info = "\icon[src] [src]:\nName: [H.real_name]\nSpecies: [H.get_species()]\nGender: [gender2text(H.gender)]\nAge: [H.age]\nPlace of Birth: [pob]\nFingerprint: [fingerprint]"
+	info = "\icon[src] [src]:\nName: [H.real_name]\nSpecies: [H.get_species_name()]\nGender: [gender2text(H.gender)]\nAge: [H.age]\nPlace of Birth: [pob]\nFingerprint: [fingerprint]"
 
 /obj/item/passport/attack_self(mob/user)
 	user.visible_message(

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -272,7 +272,7 @@
 /obj/item/shockpaddles/proc/check_blood_level(mob/living/carbon/human/H)
 	if(!H.should_have_organ(BP_HEART))
 		return FALSE
-	var/obj/item/organ/internal/heart/heart = H.internal_organs_by_name[BP_HEART]
+	var/obj/item/organ/internal/heart/heart = H.get_internal_organ(BP_HEART)
 	if(!heart || H.get_blood_volume() < BLOOD_VOLUME_SURVIVE)
 		return TRUE
 	return FALSE
@@ -363,7 +363,7 @@
 	make_announcement("pings, \"Resuscitation successful.\"", "notice")
 	playsound(get_turf(src), 'sound/machines/defib_success.ogg', 50, 0)
 	H.resuscitate()
-	var/obj/item/organ/internal/cell/potato = H.internal_organs_by_name[BP_CELL]
+	var/obj/item/organ/internal/cell/potato = H.get_internal_organ(BP_CELL)
 	if(istype(potato) && potato.cell)
 		var/obj/item/cell/C = potato.cell
 		C.give(chargecost)
@@ -446,7 +446,7 @@
 
 	if(!H.should_have_organ(BP_BRAIN)) return //no brain
 
-	var/obj/item/organ/internal/brain/brain = H.internal_organs_by_name[BP_BRAIN]
+	var/obj/item/organ/internal/brain/brain = H.get_internal_organ(BP_BRAIN)
 	if(!brain) return //no brain
 
 	var/brain_damage = Clamp((deadtime - DEFIB_TIME_LOSS)/(DEFIB_TIME_LIMIT - DEFIB_TIME_LOSS)*brain.max_damage, H.getBrainLoss(), brain.max_damage)

--- a/code/game/objects/items/weapons/implants/implants/imprinting.dm
+++ b/code/game/objects/items/weapons/implants/implants/imprinting.dm
@@ -105,7 +105,7 @@
 /obj/item/implant/imprinting/can_implant(mob/M, mob/user, target_zone)
 	var/mob/living/carbon/human/H = M	
 	if(istype(H))
-		var/obj/item/organ/internal/B = H.internal_organs_by_name[BP_BRAIN]
+		var/obj/item/organ/internal/B = H.get_internal_organ(BP_BRAIN)
 		if(!B || H.isSynthetic())
 			to_chat(user, "<span class='warning'>\The [M] cannot be imprinted.</span>")
 			return FALSE

--- a/code/modules/ZAS/Contaminants.dm
+++ b/code/modules/ZAS/Contaminants.dm
@@ -111,7 +111,7 @@ obj/var/contaminated = 0
 
 
 /mob/living/carbon/human/proc/burn_eyes()
-	var/obj/item/organ/internal/eyes/E = internal_organs_by_name[BP_EYES]
+	var/obj/item/organ/internal/eyes/E = get_internal_organ(BP_EYES)
 	if(E && !E.contaminant_guard)
 		if(prob(20)) to_chat(src, "<span class='danger'>Your eyes burn!</span>")
 		E.damage += 2.5

--- a/code/modules/augment/passive/boost/muscle.dm
+++ b/code/modules/augment/passive/boost/muscle.dm
@@ -17,9 +17,9 @@
 	//1.st Determine where we are and who we should be asking for guidance
 	//we must be second to activate buff
 	if(organ_tag == BP_AUGMENT_L_LEG)
-		other = owner.internal_organs_by_name[BP_AUGMENT_R_LEG]
+		other = owner.get_internal_organ(BP_AUGMENT_R_LEG)
 	else if(organ_tag == BP_AUGMENT_R_LEG)
-		other = owner.internal_organs_by_name[BP_AUGMENT_L_LEG]
+		other = owner.get_internal_organ(BP_AUGMENT_L_LEG)
 	if(other && istype(other))
 		var/datum/skill_buff/augment/muscle/A
 		A = owner.buff_skill(buffs, 0, buffpath)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -294,7 +294,7 @@ var/list/time_prefs_fixed = list()
 			var/status = organ_data[name]
 			if(!status)
 				continue
-			var/obj/item/organ/I = character.internal_organs_by_name[name]
+			var/obj/item/organ/I = character.get_internal_organ(name)
 			if(I)
 				if(status == "assisted")
 					I.mechassist()

--- a/code/modules/events/spontaneous_appendicitis.dm
+++ b/code/modules/events/spontaneous_appendicitis.dm
@@ -1,7 +1,7 @@
 /datum/event/spontaneous_appendicitis/start()
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.living_mob_list_))
 		if(H.client && H.stat != DEAD)
-			var/obj/item/organ/internal/appendix/A = H.internal_organs_by_name[BP_APPENDIX]
+			var/obj/item/organ/internal/appendix/A = H.get_internal_organ(BP_APPENDIX)
 			if(!istype(A) || (A && A.inflamed))
 				continue
 			A.inflamed = 1

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -144,7 +144,7 @@
 	if(!istype(H)) //Invalid input
 		return
 	if(H.Adjacent(get_turf(src))) // Like normal analysers, it can't be used at range.
-		var/obj/item/organ/internal/brain/brain = H.internal_organs_by_name[BP_BRAIN]
+		var/obj/item/organ/internal/brain/brain = H.get_internal_organ(BP_BRAIN)
 		set_pin_data(IC_OUTPUT, 1, (brain && H.stat != DEAD))
 		set_pin_data(IC_OUTPUT, 2, H.get_pulse_as_number())
 		set_pin_data(IC_OUTPUT, 3, (H.stat == 0))
@@ -198,7 +198,7 @@
 	if(H in view(get_turf(src))) // Like medbot's analyzer it can be used in range..
 
 
-		var/obj/item/organ/internal/brain/brain = H.internal_organs_by_name[BP_BRAIN]
+		var/obj/item/organ/internal/brain/brain = H.get_internal_organ(BP_BRAIN)
 		set_pin_data(IC_OUTPUT, 1, (brain && H.stat != DEAD))
 		set_pin_data(IC_OUTPUT, 2, (H.stat == 0))
 		set_pin_data(IC_OUTPUT, 3, damage_to_severity(100 * H.getBruteLoss() / H.maxHealth))

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -482,7 +482,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 		var/dam = (toxicity * removed)
 		if(toxicity_targets_organ && ishuman(M))
 			var/mob/living/carbon/human/H = M
-			var/obj/item/organ/internal/I = H.internal_organs_by_name[toxicity_targets_organ]
+			var/obj/item/organ/internal/I = H.get_internal_organ(toxicity_targets_organ)
 			if(I)
 				var/can_damage = I.max_damage - I.damage
 				if(can_damage > 0)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -397,12 +397,9 @@
 /mob/living/carbon/proc/can_devour(atom/movable/victim)
 	return FALSE
 
-/mob/living/carbon/proc/should_have_organ(var/organ_check)
-	return 0
-
-/mob/living/carbon/proc/can_feel_pain(var/check_organ)
+/mob/living/carbon/can_feel_pain(var/check_organ)
 	if(isSynthetic())
-		return 0
+		return FALSE
 	return !(species && species.species_flags & SPECIES_FLAG_NO_PAIN)
 
 /mob/living/carbon/proc/get_adjusted_metabolism(metabolism)
@@ -479,3 +476,9 @@
 		fluids.trans_to_holder(touching, saturation)
 	if(fluids.total_volume)
 		..()
+
+/mob/living/carbon/get_species()
+	return species
+
+/mob/living/carbon/get_species_name()
+	return species.name

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -4,7 +4,6 @@
 	var/life_tick = 0      // The amount of life ticks that have processed on this mob.
 	var/obj/item/handcuffed = null //Whether or not the mob is handcuffed
 	//Surgery info
-	var/list/surgeries_in_progress
 	//Active emote/pose
 	var/pose = null
 	var/datum/reagents/metabolism/bloodstr = null

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -61,21 +61,21 @@
 
 /mob/living/carbon/human/get_ingested_reagents()
 	if(should_have_organ(BP_STOMACH))
-		var/obj/item/organ/internal/stomach/stomach = internal_organs_by_name[BP_STOMACH]
+		var/obj/item/organ/internal/stomach/stomach = get_internal_organ(BP_STOMACH)
 		if(stomach)
 			return stomach.ingested
 	return touching // Kind of a shitty hack, but makes more sense to me than digesting them.
 
 /mob/living/carbon/human/proc/metabolize_ingested_reagents()
 	if(should_have_organ(BP_STOMACH))
-		var/obj/item/organ/internal/stomach/stomach = internal_organs_by_name[BP_STOMACH]
+		var/obj/item/organ/internal/stomach/stomach = get_internal_organ(BP_STOMACH)
 		if(stomach)
 			stomach.metabolize()
 
 /mob/living/carbon/human/get_fullness()
 	if(!should_have_organ(BP_STOMACH))
 		return ..()
-	var/obj/item/organ/internal/stomach/stomach = internal_organs_by_name[BP_STOMACH]
+	var/obj/item/organ/internal/stomach/stomach = get_internal_organ(BP_STOMACH)
 	if(stomach)
 		return nutrition + (stomach.ingested.total_volume * 10)
 	return 0 //Always hungry, but you can't actually eat. :(
@@ -99,7 +99,7 @@
 				stat("Tank Pressure", internal.air_contents.return_pressure())
 				stat("Distribution Pressure", internal.distribute_pressure)
 
-		var/obj/item/organ/internal/cell/potato = internal_organs_by_name[BP_CELL]
+		var/obj/item/organ/internal/cell/potato = get_internal_organ(BP_CELL)
 		if(potato && potato.cell)
 			stat("Battery charge:", "[potato.get_charge()]/[potato.cell.maxcharge]")
 
@@ -538,7 +538,7 @@
 				if(hasHUD(user, HUD_MEDICAL))
 					to_chat(usr, "<b>Name:</b> [E.get_name()]")
 					to_chat(usr, "<b>Gender:</b> [E.get_sex()]")
-					to_chat(usr, "<b>Species:</b> [E.get_species()]")
+					to_chat(usr, "<b>Species:</b> [E.get_species_name()]")
 					to_chat(usr, "<b>Blood Type:</b> [E.get_bloodtype()]")
 					to_chat(usr, "<b>Details:</b> [E.get_medRecord()]")
 					read = 1
@@ -570,7 +570,7 @@
 /mob/living/carbon/human/eyecheck()
 	var/total_protection = flash_protection
 	if(species.has_organ[species.vision_organ])
-		var/obj/item/organ/internal/eyes/I = internal_organs_by_name[species.vision_organ]
+		var/obj/item/organ/internal/eyes/I = get_internal_organ(species.vision_organ)
 		if(!I?.is_usable())
 			return FLASH_PROTECTION_MAJOR
 		total_protection = I.get_total_protection(flash_protection)
@@ -580,28 +580,28 @@
 
 /mob/living/carbon/human/flash_eyes(var/intensity = FLASH_PROTECTION_MODERATE, override_blindness_check = FALSE, affect_silicon = FALSE, visual = FALSE, type = /obj/screen/fullscreen/flash)
 	if(species.has_organ[species.vision_organ])
-		var/obj/item/organ/internal/eyes/I = internal_organs_by_name[species.vision_organ]
+		var/obj/item/organ/internal/eyes/I = get_internal_organ(species.vision_organ)
 		if(!isnull(I))
 			I.additional_flash_effects(intensity)
 	return ..()
 
 /mob/living/carbon/human/proc/getFlashMod()
 	if(species.vision_organ)
-		var/obj/item/organ/internal/eyes/I = internal_organs_by_name[species.vision_organ]
+		var/obj/item/organ/internal/eyes/I = get_internal_organ(species.vision_organ)
 		if(istype(I))
 			return I.flash_mod
 	return species.flash_mod
 
 /mob/living/carbon/human/proc/getDarkvisionRange()
 	if(species.vision_organ)
-		var/obj/item/organ/internal/eyes/I = internal_organs_by_name[species.vision_organ]
+		var/obj/item/organ/internal/eyes/I = get_internal_organ(species.vision_organ)
 		if(istype(I))
 			return I.darksight_range
 	return species.darksight_range
 
 /mob/living/carbon/human/proc/getDarkvisionTint()
 	if(species.vision_organ)
-		var/obj/item/organ/internal/eyes/I = internal_organs_by_name[species.vision_organ]
+		var/obj/item/organ/internal/eyes/I = get_internal_organ(species.vision_organ)
 		if(istype(I))
 			return I.darksight_tint
 	return species.darksight_tint
@@ -610,7 +610,7 @@
 //Checks that the species has a "head" (brain containing organ) and that hit_zone refers to it.
 /mob/living/carbon/human/proc/headcheck(var/target_zone, var/brain_tag = BP_BRAIN)
 
-	var/obj/item/organ/affecting = internal_organs_by_name[brain_tag]
+	var/obj/item/organ/affecting = get_internal_organ(brain_tag)
 
 	target_zone = check_zone(target_zone, src)
 	if(!affecting || affecting.parent_organ != target_zone)
@@ -636,10 +636,10 @@
 	dna.check_integrity(src)
 	return
 
-/mob/living/carbon/human/get_species()
+/mob/living/carbon/human/get_species_name()
 	if(!species)
 		set_species()
-	return species.name
+	. = ..()
 
 /mob/living/carbon/human/proc/play_xylophone()
 	if(!src.xylophone)
@@ -665,7 +665,7 @@
 
 	Stun(3)
 
-	var/obj/item/organ/internal/stomach/stomach = internal_organs_by_name[BP_STOMACH]
+	var/obj/item/organ/internal/stomach/stomach = get_internal_organ(BP_STOMACH)
 	var/nothing_to_puke = FALSE
 	if(should_have_organ(BP_STOMACH))
 		if(!istype(stomach) || (stomach.ingested.total_volume <= 0 && stomach.contents.len == 0))
@@ -908,11 +908,11 @@
 	..()
 
 /mob/living/carbon/human/proc/is_lung_ruptured()
-	var/obj/item/organ/internal/lungs/L = internal_organs_by_name[BP_LUNGS]
+	var/obj/item/organ/internal/lungs/L = get_internal_organ(BP_LUNGS)
 	return L && L.is_bruised()
 
 /mob/living/carbon/human/proc/rupture_lung()
-	var/obj/item/organ/internal/lungs/L = internal_organs_by_name[BP_LUNGS]
+	var/obj/item/organ/internal/lungs/L = get_internal_organ(BP_LUNGS)
 	if(L)
 		L.rupture()
 
@@ -971,7 +971,7 @@
 				if(!istype(O,/obj/item/implant) && O.w_class > ITEM_SIZE_TINY && prob(5)) //Moving with things stuck in you could be bad.
 					jostle_internal_object(organ, O)
 
-	var/obj/item/organ/internal/stomach/stomach = internal_organs_by_name[BP_STOMACH]
+	var/obj/item/organ/internal/stomach/stomach = get_internal_organ(BP_STOMACH)
 	if(stomach && stomach.contents.len)
 		for(var/obj/item/O in stomach.contents)
 			if((O.edge || O.sharp) && prob(5))
@@ -1344,16 +1344,11 @@
 	..()
 
 /mob/living/carbon/human/has_brain()
-	if(internal_organs_by_name[BP_BRAIN])
-		var/obj/item/organ/internal/brain = internal_organs_by_name[BP_BRAIN]
-		if(brain && istype(brain))
-			return 1
-	return 0
+	. = istype(get_internal_organ(BP_BRAIN), /obj/item/organ/internal)
 
 /mob/living/carbon/human/check_has_eyes()
-	if(internal_organs_by_name[BP_EYES])
-		var/obj/item/organ/internal/eyes = internal_organs_by_name[BP_EYES]
-		. = eyes && eyes.is_usable()
+	var/obj/item/organ/internal/eyes = get_internal_organ(BP_EYES)
+	. = istype(eyes) && eyes.is_usable()
 
 /mob/living/carbon/human/slip(var/slipped_on, stun_duration=8)
 	if((species.check_no_slip(src)) || (shoes && (shoes.item_flags & ITEM_FLAG_NOSLIP)))
@@ -1447,7 +1442,7 @@
 
 // Similar to get_pulse, but returns only integer numbers instead of text.
 /mob/living/carbon/human/proc/get_pulse_as_number()
-	var/obj/item/organ/internal/heart/heart_organ = internal_organs_by_name[BP_HEART]
+	var/obj/item/organ/internal/heart/heart_organ = get_internal_organ(BP_HEART)
 	if(!heart_organ)
 		return 0
 
@@ -1468,7 +1463,7 @@
 
 //generates realistic-ish pulse output based on preset levels as text
 /mob/living/carbon/human/proc/get_pulse(var/method)	//method 0 is for hands, 1 is for machines, more accurate
-	var/obj/item/organ/internal/heart/heart_organ = internal_organs_by_name[BP_HEART]
+	var/obj/item/organ/internal/heart/heart_organ = get_internal_organ(BP_HEART)
 	if(!heart_organ)
 		// No heart, no pulse
 		return "0"
@@ -1484,7 +1479,7 @@
 // output for machines ^	 ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ output for people
 
 /mob/living/carbon/human/proc/pulse()
-	var/obj/item/organ/internal/heart/H = internal_organs_by_name[BP_HEART]
+	var/obj/item/organ/internal/heart/H = get_internal_organ(BP_HEART)
 	return H ? H.pulse : PULSE_NONE
 
 /mob/living/carbon/human/can_devour(atom/movable/victim, var/silent = FALSE)
@@ -1492,7 +1487,7 @@
 	if(!should_have_organ(BP_STOMACH))
 		return ..()
 
-	var/obj/item/organ/internal/stomach/stomach = internal_organs_by_name[BP_STOMACH]
+	var/obj/item/organ/internal/stomach/stomach = get_internal_organ(BP_STOMACH)
 	if(!stomach || !stomach.is_usable())
 		if(!silent)
 			to_chat(src, SPAN_WARNING("Your stomach is not functional!"))
@@ -1511,7 +1506,7 @@
 	. = stomach.get_devour_time(victim) || ..()
 
 /mob/living/carbon/human/move_to_stomach(atom/movable/victim)
-	var/obj/item/organ/internal/stomach/stomach = internal_organs_by_name[BP_STOMACH]
+	var/obj/item/organ/internal/stomach/stomach = get_internal_organ(BP_STOMACH)
 	if(istype(stomach))
 		victim.forceMove(stomach)
 
@@ -1538,7 +1533,7 @@
 
 /mob/living/carbon/human/get_breath_volume()
 	. = ..()
-	var/obj/item/organ/internal/heart/H = internal_organs_by_name[BP_HEART]
+	var/obj/item/organ/internal/heart/H = get_internal_organ(BP_HEART)
 	if(H && !H.open)
 		. *= (!BP_IS_PROSTHETIC(H)) ? pulse()/PULSE_NORM : 1.5
 
@@ -1610,12 +1605,12 @@
 /mob/living/carbon/human/proc/resuscitate()
 	if(!is_asystole() || !should_have_organ(BP_HEART))
 		return
-	var/obj/item/organ/internal/heart/heart = internal_organs_by_name[BP_HEART]
+	var/obj/item/organ/internal/heart/heart = get_internal_organ(BP_HEART)
 	if(istype(heart) && !(heart.status & ORGAN_DEAD))
 		var/species_organ = species.breathing_organ
 		var/active_breaths = 0
 		if(species_organ)
-			var/obj/item/organ/internal/lungs/L = internal_organs_by_name[species_organ]
+			var/obj/item/organ/internal/lungs/L = get_internal_organ(species_organ)
 			if(L)
 				active_breaths = L.active_breathing
 		if(!nervous_system_failure() && active_breaths)
@@ -1683,7 +1678,7 @@
 	if(istype(T) && T.is_flooded(lying) && should_have_organ(BP_LUNGS))
 		var/can_breathe_water = (istype(wear_mask) && wear_mask.filters_water()) ? TRUE : FALSE
 		if(!can_breathe_water)
-			var/obj/item/organ/internal/lungs/lungs = internal_organs_by_name[BP_LUNGS]
+			var/obj/item/organ/internal/lungs/lungs = get_internal_organ(BP_LUNGS)
 			if(lungs && lungs.can_drown())
 				can_breathe_water = TRUE
 		if(can_breathe_water)
@@ -1725,7 +1720,7 @@
 /mob/living/carbon/human/handle_additional_vomit_reagents(var/obj/effect/decal/cleanable/vomit/vomit)
 	..()
 	if(should_have_organ(BP_STOMACH))
-		var/obj/item/organ/internal/stomach/stomach = internal_organs_by_name[BP_STOMACH]
+		var/obj/item/organ/internal/stomach/stomach = get_internal_organ(BP_STOMACH)
 		if(!stomach || stomach.is_broken() || (stomach.is_bruised() && prob(stomach.damage)))
 			if(should_have_organ(BP_HEART))
 				vessel.trans_to_obj(vomit, 5)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -69,7 +69,7 @@
 						if(chest)
 							chest.fracture()
 
-					var/obj/item/organ/internal/heart/heart = internal_organs_by_name[BP_HEART]
+					var/obj/item/organ/internal/heart/heart = get_internal_organ(BP_HEART)
 					if(heart)
 						heart.external_pump = list(world.time, 0.4 + 0.1*pumping_skill + rand(-0.1,0.1))
 
@@ -88,12 +88,12 @@
 				if((head && (head.body_parts_covered & SLOT_FACE)) || (wear_mask && (wear_mask.body_parts_covered & SLOT_FACE)))
 					to_chat(H, "<span class='warning'>You need to remove \the [src]'s mouth covering for mouth-to-mouth resuscitation!</span>")
 					return TRUE
-				if (!H.internal_organs_by_name[H.species.breathing_organ])
+				if (!H.get_internal_organ(H.species.breathing_organ))
 					to_chat(H, "<span class='danger'>You need lungs for mouth-to-mouth resuscitation!</span>")
 					return TRUE
 				if(!need_breathe())
 					return TRUE
-				var/obj/item/organ/internal/lungs/L = internal_organs_by_name[species.breathing_organ]
+				var/obj/item/organ/internal/lungs/L = get_internal_organ(species.breathing_organ)
 				if(L)
 					var/datum/gas_mixture/breath = H.get_breath_from_environment()
 					var/fail = L.handle_breath(breath, 1)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -16,14 +16,14 @@
 /mob/living/carbon/human/adjustBrainLoss(var/amount)
 	if(status_flags & GODMODE)	return 0	//godmode
 	if(should_have_organ(BP_BRAIN))
-		var/obj/item/organ/internal/brain/sponge = internal_organs_by_name[BP_BRAIN]
+		var/obj/item/organ/internal/brain/sponge = get_internal_organ(BP_BRAIN)
 		if(sponge)
 			sponge.take_internal_damage(amount)
 
 /mob/living/carbon/human/setBrainLoss(var/amount)
 	if(status_flags & GODMODE)	return 0	//godmode
 	if(should_have_organ(BP_BRAIN))
-		var/obj/item/organ/internal/brain/sponge = internal_organs_by_name[BP_BRAIN]
+		var/obj/item/organ/internal/brain/sponge = get_internal_organ(BP_BRAIN)
 		if(sponge)
 			sponge.damage = min(max(amount, 0),sponge.species.total_health)
 			updatehealth()
@@ -31,7 +31,7 @@
 /mob/living/carbon/human/getBrainLoss()
 	if(status_flags & GODMODE)	return 0	//godmode
 	if(should_have_organ(BP_BRAIN))
-		var/obj/item/organ/internal/brain/sponge = internal_organs_by_name[BP_BRAIN]
+		var/obj/item/organ/internal/brain/sponge = get_internal_organ(BP_BRAIN)
 		if(sponge)
 			if(sponge.status & ORGAN_DEAD)
 				return sponge.species.total_health
@@ -144,7 +144,7 @@
 	if(!need_breathe())
 		return 0
 	else
-		var/obj/item/organ/internal/lungs/breathe_organ = internal_organs_by_name[species.breathing_organ]
+		var/obj/item/organ/internal/lungs/breathe_organ = get_internal_organ(species.breathing_organ)
 		if(!breathe_organ)
 			return maxHealth/2
 		return breathe_organ.get_oxygen_deprivation()
@@ -159,7 +159,7 @@
 	if(!need_breathe())
 		return
 	var/heal = amount < 0
-	var/obj/item/organ/internal/lungs/breathe_organ = internal_organs_by_name[species.breathing_organ]
+	var/obj/item/organ/internal/lungs/breathe_organ = get_internal_organ(species.breathing_organ)
 	if(breathe_organ)
 		if(heal)
 			breathe_organ.remove_oxygen_deprivation(abs(amount))
@@ -196,18 +196,18 @@
 	var/list/pick_organs = shuffle(internal_organs.Copy())
 
 	// Prioritize damaging our filtration organs first.
-	var/obj/item/organ/internal/kidneys/kidneys = internal_organs_by_name[BP_KIDNEYS]
+	var/obj/item/organ/internal/kidneys/kidneys = get_internal_organ(BP_KIDNEYS)
 	if(kidneys)
 		pick_organs -= kidneys
 		pick_organs.Insert(1, kidneys)
-	var/obj/item/organ/internal/liver/liver = internal_organs_by_name[BP_LIVER]
+	var/obj/item/organ/internal/liver/liver = get_internal_organ(BP_LIVER)
 	if(liver)
 		pick_organs -= liver
 		pick_organs.Insert(1, liver)
 
 	// Move the brain to the very end since damage to it is vastly more dangerous
 	// (and isn't technically counted as toxloss) than general organ damage.
-	var/obj/item/organ/internal/brain/brain = internal_organs_by_name[BP_BRAIN]
+	var/obj/item/organ/internal/brain/brain = get_internal_organ(BP_BRAIN)
 	if(brain)
 		pick_organs -= brain
 		pick_organs += brain
@@ -368,6 +368,12 @@ This function restores all organs.
 
 /mob/living/carbon/human/get_organ(var/zone)
 	return organs_by_name[check_zone(zone, src, base_zone_only = TRUE)]
+
+/mob/living/carbon/human/get_internal_organs()
+	return internal_organs
+
+/mob/living/carbon/human/get_internal_organ(var/organ_tag)
+	return internal_organs_by_name[organ_tag]
 
 /mob/living/carbon/human/apply_damage(var/damage = 0, var/damagetype = BRUTE, var/def_zone = null, var/damage_flags = 0, var/obj/used_weapon = null, var/armor_pen, var/silent = FALSE, var/obj/item/organ/external/given_organ = null)
 

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -221,7 +221,7 @@
 	return istype(get_equipped_item(slot_l_ear_str), /obj/item/radio/headset) || istype(get_equipped_item(slot_r_ear_str), /obj/item/radio/headset)
 
 /mob/living/carbon/human/welding_eyecheck()
-	var/obj/item/organ/internal/eyes/E = src.internal_organs_by_name[species.vision_organ]
+	var/obj/item/organ/internal/eyes/E = src.get_internal_organ(species.vision_organ)
 	if(!E)
 		return
 	var/safety = eyecheck()

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/human/proc/update_eyes()
-	var/obj/item/organ/internal/eyes/eyes = internal_organs_by_name[species.vision_organ ? species.vision_organ : BP_EYES]
+	var/obj/item/organ/internal/eyes/eyes = get_internal_organ(species.vision_organ || BP_EYES)
 	if(eyes)
 		eyes.update_colour()
 		regenerate_icons()
@@ -231,12 +231,12 @@
 
 /mob/living/carbon/human/is_asystole()
 	if(isSynthetic())
-		var/obj/item/organ/internal/cell/C = internal_organs_by_name[BP_CELL]
+		var/obj/item/organ/internal/cell/C = get_internal_organ(BP_CELL)
 		if(istype(C))
 			if(!C.is_usable() || !C.percent())
 				return TRUE
 	else if(should_have_organ(BP_HEART))
-		var/obj/item/organ/internal/heart/heart = internal_organs_by_name[BP_HEART]
+		var/obj/item/organ/internal/heart/heart = get_internal_organ(BP_HEART)
 		if(!istype(heart) || !heart.is_working())
 			return TRUE
 	return FALSE

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -19,7 +19,7 @@
 
 	adjustOxyLoss(maxHealth)//cease life functions
 	setBrainLoss(maxHealth)
-	var/obj/item/organ/internal/heart/corpse_heart = internal_organs_by_name[BP_HEART]
+	var/obj/item/organ/internal/heart/corpse_heart = get_internal_organ(BP_HEART)
 	if(corpse_heart)
 		corpse_heart.pulse = PULSE_NONE//actually stops heart to make worried explorers not care too much
 	if(corpse)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -127,7 +127,7 @@
 
 	if(species_organ)
 		var/active_breaths = 0
-		var/obj/item/organ/internal/lungs/L = internal_organs_by_name[species_organ]
+		var/obj/item/organ/internal/lungs/L = get_internal_organ(species_organ)
 		if(L)
 			active_breaths = L.active_breathing
 		..(active_breaths)
@@ -183,7 +183,7 @@
 	//Vision
 	var/obj/item/organ/vision
 	if(species.vision_organ)
-		vision = internal_organs_by_name[species.vision_organ]
+		vision = get_internal_organ(species.vision_organ)
 
 	if(!species.vision_organ) // Presumably if a species has no vision organs, they see via some other means.
 		eye_blind =  0
@@ -304,7 +304,7 @@
 	if(!species_organ)
 		return
 
-	var/obj/item/organ/internal/lungs/L = internal_organs_by_name[species_organ]
+	var/obj/item/organ/internal/lungs/L = get_internal_organ(species_organ)
 	if(!L || nervous_system_failure())
 		failed_last_breath = 1
 	else
@@ -553,7 +553,7 @@
 // Check if we should die.
 /mob/living/carbon/human/proc/handle_death_check()
 	if(should_have_organ(BP_BRAIN))
-		var/obj/item/organ/internal/brain/brain = internal_organs_by_name[BP_BRAIN]
+		var/obj/item/organ/internal/brain/brain = get_internal_organ(BP_BRAIN)
 		if(!brain || (brain.status & ORGAN_DEAD))
 			return TRUE
 	return species.handle_death_check(src)
@@ -772,7 +772,7 @@
 				else							hydration_icon.icon_state = "hydration4"
 
 		if(isSynthetic())
-			var/obj/item/organ/internal/cell/C = internal_organs_by_name[BP_CELL]
+			var/obj/item/organ/internal/cell/C = get_internal_organ(BP_CELL)
 			if (istype(C))
 				var/chargeNum = Clamp(ceil(C.percent()/25), 0, 4)	//0-100 maps to 0-4, but give it a paranoid clamp just in case.
 				cells.icon_state = "charge[chargeNum]"
@@ -840,7 +840,7 @@
 	// Puke if toxloss is too high
 	var/vomit_score = 0
 	for(var/tag in list(BP_LIVER,BP_KIDNEYS))
-		var/obj/item/organ/internal/I = internal_organs_by_name[tag]
+		var/obj/item/organ/internal/I = get_internal_organ(tag)
 		if(I)
 			vomit_score += I.damage
 		else if (should_have_organ(tag))

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -26,7 +26,7 @@
 	var/obj/item/organ/internal/voicebox/voice = locate() in internal_organs
 	var/snowflake_speak = (speaking && (speaking.flags & (NONVERBAL|SIGNLANG))) || (voice && voice.is_usable() && voice.assists_languages[speaking])
 	if(!isSynthetic() && need_breathe() && failed_last_breath && !snowflake_speak)
-		var/obj/item/organ/internal/lungs/L = internal_organs_by_name[species.breathing_organ]
+		var/obj/item/organ/internal/lungs/L = get_internal_organ(species.breathing_organ)
 		if(!L || L.breath_fail_ratio > 0.9)
 			if(L && world.time < L.last_successful_breath + 2 MINUTES) //if we're in grace suffocation period, give it up for last words
 				to_chat(src, "<span class='warning'>You use your remaining air to say something!</span>")

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -133,7 +133,7 @@ var/global/list/sparring_attack_cache = list()
 		playsound(user.loc, attack_sound, 25, 1, -1)
 
 /decl/natural_attack/proc/handle_eye_attack(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target)
-	var/obj/item/organ/internal/eyes/eyes = target.internal_organs_by_name[BP_EYES]
+	var/obj/item/organ/internal/eyes/eyes = target.get_internal_organ(BP_EYES)
 	if(eyes)
 		eyes.take_internal_damage(rand(3,4), 1)
 		user.visible_message("<span class='danger'>[user] presses \his [eye_attack_text] into [target]'s [eyes.name]!</span>")

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -265,7 +265,7 @@ var/global/list/damage_icon_parts = list()
 		queue_icon_update()
 
 //BASE MOB SPRITE
-/mob/living/carbon/human/proc/update_body(var/update_icons=1)
+/mob/living/carbon/human/update_body(var/update_icons=1)
 	var/husk_color_mod = rgb(96,88,80)
 	var/hulk_color_mod = rgb(48,224,40)
 
@@ -291,7 +291,7 @@ var/global/list/damage_icon_parts = list()
 		icon_key += "[lip_style]"
 	else
 		icon_key += "nolips"
-	var/obj/item/organ/internal/eyes/eyes = internal_organs_by_name[species.vision_organ ? species.vision_organ : BP_EYES]
+	var/obj/item/organ/internal/eyes/eyes = get_internal_organ(species.vision_organ || BP_EYES)
 	icon_key += istype(eyes) ? eyes.eye_colour : COLOR_BLACK
 
 	for(var/organ_tag in species.has_limbs)
@@ -375,9 +375,7 @@ var/global/list/damage_icon_parts = list()
 
 	//tail
 	update_tail_showing(0)
-
-	if(update_icons)
-		queue_icon_update()
+	..()
 
 //UNDERWEAR OVERLAY
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -179,6 +179,10 @@ default behaviour is:
 		updatehealth()
 		to_chat(src, "<span class='notice'>You have given up life and succumbed to death.</span>")
 
+/mob/living/proc/update_body(var/update_icons=1)
+	if(update_icons)
+		queue_icon_update()
+
 /mob/living/proc/updatehealth()
 	if(status_flags & GODMODE)
 		health = 100
@@ -475,7 +479,7 @@ default behaviour is:
 /mob/living/carbon/basic_revival(var/repair_brain = TRUE)
 	if(repair_brain && should_have_organ(BP_BRAIN))
 		repair_brain = FALSE
-		var/obj/item/organ/internal/brain/brain = internal_organs_by_name[BP_BRAIN]
+		var/obj/item/organ/internal/brain/brain = get_internal_organ(BP_BRAIN)
 		if(brain.damage > (brain.max_damage/2))
 			brain.damage = (brain.max_damage/2)
 		if(brain.status & ORGAN_DEAD)
@@ -866,3 +870,9 @@ default behaviour is:
 
 /mob/living/proc/get_ingested_reagents()
 	return reagents
+
+/mob/living/proc/get_species()
+	return
+
+/mob/living/proc/should_have_organ(var/organ_check)
+	return FALSE

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -51,3 +51,5 @@
 
 	var/list/chem_effects
 	var/list/chem_doses
+	var/last_pain_message
+	var/next_pain_time = 0

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -74,7 +74,7 @@
 			var/mob/living/carbon/human/H = M
 			to_chat(user, "<span class='notice'>Analyzing Results for \the [H]:</span>")
 			to_chat(user, "Key: <font color='#ffa500'>Electronics</font>/<font color='red'>Brute</font>")
-			var/obj/item/organ/internal/cell/C = H.internal_organs_by_name[BP_CELL]
+			var/obj/item/organ/internal/cell/C = H.get_internal_organ(BP_CELL)
 			if(C)
 				to_chat(user, SPAN_NOTICE("Cell charge: [C.percent()] %"))
 			else

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -733,7 +733,7 @@
 	resting = max(resting + amount,0)
 	return
 
-/mob/proc/get_species()
+/mob/proc/get_species_name()
 	return ""
 
 /mob/proc/get_visible_implants(var/class = 0)

--- a/code/modules/mob/mob_grabs.dm
+++ b/code/modules/mob/mob_grabs.dm
@@ -11,6 +11,10 @@
 /mob/proc/get_organ(var/zone)
 	return
 // End grab casting stubs.
+/mob/proc/get_internal_organ(var/organ_tag)
+	return
+/mob/proc/get_internal_organs()
+	return
 
 /mob/can_be_grabbed(var/mob/grabber, var/target_zone)
 	if(!grabber.can_pull_mobs)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -622,7 +622,7 @@ var/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HURT)
 	return //Only for living/carbon/human/
 
 /mob/living/carbon/human/jittery_damage()
-	var/obj/item/organ/internal/heart/L = internal_organs_by_name[BP_HEART]
+	var/obj/item/organ/internal/heart/L = get_internal_organ(BP_HEART)
 	if(!istype(L))
 		return 0
 	if(BP_IS_PROSTHETIC(L))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -430,7 +430,7 @@
 			return null
 		new_character = new(spawn_turf, chosen_species.name)
 		if(chosen_species.has_organ[BP_POSIBRAIN] && client && client.prefs.is_shackled)
-			var/obj/item/organ/internal/posibrain/B = new_character.internal_organs_by_name[BP_POSIBRAIN]
+			var/obj/item/organ/internal/posibrain/B = new_character.get_internal_organ(BP_POSIBRAIN)
 			if(B)	B.shackle(client.prefs.get_lawset())
 
 	if(!new_character)
@@ -503,14 +503,12 @@
 		return 0
 	return 1
 
-/mob/new_player/get_species()
+/mob/new_player/get_species_name()
 	var/decl/species/chosen_species
 	if(client.prefs.species)
 		chosen_species = get_species_by_key(client.prefs.species)
-
 	if(!chosen_species || !check_species_allowed(chosen_species, 0))
 		return GLOB.using_map.default_species
-
 	return chosen_species.name
 
 /mob/new_player/get_gender()

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -91,7 +91,7 @@ GLOBAL_VAR_INIT(arrest_security_status, "Arrest")
 	set_sex(gender_term)
 	set_age(H ? H.age : 30)
 	set_status(GLOB.default_physical_status)
-	set_species(H ? H.get_species() : GLOB.using_map.default_species)
+	set_species_name(H ? H.get_species_name() : GLOB.using_map.default_species)
 	set_branch(H ? (H.char_branch && H.char_branch.name) : "None")
 	set_rank(H ? (H.char_rank && H.char_rank.name) : "None")
 	set_public_record(H && H.public_record && !jobban_isbanned(H, "Records") ? html_decode(H.public_record) : "No record supplied")
@@ -176,7 +176,7 @@ GLOBAL_VAR_INIT(arrest_security_status, "Arrest")
 		silicon_type = "AI"
 		robojob = "Artificial Intelligence"
 	set_job(S ? robojob : "Unset")
-	set_species(silicon_type)
+	set_species_name(silicon_type)
 
 	set_implants("Robotic body")
 
@@ -261,7 +261,7 @@ FIELD_LIST("Sex", sex, record_genders(), null, access_change_ids)
 FIELD_NUM("Age", age, null, access_change_ids)
 FIELD_LIST_EDIT("Status", status, GLOB.physical_statuses, null, access_medical)
 
-FIELD_SHORT("Species",species, null, access_change_ids)
+FIELD_SHORT("Species",species_name, null, access_change_ids)
 FIELD_LIST("Branch", branch, record_branches(), null, access_change_ids)
 FIELD_LIST("Rank", rank, record_ranks(), null, access_change_ids)
 FIELD_SHORT("Religion", religion, access_chapel_office, access_change_ids)

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -262,7 +262,7 @@ proc/blood_splatter(var/target, var/source, var/large, var/spray_dir)
 
 //Percentage of maximum blood volume, affected by the condition of circulation organs
 /mob/living/carbon/human/proc/get_blood_circulation()
-	var/obj/item/organ/internal/heart/heart = internal_organs_by_name[BP_HEART]
+	var/obj/item/organ/internal/heart/heart = get_internal_organ(BP_HEART)
 	var/blood_volume = get_blood_volume()
 	if(!heart)
 		return 0.25 * blood_volume

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1209,9 +1209,8 @@ obj/item/organ/external/proc/remove_clamps()
 					if(thing.vital || BP_IS_PROSTHETIC(thing))
 						continue
 					internal_organs -= thing
-					owner.internal_organs_by_name[thing.organ_tag] = null
+					owner.internal_organs -= thing
 					owner.internal_organs_by_name -= thing.organ_tag
-					owner.internal_organs.Remove(thing)
 					qdel(thing)
 
 		while(null in owner.internal_organs)

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -323,7 +323,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 	return FALSE
 
 /obj/item/organ/external/proc/get_brute_mod(var/damage_flags)
-	var/obj/item/organ/internal/augment/armor/A = owner && owner.internal_organs_by_name[BP_AUGMENT_CHEST_ARMOUR]
+	var/obj/item/organ/internal/augment/armor/A = owner && owner.get_internal_organ(BP_AUGMENT_CHEST_ARMOUR)
 	var/B = 1
 	if(A && istype(A))
 		B = A.brute_mult
@@ -337,7 +337,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 	return B + (0.2 * burn_dam/max_damage) //burns make you take more brute damage
 
 /obj/item/organ/external/proc/get_burn_mod(var/damage_flags)
-	var/obj/item/organ/internal/augment/armor/A = owner && owner.internal_organs_by_name[BP_AUGMENT_CHEST_ARMOUR]
+	var/obj/item/organ/internal/augment/armor/A = owner && owner.get_internal_organ(BP_AUGMENT_CHEST_ARMOUR)
 	var/B = 1
 	if(A && istype(A))
 		B = A.burn_mult

--- a/code/modules/organs/external/_external_icons.dm
+++ b/code/modules/organs/external/_external_icons.dm
@@ -50,7 +50,7 @@ var/list/limb_icon_cache = list()
 
 /obj/item/organ/external/head/sync_colour_to_human(var/mob/living/carbon/human/human)
 	..()
-	var/obj/item/organ/internal/eyes/eyes = owner.internal_organs_by_name[BP_EYES]
+	var/obj/item/organ/internal/eyes/eyes = owner.get_internal_organ(BP_EYES)
 	if(eyes) eyes.update_colour()
 
 /obj/item/organ/external/head/removed()

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -26,12 +26,12 @@
 
 /obj/item/organ/external/head/proc/get_eye_overlay()
 	if(glowing_eyes || owner?.has_chemical_effect(CE_GLOWINGEYES, 1))
-		var/obj/item/organ/internal/eyes/eyes = owner.internal_organs_by_name[owner.species.vision_organ ? owner.species.vision_organ : BP_EYES]
+		var/obj/item/organ/internal/eyes/eyes = owner.get_internal_organ(owner.species.vision_organ || BP_EYES)
 		if(eyes)
 			return eyes.get_special_overlay()
 
 /obj/item/organ/external/head/proc/get_eyes()
-	var/obj/item/organ/internal/eyes/eyes = owner.internal_organs_by_name[owner.species.vision_organ ? owner.species.vision_organ : BP_EYES]
+	var/obj/item/organ/internal/eyes/eyes = owner.get_internal_organ(owner.species.vision_organ || BP_EYES)
 	if(eyes)
 		return eyes.get_onhead_icon()
 

--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -29,7 +29,7 @@
 /obj/item/organ/external/chest/robotize(var/company, var/skip_prosthetics, var/keep_organs, var/apply_material = /decl/material/solid/metal/steel)
 	if(..())
 		// Give them a new cell.
-		var/obj/item/organ/internal/cell/C = owner.internal_organs_by_name[BP_CELL]
+		var/obj/item/organ/internal/cell/C = owner.get_internal_organ(BP_CELL)
 		if(!istype(C))
 			owner.internal_organs_by_name[BP_CELL] = new /obj/item/organ/internal/cell(owner,1)
 

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -28,8 +28,7 @@
 
 /obj/item/organ/internal/Destroy()
 	if(owner)
-		owner.internal_organs.Remove(src)
-		owner.internal_organs_by_name[organ_tag] = null
+		owner.internal_organs -= src
 		owner.internal_organs_by_name -= organ_tag
 		while(null in owner.internal_organs)
 			owner.internal_organs -= null
@@ -52,11 +51,9 @@
 
 /obj/item/organ/internal/removed(var/mob/living/user, var/drop_organ=1, var/detach=1)
 	if(owner)
-		owner.internal_organs_by_name[organ_tag] = null
-		owner.internal_organs_by_name -= organ_tag
-		owner.internal_organs_by_name -= null
-		var/obj/item/organ/external/E = owner.get_organ(parent_organ)
 		owner.internal_organs -= src
+		owner.internal_organs_by_name -= organ_tag
+		var/obj/item/organ/external/E = owner.get_organ(parent_organ)
 		E.update_internal_organs_cost()
 
 		if(detach)
@@ -94,7 +91,6 @@
 /obj/item/organ/internal/remove_rejuv()
 	if(owner)
 		owner.internal_organs -= src
-		owner.internal_organs_by_name[organ_tag] = null
 		owner.internal_organs_by_name -= organ_tag
 		while(null in owner.internal_organs)
 			owner.internal_organs -= null

--- a/code/modules/reagents/chems/chems_ethanol.dm
+++ b/code/modules/reagents/chems/chems_ethanol.dm
@@ -384,7 +384,7 @@
 		M.adjustToxLoss(2 * removed)
 	if(dose > 60 && ishuman(M) && prob(5))
 		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/internal/heart/L = H.internal_organs_by_name[BP_HEART]
+		var/obj/item/organ/internal/heart/L = H.get_internal_organ(BP_HEART)
 		if (L && istype(L))
 			if(dose < 120)
 				L.take_internal_damage(10 * removed, 0)

--- a/code/modules/reagents/chems/chems_medicines.dm
+++ b/code/modules/reagents/chems/chems_medicines.dm
@@ -11,7 +11,7 @@
 /decl/material/liquid/eyedrops/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/internal/eyes/E = H.internal_organs_by_name[BP_EYES]
+		var/obj/item/organ/internal/eyes/E = H.get_internal_organ(BP_EYES)
 		if(E && istype(E) && !E.is_broken())
 			M.eye_blurry = max(M.eye_blurry - 5, 0)
 			M.eye_blind = max(M.eye_blind - 5, 0)
@@ -276,7 +276,7 @@
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(H.resuscitate())
-				var/obj/item/organ/internal/heart = H.internal_organs_by_name[BP_HEART]
+				var/obj/item/organ/internal/heart = H.get_internal_organ(BP_HEART)
 				heart.take_internal_damage(heart.max_damage * 0.15)
 
 /decl/material/liquid/stabilizer

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -194,8 +194,8 @@
 		BP_APPENDIX = /obj/item/organ/internal/appendix,
 		BP_EYES =     /obj/item/organ/internal/eyes
 		)
-	var/vision_organ              // If set, this organ is required for vision. Defaults to "eyes" if the species has them.
-	var/breathing_organ           // If set, this organ is required for breathing. Defaults to "lungs" if the species has them.
+	var/vision_organ              // If set, this organ is required for vision.
+	var/breathing_organ           // If set, this organ is required for breathing.
 
 	var/list/override_organ_types // Used for species that only need to change one or two entries in has_organ.
 
@@ -417,7 +417,7 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 		H.organs |= H.organs_by_name[name]
 
 	for(var/name in H.internal_organs_by_name)
-		H.internal_organs |= H.internal_organs_by_name[name]
+		H.internal_organs |= H.get_internal_organ(name)
 
 	for(var/obj/item/organ/O in (H.organs|H.internal_organs))
 		O.owner = H

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -399,7 +399,7 @@
 		env.merge(removed)
 
 	for(var/mob/living/carbon/human/subject in view(src, min(7, round(sqrt(power/6)))))
-		var/obj/item/organ/internal/eyes/eyes = subject.internal_organs_by_name[BP_EYES]
+		var/obj/item/organ/internal/eyes/eyes = subject.get_internal_organ(BP_EYES)
 		if (!eyes)
 			continue
 		if (BP_IS_PROSTHETIC(eyes))

--- a/code/modules/surgery/_surgery.dm
+++ b/code/modules/surgery/_surgery.dm
@@ -1,3 +1,5 @@
+var/list/surgeries_in_progress = list()
+
 // A list of types that will not attempt to perform surgery if the user is on help intent.
 GLOBAL_LIST_INIT(surgery_tool_exceptions, list(
 	/obj/item/auto_cpr,
@@ -13,7 +15,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 /* SURGERY STEPS */
 /decl/surgery_step
 	var/name
-	var/description = "A mysterious surgical procedure."
+	var/description
 	var/list/allowed_tools               // type path referencing tools that can be used for this step, and how well are they suited for it
 	var/list/allowed_species             // type paths referencing races that this step applies to.
 	var/list/disallowed_species          // type paths referencing races that this step applies to.
@@ -27,6 +29,8 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 	var/strict_access_requirement = TRUE // Whether or not this surgery will be fuzzy on size requirements.
 	var/hidden_from_codex                // Is this surgery a secret?
 	var/list/additional_codex_lines
+	var/expected_mob_type = /mob/living/carbon/human
+	var/surgery_step_category = /decl/surgery_step
 
 /decl/surgery_step/proc/get_speed_modifier(var/mob/user, var/mob/target, var/obj/item/tool)
 	. = 1
@@ -38,38 +42,37 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 			return allowed_tools[T]
 	return 0
 
-/decl/surgery_step/proc/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/proc/pre_surgery_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	return TRUE
 
 // Checks if this step applies to the user mob at all
-/decl/surgery_step/proc/is_valid_target(mob/living/carbon/human/target)
-	if(!hasorgans(target))
-		return 0
+/decl/surgery_step/proc/is_valid_target(mob/living/target)
+	. = ((!expected_mob_type || istype(target, expected_mob_type)) && isliving(target))
+	if(.)
+		var/decl/species/species = target.get_species()
+		if(allowed_species)
+			. = FALSE
+			if(species)
+				for(var/species_name in allowed_species)
+					if(species.get_root_species_name(target) == species_name)
+						return TRUE
+		if(species && disallowed_species)
+			for(var/species_name in disallowed_species)
+				if(species.get_root_species_name(target) == species_name)
+					return FALSE
 
-	if(allowed_species)
-		for(var/species in allowed_species)
-			if(target.species.get_root_species_name(target) == species)
-				return 1
-
-	if(disallowed_species)
-		for(var/species in disallowed_species)
-			if(target.species.get_root_species_name(target) == species)
-				return 0
-
-	return 1
-
-/decl/surgery_step/proc/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
+/decl/surgery_step/proc/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool, target_zone)
 	if(delicate)
 		return SURGERY_SKILLS_DELICATE
 	else
 		return SURGERY_SKILLS_GENERIC
 
 // checks whether this step can be applied with the given user and target
-/decl/surgery_step/proc/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/proc/can_use(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	return assess_bodypart(user, target, target_zone, tool) && assess_surgery_candidate(user, target, target_zone, tool)
 
-/decl/surgery_step/proc/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	if(istype(target) && target_zone)
+/decl/surgery_step/proc/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
+	if(ishuman(target) && target_zone)
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		if(affected)
 			// Check various conditional flags.
@@ -97,18 +100,19 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 				 affected.how_open() < open_threshold))
 					return FALSE
 			// Check if clothing is blocking access
-			var/obj/item/I = target.get_covering_equipped_item_by_zone(target_zone)
+			var/mob/living/carbon/human/C = target
+			var/obj/item/I = C.get_covering_equipped_item_by_zone(target_zone)
 			if(I && (I.item_flags & ITEM_FLAG_THICKMATERIAL))
 				to_chat(user,SPAN_NOTICE("The material covering this area is too thick for you to do surgery through!"))
 				return FALSE
 			return affected
 	return FALSE
 
-/decl/surgery_step/proc/assess_surgery_candidate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/proc/assess_surgery_candidate(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	return ishuman(target)
 
 // does stuff to begin the step, usually just printing messages. Moved germs transfering and bloodying here too
-/decl/surgery_step/proc/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/proc/begin_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if (can_infect && affected)
 		spread_germs_to_organ(affected, user)
@@ -118,18 +122,19 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 			H.bloody_hands(target,2)
 		if (blood_level > 1)
 			H.bloody_body(target,2)
-	if(shock_level)
-		target.shock_stage = max(target.shock_stage, shock_level)
+	if(shock_level && ishuman(target))
+		var/mob/living/carbon/human/H = target
+		H.shock_stage = max(H.shock_stage, shock_level)
 
 // does stuff to end the step, which is normally print a message + do whatever this step changes
-/decl/surgery_step/proc/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/proc/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	return
 
 // stuff that happens when the step fails
-/decl/surgery_step/proc/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/proc/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	return null
 
-/decl/surgery_step/proc/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
+/decl/surgery_step/proc/success_chance(mob/living/user, mob/living/target, obj/item/tool, target_zone)
 	. = tool_quality(tool)
 	if(user == target)
 		. -= 10
@@ -174,7 +179,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 
 	E.germ_level = max(germ_level,E.germ_level) //as funny as scrubbing microbes out with clean gloves is - no.
 
-/obj/item/proc/do_surgery(mob/living/carbon/M, mob/living/user, fuckup_prob)
+/obj/item/proc/do_surgery(mob/living/M, mob/living/user, fuckup_prob)
 
 	// Check for the Hippocratic oath.
 	if(!istype(M) || user.a_intent == I_HURT)
@@ -189,7 +194,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 			if(!zone)
 				return FALSE
 
-	if(LAZYACCESS(M.surgeries_in_progress, zone))
+	if(zone in global.surgeries_in_progress["\ref[M]"])
 		to_chat(user, SPAN_WARNING("You can't operate on this area while surgery is already in progress."))
 		return TRUE
 
@@ -233,12 +238,12 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 	// Otherwise we can make a start on surgery!
 	else if(istype(M) && !QDELETED(M) && user.a_intent != I_HURT && user.get_active_hand() == src)
 		// Double-check this in case it changed between initial check and now.
-		if(zone in M.surgeries_in_progress)
+		if(zone in global.surgeries_in_progress["\ref[M]"])
 			to_chat(user, SPAN_WARNING("You can't operate on this area while surgery is already in progress."))
 		else if(S.can_use(user, M, zone, src) && S.is_valid_target(M))
 			var/operation_data = S.pre_surgery_step(user, M, zone, src)
 			if(operation_data)
-				LAZYSET(M.surgeries_in_progress, zone, operation_data)
+				LAZYSET(global.surgeries_in_progress["\ref[M]"], zone, operation_data)
 				S.begin_step(user, M, zone, src)
 				var/skill_reqs = S.get_skill_reqs(user, M, src, zone)
 				var/duration = user.skill_delay_mult(skill_reqs[1]) * rand(S.min_duration, S.max_duration) * S.get_speed_modifier(user, M, src)
@@ -250,7 +255,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 				else
 					to_chat(user, SPAN_WARNING("You must remain close to your patient to conduct surgery."))
 				if(!QDELETED(M))
-					LAZYREMOVE(M.surgeries_in_progress, zone) // Clear the in-progress flag.
+					LAZYREMOVE(global.surgeries_in_progress["\ref[M]"], zone) // Clear the in-progress flag.
 					if(ishuman(M))
 						var/mob/living/carbon/human/H = M
 						H.update_surgery()

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -4,10 +4,11 @@
 //////////////////////////////////////////////////////////////////
 
 /decl/surgery_step/bone
+	surgery_step_category = /decl/surgery_step/bone
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_CRYSTAL | SURGERY_NEEDS_ENCASEMENT
 	var/required_stage = 0
 
-/decl/surgery_step/bone/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/bone/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && (affected.status & ORGAN_BROKEN) && affected.stage == required_stage)
 		return affected
@@ -28,7 +29,7 @@
 	max_duration = 60
 	shock_level = 20
 
-/decl/surgery_step/bone/glue/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/bone/glue/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/bone = affected.encased ? "\the [target]'s [affected.encased]" : "bones in \the [target]'s [affected.name]"
 	if (affected.stage == 0)
@@ -37,7 +38,7 @@
 	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!",50, affecting = affected)
 	..()
 
-/decl/surgery_step/bone/glue/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/bone/glue/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/bone = affected.encased ? "\the [target]'s [affected.encased]" : "bones in \the [target]'s [affected.name]"
 	user.visible_message("<span class='notice'>[user] applies some [tool.name] to [bone]</span>", \
@@ -46,7 +47,7 @@
 		affected.stage = 1
 	affected.status &= ~ORGAN_BRITTLE
 
-/decl/surgery_step/bone/glue/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/bone/glue/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>" , \
 	"<span class='warning'>Your hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>")
@@ -57,7 +58,7 @@
 //////////////////////////////////////////////////////////////////
 /decl/surgery_step/bone/set_bone
 	name = "Set bone"
-	description = "After preparing with bone gel, this procedure sets a broken bone in place for final repair."
+	description = "This procedure sets a broken bone in place for final repair after preparing with bone gel."
 	allowed_tools = list(
 		/obj/item/bonesetter = 100,
 		/obj/item/wrench = 75
@@ -69,7 +70,7 @@
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NEEDS_ENCASEMENT
 	required_stage = 1
 
-/decl/surgery_step/bone/set_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/bone/set_bone/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/bone = affected.encased ? "\the [target]'s [affected.encased]" : "bones in \the [target]'s [affected.name]"
 	if(affected.encased == "skull")
@@ -81,7 +82,7 @@
 	target.custom_pain("The pain in your [affected.name] is going to make you pass out!",50, affecting = affected)
 	..()
 
-/decl/surgery_step/bone/set_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/bone/set_bone/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/bone = affected.encased ? "\the [target]'s [affected.encased]" : "bones in \the [target]'s [affected.name]"
 	if (affected.status & ORGAN_BROKEN)
@@ -97,7 +98,7 @@
 			"<span class='notice'>You set [bone]</span> <span class='warning'>in the WRONG place with \the [tool].</span>")
 		affected.fracture()
 
-/decl/surgery_step/bone/set_bone/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/bone/set_bone/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>\The [user]'s hand slips, damaging the [affected.encased ? affected.encased : "bones"] in \the [target]'s [affected.name] with \the [tool]!</span>" , \
 		"<span class='warning'>Your hand slips, damaging the [affected.encased ? affected.encased : "bones"] in \the [target]'s [affected.name] with \the [tool]!</span>")
@@ -109,7 +110,7 @@
 //////////////////////////////////////////////////////////////////
 /decl/surgery_step/bone/finish
 	name = "Finish bone repair"
-	description = "After setting a bone in place, this procedure seals the last of the damage with bone gel."
+	description = "This procedure seals a damaged bone with bone gel after setting the bone in place."
 	allowed_tools = list(
 		/obj/item/bonegel = 100,
 		/obj/item/tape_roll = 75
@@ -121,14 +122,14 @@
 	shock_level = 20
 	required_stage = 2
 
-/decl/surgery_step/bone/finish/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/bone/finish/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/bone = affected.encased ? "\the [target]'s damaged [affected.encased]" : "damaged bones in \the [target]'s [affected.name]"
 	user.visible_message("[user] starts to finish mending [bone] with \the [tool].", \
 	"You start to finish mending [bone] with \the [tool].")
 	..()
 
-/decl/surgery_step/bone/finish/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/bone/finish/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/bone = affected.encased ? "\the [target]'s damaged [affected.encased]" : "damaged bones in [target]'s [affected.name]"
 	user.visible_message("<span class='notice'>[user] has mended [bone] with \the [tool].</span>"  , \
@@ -137,7 +138,7 @@
 	affected.stage = 0
 	affected.update_wounds()
 
-/decl/surgery_step/bone/finish/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/bone/finish/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>" , \
 	"<span class='warning'>Your hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>")

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -23,25 +23,25 @@
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_CRYSTAL | SURGERY_NO_STUMP | SURGERY_NEEDS_RETRACTED
 	strict_access_requirement = TRUE
 
-/decl/surgery_step/open_encased/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/open_encased/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && affected.encased)
 		return affected
 
-/decl/surgery_step/open_encased/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/open_encased/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] begins to cut through [target]'s [affected.encased] with \the [tool].", \
 	"You begin to cut through [target]'s [affected.encased] with \the [tool].")
 	target.custom_pain("Something hurts horribly in your [affected.name]!",60, affecting = affected)
 	..()
 
-/decl/surgery_step/open_encased/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/open_encased/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has cut [target]'s [affected.encased] open with \the [tool].</span>",		\
 	"<span class='notice'>You have cut [target]'s [affected.encased] open with \the [tool].</span>")
 	affected.fracture()
 
-/decl/surgery_step/open_encased/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/open_encased/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, cracking [target]'s [affected.encased] with \the [tool]!</span>" , \
 	"<span class='warning'>Your hand slips, cracking [target]'s [affected.encased] with \the [tool]!</span>" )

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -15,25 +15,25 @@
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_CRYSTAL | SURGERY_NEEDS_RETRACTED
 	strict_access_requirement = TRUE
 
-/decl/surgery_step/fix_face/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/fix_face/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	if(target_zone == BP_HEAD)
 		var/obj/item/organ/external/affected = ..()
 		if(affected && (affected.status & ORGAN_DISFIGURED))
 			return affected
 
-/decl/surgery_step/fix_face/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/fix_face/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	user.visible_message("[user] starts repairing damage to \the [target]'s face with \the [tool].", \
 	"You start repairing damage to \the [target]'s face with \the [tool].")
 	..()
 
-/decl/surgery_step/fix_face/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/fix_face/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	user.visible_message("<span class='notice'>[user] repairs \the [target]'s face with \the [tool].</span>",	\
 	"<span class='notice'>You repair \the [target]'s face with \the [tool].</span>")
 	var/obj/item/organ/external/head/h = target.get_organ(target_zone)
 	if(h) 
 		h.status &= ~ORGAN_DISFIGURED
 
-/decl/surgery_step/fix_face/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/fix_face/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, tearing skin on [target]'s face with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, tearing skin on [target]'s face with \the [tool]!</span>")

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -8,11 +8,12 @@
 //	generic surgery step datum
 //////////////////////////////////////////////////////////////////
 /decl/surgery_step/generic
+	surgery_step_category = /decl/surgery_step/generic
 	can_infect = 1
 	shock_level = 10
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_CRYSTAL | SURGERY_NO_STUMP
 
-/decl/surgery_step/generic/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	if(target_zone != BP_EYES) //there are specific steps for eye surgery
 		. = ..()
 
@@ -32,14 +33,14 @@
 	min_duration = 90
 	max_duration = 110
 
-/decl/surgery_step/generic/cut_with_laser/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/cut_with_laser/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts the bloodless incision on [target]'s [affected.name] with \the [tool].", \
 	"You start the bloodless incision on [target]'s [affected.name] with \the [tool].")
 	target.custom_pain("You feel a horrible, searing pain in your [affected.name]!",50, affecting = affected)
 	..()
 
-/decl/surgery_step/generic/cut_with_laser/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/cut_with_laser/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has made a bloodless incision on [target]'s [affected.name] with \the [tool].</span>", \
 	"<span class='notice'>You have made a bloodless incision on [target]'s [affected.name] with \the [tool].</span>",)
@@ -47,7 +48,7 @@
 	affected.clamp_organ()
 	spread_germs_to_organ(affected, user)
 
-/decl/surgery_step/generic/cut_with_laser/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/cut_with_laser/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips as the blade sputters, searing a long gash in [target]'s [affected.name] with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips as the blade sputters, searing a long gash in [target]'s [affected.name] with \the [tool]!</span>")
@@ -66,14 +67,14 @@
 	min_duration = 80
 	max_duration = 120
 
-/decl/surgery_step/generic/managed/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/managed/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts to construct a prepared incision on and within [target]'s [affected.name] with \the [tool].", \
 	"You start to construct a prepared incision on and within [target]'s [affected.name] with \the [tool].")
 	target.custom_pain("You feel a horrible, searing pain in your [affected.name] as it is pushed apart!",50, affecting = affected)
 	..()
 
-/decl/surgery_step/generic/managed/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/managed/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has constructed a prepared incision on and within [target]'s [affected.name] with \the [tool].</span>", \
 	"<span class='notice'>You have constructed a prepared incision on and within [target]'s [affected.name] with \the [tool].</span>",)
@@ -81,7 +82,7 @@
 	affected.clamp_organ() // clamp
 	affected.open_incision() // retract
 
-/decl/surgery_step/generic/managed/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/managed/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand jolts as the system sparks, ripping a gruesome hole in [target]'s [affected.name] with \the [tool]!</span>", \
 	"<span class='warning'>Your hand jolts as the system sparks, ripping a gruesome hole in [target]'s [affected.name] with \the [tool]!</span>")
@@ -104,7 +105,7 @@
 	var/fail_string = "slicing open"
 	var/access_string = "an incision"
 
-/decl/surgery_step/generic/cut_open/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/cut_open/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	. = ..()
 	if(.)
 		var/obj/item/organ/external/affected = .
@@ -113,27 +114,27 @@
 			to_chat(user, SPAN_NOTICE("The [incision.desc] provides enough access."))
 			return FALSE
 
-/decl/surgery_step/generic/cut_open/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/cut_open/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts [access_string] on [target]'s [affected.name] with \the [tool].", \
 	"You start [access_string] on [target]'s [affected.name] with \the [tool].")
 	target.custom_pain("You feel a horrible pain as if from a sharp knife in your [affected.name]!",40, affecting = affected)
 	..()
 
-/decl/surgery_step/generic/cut_open/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/cut_open/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has made [access_string] on [target]'s [affected.name] with \the [tool].</span>", \
 	"<span class='notice'>You have made [access_string] on [target]'s [affected.name] with \the [tool].</span>",)
 	affected.createwound(CUT, affected.min_broken_damage/2, 1)
 	playsound(target.loc, 'sound/weapons/bladeslice.ogg', 15, 1)
 
-/decl/surgery_step/generic/cut_open/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/cut_open/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, [fail_string] \the [target]'s [affected.name] in the wrong place with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, [fail_string] \the [target]'s [affected.name] in the wrong place with \the [tool]!</span>")
 	affected.take_external_damage(10, 0, (DAM_SHARP|DAM_EDGE), used_weapon = tool)
 
-/decl/surgery_step/generic/cut_open/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
+/decl/surgery_step/generic/cut_open/success_chance(mob/living/user, mob/living/target, obj/item/tool)
 	. = ..()
 	if(user.skill_check(SKILL_FORENSICS, SKILL_ADEPT))
 		. += 40
@@ -156,19 +157,19 @@
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_CRYSTAL | SURGERY_NO_STUMP | SURGERY_NEEDS_INCISION
 	strict_access_requirement = FALSE
 
-/decl/surgery_step/generic/clamp_bleeders/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/clamp_bleeders/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && !affected.clamped())
 		return affected
 
-/decl/surgery_step/generic/clamp_bleeders/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/clamp_bleeders/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts clamping bleeders in [target]'s [affected.name] with \the [tool].", \
 	"You start clamping bleeders in [target]'s [affected.name] with \the [tool].")
 	target.custom_pain("The pain in your [affected.name] is maddening!",40, affecting = affected)
 	..()
 
-/decl/surgery_step/generic/clamp_bleeders/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/clamp_bleeders/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] clamps bleeders in [target]'s [affected.name] with \the [tool].</span>",	\
 	"<span class='notice'>You clamp bleeders in [target]'s [affected.name] with \the [tool].</span>")
@@ -176,7 +177,7 @@
 	spread_germs_to_organ(affected, user)
 	playsound(target.loc, 'sound/items/Welder.ogg', 15, 1)
 
-/decl/surgery_step/generic/clamp_bleeders/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/clamp_bleeders/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, tearing blood vessals and causing massive bleeding in [target]'s [affected.name] with \the [tool]!</span>",	\
 	"<span class='warning'>Your hand slips, tearing blood vessels and causing massive bleeding in [target]'s [affected.name] with \the [tool]!</span>",)
@@ -199,7 +200,7 @@
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_CRYSTAL | SURGERY_NO_STUMP | SURGERY_NEEDS_INCISION
 	strict_access_requirement = TRUE
 
-/decl/surgery_step/generic/retract_skin/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/retract_skin/pre_surgery_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	. = FALSE
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(affected)
@@ -209,20 +210,20 @@
 		else
 			. = TRUE
 
-/decl/surgery_step/generic/retract_skin/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/retract_skin/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts to pry open the incision on [target]'s [affected.name] with \the [tool].",	\
 	"You start to pry open the incision on [target]'s [affected.name] with \the [tool].")
 	target.custom_pain("It feels like the skin on your [affected.name] is on fire!",40,affecting = affected)
 	..()
 
-/decl/surgery_step/generic/retract_skin/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/retract_skin/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] keeps the incision open on [target]'s [affected.name] with \the [tool].</span>",	\
 	"<span class='notice'>You keep the incision open on [target]'s [affected.name] with \the [tool].</span>")
 	affected.open_incision()
 
-/decl/surgery_step/generic/retract_skin/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/retract_skin/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, tearing the edges of the incision on [target]'s [affected.name] with \the [tool]!</span>",	\
 	"<span class='warning'>Your hand slips, tearing the edges of the incision on [target]'s [affected.name] with \the [tool]!</span>")
@@ -233,6 +234,7 @@
 //////////////////////////////////////////////////////////////////
 /decl/surgery_step/generic/cauterize
 	name = "Cauterize incision"
+	description = "This procedure cauterizes and closes an incision."
 	allowed_tools = list(
 		/obj/item/cautery = 100,
 		/obj/item/clothing/mask/smokable/cigarette = 75,
@@ -245,7 +247,7 @@
 	var/cauterize_term = "cauterize"
 	var/post_cauterize_term = "cauterized"
 
-/decl/surgery_step/generic/cauterize/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/cauterize/pre_surgery_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	. = FALSE
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(affected)
@@ -259,7 +261,7 @@
 		else
 			. = TRUE
 
-/decl/surgery_step/generic/cauterize/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/cauterize/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected)
 		if(affected.is_stump())
@@ -268,7 +270,7 @@
 		else if(affected.how_open())
 			return affected
 
-/decl/surgery_step/generic/cauterize/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/cauterize/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/datum/wound/W = affected.get_incision()
 	user.visible_message("[user] is beginning to [cauterize_term][W ? " \a [W.desc] on" : ""] \the [target]'s [affected.name] with \the [tool]." , \
@@ -276,7 +278,7 @@
 	target.custom_pain("Your [affected.name] is being burned!",40,affecting = affected)
 	..()
 
-/decl/surgery_step/generic/cauterize/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/cauterize/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/datum/wound/W = affected.get_incision()
 	user.visible_message("<span class='notice'>[user] [post_cauterize_term][W ? " \a [W.desc] on" : ""] \the [target]'s [affected.name] with \the [tool].</span>", \
@@ -289,7 +291,7 @@
 	if(affected.clamped())
 		affected.remove_clamps()
 
-/decl/surgery_step/generic/cauterize/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/cauterize/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, damaging [target]'s [affected.name] with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, damaging [target]'s [affected.name] with \the [tool]!</span>")
@@ -300,6 +302,7 @@
 //////////////////////////////////////////////////////////////////
 /decl/surgery_step/generic/amputate
 	name = "Amputate limb"
+	description = "This procedure removes a limb, or the stump of a limb, from the body entirely."
 	allowed_tools = list(
 		/obj/item/circular_saw = 100,
 		/obj/item/hatchet = 75
@@ -308,12 +311,12 @@
 	max_duration = 160
 	surgery_candidate_flags = 0
 
-/decl/surgery_step/generic/amputate/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/amputate/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && (affected.limb_flags & ORGAN_FLAG_CAN_AMPUTATE) && !affected.how_open())
 		return affected
 
-/decl/surgery_step/generic/amputate/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
+/decl/surgery_step/generic/amputate/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool)
 	var/target_zone = user.zone_sel.selecting
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(BP_IS_PROSTHETIC(affected))
@@ -329,7 +332,7 @@
 	if(!is_clean(user, tool, target))
 		. *= 0.5
 
-/decl/surgery_step/generic/amputate/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/amputate/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(is_clean(user, tool, target))
 		user.visible_message( \
@@ -342,7 +345,7 @@
 	target.custom_pain("Your [affected.amputation_point] is being ripped apart!",100,affecting = affected)
 	..()
 
-/decl/surgery_step/generic/amputate/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/amputate/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/clean_cut = is_clean(user, tool, target)
 	if(clean_cut)
@@ -355,7 +358,7 @@
 			SPAN_DANGER("You hack off \the [target]'s [affected.name] with \the [tool]!"))
 	affected.droplimb(clean_cut, DROPLIMB_EDGE)
 
-/decl/surgery_step/generic/amputate/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/generic/amputate/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(user.unEquip(tool, affected))
 		user.visible_message(

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -11,8 +11,9 @@
 	shock_level = 40
 	delicate = 1
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_STUMP | SURGERY_NEEDS_ENCASEMENT
+	surgery_step_category = /decl/surgery_step/cavity
 
-/decl/surgery_step/cavity/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/cavity/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/chest/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, scraping around inside [target]'s [affected.name] with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, scraping around inside [target]'s [affected.name] with \the [tool]!</span>")
@@ -32,12 +33,12 @@
 	min_duration = 60
 	max_duration = 80
 
-/decl/surgery_step/cavity/make_space/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/cavity/make_space/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && affected.cavity_name && !affected.cavity)
 		return affected
 
-/decl/surgery_step/cavity/make_space/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/cavity/make_space/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts making some space inside [target]'s [affected.cavity_name] cavity with \the [tool].", \
 	"You start making some space inside [target]'s [affected.cavity_name] cavity with \the [tool]." )
@@ -45,7 +46,7 @@
 	affected.cavity = TRUE
 	..()
 
-/decl/surgery_step/cavity/make_space/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/cavity/make_space/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/chest/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] makes some space inside [target]'s [affected.cavity_name] cavity with \the [tool].</span>", \
 	"<span class='notice'>You make some space inside [target]'s [affected.cavity_name] cavity with \the [tool].</span>" )
@@ -65,19 +66,19 @@
 	min_duration = 60
 	max_duration = 80
 
-/decl/surgery_step/cavity/close_space/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/cavity/close_space/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && affected.cavity)
 		return affected
 
-/decl/surgery_step/cavity/close_space/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/cavity/close_space/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts mending [target]'s [affected.cavity_name] cavity wall with \the [tool].", \
 	"You start mending [target]'s [affected.cavity_name] cavity wall with \the [tool]." )
 	target.custom_pain("The pain in your chest is living hell!",1,affecting = affected)
 	..()
 
-/decl/surgery_step/cavity/close_space/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/cavity/close_space/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/chest/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] mends [target]'s [affected.cavity_name] cavity walls with \the [tool].</span>", \
 	"<span class='notice'>You mend [target]'s [affected.cavity_name] cavity walls with \the [tool].</span>" )
@@ -88,22 +89,23 @@
 //////////////////////////////////////////////////////////////////
 /decl/surgery_step/cavity/place_item
 	name = "Place item in cavity"
+	description = "This procedure inserts an item into a prepared cavity in the body."
 	allowed_tools = list(/obj/item = 100)
 	min_duration = 80
 	max_duration = 100
 	hidden_from_codex = TRUE
 
-/decl/surgery_step/cavity/place_item/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/cavity/place_item/can_use(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	if(istype(user,/mob/living/silicon/robot))
 		return FALSE
 	. = ..()
 
-/decl/surgery_step/cavity/place_item/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/cavity/place_item/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && affected.cavity)
 		return affected
 
-/decl/surgery_step/cavity/place_item/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/cavity/place_item/pre_surgery_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(affected && affected.cavity)
 		var/max_volume = BASE_STORAGE_CAPACITY(affected.cavity_max_w_class) + affected.internal_organs_size
@@ -122,7 +124,7 @@
 			return FALSE
 		return TRUE
 
-/decl/surgery_step/cavity/place_item/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/cavity/place_item/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts putting \the [tool] inside [target]'s [affected.cavity_name] cavity.", \
 	"You start putting \the [tool] inside [target]'s [affected.cavity_name] cavity." )
@@ -130,7 +132,7 @@
 	playsound(target.loc, 'sound/effects/squelch1.ogg', 25, 1)
 	..()
 
-/decl/surgery_step/cavity/place_item/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/cavity/place_item/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/chest/affected = target.get_organ(target_zone)
 	if(!user.unEquip(tool, affected))
 		return
@@ -156,7 +158,7 @@
 	min_duration = 80
 	max_duration = 100
 
-/decl/surgery_step/cavity/implant_removal/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/cavity/implant_removal/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected)
 		for(var/obj/O in affected.implants)
@@ -164,14 +166,14 @@
 				return affected
 	return FALSE
 
-/decl/surgery_step/cavity/implant_removal/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/cavity/implant_removal/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts poking around inside [target]'s [affected.name] with \the [tool].", \
 	"You start poking around inside [target]'s [affected.name] with \the [tool]." )
 	target.custom_pain("The pain in your [affected.name] is living hell!",1,affecting = affected)
 	..()
 
-/decl/surgery_step/cavity/implant_removal/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/cavity/implant_removal/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/chest/affected = target.get_organ(target_zone)
 	var/exposed = 0
 	if(affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED))
@@ -215,7 +217,7 @@
 		user.visible_message("<span class='notice'>[user] could not find anything inside [target]'s [affected.name], and pulls \the [tool] out.</span>", \
 		"<span class='notice'>You could not find anything inside [target]'s [affected.name].</span>" )
 
-/decl/surgery_step/cavity/implant_removal/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/cavity/implant_removal/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	..()
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	for(var/obj/item/implant/imp in affected.implants)

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -11,13 +11,15 @@
 	can_infect = 0
 	shock_level = 40
 	delicate = 1
+	surgery_step_category = /decl/surgery_step/limb
 
-/decl/surgery_step/limb/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/limb/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(affected)
 		return affected
-	else
-		var/list/organ_data = target.species.has_limbs["[target_zone]"]
+	else if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		var/list/organ_data = H.species.has_limbs["[target_zone]"]
 		return !isnull(organ_data)
 
 //////////////////////////////////////////////////////////////////
@@ -30,11 +32,13 @@
 	min_duration = 50
 	max_duration = 70
 
-/decl/surgery_step/limb/attach/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/limb/attach/pre_surgery_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
+	if(!ishuman(target))
+		return FALSE
 	. = FALSE
 	var/obj/item/organ/external/E = tool
-	var/obj/item/organ/external/P = target.organs_by_name[E.parent_organ]
-	var/obj/item/organ/external/T = target.organs_by_name[E.organ_tag]
+	var/obj/item/organ/external/P = target.get_organ(E.parent_organ)
+	var/obj/item/organ/external/T = target.get_organ(E.organ_tag)
 	if(!P || P.is_stump())
 		to_chat(user, SPAN_WARNING("The [E.amputation_point] is missing!"))
 	else if(T && T.is_stump())
@@ -50,7 +54,7 @@
 	else
 		. = TRUE
 
-/decl/surgery_step/limb/attach/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/organ/external/tool)
+/decl/surgery_step/limb/attach/get_skill_reqs(mob/living/user, mob/living/target, obj/item/organ/external/tool)
 	if(istype(tool) && BP_IS_PROSTHETIC(tool))
 		if(target.isSynthetic())
 			return SURGERY_SKILLS_ROBOTIC
@@ -58,18 +62,18 @@
 			return SURGERY_SKILLS_ROBOTIC_ON_MEAT
 	return ..()
 
-/decl/surgery_step/limb/attach/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/limb/attach/can_use(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	if(..())
 		var/obj/item/organ/external/E = tool
-		var/obj/item/organ/external/P = target.organs_by_name[E.parent_organ]
+		var/obj/item/organ/external/P = target.get_organ(E.parent_organ)
 		. = (P && !P.is_stump() && !(BP_IS_PROSTHETIC(P) && !BP_IS_PROSTHETIC(E)))
 
-/decl/surgery_step/limb/attach/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/limb/attach/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = tool
 	user.visible_message("[user] starts attaching [E.name] to [target]'s [E.amputation_point].", \
 	"You start attaching [E.name] to [target]'s [E.amputation_point].")
 
-/decl/surgery_step/limb/attach/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/limb/attach/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	if(!user.unEquip(tool))
 		return
 	var/obj/item/organ/external/E = tool
@@ -81,7 +85,7 @@
 	target.updatehealth()
 	target.UpdateDamageIcon()
 
-/decl/surgery_step/limb/attach/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/limb/attach/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = tool
 	user.visible_message("<span class='warning'> [user]'s hand slips, damaging [target]'s [E.amputation_point]!</span>", \
 	"<span class='warning'> Your hand slips, damaging [target]'s [E.amputation_point]!</span>")
@@ -102,7 +106,7 @@
 	min_duration = 100
 	max_duration = 120
 
-/decl/surgery_step/limb/connect/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
+/decl/surgery_step/limb/connect/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool, target_zone)
 	var/obj/item/organ/external/E = target && target.get_organ(target_zone)
 	if(istype(E) && BP_IS_PROSTHETIC(E))
 		if(target.isSynthetic())
@@ -111,17 +115,17 @@
 			return SURGERY_SKILLS_ROBOTIC_ON_MEAT
 	return ..()
 
-/decl/surgery_step/limb/connect/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/limb/connect/can_use(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	if(..())
 		var/obj/item/organ/external/E = target.get_organ(target_zone)
 		return E && !E.is_stump() && (E.status & ORGAN_CUT_AWAY)
 
-/decl/surgery_step/limb/connect/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/limb/connect/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = target.get_organ(target_zone)
 	user.visible_message("[user] starts connecting tendons and muscles in [target]'s [E.amputation_point] with [tool].", \
 	"You start connecting tendons and muscle in [target]'s [E.amputation_point].")
 
-/decl/surgery_step/limb/connect/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/limb/connect/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has connected tendons and muscles in [target]'s [E.amputation_point] with [tool].</span>",	\
 	"<span class='notice'>You have connected tendons and muscles in [target]'s [E.amputation_point] with [tool].</span>")
@@ -133,7 +137,7 @@
 	target.updatehealth()
 	target.UpdateDamageIcon()
 
-/decl/surgery_step/limb/connect/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/limb/connect/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'> [user]'s hand slips, damaging [target]'s [E.amputation_point]!</span>", \
 	"<span class='warning'> Your hand slips, damaging [target]'s [E.amputation_point]!</span>")

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -22,26 +22,26 @@
 	delicate = 1
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_RETRACTED
 
-/decl/surgery_step/fix_tendon/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/fix_tendon/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && (affected.status & ORGAN_TENDON_CUT))
 		return affected
 
-/decl/surgery_step/fix_tendon/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/fix_tendon/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts reattaching the damaged [affected.tendon_name] in [target]'s [affected.name] with \the [tool]." , \
 	"You start reattaching the damaged [affected.tendon_name] in [target]'s [affected.name] with \the [tool].")
 	target.custom_pain("The pain in your [affected.name] is unbearable!",100,affecting = affected)
 	..()
 
-/decl/surgery_step/fix_tendon/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/fix_tendon/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has reattached the [affected.tendon_name] in [target]'s [affected.name] with \the [tool].</span>", \
 		"<span class='notice'>You have reattached the [affected.tendon_name] in [target]'s [affected.name] with \the [tool].</span>")
 	affected.status &= ~ORGAN_TENDON_CUT
 	affected.update_damages()
 
-/decl/surgery_step/fix_tendon/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/fix_tendon/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>" , \
 	"<span class='warning'>Your hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>")
@@ -67,26 +67,26 @@
 	strict_access_requirement = FALSE
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_RETRACTED
 
-/decl/surgery_step/fix_vein/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/fix_vein/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && (affected.status & ORGAN_ARTERY_CUT))
 		return affected
 
-/decl/surgery_step/fix_vein/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/fix_vein/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts patching the damaged [affected.artery_name] in [target]'s [affected.name] with \the [tool]." , \
 	"You start patching the damaged [affected.artery_name] in [target]'s [affected.name] with \the [tool].")
 	target.custom_pain("The pain in your [affected.name] is unbearable!",100,affecting = affected)
 	..()
 
-/decl/surgery_step/fix_vein/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/fix_vein/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has patched the [affected.artery_name] in [target]'s [affected.name] with \the [tool].</span>", \
 		"<span class='notice'>You have patched the [affected.artery_name] in [target]'s [affected.name] with \the [tool].</span>")
 	affected.status &= ~ORGAN_ARTERY_CUT
 	affected.update_damages()
 
-/decl/surgery_step/fix_vein/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/fix_vein/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>" , \
 	"<span class='warning'>Your hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>")
@@ -98,6 +98,7 @@
 //////////////////////////////////////////////////////////////////
 /decl/surgery_step/hardsuit
 	name = "Remove hardsuit"
+	description = "This procedure cuts through the bolts on a hardsuit, allowing it to be removed."
 	allowed_tools = list(
 		/obj/item/weldingtool = 80,
 		/obj/item/circular_saw = 60,
@@ -110,13 +111,13 @@
 	surgery_candidate_flags = 0
 	hidden_from_codex = TRUE
 
-/decl/surgery_step/hardsuit/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/hardsuit/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	return TRUE
 
-/decl/surgery_step/hardsuit/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
+/decl/surgery_step/hardsuit/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool)
 	return list(SKILL_EVA = SKILL_BASIC) 
 
-/decl/surgery_step/hardsuit/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/hardsuit/can_use(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	if(!istype(target))
 		return FALSE
 	if(isWelder(tool))
@@ -125,12 +126,12 @@
 			return FALSE
 	return (target_zone == BP_CHEST) && istype(target.back, /obj/item/rig) && !(target.back.canremove)
 
-/decl/surgery_step/hardsuit/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/hardsuit/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	user.visible_message("[user] starts cutting through the support systems of [target]'s [target.back] with \the [tool]." , \
 	"You start cutting through the support systems of [target]'s [target.back] with \the [tool].")
 	..()
 
-/decl/surgery_step/hardsuit/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/hardsuit/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 
 	var/obj/item/rig/rig = target.back
 	if(!istype(rig))
@@ -139,7 +140,7 @@
 	user.visible_message("<span class='notice'>[user] has cut through the support systems of [target]'s [rig] with \the [tool].</span>", \
 		"<span class='notice'>You have cut through the support systems of [target]'s [rig] with \the [tool].</span>")
 
-/decl/surgery_step/hardsuit/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/hardsuit/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	user.visible_message("<span class='danger'>[user]'s [tool] can't quite seem to get through the metal...</span>", \
 	"<span class='danger'>Your [tool] can't quite seem to get through the metal. It's weakening, though - try again.</span>")
 
@@ -165,22 +166,22 @@
 	min_duration = 50
 	max_duration = 60
 
-/decl/surgery_step/sterilize/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/sterilize/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && !affected.is_disinfected() && check_chemicals(tool))
 		return affected
 
-/decl/surgery_step/sterilize/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
+/decl/surgery_step/sterilize/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool)
 	return list(SKILL_MEDICAL = SKILL_BASIC) 
 
-/decl/surgery_step/sterilize/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/sterilize/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts pouring [tool]'s contents on \the [target]'s [affected.name]." , \
 	"You start pouring [tool]'s contents on \the [target]'s [affected.name].")
 	target.custom_pain("Your [affected.name] is on fire!",50,affecting = affected)
 	..()
 
-/decl/surgery_step/sterilize/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/sterilize/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
 	if (!istype(tool, /obj/item/chems))
@@ -201,7 +202,7 @@
 	qdel(temp_reagents)
 	qdel(temp_holder)
 
-/decl/surgery_step/sterilize/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/sterilize/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
 	if (!istype(tool, /obj/item/chems))

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -9,16 +9,17 @@
 /decl/surgery_step/robotics
 	can_infect = 0
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_FLESH | SURGERY_NO_STUMP
+	surgery_step_category = /decl/surgery_step/robotics
 
-decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
+/decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool)
 	return SURGERY_SKILLS_ROBOTIC
 
-/decl/surgery_step/robotics/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && !(affected.status & ORGAN_CUT_AWAY))
 		return affected
 
-/decl/surgery_step/robotics/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
+/decl/surgery_step/robotics/success_chance(mob/living/user, mob/living/target, obj/item/tool)
 	. = ..()
 	//Compensating for anatomy skill req in base proc
 	. += 10
@@ -43,24 +44,24 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	min_duration = 90
 	max_duration = 110
 
-/decl/surgery_step/robotics/unscrew_hatch/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/unscrew_hatch/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && affected.hatch_state == HATCH_CLOSED)
 		return affected
 
-/decl/surgery_step/robotics/unscrew_hatch/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/unscrew_hatch/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts to unscrew the maintenance hatch on [target]'s [affected.name] with \the [tool].", \
 	"You start to unscrew the maintenance hatch on [target]'s [affected.name] with \the [tool].")
 	..()
 
-/decl/surgery_step/robotics/unscrew_hatch/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/unscrew_hatch/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has opened the maintenance hatch on [target]'s [affected.name] with \the [tool].</span>", \
 	"<span class='notice'>You have opened the maintenance hatch on [target]'s [affected.name] with \the [tool].</span>",)
 	affected.hatch_state = HATCH_UNSCREWED
 
-/decl/surgery_step/robotics/unscrew_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/unscrew_hatch/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>\The [user]'s [tool.name] slips, failing to unscrew \the [target]'s [affected.name].</span>", \
 	"<span class='warning'>Your [tool.name] slips, failing to unscrew [target]'s [affected.name].</span>")
@@ -79,24 +80,24 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	min_duration = 90
 	max_duration = 110
 
-/decl/surgery_step/robotics/screw_hatch/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/screw_hatch/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && affected.hatch_state == HATCH_UNSCREWED)
 		return affected
 
-/decl/surgery_step/robotics/screw_hatch/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/screw_hatch/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts to screw down the maintenance hatch on [target]'s [affected.name] with \the [tool].", \
 	"You start to screw down the maintenance hatch on [target]'s [affected.name] with \the [tool].")
 	..()
 
-/decl/surgery_step/robotics/screw_hatch/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/screw_hatch/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has screwed down the maintenance hatch on [target]'s [affected.name] with \the [tool].</span>", \
 	"<span class='notice'>You have screwed down the maintenance hatch on [target]'s [affected.name] with \the [tool].</span>",)
 	affected.hatch_state = HATCH_CLOSED
 
-/decl/surgery_step/robotics/screw_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/screw_hatch/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s [tool.name] slips, failing to screw down [target]'s [affected.name].</span>", \
 	"<span class='warning'>Your [tool] slips, failing to screw down [target]'s [affected.name].</span>")
@@ -116,24 +117,24 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	min_duration = 30
 	max_duration = 40
 
-/decl/surgery_step/robotics/open_hatch/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/open_hatch/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && affected.hatch_state == HATCH_UNSCREWED)
 		return affected
 
-/decl/surgery_step/robotics/open_hatch/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/open_hatch/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts to pry open the maintenance hatch on [target]'s [affected.name] with \the [tool].",
 	"You start to pry open the maintenance hatch on [target]'s [affected.name] with \the [tool].")
 	..()
 
-/decl/surgery_step/robotics/open_hatch/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/open_hatch/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] opens the maintenance hatch on [target]'s [affected.name] with \the [tool].</span>", \
 	 "<span class='notice'>You open the maintenance hatch on [target]'s [affected.name] with \the [tool].</span>")
 	affected.hatch_state = HATCH_OPENED
 
-/decl/surgery_step/robotics/open_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/open_hatch/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s [tool.name] slips, failing to open the hatch on [target]'s [affected.name].</span>",
 	"<span class='warning'>Your [tool] slips, failing to open the hatch on [target]'s [affected.name].</span>")
@@ -153,25 +154,25 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	min_duration = 70
 	max_duration = 100
 
-/decl/surgery_step/robotics/close_hatch/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/close_hatch/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && affected.hatch_state == HATCH_OPENED)
 		return affected
 
-/decl/surgery_step/robotics/close_hatch/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/close_hatch/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] begins to close the hatch on [target]'s [affected.name] with \the [tool]." , \
 	"You begin to close the hatch on [target]'s [affected.name] with \the [tool].")
 	..()
 
-/decl/surgery_step/robotics/close_hatch/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/close_hatch/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] closes the hatch on [target]'s [affected.name] with \the [tool].</span>", \
 	"<span class='notice'>You close the hatch on [target]'s [affected.name] with \the [tool].</span>")
 	affected.hatch_state = HATCH_UNSCREWED
 	affected.germ_level = 0
 
-/decl/surgery_step/robotics/close_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/close_hatch/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s [tool.name] slips, failing to close the hatch on [target]'s [affected.name].</span>",
 	"<span class='warning'>Your [tool.name] slips, failing to close the hatch on [target]'s [affected.name].</span>")
@@ -190,12 +191,12 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	min_duration = 50
 	max_duration = 60
 
-/decl/surgery_step/robotics/repair_brute/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
+/decl/surgery_step/robotics/repair_brute/success_chance(mob/living/user, mob/living/target, obj/item/tool)
 	. = ..()
 	if(user.skill_check(SKILL_CONSTRUCTION, SKILL_BASIC))
 		. += 10
 
-/decl/surgery_step/robotics/repair_brute/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/repair_brute/pre_surgery_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(affected)
 		if(!affected.brute_dam)
@@ -215,25 +216,25 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 		return TRUE
 	return FALSE
 
-/decl/surgery_step/robotics/repair_brute/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/repair_brute/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && affected.hatch_state == HATCH_OPENED && ((affected.status & ORGAN_DISFIGURED) || affected.brute_dam > 0))
 		return affected
 
-/decl/surgery_step/robotics/repair_brute/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/repair_brute/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] begins to patch damage to [target]'s [affected.name]'s support structure with \the [tool]." , \
 	"You begin to patch damage to [target]'s [affected.name]'s support structure with \the [tool].")
 	..()
 
-/decl/surgery_step/robotics/repair_brute/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/repair_brute/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] finishes patching damage to [target]'s [affected.name] with \the [tool].</span>", \
 	"<span class='notice'>You finish patching damage to [target]'s [affected.name] with \the [tool].</span>")
 	affected.heal_damage(rand(30,50),0,1,1)
 	affected.status &= ~ORGAN_DISFIGURED
 
-/decl/surgery_step/robotics/repair_brute/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/repair_brute/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s [tool.name] slips, damaging the internal structure of [target]'s [affected.name].</span>",
 	"<span class='warning'>Your [tool.name] slips, damaging the internal structure of [target]'s [affected.name].</span>")
@@ -249,29 +250,29 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	min_duration = 50
 	max_duration = 60
 
-/decl/surgery_step/robotics/repair_brittle/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
+/decl/surgery_step/robotics/repair_brittle/success_chance(mob/living/user, mob/living/target, obj/item/tool)
 	. = ..()
 	if(user.skill_check(SKILL_ELECTRICAL, SKILL_BASIC))
 		. += 10
 
-/decl/surgery_step/robotics/repair_brittle/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/repair_brittle/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && BP_IS_BRITTLE(affected) && affected.hatch_state == HATCH_OPENED)
 		return affected
 
-/decl/surgery_step/robotics/repair_brittle/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/repair_brittle/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] begins to repair the brittle metal inside \the [target]'s [affected.name]." , \
 	"You begin to repair the brittle metal inside \the [target]'s [affected.name].")
 	..()
 
-/decl/surgery_step/robotics/repair_brittle/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/repair_brittle/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] finishes repairing the brittle interior of \the [target]'s [affected.name].</span>", \
 	"<span class='notice'>You finish repairing the brittle interior of \the [target]'s [affected.name].</span>")
 	affected.status &= ~ORGAN_BRITTLE
 
-/decl/surgery_step/robotics/repair_brittle/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/repair_brittle/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user] causes some of \the [target]'s [affected.name] to crumble!</span>",
 	"<span class='warning'>You cause some of \the [target]'s [affected.name] to crumble!</span>")
@@ -289,13 +290,13 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	min_duration = 50
 	max_duration = 60
 
-/decl/surgery_step/robotics/repair_burn/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
+/decl/surgery_step/robotics/repair_burn/success_chance(mob/living/user, mob/living/target, obj/item/tool)
 	. = ..()
 
 	if(user.skill_check(SKILL_ELECTRICAL, SKILL_BASIC))
 		. += 10
 
-/decl/surgery_step/robotics/repair_burn/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/repair_burn/pre_surgery_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(affected)
 		if(!affected.burn_dam)
@@ -312,25 +313,25 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 					return TRUE
 	return FALSE
 
-/decl/surgery_step/robotics/repair_burn/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/repair_burn/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && affected.hatch_state == HATCH_OPENED && ((affected.status & ORGAN_DISFIGURED) || affected.burn_dam > 0))
 		return affected
 
-/decl/surgery_step/robotics/repair_burn/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/repair_burn/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] begins to splice new cabling into [target]'s [affected.name]." , \
 	"You begin to splice new cabling into [target]'s [affected.name].")
 	..()
 
-/decl/surgery_step/robotics/repair_burn/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/repair_burn/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] finishes splicing cable into [target]'s [affected.name].</span>", \
 	"<span class='notice'>You finishes splicing new cable into [target]'s [affected.name].</span>")
 	affected.heal_damage(0,rand(30,50),1,1)
 	affected.status &= ~ORGAN_DISFIGURED
 
-/decl/surgery_step/robotics/repair_burn/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/repair_burn/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user] causes a short circuit in [target]'s [affected.name]!</span>",
 	"<span class='warning'>You cause a short circuit in [target]'s [affected.name]!</span>")
@@ -351,13 +352,13 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	max_duration = 90
 	surgery_candidate_flags = SURGERY_NO_STUMP
 
-/decl/surgery_step/robotics/fix_organ_robotic/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
+/decl/surgery_step/robotics/fix_organ_robotic/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool)
 	if(target.isSynthetic())
 		return SURGERY_SKILLS_ROBOTIC 
 	else
 		return SURGERY_SKILLS_ROBOTIC_ON_MEAT 
 
-/decl/surgery_step/robotics/fix_organ_robotic/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/fix_organ_robotic/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected)
 		for(var/obj/item/organ/internal/I in affected.internal_organs)
@@ -367,7 +368,7 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 				if(affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED) || affected.hatch_state == HATCH_OPENED)
 					return affected
 
-/decl/surgery_step/robotics/fix_organ_robotic/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/fix_organ_robotic/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	for(var/obj/item/organ/I in affected.internal_organs)
 		if(I && I.damage > 0)
@@ -376,7 +377,7 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 				"You start mending the damage to [target]'s [I.name]'s mechanisms." )
 	..()
 
-/decl/surgery_step/robotics/fix_organ_robotic/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/fix_organ_robotic/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	for(var/obj/item/organ/I in affected.internal_organs)
 		if(I && I.damage > 0)
@@ -385,7 +386,7 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 				"<span class='notice'>You repair [target]'s [I.name] with [tool].</span>" )
 				I.damage = 0
 
-/decl/surgery_step/robotics/fix_organ_robotic/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/fix_organ_robotic/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, gumming up the mechanisms inside of [target]'s [affected.name] with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, gumming up the mechanisms inside of [target]'s [affected.name] with \the [tool]!</span>")
@@ -409,33 +410,31 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	max_duration = 110
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_FLESH | SURGERY_NO_STUMP | SURGERY_NEEDS_ENCASEMENT
 
-/decl/surgery_step/robotics/detatch_organ_robotic/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/detatch_organ_robotic/pre_surgery_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/list/attached_organs
-	for(var/organ in target.internal_organs_by_name)
-		var/obj/item/organ/I = target.internal_organs_by_name[organ]
+	for(var/obj/item/organ/I in target.get_internal_organs())
 		if(I && !(I.status & ORGAN_CUT_AWAY) && !BP_IS_CRYSTAL(I) && I.parent_organ == target_zone)
 			var/image/radial_button = image(icon = I.icon, icon_state = I.icon_state)
 			radial_button.name = "Detach \the [I.name]"
-			LAZYSET(attached_organs, organ, radial_button)
+			LAZYSET(attached_organs, I.organ_tag, radial_button)
 	if(!LAZYLEN(attached_organs))
 		to_chat(user, SPAN_WARNING("There are no appropriate internal components to decouple."))
 		return FALSE
 	return show_radial_menu(user, tool, attached_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
 
-/decl/surgery_step/robotics/detatch_organ_robotic/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message("[user] starts to decouple [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool].", \
-	"You start to decouple [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool]." )
+/decl/surgery_step/robotics/detatch_organ_robotic/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
+	user.visible_message("[user] starts to decouple [target]'s [LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone)] with \the [tool].", \
+	"You start to decouple [target]'s [LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone)] with \the [tool]." )
 	..()
 
-/decl/surgery_step/robotics/detatch_organ_robotic/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message("<span class='notice'>[user] has decoupled [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool].</span>" , \
-	"<span class='notice'>You have decoupled [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool].</span>")
-
-	var/obj/item/organ/internal/I = target.internal_organs_by_name[LAZYACCESS(target.surgeries_in_progress, target_zone)]
+/decl/surgery_step/robotics/detatch_organ_robotic/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
+	user.visible_message("<span class='notice'>[user] has decoupled [target]'s [LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone)] with \the [tool].</span>" , \
+	"<span class='notice'>You have decoupled [target]'s [LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone)] with \the [tool].</span>")
+	var/obj/item/organ/internal/I = target.get_internal_organ(LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone))
 	if(I && istype(I))
 		I.cut_away(user)
 
-/decl/surgery_step/robotics/detatch_organ_robotic/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/detatch_organ_robotic/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	user.visible_message("<span class='warning'>[user]'s hand slips, disconnecting \the [tool].</span>", \
 	"<span class='warning'>Your hand slips, disconnecting \the [tool].</span>")
 
@@ -452,7 +451,7 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	max_duration = 120
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_FLESH | SURGERY_NO_STUMP | SURGERY_NEEDS_ENCASEMENT
 
-/decl/surgery_step/robotics/attach_organ_robotic/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/attach_organ_robotic/pre_surgery_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/list/removable_organs
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	for(var/obj/item/organ/I in affected.implants)
@@ -470,16 +469,16 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 			return FALSE
 	return organ_to_replace
 
-/decl/surgery_step/robotics/attach_organ_robotic/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message("[user] begins reattaching [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool].", \
-	"You start reattaching [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool].")
+/decl/surgery_step/robotics/attach_organ_robotic/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
+	user.visible_message("[user] begins reattaching [target]'s [LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone)] with \the [tool].", \
+	"You start reattaching [target]'s [LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone)] with \the [tool].")
 	..()
 
-/decl/surgery_step/robotics/attach_organ_robotic/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message("<span class='notice'>[user] has reattached [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool].</span>" , \
-	"<span class='notice'>You have reattached [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool].</span>")
+/decl/surgery_step/robotics/attach_organ_robotic/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
+	user.visible_message("<span class='notice'>[user] has reattached [target]'s [LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone)] with \the [tool].</span>" , \
+	"<span class='notice'>You have reattached [target]'s [LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone)] with \the [tool].</span>")
 
-	var/current_organ = LAZYACCESS(target.surgeries_in_progress, target_zone)
+	var/current_organ = LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	for (var/obj/item/organ/I in affected.implants)
 		if (I.organ_tag == current_organ)
@@ -488,7 +487,7 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 			I.replaced(target, affected)
 			break
 
-/decl/surgery_step/robotics/attach_organ_robotic/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/attach_organ_robotic/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	user.visible_message("<span class='warning'>[user]'s hand slips, disconnecting \the [tool].</span>", \
 	"<span class='warning'>Your hand slips, disconnecting \the [tool].</span>")
 
@@ -505,7 +504,7 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	max_duration = 80
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_FLESH | SURGERY_NO_STUMP | SURGERY_NEEDS_ENCASEMENT
 
-/decl/surgery_step/robotics/install_mmi/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/install_mmi/pre_surgery_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/mmi/M = tool
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(affected && istype(M))
@@ -516,26 +515,27 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 		else if(!target.isSynthetic())
 			to_chat(user, SPAN_WARNING("You cannot install a computer brain into a meat body."))
 		else if(!target.should_have_organ(BP_BRAIN))
-			to_chat(user, SPAN_WARNING("You're pretty sure [target.species.name_plural] don't normally have a brain."))
-		else if(target.internal_organs[BP_BRAIN])
+			var/decl/species/species = target.get_species()
+			to_chat(user, SPAN_WARNING("You're pretty sure [species ? "[species.name_plural] don't" : "\the [target] doesn't"] normally have a brain."))
+		else if(target.has_brain())
 			to_chat(user, SPAN_WARNING("Your subject already has a brain."))
 		else
 			return TRUE
 	return FALSE
 
-/decl/surgery_step/robotics/install_mmi/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/install_mmi/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && target_zone == BP_HEAD)
 		return affected
 
-/decl/surgery_step/robotics/install_mmi/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/install_mmi/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts installing \the [tool] into [target]'s [affected.name].", \
 	"You start installing \the [tool] into [target]'s [affected.name].")
 	..()
 
-/decl/surgery_step/robotics/install_mmi/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	if(!user.unEquip(tool))
+/decl/surgery_step/robotics/install_mmi/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
+	if(!user.unEquip(tool) || !ishuman(target))
 		return
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has installed \the [tool] into [target]'s [affected.name].</span>", \
@@ -543,7 +543,8 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 
 	var/obj/item/mmi/M = tool
 	var/obj/item/organ/internal/mmi_holder/holder = new(target, 1)
-	target.internal_organs_by_name[BP_BRAIN] = holder
+	var/mob/living/carbon/human/H = target
+	H.internal_organs_by_name[BP_BRAIN] = holder
 	tool.forceMove(holder)
 	holder.stored_mmi = tool
 	holder.update_from_mmi()
@@ -551,7 +552,7 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	if(M.brainmob && M.brainmob.mind)
 		M.brainmob.mind.transfer_to(target)
 
-/decl/surgery_step/robotics/install_mmi/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/robotics/install_mmi/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	user.visible_message("<span class='warning'>[user]'s hand slips.</span>", \
 	"<span class='warning'>Your hand slips.</span>")
 
@@ -581,15 +582,15 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	can_infect = 0
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_FLESH | SURGERY_NO_STUMP | SURGERY_NEEDS_ENCASEMENT
 
-/decl/surgery_step/remove_mmi/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
+/decl/surgery_step/remove_mmi/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool)
 	return SURGERY_SKILLS_ROBOTIC
 
-/decl/surgery_step/remove_mmi/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/remove_mmi/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected && (locate(/obj/item/mmi) in affected.implants))
 		return affected
 
-/decl/surgery_step/remove_mmi/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/remove_mmi/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message( \
 	"\The [user] starts poking around inside [target]'s [affected.name] with \the [tool].", \
@@ -597,7 +598,7 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	target.custom_pain("The pain in your [affected.name] is living hell!",1,affecting = affected)
 	..()
 
-/decl/surgery_step/remove_mmi/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/remove_mmi/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(affected)
 		var/obj/item/mmi/mmi = locate() in affected.implants
@@ -611,7 +612,7 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 			SPAN_NOTICE("\The [user] could not find anything inside [target]'s [affected.name]."), \
 			SPAN_NOTICE("You could not find anything inside [target]'s [affected.name]."))
 
-/decl/surgery_step/remove_mmi/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/remove_mmi/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message( \
 	SPAN_WARNING("\The [user]'s hand slips, damaging \the [target]'s [affected.name] with \the [tool]!"), \

--- a/code/modules/surgery/slimes.dm
+++ b/code/modules/surgery/slimes.dm
@@ -7,10 +7,11 @@
 //	generic slime surgery step datum
 //////////////////////////////////////////////////////////////////
 /decl/surgery_step/slime
+	allowed_species = null
+	disallowed_species = null
+	expected_mob_type = /mob/living/carbon/slime
 	hidden_from_codex = TRUE
-
-/decl/surgery_step/slime/is_valid_target(mob/living/carbon/slime/target)
-	return isslime(target)
+	surgery_step_category = /decl/surgery_step/slime
 
 /decl/surgery_step/slime/assess_bodypart(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
 	return TRUE
@@ -18,7 +19,7 @@
 /decl/surgery_step/slime/assess_surgery_candidate(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
 	return isslime(target) && target.stat == DEAD
 
-/decl/surgery_step/slime/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
+/decl/surgery_step/slime/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool)
 	return list(SKILL_SCIENCE = SKILL_ADEPT)
 
 //////////////////////////////////////////////////////////////////
@@ -26,6 +27,7 @@
 //////////////////////////////////////////////////////////////////
 /decl/surgery_step/slime/cut_flesh
 	name = "Make incision in slime"
+	description = "This procedure begins slime core removal surgery by cutting an incision open."
 	allowed_tools = list(
 		/obj/item/scalpel = 100,
 		/obj/item/knife = 75,
@@ -55,6 +57,7 @@
 //////////////////////////////////////////////////////////////////
 /decl/surgery_step/slime/cut_innards
 	name = "Dissect innards"
+	description = "This procedure disconnects slime cores from the innards."
 	allowed_tools = list(
 		/obj/item/scalpel = 100,
 		/obj/item/knife = 75,
@@ -84,6 +87,7 @@
 //////////////////////////////////////////////////////////////////
 /decl/surgery_step/slime/saw_core
 	name = "Remove slime core"
+	description = "This procedure completely separates a slime cores and allows it to be removed."
 	allowed_tools = list(
 		/obj/item/scalpel/manager = 100,
 		/obj/item/circular_saw = 100,

--- a/code/modules/surgery/suture_wounds.dm
+++ b/code/modules/surgery/suture_wounds.dm
@@ -1,7 +1,6 @@
 /decl/surgery_step/suture_wounds
-
 	name = "Suture wound"
-
+	description = "This procedure reduces the size of a wound, allowing it to heal or close."
 	allowed_tools = list(
 		/obj/item/sutures = 100,
 		/obj/item/stack/cable_coil = 60
@@ -13,8 +12,8 @@
 	shock_level = 1
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_CRYSTAL |	 SURGERY_NO_STUMP
 
-/decl/surgery_step/suture_wounds/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/obj/item/organ/external/affected = target.organs_by_name[target_zone]
+/decl/surgery_step/suture_wounds/pre_surgery_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(affected)
 		for(var/datum/wound/W in affected.wounds)
 			if(W.damage_type == CUT && W.damage >= W.autoheal_cutoff)
@@ -22,14 +21,14 @@
 		to_chat(user, SPAN_WARNING("\The [target]'s [affected.name] has no wounds that are large enough to need suturing."))
 	return FALSE
 
-/decl/surgery_step/suture_wounds/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/suture_wounds/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] is beginning to close a wound on [target]'s [affected.name] with \the [tool]." , \
 		"You are beginning to close a wound on [target]'s [affected.name] with \the [tool].")
 	target.custom_pain("Your [affected.name] is being stabbed!",1)
 	..()
 
-/decl/surgery_step/suture_wounds/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/suture_wounds/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	for(var/datum/wound/W in affected.wounds)
 		if(W.damage_type == CUT && W.damage >= W.autoheal_cutoff)
@@ -49,7 +48,7 @@
 			break
 	affected.update_damages()
 
-/decl/surgery_step/suture_wounds/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/decl/surgery_step/suture_wounds/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message(SPAN_DANGER("[user]'s hand slips, tearing [target]'s [affected.name] with \the [tool]!"), \
 		SPAN_DANGER("Your hand slips, tearing [target]'s [affected.name] with \the [tool]!"))

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -54,7 +54,7 @@ var/list/ventcrawl_machinery = list(
 	return (carried_item in internal_organs) || ..()
 
 /mob/living/carbon/human/is_allowed_vent_crawl_item(var/obj/item/carried_item)
-	var/obj/item/organ/internal/stomach/stomach = internal_organs_by_name[BP_STOMACH]
+	var/obj/item/organ/internal/stomach/stomach = get_internal_organ(BP_STOMACH)
 	if(stomach && (carried_item in stomach.contents))
 		return TRUE
 	if(carried_item in organs)

--- a/code/unit_tests/mob_tests.dm
+++ b/code/unit_tests/mob_tests.dm
@@ -33,7 +33,7 @@
 			var/species_organ = H.species.breathing_organ
 			var/obj/item/organ/internal/lungs/L
 			H.apply_effect(20, STUN, 0)
-			L = H.internal_organs_by_name[species_organ]
+			L = H.get_internal_organ(species_organ)
 			L.last_successful_breath = -INFINITY
 			test_subjects[S.name] = list(H, damage_check(H, OXY))
 	return 1
@@ -108,7 +108,7 @@ proc/damage_check(var/mob/living/M, var/damage_type)
 			loss = M.getOxyLoss()
 			if(istype(M,/mob/living/carbon/human))
 				var/mob/living/carbon/human/H = M
-				var/obj/item/organ/internal/lungs/L = H.internal_organs_by_name["lungs"]
+				var/obj/item/organ/internal/lungs/L = H.get_internal_organ(BP_LUNGS)
 				if(L)
 					loss = L.oxygen_deprivation
 		if(CLONE)
@@ -181,7 +181,7 @@ proc/damage_check(var/mob/living/M, var/damage_type)
 		var/species_organ = H.species.breathing_organ
 		var/obj/item/organ/internal/lungs/L
 		if(species_organ)
-			L = H.internal_organs_by_name[species_organ]
+			L = H.get_internal_organ(species_organ)
 		if(L)
 			L.last_successful_breath = -INFINITY
 

--- a/code/unit_tests/organ_tests.dm
+++ b/code/unit_tests/organ_tests.dm
@@ -25,7 +25,7 @@
 /datum/unit_test/species_organ_creation/proc/check_internal_organs(var/mob/living/carbon/human/H, var/decl/species/species)
 	. = 1
 	for(var/organ_tag in species.has_organ)
-		var/obj/item/organ/internal/I = H.internal_organs_by_name[organ_tag]
+		var/obj/item/organ/internal/I = H.get_internal_organ(organ_tag)
 		if(!istype(I))
 			fail("[species.name] failed to register internal organ for tag \"[organ_tag]\" to internal_organs_by_name.")
 			. = 0
@@ -133,7 +133,7 @@
 	if(!(I in H.internal_organs))
 		fail("[H.species.name] internal organ [I] not in internal_organs.")
 		return 0
-	var/found = H.internal_organs_by_name[I.organ_tag]
+	var/found = H.get_internal_organ(I.organ_tag)
 	if(I != found)
 		fail("[H.species.name] internal organ [I] not in internal_organs_by_name. Organ tag was \"[I.organ_tag]\", found [found? found : "nothing"] instead.")
 		return 0
@@ -150,7 +150,7 @@
 	if(I in H.internal_organs)
 		fail("[H.species.name] internal organ [I] was not removed from internal_organs.")
 		return 0
-	var/found = H.internal_organs_by_name[I.organ_tag]
+	var/found = H.get_internal_organ(I.organ_tag)
 	if(found)
 		fail("[H.species.name] internal organ [I] was not removed from internal_organs_by_name. Organ tag was \"[I.organ_tag]\".")
 		return 0

--- a/code/unit_tests/surgery.dm
+++ b/code/unit_tests/surgery.dm
@@ -1,0 +1,15 @@
+/datum/unit_test/surgery_steps_shall_have_descriptions
+	name = "SURGERY: Surgery steps shall have descriptions"
+
+/datum/unit_test/surgery_steps_shall_have_descriptions/start_test()
+	var/list/failed = list()
+	var/list/all_surgery = decls_repository.get_decls_of_subtype(/decl/surgery_step)
+	for(var/stype in all_surgery)
+		var/decl/surgery_step/step = all_surgery[stype]
+		if(step.surgery_step_category != stype && !istext(step.description))
+			failed += stype
+	if(length(failed))
+		fail("Some surgery steps have no description:\n[jointext(failed, "\n")]")
+	else
+		pass("All surgery steps have a description.")
+	return 1

--- a/mods/content/psionics/system/psionics/complexus/complexus_helpers.dm
+++ b/mods/content/psionics/system/psionics/complexus/complexus_helpers.dm
@@ -88,7 +88,7 @@
 	if(ishuman(owner))
 		var/mob/living/carbon/human/pop = owner
 		if(pop.should_have_organ(BP_BRAIN))
-			var/obj/item/organ/internal/brain/sponge = pop.internal_organs_by_name[BP_BRAIN]
+			var/obj/item/organ/internal/brain/sponge = pop.get_internal_organ(BP_BRAIN)
 			if(sponge && sponge.damage >= sponge.max_damage)
 				var/obj/item/organ/external/affecting = pop.get_organ(sponge.parent_organ)
 				if(affecting && !affecting.is_stump())

--- a/mods/mobs/borers/datum/symbiote.dm
+++ b/mods/mobs/borers/datum/symbiote.dm
@@ -106,7 +106,7 @@ GLOBAL_LIST_INIT(symbiote_starting_points, new)
 /datum/job/symbiote/proc/find_valid_hosts(var/just_checking)
 	. = list()
 	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(H.stat == DEAD || !H.client || !H.ckey || !H.internal_organs_by_name[BP_BRAIN])
+		if(H.stat == DEAD || !H.client || !H.ckey || !H.has_brain())
 			continue
 		var/obj/item/organ/external/head = H.get_organ(BP_HEAD)
 		if(BP_IS_PROSTHETIC(head) || BP_IS_CRYSTAL(head) || head.has_growths())

--- a/mods/mobs/borers/mob/borer/borer_attacks.dm
+++ b/mods/mobs/borers/mob/borer/borer_attacks.dm
@@ -54,7 +54,7 @@
 		borers.add_antagonist_mind(host.mind, 1, borers.faction_name, borers.faction_welcome)
 
 	if(istype(host, /mob/living/carbon/human))
-		var/obj/item/organ/I = H.internal_organs_by_name[BP_BRAIN]
+		var/obj/item/organ/I = H.get_internal_organ(BP_BRAIN)
 		if(!I) // No brain organ, so the borer moves in and replaces it permanently.
 			replace_brain()
 		else if(E) // If they're in normally, implant removal can get them out.

--- a/mods/mobs/borers/mob/borer/borer_powers.dm
+++ b/mods/mobs/borers/mob/borer/borer_powers.dm
@@ -64,7 +64,7 @@
 	if(islist(chemical_types))
 		B.chemical_types = chemical_types.Copy()
 	H.internal_organs_by_name[BP_BRAIN] = B
-	H.internal_organs |= B
+	H.internal_organs += B
 
 	var/obj/item/organ/external/affecting = H.get_organ(BP_HEAD)
 	affecting.implants -= src

--- a/mods/species/ascent/datum/species.dm
+++ b/mods/species/ascent/datum/species.dm
@@ -390,7 +390,7 @@
 
 	H.remove_cloaking_source(src)
 
-	var/obj/item/organ/internal/B = H.internal_organs_by_name[BP_BRAIN]
+	var/obj/item/organ/internal/B = H.get_internal_organ(BP_BRAIN)
 	if(istype(B,/obj/item/organ/internal/brain/insectoid/serpentid))
 		var/obj/item/organ/internal/brain/insectoid/serpentid/N = B
 		tally += N.lowblood_tally * 2

--- a/mods/species/ascent/mobs/bodyparts_serpentid.dm
+++ b/mods/species/ascent/mobs/bodyparts_serpentid.dm
@@ -164,7 +164,7 @@
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_GENDERED_ICON | ORGAN_FLAG_CAN_BREAK
 
 /obj/item/organ/external/head/insectoid/serpentid/get_eye_overlay()
-	var/obj/item/organ/internal/eyes/eyes = owner.internal_organs_by_name[owner.species.vision_organ ? owner.species.vision_organ : BP_EYES]
+	var/obj/item/organ/internal/eyes/eyes = owner.get_internal_organ(owner.species.vision_organ || BP_EYES)
 	if(eyes)
 		return eyes.get_special_overlay()
 

--- a/mods/species/vox/datum/language.dm
+++ b/mods/species/vox/datum/language.dm
@@ -16,7 +16,7 @@
 	if(!ishuman(speaker))
 		return FALSE
 	var/mob/living/carbon/human/H = speaker
-	var/obj/item/organ/internal/hindtongue/tongue = H.internal_organs_by_name[BP_HINDTONGUE]
+	var/obj/item/organ/internal/hindtongue/tongue = H.get_internal_organ(BP_HINDTONGUE)
 	if(!istype(tongue) || !tongue.is_usable())
 		to_chat(speaker, SPAN_WARNING("You are not capable of speaking [name]!"))
 		return FALSE

--- a/nebula.dme
+++ b/nebula.dme
@@ -3243,6 +3243,7 @@
 #include "code\unit_tests\shuttle_tests.dm"
 #include "code\unit_tests\submaps.dm"
 #include "code\unit_tests\subsystem_tests.dm"
+#include "code\unit_tests\surgery.dm"
 #include "code\unit_tests\test_obj.dm"
 #include "code\unit_tests\time_tests.dm"
 #include "code\unit_tests\unique_tests.dm"


### PR DESCRIPTION
Had to implement a couple of helpers with a lot of find and replace, hence the big diff.
- `get_species()` is now `get_species_name()` with `get_species()` returning the species datum.
- New helper for internal organ tag stuff, `get_internal_organ(BP_FOO)`.
- New helper for internal organs, `get_internal_organs()`.
- Surgery now expects input mob of /mob/living at base and will fail out when appropriate for human surgeries.
