### PR TITLE
Drying Improvements and Recipe Fruit Expansion

### DIFF
--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -44,7 +44,7 @@ var/global/list/microwave_accepts_items =    list(
 		return FALSE
 	for(var/rtype in reagents)
 		if(REAGENT_VOLUME(avail_reagents, rtype) < reagents[rtype])
-			return FALSE 
+			return FALSE
 	return TRUE
 
 /decl/recipe/proc/check_fruit(var/obj/container)
@@ -54,14 +54,26 @@ var/global/list/microwave_accepts_items =    list(
 	if(length(container_contents) < length(fruit))
 		return FALSE
 	var/list/needed_fruits = fruit.Copy()
-	for(var/obj/item/chems/food/snacks/grown/G in container_contents)
-		var/ktag = G.seed?.kitchen_tag
-		if(needed_fruits[ktag] > 0)
-			needed_fruits[ktag]--
+	for(var/obj/item/chems/food/snacks/S in container_contents)
+		var/use_tag
+		if(istype(S, /obj/item/chems/food/snacks/grown))
+			var/obj/item/chems/food/snacks/grown/G = S
+			if(!G.seed || !G.seed.kitchen_tag)
+				continue
+			use_tag = G.dry ? "dried [G.seed.kitchen_tag]" : G.seed.kitchen_tag
+		else if(istype(S, /obj/item/chems/food/snacks/fruit_slice))
+			var/obj/item/chems/food/snacks/fruit_slice/FS = S
+			if(!FS.seed || !FS.seed.kitchen_tag)
+				continue
+			use_tag = "[FS.seed.kitchen_tag] slice"
+		use_tag = "[S.dry ? "dried " : ""][use_tag]"
+		if(isnull(needed_fruits[use_tag]))
+			continue
+		needed_fruits[use_tag]--
 	for(var/ktag in needed_fruits)
 		if(needed_fruits[ktag] > 0)
 			return FALSE
-	return TRUE
+	return .
 
 /decl/recipe/proc/check_items(var/obj/container)
 	if(!length(items))

--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -73,7 +73,7 @@ var/global/list/microwave_accepts_items =    list(
 	for(var/ktag in needed_fruits)
 		if(needed_fruits[ktag] > 0)
 			return FALSE
-	return .
+	return TRUE
 
 /decl/recipe/proc/check_items(var/obj/container)
 	if(!length(items))

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -121,7 +121,7 @@
 /obj/machinery/smartfridge/drying_rack/accept_check(var/obj/item/O)
 	if(istype(O, /obj/item/chems/food/snacks/))
 		var/obj/item/chems/food/snacks/S = O
-		return S.dried_type
+		return !!S.dried_type
 	else if(istype(O, /obj/item/stack/material))
 		return istype(O.material, /decl/material/solid/skin)
 	return 0
@@ -156,17 +156,12 @@
 				var/obj/item/chems/food/snacks/S = thing
 				if(S.dry || !I.get_specific_product(get_turf(src), S))
 					continue
-				if(S.dried_type == S.type)
-					S.dry = 1
-					S.SetName("dried [S.name]")
-					S.color = "#a38463"
-					stock_item(S)
+				var/result = S.on_dry(get_turf(src))
+				if(result != S)
+					remove_thing = TRUE
+				else
 					I.instances -= thing
 					I.amount--
-				else
-					var/D = S.dried_type
-					new D(get_turf(src))
-					remove_thing = TRUE
 
 			else if(istype(thing, /obj/item/stack/material))
 				var/obj/item/stack/material/skin = thing

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -144,7 +144,7 @@
 
 /obj/item/chems/food/snacks/grown/throw_impact(atom/hit_atom)
 	..()
-	if(seed) 
+	if(seed)
 		seed.thrown_at(src,hit_atom)
 
 var/global/list/_wood_materials = list(
@@ -295,6 +295,8 @@ var/global/list/_wood_materials = list(
 	desc = "A slice of some tasty fruit."
 	icon = 'icons/obj/hydroponics/hydroponics_misc.dmi'
 	icon_state = ""
+	dried_type = /obj/item/chems/food/snacks/fruit_slice
+	var/datum/seed/seed
 
 var/global/list/fruit_icon_cache = list()
 
@@ -306,6 +308,7 @@ var/global/list/fruit_icon_cache = list()
 
 	name = "[S.seed_name] slice"
 	desc = "A slice of \a [S.seed_name]. Tasty, probably."
+	seed = S
 
 	var/rind_colour = S.get_trait(TRAIT_PRODUCT_COLOUR)
 	var/flesh_colour = S.get_trait(TRAIT_FLESH_COLOUR)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -59,7 +59,7 @@
 		to_chat(C, SPAN_NOTICE("You take a bite of [src]."))
 	if (fullness > 350 && fullness <= 550)
 		to_chat(C, SPAN_NOTICE("You unwillingly chew a bit of [src]."))
-	
+
 /obj/item/chems/food/snacks/feed_sound(mob/user)
 	if(eat_sound)
 		playsound(user, pick(eat_sound), rand(10, 50), 1)
@@ -178,6 +178,17 @@
 
 /obj/item/chems/food/snacks/proc/is_sliceable()
 	return (slices_num && slice_path && slices_num > 0)
+
+/obj/item/chems/food/snacks/proc/on_dry(var/atom/newloc)
+	if(dried_type == type)
+		SetName("dried [name]")
+		color = "#a38463"
+		dry = TRUE
+		if(isloc(newloc))
+			forceMove(newloc)
+		return src
+	. = new dried_type(newloc || get_turf(src))
+	qdel(src)
 
 /obj/item/chems/food/snacks/Destroy()
 	if(contents)
@@ -522,8 +533,8 @@
 	desc = "The food of choice for the veteran. Do <b>NOT</b> overconsume."
 	filling_color = "#6d6d00"
 	heated_reagents = list(
-		/decl/material/liquid/regenerator = 5, 
-		/decl/material/liquid/amphetamines = 0.75, 
+		/decl/material/liquid/regenerator = 5,
+		/decl/material/liquid/amphetamines = 0.75,
 		/decl/material/liquid/stimulants = 0.25
 	)
 	var/has_been_heated = 0 // Unlike the warm var, this checks if the one-time self-heating operation has been used.


### PR DESCRIPTION
- Moves drying to `on_dry`, off of drying racks.
- Fruit slices now dry themselves properly.
- Cleans up some drying-related code.
- Adds the ability to specify more complex fruits in recipe fruit lists; you can specify a normal fruit, a dried fruit, a fruit slice, or a dried fruit slice.