### PR TITLE
Fixes ice ore dropping and makes rock obtainable

### DIFF
--- a/code/game/turfs/exterior/exterior_wall.dm
+++ b/code/game/turfs/exterior/exterior_wall.dm
@@ -1,3 +1,5 @@
+#define MAT_DROP_CHANCE 30
+
 var/list/default_strata_type_by_z = list()
 var/list/default_material_by_strata_and_z = list()
 var/list/default_strata_types = list()
@@ -222,6 +224,8 @@ var/list/natural_walls = list()
 	if(reinf_material?.ore_result_amount)
 		for(var/i = 1 to reinf_material.ore_result_amount)
 			pass_geodata_to(new /obj/item/ore(src, reinf_material.type))
+	if(prob(MAT_DROP_CHANCE))
+		pass_geodata_to(new /obj/item/ore(src, material.type))
 	destroy_artifacts(null, INFINITY)
 	playsound(src, 'sound/items/Welder.ogg', 100, 1)
 	. = ChangeTurf(floor_type || get_base_turf_by_area(src))
@@ -247,3 +251,5 @@ var/list/natural_walls = list()
 	set_extension(O, /datum/extension/geological_data)
 	var/datum/extension/geological_data/newdata = get_extension(O, /datum/extension/geological_data)
 	newdata.set_data(ours.geodata.get_copy())
+
+#undef MAT_DROP_CHANCE

--- a/code/modules/materials/definitions/solids/materials_solid_ice.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_ice.dm
@@ -12,6 +12,7 @@
 	removed_by_welder = TRUE
 	value = 0.2
 	sparse_material_weight = 2
+	ore_result_amount = 7
 	rich_material_weight = 37
 	heating_point = T20C + 10 // Above room temperature, to avoid drinks melting.
 	stack_type = /obj/item/stack/material/generic/brick
@@ -36,8 +37,8 @@
 	name = "lukrite ice"
 	ore_name = "lukrite ice"
 	value = 0.3
-	sparse_material_weight = 27
-	rich_material_weight = 22
+	sparse_material_weight = 20
+	rich_material_weight = 16
 
 /decl/material/solid/ice/rubenium
 	heating_products = list(
@@ -48,8 +49,8 @@
 	name = "rubenium ice"
 	ore_name = "rubenium ice"
 	value = 0.4
-	sparse_material_weight = 35
-	rich_material_weight = 12
+	sparse_material_weight = 20
+	rich_material_weight = 13
 
 /decl/material/solid/ice/trigarite
 	heating_products = list(
@@ -60,8 +61,8 @@
 	name = "trigarite ice"
 	ore_name = "trigarite ice"
 	value = 0.5
-	sparse_material_weight = 38
-	rich_material_weight = 23
+	sparse_material_weight = 20
+	rich_material_weight = 15
 
 /decl/material/solid/ice/ediroite
 	heating_products = list(
@@ -72,5 +73,5 @@
 	name = "ediroite ice"
 	ore_name = "ediroite ice"
 	value = 0.2
-	sparse_material_weight = 21
-	rich_material_weight = 39
+	sparse_material_weight = 20
+	rich_material_weight = 16

--- a/code/modules/materials/materials_ore.dm
+++ b/code/modules/materials/materials_ore.dm
@@ -10,12 +10,10 @@
 	if(istype(material))
 		matter = list()
 		matter[material.type] = SHEET_MATERIAL_AMOUNT
-		name =       material.ore_name
+		name =       material.ore_name ? material.ore_name : "[material.name] chunk"
 		desc =       material.ore_desc ? material.ore_desc : "A lump of ore."
 		color =      material.color
-		icon_state = material.ore_icon_overlay
-		if(material.ore_desc)
-			desc = material.ore_desc
+		icon_state = material.ore_icon_overlay ? material.ore_icon_overlay : "lump"
 		if(icon_state == "dust")
 			slot_flags = SLOT_HOLSTER
 


### PR DESCRIPTION
Fixes a bug with ice ores not being placed on mining. Adjusts down their spawn chance slightly to make them less prevalent.

Adds a chance for exterior walls to drop their main component material as an ore, in order to make rock obtainable.