### PR TITLE
Removes/renames an unused horrible proc.

### DIFF
--- a/code/_helpers/atom_movables.dm
+++ b/code/_helpers/atom_movables.dm
@@ -27,12 +27,6 @@
 	if(final_x || final_y)
 		return locate(final_x, final_y, T.z)
 
-// Walks up the loc tree until it finds a holder of the given holder_type
-/proc/get_holder_of_type(atom/A, holder_type)
-	if(!istype(A)) return
-	for(A, A && !istype(A, holder_type), A=A.loc);
-	return A
-
 /atom/movable/proc/throw_at_random(var/include_own_turf, var/maxrange, var/speed)
 	var/list/turfs = RANGE_TURFS(src, maxrange)
 	if(!maxrange)

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -695,13 +695,6 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	else if (zone == BP_R_FOOT) return "right foot"
 	else return zone
 
-/proc/get(atom/loc, type)
-	while(loc)
-		if(istype(loc, type))
-			return loc
-		loc = loc.loc
-	return null
-
 //Whether or not the given item counts as sharp in terms of dealing damage
 /proc/is_sharp(obj/O)
 	if (!O) return 0

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -57,3 +57,10 @@
 /datum/proc/Process()
 	SHOULD_NOT_SLEEP(TRUE)
 	return PROCESS_KILL
+
+// This is more or less a helper to avoid needing to cast extension holders to atom.
+// Previously called get() and get_holder_of_type().
+// See /atom/get_recursive_loc_of_type() for actual logic.
+/datum/proc/get_recursive_loc_of_type(var/loc_type)
+	SHOULD_CALL_PARENT(FALSE)
+	CRASH("get_recursive_loc_of_type() called on datum type [type] - this proc should only be called on /atom.")

--- a/code/datums/extensions/armor/ablative.dm
+++ b/code/datums/extensions/armor/ablative.dm
@@ -19,7 +19,7 @@
 		if(damage_blocked)
 			var/new_armor = max(0, get_value(key) - armor_degradation_coef * damage_blocked)
 			set_value(key, new_armor)
-			var/mob/M = get_holder_of_type(holder, /mob)
+			var/mob/M = holder.get_recursive_loc_of_type(/mob)
 			if(istype(M))
 				var/list/visible = get_visible_damage()
 				for(var/k in visible)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -581,3 +581,11 @@ its easier to just keep the beam vertical.
 	M.Scale(icon_scale_x, icon_scale_y)
 	M.Turn(icon_rotation)
 	animate(src, transform = M, transform_animate_time)
+
+// Walks up the loc tree until it finds a loc of the given loc_type
+/atom/get_recursive_loc_of_type(var/loc_type)
+	var/atom/check_loc = loc
+	while(check_loc)
+		if(istype(check_loc, loc_type))
+			return check_loc
+		check_loc = check_loc.loc

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -227,7 +227,7 @@ var/global/list/global/tank_gauge_cache = list()
 		proxyassembly.assembly.attack_self(user)
 
 /obj/item/tank/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
-	var/mob/living/carbon/location = get(src, /mob/living/carbon)
+	var/mob/living/carbon/location = get_recursive_loc_of_type(/mob/living/carbon)
 
 	var/using_internal
 	if(istype(location))

--- a/code/modules/clothing/rings/material.dm
+++ b/code/modules/clothing/rings/material.dm
@@ -20,7 +20,7 @@
 /obj/item/clothing/ring/material/OnTopic(var/mob/user, var/list/href_list)
 	if(href_list["examine"])
 		if(istype(user))
-			var/mob/living/carbon/human/H = get_holder_of_type(src, /mob/living/carbon/human)
+			var/mob/living/carbon/human/H = get_recursive_loc_of_type(/mob/living/carbon/human)
 			if(H.Adjacent(user))
 				user.examinate(src)
 				return TOPIC_HANDLED

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -27,7 +27,7 @@
 
 // Used to install preset-specific programs
 /obj/item/modular_computer/proc/install_default_programs()
-	var/mob/living/carbon/human/H = get_holder_of_type(src, /mob)
+	var/mob/living/carbon/human/H = get_recursive_loc_of_type(/mob)
 	var/list/job_programs = list()
 	if(H)
 		var/datum/job/jb = SSjobs.get_by_title(H.job)

--- a/code/modules/modular_computers/file_system/programs/generic/email_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/email_client.dm
@@ -90,7 +90,7 @@
 		return net.get_email_addresses()
 
 /datum/nano_module/program/email_client/proc/mail_received(var/datum/computer_file/data/email_message/received_message)
-	var/mob/living/L = get_holder_of_type(host, /mob/living)
+	var/mob/living/L = host.get_recursive_loc_of_type(/mob/living)
 	if(L)
 		var/list/msg = list()
 		msg += "*--*\n"

--- a/code/modules/modular_computers/file_system/programs/generic/folding.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/folding.dm
@@ -59,8 +59,7 @@
 
 	if(world.timeofday > next_event)
 		return
-
-	var/mob/living/holder = get_holder_of_type(computer, /mob/living/carbon/human)
+	var/mob/living/holder = computer.holder.get_recursive_loc_of_type(/mob/living/carbon/human)
 	if(!crashed)
 		if(holder)
 			switch(rand(1,3))

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -59,18 +59,19 @@
 				animate(src, pixel_x = rand(-16, 16), pixel_y = rand(-16, 16), transform = turn(matrix(), rand(120, 300)), time = rand(3, 8))
 
 /obj/item/ammo_casing/proc/leave_residue()
-	var/mob/living/carbon/human/H = get_holder_of_type(src, /mob/living/carbon/human)
-	var/obj/item/gun/G = get_holder_of_type(src, /obj/item/gun)
-	put_residue_on(G)
-	if(H)
-		for(var/bp in H.held_item_slots)
-			var/datum/inventory_slot/inv_slot = H.held_item_slots[bp]
-			if(G == inv_slot?.holding)
-				var/target = H.get_covering_equipped_item_by_zone(bp)
-				if(!target)
-					target = H.get_organ(bp)
-				put_residue_on(target)
-				break
+	var/obj/item/gun/G = get_recursive_loc_of_type(/obj/item/gun)
+	if(G)
+		put_residue_on(G)
+		var/mob/living/carbon/human/H = G.get_recursive_loc_of_type(/mob/living/carbon/human)
+		if(H)
+			for(var/bp in H.held_item_slots)
+				var/datum/inventory_slot/inv_slot = H.held_item_slots[bp]
+				if(G == inv_slot?.holding)
+					var/target = H.get_covering_equipped_item_by_zone(bp)
+					if(!target)
+						target = H.get_organ(bp)
+					put_residue_on(target)
+					break
 	if(prob(30))
 		put_residue_on(get_turf(src))
 

--- a/code/modules/projectiles/guns/energy/secure.dm
+++ b/code/modules/projectiles/guns/energy/secure.dm
@@ -23,7 +23,7 @@
 	item_flags = ITEM_FLAG_INVALID_FOR_CHAMELEON
 
 /obj/item/gun/energy/gun/secure/mounted/Initialize()
-	var/mob/borg = get_holder_of_type(src, /mob/living/silicon/robot)
+	var/mob/borg = get_recursive_loc_of_type(/mob/living/silicon/robot)
 	if(!borg)
 		. = INITIALIZE_HINT_QDEL
 		CRASH("Invalid spawn location.")

--- a/code/modules/projectiles/secure.dm
+++ b/code/modules/projectiles/secure.dm
@@ -84,7 +84,7 @@
 	if(mode == sel_mode && !authorized)
 		switch_firemodes()
 
-	var/mob/user = get_holder_of_type(src, /mob)
+	var/mob/user = get_recursive_loc_of_type(/mob)
 	if(user)
 		to_chat(user, SPAN_NOTICE("Your [src.name] has been [authorized ? "granted" : "denied"] [firemodes[mode]] fire authorization by [by]."))
 

--- a/code/modules/xenoarcheaology/finds/find_types/fossils.dm
+++ b/code/modules/xenoarcheaology/finds/find_types/fossils.dm
@@ -55,7 +55,7 @@
 	if(istype(W, /obj/item/fossil/animal))
 		if(!user.canUnEquip(W))
 			return
-		var/mob/M = get_holder_of_type(src, /mob)
+		var/mob/M = get_recursive_loc_of_type(/mob)
 		if(M && !M.unEquip(src))
 			return
 		var/obj/o = new /obj/structure/skeleton(get_turf(src))


### PR DESCRIPTION
## Description of changes
Unifies `get()` and `get_holder_of_type()` as an `/atom` proc (actually a `/datum` proc but shh).
Calling it on a `/datum` will crash, this is to expose issues that previously went hidden with the other procs.
Fixes a couple of aforementioned issues (being called on extensions instead of extension holders).

## Why and what will this PR improve
Code quality.

## Authorship
Myself.

## Changelog
Nothing player facing.