### PR TITLE
Fix a typo in a type path for the can_float proc for aquatic simple animals

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -320,6 +320,12 @@
 
 /mob/living/simple_animal/aquatic/can_float()
 	return TRUE
+	
+/mob/living/simple_animal/hostile/aquatic/can_float()
+	return TRUE
+
+/mob/living/simple_animal/hostile/retaliate/aquatic/can_float()
+	return TRUE
 
 /mob/living/carbon/human/can_float()
 	return species.can_float(src)

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -318,7 +318,7 @@
 /mob/living/can_float()
 	return !is_physically_disabled()
 
-/mob/living/aquatic/can_float()
+/mob/living/simple_animal/aquatic/can_float()
 	return TRUE
 
 /mob/living/carbon/human/can_float()


### PR DESCRIPTION
## Description of changes

I was wondering why there was a /mob/living/aquatic type floating around in the mob types... So I corrected the path. Hopefully it refers to the right aquatic class since there's a few of them..


## Changelog

:cl:
tweak: Fishes can float now.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
