### PR TITLE
Tweaks/fixes to shuttle engine code.

### DIFF
--- a/code/modules/overmap/ships/machines/fusion_thruster.dm
+++ b/code/modules/overmap/ships/machines/fusion_thruster.dm
@@ -2,13 +2,9 @@
 	name = "fusion nozzle"
 	desc = "Simple rocket nozzle, expelling gas at hypersonic velocities to propell the ship."
 
-	base_type = /obj/machinery/atmospherics/unary/engine
-	construct_state = /decl/machine_construction/default/panel_closed
-	maximum_component_parts = list(/obj/item/stock_parts = 8)//don't want too many, let upgraded component shine
+	base_type = /obj/machinery/atmospherics/unary/engine/fusion
 	engine_extension = /datum/extension/ship_engine/gas/fusion
 
-	use_power = POWER_USE_OFF
-	power_channel = EQUIP
 	idle_power_usage = 13600
 	var/initial_id_tag
 	var/obj/machinery/power/fusion_core/harvest_from

--- a/code/modules/overmap/ships/machines/gas_thruster.dm
+++ b/code/modules/overmap/ships/machines/gas_thruster.dm
@@ -10,6 +10,8 @@
 	var/engine_extension = /datum/extension/ship_engine/gas
 	construct_state = /decl/machine_construction/default/panel_closed
 	maximum_component_parts = list(/obj/item/stock_parts = 8)//don't want too many, let upgraded component shine
+	uncreated_component_parts = null
+	base_type = /obj/machinery/atmospherics/unary/engine
 
 	use_power = POWER_USE_OFF
 	power_channel = EQUIP
@@ -81,6 +83,7 @@
 	set_dir(ndir)
 	QDEL_IN(src, 2 SECONDS)
 
+// This comes with an additional terminal component and tries to set it up on init (you should map a terminal beneath it). This is for mapping only.
 /obj/machinery/atmospherics/unary/engine/terminal
-	base_type = /obj/machinery/atmospherics/unary/engine
+	uncreated_component_parts = list(/obj/item/stock_parts/power/terminal/buildable)
 	stock_part_presets = list(/decl/stock_part_preset/terminal_setup)

--- a/mods/content/generic_shuttles/tanker/tanker.dmm
+++ b/mods/content/generic_shuttles/tanker/tanker.dmm
@@ -19,7 +19,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/tanker)
 "bC" = (
-/obj/machinery/atmospherics/unary/engine/terminal{
+/obj/machinery/atmospherics/unary/engine{
 	dir = 8
 	},
 /turf/simulated/floor/reinforced/airless,


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

## Description of changes

Modifies machinery setup for subtypes of thruster engines.

## Why and what will this PR improve

They all appear to be incorrect at the moment, in different ways: normal engines spawn with two tesla links, fusion engines will deconstruct into normal engine circuitboards, and terminal engines do not spawn with a terminal.

## Authorship

me