### PR TITLE
Changes to alarm remote control

### DIFF
--- a/code/game/machinery/computer/atmos_alert.dm
+++ b/code/game/machinery/computer/atmos_alert.dm
@@ -61,16 +61,5 @@ var/global/list/minor_air_alarms = list()
 			for(var/datum/alarm_source/alarm_source in alarm.sources)
 				var/obj/machinery/alarm/air_alarm = alarm_source.source
 				if(istype(air_alarm))
-					var/list/new_ref = list("atmos_reset" = 1)
-					air_alarm.Topic(air_alarm, new_ref, state = air_alarm_topic)
+					air_alarm.set_alarm(0)
 		return TOPIC_REFRESH
-
-
-var/datum/topic_state/air_alarm_topic/air_alarm_topic = new()
-
-/datum/topic_state/air_alarm_topic/href_list(var/mob/user)
-	var/list/extra_href = list()
-	extra_href["remote_connection"] = 1
-	extra_href["remote_access"] = 1
-
-	return extra_href

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -10,7 +10,7 @@
 	light_color = "#00b000"
 	density = 1
 	anchored = 1.0
-	initial_access = list(access_ce)
+	initial_access = list(list(access_engine_equip, access_atmospherics))
 	var/list/monitored_alarm_ids = null
 	var/datum/nano_module/atmos_control/atmos_control
 	base_type = /obj/machinery/computer/atmoscontrol
@@ -27,15 +27,8 @@
 	ui_interact(user)
 	return TRUE
 
-/obj/machinery/computer/atmoscontrol/emag_act(var/remaining_carges, var/mob/user)
-	if(!emagged)
-		user.visible_message("<span class='warning'>\The [user] does something \the [src], causing the screen to flash!</span>",\
-			"<span class='warning'>You cause the screen to flash as you gain full control.</span>",\
-			"You hear an electronic warble.")
-		atmos_control.emagged = 1
-		return 1
-
 /obj/machinery/computer/atmoscontrol/ui_interact(var/mob/user)
 	if(!atmos_control)
-		atmos_control = new(src, req_access, monitored_alarm_ids)
+		atmos_control = new(src, monitored_alarm_ids)
+		atmos_control.set_monitored_alarms(monitored_alarm_ids)
 	atmos_control.ui_interact(user)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -9,7 +9,7 @@
 	if (!loc)
 		return
 
-	if(machine && !machine.CanUseTopic(src)) // unsure if this is a good idea, but using canmousedrop was ???
+	if(machine && (machine.CanUseTopic(src, machine.DefaultTopicState()) == STATUS_CLOSE)) // unsure if this is a good idea, but using canmousedrop was ???
 		machine = null
 
 	//Handle temperature/pressure differences between body and environment

--- a/code/modules/nano/interaction/base.dm
+++ b/code/modules/nano/interaction/base.dm
@@ -19,9 +19,6 @@
 /datum/topic_state
 	var/check_access = TRUE // Whether this topic state should bypass access checks or not.
 
-/datum/topic_state/proc/href_list(var/mob/user)
-	return list()
-
 /datum/topic_state/proc/can_use_topic(var/src_object, var/mob/user)
 	return STATUS_CLOSE
 

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -1,8 +1,5 @@
 GLOBAL_DATUM_INIT(default_state, /datum/topic_state/default, new)
 
-/datum/topic_state/default/href_list(var/mob/user)
-	return list()
-
 /datum/topic_state/default/can_use_topic(var/src_object, var/mob/user)
 	return user.default_can_use_topic(src_object)
 

--- a/nano/templates/air_alarm.tmpl
+++ b/nano/templates/air_alarm.tmpl
@@ -60,9 +60,9 @@ Used In File(s): \code\game\machinery\alarm.dm
                     <td>
                         <div class="item">
                             <div class="itemContent" style="width: 100%;">	
-                                {{:helper.link('Off',	null, { 'rcon' : 1}, data.remote_connection && !data.remote_access ? (data.rcon == 1 ? 'yellowButton' : 'disabled') : null, data.rcon == 1 ? 'selected' : null)}}
-                                {{:helper.link('Auto',	null, { 'rcon' : 2}, data.remote_connection && !data.remote_access ? (data.rcon == 2 ? 'yellowButton' : 'disabled') : null, data.rcon == 2 ? 'selected' : null)}}
-                                {{:helper.link('On',	null, { 'rcon' : 3}, data.remote_connection && !data.remote_access ? (data.rcon == 3 ? 'yellowButton' : 'disabled') : null, data.rcon == 3 ? 'selected' : null)}}
+                                {{:helper.link('Off',	null, { 'rcon' : 1}, !data.rcon_access ? (data.rcon == 1 ? 'yellowButton' : 'disabled') : null, data.rcon == 1 ? 'selected' : null)}}
+                                {{:helper.link('Auto',	null, { 'rcon' : 2}, !data.rcon_access ? (data.rcon == 2 ? 'yellowButton' : 'disabled') : null, data.rcon == 2 ? 'selected' : null)}}
+                                {{:helper.link('On',	null, { 'rcon' : 3}, !data.rcon_access ? (data.rcon == 3 ? 'yellowButton' : 'disabled') : null, data.rcon == 3 ? 'selected' : null)}}
                             </div>
                         </div>
                     </td>

--- a/nano/templates/atmos_control.tmpl
+++ b/nano/templates/atmos_control.tmpl
@@ -1,4 +1,15 @@
 <div class='item'>
+	{{:helper.link('Refresh', 'refresh', {'refresh' : 1})}}
+</div>
+<div class='item'>
+	<div class='itemLabel'>
+		Filter term: 
+	</div>
+	<div class='itemContent'>
+		{{:helper.link(data.filter, null, {'filter_set' : 1})}}
+	</div>
+</div>
+<div class='item'>
 	{{for data.alarmsAlert}}
         {{:helper.link(value.name, null, {'alarm' : value.ref}, null, 'redButton')}}
     {{/for}}


### PR DESCRIPTION
- You need program/console access to access the list of alarms
- You need alarm access to access control options on the alarm
- You also need either RCON to be set to on, RCON set to auto and an alarm in the area, or RCON remote set access (CE access by default) on the alarm to have access to the controls
- You can change RCON settings either locally (no access needed) or remotely (but only with RCON remote set access)
- The ui still looks like shit, but has a search function that makes it usable at least
- There are a bunch of backend changes, as it was not set up in a way I found reasonable

Closes #1437. This is largely unrelated to the other changes here.