### PR TITLE
Collapsing ChangeTurf into one proc instead of half a dozen overrides.

### DIFF
--- a/code/datums/observation/density_set.dm
+++ b/code/datums/observation/density_set.dm
@@ -22,9 +22,3 @@ GLOBAL_DATUM_INIT(density_set_event, /decl/observ/density_set, new)
 	UNLINT(. = ..())
 	if(density != old_density)
 		GLOB.density_set_event.raise_event(src, old_density, density)
-
-/turf/ChangeTurf()
-	var/old_density = opacity
-	UNLINT(. = ..())
-	if(density != old_density)
-		GLOB.density_set_event.raise_event(src, old_density, density)

--- a/code/datums/observation/turf_changed.dm
+++ b/code/datums/observation/turf_changed.dm
@@ -15,14 +15,3 @@ GLOBAL_DATUM_INIT(turf_changed_event, /decl/observ/turf_changed, new)
 /decl/observ/turf_changed
 	name = "Turf Changed"
 	expected_type = /turf
-
-/************************
-* Turf Changed Handling *
-************************/
-
-/turf/ChangeTurf()
-	var/old_density = density
-	var/old_opacity = opacity
-	. = ..()
-	if(.)
-		GLOB.turf_changed_event.raise_event(src, old_density, density, old_opacity, opacity)

--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -14,11 +14,11 @@
 	var/obj/effect/overmap/visitable/sector/exoplanet/owner
 
 /turf/exterior/ChangeTurf()
-	var/last_affecting_heat_sources
-	. = ..()
-	var/turf/exterior/ext = .
+	var/last_affecting_heat_sources = affecting_heat_sources
+	var/turf/exterior/ext = ..()
 	if(istype(ext))
 		ext.affecting_heat_sources = last_affecting_heat_sources
+	return ext
 
 /turf/exterior/is_plating()
 	return !density

--- a/code/game/turfs/turf_ao.dm
+++ b/code/game/turfs/turf_ao.dm
@@ -107,10 +107,3 @@
 #undef PROCESS_AO_CORNER
 #undef AO_TURF_CHECK
 #undef AO_SELF_CHECK
-
-/turf/ChangeTurf()
-	var/old_density = density
-	var/old_permit_ao = permit_ao
-	. = ..()
-	if(density != old_density || permit_ao != old_permit_ao)
-		regenerate_ao()

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -22,6 +22,7 @@
 
 //Creates a new turf
 /turf/proc/ChangeTurf(var/turf/N, var/tell_universe = TRUE, var/force_lighting_update = FALSE, var/keep_air = FALSE)
+
 	if (!N)
 		return
 
@@ -39,29 +40,26 @@
 	var/old_lighting_overlay = lighting_overlay
 	var/old_corners = corners
 	var/old_ao_neighbors = ao_neighbors
+	var/old_permit_ao = permit_ao
 	var/old_above = above
 	var/old_prev_type = prev_type
-
-//	log_debug("Replacing [src.type] with [N]")
+	var/old_density = density
 
 	changing_turf = TRUE
 
-	if(connections) connections.erase_all()
+	if(connections) 
+		connections.erase_all()
 
 	overlays.Cut()
 	underlays.Cut()
 
-	// Run the Destroy() chain.
 	qdel(src)
 
 	var/old_opaque_counter = opaque_counter
-	var/turf/simulated/W = new N(src)
+	var/turf/W = new N(src)
 
 	above = old_above
 	prev_type = old_prev_type
-
-	if (permit_ao)
-		regenerate_ao()
 
 	W.opaque_counter = old_opaque_counter
 	W.RecalculateOpacity()
@@ -72,7 +70,7 @@
 	if(ispath(N, /turf/simulated))
 		if(old_fire)
 			fire = old_fire
-		if (istype(W,/turf/simulated/floor))
+		if(istype(W,/turf/simulated/floor))
 			W.RemoveLattice()
 	else if(old_fire)
 		qdel(old_fire)
@@ -80,29 +78,37 @@
 	if(tell_universe)
 		GLOB.universe.OnTurfChange(W)
 
-	SSair.mark_for_update(src) //handle the addition of the new turf.
+	SSair.mark_for_update(W) //handle the addition of the new turf.
 
 	for(var/turf/S in range(W,1))
 		S.update_starlight()
 
-	W.post_change()
 	. = W
-
+	W.post_change()
 	W.ao_neighbors = old_ao_neighbors
 	if(lighting_overlays_initialised)
-		lighting_overlay = old_lighting_overlay
-		affecting_lights = old_affecting_lights
-		corners = old_corners
-		if((old_opacity != opacity) || (dynamic_lighting != old_dynamic_lighting))
-			reconsider_lights()
-		if(dynamic_lighting != old_dynamic_lighting)
-			if(dynamic_lighting)
-				lighting_build_overlay()
+		W.lighting_overlay = old_lighting_overlay
+		W.affecting_lights = old_affecting_lights
+		W.corners = old_corners
+		if(W.dynamic_lighting != old_dynamic_lighting)
+			if(W.dynamic_lighting)
+				W.lighting_build_overlay()
 			else
-				lighting_clear_overlay()
+				W.lighting_clear_overlay()
+			W.reconsider_lights()
+		else if(W.opacity != old_opacity)
+			W.reconsider_lights()
 
-	for(var/turf/T in RANGE_TURFS(src, 1))
-		T.update_icon()
+	for(var/turf/T in RANGE_TURFS(W, 1))
+		T.queue_icon_update()
+
+	GLOB.turf_changed_event.raise_event(W, old_density, W.density, old_opacity, W.opacity)
+	updateVisibility(W, FALSE)
+	if(W.density != old_density)
+		GLOB.density_set_event.raise_event(W, old_density, W.density)
+		W.regenerate_ao()
+	else if(W.permit_ao != old_permit_ao)
+		W.regenerate_ao()
 
 /turf/proc/transport_properties_from(turf/other)
 	if(!istype(other, src.type))

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -42,12 +42,6 @@
 		return aquarium.reagents.total_volume * TANK_WATER_MULTIPLIER
 	return 0
 
-/turf/ChangeTurf(var/turf/N, var/tell_universe=1, var/force_lighting_update = 0)
-	. = ..()
-	var/turf/T = .
-	if(isturf(T) && !T.flooded && T.flood_object)
-		QDEL_NULL(flood_object)
-
 /turf/proc/show_bubbles()
 	set waitfor = 0
 

--- a/code/modules/mob/observer/eye/freelook/update_triggers.dm
+++ b/code/modules/mob/observer/eye/freelook/update_triggers.dm
@@ -24,8 +24,3 @@
 	// don't check then?
 	if(!glass)
 		updateVisibility(src, FALSE)
-
-/turf/ChangeTurf()
-	. = ..()
-	if(.)
-		updateVisibility(src, FALSE)


### PR DESCRIPTION
Also causes turf changes to queue icon updates instead of hard calling them for every turf change.
Also also deletes unnecessary flood overlay updating being done in ChangeTurf when it's then done in update_icon afterwards anyway.
Some limited testing with tradeship set to 20 exoplanets took it from 90s init to 75s init on my machine, but I'm not sure how much of that is tied to the random element in exoplanet init.