### PR TITLE
Implements alternative to directional lighting macro.

### DIFF
--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -212,20 +212,6 @@
 
 #define LUM_FALLOFF(C, T)(CLAMP01(-((((C.x - T.x) ** 2 +(C.y - T.y) ** 2) ** 0.5 - light_outer_range) / max(light_outer_range - light_inner_range, 1))) ** light_falloff_curve)
 
-#define STEP_LUM(T)\
-	if(!T.lighting_corners_initialised)						\
-		{ T.generate_missing_corners(); }					\
-															\
-	for(var/datum/lighting_corner/C in T.get_corners())		\
-		{ if(C.update_gen == update_gen) { continue; }		\
-		C.update_gen = update_gen;							\
-		C.affecting += src;									\
-		if(!C.active) {effect_str[C] = 0; continue; }		\
-		APPLY_CORNER(C)										\
-		LAZYADD(T.affecting_lights, src)					\
-		affecting_turfs += T;}
-
-
 /datum/light_source/proc/apply_lum()
 	var/static/update_gen = 1
 	applied = 1
@@ -236,21 +222,29 @@
 	applied_lum_b = lum_b
 
 	FOR_DVIEW(var/turf/T, light_outer_range, source_turf, INVISIBILITY_LIGHTING)
-		STEP_LUM(T)
+		while(T.above)
+			T = T.above
+		do
+			if(!T.lighting_corners_initialised)
+				T.generate_missing_corners()
 
-		// If this turf allows lighting to pass through, crawl
-		// downwards adding the light to the tile below.
-		var/turf/z_turf = T
-		while(z_turf?.z_flags & ZM_ALLOW_LIGHTING)
-			STEP_LUM(z_turf.below)
-			z_turf = z_turf.below
-		
-		// Similar to previous, but if the tile allows light
-		// to pass through, add light to US.
-		z_turf = T.above
-		while(z_turf?.z_flags & ZM_ALLOW_LIGHTING)
-			STEP_LUM(z_turf)
-			z_turf = z_turf.above
+			for(var/datum/lighting_corner/C in T.get_corners())
+				if(C.update_gen == update_gen)
+					continue
+
+				C.update_gen = update_gen
+				C.affecting += src
+
+				if(!C.active)
+					effect_str[C] = 0
+					continue
+
+				APPLY_CORNER(C)
+
+			LAZYADD(T.affecting_lights, src)
+			affecting_turfs += T
+			T = (T.z_flags & ZM_ALLOW_LIGHTING) && (T = T.below)
+		while(T)
 
 	END_FOR_DVIEW
 


### PR DESCRIPTION
Replaces the goto from the OG implementation with a do-while and steps to the top of the turf stack before applying lighting, meaning it will traverse the entire vertical column and do up and down lights.

I'm really chuffed with the `while(T.above) { T = T.above; }` thing actually working so please admire it with your eyes.
