### PR TITLE
Always log to clients before the prefs are loaded

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -56,7 +56,10 @@ var/global/log_end= world.system_type == UNIX ? ascii2text(13) : ""
 
 /proc/to_debug_listeners(text, prefix = "DEBUG")
 	for(var/client/C in global.admins)
-		if(C.get_preference_value(/datum/client_preference/staff/show_debug_logs) == PREF_SHOW)
+		var/print_to_chat = TRUE
+		if(C.prefs?.preference_values)
+			print_to_chat = C.get_preference_value(/datum/client_preference/staff/show_debug_logs) == PREF_SHOW
+		if(print_to_chat)
 			to_chat(C, "[prefix]: [text]")
 
 /proc/log_game(text)


### PR DESCRIPTION
* to_debug_listeners() now checks if prefs are loaded so it doesn't cause the log_x procs to runtime.
* Also, now the logged messages are sent to all the relevant clients before we know if they toggled the preference on or off. After their preferences are loaded we check against them.

<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Make log_debug, log_error and etc not runtime when encountering a client with no preferences loaded yet. So log_debug can be safely used during the early stages of init. 
Also assumes we always log to the relevant clients before the "display debug log" preference value is loaded. And use the preference value after prefs are loaded.
As discussed on the discord.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship

<!-- Describe original authors of changes to credit them. -->

## Changelog

:cl:
bugfix: Logging procs don't crash when used during early init anymore.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
