### PR TITLE
Minor aiming refactor, fruit is now aimable.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -132,3 +132,5 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		power *= 2
 	return target.hit_with_weapon(src, user, power, hit_zone)
 
+/obj/item/proc/handle_reflexive_fire(var/mob/user, var/atom/aiming_at)
+	return istype(user) && istype(aiming_at)

--- a/code/game/objects/items/weapons/material/thrown.dm
+++ b/code/game/objects/items/weapons/material/thrown.dm
@@ -24,7 +24,7 @@
 /obj/item/star/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
 	if(user.a_intent == I_HURT)
-		user.throw_item(target)
+		user.throw_item(target, src)
 
 /obj/item/star/ninja
 	material = /decl/material/solid/metal/uranium

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -313,3 +313,17 @@ var/list/fruit_icon_cache = list()
 		I.color = flesh_colour
 		fruit_icon_cache["slice-[rind_colour]"] = I
 	overlays |= fruit_icon_cache["slice-[rind_colour]"]
+
+/obj/item/chems/food/snacks/grown/afterattack(atom/target, mob/user, flag)
+	if(!flag && isliving(user))
+		var/mob/living/M = user
+		M.aim_at(target, src)
+		return
+	. = ..()
+
+/obj/item/chems/food/snacks/grown/handle_reflexive_fire(var/mob/user, var/atom/aiming_at)
+	. = ..()
+	if(.)
+		user.visible_message(SPAN_DANGER("\The [user] reflexively hurls \the [src] at \the [aiming_at]!"))
+		user.throw_item(get_turf(aiming_at), src)
+		user.trigger_aiming(TARGET_CAN_CLICK)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -222,15 +222,18 @@
 /mob/proc/throw_item(atom/target)
 	return
 
-/mob/living/carbon/throw_item(atom/target)
+/mob/living/carbon/throw_item(atom/target, obj/item/item)
 	src.throw_mode_off()
 	if(src.stat || !target)
 		return
-	if(target.type == /obj/screen) return
+	if(target.type == /obj/screen) 
+		return
 
-	var/atom/movable/item = src.get_active_hand()
+	if(!item)
+		item = get_active_hand()
 
-	if(!item) return
+	if(!istype(item) || !(item in get_held_items()))
+		return
 
 	var/throw_range = item.throw_range
 	var/itemsize
@@ -259,7 +262,7 @@
 	if(!item || !isturf(item.loc))
 		return
 
-	var/message = "\The [src] has thrown \the [item]."
+	var/message = "\The [src] has thrown \the [item]!"
 	var/skill_mod = 0.2
 	if(!skill_check(SKILL_HAULING, min(round(itemsize - ITEM_SIZE_HUGE) + 2, SKILL_MAX)))
 		if(prob(30))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -671,12 +671,26 @@
 	return (autofire_enabled && world.time >= next_fire_time)
 
 /obj/item/gun/proc/check_accidents(mob/living/user, message = "[user] fumbles with the [src] and it goes off!",skill_path = SKILL_WEAPONS, fail_chance = 20, no_more_fail = SKILL_EXPERT, factor = 2)
-	if(istype(user))
-		if(!safety() && user.skill_fail_prob(skill_path, fail_chance, no_more_fail, factor) && special_check(user))
-			user.visible_message(SPAN_WARNING(message))
-			var/list/targets = list(user)
-			var/turf/checking = get_turf(src)
-			targets += RANGE_TURFS(checking, 2)
-			var/picked = pick(targets)
-			afterattack(picked, user)
-			return 1
+	if(istype(user) && !safety() && user.skill_fail_prob(skill_path, fail_chance, no_more_fail, factor) && special_check(user))
+		user.visible_message(SPAN_WARNING(message))
+		var/list/targets = list(user)
+		var/turf/checking = get_turf(src)
+		targets += RANGE_TURFS(checking, 2)
+		var/picked = pick(targets)
+		afterattack(picked, user)
+		return TRUE
+	return FALSE
+
+/obj/item/gun/handle_reflexive_fire(var/mob/user, var/atom/aiming_at)
+	. = ..()
+	if(. && isliving(user))
+		var/mob/living/M = user
+		if(prob(M.skill_fail_chance(SKILL_WEAPONS, 30, SKILL_ADEPT, 3)))
+			to_chat(user, SPAN_WARNING("You fumble with \the [src], throwing off your aim!"))
+			M.stop_aiming(src)
+		else
+			M.setClickCooldown(DEFAULT_QUICK_COOLDOWN) // Spam prevention, essentially.
+			M.visible_message(SPAN_DANGER("\The [M] pulls the trigger reflexively!"))
+			Fire(aiming_at, M)
+			if(M.aiming)
+				M.aiming.toggle_active(FALSE, TRUE)

--- a/code/modules/projectiles/targeting/targeting_gun.dm
+++ b/code/modules/projectiles/targeting/targeting_gun.dm
@@ -12,10 +12,4 @@
 //Compute how to fire.....
 //Return 1 if a target was found, 0 otherwise.
 /obj/item/gun/proc/PreFire(var/atom/A, var/mob/living/user, var/params)
-	if(!user.aiming)
-		user.aiming = new(user)
-	user.face_atom(A)
-	if(ismob(A) && user.aiming)
-		user.aiming.aim_at(A, src)
-		return 1
-	return 0
+	return istype(user) && user.aim_at(A, src)

--- a/code/modules/projectiles/targeting/targeting_mob.dm
+++ b/code/modules/projectiles/targeting/targeting_mob.dm
@@ -1,5 +1,6 @@
-/mob/living/var/obj/aiming_overlay/aiming
-/mob/living/var/list/aimed = list()
+/mob/living
+	var/obj/aiming_overlay/aiming
+	var/list/aimed_at_by
 
 /mob/verb/toggle_gun_mode()
 	set name = "Toggle Gun Mode"
@@ -31,6 +32,6 @@
 	if(aiming)
 		qdel(aiming)
 		aiming = null
-	aimed.Cut()
+	QDEL_NULL_LIST(aimed_at_by)
 	return ..()
 

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -169,9 +169,10 @@
 	forceMove(get_turf(target))
 	START_PROCESSING(SSobj, src)
 
-	aiming_at.aimed |= src
+	LAZYDISTINCTADD(aiming_at.aimed_at_by, src)
 	toggle_active(1)
 	locked = 0
+	
 	update_icon()
 	lock_time = world.time + 35
 	events_repository.register(/decl/observ/moved, owner, src, /obj/aiming_overlay/proc/update_aiming)
@@ -219,7 +220,7 @@
 	if(aiming_at)
 		events_repository.unregister(/decl/observ/moved, aiming_at, src)
 		events_repository.unregister(/decl/observ/destroyed, aiming_at, src)
-		aiming_at.aimed -= src
+		LAZYREMOVE(aiming_at.aimed_at_by, src)
 		aiming_at = null
 
 	aiming_with = null

--- a/code/modules/projectiles/targeting/targeting_triggers.dm
+++ b/code/modules/projectiles/targeting/targeting_triggers.dm
@@ -3,29 +3,27 @@
 	return
 
 /mob/living/trigger_aiming(var/trigger_type)
-	if(!aimed.len)
-		return
-	for(var/obj/aiming_overlay/AO in aimed)
+	for(var/obj/aiming_overlay/AO as anything in aimed_at_by)
 		if(AO.aiming_at == src)
 			AO.update_aiming()
 			if(AO.aiming_at == src)
 				AO.trigger(trigger_type)
 				AO.update_aiming_deferred()
 
+/mob/living/proc/aim_at(var/atom/target, var/obj/item/with)
+	if(!ismob(target) || !istype(with) || incapacitated())
+		return FALSE
+	if(!aiming)
+		aiming = new(src)
+	face_atom(target)
+	aiming.aim_at(target, with)
+	return TRUE
+
 /obj/aiming_overlay/proc/trigger(var/perm)
 	if(!owner || !aiming_with || !aiming_at || !locked)
-		return
+		return FALSE
 	if(perm && (target_permissions & perm))
-		return
+		return FALSE
 	if(!owner.canClick())
-		return
-	if(prob(owner.skill_fail_chance(SKILL_WEAPONS, 30, SKILL_ADEPT, 3)))
-		to_chat(owner, "<span class='warning'>You fumble with the gun, throwing your aim off!</span>")
-		owner.stop_aiming(aiming_with)
-		return
-	owner.setClickCooldown(DEFAULT_QUICK_COOLDOWN) // Spam prevention, essentially.
-	owner.visible_message("<span class='danger'>\The [owner] pulls the trigger reflexively!</span>")
-	var/obj/item/gun/G = aiming_with
-	if(istype(G))
-		G.Fire(aiming_at, owner)
-	toggle_active(FALSE, TRUE)
+		return FALSE
+	return aiming_with.handle_reflexive_fire(owner, aiming_at)


### PR DESCRIPTION
Inspired by the unjust closure of https://github.com/Aurorastation/Aurora.3/pull/10930.

:cl:
tweak: You can now aim at people with fruit, and will throw the fruit if they trigger reflex fire.
/:cl: