### PR TITLE
Send all nanoui templates in one file.

### DIFF
--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -174,6 +174,8 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 
 
 //DEFINITIONS FOR ASSET DATUMS START HERE.
+var/template_file_name = "all_templates.json"
+
 /datum/asset/nanoui
 	var/list/common = list()
 
@@ -185,9 +187,10 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 		"nano/js/"
 	)
 	var/list/uncommon_dirs = list(
-		"nano/templates/",
 		"news_articles/images/"
 	)
+	var/template_dir = "nano/templates/"
+	var/template_temp_dir = "data/"
 
 /datum/asset/nanoui/register()
 	// Crawl the directories to find files.
@@ -204,6 +207,19 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 			if(copytext(filename, length(filename)) != "/") // Ignore directories.
 				if(fexists(path + filename))
 					register_asset(filename, fcopy_rsc(path + filename))
+
+	var/list/templates = flist(template_dir)
+	for(var/filename in templates)
+		if(copytext(filename, length(filename)) != "/")
+			templates[filename] = replacetext(replacetext(file2text(template_dir + filename), "\n", ""), "\t", "")
+		else
+			templates -= filename
+	var/full_file_name = template_temp_dir + global.template_file_name
+	if(fexists(full_file_name))
+		fdel(file(full_file_name))
+	var/template_file = file(full_file_name)
+	to_file(template_file, json_encode(templates))
+	register_asset(global.template_file_name, fcopy_rsc(template_file))
 
 	var/list/mapnames = list()
 	for(var/z in GLOB.using_map.map_levels)

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -207,6 +207,7 @@ nanoui is used to open and update nano browser uis
 			"mapZLevels" = GLOB.using_map.map_levels,
 			"user" = list("name" = user.name),
 			"currency" = cur.name,
+			"templateFileName" = global.template_file_name
 		)
 	return config_data
 


### PR DESCRIPTION
Proof of concept aimed at people who have trouble with nanoui assets. Seems that asset send rate is (partially) limited by number of files (it sends a couple a second at most), and there are a lot of templates. This batches them all into one big file and sends only that.

Current file size is 376 KB. This is about 1.5x the size of the next largest asset, and 3x the size of each of two js libraries sent. It does store a copy in data; unsure if that's necessary or not.

Disadvantages: client needs to parse the file on UI open (seems fast enough to not be noticeable). Sending a big file may produce lag (unable to test). Code is bad (sorry).

Advantages: should speed up how early in the game you see nanoui assets, which is relevant in dev (less so in play). May or may not work better for people with nanoui troubles.