### PR TITLE
Sets the DB encoding to utf8mb4 during connection

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -645,6 +645,12 @@ proc/setup_database_connection()
 	dbcon.Connect("dbi:mysql:[db]:[address]:[port]","[user]","[pass]")
 	. = dbcon.IsConnected()
 	if(.)
+		// Setting encoding and comparison (4-byte UTF-8) for the DB server ~bear1ake
+		var/DBQuery/unicode_query = dbcon.NewQuery("SET NAMES utf8mb4 COLLATE utf8mb4_general_ci")
+		if(!unicode_query.Execute())
+			global.failed_db_connections++
+			to_world_log(unicode_query.ErrorMsg())
+			return
 		global.failed_db_connections = 0	//If this connection succeeded, reset the failed connections counter.
 	else
 		global.failed_db_connections++		//If it failed, increase the failed connections counter.


### PR DESCRIPTION
We unable to make full Unicode DB support because during connection BYOND or DB thinks what we use different encoding.
Credits to bear1ake, who did this solution for Infinity Station bay fork.

This fixes this issue, which can appear during DB query insert:
![изображение](https://user-images.githubusercontent.com/44920739/107750100-99b9a080-6d2c-11eb-9f60-1ad04396e906.png)
