### PR TITLE
Doubleclick to show turf contents is now a pref.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -160,7 +160,8 @@
 
 // Default behavior: ignore double clicks, the second click that makes the doubleclick call already calls for a normal click
 /mob/proc/DblClickOn(var/atom/A, var/params)
-	. = A.show_atom_list_for_turf(src, get_turf(A))
+	if(get_preference_value(/datum/client_preference/show_turf_contents) == global.PREF_DOUBLE_CLICK)
+		. = A.show_atom_list_for_turf(src, get_turf(A))
 
 /*
 	Translates into attack_hand, etc.
@@ -262,8 +263,10 @@
 		return
 	A.AltClick(src)
 
+
 /atom/proc/AltClick(var/mob/user)
-	. = show_atom_list_for_turf(user, get_turf(src))
+	if(user?.get_preference_value(/datum/client_preference/show_turf_contents) == global.PREF_ALT_CLICK)
+		. = show_atom_list_for_turf(user, get_turf(src))
 
 /atom/proc/show_atom_list_for_turf(var/mob/user, var/turf/T)
 	if(T && user.TurfAdjacent(T))

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -17,6 +17,7 @@ var/global/const/PREF_BASIC = "Basic"
 var/global/const/PREF_FULL = "Full"
 var/global/const/PREF_MIDDLE_CLICK = "Middle click"
 var/global/const/PREF_ALT_CLICK = "Alt click"
+var/global/const/PREF_DOUBLE_CLICK = "Double click"
 var/global/const/PREF_CTRL_CLICK = "Ctrl click"
 var/global/const/PREF_CTRL_SHIFT_CLICK = "Ctrl+shift click"
 var/global/const/PREF_HEAR = "Hear"
@@ -266,6 +267,11 @@ var/global/list/_client_preferences_by_type
 				preference_mob.client.images -= marker_image
 			else
 				preference_mob.client.images |= marker_image
+
+/datum/client_preference/show_turf_contents
+	description = "Show turf contents in side panel"
+	key = "TURF_CONTENTS"
+	options = list(PREF_ALT_CLICK, PREF_DOUBLE_CLICK, PREF_OFF)
 
 /********************
 * General Staff Preferences *


### PR DESCRIPTION
:cl:
tweak: Double-clicking to see turf contents is now a preference. You can choose alt click (default), double click or nothing.
/:cl: