### PR TITLE
Adjusts wall attack balance

### DIFF
--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -365,5 +365,5 @@
 
 	playsound(src, 'sound/effects/metalhit.ogg', 50, 1)
 	visible_message(SPAN_DANGER("\The [user] [pick(W.attack_verb)] \the [src] with \the [W]!"))
-	take_damage(10)
+	take_damage(W.force/10)
 	return TRUE


### PR DESCRIPTION
The damage walls take from attacks is now dependent on item force. Fixes #1387
## Changelog
:cl:
tweak: Attacking walls with items will now do less damage across the board. 
/:cl: