### PR TITLE
Integrates world.map_cpu to MC

### DIFF
--- a/code/__defines/_tick.dm
+++ b/code/__defines/_tick.dm
@@ -12,11 +12,8 @@
 /// Tick limit while initializing
 #define TICK_LIMIT_MC_INIT_DEFAULT (100 - TICK_BYOND_RESERVE)
 
-
 /// for general usage of tick_usage
 #define TICK_USAGE world.tick_usage
-/// to be used where the result isn't checked
-#define TICK_USAGE_REAL world.tick_usage
 
 /// Returns true if tick_usage is above the limit
 #define TICK_CHECK ( TICK_USAGE > Master.current_ticklimit )
@@ -27,7 +24,7 @@
 //percent_of_tick_used * (ticklag * 100(to convert to ms)) / 100(percent ratio)
 //collapsed to percent_of_tick_used * tick_lag
 #define TICK_DELTA_TO_MS(percent_of_tick_used) ((percent_of_tick_used) * world.tick_lag)
-#define TICK_USAGE_TO_MS(starting_tickusage) (TICK_DELTA_TO_MS(TICK_USAGE_REAL - starting_tickusage))
+#define TICK_USAGE_TO_MS(starting_tickusage) (TICK_DELTA_TO_MS(TICK_USAGE - starting_tickusage))
 
 //time of day but automatically adjusts to the server going into the next day within the same round.
 //for when you need a reliable time number that doesn't depend on byond time.

--- a/code/__defines/_tick.dm
+++ b/code/__defines/_tick.dm
@@ -1,13 +1,27 @@
-#define TICK_LIMIT_RUNNING 80
-#define TICK_LIMIT_TO_RUN 78
+/// Percentage of tick to leave for master controller to run
+#define MAPTICK_MC_MIN_RESERVE 70
+#define MAPTICK_LAST_INTERNAL_TICK_USAGE (world.map_cpu)
+
+/// Tick limit while running normally
+#define TICK_BYOND_RESERVE 2
+#define TICK_LIMIT_RUNNING (max(100 - TICK_BYOND_RESERVE - MAPTICK_LAST_INTERNAL_TICK_USAGE, MAPTICK_MC_MIN_RESERVE))
+/// Tick limit used to resume things in stoplag
+#define TICK_LIMIT_TO_RUN 70
+/// Tick limit for MC while running
 #define TICK_LIMIT_MC 70
-#define TICK_LIMIT_MC_INIT_DEFAULT 98
+/// Tick limit while initializing
+#define TICK_LIMIT_MC_INIT_DEFAULT (100 - TICK_BYOND_RESERVE)
 
-#define TICK_USAGE world.tick_usage //for general usage
-#define TICK_USAGE_REAL world.tick_usage    //to be used where the result isn't checked
 
+/// for general usage of tick_usage
+#define TICK_USAGE world.tick_usage
+/// to be used where the result isn't checked
+#define TICK_USAGE_REAL world.tick_usage
+
+/// Returns true if tick_usage is above the limit
 #define TICK_CHECK ( TICK_USAGE > Master.current_ticklimit )
-#define CHECK_TICK if TICK_CHECK stoplag()
+/// runs stoplag if tick_usage is above the limit
+#define CHECK_TICK ( TICK_CHECK ? stoplag() : 0 )
 
 //"fancy" math for calculating time in ms from tick_usage percentage and the length of ticks
 //percent_of_tick_used * (ticklag * 100(to convert to ms)) / 100(percent ratio)

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -91,7 +91,7 @@
 	var/starttime = world.time
 	. = 1
 	while (world.time < endtime)
-		sleep(1)
+		stoplag(1)
 		if (progress)
 			progbar.update(world.time - starttime)
 		if(!user || !target)
@@ -151,7 +151,7 @@
 	var/starttime = world.time
 	. = 1
 	while (world.time < endtime)
-		sleep(1)
+		stoplag(1)
 		if (progress)
 			progbar.update(world.time - starttime)
 

--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -142,7 +142,7 @@ var/global/rollovercheck_last_timeofday = 0
 /proc/stoplag(initial_delay)
 	// If we're initializing, our tick limit might be over 100 (testing config), but stoplag() penalizes procs that go over.
 	// 	Unfortunately, this penalty slows down init a *lot*. So, we disable it during boot and lobby, when relatively few things should be calling this.
-	if (!Master || !(Master.current_runlevel & RUNLEVELS_DEFAULT))
+	if (!Master || Master.current_runlevel < 3)
 		sleep(world.tick_lag)
 		return 1
 

--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -134,14 +134,15 @@ var/global/rollovercheck_last_timeofday = 0
 	global.rollovercheck_last_timeofday = world.timeofday
 	return global.midnight_rollovers
 
-//Increases delay as the server gets more overloaded,
-//as sleeps aren't cheap and sleeping only to wake up and sleep again is wasteful
-#define DELTA_CALC max(((max(world.tick_usage, world.cpu) / 100) * max(Master.sleep_delta-1,1)), 1)
+/// Increases delay as the server gets more overloaded 
+/// as sleeps aren't cheap and sleeping only to wake up and sleep again is wasteful
+#define DELTA_CALC max(((max(TICK_USAGE, world.cpu) / 100) * max(Master.sleep_delta-1,1)), 1)
 
+/// returns the number of ticks slept
 /proc/stoplag(initial_delay)
 	// If we're initializing, our tick limit might be over 100 (testing config), but stoplag() penalizes procs that go over.
 	// 	Unfortunately, this penalty slows down init a *lot*. So, we disable it during boot and lobby, when relatively few things should be calling this.
-	if (!Master || Master.current_runlevel < 3)
+	if (!Master || !(Master.current_runlevel & RUNLEVELS_DEFAULT))
 		sleep(world.tick_lag)
 		return 1
 
@@ -152,9 +153,9 @@ var/global/rollovercheck_last_timeofday = 0
 	var/i = DS2TICKS(initial_delay)
 	do
 		. += NONUNIT_CEILING(i*DELTA_CALC, 1)
-		sleep(i*world.tick_lag*DELTA_CALC)
+		sleep(i * world.tick_lag * DELTA_CALC)
 		i *= 2
-	while (world.tick_usage > min(TICK_LIMIT_TO_RUN, Master.current_ticklimit))
+	while (TICK_USAGE > min(TICK_LIMIT_TO_RUN, Master.current_ticklimit))
 
 #undef DELTA_CALC
 

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -587,8 +587,43 @@ var/global/datum/controller/master/Master = new
 	if(!statclick)
 		statclick = new/obj/effect/statclick/debug(null, "Initializing...", src)
 
-	stat("Byond:", "(FPS:[world.fps]) (TickCount:[world.time/world.tick_lag]) (TickDrift:[round(Master.tickdrift,1)]([round((Master.tickdrift/(world.time/world.tick_lag))*100,0.1)]%))")
+	stat("Byond:", "(FPS:[world.fps]) (TickCount:[world.time/world.tick_lag]) (TickDrift:[round(Master.tickdrift,1)]([round((Master.tickdrift/(world.time/world.tick_lag))*100,0.1)]%)) (Internal Tick Usage: [round(MAPTICK_LAST_INTERNAL_TICK_USAGE,0.1)]%)")
 	stat("Master Controller:", statclick.update("(TickRate:[Master.processing]) (Iteration:[Master.iteration])"))
+
+/// Colors cpu number before output.
+/datum/controller/master/proc/format_color_cpu()
+	switch(world.cpu)
+		// 0-80 = green
+		if(0 to 80)
+			. = "<font color='#32a852'>[world.cpu]</font>"
+		// 80-90 = orange
+		if(80 to 90)
+			. = "<font color='#fcba03'>[world.cpu]</font>"
+		// 90-100 = red
+		if(90 to 100)
+			. = "<font color='#eb4034'>[world.cpu]</font>"
+		// >100 = bold red
+		if(100 to INFINITY)
+			. = "<font color='#eb4034'><b>[world.cpu]</b></font>"
+
+/// Colors map cpu number before output.
+/// Same as before, but specially for map cpu.
+/// It uses same colors, but need different number range.
+/datum/controller/master/proc/format_color_cpu_map()
+	var/current_map_cpu = MAPTICK_LAST_INTERNAL_TICK_USAGE
+	switch(current_map_cpu)
+		// 0-30 = green
+		if(0 to 30)
+			. = "<font color='#32a852'>[current_map_cpu]</font>"
+		// 30-60 = orange
+		if(30 to 60)
+			. = "<font color='#fcba03'>[current_map_cpu]</font>"
+		// 60-80 = red
+		if(60 to 80)
+			. = "<font color='#eb4034'>[current_map_cpu]</font>"
+		// >100 = bold red
+		if(80 to INFINITY)
+			. = "<font color='#eb4034'><b>[current_map_cpu]</b></font>"
 
 /datum/controller/master/StartLoadingMap()
 	//disallow more than one map to load at once, multithreading it will just cause race conditions

--- a/code/controllers/subsystems/machines.dm
+++ b/code/controllers/subsystems/machines.dm
@@ -62,9 +62,9 @@ SUBSYSTEM_DEF(machines)
 
 #define INTERNAL_PROCESS_STEP(this_step, check_resumed, proc_to_call, cost_var, next_step)\
 if(current_step == this_step || (check_resumed && !resumed)) {\
-	timer = TICK_USAGE_REAL;\
+	timer = TICK_USAGE;\
 	proc_to_call(resumed);\
-	cost_var = MC_AVERAGE(cost_var, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer));\
+	cost_var = MC_AVERAGE(cost_var, TICK_DELTA_TO_MS(TICK_USAGE - timer));\
 	if(state != SS_RUNNING){\
 		return;\
 	}\
@@ -73,7 +73,7 @@ if(current_step == this_step || (check_resumed && !resumed)) {\
 }
 
 /datum/controller/subsystem/machines/fire(resumed = 0)
-	var/timer = TICK_USAGE_REAL
+	var/timer = TICK_USAGE
 
 	INTERNAL_PROCESS_STEP(SSMACHINES_PIPENETS,TRUE,process_pipenets,cost_pipenets,SSMACHINES_MACHINERY)
 	INTERNAL_PROCESS_STEP(SSMACHINES_MACHINERY,FALSE,process_machinery,cost_machinery,SSMACHINES_POWERNETS)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -555,8 +555,10 @@
 
 	if(client.holder)
 		if(statpanel("MC"))
-			stat("CPU:","[world.cpu]")
+			stat("CPU:", "[Master.format_color_cpu()]")
+			stat("Map CPU:", "[Master.format_color_cpu_map()]")
 			stat("Instances:","[world.contents.len]")
+			stat("World Time:", "[world.time]")
 			stat(null)
 			if(Master)
 				Master.stat_entry()


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

_tick.dm: Replaces some define values in _tick.dm with tgstation numbers.

stoplag(): Replaces sleeps with stoplag() in do_after and do_mob.

map_cpu: Integrates it into tick. Plus there is map cpu indicator in MC panel now, which will... indicate it. Informative.

And colorful numbers.

## Why and what will this PR improve

_tick.dm: I'm not sure if this fine to just update MC/tick defines like that. Most updates which bay got for MC was updates straight from tg, and this is why I think some tg's things compatible with nebula.
But while being skeptical, I think values in this PR might be weird and not performant for our codebase, so I asking @Lohikar to check if values are fine.

stoplag(): Lohikar said what stoplag() is fine and better than sleep() in do_after() and do_mob(). Loaf said, that this doesn't seems fine, so I probably will continue to discuss this with them to find answer what to do with it.

map_cpu: The indicator is useful - it gives info how server loaded while dispatching map information to players. 
Seems tgstation integrated map_cpu into tick, so I think this too should be noted before merging.

## Authorship

tgstation for initial tick define values
Vallat for colored CPU numbers idea