### PR TITLE
General machinery optimization

### DIFF
--- a/code/game/area/area_power.dm
+++ b/code/game/area/area_power.dm
@@ -4,6 +4,9 @@
 #define ENVIRON 3
 */
 
+/area
+	var/list/machinery_list
+
 /area/proc/powered(var/chan)		// return true if the area has power to given channel
 	if(!requires_power)
 		return 1
@@ -23,7 +26,7 @@
 
 // called when power status changes
 /area/proc/power_change()
-	for(var/obj/machinery/M in src)	// for each machine in the area
+	for(var/obj/machinery/M in machinery_list)	// for each machine in the area
 		M.power_change()			// reverify power status (to update icons etc.)
 	if (atmosalm || fire || eject || party)
 		update_icon()
@@ -74,7 +77,7 @@
 	used_equip = 0
 	used_light = 0
 	used_environ = 0
-	for(var/obj/machinery/M in src)
+	for(var/obj/machinery/M in machinery_list)
 		switch(M.power_channel)
 			if(EQUIP)
 				used_equip += M.get_power_usage()

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -134,12 +134,20 @@ Class Procs:
 	RefreshParts()
 	power_change()
 
+	var/area/A = get_area(src)
+	if(A)
+		LAZYADD(A.machinery_list, src) // Add machinery object to area machinery list
+
 /obj/machinery/Destroy()
 	if(istype(wires))
 		QDEL_NULL(wires)
 	SSmachines.machinery -= src
 	QDEL_NULL_LIST(component_parts) // Further handling is done via destroyed events.
 	STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_ALL)
+
+	var/area/A = get_area(src)
+	if(A)
+		LAZYREMOVE(A.machinery_list, src) // Remove machinery object from area machinery list
 	. = ..()
 
 /obj/machinery/proc/ProcessAll(var/wait)
@@ -467,3 +475,11 @@ Class Procs:
 
 /obj/machinery/get_matter_amount_modifier()
 	. = ..() * HOLLOW_OBJECT_MATTER_MULTIPLIER // machine matter is largely just the frame, and the components contribute most of the matter/value.
+
+/obj/machinery/wrench_floor_bolts(mob/user, delay)
+	. = ..()
+	var/area/A = get_area(src)
+	if(anchored)
+		A.machinery_list |= src
+	else
+		A.machinery_list -= src

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -228,6 +228,8 @@ var/global/list/all_apcs = list()
 		return
 	failure_timer = max(failure_timer, round(duration))
 	playsound(src, 'sound/machines/apc_nopower.ogg', 75, 0)
+	update()
+	queue_icon_update()
 
 /obj/machinery/power/apc/proc/init_round_start()
 	var/obj/item/stock_parts/power/terminal/term = get_component_of_type(/obj/item/stock_parts/power/terminal)
@@ -738,11 +740,13 @@ var/global/list/all_apcs = list()
 		return
 
 	if(failure_timer)
-		update()
-		queue_icon_update()
 		failure_timer--
-		force_update = 1
-		return
+
+		if(!failure_timer)
+			update()
+			queue_icon_update()
+
+		else return
 
 	lastused_light = (lighting >= POWERCHAN_ON) ? area.usage(LIGHT) : 0
 	lastused_equip = (equipment >= POWERCHAN_ON) ? area.usage(EQUIP) : 0
@@ -786,8 +790,7 @@ var/global/list/all_apcs = list()
 	update_channels()
 
 	// update icon & area power if anything changed
-	if(last_lt != lighting || last_eq != equipment || last_en != environ || force_update)
-		force_update = 0
+	if(last_lt != lighting || last_eq != equipment || last_en != environ)
 		queue_icon_update()
 		update()
 	else if (last_ch != charging)
@@ -971,4 +974,3 @@ var/global/list/all_apcs = list()
 		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 
 #undef APC_UPDATE_ICON_COOLDOWN
- 


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

General machinery optimization, escpecially when change_power() proc is called

## Why and what will this PR improve

- significantly decrease CPU consumption by change_power() proc (up to 20-30 times)

## Authorship

@Vallat and his PR https://github.com/ss220-space/Baystation12/pull/90

## Changelog

:cl:
tweak: optimize looping through area machine when change_power() is called by creating area machinery list and using it
tweak: optimize update() calling, to not being called when not needed
/:cl:
