### PR TITLE
Fixes constructed doors always spawning a lock

### DIFF
--- a/code/game/machinery/doors/_door.dm
+++ b/code/game/machinery/doors/_door.dm
@@ -93,12 +93,12 @@
 		PRINT_STACK_TRACE("A door with mapped access restrictions was set to autoinitialize access.")
 #endif
 
-/obj/machinery/door/LateInitialize()
+/obj/machinery/door/LateInitialize(mapload, dir=0, populate_parts=TRUE)
 	..()
 	update_connections(1)
 	update_icon()
 	update_nearby_tiles(need_rebuild=1)
-	if(autoset_access || length(req_access)) // Delayed because apparently the dir is not set by mapping and we need to wait for nearby walls to init and turn us.
+	if(populate_parts && (autoset_access || length(req_access))) // Delayed because apparently the dir is not set by mapping and we need to wait for nearby walls to init and turn us.
 		var/obj/item/stock_parts/access_lock/lock = install_component(/obj/item/stock_parts/access_lock/buildable, refresh_parts = FALSE)
 		if(autoset_access)
 			lock.autoset = TRUE


### PR DESCRIPTION
Now properly checking if door needs to

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->

## Changelog
:cl:
bugfix: Airlocks no longer spawn extra lock when constructed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
