### PR TITLE
Generalizes unit test map

### DIFF
--- a/code/unit_tests/chemistry_tests.dm
+++ b/code/unit_tests/chemistry_tests.dm
@@ -39,6 +39,10 @@
 			fail("Error after transfer: [error]")
 		else
 			pass("Final reagent holders had correct values.")
+
+	qdel(from)
+	if(!isturf(target))
+		qdel(target)
 	return TRUE
 
 /datum/unit_test/chemistry/proc/perform_transfer(var/atom/from, var/atom/target)

--- a/code/unit_tests/extension_tests.dm
+++ b/code/unit_tests/extension_tests.dm
@@ -101,6 +101,7 @@
 	else
 		fail("[log_info_line(four)] had unexpected arguments:\n[log_info_line(four.holder)]\n[log_info_line(four.first_argument)]\n[log_info_line(four.second_argument)]")
 
+	qdel(O)
 	return TRUE
 
 /datum/unit_test/extensions/immediate_extension_shall_be_provided_arguments_as_expected
@@ -117,6 +118,7 @@
 	else
 		fail("[log_info_line(five)] had unexpected arguments:\n[log_info_line(five.holder)]\n[log_info_line(five.first_argument)]\n[log_info_line(five.second_argument)]")
 
+	qdel(O)
 	return TRUE
 
 /datum/unit_test/extensions/get_or_create_extension_shall_initialize_as_expected
@@ -141,6 +143,7 @@
 	else
 		pass("All assertions passed.")
 
+	qdel(O)
 	return TRUE
 
 /datum/unit_test/extensions/get_or_create_extension_with_arguments_shall_initialize_as_expected
@@ -156,6 +159,7 @@
 	else
 		fail("[log_info_line(four)] had unexpected arguments:\n[log_info_line(four.holder)]\n[log_info_line(four.first_argument)]\n[log_info_line(four.second_argument)]")
 
+	qdel(O)
 	return TRUE
 
 /datum/extension/test_one

--- a/code/unit_tests/foundation_tests.dm
+++ b/code/unit_tests/foundation_tests.dm
@@ -28,3 +28,5 @@
 	. = . && start.x == T.x
 	. = . && start.y + 1 == T.y
 	. = . && start.z == T.z
+
+	qdel(T)

--- a/code/unit_tests/mob_tests.dm
+++ b/code/unit_tests/mob_tests.dm
@@ -1,4 +1,3 @@
-
 /*
  *
  *  Mob Unit Tests.
@@ -190,6 +189,7 @@
 	var/ending_damage = damage_check(H, damagetype)
 
 	var/ending_health = H.health
+	qdel(H)
 
 	// Now test this stuff.
 

--- a/code/unit_tests/proximity_tests.dm
+++ b/code/unit_tests/proximity_tests.dm
@@ -16,6 +16,7 @@
 /datum/unit_test/proximity/teardown_test()
 	QDEL_NULL(proximity_listener)
 	wall = null
+	..()
 
 /datum/unit_test/proximity/proc/SetWallOpacity(opacity)
 	for(var/turf/simulated/wall/wall in range(7, proximity_listener))

--- a/code/unit_tests/virtual_mob_tests.dm
+++ b/code/unit_tests/virtual_mob_tests.dm
@@ -21,10 +21,22 @@
 	var/list/excessive_mobs= actual_mobs - expected_mobs
 
 	if(missing_mobs.len || excessive_mobs.len)
-		fail("[helper_proc] did not return the expected mobs. Expected [english_list(expected_mobs)], was [english_list(actual_mobs)]")
+		log_bad("Expected: ")
+		for(var/expected in expected_mobs)
+			log_bad("\t[log_info_line(expected)]")
+		log_bad("Was: ")
+		for(var/actual in actual_mobs)
+			log_bad("\t[log_info_line(actual)]")
+		log_bad("Missing: ")
+		for(var/missing in missing_mobs)
+			log_bad("\t[log_info_line(missing)]")
+		log_bad("Excess: ")
+		for(var/excess in excessive_mobs)
+			log_bad("\t[log_info_line(excess)]")
 		log_debug(mob_one.virtual_mob.sight)
 		log_debug(mob_one.virtual_mob.see_invisible)
 		log_debug(mob_one.virtual_mob.see_in_dark)
+		fail("[helper_proc] did not return the expected mobs")
 	else
 		pass("[helper_proc] returned the expected mobs.")
 
@@ -48,7 +60,7 @@
 	storage = new(mob_one.loc)
 	mob_one.forceMove(storage)
 	expected_mobs = list(mob_one, mob_two, mob_three)
-/datum/unit_test/virtual/helper/check_hearers_in_range_with_mob_inside_storage/Destroy()
+/datum/unit_test/virtual/helper/check_hearers_in_range_with_mob_inside_storage/teardown_test()
 	QDEL_NULL(storage)
 	. = ..()
 
@@ -89,7 +101,7 @@
 	storage = new(mob_one.loc)
 	mob_one.forceMove(storage)
 	expected_mobs = list(mob_one, mob_two)
-/datum/unit_test/virtual/helper/check_hosts_in_view_range_with_mob_inside_object/Destroy()
+/datum/unit_test/virtual/helper/check_hosts_in_view_range_with_mob_inside_object/teardown_test()
 	QDEL_NULL(storage)
 	. = ..()
 

--- a/code/unit_tests/~unit_test_subsystems.dm
+++ b/code/unit_tests/~unit_test_subsystems.dm
@@ -80,15 +80,19 @@ SUBSYSTEM_DEF(unit_tests)
 	while (curr.len)
 		var/datum/unit_test/test = curr[curr.len]
 		curr.len--
-		if(do_unit_test(test, end_unit_tests))
-			if(test.async)
-				async_tests += test
-			else
-				test.teardown_test()
+		if(test.async)
+			async_tests += test
+		else
+			do_unit_test(test, end_unit_tests)
 		total_unit_tests++
 		if (MC_TICK_CHECK)
 			return
+
+	// Once we have dealt with all synchronous tests
+	//  start all async tests and proceed to the next stage
 	if (!curr.len)
+		for(var/test in async_tests)
+			do_unit_test(test, end_unit_tests)
 		stage++
 
 /datum/controller/subsystem/unit_tests/proc/handle_async(resumed = 0)
@@ -127,7 +131,7 @@ SUBSYSTEM_DEF(unit_tests)
 		if (4)	// do normal tests
 			handle_tests()
 
-		if (5)
+		if (5) // do async tests
 			handle_async(resumed)
 
 		if (6)	// Finalization.

--- a/code/unit_tests/~unit_test_types.dm
+++ b/code/unit_tests/~unit_test_types.dm
@@ -35,6 +35,9 @@
 /obj/unit_test/transparent
 	opacity = FALSE
 
+/area/test_area/general
+	icon_state = "blue"
+
 /area/test_area/powered_non_dynamic_lighting
 	name = "\improper Test Area - Powered - Non-Dynamic Lighting"
 	icon_state = "green"
@@ -58,3 +61,6 @@
 	icon_state = "purple"
 	requires_power = 1
 	dynamic_lighting = 1
+
+/area/test_area/edge_of_map
+	name = "Edge of Map - Only map space turfs here"

--- a/maps/away_sites_testing/blank.dmm
+++ b/maps/away_sites_testing/blank.dmm
@@ -8,19 +8,11 @@
 "c" = (
 /turf/simulated/floor/tiled,
 /area/space)
-"d" = (
-/obj/effect/landmark/test/safe_turf,
-/turf/simulated/floor/tiled,
-/area/space)
 "e" = (
 /obj/effect/landmark/start{
 	name = "JoinLate"
 	},
 /turf/simulated/floor/tiled,
-/area/space)
-"f" = (
-/obj/effect/landmark/test/space_turf,
-/turf/space,
 /area/space)
 
 (1,1,1) = {"
@@ -44,7 +36,7 @@ a
 a
 a
 a
-f
+a
 a
 "}
 (3,1,1) = {"
@@ -98,7 +90,7 @@ a
 (7,1,1) = {"
 b
 c
-d
+c
 c
 c
 b

--- a/maps/example/example-1.dmm
+++ b/maps/example/example-1.dmm
@@ -379,10 +379,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/constructionsite)
-"UM" = (
-/obj/effect/landmark/test/space_turf,
-/turf/space,
-/area/space)
 "Vt" = (
 /turf/simulated/floor/plating,
 /area/constructionsite)
@@ -423,10 +419,6 @@
 	dir = 5
 	},
 /obj/machinery/teleport/station,
-/turf/simulated/floor/tiled/steel_grid,
-/area/constructionsite)
-"YO" = (
-/obj/effect/landmark/test/safe_turf,
 /turf/simulated/floor/tiled/steel_grid,
 /area/constructionsite)
 "Zi" = (
@@ -486,7 +478,7 @@ Hk
 Hk
 Hk
 Hk
-UM
+Hk
 "}
 (2,1,1) = {"
 Hk
@@ -1151,7 +1143,7 @@ mC
 mC
 vd
 WF
-YO
+dI
 fT
 iM
 us

--- a/maps/ministation/ministation.dmm
+++ b/maps/ministation/ministation.dmm
@@ -1220,9 +1220,6 @@
 /obj/structure/plasticflaps/airtight,
 /turf/simulated/floor/tiled,
 /area/ministation/cargo)
-"df" = (
-/turf/simulated/wall,
-/area/ministation/cargo)
 "dg" = (
 /obj/structure/closet,
 /obj/random/maintenance,
@@ -2830,9 +2827,6 @@
 /area/ministation/science)
 "hh" = (
 /obj/structure/closet/l3closet/scientist,
-/turf/simulated/floor/tiled/white,
-/area/ministation/science)
-"hi" = (
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "hj" = (
@@ -10340,18 +10334,6 @@
 /obj/machinery/computer/arcade/battle,
 /turf/simulated/floor/shuttle/blue,
 /area/ministation/arrival_shuttle)
-"yN" = (
-/turf/simulated/floor/shuttle/blue,
-/area/ministation/arrival_shuttle)
-"yO" = (
-/turf/simulated/floor/shuttle/blue,
-/area/ministation/arrival_shuttle)
-"yP" = (
-/turf/simulated/floor/shuttle/blue,
-/area/ministation/arrival_shuttle)
-"yQ" = (
-/turf/simulated/floor/shuttle/blue,
-/area/ministation/arrival_shuttle)
 "yR" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = 32
@@ -11397,18 +11379,10 @@
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/holofloor/lino,
 /area/ministation/telecomms)
-"Bz" = (
-/obj/effect/landmark/test/safe_turf,
-/turf/simulated/floor/tiled,
-/area/ministation/hall/s)
 "BA" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/ministation/maint/sw)
-"BB" = (
-/obj/effect/landmark/test/space_turf,
-/turf/space,
-/area/space)
 "BC" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "stripe";
@@ -16234,10 +16208,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n)
-"Rw" = (
-/obj/machinery/door/airlock/hatch/maintenance,
-/turf/simulated/floor/plating,
-/area/ministation/court)
 "RD" = (
 /turf/simulated/wall/r_wall,
 /area/ministation/cryo)
@@ -16343,18 +16313,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/detective)
-"SF" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/ministation/court)
 "SN" = (
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/ministation/court)
-"SS" = (
-/turf/simulated/wall,
 /area/ministation/court)
 "ST" = (
 /obj/structure/lattice,
@@ -43521,7 +43484,7 @@ mS
 xf
 la
 yk
-yN
+yj
 yj
 zS
 yj
@@ -43778,7 +43741,7 @@ mS
 xf
 la
 yk
-yO
+yj
 zo
 zo
 zo
@@ -44035,7 +43998,7 @@ mS
 kE
 la
 yk
-yP
+yj
 yj
 yj
 yj
@@ -44292,7 +44255,7 @@ mS
 xh
 la
 yk
-yQ
+yj
 zo
 zo
 zo
@@ -45026,7 +44989,7 @@ cd
 cn
 cy
 cO
-df
+au
 dD
 dI
 eF
@@ -45540,7 +45503,7 @@ ce
 cm
 cy
 cN
-df
+au
 dF
 dI
 dI
@@ -49117,7 +49080,7 @@ aa
 aa
 aa
 aa
-BB
+aa
 aa
 aa
 aa
@@ -49424,7 +49387,7 @@ aV
 aV
 sC
 tv
-Bz
+aV
 aV
 aV
 wf
@@ -49905,13 +49868,13 @@ ah
 ah
 ah
 dR
-SS
+Ib
 UI
 UI
 CY
 UI
 ZP
-SS
+Ib
 di
 eQ
 di
@@ -50162,13 +50125,13 @@ cu
 cW
 cV
 dS
-SS
+Ib
 Qh
 Od
 ND
 Od
 Xe
-SS
+Ib
 eR
 fD
 fV
@@ -50419,13 +50382,13 @@ cv
 cJ
 cJ
 dT
-SS
+Ib
 Zt
 Od
 ND
 Od
 Od
-SS
+Ib
 eS
 dm
 dU
@@ -50676,7 +50639,7 @@ cw
 Qq
 cW
 Zr
-Rw
+OD
 Ir
 Ir
 UD
@@ -50933,7 +50896,7 @@ cw
 cJ
 cX
 cJ
-SS
+Ib
 Sf
 Pk
 TF
@@ -51190,7 +51153,7 @@ cw
 cw
 cw
 cJ
-SS
+Ib
 Ir
 Ir
 ND
@@ -51447,7 +51410,7 @@ aa
 aa
 cw
 cK
-SS
+Ib
 IB
 ZZ
 PT
@@ -51704,7 +51667,7 @@ aa
 aa
 cw
 cJ
-SS
+Ib
 Nc
 Ms
 Vv
@@ -51961,13 +51924,13 @@ ad
 aa
 cw
 cK
-SS
-SS
-SS
-SS
-SS
-SS
-SS
+Ib
+Ib
+Ib
+Ib
+Ib
+Ib
+Ib
 eW
 fJ
 fZ
@@ -52220,7 +52183,7 @@ ad
 cn
 aa
 aa
-SS
+Ib
 MA
 YQ
 dX
@@ -52477,7 +52440,7 @@ aa
 ad
 aa
 aa
-SF
+Ia
 Nw
 dq
 dY
@@ -52734,7 +52697,7 @@ aa
 aa
 aa
 aa
-SF
+Ia
 Nw
 OP
 Nw
@@ -52991,7 +52954,7 @@ aa
 aa
 aa
 aa
-SS
+Ib
 Vj
 YY
 Po
@@ -53248,13 +53211,13 @@ aa
 aa
 aa
 aa
-SS
-SS
-SS
-SS
-SS
+Ib
+Ib
+Ib
+Ib
+Ib
 fa
-SS
+Ib
 Wv
 SC
 Wv
@@ -56598,7 +56561,7 @@ fb
 fK
 gd
 ae
-hi
+db
 db
 ih
 iL

--- a/maps/modpack_testing/blank.dmm
+++ b/maps/modpack_testing/blank.dmm
@@ -8,19 +8,11 @@
 "c" = (
 /turf/simulated/floor/tiled,
 /area/space)
-"d" = (
-/obj/effect/landmark/test/safe_turf,
-/turf/simulated/floor/tiled,
-/area/space)
 "e" = (
 /obj/effect/landmark/start{
 	name = "JoinLate"
 	},
 /turf/simulated/floor/tiled,
-/area/space)
-"f" = (
-/obj/effect/landmark/test/space_turf,
-/turf/space,
 /area/space)
 
 (1,1,1) = {"
@@ -44,7 +36,7 @@ a
 a
 a
 a
-f
+a
 a
 "}
 (3,1,1) = {"
@@ -98,7 +90,7 @@ a
 (7,1,1) = {"
 b
 c
-d
+c
 c
 c
 b

--- a/maps/tradeship/tradeship-1.dmm
+++ b/maps/tradeship/tradeship-1.dmm
@@ -2082,10 +2082,6 @@
 /obj/machinery/suit_cycler/tradeship,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/eva)
-"fe" = (
-/obj/effect/landmark/test/space_turf,
-/turf/space,
-/area/space)
 "fs" = (
 /obj/structure/closet/wardrobe/mixed,
 /obj/item/storage/backpack/dufflebag,
@@ -2526,11 +2522,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/techstorage)
-"pq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/test/safe_turf,
-/turf/simulated/floor/tiled,
-/area/ship/trade/cargo/lower)
 "pr" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
@@ -4948,7 +4939,7 @@ aa
 aa
 aa
 aa
-fe
+aa
 aa
 aa
 aa
@@ -6894,7 +6885,7 @@ du
 du
 aU
 du
-pq
+du
 Dh
 bv
 du

--- a/maps/~unit_tests/unit_testing.dm
+++ b/maps/~unit_tests/unit_testing.dm
@@ -1,6 +1,6 @@
 // It's unlikely you'll be able to open these maps without UNIT_TEST defined
 
 #ifdef UNIT_TEST
-	#include "virtual_mob_tests.dmm"
 	#include "proximity_tests.dmm"
+	#include "unit_tests.dmm"
 #endif

--- a/maps/~unit_tests/unit_tests.dmm
+++ b/maps/~unit_tests/unit_tests.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/space,
-/area/space)
+/area/test_area/edge_of_map)
 "b" = (
 /turf/unsimulated/wall,
 /area/test_area/powered_dynamic_lighting)
@@ -52,8 +52,31 @@
 	icon_state = "hydrofloor"
 	},
 /area/test_area/requires_power_non_dynamic_lighting)
+"m" = (
+/turf/unsimulated/wall,
+/area/test_area/general)
+"n" = (
+/turf/simulated/floor,
+/area/test_area/general)
+"o" = (
+/turf/space,
+/area/test_area/general)
+"p" = (
+/obj/effect/landmark/test/safe_turf,
+/turf/simulated/floor,
+/area/test_area/general)
+"q" = (
+/obj/effect/landmark/test/space_turf,
+/turf/space,
+/area/test_area/general)
 
 (1,1,1) = {"
+a
+a
+a
+a
+a
+a
 a
 a
 a
@@ -96,8 +119,20 @@ a
 a
 a
 a
+a
+a
+a
+a
+a
+a
 "}
 (3,1,1) = {"
+a
+a
+a
+a
+a
+a
 a
 a
 a
@@ -140,8 +175,20 @@ a
 a
 a
 a
+a
+a
+a
+a
+a
+a
 "}
 (5,1,1) = {"
+a
+a
+a
+a
+a
+a
 a
 a
 a
@@ -184,8 +231,20 @@ a
 a
 a
 a
+a
+a
+a
+a
+a
+a
 "}
 (7,1,1) = {"
+a
+a
+a
+a
+a
+a
 a
 a
 a
@@ -215,6 +274,12 @@ a
 a
 a
 a
+m
+m
+m
+m
+m
+m
 b
 b
 b
@@ -237,6 +302,12 @@ a
 a
 a
 a
+m
+n
+n
+n
+n
+n
 b
 d
 b
@@ -259,6 +330,12 @@ a
 a
 a
 a
+m
+n
+n
+n
+n
+n
 b
 d
 b
@@ -281,6 +358,12 @@ a
 a
 a
 a
+m
+n
+n
+p
+n
+n
 b
 d
 b
@@ -303,6 +386,12 @@ a
 a
 a
 a
+m
+n
+n
+n
+n
+n
 b
 b
 b
@@ -325,6 +414,12 @@ a
 a
 a
 a
+m
+n
+n
+n
+n
+n
 b
 d
 b
@@ -347,6 +442,12 @@ a
 a
 a
 a
+m
+m
+m
+m
+m
+m
 b
 b
 b
@@ -369,6 +470,12 @@ a
 a
 a
 a
+m
+m
+m
+m
+m
+m
 c
 c
 c
@@ -391,6 +498,12 @@ a
 a
 a
 a
+m
+o
+o
+o
+o
+o
 c
 e
 c
@@ -413,6 +526,12 @@ a
 a
 a
 a
+m
+o
+o
+o
+o
+o
 c
 e
 c
@@ -435,6 +554,12 @@ a
 a
 a
 a
+m
+o
+o
+q
+o
+o
 c
 e
 c
@@ -457,6 +582,12 @@ a
 a
 a
 a
+m
+o
+o
+o
+o
+o
 c
 c
 c
@@ -479,6 +610,12 @@ a
 a
 a
 a
+m
+o
+o
+o
+o
+o
 c
 e
 c
@@ -501,6 +638,12 @@ a
 a
 a
 a
+m
+m
+m
+m
+m
+m
 c
 c
 c
@@ -516,6 +659,12 @@ a
 a
 "}
 (22,1,1) = {"
+a
+a
+a
+a
+a
+a
 a
 a
 a
@@ -558,8 +707,20 @@ a
 a
 a
 a
+a
+a
+a
+a
+a
+a
 "}
 (24,1,1) = {"
+a
+a
+a
+a
+a
+a
 a
 a
 a
@@ -602,8 +763,20 @@ a
 a
 a
 a
+a
+a
+a
+a
+a
+a
 "}
 (26,1,1) = {"
+a
+a
+a
+a
+a
+a
 a
 a
 a
@@ -646,8 +819,20 @@ a
 a
 a
 a
+a
+a
+a
+a
+a
+a
 "}
 (28,1,1) = {"
+a
+a
+a
+a
+a
+a
 a
 a
 a


### PR DESCRIPTION
Moves the safe and space landmarks to the unit test map.
Makes it so that main maps (Torch, Exodus, Example,etc.) do not have to map these landmarks themselves.