### PR TITLE
dbban: adds database based ban panel to verbs list

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -94,6 +94,7 @@ var/global/list/admin_verbs_admin = list(
 	/datum/admins/proc/show_aspects
 )
 var/global/list/admin_verbs_ban = list(
+	/client/proc/DB_ban_panel,
 	/client/proc/unban_panel,
 	/client/proc/jobbans
 	)

--- a/code/modules/admin/dbban/functions.dm
+++ b/code/modules/admin/dbban/functions.dm
@@ -294,7 +294,7 @@
 /client/proc/DB_ban_panel()
 	set category = "Admin"
 	set name = "Banning Panel"
-	set desc = "Edit admin permissions"
+	set desc = "Allow edit existing bans or create new ones."
 
 	if(!holder)
 		return

--- a/nebula.dme
+++ b/nebula.dme
@@ -1386,7 +1386,7 @@
 #include "code\modules\admin\buildmode\room_builder.dm"
 #include "code\modules\admin\buildmode\throw_at.dm"
 #include "code\modules\admin\callproc\callproc.dm"
-#include "code\modules\admin\DB ban\functions.dm"
+#include "code\modules\admin\dbban\functions.dm"
 #include "code\modules\admin\permissionverbs\permissionedit.dm"
 #include "code\modules\admin\secrets\admin_secrets\admin_logs.dm"
 #include "code\modules\admin\secrets\admin_secrets\bombing_list.dm"


### PR DESCRIPTION
## Description of changes
Adds database ban panel in admin verbs list.
Renamed DB ban folder to lowercase and underscore version.

## Why and what will this PR improve
Banning in the Player Panel is maybe faster, but such place don't allow you to view existing bans. Most admins I know don't use PP's because of their limits.
Afaik it should work if nobody touched it. Since we don't edit db fields much, it should work with stock neb's databases.

## Authorship
Myself.