### PR TITLE
Fixes lighting_overlays breaking SSlighting.overlay_queue

### DIFF
--- a/code/controllers/subsystems/lighting.dm
+++ b/code/controllers/subsystems/lighting.dm
@@ -141,6 +141,9 @@ SUBSYSTEM_DEF(lighting)
 		var/atom/movable/lighting_overlay/O = overlay_queue[oq_idex]
 		oq_idex += 1
 
+		if(QDELETED(O))
+			continue
+			
 		O.update_overlay()
 		O.needs_update = 0
 

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -127,8 +127,10 @@
 	return
 
 /atom/movable/lighting_overlay/Destroy()
+	// Do not remove this from SSlighting.overlay_queue
+	// or it will mess with the queue. It will fall out 
+	// safely during processing
 	total_lighting_overlays--
-	SSlighting.overlay_queue -= src
 
 	var/turf/T = loc
 	if(istype(T))


### PR DESCRIPTION
Deleting a lighting_overlay would remove it from the SSlighting.overlay_queue. This would cause the current index to potentially skip over an item, and rarely cause a runtime.
