### PR TITLE
Update helm skill and operator handling

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -23,6 +23,8 @@ var/global/list/overmap_helm_computers
 	var/dy		//coordinates
 	var/speedlimit = 1/(20 SECONDS) //top speed for autopilot, 5
 	var/accellimit = 1 //manual limiter for acceleration
+	/// The mob currently operating the helm - The last one to click one of the movement buttons and be on the overmap screen. Set to `null` for autopilot or when the mob isn't in range.
+	var/mob/current_operator
 
 /obj/machinery/computer/ship/helm/Initialize()
 	. = ..()
@@ -43,6 +45,14 @@ var/global/list/overmap_helm_computers
 
 /obj/machinery/computer/ship/helm/Process()
 	..()
+
+	if (current_operator)
+		if (!linked)
+			to_chat(current_operator, SPAN_DANGER("\The [src]'s controls lock up with an error flashing across the screen: Connection to vessel lost!"))
+			set_operator(null, TRUE)
+		else if (!Adjacent(current_operator) || CanUseTopic(current_operator) != STATUS_INTERACTIVE || !viewing_overmap(current_operator))
+			set_operator(null)
+
 	if (autopilot && dx && dy)
 		var/turf/T = locate(dx,dy,global.using_map.overmap_z)
 		if(linked.loc == T)
@@ -66,7 +76,11 @@ var/global/list/overmap_helm_computers
 			// All other cases, move toward direction
 			else if (speed + acceleration <= speedlimit)
 				linked.accelerate(direction, accellimit)
-		linked.operator_skill = null//if this is on you can't dodge meteors
+
+		if (current_operator)
+			to_chat(current_operator, SPAN_DANGER("\The [src]'s autopilot is active and wrests control from you!"))
+			set_operator(null, TRUE, TRUE)
+
 		return
 
 /obj/machinery/computer/ship/helm/relaymove(var/mob/user, direction)
@@ -74,6 +88,7 @@ var/global/list/overmap_helm_computers
 		if(prob(user.skill_fail_chance(SKILL_PILOT, 50, linked.skill_needed, factor = 1)))
 			direction = turn(direction,pick(90,-90))
 		linked.relaymove(user, direction, accellimit)
+		set_operator(user)
 		return 1
 
 /obj/machinery/computer/ship/helm/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
@@ -213,6 +228,10 @@ var/global/list/overmap_helm_computers
 
 	if (href_list["apilot"])
 		autopilot = !autopilot
+		if (autopilot)
+			set_operator(null, autopilot = TRUE)
+		else if (viewing_overmap(user))
+			set_operator(user)
 
 	if (href_list["manual"])
 		if(!isliving(user))
@@ -222,6 +241,67 @@ var/global/list/overmap_helm_computers
 
 	add_fingerprint(user)
 	updateUsrDialog()
+
+/obj/machinery/computer/ship/helm/unlook(mob/user)
+	. = ..()
+	if (current_operator == user)
+		set_operator(null)
+
+
+/obj/machinery/computer/ship/helm/look(mob/user)
+	. = ..()
+	if (!autopilot)
+		set_operator(user)
+
+
+/**
+ * Updates `current_operator` to the new user, or `null` and ejects the old operator from the overmap view - Only one person on a helm at a time!
+ * Will call `display_operator_change_message()` if `silent` is `FALSE`.
+ * `autopilot` will prevent ejection from the overmap (You want to monitor your autopilot right?) and by passed on to `display_operator_change_message()`.
+ * Skips ghosts and observers to prevent accidental external influencing of flight.
+ */
+/obj/machinery/computer/ship/helm/proc/set_operator(mob/user, silent, autopilot)
+	if (isobserver(user) || user == current_operator)
+		return
+
+	var/mob/old_operator = current_operator
+	current_operator = user
+	linked.update_operator_skill(current_operator)
+	if (!autopilot && old_operator && viewing_overmap(old_operator))
+		addtimer(CALLBACK(src, /obj/machinery/computer/ship/.proc/unlook, old_operator), 0) // Workaround for linter SHOULD_NOT_SLEEP checks.
+
+	log_debug("HELM CONTROL: [current_operator ? current_operator : "NO PILOT"] taking control of [src] from [old_operator ? old_operator : "NO PILOT"] in [get_area(src)]. [autopilot ? "(AUTOPILOT MODE)" : null]")
+
+	if (!silent)
+		display_operator_change_message(old_operator, current_operator, autopilot)
+
+
+/**
+ * Displays visible messages indicating a change in operator.
+ * `autopilot` will affect the displayed message.
+ */
+/obj/machinery/computer/ship/helm/proc/display_operator_change_message(mob/old_operator, mob/new_operator, autopilot)
+	if (!old_operator)
+		new_operator.visible_message(
+			SPAN_NOTICE("\The [new_operator] takes \the [src]'s controls."),
+			SPAN_NOTICE("You take \the [src]'s controls.")
+		)
+	else if (!new_operator)
+		if (autopilot)
+			old_operator.visible_message(
+				SPAN_NOTICE("\The [old_operator] engages \the [src]'s autopilot and releases the controls."),
+				SPAN_NOTICE("You engage \the [src]'s autopilot and release the controls.")
+			)
+		else
+			old_operator.visible_message(
+				SPAN_WARNING("\The [old_operator] releases \the [src]'s controls."),
+				SPAN_WARNING("You release \the [src]'s controls.")
+			)
+	else
+		old_operator.visible_message(
+			SPAN_WARNING("\The [new_operator] takes \the [src]'s controls from \the [old_operator]."),
+			SPAN_DANGER("\The [new_operator] takes \the [src]'s controls from you!")
+		)
 
 
 /obj/machinery/computer/ship/navigation

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -62,8 +62,17 @@ var/global/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 
 
 /obj/effect/overmap/visitable/ship/relaymove(mob/user, direction, accel_limit)
-	operator_skill = user.get_skill_value(SKILL_PILOT)
+	update_operator_skill(user)
 	accelerate(direction, accel_limit)
+
+/**
+ * Updates `operator_skill` to match the current user's skill level, or to null if no user is provided.
+ * Will skip observers to avoid allowing unintended external influences on flight.
+ */
+/obj/effect/overmap/visitable/ship/proc/update_operator_skill(mob/user)
+	if (isobserver(user))
+		return
+	operator_skill = user?.get_skill_value(SKILL_PILOT)
 
 /obj/effect/overmap/visitable/ship/get_scan_data(mob/user)
 	. = ..()


### PR DESCRIPTION
Port of https://github.com/Baystation12/Baystation12/pull/30643

- Fixes ambiguity issues with how the helm decides who's skills are being used to calculate maneuvering and meteor dodging.
- Adds visual messages indicating when someone takes or releases control of a helm.
- Adds debug log messages for the above to allow for easier debugging if this breaks.
- Restricts helm control and overmap view access to a single person (The same person whose skills are being used).

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->

## Changelog
:cl:
bugfix: Ghosts will no longer break skill checks for helm controls.
tweak: Ship helm consoles now only allow a single person to use manual control at a time, including viewing the overmap through the helm.
rscadd: Messages are now displayed whenever another mob takes control of a helm control, to make it outwardly obvious who's skills are used to calculate flight.
admin: Debug log messages were added for helm control changes, for tracking of potential issues on live.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
