### PR TITLE
Staging fixes.

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -20,6 +20,7 @@
 #define ATOM_FLAG_SHOW_REAGENT_NAME       BITFLAG(8) // Reagent presentation name is attached to the atom name
 #define ATOM_FLAG_CAN_BE_PAINTED          BITFLAG(9) // Can be painted using a paint sprayer or similar.
 #define ATOM_FLAG_SHIELD_CONTENTS         BITFLAG(10)// Protects contents from some global effects (Solar storms)
+#define ATOM_FLAG_ADJACENT_EXCEPTION      BITFLAG(11)// Skips adjacent checks for atoms that should always be reachable in window tiles
 
 #define ATOM_IS_CONTAINER(A)              (A.atom_flags & ATOM_FLAG_CONTAINER)
 #define ATOM_IS_OPEN_CONTAINER(A)         (A.atom_flags & ATOM_FLAG_OPEN_CONTAINER)

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -63,11 +63,13 @@ var/global/list/string_slot_flags = list(
 //////////////////////////
 
 /proc/get_mannequin(var/ckey)
+	if(SSatoms.atom_init_stage < INITIALIZATION_INNEW_REGULAR)
+		return
 	if(!mannequins_)
 		mannequins_ = new()
 	. = mannequins_[ckey]
 	if(!.)
-		. = new/mob/living/carbon/human/dummy/mannequin()
+		. = new /mob/living/carbon/human/dummy/mannequin()
 		mannequins_[ckey] = .
 
 /hook/global_init/proc/makeDatumRefLists()

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -110,16 +110,17 @@ Quick adjacency (to turf):
 	This is defined as any dense ATOM_FLAG_CHECKS_BORDER object, or any dense object without throwpass.
 	The border_only flag allows you to not objects (for source and destination squares)
 */
-/turf/proc/ClickCross(var/target_dir, var/border_only, var/target_atom = null)
+/turf/proc/ClickCross(target_dir, border_only, atom/target_atom = null)
 	for(var/obj/O in src)
 		if( !O.density || O == target_atom || O.throwpass) continue // throwpass is used for anything you can click through
 
 		if(O.atom_flags & ATOM_FLAG_CHECKS_BORDER) // windows have throwpass but are on border, check them first
 			if( O.dir & target_dir || O.dir&(O.dir-1) ) // full tile windows are just diagonals mechanically
 				var/obj/structure/window/W = target_atom
-				if(istype(W))
-					if(!W.is_fulltile())	//exception for breaking full tile windows on top of single pane windows
-						return 0
+				if(istype(W) && W.is_fulltile()) //exception for breaking full tile windows on top of single pane windows
+					return 1
+				if(target_atom && (target_atom.atom_flags & ATOM_FLAG_ADJACENT_EXCEPTION)) // exception for atoms that should always be reachable
+					return 1
 				else
 					return 0
 

--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -32,7 +32,7 @@ var/global/list/radial_menus = list()
 		closeToolTip(usr)
 
 /obj/screen/radial/slice/Click(location, control, params)
-	if(usr.client == parent.current_user)
+	if(parent && usr.client == parent.current_user)
 		if(next_page)
 			parent.next_page()
 		else

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -367,5 +367,6 @@
 	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /obj/screen/setup_preview/bg/Click(params)
-	pref?.bgstate = next_in_list(pref.bgstate, pref.bgstate_options)
-	pref?.update_preview_icon()
+	if(pref)
+		pref.bgstate = next_in_list(pref.bgstate, pref.bgstate_options)
+		pref.update_preview_icon()

--- a/code/controllers/subsystems/atoms.dm
+++ b/code/controllers/subsystems/atoms.dm
@@ -23,6 +23,12 @@ SUBSYSTEM_DEF(atoms)
 /datum/controller/subsystem/atoms/Initialize(timeofday)
 	atom_init_stage = INITIALIZATION_INNEW_MAPLOAD
 	InitializeAtoms()
+
+	// Mannequins refuse to spawn prior to atoms init, so refresh them in case anyone connected before init finished.
+	for(var/client/C)
+		if(C.prefs)
+			C.prefs.update_preview_icon()
+
 	return ..()
 
 /datum/controller/subsystem/atoms/proc/InitializeAtoms()

--- a/code/controllers/subsystems/throwing.dm
+++ b/code/controllers/subsystems/throwing.dm
@@ -158,7 +158,9 @@ SUBSYSTEM_DEF(throwing)
 	//done throwing, either because it hit something or it finished moving
 	if(QDELETED(thrownthing))
 		return
+
 	thrownthing.throwing = null
+
 	if (!hit)
 		for (var/thing in get_turf(thrownthing)) //looking for our target on the turf we land on.
 			var/atom/A = thing
@@ -166,7 +168,11 @@ SUBSYSTEM_DEF(throwing)
 				hit = TRUE
 				thrownthing.throw_impact(A, src)
 				break
-		if (!hit)
+		
+		if(QDELETED(thrownthing))
+			return
+		
+		if(!hit)
 			thrownthing.throw_impact(get_turf(thrownthing), src)  // we haven't hit something yet and we still must, let's hit the ground.
 			thrownthing.space_drift(init_dir)
 

--- a/code/datums/outfits/horror_killers.dm
+++ b/code/datums/outfits/horror_killers.dm
@@ -32,8 +32,9 @@
 /decl/hierarchy/outfit/masked_killer/post_equip(var/mob/living/carbon/human/H)
 	..()
 	var/victim = get_mannequin(H.ckey)
-	for(var/obj/item/carried_item in H.get_equipped_items(TRUE))
-		carried_item.add_blood(victim) //Oh yes, there will be blood.. just not blood from the killer because that's odd
+	if(victim)
+		for(var/obj/item/carried_item in H.get_equipped_items(TRUE))
+			carried_item.add_blood(victim) //Oh yes, there will be blood.. just not blood from the killer because that's odd
 
 /decl/hierarchy/outfit/reaper
 	name = "Reaper"

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -539,7 +539,7 @@
 	var/use
 	use = min(charges, user.species.blood_volume - user.vessel.total_volume)
 	if(use > 0)
-		user.vessel.add_reagent(user.species.blood_reagent, use)
+		user.adjust_blood(use)
 		charges -= use
 		statuses += "you regain lost blood"
 		if(!charges)

--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -354,11 +354,12 @@
 /datum/job/proc/get_job_icon()
 	if(!SSjobs.job_icons[title])
 		var/mob/living/carbon/human/dummy/mannequin/mannequin = get_mannequin("#job_icon")
-		dress_mannequin(mannequin)
-		mannequin.set_dir(SOUTH)
-		var/icon/preview_icon = getFlatIcon(mannequin)
-		preview_icon.Scale(preview_icon.Width() * 2, preview_icon.Height() * 2) // Scaling here to prevent blurring in the browser.
-		SSjobs.job_icons[title] = preview_icon
+		if(mannequin)
+			dress_mannequin(mannequin)
+			mannequin.set_dir(SOUTH)
+			var/icon/preview_icon = getFlatIcon(mannequin)
+			preview_icon.Scale(preview_icon.Width() * 2, preview_icon.Height() * 2) // Scaling here to prevent blurring in the browser.
+			SSjobs.job_icons[title] = preview_icon
 	return SSjobs.job_icons[title]
 
 /datum/job/proc/get_unavailable_reasons(var/client/caller)
@@ -389,8 +390,9 @@
 		. = reasons
 
 /datum/job/proc/dress_mannequin(var/mob/living/carbon/human/dummy/mannequin/mannequin)
-	mannequin.delete_inventory(TRUE)
-	equip_preview(mannequin, additional_skips = OUTFIT_ADJUSTMENT_SKIP_BACKPACK)
+	if(mannequin)
+		mannequin.delete_inventory(TRUE)
+		equip_preview(mannequin, additional_skips = OUTFIT_ADJUSTMENT_SKIP_BACKPACK)
 
 /datum/job/proc/is_available(var/client/caller)
 	if(!is_position_available())

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -29,6 +29,7 @@
 	closed_layer = ABOVE_WINDOW_LAYER
 	dir = NORTH
 	explosion_resistance = 25
+	atom_flags = ATOM_FLAG_ADJACENT_EXCEPTION
 
 	//Most blast doors are infrequently toggled and sometimes used with regular doors anyways,
 	//turning this off prevents awkward zone geometry in places like medbay lobby, for example.

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -10,7 +10,7 @@
 
 /obj/machinery/door/firedoor
 	name = "emergency shutter"
-	desc = "Emergency air-tight shutter, capable of sealing off breached areas."
+	desc = "Emergency air-tight shutters, capable of sealing off breached areas."
 	icon = 'icons/obj/doors/hazard/door.dmi'
 	var/panel_file = 'icons/obj/doors/hazard/panel.dmi'
 	var/welded_file = 'icons/obj/doors/hazard/welded.dmi'
@@ -24,6 +24,7 @@
 	closed_layer = ABOVE_WINDOW_LAYER
 	movable_flags = MOVABLE_FLAG_Z_INTERACT
 	pry_mod = 0.75
+	atom_flags = ATOM_FLAG_ADJACENT_EXCEPTION
 
 	//These are frequenly used with windows, so make sure zones can pass.
 	//Generally if a firedoor is at a place where there should be a zone boundery then there will be a regular door underneath it.

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -30,7 +30,8 @@
 	var/open_sound = null
 
 /obj/item/storage/Destroy()
-	QDEL_NULL(storage_ui)
+	if(istype(storage_ui))
+		QDEL_NULL(storage_ui)
 	. = ..()
 
 /obj/item/storage/check_mousedrop_adjacency(var/atom/over, var/mob/user)

--- a/code/game/objects/items/weapons/storage/storage_ui/default.dm
+++ b/code/game/objects/items/weapons/storage/storage_ui/default.dm
@@ -84,7 +84,7 @@
 				M.client.screen -= W
 
 /datum/storage_ui/default/on_post_remove(var/mob/user)
-	if(user?.s_active)
+	if(user && user.s_active) // Using ?. here causes a runtime ('Cannot read 0.s_active'), it shouldn't but it does.
 		user.s_active.show_to(user)
 
 /datum/storage_ui/default/on_hand_attack(var/mob/user)

--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -6,7 +6,7 @@
 	desc = "A low wall section which serves as the base of windows, amongst other things."
 	icon = 'icons/obj/structures/wall_frame.dmi'
 	icon_state = "frame"
-	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CLIMBABLE | ATOM_FLAG_CAN_BE_PAINTED
+	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CLIMBABLE | ATOM_FLAG_CAN_BE_PAINTED | ATOM_FLAG_ADJACENT_EXCEPTION
 	anchored = 1
 	density = 1
 	throwpass = 1

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -402,8 +402,12 @@
 		dat += "<p style='background-color: [job.selection_color]'><br><br><p>"
 		if(job.alt_titles)
 			dat += "<i><b>Alternative titles:</b> [english_list(job.alt_titles)].</i>"
-		send_rsc(user, job.get_job_icon(), "job[ckey(rank)].png")
-		dat += "<img src=job[ckey(rank)].png width=96 height=96 style='float:left;'>"
+
+		var/job_icon = job.get_job_icon()
+		if(job_icon)
+			send_rsc(user, job_icon, "job[ckey(rank)].png")
+			dat += "<img src=job[ckey(rank)].png width=96 height=96 style='float:left;'>"
+
 		if(LAZYLEN(job.department_types) && job.primary_department)
 			var/decl/department/dept = SSjobs.get_department_by_type(job.primary_department)
 			if(dept)

--- a/code/modules/detectivework/evidence/fingerprints.dm
+++ b/code/modules/detectivework/evidence/fingerprints.dm
@@ -12,7 +12,7 @@
 		add_data(F)
 
 /datum/forensics/fingerprints/add_data(var/datum/fingerprint/newprint)
-	if(newprint.completeness <= 0)
+	if(!newprint || newprint.completeness <= 0)
 		return
 	for(var/datum/fingerprint/F in data)
 		if(F.merge(newprint))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -883,12 +883,9 @@
 
 /mob/living/carbon/human/revive()
 
-	if(should_have_organ(BP_HEART))
-		vessel.add_reagent(species.blood_reagent, species.blood_volume-vessel.total_volume)
-		fixblood()
-
 	species.create_organs(src) // Reset our organs/limbs.
 	restore_all_organs()       // Reapply robotics/amputated status from preferences.
+	reset_blood()
 
 	if(!client || !key) //Don't boot out anyone already in the mob.
 		for (var/obj/item/organ/internal/brain/H in world)
@@ -1132,15 +1129,8 @@
 	bone_material = species.bone_material
 	bone_amount =   species.bone_amount
 
-	spawn(0)
-		regenerate_icons()
-		if(vessel.total_volume < species.blood_volume)
-			vessel.maximum_volume = species.blood_volume
-			vessel.add_reagent(species.blood_reagent, species.blood_volume - vessel.total_volume)
-		else if(vessel.total_volume > species.blood_volume)
-			vessel.remove_any(vessel.total_volume - species.blood_volume)
-			vessel.maximum_volume = species.blood_volume
-		fixblood()
+	regenerate_icons()
+	reset_blood()
 
 	// Rebuild the HUD and visual elements.
 	if(client)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -312,18 +312,6 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 	updatehealth()
 	BITSET(hud_updateflag, HEALTH_HUD)
 
-
-////////////////////////////////////////////
-
-/*
-This function restores the subjects blood to max.
-*/
-/mob/living/carbon/human/proc/restore_blood()
-	if(!should_have_organ(BP_HEART))
-		return
-	if(vessel.total_volume < species.blood_volume)
-		vessel.add_reagent(species.blood_reagent, species.blood_volume - vessel.total_volume)
-
 /*
 This function restores all organs.
 */

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -7,7 +7,6 @@
 	. = ..()
 	STOP_PROCESSING(SSmobs, src)
 	global.human_mob_list -= src
-	delete_inventory()
 
 /mob/living/carbon/human/dummy/selfdress/Initialize()
 	. = ..()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1039,7 +1039,7 @@
 			E.take_external_damage(burn = round(species_heat_mod * log(10, (burn_temperature + 10)), 0.1), used_weapon = "fire")
 
 /mob/living/carbon/human/rejuvenate()
-	restore_blood()
+	reset_blood()
 	full_prosthetic = null
 	shock_stage = 0
 	..()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -290,12 +290,16 @@ var/global/list/damage_icon_parts = list()
 
 //BASE MOB SPRITE
 /mob/living/carbon/human/update_body(var/update_icons=1)
+
+	if(!length(organs))
+		return // Something is trying to update our body pre-init (probably loading a preview image during world startup).
+
 	var/husk_color_mod = rgb(96,88,80)
 	var/hulk_color_mod = rgb(48,224,40)
 
-	var/husk = (MUTATION_HUSK in src.mutations)
-	var/fat = (MUTATION_FAT in src.mutations)
-	var/hulk = (MUTATION_HULK in src.mutations)
+	var/husk =     (MUTATION_HUSK in src.mutations)
+	var/fat =      (MUTATION_FAT in src.mutations)
+	var/hulk =     (MUTATION_HULK in src.mutations)
 	var/skeleton = (MUTATION_SKELETON in src.mutations)
 
 	//CACHING: Generate an index key from visible bodyparts.

--- a/code/modules/mob/living/deity/phenomena/narsie.dm
+++ b/code/modules/mob/living/deity/phenomena/narsie.dm
@@ -15,7 +15,7 @@
 	return 1
 
 /datum/phenomena/exhude_blood/activate(var/mob/living/carbon/human/H, var/mob/living/deity/user)
-	H.vessel.add_reagent(H.species.blood_reagent, 30)
+	H.adjust_blood(30)
 	to_chat(H,"<span class='notice'>You feel a rush as new blood enters your system.</span>")
 
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -145,10 +145,11 @@
 			if(isnull(client.holder))
 				announce_ghost_joinleave(src)
 
-			var/mob/living/carbon/human/dummy/mannequin = new()
-			client.prefs.dress_preview_mob(mannequin)
-			observer.set_appearance(mannequin)
-			qdel(mannequin)
+			var/mob/living/carbon/human/dummy/mannequin = get_mannequin(client.ckey)
+			if(mannequin)
+				client.prefs.dress_preview_mob(mannequin)
+				observer.set_appearance(mannequin)
+				qdel(mannequin)
 
 			if(client.prefs.be_random_name)
 				client.prefs.real_name = client.prefs.get_random_name()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -149,7 +149,6 @@
 			if(mannequin)
 				client.prefs.dress_preview_mob(mannequin)
 				observer.set_appearance(mannequin)
-				qdel(mannequin)
 
 			if(client.prefs.be_random_name)
 				client.prefs.real_name = client.prefs.get_random_name()

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -39,6 +39,10 @@
 		copy_to(H)
 
 /datum/preferences/proc/dress_preview_mob(var/mob/living/carbon/human/mannequin)
+
+	if(!mannequin)
+		return
+
 	var/update_icon = FALSE
 	copy_to(mannequin, TRUE)
 
@@ -93,10 +97,10 @@
 
 /datum/preferences/proc/update_preview_icon()
 	var/mob/living/carbon/human/dummy/mannequin/mannequin = get_mannequin(client_ckey)
-	mannequin.delete_inventory(TRUE)
-	dress_preview_mob(mannequin)
-
-	update_character_previews(new /mutable_appearance(mannequin))
+	if(mannequin)
+		mannequin.delete_inventory(TRUE)
+		dress_preview_mob(mannequin)
+		update_character_previews(new /mutable_appearance(mannequin))
 
 /datum/preferences/proc/get_random_name()
 	var/decl/cultural_info/culture/check_culture = cultural_info[TAG_CULTURE]

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -273,7 +273,7 @@
 	log_admin("[key_name(src)] has transformed into a zombie!")
 	SET_STATUS_MAX(src, STAT_WEAK, 5)
 	if (should_have_organ(BP_HEART))
-		vessel.add_reagent(species.blood_reagent, species.blood_volume - vessel.total_volume)
+		adjust_blood(species.blood_volume - vessel.total_volume)
 	for (var/o in organs)
 		var/obj/item/organ/organ = o
 		organ.vital = 0

--- a/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
@@ -88,9 +88,9 @@
 				alarms[++alarms.len] = list("name" = alarm_name, "ref"= "\ref[alarm]", "danger" = danger_level)
 
 		alarms_data = list()
-		alarms_data["alarms"] =       sortTim(alarms,       /proc/cmp_list_name_key_asc, TRUE)
-		alarms_data["alarmsAlert"] =  sortTim(alarmsAlert,  /proc/cmp_list_name_key_asc, TRUE)
-		alarms_data["alarmsDanger"] = sortTim(alarmsDanger, /proc/cmp_list_name_key_asc, TRUE)
+		alarms_data["alarms"] =       sortTim(alarms,       /proc/cmp_list_name_key_asc)
+		alarms_data["alarmsAlert"] =  sortTim(alarmsAlert,  /proc/cmp_list_name_key_asc)
+		alarms_data["alarmsDanger"] = sortTim(alarmsDanger, /proc/cmp_list_name_key_asc)
 		alarm_data_cache[weakref(user)] = alarms_data
 	
 	data += alarms_data

--- a/code/modules/modular_computers/file_system/programs/engineering/rcon_console.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/rcon_console.dm
@@ -125,7 +125,7 @@
 	for(var/obj/machinery/power/smes/buildable/SMES in SSmachines.machinery)
 		if(can_connect_to(SMES))
 			known_SMESs.Add(SMES)
-	known_SMESs = sortTim(known_SMESs, /proc/cmp_rcon_tag_asc, TRUE)
+	known_SMESs = sortTim(known_SMESs, /proc/cmp_rcon_tag_asc)
 
 	known_breakers = new /list()
 	for(var/obj/machinery/power/breakerbox/breaker in SSmachines.machinery)

--- a/code/modules/modular_computers/file_system/programs/generic/supply.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/supply.dm
@@ -100,13 +100,15 @@
 
 		if(3)// Shuttle monitoring and control
 			var/datum/shuttle/autodock/ferry/supply/shuttle = SSsupply.shuttle
-			data["shuttle_name"] = shuttle.name
 			if(istype(shuttle))
-				data["shuttle_location"] = shuttle.at_station() ? global.using_map.name : "Remote location"
+				data["shuttle_name"] =        shuttle.name
+				data["shuttle_location"] =    shuttle.at_station() ? global.using_map.name : "Remote location"
+				data["shuttle_can_control"] = shuttle.can_launch()
 			else
-				data["shuttle_location"] = "No Connection"
+				data["shuttle_name"] =        "No Connection"
+				data["shuttle_location"] =    "No Connection"
+				data["shuttle_can_control"] = FALSE
 			data["shuttle_status"] = get_shuttle_status()
-			data["shuttle_can_control"] = shuttle.can_launch()
 
 		if(4)// Order processing
 			if(is_admin) // No bother sending all of this if the user can't see it.

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -56,7 +56,6 @@
 /obj/item/organ/internal/lungs/set_dna(var/datum/dna/new_dna)
 	..()
 	sync_breath_types()
-	max_pressure_diff = species.max_pressure_diff
 
 /obj/item/organ/internal/lungs/replaced()
 	..()
@@ -66,10 +65,18 @@
  *  Set these lungs' breath types based on the lungs' species
  */
 /obj/item/organ/internal/lungs/proc/sync_breath_types()
-	min_breath_pressure = species.breath_pressure
-	breath_type = species.breath_type ? species.breath_type : /decl/material/gas/oxygen
-	poison_types = species.poison_types ? species.poison_types : list(/decl/material/gas/chlorine = TRUE)
-	exhale_type = species.exhale_type ? species.exhale_type : /decl/material/gas/carbon_dioxide
+	if(species)
+		max_pressure_diff =   species.max_pressure_diff
+		min_breath_pressure = species.breath_pressure
+		breath_type =         species.breath_type  || /decl/material/gas/oxygen
+		poison_types =        species.poison_types || list(/decl/material/gas/chlorine = TRUE)
+		exhale_type =         species.exhale_type  || /decl/material/gas/carbon_dioxide
+	else
+		max_pressure_diff =   initial(max_pressure_diff)
+		min_breath_pressure = initial(min_breath_pressure)
+		breath_type =         /decl/material/gas/oxygen
+		poison_types =        list(/decl/material/gas/chlorine = TRUE)
+		exhale_type =         /decl/material/gas/carbon_dioxide
 
 /obj/item/organ/internal/lungs/Process()
 	..()

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -127,7 +127,7 @@ var/global/list/overmap_helm_computers
 
 		ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 		if (!ui)
-			ui = new(user, src, ui_key, "helm.tmpl", "[linked.name] Helm Control", 565, 545)
+			ui = new(user, src, ui_key, "helm.tmpl", "[linked.name] Helm Control", 565, 545, nref = src)
 			ui.set_initial_data(data)
 			ui.open()
 			ui.set_auto_update(1)
@@ -256,7 +256,7 @@ var/global/list/overmap_helm_computers
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "nav.tmpl", "[linked.name] Navigation Screen", 380, 530)
+		ui = new(user, src, ui_key, "nav.tmpl", "[linked.name] Navigation Screen", 380, 530, nref = src)
 		ui.set_initial_data(data)
 		ui.open()
 		ui.set_auto_update(1)

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -99,7 +99,7 @@
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "shipsensors.tmpl", "[linked.name] Sensors Control", 420, 530, src)
+		ui = new(user, src, ui_key, "shipsensors.tmpl", "[linked.name] Sensors Control", 420, 530, nref = src)
 		ui.set_initial_data(data)
 		ui.open()
 		ui.set_auto_update(1)

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -70,6 +70,7 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 	LAZYDISTINCTADD(viewers, weakref(user))
 
 /obj/machinery/computer/ship/proc/unlook(var/mob/user)
+	world << "[type] unlook [user]"
 	user.reset_view()
 	if(user.client)
 		user.client.view = world.view

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -70,7 +70,6 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 	LAZYDISTINCTADD(viewers, weakref(user))
 
 /obj/machinery/computer/ship/proc/unlook(var/mob/user)
-	world << "[type] unlook [user]"
 	user.reset_view()
 	if(user.client)
 		user.client.view = world.view

--- a/code/modules/power/fusion/consoles/injector_control.dm
+++ b/code/modules/power/fusion/consoles/injector_control.dm
@@ -53,7 +53,7 @@
 			injector["id"] =       "#[i]"
 			injector["ref"] =       "\ref[I]"
 			injector["injecting"] =  I.injecting
-			injector["fueltype"] =  "[I.cur_assembly ? capitalize(I.cur_assembly.material.solid_name) : "No Fuel Inserted"]"
+			injector["fueltype"] =  "[I.cur_assembly ? capitalize(I.cur_assembly.material.name) : "No Fuel Inserted"]"
 			injector["depletion"] = "[I.cur_assembly ? (I.cur_assembly.percent_depleted * 100) : 100]%"
 			injector["injection_rate"] = "[I.injection_rate * 100]%"
 			injectors += list(injector)

--- a/code/modules/spells/aoe_turf/drain_blood.dm
+++ b/code/modules/spells/aoe_turf/drain_blood.dm
@@ -38,7 +38,7 @@
 				var/mob/living/carbon/human/H = user
 				var/amount = min(10, H.species.blood_volume - H.vessel.total_volume)
 				if(amount > 0)
-					H.vessel.add_reagent(H.species.blood_reagent, amount)
+					H.adjust_blood(amount)
 					continue
 			L.adjustBruteLoss(-5)
 			L.adjustFireLoss(-2.5)

--- a/code/modules/spells/targeted/targeted.dm
+++ b/code/modules/spells/targeted/targeted.dm
@@ -153,10 +153,10 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 			if(affecting && istype(affecting))
 				var/dam = BP_IS_PROSTHETIC(affecting) ? -amt_dam_robo : amt_organ
 				affecting.heal_damage(dam, dam, robo_repair = BP_IS_PROSTHETIC(affecting))
-		H.vessel.add_reagent(H.species.blood_reagent, amt_blood)
+		H.adjust_blood(amt_blood)
 		H.adjustBrainLoss(amt_brain)
 		H.radiation += min(H.radiation, amt_radiation)
-		H.fixblood()
+
 	target.regenerate_icons()
 	//disabling
 	SET_STATUS_MAX(target, STAT_WEAK, amt_weakened)

--- a/mods/mobs/borers/mob/borer/borer_powers.dm
+++ b/mods/mobs/borers/mob/borer/borer_powers.dm
@@ -89,8 +89,5 @@
 
 	verbs -= /mob/living/carbon/human/proc/jumpstart
 	visible_message(SPAN_DANGER("With a hideous, rattling moan, [src] shudders back to life!"))
-
 	rejuvenate()
-	restore_blood()
-	fixblood()
 	UpdateLyingBuckledAndVerbStatus()


### PR DESCRIPTION
- Fixes a bunch of runtimes, mainly the ones I marked with a rocket in #1635.
- Blocks mannequins from being generated prior to SSatoms init to avoid runtimes in char setup from early joiners.
- Cherrypicks a commit I should have pointed at staging that fixes a runtime in lungs.
- Moves some blood logic into a proc to allow for easier safeguarding of vessel creation.
- Fixes most of #1641.
- Steals #1702.
- Fixes #1636 by stealing https://github.com/Baystation12/Baystation12/pull/30662.