### PR TITLE
Power machine rework

### DIFF
--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -61,7 +61,7 @@
 
 /decl/hierarchy/supply_pack/engineering/emitter
 	name = "Equipment - Emitter"
-	contains = list(/obj/machinery/power/emitter = 2)
+	contains = list(/obj/machinery/emitter = 2)
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "emitter crate"
 	access = access_engine_equip
@@ -82,7 +82,7 @@
 
 /decl/hierarchy/supply_pack/engineering/collector
 	name = "Power - Collector"
-	contains = list(/obj/machinery/power/rad_collector = 2)
+	contains = list(/obj/machinery/rad_collector = 2)
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "collector crate"
 	access = access_engine_equip
@@ -122,7 +122,7 @@
 
 /decl/hierarchy/supply_pack/engineering/teg
 	name = "Power - Mark I Thermoelectric Generator"
-	contains = list(/obj/machinery/power/generator)
+	contains = list(/obj/machinery/generator)
 	containertype = /obj/structure/closet/crate/secure/large
 	containername = "\improper Mk1 TEG crate"
 	access = access_engine_equip

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -136,7 +136,7 @@
 
 /datum/uplink_item/item/tools/supply_beacon
 	name = "Hacked Supply Beacon (DANGER!)"
-	desc = "Wrench this large beacon onto an exposed power cable, in order to activate it. This will call in a \
+	desc = "Wrench this large beacon onto an exposed power cable and add some cabling, in order to activate it. This will call in a \
 	drop pod to the target location, containing a random assortment of (possibly useful) items. \
 	The ship's computer system will announce when this pod is enroute."
 	item_cost = 52

--- a/code/datums/wires/shield_generator.dm
+++ b/code/datums/wires/shield_generator.dm
@@ -1,5 +1,5 @@
 /datum/wires/shield_generator
-	holder_type = /obj/machinery/power/shield_generator/
+	holder_type = /obj/machinery/shield_generator/
 	wire_count = 5
 	descriptions = list(
 		new /datum/wire_description(SHIELDGEN_WIRE_POWER, "This wire seems to be carrying a heavy current.", SKILL_EXPERT),
@@ -15,13 +15,13 @@ var/global/const/SHIELDGEN_WIRE_AICONTROL = 8		// Cut to disable AI control. Men
 var/global/const/SHIELDGEN_WIRE_NOTHING = 16		// A blank wire that doesn't have any specific function
 
 /datum/wires/shield_generator/CanUse()
-	var/obj/machinery/power/shield_generator/S = holder
+	var/obj/machinery/shield_generator/S = holder
 	if(S.panel_open)
 		return 1
 	return 0
 
 /datum/wires/shield_generator/UpdateCut(index, mended)
-	var/obj/machinery/power/shield_generator/S = holder
+	var/obj/machinery/shield_generator/S = holder
 	switch(index)
 		if(SHIELDGEN_WIRE_POWER)
 			S.input_cut = !mended
@@ -38,7 +38,7 @@ var/global/const/SHIELDGEN_WIRE_NOTHING = 16		// A blank wire that doesn't have 
 			S.ai_control_disabled = !mended
 
 /datum/wires/shield_generator/UpdatePulsed(var/index)
-	var/obj/machinery/power/shield_generator/S = holder
+	var/obj/machinery/shield_generator/S = holder
 	switch(index)
 		if(SHIELDGEN_WIRE_HACK)
 			S.hacked = 1

--- a/code/game/gamemodes/objectives/objective_heist.dm
+++ b/code/game/gamemodes/objectives/objective_heist.dm
@@ -40,7 +40,7 @@
 			target_amount = 1
 			loot = "a gravitational generator"
 		if(3)
-			target = /obj/machinery/power/emitter
+			target = /obj/machinery/emitter
 			target_amount = 4
 			loot = "four emitters"
 		if(4)

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -246,13 +246,25 @@ Class Procs:
 		if(info)
 			to_chat(usr, jointext(info, "<br>"))
 			return TOPIC_HANDLED
-
+	if(href_list["power_text"]) // As above. Reports OOC info on how to use installed power sources.
+		var/list/info = get_power_sources_info()
+		if(info)
+			to_chat(usr, jointext(info, "<br>"))
+			return TOPIC_HANDLED
 	. = ..()
 	if(. == TOPIC_REFRESH)
 		updateUsrDialog() // Update legacy UIs to the extent possible.
 
 /obj/machinery/proc/get_tool_manipulation_info()
 	return construct_state?.mechanics_info()
+
+/obj/machinery/proc/get_power_sources_info()
+	. = list()
+	var/list/power_sources = get_all_components_of_type(/obj/item/stock_parts/power, FALSE)
+	if(!length(power_sources))
+		. += "The machine has no power sources installed."
+	for(var/obj/item/stock_parts/power/source in power_sources)
+		. += source.get_source_info()
 
 ////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -404,8 +416,13 @@ Class Procs:
 		to_chat(user, "It is missing a screen, making it hard to interact with.")
 	else if(stat & NOINPUT)
 		to_chat(user, "It is missing any input device.")
-	else if((stat & NOPOWER) && !interact_offline)
-		to_chat(user, "It is not receiving power.")
+	
+	if((stat & NOPOWER))
+		if(interact_offline)
+			to_chat(user, "It is not receiving <a href ='?src=\ref[src];power_text=1'>power</a>.")
+		else
+			to_chat(user, "It is not receiving <a href ='?src=\ref[src];power_text=1'>power</a>, making it hard to interact with.")
+
 	if(construct_state && construct_state.mechanics_info())
 		to_chat(user, "It can be <a href='?src=\ref[src];mechanics_text=1'>manipulated</a> using tools.")
 	var/list/missing = missing_parts()

--- a/code/game/machinery/_machines_base/machinery_power.dm
+++ b/code/game/machinery/_machines_base/machinery_power.dm
@@ -162,5 +162,22 @@ This is /obj/machinery level code to properly manage power usage from the area.
 	if(power_init_complete && (use_power_mode == use_power))
 		REPORT_POWER_CONSUMPTION_CHANGE(old_power, new_power_consumption)
 
+// Return the powernet of a cable node underneath the machine.
+/obj/machinery/proc/get_powernet()
+	var/turf/T = loc
+	if(!T || !istype(T))
+		return
+
+	var/obj/structure/cable/C = T.get_cable_node()
+	if(C)
+		return C.powernet
+
+// Adds available power to a connected powernet, if available.
+/obj/machinery/proc/generate_power(var/amount)
+	var/datum/powernet/P = get_powernet()
+	if(!P)
+		return
+	P.newavail += amount
+
 #undef REPORT_POWER_CONSUMPTION_CHANGE
 #undef MACHINE_UPDATES_FROM_AREA_POWER

--- a/code/game/machinery/_machines_base/machinery_power.dm
+++ b/code/game/machinery/_machines_base/machinery_power.dm
@@ -165,7 +165,7 @@ This is /obj/machinery level code to properly manage power usage from the area.
 // Return the powernet of a cable node underneath the machine.
 /obj/machinery/proc/get_powernet()
 	var/turf/T = loc
-	if(!T || !istype(T))
+	if(!istype(T))
 		return
 
 	var/obj/structure/cable/C = T.get_cable_node()

--- a/code/game/machinery/_machines_base/stock_parts/power/battery.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/battery.dm
@@ -190,6 +190,9 @@
 /obj/item/stock_parts/power/battery/get_cell()
 	return cell
 
+/obj/item/stock_parts/power/battery/get_source_info()
+	return "The machine can receive power from an installed power cell."
+
 /obj/item/stock_parts/power/battery/buildable
 	part_flags = PART_FLAG_HAND_REMOVE
 	material = /decl/material/solid/metal/steel

--- a/code/game/machinery/_machines_base/stock_parts/power/power.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/power.dm
@@ -35,3 +35,6 @@
 
 // This alerts the part that it does not need to provide power anymore.
 /obj/item/stock_parts/power/proc/not_needed(var/obj/machinery/machine)
+
+// Returns OOC information about how to use this power source on examine, if the machine is not receiving power.
+/obj/item/stock_parts/power/proc/get_source_info()

--- a/code/game/machinery/_machines_base/stock_parts/power/terminal.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/terminal.dm
@@ -176,10 +176,17 @@
 	part_flags = PART_FLAG_HAND_REMOVE
 	material = /decl/material/solid/metal/steel
 
+/decl/stock_part_preset/terminal_connect
+	expected_part_type = /obj/item/stock_parts/power/terminal
+
+/decl/stock_part_preset/terminal_connect/apply(obj/machinery/machine, var/obj/item/stock_parts/power/terminal/part)
+	var/obj/machinery/power/terminal/term = locate() in machine.loc
+	if(istype(term) && !term.master)
+		part.set_terminal(machine, term)
+
 /decl/stock_part_preset/terminal_setup
 	expected_part_type = /obj/item/stock_parts/power/terminal
 
 /decl/stock_part_preset/terminal_setup/apply(obj/machinery/machine, var/obj/item/stock_parts/power/terminal/part)
-	var/obj/machinery/power/terminal/term = locate() in machine.loc
-	if(istype(term) && !term.master)
-		part.set_terminal(machine, term)
+	if(isturf(machine.loc))
+		part.make_terminal(machine)

--- a/code/game/machinery/_machines_base/stock_parts/power/terminal.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/terminal.dm
@@ -172,6 +172,16 @@
 				qdel(terminal)
 		return TRUE
 
+/obj/item/stock_parts/power/terminal/get_source_info()
+	. =  "The machine can receive power by direct connection to the powernet. "
+	if(terminal)
+		if(!terminal.get_powernet())
+			. += "The power terminal must be connected to the powernet using additional cables."
+		else
+			. += "The connected powernet must be powered."
+	else
+		. += "Add cables to the machine to construct a power terminal."
+
 /obj/item/stock_parts/power/terminal/buildable
 	part_flags = PART_FLAG_HAND_REMOVE
 	material = /decl/material/solid/metal/steel

--- a/code/game/machinery/_machines_base/stock_parts/power/tesla.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/tesla.dm
@@ -26,6 +26,9 @@
 		A.use_power_oneoff(amount, channel)
 		return amount
 
+/obj/item/stock_parts/power/apc/get_source_info()
+	return "The machine can receive power wirelessly from a nearby area power controller."
+
 /obj/item/stock_parts/power/apc/buildable
 	part_flags = PART_FLAG_HAND_REMOVE
 	material = /decl/material/solid/metal/steel

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -14,7 +14,7 @@
 
 	anchored = 1
 	density = 1
-
+	
 	var/temptext = ""
 	var/selfdestructing = 0
 	var/charges = 1
@@ -81,89 +81,83 @@
 ////////////////////////////////////////
 //Singularity beacon
 ////////////////////////////////////////
-/obj/machinery/power/singularity_beacon
+/obj/machinery/singularity_beacon
 	name = "ominous beacon"
 	desc = "This looks suspicious..."
 	icon = 'icons/obj/singularity.dmi'
 	icon_state = "beacon"
 
+	uncreated_component_parts = list(/obj/item/stock_parts/power/terminal)
 	anchored = 0
 	density = 1
 	layer = BASE_ABOVE_OBJ_LAYER //so people can't hide it and it's REALLY OBVIOUS
 	stat = 0
+	use_power = POWER_USE_OFF
 
-	var/active = 0
 	var/icontype = "beacon"
 
-/obj/machinery/power/singularity_beacon/proc/Activate(mob/user = null)
-	if(surplus() < 1500)
-		if(user) to_chat(user, "<span class='notice'>The connected wire doesn't have enough current.</span>")
-		return
+/obj/machinery/singularity_beacon/proc/Activate(mob/user = null)
 	for(var/obj/singularity/singulo in global.singularities)
 		if(singulo.z == z)
 			singulo.target = src
 	icon_state = "[icontype]1"
-	active = 1
-
-	START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
+	update_use_power(POWER_USE_ACTIVE)
 	if(user)
 		to_chat(user, "<span class='notice'>You activate the beacon.</span>")
 
 
-/obj/machinery/power/singularity_beacon/proc/Deactivate(mob/user = null)
+/obj/machinery/singularity_beacon/proc/Deactivate(mob/user = null)
 	for(var/obj/singularity/singulo in global.singularities)
 		if(singulo.target == src)
 			singulo.target = null
 	icon_state = "[icontype]0"
-	active = 0
+	update_use_power(POWER_USE_OFF)
 	if(user)
 		to_chat(user, "<span class='notice'>You deactivate the beacon.</span>")
 
 
-/obj/machinery/power/singularity_beacon/physical_attack_hand(var/mob/user)
+/obj/machinery/singularity_beacon/physical_attack_hand(var/mob/user)
 	. = TRUE
 	if(anchored)
-		if(active)
+		if(use_power)
 			Deactivate(user)
 		else
 			Activate(user)
 	else
 		to_chat(user, "<span class='danger'>You need to screw the beacon to the floor first!</span>")
 
-/obj/machinery/power/singularity_beacon/attackby(obj/item/W, mob/user)
+/obj/machinery/singularity_beacon/attackby(obj/item/W, mob/user)
 	if(isScrewdriver(W))
-		if(active)
+		if(use_power)
 			to_chat(user, "<span class='danger'>You need to deactivate the beacon first!</span>")
 			return
 
 		if(anchored)
 			anchored = 0
 			to_chat(user, "<span class='notice'>You unscrew the beacon from the floor.</span>")
-			disconnect_from_network()
 			return
 		else
-			if(!connect_to_network())
-				to_chat(user, "This device must be placed over an exposed cable.")
-				return
 			anchored = 1
-			to_chat(user, "<span class='notice'>You screw the beacon to the floor and attach the cable.</span>")
+			to_chat(user, "<span class='notice'>You screw the beacon to the floor.</span>")
 			return
 	..()
 	return
 
+// Ensure the terminal is always accessible to be plugged in.
+/obj/machinery/singularity_beacon/components_are_accessible(var/path)
+	if(ispath(path, /obj/item/stock_parts/power/terminal))
+		return TRUE
+	return ..()
 
-/obj/machinery/power/singularity_beacon/Destroy()
-	if(active)
+/obj/machinery/singularity_beacon/Destroy()
+	if(use_power)
 		Deactivate()
 	..()
 
-//stealth direct power usage
-/obj/machinery/power/singularity_beacon/Process()
-	if(!active)
-		return PROCESS_KILL
-	if(draw_power(1500) < 1500)
+/obj/machinery/singularity_beacon/Process()
+	if(use_power && (stat & NOPOWER))
 		Deactivate()
 
-/obj/machinery/power/singularity_beacon/syndicate
+/obj/machinery/singularity_beacon/syndicate
 	icontype = "beaconsynd"
 	icon_state = "beaconsynd0"

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -105,7 +105,6 @@
 	if(user)
 		to_chat(user, "<span class='notice'>You activate the beacon.</span>")
 
-
 /obj/machinery/singularity_beacon/proc/Deactivate(mob/user = null)
 	for(var/obj/singularity/singulo in global.singularities)
 		if(singulo.target == src)
@@ -114,7 +113,6 @@
 	update_use_power(POWER_USE_OFF)
 	if(user)
 		to_chat(user, "<span class='notice'>You deactivate the beacon.</span>")
-
 
 /obj/machinery/singularity_beacon/physical_attack_hand(var/mob/user)
 	. = TRUE
@@ -152,10 +150,13 @@
 /obj/machinery/singularity_beacon/Destroy()
 	if(use_power)
 		Deactivate()
-	..()
+	. = ..()
 
-/obj/machinery/singularity_beacon/Process()
-	if(use_power && (stat & NOPOWER))
+/obj/machinery/singularity_beacon/power_change()
+	. = ..()
+	if(!. || !use_power)
+		return
+	if(stat & NOPOWER)
 		Deactivate()
 
 /obj/machinery/singularity_beacon/syndicate

--- a/code/game/objects/items/weapons/circuitboards/machinery/pacman.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/pacman.dm
@@ -1,6 +1,6 @@
 /obj/item/stock_parts/circuitboard/pacman
 	name = "circuitboard (portable generator)"
-	build_path = /obj/machinery/power/port_gen/pacman
+	build_path = /obj/machinery/port_gen/pacman
 	board_type = "machine"
 	origin_tech = "{'programming':3,'powerstorage':3,'exoticmatter':3,'engineering':3}"
 	req_components = list(
@@ -15,15 +15,15 @@
 	)
 /obj/item/stock_parts/circuitboard/pacman/super
 	name = "circuitboard (portable fission generator)"
-	build_path = /obj/machinery/power/port_gen/pacman/super
+	build_path = /obj/machinery/port_gen/pacman/super
 	origin_tech = "{'programming':3,'powerstorage':4,'engineering':4}"
 
 /obj/item/stock_parts/circuitboard/pacman/super/potato
 	name = "circuitboard (PTTO-3 nuclear generator)"
-	build_path = /obj/machinery/power/port_gen/pacman/super/potato
+	build_path = /obj/machinery/port_gen/pacman/super/potato
 	origin_tech = "{'programming':3,'powerstorage':5,'engineering':4}"
 
 /obj/item/stock_parts/circuitboard/pacman/mrs
 	name = "circuitboard (portable fusion generator)"
-	build_path = /obj/machinery/power/port_gen/pacman/mrs
+	build_path = /obj/machinery/port_gen/pacman/mrs
 	origin_tech = "{'programming':3,'powerstorage':5,'engineering':5}"

--- a/code/game/objects/items/weapons/circuitboards/machinery/power.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/power.dm
@@ -64,7 +64,7 @@
 
 /obj/item/stock_parts/circuitboard/turbine/motor
 	name = "circuitboard (small turbine motor)"
-	build_path = /obj/machinery/power/turbinemotor
+	build_path = /obj/machinery/turbinemotor
 	board_type = "machine"
 	origin_tech = "{'powerstorage':4,'engineering':4}"
 	req_components = list(
@@ -87,7 +87,7 @@
 
 /obj/item/stock_parts/circuitboard/big_turbine/center
 	name = "circuitboard (large turbine motor)"
-	build_path = /obj/machinery/power/turbine
+	build_path = /obj/machinery/turbine
 	board_type = "machine"
 	origin_tech = "{'powerstorage':4,'engineering':4}"
 	req_components = list(
@@ -115,7 +115,7 @@
 
 /obj/item/stock_parts/circuitboard/teg_turbine/motor
 	name = "circuitboard (thermoelectric generator motor)"
-	build_path = /obj/machinery/power/generator
+	build_path = /obj/machinery/generator
 	board_type = "machine"
 	origin_tech = "{'powerstorage':4,'engineering':4}"
 	req_components = list(

--- a/code/game/objects/items/weapons/circuitboards/machinery/shieldgen.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/shieldgen.dm
@@ -2,7 +2,7 @@
 /obj/item/stock_parts/circuitboard/shield_generator
 	name = "circuitboard (advanced shield generator)"
 	board_type = "machine"
-	build_path = /obj/machinery/power/shield_generator
+	build_path = /obj/machinery/shield_generator
 	origin_tech = "{'magnets':3,'powerstorage':4}"
 	req_components = list(
 							/obj/item/stock_parts/capacitor = 1,
@@ -11,7 +11,7 @@
 	additional_spawn_components = list(
 		/obj/item/stock_parts/console_screen = 1,
 		/obj/item/stock_parts/keyboard = 1,
-		/obj/item/stock_parts/power/apc/buildable = 1
+		/obj/item/stock_parts/power/terminal = 1
 	)
 
 /obj/item/stock_parts/circuitboard/shield_diffuser

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -311,7 +311,7 @@
 	if(alert("Are you sure? This will start up the engine. Should only be used during debug!",,"Yes","No") != "Yes")
 		return
 
-	for(var/obj/machinery/power/emitter/E in SSmachines.machinery)
+	for(var/obj/machinery/emitter/E in SSmachines.machinery)
 		if(E.anchored)
 			E.active = 1
 
@@ -337,7 +337,7 @@
 				//S.dissipate_track = 0
 				//S.dissipate_strength = 10
 
-	for(var/obj/machinery/power/rad_collector/Rad in SSmachines.machinery)
+	for(var/obj/machinery/rad_collector/Rad in SSmachines.machinery)
 		if(Rad.anchored)
 			if(!Rad.loaded_tank)
 				Rad.loaded_tank = new /obj/item/tank/hydrogen(Rad)

--- a/code/modules/atmospherics/components/binary_devices/pipeturbine.dm
+++ b/code/modules/atmospherics/components/binary_devices/pipeturbine.dm
@@ -73,7 +73,7 @@
 	if (kin_energy > 1000000)
 		overlays += image('icons/obj/pipeturbine.dmi', "hi-turb")
 
-/obj/machinery/power/turbinemotor
+/obj/machinery/turbinemotor
 	name = "motor"
 	desc = "Electrogenerator. Converts rotation into power."
 	icon = 'icons/obj/pipeturbine.dmi'
@@ -88,26 +88,26 @@
 	uncreated_component_parts = null
 	construct_state = /decl/machine_construction/default/panel_closed
 
-/obj/machinery/power/turbinemotor/Initialize()
+/obj/machinery/turbinemotor/Initialize()
 	. = ..()
 	updateConnection()
 
-/obj/machinery/power/turbinemotor/proc/updateConnection()
+/obj/machinery/turbinemotor/proc/updateConnection()
 	turbine = null
 	if(src.loc && anchored)
 		turbine = locate(/obj/machinery/atmospherics/pipeturbine) in get_step(src,dir)
 		if (turbine.stat & (BROKEN) || !turbine.anchored || turn(turbine.dir,180) != dir)
 			turbine = null
 
-/obj/machinery/power/turbinemotor/wrench_floor_bolts(user)
+/obj/machinery/turbinemotor/wrench_floor_bolts(user)
 	. = ..()
 	updateConnection()
 
-/obj/machinery/power/turbinemotor/Process()
+/obj/machinery/turbinemotor/Process()
 	updateConnection()
 	if(!turbine || !anchored || stat & (BROKEN))
 		return
 
 	var/power_generated = kin_to_el_ratio * turbine.kin_energy
 	turbine.kin_energy -= power_generated
-	add_avail(power_generated)
+	generate_power(power_generated)

--- a/code/modules/codex/entries/machinery.dm
+++ b/code/modules/codex/entries/machinery.dm
@@ -60,9 +60,9 @@
 	antag_text = "People can be inserted into the disposal unit. If they're capable of moving however, it's easy for them to get out. Be careful though, putting things in disposal units doesn't always mean they're gone forever. <BR>If you turn it off, it can be used to hide in. Just be careful no one turns it back on while you're still in there!"
 
 /datum/codex_entry/emitter
-	associated_paths = list(/obj/machinery/power/emitter)
-	mechanics_text = "You must secure this in place with a wrench and weld it to the floor before using it. The emitter will only fire if it is installed above a cable endpoint. Clicking will toggle it on and off, at which point, so long as it remains powered, it will fire in a single direction in bursts of four."
-	lore_text = "Lasers like this one have been in use for ages, in applications such as mining, cutting, and in the startup sequence of many advanced space station and starship engines."
+	associated_paths = list(/obj/machinery/emitter)
+	mechanics_text = "You must secure this in place with a wrench and weld it to the floor before using it. Using cables on the emitter will allow you to connect it to the powernet with a terminal, placed over a cable node. Clicking will toggle it on and off, at which point, so long as it remains powered, it will fire in a single direction in bursts of four."
+	lore_text = "Lasers like this one have been in use for ages, in applications such as mining, cutting, and in the startup sequence of many advanced space station and starshipn engines."
 	antag_text = "This baby is capable of slicing through walls, sealed lockers, and people."
 
 /datum/codex_entry/fusion_fuel_injector
@@ -72,7 +72,7 @@
 	mechanics_text = "Accepts a fuel rod produced by the fuel compressor and regularly fires fuel pellets into the fusion field. Rods can be swapped by hand when the injector is not firing. Power outages will require the injector to be turned on again. If there is no electromagnetic field active to catch the injected fuel, the results can be very unhealthy for anyone standing in the firing path. <BR>Controlled via the fuel injection control computer."
 
 /datum/codex_entry/fusion_core
-	associated_paths = list(/obj/machinery/power/fusion_core, /obj/machinery/computer/fusion/core_control)
+	associated_paths = list(/obj/machinery/fusion_core, /obj/machinery/computer/fusion/core_control)
 	associated_strings = list("R-UST Mk. 8 Tokamak core","\improper R-UST Mk. 8 core control","rust","fusion","tokamak")
 	lore_text = "An old but more or less reliable fusion field generator. Probably sourced from a retired cargo freighter."
 	mechanics_text = "Generates the field used to contain reaction material from fuel injectors, and dumps power into the power network under it based on plasma heat. Needs 500W or more in the network to start the field. Field will become unstable if it intersects with windows or other objects, and from some reactions, and will eventually rupture violently if not stabilized by a gyrotron. Turning the field off without letting it cool below 1000K will cause a violent explosion and EMP depending on the contents of the field. <BR>Controlled via the R-UST Mk. 8 core control. Make careful note of the instability."
@@ -84,13 +84,13 @@
 	mechanics_text = "Uses sheets of material or units of reagents to produce fuel rods. Material/units are inserted by hand. Can also have some objects click-dragged onto it for more exotic fuel."
 
 /datum/codex_entry/gyrotron
-	associated_paths = list(/obj/machinery/power/emitter/gyrotron, /obj/machinery/computer/fusion/gyrotron)
+	associated_paths = list(/obj/machinery/emitter/gyrotron, /obj/machinery/computer/fusion/gyrotron)
 	associated_strings = list ("gyrotron","gyrotron control console")
 	lore_text = "A high-power industrial laser used to excite plasma for fusion reactions. Also used to excite careless engineers, usually fatally."
 	mechanics_text = "Fires in pulses and will heat up a plasma toroid that is below 1000K. Mostly used to lower field instability after heating it to ignition point. Very power hungry, uses 20k per point of power. <BR>Controlled via the gyrotron control console."
 
 /datum/codex_entry/pacman
-	associated_paths = list(/obj/machinery/power/port_gen/pacman)
+	associated_paths = list(/obj/machinery/port_gen/pacman)
 	mechanics_text = "Lends itself to being portable thanks to the small size and ease of use. Some versions use radioactive fuel and as such produces radiation, while others may produce dangerous byproducts as gasses. Ideally one should wear protective gear while interacting with an active generator. While active it also produces heat and will eventually overheat and explode. While the power output can be increased, doing this causes it to heat up faster. Must be secured using a wrench before use."
 	antag_text = "Can be used as a makeshift delayed explosive when power output is set to unsafe levels, though it may take some time to go off."
 

--- a/code/modules/economy/worth_misc.dm
+++ b/code/modules/economy/worth_misc.dm
@@ -6,6 +6,6 @@
 PATH/get_value_multiplier() { . = 1 } \
 PATH/get_base_value() { . = AMT }
 
-ARBITRARY_WORTH(/obj/machinery/power/emitter,        700)
-ARBITRARY_WORTH(/obj/machinery/power/rad_collector,  500)
+ARBITRARY_WORTH(/obj/machinery/emitter,        700)
+ARBITRARY_WORTH(/obj/machinery/rad_collector,  500)
 ARBITRARY_WORTH(/obj/structure/particle_accelerator, 500) 

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -63,21 +63,21 @@
 	var/list/shields = list()
 	if(overmap_only)
 		for(var/obj/effect/overmap/visitable/sector AS_ANYTHING in overmap_sectors)
-			var/list/sector_shields = sector.get_linked_machines_of_type(/obj/machinery/power/shield_generator)
+			var/list/sector_shields = sector.get_linked_machines_of_type(/obj/machinery/shield_generator)
 			if(length(sector_shields))
 				shields |= sector_shields
 	else
-		for(var/obj/machinery/power/shield_generator/G in SSmachines.machinery)
+		for(var/obj/machinery/shield_generator/G in SSmachines.machinery)
 			if(G.z in affecting_z)
 				shields |= G
 
-	for(var/obj/machinery/power/shield_generator/G AS_ANYTHING in shields)
+	for(var/obj/machinery/shield_generator/G AS_ANYTHING in shields)
 		if(!(G.running) || !G.check_flag(MODEFLAG_EM))
 			shields -= G
 
 	var/shielded = FALSE
 	if(length(shields))
-		var/obj/machinery/power/shield_generator/shield_gen = pick(shields)
+		var/obj/machinery/shield_generator/shield_gen = pick(shields)
 		//Minor breaches aren't enough to let through frying amounts of power
 		if(shield_gen.take_shield_damage(30 * severity, SHIELD_DAMTYPE_EM) <= SHIELD_BREACHED_MINOR)
 			shielded = TRUE

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -121,7 +121,7 @@
 /obj/machinery/mining/drill/physical_attack_hand(mob/user)
 	check_supports()
 	if(need_player_check)
-		if(can_use_power_oneoff(10 KILOWATTS))
+		if(can_use_power_oneoff(10 KILOWATTS) <= 0)
 			system_error("insufficient charge")
 		else if(anchored)
 			get_resource_field()

--- a/code/modules/modular_computers/file_system/programs/engineering/shields_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/shields_monitor.dm
@@ -13,13 +13,13 @@
 
 /datum/nano_module/program/shields_monitor
 	name = "Shields monitor"
-	var/obj/machinery/power/shield_generator/active = null
+	var/obj/machinery/shield_generator/active = null
 
 /datum/nano_module/program/shields_monitor/Destroy()
 	. = ..()
 	deselect_shield()
 
-/datum/nano_module/program/shields_monitor/proc/can_connect_to_shield(obj/machinery/power/shield_generator/S)
+/datum/nano_module/program/shields_monitor/proc/can_connect_to_shield(obj/machinery/shield_generator/S)
 	var/datum/computer_network/network = get_network()
 	if(!network)
 		return FALSE
@@ -27,7 +27,7 @@
 
 /datum/nano_module/program/shields_monitor/proc/get_shields()
 	var/list/shields = list()
-	for(var/obj/machinery/power/shield_generator/S in SSmachines.machinery)
+	for(var/obj/machinery/shield_generator/S in SSmachines.machinery)
 		if(!can_connect_to_shield(S))
 			continue
 		shields.Add(S)
@@ -71,7 +71,7 @@
 		data["active"] = null
 		var/list/shields = get_shields()
 		var/list/shields_info = list()
-		for(var/obj/machinery/power/shield_generator/S in shields)
+		for(var/obj/machinery/shield_generator/S in shields)
 			var/area/A = get_area(S)
 			var/list/temp = list(list(
 				"shield_status" = S.running,
@@ -100,7 +100,7 @@
 		return 1
 	if( href_list["ref"] )
 		var/list/shields = get_shields()
-		var/obj/machinery/power/shield_generator/S = locate(href_list["ref"]) in shields
+		var/obj/machinery/shield_generator/S = locate(href_list["ref"]) in shields
 		if(S)
 			deselect_shield()
 			events_repository.register(/decl/observ/destroyed, S, src, /datum/nano_module/program/shields_monitor/proc/deselect_shield)

--- a/code/modules/overmap/contacts/_contacts.dm
+++ b/code/modules/overmap/contacts/_contacts.dm
@@ -66,8 +66,8 @@
 	var/obj/effect/overmap/visitable/visitable_effect = effect
 	if(!visitable_effect || !istype(visitable_effect))
 		return FALSE
-	for(var/thing in visitable_effect.get_linked_machines_of_type(/obj/machinery/power/shield_generator))
-		var/obj/machinery/power/shield_generator/S = thing 
+	for(var/thing in visitable_effect.get_linked_machines_of_type(/obj/machinery/shield_generator))
+		var/obj/machinery/shield_generator/S = thing 
 		if(S.running == SHIELD_RUNNING)
 			return TRUE
 	return FALSE

--- a/code/modules/overmap/ftl_shunt/core.dm
+++ b/code/modules/overmap/ftl_shunt/core.dm
@@ -53,7 +53,7 @@
 	idle_power_usage = 1600
 	icon_state = "bsd"
 	light_color = COLOR_BLUE
-
+	stock_part_presets = list(/decl/stock_part_preset/terminal_setup)
 //Base procs
 
 /obj/machinery/ftl_shunt/core/Initialize(mapload, d, populate_parts)
@@ -65,10 +65,6 @@
 	find_ports()
 	set_light(2)
 	target_charge = max_charge * 0.25 //Target charge set to a quarter of our maximum charge, just for weirdness prevention
-	if(populate_parts)
-		var/obj/item/stock_parts/power/terminal/term = get_component_of_type(/obj/item/stock_parts/power/terminal)
-		if(!term.terminal)
-			term.make_terminal(src)
 
 /obj/machinery/ftl_shunt/core/modify_mapped_vars(map_hash)
 	..()

--- a/code/modules/overmap/ships/machines/fusion_thruster.dm
+++ b/code/modules/overmap/ships/machines/fusion_thruster.dm
@@ -7,7 +7,7 @@
 
 	idle_power_usage = 13600
 	var/initial_id_tag
-	var/obj/machinery/power/fusion_core/harvest_from
+	var/obj/machinery/fusion_core/harvest_from
 
 /obj/machinery/atmospherics/unary/engine/fusion/Initialize()
 	..()
@@ -30,7 +30,7 @@
 	var/datum/local_network/lan = lanm.get_local_network()
 
 	if(lan)	
-		var/list/fusion_cores = lan.get_devices(/obj/machinery/power/fusion_core)
+		var/list/fusion_cores = lan.get_devices(/obj/machinery/fusion_core)
 		if(fusion_cores && fusion_cores.len)
 			harvest_from = fusion_cores[1]
 	return harvest_from

--- a/code/modules/overmap/ships/machines/gas_thruster.dm
+++ b/code/modules/overmap/ships/machines/gas_thruster.dm
@@ -89,4 +89,4 @@
 // This comes with an additional terminal component and tries to set it up on init (you should map a terminal beneath it). This is for mapping only.
 /obj/machinery/atmospherics/unary/engine/terminal
 	uncreated_component_parts = list(/obj/item/stock_parts/power/terminal/buildable)
-	stock_part_presets = list(/decl/stock_part_preset/terminal_setup)
+	stock_part_presets = list(/decl/stock_part_preset/terminal_connect)

--- a/code/modules/pointdefense/pointdefense.dm
+++ b/code/modules/pointdefense/pointdefense.dm
@@ -109,7 +109,7 @@
 	idle_power_usage = 0.1 KILOWATTS
 	construct_state = /decl/machine_construction/default/panel_closed
 	base_type = /obj/machinery/pointdefense
-	stock_part_presets = list(/decl/stock_part_preset/terminal_setup)
+	stock_part_presets = list(/decl/stock_part_preset/terminal_connect)
 	uncreated_component_parts = null
 	appearance_flags = PIXEL_SCALE | LONG_GLIDE
 	var/active = TRUE

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -147,6 +147,7 @@ var/global/list/all_apcs = list()
 	uncreated_component_parts = list(
 		/obj/item/cell/apc
 	)
+	stock_part_presets = list(/decl/stock_part_preset/terminal_setup)
 
 /obj/machinery/power/apc/buildable
 	uncreated_component_parts = null
@@ -190,11 +191,10 @@ var/global/list/all_apcs = list()
 
 	. = ..()
 
-	if (populate_parts)
-		init_round_start()
-	else
+	if(!populate_parts)
 		operating = 0
-		queue_icon_update()
+	
+	queue_icon_update()
 
 	if(operating)
 		force_update_channels()
@@ -229,11 +229,6 @@ var/global/list/all_apcs = list()
 	if(!failure_timer && duration)
 		playsound(src, 'sound/machines/apc_nopower.ogg', 75, 0)
 	failure_timer = max(failure_timer, round(duration))
-
-/obj/machinery/power/apc/proc/init_round_start()
-	var/obj/item/stock_parts/power/terminal/term = get_component_of_type(/obj/item/stock_parts/power/terminal)
-	term.make_terminal(src) // intentional crash if there is no terminal
-	queue_icon_update()
 
 /obj/machinery/power/apc/proc/terminal(var/functional_only)
 	var/obj/item/stock_parts/power/terminal/term = get_component_of_type(/obj/item/stock_parts/power/terminal)

--- a/code/modules/power/fission/core.dm
+++ b/code/modules/power/fission/core.dm
@@ -221,7 +221,7 @@
 	. = ..()
 
 /obj/machinery/atmospherics/unary/fission_core/proc/jump_start()
-	if((stat & (BROKEN|NOPOWER)) || can_use_power_oneoff(5 KILOWATTS))
+	if((stat & (BROKEN|NOPOWER)) || (can_use_power_oneoff(5 KILOWATTS) <= 0))
 		visible_message("\The [src] flashes an 'Insufficient Power' error.")
 		return
 	use_power_oneoff(5 KILOWATTS)

--- a/code/modules/power/fusion/_setup.dm
+++ b/code/modules/power/fusion/_setup.dm
@@ -17,7 +17,7 @@
 		to_chat(usr, "Error: you are not an admin!")
 		return
 
-	if(!(locate(/obj/machinery/power/fusion_core/mapped) in SSmachines.machinery))
+	if(!(locate(/obj/machinery/fusion_core/mapped) in SSmachines.machinery))
 		to_chat(usr, "This map is not appropriate for this verb.")
 		return
 
@@ -31,14 +31,14 @@
 
 	log_and_message_admins("## FUSION CORE SETUP - Setup initiated by [usr].")
 
-	var/obj/machinery/power/fusion_core/mapped/core = locate() in SSmachines.machinery
+	var/obj/machinery/fusion_core/mapped/core = locate() in SSmachines.machinery
 	if(core.jumpstart(15000))
 
 		for(var/obj/machinery/fusion_fuel_injector/mapped/injector in SSmachines.machinery)
 			injector.cur_assembly = new /obj/item/fuel_assembly/deuterium(injector)
 			injector.BeginInjecting()
 
-		for(var/obj/machinery/power/emitter/gyrotron/gyro in SSmachines.machinery)
+		for(var/obj/machinery/emitter/gyrotron/gyro in SSmachines.machinery)
 			gyro.activate(usr)
 
 		var/list/delayed_objects = list()

--- a/code/modules/power/fusion/consoles/core_control.dm
+++ b/code/modules/power/fusion/consoles/core_control.dm
@@ -5,7 +5,7 @@
 /obj/machinery/computer/fusion/core_control/OnTopic(var/mob/user, var/href_list, var/datum/topic_state/state)
 
 	if(href_list["toggle_active"] || href_list["str"])
-		var/obj/machinery/power/fusion_core/C = locate(href_list["machine"])
+		var/obj/machinery/fusion_core/C = locate(href_list["machine"])
 		if(!istype(C))
 			return TOPIC_NOACTION
 
@@ -13,7 +13,7 @@
 		if(!lan || !lan.is_connected(C))
 			return TOPIC_NOACTION
 
-		if(!C.check_core_status())
+		if(C.stat & BROKEN)
 			return TOPIC_NOACTION
 
 		if(href_list["toggle_active"])
@@ -38,10 +38,10 @@
 	var/datum/local_network/lan = fusion.get_local_network()
 	var/list/cores = list()
 	if(lan)
-		var/list/fusion_cores = lan.get_devices(/obj/machinery/power/fusion_core)
+		var/list/fusion_cores = lan.get_devices(/obj/machinery/fusion_core)
 		for(var/i = 1 to LAZYLEN(fusion_cores))
 			var/list/core = list()
-			var/obj/machinery/power/fusion_core/C = fusion_cores[i]
+			var/obj/machinery/fusion_core/C = fusion_cores[i]
 			core["id"] =          "#[i]"
 			core["ref"] =         "\ref[C]"
 			core["field"] =       !isnull(C.owned_field)
@@ -49,7 +49,7 @@
 			core["size"] =        C.owned_field ? "[C.owned_field.size] meter\s" : "Field offline."
 			core["instability"] = C.owned_field ? "[C.owned_field.percent_unstable * 100]%" : "Field offline."
 			core["temperature"] = C.owned_field ? "[C.owned_field.plasma_temperature + 295]K" : "Field offline."
-			core["powerstatus"] = "[C.avail()]/[C.active_power_usage] W"
+			core["powerstatus"] = "[C.active_power_usage] W"
 			var/fuel_string = "<table width = '100%'>"
 			if(C.owned_field && LAZYLEN(C.owned_field.reactants))
 				for(var/reactant in C.owned_field.reactants)

--- a/code/modules/power/fusion/consoles/gyrotron_control.dm
+++ b/code/modules/power/fusion/consoles/gyrotron_control.dm
@@ -9,12 +9,12 @@
 
 	if(href_list["modifypower"] || href_list["modifyrate"] || href_list["toggle"])
 
-		var/obj/machinery/power/emitter/gyrotron/G = locate(href_list["machine"])
+		var/obj/machinery/emitter/gyrotron/G = locate(href_list["machine"])
 		if(!istype(G))
 			return TOPIC_NOACTION
 
 		var/datum/local_network/lan = get_local_network()
-		var/list/gyrotrons = lan.get_devices(/obj/machinery/power/emitter/gyrotron)
+		var/list/gyrotrons = lan.get_devices(/obj/machinery/emitter/gyrotron)
 		if(!lan || !gyrotrons || !gyrotrons[G])
 			return TOPIC_NOACTION
 
@@ -49,10 +49,10 @@
 	var/datum/local_network/lan = fusion.get_local_network()
 	var/list/gyrotrons = list()
 	if(lan && gyrotrons)
-		var/list/lan_gyrotrons = lan.get_devices(/obj/machinery/power/emitter/gyrotron)
+		var/list/lan_gyrotrons = lan.get_devices(/obj/machinery/emitter/gyrotron)
 		for(var/i = 1 to LAZYLEN(lan_gyrotrons))
 			var/list/gyrotron = list()
-			var/obj/machinery/power/emitter/gyrotron/G = lan_gyrotrons[i]
+			var/obj/machinery/emitter/gyrotron/G = lan_gyrotrons[i]
 			gyrotron["id"] =        "#[i]"
 			gyrotron["ref"] =       "\ref[G]" 
 			gyrotron["active"] =    G.active

--- a/code/modules/power/fusion/core/_core.dm
+++ b/code/modules/power/fusion/core/_core.dm
@@ -1,7 +1,7 @@
 #define MAX_FIELD_STR 10000
 #define MIN_FIELD_STR 1
 
-/obj/machinery/power/fusion_core
+/obj/machinery/fusion_core
 	name = "\improper R-UST Mk. 8 Tokamak core"
 	desc = "An enormous solenoid for generating extremely high power electromagnetic fields. It includes a kinetic energy harvester."
 	icon = 'icons/obj/machines/power/fusion_core.dmi'
@@ -15,34 +15,35 @@
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
-	base_type = /obj/machinery/power/fusion_core
+	base_type = /obj/machinery/fusion_core
+	stock_part_presets = list(/decl/stock_part_preset/terminal_setup)
 
 	var/obj/effect/fusion_em_field/owned_field
 	var/field_strength = 1//0.01
 	var/initial_id_tag
 
-/obj/machinery/power/fusion_core/mapped
+/obj/machinery/fusion_core/mapped
 	anchored = 1
 
-/obj/machinery/power/fusion_core/Initialize()
+/obj/machinery/fusion_core/Initialize()
 	. = ..()
-	connect_to_network()
 	set_extension(src, /datum/extension/local_network_member)
 	if(initial_id_tag)
 		var/datum/extension/local_network_member/fusion = get_extension(src, /datum/extension/local_network_member)
 		fusion.set_tag(null, initial_id_tag)
 
-/obj/machinery/power/fusion_core/modify_mapped_vars(map_hash)
+/obj/machinery/fusion_core/modify_mapped_vars(map_hash)
 	..()
 	ADJUST_TAG_VAR(initial_id_tag, map_hash)
 
-/obj/machinery/power/fusion_core/Process()
-	if((stat & BROKEN) || !powernet || !owned_field)
-		Shutdown()
-	else
-		owned_field.handle_tick()
+/obj/machinery/fusion_core/Process()
+	if(use_power == POWER_USE_ACTIVE)
+		if((stat & BROKEN) || !owned_field)
+			update_use_power(POWER_USE_IDLE)
+		else
+			owned_field.handle_tick()
 
-/obj/machinery/power/fusion_core/Topic(href, href_list)
+/obj/machinery/fusion_core/Topic(href, href_list)
 	if(..())
 		return 1
 	if(href_list["str"])
@@ -52,7 +53,12 @@
 		if(owned_field)
 			owned_field.ChangeFieldStrength(field_strength)
 
-/obj/machinery/power/fusion_core/proc/Startup()
+/obj/machinery/fusion_core/update_use_power(new_use_power)
+	. = ..()
+	if(use_power == POWER_USE_IDLE && owned_field)
+		Shutdown()
+
+/obj/machinery/fusion_core/proc/Startup()
 	if(owned_field)
 		return
 	owned_field = new(loc, src)
@@ -61,7 +67,7 @@
 	update_use_power(POWER_USE_ACTIVE)
 	. = 1
 
-/obj/machinery/power/fusion_core/proc/Shutdown(var/force_rupture)
+/obj/machinery/fusion_core/proc/Shutdown(var/force_rupture)
 	if(owned_field)
 		icon_state = "core0"
 		if(force_rupture || owned_field.plasma_temperature > 1000)
@@ -70,31 +76,29 @@
 			owned_field.RadiateAll()
 		qdel(owned_field)
 		owned_field = null
-	update_use_power(POWER_USE_IDLE)
 
-/obj/machinery/power/fusion_core/proc/AddParticles(var/name, var/quantity = 1)
+/obj/machinery/fusion_core/proc/AddParticles(var/name, var/quantity = 1)
 	if(owned_field)
 		owned_field.AddParticles(name, quantity)
 		. = 1
 
-/obj/machinery/power/fusion_core/bullet_act(var/obj/item/projectile/Proj)
+/obj/machinery/fusion_core/bullet_act(var/obj/item/projectile/Proj)
 	if(owned_field)
 		. = owned_field.bullet_act(Proj)
 
-/obj/machinery/power/fusion_core/proc/set_strength(var/value)
+/obj/machinery/fusion_core/proc/set_strength(var/value)
 	value = Clamp(value, MIN_FIELD_STR, MAX_FIELD_STR)
 	field_strength = value
 	change_power_consumption(5 * value, POWER_USE_ACTIVE)
 	if(owned_field)
 		owned_field.ChangeFieldStrength(value)
 
-/obj/machinery/power/fusion_core/physical_attack_hand(var/mob/user)
+/obj/machinery/fusion_core/physical_attack_hand(var/mob/user)
 	visible_message(SPAN_NOTICE("\The [user] hugs \the [src] to make it feel better!"))
-	if(owned_field)
-		Shutdown()
+	Shutdown()
 	return TRUE
 
-/obj/machinery/power/fusion_core/attackby(var/obj/item/W, var/mob/user)
+/obj/machinery/fusion_core/attackby(var/obj/item/W, var/mob/user)
 
 	if(owned_field)
 		to_chat(user,"<span class='warning'>Shut \the [src] off first!</span>")
@@ -120,17 +124,10 @@
 
 	return ..()
 
-/obj/machinery/power/fusion_core/proc/jumpstart(var/field_temperature)
+/obj/machinery/fusion_core/proc/jumpstart(var/field_temperature)
 	field_strength = 200 // 3x3, generally a good size.
 	Startup()
 	if(!owned_field)
 		return FALSE
 	owned_field.plasma_temperature = field_temperature
 	return TRUE
-
-/obj/machinery/power/fusion_core/proc/check_core_status()
-	if(stat & BROKEN)
-		return FALSE
-	if(idle_power_usage > avail())
-		return FALSE
-	. = TRUE

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -26,7 +26,7 @@
 	var/fusion_reactant_cap
 	var/cohesion_regeneration = 1
 
-	var/obj/machinery/power/fusion_core/owned_core
+	var/obj/machinery/fusion_core/owned_core
 	var/list/reactants = list()
 	var/list/particle_catchers = list()
 
@@ -34,7 +34,8 @@
 		/obj/item/projectile,
 		/obj/effect,
 		/obj/structure/cable,
-		/obj/machinery/atmospherics
+		/obj/machinery/atmospherics,
+		/obj/machinery/power/terminal
 		)
 
 	var/light_min_range = 2
@@ -45,7 +46,7 @@
 	var/last_range
 	var/last_power
 
-/obj/effect/fusion_em_field/Initialize(mapload, var/obj/machinery/power/fusion_core/new_owned_core)
+/obj/effect/fusion_em_field/Initialize(mapload, var/obj/machinery/fusion_core/new_owned_core)
 	. = ..()
 
 	set_light(light_min_range, light_min_power)
@@ -111,7 +112,7 @@
 	React()
 
 	// Dump power to our powernet.
-	owned_core.add_avail(FUSION_ENERGY_PER_K * plasma_temperature)
+	owned_core.generate_power(FUSION_ENERGY_PER_K * plasma_temperature)
 
 	// Energy decay.
 	if(plasma_temperature >= 1)

--- a/code/modules/power/fusion/fusion_circuits.dm
+++ b/code/modules/power/fusion/fusion_circuits.dm
@@ -30,9 +30,12 @@
 
 /obj/item/stock_parts/circuitboard/fusion_core
 	name = "circuitboard (fusion core)"
-	build_path = /obj/machinery/power/fusion_core
+	build_path = /obj/machinery/fusion_core
 	board_type = "machine"
 	origin_tech = "{'wormholes':2,'magnets':4,'powerstorage':4}"
+	additional_spawn_components = list(
+		/obj/item/stock_parts/power/terminal = 1
+	)
 	req_components = list(
 							/obj/item/stock_parts/manipulator/pico = 2,
 							/obj/item/stock_parts/micro_laser/ultra = 1,
@@ -56,9 +59,12 @@
 
 /obj/item/stock_parts/circuitboard/gyrotron
 	name = "circuitboard (gyrotron)"
-	build_path = /obj/machinery/power/emitter/gyrotron
+	build_path = /obj/machinery/emitter/gyrotron
 	board_type = "machine"
 	origin_tech = "{'powerstorage':4,'engineering':4}"
+	additional_spawn_components = list(
+		/obj/item/stock_parts/power/terminal = 1
+	)
 	req_components = list(
 							/obj/item/stack/cable_coil = 20,
 							/obj/item/stock_parts/micro_laser/ultra = 2

--- a/code/modules/power/fusion/gyrotron/gyrotron.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron.dm
@@ -15,9 +15,8 @@
 
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = list(
-		/obj/item/stock_parts/radio/receiver,
+		/obj/item/stock_parts/radio/receiver
 	)
-	stat_immune = 0
 	base_type = /obj/machinery/emitter/gyrotron
 
 /obj/machinery/emitter/gyrotron/anchored

--- a/code/modules/power/fusion/gyrotron/gyrotron.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron.dm
@@ -1,6 +1,6 @@
 #define GYRO_POWER 25000
 
-/obj/machinery/power/emitter/gyrotron
+/obj/machinery/emitter/gyrotron
 	name = "gyrotron"
 	icon = 'icons/obj/machines/power/fusion.dmi'
 	desc = "It is a heavy duty industrial gyrotron suited for powering fusion reactors."
@@ -18,13 +18,13 @@
 		/obj/item/stock_parts/radio/receiver,
 	)
 	stat_immune = 0
-	base_type = /obj/machinery/power/emitter/gyrotron
+	base_type = /obj/machinery/emitter/gyrotron
 
-/obj/machinery/power/emitter/gyrotron/anchored
+/obj/machinery/emitter/gyrotron/anchored
 	anchored = 1
 	state = 2
 
-/obj/machinery/power/emitter/gyrotron/Initialize()
+/obj/machinery/emitter/gyrotron/Initialize()
 	set_extension(src, /datum/extension/local_network_member)
 	if(initial_id_tag)
 		var/datum/extension/local_network_member/fusion = get_extension(src, /datum/extension/local_network_member)
@@ -32,32 +32,32 @@
 	change_power_consumption(mega_energy * GYRO_POWER, POWER_USE_ACTIVE)
 	. = ..()
 
-/obj/machinery/power/emitter/gyrotron/modify_mapped_vars(map_hash)
+/obj/machinery/emitter/gyrotron/modify_mapped_vars(map_hash)
 	..()
 	ADJUST_TAG_VAR(initial_id_tag, map_hash)
 
-/obj/machinery/power/emitter/gyrotron/Process()
+/obj/machinery/emitter/gyrotron/Process()
 	change_power_consumption(mega_energy * GYRO_POWER, POWER_USE_ACTIVE)
 	. = ..()
 
-/obj/machinery/power/emitter/gyrotron/get_rand_burst_delay()
+/obj/machinery/emitter/gyrotron/get_rand_burst_delay()
 	return rate*10
 
-/obj/machinery/power/emitter/gyrotron/get_burst_delay()
+/obj/machinery/emitter/gyrotron/get_burst_delay()
 	return rate*10
 
-/obj/machinery/power/emitter/gyrotron/get_emitter_beam()
+/obj/machinery/emitter/gyrotron/get_emitter_beam()
 	var/obj/item/projectile/beam/emitter/E = ..()
 	E.damage = mega_energy * 50
 	return E
 
-/obj/machinery/power/emitter/gyrotron/on_update_icon()
-	if (active && powernet && avail(active_power_usage))
+/obj/machinery/emitter/gyrotron/on_update_icon()
+	if (active && can_use_power_oneoff(active_power_usage))
 		icon_state = "emitter-on"
 	else
 		icon_state = "emitter-off"
 
-/obj/machinery/power/emitter/gyrotron/attackby(var/obj/item/W, var/mob/user)
+/obj/machinery/emitter/gyrotron/attackby(var/obj/item/W, var/mob/user)
 	if(isMultitool(W))
 		var/datum/extension/local_network_member/fusion = get_extension(src, /datum/extension/local_network_member)
 		fusion.get_new_tag(user)

--- a/code/modules/power/fusion/kinetic_harvester.dm
+++ b/code/modules/power/fusion/kinetic_harvester.dm
@@ -13,7 +13,7 @@
 	var/initial_id_tag
 	var/list/stored =     list()
 	var/list/harvesting = list()
-	var/obj/machinery/power/fusion_core/harvest_from
+	var/obj/machinery/fusion_core/harvest_from
 
 /obj/machinery/kinetic_harvester/Initialize()
 	set_extension(src, /datum/extension/local_network_member)
@@ -46,7 +46,7 @@
 	var/datum/local_network/lan = lanm.get_local_network()
 
 	if(lan)	
-		var/list/fusion_cores = lan.get_devices(/obj/machinery/power/fusion_core)
+		var/list/fusion_cores = lan.get_devices(/obj/machinery/fusion_core)
 		if(fusion_cores && fusion_cores.len)
 			harvest_from = fusion_cores[1]
 	return harvest_from

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -1,4 +1,4 @@
-/obj/machinery/power/generator
+/obj/machinery/generator
 	name = "thermoelectric generator"
 	desc = "It's a high efficiency thermoelectric generator."
 	icon_state = "teg-unassembled"
@@ -27,7 +27,7 @@
 	construct_state = /decl/machine_construction/default/panel_closed
 	stat_immune = 0
 
-/obj/machinery/power/generator/Initialize()
+/obj/machinery/generator/Initialize()
 	. = ..()
 	desc = initial(desc) + " Rated for [round(max_power/1000)] kW."
 	reconnect()
@@ -37,7 +37,7 @@
 //so a circulator to the NORTH of the generator connects first to the EAST, then to the WEST
 //and a circulator to the WEST of the generator connects first to the NORTH, then to the SOUTH
 //note that the circulator's outlet dir is it's always facing dir, and it's inlet is always the reverse
-/obj/machinery/power/generator/proc/reconnect()
+/obj/machinery/generator/proc/reconnect()
 	if(circ1)
 		circ1.temperature_overlay = null
 	if(circ2)
@@ -63,7 +63,7 @@
 				circ2 = null
 	update_icon()
 
-/obj/machinery/power/generator/on_update_icon()
+/obj/machinery/generator/on_update_icon()
 	icon_state = anchored ? "teg-assembled" : "teg-unassembled"
 	overlays.Cut()
 	if (circ1)
@@ -85,7 +85,7 @@
 					circ2.temperature_overlay = "circ-[extreme]cold"
 		return 1
 
-/obj/machinery/power/generator/Process()
+/obj/machinery/generator/Process()
 	if(!circ1 || !circ2 || !anchored || stat & (BROKEN|NOPOWER))
 		stored_energy = 0
 		return
@@ -149,9 +149,10 @@
 	if(genlev != lastgenlev)
 		lastgenlev = genlev
 		update_icon()
-	add_avail(effective_gen)
+	
+	generate_power(effective_gen)
 
-/obj/machinery/power/generator/attackby(obj/item/W, mob/user)
+/obj/machinery/generator/attackby(obj/item/W, mob/user)
 	if(isWrench(W))
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
 		anchored = !anchored
@@ -159,26 +160,22 @@
 					"You [anchored ? "secure" : "unsecure"] the bolts holding [src] to the floor.", \
 					"You hear a ratchet.")
 		update_use_power(anchored)
-		if(anchored) // Powernet connection stuff.
-			connect_to_network()
-		else
-			disconnect_from_network()
 		reconnect()
 	else
 		..()
 
-/obj/machinery/power/generator/CanUseTopic(mob/user)
+/obj/machinery/generator/CanUseTopic(mob/user)
 	if(!anchored)
 		return STATUS_CLOSE
 	return ..()
 
-/obj/machinery/power/generator/interface_interact(mob/user)
+/obj/machinery/generator/interface_interact(mob/user)
 	if(!circ1 || !circ2) //Just incase the middle part of the TEG was not wrenched last.
 		reconnect()
 	ui_interact(user)
 	return TRUE
 
-/obj/machinery/power/generator/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
+/obj/machinery/generator/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	// this is the data which will be sent to the ui
 	var/vertical = 0
 	if (dir == NORTH || dir == SOUTH)
@@ -229,7 +226,7 @@
 		// auto update every Master Controller tick
 		ui.set_auto_update(1)
 
-/obj/machinery/power/generator/verb/rotate_clock()
+/obj/machinery/generator/verb/rotate_clock()
 	set category = "Object"
 	set name = "Rotate Generator (Clockwise)"
 	set src in view(1)
@@ -239,7 +236,7 @@
 
 	src.set_dir(turn(src.dir, 90))
 
-/obj/machinery/power/generator/verb/rotate_anticlock()
+/obj/machinery/generator/verb/rotate_anticlock()
 	set category = "Object"
 	set name = "Rotate Generator (Counterclockwise)"
 	set src in view(1)

--- a/code/modules/power/geothermal/geothermal_circuit.dm
+++ b/code/modules/power/geothermal/geothermal_circuit.dm
@@ -1,6 +1,6 @@
 /obj/item/stock_parts/circuitboard/geothermal
 	name = "circuitboard (geothermal turbine)"
-	build_path = /obj/machinery/power/geothermal
+	build_path = /obj/machinery/geothermal
 	board_type = "machine"
 	origin_tech = "{'magnets':3,'powerstorage':3}"
 	req_components = list(

--- a/code/modules/power/geothermal/geothermal_extension.dm
+++ b/code/modules/power/geothermal/geothermal_extension.dm
@@ -24,7 +24,7 @@
 		var/turf/T = get_turf(holder)
 		if(!istype(T))
 			return
-		var/obj/machinery/power/geothermal/geothermal = locate() in T
+		var/obj/machinery/geothermal/geothermal = locate() in T
 		if(geothermal?.anchored)
 			geothermal.add_pressure(rand(pressure_min, pressure_max))
 			return

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -1,5 +1,5 @@
 //Baseline portable generator. Has all the default handling. Not intended to be used on it's own (since it generates unlimited power).
-/obj/machinery/power/port_gen
+/obj/machinery/port_gen
 	name = "Placeholder Generator"	//seriously, don't use this. It can't be anchored without VV magic.
 	desc = "A portable generator for emergency backup power."
 	icon = 'icons/obj/power.dmi'
@@ -17,26 +17,26 @@
 	var/sound_id
 	var/working_sound
 
-/obj/machinery/power/port_gen/proc/IsBroken()
+/obj/machinery/port_gen/proc/IsBroken()
 	return (stat & (BROKEN|EMPED))
 
-/obj/machinery/power/port_gen/proc/HasFuel() //Placeholder for fuel check.
+/obj/machinery/port_gen/proc/HasFuel() //Placeholder for fuel check.
 	return 1
 
-/obj/machinery/power/port_gen/proc/UseFuel() //Placeholder for fuel use.
+/obj/machinery/port_gen/proc/UseFuel() //Placeholder for fuel use.
 	return
 
-/obj/machinery/power/port_gen/proc/DropFuel()
+/obj/machinery/port_gen/proc/DropFuel()
 	return
 
-/obj/machinery/power/port_gen/proc/handleInactive()
+/obj/machinery/port_gen/proc/handleInactive()
 	return
 
-/obj/machinery/power/port_gen/proc/update_sound()
+/obj/machinery/port_gen/proc/update_sound()
 	if(!working_sound)
 		return
 	if(!sound_id)
-		sound_id = "[type]_[sequential_id(/obj/machinery/power/port_gen)]"
+		sound_id = "[type]_[sequential_id(/obj/machinery/port_gen)]"
 	if(active && HasFuel() && !IsBroken())
 		var/volume = 10 + 15*power_output
 		if(!sound_token)
@@ -47,10 +47,10 @@
 		QDEL_NULL(sound_token)
 
 
-/obj/machinery/power/port_gen/Process()
+/obj/machinery/port_gen/Process()
 	..()
-	if(active && HasFuel() && !IsBroken() && anchored && powernet)
-		add_avail(power_gen * power_output)
+	if(active && HasFuel() && !IsBroken() && anchored)
+		generate_power(power_gen * power_output)
 		UseFuel()
 		src.updateDialog()
 	else
@@ -59,20 +59,20 @@
 	update_icon()
 	update_sound()
 
-/obj/machinery/power/port_gen/on_update_icon()
+/obj/machinery/port_gen/on_update_icon()
 	if(!active)
 		icon_state = initial(icon_state)
 		return 1
 	else
 		icon_state = "[initial(icon_state)]on"
 
-/obj/machinery/power/port_gen/CanUseTopic(mob/user)
+/obj/machinery/port_gen/CanUseTopic(mob/user)
 	if(!anchored)
 		to_chat(user, "<span class='warning'>The generator needs to be secured first.</span>")
 		return STATUS_CLOSE
 	return ..()
 
-/obj/machinery/power/port_gen/examine(mob/user, distance)
+/obj/machinery/port_gen/examine(mob/user, distance)
 	. = ..()
 	if(distance > 1)
 		return
@@ -80,8 +80,7 @@
 		to_chat(usr, "<span class='notice'>The generator is on.</span>")
 	else
 		to_chat(usr, "<span class='notice'>The generator is off.</span>")
-
-/obj/machinery/power/port_gen/emp_act(severity)
+/obj/machinery/port_gen/emp_act(severity)
 	if(!active)
 		return
 	var/duration = 6000 //ten minutes
@@ -101,7 +100,7 @@
 		spawn(duration)
 			stat &= ~EMPED
 
-/obj/machinery/power/port_gen/proc/explode()
+/obj/machinery/port_gen/proc/explode()
 	explosion(src.loc, -1, 3, 5, -1)
 	qdel(src)
 
@@ -109,7 +108,7 @@
 #define TEMPERATURE_CHANGE_MAX 20
 
 //A power generator that runs on solid plasma sheets.
-/obj/machinery/power/port_gen/pacman
+/obj/machinery/port_gen/pacman
 	name = "portable generator"
 	desc = "A power generator that runs on solid graphite sheets. Rated for 80 kW max safe output."
 
@@ -141,7 +140,7 @@
 	var/overheating = 0		//if this gets high enough the generator explodes
 	var/max_overheat = 150
 
-/obj/machinery/power/port_gen/pacman/examine(mob/user)
+/obj/machinery/port_gen/pacman/examine(mob/user)
 	. = ..()
 	if(active)
 		to_chat(user, "\The [src] appears to be producing [power_gen*power_output] W.")
@@ -157,7 +156,7 @@
 		to_chat(user, "There [sheets == 1 ? "is" : "are"] [sheets] [sheets == 1 ? initial(sheet.singular_name) : initial(sheet.plural_name)] left in the hopper.")
 		to_chat(user, SPAN_SUBTLE("\The [src] uses [mat.solid_name] [initial(sheet.plural_name)] as fuel to produce power."))
 
-/obj/machinery/power/port_gen/pacman/Initialize()
+/obj/machinery/port_gen/pacman/Initialize()
 	. = ..()
 
 	if(isnull(sheet_path))
@@ -165,14 +164,11 @@
 		if(mat)
 			sheet_path = mat.default_solid_form
 
-	if(anchored)
-		connect_to_network()
-
-/obj/machinery/power/port_gen/pacman/Destroy()
+/obj/machinery/port_gen/pacman/Destroy()
 	DropFuel()
 	return ..()
 
-/obj/machinery/power/port_gen/pacman/RefreshParts()
+/obj/machinery/port_gen/pacman/RefreshParts()
 	var/temp_rating = total_component_rating_of_type(/obj/item/stock_parts/micro_laser)
 	temp_rating += total_component_rating_of_type(/obj/item/stock_parts/capacitor)
 
@@ -181,21 +177,21 @@
 	power_gen = round(initial(power_gen) * Clamp(temp_rating, 0, 20) / 2)
 	..()
 
-/obj/machinery/power/port_gen/pacman/proc/process_exhaust()
+/obj/machinery/port_gen/pacman/proc/process_exhaust()
 	var/decl/material/mat = GET_DECL(sheet_material)
 	if(mat && mat.burn_product)
 		var/datum/gas_mixture/environment = loc.return_air()
 		if(environment)
 			environment.adjust_gas(mat.burn_product, 0.05*power_output)
 
-/obj/machinery/power/port_gen/pacman/HasFuel()
+/obj/machinery/port_gen/pacman/HasFuel()
 	var/needed_sheets = power_output / time_per_sheet
 	if(sheets >= needed_sheets - sheet_left)
 		return 1
 	return 0
 
 //Removes one stack's worth of material from the generator.
-/obj/machinery/power/port_gen/pacman/DropFuel()
+/obj/machinery/port_gen/pacman/DropFuel()
 	if(sheets)
 		var/obj/item/stack/sheet_prototype = sheet_path
 		var/dump_amount = min(sheets, initial(sheet_prototype.max_amount))
@@ -206,7 +202,7 @@
 			new sheet_path(loc, dump_amount)
 		sheets -= dump_amount
 
-/obj/machinery/power/port_gen/pacman/UseFuel()
+/obj/machinery/port_gen/pacman/UseFuel()
 
 	//how much material are we using this iteration?
 	var/needed_sheets = power_output / time_per_sheet
@@ -256,7 +252,7 @@
 		overheating--
 	process_exhaust()
 
-/obj/machinery/power/port_gen/pacman/handleInactive()
+/obj/machinery/port_gen/pacman/handleInactive()
 	var/cooling_temperature = 20
 	var/datum/gas_mixture/environment = loc.return_air()
 	if (environment)
@@ -273,12 +269,12 @@
 	if(overheating)
 		overheating--
 
-/obj/machinery/power/port_gen/pacman/proc/overheat()
+/obj/machinery/port_gen/pacman/proc/overheat()
 	overheating++
 	if (overheating > max_overheat)
 		explode()
 
-/obj/machinery/power/port_gen/pacman/explode()
+/obj/machinery/port_gen/pacman/explode()
 	// Vaporize all the fuel
 	// When ground up in a grinder, 1 sheet produces 20 u of material -- Chemistry-Machinery.dm
 	// 1 mol = 10 u? I dunno. 1 mol of carbon is definitely bigger than a pill
@@ -290,7 +286,7 @@
 	sheet_left = 0
 	..()
 
-/obj/machinery/power/port_gen/pacman/emag_act(var/remaining_charges, var/mob/user)
+/obj/machinery/port_gen/pacman/emag_act(var/remaining_charges, var/mob/user)
 	if (active && prob(25))
 		explode() //if they're foolish enough to emag while it's running
 
@@ -298,15 +294,15 @@
 		emagged = 1
 		return 1
 
-/obj/machinery/power/port_gen/pacman/components_are_accessible(path)
+/obj/machinery/port_gen/pacman/components_are_accessible(path)
 	return !active && ..()
 
-/obj/machinery/power/port_gen/pacman/cannot_transition_to(state_path, mob/user)
+/obj/machinery/port_gen/pacman/cannot_transition_to(state_path, mob/user)
 	if(active)
 		return SPAN_WARNING("You cannot do this while \the [src] is running!")
 	return ..()
 
-/obj/machinery/power/port_gen/pacman/attackby(var/obj/item/O, var/mob/user)
+/obj/machinery/port_gen/pacman/attackby(var/obj/item/O, var/mob/user)
 	if(istype(O, sheet_path) && (isnull(sheet_material) || sheet_material == O.get_material_type()))
 		var/obj/item/stack/addstack = O
 		var/amount = min((max_sheets - sheets), addstack.amount)
@@ -320,26 +316,24 @@
 		return
 	if(isWrench(O) && !active)
 		if(!anchored)
-			connect_to_network()
 			to_chat(user, "<span class='notice'>You secure \the [src] to the floor.</span>")
 		else
-			disconnect_from_network()
 			to_chat(user, "<span class='notice'>You unsecure \the [src] from the floor.</span>")
 
 		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		anchored = !anchored
 	return component_attackby(O, user)
 
-/obj/machinery/power/port_gen/pacman/dismantle()
+/obj/machinery/port_gen/pacman/dismantle()
 	while (sheets > 0)
 		DropFuel()
 	. = ..()
 
-/obj/machinery/power/port_gen/pacman/interface_interact(mob/user)
+/obj/machinery/port_gen/pacman/interface_interact(mob/user)
 	ui_interact(user)
 	return TRUE
 
-/obj/machinery/power/port_gen/pacman/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
+/obj/machinery/port_gen/pacman/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	if(IsBroken())
 		return
 
@@ -384,7 +378,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/power/port_gen/pacman/Topic(href, href_list)
+/obj/machinery/port_gen/pacman/Topic(href, href_list)
 	if(..())
 		return
 
@@ -408,7 +402,7 @@
 			if (power_output < max_power_output || (emagged && power_output < round(max_power_output*2.5)))
 				power_output++
 
-/obj/machinery/power/port_gen/pacman/super
+/obj/machinery/port_gen/pacman/super
 	name = "portable fission generator"
 	desc = "A power generator that utilizes uranium sheets as fuel. Can run for much longer than the standard portabke generators. Rated for 80 kW max safe output."
 	icon_state = "portgen1"
@@ -418,16 +412,16 @@
 	var/rad_power = 4
 
 //nuclear energy is green energy!
-/obj/machinery/power/port_gen/pacman/super/process_exhaust()
+/obj/machinery/port_gen/pacman/super/process_exhaust()
 	return
 
-/obj/machinery/power/port_gen/pacman/super/UseFuel()
+/obj/machinery/port_gen/pacman/super/UseFuel()
 	//produces a tiny amount of radiation when in use
 	if (prob(rad_power*power_output))
 		SSradiation.radiate(src, 2*rad_power)
 	..()
 
-/obj/machinery/power/port_gen/pacman/super/on_update_icon()
+/obj/machinery/port_gen/pacman/super/on_update_icon()
 	if(..())
 		set_light(0)
 		return 1
@@ -442,7 +436,7 @@
 		set_light(0)
 
 
-/obj/machinery/power/port_gen/pacman/super/explode()
+/obj/machinery/port_gen/pacman/super/explode()
 	//a nice burst of radiation
 	var/rads = rad_power*25 + (sheets + sheet_left)*1.5
 	SSradiation.radiate(src, (max(40, rads)))
@@ -450,7 +444,7 @@
 	explosion(src.loc, rad_power+1, rad_power+1, rad_power*2, 3)
 	qdel(src)
 
-/obj/machinery/power/port_gen/pacman/super/potato
+/obj/machinery/port_gen/pacman/super/potato
 	name = "nuclear reactor"
 	desc = "PTTO-3, an industrial all-in-one nuclear power plant by Neo-Chernobyl GmbH. It uses uranium and vodka as a fuel source. Rated for 150 kW max safe output."
 	power_gen = 30000			//Watts output per power_output level
@@ -464,15 +458,15 @@
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	anchored = 1
 
-/obj/machinery/power/port_gen/pacman/super/potato/Initialize()
+/obj/machinery/port_gen/pacman/super/potato/Initialize()
 	create_reagents(120)
 	. = ..()
 
-/obj/machinery/power/port_gen/pacman/super/potato/examine(mob/user)
+/obj/machinery/port_gen/pacman/super/potato/examine(mob/user)
 	. = ..()
 	to_chat(user, "Auxilary tank shows [reagents.total_volume]u of liquid in it.")
 
-/obj/machinery/power/port_gen/pacman/super/potato/UseFuel()
+/obj/machinery/port_gen/pacman/super/potato/UseFuel()
 	if(reagents.has_reagent(/decl/material/liquid/ethanol/vodka))
 		rad_power = 4
 		temperature_gain = 60
@@ -484,13 +478,13 @@
 		temperature_gain = initial(temperature_gain)
 	..()
 
-/obj/machinery/power/port_gen/pacman/super/potato/on_update_icon()
+/obj/machinery/port_gen/pacman/super/potato/on_update_icon()
 	if(..())
 		return 1
 	if(power_output > max_safe_output)
 		icon_state = "potatodanger"
 
-/obj/machinery/power/port_gen/pacman/super/potato/attackby(var/obj/item/O, var/mob/user)
+/obj/machinery/port_gen/pacman/super/potato/attackby(var/obj/item/O, var/mob/user)
 	if(istype(O, /obj/item/chems/))
 		var/obj/item/chems/R = O
 		if(R.standard_pour_into(src,user))
@@ -503,7 +497,7 @@
 		return
 	..()
 
-/obj/machinery/power/port_gen/pacman/mrs
+/obj/machinery/port_gen/pacman/mrs
 	name = "portable fusion generator"
 	desc = "An advanced portable fusion generator that runs on tritium. Rated for 200 kW maximum safe output!"
 	icon_state = "portgen2"
@@ -518,7 +512,7 @@
 	max_temperature = 800
 	temperature_gain = 90
 
-/obj/machinery/power/port_gen/pacman/mrs/explode()
+/obj/machinery/port_gen/pacman/mrs/explode()
 	//no special effects, but the explosion is pretty big (same as a supermatter shard).
 	explosion(src.loc, 3, 6, 12, 16, 1)
 	qdel(src)

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -2,7 +2,7 @@ var/global/list/rad_collectors = list()
 
 // TODO: swap the hydrogen tanks out for lithium sheets or something like that.
 
-/obj/machinery/power/rad_collector
+/obj/machinery/rad_collector
 	name = "radiation collector array"
 	desc = "A device which uses radiation and hydrogen to produce power."
 	icon = 'icons/obj/machines/rad_collector.dmi'
@@ -29,15 +29,15 @@ var/global/list/rad_collectors = list()
 	var/end_time = 0
 	var/alert_delay = 10 SECONDS
 
-/obj/machinery/power/rad_collector/Initialize()
+/obj/machinery/rad_collector/Initialize()
 	. = ..()
 	rad_collectors += src
 
-/obj/machinery/power/rad_collector/Destroy()
+/obj/machinery/rad_collector/Destroy()
 	rad_collectors -= src
 	. = ..()
 
-/obj/machinery/power/rad_collector/Process()
+/obj/machinery/rad_collector/Process()
 	if((stat & BROKEN) || melted)
 		return
 	var/turf/T = get_turf(src)
@@ -70,12 +70,12 @@ var/global/list/rad_collectors = list()
 		else
 			loaded_tank.air_adjust_gas(/decl/material/gas/hydrogen, -0.01*drainratio*min(last_rads,max_rads)/max_rads) //fuel cost increases linearly with incoming radiation
 
-/obj/machinery/power/rad_collector/CanUseTopic(mob/user)
+/obj/machinery/rad_collector/CanUseTopic(mob/user)
 	if(!anchored)
 		return STATUS_CLOSE
 	return ..()
 
-/obj/machinery/power/rad_collector/interface_interact(mob/user)
+/obj/machinery/rad_collector/interface_interact(mob/user)
 	if(!CanInteract(user, DefaultTopicState()))
 		return FALSE
 	. = TRUE
@@ -89,7 +89,7 @@ var/global/list/rad_collectors = list()
 	else
 		to_chat(user, "<span class='warning'>The controls are locked!</span>")
 
-/obj/machinery/power/rad_collector/attackby(obj/item/W, mob/user)
+/obj/machinery/rad_collector/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/tank/hydrogen))
 		if(!src.anchored)
 			to_chat(user, "<span class='warning'>The [src] needs to be secured to the floor first.</span>")
@@ -110,7 +110,7 @@ var/global/list/rad_collectors = list()
 		if(loaded_tank)
 			to_chat(user, "<span class='notice'>Remove the tank first.</span>")
 			return 1
-		for(var/obj/machinery/power/rad_collector/R in get_turf(src))
+		for(var/obj/machinery/rad_collector/R in get_turf(src))
 			if(R != src)
 				to_chat(user, "<span class='warning'>You cannot install more than one collector on the same spot.</span>")
 				return 1
@@ -119,10 +119,6 @@ var/global/list/rad_collectors = list()
 		user.visible_message("[user.name] [anchored? "secures":"unsecures"] the [src.name].", \
 			"You [anchored? "secure":"undo"] the external bolts.", \
 			"You hear a ratchet.")
-		if(anchored && !(stat & BROKEN))
-			connect_to_network()
-		else
-			disconnect_from_network()
 		return 1
 	else if(istype(W, /obj/item/card/id)||istype(W, /obj/item/modular_computer))
 		if (src.allowed(user))
@@ -137,18 +133,18 @@ var/global/list/rad_collectors = list()
 		return 1
 	return ..()
 
-/obj/machinery/power/rad_collector/examine(mob/user, distance)
+/obj/machinery/rad_collector/examine(mob/user, distance)
 	. = ..()
 	if (distance <= 3 && !(stat & BROKEN))
 		to_chat(user, "The meter indicates that \the [src] is collecting [last_power] W.")
 		return 1
 
-/obj/machinery/power/rad_collector/explosion_act(severity)
+/obj/machinery/rad_collector/explosion_act(severity)
 	if(severity != 1)
 		eject()
 	. = ..()
 
-/obj/machinery/power/rad_collector/proc/collector_break()
+/obj/machinery/rad_collector/proc/collector_break()
 	if(loaded_tank?.air_contents)
 		var/turf/T = get_turf(src)
 		if(T)
@@ -157,7 +153,6 @@ var/global/list/rad_collectors = list()
 			fragmentate(T, 2, 4, list(/obj/item/projectile/bullet/pellet/fragment/tank/small = 3, /obj/item/projectile/bullet/pellet/fragment/tank = 1))
 			explosion(T, -1, -1, 0)
 			QDEL_NULL(loaded_tank)
-	disconnect_from_network()
 	stat |= BROKEN
 	melted = TRUE
 	anchored = FALSE
@@ -165,10 +160,10 @@ var/global/list/rad_collectors = list()
 	desc += " This one is destroyed beyond repair."
 	update_icon()
 
-/obj/machinery/power/rad_collector/return_air()
+/obj/machinery/rad_collector/return_air()
 	. =loaded_tank?.return_air()
 
-/obj/machinery/power/rad_collector/proc/eject()
+/obj/machinery/rad_collector/proc/eject()
 	locked = 0
 	var/obj/item/tank/hydrogen/Z = src.loaded_tank
 	if (!Z)
@@ -181,17 +176,17 @@ var/global/list/rad_collectors = list()
 	else
 		update_icon()
 
-/obj/machinery/power/rad_collector/proc/receive_pulse(var/pulse_strength)
+/obj/machinery/rad_collector/proc/receive_pulse(var/pulse_strength)
 	if(loaded_tank && active)
 		var/power_produced = 0
 		power_produced = min(100*loaded_tank.air_contents.gas[/decl/material/gas/hydrogen]*pulse_strength*pulse_coeff,max_power)
-		add_avail(power_produced)
+		generate_power(power_produced)
 		last_power_new = power_produced
 		return
 	return
 
 
-/obj/machinery/power/rad_collector/on_update_icon()
+/obj/machinery/rad_collector/on_update_icon()
 	if(melted)
 		icon_state = "ca_melt"
 	else if(active)
@@ -213,7 +208,7 @@ var/global/list/rad_collectors = list()
 		overlays += image(icon, "rads_[rad_power]")
 		overlays += image(icon, "on")
 
-/obj/machinery/power/rad_collector/toggle_power()
+/obj/machinery/rad_collector/toggle_power()
 	active = !active
 	if(active)
 		flick("ca_active", src)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -1,6 +1,6 @@
 #define EMITTER_DAMAGE_POWER_TRANSFER 450 //used to transfer power to containment field generators
 
-/obj/machinery/power/emitter
+/obj/machinery/emitter
 	name = "emitter"
 	desc = "A massive heavy industrial laser. This design is a fixed installation, capable of shooting in only one direction."
 	icon = 'icons/obj/singularity.dmi'
@@ -11,8 +11,8 @@
 	active_power_usage = 100 KILOWATTS
 
 	var/efficiency = 0.3	// Energy efficiency. 30% at this time, so 100kW load means 30kW laser pulses.
+	var/minimum_power = 10 KILOWATTS // The minimum power the emitter will still fire at it it doesn't have enough power available.
 	var/active = 0
-	var/powered = 0
 	var/fire_delay = 100
 	var/max_burst_delay = 100
 	var/min_burst_delay = 20
@@ -21,11 +21,12 @@
 	var/shot_number = 0
 	var/state = 0
 	var/locked = 0
+	var/powered = 0
 	core_skill = SKILL_ENGINES
 
 	uncreated_component_parts = list(
 		/obj/item/stock_parts/radio/receiver,
-		/obj/item/stock_parts/power/apc
+		/obj/item/stock_parts/power/terminal
 	)
 	public_variables = list(
 		/decl/public_access/public_variable/emitter_active,
@@ -34,56 +35,48 @@
 	public_methods = list(
 		/decl/public_access/public_method/toggle_emitter
 	)
-	stock_part_presets = list(/decl/stock_part_preset/radio/receiver/emitter = 1)
+	stock_part_presets = list(/decl/stock_part_preset/radio/receiver/emitter = 1, /decl/stock_part_preset/terminal_connect = 1)
 
-/obj/machinery/power/emitter/anchored
+/obj/machinery/emitter/anchored
 	anchored = 1
 	state = 2
 
-/obj/machinery/power/emitter/Initialize()
-	. = ..()
-	if(state == 2 && anchored)
-		connect_to_network()
-
-/obj/machinery/power/emitter/Destroy()
+/obj/machinery/emitter/Destroy()
 	log_and_message_admins("deleted \the [src]")
 	investigate_log("<font color='red'>deleted</font> at ([x],[y],[z])","singulo")
 	return ..()
 
-/obj/machinery/power/emitter/on_update_icon()
-	if (active && powernet && avail(active_power_usage))
+/obj/machinery/emitter/on_update_icon()
+	if (active && powered)
 		icon_state = "emitter_+a"
 	else
 		icon_state = "emitter"
 
-/obj/machinery/power/emitter/interface_interact(mob/user)
+/obj/machinery/emitter/interface_interact(mob/user)
 	if(!CanInteract(user, DefaultTopicState()))
 		return FALSE
 	activate(user)
 	return TRUE
 
-/obj/machinery/power/emitter/proc/activate(mob/user)
+/obj/machinery/emitter/proc/activate(mob/user)
 	if(!istype(user))
 		user = null // safety, as the proc is publicly available.
 
 	if(state == 2)
-		if(!powernet)
-			to_chat(user, "\The [src] isn't connected to a wire.")
-			return 1
-		if(!src.locked)
-			if(src.active==1)
-				src.active = 0
+		if(!locked)
+			if(active==1)
+				active = 0
 				to_chat(user, "You turn off \the [src].")
 				log_and_message_admins("turned off \the [src]")
 				investigate_log("turned <font color='red'>off</font> by [key_name_admin(user || usr)]","singulo")
 			else
-				src.active = 1
+				active = 1
 				if(user)
 					operator_skill = user.get_skill_value(core_skill)
 				update_efficiency()
 				to_chat(user, "You turn on \the [src].")
-				src.shot_number = 0
-				src.fire_delay = get_initial_fire_delay()
+				shot_number = 0
+				fire_delay = get_initial_fire_delay()
 				log_and_message_admins("turned on \the [src]")
 				investigate_log("turned <font color='green'>on</font> by [key_name_admin(user || usr)]","singulo")
 			update_icon()
@@ -93,59 +86,54 @@
 		to_chat(user, "<span class='warning'>\The [src] needs to be firmly secured to the floor first.</span>")
 		return 1
 
-/obj/machinery/power/emitter/proc/update_efficiency()
+/obj/machinery/emitter/proc/update_efficiency()
 	efficiency = initial(efficiency)
 	if(!operator_skill)
 		return
 	var/skill_modifier = 0.8 * (SKILL_MAX - operator_skill)/(SKILL_MAX - SKILL_MIN) //How much randomness is added
 	efficiency *= 1 + (rand() - 1) * skill_modifier //subtract off between 0.8 and 0, depending on skill and luck.
 
-/obj/machinery/power/emitter/emp_act(var/severity)
+/obj/machinery/emitter/emp_act(var/severity)
 	return 1
 
-/obj/machinery/power/emitter/Process()
+/obj/machinery/emitter/Process()
 	if(stat & (BROKEN))
 		return
-	if(src.state != 2 || (!powernet && active_power_usage))
-		src.active = 0
+	if(state != 2)
+		active = FALSE
 		update_icon()
 		return
-	if(((src.last_shot + src.fire_delay) <= world.time) && (src.active == 1))
-
-		var/actual_load = draw_power(active_power_usage)
-		if(actual_load >= active_power_usage) //does the laser have enough power to shoot?
-			if(!powered)
-				powered = 1
-				update_icon()
-				investigate_log("regained power and turned <font color='green'>on</font>","singulo")
-		else
-			if(powered)
-				powered = 0
-				update_icon()
-				investigate_log("lost power and turned <font color='red'>off</font>","singulo")
+	if(((last_shot + fire_delay) <= world.time) && (active == 1))
+		if(active_power_usage - can_use_power_oneoff(active_power_usage) < minimum_power)
+			powered = FALSE
+			update_icon()
 			return
-
-		src.last_shot = world.time
-		if(src.shot_number < burst_shots)
-			src.fire_delay = get_burst_delay()
-			src.shot_number ++
+		var/drawn_power = min(active_power_usage, active_power_usage - use_power_oneoff(active_power_usage))
+		last_shot = world.time
+		if(shot_number < burst_shots)
+			fire_delay = get_burst_delay()
+			shot_number ++
 		else
-			src.fire_delay = get_rand_burst_delay()
-			src.shot_number = 0
+			fire_delay = get_rand_burst_delay()
+			shot_number = 0
 
 		//need to calculate the power per shot as the emitter doesn't fire continuously.
 		var/burst_time = (min_burst_delay + max_burst_delay)/2 + 2*(burst_shots-1)
-		var/power_per_shot = (active_power_usage * efficiency) * (burst_time/10) / burst_shots
+		var/power_per_shot = (drawn_power * efficiency) * (burst_time/10) / burst_shots
 
 		if(prob(35))
 			spark_at(src, amount=5, cardinal_only = TRUE)
 
 		var/obj/item/projectile/beam/emitter/A = get_emitter_beam()
-		playsound(src.loc, A.fire_sound, 25, 1)
+		playsound(loc, A.fire_sound, 25, 1)
 		A.damage = round(power_per_shot/EMITTER_DAMAGE_POWER_TRANSFER)
-		A.launch( get_step(src.loc, src.dir) )
+		A.launch( get_step(loc, dir) )
+		
+		if(!powered)
+			powered = TRUE
+			update_icon()
 
-/obj/machinery/power/emitter/attackby(obj/item/W, mob/user)
+/obj/machinery/emitter/attackby(obj/item/W, mob/user)
 
 	if(isWrench(W))
 		if(active)
@@ -154,18 +142,18 @@
 		switch(state)
 			if(0)
 				state = 1
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
+				playsound(loc, 'sound/items/Ratchet.ogg', 75, 1)
 				user.visible_message("[user.name] secures [src] to the floor.", \
 					"You secure the external reinforcing bolts to the floor.", \
 					"You hear a ratchet.")
-				src.anchored = 1
+				anchored = 1
 			if(1)
 				state = 0
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
+				playsound(loc, 'sound/items/Ratchet.ogg', 75, 1)
 				user.visible_message("[user.name] unsecures [src] reinforcing bolts from the floor.", \
 					"You undo the external reinforcing bolts.", \
 					"You hear a ratchet.")
-				src.anchored = 0
+				anchored = 0
 			if(2)
 				to_chat(user, "<span class='warning'>\The [src] needs to be unwelded from the floor.</span>")
 		return
@@ -180,7 +168,7 @@
 				to_chat(user, "<span class='warning'>\The [src] needs to be wrenched to the floor.</span>")
 			if(1)
 				if (WT.remove_fuel(0,user))
-					playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
+					playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
 					user.visible_message("[user.name] starts to weld [src] to the floor.", \
 						"You start to weld [src] to the floor.", \
 						"You hear welding.")
@@ -188,12 +176,11 @@
 						if(!src || !WT.isOn()) return
 						state = 2
 						to_chat(user, "You weld [src] to the floor.")
-						connect_to_network()
 				else
 					to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 			if(2)
 				if (WT.remove_fuel(0,user))
-					playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
+					playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
 					user.visible_message("[user.name] starts to cut [src] free from the floor.", \
 						"You start to cut [src] free from the floor.", \
 						"You hear welding.")
@@ -201,7 +188,6 @@
 						if(!src || !WT.isOn()) return
 						state = 1
 						to_chat(user, "You cut [src] free from the floor.")
-						disconnect_from_network()
 				else
 					to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 		return
@@ -210,16 +196,16 @@
 		if(emagged)
 			to_chat(user, "<span class='warning'>The lock seems to be broken.</span>")
 			return
-		if(src.allowed(user))
-			src.locked = !src.locked
-			to_chat(user, "The controls are now [src.locked ? "locked." : "unlocked."]")
+		if(allowed(user))
+			locked = !locked
+			to_chat(user, "The controls are now [locked ? "locked." : "unlocked."]")
 		else
 			to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 	..()
 	return
 
-/obj/machinery/power/emitter/emag_act(var/remaining_charges, var/mob/user)
+/obj/machinery/emitter/emag_act(var/remaining_charges, var/mob/user)
 	if(!emagged)
 		locked = 0
 		emagged = 1
@@ -227,41 +213,46 @@
 		user.visible_message("[user.name] emags [src].","<span class='warning'>You short out the lock.</span>")
 		return 1
 
-/obj/machinery/power/emitter/proc/get_initial_fire_delay()
+/obj/machinery/emitter/components_are_accessible(var/path)
+	if(ispath(path, /obj/item/stock_parts/power/terminal))
+		return TRUE
+	return ..()
+
+/obj/machinery/emitter/proc/get_initial_fire_delay()
 	return 100
 
-/obj/machinery/power/emitter/proc/get_rand_burst_delay()
+/obj/machinery/emitter/proc/get_rand_burst_delay()
 	return rand(min_burst_delay, max_burst_delay)
 
-/obj/machinery/power/emitter/proc/get_burst_delay()
+/obj/machinery/emitter/proc/get_burst_delay()
 	return 2
 
-/obj/machinery/power/emitter/proc/get_emitter_beam()
+/obj/machinery/emitter/proc/get_emitter_beam()
 	return new /obj/item/projectile/beam/emitter(get_turf(src))
 
 /decl/public_access/public_method/toggle_emitter
 	name = "toggle emitter"
 	desc = "Toggles whether or not the emitter is active. It must be unlocked to work."
-	call_proc = /obj/machinery/power/emitter/proc/activate
+	call_proc = /obj/machinery/emitter/proc/activate
 
 /decl/public_access/public_variable/emitter_active
-	expected_type = /obj/machinery/power/emitter
+	expected_type = /obj/machinery/emitter
 	name = "emitter active"
 	desc = "Whether or not the emitter is firing."
 	can_write = FALSE
 	has_updates = FALSE
 
-/decl/public_access/public_variable/emitter_active/access_var(obj/machinery/power/emitter/emitter)
+/decl/public_access/public_variable/emitter_active/access_var(obj/machinery/emitter/emitter)
 	return emitter.active
 
 /decl/public_access/public_variable/emitter_locked
-	expected_type = /obj/machinery/power/emitter
+	expected_type = /obj/machinery/emitter
 	name = "emitter locked"
 	desc = "Whether or not the emitter is locked. Being locked prevents one from changing the active state."
 	can_write = FALSE
 	has_updates = FALSE
 
-/decl/public_access/public_variable/emitter_locked/access_var(obj/machinery/power/emitter/emitter)
+/decl/public_access/public_variable/emitter_locked/access_var(obj/machinery/emitter/emitter)
 	return emitter.locked
 
 /decl/stock_part_preset/radio/receiver/emitter

--- a/code/modules/power/singularity/particle_accelerator/particle.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle.dm
@@ -37,8 +37,8 @@
 			toxmob(A)
 		if((istype(A,/obj/machinery/the_singularitygen))||(istype(A,/obj/singularity/)))
 			A:energy += energy
-		else if(istype(A,/obj/machinery/power/fusion_core))
-			var/obj/machinery/power/fusion_core/collided_core = A
+		else if(istype(A,/obj/machinery/fusion_core))
+			var/obj/machinery/fusion_core/collided_core = A
 			if(particle_type && particle_type != "neutron")
 				if(collided_core.AddParticles(particle_type, 1 + additional_particles))
 					collided_core.owned_field.plasma_temperature += mega_energy

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -38,8 +38,8 @@ var/global/list/singularities = list()
 	if (temp)
 		QDEL_IN(src, temp)
 	START_PROCESSING(SSobj, src)
-	for(var/obj/machinery/power/singularity_beacon/singubeacon in SSmachines.machinery)
-		if(singubeacon.active)
+	for(var/obj/machinery/singularity_beacon/singubeacon in SSmachines.machinery)
+		if(singubeacon.use_power == POWER_USE_ACTIVE)
 			target = singubeacon
 			break
 
@@ -461,7 +461,7 @@ var/global/list/singularities = list()
 	return
 
 /obj/singularity/proc/pulse()
-	for(var/obj/machinery/power/rad_collector/R in rad_collectors)
+	for(var/obj/machinery/rad_collector/R in rad_collectors)
 		if (get_dist(R, src) <= 15) //Better than using orange() every process.
 			R.receive_pulse(energy)
 

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -5,7 +5,7 @@
 	icon_state = "compressor"
 	anchored = 1
 	density = 1
-	var/obj/machinery/power/turbine/turbine
+	var/obj/machinery/turbine/turbine
 	var/datum/gas_mixture/gas_contained
 	var/turf/simulated/inturf
 	var/starter = 0
@@ -17,7 +17,7 @@
 	uncreated_component_parts = null
 	construct_state = /decl/machine_construction/default/panel_closed
 
-/obj/machinery/power/turbine
+/obj/machinery/turbine
 	name = "gas turbine generator"
 	desc = "A gas turbine used for backup power generation."
 	icon = 'icons/obj/pipes.dmi'
@@ -103,17 +103,17 @@
 		overlays += image('icons/obj/pipes.dmi', "comp-o1", FLY_LAYER)
 	 //TODO: DEFERRED
 
-/obj/machinery/power/turbine/Initialize()
+/obj/machinery/turbine/Initialize()
 	..()
 	outturf = get_step(src, dir)
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/machinery/power/turbine/LateInitialize()
+/obj/machinery/turbine/LateInitialize()
 	..()
 	if(!compressor) // It should have found us and subscribed.
 		set_broken(TRUE)
 
-/obj/machinery/power/turbine/Destroy()
+/obj/machinery/turbine/Destroy()
 	if(compressor)
 		compressor.turbine = null
 		compressor.set_broken(TRUE)
@@ -124,7 +124,7 @@
 #define TURBGENQ 20000
 #define TURBGENG 0.8
 
-/obj/machinery/power/turbine/Process()
+/obj/machinery/turbine/Process()
 	if(!compressor.starter)
 		return
 	overlays.Cut()
@@ -132,7 +132,7 @@
 		return
 	lastgen = ((compressor.rpm / TURBGENQ)**TURBGENG) *TURBGENQ
 
-	add_avail(lastgen)
+	generate_power(lastgen)
 	var/newrpm = ((compressor.gas_contained.temperature) * compressor.gas_contained.total_moles)/4
 	newrpm = max(0, newrpm)
 
@@ -153,7 +153,7 @@
 			src.interact(M)
 	AutoUpdateAI(src)
 
-/obj/machinery/power/turbine/interact(mob/user)
+/obj/machinery/turbine/interact(mob/user)
 
 	if ( (get_dist(src, user) > 1 ) || (stat & (NOPOWER|BROKEN)) && (!istype(user, /mob/living/silicon/ai)) )
 		user.machine = null
@@ -178,12 +178,12 @@
 
 	return
 
-/obj/machinery/power/turbine/CanUseTopic(var/mob/user, href_list)
+/obj/machinery/turbine/CanUseTopic(var/mob/user, href_list)
 	if(!user.check_dexterity(DEXTERITY_KEYBOARDS))
 		return min(..(), STATUS_UPDATE)
 	return ..()
 
-/obj/machinery/power/turbine/OnTopic(user, href_list)
+/obj/machinery/turbine/OnTopic(user, href_list)
 	if(href_list["close"])
 		close_browser(usr, "window=turbine")
 		return TOPIC_HANDLED

--- a/code/modules/random_map/drop/drop_types.dm
+++ b/code/modules/random_map/drop/drop_types.dm
@@ -188,9 +188,9 @@ var/global/list/datum/supply_drop_loot/supply_drop
 /datum/supply_drop_loot/power/New()
 	..()
 	contents = list(
-		/obj/machinery/power/port_gen/pacman,
-		/obj/machinery/power/port_gen/pacman/super,
-		/obj/machinery/power/port_gen/pacman/mrs)
+		/obj/machinery/port_gen/pacman,
+		/obj/machinery/port_gen/pacman/super,
+		/obj/machinery/port_gen/pacman/mrs)
 
 /datum/supply_drop_loot/power/contents()
 	return list(pick(contents))

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -9,7 +9,7 @@
 	density = 1
 	invisibility = 0
 	atmos_canpass = CANPASS_PROC
-	var/obj/machinery/power/shield_generator/gen = null
+	var/obj/machinery/shield_generator/gen = null
 	var/disabled_for = 0
 	var/diffused_for = 0
 
@@ -267,34 +267,34 @@
 		explosion_resistance = 0
 
 // Shield collision checks below
-/atom/movable/proc/can_pass_shield(var/obj/machinery/power/shield_generator/gen)
+/atom/movable/proc/can_pass_shield(var/obj/machinery/shield_generator/gen)
 	return 1
 
 // Other mobs
-/mob/living/can_pass_shield(var/obj/machinery/power/shield_generator/gen)
+/mob/living/can_pass_shield(var/obj/machinery/shield_generator/gen)
 	return !gen.check_flag(MODEFLAG_NONHUMANS)
 
 // Human mobs
-/mob/living/carbon/human/can_pass_shield(var/obj/machinery/power/shield_generator/gen)
+/mob/living/carbon/human/can_pass_shield(var/obj/machinery/shield_generator/gen)
 	if(isSynthetic())
 		return !gen.check_flag(MODEFLAG_ANORGANIC)
 	return !gen.check_flag(MODEFLAG_HUMANOIDS)
 
 // Silicon mobs
-/mob/living/silicon/can_pass_shield(var/obj/machinery/power/shield_generator/gen)
+/mob/living/silicon/can_pass_shield(var/obj/machinery/shield_generator/gen)
 	return !gen.check_flag(MODEFLAG_ANORGANIC)
 
 
 // Generic objects. Also applies to bullets and meteors.
-/obj/can_pass_shield(var/obj/machinery/power/shield_generator/gen)
+/obj/can_pass_shield(var/obj/machinery/shield_generator/gen)
 	return !gen.check_flag(MODEFLAG_HYPERKINETIC)
 
 // Beams
-/obj/item/projectile/beam/can_pass_shield(var/obj/machinery/power/shield_generator/gen)
+/obj/item/projectile/beam/can_pass_shield(var/obj/machinery/shield_generator/gen)
 	return !gen.check_flag(MODEFLAG_PHOTONIC)
 
 // Beams
-/obj/item/projectile/ship_munition/energy/can_pass_shield(var/obj/machinery/power/shield_generator/gen)
+/obj/item/projectile/ship_munition/energy/can_pass_shield(var/obj/machinery/shield_generator/gen)
 	return !gen.check_flag(MODEFLAG_PHOTONIC)
 
 // Shield on-impact logic here. This is called only if the object is actually blocked by the field (can_pass_shield applies first)

--- a/maps/antag_spawn/ert/ert_base.dmm
+++ b/maps/antag_spawn/ert/ert_base.dmm
@@ -2101,7 +2101,7 @@
 	},
 /area/map_template/rescue_base/base)
 "eu" = (
-/obj/machinery/power/emitter,
+/obj/machinery/emitter,
 /turf/unsimulated/floor{
 	dir = 1;
 	icon_state = "vault"

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -1588,7 +1588,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/merc_shuttle/rear)
 "cS" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/port_gen/pacman,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -2044,7 +2044,7 @@
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
 "nN" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/port_gen/pacman,
 /obj/structure/railing/mapped/no_density{
 	dir = 4
 	},
@@ -2166,7 +2166,7 @@
 /turf/simulated/floor/tiled/airless,
 /area/space)
 "uG" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/port_gen/pacman,
 /obj/structure/railing/mapped/no_density{
 	dir = 4
 	},
@@ -2599,7 +2599,7 @@
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
 "PK" = (
-/obj/machinery/power/port_gen/pacman/super,
+/obj/machinery/port_gen/pacman/super,
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
 "PZ" = (
@@ -2684,7 +2684,7 @@
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
 "Tu" = (
-/obj/machinery/power/port_gen/pacman/super,
+/obj/machinery/port_gen/pacman/super,
 /obj/structure/railing/mapped/no_density,
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -4392,7 +4392,7 @@
 /turf/simulated/floor/tiled/usedup,
 /area/ship/scrap/maintenance/power)
 "in" = (
-/obj/machinery/power/shield_generator,
+/obj/machinery/shield_generator,
 /obj/structure/cable{
 	icon_state = "0-2";
 	pixel_y = 1
@@ -5377,7 +5377,7 @@
 /obj/structure/cable{
 	icon_state = "0-6"
 	},
-/obj/machinery/power/port_gen/pacman/super,
+/obj/machinery/port_gen/pacman/super,
 /turf/simulated/floor/usedup,
 /area/ship/scrap/hidden)
 "Qe" = (

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -1393,7 +1393,7 @@
 /obj/structure/cable/blue{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/port_gen/pacman,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/constructionsite/teleporter)
@@ -1461,7 +1461,7 @@
 /area/constructionsite/teleporter)
 "eW" = (
 /obj/structure/cable/blue,
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/port_gen/pacman,
 /obj/machinery/power/terminal,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
@@ -2959,7 +2959,7 @@
 /turf/simulated/floor/airless,
 /area/constructionsite)
 "kr" = (
-/obj/machinery/power/shield_generator{
+/obj/machinery/shield_generator{
 	desc = "A heavy-duty shield generator and capacitor, capable of generating energy shields at large distances. This one seems to be in a state of disrepair.";
 	name = "disused shield generator"
 	},
@@ -3128,7 +3128,7 @@
 /turf/simulated/floor/airless,
 /area/constructionsite/engineering)
 "le" = (
-/obj/machinery/power/rad_collector,
+/obj/machinery/rad_collector,
 /turf/simulated/floor/airless,
 /area/constructionsite/engineering)
 "lf" = (
@@ -3379,7 +3379,7 @@
 /turf/simulated/floor/airless,
 /area/AIsattele)
 "lZ" = (
-/obj/machinery/power/emitter{
+/obj/machinery/emitter{
 	anchored = 1;
 	dir = 4;
 	state = 2
@@ -3391,7 +3391,7 @@
 /turf/simulated/floor/airless,
 /area/constructionsite/engineering)
 "mb" = (
-/obj/machinery/power/emitter{
+/obj/machinery/emitter{
 	anchored = 1;
 	dir = 8;
 	state = 2

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -1853,7 +1853,7 @@
 /turf/simulated/floor/plating,
 /area/errant_pisces/smes_room)
 "eQ" = (
-/obj/machinery/power/port_gen/pacman/mrs,
+/obj/machinery/port_gen/pacman/mrs,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -1982,7 +1982,7 @@
 /turf/simulated/floor/plating,
 /area/errant_pisces/smes_room)
 "ff" = (
-/obj/machinery/power/port_gen/pacman/mrs,
+/obj/machinery/port_gen/pacman/mrs,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -2137,7 +2137,7 @@
 /turf/simulated/floor/plating,
 /area/errant_pisces/smes_room)
 "fx" = (
-/obj/machinery/power/port_gen/pacman/mrs,
+/obj/machinery/port_gen/pacman/mrs,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -4878,7 +4878,7 @@
 /turf/simulated/wall/r_wall,
 /area/errant_pisces/aux_power)
 "nl" = (
-/obj/machinery/power/port_gen/pacman/mrs,
+/obj/machinery/port_gen/pacman/mrs,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -5183,7 +5183,7 @@
 /turf/simulated/floor/plating,
 /area/errant_pisces/aft_hallway)
 "nK" = (
-/obj/machinery/power/port_gen/pacman/mrs,
+/obj/machinery/port_gen/pacman/mrs,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},

--- a/maps/away/liberia/liberia.dmm
+++ b/maps/away/liberia/liberia.dmm
@@ -215,7 +215,7 @@
 /turf/simulated/floor,
 /area/liberia/engineeringreactor)
 "aA" = (
-/obj/machinery/power/port_gen/pacman/super/potato,
+/obj/machinery/port_gen/pacman/super/potato,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -376,7 +376,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/merchantstorage)
 "aR" = (
-/obj/machinery/power/shield_generator,
+/obj/machinery/shield_generator,
 /obj/structure/cable,
 /obj/structure/cable/blue{
 	icon_state = "1-2"
@@ -4912,7 +4912,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/power/port_gen/pacman/mrs,
+/obj/machinery/port_gen/pacman/mrs,
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/structure/cable/blue{
 	icon_state = "0-4"

--- a/maps/away/magshield/magshield.dmm
+++ b/maps/away/magshield/magshield.dmm
@@ -773,7 +773,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/generator{
+/obj/machinery/generator{
 	anchored = 1
 	},
 /turf/simulated/floor/plating,
@@ -1384,7 +1384,7 @@
 /turf/simulated/floor/airless,
 /area/magshield/north)
 "ea" = (
-/obj/machinery/power/port_gen/pacman/mrs,
+/obj/machinery/port_gen/pacman/mrs,
 /turf/simulated/floor/airless,
 /area/magshield/north)
 "eb" = (

--- a/maps/away/slavers/slavers_base.dmm
+++ b/maps/away/slavers/slavers_base.dmm
@@ -2993,14 +2993,14 @@
 /turf/simulated/floor/airless/ceiling,
 /area/slavers_base/powatm)
 "iq" = (
-/obj/machinery/power/port_gen/pacman/super,
+/obj/machinery/port_gen/pacman/super,
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/airless/ceiling,
 /area/slavers_base/powatm)
 "ir" = (
-/obj/machinery/power/port_gen/pacman/super,
+/obj/machinery/port_gen/pacman/super,
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
@@ -3010,7 +3010,7 @@
 /turf/simulated/floor/airless/ceiling,
 /area/slavers_base/powatm)
 "is" = (
-/obj/machinery/power/port_gen/pacman/super,
+/obj/machinery/port_gen/pacman/super,
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},

--- a/maps/away/smugglers/smugglers.dmm
+++ b/maps/away/smugglers/smugglers.dmm
@@ -157,7 +157,7 @@
 /turf/simulated/floor,
 /area/smugglers/base)
 "az" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/port_gen/pacman,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},

--- a/maps/away/unishi/unishi-1.dmm
+++ b/maps/away/unishi/unishi-1.dmm
@@ -9,7 +9,7 @@
 /turf/simulated/wall,
 /area/space)
 "ad" = (
-/obj/machinery/power/port_gen/pacman/super/potato,
+/obj/machinery/port_gen/pacman/super/potato,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -52,7 +52,7 @@
 /turf/simulated/wall,
 /area/unishi/engineering)
 "aj" = (
-/obj/machinery/power/port_gen/pacman/super/potato,
+/obj/machinery/port_gen/pacman/super/potato,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},

--- a/maps/away/unishi/unishi-2.dmm
+++ b/maps/away/unishi/unishi-2.dmm
@@ -2450,13 +2450,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/unishi/smresearch)
 "gF" = (
-/obj/machinery/power/emitter/anchored/on,
+/obj/machinery/emitter/anchored/on,
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/terminal,
 /obj/machinery/atmospherics/binary/pump/high_power,
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor,

--- a/maps/away/unishi/unishi.dm
+++ b/maps/away/unishi/unishi.dm
@@ -77,7 +77,7 @@
 	oxygen_release_modifier = 100000000000
 	radiation_release_modifier = 1
 
-/obj/machinery/power/emitter/anchored/on
+/obj/machinery/emitter/anchored/on
 	active = 1
 	powered = 1
 

--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -46572,7 +46572,7 @@
 /turf/simulated/floor/tiled/white,
 /area/exodus/medical/medbay)
 "bSp" = (
-/obj/machinery/power/port_gen/pacman{
+/obj/machinery/port_gen/pacman{
 	sheets = 25
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -57522,7 +57522,7 @@
 /turf/simulated/floor/airless,
 /area/exodus/solar/starboard)
 "cpn" = (
-/obj/machinery/power/rad_collector,
+/obj/machinery/rad_collector,
 /turf/simulated/floor/plating,
 /area/exodus/engineering/storage)
 "cpo" = (
@@ -59423,7 +59423,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/exodus/engineering/storage)
 "cuB" = (
-/obj/machinery/power/emitter,
+/obj/machinery/emitter,
 /turf/simulated/floor/plating,
 /area/exodus/engineering/storage)
 "cuC" = (
@@ -59510,7 +59510,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/generator{
+/obj/machinery/generator{
 	anchored = 1;
 	dir = 4
 	},
@@ -62224,12 +62224,15 @@
 /turf/simulated/floor/plating,
 /area/exodus/engineering/engine_room)
 "cIa" = (
-/obj/machinery/power/emitter{
+/obj/machinery/emitter{
 	anchored = 1;
 	id_tag = "EngineEmitter";
 	state = 2
 	},
 /obj/structure/cable/cyan,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/exodus/engineering/engine_room)
 "cIb" = (
@@ -62756,7 +62759,7 @@
 /turf/simulated/floor/plating,
 /area/exodus/maintenance/engi_engine)
 "cJZ" = (
-/obj/machinery/power/generator{
+/obj/machinery/generator{
 	anchored = 1;
 	dir = 4
 	},
@@ -63996,7 +63999,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
 "jko" = (
-/obj/machinery/power/rad_collector,
+/obj/machinery/rad_collector,
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
@@ -64310,7 +64313,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/research/chargebay)
 "ohn" = (
-/obj/machinery/power/emitter,
+/obj/machinery/emitter,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},

--- a/maps/ministation/ministation.dmm
+++ b/maps/ministation/ministation.dmm
@@ -11786,7 +11786,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/engine)
 "FJ" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/port_gen/pacman,
 /turf/simulated/floor/tiled,
 /area/ministation/engine)
 "FK" = (
@@ -13853,7 +13853,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/ai_sat)
 "LG" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/port_gen/pacman,
 /obj/structure/cable,
 /turf/simulated/floor/tiled,
 /area/ministation/ai_sat)

--- a/maps/nexus/nexus-1.dmm
+++ b/maps/nexus/nexus-1.dmm
@@ -778,7 +778,7 @@
 /obj/structure/window/borosilicate_reinforced{
 	dir = 1
 	},
-/obj/machinery/power/emitter/gyrotron/anchored{
+/obj/machinery/emitter/gyrotron/anchored{
 	dir = 1;
 	initial_id_tag = "main"
 	},
@@ -789,6 +789,7 @@
 	icon_state = "0-8"
 	},
 /obj/structure/catwalk,
+/obj/machinery/power/terminal,
 /turf/simulated/floor/plating,
 /area/nexus/engineering/engine)
 "hn" = (
@@ -2606,7 +2607,7 @@
 /turf/simulated/floor/tiled,
 /area/nexus/hallway/starboard/aft)
 "yE" = (
-/obj/machinery/power/port_gen/pacman/super,
+/obj/machinery/port_gen/pacman/super,
 /obj/structure/cable,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -3780,7 +3781,7 @@
 /turf/simulated/floor/tiled/white,
 /area/nexus/civilian)
 "JR" = (
-/obj/machinery/power/fusion_core/mapped{
+/obj/machinery/fusion_core/mapped{
 	initial_id_tag = "main"
 	},
 /obj/structure/cable{

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -971,7 +971,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/power/port_gen/pacman/super,
+/obj/machinery/port_gen/pacman/super,
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)

--- a/maps/random_ruins/exoplanet_ruins/lodge/lodge.dmm
+++ b/maps/random_ruins/exoplanet_ruins/lodge/lodge.dmm
@@ -6,7 +6,7 @@
 /turf/simulated/wall/wood,
 /area/template_noop)
 "c" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/port_gen/pacman,
 /turf/simulated/floor/wood,
 /area/template_noop)
 "d" = (

--- a/maps/random_ruins/exoplanet_ruins/marooned/marooned.dmm
+++ b/maps/random_ruins/exoplanet_ruins/marooned/marooned.dmm
@@ -216,7 +216,7 @@
 "aI" = (
 /obj/item/wirecutters,
 /obj/item/stack/cable_coil,
-/obj/machinery/power/port_gen/pacman/super,
+/obj/machinery/port_gen/pacman/super,
 /obj/structure/cable{
 	dir = 8;
 	icon_state = "0-5"

--- a/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
@@ -450,7 +450,7 @@
 /turf/simulated/floor/plating,
 /area/map_template/oldpod)
 "bc" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/port_gen/pacman,
 /obj/structure/cable/cyan,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -886,7 +886,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/power/port_gen/pacman/mrs,
+/obj/machinery/port_gen/pacman/mrs,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/colony/engineering)
 "cb" = (
@@ -922,7 +922,7 @@
 "cf" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/emitter/gyrotron,
+/obj/machinery/emitter/gyrotron,
 /turf/exterior/concrete,
 /area/template_noop)
 "cg" = (
@@ -1411,7 +1411,7 @@
 /area/template_noop)
 "dn" = (
 /obj/structure/catwalk,
-/obj/machinery/power/rad_collector,
+/obj/machinery/rad_collector,
 /obj/effect/decal/cleanable/dirt,
 /turf/exterior/concrete,
 /area/template_noop)

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -1056,7 +1056,7 @@
 /area/ship/trade/shuttle/outgoing)
 "cI" = (
 /obj/structure/cable,
-/obj/machinery/power/port_gen/pacman/super,
+/obj/machinery/port_gen/pacman/super,
 /turf/simulated/floor/plating,
 /area/ship/trade/shuttle/outgoing)
 "cL" = (
@@ -3528,7 +3528,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/trade/maintenance/power)
 "iU" = (
-/obj/machinery/power/shield_generator,
+/obj/machinery/shield_generator,
 /obj/structure/cable{
 	icon_state = "0-2";
 	pixel_y = 1
@@ -4035,7 +4035,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/fusion_core/mapped{
+/obj/machinery/fusion_core/mapped{
 	initial_id_tag = "main_drive"
 	},
 /turf/simulated/floor/reinforced/airless,
@@ -4059,7 +4059,7 @@
 "kc" = (
 /obj/structure/cable,
 /obj/machinery/light,
-/obj/machinery/power/port_gen/pacman/super,
+/obj/machinery/port_gen/pacman/super,
 /obj/item/wrench,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/trade/maintenance/power)
@@ -5889,7 +5889,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/port_gen/pacman/super,
+/obj/machinery/port_gen/pacman/super,
 /turf/simulated/floor/plating,
 /area/ship/trade/shieldbay)
 "IM" = (
@@ -6140,7 +6140,7 @@
 /turf/simulated/floor/plating,
 /area/ship/trade/crew/hallway/starboard)
 "Lm" = (
-/obj/machinery/power/shield_generator,
+/obj/machinery/shield_generator,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -6366,12 +6366,13 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel,
 /obj/structure/window/borosilicate_reinforced,
-/obj/machinery/power/emitter/gyrotron/anchored{
+/obj/machinery/emitter/gyrotron/anchored{
 	initial_id_tag = "main_drive"
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/terminal,
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/engine/aft)
 "OP" = (

--- a/mods/content/corporate/away_sites/lar_maria/lar_maria-1.dmm
+++ b/mods/content/corporate/away_sites/lar_maria/lar_maria-1.dmm
@@ -2576,7 +2576,7 @@
 /turf/simulated/floor/plating,
 /area/lar_maria/sec_wing)
 "gJ" = (
-/obj/machinery/power/port_gen/pacman/mrs,
+/obj/machinery/port_gen/pacman/mrs,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},

--- a/mods/content/corporate/away_sites/lar_maria/lar_maria-2.dmm
+++ b/mods/content/corporate/away_sites/lar_maria/lar_maria-2.dmm
@@ -108,7 +108,7 @@
 /turf/simulated/floor/reinforced,
 /area/space)
 "au" = (
-/obj/machinery/power/port_gen/pacman/super,
+/obj/machinery/port_gen/pacman/super,
 /turf/simulated/floor/plating,
 /area/lar_maria/solar_control)
 "av" = (


### PR DESCRIPTION
## Description of changes
Attempts to kill the /obj/machinery/power subtype and nearly succeeds. Now all machinery that uses the power subtype are those which require a direct reference to the powernet. Every other feature of the power subtype have been moved to base machinery
* Power generation procs have been moved to the base machinery type. Generating power adds available power to a cable node beneath the machine, and does not use the terminal stock part.
* All machinery which used to draw power directly from a cable node beneath it now use terminals. Machinery which will theoretically always be mapped over a power node (shield generations, FTL shunts) will create a terminal using the terminal_setup stock part preset. Other machinery such as emitters use the terminal_connect stock part preset, which will only connect to a terminal which it has been mapped on top of.

## Why and what will this PR improve
The power subtype is current a mix of objects actually related to power generation and management, and machinery which just draws power from the net directly. Bringing this machinery in line with other machines which use the terminal stock part for  drawing power from the powernet improves clarity.

These changes also allow for more flexibility in power generation. For example, currently atmospheric machinery cannot generate power, which is something I plan to use for Stirling engines in the near future.

## Authorship
Myself

## Changelog
:cl:
tweak: Machinery which previously connected to cables directly for power now require terminals, which can be added by attacking the machine with a stack of cables.
/:cl: