### PR TITLE
Adjusted structure debris gen to use parts_type for rods.

### DIFF
--- a/code/datums/repositories/atom_info.dm
+++ b/code/datums/repositories/atom_info.dm
@@ -5,6 +5,7 @@ var/global/repository/atom_info/atom_info_repository = new()
 	var/list/combined_worth_cache = list()
 	var/list/single_worth_cache =   list()
 	var/list/name_cache =           list()
+	var/list/matter_mult_cache =    list()
 
 /repository/atom_info/proc/create_key_for(var/path, var/material, var/amount)
 	. = "[path]"
@@ -41,6 +42,9 @@ var/global/repository/atom_info/atom_info_repository = new()
 	if(!name_cache[key])
 		instance = instance || get_instance_of(path, material, amount)
 		name_cache[key] = instance.name
+	if(!matter_mult_cache[key] && ispath(path, /obj))
+		var/obj/obj_instance = instance || get_instance_of(path, material, amount)
+		matter_mult_cache[key] = obj_instance.get_matter_amount_modifier()
 	if(!QDELETED(instance))
 		qdel(instance)
 
@@ -63,3 +67,8 @@ var/global/repository/atom_info/atom_info_repository = new()
 	var/key = create_key_for(path, material, amount)
 	update_cached_info_for(path, material, amount, key)
 	. = name_cache[key]
+
+/repository/atom_info/proc/get_matter_multiplier_for(var/path, var/material, var/amount)
+	var/key = create_key_for(path, material, amount)
+	update_cached_info_for(path, material, amount, key)
+	. = matter_mult_cache[key]

--- a/code/game/objects/structures/__structure.dm
+++ b/code/game/objects/structures/__structure.dm
@@ -9,6 +9,7 @@
 	var/hitsound = 'sound/weapons/smash.ogg'
 	var/breakable
 	var/parts_type
+	var/parts_amount
 	var/footstep_type
 	var/mob_offset
 

--- a/code/game/objects/structures/_structure_materials.dm
+++ b/code/game/objects/structures/_structure_materials.dm
@@ -56,14 +56,22 @@
 
 /obj/structure/proc/create_dismantled_products(var/turf/T)
 	SHOULD_CALL_PARENT(TRUE)
-	if(parts_type)
-		new parts_type(T, (material && material.type), (reinf_material && reinf_material.type))
+	if(parts_type && !ispath(parts_type, /obj/item/stack))
+		for(var/i = 1 to max(parts_amount, 1))
+			new parts_type(T, (material && material.type), (reinf_material && reinf_material.type))
 	else
 		for(var/mat in matter)
 			var/decl/material/M = GET_DECL(mat)
-			var/placing = FLOOR((matter[mat] / SHEET_MATERIAL_AMOUNT) * 0.75)
+			var/placing
+			if(isnull(parts_amount))
+				placing = (matter[mat] / SHEET_MATERIAL_AMOUNT) * 0.75
+				if(parts_type)
+					placing *= atom_info_repository.get_matter_multiplier_for(parts_type, mat, placing)
+				placing = FLOOR(placing)
+			else
+				placing = parts_amount
 			if(placing > 0)
-				M.place_dismantled_product(T, amount = placing)
+				M.place_dismantled_product(T, FALSE, placing, parts_type)
 	matter = null
 	material = null
 	reinf_material = null

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -11,6 +11,8 @@
 	handle_generic_blending = TRUE
 	tool_interaction_flags = TOOL_INTERACTION_DECONSTRUCT
 	material = /decl/material/solid/metal/steel
+	parts_type = /obj/item/stack/material/rods
+	parts_amount = 2
 
 	var/hatch_open = FALSE
 	var/decl/flooring/tiling/plated_tile
@@ -69,10 +71,6 @@
 		overlays += I
 
 /obj/structure/catwalk/create_dismantled_products(var/turf/T)
-	if(material)
-		material.create_object(get_turf(src), 2, /obj/item/stack/material/rods)
-		matter -= material.type
-		material = null
 	if(plated_tile)
 		var/plate_path = plated_tile.build_type
 		new plate_path(T)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -11,6 +11,9 @@
 	rad_resistance_modifier = 0.1
 	color = COLOR_STEEL
 	material = /decl/material/solid/metal/steel
+	parts_type = /obj/item/stack/material/rods
+	parts_amount = 2
+
 	handle_generic_blending = TRUE
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME
 	maxhealth = 20
@@ -159,8 +162,9 @@
 	else
 		set_density(0)
 		if(material)
-			material.create_object(get_turf(src), 1,/obj/item/stack/material/rods)
+			material.create_object(get_turf(src), 1, parts_type)
 		destroyed = TRUE
+		parts_amount = 1
 		update_icon()
 
 /obj/structure/grille/attackby(obj/item/W, mob/user)
@@ -279,10 +283,3 @@
 		var/obj/structure/grille/F = new(loc, ST.material.type)
 		user.visible_message(SPAN_NOTICE("\The [user] finishes building \a [F]."))
 		F.add_fingerprint(user)
-
-/obj/structure/grille/create_dismantled_products(var/turf/T)
-	if(material)
-		material.create_object(get_turf(src), (destroyed ? 1 : 2), /obj/item/stack/material/rods)
-		matter -= material.type
-		material = null
-	. = ..()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -282,6 +282,7 @@
 		..()
 	return
 
+// TODO: generalize to matter list and parts_type.
 /obj/structure/window/create_dismantled_products(turf/T)
 	SHOULD_CALL_PARENT(FALSE)
 	var/obj/item/stack/material/S = material.create_object(loc, is_fulltile() ? 4 : 2)

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -376,10 +376,10 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 
 // General wall debris product placement.
 // Not particularly necessary aside from snowflakey cult girders.
-/decl/material/proc/place_dismantled_product(var/turf/target, var/is_devastated, var/amount = 2)
+/decl/material/proc/place_dismantled_product(var/turf/target, var/is_devastated, var/amount = 2, var/drop_type)
 	amount = is_devastated ? FLOOR(amount * 0.5) : amount
 	if(amount > 0)
-		return create_object(target, amount)
+		return create_object(target, amount, object_type = drop_type)
 
 // As above.
 /decl/material/proc/place_shard(var/turf/target)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -214,6 +214,7 @@ By design, d1 is the smallest direction and d2 is the highest
 			return 1
 	return 0
 
+// TODO: generalize to matter list and parts_type.
 /obj/structure/cable/create_dismantled_products(turf/T)
 	SHOULD_CALL_PARENT(FALSE)
 	new /obj/item/stack/cable_coil(loc, (d1 ? 2 : 1), color)


### PR DESCRIPTION
Moves rod and catwalk deconstruction into the shared proc instead of doing it bespoke in overrides. Needed for #2034.