### PR TITLE
Adds cross-icon wall blending via material defs

### DIFF
--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -92,11 +92,11 @@
 				switch(can_join_with(T))
 					if(0)
 						continue
+					if(1)
+						wall_dirs += get_dir(src, T)
 					if(2)
 						wall_dirs += get_dir(src, T)
 						other_dirs += get_dir(src, T)
-					if(1)
-						wall_dirs += get_dir(src, T)
 			if(handle_structure_blending)
 				var/success = 0
 				for(var/O in T)
@@ -180,8 +180,9 @@
 
 /turf/simulated/wall/proc/can_join_with(var/turf/simulated/wall/W)
 	if(material && istype(W.material))
-		if(W.get_wall_icon() in material.wall_blend_icons)
+		var/other_wall_icon = W.get_wall_icon()
+		if(material.wall_blend_icons[other_wall_icon])
 			return 2
-		if(get_wall_icon() == W.get_wall_icon())
+		if(get_wall_icon() == other_wall_icon)
 			return 1
 	return 0

--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -75,7 +75,6 @@
 	. = istype(reinf_material)
 
 /turf/simulated/wall/on_update_icon()
-
 	. = ..()
 	cut_overlays()
 
@@ -93,6 +92,9 @@
 				switch(can_join_with(T))
 					if(0)
 						continue
+					if(2)
+						wall_dirs += get_dir(src, T)
+						other_dirs += get_dir(src, T)
 					if(1)
 						wall_dirs += get_dir(src, T)
 			if(handle_structure_blending)
@@ -177,6 +179,9 @@
 		add_overlay(SSmaterials.wall_damage_overlays[Clamp(round(damage / integrity * DAMAGE_OVERLAY_COUNT) + 1, 1, DAMAGE_OVERLAY_COUNT)])
 
 /turf/simulated/wall/proc/can_join_with(var/turf/simulated/wall/W)
-	if(material && istype(W.material) && get_wall_icon() == W.get_wall_icon())
-		return 1
+	if(material && istype(W.material))
+		if(W.get_wall_icon() in material.wall_blend_icons)
+			return 2
+		if(get_wall_icon() == W.get_wall_icon())
+			return 1
 	return 0

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -94,6 +94,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	var/icon_base_natural = 'icons/turf/walls/natural.dmi'
 	var/icon_reinf = 'icons/turf/walls/reinforced_metal.dmi'
 	var/wall_flags = 0
+	var/list/wall_blend_icons = null // Which wall icon types walls of this material type will consider blending with
 	var/use_reinf_state = "full"
 
 	var/door_icon_base = "metal"                         // Door base icon tag. See header.

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -94,7 +94,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	var/icon_base_natural = 'icons/turf/walls/natural.dmi'
 	var/icon_reinf = 'icons/turf/walls/reinforced_metal.dmi'
 	var/wall_flags = 0
-	var/list/wall_blend_icons = null // Which wall icon types walls of this material type will consider blending with
+	var/list/wall_blend_icons = list() // Which wall icon types walls of this material type will consider blending with. Assoc list (icon path = TRUE/FALSE)
 	var/use_reinf_state = "full"
 
 	var/door_icon_base = "metal"                         // Door base icon tag. See header.

--- a/code/modules/materials/definitions/solids/materials_solid_metal.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_metal.dm
@@ -7,6 +7,7 @@
 	weight = MAT_VALUE_HEAVY
 	hardness = MAT_VALUE_RIGID
 	wall_support_value = MAT_VALUE_HEAVY
+	wall_blend_icons = list('icons/turf/walls/wood.dmi', 'icons/turf/walls/stone.dmi')
 	default_solid_form = /obj/item/stack/material/ingot
 
 /decl/material/solid/metal/uranium

--- a/code/modules/materials/definitions/solids/materials_solid_metal.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_metal.dm
@@ -7,7 +7,10 @@
 	weight = MAT_VALUE_HEAVY
 	hardness = MAT_VALUE_RIGID
 	wall_support_value = MAT_VALUE_HEAVY
-	wall_blend_icons = list('icons/turf/walls/wood.dmi', 'icons/turf/walls/stone.dmi')
+	wall_blend_icons = list(
+		'icons/turf/walls/wood.dmi' = TRUE,
+		'icons/turf/walls/stone.dmi' = TRUE
+	)
 	default_solid_form = /obj/item/stack/material/ingot
 
 /decl/material/solid/metal/uranium

--- a/code/modules/materials/definitions/solids/materials_solid_stone.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_stone.dm
@@ -8,7 +8,11 @@
 	brute_armor = 3
 	conductive = 0
 	construction_difficulty = MAT_VALUE_NORMAL_DIY
-	wall_blend_icons = list('icons/turf/walls/solid.dmi', 'icons/turf/walls/wood.dmi', 'icons/turf/walls/metal.dmi')
+	wall_blend_icons = list(
+		'icons/turf/walls/solid.dmi' = TRUE,
+		'icons/turf/walls/wood.dmi' = TRUE,
+		'icons/turf/walls/metal.dmi' = TRUE
+	)
 	dissolves_into = list(
 		/decl/material/solid/silicon = 1
 	)

--- a/code/modules/materials/definitions/solids/materials_solid_stone.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_stone.dm
@@ -8,6 +8,7 @@
 	brute_armor = 3
 	conductive = 0
 	construction_difficulty = MAT_VALUE_NORMAL_DIY
+	wall_blend_icons = list('icons/turf/walls/solid.dmi', 'icons/turf/walls/wood.dmi', 'icons/turf/walls/metal.dmi')
 	dissolves_into = list(
 		/decl/material/solid/silicon = 1
 	)

--- a/code/modules/materials/definitions/solids/materials_solid_wood.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_wood.dm
@@ -7,6 +7,7 @@
 	integrity = 75
 	icon_base = 'icons/turf/walls/wood.dmi'
 	wall_flags = PAINT_PAINTABLE|PAINT_STRIPABLE|WALL_HAS_EDGES
+	wall_blend_icons = list('icons/turf/walls/solid.dmi', 'icons/turf/walls/stone.dmi', 'icons/turf/walls/metal.dmi')
 	table_icon_base = "wood"
 	explosion_resistance = 2
 	shard_type = SHARD_SPLINTER

--- a/code/modules/materials/definitions/solids/materials_solid_wood.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_wood.dm
@@ -7,7 +7,11 @@
 	integrity = 75
 	icon_base = 'icons/turf/walls/wood.dmi'
 	wall_flags = PAINT_PAINTABLE|PAINT_STRIPABLE|WALL_HAS_EDGES
-	wall_blend_icons = list('icons/turf/walls/solid.dmi', 'icons/turf/walls/stone.dmi', 'icons/turf/walls/metal.dmi')
+	wall_blend_icons = list(
+		'icons/turf/walls/solid.dmi' = TRUE,
+		'icons/turf/walls/stone.dmi' = TRUE,
+		'icons/turf/walls/metal.dmi' = TRUE
+	)
 	table_icon_base = "wood"
 	explosion_resistance = 2
 	shard_type = SHARD_SPLINTER


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->

## Changelog
:cl:
rscadd: Walls can now connect to walls of other types depending on their material by comparing material wall icons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Would have gone with comparing material decl types but other similar functionality uses icon comparisons already and it's a lot cleaner to do it this way rather than the mess that would have been allowing subtypes of /decl/material/solid/metal and disallowing any subtypes that used metal wall icons which to avoid shuttles blending into other structures which was the original design intention

![image](https://user-images.githubusercontent.com/17550641/122553670-e3dec580-d02f-11eb-8f84-b70a545a5e5a.png)
