### PR TITLE
Makes dreamchecker output not in separate tab

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Dreamchecker
         run:  scripts/install-spaceman-dmm.sh dreamchecker
       - name: Run Dreamchecker
-        run: ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
+        run: ~/dreamchecker 2>&1 | tee ${GITHUB_WORKSPACE}/output-annotations.txt
       - name: Annotate Lints
         uses: yogstation13/DreamAnnotate@34029606cd7c22a08a589e084f860c1cc287363c
         if: always()


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

## Description of changes

Trying to move dreamchecker output back, so it won't create two windows.

## Why and what will this PR improve

Fixes pain in the ass and readability.

## Authorship

Lohikar
