### PR TITLE
Reworking skybox scaling to take client scale into account.

### DIFF
--- a/code/_onclick/hud/skybox.dm
+++ b/code/_onclick/hud/skybox.dm
@@ -1,5 +1,4 @@
-#define SKYBOX_MAX_BOUND 736
-
+var/global/const/SKYBOX_DIMENSION = 736 // Largest measurement for icon sides, used for offsets/scaling
 /obj/skybox
 	name = "skybox"
 	mouse_opacity = 0
@@ -7,13 +6,14 @@
 	simulated = FALSE
 	plane = SKYBOX_PLANE
 	blend_mode = BLEND_MULTIPLY
-	var/base_x_dim = 7
-	var/base_y_dim = 7
-	var/base_offset_x = -224 // -(world.view x dimension * world.icon_size)
-	var/base_offset_y = -224 // -(world.view y dimension * world.icon_size)
+	screen_loc = "CENTER,CENTER"
+	transform_animate_time = 0
+	var/static/max_view_dim
+	var/static/const/parallax_bleed_percent = 0.2 // 20% parallax offset when going from x=1 to x=max
 
 /obj/skybox/Initialize()
-	screen_loc = "CENTER:[base_offset_x],CENTER:[base_offset_y]"
+	if(!max_view_dim)
+		max_view_dim = CEILING(SKYBOX_DIMENSION / world.icon_size)
 	. = ..()
 
 /client
@@ -22,35 +22,45 @@
 /client/proc/set_skybox_offsets(var/x_dim, var/y_dim)
 	if(!skybox)
 		update_skybox()
-	if(skybox)
-		skybox.base_x_dim = x_dim
-		skybox.base_y_dim = y_dim
-		skybox.base_offset_x = -((world.icon_size * skybox.base_x_dim)/2)
-		skybox.base_offset_y = -((world.icon_size * skybox.base_y_dim)/2)
-		
-		// Check if the skybox needs to be scaled to fit large displays.
-		var/new_max_tile_bound = max(skybox.base_x_dim, skybox.base_y_dim)
-		var/old_max_tile_bound = SKYBOX_MAX_BOUND/world.icon_size
-		if(new_max_tile_bound > old_max_tile_bound)
-			var/matrix/M = matrix()
-			M.Scale(1 + (new_max_tile_bound/old_max_tile_bound))
-			skybox.transform = M
-		else
-			skybox.transform = null
-		update_skybox()
+	var/scale_against = 1
+	if(isnum(view))
+		var/base_dim = min(view*2, skybox.max_view_dim)
+		scale_against = Clamp(base_dim, 1, skybox.max_view_dim) * world.icon_size
+		skybox.screen_loc = "CENTER:-[view * world.icon_size],CENTER:-[view * world.icon_size]"
+	else
+		var/base_x_dim = min(x_dim, skybox.max_view_dim)
+		var/base_y_dim = min(y_dim, skybox.max_view_dim)
+		scale_against = Clamp(max(base_x_dim, base_y_dim), 1, skybox.max_view_dim) * world.icon_size
+		skybox.screen_loc = "CENTER:-[round((x_dim * world.icon_size) / 2)],CENTER:-[round((y_dim * world.icon_size) / 2)]"
+	skybox.set_scale(skybox.parallax_bleed_percent + max((scale_against / SKYBOX_DIMENSION), 1))
+	update_skybox()
 
 /client/proc/update_skybox(rebuild)
+
+	var/turf/T = get_turf(eye)
+	if(!T)
+		return
+
 	if(!skybox)
 		skybox = new()
 		screen += skybox
-		rebuild = 1
-	var/turf/T = get_turf(eye)
-	if(T)
-		if(rebuild)
-			skybox.overlays.Cut()
-			skybox.overlays += SSskybox.get_skybox(T.z)
-			screen |= skybox
-		skybox.screen_loc = "CENTER:[skybox.base_offset_x - T.x],CENTER:[skybox.base_offset_y - T.y]"
+		rebuild = TRUE
+		
+	if(rebuild)
+		skybox.overlays.Cut()
+		var/image/I = SSskybox.get_skybox(T.z)
+		I.appearance_flags |= PIXEL_SCALE
+		skybox.overlays += I
+		screen |= skybox
+		set_skybox_offsets(last_view_x_dim, last_view_y_dim)
+		return
+
+	if(skybox.parallax_bleed_percent > 0)
+		var/matrix/M = skybox.update_transform() || matrix()
+		var/x_translate = -((T.x/world.maxx)-0.5) * skybox.parallax_bleed_percent * SKYBOX_DIMENSION
+		var/y_translate = -((T.y/world.maxy)-0.5) * skybox.parallax_bleed_percent * SKYBOX_DIMENSION
+		M.Translate(x_translate, y_translate)
+		skybox.transform = M
 
 /mob/Move()
 	var/old_z = get_z(src)
@@ -63,5 +73,3 @@
 	. = ..()
 	if(. && client)
 		client.update_skybox(old_z != get_z(src))
-
-#undef SKYBOX_MAX_BOUND

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -588,4 +588,8 @@ its easier to just keep the beam vertical.
 	var/matrix/M = matrix()
 	M.Scale(icon_scale_x, icon_scale_y)
 	M.Turn(icon_rotation)
-	animate(src, transform = M, transform_animate_time)
+	if(transform_animate_time)
+		animate(src, transform = M, transform_animate_time)
+	else
+		transform = M
+	return transform

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -236,7 +236,11 @@ Please contact me on #coderbus IRC. ~Carn x
 	else
 		M.Scale(desired_scale_x, desired_scale_y)
 		M.Translate(0, 16*(desired_scale_y-1))
-	animate(src, transform = M, time = transform_animate_time)
+	if(transform_animate_time)
+		animate(src, transform = M, time = transform_animate_time)
+	else
+		transform = M
+	return transform
 
 var/global/list/damage_icon_parts = list()
 


### PR DESCRIPTION
## Description of changes
- Changes skybox scaling to be more reliable and to make use of scaling procs.
- Changes skybox parallax calc to take rescaled skybox into account.

Still working on getting the offsets to actually work, this is WIP and also depends on #2059. I am struggling with the math involved in calculating the scale and offset to center the skybox and allow sufficient wiggle room, so any input is appreciated.

## Why and what will this PR improve
This will fix the skybox looking far too huge or not being large enough to cover the backdrop.

## Authorship
Myself.

## Changelog
Nothing player facing.