### PR TITLE
Adds PDA frame to modular computer recipe list

### DIFF
--- a/code/modules/materials/recipes_items.dm
+++ b/code/modules/materials/recipes_items.dm
@@ -138,6 +138,11 @@
 	result_type = /obj/item/modular_computer/tablet
 	difficulty = 2
 
+/datum/stack_recipe/computer/pda
+	title = "modular PDA frame"
+	result_type = /obj/item/modular_computer/pda
+	difficulty = 2
+
 /datum/stack_recipe/hazard_cone
 	title = "hazard cone"
 	result_type = /obj/item/caution/cone


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

## Description of changes

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds PDA assemblies to the list of constructable modular computer assemblies.


## Why and what will this PR improve

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
PDAs aren't constructable like other modular computer subtypes, but they're pretty vital. They're the only portable device that takes a credstick broadcaster, for example. Not being able to construct them, while you can construct tablets and the like, doesn't make much sense.

## Authorship

<!-- Describe original authors of changes to credit them. -->
Me. I literally just added a new recipe, that's it.

## Changelog

:cl:
rscadd: PDAs are now constructable
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
