### PR TITLE
Attempts fixes to GFI

### DIFF
--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -742,9 +742,17 @@ The _flatIcons list is a cache for generated icon files.
 					add = icon(I.icon, I.icon_state)
 		else // 'I' is an appearance object.
 			if(istype(A,/obj/machinery/atmospherics) && (I in A.underlays))
-				add = getFlatIcon(new /image(I), I.dir, curicon, curstate, curblend, 1)
+				add = getFlatIcon(new /image(I), I.dir, curicon, null, curblend, 1)
 			else
-				add = getFlatIcon(new/image(I), curdir, curicon, curstate, curblend, always_use_defdir)
+				/*
+				The state var is null so that it uses the appearance's state, not ours or the default
+				Falling back to our state if state is null would be incorrect overlay logic (overlay with null state does not inherit it from parent to which it is attached)
+
+				If icon is null on an overlay it will inherit the icon from the attached parent, so we _do_ pass curicon ...
+				but it does not do so if its icon_state is ""/null, so we check beforehand to exclude this
+				*/
+				var/icon_to_pass = (!I.icon_state && !I.icon) ? null : curicon
+				add = getFlatIcon(new/image(I), curdir, icon_to_pass, null, curblend, always_use_defdir)
 
 		// Find the new dimensions of the flat icon to fit the added overlay
 		addX1 = min(flatX1, I.pixel_x + 1)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -11,7 +11,6 @@
 	var/skin_tone = 0  //Skin tone
 
 	var/damage_multiplier = 1 //multiplies melee combat damage
-	var/icon_update = 1 //whether icon updating shall take place
 
 	var/lip_style = null	//no lipstick by default- arguably misleading, as it could be used for general makeup
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -148,44 +148,42 @@ Please contact me on #coderbus IRC. ~Carn x
 	overlays.Cut()
 
 	var/list/overlays_to_apply = list()
-	if (icon_update)
 
-		var/list/visible_overlays
-		if(is_cloaked())
-			icon = 'icons/mob/human.dmi'
-			icon_state = "blank"
-			visible_overlays = overlays_standing[HO_INHAND_LAYER]
-		else
-			icon = stand_icon
-			icon_state = null
-			visible_overlays = overlays_standing
+	var/list/visible_overlays
+	if(is_cloaked())
+		icon = 'icons/mob/human.dmi'
+		icon_state = "blank"
+		visible_overlays = overlays_standing[HO_INHAND_LAYER]
+	else
+		icon = stand_icon
+		icon_state = null
+		visible_overlays = overlays_standing
 
-		var/matrix/M = matrix()
-		if(lying && (bodytype.prone_overlay_offset[1] || bodytype.prone_overlay_offset[2]))
-			M.Translate(bodytype.prone_overlay_offset[1], bodytype.prone_overlay_offset[2])
+	var/matrix/M = matrix()
+	if(lying && (bodytype.prone_overlay_offset[1] || bodytype.prone_overlay_offset[2]))
+		M.Translate(bodytype.prone_overlay_offset[1], bodytype.prone_overlay_offset[2])
 
-		for(var/i = 1 to LAZYLEN(visible_overlays))
-			var/entry = visible_overlays[i]
-			if(istype(entry, /image))
-				var/image/overlay = entry
+	for(var/i = 1 to LAZYLEN(visible_overlays))
+		var/entry = visible_overlays[i]
+		if(istype(entry, /image))
+			var/image/overlay = entry
+			if(i != HO_DAMAGE_LAYER)
+				overlay.transform = M
+			overlays_to_apply += overlay
+		else if(istype(entry, /list))
+			for(var/image/overlay in entry)
 				if(i != HO_DAMAGE_LAYER)
 					overlay.transform = M
 				overlays_to_apply += overlay
-			else if(istype(entry, /list))
-				for(var/image/overlay in entry)
-					if(i != HO_DAMAGE_LAYER)
-						overlay.transform = M
-					overlays_to_apply += overlay
 
-		var/obj/item/organ/external/head/head = organs_by_name[BP_HEAD]
-		if(istype(head) && !head.is_stump())
-			var/image/I = head.get_eye_overlay()
-			if(I) 
-				overlays_to_apply += I
+	var/obj/item/organ/external/head/head = organs_by_name[BP_HEAD]
+	if(istype(head) && !head.is_stump())
+		var/image/I = head.get_eye_overlay()
+		if(I) 
+			overlays_to_apply += I
 
 	if(auras)
 		overlays_to_apply += auras
-
 	overlays = overlays_to_apply
 
 /mob/living/carbon/human/proc/get_icon_scale_mult()


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

## Description of changes

The functional change here are the 3 lines in GFI, which (1) do not pass parent icon state to overlay recursive GFI, and (2) only pass parent icon to recursive GFI if the overlay appearance has a non-"" icon_state.

## Why and what will this PR improve

Overlay logic makes overlays use parent's icon as their icon if an icon is not supplied, but this does not apply if the icon_state of the overlay is "" (in this case, the overlay's icon is just not rendered, though the overlay may have other visible effects like overlays of its own, etc.)

Currently, if icon/icon_state is false in an overlay, it is replaced by the "parent's" icon/icon_state in GFI. If both are false, this leads to the wrong result, adding the parent's icon's "" state as an overlay. This makes certain clothing items (e.g. Hawaiian shirts) overlay a naked human icon over other clothing, messing up ID pictures.

Am I sure the logic here is correct and won't break other GFI users? No, not really.

The changes to human/update_icons remove an unused bool.

Fixes #1906.
Is an alternative to #1907 (which from my testing does not fix the issue).

## Authorship

me
