### PR TITLE
SQL ticket logging

### DIFF
--- a/code/modules/admin/ticket.dm
+++ b/code/modules/admin/ticket.dm
@@ -8,14 +8,21 @@ var/list/ticket_panels = list()
 	var/list/msgs = list()
 	var/datum/client_lite/closed_by
 	var/id
+	var/sql_id
 	var/opened_time
 	var/timeout = FALSE
+	var/to_check
+	var/to_close
 
 /datum/ticket/New(var/datum/client_lite/owner)
 	src.owner = owner
 	tickets |= src
 	id = tickets.len
 	opened_time = world.time
+	if(establish_db_connection())
+		var/sql_ckey = sanitizeSQL(owner.ckey)
+		var/DBQuery/ticket_query = dbcon.NewQuery("INSERT INTO erro_admin_tickets(ckey, round, inround_id, status, open_date) VALUES ('[sql_ckey]', '[game_id]', [src.id], 'OPEN', NOW());")
+		ticket_query.Execute()
 	addtimer(CALLBACK(src, .proc/timeoutcheck), 5 MINUTES)
 
 /datum/ticket/proc/timeoutcheck()
@@ -38,6 +45,9 @@ var/list/ticket_panels = list()
 	src.status = TICKET_CLOSED
 
 	if(timeout == TRUE)
+		if(establish_db_connection())
+			var/DBQuery/ticket_timeout = dbcon.NewQuery("UPDATE erro_admin_tickets SET status = 'TIMED_OUT' WHERE round = '[game_id]' AND inround_id = '[src.id]';")
+			ticket_timeout.Execute()
 		to_chat(client_by_ckey(src.owner.ckey), "<span class='notice'><b>Your ticket has timed out. Please adminhelp again if your issue is not resolved.</b></span>")
 		SSwebhooks.send(WEBHOOK_AHELP_SENT, list("name" = "Ticket ([id]) (Game ID: [game_id]) Ticket Timed Out", "body" = "[src.owner.key_name(0)] 's ticket (ID [id]) has timed out."))
 	else
@@ -47,6 +57,20 @@ var/list/ticket_panels = list()
 		send2adminirc("[src.owner.key_name(0)]'s ticket has been closed by [closed_by.key].")
 		SSwebhooks.send(WEBHOOK_AHELP_SENT, list("name" = "Ticket ([id]) (Game ID: [game_id]) Ticket Closed", "body" = "[src.owner.key_name(0)] 's ticket (ID [id]) has been closed by [closed_by.key]."))
 
+	var/closed_by_not_assigned = TRUE
+	if(!closed_by)
+		closed_by_not_assigned = TRUE
+
+	if((closed_by.ckey in assigned_admin_ckeys()) || owner.ckey == closed_by.ckey)
+		closed_by_not_assigned = FALSE
+
+	if(establish_db_connection())
+		var/sql_text = "[closed_by_not_assigned ? "CLOSED" : "SOLVED"]: [closed_by.ckey]\n"
+		var/DBQuery/ticket_text = dbcon.NewQuery("UPDATE erro_admin_tickets SET text = CONCAT(text, '[sql_text]') WHERE round = '[game_id]' AND inround_id = '[src.id]';")
+		var/DBQuery/ticket_close = dbcon.NewQuery("UPDATE erro_admin_tickets SET status = '[closed_by_not_assigned ? "CLOSED" : "SOLVED"]' WHERE round = '[game_id]' AND inround_id = '[src.id]';")
+		ticket_text.Execute()
+		ticket_close.Execute()
+	
 	update_ticket_panels()
 
 	return 1
@@ -62,7 +86,22 @@ var/list/ticket_panels = list()
 		return
 
 	assigned_admins |= assigned_admin
-	src.status = TICKET_ASSIGNED
+	
+	if(src.status != TICKET_ASSIGNED)
+		if(establish_db_connection())
+			var/DBQuery/ticket_timeout = dbcon.NewQuery("UPDATE erro_admin_tickets SET status = 'ASSIGNED' WHERE round = '[game_id]' AND inround_id = '[src.id]';")
+			ticket_timeout.Execute()
+		src.status = TICKET_ASSIGNED
+
+	if(establish_db_connection())
+		var/sql_assignee
+		for(var/datum/client_lite/_admin in assigned_admins)
+			if(!sql_assignee)
+				sql_assignee += "[_admin.ckey]"
+			else
+				sql_assignee += ", [_admin.ckey]"
+		var/DBQuery/ticket_take = dbcon.NewQuery("UPDATE erro_admin_tickets SET assignee = '[sql_assignee]' WHERE round = '[game_id]' AND inround_id = '[src.id]';")
+		ticket_take.Execute()
 
 	message_staff("<span class='notice'><b>[assigned_admin.key]</b> has assigned themself to <b>[src.owner.key_name(0)]'s</b> ticket.</span>")
 	send2adminirc("[assigned_admin.key] has assigned themself to [src.owner.key_name(0)]'s ticket.")

--- a/code/modules/admin/ticket.dm
+++ b/code/modules/admin/ticket.dm
@@ -11,7 +11,6 @@ var/list/ticket_panels = list()
 	var/sql_id
 	var/opened_time
 	var/timeout = FALSE
-	var/to_check
 	var/to_close
 
 /datum/ticket/New(var/datum/client_lite/owner)
@@ -21,7 +20,7 @@ var/list/ticket_panels = list()
 	opened_time = world.time
 	if(establish_db_connection())
 		var/sql_ckey = sanitizeSQL(owner.ckey)
-		var/DBQuery/ticket_query = dbcon.NewQuery("INSERT INTO erro_admin_tickets(ckey, round, inround_id, status, open_date) VALUES ('[sql_ckey]', '[game_id]', [src.id], 'OPEN', NOW());")
+		var/DBQuery/ticket_query = dbcon.NewQuery("INSERT INTO `erro_admin_tickets`(`ckey`, `round`, `inround_id`, `status`, `open_date`) VALUES ('[sql_ckey]', '[game_id]', [src.id], 'OPEN', NOW());")
 		ticket_query.Execute()
 	addtimer(CALLBACK(src, .proc/timeoutcheck), 5 MINUTES)
 
@@ -46,7 +45,7 @@ var/list/ticket_panels = list()
 
 	if(timeout == TRUE)
 		if(establish_db_connection())
-			var/DBQuery/ticket_timeout = dbcon.NewQuery("UPDATE erro_admin_tickets SET status = 'TIMED_OUT' WHERE round = '[game_id]' AND inround_id = '[src.id]';")
+			var/DBQuery/ticket_timeout = dbcon.NewQuery("UPDATE `erro_admin_tickets` SET `status` = 'TIMED_OUT' WHERE `round` = '[game_id]' AND `inround_id` = '[src.id]';")
 			ticket_timeout.Execute()
 		to_chat(client_by_ckey(src.owner.ckey), "<span class='notice'><b>Your ticket has timed out. Please adminhelp again if your issue is not resolved.</b></span>")
 		SSwebhooks.send(WEBHOOK_AHELP_SENT, list("name" = "Ticket ([id]) (Game ID: [game_id]) Ticket Timed Out", "body" = "[src.owner.key_name(0)] 's ticket (ID [id]) has timed out."))
@@ -66,8 +65,8 @@ var/list/ticket_panels = list()
 
 	if(establish_db_connection())
 		var/sql_text = "[closed_by_not_assigned ? "CLOSED" : "SOLVED"]: [closed_by.ckey]\n"
-		var/DBQuery/ticket_text = dbcon.NewQuery("UPDATE erro_admin_tickets SET text = CONCAT(text, '[sql_text]') WHERE round = '[game_id]' AND inround_id = '[src.id]';")
-		var/DBQuery/ticket_close = dbcon.NewQuery("UPDATE erro_admin_tickets SET status = '[closed_by_not_assigned ? "CLOSED" : "SOLVED"]' WHERE round = '[game_id]' AND inround_id = '[src.id]';")
+		var/DBQuery/ticket_text = dbcon.NewQuery("UPDATE `erro_admin_tickets` SET `text` = CONCAT(text, '[sql_text]') WHERE `round` = '[game_id]' AND `inround_id` = '[src.id]';")
+		var/DBQuery/ticket_close = dbcon.NewQuery("UPDATE `erro_admin_tickets` SET `status` = '[closed_by_not_assigned ? "CLOSED" : "SOLVED"]' WHERE `round` = '[game_id]' AND `inround_id` = '[src.id]';")
 		ticket_text.Execute()
 		ticket_close.Execute()
 	
@@ -89,7 +88,7 @@ var/list/ticket_panels = list()
 	
 	if(src.status != TICKET_ASSIGNED)
 		if(establish_db_connection())
-			var/DBQuery/ticket_timeout = dbcon.NewQuery("UPDATE erro_admin_tickets SET status = 'ASSIGNED' WHERE round = '[game_id]' AND inround_id = '[src.id]';")
+			var/DBQuery/ticket_timeout = dbcon.NewQuery("UPDATE `erro_admin_tickets` SET `status` = 'ASSIGNED' WHERE `round` = '[game_id]' AND `inround_id` = '[src.id]';")
 			ticket_timeout.Execute()
 		src.status = TICKET_ASSIGNED
 
@@ -100,7 +99,7 @@ var/list/ticket_panels = list()
 				sql_assignee += "[_admin.ckey]"
 			else
 				sql_assignee += ", [_admin.ckey]"
-		var/DBQuery/ticket_take = dbcon.NewQuery("UPDATE erro_admin_tickets SET assignee = '[sql_assignee]' WHERE round = '[game_id]' AND inround_id = '[src.id]';")
+		var/DBQuery/ticket_take = dbcon.NewQuery("UPDATE `erro_admin_tickets` SET `assignee` = '[sql_assignee]' WHERE `round` = '[game_id]' AND `inround_id` = '[src.id]';")
 		ticket_take.Execute()
 
 	message_staff("<span class='notice'><b>[assigned_admin.key]</b> has assigned themself to <b>[src.owner.key_name(0)]'s</b> ticket.</span>")

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -110,6 +110,11 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 	ticket.msgs += new /datum/ticket_msg(src.ckey, null, original_msg)
 	update_ticket_panels()
 
+	if(establish_db_connection())
+		var/sql_text = "HELP [src.ckey]: [sanitizeSQL(original_msg)]\n"
+		var/DBQuery/ticket_text = dbcon.NewQuery("UPDATE erro_admin_tickets SET text = '[sql_text]' WHERE round = '[game_id]' AND inround_id = '[ticket.id]';")
+		ticket_text.Execute()
+
 	//Options bar:  mob, details ( admin = 2, dev = 3, character name (0 = just ckey, 1 = ckey and character name), link? (0 no don't make it a link, 1 do so),
 	//		highlight special roles (0 = everyone has same looking name, 1 = antags / special roles get a golden name)
 

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -112,7 +112,7 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 
 	if(establish_db_connection())
 		var/sql_text = "HELP [src.ckey]: [sanitizeSQL(original_msg)]\n"
-		var/DBQuery/ticket_text = dbcon.NewQuery("UPDATE erro_admin_tickets SET text = '[sql_text]' WHERE round = '[game_id]' AND inround_id = '[ticket.id]';")
+		var/DBQuery/ticket_text = dbcon.NewQuery("UPDATE `erro_admin_tickets` SET `text` = '[sql_text]' WHERE `round` = '[game_id]' AND `inround_id` = '[ticket.id]';")
 		ticket_text.Execute()
 
 	//Options bar:  mob, details ( admin = 2, dev = 3, character name (0 = just ckey, 1 = ckey and character name), link? (0 no don't make it a link, 1 do so),

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -152,6 +152,11 @@
 	ticket.msgs += new /datum/ticket_msg(src.ckey, C.ckey, msg)
 	update_ticket_panels()
 
+	if(establish_db_connection())
+		var/sql_text = "[src.ckey] -> [C.ckey]: [sanitizeSQL(msg)]\n"
+		var/DBQuery/ticket_text = dbcon.NewQuery("UPDATE erro_admin_tickets SET text = CONCAT(COALESCE(text,''), '[sql_text]') WHERE round = '[game_id]' AND inround_id = '[ticket.id]';")
+		ticket_text.Execute()
+
 	//we don't use message_admins here because the sender/receiver might get it too
 	for(var/client/X in GLOB.admins)
 		//check client/X is an admin and isn't the sender or recipient

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -154,7 +154,7 @@
 
 	if(establish_db_connection())
 		var/sql_text = "[src.ckey] -> [C.ckey]: [sanitizeSQL(msg)]\n"
-		var/DBQuery/ticket_text = dbcon.NewQuery("UPDATE erro_admin_tickets SET text = CONCAT(COALESCE(text,''), '[sql_text]') WHERE round = '[game_id]' AND inround_id = '[ticket.id]';")
+		var/DBQuery/ticket_text = dbcon.NewQuery("UPDATE `erro_admin_tickets` SET `text` = CONCAT(COALESCE(text,''), '[sql_text]') WHERE `round` = '[game_id]' AND `inround_id` = '[ticket.id]';")
 		ticket_text.Execute()
 
 	//we don't use message_admins here because the sender/receiver might get it too

--- a/sql/migrate/V008_Ticket_Logging.sql
+++ b/sql/migrate/V008_Ticket_Logging.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS `erro_admin_tickets`;
+CREATE TABLE `erro_admin_tickets` (
+  `id` int(11) AUTO_INCREMENT,
+  `assignee` text DEFAULT NULL,
+  `ckey` varchar(32) NOT NULL,
+  `text` text DEFAULT NULL,
+  `status` enum('OPEN','ASSIGNED','CLOSED','SOLVED','TIMED_OUT') NOT NULL,
+  `round` varchar(32),
+  `inround_id` int(11),
+  `open_date` date,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
Adds SQL-based admin tickets logging, including date, round id, full conversation and specified status. 
If assigned admin closes ticket, its status is solved. When not assigned admin closes ticket, it will closed.