### PR TITLE
Adds "Storage" category to the textiles fabricator.

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -13,6 +13,7 @@
 	max_w_class = ITEM_SIZE_LARGE
 	max_storage_space = DEFAULT_BACKPACK_STORAGE
 	open_sound = 'sound/effects/storage/unzip.ogg'
+	material = /decl/material/solid/leather/synth
 
 /obj/item/storage/backpack/equipped()
 	if(!has_extension(src, /datum/extension/appearance))

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -110,3 +110,4 @@
 	max_w_class = ITEM_SIZE_HUGE
 	w_class = ITEM_SIZE_SMALL
 	can_hold = list(/obj/item/coin, /obj/item/cash)
+	material = /decl/material/solid/leather/synth

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -126,6 +126,7 @@
 		/obj/item/hand_labeler,
 		/obj/item/clothing/gloves
 		)
+	material = /decl/material/solid/leather
 
 /obj/item/storage/belt/utility/full/Initialize()
 	. = ..()

--- a/code/game/objects/items/weapons/storage/specialized.dm
+++ b/code/game/objects/items/weapons/storage/specialized.dm
@@ -22,6 +22,7 @@
 	allow_quick_gather = 1
 	allow_quick_empty = 1
 	use_to_pickup = 1
+	material = /decl/material/solid/leather
 
 
 // -----------------------------
@@ -64,6 +65,7 @@
 	allow_quick_gather = 1
 	allow_quick_empty = 1
 	use_to_pickup = 1
+	material = /decl/material/solid/leather
 
 
 // -----------------------------

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -58,7 +58,6 @@
 		/obj/item/storage/box/syndie_kit/chameleon,
 		/obj/item/gun/energy/chameleon,
 		)
-	/obj/item/storage/backpack/chameleon/sydie_kit
 	material = /decl/material/solid/metal/gold
 	matter = list(
 		/decl/material/solid/gemstone/diamond = MATTER_AMOUNT_REINFORCEMENT,

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -58,6 +58,14 @@
 		/obj/item/storage/box/syndie_kit/chameleon,
 		/obj/item/gun/energy/chameleon,
 		)
+	/obj/item/storage/backpack/chameleon/sydie_kit
+	material = /decl/material/solid/metal/gold
+	matter = list(
+		/decl/material/solid/gemstone/diamond = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/silver = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/fiberglass = MATTER_AMOUNT_TRACE,
+		/decl/material/solid/metal/uranium = MATTER_AMOUNT_TRACE
+	) 
 
 /obj/item/storage/box/syndie_kit/chameleon
 	startswith = list(

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -42,6 +42,7 @@
 		/obj/item/clothing/accessory/armor/tag,
 		)
 	slot_flags = SLOT_ID
+	material = /decl/material/solid/leather
 
 	var/obj/item/card/id/front_id = null
 	var/obj/item/charge_stick/front_stick = null

--- a/code/modules/fabrication/designs/textile/storage.dm
+++ b/code/modules/fabrication/designs/textile/storage.dm
@@ -1,3 +1,27 @@
 /datum/fabricator_recipe/textiles/storage
 	category = "Storage"
 	path = /obj/item/storage/backpack
+
+/datum/fabricator_recipe/textiles/storage/dufflebag
+	path = /obj/item/storage/backpack/dufflebag
+
+/datum/fabricator_recipe/textiles/storage/satchel
+	path = /obj/item/storage/backpack/satchel
+
+/datum/fabricator_recipe/textiles/storage/messenger
+	path = /obj/item/storage/backpack/messenger
+
+/datum/fabricator_recipe/textiles/storage/tool_belt
+	path= /obj/item/storage/belt/utility
+
+/datum/fabricator_recipe/textiles/storage/mining_satchel
+	path = /obj/item/storage/ore
+
+/datum/fabricator_recipe/textiles/storage/botanical_satchel
+	path = /obj/item/storage/plants
+
+/datum/fabricator_recipe/textiles/storage/wallet
+	path = /obj/item/storage/wallet/leather
+
+/datum/fabricator_recipe/textiles/storage/money_bag
+	path = /obj/item/storage/bag/cash 

--- a/code/modules/fabrication/designs/textile/storage.dm
+++ b/code/modules/fabrication/designs/textile/storage.dm
@@ -1,0 +1,3 @@
+/datum/fabricator_recipe/textiles/storage
+	category = "Storage"
+	path = /obj/item/storage/backpack

--- a/nebula.dme
+++ b/nebula.dme
@@ -1932,6 +1932,7 @@
 #include "code\modules\fabrication\designs\textile\overwear.dm"
 #include "code\modules\fabrication\designs\textile\protective.dm"
 #include "code\modules\fabrication\designs\textile\space.dm"
+#include "code\modules\fabrication\designs\textile\storage.dm"
 #include "code\modules\flufftext\Dreaming.dm"
 #include "code\modules\flufftext\TextFilters.dm"
 #include "code\modules\food\recipes_microwave.dm"


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

## Description of changes
Added a new category "Storage" to the textiles fabricator with some storage items that would fit this fabricator (e.g: backpacks, bags, etc.).
Gave chamaleon kit a material price because otherwise it causes conflicts with backpacks. This was because this kit is printable from the autolathe which does not accept leather and backpacks are printed with leather.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
Most of these storages items weren't able to be printed before. Some of them could be printed through the biogenerator but they do not fit with this "fabricator". This PR allows these storage items to be printed and gives them their own category on the textiles fab to keep it orderly.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
