### PR TITLE
update_transform: respect human direction for turn_angle

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -231,7 +231,14 @@ Please contact me on #coderbus IRC. ~Carn x
 	// Scale/translate/rotate and apply the transform.
 	var/matrix/M = matrix()
 	if(lying)
-		M.Turn(pick(90, -90))
+		var/turn_angle
+		if(dir & WEST)
+			turn_angle = -90
+		else if(dir & EAST)
+			turn_angle = 90
+		else 
+			turn_angle = pick(-90, 90)
+		M.Turn(turn_angle)
 		M.Scale(desired_scale_y, desired_scale_x)
 		M.Translate(1, -6-default_pixel_z)
 	else

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -591,7 +591,7 @@
 
 // facing verbs
 /mob/proc/canface()
-	return !incapacitated()
+	return !incapacitated(INCAPACITATION_UNRESISTING)
 
 // Not sure what to call this. Used to check if humans are wearing an AI-controlled exosuit and hence don't need to fall over yet.
 /mob/proc/can_stand_overridden()


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

Title.

## Why and what will this PR improve

* The direction you are facing (EAST/WEST) now influences the direction you lay down in.
* canface() now checks for INCAPACITATION_UNRESISTING which means you can change facing direction ~~and pixelshift~~ while lying down, but not while dead.

## Authorship

@NotRanged as author of an improvements.

## Changelog

:cl: NotRanged
tweak: Lying down while facing left or right now lays you down left or right.
tweak: You can now change facing direction while lying down.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
