### PR TITLE
Hotfix for eating with forks, food crafting + slicing

### DIFF
--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -123,9 +123,6 @@
 	if(istype(W,/obj/item/storage))
 		..()// -> item/attackby()
 		return
-	if(!ATOM_IS_OPEN_CONTAINER(src))
-		to_chat(user, "<span class='notice'>\The [src] isn't open!</span>")
-		return 0
 	// Eating with forks
 	if(istype(W,/obj/item/kitchen/utensil))
 		var/obj/item/kitchen/utensil/U = W


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

## Description of changes

Removes a duplicated check in the wrong place; it's redundant after the canned food rework.

## Why and what will this PR improve

Food attackby now works properly.

## Authorship

MoondancerPony/jade2562/koboldlove