### PR TITLE
Moves AO layer down to avoid mouse opacity issues.

### DIFF
--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -93,6 +93,7 @@ What is the naming convention for planes or layers?
 	//ABOVE TURF
 	#define DECAL_LAYER                 2.03
 	#define RUNE_LAYER                  2.04
+	#define AO_LAYER                    2.045
 	#define ABOVE_TILE_LAYER            2.05
 	#define EXPOSED_PIPE_LAYER          2.06
 	#define EXPOSED_WIRE_LAYER          2.07
@@ -101,7 +102,6 @@ What is the naming convention for planes or layers?
 	#define BLOOD_LAYER                 2.10
 	#define MOUSETRAP_LAYER             2.11
 	#define PLANT_LAYER                 2.12
-	#define AO_LAYER                    2.13
 	//HIDING MOB
 	#define HIDING_MOB_LAYER            2.14
 	#define SHALLOW_FLUID_LAYER         2.15

--- a/code/modules/atmospherics/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/components/binary_devices/circulator.dm
@@ -8,6 +8,7 @@
 	icon_state = "circ-unassembled"
 	anchored = 0
 	obj_flags = OBJ_FLAG_ANCHORABLE | OBJ_FLAG_ROTATABLE
+	layer = STRUCTURE_LAYER
 
 	var/kinetic_efficiency = 0.04 //combined kinetic and kinetic-to-electric efficiency
 	var/volume_ratio = 0.2

--- a/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
+++ b/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
@@ -12,6 +12,7 @@
 	uncreated_component_parts = null
 	stat_immune = 0
 	obj_flags = OBJ_FLAG_ANCHORABLE | OBJ_FLAG_ROTATABLE
+	layer = STRUCTURE_LAYER
 
 	var/target_pressure = 10*ONE_ATMOSPHERE
 	var/id = null

--- a/code/modules/atmospherics/components/unary/cold_sink.dm
+++ b/code/modules/atmospherics/components/unary/cold_sink.dm
@@ -6,6 +6,7 @@
 	desc = "Cools gas when connected to a pipe network."
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "freezer_0"
+	layer = STRUCTURE_LAYER
 	density = 1
 	anchored = 1
 	use_power = POWER_USE_OFF

--- a/code/modules/atmospherics/components/unary/heat_source.dm
+++ b/code/modules/atmospherics/components/unary/heat_source.dm
@@ -6,6 +6,7 @@
 	desc = "Heats gas when connected to a pipe network."
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "heater_0"
+	layer = STRUCTURE_LAYER
 	density = 1
 	anchored = 1
 	use_power = POWER_USE_OFF

--- a/code/modules/overmap/ships/machines/gas_thruster.dm
+++ b/code/modules/overmap/ships/machines/gas_thruster.dm
@@ -3,6 +3,7 @@
 	desc = "Simple rocket nozzle, expelling gas at hypersonic velocities to propell the ship."
 	icon = 'icons/obj/ship_engine.dmi'
 	icon_state = "nozzle"
+	layer = STRUCTURE_LAYER
 	opacity = 1
 	density = 1
 	atmos_canpass = CANPASS_NEVER


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

## Description of changes

Moves the AO layer up. Makes a bunch of atmos devices I think are "safe" use structure layer by default (instead of exposed pipe layer).

## Why and what will this PR improve

AO overlays inherit the mouse opacity of whatever they are attached to (i.e. turfs). This cannot be overwritten, apparently, and turfs are mouse opaque. This means that if you click on anything layered above turfs but below the AO layer, your click is passed to the AO overlay and so to the turf. This leads to objects seeming (partially) mouse transparent.

The atmos devices touched (and possibly some others, but I'm unsure) should likely be using the default machinery layer, which is STRUCTURE_LAYER. This alone "fixes" the mouse opacity issue for them as well, but the AO layer change should address other (or future) offenders.

This does make AO layer below pipes and wires, but it seems to look OK to me.

Fixes #1355.

## Authorship

me