### PR TITLE
Add master list of ignored revisions

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,27 @@
+# git blame master ignore list.
+#
+# This file contains a list of git hashes of revisions to be ignored by git
+# blame. These revisions are considered "unimportant" in that they
+# are unlikely to be what you are interested in when blaming.
+#
+# Requires git 2.23 or later (or equivalent)
+# To enable, execute: git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Instructions:
+# - Only large (generally automated) reformatting or renaming CLs should be
+#   added to this list. Do not put things here just because you feel they are
+#   trivial or unimportant. If in doubt, do not put it on this list.
+# - Precede each revision with a comment containing the first line of its log.
+#   For bulk work over many commits, place all commits in a block with a single
+#   comment at the top describing the work done in those commits.
+# - Only put full 40-character hashes on this list (not short hashes or any
+#   other revision reference).
+# - Append to the bottom of the file (revisions should be in chronological order
+#   from oldest to newest).
+# - Because you must use a hash, you need to append to this list in a follow-up
+#   CL to the actual reformatting CL that you are trying to ignore.
+
+# Major whitespace changes but nothing else
+51e1a662317e4fc5f4048bbd19375e46187dd91b
+bf996203dfc4b09f8dc4dd73b532f9ee49691776
+bfa20cdc17d1794969331c4272c4a8d7ad523a44

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,9 @@
 	},
 	"files.associations": {
 		"*.tmpl": "html"
-	}
+	},
+	"gitlens.advanced.blame.customArguments": [
+		"--ignore-revs-file",
+		".git-blame-ignore-revs"
+	]
 }


### PR DESCRIPTION
Works with GitLens in Visual Studio Code, due to the provided settings
Works with `git blame` if one execute the command listed in  `.git-blame-ignore-revs`

May eventually be supported natively on GitHub - Or at least there is a community request to add support

In case anyone is interested, I borrowed the header in `.git-blame-ignore-revs` from https://chromium.googlesource.com/chromium/src.git/+/refs/heads/main/.git-blame-ignore-revs