### PR TITLE
Fix blanks runtiming

### DIFF
--- a/code/modules/mob/living/carbon/human/npcs.dm
+++ b/code/modules/mob/living/carbon/human/npcs.dm
@@ -32,7 +32,7 @@
 		C.sensor_mode = SUIT_SENSOR_OFF
 
 /mob/living/carbon/human/blank/Initialize(mapload)
-	. = ..(mapload, "Vat-Grown Human")
+	. = ..(mapload, SPECIES_HUMAN)
 	var/number = "[pick(possible_changeling_IDs)]-[rand(1,30)]"
 	fully_replace_character_name("Subject [number]")
 	var/decl/hierarchy/outfit/outfit = outfit_by_type(/decl/hierarchy/outfit/blank_subject)


### PR DESCRIPTION
## Description of changes

Blanks were still in the code and used a species name that doesn't exist. Set it to be a human, since vat-grown humans were removed.
This is code split off #2184 

## Changelog

:cl:
bugfix: Blanks don't runtime.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
