### PR TITLE
Fixes sight issues with blueprints and shuttle landing

### DIFF
--- a/code/datums/observation/sight_set.dm
+++ b/code/datums/observation/sight_set.dm
@@ -20,6 +20,8 @@
 	var/old_sight = sight
 	if(!(new_sight & (SEE_MOBS|SEE_OBJS|SEE_TURFS)))
 		new_sight |= SEE_BLACKNESS // Avoids pixel bleed from atoms overlapping completely dark turfs, but conflicts with other flags.
+	else
+		new_sight &= ~SEE_BLACKNESS
 	if(old_sight != new_sight)
 		sight = new_sight
 		events_repository.raise_event(/decl/observ/sight_set, src, old_sight, new_sight)


### PR DESCRIPTION
## Description of changes

Fixes a bug with vision handlers in general that caused SEE_BLACKNESS to be applied to the parent mob's sight even when SEE_TURF etc. were present. In particular, this affect shuttle landing and blueprints, making them essentially unfunctional as mobs would only see blackness.

The cause of this bug is update_sight() being called multiple times in the vision update procs, with the initial call adding the SEE_BLACKNESS flag which wasn't removed afterwards. This should really be cleaned up in the future, but if SEE_BLACKNESS and SEE_TURF|SEE_MOBS|SEE_OBJS aren't supposed to be present together as a rule, then this fix seems appropriate as well.

## Authorship

Myself

## Changelog

:cl:
bugfix: Fixes a bug with blueprint and shuttle landing vision causing mobs to see blackness.
/:cl: