### PR TITLE
tweaks tool archetype stuff a little bit

### DIFF
--- a/code/modules/tools/tool_extension.dm
+++ b/code/modules/tools/tool_extension.dm
@@ -49,8 +49,7 @@
 	if(check_result != TOOL_USE_SUCCESS)
 		return check_result
 
-	to_chat(user, SPAN_NOTICE("You begin [start_message || tool_archetype.use_message] \the [target] with \the [holder]."))
-	user.visible_message(SPAN_NOTICE("You begin [start_message || tool_archetype.use_message] \the [target] with \the [holder]."))
+	user.visible_message(SPAN_NOTICE("[user] begins [start_message || tool_archetype.use_message] \the [target] with \the [holder]."))
 	var/use_sound = LAZYACCESS(tool_use_sounds, archetype)
 	if(islist(use_sound) && length(use_sound))
 		use_sound = pick(use_sound)

--- a/code/modules/tools/tool_extension.dm
+++ b/code/modules/tools/tool_extension.dm
@@ -49,7 +49,7 @@
 	if(check_result != TOOL_USE_SUCCESS)
 		return check_result
 
-	user.visible_message(SPAN_NOTICE("\the [user] begins [start_message || tool_archetype.use_message] \the [target] with \the [holder]."))
+	user.visible_message(SPAN_NOTICE("\The [user] begins [start_message || tool_archetype.use_message] \the [target] with \the [holder]."), SPAN_NOTICE("You begin [start_message || tool_archetype.use_message] \the [target] with \the [holder]."))
 	var/use_sound = LAZYACCESS(tool_use_sounds, archetype)
 	if(islist(use_sound) && length(use_sound))
 		use_sound = pick(use_sound)

--- a/code/modules/tools/tool_extension.dm
+++ b/code/modules/tools/tool_extension.dm
@@ -49,7 +49,7 @@
 	if(check_result != TOOL_USE_SUCCESS)
 		return check_result
 
-	user.visible_message(SPAN_NOTICE("[user] begins [start_message || tool_archetype.use_message] \the [target] with \the [holder]."))
+	user.visible_message(SPAN_NOTICE("\the [user] begins [start_message || tool_archetype.use_message] \the [target] with \the [holder]."))
 	var/use_sound = LAZYACCESS(tool_use_sounds, archetype)
 	if(islist(use_sound) && length(use_sound))
 		use_sound = pick(use_sound)
@@ -63,8 +63,7 @@
 	if(check_result != TOOL_USE_SUCCESS)
 		return check_result
 	
-	if(check_result == TOOL_USE_SUCCESS)
-		if(use_sound)
-			playsound(user.loc, use_sound, 100) //A lot of interactions played a sound when starting and ending the interaction. This was missed.
+	if(check_result == TOOL_USE_SUCCESS && use_sound)
+		playsound(user.loc, use_sound, 100) //A lot of interactions played a sound when starting and ending the interaction. This was missed.
 	
 	return TOOL_USE_SUCCESS

--- a/code/modules/tools/tool_extension.dm
+++ b/code/modules/tools/tool_extension.dm
@@ -50,6 +50,7 @@
 		return check_result
 
 	to_chat(user, SPAN_NOTICE("You begin [start_message || tool_archetype.use_message] \the [target] with \the [holder]."))
+	user.visible_message(SPAN_NOTICE("You begin [start_message || tool_archetype.use_message] \the [target] with \the [holder]."))
 	var/use_sound = LAZYACCESS(tool_use_sounds, archetype)
 	if(islist(use_sound) && length(use_sound))
 		use_sound = pick(use_sound)
@@ -62,5 +63,9 @@
 	check_result = tool_archetype.handle_post_interaction(user, holder, fuel_expenditure)
 	if(check_result != TOOL_USE_SUCCESS)
 		return check_result
-
+	
+	if(check_result == TOOL_USE_SUCCESS)
+		if(use_sound)
+			playsound(user.loc, use_sound, 100) //A lot of interactions played a sound when starting and ending the interaction. This was missed.
+	
 	return TOOL_USE_SUCCESS

--- a/code/modules/tools/tool_item.dm
+++ b/code/modules/tools/tool_item.dm
@@ -19,7 +19,7 @@
 
 	if(. == TOOL_USE_SUCCESS)
 		var/decl/tool_archetype/tool_archetype = GET_DECL(archetype)
-		user.visible_message(SPAN_NOTICE("[user] finishes [success_message || tool_archetype.use_message] \the [target] with \the [src]."))
+		user.visible_message(SPAN_NOTICE("\the [user] finishes [success_message || tool_archetype.use_message] \the [target] with \the [src]."))
 		return TRUE
 
 	if(. == TOOL_USE_FAILURE_NOMESSAGE && failure_message)

--- a/code/modules/tools/tool_item.dm
+++ b/code/modules/tools/tool_item.dm
@@ -19,8 +19,7 @@
 
 	if(. == TOOL_USE_SUCCESS)
 		var/decl/tool_archetype/tool_archetype = GET_DECL(archetype)
-		to_chat(user, SPAN_NOTICE("You finish [success_message || tool_archetype.use_message] \the [target] with \the [src]."))
-		user.visible_message(SPAN_NOTICE("You finish [success_message || tool_archetype.use_message] \the [target] with \the [src]."))
+		user.visible_message(SPAN_NOTICE("[user] finishes [success_message || tool_archetype.use_message] \the [target] with \the [src]."))
 		return TRUE
 
 	if(. == TOOL_USE_FAILURE_NOMESSAGE && failure_message)

--- a/code/modules/tools/tool_item.dm
+++ b/code/modules/tools/tool_item.dm
@@ -19,7 +19,7 @@
 
 	if(. == TOOL_USE_SUCCESS)
 		var/decl/tool_archetype/tool_archetype = GET_DECL(archetype)
-		user.visible_message(SPAN_NOTICE("\the [user] finishes [success_message || tool_archetype.use_message] \the [target] with \the [src]."))
+		user.visible_message(SPAN_NOTICE("\The [user] finishes [success_message || tool_archetype.use_message] \the [target] with \the [src]."), SPAN_NOTICE("You finish [success_message || tool_archetype.use_message] \the [target] with \the [src]."))
 		return TRUE
 
 	if(. == TOOL_USE_FAILURE_NOMESSAGE && failure_message)

--- a/code/modules/tools/tool_item.dm
+++ b/code/modules/tools/tool_item.dm
@@ -20,6 +20,7 @@
 	if(. == TOOL_USE_SUCCESS)
 		var/decl/tool_archetype/tool_archetype = GET_DECL(archetype)
 		to_chat(user, SPAN_NOTICE("You finish [success_message || tool_archetype.use_message] \the [target] with \the [src]."))
+		user.visible_message(SPAN_NOTICE("You finish [success_message || tool_archetype.use_message] \the [target] with \the [src]."))
 		return TRUE
 
 	if(. == TOOL_USE_FAILURE_NOMESSAGE && failure_message)


### PR DESCRIPTION
I noticed while doing some more tool conversion stuff that a lot of interactions had a sound at the *start* and *end* of the interaction, as well as visible messages within the interaction. 

I think both are important for feedback around the user, so I went back and added them in what I think are appropriate places.