### PR TITLE
Lighting and darkness tweaks.

### DIFF
--- a/code/datums/observation/sight_set.dm
+++ b/code/datums/observation/sight_set.dm
@@ -18,6 +18,8 @@
 
 /mob/proc/set_sight(var/new_sight)
 	var/old_sight = sight
+	if(!(new_sight & (SEE_MOBS|SEE_OBJS|SEE_TURFS)))
+		new_sight |= SEE_BLACKNESS // Avoids pixel bleed from atoms overlapping completely dark turfs, but conflicts with other flags.
 	if(old_sight != new_sight)
 		sight = new_sight
 		events_repository.raise_event(/decl/observ/sight_set, src, old_sight, new_sight)

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -15,8 +15,8 @@
 	use_power = POWER_USE_OFF
 
 	//better laser, increased brightness & power consumption
-	var/l_power = 0.8 //brightness of light when on, can be negative
-	var/l_range = 6 //outer range of light when on, can be negative
+	var/l_power = 4 //brightness of light when on, can be negative
+	var/l_range = 12 //outer range of light when on, can be negative
 
 /obj/machinery/floodlight/on_update_icon()
 	icon_state = "flood[panel_open ? "o" : ""][panel_open && get_cell() ? "b" : ""]0[use_power == POWER_USE_ACTIVE]"

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -503,7 +503,7 @@
 	var/rigged = 0		// true if rigged to explode
 	var/broken_chance = 2
 
-	var/b_power = 0.9
+	var/b_power = 0.7
 	var/b_range = 5
 	var/b_color = LIGHT_COLOR_HALOGEN
 	var/list/lighting_modes = list()
@@ -525,7 +525,8 @@
 	material = /decl/material/solid/glass
 	matter = list(/decl/material/solid/metal/aluminium = MATTER_AMOUNT_REINFORCEMENT)
 
-	b_range = 5
+	b_range = 8
+	b_power = 0.8
 	b_color = LIGHT_COLOR_HALOGEN
 	lighting_modes = list(
 		LIGHTMODE_EMERGENCY = list(l_range = 4, l_power = 1, l_color = LIGHT_COLOR_EMERGENCY),
@@ -539,8 +540,8 @@
 /obj/item/light/tube/large
 	w_class = ITEM_SIZE_SMALL
 	name = "large light tube"
-	b_power = 0.95
-	b_range = 8
+	b_power = 4
+	b_range = 12
 
 /obj/item/light/tube/large/party/Initialize() //Randomly colored light tubes. Mostly for testing, but maybe someone will find a use for them.
 	. = ..()
@@ -554,9 +555,6 @@
 	item_state = "contvapour"
 	broken_chance = 3
 	material = /decl/material/solid/glass
-
-	b_power = 0.6
-	b_range = 4
 	b_color = LIGHT_COLOR_TUNGSTEN
 	lighting_modes = list(
 		LIGHTMODE_EMERGENCY = list(l_range = 3, l_power = 1, l_color = LIGHT_COLOR_EMERGENCY),


### PR DESCRIPTION
## Description of changes
Steals some lighting values from O7 and adds SEE_BLACKNESS to base mob vision if the other SEE_FOO flags aren't present.

## Why and what will this PR improve
Light tubes look nicer.
Fixes #2051.

## Authorship
Mostly @Lohikar.

## Changelog
:cl:
tweak: Light tubes and floodlights are higher range.
/:cl:
