### PR TITLE
Optimizing flooded turfs.

### DIFF
--- a/code/game/atoms_fluids.dm
+++ b/code/game/atoms_fluids.dm
@@ -43,10 +43,10 @@
 		depth = get_fluid_depth()
 	return depth >= FLUID_OVER_MOB_HEAD
 
-/atom/proc/fluid_update()
+/atom/proc/fluid_update(var/ignore_neighbors)
 	var/turf/T = get_turf(src)
 	if(istype(T))
-		T.fluid_update()
+		T.fluid_update(ignore_neighbors)
 
 /atom/movable/update_nearby_tiles(var/need_rebuild)
 	UNLINT(. = ..(need_rebuild))

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -431,8 +431,11 @@ Class Procs:
 		explosion_act(3)
 
 /obj/machinery/Move()
+	var/atom/lastloc = loc
 	. = ..()
 	if(. && !CanFluidPass())
+		if(lastloc)
+			lastloc.fluid_update()
 		fluid_update()
 
 /obj/machinery/get_cell(var/functional_only = TRUE)

--- a/code/game/objects/structures/__structure.dm
+++ b/code/game/objects/structures/__structure.dm
@@ -36,7 +36,7 @@
 	. = ..()
 	update_materials()
 	if(!CanFluidPass())
-		fluid_update()
+		fluid_update(TRUE)
 
 /obj/structure/proc/show_examined_damage(mob/user, var/perc)
 	if(maxhealth == -1)
@@ -147,10 +147,9 @@
 
 /obj/structure/Destroy()
 	var/turf/T = get_turf(src)
-	if(T)
-		T.fluid_update()
 	. = ..()
 	if(T)
+		T.fluid_update()
 		for(var/atom/movable/AM in T)
 			AM.reset_offsets()
 			AM.reset_plane_and_layer()
@@ -175,6 +174,7 @@
 	if(. && !CanFluidPass())
 		fluid_update()
 		if(T)
+			T.fluid_update()
 			for(var/atom/movable/AM in T)
 				AM.reset_offsets()	
 				AM.reset_plane_and_layer()

--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -131,6 +131,14 @@
 	if(LAZYLEN(decals))
 		add_overlay(decals)
 
+	var/datum/gas_mixture/air = (owner ? owner.atmosphere : global.using_map.exterior_atmosphere)
+	if(length(air?.graphic))
+		vis_contents += air.graphic
+	else if(flooded)
+		vis_contents = list(global.flood_object)
+	else
+		vis_contents.Cut()
+
 	if(icon_edge_layer < 0)
 		return
 
@@ -181,11 +189,3 @@
 					else if(direction & WEST)
 						I.pixel_x -= world.icon_size
 					add_overlay(I)
-
-	var/datum/gas_mixture/air = (owner ? owner.atmosphere : global.using_map.exterior_atmosphere)
-	if(length(air?.graphic))
-		vis_contents += air.graphic
-	else
-		vis_contents.Cut()
-		if(flooded)
-			vis_contents |= global.flood_object

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -177,8 +177,6 @@
 	var/area/A = loc
 	holy = istype(A) && (A.area_flags & AREA_FLAG_HOLY)
 	levelupdate()
-	if(GAME_STATE >= RUNLEVEL_GAME)
-		fluid_update()
 	. = ..()
 
 /turf/simulated/initialize_ambient_light(var/mapload)

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -65,8 +65,6 @@
 //This proc auto corrects the grass tiles' siding.
 /turf/simulated/floor/proc/make_plating(var/place_product, var/defer_icon_update)
 
-	overlays.Cut()
-
 	for(var/obj/effect/decal/writing/W in src)
 		qdel(W)
 

--- a/code/game/turfs/simulated/floor_static.dm
+++ b/code/game/turfs/simulated/floor_static.dm
@@ -15,7 +15,6 @@
 
 /turf/simulated/floor/fixed/on_update_icon()
 	queue_ao(FALSE)
-	update_flood_overlay()
 
 /turf/simulated/floor/fixed/is_plating()
 	return 0

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -80,17 +80,6 @@
 /turf/proc/update_ambient_light(var/mapload)
 	return
 
-/turf/on_update_icon()
-	update_flood_overlay()
-
-/turf/proc/update_flood_overlay()
-	if(flooded)
-		vis_contents |= global.flood_object
-		for(var/obj/effect/fluid/fluid in src)
-			qdel(fluid)
-	else
-		vis_contents -= global.flood_object
-
 /turf/Destroy()
 
 	if (!changing_turf)
@@ -99,7 +88,6 @@
 	changing_turf = FALSE
 
 	remove_cleanables()
-	fluid_update()
 	REMOVE_ACTIVE_FLUID_SOURCE(src)
 
 	if (ao_queued)

--- a/code/modules/overmap/exoplanets/turfs.dm
+++ b/code/modules/overmap/exoplanets/turfs.dm
@@ -29,7 +29,12 @@
 
 	var/turf/NT = locate(nx, ny, z)
 	if(NT)
-		vis_contents = list(NT)
+		if(flooded)
+			vis_contents = list(NT, global.flood_object)
+		else
+			vis_contents = list(NT)
+	else if(flooded)
+		vis_contents = list(global.flood_object)
 
 	//Need to put a mouse-opaque overlay there to prevent people turning/shooting towards ACTUAL location of vis_content things
 	var/obj/effect/overlay/O = new(src)


### PR DESCRIPTION
## Description of changes
- Cleans up where and why vis_contents are updated for turfs. This cuts init time for large numbers of flooded turfs by almost half.
- Moves vis_contents updates for exterior turfs before the edge check early return, should fix #1562.

## Why and what will this PR improve
Takes Europa map init time from 160 seconds to 90. Exterior lighting is the next big init delay to tackle.

## Authorship
Me.

## Changelog
Nothing player facing.