### PR TITLE
Spawn logic stub

### DIFF
--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -486,3 +486,6 @@
 
 /datum/job/proc/check_special_blockers(var/datum/preferences/prefs)
 	return
+
+/datum/job/proc/do_spawn_special(var/mob/living/character)
+	return FALSE

--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -487,5 +487,5 @@
 /datum/job/proc/check_special_blockers(var/datum/preferences/prefs)
 	return
 
-/datum/job/proc/do_spawn_special(var/mob/living/character)
+/datum/job/proc/do_spawn_special(var/mob/living/character, var/mob/new_player/new_player_mob)
 	return FALSE

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -28,6 +28,23 @@
 /datum/job/ai/handle_variant_join(var/mob/living/carbon/human/H, var/alt_title)
 	return H
 
+/datum/job/ai/do_spawn_special(var/mob/living/character)
+	character = character.AIize(move=0) // AIize the character, but don't move them yet
+
+	// is_available for AI checks that there is an empty core available in this list
+	var/obj/structure/aicore/deactivated/C = empty_playable_ai_cores[1]
+	empty_playable_ai_cores -= C
+
+	character.forceMove(C.loc)
+	var/mob/living/silicon/ai/A = character
+	A.on_mob_init()
+
+	AnnounceCyborg(character, job.title, "has been downloaded to the empty core in \the [character.loc.loc]")
+	SSticker.mode.handle_latejoin(character)
+
+	qdel(C)
+	return TRUE
+
 /datum/job/cyborg
 	title = "Robot"
 	event_categories = list("Robot")

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -28,7 +28,7 @@
 /datum/job/ai/handle_variant_join(var/mob/living/carbon/human/H, var/alt_title)
 	return H
 
-/datum/job/ai/do_spawn_special(var/mob/living/character)
+/datum/job/ai/do_spawn_special(var/mob/living/character, var/mob/new_player/new_player_mob)
 	character = character.AIize(move=0) // AIize the character, but don't move them yet
 
 	// is_available for AI checks that there is an empty core available in this list
@@ -39,7 +39,7 @@
 	var/mob/living/silicon/ai/A = character
 	A.on_mob_init()
 
-	AnnounceCyborg(character, job.title, "has been downloaded to the empty core in \the [character.loc.loc]")
+	new_player_mob.AnnounceCyborg(character, title, "has been downloaded to the empty core in \the [character.loc.loc]")
 	SSticker.mode.handle_latejoin(character)
 
 	qdel(C)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -293,23 +293,7 @@
 	character = SSjobs.equip_rank(character, job.title, 1)					//equips the human
 	SScustomitems.equip_custom_items(character)
 
-	// AIs don't need a spawnpoint, they must spawn at an empty core
-	if(character.mind.assigned_role == "AI")
-
-		character = character.AIize(move=0) // AIize the character, but don't move them yet
-
-		// is_available for AI checks that there is an empty core available in this list
-		var/obj/structure/aicore/deactivated/C = empty_playable_ai_cores[1]
-		empty_playable_ai_cores -= C
-
-		character.forceMove(C.loc)
-		var/mob/living/silicon/ai/A = character
-		A.on_mob_init()
-
-		AnnounceCyborg(character, job.title, "has been downloaded to the empty core in \the [character.loc.loc]")
-		SSticker.mode.handle_latejoin(character)
-
-		qdel(C)
+	if(job.do_spawn_special(character)) //This replaces the AI spawn logic with a proc stub. Refer to silicon.dm for the spawn logic.
 		qdel(src)
 		return
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -293,7 +293,7 @@
 	character = SSjobs.equip_rank(character, job.title, 1)					//equips the human
 	SScustomitems.equip_custom_items(character)
 
-	if(job.do_spawn_special(character)) //This replaces the AI spawn logic with a proc stub. Refer to silicon.dm for the spawn logic.
+	if(job.do_spawn_special(character, src)) //This replaces the AI spawn logic with a proc stub. Refer to silicon.dm for the spawn logic.
 		qdel(src)
 		return
 


### PR DESCRIPTION
Implements a stub for special job spawning logic like the AI, so it can be modified easier by mods.
