### PR TITLE
Replace initial(name) in stored_items with atom info repository

### DIFF
--- a/code/datums/vending/stored_item.dm
+++ b/code/datums/vending/stored_item.dm
@@ -11,12 +11,7 @@
 	src.storing_object = storing_object
 	src.item_path = path
 	src.amount = amount
-
-	if(!name)
-		var/atom/tmp = path
-		src.item_name = initial(tmp.name)
-	else
-		src.item_name = name
+	src.item_name = name || atom_info_repository.get_name_for(path)
 	..()
 
 /datum/stored_items/Destroy()

--- a/code/game/machinery/vending/botany.dm
+++ b/code/game/machinery/vending/botany.dm
@@ -43,9 +43,9 @@
 		/obj/item/seeds/carrotseed = 3,
 		/obj/item/seeds/chantermycelium = 3,
 		/obj/item/seeds/chiliseed = 3,
-		/obj/item/seeds/cornseed = 3, 
-		/obj/item/seeds/eggplantseed = 3, 
-		/obj/item/seeds/potatoseed = 3, 
+		/obj/item/seeds/cornseed = 3,
+		/obj/item/seeds/eggplantseed = 3,
+		/obj/item/seeds/potatoseed = 3,
 		/obj/item/seeds/soyaseed = 3,
 		/obj/item/seeds/sunflowerseed = 3,
 		/obj/item/seeds/tomatoseed = 3,
@@ -92,6 +92,3 @@
 	icon_state = "seeds_generic"
 	icon_vend = "seeds_generic-vend"
 	icon_deny = "seeds_generic-deny"
-
-/obj/machinery/vending/hydroseeds/get_product_name(var/entry)
-	. = atom_info_repository.get_name_for(entry)


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Replaces initial(name) in stored_items with getting the name from the atom info repository.
Also removes code from hydroseed vendors that basically did this but with a bespoke override; it's now the default functionality. I kept `/obj/machinery/vending/get_product_name(entry)` because it could be useful in the future, though.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
Bottles in the hydroponics vendor and Medical's vendors were just named `bottle`, this should take label_text into effect. It'll probably make names in vendors/smartfridges more accurate in general, too.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Me.
<!-- Describe original authors of changes to credit them. -->

## Changelog

:cl:
bugfix: Vendors will no longer show all bottles as simply 'bottle'.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
