### PR TITLE
Fixes glass floor deconstruct 

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -77,7 +77,13 @@
 	if(flooring)
 		flooring.on_remove()
 		if(flooring.build_type && place_product)
-			new flooring.build_type(src)
+			// If build type uses material stack, check for it
+			// Because material stack uses different arguments
+			// And we need to use build material to spawn stack
+			if(ispath(flooring.build_type, /obj/item/stack/material))
+				new flooring.build_type(src, flooring.build_cost, flooring.build_material)
+			else
+				new flooring.build_type(src)
 		flooring = null
 
 	set_light(0)


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

## Description of changes

Title.
Because you can specify any stack item and args are different between stack and stack/material, I did this check.

## Why and what will this PR improve

Floors are deconstruct-able again.

## Authorship

me