### PR TITLE
Refactoring grabs to allow some more information to pass through the call chain.

### DIFF
--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -19,10 +19,10 @@
 	var/grab_slowdown = 0.15                    // Multiplier for the object size (w_class or mob_size) of the grabbed atom, applied as slowdown.
 	var/shift = 0                               // Whether or not this grab causes atoms to adjust their pixel offsets according to grabber dir.
 	var/adjust_plane = TRUE                     // Whether or not this grab causes atoms to adjust their plane/layer according to grabber dir.
-	var/success_up =   "You get a better grip on rep_affecting."
-	var/success_down = "You adjust your grip on rep_affecting."
-	var/fail_up =      "You can't get a better grip on rep_affecting!"
-	var/fail_down =    "You can't seem to shift your grip on rep_affecting!"
+	var/success_up =   "You get a better grip on $rep_affecting$."
+	var/success_down = "You adjust your grip on $rep_affecting$."
+	var/fail_up =      "You can't get a better grip on $rep_affecting$!"
+	var/fail_down =    "You can't seem to shift your grip on $rep_affecting$!"
 	var/icon
 	var/icon_state
 	var/upgrade_cooldown = 40
@@ -45,10 +45,10 @@
 	. = ..()
 
 /decl/grab/proc/string_process(var/obj/item/grab/G, var/to_write, var/obj/item/used_item)
-	to_write = replacetext(to_write, "rep_affecting", G.affecting)
-	to_write = replacetext(to_write, "rep_assailant", G.assailant)
+	to_write = replacetext(to_write, "$rep_affecting$", G.affecting)
+	to_write = replacetext(to_write, "$rep_assailant$", G.assailant)
 	if(used_item)
-		to_write = replacetext(to_write, "rep_item", used_item)
+		to_write = replacetext(to_write, "$rep_item$", used_item)
 	return to_write
 
 /decl/grab/proc/upgrade(var/obj/item/grab/G)
@@ -60,7 +60,7 @@
 		admin_attack_log(G.assailant, G.affecting, "upgraded grab on their victim to [upgrab]", "was grabbed more tightly to [upgrab]", "upgraded grab to [upgrab] on")
 		return upgrab
 	else
-		to_chat(G.assailant, "<span class='warning'>[string_process(G, fail_up)]</span>")
+		to_chat(G.assailant, SPAN_WARNING("[string_process(G, fail_up)]"))
 		return
 
 /decl/grab/proc/downgrade(var/obj/item/grab/G)
@@ -69,8 +69,7 @@
 		downgrade_effect(G)
 		return downgrab
 	else
-		to_chat(G.assailant, "<span class='warning'>[string_process(G, fail_down)]</span>")
-		return
+		to_chat(G.assailant, SPAN_WARNING("[string_process(G, fail_down)]"))
 
 /decl/grab/proc/let_go(var/obj/item/grab/G)
 	let_go_effect(G)
@@ -99,39 +98,40 @@
 		for(var/obj/item/grab/grab in thrower.get_inactive_held_items())
 			qdel(grab)
 
-/decl/grab/proc/hit_with_grab(var/obj/item/grab/G)
-	if(downgrade_on_action)
-		G.downgrade()
+/decl/grab/proc/hit_with_grab(var/obj/item/grab/G, var/atom/A, var/P = TRUE)
 
-	if(G.check_action_cooldown() && !G.attacking)
-		var/intent = G.assailant.a_intent
-		switch(intent)
+	if(QDELETED(G) || !istype(G))
+		return FALSE
 
-			if(I_HELP)
-				if(on_hit_help(G))
-					G.action_used()
-					make_log(G, help_action)
+	if(!G.check_action_cooldown() || G.is_currently_resolving_hit)
+		to_chat(G.assailant, SPAN_WARNING("You must wait before you can do that."))
+		return FALSE
 
-			if(I_DISARM)
-				if(on_hit_disarm(G))
-					G.action_used()
-					make_log(G, disarm_action)
+	G.is_currently_resolving_hit = TRUE 
+	switch(G.assailant.a_intent)
+		if(I_HELP)
+			if(on_hit_help(G, A, P))
+				. = help_action || TRUE
+		if(I_DISARM)
+			if(on_hit_disarm(G, A, P))
+				. = disarm_action || TRUE
+		if(I_GRAB)
+			if(on_hit_grab(G, A, P))
+				. = grab_action || TRUE
+		if(I_HURT)
+			if(on_hit_harm(G, A, P))
+				. = harm_action || TRUE
 
-			if(I_GRAB)
-				if(on_hit_grab(G))
-					G.action_used()
-					make_log(G, grab_action)
-
-			if(I_HURT)
-				if(on_hit_harm(G))
-					G.action_used()
-					make_log(G, harm_action)
-
-	else
-		to_chat(G.assailant, "<span class='warning'>You must wait before you can do that.</span>")
-
-/decl/grab/proc/make_log(var/obj/item/grab/G, var/action)
-	admin_attack_log(G.assailant, G.affecting, "[action]s their victim", "was [action]ed", "used [action] on")
+	if(!QDELETED(G))
+		G.is_currently_resolving_hit = FALSE
+		if(.)
+			G.action_used()
+			if(G.assailant)
+				G.assailant.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+				if(istext(.) && G.affecting)
+					admin_attack_log(G.assailant, G.affecting, "[.]s their victim", "was [.]ed", "used [.] on")
+			if(downgrade_on_action)
+				G.downgrade()
 
 // This is called whenever the assailant moves.
 /decl/grab/proc/assailant_moved(var/obj/item/grab/G)
@@ -142,7 +142,7 @@
 
 /*
 	Override these procs to set how the grab state will work. Some of them are best
-	overriden in the parent of the grab set (for example, the behaviour for on_hit_intent(var/obj/item/grab/G)
+	overriden in the parent of the grab set (for example, the behaviour for on_hit_intent()
 	procs is determined in /decl/grab/normal and then inherited by each intent).
 */
 
@@ -177,23 +177,23 @@
 // Checks if the special target works on the grabbed humanoid.
 /decl/grab/proc/check_special_target(var/obj/item/grab/G)
 
-// What happens when you hit the grabbed person with the grab on help intent.
-/decl/grab/proc/on_hit_help(var/obj/item/grab/G)
-	return 1
+// What happens when you a target with the grab on help intent.
+/decl/grab/proc/on_hit_help(var/obj/item/grab/G, var/atom/A, var/proximity)
+	return TRUE
 
-// What happens when you hit the grabbed person with the grab on disarm intent.
-/decl/grab/proc/on_hit_disarm(var/obj/item/grab/G)
-	return 1
+// What happens when you a target with the grab on disarm intent.
+/decl/grab/proc/on_hit_disarm(var/obj/item/grab/G, var/atom/A, var/proximity)
+	return TRUE
 
-// What happens when you hit the grabbed person with the grab on grab intent.
-/decl/grab/proc/on_hit_grab(var/obj/item/grab/G)
-	return 1
+// What happens when you a target with the grab on grab intent.
+/decl/grab/proc/on_hit_grab(var/obj/item/grab/G, var/atom/A, var/proximity)
+	return TRUE
 
-// What happens when you hit the grabbed person with the grab on harm intent.
-/decl/grab/proc/on_hit_harm(var/obj/item/grab/G)
-	return 1
+// What happens when you a target with the grab on harm intent.
+/decl/grab/proc/on_hit_harm(var/obj/item/grab/G, var/atom/A, var/proximity)
+	return TRUE
 
-// What happens when you hit the grabbed person with an open hand and you want it
+// What happens when you hit a target with an open hand and you want it
 // to do some special snowflake action based on some other factor such as
 // intent.
 /decl/grab/proc/resolve_openhand_attack(var/obj/item/grab/G)
@@ -213,7 +213,7 @@
 	if(!affecting)
 		return
 	if(affecting.incapacitated(INCAPACITATION_KNOCKOUT | INCAPACITATION_STUNNED))
-		to_chat(G.affecting, "<span class='warning'>You can't resist in your current state!</span>")
+		to_chat(G.affecting, SPAN_WARNING("You can't resist in your current state!"))
 	var/skill_mod = Clamp(affecting.get_skill_difference(SKILL_COMBAT, assailant), -1, 1)
 	var/break_strength = breakability + size_difference(affecting, assailant) + skill_mod
 
@@ -223,17 +223,17 @@
 		break_strength--
 
 	if(break_strength < 1)
-		to_chat(G.affecting, "<span class='warning'>You try to break free but feel that unless something changes, you'll never escape!</span>")
+		to_chat(G.affecting, SPAN_WARNING("You try to break free but feel that unless something changes, you'll never escape!"))
 		return
 
 	var/break_chance = break_chance_table[Clamp(break_strength, 1, break_chance_table.len)]
 	if(prob(break_chance))
 		if(can_downgrade_on_resist && !prob((break_chance+100)/2))
-			affecting.visible_message("<span class='warning'>[affecting] has loosened [assailant]'s grip!</span>")
+			affecting.visible_message(SPAN_WARNING("\The [affecting] has loosened \the [assailant]'s grip!"))
 			G.downgrade()
 			return
 		else
-			affecting.visible_message("<span class='warning'>[affecting] has broken free of [assailant]'s grip!</span>")
+			affecting.visible_message(SPAN_WARNING("\The [affecting] has broken free of \the [assailant]'s grip!"))
 			let_go(G)
 
 /decl/grab/proc/size_difference(mob/A, mob/B)

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -7,111 +7,108 @@
 	harm_action = "dislocate"
 	var/drop_headbutt = 1
 
-/decl/grab/normal/on_hit_help(var/obj/item/grab/G)
-	var/obj/item/organ/external/O = G.get_targeted_organ()
-	if(O)
-		return O.inspect(G.assailant)
+/decl/grab/normal/on_hit_help(var/obj/item/grab/G, var/atom/A, var/proximity)
 
-/decl/grab/normal/on_hit_disarm(var/obj/item/grab/G)
+	var/obj/item/organ/external/O = G.get_targeted_organ()
+	if(!O || !proximity || (A && A != G.get_affecting_mob()))
+		return FALSE
+	return O.inspect(G.assailant)
+
+/decl/grab/normal/on_hit_disarm(var/obj/item/grab/G, var/atom/A, var/proximity)
+
+	if(!proximity)
+		return FALSE
+
 	var/mob/living/affecting = G.get_affecting_mob()
 	var/mob/living/assailant = G.assailant
-	if(!affecting)
-		return
-	if(!G.attacking && !affecting.lying)
+	if(affecting && A && A == affecting && !affecting.lying)
 
-		affecting.visible_message("<span class='notice'>[assailant] is trying to pin [affecting] to the ground!</span>")
-		G.attacking = 1
-
+		affecting.visible_message(SPAN_DANGER("\The [assailant] is trying to pin \the [affecting] to the ground!"))
 		if(do_mob(assailant, affecting, action_cooldown - 1))
-			G.attacking = 0
 			G.action_used()
 			SET_STATUS_MAX(affecting, STAT_WEAK, 2)
-			affecting.visible_message("<span class='notice'>[assailant] pins [affecting] to the ground!</span>")
+			affecting.visible_message(SPAN_DANGER("\The [assailant] pins \the [affecting] to the ground!"))
+			return TRUE
+		affecting.visible_message(SPAN_WARNING("\The [assailant] fails to pin \the [affecting] to the ground."))
 
-			return 1
-		else
-			affecting.visible_message("<span class='notice'>[assailant] fails to pin [affecting] to the ground.</span>")
-			G.attacking = 0
-			return 0
-	else
-		return 0
+	return FALSE
 
-/decl/grab/normal/on_hit_grab(var/obj/item/grab/G)
+/decl/grab/normal/on_hit_grab(var/obj/item/grab/G, var/atom/A, var/proximity)
+
+	if(!proximity)
+		return FALSE
+
 	var/mob/living/affecting = G.get_affecting_mob()
-	var/mob/living/assailant = G.assailant
-	if(!affecting)
-		return
+	if(!affecting || (A && A != affecting))
+		return FALSE
 
-	if(!assailant.skill_check(SKILL_COMBAT, SKILL_ADEPT))
-		return
+	var/mob/living/assailant = G.assailant
+	if(!assailant || !assailant.skill_check(SKILL_COMBAT, SKILL_ADEPT))
+		return FALSE
 
 	var/obj/item/organ/external/O = G.get_targeted_organ()
 	if(!O)
-		to_chat(assailant, "<span class='warning'>[affecting] is missing that body part!</span>")
-		return 0
+		to_chat(assailant, SPAN_WARNING("\The [affecting] is missing that body part!"))
+		return FALSE
 
-	assailant.visible_message("<span class='danger'>[assailant] begins to [pick("bend", "twist")] [affecting]'s [O.name] into a jointlock!</span>")
-	G.attacking = 1
-
+	assailant.visible_message(SPAN_DANGER("\The [assailant] begins to [pick("bend", "twist")] \the [affecting]'s [O.name] into a jointlock!"))
 	if(do_mob(assailant, affecting, action_cooldown - 1))
-		G.attacking = 0
 		G.action_used()
 		O.jointlock(assailant)
-		assailant.visible_message("<span class='danger'>[affecting]'s [O.name] is twisted!</span>")
+		assailant.visible_message(SPAN_DANGER("\The [affecting]'s [O.name] is twisted!"))
 		playsound(assailant.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-		return 1
-	else
-		affecting.visible_message("<span class='notice'>[assailant] fails to jointlock [affecting]'s [O.name].</span>")
-		G.attacking = 0
-		return 0
+		return TRUE
 
-/decl/grab/normal/on_hit_harm(var/obj/item/grab/G)
+	affecting.visible_message(SPAN_WARNING("\The [assailant] fails to jointlock \the [affecting]'s [O.name]."))
+	return FALSE
+
+/decl/grab/normal/on_hit_harm(var/obj/item/grab/G, var/atom/A, var/proximity)
+
+	if(!proximity)
+		return FALSE
+
 	var/mob/living/affecting = G.get_affecting_mob()
+	if(!affecting || (A && A != affecting))
+		return FALSE
+
 	var/mob/living/assailant = G.assailant
-	if(!affecting)
-		return
-	if(!assailant.skill_check(SKILL_COMBAT, SKILL_ADEPT))
-		return
+	if(!assailant || !assailant.skill_check(SKILL_COMBAT, SKILL_ADEPT))
+		return FALSE
 
 	var/obj/item/organ/external/O = G.get_targeted_organ()
 	if(!O)
-		to_chat(assailant, "<span class='warning'>[affecting] is missing that body part!</span>")
-		return 0
+		to_chat(assailant, SPAN_WARNING("\The [affecting] is missing that body part!"))
+		return  FALSE
 
 	if(!O.dislocated)
-		assailant.visible_message("<span class='warning'>[assailant] begins to dislocate [affecting]'s [O.joint]!</span>")
-		G.attacking = 1
+		assailant.visible_message(SPAN_DANGER("\The [assailant] begins to dislocate \the [affecting]'s [O.joint]!"))
 		if(do_mob(assailant, affecting, action_cooldown - 1))
-			G.attacking = 0
 			G.action_used()
 			O.dislocate(1)
-			assailant.visible_message("<span class='danger'>[affecting]'s [O.joint] [pick("gives way","caves in","crumbles","collapses")]!</span>")
+			assailant.visible_message(SPAN_DANGER("\The [affecting]'s [O.joint] [pick("gives way","caves in","crumbles","collapses")]!"))
 			playsound(assailant.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-			return 1
-		else
-			affecting.visible_message("<span class='notice'>[assailant] fails to dislocate [affecting]'s [O.joint].</span>")
-			G.attacking = 0
-			return 0
+			return TRUE
+		affecting.visible_message(SPAN_WARNING("\The [assailant] fails to dislocate \the [affecting]'s [O.joint]."))
+		return FALSE
 
-	else if (O.dislocated > 0)
-		to_chat(assailant, "<span class='warning'>[affecting]'s [O.joint] is already dislocated!</span>")
-		return 0
+	if (O.dislocated > 0)
+		to_chat(assailant, SPAN_WARNING("\The [affecting]'s [O.joint] is already dislocated!"))
 	else
-		to_chat(assailant, "<span class='warning'>You can't dislocate [affecting]'s [O.joint]!</span>")
-		return 0
+		to_chat(assailant, SPAN_WARNING("You can't dislocate \the [affecting]'s [O.joint]!"))
+	return FALSE
 
 /decl/grab/normal/resolve_openhand_attack(var/obj/item/grab/G)
 	if(G.assailant.a_intent != I_HELP)
 		if(G.target_zone == BP_HEAD)
 			if(G.assailant.zone_sel.selecting == BP_EYES)
 				if(attack_eye(G))
-					return 1
+					return TRUE
 			else
 				if(headbutt(G))
 					if(drop_headbutt)
 						let_go()
-					return 1
-	return 0
+					return TRUE
+	return FALSE
 
 /decl/grab/normal/proc/attack_eye(var/obj/item/grab/G)
 	var/mob/living/carbon/human/target = G.get_affecting_mob()

--- a/code/modules/mob/grab/normal/norm_passive.dm
+++ b/code/modules/mob/grab/normal/norm_passive.dm
@@ -12,17 +12,20 @@
 	icon_state = "reinforce"
 	break_chance_table = list(15, 60, 100)
 
-/decl/grab/normal/passive/on_hit_disarm(var/obj/item/grab/G)
-	to_chat(G.assailant, SPAN_WARNING("Your grip isn't strong enough to pin."))
-	return 0
+/decl/grab/normal/passive/on_hit_disarm(var/obj/item/grab/G, var/atom/A, var/proximity)
+	if(proximity)
+		to_chat(G.assailant, SPAN_WARNING("Your grip isn't strong enough to pin."))
+	return FALSE
 
-/decl/grab/normal/passive/on_hit_grab(var/obj/item/grab/G)
-	to_chat(G.assailant, SPAN_WARNING("Your grip isn't strong enough to jointlock."))
-	return 0
+/decl/grab/normal/passive/on_hit_grab(var/obj/item/grab/G, var/atom/A, var/proximity)
+	if(proximity)
+		to_chat(G.assailant, SPAN_WARNING("Your grip isn't strong enough to jointlock."))
+	return FALSE
 
-/decl/grab/normal/passive/on_hit_harm(var/obj/item/grab/G)
-	to_chat(G.assailant, SPAN_WARNING("Your grip isn't strong enough to dislocate."))
-	return 0
+/decl/grab/normal/passive/on_hit_harm(var/obj/item/grab/G, var/atom/A, var/proximity)
+	if(proximity)
+		to_chat(G.assailant, SPAN_WARNING("Your grip isn't strong enough to dislocate."))
+	return FALSE
 
 /decl/grab/normal/passive/resolve_openhand_attack(var/obj/item/grab/G)
-	return 0
+	return FALSE

--- a/code/modules/mob/grab/normal/norm_struggle.dm
+++ b/code/modules/mob/grab/normal/norm_struggle.dm
@@ -59,17 +59,20 @@
 /decl/grab/normal/struggle/can_upgrade(var/obj/item/grab/G)
 	. = ..() && G.done_struggle
 
-/decl/grab/normal/struggle/on_hit_disarm(var/obj/item/grab/G)
-	to_chat(G.assailant, "<span class='warning'>Your grip isn't strong enough to pin.</span>")
-	return 0
+/decl/grab/normal/struggle/on_hit_disarm(var/obj/item/grab/G, var/atom/A, var/proximity)
+	if(proximity)
+		to_chat(G.assailant, SPAN_WARNING("Your grip isn't strong enough to pin."))
+	return FALSE
 
-/decl/grab/normal/struggle/on_hit_grab(var/obj/item/grab/G)
-	to_chat(G.assailant, "<span class='warning'>Your grip isn't strong enough to jointlock.</span>")
-	return 0
+/decl/grab/normal/struggle/on_hit_grab(var/obj/item/grab/G, var/atom/A, var/proximity)
+	if(proximity)
+		to_chat(G.assailant, SPAN_WARNING("Your grip isn't strong enough to jointlock."))
+	return FALSE
 
-/decl/grab/normal/struggle/on_hit_harm(var/obj/item/grab/G)
-	to_chat(G.assailant, "<span class='warning'>Your grip isn't strong enough to dislocate.</span>")
-	return 0
+/decl/grab/normal/struggle/on_hit_harm(var/obj/item/grab/G, var/atom/A, var/proximity)
+	if(proximity)
+		to_chat(G.assailant, SPAN_WARNING("Your grip isn't strong enough to dislocate."))
+	return FALSE
 
 /decl/grab/normal/struggle/resolve_openhand_attack(var/obj/item/grab/G)
-	return 0
+	return FALSE

--- a/code/modules/mob/grab/simple/simple_passive.dm
+++ b/code/modules/mob/grab/simple/simple_passive.dm
@@ -14,14 +14,14 @@
 /decl/grab/simple/upgrade(obj/item/grab/G)
 	return
 	
-/decl/grab/simple/on_hit_disarm(var/obj/item/grab/G)
-	return 0
+/decl/grab/simple/on_hit_disarm(var/obj/item/grab/G, var/atom/A, var/proximity)
+	return FALSE
 
-/decl/grab/simple/on_hit_grab(var/obj/item/grab/G)
-	return 0
+/decl/grab/simple/on_hit_grab(var/obj/item/grab/G, var/atom/A, var/proximity)
+	return FALSE
 
-/decl/grab/simple/on_hit_harm(var/obj/item/grab/G)
-	return 0
+/decl/grab/simple/on_hit_harm(var/obj/item/grab/G, var/atom/A, var/proximity)
+	return FALSE
 
 /decl/grab/simple/resolve_openhand_attack(var/obj/item/grab/G)
-	return 0
+	return FALSE


### PR DESCRIPTION
Split out of #2031. Basically just passes proximity and target atom through the grab chain, to be used in the ridable mob system to direct the mob towards a target.