### PR TITLE
Suicide & supply beacon attack logs

### DIFF
--- a/code/game/machinery/supplybeacon.dm
+++ b/code/game/machinery/supplybeacon.dm
@@ -80,6 +80,7 @@
 	set_light(1, 0.5, 2, 2, "#00ccaa")
 	icon_state = "beacon_active"
 	update_use_power(POWER_USE_IDLE)
+	admin_attacker_log(user, "has activated \a [src] at [get_area(src)]")
 	if(user) to_chat(user, "<span class='notice'>You activate the beacon. The supply drop will be dispatched soon.</span>")
 
 /obj/machinery/power/supply_beacon/proc/deactivate(var/mob/user, var/permanent)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -348,7 +348,7 @@
 		var/user_message = SPAN_WARNING("You fire \the [src][pointblank ? " point blank":""] at \the [target][reflex ? " by reflex" : ""]!")
 		if (silenced)
 			to_chat(user, user_message)
-		else 
+		else
 			user.visible_message(
 				SPAN_DANGER("\The [user] fires \the [src][pointblank ? " point blank":""] at \the [target][reflex ? " by reflex" : ""]!"),
 				user_message,
@@ -511,6 +511,7 @@
 	var/mob/living/carbon/human/M = user
 
 	mouthshoot = 1
+	admin_attacker_log(user, "is attempting to suicide with \a [src]")
 	M.visible_message("<span class='danger'>[user] sticks their gun in their mouth, ready to pull the trigger...</span>")
 	if(!do_after(user, 40, progress=0))
 		M.visible_message("<span class='notice'>[user] decided life was worth living</span>")
@@ -538,6 +539,7 @@
 
 		in_chamber.on_hit(M)
 		if (in_chamber.damage_type != PAIN)
+			admin_attacker_log(user, "commited suicide using \a [src]")
 			log_and_message_admins("[key_name(user)] commited suicide using \a [src]")
 			user.apply_damage(in_chamber.damage*2.5, in_chamber.damage_type, BP_HEAD, in_chamber.damage_flags(), used_weapon = "Point blank shot in the mouth with \a [in_chamber]")
 			user.death()


### PR DESCRIPTION
Ported from https://github.com/Baystation12/Baystation12/pull/30244

## Changelog
:cl:
admin: Supply beacons now generate attack logs when activated
admin: Suicide by gun in the mouth now trigger attack logs instead of admin logs, including a new log when starting the suicide process
/:cl:
