### PR TITLE
Fixes eye unlook not resetting view.

### DIFF
--- a/code/modules/mob/observer/eye/eye.dm
+++ b/code/modules/mob/observer/eye/eye.dm
@@ -78,6 +78,7 @@
 	LAZYREMOVE(user.additional_vision_handlers, src)
 	remove_visual(owner)
 	owner.eyeobj = null
+	owner.reset_view()
 	if(click_handler_type)
 		owner.RemoveClickHandler(click_handler_type)
 	owner = null


### PR DESCRIPTION
Closes  #1436.

Artifact of me making mob/Life no longer call reset_view: it still does it if you have an eye set, but here you don't have eye set anymore and so it doesn't reset view. No idea why it didn't call reset view on `release` previously: it meant you'd have 0-2 seconds of blackness whenever you unset the eye.