### PR TITLE
fixes ai hologram choosing

### DIFF
--- a/code/datums/ai/ai_holo.dm
+++ b/code/datums/ai/ai_holo.dm
@@ -11,7 +11,12 @@
 
 
 /decl/ai_holo/proc/may_be_used_by_ai(var/mob/living/silicon/ai/AI)
-	return AI.is_traitor()
+	if(requires_malf)
+		if(AI.malfunctioning)
+			return TRUE
+		else	
+			return FALSE
+	return TRUE
 
 /decl/ai_holo/New()
 	..()

--- a/code/datums/ai/ai_holo.dm
+++ b/code/datums/ai/ai_holo.dm
@@ -11,12 +11,7 @@
 
 
 /decl/ai_holo/proc/may_be_used_by_ai(var/mob/living/silicon/ai/AI)
-	if(requires_malf)
-		if(AI.malfunctioning)
-			return TRUE
-		else	
-			return FALSE
-	return TRUE
+	return !requires_malf || AI.is_traitor()
 
 /decl/ai_holo/New()
 	..()


### PR DESCRIPTION
Fixes a bug with AI hologram choosing. Is_traitor always returns false for non-traitors, meaning you couldn't pick an AI icon.
