### PR TITLE
Removes reduant command from info's on-show skin panel

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1246,6 +1246,6 @@ window "infowindow"
 		is-default = true
 		saved-params = ""
 		highlight-color = #00aa00
-		on-show = ".winset\"rpane.infob.is-visible=true;rpane.infob.pos=65,0 rpane.textb.is-visible=true rpane.infob.is-checked=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0 rpane.rpanewindow.left=infowindow\""
+		on-show = ".winset\"rpane.infob.is-visible=true;rpane.textb.is-visible=true rpane.infob.is-checked=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0 rpane.rpanewindow.left=infowindow\""
 		on-hide = ".winset\"rpane.infob.is-visible=false;rpane.textb.is-visible=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0 rpane.rpanewindow.left=\""
 


### PR DESCRIPTION
Fixes Info button, which always was stuck in one place (it can be moved normally now)
![изображение](https://user-images.githubusercontent.com/44920739/112554326-2436fa80-8dd7-11eb-95c0-6148812ce60a.png)
