### PR TITLE
A fairly small transform refactor

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -14,6 +14,10 @@
 	var/list/climbers
 	var/climb_speed_mult = 1
 	var/explosion_resistance = 0
+	var/icon_scale_x = 1 // Holds state of horizontal scaling applied.
+	var/icon_scale_y = 1 // Ditto, for vertical scaling.
+	var/icon_rotation = 0 // And one for rotation as well.
+	var/transform_animate_time = 0 // If greater than zero, transform-based adjustments (scaling, rotating) will visually occur over this time.
 
 /atom/New(loc, ...)
 	//atom creation method that preloads variables at creation
@@ -611,3 +615,23 @@ its easier to just keep the beam vertical.
 
 /atom/proc/isflamesource()
 	. = FALSE
+
+// Transform setters.
+/atom/proc/set_rotation(new_rotation)
+	icon_rotation = new_rotation
+	update_transform()
+
+/atom/proc/set_scale(new_scale_x, new_scale_y)
+	if(isnull(new_scale_y))
+		new_scale_y = new_scale_x
+	if(new_scale_x != 0)
+		icon_scale_x = new_scale_x
+	if(new_scale_y != 0)
+		icon_scale_y = new_scale_y
+	update_transform()
+
+/atom/proc/update_transform()
+	var/matrix/M = matrix()
+	M.Scale(icon_scale_x, icon_scale_y)
+	M.Turn(icon_rotation)
+	animate(src, transform = M, transform_animate_time)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -330,3 +330,4 @@
 
 /atom/movable/CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
 	. = ..() || (mover && !(mover.movable_flags & MOVABLE_FLAG_NONDENSE_COLLISION) && !mover.density)
+

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1,6 +1,6 @@
 /atom/movable
 	layer = OBJ_LAYER
-	appearance_flags = TILE_BOUND
+	appearance_flags = TILE_BOUND|PIXEL_SCALE
 	glide_size = 8
 	var/movable_flags
 	var/last_move = null

--- a/code/game/machinery/slide_projector.dm
+++ b/code/game/machinery/slide_projector.dm
@@ -123,7 +123,6 @@
 	icon_state = "white"
 	anchored = TRUE
 	simulated = FALSE
-	appearance_flags = PIXEL_SCALE
 	blend_mode = BLEND_ADD
 	plane = EFFECTS_ABOVE_LIGHTING_PLANE
 	alpha = 100

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -74,9 +74,7 @@
 	atom_flags |= ATOM_FLAG_OPEN_CONTAINER
 	create_reagents(30, src)
 	if(prob(75))
-		var/matrix/M = matrix()
-		M.Turn(pick(90, 180, 270))
-		transform = M
+		set_rotation(pick(90, 180, 270))
 
 /obj/effect/decal/cleanable/vomit/on_update_icon()
 	. = ..()

--- a/code/game/objects/structures/rubble.dm
+++ b/code/game/objects/structures/rubble.dm
@@ -3,7 +3,6 @@
 	desc = "One man's garbage is another man's treasure."
 	icon = 'icons/obj/structures/rubble.dmi'
 	icon_state = "base"
-	appearance_flags = PIXEL_SCALE
 	opacity = 1
 	density = 1
 	anchored = 1

--- a/code/modules/admin/view_variables/vv_set_handlers.dm
+++ b/code/modules/admin/view_variables/vv_set_handlers.dm
@@ -132,3 +132,22 @@
 	var/new_falloff = variable == "light_falloff_curve" ? var_value : A.light_falloff_curve
 
 	A.set_light(new_max, new_inner, new_outer, new_falloff)
+
+/decl/vv_set_handler/icon_rotation_handler
+	handled_type = /atom
+	handled_vars = list("icon_rotation" = /atom/proc/set_rotation)
+	predicates = list(/proc/is_num_predicate)
+
+/decl/vv_set_handler/icon_scale_handler
+	handled_type = /atom
+	handled_vars = list("icon_scale_x", "icon_scale_y")
+
+/decl/vv_set_handler/icon_scale_handler/handle_set_var(atom/A, variable, var_value, client)
+	var_value = text2num(var_value)
+	if(!is_num_predicate(var_value, client))
+		return
+	
+	var/new_scale_x = variable == "icon_scale_x" ? var_value : A.icon_scale_x
+	var/new_scale_y = variable == "icon_scale_y" ? var_value : A.icon_scale_y
+
+	A.set_scale(new_scale_x, new_scale_y)

--- a/code/modules/economy/worth_cash.dm
+++ b/code/modules/economy/worth_cash.dm
@@ -17,7 +17,6 @@
 
 /obj/item/cash/Initialize(ml, material_key)
 	. = ..()
-	appearance_flags |= PIXEL_SCALE
 	if(!ispath(currency, /decl/currency))
 		currency = GLOB.using_map.default_currency
 	if(absolute_worth > 0)
@@ -182,7 +181,6 @@
 /obj/item/charge_stick/Initialize(ml, material_key)
 	. = ..()
 	id = "[grade]-card-[sequential_id("charge_stick")]"
-	appearance_flags |= PIXEL_SCALE
 	if(!ispath(currency, /decl/currency))
 		currency = GLOB.using_map.default_currency
 		update_name_desc()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1749,8 +1749,7 @@
 				var/obj/effect/decal/cleanable/blood/B = blood_splatter(get_step(src, hit_dir), src, 1, hit_dir)
 				B.icon_state = pick("dir_splatter_1","dir_splatter_2")
 				var/scale = min(1, round(P.damage / 50, 0.2))
-				var/matrix/M = new()
-				B.transform = M.Scale(scale)
+				B.set_scale(scale)
 
 				new /obj/effect/temp_visual/bloodsplatter(loc, hit_dir, species.blood_color)
 

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -11,7 +11,6 @@
 	var/skin_tone = 0  //Skin tone
 	var/skin_base = "" //Skin base
 
-	var/size_multiplier = 1 //multiplier for the mob's icon size
 	var/damage_multiplier = 1 //multiplies melee combat damage
 	var/icon_update = 1 //whether icon updating shall take place
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -143,7 +143,6 @@ Please contact me on #coderbus IRC. ~Carn x
 
 //UPDATES OVERLAYS FROM OVERLAYS_LYING/OVERLAYS_STANDING
 /mob/living/carbon/human/update_icons()
-	lying_prev = lying	//so we don't update overlays for lying/standing unless our stance changes again
 	update_hud()		//TODO: remove the need for this
 	overlays.Cut()
 
@@ -187,15 +186,23 @@ Please contact me on #coderbus IRC. ~Carn x
 
 	overlays = overlays_to_apply
 
+/mob/living/carbon/human/update_transform()
+	// First, get the correct size.
+	var/desired_scale_x = icon_scale_x
+	var/desired_scale_y = icon_scale_y
+
+	// If you want stuff like scaling based on species or something, here is a good spot to mix the numbers together.
+
 	var/matrix/M = matrix()
 	if(lying)
 		M.Turn(90)
-		M.Scale(size_multiplier)
+		M.Scale(desired_scale_x, desired_scale_y)
 		M.Translate(1, -6-default_pixel_z)
 	else
-		M.Scale(size_multiplier)
-		M.Translate(0, 16*(size_multiplier-1))
-	animate(src, transform = M, time = ANIM_LYING_TIME)
+		M.Scale(desired_scale_x, desired_scale_y)
+		M.Translate(0, 16*(desired_scale_y-1))
+
+	animate(src, transform = M, time = transform_animate_time)
 
 var/global/list/damage_icon_parts = list()
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -1,6 +1,7 @@
 /mob/living
 	see_in_dark = 2
 	see_invisible = SEE_INVISIBLE_LIVING
+	transform_animate_time = ANIM_LYING_TIME
 
 	//Health and life related vars
 	var/maxHealth = 100 //Maximum health that should be possible.

--- a/code/modules/mob/living/simple_animal/hostile/antlion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/antlion.dm
@@ -132,7 +132,4 @@
 
 /mob/living/simple_animal/hostile/antlion/mega/Initialize()
 	. = ..()
-	var/matrix/M = new
-	M.Scale(1.5)
-	transform = M
-	update_icon()
+	set_scale(1.5)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/giant_crab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/giant_crab.dm
@@ -43,9 +43,7 @@
 
 /mob/living/simple_animal/hostile/retaliate/giant_crab/Initialize() //embiggen
 	. = ..()
-	var/matrix/M = new
-	M.Scale(1.5)
-	transform = M
+	set_scale(1.5)
 
 /mob/living/simple_animal/hostile/retaliate/giant_crab/Destroy()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/giant_parrot/giant_parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/giant_parrot/giant_parrot.dm
@@ -44,9 +44,7 @@
 		skin_material = ps.feathers
 		if(get_subspecies_name)
 			SetName(ps.name)
-	var/matrix/M = new
-	M.Scale(2)
-	transform = M
+	set_scale(2)
 	update_icon()
 
 /mob/living/simple_animal/hostile/retaliate/parrot/space/AttackingTarget()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/jelly.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/jelly.dm
@@ -45,9 +45,7 @@
 
 /mob/living/simple_animal/hostile/retaliate/jelly/mega/Initialize()
 	. = ..()
-	var/matrix/M = new
-	M.Scale(jelly_scale)
-	transform = M
+	set_scale(jelly_scale)
 	var/obj/item/W = get_natural_weapon()
 	if(W)
 		W.force *= jelly_scale

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
@@ -194,14 +194,12 @@
 	visible_message("<span class='cultannounce'>\The [src]' wounds close with a flash, and when he emerges, he's even larger than before!</span>")
 
 /mob/living/simple_animal/hostile/retaliate/goat/king/phase2/on_update_icon()
-	var/matrix/M = new
 	if(phase3)
 		icon_state = "king_goat3"
 		icon_living = "king_goat3"
-		M.Scale(1.5)
+		set_scale(1.5)
 	else
-		M.Scale(1.25)
-	transform = M
+		set_scale(1.25)
 	default_pixel_y = 10
 
 /mob/living/simple_animal/hostile/retaliate/goat/king/phase2/Life()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -468,8 +468,7 @@
 				B.icon_state = pick("dir_splatter_1","dir_splatter_2")
 				B.basecolor = bleed_colour
 				var/scale = min(1, round(mob_size / MOB_SIZE_MEDIUM, 0.1))
-				var/matrix/M = new()
-				B.transform = M.Scale(scale)
+				B.set_scale(scale)
 				B.update_icon()
 
 /mob/living/simple_animal/handle_fire()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -587,6 +587,7 @@
 
 //Updates lying and icons
 /mob/proc/UpdateLyingBuckledAndVerbStatus()
+	var/last_lying = lying
 	if(!resting && cannot_stand() && can_stand_overridden())
 		lying = 0
 	else if(buckled)
@@ -614,8 +615,8 @@
 	if( update_icon )	//forces a full overlay update
 		update_icon = 0
 		regenerate_icons()
-	else if( lying != lying_prev )
-		update_icons()
+	if( lying != last_lying )
+		update_transform()
 
 /mob/proc/reset_layer()
 	if(lying)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -87,7 +87,6 @@
 	var/sleeping = 0		//Carbon
 	var/resting = 0			//Carbon
 	var/lying = 0
-	var/lying_prev = 0
 
 	var/radio_interrupt_cooldown = 0
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -3,7 +3,6 @@
 	plane = DEFAULT_PLANE
 	layer = MOB_LAYER
 
-	appearance_flags = PIXEL_SCALE
 	animate_movement = 2
 	movable_flags = MOVABLE_FLAG_PROXMOVE
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -963,9 +963,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		if(DISMEMBER_METHOD_EDGE)
 			compile_icon()
 			add_blood(victim)
-			var/matrix/M = matrix()
-			M.Turn(rand(180))
-			src.transform = M
+			set_rotation(rand(180))
 			forceMove(get_turf(src))
 			if(!clean)
 				// Throw limb around.

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -7,7 +7,6 @@
 	min_broken_damage = 30
 	dir = SOUTH
 	organ_tag = "limb"
-	appearance_flags = PIXEL_SCALE
 
 	var/slowdown = 0
 

--- a/code/modules/pointdefense/pointdefense.dm
+++ b/code/modules/pointdefense/pointdefense.dm
@@ -106,7 +106,6 @@
 	base_type = /obj/machinery/pointdefense
 	stock_part_presets = list(/decl/stock_part_preset/terminal_setup)
 	uncreated_component_parts = null
-	appearance_flags = PIXEL_SCALE
 	var/active = TRUE
 	var/charge_cooldown = 1 SECOND  //time between it can fire at different targets
 	var/last_shot = 0

--- a/mods/mobs/dionaea/mob/gestalt/_gestalt.dm
+++ b/mods/mobs/dionaea/mob/gestalt/_gestalt.dm
@@ -7,7 +7,6 @@
 	opacity = FALSE
 	anchored = FALSE
 	movement_handlers = list(/datum/movement_handler/deny_multiz, /datum/movement_handler/delay = list(5))
-	appearance_flags = PIXEL_SCALE
 
 	var/list/nymphs                  = list()
 	var/list/valid_things_to_roll_up = list(/mob/living/carbon/alien/diona = TRUE, /mob/living/carbon/alien/diona/sterile = TRUE)


### PR DESCRIPTION
Semi-ports some new procs that will conveniently allow for rotating or scaling of objects by acting as a setter. Optionally you can have the adjustment be animated over a period of time with a var on the object being scaled, which is used to keep the rotation delay for when humans lie down. It might also be useful for other objects in the future (like, say, refactored turrets perhaps).

Other changes include;
* In VV, modifying the variables `icon_scale_x`, `icon_scale_y`, or `icon_rotation` will apply the transform immediately.
* `PIXEL_SCALE` is added onto `/atom/movable` by request, which will make objects that are rotated/scaled look nicer instead of superblur.
* Changes some `matrix.Turn()` and `matrix.Scale()` calls that seemed safe to replace.
* Decouples human mob rotation from the icon updating code. Lying down or getting up no longer needs to call for an icon update. Probably the best part of this PR.

This is my first PR and apparently its to add some backend stuff instead of shiny features. Let me know if this can be improved.
