### PR TITLE
Fixes exosuit radios and lets them use intercom shortcut

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -13,6 +13,7 @@
 	cell = null
 	power_usage = 0
 	intercom = TRUE
+	intercom_handling = TRUE
 	var/number = 0
 	var/last_tick //used to delay the powercheck
 	

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -41,6 +41,8 @@
 
 	var/last_radio_sound = -INFINITY
 
+	var/intercom_handling = FALSE
+
 /obj/item/radio/proc/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)
 	frequency = new_frequency
@@ -839,6 +841,7 @@
 /obj/item/radio/exosuit
 	name = "exosuit radio"
 	cell = null
+	intercom_handling = TRUE
 
 /obj/item/radio/exosuit/get_cell()
 	. = ..()

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -46,8 +46,15 @@
 //UI distance checks
 /mob/living/exosuit/contents_nano_distance(src_object, mob/living/user)
 	. = ..()
+	if((user in pilots) && (src_object == src))
+		return STATUS_INTERACTIVE //Pilots can always interact with exosuit hosted uis
 	if(!hatch_closed)
 		return max(shared_living_nano_distance(src_object), .) //Either visible to mech(outside) or visible to user (inside)
+
+/mob/living/exosuit/exosuit/CanUseTopic(mob/user, datum/topic_state/state, href_list)
+	if(user in pilots)
+		return STATUS_INTERACTIVE
+	return ..()
 
 
 /mob/living/exosuit/ClickOn(var/atom/A, var/params, var/mob/user)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -128,10 +128,11 @@
 	switch(message_mode)
 		if("intercom")
 			if(!src.restrained())
-				for(var/obj/item/radio/intercom/I in view(1))
-					I.talk_into(src, message, null, verb, speaking)
-					I.add_fingerprint(src)
-					used_radios += I
+				for(var/obj/item/radio/I in view(1))
+					if(I.intercom_handling)
+						I.talk_into(src, message, null, verb, speaking)
+						I.add_fingerprint(src)
+						used_radios += I
 		if("headset")
 			if(l_ear && istype(l_ear,/obj/item/radio))
 				var/obj/item/radio/R = l_ear

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -122,9 +122,10 @@ var/global/list/channel_to_radio_key = new
 
 /mob/living/proc/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
 	if(message_mode == "intercom")
-		for(var/obj/item/radio/intercom/I in view(1, null))
-			I.talk_into(src, message, verb, speaking)
-			used_radios += I
+		for(var/obj/item/radio/I in view(1, null))
+			if(I.intercom_handling)
+				I.talk_into(src, message, verb, speaking)
+				used_radios += I
 	return 0
 
 /mob/living/proc/handle_speech_sound()


### PR DESCRIPTION
## Description of changes

Fixes exosuit radios being unusable, also reuses the intercom shortcut for them, so that you can talk into it without having mic on at all times

## Why and what will this PR improve

Makes exosuit radios usable and easier to use.

## Authorship

CrimsonShrike

## Changelog

:cl: CrimsonShrike
bugfix: Exosuit radios work again.
tweak: Intercom shortcut is not usable for exosuits too
/:cl:
