### PR TITLE
Hotfix for observer compile error.

### DIFF
--- a/code/modules/mob/observer/observer.dm
+++ b/code/modules/mob/observer/observer.dm
@@ -15,12 +15,12 @@ var/global/const/GHOST_IMAGE_ALL = ~GHOST_IMAGE_NONE
 	stat = DEAD
 	status_flags = GODMODE
 	shift_to_open_context_menu = FALSE
-	glide_size = 0
 	var/ghost_image_flag = GHOST_IMAGE_DARKNESS
 	var/image/ghost_image = null //this mobs ghost image, for deleting and stuff
 
 /mob/observer/Initialize()
 	. = ..()
+	glide_size = 0
 	ghost_image = image(src.icon,src)
 	ghost_image.plane = plane
 	ghost_image.layer = layer


### PR DESCRIPTION
Fixes the compiler error due to glide size override on latest BYOND. To be reverted once BYOND is updated to 514.1570