### PR TITLE
Normalizing typed user arg in attack procs.

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -85,7 +85,7 @@
 	A.attack_ai(src)
 	return TRUE
 
-/atom/proc/attack_ai(mob/user)
+/atom/proc/attack_ai(mob/living/silicon/ai/user)
 	return
 
 /*

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -321,9 +321,10 @@
 /atom/movable/proc/get_bullet_impact_effect_type()
 	return BULLET_IMPACT_NONE
 
-/atom/movable/attack_hand(mob/living/user)
+/atom/movable/attack_hand(mob/user)
 	// Anchored check so we can operate switches etc on grab intent without getting grab failure msgs.
-	if(istype(user) && !user.lying && user.a_intent == I_GRAB && !anchored)
-		user.make_grab(src)
+	if(isliving(user) && !user.lying && user.a_intent == I_GRAB && !anchored)
+		var/mob/living/M = user
+		M.make_grab(src)
 		return 0
 	. = ..()

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -45,7 +45,7 @@
 	if(iscultist(user))
 		to_chat(user, "This is \a [cultname] rune.")
 
-/obj/effect/rune/attackby(var/obj/item/I, var/mob/living/user)
+/obj/effect/rune/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/book/tome) && iscultist(user))
 		user.visible_message("<span class='notice'>[user] rubs \the [src] with \the [I], and \the [src] is absorbed by it.</span>", "You retrace your steps, carefully undoing the lines of \the [src].")
 		qdel(src)
@@ -55,11 +55,11 @@
 		qdel(src)
 		return
 
-/obj/effect/rune/attack_hand(var/mob/living/user)
+/obj/effect/rune/attack_hand(var/mob/user)
 	if(!iscultist(user))
 		to_chat(user, "You can't mouth the arcane scratchings without fumbling over them.")
 		return
-	if(user.is_muzzled() || user.silent)
+	if(user.is_silenced())
 		to_chat(user, "You are unable to speak the words of the rune.")
 		return
 	var/decl/special_role/cultist/cult = GET_DECL(/decl/special_role/cultist)
@@ -68,7 +68,7 @@
 		return fizzle(user)
 	cast(user)
 
-/obj/effect/rune/attack_ai(var/mob/living/user) // Cult borgs!
+/obj/effect/rune/attack_ai(var/mob/user) // Cult borgs!
 	if(Adjacent(user))
 		attack_hand(user)
 
@@ -294,14 +294,14 @@
 		else
 			to_chat(user, "<span class='danger'>It is about to dissipate.</span>")
 
-/obj/effect/cultwall/attack_hand(var/mob/living/user)
+/obj/effect/cultwall/attack_hand(var/mob/user)
 	if(iscultist(user))
 		user.visible_message("<span class='notice'>\The [user] touches \the [src], and it fades.</span>", "<span class='notice'>You touch \the [src], whispering the old ritual, making it disappear.</span>")
 		qdel(src)
 	else
 		to_chat(user, "<span class='notice'>You touch \the [src]. It feels wet and becomes harder the further you push your arm.</span>")
 
-/obj/effect/cultwall/attackby(var/obj/item/I, var/mob/living/user)
+/obj/effect/cultwall/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/nullrod))
 		user.visible_message("<span class='notice'>\The [user] touches \the [src] with \the [I], and it disappears.</span>", "<span class='notice'>You disrupt the vile magic with the deadening field of \the [I].</span>")
 		qdel(src)
@@ -794,7 +794,7 @@
 		command_announcement.Announce("Gravitational anomaly has ceased.")
 		qdel(src)
 
-/obj/effect/rune/tearreality/attack_hand(var/mob/living/user)
+/obj/effect/rune/tearreality/attack_hand(var/mob/user)
 	..()
 	if(HECOMES && !iscultist(user))
 		var/input = input(user, "Are you SURE you want to sacrifice yourself?", "DO NOT DO THIS") in list("Yes", "No")

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -3,7 +3,7 @@
 	var/imbue = null
 	info = "<center><img src='talisman.png'></center><br/><br/>"
 
-/obj/item/paper/talisman/attack_self(var/mob/living/user)
+/obj/item/paper/talisman/attack_self(var/mob/user)
 	if(iscultist(user))
 		to_chat(user, "Attack your target to use this talisman.")
 	else
@@ -12,7 +12,7 @@
 /obj/item/paper/talisman/attack(var/mob/living/M, var/mob/living/user)
 	return
 
-/obj/item/paper/talisman/stun/attack_self(var/mob/living/user)
+/obj/item/paper/talisman/stun/attack_self(var/mob/user)
 	if(iscultist(user))
 		to_chat(user, "This is a stun talisman.")
 	..()
@@ -40,7 +40,7 @@
 	user.unEquip(src)
 	qdel(src)
 
-/obj/item/paper/talisman/emp/attack_self(var/mob/living/user)
+/obj/item/paper/talisman/emp/attack_self(var/mob/user)
 	if(iscultist(user))
 		to_chat(user, "This is an emp talisman.")
 	..()

--- a/code/game/gamemodes/endgame/supermatter_cascade/cascade_blob.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/cascade_blob.dm
@@ -59,7 +59,7 @@
 /turf/unsimulated/wall/cascade/attack_ghost(mob/user)
 	user.examinate(src)
 
-/turf/unsimulated/wall/cascade/attack_ai(mob/user)
+/turf/unsimulated/wall/cascade/attack_ai(mob/living/silicon/ai/user)
 	user.examinate(src)
 
 /turf/unsimulated/wall/cascade/attack_hand(mob/user)
@@ -72,7 +72,7 @@
 	Consume(user)
 	return TRUE
 
-/turf/unsimulated/wall/cascade/attackby(obj/item/W, mob/living/user)
+/turf/unsimulated/wall/cascade/attackby(obj/item/W, mob/user)
 	user.visible_message("<span class=\"warning\">\The [user] touches \a [W] to \the [src] as a silence fills the room...</span>",\
 		"<span class=\"danger\">You touch \the [W] to \the [src] when everything suddenly goes silent.\"</span>\n<span class=\"notice\">\The [W] flashes into dust as you flinch away from \the [src].</span>",\
 		"<span class=\"warning\">Everything suddenly goes silent.</span>")

--- a/code/game/gamemodes/godmode/form_items/starlight_structures.dm
+++ b/code/game/gamemodes/godmode/form_items/starlight_structures.dm
@@ -177,7 +177,7 @@
 			if(get_dist(M.current, src) <= 3)
 				. += M.current
 
-/obj/structure/deity/radiant_statue/attack_hand(var/mob/living/L)
+/obj/structure/deity/radiant_statue/attack_hand(var/mob/L)
 	if(!istype(L))
 		return
 	var/obj/O = L.get_equipped_item(slot_wear_suit_str)

--- a/code/game/gamemodes/godmode/form_items/wizard_structures.dm
+++ b/code/game/gamemodes/godmode/form_items/wizard_structures.dm
@@ -8,7 +8,7 @@
 	power_adjustment = 2
 	build_cost = 700
 
-/obj/structure/deity/wizard_recharger/attack_hand(var/mob/living/hitter)
+/obj/structure/deity/wizard_recharger/attack_hand(var/mob/hitter)
 	if(!hitter.mind || !hitter.mind.learned_spells || !hitter.mind.learned_spells.len)
 		to_chat(hitter, "<span class='warning'>You don't feel as if this will do anything for you.</span>")
 		return

--- a/code/game/gamemodes/godmode/god_pylon.dm
+++ b/code/game/gamemodes/godmode/god_pylon.dm
@@ -18,7 +18,7 @@
 		linked_god.leave_pylon()
 	return ..()
 
-/obj/structure/deity/pylon/attack_hand(var/mob/living/L)
+/obj/structure/deity/pylon/attack_hand(var/mob/L)
 	if(!linked_god)
 		return
 	if(L in intuned)

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -249,7 +249,7 @@ Class Procs:
 
 ////////////////////////////////////////////////////////////////////////////////////////////
 
-/obj/machinery/attack_ai(mob/user)
+/obj/machinery/attack_ai(mob/living/silicon/ai/user)
 	if(CanUseTopic(user, DefaultTopicState()) > STATUS_CLOSE)
 		return interface_interact(user)
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -162,7 +162,7 @@
 		destroy()
 		return TRUE
 
-/obj/machinery/camera/attackby(obj/item/W, mob/living/user)
+/obj/machinery/camera/attackby(obj/item/W, mob/user)
 	update_coverage()
 	var/datum/wires/camera/camera_wires = wires
 	// DECONSTRUCTION

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -24,7 +24,7 @@
 				4 = Screwdriver panel closed and is fully built (you cannot attach upgrades)
 	*/
 
-/obj/item/camera_assembly/attackby(obj/item/W, mob/living/user)
+/obj/item/camera_assembly/attackby(obj/item/W, mob/user)
 
 	switch(state)
 

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -183,7 +183,7 @@
 				return
 			sleep(10)
 
-/obj/machinery/camera/attack_ai(var/mob/living/silicon/ai/user)
+/obj/machinery/camera/attack_ai(mob/living/silicon/ai/user)
 	if (!istype(user))
 		return
 	if (!src.can_use())

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -38,7 +38,7 @@
 				break
 	. = tracking_linked_server
 
-/obj/machinery/computer/message_monitor/attackby(obj/item/O, mob/living/user)
+/obj/machinery/computer/message_monitor/attackby(obj/item/O, mob/user)
 	if(stat & (NOPOWER|BROKEN))
 		..()
 		return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -465,7 +465,7 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/attack_robot(mob/user)
 	ui_interact(user)
 
-/obj/machinery/door/airlock/attack_ai(mob/user)
+/obj/machinery/door/airlock/attack_ai(mob/living/silicon/ai/user)
 	ui_interact(user)
 
 /obj/machinery/door/airlock/attack_ghost(mob/user)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -164,7 +164,7 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 	return 0
 
 /obj/machinery/hologram/holopad/attack_ai(mob/living/silicon/ai/user)
-	if (!istype(user))
+	if(!istype(user))
 		return
 	/*There are pretty much only three ways to interact here.
 	I don't need to check for client since they're clicking on an object.

--- a/code/game/machinery/message_server.dm
+++ b/code/game/machinery/message_server.dm
@@ -117,7 +117,7 @@
 	update_icon()
 	return TRUE
 
-/obj/machinery/network/message_server/attackby(obj/item/O, mob/living/user)
+/obj/machinery/network/message_server/attackby(obj/item/O, mob/user)
 	if (active && !(stat & (BROKEN|NOPOWER)) && (spamfilter_limit < MESSAGE_SERVER_DEFAULT_SPAM_LIMIT*2) && \
 		istype(O,/obj/item/stock_parts/circuitboard/message_monitor))
 		spamfilter_limit += round(MESSAGE_SERVER_DEFAULT_SPAM_LIMIT / 2)

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -41,7 +41,7 @@
 		to_chat(user, "<span class='notice'>The console is locked on to \[[T.loc.name]\].</span>")
 
 
-/obj/machinery/computer/teleporter/attackby(var/obj/I, var/mob/living/user)
+/obj/machinery/computer/teleporter/attackby(var/obj/I, var/mob/user)
 	if(istype(I, /obj/item/card/data/))
 		var/obj/item/card/data/C = I
 		if(stat & (NOPOWER|BROKEN) & (C.function != "teleporter"))

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -10,7 +10,7 @@
 	var/buckle_sound
 	var/mob/living/buckled_mob = null
 
-/obj/attack_hand(mob/living/user)
+/obj/attack_hand(mob/user)
 	. = ..()
 	if(can_buckle && buckled_mob)
 		user_unbuckle_mob(user)

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -126,14 +126,15 @@ var/global/list/image/splatter_cache=list()
 	remove_extension(src, /datum/extension/scent)
 	STOP_PROCESSING(SSobj, src)
 
-/obj/effect/decal/cleanable/blood/attack_hand(mob/living/carbon/human/user)
+/obj/effect/decal/cleanable/blood/attack_hand(mob/user)
 	..()
-	if (amount && length(blood_data) && istype(user))
-		if (user.gloves)
+	if (amount && length(blood_data) && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.gloves)
 			return
 		var/taken = rand(1,amount)
 		amount -= taken
-		to_chat(user, "<span class='notice'>You get some of \the [src] on your hands.</span>")
+		to_chat(user, SPAN_NOTICE("You get some of \the [src] on your hands."))
 		for(var/bloodthing in blood_data)
 			user.add_blood(null, max(1, amount/length(blood_data)), blood_data[bloodthing])
 		user.verbs += /mob/living/carbon/human/proc/bloody_doodle

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -13,7 +13,7 @@
 	if(!QDELETED(src) && (severity == 1 || (severity == 2 && prob(50) || (severity == 3 && prob(5)))))
 		qdel(src)
 
-/obj/effect/spider/attack_hand(mob/living/user)
+/obj/effect/spider/attack_hand(mob/user)
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(src)

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -293,7 +293,7 @@
 			pixel_x = 0
 			pixel_y = 0
 
-/obj/item/attack_ai(mob/user)
+/obj/item/attack_ai(mob/living/silicon/ai/user)
 	if (istype(src.loc, /obj/item/robot_module))
 		//If the item is part of a cyborg module, equip it
 		if(!isrobot(user))

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -15,8 +15,8 @@
 	if(set_valid_z_levels())
 		set_extension(src, /datum/extension/eye/blueprints)
 
-/obj/item/blueprints/attack_self(var/mob/living/carbon/human/user)
-	if (!istype(user) || !user.check_dexterity(DEXTERITY_COMPLEX_TOOLS)) // Monkeys et al. cannot blueprint.
+/obj/item/blueprints/attack_self(mob/user)
+	if (!ishuman(user) || !user.check_dexterity(DEXTERITY_COMPLEX_TOOLS)) // Monkeys et al. cannot blueprint.
 		to_chat(user, SPAN_WARNING("This stack of blue paper means nothing to you."))
 		return
 
@@ -59,7 +59,7 @@
 	name = "outpost blueprints"
 	icon_state = "blueprints2"
 
-/obj/item/blueprints/outpost/attack_self(var/mob/living/carbon/human/user)
+/obj/item/blueprints/outpost/attack_self(mob/user)
 	var/obj/effect/overmap/visitable/sector/S = map_sectors["[get_z(user)]"]
 	area_prefix = S.name
 	. = ..()

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -55,7 +55,7 @@
 	color_description = "white crayon"
 	uses = 0
 
-/obj/item/pen/crayon/mime/attack_self(mob/living/user) //inversion
+/obj/item/pen/crayon/mime/attack_self(mob/user) //inversion
 	if(colour != "#ffffff" && shadeColour != "#000000")
 		colour = "#ffffff"
 		shadeColour = "#000000"
@@ -74,7 +74,7 @@
 	color_description = "rainbow crayon"
 	uses = 0
 
-/obj/item/pen/crayon/rainbow/attack_self(mob/living/user)
+/obj/item/pen/crayon/rainbow/attack_self(mob/user)
 	colour = input(user, "Please select the main colour.", "Crayon colour") as color
 	shadeColour = input(user, "Please select the shade colour.", "Crayon colour") as color
 	return

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -139,7 +139,7 @@
 
 
 
-/obj/item/flash/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
+/obj/item/flash/attack_self(mob/user, flag = 0, emp = 0)
 	if(!user || !clown_check(user)) 	return 0
 
 	if(broken)

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -28,7 +28,7 @@
 		to_chat(user, "<span class='notice'>You have to be closer if you want to read it.</span>")
 
 //hit yourself with it
-/obj/item/holowarrant/attack_self(mob/living/user)
+/obj/item/holowarrant/attack_self(mob/user)
 	ui_interact(user)
 
 /obj/item/holowarrant/ui_interact(mob/user, ui_key = "main",var/datum/nanoui/ui = null)

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -12,12 +12,12 @@
 	var/insults = 0
 	var/list/insultmsg = list("FUCK EVERYONE!", "I'M A TATER!", "ALL SECURITY TO SHOOT ME ON SIGHT!", "I HAVE A BOMB!", "CAPTAIN IS A COMDOM!", "FOR THE SYNDICATE!")
 
-/obj/item/megaphone/attack_self(mob/living/user)
-	if (user.client)
+/obj/item/megaphone/attack_self(mob/user)
+	if(user.client)
 		if(user.client.prefs.muted & MUTE_IC)
 			to_chat(src, "<span class='warning'>You cannot speak in IC (muted).</span>")
 			return
-	if(user.silent)
+	if(user.is_silenced())
 		return
 	if(spamcheck)
 		to_chat(user, "<span class='warning'>\The [src] needs to recharge!</span>")

--- a/code/game/objects/items/devices/personal_shield.dm
+++ b/code/game/objects/items/devices/personal_shield.dm
@@ -6,7 +6,7 @@
 	var/uses = 5
 	var/obj/aura/personal_shield/device/shield
 
-/obj/item/personal_shield/attack_self(var/mob/living/user)
+/obj/item/personal_shield/attack_self(var/mob/user)
 	if(uses && !shield)
 		shield = new(user,src)
 	else

--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -63,7 +63,7 @@
 	var/turf/T = get_turf(src)
 	hide(hides_under_flooring() && !T.is_plating())
 
-/obj/item/radio/beacon/anchored/attackby(obj/item/I, mob/living/user)
+/obj/item/radio/beacon/anchored/attackby(obj/item/I, mob/user)
 	..()
 	if(istype(I, /obj/item/stack/nanopaste))
 		var/obj/item/stack/nanopaste/S = I

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -99,7 +99,7 @@
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 
-/obj/item/radio/intercom/attack_ai(mob/user)
+/obj/item/radio/intercom/attack_ai(mob/living/silicon/ai/user)
 	src.add_fingerprint(user)
 	spawn (0)
 		attack_self(user)

--- a/code/game/objects/items/devices/spy_bug.dm
+++ b/code/game/objects/items/devices/spy_bug.dm
@@ -40,7 +40,7 @@
 /obj/item/spy_bug/attack_self(mob/user)
 	radio.attack_self(user)
 
-/obj/item/spy_bug/attackby(obj/W, mob/living/user)
+/obj/item/spy_bug/attackby(obj/W, mob/user)
 	if(istype(W, /obj/item/spy_monitor))
 		var/obj/item/spy_monitor/SM = W
 		SM.pair(src, user)
@@ -88,7 +88,7 @@
 	radio.attack_self(user)
 	view_cameras(user)
 
-/obj/item/spy_monitor/attackby(obj/W, mob/living/user)
+/obj/item/spy_monitor/attackby(obj/W, mob/user)
 	if(istype(W, /obj/item/spy_bug))
 		pair(W, user)
 	else

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -29,7 +29,7 @@ effective or pretty fucking useless.
 	var/times_used = 0 //Number of times it's been used.
 	var/max_uses = 2
 
-/obj/item/batterer/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
+/obj/item/batterer/attack_self(mob/user, flag = 0, emp = 0)
 	if(!user) 	return
 	if(times_used >= max_uses)
 		to_chat(user, "<span class='warning'>The mind batterer has been burnt out!</span>")

--- a/code/game/objects/items/devices/whistle.dm
+++ b/code/game/objects/items/devices/whistle.dm
@@ -27,7 +27,7 @@
 
 	to_chat(usr, "You configure the hailer to shout \"[use_message]\".")
 
-/obj/item/hailer/attack_self(mob/living/carbon/user)
+/obj/item/hailer/attack_self(mob/user)
 	if (spamcheck)
 		return
 

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -54,7 +54,7 @@
 	else
 		icon_state = base_state
 
-/obj/item/stack/material/rods/attackby(obj/item/W, mob/living/user)
+/obj/item/stack/material/rods/attackby(obj/item/W, mob/user)
 	if(isWelder(W))
 		var/obj/item/weldingtool/WT = W
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -654,7 +654,7 @@
 	set_light(0.6, 0.5, 2, 2, "#ff0000")
 	return ..()
 
-/obj/item/marshalling_wand/attack_self(mob/living/user)
+/obj/item/marshalling_wand/attack_self(mob/user)
 	playsound(src.loc, 'sound/effects/rustle1.ogg', 100, 1)
 	if (user.a_intent == I_HELP)
 		user.visible_message("<span class='notice'>[user] beckons with \the [src], signalling forward motion.</span>",

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -64,7 +64,7 @@
 	detail_overlay.color = detail_color
 	overlays += detail_overlay
 
-/obj/item/card/data/attackby(obj/item/I, mob/living/user)
+/obj/item/card/data/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/integrated_electronics/detailer))
 		var/obj/item/integrated_electronics/detailer/D = I
 		detail_color = D.detail_color

--- a/code/game/objects/items/weapons/hair_care.dm
+++ b/code/game/objects/items/weapons/hair_care.dm
@@ -12,7 +12,7 @@
 	. = ..()
 	color = get_random_colour(lower = 150)
 
-/obj/item/haircomb/attack_self(var/mob/living/carbon/human/user)
+/obj/item/haircomb/attack_self(mob/user)
 	if(!user.incapacitated())
 		user.visible_message("<span class='notice'>\The [user] uses \the [src] to comb their hair with incredible style and sophistication. What a [user.gender == FEMALE ? "lady" : "guy"].</span>")
 
@@ -25,10 +25,11 @@
 	icon_state = "brush"
 	item_state = "brush"
 
-/obj/item/haircomb/brush/attack_self(mob/living/carbon/human/user)
-	if(!user.incapacitated())
-		var/datum/sprite_accessory/hair/hair_style = GLOB.hair_styles_list[user.h_style]
+/obj/item/haircomb/brush/attack_self(mob/user)
+	if(ishuman(user) && !user.incapacitated())
+		var/mob/living/carbon/human/H = user
+		var/datum/sprite_accessory/hair/hair_style = GLOB.hair_styles_list[H.h_style]
 		if(hair_style.flags & VERY_SHORT)
-			user.visible_message("<span class='notice'>\The [user] just sort of runs \the [src] over their scalp.</span>")
+			H.visible_message(SPAN_NOTICE("\The [H] just sort of runs \the [src] over their scalp."))
 		else
-			user.visible_message("<span class='notice'>\The [user] meticulously brushes their hair with \the [src].</span>")
+			H.visible_message(SPAN_NOTICE("\The [H] meticulously brushes their hair with \the [src]."))

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -58,7 +58,7 @@
 /obj/item/flame/lighter/proc/shutoff_effects(mob/user)
 	user.visible_message("<span class='notice'>[user] quietly shuts off the [src].</span>")
 
-/obj/item/flame/lighter/attack_self(mob/living/user)
+/obj/item/flame/lighter/attack_self(mob/user)
 	if(!lit)
 		if(reagents.has_reagent(/decl/material/liquid/fuel))
 			light(user)

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -72,12 +72,15 @@
 		to_chat(user, "<span class='notice'>\The [src] deactivates!</span>")
 	set_light(0)
 
-/obj/item/energy_blade/attack_self(mob/living/user)
+/obj/item/energy_blade/attack_self(mob/user)
 	if(active)
 		if((MUTATION_CLUMSY in user.mutations) && prob(50))
-			user.visible_message("<span class='danger'>\The [user] accidentally cuts \himself with \the [src].</span>",\
-			"<span class='danger'>You accidentally cut yourself with \the [src].</span>")
-			user.take_organ_damage(5,5)
+			user.visible_message( \
+				SPAN_DANGER("\The [user] accidentally cuts \himself with \the [src]."), \
+				SPAN_DANGER("You accidentally cut yourself with \the [src]."))
+			if(isliving(user))
+				var/mob/living/M = user
+				M.take_organ_damage(5,5)
 		deactivate(user)
 	else
 		activate(user)

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -169,24 +169,26 @@
 			return (base_block_chance - round(damage / 2.5)) //block bullets and beams using the old block chance
 	return base_block_chance
 
-/obj/item/shield/energy/attack_self(mob/living/user)
-	if ((MUTATION_CLUMSY in user.mutations) && prob(50))
-		to_chat(user, "<span class='warning'>You beat yourself in the head with [src].</span>")
-		user.take_organ_damage(5)
+/obj/item/shield/energy/attack_self(mob/user)
+	if((MUTATION_CLUMSY in user.mutations) && prob(50))
+		to_chat(user, SPAN_DANGER("You beat yourself in the head with [src]."))
+		if(isliving(user))
+			var/mob/living/M = user
+			M.take_organ_damage(5, 0)
 	active = !active
 	if (active)
 		force = 10
 		update_icon()
 		w_class = ITEM_SIZE_HUGE
 		playsound(user, 'sound/weapons/saberon.ogg', 50, 1)
-		to_chat(user, "<span class='notice'>\The [src] is now active.</span>")
+		to_chat(user, SPAN_NOTICE("\The [src] is now active."))
 
 	else
 		force = 3
 		update_icon()
 		w_class = ITEM_SIZE_TINY
 		playsound(user, 'sound/weapons/saberoff.ogg', 50, 1)
-		to_chat(user, "<span class='notice'>\The [src] can now be concealed.</span>")
+		to_chat(user, SPAN_NOTICE("\The [src] can now be concealed."))
 
 	if(istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -88,15 +88,16 @@
 		playsound(src.loc, src.use_sound, 50, 1, -5)
 	return ..()
 
-/obj/item/storage/bible/attack_self(mob/living/carbon/human/user)
+/obj/item/storage/bible/attack_self(mob/user)
 	if(!ishuman(user))
 		return
-	if(user?.mind?.assigned_job?.is_holy)
-		user.visible_message("\The [user] begins to read a passage from \the [src]...", "You begin to read a passage from \the [src]...")
-		if(do_after(user, 5 SECONDS))
-			user.visible_message("\The [user] reads a passage from \the [src].", "You read a passage from \the [src].")
-			for(var/mob/living/carbon/human/H in view(user))
-				if(user.get_cultural_value(TAG_RELIGION) == H.get_cultural_value(TAG_RELIGION))
+	var/mob/living/carbon/human/preacher = user
+	if(preacher.mind?.assigned_job?.is_holy)
+		preacher.visible_message("\The [preacher] begins to read a passage from \the [src]...", "You begin to read a passage from \the [src]...")
+		if(do_after(preacher, 5 SECONDS))
+			preacher.visible_message("\The [preacher] reads a passage from \the [src].", "You read a passage from \the [src].")
+			for(var/mob/living/carbon/human/H in view(preacher))
+				if(preacher.get_cultural_value(TAG_RELIGION) == H.get_cultural_value(TAG_RELIGION))
 					to_chat(H, SPAN_NOTICE("You feel calm and relaxed, at one with the universe."))
 
 /obj/item/storage/bible/verb/rename_bible()

--- a/code/game/objects/items/weapons/storage/wall_mirror.dm
+++ b/code/game/objects/items/weapons/storage/wall_mirror.dm
@@ -27,7 +27,7 @@
 	if(.)
 		flick("mirror_open",src)
 
-/obj/item/storage/mirror/attack_hand(var/mob/living/carbon/human/user)
+/obj/item/storage/mirror/attack_hand(mob/user)
 	use_mirror(user)
 
 /obj/item/storage/mirror/proc/use_mirror(var/mob/living/carbon/human/user)

--- a/code/game/objects/items/weapons/towels.dm
+++ b/code/game/objects/items/weapons/towels.dm
@@ -10,7 +10,7 @@
 	hitsound = 'sound/weapons/towelwhip.ogg'
 	desc = "A soft cotton towel."
 
-/obj/item/towel/attack_self(mob/living/user)
+/obj/item/towel/attack_self(mob/user)
 	if(user.a_intent == I_GRAB)
 		lay_out()
 		return

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -69,7 +69,7 @@
 	else
 		..()
 
-/obj/item/beartrap/proc/attack_mob(mob/living/L)
+/obj/item/beartrap/proc/attack_mob(mob/L)
 
 	var/target_zone
 	if(L.lying)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -159,7 +159,7 @@
 		anchored = !anchored
 	return 1
 
-/obj/attack_hand(mob/living/user)
+/obj/attack_hand(mob/user)
 	if(Adjacent(user))
 		add_fingerprint(user)
 	..()

--- a/code/game/objects/structures/charge_pylon.dm
+++ b/code/game/objects/structures/charge_pylon.dm
@@ -8,11 +8,11 @@
 	opacity = FALSE
 	var/next_use
 
-/obj/structure/charge_pylon/attack_ai(var/mob/living/user)
+/obj/structure/charge_pylon/attack_ai(var/mob/user)
 	if(Adjacent(user))
 		attack_hand(user)
 
-/obj/structure/charge_pylon/attack_hand(var/mob/living/user)
+/obj/structure/charge_pylon/attack_hand(var/mob/user)
 	charge_user(user)
 
 /obj/structure/charge_pylon/proc/charge_user(var/mob/living/user)

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -306,7 +306,7 @@
 			user.show_viewers(SPAN_DANGER("\The [user] stuffs \the [dropping] into \the [src]!"))
 		return TRUE
 
-/obj/structure/closet/attack_ai(mob/user)
+/obj/structure/closet/attack_ai(mob/living/silicon/ai/user)
 	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) // Robots can open/close it, but not the AI.
 		attack_hand(user)
 

--- a/code/game/objects/structures/defensive_barrier.dm
+++ b/code/game/objects/structures/defensive_barrier.dm
@@ -111,9 +111,10 @@
 /obj/structure/defensive_barrier/CtrlClick(mob/living/user)
 	try_pack_up(user)
 
-/obj/structure/defensive_barrier/attack_hand(mob/living/carbon/human/user)
+/obj/structure/defensive_barrier/attack_hand(mob/user)
 
-	if(ishuman(user) && user.species.can_shred(user) && user.a_intent == I_HURT)
+	var/decl/species/species = user.get_species()
+	if(ishuman(user) && species?.can_shred(user) && user.a_intent == I_HURT)
 		take_damage(20)
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		return TRUE

--- a/code/game/objects/structures/doors/_door.dm
+++ b/code/game/objects/structures/doors/_door.dm
@@ -95,7 +95,7 @@
 	if(distance <= 1 && lock)
 		to_chat(user, SPAN_NOTICE("It appears to have a lock."))
 
-/obj/structure/door/attack_ai(mob/user)
+/obj/structure/door/attack_ai(mob/living/silicon/ai/user)
 	if(Adjacent(user) && isrobot(user))
 		return attack_hand(user)
 

--- a/code/game/objects/structures/fitness.dm
+++ b/code/game/objects/structures/fitness.dm
@@ -10,23 +10,24 @@
 	density = 1
 	var/list/hit_message = list("hit", "punch", "kick", "robust")
 
-/obj/structure/fitness/punchingbag/attack_hand(var/mob/living/carbon/human/user)
-	if(!istype(user))
+/obj/structure/fitness/punchingbag/attack_hand(mob/user)
+	if(!ishuman(user))
 		..()
 		return
-	var/synth = user.isSynthetic()
-	if(!synth && user.nutrition < 20)
-		to_chat(user, "<span class='warning'>You need more energy to use the punching bag. Go eat something.</span>")
+	var/mob/living/carbon/human/H = user
+	var/synth = H.isSynthetic()
+	if(!synth && H.nutrition < 20)
+		to_chat(H, SPAN_WARNING("You [synth ? "need more energy" : "are too tired"] to use the punching bag. Go [synth ? "recharge" : "eat something"]."))
 	else
-		if(user.a_intent == I_HURT)
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		if(H.a_intent == I_HURT)
+			H.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 			flick("[icon_state]_hit", src)
 			playsound(src.loc, 'sound/effects/woodhit.ogg', 25, 1, -1)
-			user.do_attack_animation(src)
+			H.do_attack_animation(src)
 			if(!synth)
-				user.adjust_nutrition(-(5 * DEFAULT_HUNGER_FACTOR))
-				user.adjust_hydration(-(5 * DEFAULT_THIRST_FACTOR))
-			to_chat(user, "<span class='warning'>You [pick(hit_message)] \the [src].</span>")
+				H.adjust_nutrition(-(5 * DEFAULT_HUNGER_FACTOR))
+				H.adjust_hydration(-(5 * DEFAULT_THIRST_FACTOR))
+			to_chat(H, SPAN_NOTICE("You [pick(hit_message)] \the [src]."))
 
 /obj/structure/fitness/weightlifter
 	name = "weightlifting machine"
@@ -44,46 +45,51 @@
 		weight = (weight % max_weight) + 1
 		to_chat(user, "You set the machine's weight level to [weight].")
 
-/obj/structure/fitness/weightlifter/attack_hand(var/mob/living/carbon/human/user)
-	if(!istype(user))
+/obj/structure/fitness/weightlifter/attack_hand(mob/user)
+	if(!ishuman(user))
 		return
-	var/synth = user.isSynthetic()
-	if(user.loc != src.loc)
-		to_chat(user, "<span class='warning'>You must be on the weight machine to use it.</span>")
+	var/mob/living/carbon/human/H = user
+	var/synth = H.isSynthetic()
+	if(H.loc != src.loc)
+		to_chat(H, SPAN_WARNING("You must be on the weight machine to use it."))
 		return
-	if(!synth && user.nutrition < 50)
-		to_chat(user, "<span class='warning'>You need more energy to lift weights. Go eat something.</span>")
+	if(!synth && H.nutrition < 50)
+		to_chat(H, SPAN_WARNING("You need more energy to lift weights. Go eat something."))
 		return
 	if(being_used)
-		to_chat(user, "<span class='warning'>The weight machine is already in use by somebody else.</span>")
+		to_chat(H, SPAN_WARNING("The weight machine is already in use by somebody else."))
 		return
 	else
 		being_used = 1
 		playsound(src.loc, 'sound/effects/weightlifter.ogg', 50, 1)
-		user.set_dir(SOUTH)
+		H.set_dir(SOUTH)
 		flick("[icon_state]_[weight]", src)
-		if(do_after(user, 20 + (weight * 10)))
+		if(do_after(H, 20 + (weight * 10)))
 			playsound(src.loc, 'sound/effects/weightdrop.ogg', 25, 1)
-			var/skill = max_weight * user.get_skill_value(SKILL_HAULING)/SKILL_MAX
+			var/skill = max_weight * H.get_skill_value(SKILL_HAULING)/SKILL_MAX
 			var/message
 			if(skill < weight)
 				if(weight - skill > max_weight/2)
 					if(prob(50))
 						message = ", getting hurt in the process"
-						user.apply_damage(5)
+						H.apply_damage(5)
 					else
 						message = "; this does not look safe"
 				else
 					message = fail_message[min(1 + round(weight - skill), fail_message.len)]
-				user.visible_message("<span class='notice'>\The [user] fails to lift the weights[message].</span>", "<span class='notice'>You fail to lift the weights[message].</span>")
+				H.visible_message( \
+					SPAN_NOTICE("\The [H] fails to lift the weights[message]."), \
+					SPAN_NOTICE("You fail to lift the weights[message]."))
 			else
 				if(!synth)
 					var/adj_weight = weight * 5
-					user.adjust_nutrition(-(adj_weight * DEFAULT_HUNGER_FACTOR))
-					user.adjust_hydration(-(adj_weight * DEFAULT_THIRST_FACTOR))
+					H.adjust_nutrition(-(adj_weight * DEFAULT_HUNGER_FACTOR))
+					H.adjust_hydration(-(adj_weight * DEFAULT_THIRST_FACTOR))
 				message = success_message[min(1 + round(skill - weight), fail_message.len)]
-				user.visible_message("<span class='notice'>\The [user] lift\s the weights [message].</span>", "<span class='notice'>You lift the weights [message].</span>")
+				H.visible_message( \
+					SPAN_NOTICE("\The [H] lift\s the weights [message]."), \
+					SPAN_NOTICE("You lift the weights [message]."))
 			being_used = 0
 		else
-			to_chat(user, "<span class='notice'>Against your previous judgement, perhaps working out is not for you.</span>")
+			to_chat(H, SPAN_NOTICE("Against your previous judgement, perhaps working out is not for you."))
 			being_used = 0

--- a/code/game/objects/structures/fountain.dm
+++ b/code/game/objects/structures/fountain.dm
@@ -16,16 +16,18 @@
 	light_color = get_random_colour(lower = 190)
 	set_light(0.6, 3, 5, 2, light_color)
 
-/obj/structure/fountain/attack_hand(var/mob/living/user)
+/obj/structure/fountain/attack_hand(var/mob/user)
 	if(user.incapacitated())
 		return
 	if(!CanPhysicallyInteract(user))
 		return
 	if(used)
-		to_chat(user, "\The [src] is still and lifeless...")
+		to_chat(user,  SPAN_WARNING("\The [src] is still and lifeless..."))
 		return
-	if(!ishuman(user) || user.isSynthetic())
-		to_chat(user, "Try as you might to touch the fountain, some force prevents you from doing so.")
+
+	var/mob/living/carbon/human/H = user
+	if(!istype(H) || H.isSynthetic())
+		to_chat(user, SPAN_WARNING("A feeling of foreboding stills your hand. The fountain is not for your kind."))
 		return
 
 	if(alert("As you reach out to touch the fountain, a feeling of doubt overcomes you. Steel yourself and proceed?",,"Yes", "No") == "Yes")

--- a/code/game/objects/structures/handrail.dm
+++ b/code/game/objects/structures/handrail.dm
@@ -9,7 +9,7 @@
 	buckle_sound = 'sound/effects/buckle.ogg'
 	buckle_allow_rotation = TRUE
 
-/obj/structure/handrail/attack_hand(mob/living/user)
+/obj/structure/handrail/attack_hand(mob/user)
 	if(can_buckle && !buckled_mob && istype(user))
 		user_buckle_mob(user, user)
 		return

--- a/code/game/objects/structures/holosigns.dm
+++ b/code/game/objects/structures/holosigns.dm
@@ -18,14 +18,14 @@
 		projector = null
 	return ..()
 
-/obj/structure/holosign/attack_hand(mob/living/user)
+/obj/structure/holosign/attack_hand(mob/user)
 	. =  ..()
 	if(.)
 		return
 	visible_message(SPAN_NOTICE("\The [user] waves through \the [src], causing it to dissipate."))
 	deactivate(user)
 
-/obj/structure/holosign/attackby(obj/W, mob/living/user)
+/obj/structure/holosign/attackby(obj/W, mob/user)
 	visible_message(SPAN_NOTICE("\The [user] waves \a [W] through \the [src], causing it to dissipate."))
 	deactivate(user)
 

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -194,7 +194,7 @@
 	var/state = 0 //closed, 1 == open
 	var/isSwitchingStates = 0
 
-/obj/structure/inflatable/door/attack_ai(mob/user) //those aren't machinery, they're just big fucking slabs of a mineral
+/obj/structure/inflatable/door/attack_ai(mob/living/silicon/ai/user) //those aren't machinery, they're just big fucking slabs of a mineral
 	if(isAI(user)) //so the AI can't open it
 		return
 	else if(isrobot(user)) //but cyborgs can

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -185,7 +185,7 @@
 		return 1
 	..()
 
-/obj/structure/bed/roller/attack_hand(mob/living/user)
+/obj/structure/bed/roller/attack_hand(mob/user)
 	if(beaker && !buckled_mob)
 		remove_beaker(user)
 	else

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -44,7 +44,7 @@
 	if(bloodiness)
 		create_track()
 
-/obj/structure/bed/chair/wheelchair/attack_hand(mob/living/user)
+/obj/structure/bed/chair/wheelchair/attack_hand(mob/user)
 	user_unbuckle_mob(user)
 
 /obj/structure/bed/chair/wheelchair/Bump(atom/A)

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -31,7 +31,7 @@
 		if(1 to 4)	overlays += "hydrogen-[hydrogentanks]"
 		if(5 to INFINITY) overlays += "hydrogen-5"
 
-/obj/structure/dispenser/attack_ai(mob/user)
+/obj/structure/dispenser/attack_ai(mob/living/silicon/ai/user)
 	if(user.Adjacent(src))
 		return attack_hand(user)
 	..()

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -112,7 +112,7 @@
 	open = round(rand(0, 1))
 	update_icon()
 
-/obj/structure/hygiene/toilet/attack_hand(var/mob/living/user)
+/obj/structure/hygiene/toilet/attack_hand(var/mob/user)
 	if(swirlie)
 		usr.visible_message(
 			"<span class='danger'>[user] slams the toilet seat onto [swirlie.name]'s head!</span>",
@@ -140,7 +140,7 @@
 /obj/structure/hygiene/toilet/on_update_icon()
 	icon_state = "toilet[open][cistern]"
 
-/obj/structure/hygiene/toilet/attackby(obj/item/I, var/mob/living/user)
+/obj/structure/hygiene/toilet/attackby(obj/item/I, var/mob/user)
 	if(isCrowbar(I))
 		to_chat(user, "<span class='notice'>You start to [cistern ? "replace the lid on the cistern" : "lift the lid off the cistern"].</span>")
 		playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 50, 1)
@@ -429,7 +429,7 @@
 		"<span class='notice'>You wash your hands using \the [src].</span>")
 
 
-/obj/structure/hygiene/sink/attackby(obj/item/O, var/mob/living/user)
+/obj/structure/hygiene/sink/attackby(obj/item/O, var/mob/user)
 	if(isplunger(O) && clogged > 0)
 		return ..()
 
@@ -449,9 +449,11 @@
 		if(B.bcell)
 			if(B.bcell.charge > 0 && B.status == 1)
 				flick("baton_active", src)
-				user.Stun(10)
-				user.stuttering = 10
-				user.Weaken(10)
+				if(isliving(user))
+					var/mob/living/M = user
+					M.Stun(10)
+					M.stuttering = 10
+					M.Weaken(10)
 				if(isrobot(user))
 					var/mob/living/silicon/robot/R = user
 					R.cell.charge -= 20

--- a/code/game/turfs/exterior/exterior_water.dm
+++ b/code/game/turfs/exterior/exterior_water.dm
@@ -10,7 +10,7 @@
 /turf/exterior/water/is_flooded(lying_mob, absolute)
 	. = absolute ? ..() : lying_mob
 
-/turf/exterior/water/attackby(obj/item/O, var/mob/living/user)
+/turf/exterior/water/attackby(obj/item/O, var/mob/user)
 	if (reagent_type && ATOM_IS_OPEN_CONTAINER(O) && O.reagents)
 		var/fill_amount = O.reagents.maximum_volume - O.reagents.total_volume
 		if(fill_amount <= 0)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -66,10 +66,10 @@
 	playsound(user.loc, 'sound/weapons/handcuffs.ogg', 30, 1, -3)
 	return TRUE
 
-/obj/item/assembly/mousetrap/attack_self(mob/living/user)
+/obj/item/assembly/mousetrap/attack_self(mob/user)
 	. = toggle_arming(user) || ..()
 
-/obj/item/assembly/mousetrap/attack_hand(mob/living/user)
+/obj/item/assembly/mousetrap/attack_hand(mob/user)
 	. = toggle_arming(user) || ..()
 
 /obj/item/assembly/mousetrap/Crossed(atom/movable/AM)

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -131,7 +131,7 @@
 	if(forceLeft)
 		B.pulse(forceLeft - 1, dirs)
 
-/obj/effect/blob/proc/attack_living(var/mob/living/L)
+/obj/effect/blob/proc/attack_living(var/mob/L)
 	if(!L)
 		return
 	var/blob_damage = pick(BRUTE, BURN)

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -40,7 +40,7 @@
 		else if (get_dist(src, user) == 1)
 			to_chat(user, SPAN_ITALIC("Something is hidden inside."))
 
-/obj/item/clothing/shoes/attack_hand(var/mob/living/user)
+/obj/item/clothing/shoes/attack_hand(var/mob/user)
 	if (remove_hidden(user))
 		return
 	..()

--- a/code/modules/games/boardgame.dm
+++ b/code/modules/games/boardgame.dm
@@ -16,7 +16,7 @@
 	else
 		..()
 
-/obj/item/board/attack_hand(mob/living/carbon/human/M)
+/obj/item/board/attack_hand(mob/M)
 	if(M.machine == src)
 		return ..()
 	else

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -253,7 +253,7 @@
 	. = ..()
 	item_color = pick("red","blue","green","purple")
 
-/obj/item/holo/esword/attack_self(mob/living/user)
+/obj/item/holo/esword/attack_self(mob/user)
 	active = !active
 	if (active)
 		force = 30
@@ -358,7 +358,7 @@
 	active_power_usage = 6
 	power_channel = ENVIRON
 
-/obj/machinery/readybutton/attack_ai(mob/user)
+/obj/machinery/readybutton/attack_ai(mob/living/silicon/ai/user)
 	to_chat(user, "The AI is not to interact with these devices!")
 	return
 

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -410,7 +410,7 @@
 				visible_message("<span class='notice'>\The [user] points \the [src] towards \the [target].</span>")
 
 
-/obj/item/electronic_assembly/attackby(obj/item/I, mob/living/user)
+/obj/item/electronic_assembly/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/wrench))
 		if(istype(loc, /turf) && (IC_FLAG_ANCHORABLE & circuit_flags))
 			user.visible_message("\The [user] wrenches \the [src]'s anchoring bolts [anchored ? "back" : "into position"].")

--- a/code/modules/integrated_electronics/subtypes/access.dm
+++ b/code/modules/integrated_electronics/subtypes/access.dm
@@ -18,7 +18,7 @@
 	name = "card reader"
 	spawn_flags = 0
 
-/obj/item/integrated_circuit/input/card_reader/attackby_react(obj/item/I, mob/living/user, intent)
+/obj/item/integrated_circuit/input/card_reader/attackby_react(obj/item/I, mob/user, intent)
 	var/obj/item/card/id/card = I.GetIdCard()
 	var/list/access = I.GetAccess()
 	var/json_access = json_encode(access)

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -1141,7 +1141,7 @@
 		"on read" = IC_PINTYPE_PULSE_OUT
 	)
 
-/obj/item/integrated_circuit/input/data_card_reader/attackby_react(obj/item/I, mob/living/user, intent)
+/obj/item/integrated_circuit/input/data_card_reader/attackby_react(obj/item/I, mob/user, intent)
 	var/obj/item/card/data/card = I
 	var/write_mode = get_pin_data(IC_INPUT, 3)
 	if(istype(card))

--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -517,7 +517,7 @@
 	complexity = 4
 	power_draw_per_use = 5
 
-/obj/item/integrated_circuit/input/funnel/attackby_react(obj/item/I, mob/living/user, intent)
+/obj/item/integrated_circuit/input/funnel/attackby_react(obj/item/I, mob/user, intent)
 	var/atom/movable/target = get_pin_data_as_type(IC_INPUT, 1, /atom/movable)
 	var/obj/item/chems/container = I
 

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -214,7 +214,7 @@
 		else
 			return attack_tendons(G, I, user, G.target_zone)
 
-/decl/grab/normal/proc/attack_throat(var/obj/item/grab/G, var/obj/item/W, var/mob/living/carbon/human/user)
+/decl/grab/normal/proc/attack_throat(var/obj/item/grab/G, var/obj/item/W, mob/user)
 	var/mob/living/affecting = G.get_affecting_mob()
 	if(!affecting)
 		return
@@ -257,7 +257,7 @@
 	admin_attack_log(user, affecting, "Knifed their victim", "Was knifed", "knifed")
 	return 1
 
-/decl/grab/normal/proc/attack_tendons(var/obj/item/grab/G, var/obj/item/W, var/mob/living/carbon/human/user, var/target_zone)
+/decl/grab/normal/proc/attack_tendons(var/obj/item/grab/G, var/obj/item/W, mob/user, var/target_zone)
 	var/mob/living/affecting = G.get_affecting_mob()
 	if(!affecting)
 		return

--- a/code/modules/mob/living/bot/remotebot.dm
+++ b/code/modules/mob/living/bot/remotebot.dm
@@ -41,7 +41,7 @@
 	s.start()
 	qdel(src)
 
-/mob/living/bot/remotebot/attackby(var/obj/item/I, var/mob/living/user)
+/mob/living/bot/remotebot/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/bot_controller) && !controller)
 		user.visible_message("\The [user] waves \the [I] over \the [src].")
 		to_chat(user, "<span class='notice'>You link \the [src] to \the [I].</span>")
@@ -162,7 +162,7 @@
 	icon = 'icons/obj/items/bot_kit.dmi'
 	icon_state = "remotebot"
 
-/obj/item/bot_kit/attack_self(var/mob/living/user)
+/obj/item/bot_kit/attack_self(var/mob/user)
 	to_chat(user, "You quickly dismantle the box and retrieve the controller and the remote bot itself.")
 	var/turf/T = get_turf(src.loc)
 	new /mob/living/bot/remotebot(T)

--- a/code/modules/mob/living/carbon/alien/alien_attacks.dm
+++ b/code/modules/mob/living/carbon/alien/alien_attacks.dm
@@ -2,39 +2,33 @@
 /mob/living/carbon/alien/attack_ui(slot_id)
 	return
 
-/mob/living/carbon/alien/attack_hand(mob/living/carbon/M)
+/mob/living/carbon/alien/attack_hand(mob/user)
 
-	switch(M.a_intent)
+	switch(user.a_intent)
 
 		if(I_GRAB)
 			return ..()
 
 		if (I_HELP)
-			help_shake_act(M)
+			help_shake_act(user)
 
 		else
 			var/damage = rand(1, 9)
 			if (prob(90))
-				if (MUTATION_HULK in M.mutations)
+				if (MUTATION_HULK in user.mutations)
 					damage += 5
 					spawn(0)
 						Paralyse(1)
-						step_away(src,M,15)
+						step_away(src, user, 15)
 						sleep(3)
-						step_away(src,M,15)
+						step_away(src, user, 15)
 				playsound(loc, "punch", 25, 1, -1)
-				for(var/mob/O in viewers(src, null))
-					if ((O.client && !( O.blinded )))
-						O.show_message("<span class='danger'>\The [M] has punched \the [src]!</span>", 1)
+				visible_message(SPAN_DANGER("\The [user] has punched \the [src]!"), 1)
 				if (damage > 4.9)
 					Weaken(rand(10,15))
-					for(var/mob/O in viewers(M, null))
-						if ((O.client && !( O.blinded )))
-							O.show_message("<span class='danger'>\The [M] has weakened \the [src]!</span>", 1, "<span class='warning'>You hear someone fall.</span>", 2)
+					user.visible_message(SPAN_DANGER("\The [user] has weakened \the [src]!"), 1, SPAN_WARNING("You hear someone fall."), 2)
 				adjustBruteLoss(damage)
 				updatehealth()
 			else
 				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-				for(var/mob/O in viewers(src, null))
-					if ((O.client && !( O.blinded )))
-						O.show_message("<span class='danger'>\The [M] has attempted to punch \the [src]!</span>", 1)
+				visible_message(SPAN_DANGER("\The [user] has attempted to punch \the [src]!"), 1)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -81,15 +81,14 @@
 		visible_message(SPAN_DANGER("\The [M] bursts out of \the [src]!"))
 	..()
 
-/mob/living/carbon/attack_hand(var/mob/living/carbon/human/M)
-	if(istype(M))
-		var/obj/item/organ/external/temp = M.organs_by_name[M.get_active_held_item_slot()]
-		if(!temp)
-			to_chat(M, SPAN_WARNING("You don't have a usable limb!"))
-			return TRUE
-		if(!temp.is_usable())
-			to_chat(M, SPAN_WARNING("You can't use your [temp.name]."))
-			return TRUE
+/mob/living/carbon/attack_hand(mob/user)
+	var/obj/item/organ/external/temp = user.get_organ(user.get_active_held_item_slot())
+	if(!temp)
+		to_chat(user, SPAN_WARNING("You don't have a usable limb!"))
+		return TRUE
+	if(!temp.is_usable())
+		to_chat(user, SPAN_WARNING("You can't use your [temp.name]."))
+		return TRUE
 	. = ..()
 
 /mob/living/carbon/electrocute_act(var/shock_damage, var/obj/source, var/siemens_coeff = 1.0, var/def_zone = null)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -24,16 +24,16 @@
 		if(length(limb.unarmed_attacks) && limb.is_usable())
 			. |= limb.unarmed_attacks
 
-/mob/living/carbon/human/attack_hand(mob/living/carbon/M)
+/mob/living/carbon/human/attack_hand(mob/user)
 
 	remove_cloaking_source(species)
 
 	// Grabs are handled at a lower level.
-	if(istype(M) && M.a_intent == I_GRAB)
+	if(user.a_intent == I_GRAB)
 		return ..()
 
 	// Should this all be in Touch()?
-	var/mob/living/carbon/human/H = M
+	var/mob/living/carbon/human/H = user
 	if(istype(H))
 		if(H != src && check_shields(0, null, H, H.zone_sel.selecting, H.name))
 			H.do_attack_animation(src)
@@ -44,14 +44,14 @@
 				if(G.resolve_openhand_attack())
 					return TRUE
 
-	switch(M.a_intent)
+	switch(user.a_intent)
 		if(I_HELP)
 			if(H != src && istype(H) && (is_asystole() || (status_flags & FAKEDEATH) || failed_last_breath) && !(H.zone_sel.selecting == BP_R_ARM || H.zone_sel.selecting == BP_L_ARM))
 				if (!cpr_time)
 					return TRUE
 
-				var/pumping_skill = max(M.get_skill_value(SKILL_MEDICAL),M.get_skill_value(SKILL_ANATOMY))
-				var/cpr_delay = 15 * M.skill_delay_mult(SKILL_ANATOMY, 0.2)
+				var/pumping_skill = max(user.get_skill_value(SKILL_MEDICAL), user.get_skill_value(SKILL_ANATOMY))
+				var/cpr_delay = 15 * user.skill_delay_mult(SKILL_ANATOMY, 0.2)
 				cpr_time = 0
 
 				H.visible_message("<span class='notice'>\The [H] is trying to perform CPR on \the [src].</span>")
@@ -102,8 +102,8 @@
 							losebreath = 0
 						to_chat(src, "<span class='notice'>You feel a breath of fresh air enter your lungs. It feels good.</span>")
 
-			else if(!(M == src && apply_pressure(M, M.zone_sel.selecting)))
-				help_shake_act(M)
+			else if(!(user == src && apply_pressure(user, user.zone_sel.selecting)))
+				help_shake_act(user)
 			return TRUE
 
 		if(I_HURT)
@@ -133,7 +133,7 @@
 				H.last_attack = world.time
 
 			if(!affecting || affecting.is_stump())
-				to_chat(M, "<span class='danger'>They are missing that limb!</span>")
+				to_chat(user, "<span class='danger'>They are missing that limb!</span>")
 				return TRUE
 
 			switch(src.a_intent)
@@ -146,7 +146,7 @@
 					if(MayMove() && src!=H && prob(20))
 						block = 1
 
-			if (LAZYLEN(M.grabbed_by))
+			if (LAZYLEN(user.grabbed_by))
 				// Someone got a good grip on them, they won't be able to do much damage
 				rand_damage = max(1, rand_damage - 2)
 
@@ -224,7 +224,7 @@
 
 		if(I_DISARM)
 			if(H.species)
-				admin_attack_log(M, src, "Disarmed their victim.", "Was disarmed.", "disarmed")
+				admin_attack_log(user, src, "Disarmed their victim.", "Was disarmed.", "disarmed")
 				H.species.disarm_attackhand(H, src)
 				return TRUE
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -213,7 +213,7 @@ meteor_act
 
 	return 1
 
-/mob/living/carbon/human/proc/attack_bloody(obj/item/W, mob/living/attacker, var/effective_force, var/hit_zone)
+/mob/living/carbon/human/proc/attack_bloody(obj/item/W, mob/attacker, var/effective_force, var/hit_zone)
 	if(W.damtype != BRUTE)
 		return
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -875,9 +875,6 @@ default behaviour is:
 /mob/living/proc/get_ingested_reagents()
 	return reagents
 
-/mob/living/proc/get_species()
-	return
-
 /mob/living/proc/should_have_organ(var/organ_check)
 	return FALSE
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -88,8 +88,8 @@ proc/get_radio_key_from_channel(var/channel)
 /mob/living/proc/get_default_language()
 	. = ispath(default_language, /decl/language) && GET_DECL(default_language)
 
-/mob/proc/is_muzzled()
-	return istype(wear_mask, /obj/item/clothing/mask/muzzle) || istype(wear_mask, /obj/item/clothing/sealant)
+/mob/living/is_silenced()
+	. = ..() || silent
 
 //Takes a list of the form list(message, verb, whispering) and modifies it as needed
 //Returns 1 if a speech problem was applied, 0 otherwise

--- a/code/modules/mob/living/silicon/robot/drone/drone_remote_control.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_remote_control.dm
@@ -5,17 +5,17 @@
 	var/mob/living/silicon/ai/controlling_ai
 	var/obj/item/radio/drone_silicon_radio
 
-/mob/living/silicon/robot/drone/attack_ai(var/mob/living/silicon/ai/user)
+/mob/living/silicon/robot/drone/attack_ai(mob/living/silicon/ai/user)
 
 	if(!istype(user) || controlling_ai || !config.allow_drone_spawn)
 		return
 
 	if(stat != 2 || client || key)
-		to_chat(user, "<span class='warning'>You cannot take control of an autonomous, active drone.</span>")
+		to_chat(user, SPAN_WARNING("You cannot take control of an autonomous, active drone."))
 		return
 
 	if(health < -35 || emagged)
-		to_chat(user, "<span class='notice'><b>WARNING:</b> connection timed out.</span>")
+		to_chat(user, SPAN_WARNING("<b>WARNING:</b> connection timed out."))
 		return
 	
 	assume_control(user)
@@ -45,7 +45,7 @@
 	updatename()
 	to_chat(src, "<span class='notice'><b>You have shunted your primary control loop into \a [initial(name)].</b> Use the <b>Release Control</b> verb to return to your core.</span>")
 
-/obj/machinery/drone_fabricator/attack_ai(var/mob/living/silicon/ai/user)
+/obj/machinery/drone_fabricator/attack_ai(mob/living/silicon/ai/user)
 
 	if(!istype(user) || user.controlling_drone || !config.allow_drone_spawn)
 		return

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -112,7 +112,7 @@
 	if(O.force)
 		set_flee_target(user? user : src.loc)
 
-/mob/living/simple_animal/cat/attack_hand(mob/living/carbon/human/M)
+/mob/living/simple_animal/cat/attack_hand(mob/M)
 	. = ..()
 	if(M.a_intent == I_HURT)
 		set_flee_target(M)

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -138,7 +138,7 @@
 	if(udder && prob(5))
 		udder.add_reagent(/decl/material/liquid/drink/milk, rand(5, 10))
 
-/mob/living/simple_animal/cow/attack_hand(mob/living/carbon/M)
+/mob/living/simple_animal/cow/attack_hand(mob/M)
 	if(!stat && M.a_intent == I_DISARM && icon_state != icon_dead)
 		M.visible_message("<span class='warning'>[M] tips over [src].</span>","<span class='notice'>You tip over [src].</span>")
 		Weaken(30)

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -101,7 +101,7 @@
 		target_mob = user
 	..()
 
-/mob/living/simple_animal/hostile/bear/attack_hand(mob/living/carbon/human/M)
+/mob/living/simple_animal/hostile/bear/attack_hand(mob/M)
 	if(stance != HOSTILE_STANCE_ATTACK && stance != HOSTILE_STANCE_ATTACKING)
 		stance = HOSTILE_STANCE_ALERT
 		stance_step = 6

--- a/code/modules/mob/living/simple_animal/hostile/commanded/bear_companion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/bear_companion.dm
@@ -31,7 +31,7 @@
 	if(.)
 		src.emote("roars in rage!")
 
-/mob/living/simple_animal/hostile/commanded/bear/attack_hand(mob/living/carbon/human/M)
+/mob/living/simple_animal/hostile/commanded/bear/attack_hand(mob/M)
 	..()
 	if(M.a_intent == I_HURT)
 		src.emote("roars in rage!")

--- a/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
@@ -179,7 +179,7 @@
 			friends -= weakref(user)
 
 
-/mob/living/simple_animal/hostile/commanded/attack_hand(mob/living/carbon/human/M)
+/mob/living/simple_animal/hostile/commanded/attack_hand(mob/M)
 	..()
 	if(M.a_intent == I_HURT && retribution) //assume he wants to hurt us.
 		target_mob = M

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -203,7 +203,7 @@
 		target_mob = user
 		MoveToTarget()
 
-/mob/living/simple_animal/hostile/attack_hand(mob/living/carbon/human/M)
+/mob/living/simple_animal/hostile/attack_hand(mob/M)
 	. = ..()
 	if(M.a_intent == I_HURT && !incapacitated(INCAPACITATION_KNOCKOUT))
 		target_mob = M

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
@@ -206,9 +206,10 @@
 	force = 5
 	attack_verb = list("singed")
 
-/mob/living/simple_animal/hostile/retaliate/beast/charbaby/attack_hand(mob/living/carbon/human/H)
+/mob/living/simple_animal/hostile/retaliate/beast/charbaby/attack_hand(mob/user)
 	. = ..()
-	reflect_unarmed_damage(H, BURN, "amorphous mass")
+	if(ishuman(user))
+		reflect_unarmed_damage(user, BURN, "amorphous mass")
 
 /mob/living/simple_animal/hostile/retaliate/beast/charbaby/AttackingTarget()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/giant_crab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/giant_crab.dm
@@ -49,9 +49,10 @@
 	. = ..()
 	victim = null
 
-/mob/living/simple_animal/hostile/retaliate/giant_crab/attack_hand(mob/living/carbon/human/H)
+/mob/living/simple_animal/hostile/retaliate/giant_crab/attack_hand(mob/user)
 	. = ..()
-	reflect_unarmed_damage(H, BRUTE, "armoured carapace")
+	if(ishuman(user))
+		reflect_unarmed_damage(user, BRUTE, "armoured carapace")
 
 /mob/living/simple_animal/hostile/retaliate/giant_crab/Life()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
@@ -223,29 +223,21 @@
  * Attack responces
  */
 //Humans, monkeys, aliens
-/mob/living/simple_animal/hostile/retaliate/parrot/attack_hand(mob/living/carbon/M)
-	..()
-	if(client)
-		return
-
-	if(simple_parrot) //all the real stuff gets handled in /hostile/retaliate
-		return
-
-	if(!stat && M.a_intent == I_HURT)
+/mob/living/simple_animal/hostile/retaliate/parrot/attack_hand(mob/user)
+	. = ..()
+	if(!client && !simple_parrot && !stat && user.a_intent == I_HURT)
 		icon_state = "[icon_set]_fly" //It is going to be flying regardless of whether it flees or attacks
-
 		if(parrot_state == PARROT_PERCH)
 			parrot_sleep_dur = parrot_sleep_max //Reset it's sleep timer if it was perched
-
-		parrot_interest = M
+		parrot_interest = user
 		parrot_state = PARROT_SWOOP //The parrot just got hit, it WILL move, now to pick a direction..
-
-		if(M.health < 50) //Weakened mob? Fight back!
-			parrot_state |= PARROT_ATTACK
-		else
-			parrot_state |= PARROT_FLEE		//Otherwise, fly like a bat out of hell!
-			drop_held_item(0)
-	return
+		if(isliving(user))
+			var/mob/living/M = user
+			if(M.health < 50) //Weakened mob? Fight back!
+				parrot_state |= PARROT_ATTACK
+				return
+		parrot_state |= PARROT_FLEE		//Otherwise, fly like a bat out of hell!
+		drop_held_item(0)
 
 //Mobs with objects
 /mob/living/simple_animal/hostile/retaliate/parrot/attackby(var/obj/item/O, var/mob/user)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -262,26 +262,27 @@
 	Proj.on_hit(src)
 	return 0
 
-/mob/living/simple_animal/attack_hand(mob/living/carbon/human/M)
+/mob/living/simple_animal/attack_hand(mob/user)
 	..()
 
-	switch(M.a_intent)
+	switch(user.a_intent)
 
 		if(I_HELP)
 			if (health > 0)
-				M.visible_message("<span class='notice'>[M] [response_help] \the [src].</span>")
-				M.update_personal_goal(/datum/goal/achievement/specific_object/pet, type)
+				user.visible_message(SPAN_NOTICE("\The [user] [response_help] \the [src]."))
+				user.update_personal_goal(/datum/goal/achievement/specific_object/pet, type)
 
 		if(I_DISARM)
-			M.visible_message("<span class='notice'>[M] [response_disarm] \the [src].</span>")
-			M.do_attack_animation(src)
+			user.visible_message(SPAN_NOTICE("\The [user] [response_disarm] \the [src]."))
+			user.do_attack_animation(src)
 			//TODO: Push the mob away or something
 
 		if(I_HURT)
 			var/dealt_damage = harm_intent_damage
 			var/harm_verb = response_harm
-			if(ishuman(M))
-				var/decl/natural_attack/attack = M.get_unarmed_attack(src)
+			if(ishuman(user))
+				var/mob/living/carbon/human/H = user
+				var/decl/natural_attack/attack = H.get_unarmed_attack(src)
 				if(istype(attack))
 					dealt_damage = attack.damage <= dealt_damage ? dealt_damage : attack.damage
 					harm_verb = pick(attack.attack_verb)
@@ -289,10 +290,8 @@
 						adjustBleedTicks(dealt_damage)
 
 			adjustBruteLoss(dealt_damage)
-			M.visible_message("<span class='warning'>[M] [harm_verb] \the [src]!</span>")
-			M.do_attack_animation(src)
-
-	return
+			user.visible_message(SPAN_DANGER("\The [user] [harm_verb] \the [src]!"))
+			user.do_attack_animation(src)
 
 /mob/living/simple_animal/attackby(var/obj/item/O, var/mob/user)
 	if(istype(O, /obj/item/stack/medical))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1092,3 +1092,6 @@
 			to_chat(user, SPAN_WARNING("\The [src] cannot use that, as they are dead."))
 		return FALSE
 	return TRUE
+
+/mob/proc/get_species()
+	return

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -115,3 +115,9 @@
 			return L
 
 	return null
+
+/mob/proc/is_silenced()
+	. = is_muzzled()
+
+/mob/proc/is_muzzled()
+	return istype(wear_mask, /obj/item/clothing/mask/muzzle) || istype(wear_mask, /obj/item/clothing/sealant)

--- a/code/modules/modular_computers/hardware/_hardware.dm
+++ b/code/modules/modular_computers/hardware/_hardware.dm
@@ -10,7 +10,7 @@
 	var/usage_flags = PROGRAM_ALL
 	var/external_slot				// Whether attackby will be passed on it even with a closed panel
 
-/obj/item/stock_parts/computer/attackby(var/obj/item/W, var/mob/living/user)
+/obj/item/stock_parts/computer/attackby(var/obj/item/W, var/mob/user)
 	// Multitool. Runs diagnostics
 	if(isMultitool(W))
 		to_chat(user, "***** DIAGNOSTICS REPORT *****")

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -102,7 +102,7 @@
 		loc.verbs |= /obj/item/stock_parts/computer/card_slot/proc/verb_eject_id
 	return TRUE
 
-/obj/item/stock_parts/computer/card_slot/attackby(obj/item/card/id/I, mob/living/user)
+/obj/item/stock_parts/computer/card_slot/attackby(obj/item/card/id/I, mob/user)
 	if(!istype(I))
 		return ..()
 	insert_id(I, user)

--- a/code/modules/modular_computers/hardware/charge_stick_slot.dm
+++ b/code/modules/modular_computers/hardware/charge_stick_slot.dm
@@ -79,7 +79,7 @@
 		loc.verbs |= /obj/item/stock_parts/computer/charge_stick_slot/proc/verb_eject_stick
 	return TRUE
 
-/obj/item/stock_parts/computer/charge_stick_slot/attackby(obj/item/card/id/I, mob/living/user)
+/obj/item/stock_parts/computer/charge_stick_slot/attackby(obj/item/card/id/I, mob/user)
 	if(!istype(I))
 		return
 	insert_stick(I, user)

--- a/code/modules/modular_computers/hardware/drive_slot.dm
+++ b/code/modules/modular_computers/hardware/drive_slot.dm
@@ -67,7 +67,7 @@
 		loc.verbs |= /obj/item/stock_parts/computer/drive_slot/proc/verb_eject_drive
 	return TRUE
 
-/obj/item/stock_parts/computer/drive_slot/attackby(obj/item/stock_parts/computer/hard_drive/portable/I, mob/living/user)
+/obj/item/stock_parts/computer/drive_slot/attackby(obj/item/stock_parts/computer/hard_drive/portable/I, mob/user)
 	if(!istype(I))
 		return
 	insert_drive(I, user)

--- a/code/modules/modular_computers/hardware/scanners/scanner.dm
+++ b/code/modules/modular_computers/hardware/scanners/scanner.dm
@@ -50,7 +50,7 @@
 
 /obj/item/stock_parts/computer/scanner/proc/do_on_afterattack(mob/user, atom/target, proximity)
 
-/obj/item/stock_parts/computer/scanner/attackby(obj/W, mob/living/user)
+/obj/item/stock_parts/computer/scanner/attackby(obj/W, mob/user)
 	do_on_attackby(user, W)
 
 /obj/item/stock_parts/computer/scanner/proc/do_on_attackby(mob/user, atom/target)

--- a/code/modules/multiz/hoist.dm
+++ b/code/modules/multiz/hoist.dm
@@ -33,7 +33,7 @@
 
 	var/obj/structure/hoist/source_hoist
 
-/obj/effect/hoist_hook/attack_hand(mob/living/user)
+/obj/effect/hoist_hook/attack_hand(mob/user)
 	return // no, bad
 
 /obj/effect/hoist_hook/receive_mouse_drop(atom/dropping, mob/user)
@@ -156,7 +156,7 @@
 	if(. && (severity == 1 || (severity == 2 && prob(50)) || (severity == 3 && prob(25))))
 		source_hoist.break_hoist()
 
-/obj/structure/hoist/attack_hand(mob/living/user)
+/obj/structure/hoist/attack_hand(mob/user)
 	if (!ishuman(user))
 		return
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -106,7 +106,7 @@
 		SetName(n_name)
 	add_fingerprint(usr)
 
-/obj/item/paper/attack_self(mob/living/user)
+/obj/item/paper/attack_self(mob/user)
 	if(user.a_intent == I_HURT)
 		if(icon_state == "scrap")
 			user.show_message("<span class='warning'>\The [src] is already crumpled.</span>")
@@ -124,7 +124,7 @@
 			spawn(20)
 				spam_flag = 0
 
-/obj/item/paper/attack_ai(var/mob/living/silicon/ai/user)
+/obj/item/paper/attack_ai(mob/living/silicon/ai/user)
 	show_content(user)
 
 /obj/item/paper/attack(mob/living/carbon/M, mob/living/carbon/user)

--- a/code/modules/power/breaker_box.dm
+++ b/code/modules/power/breaker_box.dm
@@ -44,7 +44,7 @@
 	else
 		to_chat(user, "<span class='warning'>It seems to be offline.</span>")
 
-/obj/machinery/power/breakerbox/attack_ai(mob/user)
+/obj/machinery/power/breakerbox/attack_ai(mob/living/silicon/ai/user)
 	if(update_locked)
 		to_chat(user, "<span class='warning'>System locked. Please try again later.</span>")
 		return

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -311,7 +311,7 @@
 
 // ai attack - make lights flicker, because why not
 
-/obj/machinery/light/attack_ai(mob/user)
+/obj/machinery/light/attack_ai(mob/living/silicon/ai/user)
 	src.flicker(1)
 
 // attack with hand - remove tube/bulb

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -114,7 +114,7 @@
 // Proc: attack_ai()
 // Parameters: None
 // Description: AI requires the RCON wire to be intact to operate the SMES.
-/obj/machinery/power/smes/buildable/attack_ai(mob/user)
+/obj/machinery/power/smes/buildable/attack_ai(mob/living/silicon/ai/user)
 	if(RCon)
 		..()
 	else // RCON wire cut

--- a/code/modules/projectiles/guns/energy/temperature.dm
+++ b/code/modules/projectiles/guns/energy/temperature.dm
@@ -30,7 +30,7 @@
 	. = ..()
 
 
-/obj/item/gun/energy/temperature/attack_self(mob/living/user)
+/obj/item/gun/energy/temperature/attack_self(mob/user)
 	user.set_machine(src)
 	var/temp_text = ""
 	if(firing_temperature > (T0C - 50))

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -75,7 +75,7 @@
 	update_icon()
 	..()
 
-/obj/item/gun/launcher/crossbow/attack_self(mob/living/user)
+/obj/item/gun/launcher/crossbow/attack_self(mob/user)
 	if(tension)
 		if(bolt)
 			user.visible_message("[user] relaxes the tension on [src]'s string and removes [bolt].","You relax the tension on [src]'s string and remove [bolt].")
@@ -230,7 +230,7 @@
 		flick("[icon_state]-empty", src)
 
 
-/obj/item/gun/launcher/crossbow/rapidcrossbowdevice/attack_self(mob/living/user)
+/obj/item/gun/launcher/crossbow/rapidcrossbowdevice/attack_self(mob/user)
 	if(tension)
 		user.visible_message("[user] relaxes the tension on [src]'s string.","You relax the tension on [src]'s string.")
 		tension = 0

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -91,7 +91,7 @@
 	darts -= next
 	next = null
 
-/obj/item/gun/launcher/syringe/attack_self(mob/living/user)
+/obj/item/gun/launcher/syringe/attack_self(mob/user)
 	if(next)
 		user.visible_message("[user] unlatches and carefully relaxes the bolt on [src].", "<span class='warning'>You unlatch and carefully relax the bolt on [src], unloading the spring.</span>")
 		next = null
@@ -101,7 +101,7 @@
 		next = darts[1]
 	add_fingerprint(user)
 
-/obj/item/gun/launcher/syringe/attack_hand(mob/living/user)
+/obj/item/gun/launcher/syringe/attack_hand(mob/user)
 	if(user.is_holding_offhand(src))
 		if(!darts.len)
 			to_chat(user, "<span class='warning'>[src] is empty.</span>")

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -29,7 +29,7 @@
 		return chambered.BB
 	return null
 
-/obj/item/gun/projectile/shotgun/pump/attack_self(mob/living/user)
+/obj/item/gun/projectile/shotgun/pump/attack_self(mob/user)
 	if(world.time >= recentpump + 10)
 		pump(user)
 		recentpump = world.time

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -28,7 +28,7 @@
 		var/mob/living/L = target
 		shake_camera(L, 3, 2)
 
-/obj/item/projectile/bullet/attack_mob(var/mob/living/target_mob, var/distance, var/miss_modifier)
+/obj/item/projectile/bullet/attack_mob(var/mob/target_mob, var/distance, var/miss_modifier)
 	if(penetrating > 0 && damage > 20 && prob(damage))
 		mob_passthrough_check = 1
 	else

--- a/code/modules/projectiles/projectile/pellets.dm
+++ b/code/modules/projectiles/projectile/pellets.dm
@@ -16,7 +16,7 @@
 	var/pellet_loss = round((distance - 1)/range_step) //pellets lost due to distance
 	return max(pellets - pellet_loss, 1)
 
-/obj/item/projectile/bullet/pellet/attack_mob(var/mob/living/target_mob, var/distance, var/miss_modifier)
+/obj/item/projectile/bullet/pellet/attack_mob(var/mob/target_mob, var/distance, var/miss_modifier)
 	if (pellets < 0) return 1
 
 	var/total_pellets = get_pellets(distance)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -188,7 +188,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// FOOD END
 ////////////////////////////////////////////////////////////////////////////////
-/obj/item/chems/food/snacks/attack_animal(var/mob/living/user)
+/obj/item/chems/food/snacks/attack_animal(var/mob/user)
 	if(!isanimal(user) && !isalien(user))
 		return
 	user.visible_message("<b>[user]</b> nibbles away at \the [src].","You nibble away at \the [src].")

--- a/code/modules/reagents/storage/pill_bottle.dm
+++ b/code/modules/reagents/storage/pill_bottle.dm
@@ -62,7 +62,7 @@
 /obj/item/storage/pill_bottle/afterattack(mob/living/target, mob/living/user, proximity_flag)
 	. = (proximity_flag && user == target && pop_pill(user)) || ..()
 
-/obj/item/storage/pill_bottle/attack_self(mob/living/user)
+/obj/item/storage/pill_bottle/attack_self(mob/user)
 	. = pop_pill(user) || ..()
 
 /obj/item/storage/pill_bottle/Initialize()

--- a/code/modules/security levels/keycard_authentication.dm
+++ b/code/modules/security levels/keycard_authentication.dm
@@ -22,7 +22,7 @@
 	//1 = select event
 	//2 = authenticate
 
-/obj/machinery/keycard_auth/attack_ai(mob/user)
+/obj/machinery/keycard_auth/attack_ai(mob/living/silicon/ai/user)
 	to_chat(user, "<span class='warning'>A firewall prevents you from interfacing with this device!</span>")
 	return
 

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -332,6 +332,6 @@
 				if(!(F in affected_shields))
 					F.impact_effect(i, affected_shields) // Spread the effect to them
 
-/obj/effect/shield/attack_hand(var/mob/living/user)
+/obj/effect/shield/attack_hand(var/mob/user)
 	impact_effect(3) // Harmless, but still produces the 'impact' effect.
 	..()

--- a/code/modules/shuttles/docking_beacon.dm
+++ b/code/modules/shuttles/docking_beacon.dm
@@ -37,7 +37,7 @@
 	SSshuttle.docking_beacons -= src
 	permitted_shuttles.Cut()
 
-/obj/machinery/docking_beacon/attackby(obj/item/I, mob/living/user)
+/obj/machinery/docking_beacon/attackby(obj/item/I, mob/user)
 	if(isWrench(I))
 		if(!allowed(user))
 			to_chat(user, SPAN_WARNING("The bolts on \the [src] are locked!"))

--- a/code/modules/species/outsider/random.dm
+++ b/code/modules/species/outsider/random.dm
@@ -141,22 +141,26 @@
 	icon_state = "ano51"
 	anchored = 1
 
-/obj/structure/aliumizer/attack_hand(mob/living/carbon/human/user)
-	if(!istype(user))
-		to_chat(user, "You got no business touching this.")
+/obj/structure/aliumizer/attack_hand(mob/user)
+	if(!ishuman(user))
+		to_chat(user, SPAN_WARNING("You've got no business touching this."))
 		return
-	if(user.species.name == SPECIES_ALIEN)
-		to_chat(user, "You're already a [SPECIES_ALIEN].")
+	var/decl/species/species = user.get_species()
+	if(!species)
+		return
+	if(species.name == SPECIES_ALIEN)
+		to_chat(user, SPAN_WARNING("You're already a [SPECIES_ALIEN]."))
 		return
 	if(alert("Are you sure you want to be an alien?", "Mom Look I'm An Alien!", "Yes", "No") == "No")
-		to_chat(user, "Okie dokie.")
+		to_chat(user, SPAN_NOTICE("<b>You are now a [SPECIES_ALIEN]!</b>"))
 		return
-	if(user && user.species.name == SPECIES_ALIEN) //no spamming it to get free implants
+	if(species.name == SPECIES_ALIEN) //no spamming it to get free implants
 		return
 	to_chat(user, "You're now an alien humanoid of some undiscovered species. Make up what lore you want, no one knows a thing about your species! You can check info about your traits with Check Species Info verb in IC tab.")
-	to_chat(user, "You can't speak GalCom or any other languages by default. You can use translator implant that spawns on top of this monolith - it will give you knowledge of any language if you hear it enough times.")
-	new/obj/item/implanter/translator(get_turf(src))
-	user.set_species(SPECIES_ALIEN)
-	var/decl/cultural_info/culture = user.get_cultural_value(TAG_CULTURE)
-	user.fully_replace_character_name(culture.get_random_name(user, user.gender))
-	user.rename_self("Humanoid Alien", 1)
+	to_chat(user, "You can't speak any other languages by default. You can use translator implant that spawns on top of this monolith - it will give you knowledge of any language if you hear it enough times.")
+	var/mob/living/carbon/human/H = user
+	new /obj/item/implanter/translator(get_turf(src))
+	H.set_species(SPECIES_ALIEN)
+	var/decl/cultural_info/culture = H.get_cultural_value(TAG_CULTURE)
+	H.fully_replace_character_name(culture.get_random_name(H, H.gender))
+	H.rename_self("Humanoid Alien", 1)

--- a/code/modules/spells/artifacts.dm
+++ b/code/modules/spells/artifacts.dm
@@ -31,9 +31,11 @@
 /obj/item/dice/d20/cursed
 	desc = "A dice with twenty sides said to have an ill effect on those that are unlucky..."
 
-/obj/item/dice/d20/cursed/attack_self(mob/living/user)
+/obj/item/dice/d20/cursed/attack_self(mob/user)
 	..()
-	if(icon_state == "[name][sides]")
-		user.adjustBruteLoss(-30)
-	else if(icon_state == "[name]1")
-		user.adjustBruteLoss(30)
+	if(isliving(user))
+		var/mob/living/M = user
+		if(icon_state == "[name][sides]")
+			M.adjustBruteLoss(-30)
+		else if(icon_state == "[name]1")
+			M.adjustBruteLoss(30)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -438,7 +438,7 @@
 		ui_interact(user)
 	return
 
-/obj/machinery/power/supermatter/attack_ai(mob/user)
+/obj/machinery/power/supermatter/attack_ai(mob/living/silicon/ai/user)
 	ui_interact(user)
 
 /obj/machinery/power/supermatter/attack_ghost(mob/user)
@@ -479,7 +479,7 @@
 		ui.set_auto_update(1)
 
 
-/obj/machinery/power/supermatter/attackby(obj/item/W, mob/living/user)
+/obj/machinery/power/supermatter/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/tape_roll))
 		to_chat(user, "You repair some of the damage to \the [src] with \the [W].")
 		damage = max(damage -10, 0)

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -144,7 +144,7 @@
 		if(was_on)
 			turn_on()
 
-/obj/vehicle/attack_ai(mob/user)
+/obj/vehicle/attack_ai(mob/living/silicon/ai/user)
 	return
 
 /obj/vehicle/unbuckle_mob(mob/user)

--- a/code/modules/xenoarcheaology/artifacts/artifact.dm
+++ b/code/modules/xenoarcheaology/artifacts/artifact.dm
@@ -73,20 +73,20 @@
 	for(var/datum/artifact_effect/effect in list(my_effect, secondary_effect))
 		effect.process()
 
-/obj/structure/artifact/attack_robot(mob/living/user)
+/obj/structure/artifact/attack_robot(mob/user)
 	if(!CanPhysicallyInteract(user))
 		return
 	visible_message(SPAN_NOTICE("[user] touches \the [src]."))
 	check_triggers(/datum/artifact_trigger/proc/on_touch, user)
 	touched(user)
 
-/obj/structure/artifact/attack_hand(mob/living/user)
+/obj/structure/artifact/attack_hand(mob/user)
 	. = ..()
 	visible_message(SPAN_NOTICE("[user] touches \the [src]."))
 	check_triggers(/datum/artifact_trigger/proc/on_touch, user)
 	touched(user)
 
-/obj/structure/artifact/attackby(obj/item/W, mob/living/user)
+/obj/structure/artifact/attackby(obj/item/W, mob/user)
 	. = ..()
 	visible_message(SPAN_WARNING("[user] hits \the [src] with \the [W]."))
 	check_triggers(/datum/artifact_trigger/proc/on_hit, W, user)

--- a/code/modules/xenoarcheaology/artifacts/standalone/replicator.dm
+++ b/code/modules/xenoarcheaology/artifacts/standalone/replicator.dm
@@ -124,7 +124,7 @@
 
 	show_browser(user, dat, "window=alien_replicator")
 
-/obj/machinery/replicator/attackby(obj/item/W, mob/living/user)
+/obj/machinery/replicator/attackby(obj/item/W, mob/user)
 	if(!user.unEquip(W, src))
 		return
 	stored_materials.Add(W)

--- a/code/modules/xenoarcheaology/tools/anomaly_scanner.dm
+++ b/code/modules/xenoarcheaology/tools/anomaly_scanner.dm
@@ -16,7 +16,7 @@
 	var/last_scan_time = 0
 	var/scan_delay = 25
 
-/obj/item/ano_scanner/attack_self(var/mob/living/user)
+/obj/item/ano_scanner/attack_self(var/mob/user)
 	interact(user)
 
 /obj/item/ano_scanner/interact(var/mob/living/user)

--- a/code/modules/xenoarcheaology/tools/core_sampler.dm
+++ b/code/modules/xenoarcheaology/tools/core_sampler.dm
@@ -28,7 +28,7 @@
 /obj/item/core_sampler/on_update_icon()
 	icon_state = "sampler[!!sample]"
 
-/obj/item/core_sampler/attack_self(var/mob/living/user)
+/obj/item/core_sampler/attack_self(var/mob/user)
 	if(sample)
 		to_chat(user, SPAN_NOTICE("You eject the sample."))
 		user.put_in_hands(sample)

--- a/code/modules/xenoarcheaology/tools/depth_scanner.dm
+++ b/code/modules/xenoarcheaology/tools/depth_scanner.dm
@@ -67,7 +67,7 @@
 
 			to_chat(user, "<span class='notice'>[html_icon(src)] [src] pings [pick("madly","wildly","excitedly","crazily")]!</span>")
 
-/obj/item/depth_scanner/attack_self(var/mob/living/user)
+/obj/item/depth_scanner/attack_self(var/mob/user)
 	interact(user)
 
 /obj/item/depth_scanner/interact(var/mob/user)

--- a/mods/content/psionics/items/id_card.dm
+++ b/mods/content/psionics/items/id_card.dm
@@ -23,16 +23,18 @@
 		else
 			to_chat(user, SPAN_NOTICE("This is the real deal, stamped by [GLOB.using_map.boss_name]. It gives the holder the full authority to pursue their goals. You believe it implicitly."))
 
-/obj/item/card/id/foundation/attack_self(var/mob/living/user)
+/obj/item/card/id/foundation/attack_self(var/mob/user)
 	. = ..()
-	if(istype(user))
-		for(var/mob/M in viewers(world.view, get_turf(user))-user)
-			if(user.psi && isliving(M))
-				var/mob/living/L = M
-				if(!L.psi)
-					to_chat(L, SPAN_NOTICE("This is the real deal, stamped by [GLOB.using_map.boss_name]. It gives the holder the full authority to pursue their goals. You believe \the [user] implicitly."))
-					continue
-			to_chat(M, SPAN_WARNING("There is a psionic compulsion surrounding \the [src] in a flicker of indescribable light."))
+	if(isliving(user))
+		var/mob/living/show = user
+		if(show.psi)
+			for(var/mob/M in viewers(world.view, get_turf(user))-user)
+				if(isliving(M))
+					var/mob/living/L = M
+					if(!L.psi)
+						to_chat(L, SPAN_NOTICE("This is the real deal, stamped by [GLOB.using_map.boss_name]. It gives the holder the full authority to pursue their goals. You believe \the [user] implicitly."))
+						continue
+				to_chat(M, SPAN_WARNING("There is a psionic compulsion surrounding \the [src] in a flicker of indescribable light."))
 
 /obj/item/card/id/foundation/on_update_icon()
 	return

--- a/mods/content/xenobiology/slime/_slime.dm
+++ b/mods/content/xenobiology/slime/_slime.dm
@@ -199,7 +199,7 @@
 		if(istype(slime_ai))
 			return slime_ai.adjust_friendship(user, amount)
 
-/mob/living/slime/attack_hand(mob/living/carbon/human/user)
+/mob/living/slime/attack_hand(mob/user)
 
 	if(stat == DEAD)
 		visible_message(SPAN_NOTICE("\The [user] pokes \the [src]."))

--- a/mods/content/xenobiology/slime/items.dm
+++ b/mods/content/xenobiology/slime/items.dm
@@ -78,7 +78,7 @@
 	else
 		icon_state = "golem"
 
-/obj/effect/golemrune/attack_hand(mob/living/user)
+/obj/effect/golemrune/attack_hand(mob/user)
 	var/mob/observer/ghost/ghost
 	for(var/mob/observer/ghost/O in src.loc)
 		if(!O.client)

--- a/mods/species/ascent/effects/razorweb.dm
+++ b/mods/species/ascent/effects/razorweb.dm
@@ -72,7 +72,7 @@
 	playsound(usr, 'mods/species/ascent/sounds/razorweb_break.ogg', 50)
 	qdel_self()
 
-/obj/effect/razorweb/attack_hand(mob/living/user)
+/obj/effect/razorweb/attack_hand(mob/user)
 	user.visible_message(SPAN_DANGER("\The [user] yanks on \the [src]!"))
 	entangle(user, TRUE)
 	qdel_self()

--- a/mods/species/vox/gear/gun_slugsling.dm
+++ b/mods/species/vox/gear/gun_slugsling.dm
@@ -15,7 +15,7 @@
 		movable_flags |= MOVABLE_FLAG_PROXMOVE //Dont want it active during the throw... loooots of unneeded checking.
 	return ..()
 
-/obj/item/slugegg/attack_self(var/mob/living/user)
+/obj/item/slugegg/attack_self(var/mob/user)
 	squish()
 
 /obj/item/slugegg/HasProximity(var/atom/movable/AM)
@@ -61,6 +61,6 @@
 	return S
 
 
-/obj/item/gun/launcher/alien/slugsling/attack_self(var/mob/living/user)
+/obj/item/gun/launcher/alien/slugsling/attack_self(var/mob/user)
 	mode = mode == "Impact" ? "Sentry" : "Impact"
 	to_chat(user,"<span class='notice'>You switch \the [src]'s mode to \"[mode]\"</span>")


### PR DESCRIPTION
Removes the /living from most user args in attack procs, and adds /living/silicon/ai to attack_ai. Redoes some logic to check type and cast appropriately. This is preparing the ground for the status PR, which is busted because I accidentally committed a find and replace that does this PR but badly.