### PR TITLE
Removes view reset default in life; fixes zooming.

### DIFF
--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -756,9 +756,9 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 	user.visible_message("\The [user] peers through [zoomdevicename ? "the [zoomdevicename] of [src]" : "[src]"].")
 
-	GLOB.destroyed_event.register(src, src, /obj/item/proc/unzoom)
-	GLOB.moved_event.register(src, src, /obj/item/proc/unzoom)
-	GLOB.dir_set_event.register(src, src, /obj/item/proc/unzoom)
+	GLOB.destroyed_event.register(user, src, /obj/item/proc/unzoom)
+	GLOB.moved_event.register(user, src, /obj/item/proc/unzoom)
+	GLOB.dir_set_event.register(user, src, /obj/item/proc/unzoom)
 	GLOB.item_unequipped_event.register(src, src, /obj/item/proc/zoom_drop)
 	GLOB.stat_set_event.register(user, src, /obj/item/proc/unzoom)
 
@@ -770,16 +770,10 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 		return
 	zoom = 0
 
-	GLOB.destroyed_event.unregister(src, src, /obj/item/proc/unzoom)
-	GLOB.moved_event.unregister(src, src, /obj/item/proc/unzoom)
-	GLOB.dir_set_event.unregister(src, src, /obj/item/proc/unzoom)
+	GLOB.destroyed_event.unregister(user, src, /obj/item/proc/unzoom)
+	GLOB.moved_event.unregister(user, src, /obj/item/proc/unzoom)
+	GLOB.dir_set_event.unregister(user, src, /obj/item/proc/unzoom)
 	GLOB.item_unequipped_event.unregister(src, src, /obj/item/proc/zoom_drop)
-
-	user = user == src ? loc : (user || loc)
-	if(!istype(user))
-		PRINT_STACK_TRACE("[log_info_line(src)]: Zoom user lost]")
-		return
-
 	GLOB.stat_set_event.unregister(user, src, /obj/item/proc/unzoom)
 
 	if(!user.client)

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -112,10 +112,6 @@
 		if(machine)
 			if(machine.check_eye(src) < 0)
 				reset_view(null)
-		else
-			if(client && !client.adminobs)
-				reset_view(null)
-
 	return 1
 
 /mob/living/carbon/alien/handle_environment(var/datum/gas_mixture/environment)

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -175,8 +175,4 @@
 		if (machine)
 			if (!( machine.check_eye(src) ))
 				reset_view(null)
-		else
-			if(client && !client.adminobs)
-				reset_view(null)
-
 	return 1

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1075,19 +1075,11 @@
 			reset_view(null, 0)
 		else if(viewflags)
 			set_sight(sight|viewflags)
-	else if(eyeobj)
-		if(eyeobj.owner != src)
-			reset_view(null)
-	else
-		var/isRemoteObserve = 0
-		if(z_eye)
-			isRemoteObserve = 1
-		else if((mRemote in mutations) && remoteview_target)
-			if(remoteview_target.stat == CONSCIOUS)
-				isRemoteObserve = 1
-		if(!isRemoteObserve && client && !client.adminobs)
-			remoteview_target = null
-			reset_view(null, 0)
+	if(eyeobj && eyeobj.owner != src)
+		reset_view(null)
+	if((mRemote in mutations) && remoteview_target && remoteview_target.stat != CONSCIOUS)
+		remoteview_target = null
+		reset_view(null, 0)
 
 	update_equipment_vision()
 	species.handle_vision(src)


### PR DESCRIPTION
Closes #1359.
Closes #1263.

Changes the default view reset behavior in Life() from reset to don't reset; machines and eyemobs still reset if conditions aren't met, so this shouldn't affect cameras or AI unless they were extremely broken to begin with. It will cause issues with sloppy/broken code elsewhere if there is any.