### PR TITLE
Adding webhook support for per-endpoint mentions.

### DIFF
--- a/config/example/webhooks.json
+++ b/config/example/webhooks.json
@@ -1,7 +1,12 @@
 [
   {
     "id" : "webhook_roundend",
-    "url" : "someurl",
-    "mentions" : []
+    "url" : {
+		"someurl0" : [],
+		"someurl1" : [],
+		"someurl2" : "somemention0",
+		"someurl3" : [ "somemention1", "somemention2" ]
+	},
+    "mentions" : [ "somemention3", "somemention4" ]
   }
 ]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -52,7 +52,7 @@ If you wish to use Discord webhooks, which are a way of passing information from
 - webhook_submap_loaded: A submap has been loaded and placed, and is available for people to join. Includes the name of the submap.
 - webhook_custom_event: The custom event text for the round has been set or changed.
 
-Each definition can optionally include an array of roles to mention when the webhook is called. Roles must be provided using the role ID (ex. `<@&555231866735689749>`), which can be obtained by writing `\@somerole` into the chat, in order for pinging to work correctly.
+Each definition can optionally include an array of roles to mention when the webhook is called. Roles must be provided using the role ID (ex. `<@&555231866735689749>`), which can be obtained by writing `\@somerole` into the chat, in order for pinging to work correctly. Including the mentions as the value keyed to a URL will send the mentions only with that URL, while using the "mentions" field will attach the mentions to all URLs.
 
 Webhooks additionally require a HTTP POST library called [byhttp](https://github.com/Lohikar/byhttp). The compiled lib, `byhttp.dll` on Windows or `libbyhttp.so` on Linux, must be placed in the lib directory by default in order for webhooks to function. The DLL location can be customized by supplying `WINDOWS_HTTP_POST_DLL_LOCATION` `UNIX_HTTP_POST_DLL_LOCATION`, or `HTTP_POST_DLL_LOCATION` as preprocessor macros containing the desired path.
 


### PR DESCRIPTION
Can't believe it didn't occur to me that having multiple URLs meant multiple servers.
Tested with new and old config format, you should not need to update your JSON unless you want to add endpoint specific mentions, in which case you will need to use the new format.

:cl:
tweak: Webhook config now supports per-endpoint mention lists. Consult config/example/webhooks.json for the format. If you don't need individual pings, you don't need to update anything.
/:cl: