### PR TITLE
Ambient Light

### DIFF
--- a/code/controllers/subsystems/lighting.dm
+++ b/code/controllers/subsystems/lighting.dm
@@ -82,14 +82,6 @@ SUBSYSTEM_DEF(lighting)
 			new /atom/movable/lighting_overlay(T)
 			. += 1
 
-		// Non-dyn light turfs might be ambient sources.
-		else if (T.ambient_light)
-			T.generate_missing_corners()
-			for (var/datum/lighting_corner/C as anything in T.corners)
-				if (!C.needs_update)
-					C.needs_update = TRUE
-					corner_queue += C
-
 		CHECK_TICK
 
 // It's safe to pass a list of non-turfs to this list - it'll only check turfs.

--- a/code/controllers/subsystems/lighting.dm
+++ b/code/controllers/subsystems/lighting.dm
@@ -82,6 +82,14 @@ SUBSYSTEM_DEF(lighting)
 			new /atom/movable/lighting_overlay(T)
 			. += 1
 
+		// Non-dyn light turfs might be ambient sources.
+		else if (T.ambient_light)
+			T.generate_missing_corners()
+			for (var/datum/lighting_corner/C as anything in T.corners)
+				if (!C.needs_update)
+					C.needs_update = TRUE
+					corner_queue += C
+
 		CHECK_TICK
 
 // It's safe to pass a list of non-turfs to this list - it'll only check turfs.

--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -29,7 +29,7 @@
 			ChangeArea(src, owner.planetary_area)
 
 	. = ..(mapload)	// second param is our own, don't pass to children
-	setup_environmental_lighting(mapload)
+	setup_environmental_lighting()
 
 	if (no_update_icon)
 		return
@@ -52,7 +52,7 @@
 		ext.affecting_heat_sources = last_affecting_heat_sources
 	return ext
 
-/turf/exterior/proc/setup_environmental_lighting(mapload)
+/turf/exterior/proc/setup_environmental_lighting()
 	if (is_outside())
 		if (owner)
 			set_ambient_light(COLOR_WHITE, owner.lightlevel)

--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -55,13 +55,13 @@
 /turf/exterior/proc/setup_environmental_lighting(mapload)
 	if (is_outside())
 		if (owner)
-			set_ambient_light(COLOR_WHITE, owner.lightlevel, mapload)
+			set_ambient_light(COLOR_WHITE, owner.lightlevel)
 			return
 
 		if (config.starlight)
 			var/area/A = loc
 			if (A.show_starlight)
-				set_ambient_light(SSskybox.background_color, skip_update = mapload)
+				set_ambient_light(SSskybox.background_color)
 			else if (ambient_light)
 				clear_ambient_light()
 	else if (ambient_light)

--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -53,9 +53,9 @@
 	return ext
 
 /turf/exterior/initialize_ambient_light(var/mapload)
-	update_ambient_light(mapload)
+	update_ambient_lighting(mapload)
 
-/turf/exterior/update_ambient_light(var/mapload)
+/turf/exterior/update_ambient_lighting(var/mapload)
 	if(is_outside())
 		if(owner) // Exoplanets do their own lighting shenanigans.
 			//Must be done here, as light data is not fully carried over by ChangeTurf (but overlays are).

--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -25,11 +25,11 @@
 		owner = null
 	else
 		//Must be done here, as light data is not fully carried over by ChangeTurf (but overlays are).
-		set_light(owner.lightlevel)
 		if(owner.planetary_area && istype(loc, world.area))
 			ChangeArea(src, owner.planetary_area)
 
 	. = ..(mapload)	// second param is our own, don't pass to children
+	setup_environmental_lighting(mapload)
 
 	if (no_update_icon)
 		return
@@ -52,22 +52,20 @@
 		ext.affecting_heat_sources = last_affecting_heat_sources
 	return ext
 
-/turf/exterior/initialize_ambient_light(var/mapload)
-	update_ambient_lighting(mapload)
-
-/turf/exterior/update_ambient_lighting(var/mapload)
-	if(is_outside())
-		if(owner) // Exoplanets do their own lighting shenanigans.
-			//Must be done here, as light data is not fully carried over by ChangeTurf (but overlays are).
-			set_light(owner.lightlevel)
+/turf/exterior/proc/setup_environmental_lighting(mapload)
+	if (is_outside())
+		if (owner)
+			set_ambient_light(COLOR_WHITE, owner.lightlevel, mapload)
 			return
-		if(config.starlight)
-			var/area/A = get_area(src)
-			if(A.show_starlight)
-				set_light(config.starlight, 0.75, l_color = SSskybox.background_color)
-				return
-	if(!mapload)
-		set_light(0)
+
+		if (config.starlight)
+			var/area/A = loc
+			if (A.show_starlight)
+				set_ambient_light(SSskybox.background_color, skip_update = mapload)
+			else if (ambient_light)
+				clear_ambient_light()
+	else if (ambient_light)
+		clear_ambient_light()
 
 /turf/exterior/is_plating()
 	return !density

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -178,10 +178,6 @@
 	levelupdate()
 	. = ..()
 
-/turf/simulated/initialize_ambient_light(var/mapload)
-	for(var/turf/T as anything in RANGE_TURFS(src, 1))
-		T.update_ambient_lighting(mapload)
-
 /turf/simulated/Destroy()
 	if (zone)
 		if (can_safely_remove_from_zone())

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -1,7 +1,7 @@
 /turf/simulated
 	name = "station"
 	initial_gas = list(
-		/decl/material/gas/oxygen = MOLES_O2STANDARD, 
+		/decl/material/gas/oxygen = MOLES_O2STANDARD,
 		/decl/material/gas/nitrogen = MOLES_N2STANDARD
 	)
 	open_turf_type = /turf/simulated/open
@@ -180,7 +180,7 @@
 
 /turf/simulated/initialize_ambient_light(var/mapload)
 	for(var/turf/T as anything in RANGE_TURFS(src, 1))
-		T.update_ambient_light(mapload)
+		T.update_ambient_lighting(mapload)
 
 /turf/simulated/Destroy()
 	if (zone)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -15,7 +15,7 @@
 	/// Force this one to pretend it's an overedge turf.
 	var/forced_dirs = 0
 
-/turf/space/proc/update_starlight(mapload)
+/turf/space/proc/update_starlight()
 	for (var/turf/T in RANGE_TURFS(src, 1))
 		// Fuck if I know how these turfs are located in an area that is not an area.
 		if (!isloc(T.loc) || !TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
@@ -27,13 +27,13 @@
 	if (ambient_light)
 		clear_ambient_light()
 
-/turf/space/Initialize(var/mapload)
+/turf/space/Initialize()
 
 	SHOULD_CALL_PARENT(FALSE)
 	atom_flags |= ATOM_FLAG_INITIALIZED
 
 	if (config.starlight)
-		update_starlight(mapload)
+		update_starlight()
 
 	//We might be an edge
 	if(y == world.maxy || forced_dirs & NORTH)
@@ -83,7 +83,7 @@
 		if (AM.simulated && !AM.anchored)
 			AM.throw_at(get_step(src, global.reverse_dir[direction]), 5, 1)
 
-		if(istype(AM, /obj/effect/decal)) 
+		if(istype(AM, /obj/effect/decal))
 			qdel(AM)
 
 /turf/space/Destroy()

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -15,18 +15,25 @@
 	/// Force this one to pretend it's an overedge turf.
 	var/forced_dirs = 0
 
-/turf/space/update_ambient_lighting(var/mapload)
-	if(config.starlight && (locate(/turf/simulated) in RANGE_TURFS(src, 1)))
-		set_light(config.starlight, 0.75, l_color = SSskybox.background_color)
-	else
-		set_light(0)
+/turf/space/proc/update_starlight(mapload)
+	for (var/turf/T in RANGE_TURFS(src, 1))
+		// Fuck if I know how these turfs are located in an area that is not an area.
+		if (!isloc(T.loc) || !TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+			continue
+
+		set_ambient_light(SSskybox.background_color, skip_update = mapload)
+		return
+
+	if (ambient_light)
+		set_ambient_light(skip_update = mapload)
 
 /turf/space/Initialize(var/mapload)
 
 	SHOULD_CALL_PARENT(FALSE)
 	atom_flags |= ATOM_FLAG_INITIALIZED
 
-	update_ambient_lighting(mapload)
+	if (config.starlight)
+		update_starlight(mapload)
 
 	//We might be an edge
 	if(y == world.maxy || forced_dirs & NORTH)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -21,11 +21,11 @@
 		if (!isloc(T.loc) || !TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
 			continue
 
-		set_ambient_light(SSskybox.background_color, skip_update = mapload)
+		set_ambient_light(SSskybox.background_color)
 		return
 
 	if (ambient_light)
-		set_ambient_light(skip_update = mapload)
+		clear_ambient_light()
 
 /turf/space/Initialize(var/mapload)
 

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -13,9 +13,9 @@
 	/// If we're an edge.
 	var/edge = 0
 	/// Force this one to pretend it's an overedge turf.
-	var/forced_dirs = 0 
+	var/forced_dirs = 0
 
-/turf/space/update_ambient_light(var/mapload)
+/turf/space/update_ambient_lighting(var/mapload)
 	if(config.starlight && (locate(/turf/simulated) in RANGE_TURFS(src, 1)))
 		set_light(config.starlight, 0.75, l_color = SSskybox.background_color)
 	else
@@ -26,7 +26,7 @@
 	SHOULD_CALL_PARENT(FALSE)
 	atom_flags |= ATOM_FLAG_INITIALIZED
 
-	update_ambient_light(mapload)
+	update_ambient_lighting(mapload)
 
 	//We might be an edge
 	if(y == world.maxy || forced_dirs & NORTH)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -47,8 +47,12 @@
 		PRINT_STACK_TRACE("Warning: [src]([type]) initialized multiple times!")
 	atom_flags |= ATOM_FLAG_INITIALIZED
 
-	if(light_power && light_range)
+	if (light_range && light_power)
+		if (ambient_light)
+			update_ambient_light(TRUE)
 		update_light()
+	else if (ambient_light)
+		update_ambient_light(FALSE)
 
 	if(dynamic_lighting)
 		luminosity = 0

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -84,7 +84,7 @@
 /turf/proc/initialize_ambient_light(var/mapload)
 	return
 
-/turf/proc/update_ambient_light(var/mapload)
+/turf/proc/update_ambient_lighting(var/mapload)
 	return
 
 /turf/Destroy()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -76,20 +76,12 @@
 	if(flooded && !density)
 		make_flooded(TRUE)
 
-	initialize_ambient_light(mapload)
-
 	return INITIALIZE_HINT_NORMAL
 
 /turf/examine(mob/user, distance, infix, suffix)
 	. = ..()
 	if(user && weather)
 		weather.examine(user)
-
-/turf/proc/initialize_ambient_light(var/mapload)
-	return
-
-/turf/proc/update_ambient_lighting(var/mapload)
-	return
 
 /turf/Destroy()
 

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -44,8 +44,6 @@
 	var/old_affecting_lights = affecting_lights
 	var/old_lighting_overlay = lighting_overlay
 	var/old_dynamic_lighting = TURF_IS_DYNAMICALLY_LIT_UNSAFE(src)
-	var/old_ambient_light    = ambient_light
-	var/old_ambient_mult     = ambient_light_multiplier
 	var/old_flooded =          flooded
 	var/old_outside =          is_outside
 
@@ -91,11 +89,6 @@
 	corners = old_corners
 
 	lighting_overlay = old_lighting_overlay
-
-	if (ambient_light != old_ambient_light || ambient_light_multiplier != old_ambient_mult)
-		ambient_light = old_ambient_light || ambient_light	// If null, don't inherit.
-		ambient_light_multiplier = old_ambient_mult || ambient_light_multiplier
-		update_ambient_light()
 
 	recalc_atom_opacity()
 

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -46,6 +46,8 @@
 	var/old_dynamic_lighting = TURF_IS_DYNAMICALLY_LIT_UNSAFE(src)
 	var/old_flooded =          flooded
 	var/old_outside =          is_outside
+	var/old_ambience =         ambient_light
+	var/old_ambience_mult =    ambient_light_multiplier
 
 	changing_turf = TRUE
 
@@ -91,6 +93,9 @@
 	lighting_overlay = old_lighting_overlay
 
 	recalc_atom_opacity()
+
+	if (old_ambience != ambient_light || old_ambience_mult != ambient_light_multiplier)
+		update_ambient_light(FALSE)
 
 	var/tidlu = TURF_IS_DYNAMICALLY_LIT_UNSAFE(src)
 	if ((old_opacity != opacity) || (tidlu != old_dynamic_lighting) || force_lighting_update)

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -44,6 +44,8 @@
 	var/old_affecting_lights = affecting_lights
 	var/old_lighting_overlay = lighting_overlay
 	var/old_dynamic_lighting = TURF_IS_DYNAMICALLY_LIT_UNSAFE(src)
+	var/old_ambient_light    = ambient_light
+	var/old_ambient_mult     = ambient_light_multiplier
 	var/old_flooded =          flooded
 	var/old_outside =          is_outside
 
@@ -89,6 +91,12 @@
 	corners = old_corners
 
 	lighting_overlay = old_lighting_overlay
+
+	if (ambient_light != old_ambient_light || ambient_light_multiplier != old_ambient_mult)
+		ambient_light = old_ambient_light || ambient_light	// If null, don't inherit.
+		ambient_light_multiplier = old_ambient_mult || ambient_light_multiplier
+		update_ambient_light()
+
 	recalc_atom_opacity()
 
 	var/tidlu = TURF_IS_DYNAMICALLY_LIT_UNSAFE(src)

--- a/code/modules/admin/view_variables/vv_set_handlers.dm
+++ b/code/modules/admin/view_variables/vv_set_handlers.dm
@@ -141,6 +141,28 @@
 
 #undef VV_LIGHTING_SET
 
+/decl/vv_set_handler/ambient_light_handler
+	handled_type = /turf
+	handled_vars = list("ambient_light", "ambient_light_multiplier")
+
+/decl/vv_set_handler/ambient_light_handler/handle_set_var(turf/T, variable, value, client)
+	switch (variable)
+		if ("ambient_light")
+			if (!istext(value) && !isnull(value))
+				to_chat(client, "<span class='alert'><pre>ambient_light</pre> must be text or null.</span>")
+				return
+			var/static/regex/color_regex = regex(@"^#[\dA-Fa-f]{6}$")
+			if (istext(value) && !color_regex.Find(value))
+				to_chat(client, "<span class='alert'><pre>ambient_light</pre> must be a 6 digit (<pre>#AABBCC</pre>) hexadecimal color string.</span>")
+				return
+			T.set_ambient_light(value)
+
+		if ("ambient_light_multiplier")
+			if (!isnum(value))
+				to_chat(client, "<span class='alert'><pre>ambient_light_multiplier</pre> must be num.</span>")
+				return
+			T.set_ambient_light(multiplier = value)
+
 /decl/vv_set_handler/icon_rotation_handler
 	handled_type = /atom
 	handled_vars = list("icon_rotation" = /atom/proc/set_rotation)

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -118,6 +118,8 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 
 #define GET_ABOVE(T) (HasAbove(T:z) ? get_step(T, UP) : null)
 
+#define UPDATE_APPARENT apparent_r = self_r + below_r + ambient_r; apparent_b = self_b + below_b + ambient_b; apparent_g = self_g + below_g + ambient_g
+
 // God that was a mess, now to do the rest of the corner code! Hooray!
 /datum/lighting_corner/proc/update_lumcount(delta_r, delta_g, delta_b, now = FALSE)
 	if (!(delta_r + delta_g + delta_b))
@@ -127,9 +129,7 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	self_g += delta_g
 	self_b += delta_b
 
-	apparent_r = self_r + below_r + ambient_r
-	apparent_g = self_g + below_g + ambient_g
-	apparent_b = self_b + below_b + ambient_b
+	UPDATE_APPARENT
 
 	var/turf/T
 	var/Ti
@@ -171,9 +171,7 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	below_g += delta_g
 	below_b += delta_b
 
-	apparent_r = self_r + below_r + ambient_r
-	apparent_g = self_g + below_g + ambient_g
-	apparent_b = self_b + below_b + ambient_b
+	UPDATE_APPARENT
 
 	// This needs to be down here instead of the above if so the lum values are properly updated.
 	if (needs_update)
@@ -194,9 +192,7 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	ambient_g = ag
 	ambient_b = ab
 
-	apparent_r = self_r + below_r + ar
-	apparent_g = self_g + below_g + ag
-	apparent_b = self_b + below_b + ab
+	UPDATE_APPARENT
 
 	if (needs_update || skip_update)
 		return
@@ -204,6 +200,8 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	// Always queue for this, not important enough to hit the synchronous path.
 	needs_update = TRUE
 	SSlighting.corner_queue += src
+
+#undef UPDATE_APPARENT
 
 /datum/lighting_corner/proc/update_overlays(now = FALSE)
 	var/lr = apparent_r

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -11,11 +11,25 @@
 	var/tmp/list/datum/lighting_corner/corners
 	var/tmp/has_opaque_atom = FALSE // Not to be confused with opacity, this will be TRUE if there's any opaque atom on the tile.
 
-/turf/proc/update_ambient_light(skip_update = FALSE)
-	// No, you're not allowed to light up space.
-	if (!TURF_IS_DYNAMICALLY_LIT_UNSAFE(src))
+/turf/proc/set_ambient_light(color, multiplier, skip_update = FALSE)
+	if (color == ambient_light && multiplier == ambient_light_multiplier)
 		return
 
+	ambient_light = color || ambient_light
+	ambient_light_multiplier = multiplier || ambient_light_multiplier
+	if (!ambient_light_multiplier)
+		ambient_light_multiplier = initial(ambient_light_multiplier)
+
+	update_ambient_light(skip_update)
+
+/turf/proc/clear_ambient_light(skip_update = FALSE)
+	if (ambient_light == null)
+		return
+
+	ambient_light = null
+	update_ambient_light(skip_update)
+
+/turf/proc/update_ambient_light(skip_update = FALSE)
 	var/ambient_r = 0
 	var/ambient_g = 0
 	var/ambient_b = 0
@@ -24,7 +38,6 @@
 		ambient_g = (HEX_GREEN(ambient_light) / 255) * ambient_light_multiplier
 		ambient_b = (HEX_BLUE(ambient_light) / 255) * ambient_light_multiplier
 
-	// hell if I know why there's nulls in here
 	if (!corners || (null in corners))
 		generate_missing_corners()
 

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -11,7 +11,7 @@
 	var/tmp/list/datum/lighting_corner/corners
 	var/tmp/has_opaque_atom = FALSE // Not to be confused with opacity, this will be TRUE if there's any opaque atom on the tile.
 
-/turf/proc/set_ambient_light(color, multiplier, skip_update = FALSE)
+/turf/proc/set_ambient_light(color, multiplier)
 	if (color == ambient_light && multiplier == ambient_light_multiplier)
 		return
 
@@ -20,16 +20,16 @@
 	if (!ambient_light_multiplier)
 		ambient_light_multiplier = initial(ambient_light_multiplier)
 
-	update_ambient_light(skip_update)
+	update_ambient_light()
 
-/turf/proc/clear_ambient_light(skip_update = FALSE)
+/turf/proc/clear_ambient_light()
 	if (ambient_light == null)
 		return
 
 	ambient_light = null
-	update_ambient_light(skip_update)
+	update_ambient_light()
 
-/turf/proc/update_ambient_light(skip_update = FALSE)
+/turf/proc/update_ambient_light(no_corner_update = FALSE)
 	var/ambient_r = 0
 	var/ambient_g = 0
 	var/ambient_b = 0
@@ -43,7 +43,7 @@
 
 	for (var/thing in corners)
 		var/datum/lighting_corner/C = thing
-		C.set_ambient_lumcount(ambient_r, ambient_g, ambient_b, skip_update)
+		C.set_ambient_lumcount(ambient_r, ambient_g, ambient_b, no_corner_update)
 
 
 // Causes any affecting light sources to be queued for a visibility update, for example a door got opened.

--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -174,7 +174,10 @@
 	if(!night)
 		light = lightlevel
 	for(var/turf/exterior/T in block(locate(daycolumn,1,min(map_z)),locate(daycolumn,maxy,max(map_z))))
-		T.set_light(light)
+		if (light)
+			T.set_ambient_light(COLOR_WHITE, light)
+		else
+			T.clear_ambient_light()
 	daycolumn++
 	if(daycolumn > maxx)
 		daycolumn = 0


### PR DESCRIPTION
Adds basic support for ambient lighting -- effectively radius 2 lights that can only be emitted by turfs.
These lights are much cheaper than using normal lights, at the cost of being much more limited.

Todo:
- [x] VV hook
- [x] Improve naming
- [x] Add setter (ala `set_light()`)