### PR TITLE
Fixes wall router circuit printing

### DIFF
--- a/code/modules/fabrication/designs/imprinter/designs_misc_circuits.dm
+++ b/code/modules/fabrication/designs/imprinter/designs_misc_circuits.dm
@@ -440,6 +440,9 @@
 /datum/fabricator_recipe/imprinter/circuit/router
 	path = /obj/item/stock_parts/circuitboard/router
 
+/datum/fabricator_recipe/imprinter/circuit/router_wall_mounted
+	path = /obj/item/stock_parts/circuitboard/router/wall_mounted
+
 /datum/fabricator_recipe/imprinter/circuit/relay
 	path = /obj/item/stock_parts/circuitboard/relay
 


### PR DESCRIPTION
(cherry picked from commit 51db796f37f5254293e13de74dc51d571e9e92c2)

<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

## Description of changes

Fixes issue which don't allow you to print wall mounted routers.

## Why and what will this PR improve

CI go green on maps which uses wall routers.

## Authorship

Peeked changes from Loaf PR.