### PR TITLE
Fixes minor path issue with abstract objects, converts landmarks to abstract objects. [MDB IGNORE]

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -496,7 +496,7 @@ SUBSYSTEM_DEF(jobs)
 	if(!joined_late || job.latejoin_at_spawnpoints)
 		var/obj/S = job.get_roundstart_spawnpoint()
 
-		if(istype(S, /obj/effect/landmark/start) && isturf(S.loc))
+		if(istype(S, /obj/abstract/landmark/start) && isturf(S.loc))
 			H.forceMove(S.loc)
 		else
 			var/decl/spawnpoint/spawnpoint = job.get_spawnpoint(H.client)
@@ -571,7 +571,7 @@ SUBSYSTEM_DEF(jobs)
 	return positions_by_department[dept] || list()
 
 /datum/controller/subsystem/jobs/proc/spawn_empty_ai()
-	for(var/obj/effect/landmark/start/S in global.landmarks_list)
+	for(var/obj/abstract/landmark/start/S in global.landmarks_list)
 		if(S.name != "AI")
 			continue
 		if(locate(/mob/living) in S.loc)

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -17,7 +17,7 @@ SUBSYSTEM_DEF(mapping)
 	overmap_event_handler = GET_DECL(/decl/overmap_event_handler)
 
 	// Load templates and build away sites.
-	for(var/obj/effect/landmark/map_load_mark/marker AS_ANYTHING in compile_time_map_markers)
+	for(var/obj/abstract/landmark/map_load_mark/marker AS_ANYTHING in compile_time_map_markers)
 		compile_time_map_markers -= marker
 		marker.load_template()
 

--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -58,7 +58,7 @@
 /decl/special_role/proc/create_nuke(var/atom/paper_spawn_loc, var/datum/mind/code_owner)
 
 	// Decide on a code.
-	var/obj/effect/landmark/nuke_spawn = locate(nuke_spawn_loc ? nuke_spawn_loc : "landmark*Nuclear-Bomb")
+	var/obj/abstract/landmark/nuke_spawn = locate(nuke_spawn_loc ? nuke_spawn_loc : "landmark*Nuclear-Bomb")
 
 	var/code
 	if(nuke_spawn)

--- a/code/game/antagonist/antagonist_place.dm
+++ b/code/game/antagonist/antagonist_place.dm
@@ -1,7 +1,7 @@
 /decl/special_role/proc/get_starting_locations()
 	if(landmark_id)
 		starting_locations = list()
-		for(var/obj/effect/landmark/L in global.landmarks_list)
+		for(var/obj/abstract/landmark/L in global.landmarks_list)
 			if(L.name == landmark_id)
 				starting_locations |= get_turf(L)
 

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -13,7 +13,7 @@ var/global/hadevent    = 0
 			break
 
 /proc/carp_migration() // -- Darem
-	for(var/obj/effect/landmark/C in global.landmarks_list)
+	for(var/obj/abstract/landmark/C in global.landmarks_list)
 		if(C.name == "carpspawn")
 			new /mob/living/simple_animal/hostile/carp(C.loc)
 	//sleep(100)
@@ -29,7 +29,7 @@ var/global/hadevent    = 0
 
 		for(var/i=1,i<=lightsoutAmount,i++)
 			var/list/possibleEpicentres = list()
-			for(var/obj/effect/landmark/newEpicentre in global.landmarks_list)
+			for(var/obj/abstract/landmark/newEpicentre in global.landmarks_list)
 				if(newEpicentre.name == "lightsout" && !(newEpicentre in epicentreList))
 					possibleEpicentres += newEpicentre
 			if(possibleEpicentres.len)
@@ -40,7 +40,7 @@ var/global/hadevent    = 0
 		if(!epicentreList.len)
 			return
 
-		for(var/obj/effect/landmark/epicentre in epicentreList)
+		for(var/obj/abstract/landmark/epicentre in epicentreList)
 			for(var/obj/machinery/power/apc/apc in range(epicentre,lightsoutRange))
 				apc.overload_lighting()
 

--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -418,7 +418,7 @@
 
 /datum/job/proc/get_roundstart_spawnpoint()
 	var/list/loc_list = list()
-	for(var/obj/effect/landmark/start/sloc in global.landmarks_list)
+	for(var/obj/abstract/landmark/start/sloc in global.landmarks_list)
 		if(sloc.name != title)	continue
 		if(locate(/mob/living) in sloc.loc)	continue
 		loc_list += sloc

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -57,7 +57,7 @@
 
 		var/obj/L = null
 
-		for(var/obj/effect/landmark/sloc in global.landmarks_list)
+		for(var/obj/abstract/landmark/sloc in global.landmarks_list)
 			if(sloc.name != C.data || (locate(/mob/living) in sloc.loc))
 				continue
 			L = sloc
@@ -66,7 +66,7 @@
 		if(!L)
 			L = locate("landmark*[C.data]") // use old stype
 
-		if(istype(L, /obj/effect/landmark) && isturf(L.loc) && user.unEquip(I))
+		if(istype(L, /obj/abstract/landmark) && isturf(L.loc) && user.unEquip(I))
 			to_chat(usr, "You insert the coordinates into the machine.")
 			to_chat(usr, "A message flashes across the screen reminding the traveller that the nuclear authentication disk is to remain on the [station_name()] at all times.")
 			qdel(I)

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -1,53 +1,47 @@
-/obj/effect/landmark
+/obj/abstract/landmark
 	name = "landmark"
-	icon = 'icons/effects/landmarks.dmi'
-	icon_state = "x2"
-	anchored = 1.0
-	unacidable = 1
-	simulated = 0
-	invisibility = 101
 	var/delete_me = 0
 
-/obj/effect/landmark/Initialize()
+/obj/abstract/landmark/Initialize()
 	. = ..()
 	tag = "landmark*[name]"
 	if(delete_me)
 		return INITIALIZE_HINT_QDEL
 	global.landmarks_list += src
 
-/obj/effect/landmark/proc/delete()
+/obj/abstract/landmark/proc/delete()
 	delete_me = TRUE
 
-/obj/effect/landmark/Destroy()
+/obj/abstract/landmark/Destroy()
 	global.landmarks_list -= src
 	return ..()
 
-/obj/effect/landmark/start
+/obj/abstract/landmark/start
 	name = "start"
 	icon = 'icons/mob/screen1.dmi'
 	icon_state = "x"
 	anchored = 1.0
 	invisibility = 101
 
-/obj/effect/landmark/start/Initialize()
+/obj/abstract/landmark/start/Initialize()
 	tag = "start*[name]"
 	return ..()
 
 //Costume spawner landmarks
-/obj/effect/landmark/costume
+/obj/abstract/landmark/costume
 	delete_me = TRUE
 
-/obj/effect/landmark/costume/Initialize()
+/obj/abstract/landmark/costume/Initialize()
 	make_costumes()
 	. = ..() //costume spawner, selects a random subclass and disappears
 
-/obj/effect/landmark/costume/proc/make_costumes()
-	var/list/options = typesof(/obj/effect/landmark/costume)
+/obj/abstract/landmark/costume/proc/make_costumes()
+	var/list/options = typesof(/obj/abstract/landmark/costume)
 	var/PICK= options[rand(1,options.len)]
 	new PICK(loc)
 
 //SUBCLASSES.  Spawn a bunch of items and disappear likewise
-/obj/effect/landmark/costume/chameleon/make_costumes()
+/obj/abstract/landmark/costume/chameleon/make_costumes()
 	new /obj/item/clothing/mask/chameleon(src.loc)
 	new /obj/item/clothing/under/chameleon(src.loc)
 	new /obj/item/clothing/glasses/chameleon(src.loc)
@@ -57,38 +51,38 @@
 	new /obj/item/clothing/head/chameleon(src.loc)
 	new /obj/item/storage/backpack/chameleon(src.loc)
 
-/obj/effect/landmark/costume/gladiator/make_costumes()
+/obj/abstract/landmark/costume/gladiator/make_costumes()
 	new /obj/item/clothing/under/gladiator(src.loc)
 	new /obj/item/clothing/head/helmet/gladiator(src.loc)
 
-/obj/effect/landmark/costume/madscientist/make_costumes()
+/obj/abstract/landmark/costume/madscientist/make_costumes()
 	new /obj/item/clothing/under/gimmick/rank/captain/suit(src.loc)
 	new /obj/item/clothing/head/flatcap(src.loc)
 	new /obj/item/clothing/suit/storage/toggle/labcoat/mad(src.loc)
 	new /obj/item/clothing/glasses/prescription/gglasses(src.loc)
 
-/obj/effect/landmark/costume/elpresidente/make_costumes()
+/obj/abstract/landmark/costume/elpresidente/make_costumes()
 	new /obj/item/clothing/under/gimmick/rank/captain/suit(src.loc)
 	new /obj/item/clothing/head/flatcap(src.loc)
 	new /obj/item/clothing/mask/smokable/cigarette/cigar/havana(src.loc)
 	new /obj/item/clothing/shoes/jackboots(src.loc)
 
-/obj/effect/landmark/costume/nyangirl/make_costumes()
+/obj/abstract/landmark/costume/nyangirl/make_costumes()
 	new /obj/item/clothing/under/schoolgirl(src.loc)
 	new /obj/item/clothing/head/kitty(src.loc)
 
-/obj/effect/landmark/costume/maid/make_costumes()
+/obj/abstract/landmark/costume/maid/make_costumes()
 	new /obj/item/clothing/under/blackskirt(src.loc)
 	var/CHOICE = pick( /obj/item/clothing/head/beret , /obj/item/clothing/head/rabbitears )
 	new CHOICE(src.loc)
 	new /obj/item/clothing/glasses/blindfold(src.loc)
 
-/obj/effect/landmark/costume/butler/make_costumes()
+/obj/abstract/landmark/costume/butler/make_costumes()
 	new /obj/item/clothing/accessory/wcoat/black(src.loc)
 	new /obj/item/clothing/under/suit_jacket(src.loc)
 	new /obj/item/clothing/head/that(src.loc)
 
-/obj/effect/landmark/costume/prig/make_costumes()
+/obj/abstract/landmark/costume/prig/make_costumes()
 	new /obj/item/clothing/accessory/wcoat/black(src.loc)
 	new /obj/item/clothing/glasses/eyepatch/monocle(src.loc)
 	var/CHOICE= pick( /obj/item/clothing/head/bowler, /obj/item/clothing/head/that)
@@ -98,79 +92,79 @@
 	new /obj/item/clothing/under/sl_suit(src.loc)
 	new /obj/item/clothing/mask/fakemoustache(src.loc)
 
-/obj/effect/landmark/costume/plaguedoctor/make_costumes()
+/obj/abstract/landmark/costume/plaguedoctor/make_costumes()
 	new /obj/item/clothing/suit/bio_suit/plaguedoctorsuit(src.loc)
 	new /obj/item/clothing/head/plaguedoctorhat(src.loc)
 
-/obj/effect/landmark/costume/nightowl/make_costumes()
+/obj/abstract/landmark/costume/nightowl/make_costumes()
 	new /obj/item/clothing/under/owl(src.loc)
 	new /obj/item/clothing/mask/gas/owl_mask(src.loc)
 
-/obj/effect/landmark/costume/waiter/make_costumes()
+/obj/abstract/landmark/costume/waiter/make_costumes()
 	new /obj/item/clothing/under/waiter(src.loc)
 	var/CHOICE= pick( /obj/item/clothing/head/kitty, /obj/item/clothing/head/rabbitears)
 	new CHOICE(src.loc)
 	new /obj/item/clothing/suit/apron(src.loc)
 
-/obj/effect/landmark/costume/pirate/make_costumes()
+/obj/abstract/landmark/costume/pirate/make_costumes()
 	new /obj/item/clothing/under/pirate(src.loc)
 	new /obj/item/clothing/suit/pirate(src.loc)
 	var/CHOICE = pick( /obj/item/clothing/head/pirate , /obj/item/clothing/mask/bandana/red)
 	new CHOICE(src.loc)
 	new /obj/item/clothing/glasses/eyepatch(src.loc)
 
-/obj/effect/landmark/costume/commie/make_costumes()
+/obj/abstract/landmark/costume/commie/make_costumes()
 	new /obj/item/clothing/under/soviet(src.loc)
 	new /obj/item/clothing/head/ushanka(src.loc)
 
-/obj/effect/landmark/costume/imperium_monk/make_costumes()
+/obj/abstract/landmark/costume/imperium_monk/make_costumes()
 	new /obj/item/clothing/suit/imperium_monk(src.loc)
 	if (prob(25))
 		new /obj/item/clothing/mask/gas/cyborg(src.loc)
 
-/obj/effect/landmark/costume/holiday_priest/make_costumes()
+/obj/abstract/landmark/costume/holiday_priest/make_costumes()
 	new /obj/item/clothing/suit/holidaypriest(src.loc)
 
-/obj/effect/landmark/costume/marisawizard/fake/make_costumes()
+/obj/abstract/landmark/costume/marisawizard/fake/make_costumes()
 	new /obj/item/clothing/head/wizard/marisa/fake(src.loc)
 	new/obj/item/clothing/suit/wizrobe/marisa/fake(src.loc)
 
-/obj/effect/landmark/costume/cutewitch/make_costumes()
+/obj/abstract/landmark/costume/cutewitch/make_costumes()
 	new /obj/item/clothing/under/sundress(src.loc)
 	new /obj/item/clothing/head/witchwig(src.loc)
 	new /obj/item/staff/broom(src.loc)
 
-/obj/effect/landmark/costume/fakewizard/make_costumes()
+/obj/abstract/landmark/costume/fakewizard/make_costumes()
 	new /obj/item/clothing/suit/wizrobe/fake(src.loc)
 	new /obj/item/clothing/head/wizard/fake(src.loc)
 	new /obj/item/staff/(src.loc)
 
-/obj/effect/landmark/costume/sexyclown/make_costumes()
+/obj/abstract/landmark/costume/sexyclown/make_costumes()
 	new /obj/item/clothing/mask/gas/sexyclown(src.loc)
 	new /obj/item/clothing/under/sexyclown(src.loc)
 
-/obj/effect/landmark/costume/sexymime/make_costumes()
+/obj/abstract/landmark/costume/sexymime/make_costumes()
 	new /obj/item/clothing/mask/gas/sexymime(src.loc)
 	new /obj/item/clothing/under/sexymime(src.loc)
 
-/obj/effect/landmark/costume/savagehunter/make_costumes()
+/obj/abstract/landmark/costume/savagehunter/make_costumes()
 	new /obj/item/clothing/mask/spirit(src.loc)
 	new /obj/item/clothing/under/savage_hunter(src.loc)
 
-/obj/effect/landmark/costume/savagehuntress/make_costumes()
+/obj/abstract/landmark/costume/savagehuntress/make_costumes()
 	new /obj/item/clothing/mask/spirit(src.loc)
 	new /obj/item/clothing/under/savage_hunter/female(src.loc)
 
-/obj/effect/landmark/ruin
+/obj/abstract/landmark/ruin
 	var/datum/map_template/ruin/ruin_template
 
-/obj/effect/landmark/ruin/Initialize(mapload, my_ruin_template)
-	name = "ruin_[sequential_id(/obj/effect/landmark/ruin)]"
+/obj/abstract/landmark/ruin/Initialize(mapload, my_ruin_template)
+	name = "ruin_[sequential_id(/obj/abstract/landmark/ruin)]"
 	. = ..()
 	ruin_template = my_ruin_template
 	global.ruin_landmarks |= src
 
-/obj/effect/landmark/ruin/Destroy()
+/obj/abstract/landmark/ruin/Destroy()
 	global.ruin_landmarks -= src
 	ruin_template = null
 	. = ..()

--- a/code/game/objects/effects/landmarks_endgame.dm
+++ b/code/game/objects/effects/landmarks_endgame.dm
@@ -1,13 +1,13 @@
 var/global/list/endgame_exits = list()
 var/global/list/endgame_safespawns = list()
 
-/obj/effect/landmark/endgame
+/obj/abstract/landmark/endgame
 	delete_me = TRUE
 
-/obj/effect/landmark/endgame/safe_spawn/Initialize()
+/obj/abstract/landmark/endgame/safe_spawn/Initialize()
 	global.endgame_safespawns |= get_turf(src)
 	. = ..()
 
-/obj/effect/landmark/endgame/exit/Initialize()
+/obj/abstract/landmark/endgame/exit/Initialize()
 	global.endgame_exits |= get_turf(src)
 	. = ..()

--- a/code/game/objects/effects/landmarks_latejoin.dm
+++ b/code/game/objects/effects/landmarks_latejoin.dm
@@ -3,21 +3,21 @@ var/global/list/latejoin_cryo_locations =    list()
 var/global/list/latejoin_cyborg_locations =  list()
 var/global/list/latejoin_gateway_locations = list()
 
-/obj/effect/landmark/latejoin
+/obj/abstract/landmark/latejoin
 	delete_me = TRUE
 
-/obj/effect/landmark/latejoin/Initialize()
+/obj/abstract/landmark/latejoin/Initialize()
 	add_loc()
 	. = ..()
 
-/obj/effect/landmark/latejoin/proc/add_loc()
+/obj/abstract/landmark/latejoin/proc/add_loc()
 	global.latejoin_locations |= get_turf(src)
 
-/obj/effect/landmark/latejoin/gateway/add_loc()
+/obj/abstract/landmark/latejoin/gateway/add_loc()
 	global.latejoin_gateway_locations |= get_turf(src)
 
-/obj/effect/landmark/latejoin/cryo/add_loc()
+/obj/abstract/landmark/latejoin/cryo/add_loc()
 	global.latejoin_cryo_locations |= get_turf(src)
 
-/obj/effect/landmark/latejoin/cyborg/add_loc()
+/obj/abstract/landmark/latejoin/cyborg/add_loc()
 	global.latejoin_cyborg_locations |= get_turf(src)

--- a/code/modules/abstract/_abstract.dm
+++ b/code/modules/abstract/_abstract.dm
@@ -1,3 +1,5 @@
+// TODO: consider converting to /atom/movable or some other form that will
+// hel with removing abstract objects from contents checks and maptick.
 /obj/abstract
 	name =          ""
 	icon =          'icons/effects/landmarks.dmi'

--- a/code/modules/abstract/_abstract.dm
+++ b/code/modules/abstract/_abstract.dm
@@ -1,12 +1,15 @@
 /obj/abstract
 	name =          ""
+	icon =          'icons/effects/landmarks.dmi'
+	icon_state =    "x2"
 	mouse_opacity = 0
 	alpha =         0
 	simulated =     FALSE
 	density =       FALSE
 	opacity =       FALSE
 	anchored =      TRUE
-	invisibility =  INVISIBILITY_MAXIMUM
+	unacidable =    TRUE
+	invisibility =  INVISIBILITY_MAXIMUM+1
 
 /obj/abstract/Initialize()
 	. = ..()

--- a/code/modules/abstract/_abstract.dm
+++ b/code/modules/abstract/_abstract.dm
@@ -12,6 +12,6 @@
 	. = ..()
 	verbs.Cut()
 
-/obj/abstract/weather_system/explosion_act()
+/obj/abstract/explosion_act()
 	SHOULD_CALL_PARENT(FALSE)
 	return

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -19,7 +19,7 @@
 #define CORPSE_SPAWNER_NO_RANDOMIZATION ~(CORPSE_SPAWNER_RANDOM_NAME|CORPSE_SPAWNER_RANDOM_SKIN_TONE|CORPSE_SPAWNER_RANDOM_SKIN_COLOR|CORPSE_SPAWNER_RANDOM_HAIR_COLOR|CORPSE_SPAWNER_RANDOM_HAIR_STYLE|CORPSE_SPAWNER_RANDOM_FACIAL_STYLE|CORPSE_SPAWNER_RANDOM_EYE_COLOR)
 
 
-/obj/effect/landmark/corpse
+/obj/abstract/landmark/corpse
 	name = "Unknown"
 	var/species                                       // List of species to pick from.
 	var/corpse_outfits = list(/decl/hierarchy/outfit) // List of outfits to pick from. Uses pickweight()
@@ -33,14 +33,14 @@
 	var/facial_styles_per_species = list() // Custom facial hair styles, per species -type-, if any. See above as to why
 	var/genders_per_species       = list() // For gender biases per species -type-
 
-/obj/effect/landmark/corpse/Initialize()
+/obj/abstract/landmark/corpse/Initialize()
 	..()
 	if(!species) species = global.using_map.default_species
 	var/species_choice = islist(species) ? pickweight(species) : species 
 	new /mob/living/carbon/human/corpse(loc, species_choice, src)
 	return INITIALIZE_HINT_QDEL
 
-/obj/effect/landmark/corpse/proc/randomize_appearance(var/mob/living/carbon/human/M, species_choice)
+/obj/abstract/landmark/corpse/proc/randomize_appearance(var/mob/living/carbon/human/M, species_choice)
 	if((spawn_flags & CORPSE_SPAWNER_RANDOM_GENDER))
 		if(species_choice in genders_per_species)
 			M.set_gender(pick(genders_per_species[species_choice]), TRUE)
@@ -91,7 +91,7 @@
 		M.SetName(name)
 	M.real_name = M.name
 
-/obj/effect/landmark/corpse/proc/equip_outfit(var/mob/living/carbon/human/M)
+/obj/abstract/landmark/corpse/proc/equip_outfit(var/mob/living/carbon/human/M)
 	var/adjustments = 0
 	adjustments = (spawn_flags & CORPSE_SPAWNER_CUT_SURVIVAL)  ? (adjustments|OUTFIT_ADJUSTMENT_SKIP_SURVIVAL_GEAR) : adjustments
 	adjustments = (spawn_flags & CORPSE_SPAWNER_CUT_ID_PDA)    ? (adjustments|OUTFIT_ADJUSTMENT_SKIP_ID_PDA)        : adjustments
@@ -100,44 +100,44 @@
 	var/decl/hierarchy/outfit/corpse_outfit = outfit_by_type(pickweight(corpse_outfits))
 	corpse_outfit.equip(M, equip_adjustments = adjustments)
 
-/obj/effect/landmark/corpse/pirate
+/obj/abstract/landmark/corpse/pirate
 	name = "Pirate"
 	corpse_outfits = list(/decl/hierarchy/outfit/pirate/norm)
 	spawn_flags = CORPSE_SPAWNER_NO_RANDOMIZATION
 
-/obj/effect/landmark/corpse/pirate/ranged
+/obj/abstract/landmark/corpse/pirate/ranged
 	name = "Pirate Gunner"
 	corpse_outfits = list(/decl/hierarchy/outfit/pirate/space)
 
-/obj/effect/landmark/corpse/russian
+/obj/abstract/landmark/corpse/russian
 	name = "Russian"
 	corpse_outfits = list(/decl/hierarchy/outfit/soviet_soldier)
 	spawn_flags = CORPSE_SPAWNER_NO_RANDOMIZATION
 
-/obj/effect/landmark/corpse/russian/ranged
+/obj/abstract/landmark/corpse/russian/ranged
 	corpse_outfits = list(/decl/hierarchy/outfit/soviet_soldier)
 
-/obj/effect/landmark/corpse/syndicate
+/obj/abstract/landmark/corpse/syndicate
 	name = "Syndicate Operative"
 	corpse_outfits = list(/decl/hierarchy/outfit/mercenary/syndicate)
 	spawn_flags = CORPSE_SPAWNER_NO_RANDOMIZATION
 
-/obj/effect/landmark/corpse/syndicate/commando
+/obj/abstract/landmark/corpse/syndicate/commando
 	name = "Syndicate Commando"
 	corpse_outfits = list(/decl/hierarchy/outfit/mercenary/syndicate/commando)
 
-/obj/effect/landmark/corpse/chef
+/obj/abstract/landmark/corpse/chef
 	name = "Chef"
 	corpse_outfits = list(/decl/hierarchy/outfit/job/generic/chef)
 
-/obj/effect/landmark/corpse/doctor
+/obj/abstract/landmark/corpse/doctor
 	name = "Doctor"
 	corpse_outfits = list(/decl/hierarchy/outfit/job/generic/doctor)
 
-/obj/effect/landmark/corpse/engineer
+/obj/abstract/landmark/corpse/engineer
 	name = "Engineer"
 	corpse_outfits = list(/decl/hierarchy/outfit/job/generic/engineer)
 
-/obj/effect/landmark/corpse/scientist
+/obj/abstract/landmark/corpse/scientist
 	name = "Scientist"
 	corpse_outfits = list(/decl/hierarchy/outfit/job/generic/scientist)

--- a/code/modules/chatter/_chatter.dm
+++ b/code/modules/chatter/_chatter.dm
@@ -7,7 +7,7 @@
 	chatter_on_frequency = PUB_FREQ
 	listener_landmark = "radioChatterDebugLandmark"
 
-/obj/effect/landmark/radio_chatter_debug
+/obj/abstract/landmark/radio_chatter_debug
 	name = "radioChatterDebugLandmark"
 
 /decl/radio_chatter/debug/create_conversations()
@@ -48,7 +48,7 @@
 	create_conversations()
 	next_chatter_time = world.time + rand(min_chatter_time_elapsed, max_chatter_time_elapsed)
 	if(listener_landmark && ispath(listener_instance))
-		for(var/obj/effect/landmark/landmark in global.landmarks_list)
+		for(var/obj/abstract/landmark/landmark in global.landmarks_list)
 			if(landmark.name != listener_landmark)
 				continue
 			var/turf/T = get_turf(landmark)

--- a/code/modules/events/apc_damage.dm
+++ b/code/modules/events/apc_damage.dm
@@ -22,7 +22,7 @@
 	var/list/possibleEpicentres = list()
 	var/list/apcs = list()
 
-	for(var/obj/effect/landmark/newEpicentre in global.landmarks_list)
+	for(var/obj/abstract/landmark/newEpicentre in global.landmarks_list)
 		if(newEpicentre.name == "lightsout")
 			possibleEpicentres += newEpicentre
 

--- a/code/modules/events/rogue_drones.dm
+++ b/code/modules/events/rogue_drones.dm
@@ -5,7 +5,7 @@
 /datum/event/rogue_drone/start()
 	//spawn them at the same place as carp
 	var/list/possible_spawns = list()
-	for(var/obj/effect/landmark/C in global.landmarks_list)
+	for(var/obj/abstract/landmark/C in global.landmarks_list)
 		if(C.name == "carpspawn")
 			possible_spawns.Add(C)
 

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -290,7 +290,7 @@
 	linkedholodeck.sound_env = A.sound_env
 
 	spawn(30)
-		for(var/obj/effect/landmark/L in linkedholodeck)
+		for(var/obj/abstract/landmark/L in linkedholodeck)
 			if(L.name=="Atmospheric Test Start")
 				spawn(20)
 					var/turf/T = get_turf(L)

--- a/code/modules/maps/helper_landmarks.dm
+++ b/code/modules/maps/helper_landmarks.dm
@@ -1,12 +1,12 @@
 //Load a random map template from the list. Maploader handles it to avoid order of init madness
-/obj/effect/landmark/map_load_mark
+/obj/abstract/landmark/map_load_mark
 	name = "map loader landmark"
 	var/list/templates	//list of template types to pick from
 
-/obj/effect/landmark/map_load_mark/proc/get_template()
+/obj/abstract/landmark/map_load_mark/proc/get_template()
 	. = LAZYLEN(templates) && pick(templates)
 
-/obj/effect/landmark/map_load_mark/proc/load_template()
+/obj/abstract/landmark/map_load_mark/proc/load_template()
 	var/template = get_template()
 	var/turf/spawn_loc = get_turf(src)
 	qdel(src)
@@ -14,24 +14,24 @@
 		var/datum/map_template/M = new template
 		M.load(spawn_loc, TRUE)
 
-INITIALIZE_IMMEDIATE(/obj/effect/landmark/map_load_mark/non_template)
-/obj/effect/landmark/map_load_mark/non_template
+INITIALIZE_IMMEDIATE(/obj/abstract/landmark/map_load_mark/non_template)
+/obj/abstract/landmark/map_load_mark/non_template
 	name = "compile-time map loader landmark"
-/obj/effect/landmark/map_load_mark/non_template/Initialize()
+/obj/abstract/landmark/map_load_mark/non_template/Initialize()
 	. = ..()
 	LAZYADD(SSmapping.compile_time_map_markers, src)
 
 //Throw things in the area around randomly
-/obj/effect/landmark/carnage_mark
+/obj/abstract/landmark/carnage_mark
 	name = "carnage landmark"
 	var/movement_prob = 50	// a chance random unanchored item in the room will be moved randomly
 	var/movement_range = 3  // how far would items get thrown
 
-/obj/effect/landmark/carnage_mark/Initialize()
+/obj/abstract/landmark/carnage_mark/Initialize()
 	. = ..()
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/effect/landmark/carnage_mark/LateInitialize()
+/obj/abstract/landmark/carnage_mark/LateInitialize()
 	var/area/A = get_area(src)
 	for(var/atom/movable/AM in A)
 		if(AM && !AM.anchored && AM.simulated && prob(movement_prob))
@@ -40,51 +40,51 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/map_load_mark/non_template)
 	qdel(src)
 
 //Clears walls
-/obj/effect/landmark/clear
+/obj/abstract/landmark/clear
 	name = "clear turf"
 	icon_state = "clear"
 	delete_me = TRUE
 
-/obj/effect/landmark/clear/Initialize()
+/obj/abstract/landmark/clear/Initialize()
 	var/turf/simulated/wall/W = get_turf(src)
 	if(istype(W))
 		W.dismantle_wall(1,1,1)
 	. = ..()
 
 //Applies fire act to the turf
-/obj/effect/landmark/scorcher
+/obj/abstract/landmark/scorcher
 	name = "fire"
 	icon_state = "fire"
 	var/temp = T0C + 4000
 
-/obj/effect/landmark/scorcher/Initialize()
+/obj/abstract/landmark/scorcher/Initialize()
 	var/turf/T = get_turf(src)
 	if(istype(T))
 		T.fire_act(exposed_temperature = temp)
 	. = ..()
 
 //Delete specified things when a specified shuttle moves
-/obj/effect/landmark/delete_on_shuttle
+/obj/abstract/landmark/delete_on_shuttle
 	var/shuttle_name
 	var/shuttle_datum
 	var/list/typetodelete = list(/obj/machinery, /obj/item/gun, /mob/living/exosuit, /obj/item/transfer_valve)
 
-/obj/effect/landmark/delete_on_shuttle/Initialize()
+/obj/abstract/landmark/delete_on_shuttle/Initialize()
 	. = ..()
 	events_repository.register_global(/decl/observ/shuttle_added, src, .proc/check_shuttle)
 
-/obj/effect/landmark/delete_on_shuttle/proc/check_shuttle(var/shuttle)
+/obj/abstract/landmark/delete_on_shuttle/proc/check_shuttle(var/shuttle)
 	if(SSshuttle.shuttles[shuttle_name] == shuttle)
 		events_repository.register(/decl/observ/shuttle_moved, shuttle, src, .proc/delete_everything)
 		shuttle_datum = shuttle
 
-/obj/effect/landmark/delete_on_shuttle/proc/delete_everything()
+/obj/abstract/landmark/delete_on_shuttle/proc/delete_everything()
 	for(var/O in loc)
 		if(is_type_in_list(O,typetodelete))
 			qdel(O)
 	qdel(src)
 
-/obj/effect/landmark/delete_on_shuttle/Destroy()
+/obj/abstract/landmark/delete_on_shuttle/Destroy()
 	events_repository.unregister_global(/decl/observ/shuttle_added, src, .proc/check_shuttle)
 	if(shuttle_datum)
 		events_repository.unregister(/decl/observ/shuttle_moved, shuttle_datum, src, .proc/delete_everything)

--- a/code/modules/maps/map_template.dm
+++ b/code/modules/maps/map_template.dm
@@ -58,7 +58,7 @@
 			atmos_machines += A
 		if(istype(A, /obj/machinery))
 			machines += A
-		if(istype(A, /obj/effect/landmark/map_load_mark))
+		if(istype(A, /obj/abstract/landmark/map_load_mark))
 			LAZYADD(subtemplates_to_spawn, A)
 
 	var/notsuspended
@@ -133,7 +133,7 @@
 			global.using_map.accessible_z_levels[num2text(z_index)] = accessibility_weight
 		if (base_turf_for_zs)
 			global.using_map.base_turf_by_z[num2text(z_index)] = base_turf_for_zs
-		global.using_map.player_levels |= z_index // TODO: make maps handle this with /obj/level_data
+		global.using_map.player_levels |= z_index // TODO: make maps handle this with /obj/abstract/level_data
 
 	//initialize things that are normally initialized after map load
 	init_atoms(atoms_to_initialise)
@@ -187,7 +187,7 @@
 	return TRUE
 
 /datum/map_template/proc/after_load(z)
-	for(var/obj/effect/landmark/map_load_mark/mark AS_ANYTHING in subtemplates_to_spawn)
+	for(var/obj/abstract/landmark/map_load_mark/mark AS_ANYTHING in subtemplates_to_spawn)
 		subtemplates_to_spawn -= mark
 		mark.load_template()
 	subtemplates_to_spawn = null

--- a/code/modules/maps/ruins.dm
+++ b/code/modules/maps/ruins.dm
@@ -81,5 +81,5 @@ var/global/list/banned_ruin_ids = list()
 	template.load(central_turf,centered = TRUE)
 	var/datum/map_template/ruin = template
 	if(istype(ruin))
-		new /obj/effect/landmark/ruin(central_turf, ruin)
+		new /obj/abstract/landmark/ruin(central_turf, ruin)
 	return TRUE

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -16,7 +16,7 @@
 /mob/living/carbon/human/corpse
 	real_name = "corpse"
 
-/mob/living/carbon/human/corpse/Initialize(mapload, new_species, obj/effect/landmark/corpse/corpse)
+/mob/living/carbon/human/corpse/Initialize(mapload, new_species, obj/abstract/landmark/corpse/corpse)
 
 	. = ..(mapload, new_species)
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -77,21 +77,21 @@
 
 	if(move)
 		var/obj/loc_landmark
-		for(var/obj/effect/landmark/start/sloc in global.landmarks_list)
+		for(var/obj/abstract/landmark/start/sloc in global.landmarks_list)
 			if (sloc.name != "AI")
 				continue
 			if (locate(/mob/living) in sloc.loc)
 				continue
 			loc_landmark = sloc
 		if (!loc_landmark)
-			for(var/obj/effect/landmark/tripai in global.landmarks_list)
+			for(var/obj/abstract/landmark/tripai in global.landmarks_list)
 				if (tripai.name == "tripai")
 					if((locate(/mob/living) in tripai.loc) || (locate(/obj/structure/aicore) in tripai.loc))
 						continue
 					loc_landmark = tripai
 		if (!loc_landmark)
 			to_chat(O, "Oh god sorry we can't find an unoccupied AI spawn location, so we're spawning you on top of someone.")
-			for(var/obj/effect/landmark/start/sloc in global.landmarks_list)
+			for(var/obj/abstract/landmark/start/sloc in global.landmarks_list)
 				if (sloc.name == "AI")
 					loc_landmark = sloc
 		O.forceMove(loc_landmark ? loc_landmark.loc : get_turf(src))

--- a/code/modules/multiz/basic.dm
+++ b/code/modules/multiz/basic.dm
@@ -27,7 +27,7 @@ var/global/list/z_levels = list() // Each Z-level is associated with the relevan
 
 	// Check stack for any laterally connected neighbors.
 	for(var/tz in .)
-		var/obj/level_data/level = global.levels_by_z["[tz]"]
+		var/obj/abstract/level_data/level = global.levels_by_z["[tz]"]
 		if(level)
 			level.find_connected_levels(.)
 

--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -7,17 +7,15 @@
 var/global/list/levels_by_z =  list()
 var/global/list/levels_by_id = list()
 
-/obj/level_data
-	simulated = FALSE
+/obj/abstract/level_data
 	var/my_z
 	var/level_id
 	var/base_turf
 	var/list/connects_to
 	var/level_flags
 
-
-INITIALIZE_IMMEDIATE(/obj/level_data)
-/obj/level_data/Initialize()
+INITIALIZE_IMMEDIATE(/obj/abstract/level_data)
+/obj/abstract/level_data/Initialize()
 	. = ..()
 	my_z = z
 	forceMove(null)
@@ -25,7 +23,7 @@ INITIALIZE_IMMEDIATE(/obj/level_data)
 		PRINT_STACK_TRACE("Duplicate level data created for z[z].")
 	global.levels_by_z["[my_z]"] = src
 	if(!level_id)
-		level_id = "leveldata_[my_z]_[sequential_id(/obj/level_data)]"
+		level_id = "leveldata_[my_z]_[sequential_id(/obj/abstract/level_data)]"
 	if(level_id in global.levels_by_id)
 		PRINT_STACK_TRACE("Duplicate level_id '[level_id]' for z[my_z].")
 	else
@@ -45,18 +43,18 @@ INITIALIZE_IMMEDIATE(/obj/level_data)
 	if(level_flags & ZLEVEL_SEALED)
 		global.using_map.sealed_levels  |= my_z
 
-/obj/level_data/Destroy(var/force)
+/obj/abstract/level_data/Destroy(var/force)
 	if(force)
 		new type(locate(round(world.maxx/2), round(world.maxy/2), my_z))
 		return ..()
 	return QDEL_HINT_LETMELIVE
 
-/obj/level_data/proc/find_connected_levels(var/list/found)
+/obj/abstract/level_data/proc/find_connected_levels(var/list/found)
 	for(var/other_id in connects_to)
-		var/obj/level_data/neighbor = global.levels_by_id[other_id] 
+		var/obj/abstract/level_data/neighbor = global.levels_by_id[other_id] 
 		neighbor.add_connected_levels(found)
 
-/obj/level_data/proc/add_connected_levels(var/list/found)
+/obj/abstract/level_data/proc/add_connected_levels(var/list/found)
 	. = found
 	if((my_z in found))
 		return
@@ -64,19 +62,19 @@ INITIALIZE_IMMEDIATE(/obj/level_data)
 	if(!length(connects_to))
 		return
 	for(var/other_id in connects_to)
-		var/obj/level_data/neighbor = global.levels_by_id[other_id] 
+		var/obj/abstract/level_data/neighbor = global.levels_by_id[other_id] 
 		neighbor.add_connected_levels(found)
 
 // Mappable subtypes.
-/obj/level_data/main_level
+/obj/abstract/level_data/main_level
 	name = "Main Station Level"
 	level_flags = (ZLEVEL_STATION|ZLEVEL_CONTACT|ZLEVEL_PLAYER)
 
-/obj/level_data/admin_level
+/obj/abstract/level_data/admin_level
 	name = "Admin Level"
 	level_flags = (ZLEVEL_ADMIN|ZLEVEL_SEALED)
 
-/obj/level_data/player_level
+/obj/abstract/level_data/player_level
 	name = "Player Level"
 	level_flags = (ZLEVEL_CONTACT|ZLEVEL_PLAYER)
 

--- a/code/modules/multiz/map_data.dm
+++ b/code/modules/multiz/map_data.dm
@@ -1,4 +1,4 @@
-/obj/effect/landmark/map_data
+/obj/abstract/landmark/map_data
 	name = "Map Data"
 	desc = "An unknown location."
 	invisibility = 101
@@ -10,7 +10,7 @@
 
 // If the height is more than 1, we mark all contained levels as connected.
 // This is in New because it is an auxiliary effect specifically needed pre-init.
-/obj/effect/landmark/map_data/New(turf/loc, _height)
+/obj/abstract/landmark/map_data/New(turf/loc, _height)
 	..()
 	if(!istype(loc)) // Using loc.z is safer when using the maploader and New.
 		return
@@ -24,7 +24,7 @@
 	if (length(SSzcopy.zlev_maximums))
 		SSzcopy.calculate_zstack_limits()
 
-/obj/effect/landmark/map_data/Destroy(forced)
+/obj/abstract/landmark/map_data/Destroy(forced)
 	if(forced)
 		new type(loc, height) // Will replace our references in z_levels
 		return ..()

--- a/code/modules/multiz/map_data.dm
+++ b/code/modules/multiz/map_data.dm
@@ -1,4 +1,4 @@
-/obj/abstract/landmark/map_data
+/obj/abstract/map_data
 	name = "Map Data"
 	desc = "An unknown location."
 	invisibility = 101
@@ -10,7 +10,7 @@
 
 // If the height is more than 1, we mark all contained levels as connected.
 // This is in New because it is an auxiliary effect specifically needed pre-init.
-/obj/abstract/landmark/map_data/New(turf/loc, _height)
+/obj/abstract/map_data/New(turf/loc, _height)
 	..()
 	if(!istype(loc)) // Using loc.z is safer when using the maploader and New.
 		return
@@ -24,7 +24,7 @@
 	if (length(SSzcopy.zlev_maximums))
 		SSzcopy.calculate_zstack_limits()
 
-/obj/abstract/landmark/map_data/Destroy(forced)
+/obj/abstract/map_data/Destroy(forced)
 	if(forced)
 		new type(loc, height) // Will replace our references in z_levels
 		return ..()

--- a/code/modules/overmap/exoplanets/exoplanet_fauna.dm
+++ b/code/modules/overmap/exoplanets/exoplanet_fauna.dm
@@ -75,30 +75,30 @@
 	return TRUE
 
 // Landmarks placed by random map generator
-/obj/effect/landmark/exoplanet_spawn
+/obj/abstract/landmark/exoplanet_spawn
 	name = "spawn exoplanet animal"
 
-/obj/effect/landmark/exoplanet_spawn/Initialize()
+/obj/abstract/landmark/exoplanet_spawn/Initialize()
 	..()
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/effect/landmark/exoplanet_spawn/LateInitialize()
+/obj/abstract/landmark/exoplanet_spawn/LateInitialize()
 	. = ..()
 	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors["[z]"]
 	if(istype(E))
 		do_spawn(E)
 		
-/obj/effect/landmark/exoplanet_spawn/proc/do_spawn(var/obj/effect/overmap/visitable/sector/exoplanet/planet)
+/obj/abstract/landmark/exoplanet_spawn/proc/do_spawn(var/obj/effect/overmap/visitable/sector/exoplanet/planet)
 	if(LAZYLEN(planet.fauna_types))
 		var/beastie = pick(planet.fauna_types)
 		var/mob/M = new beastie(get_turf(src))
 		planet.adapt_animal(M)
 		planet.track_animal(M)
 
-/obj/effect/landmark/exoplanet_spawn/megafauna
+/obj/abstract/landmark/exoplanet_spawn/megafauna
 	name = "spawn exoplanet megafauna"
 
-/obj/effect/landmark/exoplanet_spawn/megafauna/do_spawn(var/obj/effect/overmap/visitable/sector/exoplanet/planet)
+/obj/abstract/landmark/exoplanet_spawn/megafauna/do_spawn(var/obj/effect/overmap/visitable/sector/exoplanet/planet)
 	if(LAZYLEN(planet.megafauna_types))
 		var/beastie = pick(planet.megafauna_types)
 		var/mob/M = new beastie(get_turf(src))

--- a/code/modules/overmap/exoplanets/exoplanet_flora.dm
+++ b/code/modules/overmap/exoplanets/exoplanet_flora.dm
@@ -60,16 +60,16 @@
 			S.chems[chem_type] = list(rand(1,10),rand(10,20))
 
 // Landmarks placed by random map generator
-/obj/effect/landmark/exoplanet_spawn/plant
+/obj/abstract/landmark/exoplanet_spawn/plant
 	name = "spawn exoplanet plant"
 
-/obj/effect/landmark/exoplanet_spawn/plant/do_spawn(var/obj/effect/overmap/visitable/sector/exoplanet/planet)
+/obj/abstract/landmark/exoplanet_spawn/plant/do_spawn(var/obj/effect/overmap/visitable/sector/exoplanet/planet)
 	if(LAZYLEN(planet.small_flora_types))
 		new /obj/machinery/portable_atmospherics/hydroponics/soil/invisible(get_turf(src), pick(planet.small_flora_types), 1)
 
-/obj/effect/landmark/exoplanet_spawn/large_plant
+/obj/abstract/landmark/exoplanet_spawn/large_plant
 	name = "spawn exoplanet large plant"
 
-/obj/effect/landmark/exoplanet_spawn/large_plant/do_spawn(var/obj/effect/overmap/visitable/sector/exoplanet/planet)
+/obj/abstract/landmark/exoplanet_spawn/large_plant/do_spawn(var/obj/effect/overmap/visitable/sector/exoplanet/planet)
 	if(LAZYLEN(planet.big_flora_types))
 		new /obj/machinery/portable_atmospherics/hydroponics/soil/invisible(get_turf(src), pick(planet.big_flora_types), 1)

--- a/code/modules/overmap/exoplanets/planet_themes/ruined_city.dm
+++ b/code/modules/overmap/exoplanets/planet_themes/ruined_city.dm
@@ -142,7 +142,7 @@
 	if((T.broken && prob(80)) || prob(10))
 		new/obj/structure/rubble/house(T)
 	if(prob(1))
-		new/obj/effect/landmark/exoplanet_spawn(T)
+		new/obj/abstract/landmark/exoplanet_spawn(T)
 
 //Artifact containment lab
 /turf/simulated/wall/containment

--- a/code/modules/overmap/exoplanets/random_map.dm
+++ b/code/modules/overmap/exoplanets/random_map.dm
@@ -75,9 +75,9 @@
 
 /datum/random_map/noise/exoplanet/proc/spawn_fauna(var/turf/T)
 	if(prob(megafauna_spawn_prob))
-		new /obj/effect/landmark/exoplanet_spawn/megafauna(T)
+		new /obj/abstract/landmark/exoplanet_spawn/megafauna(T)
 	else
-		new /obj/effect/landmark/exoplanet_spawn(T)
+		new /obj/abstract/landmark/exoplanet_spawn(T)
 
 /datum/random_map/noise/exoplanet/proc/get_grass_overlay()
 	var/grass_num = "[rand(1,6)]"
@@ -92,11 +92,11 @@
 
 /datum/random_map/noise/exoplanet/proc/spawn_flora(var/turf/T, var/big)
 	if(big)
-		new /obj/effect/landmark/exoplanet_spawn/large_plant(T)
+		new /obj/abstract/landmark/exoplanet_spawn/large_plant(T)
 		for(var/turf/neighbor in RANGE_TURFS(T, 1))
 			spawn_grass(neighbor)
 	else
-		new /obj/effect/landmark/exoplanet_spawn/plant(T)
+		new /obj/abstract/landmark/exoplanet_spawn/plant(T)
 		spawn_grass(T)
 
 /datum/random_map/noise/exoplanet/proc/spawn_grass(var/turf/T)

--- a/code/modules/overmap/ships/landable.dm
+++ b/code/modules/overmap/ships/landable.dm
@@ -67,7 +67,7 @@
 			map_z += world.maxz
 
 		if(multiz)
-			new /obj/abstract/landmark/map_data(locate(1, 1, world.maxz), (multiz + 1))
+			new /obj/abstract/map_data(locate(1, 1, world.maxz), (multiz + 1))
 	else
 		..()
 

--- a/code/modules/overmap/ships/landable.dm
+++ b/code/modules/overmap/ships/landable.dm
@@ -67,7 +67,7 @@
 			map_z += world.maxz
 
 		if(multiz)
-			new /obj/effect/landmark/map_data(locate(1, 1, world.maxz), (multiz + 1))
+			new /obj/abstract/landmark/map_data(locate(1, 1, world.maxz), (multiz + 1))
 	else
 		..()
 

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -1,6 +1,6 @@
 var/global/list/shuttle_landmarks = list()
 
-//making this separate from /obj/effect/landmark until that mess can be dealt with
+//making this separate from /obj/abstract/landmark until that mess can be dealt with
 /obj/effect/shuttle_landmark
 	name = "Nav Point"
 	icon = 'icons/effects/effects.dmi'

--- a/code/modules/shuttles/shuttle_specops.dm
+++ b/code/modules/shuttles/shuttle_specops.dm
@@ -155,10 +155,10 @@
 		sleep(10)
 
 		var/spawn_marauder[] = new()
-		for(var/obj/effect/landmark/L in global.landmarks_list)
+		for(var/obj/abstract/landmark/L in global.landmarks_list)
 			if(L.name == "Marauder Entry")
 				spawn_marauder.Add(L)
-		for(var/obj/effect/landmark/L in global.landmarks_list)
+		for(var/obj/abstract/landmark/L in global.landmarks_list)
 			if(L.name == "Marauder Exit")
 				var/obj/effect/portal/P = new(L.loc)
 				P.set_invisibility(101)//So it is not seen by anyone.

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -819,7 +819,7 @@
 			log_bad("Invalid door turf: [log_info_line(D.loc)]]")
 		else
 			var/list/turf_exceptions
-			var/obj/abstract/landmark/map_data/MD = get_map_data(D.loc.z)
+			var/obj/abstract/map_data/MD = get_map_data(D.loc.z)
 			if(UNLINT(MD?.UT_turf_exceptions_by_door_type))
 				turf_exceptions = UNLINT(MD.UT_turf_exceptions_by_door_type[D.type])
 

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -322,14 +322,14 @@
 	var/space_landmarks = 0
 
 	for(var/lm in global.landmarks_list)
-		var/obj/effect/landmark/landmark = lm
-		if(istype(landmark, /obj/effect/landmark/test/safe_turf))
+		var/obj/abstract/landmark/landmark = lm
+		if(istype(landmark, /obj/abstract/landmark/test/safe_turf))
 			log_debug("Safe landmark found: [log_info_line(landmark)]")
 			safe_landmarks++
-		else if(istype(landmark, /obj/effect/landmark/test/space_turf))
+		else if(istype(landmark, /obj/abstract/landmark/test/space_turf))
 			log_debug("Space landmark found: [log_info_line(landmark)]")
 			space_landmarks++
-		else if(istype(landmark, /obj/effect/landmark/test))
+		else if(istype(landmark, /obj/abstract/landmark/test))
 			log_debug("Test landmark with unknown tag found: [log_info_line(landmark)]")
 
 	if(safe_landmarks != 1 || space_landmarks != 1)
@@ -819,7 +819,7 @@
 			log_bad("Invalid door turf: [log_info_line(D.loc)]]")
 		else
 			var/list/turf_exceptions
-			var/obj/effect/landmark/map_data/MD = get_map_data(D.loc.z)
+			var/obj/abstract/landmark/map_data/MD = get_map_data(D.loc.z)
 			if(UNLINT(MD?.UT_turf_exceptions_by_door_type))
 				turf_exceptions = UNLINT(MD.UT_turf_exceptions_by_door_type[D.type])
 

--- a/code/unit_tests/proximity_tests.dm
+++ b/code/unit_tests/proximity_tests.dm
@@ -10,8 +10,8 @@
 	name = "PROXIMITY: " + name
 
 /datum/unit_test/proximity/setup_test()
-	proximity_listener = new(get_turf(locate(/obj/effect/landmark/proximity_spawner)))
-	wall = get_turf(locate(/obj/effect/landmark/proximity_wall))
+	proximity_listener = new(get_turf(locate(/obj/abstract/landmark/proximity_spawner)))
+	wall = get_turf(locate(/obj/abstract/landmark/proximity_wall))
 
 /datum/unit_test/proximity/teardown_test()
 	QDEL_NULL(proximity_listener)
@@ -80,11 +80,11 @@
 	)
 
 /datum/unit_test/proximity/visibility/shall_see_the_number_of_expected_turfs_after_opacity_change/AfterSetTrigger()
-	var/turf/T = get_turf(locate(/obj/effect/landmark/proximity_wall))
+	var/turf/T = get_turf(locate(/obj/abstract/landmark/proximity_wall))
 	T.set_opacity(FALSE)
 
 /datum/unit_test/proximity/visibility/shall_see_the_number_of_expected_turfs_after_opacity_change/AfterTestRun()
-	var/turf/T = get_turf(locate(/obj/effect/landmark/proximity_wall))
+	var/turf/T = get_turf(locate(/obj/abstract/landmark/proximity_wall))
 	T.set_opacity(TRUE)
 
 
@@ -146,6 +146,6 @@
 /area/test_area/proximity
 	icon_state = "green"
 
-/obj/effect/landmark/proximity_spawner
+/obj/abstract/landmark/proximity_spawner
 
-/obj/effect/landmark/proximity_wall
+/obj/abstract/landmark/proximity_wall

--- a/code/unit_tests/unit_test.dm
+++ b/code/unit_tests/unit_test.dm
@@ -102,7 +102,7 @@ var/global/ascii_reset = "[ascii_esc]\[0m"
 	var/cleanup_failed = FALSE
 
 	if(!async && check_cleanup) // Async tests run at the same time, so cleaning up after any one completes risks breaking other tests
-		var/ignored_types = list(/atom/movable/lighting_overlay, /obj/effect/landmark/test)
+		var/ignored_types = list(/atom/movable/lighting_overlay, /obj/abstract/landmark/test)
 		var/z_levels = list()
 		var/turf/safe = get_safe_turf()
 		var/turf/space = get_space_turf()
@@ -126,7 +126,7 @@ var/global/ascii_reset = "[ascii_esc]\[0m"
 	check_cleanup = TRUE
 	if(!safe_landmark)
 		for(var/landmark in global.landmarks_list)
-			if(istype(landmark, /obj/effect/landmark/test/safe_turf))
+			if(istype(landmark, /obj/abstract/landmark/test/safe_turf))
 				safe_landmark = landmark
 				break
 	return get_turf(safe_landmark)
@@ -135,7 +135,7 @@ var/global/ascii_reset = "[ascii_esc]\[0m"
 	check_cleanup = TRUE
 	if(!space_landmark)
 		for(var/landmark in global.landmarks_list)
-			if(istype(landmark, /obj/effect/landmark/test/space_turf))
+			if(istype(landmark, /obj/abstract/landmark/test/space_turf))
 				space_landmark = landmark
 				break
 	return get_turf(space_landmark)
@@ -217,10 +217,10 @@ var/global/ascii_reset = "[ascii_esc]\[0m"
 	test.teardown_test()
 	unit_test_final_message()
 
-/obj/effect/landmark/test/safe_turf
+/obj/abstract/landmark/test/safe_turf
 	name = "safe_turf" // At creation, landmark tags are set to: "landmark*[name]"
 	desc = "A safe turf should be an as large block as possible of livable, passable turfs, preferably at least 3x3 with the marked turf as the center"
 
-/obj/effect/landmark/test/space_turf
+/obj/abstract/landmark/test/space_turf
 	name = "space_turf"
 	desc = "A space turf should be an as large block as possible of space, preferably at least 3x3 with the marked turf as the center"

--- a/code/unit_tests/virtual_mob_tests.dm
+++ b/code/unit_tests/virtual_mob_tests.dm
@@ -106,15 +106,15 @@
 	. = ..()
 
 /datum/unit_test/virtual/helper/proc/standard_setup()
-	mob_one   = get_named_instance(/mob/fake_mob, get_turf(locate(/obj/effect/landmark/test/virtual_spawn/one)),   "Test Mob 1")
-	mob_two   = get_named_instance(/mob/fake_mob, get_turf(locate(/obj/effect/landmark/test/virtual_spawn/two)),   "Test Mob 2")
-	mob_three = get_named_instance(/mob/fake_mob, get_turf(locate(/obj/effect/landmark/test/virtual_spawn/three)), "Test Mob 3")
+	mob_one   = get_named_instance(/mob/fake_mob, get_turf(locate(/obj/abstract/landmark/test/virtual_spawn/one)),   "Test Mob 1")
+	mob_two   = get_named_instance(/mob/fake_mob, get_turf(locate(/obj/abstract/landmark/test/virtual_spawn/two)),   "Test Mob 2")
+	mob_three = get_named_instance(/mob/fake_mob, get_turf(locate(/obj/abstract/landmark/test/virtual_spawn/three)), "Test Mob 3")
 
 /datum/unit_test/virtual/helper/proc/standard_cleanup()
 	QDEL_NULL(mob_one)
 	QDEL_NULL(mob_two)
 	QDEL_NULL(mob_three)
 
-/obj/effect/landmark/test/virtual_spawn/one
-/obj/effect/landmark/test/virtual_spawn/two
-/obj/effect/landmark/test/virtual_spawn/three
+/obj/abstract/landmark/test/virtual_spawn/one
+/obj/abstract/landmark/test/virtual_spawn/two
+/obj/abstract/landmark/test/virtual_spawn/three

--- a/code/unit_tests/~unit_test_subsystems.dm
+++ b/code/unit_tests/~unit_test_subsystems.dm
@@ -52,7 +52,7 @@ SUBSYSTEM_DEF(unit_tests)
 	// Suggestion: Do smart things here to squeeze as many templates as possible into the same Z-level
 	if(map_template.tallness == 1)
 		INCREMENT_WORLD_Z_SIZE
-		global.using_map.sealed_levels += world.maxz // TODO: make maps handle this with /obj/level_data
+		global.using_map.sealed_levels += world.maxz // TODO: make maps handle this with /obj/abstract/level_data
 		var/corner = locate(world.maxx/2, world.maxy/2, world.maxz)
 		log_unit_test("Loading template '[map_template]' ([map_template.type]) at [log_info_line(corner)]")
 		map_template.load(corner)

--- a/maps/antag_spawn/deity/deity_base.dmm
+++ b/maps/antag_spawn/deity/deity_base.dmm
@@ -16,7 +16,7 @@
 	},
 /area/map_template/deity_spawn)
 "d" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "DeitySpawn"
 	},
 /turf/unsimulated/floor{
@@ -25,7 +25,7 @@
 	},
 /area/map_template/deity_spawn)
 "e" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "DeitySpawn"
 	},
 /turf/unsimulated/floor{

--- a/maps/antag_spawn/ert/ert_base.dmm
+++ b/maps/antag_spawn/ert/ert_base.dmm
@@ -825,7 +825,7 @@
 	},
 /area/map_template/rescue_base/base)
 "bV" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "Response Team"
 	},
 /turf/unsimulated/floor{

--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -248,7 +248,7 @@
 	},
 /area/map_template/syndicate_mothership/raider_base)
 "aL" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "raiderstart"
 	},
 /obj/effect/floor_decal/carpet{
@@ -356,7 +356,7 @@
 	},
 /area/map_template/syndicate_mothership/raider_base)
 "aX" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "raiderstart"
 	},
 /turf/unsimulated/floor{

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -1613,7 +1613,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "Nuclear-Bomb"
 	},
 /obj/structure/railing/mapped{
@@ -1663,7 +1663,7 @@
 /turf/simulated/floor/tiled,
 /area/map_template/merc_spawn)
 "eb" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "Syndicate-Spawn"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -1832,7 +1832,7 @@
 /obj/item/gun/projectile/revolver,
 /obj/item/ammo_magazine/speedloader,
 /obj/item/ammo_magazine/speedloader,
-/obj/effect/landmark/delete_on_shuttle{
+/obj/abstract/landmark/delete_on_shuttle{
 	shuttle_name = "Desperado"
 	},
 /turf/simulated/floor/plating,
@@ -1850,7 +1850,7 @@
 /obj/item/ammo_magazine/pistol,
 /obj/item/ammo_magazine/pistol,
 /obj/item/ammo_magazine/pistol,
-/obj/effect/landmark/delete_on_shuttle{
+/obj/abstract/landmark/delete_on_shuttle{
 	shuttle_name = "Desperado"
 	},
 /turf/simulated/floor/plating,
@@ -1899,7 +1899,7 @@
 "jP" = (
 /obj/machinery/acting/changer,
 /obj/machinery/light/spot,
-/obj/effect/landmark/delete_on_shuttle{
+/obj/abstract/landmark/delete_on_shuttle{
 	shuttle_name = "Desperado"
 	},
 /turf/simulated/floor/plating,
@@ -1914,7 +1914,7 @@
 /obj/structure/rack,
 /obj/item/gun/energy/gun,
 /obj/item/gun/energy/gun,
-/obj/effect/landmark/delete_on_shuttle{
+/obj/abstract/landmark/delete_on_shuttle{
 	shuttle_name = "Desperado"
 	},
 /turf/simulated/floor/plating,
@@ -1929,7 +1929,7 @@
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
 "ks" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "Syndicate-Spawn"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -1970,7 +1970,7 @@
 /obj/structure/rack,
 /obj/item/gun/energy/gun/small,
 /obj/item/gun/energy/gun/small,
-/obj/effect/landmark/delete_on_shuttle{
+/obj/abstract/landmark/delete_on_shuttle{
 	shuttle_name = "Desperado"
 	},
 /turf/simulated/floor/plating,
@@ -2090,7 +2090,7 @@
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
 "qa" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "Syndicate-Uplink"
 	},
 /obj/effect/overmap/visitable/merc_base{
@@ -2174,7 +2174,7 @@
 /area/map_template/merc_spawn)
 "uV" = (
 /obj/structure/table,
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "Nuclear-Code"
 	},
 /turf/simulated/floor/tiled,
@@ -2414,7 +2414,7 @@
 "IB" = (
 /obj/structure/rack,
 /obj/item/gun/energy/ionrifle,
-/obj/effect/landmark/delete_on_shuttle{
+/obj/abstract/landmark/delete_on_shuttle{
 	shuttle_name = "Desperado"
 	},
 /turf/simulated/floor/plating,
@@ -2521,7 +2521,7 @@
 /obj/item/assembly/signaler{
 	pixel_y = 2
 	},
-/obj/effect/landmark/delete_on_shuttle{
+/obj/abstract/landmark/delete_on_shuttle{
 	shuttle_name = "Desperado"
 	},
 /turf/simulated/floor/plating,
@@ -2652,7 +2652,7 @@
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
 "RT" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "Syndicate-Spawn"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -2690,7 +2690,7 @@
 /area/map_template/merc_spawn)
 "Ua" = (
 /obj/machinery/mech_recharger,
-/obj/effect/landmark/delete_on_shuttle{
+/obj/abstract/landmark/delete_on_shuttle{
 	shuttle_name = "Desperado"
 	},
 /mob/living/exosuit/premade/heavy/merc,
@@ -2715,7 +2715,7 @@
 /turf/simulated/floor/plating,
 /area/map_template/merc_spawn)
 "UT" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "Syndicate-Spawn"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{

--- a/maps/antag_spawn/ninja/ninja_base.dmm
+++ b/maps/antag_spawn/ninja/ninja_base.dmm
@@ -303,7 +303,7 @@
 /obj/effect/floor_decal/carpet/blue{
 	dir = 9
 	},
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "ninjastart"
 	},
 /turf/unsimulated/floor{
@@ -505,7 +505,7 @@
 /obj/effect/floor_decal/carpet/blue{
 	dir = 6
 	},
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "ninjastart"
 	},
 /turf/unsimulated/floor{
@@ -741,7 +741,7 @@
 	},
 /area/map_template/ninja_dojo/dojo)
 "bN" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "ninjastart"
 	},
 /turf/unsimulated/floor{
@@ -899,7 +899,7 @@
 	},
 /area/map_template/ninja_dojo/dojo)
 "cf" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "ninjastart"
 	},
 /obj/effect/floor_decal/carpet{

--- a/maps/antag_spawn/wizard/wizard_base.dmm
+++ b/maps/antag_spawn/wizard/wizard_base.dmm
@@ -98,7 +98,7 @@
 /area/map_template/wizard_station)
 "ar" = (
 /obj/structure/table/woodentable,
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "Teleport-Scroll"
 	},
 /obj/item/toy/figure/ninja,
@@ -155,7 +155,7 @@
 	},
 /area/map_template/wizard_station)
 "ay" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "wizard"
 	},
 /turf/simulated/floor/carpet,

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -65,7 +65,7 @@
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
 	},
-/obj/effect/landmark/deadcap,
+/obj/abstract/landmark/deadcap,
 /turf/simulated/floor/tiled/dark/usedup,
 /area/ship/scrap/command/bridge)
 "ak" = (
@@ -101,7 +101,7 @@
 /turf/simulated/floor/tiled/dark/usedup,
 /area/ship/scrap/command/bridge)
 "ap" = (
-/obj/effect/landmark/map_data{
+/obj/abstract/landmark/map_data{
 	height = 2
 	},
 /turf/space,

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -101,7 +101,7 @@
 /turf/simulated/floor/tiled/dark/usedup,
 /area/ship/scrap/command/bridge)
 "ap" = (
-/obj/abstract/landmark/map_data{
+/obj/abstract/map_data{
 	height = 2
 	},
 /turf/space,

--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -101,15 +101,15 @@
 /turf/simulated/floor/tiled/white/usedup
 	initial_gas = list(/decl/material/gas/carbon_dioxide = MOLES_O2STANDARD, /decl/material/gas/nitrogen = MOLES_N2STANDARD)
 
-/obj/effect/landmark/deadcap
+/obj/abstract/landmark/deadcap
 	name = "Dead Captain"
 
-/obj/effect/landmark/deadcap/Initialize()
+/obj/abstract/landmark/deadcap/Initialize()
 	..()
 	return INITIALIZE_HINT_LATELOAD
 
 // chair may need to init first
-/obj/effect/landmark/deadcap/LateInitialize()
+/obj/abstract/landmark/deadcap/LateInitialize()
 	..()
 	var/turf/T = get_turf(src)
 	var/mob/living/carbon/human/corpse = new(T)

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -234,7 +234,7 @@
 	desc = "A suit in a shape of a space carp. Usually worn by corporate interns who are sent to entertain children during HQ excursions."
 	icon = 'maps/away/errant_pisces/icons/carpsuit.dmi'
 
-/obj/effect/landmark/corpse/carp_fisher
+/obj/abstract/landmark/corpse/carp_fisher
 	name = "carp fisher"
 	corpse_outfits = list(/decl/hierarchy/outfit/corpse/carp_fisher)
 

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -841,7 +841,7 @@
 /turf/simulated/floor/plating,
 /area/errant_pisces/enginering)
 "cC" = (
-/obj/effect/landmark/corpse/engineer,
+/obj/abstract/landmark/corpse/engineer,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
 /area/errant_pisces/enginering)
@@ -1576,7 +1576,7 @@
 	alarm_id = "xenobio1_alarm";
 	pixel_y = 24
 	},
-/obj/effect/landmark/corpse/carp_fisher,
+/obj/abstract/landmark/corpse/carp_fisher,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/errant_pisces/head_f)
@@ -2018,7 +2018,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/landmark/corpse/engineer,
+/obj/abstract/landmark/corpse/engineer,
 /turf/simulated/floor/plating,
 /area/errant_pisces/bow_maint)
 "fk" = (
@@ -2867,7 +2867,7 @@
 /turf/simulated/floor/wood,
 /area/errant_pisces/rooms)
 "hs" = (
-/obj/effect/landmark/corpse/bridgeofficer,
+/obj/abstract/landmark/corpse/bridgeofficer,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/wood,
 /area/errant_pisces/rooms)
@@ -3118,7 +3118,7 @@
 /turf/simulated/floor/tiled,
 /area/errant_pisces/dorms)
 "im" = (
-/obj/effect/landmark/corpse/chef,
+/obj/abstract/landmark/corpse/chef,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/errant_pisces/dorms)
@@ -3170,7 +3170,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/landmark/corpse/carp_fisher,
+/obj/abstract/landmark/corpse/carp_fisher,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
 /area/errant_pisces/infirmary)
@@ -3325,7 +3325,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/landmark/corpse/doctor,
+/obj/abstract/landmark/corpse/doctor,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/errant_pisces/infirmary)
@@ -3513,7 +3513,7 @@
 /turf/simulated/floor/tiled,
 /area/errant_pisces/dorms)
 "jv" = (
-/obj/effect/landmark/corpse/carp_fisher,
+/obj/abstract/landmark/corpse/carp_fisher,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/freezer,
 /area/errant_pisces/dorms)
@@ -4090,7 +4090,7 @@
 /turf/simulated/floor/tiled,
 /area/errant_pisces/science_wing)
 "le" = (
-/obj/effect/landmark/corpse/scientist,
+/obj/abstract/landmark/corpse/scientist,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/errant_pisces/science_wing)
@@ -4636,7 +4636,7 @@
 /area/errant_pisces/science_wing)
 "mJ" = (
 /obj/machinery/light,
-/obj/effect/landmark/corpse/carp_fisher,
+/obj/abstract/landmark/corpse/carp_fisher,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/errant_pisces/cryo)
@@ -5234,7 +5234,7 @@
 /turf/simulated/floor/tiled,
 /area/errant_pisces/aft_hallway)
 "nR" = (
-/obj/effect/landmark/corpse/scientist,
+/obj/abstract/landmark/corpse/scientist,
 /turf/simulated/floor/tiled,
 /area/errant_pisces/aft_hallway)
 "nS" = (
@@ -5283,7 +5283,7 @@
 /turf/simulated/floor/tiled,
 /area/errant_pisces/aft_hallway)
 "oa" = (
-/obj/effect/landmark/corpse/bridgeofficer,
+/obj/abstract/landmark/corpse/bridgeofficer,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/errant_pisces/aft_hallway)
@@ -5517,7 +5517,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/landmark/corpse/bridgeofficer,
+/obj/abstract/landmark/corpse/bridgeofficer,
 /turf/simulated/floor/tiled,
 /area/errant_pisces/bridge)
 "oH" = (
@@ -5661,7 +5661,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/corpse/carp_fisher,
+/obj/abstract/landmark/corpse/carp_fisher,
 /turf/simulated/floor/tiled,
 /area/errant_pisces/fishing_wing)
 "pc" = (
@@ -6206,7 +6206,7 @@
 /turf/simulated/floor/plating,
 /area/errant_pisces/fishing_wing)
 "qL" = (
-/obj/effect/landmark/corpse/carp_fisher,
+/obj/abstract/landmark/corpse/carp_fisher,
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,

--- a/maps/away/lost_supply_base/lost_supply_base.dmm
+++ b/maps/away/lost_supply_base/lost_supply_base.dmm
@@ -421,7 +421,7 @@
 /area/lost_supply_base)
 "bc" = (
 /obj/random/projectile,
-/obj/effect/landmark/corpse/syndicate,
+/obj/abstract/landmark/corpse/syndicate,
 /turf/simulated/floor/airless,
 /area/lost_supply_base)
 "bd" = (
@@ -621,7 +621,7 @@
 /turf/simulated/floor/tiled/airless,
 /area/lost_supply_base/office)
 "bF" = (
-/obj/effect/landmark/corpse/engineer,
+/obj/abstract/landmark/corpse/engineer,
 /turf/simulated/floor/tiled/airless,
 /area/lost_supply_base/office)
 "bG" = (
@@ -1413,7 +1413,7 @@
 /area/lost_supply_base)
 "em" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/landmark/corpse/engineer,
+/obj/abstract/landmark/corpse/engineer,
 /turf/simulated/floor/airless,
 /area/lost_supply_base)
 "en" = (
@@ -1786,12 +1786,12 @@
 /area/lost_supply_base)
 "fC" = (
 /obj/random/energy,
-/obj/effect/landmark/corpse/syndicate,
+/obj/abstract/landmark/corpse/syndicate,
 /turf/simulated/floor/airless,
 /area/lost_supply_base)
 "fD" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/landmark/corpse/engineer,
+/obj/abstract/landmark/corpse/engineer,
 /turf/simulated/floor/airless,
 /area/lost_supply_base)
 "fE" = (
@@ -1931,7 +1931,7 @@
 /area/lost_supply_base/supply)
 "fX" = (
 /obj/item/gun/projectile/shotgun/pump,
-/obj/effect/landmark/corpse/syndicate,
+/obj/abstract/landmark/corpse/syndicate,
 /turf/simulated/floor/tiled/airless{
 	icon_state = "steel_broken4"
 	},

--- a/maps/away/slavers/slavers_base.dm
+++ b/maps/away/slavers/slavers_base.dm
@@ -62,7 +62,7 @@
 /decl/hierarchy/outfit/corpse/slavers_base
 	name = "Basic slaver output"
 
-/obj/effect/landmark/corpse/slavers_base/slaver1
+/obj/abstract/landmark/corpse/slavers_base/slaver1
 	name = "Slaver"
 	corpse_outfits = list(/decl/hierarchy/outfit/corpse/slavers_base/slaver1)
 
@@ -72,7 +72,7 @@
 	shoes = /obj/item/clothing/shoes/color/black
 	glasses = /obj/item/clothing/glasses/sunglasses
 
-/obj/effect/landmark/corpse/slavers_base/slaver2
+/obj/abstract/landmark/corpse/slavers_base/slaver2
 	name = "Slaver"
 	corpse_outfits = list(/decl/hierarchy/outfit/corpse/slavers_base/slaver2)
 
@@ -81,7 +81,7 @@
 	uniform = /obj/item/clothing/under/johnny
 	shoes = /obj/item/clothing/shoes/color/blue
 
-/obj/effect/landmark/corpse/slavers_base/slaver3
+/obj/abstract/landmark/corpse/slavers_base/slaver3
 	name = "Slaver"
 	corpse_outfits = list(/decl/hierarchy/outfit/corpse/slavers_base/slaver3)
 
@@ -90,7 +90,7 @@
 	uniform = /obj/item/clothing/under/pirate
 	shoes = /obj/item/clothing/shoes/color/brown
 
-/obj/effect/landmark/corpse/slavers_base/slaver4
+/obj/abstract/landmark/corpse/slavers_base/slaver4
 	name = "Slaver"
 	corpse_outfits = list(/decl/hierarchy/outfit/corpse/slavers_base/slaver4)
 
@@ -99,7 +99,7 @@
 	uniform = /obj/item/clothing/under/redcoat
 	shoes = /obj/item/clothing/shoes/color/brown
 
-/obj/effect/landmark/corpse/slavers_base/slaver5
+/obj/abstract/landmark/corpse/slavers_base/slaver5
 	name = "Slaver"
 	corpse_outfits = list(/decl/hierarchy/outfit/corpse/slavers_base/slaver5)
 
@@ -109,7 +109,7 @@
 	shoes = /obj/item/clothing/shoes/color/orange
 	mask = /obj/item/clothing/mask/surgical
 
-/obj/effect/landmark/corpse/slavers_base/slaver6
+/obj/abstract/landmark/corpse/slavers_base/slaver6
 	name = "Slaver"
 	corpse_outfits = list(/decl/hierarchy/outfit/corpse/slavers_base/slaver6)
 
@@ -118,7 +118,7 @@
 	uniform = /obj/item/clothing/under/frontier
 	shoes = /obj/item/clothing/shoes/color/orange
 
-/obj/effect/landmark/corpse/slavers_base/slave
+/obj/abstract/landmark/corpse/slavers_base/slave
 	name = "Slave"
 	corpse_outfits = list(/decl/hierarchy/outfit/corpse/slavers_base/slave)
 
@@ -140,7 +140,7 @@
 	natural_weapon = /obj/item/natural_weapon/punch
 	can_escape = TRUE
 	unsuitable_atmos_damage = 15
-	var/corpse = /obj/effect/landmark/corpse/abolitionist
+	var/corpse = /obj/abstract/landmark/corpse/abolitionist
 	var/weapon = /obj/item/gun/energy/laser
 	projectilesound = 'sound/weapons/laser.ogg'
 	ranged = 1
@@ -155,7 +155,7 @@
 		new weapon(loc)
 	qdel(src)
 
-/obj/effect/landmark/corpse/abolitionist
+/obj/abstract/landmark/corpse/abolitionist
 	name = "abolitionist"
 	corpse_outfits = list(/decl/hierarchy/outfit/corpse/abolitionist)
 

--- a/maps/away/slavers/slavers_base.dmm
+++ b/maps/away/slavers/slavers_base.dmm
@@ -61,7 +61,7 @@
 /area/slavers_base/mort)
 "ap" = (
 /obj/structure/table,
-/obj/effect/landmark/corpse/slavers_base/slave,
+/obj/abstract/landmark/corpse/slavers_base/slave,
 /turf/simulated/floor/airless/ceiling,
 /area/slavers_base/mort)
 "aq" = (
@@ -281,7 +281,7 @@
 "bd" = (
 /obj/structure/mattress/dirty,
 /obj/item/trash/liquidfood,
-/obj/effect/landmark/corpse/slavers_base/slave,
+/obj/abstract/landmark/corpse/slavers_base/slave,
 /turf/simulated/floor/airless/ceiling,
 /area/slavers_base/cells)
 "be" = (
@@ -435,7 +435,7 @@
 /area/slavers_base/cells)
 "bu" = (
 /obj/structure/mattress/dirty,
-/obj/effect/landmark/corpse/slavers_base/slave,
+/obj/abstract/landmark/corpse/slavers_base/slave,
 /turf/simulated/floor/airless/ceiling,
 /area/slavers_base/cells)
 "bv" = (
@@ -572,7 +572,7 @@
 "bP" = (
 /obj/machinery/light/small/red,
 /obj/structure/mattress/dirty,
-/obj/effect/landmark/corpse/slavers_base/slave,
+/obj/abstract/landmark/corpse/slavers_base/slave,
 /turf/simulated/floor/airless/ceiling,
 /area/slavers_base/cells)
 "bQ" = (
@@ -686,7 +686,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/landmark/corpse/slavers_base/slaver4,
+/obj/abstract/landmark/corpse/slavers_base/slaver4,
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
@@ -889,7 +889,7 @@
 /turf/simulated/floor/airless/ceiling,
 /area/slavers_base/hangar)
 "cv" = (
-/obj/effect/landmark/corpse/slavers_base/slave,
+/obj/abstract/landmark/corpse/slavers_base/slave,
 /turf/simulated/floor/airless/ceiling,
 /area/slavers_base/cells)
 "cw" = (
@@ -1017,7 +1017,7 @@
 /obj/structure/mattress/dirty,
 /obj/item/chems/glass/rag,
 /obj/item/chems/drinks/cans/waterbottle,
-/obj/effect/landmark/corpse/slavers_base/slave,
+/obj/abstract/landmark/corpse/slavers_base/slave,
 /turf/simulated/floor/airless/ceiling,
 /area/slavers_base/cells)
 "cP" = (
@@ -1501,7 +1501,7 @@
 /turf/simulated/floor/tiled,
 /area/slavers_base/secwing)
 "el" = (
-/obj/effect/landmark/corpse/slavers_base/slaver6,
+/obj/abstract/landmark/corpse/slavers_base/slaver6,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/slavers_base/secwing)
@@ -1561,7 +1561,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpse/slavers_base/slaver5,
+/obj/abstract/landmark/corpse/slavers_base/slaver5,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/airless,
 /area/slavers_base/med)
@@ -3595,7 +3595,7 @@
 /turf/simulated/floor/tiled/white/airless,
 /area/slavers_base/dorms)
 "jZ" = (
-/obj/effect/landmark/corpse/slavers_base/slaver3,
+/obj/abstract/landmark/corpse/slavers_base/slaver3,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/slavers_base/dorms)
@@ -3607,7 +3607,7 @@
 /turf/simulated/floor/tiled/white,
 /area/slavers_base/dorms)
 "kc" = (
-/obj/effect/landmark/corpse/slavers_base/slaver1,
+/obj/abstract/landmark/corpse/slavers_base/slaver1,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/slavers_base/dorms)
@@ -3871,7 +3871,7 @@
 /obj/item/storage/mirror{
 	pixel_y = -35
 	},
-/obj/effect/landmark/corpse/slavers_base/slaver2,
+/obj/abstract/landmark/corpse/slavers_base/slaver2,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/slavers_base/dorms)

--- a/maps/away/smugglers/smugglers.dmm
+++ b/maps/away/smugglers/smugglers.dmm
@@ -945,7 +945,7 @@
 /area/space)
 "db" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpse/doctor,
+/obj/abstract/landmark/corpse/doctor,
 /turf/simulated/floor/asteroid,
 /area/mine/explored)
 "eb" = (

--- a/maps/away/unishi/unishi-3.dmm
+++ b/maps/away/unishi/unishi-3.dmm
@@ -1875,7 +1875,7 @@
 /turf/simulated/floor/wood,
 /area/unishi/living)
 "fe" = (
-/obj/abstract/landmark/map_data{
+/obj/abstract/map_data{
 	height = 3
 	},
 /turf/space,

--- a/maps/away/unishi/unishi-3.dmm
+++ b/maps/away/unishi/unishi-3.dmm
@@ -1875,7 +1875,7 @@
 /turf/simulated/floor/wood,
 /area/unishi/living)
 "fe" = (
-/obj/effect/landmark/map_data{
+/obj/abstract/landmark/map_data{
 	height = 3
 	},
 /turf/space,

--- a/maps/away_sites_testing/blank.dmm
+++ b/maps/away_sites_testing/blank.dmm
@@ -9,7 +9,7 @@
 /turf/simulated/floor/tiled,
 /area/space)
 "e" = (
-/obj/effect/landmark/latejoin,
+/obj/abstract/landmark/latejoin,
 /turf/simulated/floor/tiled,
 /area/space)
 

--- a/maps/example/example-1.dmm
+++ b/maps/example/example-1.dmm
@@ -114,7 +114,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/constructionsite)
 "oy" = (
-/obj/level_data/main_level,
+/obj/abstract/level_data/main_level,
 /turf/space,
 /area/space)
 "oZ" = (
@@ -187,7 +187,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/constructionsite)
 "us" = (
-/obj/effect/landmark/latejoin,
+/obj/abstract/landmark/latejoin,
 /turf/simulated/floor/tiled/steel_grid,
 /area/constructionsite)
 "vd" = (
@@ -229,7 +229,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/constructionsite)
 "Bv" = (
-/obj/effect/landmark/start,
+/obj/abstract/landmark/start,
 /turf/simulated/floor/tiled/steel_grid,
 /area/constructionsite)
 "BV" = (

--- a/maps/example/example-2.dmm
+++ b/maps/example/example-2.dmm
@@ -403,7 +403,7 @@
 /turf/simulated/floor/tiled/white,
 /area/surgery)
 "LO" = (
-/obj/level_data/main_level,
+/obj/abstract/level_data/main_level,
 /turf/space,
 /area/space)
 "Ry" = (

--- a/maps/example/example-3.dmm
+++ b/maps/example/example-3.dmm
@@ -127,7 +127,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/maintenance/fsmaint2)
 "w" = (
-/obj/level_data/main_level,
+/obj/abstract/level_data/main_level,
 /turf/space,
 /area/space)
 "x" = (
@@ -285,7 +285,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/maintenance/fsmaint2)
 "V" = (
-/obj/effect/landmark/map_data{
+/obj/abstract/landmark/map_data{
 	height = 3
 	},
 /turf/space,

--- a/maps/example/example-3.dmm
+++ b/maps/example/example-3.dmm
@@ -285,7 +285,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/maintenance/fsmaint2)
 "V" = (
-/obj/abstract/landmark/map_data{
+/obj/abstract/map_data{
 	height = 3
 	},
 /turf/space,

--- a/maps/exodus/exodus-1.dmm
+++ b/maps/exodus/exodus-1.dmm
@@ -593,7 +593,7 @@
 /turf/simulated/floor/plating,
 /area/exodus/maintenance/sub/port)
 "bY" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "carpspawn"
 	},
 /turf/space,
@@ -3695,7 +3695,7 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Atmospheric Technician"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -5592,7 +5592,7 @@
 /turf/simulated/floor/bluegrid,
 /area/exodus/maintenance/telecomms)
 "xM" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
@@ -5677,7 +5677,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/exodus/maintenance/telecomms)
 "AE" = (
-/obj/level_data/main_level,
+/obj/abstract/level_data/main_level,
 /turf/space,
 /area/space)
 "AG" = (

--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -34,7 +34,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exodus/security/meeting)
 "aac" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "carpspawn"
 	},
 /turf/space,
@@ -79,7 +79,7 @@
 /turf/space,
 /area/space)
 "aag" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "carpspawn"
 	},
 /turf/simulated/floor/airless,
@@ -1775,7 +1775,7 @@
 /area/exodus/security/main)
 "adV" = (
 /obj/structure/bed/chair/office/dark,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Security Officer"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -1964,7 +1964,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Security Officer"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -2313,7 +2313,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Security Officer"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -3962,7 +3962,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Warden"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -4157,7 +4157,7 @@
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Head of Security"
 	},
 /obj/machinery/button/alternate/door{
@@ -5526,7 +5526,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Detective"
 	},
 /turf/simulated/floor/carpet,
@@ -6125,7 +6125,7 @@
 /area/exodus/security/prison)
 "amP" = (
 /obj/structure/bed/chair/office/dark,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Internal Affairs Agent"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -6718,7 +6718,7 @@
 "anU" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "Syndicate Breach Area"
 	},
 /turf/simulated/floor/plating,
@@ -6790,7 +6790,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Detective"
 	},
 /turf/simulated/floor/carpet,
@@ -7942,7 +7942,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Internal Affairs Agent"
 	},
 /obj/structure/disposalpipe/segment{
@@ -8672,7 +8672,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
@@ -9500,7 +9500,7 @@
 /area/exodus/hallway/secondary/entry/starboard)
 "atK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /turf/simulated/floor/tiled/freezer,
 /area/exodus/crew_quarters/sleep/cryo)
 "atL" = (
@@ -9525,7 +9525,7 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /turf/simulated/floor/tiled/freezer,
 /area/exodus/crew_quarters/sleep/cryo)
 "atN" = (
@@ -9849,7 +9849,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/exodus/crew_quarters/sleep)
 "auD" = (
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/freezer,
 /area/exodus/crew_quarters/sleep/cryo)
@@ -9860,7 +9860,7 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/exodus/crew_quarters/sleep/cryo)
 "auF" = (
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
@@ -10317,7 +10317,7 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/exodus/crew_quarters/sleep/cryo)
 "avF" = (
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
@@ -10419,7 +10419,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/landmark/paperwork_finish_exodus,
+/obj/abstract/landmark/paperwork_finish_exodus,
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/bridge)
 "avT" = (
@@ -13612,19 +13612,19 @@
 /obj/machinery/gateway{
 	dir = 10
 	},
-/obj/effect/landmark/latejoin/gateway,
+/obj/abstract/landmark/latejoin/gateway,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/exodus/gateway)
 "aCN" = (
 /obj/machinery/gateway{
 	dir = 6
 	},
-/obj/effect/landmark/latejoin/gateway,
+/obj/abstract/landmark/latejoin/gateway,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/exodus/gateway)
 "aCO" = (
 /obj/machinery/gateway,
-/obj/effect/landmark/latejoin/gateway,
+/obj/abstract/landmark/latejoin/gateway,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/exodus/gateway)
 "aCP" = (
@@ -13787,7 +13787,7 @@
 /turf/simulated/wall/prepainted,
 /area/exodus/maintenance/substation/civilian_east)
 "aDf" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
@@ -14158,7 +14158,7 @@
 /turf/simulated/floor/wood/walnut,
 /area/exodus/crew_quarters/bar/cabin)
 "aDW" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
@@ -14880,7 +14880,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/storage/primary)
 "aFn" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Assistant"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -14893,13 +14893,13 @@
 /area/exodus/security/prison/restroom)
 "aFr" = (
 /obj/item/stool,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Assistant"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/storage/primary)
 "aFs" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Assistant"
 	},
 /obj/structure/cable/green{
@@ -16385,7 +16385,7 @@
 /turf/simulated/floor/plating,
 /area/exodus/maintenance/library)
 "aIc" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Assistant"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -16446,14 +16446,14 @@
 /turf/simulated/floor/tiled/freezer,
 /area/exodus/security/prison/restroom)
 "aIi" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Assistant"
 	},
 /obj/item/stool,
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/storage/primary)
 "aIj" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Assistant"
 	},
 /obj/structure/cable/green{
@@ -16471,7 +16471,7 @@
 /obj/structure/bed/chair/shuttle/black{
 	dir = 8
 	},
-/obj/effect/landmark/latejoin,
+/obj/abstract/landmark/latejoin,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/shuttle/arrival/station)
@@ -16483,7 +16483,7 @@
 /turf/simulated/floor/plating,
 /area/exodus/maintenance/evahallway)
 "aIm" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Assistant"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -16566,7 +16566,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exodus/research/xenobiology)
 "aIv" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "Marauder Entry"
 	},
 /turf/space,
@@ -16594,7 +16594,7 @@
 /obj/structure/bed/chair/shuttle/black{
 	dir = 8
 	},
-/obj/effect/landmark/latejoin,
+/obj/abstract/landmark/latejoin,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/shuttle/arrival/station)
 "aIz" = (
@@ -16875,7 +16875,7 @@
 /turf/simulated/wall/prepainted,
 /area/exodus/hallway/primary/central_two)
 "aJm" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Chaplain"
 	},
 /obj/structure/bed/chair,
@@ -18173,7 +18173,7 @@
 /turf/simulated/floor/tiled/white,
 /area/exodus/research)
 "aMe" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "lightsout"
 	},
 /obj/machinery/door/firedoor,
@@ -18308,7 +18308,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Chef"
 	},
 /obj/effect/floor_decal/corner/brown/diagonal{
@@ -19970,7 +19970,7 @@
 /turf/simulated/floor/lino,
 /area/exodus/crew_quarters/bar)
 "aPJ" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Bartender"
 	},
 /obj/structure/cable/green{
@@ -20617,7 +20617,7 @@
 	pixel_x = -38;
 	pixel_y = 2
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Research Director"
 	},
 /obj/effect/floor_decal/corner/purple/diagonal{
@@ -22212,7 +22212,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/medical/sleeper)
 "aUN" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Gardener"
 	},
 /obj/item/stool/padded,
@@ -22517,7 +22517,7 @@
 /turf/simulated/floor/wood/walnut,
 /area/exodus/library)
 "aVy" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "lightsout"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -22884,7 +22884,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/hydroponics/garden)
 "aWq" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Gardener"
 	},
 /obj/structure/cable/green{
@@ -22948,7 +22948,7 @@
 /turf/simulated/floor/wood/walnut,
 /area/exodus/library)
 "aWz" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Librarian"
 	},
 /obj/structure/bed/chair/office/dark,
@@ -23039,7 +23039,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Chef"
 	},
 /turf/simulated/floor/tiled/white,
@@ -23244,7 +23244,7 @@
 	dir = 5
 	},
 /obj/structure/table/reinforced,
-/obj/effect/landmark/paperwork_spawn_exodus,
+/obj/abstract/landmark/paperwork_spawn_exodus,
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/bridge)
 "aXl" = (
@@ -23329,7 +23329,7 @@
 	dir = 5
 	},
 /obj/structure/table/reinforced,
-/obj/effect/landmark/paperwork_spawn_exodus,
+/obj/abstract/landmark/paperwork_spawn_exodus,
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/bridge)
 "aXu" = (
@@ -23496,7 +23496,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/quartermaster/storage)
 "aXN" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Gardener"
 	},
 /obj/item/stool/padded,
@@ -27877,7 +27877,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/starboard)
 "bhk" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "tripai"
 	},
 /obj/structure/cable/cyan{
@@ -28726,7 +28726,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exodus/maintenance/disposal)
 "biU" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
@@ -28788,7 +28788,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_one)
 "bjc" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "AI"
 	},
 /obj/machinery/newscaster{
@@ -28845,7 +28845,7 @@
 /turf/simulated/floor/plating,
 /area/exodus/hallway/secondary/exit)
 "bje" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "tripai"
 	},
 /obj/structure/cable/cyan{
@@ -29317,7 +29317,7 @@
 /turf/simulated/floor/wood/walnut,
 /area/exodus/crew_quarters/captain)
 "bjY" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "lightsout"
 	},
 /turf/simulated/wall/prepainted,
@@ -30109,7 +30109,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Cargo Technician"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -31260,7 +31260,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Chemist"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -31472,7 +31472,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Captain"
 	},
 /turf/simulated/floor/wood/walnut,
@@ -31617,7 +31617,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 1
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Roboticist"
 	},
 /turf/simulated/floor/tiled/white,
@@ -31694,7 +31694,7 @@
 /turf/simulated/floor/tiled/white,
 /area/exodus/medical/chemistry)
 "boS" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Scientist"
 	},
 /obj/effect/floor_decal/corner/purple{
@@ -33395,7 +33395,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/effect/landmark/latejoin/cyborg,
+/obj/abstract/landmark/latejoin/cyborg,
 /obj/machinery/computer/cryopod/robot{
 	pixel_x = -30
 	},
@@ -33976,7 +33976,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Medical Doctor"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -34124,7 +34124,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Medical Doctor"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -34405,7 +34405,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/exodus/research/lab)
 "but" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Scientist"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -35392,7 +35392,7 @@
 /turf/simulated/wall/prepainted,
 /area/exodus/medical/medbay2)
 "bwl" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Cargo Technician"
 	},
 /obj/structure/bed/chair/office/dark{
@@ -37634,7 +37634,7 @@
 /area/exodus/research/robotics)
 "bAN" = (
 /obj/item/stool/padded,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Roboticist"
 	},
 /turf/simulated/floor/tiled/white,
@@ -37860,7 +37860,7 @@
 /turf/simulated/floor/tiled/white,
 /area/exodus/crew_quarters/heads/hor)
 "bBh" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Assistant"
 	},
 /obj/structure/cable{
@@ -37878,7 +37878,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/storage/primary)
 "bBi" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Assistant"
 	},
 /obj/structure/cable{
@@ -38458,7 +38458,7 @@
 /turf/simulated/floor/tiled/white,
 /area/exodus/crew_quarters/heads/hor)
 "bCu" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Assistant"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -38659,7 +38659,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Head of Personnel"
 	},
 /obj/machinery/button/blast_door{
@@ -38713,7 +38713,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/exodus/turret_protected/ai_server_room)
 "bCW" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Cyborg"
 	},
 /obj/machinery/light/small{
@@ -38740,7 +38740,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/exodus/turret_protected/ai_server_room)
 "bCY" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Cyborg"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -41182,7 +41182,7 @@
 /area/exodus/research/misc_lab)
 "bHH" = (
 /obj/structure/bed/chair/office/dark,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Quartermaster"
 	},
 /obj/machinery/button/windowtint{
@@ -41725,7 +41725,7 @@
 /area/exodus/medical/genetics/cloning)
 "bIH" = (
 /obj/structure/bed/chair/office/dark,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Geneticist"
 	},
 /turf/simulated/floor/plating,
@@ -43299,7 +43299,7 @@
 /turf/simulated/floor/tiled/white,
 /area/exodus/research)
 "bLR" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Paramedic"
 	},
 /obj/item/stool/padded,
@@ -43441,7 +43441,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Shaft Miner"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -43660,7 +43660,7 @@
 	name = "Acute Separation Shutters";
 	pixel_y = -25
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Paramedic"
 	},
 /obj/machinery/camera/network/medbay{
@@ -44499,7 +44499,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exodus/medical/medbay2)
 "bOm" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Medical Doctor"
 	},
 /obj/structure/cable/green{
@@ -44513,7 +44513,7 @@
 /turf/simulated/floor/tiled/white,
 /area/exodus/crew_quarters/medbreak)
 "bOn" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Medical Doctor"
 	},
 /obj/structure/cable/green{
@@ -44608,7 +44608,7 @@
 /turf/simulated/floor/reinforced,
 /area/exodus/research/misc_lab)
 "bOz" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
@@ -45013,7 +45013,7 @@
 /area/exodus/medical/virology/access)
 "bPm" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Shaft Miner"
 	},
 /obj/structure/cable/green{
@@ -45054,7 +45054,7 @@
 /area/exodus/hallway/primary/aft)
 "bPr" = (
 /obj/item/stool,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Janitor"
 	},
 /obj/structure/cable/green{
@@ -45271,7 +45271,7 @@
 /turf/simulated/floor/tiled/white,
 /area/exodus/medical/medbay2)
 "bPM" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Medical Doctor"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -45311,7 +45311,7 @@
 /turf/simulated/floor/tiled/white,
 /area/exodus/crew_quarters/medbreak)
 "bPR" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Geneticist"
 	},
 /obj/item/stool/padded,
@@ -45887,7 +45887,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Chief Medical Officer"
 	},
 /obj/machinery/button/blast_door{
@@ -46117,7 +46117,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Scientist"
 	},
 /turf/simulated/floor/tiled/white,
@@ -46418,7 +46418,7 @@
 /turf/simulated/floor/plating,
 /area/exodus/storage/tech)
 "bRY" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
@@ -46593,7 +46593,7 @@
 /turf/simulated/floor/tiled/white,
 /area/exodus/crew_quarters/heads/cmo)
 "bSs" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Chemist"
 	},
 /obj/item/stool/padded,
@@ -46611,7 +46611,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Atmospheric Technician"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -46652,7 +46652,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Chemist"
 	},
 /obj/item/stool/padded,
@@ -48603,7 +48603,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exodus/research/mixing)
 "bWD" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
@@ -48630,7 +48630,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 1
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Scientist"
 	},
 /obj/structure/cable/green{
@@ -48986,7 +48986,7 @@
 /turf/simulated/floor/tiled/white,
 /area/exodus/medical/medbay4)
 "bXu" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Station Engineer"
 	},
 /obj/structure/bed/chair/comfy/brown,
@@ -49292,7 +49292,7 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/exodus/maintenance/substation/research)
 "bYa" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Scientist"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -49761,7 +49761,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/crew_quarters/heads/chief)
 "bYQ" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Station Engineer"
 	},
 /obj/structure/bed/chair/comfy/brown{
@@ -50115,7 +50115,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
@@ -50337,7 +50337,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 4
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Chief Engineer"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -50870,7 +50870,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/engineering/engine_smes)
 "cbk" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Atmospheric Technician"
 	},
 /obj/structure/bed/chair/comfy/brown{
@@ -52302,7 +52302,7 @@
 /turf/simulated/floor/plating,
 /area/exodus/maintenance/research_starboard)
 "cdY" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Station Engineer"
 	},
 /obj/structure/bed/chair/comfy/brown{
@@ -52311,7 +52311,7 @@
 /turf/simulated/floor/carpet,
 /area/exodus/engineering/break_room)
 "cdZ" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Atmospheric Technician"
 	},
 /obj/structure/bed/chair/comfy/brown{
@@ -53351,7 +53351,7 @@
 /area/exodus/engineering/foyer)
 "cgp" = (
 /obj/structure/bed/chair/comfy/brown,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Psychiatrist"
 	},
 /turf/simulated/floor/carpet/blue,
@@ -53437,7 +53437,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Xenobiologist"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -54010,7 +54010,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
@@ -54273,7 +54273,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Xenobiologist"
 	},
 /turf/simulated/floor/tiled/white,
@@ -54929,7 +54929,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Xenobiologist"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -54972,7 +54972,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Xenobiologist"
 	},
 /turf/simulated/floor/tiled/white,
@@ -57488,7 +57488,7 @@
 /turf/simulated/floor/plating,
 /area/exodus/engineering/storage)
 "cpf" = (
-/obj/effect/landmark/map_data/exodus,
+/obj/abstract/landmark/map_data/exodus,
 /turf/space,
 /area/space)
 "cpg" = (
@@ -57804,7 +57804,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Station Engineer"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -58147,7 +58147,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Station Engineer"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -58877,7 +58877,7 @@
 /turf/space,
 /area/space)
 "ctn" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "carpspawn"
 	},
 /obj/structure/lattice,
@@ -60142,7 +60142,7 @@
 /obj/structure/bed/chair/shuttle/black{
 	dir = 8
 	},
-/obj/effect/landmark/latejoin,
+/obj/abstract/landmark/latejoin,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -60452,7 +60452,7 @@
 /area/exodus/engineering/workshop)
 "cyz" = (
 /obj/structure/bed/chair,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Station Engineer"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -61279,7 +61279,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/landmark/latejoin/cyborg,
+/obj/abstract/landmark/latejoin/cyborg,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
 	},
@@ -61791,7 +61791,7 @@
 /turf/simulated/floor/tiled/white,
 /area/exodus/research)
 "cGc" = (
-/obj/effect/landmark/latejoin/cyborg,
+/obj/abstract/landmark/latejoin/cyborg,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
@@ -61849,7 +61849,7 @@
 /area/exodus/engineering/engine_monitoring)
 "cGn" = (
 /obj/structure/bed/chair/office/dark,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Station Engineer"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -63435,7 +63435,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/exodus_pod_mining)
 "doN" = (
-/obj/level_data/main_level,
+/obj/abstract/level_data/main_level,
 /turf/space,
 /area/space)
 "drB" = (
@@ -63578,7 +63578,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/landmark/latejoin,
+/obj/abstract/landmark/latejoin,
 /turf/simulated/floor/tiled/freezer,
 /area/shuttle/arrival/station)
 "eNu" = (
@@ -63754,7 +63754,7 @@
 /obj/structure/bed/chair/shuttle/black{
 	dir = 8
 	},
-/obj/effect/landmark/latejoin,
+/obj/abstract/landmark/latejoin,
 /obj/machinery/camera/network/exodus{
 	c_tag = "Arrivals - Main Shuttle";
 	dir = 8
@@ -63896,7 +63896,7 @@
 /area/ship/exodus_pod_mining)
 "igB" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "Observer-Start"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -63923,7 +63923,7 @@
 /obj/structure/bed/chair/shuttle/black{
 	dir = 8
 	},
-/obj/effect/landmark/latejoin,
+/obj/abstract/landmark/latejoin,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/shuttle/arrival/station)
 "itS" = (
@@ -63990,7 +63990,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/starboard)
 "jfD" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Shaft Miner"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -64269,7 +64269,7 @@
 /obj/effect/floor_decal/corner/white{
 	dir = 6
 	},
-/obj/effect/landmark/latejoin,
+/obj/abstract/landmark/latejoin,
 /turf/simulated/floor/tiled/freezer,
 /area/shuttle/arrival/station)
 "nPR" = (
@@ -65079,7 +65079,7 @@
 /obj/structure/bed/chair/shuttle/black{
 	dir = 8
 	},
-/obj/effect/landmark/latejoin,
+/obj/abstract/landmark/latejoin,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/shuttle/arrival/station)
 "xVT" = (

--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -57488,7 +57488,7 @@
 /turf/simulated/floor/plating,
 /area/exodus/engineering/storage)
 "cpf" = (
-/obj/abstract/landmark/map_data/exodus,
+/obj/abstract/map_data/exodus,
 /turf/space,
 /area/space)
 "cpg" = (

--- a/maps/exodus/exodus-admin.dmm
+++ b/maps/exodus/exodus-admin.dmm
@@ -2311,7 +2311,7 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "tdomeadmin"
 	},
 /turf/unsimulated/floor{
@@ -2653,7 +2653,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "tdomeadmin"
 	},
 /turf/unsimulated/floor{
@@ -2776,7 +2776,7 @@
 /area/tdome)
 "kfk" = (
 /obj/structure/bed/chair,
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "tdomeobserve"
 	},
 /turf/unsimulated/floor{
@@ -2900,7 +2900,7 @@
 "lQy" = (
 /obj/structure/bed/chair,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "tdomeobserve"
 	},
 /turf/unsimulated/floor{
@@ -3017,7 +3017,7 @@
 /turf/simulated/floor/tiled,
 /area/shuttle/escape_shuttle)
 "nKw" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "tdome2"
 	},
 /turf/unsimulated/floor{
@@ -3055,7 +3055,7 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "tdome2"
 	},
 /turf/unsimulated/floor{
@@ -3064,7 +3064,7 @@
 	},
 /area/tdome/tdome2)
 "oVC" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "tdome2"
 	},
 /obj/machinery/camera/network/television{
@@ -3102,7 +3102,7 @@
 	},
 /area/tdome/tdomeadmin)
 "pyW" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "tdome1"
 	},
 /obj/machinery/camera/network/television{
@@ -3204,7 +3204,7 @@
 	},
 /area/tdome/tdomeadmin)
 "sKA" = (
-/obj/level_data/admin_level,
+/obj/abstract/level_data/admin_level,
 /turf/space,
 /area/space)
 "sMD" = (
@@ -3261,7 +3261,7 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "tdome1"
 	},
 /turf/unsimulated/floor{
@@ -3374,7 +3374,7 @@
 	},
 /area/tdome)
 "xog" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "tdome1"
 	},
 /turf/unsimulated/floor{

--- a/maps/exodus/exodus-transit.dmm
+++ b/maps/exodus/exodus-transit.dmm
@@ -42,7 +42,7 @@
 /turf/space,
 /area/space)
 "QP" = (
-/obj/level_data/admin_level,
+/obj/abstract/level_data/admin_level,
 /turf/space,
 /area/space)
 

--- a/maps/exodus/exodus_unit_testing.dm
+++ b/maps/exodus/exodus_unit_testing.dm
@@ -51,5 +51,5 @@
 		/area/exodus/engineering/atmos = 4,
 		/area/exodus/maintenance/incinerator = 2)
 
-/obj/effect/landmark/map_data/exodus
+/obj/abstract/landmark/map_data/exodus
 	height = 2

--- a/maps/exodus/exodus_unit_testing.dm
+++ b/maps/exodus/exodus_unit_testing.dm
@@ -51,5 +51,5 @@
 		/area/exodus/engineering/atmos = 4,
 		/area/exodus/maintenance/incinerator = 2)
 
-/obj/abstract/landmark/map_data/exodus
+/obj/abstract/map_data/exodus
 	height = 2

--- a/maps/exodus/jobs/_goals.dm
+++ b/maps/exodus/jobs/_goals.dm
@@ -4,20 +4,20 @@
 var/global/list/exodus_paperwork_spawn_turfs = list()
 var/global/list/exodus_paperwork_end_areas = list()
 
-/obj/effect/landmark/paperwork_spawn_exodus
+/obj/abstract/landmark/paperwork_spawn_exodus
 	name = "Exodus Paperwork Goal Spawn Point"
 
-/obj/effect/landmark/paperwork_spawn_exodus/Initialize()
+/obj/abstract/landmark/paperwork_spawn_exodus/Initialize()
 	..()
 	var/turf/T = get_turf(src)
 	if(istype(T))
 		global.exodus_paperwork_spawn_turfs |= T
 	return INITIALIZE_HINT_QDEL
 
-/obj/effect/landmark/paperwork_finish_exodus
+/obj/abstract/landmark/paperwork_finish_exodus
 	name = "Exodus Paperwork Goal Finish Point"
 
-/obj/effect/landmark/paperwork_finish_exodus/Initialize()
+/obj/abstract/landmark/paperwork_finish_exodus/Initialize()
 	..()
 	var/turf/T = get_turf(src)
 	if(istype(T))

--- a/maps/ministation/ministation.dmm
+++ b/maps/ministation/ministation.dmm
@@ -3,7 +3,7 @@
 /turf/space,
 /area/space)
 "ab" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "carpspawn"
 	},
 /turf/space,
@@ -545,7 +545,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/bridge/vault)
 "bz" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Captain"
 	},
 /obj/structure/cable{
@@ -658,7 +658,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "bluespace_a"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1605,7 +1605,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/cargo)
 "eF" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Cargo Technician"
 	},
 /turf/simulated/floor/tiled,
@@ -1958,7 +1958,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "lightsout"
 	},
 /obj/structure/cable{
@@ -2209,7 +2209,7 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "gg" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Scientist"
 	},
 /obj/item/stool/padded,
@@ -2269,7 +2269,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/cargo)
 "gs" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Cargo Technician"
 	},
 /obj/structure/bed/chair,
@@ -2433,7 +2433,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/cargo)
 "gM" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "bluespace_a"
 	},
 /turf/simulated/floor/tiled,
@@ -2954,7 +2954,7 @@
 /turf/simulated/floor/wood,
 /area/ministation/detective)
 "ic" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Detective"
 	},
 /obj/structure/bed/chair/office/comfy/brown{
@@ -3088,7 +3088,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/security)
 "ix" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Security Officer"
 	},
 /obj/structure/bed/chair,
@@ -3167,7 +3167,7 @@
 /obj/machinery/cryopod{
 	dir = 1
 	},
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /obj/machinery/camera/network/medbay{
 	dir = 1
 	},
@@ -3222,7 +3222,7 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "iQ" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Scientist"
 	},
 /obj/structure/bed/chair/office/light,
@@ -3485,7 +3485,7 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "jw" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "blobstart"
 	},
 /turf/simulated/floor/tiled/white,
@@ -3720,7 +3720,7 @@
 /turf/simulated/floor/holofloor/lino,
 /area/ministation/commons)
 "kd" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Assistant"
 	},
 /turf/simulated/floor/tiled,
@@ -3940,7 +3940,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/commons)
 "kI" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Assistant"
 	},
 /obj/machinery/firealarm{
@@ -3956,7 +3956,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/commons)
 "kJ" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "bluespace_a"
 	},
 /obj/structure/table/gamblingtable,
@@ -3996,7 +3996,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n)
 "kN" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "lightsout"
 	},
 /turf/simulated/floor/tiled,
@@ -4068,7 +4068,7 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "kV" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "bluespace_a"
 	},
 /obj/structure/cable{
@@ -4078,7 +4078,7 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "kW" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Scientist"
 	},
 /turf/simulated/floor/tiled/white,
@@ -5075,7 +5075,7 @@
 /turf/simulated/floor/plating,
 /area/ministation/maint/e)
 "nX" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "blobstart"
 	},
 /turf/simulated/floor/plating,
@@ -5851,7 +5851,7 @@
 /turf/simulated/floor/plating,
 /area/ministation/medical)
 "pV" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Clown"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -5900,7 +5900,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/janitor)
 "qb" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Janitor"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6299,7 +6299,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hall/w)
 "rd" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Medical Doctor"
 	},
 /obj/effect/floor_decal/corner/paleblue{
@@ -6315,7 +6315,7 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "re" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Medical Doctor"
 	},
 /turf/simulated/floor/tiled/white,
@@ -7175,7 +7175,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hall/w)
 "tn" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "lightsout"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7224,7 +7224,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s)
 "tv" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "bluespace_a"
 	},
 /turf/simulated/floor/tiled,
@@ -7275,7 +7275,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hall/e)
 "tE" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "lightsout"
 	},
 /obj/structure/cable{
@@ -7333,7 +7333,7 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "tL" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Medical Doctor"
 	},
 /obj/structure/bed/chair/office/light{
@@ -7348,7 +7348,7 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "tM" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "bluespace_a"
 	},
 /obj/structure/cable{
@@ -7475,7 +7475,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "bluespace_a"
 	},
 /obj/effect/floor_decal/ss13/l10,
@@ -8164,7 +8164,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hop)
 "vW" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Lieutenant"
 	},
 /obj/item/stool/padded,
@@ -8328,7 +8328,7 @@
 /area/ministation/medical)
 "wx" = (
 /obj/structure/bed/chair/office/light,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Medical Doctor"
 	},
 /turf/simulated/floor/tiled/white,
@@ -8678,7 +8678,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/cafe)
 "xq" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "bluespace_a"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -9364,7 +9364,7 @@
 /turf/simulated/floor/plating,
 /area/ministation/maint/sw)
 "zd" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Robot"
 	},
 /turf/simulated/floor/tiled/white,
@@ -9432,7 +9432,7 @@
 /obj/structure/bed/chair/shuttle/white{
 	dir = 8
 	},
-/obj/effect/landmark/latejoin,
+/obj/abstract/landmark/latejoin,
 /turf/simulated/floor/shuttle/blue,
 /area/ministation/arrival_shuttle)
 "zp" = (
@@ -9618,7 +9618,7 @@
 /turf/simulated/floor/shuttle/blue,
 /area/ministation/arrival_shuttle)
 "zS" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "Observer-Start"
 	},
 /turf/simulated/floor/shuttle/blue,
@@ -9715,7 +9715,7 @@
 /turf/simulated/floor/wood,
 /area/ministation/cafe)
 "Af" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Bartender"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9728,7 +9728,7 @@
 /turf/simulated/floor/wood,
 /area/ministation/cafe)
 "Ag" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Bartender"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9902,7 +9902,7 @@
 /turf/simulated/floor/plating,
 /area/ministation/maint/sw)
 "AF" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "blobstart"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -10342,7 +10342,7 @@
 /turf/simulated/floor/plating,
 /area/ministation/maint/w)
 "BW" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "bluespace_a"
 	},
 /turf/simulated/wall,
@@ -10659,7 +10659,7 @@
 /turf/simulated/floor/plating,
 /area/ministation/maint/se)
 "CP" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Assistant"
 	},
 /obj/item/stool/padded,
@@ -11254,7 +11254,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s)
 "Ef" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "lightsout"
 	},
 /obj/structure/cable{
@@ -11393,7 +11393,7 @@
 /area/ministation/engine)
 "EE" = (
 /obj/item/stool/padded,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Security Officer"
 	},
 /turf/simulated/floor/tiled,
@@ -11425,7 +11425,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/engine)
 "EL" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Station Engineer"
 	},
 /obj/item/stool/padded,
@@ -11618,7 +11618,7 @@
 /turf/simulated/wall/r_wall,
 /area/ministation/engine)
 "Fl" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Assistant"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11742,7 +11742,7 @@
 /turf/simulated/wall,
 /area/ministation/engine)
 "FD" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Station Engineer"
 	},
 /turf/simulated/floor/tiled,
@@ -11834,7 +11834,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/engine)
 "FR" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "bluespace_a"
 	},
 /obj/structure/cable{
@@ -12268,7 +12268,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Robot"
 	},
 /turf/simulated/floor/plating,
@@ -13300,7 +13300,7 @@
 	pixel_x = 27;
 	pixel_y = 5
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "AI"
 	},
 /obj/machinery/network/requests_console{
@@ -13787,7 +13787,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/ai_sat)
 "Lw" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
@@ -14110,7 +14110,7 @@
 /obj/machinery/cryopod{
 	dir = 1
 	},
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /turf/simulated/floor/tiled/dark,
 /area/ministation/cryo)
 "Mx" = (
@@ -14149,7 +14149,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/security)
 "MI" = (
-/obj/effect/landmark/latejoin/cyborg,
+/obj/abstract/landmark/latejoin/cyborg,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "MJ" = (
@@ -14353,7 +14353,7 @@
 /turf/simulated/floor/plating,
 /area/ministation/maint/sw)
 "NO" = (
-/obj/level_data/main_level,
+/obj/abstract/level_data/main_level,
 /turf/space,
 /area/space)
 "NR" = (
@@ -14494,7 +14494,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Librarian"
 	},
 /turf/simulated/floor/wood/mahogany,
@@ -14949,7 +14949,7 @@
 	dir = 1;
 	pixel_y = -32
 	},
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /turf/simulated/floor/tiled/dark,
 /area/ministation/cryo)
 "Rd" = (
@@ -15672,7 +15672,7 @@
 /obj/machinery/light_switch{
 	pixel_y = 25
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Librarian"
 	},
 /turf/simulated/floor/wood/mahogany,
@@ -15797,7 +15797,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hall/w)
 "VR" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Assistant"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -16004,7 +16004,7 @@
 /turf/simulated/floor/plating,
 /area/ministation/maint/se)
 "WW" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Robot"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -16067,7 +16067,7 @@
 /turf/simulated/wall/r_wall,
 /area/ministation/cryo)
 "Xr" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "bluespace_a"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -16483,7 +16483,7 @@
 /turf/simulated/floor/plating,
 /area/ministation/maint/se)
 "ZE" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Assistant"
 	},
 /obj/machinery/light{
@@ -16535,7 +16535,7 @@
 /turf/simulated/floor/plating,
 /area/ministation/court)
 "ZQ" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Assistant"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{

--- a/maps/modpack_testing/blank.dmm
+++ b/maps/modpack_testing/blank.dmm
@@ -9,7 +9,7 @@
 /turf/simulated/floor/tiled,
 /area/space)
 "e" = (
-/obj/effect/landmark/latejoin,
+/obj/abstract/landmark/latejoin,
 /turf/simulated/floor/tiled,
 /area/space)
 

--- a/maps/nexus/nexus-1.dmm
+++ b/maps/nexus/nexus-1.dmm
@@ -305,7 +305,7 @@
 /obj/machinery/alarm{
 	dir = 1
 	},
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /turf/simulated/floor/tiled/white,
 /area/nexus/civilian)
 "cQ" = (
@@ -357,7 +357,7 @@
 /obj/machinery/power/apc{
 	dir = 1
 	},
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /turf/simulated/floor/tiled/white,
 /area/nexus/civilian)
 "de" = (
@@ -1903,7 +1903,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /turf/simulated/floor/tiled/white,
 /area/nexus/civilian)
 "rP" = (
@@ -2555,7 +2555,7 @@
 /turf/simulated/floor/plating,
 /area/nexus/command)
 "xX" = (
-/obj/level_data/main_level,
+/obj/abstract/level_data/main_level,
 /turf/space,
 /area/space)
 "yf" = (
@@ -3685,7 +3685,7 @@
 /obj/structure/sign/warning/secure_area{
 	pixel_y = -24
 	},
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /turf/simulated/floor/tiled/white,
 /area/nexus/civilian)
 "IQ" = (
@@ -4000,7 +4000,7 @@
 /obj/structure/sign/warning/secure_area{
 	pixel_y = -24
 	},
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /turf/simulated/floor/tiled/white,
 /area/nexus/civilian)
 "MD" = (
@@ -5353,7 +5353,7 @@
 /obj/machinery/computer/cryopod{
 	pixel_y = -32
 	},
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /turf/simulated/floor/tiled/white,
 /area/nexus/civilian)
 "Ys" = (
@@ -5420,7 +5420,7 @@
 /obj/effect/floor_decal/corner/b_green{
 	dir = 1
 	},
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /turf/simulated/floor/tiled/white,
 /area/nexus/civilian)
 "YG" = (
@@ -5453,7 +5453,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /turf/simulated/floor/tiled/white,
 /area/nexus/civilian)
 "Zy" = (

--- a/maps/nexus/nexus-2.dmm
+++ b/maps/nexus/nexus-2.dmm
@@ -204,7 +204,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/nexus/civilian/hygiene)
 "lo" = (
-/obj/abstract/landmark/map_data{
+/obj/abstract/map_data{
 	height = 2
 	},
 /turf/simulated/floor/reinforced/airless,

--- a/maps/nexus/nexus-2.dmm
+++ b/maps/nexus/nexus-2.dmm
@@ -204,7 +204,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/nexus/civilian/hygiene)
 "lo" = (
-/obj/effect/landmark/map_data{
+/obj/abstract/landmark/map_data{
 	height = 2
 	},
 /turf/simulated/floor/reinforced/airless,
@@ -607,7 +607,7 @@
 /turf/simulated/floor/carpet/blue3,
 /area/nexus/civilian/bar)
 "Db" = (
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "Observer-Start"
 	},
 /turf/simulated/floor/glass,
@@ -907,7 +907,7 @@
 /turf/simulated/floor/carpet/blue3,
 /area/nexus/civilian/bar)
 "Oa" = (
-/obj/level_data/main_level,
+/obj/abstract/level_data/main_level,
 /turf/space,
 /area/space)
 "Ok" = (

--- a/maps/random_ruins/exoplanet_ruins/datacapsule/contents_3.dmm
+++ b/maps/random_ruins/exoplanet_ruins/datacapsule/contents_3.dmm
@@ -34,7 +34,7 @@
 /turf/template_noop,
 /area/template_noop)
 "i" = (
-/obj/effect/landmark/corpse/zombiescience,
+/obj/abstract/landmark/corpse/zombiescience,
 /obj/structure/foamedmetal,
 /turf/template_noop,
 /area/template_noop)

--- a/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
+++ b/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
@@ -15,7 +15,7 @@
 	name = "\improper Ejected Data Capsule"
 	icon_state = "blue"
 
-/obj/effect/landmark/corpse/zombiescience
+/obj/abstract/landmark/corpse/zombiescience
 	name = "Dead Scientist"
 	corpse_outfits = list(/decl/hierarchy/outfit/zombie_science)
 
@@ -62,7 +62,7 @@
 		return TRUE
 	. = ..()
 		
-/obj/effect/landmark/map_load_mark/ejected_datapod
+/obj/abstract/landmark/map_load_mark/ejected_datapod
 	name = "random datapod contents"
 	templates = list(/datum/map_template/ejected_datapod_contents, /datum/map_template/ejected_datapod_contents/type2, /datum/map_template/ejected_datapod_contents/type3)
 

--- a/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dmm
+++ b/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dmm
@@ -7,7 +7,7 @@
 /turf/simulated/wall/ocp_wall,
 /area/map_template/datacapsule)
 "c" = (
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/template_noop)
 "d" = (
@@ -21,7 +21,7 @@
 /turf/simulated/floor/reinforced/airless,
 /area/map_template/datacapsule)
 "g" = (
-/obj/effect/landmark/map_load_mark/ejected_datapod,
+/obj/abstract/landmark/map_load_mark/ejected_datapod,
 /turf/simulated/floor/reinforced/airless,
 /area/map_template/datacapsule)
 

--- a/maps/random_ruins/exoplanet_ruins/deserted_lab/deserted_lab.dmm
+++ b/maps/random_ruins/exoplanet_ruins/deserted_lab/deserted_lab.dmm
@@ -23,7 +23,7 @@
 /area/template_noop)
 "af" = (
 /obj/structure/anomaly_container,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "ag" = (
@@ -40,7 +40,7 @@
 /area/template_noop)
 "ai" = (
 /obj/machinery/floodlight,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "aj" = (
@@ -70,7 +70,7 @@
 /area/template_noop)
 "ap" = (
 /obj/structure/closet/crate,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "aq" = (
@@ -79,12 +79,12 @@
 /area/template_noop)
 "ar" = (
 /obj/structure/closet/crate/trashcart,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "as" = (
 /obj/structure/closet/crate/freezer/rations,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "at" = (
@@ -235,7 +235,7 @@
 /area/template_noop)
 "aV" = (
 /obj/item/harpoon,
-/obj/effect/landmark/corpse/scientist,
+/obj/abstract/landmark/corpse/scientist,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/template_noop)
@@ -301,7 +301,7 @@
 /turf/simulated/floor/tiled/white,
 /area/template_noop)
 "za" = (
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 

--- a/maps/random_ruins/exoplanet_ruins/drill_site/drill_site.dmm
+++ b/maps/random_ruins/exoplanet_ruins/drill_site/drill_site.dmm
@@ -4,84 +4,84 @@
 /area/template_noop)
 "b" = (
 /obj/random/trash,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "d" = (
 /obj/random/loot,
 /obj/random/junk,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "e" = (
 /obj/machinery/floodlight,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "f" = (
 /obj/machinery/mining/brace,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "g" = (
 /obj/structure/ore_box,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "h" = (
 /obj/random/tool,
-/obj/effect/landmark/clear,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "j" = (
 /obj/random/tool,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "k" = (
 /obj/machinery/mining/drill,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "l" = (
 /obj/structure/pit,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "n" = (
 /obj/random/drinkbottle,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "s" = (
 /obj/random/loot,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "u" = (
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "y" = (
 /obj/random/hat,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "C" = (
 /obj/random/trash,
-/obj/effect/landmark/clear,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "H" = (
 /obj/random/powercell,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "O" = (
 /obj/random/toolbox,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 

--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
@@ -2690,7 +2690,7 @@
 	pixel_y = 24;
 	req_access = newlist()
 	},
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "NL" = (
@@ -2698,7 +2698,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/hydrobase/station/goatzone)
 "RI" = (
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 

--- a/maps/random_ruins/exoplanet_ruins/marooned/marooned.dm
+++ b/maps/random_ruins/exoplanet_ruins/marooned/marooned.dm
@@ -20,7 +20,7 @@
 	desc = "An silver round medal of marooned officer. It has inscription \"For Distinguished Service\" in lower part. On medal's plank it's engraved \"H. Warda\"" 
 	icon = 'maps/random_ruins/exoplanet_ruins/marooned/icons/medal_magnitka.dmi' 
  
-/obj/effect/landmark/corpse/marooned_officer 
+/obj/abstract/landmark/corpse/marooned_officer 
 	name = "Horazy Warda" 
 	corpse_outfits = list(/decl/hierarchy/outfit/marooned_officer) 
 	spawn_flags = ~CORPSE_SPAWNER_RANDOM_NAME 

--- a/maps/random_ruins/exoplanet_ruins/marooned/marooned.dmm
+++ b/maps/random_ruins/exoplanet_ruins/marooned/marooned.dmm
@@ -18,7 +18,7 @@
 "af" = (
 /obj/structure/lattice,
 /obj/item/stack/material/reinforced/mapped/ocp,
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/template_noop)
 "ag" = (
@@ -29,12 +29,12 @@
 /turf/simulated/wall/ocp_wall,
 /area/map_template/marooned)
 "ai" = (
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/template_noop)
 "aj" = (
 /obj/item/stack/material/reinforced/mapped/ocp,
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/template_noop)
 "ak" = (
@@ -50,7 +50,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/marooned)
 "am" = (
-/obj/effect/landmark/corpse/marooned_officer,
+/obj/abstract/landmark/corpse/marooned_officer,
 /obj/structure/bed/chair{
 	dir = 1
 	},
@@ -72,7 +72,7 @@
 /area/map_template/marooned)
 "ao" = (
 /obj/structure/lattice,
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/template_noop)
 "ap" = (
@@ -175,8 +175,8 @@
 /area/map_template/marooned)
 "aC" = (
 /obj/structure/shuttle/engine/propulsion,
-/obj/effect/landmark/scorcher,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/scorcher,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "aD" = (
@@ -272,20 +272,20 @@
 /obj/structure/cable{
 	icon_state = "2-5"
 	},
-/obj/effect/landmark/scorcher,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/scorcher,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "aR" = (
 /obj/structure/inflatable/door,
-/obj/effect/landmark/scorcher,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/scorcher,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "aS" = (
 /obj/structure/inflatable/wall,
-/obj/effect/landmark/scorcher,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/scorcher,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "aT" = (
@@ -293,8 +293,8 @@
 	dir = 1;
 	icon_state = "2-5"
 	},
-/obj/effect/landmark/scorcher,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/scorcher,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "aU" = (
@@ -323,16 +323,16 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/landmark/scorcher,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/scorcher,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "aX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/scorcher,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/scorcher,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "aY" = (
@@ -345,25 +345,25 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/landmark/scorcher,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/scorcher,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "hi" = (
-/obj/effect/landmark/scorcher,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/scorcher,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "tb" = (
-/obj/effect/landmark/clear,
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/clear,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/template_noop)
 "Wb" = (
 /obj/structure/shuttle/engine/propulsion,
-/obj/effect/landmark/scorcher,
-/obj/effect/landmark/clear,
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
+/obj/abstract/landmark/clear,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/template_noop)
 

--- a/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dmm
+++ b/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dmm
@@ -4,7 +4,7 @@
 /area/template_noop)
 "b" = (
 /obj/structure/monolith,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "c" = (
@@ -25,7 +25,7 @@
 /turf/simulated/floor/fixed/alium/ruin,
 /area/template_noop)
 "e" = (
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 

--- a/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
@@ -66,7 +66,7 @@
 /area/map_template/oldpod)
 "ak" = (
 /obj/structure/bed,
-/obj/effect/landmark/corpse/doctor,
+/obj/abstract/landmark/corpse/doctor,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/monotile,
@@ -265,7 +265,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aJ" = (
-/obj/effect/landmark/corpse/pirate,
+/obj/abstract/landmark/corpse/pirate,
 /obj/item/gun/energy/captain,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -286,7 +286,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aM" = (
-/obj/effect/landmark/corpse/scientist,
+/obj/abstract/landmark/corpse/scientist,
 /obj/item/baton/cattleprod,
 /obj/item/shard,
 /obj/effect/decal/cleanable/blood,
@@ -458,7 +458,7 @@
 /turf/simulated/floor/plating,
 /area/map_template/oldpod)
 "bd" = (
-/obj/effect/landmark/corpse/bridgeofficer,
+/obj/abstract/landmark/corpse/bridgeofficer,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/monotile,
 /area/map_template/oldpod)

--- a/maps/random_ruins/exoplanet_ruins/spider_nest/spider_nest.dmm
+++ b/maps/random_ruins/exoplanet_ruins/spider_nest/spider_nest.dmm
@@ -79,7 +79,7 @@
 /turf/simulated/floor/lino,
 /area/template_noop)
 "p" = (
-/obj/effect/landmark/corpse/doctor,
+/obj/abstract/landmark/corpse/doctor,
 /obj/effect/decal/cleanable/blood,
 /obj/item/shard,
 /obj/effect/decal/cleanable/blood/drip,

--- a/maps/random_ruins/exoplanet_ruins/tar_anomaly/tar_anomaly.dmm
+++ b/maps/random_ruins/exoplanet_ruins/tar_anomaly/tar_anomaly.dmm
@@ -11,7 +11,7 @@
 /area/template_noop)
 "d" = (
 /obj/structure/artifact,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/exterior/shrouded,
 /area/template_noop)
 "e" = (

--- a/maps/random_ruins/space_ruins/multi_zas_test.dmm
+++ b/maps/random_ruins/space_ruins/multi_zas_test.dmm
@@ -16,7 +16,7 @@
 /turf/unsimulated/floor/shuttle_ceiling,
 /area/template_noop)
 "f" = (
-/obj/abstract/landmark/map_data{
+/obj/abstract/map_data{
 	height = 3
 	},
 /turf/unsimulated/floor/shuttle_ceiling,

--- a/maps/random_ruins/space_ruins/multi_zas_test.dmm
+++ b/maps/random_ruins/space_ruins/multi_zas_test.dmm
@@ -16,7 +16,7 @@
 /turf/unsimulated/floor/shuttle_ceiling,
 /area/template_noop)
 "f" = (
-/obj/effect/landmark/map_data{
+/obj/abstract/landmark/map_data{
 	height = 3
 	},
 /turf/unsimulated/floor/shuttle_ceiling,

--- a/maps/tradeship/jobs/_goals.dm
+++ b/maps/tradeship/jobs/_goals.dm
@@ -1,20 +1,20 @@
 var/global/list/tradeship_paperwork_spawn_turfs = list()
 var/global/list/tradeship_paperwork_end_areas = list()
 
-/obj/effect/landmark/paperwork_spawn_tradeship
+/obj/abstract/landmark/paperwork_spawn_tradeship
 	name = "Tradeship Paperwork Goal Spawn Point"
 
-/obj/effect/landmark/paperwork_spawn_tradeship/Initialize()
+/obj/abstract/landmark/paperwork_spawn_tradeship/Initialize()
 	..()
 	var/turf/T = get_turf(src)
 	if(istype(T))
 		global.tradeship_paperwork_spawn_turfs |= T
 	return INITIALIZE_HINT_QDEL
 
-/obj/effect/landmark/paperwork_finish_tradeship
+/obj/abstract/landmark/paperwork_finish_tradeship
 	name = "Tradeship Paperwork Goal Finish Point"
 
-/obj/effect/landmark/paperwork_finish_tradeship/Initialize()
+/obj/abstract/landmark/paperwork_finish_tradeship/Initialize()
 	..()
 	var/turf/T = get_turf(src)
 	if(istype(T))

--- a/maps/tradeship/tradeship-0.dmm
+++ b/maps/tradeship/tradeship-0.dmm
@@ -1596,7 +1596,7 @@
 /turf/simulated/floor,
 /area/ship/trade/fore_port_underside_maint)
 "Dt" = (
-/obj/level_data/main_level,
+/obj/abstract/level_data/main_level,
 /turf/space,
 /area/space)
 "Dz" = (

--- a/maps/tradeship/tradeship-1.dmm
+++ b/maps/tradeship/tradeship-1.dmm
@@ -211,7 +211,7 @@
 /obj/machinery/computer/cryopod{
 	pixel_y = -32
 	},
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -228,7 +228,7 @@
 /obj/effect/floor_decal/industrial/loading{
 	dir = 1
 	},
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -276,7 +276,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/landmark/latejoin/cryo_two,
+/obj/abstract/landmark/latejoin/cryo_two,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/trade/escape_star)
 "aM" = (
@@ -292,7 +292,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/latejoin/cryo_two,
+/obj/abstract/landmark/latejoin/cryo_two,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/trade/escape_star)
 "aO" = (
@@ -700,7 +700,7 @@
 /obj/structure/curtain/open/bed,
 /obj/structure/bed/padded,
 /obj/item/bedsheet/brown,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Head Doctor"
 	},
 /turf/simulated/floor/lino,
@@ -771,7 +771,7 @@
 	dir = 1;
 	pixel_y = -30
 	},
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -874,7 +874,7 @@
 	dir = 5
 	},
 /obj/item/bedsheet/ce,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Cook"
 	},
 /turf/simulated/floor/lino,
@@ -1019,7 +1019,7 @@
 	},
 /obj/item/bedsheet/red,
 /obj/random_multi/single_item/captains_spare_id,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Head Engineer"
 	},
 /turf/simulated/floor/lino,
@@ -1206,7 +1206,7 @@
 	dir = 5
 	},
 /obj/item/stool/padded,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Junior Researcher"
 	},
 /turf/simulated/floor/tiled/white,
@@ -1821,7 +1821,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/eva)
 "eV" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Robot"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -2043,7 +2043,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/techstorage)
 "iS" = (
-/obj/level_data/main_level,
+/obj/abstract/level_data/main_level,
 /turf/space,
 /area/space)
 "iW" = (
@@ -2061,7 +2061,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/landmark/latejoin/cryo,
+/obj/abstract/landmark/latejoin/cryo,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -2185,7 +2185,7 @@
 /area/ship/trade/cargo/lower)
 "my" = (
 /obj/machinery/cryopod/robot,
-/obj/effect/landmark/latejoin/cyborg,
+/obj/abstract/landmark/latejoin/cyborg,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/techstorage)
 "mN" = (
@@ -2209,7 +2209,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/latejoin/cryo_two,
+/obj/abstract/landmark/latejoin/cryo_two,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/trade/escape_star)
 "nf" = (
@@ -2273,7 +2273,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Junior Engineer"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -2306,7 +2306,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/latejoin/cryo_two,
+/obj/abstract/landmark/latejoin/cryo_two,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/trade/escape_star)
 "ql" = (
@@ -2414,7 +2414,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Head Researcher"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3066,7 +3066,7 @@
 	},
 /obj/item/bedsheet/red,
 /obj/random_multi/single_item/captains_spare_id,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Head Engineer"
 	},
 /obj/item/stack/material/ingot/mapped/osmium/ten,
@@ -3357,7 +3357,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/ship/trade/cargo/lower)
 "Zs" = (
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Junior Researcher"
 	},
 /turf/simulated/floor/tiled/white,

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -61,7 +61,7 @@
 /obj/item/bedsheet/captain,
 /obj/item/gun/projectile/pistol/holdout,
 /obj/structure/bed/padded,
-/obj/effect/landmark/latejoin/cryo_captain,
+/obj/abstract/landmark/latejoin/cryo_captain,
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
@@ -976,7 +976,7 @@
 /obj/structure/bed/chair/comfy/teal{
 	dir = 1
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Captain"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1211,7 +1211,7 @@
 	icon_state = "twindow"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Deck Hand"
 	},
 /turf/simulated/floor/tiled/freezer,
@@ -1234,7 +1234,7 @@
 /area/ship/trade/crew/saloon)
 "dm" = (
 /obj/item/stool/padded,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Junior Researcher"
 	},
 /turf/simulated/floor/tiled,
@@ -1473,7 +1473,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Junior Doctor"
 	},
 /obj/structure/cable{
@@ -1748,7 +1748,7 @@
 /obj/item/stool/padded,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Cook"
 	},
 /turf/simulated/floor/tiled,
@@ -2277,7 +2277,7 @@
 /area/ship/trade/crew/wash)
 "fV" = (
 /obj/structure/bed/chair/office/light,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Head Doctor"
 	},
 /turf/simulated/floor/tiled/white,
@@ -3063,7 +3063,7 @@
 /area/ship/trade/maintenance/engineering)
 "hW" = (
 /obj/structure/bed/chair/comfy/brown,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Head Engineer"
 	},
 /obj/effect/floor_decal/corner/yellow{
@@ -3229,7 +3229,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Junior Engineer"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -5017,7 +5017,7 @@
 /obj/structure/table,
 /obj/random/smokes,
 /obj/item/ashtray/glass,
-/obj/effect/landmark{
+/obj/abstract/landmark{
 	name = "Observer-Start"
 	},
 /obj/structure/cable{
@@ -5113,7 +5113,7 @@
 /turf/simulated/floor/tiled,
 /area/ship/trade/crew/saloon)
 "xh" = (
-/obj/level_data/main_level,
+/obj/abstract/level_data/main_level,
 /turf/space,
 /area/space)
 "xn" = (
@@ -5290,7 +5290,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/landmark/paperwork_finish_tradeship,
+/obj/abstract/landmark/paperwork_finish_tradeship,
 /turf/simulated/floor/tiled/dark,
 /area/ship/trade/command/bridge)
 "As" = (
@@ -5447,7 +5447,7 @@
 	},
 /obj/item/radio,
 /obj/random/drinkbottle,
-/obj/effect/landmark/paperwork_spawn_tradeship,
+/obj/abstract/landmark/paperwork_spawn_tradeship,
 /turf/simulated/floor/tiled/dark,
 /area/ship/trade/command/bridge)
 "CP" = (
@@ -5670,7 +5670,7 @@
 /obj/random_multi/single_item/captains_spare_id,
 /obj/item/documents/tradehouse/account,
 /obj/item/documents/tradehouse/personnel,
-/obj/effect/landmark/paperwork_spawn_tradeship,
+/obj/abstract/landmark/paperwork_spawn_tradeship,
 /turf/simulated/floor/tiled/dark,
 /area/ship/trade/command/bridge)
 "FT" = (
@@ -5931,7 +5931,7 @@
 /area/ship/trade/command/hallway)
 "Jk" = (
 /obj/structure/bed/chair/office/dark,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "First Mate"
 	},
 /turf/simulated/floor/wood,
@@ -6219,7 +6219,7 @@
 	dir = 4;
 	level = 2
 	},
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Junior Doctor"
 	},
 /turf/simulated/floor/tiled,
@@ -6591,7 +6591,7 @@
 /area/ship/trade/command/captain)
 "Rv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Cargo Technician"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -7063,7 +7063,7 @@
 	dir = 1
 	},
 /obj/structure/bed/padded,
-/obj/effect/landmark/start{
+/obj/abstract/landmark/start{
 	name = "Head Engineer"
 	},
 /turf/simulated/floor/tiled/techfloor,

--- a/maps/tradeship/tradeship-3.dmm
+++ b/maps/tradeship/tradeship-3.dmm
@@ -168,7 +168,7 @@
 /turf/simulated/floor/airless,
 /area/space)
 "aK" = (
-/obj/abstract/landmark/map_data{
+/obj/abstract/map_data{
 	height = 4
 	},
 /turf/space,

--- a/maps/tradeship/tradeship-3.dmm
+++ b/maps/tradeship/tradeship-3.dmm
@@ -168,7 +168,7 @@
 /turf/simulated/floor/airless,
 /area/space)
 "aK" = (
-/obj/effect/landmark/map_data{
+/obj/abstract/landmark/map_data{
 	height = 4
 	},
 /turf/space,
@@ -269,7 +269,7 @@
 /turf/simulated/floor/plating,
 /area/ship/trade/bridge_unused)
 "dm" = (
-/obj/level_data/main_level,
+/obj/abstract/level_data/main_level,
 /turf/space,
 /area/space)
 "dq" = (

--- a/maps/tradeship/tradeship_spawnpoints.dm
+++ b/maps/tradeship/tradeship_spawnpoints.dm
@@ -1,9 +1,9 @@
 var/global/list/latejoin_cryo_two = list()
 var/global/list/latejoin_cryo_captain = list()
-/obj/effect/landmark/latejoin/cryo_two/add_loc()
+/obj/abstract/landmark/latejoin/cryo_two/add_loc()
 	global.latejoin_cryo_two |= get_turf(src)
 
-/obj/effect/landmark/latejoin/cryo_captain/add_loc()
+/obj/abstract/landmark/latejoin/cryo_captain/add_loc()
 	global.latejoin_cryo_captain |= get_turf(src)
 
 /datum/map/tradeship

--- a/maps/~unit_tests/proximity_tests.dmm
+++ b/maps/~unit_tests/proximity_tests.dmm
@@ -12,11 +12,11 @@
 /turf/simulated/wall,
 /area/test_area/proximity)
 "e" = (
-/obj/effect/landmark/proximity_spawner,
+/obj/abstract/landmark/proximity_spawner,
 /turf/simulated/floor,
 /area/test_area/proximity)
 "f" = (
-/obj/effect/landmark/proximity_wall,
+/obj/abstract/landmark/proximity_wall,
 /turf/simulated/wall,
 /area/test_area/proximity)
 

--- a/maps/~unit_tests/unit_tests.dmm
+++ b/maps/~unit_tests/unit_tests.dmm
@@ -25,7 +25,7 @@
 /turf/unsimulated/wall,
 /area/test_area/requires_power_non_dynamic_lighting)
 "h" = (
-/obj/effect/landmark/test/virtual_spawn/two,
+/obj/abstract/landmark/test/virtual_spawn/two,
 /turf/unsimulated/floor{
 	icon_state = "hydrofloor"
 	},
@@ -36,13 +36,13 @@
 	},
 /area/test_area/powered_non_dynamic_lighting)
 "j" = (
-/obj/effect/landmark/test/virtual_spawn/one,
+/obj/abstract/landmark/test/virtual_spawn/one,
 /turf/unsimulated/floor{
 	icon_state = "hydrofloor"
 	},
 /area/test_area/powered_non_dynamic_lighting)
 "k" = (
-/obj/effect/landmark/test/virtual_spawn/three,
+/obj/abstract/landmark/test/virtual_spawn/three,
 /turf/unsimulated/floor{
 	icon_state = "hydrofloor"
 	},
@@ -62,11 +62,11 @@
 /turf/space,
 /area/test_area/general)
 "p" = (
-/obj/effect/landmark/test/safe_turf,
+/obj/abstract/landmark/test/safe_turf,
 /turf/simulated/floor,
 /area/test_area/general)
 "q" = (
-/obj/effect/landmark/test/space_turf,
+/obj/abstract/landmark/test/space_turf,
 /turf/space,
 /area/test_area/general)
 

--- a/mods/content/corporate/away_sites/lar_maria/lar_maria-1.dmm
+++ b/mods/content/corporate/away_sites/lar_maria/lar_maria-1.dmm
@@ -104,7 +104,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/effect/landmark/corpse/lar_maria/zhp_guard/dark,
+/obj/abstract/landmark/corpse/lar_maria/zhp_guard/dark,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
 /area/lar_maria/morgue)
@@ -237,7 +237,7 @@
 /area/lar_maria/vir_main)
 "aK" = (
 /obj/structure/bed,
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -297,12 +297,12 @@
 /area/lar_maria/cells)
 "aW" = (
 /obj/structure/bed/padded,
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /turf/simulated/floor/tiled,
 /area/lar_maria/cells)
 "aX" = (
 /obj/structure/bed/padded,
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/machinery/alarm{
 	alarm_id = "xenobio1_alarm";
 	pixel_y = 24
@@ -340,7 +340,7 @@
 /turf/simulated/floor/plating,
 /area/lar_maria/cells)
 "bc" = (
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /turf/simulated/floor/plating,
 /area/lar_maria/cells)
 "bd" = (
@@ -407,7 +407,7 @@
 /obj/structure/hygiene/shower{
 	dir = 4
 	},
-/obj/effect/landmark/corpse/lar_maria/virologist,
+/obj/abstract/landmark/corpse/lar_maria/virologist,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_main)
@@ -424,7 +424,7 @@
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_main)
 "bp" = (
-/obj/effect/landmark/corpse/lar_maria/virologist_female,
+/obj/abstract/landmark/corpse/lar_maria/virologist_female,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_main)
@@ -474,7 +474,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/lar_maria/cells)
@@ -518,7 +518,7 @@
 /area/lar_maria/cells)
 "bE" = (
 /obj/structure/mattress/dirty,
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /turf/simulated/floor/plating,
 /area/lar_maria/cells)
 "bF" = (
@@ -673,7 +673,7 @@
 /area/lar_maria/cells)
 "ce" = (
 /obj/machinery/door/window/westleft,
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	icon_state = "pdoor0";
@@ -682,7 +682,7 @@
 /turf/simulated/floor/plating,
 /area/lar_maria/cells)
 "cf" = (
-/obj/effect/landmark/corpse/lar_maria/virologist,
+/obj/abstract/landmark/corpse/lar_maria/virologist,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
 /area/lar_maria/morgue)
@@ -801,7 +801,7 @@
 /obj/structure/hygiene/toilet{
 	dir = 4
 	},
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/cells)
@@ -933,7 +933,7 @@
 	dir = 4
 	},
 /obj/machinery/optable,
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_main)
@@ -1093,7 +1093,7 @@
 /obj/structure/sign/warning/biohazard{
 	pixel_y = 32
 	},
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
 /area/lar_maria/cells)
@@ -1286,7 +1286,7 @@
 /turf/simulated/floor/plating,
 /area/lar_maria/sec_wing)
 "dE" = (
-/obj/effect/landmark/corpse/lar_maria/virologist,
+/obj/abstract/landmark/corpse/lar_maria/virologist,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/lar_maria/vir_hallway)
@@ -1414,7 +1414,7 @@
 /area/lar_maria/vir_aux)
 "ea" = (
 /obj/machinery/door/window/southright,
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_aux)
@@ -1453,7 +1453,7 @@
 /area/lar_maria/sec_wing)
 "eh" = (
 /obj/structure/bed/roller,
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_ward)
 "ei" = (
@@ -1509,7 +1509,7 @@
 /area/space)
 "eq" = (
 /obj/structure/bed/padded,
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/lar_maria/cells)
@@ -1552,7 +1552,7 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/effect/landmark/corpse/lar_maria/zhp_guard,
+/obj/abstract/landmark/corpse/lar_maria/zhp_guard,
 /turf/simulated/floor/tiled,
 /area/lar_maria/sec_wing)
 "ex" = (
@@ -1695,7 +1695,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/landmark/corpse/lar_maria/zhp_guard/dark,
+/obj/abstract/landmark/corpse/lar_maria/zhp_guard/dark,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -2079,7 +2079,7 @@
 /turf/simulated/floor/plating,
 /area/lar_maria/cells)
 "fK" = (
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -2401,7 +2401,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/lar_maria/cells)
@@ -2572,7 +2572,7 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/effect/landmark/corpse/lar_maria/zhp_guard,
+/obj/abstract/landmark/corpse/lar_maria/zhp_guard,
 /turf/simulated/floor/plating,
 /area/lar_maria/sec_wing)
 "gJ" = (
@@ -2754,7 +2754,7 @@
 /area/lar_maria/vir_access)
 "hk" = (
 /obj/structure/hygiene/shower,
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_access)
@@ -2989,7 +2989,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/landmark/corpse/lar_maria/zhp_guard/dark,
+/obj/abstract/landmark/corpse/lar_maria/zhp_guard/dark,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_access)
@@ -3052,7 +3052,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
 /area/lar_maria/cells)
@@ -3388,7 +3388,7 @@
 /obj/structure/hygiene/shower{
 	dir = 1
 	},
-/obj/effect/landmark/corpse/lar_maria/virologist,
+/obj/abstract/landmark/corpse/lar_maria/virologist,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_access)

--- a/mods/content/corporate/away_sites/lar_maria/lar_maria-2.dmm
+++ b/mods/content/corporate/away_sites/lar_maria/lar_maria-2.dmm
@@ -15,7 +15,7 @@
 /turf/simulated/floor/reinforced,
 /area/space)
 "ae" = (
-/obj/abstract/landmark/map_data{
+/obj/abstract/map_data{
 	height = 2
 	},
 /turf/simulated/floor/reinforced,

--- a/mods/content/corporate/away_sites/lar_maria/lar_maria-2.dmm
+++ b/mods/content/corporate/away_sites/lar_maria/lar_maria-2.dmm
@@ -15,7 +15,7 @@
 /turf/simulated/floor/reinforced,
 /area/space)
 "ae" = (
-/obj/effect/landmark/map_data{
+/obj/abstract/landmark/map_data{
 	height = 2
 	},
 /turf/simulated/floor/reinforced,
@@ -341,7 +341,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/reinforced,
 /area/space)
@@ -508,7 +508,7 @@
 /turf/simulated/floor/plating,
 /area/lar_maria/solar_control)
 "bp" = (
-/obj/effect/landmark/corpse/lar_maria/zhp_guard,
+/obj/abstract/landmark/corpse/lar_maria/zhp_guard,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
 /area/lar_maria/solar_control)
@@ -722,7 +722,7 @@
 /turf/simulated/floor/wood,
 /area/lar_maria/dorms)
 "ca" = (
-/obj/effect/landmark/corpse/lar_maria/virologist,
+/obj/abstract/landmark/corpse/lar_maria/virologist,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/wood,
 /area/lar_maria/dorms)
@@ -744,7 +744,7 @@
 /turf/simulated/floor/tiled,
 /area/lar_maria/library)
 "cf" = (
-/obj/effect/landmark/corpse/lar_maria/virologist,
+/obj/abstract/landmark/corpse/lar_maria/virologist,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/lar_maria/library)
@@ -1016,7 +1016,7 @@
 /turf/simulated/floor/wood,
 /area/lar_maria/dorms)
 "cZ" = (
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/wood,
 /area/lar_maria/dorms)
@@ -1224,7 +1224,7 @@
 /turf/simulated/floor/tiled,
 /area/lar_maria/library)
 "dK" = (
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/lar_maria/library)
@@ -1398,7 +1398,7 @@
 /turf/simulated/floor/wood,
 /area/lar_maria/dorms)
 "el" = (
-/obj/effect/landmark/corpse/lar_maria/virologist_female,
+/obj/abstract/landmark/corpse/lar_maria/virologist_female,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/wood,
 /area/lar_maria/dorms)
@@ -1489,7 +1489,7 @@
 /area/lar_maria/office)
 "eD" = (
 /obj/structure/bed/chair/office/light,
-/obj/effect/landmark/corpse/lar_maria/virologist_female,
+/obj/abstract/landmark/corpse/lar_maria/virologist_female,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/lar_maria/office)
@@ -1541,7 +1541,7 @@
 	dir = 1
 	},
 /obj/random/trash,
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_m)
@@ -1577,7 +1577,7 @@
 /area/lar_maria/office)
 "eS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/lar_maria/office)
@@ -1787,7 +1787,7 @@
 /turf/simulated/floor/tiled,
 /area/lar_maria/office)
 "fA" = (
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/lar_maria/office)
@@ -2026,12 +2026,12 @@
 /area/lar_maria/dorms)
 "go" = (
 /obj/structure/bed/padded,
-/obj/effect/landmark/corpse/lar_maria/virologist,
+/obj/abstract/landmark/corpse/lar_maria/virologist,
 /turf/simulated/floor/wood,
 /area/lar_maria/dorms)
 "gp" = (
 /obj/random/trash,
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_m)
@@ -2409,7 +2409,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/lar_maria/hallway)
@@ -2546,7 +2546,7 @@
 /turf/simulated/floor/plating,
 /area/lar_maria/hallway)
 "hT" = (
-/obj/effect/landmark/corpse/lar_maria/zhp_guard/dark,
+/obj/abstract/landmark/corpse/lar_maria/zhp_guard/dark,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/lar_maria/hallway)
@@ -2628,7 +2628,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/lar_maria/mess_hall)
 "ih" = (
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/freezer,
 /area/lar_maria/mess_hall)
@@ -2765,7 +2765,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/effect/landmark/corpse/lar_maria/virologist,
+/obj/abstract/landmark/corpse/lar_maria/virologist,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/lar_maria/mess_hall)
@@ -2786,7 +2786,7 @@
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "iD" = (
-/obj/effect/landmark/corpse/lar_maria/virologist_female,
+/obj/abstract/landmark/corpse/lar_maria/virologist_female,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
@@ -2809,7 +2809,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/abstract/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_f)

--- a/mods/content/corporate/away_sites/lar_maria/lar_maria.dm
+++ b/mods/content/corporate/away_sites/lar_maria/lar_maria.dm
@@ -16,7 +16,7 @@
 	area_usage_test_exempted_root_areas = list(/area/lar_maria)
 
 ///////////////////////////////////crew and prisoners
-/obj/effect/landmark/corpse/lar_maria
+/obj/abstract/landmark/corpse/lar_maria
 	eye_colors_per_species = list(SPECIES_HUMAN = list(COLOR_RED))//red eyes
 	skin_tones_per_species = list(SPECIES_HUMAN = list(-15))
 	facial_styles_per_species = list(SPECIES_HUMAN = list(/decl/sprite_accessory/facial_hair/shaved))
@@ -40,7 +40,7 @@
 	stop_automated_movement_when_pulled = 0
 	natural_weapon = /obj/item/natural_weapon/punch
 
-	var/obj/effect/landmark/corpse/lar_maria/corpse = null
+	var/obj/abstract/landmark/corpse/lar_maria/corpse = null
 	var/weapon = null
 
 /mob/living/simple_animal/hostile/lar_maria/death(gibbed, deathmessage, show_dead_message)
@@ -57,10 +57,10 @@
 	desc = "Sick, filthy, angry and probably crazy human in an orange robe."
 	maxHealth = 40
 	health = 40
-	corpse = /obj/effect/landmark/corpse/lar_maria/test_subject
+	corpse = /obj/abstract/landmark/corpse/lar_maria/test_subject
 	icon = 'mods/content/corporate/away_sites/lar_maria/lar_maria_test_subject.dmi'
 
-/obj/effect/landmark/corpse/lar_maria/test_subject
+/obj/abstract/landmark/corpse/lar_maria/test_subject
 	name = "dead test subject"
 	corpse_outfits = list(/decl/hierarchy/outfit/corpse/test_subject)
 	spawn_flags = CORPSE_SPAWNER_NO_RANDOMIZATION//no name, no hairs etc.
@@ -70,12 +70,12 @@
 	uniform = /obj/item/clothing/under/color/orange
 	shoes = /obj/item/clothing/shoes/color/orange
 
-/obj/effect/landmark/corpse/lar_maria/zhp_guard
+/obj/abstract/landmark/corpse/lar_maria/zhp_guard
 	name = "dead guard"
 	corpse_outfits = list(/decl/hierarchy/outfit/corpse/zhp_guard)
 	skin_tones_per_species = list(SPECIES_HUMAN = list(-15))
 
-/obj/effect/landmark/corpse/lar_maria/zhp_guard/dark
+/obj/abstract/landmark/corpse/lar_maria/zhp_guard/dark
 	skin_tones_per_species = list(SPECIES_HUMAN = list(-115))
 
 /decl/hierarchy/outfit/corpse/zhp_guard
@@ -93,7 +93,7 @@
 	health = 60
 	natural_weapon = /obj/item/baton
 	weapon = /obj/item/baton
-	corpse = /obj/effect/landmark/corpse/lar_maria/zhp_guard
+	corpse = /obj/abstract/landmark/corpse/lar_maria/zhp_guard
 
 /mob/living/simple_animal/hostile/lar_maria/guard/Initialize()
 	. = ..()
@@ -109,7 +109,7 @@
 		else
 			icon = 'mods/content/corporate/away_sites/lar_maria/lar_maria_guard_light.dmi'
 	if (skin_color == "dark")
-		corpse = /obj/effect/landmark/corpse/lar_maria/zhp_guard/dark
+		corpse = /obj/abstract/landmark/corpse/lar_maria/zhp_guard/dark
 
 /mob/living/simple_animal/hostile/lar_maria/guard/ranged
 	weapon = /obj/item/gun/projectile/shotgun/pump
@@ -127,9 +127,9 @@
 	icon = 'mods/content/corporate/away_sites/lar_maria/lar_maria_virologist_m.dmi'
 	maxHealth = 50
 	health = 50
-	corpse = /obj/effect/landmark/corpse/lar_maria/virologist
+	corpse = /obj/abstract/landmark/corpse/lar_maria/virologist
 
-/obj/effect/landmark/corpse/lar_maria/virologist
+/obj/abstract/landmark/corpse/lar_maria/virologist
 	name = "dead virologist"
 	corpse_outfits = list(/decl/hierarchy/outfit/corpse/zhp_virologist)
 
@@ -146,9 +146,9 @@
 /mob/living/simple_animal/hostile/lar_maria/virologist/female
 	icon = 'mods/content/corporate/away_sites/lar_maria/lar_maria_virologist_f.dmi'
 	weapon = /obj/item/scalpel
-	corpse = /obj/effect/landmark/corpse/lar_maria/virologist_female
+	corpse = /obj/abstract/landmark/corpse/lar_maria/virologist_female
 
-/obj/effect/landmark/corpse/lar_maria/virologist_female
+/obj/abstract/landmark/corpse/lar_maria/virologist_female
 	name = "dead virologist"
 	corpse_outfits = list(/decl/hierarchy/outfit/corpse/zhp_virologist_female)
 	hair_styles_per_species = list(SPECIES_HUMAN = list(/decl/sprite_accessory/hair/flair))

--- a/mods/content/corporate/effects/landmarks.dm
+++ b/mods/content/corporate/effects/landmarks.dm
@@ -1,7 +1,7 @@
-/obj/effect/landmark/corpse/bridgeofficer
+/obj/abstract/landmark/corpse/bridgeofficer
 	name = "Bridge Officer"
 	corpse_outfits = list(/decl/hierarchy/outfit/nanotrasen/officer)
 
-/obj/effect/landmark/corpse/commander
+/obj/abstract/landmark/corpse/commander
 	name = "Commander"
 	corpse_outfits = list(/decl/hierarchy/outfit/nanotrasen/commander)

--- a/mods/content/government/away_sites/icarus/icarus-1.dmm
+++ b/mods/content/government/away_sites/icarus/icarus-1.dmm
@@ -699,7 +699,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpse/chef,
+/obj/abstract/landmark/corpse/chef,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor/tiled/white,
 /area/icarus/vessel)
@@ -975,7 +975,7 @@
 /turf/simulated/wall,
 /area/icarus/vessel)
 "ds" = (
-/obj/effect/landmark/corpse/doctor,
+/obj/abstract/landmark/corpse/doctor,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor/tiled,
 /area/icarus/open)
@@ -2212,7 +2212,7 @@
 /turf/simulated/floor/plating,
 /area/icarus/vessel)
 "hl" = (
-/obj/effect/landmark/corpse/engineer,
+/obj/abstract/landmark/corpse/engineer,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor/plating,
 /area/icarus/vessel)

--- a/mods/content/government/away_sites/icarus/icarus-2.dmm
+++ b/mods/content/government/away_sites/icarus/icarus-2.dmm
@@ -118,7 +118,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/effect/landmark/corpse/bridgeofficer,
+/obj/abstract/landmark/corpse/bridgeofficer,
 /turf/simulated/floor/tiled,
 /area/icarus/vessel)
 "aB" = (
@@ -607,7 +607,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/effect/landmark/corpse/engineer,
+/obj/abstract/landmark/corpse/engineer,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/icarus/vessel)
@@ -1009,7 +1009,7 @@
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
 	},
-/obj/effect/landmark/corpse/scientist,
+/obj/abstract/landmark/corpse/scientist,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled,
 /area/icarus/vessel)
@@ -1781,7 +1781,7 @@
 /turf/simulated/floor/reinforced,
 /area/icarus/open)
 "gb" = (
-/obj/effect/landmark/map_data{
+/obj/abstract/landmark/map_data{
 	height = 2
 	},
 /turf/unsimulated/mineral,

--- a/mods/content/government/away_sites/icarus/icarus-2.dmm
+++ b/mods/content/government/away_sites/icarus/icarus-2.dmm
@@ -1781,7 +1781,7 @@
 /turf/simulated/floor/reinforced,
 /area/icarus/open)
 "gb" = (
-/obj/abstract/landmark/map_data{
+/obj/abstract/map_data{
 	height = 2
 	},
 /turf/unsimulated/mineral,

--- a/mods/content/government/ruins/ec_old_crash/ec_old_crash.dmm
+++ b/mods/content/government/ruins/ec_old_crash/ec_old_crash.dmm
@@ -3,15 +3,15 @@
 /turf/template_noop,
 /area/template_noop)
 "ab" = (
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/simulated/wall/r_wall/hull,
 /area/map_template/ecship/cryo)
 "ac" = (
 /turf/simulated/wall/r_wall/hull,
 /area/map_template/ecship/cockpit)
 "ad" = (
-/obj/effect/landmark/scorcher,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/scorcher,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/cockpit)
 "ae" = (
@@ -24,7 +24,7 @@
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/simulated/floor,
 /area/map_template/ecship/cockpit)
 "af" = (
@@ -107,7 +107,7 @@
 /area/map_template/ecship/cryo)
 "at" = (
 /obj/structure/lattice,
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/map_template/ecship/cryo)
 "au" = (
@@ -448,7 +448,7 @@
 /area/map_template/ecship/cryo)
 "bi" = (
 /obj/structure/catwalk,
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "bj" = (
@@ -468,7 +468,7 @@
 	dir = 8;
 	icon_state = "1-4"
 	},
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "bl" = (
@@ -578,7 +578,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "bx" = (
@@ -661,7 +661,7 @@
 	dir = 4;
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "bD" = (
@@ -983,13 +983,13 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "cj" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "ck" = (
@@ -1473,7 +1473,7 @@
 "dl" = (
 /obj/structure/catwalk,
 /obj/structure/handrail,
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "dm" = (
@@ -1482,7 +1482,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
 	},
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "dn" = (
@@ -1594,7 +1594,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "dw" = (
@@ -1602,13 +1602,13 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 9
 	},
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "dx" = (
 /obj/structure/catwalk,
-/obj/effect/landmark/scorcher,
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "dy" = (
@@ -1631,7 +1631,7 @@
 	dir = 4;
 	icon_state = "0-2"
 	},
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "dA" = (
@@ -1684,7 +1684,7 @@
 	dir = 4;
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "dH" = (
@@ -1701,7 +1701,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "dJ" = (
@@ -1734,7 +1734,7 @@
 	dir = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/simulated/floor/airless,
 /area/map_template/ecship/engine)
 "dR" = (
@@ -1743,7 +1743,7 @@
 "dS" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/simulated/floor/airless,
 /area/map_template/ecship/engine)
 "dT" = (
@@ -1772,7 +1772,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5
 	},
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/simulated/floor/airless,
 /area/map_template/ecship/engine)
 "dY" = (
@@ -1780,8 +1780,8 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/obj/effect/landmark/scorcher,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/scorcher,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "dZ" = (
@@ -1791,7 +1791,7 @@
 	target_pressure = 2500;
 	use_power = 1
 	},
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "ea" = (
@@ -1849,7 +1849,7 @@
 	target_pressure = 2500;
 	use_power = 1
 	},
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "eh" = (
@@ -1857,8 +1857,8 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 10
 	},
-/obj/effect/landmark/scorcher,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/scorcher,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "ei" = (
@@ -1870,8 +1870,8 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
 	},
-/obj/effect/landmark/scorcher,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/scorcher,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "ek" = (
@@ -1881,7 +1881,7 @@
 	target_pressure = 2500;
 	use_power = 1
 	},
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/map_template/ecship/engine)
 "el" = (
@@ -1907,37 +1907,37 @@
 "eo" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "ep" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "mD" = (
 /obj/structure/lattice,
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/template_noop)
 "qB" = (
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "yb" = (
 /obj/structure/lattice,
-/obj/effect/landmark/scorcher,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/scorcher,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "yZ" = (
 /obj/structure/grille,
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/template_noop)
 "NM" = (
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/template_noop,
 /area/template_noop)
 "SX" = (
@@ -1949,7 +1949,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "Vy" = (
@@ -1959,17 +1959,17 @@
 /area/map_template/ecship/science)
 "Wb" = (
 /obj/structure/lattice,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 "YW" = (
 /obj/structure/catwalk,
-/obj/effect/landmark/scorcher,
+/obj/abstract/landmark/scorcher,
 /turf/simulated/floor/airless,
 /area/map_template/ecship/engine)
 "ZF" = (
-/obj/effect/landmark/scorcher,
-/obj/effect/landmark/clear,
+/obj/abstract/landmark/scorcher,
+/obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
 

--- a/mods/mobs/borers/datum/symbiote.dm
+++ b/mods/mobs/borers/datum/symbiote.dm
@@ -120,10 +120,10 @@ var/global/list/symbiote_starting_points = list()
 /datum/job/symbiote/is_position_available()
 	. = ..() && length(find_valid_hosts(TRUE)) 
 
-/obj/effect/landmark/symbiote_start
+/obj/abstract/landmark/symbiote_start
 	name = "Symbiote Start"
 	delete_me = TRUE
 
-/obj/effect/landmark/symbiote_start/Initialize()
+/obj/abstract/landmark/symbiote_start/Initialize()
 	global.symbiote_starting_points |= get_turf(src)
 	. = ..()


### PR DESCRIPTION
- Fixes erroneous weather_system inclusion in abstract explosion_act().
- Moves landmark icon and a couple of vars to /abstract.
- Converts `/obj/effect/landmark` to `/obj/abstract/landmark`.
- Converts `/obj/effect/landmark/map_data` to `/obj/abstract/map_data`.