### PR TITLE
Changes the VV type prompt when setting a var's type to be more useful

### DIFF
--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -139,8 +139,9 @@
 				if(isnull(current)) return CANCEL
 
 			if("type")
-				current = input("Select type for [arguments.len+1]\th argument") as null|anything in typesof(/obj, /mob, /area, /turf)
+				current = input("Enter type path for [arguments.len+1]\th argument") as null|text
 				if(isnull(current)) return CANCEL
+				current = text2path(current)
 
 			if("obj reference")
 				current = input("Select object for [arguments.len+1]\th argument") as null|obj in world

--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -142,6 +142,9 @@
 				current = input("Enter type path for [arguments.len+1]\th argument") as null|text
 				if(isnull(current)) return CANCEL
 				current = text2path(current)
+				if(!ispath(current))
+					to_chat("Inputed a bad path: '[current]'")
+					return CANCEL
 
 			if("obj reference")
 				current = input("Select object for [arguments.len+1]\th argument") as null|obj in world

--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -143,7 +143,7 @@
 				if(isnull(current)) return CANCEL
 				current = text2path(current)
 				if(!ispath(current))
-					to_chat("Inputed a bad path: '[current]'")
+					to_chat(usr, "Inputed a bad path: '[current]'")
 					return CANCEL
 
 			if("obj reference")

--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -139,11 +139,11 @@
 				if(isnull(current)) return CANCEL
 
 			if("type")
-				current = input("Enter type path for [arguments.len+1]\th argument") as null|text
-				if(isnull(current)) return CANCEL
-				current = text2path(current)
+				var/tpath = input("Enter type path for [arguments.len+1]\th argument") as null|text
+				if(isnull(tpath)) return CANCEL
+				current = text2path(tpath)
 				if(!ispath(current))
-					to_chat(usr, "Inputed a bad path: '[current]'")
+					to_chat(usr, SPAN_WARNING("Inputed a bad path: '[tpath]'"))
 					return CANCEL
 
 			if("obj reference")

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -35,7 +35,7 @@ exactly 1 "world<< uses" 'world<<|world[[:space:]]<<'
 exactly 1 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
 exactly 118 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
-exactly 19 "text2path uses" 'text2path'
+exactly 20 "text2path uses" 'text2path'
 exactly 4 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto uses" 'goto '
 exactly 6 "atom/New uses" '^/(obj|atom|area|mob|turf).*/New\('


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

Made the prompt actually ask for a type path string instead of freezing the whole server while it builds an horrible listbox with all the atom types in the game. As a bonus you can also use datum types now, which is incredibly handy for debugging and admining.

## Changelog

:cl:
tweak: Makes changing a var type in VV take a type path string instead of having the slow nearly useless listbox with all the atom types listed in.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
