### PR TITLE
Fix missing argument to bodytype.get_tail

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -730,7 +730,7 @@ var/global/list/damage_icon_parts = list()
 
 /mob/living/carbon/human/set_dir()
 	. = ..()
-	if(. && bodytype.get_tail())
+	if(. && bodytype.get_tail(src))
 		update_tail_showing()
 
 


### PR DESCRIPTION
Solves a downstream issue. Not directly relevant here.