### PR TITLE
screen-movable: fixes loc offset on assign

### DIFF
--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -8,4 +8,4 @@
 		var/list/screen_loc_params = splittext(PM["screen-loc"], ",")
 		var/list/x_data = splittext(screen_loc_params[1], ":")
 		var/list/y_data = splittext(screen_loc_params[2], ":")
-		screen_loc = "LEFT+[x_data[1]]:[text2num(x_data[2])-16],BOTTOM+[y_data[1]]:[text2num(y_data[2])-16]"
+		screen_loc = "LEFT+[x_data[1]]:[text2num(x_data[2])-(1.5 * world.icon_size)],BOTTOM+[y_data[1]]:[text2num(y_data[2])-(1.5 * world.icon_size)]"


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
moving movable screen objects now respect world icon size

## Why and what will this PR improve
works now as intended
![2021-12-18_12-33-13](https://user-images.githubusercontent.com/44920739/146636614-3a1bd3a8-e8b4-4bb5-81ed-af0a64d3583d.gif)