### PR TITLE
Renames NETWORK_EXODUS to remove exodus references

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -42,18 +42,24 @@ var/global/defer_powernet_rebuild = 0      // True if net rebuild will be called
 #define AI_CAMERA_LUMINOSITY 6
 
 // Camera networks
-#define NETWORK_CRESCENT "Crescent"
+// Station networks
+#define NETWORK_PUBLIC "Public"
 #define NETWORK_ENGINEERING "Engineering"
-#define NETWORK_ERT "ZeEmergencyResponseTeam"
-#define NETWORK_EXODUS "Exodus"
 #define NETWORK_MEDICAL "Medical"
-#define NETWORK_MERCENARY "MercurialNet"
-#define NETWORK_MINE "Mining"
 #define NETWORK_RESEARCH "Research"
-#define NETWORK_ROBOTS "Robots"
 #define NETWORK_SECURITY "Security"
+
+#define NETWORK_ROBOTS "Robots"
+#define NETWORK_MINE "Mining"
+#define NETWORK_SECRET "Secret"
+
+// Non-station networks
+#define NETWORK_CRESCENT "Crescent"
+#define NETWORK_ERT "ZeEmergencyResponseTeam"
+#define NETWORK_MERCENARY "MercurialNet"
 #define NETWORK_THUNDER "Thunderdome"
 
+// Alarm networks
 #define NETWORK_ALARM_ATMOS "Atmosphere Alarms"
 #define NETWORK_ALARM_CAMERA "Camera Alarms"
 #define NETWORK_ALARM_FIRE "Fire Alarms"
@@ -61,7 +67,7 @@ var/global/defer_powernet_rebuild = 0      // True if net rebuild will be called
 #define NETWORK_ALARM_POWER "Power Alarms"
 
 // Those networks can only be accessed by pre-existing terminals. AIs and new terminals can't use them.
-var/list/restricted_camera_networks = list(NETWORK_ERT, NETWORK_MERCENARY, NETWORK_CRESCENT, "Secret")
+var/list/restricted_camera_networks = list(NETWORK_ERT, NETWORK_MERCENARY, NETWORK_CRESCENT, NETWORK_SECRET)
 
 
 //singularity defines

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -8,7 +8,7 @@
 	active_power_usage = 10
 	layer = CAMERA_LAYER
 
-	var/list/network = list(NETWORK_EXODUS)
+	var/list/network = list(NETWORK_PUBLIC)
 	var/c_tag = null
 	var/c_tag_order = 999
 	var/number = 0 //camera number in area
@@ -183,7 +183,7 @@
 				assembly.dropInto(loc)
 				assembly.anchored = 1
 				assembly.camera_name = c_tag
-				assembly.camera_network = english_list(network, "Exodus", ",", ",")
+				assembly.camera_network = english_list(network, NETWORK_PUBLIC, ",", ",")
 				assembly.update_icon()
 				assembly.set_dir(src.dir)
 				if(stat & BROKEN)

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -81,7 +81,7 @@
 			if(isScrewdriver(W))
 				playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 
-				var/input = sanitize(input(usr, "Which networks would you like to connect this camera to? Separate networks with a comma. No Spaces!\nFor example: Exodus,Security,Secret", "Set Network", camera_network ? camera_network : NETWORK_EXODUS))
+				var/input = sanitize(input(usr, "Which networks would you like to connect this camera to? Separate networks with a comma. No Spaces!\nFor example: [NETWORK_PUBLIC],[NETWORK_SECURITY],[NETWORK_SECRET]", "Set Network", camera_network ? camera_network : NETWORK_PUBLIC))
 				if(!input)
 					to_chat(usr, "No input found please hang up and try your call again.")
 					return

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -49,7 +49,7 @@ var/list/ai_verbs_default = list(
 
 /mob/living/silicon/ai
 	name = "AI"
-	icon = 'icons/mob/AI.dmi'//
+	icon = 'icons/mob/AI.dmi'
 	icon_state = "ai"
 	mob_sort_value = 2
 	anchored = 1 // -- TLE
@@ -57,12 +57,12 @@ var/list/ai_verbs_default = list(
 	status_flags = CANSTUN|CANPARALYSE|CANPUSH
 	shouldnt_see = list(/obj/effect/rune)
 	maxHealth = 200
-	var/list/network = list("Exodus")
+	var/list/network = list(NETWORK_PUBLIC)
 	var/obj/machinery/camera/camera = null
 	var/list/connected_robots = list()
 	var/aiRestorePowerRoutine = 0
 	var/viewalerts = 0
-	var/icon/holo_icon//Blue hologram. Face is assigned when AI is created.
+	var/icon/holo_icon //Blue hologram. Face is assigned when AI is created.
 	var/icon/holo_icon_longrange //Yellow hologram.
 	var/holo_icon_malf = FALSE // for new hologram system
 	var/obj/item/multitool/aiMulti = null
@@ -699,7 +699,7 @@ var/list/ai_verbs_default = list(
 /mob/living/silicon/ai/on_update_icon()
 	if(!selected_sprite || !(selected_sprite in available_icons()))
 		// This should NOT be using the decl repository as default_ai_icon is a datum. TODO: rewrite AI icon handling.
-		selected_sprite = decls_repository.get_decl(default_ai_icon) 
+		selected_sprite = decls_repository.get_decl(default_ai_icon)
 
 	icon = selected_sprite.icon
 	if(stat == DEAD)

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -15,7 +15,7 @@
 	idle_power_usage = 20
 	active_power_usage = 5000
 
-	var/fabricator_tag = "Exodus"
+	var/fabricator_tag
 	var/drone_progress = 0
 	var/produce_drones = 1
 	var/time_last_drone = 500
@@ -23,6 +23,11 @@
 
 	icon = 'icons/obj/machines/drone_fab.dmi'
 	icon_state = "drone_fab_idle"
+
+/obj/machinery/drone_fabricator/Initialize()
+	. = ..()
+	if(isnull(fabricator_tag))
+		fabricator_tag = GLOB.using_map.station_short
 
 /obj/machinery/drone_fabricator/derelict
 	name = "construction drone fabricator"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -120,7 +120,7 @@
 	if(!scrambledcodes && !camera)
 		camera = new /obj/machinery/camera(src)
 		camera.c_tag = real_name
-		camera.replace_networks(list(NETWORK_EXODUS,NETWORK_ROBOTS))
+		camera.replace_networks(list(NETWORK_PUBLIC,NETWORK_ROBOTS))
 		if(wires.IsIndexCut(BORG_WIRE_CAMERA))
 			camera.status = 0
 	init()

--- a/code/modules/overmap/README.dm
+++ b/code/modules/overmap/README.dm
@@ -37,7 +37,7 @@ If this zlevel (or any of connected ones for multiz) doesn't have this object, y
 2. Put it anywhere on the ship/sector map. It will do the rest on its own during init.
 If your thing is multiz, only one is needed per multiz sector/ship.
 
-If it's player's main base (e.g Exodus), set 'base' var to 1, so it adds itself to station_levels list.
+If it's player's main base (e.g tradeship), set 'base' var to 1, so it adds itself to station_levels list.
 If this place cannot be reached or left with EVA, set 'in_space' var to 0
 If you want exploration shuttles (look below) to be able to dock here, set up waypoints lists.
 generic_waypoints is list of landmark_tags of waypoints any shttle should be able to visit.

--- a/maps/ministation/ministation_define.dm
+++ b/maps/ministation/ministation_define.dm
@@ -29,7 +29,7 @@
 	evac_controller_type = /datum/evacuation_controller/ministation_substitute
 
 	station_networks = list(
-		NETWORK_EXODUS,
+		NETWORK_PUBLIC,
 		NETWORK_MINE,
 		NETWORK_SECURITY,
 		NETWORK_RESEARCH,


### PR DESCRIPTION
Also small drone fabricator edit so it will pick map's short name for fabricator tag