### PR TITLE
Added update/reaction deferral to chemistry procs, optimized fluids.

### DIFF
--- a/code/__defines/fluids.dm
+++ b/code/__defines/fluids.dm
@@ -1,10 +1,11 @@
-#define FLUID_EVAPORATION_POINT 1          // Depth a fluid begins self-deleting
-#define FLUID_PUDDLE 25
-#define FLUID_SHALLOW 200                  // Depth shallow icon is used
-#define FLUID_OVER_MOB_HEAD 300
-#define FLUID_DEEP 800                     // Depth deep icon is used
-#define FLUID_MAX_DEPTH FLUID_DEEP*4       // Arbitrary max value for flooding.
-#define FLUID_PUSH_THRESHOLD 20            // Amount of water flow needed to push items.
+#define FLUID_QDEL_POINT 1           // Depth a fluid begins self-deleting
+#define FLUID_MINIMUM_TRANSFER 10    // Minimum amount that a flowing fluid will transfer from one turf to another.
+#define FLUID_PUDDLE 25              // Minimum total depth that a fluid needs before it will start spreading.
+#define FLUID_SHALLOW 200            // Depth shallow icon is used
+#define FLUID_OVER_MOB_HEAD 300      // Depth icon layers over mobs.
+#define FLUID_DEEP 800               // Depth deep icon is used
+#define FLUID_MAX_DEPTH FLUID_DEEP*4 // Arbitrary max value for flooding.
+#define FLUID_PUSH_THRESHOLD 20      // Amount of flow needed to push items.
 
 // Expects /turf for T.
 #define ADD_ACTIVE_FLUID_SOURCE(T)    SSfluids.water_sources[T] = TRUE

--- a/code/controllers/subsystems/initialization/materials.dm
+++ b/code/controllers/subsystems/initialization/materials.dm
@@ -133,17 +133,6 @@ SUBSYSTEM_DEF(materials)
 		if(random.randomize_data(temperature))
 			return random.type
 
-// This is a fairly hacky way of preventing multiple on_reagent_change() calls being fired within the same tick.
-/datum/controller/subsystem/materials/proc/queue_reagent_change(var/atom/changing)
-	if(!pending_reagent_change[changing])
-		pending_reagent_change[changing] = TRUE
-		addtimer(CALLBACK(src, .proc/do_reagent_change, changing), 0)
-
-/datum/controller/subsystem/materials/proc/do_reagent_change(var/atom/changing)
-	pending_reagent_change -= changing
-	if(!QDELETED(changing))
-		changing.on_reagent_change()
-
 /datum/controller/subsystem/materials/proc/get_cocktails_by_primary_ingredient(var/primary)
 	. = cocktails_by_primary_ingredient[primary]
 

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(ticker)
 	name = "Ticker"
-	wait = 10
+	wait = 1 SECOND
 	priority = SS_PRIORITY_TICKER
 	init_order = SS_INIT_TICKER
 	flags = SS_NO_TICK_CHECK | SS_KEEP_TIMING

--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -98,9 +98,12 @@
 //general version
 /datum/recipe/proc/make(var/obj/container)
 	var/obj/result_obj = new result(container)
-	for (var/obj/O in (container.get_contained_external_atoms()-result_obj))
-		O.reagents.trans_to_obj(result_obj, O.reagents.total_volume)
-		qdel(O)
+	var/list/contained_atoms = container.get_contained_external_atoms()
+	if(contained_atoms)
+		contained_atoms -= result_obj
+		for(var/obj/O in contained_atoms)
+			O.reagents.trans_to_obj(result_obj, O.reagents.total_volume)
+			qdel(O)
 	container.reagents.clear_reagents()
 	return result_obj
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -307,7 +307,9 @@ its easier to just keep the beam vertical.
 	return
 
 /atom/proc/get_contained_external_atoms()
-	. = contents
+	for(var/atom/movable/AM in contents)
+		if(!QDELETED(AM) && AM.simulated)
+			LAZYADD(., AM)
 
 /atom/proc/dump_contents()
 	for(var/thing in get_contained_external_atoms())

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -338,3 +338,7 @@
 		M.make_grab(src)
 		return 0
 	. = ..()
+
+/atom/movable/proc/pushed(var/pushdir)
+	set waitfor = FALSE
+	step(src, pushdir)

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -456,7 +456,8 @@ Class Procs:
 		.+= lock.get_req_access()
 
 /obj/machinery/get_contained_external_atoms()
-	. = (contents - component_parts)
+	. = ..()
+	. -= component_parts
 
 /obj/machinery/proc/get_auto_access()
 	var/area/A = get_area(src)

--- a/code/game/objects/effects/fluids.dm
+++ b/code/game/objects/effects/fluids.dm
@@ -10,9 +10,8 @@
 	alpha = 0
 	color = COLOR_OCEAN
 
-	var/list/neighbors = list()
 	var/last_flow_strength = 0
-	var/next_fluid_act = 0
+	var/last_flow_dir = 0
 	var/update_lighting = FALSE
 
 /obj/effect/fluid/airlock_crush()
@@ -23,47 +22,40 @@
 	return FALSE
 
 /obj/effect/fluid/on_reagent_change()
-	if(reagents?.total_volume <= FLUID_EVAPORATION_POINT)
-		qdel(src)
-		return
 	. = ..()
 	ADD_ACTIVE_FLUID(src)
+	for(var/checkdir in global.cardinal)
+		var/obj/effect/fluid/F = locate() in get_step(loc, checkdir)
+		if(F)
+			ADD_ACTIVE_FLUID(F)
 	update_lighting = TRUE
-	queue_icon_update()
+	update_icon()
 
 /obj/effect/fluid/Initialize()
-	START_PROCESSING(SSobj, src)
 	atom_flags |= ATOM_FLAG_OPEN_CONTAINER
 	icon_state = ""
 	create_reagents(FLUID_MAX_DEPTH)
 	. = ..()
 	var/turf/simulated/T = get_turf(src)
-	if(!isturf(T) || T.flooded)
+	if(!isturf(T) || !T.CanFluidPass())
 		return INITIALIZE_HINT_QDEL
 	if(istype(T))
 		T.unwet_floor(FALSE)
-	for(var/checkdir in global.cardinal)
-		var/obj/effect/fluid/F = locate() in get_step(src, checkdir)
-		if(F)
-			LAZYSET(neighbors, F, TRUE)
-			LAZYSET(F.neighbors, src, TRUE)
-			ADD_ACTIVE_FLUID(F)
-	ADD_ACTIVE_FLUID(src)
 
 /obj/effect/fluid/Destroy()
 	var/turf/simulated/T = get_turf(src)
-	STOP_PROCESSING(SSobj, src)
-	for(var/thing in neighbors)
-		var/obj/effect/fluid/F = thing
-		LAZYREMOVE(F.neighbors, src)
-		ADD_ACTIVE_FLUID(F)
-	neighbors = null
+	for(var/checkdir in global.cardinal)
+		var/obj/effect/fluid/F = locate() in get_step(T, checkdir)
+		if(F)
+			ADD_ACTIVE_FLUID(F)
 	REMOVE_ACTIVE_FLUID(src)
+	SSfluids.pending_flows -= src
 	. = ..()
 	if(istype(T))
-		if(length(T.zone?.fuel_objs))
+		if(T.zone)
 			T.zone.fuel_objs -= src
-		T.wet_floor()
+		if(reagents?.total_volume > 0)
+			T.wet_floor()
 
 /obj/effect/fluid/proc/remove_fuel(var/amt)
 	for(var/rtype in reagents.reagent_volumes)
@@ -81,40 +73,6 @@
 		var/decl/material/liquid/fuel = GET_DECL(rtype)
 		if(fuel.fuel_value)
 			. += REAGENT_VOLUME(reagents, rtype) * fuel.fuel_value
-
-/obj/effect/fluid/Process()
-
-	// Evaporation! TODO: add fumes to the air from this, if appropriate.
-	if(reagents.total_volume > FLUID_EVAPORATION_POINT && reagents.total_volume <= FLUID_PUDDLE && prob(15))
-		reagents.remove_any(min(reagents.total_volume, 1))
-
-	if(reagents.total_volume <= FLUID_EVAPORATION_POINT)
-		qdel(src)
-		return
-
-	// Apply reagent interactions to everything on the turf, and the turf itself.
-	var/list/pushable
-	if(!isturf(loc))
-		return
-
-	loc.fluid_act(reagents)
-	var/pushing = (world.time >= next_fluid_act && reagents.total_volume > FLUID_SHALLOW && last_flow_strength >= 10)
-	for(var/thing in loc.contents)
-		if(thing == src)
-			continue
-		var/atom/movable/AM = thing
-		if(!AM.simulated)
-			continue
-		AM.fluid_act(reagents)
-		if(!QDELETED(AM) && pushing && AM.is_fluid_pushable(last_flow_strength))
-			LAZYADD(pushable, AM)
-
-	if(length(pushable))
-		next_fluid_act = world.time + SSfluids.fluid_act_delay
-		if(prob(1))
-			playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
-		for(var/thing in pushable)
-			step(thing, dir)
 
 /obj/effect/fluid/on_update_icon()
 
@@ -143,6 +101,7 @@
 		APPLY_FLUID_OVERLAY("deep_still")
 	else
 		APPLY_FLUID_OVERLAY("ocean")
+	compile_overlays()
 
 	if(update_lighting)
 		update_lighting = FALSE
@@ -171,9 +130,7 @@
 	..()
 	var/turf/T = get_turf(src)
 	if(istype(T))
-		var/obj/effect/fluid/F = locate() in T
-		if(!F) F = new(T)
-		F.reagents.add_reagent(fluid_type, fluid_initial)
+		T.add_fluid(fluid_type, fluid_initial)
 	return INITIALIZE_HINT_QDEL
 
 /obj/effect/fluid_mapped/fuel

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -55,7 +55,7 @@
 		if(!T)
 			return
 
-		var/trans_amt = FLUID_EVAPORATION_POINT
+		var/trans_amt = FLUID_QDEL_POINT
 		if(user.a_intent == I_HURT)
 			trans_amt = round(FLUID_PUDDLE * 0.25)
 			user.visible_message(SPAN_DANGER("\The [user] begins to aggressively mop \the [T]!"))

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -59,7 +59,7 @@
 			return
 		user.visible_message(SPAN_NOTICE("\The [user] starts scrubbing \the [T]."))
 		if(do_after(user, 8 SECONDS, T) && reagents?.total_volume)
-			reagents.splash(T, FLUID_EVAPORATION_POINT)
+			reagents.splash(T, FLUID_QDEL_POINT)
 			to_chat(user, SPAN_NOTICE("You scrub \the [target] clean."))
 			cleaned = TRUE
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -1,3 +1,5 @@
+var/global/list/hygiene_props = list()
+
 //todo: toothbrushes, and some sort of "toilet-filthinator" for the hos
 /obj/structure/hygiene
 	var/next_gurgle = 0
@@ -8,11 +10,11 @@
 
 /obj/structure/hygiene/Initialize()
 	. = ..()
-	SSfluids.hygiene_props += src
+	global.hygiene_props += src
 	START_PROCESSING(SSobj, src)
 
 /obj/structure/hygiene/Destroy()
-	SSfluids.hygiene_props -= src
+	global.hygiene_props -= src
 	STOP_PROCESSING(SSobj, src)
 	. = ..()
 

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -14,7 +14,7 @@
 	if(locate(/obj/effect/flood) in src)
 		return
 
-	if(get_fluid_depth() > FLUID_EVAPORATION_POINT)
+	if(get_fluid_depth() > FLUID_QDEL_POINT)
 		return
 
 	if(wet_val < wet && !overwrite)

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -74,3 +74,41 @@
 		REMOVE_ACTIVE_FLUID_SOURCE(src)
 		for(var/obj/effect/fluid/F in src)
 			ADD_ACTIVE_FLUID(F)
+
+/turf/proc/add_fluid(var/fluid_type, var/fluid_amount, var/defer_update)
+	var/obj/effect/fluid/F = locate() in src
+	if(!F)
+		F = new(src)
+	if(!QDELETED(F))
+		F.reagents.add_reagent(fluid_type, min(fluid_amount, FLUID_MAX_DEPTH - F.reagents.total_volume), defer_update = defer_update)
+
+/turf/proc/get_physical_height()
+	return 0
+
+/turf/fluid_act(var/datum/reagents/fluids)
+	fluids.touch(src)
+	for(var/atom/movable/AM as anything in get_contained_external_atoms())
+		AM.fluid_act(fluids)
+
+/turf/proc/remove_fluids(var/amount, var/defer_update)
+	var/obj/effect/fluid/F = locate() in src
+	if(QDELETED(F) || !F.reagents?.total_volume)
+		return
+	F.reagents.remove_any(amount, defer_update = defer_update)
+	if(defer_update && !QDELETED(F.reagents))
+		SSfluids.holders_to_update[F.reagents] = TRUE
+
+/turf/proc/transfer_fluids_to(var/turf/target, var/amount, var/defer_update)
+	var/obj/effect/fluid/F = locate() in src
+	if(!F || !F.reagents?.total_volume)
+		return
+	var/obj/effect/fluid/other = locate() in target
+	if(!other)
+		other = new(target)
+	if(!QDELETED(other) && other.reagents)
+		F.reagents.trans_to_holder(other.reagents, min(F.reagents.total_volume, min(FLUID_MAX_DEPTH - other.reagents.total_volume, amount)), defer_update = defer_update)
+		if(defer_update)
+			if(!QDELETED(F.reagents))
+				SSfluids.holders_to_update[F.reagents] = TRUE
+			if(!QDELETED(other.reagents))
+				SSfluids.holders_to_update[other.reagents] = TRUE

--- a/code/modules/ZAS/Zone.dm
+++ b/code/modules/ZAS/Zone.dm
@@ -150,7 +150,6 @@ Class Procs:
 
 	// Update fires.
 	if(air.temperature >= FLAMMABLE_GAS_FLASHPOINT && !(src in SSair.active_fire_zones) && air.check_combustibility() && contents.len)
-
 		var/turf/T = pick(contents)
 		if(istype(T))
 			T.create_fire(vsc.fire_firelevel_multiplier)
@@ -159,6 +158,7 @@ Class Procs:
 	if(air.check_tile_graphic(graphic_add, graphic_remove))
 		for(var/turf/simulated/T in contents)
 			T.update_graphic(graphic_add, graphic_remove)
+			CHECK_TICK
 		graphic_add.len = 0
 		graphic_remove.len = 0
 
@@ -166,6 +166,7 @@ Class Procs:
 	for(var/connection_edge/E in edges)
 		if(E.sleeping)
 			E.recheck()
+			CHECK_TICK
 
 	// Handle condensation from the air.
 	if(!condensing)
@@ -198,7 +199,7 @@ Class Procs:
 				var/obj/effect/fluid/F = locate() in flooding
 				if(!F) F = new(flooding)
 				F.reagents.add_reagent(g, condense_amt * REAGENT_UNITS_PER_GAS_MOLE)
-				CHECK_TICK
+		CHECK_TICK
 	condensing = FALSE
 
 /zone/proc/dbg_data(mob/M)

--- a/code/modules/admin/verbs/fluids.dm
+++ b/code/modules/admin/verbs/fluids.dm
@@ -17,10 +17,8 @@
 	if(!reagent_type || !user || !check_rights(R_SPAWN))
 		return
 	var/turf/flooding = get_turf(user)
-	for(var/thing in RANGE_TURFS(flooding, spawn_range))
-		var/obj/effect/fluid/F = locate() in thing
-		if(!F) F = new(thing)
-		F.reagents.add_reagent(reagent_type, reagent_amount)
+	for(var/turf/T as anything in RANGE_TURFS(flooding, spawn_range))
+		T.add_fluid(reagent_type, reagent_amount)
 
 /datum/admins/proc/jump_to_fluid_source()
 

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -90,7 +90,7 @@
 		update_name()
 		if(do_after(user,30, progress = 1))
 			user.visible_message("\The [user] finishes wiping off the [A]!")
-			reagents.splash(A, FLUID_EVAPORATION_POINT)
+			reagents.splash(A, FLUID_QDEL_POINT)
 
 /obj/item/chems/glass/rag/attack(atom/target, mob/user , flag)
 	if(isliving(target))

--- a/code/modules/events/toilets.dm
+++ b/code/modules/events/toilets.dm
@@ -7,7 +7,7 @@
 /datum/event/toilet_clog/start()
 	var/clog_amt = rand(clog_min,clog_max)
 	var/clog_severity = rand(clog_severity_min, clog_severity_max)
-	var/list/toilets = SSfluids.hygiene_props.Copy()
+	var/list/toilets = global.hygiene_props.Copy()
 	while(clog_amt && toilets.len)
 		var/obj/structure/hygiene/toilet = pick_n_take(toilets)
 		if((toilet.z in affecting_z) && toilet.clog(clog_severity)) clog_amt--

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -388,7 +388,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 
 /decl/material/proc/touch_turf(var/turf/T, var/amount, var/datum/reagents/holder) // Cleaner cleaning, lube lubbing, etc, all go here
 
-	if(REAGENT_VOLUME(holder, type) < FLUID_EVAPORATION_POINT)
+	if(REAGENT_VOLUME(holder, type) < FLUID_QDEL_POINT)
 		return
 
 	if(istype(T) && dirtiness <= DIRTINESS_CLEAN)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -624,7 +624,9 @@ default behaviour is:
 	return 1
 
 /mob/living/carbon/get_contained_external_atoms()
-	. = contents - (internal_organs|organs)
+	. = ..()
+	. -= internal_organs
+	. -= organs
 
 /mob/proc/can_be_possessed_by(var/mob/observer/ghost/possessor)
 	return istype(possessor) && possessor.client

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -45,7 +45,7 @@
 			else
 				to_chat(user, "<span class='notice'>You remove the label.</span>")
 				label_text = null
-				SSmaterials.queue_reagent_change(src)
+				on_reagent_change()
 		return
 
 


### PR DESCRIPTION
- Reagent addition and removal procs now have an argument that allows general updates to be deferred until later.
- Fluid spreading has been drastically simplified/optimized and should now support turf depth a la Bay (hi @CrimsonShrike).
- Fluid interactions are currently not hooked in to code as they turned out to be the primary reason fluids were killing the master controller. I'm going to look into a permanent solution to them but for now people will need to splash acid with a beaker instead of a vat.

Post-optimizing (Tradeship galley, `Spawn-Fluid`, 10, 5000, `/decl/material/liquid/water`):
![image](https://user-images.githubusercontent.com/2468979/116975126-7c301d80-ad02-11eb-8ad5-fa1b615860a5.png)

Pre-optimizing (as above, with fluid_act disabled in code for a fair comparison):
![image](https://user-images.githubusercontent.com/2468979/116975417-f6f93880-ad02-11eb-894e-7cb29939826f.png)

:cl:
tweak: Fluid interactions with atoms have been disabled until they can be optimized to be less of a server killer. Mobs will still drown, you just won't melt in acid. On the plus side, fluids are more performant now.
/:cl: