### PR TITLE
Small map tweaks to tradeship

### DIFF
--- a/maps/tradeship/tradeship-1.dmm
+++ b/maps/tradeship/tradeship-1.dmm
@@ -823,6 +823,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/emergency_dispenser/east,
 /turf/simulated/floor/tiled/monotile,
 /area/ship/trade/cargo/lower)
 "ca" = (
@@ -1453,10 +1454,8 @@
 	pixel_x = 11;
 	pixel_y = 0
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+/obj/machinery/light_switch{
+	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/science)
@@ -1484,6 +1483,7 @@
 /obj/machinery/light_switch{
 	pixel_w = -23
 	},
+/obj/structure/emergency_dispenser/south,
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/science)
 "dL" = (
@@ -1600,6 +1600,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/emergency_dispenser/north,
 /turf/simulated/floor/tiled,
 /area/ship/trade/maintenance/lower)
 "dV" = (
@@ -2216,6 +2217,9 @@
 	icon_state = "railing0";
 	dir = 8
 	},
+/obj/machinery/light_switch{
+	pixel_y = -25
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
 "ib" = (
@@ -2526,6 +2530,19 @@
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
 /area/ship/trade/cargo/lower)
+"ps" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/emergency_dispenser/east,
+/turf/simulated/floor/plating,
+/area/ship/trade/maintenance/lower)
 "qb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -2791,6 +2808,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/science/fabricaton)
+"vI" = (
+/obj/structure/emergency_dispenser/east,
+/turf/simulated/floor/tiled,
+/area/ship/trade/maintenance/lower)
 "vW" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
@@ -2911,6 +2932,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/cargo/lower)
+"zJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/emergency_dispenser/east,
+/turf/simulated/floor/tiled,
+/area/ship/trade/maintenance/lower)
 "Ab" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/door/firedoor,
@@ -2994,6 +3020,15 @@
 	},
 /turf/simulated/floor/lino,
 /area/ship/trade/crew/dorms1)
+"De" = (
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/trade/science)
 "Dh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
@@ -3091,14 +3126,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24;
-	pixel_y = 0
-	},
 /obj/structure/railing/mapped{
 	icon_state = "railing0-1";
 	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
@@ -3514,6 +3547,11 @@
 	icon_state = "railing0-1";
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
 "Sx" = (
@@ -3696,6 +3734,8 @@
 	icon_state = "corner_white";
 	dir = 5
 	},
+/obj/structure/emergency_dispenser/east,
+/obj/structure/emergency_dispenser/north,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/techstorage)
 "Zd" = (
@@ -3722,6 +3762,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/storage)
+"ZA" = (
+/obj/structure/emergency_dispenser/west,
+/turf/simulated/floor/tiled,
+/area/ship/trade/maintenance/lower)
 "ZJ" = (
 /turf/simulated/wall,
 /area/ship/trade/escape_star)
@@ -6160,7 +6204,7 @@ JM
 fL
 fL
 fL
-fL
+De
 yF
 se
 se
@@ -6560,7 +6604,7 @@ ah
 ah
 On
 br
-bI
+zJ
 bI
 ds
 On
@@ -6568,7 +6612,7 @@ On
 ap
 VX
 VX
-On
+vI
 dP
 VX
 dZ
@@ -7306,7 +7350,7 @@ VX
 ap
 dk
 On
-On
+ZA
 dY
 VX
 ee
@@ -7380,7 +7424,7 @@ aK
 wb
 EB
 bz
-bP
+ps
 yL
 cl
 cC

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -1812,6 +1812,7 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
+/obj/structure/emergency_dispenser/west,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "dW" = (
@@ -1868,6 +1869,7 @@
 /area/ship/trade/cargo)
 "ed" = (
 /obj/machinery/light_switch{
+	on = 1;
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1933,7 +1935,6 @@
 /obj/structure/sign/warning/nosmoking_2{
 	pixel_y = 28
 	},
-/obj/structure/emergency_dispenser/west,
 /obj/structure/handrail{
 	icon_state = "handrail";
 	dir = 4
@@ -2402,6 +2403,9 @@
 	icon_state = "handrail";
 	dir = 8
 	},
+/obj/machinery/light_switch{
+	pixel_x = 28
+	},
 /turf/simulated/open,
 /area/ship/trade/cargo)
 "fu" = (
@@ -2421,9 +2425,7 @@
 /obj/item/chems/ivbag/blood/BPlus,
 /obj/item/chems/ivbag/blood/OMinus,
 /obj/item/chems/ivbag/blood/OPlus,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
+/obj/structure/emergency_dispenser/west,
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/crew/medbay)
 "fw" = (
@@ -2818,6 +2820,7 @@
 	icon_state = "railing0";
 	dir = 8
 	},
+/obj/structure/emergency_dispenser/east,
 /turf/simulated/open,
 /area/ship/trade/cargo)
 "gt" = (
@@ -2988,6 +2991,9 @@
 	dir = 1
 	},
 /obj/machinery/light/spot,
+/obj/machinery/light_switch{
+	pixel_y = -25
+	},
 /turf/simulated/open,
 /area/ship/trade/cargo)
 "hb" = (
@@ -3147,6 +3153,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/emergency_dispenser/north,
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/hallway)
 "hv" = (
@@ -5278,8 +5285,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/computer/modular/preset/merchant/tradeship,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/machinery/light_switch{
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/cargo)
@@ -5390,6 +5397,7 @@
 	icon_state = "corner_white";
 	dir = 5
 	},
+/obj/structure/emergency_dispenser/north,
 /turf/simulated/floor/tiled/dark,
 /area/ship/trade/command/bridge)
 "sb" = (
@@ -6319,9 +6327,6 @@
 /obj/random_multi/single_item/captains_spare_id,
 /obj/item/documents/tradehouse/account,
 /obj/item/documents/tradehouse/personnel,
-/obj/machinery/light_switch{
-	pixel_x = 28
-	},
 /obj/effect/landmark/paperwork_spawn_tradeship,
 /turf/simulated/floor/tiled/dark,
 /area/ship/trade/command/bridge)
@@ -7304,6 +7309,11 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/merchant_pad,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/cargo)
 "RL" = (
@@ -7346,6 +7356,9 @@
 /area/ship/trade/garden)
 "Sg" = (
 /obj/machinery/light,
+/obj/machinery/light_switch{
+	pixel_y = -25
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/trade/shieldbay)
 "Si" = (
@@ -7524,13 +7537,13 @@
 /area/ship/trade/crew/toilets)
 "UB" = (
 /obj/machinery/light,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	pixel_y = -25
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/trade/command/bridge)


### PR DESCRIPTION
Puts more light switches around so you don't have to cross entire cargo bay to turn lights on.
Makes switch for hallway on deck 1 start as on, cause you need to walk aaaall the way around to switch it and it's awkward.
Puts emergency dispeners around 2nd deck hallway so you ahve a bit of a chance to live during breach.


<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
