### PR TITLE
Converts unit testing to byond version 514.1566

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ on:
   workflow_dispatch:
 
 env:
-  BYOND_MAJOR: "513"
-  BYOND_MINOR: "1542"
+  BYOND_MAJOR: "514"
+  BYOND_MINOR: "1566"
   SPACEMAN_DMM_VERSION: suite-1.7
 
 jobs:

--- a/code/__defines/_compile_options.dm
+++ b/code/__defines/_compile_options.dm
@@ -2,8 +2,8 @@
 // 1 will enable set background. 0 will disable set background.
 #define BACKGROUND_ENABLED 0
 
-#define REQUIRED_DM_VERSION 513
+#define REQUIRED_DM_VERSION 514
 
 #if DM_VERSION < REQUIRED_DM_VERSION
-#warn Nebula is not tested on BYOND versions older than 513. The code may not compile, and if it does compile it may have severe problems.
+#warn Nebula is not tested on BYOND versions older than 514. The code may not compile, and if it does compile it may have severe problems.
 #endif

--- a/code/modules/persistence/persistence_datum.dm
+++ b/code/modules/persistence/persistence_datum.dm
@@ -127,17 +127,6 @@
 		if(IsValidEntry(thing))
 			entries += list(CompileEntry(thing))
 
-#if DM_VERSION < 513 || (DM_VERSION == 513 && DM_BUILD < 1540)
-	for(var/list/entry in entries)
-		for(var/i in 1 to entry.len)
-			var/item = entry[i]
-			var/encoded_value = (istext(entry[item]) ? url_encode(entry[item]) : entry[item])
-			var/encoded_key = url_encode(item)
-			entry[i] = encoded_key
-			entry[encoded_key] = encoded_value
-	entries.Insert(1, list(list("url_encoded" = TRUE)))
-#endif
-
 	if(fexists(filename))
 		fdel(filename)
 	to_file(file(filename), json_encode(entries))

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-This repository is built and tested against BYOND version 513.1542 at time of writing. If this version number is at odds with `BYOND_MAJOR`.`BYOND_MINOR` as defined in [the test workflow](https://github.com/NebulaSS13/Nebula/blob/dev/.github/workflows/test.yml#L11) in the .github workflow folder, the workflow configuration should be considered authoritative and this document should be noted as out of date. Security vulnerabilities or exploits that apply to this version should be reported so that they can be closed.
+This repository is built and tested against BYOND version 514.1566 at time of writing. If this version number is at odds with `BYOND_MAJOR`.`BYOND_MINOR` as defined in [the test workflow](https://github.com/NebulaSS13/Nebula/blob/dev/.github/workflows/test.yml#L11) in the .github workflow folder, the workflow configuration should be considered authoritative and this document should be noted as out of date. Security vulnerabilities or exploits that apply to this version should be reported so that they can be closed.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Description of changes

Moves unit testing to 514.1566. Indicates that 513 will no longer be actively supported.

## Why and what will this PR improve

Allows contributors to use features from the latest stable BYOND version.

## Authorship

me

## Changelog