### PR TITLE
allows AIs to change their hologram colors on-ship

### DIFF
--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -814,13 +814,15 @@ The _flatIcons list is a cache for generated icon files.
 #define HOLOPAD_SHORT_RANGE 1 //For determining the color of holopads based on whether they're short or long range.
 #define HOLOPAD_LONG_RANGE 2
 
-/proc/getHologramIcon(icon/A, safety=1, noDecolor=FALSE, var/hologram_color=HOLOPAD_SHORT_RANGE)//If safety is on, a new icon is not created.
+/proc/getHologramIcon(icon/A, safety=1, noDecolor=FALSE, var/hologram_color=HOLOPAD_SHORT_RANGE, var/custom_tone)//If safety is on, a new icon is not created.
 	var/icon/flat_icon = safety ? A : new(A)//Has to be a new icon to not constantly change the same icon.
 	if (noDecolor == FALSE)
 		if(hologram_color == HOLOPAD_LONG_RANGE)
 			flat_icon.ColorTone(rgb(225,223,125)) //Light yellow if it's a call to a long-range holopad.
-		else
+		else if(!custom_tone)
 			flat_icon.ColorTone(rgb(125,180,225))//Let's make it bluish.
+		else
+			flat_icon.ColorTone(rgb(HEX_RED(custom_tone), HEX_GREEN(custom_tone), HEX_BLUE(custom_tone)))
 	flat_icon.ChangeOpacity(0.5)//Make it half transparent.
 	var/icon/alpha_mask = new('icons/effects/effects.dmi', "scanline-[hologram_color]")//Scanline effect.
 	flat_icon.AddAlphaMask(alpha_mask)//Finally, let's mix in a distortion effect.

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -110,6 +110,7 @@ var/list/ai_verbs_default = list(
 
 	var/default_ai_icon = /datum/ai_icon/blue
 	var/static/list/custom_ai_icons_by_ckey_and_name
+	var/custom_color_tone //This is a hex, despite being converted to rgb by gethologramicon.
 
 /mob/living/silicon/ai/proc/add_ai_verbs()
 	src.verbs |= ai_verbs_default
@@ -139,7 +140,7 @@ var/list/ai_verbs_default = list(
 	anchored = 1
 	set_density(1)
 
-	holo_icon = getHologramIcon(icon('icons/mob/hologram.dmi',"Face"))
+	holo_icon = getHologramIcon(icon('icons/mob/hologram.dmi',"Face"), custom_color_tone)
 	holo_icon_longrange = getHologramIcon(icon('icons/mob/hologram.dmi',"Face"), hologram_color = HOLOPAD_LONG_RANGE)
 
 	if(istype(L, /datum/ai_laws))
@@ -292,6 +293,17 @@ var/list/ai_verbs_default = list(
 		selected_sprite = new_sprite
 
 	update_icon()
+
+/mob/living/silicon/ai/proc/pick_color()
+	set category = "Silicon Commands"
+	set name = "Set AI Hologram Color"
+	if(stat || !has_power())
+		return
+
+	var/new_color = input("Select or enter a color!", "AI") as color
+	if(new_color)
+		custom_color_tone = new_color
+		to_chat(src, SPAN_NOTICE("You need to change your holopad icon in order for the color change to take effect!"))
 
 /mob/living/silicon/ai/proc/available_icons()
 	. = list()
@@ -536,7 +548,7 @@ var/list/ai_verbs_default = list(
 			if(character_icon)
 				qdel(holo_icon)//Clear old icon so we're not storing it in memory.
 				qdel(holo_icon_longrange)
-				holo_icon = getHologramIcon(icon(character_icon))
+				holo_icon = getHologramIcon(icon(character_icon), custom_tone = custom_color_tone)
 				holo_icon_longrange = getHologramIcon(icon(character_icon), hologram_color = HOLOPAD_LONG_RANGE)
 		else
 			alert("No suitable records found. Aborting.")
@@ -552,7 +564,7 @@ var/list/ai_verbs_default = list(
 		if(choice)
 			qdel(holo_icon)
 			qdel(holo_icon_longrange)
-			holo_icon = getHologramIcon(icon(choice.icon, choice.icon_state), noDecolor=choice.bypass_colorize)
+			holo_icon = getHologramIcon(icon(choice.icon, choice.icon_state), noDecolor=choice.bypass_colorize, custom_tone = custom_color_tone)
 			holo_icon_longrange = getHologramIcon(icon(choice.icon, choice.icon_state), noDecolor=choice.bypass_colorize, hologram_color = HOLOPAD_LONG_RANGE)
 			holo_icon_malf = choice.requires_malf
 	return


### PR DESCRIPTION
## Changelog
:cl:
tweak: AIs can now have a default holopad color tone set, and set their own color tone for on-station/ship holopad rendering.
/:cl: