### PR TITLE
Constructable trays

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/portable_atmospherics.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/portable_atmospherics.dm
@@ -43,7 +43,6 @@
 	req_components = list(
 		/obj/item/stock_parts/matter_bin = 2,
 		/obj/item/chems/glass/beaker = 1,
-		/obj/item/weedkiller = 1,
 		/obj/item/pipe = 2)
 	additional_spawn_components = list(
 		/obj/item/stock_parts/console_screen = 1,


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->

You can now construct hydroponics trays, since they no longer require a class of multiple unobtainable objects.

## Changelog
:cl:
bugfix: Hydroponics trays may now be constructed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
