### PR TITLE
Added glide smoothing.

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -312,3 +312,5 @@
 #define CAN_INJECT 1
 #define INJECTION_PORT 2
 #define INJECTION_PORT_DELAY 3 SECONDS // used by injectors to apply delay due to searching for a port on the injectee's suit
+
+#define ADJUSTED_GLIDE_SIZE(DELAY) (CEILING((WORLD_ICON_SIZE / max((DELAY), world.tick_lag) * world.tick_lag) - world.tick_lag, 1) + (config.glide_size_delay))

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -136,6 +136,7 @@ var/list/gamemode_cache = list()
 	var/skill_sprint_cost_range = 0.8
 	var/minimum_stamina_recovery = 1
 	var/maximum_stamina_recovery = 3
+	var/glide_size_delay = 1
 
 	//Mob specific modifiers. NOTE: These will affect different mob types in different ways
 	var/human_delay = 0
@@ -821,6 +822,8 @@ var/list/gamemode_cache = list()
 					config.walk_delay = value
 				if("creep_delay")
 					config.creep_delay = value
+				if("glide_size_delay")
+					config.glide_size_delay = value
 				if("minimum_sprint_cost")
 					config.minimum_sprint_cost = value
 				if("skill_sprint_cost_range")

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -131,9 +131,10 @@
 	var/next_move
 
 /datum/movement_handler/mob/delay/DoMove(var/direction, var/mover, var/is_external)
-	if(is_external)
-		return
-	next_move = world.time + max(1, mob.movement_delay())
+	if(!is_external)
+		var/delay = max(1, mob.movement_delay())
+		next_move = world.time + delay
+		mob.glide_size = ADJUSTED_GLIDE_SIZE(delay)
 
 /datum/movement_handler/mob/delay/MayMove(var/mover, var/is_external)
 	if(IS_NOT_SELF(mover) && is_external)

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -275,6 +275,7 @@
 	return current_grab.grab_slowdown
 
 /obj/item/grab/proc/assailant_moved()
+	affecting.glide_size = assailant.glide_size
 	current_grab.assailant_moved(src)
 
 /obj/item/grab/proc/restrains()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -128,6 +128,7 @@ default behaviour is:
 					for(var/obj/structure/window/win in get_step(AM,t))
 						now_pushing = 0
 						return
+				AM.glide_size = glide_size
 				step(AM, t)
 				if (istype(AM, /mob/living))
 					var/mob/living/tmob = AM

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -48,6 +48,10 @@ REVIVAL_BRAIN_LIFE -1
 RUN_DELAY 2
 WALK_DELAY 4
 CREEP_DELAY 6
+
+## Set this to 0 for perfectly smooth movement gliding, or 1 or more for delayed chess move style movements.
+#GLIDE_SIZE_DELAY 0
+
 MINIMUM_SPRINT_COST 0.8
 SKILL_SPRINT_COST_RANGE 0.8
 MINIMUM_STAMINA_RECOVERY 5


### PR DESCRIPTION
Adds adaptive glide_size that smooths out your tile movements. By default it includes a one tick delay at the end of your glide size, which causes a pause between each move (nearly identical to current movement behavior). If configured to 0, it will completely smooth your movements between tiles.