### PR TITLE
Fixes #2108

### DIFF
--- a/code/modules/modular_computers/networking/machinery/mainframe.dm
+++ b/code/modules/modular_computers/networking/machinery/mainframe.dm
@@ -20,6 +20,7 @@
 	. = ..()
 	var/datum/extension/network_device/mainframe/M = get_extension(src, /datum/extension/network_device)
 	M.roles |= initial_roles
+	M.update_roles()
 
 /obj/machinery/network/mainframe/ui_data(mob/user, ui_key)
 	var/data = ..()


### PR DESCRIPTION
Mainframes were not telling network their roles are updated post-connection

## Description of changes

Removes the immersive IT roleplay of having to manually reboot the mainframes for network to recognize config change that happened after service was already running.

## Why and what will this PR improve

Not everyone appreciate gritty IT simulation like that

## Authorship

mememememe

## Changelog

:cl:
bugfix: Mainframes now properly start with roles enabled, so records and program download should work without a reboot
/:cl:

