### PR TITLE
Machines rely more on dex checks than brain damage, dex checks now influenced by brainloss

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -255,6 +255,8 @@ var/global/list/gamemode_cache = list()
 
 	var/no_throttle_localhost
 
+	var/dex_malus_brainloss_threshold = 30 //The threshold of when brainloss begins to affect dexterity. 
+
 	var/static/list/protected_vars = list(
 		"comms_password",
 		"ban_comms_password",
@@ -893,6 +895,8 @@ var/global/list/gamemode_cache = list()
 
 				if("use_loyalty_implants")
 					config.use_loyalty_implants = 1
+				if("dexterity_malus_brainloss_threshold")
+					config.dex_malus_brainloss_threshold = text2num(value)
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -279,14 +279,6 @@ Class Procs:
 		return FALSE // The interactions below all assume physical access to the machine. If this is not the case, we let the machine take further action.
 	if(!user.check_dexterity(required_interaction_dexterity))
 		return TRUE
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.getBrainLoss() >= 55)
-			visible_message("<span class='warning'>[H] stares cluelessly at \the [src].</span>")
-			return 1
-		else if(prob(H.getBrainLoss()))
-			to_chat(user, "<span class='warning'>You momentarily forget how to use \the [src].</span>")
-			return 1
 	if((. = component_attack_hand(user)))
 		return
 	if(wires && (. = wires.Interact(user)))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1764,6 +1764,9 @@
 	if(isnull(force_active_hand))
 		force_active_hand = get_active_held_item_slot()
 	var/obj/item/organ/external/active_hand = organs_by_name[force_active_hand]
+	var/dex_malus = 0
+	if(getBrainLoss() && getBrainLoss() > config.dex_malus_brainloss_threshold) ///brainloss shouldn't instantly cripple you, so the effects only start once past the threshold and escalate from there.
+		dex_malus = round(clamp(round(getBrainLoss()-config.dex_malus_brainloss_threshold)/10, 0, 7))
 	if(!active_hand)
 		if(!silent)
 			to_chat(src, SPAN_WARNING("Your hand is missing!"))
@@ -1771,9 +1774,11 @@
 	if(!active_hand.is_usable())
 		to_chat(src, SPAN_WARNING("Your [active_hand.name] is unusable!"))
 		return
-	if(active_hand.get_dexterity() < dex_level)
-		if(!silent)
+	if((active_hand.get_dexterity()-dex_malus) < dex_level)
+		if(!silent && !dex_malus)
 			to_chat(src, SPAN_WARNING("Your [active_hand.name] doesn't have the dexterity to use that!"))
+		else if(!silent)
+			to_chat(src, SPAN_WARNING("Your [active_hand.name] doesn't respond properly!"))
 		return FALSE
 	return TRUE
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1766,7 +1766,7 @@
 	var/obj/item/organ/external/active_hand = organs_by_name[force_active_hand]
 	var/dex_malus = 0
 	if(getBrainLoss() && getBrainLoss() > config.dex_malus_brainloss_threshold) ///brainloss shouldn't instantly cripple you, so the effects only start once past the threshold and escalate from there.
-		dex_malus = round(clamp(round(getBrainLoss()-config.dex_malus_brainloss_threshold)/10, 0, 7))
+		dex_malus = round(clamp(round(getBrainLoss()-config.dex_malus_brainloss_threshold)/10, DEXTERITY_NONE, DEXTERITY_FULL))
 	if(!active_hand)
 		if(!silent)
 			to_chat(src, SPAN_WARNING("Your hand is missing!"))

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -88,3 +88,6 @@ MAX_CLIENT_VIEW_Y 30
 
 ## Allow multiple input keys to be pressed for diagonal movement.
 #ALLOW_DIAGONAL_MOVEMENT
+
+## Threshold of where brain damage begins to affect dexterity (70 brainloss above this means zero dexterity). Default is 30.
+#DEXTERITY_MALUS_BRAINLOSS_THRESHOLD 30


### PR DESCRIPTION

<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

Machinery no longer has the weird brainloss check that makes you completely incapable of using machines.
Instead, human dexterity is influenced by a malus to dexterity over a certain threshold of brain damage.

## Why and what will this PR improve

It's really bad that if you have 55 brain damage, you can't do anything. Even press buttons.

This PR changes that behavior. As of current, over 30 brain damage, for every 10 brainloss you take a -1 to dexterity. Meaning you can take 110 brainloss before you are completely incapable of using objects.

## Authorship

Mazian/Andromeda-K22

## Changelog

:cl:
tweak: machines no longer directly check brainloss, but instead rely fully on dexterity checks.
balance: dexterity is influenced by brain damage, starting at 30 brainloss (configurable). Dexterity loss is on a sliding scale.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
