### PR TITLE
Lighting: Remove goto

### DIFF
--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -348,9 +348,7 @@
 
 	var/should_do_wedge = light_angle && !facing_opaque
 
-	FOR_DVIEW(T, NONUNIT_CEILING(actual_range, 1), source_turf, 0)
-		check_t:
-
+	FOR_DVIEW(T, NONUNIT_CEILING(actual_range, 1), source_turf, 0) do
 		if (should_do_wedge)	// Directional lighting coordinate filter.
 			test_x = T.x - test_x_offset
 			test_y = T.y - test_y_offset
@@ -382,13 +380,9 @@
 
 		turfs += T
 
-		// Note: above is defined on ALL turfs, but below is only defined on OPEN TURFS.
-
-		// Upwards lights are handled at the corner level, so only search down.
-		if (T && (T.z_flags & ZM_ALLOW_LIGHTING) && T.below)
-			T = T.below
-			goto check_t
-
+	// Upwards lights are handled at the corner level, so only search down.
+	//  This is a do-while associated with the FOR_DVIEW above.
+	while (T && (T.z_flags & ZM_ALLOW_LIGHTING) && (T = T.below))
 	END_FOR_DVIEW
 
 	LAZYINITLIST(affecting_turfs)

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -39,7 +39,7 @@ exactly 10 ">> uses" '>>(?!>)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 20 "text2path uses" 'text2path'
 exactly 4 "update_icon() override" '/update_icon\((.*)\)'  -P
-exactly 1 "goto uses" 'goto '
+exactly 0 "goto uses" 'goto '
 exactly 6 "atom/New uses" '^/(obj|atom|area|mob|turf).*/New\('
 exactly 1 "decl/New uses" '^/decl.*/New\('
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'


### PR DESCRIPTION
Turns out that DM procs with labels are slower than normal procs because of the utterly cursed way they're implemented.

This implementation does the same thing with a do-while instead, but avoids the indentation increase with a mildly cursed placement of the do-while. Functionally equivalent to the old code.