### PR TITLE
(Outreach port) Added a skillset path check to mob/Initialize

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -48,7 +48,8 @@
 
 /mob/Initialize()
 	. = ..()
-	skillset = new skillset(src)
+	if(ispath(skillset))
+		skillset = new skillset(src)
 	if(!move_intent)
 		move_intent = move_intents[1]
 	if(ispath(move_intent))


### PR DESCRIPTION
## Description of changes

Just adds a ispath() in mob/Initialize() to make sure we're not trying to call new on something that's not a path. Its probably unlikely to be a problem on nebula itself, but since we load a saved skillset before initialize we end up with having to do variable swaps when we could avoid it all with this simple check. And we can't override it since its part of the initialize chain.

## Changelog

:cl:
bugfix: Fix skillset not being a path on mob init crashing mob/Initialize().
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
