### PR TITLE
Z-Mimic: Plane Fixup/Mangling

### DIFF
--- a/code/__defines/zmimic.dm
+++ b/code/__defines/zmimic.dm
@@ -3,12 +3,12 @@
 #define UPDATE_OO_IF_PRESENT CHECK_OO_EXISTENCE(bound_overlay); if (bound_overlay) { update_above(); }
 
 // Turf MZ flags.
-#define ZM_MIMIC_BELOW     1	// If this turf should mimic the turf on the Z below.
-#define ZM_MIMIC_OVERWRITE 2	// If this turf is Z-mimicing, overwrite the turf's appearance instead of using a movable. This is faster, but means the turf cannot have its own appearance (say, edges or a translucent sprite).
-#define ZM_ALLOW_LIGHTING  4	// If this turf should permit passage of lighting.
-#define ZM_ALLOW_ATMOS     8	// If this turf permits passage of air.
-#define ZM_MIMIC_NO_AO    16	// If the turf shouldn't apply regular turf AO and only do Z-mimic AO.
-#define ZM_NO_OCCLUDE     32	// Don't occlude below atoms if we're a non-mimic z-turf.
+#define ZM_MIMIC_BELOW     1	//! If this turf should mimic the turf on the Z below.
+#define ZM_MIMIC_OVERWRITE 2	//! If this turf is Z-mimicing, overwrite the turf's appearance instead of using a movable. This is faster, but means the turf cannot have its own appearance (say, edges or a translucent sprite).
+#define ZM_ALLOW_LIGHTING  4	//! If this turf should permit passage of lighting.
+#define ZM_ALLOW_ATMOS     8	//! If this turf permits passage of air.
+#define ZM_MIMIC_NO_AO    16	//! If the turf shouldn't apply regular turf AO and only do Z-mimic AO.
+#define ZM_NO_OCCLUDE     32	//! Don't occlude below atoms if we're a non-mimic z-turf.
 
 // Convenience flag.
 #define ZM_MIMIC_DEFAULTS (ZM_MIMIC_BELOW|ZM_ALLOW_LIGHTING)
@@ -22,3 +22,7 @@ var/global/list/mimic_defines = list(
 	"ZM_MIMIC_NO_AO",
 	"ZM_NO_OCCLUDE"
 )
+
+// Movable flags.
+#define ZMM_IGNORE 1	//! Do not copy this movable.
+#define ZMM_MANGLE_PLANES  2	//! Check this movable's overlays/underlays for explicit plane use and mangle for compatibility with Z-Mimic. If you're using emissive overlays, you probably should be using this flag. Expensive, only use if necessary.

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -10,6 +10,7 @@
 	idle_power_usage = 20
 	power_channel = LIGHT
 	required_interaction_dexterity = DEXTERITY_SIMPLE_MACHINES
+	z_flags = ZMM_MANGLE_PLANES
 
 	var/on = 0
 	var/area/connected_area = null

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -185,6 +185,7 @@
 	amount = 10
 	max_amount = 10
 	icon = 'icons/obj/items/marking_beacon.dmi'
+	z_flags = ZMM_MANGLE_PLANES
 
 	var/upright = 0
 	var/fringe = null

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -9,6 +9,8 @@
 	health = 300
 	mob_sort_value = 4
 
+	z_flags = ZMM_MANGLE_PLANES
+
 	mob_bump_flag = ROBOT
 	mob_swap_flags = ROBOT|MONKEY|SLIME|SIMPLE_ANIMAL
 	mob_push_flags = ~HEAVY //trundle trundle

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -38,6 +38,8 @@
 	skin_material = null
 	skin_amount =   0
 
+	z_flags = ZMM_MANGLE_PLANES
+
 	var/nullblock = 0
 	var/list/construct_spells = list()
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -157,11 +157,13 @@
 
 /mob/living/simple_animal/hostile/giant_spider/on_update_icon()
 	if(stat == DEAD)
+		z_flags &= ~ZMM_MANGLE_PLANES
 		var/image/I = image(icon = icon, icon_state = "[icon_dead]_eyes")
 		I.color = eye_colour
 		I.appearance_flags = RESET_COLOR
 		set_overlays(I)
 	else
+		z_flags |= ZMM_MANGLE_PLANES
 		var/image/I = emissive_overlay(icon = icon, icon_state = "[icon_state]_eyes")
 		I.color = eye_colour
 		I.appearance_flags = RESET_COLOR

--- a/code/modules/mob/observer/virtual/base.dm
+++ b/code/modules/mob/observer/virtual/base.dm
@@ -8,7 +8,7 @@ var/global/list/all_virtual_listeners = list()
 	sight = SEE_SELF
 
 	virtual_mob = null
-	no_z_overlay = TRUE
+	z_flags = ZMM_IGNORE
 
 	var/atom/movable/host
 	var/host_type = /atom/movable

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -1,8 +1,8 @@
 /atom/movable
 	/// The mimic (if any) that's *directly* copying us.
 	var/tmp/atom/movable/openspace/mimic/bound_overlay
-	/// If TRUE, this atom is ignored by Z-Mimic.
-	var/no_z_overlay
+	/// Movable-level Z-Mimic flags. This uses ZMM_* flags, not ZM_* flags.
+	var/z_flags = 0
 
 /atom/movable/forceMove(atom/dest)
 	. = ..(dest)
@@ -184,7 +184,7 @@
 /atom/movable/openspace/turf_proxy
 	plane = OPENTURF_MAX_PLANE
 	mouse_opacity = 0
-	no_z_overlay = TRUE  // Only one of these should ever be visible at a time, the mimic logic will handle that.
+	z_flags = ZMM_IGNORE  // Only one of these should ever be visible at a time, the mimic logic will handle that.
 
 /atom/movable/openspace/turf_proxy/attackby(obj/item/W, mob/user)
 	loc.attackby(W, user)

--- a/code/modules/multiz/zmimic/mimic_turf.dm
+++ b/code/modules/multiz/zmimic/mimic_turf.dm
@@ -22,7 +22,7 @@
 
 /turf/Entered(atom/movable/thing, turf/oldLoc)
 	. = ..()
-	if (thing.bound_overlay || thing.no_z_overlay || !TURF_IS_MIMICING(above))
+	if (thing.bound_overlay || (thing.z_flags & ZMM_IGNORE) || !TURF_IS_MIMICING(above))
 		return
 	above.update_mimic()
 

--- a/code/modules/overmap/ships/machines/gas_thruster.dm
+++ b/code/modules/overmap/ships/machines/gas_thruster.dm
@@ -17,6 +17,7 @@
 	use_power = POWER_USE_OFF
 	power_channel = EQUIP
 	idle_power_usage = 11600
+	z_flags = ZMM_MANGLE_PLANES
 
 /obj/machinery/atmospherics/unary/engine/Initialize()
 	. = ..()

--- a/code/modules/overmap/ships/machines/ion_thruster.dm
+++ b/code/modules/overmap/ships/machines/ion_thruster.dm
@@ -37,6 +37,7 @@
 	anchored = TRUE
 	construct_state = /decl/machine_construction/default/panel_closed
 	use_power = POWER_USE_IDLE
+	z_flags = ZMM_MANGLE_PLANES
 
 	var/thrust_limit = 1
 	var/burn_cost = 750

--- a/code/modules/projectiles/guns/energy/capacitor.dm
+++ b/code/modules/projectiles/guns/energy/capacitor.dm
@@ -60,6 +60,7 @@ var/global/list/laser_wavelengths
 		/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/gemstone/diamond = MATTER_AMOUNT_TRACE
 	)
+	z_flags = ZMM_MANGLE_PLANES
 
 	var/wiring_color = COLOR_CYAN_BLUE
 	var/max_capacitors = 2

--- a/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
+++ b/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
@@ -17,6 +17,7 @@
 	anchored = 1
 	material = /decl/material/solid/metal/aliumium
 	material_alteration = MAT_FLAG_ALTERATION_COLOR
+	z_flags = ZMM_MANGLE_PLANES
 	var/active = 0
 
 /obj/structure/monolith/Initialize()

--- a/mods/mobs/dionaea/mob/_nymph.dm
+++ b/mods/mobs/dionaea/mob/_nymph.dm
@@ -40,6 +40,8 @@
 
 	ai = /datum/ai/nymph
 
+	z_flags = ZMM_MANGLE_PLANES
+
 	var/obj/item/holding_item
 	var/mob/living/carbon/alien/diona/next_nymph
 	var/mob/living/carbon/alien/diona/previous_nymph

--- a/mods/mobs/dionaea/mob/gestalt/_gestalt.dm
+++ b/mods/mobs/dionaea/mob/gestalt/_gestalt.dm
@@ -7,6 +7,7 @@
 	opacity = FALSE
 	anchored = FALSE
 	movement_handlers = list(/datum/movement_handler/deny_multiz, /datum/movement_handler/delay = list(5))
+	z_flags = ZMM_MANGLE_PLANES
 
 	var/list/nymphs                  = list()
 	var/list/valid_things_to_roll_up = list(/mob/living/carbon/alien/diona = TRUE, /mob/living/carbon/alien/diona/sterile = TRUE)

--- a/mods/species/ascent/effects/razorweb.dm
+++ b/mods/species/ascent/effects/razorweb.dm
@@ -22,6 +22,7 @@
 	icon = 'mods/species/ascent/icons/razorweb.dmi'
 	icon_state = "razorweb"
 	anchored = TRUE
+	z_flags = ZMM_MANGLE_PLANES
 
 	var/mob/owner
 	var/decays = TRUE


### PR DESCRIPTION
This fixes issues with emissive overlays shining through floors.

- `no_z_overlay` is now a more general `z_flags` bitfield on movable, with `ZMM_IGNORE` controlling skip behavior now.
- `ZMM_MANGLE_PLANES` can be set on movables to forcibly correct planes of overlays/underlays during mimic so that they mimic properly.
- Existing Z-Mimic defines' comments are doccomments now.

I haven't added logic for handling fixup/mangling on humantypes for things like glowing eyes or smokables.