### PR TITLE
Changing area power updates to use an event.

### DIFF
--- a/code/datums/observation/area_power_change.dm
+++ b/code/datums/observation/area_power_change.dm
@@ -1,0 +1,11 @@
+//	Observer Pattern Implementation: Destroyed
+//		Registration type: /area
+//
+//		Raised when: An /area's power state changes.
+//
+//		Arguments that the called proc should expect:
+//			/area/power_changed: The instance that had a power change.
+
+/decl/observ/area_power_change
+	name = "Area Power Change"
+	expected_type = /area

--- a/code/game/area/area_power.dm
+++ b/code/game/area/area_power.dm
@@ -23,8 +23,7 @@
 
 // called when power status changes
 /area/proc/power_change()
-	for(var/obj/machinery/M in src)	// for each machine in the area
-		M.power_change()			// reverify power status (to update icons etc.)
+	events_repository.raise_event(/decl/observ/area_power_change, src)
 	if (atmosalm || fire || eject || party)
 		update_icon()
 

--- a/code/game/machinery/_machines_base/machinery_power.dm
+++ b/code/game/machinery/_machines_base/machinery_power.dm
@@ -2,6 +2,8 @@
 This is /obj/machinery level code to properly manage power usage from the area.
 */
 
+#define MACHINE_UPDATES_FROM_AREA_POWER !(stat_immune & NOPOWER)
+
 // Note that we update the area even if the area is unpowered.
 #define REPORT_POWER_CONSUMPTION_CHANGE(old_power, new_power)\
 	if(old_power != new_power){\
@@ -82,6 +84,10 @@ This is /obj/machinery level code to properly manage power usage from the area.
 
 // Do not do power stuff in New/Initialize until after ..()
 /obj/machinery/Initialize()
+	if(MACHINE_UPDATES_FROM_AREA_POWER)
+		var/area/my_area = get_area(src)
+		if(istype(my_area))
+			events_repository.register(/decl/observ/area_power_change, my_area, src, .proc/power_change)
 	REPORT_POWER_CONSUMPTION_CHANGE(0, get_power_usage())
 	events_repository.register(/decl/observ/moved, src, src, .proc/update_power_on_move)
 	power_init_complete = TRUE
@@ -89,6 +95,10 @@ This is /obj/machinery level code to properly manage power usage from the area.
 
 // Or in Destroy at all, but especially after the ..().
 /obj/machinery/Destroy()
+	if(MACHINE_UPDATES_FROM_AREA_POWER)
+		var/area/my_area = get_area(src)
+		if(istype(my_area))
+			events_repository.unregister(/decl/observ/area_power_change, my_area, src, .proc/power_change)
 	events_repository.unregister(/decl/observ/moved, src, src, .proc/update_power_on_move)
 	REPORT_POWER_CONSUMPTION_CHANGE(get_power_usage(), 0)
 	. = ..()
@@ -105,8 +115,13 @@ This is /obj/machinery level code to properly manage power usage from the area.
 
 	if(old_area)
 		old_area.power_use_change(power, 0, power_channel)
+		if(MACHINE_UPDATES_FROM_AREA_POWER)
+			events_repository.unregister(/decl/observ/area_power_change, old_area, src, .proc/power_change)	
 	if(new_area)
 		new_area.power_use_change(0, power, power_channel)
+		if(MACHINE_UPDATES_FROM_AREA_POWER)
+			events_repository.register(/decl/observ/area_power_change, new_area, src, .proc/power_change)
+
 	power_change() // Force check in case the old area was powered and the new one isn't or vice versa.
 
 // The three procs below are the only allowed ways of modifying the corresponding variables.
@@ -148,3 +163,4 @@ This is /obj/machinery level code to properly manage power usage from the area.
 		REPORT_POWER_CONSUMPTION_CHANGE(old_power, new_power_consumption)
 
 #undef REPORT_POWER_CONSUMPTION_CHANGE
+#undef MACHINE_UPDATES_FROM_AREA_POWER

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -2,24 +2,13 @@
 
 /obj/machinery/atmospherics/pipe
 
-	var/datum/gas_mixture/air_temporary    // used when reconstructing a pipeline that broke
-	var/datum/reagents/liquid_temporary // used when reconstructing a pipeline that broke
-
-	var/datum/pipeline/parent
-	var/volume = 0
-	var/leaking = 0		// Do not set directly, use set_leaking(TRUE/FALSE)
 	use_power = POWER_USE_OFF
+	stat_immune = NOSCREEN | NOINPUT | NOPOWER
 	interact_offline = TRUE //Needs to be set so that pipes don't say they lack power in their description
-
-	//minimum pressure before check_pressure(...) should be called
-	var/maximum_pressure = 210 * ONE_ATMOSPHERE
-	var/fatigue_pressure = 170 * ONE_ATMOSPHERE
-	var/alert_pressure = 170 * ONE_ATMOSPHERE
 
 	can_buckle = 1
 	buckle_require_restraints = 1
 	buckle_lying = -1
-	var/datum/sound_token/sound_token
 	build_icon_state = "simple"
 	build_icon = 'icons/obj/pipe-item.dmi'
 	pipe_class = PIPE_CLASS_BINARY
@@ -28,6 +17,18 @@
 	frame_type = /obj/item/pipe
 	uncreated_component_parts = null // No apc connection
 	construct_state = /decl/machine_construction/pipe
+
+	var/datum/gas_mixture/air_temporary    // used when reconstructing a pipeline that broke
+	var/datum/reagents/liquid_temporary // used when reconstructing a pipeline that broke
+	var/datum/pipeline/parent
+	var/volume = 0
+	var/leaking = 0		// Do not set directly, use set_leaking(TRUE/FALSE)
+
+	//minimum pressure before check_pressure(...) should be called
+	var/maximum_pressure = 210 * ONE_ATMOSPHERE
+	var/fatigue_pressure = 170 * ONE_ATMOSPHERE
+	var/alert_pressure = 170 * ONE_ATMOSPHERE
+	var/datum/sound_token/sound_token
 
 /obj/machinery/atmospherics/pipe/drain_power()
 	return -1

--- a/nebula.dme
+++ b/nebula.dme
@@ -389,6 +389,7 @@
 #include "code\datums\music_tracks\treacherous_voyage.dm"
 #include "code\datums\music_tracks\wake.dm"
 #include "code\datums\observation\_defines.dm"
+#include "code\datums\observation\area_power_change.dm"
 #include "code\datums\observation\death.dm"
 #include "code\datums\observation\density_set.dm"
 #include "code\datums\observation\destroyed.dm"


### PR DESCRIPTION
## Description of changes
Areas raise an event on power change instead of iterating machinery in contents.
Alternative to #2227 that hopefully avoids memory and GC issues while also removing atmos pipes from the power change update lists.

## Why and what will this PR improve
Shaves 65k /obj/machinery/power_change calls off the grid check event and appears to drastically reduce the number of atoms iterated over by area power changes.

## Authorship
Gaxer raised the issue and PR'd the first implementation, I coded this one.
## Changelog
Nothing player facing.