### PR TITLE
Atom init optimizations & fixes

### DIFF
--- a/code/_global_vars/lists/objects.dm
+++ b/code/_global_vars/lists/objects.dm
@@ -20,5 +20,3 @@ var/global/list/alphabet_no_vowels = list("b","c","d","f","g","h","j","k","l","m
 var/global/list/full_alphabet =      list("a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x","y","z")
 
 var/global/list/meteor_list = list()
-
-var/global/list/is_currently_exploding = list()

--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -31,6 +31,76 @@
 			return 1
 	return 0
 
+//returns a new list with only atoms that are in typecache L
+/proc/typecache_filter_list(list/atoms, list/typecache)
+	. = list()
+	for(var/thing in atoms)
+		var/atom/A = thing
+		if (typecache[A.type])
+			. += A
+
+/proc/typecache_filter_list_reverse(list/atoms, list/typecache)
+	. = list()
+	for(var/thing in atoms)
+		var/atom/A = thing
+		if(!typecache[A.type])
+			. += A
+
+/proc/typecache_filter_multi_list_exclusion(list/atoms, list/typecache_include, list/typecache_exclude)
+	. = list()
+	for(var/thing in atoms)
+		var/atom/A = thing
+		if(typecache_include[A.type] && !typecache_exclude[A.type])
+			. += A
+
+/proc/range_in_typecache(dist, center, list/typecache)
+	for (var/thing in range(dist, center))
+		var/atom/A = thing
+		if (typecache[A.type])
+			return TRUE
+
+/proc/typecache_first_match(list/target, list/typecache)
+	for (var/thing in target)
+		var/datum/D = thing
+		if (typecache[D.type])
+			return D
+
+//Like typesof() or subtypesof(), but returns a typecache instead of a list
+/proc/typecacheof(path, ignore_root_path, only_root_path = FALSE)
+	if(ispath(path))
+		var/list/types = list()
+		if(only_root_path)
+			types = list(path)
+		else
+			types = ignore_root_path ? subtypesof(path) : typesof(path)
+		var/list/L = list()
+		for(var/T in types)
+			L[T] = TRUE
+		return L
+	else if(islist(path))
+		var/list/pathlist = path
+		var/list/L = list()
+		if(ignore_root_path)
+			for(var/P in pathlist)
+				for(var/T in subtypesof(P))
+					L[T] = TRUE
+		else
+			for(var/P in pathlist)
+				if(only_root_path)
+					L[P] = TRUE
+				else
+					for(var/T in typesof(P))
+						L[T] = TRUE
+		return L
+
+//Checks for specific types in specifically structured (Assoc "type" = TRUE) lists ('typecaches')
+/proc/is_type_in_typecache(atom/A, list/L)
+	if(!L || !L.len || !A)
+
+		return 0
+	return L[A.type]
+
+
 /proc/instances_of_type_in_list(var/atom/A, var/list/L)
 	var/instances = 0
 	for(var/type in L)

--- a/code/datums/repositories/follow.dm
+++ b/code/datums/repositories/follow.dm
@@ -6,6 +6,7 @@ var/global/repository/follow/follow_repository = new()
 	var/list/followed_objects
 	var/list/followed_objects_assoc
 	var/list/followed_subtypes
+	var/list/followed_subtypes_tcache = list()
 
 	var/list/excluded_subtypes = list(
 		/obj/machinery/atmospherics, // Atmos stuff calls initialize time and time again..,
@@ -21,6 +22,10 @@ var/global/repository/follow/follow_repository = new()
 	for(var/fht in subtypesof(/datum/follow_holder))
 		var/datum/follow_holder/fh = fht
 		followed_subtypes[initial(fh.followed_type)] = fht
+		followed_subtypes_tcache += initial(fh.followed_type)
+
+	followed_subtypes_tcache = typecacheof(followed_subtypes_tcache)
+	excluded_subtypes = typecacheof(excluded_subtypes)
 
 /repository/follow/proc/add_subject(var/atom/movable/AM)
 	cache = null
@@ -78,11 +83,6 @@ var/global/repository/follow/follow_repository = new()
 
 	cache.data = L
 	return L
-
-/atom/movable/Initialize()
-	. = ..()
-	if(!is_type_in_list(src, follow_repository.excluded_subtypes) && is_type_in_list(src, follow_repository.followed_subtypes))
-		follow_repository.add_subject(src)
 
 /******************
 * Follow Metadata *

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -19,6 +19,8 @@
 	var/icon_rotation = 0 // And one for rotation as well.
 	var/transform_animate_time = 0 // If greater than zero, transform-based adjustments (scaling, rotating) will visually occur over this time.
 
+	var/tmp/currently_exploding = FALSE
+
 // This is called by the maploader prior to Initialize to perform static modifications to vars set on the map. Intended use case: adjust tag vars on duplicate templates.
 /atom/proc/modify_mapped_vars(map_hash)
 	SHOULD_CALL_PARENT(TRUE)
@@ -275,14 +277,14 @@ its easier to just keep the beam vertical.
 
 /atom/proc/explosion_act(var/severity)
 	SHOULD_CALL_PARENT(TRUE)
-	if(!global.is_currently_exploding[src])
-		global.is_currently_exploding[src] = TRUE
+	if(!currently_exploding)
+		currently_exploding = TRUE
 		. = (severity <= 3)
 		if(.)
 			for(var/atom/movable/AM in contents)
 				AM.explosion_act(severity++)
 			try_detonate_reagents(severity)
-		global.is_currently_exploding -= src
+		currently_exploding = FALSE
 
 /atom/proc/emag_act(var/remaining_charges, var/mob/user, var/emag_source)
 	return NO_EMAG_ACT

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -19,67 +19,6 @@
 	var/icon_rotation = 0 // And one for rotation as well.
 	var/transform_animate_time = 0 // If greater than zero, transform-based adjustments (scaling, rotating) will visually occur over this time.
 
-/atom/New(loc, ...)
-	//atom creation method that preloads variables at creation
-	if(global.use_preloader && (src.type == global._preloader.target_path))//in case the instanciated atom is creating other atoms in New()
-		global._preloader.load(src)
-
-	var/do_initialize = SSatoms.atom_init_stage
-	var/list/created = SSatoms.created_atoms
-	if(do_initialize > INITIALIZATION_INSSATOMS_LATE)
-		args[1] = do_initialize == INITIALIZATION_INNEW_MAPLOAD
-		if(SSatoms.InitAtom(src, args))
-			//we were deleted
-			return
-	else if(created)
-		var/list/argument_list
-		if(length(args) > 1)
-			argument_list = args.Copy(2)
-		if(argument_list || do_initialize == INITIALIZATION_INSSATOMS_LATE)
-			created[src] = argument_list
-
-	if(atom_flags & ATOM_FLAG_CLIMBABLE)
-		verbs += /atom/proc/climb_on
-
-//Called after New if the map is being loaded. mapload = TRUE
-//Called from base of New if the map is not being loaded. mapload = FALSE
-//This base must be called or derivatives must set initialized to TRUE
-//must not sleep
-//Other parameters are passed from New (excluding loc)
-//Must return an Initialize hint. Defined in __DEFINES/subsystems.dm
-
-/atom/proc/Initialize(mapload, ...)
-	SHOULD_CALL_PARENT(TRUE)
-	SHOULD_NOT_SLEEP(TRUE)
-	if(atom_flags & ATOM_FLAG_INITIALIZED)
-		PRINT_STACK_TRACE("Warning: [src]([type]) initialized multiple times!")
-	atom_flags |= ATOM_FLAG_INITIALIZED
-
-	if(light_power && light_range)
-		update_light()
-
-	if(opacity)
-		updateVisibility(src)
-		var/turf/T = loc
-		if(istype(T))
-			T.recalc_atom_opacity()
-
-	return INITIALIZE_HINT_NORMAL
-
-//called if Initialize returns INITIALIZE_HINT_LATELOAD
-/atom/proc/LateInitialize()
-	return
-
-/atom/Destroy()
-	overlays.Cut()
-	underlays.Cut()
-	global.is_currently_exploding -= src
-	QDEL_NULL(reagents)
-	QDEL_NULL(light)
-	if(opacity)
-		updateVisibility(src)
-	. = ..()
-
 // This is called by the maploader prior to Initialize to perform static modifications to vars set on the map. Intended use case: adjust tag vars on duplicate templates.
 /atom/proc/modify_mapped_vars(map_hash)
 	SHOULD_CALL_PARENT(TRUE)

--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -52,14 +52,12 @@
 	return
 
 /atom/Destroy()
-	if (reagents)
-		QDEL_NULL(reagents)
+	QDEL_NULL(reagents)
 
 	LAZYCLEARLIST(our_overlays)
 	LAZYCLEARLIST(priority_overlays)
 
-	if (light)
-		QDEL_NULL(light)
+	QDEL_NULL(light)
 
 	if(opacity)
 		updateVisibility(src)

--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -59,3 +59,29 @@
 	if(opacity)
 		updateVisibility(src)
 	. = ..()
+
+// Movable level stuff
+
+/atom/movable/Destroy()
+	. = ..()
+#ifdef DISABLE_DEBUG_CRASH
+	// meh do nothing. we know what we're doing. pro engineers.
+#else
+	if(!(atom_flags & ATOM_FLAG_INITIALIZED))
+		PRINT_STACK_TRACE("Was deleted before initialization")
+#endif
+
+	for(var/A in src)
+		qdel(A)
+
+	forceMove(null)
+
+	if(LAZYLEN(movement_handlers) && !ispath(movement_handlers[1]))
+		QDEL_NULL_LIST(movement_handlers)
+
+	if (bound_overlay)
+		QDEL_NULL(bound_overlay)
+
+	if(virtual_mob && !ispath(virtual_mob))
+		qdel(virtual_mob)
+		virtual_mob = null

--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -64,7 +64,7 @@
 	if(opacity)
 		updateVisibility(src)
 
-	. = ..()
+	return ..()
 
 // Movable level stuff
 
@@ -75,6 +75,10 @@
 
 	if (virtual_mob && ispath(initial(virtual_mob)))
 		virtual_mob = new virtual_mob(get_turf(src), src)
+
+	// Fire Entered events for freshly created movables.
+	if (!ml && loc)
+		loc.Entered(src, null)
 
 /atom/movable/Destroy()
 	. = ..()

--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -1,0 +1,61 @@
+// Atom-level definitions
+
+/atom/New(loc, ...)
+	//atom creation method that preloads variables at creation
+	if(global.use_preloader && (src.type == global._preloader.target_path))//in case the instanciated atom is creating other atoms in New()
+		global._preloader.load(src)
+
+	var/do_initialize = SSatoms.atom_init_stage
+	var/list/created = SSatoms.created_atoms
+	if(do_initialize > INITIALIZATION_INSSATOMS_LATE)
+		args[1] = do_initialize == INITIALIZATION_INNEW_MAPLOAD
+		if(SSatoms.InitAtom(src, args))
+			//we were deleted
+			return
+	else if(created)
+		var/list/argument_list
+		if(length(args) > 1)
+			argument_list = args.Copy(2)
+		if(argument_list || do_initialize == INITIALIZATION_INSSATOMS_LATE)
+			created[src] = argument_list
+
+	if(atom_flags & ATOM_FLAG_CLIMBABLE)
+		verbs += /atom/proc/climb_on
+
+//Called after New if the map is being loaded. mapload = TRUE
+//Called from base of New if the map is not being loaded. mapload = FALSE
+//This base must be called or derivatives must set initialized to TRUE
+//must not sleep
+//Other parameters are passed from New (excluding loc)
+//Must return an Initialize hint. Defined in __DEFINES/subsystems.dm
+
+/atom/proc/Initialize(mapload, ...)
+	SHOULD_CALL_PARENT(TRUE)
+	SHOULD_NOT_SLEEP(TRUE)
+	if(atom_flags & ATOM_FLAG_INITIALIZED)
+		PRINT_STACK_TRACE("Warning: [src]([type]) initialized multiple times!")
+	atom_flags |= ATOM_FLAG_INITIALIZED
+
+	if(light_power && light_range)
+		update_light()
+
+	if(opacity)
+		updateVisibility(src)
+		var/turf/T = loc
+		if(istype(T))
+			T.recalc_atom_opacity()
+
+	return INITIALIZE_HINT_NORMAL
+
+//called if Initialize returns INITIALIZE_HINT_LATELOAD
+/atom/proc/LateInitialize()
+	return
+
+/atom/Destroy()
+	overlays.Cut()
+	underlays.Cut()
+	QDEL_NULL(reagents)
+	QDEL_NULL(light)
+	if(opacity)
+		updateVisibility(src)
+	. = ..()

--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -52,15 +52,29 @@
 	return
 
 /atom/Destroy()
-	overlays.Cut()
-	underlays.Cut()
-	QDEL_NULL(reagents)
-	QDEL_NULL(light)
+	if (reagents)
+		QDEL_NULL(reagents)
+
+	LAZYCLEARLIST(our_overlays)
+	LAZYCLEARLIST(priority_overlays)
+
+	if (light)
+		QDEL_NULL(light)
+
 	if(opacity)
 		updateVisibility(src)
+
 	. = ..()
 
 // Movable level stuff
+
+/atom/movable/Initialize(ml, ...)
+	. = ..()
+	if (!follow_repository.excluded_subtypes[type] && follow_repository.followed_subtypes_tcache[type])
+		follow_repository.add_subject(src)
+
+	if (virtual_mob && ispath(initial(virtual_mob)))
+		virtual_mob = new virtual_mob(get_turf(src), src)
 
 /atom/movable/Destroy()
 	. = ..()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -111,30 +111,6 @@
 /atom/movable/proc/get_mass()
 	return 1.5
 
-/atom/movable/Destroy()
-	. = ..()
-#ifdef DISABLE_DEBUG_CRASH
-	// meh do nothing. we know what we're doing. pro engineers.
-#else
-	if(!(atom_flags & ATOM_FLAG_INITIALIZED))
-		PRINT_STACK_TRACE("Was deleted before initialization")
-#endif
-
-	for(var/A in src)
-		qdel(A)
-
-	forceMove(null)
-
-	if(LAZYLEN(movement_handlers) && !ispath(movement_handlers[1]))
-		QDEL_NULL_LIST(movement_handlers)
-
-	if (bound_overlay)
-		QDEL_NULL(bound_overlay)
-
-	if(virtual_mob && !ispath(virtual_mob))
-		qdel(virtual_mob)
-		virtual_mob = null
-
 /atom/movable/Bump(var/atom/A, yes)
 	if(!QDELETED(throwing))
 		throwing.hit_atom(A)

--- a/code/modules/mob/observer/virtual/base.dm
+++ b/code/modules/mob/observer/virtual/base.dm
@@ -54,10 +54,8 @@ var/global/list/all_virtual_listeners = list()
 /atom/movable
 	var/mob/observer/virtual/virtual_mob
 
-/atom/movable/Initialize()
-	. = ..()
-	if(shall_have_virtual_mob())
-		virtual_mob = new virtual_mob(get_turf(src), src)
+// There is a hook in the common /atom/movable/Initialize() fn.
+// The below function was also inlined in that function, as nowhere else used it.
 
-/atom/movable/proc/shall_have_virtual_mob()
-	return ispath(initial(virtual_mob))
+// /atom/movable/proc/shall_have_virtual_mob()
+// 	return ispath(initial(virtual_mob))

--- a/nebula.dme
+++ b/nebula.dme
@@ -532,6 +532,7 @@
 #include "code\datums\wires\wires.dm"
 #include "code\game\atoms.dm"
 #include "code\game\atoms_fluids.dm"
+#include "code\game\atoms_init.dm"
 #include "code\game\atoms_movable.dm"
 #include "code\game\atoms_movable_grabs.dm"
 #include "code\game\atoms_temperature.dm"


### PR DESCRIPTION
This should speed up atom init a little, there was some inefficient work being done in Initialize that didn't apply to many types.

Additional changes:
- Fix atoms not triggering Entered() on new (fixes some atoms not being spotted by z-mimic)
- Ports typecaches (this copy is from O7, but that's a port from TG)
- Kills the `is_currently_exploding` global list in favor of an atom var.
- Moves atom init/destruction code to its own file (`atoms_init.dm`)