### PR TITLE
Adds default custom client fps in config

### DIFF
--- a/code/__defines/client.dm
+++ b/code/__defines/client.dm
@@ -1,2 +1,2 @@
-#define CLIENT_MIN_FPS 0
+#define CLIENT_MIN_FPS -1
 #define CLIENT_MAX_FPS 1000

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -45,6 +45,7 @@ var/global/list/gamemode_cache = list()
 	var/popup_admin_pm = 0				//adminPMs to non-admins show in a pop-up 'reply' window when set to 1.
 	var/allow_holidays = FALSE
 	var/fps = 20
+	var/clientfps = 20					// Default fps for clients with "0" in prefs. -1 for synced with server.
 	var/tick_limit_mc_init = TICK_LIMIT_MC_INIT_DEFAULT	//SSinitialization throttling
 	var/list/resource_urls = null
 	var/antag_hud_allowed = 0			// Ghosts can turn on Antagovision to see a HUD of who is the bad guys this round.
@@ -601,6 +602,9 @@ var/global/list/gamemode_cache = list()
 
 				if("fps")
 					fps = text2num(value)
+
+				if("clientfps")
+					clientfps = text2num(value)
 
 				if("tick_limit_mc_init")
 					tick_limit_mc_init = text2num(value)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -230,6 +230,7 @@ var/global/list/localhost_addresses = list(
 
 	if(prefs && !istype(mob, world.mob))
 		prefs.apply_post_login_preferences()
+
 	//////////////
 	//DISCONNECT//
 	//////////////

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -111,9 +111,9 @@ var/global/list/valid_icon_sizes = list(32, 48, 64, 96, 128)
 			version_message = "\nYou need to be using byond version 511 or later to take advantage of this feature, your version of [user.client.byond_version] is too low"
 		if (world.byond_version < 511)
 			version_message += "\nThis server does not currently support client side fps. You can set now for when it does."
-		var/new_fps = input(user, "Choose your desired fps.[version_message]\n(0 = synced with server tick rate (currently:[world.fps]))", "Global Preference") as num|null
+		var/new_fps = input(user, "Choose your desired fps.[version_message]\n(0 = default value (currently: [config.clientfps]) < RECOMMENDED) \n -1 = synced with server tick rate (currently: [world.fps])", "Global Preference") as num|null
 		if (isnum(new_fps) && CanUseTopic(user))
-			pref.clientfps = Clamp(new_fps, CLIENT_MIN_FPS, CLIENT_MAX_FPS)
+			pref.clientfps = Clamp(new_fps ? new_fps : config.clientfps, CLIENT_MIN_FPS, CLIENT_MAX_FPS)
 
 			var/mob/target_mob = preference_mob()
 			if(target_mob && target_mob.client)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -456,7 +456,7 @@ var/global/list/time_prefs_fixed = list()
 	if(!client)
 		return
 
-	client.apply_fps(clientfps)
+	client.apply_fps(clientfps ? clientfps : config.clientfps)
 
 	if(client.get_preference_value(/datum/client_preference/fullscreen_mode) != PREF_OFF)
 		client.toggle_fullscreen(client.get_preference_value(/datum/client_preference/fullscreen_mode))

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -239,6 +239,9 @@ TICKLAG 0.7
 ##Defines world FPS. Defaults to 20.
 # FPS 20
 
+##Defines the fps for the players with 0 in preferences. -1 for synced with server fps.
+# CLIENTFPS 20
+
 ## Whether the server will talk to other processes through socket_talk
 SOCKET_TALK 0
 


### PR DESCRIPTION
Nobody reading pr body tldw: Breaks fps settings into client and world config option. By default client pref is 20 (can be changed in config to any hecking number you want).