### PR TITLE
Hide attack logs for pulled punches

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -204,7 +204,8 @@
 				H.visible_message("<span class='danger'>[attack_message]</span>")
 
 			playsound(loc, ((miss_type) ? (miss_type == 1 ? attack.miss_sound : 'sound/weapons/thudswoosh.ogg') : attack.attack_sound), 25, 1, -1)
-			admin_attack_log(H, src, "[miss_type ? (miss_type == 1 ? "Has missed" : "Was blocked by") : "Has [pick(attack.attack_verb)]"] their victim.", "[miss_type ? (miss_type == 1 ? "Missed" : "Blocked") : "[pick(attack.attack_verb)]"] their attacker", "[miss_type ? (miss_type == 1 ? "has missed" : "was blocked by") : "has [pick(attack.attack_verb)]"]")
+			if (attack.should_attack_log)
+				admin_attack_log(H, src, "[miss_type ? (miss_type == 1 ? "Has missed" : "Was blocked by") : "Has [pick(attack.attack_verb)]"] their victim.", "[miss_type ? (miss_type == 1 ? "Missed" : "Blocked") : "[pick(attack.attack_verb)]"] their attacker", "[miss_type ? (miss_type == 1 ? "has missed" : "was blocked by") : "has [pick(attack.attack_verb)]"]")
 
 			if(miss_type)
 				return TRUE

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -18,6 +18,7 @@ var/global/list/sparring_attack_cache = list()
 	var/eye_attack_text_victim
 	var/list/usable_with_limbs = list(BP_L_HAND, BP_R_HAND)
 	var/is_starting_default = FALSE
+	var/should_attack_log = TRUE
 
 /decl/natural_attack/proc/summarize()
 	var/list/usable_limbs = list()
@@ -206,7 +207,7 @@ var/global/list/sparring_attack_cache = list()
 
 	var/decl/pronouns/user_gender =   user.get_pronouns()
 	var/decl/pronouns/target_gender = target.get_pronouns()
-	var/attack_string 
+	var/attack_string
 	if(!target.lying)
 		switch(zone)
 			if(BP_HEAD, BP_MOUTH, BP_EYES)
@@ -228,9 +229,9 @@ var/global/list/sparring_attack_cache = list()
 			else
 				// ----- BODY ----- //
 				switch(attack_damage)
-					if(1 to 2)	
+					if(1 to 2)
 						attack_string = "threw a glancing punch at [target]'s [affecting.name]"
-					if(1 to 4)	
+					if(1 to 4)
 						attack_string = "[pick(attack_verb)] [target] in \the [affecting]"
 					if(5)
 						attack_string = "smashed [user_gender.his] [pick(attack_noun)] into [target]'s [affecting.name]"
@@ -336,6 +337,7 @@ var/global/list/sparring_attack_cache = list()
 	sharp = 0
 	edge = 0
 	attack_sound = "light_strike"
+	should_attack_log = FALSE
 
 /decl/natural_attack/light_strike/punch
 	name = "light punch"


### PR DESCRIPTION
https://github.com/Baystation12/Baystation12/pull/30448

Because I imagine staff on nebula servers hate the holodeck fight spam as much as I did.

## Changelog
:cl:
admin: Pulled punches no longer generate attack logs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
