### PR TITLE
Tweaking painkiller dosage effects.

### DIFF
--- a/code/modules/reagents/chems/chems_painkillers.dm
+++ b/code/modules/reagents/chems/chems_painkillers.dm
@@ -12,6 +12,7 @@
 	value = 1.8
 	var/pain_power = 80 //magnitide of painkilling effect
 	var/effective_dose = 0.5 //how many units it need to process to reach max power
+	var/additional_effect_threshold = 2 // cumulative dosage at which slowdown and drowsiness are applied
 
 /decl/material/liquid/painkillers/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
 
@@ -25,15 +26,15 @@
 
 	M.add_chemical_effect(CE_PAINKILLER, (pain_power * effectiveness))
 
-	if(dose > 0.5 * overdose)
+	if(dose > 0.5 * additional_effect_threshold)
 		M.add_chemical_effect(CE_SLOWDOWN, 1)
 		if(prob(1))
 			SET_STATUS_MAX(M, STAT_SLUR, 10)
-	if(dose > 0.75 * overdose)
+	if(dose > 0.75 * additional_effect_threshold)
 		M.add_chemical_effect(CE_SLOWDOWN, 1)
 		if(prob(5))
 			SET_STATUS_MAX(M, STAT_SLUR, 20)
-	if(dose > overdose)
+	if(dose > additional_effect_threshold)
 		M.add_chemical_effect(CE_SLOWDOWN, 1)
 		SET_STATUS_MAX(M, STAT_SLUR, 30)
 		if(prob(1))


### PR DESCRIPTION
## Description of changes
Adds a new var to painkillers to control the cumulative dose at which additional effects begin to be applied.

## Why and what will this PR improve
Previous code used overdose, which meant you had to be sitting there taking painkillers for upwards of ten minutes before they would have additional effects.

## Authorship
Me.

## Changelog
:cl:
tweak: Painkillers will now apply their additional effects at much lower cumulative dosage.
/:cl:
