### PR TITLE
Made material doors less loud

### DIFF
--- a/code/game/objects/structures/doors/_door.dm
+++ b/code/game/objects/structures/doors/_door.dm
@@ -1,3 +1,4 @@
+#define MATERIAL_DOOR_SOUND_VOLUME 25
 /obj/structure/door
 	name = "door"
 	icon = 'icons/obj/doors/material_doors.dmi'
@@ -59,7 +60,7 @@
 	if(!can_close())
 		return FALSE
 	flick("[icon_base]closing", src)
-	playsound(src.loc, material.dooropen_noise, 100, 1)
+	playsound(src.loc, material.doorclose_noise, MATERIAL_DOOR_SOUND_VOLUME, 1)
 
 	changing_state = TRUE
 	sleep(1 SECOND)
@@ -73,7 +74,7 @@
 	if(!can_open())
 		return FALSE
 	flick("[icon_base]opening", src)
-	playsound(src.loc, material.dooropen_noise, 100, 1)
+	playsound(src.loc, material.dooropen_noise, MATERIAL_DOOR_SOUND_VOLUME, 1)
 
 	changing_state = TRUE
 	sleep(1 SECOND)
@@ -211,3 +212,4 @@
 
 /obj/structure/door/shuttle
 	material = /decl/material/solid/metal/steel
+#undef MATERIAL_DOOR_SOUND_VOLUME 

--- a/code/game/objects/structures/doors/_door.dm
+++ b/code/game/objects/structures/doors/_door.dm
@@ -60,7 +60,7 @@
 	if(!can_close())
 		return FALSE
 	flick("[icon_base]closing", src)
-	playsound(src.loc, material.doorclose_noise, MATERIAL_DOOR_SOUND_VOLUME, 1)
+	playsound(src.loc, material.dooropen_noise, MATERIAL_DOOR_SOUND_VOLUME, 1)
 
 	changing_state = TRUE
 	sleep(1 SECOND)


### PR DESCRIPTION
Material doors can get really loud and obnoxious, since their volume is all the way up to 100. Reduced it to a quarter of that.

<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Just makes material doors more tolerable by reducing their open/close sound volume from 100 to 25.

## Why and what will this PR improve
If you ever do the mistake of building material doors in your office, you'll probably be really happy about not hearing the loud ass creaking or rock door sliding noise constantly blasting at max volume.

## Changelog

:cl:
tweak: Made material doors less loud.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
