### PR TITLE
Added a mouseover highlight preference.

### DIFF
--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -5,8 +5,10 @@ var/list/valid_icon_sizes = list(32, 48, 64, 96, 128)
 	var/ooccolor = "#010000" //Whatever this is set to acts as 'reset' color and is thus unusable as an actual custom color
 	var/icon_size = 48
 	var/UI_style = "Midnight"
-	var/UI_style_color = "#ffffff"
-	var/UI_style_alpha = 255
+	var/UI_style_alpha =     255
+	var/UI_style_color =     COLOR_WHITE
+	var/UI_mouseover_alpha = 255
+	var/UI_mouseover_color = COLOR_AMBER
 	//Style for popup tooltips
 	var/tooltip_style = "Midnight"
 
@@ -15,38 +17,58 @@ var/list/valid_icon_sizes = list(32, 48, 64, 96, 128)
 	sort_order = 1
 
 /datum/category_item/player_setup_item/player_global/ui/load_preferences(var/savefile/S)
-	from_file(S["icon_size"],      pref.icon_size)
-	from_file(S["UI_style"],       pref.UI_style)
-	from_file(S["UI_style_color"], pref.UI_style_color)
-	from_file(S["UI_style_alpha"], pref.UI_style_alpha)
-	from_file(S["ooccolor"],       pref.ooccolor)
-	from_file(S["clientfps"],      pref.clientfps)
+	from_file(S["icon_size"],          pref.icon_size)
+	from_file(S["UI_style"],           pref.UI_style)
+	from_file(S["UI_mouseover_color"], pref.UI_mouseover_color)
+	from_file(S["UI_style_alpha"],     pref.UI_style_alpha)
+	from_file(S["UI_mouseover_alpha"], pref.UI_mouseover_alpha)
+	from_file(S["UI_style_alpha"],     pref.UI_style_alpha)
+	from_file(S["ooccolor"],           pref.ooccolor)
+	from_file(S["clientfps"],          pref.clientfps)
 
 /datum/category_item/player_setup_item/player_global/ui/save_preferences(var/savefile/S)
-	to_file(S["icon_size"],        pref.icon_size)
-	to_file(S["UI_style"],         pref.UI_style)
-	to_file(S["UI_style_color"],   pref.UI_style_color)
-	to_file(S["UI_style_alpha"],   pref.UI_style_alpha)
-	to_file(S["ooccolor"],         pref.ooccolor)
-	to_file(S["clientfps"],        pref.clientfps)
+	to_file(S["icon_size"],            pref.icon_size)
+	to_file(S["UI_style"],             pref.UI_style)
+	to_file(S["UI_mouseover_color"],   pref.UI_mouseover_color)
+	to_file(S["UI_mouseover_alpha"],   pref.UI_mouseover_alpha)
+	to_file(S["UI_style_color"],       pref.UI_style_color)
+	to_file(S["UI_style_alpha"],       pref.UI_style_alpha)
+	to_file(S["ooccolor"],             pref.ooccolor)
+	to_file(S["clientfps"],            pref.clientfps)
 
 /datum/category_item/player_setup_item/player_global/ui/sanitize_preferences()
-	pref.UI_style		= sanitize_inlist(pref.UI_style, all_ui_styles, initial(pref.UI_style))
-	pref.UI_style_color	= sanitize_hexcolor(pref.UI_style_color, initial(pref.UI_style_color))
-	pref.UI_style_alpha	= sanitize_integer(pref.UI_style_alpha, 0, 255, initial(pref.UI_style_alpha))
-	pref.ooccolor		= sanitize_hexcolor(pref.ooccolor, initial(pref.ooccolor))
-	pref.clientfps	    = sanitize_integer(pref.clientfps, CLIENT_MIN_FPS, CLIENT_MAX_FPS, initial(pref.clientfps))
+	pref.UI_style		    = sanitize_inlist(pref.UI_style, all_ui_styles, initial(pref.UI_style))
+	pref.UI_mouseover_color	= sanitize_hexcolor(pref.UI_mouseover_color, initial(pref.UI_mouseover_color))
+	pref.UI_mouseover_alpha	= sanitize_integer(pref.UI_mouseover_alpha, 0, 255, initial(pref.UI_mouseover_alpha))
+	pref.UI_style_color	    = sanitize_hexcolor(pref.UI_style_color, initial(pref.UI_style_color))
+	pref.UI_style_alpha	    = sanitize_integer(pref.UI_style_alpha, 0, 255, initial(pref.UI_style_alpha))
+	pref.ooccolor		    = sanitize_hexcolor(pref.ooccolor, initial(pref.ooccolor))
+	pref.clientfps	        = sanitize_integer(pref.clientfps, CLIENT_MIN_FPS, CLIENT_MAX_FPS, initial(pref.clientfps))
 
 	if(!isnum(pref.icon_size)) 
 		pref.icon_size = initial(pref.icon_size)
 	pref.client?.SetWindowIconSize(pref.icon_size)
 
+/datum/category_item/player_setup_item/player_global/ui/proc/get_ui_table(var/mob/user)
+	LAZYINITLIST(.)
+	. += "<tr><td>UI Color</td>"
+	. += "<td><a href='?src=\ref[src];select_color=1'><b>[pref.UI_style_color]</b></a></td>"
+	. += "<td><table style='display:inline;' bgcolor='[pref.UI_style_color]'><tr><td>__</td></tr></table></td>"
+	. += "<td><a href='?src=\ref[src];reset=ui'>reset</a></td>"
+	. += "</tr>"
+	. += "<tr><td>UI Opacity</td>"
+	. += "<td colspan = 2><a href='?src=\ref[src];select_alpha=1'><b>[pref.UI_style_alpha]</b></a></td>"
+	. += "<td><a href='?src=\ref[src];reset=alpha'>reset</a></td>"
+	. += "</tr>"
+
 /datum/category_item/player_setup_item/player_global/ui/content(var/mob/user)
-	. += "<b>UI Settings</b><br>"
+	. = "<b>UI Settings</b><br>"
 	. += "<b>UI Style:</b> <a href='?src=\ref[src];select_style=1'><b>[pref.UI_style]</b></a><br>"
-	. += "<b>Custom UI</b> (recommended for White UI):<br>"
-	. += "-Color: <a href='?src=\ref[src];select_color=1'><b>[pref.UI_style_color]</b></a> <table style='display:inline;' bgcolor='[pref.UI_style_color]'><tr><td>__</td></tr></table> <a href='?src=\ref[src];reset=ui'>reset</a><br>"
-	. += "-Alpha(transparency): <a href='?src=\ref[src];select_alpha=1'><b>[pref.UI_style_alpha]</b></a> <a href='?src=\ref[src];reset=alpha'>reset</a><br>"
+
+	. += "<b>Custom UI</b> (recommended for White UI):"
+	. += "<table style='margin: 0px auto; padding: 1px;'>"
+	. += jointext(get_ui_table(), null)
+	. += "</table><br>"
 	. += "<b>Tooltip Style:</b> <a href='?src=\ref[src];select_tooltip_style=1'><b>[pref.tooltip_style]</b></a><br>"
 	. += "<b>Default icon size:</b> <a href='?src=\ref[src];select_icon_size=1'>[pref.icon_size]x[pref.icon_size]</a><br>"
 
@@ -111,6 +133,10 @@ var/list/valid_icon_sizes = list(32, 48, 64, 96, 128)
 				pref.UI_style_color = initial(pref.UI_style_color)
 			if("alpha")
 				pref.UI_style_alpha = initial(pref.UI_style_alpha)
+			if("mouseover_color")
+				pref.UI_mouseover_color = initial(pref.UI_mouseover_color)
+			if("mouseover_alpha")
+				pref.UI_mouseover_alpha = initial(pref.UI_mouseover_alpha)
 			if("ooc")
 				pref.ooccolor = initial(pref.ooccolor)
 		return TOPIC_REFRESH

--- a/mods/content/mouse_highlights/_mouse_highlight.dme
+++ b/mods/content/mouse_highlights/_mouse_highlight.dme
@@ -1,0 +1,6 @@
+#ifndef CONTENT_PACK_MOUSEOVER
+#define CONTENT_PACK_MOUSEOVER
+#include "mouse_highlight.dm"
+#include "mouse_highlight_client.dm"
+#include "mouse_highlight_prefs.dm"
+#endif

--- a/mods/content/mouse_highlights/mouse_highlight.dm
+++ b/mods/content/mouse_highlights/mouse_highlight.dm
@@ -1,0 +1,16 @@
+/atom/movable
+	var/show_client_mouseover_highlight = FALSE
+/mob
+	show_client_mouseover_highlight = TRUE
+/obj/item
+	show_client_mouseover_highlight = TRUE
+/obj/machinery
+	show_client_mouseover_highlight = TRUE
+/obj/structure/cable
+	show_client_mouseover_highlight = TRUE
+/obj/structure/railing
+	show_client_mouseover_highlight = TRUE
+/obj/structure/stairs
+	show_client_mouseover_highlight = TRUE
+/obj/structure/ladder
+	show_client_mouseover_highlight = TRUE

--- a/mods/content/mouse_highlights/mouse_highlight_client.dm
+++ b/mods/content/mouse_highlights/mouse_highlight_client.dm
@@ -1,0 +1,116 @@
+
+/client
+	var/datum/callback/mouseover_callback   // Cached callback, see /client/New()
+	var/obj/mouseover_highlight_dummy       // Dummy atom to hold the appearance of our highlighted atom, see comments in /client/proc/refresh_mouseover_highlight.
+	var/weakref/current_highlight_atom      // Current weakref to highlighted atom, used for checking if we're mousing over the same atom repeatedly.
+	var/image/current_highlight             // Current dummy image holding our highlight.
+
+	var/mouseover_refresh_timer             // Holds an ID to the timer used to update the mouseover highlight.
+	var/last_mouseover_params               // Stores mouse/keyboard params as of last mouseover, to check for shift being held. 
+	var/last_mouseover_highlight_time       // Stores last world.time we mouseover'd, to prevent it happening more than once per world.tick_lag.
+
+/client/New()
+	// Cache our callback as we will potentially be using it (10 / ticklag) times per second,
+	mouseover_callback = CALLBACK(src, .proc/refresh_mouseover_highlight_timer)
+	. = ..()
+
+// This proc iterates constantly whenever something is being mouseover'd, so that it
+// can update appearance to match any changes in the base icon. I considered using
+// some kind of hook in update_icon() and set_dir() but this seemed much more robust.
+/client/proc/refresh_mouseover_highlight_timer()
+	if(!current_highlight_atom || !refresh_mouseover_highlight(current_highlight_atom?.resolve(), last_mouseover_params))
+		// If refresh_mouseover_highlight() returns false we need to end our iteration and kill the highlight.
+		if(current_highlight)
+			images -= current_highlight
+			qdel(current_highlight)
+			current_highlight = null
+		current_highlight_atom = null
+		deltimer(mouseover_refresh_timer)
+		mouseover_refresh_timer = null
+
+// Main body of work happens in this proc.
+/client/proc/refresh_mouseover_highlight(object, params, check_adjacency = FALSE)
+
+	// Verify if we should be showing a highlight at all.
+	if(!istype(object, /atom/movable) || (check_adjacency && !mob.Adjacent(object)))
+		return FALSE
+	var/list/modifiers = params2list(params)
+	var/highlight_pref = get_preference_value(/datum/client_preference/show_mouseover_highlights)
+	if(highlight_pref != GLOB.PREF_SHOW && (highlight_pref != GLOB.PREF_SHOW_HOLD_SHIFT || !modifiers["shift"]))
+		return FALSE
+	var/atom/movable/AM = object
+	if(!AM.show_client_mouseover_highlight || get_dist(mob, object) > 1)
+		return FALSE
+
+	// Generate our dummy objects if they got nulled/discarded.
+	if(!current_highlight)
+		current_highlight = new /image
+		current_highlight.appearance_flags |= (KEEP_TOGETHER|RESET_COLOR)
+		images += current_highlight
+	if(!mouseover_highlight_dummy)
+		mouseover_highlight_dummy = new
+
+	// Copy over the atom's appearance to our holder object.
+	// client.images does not respect pixel offsets for images, but vis_contents does,
+	// and images have vis_contents - so we throw a null image into client.images, then
+	// throw a holder object with the appearance of the mouse-overed atom into its vis_contents. 
+	mouseover_highlight_dummy.appearance =        AM
+	mouseover_highlight_dummy.dir =               AM.dir
+	mouseover_highlight_dummy.transform =         AM.transform
+
+	// For some reason you need to explicitly zero the pixel offsets of the holder object
+	// or anything with a pixel offset will not line up with the highlight. Thanks DM.
+	mouseover_highlight_dummy.pixel_x =           0
+	mouseover_highlight_dummy.pixel_y =           0
+	mouseover_highlight_dummy.pixel_w =           0
+	mouseover_highlight_dummy.pixel_z =           0
+
+	// Replane to be over the UI, make sure it can't block clicks, and set its outline.
+	mouseover_highlight_dummy.mouse_opacity =     0
+	mouseover_highlight_dummy.layer =             HUD_PLANE
+	mouseover_highlight_dummy.plane =             HUD_ABOVE_ITEM_LAYER
+	mouseover_highlight_dummy.alpha =             prefs?.UI_mouseover_alpha || 255
+	mouseover_highlight_dummy.appearance_flags |= (KEEP_TOGETHER|RESET_COLOR)
+	mouseover_highlight_dummy.filters =           filter(type="drop_shadow", color = (prefs?.UI_mouseover_color || COLOR_AMBER) + "F0", size = 1, offset = 1, x = 0, y = 0)
+
+	// Replanes the overlays to avoid explicit plane/layer setting (such as 
+	// computer overlays) interfering with the ordering of the highlight.
+	if(length(mouseover_highlight_dummy.overlays))
+		var/list/replaned_overlays
+		for(var/thing in mouseover_highlight_dummy.overlays)
+			var/mutable_appearance/MA = new(thing)
+			MA.plane = FLOAT_PLANE
+			MA.layer = FLOAT_LAYER
+			LAZYADD(replaned_overlays, MA)
+		mouseover_highlight_dummy.overlays = replaned_overlays
+	if(length(mouseover_highlight_dummy.underlays))
+		var/list/replaned_underlays
+		for(var/thing in mouseover_highlight_dummy.underlays)
+			var/mutable_appearance/MA = new(thing)
+			MA.plane = FLOAT_PLANE
+			MA.layer = FLOAT_LAYER
+			LAZYADD(replaned_underlays, MA)
+		mouseover_highlight_dummy.underlays = replaned_underlays
+
+	// Finally update our highlight's vis_contents and location .
+	current_highlight.vis_contents.Cut()
+	current_highlight.vis_contents += mouseover_highlight_dummy
+	current_highlight.loc = object
+	current_highlight_atom = weakref(AM)
+
+	// Keep track our params so the update ticker knows if we were holding shift or not.
+	last_mouseover_params = params
+
+	return TRUE
+
+// Simple hooks to catch the client mouseover/mouseleave events and start our highlight timer as needed.
+/client/MouseEntered(object,location,control,params)
+	if(world.time > last_mouseover_highlight_time && mouseover_callback && refresh_mouseover_highlight(object, params, check_adjacency = TRUE) && !mouseover_refresh_timer)
+		last_mouseover_highlight_time = world.time
+		mouseover_refresh_timer = addtimer(mouseover_callback, 1, (TIMER_UNIQUE | TIMER_LOOP | TIMER_STOPPABLE))
+	. = ..()
+/client/MouseExited(object, location, control, params)
+	if(current_highlight_atom?.resolve() == object)
+		current_highlight_atom = null
+		refresh_mouseover_highlight_timer()
+	. = ..()

--- a/mods/content/mouse_highlights/mouse_highlight_prefs.dm
+++ b/mods/content/mouse_highlights/mouse_highlight_prefs.dm
@@ -1,0 +1,37 @@
+GLOBAL_VAR_CONST(PREF_SHOW_HOLD_SHIFT, "While Holding Shift")
+
+/datum/client_preference/show_mouseover_highlights
+	description ="Mouseover Highlights"
+	key = "SHOW_MOUSEOVER_HIGHLIGHT"
+	options = list(GLOB.PREF_SHOW_HOLD_SHIFT, GLOB.PREF_HIDE, GLOB.PREF_SHOW)
+
+/datum/category_item/player_setup_item/player_global/ui/OnTopic(var/href,var/list/href_list, var/mob/user)
+	. = ..()
+	if(.)
+		return 
+	if(href_list["select_mouseover_color"])
+		var/UI_mouseover_color_new = input(user, "Choose mouseover color, dark colors are not recommended!", "Global Preference", pref.UI_mouseover_color) as color|null
+		if(isnull(UI_mouseover_color_new) || !CanUseTopic(user)) return TOPIC_NOACTION
+		pref.UI_mouseover_color = UI_mouseover_color_new
+		if(user?.client?.current_highlight)
+			user.client.current_highlight = null
+		return TOPIC_REFRESH
+	else if(href_list["select_mouseover_alpha"])
+		var/UI_mouseover_alpha_new = input(user, "Select mouseover alpha (transparency) level, between 50 and 255.", "Global Preference", pref.UI_mouseover_alpha) as num|null
+		if(isnull(UI_mouseover_alpha_new) || (UI_mouseover_alpha_new < 50 || UI_mouseover_alpha_new > 255) || !CanUseTopic(user)) return TOPIC_NOACTION
+		pref.UI_mouseover_alpha = UI_mouseover_alpha_new
+		if(user?.client?.current_highlight)
+			user.client.current_highlight = null
+		return TOPIC_REFRESH
+
+/datum/category_item/player_setup_item/player_global/ui/get_ui_table(var/mob/user)
+	. = ..() || list()
+	. += "<tr><td>UI Mouseover Color</td>"
+	. += "<td><a href='?src=\ref[src];select_mouseover_color=1'><b>[pref.UI_mouseover_color]</b></a></td>"
+	. += "<td><table style='display:inline;' bgcolor='[pref.UI_mouseover_color]'><tr><td>__</td></tr></table></td>"
+	. += "<td><a href='?src=\ref[src];reset=mouseover_color'>reset</a></td>"
+	. += "</tr>"
+	. += "<tr><td>UI Mouseover Opacity</td>"
+	. += "<td colspan = 2><a href='?src=\ref[src];select_mouseover_alpha=1'><b>[pref.UI_mouseover_alpha]</b></a></td>"
+	. += "<td><a href='?src=\ref[src];reset=mouseover_alpha'>reset</a></td>"
+	. += "</tr>"


### PR DESCRIPTION
Allows you to mouseover items and machines adjacent to your mob to get an over-darkness outlined version. Preferences can be set to always, only when holding shift, and never. Good for visibility, blindness RP, and generally making the game feel slightly less opaque about what you're interacting with.

~~However it seems that client images ignore pixel offsets, so stuff like air alarms and APCs look strange. Same with items placed on a table. Not sure how to fix this - it seems to be a limitation of DM.~~ Many thanks to Crazah on the BYOND Discord for suggesting using a dummy object and vis_contents.

https://user-images.githubusercontent.com/2468979/107604981-e007f480-6c85-11eb-9080-bf071474a47a.mp4

:cl:
rscadd: There is now a Mouseover Highlight preference that can be set to Show, Hide or Show While Shift Held. This will highlight the object you are currently mousing over. You can set colour and alpha for the highlight in your UI preferences.
/:cl: