### PR TITLE
Blood types are now handled as decls.

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -213,7 +213,7 @@
 // Limb flag helpers
 #define BP_IS_DEFORMED(org) (org.limb_flags & ORGAN_FLAG_DEFORMED)
 
-#define SYNTH_BLOOD_COLOUR "#030303"
+#define SYNTH_BLOOD_COLOR "#030303"
 #define SYNTH_FLESH_COLOUR "#575757"
 
 #define MOB_PULL_NONE 0

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -117,8 +117,6 @@
 
 #define map_image_file_name(z_level) "[global.using_map.path]-[z_level].png"
 
-#define RANDOM_BLOOD_TYPE pick(4;"O-", 36;"O+", 3;"A-", 28;"A+", 1;"B-", 20;"B+", 1;"AB-", 5;"AB+")
-
 #define CanInteract(user, state) (CanUseTopic(user, state) == STATUS_INTERACTIVE)
 
 #define CanInteractWith(user, target, state) (target.CanUseTopic(user, state) == STATUS_INTERACTIVE)

--- a/code/datums/supplypacks/medical.dm
+++ b/code/datums/supplypacks/medical.dm
@@ -59,9 +59,9 @@
 	containername = "blood pack crate"
 
 /decl/hierarchy/supply_pack/medical/blood
-	name = "Refills - Nanoblood"
+	name = "Refills - Synthetic Blood"
 	contains = list(/obj/item/chems/ivbag/nanoblood = 4)
-	containername = "nanoblood crate"
+	containername = "synthetic blood crate"
 
 /decl/hierarchy/supply_pack/medical/bodybag
 	name = "Equipment - Body bags"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -325,7 +325,7 @@ its easier to just keep the beam vertical.
 			M.dna = new /datum/dna(null)
 			M.dna.real_name = M.real_name
 		M.check_dna()
-		blood_color = M.species.get_blood_colour(M)
+		blood_color = M.species.get_blood_color(M)
 	. = 1
 	return 1
 

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -133,7 +133,7 @@
 	return "#c80000"
 
 /mob/living/carbon/human/get_rune_color()
-	return species.get_blood_colour(src)
+	return species.get_blood_color(src)
 
 var/global/list/Tier1Runes = list(
 	/mob/proc/convert_rune,

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -117,7 +117,7 @@
 
 /mob/living/carbon/human/get_blood_name()
 	if(species)
-		return species.get_blood_name()
+		return species.get_blood_name(src)
 	return "blood"
 
 /mob/living/simple_animal/construct/get_blood_name()
@@ -133,7 +133,7 @@
 	return "#c80000"
 
 /mob/living/carbon/human/get_rune_color()
-	return species.blood_color
+	return species.get_blood_colour(src)
 
 var/global/list/Tier1Runes = list(
 	/mob/proc/convert_rune,

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -81,7 +81,7 @@ var/global/list/image/splatter_cache=list()
 /obj/effect/decal/cleanable/blood/on_update_icon()
 	if(basecolor == "rainbow") basecolor = get_random_colour(1)
 	color = basecolor
-	if(basecolor == SYNTH_BLOOD_COLOUR)
+	if(basecolor == SYNTH_BLOOD_COLOR)
 		SetName("oil")
 		desc = "It's black and greasy."
 	else

--- a/code/game/objects/effects/decals/Cleanable/robots.dm
+++ b/code/game/objects/effects/decals/Cleanable/robots.dm
@@ -3,7 +3,7 @@
 	desc = "It's a useless heap of junk..."
 	icon = 'icons/mob/robots/_gibs.dmi'
 	icon_state = "gib1"
-	basecolor = SYNTH_BLOOD_COLOUR
+	basecolor = SYNTH_BLOOD_COLOR
 	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6", "gib7")
 	cleanable_scent = "industrial lubricant"
 	scent_intensity = /decl/scent_intensity/normal
@@ -40,7 +40,7 @@
 	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6", "gib7","gibdown1","gibdown1") //2:7 is close enough to 1:4
 
 /obj/effect/decal/cleanable/blood/oil
-	basecolor = SYNTH_BLOOD_COLOUR
+	basecolor = SYNTH_BLOOD_COLOR
 	chemical = /decl/material/liquid/lube
 
 /obj/effect/decal/cleanable/blood/oil/dry()

--- a/code/modules/client/preference_setup/background/01_species.dm
+++ b/code/modules/client/preference_setup/background/01_species.dm
@@ -25,7 +25,7 @@
 
 	pref.skills_allocated = pref.sanitize_skills(pref.skills_allocated)
 
-	if(!has_flag(get_species_by_key(pref.species), HAS_UNDERWEAR))
+	if(pref.all_underwear && !has_flag(get_species_by_key(pref.species), HAS_UNDERWEAR))
 		pref.all_underwear.Cut()
 
 /datum/category_item/player_setup_item/background/species/proc/has_flag(var/decl/species/mob_species, var/flag)

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -1,5 +1,3 @@
-var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-")
-
 /datum/preferences
 	var/species
 	var/b_type                           //blood type
@@ -93,13 +91,12 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 	pref.b_type = sanitize_text(pref.b_type, initial(pref.b_type))
 
-	if(!pref.b_type || !(pref.b_type in global.valid_bloodtypes))
-		pref.b_type = RANDOM_BLOOD_TYPE
-
 	if(!pref.species || !(pref.species in get_playable_species()))
 		pref.species = global.using_map.default_species
 
 	var/decl/species/mob_species = get_species_by_key(pref.species)
+	if(!pref.b_type || !(pref.b_type in mob_species.blood_types))
+		pref.b_type = pickweight(mob_species.blood_types)
 
 	var/low_skin_tone = mob_species ? (35 - mob_species.max_skin_tone()) : -185
 	sanitize_integer(pref.skin_tone, low_skin_tone, 34, initial(pref.skin_tone))
@@ -230,10 +227,12 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 
 	else if(href_list["blood_type"])
-		var/new_b_type = input(user, "Choose your character's blood-type:", CHARACTER_PREFERENCE_INPUT_TITLE) as null|anything in global.valid_bloodtypes
+		var/new_b_type = input(user, "Choose your character's blood type:", CHARACTER_PREFERENCE_INPUT_TITLE) as null|anything in mob_species.blood_types
 		if(new_b_type && CanUseTopic(user))
-			pref.b_type = new_b_type
-			return TOPIC_REFRESH
+			mob_species = get_species_by_key(pref.species)
+			if(new_b_type in mob_species.blood_types)
+				pref.b_type = new_b_type
+				return TOPIC_REFRESH
 
 	else if(href_list["hair_color"])
 		if(!has_flag(mob_species, HAS_HAIR_COLOR))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -83,7 +83,9 @@ var/global/list/time_prefs_fixed = list()
 	player_setup = new(src)
 	gender = pick(MALE, FEMALE)
 	real_name = get_random_name()
-	b_type = RANDOM_BLOOD_TYPE
+
+	var/decl/species/species = get_species_by_key(global.using_map.default_species)
+	b_type = pickweight(species.blood_types)
 
 	if(client)
 		if(IsGuestKey(client.key))

--- a/code/modules/materials/definitions/liquids/materials_liquid_chemistry.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_chemistry.dm
@@ -19,6 +19,6 @@
 	uid = "liquid_lubricant"
 	lore_text = "Lubricant is a substance introduced between two moving surfaces to reduce the friction and wear between them. giggity."
 	taste_description = "slime"
-	color = SYNTH_BLOOD_COLOUR
+	color = SYNTH_BLOOD_COLOR
 	value = 0.1
 	slipperiness = 80

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -15,7 +15,7 @@
 			I.throw_at(get_edge_target_turf(src,pick(global.alldirs)), rand(1,3), round(THROWFORCE_GIBS/I.w_class))
 
 	..(species.gibbed_anim)
-	gibs(loc, dna, null, species.get_flesh_colour(src), species.get_blood_colour(src))
+	gibs(loc, dna, null, species.get_flesh_colour(src), species.get_blood_color(src))
 
 /mob/living/carbon/human/dust()
 	if(species)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1063,6 +1063,7 @@
 	// No more invisible screaming wheelchairs because of set_species() typos.
 	if(!get_species_by_key(new_species))
 		new_species = global.using_map.default_species
+
 	if(dna)
 		dna.species = new_species
 
@@ -1124,6 +1125,11 @@
 	bone_amount =   species.bone_amount
 
 	refresh_visible_overlays()
+
+	if(!(b_type in species.blood_types))
+		b_type = pickweight(species.blood_types)
+		if(dna)
+			dna.b_type = b_type
 	reset_blood()
 
 	// Rebuild the HUD and visual elements.

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1758,7 +1758,7 @@
 				var/scale = min(1, round(P.damage / 50, 0.2))
 				B.set_scale(scale)
 
-				new /obj/effect/temp_visual/bloodsplatter(loc, hit_dir, species.blood_color)
+				new /obj/effect/temp_visual/bloodsplatter(loc, hit_dir, species.get_blood_color(src))
 
 /mob/living/carbon/human/has_dexterity(var/dex_level)
 	. = check_dexterity(dex_level, silent = TRUE)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -269,7 +269,7 @@ var/global/list/damage_icon_parts = list()
 		O.update_icon()
 		if(O.damage_state == "00") continue
 		var/icon/DI
-		var/use_colour = (BP_IS_PROSTHETIC(O) ? SYNTH_BLOOD_COLOUR : O.species.get_blood_colour(src))
+		var/use_colour = (BP_IS_PROSTHETIC(O) ? SYNTH_BLOOD_COLOR : O.species.get_blood_color(src))
 		var/cache_index = "[O.damage_state]/[O.icon_name]/[use_colour]/[species.name]"
 		if(damage_icon_parts[cache_index] == null)
 			DI = new /icon(bodytype.get_damage_overlays(src), O.damage_state) // the damage icon for whole human
@@ -834,7 +834,7 @@ var/global/list/damage_icon_parts = list()
 		overlay_state = "[base_state]-blood"
 		if(overlay_state in surgery_states)
 			var/image/blood = image(icon = surgery_icon, icon_state = overlay_state, layer = -HO_SURGERY_LAYER)
-			blood.color = E.species.get_blood_colour(src)
+			blood.color = E.species.get_blood_color(src)
 			LAZYADD(overlays_to_add, blood)
 		overlay_state = "[base_state]-bones"
 		if(overlay_state in surgery_states)

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -15,7 +15,7 @@
 	natural_armor = list(
 		melee = ARMOR_MELEE_KNIVES
 		)
-	bleed_colour = SYNTH_BLOOD_COLOUR
+	bleed_colour = SYNTH_BLOOD_COLOR
 	gene_damage = -1
 
 	meat_type =     null

--- a/code/modules/mob/living/simple_animal/hostile/viscerator.dm
+++ b/code/modules/mob/living/simple_animal/hostile/viscerator.dm
@@ -11,7 +11,7 @@
 	max_gas = null
 	minbodytemp = 0
 
-	bleed_colour = SYNTH_BLOOD_COLOUR
+	bleed_colour = SYNTH_BLOOD_COLOR
 
 	meat_type =     null
 	meat_amount =   0

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -34,7 +34,7 @@
 			appearance_descriptors[descriptor.name] = descriptor.randomize_value()
 
 	backpack = GET_DECL(pick(subtypesof(/decl/backpack_outfit)))
-	b_type = RANDOM_BLOOD_TYPE
+	b_type = pickweight(current_species.blood_types)
 	if(H)
 		copy_to(H)
 

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -239,7 +239,7 @@
 					if(hash_check.Find(sug_dna_hash) && CanUseTopic(user))
 						id_card.dna_hash = sug_dna_hash
 				else if(href_list["blood_type"])
-					var/sug_blood_type = input("Select blood type.", "Blood type") as null|anything in global.blood_types
+					var/sug_blood_type = input("Select blood type.", "Blood type") as null|anything in get_all_blood_types()
 					if(!isnull(sug_blood_type) && CanUseTopic(user))
 						id_card.blood_type = sug_blood_type
 				else if(href_list["front_photo"])

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -1,5 +1,4 @@
 var/global/list/all_crew_records =  list()
-var/global/list/blood_types =       list("A-", "A+", "B-", "B+", "AB-", "AB+", "O-", "O+")
 var/global/list/physical_statuses = list("Active", "Disabled", "SSD", "Deceased", "MIA")
 var/global/list/security_statuses = list("None", "Released", "Parolled", "Incarcerated", "Arrest")
 
@@ -282,7 +281,7 @@ FIELD_SHORT("Religion", religion, access_chapel_office, access_change_ids)
 FIELD_LONG("General Notes (Public)", public_record, null, access_bridge)
 
 // MEDICAL RECORDS
-FIELD_LIST("Blood Type", bloodtype, global.blood_types, access_medical, access_medical)
+FIELD_LIST("Blood Type", bloodtype, get_all_blood_types(), access_medical, access_medical)
 FIELD_LONG("Medical Record", medical_record, access_medical, access_medical)
 FIELD_LONG("Known Implants", implants, access_medical, access_medical)
 

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -172,8 +172,13 @@
 		reagents.add_reagent(species.blood_reagent, amount, REAGENT_DATA(donor, species.blood_reagent))
 		return
 	var/injected_data = REAGENT_DATA(donor, species.blood_reagent)
-	if(blood_incompatible(LAZYACCESS(injected_data, "blood_type")))
-		reagents.add_reagent(/decl/material/liquid/coagulated_blood, amount * 0.5)
+	var/injected_b_type = LAZYACCESS(injected_data, "blood_type")
+	if(blood_incompatible(injected_b_type))
+		var/decl/blood_type/blood_decl = injected_b_type && get_blood_type_by_name(injected_b_type)
+		if(istype(blood_decl))
+			reagents.add_reagent(blood_decl.transfusion_fail_reagent, amount * blood_decl.transfusion_fail_percentage)
+		else
+			reagents.add_reagent(/decl/material/liquid/coagulated_blood, amount * 0.5)
 	else
 		adjust_blood(amount, injected_data)
 	..()

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -234,19 +234,17 @@
 
 	// If there's no data to copy, call it quits here.
 	var/blood_data
+	var/blood_type
 	if(ishuman(source))
 		var/mob/living/carbon/human/donor = source
 		blood_data = REAGENT_DATA(donor.vessel, donor.species.blood_reagent)
+		blood_type = donor.b_type
 	else if(isatom(source))
 		var/atom/donor = source
 		blood_data = REAGENT_DATA(donor.reagents, /decl/material/liquid/blood)
 	if(!islist(blood_data))
 		return splatter
 
-	// Update appearance.
-	if(LAZYACCESS(blood_data, "blood_colour"))
-		splatter.basecolor = blood_data["blood_colour"]
-		splatter.update_icon()
 	if(spray_dir)
 		splatter.icon_state = "squirt"
 		splatter.set_dir(spray_dir)
@@ -261,12 +259,20 @@
 		var/datum/extension/forensic_evidence/forensics = get_or_create_extension(splatter, /datum/extension/forensic_evidence)
 		forensics.add_data(/datum/forensics/blood_dna, blood_data["blood_DNA"])
 
-	if(LAZYACCESS(blood_data, "blood_type"))
-		var/decl/blood_type/blood_type_decl = get_blood_type_by_name(blood_data["blood_type"])
-		splatter.name =  blood_type_decl.splatter_name
-		splatter.desc =  blood_type_decl.splatter_desc
-		splatter.color = blood_type_decl.splatter_colour
+	if(!blood_type && LAZYACCESS(blood_data, "blood_type"))
+		blood_type = LAZYACCESS(blood_data, "blood_type")
 
+	// Update appearance.
+	if(blood_type)
+		var/decl/blood_type/blood_type_decl = get_blood_type_by_name(blood_type)
+		splatter.name =      blood_type_decl.splatter_name
+		splatter.desc =      blood_type_decl.splatter_desc
+		splatter.basecolor = blood_type_decl.splatter_colour
+
+	if(LAZYACCESS(blood_data, "blood_colour"))
+		splatter.basecolor = blood_data["blood_colour"]
+
+	splatter.update_icon()
 	splatter.fluorescent  = 0
 	splatter.set_invisibility(0)
 	return splatter

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -48,7 +48,7 @@
 		"donor" =        weakref(src),
 		"species" =      species.name,
 		"blood_DNA" =    dna?.unique_enzymes,
-		"blood_colour" = species.get_blood_colour(src),
+		"blood_color" = species.get_blood_color(src),
 		"blood_type" =   dna?.b_type,
 		"trace_chem" = null
 	))
@@ -201,7 +201,7 @@
 		temp_chem[R] = REAGENT_VOLUME(reagents, R)
 	data["trace_chem"] = temp_chem
 	data["dose_chem"] = chem_doses ? chem_doses.Copy() : list()
-	data["blood_colour"] = species.get_blood_colour(src)
+	data["blood_color"] = species.get_blood_color(src)
 	return data
 
 /proc/blood_splatter(var/target, var/source, var/large, var/spray_dir)
@@ -269,8 +269,8 @@
 		splatter.desc =      blood_type_decl.splatter_desc
 		splatter.basecolor = blood_type_decl.splatter_colour
 
-	if(LAZYACCESS(blood_data, "blood_colour"))
-		splatter.basecolor = blood_data["blood_colour"]
+	if(LAZYACCESS(blood_data, "blood_color"))
+		splatter.basecolor = blood_data["blood_color"]
 
 	splatter.update_icon()
 	splatter.fluorescent  = 0

--- a/code/modules/organs/blood_types.dm
+++ b/code/modules/organs/blood_types.dm
@@ -1,0 +1,106 @@
+var/global/list/blood_types_by_name
+/proc/get_blood_type_by_name(var/blood_type)
+	var/list/blood_types = get_all_blood_types()
+	. = blood_types[blood_type]
+	if(!.)
+		PRINT_STACK_TRACE("Invalid blood_type key supplied to get_blood_type_by_name(): [blood_type || "NULL"]")
+
+/proc/get_all_blood_types()
+	if(!global.blood_types_by_name)
+		global.blood_types_by_name = list()
+		var/list/all_blood_types = decls_repository.get_decls_of_subtype(/decl/blood_type)
+		for(var/btype in all_blood_types)
+			var/decl/blood_type/blood_decl = all_blood_types[btype]
+			global.blood_types_by_name[blood_decl.name] = blood_decl
+	return global.blood_types_by_name
+
+/decl/blood_type
+	var/name
+	var/list/antigens
+	var/random_weighting = 1
+	var/antigen_category = SPECIES_MONKEY // Rhesus factor oh no
+
+	var/splatter_name =   "blood"
+	var/splatter_desc =   "It's some blood. That's not supposed to be there."
+	var/splatter_colour = COLOR_BLOOD_HUMAN
+
+/decl/blood_type/proc/can_take_donation_from(var/decl/blood_type/other_blood_type)
+
+	// Invalid object type, probably did a stack trace already, return early.
+	if(!istype(other_blood_type))
+		return FALSE
+
+	// This is alien blood, gross yuck.
+	if(other_blood_type.antigen_category != antigen_category)
+		return FALSE
+
+	// Other blood type is O, universal donor.
+	if(!LAZYLEN(other_blood_type.antigens))
+		return TRUE
+
+	// Our blood type is O and the other blood type is not; can't take donation.
+	if(!LAZYLEN(antigens))
+		return FALSE
+
+	// Check if we have all the associated antigens.
+	for(var/antigen in other_blood_type.antigens)
+		if(!(antigen in antigens))
+			return FALSE
+	return TRUE
+
+/decl/blood_type/ominus
+	name = "O-"
+	random_weighting = 4
+
+/decl/blood_type/oplus
+	name = "O+"
+	antigens = list("Rh")
+	random_weighting = 36
+
+/decl/blood_type/aminus
+	name = "A-"
+	antigens = list("A")
+	random_weighting = 3
+
+/decl/blood_type/aplus
+	name = "A+"
+	antigens = list("A", "Rh")
+	random_weighting = 28
+
+/decl/blood_type/bminus
+	name = "B-"
+	antigens = list("B")
+
+/decl/blood_type/bplus
+	name = "B+"
+	antigens = list("B", "Rh")
+	random_weighting = 20
+
+/decl/blood_type/abminus
+	name = "AB-"
+	antigens = list("A", "B")
+
+/decl/blood_type/abplus
+	name = "AB+"
+	antigens = list("A", "B", "Rh")
+	random_weighting = 5
+
+// Insect blood.
+/decl/blood_type/hemolymph
+
+	name = "hemolymph"
+	antigen_category = "insect"
+
+	splatter_name = "ichor"
+	splatter_desc = "A smear of insect ichor. It smells acrid."
+	splatter_colour = COLOR_GREEN_GRAY
+
+// Robo-blood.
+/decl/blood_type/coolant
+
+	name = "coolant"
+	antigen_category = "machine"
+
+	splatter_name = "coolant"
+	splatter_desc = "A smear of machine coolant. It looks discoloured."
+	splatter_colour = COLOR_DARK_BROWN

--- a/code/modules/organs/blood_types.dm
+++ b/code/modules/organs/blood_types.dm
@@ -15,6 +15,8 @@ var/global/list/blood_types_by_name
 	return global.blood_types_by_name
 
 /decl/blood_type
+	abstract_type = /decl/blood_type
+
 	var/name
 	var/list/antigens
 	var/random_weighting = 1
@@ -93,7 +95,7 @@ var/global/list/blood_types_by_name
 
 	splatter_name = "ichor"
 	splatter_desc = "A smear of insect ichor. It smells acrid."
-	splatter_colour = COLOR_GREEN_GRAY
+	splatter_colour = "#525252"
 
 // Robo-blood.
 /decl/blood_type/coolant
@@ -103,4 +105,4 @@ var/global/list/blood_types_by_name
 
 	splatter_name = "coolant"
 	splatter_desc = "A smear of machine coolant. It looks discoloured."
-	splatter_colour = COLOR_DARK_BROWN
+	splatter_colour = SYNTH_BLOOD_COLOUR

--- a/code/modules/organs/blood_types.dm
+++ b/code/modules/organs/blood_types.dm
@@ -26,6 +26,9 @@ var/global/list/blood_types_by_name
 	var/splatter_desc =   "It's some blood. That's not supposed to be there."
 	var/splatter_colour = COLOR_BLOOD_HUMAN
 
+	var/transfusion_fail_percentage = 0.5
+	var/transfusion_fail_reagent = /decl/material/liquid/coagulated_blood
+
 var/global/list/antigen_comparison_cache = list()
 /decl/blood_type/proc/can_take_donation_from(var/decl/blood_type/other_blood_type)
 
@@ -113,3 +116,5 @@ var/global/list/antigen_comparison_cache = list()
 	splatter_name = "coolant"
 	splatter_desc = "A smear of machine coolant. It looks discoloured."
 	splatter_colour = SYNTH_BLOOD_COLOR
+
+	transfusion_fail_reagent = /decl/material/liquid/acid

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -913,7 +913,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	var/obj/item/organ/external/original_parent = parent
 
 	var/use_flesh_colour = species.get_flesh_colour(owner)
-	var/use_blood_colour = species.get_blood_colour(owner)
+	var/use_blood_color = species.get_blood_color(owner)
 
 	add_pain(60)
 	if(!clean)
@@ -979,7 +979,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 				if(species)
 					var/obj/effect/decal/cleanable/blood/gibs/G = gore
 					G.fleshcolor = use_flesh_colour
-					G.basecolor =  use_blood_colour
+					G.basecolor =  use_blood_color
 					G.update_icon()
 
 			gore.throw_at(get_edge_target_turf(src,pick(global.alldirs)),rand(1,3),30)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -219,7 +219,7 @@
 		return
 	if(dna)
 		if(!rejecting)
-			if(owner.blood_incompatible(dna.b_type, species))
+			if(owner.blood_incompatible(dna.b_type))
 				rejecting = 1
 		else
 			rejecting++ //Rejection severity increases over time.

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -233,7 +233,11 @@
 						germ_level += rand(2,3)
 					if(501 to INFINITY)
 						germ_level += rand(3,5)
-						owner.reagents.add_reagent(/decl/material/liquid/coagulated_blood, rand(1,2))
+						var/decl/blood_type/blood_decl = dna?.b_type && get_blood_type_by_name(dna.b_type)
+						if(istype(blood_decl))
+							owner.reagents.add_reagent(blood_decl.transfusion_fail_reagent, round(rand(2,4) * blood_decl.transfusion_fail_percentage))
+						else
+							owner.reagents.add_reagent(/decl/material/liquid/coagulated_blood, rand(1,2))
 
 /obj/item/organ/proc/receive_chem(chemical)
 	return 0

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -86,7 +86,7 @@
 /obj/item/chems/ivbag/blood/Initialize()
 	. = ..()
 	if(blood_type)
-		name = "blood pack [blood_type]"
+		name = "blood pack ([blood_type])"
 		reagents.add_reagent(/decl/material/liquid/blood, volume, list("donor" = null, "blood_DNA" = null, "blood_type" = blood_type, "trace_chem" = null))
 
 /obj/item/chems/ivbag/blood/APlus

--- a/code/modules/species/outsider/random.dm
+++ b/code/modules/species/outsider/random.dm
@@ -31,7 +31,8 @@
 		/decl/emote/exertion/biological/breath,
 		/decl/emote/exertion/biological/pant
 	)
-
+	var/blood_color
+	
 /decl/species/alium/Initialize()
 
 	//Coloring
@@ -99,6 +100,11 @@
 		species_flags |= SPECIES_FLAG_NO_PAIN
 
 	. = ..()
+
+/decl/species/alium/get_blood_colour(mob/living/carbon/human/H)
+	if(istype(H) && H.isSynthetic())
+		return ..()
+	return blood_color
 
 /decl/species/alium/proc/adapt_to_atmosphere(var/datum/gas_mixture/atmosphere)
 	var/temp_comfort_shift = atmosphere.temperature - body_temperature

--- a/code/modules/species/outsider/random.dm
+++ b/code/modules/species/outsider/random.dm
@@ -101,7 +101,7 @@
 
 	. = ..()
 
-/decl/species/alium/get_blood_colour(mob/living/carbon/human/H)
+/decl/species/alium/get_blood_color(mob/living/carbon/human/H)
 	if(istype(H) && H.isSynthetic())
 		return ..()
 	return blood_color

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -19,7 +19,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	var/list/available_bodytypes = list()
 	var/decl/bodytype/default_bodytype
 
-	var/blood_color = COLOR_BLOOD_HUMAN       // Red.
 	var/list/blood_types = list(
 		/decl/blood_type/aplus,
 		/decl/blood_type/aminus,
@@ -665,9 +664,18 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 /decl/species/proc/handle_additional_hair_loss(var/mob/living/carbon/human/H, var/defer_body_update = TRUE)
 	return FALSE
 
-/decl/species/proc/get_blood_name()
-	var/decl/blood_type/blood = get_blood_type_by_name(blood_types[1])
+/decl/species/proc/get_blood_decl(var/mob/living/carbon/human/H)
+	if(istype(H) && H.isSynthetic())
+		return GET_DECL(/decl/blood_type/coolant)
+	return get_blood_type_by_name(blood_types[1])
+
+/decl/species/proc/get_blood_name(var/mob/living/carbon/human/H)
+	var/decl/blood_type/blood = get_blood_decl(H)
 	return istype(blood) ? blood.splatter_name : "blood"
+
+/decl/species/proc/get_blood_colour(var/mob/living/carbon/human/H)
+	var/decl/blood_type/blood = get_blood_decl(H)
+	return istype(blood) ? blood.splatter_colour : COLOR_BLOOD_HUMAN
 
 /decl/species/proc/handle_death_check(var/mob/living/carbon/human/H)
 	return FALSE

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -20,6 +20,16 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	var/decl/bodytype/default_bodytype
 
 	var/blood_color = COLOR_BLOOD_HUMAN       // Red.
+	var/list/blood_types = list(
+		/decl/blood_type/aplus,
+		/decl/blood_type/aminus,
+		/decl/blood_type/bplus,
+		/decl/blood_type/bminus,
+		/decl/blood_type/abplus,
+		/decl/blood_type/abminus,
+		/decl/blood_type/oplus
+	)
+
 	var/flesh_color = "#ffc896"             // Pink.
 	var/blood_oxy = 1
 
@@ -272,6 +282,12 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 
 	if(!codex_description)
 		codex_description = description
+
+	// Populate blood type table.
+	for(var/blood_type in blood_types)
+		var/decl/blood_type/blood_decl = GET_DECL(blood_type)
+		blood_types -= blood_type
+		blood_types[blood_decl.name] = blood_decl.random_weighting
 
 	// Generate OOC info.
 	var/list/codex_traits = list()
@@ -650,7 +666,8 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	return FALSE
 
 /decl/species/proc/get_blood_name()
-	return "blood"
+	var/decl/blood_type/blood = get_blood_type_by_name(blood_types[1])
+	return istype(blood) ? blood.splatter_name : "blood"
 
 /decl/species/proc/handle_death_check(var/mob/living/carbon/human/H)
 	return FALSE

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -673,7 +673,7 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	var/decl/blood_type/blood = get_blood_decl(H)
 	return istype(blood) ? blood.splatter_name : "blood"
 
-/decl/species/proc/get_blood_colour(var/mob/living/carbon/human/H)
+/decl/species/proc/get_blood_color(var/mob/living/carbon/human/H)
 	var/decl/blood_type/blood = get_blood_decl(H)
 	return istype(blood) ? blood.splatter_colour : COLOR_BLOOD_HUMAN
 

--- a/code/modules/species/species_getters.dm
+++ b/code/modules/species/species_getters.dm
@@ -19,9 +19,6 @@
 /decl/species/proc/get_ssd(var/mob/living/carbon/human/H)
 	return ((H && H.isSynthetic()) ? "flashing a 'system offline' glyph on their monitor" : show_ssd)
 
-/decl/species/proc/get_blood_colour(var/mob/living/carbon/human/H)
-	return ((H && H.isSynthetic()) ? SYNTH_BLOOD_COLOUR : blood_color)
-
 /decl/species/proc/get_flesh_colour(var/mob/living/carbon/human/H)
 	return ((H && H.isSynthetic()) ? SYNTH_FLESH_COLOUR : flesh_color)
 

--- a/code/modules/species/species_helpers.dm
+++ b/code/modules/species/species_helpers.dm
@@ -91,3 +91,9 @@ var/global/list/stored_shock_by_ref = list()
 /decl/species/proc/equip_default_fallback_uniform(var/mob/living/carbon/human/H)
 	if(istype(H))
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/harness, slot_w_uniform_str)
+
+/decl/species/proc/is_blood_incompatible(var/my_blood_type, var/their_blood_type)
+	var/decl/blood_type/my_blood = get_blood_type_by_name(my_blood_type)
+	if(!istype(my_blood))
+		return FALSE
+	return !my_blood.can_take_donation_from(get_blood_type_by_name(their_blood_type))

--- a/code/modules/species/station/golem.dm
+++ b/code/modules/species/station/golem.dm
@@ -22,6 +22,8 @@
 	breath_type = null
 	poison_types = null
 
+	blood_types = list(/decl/blood_type/coolant)
+
 	blood_color = "#515573"
 	flesh_color = "#137e8f"
 

--- a/code/modules/species/station/golem.dm
+++ b/code/modules/species/station/golem.dm
@@ -24,7 +24,6 @@
 
 	blood_types = list(/decl/blood_type/coolant)
 
-	blood_color = "#515573"
 	flesh_color = "#137e8f"
 
 	cold_level_1 = SYNTH_COLD_LEVEL_1

--- a/mods/species/adherent/datum/species.dm
+++ b/mods/species/adherent/datum/species.dm
@@ -63,7 +63,6 @@
 	spawn_flags =   SPECIES_CAN_JOIN
 
 	appearance_flags = HAS_EYE_COLOR
-	blood_color = "#2de00d"
 	flesh_color = "#90edeb"
 	slowdown = -1
 	hud_type = /datum/hud_data/adherent

--- a/mods/species/adherent/datum/species.dm
+++ b/mods/species/adherent/datum/species.dm
@@ -23,6 +23,8 @@
 	bone_material = null
 	skin_material = null
 
+	blood_types = list(/decl/blood_type/coolant)
+
 	available_pronouns = list(/decl/pronouns)
 	available_bodytypes = list(
 		/decl/bodytype/adherent,
@@ -135,9 +137,6 @@
 			H.visible_message("\The [H] floats gracefully down from \the [landing].", "You land gently on \the [landing].")
 		return TRUE
 	return FALSE
-
-/decl/species/adherent/get_blood_name()
-	return "coolant"
 
 /decl/species/adherent/skills_from_age(age)
 	switch(age)

--- a/mods/species/ascent/datum/species.dm
+++ b/mods/species/ascent/datum/species.dm
@@ -33,7 +33,8 @@
 
 /decl/blood_type/hemolymph/mantid
 	name = "crystalline ichor"
-	antigens = "Hc" // hemocyanin, more of an octopus thing than a bug thing but whatever, it sounds neat
+	antigens = list("Hc") // hemocyanin, more of an octopus thing than a bug thing but whatever, it sounds neat
+	splatter_colour = "#660066"
 
 /decl/species/mantid
 
@@ -48,7 +49,6 @@
 	amid reports of highly advanced, astonishingly violent mantid-cephlapodean sentients with particle cannons."
 	organs_icon =       'mods/species/ascent/icons/species/body/organs.dmi'
 
-	blood_color =             "#660066"
 	flesh_color =             "#009999"
 	hud_type =                /datum/hud_data/mantid
 	move_trail =              /obj/effect/decal/cleanable/blood/tracks/snake
@@ -272,7 +272,6 @@
 	warning_low_pressure = 50
 	hazard_low_pressure = -1
 	body_temperature = null
-	blood_color = "#525252"
 	flesh_color = "#525252"
 	blood_oxy = 0
 	reagent_tag = IS_SERPENTID

--- a/mods/species/ascent/datum/species.dm
+++ b/mods/species/ascent/datum/species.dm
@@ -31,6 +31,10 @@
 		"senescent" =      45
 	)
 
+/decl/blood_type/hemolymph/mantid
+	name = "crystalline ichor"
+	antigens = "Hc" // hemocyanin, more of an octopus thing than a bug thing but whatever, it sounds neat
+
 /decl/species/mantid
 
 	name =                   SPECIES_MANTID_ALATE
@@ -48,6 +52,8 @@
 	flesh_color =             "#009999"
 	hud_type =                /datum/hud_data/mantid
 	move_trail =              /obj/effect/decal/cleanable/blood/tracks/snake
+
+	blood_types = list(/decl/blood_type/hemolymph/mantid)
 
 	speech_chance = 100
 	speech_sounds = list(
@@ -147,9 +153,6 @@
 /decl/species/mantid/handle_sleeping(var/mob/living/carbon/human/H)
 	return
 
-/decl/species/mantid/get_blood_name()
-	return "hemolymph"
-
 /decl/species/mantid/post_organ_rejuvenate(var/obj/item/organ/org, var/mob/living/carbon/human/H)
 	org.status |= ORGAN_CRYSTAL
 
@@ -218,6 +221,8 @@
 	name = SPECIES_SERPENTID
 	name_plural = "Serpentids"
 	spawn_flags = SPECIES_IS_RESTRICTED
+
+	blood_types = list(/decl/blood_type/hemolymph)
 
 	has_organ = list(
 		BP_BRAIN =             /obj/item/organ/internal/brain/insectoid/serpentid,
@@ -319,9 +324,6 @@
 			list(/decl/emote/audible/bug_hiss) = 40
 	)
 	var/list/skin_overlays = list()
-
-/decl/species/serpentid/get_blood_name()
-	return "haemolymph"
 
 /decl/species/serpentid/can_overcome_gravity(var/mob/living/carbon/human/H)
 	var/datum/gas_mixture/mixture = H.loc.return_air()

--- a/mods/species/lizard/_lizard.dme
+++ b/mods/species/lizard/_lizard.dme
@@ -2,6 +2,7 @@
 #define MODPACK_LIZARD
 #include "_lizard.dm"
 #include "datum\autohiss.dm"
+#include "datum\blood.dm"
 #include "datum\culture.dm"
 #include "datum\language.dm"
 #include "datum\species.dm"

--- a/mods/species/lizard/datum/blood.dm
+++ b/mods/species/lizard/datum/blood.dm
@@ -1,0 +1,52 @@
+/decl/blood_type/reptile
+	abstract_type = /decl/blood_type/reptile
+	splatter_colour = "#f24b2e"
+	antigens = list("S", "X", "Li")
+
+/decl/blood_type/reptile/splus
+	name = "S+"
+	antigens = list("S", "Li")
+
+/decl/blood_type/reptile/sminus
+	name = "S-"
+	antigens = list("S")
+
+/decl/blood_type/reptile/xplus
+	name = "X+"
+	antigens = list("X", "Li")
+
+/decl/blood_type/reptile/xminus
+	name = "X-"
+	antigens = list("X")
+
+/decl/blood_type/reptile/sxplus
+	name = "SX+"
+	antigens = list("S", "X", "Li")
+
+/decl/blood_type/reptile/sxminus
+	name = "SX-"
+	antigens = list("S", "X")
+
+/decl/blood_type/reptile/oplus
+	name = "Or+"
+	antigens = list("Li")
+
+/decl/blood_type/reptile/ominus
+	name = "Or-"
+
+/obj/item/chems/ivbag/blood/reptile_splus
+	blood_type = "S+"
+/obj/item/chems/ivbag/blood/reptile_sminus
+	blood_type = "S-"
+/obj/item/chems/ivbag/blood/reptile_xplus
+	blood_type = "X+"
+/obj/item/chems/ivbag/blood/reptile_xminus
+	blood_type = "X-"
+/obj/item/chems/ivbag/blood/reptile_sxplus
+	blood_type = "SX+"
+/obj/item/chems/ivbag/blood/reptile_sxminus
+	blood_type = "SX-"
+/obj/item/chems/ivbag/blood/reptile_oplus
+	blood_type = "Or+"
+/obj/item/chems/ivbag/blood/reptile_ominus
+	blood_type = "Or-"

--- a/mods/species/lizard/datum/blood.dm
+++ b/mods/species/lizard/datum/blood.dm
@@ -6,14 +6,17 @@
 /decl/blood_type/reptile/splus
 	name = "S+"
 	antigens = list("S", "Li")
+	random_weighting = 28
 
 /decl/blood_type/reptile/sminus
 	name = "S-"
 	antigens = list("S")
+	random_weighting = 3
 
 /decl/blood_type/reptile/xplus
 	name = "X+"
 	antigens = list("X", "Li")
+	random_weighting = 20
 
 /decl/blood_type/reptile/xminus
 	name = "X-"
@@ -22,6 +25,7 @@
 /decl/blood_type/reptile/sxplus
 	name = "SX+"
 	antigens = list("S", "X", "Li")
+	random_weighting = 5
 
 /decl/blood_type/reptile/sxminus
 	name = "SX-"
@@ -30,9 +34,11 @@
 /decl/blood_type/reptile/oplus
 	name = "Or+"
 	antigens = list("Li")
+	random_weighting = 36
 
 /decl/blood_type/reptile/ominus
 	name = "Or-"
+	random_weighting = 4
 
 /obj/item/chems/ivbag/blood/reptile_splus
 	blood_type = "S+"

--- a/mods/species/lizard/datum/species.dm
+++ b/mods/species/lizard/datum/species.dm
@@ -62,9 +62,18 @@
 
 	reagent_tag = IS_LIZARD
 	base_color = "#066000"
-	blood_color = "#f24b2e"
 	organs_icon = 'mods/species/lizard/icons/organs.dmi'
 
+	blood_types = list(
+		/decl/blood_type/reptile/splus,
+		/decl/blood_type/reptile/sminus,
+		/decl/blood_type/reptile/xplus,
+		/decl/blood_type/reptile/xminus,
+		/decl/blood_type/reptile/sxplus,
+		/decl/blood_type/reptile/sxminus,
+		/decl/blood_type/reptile/oplus,
+		/decl/blood_type/reptile/ominus,
+	)
 	move_trail = /obj/effect/decal/cleanable/blood/tracks/claw
 
 	heat_discomfort_level = 320

--- a/mods/species/tajaran/_tajaran.dme
+++ b/mods/species/tajaran/_tajaran.dme
@@ -4,6 +4,7 @@
 #include "datum/accessory.dm"
 #include "datum/culture.dm"
 #include "datum/emotes.dm"
+#include "datum/blood.dm"
 #include "datum/language.dm"
 #include "datum/species.dm"
 #include "datum/species_bodytypes.dm"

--- a/mods/species/tajaran/datum/blood.dm
+++ b/mods/species/tajaran/datum/blood.dm
@@ -1,0 +1,52 @@
+/decl/blood_type/feline
+	antigen_category = "feline"
+	splatter_colour = "#862a51"
+	abstract_type = /decl/blood_type/feline
+
+/decl/blood_type/feline/mplus
+	name = "M+"
+	antigens = list("M", "Fe")
+
+/decl/blood_type/feline/mminus
+	name = "M-"
+	antigens = list("M")
+
+/decl/blood_type/feline/rplus
+	name = "R+"
+	antigens = list("R", "Fe")
+
+/decl/blood_type/feline/rminus
+	name = "M-"
+	antigens = list("R",)
+
+/decl/blood_type/feline/mrplus
+	name = "MR+"
+	antigens = list("M", "R", "Fe")
+
+/decl/blood_type/feline/mrminus
+	name = "MR-"
+	antigens = list("M", "R")
+
+/decl/blood_type/feline/oplus
+	name = "Of+"
+	antigens = list("Fe")
+
+/decl/blood_type/feline/ominus
+	name = "Of-"
+
+/obj/item/chems/ivbag/blood/feline_mplus
+	blood_type = "M+"
+/obj/item/chems/ivbag/blood/feline_mminus
+	blood_type = "M-"
+/obj/item/chems/ivbag/blood/feline_rplus
+	blood_type = "R+"
+/obj/item/chems/ivbag/blood/feline_mminus
+	blood_type = "M-"
+/obj/item/chems/ivbag/blood/feline_mrplus
+	blood_type = "MR+"
+/obj/item/chems/ivbag/blood/feline_mrminus
+	blood_type = "MR-"
+/obj/item/chems/ivbag/blood/feline_oplus
+	blood_type = "Of+"
+/obj/item/chems/ivbag/blood/feline_oplus
+	blood_type = "Of-"

--- a/mods/species/tajaran/datum/blood.dm
+++ b/mods/species/tajaran/datum/blood.dm
@@ -6,22 +6,26 @@
 /decl/blood_type/feline/mplus
 	name = "M+"
 	antigens = list("M", "Fe")
+	random_weighting = 28
 
 /decl/blood_type/feline/mminus
 	name = "M-"
 	antigens = list("M")
+	random_weighting = 3
 
 /decl/blood_type/feline/rplus
 	name = "R+"
 	antigens = list("R", "Fe")
+	random_weighting = 20
 
 /decl/blood_type/feline/rminus
-	name = "M-"
+	name = "R-"
 	antigens = list("R",)
 
 /decl/blood_type/feline/mrplus
 	name = "MR+"
 	antigens = list("M", "R", "Fe")
+	random_weighting = 5
 
 /decl/blood_type/feline/mrminus
 	name = "MR-"
@@ -30,9 +34,11 @@
 /decl/blood_type/feline/oplus
 	name = "Of+"
 	antigens = list("Fe")
+	random_weighting = 36
 
 /decl/blood_type/feline/ominus
 	name = "Of-"
+	random_weighting = 4
 
 /obj/item/chems/ivbag/blood/feline_mplus
 	blood_type = "M+"

--- a/mods/species/tajaran/datum/species.dm
+++ b/mods/species/tajaran/datum/species.dm
@@ -25,6 +25,16 @@
 	spawn_flags = SPECIES_CAN_JOIN
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
 
+	blood_types = list(
+		/decl/blood_type/feline/mplus,
+		/decl/blood_type/feline/mminus,
+		/decl/blood_type/feline/rplus,
+		/decl/blood_type/feline/rminus,
+		/decl/blood_type/feline/mrplus,
+		/decl/blood_type/feline/mrminus,
+		/decl/blood_type/feline/oplus,
+		/decl/blood_type/feline/ominus
+	)
 
 	flesh_color = "#afa59e"
 	base_markings = list(/decl/sprite_accessory/marking/tajaran = "#888888")
@@ -33,7 +43,6 @@
 	base_eye_color = "#00aa00"
 	default_h_style = /decl/sprite_accessory/hair/taj
 
-	blood_color = "#862a51"
 	organs_icon = 'mods/species/tajaran/icons/organs.dmi'
 
 	darksight_range = 7

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -15,6 +15,8 @@
 	description =           "Simple AI-driven robots are used for many menial or repetitive tasks in human space."
 	cyborg_noun = null
 
+	blood_types = list(/decl/blood_type/coolant)
+
 	available_bodytypes = list(/decl/bodytype/utility_frame)
 	age_descriptor =        /datum/appearance_descriptor/age/utility_frame
 	hidden_from_codex =     FALSE
@@ -82,9 +84,6 @@
 	if(istype(eyes))
 		eyes.eye_icon = 'mods/species/utility_frames/icons/eyes.dmi'
 	H.refresh_visible_overlays()
-
-/decl/species/utility_frame/get_blood_name()
-	. = "coolant"
 
 /decl/species/utility_frame/disfigure_msg(var/mob/living/carbon/human/H)
 	. = SPAN_DANGER("The faceplate is dented and cracked!\n")

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -26,7 +26,6 @@
 	strength =              STR_HIGH
 	warning_low_pressure =  50
 	hazard_low_pressure =  -1
-	blood_color =           COLOR_GRAY15
 	flesh_color =           COLOR_GUNMETAL
 	cold_level_1 =          SYNTH_COLD_LEVEL_1
 	cold_level_2 =          SYNTH_COLD_LEVEL_2

--- a/mods/species/vox/datum/species.dm
+++ b/mods/species/vox/datum/species.dm
@@ -19,6 +19,7 @@
 	splatter_name = "ichor"
 	splatter_desc = "A smear of thin, sticky alien ichor."
 	splatter_colour = "#2299fc"
+	transfusion_fail_reagent = /decl/material/gas/ammonia
 
 /decl/species/vox
 	name = SPECIES_VOX

--- a/mods/species/vox/datum/species.dm
+++ b/mods/species/vox/datum/species.dm
@@ -13,6 +13,13 @@
 
 #define IS_VOX "vox"
 
+/decl/blood_type/vox
+	name = "vox ichor"
+	antigen_category = "vox"
+	splatter_name = "ichor"
+	splatter_desc = "A smear of thin, sticky alien ichor."
+	splatter_colour = "#2299fc"
+
 /decl/species/vox
 	name = SPECIES_VOX
 	name_plural = SPECIES_VOX
@@ -67,7 +74,7 @@
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED
 	appearance_flags = HAS_EYE_COLOR | HAS_HAIR_COLOR
 
-	blood_color = "#2299fc"
+	blood_types = list(/decl/blood_type/vox)
 	flesh_color = "#808d11"
 
 	reagent_tag = IS_VOX

--- a/nebula.dme
+++ b/nebula.dme
@@ -2653,6 +2653,7 @@
 #include "code\modules\nano\modules\nano_module.dm"
 #include "code\modules\organs\_organ_setup.dm"
 #include "code\modules\organs\blood.dm"
+#include "code\modules\organs\blood_types.dm"
 #include "code\modules\organs\organ.dm"
 #include "code\modules\organs\pain.dm"
 #include "code\modules\organs\ailments\_ailment.dm"


### PR DESCRIPTION
## Description of changes
- Blood types are decls.
- Blood incompatibility no longer breaks organ transplants 100% of the time.
- Utility frames, adherents, Kharmaani and serpentids now have their own "blood" types.

## Why and what will this PR improve
Nicer blood code, less hardcoded antigen checking.

## Authorship
Myself. @Kaedwuff pitched the original idea and worked on the first implementation. They also came up with the Taj and lizard antigen pairs.

## Changelog

:cl:
tweak: Utility frames, Kharmaani and adherent now bleed exciting new colours.
tweak: Human subtypes can now share blood without triggering a rejection.
/:cl: