### PR TITLE
lowers skill barrier on gravity restored event

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -362,7 +362,7 @@ var/global/list/mob/living/forced_ambiance_list = new
 
 	if(istype(mob,/mob/living/carbon/human/))
 		var/mob/living/carbon/human/H = mob
-		if(prob(H.skill_fail_chance(SKILL_EVA, 100, SKILL_PROF)))
+		if(prob(H.skill_fail_chance(SKILL_EVA, 100, SKILL_ADEPT)))
 			if(!MOVING_DELIBERATELY(H))
 				ADJ_STATUS(H, STAT_STUN, 6)
 				ADJ_STATUS(H, STAT_WEAK, 6)


### PR DESCRIPTION


<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

changes the skill requirement for landing on your feet during the gravity restored event from SKILL_PROF to SKILL_ADEPT

## Why and what will this PR improve

Most people probably have SKILL_ADEPT.

## Authorship

Mazian/AndromedaK22

## Changelog

:cl:
tweak: the skill requirements for landing properly during the gravity failure event has been changed from professional to trained.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
