### PR TITLE
Display OOC notices for admin paralysis

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -122,7 +122,7 @@ var/global/floorIsLava = 0
 		if(extra_body)
 			body += "<br><br>"
 			body += extra_body
-			
+
 	if (M.client)
 		if(!istype(M, /mob/new_player))
 			body += "<br><br>"
@@ -1440,10 +1440,18 @@ var/global/floorIsLava = 0
 		return
 
 	if(check_rights(R_INVESTIGATE))
-		if(!HAS_STATUS(M, STAT_PARA))
+		if(!M.admin_paralyzed)
+			M.visible_message(
+				SPAN_OCCULT("OOC: \The [M] has been paralyzed by a staff member. Please hold all interactions with them until staff have finished with them."),
+				SPAN_OCCULT("OOC: You have been paralyzed by a staff member. Please refer to your currently open admin help ticket or, if you don't have one, admin help for assistance.")
+			)
 			M.set_status(STAT_PARA, 8000)
+			M.admin_paralyzed = TRUE
 		else
 			M.set_status(STAT_PARA, 0)
+			M.admin_paralyzed = FALSE
+			M.visible_message(SPAN_OCCULT("OOC: \The [M] has been released from paralysis by staff. You may resume interactions with them."))
+			to_chat(M, SPAN_OCCULT("OOC: You have been released from paralysis by staff and can return to your game."))
 		log_and_message_admins("has [HAS_STATUS(M, STAT_PARA) ? "paralyzed" : "unparalyzed"] [key_name(M)].")
 
 /datum/admins/proc/sendFax()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -205,6 +205,9 @@
 		else if(!client)
 			msg += "<span class='deadsay'>[G.He] [G.is] [ssd_msg].</span>\n"
 
+	if (admin_paralyzed)
+		msg += SPAN_OCCULT("OOC: [G.He] [G.has] been paralyzed by staff. Please avoid interacting with [G.him] unless cleared to do so by staff.") + "\n"
+
 	var/obj/item/organ/external/head/H = organs_by_name[BP_HEAD]
 	if(istype(H) && H.forehead_graffiti && H.graffiti_style)
 		msg += "<span class='notice'>[G.He] [G.has] \"[H.forehead_graffiti]\" written on [G.his] [H.name] in [H.graffiti_style]!</span>\n"
@@ -360,7 +363,7 @@
 /mob/living/carbon/human/getHUDsource(hudtype)
 	var/obj/item/clothing/glasses/G = glasses
 	if(!istype(G))
-		return 
+		return
 	if(G.hud_type & hudtype)
 		return G
 	if(G.hud && (G.hud.hud_type & hudtype))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -5,6 +5,11 @@
 	else
 		add_to_living_mob_list()
 
+/mob/living/examine(mob/user, distance, infix, suffix)
+	. = ..()
+	if (admin_paralyzed)
+		to_chat(user, SPAN_OCCULT("OOC: They have been paralyzed by staff. Please avoid interacting with them unless cleared to do so by staff."))
+
 //mob verbs are faster than object verbs. See above.
 /mob/living/pointed(atom/A as mob|obj|turf in view())
 	if(incapacitated())

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -41,6 +41,7 @@
 	var/list/obj/aura/auras = null //Basically a catch-all aura/force-field thing.
 
 	var/last_resist = 0
+	var/admin_paralyzed = FALSE
 
 	var/list/chem_effects
 	var/list/chem_doses


### PR DESCRIPTION
This should save people the step of having to constantly inform passers-by to not touch someone while they're being bonked.

## Changelog
:cl:
rscadd: Admin paralyzed players now have notices to inform other players they're paralyzed and being handled by staff, and to not interact until staff are done.
/:cl:
