### PR TITLE
Adds flag on shuttles to bypass docking codes.

### DIFF
--- a/code/__defines/shuttle.dm
+++ b/code/__defines/shuttle.dm
@@ -2,6 +2,7 @@
 #define SHUTTLE_FLAGS_PROCESS 1
 #define SHUTTLE_FLAGS_SUPPLY  2
 #define SHUTTLE_FLAGS_ZERO_G  4
+#define SHUTTLE_FLAGS_NO_CODE 8  // Essentially bypasses docking codes by extracting them from the target docking controller. Only relevant on /autodock.
 #define SHUTTLE_FLAGS_ALL (~SHUTTLE_FLAGS_NONE)
 
 #define SLANDMARK_FLAG_AUTOSET      1 // If set, will set base area and turf type to same as where it was spawned at.

--- a/code/modules/shuttles/shuttle_autodock.dm
+++ b/code/modules/shuttles/shuttle_autodock.dm
@@ -63,6 +63,8 @@
 */
 /datum/shuttle/autodock/proc/dock()
 	if(active_docking_controller && shuttle_docking_controller)
+		if(flags & SHUTTLE_FLAGS_NO_CODE)
+			set_docking_codes(active_docking_controller.docking_codes)
 		shuttle_docking_controller.initiate_docking(active_docking_controller.id_tag)
 		last_dock_attempt_time = world.time
 

--- a/code/modules/shuttles/shuttle_emergency.dm
+++ b/code/modules/shuttles/shuttle_emergency.dm
@@ -1,6 +1,7 @@
 /datum/shuttle/autodock/ferry/emergency
 	category = /datum/shuttle/autodock/ferry/emergency
 	move_time = 10 MINUTES
+	flags = SHUTTLE_FLAGS_PROCESS | SHUTTLE_FLAGS_ZERO_G | SHUTTLE_FLAGS_NO_CODE
 	var/datum/evacuation_controller/shuttle/emergency_controller
 
 /datum/shuttle/autodock/ferry/emergency/New()

--- a/code/modules/shuttles/shuttle_supply.dm
+++ b/code/modules/shuttles/shuttle_supply.dm
@@ -2,7 +2,7 @@
 	var/away_location = 1	//the location to hide at while pretending to be in-transit
 	var/late_chance = 80
 	var/max_late_time = (30 SECONDS)
-	flags = SHUTTLE_FLAGS_PROCESS|SHUTTLE_FLAGS_SUPPLY
+	flags = SHUTTLE_FLAGS_PROCESS|SHUTTLE_FLAGS_SUPPLY|SHUTTLE_FLAGS_NO_CODE
 	category = /datum/shuttle/autodock/ferry/supply
 	ceiling_type = /turf/simulated/floor/shuttle_ceiling
 


### PR DESCRIPTION
This is designed for use with legacy shuttles (ferries) which start out off-station and will only be docking with the station. Potentially also useful for debugging.