### PR TITLE
Add reboot hook to world/Reboot

### DIFF
--- a/code/controllers/hooks-defs.dm
+++ b/code/controllers/hooks-defs.dm
@@ -29,6 +29,12 @@
 /hook/shutdown
 
 /**
+ * Reboot hook.
+ * Called in world.dm prior to the parent call in world/Reboot.
+ */
+/hook/reboot
+
+/**
  * Death hook.
  * Called in death.dm when someone dies.
  * Parameters: var/mob/living/carbon/human, var/gibbed

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -145,6 +145,8 @@ var/global/world_topic_last = world.timeofday
 
 	game_log("World rebooted at [time_stamp()]")
 
+	callHook("reboot")
+
 	..(reason)
 
 /world/Del()

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -32,7 +32,7 @@ exactly 2 "/mob text paths" '"/mob'
 exactly 6 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
 exactly 1 "world<< uses" 'world<<|world[[:space:]]<<'
-exactly 90 "'in world' uses" 'in world'
+exactly 91 "'in world' uses" 'in world'
 exactly 1 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
 exactly 18 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 10 ">> uses" '>>(?!>)' -P


### PR DESCRIPTION


<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Adds a reboot hook to world/Reboot
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
Sometimes things need to be called on reboot but prior to world/Del(), and creating a dummy subsystem is overkill especially compared to how simple hooks are.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Me.
<!-- Describe original authors of changes to credit them. -->