### PR TITLE
add density/opacity caching to turfs

### DIFF
--- a/code/controllers/subsystems/processing/airflow.dm
+++ b/code/controllers/subsystems/processing/airflow.dm
@@ -5,7 +5,7 @@
 	TARGET.airflow_time = 0;                \
 	TARGET.airflow_skip_speedcheck = FALSE; \
 	if (TARGET.airflow_od) {                \
-		TARGET.density = 0;                 \
+		TARGET.set_density(0);                 \
 	}
 
 PROCESSING_SUBSYSTEM_DEF(airflow)
@@ -54,7 +54,7 @@ PROCESSING_SUBSYSTEM_DEF(airflow)
 			if (target.airflow_speed > 7)
 				if (target.airflow_time++ >= target.airflow_speed - 7)
 					if (target.airflow_od)
-						target.density = 0
+						target.set_density(0)
 					target.airflow_skip_speedcheck = TRUE
 
 					if (MC_TICK_CHECK)
@@ -62,7 +62,7 @@ PROCESSING_SUBSYSTEM_DEF(airflow)
 					continue
 			else
 				if (target.airflow_od)
-					target.density = 0
+					target.set_density(0)
 				target.airflow_process_delay = max(1, 10 - (target.airflow_speed + 3))
 				target.airflow_skip_speedcheck = TRUE
 
@@ -73,7 +73,7 @@ PROCESSING_SUBSYSTEM_DEF(airflow)
 		target.airflow_skip_speedcheck = FALSE
 
 		if (target.airflow_od)
-			target.density = 1
+			target.set_density(1)
 
 		if (!target.airflow_dest || target.loc == target.airflow_dest)
 			target.airflow_dest = locate(min(max(target.x + target.airflow_xo, 1), world.maxx), min(max(target.y + target.airflow_yo, 1), world.maxy), target.z)

--- a/code/datums/observation/opacity_set.dm
+++ b/code/datums/observation/opacity_set.dm
@@ -20,6 +20,12 @@
 		var/old_opacity = opacity
 		opacity = new_opacity
 		events_repository.raise_event(/decl/observ/opacity_set, src, old_opacity, new_opacity)
+		if (isturf(loc))
+			var/turf/T = loc
+			if (opacity)
+				T.has_opaque_atom = TRUE
+			else
+				T.has_opaque_atom = null
 		return TRUE
 	else
 		return FALSE

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -83,6 +83,12 @@
 /atom/proc/set_density(var/new_density)
 	if(density != new_density)
 		density = !!new_density
+		if (isturf(loc))
+			var/turf/T = loc
+			if (density)
+				T.has_dense_atom = TRUE
+			else
+				T.has_dense_atom = null
 
 /atom/proc/bullet_act(obj/item/projectile/P, def_zone)
 	P.on_hit(src, 0, def_zone)

--- a/code/game/machinery/self_destruct.dm
+++ b/code/game/machinery/self_destruct.dm
@@ -31,7 +31,7 @@
 		user.visible_message("[user] begins to carefully place [W] onto the Inserter.", "You begin to carefully place [W] onto the Inserter.")
 		if(do_after(user, 80, src) && user.unEquip(W, src))
 			cylinder = W
-			density = 1
+			set_density(1)
 			user.visible_message("[user] places [W] onto the Inserter.", "You place [W] onto the Inserter.")
 			update_icon()
 			return
@@ -55,13 +55,13 @@
 			if(do_after(user, 40, src))
 				user.visible_message("[user] extracts [cylinder].", "You extract [cylinder].")
 				armed = 0
-				density = 1
+				set_density(1)
 				flick("unloading", src)
 		else if(!damaged)
 			user.visible_message("[user] begins to arm [cylinder].", "You begin to arm [cylinder].")
 			if(do_after(user, 40, src))
 				armed = 1
-				density = 0
+				set_density(0)
 				user.visible_message("[user] arms [cylinder].", "You arm [cylinder].")
 				flick("loading", src)
 				playsound(src.loc,'sound/effects/caution.ogg',50,1,5)
@@ -82,7 +82,7 @@
 		user.visible_message( \
 			SPAN_NOTICE("\The [user] picks up \the [cylinder]."), \
 			SPAN_NOTICE("You pick up \the [cylinder]."))
-		density = FALSE
+		set_density(FALSE)
 		cylinder = null
 		update_icon()
 		add_fingerprint(user)

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -95,7 +95,7 @@
 		stored_units += store_mobs(stored_units)
 	if(storage_types & CLOSET_STORAGE_STRUCTURES)
 		stored_units += store_structures(stored_units)
-		
+
 /obj/structure/closet/proc/open()
 	if(src.opened)
 		return 0
@@ -107,7 +107,7 @@
 
 	src.opened = 1
 	playsound(src.loc, open_sound, 50, 1, -3)
-	density = 0
+	set_density(FALSE)
 	update_icon()
 	return 1
 
@@ -122,7 +122,7 @@
 
 	playsound(src.loc, close_sound, 50, 0, -3)
 	if(!wall_mounted)
-		density = 1
+		set_density(TRUE)
 
 	update_icon()
 
@@ -226,7 +226,7 @@
 		take_damage(proj_damage)
 
 /obj/structure/closet/attackby(obj/item/W, mob/user)
-	
+
 	if(user.a_intent == I_HURT && W.force)
 		return ..()
 

--- a/code/game/objects/structures/defensive_barrier.dm
+++ b/code/game/objects/structures/defensive_barrier.dm
@@ -131,7 +131,7 @@
 		return TRUE
 
 	playsound(src, 'sound/effects/extout.ogg', 100, 1)
-	density = !density
+	set_density(!density)
 	to_chat(user, SPAN_NOTICE("You [density ? "raise" : "lower"] \the [src]."))
 	update_icon()
 	return TRUE

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -240,10 +240,10 @@
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 			if(density)
 				user.visible_message("<span class='notice'>\The [user] wrenches \the [src] open.</span>", "<span class='notice'>You wrench \the [src] open.</span>")
-				density = 0
+				set_density(FALSE)
 			else
 				user.visible_message("<span class='notice'>\The [user] wrenches \the [src] closed.</span>", "<span class='notice'>You wrench \the [src] closed.</span>")
-				density = 1
+				set_density(TRUE)
 			update_icon()
 			return
 	// Repair

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -38,6 +38,9 @@
 
 	var/prev_type // Previous type of the turf, prior to turf translation.
 
+	var/has_dense_atom
+	var/has_opaque_atom
+
 /turf/Initialize(mapload, ...)
 	. = null && ..()	// This weird construct is to shut up the 'parent proc not called' warning without disabling the lint for child types. We explicitly return an init hint so this won't change behavior.
 
@@ -366,3 +369,42 @@ var/global/const/enterloopsanity = 100
 
 /turf/proc/get_footstep_sound(var/mob/caller)
 	return
+
+/turf/proc/is_dense()
+	if (density)
+		return TRUE
+	if (isnull(has_dense_atom))
+		has_dense_atom = FALSE
+		if (contains_dense_objects())
+			has_dense_atom = TRUE
+	return has_dense_atom
+
+/turf/proc/is_opaque()
+	if (opacity)
+		return TRUE
+	if (isnull(has_opaque_atom))
+		has_opaque_atom = FALSE
+		for (var/atom/A in contents)
+			if (A.opacity)
+				has_opaque_atom = TRUE
+				break
+	return has_opaque_atom
+
+/turf/Entered(atom/movable/AM)
+	. = ..()
+	if (istype(AM))
+		if (AM.density)
+			has_dense_atom = TRUE
+		if (AM.opacity)
+			has_opaque_atom = TRUE
+
+/turf/Exited(atom/movable/AM, atom/newloc)
+	. = ..()
+	if (istype(AM))
+		if(AM.density)
+			has_dense_atom = null
+		if (AM.opacity)
+			has_opaque_atom = null
+	else
+		has_dense_atom = null
+		has_opaque_atom = null

--- a/code/modules/mechs/components/frame.dm
+++ b/code/modules/mechs/components/frame.dm
@@ -69,12 +69,12 @@
 /obj/structure/heavy_vehicle_frame/on_update_icon()
 	var/list/new_overlays = get_mech_images(list(legs, head, body, arms), layer)
 	if(body)
-		density = TRUE
+		set_density(TRUE)
 		overlays += get_mech_image(null, "[body.icon_state]_cockpit", body.icon, body.color)
 		if(body.pilot_coverage < 100 || body.transparent_cabin)
 			new_overlays += get_mech_image(null, "[body.icon_state]_open_overlay", body.icon, body.color)
 	else
-		density = FALSE
+		set_density(FALSE)
 	overlays = new_overlays
 	if(density != opacity)
 		set_opacity(density)

--- a/code/modules/spells/general/tear_veil.dm
+++ b/code/modules/spells/general/tear_veil.dm
@@ -21,7 +21,7 @@
 	var/turf/T = get_turf(holder)
 	holder.visible_message("<span class='notice'>A strange portal rips open underneath \the [holder]!</span>")
 	var/obj/effect/gateway/hole = new(get_turf(T))
-	hole.density = 0
+	hole.set_density(FALSE)
 	return list(hole)
 
 /spell/tear_veil/cast(var/list/targets, var/mob/holder, var/channel_count)


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

## Description of changes

Adds caching of a turfs current opacity and density based on its own values and those of the atoms it contains.

## Why and what will this PR improve

Instead of checking the opacity/density properties of a turf's contents every time you want to know if it's opaque or dense, this instead keeps track of if there is at least one atom that is dense or opaque in the turfs contents, and updates values attached to the turf that can be checked directly based off of those results.

## Authorship

Myself and Loaf (his idea and implementation, tested and fixed up by me.)

## Changelog

:cl:
rscadd: Add density/opacity caching to turfs.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->

The caching will break if any `density` or `opacity` var is set directly and not through `set_density` or `set_opacity`, so I did a run-through of the code and swapped those out where I found them.