### PR TITLE
Walls are now harder to bash

### DIFF
--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -349,12 +349,16 @@
 			return
 	
 	user.do_attack_animation(src)
-	if(W.force < 5)
+	var/material_divisor = max(material.brute_armor, reinf_material?.brute_armor)
+	if(W.damtype == BURN)
+		material_divisor = max(material.burn_armor, reinf_material?.burn_armor)
+	var/effective_force = round(W.force / material_divisor)
+	if(effective_force < 2)
 		visible_message(SPAN_DANGER("\The [user] [pick(W.attack_verb)] \the [src] with \the [W], but it had no effect!"))
 		playsound(src, hitsound, 25, 1)
 		return
 	// Check for a glancing blow.
-	var/dam_prob = max(0, 100 - material.hardness + W.force)
+	var/dam_prob = max(0, 100 - material.hardness + effective_force + W.armor_penetration)
 	if(!prob(dam_prob))
 		visible_message(SPAN_DANGER("\The [user] [pick(W.attack_verb)] \the [src] with \the [W], but it bounced off!"))
 		playsound(src, hitsound, 25, 1)
@@ -365,5 +369,5 @@
 
 	playsound(src, 'sound/effects/metalhit.ogg', 50, 1)
 	visible_message(SPAN_DANGER("\The [user] [pick(W.attack_verb)] \the [src] with \the [W]!"))
-	take_damage(10)
+	take_damage(effective_force)
 	return TRUE

--- a/code/modules/materials/definitions/solids/materials_solid_metal.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_metal.dm
@@ -185,7 +185,7 @@
 	icon_reinf = 'icons/turf/walls/reinforced.dmi'
 	color = "#a8a9b2"
 	explosion_resistance = 25
-	brute_armor = 6
+	brute_armor = 8
 	burn_armor = 10
 	hardness = MAT_VALUE_VERY_HARD
 	stack_origin_tech = "{'materials':2}"


### PR DESCRIPTION
Fixes #1387
Now they're divided by those gross 'armor' values materials have.
Overall should make breaking down walls by bashing way less viable, since run of the mill steel walls will divide damage by 5, and rwalls by 8

Alternative to #1401 using material vars instead of one number for all

## Changelog
:cl:
tweak: Walls now take much less damage from melee strikes, depending on material.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
