### PR TITLE
Convert mech module admin logs to attack logs

### DIFF
--- a/code/modules/admin/admin_attack_log.dm
+++ b/code/modules/admin/admin_attack_log.dm
@@ -41,6 +41,9 @@
 /proc/admin_attack_log(var/mob/attacker, var/mob/victim, var/attacker_message, var/victim_message, var/admin_message)
 	if(!(attacker || victim))
 		EXCEPTION("Neither attacker or victim was supplied.")
+	if ((attacker && !istype(attacker)) || (victim && !istype(victim)))
+		log_debug("Attack log skipped due to invalid mobtype - ATTACKER '[attacker.name]' ([attacker.type]) - VICTIM '[victim.name]' ([victim.type]) - MESSAGE '[admin_message]'.")
+		return
 	if(!store_admin_attack_log(attacker, victim))
 		return
 

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -158,7 +158,7 @@
 					ruser = user
 				temp_system.afterattack(A,ruser,adj,params)
 			if(system_moved) //We are using a proxy system that may not have logging like mech equipment does
-				log_and_message_admins("used [temp_system] targetting [A]", user, src.loc)
+				admin_attack_log(user, A, "Attacked using \a [temp_system] (MECH)", "Was attacked with \a [temp_system] (MECH)", "used \a [temp_system] (MECH) to attack")
 			//Mech equipment subtypes can add further click delays
 			var/extra_delay = 0
 			if(ME != null)


### PR DESCRIPTION
Mech attacks being admin logs gets really spammy, especially with things like drills and plasma cutters that aren't even targeting mobs.

Also adds a ismob() check to the attack log proc based on a suggestion from the Bay12 PR. Debug log is so it's known if something doesn't log when it called the proc, for investigation.

Cloned from https://github.com/Baystation12/Baystation12/pull/30385

## Changelog
:cl:
admin: Mech weapons now generate proper attack logs instead of admin logs, and only appear when targeting mobs.
/:cl:

