### PR TITLE
Fix the flooring definition for reinforced floor

### DIFF
--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -292,7 +292,8 @@
 	icon = 'icons/turf/flooring/tiles.dmi'
 	icon_base = "reinforced"
 	flags = TURF_REMOVE_WRENCH | TURF_ACID_IMMUNE
-	build_type = /obj/item/stack/material/rods
+	build_type = /obj/item/stack/material/sheet
+	build_material = /decl/material/solid/metal/steel
 	build_cost = 1
 	build_time = 30
 	apply_thermal_conductivity = 0.025

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -84,7 +84,10 @@
 			// Because material stack uses different arguments
 			// And we need to use build material to spawn stack
 			if(ispath(flooring.build_type, /obj/item/stack/material))
-				new flooring.build_type(src, flooring.build_cost, flooring.build_material)
+				var/decl/material/M = GET_DECL(flooring.build_material)
+				if(!M)
+					CRASH("[src] at ([x], [y], [z]) cannot create stack because it has a bad build_material path: '[flooring.build_material]'")
+				M.create_object(src, flooring.build_cost, flooring.build_type)
 			else
 				new flooring.build_type(src)
 		flooring = null


### PR DESCRIPTION

## Description of changes
Set the build_material of reinforced flooring to steel, since it was missing and preventing construction. Also changed the build_type to material/sheet since rods would also prevent building reinforced floor because of the catwalk code being hardcoded in before. 
Also while I was at it, I changed the make_plating proc to use the create_object() proc instead of calling directly the constructor for the stack/material stuff.

## Why and what will this PR improve
Makes reinforced floor buildable again.

## Changelog

:cl:
bugfix: Fix reinforced floor being impossible to build due to a bug.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
