### PR TITLE
Fix examine returning that some machines not using power were unpowered

### DIFF
--- a/code/game/machinery/CableLayer.dm
+++ b/code/game/machinery/CableLayer.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/obj/machines/pipe_dispenser.dmi'
 	icon_state = "pipe_d"
 	density = 1
+	interact_offline = TRUE
 	var/obj/structure/cable/last_piece
 	var/obj/item/stack/cable_coil/cable
 	var/max_cable = 100

--- a/code/game/machinery/floorlayer.dm
+++ b/code/game/machinery/floorlayer.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/machines/pipe_dispenser.dmi'
 	icon_state = "pipe_d"
 	density = 1
+	interact_offline = TRUE
 	var/turf/old_turf
 	var/on = 0
 	var/obj/item/stack/tile/T

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -11,7 +11,7 @@
 	desc = "A one-way air valve that can be used to regulate input or output pressure, and flow rate. Does not require power."
 
 	use_power = POWER_USE_OFF
-	interact_offline = 1
+	interact_offline = TRUE
 	var/unlocked = 0	//If 0, then the valve is locked closed, otherwise it is open(-able, it's a one-way valve so it closes if gas would flow backwards).
 	var/target_pressure = ONE_ATMOSPHERE
 	var/max_pressure_setting = MAX_PUMP_PRESSURE

--- a/code/modules/atmospherics/components/portables_connector.dm
+++ b/code/modules/atmospherics/components/portables_connector.dm
@@ -11,6 +11,7 @@
 	var/obj/machinery/portable_atmospherics/connected_device
 	var/on = 0
 	use_power = POWER_USE_OFF
+	interact_offline = TRUE
 
 	uncreated_component_parts = null
 	frame_type = /obj/item/pipe

--- a/code/modules/atmospherics/components/tvalve.dm
+++ b/code/modules/atmospherics/components/tvalve.dm
@@ -25,6 +25,7 @@
 	frame_type = /obj/item/pipe
 	construct_state = /decl/machine_construction/default/panel_closed/item_chassis
 	base_type = /obj/machinery/atmospherics/tvalve/buildable
+	interact_offline = TRUE
 
 /obj/machinery/atmospherics/tvalve/buildable
 	uncreated_component_parts = null

--- a/code/modules/atmospherics/components/unary/heat_exchanger.dm
+++ b/code/modules/atmospherics/components/unary/heat_exchanger.dm
@@ -16,6 +16,7 @@
 	frame_type = /obj/item/pipe
 	uncreated_component_parts = null
 	construct_state = /decl/machine_construction/pipe
+	interact_offline = TRUE
 
 /obj/machinery/atmospherics/unary/heat_exchanger/Destroy()
 	if(partner)

--- a/code/modules/atmospherics/components/unary/thermal_plate.dm
+++ b/code/modules/atmospherics/components/unary/thermal_plate.dm
@@ -13,6 +13,7 @@
 	uncreated_component_parts = null
 	frame_type = /obj/item/pipe
 	construct_state = /decl/machine_construction/pipe
+	interact_offline = TRUE
 
 /obj/machinery/atmospherics/unary/thermal_plate/on_update_icon()
 	if(LAZYLEN(nodes_to_networks))

--- a/code/modules/atmospherics/components/valve.dm
+++ b/code/modules/atmospherics/components/valve.dm
@@ -24,6 +24,7 @@
 	frame_type = /obj/item/pipe
 	construct_state = /decl/machine_construction/default/panel_closed/item_chassis
 	base_type = /obj/machinery/atmospherics/valve/buildable
+	interact_offline = TRUE
 
 /obj/machinery/atmospherics/valve/buildable
 	uncreated_component_parts = null

--- a/code/modules/atmospherics/he_pipes.dm
+++ b/code/modules/atmospherics/he_pipes.dm
@@ -5,6 +5,7 @@
 	color = "#404040"
 	level = 2
 	connect_types = CONNECT_TYPE_HE
+	interact_offline = TRUE //Needs to be set so that pipes don't say they lack power in their description
 	var/initialize_directions_he
 	var/surface = 2	//surface area in m^2
 	var/icon_temperature = T20C //stop small changes in temperature causing an icon refresh

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -7,6 +7,7 @@
 	var/volume = 0
 	var/leaking = 0		// Do not set directly, use set_leaking(TRUE/FALSE)
 	use_power = POWER_USE_OFF
+	interact_offline = TRUE //Needs to be set so that pipes don't say they lack power in their description
 
 	//minimum pressure before check_pressure(...) should be called
 	var/maximum_pressure = 210 * ONE_ATMOSPHERE


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Examining those machines would result in the examine text mentioning that the machine was not receiving power. Even if they do not need power.
The issue was that the base machinery code for examine() is assuming things need power unless interact_offline is true. Since none of those machines have a ui its a bit weird to toggle it to true, but it keeps the message from showing up.

## Why and what will this PR improve
Make the examine description less confusing on some machines that do not need power.

## Authorship

<!-- Describe original authors of changes to credit them. -->

## Changelog

:cl:
bugfix: Made a few machines stop reporting they're not receiving power when they do not need power at all.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
