### PR TITLE
Fix runtime on update icon for injectors

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -168,7 +168,7 @@
 
 /obj/item/chems/hypospray/autoinjector/on_update_icon()
 	overlays.Cut()
-	if(reagents.total_volume > 0)
+	if(reagents?.total_volume > 0)
 		icon_state = "[initial(icon_state)]1"
 	else
 		icon_state = "[initial(icon_state)]0"


### PR DESCRIPTION
## Description of changes
If an autoinjector had no reagent contents and the reagents var wasn't initialized it would result in runtime spam on update icon. 

## Changelog

:cl:
bugfix: Fix runtime on updating the icon for empty autoinjectors.
/:cl:
