### PR TITLE
Ports SSprofiler from Paradise Station

### DIFF
--- a/code/__defines/_compile_options.dm
+++ b/code/__defines/_compile_options.dm
@@ -7,3 +7,8 @@
 #if DM_VERSION < REQUIRED_DM_VERSION
 #warn Nebula is not tested on BYOND versions older than 513. The code may not compile, and if it does compile it may have severe problems.
 #endif
+
+// Log the full sendmaps profile on 514.1556+, any earlier and we get bugs or it not existing.
+#if DM_VERSION >= 514 && DM_BUILD >= 1556
+#define SENDMAPS_PROFILE
+#endif

--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -20,6 +20,7 @@
 // Subsystems shutdown in the reverse of the order they initialize in
 // The numbers just define the ordering, they are meaningless otherwise.
 
+#define SS_INIT_PROFILER         18
 #define SS_INIT_EARLY            17
 #define SS_INIT_GARBAGE          16
 #define SS_INIT_MATERIALS        15

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -251,6 +251,8 @@ var/global/list/gamemode_cache = list()
 
 	var/no_throttle_localhost
 
+	var/enable_automatic_profiler
+
 	var/static/list/protected_vars = list(
 		"comms_password",
 		"ban_comms_password",
@@ -805,6 +807,9 @@ var/global/list/gamemode_cache = list()
 
 				if("no_throttle_localhost")
 					config.no_throttle_localhost = TRUE
+
+				if("enable_automatic_profiler")
+					config.enable_automatic_profiler = TRUE
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/controllers/subsystems/profiler.dm
+++ b/code/controllers/subsystems/profiler.dm
@@ -1,54 +1,100 @@
 #define PROFILER_FILENAME "profiler.json"
+#ifdef SENDMAPS_PROFILE
+#define SENDMAPS_FILENAME "sendmaps.json"
+var/global/world_init_maptick_profiler = world.Profile(PROFILE_RESTART, type = "sendmaps")
+#endif
 
 SUBSYSTEM_DEF(profiler)
 	name = "Profiler"
 	init_order = SS_INIT_PROFILER
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
 	wait = 5 MINUTES
-	flags = SS_NO_TICK_CHECK
 	/// Time it took to fetch profile data (ms)
 	var/fetch_cost = 0
 	/// Time it took to write the file (ms)
 	var/write_cost = 0
 
-/datum/controller/subsystem/profiler/stat_entry()
-	..("F:[round(fetch_cost, 1)]ms | W:[round(write_cost, 1)]ms")
+/datum/controller/subsystem/profiler/stat_entry(msg)
+	msg += "F:[round(fetch_cost,1)]ms"
+	msg += "|W:[round(write_cost,1)]ms"
+	return msg
 
 /datum/controller/subsystem/profiler/Initialize()
-	if(!config.enable_automatic_profiler)
-		StopProfiling() //Stop the early start profiler if we dont want it on in the config
-		flags |= SS_NO_FIRE
+	if(config.enable_automatic_profiler)
+		StartProfiling()
+	else
+		StopProfiling() //Stop the early start profiler
+
+#ifdef SENDMAPS_PROFILE
+	global.admin_verbs_debug |= /client/proc/display_sendmaps
+#endif
+
 	return ..()
 
 /datum/controller/subsystem/profiler/fire()
-	DumpFile()
+	if(config.enable_automatic_profiler)
+		DumpFile()
 
 /datum/controller/subsystem/profiler/Shutdown()
 	if(config.enable_automatic_profiler)
 		DumpFile()
+		world.Profile(PROFILE_CLEAR, type = "sendmaps")
 	return ..()
 
 // These procs may seem useless, but they exist like this so we can proc call them on and off
 // You cant proc-call onto /world
 /datum/controller/subsystem/profiler/proc/StartProfiling()
 	world.Profile(PROFILE_START)
+#ifdef SENDMAPS_PROFILE
+	world.Profile(PROFILE_START, type = "sendmaps")
+#endif
 
 /datum/controller/subsystem/profiler/proc/StopProfiling()
 	world.Profile(PROFILE_STOP)
+#ifdef SENDMAPS_PROFILE
+	world.Profile(PROFILE_STOP, type = "sendmaps")
+#endif
 
 // Write the file while also cost tracking
 /datum/controller/subsystem/profiler/proc/DumpFile()
 	var/timer = TICK_USAGE_REAL
 	var/current_profile_data = world.Profile(PROFILE_REFRESH, format = "json")
+#ifdef SENDMAPS_PROFILE
+	var/current_sendmaps_data = world.Profile(PROFILE_REFRESH, type = "sendmaps", format = "json")
+#endif
 	fetch_cost = MC_AVERAGE(fetch_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 	CHECK_TICK
+
 	if(!length(current_profile_data)) //Would be nice to have explicit proc to check this
 		PRINT_STACK_TRACE("Warning, profiling stopped manually before dump.")
-	var/json_file = file("[global.log_directory]/[PROFILER_FILENAME]")
-	if(fexists(json_file))
-		fdel(json_file)
+	var/profiler_file = file("[global.log_directory]/[PROFILER_FILENAME]")
+	if(fexists(profiler_file))
+		fdel(profiler_file)
+
+#ifdef SENDMAPS_PROFILE	
+	if(!length(current_sendmaps_data)) //Would be nice to have explicit proc to check this
+		PRINT_STACK_TRACE("Warning, sendmaps profiling stopped manually before dump.")
+	var/sendmaps_file = file("[global.log_directory]/[SENDMAPS_FILENAME]")
+	if(fexists(sendmaps_file))
+		fdel(sendmaps_file)
+#endif
+
 	timer = TICK_USAGE_REAL
-	WRITE_FILE(json_file, current_profile_data)
+	WRITE_FILE(profiler_file, current_profile_data)
+#ifdef SENDMAPS_PROFILE
+	WRITE_FILE(sendmaps_file, current_sendmaps_data)
+#endif
 	write_cost = MC_AVERAGE(write_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 
 #undef PROFILER_FILENAME
+#ifdef SENDMAPS_PROFILE
+#undef SENDMAPS_FILENAME
+#endif
+
+#ifdef SENDMAPS_PROFILE
+/client/proc/display_sendmaps()
+	set name = "Send Maps Profile"
+	set category = "Debug"
+
+	open_link(src, "?debug=profile&type=sendmaps&window=test")
+#endif

--- a/code/controllers/subsystems/profiler.dm
+++ b/code/controllers/subsystems/profiler.dm
@@ -1,0 +1,54 @@
+#define PROFILER_FILENAME "profiler.json"
+
+SUBSYSTEM_DEF(profiler)
+	name = "Profiler"
+	init_order = SS_INIT_PROFILER
+	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
+	wait = 5 MINUTES
+	flags = SS_NO_TICK_CHECK
+	/// Time it took to fetch profile data (ms)
+	var/fetch_cost = 0
+	/// Time it took to write the file (ms)
+	var/write_cost = 0
+
+/datum/controller/subsystem/profiler/stat_entry()
+	..("F:[round(fetch_cost, 1)]ms | W:[round(write_cost, 1)]ms")
+
+/datum/controller/subsystem/profiler/Initialize()
+	if(!config.enable_automatic_profiler)
+		StopProfiling() //Stop the early start profiler if we dont want it on in the config
+		flags |= SS_NO_FIRE
+	return ..()
+
+/datum/controller/subsystem/profiler/fire()
+	DumpFile()
+
+/datum/controller/subsystem/profiler/Shutdown()
+	if(config.enable_automatic_profiler)
+		DumpFile()
+	return ..()
+
+// These procs may seem useless, but they exist like this so we can proc call them on and off
+// You cant proc-call onto /world
+/datum/controller/subsystem/profiler/proc/StartProfiling()
+	world.Profile(PROFILE_START)
+
+/datum/controller/subsystem/profiler/proc/StopProfiling()
+	world.Profile(PROFILE_STOP)
+
+// Write the file while also cost tracking
+/datum/controller/subsystem/profiler/proc/DumpFile()
+	var/timer = TICK_USAGE_REAL
+	var/current_profile_data = world.Profile(PROFILE_REFRESH, format = "json")
+	fetch_cost = MC_AVERAGE(fetch_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
+	CHECK_TICK
+	if(!length(current_profile_data)) //Would be nice to have explicit proc to check this
+		PRINT_STACK_TRACE("Warning, profiling stopped manually before dump.")
+	var/json_file = file("[global.log_directory]/[PROFILER_FILENAME]")
+	if(fexists(json_file))
+		fdel(json_file)
+	timer = TICK_USAGE_REAL
+	WRITE_FILE(json_file, current_profile_data)
+	write_cost = MC_AVERAGE(write_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
+
+#undef PROFILER_FILENAME

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -454,3 +454,8 @@ RADIATION_LOWER_LIMIT 0.15
 ## Whether or not to make localhost immune to throttling.
 ## Localhost will still be throttled internally; it just won't be affected by it.
 #NO_THROTTLE_LOCALHOST
+
+## Uncomment this to toggle profiler on server and profiler controller.
+## This will make profiler controller collect profiler info and store it in log directory in json format.
+## Don't use it on live server, exept you need it for live tests.
+#ENABLE_AUTOMATIC_PROFILER

--- a/nebula.dme
+++ b/nebula.dme
@@ -208,6 +208,7 @@
 #include "code\controllers\subsystems\misc_late.dm"
 #include "code\controllers\subsystems\overlays.dm"
 #include "code\controllers\subsystems\plants.dm"
+#include "code\controllers\subsystems\profiler.dm"
 #include "code\controllers\subsystems\radiation.dm"
 #include "code\controllers\subsystems\shuttle.dm"
 #include "code\controllers\subsystems\skybox.dm"


### PR DESCRIPTION
Ports SS220 (Actually, Paradise one) SSprofiler, provided by @Vallat.
This thing allows to collect profiler's data in JSON format as log entry.

~~Currently don't respect config option because I don't know how to integrate the check in subsystem. This is main reason why I putting it on draft.~~