### PR TITLE
implements a decl-based method for adding onto human/examine()

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -351,6 +351,14 @@
 	var/show_descs = show_descriptors_to(user)
 	if(show_descs)
 		msg += "<span class='notice'>[jointext(show_descs, "<br>")]</span>"
+
+	var/list/human_examines = decls_repository.get_decls_of_subtype(/decl/human_examination)
+	for(var/exam in human_examines)
+		var/decl/human_examination/HE = human_examines[exam]
+		var/adding_text = HE.do_examine(user, distance, src)
+		if(adding_text)
+			msg += adding_text
+
 	to_chat(user, jointext(msg, null))
 
 //Helper procedure. Called by /mob/living/carbon/human/examine() and /mob/living/carbon/human/Topic() to determine HUD access to security and medical records.

--- a/code/modules/mob/living/carbon/human/human_examine_decl.dm
+++ b/code/modules/mob/living/carbon/human/human_examine_decl.dm
@@ -1,0 +1,4 @@
+/decl/human_examination //This is essentially a stub-method for modpacks to be able to add onto the human examination stuff due to ... messy stuff.
+
+/decl/human_examination/proc/do_examine(var/user, var/distance, var/source) //These can either return text, or should return nothing at all if you're doing to_chat()
+	return

--- a/nebula.dme
+++ b/nebula.dme
@@ -2212,6 +2212,7 @@
 #include "code\modules\mob\living\carbon\human\human_damage.dm"
 #include "code\modules\mob\living\carbon\human\human_defense.dm"
 #include "code\modules\mob\living\carbon\human\human_defines.dm"
+#include "code\modules\mob\living\carbon\human\human_examine_decl.dm"
 #include "code\modules\mob\living\carbon\human\human_grabs.dm"
 #include "code\modules\mob\living\carbon\human\human_helpers.dm"
 #include "code\modules\mob\living\carbon\human\human_maneuvers.dm"


### PR DESCRIPTION
implements /decl/human_examination - which is more or less just a stub proc so modpacks can add onto human/examine() without too much fuss.
