### PR TITLE
Fixing inventory hiding redux

### DIFF
--- a/code/_onclick/hud/ability_screen_objects.dm
+++ b/code/_onclick/hud/ability_screen_objects.dm
@@ -134,6 +134,14 @@
 			return S
 	return null
 
+/obj/screen/movable/ability_master/proc/synch_spells_to_mind(var/datum/mind/M)
+	if(!M)
+		return
+	LAZYINITLIST(M.learned_spells)
+	for(var/obj/screen/ability/spell/screen in spell_objects)
+		var/spell/S = screen.spell
+		M.learned_spells |= S
+
 /mob/Initialize()
 	. = ..()
 	ability_master = new /obj/screen/movable/ability_master(null,src)

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -19,10 +19,10 @@
 /datum/hud
 	var/mob/mymob
 
-	var/hud_shown = 1			//Used for the HUD toggle (F12)
-	var/inventory_shown = 1		//the inventory
-	var/show_intent_icons = 0
-	var/hotkey_ui_hidden = 0	//This is to hide the buttons that can be used via hotkeys. (hotkeybuttons list of buttons)
+	var/hud_shown 			= 1			//Used for the HUD toggle (F12)
+	var/inventory_shown 	= TRUE		//the inventory
+	var/show_intent_icons 	= FALSE
+	var/hotkey_ui_hidden 	= FALSE		//This is to hide the buttons that can be used via hotkeys. (hotkeybuttons list of buttons)
 
 	var/obj/screen/lingchemdisplay
 	var/list/hand_hud_objects
@@ -35,7 +35,7 @@
 	var/list/obj/screen/hotkeybuttons
 
 	var/obj/screen/movable/action_button/hide_toggle/hide_actions_toggle
-	var/action_buttons_hidden = 0
+	var/action_buttons_hidden = FALSE
 
 	var/static/list/hidden_inventory_slots = list(
 		slot_head_str,
@@ -73,6 +73,16 @@
 		if(stamina < 100)
 			stamina_bar.invisibility = 0
 			stamina_bar.icon_state = "prog_bar_[FLOOR(stamina/5)*5][(stamina >= 5) && (stamina <= 25) ? "_fail" : null]"
+
+/datum/hud/proc/hide_inventory()
+	inventory_shown = FALSE
+	hidden_inventory_update()
+	persistant_inventory_update()
+
+/datum/hud/proc/show_inventory()
+	inventory_shown = TRUE
+	hidden_inventory_update()
+	persistant_inventory_update()
 
 /datum/hud/proc/hidden_inventory_update()
 	if(!mymob) return

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -19,10 +19,10 @@
 /datum/hud
 	var/mob/mymob
 
-	var/hud_shown 			= 1			//Used for the HUD toggle (F12)
-	var/inventory_shown 	= TRUE		//the inventory
-	var/show_intent_icons 	= FALSE
-	var/hotkey_ui_hidden 	= FALSE		//This is to hide the buttons that can be used via hotkeys. (hotkeybuttons list of buttons)
+	var/hud_shown           = 1         //Used for the HUD toggle (F12)
+	var/inventory_shown     = TRUE      //the inventory
+	var/show_intent_icons   = FALSE
+	var/hotkey_ui_hidden    = FALSE     //This is to hide the buttons that can be used via hotkeys. (hotkeybuttons list of buttons)
 
 	var/obj/screen/lingchemdisplay
 	var/list/hand_hud_objects

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -264,7 +264,8 @@
 	if(length(hud_elements))
 		mymob.client.screen += hud_elements
 	mymob.client.screen += src.adding + src.hotkeybuttons
-	inventory_shown = 0
+
+	hide_inventory()
 
 	hidden_inventory_update()
 	persistant_inventory_update()

--- a/code/_onclick/hud/pai.dm
+++ b/code/_onclick/hud/pai.dm
@@ -24,7 +24,7 @@
 
 	mymob.client.screen = list()
 	mymob.client.screen += adding
-	inventory_shown = 0
+	hide_inventory()
 
 /obj/screen/pai
 	icon = 'icons/mob/screen/pai.dmi'

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -237,13 +237,11 @@
 	switch(name)
 		if("toggle")
 			if(usr.hud_used.inventory_shown)
-				usr.hud_used.inventory_shown = 0
 				usr.client.screen -= usr.hud_used.other
+				usr.hud_used.hide_inventory()
 			else
-				usr.hud_used.inventory_shown = 1
 				usr.client.screen += usr.hud_used.other
-
-			usr.hud_used.hidden_inventory_update()
+				usr.hud_used.show_inventory()
 
 		if("equip")
 			if(ishuman(usr))

--- a/code/modules/mob/living/carbon/human/login.dm
+++ b/code/modules/mob/living/carbon/human/login.dm
@@ -1,15 +1,4 @@
 /mob/living/carbon/human/Login()
 	..()
-	// Callback needed as SOMETHING in inventory code fucks with
-	// screen loc and screen presence after this proc runs.
-	addtimer(CALLBACK(src, .proc/refresh_inventory_ui), 0)
 	if(species)
 		species.handle_login_special(src)
-
-/mob/living/carbon/human/proc/refresh_inventory_ui()
-	if(client)
-		for(var/obj/item/gear in get_equipped_items(TRUE))
-			gear.reconsider_client_screen_presence(client, get_inventory_slot(gear))
-		if(hud_used)
-			hud_used.hidden_inventory_update()
-			hud_used.persistant_inventory_update()

--- a/code/modules/mob/living/carbon/human/login.dm
+++ b/code/modules/mob/living/carbon/human/login.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/human/Login()
 	..()
-	// Callback needed as SOMETHING in inventory code fucks with 
+	// Callback needed as SOMETHING in inventory code fucks with
 	// screen loc and screen presence after this proc runs.
 	addtimer(CALLBACK(src, .proc/refresh_inventory_ui), 0)
 	if(species)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -846,6 +846,18 @@ var/global/list/damage_icon_parts = list()
 	if(update_icons)
 		queue_icon_update()
 
+//Ported from hud login stuff
+//
+/mob/living/carbon/hud_reset(full_reset = FALSE)
+	if(!(. = ..()))
+		return .
+	for(var/obj/item/gear in get_equipped_items(TRUE))
+		client.screen |= gear
+	if(hud_used)
+		hud_used.hidden_inventory_update()
+		hud_used.persistant_inventory_update()
+		update_action_buttons()
+
 //Human Overlays Indexes/////////
 #undef HO_MUTATIONS_LAYER
 #undef HO_SKIN_LAYER

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -67,7 +67,6 @@
 	client.images = null				//remove the images such as AIs being unable to see runes
 	client.screen = list()				//remove hud items just in case
 	client.set_right_click_menu_mode(shift_to_open_context_menu)
-	InitializeHud()
 
 	next_move = 1
 	set_sight(sight|SEE_SELF)
@@ -86,28 +85,32 @@
 	if(eyeobj)
 		eyeobj.possess(src)
 
+	client.update_skybox(1)
+	events_repository.raise_event(/decl/observ/logged_in, src)
+
+	hud_reset(TRUE)
+	if(machine)
+		machine.on_user_login(src)
+
+/mob/proc/hud_reset(var/full_reset = FALSE)
+	if(!client)
+		return
+	if(full_reset)
+		client.images = null	//remove the images such as AIs being unable to see runes
+		client.screen = list()	//remove hud items just in case
+		client.set_right_click_menu_mode(shift_to_open_context_menu)
+		InitializeHud()
+
 	refresh_client_images()
 	reload_fullscreen() // Reload any fullscreen overlays this mob has.
 	add_click_catcher()
 	update_action_buttons()
 	update_mouse_pointer()
 
-	if(machine)
-		machine.on_user_login(src)
-
-	client.update_skybox(1)
 	if(ability_master)
-		ability_master.update_abilities(1, src)
+		ability_master.update_abilities(TRUE, src)
 		ability_master.toggle_open(1)
-	events_repository.raise_event(/decl/observ/logged_in, src)
-
-	if(mind)
-		if(!mind.learned_spells)
-			mind.learned_spells = list()
-		if(ability_master && ability_master.spell_objects)
-			for(var/obj/screen/ability/spell/screen in ability_master.spell_objects)
-				var/spell/S = screen.spell
-				mind.learned_spells |= S
+		ability_master.synch_spells_to_mind(mind)
 
 	if(get_preference_value(/datum/client_preference/show_status_markers) == PREF_SHOW)
 		if(status_markers)
@@ -115,8 +118,10 @@
 		for(var/datum/status_marker_holder/marker AS_ANYTHING in global.status_marker_holders)
 			if(marker != status_markers)
 				client.images |= marker.mob_image
+	return TRUE
 
-/mob/living/carbon/Login()
-	. = ..()
+/mob/living/carbon/hud_reset(full_reset = FALSE)
+	if(!(. = ..()))
+		return .
 	if(internals && internal)
 		internals.icon_state = "internal1"


### PR DESCRIPTION
## Description of changes

Fix inventory hiding/showing.. without using a timer 😛 
Also splits off some of the code into a hud_reset proc for use in mobs when doing extensive hud changes, like when changing species and etc.. (Its used in #2184 for mob transformations only right now)
Code split off from #2184 .

## Changelog

:cl:
tweak: Tweak inventory hiding fix.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
