### PR TITLE
Fixes #1796.

### DIFF
--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -40,17 +40,18 @@
 
 /datum/event/electrical_storm/start()
 	..()
-	valid_apcs = list()
-	for(var/obj/machinery/power/apc/A in SSmachines.machinery)
-		if(A.z in affecting_z && !A.is_critical)
-			valid_apcs.Add(A)
 	endWhen = (severity * 60) + startWhen
 
 /datum/event/electrical_storm/tick()
+
 	..()
+
 	//See if shields can stop it first
 	var/overmap_only = TRUE
 	var/list/overmap_sectors = list()
+	if(!length(affecting_z))
+		return
+
 	for(var/i in affecting_z)
 		var/obj/effect/overmap/visitable/sector = map_sectors["[i]"]
 		if(istype(sector))
@@ -80,89 +81,88 @@
 		//Minor breaches aren't enough to let through frying amounts of power
 		if(shield_gen.take_shield_damage(30 * severity, SHIELD_DAMTYPE_EM) <= SHIELD_BREACHED_MINOR)
 			shielded = TRUE
-	if(!valid_apcs.len)
-		CRASH("No valid APCs found for electrical storm event! This is likely a bug.")
-	var/list/picked_apcs = list()
-	for(var/i=0, i< severity*2, i++) // up to 2/4/6 APCs per tick depending on severity
-		picked_apcs |= pick(valid_apcs)
 
-	for(var/obj/machinery/power/apc/T AS_ANYTHING in picked_apcs)
-		// Main breaker is turned off. Consider this APC protected.
-		if(!T.operating || T.failure_timer)
-			continue
+	valid_apcs = list()
+	for(var/obj/machinery/power/apc/A AS_ANYTHING in global.all_apcs)
+		if(!A.is_critical && (A.z in affecting_z))
+			valid_apcs.Add(A)
 
-		if(!shielded) //If there's a shield doing it's thing, we don't bother to  actually mess with anything. We still make a racket, though.
-			spark_at(get_turf(T), amount = 4, cardinal_only = TRUE) //always spark a little if we're affected.
-			// Decent chance to overload lighting circuit.
-			if(prob(3 * severity))
-				T.overload_lighting()
+	if(length(valid_apcs) < 2)
+		log_debug("Insufficient APCs found for electrical storm event! This is likely a bug.")
+	else
+		var/list/picked_apcs = list()
+		for(var/i=0, i< severity*2, i++) // up to 2/4/6 APCs per tick depending on severity
+			picked_apcs |= pick(valid_apcs)
 
-			// Relatively small chance to emag the apc as apc_damage event does.
-			if(prob(0.2 * severity))
-				T.emagged = 1
-				T.update_icon()
-
-			if(T.is_critical)
-				T.energy_fail(10 * severity)
+		for(var/obj/machinery/power/apc/T AS_ANYTHING in picked_apcs)
+			// Main breaker is turned off. Consider this APC protected.
+			if(!T.operating || T.failure_timer)
 				continue
-			else
-				T.energy_fail(10 * severity * rand(severity * 2, severity * 4))
 
-			// Very tiny chance to completely break the APC. Has a check to ensure we don't break critical APCs such as the Engine room, or AI core. Does not occur on Mundane severity.
-			if(prob((0.2 * severity) - 0.2))
-				T.set_broken()
+			if(!shielded) //If there's a shield doing it's thing, we don't bother to  actually mess with anything. We still make a racket, though.
+				spark_at(get_turf(T), amount = 4, cardinal_only = TRUE) //always spark a little if we're affected.
+				// Decent chance to overload lighting circuit.
+				if(prob(3 * severity))
+					T.overload_lighting()
 
-		for(var/mob/living/carbon/human/H in T.area)
-			to_chat(H, SPAN_WARNING("You feel the hairs on the back of your neck standing up!"))
-			if(prob(25))
-				if(H.eyecheck() == FLASH_PROTECTION_NONE)
-					H.flash_eyes()
-					to_chat(H, SPAN_DANGER("You're briefly blinded by an electrical discharge!"))
+				// Relatively small chance to emag the apc as apc_damage event does.
+				if(prob(0.2 * severity))
+					T.emagged = 1
+					T.update_icon()
 
-		playsound(T.loc, pick(lightning_sounds), 100, 1, world.view * 4, frequency = get_rand_frequency())
+				if(T.is_critical)
+					T.energy_fail(10 * severity)
+					continue
+				else
+					T.energy_fail(10 * severity * rand(severity * 2, severity * 4))
+
+				// Very tiny chance to completely break the APC. Has a check to ensure we don't break critical APCs such as the Engine room, or AI core. Does not occur on Mundane severity.
+				if(prob((0.2 * severity) - 0.2))
+					T.set_broken()
+
+			for(var/mob/living/carbon/human/H in T.area)
+				to_chat(H, SPAN_WARNING("You feel the hairs on the back of your neck standing up!"))
+				if(prob(25))
+					if(H.eyecheck() == FLASH_PROTECTION_NONE)
+						H.flash_eyes()
+						to_chat(H, SPAN_DANGER("You're briefly blinded by an electrical discharge!"))
+
+			playsound(T.loc, pick(lightning_sounds), 100, 1, world.view * 4, frequency = get_rand_frequency())
 
 	//If we are affecting a movable overmap object, bounce it around a little. This will either increase the speed the ship is moving at, or change the heading. It is more likely to increase the speed.
 	var/obj/effect/overmap/visitable/ship/S
-
 	for(var/obj/effect/overmap/visitable/ship/V in SSshuttle.ships) //Find the overmap object.
 		for(var/Z in V.map_z)
 			if(Z in affecting_z)
 				S = V
 
-	if(last_bounce <= world.time && !shielded)
+	if(S && last_bounce <= world.time && !shielded)
 		var/acceleration = rand(1,10) * severity
 		var/actual_accel = clamp(acceleration, KM_OVERMAP_RATE, 0)
 		if(prob(50)) //Small chance to fuck the heading up.
 			S.set_dir(rand(1,8))
+
 		var/ax = 0
-		var/ay = 0
 		if (S.dir & EAST)
 			ax = actual_accel
 		else if (S.dir & WEST)
 			ax = -actual_accel
+
+		var/ay = 0
 		if (S.dir & NORTH)
 			ay = actual_accel
 		else if (S.dir & SOUTH)
 			ay = -actual_accel
+
 		if (ax || ay)
 			S.adjust_speed(ax, ay)
 
-		last_bounce = world.time += (bounce_delay / severity)
-
+		last_bounce = world.time + (bounce_delay / severity)
 		for(var/mob/living/carbon/human/H in global.living_mob_list_) //Affect mobs, skip synthetics.
-
-			if(!(H.z in affecting_z))
+			if(!(H.z in affecting_z) || isnull(H) || QDELETED(H))
 				continue
-
-			if(isnull(H) || QDELETED(H))
-				continue
-
 			to_chat(H, SPAN_WARNING("You're shaken about as the storm disrupts the ship's course!"))
 			shake_camera(H, 2, 1)
-
-
-
-
 
 /datum/event/electrical_storm/end()
 	..()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1,4 +1,4 @@
-
+var/global/list/all_apcs = list()
 
 // The Area Power Controller (APC)
 // Controls and provides power to most electronics in an area
@@ -173,6 +173,7 @@
 	return amount - use_power_oneoff(amount, LOCAL)
 
 /obj/machinery/power/apc/Initialize(mapload, var/ndir, var/populate_parts = TRUE)
+	global.all_apcs += src
 	if(areastring)
 		area = get_area_name(areastring)
 	else
@@ -200,6 +201,7 @@
 	power_change()
 
 /obj/machinery/power/apc/Destroy()
+	global.all_apcs -= src
 	if(area)
 		update()
 		area.apc = null


### PR DESCRIPTION
## Description of changes
- Fixes #1796.
- More specifically, fixes erroneous `+=` and APC operator precedence issue in electrical storm logic.
- Adds a global APC list to use instead of iterating SSmachinery.
- Rechecks for valid APCs each tick() instead of assuming none of them were qdeleted or otherwise rendered invalid.

## Why and what will this PR improve
Electrical storm is now functional.

## Authorship
Me.

## Changelog
Nothing player facing.