### PR TITLE
Cryopod init fix

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -268,7 +268,8 @@
 /obj/machinery/cryopod/proc/find_control_computer()
 	if(!control_computer)
 		control_computer = locate(/obj/machinery/computer/cryopod) in src.loc.loc
-		events_repository.register(/decl/observ/destroyed, control_computer, src, .proc/clear_control_computer)
+		if(control_computer)
+			events_repository.register(/decl/observ/destroyed, control_computer, src, .proc/clear_control_computer)
 	return control_computer
 
 /obj/machinery/cryopod/proc/clear_control_computer()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -267,7 +267,7 @@
 
 /obj/machinery/cryopod/proc/find_control_computer()
 	if(!control_computer)
-		control_computer = locate(/obj/machinery/computer/cryopod) in src.loc.loc
+		control_computer = locate(/obj/machinery/computer/cryopod) in get_area(src)
 		if(control_computer)
 			events_repository.register(/decl/observ/destroyed, control_computer, src, .proc/clear_control_computer)
 	return control_computer


### PR DESCRIPTION
## Description of changes
Cryopods used without control computers would runtime on init, even though they shouldn't. Since the control computer was implemented to be mostly optional everywhere else in the code. 

## Changelog

:cl:
bugfix: Fix cryopods without control computers from runtiming during init.
/:cl:
