### PR TITLE
Added more instructions to xenoarch triggers

### DIFF
--- a/code/modules/xenoarcheaology/artifacts/triggers/chemical.dm
+++ b/code/modules/xenoarcheaology/artifacts/triggers/chemical.dm
@@ -5,6 +5,8 @@
 /datum/artifact_trigger/chemical/New()
 	if(isnull(required_chemicals))
 		required_chemicals = list(pick(/decl/material/liquid/acid, /decl/material/liquid/bromide, /decl/material/liquid/water))
+		var/decl/material/M = GET_DECL(required_chemicals[1])
+		name = "presence of [M.name]"
 
 /datum/artifact_trigger/chemical/copy()
 	var/datum/artifact_trigger/chemical/C = ..()
@@ -14,7 +16,7 @@
 	. = ..()
 	if(istype(O, /obj/item/chems))
 		for(var/reagent in required_chemicals)
-			if(O.reagents.remove_reagent(reagent, 5))
+			if(O.reagents.remove_reagent(reagent, 1))
 				return TRUE
 
 /datum/artifact_trigger/chemical/water

--- a/code/modules/xenoarcheaology/artifacts/triggers/gas.dm
+++ b/code/modules/xenoarcheaology/artifacts/triggers/gas.dm
@@ -6,6 +6,8 @@
 /datum/artifact_trigger/gas/New()
 	if(!gas_needed)
 		gas_needed = list(pick(subtypesof(/decl/material/gas)) = rand(1,10))
+	var/decl/material/gas/G = GET_DECL(gas_needed[1])
+	name = "concentration of [G.name]"
 
 /datum/artifact_trigger/gas/copy()
 	var/datum/artifact_trigger/gas/C = ..()
@@ -19,17 +21,13 @@
 			return FALSE
 
 /datum/artifact_trigger/gas/co2
-	name = "concentration of CO2"
 	gas_needed = list(/decl/material/gas/carbon_dioxide = 5)
 
 /datum/artifact_trigger/gas/o2
-	name = "concentration of oxygen"
 	gas_needed = list(/decl/material/gas/oxygen = 5)
 
 /datum/artifact_trigger/gas/n2
-	name = "concentration of nitrogen"
 	gas_needed = list(/decl/material/gas/nitrogen = 5)
 
 /datum/artifact_trigger/gas/hydrogen
-	name = "concentration of hydrogen"
 	gas_needed = list(/decl/material/gas/hydrogen = 5)

--- a/code/modules/xenoarcheaology/artifacts/triggers/temperature.dm
+++ b/code/modules/xenoarcheaology/artifacts/triggers/temperature.dm
@@ -9,6 +9,15 @@
 		min_temp = rand(T0C - 100, T0C + 200)
 		max_temp = min_temp + rand(10, 30)
 
+	if (max_temp <= T0C)
+		name = "low temperature"
+	else if (min_temp >= T20C)
+		name = "high temperature"
+	else
+		name = "room temperature"
+	if(min_temp > -INFINITY && max_temp < INFINITY)
+		name += " (specific range)"
+
 /datum/artifact_trigger/temperature/copy()
 	var/datum/artifact_trigger/temperature/C = ..()
 	C.min_temp = min_temp
@@ -18,24 +27,18 @@
 	return gas.temperature >= min_temp && gas.temperature <= max_temp
 
 /datum/artifact_trigger/temperature/on_hit(obj/O, mob/user)
-	return O.temperature >= min_temp && O.temperature <= max_temp
+	. = O.get_heat() >= min_temp && O.get_heat() <= max_temp
+	if(max_temp > T20C) 
+		. = . || O.isflamesource()
 
-/datum/artifact_trigger/temperature/cold
-	name = "low temperature"
+/datum/artifact_trigger/temperature/on_explosion(severity)
+	if(max_temp > T20C)
+		return TRUE
 
 /datum/artifact_trigger/temperature/cold/New()
 	min_temp = -INFINITY
 	max_temp = rand(T0C - 100, T0C)
 
-/datum/artifact_trigger/temperature/heat
-	name = "high temperature"
-
 /datum/artifact_trigger/temperature/heat/New()
 	min_temp = rand(T0C + 20, T0C + 300)
 	max_temp = INFINITY
-
-/datum/artifact_trigger/temperature/heat/on_hit(obj/O, mob/user)
-	. = ..() || O.get_heat() >= T100C || O.isflamesource()
-
-/datum/artifact_trigger/temperature/heat/on_explosion(severity)
-	return TRUE


### PR DESCRIPTION
Random gas/chemical triggers now list the name of trigger like specific subtypes do
Temperature effects are now auto-named to reflect what kind of temperature we're talking about. Merged subtypes into main one mostly

<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve

```
The purpose of all this is to avoid giving the player unknown or very hard to activate triggers so that the artifact's effects can be more often seen and interacted with.```

## Authorship

<!-- Describe original authors of changes to credit them. -->
Mostly theft of https://github.com/Baystation12/Baystation12/pull/31121 by MuckerMayhem 

## Changelog

:cl:
tweak: Added more hints to xenoarch effects
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
