### PR TITLE
Fixes movement

### DIFF
--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -173,14 +173,14 @@
 
 // Is anything physically preventing movement?
 /datum/movement_handler/mob/physically_restrained/MayMove(var/mob/mover)
-	if(mob.anchored)
-		if(mover == mob)
-			to_chat(mob, SPAN_WARNING("You're anchored down!"))
-		return MOVEMENT_STOP
-
 	if(istype(mob.buckled) && !mob.buckled.buckle_movable)
 		if(mover == mob)
 			to_chat(mob, SPAN_WARNING("You're buckled to \the [mob.buckled]!"))
+		return MOVEMENT_STOP
+
+	if(mob.anchored)
+		if(mover == mob)
+			to_chat(mob, SPAN_WARNING("You're anchored down!"))
 		return MOVEMENT_STOP
 
 	if(LAZYLEN(mob.pinned))

--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -29,6 +29,6 @@
 			keybind_face_direction(movement_dir)
 		else
 			user.Move(get_step(src, movement_dir), movement_dir)
-	else
-		user.next_move_dir_add = 0
-		user.next_move_dir_sub = 0
+
+	user.next_move_dir_add = 0
+	user.next_move_dir_sub = 0

--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -29,3 +29,6 @@
 			keybind_face_direction(movement_dir)
 		else
 			user.Move(get_step(src, movement_dir), movement_dir)
+	else
+		user.next_move_dir_add = 0
+		user.next_move_dir_sub = 0

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -150,13 +150,6 @@
 	if(!mob)
 		return // Moved here to avoid nullrefs below
 
-	var/datum/movement_handler/H = mob.GetMovementHandler(/datum/movement_handler/mob/delay)
-	if(direction && H && H.MayMove() != MOVEMENT_PROCEED)
-		return
-	else
-		next_move_dir_add = 0
-		next_move_dir_sub = 0
-
 	return mob.SelfMove(direction)
 
 /mob/Process_Spacemove(var/allow_movement)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -138,7 +138,7 @@
 		src.m_flag = 1
 		if ((A != src.loc && A && A.z == src.z))
 			src.last_move = get_dir(A, src.loc)
-	
+
 	if(!inertia_moving)
 		inertia_next_move = world.time + inertia_move_delay
 		space_drift(direct ? direct : last_move)
@@ -151,7 +151,7 @@
 		return // Moved here to avoid nullrefs below
 
 	var/datum/movement_handler/H = mob.GetMovementHandler(/datum/movement_handler/mob/delay)
-	if(H && H.MayMove() != MOVEMENT_PROCEED)
+	if(direction && H && H.MayMove() != MOVEMENT_PROCEED)
 		return
 	else
 		next_move_dir_add = 0
@@ -170,7 +170,7 @@
 			return backup
 		return -1
 
-/mob/proc/space_do_move(var/allow_move, var/direction)	
+/mob/proc/space_do_move(var/allow_move, var/direction)
 	if(ismovable(allow_move))//push off things in space
 		handle_space_pushoff(allow_move, direction)
 		allow_move = -1


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

Fixes movement no longer working in one direction if you stop holding that direction key.
Prioritises the buckling message over the anchoring message in `/datum/movement_handler/mob/physically_restrained/MayMove()`

## Why and what will this PR improve

#2007 introduced a bug where you would no longer be able to move in a direction after raising that direction key due to an oversight in SSInput. This has more robust logic to avoid that.
Also stops chairs from spamming messages at you, and makes it show the right message if you try to move while buckled in a chair.

## Authorship
MoondancerPony for fixes, Afterthought for the suggestion to move the var resets to `keyLoop`
<!-- Describe original authors of changes to credit them. -->
