### PR TITLE
Deleted redundant work done by ChangeTurf, moved other work to turf init.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -71,8 +71,15 @@
 	return
 
 /atom/Destroy()
+	overlays.Cut()
+	underlays.Cut()
 	global.is_currently_exploding -= src
 	QDEL_NULL(reagents)
+	if(light)
+		light.destroy()
+		light = null
+	if(opacity)
+		updateVisibility(src)
 	. = ..()
 
 /atom/proc/reveal_blood()

--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -98,7 +98,7 @@
 		ChangeTurf(get_base_turf_by_area(src))
 
 /turf/exterior/on_update_icon(var/update_neighbors)
-	..() // Recalc AO and flooding overlay.
+	. = ..() // Recalc AO and flooding overlay.
 	cut_overlays()
 	if(LAZYLEN(decals))
 		add_overlay(decals)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -35,6 +35,8 @@
 		floortype = initial_flooring
 	if(floortype)
 		set_flooring(GET_DECL(floortype))
+	if(!ml)
+		RemoveLattice()
 
 /turf/simulated/floor/proc/set_flooring(var/decl/flooring/newflooring)
 	make_plating(defer_icon_update = 1)

--- a/code/game/turfs/simulated/floor_static.dm
+++ b/code/game/turfs/simulated/floor_static.dm
@@ -14,6 +14,7 @@
 	return ..()
 
 /turf/simulated/floor/fixed/on_update_icon()
+	queue_ao(FALSE)
 	update_flood_overlay()
 
 /turf/simulated/floor/fixed/is_plating()

--- a/code/game/turfs/turf_ao.dm
+++ b/code/game/turfs/turf_ao.dm
@@ -10,9 +10,9 @@
 	var/ao_queued = AO_UPDATE_NONE
 
 /turf/proc/regenerate_ao()
-	for (var/thing in RANGE_TURFS(src, 1))
+	for(var/thing in RANGE_TURFS(src, 1))
 		var/turf/T = thing
-		if (T.permit_ao)
+		if(istype(T) && T.permit_ao)
 			T.queue_ao(TRUE)
 
 /turf/proc/calculate_ao_neighbors()

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -62,12 +62,6 @@
 		else
 			light = new /datum/light_source(src, .)
 
-/atom/Destroy()
-	if(light)
-		light.destroy()
-		light = null
-	return ..()
-
 /atom/set_opacity()
 	. = ..()
 	if(.)

--- a/code/modules/mob/observer/eye/freelook/update_triggers.dm
+++ b/code/modules/mob/observer/eye/freelook/update_triggers.dm
@@ -10,11 +10,6 @@
 /turf/drain_power()
 	return -1
 
-/atom/Destroy()
-	if(opacity)
-		updateVisibility(src)
-	. = ..()
-
 // DOORS
 
 // Simply updates the visibility of the area when it opens/closes/destroyed.

--- a/code/modules/multiz/zmimic/mimic_common.dm
+++ b/code/modules/multiz/zmimic/mimic_common.dm
@@ -10,7 +10,7 @@
 
 /turf/update_icon()
 	..()
-	if (above)
+	if(above)
 		update_above()
 
 /atom/movable/update_icon()


### PR DESCRIPTION
Big chunk of what ChangeTurf was doing is already handled by Initialize() or other systems that are independant of turf creation.

I had to type these turf loops due to some kind of issue with block() and neighbors that have been maploaded after DMMSuite has expanded the map, it ends up treating them as valid turfs, the compiler skips the type check, and then they are invalid for var reference. Lummox's commentary:
````
[3:48 PM] Lummox JR: Already of course this shouldn't be happening. There's no way a turf's type path should ever be empty, unless maybe during creation.
[3:48 PM] Lummox JR: Ohhh, but DMMsuite is probably changing the map size.
[3:51 PM] Lummox JR: Okay, I see what's happening.
[3:53 PM] Lummox JR: ResizeWorldMap() is being called during DMMsuite to load the new map. When new turfs get filled in, they're given the default area and then assigned a type path, then New() is called. This happens in a loop (which I could stand to optimize).
[3:53 PM] Lummox JR:
    for(z=0,new_idx=0;z<new_maxz;z++) {
        for(y=0;y<new_maxy;y++) {
            for(x=0;x<new_maxx;x++,new_idx++) {
                if(x>=old_maxx || y>=old_maxy || z>=old_maxz) {
                    loc = Map2Value(new_idx);    // for now we'll set this every time, in case MakeDataObject() were to screw with the loc value
                    MakeAreaAt(NULL_VALUE,ddeng->dmb->world.default_area,loc);
                    MakeDataObject(NULL_VALUE,PTurf2Value(ddeng->dmb->world.default_turf),NONE,&loc,1);
                }
            }
        }
    }
[3:54 PM] Lummox JR: So, the problem here is that New() is being called on a turf that's been fully created, but that turf's New() is doing stuff to check its neighbors that have not been created.
[3:54 PM] Lummox JR: That is, they have indexes and valid refs, but no valid type path yet.
````