### PR TITLE
Ctrl-click grabs are now deferred to an empty hand

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -259,7 +259,7 @@
 	return FALSE
 
 /atom/movable/CtrlClick(var/mob/living/user)
-	return try_make_grab(user) || ..()
+	return try_make_grab(user, defer_hand = TRUE) || ..()
 
 /*
 	Alt click

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -490,5 +490,5 @@
 /atom/movable/proc/handle_buckled_relaymove(var/datum/movement_handler/mh, var/mob/mob, var/direction, var/mover)
 	return
 
-/atom/movable/proc/try_make_grab(var/mob/living/user)
+/atom/movable/proc/try_make_grab(var/mob/living/user, var/defer_hand = FALSE)
 	return istype(user) && CanPhysicallyInteract(user) && !user.lying && user.make_grab(src)

--- a/code/modules/mechs/mech_grabs.dm
+++ b/code/modules/mechs/mech_grabs.dm
@@ -1,4 +1,4 @@
-/mob/living/exosuit/can_grab(atom/movable/target, target_zone)
+/mob/living/exosuit/can_grab(atom/movable/target, target_zone, defer_hand = FALSE)
 	return FALSE
 
 /mob/living/exosuit/can_be_grabbed(mob/grabber, target_zone)

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -20,7 +20,7 @@
 /*
 	This section is for overrides of existing procs.
 */
-/obj/item/grab/Initialize(mapload, atom/movable/target, var/use_grab_state)
+/obj/item/grab/Initialize(mapload, atom/movable/target, var/use_grab_state, var/defer_hand)
 	. = ..(mapload)
 	if(. == INITIALIZE_HINT_QDEL)
 		return
@@ -29,7 +29,7 @@
 	if(!istype(current_grab))
 		return INITIALIZE_HINT_QDEL
 	assailant = loc
-	if(!istype(assailant) || !assailant.add_grab(src))
+	if(!istype(assailant) || !assailant.add_grab(src, defer_hand = defer_hand))
 		return INITIALIZE_HINT_QDEL
 	affecting = target
 	if(!istype(affecting))

--- a/code/modules/mob/living/carbon/human/human_grabs.dm
+++ b/code/modules/mob/living/carbon/human/human_grabs.dm
@@ -1,7 +1,10 @@
-/mob/living/carbon/human/add_grab(var/obj/item/grab/grab)
-	. = put_in_active_hand(grab)
+/mob/living/carbon/human/add_grab(var/obj/item/grab/grab, var/defer_hand = FALSE)
+	if(defer_hand)
+		. = put_in_hands(grab)
+	else
+		. = put_in_active_hand(grab)
 
-/mob/living/carbon/human/can_be_grabbed(var/mob/grabber, var/target_zone)
+/mob/living/carbon/human/can_be_grabbed(var/mob/grabber, var/target_zone, var/defer_hand = FALSE)
 	. = ..()
 	if(.)
 		var/obj/item/organ/external/organ = get_organ(target_zone)
@@ -9,7 +12,7 @@
 			to_chat(grabber, SPAN_WARNING("\The [src] is missing that body part!"))
 			return FALSE
 		if(grabber == src)
-			var/using_slot = get_active_held_item_slot()
+			var/using_slot = defer_hand ? get_empty_hand_slot() : get_active_held_item_slot()
 			if(!using_slot)
 				to_chat(src, SPAN_WARNING("You cannot grab yourself without a usable hand!"))
 				return FALSE

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
@@ -15,7 +15,7 @@
 		return
 	. = ..()
 	if(length(.))
-		var/list/filtered_enemies = list() 
+		var/list/filtered_enemies = list()
 		for(var/weakref/enemy in enemies) // Remove all entries that aren't in enemies
 			var/M = enemy.resolve()
 			if(M in .)
@@ -46,6 +46,6 @@
 	. = ..()
 	Retaliate()
 
-/mob/living/simple_animal/hostile/retaliate/try_make_grab(mob/living/user)
+/mob/living/simple_animal/hostile/retaliate/try_make_grab(mob/living/user, defer_hand = FALSE)
 	. = ..()
 	Retaliate()

--- a/code/modules/mob/mob_grabs.dm
+++ b/code/modules/mob/mob_grabs.dm
@@ -39,7 +39,7 @@
 /mob/proc/handle_grabs_after_move()
 	set waitfor = FALSE
 
-/mob/proc/add_grab(var/obj/item/grab/grab)
+/mob/proc/add_grab(var/obj/item/grab/grab, var/defer_hand = FALSE)
 	return FALSE
 
 /mob/proc/ProcessGrabs()
@@ -51,4 +51,4 @@
 		. += grab
 
 /mob/get_object_size()
-	return mob_size	
+	return mob_size


### PR DESCRIPTION


<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Grabs with ctrl-click will now go into any available empty hand, if one exists.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
Highly requested QoL change from Hearth. I think this is an acceptable compromise between requiring hand-switching (which is sensible on grab intent) and the old pull functionality. Now, ctrl-clicking will put the grab in any hand
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship

<!-- Describe original authors of changes to credit them. -->

## Changelog

:cl:
tweak: Grabs with ctrl-click will now go into any available empty hand, if one exists.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
