### PR TITLE
Brute and burn meds now use max chem effect instead of stacking.

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -38,6 +38,9 @@
 #define	CE_VOICELOSS     "whispers"     // Lowers the subject's voice to a whisper
 #define CE_GLOWINGEYES   "eyeglow"      // Causes eyes to glow.
 
+#define CE_REGEN_BRUTE   "bruteheal"    // Causes brute damage to regenerate.
+#define CE_REGEN_BURN    "burnheal"     // Causes burn damage to regenerate.
+
 #define GET_CHEMICAL_EFFECT(X, C) (LAZYACCESS(X.chem_effects, C) || 0)
 
 //reagent flags

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -67,12 +67,11 @@
 		//adjustFireLoss(2.5*discomfort)
 		adjustFireLoss(5.0*discomfort)
 
-/mob/living/carbon/brain/handle_chemicals_in_body()
+/mob/living/carbon/brain/apply_chemical_effects()
 	. = ..()
-	if(.)
-		if(resting)
-			ADJ_STATUS(src, STAT_DIZZY, -4)
-		updatehealth()
+	if(resting)
+		ADJ_STATUS(src, STAT_DIZZY, -4)
+		return TRUE
 
 /mob/living/carbon/brain/handle_regular_status_updates()	//TODO: comment out the unused bits >_>
 	updatehealth()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -517,12 +517,11 @@
 			. += THERMAL_PROTECTION_HAND_RIGHT
 	return min(1,.)
 
-/mob/living/carbon/human/handle_chemicals_in_body()
+/mob/living/carbon/human/apply_chemical_effects()
 	. = ..()
-	if(.)
-		if(has_chemical_effect(CE_GLOWINGEYES, 1))
-			update_eyes()
-		updatehealth()
+	if(has_chemical_effect(CE_GLOWINGEYES, 1))
+		update_eyes()
+		return TRUE
 
 // Check if we should die.
 /mob/living/carbon/human/proc/handle_death_check()

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -70,7 +70,18 @@
 			LAZYSET(chem_doses, T, dose)
 			if(LAZYACCESS(chem_doses, T) <= 0)
 				LAZYREMOVE(chem_doses, T)
+
+	if(apply_chemical_effects())
+		updatehealth()
+
 	return TRUE
+
+/mob/living/proc/apply_chemical_effects()
+	var/burn_regen = GET_CHEMICAL_EFFECT(src, CE_REGEN_BURN)
+	var/brute_regen = GET_CHEMICAL_EFFECT(src, CE_REGEN_BURN)
+	if(burn_regen || brute_regen)
+		heal_organ_damage(brute_regen, burn_regen)
+		return TRUE
 
 /mob/living/proc/metabolize_touching_reagents()
 	var/datum/reagents/metabolism/touching_reagents = get_contact_reagents()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -797,6 +797,16 @@ default behaviour is:
 	magnitude += GET_CHEMICAL_EFFECT(src, effect)
 	LAZYSET(chem_effects, effect, magnitude)
 
+/mob/living/proc/add_chemical_effect_max(var/effect, var/magnitude = 1)
+	magnitude = max(LAZYACCESS(chem_effects, effect), magnitude)
+	LAZYSET(chem_effects, effect, magnitude)
+
+/mob/living/proc/add_chemical_effect_min(var/effect, var/magnitude = 1)
+	var/old_magnitude = LAZYACCESS(chem_effects, effect)
+	if(!isnull(old_magnitude))
+		magnitude = min(old_magnitude, magnitude)
+	LAZYSET(chem_effects, effect, magnitude)
+
 /mob/living/proc/adjust_immunity(var/amt)
 	return
 

--- a/code/modules/reagents/chems/chems_medicines.dm
+++ b/code/modules/reagents/chems/chems_medicines.dm
@@ -42,6 +42,7 @@
 	flags = IGNORE_MOB_SIZE
 	value = 1.5
 	fruit_descriptor = "medicinal"
+	var/effectiveness = 1
 
 /decl/material/liquid/brute_meds/affect_overdose(mob/living/M, alien, var/datum/reagents/holder)
 	..()
@@ -52,9 +53,11 @@
 			if(E.status & ORGAN_ARTERY_CUT && prob(2 + REAGENT_VOLUME(holder, type) / overdose))
 				E.status &= ~ORGAN_ARTERY_CUT
 
+//This is a logistic function that effectively doubles the healing rate as brute amounts get to around 200. Any injury below 60 is essentially unaffected and there's a scaling inbetween.
+#define ADJUSTED_REGEN_VAL(X) (6+(6/(1+200*2.71828**(-0.05*(X)))))
 /decl/material/liquid/brute_meds/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
-	var/overkill_healing = 6/(1+200*2.71828**(-0.05*M.getBruteLoss())) //This is a logistic function that effectively doubles the healing rate as brute amounts get to around 200. Any injury below 60 is essentially unaffected and there's a scaling inbetween.
-	M.heal_organ_damage((6+overkill_healing) * removed, 0)
+	..()
+	M.add_chemical_effect_max(CE_REGEN_BRUTE, round(effectiveness*ADJUSTED_REGEN_VAL(M.getBruteLoss())))
 	M.add_chemical_effect(CE_PAINKILLER, 10)
 
 /decl/material/liquid/burn_meds
@@ -66,11 +69,13 @@
 	scannable = 1
 	flags = IGNORE_MOB_SIZE
 	value = 1.5
+	var/effectiveness = 1
 
 /decl/material/liquid/burn_meds/affect_blood(mob/living/M, alien, removed, var/datum/reagents/holder)
-	var/overkill_healing = 6/(1+200*2.71828**(-0.05*M.getFireLoss()))	
-	M.heal_organ_damage(0, (6+overkill_healing) * removed)
+	..()
+	M.add_chemical_effect_max(CE_REGEN_BURN, round(effectiveness*ADJUSTED_REGEN_VAL(M.getFireLoss())))
 	M.add_chemical_effect(CE_PAINKILLER, 10)
+#undef ADJUSTED_REGEN_VAL
 
 /decl/material/liquid/adminordrazine //An OP chemical for admins
 	name = "Adminordrazine"
@@ -305,7 +310,9 @@
 	value = 1.5
 
 /decl/material/liquid/regenerator/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
-	M.heal_organ_damage(3 * removed, 3 * removed)
+	..()
+	M.add_chemical_effect_max(CE_REGEN_BRUTE, 3 * removed)
+	M.add_chemical_effect_max(CE_REGEN_BURN, 3 * removed)
 
 /decl/material/liquid/neuroannealer
 	name = "neuroannealer"


### PR DESCRIPTION
## Description of changes
Previously you could make things like keloderm mixes that stacked various tiers of drug with the same effect to get cumulative effects. This PR changes brute and burn meds to use the maximum chem value instead of stacking.

## Why and what will this PR improve
This removes one of the more irritating tendencies of chem/med players to push for optimized play. It is also preparation for adding more tiered chems that would be exploitable with the previous behavior.

## Authorship
Myself.

## Changelog

:cl:
tweak: Brute and burn meds no longer stack with regenerative serum.
/:cl:
