### PR TITLE
Misc Z-Mimic Patch

### DIFF
--- a/code/__defines/zmimic.dm
+++ b/code/__defines/zmimic.dm
@@ -8,7 +8,7 @@
 #define ZM_ALLOW_LIGHTING  4	// If this turf should permit passage of lighting.
 #define ZM_ALLOW_ATMOS     8	// If this turf permits passage of air.
 #define ZM_MIMIC_NO_AO    16	// If the turf shouldn't apply regular turf AO and only do Z-mimic AO.
-#define ZM_FIX_BIGTURF    32	// Fix bigturf (greater than world.icon_size) rendering at the cost of breaking object layering a bit. This flag is infectious, so all Z-turfs above this one will also get this flag. Valid on non-zturfs.
+#define ZM_NO_OCCLUDE     32	// Don't occlude below atoms if we're a non-mimic z-turf.
 
 // Convenience flag.
 #define ZM_MIMIC_DEFAULTS (ZM_MIMIC_BELOW|ZM_ALLOW_LIGHTING)
@@ -20,5 +20,5 @@ var/global/list/mimic_defines = list(
 	"ZM_ALLOW_LIGHTING",
 	"ZM_ALLOW_ATMOS",
 	"ZM_MIMIC_NO_AO",
-	"ZM_FIX_BIGTURF"
+	"ZM_NO_OCCLUDE"
 )

--- a/code/controllers/subsystems/skybox.dm
+++ b/code/controllers/subsystems/skybox.dm
@@ -13,6 +13,11 @@ SUBSYSTEM_DEF(skybox)
 	var/star_state = "stars"
 	var/list/skybox_cache = list()
 
+	var/list/space_appearance_cache
+
+/datum/controller/subsystem/skybox/PreInit()
+	build_space_appearances()
+
 /datum/controller/subsystem/skybox/Initialize()
 	. = ..()
 	if(isnull(background_color))
@@ -21,6 +26,19 @@ SUBSYSTEM_DEF(skybox)
 /datum/controller/subsystem/skybox/Recover()
 	background_color = SSskybox.background_color
 	skybox_cache = SSskybox.skybox_cache
+
+/datum/controller/subsystem/skybox/proc/build_space_appearances()
+	space_appearance_cache = new(26)
+	for (var/i in 0 to 25)
+		var/mutable_appearance/dust = mutable_appearance('icons/turf/space_dust.dmi', "[i]")
+		dust.plane = DUST_PLANE
+		dust.alpha = 80
+		dust.blend_mode = BLEND_ADD
+
+		var/mutable_appearance/space = new /mutable_appearance(/turf/space)
+		space.icon_state = "white"
+		space.overlays += dust
+		space_appearance_cache[i + 1] = space.appearance
 
 /datum/controller/subsystem/skybox/proc/get_skybox(z)
 	if(!skybox_cache["[z]"])

--- a/code/controllers/subsystems/zcopy.dm
+++ b/code/controllers/subsystems/zcopy.dm
@@ -18,7 +18,10 @@ SUBSYSTEM_DEF(zcopy)
 	var/openspace_overlays = 0
 	var/openspace_turfs = 0
 
-	// Highest Z level in a given Z-group for absolute layering used by FIX_BIGTURF.
+	var/multiqueue_skips_turf = 0
+	var/multiqueue_skips_object = 0
+
+	// Highest Z level in a given Z-group for absolute layering.
 	// zstm[zlev] = group_max
 	var/list/zlev_maximums = list()
 
@@ -38,7 +41,7 @@ SUBSYSTEM_DEF(zcopy)
 				T.update_mimic()
 				num_upd += 1
 
-		else if (istype(A, /atom/movable/openspace/overlay))
+		else if (istype(A, /atom/movable/openspace/mimic))
 			var/turf/Tloc = A.loc
 			if (TURF_IS_MIMICING(Tloc))
 				Tloc.update_mimic()
@@ -68,7 +71,7 @@ SUBSYSTEM_DEF(zcopy)
 				T.update_mimic()
 				num_turfs += 1
 
-		else if (istype(A, /atom/movable/openspace/overlay))
+		else if (istype(A, /atom/movable/openspace/mimic))
 			qdel(A)
 			num_deleted += 1
 
@@ -79,13 +82,12 @@ SUBSYSTEM_DEF(zcopy)
 	enable()
 
 /datum/controller/subsystem/zcopy/stat_entry()
-	..("Q:{T:[queued_turfs.len - (qt_idex - 1)]|O:[queued_overlays.len - (qo_idex - 1)]} T:{T:[openspace_turfs]|O:[openspace_overlays]}")
+	..("Mx:[json_encode(zlev_maximums)]\n\tQ:{T:[queued_turfs.len - (qt_idex - 1)]|O:[queued_overlays.len - (qo_idex - 1)]}\n\tT:{T:[openspace_turfs]|O:[openspace_overlays]}\n\tSk:{T:[multiqueue_skips_turf]|O:[multiqueue_skips_object]}")
 
 /datum/controller/subsystem/zcopy/Initialize(timeofday)
 	calculate_zstack_limits()
 	// Flush the queue.
 	fire(FALSE, TRUE)
-	return ..()
 
 // If you add a new Zlevel or change Z-connections, call this.
 /datum/controller/subsystem/zcopy/proc/calculate_zstack_limits()
@@ -98,7 +100,7 @@ SUBSYSTEM_DEF(zcopy)
 			if (z - start_zlev > OPENTURF_MAX_DEPTH)
 				log_ss("zcopy", "WARNING: Z-levels [start_zlev] through [z] exceed maximum depth of [OPENTURF_MAX_DEPTH]; layering may behave strangely in this Z-stack.")
 			else if (z - start_zlev > 1)
-				log_ss("zcopy", "Found Z-Stack: [start_zlev] -> [z] = [z - start_zlev] zl")
+				log_ss("zcopy", "Found Z-Stack: [start_zlev] -> [z] = [z - start_zlev + 1] zl")
 			start_zlev = z + 1
 
 	log_ss("zcopy", "Z-Level maximums: [json_encode(zlev_maximums)]")
@@ -126,7 +128,7 @@ SUBSYSTEM_DEF(zcopy)
 		curr_turfs[qt_idex] = null
 		qt_idex += 1
 
-		if (!isturf(T) || !T.below || !(T.z_flags & ZM_MIMIC_BELOW) || !T.z_queued)
+		if (!isturf(T) || !(T.z_flags & ZM_MIMIC_BELOW) || !T.z_queued)
 			if (no_mc_tick)
 				CHECK_TICK
 			else if (MC_TICK_CHECK)
@@ -136,15 +138,42 @@ SUBSYSTEM_DEF(zcopy)
 		// If we're not at our most recent queue position, don't bother -- we're updating again later anyways.
 		if (T.z_queued > 1)
 			T.z_queued -= 1
+			multiqueue_skips_turf += 1
 			if (no_mc_tick)
 				CHECK_TICK
 			else if (MC_TICK_CHECK)
-				return
+				break
+			continue
+
+		// Z-Turf on the bottom-most level, just fake-copy space.
+		// If this is ever true, that turf should always pass this condition, so don't bother cleaning up beyond the Destroy() hook.
+		if (!T.below)	// Z-turf on the bottom-most level, just fake-copy space.
+			if (T.z_flags & ZM_MIMIC_OVERWRITE)
+				T.appearance = SSskybox.space_appearance_cache[(((T.x + T.y) ^ ~(T.x * T.y) + T.z) % 25) + 1]
+				T.name = initial(T.name)
+				T.desc = initial(T.desc)
+				T.gender = initial(T.gender)
+			else
+				// Some openturfs have icons, so we can't overwrite their appearance.
+				if (!T.mimic_underlay)
+					T.mimic_underlay = new(T)
+				var/atom/movable/openspace/turf_proxy/TO = T.mimic_underlay
+				TO.appearance = SSskybox.space_appearance_cache[(((T.x + T.y) ^ ~(T.x * T.y) + T.z) % 25) + 1]
+				TO.name = T.name
+				TO.gender = T.gender	// Need to grab this too so PLURAL works properly in examine.
+				TO.mouse_opacity = initial(TO.mouse_opacity)
+
+			if (no_mc_tick)
+				CHECK_TICK
+			else if (MC_TICK_CHECK)
+				break
 			continue
 
 		if (!T.shadower)	// If we don't have a shadower yet, something has gone horribly wrong.
 			WARNING("Turf [T] at [T.x],[T.y],[T.z] was queued, but had no shadower.")
 			continue
+
+		T.z_generation += 1
 
 		// Get the bottom-most turf, the one we want to mimic.
 		var/turf/Td = T
@@ -162,13 +191,10 @@ SUBSYSTEM_DEF(zcopy)
 			T.z_eventually_space = TRUE
 			t_target = SPACE_PLANE
 
-		if (T.below.z_flags & ZM_FIX_BIGTURF)
-			T.z_flags |= ZM_FIX_BIGTURF	// this flag is infectious
-
 		if (T.z_flags & ZM_MIMIC_OVERWRITE)
 			// This openturf doesn't care about its icon, so we can just overwrite it.
-			if (T.below.bound_overlay)
-				QDEL_NULL(T.below.bound_overlay)
+			if (T.below.mimic_proxy)
+				QDEL_NULL(T.below.mimic_proxy)
 			T.appearance = T.below
 			T.name = initial(T.name)
 			T.desc = initial(T.desc)
@@ -177,9 +203,9 @@ SUBSYSTEM_DEF(zcopy)
 			T.plane = t_target
 		else
 			// Some openturfs have icons, so we can't overwrite their appearance.
-			if (!T.below.bound_overlay)
-				T.below.bound_overlay = new(T)
-			var/atom/movable/openspace/turf_delegate/TO = T.below.bound_overlay
+			if (!T.below.mimic_proxy)
+				T.below.mimic_proxy = new(T)
+			var/atom/movable/openspace/turf_proxy/TO = T.below.mimic_proxy
 			TO.appearance = Td
 			TO.name = T.name
 			TO.gender = T.gender	// Need to grab this too so PLURAL works properly in examine.
@@ -193,15 +219,15 @@ SUBSYSTEM_DEF(zcopy)
 		//   I think it's possible to get this to work without discrete delegate copy objects, but I'd rather this just work.
 		if ((T.below.z_flags & (ZM_MIMIC_BELOW|ZM_MIMIC_OVERWRITE)) == ZM_MIMIC_BELOW)
 			// Below is a delegate, gotta explicitly copy it for recursive copy.
-			if (!T.below.z_delegate)
-				T.below.z_delegate = new(T)
-			var/atom/movable/openspace/delegate_copy/DC = T.below.z_delegate
+			if (!T.below.mimic_above_copy)
+				T.below.mimic_above_copy = new(T)
+			var/atom/movable/openspace/turf_mimic/DC = T.below.mimic_above_copy
 			DC.appearance = T.below
 			DC.mouse_opacity = initial(DC.mouse_opacity)
 			DC.plane = OPENTURF_MAX_PLANE
 
-		else if (T.below.z_delegate)
-			QDEL_NULL(T.below.z_delegate)
+		else if (T.below.mimic_above_copy)
+			QDEL_NULL(T.below.mimic_above_copy)
 
 		// Handle below atoms.
 
@@ -215,7 +241,7 @@ SUBSYSTEM_DEF(zcopy)
 			// Special case: these are merged into the shadower to reduce memory usage.
 			if (object.type == /atom/movable/lighting_overlay)
 				T.shadower.copy_lighting(object)
-			else
+			else	// TODO: Reduce indentation level here? Above block probably could be made an early continue.
 				if (!object.bound_overlay)	// Generate a new overlay if the atom doesn't already have one.
 					object.bound_overlay = new(T)
 					object.bound_overlay.associated_atom = object
@@ -224,39 +250,45 @@ SUBSYSTEM_DEF(zcopy)
 				var/original_type = object.type
 				var/original_z = object.z
 				switch (object.type)
-					if (/atom/movable/openspace/overlay)
-						var/atom/movable/openspace/overlay/OOO = object
+					if (/atom/movable/openspace/mimic)
+						var/atom/movable/openspace/mimic/OOO = object
 						original_type = OOO.mimiced_type
 						override_depth = OOO.override_depth
 						original_z = OOO.original_z
 
-					if (/atom/movable/openspace/turf_delegate, /atom/movable/openspace/delegate_copy)
+					if (/atom/movable/openspace/turf_proxy, /atom/movable/openspace/turf_mimic)
 						// If we're a turf overlay (the mimic for a non-OVERWRITE turf), we need to make sure copies of us respect space parallax too
 						if (T.z_eventually_space)
 							// Yes, this is an awful hack; I don't want to add yet another override_* var.
 							override_depth = OPENTURF_MAX_PLANE - SPACE_PLANE
 
-				if ((T.z_flags & ZM_FIX_BIGTURF) && original_type == /atom/movable/openspace/multiplier)
-					override_depth = turf_depth
-
-				var/atom/movable/openspace/overlay/OO = object.bound_overlay
+				var/atom/movable/openspace/mimic/OO = object.bound_overlay
 
 				// If the OO was queued for destruction but was claimed by another OT, stop the destruction timer.
 				if (OO.destruction_timer)
 					deltimer(OO.destruction_timer)
 					OO.destruction_timer = null
 
-				OO.depth = override_depth || min(T.z - original_z, OPENTURF_MAX_DEPTH)
+				OO.depth = override_depth || min(zlev_maximums[T.z] - original_z, OPENTURF_MAX_DEPTH)
+
+				// These types need to be pushed a layer down for bigturfs to function correctly.
+				switch (original_type)
+					if (/atom/movable/openspace/multiplier, /atom/movable/openspace/turf_mimic, /atom/movable/openspace/turf_proxy)
+						if (OO.depth < OPENTURF_MAX_DEPTH)
+							OO.depth += 1
+
 				OO.mimiced_type = original_type
 				OO.override_depth = override_depth
 				OO.original_z = original_z
 
-				if (!OO.queued)
-					OO.queued = TRUE
-					queued_overlays += OO
+				// Multi-queue to maintain ordering of updates to these
+				//   queueing it multiple times will result in only the most recent
+				//   actually processing.
+				OO.queued += 1
+				queued_overlays += OO
 
 		T.z_queued -= 1
-		if (!no_mc_tick && T.above)
+		if (T.above)
 			T.above.update_mimic()
 
 		if (no_mc_tick)
@@ -272,11 +304,11 @@ SUBSYSTEM_DEF(zcopy)
 		MC_SPLIT_TICK
 
 	while (qo_idex <= curr_ov.len)
-		var/atom/movable/openspace/overlay/OO = curr_ov[qo_idex]
+		var/atom/movable/openspace/mimic/OO = curr_ov[qo_idex]
 		curr_ov[qo_idex] = null
 		qo_idex += 1
 
-		if (QDELETED(OO))
+		if (QDELETED(OO) || !OO.queued)
 			if (no_mc_tick)
 				CHECK_TICK
 			else if (MC_TICK_CHECK)
@@ -292,6 +324,16 @@ SUBSYSTEM_DEF(zcopy)
 				break
 			continue
 
+		// Don't update unless we're at the most recent queue occurrence.
+		if (OO.queued > 1)
+			OO.queued -= 1
+			multiqueue_skips_object += 1
+			if (no_mc_tick)
+				CHECK_TICK
+			else if (MC_TICK_CHECK)
+				break
+			continue
+
 		// Actually update the overlay.
 		if (OO.dir != OO.associated_atom.dir)
 			OO.set_dir(OO.associated_atom.dir)
@@ -300,7 +342,7 @@ SUBSYSTEM_DEF(zcopy)
 		OO.plane = OPENTURF_MAX_PLANE - OO.depth
 
 		OO.opacity = FALSE
-		OO.queued = FALSE
+		OO.queued = 0
 
 		if (OO.bound_overlay)	// If we have a bound overlay, queue it too.
 			OO.update_above()
@@ -316,6 +358,9 @@ SUBSYSTEM_DEF(zcopy)
 
 #define FMT_DEPTH(X) (X == null ? "(null)" : X)
 
+// This is a dummy object used so overlays can be shown in the analyzer.
+/atom/movable/openspace/debug
+
 /client/proc/analyze_openturf(turf/T)
 	set name = "Analyze Openturf"
 	set desc = "Show the layering of an openturf and everything it's mimicking."
@@ -324,21 +369,34 @@ SUBSYSTEM_DEF(zcopy)
 	if (!check_rights(R_DEBUG))
 		return
 
+	var/is_above_space = T.is_above_space()
 	var/list/out = list(
 		"<head><meta charset='utf-8'/></head><body>",
 		"<h1>Analysis of [T] at [T.x],[T.y],[T.z]</h1>",
 		"<b>Queue occurrences:</b> [T.z_queued]",
-		"<b>Above space:</b> Apparent [T.z_eventually_space ? "Yes" : "No"], Actual [T.is_above_space() ? "Yes" : "No"]",
+		"<b>Above space:</b> Apparent [T.z_eventually_space ? "Yes" : "No"], Actual [is_above_space ? "Yes" : "No"] - [T.z_eventually_space == is_above_space ? "<font color='green'>OK</font>" : "<font color='red'>MISMATCH</font>"]",
 		"<b>Z Flags</b>: [english_list(bitfield2list(T.z_flags, global.mimic_defines), "(none)")]",
 		"<b>Has Shadower:</b> [T.shadower ? "Yes" : "No"]",
+		"<b>Has turf proxy:</b> [T.mimic_proxy ? "Yes" : "No"]",
+		"<b>Has above copy:</b> [T.mimic_above_copy ? "Yes" : "No"]",
+		"<b>Has mimic underlay:</b> [T.mimic_underlay ? "Yes" : "No"]",
 		"<b>Below:</b> [!T.below ? "(nothing)" : "[T.below] at [T.below.x],[T.below.y],[T.below.z]"]",
 		"<b>Depth:</b> [FMT_DEPTH(T.z_depth)] [T.z_depth == OPENTURF_MAX_DEPTH ? "(max)" : ""]",
+		"<b>Generation:</b> [T.z_generation]",
 		"<ul>"
 	)
 
 	var/list/found_oo = list(T)
 	for (var/atom/movable/openspace/O in T)
 		found_oo += O
+
+	if (T.shadower.overlays.len)
+		for (var/overlay in T.shadower.overlays)
+			var/atom/movable/openspace/debug/D = new
+			D.appearance = overlay
+			if (D.plane < -10000)	// FLOAT_PLANE
+				D.plane = T.shadower.plane
+			found_oo += D
 
 	sortTim(found_oo, /proc/cmp_planelayer)
 
@@ -367,6 +425,11 @@ SUBSYSTEM_DEF(zcopy)
 		// Flush the list so we can find orphans.
 		atoms_list_list -= "[pl]"
 
+	if (atoms_list_list["[SPACE_PLANE]"])	// Space parallax plane
+		out += "<strong>Space parallax plane</strong> ([SPACE_PLANE])"
+		SSzcopy.debug_fmt_planelist(atoms_list_list["[SPACE_PLANE]"], out, T)
+		atoms_list_list -= "[SPACE_PLANE]"
+
 	log_debug("atoms_list_list => [json_encode(atoms_list_list)]")
 	for (var/key in atoms_list_list)
 		out += "<strong style='color: red;'>Unknown plane: [key]</strong>"
@@ -380,14 +443,14 @@ SUBSYSTEM_DEF(zcopy)
 
 // Yes, I know this proc is a bit of a mess. Feel free to clean it up.
 /datum/controller/subsystem/zcopy/proc/debug_fmt_thing(atom/A, list/out, turf/original)
-	if (istype(A, /atom/movable/openspace/overlay))
-		var/atom/movable/openspace/overlay/OO = A
+	if (istype(A, /atom/movable/openspace/mimic))
+		var/atom/movable/openspace/mimic/OO = A
 		var/atom/movable/AA = OO.associated_atom
 		var/copied_type = AA.type == OO.mimiced_type ? "[AA.type] \[direct\]" : "[AA.type], eventually [OO.mimiced_type]"
 		return "<li>\icon[A] <b>\[Mimic\]</b> plane [A.plane], layer [A.layer], depth [FMT_DEPTH(OO.depth)], associated Z-level [AA.z] - [OO.type] copying [AA] ([copied_type])</li>"
-	else if (istype(A, /atom/movable/openspace/delegate_copy))
-		var/atom/movable/openspace/delegate_copy/DC = A
-		return "<li>\icon[A] <b>\[Turf Delegate Copy\]</b> plane [A.plane], layer [A.layer], Z-level [A.z], delegate of \icon[DC.delegate] [DC.delegate] ([DC.delegate.type])</li>"
+	else if (istype(A, /atom/movable/openspace/turf_mimic))
+		var/atom/movable/openspace/turf_mimic/DC = A
+		return "<li>\icon[A] <b>\[Turf Mimic\]</b> plane [A.plane], layer [A.layer], Z-level [A.z], delegate of \icon[DC.delegate] [DC.delegate] ([DC.delegate.type])</li>"
 	else if (isturf(A))
 		if (A == original)
 			return "<li>\icon[A] <b>\[Turf\]</b> plane [A.plane], layer [A.layer], depth [FMT_DEPTH(A:z_depth)], Z-level [A.z] - [A] ([A.type]) - <font color='green'>SELF</font></li>"
@@ -395,8 +458,10 @@ SUBSYSTEM_DEF(zcopy)
 			return "<li>\icon[A] <b>\[Turf\]</b> <em><font color='#646464'>plane [A.plane], layer [A.layer], depth [FMT_DEPTH(A:z_depth)], Z-level [A.z] - [A] ([A.type])</font></em> - <font color='red'>FOREIGN</font></em></li>"
 	else if (A.type == /atom/movable/openspace/multiplier)
 		return "<li>\icon[A] <b>\[Shadower\]</b> plane [A.plane], layer [A.layer], Z-level [A.z] - [A] ([A.type])</li>"
-	else if (A.type == /atom/movable/openspace/turf_delegate)
-		return "<li>\icon[A] <b>\[Turf Delegate (Mimic)\]</b> plane [A.plane], layer [A.layer], Z-level [A.z] - [A] ([A.type])</li>"
+	else if (A.type == /atom/movable/openspace/debug)	// These are fake objects that exist just to show the shadower's overlays in this list.
+		return "<li>\icon[A] <b>\[Shadower True Overlay\]</b> plane [A.plane], layer [A.layer] - <font color='grey'>VIRTUAL</font></li>"
+	else if (A.type == /atom/movable/openspace/turf_proxy)
+		return "<li>\icon[A] <b>\[Turf Proxy\]</b> plane [A.plane], layer [A.layer], Z-level [A.z] - [A] ([A.type])</li>"
 	else
 		return "<li>\icon[A] <b>\[?\]</b>  plane [A.plane], layer [A.layer], Z-level [A.z] - [A] ([A.type])</li>"
 

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -9,21 +9,6 @@
 	thermal_conductivity = OPEN_HEAT_TRANSFER_COEFFICIENT
 	permit_ao = FALSE
 	z_eventually_space = TRUE
-	var/static/list/dust_cache
-
-/turf/space/proc/build_dust_cache()
-	LAZYINITLIST(dust_cache)
-	for (var/i in 0 to 25)
-		var/image/im = image('icons/turf/space_dust.dmi',"[i]")
-		im.plane = DUST_PLANE
-		im.alpha = 80
-		im.blend_mode = BLEND_ADD
-
-		var/image/I = new()
-		I.appearance = /turf/space
-		I.icon_state = "white"
-		I.overlays += im
-		dust_cache["[i]"] = I
 
 /turf/space/proc/update_starlight()
 	if(config.starlight && (locate(/turf/simulated) in RANGE_TURFS(src, 1)))
@@ -38,9 +23,7 @@
 
 	update_starlight()
 
-	if (!dust_cache)
-		build_dust_cache()
-	appearance = dust_cache["[((x + y) ^ ~(x * y) + z) % 25]"]
+	appearance = SSskybox.space_appearance_cache[(((x + y) ^ ~(x * y) + z) % 25) + 1]
 
 	if(!HasBelow(z))
 		return INITIALIZE_HINT_NORMAL

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -100,8 +100,8 @@
 	if (z_flags & ZM_MIMIC_BELOW)
 		cleanup_zmimic()
 
-	if (bound_overlay)
-		QDEL_NULL(bound_overlay)
+	if (mimic_proxy)
+		QDEL_NULL(mimic_proxy)
 
 	if(connections)
 		connections.erase_all()

--- a/code/modules/multiz/zmimic/mimic_docs.dm
+++ b/code/modules/multiz/zmimic/mimic_docs.dm
@@ -1,0 +1,51 @@
+/*
+Types:
+	openspace/multiplier -> shadows the below level, also copies lighting
+	openspace/mimic -> copies below movables
+	openspace/turf_proxy -> holds the appearance of the below turf for non-OVERWRITE Z-turfs
+	openspace/turf_mimic -> copies openspace/turf_proxy objects
+
+Public API:
+	Notifying Z-Mimic of icon updates:
+	- UPDATE_OO_IF_PRESENT
+		- valid on movables only
+		- if this movable is being copied, update the copies
+		- cheap (if this movable is not being mimiced, this is a null check)
+
+	- atom/update_above()
+		- similar to UPDATE_OO_IF_PRESENT, but for both turfs and movables
+		- less cheap (pretty much just proc-call overhead)
+
+	Checking state:
+	- TURF_IS_MIMICING(turf or any)
+		- value: bool - if the passed turf is z-mimic enabled
+
+	- movable/get_above_oo()
+		- return: list of movables
+		- get a list of every openspace mimic that's copying this atom for things like animate()
+
+	Changing state:
+	- turf/enable_zmimic(extra_flags = 0)
+		- return: bool - FALSE if this turf was already mimicing, TRUE otherwise
+		- Enables z-mimic for this turf, potentially adding extra z_flags.
+		- This will automatically queue the turf for update.
+
+	- turf/disable_zmimic()
+		- return: bool - FALSE if this turf was not mimicing, TRUE otherwise
+		- Disables z-mimic for this turf.
+		- This will clean up associated mimic objects, but they may hang around for a few additional seconds.
+
+	Vars:
+	- turf/z_flags
+		- bitfield
+			- ZM_MIMIC_BELOW: copy below atoms
+			- ZM_MIMIC_OVERWRITE: z-mimic can overwrite this turf's appearance
+			- ZM_ALLOW_LIGHTING: lighting should pass through this turf
+			- ZM_ALLOW_ATMOS: air should pass through this turf
+			- ZM_MIMIC_NO_AO: normal turf AO should be skipped, only do openspace AO (if your turf is not solid, you probably want this)
+			- ZM_NO_OCCLUDE: don't block clicking on below atoms if not OVERWRITE
+
+	- movable/no_z_overlay
+		- bool
+		- Set this to TRUE if you want Z-Mimic to ignore this atom. Atoms with INVISIBLITY_ABSTRACT are automatically ignored; other invisibility values are inherited.
+*/

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -1,6 +1,8 @@
 /atom/movable
-	var/tmp/atom/movable/openspace/overlay/bound_overlay	// The overlay that is directly mirroring us that we proxy movement to.
-	var/no_z_overlay	// If TRUE, this atom will not be drawn on open turfs.
+	/// The mimic (if any) that's *directly* copying us.
+	var/tmp/atom/movable/openspace/mimic/bound_overlay
+	/// If TRUE, this atom is ignored by Z-Mimic.
+	var/no_z_overlay
 
 /atom/movable/forceMove(atom/dest)
 	. = ..(dest)
@@ -32,9 +34,8 @@
 	var/turf/T = loc
 
 	if (TURF_IS_MIMICING(T.above))
-		if (!bound_overlay.queued)
-			SSzcopy.queued_overlays += bound_overlay
-			bound_overlay.queued = TRUE
+		SSzcopy.queued_overlays += bound_overlay
+		bound_overlay.queued += 1
 	else
 		qdel(bound_overlay)
 
@@ -82,11 +83,7 @@
 	plane = OPENTURF_MAX_PLANE
 	layer = MIMICED_LIGHTING_LAYER
 	blend_mode = BLEND_MULTIPLY
-	color = list(
-		SHADOWER_DARKENING_FACTOR, 0, 0,
-		0, SHADOWER_DARKENING_FACTOR, 0,
-		0, 0, SHADOWER_DARKENING_FACTOR
-	)
+	color = SHADOWER_DARKENING_COLOR
 
 /atom/movable/openspace/multiplier/Destroy()
 	var/turf/myturf = loc
@@ -103,8 +100,6 @@
 
 	if (icon_state == LIGHTING_BASE_ICON_STATE)
 		// We're using a color matrix, so just darken the colors across the board.
-		// Bay stores lights as inverted so the lighting PM can invert it for darksight, but
-		//   we don't have a plane master, so invert it again.
 		var/list/c_list = color
 		c_list[CL_MATRIX_RR] *= SHADOWER_DARKENING_FACTOR
 		c_list[CL_MATRIX_RG] *= SHADOWER_DARKENING_FACTOR
@@ -129,26 +124,26 @@
 		// compile_overlays() calls update_above().
 		update_above()
 
-// -- OPENSPACE OVERLAY --
-// todo: rename
+// -- OPENSPACE MIMIC --
 
 // Object used to hold a mimiced atom's appearance.
-/atom/movable/openspace/overlay
+/atom/movable/openspace/mimic
 	plane = OPENTURF_MAX_PLANE
 	var/atom/movable/associated_atom
 	var/depth
-	var/queued = FALSE
+	var/queued = 0
 	var/destruction_timer
 	var/mimiced_type
 	var/original_z
 	var/override_depth
 
-/atom/movable/openspace/overlay/New()
+/atom/movable/openspace/mimic/New()
 	atom_flags |= ATOM_FLAG_INITIALIZED
 	SSzcopy.openspace_overlays += 1
 
-/atom/movable/openspace/overlay/Destroy()
+/atom/movable/openspace/mimic/Destroy()
 	SSzcopy.openspace_overlays -= 1
+	queued = 0
 
 	if (associated_atom)
 		associated_atom.bound_overlay = null
@@ -159,17 +154,17 @@
 
 	return ..()
 
-/atom/movable/openspace/overlay/attackby(obj/item/W, mob/user)
+/atom/movable/openspace/mimic/attackby(obj/item/W, mob/user)
 	to_chat(user, SPAN_NOTICE("\The [src] is too far away."))
 
-/atom/movable/openspace/overlay/attack_hand(mob/user)
+/atom/movable/openspace/mimic/attack_hand(mob/user)
 	to_chat(user, SPAN_NOTICE("You cannot reach \the [src] from here."))
 
-/atom/movable/openspace/overlay/examine(...)
+/atom/movable/openspace/mimic/examine(...)
 	SHOULD_CALL_PARENT(FALSE)
 	. = associated_atom.examine(arglist(args))	// just pass all the args to the copied atom
 
-/atom/movable/openspace/overlay/forceMove(turf/dest)
+/atom/movable/openspace/mimic/forceMove(turf/dest)
 	. = ..()
 	if (TURF_IS_MIMICING(dest))
 		if (destruction_timer)
@@ -179,54 +174,54 @@
 		destruction_timer = addtimer(CALLBACK(src, /datum/.proc/qdel_self), 10 SECONDS, TIMER_STOPPABLE)
 
 // Called when the turf we're on is deleted/changed.
-/atom/movable/openspace/overlay/proc/owning_turf_changed()
+/atom/movable/openspace/mimic/proc/owning_turf_changed()
 	if (!destruction_timer)
 		destruction_timer = addtimer(CALLBACK(src, /datum/.proc/qdel_self), 10 SECONDS, TIMER_STOPPABLE)
 
-// -- TURF DELEGATE --
+// -- TURF PROXY --
 
 // This thing holds the mimic appearance for non-OVERWRITE turfs.
-/atom/movable/openspace/turf_delegate
+/atom/movable/openspace/turf_proxy
 	plane = OPENTURF_MAX_PLANE
 	mouse_opacity = 0
 	no_z_overlay = TRUE  // Only one of these should ever be visible at a time, the mimic logic will handle that.
 
-/atom/movable/openspace/turf_delegate/attackby(obj/item/W, mob/user)
+/atom/movable/openspace/turf_proxy/attackby(obj/item/W, mob/user)
 	loc.attackby(W, user)
 
-/atom/movable/openspace/turf_delegate/attack_hand(mob/user as mob)
+/atom/movable/openspace/turf_proxy/attack_hand(mob/user as mob)
 	loc.attack_hand(user)
 
-/atom/movable/openspace/turf_delegate/attack_generic(mob/user as mob)
+/atom/movable/openspace/turf_proxy/attack_generic(mob/user as mob)
 	loc.attack_generic(user)
 
-/atom/movable/openspace/turf_delegate/examine(mob/examiner)
+/atom/movable/openspace/turf_proxy/examine(mob/examiner)
 	SHOULD_CALL_PARENT(FALSE)
 	. = loc.examine(examiner)
 
 
-// -- DELEGATE COPY --
+// -- TURF MIMIC --
 
-// A type for copying delegates' self-appearance.
-/atom/movable/openspace/delegate_copy
+// A type for copying non-overwrite turfs' self-appearance.
+/atom/movable/openspace/turf_mimic
 	plane = OPENTURF_MAX_PLANE	// These *should* only ever be at the top?
 	mouse_opacity = 0
 	var/turf/delegate
 
-/atom/movable/openspace/delegate_copy/Initialize(mapload, ...)
+/atom/movable/openspace/turf_mimic/Initialize(mapload, ...)
 	. = ..()
 	ASSERT(isturf(loc))
 	delegate = loc:below
 
-/atom/movable/openspace/delegate_copy/attackby(obj/item/W, mob/user)
+/atom/movable/openspace/turf_mimic/attackby(obj/item/W, mob/user)
 	loc.attackby(W, user)
 
-/atom/movable/openspace/delegate_copy/attack_hand(mob/user as mob)
+/atom/movable/openspace/turf_mimic/attack_hand(mob/user as mob)
 	to_chat(user, SPAN_NOTICE("You cannot reach \the [src] from here."))
 
-/atom/movable/openspace/delegate_copy/attack_generic(mob/user as mob)
+/atom/movable/openspace/turf_mimic/attack_generic(mob/user as mob)
 	to_chat(user, SPAN_NOTICE("You cannot reach \the [src] from here."))
 
-/atom/movable/openspace/delegate_copy/examine(mob/examiner)
+/atom/movable/openspace/turf_mimic/examine(mob/examiner)
 	SHOULD_CALL_PARENT(FALSE)
 	. = delegate.examine(examiner)

--- a/code/modules/multiz/zmimic/mimic_turf.dm
+++ b/code/modules/multiz/zmimic/mimic_turf.dm
@@ -2,16 +2,23 @@
 	// Reference to any open turf that might be above us to speed up atom Entered() updates.
 	var/tmp/turf/above
 	var/tmp/turf/below
-	// If we're a delegate z-turf, this holds the appearance of the bottom-most Z-turf in the z-stack.
-	var/tmp/atom/movable/openspace/turf_delegate/bound_overlay
-	// Overlay used to multiply color of all OO overlays at once.
+	/// If we're a non-overwrite z-turf, this holds the appearance of the bottom-most Z-turf in the z-stack.
+	var/tmp/atom/movable/openspace/turf_proxy/mimic_proxy
+	/// Overlay used to multiply color of all OO overlays at once.
 	var/tmp/atom/movable/openspace/multiplier/shadower
-	// If this is a delegate (non-overwrite) Z-turf with a z-turf above, this is the delegate copy that's copying us.
-	var/tmp/atom/movable/openspace/delegate_copy/z_delegate
-	var/tmp/z_queued = 0	// How many times this turf is currently queued - multiple queue occurrences are allowed to ensure update consistency
+	/// If this is a delegate (non-overwrite) Z-turf with a z-turf above, this is the delegate copy that's copying us.
+	var/tmp/atom/movable/openspace/turf_mimic/mimic_above_copy
+	/// If we're at the bottom of the stack, a proxy used to fake a below space turf.
+	var/tmp/atom/movable/openspace/turf_proxy/mimic_underlay
+	/// How many times this turf is currently queued - multiple queue occurrences are allowed to ensure update consistency.
+	var/tmp/z_queued = 0
+	/// If this Z-turf leads to space, uninterrupted.
 	var/tmp/z_eventually_space = FALSE
 	var/z_flags = 0
+
+	// debug
 	var/tmp/z_depth
+	var/tmp/z_generation = 0
 
 /turf/Entered(atom/movable/thing, turf/oldLoc)
 	. = ..()
@@ -27,11 +34,10 @@
 	if (!(z_flags & ZM_MIMIC_BELOW))
 		return
 
-	if (below)
-		z_queued += 1
-		SSzcopy.queued_turfs += src
+	z_queued += 1
+	SSzcopy.queued_turfs += src
 
-// Enables Z-mimic for a turf that didn't already have it enabled.
+/// Enables Z-mimic for a turf that didn't already have it enabled.
 /turf/proc/enable_zmimic(additional_flags = 0)
 	if (z_flags & ZM_MIMIC_BELOW)
 		return FALSE
@@ -40,15 +46,16 @@
 	setup_zmimic(FALSE)
 	return TRUE
 
-// Disables Z-mimic for a turf.
+/// Disables Z-mimic for a turf.
 /turf/proc/disable_zmimic()
 	if (!(z_flags & ZM_MIMIC_BELOW))
 		return FALSE
 
 	z_flags &= ~ZM_MIMIC_BELOW
 	cleanup_zmimic()
+	return TRUE
 
-// Sets up Z-mimic for this turf. You shouldn't call this directly 99% of the time.
+/// Sets up Z-mimic for this turf. You shouldn't call this directly 99% of the time.
 /turf/proc/setup_zmimic(mapload)
 	if (shadower)
 		CRASH("Attempt to enable Z-mimic on already-enabled turf!")
@@ -59,21 +66,22 @@
 		below = under
 		below.above = src
 
-	if (!(z_flags & ZM_MIMIC_OVERWRITE) && mouse_opacity)
+	if (!(z_flags & (ZM_MIMIC_OVERWRITE|ZM_NO_OCCLUDE)) && mouse_opacity)
 		mouse_opacity = 2
 
 	update_mimic(!mapload)	// Only recursively update if the map isn't loading.
 
-// Cleans up Z-mimic objects for this turf. You shouldn't call this directly 99% of the time.
+/// Cleans up Z-mimic objects for this turf. You shouldn't call this directly 99% of the time.
 /turf/proc/cleanup_zmimic()
 	SSzcopy.openspace_turfs -= 1
 	// Don't remove ourselves from the queue, the subsystem will explode. We'll naturally fall out of the queue.
 	z_queued = 0
 
 	QDEL_NULL(shadower)
-	QDEL_NULL(z_delegate)
+	QDEL_NULL(mimic_above_copy)
+	QDEL_NULL(mimic_underlay)
 
-	for (var/atom/movable/openspace/overlay/OO in src)
+	for (var/atom/movable/openspace/mimic/OO in src)
 		OO.owning_turf_changed()
 
 	if (above)


### PR DESCRIPTION
Updates Z-Mimic from the upstream O7 revision, plus changes how space appearance caching works a bit.
- FIX_BIGTURF is dead, bigturfs just work now.
- Z-Turfs can be on the bottom of the stack now, they'll just copy space.
- Click occlusion for non-OVERWRITES can now be opted out of.
- Fixed some update ordering issues for movables.
- Renamed openspace types to be more clear.

Space appearance caching is now on SSskybox as SSzcopy needs to be able to access it as well.
