### PR TITLE
Radio transmitter and receiver fixes

### DIFF
--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -288,10 +288,6 @@ var/global/datum/controller/radio/radio_controller
 	if(frequency)
 		frequency.remove_listener(device)
 
-		if(frequency.devices.len == 0)
-			qdel(frequency)
-			frequencies -= f_text
-
 	return 1
 
 /datum/controller/radio/proc/return_frequency(var/new_frequency as num)

--- a/code/datums/extensions/multitool/items/stock_parts_radio.dm
+++ b/code/datums/extensions/multitool/items/stock_parts_radio.dm
@@ -156,6 +156,8 @@
 	if(!actual_machine)
 		return
 	var/obj/item/stock_parts/radio/transmitter/basic/radio = holder
+	LAZYINITLIST(radio.transmit_on_change)
+	LAZYINITLIST(radio.transmit_on_tick)
 	radio.sanitize_events(actual_machine, radio.transmit_on_change)
 	radio.sanitize_events(actual_machine, radio.transmit_on_tick)
 
@@ -189,6 +191,7 @@
 	if(!actual_machine)
 		return
 	var/obj/item/stock_parts/radio/transmitter/on_event/radio = holder
+	LAZYINITLIST(radio.transmit_on_event)
 	if(!radio.is_valid_event(actual_machine, radio.event))
 		radio.event = null
 	radio.sanitize_events(actual_machine, radio.transmit_on_event)
@@ -232,6 +235,8 @@
 	if(!actual_machine)
 		return
 	var/obj/item/stock_parts/radio/receiver/radio = holder
+	LAZYINITLIST(radio.receive_and_call)
+	LAZYINITLIST(radio.receive_and_write)
 	radio.sanitize_events(actual_machine, radio.receive_and_call)
 	radio.sanitize_events(actual_machine, radio.receive_and_write)
 
@@ -239,10 +244,10 @@
 	var/obj/item/stock_parts/radio/receiver/radio = holder
 	var/list/dat = list()
 
-	dat += "<b>Transmit on change:</b><br>"
+	dat += "<b>Called on signal reception:</b><br>"
 	dat += event_list_to_selection_table("call", radio.receive_and_call)
 	dat += "<br>"
-	dat += "<b>Transmit every tick:</b><br>"
+	dat += "<b>Written to on signal reception:</b><br>"
 	dat += event_list_to_selection_table("write", radio.receive_and_write)
 	return ..() + JOINTEXT(dat)
 
@@ -257,4 +262,4 @@
 	if(href_list["call"])
 		return event_list_topic(radio.receive_and_call, actual_machine.public_methods, user, href_list)
 	if(href_list["write"])
-		return event_list_topic(radio.receive_and_write, radio.sanitize_events(actual_machine.public_variables.Copy()), user, href_list)
+		return event_list_topic(radio.receive_and_write, actual_machine.public_variables, user, href_list)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -336,7 +336,6 @@
 
 /obj/machinery/sleeper/proc/set_occupant(var/mob/living/carbon/occupant)
 	src.occupant = occupant
-	update_icon()
 	if(!occupant)
 		SetName(initial(name))
 		update_use_power(POWER_USE_IDLE)

--- a/code/game/machinery/_machines_base/machinery_power.dm
+++ b/code/game/machinery/_machines_base/machinery_power.dm
@@ -120,6 +120,7 @@ This is /obj/machinery level code to properly manage power usage from the area.
 	use_power = new_use_power
 	var/new_power = get_power_usage()
 	REPORT_POWER_CONSUMPTION_CHANGE(old_power, new_power)
+	queue_icon_update()
 
 /obj/machinery/proc/update_power_channel(new_channel)
 	if(power_channel == new_channel)

--- a/code/game/machinery/atmoalter/area_atmos_computer.dm
+++ b/code/game/machinery/atmoalter/area_atmos_computer.dm
@@ -107,7 +107,6 @@
 			return
 
 		scrubber.update_use_power(text2num(href_list["toggle"]) ? POWER_USE_ACTIVE : POWER_USE_IDLE)
-		scrubber.update_icon()
 
 /obj/machinery/computer/area_atmos/proc/validscrubber(var/obj/machinery/portable_atmospherics/powered/scrubber/huge/scrubber)
 	if(!isobj(scrubber) || get_dist(scrubber.loc, src.loc) > src.range || scrubber.loc.z != src.loc.z)

--- a/code/game/machinery/bodyscanner.dm
+++ b/code/game/machinery/bodyscanner.dm
@@ -58,7 +58,6 @@
 	src.occupant.dropInto(loc)
 	src.occupant = null
 	update_use_power(POWER_USE_IDLE)
-	update_icon()
 	SetName(initial(name))
 	if(open_sound)
 		playsound(src, open_sound, 40)
@@ -94,7 +93,6 @@
 	src.occupant = target
 
 	update_use_power(POWER_USE_ACTIVE)
-	update_icon()
 	drop_contents()
 	SetName("[name] ([occupant])")
 

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -9,6 +9,7 @@
 	idle_power_usage = 10
 	public_variables = list(
 		/decl/public_access/public_variable/button_active,
+		/decl/public_access/public_variable/inv_button_active,
 		/decl/public_access/public_variable/button_state,
 		/decl/public_access/public_variable/input_toggle
 	)
@@ -87,6 +88,21 @@
 	. = ..()
 	if(.)
 		button.active = new_val
+
+/decl/public_access/public_variable/inv_button_active
+	expected_type = /obj/machinery/button
+	name = "inverse button toggle"
+	desc = "Toggled whenever the button is pressed. Inverse value of button toggle."
+	can_write = FALSE
+	has_updates = TRUE
+
+/decl/public_access/public_variable/inv_button_active/access_var(obj/machinery/button/button)
+	return !button.active
+
+/decl/public_access/public_variable/inv_button_active/write_var(obj/machinery/button/button, new_val)
+	. = ..()
+	if(.)
+		button.active = !new_val
 
 // The point here is that button_active just pulses on button press and can't be changed otherwise, while button_state can be changed externally.
 /decl/public_access/public_variable/button_state

--- a/code/game/machinery/cracker.dm
+++ b/code/game/machinery/cracker.dm
@@ -24,20 +24,17 @@
 	else
 		update_use_power(POWER_USE_IDLE)
 	user.visible_message(SPAN_NOTICE("\The [user] [use_power == POWER_USE_ACTIVE ? "engages" : "disengages"] \the [src]."))
-	update_icon()
 	return TRUE
 
 /obj/machinery/portable_atmospherics/cracker/power_change()
 	. = ..()
 	if(. && (stat & NOPOWER))
 		update_use_power(POWER_USE_IDLE)
-		update_icon()
 
 /obj/machinery/portable_atmospherics/cracker/set_broken(new_state)
 	. = ..()
 	if(. && (stat & BROKEN))
 		update_use_power(POWER_USE_IDLE)
-		update_icon()
 
 /obj/machinery/portable_atmospherics/cracker/Process()
 	..()

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -45,7 +45,6 @@
 	set_light(l_max_bright, l_inner_range, l_outer_range)
 	update_use_power(POWER_USE_ACTIVE)
 	use_power_oneoff(active_power_usage)//so we drain cell if they keep trying to use it
-	update_icon()
 	if(loud)
 		visible_message("\The [src] turns on.")
 		playsound(src.loc, 'sound/effects/flashlight.ogg', 50, 0)
@@ -54,7 +53,6 @@
 /obj/machinery/floodlight/proc/turn_off(var/loud = 0)
 	set_light(0, 0)
 	update_use_power(POWER_USE_OFF)
-	update_icon()
 	if(loud)
 		visible_message("\The [src] shuts down.")
 		playsound(src.loc, 'sound/effects/flashlight.ogg', 50, 0)

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -31,7 +31,6 @@ var/list/floor_light_cache = list()
 		anchored = !anchored
 		if(use_power)
 			update_use_power(POWER_USE_OFF)
-			queue_icon_update()
 		visible_message("<span class='notice'>\The [user] has [anchored ? "attached" : "detached"] \the [src].</span>")
 	else if(isWelder(W) && (damaged || (stat & BROKEN)))
 		var/obj/item/weldingtool/WT = W
@@ -78,7 +77,6 @@ var/list/floor_light_cache = list()
 	var/on = (use_power == POWER_USE_ACTIVE)
 	update_use_power(on ? POWER_USE_OFF : POWER_USE_ACTIVE)
 	visible_message("<span class='notice'>\The [user] turns \the [src] [!on ? "on" : "off"].</span>")
-	queue_icon_update()
 	return TRUE
 
 /obj/machinery/floor_light/set_broken(new_state)

--- a/code/game/machinery/holosign.dm
+++ b/code/game/machinery/holosign.dm
@@ -28,7 +28,6 @@
 		return
 	lit = !lit
 	update_use_power(lit ? POWER_USE_ACTIVE : POWER_USE_IDLE)
-	update_icon()
 
 /obj/machinery/holosign/on_update_icon()
 	if (!lit || inoperable())

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -172,7 +172,6 @@
 /obj/machinery/media/jukebox/proc/StopPlaying()
 	playing = 0
 	update_use_power(POWER_USE_IDLE)
-	update_icon()
 	QDEL_NULL(sound_token)
 
 
@@ -186,7 +185,6 @@
 
 	playing = 1
 	update_use_power(POWER_USE_ACTIVE)
-	update_icon()
 
 /obj/machinery/media/jukebox/proc/AdjustVolume(var/new_volume)
 	volume = Clamp(new_volume, 0, 50)

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -153,9 +153,6 @@
 	else
 		update_use_power(POWER_USE_IDLE)
 
-	update_icon()
-
-
 /obj/machinery/magnetic_module/proc/magnetic_process() // proc that actually does the pulling
 	set waitfor = FALSE
 	if(pulling) return

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -64,7 +64,6 @@
 		state |= WASHER_STATE_BLOODY
 
 	update_use_power(POWER_USE_ACTIVE)
-	update_icon()
 	addtimer(CALLBACK(src, /obj/machinery/washing_machine/proc/wash), 20 SECONDS)
 
 /obj/machinery/washing_machine/proc/wash()
@@ -86,11 +85,10 @@
 					addtimer(CALLBACK(C, /obj/item/clothing/proc/change_smell), detergent.smell_clean_time, TIMER_UNIQUE | TIMER_OVERRIDE)
 	QDEL_NULL(detergent)
 
-	update_use_power(POWER_USE_IDLE)
 	if(locate(/mob/living) in src)
 		gibs_ready = 1
 	state &= ~WASHER_STATE_RUNNING
-	update_icon()
+	update_use_power(POWER_USE_IDLE)
 
 /obj/machinery/washing_machine/verb/climb_out()
 	set name = "Climb out"

--- a/code/modules/atmospherics/components/unary/cold_sink.dm
+++ b/code/modules/atmospherics/components/unary/cold_sink.dm
@@ -73,7 +73,6 @@
 		return 1
 	if(href_list["toggleStatus"])
 		update_use_power(!use_power)
-		update_icon()
 	if(href_list["temp"])
 		var/amount = text2num(href_list["temp"])
 		if(amount > 0)

--- a/code/modules/atmospherics/components/unary/heat_source.dm
+++ b/code/modules/atmospherics/components/unary/heat_source.dm
@@ -90,7 +90,6 @@
 		return 1
 	if(href_list["toggleStatus"])
 		update_use_power(!use_power)
-		update_icon()
 	if(href_list["temp"])
 		var/amount = text2num(href_list["temp"])
 		if(amount > 0)

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -78,7 +78,6 @@
 		return
 	if(href_list["toggle_power"])
 		update_use_power(!use_power)
-		queue_icon_update()
 		to_chat(user, "<span class='notice'>The multitool emits a short beep confirming the change.</span>")
 		return TOPIC_REFRESH
 

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -64,6 +64,7 @@
 	)
 	public_methods = list(
 		/decl/public_access/public_method/toggle_power,
+		/decl/public_access/public_method/toggle_pump_dir,
 		/decl/public_access/public_method/purge_pump,
 		/decl/public_access/public_method/refresh
 	)
@@ -237,6 +238,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/proc/purge()
 	pressure_checks &= ~PRESSURE_CHECK_EXTERNAL
 	pump_direction = 0
+	queue_icon_update()
+
+/obj/machinery/atmospherics/unary/vent_pump/proc/toggle_pump_dir()
+	pump_direction = !pump_direction
+	queue_icon_update()
 
 /obj/machinery/atmospherics/unary/vent_pump/refresh()
 	..()
@@ -327,9 +333,8 @@
 	if((. = ..()))
 		return
 	if(href_list["switchMode"])
-		pump_direction = !pump_direction
+		toggle_pump_dir()
 		to_chat(user, "<span class='notice'>The multitool emits a short beep confirming the change.</span>")
-		queue_icon_update() //force the icon to refresh after changing directional mode.
 		return TOPIC_REFRESH
 
 /decl/public_access/public_variable/pump_dir
@@ -410,6 +415,11 @@
 	name = "activate purge mode"
 	desc = "Activates purge mode, overriding pressure checks and removing air."
 	call_proc = /obj/machinery/atmospherics/unary/vent_pump/proc/purge
+
+/decl/public_access/public_method/toggle_pump_dir
+	name = "toggle pump direction"
+	desc = "Toggles the pump's direction, from release to siphon or vice versa."
+	call_proc = /obj/machinery/atmospherics/unary/vent_pump/proc/toggle_pump_dir
 
 /decl/stock_part_preset/radio/event_transmitter/vent_pump
 	frequency = PUMP_FREQ

--- a/code/modules/fabrication/fabricator_build.dm
+++ b/code/modules/fabrication/fabricator_build.dm
@@ -24,14 +24,12 @@
 	if(!(fab_status_flags & FAB_BUSY) && is_functioning())
 		fab_status_flags |= FAB_BUSY
 		update_use_power(POWER_USE_ACTIVE)
-		update_icon()
 		sound_token = GLOB.sound_player.PlayLoopingSound(src, sound_id, fabricator_sound, volume = 30)
 
 /obj/machinery/fabricator/proc/stop_building()
 	if(fab_status_flags & FAB_BUSY)
 		fab_status_flags &= ~FAB_BUSY
 		update_use_power(POWER_USE_IDLE)
-		update_icon()
 		QDEL_NULL(sound_token)
 
 /obj/machinery/fabricator/proc/get_next_build()

--- a/code/modules/overmap/ftl_shunt/core.dm
+++ b/code/modules/overmap/ftl_shunt/core.dm
@@ -246,7 +246,6 @@
 	if(!silent)
 		ftl_announcement.Announce(shunt_cancel_text, "FTL Shunt Management System", new_sound = sound('sound/misc/notice2.ogg'))
 	update_use_power(POWER_USE_IDLE)
-	update_icon()
 	chargepercent = 0
 
 //Starts the shunt, and then hands off to do_shunt to finish it.
@@ -257,14 +256,13 @@
 		do_sabotage()
 		return
 
-	update_use_power(POWER_USE_IDLE)
 	var/destination = locate(shunt_x, shunt_y, GLOB.using_map.overmap_z)
 	var/jumpdist = get_dist(get_turf(ftl_computer.linked), destination)
 	var/obj/effect/portal/wormhole/W = new(destination) //Generate a wormhole effect on overmap to give some indication that something is about to happen.
 	QDEL_IN(W, 6 SECONDS)
 	addtimer(CALLBACK(src, .proc/do_shunt, shunt_x, shunt_y, jumpdist, destination), 6 SECONDS)
 	jumping = TRUE
-	update_icon()
+	update_use_power(POWER_USE_IDLE)
 	for(var/mob/living/carbon/M in GLOB.living_mob_list_)
 		if(!(M.z in ftl_computer.linked.map_z))
 			continue
@@ -274,10 +272,9 @@
 	ftl_computer.linked.forceMove(destination)
 	ftl_announcement.Announce(shunt_complete_text, "FTL Shunt Management System", new_sound = sound('sound/misc/notice2.ogg'))
 	cooldown = world.time + cooldown_delay
-	update_use_power(POWER_USE_IDLE)
 	do_effects(jumpdist)
 	jumping = FALSE
-	update_icon()
+	update_use_power(POWER_USE_IDLE)
 	chargepercent = 0
 	charge_started = 0
 

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -190,7 +190,6 @@
 	if(!use_power) //need some juice to kickstart
 		use_power_oneoff(idle_power_usage*5)
 	update_use_power(!use_power)
-	queue_icon_update()
 
 /obj/machinery/shipsensors/Process()
 	if(use_power) //can't run in non-vacuum

--- a/code/modules/overmap/ships/device_types/_engine.dm
+++ b/code/modules/overmap/ships/device_types/_engine.dm
@@ -95,4 +95,3 @@ var/list/ship_engines = list()
 			M.power_change()
 		if(is_on())//if everything is in working order, start booting!
 			next_on = world.time + boot_time
-	M.update_icon()

--- a/code/modules/overmap/ships/machines/gas_thruster.dm
+++ b/code/modules/overmap/ships/machines/gas_thruster.dm
@@ -39,10 +39,6 @@
 	if(stat & NOPOWER)
 		update_use_power(POWER_USE_OFF)
 
-/obj/machinery/atmospherics/unary/engine/update_use_power(new_use_power)
-	..()
-	update_icon()
-
 /obj/machinery/atmospherics/unary/engine/RefreshParts()
 	..()
 	var/datum/extension/ship_engine/E = get_extension(src, /datum/extension/ship_engine)

--- a/code/modules/reagents/heat_sources/_heat_source.dm
+++ b/code/modules/reagents/heat_sources/_heat_source.dm
@@ -63,7 +63,6 @@
 		queue_icon_update()
 	if(((stat & (BROKEN|NOPOWER)) || !anchored) && use_power >= POWER_USE_ACTIVE)
 		update_use_power(POWER_USE_IDLE)
-		queue_icon_update()
 
 /obj/machinery/reagent_temperature/interface_interact(var/mob/user)
 	interact(user)

--- a/code/modules/shield_generators/floor_diffuser.dm
+++ b/code/modules/shield_generators/floor_diffuser.dm
@@ -49,7 +49,6 @@
 		return TRUE
 	enabled = !enabled
 	update_use_power(enabled + 1)
-	update_icon()
 	to_chat(user, "You turn \the [src] [enabled ? "on" : "off"].")
 	return TRUE
 

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -131,7 +131,6 @@
 	if(active) return 0 //If it's already turned on, how did this get called?
 
 	src.active = 1
-	update_icon()
 
 	create_shields()
 
@@ -145,7 +144,6 @@
 	if(!active) return 0 //If it's already off, how did this get called?
 
 	src.active = 0
-	update_icon()
 
 	collapse_shields()
 

--- a/code/modules/supermatter/setup_supermatter.dm
+++ b/code/modules/supermatter/setup_supermatter.dm
@@ -123,7 +123,6 @@
 		return SETUP_WARNING
 	P.target_pressure = P.max_pressure_setting
 	P.update_use_power(POWER_USE_IDLE)
-	P.update_icon()
 	return SETUP_OK
 
 
@@ -236,7 +235,6 @@
 		F.rebuild_filtering_list()
 
 	F.update_use_power(POWER_USE_IDLE)
-	F.update_icon()
 	return SETUP_OK
 
 

--- a/code/modules/xenoarcheaology/machinery/artifact_harvester.dm
+++ b/code/modules/xenoarcheaology/machinery/artifact_harvester.dm
@@ -108,7 +108,6 @@
 		update_use_power(POWER_USE_IDLE)
 	else
 		update_use_power(POWER_USE_ACTIVE)
-	update_icon()
 
 /obj/machinery/artifact_harvester/Process()
 	if(!operable())

--- a/code/modules/xenoarcheaology/machinery/suspension_generator.dm
+++ b/code/modules/xenoarcheaology/machinery/suspension_generator.dm
@@ -81,13 +81,11 @@
 	var/turf/T = get_turf(get_step(src,dir))
 	suspension_field = new(T)
 	visible_message(SPAN_NOTICE("[html_icon(src)] [src] activates with a low hum."))
-	update_icon()
 	update_use_power(POWER_USE_ACTIVE)
 
 /obj/machinery/suspension_gen/proc/deactivate()
 	visible_message(SPAN_NOTICE("[src] deactivates with a gentle shudder."))
 	QDEL_NULL(suspension_field)
-	update_icon()
 	update_use_power(POWER_USE_IDLE)
 
 /obj/machinery/suspension_gen/on_update_icon()


### PR DESCRIPTION
Fixes various bugs and oversights related to radio transmitters, receivers, and public variables/methods in general.
* Machinery now calls queue_icon_update() in update_power(). This replaces a lot of individual calls already in the code, and fixes a bug with receivers not properly updating machinery icons.
* Frequency datums no longer delete themselves if their devices list is empty. This fixes a bug where transmitters (which do not add themselves to the devices list, as they do not listen for signals) keep transmitting on an empty, qdeleted frequency after a lone device is removed from the frequency.
* Radio stock parts now LAZYINIT their transmit/receive lists on acquiring a target. This fixes a bug where players could not add events to newly created radio stock parts.
* Fixes some misleading descriptions for the radio receiver configuration window.
* Adds a new public variable for buttons that returns the inverse of a button's toggle.
* Adds a new public method for vents that inverses the pump direction of the vent.