### PR TITLE
Minor movement handler refactor.

### DIFF
--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -1,24 +1,3 @@
-// Movement relayed to self handling
-/datum/movement_handler/mob/relayed_movement
-	var/prevent_host_move = FALSE
-	var/list/allowed_movers
-
-/datum/movement_handler/mob/relayed_movement/MayMove(var/mob/mover, var/is_external)
-	if(is_external)
-		return MOVEMENT_PROCEED
-	if(mover == mob && !(prevent_host_move && LAZYLEN(allowed_movers) && !LAZYISIN(allowed_movers, mover)))
-		return MOVEMENT_PROCEED
-	if(LAZYISIN(allowed_movers, mover))
-		return MOVEMENT_PROCEED
-
-	return MOVEMENT_STOP
-
-/datum/movement_handler/mob/relayed_movement/proc/AddAllowedMover(var/mover)
-	LAZYDISTINCTADD(allowed_movers, mover)
-
-/datum/movement_handler/mob/relayed_movement/proc/RemoveAllowedMover(var/mover)
-	LAZYREMOVE(allowed_movers, mover)
-
 // Admin object possession
 /datum/movement_handler/mob/admin_possess/DoMove(var/direction)
 	if(QDELETED(mob.control_object))
@@ -102,24 +81,7 @@
 
 // Buckle movement
 /datum/movement_handler/mob/buckle_relay/DoMove(var/direction, var/mover)
-	// TODO: Datumlize buckle-handling
-	if(istype(mob.buckled, /obj/vehicle))
-		//drunk driving
-		if(HAS_STATUS(mob, STAT_CONFUSE) && prob(20)) //vehicles tend to keep moving in the same direction
-			direction = turn(direction, pick(90, -90))
-		mob.buckled.relaymove(mob, direction)
-		return MOVEMENT_HANDLED
-
-	if(mob.buckled) // Wheelchair driving!
-		if(isspaceturf(mob.loc))
-			return // No wheelchair driving in space
-		if(istype(mob.buckled, /obj/structure/bed/chair/wheelchair))
-			. = MOVEMENT_HANDLED
-			if(!mob.has_held_item_slot())
-				return // No hands to drive your chair? Tough luck!
-			//drunk wheelchair driving
-			direction = mob.AdjustMovementDirection(direction)
-			mob.buckled.DoMove(direction, mob)
+	return mob?.buckled?.handle_buckled_relaymove(src, mob, direction, mover)
 
 /datum/movement_handler/mob/buckle_relay/MayMove(var/mover)
 	if(mob.buckled)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -326,3 +326,6 @@
 */
 /atom/movable/proc/keybind_face_direction(direction)
 	return
+
+/atom/movable/proc/handle_buckled_relaymove(var/datum/movement_handler/mh, var/mob/mob, var/direction, var/mover)
+	return

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -4,7 +4,11 @@
 	icon_state = "wheelchair"
 	anchored = FALSE
 	buckle_movable = TRUE
-	movement_handlers = list(/datum/movement_handler/deny_multiz, /datum/movement_handler/delay = list(5), /datum/movement_handler/move_relay_self)
+	movement_handlers = list(
+		/datum/movement_handler/deny_multiz, 
+		/datum/movement_handler/delay = list(5), 
+		/datum/movement_handler/move_relay_self
+	)
 
 	var/item_form_type = /obj/item/wheelchair_kit
 	var/bloodiness
@@ -119,6 +123,16 @@
 		visible_message(SPAN_NOTICE("<b>[usr]</b> collapses \the [src.name]."))
 		K.add_fingerprint(usr)
 		qdel(src)
+
+/obj/structure/bed/chair/wheelchair/handle_buckled_relaymove(var/datum/movement_handler/mh, var/mob/mob, var/direction, var/mover)
+	if(isspaceturf(loc))
+		return // No wheelchair driving in space
+	. = MOVEMENT_HANDLED
+	if(!mob.has_held_item_slot())
+		return // No hands to drive your chair? Tough luck!
+	//drunk wheelchair driving
+	direction = mob.AdjustMovementDirection(direction)
+	DoMove(direction, mob)
 
 /obj/item/wheelchair_kit
 	name = "compressed wheelchair kit"

--- a/code/modules/admin/quantum_mechanic.dm
+++ b/code/modules/admin/quantum_mechanic.dm
@@ -56,7 +56,6 @@
 	universal_understand = TRUE
 	var/fall_override = TRUE
 	movement_handlers = list(
-		/datum/movement_handler/mob/relayed_movement,
 		/datum/movement_handler/mob/death,
 		/datum/movement_handler/mob/conscious,
 		/datum/movement_handler/mob/eye,

--- a/code/modules/mob/living/silicon/ai/ai_movement.dm
+++ b/code/modules/mob/living/silicon/ai/ai_movement.dm
@@ -1,6 +1,5 @@
 /mob/living/silicon/ai
 	movement_handlers = list(
-		/datum/movement_handler/mob/relayed_movement,
 		/datum/movement_handler/mob/death,
 		/datum/movement_handler/mob/conscious,
 		/datum/movement_handler/mob/eye,

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -10,7 +10,6 @@
 	virtual_mob = /mob/observer/virtual/mob
 
 	movement_handlers = list(
-		/datum/movement_handler/mob/relayed_movement,
 		/datum/movement_handler/mob/death,
 		/datum/movement_handler/mob/conscious,
 		/datum/movement_handler/mob/eye,

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -340,3 +340,10 @@
 //-------------------------------------------------------
 /obj/vehicle/proc/update_stats()
 	return
+
+/obj/vehicle/handle_buckled_relaymove(var/datum/movement_handler/mh, var/mob/mob, var/direction, var/mover)
+	//drunk driving
+	if(HAS_STATUS(mob, STAT_CONFUSE) && prob(20)) //vehicles tend to keep moving in the same direction
+		direction = turn(direction, pick(90, -90))
+	relaymove(mob, direction)
+	return MOVEMENT_HANDLED


### PR DESCRIPTION
Split out of #2031, just some housekeeping. The removed type is half-implemented and was intended for borers before Psi realized they swap clients instead of relaying movement.