### PR TITLE
fix sleeper overdose

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -366,10 +366,10 @@
 	if(!occupant || !occupant.reagents)
 		to_chat(user, SPAN_WARNING("There's no suitable occupant in \the [src]."))
 		return
-	var/decl/material/chem = GET_DECL(canister.reagents.primary_reagent)
-	if(canister.reagents.primary_reagent in occupant.reagents.reagent_volumes)
-		if((occupant.reagents.reagent_volumes[canister.reagents.primary_reagent] + amount) > chem.overdose && chem.overdose != 0 && !emagged)
-			to_chat(user, SPAN_WARNING("Injecting more chemicals presents an overdose risk to the subject."))
+	if(!emagged && canister.reagents?.primary_reagent)
+		var/decl/material/chem = GET_DECL(canister.reagents.primary_reagent)
+		if(chem.overdose && REAGENT_VOLUME(occupant.reagents, canister.reagents.primary_reagent) + amount >= chem.overdose)
+			to_chat(user, SPAN_WARNING("Injecting more [chem.name] presents an overdose risk to the subject."))
 			return
 	canister.reagents.trans_to_mob(occupant, amount, target_transfer_type)
 	to_chat(user, SPAN_NOTICE("You use \the [src] to [target_transfer_type == CHEM_INJECT ? "inject" : "infuse"] [amount] unit\s from \the [canister] into \the [occupant]."))

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -366,9 +366,11 @@
 	if(!occupant || !occupant.reagents)
 		to_chat(user, SPAN_WARNING("There's no suitable occupant in \the [src]."))
 		return
-	if(occupant.reagents.total_volume + amount > 20 && !emagged)
-		to_chat(user, SPAN_WARNING("Injecting more chemicals presents an overdose risk to the subject."))
-		return
+	var/decl/material/chem = GET_DECL(canister.reagents.primary_reagent)
+	if(canister.reagents.primary_reagent in occupant.reagents.reagent_volumes)
+		if((occupant.reagents.reagent_volumes[canister.reagents.primary_reagent] + amount) > chem.overdose && chem.overdose != 0 && !emagged)
+			to_chat(user, SPAN_WARNING("Injecting more chemicals presents an overdose risk to the subject."))
+			return
 	canister.reagents.trans_to_mob(occupant, amount, target_transfer_type)
 	to_chat(user, SPAN_NOTICE("You use \the [src] to [target_transfer_type == CHEM_INJECT ? "inject" : "infuse"] [amount] unit\s from \the [canister] into \the [occupant]."))
 


### PR DESCRIPTION
## Description of changes
now the sleeper checks if the main reagent of the mixture is actually causing an overdose 

## Authorship

Me

## Changelog

:cl:
tweak: Sleeper uses actual drug dosages to stop you from overdosing 
/:cl:
