### PR TITLE
Fixes empty list check in id/job access setting

### DIFF
--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -86,7 +86,7 @@
 	var/decl/hierarchy/outfit/outfit = get_outfit(H, alt_title, branch, grade)
 	if(outfit) . = outfit.equip(H, title, alt_title)
 
-	if(!QDELETED(H) && length(access))
+	if(!QDELETED(H))
 		var/obj/item/card/id/id = H.GetIdCard()
 		if(id)
 			id.rank = title


### PR DESCRIPTION
Fixes captain job access (tradeship for example), which is currently `list()` in job datum, but `get_access()` return all station accesses