### PR TITLE
Species Footprint Trail Handling

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -117,6 +117,7 @@
 			if(istype(stomper) && !stomper.is_stump() && stomper.coating && stomper.coating.total_volume > 1)
 				source = stomper
 	if(!source)
+		species.handle_trail(src, T)
 		return
 
 	var/list/bloodDNA

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -584,6 +584,9 @@
 	else
 		return move_trail
 
+/decl/species/proc/handle_trail(var/mob/living/carbon/human/H, var/turf/simulated/T)
+	return
+
 /decl/species/proc/update_skin(var/mob/living/carbon/human/H)
 	return
 


### PR DESCRIPTION
## Description of changes

Some backend code that lets species override what happens when they move onto a simulated turf without bloodstains on their feet or shoes. Required for https://github.com/HearthOfHestia/Nebula/pull/50.

## Why and what will this PR improve

Species-based footprint roleplay. Or something.

## Authorship

issa me, geevio

## Changelog

:cl:
rscadd: Species now have special footprint handling when walking on simulated turfs, though no core species has anything implemented yet.
/:cl: