### PR TITLE
Changes me/looc binds to call existing verbs

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -658,8 +658,11 @@ var/global/const/MAX_VIEW = 41
 				if("OOC")
 					winset(src, "default-\ref[key]", "parent=default;name=[key];command=ooc")
 					communication_hotkeys += key
+				if("LOOC")
+					winset(src, "default-\ref[key]", "parent=default;name=[key];command=looc")
+					communication_hotkeys += key
 				if("Me")
-					winset(src, "default-\ref[key]", "parent=default;name=[key];command=me")
+					winset(src, "default-\ref[key]", "parent=default;name=[key];command=.me")
 					communication_hotkeys += key
 
 	// winget() does not work for F1 and F2

--- a/code/modules/keybindings/communication.dm
+++ b/code/modules/keybindings/communication.dm
@@ -16,15 +16,7 @@
 	name = "LOOC"
 	full_name = "Local Out Of Character Say (LOOC)"
 
-/datum/keybinding/client/communication/looc/down(client/user)
-	user.looc()
-	return TRUE
-
 /datum/keybinding/client/communication/me
 	hotkey_keys = list("F4", "M")
 	name = "Me"
 	full_name = "Custom Emote (/Me)"
-
-/datum/keybinding/client/communication/me/down(client/user)
-	user.mob.me_wrapper()
-	return TRUE


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Changes me/looc binds to call existing verbs instead of down proc overrides.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
This fixes double windows for the me keybinds and makes all the communication keybinds use the same system.
Eventually all keybinds should use winset but that's down the road.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Quardbreak and Afterthought for helping me find this, me for making the fix.
<!-- Describe original authors of changes to credit them. -->

## Changelog

:cl:
bugfix: fixes the emote keybind creating two windows
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
