### PR TITLE
Refactoring grab movement handling.

### DIFF
--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -188,8 +188,8 @@
 			to_chat(mob, SPAN_WARNING("You're pinned down by \a [mob.pinned[1]]!"))
 		return MOVEMENT_STOP
 
-	for(var/obj/item/grab/G in mob.grabbed_by)
-		if(G.assailant != mob && (mob.restrained() || G.stop_move()))
+	for(var/obj/item/grab/G as anything in mob.grabbed_by)
+		if(G.assailant != mob && G.assailant != mover && (mob.restrained() || G.stop_move()))
 			if(mover == mob)
 				to_chat(mob, SPAN_WARNING("You're restrained and cannot move!"))
 			mob.ProcessGrabs()
@@ -223,9 +223,7 @@
 		for(var/atom/movable/AM as anything in mob.ret_grab())
 			if(AM != src && AM.loc != mob.loc && !AM.anchored && old_turf.Adjacent(AM))
 				AM.glide_size = mob.glide_size // This is adjusted by grabs again from events/some of the procs below, but doing it here makes it more likely to work with recursive movement.
-				// attempt 1: step(AM, get_dir(get_turf(AM), old_turf)) // Breaks on moving with a diagonal grab.
-				// attempt 2: AM.DoMove(get_dir(get_turf(AM), old_turf), mob, TRUE) // Why doesn't this work? :(
-				AM.dropInto(old_turf) // attempt 3
+				AM.DoMove(get_dir(get_turf(AM), old_turf), mob, TRUE)
 
 		for(var/obj/item/grab/G as anything in mob.get_active_grabs())
 			G.adjust_position()
@@ -233,7 +231,7 @@
 	if(QDELETED(mob)) // No idea why, but this was causing null check runtimes on live.
 		return
 
-	for(var/obj/item/grab/G as anything in mob)
+	for(var/obj/item/grab/G as anything in mob.get_active_grabs())
 		if(G.assailant_reverse_facing())
 			mob.set_dir(GLOB.reverse_dir[direction])
 		G.assailant_moved()
@@ -243,7 +241,7 @@
 	if(direction & (UP|DOWN))
 		var/txt_dir = (direction & UP) ? "upwards" : "downwards"
 		old_turf.visible_message(SPAN_NOTICE("[mob] moves [txt_dir]."))
-		for(var/obj/item/grab/G in mob.get_active_grabs())
+		for(var/obj/item/grab/G as anything in mob.get_active_grabs())
 			if(!G.affecting)
 				continue
 			var/turf/start = G.affecting.loc

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -262,10 +262,16 @@
 			G.affecting.forceMove(destination)
 			continue
 
-	//Moving with objects stuck in you can cause bad times.
+	// Sprinting uses up stamina and causes exertion effects.
 	if(MOVING_QUICKLY(mob))
 		mob.last_quick_move_time = world.time
 		mob.adjust_stamina(-(mob.get_stamina_used_per_step() * (1+mob.encumbrance())))
+		if(ishuman(mob))
+			var/decl/species/species = mob.get_species()
+			if(species)
+				species.handle_exertion(mob)
+
+	//Moving with objects stuck in you can cause bad times.
 	mob.handle_embedded_and_stomach_objects()
 	mob.moving = FALSE
 

--- a/code/datums/movement/movement.dm
+++ b/code/datums/movement/movement.dm
@@ -83,6 +83,16 @@ if(LAZYLEN(movement_handlers) && ispath(movement_handlers[1])) { \
 	SET_MOVER(mover)
 	SET_IS_EXTERNAL(mover)
 
+	if(!length(movement_handlers) && is_external && isturf(loc))
+		var/oldloc = loc
+		var/turf/T = get_step(loc, direction)
+		if(istype(T))
+			if(direction in GLOB.cornerdirs) // Diagonal movement with step() currently breaks
+				forceMove(T)                 // grabs, remove these lines when that is fixed.
+			else
+				step(src, direction)
+		return loc != oldloc
+
 	for(var/mh in movement_handlers)
 		var/datum/movement_handler/movement_handler = mh
 		if(movement_handler.MayMove(mover, is_external) & MOVEMENT_STOP)

--- a/code/game/atoms_movable_grabs.dm
+++ b/code/game/atoms_movable_grabs.dm
@@ -16,3 +16,5 @@
 /atom/movable/proc/adjust_pixel_offsets_for_grab(var/obj/item/grab/G, var/grab_dir)
 	reset_plane_and_layer()
 
+/atom/movable/proc/get_object_size()
+	return ITEM_SIZE_NORMAL

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -201,3 +201,6 @@
 
 /obj/get_mass()
 	return min(2**(w_class-1), 100)
+
+/obj/get_object_size()
+	return w_class

--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -16,7 +16,7 @@
 	var/downgrade_on_move = 0					// If the grab needs to be downgraded when the grabber moves.
 	var/force_danger = 0						// If the grab is strong enough to be able to force someone to do something harmful to them.
 	var/restrains = 0							// If the grab acts like cuffs and prevents action from the victim.
-	var/grab_slowdown = 7
+	var/grab_slowdown = 0.35                    // Multiplier for the object size (w_class or mob_size) of the grabbed atom, applied as slowdown.
 	var/shift = 0
 	var/success_up =   "You get a better grip on rep_affecting."
 	var/success_down = "You adjust your grip on rep_affecting."

--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -16,7 +16,7 @@
 	var/downgrade_on_move = 0					// If the grab needs to be downgraded when the grabber moves.
 	var/force_danger = 0						// If the grab is strong enough to be able to force someone to do something harmful to them.
 	var/restrains = 0							// If the grab acts like cuffs and prevents action from the victim.
-	var/grab_slowdown = 0.35                    // Multiplier for the object size (w_class or mob_size) of the grabbed atom, applied as slowdown.
+	var/grab_slowdown = 0.15                    // Multiplier for the object size (w_class or mob_size) of the grabbed atom, applied as slowdown.
 	var/shift = 0
 	var/success_up =   "You get a better grip on rep_affecting."
 	var/success_down = "You adjust your grip on rep_affecting."

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -272,7 +272,7 @@
 	return current_grab.force_danger
 
 /obj/item/grab/proc/grab_slowdown()
-	return current_grab.grab_slowdown
+	return max(ceil(affecting?.get_object_size() * current_grab.grab_slowdown), 1)
 
 /obj/item/grab/proc/assailant_moved()
 	affecting.glide_size = assailant.glide_size // Note that this is called _after_ the Move() call resolves, so while it adjusts affecting's move animation, it won't adjust anything else depending on it.

--- a/code/modules/mob/grab/normal/norm_struggle.dm
+++ b/code/modules/mob/grab/normal/norm_struggle.dm
@@ -10,7 +10,7 @@
 	point_blank_mult = 1
 	same_tile = 0
 	breakability = 3
-	grab_slowdown = 0.5
+	grab_slowdown = 0.35
 	upgrade_cooldown = 20
 	can_downgrade_on_resist = 0
 	icon_state = "reinforce"

--- a/code/modules/mob/grab/normal/norm_struggle.dm
+++ b/code/modules/mob/grab/normal/norm_struggle.dm
@@ -10,7 +10,7 @@
 	point_blank_mult = 1
 	same_tile = 0
 	breakability = 3
-	grab_slowdown = 10
+	grab_slowdown = 0.5
 	upgrade_cooldown = 20
 	can_downgrade_on_resist = 0
 	icon_state = "reinforce"

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -134,6 +134,14 @@
 	. = ..()
 	if(.) //We moved
 		species.handle_exertion(src)
+
+		var/stamina_cost = 0
+		for(var/obj/item/grab/G as anything in get_active_grabs())
+			stamina_cost -= G.grab_slowdown()
+		stamina_cost = round(stamina_cost)
+		if(stamina_cost < 0)
+			adjust_stamina(stamina_cost)
+
 		handle_leg_damage()
 
 		if(client)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -205,7 +205,7 @@
 #undef ENCUMBERANCE_MOVEMENT_MOD
 
 /mob/proc/encumbrance()
-	for(var/obj/item/grab/G in get_active_grabs())
+	for(var/obj/item/grab/G as anything in get_active_grabs())
 		. = max(., G.grab_slowdown())
 	. *= (0.8 ** size_strength_mod())
 	. *= (0.5 + 1.5 * (SKILL_MAX - get_skill_value(SKILL_HAULING))/(SKILL_MAX - SKILL_MIN))

--- a/code/modules/mob/mob_grabs.dm
+++ b/code/modules/mob/mob_grabs.dm
@@ -47,3 +47,6 @@
 	. = list()
 	for(var/obj/item/grab/grab in contents)
 		. += grab
+
+/mob/get_object_size()
+	return mob_size	

--- a/code/modules/mob/mob_grabs.dm
+++ b/code/modules/mob/mob_grabs.dm
@@ -32,10 +32,10 @@
 			last_handled_by_mob = weakref(grabber)
 
 /mob/proc/handle_grab_damage()
-	set waitfor = 0
+	set waitfor = FALSE
 
 /mob/proc/handle_grabs_after_move()
-	set waitfor = 0
+	set waitfor = FALSE
 
 /mob/proc/add_grab(var/obj/item/grab/grab)
 	return FALSE

--- a/code/modules/reagents/chems/chems_compounds.dm
+++ b/code/modules/reagents/chems/chems_compounds.dm
@@ -250,11 +250,11 @@
 	var/volume = REAGENT_VOLUME(holder, type)
 	M.add_chemical_effect(CE_PULSE, 1)
 	M.add_chemical_effect(CE_BREATHLOSS, 0.02 * volume)
-	if(volume >= 5)
+	if(volume >= 10)
 		M.add_chemical_effect(CE_PULSE, 1)
-		M.add_chemical_effect(CE_SLOWDOWN, (volume/5) ** 2)
-	else if(LAZYACCESS(M.chem_doses, type) > 20) //after prolonged exertion
-		ADJ_STATUS(M, STAT_JITTER, 10)
+		M.add_chemical_effect(CE_SLOWDOWN, (volume/10) ** 2)
+	else if(LAZYACCESS(M.chem_doses, type) > 30) //after prolonged exertion
+		ADJ_STATUS(M, STAT_JITTER, 5)
 
 /decl/material/liquid/nanoblood
 	name = "nanoblood"

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -860,7 +860,7 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 /decl/species/proc/handle_exertion(mob/living/carbon/human/H)
 	if (!exertion_effect_chance)
 		return
-	var/chance = exertion_effect_chance * H.encumbrance()
+	var/chance = max((100 - H.stamina), exertion_effect_chance * H.encumbrance())
 	if (chance && prob(H.skill_fail_chance(SKILL_HAULING, chance)))
 		var/synthetic = H.isSynthetic()
 		if (synthetic)


### PR DESCRIPTION
- Prevents grabbed atoms from moving if the holder does not move, which is what was resulting in doors failing to open.
- Replaced `step(AM, get_dir(src, old_turf))` with `AM.DoMove(foo)` and an adjacency check.
- Added some basic move handling for atoms with no movement handlers defined. Includes a workaround for an annoying issue with dragging non-mobs.
- Grab slowdown has been significantly decreased across the board and scales to the size of the atom being dragged.
- Lactate now takes effect slower.
- Fixes #1435.

The workaround is not an ideal solution, but step() breaks grabs on diagonal moves.
