### PR TITLE
Removes some direct loc sets.

### DIFF
--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -38,13 +38,13 @@
 
 	return
 
-/mob/living/silicon/ai/proc/ai_store_location(loc as text)
+/mob/living/silicon/ai/proc/ai_store_location(camera_loc as text)
 	set category = "Silicon Commands"
 	set name = "Store Camera Location"
 	set desc = "Stores your current camera location by the given name"
 
-	loc = sanitize(loc)
-	if(!loc)
+	camera_loc = sanitize(camera_loc)
+	if(!camera_loc)
 		to_chat(src, "<span class='warning'>Must supply a location name</span>")
 		return
 
@@ -52,7 +52,7 @@
 		to_chat(src, "<span class='warning'>Cannot store additional locations. Remove one first</span>")
 		return
 
-	if(loc in stored_locations)
+	if(camera_loc in stored_locations)
 		to_chat(src, "<span class='warning'>There is already a stored location by this name</span>")
 		return
 
@@ -61,8 +61,8 @@
 		to_chat(src, "<span class='warning'>Unable to store this location</span>")
 		return
 
-	stored_locations[loc] = L
-	to_chat(src, "Location '[loc]' stored")
+	stored_locations[camera_loc] = L
+	to_chat(src, "Location '[camera_loc]' stored")
 
 /mob/living/silicon/ai/proc/sorted_stored_locations()
 	return sortTim(stored_locations, /proc/cmp_text_asc)

--- a/code/game/objects/effects/chem/foam.dm
+++ b/code/game/objects/effects/chem/foam.dm
@@ -166,7 +166,7 @@
 /obj/structure/foamedmetal/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/grab))
 		var/obj/item/grab/G = I
-		G.affecting.loc = src.loc
+		G.affecting.forceMove(loc)
 		visible_message("<span class='warning'>[G.assailant] smashes [G.affecting] through the foamed metal wall.</span>")
 		qdel(I)
 		qdel(src)

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -363,9 +363,9 @@ I said no!
 
 /decl/recipe/fortunecookie/make_food(obj/container)
 	var/obj/item/paper/paper = locate() in container
-	paper.loc = null //prevent deletion
+	paper.forceMove(null) //prevent deletion
 	var/obj/item/chems/food/fortunecookie/being_cooked = ..(container)
-	paper.loc = being_cooked
+	paper.forceMove(being_cooked)
 	being_cooked.trash = paper //so the paper is left behind as trash without special-snowflake(TM Nodrak) code ~carn
 	return being_cooked
 

--- a/code/modules/xenoarcheaology/tools/picks.dm
+++ b/code/modules/xenoarcheaology/tools/picks.dm
@@ -112,7 +112,7 @@
 	var/list/obj/item/pickaxe/xeno/picksToSort = list()
 	for(var/obj/item/pickaxe/xeno/P in src)
 		picksToSort += P
-		P.loc = null
+		P.forceMove(null)
 	while(picksToSort.len)
 		var/min = 200 // No pick is bigger than 200
 		var/selected = 0
@@ -122,6 +122,6 @@
 				selected = i
 				min = current.excavation_amount
 		var/obj/item/pickaxe/xeno/smallest = picksToSort[selected]
-		smallest.loc = src
+		smallest.forceMove(src)
 		picksToSort -= smallest
 	prepare_ui()

--- a/mods/species/ascent/mobs/insectoid_egg.dm
+++ b/mods/species/ascent/mobs/insectoid_egg.dm
@@ -97,7 +97,6 @@ var/global/default_gyne
 		return
 
 	var/mob/living/carbon/alien/ascent_nymph/new_nymph = new(src, SPECIES_MANTID_NYMPH) // Spawn in the egg.
-	new_nymph.loc = src
 	new_nymph.lastarea = get_area(src)
 	new_nymph.key = C.ckey
 	new_nymph.real_name = "[random_id(/decl/species/mantid, 10000, 99999)] [lineage]"
@@ -112,5 +111,5 @@ var/global/default_gyne
 	hatching = FALSE
 	update_icon()
 	for(var/mob/M in src)
-		M.loc = get_turf(src) // Pop!
+		M.forceMove(get_turf(src)) // Pop!
 		visible_message(SPAN_NOTICE("\icon[src] \The [M] hatches out of \the [src]."))


### PR DESCRIPTION
## Description of changes

Removes instances of direct atom loc setting, or using loc as a local variable on atoms.

## Why and what will this PR improve

Direct atom loc setting is incompatible with moved event tracking and should not be used.

## Authorship

me

## Changelog
