### PR TITLE
Z-Mimic: Actually Working edition

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -260,7 +260,7 @@
 #define SOULSTONE_EMPTY 0
 #define SOULSTONE_ESSENCE 1
 
-#define INCREMENT_WORLD_Z_SIZE world.maxz++; global.connected_z_cache.Cut(); if (SSzcopy.zstack_maximums.len) { SSzcopy.calculate_zstack_limits() }
+#define INCREMENT_WORLD_Z_SIZE world.maxz++; global.connected_z_cache.Cut(); if (SSzcopy.zlev_maximums.len) { SSzcopy.calculate_zstack_limits() }
 #define ARE_Z_CONNECTED(ZA, ZB) (ZA > 0 && ZB > 0 && ZA <= world.maxz && ZB <= world.maxz && ((ZA == ZB) || ((global.connected_z_cache.len >= ZA && global.connected_z_cache[ZA]) ? global.connected_z_cache[ZA][ZB] : AreConnectedZLevels(ZA, ZB))))
 
 //Request Console Department Types

--- a/code/controllers/subsystems/zcopy.dm
+++ b/code/controllers/subsystems/zcopy.dm
@@ -1,6 +1,7 @@
 #define OPENTURF_MAX_PLANE -70
 #define OPENTURF_MAX_DEPTH 10		// The maxiumum number of planes deep we'll go before we just dump everything on the same plane.
 #define SHADOWER_DARKENING_FACTOR 0.6	// The multiplication factor for openturf shadower darkness. Lighting will be multiplied by this.
+#define SHADOWER_DARKENING_COLOR "#999999"	// The above, but as an RGB string for lighting-less turfs.
 
 SUBSYSTEM_DEF(zcopy)
 	name = "Z-Copy"
@@ -19,7 +20,7 @@ SUBSYSTEM_DEF(zcopy)
 
 	// Highest Z level in a given Z-group for absolute layering used by FIX_BIGTURF.
 	// zstm[zlev] = group_max
-	var/list/zstack_maximums = list()
+	var/list/zlev_maximums = list()
 
 // for admin proc-call
 /datum/controller/subsystem/zcopy/proc/update_all()
@@ -88,15 +89,19 @@ SUBSYSTEM_DEF(zcopy)
 
 // If you add a new Zlevel or change Z-connections, call this.
 /datum/controller/subsystem/zcopy/proc/calculate_zstack_limits()
-	zstack_maximums = new(world.maxz)
+	zlev_maximums = new(world.maxz)
 	var/start_zlev = 1
 	for (var/z in 1 to world.maxz)
 		if (!HasAbove(z))
 			for (var/member_zlev in start_zlev to z)
-				zstack_maximums[member_zlev] = z
+				zlev_maximums[member_zlev] = z
+			if (z - start_zlev > OPENTURF_MAX_DEPTH)
+				log_ss("zcopy", "WARNING: Z-levels [start_zlev] through [z] exceed maximum depth of [OPENTURF_MAX_DEPTH]; layering may behave strangely in this Z-stack.")
+			else if (z - start_zlev > 1)
+				log_ss("zcopy", "Found Z-Stack: [start_zlev] -> [z] = [z - start_zlev] zl")
 			start_zlev = z + 1
 
-	log_ss("zcopy", "Z-Stack maximums: [json_encode(zstack_maximums)]")
+	log_ss("zcopy", "Z-Level maximums: [json_encode(zlev_maximums)]")
 
 /datum/controller/subsystem/zcopy/StartLoadingMap()
 	suspend()
@@ -121,29 +126,38 @@ SUBSYSTEM_DEF(zcopy)
 		curr_turfs[qt_idex] = null
 		qt_idex += 1
 
-		if (!isturf(T) || !T.below || !(T.z_flags & ZM_MIMIC_BELOW))
+		if (!isturf(T) || !T.below || !(T.z_flags & ZM_MIMIC_BELOW) || !T.z_queued)
 			if (no_mc_tick)
 				CHECK_TICK
 			else if (MC_TICK_CHECK)
 				break
 			continue
 
+		// If we're not at our most recent queue position, don't bother -- we're updating again later anyways.
+		if (T.z_queued > 1)
+			T.z_queued -= 1
+			if (no_mc_tick)
+				CHECK_TICK
+			else if (MC_TICK_CHECK)
+				return
+			continue
+
 		if (!T.shadower)	// If we don't have a shadower yet, something has gone horribly wrong.
 			WARNING("Turf [T] at [T.x],[T.y],[T.z] was queued, but had no shadower.")
 			continue
 
-		// Figure out how many z-levels down we are.
-		var/depth = 0
+		// Get the bottom-most turf, the one we want to mimic.
 		var/turf/Td = T
-
 		while (Td.below)
 			Td = Td.below
 
-		T.z_depth = depth = min(T.z - Td.z, OPENTURF_MAX_DEPTH)
+		// Depth must be the depth of the *visible* turf, not self.
+		var/turf_depth
+		turf_depth = T.z_depth = zlev_maximums[Td.z] - Td.z
 
-		var/t_target = OPENTURF_MAX_PLANE - depth	// this is where the openturf gets put
+		var/t_target = OPENTURF_MAX_PLANE - turf_depth	// This is where the turf (but not the copied atoms) gets put.
 
-		// Handle space parallax.
+		// Handle space parallax & starlight.
 		if (T.below.z_eventually_space)
 			T.z_eventually_space = TRUE
 			t_target = SPACE_PLANE
@@ -165,14 +179,31 @@ SUBSYSTEM_DEF(zcopy)
 			// Some openturfs have icons, so we can't overwrite their appearance.
 			if (!T.below.bound_overlay)
 				T.below.bound_overlay = new(T)
-			var/atom/movable/openspace/turf_overlay/TO = T.below.bound_overlay
-			TO.appearance = T.below
+			var/atom/movable/openspace/turf_delegate/TO = T.below.bound_overlay
+			TO.appearance = Td
 			TO.name = T.name
 			TO.gender = T.gender	// Need to grab this too so PLURAL works properly in examine.
 			TO.opacity = FALSE
 			TO.plane = t_target
+			TO.mouse_opacity = initial(TO.mouse_opacity)
 
-		T.queue_ao()	// TODO: non-rebuild updates seem to break pixel offsets, but should work in theory if that's fixed?
+		T.queue_ao(T.ao_neighbors_mimic == null)	// If ao_neighbors hasn't been set yet, we need to do a rebuild
+
+		// Explicitly copy turf delegates so they show up properly on below levels.
+		//   I think it's possible to get this to work without discrete delegate copy objects, but I'd rather this just work.
+		if ((T.below.z_flags & (ZM_MIMIC_BELOW|ZM_MIMIC_OVERWRITE)) == ZM_MIMIC_BELOW)
+			// Below is a delegate, gotta explicitly copy it for recursive copy.
+			if (!T.below.z_delegate)
+				T.below.z_delegate = new(T)
+			var/atom/movable/openspace/delegate_copy/DC = T.below.z_delegate
+			DC.appearance = T.below
+			DC.mouse_opacity = initial(DC.mouse_opacity)
+			DC.plane = OPENTURF_MAX_PLANE
+
+		else if (T.below.z_delegate)
+			QDEL_NULL(T.below.z_delegate)
+
+		// Handle below atoms.
 
 		// Add everything below us to the update queue.
 		for (var/thing in T.below)
@@ -191,23 +222,22 @@ SUBSYSTEM_DEF(zcopy)
 
 				var/override_depth
 				var/original_type = object.type
+				var/original_z = object.z
 				switch (object.type)
 					if (/atom/movable/openspace/overlay)
 						var/atom/movable/openspace/overlay/OOO = object
 						original_type = OOO.mimiced_type
 						override_depth = OOO.override_depth
+						original_z = OOO.original_z
 
-					if (/atom/movable/openspace/multiplier)
-						// Large turfs require special (read: broken) layering to not look awful.
-						// This isn't enabled on other turfs that can layer normally as it breaks atom/shadower layer order (causing them to be lighter than intended.)
-						if (T.z_flags & ZM_FIX_BIGTURF)
-							override_depth = min((zstack_maximums[T.z] - object.z) + 1, OPENTURF_MAX_DEPTH)
-
-					if (/atom/movable/openspace/turf_overlay)
+					if (/atom/movable/openspace/turf_delegate, /atom/movable/openspace/delegate_copy)
 						// If we're a turf overlay (the mimic for a non-OVERWRITE turf), we need to make sure copies of us respect space parallax too
 						if (T.z_eventually_space)
 							// Yes, this is an awful hack; I don't want to add yet another override_* var.
 							override_depth = OPENTURF_MAX_PLANE - SPACE_PLANE
+
+				if ((T.z_flags & ZM_FIX_BIGTURF) && original_type == /atom/movable/openspace/multiplier)
+					override_depth = turf_depth
 
 				var/atom/movable/openspace/overlay/OO = object.bound_overlay
 
@@ -216,9 +246,10 @@ SUBSYSTEM_DEF(zcopy)
 					deltimer(OO.destruction_timer)
 					OO.destruction_timer = null
 
-				OO.depth = override_depth || min(T.z - object.z, OPENTURF_MAX_DEPTH)
+				OO.depth = override_depth || min(T.z - original_z, OPENTURF_MAX_DEPTH)
 				OO.mimiced_type = original_type
 				OO.override_depth = override_depth
+				OO.original_z = original_z
 
 				if (!OO.queued)
 					OO.queued = TRUE
@@ -262,7 +293,9 @@ SUBSYSTEM_DEF(zcopy)
 			continue
 
 		// Actually update the overlay.
-		OO.set_dir(OO.associated_atom.dir)
+		if (OO.dir != OO.associated_atom.dir)
+			OO.set_dir(OO.associated_atom.dir)
+
 		OO.appearance = OO.associated_atom
 		OO.plane = OPENTURF_MAX_PLANE - OO.depth
 
@@ -281,6 +314,8 @@ SUBSYSTEM_DEF(zcopy)
 		curr_ov.Cut(1, qo_idex)
 		qo_idex = 1
 
+#define FMT_DEPTH(X) (X == null ? "(null)" : X)
+
 /client/proc/analyze_openturf(turf/T)
 	set name = "Analyze Openturf"
 	set desc = "Show the layering of an openturf and everything it's mimicking."
@@ -290,41 +325,88 @@ SUBSYSTEM_DEF(zcopy)
 		return
 
 	var/list/out = list(
+		"<head><meta charset='utf-8'/></head><body>",
 		"<h1>Analysis of [T] at [T.x],[T.y],[T.z]</h1>",
 		"<b>Queue occurrences:</b> [T.z_queued]",
 		"<b>Above space:</b> Apparent [T.z_eventually_space ? "Yes" : "No"], Actual [T.is_above_space() ? "Yes" : "No"]",
 		"<b>Z Flags</b>: [english_list(bitfield2list(T.z_flags, global.mimic_defines), "(none)")]",
 		"<b>Has Shadower:</b> [T.shadower ? "Yes" : "No"]",
 		"<b>Below:</b> [!T.below ? "(nothing)" : "[T.below] at [T.below.x],[T.below.y],[T.below.z]"]",
-		"<b>Depth:</b> [T.z_depth == null ? "(null)" : T.z_depth] [T.z_depth == OPENTURF_MAX_DEPTH ? "(max)" : ""]",
+		"<b>Depth:</b> [FMT_DEPTH(T.z_depth)] [T.z_depth == OPENTURF_MAX_DEPTH ? "(max)" : ""]",
 		"<ul>"
 	)
 
 	var/list/found_oo = list(T)
-	for (var/thing in T)
-		if (istype(thing, /atom/movable/openspace))
-			found_oo += thing
-
-	var/turf/Td = T
-	while (Td.below)
-		Td = Td.below
-		found_oo += Td
+	for (var/atom/movable/openspace/O in T)
+		found_oo += O
 
 	sortTim(found_oo, /proc/cmp_planelayer)
+
+	var/list/atoms_list_list = list()
 	for (var/thing in found_oo)
 		var/atom/A = thing
-		if (istype(A, /atom/movable/openspace/overlay))
-			var/atom/movable/openspace/overlay/OO = A
-			var/atom/movable/AA = OO.associated_atom
-			out += "<li>[html_icon(A)] plane [A.plane], layer [A.layer], depth [OO.depth], associated Z-level [AA.z] - [OO.type] copying [AA] ([AA.type], eventually [OO.mimiced_type])</li>"
-		else if (isturf(A))
-			if (A == T)
-				out += "<li>[html_icon(A)] plane [A.plane], layer [A.layer], depth [A:z_depth], Z-level [A.z] - [A] ([A.type]) - <font color='green'>SELF</font></li>"
-			else	// foreign turfs - not visible here, but good for figuring out layering
-				out += "<li>[html_icon(A)] plane [A.plane], layer [A.layer], depth [A:z_depth], Z-level [A.z] - [A] ([A.type]) - <font color='red'>FOREIGN</font></li>"
-		else
-			out += "<li>[html_icon(A)] plane [A.plane], layer [A.layer], Z-level [A.z] - [A] ([A.type])</li>"
+		var/pl = "[A.plane]"
+		LAZYINITLIST(atoms_list_list[pl])
+		atoms_list_list[pl] += A
 
-	out += "</ul>"
+	if (atoms_list_list["0"])
+		out += "<strong>Non-Z</strong>"
+		SSzcopy.debug_fmt_planelist(atoms_list_list["0"], out, T)
+
+		atoms_list_list -= "0"
+
+	for (var/d in 0 to OPENTURF_MAX_DEPTH)
+		var/pl = OPENTURF_MAX_PLANE - d
+		if (!atoms_list_list["[pl]"])
+			out += "<strong>Depth [d], plane [pl] — empty</strong>"
+			continue
+
+		out += "<strong>Depth [d], plane [pl]</strong>"
+		SSzcopy.debug_fmt_planelist(atoms_list_list["[pl]"], out, T)
+
+		// Flush the list so we can find orphans.
+		atoms_list_list -= "[pl]"
+
+	log_debug("atoms_list_list => [json_encode(atoms_list_list)]")
+	for (var/key in atoms_list_list)
+		out += "<strong style='color: red;'>Unknown plane: [key]</strong>"
+		SSzcopy.debug_fmt_planelist(atoms_list_list[key], out, T)
+
+		out += "<hr/>"
+
+	out += "</body>"
 
 	show_browser(usr, out.Join("<br>"), "size=980x580;window=openturfanalysis-\ref[T]")
+
+// Yes, I know this proc is a bit of a mess. Feel free to clean it up.
+/datum/controller/subsystem/zcopy/proc/debug_fmt_thing(atom/A, list/out, turf/original)
+	if (istype(A, /atom/movable/openspace/overlay))
+		var/atom/movable/openspace/overlay/OO = A
+		var/atom/movable/AA = OO.associated_atom
+		var/copied_type = AA.type == OO.mimiced_type ? "[AA.type] \[direct\]" : "[AA.type], eventually [OO.mimiced_type]"
+		return "<li>\icon[A] <b>\[Mimic\]</b> plane [A.plane], layer [A.layer], depth [FMT_DEPTH(OO.depth)], associated Z-level [AA.z] - [OO.type] copying [AA] ([copied_type])</li>"
+	else if (istype(A, /atom/movable/openspace/delegate_copy))
+		var/atom/movable/openspace/delegate_copy/DC = A
+		return "<li>\icon[A] <b>\[Turf Delegate Copy\]</b> plane [A.plane], layer [A.layer], Z-level [A.z], delegate of \icon[DC.delegate] [DC.delegate] ([DC.delegate.type])</li>"
+	else if (isturf(A))
+		if (A == original)
+			return "<li>\icon[A] <b>\[Turf\]</b> plane [A.plane], layer [A.layer], depth [FMT_DEPTH(A:z_depth)], Z-level [A.z] - [A] ([A.type]) - <font color='green'>SELF</font></li>"
+		else	// foreign turfs - not visible here, but sometimes good for figuring out layering -- showing these is currently not enabled
+			return "<li>\icon[A] <b>\[Turf\]</b> <em><font color='#646464'>plane [A.plane], layer [A.layer], depth [FMT_DEPTH(A:z_depth)], Z-level [A.z] - [A] ([A.type])</font></em> - <font color='red'>FOREIGN</font></em></li>"
+	else if (A.type == /atom/movable/openspace/multiplier)
+		return "<li>\icon[A] <b>\[Shadower\]</b> plane [A.plane], layer [A.layer], Z-level [A.z] - [A] ([A.type])</li>"
+	else if (A.type == /atom/movable/openspace/turf_delegate)
+		return "<li>\icon[A] <b>\[Turf Delegate (Mimic)\]</b> plane [A.plane], layer [A.layer], Z-level [A.z] - [A] ([A.type])</li>"
+	else
+		return "<li>\icon[A] <b>\[?\]</b>  plane [A.plane], layer [A.layer], Z-level [A.z] - [A] ([A.type])</li>"
+
+/datum/controller/subsystem/zcopy/proc/debug_fmt_planelist(list/things, list/out, turf/original)
+	if (things)
+		out += "<ul>"
+		for (var/thing in things)
+			out += debug_fmt_thing(thing, out, original)
+		out += "</ul>"
+	else
+		out += "<em>No atoms.</em>"
+
+#undef FMT_DEPTH

--- a/code/modules/multiz/basic.dm
+++ b/code/modules/multiz/basic.dm
@@ -17,7 +17,7 @@ var/list/z_levels = list() // Each Z-level is associated with the relevant map d
 			z_levels.len = i
 		z_levels[i] = src
 
-	if (length(SSzcopy.zstack_maximums))
+	if (length(SSzcopy.zlev_maximums))
 		SSzcopy.calculate_zstack_limits()
 
 /obj/effect/landmark/map_data/Destroy(forced)

--- a/code/modules/multiz/zmimic/mimic_turf.dm
+++ b/code/modules/multiz/zmimic/mimic_turf.dm
@@ -2,8 +2,12 @@
 	// Reference to any open turf that might be above us to speed up atom Entered() updates.
 	var/tmp/turf/above
 	var/tmp/turf/below
-	var/tmp/atom/movable/openspace/turf_overlay/bound_overlay
-	var/tmp/atom/movable/openspace/multiplier/shadower		// Overlay used to multiply color of all OO overlays at once.
+	// If we're a delegate z-turf, this holds the appearance of the bottom-most Z-turf in the z-stack.
+	var/tmp/atom/movable/openspace/turf_delegate/bound_overlay
+	// Overlay used to multiply color of all OO overlays at once.
+	var/tmp/atom/movable/openspace/multiplier/shadower
+	// If this is a delegate (non-overwrite) Z-turf with a z-turf above, this is the delegate copy that's copying us.
+	var/tmp/atom/movable/openspace/delegate_copy/z_delegate
 	var/tmp/z_queued = 0	// How many times this turf is currently queued - multiple queue occurrences are allowed to ensure update consistency
 	var/tmp/z_eventually_space = FALSE
 	var/z_flags = 0
@@ -55,6 +59,9 @@
 		below = under
 		below.above = src
 
+	if (!(z_flags & ZM_MIMIC_OVERWRITE) && mouse_opacity)
+		mouse_opacity = 2
+
 	update_mimic(!mapload)	// Only recursively update if the map isn't loading.
 
 // Cleans up Z-mimic objects for this turf. You shouldn't call this directly 99% of the time.
@@ -64,6 +71,7 @@
 	z_queued = 0
 
 	QDEL_NULL(shadower)
+	QDEL_NULL(z_delegate)
 
 	for (var/atom/movable/openspace/overlay/OO in src)
 		OO.owning_turf_changed()
@@ -74,17 +82,3 @@
 	if (below)
 		below.above = null
 		below = null
-
-// Movable for mimicing turfs that don't allow appearance mutation.
-/atom/movable/openspace/turf_overlay
-	plane = OPENTURF_MAX_PLANE
-
-/atom/movable/openspace/turf_overlay/attackby(obj/item/W, mob/user)
-	return loc.attackby(W, user)
-
-/atom/movable/openspace/turf_overlay/attack_hand(mob/user)
-	return loc.attack_hand(user)
-
-/atom/movable/openspace/turf_overlay/examine(mob/examiner)
-	SHOULD_CALL_PARENT(FALSE)
-	. = loc.examine(examiner)


### PR DESCRIPTION
PR title not guaranteed to be accurate.

changes:
- Layering should actually work now, even for stacked non-OVERWRITE turfs - some edge cases with bigturfs and space remain.
- Pointless non-head updates of z-turfs are just skipped now.
- Z-Copy has been told to let go and not attempt to update de-queued zturfs.
- Openturf analyzer now shows absolute z-stack ordering, rather than throwing a pile of numbers at you and letting you figure it out.
- Renamed some Z-M types to be less misleading.
- ~~Some mouse opacity changes that do things I forget, but presumably they're important~~ Mimics of non-OVERWRITE turfs are now not clickable so they won't spam the right click menu.
- Z-Stack messages have been made a bit clearer & now show more information.
- Z-Mimic will now print logs if it finds a Z-Stack taller than what Z-Mimic can deal with without loss of layering information.
- Lighting mimics now respect SSoverlays, not that they're actually used right now.

This port has not been tested at all beyond 'it compiles' (the upstream O7 version *has* been tested, though).