### PR TITLE
Speech can now use multiple language keys.

### DIFF
--- a/code/game/gamemodes/godmode/god_pylon.dm
+++ b/code/game/gamemodes/godmode/god_pylon.dm
@@ -57,19 +57,21 @@
 		. = TOPIC_REFRESH
 	. = ..()
 
-/obj/structure/deity/pylon/hear_talk(mob/M, text, verb, decl/language/speaking)
+/obj/structure/deity/pylon/hear_talk(mob/speaker, list/phrases, verb = "says")
+	..()
 	if(!linked_god)
 		return
 	if(linked_god.pylon != src)
-		if(!(M in intuned))
+		if(!(speaker in intuned))
 			return
 		for(var/obj/structure/deity/pylon/P in linked_god.structures)
 			if(P == src || linked_god.pylon == P)
 				continue
-			P.audible_message("<b>\The [P]</b> resonates, \"[text]\"")
-	to_chat(linked_god, "[html_icon(src)] <span class='game say'><span class='name'>[M]</span> (<A href='?src=\ref[linked_god];jump=\ref[src];'>P</A>) [verb], [linked_god.pylon == src ? "<b>" : ""]<span class='message'><span class='body'>\"[text]\"</span></span>[linked_god.pylon == src ? "</b>" : ""]</span>")
+			P.audible_message("<b>\The [P]</b> resonates, \"[compile_mixed_language_text_for(speaker, P, phrases)]\"")
+
+	to_chat(linked_god, "[html_icon(src)] <span class='game say'><span class='name'>[speaker]</span> (<A href='?src=\ref[linked_god];jump=\ref[src];'>P</A>) [verb], [linked_god.pylon == src ? "<b>" : ""]<span class='message'><span class='body'>\"[compile_mixed_language_text_for(speaker, linked_god, phrases)]\"</span></span>[linked_god.pylon == src ? "</b>" : ""]</span>")
 	if(linked_god.minions.len)
 		for(var/minion in linked_god.minions)
 			var/datum/mind/mind = minion
 			if(mind.current && mind.current.eyeobj) //If it is currently having a vision of some sort
-				to_chat(mind.current,"[html_icon(src)] <span class='game say'><span class='name'>[M]</span> (<A href='?src=\ref[src];vision_jump=\ref[src];'>J</A>) [verb], <span class='message'<span class='body'>\"[text]\"</span></span>")
+				to_chat(mind.current,"[html_icon(src)] <span class='game say'><span class='name'>[speaker]</span> (<A href='?src=\ref[src];vision_jump=\ref[src];'>J</A>) [verb], <span class='message'<span class='body'>\"[compile_mixed_language_text_for(speaker, mind.current, phrases)]\"</span></span>")

--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -24,8 +24,8 @@ var/global/list/radio_beacons = list()
 /obj/item/radio/beacon/toggle_panel(var/mob/user)
 	return FALSE
 
-/obj/item/radio/beacon/hear_talk()
-	return
+/obj/item/radio/beacon/hear_talk(mob/speaker, list/phrases, verb = "says")
+	SHOULD_CALL_PARENT(FALSE)
 
 /obj/item/radio/beacon/emp_act(severity)
 	if(functioning && severity >= 1)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -324,27 +324,26 @@
 				return channel.frequency
 	return frequency
 
-/obj/item/radio/talk_into(mob/living/M, message, message_mode, var/verb = "says", var/decl/language/speaking = null)
+/obj/item/radio/talk_into(mob/speaker, list/phrases, channel, var/verb = "says")
 	set waitfor = FALSE
 	if(!on) return 0 // the device has to be on
 	//  Fix for permacell radios, but kinda eh about actually fixing them.
-	if(!M || !message) return 0
+	if(!speaker)
+		return 0
 
-	if(speaking && (speaking.flags & (LANG_FLAG_NONVERBAL|LANG_FLAG_SIGNLANG))) return 0
-
-	if (!broadcasting)
+	if(!broadcasting)
 		// Sedation chemical effect should prevent radio use.
-		var/mob/living/carbon/C = M
+		var/mob/living/carbon/C = speaker
 		if(istype(C) && (C.has_chemical_effect(CE_SEDATE, 1) || C.incapacitated(INCAPACITATION_DISRUPTED)))
-			to_chat(M, SPAN_WARNING("You're unable to reach \the [src]."))
+			to_chat(speaker, SPAN_WARNING("You're unable to reach \the [src]."))
 			return 0
 
 		if((istype(C)) && C.radio_interrupt_cooldown > world.time)
-			to_chat(M, SPAN_WARNING("You're disrupted as you reach for \the [src]."))
+			to_chat(speaker, SPAN_WARNING("You're disrupted as you reach for \the [src]."))
 			return 0
 
-		if(istype(M))
-			M.trigger_aiming(TARGET_CAN_RADIO)
+		if(istype(speaker))
+			speaker.trigger_aiming(TARGET_CAN_RADIO)
 
 	addtimer(CALLBACK(src, .proc/transmit, M, message, message_mode, verb, speaking), 0)
 

--- a/code/game/objects/items/devices/spy_bug.dm
+++ b/code/game/objects/items/devices/spy_bug.dm
@@ -51,9 +51,10 @@
 	else
 		..()
 
-/obj/item/spy_bug/hear_talk(mob/M, var/msg, verb, decl/language/speaking)
-	radio.hear_talk(M, msg, speaking)
-
+/obj/item/spy_bug/hear_talk(mob/speaker, list/phrases, verb = "says")
+	..()
+	if(radio)
+		radio.hear_talk(speaker, phrases, verb)
 
 /obj/item/spy_monitor
 	name = "\improper PDA"
@@ -145,8 +146,22 @@
 		return -1
 	return 0
 
-/obj/item/spy_monitor/hear_talk(mob/M, var/msg, verb, decl/language/speaking)
-	return radio.hear_talk(M, msg, speaking)
+/obj/item/spy_monitor/hear_talk(mob/speaker, list/phrases, verb = "says")
+	..()
+	if(radio)
+		radio.hear_talk(speaker, phrases, verb)
+
+/obj/machinery/camera/spy
+	// These cheap toys are accessible from the mercenary camera console as well
+	network = list(NETWORK_MERCENARY)
+
+/obj/machinery/camera/spy/Initialize()
+	. = ..()
+	name = "DV-136ZB #[random_id(/obj/machinery/camera/spy, 1000,9999)]"
+	c_tag = name
+
+/obj/machinery/camera/spy/check_eye(var/mob/user)
+	return 0
 
 /obj/item/radio/spy
 	listening = 0

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -101,8 +101,10 @@
 	if(distance <= 1 && maintenance)
 		to_chat(user, "<span class='notice'>The wires are exposed.</span>")
 
-/obj/item/taperecorder/hear_talk(mob/living/M, msg, var/verb="says", decl/language/speaking=null)
+/obj/item/taperecorder/hear_talk(mob/speaker, list/phrases, var/verb)
+	..()
 	if(mytape && recording)
+		mytape.record_speech("[speaker.name] [verb], \"[compile_mixed_language_text_for(speaker, src, phrases)]\"")
 
 		if(speaking)
 			if(!speaking.machine_understands)

--- a/code/game/objects/items/weapons/implants/implants/explosive.dm
+++ b/code/game/objects/items/weapons/implants/implants/explosive.dm
@@ -91,15 +91,15 @@
 	frequency = new_frequency
 	radio_connection = radio_controller.add_object(src, frequency, RADIO_CHAT)
 
-/obj/item/implant/explosive/hear_talk(mob/M, msg)
-	hear(msg)
-
-/obj/item/implant/explosive/hear(var/msg)
+/obj/item/implant/explosive/hear_talk(mob/speaker, list/phrases, verb = "says")
+	..()
 	if(!phrase)
 		return
-	if(findtext(sanitize_phrase(msg),phrase))
-		activate()
-		qdel(src)
+	for(var/list/phrase_data in phrases)
+		if(findtext(sanitize_phrase(phrase_data[2]), phrase))
+			activate()
+			qdel(src)
+			break
 
 /obj/item/implant/explosive/exposed()
 	if(warning_message)

--- a/code/game/objects/items/weapons/implants/implants/translator.dm
+++ b/code/game/objects/items/weapons/implants/implants/translator.dm
@@ -16,17 +16,21 @@
 	. = ..()
 	global.listening_objects += src
 
-/obj/item/implant/translator/hear_talk(mob/M, msg, verb, decl/language/speaking)
+/obj/item/implant/translator/hear_talk(mob/speaker, list/phrases, verb = "says")
+	..()
 	if(!imp_in)
 		return
 	if(length(languages) == max_languages)
 		return
-	if(!languages[speaking.name])
-		languages[speaking.name] = 1
-	languages[speaking.name] = languages[speaking.name] + 1
-	if(!imp_in.say_understands(M, speaking) && languages[speaking.name] > learning_threshold)
-		to_chat(imp_in, SPAN_NOTICE("You feel like you can understand [speaking.name] now..."))
-		imp_in.add_language(speaking.type)
+	for(var/list/phrase in phrases)
+		var/decl/language/speaking = phrase[1]
+		if(speaking)
+			if(!languages[speaking.name])
+				languages[speaking.name] = 1
+			languages[speaking.name] = languages[speaking.name] + 1
+			if(!imp_in.say_understands(speaker, speaking) && languages[speaking.name] > learning_threshold)
+				to_chat(imp_in, SPAN_NOTICE("You feel like you can understand [speaking.name] now..."))
+				imp_in.add_language(speaking.type)
 
 /obj/item/implant/translator/implanted(mob/target)
 	return TRUE

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -89,16 +89,11 @@
 /obj/proc/hides_under_flooring()
 	return level == 1
 
-/obj/proc/hear_talk(mob/M, text, verb, decl/language/speaking)
+/obj/proc/hear_talk(mob/speaker, list/phrases, verb = "says")
+	SHOULD_CALL_PARENT(TRUE)
+	set waitfor = FALSE
 	if(talking_atom)
-		talking_atom.catchMessage(text, M)
-/*
-	var/mob/mo = locate(/mob) in src
-	if(mo)
-		var/rendered = "<span class='game say'><span class='name'>[M.name]: </span> <span class='message'>[text]</span></span>"
-		mo.show_message(rendered, 2)
-		*/
-	return
+		talking_atom.catchMessage(compile_mixed_language_text_for(speaker, src, phrases), speaker)
 
 /obj/proc/see_emote(mob/M, text, var/emote_type)
 	return

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -198,11 +198,12 @@
 //			special_assembly.dothings()
 	return 1
 
-/obj/item/assembly_holder/hear_talk(mob/living/M, msg, verb, decl/language/speaking)
+/obj/item/assembly_holder/hear_talk(mob/speaker, list/phrases, verb = "says")
+	..()
 	if(a_right)
-		a_right.hear_talk(M,msg,verb,speaking)
+		a_right.hear_talk(speaker, phrases, verb)
 	if(a_left)
-		a_left.hear_talk(M,msg,verb,speaking)
+		a_left.hear_talk(speaker, phrases, verb)
 
 /obj/item/assembly_holder/examine(mob/user, distance)
 	. = ..()

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -19,7 +19,14 @@
 	global.listening_objects -= src
 	return ..()
 
-/obj/item/assembly/voice/hear_talk(mob/living/M, msg)
+/obj/item/assembly/voice/hear_talk(mob/speaker, list/phrases, verb = "says")
+
+	..()
+
+	var/msg = compile_mixed_language_text_for(speaker, src, phrases)
+	if(!msg)
+		return
+
 	if(listening)
 		recorded = msg
 		listening = 0

--- a/code/modules/fabrication/fabricator_food.dm
+++ b/code/modules/fabrication/fabricator_food.dm
@@ -8,22 +8,21 @@
 	base_storage_capacity_mult = 5
 	has_recycler = FALSE
 
-/obj/machinery/fabricator/replicator/hear_talk(var/mob/M, var/text, var/verb, var/decl/language/speaking)
-	if(speaking && !speaking.machine_understands)
-		return ..()
-	var/true_text = lowertext(html_decode(text))
+/obj/machinery/fabricator/replicator/hear_talk(mob/speaker, list/phrases, verb = "says")
+	..()
+	var/true_text = lowertext(html_decode(compile_mixed_language_text_for(speaker, src, phrases)))
 	if(findtext(true_text, "status"))
 		addtimer(CALLBACK(src, /obj/machinery/fabricator/replicator/proc/state_status), 2 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
-	else if(findtext(true_text, "menu"))
+		return
+	if(findtext(true_text, "menu"))
 		addtimer(CALLBACK(src, /obj/machinery/fabricator/replicator/proc/state_menu), 2 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
-	else 
-		for(var/datum/fabricator_recipe/recipe in design_cache)
-			if(recipe.hidden && !(fab_status_flags & FAB_HACKED))
-				continue
-			if(findtext(true_text, lowertext(recipe.name)))
-				addtimer(CALLBACK(src, /obj/machinery/fabricator/proc/try_queue_build, recipe, 1), 2 SECONDS)
-				break
-	..()
+		return
+	for(var/datum/fabricator_recipe/recipe in design_cache)
+		if(recipe.hidden && !(fab_status_flags & FAB_HACKED))
+			continue
+		if(findtext(true_text, lowertext(recipe.name)))
+			addtimer(CALLBACK(src, /obj/machinery/fabricator/proc/try_queue_build, recipe, 1), 2 SECONDS)
+			return
 
 /obj/machinery/fabricator/replicator/proc/state_status()
 	for(var/thing in storage_capacity)

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -833,19 +833,20 @@
 	global.listening_objects -= src
 	. = ..()
 
-/obj/item/integrated_circuit/input/microphone/hear_talk(var/mob/living/M, text, verb, decl/language/speaking)
-	var/translated = TRUE
-	if(M && text)
-		if(speaking && !speaking.machine_understands)
-			text = speaking.scramble(M, text)
-			translated = FALSE
-		set_pin_data(IC_OUTPUT, 1, M.GetVoice())
-		set_pin_data(IC_OUTPUT, 2, text)
+/obj/item/integrated_circuit/input/microphone/hear_talk(mob/speaker, list/phrases, verb = "says")
 
+	var/text = compile_mixed_language_text_for(speaker, src, phrases)
+	if(isliving(speaker) && text)
+		var/mob/living/L = speaker
+		set_pin_data(IC_OUTPUT, 1, L.get_voice())
+		set_pin_data(IC_OUTPUT, 2, text)
 	push_data()
 	activate_pin(1)
-	if(translated && !(speaking.type == /decl/language/human/common))
-		activate_pin(2)
+	for(var/list/phrase in phrases)
+		if(phrase[1] != GET_DECL(/decl/language/human/common))
+			activate_pin(2)
+			return
+	..()
 
 /obj/item/integrated_circuit/input/sensor
 	name = "sensor"

--- a/code/modules/mob/floating_message.dm
+++ b/code/modules/mob/floating_message.dm
@@ -15,15 +15,8 @@ var/global/list/floating_chat_colors = list()
 /atom/movable
 	var/list/stored_chat_text
 
-/atom/movable/proc/animate_chat(message, decl/language/language, small, list/show_to, duration = CHAT_MESSAGE_LIFESPAN)
+/atom/movable/proc/animate_chat(list/phrases, decl/language/language, small, list/show_to, duration = CHAT_MESSAGE_LIFESPAN, var/scramble)
 	set waitfor = FALSE
-
-	/// Get rid of any URL schemes that might cause BYOND to automatically wrap something in an anchor tag
-	var/static/regex/url_scheme = new(@"[A-Za-z][A-Za-z0-9+-\.]*:\/\/", "g")
-	message = replacetext(message, url_scheme, "")
-
-	var/static/regex/html_metachars = new(@"&[A-Za-z]{1,7};", "g")
-	message = replacetext(message, html_metachars, "")
 
 	//additional style params for the message
 	var/style
@@ -33,13 +26,11 @@ var/global/list/floating_chat_colors = list()
 	if(small)
 		fontsize = 6
 
-	if(copytext_char(message, length_char(message) - 1) == "!!")
+	var/last_phrase = phrases[length(phrases)]
+	if(copytext_char(last_phrase, length_char(last_phrase) - 1) == "!!")
 		fontsize = 8
 		limit = 60
 		style += "font-weight: bold;"
-
-	if(length_char(message) > limit)
-		message = "[copytext_char(message, 1, limit)]..."
 
 	if(!global.floating_chat_colors[name])
 		global.floating_chat_colors[name] = get_random_colour(0, 160, 230)

--- a/code/modules/mob/language/alien/antag.dm
+++ b/code/modules/mob/language/alien/antag.dm
@@ -15,7 +15,7 @@
 		"sektath", "mal'zua", "zasan", "therium", "viortia", "kla'atu", "barada", "nikt'o", "fwe'sh", "mah", "erl", "nyag", "r'ya", \
 		"gal'h'rfikk", "harfrandid", "mud'gib", "fuu", "ma'jin", "dedo", "ol'btoh", "n'ath", "reth", "sh'yro", "eth", \
 		"d'rekkathnor", "khari'd", "gual'te", "nikka", "nikt'o", "barada", "kla'atu", "barhah", "hra" ,"zar'garis")
-	machine_understands = 0
+	machine_understands = FALSE
 	shorthand = "CT"
 	hidden_from_codex = TRUE
 
@@ -40,7 +40,7 @@
 	syllables = list("qy","bok","mok","yok","dy","gly","ryl","byl","dok","forbici", "tarem", "n'ath", "reth", "sh'yro", "eth", "d'raggathnor","niii",
 	"d'rekkathnor", "khari'd", "gual'te", "ki","ki","ki","ki","ya","ta","wej","nym","assah","qwssa","nieasl","qyno","shaffar",
 	"eg","bog","voijs","nekks","bollos","qoulsan","borrksakja","neemen","aka","nikka","qyegno","shafra","beolas","Byno")
-	machine_understands = 0
+	machine_understands = FALSE
 	shorthand = "AL"
 	hidden_from_codex = TRUE
 

--- a/code/modules/mob/living/carbon/brain/say.dm
+++ b/code/modules/mob/living/carbon/brain/say.dm
@@ -34,5 +34,5 @@
 		if(istype(container, /obj/item/mmi/radio_enabled))
 			var/obj/item/mmi/radio_enabled/R = container
 			if(R.radio)
-				spawn(0) R.radio.hear_talk(src, sanitize(message), verb, speaking)
+				spawn(0) R.radio.hear_talk(src, list(get_default_language(), sanitize(message)), verb)
 		..(trim(message), speaking, verb)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -28,7 +28,7 @@
 
 	var/icon/stand_icon = null
 
-	var/voice = ""	//Instead of new say code calling GetVoice() over and over and over, we're just going to ask this variable, which gets updated in Life()
+	var/voice = ""	//Instead of new say code calling get_voice() over and over and over, we're just going to ask this variable, which gets updated in Life()
 
 	var/last_dam = -1	//Used for determining if we need to process all organs or just some or even none.
 	/// organs we check until they are good.

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -50,7 +50,7 @@
 	if(life_tick%30==15)
 		hud_updateflag = 1022
 
-	voice = GetVoice()
+	voice = get_voice()
 
 	//No need to update all of these procs if the guy is dead.
 	if(stat != DEAD && !is_in_stasis())

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -15,8 +15,8 @@
 					return
 			else if(L.breath_fail_ratio > 0.7 || (L.breath_fail_ratio > 0.4 && length(message) > 10) || (L.breath_fail_ratio > 0.2 && length(message) > 30))
 				whispering = TRUE
-	if(name != GetVoice())
-		if(get_id_name("Unknown") == GetVoice())
+	if(name != get_voice())
+		if(get_id_name("Unknown") == get_voice())
 			SetName(get_id_name("Unknown"))
 	. = ..(message, speaking, verb, alt_name, whispering)
 
@@ -54,10 +54,10 @@
 					say(temp)
 				winset(client, "input", "text=[null]")
 
-/mob/living/carbon/human/say_understands(mob/speaker, decl/language/speaking)
+/mob/living/carbon/human/say_understands(var/mob/other, var/decl/language/speaking)
 	return (!speaking && (issilicon(speaker) || istype(speaker, /mob/announcer) || isbrain(speaker))) || ..()
 
-/mob/living/carbon/human/GetVoice()
+/mob/living/carbon/human/get_voice()
 
 	var/voice_sub
 	var/obj/item/rig/rig = get_rig()
@@ -111,7 +111,7 @@
 
 	return ..(message_data)
 
-/mob/living/carbon/human/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
+/mob/living/carbon/human/handle_message_mode(mob/speaker, list/phrases, channel, verb = "says", used_radios, alt_name)
 	if(message_mode == MESSAGE_MODE_WHISPER) //It's going to get sanitized again immediately, so decode.
 		whisper_say(html_decode(message), speaking, alt_name)
 		return TRUE

--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -17,7 +17,7 @@
 	if (src.stat)
 		return
 
-	if(get_id_name("Unknown") == GetVoice())
+	if(get_id_name("Unknown") == get_voice())
 		SetName(get_id_name("Unknown"))
 
 	whisper_say(message)

--- a/code/modules/mob/living/simple_animal/friendly/possum.dm
+++ b/code/modules/mob/living/simple_animal/friendly/possum.dm
@@ -92,9 +92,9 @@
 	. = ..()
 	addtimer(CALLBACK(src, .proc/check_keywords, message), rand(1 SECOND, 3 SECONDS))
 
-/mob/living/simple_animal/opossum/poppy/hear_say(var/message, var/verb = "says", var/decl/language/language = null, var/alt_name = "",var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol)
+/mob/living/simple_animal/opossum/poppy/hear_say(var/list/phrases, var/verb = "says", var/alt_name = "",var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol, var/scramble = FALSE)
 	. = ..()
-	addtimer(CALLBACK(src, .proc/check_keywords, message), rand(1 SECOND, 3 SECONDS))
+	addtimer(CALLBACK(src, .proc/check_keywords, compile_mixed_language_text_for(speaker, src, phrases, colourize = FALSE)), rand(1 SECOND, 3 SECONDS))
 
 /mob/living/simple_animal/opossum/poppy/proc/check_keywords(var/message)
 	if(!client && stat == CONSCIOUS)

--- a/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
@@ -9,16 +9,16 @@
 	var/list/allowed_targets = list() //WHO CAN I KILL D:
 	var/retribution = 1 //whether or not they will attack us if we attack them like some kinda dick.
 
-/mob/living/simple_animal/hostile/commanded/hear_say(var/message, var/verb = "says", var/decl/language/language = null, var/alt_name = "", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol)
+/mob/living/simple_animal/hostile/commanded/hear_say(var/list/phrases, var/verb = "says", var/alt_name = "", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol, var/scramble = FALSE)
 	if((weakref(speaker) in friends) || speaker == master)
 		command_buffer.Add(speaker)
-		command_buffer.Add(lowertext(html_decode(message)))
+		command_buffer.Add(lowertext(html_decode(compile_mixed_language_text_for(speaker, src, phrases, colourize = FALSE))))
 	return 0
 
-/mob/living/simple_animal/hostile/commanded/hear_radio(var/message, var/verb="says", var/decl/language/language=null, var/part_a, var/part_b, var/part_c, var/mob/speaker = null, var/hard_to_hear = 0)
+/mob/living/simple_animal/hostile/commanded/hear_radio(var/list/phrases, var/verb="says", var/part_a, var/part_b, var/part_c, var/mob/speaker = null, var/hard_to_hear = 0)
 	if((weakref(speaker) in friends) || speaker == master)
 		command_buffer.Add(speaker)
-		command_buffer.Add(lowertext(html_decode(message)))
+		command_buffer.Add(lowertext(html_decode(compile_mixed_language_text_for(speaker, src, phrases, colourize = FALSE))))
 	return 0
 
 /mob/living/simple_animal/hostile/commanded/Life()

--- a/code/modules/mob/living/simple_animal/hostile/faithful_hound.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithful_hound.dm
@@ -61,8 +61,8 @@
 			if(3)
 				src.visible_message("<span class='danger'>\The [src] snaps at the air!</span>")
 
-/mob/living/simple_animal/faithful_hound/hear_say(var/message, var/verb = "says", var/decl/language/language = null, var/alt_name = "", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol)
-	if(password && findtext(message,password))
+/mob/living/simple_animal/faithful_hound/hear_say(var/list/phrases, var/verb = "says", var/alt_name = "", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol, var/scramble = FALSE)
+	if(password && findtext(compile_mixed_language_text_for(speaker, src, phrases, colourize = FALSE), password))
 		allowed_mobs |= speaker
 		spawn(10)
 			src.visible_message("<span class='notice'>\The [src] nods in understanding towards \the [speaker].</span>")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -174,7 +174,7 @@
 	for(var/o in objs)
 		var/obj/O = o
 		if(radio_message)
-			O.hear_talk(src, radio_message, null, GET_DECL(/decl/language/noise))
+			O.hear_talk(src, list(GET_DECL(/decl/language/noise), radio_message), null)
 		else
 			O.show_message(message, AUDIBLE_MESSAGE, deaf_message, VISIBLE_MESSAGE)
 
@@ -1157,6 +1157,10 @@
 			break
 	if(old_zflags != z_flags)
 		UPDATE_OO_IF_PRESENT
+
+/mob/proc/get_voice()
+	return name
+
 
 /mob/get_mob()
 	return src

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -444,10 +444,10 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 /mob/new_player/is_ready()
 	return ready && ..()
 
-/mob/new_player/hear_say(var/message, var/verb = "says", var/decl/language/language = null, var/alt_name = "",var/italics = 0, var/mob/speaker = null)
+/mob/new_player/hear_say(var/list/phrases, var/verb = "says", var/alt_name = "",var/italics = 0, var/mob/speaker = null, var/scramble = FALSE)
 	return
 
-/mob/new_player/hear_radio(var/message, var/verb="says", var/decl/language/language=null, var/part_a, var/part_b, var/part_c, var/mob/speaker = null, var/hard_to_hear = 0)
+/mob/new_player/hear_radio(var/list/phrases, var/verb="says", var/part_a, var/part_b, var/part_c, var/mob/speaker = null, var/hard_to_hear = 0)
 	return
 
 /mob/new_player/show_message(msg, type, alt, alt_type)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -5,11 +5,11 @@ var/global/list/special_channel_keys = list(
 	"h" = MESSAGE_MODE_DEPARTMENT,
 	"+" = MESSAGE_MODE_SPECIAL,    //activate radio-specific special functions
 	"w" = MESSAGE_MODE_WHISPER,
-	"к" = MESSAGE_MODE_RIGHT,
-	"д" = MESSAGE_MODE_LEFT,
-	"ш" = MESSAGE_MODE_INTERCOM,
-	"р" = MESSAGE_MODE_DEPARTMENT,
-	"ц" = MESSAGE_MODE_WHISPER
+	"?" = MESSAGE_MODE_RIGHT,
+	"?" = MESSAGE_MODE_LEFT,
+	"?" = MESSAGE_MODE_INTERCOM,
+	"?" = MESSAGE_MODE_DEPARTMENT,
+	"?" = MESSAGE_MODE_WHISPER
 )
 
 /mob/proc/say()
@@ -42,7 +42,7 @@ var/global/list/special_channel_keys = list(
 /mob/proc/say_dead(var/message)
 	communicate(/decl/communication_channel/dsay, client, message)
 
-/mob/proc/say_understands(mob/speaker, decl/language/speaking)
+/mob/proc/say_understands(var/mob/other, var/decl/language/speaking)
 	if(stat == DEAD || universal_speak || universal_understand)
 		return TRUE
 	if(!istype(speaker))
@@ -51,7 +51,7 @@ var/global/list/special_channel_keys = list(
 		return speaking.can_be_understood_by(speaker, src)
 	return (speaker.universal_speak || istype(speaker, type) || istype(src, speaker.type))
 
-/mob/proc/say_quote(var/message, var/decl/language/speaking = null)
+/mob/proc/say_quote(var/message, var/decl/language/speaking)
 	var/ending = copytext(message, length(message))
 	if(speaking)
 		return speaking.get_spoken_verb(src, ending)

--- a/code/modules/xenoarcheaology/finds/find_types/mask.dm
+++ b/code/modules/xenoarcheaology/finds/find_types/mask.dm
@@ -30,10 +30,11 @@
 		var/mob/living/M = src.loc
 		M.say(pick(heard_talk))
 
-/obj/item/clothing/mask/gas/poltergeist/hear_talk(mob/M, text)
+/obj/item/clothing/mask/gas/poltergeist/hear_talk(mob/speaker, list/phrases, verb = "says")
 	..()
+	var/text = compile_mixed_language_text_for(speaker, src, phrases)
 	if(heard_talk.len > max_stored_messages)
 		heard_talk.Remove(pick(heard_talk))
 	heard_talk.Add(text)
-	if(istype(src.loc, /mob/living) && world.time - last_twitch > 50)
+	if(istype(loc, /mob/living) && world.time - last_twitch > 50)
 		last_twitch = world.time

--- a/code/modules/xenoarcheaology/finds/find_types/statuette.dm
+++ b/code/modules/xenoarcheaology/finds/find_types/statuette.dm
@@ -95,10 +95,10 @@
 		else if(get_dist(W, src) > 10)
 			shadow_wights.Remove(wight_check_index)
 
-/obj/item/vampiric/hear_talk(mob/M, text)
+/obj/item/vampiric/hear_talk(mob/speaker, list/phrases, verb = "says")
 	..()
-	if(world.time - last_bloodcall >= bloodcall_interval && (M in view(7, src)))
-		bloodcall(M)
+	if(world.time - last_bloodcall >= bloodcall_interval && (speaker in view(7, src)))
+		bloodcall(speaker)
 
 /obj/item/vampiric/proc/bloodcall(var/mob/living/carbon/human/M)
 	last_bloodcall = world.time

--- a/mods/content/xenobiology/slime/say.dm
+++ b/mods/content/xenobiology/slime/say.dm
@@ -9,14 +9,14 @@
 /mob/living/slime/say_understands(mob/speaker, decl/language/speaking)
 	. = isslime(speaker) || ..()
 
-/mob/living/slime/hear_say(var/message, var/verb = "says", var/decl/language/language = null, var/alt_name = "", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol)
+/mob/living/slime/hear_say(var/list/phrases, var/verb = "says", var/alt_name = "", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol, var/scramble = FALSE)
 	var/datum/ai/slime/slime_ai = ai
 	if(istype(slime_ai) && (weakref(speaker) in slime_ai.observed_friends))
-		LAZYSET(slime_ai.speech_buffer, speaker, lowertext(html_decode(message)))
+		LAZYSET(slime_ai.speech_buffer, speaker, lowertext(html_decode(compile_mixed_language_text_for(speaker, src, phrases, colourize = FALSE))))
 	..()
 
-/mob/living/slime/hear_radio(var/message, var/verb="says", var/decl/language/language=null, var/part_a, var/part_b, var/part_c, var/mob/speaker = null, var/hard_to_hear = 0, var/vname ="")
+/mob/living/slime/hear_radio(var/list/phrases, var/verb="says", var/part_a, var/part_b, var/part_c, var/mob/speaker = null, var/hard_to_hear = 0, var/vname ="")
 	var/datum/ai/slime/slime_ai = ai
 	if(istype(slime_ai) && (weakref(speaker) in slime_ai.observed_friends))
-		LAZYSET(slime_ai.speech_buffer, speaker, lowertext(html_decode(message)))
+		LAZYSET(slime_ai.speech_buffer, speaker, lowertext(html_decode(compile_mixed_language_text_for(speaker, src, phrases, colourize = FALSE))))
 	..()

--- a/mods/species/ascent/datum/languages.dm
+++ b/mods/species/ascent/datum/languages.dm
@@ -63,9 +63,9 @@
 		scramble_cache[input] = n
 		return n
 	var/scrambled_text = ""
-	scramble_cache[input] = make_rainbow("**********************************")
-	if(scramble_cache.len > MANTID_SCRAMBLE_CACHE_LEN)
-		scramble_cache.Cut(1, scramble_cache.len-MANTID_SCRAMBLE_CACHE_LEN-1)
+	LAZYSET(scramble_cache, input, make_rainbow("**********************************"))
+	if(LAZYLEN(scramble_cache) > MANTID_SCRAMBLE_CACHE_LEN)
+		scramble_cache.Cut(1, length(scramble_cache)-MANTID_SCRAMBLE_CACHE_LEN-1)
 	return scrambled_text
 #undef MANTID_SCRAMBLE_CACHE_LEN
 

--- a/mods/species/bayliens/tajaran/datum/language.dm
+++ b/mods/species/bayliens/tajaran/datum/language.dm
@@ -21,10 +21,6 @@
 		new_name += " [..(gender,1)]"
 	return new_name
 
-//#803b56 is color
-
-/decl/language/tajaran/format_message(message, verb)
-	return "[verb], <span class='message'><span style='color: #803b56'>\"[capitalize(message)]\"</span></span>"
-
-/decl/language/tajaran/format_message_radio(message, verb)
-	return "[verb], <span style='color: #803b56'>\"[capitalize(message)]\"</span>"
+// Can't use color var as CSS is not overridable/modifiable from a modpack currently.
+/decl/language/tajaran/colourize_message(message)
+	return "<span style='color: #803b56'>[message]</span>"

--- a/mods/species/vox/datum/language.dm
+++ b/mods/species/vox/datum/language.dm
@@ -9,7 +9,7 @@
 	flags = LANG_FLAG_WHITELISTED
 	syllables = list("ti","ti","ti","hi","hi","ki","ki","ki","ki","ya","ta","ha","ka","ya","chi","cha","kah", \
 	"SKRE","AHK","EHK","RAWK","KRA","AAA","EEE","KI","II","KRI","KA")
-	machine_understands = 0
+	machine_understands = FALSE
 	shorthand = "Vox"
 
 /decl/language/vox/can_speak_special(var/mob/speaker)


### PR DESCRIPTION
## TODO ##
- [ ] Fix radio keys.
- [ ] Fix runechat.
- [ ] Fix `hear_say`.
- [ ] Fix `hear_radio`.
- [ ] Fix sign language.
- [ ] Reimplement INTRINSIC language flag.
- [ ] Rework simplemobs to use languages.

## Description of changes
Speech now passes a list of phrases and languages around instead of passing a single string. This allows say() to break speech up based on language token to produce a sequence combining several spoken languages.

## Why and what will this PR improve
It's a cool feature that servers like Polaris already have and it allows you to call people a bosh'tet in the middle of a Galcom sentence.

## Authorship
Me. Inspired by Polaris' feature but without looking at their code.

## Changelog
:cl:
tweak: You can now chain multiple language tokens in a single say command to mix your speech.
/:cl: