### PR TITLE
Fix APCs sometimes spamming a lot of runtimes when ending up in nullspace

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -966,10 +966,7 @@ var/global/list/all_apcs = list()
 	//Make sure to resume processing if our area changed to something else than null
 	if(QDELETED(src))
 		return
-	if(area)
-		if(is_processing && !(processing_flags & MACHINERY_PROCESS_SELF))
-			processing_flags |= MACHINERY_PROCESS_SELF //don't use START_PROCESSING_MACHINE here or it'll print a stack trace for being already in the processing list
-		else if(!is_processing)
-			START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
+	if(area && !(processing_flags & MACHINERY_PROCESS_SELF))
+		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 
 #undef APC_UPDATE_ICON_COOLDOWN

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -576,7 +576,7 @@ var/global/list/all_apcs = list()
 	if (!ui)
 		// the ui does not exist, so we'll create a new() one
 		// for a list of parameters and their descriptions see the code docs in \code\modules\nano\nanoui.dm
-		ui = new(user, src, ui_key, "apc.tmpl", "[area.name] - APC", 520, data["siliconUser"] ? 465 : 440)
+		ui = new(user, src, ui_key, "apc.tmpl", "[area? area.name : "ERROR"] - APC", 520, data["siliconUser"] ? 465 : 440)
 		// when the ui is first opened this is the data it will use
 		ui.set_initial_data(data)
 		// open the new ui window
@@ -961,6 +961,15 @@ var/global/list/all_apcs = list()
 			environ = state
 	force_update_channels()
 
-
+/obj/machinery/power/apc/area_changed()
+	. = ..()
+	//Make sure to resume processing if our area changed to something else than null
+	if(QDELETED(src))
+		return
+	if(area)
+		if(is_processing && !(processing_flags & MACHINERY_PROCESS_SELF))
+			processing_flags |= MACHINERY_PROCESS_SELF //don't use START_PROCESSING_MACHINE here or it'll print a stack trace for being already in the processing list
+		else if(!is_processing)
+			START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 
 #undef APC_UPDATE_ICON_COOLDOWN

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -970,3 +970,4 @@ var/global/list/all_apcs = list()
 		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 
 #undef APC_UPDATE_ICON_COOLDOWN
+ 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -730,7 +730,7 @@ var/global/list/all_apcs = list()
 		. += area.usage(ENVIRON)
 
 /obj/machinery/power/apc/Process()
-	if(!area.requires_power)
+	if(!area?.requires_power)
 		return PROCESS_KILL
 
 	if(stat & (BROKEN|MAINT))


### PR DESCRIPTION
## Description of changes

Sometimes when doing admin delete, or some other times when players attempt constructing in space, APCs would end up with a null area, and slow things down spamming runtimes every ticks. Making debugging an absolute pain in the ass. This ensures the APC just stops processing when its not in a valid area instead of hanging machine processing. 
This is just to prevent the runtime spam though, not preventing the APC from being in a null area, which is most likely only an issue on outreach anyways.

## Changelog

:cl:
bugfix: Prevent APC runtime spam when in a null area.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
