### PR TITLE
Tweaking occupations tab display.

### DIFF
--- a/code/_helpers/cmp.dm
+++ b/code/_helpers/cmp.dm
@@ -108,3 +108,9 @@
 
 /proc/cmp_category_groups(var/datum/category_group/A, var/datum/category_group/B)
 	return A.sort_order - B.sort_order
+
+/proc/cmp_job_asc(var/datum/job/A, var/datum/job/B)
+	return A.get_occupations_tab_sort_score() - B.get_occupations_tab_sort_score()
+
+/proc/cmp_job_desc(var/datum/job/A, var/datum/job/B)
+	return B.get_occupations_tab_sort_score() - A.get_occupations_tab_sort_score()

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -39,10 +39,6 @@ SUBSYSTEM_DEF(jobs)
 			job = new jobtype
 		primary_job_datums += job
 
-	for(var/datum/job/job in primary_job_datums)
-		if(isnull(job.primary_department) && length(job.department_types))
-			job.primary_department = job.department_types[1]
-
 	// Create abstract submap archetype jobs for use in prefs, etc.
 	archetype_job_datums.Cut()
 
@@ -89,6 +85,7 @@ SUBSYSTEM_DEF(jobs)
 
 	// Update title and path tracking, submap list, etc.
 	// Populate/set up map job lists.
+	primary_job_datums = sortTim(primary_job_datums, /proc/cmp_job_desc)
 	job_lists_by_map_name = list("[global.using_map.full_name]" = list("jobs" = primary_job_datums, "default_to_hidden" = FALSE))
 
 	for(var/atype in submap_archetypes)
@@ -99,6 +96,7 @@ SUBSYSTEM_DEF(jobs)
 			if(job)
 				LAZYADD(submap_job_datums, job)
 		if(LAZYLEN(submap_job_datums))
+			submap_job_datums = sortTim(submap_job_datums, /proc/cmp_job_desc)
 			job_lists_by_map_name[arch.descriptor] = list("jobs" = submap_job_datums, "default_to_hidden" = TRUE)
 
 	// Update global map blacklists and whitelists.

--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -68,6 +68,8 @@
 
 	if(!length(department_types) && autoset_department)
 		department_types = list(global.using_map.default_department_type)
+	if(isnull(primary_department) && length(department_types))
+		primary_department = department_types[1]
 
 	if(prob(100-availablity_chance))	//Close positions, blah blah.
 		total_positions = 0
@@ -475,3 +477,9 @@
 
 /datum/job/proc/do_spawn_special(var/mob/living/character, var/mob/new_player/new_player_mob, var/latejoin = FALSE)
 	return FALSE
+
+/datum/job/proc/get_occupations_tab_sort_score()
+	. = (0.1 * head_position)
+	if(primary_department)
+		var/decl/department/dept = GET_DECL(primary_department)
+		. += dept.display_priority

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -126,7 +126,7 @@
 						if(LAZYLEN(branch_rank) > 1)
 							branch_string += "<td width='10%' align='left'><a href='?src=\ref[src];char_branch=1;checking_job=\ref[job]'>[player_branch.name_short || player_branch.name]</a></td>"
 						else
-							branch_string += "<td width='10%' align='left'>[player_branch.name_short || player_branch.name]</td>"
+							branch_string += "<td width='10%' align='left'><span class='linkOff'>[player_branch.name_short || player_branch.name]</span></td>"
 				if(!branch_string)
 					branch_string = "<td>-</td>"
 				if(player_branch)
@@ -137,7 +137,7 @@
 							if(LAZYLEN(ranks) > 1)
 								rank_branch_string += "<td width='10%' align='left'><a href='?src=\ref[src];char_rank=1;checking_job=\ref[job]'>[player_rank.name_short || player_rank.name]</a></td>"
 							else
-								rank_branch_string += "<td width='10%' align='left'>[player_rank.name_short || player_rank.name]</td>"
+								rank_branch_string += "<td width='10%' align='left'><span class='linkOff'>[player_rank.name_short || player_rank.name]</span></td>"
 				if(!rank_branch_string)
 					rank_branch_string = "<td>-</td>"
 				rank_branch_string = "[branch_string][rank_branch_string]"

--- a/maps/exodus/exodus_departments.dm
+++ b/maps/exodus/exodus_departments.dm
@@ -2,7 +2,7 @@
 	name = "Engineering"
 	announce_channel = "Engineering"
 	colour = "#ffa500"
-	display_priority = 2
+	display_priority = 4
 	display_color = "#fff5cc"
 
 /obj/item/robot_module/engineering
@@ -15,7 +15,7 @@
 	name = "Security"
 	announce_channel = "Security"
 	colour = "#dd0000"
-	display_priority = 2
+	display_priority = 3
 	display_color = "#ffddf0"
 
 /obj/item/robot_module/security
@@ -59,7 +59,7 @@
 /decl/department/command
 	name = "Command"
 	colour = "#800080"
-	display_priority = 3
+	display_priority = 5
 	display_color = "#ccccff"
 
 /obj/machinery/network/pager

--- a/maps/ministation/ministation_departments.dm
+++ b/maps/ministation/ministation_departments.dm
@@ -7,7 +7,7 @@
 /decl/department/command
 	name = "Command"
 	colour = "#800080"
-	display_priority = 3
+	display_priority = 5
 	display_color = "#ccccff"
 
 /obj/machinery/network/pager
@@ -30,7 +30,7 @@
 	goals = list(/datum/goal/department/medical_fatalities)
 	announce_channel = "Medical"
 	colour = "#008000"
-	display_priority = 2
+	display_priority = 3
 	display_color = "#ffeef0"
 
 /obj/item/robot_module/medical
@@ -56,7 +56,7 @@
 	name = "Security"
 	announce_channel = "Security"
 	colour = "#dd0000"
-	display_priority = 2
+	display_priority = 4
 	display_color = "#ffddf0"
 
 /obj/item/robot_module/security

--- a/maps/tradeship/tradeship_departments.dm
+++ b/maps/tradeship/tradeship_departments.dm
@@ -21,7 +21,7 @@
 	goals = list(/datum/goal/department/medical_fatalities)
 	announce_channel = "Medical"
 	colour = "#008000"
-	display_priority = 2
+	display_priority = 3
 	display_color = "#ffeef0"
 
 /obj/item/robot_module/medical
@@ -46,7 +46,7 @@
 /decl/department/command
 	name = "Command"
 	colour = "#800080"
-	display_priority = 3
+	display_priority = 4
 	display_color = "#ccccff"
 	goals = list(/datum/goal/department/paperwork/tradeship)
 


### PR DESCRIPTION
The occupations tab now sorts jobs a bit nicer, and formats single branch/single rank options in a more readable way.

![image](https://user-images.githubusercontent.com/2468979/133291235-ce6406ed-9e8f-4943-96c3-e782e31fa86a.png)
