### PR TITLE
Added fuel vaporization to fluid puddles.

### DIFF
--- a/code/game/objects/effects/fluids.dm
+++ b/code/game/objects/effects/fluids.dm
@@ -139,3 +139,25 @@
 /obj/effect/flood/Initialize()
 	. = ..()
 	verbs.Cut()
+
+/obj/effect/fluid/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	. = ..()
+	if(exposed_temperature >= FLAMMABLE_GAS_MINIMUM_BURN_TEMPERATURE)
+		vaporize_fuel(air)
+
+/obj/effect/fluid/proc/vaporize_fuel(datum/gas_mixture/air)
+	if(!length(reagents?.reagent_volumes) || !istype(air))
+		return
+	var/update_air = FALSE
+	for(var/rtype in reagents.reagent_volumes)
+		var/decl/material/mat = GET_DECL(rtype)
+		if(mat.gas_flags & XGM_GAS_FUEL)
+			var/moles = round(reagents.reagent_volumes[rtype] / REAGENT_UNITS_PER_GAS_MOLE)
+			if(moles > 0)
+				air.adjust_gas(rtype, moles, FALSE)
+				reagents.remove_reagent(round(moles * REAGENT_UNITS_PER_GAS_MOLE))
+				update_air = TRUE
+	if(update_air)
+		air.update_values()
+		return TRUE
+	return FALSE

--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -28,9 +28,14 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 		return 0
 	if(locate(/obj/fire) in src)
 		return 1
+
 	var/datum/gas_mixture/air_contents = return_air()
 	if(!air_contents || exposed_temperature < FLAMMABLE_GAS_MINIMUM_BURN_TEMPERATURE)
 		return 0
+
+	var/obj/effect/fluid/F = locate() in src
+	if(F)
+		F.vaporize_fuel(air_contents)
 
 	var/igniting = 0
 	if(air_contents.check_combustibility())
@@ -124,6 +129,12 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 	loc.fire_act(air_contents, air_contents.temperature, air_contents.volume)
 	for(var/atom/A in loc)
 		A.fire_act(air_contents, air_contents.temperature, air_contents.volume)
+
+	// prioritize nearby fuel overlays first
+	for(var/direction in global.cardinal)
+		var/turf/simulated/enemy_tile = get_step(my_tile, direction)
+		if(istype(enemy_tile) && (locate(/obj/effect/fluid) in enemy_tile))
+			enemy_tile.hotspot_expose(air_contents.temperature, air_contents.volume)
 
 	//spread
 	for(var/direction in global.cardinal)

--- a/code/modules/reagents/chems/chems_fuel.dm
+++ b/code/modules/reagents/chems/chems_fuel.dm
@@ -6,6 +6,7 @@
 	touch_met = 5
 	fuel_value = 1
 	burn_product = /decl/material/gas/carbon_monoxide
+	gas_flags = XGM_GAS_FUEL
 
 	glass_name = "welder fuel"
 	glass_desc = "Unless you are an industrial tool, this is probably not safe for consumption."


### PR DESCRIPTION
Adding some very basic fire interaction to fuel puddles, as a stopover between now and a proper fire rewrite. Essentially just causes puddles to vaporize any fuel in their reagents on exposure to sufficient heat, meaning that zone fires will start.
DNM, have not tested locally due to putting it together at work.