### PR TITLE
Fix being unable to anchor/unanchor /obj/structure/closet

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -5,6 +5,7 @@
 	icon_state = "base"
 	density = 1
 	maxhealth = 100
+	tool_interaction_flags = TOOL_INTERACTION_ANCHOR
 
 	var/welded = 0
 	var/large = 1
@@ -229,7 +230,7 @@
 	if(user.a_intent == I_HURT && W.force)
 		return ..()
 
-	if(!opened && istype(W, /obj/item/stack/material))
+	if(!opened && (istype(W, /obj/item/stack/material) || isWrench(W)) )
 		return ..()
 
 	if(src.opened)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -127,6 +127,10 @@
 	wall_mounted = 1
 	storage_types = CLOSET_STORAGE_ITEMS
 	req_access = list(access_medical_equip)
+	
+/obj/structure/closet/secure_closet/medical_wall/Initialize()
+	. = ..()
+	tool_interaction_flags &= ~TOOL_INTERACTION_ANCHOR
 
 /obj/structure/closet/secure_closet/counselor
 	name = "counselor's locker"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -230,6 +230,10 @@
 	//too small to put a man in
 	large = 0
 
+/obj/structure/closet/secure_closet/wall/Initialize()
+	. = ..()
+	tool_interaction_flags &= ~TOOL_INTERACTION_ANCHOR
+
 /obj/structure/closet/secure_closet/lawyer
 	name = "internal affairs secure closet"
 	req_access = list(access_lawyer)

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -158,6 +158,10 @@
 	wall_mounted = 1
 	storage_types = CLOSET_STORAGE_ITEMS
 	setup = 0
+	
+/obj/structure/closet/hydrant/Initialize()
+	. = ..()
+	tool_interaction_flags &= ~TOOL_INTERACTION_ANCHOR
 
 /obj/structure/closet/hydrant/WillContain()
 	return list(
@@ -180,6 +184,10 @@
 	storage_types = CLOSET_STORAGE_ITEMS
 	setup = 0
 
+/obj/structure/closet/medical_wall/Initialize()
+	. = ..()
+	tool_interaction_flags &= ~TOOL_INTERACTION_ANCHOR
+
 /obj/structure/closet/medical_wall/filled/WillContain()
 	return list(
 		/obj/random/firstaid,
@@ -194,6 +202,10 @@
 	wall_mounted = 1
 	storage_types = CLOSET_STORAGE_ITEMS
 	setup = 0
+
+/obj/structure/closet/shipping_wall/Initialize()
+	. = ..()
+	tool_interaction_flags &= ~TOOL_INTERACTION_ANCHOR
 
 /obj/structure/closet/shipping_wall/filled/WillContain()
 	return list(

--- a/code/game/objects/structures/crates_lockers/closets/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/closets/walllocker.dm
@@ -10,3 +10,7 @@
 	wall_mounted = 1
 	storage_types = CLOSET_STORAGE_ITEMS
 	setup = 0
+
+/obj/structure/closet/walllocker/Initialize()
+	. = ..()
+	tool_interaction_flags &= ~TOOL_INTERACTION_ANCHOR


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

## Description of changes
~~Ensure the base class' handling for wrenches is reachable when the closet is closed so closets can be anchored like they're supposed to. Also set the tool_interaction_flags var  to allow anchoring.~~
EDIT:
Seems like my life is a lie and closets couldn't be anchored on bay apparently?? Anyways, treat this as a feature PR I guess.

## Changelog

:cl:
tweak: Allow anchoring/unanchoring closets/crates to the ground.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
