### PR TITLE
Fixes a few network camera bugs

### DIFF
--- a/code/datums/extensions/extensions.dm
+++ b/code/datums/extensions/extensions.dm
@@ -9,6 +9,8 @@
 		CRASH("Invalid holder type. Expected [expected_type], was [holder.type]")
 	src.holder = holder
 
+/datum/extension/proc/post_construction()
+
 /datum/extension/Destroy()
 	holder = null
 	. = ..()
@@ -30,13 +32,15 @@
 		qdel(existing_extension)
 
 	if(initial(extension_base_type.flags) & EXTENSION_FLAG_IMMEDIATE)
-		. = construct_extension_instance(extension_type, source, args.Copy(3))
-		source.extensions[extension_base_type] = .
-	else
-		var/list/extension_data = list(extension_type, source)
-		if(args.len > 2)
-			extension_data += args.Copy(3)
-		source.extensions[extension_base_type] = extension_data
+		var/datum/extension/created = construct_extension_instance(extension_type, source, args.Copy(3))
+		source.extensions[extension_base_type] = created
+		created.post_construction()
+		return created
+
+	var/list/extension_data = list(extension_type, source)
+	if(args.len > 2)
+		extension_data += args.Copy(3)
+	source.extensions[extension_base_type] = extension_data
 
 /proc/get_or_create_extension(var/datum/source, var/datum/extension/extension_type)
 	var/base_type = initial(extension_type.base_type)
@@ -52,8 +56,10 @@
 		return
 	if(islist(.)) //a list, so it's expecting to be lazy-loaded
 		var/list/extension_data = .
-		. = construct_extension_instance(extension_data[1], extension_data[2], extension_data.Copy(3))
-		source.extensions[base_type] = .
+		var/datum/extension/created = construct_extension_instance(extension_data[1], extension_data[2], extension_data.Copy(3))
+		source.extensions[base_type] = created
+		created.post_construction()
+		return created
 
 //Fast way to check if it has an extension, also doesn't trigger instantiation of lazy loaded extensions
 /proc/has_extension(var/datum/source, var/base_type)

--- a/code/game/machinery/camera/_camera_device.dm
+++ b/code/game/machinery/camera/_camera_device.dm
@@ -17,13 +17,15 @@
 	. = ..()
 	cameranet_enabled = camnet_enabled
 	requires_connection = req_connection
-	if(cameranet_enabled)
-		cameranet.add_source(holder)
 	camera_repository.add_camera_to_channels(src, channels)
 	display_name = camera_name
 
+/datum/extension/network_device/camera/post_construction()
+	if(cameranet_enabled)
+		cameranet.add_source(holder)
+
 /datum/extension/network_device/camera/Destroy()
-	camera_repository.add_camera_to_channels(src, channels)
+	camera_repository.remove_camera_from_channels(src, channels)
 	. = ..()
 
 /datum/extension/network_device/camera/ui_interact(mob/user, ui_key, datum/nanoui/ui, force_open, datum/nanoui/master_ui, datum/topic_state/state)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -204,7 +204,7 @@
 
 /obj/machinery/camera/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/paper))
-		var/datum/extension/network_device/camera/D = get_extension(src, /datum/extension/network_device/camera)
+		var/datum/extension/network_device/camera/D = get_extension(src, /datum/extension/network_device)
 		D.show_paper(W, user)
 	return ..()
 

--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -16,7 +16,7 @@
 	. = ..()
 
 /obj/item/camera/tvcamera/Initialize()
-	set_extension(src, /datum/extension/network_device/camera/television, null, null, null, TRUE, list(CAMERA_CHANNEL_TELEVISION), channel)
+	set_extension(src, /datum/extension/network_device/camera/television, null, null, null, TRUE, list(CAMERA_CHANNEL_TELEVISION), channel, FALSE)
 	radio = new(src)
 	radio.listening = FALSE
 	radio.set_frequency(ENT_FREQ)
@@ -56,7 +56,7 @@
 		var/nc = sanitize(input(usr, "Channel name", "Select new channel name", channel) as text|null)
 		if(nc)
 			channel = nc
-			var/datum/extension/network_device/camera/television/D = get_extension(src, /datum/extension/network_device/camera)
+			var/datum/extension/network_device/camera/television/D = get_extension(src, /datum/extension/network_device)
 			D.display_name = channel
 			to_chat(usr, "<span class='notice'>New channel name: '[channel]' has been set.</span>")
 	if(href_list["video"])
@@ -73,7 +73,7 @@
 		else
 			to_chat(usr,"<span class='notice'>Audio streaming: Deactivated.</span>")
 	if(href_list["net_options"])
-		var/datum/extension/network_device/camera/television/D = get_extension(src, /datum/extension/network_device/camera)
+		var/datum/extension/network_device/camera/television/D = get_extension(src, /datum/extension/network_device)
 		D.ui_interact(usr)
 	if(!href_list["close"])
 		attack_self(usr)
@@ -159,7 +159,6 @@ Using robohead because of restricting to roboticist */
 
 /datum/extension/network_device/camera/television
 	expected_type = /obj/item/camera/tvcamera
-	cameranet_enabled = FALSE
 	requires_connection = FALSE
 
 /datum/extension/network_device/camera/television/is_functional()


### PR DESCRIPTION
## Description of changes

Fixes a few bugs with network cameras. Adds a hook for post-extension construction since it's needed to properly check valid sources for the camera net.

## Why and what will this PR improve

Bugs bad.

## Authorship

Myself
## Changelog

:cl:
bugfix: Robots now properly work as cameras for the purpose of AI vision
bugfix: TV cameras can now have their network settings adjusted as intended.
/:cl: