### PR TITLE
Rewrote theft objective to allow for non-type-dependant material sheet targets.

### DIFF
--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -329,14 +329,8 @@
 				new_objective.owner = src
 
 			if ("steal")
-				if (!istype(objective, /datum/objective/steal))
-					new_objective = new /datum/objective/steal
-					new_objective.owner = src
-				else
-					new_objective = objective
-				var/datum/objective/steal/steal = new_objective
-				if (!steal.select_target())
-					return
+				new_objective = new /datum/objective/steal
+				new_objective.owner = src
 
 			if("download","capture","absorb")
 				var/def_num

--- a/code/game/gamemodes/objectives/objective_steal.dm
+++ b/code/game/gamemodes/objectives/objective_steal.dm
@@ -1,37 +1,28 @@
 /datum/objective/steal
-	var/obj/item/steal_target
-	var/target_name
-
-/datum/objective/steal/proc/set_target(item_name)
-	target_name = item_name
-	var/list/possible_items = GLOB.using_map.get_theft_targets()
-	steal_target = possible_items[target_name]
-	if (!steal_target )
-		var/list/possible_items_special = GLOB.using_map.get_special_theft_targets()
-		steal_target = possible_items_special[target_name]
-	explanation_text = "Steal [target_name]."
-	return steal_target
+	var/theft_name
+	var/theft_type
+	var/theft_material
+	var/theft_amount = 1
 
 /datum/objective/steal/find_target()
-	return set_target(pick(GLOB.using_map.get_theft_targets()))
 
-/datum/objective/steal/proc/select_target()
-	var/possible_items = GLOB.using_map.get_theft_targets()
-	var/possible_items_special = GLOB.using_map.get_special_theft_targets()
-	var/list/possible_items_all = possible_items+possible_items_special+"custom"
-	var/new_target = input("Select target:", "Objective target", steal_target) as null|anything in possible_items_all
-	if (!new_target) return
-	if (new_target == "custom")
-		var/obj/item/custom_target = input("Select type:","Type") as null|anything in typesof(/obj/item)
-		if (!custom_target) return
-		var/tmp_obj = new custom_target
-		var/custom_name = tmp_obj:name
-		qdel(tmp_obj)
-		custom_name = sanitize(input("Enter target name:", "Objective target", custom_name) as text|null)
-		if (!custom_name) return
-		target_name = custom_name
-		steal_target = custom_target
-		explanation_text = "Steal [target_name]."
+	var/list/possible_items = GLOB.using_map.get_theft_targets() | GLOB.using_map.get_special_theft_targets()
+	if(!length(possible_items))
+		return
+	theft_name = pick(possible_items)
+	var/theft_data = possible_items[theft_name]
+	if(ispath(theft_data))
+		theft_type = theft_data
+	else if(islist(theft_data))
+		if(length(theft_data) >= 1 && ispath(theft_data[1]))
+			theft_type = theft_data[1]
+		if(length(theft_data) >= 2 && isnum(theft_data[2]))
+			theft_amount = theft_data[2]
+		if(length(theft_data) >= 3 && ispath(theft_data[3], /decl/material))
+			theft_material = theft_data[3]
+
+	if(!theft_type || theft_amount <= 0)
+		explanation_text = "Free objective."
 	else
-		set_target(new_target)
-	return steal_target
+		explanation_text = "Steal [theft_name]."
+	return theft_type

--- a/maps/~mapsystem/maps_antagonism.dm
+++ b/maps/~mapsystem/maps_antagonism.dm
@@ -22,13 +22,13 @@
 	)
 
 	var/list/potential_special_theft_targets = list(
-		"nuclear gun"             = /obj/item/gun/energy/gun/nuclear,
-		"diamond drill"           = /obj/item/pickaxe/diamonddrill,
-		"bag of holding"          = /obj/item/storage/backpack/holding,
-		"hyper-capacity cell"     = /obj/item/cell/hyper,
-		"10 diamonds"             = /obj/item/stack/material/diamond,
-		"50 gold bars"            = /obj/item/stack/material/gold,
-		"25 refined uranium bars" = /obj/item/stack/material/uranium,
+		"nuclear gun"         = /obj/item/gun/energy/gun/nuclear,
+		"diamond drill"       = /obj/item/pickaxe/diamonddrill,
+		"bag of holding"      = /obj/item/storage/backpack/holding,
+		"hyper-capacity cell" = /obj/item/cell/hyper,
+		"10 diamonds"         = list(/obj/item/stack/material/*gemstone*/, 10, /decl/material/solid/gemstone/diamond),
+		"50 gold ingots"      = list(/obj/item/stack/material/*ingot*/,    50, /decl/material/solid/metal/gold),
+		"25 uranium pucks"    = list(/obj/item/stack/material/*puck*/,     25, /decl/material/solid/metal/uranium),
 	)
 
 /datum/map/proc/get_theft_targets()


### PR DESCRIPTION
It seems like objectives don't actually check for success or failure anymore, not sure if that got removed on Neb or not but all this code is basically unused currently. Cleaned it up anyway for the material stack PR.