### PR TITLE
Turned curtain types into decl

### DIFF
--- a/code/game/objects/structures/curtain_decls.dm
+++ b/code/game/objects/structures/curtain_decls.dm
@@ -1,0 +1,63 @@
+//
+// Curtain types declaration
+//
+/decl/curtain_kind
+	var/name = "curtain"
+	var/color = "white"
+	var/alpha = 255
+	var/material_key = /decl/material/solid/plastic
+
+/decl/curtain_kind/proc/make_item(var/loc)
+	var/obj/item/curtain/C = new(loc)
+	C.set_curtain_kind(src)
+	return C
+
+/decl/curtain_kind/proc/make_structure(var/loc, var/dir, var/opened = FALSE)
+	var/obj/structure/curtain/C = new(loc)
+	C.set_curtain_kind(src)
+	C.set_dir(dir)
+	C.set_opacity(opened)
+	return C
+
+//Cloth curtains
+/decl/curtain_kind/cloth
+	material_key = /decl/material/solid/cloth
+
+/decl/curtain_kind/cloth/bed
+	name = "bed curtain"
+	color = "#854636"
+
+/decl/curtain_kind/cloth/black
+	name = "black curtain"
+	color = "#222222"
+
+/decl/curtain_kind/cloth/bar
+	name = "bar curtain"
+	color = "#854636"
+
+//Plastic curtains
+/decl/curtain_kind/plastic
+	name = "plastic curtain"
+	color = "#b8f5e3"
+	material_key = /decl/material/solid/plastic
+
+/decl/curtain_kind/plastic/medical
+	alpha = 200
+
+/decl/curtain_kind/plastic/privacy
+	name = "privacy curtain"
+
+/decl/curtain_kind/plastic/shower
+	name = "shower curtain"
+	color = "#acd1e9"
+	alpha = 200
+
+/decl/curtain_kind/plastic/shower/engineering
+	color = "#ffa500"
+
+/decl/curtain_kind/plastic/shower/security
+	color = "#aa0000"
+
+/decl/curtain_kind/plastic/canteen
+	name = "privacy curtain"
+	color = COLOR_BLUE_GRAY

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -1,3 +1,71 @@
+//
+// Curtain types declaration
+//
+/decl/curtain_kind
+	var/name = "curtain"
+	var/color = "white"
+	var/alpha = 255
+	var/material_key = /decl/material/solid/plastic
+
+/decl/curtain_kind/proc/make_item(var/loc)
+	var/obj/item/curtain/C = new(loc, material_key, src)
+	C.alpha = alpha
+	C.set_color(color)
+	C.SetName("rolled [name]")
+	return C
+
+/decl/curtain_kind/proc/make_structure(var/loc, var/dir, var/opened = FALSE)
+	var/obj/structure/curtain/C = new(loc, dir, material_key, null, src)
+	C.alpha = alpha
+	C.set_color(color)
+	C.SetName(name)
+	C.set_opacity(opened)
+	return C
+
+//Cloth curtains
+/decl/curtain_kind/cloth
+	material_key = /decl/material/solid/cloth
+
+/decl/curtain_kind/cloth/bed
+	name = "bed curtain"
+	color = "#854636"
+
+/decl/curtain_kind/cloth/black
+	name = "black curtain"
+	color = "#222222"
+
+/decl/curtain_kind/cloth/bar
+	name = "bar curtain"
+	color = "#854636"
+
+//Plastic curtains
+/decl/curtain_kind/plastic
+	name = "plastic curtain"
+	color = "#b8f5e3"
+	material_key = /decl/material/solid/plastic
+
+/decl/curtain_kind/plastic/medical
+	alpha = 200
+
+/decl/curtain_kind/plastic/privacy
+	name = "privacy curtain"
+
+/decl/curtain_kind/plastic/shower
+	name = "shower curtain"
+	color = "#acd1e9"
+	alpha = 200
+
+/decl/curtain_kind/plastic/shower/engineering
+	color = "#ffa500"
+
+/decl/curtain_kind/plastic/shower/security
+	color = "#aa0000"
+
+/decl/curtain_kind/plastic/canteen
+	name = "privacy curtain"
+	color = COLOR_BLUE_GRAY
+
+
 /obj/item/curtain
 	name = "rolled curtain"
 	desc = "A rolled curtains."
@@ -6,11 +74,44 @@
 	force = 3 //just plastic
 	w_class = ITEM_SIZE_HUGE //curtains, yeap
 
-	var/obj/structure/curtain/holder = /obj/structure/curtain
+	var/curtain_kind_path = /decl/curtain_kind //path to decl containing the curtain's details
+
+/obj/item/curtain/bed
+	curtain_kind_path = /decl/curtain_kind/cloth/bed
+/obj/item/curtain/black
+	curtain_kind_path = /decl/curtain_kind/cloth/black
+/obj/item/curtain/bar
+	curtain_kind_path = /decl/curtain_kind/cloth/bar
+/obj/item/curtain/medical
+	curtain_kind_path = /decl/curtain_kind/plastic/medical
+/obj/item/curtain/privacy
+	curtain_kind_path = /decl/curtain_kind/plastic/privacy
+/obj/item/curtain/shower
+	curtain_kind_path = /decl/curtain_kind/plastic/shower
+/obj/item/curtain/shower/engineering
+	curtain_kind_path = /decl/curtain_kind/plastic/shower/engineering
+/obj/item/curtain/shower/security
+	curtain_kind_path = /decl/curtain_kind/plastic/shower/security
+/obj/item/curtain/canteen
+	curtain_kind_path = /decl/curtain_kind/plastic/canteen
+
+/obj/item/curtain/Initialize(ml, material_key, var/decl/curtain_kind/kind = null)
+	if(kind)
+		if(istype(kind))
+			curtain_kind_path = kind.type
+		else if(ispath(kind))
+			curtain_kind_path = kind
+	else
+		kind = GET_DECL(curtain_kind_path)
+	src.alpha = kind.alpha
+	src.set_color(kind.color)
+	src.SetName(kind.name)
+	material_key = kind.material_key
+	. = ..()
 
 /obj/item/curtain/attackby(obj/item/W, mob/user)
 	if(isScrewdriver(W))
-		if(!holder)
+		if(!curtain_kind_path)
 			return
 
 		if(!isturf(loc))
@@ -32,10 +133,9 @@
 		if(QDELETED(src))
 			return
 
-		var/obj/structure/curtain/C = new holder(loc)
+		var/decl/curtain_kind/kind = GET_DECL(curtain_kind_path)
+		var/obj/structure/curtain/C = kind.make_structure(loc, dir)
 		transfer_fingerprints_to(C)
-		C.SetName(replacetext(name, "rolled", ""))
-		C.color = color
 		qdel(src)
 	else
 		..()
@@ -48,16 +148,26 @@
 	opacity = TRUE
 	density = FALSE
 	anchored = TRUE
-
-	var/obj/item/curtain/holder = /obj/item/curtain
+	var/curtain_kind_path = /decl/curtain_kind
 
 /obj/structure/curtain/open
 	icon_state = "open"
 	layer = ABOVE_HUMAN_LAYER
 	opacity = FALSE
 
-/obj/structure/curtain/Initialize()
+/obj/structure/curtain/Initialize(ml, _mat, _reinf_mat, var/decl/curtain_kind/kind = null)
+	if(kind)
+		if(istype(kind))
+			curtain_kind_path = kind.type
+		else if(ispath(kind))
+			curtain_kind_path = kind
+	else
+		kind = GET_DECL(curtain_kind_path)
+	_mat = kind.material_key
 	. = ..()
+	src.SetName(kind.name)
+	src.alpha = kind.alpha
+	src.set_color(kind.color)
 	set_extension(src, /datum/extension/turf_hand)
 
 /obj/structure/curtain/bullet_act(obj/item/projectile/P, def_zone)
@@ -73,7 +183,7 @@
 
 /obj/structure/curtain/attackby(obj/item/W, mob/user)
 	if(isScrewdriver(W))
-		if(!holder)
+		if(!curtain_kind_path)
 			return
 
 		user.visible_message(
@@ -87,10 +197,9 @@
 		if(QDELETED(src))
 			return
 
-		var/obj/item/curtain/C = new holder(loc)
+		var/decl/curtain_kind/kind = GET_DECL(curtain_kind_path)
+		var/obj/item/curtain/C = kind.make_item(loc)
 		transfer_fingerprints_to(C)
-		C.SetName("rolled [name]")
-		C.color = color
 		qdel(src)
 	else
 		..()
@@ -111,68 +220,36 @@
 
 // Normal subtypes
 /obj/structure/curtain/bed
-	name = "bed curtain"
-	color = "#854636"
-
+	curtain_kind_path = /decl/curtain_kind/cloth/bed
 /obj/structure/curtain/black
-	name = "black curtain"
-	color = "#222222"
-
-/obj/structure/curtain/medical
-	name = "plastic curtain"
-	color = "#b8f5e3"
-	alpha = 200
-
+	curtain_kind_path = /decl/curtain_kind/cloth/black
 /obj/structure/curtain/bar
-	name = "bar curtain"
-	color = "#854636"
-
+	curtain_kind_path = /decl/curtain_kind/cloth/bar
+/obj/structure/curtain/medical
+	curtain_kind_path = /decl/curtain_kind/plastic/medical
 /obj/structure/curtain/privacy
-	name = "privacy curtain"
-	color = "#b8f5e3"
-
+	curtain_kind_path = /decl/curtain_kind/plastic/privacy
 /obj/structure/curtain/shower
-	name = "shower curtain"
-	color = "#acd1e9"
-	alpha = 200
-
+	curtain_kind_path = /decl/curtain_kind/plastic/shower
 /obj/structure/curtain/canteen
-	name = "privacy curtain"
-	color = COLOR_BLUE_GRAY
+	curtain_kind_path = /decl/curtain_kind/plastic/canteen
 
 // Open subtypes
 /obj/structure/curtain/open/bed
-	name = "bed curtain"
-	color = "#854636"
-
+	curtain_kind_path = /decl/curtain_kind/cloth/bed
 /obj/structure/curtain/open/black
-	name = "black curtain"
-	color = "#222222"
-
+	curtain_kind_path = /decl/curtain_kind/cloth/black
 /obj/structure/curtain/open/medical
-	name = "plastic curtain"
-	color = "#b8f5e3"
-	alpha = 200
-
+	curtain_kind_path = /decl/curtain_kind/plastic/medical
 /obj/structure/curtain/open/bar
-	name = "bar curtain"
-	color = "#854636"
-
+	curtain_kind_path = /decl/curtain_kind/cloth/bar
 /obj/structure/curtain/open/privacy
-	name = "privacy curtain"
-	color = "#b8f5e3"
-
+	curtain_kind_path = /decl/curtain_kind/plastic/privacy
 /obj/structure/curtain/open/shower
-	name = "shower curtain"
-	color = "#acd1e9"
-	alpha = 200
-
+	curtain_kind_path = /decl/curtain_kind/plastic/shower
 /obj/structure/curtain/open/canteen
-	name = "privacy curtain"
-	color = COLOR_BLUE_GRAY
-
+	curtain_kind_path = /decl/curtain_kind/plastic/canteen
 /obj/structure/curtain/open/shower/engineering
-	color = "#ffa500"
-
+	curtain_kind_path = /decl/curtain_kind/plastic/shower/engineering
 /obj/structure/curtain/open/shower/security
-	color = "#aa0000"
+	curtain_kind_path = /decl/curtain_kind/plastic/shower/security

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -76,6 +76,12 @@
 
 	var/curtain_kind_path = /decl/curtain_kind //path to decl containing the curtain's details
 
+/obj/item/curtain/Initialize()
+  . = ..()
+  //Init matter content
+  var/decl/curtain_kind/curtain_decl = GET_DECL(curtain_kind_path)
+  matter = atom_info_repository.get_matter_for(/obj/structure/curtain, curtain_decl.material_key)
+
 /obj/item/curtain/bed
 	curtain_kind_path = /decl/curtain_kind/cloth/bed
 /obj/item/curtain/black

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -1,119 +1,28 @@
-//
-// Curtain types declaration
-//
-/decl/curtain_kind
-	var/name = "curtain"
-	var/color = "white"
-	var/alpha = 255
-	var/material_key = /decl/material/solid/plastic
-	var/material_cost = SHEET_MATERIAL_AMOUNT //Can't fetch material amount from repository
-
-/decl/curtain_kind/proc/make_item(var/loc)
-	var/obj/item/curtain/C = new(loc, material_key, src)
-	C.alpha = alpha
-	C.set_color(color)
-	C.SetName("rolled [name]")
-	return C
-
-/decl/curtain_kind/proc/make_structure(var/loc, var/dir, var/opened = FALSE)
-	var/obj/structure/curtain/C = new(loc, material_key, null, src)
-	C.alpha = alpha
-	C.set_color(color)
-	C.SetName(name)
-	C.set_opacity(opened)
-	C.set_dir(dir)
-	C.update_icon()
-	return C
-
-//Cloth curtains
-/decl/curtain_kind/cloth
-	material_key = /decl/material/solid/cloth
-
-/decl/curtain_kind/cloth/bed
-	name = "bed curtain"
-	color = "#854636"
-
-/decl/curtain_kind/cloth/black
-	name = "black curtain"
-	color = "#222222"
-
-/decl/curtain_kind/cloth/bar
-	name = "bar curtain"
-	color = "#854636"
-
-//Plastic curtains
-/decl/curtain_kind/plastic
-	name = "plastic curtain"
-	color = "#b8f5e3"
-	material_key = /decl/material/solid/plastic
-
-/decl/curtain_kind/plastic/medical
-	alpha = 200
-
-/decl/curtain_kind/plastic/privacy
-	name = "privacy curtain"
-
-/decl/curtain_kind/plastic/shower
-	name = "shower curtain"
-	color = "#acd1e9"
-	alpha = 200
-
-/decl/curtain_kind/plastic/shower/engineering
-	color = "#ffa500"
-
-/decl/curtain_kind/plastic/shower/security
-	color = "#aa0000"
-
-/decl/curtain_kind/plastic/canteen
-	name = "privacy curtain"
-	color = COLOR_BLUE_GRAY
-
-//
-// Curtain Item
-//
 /obj/item/curtain
 	name = "rolled curtain"
-	desc = "A rolled curtains."
+	desc = "A rolled-up curtain."
 	icon = 'icons/obj/structures/curtain.dmi'
 	icon_state = "curtain_rolled"
 	force = 3 //just plastic
 	w_class = ITEM_SIZE_HUGE //curtains, yeap
-
 	var/curtain_kind_path = /decl/curtain_kind //path to decl containing the curtain's details
 
-/obj/item/curtain/bed
-	curtain_kind_path = /decl/curtain_kind/cloth/bed
-/obj/item/curtain/black
-	curtain_kind_path = /decl/curtain_kind/cloth/black
-/obj/item/curtain/bar
-	curtain_kind_path = /decl/curtain_kind/cloth/bar
-/obj/item/curtain/medical
-	curtain_kind_path = /decl/curtain_kind/plastic/medical
-/obj/item/curtain/privacy
-	curtain_kind_path = /decl/curtain_kind/plastic/privacy
-/obj/item/curtain/shower
-	curtain_kind_path = /decl/curtain_kind/plastic/shower
-/obj/item/curtain/shower/engineering
-	curtain_kind_path = /decl/curtain_kind/plastic/shower/engineering
-/obj/item/curtain/shower/security
-	curtain_kind_path = /decl/curtain_kind/plastic/shower/security
-/obj/item/curtain/canteen
-	curtain_kind_path = /decl/curtain_kind/plastic/canteen
-
-/obj/item/curtain/Initialize(ml, material_key, var/decl/curtain_kind/kind = null)
-	if(kind)
-		if(istype(kind))
-			curtain_kind_path = kind.type
-		else if(ispath(kind))
-			curtain_kind_path = kind
-	else
-		kind = GET_DECL(curtain_kind_path)
-
-	SetName(kind.name)
-	material_key = kind.material_key
-	LAZYINITLIST(matter)
-	matter[material_key] = kind.material_cost
+/obj/item/curtain/Initialize(ml, material_key)
 	. = ..()
+	if(curtain_kind_path)
+		set_curtain_kind(GET_DECL(curtain_kind_path))
+
+/obj/item/curtain/proc/set_curtain_kind(var/decl/curtain_kind/kind)
+
+	if(!istype(kind))
+		CRASH("Invalid curtain kind supplied to set_curtain_kind on [type]: [kind || "NULL"]")
+		return
+
+	curtain_kind_path = kind.type
+	SetName("rolled [kind.name]")
+	material = GET_DECL(kind.material_key)
+	matter = atom_info_repository.get_matter_for(/obj/structure/curtain, kind.material_key)
+	update_icon()
 
 /obj/item/curtain/attackby(obj/item/W, mob/user)
 	if(isScrewdriver(W))
@@ -148,11 +57,10 @@
 
 /obj/item/curtain/on_update_icon()
 	. = ..()
-	var/decl/curtain_kind/kind = GET_DECL(curtain_kind_path)
-	if(!kind)
-		CRASH("Couldn't get curtain data for curtain kind path '[curtain_kind_path]'!")
-	alpha = kind.alpha
-	color = kind.color
+	if(curtain_kind_path)
+		var/decl/curtain_kind/kind = GET_DECL(curtain_kind_path)
+		alpha = kind.alpha
+		color = kind.color
 
 //
 // Curtain Structure
@@ -172,19 +80,23 @@
 	layer = ABOVE_HUMAN_LAYER
 	opacity = FALSE
 
-/obj/structure/curtain/Initialize(ml, _mat, _reinf_mat, var/decl/curtain_kind/kind = null)
-	if(kind)
-		if(istype(kind))
-			curtain_kind_path = kind.type
-		else if(ispath(kind))
-			curtain_kind_path = kind
-	else
-		kind = GET_DECL(curtain_kind_path)
-	_mat = kind.material_key
-	matter = atom_info_repository.get_matter_for(/obj/item/curtain, kind.material_key) //Fetch it from the item version
-	. = ..()
-	SetName(kind.name)
+/obj/structure/curtain/Initialize(ml, _mat, _reinf_mat)
+	. = ..(ml)
 	set_extension(src, /datum/extension/turf_hand)
+	if(curtain_kind_path)
+		set_curtain_kind(GET_DECL(curtain_kind_path))
+
+/obj/structure/curtain/proc/set_curtain_kind(var/decl/curtain_kind/kind)
+
+	if(!istype(kind))
+		CRASH("Invalid curtain kind supplied to set_curtain_kind on [type]: [kind || "NULL"]")
+		return
+
+	SetName(kind.name)
+	curtain_kind_path = kind.type
+	material = GET_DECL(kind.material_key)
+	create_matter()
+	update_icon()
 
 /obj/structure/curtain/bullet_act(obj/item/projectile/P, def_zone)
 	if(!P.nodamage)
@@ -231,15 +143,37 @@
 
 /obj/structure/curtain/on_update_icon()
 	. = ..()
-	var/decl/curtain_kind/kind = GET_DECL(curtain_kind_path)
+
 	icon_state = opacity ? "closed" : "open"
 	layer = opacity ? ABOVE_HUMAN_LAYER : ABOVE_WINDOW_LAYER
-	if(!kind)
-		CRASH("Couldn't get curtain data for curtain kind path '[curtain_kind_path]'!")
-	alpha = kind.alpha
-	color = kind.color
 
-// Normal subtypes
+	if(curtain_kind_path)
+		var/decl/curtain_kind/kind = GET_DECL(curtain_kind_path)
+		alpha = kind.alpha
+		set_color(kind.color)
+
+// Subtypes for mapping/spawning below:
+// - Item subtypes
+/obj/item/curtain/bed
+	curtain_kind_path = /decl/curtain_kind/cloth/bed
+/obj/item/curtain/black
+	curtain_kind_path = /decl/curtain_kind/cloth/black
+/obj/item/curtain/bar
+	curtain_kind_path = /decl/curtain_kind/cloth/bar
+/obj/item/curtain/medical
+	curtain_kind_path = /decl/curtain_kind/plastic/medical
+/obj/item/curtain/privacy
+	curtain_kind_path = /decl/curtain_kind/plastic/privacy
+/obj/item/curtain/shower
+	curtain_kind_path = /decl/curtain_kind/plastic/shower
+/obj/item/curtain/shower/engineering
+	curtain_kind_path = /decl/curtain_kind/plastic/shower/engineering
+/obj/item/curtain/shower/security
+	curtain_kind_path = /decl/curtain_kind/plastic/shower/security
+/obj/item/curtain/canteen
+	curtain_kind_path = /decl/curtain_kind/plastic/canteen
+
+// - Closed subtypes
 /obj/structure/curtain/bed
 	curtain_kind_path = /decl/curtain_kind/cloth/bed
 /obj/structure/curtain/black
@@ -255,7 +189,7 @@
 /obj/structure/curtain/canteen
 	curtain_kind_path = /decl/curtain_kind/plastic/canteen
 
-// Open subtypes
+// - Open subtypes
 /obj/structure/curtain/open/bed
 	curtain_kind_path = /decl/curtain_kind/cloth/bed
 /obj/structure/curtain/open/black

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -76,12 +76,6 @@
 
 	var/curtain_kind_path = /decl/curtain_kind //path to decl containing the curtain's details
 
-/obj/item/curtain/Initialize()
-  . = ..()
-  //Init matter content
-  var/decl/curtain_kind/curtain_decl = GET_DECL(curtain_kind_path)
-  matter = atom_info_repository.get_matter_for(/obj/structure/curtain, curtain_decl.material_key)
-
 /obj/item/curtain/bed
 	curtain_kind_path = /decl/curtain_kind/cloth/bed
 /obj/item/curtain/black
@@ -113,6 +107,7 @@
 	src.set_color(kind.color)
 	src.SetName(kind.name)
 	material_key = kind.material_key
+	matter = atom_info_repository.get_matter_for(/obj/item/curtain, kind.material_key)
 	. = ..()
 
 /obj/item/curtain/attackby(obj/item/W, mob/user)
@@ -170,6 +165,7 @@
 	else
 		kind = GET_DECL(curtain_kind_path)
 	_mat = kind.material_key
+	matter = atom_info_repository.get_matter_for(/obj/structure/curtain, kind.material_key)
 	. = ..()
 	src.SetName(kind.name)
 	src.alpha = kind.alpha

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -16,7 +16,6 @@
 
 	if(!istype(kind))
 		CRASH("Invalid curtain kind supplied to set_curtain_kind on [type]: [kind || "NULL"]")
-		return
 
 	curtain_kind_path = kind.type
 	SetName("rolled [kind.name]")
@@ -90,7 +89,6 @@
 
 	if(!istype(kind))
 		CRASH("Invalid curtain kind supplied to set_curtain_kind on [type]: [kind || "NULL"]")
-		return
 
 	SetName(kind.name)
 	curtain_kind_path = kind.type

--- a/nebula.dme
+++ b/nebula.dme
@@ -1190,6 +1190,7 @@
 #include "code\game\objects\structures\charge_pylon.dm"
 #include "code\game\objects\structures\coathanger.dm"
 #include "code\game\objects\structures\crematorium.dm"
+#include "code\game\objects\structures\curtain_decls.dm"
 #include "code\game\objects\structures\curtains.dm"
 #include "code\game\objects\structures\defensive_barrier.dm"
 #include "code\game\objects\structures\displaycase.dm"


### PR DESCRIPTION
## Description of changes

Moved the curtains decl into a new PR branch as requested on #1962.

Basically makes all curtains a single structure and a single item that just take on the properties specified in a decl. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship

<!-- Describe original authors of changes to credit them. -->

## Changelog

:cl:
tweak: Make curtains use decl instead of several subtypes.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
