### PR TITLE
Apply KEEP_TOGETHER to humantype mobs

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -206,7 +206,7 @@ Please contact me on #coderbus IRC. ~Carn x
 	var/obj/item/organ/external/head/head = organs_by_name[BP_HEAD]
 	if(istype(head) && !head.is_stump())
 		var/image/I = head.get_eye_overlay()
-		if(I) 
+		if(I)
 			add_overlay(I)
 
 /mob/living/carbon/human/proc/get_icon_scale_mult()
@@ -220,9 +220,10 @@ Please contact me on #coderbus IRC. ~Carn x
 	var/desired_scale_x = icon_scale_values[1]
 	var/desired_scale_y = icon_scale_values[2]
 
-	// Apply KEEP_TOGETHER so all the component overlays don't ignore PIXEL_SCALE 
-	// when scaling, or remove it if we aren't doing any scaling (due to cost).
-	if(desired_scale_x == 1 && desired_scale_y == 1)
+	// Apply KEEP_TOGETHER so all the component overlays move properly when
+	// applying a transform, or remove it if we aren't doing any transforms
+	// (due to cost).
+	if(!lying && desired_scale_x == 1 && desired_scale_y == 1)
 		appearance_flags &= ~KEEP_TOGETHER
 	else
 		appearance_flags |= KEEP_TOGETHER


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Applies KEEP_TOGETHER to humantype mobs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
In testing, this fixed the issue of non-32x32 mobs with 32x32 overlays falling apart/dismantling when transforms are applied.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Thanks to Loaf for suggesting this.
<!-- Describe original authors of changes to credit them. -->