### PR TITLE
Replaces return in auxtools_expr_stub with crash message

### DIFF
--- a/code/_helpers/auxtools.dm
+++ b/code/_helpers/auxtools.dm
@@ -1,13 +1,13 @@
 var/global/auxtools_debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
 
-/proc/enable_debugging(mode, port)
-	CRASH("auxtools not loaded")
-
 /proc/auxtools_stack_trace(msg)
 	CRASH(msg)
 
 /proc/auxtools_expr_stub()
-	return
+	CRASH("auxtools not loaded")
+
+/proc/enable_debugging(mode, port)
+	CRASH("auxtools not loaded")
 
 /hook/startup/proc/auxtools_init()
 	if (global.auxtools_debug_server)


### PR DESCRIPTION
No actual difference, but if anyone call this proc, they're will get CRASH message now. 
Something like a port from TG.