### PR TITLE
Door machinery interactions tweak

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -45,7 +45,7 @@ var/const/AIRLOCK_WIRE_SPEAKER = 4096
 		if(A.isElectrified())
 			if(A.shock(L, 100))
 				return 0
-	if(A.panel_open)
+	if(istype(A.construct_state, /decl/machine_construction/default/panel_closed/door/hacking))
 		return 1
 	return 0
 

--- a/code/game/machinery/_machines_base/machine_construction/airlock.dm
+++ b/code/game/machinery/_machines_base/machine_construction/airlock.dm
@@ -1,0 +1,50 @@
+/decl/machine_construction/default/panel_closed/door
+	needs_board = "door"
+	down_state = /decl/machine_construction/default/panel_open/door
+	var/hacking_state = /decl/machine_construction/default/panel_closed/door/hacking
+
+/decl/machine_construction/default/panel_closed/door/attackby(obj/item/I, mob/user, obj/machinery/machine)
+	if(isScrewdriver(I))
+		TRANSFER_STATE(hacking_state)
+		playsound(get_turf(machine), 'sound/items/Screwdriver.ogg', 50, 1)
+		to_chat(user, SPAN_NOTICE("You release some of the logic wiring on \the [machine]. The cover panel remains closed."))
+		machine.update_icon()
+		return
+	if(isCrowbar(I))
+		TRANSFER_STATE(down_state)
+		playsound(get_turf(machine), 'sound/items/Crowbar.ogg', 50, 1)
+		machine.panel_open = TRUE
+		to_chat(user, SPAN_NOTICE("You open the main cover panel on \the [machine], exposing the internals."))
+		machine.queue_icon_update()
+		return TRUE
+	if(istype(I, /obj/item/storage/part_replacer))
+		var/obj/item/storage/part_replacer/replacer = I
+		if(replacer.remote_interaction)
+			machine.part_replacement(user, replacer)
+		machine.display_parts(user)
+		return TRUE
+
+/decl/machine_construction/default/panel_closed/door/mechanics_info()
+	. = list()
+	. += "Use a screwdriver to open a small hatch and expose some logic wires."
+	. += "Use a crowbar on the secured (bolted, welded or braced) airlock to pry open the main cover."
+	. += "Use a parts replacer to view installed parts."
+
+/decl/machine_construction/default/panel_closed/door/hacking
+	up_state = /decl/machine_construction/default/panel_closed/door
+
+/decl/machine_construction/default/panel_closed/door/hacking/attackby(obj/item/I, mob/user, obj/machinery/machine)
+	if(isScrewdriver(I))
+		TRANSFER_STATE(up_state)
+		playsound(get_turf(machine), 'sound/items/Screwdriver.ogg', 50, 1)
+		to_chat(user, SPAN_NOTICE("You tuck the exposed wiring back into \the [machine] and screw the hatch back into place."))
+		machine.queue_icon_update()
+		return TRUE
+
+/decl/machine_construction/default/panel_closed/door/hacking/mechanics_info()
+	. = list()
+	. += "Use a screwdriver close the hatch and tuck the exposed wires back in."
+
+/decl/machine_construction/default/panel_open/door
+	needs_board = "door"
+	up_state = /decl/machine_construction/default/panel_closed/door

--- a/code/game/machinery/_machines_base/machine_construction/default.dm
+++ b/code/game/machinery/_machines_base/machine_construction/default.dm
@@ -96,12 +96,3 @@
 
 // Not implemented fully as the machine will qdel on transition to this. Path needed for checks.
 /decl/machine_construction/default/deconstructed
-
-// door variants, just use different boards
-/decl/machine_construction/default/panel_closed/door
-	needs_board = "door"
-	down_state = /decl/machine_construction/default/panel_open/door
-
-/decl/machine_construction/default/panel_open/door
-	needs_board = "door"
-	up_state = /decl/machine_construction/default/panel_closed/door

--- a/code/game/machinery/doors/_door.dm
+++ b/code/game/machinery/doors/_door.dm
@@ -100,6 +100,9 @@
 	update_nearby_tiles(need_rebuild=1)
 	if(autoset_access) // Delayed because apparently the dir is not set by mapping and we need to wait for nearby walls to init and turn us.
 		inherit_access_from_area()
+		var/obj/item/stock_parts/circuitboard/airlock_electronics/circuit = get_component_of_type(/obj/item/stock_parts/circuitboard/airlock_electronics)
+		if(circuit)
+			circuit.req_access = req_access?.Copy()
 
 /obj/machinery/door/Destroy()
 	set_density(0)
@@ -536,6 +539,11 @@
 	if((!requiresID() || allowed(null)) && can_open_manually)
 		toggle()
 	return TRUE
+
+/obj/machinery/door/components_are_accessible(var/path)
+	if(ispath(path, /obj/item/stock_parts/circuitboard))
+		return TRUE
+	return ..()
 
 // Public access
 

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -103,6 +103,16 @@
 			conf_access -= access
 		return TOPIC_REFRESH
 
+/obj/item/stock_parts/circuitboard/airlock_electronics/attackby(obj/item/W, mob/user)
+	if(istype(W.GetIdCard(), /obj/item/card/id))
+		if(!locked || check_access(W))
+			locked = !locked
+			to_chat(user, SPAN_NOTICE("[src] beeps as its hatch access is [locked ? null : "un"]locked."))
+		else if (locked)
+			to_chat(user, SPAN_WARNING("[src] buzzes, denying access to the circuitry."))
+		return TRUE
+	. = ..()
+
 /obj/item/stock_parts/circuitboard/airlock_electronics/secure
 	name = "secure airlock electronics"
 	desc = "designed to be somewhat more resistant to hacking than standard electronics."

--- a/nebula.dme
+++ b/nebula.dme
@@ -729,6 +729,7 @@
 #include "code\game\machinery\_machines_base\machinery_public_vars.dm"
 #include "code\game\machinery\_machines_base\machinery_public_vars_common.dm"
 #include "code\game\machinery\_machines_base\machine_construction\_construction.dm"
+#include "code\game\machinery\_machines_base\machine_construction\airlock.dm"
 #include "code\game\machinery\_machines_base\machine_construction\computer.dm"
 #include "code\game\machinery\_machines_base\machine_construction\default.dm"
 #include "code\game\machinery\_machines_base\machine_construction\frame.dm"


### PR DESCRIPTION
Fixes #1274

Doors now use special states a-la APCs.
Screwdriver on closed panel exposes wires for hacking etc.
Crowbar on welded airlock opens the panel for component access / deconstruction.

Panel opening is prevented by airlock circuit's access. Can swipe ID at the door to toggle the hatch locking (doesn't grant door passing access).
Also made circuit inherit access from door when door gets it from area.

Opening as draft cause  I have little idea what am I doing with machinery states.
Also the UX and interactions could be probably improved since currently chain is weird (e.g. you open panel with crowbar, but close with screwdriver, and requirement for welding)
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->

## Changelog
:cl:
tweak: Airlock tool interactions changed.
tweak: Screwdriver on airlock will open wires panel, letting you access wires for hacking.
tweak: Crowbarring a secured (welded/bolted/braced) airlock will open the hatch letting you access components for repairs and deconstruction.
tweak: Hatch can only be opened if you have appropriate access to the door. Use ID on the door to toggle the lock.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
