### PR TITLE
Allowed crafting of specific currency coins.

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -109,4 +109,4 @@
 	max_storage_space = 100
 	max_w_class = ITEM_SIZE_HUGE
 	w_class = ITEM_SIZE_SMALL
-	can_hold = list(/obj/item/coin,/obj/item/cash)
+	can_hold = list(/obj/item/coin, /obj/item/cash)

--- a/code/modules/economy/worth_cash.dm
+++ b/code/modules/economy/worth_cash.dm
@@ -315,6 +315,3 @@
 	
 /obj/item/charge_stick/GetChargeStick()
 	return src
-
-/obj/item/coin/get_base_value()
-	. = max((holographic ? 0 : absolute_worth), ..())

--- a/code/modules/economy/worth_currency.dm
+++ b/code/modules/economy/worth_currency.dm
@@ -6,9 +6,11 @@
 	var/marked_value
 	var/image/overlay
 	var/rotate_icon = TRUE
+	var/decl/currency/currency
 
-/datum/denomination/New(var/decl/currency/currency, var/value, var/value_name, var/colour = COLOR_PALE_BTL_GREEN)
+/datum/denomination/New(var/decl/currency/_currency, var/value, var/value_name, var/colour = COLOR_PALE_BTL_GREEN)
 	..()
+	currency = _currency
 	name = "[value_name] [currency.name_singular] [name || "piece"]"
 	state = state || "cash"
 	marked_value = value
@@ -90,7 +92,7 @@
 	state = "coin_large"
 
 /decl/currency/trader
-	name =     "scrip"
+	name = "scrip"
 	name_prefix = "$"
 	material = /decl/material/solid/metal/copper
 

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -35,8 +35,17 @@
 		. += new/datum/stack_recipe/baseball_bat(src)
 		. += new/datum/stack_recipe/urn(src)
 		. += new/datum/stack_recipe/spoon(src)
-		. += new/datum/stack_recipe/coin(src)
 		. += new/datum/stack_recipe/furniture/door(src)
+
+		var/list/coin_recipes = list()
+		var/list/all_currencies = decls_repository.get_decls_of_subtype(/decl/currency)
+		for(var/cur in all_currencies)
+			var/decl/currency/currency = all_currencies[cur]
+			for(var/datum/denomination/denomination in currency.denominations)
+				if(length(denomination.faces))
+					coin_recipes += new /datum/stack_recipe/coin(src, null, denomination)
+		if(length(coin_recipes))
+			. += new/datum/stack_recipe_list("antique coins", coin_recipes)
 
 	if(wall_support_value >= 10)
 		. += new/datum/stack_recipe/furniture/girder(src)

--- a/code/modules/materials/recipes_items.dm
+++ b/code/modules/materials/recipes_items.dm
@@ -1,5 +1,4 @@
 //Recipes that produce items which aren't stacks or storage.
-
 /datum/stack_recipe/baseball_bat
 	title = "baseball bat"
 	result_type = /obj/item/twohanded/baseballbat
@@ -24,7 +23,19 @@
 /datum/stack_recipe/coin
 	title = "coin"
 	result_type = /obj/item/coin
-	one_per_turf = 1
+	var/datum/denomination/denomination
+
+/datum/stack_recipe/coin/New(decl/material/material, reinforce_material, datum/denomination/_denomination)
+	denomination = _denomination
+	. = ..()
+	title = denomination.name
+
+/datum/stack_recipe/coin/spawn_result(mob/user, location, amount)
+	var/obj/item/coin/coin = ..()
+	if(denomination)
+		coin.denomination = denomination
+		coin.SetName(coin.denomination.name)
+	return coin
 
 /datum/stack_recipe/ring
 	title = "ring"

--- a/code/modules/mob/skills/skill.dm
+++ b/code/modules/mob/skills/skill.dm
@@ -96,10 +96,10 @@ GLOBAL_LIST_EMPTY(skills)
 	name = "Finance"
 	desc = "Your ability to manage money and investments."
 	levels = list(
-		"Unskilled"   = "Your understanding of money starts and ends with personal finance. While you are able to perform basic transactions, you get lost in the details, and can find yourself ripped off on occasion.<br>- You get some starting money. Its amount increases with level.<br>- You can use the verb \"Appraise\" to see the value of different objects.",
-		"Basic"       = "You have some limited understanding of financial transactions, and will generally be able to keep accurate records. You have little experience with investment, and managing large sums of money will likely go poorly for you.",
+		"Unskilled"   = "Your understanding of money starts and ends with personal finance. While you are able to perform basic transactions, you get lost in the details, and can find yourself ripped off on occasion.<br>- You get some starting money, increasing with level.",
+		"Basic"       = "You have some limited understanding of financial transactions, and will generally be able to keep accurate records. You have little experience with investment, and managing large sums of money will likely go poorly for you.<br>- You can use the verb \"Appraise\" to see the value of different objects.",
 		"Trained"     = "You are good at managing accounts, keeping records, and arranging transactions. You have some familiarity with mortgages, insurance, stocks, and bonds, but may be stumped when facing more complicated financial devices.",
-		"Experienced" = "With your experience, you are familiar with any financial entities you may run across, and are a shrewd judge of value. More often than not, investments you make will pan out well.<BR> - You can speak and understand Legalese.",
+		"Experienced" = "With your experience, you are familiar with any financial entities you may run across, and are a shrewd judge of value. More often than not, investments you make will pan out well.<BR>- You can speak and understand Legalese.",
 		"Master"      = "You have an excellent knowledge of finance, will often make brilliant investments, and have an instinctive feel for interstellar economics. Financial instruments are weapons in your hands. You likely have professional experience in the finance industry."
 	)
 


### PR DESCRIPTION
- The crafting list now populates with a 'coins' category so specific denominations can be crafted. This is sort of a placeholder for a proper minting machine.
- `/obj/item/coin` (as opposed to the `/obj/item/cash` object, which can contain coins) now has a flat value rather than using denomination value.