### PR TITLE
Fixes inconsistent markdown

### DIFF
--- a/code/modules/chat_filter/filter_markdown.dm
+++ b/code/modules/chat_filter/filter_markdown.dm
@@ -6,7 +6,7 @@
 
 /decl/chat_filter/regexp/markdown/New()
 	..()
-	filter_regex = regex("([format_char])(.+)([format_char])", "g")
+	filter_regex = regex("([format_char])(.+?)([format_char])", "g")
 
 /decl/chat_filter/regexp/markdown/replace(var/message, var/match)
 	. = filter_regex.Replace(message, format_replace_proc)

--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -7,13 +7,13 @@
 	hidden_from_codex = 1
 
 /decl/language/noise/format_message(message, verb)
-	return "<span class='message'><span class='[colour]'>[filter_modify_message(message)]</span></span>"
+	return "<span class='message'><span class='[colour]'>[message]</span></span>"
 
 /decl/language/noise/format_message_plain(message, verb)
-	return filter_modify_message(message)
+	return message
 
 /decl/language/noise/format_message_radio(message, verb)
-	return "<span class='[colour]'>[filter_modify_message(message)]</span>"
+	return "<span class='[colour]'>[message]</span>"
 
 /decl/language/noise/get_talkinto_msg_range(message)
 	// if you make a loud noise (screams etc), you'll be heard from 4 tiles over instead of two

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -126,13 +126,13 @@
 	return scrambled_text
 
 /decl/language/proc/format_message(message, verb)
-	return "[verb], <span class='message'><span class='[colour]'>\"[capitalize(filter_modify_message(message))]\"</span></span>"
+	return "[verb], <span class='message'><span class='[colour]'>\"[capitalize(message)]\"</span></span>"
 
 /decl/language/proc/format_message_plain(message, verb)
-	return "[verb], \"[capitalize(filter_modify_message(message))]\""
+	return "[verb], \"[capitalize(message)]\""
 
 /decl/language/proc/format_message_radio(message, verb)
-	return "[verb], <span class='[colour]'>\"[capitalize(filter_modify_message(message))]\"</span>"
+	return "[verb], <span class='[colour]'>\"[capitalize(message)]\"</span>"
 
 /decl/language/proc/get_talkinto_msg_range(message)
 	// if you yell, you'll be heard from two tiles over instead of one

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -207,6 +207,7 @@ var/global/list/channel_to_radio_key = new
 	message = trim_left(message)
 	message = handle_autohiss(message, speaking)
 	message = format_say_message(message)
+	message = filter_modify_message(message)
 
 	if(speaking && !speaking.can_be_spoken_properly_by(src))
 		message = speaking.muddle(message)
@@ -326,7 +327,6 @@ var/global/list/channel_to_radio_key = new
 	return 1
 
 /mob/living/proc/say_signlang(var/message, var/verb="gestures", var/decl/language/language)
-	message = filter_modify_message(message)
 	for (var/mob/O in viewers(src, null))
 		O.hear_signlang(message, verb, language, src)
 	return 1

--- a/mods/species/tajaran/datum/language.dm
+++ b/mods/species/tajaran/datum/language.dm
@@ -24,7 +24,7 @@
 //#803b56 is color
 
 /decl/language/tajaran/format_message(message, verb)
-	return "[verb], <span class='message'><span style='color: #803b56'>\"[capitalize(filter_modify_message(message))]\"</span></span>"
+	return "[verb], <span class='message'><span style='color: #803b56'>\"[capitalize(message)]\"</span></span>"
 
 /decl/language/tajaran/format_message_radio(message, verb)
-	return "[verb], <span style='color: #803b56'>\"[capitalize(filter_modify_message(message))]\"</span>"
+	return "[verb], <span style='color: #803b56'>\"[capitalize(message)]\"</span>"


### PR DESCRIPTION
Fixes #1746 
Moves all the processing to say code. Makes the regex lazy to allow for multiple matches in a single message.