### PR TITLE
adds graphite bricks to mapping/orders

### DIFF
--- a/code/datums/supplypacks/materials.dm
+++ b/code/datums/supplypacks/materials.dm
@@ -52,6 +52,10 @@
 	contains = list(/obj/item/stack/material/reinforced/mapped/ocp/fifty)
 	containername = "osmium carbide plasteel sheets crate"
 
+/decl/hierarchy/supply_pack/materials/graphite50
+	name = "50 graphite bricks"
+	contains = list(/obj/item/stack/material/brick/mapped/graphite/fifty)
+
 // Material sheets (10 - Smaller amounts, less cost efficient)
 /decl/hierarchy/supply_pack/materials/marble10
 	name = "10 slabs of marble"
@@ -92,6 +96,10 @@
 	name = "10 diamond sheets"
 	contains = list(/obj/item/stack/material/gemstone/mapped/diamond/ten)
 	containername = "diamond sheets crate"
+
+/decl/hierarchy/supply_pack/materials/graphite10
+	name = "10 graphite bricks"
+	contains = list(/obj/item/stack/material/brick/mapped/graphite/ten)
 
 //wood zone
 /decl/hierarchy/supply_pack/materials/wood50

--- a/code/modules/materials/material_sheets_mapping.dm
+++ b/code/modules/materials/material_sheets_mapping.dm
@@ -44,6 +44,7 @@ STACK_SUBTYPES(iron,           "iron",                          solid/metal/iron
 STACK_SUBTYPES(copper,         "copper",                        solid/metal/copper,         ingot,      null)
 STACK_SUBTYPES(sandstone,      "sandstone",                     solid/stone/sandstone,      brick,      null)
 STACK_SUBTYPES(marble,         "marble",                        solid/stone/marble,         brick,      null)
+STACK_SUBTYPES(graphite,       "graphite",                      solid/graphite,             brick,      null)
 STACK_SUBTYPES(diamond,        "diamond",                       solid/gemstone/diamond,     gemstone,   null)
 STACK_SUBTYPES(uranium,        "uranium",                       solid/metal/uranium,        puck,       null)
 STACK_SUBTYPES(plastic,        "plastic",                       solid/plastic,              panel,      null)


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Adds graphite bricks so you can put them in maps and order them, mostly so you can power pacman generators.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
pacman generators can actually be fueled consistently now, which is cool.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Rock
<!-- Describe original authors of changes to credit them. -->

## Changelog

:cl:
tweak: graphite is now spawnable and orderable.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
