### PR TITLE
Converts bodytype_restricted to a bitfield.

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -256,6 +256,10 @@
 #define SPECIES_ALIEN            "Humanoid"
 #define SPECIES_GOLEM            "Golem"
 
+#define BODY_FLAG_EXCLUDE        BITFLAG(0)
+#define BODY_FLAG_HUMANOID       BITFLAG(1)
+#define BODY_FLAG_MONKEY         BITFLAG(2)
+
 #define BODYTYPE_HUMANOID        "humanoid body"
 #define BODYTYPE_OTHER           "alien body"
 #define BODYTYPE_MONKEY          "small humanoid body"

--- a/code/game/gamemodes/wizard/servant_items/caretaker.dm
+++ b/code/game/gamemodes/wizard/servant_items/caretaker.dm
@@ -9,7 +9,7 @@
 		energy = ARMOR_ENERGY_SMALL, 
 		rad = ARMOR_RAD_SHIELDED
 	)
-	bodytype_restricted = list(BODYTYPE_HUMANOID)
+	bodytype_equip_flags = BODY_FLAG_HUMANOID
 	flags_inv = HIDEEARS | BLOCKHAIR
 
 /obj/item/clothing/suit/caretakercloak
@@ -28,7 +28,7 @@
 	name = "caretaker's jumpsuit"
 	desc = "A holy jumpsuit. Treat it well."
 	icon = 'icons/clothing/under/caretaker.dmi'
-	bodytype_restricted = list(BODYTYPE_HUMANOID)
+	bodytype_equip_flags = BODY_FLAG_HUMANOID
 
 /obj/item/clothing/shoes/dress/caretakershoes
 	name = "black leather shoes"

--- a/code/game/gamemodes/wizard/servant_items/champion.dm
+++ b/code/game/gamemodes/wizard/servant_items/champion.dm
@@ -11,7 +11,7 @@
 		bomb = ARMOR_BOMB_RESISTANT,
 		bio = ARMOR_BIO_MINOR
 		)
-	bodytype_restricted = list(BODYTYPE_HUMANOID)
+	bodytype_equip_flags = BODY_FLAG_HUMANOID
 
 /obj/item/clothing/suit/champarmor
 	name = "champion's armor"
@@ -37,7 +37,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_MINOR
 	)
-	bodytype_restricted = list(BODYTYPE_HUMANOID)
+	bodytype_equip_flags = BODY_FLAG_HUMANOID
 
 /obj/item/clothing/shoes/jackboots/medievalboots
 	name = "leather boots"

--- a/code/game/gamemodes/wizard/servant_items/familiar.dm
+++ b/code/game/gamemodes/wizard/servant_items/familiar.dm
@@ -12,7 +12,7 @@
 		laser = ARMOR_LASER_MINOR, 
 		energy = ARMOR_ENERGY_SMALL
 	)
-	bodytype_restricted = list(BODYTYPE_HUMANOID)
+	bodytype_equip_flags = BODY_FLAG_HUMANOID
 
 /obj/item/clothing/under/familiargarb/Initialize()
 	. = ..()

--- a/code/game/gamemodes/wizard/servant_items/fiend.dm
+++ b/code/game/gamemodes/wizard/servant_items/fiend.dm
@@ -9,7 +9,7 @@
 		energy = ARMOR_ENERGY_SMALL, 
 		rad = ARMOR_RAD_SHIELDED
 	)
-	bodytype_restricted = list(BODYTYPE_HUMANOID)
+	bodytype_equip_flags = BODY_FLAG_HUMANOID
 	flags_inv = HIDEEARS | BLOCKHAIR
 
 /obj/item/clothing/suit/fiendcowl
@@ -29,7 +29,7 @@
 	name = "black suit"
 	desc = "A snappy black suit with red trim. The undershirt's stained with something, though..."
 	icon = 'icons/clothing/under/suits/suit_fiend.dmi'
-	bodytype_restricted = list(BODYTYPE_HUMANOID)
+	bodytype_equip_flags = BODY_FLAG_HUMANOID
 
 /obj/item/clothing/shoes/dress/devilshoes
 	desc = "Off-colour leather dress shoes. Their footsteps are silent."

--- a/code/game/gamemodes/wizard/servant_items/infiltrator.dm
+++ b/code/game/gamemodes/wizard/servant_items/infiltrator.dm
@@ -11,7 +11,7 @@
 		laser = ARMOR_LASER_MINOR,
 		energy = ARMOR_ENERGY_MINOR
 		)
-	bodytype_restricted = list(BODYTYPE_HUMANOID)
+	bodytype_equip_flags = BODY_FLAG_HUMANOID
 
 /obj/item/clothing/suit/infilsuit
 	name = "immaculate suit"
@@ -28,7 +28,7 @@
 	name = "formal outfit"
 	desc = "A white dress shirt and navy pants. Snazzy."
 	icon = 'icons/clothing/under/formal.dmi'
-	bodytype_restricted = list(BODYTYPE_HUMANOID)
+	bodytype_equip_flags = BODY_FLAG_HUMANOID
 
 /obj/item/clothing/shoes/dress/infilshoes
 	name = "black leather shoes"

--- a/code/game/gamemodes/wizard/servant_items/overseer.dm
+++ b/code/game/gamemodes/wizard/servant_items/overseer.dm
@@ -12,7 +12,7 @@
 	item_flags = ITEM_FLAG_AIRTIGHT
 	max_pressure_protection = FIRESUIT_MAX_PRESSURE
 	min_pressure_protection = 0
-	bodytype_restricted = list(BODYTYPE_HUMANOID)
+	bodytype_equip_flags = BODY_FLAG_HUMANOID
 	flags_inv = HIDEEARS | BLOCKHAIR
 
 /obj/item/clothing/suit/straight_jacket/overseercloak
@@ -35,7 +35,7 @@
 	name = "black hoodie"
 	desc = "A generic black hoodie. There's a pattern akin to splattered blood along the bottom."
 	icon = 'icons/clothing/under/grim_hoodie.dmi'
-	bodytype_restricted = list(BODYTYPE_HUMANOID)
+	bodytype_equip_flags = BODY_FLAG_HUMANOID
 
 //These are the ones that it gets when they toggle it off
 /obj/item/clothing/shoes/sandal/grimboots

--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -17,7 +17,8 @@
 
 /obj/item/modkit/Initialize(ml, material_key)
 	if(!target_bodytype)
-		target_bodytype = global.using_map.default_species
+		var/decl/species/species = GET_DECL(global.using_map.default_species)
+		target_bodytype = species.default_bodytype.bodytype_flag
 	. = ..()
 	
 /obj/item/modkit/afterattack(obj/O, mob/user, proximity)
@@ -40,12 +41,6 @@
 	var/obj/item/clothing/I = O
 	if (!istype(I) || !allowed)
 		to_chat(user, "<span class='notice'>[src] is unable to modify that.</span>")
-		return
-
-	var/excluding = ("exclude" in I.bodytype_restricted)
-	var/in_list = (target_bodytype in I.bodytype_restricted)
-	if (excluding ^ in_list)
-		to_chat(user, "<span class='notice'>[I] is already modified.</span>")
 		return
 
 	if(!isturf(O.loc))

--- a/code/game/objects/items/paintkit.dm
+++ b/code/game/objects/items/paintkit.dm
@@ -56,7 +56,7 @@
 
 		var/mob/living/carbon/human/H = user
 		if(istype(H))
-			bodytype_restricted = list(H.get_bodytype_category())
+			bodytype_equip_flags = H.bodytype.bodytype_flag
 		kit.use(1,user)
 		reconsider_single_icon()
 		return TRUE
@@ -75,7 +75,7 @@
 
 		var/mob/living/carbon/human/H = user
 		if(istype(H))
-			bodytype_restricted = list(H.get_bodytype_category())
+			bodytype_equip_flags = H.bodytype.bodytype_flag
 		kit.use(1,user)
 		reconsider_single_icon()
 		return TRUE

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -7,7 +7,9 @@
 	var/wizard_garb = 0
 	var/flash_protection = FLASH_PROTECTION_NONE	  // Sets the item's level of flash protection.
 	var/tint = TINT_NONE							  // Sets the item's level of visual impairment tint.
-	var/list/bodytype_restricted
+
+	var/bodytype_equip_flags    // Bitfields; if null, checking is skipped. Determine if a given mob can equip this item or not.
+
 	var/list/accessories = list()
 	var/list/valid_accessory_slots
 	var/list/restricted_accessory_slots
@@ -128,9 +130,9 @@
 
 /obj/item/clothing/mob_can_equip(mob/living/M, slot, disable_warning = 0)
 	. = ..()
-	if(. && length(bodytype_restricted) && ishuman(M) && !(slot in list(slot_l_store_str, slot_r_store_str, slot_s_store_str)) && !(slot in M.held_item_slots))
+	if(. && !isnull(bodytype_equip_flags) && ishuman(M) && !(slot in list(slot_l_store_str, slot_r_store_str, slot_s_store_str)) && !(slot in M.held_item_slots))
 		var/mob/living/carbon/human/H = M
-		. = ("exclude" in bodytype_restricted) ? !(H.get_bodytype_category() in bodytype_restricted) : (H.get_bodytype_category() in bodytype_restricted)
+		. = (bodytype_equip_flags & BODY_FLAG_EXCLUDE) ? !(bodytype_equip_flags & H.bodytype.bodytype_flag) : (bodytype_equip_flags & H.bodytype.bodytype_flag)
 		if(!. && !disable_warning)
 			to_chat(H, SPAN_WARNING("\The [src] [gender == PLURAL ? "do" : "does"] not fit you."))
 
@@ -140,8 +142,7 @@
 	return ..()
 
 /obj/item/clothing/proc/refit_for_bodytype(var/target_bodytype)
-	if(bodytype_restricted)
-		bodytype_restricted = list(target_bodytype)
+	bodytype_equip_flags = target_bodytype
 
 /obj/item/clothing/get_examine_line()
 	. = ..()

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -12,7 +12,7 @@
 	toggle_off_message = "$ITEM$ powers down with a beep."
 	material = /decl/material/solid/metal/aluminium
 	matter = list(/decl/material/solid/glass = MATTER_AMOUNT_REINFORCEMENT)
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 	var/list/icon/current = list() //the current hud icons
 
 /obj/item/clothing/glasses/proc/process_hud(var/mob/M)

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -11,7 +11,7 @@
 	slot_flags = SLOT_HANDS
 	attack_verb = list("challenged")
 	blood_overlay_type = "bloodyhands"
-	bodytype_restricted = list(BODYTYPE_HUMANOID)
+	bodytype_equip_flags = BODY_FLAG_HUMANOID
 	var/obj/item/clothing/ring/covering_ring
 
 /obj/item/clothing/gloves/update_clothing_icon()

--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/clothing/feet/galoshes.dmi'
 	permeability_coefficient = 0.05
 	item_flags = ITEM_FLAG_NOSLIP
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 
 /obj/item/clothing/shoes/galoshes/Initialize()
 	. = ..()

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -4,7 +4,7 @@
 	desc = "Magnetic boots, often used during extravehicular activity to ensure the user remains safely attached to the vehicle. They're large enough to be worn over other footwear."
 	icon_state = ICON_STATE_WORLD
 	icon = 'icons/clothing/feet/magboots.dmi'
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 	force = 3
 	can_fit_under_magboots = FALSE
 	action_button_name = "Toggle Magboots"

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -9,7 +9,7 @@
 	origin_tech = "{'esoteric':3}"
 	var/list/clothing_choices = list()
 	siemens_coefficient = 0.8
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 	matter = list(/decl/material/solid/metal/steel = MATTER_AMOUNT_REINFORCEMENT)
 
 /obj/item/clothing/shoes/jackboots/swat
@@ -84,7 +84,7 @@
 	name = "sandals"
 	desc = "A pair of rather plain wooden sandals."
 	icon = 'icons/clothing/feet/sandals.dmi'
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 	body_parts_covered = 0
 	wizard_garb = 1
 	can_add_hidden_item = FALSE
@@ -102,7 +102,7 @@
 	name = "clown shoes"
 	icon = 'icons/clothing/feet/clown.dmi'
 	force = 0
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 	can_add_hidden_item = FALSE
 	var/footstep = 1	//used for squeeks whilst walking
 
@@ -131,14 +131,14 @@
 	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
 	heat_protection = SLOT_FEET
 	max_heat_protection_temperature = SHOE_MAX_HEAT_PROTECTION_TEMPERATURE
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 
 /obj/item/clothing/shoes/slippers
 	name = "bunny slippers"
 	desc = "Fluffy!"
 	icon = 'icons/clothing/feet/bunny_slippers.dmi'
 	force = 0
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 	w_class = ITEM_SIZE_SMALL
 	can_add_hidden_item = FALSE
 	can_add_cuffs = FALSE
@@ -148,7 +148,7 @@
 	desc = "Help you swim good."
 	icon = 'icons/clothing/feet/flippers.dmi'
 	item_flags = ITEM_FLAG_NOSLIP
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 	can_add_hidden_item = FALSE
 	can_add_cuffs = FALSE
 

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -21,7 +21,7 @@
 	cold_protection =    SLOT_HEAD|SLOT_FACE|SLOT_EYES
 	brightness_on = 4
 	light_wedge = LIGHT_WIDE
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 
 /obj/item/clothing/head/helmet/space/rig/on_update_icon(mob/user)
 	..()
@@ -40,7 +40,7 @@
 	body_parts_covered = SLOT_HANDS
 	heat_protection =    SLOT_HANDS
 	cold_protection =    SLOT_HANDS
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 	gender = PLURAL
 
 /obj/item/clothing/gloves/rig/on_update_icon(mob/user)
@@ -60,7 +60,7 @@
 	body_parts_covered = SLOT_FEET
 	cold_protection = SLOT_FEET
 	heat_protection = SLOT_FEET
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 	gender = PLURAL
 
 /obj/item/clothing/shoes/magboots/rig/on_update_icon(mob/user)
@@ -185,7 +185,7 @@
 	body_parts_covered = SLOT_FEET
 	cold_protection = SLOT_FEET
 	heat_protection = SLOT_FEET
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 	gender = PLURAL
 
 /obj/item/clothing/gloves/lightrig
@@ -195,5 +195,5 @@
 	body_parts_covered = SLOT_HANDS
 	heat_protection =    SLOT_HANDS
 	cold_protection =    SLOT_HANDS
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 	gender = PLURAL

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -3,7 +3,7 @@
 	name = "void helmet"
 	desc = "A high-tech dark red space suit helmet. Used for AI satellite maintenance."
 	icon = 'icons/clothing/spacesuit/void/nasa/helmet.dmi'
-	bodytype_restricted = list(BODYTYPE_HUMANOID)
+	bodytype_equip_flags = BODY_FLAG_HUMANOID
 	heat_protection = SLOT_HEAD
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT, 
@@ -22,7 +22,7 @@
 /obj/item/clothing/suit/space/void
 	name = "voidsuit"
 	icon = 'icons/clothing/spacesuit/void/nasa/suit.dmi'
-	bodytype_restricted = list(BODYTYPE_HUMANOID)
+	bodytype_equip_flags = BODY_FLAG_HUMANOID
 	w_class = ITEM_SIZE_HUGE//bulky item
 	desc = "A high-tech dark red space suit. Used for AI satellite maintenance."
 	armor = list(

--- a/code/modules/clothing/spacesuits/void/wizard.dm
+++ b/code/modules/clothing/spacesuits/void/wizard.dm
@@ -49,7 +49,7 @@
 	body_parts_covered = SLOT_HANDS
 	cold_protection =    SLOT_HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 	gender = PLURAL
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.02

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -9,7 +9,7 @@
 	icon = 'icons/clothing/suit/apron.dmi'
 	blood_overlay_type = "armor"
 	body_parts_covered = 0
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 	allowed = list (/obj/item/chems/spray/plantbgone,/obj/item/scanner/plant,/obj/item/seeds,/obj/item/chems/glass/bottle,/obj/item/minihoe)
 
 //Captain
@@ -57,7 +57,7 @@
 	name = "classic chef's apron"
 	desc = "A basic, dull, white chef's apron."
 	icon = 'icons/clothing/suit/apron_chef.dmi'
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 	blood_overlay_type = "armor"
 	body_parts_covered = 0
 
@@ -118,7 +118,7 @@
 	desc = "A high-visibility vest used in work zones."
 	icon = 'icons/clothing/suit/hazard_vest/orange.dmi'
 	blood_overlay_type = "armor"
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 	allowed = list (
 		/obj/item/scanner/gas,
 		/obj/item/flashlight,

--- a/code/modules/clothing/suits/poncho.dm
+++ b/code/modules/clothing/suits/poncho.dm
@@ -2,8 +2,8 @@
 /obj/item/clothing/suit/poncho/colored
 	name = "poncho"
 	desc = "A simple, comfortable poncho."
-	bodytype_restricted = null
 	icon = 'icons/clothing/suit/poncho/classic.dmi'
+	bodytype_equip_flags = null
 
 /obj/item/clothing/suit/poncho/colored/green
 	name = "green poncho"
@@ -26,7 +26,7 @@
 	icon = 'icons/clothing/suit/poncho/blue.dmi'
 
 /obj/item/clothing/suit/poncho/roles
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 
 /obj/item/clothing/suit/poncho/roles/security
 	name = "security poncho"

--- a/code/modules/clothing/under/accessories/armband.dm
+++ b/code/modules/clothing/under/accessories/armband.dm
@@ -3,7 +3,7 @@
 	desc = "A fancy red armband!"
 	icon = 'icons/clothing/accessories/armbands/armband_security.dmi'
 	slot = ACCESSORY_SLOT_ARMBAND
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 	hide_on_uniform_rolldown = TRUE
 	hide_on_uniform_rollsleeves = TRUE
 

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -389,7 +389,7 @@
 	name = "gear harness"
 	desc = "How... minimalist."
 	icon = 'icons/clothing/under/harness.dmi'
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 	body_parts_covered = 0
 
 /obj/item/clothing/under/frontier

--- a/code/modules/clothing/under/monkey.dm
+++ b/code/modules/clothing/under/monkey.dm
@@ -1,9 +1,9 @@
 /obj/item/clothing/under/waiter/monke
 	name = "fancy uniform"
 	desc = "It looks like it was tailored for a monkey."
-	bodytype_restricted = list(BODYTYPE_MONKEY)
+	bodytype_equip_flags = BODY_FLAG_MONKEY
 
 /obj/item/clothing/pants/casual/mustangjeans/monke
 	name = "monkey pants"
 	desc = "They look like they were tailored for a monkey."
-	bodytype_restricted = list(BODYTYPE_MONKEY)
+	bodytype_equip_flags = BODY_FLAG_MONKEY

--- a/code/modules/species/species_bodytype.dm
+++ b/code/modules/species/species_bodytype.dm
@@ -4,6 +4,7 @@
 	var/icon_deformed
 	var/lip_icon
 	var/bandages_icon
+	var/bodytype_flag = BODY_FLAG_HUMANOID
 	var/bodytype_category = BODYTYPE_OTHER
 	var/limb_icon_intensity = 1.5
 	var/damage_mask

--- a/code/modules/species/station/monkey_bodytypes.dm
+++ b/code/modules/species/station/monkey_bodytypes.dm
@@ -6,6 +6,7 @@
 	blood_mask =        'icons/mob/human_races/species/monkey/blood_mask.dmi'
 	health_hud_intensity = 1.75
 	tail = "chimptail"
+	bodytype_flag = BODY_FLAG_MONKEY
 
 /decl/bodytype/monkey/Initialize()
 	equip_adjust = list(

--- a/mods/content/corporate/clothing/suit/ponchos.dm
+++ b/mods/content/corporate/clothing/suit/ponchos.dm
@@ -1,7 +1,7 @@
 /obj/item/clothing/suit/poncho/roles/science
 	name = "science poncho"
 	desc = "A simple, comfortable cloak without sleeves. This one is white with a few bottle green stripes, corporate colors."
-	bodytype_restricted = null
+	bodytype_equip_flags = null
 	icon = 'mods/content/corporate/icons/clothing/suit/sci_poncho.dmi'
 
 /obj/item/clothing/suit/poncho/roles/science/nanotrasen

--- a/mods/species/ascent/ascent.dm
+++ b/mods/species/ascent/ascent.dm
@@ -4,9 +4,12 @@
 #define SPECIES_MANTID_NYMPH   "Kharmaan Nymph"
 
 #define BODYTYPE_SNAKE "snakelike body"
-#define BODYTYPE_NYMPH	"small nymph body"
 #define BODYTYPE_MANTID_SMALL "small mantid body"
 #define BODYTYPE_MANTID_LARGE "large mantid body"
+
+#define BODY_FLAG_SNAKE BITFLAG(3)
+#define BODY_FLAG_ALATE BITFLAG(4)
+#define BODY_FLAG_GYNE  BITFLAG(5)
 
 #define IS_MANTID    "mantid"
 #define IS_SERPENTID "serpentid"

--- a/mods/species/ascent/datum/species_bodytypes.dm
+++ b/mods/species/ascent/datum/species_bodytypes.dm
@@ -4,6 +4,7 @@
 	icon_base =         'mods/species/ascent/icons/species/body/alate/body.dmi'
 	blood_mask =        'mods/species/ascent/icons/species/body/alate/blood_mask.dmi'
 	associated_gender = MALE
+	bodytype_flag =     BODY_FLAG_ALATE
 
 /decl/bodytype/gyne
 	name =              "gyne"
@@ -16,6 +17,7 @@
 	antaghud_offset_y = 18
 	antaghud_offset_x = 4
 	associated_gender = FEMALE
+	bodytype_flag =     BODY_FLAG_GYNE
 
 /decl/bodytype/gyne/Initialize()
 	equip_adjust = list(
@@ -36,6 +38,7 @@
 	limb_blend = ICON_MULTIPLY
 	bodytype_category = BODYTYPE_SNAKE
 	antaghud_offset_y = 8
+	bodytype_flag =     BODY_FLAG_SNAKE
 
 /decl/bodytype/serpentid/Initialize()
 	equip_adjust = list(

--- a/mods/species/ascent/items/clothing.dm
+++ b/mods/species/ascent/items/clothing.dm
@@ -26,7 +26,7 @@
 		BODYTYPE_SNAKE =        'mods/species/ascent/icons/clothing/mask_serpentid.dmi',
 		BODYTYPE_MANTID_LARGE = 'mods/species/ascent/icons/clothing/mask_gyne.dmi'
 	)
-	bodytype_restricted = list(BODYTYPE_MANTID_SMALL, BODYTYPE_MANTID_LARGE)
+	bodytype_equip_flags = BODY_FLAG_GYNE | BODY_FLAG_ALATE
 	filtered_gases = list(
 		/decl/material/gas/nitrous_oxide,
 		/decl/material/gas/chlorine,
@@ -47,13 +47,13 @@
 		/decl/material/gas/methyl_bromide,
 		/decl/material/gas/methane
 	)
-	bodytype_restricted = list(BODYTYPE_SNAKE)
+	bodytype_equip_flags = BODY_FLAG_SNAKE
 
 /obj/item/clothing/shoes/magboots/ascent
 	name = "mantid mag-claws"
 	desc = "A set of powerful gripping claws."
 	icon = 'mods/species/ascent/icons/magboots/boots.dmi'
-	bodytype_restricted = list(BODYTYPE_MANTID_SMALL, BODYTYPE_MANTID_LARGE)
+	bodytype_equip_flags = BODY_FLAG_GYNE | BODY_FLAG_ALATE
 	sprite_sheets = list(
 		BODYTYPE_MANTID_LARGE = 'mods/species/ascent/icons/magboots/boots_gyne.dmi'
 	)
@@ -61,7 +61,7 @@
 /obj/item/clothing/under/ascent
 	name = "mantid undersuit"
 	desc = "A ribbed, spongy undersuit of some sort. It has a big sleeve for a tail, so it probably isn't for humans."
-	bodytype_restricted = list(BODYTYPE_MANTID_LARGE, BODYTYPE_MANTID_SMALL)
+	bodytype_equip_flags = BODY_FLAG_GYNE | BODY_FLAG_ALATE
 	icon = 'mods/species/ascent/icons/clothing/under.dmi'
 	color = COLOR_DARK_GUNMETAL
 	sprite_sheets = list(
@@ -71,7 +71,7 @@
 /obj/item/clothing/suit/storage/ascent
 	name = "mantid gear harness"
 	desc = "A complex tangle of articulated cables and straps."
-	bodytype_restricted = list(BODYTYPE_MANTID_LARGE, BODYTYPE_MANTID_SMALL, BODYTYPE_SNAKE)
+	bodytype_equip_flags = BODY_FLAG_GYNE | BODY_FLAG_ALATE | BODY_FLAG_SNAKE
 	icon_state = ICON_STATE_WORLD
 	icon = 'mods/species/ascent/icons/clothing/under_harness.dmi'
 	sprite_sheets = list(

--- a/mods/species/ascent/items/rig.dm
+++ b/mods/species/ascent/items/rig.dm
@@ -257,7 +257,7 @@
 /obj/item/clothing/head/helmet/space/rig/mantid
 	light_color = "#00ffff"
 	desc = "More like a torpedo casing than a helmet."
-	bodytype_restricted = list(BODYTYPE_MANTID_LARGE, BODYTYPE_MANTID_SMALL, BODYTYPE_SNAKE)
+	bodytype_equip_flags = BODY_FLAG_GYNE | BODY_FLAG_ALATE | BODY_FLAG_SNAKE
 	icon = 'mods/species/ascent/icons/rig/rig_helmet.dmi'
 	sprite_sheets = list(
 		BODYTYPE_MANTID_LARGE = 'mods/species/ascent/icons/rig/rig_helmet_gyne.dmi',
@@ -266,7 +266,7 @@
 
 /obj/item/clothing/suit/space/rig/mantid
 	desc = "It's closer to a mech than a suit."
-	bodytype_restricted = list(BODYTYPE_MANTID_LARGE, BODYTYPE_MANTID_SMALL, BODYTYPE_SNAKE)
+	bodytype_equip_flags = BODY_FLAG_GYNE | BODY_FLAG_ALATE | BODY_FLAG_SNAKE
 	icon = 'mods/species/ascent/icons/rig/rig_chest.dmi'
 	allowed = list(
 		/obj/item/clustertool,
@@ -284,7 +284,7 @@
 /obj/item/clothing/shoes/magboots/rig/mantid
 	icon = 'mods/species/ascent/icons/rig/rig_boots.dmi'
 	desc = "It's like a highly advanced forklift."
-	bodytype_restricted = list(BODYTYPE_MANTID_LARGE, BODYTYPE_MANTID_SMALL)
+	bodytype_equip_flags = BODY_FLAG_GYNE | BODY_FLAG_ALATE
 	sprite_sheets = list(
 		BODYTYPE_MANTID_LARGE = 'mods/species/ascent/icons/rig/rig_boots_gyne.dmi'
 	)
@@ -292,7 +292,7 @@
 /obj/item/clothing/gloves/rig/mantid
 	icon = 'mods/species/ascent/icons/rig/rig_gloves.dmi'
 	desc = "They look like a cross between a can opener and a Swiss army knife the size of a shoebox."
-	bodytype_restricted = list(BODYTYPE_MANTID_LARGE, BODYTYPE_MANTID_SMALL, BODYTYPE_SNAKE)
+	bodytype_equip_flags = BODY_FLAG_GYNE | BODY_FLAG_ALATE | BODY_FLAG_SNAKE
 	sprite_sheets = list(
 		BODYTYPE_MANTID_LARGE = 'mods/species/ascent/icons/rig/rig_gloves_gyne.dmi',
 		BODYTYPE_SNAKE = 'mods/species/ascent/icons/rig/rig_gloves_serpentid.dmi'

--- a/mods/species/ascent/items/suits.dm
+++ b/mods/species/ascent/items/suits.dm
@@ -12,7 +12,7 @@
 		rad = ARMOR_RAD_SHIELDED
 	)
 	max_pressure_protection = ENG_VOIDSUIT_MAX_PRESSURE
-	bodytype_restricted = list(BODYTYPE_MANTID_SMALL)
+	bodytype_equip_flags = BODY_FLAG_ALATE
 
 /obj/item/clothing/suit/space/void/ascent
 	name = "\improper Ascent voidsuit"
@@ -28,7 +28,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED
 	)
-	bodytype_restricted = list(BODYTYPE_MANTID_SMALL)
+	bodytype_equip_flags = BODY_FLAG_ALATE
 	allowed = list(
 		/obj/item/clustertool,
 		/obj/item/tank/mantid,

--- a/mods/species/neoavians/_neoavians.dm
+++ b/mods/species/neoavians/_neoavians.dm
@@ -1,6 +1,7 @@
 #define SPECIES_AVIAN            "Neo-Avian"
 #define BODYTYPE_AVIAN           "avian body"
 #define IS_AVIAN                 "avian"
+#define BODY_FLAG_AVIAN          BITFLAG(6)
 
 /decl/modpack/neoavians
 	name = "Neo-Avian Content"

--- a/mods/species/neoavians/clothing.dm
+++ b/mods/species/neoavians/clothing.dm
@@ -47,7 +47,7 @@
 	desc = "A loose-fitting smock favoured by neo-avians."
 	icon = 'mods/species/neoavians/icons/clothing/under/smock.dmi'
 	icon_state = ICON_STATE_WORLD
-	bodytype_restricted = list(BODYTYPE_AVIAN)
+	bodytype_equip_flags = BODY_FLAG_AVIAN
 
 /obj/item/clothing/under/avian_smock/worker
 	name = "worker's smock"
@@ -84,7 +84,7 @@
 	name = "small shoes"
 	icon = 'mods/species/neoavians/icons/clothing/feet/shoes.dmi'
 	color = COLOR_GRAY
-	bodytype_restricted = list(BODYTYPE_AVIAN)
+	bodytype_equip_flags = BODY_FLAG_AVIAN
 
 /obj/item/clothing/shoes/avian/footwraps
 	name = "cloth footwraps"

--- a/mods/species/neoavians/datum/species_bodytypes.dm
+++ b/mods/species/neoavians/datum/species_bodytypes.dm
@@ -7,6 +7,7 @@
 	limb_blend =        ICON_MULTIPLY
 	tail_blend =        ICON_MULTIPLY
 	tail =              "tail_avian"
+	bodytype_flag =     BODY_FLAG_AVIAN
 
 /decl/bodytype/avian/raptor
 	name =              "raptor"

--- a/mods/species/tajaran/_tajaran.dm
+++ b/mods/species/tajaran/_tajaran.dm
@@ -1,11 +1,12 @@
-#define SPECIES_TAJARA "Tajara"
+#define SPECIES_TAJARA  "Tajara"
 #define LANGUAGE_TAJARA "Siik'maas"
 #define BODYTYPE_FELINE "feline body"
+#define BODY_FLAG_FELINE BITFLAG(7)
 
 /obj/item/clothing/Initialize()
 	. = ..()
-	if(length(bodytype_restricted) && !("exclude" in bodytype_restricted))
-		bodytype_restricted |= BODYTYPE_FELINE
+	if(bodytype_equip_flags & BODY_FLAG_EXCLUDE)
+		bodytype_equip_flags |= BODY_FLAG_FELINE
 
 /decl/modpack/tajaran
 	name = "Tajaran"

--- a/mods/species/tajaran/datum/species_bodytypes.dm
+++ b/mods/species/tajaran/datum/species_bodytypes.dm
@@ -10,6 +10,7 @@
 	tail_animation = 'mods/species/tajaran/icons/tail.dmi'
 	tail = "tajtail"
 	tail_blend = ICON_MULTIPLY
+	bodytype_flag = BODY_FLAG_FELINE
 
 /decl/bodytype/feline/Initialize()
 	equip_adjust = list(

--- a/mods/species/vox/_vox.dm
+++ b/mods/species/vox/_vox.dm
@@ -1,6 +1,7 @@
 #define SPECIES_VOX   "Vox"
 #define BODYTYPE_VOX  "reptoavian body"
 #define BP_HINDTONGUE "hindtongue"
+#define BODY_FLAG_VOX BITFLAG(8)
 
 /decl/modpack/vox
 	name = "Vox Content"

--- a/mods/species/vox/datum/species_bodytypes.dm
+++ b/mods/species/vox/datum/species_bodytypes.dm
@@ -9,6 +9,7 @@
 	tail =              "voxtail"
 	tail_icon =         'mods/species/vox/icons/body/tail.dmi'
 	tail_blend =        ICON_OVERLAY
+	bodytype_flag =     BODY_FLAG_VOX
 
 /decl/bodytype/vox/Initialize()
 	equip_adjust = list(

--- a/mods/species/vox/gear/gear_gloves.dm
+++ b/mods/species/vox/gear/gear_gloves.dm
@@ -4,8 +4,4 @@
 	icon = 'mods/species/vox/icons/clothing/gloves.dmi'
 	siemens_coefficient = 0
 	permeability_coefficient = 0.05
-	bodytype_restricted = list(BODYTYPE_VOX)
-
-/obj/item/clothing/gloves/vox/Initialize()
-	. = ..()
-	bodytype_restricted = list(BODYTYPE_VOX)
+	bodytype_equip_flags = BODY_FLAG_VOX

--- a/mods/species/vox/gear/gear_head.dm
+++ b/mods/species/vox/gear/gear_head.dm
@@ -1,11 +1,7 @@
 /obj/item/clothing/head/helmet/space/void/Initialize()
 	. = ..()
-	if("exclude" in bodytype_restricted)
-		LAZYDISTINCTADD(bodytype_restricted, BODYTYPE_VOX)
-	else if(length(bodytype_restricted))
-		LAZYREMOVE(bodytype_restricted, BODYTYPE_VOX)
-	else
-		bodytype_restricted = list("exclude", BODYTYPE_VOX)
+	if(bodytype_equip_flags & BODY_FLAG_EXCLUDE)
+		bodytype_equip_flags |= BODY_FLAG_VOX
 
 /obj/item/clothing/head/helmet/space/vox
 	name = "alien helmet"
@@ -24,11 +20,7 @@
 	siemens_coefficient = 0.6
 	item_flags = 0
 	flags_inv = 0
-	bodytype_restricted = list(BODYTYPE_VOX)
-
-/obj/item/clothing/head/helmet/space/vox/Initialize()
-	. = ..()
-	bodytype_restricted = list(BODYTYPE_VOX)
+	bodytype_equip_flags = BODY_FLAG_VOX
 	
 /obj/item/clothing/head/helmet/space/vox/carapace
 	name = "alien visor"

--- a/mods/species/vox/gear/gear_mask.dm
+++ b/mods/species/vox/gear/gear_mask.dm
@@ -5,17 +5,13 @@
 	flags_inv = 0
 	body_parts_covered = 0
 	filtered_gases = list(/decl/material/gas/oxygen)
+	bodytype_equip_flags = BODY_FLAG_VOX
 
-/obj/item/clothing/mask/gas/vox/Initialize()
-	. = ..()
-	bodytype_restricted = list(BODYTYPE_VOX)
-	
 /obj/item/clothing/mask/gas/swat/vox
 	name = "alien mask"
 	desc = "Clearly not designed for a human face."
 	icon = 'mods/species/vox/icons/clothing/mask.dmi'
 	body_parts_covered = SLOT_EYES
-	bodytype_restricted = list(BODYTYPE_VOX)
 	filtered_gases = list(
 		/decl/material/gas/oxygen,
 		/decl/material/gas/nitrous_oxide,
@@ -25,7 +21,4 @@
 		/decl/material/gas/methyl_bromide,
 		/decl/material/gas/methane
 	)
-
-/obj/item/clothing/mask/gas/swat/vox/Initialize()
-	. = ..()
-	bodytype_restricted = list(BODYTYPE_VOX)
+	bodytype_equip_flags = BODY_FLAG_VOX

--- a/mods/species/vox/gear/gear_rig.dm
+++ b/mods/species/vox/gear/gear_rig.dm
@@ -46,22 +46,14 @@
 
 /obj/item/clothing/head/helmet/space/rig/vox_rig
 	icon = 'mods/species/vox/icons/rig/helmet.dmi'
-/obj/item/clothing/head/helmet/space/rig/vox_rig/Initialize()
-	. = ..()
-	bodytype_restricted = list(BODYTYPE_VOX)
+	bodytype_equip_flags = BODY_FLAG_VOX
 /obj/item/clothing/suit/space/rig/vox_rig
 	icon = 'mods/species/vox/icons/rig/chest.dmi'
-/obj/item/clothing/suit/space/rig/vox_rig/Initialize()
-	. = ..()
-	bodytype_restricted = list(BODYTYPE_VOX)
+	bodytype_equip_flags = BODY_FLAG_VOX
 /obj/item/clothing/shoes/magboots/rig/vox_rig
 	icon = 'mods/species/vox/icons/rig/boots.dmi'
-/obj/item/clothing/shoes/magboots/rig/vox_rig/Initialize()
-	. = ..()
-	bodytype_restricted = list(BODYTYPE_VOX)
+	bodytype_equip_flags = BODY_FLAG_VOX
 /obj/item/clothing/gloves/rig/vox_rig
 	icon = 'mods/species/vox/icons/rig/gloves.dmi'
 	siemens_coefficient = 0
-/obj/item/clothing/gloves/rig/vox_rig/Initialize()
-	. = ..()
-	bodytype_restricted = list(BODYTYPE_VOX)
+	bodytype_equip_flags = BODY_FLAG_VOX

--- a/mods/species/vox/gear/gear_shoes.dm
+++ b/mods/species/vox/gear/gear_shoes.dm
@@ -3,10 +3,7 @@
 	desc = "A pair of heavy, jagged, armoured foot pieces, seemingly suitable for a velociraptor."
 	icon = 'mods/species/vox/icons/clothing/boots_vox.dmi'
 	action_button_name = "Toggle the magclaws"
-
-/obj/item/clothing/shoes/magboots/vox/Initialize()
-	. = ..()
-	bodytype_restricted = list(BODYTYPE_VOX)
+	bodytype_equip_flags = BODY_FLAG_VOX
 
 /obj/item/clothing/shoes/magboots/vox/attack_self(mob/user)
 	if(magpulse)

--- a/mods/species/vox/gear/gear_suit.dm
+++ b/mods/species/vox/gear/gear_suit.dm
@@ -1,11 +1,7 @@
 /obj/item/clothing/suit/space/void/Initialize()
 	. = ..()
-	if("exclude" in bodytype_restricted)
-		LAZYDISTINCTADD(bodytype_restricted, BODYTYPE_VOX)
-	else if(length(bodytype_restricted))
-		LAZYREMOVE(bodytype_restricted, BODYTYPE_VOX)
-	else
-		bodytype_restricted = list("exclude", BODYTYPE_VOX)
+	if(bodytype_equip_flags & BODY_FLAG_EXCLUDE)
+		bodytype_equip_flags |= BODY_FLAG_VOX
 
 /obj/item/clothing/suit/space/vox
 	name = "alien pressure suit"
@@ -33,13 +29,12 @@
 	siemens_coefficient = 0.6
 	heat_protection = SLOT_UPPER_BODY|SLOT_LOWER_BODY|SLOT_LEGS|SLOT_FEET|SLOT_ARMS|SLOT_HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	bodytype_restricted = list(BODYTYPE_VOX)
+	bodytype_equip_flags = BODY_FLAG_VOX
 	flags_inv = (HIDEJUMPSUIT|HIDETAIL)
 
 /obj/item/clothing/suit/space/vox/Initialize()
 	. = ..()
 	LAZYSET(slowdown_per_slot, slot_wear_suit_str, 1)
-	bodytype_restricted = list(BODYTYPE_VOX)
 
 /obj/item/clothing/suit/space/vox/carapace
 	name = "alien carapace armour"
@@ -85,10 +80,5 @@
 		laser = ARMOR_LASER_MINOR,
 		bomb = ARMOR_BOMB_PADDED) //Higher melee armor versus lower everything else.
 	body_parts_covered = SLOT_UPPER_BODY|SLOT_ARMS|SLOT_LOWER_BODY|SLOT_LEGS
-	bodytype_restricted = list(BODYTYPE_VOX)
+	bodytype_equip_flags = BODY_FLAG_VOX
 	siemens_coefficient = 1 //Its literally metal
-
-/obj/item/clothing/suit/armor/vox_scrap/Initialize()
-	. = ..()
-	bodytype_restricted = list(BODYTYPE_VOX)
-	

--- a/mods/species/vox/gear/gear_under.dm
+++ b/mods/species/vox/gear/gear_under.dm
@@ -1,9 +1,6 @@
 /obj/item/clothing/under/vox
 	has_sensor = 0
-
-/obj/item/clothing/under/vox/Initialize()
-	. = ..()
-	bodytype_restricted = list(BODYTYPE_VOX)
+	bodytype_equip_flags = BODY_FLAG_VOX
 
 /obj/item/clothing/under/vox/vox_casual
 	name = "alien clothing"


### PR DESCRIPTION
## Description of changes
Someone on Bay linked https://github.com/BeeStation/BeeStation-Hornet/pull/5363 and it reminded me to do this. This PR swaps the `bodytype_restricted` list out for a bitfield. Means there can be an effective maximum of 23 restriction types but current code only has 7 so I don't think it'll be an issue unless Virgo tries to make a Neb fork.

## Why and what will this PR improve
Decreased init time and memory footprint for clothing.

## Authorship
Myself.

## Changelog
Nothing player facing.
