### PR TITLE
Added scanner-based ailment diagnosis.

### DIFF
--- a/code/_helpers/medical_scans.dm
+++ b/code/_helpers/medical_scans.dm
@@ -58,31 +58,29 @@
 			scan["reagents"] += list(reagent)
 
 	scan["external_organs"] = list()
-
 	for(var/obj/item/organ/external/E in H.organs)
-		var/list/O = list()
-		O["name"] = E.name
-		O["is_stump"] = E.is_stump()
-		O["brute_ratio"] = E.brute_ratio
-		O["burn_ratio"] = E.burn_ratio
-		O["limb_flags"] = E.limb_flags
-		O["brute_dam"] = E.brute_dam
-		O["burn_dam"] = E.burn_dam
-		O["scan_results"] = E.get_scan_results(tag)
-		O["tumors"] = E.has_growths()
-
+		var/list/O =               list()
+		O["name"] =                E.name
+		O["is_stump"] =            E.is_stump()
+		O["brute_ratio"] =         E.brute_ratio
+		O["burn_ratio"] =          E.burn_ratio
+		O["limb_flags"] =          E.limb_flags
+		O["brute_dam"] =           E.brute_dam
+		O["burn_dam"] =            E.burn_dam
+		O["scan_results"] =        E.get_scan_results(tag)
+		O["tumors"] =              E.has_growths()
+		O["ailments"] =            E.has_diagnosable_ailments(scanner = TRUE)
 		scan["external_organs"] += list(O)
 
 	scan["internal_organs"] = list()
-
 	for(var/obj/item/organ/internal/I in H.internal_organs)
-		var/list/O = list()
-		O["name"] = I.name
-		O["is_broken"] = I.is_broken()
-		O["is_bruised"] = I.is_bruised()
-		O["is_damaged"] = I.is_damaged()
-		O["scan_results"] = I.get_scan_results(tag)
-
+		var/list/O =               list()
+		O["name"] =                I.name
+		O["is_broken"] =           I.is_broken()
+		O["is_bruised"] =          I.is_bruised()
+		O["is_damaged"] =          I.is_damaged()
+		O["scan_results"] =        I.get_scan_results(tag)
+		O["ailments"] =            I.has_diagnosable_ailments(scanner = TRUE)
 		scan["internal_organs"] += list(O)
 
 	scan["missing_organs"] = list()
@@ -266,10 +264,6 @@
 		row += "<tr><td>[E["name"]]</td>"
 		if(E["is_stump"])
 			row += "<td><span class='bad'>Missing</span></td>"
-			if(skill_level >= SKILL_ADEPT)
-				row += "<td><span class='bad'>[english_list(E["scan_results"], nothing_text = "&nbsp;")]</span></td>"
-			else
-				row += "<td>&nbsp;</td>"
 		else
 			row += "<td>"
 			var/rowdata = list()
@@ -285,21 +279,25 @@
 					rowdata += "<span class='bad'>[capitalize(get_wound_severity(E["brute_ratio"], (E["limb_flags"] & ORGAN_FLAG_HEALS_OVERKILL)))] physical trauma</span>"
 				if(E["burn_dam"])
 					rowdata += "<span class='average'>[capitalize(get_wound_severity(E["burn_ratio"], (E["limb_flags"] & ORGAN_FLAG_HEALS_OVERKILL)))] burns</span>"
-			if(E["tumors"])
-				rowdata += "<span class='bad'>Abnormal internal growth</span>"
-			row += "<td>[jointext(rowdata, "<br>")]</td>"
+			rowdata += "</td><td>[jointext(rowdata, "<br>")]</td>"
 
-			if(skill_level >= SKILL_ADEPT)
-				row += "<td>"
-				row += "<span class='bad'>[english_list(E["scan_results"], nothing_text="&nbsp;")]</span>"
-				row += "</td>"
-			else
-				row += "<td>&nbsp;</td>"
+		if(skill_level >= SKILL_ADEPT)
+			var/list/status = list()
+			if(E["scan_results"])
+				status += "<span class='bad'>[english_list(E["scan_results"], nothing_text = "&nbsp;")]</span>"
+			if(E["tumors"])
+				status += "<span class='bad'>Abnormal internal growth</span>"
+			if(E["ailments"])
+				status += "[jointext(E["ailments"], "<br>")]"
+			row += "<td>[status ? jointext(status, "<br>") : "Nominal."]</td>"
+		else
+			row += "<td>&nbsp;</td>"
+
 		row += "</tr>"
 		subdat += JOINTEXT(row)
+
 	dat += subdat
 	subdat = list()
-
 
 	//Internal Organs
 	if(skill_level >= SKILL_BASIC)
@@ -315,9 +313,18 @@
 				row += "<td><span class='mild'>Minor</span></td>"
 			else
 				row += "<td>None</td>"
-			row += "<td>"
-			row += "<span class='bad'>[english_list(I["scan_results"], nothing_text="&nbsp;")]</span>"
-			row += "</td></tr>"
+
+			if(skill_level >= SKILL_ADEPT)
+				var/list/status = list()
+				if(I["scan_results"])
+					status += "<span class='bad'>[english_list(I["scan_results"], nothing_text = "&nbsp;")]</span>"
+				if(I["ailments"])
+					status += "[jointext(I["ailments"], "<br>")]"
+				row += "<td>[status ? jointext(status, "<br>") : "Nominal."]</td>"
+			else
+				row += "<td>&nbsp;</td>"
+
+			row += "</tr>"
 			subdat += jointext(row, null)
 
 	if(skill_level <= SKILL_ADEPT)

--- a/code/modules/organs/ailments/_ailment.dm
+++ b/code/modules/organs/ailments/_ailment.dm
@@ -19,11 +19,12 @@
 	var/treated_by_reagent_dosage = 1 // What is the minimum dosage for a reagent to cure this ailment?
 
 	// Fluff strings
-	var/initial_ailment_message = "Your $ORGAN$ doesn't feel quite right..."              // Shown in New()
-	var/third_person_treatement_message = "$USER$ treats $TARGET$'s ailment with $ITEM$." // Shown when treating other with an item.
-	var/self_treatement_message = "$USER$ treats $USER_HIS$ ailment with $ITEM$."         // Shown when treating self with an item.
-	var/medication_treatment_message = "Your ailment abates."                             // Shown when treated by a metabolized reagent.
-	var/diagnosis_string  /* ex: "$USER_HIS$ $ORGAN$ has something wrong with it" */      // Shown when grab-diagnosed by a doctor. Leave null to be undiagnosable.
+	var/initial_ailment_message = "Your $ORGAN$ doesn't feel quite right..."                // Shown in New()
+	var/third_person_treatement_message = "$USER$ treats $TARGET$'s ailment with $ITEM$."   // Shown when treating other with an item.
+	var/self_treatement_message = "$USER$ treats $USER_HIS$ ailment with $ITEM$."           // Shown when treating self with an item.
+	var/medication_treatment_message = "Your ailment abates."                               // Shown when treated by a metabolized reagent.
+	var/manual_diagnosis_string  /* ex: "$USER_HIS$ $ORGAN$ has something wrong with it" */ // Shown when grab-diagnosed by a doctor. Leave null to be undiagnosable.
+	var/scanner_diagnosis_string /* ex: "Significant swelling" */                           // Shown on the handheld and body scanners. Leave null to be undiagnosable.
 
 /datum/ailment/New(var/obj/item/organ/_organ)
 	..()

--- a/code/modules/organs/ailments/ailments_medical.dm
+++ b/code/modules/organs/ailments/ailments_medical.dm
@@ -29,7 +29,7 @@
 	treated_by_reagent_type = /decl/material/liquid/nutriment/honey
 	treated_by_reagent_dosage = 1
 	medication_treatment_message = "You swallow, finding that your sore throat is rapidly recovering."
-	diagnosis_string = "$USER_HIS$ throat is red and inflamed."
+	manual_diagnosis_string = "$USER_HIS$ throat is red and inflamed."
 
 /datum/ailment/head/sore_throat/on_ailment_event()
 	to_chat(organ.owner, SPAN_DANGER("You swallow painfully past your sore throat."))
@@ -39,7 +39,7 @@
 	treated_by_reagent_type = /decl/material/liquid/antiseptic
 	treated_by_reagent_dosage = 1
 	medication_treatment_message = "The itching in your sinuses fades away."
-	diagnosis_string = "$USER_HIS$ sinuses are inflamed and running."
+	manual_diagnosis_string = "$USER_HIS$ sinuses are inflamed and running."
 
 /datum/ailment/head/sneezing/can_apply_to(obj/item/organ/_organ)
 	. = ..()
@@ -57,7 +57,7 @@
 	treated_by_item_type = /obj/item/stack/medical/bruise_pack
 	third_person_treatement_message = "$USER$ wraps $TARGET$'s sprained $ORGAN$ in $ITEM$."
 	self_treatement_message = "$USER$ wraps $USER_HIS$ sprained $ORGAN$ in $ITEM$."
-	diagnosis_string = "$USER_HIS$ $ORGAN$ is visibly swollen."
+	manual_diagnosis_string = "$USER_HIS$ $ORGAN$ is visibly swollen."
 
 /datum/ailment/sprain/on_ailment_event()
 	to_chat(organ.owner, SPAN_DANGER("Your sprained [organ.name] aches distractingly."))
@@ -71,7 +71,7 @@
 	treated_by_item_type = /obj/item/stack/medical/ointment
 	third_person_treatement_message = "$USER$ salves $TARGET$'s rash-stricken $ORGAN$ with $ITEM$."
 	self_treatement_message = "$USER$ salves $USER_HIS$ rash-stricken $ORGAN$ with $ITEM$."
-	diagnosis_string = "$USER_HIS$ $ORGAN$ is covered in a bumpy red rash."
+	manual_diagnosis_string = "$USER_HIS$ $ORGAN$ is covered in a bumpy red rash."
 
 /datum/ailment/rash/on_ailment_event()
 	to_chat(organ.owner, SPAN_DANGER("A bright red rash on your [organ.name] itches distractingly."))
@@ -83,7 +83,7 @@
 	applies_to_organ = list(BP_LUNGS)
 	treated_by_reagent_type = /decl/material/liquid/antiseptic
 	medication_treatment_message = "The tickling in your throat fades away."
-	diagnosis_string = "$USER_HIS$ throat is red and inflamed."
+	manual_diagnosis_string = "$USER_HIS$ throat is red and inflamed."
 
 /datum/ailment/coughing/can_apply_to(obj/item/organ/_organ)
 	. = ..()
@@ -99,7 +99,7 @@
 	name = "sore joint"
 	treated_by_reagent_type = /decl/material/liquid/painkillers
 	medication_treatment_message = "The dull pulse of pain in your $ORGAN$ fades away."
-	diagnosis_string = "$USER_HIS$ $ORGAN$ is visibly swollen."
+	manual_diagnosis_string = "$USER_HIS$ $ORGAN$ is visibly swollen."
 
 /datum/ailment/sore_joint/on_ailment_event()
 	var/obj/item/organ/external/E = organ

--- a/code/modules/organs/ailments/faults/fault_acid_discharge.dm
+++ b/code/modules/organs/ailments/faults/fault_acid_discharge.dm
@@ -1,6 +1,6 @@
 /datum/ailment/fault/acid
 	name = "acidic discharge"
-	diagnosis_string = "$USER_HIS$ $ORGAN$ is leaking some kind of chemical."
+	manual_diagnosis_string = "$USER_HIS$ $ORGAN$ is leaking some kind of chemical."
 
 /datum/ailment/fault/acid/on_ailment_event()
 	organ.owner.custom_pain("A burning sensation spreads through your [organ.name].", 5, affecting = organ.owner)

--- a/code/modules/organs/ailments/faults/fault_elec_discharge.dm
+++ b/code/modules/organs/ailments/faults/fault_elec_discharge.dm
@@ -1,6 +1,6 @@
 /datum/ailment/fault/elec_discharge
 	name = "electrical discharge"
-	diagnosis_string = "$USER_HIS$ $ORGAN$ gives you a static shock when you touch it!"
+	manual_diagnosis_string = "$USER_HIS$ $ORGAN$ gives you a static shock when you touch it!"
 
 /datum/ailment/fault/elec_discharge/on_ailment_event()
 	organ.owner.custom_pain("Shock jolts through your [organ.name], staggering you!", 50, affecting = organ.owner)

--- a/code/modules/organs/ailments/faults/fault_leaky.dm
+++ b/code/modules/organs/ailments/faults/fault_leaky.dm
@@ -1,6 +1,6 @@
 /datum/ailment/fault/leaky
 	name = "leaky prosthetic"
-	diagnosis_string = "$USER_HIS$ $ORGAN$ is leaking some kind of chemical."
+	manual_diagnosis_string = "$USER_HIS$ $ORGAN$ is leaking some kind of chemical."
 	var/static/list/chemicals = list(
 		/decl/material/liquid/enzyme,
 		/decl/material/liquid/frostoil,

--- a/code/modules/organs/ailments/faults/fault_locking_thumbs.dm
+++ b/code/modules/organs/ailments/faults/fault_locking_thumbs.dm
@@ -1,6 +1,6 @@
 /datum/ailment/fault/locking_thumbs
 	name = "self-locking thumbs"
-	diagnosis_string = "$USER_HIS$ $ORGAN$ makes a grinding sound when you move the joints."
+	manual_diagnosis_string = "$USER_HIS$ $ORGAN$ makes a grinding sound when you move the joints."
 	applies_to_organ = list(
 		BP_L_ARM,
 		BP_L_HAND, 

--- a/code/modules/organs/ailments/faults/fault_noisemaker.dm
+++ b/code/modules/organs/ailments/faults/fault_noisemaker.dm
@@ -1,6 +1,6 @@
 /datum/ailment/fault/noisemaker
 	name = "noisemaker"
-	diagnosis_string = "$USER_HIS$ $ORGAN$ is emitting a low capacitor whine."
+	manual_diagnosis_string = "$USER_HIS$ $ORGAN$ is emitting a low capacitor whine."
 
 /datum/ailment/fault/noisemaker/on_ailment_event()
 	organ.owner.audible_message(SPAN_DANGER("[organ.owner]'s [organ.name] emits a loud, piezoelectric screal."), hearing_distance = 7)

--- a/code/modules/organs/external/diagnostics.dm
+++ b/code/modules/organs/external/diagnostics.dm
@@ -115,12 +115,10 @@
 		return
 
 	user.visible_message("<span class='notice'>[user] starts inspecting [owner]'s [name] carefully.</span>")
-
-	for(var/datum/ailment/ailment in ailments)
-		if(ailment.diagnosis_string)
-			if(!do_mob(user, owner, 5))
-				return
-			to_chat(user, SPAN_NOTICE(ailment.replace_tokens(message = ailment.diagnosis_string, user = user)))
+	for(var/ailment in has_diagnosable_ailments(user, scanner = FALSE))
+		if(!do_mob(user, owner, 5))
+			return
+		to_chat(user, SPAN_NOTICE(ailment))
 
 	if(!do_mob(user, owner, 5))
 		return

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -469,3 +469,10 @@ var/global/list/ailment_reference_cache = list()
 				LAZYREMOVE(ailments, ext_ailment)
 				return TRUE
 	return FALSE
+
+/obj/item/organ/proc/has_diagnosable_ailments(var/mob/user, var/scanner = FALSE)
+	for(var/datum/ailment/ailment in ailments)
+		if(ailment.manual_diagnosis_string && !scanner)
+			LAZYADD(., ailment.replace_tokens(message = ailment.manual_diagnosis_string, user = user))
+		else if(ailment.scanner_diagnosis_string && scanner)
+			LAZYADD(., ailment.replace_tokens(message = ailment.scanner_diagnosis_string, user = user))


### PR DESCRIPTION
TODO:
- Add to body scanner output.
- Add to health scanner output.

## Description of changes
Adds a `scanner_diagnosis_string` and associated display code to allow ailments to show up on the body scanner and health scanner output.

## Why and what will this PR improve
It will allow some ailments to be shown in the body scanner, adding variety to medical play.

## Authorship
Me and Mazian.

## Changelog

:cl:
tweak: Some ailments are now diagnosable via body scanner/hand scanner.
/:cl:
