### PR TITLE
Changes to CanPass, movement glide buckle/grab interactions, wheelchairs.

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -30,7 +30,6 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define MOVABLE_FLAG_Z_INTERACT           BITFLAG(1) // Should attackby and attack_hand be relayed through ladders and open spaces?
 #define MOVABLE_FLAG_EFFECTMOVE           BITFLAG(2) // Is this an effect that should move?
 #define MOVABLE_FLAG_DEL_SHUTTLE          BITFLAG(3) // Shuttle transistion will delete this.
-#define MOVABLE_FLAG_NONDENSE_COLLISION   BITFLAG(4) // Used for non-dense movables that should be capable of colliding when attempting to move onto dense atoms
 
 #define OBJ_FLAG_ANCHORABLE               BITFLAG(0) // This object can be stuck in place with a tool
 #define OBJ_FLAG_CONDUCTIBLE              BITFLAG(1) // Conducts electricity. (metal etc.)

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -217,6 +217,7 @@
 	if(isturf(mob.loc))
 		for(var/atom/movable/M in mob.ret_grab())
 			if(M != src && M.loc != mob.loc && !M.anchored && get_dist(old_turf, M) <= 1)
+				M.glide_size = mob.glide_size // This is adjusted by grabs again from events/some of the procs below, but doing it here makes it more likely to work with recursive movement.
 				step(M, get_dir(M.loc, old_turf))
 		for(var/obj/item/grab/G in mob.get_active_grabs())
 			G.adjust_position()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -327,7 +327,3 @@
 		user.make_grab(src)
 		return 0
 	. = ..()
-
-/atom/movable/CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-	. = ..() || (mover && !(mover.movable_flags & MOVABLE_FLAG_NONDENSE_COLLISION) && !mover.density)
-

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -116,6 +116,3 @@
 				"<span class='notice'>You hear metal clanking.</span>")
 		add_fingerprint(user)
 	return M
-
-/obj/CanPass(atom/movable/mover, turf/target, height = 1.5, air_group = 0)
-	. = ..() || (buckled_mob == mover)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -107,7 +107,8 @@
 /obj/structure/bed/Move()
 	. = ..()
 	if(buckled_mob)
-		buckled_mob.forceMove(src.loc)
+		buckled_mob.glide_size = glide_size // Setting loc apparently does animate with glide size.
+		buckled_mob.forceMove(loc)
 
 /obj/structure/bed/forceMove()
 	. = ..()

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -5,10 +5,8 @@
 	anchored = FALSE
 	buckle_movable = TRUE
 	movement_handlers = list(/datum/movement_handler/deny_multiz, /datum/movement_handler/delay = list(5), /datum/movement_handler/move_relay_self)
-	movable_flags = MOVABLE_FLAG_NONDENSE_COLLISION
 
 	var/item_form_type = /obj/item/wheelchair_kit
-	var/driving = FALSE
 	var/bloodiness
 
 /obj/structure/bed/chair/wheelchair/Initialize()
@@ -40,37 +38,11 @@
 		return
 	if(propelled)
 		return
-	// Let's roll
-	driving = TRUE
-	//--1---Move occupant---1--//
-	if(buckled_mob)
-		buckled_mob.buckled = null
-		step(buckled_mob, direction)
-		buckled_mob.buckled = src
-	//--2--Move wheelchair--2--//
+
 	step(src, direction)
-	if(buckled_mob) // Make sure it stays beneath the occupant
-		Move(buckled_mob.loc)
 	set_dir(direction)
 	if(bloodiness)
 		create_track()
-	driving = FALSE
-
-/obj/structure/bed/chair/wheelchair/Move()
-	. = ..()
-	if(buckled_mob)
-		var/mob/living/occupant = buckled_mob
-		if(!driving)
-			if (occupant && (src.loc != occupant.loc))
-				if (propelled)
-					for (var/mob/O in src.loc)
-						if (O != occupant)
-							Bump(O)
-				else
-					unbuckle_mob()
-		else
-			if (occupant && (src.loc != occupant.loc))
-				src.forceMove(occupant.loc) // Failsafe to make sure the wheelchair stays beneath the occupant after driving
 
 /obj/structure/bed/chair/wheelchair/attack_hand(mob/living/user)
 	user_unbuckle_mob(user)

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -275,7 +275,7 @@
 	return current_grab.grab_slowdown
 
 /obj/item/grab/proc/assailant_moved()
-	affecting.glide_size = assailant.glide_size
+	affecting.glide_size = assailant.glide_size // Note that this is called _after_ the Move() call resolves, so while it adjusts affecting's move animation, it won't adjust anything else depending on it.
 	current_grab.assailant_moved(src)
 
 /obj/item/grab/proc/restrains()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -6,7 +6,7 @@
 		return TRUE // Doesn't necessarily mean the mob physically moved
 
 /mob/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	. = lying || ..() || (mover == buckled)
+	. = lying || ..() || !mover.density
 
 /mob/proc/SetMoveCooldown(var/timeout)
 	var/datum/movement_handler/mob/delay/delay = GetMovementHandler(/datum/movement_handler/mob/delay)


### PR DESCRIPTION
Closes #1103.

The CanPass handling essentially reverts it to a more bay-like state. Non-dense movables can't pass through dense ones by default again (but can pass through dense mobs).

The glide size changes make buckling look less awful when moving, and also work with grabbing the bucked obj.

The wheelchair changes remove a bunch of code which is inaccessible or redundant.