### PR TITLE
Adding inherent turf lights to lighting sim to replace starlight.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -206,7 +206,10 @@ var/global/list/gamemode_cache = list()
 	var/dsay_allowed = 1
 	var/aooc_allowed = 1
 
-	var/starlight = 0	// Whether space turfs have ambient light or not
+	// Default exterior lighting values for space turfs, planet turfs, etc.
+	var/starlight_r
+	var/starlight_g
+	var/starlight_b
 
 	var/law_zero = "ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'ALL LAWS OVERRIDDEN#*?&110010"
 
@@ -737,7 +740,9 @@ var/global/list/gamemode_cache = list()
 
 				if("starlight")
 					value = text2num(value)
-					config.starlight = value >= 0 ? value : 0
+					config.starlight_r = value
+					config.starlight_g = value
+					config.starlight_b = value
 
 				if("law_zero")
 					law_zero = value

--- a/code/controllers/subsystems/skybox.dm
+++ b/code/controllers/subsystems/skybox.dm
@@ -4,7 +4,12 @@ SUBSYSTEM_DEF(skybox)
 	name = "Space skybox"
 	init_order = SS_INIT_SKYBOX
 	flags = SS_NO_FIRE
-	var/background_color
+
+	// Starlight
+	var/tmp/background_color_r
+	var/tmp/background_color_g
+	var/tmp/background_color_b
+
 	var/skybox_icon = 'icons/skybox/skybox.dmi' //Path to our background. Lets us use anything we damn well please. Skyboxes need to be 736x736
 	var/background_icon = "dyable"
 	var/use_stars = TRUE
@@ -29,11 +34,14 @@ SUBSYSTEM_DEF(skybox)
 
 /datum/controller/subsystem/skybox/Initialize()
 	. = ..()
-	if(isnull(background_color))
-		background_color = RANDOM_RGB
+	background_color_r = rand(0.2, 1)
+	background_color_g = rand(0.2, 1)
+	background_color_b = rand(0.2, 1)
 
 /datum/controller/subsystem/skybox/Recover()
-	background_color = SSskybox.background_color
+	background_color_r = SSskybox.background_color_r
+	background_color_g = SSskybox.background_color_g
+	background_color_b = SSskybox.background_color_b
 	skybox_cache = SSskybox.skybox_cache
 
 /datum/controller/subsystem/skybox/proc/build_space_appearances()
@@ -114,7 +122,7 @@ SUBSYSTEM_DEF(skybox)
 	var/image/res = image(skybox_icon)
 	res.appearance_flags = PIXEL_SCALE | KEEP_TOGETHER
 
-	var/image/base = overlay_image(skybox_icon, background_icon, background_color, PIXEL_SCALE)
+	var/image/base = overlay_image(skybox_icon, background_icon, rgb(round(background_color_r * 255), round(background_color_g * 255), round(background_color_b * 255)), PIXEL_SCALE)
 
 	if(use_stars)
 		var/image/stars = overlay_image(skybox_icon, star_state, flags = PIXEL_SCALE | RESET_COLOR)
@@ -147,14 +155,16 @@ SUBSYSTEM_DEF(skybox)
 		C.update_skybox(1)
 
 //Update skyboxes. Called by universes, for now.
-/datum/controller/subsystem/skybox/proc/change_skybox(new_state, new_color, new_use_stars, new_use_overmap_details)
+/datum/controller/subsystem/skybox/proc/change_skybox(new_state, new_color_r, new_color_g, new_color_b, new_use_stars, new_use_overmap_details)
 	var/need_rebuild = FALSE
 	if(new_state != background_icon)
 		background_icon = new_state
 		need_rebuild = TRUE
 
-	if(new_color != background_color)
-		background_color = new_color
+	if(background_color_r != new_color_r || background_color_g != new_color_g || background_color_b != new_color_b)
+		background_color_r = max(new_color_r, 0.2)
+		background_color_g = max(new_color_g, 0.2)
+		background_color_b = max(new_color_b, 0.2)
 		need_rebuild = TRUE
 
 	if(new_use_stars != use_stars)

--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -23,11 +23,8 @@
 	owner = LAZYACCESS(global.overmap_sectors, "[z]")
 	if(!istype(owner))
 		owner = null
-	else
-		//Must be done here, as light data is not fully carried over by ChangeTurf (but overlays are).
-		set_light(owner.lightlevel)
-		if(owner.planetary_area && istype(loc, world.area))
-			ChangeArea(src, owner.planetary_area)
+	else if(owner.planetary_area && istype(loc, world.area))
+		ChangeArea(src, owner.planetary_area)
 
 	. = ..(mapload)	// second param is our own, don't pass to children
 
@@ -58,15 +55,14 @@
 /turf/exterior/update_ambient_light(var/mapload)
 	if(owner) // Exoplanets do their own lighting shenanigans.
 		//Must be done here, as light data is not fully carried over by ChangeTurf (but overlays are).
-		set_light(owner.lightlevel)
+		set_inherent_light(owner.lightlevel_r, owner.lightlevel_g, owner.lightlevel_b)
 		return
-	if(config.starlight)
+	if(config.starlight_r || config.starlight_g || config.starlight_b)
 		var/area/A = get_area(src)
 		if(A.show_starlight)
-			set_light(config.starlight, 0.75, l_color = SSskybox.background_color)
+			set_inherent_light(config.starlight_r, config.starlight_g, config.starlight_b)
 			return
-	if(!mapload)
-		set_light(0)
+	set_inherent_light()
 
 /turf/exterior/is_plating()
 	return !density

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -16,10 +16,10 @@
 	var/forced_dirs = 0 
 
 /turf/space/update_ambient_light(var/mapload)
-	if(config.starlight && (locate(/turf/simulated) in RANGE_TURFS(src, 1)))
-		set_light(config.starlight, 0.75, l_color = SSskybox.background_color)
+	if((config.starlight_r || config.starlight_g || config.starlight_b) && (locate(/turf/simulated) in RANGE_TURFS(src, 1)))
+		set_inherent_light(config.starlight_r * SSskybox.background_color_r, config.starlight_g * SSskybox.background_color_g, config.starlight_b * SSskybox.background_color_b)
 	else
-		set_light(0)
+		set_inherent_light()
 
 /turf/space/Initialize(var/mapload)
 

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -114,17 +114,18 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 #define GET_ABOVE(T) (HasAbove(T:z) ? get_step(T, UP) : null)
 
 // God that was a mess, now to do the rest of the corner code! Hooray!
-/datum/lighting_corner/proc/update_lumcount(delta_r, delta_g, delta_b, now = FALSE)
-	if (!(delta_r + delta_g + delta_b))
+/datum/lighting_corner/proc/update_lumcount(delta_r, delta_g, delta_b, now = FALSE, force = FALSE)
+	if (!force && !(delta_r + delta_g + delta_b))
 		return
 
 	self_r += delta_r
 	self_g += delta_g
 	self_b += delta_b
 
-	apparent_r = self_r + below_r
-	apparent_g = self_g + below_g
-	apparent_b = self_b + below_b
+	// We average our own lighting, the light below us, and any inherent light like starlight on our turf.
+	apparent_r = self_r + below_r + ((t1?.inherent_light_r + t2?.inherent_light_r + t3?.inherent_light_r + t4?.inherent_light_r) / 4)
+	apparent_g = self_g + below_g + ((t1?.inherent_light_g + t2?.inherent_light_g + t3?.inherent_light_g + t4?.inherent_light_g) / 4)
+	apparent_b = self_b + below_b + ((t1?.inherent_light_b + t2?.inherent_light_b + t3?.inherent_light_b + t4?.inherent_light_b) / 4)
 
 	var/turf/T
 	var/Ti
@@ -166,9 +167,10 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	below_g += delta_g
 	below_b += delta_b
 
-	apparent_r = self_r + below_r
-	apparent_g = self_g + below_g
-	apparent_b = self_b + below_b
+	// We average our own lighting, the light below us, and any inherent light like starlight on our turf.
+	apparent_r = self_r + below_r + ((t1?.inherent_light_r + t2?.inherent_light_r + t3?.inherent_light_r + t4?.inherent_light_r) / 4)
+	apparent_g = self_g + below_g + ((t1?.inherent_light_g + t2?.inherent_light_g + t3?.inherent_light_g + t4?.inherent_light_g) / 4)
+	apparent_b = self_b + below_b + ((t1?.inherent_light_b + t2?.inherent_light_b + t3?.inherent_light_b + t4?.inherent_light_b) / 4)
 
 	// This needs to be down here instead of the above if so the lum values are properly updated.
 	if (needs_update)

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -9,6 +9,22 @@
 	var/tmp/list/datum/lighting_corner/corners
 	var/tmp/has_opaque_atom = FALSE // Not to be confused with opacity, this will be TRUE if there's any opaque atom on the tile.
 
+	// Any inherent sourceless lights, like starlight.
+	var/tmp/inherent_light_r
+	var/tmp/inherent_light_g
+	var/tmp/inherent_light_b
+
+/turf/proc/set_inherent_light(var/_r, var/_g, var/_b)
+	if(inherent_light_r == _r && inherent_light_g == _g  && inherent_light_b == _b)
+		return
+	inherent_light_r = _r
+	inherent_light_g = _g
+	inherent_light_b = _b
+	if(!lighting_corners_initialised)
+		generate_missing_corners()
+	for(var/datum/lighting_corner/L in corners)
+		L.update_lumcount(force = TRUE)
+
 // Causes any affecting light sources to be queued for a visibility update, for example a door got opened.
 /turf/proc/reconsider_lights()
 	var/datum/light_source/L

--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -6,7 +6,11 @@
 	free_landing = TRUE
 	var/area/planetary_area
 
-	var/lightlevel = 0 		//This default makes turfs not generate light. Adjust to have exoplanents be lit.
+	// Exterior light components, 0-1. Adjust to have exoplanents be lit.
+	var/lightlevel_r = 0 		
+	var/lightlevel_g = 0 		
+	var/lightlevel_b = 0 		
+
 	var/night = TRUE
 	var/daycycle 			//How often do we change day and night
 	var/daycolumn = 0 		//Which column's light needs to be updated next?
@@ -160,11 +164,11 @@
 			update_daynight()
 
 /obj/effect/overmap/visitable/sector/exoplanet/proc/update_daynight()
-	var/light = 0.1
-	if(!night)
-		light = lightlevel
 	for(var/turf/exterior/T in block(locate(daycolumn,1,min(map_z)),locate(daycolumn,maxy,max(map_z))))
-		T.set_light(light)
+		if(night)
+			T.set_inherent_light(0.1, 0.1, 0.1)
+		else
+			T.set_inherent_light(lightlevel_r, lightlevel_g, lightlevel_b)
 	daycolumn++
 	if(daycolumn > maxx)
 		daycolumn = 0
@@ -202,7 +206,7 @@
 	spawned_features = seedRuins(map_z, features_budget, /area/exoplanet, possible_features, maxx, maxy)
 
 /obj/effect/overmap/visitable/sector/exoplanet/proc/generate_daycycle()
-	if(lightlevel)
+	if(lightlevel_r || lightlevel_g || lightlevel_b)
 		night = FALSE //we start with a day if we have light.
 
 		//When you set daycycle ensure that the minimum is larger than [maxx * daycycle_column_delay].

--- a/code/modules/overmap/exoplanets/planet_types/chlorine.dm
+++ b/code/modules/overmap/exoplanets/planet_types/chlorine.dm
@@ -22,9 +22,13 @@
 
 /obj/effect/overmap/visitable/sector/exoplanet/chlorine/generate_map()
 	if(prob(50))
-		lightlevel = rand(7,10)/10 //It could be night.
+		lightlevel_r = rand(0.5, 0.7)
+		lightlevel_g = rand(0.5, 0.7)
+		lightlevel_b = rand(0.5, 0.7)
 	else
-		lightlevel = 0.1
+		lightlevel_r = 0.1
+		lightlevel_g = 0.1
+		lightlevel_b = 0.1
 	..()
 
 /obj/effect/overmap/visitable/sector/exoplanet/chlorine/get_target_temperature()

--- a/code/modules/overmap/exoplanets/planet_types/desert.dm
+++ b/code/modules/overmap/exoplanets/planet_types/desert.dm
@@ -15,7 +15,9 @@
 
 /obj/effect/overmap/visitable/sector/exoplanet/desert/generate_map()
 	if(prob(70))
-		lightlevel = rand(5,10)/10	//deserts are usually :lit:
+		lightlevel_r = rand(0.7, 0.9)
+		lightlevel_g = rand(0.7, 0.9)
+		lightlevel_b = rand(0.7, 0.9)
 	..()
 
 /obj/effect/overmap/visitable/sector/exoplanet/desert/get_target_temperature()

--- a/code/modules/overmap/exoplanets/planet_types/grass.dm
+++ b/code/modules/overmap/exoplanets/planet_types/grass.dm
@@ -12,7 +12,9 @@
 
 /obj/effect/overmap/visitable/sector/exoplanet/grass/generate_map()
 	if(prob(40))
-		lightlevel = rand(1,7)/10	//give a chance of twilight jungle
+		lightlevel_r = rand(0.3, 0.5)
+		lightlevel_g = rand(0.3, 0.5)
+		lightlevel_b = rand(0.3, 0.5)
 	..()
 
 /obj/effect/overmap/visitable/sector/exoplanet/grass/get_target_temperature()

--- a/code/modules/overmap/exoplanets/planet_types/meat.dm
+++ b/code/modules/overmap/exoplanets/planet_types/meat.dm
@@ -17,7 +17,9 @@
 	spawn_weight = 10	// meat
 
 /obj/effect/overmap/visitable/sector/exoplanet/meat/generate_map()
-	lightlevel = rand(1,7)/10
+	lightlevel_r = rand(0.3, 0.5)
+	lightlevel_g = rand(0.3, 0.5)
+	lightlevel_b = rand(0.3, 0.5)
 	..()
 
 /obj/effect/overmap/visitable/sector/exoplanet/meat/get_target_temperature()

--- a/code/modules/overmap/exoplanets/planet_types/shrouded.dm
+++ b/code/modules/overmap/exoplanets/planet_types/shrouded.dm
@@ -7,7 +7,6 @@
 	plant_colors = list("#3c5434", "#2f6655", "#0e703f", "#495139", "#394c66", "#1a3b77", "#3e3166", "#52457c", "#402d56", "#580d6d")
 	map_generators = list(/datum/random_map/noise/exoplanet/shrouded, /datum/random_map/noise/ore/poor)
 	ruin_tags_blacklist = RUIN_HABITAT
-	lightlevel = -0.15
 	surface_color = "#3e3960"
 	water_color = "#2b2840"
 	flora_diversity = 3
@@ -18,6 +17,12 @@
 		/mob/living/simple_animal/hostile/leech
 	)
 	spawn_weight = 50
+
+/obj/effect/overmap/visitable/sector/exoplanet/shrouded/generate_map()
+	lightlevel_r = rand(0.1, 0.3)
+	lightlevel_g = rand(0.1, 0.3)
+	lightlevel_b = rand(0.1, 0.3)
+	..()
 
 /obj/effect/overmap/visitable/sector/exoplanet/shrouded/get_target_temperature()
 	return T20C - rand(10, 20)


### PR DESCRIPTION
## Description of changes
Adds inherent lighting to turfs that skips a big chunk of the lighting sim.

## Why and what will this PR improve
Should drastically lower overhead for lighting on exoplanets and space turfs.

## Authorship
Me and @Lohikar.

## Changelog
Nothing player facing.