### PR TITLE
Allow const use

### DIFF
--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -40,7 +40,7 @@ exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto uses" 'goto '
 exactly 6 "atom/New uses" '^/(obj|atom|area|mob|turf).*/New\('
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
-exactly 3 "unmarked globally scoped variables" -P '^(/|)var/(?!global)'
+exactly 3 "unmarked globally scoped variables" -P '^(/|)var/(?!(global|const))'
 exactly 0 "global-marked member variables" -P '\t(/|)var.*/global/.+'
 exactly 0 "static-marked globally scoped variables" -P '^(/|)var.*/static/.+'
 


### PR DESCRIPTION
Stops `var/const/whatever` vars from failing the code quality checks.