### PR TITLE
sstimer: fix potential bucket corruption in timer reset_buckets

### DIFF
--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -259,6 +259,12 @@ SUBSYSTEM_DEF(timer)
 	// Add all timed events from the secondary queue as well
 	alltimers += second_queue
 
+	for (var/datum/timedevent/t in alltimers)
+		t.bucket_joined = FALSE
+		t.bucket_pos = -1
+		t.prev = null
+		t.next = null
+
 	// If there are no timers being tracked by the subsystem,
 	// there is no need to do any further rebuilding
 	if (!length(alltimers))
@@ -302,6 +308,7 @@ SUBSYSTEM_DEF(timer)
 		new_bucket_count++
 		var/bucket_pos = BUCKET_POS(timer)
 		timer.bucket_pos = bucket_pos
+		timer.bucket_joined = TRUE
 
 		var/datum/timedevent/bucket_head = bucket_list[bucket_pos]
 		if (!bucket_head)

--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -259,7 +259,7 @@ SUBSYSTEM_DEF(timer)
 	// Add all timed events from the secondary queue as well
 	alltimers += second_queue
 
-	for (var/datum/timedevent/t in alltimers)
+	for (var/datum/timedevent/t as anything in alltimers)
 		t.bucket_joined = FALSE
 		t.bucket_pos = -1
 		t.prev = null


### PR DESCRIPTION
## Description of changes
ports semoro's fix related to potential SStimer bucket corruption
> Hi! The essence of the fix is that earlier timers with a built linkedlist could get into the second queue, which could cause an incorrect state
It works super stupidly, resets the state to the original correct one

## Why and what will this PR improve
this should fix potential error

## Authorship
semoro (https://github.com/ss220-space/Paradise/pull/511)