### PR TITLE
window: removes border check flag from fulltile types

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -51,6 +51,7 @@
 		if(!isnull(dir_to_set))
 			set_dir(dir_to_set)
 		if(is_fulltile())
+			atom_flags &= ~ATOM_FLAG_CHECKS_BORDER
 			layer = FULL_WINDOW_LAYER
 		. = INITIALIZE_HINT_LATELOAD
 


### PR DESCRIPTION
## Description of changes
Removes ATOM_FLAG_CHECKS_BORDER from fulltile windows.

## Why and what will this PR improve
* fixes https://github.com/NebulaSS13/Nebula/issues/2211

Didn't test, so can't 100% be sure that this fix the issue.

## Authorship
Myaself