### PR TITLE
Various tweaks made during setting up the flooded Europa map.

### DIFF
--- a/code/__defines/fluids.dm
+++ b/code/__defines/fluids.dm
@@ -32,6 +32,6 @@
 	if(!SSfluids.fluid_images[img_state]) SSfluids.fluid_images[img_state] = image('icons/effects/liquids.dmi',img_state); \
 	add_overlay(SSfluids.fluid_images[img_state]);
 
-#define FLUID_MAX_ALPHA 240
+#define FLUID_MAX_ALPHA 200
 #define FLUID_MIN_ALPHA 45
 #define TANK_WATER_MULTIPLIER 5

--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -4,6 +4,7 @@
 	footstep_type = /decl/footsteps/asteroid
 	icon_state = "0"
 	layer = PLATING_LAYER
+	open_turf_type = /turf/exterior/open
 	var/diggable = 1
 	var/dirt_color = "#7c5e42"
 	var/possible_states = 0

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -1,6 +1,7 @@
 /turf/simulated
 	name = "station"
 	initial_gas = list(/decl/material/gas/oxygen = MOLES_O2STANDARD, /decl/material/gas/nitrogen = MOLES_N2STANDARD)
+	open_turf_type = /turf/simulated/open
 	var/wet = 0
 	var/image/wet_overlay = null
 	var/to_be_destroyed = 0 //Used for fire, if a melting temperature was reached, it will be destroyed

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -29,11 +29,10 @@
 	var/movement_delay
 
 	var/fluid_can_pass
-	var/obj/effect/flood/flood_object
 	var/fluid_blocked_dirs = 0
 	var/flooded // Whether or not this turf is absolutely flooded ie. a water source.
 	var/footstep_type
-
+	var/open_turf_type
 	var/tmp/changing_turf
 
 	var/prev_type // Previous type of the turf, prior to turf translation.
@@ -77,11 +76,14 @@
 	update_flood_overlay()
 
 /turf/proc/update_flood_overlay()
-	if(is_flooded(absolute = TRUE))
-		if(!flood_object)
-			flood_object = new(src)
-	else if(flood_object)
-		QDEL_NULL(flood_object)
+	if(flooded)
+		if(!locate(/obj/effect/flood) in src)
+			new /obj/effect/flood(src)
+		for(var/obj/effect/fluid/fluid in src)
+			qdel(fluid)
+	else
+		for(var/obj/effect/flood/flood in src)
+			qdel(flood)
 
 /turf/Destroy()
 

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -1,8 +1,10 @@
 /turf/proc/ReplaceWithLattice(var/material)
-	var base_turf = get_base_turf_by_area(src);
+	var/base_turf = open_turf_type
+	if(!base_turf || HasBelow(z))
+		base_turf = get_base_turf_by_area(src);
 	if(type != base_turf)
 		src.ChangeTurf(get_base_turf_by_area(src))
-	if(!locate(/obj/structure/lattice) in src)
+	if(!(locate(/obj/structure/lattice) in src))
 		new /obj/structure/lattice(src, material)
 
 // Removes all signs of lattice on the pos of the turf -Donkieyo
@@ -43,6 +45,7 @@
 	var/old_affecting_lights = affecting_lights
 	var/old_lighting_overlay = lighting_overlay
 	var/old_dynamic_lighting = TURF_IS_DYNAMICALLY_LIT_UNSAFE(src)
+	var/old_flooded =          flooded
 
 	changing_turf = TRUE
 
@@ -64,6 +67,10 @@
 			W.fire = old_fire
 		else if(old_fire)
 			qdel(old_fire)
+
+	if(old_flooded != W.flooded)
+		W.flooded = old_flooded
+		W.fluid_update()
 
 	// Raise appropriate events.
 	W.post_change()

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -20,8 +20,6 @@
 /turf/proc/make_flooded()
 	if(!flooded)
 		flooded = TRUE
-		for(var/obj/effect/fluid/F in src)
-			qdel(F)
 		update_icon()
 		fluid_update()
 
@@ -46,8 +44,9 @@
 	set waitfor = 0
 
 	if(flooded)
-		if(istype(flood_object))
-			flick("ocean-bubbles", flood_object)
+		var/obj/effect/flood/flood = locate() in src
+		if(istype(flood))
+			flick("ocean-bubbles", flood)
 		return
 
 	var/obj/effect/fluid/F = locate() in src
@@ -68,12 +67,9 @@
 	// Wake up ourself!
 	if(flooded)
 		ADD_ACTIVE_FLUID_SOURCE(src)
-		for(var/obj/effect/fluid/F in src)
-			qdel(F)
 	else
-		REMOVE_ACTIVE_FLUID_SOURCE(src)
-		for(var/obj/effect/fluid/F in src)
-			ADD_ACTIVE_FLUID(F)
+		REMOVE_ACTIVE_FLUID_SOURCE(src)	
+	update_flood_overlay()
 
 /turf/proc/add_fluid(var/fluid_type, var/fluid_amount, var/defer_update)
 	var/obj/effect/fluid/F = locate() in src

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -130,7 +130,6 @@
 /mob/living/carbon/human/Move()
 	. = ..()
 	if(.) //We moved
-		species.handle_exertion(src)
 
 		var/stamina_cost = 0
 		for(var/obj/item/grab/G AS_ANYTHING in get_active_grabs())
@@ -140,7 +139,7 @@
 			adjust_stamina(stamina_cost)
 
 		handle_leg_damage()
-
+		species.handle_post_move(src)
 		if(client)
 			var/turf/B = GetAbove(src)
 			up_hint.icon_state = "uphint[(B ? B.is_open() : 0)]"

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -340,7 +340,7 @@ var/global/list/damage_icon_parts = list()
 		for(var/M in part.markings)
 			icon_key += "[M][part.markings[M]]"
 		if(part)
-			icon_key += "[part.bodytype.get_icon_cache_uid(part.owner)]"
+			icon_key += "[part.bodytype.get_icon_cache_uid(part.owner)][part.render_alpha]"
 			icon_key += "[part.dna.GetUIState(DNA_UI_GENDER)]"
 			icon_key += "[part.skin_tone]"
 			if(part.skin_colour)

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -60,7 +60,11 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 			mind = new /datum/mind(key)
 			mind.current = src
 	if(!T)
-		T = pick(global.latejoin_locations | global.latejoin_cryo_locations | global.latejoin_gateway_locations)
+		var/list/spawn_locs = global.latejoin_locations | global.latejoin_cryo_locations | global.latejoin_gateway_locations
+		if(length(spawn_locs))
+			T = pick(spawn_locs)
+		else
+			T = locate(1, 1, 1) 
 	forceMove(T)
 
 	if(!name)							//To prevent nameless ghosts

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -39,6 +39,7 @@
 	var/skin_blend = ICON_ADD          // How the skin colour is applied.
 	var/hair_colour                    // hair colour
 	var/list/markings = list()         // Markings (body_markings) to apply to the icon
+	var/render_alpha = 255
 
 	// Wound and structural data.
 	var/wound_update_accuracy = 1      // how often wounds should be updated, a higher number means less often
@@ -107,7 +108,7 @@
 		replaced(owner)
 		sync_colour_to_human(owner)
 	get_icon()
-	slowdown = species.get_slowdown(owner)
+	slowdown = species.get_slowdown(owner) // TODO make this a getter so octopodes can override it based on flooding
 	if(species)
 		for(var/attack_type in species.unarmed_attacks)
 			var/decl/natural_attack/attack = GET_DECL(attack_type)

--- a/code/modules/organs/external/_external_icons.dm
+++ b/code/modules/organs/external/_external_icons.dm
@@ -83,7 +83,7 @@ var/global/list/limb_icon_cache = list()
 /obj/item/organ/external/on_update_icon(var/regenerate = 0)
 
 	icon_state = "[icon_name]"
-	icon_cache_key = "[icon_state]_[species ? species.name : "unknown"]"
+	icon_cache_key = "[icon_state]_[species ? species.name : "unknown"][render_alpha]"
 	if(model)
 		icon_cache_key += "_model_[model]"
 
@@ -101,6 +101,10 @@ var/global/list/limb_icon_cache = list()
 			icon_cache_key += "[M][markings[M]]"
 
 	set_dir(EAST, TRUE)
+
+	if(render_alpha < 255)
+		mob_icon += rgb(,,,render_alpha)
+
 	icon = mob_icon
 
 /obj/item/organ/external/proc/get_icon()

--- a/code/modules/pronouns/_pronouns.dm
+++ b/code/modules/pronouns/_pronouns.dm
@@ -43,7 +43,7 @@
 /atom/proc/get_pronouns(var/ignore_coverings)
 	. = get_pronouns_by_gender(gender)
 
-/atom/proc/set_gender(var/new_gender, var/update_body = FALSE)
+/atom/proc/set_gender(var/new_gender = NEUTER, var/update_body = FALSE)
 	if(gender != new_gender)
 		gender = new_gender
 		if(update_body)

--- a/code/modules/random_map/noise/seafloor.dm
+++ b/code/modules/random_map/noise/seafloor.dm
@@ -17,7 +17,8 @@
 	flooded = TRUE
 
 /datum/random_map/noise/seafloor/get_appropriate_path(var/value)
-	switch(value)
+	var/val = min(9,max(0,round((value/cell_range)*10)))
+	switch(val)
 		if(6)
 			return /turf/exterior/mud/flooded
 		if(7 to 9)

--- a/code/modules/reagents/chems/chems_blood.dm
+++ b/code/modules/reagents/chems/chems_blood.dm
@@ -11,6 +11,7 @@
 	value = 2.5
 	opacity = 1
 	min_fluid_opacity = FLUID_MAX_ALPHA
+	max_fluid_opacity = 240
 
 	chilling_products = list(
 		/decl/material/liquid/coagulated_blood = 1

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -223,12 +223,7 @@
 	var/standing_jump_range = 2
 	var/list/maneuvers = list(/decl/maneuver/leap)
 
-	var/list/available_cultural_info = list(
-		TAG_CULTURE =   list(/decl/cultural_info/culture/other),
-		TAG_HOMEWORLD = list(/decl/cultural_info/location/stateless),
-		TAG_FACTION =   list(/decl/cultural_info/faction/other),
-		TAG_RELIGION =  list(/decl/cultural_info/religion/other)
-	)
+	var/list/available_cultural_info =            list()
 	var/list/force_cultural_info =                list()
 	var/list/default_cultural_info =              list()
 	var/list/additional_available_cultural_info = list()
@@ -822,6 +817,9 @@
 			// This assumes that if a pain-level has been defined it also has a list of emotes to go with it
 			var/decl/emote/E = GET_DECL(pick(pain_emotes))
 			return E.key
+
+/decl/species/proc/handle_post_move(var/mob/living/carbon/human/H)
+	handle_exertion(H)
 
 /decl/species/proc/handle_exertion(mob/living/carbon/human/H)
 	if (!exertion_effect_chance)

--- a/code/modules/species/station/human.dm
+++ b/code/modules/species/station/human.dm
@@ -14,13 +14,6 @@
 		/decl/bodytype/human/masculine
 	)
 
-	available_cultural_info = list(
-		TAG_CULTURE = list(
-			/decl/cultural_info/culture/other,
-			/decl/cultural_info/culture/human
-		)
-	)
-
 	exertion_effect_chance = 10
 	exertion_hydration_scale = 1
 	exertion_charge_scale = 1


### PR DESCRIPTION
- Makes flooded turfs less opaque.
- Sets a default open type for sim and exterior turfs, for use when making lattices (ex. ladders)
- Removes the flood_object ref and makes the flood/fluid overlap swapping more robust (avoids duplicate overlays).
- Properly transfers flooded turf status in ChangeTurf().
- Adds support for movement based species logic and variable alpha on limbs (octopus supporting code).
- Safeguards against no latejoin logs in ghost join proc.
- Adds a default gender to set_gender().
- Fixes an issue with seafloor random map gen.
- Removes trailing human species culture setting.