### PR TITLE
Expands turf movement delay to flooring

### DIFF
--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -34,6 +34,8 @@
 	var/can_paint
 	var/can_engrave = TRUE
 
+	var/movement_delay
+
 	//How we smooth with other flooring
 	var/decal_layer = DECAL_LAYER
 	var/floor_smooth = SMOOTH_ALL

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -26,6 +26,9 @@
 /turf/simulated/floor/is_plating()
 	return !flooring
 
+/turf/simulated/floor/movement_delay()
+	return flooring?.movement_delay || movement_delay
+
 /turf/simulated/floor/protects_atom(var/atom/A)
 	return (A.level <= 1 && !is_plating()) || ..()
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -25,6 +25,7 @@
 
 	var/list/decals
 
+	// Used for slowdown.
 	var/movement_delay
 
 	var/fluid_can_pass
@@ -115,6 +116,9 @@
 
 /turf/proc/is_solid_structure()
 	return 1
+
+/turf/proc/movement_delay()
+	return movement_delay
 
 /turf/attack_hand(mob/user)
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -196,7 +196,7 @@
 	. = 0
 	if(istype(loc, /turf))
 		var/turf/T = loc
-		. += T.movement_delay
+		. += T.movement_delay()
 	if(HAS_STATUS(src, STAT_DROWSY))
 		. += 6
 	if(lying) //Crawling, it's slower


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

## Description of changes

Adds `movement_delay` variable for /decl/flooring to use on simulated turfs.

## Why and what will this PR improve

Ability to control turf's delay based on flooring for `/turf/simulated/floor` type,

## Authorship

Myself

## Changelog

No player facing changes, just support for it.
