### PR TITLE
Fix runtime on airlock init

### DIFF
--- a/code/_helpers/areas.dm
+++ b/code/_helpers/areas.dm
@@ -80,13 +80,16 @@
 	. = (A.z in z_levels)
 
 /proc/is_station_area(var/area/A)
-	. = isStationLevel(A.z)
+	if(istype(A))
+		. = isStationLevel(A.z)
 
 /proc/is_contact_area(var/area/A)
-	. = isContactLevel(A.z)
+	if(istype(A))
+		. = isContactLevel(A.z)
 
 /proc/is_player_area(var/area/A)
-	. = isPlayerLevel(A.z)
+	if(istype(A))
+		. = isPlayerLevel(A.z)
 
 /proc/is_not_space_area(var/area/A)
 	. = !istype(A,/area/space)
@@ -95,7 +98,8 @@
 	. = !istype(A) || !(A.area_flags & AREA_FLAG_SHUTTLE)
 
 /proc/is_area_with_turf(var/area/A)
-	. = isnum(A.x)
+	if(istype(A))
+		. = isnum(A.x)
 
 /proc/is_area_without_turf(var/area/A)
 	. = !is_area_with_turf(A)

--- a/code/game/machinery/doors/airlock_autoname.dm
+++ b/code/game/machinery/doors/airlock_autoname.dm
@@ -3,7 +3,10 @@
 /obj/machinery/door/airlock/hatch/autoname/Initialize()
 	. = ..()
 	var/area/A = get_area(src)
-	SetName("hatch ([A.name])")
+	if(A)
+		SetName("hatch ([A.name])")
+	else
+		log_warning("\the [src] at ([x], [y], [z]) couldn't find an area to take its name from!")
 
 /obj/machinery/door/airlock/hatch/autoname/general
 	stripe_color = COLOR_CIVIE_GREEN

--- a/code/game/machinery/doors/airlock_autoname.dm
+++ b/code/game/machinery/doors/airlock_autoname.dm
@@ -5,8 +5,6 @@
 	var/area/A = get_area(src)
 	if(A)
 		SetName("hatch ([A.name])")
-	else
-		log_warning("\the [src] at ([x], [y], [z]) couldn't find an area to take its name from!")
 
 /obj/machinery/door/airlock/hatch/autoname/general
 	stripe_color = COLOR_CIVIE_GREEN

--- a/code/game/machinery/doors/airlock_subtypes.dm
+++ b/code/game/machinery/doors/airlock_subtypes.dm
@@ -147,8 +147,10 @@
 
 /obj/machinery/door/airlock/external/get_auto_access()
 	. = ..()
-	if(is_station_area(get_area(src)))
+	var/area/A = get_area(src)
+	if(A && is_station_area(A))
 		LAZYADD(., access_external_airlocks)
+
 /obj/machinery/door/airlock/external/escapepod
 	name = "Escape Pod"
 	locked = TRUE

--- a/code/game/machinery/doors/airlock_subtypes.dm
+++ b/code/game/machinery/doors/airlock_subtypes.dm
@@ -148,7 +148,7 @@
 /obj/machinery/door/airlock/external/get_auto_access()
 	. = ..()
 	var/area/A = get_area(src)
-	if(A && is_station_area(A))
+	if(istype(A))
 		LAZYADD(., access_external_airlocks)
 
 /obj/machinery/door/airlock/external/escapepod

--- a/code/game/machinery/doors/airlock_subtypes.dm
+++ b/code/game/machinery/doors/airlock_subtypes.dm
@@ -148,7 +148,7 @@
 /obj/machinery/door/airlock/external/get_auto_access()
 	. = ..()
 	var/area/A = get_area(src)
-	if(istype(A))
+	if(A && is_station_area(A))
 		LAZYADD(., access_external_airlocks)
 
 /obj/machinery/door/airlock/external/escapepod


### PR DESCRIPTION
## Description of changes

Airlocks that autoset their access and names would runtime on init if placed outside an area. Added a warning on init without a proper area. (Edge case)

Also made sure external airlocks wouldn't runtime if they tried to get their access req from their areas if there weren't any. Was mostly an issue when building a new airlock from scratch.

## Changelog

:cl:
bugfix: Fixed runtime on autosetting airlocks placed outside an area.
bugfix: Fixed runtime on building an external airlock outside an area.
/:cl:
