### PR TITLE
Refactoring reagent metabolism to be more compatible with /mob/living.

### DIFF
--- a/code/_helpers/washing.dm
+++ b/code/_helpers/washing.dm
@@ -22,9 +22,10 @@
 		M.back.clean_blood()
 
 	//flush away reagents on the skin
-	if(M.touching)
-		var/remove_amount = M.touching.maximum_volume * M.reagent_permeability() //take off your suit first
-		M.touching.remove_any(remove_amount)
+	var/datum/reagents/touching_reagents = M.get_contact_reagents()
+	if(touching_reagents)
+		var/remove_amount = touching_reagents.maximum_volume * M.reagent_permeability() //take off your suit first
+		touching_reagents.remove_any(remove_amount)
 
 	if(!ishuman(M))
 		if(M.wear_mask)

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -264,10 +264,11 @@
 			print_reagent_default_message = FALSE
 			. += "<span class='scan_warning'>Warning: Unknown substance[(unknown>1)?"s":""] detected in subject's blood.</span>"
 
-	if(H.touching.total_volume)
+	var/datum/reagents/touching_reagents = H.get_contact_reagents()
+	if(touching_reagents && touching_reagents.total_volume)
 		var/unknown = 0
 		var/reagentdata[0]
-		for(var/A in H.touching.reagent_volumes)
+		for(var/A in touching_reagents.reagent_volumes)
 			var/decl/material/R = decls_repository.get_decl(A)
 			if(R.scannable)
 				print_reagent_default_message = FALSE

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -214,7 +214,7 @@
 			var/datum/reagents/R = M.reagents
 			var/mob/living/carbon/human/H = M
 			if(istype(H))
-				R = H.touching
+				R = H.get_contact_reagents()
 			if(istype(R))
 				for(var/chem in chems)
 					R.add_reagent(chem,min(5,max(1,get_trait(TRAIT_POTENCY)/3)))

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -436,7 +436,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 			T.assume_gas(vapor, (volume * vapor_products[vapor]), temperature)
 		holder.remove_reagent(type, volume)
 
-/decl/material/proc/on_mob_life(var/mob/living/carbon/M, var/alien, var/location, var/datum/reagents/holder) // Currently, on_mob_life is called on carbons. Any interaction with non-carbon mobs (lube) will need to be done in touch_mob.
+/decl/material/proc/on_mob_life(var/mob/living/M, var/alien, var/location, var/datum/reagents/holder) // Currently, on_mob_life is called on carbons. Any interaction with non-carbon mobs (lube) will need to be done in touch_mob.
 	if(QDELETED(src))
 		return // Something else removed us.
 	if(!istype(M))

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -67,24 +67,12 @@
 		//adjustFireLoss(2.5*discomfort)
 		adjustFireLoss(5.0*discomfort)
 
-
 /mob/living/carbon/brain/handle_chemicals_in_body()
-	..()
-	if(touching) touching.metabolize()
-	var/datum/reagents/metabolism/ingested = get_ingested_reagents()
-	if(istype(ingested)) ingested.metabolize()
-	if(bloodstr) bloodstr.metabolize()
-
-	handle_confused()
-	// decrement dizziness counter, clamped to 0
-	if(resting)
-		dizziness = max(0, dizziness - 5)
-	else
-		dizziness = max(0, dizziness - 1)
-
-	updatehealth()
-
-	return //TODO: DEFERRED
+	. = ..()
+	if(.)
+		handle_confused()
+		dizziness = max(0, dizziness - (resting ? 5 : 1))
+		updatehealth()
 
 /mob/living/carbon/brain/handle_regular_status_updates()	//TODO: comment out the unused bits >_>
 	updatehealth()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -22,11 +22,6 @@
 	return ..()
 
 /mob/living/carbon/rejuvenate()
-	bloodstr.clear_reagents()
-	touching.clear_reagents()
-	var/datum/reagents/R = get_ingested_reagents()
-	if(istype(R))
-		R.clear_reagents()
 	set_nutrition(400)
 	set_hydration(400)
 	..()
@@ -402,9 +397,6 @@
 		return FALSE
 	return !(species && species.species_flags & SPECIES_FLAG_NO_PAIN)
 
-/mob/living/carbon/proc/get_adjusted_metabolism(metabolism)
-	return metabolism
-
 /mob/living/carbon/proc/need_breathe()
 	return
 
@@ -482,3 +474,10 @@
 
 /mob/living/carbon/get_species_name()
 	return species.name
+
+/mob/living/carbon/get_contact_reagents()
+	return touching
+
+/mob/living/carbon/get_injected_reagents()
+	return bloodstr
+

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -6,8 +6,8 @@
 	//Surgery info
 	//Active emote/pose
 	var/pose = null
-	var/datum/reagents/metabolism/bloodstr = null
-	var/datum/reagents/metabolism/touching = null
+	var/datum/reagents/metabolism/bloodstr
+	var/datum/reagents/metabolism/touching
 	var/losebreath = 0 //if we failed to breathe last tick
 
 	var/coughedtime = null

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -64,20 +64,21 @@
 		var/obj/item/organ/internal/stomach/stomach = get_internal_organ(BP_STOMACH)
 		if(stomach)
 			return stomach.ingested
-	return touching // Kind of a shitty hack, but makes more sense to me than digesting them.
+	return get_contact_reagents() // Kind of a shitty hack, but makes more sense to me than digesting them.
 
-/mob/living/carbon/human/proc/metabolize_ingested_reagents()
+/mob/living/carbon/human/metabolize_ingested_reagents()
 	if(should_have_organ(BP_STOMACH))
 		var/obj/item/organ/internal/stomach/stomach = get_internal_organ(BP_STOMACH)
 		if(stomach)
 			stomach.metabolize()
+		return stomach?.ingested
 
 /mob/living/carbon/human/get_fullness()
 	if(!should_have_organ(BP_STOMACH))
 		return ..()
 	var/obj/item/organ/internal/stomach/stomach = get_internal_organ(BP_STOMACH)
 	if(stomach)
-		return nutrition + (stomach.ingested.total_volume * 10)
+		return nutrition + (stomach.ingested?.total_volume * 10)
 	return 0 //Always hungry, but you can't actually eat. :(
 
 /mob/living/carbon/human/Stat()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -520,35 +520,11 @@
 	return min(1,.)
 
 /mob/living/carbon/human/handle_chemicals_in_body()
-	..()
-	if(status_flags & GODMODE)
-		return 0
-
-	if(isSynthetic())
-		return
-
-	var/datum/reagents/metabolism/ingested = get_ingested_reagents()
-
-	if(reagents)
-		if(touching) touching.metabolize()
-		if(bloodstr) bloodstr.metabolize()
-		if(ingested) metabolize_ingested_reagents()
-
-	// Trace chemicals
-	for(var/T in chem_doses)
-		if(bloodstr.has_reagent(T) || ingested.has_reagent(T) || touching.has_reagent(T))
-			continue
-		var/decl/material/R = T
-		var/dose = LAZYACCESS(chem_doses, T) - initial(R.metabolism)*2
-		LAZYSET(chem_doses, T, dose)
-		if(LAZYACCESS(chem_doses, T) <= 0)
-			LAZYREMOVE(chem_doses, T)
-
-	// Not an ideal place to handle this, but there doesn't seem to be a more appropriate centralized area.
-	if(has_chemical_effect(CE_GLOWINGEYES, 1))
-		update_eyes()
-
-	updatehealth()
+	. = ..()
+	if(.)
+		if(has_chemical_effect(CE_GLOWINGEYES, 1))
+			update_eyes()
+		updatehealth()
 
 // Check if we should die.
 /mob/living/carbon/human/proc/handle_death_check()

--- a/code/modules/mob/living/carbon/taste.dm
+++ b/code/modules/mob/living/carbon/taste.dm
@@ -1,16 +1,16 @@
+/mob/living/proc/ingest(var/datum/reagents/from, var/datum/reagents/target, var/amount = 1, var/multiplier = 1, var/copy = 0)
+	. = from.trans_to_holder(target,amount,multiplier,copy)
 
-/mob/living/carbon/proc/ingest(var/datum/reagents/from, var/datum/reagents/target, var/amount = 1, var/multiplier = 1, var/copy = 0) //we kind of 'sneak' a proc in here for ingesting stuff so we can play with it.
+/mob/living/carbon/ingest(var/datum/reagents/from, var/datum/reagents/target, var/amount = 1, var/multiplier = 1, var/copy = 0) //we kind of 'sneak' a proc in here for ingesting stuff so we can play with it.
 	if(last_taste_time + 50 < world.time)
 		var/datum/reagents/temp = new(amount, GLOB.temp_reagents_holder) //temporary holder used to analyse what gets transfered.
 		from.trans_to_holder(temp, amount, multiplier, 1)
-
 		var/text_output = temp.generate_taste_message(src)
 		if(text_output != last_taste_text || last_taste_time + 1 MINUTE < world.time) //We dont want to spam the same message over and over again at the person. Give it a bit of a buffer.
-			to_chat(src, "<span class='notice'>You can taste [text_output].</span>")//no taste means there are too many tastes and not enough flavor.
-
+			to_chat(src, SPAN_NOTICE("You can taste [text_output].")) //no taste means there are too many tastes and not enough flavor.
 			last_taste_time = world.time
 			last_taste_text = text_output
-	return from.trans_to_holder(target,amount,multiplier,copy) //complete transfer
+	. = ..()
 
 /* what this does:
 catalogue the 'taste strength' of each one

--- a/code/modules/mob/living/carbon/xenobiological/life.dm
+++ b/code/modules/mob/living/carbon/xenobiological/life.dm
@@ -61,15 +61,9 @@
 	return temp_change
 
 /mob/living/carbon/slime/handle_chemicals_in_body()
-	..()
-	if(touching) touching.metabolize()
-	var/datum/reagents/metabolism/ingested = get_ingested_reagents()
-	if(istype(ingested)) ingested.metabolize()
-	if(bloodstr) bloodstr.metabolize()
-
-	src.updatehealth()
-
-	return //TODO: DEFERRED
+	. = ..()
+	if(.)
+		updatehealth()
 
 /mob/living/carbon/slime/handle_regular_status_updates()
 

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -48,6 +48,46 @@
 	SHOULD_CALL_PARENT(TRUE)
 	chem_effects = null
 
+	// TODO: handle isSynthetic() properly via Psi's metabolism modifiers for contact reagents like acid.
+	if((status_flags & GODMODE) || isSynthetic())
+		return FALSE
+
+	// Metabolize any reagents currently in our body and keep a reference for chem dose checking.
+	var/datum/reagents/metabolism/touching_reagents = metabolize_touching_reagents()
+	var/datum/reagents/metabolism/bloodstr_reagents = metabolize_injected_reagents()
+	var/datum/reagents/metabolism/ingested_reagents = metabolize_ingested_reagents()
+
+	// Update chem dosage.
+	// TODO: refactor chem dosage above isSynthetic() and GODMODE checks.
+	if(length(chem_doses))
+		for(var/T in chem_doses)
+			if(bloodstr_reagents?.has_reagent(T) || ingested_reagents?.has_reagent(T) || touching_reagents?.has_reagent(T))
+				continue
+			var/decl/material/R = T
+			var/dose = LAZYACCESS(chem_doses, T) - initial(R.metabolism)*2
+			LAZYSET(chem_doses, T, dose)
+			if(LAZYACCESS(chem_doses, T) <= 0)
+				LAZYREMOVE(chem_doses, T)
+	return TRUE
+
+/mob/living/proc/metabolize_touching_reagents()
+	var/datum/reagents/metabolism/touching_reagents = get_contact_reagents()
+	if(istype(touching_reagents))
+		touching_reagents.metabolize()
+		return touching_reagents
+		
+/mob/living/proc/metabolize_injected_reagents()
+	var/datum/reagents/metabolism/injected_reagents = get_injected_reagents()
+	if(istype(injected_reagents))
+		injected_reagents.metabolize()
+		return injected_reagents
+		
+/mob/living/proc/metabolize_ingested_reagents()
+	var/datum/reagents/metabolism/ingested_reagents = get_ingested_reagents()
+	if(istype(ingested_reagents))
+		ingested_reagents.metabolize()
+		return ingested_reagents
+
 /mob/living/proc/handle_random_events()
 	return
 

--- a/code/modules/organs/ailments/faults/fault_acid_discharge.dm
+++ b/code/modules/organs/ailments/faults/fault_acid_discharge.dm
@@ -3,4 +3,6 @@
 
 /datum/ailment/fault/acid/on_ailment_event()
 	organ.owner.custom_pain("A burning sensation spreads through your [organ].", 5, affecting = organ.owner)
-	organ.owner.bloodstr.add_reagent(/decl/material/liquid/acid, rand(1, 3))
+	var/datum/reagents/metabolism/bloodstr_reagents = organ.owner.get_injected_reagents()
+	if(bloodstr_reagents)
+		bloodstr_reagents.add_reagent(/decl/material/liquid/acid, rand(1, 3))

--- a/code/modules/organs/ailments/faults/fault_leaky.dm
+++ b/code/modules/organs/ailments/faults/fault_leaky.dm
@@ -8,5 +8,6 @@
 
 /datum/ailment/fault/leaky/on_ailment_event()
 	var/reagent = pick(chemicals)
-	organ.owner.bloodstr.add_reagent(reagent, rand(1, 3))
-
+	var/datum/reagents/bloodstr_reagents = organ.owner.get_injected_reagents()
+	if(bloodstr_reagents)
+		bloodstr_reagents.add_reagent(reagent, rand(1, 3))

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -32,10 +32,11 @@
 
 //Makes a blood drop, leaking amt units of blood from the mob
 /mob/living/carbon/human/proc/drip(var/amt, var/tar = src, var/ddir)
+	var/datum/reagents/bloodstream = get_injected_reagents()
 	if(remove_blood(amt))
-		if(bloodstr.total_volume && vessel.total_volume)
-			var/chem_share = round(0.3 * amt * (bloodstr.total_volume/vessel.total_volume), 0.01)
-			bloodstr.remove_any(chem_share * bloodstr.total_volume)
+		if(bloodstream.total_volume && vessel.total_volume)
+			var/chem_share = round(0.3 * amt * (bloodstream.total_volume/vessel.total_volume), 0.01)
+			bloodstream.remove_any(chem_share * bloodstream.total_volume)
 		blood_splatter(tar, src, (ddir && ddir>0), spray_dir = ddir)
 		return amt
 	return 0

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -134,14 +134,16 @@
 			if(!ailment.treated_by_reagent_type)
 				continue
 			var/treated
-			if(REAGENT_VOLUME(owner.bloodstr, ailment.treated_by_reagent_type) >= ailment.treated_by_reagent_dosage)
-				treated = owner.bloodstr
-			else if(REAGENT_VOLUME(owner.reagents, ailment.treated_by_reagent_type) >= ailment.treated_by_reagent_dosage)
-				treated = owner.reagents
-			else
-				var/datum/reagents/ingested = owner.get_ingested_reagents()
-				if(ingested && REAGENT_VOLUME(ingested, ailment.treated_by_reagent_type) >= ailment.treated_by_reagent_dosage)
-					treated = ingested
+			var/datum/reagents/bloodstr_reagents = owner.get_injected_reagents()
+			if(bloodstr_reagents)
+				if(REAGENT_VOLUME(bloodstr_reagents, ailment.treated_by_reagent_type) >= ailment.treated_by_reagent_dosage)
+					treated = bloodstr_reagents
+				else if(REAGENT_VOLUME(owner.reagents, ailment.treated_by_reagent_type) >= ailment.treated_by_reagent_dosage)
+					treated = owner.reagents
+				else
+					var/datum/reagents/ingested = owner.get_ingested_reagents()
+					if(ingested && REAGENT_VOLUME(ingested, ailment.treated_by_reagent_type) >= ailment.treated_by_reagent_dosage)
+						treated = ingested
 			if(treated)
 				ailment.was_treated_by_medication(treated)
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -371,22 +371,24 @@ GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
 /datum/reagents/proc/trans_to_mob(var/mob/target, var/amount = 1, var/type = CHEM_INJECT, var/multiplier = 1, var/copy = 0) // Transfer after checking into which holder...
 	if(!target || !istype(target) || !target.simulated)
 		return
-	if(iscarbon(target))
-		var/mob/living/carbon/C = target
+	if(isliving(target))
+		var/mob/living/L = target
 		if(type == CHEM_INJECT)
-			var/datum/reagents/R = C.reagents
-			return trans_to_holder(R, amount, multiplier, copy)
+			var/datum/reagents/R = L.get_injected_reagents()
+			if(R)
+				return trans_to_holder(R, amount, multiplier, copy)
 		if(type == CHEM_INGEST)
-			var/datum/reagents/R = C.get_ingested_reagents()
-			return C.ingest(src, R, amount, multiplier, copy) //perhaps this is a bit of a hack, but currently there's no common proc for eating reagents
+			var/datum/reagents/R = L.get_ingested_reagents()
+			if(R)
+				return L.ingest(src, R, amount, multiplier, copy) //perhaps this is a bit of a hack, but currently there's no common proc for eating reagents
 		if(type == CHEM_TOUCH)
-			var/datum/reagents/R = C.touching
-			return trans_to_holder(R, amount, multiplier, copy)
-	else
-		var/datum/reagents/R = new /datum/reagents(amount, GLOB.temp_reagents_holder)
-		. = trans_to_holder(R, amount, multiplier, copy, 1)
-		R.touch_mob(target)
-		qdel(R)
+			var/datum/reagents/R = L.get_contact_reagents()
+			if(R)
+				return trans_to_holder(R, amount, multiplier, copy)
+	var/datum/reagents/R = new /datum/reagents(amount, GLOB.temp_reagents_holder)
+	. = trans_to_holder(R, amount, multiplier, copy, 1)
+	R.touch_mob(target)
+	qdel(R)
 
 /datum/reagents/proc/trans_to_turf(var/turf/target, var/amount = 1, var/multiplier = 1, var/copy = 0) // Turfs don't have any reagents (at least, for now). Just touch it.
 	if(!target || !target.simulated)

--- a/code/modules/reagents/Chemistry-Metabolism.dm
+++ b/code/modules/reagents/Chemistry-Metabolism.dm
@@ -1,6 +1,7 @@
 /datum/reagents/metabolism
 	var/metabolism_class //CHEM_TOUCH, CHEM_INGEST, or CHEM_INJECT
-	var/mob/living/carbon/parent
+	var/mob/living/parent
+	var/last_metabolize_time = 0
 
 /datum/reagents/metabolism/clear_reagent(var/reagent_type)
 	if(REAGENT_VOLUME(src, reagent_type))
@@ -8,7 +9,7 @@
 		current.on_leaving_metabolism(parent, metabolism_class)
 	. = ..()
 
-/datum/reagents/metabolism/New(var/max = 100, mob/living/carbon/parent_mob, var/met_class)
+/datum/reagents/metabolism/New(var/max = 100, mob/living/parent_mob, var/met_class)
 	..(max, parent_mob)
 
 	metabolism_class = met_class
@@ -16,7 +17,8 @@
 		parent = parent_mob
 
 /datum/reagents/metabolism/proc/metabolize()
-	if(parent)
+	if(parent && world.time > last_metabolize_time)
+		last_metabolize_time = world.time // prevents mobs that reuse a holder between functions (ingested/injected) from metabolizing twice in a tick
 		var/metabolism_type = 0 //non-human mobs
 		if(ishuman(parent))
 			var/mob/living/carbon/human/H = parent

--- a/code/unit_tests/chemistry_tests.dm
+++ b/code/unit_tests/chemistry_tests.dm
@@ -56,11 +56,15 @@
 		var/to_holding_target = container_volume * 0.5
 		var/from_remaining_target = container_volume - to_holding_target
 		var/datum/reagents/checking = get_first_reagent_holder(from)
+		if(!checking)
+			return "first holder is null."
 		if(checking?.total_volume != from_remaining_target)
-			return "first holder should have [from_remaining_target]u remaining but has [from.reagents.total_volume]u."
+			return "first holder should have [from_remaining_target]u remaining but has [checking.total_volume]u."
 		checking = get_second_reagent_holder(target)
+		if(!checking)
+			return "second holder is null."
 		if(checking?.total_volume != to_holding_target)
-			return "second holder should hold [to_holding_target]u but has [target.reagents.total_volume]u."
+			return "second holder should hold [to_holding_target]u but has [checking.total_volume]u."
 
 /datum/unit_test/chemistry/proc/validate_holders(var/atom/from, var/atom/target)
 	if(QDELETED(from))
@@ -86,11 +90,11 @@
 
 /datum/unit_test/chemistry/test_trans_to/to_mob
 	name = "CHEMISTRY: trans_to() Test (mob)"
-	recipient_type = /mob/living/carbon
+	recipient_type = /mob/living
 
 /datum/unit_test/chemistry/test_trans_to/to_mob/get_second_reagent_holder(var/atom/from)
-	var/mob/living/carbon/C = from
-	. = C.touching
+	var/mob/living/testmob = from
+	. = testmob.get_contact_reagents()
 
 /datum/unit_test/chemistry/test_trans_to_holder
 	name = "CHEMISTRY: trans_to_holder() Test"
@@ -110,7 +114,7 @@
 
 /datum/unit_test/chemistry/test_trans_to_mob
 	name = "CHEMISTRY: trans_to_mob() Test"
-	recipient_type = /mob/living/carbon
+	recipient_type = /mob/living
 
 /datum/unit_test/chemistry/test_trans_to_mob/perform_transfer(var/atom/from, var/atom/target)
 	. = ..()

--- a/mods/species/ascent/mobs/nymph/nymph_life.dm
+++ b/mods/species/ascent/mobs/nymph/nymph_life.dm
@@ -1,5 +1,6 @@
 /mob/living/carbon/alien/ascent_nymph/Life()
-	UNLINT(. = ..()) // Unlinting because metabolize in handle_chemicals_in_body() has a non-execution chance of triggering an emote.
+
+	. = ..()
 	if(stat == DEAD)
 		return
 	
@@ -20,13 +21,6 @@
 		adjust_hydration(DEFAULT_THIRST_FACTOR * -1)
 
 	update_nymph_hud()
-
-/mob/living/carbon/alien/ascent_nymph/handle_chemicals_in_body()
-	// Do metabolism.
-	..()
-	var/datum/reagents/metabolism/ingested_reagents = get_ingested_reagents()
-	if(istype(ingested_reagents))
-		ingested_reagents.metabolize()
 
 /mob/living/carbon/alien/ascent_nymph/proc/update_nymph_hud()
 	// Update the HUD.


### PR DESCRIPTION
Moves some reagent handling procs down to /mob/living and swaps out usage of member variables to use them. Tested with humans and slimes, works fine.