### PR TITLE
pr-template: cut empty lines, author name override comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,31 +1,26 @@
+<!-- !! PLEASE, READ THIS !! -->
 <!-- We recommend to check the contributing page before opening pull requests. -->
 <!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
-
-<!-- !! PLEASE, READ THIS !! -->
 <!-- If you opening a pull request which changes A LOT icon/map files: -->
-<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
+<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
 <!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->
 
 ## Description of changes
-
 <!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
 
 ## Why and what will this PR improve
-
 <!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
 
 ## Authorship
-
 <!-- Describe original authors of changes to credit them. -->
 
 ## Changelog
-
+<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
 :cl:
 prefix:
 /:cl:
 
 <!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
-
 - bugfix
 - balance
 - tweak
@@ -39,5 +34,4 @@ prefix:
 - spellcheck
 - experiment
 - admin
-
 -->


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Removes nonsense empty lines from pull-request template and adds comment about the author name override.

## Why and what will this PR improve
Discord webhook show text in filled PR template with extra empty line after headings, that looks less compact and prevent to show next lines. Now it should look a bit more compact.