### PR TITLE
Thrusters are now dense.

### DIFF
--- a/code/modules/overmap/ships/machines/ion_thruster.dm
+++ b/code/modules/overmap/ships/machines/ion_thruster.dm
@@ -32,6 +32,7 @@
 	desc = "An advanced propulsion device, using energy and minutes amount of gas to generate thrust."
 	icon = 'icons/obj/ship_engine.dmi'
 	icon_state = "nozzle2"
+	density = 1
 	power_channel = ENVIRON
 	idle_power_usage = 100
 	anchored = TRUE
@@ -50,7 +51,7 @@
 		else
 			to_chat(user, SPAN_WARNING("\The [src] flashes an error!"))
 		return TRUE
-	
+
 	. = ..()
 
 /obj/machinery/ion_thruster/proc/burn(var/partial)


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

Thruster now has density = 1

Fixes https://github.com/HearthOfHestia/Nebula/issues/128

## Why and what will this PR improve

As with normal thrusters, you should not be able to walk on top of them.

## Authorship

me

## Changelog

:cl:
tweak: Ion Thruster density is now set to 1.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
