### PR TITLE
Blastdoor and shutters assembly fix

### DIFF
--- a/code/game/machinery/_machines_base/machine_construction/blast_doors.dm
+++ b/code/game/machinery/_machines_base/machine_construction/blast_doors.dm
@@ -1,0 +1,10 @@
+//Uses default states except with a door board needed.
+// Cannot use airlock states, because blast doors do not weld or act the same way as airlocks
+/decl/machine_construction/default/panel_closed/blast_door
+	needs_board = "door"
+	down_state = /decl/machine_construction/default/panel_open/blast_door
+
+/decl/machine_construction/default/panel_open/blast_door
+	needs_board = "door"
+	up_state = /decl/machine_construction/default/panel_closed/blast_door
+

--- a/code/game/machinery/doors/_door.dm
+++ b/code/game/machinery/doors/_door.dm
@@ -69,7 +69,9 @@
 		visible_message("<span class='notice'>\The [user] bonks \the [src] harmlessly.</span>")
 	attack_animation(user)
 
-/obj/machinery/door/Initialize()
+/obj/machinery/door/Initialize(var/mapload, var/d, var/populate_parts = TRUE, var/obj/structure/door_assembly/assembly = null)
+	if(!populate_parts)
+		inherit_from_assembly(assembly)
 	set_extension(src, /datum/extension/penetration, /datum/extension/penetration/proc_call, .proc/CheckPenetration)
 	..()
 	. = INITIALIZE_HINT_LATELOAD
@@ -90,6 +92,8 @@
 	if(autoset_access && length(req_access))
 		PRINT_STACK_TRACE("A door with mapped access restrictions was set to autoinitialize access.")
 #endif
+
+/obj/machinery/door/proc/inherit_from_assembly(var/obj/structure/door_assembly/assembly)
 
 /obj/machinery/door/LateInitialize(mapload, dir=0, populate_parts=TRUE)
 	..()

--- a/code/game/machinery/doors/_door.dm
+++ b/code/game/machinery/doors/_door.dm
@@ -94,6 +94,13 @@
 #endif
 
 /obj/machinery/door/proc/inherit_from_assembly(var/obj/structure/door_assembly/assembly)
+	if (assembly && istype(assembly))
+		frame_type = assembly.type
+		if(assembly.electronics)
+			var/obj/item/stock_parts/circuitboard/electronics = assembly.electronics
+			install_component(electronics, FALSE) // will be refreshed in parent call; unsafe to refresh prior to calling ..() in Initialize
+			electronics.construct(src)
+		return TRUE
 
 /obj/machinery/door/LateInitialize(mapload, dir=0, populate_parts=TRUE)
 	..()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -979,10 +979,8 @@ About the new airlock wires panel:
 		return 0
 	return ..(M)
 
-/obj/machinery/door/airlock/Initialize(var/mapload, var/d, var/populate_parts = TRUE, var/obj/structure/door_assembly/assembly = null)
-	if(!populate_parts)
-		inherit_from_assembly(assembly)
-
+/obj/machinery/door/airlock/Initialize(var/mapload, var/d, var/populate_parts = TRUE, obj/structure/door_assembly/assembly = null)
+	. = ..()
 	//wires
 	var/turf/T = get_turf(loc)
 	if(T && (T.z in global.using_map.admin_levels))
@@ -1007,9 +1005,7 @@ About the new airlock wires panel:
 			var/decl/material/window = get_window_material()
 			window_color = window.color
 
-	. = ..()
-
-/obj/machinery/door/airlock/proc/inherit_from_assembly(obj/structure/door_assembly/assembly)
+/obj/machinery/door/airlock/inherit_from_assembly(obj/structure/door_assembly/assembly)
 	//if assembly is given, create the new door from the assembly
 	if (assembly && istype(assembly))
 		frame_type = assembly.type

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1007,12 +1007,7 @@ About the new airlock wires panel:
 
 /obj/machinery/door/airlock/inherit_from_assembly(obj/structure/door_assembly/assembly)
 	//if assembly is given, create the new door from the assembly
-	if (assembly && istype(assembly))
-		frame_type = assembly.type
-
-		var/obj/item/stock_parts/circuitboard/electronics = assembly.electronics
-		install_component(electronics, FALSE) // will be refreshed in parent call; unsafe to refresh prior to calling ..() in Initialize
-		electronics.construct(src)
+	if (..(assembly))
 		var/decl/material/mat = GET_DECL(assembly.glass_material)
 
 		if(assembly.glass == 1) // supposed to use material in this case
@@ -1038,6 +1033,7 @@ About the new airlock wires panel:
 		stripe_color = assembly.stripe_color
 		symbol_color = assembly.symbol_color
 		queue_icon_update()
+		return TRUE
 
 /obj/machinery/door/airlock/Destroy()
 	if(brace)

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -326,7 +326,7 @@
 	maxhealth = 500
 	explosion_resistance = 10
 	pry_mod = 0.55
-	frame_type = /obj/structure/door_assembly/blast
+	frame_type = /obj/structure/door_assembly/blast/shutter
 
 /obj/machinery/door/blast/shutters/open
 	begins_closed = FALSE

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -64,15 +64,6 @@
 
 	implicit_material = GET_DECL(/decl/material/solid/metal/plasteel)
 
-/obj/machinery/door/blast/inherit_from_assembly(var/obj/structure/door_assembly/assembly)
-	//if assembly is given, create the new door from the assembly
-	if (assembly && istype(assembly))
-		frame_type = assembly.type
-
-		var/obj/item/stock_parts/circuitboard/electronics = assembly.electronics
-		install_component(electronics, FALSE) // will be refreshed in parent call; unsafe to refresh prior to calling ..() in Initialize
-		electronics.construct(src)
-
 /obj/machinery/door/blast/examine(mob/user)
 	. = ..()
 	if((stat & BROKEN))

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -144,16 +144,17 @@
 // This only works on broken doors or doors without power. Also allows repair with Plasteel.
 /obj/machinery/door/blast/attackby(obj/item/C, mob/user)
 	add_fingerprint(user, 0, C)
-	if(isCrowbar(C) || (istype(C, /obj/item/twohanded/fireaxe) && C:wielded == 1))
-		if(((stat & NOPOWER) || (stat & BROKEN)) && !( operating ))
-			to_chat(user, "<span class='notice'>You begin prying at \the [src]...</span>")
-			if(do_after(user, 2 SECONDS, src))
-				force_toggle()
+	if(!panel_open) //Do this here so the door won't change state while prying out the circuit
+		if(isCrowbar(C) || (istype(C, /obj/item/twohanded/fireaxe) && C:wielded == 1))
+			if(((stat & NOPOWER) || (stat & BROKEN)) && !( operating ))
+				to_chat(user, "<span class='notice'>You begin prying at \the [src]...</span>")
+				if(do_after(user, 2 SECONDS, src))
+					force_toggle()
+				else
+					to_chat(user, "<span class='warning'>You must remain still while working on \the [src].</span>")
 			else
-				to_chat(user, "<span class='warning'>You must remain still while working on \the [src].</span>")
-		else
-			to_chat(user, "<span class='notice'>[src]'s motors resist your effort.</span>")
-		return
+				to_chat(user, "<span class='notice'>[src]'s motors resist your effort.</span>")
+			return
 	if(istype(C, /obj/item/stack/material) && C.get_material_type() == /decl/material/solid/metal/plasteel)
 		var/amt = Ceiling((maxhealth - health)/150)
 		if(!amt)

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -49,7 +49,7 @@
 		/decl/public_access/public_method/toggle_door_to
 	)
 	stock_part_presets = list(/decl/stock_part_preset/radio/receiver/blast_door = 1)
-
+	construct_state = /decl/machine_construction/default/panel_closed/blast_door
 	frame_type = /obj/structure/door_assembly/blast
 	base_type = /obj/machinery/door/blast
 

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -64,6 +64,15 @@
 
 	implicit_material = GET_DECL(/decl/material/solid/metal/plasteel)
 
+/obj/machinery/door/blast/inherit_from_assembly(var/obj/structure/door_assembly/assembly)
+	//if assembly is given, create the new door from the assembly
+	if (assembly && istype(assembly))
+		frame_type = assembly.type
+
+		var/obj/item/stock_parts/circuitboard/electronics = assembly.electronics
+		install_component(electronics, FALSE) // will be refreshed in parent call; unsafe to refresh prior to calling ..() in Initialize
+		electronics.construct(src)
+
 /obj/machinery/door/blast/examine(mob/user)
 	. = ..()
 	if((stat & BROKEN))

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -96,7 +96,7 @@
 /obj/structure/door_assembly/blast/shutter
 	name = "shutter assembly"
 	icon = 'icons/obj/doors/rapid_pdoor.dmi'
-	icon_state = "pdoor1"
+	icon_state = "shutter1"
 	airlock_type = /obj/machinery/door/blast/shutters
 
 /obj/structure/door_assembly/attackby(obj/item/W, mob/user)

--- a/nebula.dme
+++ b/nebula.dme
@@ -743,6 +743,7 @@
 #include "code\game\machinery\_machines_base\machinery_public_vars_common.dm"
 #include "code\game\machinery\_machines_base\machine_construction\_construction.dm"
 #include "code\game\machinery\_machines_base\machine_construction\airlock.dm"
+#include "code\game\machinery\_machines_base\machine_construction\blast_doors.dm"
 #include "code\game\machinery\_machines_base\machine_construction\computer.dm"
 #include "code\game\machinery\_machines_base\machine_construction\default.dm"
 #include "code\game\machinery\_machines_base\machine_construction\frame.dm"


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

## Description of changes
Blast doors and shutters cannot be welded so they needed to have their own construct state since airlocks' states expect the door to be welded before being able to open the maintenance panel. 
Also, building blast doors/shutters from an assembly would result in the electronics not being moved to the blast door since the code handling inheriting electronics from assemblies was left completely in the airlock class. That resulted in the blast door/shutter being broken after construction.

This PR attempts to fix those issues, along with some extra minor bugfixes.

## Why and what will this PR improve
The PR moves the inherit_from_assembly() proc to the door class, so both the blast door and airlock class can reuse common code between both. 
It also create 2 new states for blast doors, for the panel_open and panel_closed state, so that it enforces door electronics, and uses the default machine behavior for opening the maintenance panel.
Also fixes the wrong icon being used on shutter assemblies, and the wrong assembly being used when deconstructing a shutter.

## Authorship
Me

## Changelog

:cl:
bugfix: Fixed shutters and blast doors deconstructed and panel_open state being unreachable.
bugfix: Fixed shutters assemblies having the wrong icon.
bugfix: Fixed shutters deconstructing to blast door assemblies.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
