### PR TITLE
Removes AS_ANYTHING and replaces with as anything

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -264,9 +264,3 @@
 
 #define GET_DECL(D) (ispath(D, /decl) ? (decls_repository.fetched_decls[D] || decls_repository.get_decl(D)) : null)
 #define Z_ALL_TURFS(Z) block(locate(1, 1, Z), locate(world.maxx, world.maxy, Z))
-
-#if DM_BUILD < 1540
-#define AS_ANYTHING as()
-#else
-#define AS_ANYTHING as anything
-#endif

--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -714,7 +714,7 @@ The _flatIcons list is a cache for generated icon files.
 	var/addY2
 
 	var/icon/add // Icon of overlay being added
-	for(var/image/I AS_ANYTHING in layers)
+	for(var/image/I as anything in layers)
 
 		if(I.alpha == 0)
 			continue

--- a/code/controllers/subsystems/fluids.dm
+++ b/code/controllers/subsystems/fluids.dm
@@ -219,7 +219,7 @@ SUBSYSTEM_DEF(fluids)
 		current_turf = current_fluid.loc
 		var/pushed_something = FALSE
 		if(reagent_holder.total_volume > FLUID_SHALLOW && current_fluid.last_flow_strength >= 10)
-			for(var/atom/movable/AM AS_ANYTHING in current_turf.get_contained_external_atoms())
+			for(var/atom/movable/AM as anything in current_turf.get_contained_external_atoms())
 				if(AM.is_fluid_pushable(current_fluid.last_flow_strength))
 					AM.pushed(current_fluid.last_flow_dir)
 					pushed_something = TRUE

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -17,7 +17,7 @@ SUBSYSTEM_DEF(mapping)
 	overmap_event_handler = GET_DECL(/decl/overmap_event_handler)
 
 	// Load templates and build away sites.
-	for(var/obj/effect/landmark/map_load_mark/marker AS_ANYTHING in compile_time_map_markers)
+	for(var/obj/effect/landmark/map_load_mark/marker as anything in compile_time_map_markers)
 		compile_time_map_markers -= marker
 		marker.load_template()
 

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -188,7 +188,7 @@
 			to_chat(mob, SPAN_WARNING("You're pinned down by \a [mob.pinned[1]]!"))
 		return MOVEMENT_STOP
 
-	for(var/obj/item/grab/G AS_ANYTHING in mob.grabbed_by)
+	for(var/obj/item/grab/G as anything in mob.grabbed_by)
 		if(G.assailant != mob && G.assailant != mover && (mob.restrained() || G.stop_move()))
 			if(mover == mob)
 				to_chat(mob, SPAN_WARNING("You're restrained and cannot move!"))
@@ -222,25 +222,25 @@
 
 	var/turf/new_loc = mob.loc
 	if(istype(new_loc))
-		for(var/atom/movable/AM AS_ANYTHING in mob.ret_grab())
+		for(var/atom/movable/AM as anything in mob.ret_grab())
 			if(AM != src && AM.loc != mob.loc && !AM.anchored && old_turf.Adjacent(AM))
 				AM.glide_size = mob.glide_size // This is adjusted by grabs again from events/some of the procs below, but doing it here makes it more likely to work with recursive movement.
 				AM.DoMove(get_dir(get_turf(AM), old_turf), mob, TRUE)
 
-		for(var/obj/item/grab/G AS_ANYTHING in mob.get_active_grabs())
+		for(var/obj/item/grab/G as anything in mob.get_active_grabs())
 			G.adjust_position()
 
-	for(var/obj/item/grab/G AS_ANYTHING in mob.get_active_grabs())
+	for(var/obj/item/grab/G as anything in mob.get_active_grabs())
 		if(G.assailant_reverse_facing())
 			mob.set_dir(global.reverse_dir[direction])
 		G.assailant_moved()
-	for(var/obj/item/grab/G AS_ANYTHING in mob.grabbed_by)
+	for(var/obj/item/grab/G as anything in mob.grabbed_by)
 		G.adjust_position()
 
 	if(direction & (UP|DOWN))
 		var/txt_dir = (direction & UP) ? "upwards" : "downwards"
 		old_turf.visible_message(SPAN_NOTICE("[mob] moves [txt_dir]."))
-		for(var/obj/item/grab/G AS_ANYTHING in mob.get_active_grabs())
+		for(var/obj/item/grab/G as anything in mob.get_active_grabs())
 			if(!G.affecting)
 				continue
 			var/turf/start = G.affecting.loc

--- a/code/datums/state_machine/state.dm
+++ b/code/datums/state_machine/state.dm
@@ -16,7 +16,7 @@
 // Returns a list of transitions that a FSM could switch to.
 // Note that `holder` is NOT the FSM, but instead the thing the FSM is attached to.
 /decl/state/proc/get_open_transitions(datum/holder)
-	for(var/decl/state_transition/T AS_ANYTHING in transitions)
+	for(var/decl/state_transition/T as anything in transitions)
 		if(T.is_open(holder))
 			LAZYADD(., T)
 

--- a/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
@@ -77,7 +77,7 @@ var/global/universe_has_ended = 0
 	universe_has_ended = TRUE
 
 /datum/universal_state/supermatter_cascade/proc/AreaSet()
-	for(var/area/A AS_ANYTHING in global.areas)
+	for(var/area/A as anything in global.areas)
 		var/invalid_area = FALSE
 		for(var/check_area in global.using_map.get_universe_end_evac_areas())
 			if(istype(A, check_area))

--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -447,7 +447,7 @@
 		spawnpos = null
 	if(!spawnpos)
 		// Step through all spawnpoints and pick first appropriate for job
-		for(var/decl/spawnpoint/candidate AS_ANYTHING in global.using_map.allowed_spawns)
+		for(var/decl/spawnpoint/candidate as anything in global.using_map.allowed_spawns)
 			if(candidate?.check_job_spawning(src))
 				spawnpos = candidate
 				break

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -115,7 +115,7 @@
 				SPAN_NOTICE("\The [M.name] unbuckled themselves!"),\
 				SPAN_NOTICE("You unbuckle yourself from \the [src]."),\
 				SPAN_NOTICE("You hear metal clanking."))
-		for(var/obj/item/grab/G AS_ANYTHING in (M.grabbed_by|grabbed_by))
+		for(var/obj/item/grab/G as anything in (M.grabbed_by|grabbed_by))
 			qdel(G)
 		add_fingerprint(user)
 	return M

--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -19,7 +19,7 @@
 			W.wall_connections = null
 			W.other_connections = null
 			iterate_turfs += W
-		for(var/turf/simulated/wall/W AS_ANYTHING in iterate_turfs)
+		for(var/turf/simulated/wall/W as anything in iterate_turfs)
 			W.update_icon()
 	else
 		wall_connections = null

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -87,7 +87,7 @@
 
 /turf/fluid_act(var/datum/reagents/fluids)
 	fluids.touch(src)
-	for(var/atom/movable/AM AS_ANYTHING in get_contained_external_atoms())
+	for(var/atom/movable/AM as anything in get_contained_external_atoms())
 		AM.fluid_act(fluids)
 
 /turf/proc/remove_fluids(var/amount, var/defer_update)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -483,7 +483,7 @@
 	trap = GET_DECL(trap)
 	trap.forced(mob)
 
-/client/proc/spawn_exoplanet(exoplanet_type AS_ANYTHING in subtypesof(/obj/effect/overmap/visitable/sector/exoplanet))
+/client/proc/spawn_exoplanet(exoplanet_type as anything in subtypesof(/obj/effect/overmap/visitable/sector/exoplanet))
 	set category = "Debug"
 	set name = "Create Exoplanet"
 

--- a/code/modules/admin/verbs/fluids.dm
+++ b/code/modules/admin/verbs/fluids.dm
@@ -17,7 +17,7 @@
 	if(!reagent_type || !user || !check_rights(R_SPAWN))
 		return
 	var/turf/flooding = get_turf(user)
-	for(var/turf/T AS_ANYTHING in RANGE_TURFS(flooding, spawn_range))
+	for(var/turf/T as anything in RANGE_TURFS(flooding, spawn_range))
 		T.add_fluid(reagent_type, reagent_amount)
 
 /datum/admins/proc/jump_to_fluid_source()

--- a/code/modules/atmospherics/atmospherics.dm
+++ b/code/modules/atmospherics/atmospherics.dm
@@ -48,7 +48,7 @@ Pipelines + Other Objects -> Pipe network
 	. = ..()
 
 /obj/machinery/atmospherics/Destroy()
-	for(var/obj/machinery/atmospherics/node AS_ANYTHING in nodes_to_networks)
+	for(var/obj/machinery/atmospherics/node as anything in nodes_to_networks)
 		QDEL_NULL(nodes_to_networks[node])
 		node.disconnect(src)
 	nodes_to_networks = null
@@ -56,7 +56,7 @@ Pipelines + Other Objects -> Pipe network
 
 /obj/machinery/atmospherics/proc/atmos_init()
 	atmos_initalized = TRUE
-	for(var/obj/machinery/atmospherics/node AS_ANYTHING in nodes_to_networks)
+	for(var/obj/machinery/atmospherics/node as anything in nodes_to_networks)
 		QDEL_NULL(nodes_to_networks[node])
 	nodes_to_networks = null
 	for(var/direction in global.cardinal)
@@ -105,7 +105,7 @@ Pipelines + Other Objects -> Pipe network
 		return
 	var/disconnected_directions = initialize_directions
 	var/visible_directions = 0
-	for(var/obj/machinery/atmospherics/node AS_ANYTHING in nodes_to_networks)
+	for(var/obj/machinery/atmospherics/node as anything in nodes_to_networks)
 		var/node_dir = get_dir(src, node)
 		disconnected_directions &= ~node_dir
 		if(hide_hidden_pipes && !T.is_plating() && node.level == 1 && istype(node, /obj/machinery/atmospherics/pipe))
@@ -144,7 +144,7 @@ Pipelines + Other Objects -> Pipe network
 	// Note don't forget to have neighbors look as well!
 
 	// Default behavior is: one network for all nodes in a given dir
-	for(var/obj/machinery/atmospherics/node AS_ANYTHING in nodes_in_dir(get_dir(src, reference)))
+	for(var/obj/machinery/atmospherics/node as anything in nodes_in_dir(get_dir(src, reference)))
 		if(nodes_to_networks[node] != new_network)
 			qdel(nodes_to_networks[node])
 			nodes_to_networks[node] = new_network
@@ -260,8 +260,8 @@ Pipelines + Other Objects -> Pipe network
 // called after being built by hand, before the pipe item or circuit is deleted
 /obj/machinery/atmospherics/proc/build(obj/item/builder)
 	atmos_init()
-	for(var/obj/machinery/atmospherics/node AS_ANYTHING in nodes_to_networks)
+	for(var/obj/machinery/atmospherics/node as anything in nodes_to_networks)
 		node.atmos_init()
 	build_network()
-	for(var/obj/machinery/atmospherics/node AS_ANYTHING in nodes_to_networks)
+	for(var/obj/machinery/atmospherics/node as anything in nodes_to_networks)
 		node.build_network()

--- a/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
+++ b/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
@@ -35,13 +35,13 @@
 	if(anchored)
 		set_dir(dir) // making sure
 		atmos_init()
-		for(var/obj/machinery/atmospherics/node AS_ANYTHING in nodes_to_networks)
+		for(var/obj/machinery/atmospherics/node as anything in nodes_to_networks)
 			node.atmos_init()
 		build_network()
-		for(var/obj/machinery/atmospherics/node AS_ANYTHING in nodes_to_networks)
+		for(var/obj/machinery/atmospherics/node as anything in nodes_to_networks)
 			node.build_network()
 	else
-		for(var/obj/machinery/atmospherics/node AS_ANYTHING in nodes_to_networks)
+		for(var/obj/machinery/atmospherics/node as anything in nodes_to_networks)
 			node.disconnect(src)
 		for(var/node in nodes_to_networks)
 			QDEL_NULL(nodes_to_networks[node])

--- a/code/modules/atmospherics/components/omni_devices/_omni_extras.dm
+++ b/code/modules/atmospherics/components/omni_devices/_omni_extras.dm
@@ -48,14 +48,14 @@
 	if(LAZYLEN(nodes))
 		return
 	master.atmos_init()
-	for(var/obj/machinery/atmospherics/node AS_ANYTHING in nodes)
+	for(var/obj/machinery/atmospherics/node as anything in nodes)
 		node.atmos_init()
 	master.build_network()
-	for(var/obj/machinery/atmospherics/node AS_ANYTHING in nodes)
+	for(var/obj/machinery/atmospherics/node as anything in nodes)
 		node.build_network()
 
 /datum/omni_port/proc/disconnect()
-	for(var/obj/machinery/atmospherics/node AS_ANYTHING in nodes)
+	for(var/obj/machinery/atmospherics/node as anything in nodes)
 		node.disconnect(master)
 		master.disconnect(node)
 

--- a/code/modules/atmospherics/components/omni_devices/omni_base.dm
+++ b/code/modules/atmospherics/components/omni_devices/omni_base.dm
@@ -199,7 +199,7 @@
 		if((reference in P.nodes) && (new_network != P.network))
 			qdel(P.network)
 			P.network = new_network
-			for(var/obj/machinery/atmospherics/node AS_ANYTHING in P.nodes)
+			for(var/obj/machinery/atmospherics/node as anything in P.nodes)
 				if(node != reference)
 					node.network_expand(new_network, src)
 

--- a/code/modules/atmospherics/components/tvalve.dm
+++ b/code/modules/atmospherics/components/tvalve.dm
@@ -61,7 +61,7 @@
 		. |= nodes_in_dir(other_dir)
 
 /obj/machinery/atmospherics/tvalve/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
-	for(var/obj/machinery/atmospherics/node AS_ANYTHING in get_nodes_connected_to(reference))
+	for(var/obj/machinery/atmospherics/node as anything in get_nodes_connected_to(reference))
 		if(nodes_to_networks[node] != new_network)
 			QDEL_NULL(nodes_to_networks[node])
 			nodes_to_networks[node] = new_network

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -310,7 +310,7 @@
 			return SPAN_WARNING("You cannot unwrench \the [src], turn it off first.")
 		var/turf/T = src.loc
 		var/hidden_pipe_check = FALSE
-		for(var/obj/machinery/atmospherics/node AS_ANYTHING in nodes_to_networks)
+		for(var/obj/machinery/atmospherics/node as anything in nodes_to_networks)
 			if(node.level)
 				hidden_pipe_check = TRUE
 				break

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -169,7 +169,7 @@
 			return SPAN_WARNING("You cannot take this [src] apart, turn it off first.")
 		var/turf/T = get_turf(src)
 		var/hidden_pipe_check = FALSE
-		for(var/obj/machinery/atmospherics/node AS_ANYTHING in nodes_to_networks)
+		for(var/obj/machinery/atmospherics/node as anything in nodes_to_networks)
 			if(node.level)
 				hidden_pipe_check = TRUE
 				break

--- a/code/modules/atmospherics/components/valve.dm
+++ b/code/modules/atmospherics/components/valve.dm
@@ -44,7 +44,7 @@
 
 /obj/machinery/atmospherics/valve/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
 	if(open) // connect everything
-		for(var/obj/machinery/atmospherics/node AS_ANYTHING in nodes_to_networks)
+		for(var/obj/machinery/atmospherics/node as anything in nodes_to_networks)
 			if(nodes_to_networks[node] != new_network)
 				QDEL_NULL(nodes_to_networks[node])
 				nodes_to_networks[node] = new_network

--- a/code/modules/atmospherics/he_pipes.dm
+++ b/code/modules/atmospherics/he_pipes.dm
@@ -33,7 +33,7 @@
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/atmos_init()
 	atmos_initalized = TRUE
-	for(var/obj/machinery/atmospherics/node AS_ANYTHING in nodes_to_networks)
+	for(var/obj/machinery/atmospherics/node as anything in nodes_to_networks)
 		QDEL_NULL(nodes_to_networks[node])
 	nodes_to_networks = null
 	for(var/direction in global.cardinal)

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -165,7 +165,7 @@
 /obj/machinery/atmospherics/pipe/set_color(new_color)
 	..()
 	//for updating connected atmos device pipes (i.e. vents, manifolds, etc)
-	for(var/obj/machinery/atmospherics/node AS_ANYTHING in nodes_to_networks)
+	for(var/obj/machinery/atmospherics/node as anything in nodes_to_networks)
 		node.update_icon()
 
 /obj/machinery/atmospherics/pipe/proc/try_leak()
@@ -708,7 +708,7 @@
 /obj/machinery/atmospherics/proc/universal_underlays(var/direction)
 	var/turf/T = loc
 	var/connections = list("", "-supply", "-scrubbers")
-	for(var/obj/machinery/atmospherics/node AS_ANYTHING in nodes_in_dir(direction))
+	for(var/obj/machinery/atmospherics/node as anything in nodes_in_dir(direction))
 		if(node.icon_connect_type in connections)
 			connections[node.icon_connect_type] = node
 	for(var/suffix in connections)

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -16,7 +16,7 @@
 	pref.be_random_name = R.read("name_is_always_random")
 
 	pref.spawnpoint = R.read("spawnpoint")
-	for(var/decl/spawnpoint/spawnpoint AS_ANYTHING in global.using_map.allowed_spawns)
+	for(var/decl/spawnpoint/spawnpoint as anything in global.using_map.allowed_spawns)
 		if(pref.spawnpoint == spawnpoint.name)
 			pref.spawnpoint = spawnpoint.type
 			break
@@ -35,7 +35,7 @@
 /datum/category_item/player_setup_item/physical/basic/sanitize_character()
 	
 	var/valid_spawn = FALSE
-	for(var/decl/spawnpoint/spawnpoint AS_ANYTHING in global.using_map.allowed_spawns)
+	for(var/decl/spawnpoint/spawnpoint as anything in global.using_map.allowed_spawns)
 		if(pref.spawnpoint == spawnpoint.type)
 			valid_spawn = TRUE
 			break

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -262,7 +262,7 @@ var/global/list/_client_preferences_by_type
 /datum/client_preference/show_status_markers/changed(mob/preference_mob, new_value)
 	. = ..()
 	if(preference_mob.client)
-		for(var/datum/status_marker_holder/marker AS_ANYTHING in global.status_marker_holders)
+		for(var/datum/status_marker_holder/marker as anything in global.status_marker_holders)
 			var/marker_image = (preference_mob.status_markers == marker) ? marker.mob_image_personal : marker.mob_image
 			if(new_value == PREF_HIDE)
 				preference_mob.client.images -= marker_image

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -61,7 +61,7 @@
 
 	var/list/shields = list()
 	if(overmap_only)
-		for(var/obj/effect/overmap/visitable/sector AS_ANYTHING in overmap_sectors)
+		for(var/obj/effect/overmap/visitable/sector as anything in overmap_sectors)
 			var/list/sector_shields = sector.get_linked_machines_of_type(/obj/machinery/power/shield_generator)
 			if(length(sector_shields))
 				shields |= sector_shields
@@ -70,7 +70,7 @@
 			if(G.z in affecting_z)
 				shields |= G
 
-	for(var/obj/machinery/power/shield_generator/G AS_ANYTHING in shields)
+	for(var/obj/machinery/power/shield_generator/G as anything in shields)
 		if(!(G.running) || !G.check_flag(MODEFLAG_EM))
 			shields -= G
 
@@ -86,7 +86,7 @@
 	for(var/i=0, i< severity*2, i++) // up to 2/4/6 APCs per tick depending on severity
 		picked_apcs |= pick(valid_apcs)
 
-	for(var/obj/machinery/power/apc/T AS_ANYTHING in picked_apcs)
+	for(var/obj/machinery/power/apc/T as anything in picked_apcs)
 		// Main breaker is turned off. Consider this APC protected.
 		if(!T.operating || T.failure_timer)
 			continue

--- a/code/modules/maps/map_template.dm
+++ b/code/modules/maps/map_template.dm
@@ -187,7 +187,7 @@
 	return TRUE
 
 /datum/map_template/proc/after_load(z)
-	for(var/obj/effect/landmark/map_load_mark/mark AS_ANYTHING in subtemplates_to_spawn)
+	for(var/obj/effect/landmark/map_load_mark/mark as anything in subtemplates_to_spawn)
 		subtemplates_to_spawn -= mark
 		mark.load_template()
 	subtemplates_to_spawn = null

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -133,7 +133,7 @@
 		species.handle_exertion(src)
 
 		var/stamina_cost = 0
-		for(var/obj/item/grab/G AS_ANYTHING in get_active_grabs())
+		for(var/obj/item/grab/G as anything in get_active_grabs())
 			stamina_cost -= G.grab_slowdown()
 		stamina_cost = round(stamina_cost)
 		if(stamina_cost < 0)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -113,7 +113,7 @@
 	if(get_preference_value(/datum/client_preference/show_status_markers) == PREF_SHOW)
 		if(status_markers)
 			client.images |= status_markers.mob_image_personal
-		for(var/datum/status_marker_holder/marker AS_ANYTHING in global.status_marker_holders)
+		for(var/datum/status_marker_holder/marker as anything in global.status_marker_holders)
 			if(marker != status_markers)
 				client.images |= marker.mob_image
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -205,7 +205,7 @@
 #undef ENCUMBERANCE_MOVEMENT_MOD
 
 /mob/proc/encumbrance()
-	for(var/obj/item/grab/G AS_ANYTHING in get_active_grabs())
+	for(var/obj/item/grab/G as anything in get_active_grabs())
 		. = max(., G.grab_slowdown())
 	. *= (0.8 ** size_strength_mod())
 	. *= (0.5 + 1.5 * (SKILL_MAX - get_skill_value(SKILL_HAULING))/(SKILL_MAX - SKILL_MIN))

--- a/code/modules/nano/modules/human_appearance.dm
+++ b/code/modules/nano/modules/human_appearance.dm
@@ -103,7 +103,7 @@
 	data["change_gender"] = can_change(APPEARANCE_GENDER)
 	if(data["change_gender"])
 		var/genders[0]
-		for(var/decl/pronouns/G AS_ANYTHING in owner.species.available_pronouns)
+		for(var/decl/pronouns/G as anything in owner.species.available_pronouns)
 			genders[++genders.len] =  list("gender_name" = capitalize(G.name), "gender_key" = G.name)
 		data["genders"] = genders
 
@@ -111,7 +111,7 @@
 	data["change_bodytype"] = can_change(APPEARANCE_BODY)
 	if(data["change_bodytype"])
 		var/bodytypes[0]
-		for(var/decl/bodytype/B AS_ANYTHING in owner.species.available_bodytypes)
+		for(var/decl/bodytype/B as anything in owner.species.available_bodytypes)
 			bodytypes += capitalize(B.name)
 		data["bodytypes"] = bodytypes
 

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -65,7 +65,7 @@ var/global/list/known_overmap_sectors
 		LAZYADD(global.known_overmap_sectors, src)
 		layer = ABOVE_LIGHTING_LAYER
 		plane = ABOVE_LIGHTING_PLANE
-		for(var/obj/machinery/computer/ship/helm/H AS_ANYTHING in global.overmap_helm_computers)
+		for(var/obj/machinery/computer/ship/helm/H as anything in global.overmap_helm_computers)
 			H.add_known_sector(src)
 
 	find_z_levels()     // This populates map_z and assigns z levels to the ship.

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -29,7 +29,7 @@ var/global/list/overmap_helm_computers
 /obj/machinery/computer/ship/helm/Initialize()
 	. = ..()
 	LAZYADD(global.overmap_helm_computers, src)
-	for(var/obj/effect/overmap/visitable/sector AS_ANYTHING in global.known_overmap_sectors)
+	for(var/obj/effect/overmap/visitable/sector as anything in global.known_overmap_sectors)
 		add_known_sector(sector)
 
 /obj/machinery/computer/ship/helm/Destroy()

--- a/code/modules/projectiles/targeting/targeting_triggers.dm
+++ b/code/modules/projectiles/targeting/targeting_triggers.dm
@@ -3,7 +3,7 @@
 	return
 
 /mob/living/trigger_aiming(var/trigger_type)
-	for(var/obj/aiming_overlay/AO AS_ANYTHING in aimed_at_by)
+	for(var/obj/aiming_overlay/AO as anything in aimed_at_by)
 		if(AO.aiming_at == src)
 			AO.update_aiming()
 			if(AO.aiming_at == src)

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -291,9 +291,9 @@
 			var/datum/powernet/NewPN = new()
 			NewPN.add_cable(C)
 			propagate_network(C,C.powernet)
-	for(var/obj/machinery/atmospherics/pipe AS_ANYTHING in pipes)
+	for(var/obj/machinery/atmospherics/pipe as anything in pipes)
 		pipe.atmos_init() // this will clear pipenet/pipeline
-	for(var/obj/machinery/atmospherics/pipe AS_ANYTHING in pipes)
+	for(var/obj/machinery/atmospherics/pipe as anything in pipes)
 		pipe.build_network()
 
 //returns 1 if the shuttle has a valid arrive time

--- a/code/modules/status_conditions/_status_markers.dm
+++ b/code/modules/status_conditions/_status_markers.dm
@@ -28,9 +28,9 @@
 	var/image/mob_image_personal
 
 /datum/status_marker_holder/proc/clear_markers()
-	for(var/marker AS_ANYTHING in markers)
+	for(var/marker as anything in markers)
 		animate(markers[marker], pixel_z = 12, alpha = 0, time = 3)
-	for(var/marker AS_ANYTHING in markers_personal)
+	for(var/marker as anything in markers_personal)
 		animate(markers_personal[marker], pixel_z = 12, alpha = 0, time = 3)
 
 /datum/status_marker_holder/New(var/mob/owner)
@@ -103,7 +103,7 @@
 
 /datum/status_marker_holder/proc/apply_offsets(var/mob/owner, var/list/markers_to_check, var/check_show_status = TRUE)
 	var/list/visible_markers
-	for(var/decl/status_condition/stat AS_ANYTHING in markers_to_check)
+	for(var/decl/status_condition/stat as anything in markers_to_check)
 		if(HAS_STATUS(owner, stat.type) && (!check_show_status || stat.show_status(owner)))
 			LAZYADD(visible_markers, markers_to_check[stat])
 		else

--- a/code/unit_tests/aspects.dm
+++ b/code/unit_tests/aspects.dm
@@ -32,7 +32,7 @@
 		var/decl/aspect/aspect = all_aspects[atype]
 		if(initial(aspect.parent) && !istype(aspect.parent))
 			failures += "[atype] - invalid parent - [aspect.parent || "NULL"]"
-		for(var/decl/aspect/A AS_ANYTHING in aspect.children)
+		for(var/decl/aspect/A as anything in aspect.children)
 			if(!istype(A))
 				failures += "[atype] - invalid child - [A || "NULL"]"
 			else if(A.parent != aspect)

--- a/code/unit_tests/atmospherics_tests.dm
+++ b/code/unit_tests/atmospherics_tests.dm
@@ -339,7 +339,7 @@
 /datum/unit_test/atmos_machinery_node_reciprocity/start_test()
 	var/fail = FALSE
 	for(var/obj/machinery/atmospherics/machine in SSmachines.machinery)
-		for(var/obj/machinery/atmospherics/node AS_ANYTHING in machine.nodes_to_networks)
+		for(var/obj/machinery/atmospherics/node as anything in machine.nodes_to_networks)
 			if(node == machine)
 				log_bad("[log_info_line(machine)] was its own node.")
 				fail = TRUE

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -266,7 +266,7 @@
 
 /datum/unit_test/correct_allowed_spawn_test/start_test()
 	var/list/failed = list()
-	for(var/decl/spawnpoint/spawnpoint AS_ANYTHING in global.using_map.allowed_spawns)
+	for(var/decl/spawnpoint/spawnpoint as anything in global.using_map.allowed_spawns)
 		if(!length(spawnpoint.turfs))
 			log_unit_test("Map allows spawning in [spawnpoint.name], but [spawnpoint.name] has no associated spawn turfs.")
 			failed += spawnpoint.type


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

## Description of changes

Removes overkill define which used to be a gap for old byond versions where `as anything` had issues.

## Why and what will this PR improve

Main reason why I opened this PR:
![изображение](https://user-images.githubusercontent.com/44920739/125701252-333f965a-5943-453f-bcb2-8e1910ace7a2.png)


Currently MapDiff rendering is broken on our dev branch, because MapDiffBot trying to parse define instead just `as anything`.
I know what I can just replace it with `as anything` in one place, but then, this means what `AS_ANYTHING` is not what we need to support. In my option, this is crutches. 

## Authorship

Affected found the issue, I removed the define.