### PR TITLE
Probably fixes id photo generation

### DIFF
--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -92,6 +92,7 @@ var/list/outfits_decls_by_type_
 
 	if(!(OUTFIT_ADJUSTMENT_SKIP_POST_EQUIP & equip_adjustments))
 		post_equip(H)
+	H.regenerate_icons()
 	H.update_icons()
 	if(W) // We set ID info last to ensure the ID photo is as correct as possible.
 		H.set_id_info(W)


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

## Description of changes

Fixes NebulaSS13/Nebula#1906

~~This is not a ideal fix, but it seems it's only one way to do it because we trying to get images before mob end generating overlays.~~

## Why and what will this PR improve

It fixes annoying bug.

## Authorship

My stupid brain

## Changelog

:cl:
bugfix: Crew ID cards should now properly display icons.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
