### PR TITLE
interface: skin cleanup

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -506,4 +506,4 @@
 /proc/window_flash(var/client_or_usr)
 	if (!client_or_usr)
 		return
-	winset(client_or_usr, "mainwindow", "flash=5")
+	winset(client_or_usr, "window_main", "flash=5")

--- a/code/_helpers/view.dm
+++ b/code/_helpers/view.dm
@@ -1,12 +1,7 @@
 /proc/getviewsize(view)
-	var/viewX
-	var/viewY
 	if(isnum(view))
-		var/totalviewrange = 1 + 2 * view
-		viewX = totalviewrange
-		viewY = totalviewrange
+		var/totalviewrange = (view < 0 ? -1 : 1) + 2 * view
+		return list(totalviewrange, totalviewrange)
 	else
 		var/list/viewrangelist = splittext(view,"x")
-		viewX = text2num(viewrangelist[1])
-		viewY = text2num(viewrangelist[2])
-	return list(viewX, viewY)
+		return list(text2num(viewrangelist[1]), text2num(viewrangelist[2]))

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -95,7 +95,6 @@ var/global/list/gamemode_cache = list()
 	var/banappeals
 	var/wikiurl
 	var/forumurl
-	var/discordurl
 	var/githuburl
 	var/issuereporturl
 
@@ -244,7 +243,7 @@ var/global/list/gamemode_cache = list()
 	var/act_interval = 0.1 SECONDS //Interval for spam prevention.
 
 	var/panic_bunker = FALSE //is the panic bunker enabled?
-	var/panic_bunker_message = "Sorry! The panic bunker is enabled. Please head to our Discord or forum to get yourself added to the panic bunker bypass."
+	var/panic_bunker_message = "Sorry! The panic bunker is enabled. Please head to our staff to get yourself added to the panic bunker bypass."
 
 	var/lock_client_view_x
 	var/lock_client_view_y
@@ -478,9 +477,6 @@ var/global/list/gamemode_cache = list()
 
 				if ("forumurl")
 					config.forumurl = value
-
-				if ("discordurl")
-					config.discordurl = value
 
 				if ("githuburl")
 					config.githuburl = value

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -94,7 +94,7 @@ var/global/list/gamemode_cache = list()
 	var/server
 	var/banappeals
 	var/wikiurl
-	var/forumurl
+	var/communityurl
 	var/githuburl
 	var/issuereporturl
 
@@ -243,7 +243,7 @@ var/global/list/gamemode_cache = list()
 	var/act_interval = 0.1 SECONDS //Interval for spam prevention.
 
 	var/panic_bunker = FALSE //is the panic bunker enabled?
-	var/panic_bunker_message = "Sorry! The panic bunker is enabled. Please head to our staff to get yourself added to the panic bunker bypass."
+	var/panic_bunker_message = "Sorry! The panic bunker is enabled. Please contact an admin to get yourself added to the panic bunker bypass."
 
 	var/lock_client_view_x
 	var/lock_client_view_y
@@ -475,8 +475,8 @@ var/global/list/gamemode_cache = list()
 				if ("wikiurl")
 					config.wikiurl = value
 
-				if ("forumurl")
-					config.forumurl = value
+				if ("communityurl")
+					config.communityurl = value
 
 				if ("githuburl")
 					config.githuburl = value

--- a/code/controllers/subsystems/input.dm
+++ b/code/controllers/subsystems/input.dm
@@ -18,7 +18,7 @@ SUBSYSTEM_DEF(input)
 	macro_set = list(
 	"Any" = "\"KeyDown \[\[*\]\]\"",
 	"Any+UP" = "\"KeyUp \[\[*\]\]\"",
-	"Back" = "\".winset \\\"outputwindow.input.text=\\\"\\\"\\\"\"",
+	"Back" = "\".winset \\\"window_output.input.text=\\\"\\\"\\\"\"",
 	"Escape" = "Reset-Held-Keys"
 	)
 

--- a/code/controllers/subsystems/input.dm
+++ b/code/controllers/subsystems/input.dm
@@ -18,8 +18,7 @@ SUBSYSTEM_DEF(input)
 	macro_set = list(
 	"Any" = "\"KeyDown \[\[*\]\]\"",
 	"Any+UP" = "\"KeyUp \[\[*\]\]\"",
-	"Back" = "\".winset \\\"window_output.input.text=\\\"\\\"\\\"\"",
-	"Escape" = "Reset-Held-Keys"
+	"Back" = "\".winset \\\"window_output.input.text=\\\"\\\"\\\"\""
 	)
 
 // Badmins just wanna have fun ♪

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -24,23 +24,22 @@ var/global/datum/getrev/revdata = new()
 					date = unix2date(unix_time)
 			break
 
-	to_world_log("Running revision:")
-	to_world_log(branch)
-	to_world_log(date)
-	to_world_log(revision)
+	to_world_log("Running revision: [branch] | [date] | [revision].")
 
 /client/verb/showrevinfo()
 	set category = "OOC"
 	set name = "Show Server Revision"
-	set desc = "Check the current server code revision"
+	set desc = "Check the current server code revision."
 
-	to_chat(src, "<b>Client Version:</b> [byond_version]")
-	if(revdata.revision)
-		var/server_revision = revdata.revision
+	to_chat(src, "<b>Client Version:</b> [byond_version].[byond_build].")
+
+	var/server_revision = revdata.revision
+	if(!revdata.revision)
+		to_chat(src, "<b>Server Revision:</b> Revision Unknown.")
+	else
 		if(config.githuburl)
 			server_revision = "<a href='[config.githuburl]/commit/[server_revision]'>[server_revision]</a>"
-		to_chat(src, "<b>Server Revision:</b> [server_revision] - [revdata.branch] - [revdata.date]")
-	else
-		to_chat(src, "<b>Server Revision:</b> Revision Unknown")
-	to_chat(src, "Game ID: <b>[game_id]</b>")
-	to_chat(src, "Current map: [global.using_map.full_name]")
+		to_chat(src, "<b>Server Revision:</b> [revdata.branch] | [revdata.date] | [server_revision].")
+
+	to_chat(src, "Game ID: [SPAN_NOTICE("<b>[global.game_id]</b>")].")
+	to_chat(src, "Current map: [global.using_map.full_name].")

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -217,8 +217,8 @@ var/global/world_topic_last = world.timeofday
 /world/proc/update_status()
 	var/s = "<b>[station_name()]</b>"
 
-	if(config && config.forumurl)
-		s += " (<a href=\"[config.forumurl]\">Community</a>)"
+	if(config && config.communityurl)
+		s += " (<a href=\"[config.communityurl]\">Community</a>)"
 
 	if(config && config.server_name)
 		s = "<b>[config.server_name]</b> &#8212; [s]"

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -217,8 +217,8 @@ var/global/world_topic_last = world.timeofday
 /world/proc/update_status()
 	var/s = "<b>[station_name()]</b>"
 
-	if(config && config.discordurl)
-		s += " (<a href=\"[config.discordurl]\">Discord</a>)"
+	if(config && config.forumurl)
+		s += " (<a href=\"[config.forumurl]\">Community</a>)"
 
 	if(config && config.server_name)
 		s = "<b>[config.server_name]</b> &#8212; [s]"

--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -26,17 +26,9 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 //This proc sends the asset to the client, but only if it needs it.
 //This proc blocks(sleeps) unless verify is set to false
 /proc/send_asset(var/client/client, var/asset_name, var/verify = TRUE, var/check_cache = TRUE)
-	if(!istype(client))
-		if(ismob(client))
-			var/mob/M = client
-			if(M.client)
-				client = M.client
-
-			else
-				return 0
-
-		else
-			return 0
+	client = client.get_client()
+	if(!client)
+		return FALSE
 
 	if(check_cache && (client.cache.Find(asset_name) || client.sending.Find(asset_name)))
 		return 0
@@ -70,17 +62,9 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 
 //This proc blocks(sleeps) unless verify is set to false
 /proc/send_asset_list(var/client/client, var/list/asset_list, var/verify = TRUE)
-	if(!istype(client))
-		if(ismob(client))
-			var/mob/M = client
-			if(M.client)
-				client = M.client
-
-			else
-				return 0
-
-		else
-			return 0
+	client = client.get_client()
+	if(!client)
+		return FALSE
 
 	var/list/unreceived = asset_list - (client.cache + client.sending)
 	if(!unreceived || !unreceived.len)
@@ -261,7 +245,7 @@ var/global/template_file_name = "all_templates.json"
 	var/list/cache = list()
 
 /decl/asset_cache/proc/load()
-	for(var/type in typesof(/datum/asset) - list(/datum/asset, /datum/asset/simple))
+	for(var/type in subtypesof(/datum/asset) - /datum/asset/simple)
 		var/datum/asset/A = new type()
 		A.register()
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -218,7 +218,7 @@ var/global/list/time_prefs_fixed = list()
 	if(!SScharacter_setup.initialized)
 		return
 
-	winshow(user, "preferences_window", TRUE)
+	winshow(user, "window_preferences", TRUE)
 	var/datum/browser/popup = new(user, "preferences_browser", "Character Setup", 800, 800)
 	var/content = {"
 	<script type='text/javascript'>
@@ -232,7 +232,7 @@ var/global/list/time_prefs_fixed = list()
 	"}
 	popup.set_content(content)
 	popup.open(FALSE) // Skip registring onclose on the browser pane
-	onclose(user, "preferences_window", src) // We want to register on the window itself
+	onclose(user, "window_preferences", src) // We want to register on the window itself
 
 /datum/preferences/proc/update_setup_window(mob/user)
 	send_output(user, url_encode(get_content(user)), "preferences_browser:update_content")
@@ -277,16 +277,9 @@ var/global/list/time_prefs_fixed = list()
 	char_render_holders = null
 
 /datum/preferences/proc/process_link(mob/user, list/href_list)
+	if(!user || isliving(user))
+		return
 
-	if(!user)	return
-	if(isliving(user)) return
-
-	if(href_list["preference"] == "open_whitelist_forum")
-		if(config.forumurl)
-			direct_output(user, link(config.forumurl))
-		else
-			to_chat(user, "<span class='danger'>The forum URL is not set in the server configuration.</span>")
-			return
 	update_setup_window(usr)
 	return 1
 

--- a/code/modules/client/ui_style.dm
+++ b/code/modules/client/ui_style.dm
@@ -14,8 +14,7 @@ var/global/all_tooltip_styles = list(
 	"Plasmafire",
 	"Retro",
 	"Slimecore",
-	"Operative",
-	"Clockwork"
+	"Operative"
 	)
 
 /proc/ui_style2icon(ui_style)

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -24,7 +24,7 @@
 
 	//Focus Chat failsafe. Overrides movement checks to prevent WASD.
 	if(!prefs.hotkeys && length(_key) == 1 && _key != "Alt" && _key != "Ctrl" && _key != "Shift")
-		winset(src, null, "outputwindow.input.focus=true ; input.text=[url_encode(_key)]")
+		winset(src, null, "window_output.input.focus=true ; input.text=[url_encode(_key)]")
 		return
 
 	if(length(keys_held) >= HELD_KEY_BUFFER_LENGTH && !keys_held[_key])

--- a/code/modules/keybindings/setup.dm
+++ b/code/modules/keybindings/setup.dm
@@ -54,8 +54,6 @@
 
 /**
  * Manually clears any held keys, in case due to lag or other undefined behavior a key gets stuck.
- *
- * Hardcoded to the ESC key.
  */
 /client/verb/reset_held_keys()
 	set name = "Reset Held Keys"

--- a/code/modules/keybindings/setup.dm
+++ b/code/modules/keybindings/setup.dm
@@ -33,9 +33,9 @@
 		winset(src, "default-\ref[key]", "parent=default;name=[key];command=[command]")
 
 	if(prefs?.hotkeys)
-		winset(src, null, "outputwindow.input.focus=true input.background-color=[COLOR_INPUT_ENABLED]")
+		winset(src, null, "window_output.input.focus=true input.background-color=[COLOR_INPUT_ENABLED]")
 	else
-		winset(src, null, "outputwindow.input.focus=true input.background-color=[COLOR_INPUT_DISABLED]")
+		winset(src, null, "window_output.input.focus=true input.background-color=[COLOR_INPUT_DISABLED]")
 
 	update_special_keybinds()
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -450,7 +450,7 @@
 	if(prefs.lastchangelog != changelog_hash)
 		prefs.lastchangelog = changelog_hash
 		SScharacter_setup.queue_preferences_save(prefs)
-		winset(src, "rpane.changelog", "background-color=none;font-style=;")
+		winset(src, "window_panel_right.button_changelog", "background-color=none;font-style=;")
 
 /mob/verb/cancel_camera()
 	set name = "Cancel Camera View"

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -46,5 +46,6 @@
 	// bolds the changelog button on the interface so we know there are updates.
 	if(client.prefs?.lastchangelog != global.changelog_hash)
 		to_chat(client, SPAN_NOTICE("You have unread updates in the changelog."))
+		winset(src, "window_panel_right.button_changelog", "background-color=#ffcc99")
 		if(config.aggressive_changelog)
 			client.changes()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -421,7 +421,7 @@
 
 /mob/new_player/proc/close_spawn_windows()
 	close_browser(src, "window=latechoices") //closes late choices window
-	close_browser(src, "window=preferences_window") //closes preferences window
+	close_browser(src, "window=window_preferences") //closes preferences window
 	panel.close()
 
 /mob/new_player/proc/check_species_allowed(var/decl/species/S, var/show_alert=1)

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -434,7 +434,7 @@ nanoui is used to open and update nano browser uis
 		return // Will be closed by update_status().
 
 	show_browser(user, get_html(), "window=[window_id];[window_size][window_options]")
-	winset(user, "mapwindow.map", "focus=true") // return keyboard focus to map
+	winset(user, "window_map.map", "focus=true") // return keyboard focus to map
 	on_close_winset()
 	//onclose(user, window_id)
 	SSnano.ui_opened(src)

--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -31,7 +31,7 @@ Notes:
 
 /datum/tooltip
 	var/client/owner
-	var/control = "mainwindow.tooltip"
+	var/control = "window_main.tooltip"
 	var/showing = FALSE
 	var/queueHide = FALSE
 	var/init = FALSE

--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -3,31 +3,33 @@ Tooltips v1.1 - 22/10/15
 Developed by Wire (#goonstation on irc.synirc.net)
 - Added support for screen_loc pixel offsets. Should work. Maybe.
 - Added init function to more efficiently send base vars
+
 Configuration:
 - Set control to the correct skin element (remember to actually place the skin element)
 - Set file to the correct path for the .html file (remember to actually place the html file)
 - Attach the datum to the user client on login, e.g.
-
 /client/New()
 	src.tooltips = new /datum/tooltip(src)
 
 Usage:
 - Define mouse event procs on your (probably HUD) object and simply call the show and hide procs respectively:
-
 /obj/screen/hud
 	MouseEntered(location, control, params)
 		usr.client.tooltip.show(params, title = src.name, content = src.desc)
+
 	MouseExited()
 		usr.client.tooltip.hide()
 
 Customization:
 - Theming can be done by passing the theme var to show() and using css in the html file to change the look
 - For your convenience some pre-made themes are included
+
 Notes:
 - You may have noticed 90% of the work is done via javascript on the client. Gotta save those cycles man.
 - This is entirely untested in any other codebase besides goonstation so I have no idea if it will port nicely. Good luck!
 	- After testing and discussion (Wire, Remie, MrPerson, AnturK) ToolTips are ok and work for /tg/station13
 */
+
 
 /datum/tooltip
 	var/client/owner
@@ -36,28 +38,31 @@ Notes:
 	var/queueHide = FALSE
 	var/init = FALSE
 
+
 /datum/tooltip/New(client/C)
-	if(C)
+	if (C)
 		owner = C
 		show_browser(owner, file2text('code/modules/tooltip/tooltip.html'), "window=[control]")
+
 	..()
 
+
 /datum/tooltip/proc/show(atom/movable/thing, params = null, title = null, content = null, theme = "default", special = "none")
-	if(!thing || !params || (!title && !content) || !owner || !isnum(world.icon_size))
+	if (!thing || !params || (!title && !content) || !owner || !isnum(world.icon_size))
 		return FALSE
-	if(!init)
+	if (!init)
 		//Initialize some vars
 		init = TRUE
 		send_output(owner, list2params(list(world.icon_size, control)), "[control]:tooltip.init")
 
 	showing = TRUE
 
-	if(title && content)
+	if (title && content)
 		title = "<h1>[title]</h1>"
 		content = "<p>[content]</p>"
-	else if(title && !content)
+	else if (title && !content)
 		title = "<p>[title]</p>"
-	else if(!title && content)
+	else if (!title && content)
 		content = "<p>[content]</p>"
 
 	// Strip macros from item names
@@ -65,28 +70,27 @@ Notes:
 	title = replacetext(title, "\improper", "")
 
 	//Make our dumb param object
-	if(params[1] != "i") //Byond Bug: http://www.byond.com/forum/?post=2352648
-		params = "icon-x=16;icon-y=16;[params]" //Put in some placeholders
 	params = {"{ "cursor": "[params]", "screenLoc": "[thing.screen_loc]" }"}
 
 	//Send stuff to the tooltip
 	var/view_size = getviewsize(owner.view)
 	send_output(owner, list2params(list(params, view_size[1] , view_size[2], "[title][content]", theme, special)), "[control]:tooltip.update")
 
-	//ifa hide() was hit while we were showing, run hide() again to avoid stuck tooltips
+	//If a hide() was hit while we were showing, run hide() again to avoid stuck tooltips
 	showing = FALSE
-	if(queueHide)
+	if (queueHide)
 		hide()
 
 	return TRUE
 
+
 /datum/tooltip/proc/hide()
-	if(queueHide)
+	queueHide = showing ? TRUE : FALSE
+
+	if (queueHide)
 		addtimer(CALLBACK(src, .proc/do_hide), 1)
 	else
 		do_hide()
-
-	queueHide = showing ? TRUE : FALSE
 
 	return TRUE
 
@@ -95,17 +99,20 @@ Notes:
 
 /* TG SPECIFIC CODE */
 
+
 //Open a tooltip for user, at a location based on params
 //Theme is a CSS class in tooltip.html, by default this wrapper chooses a CSS class based on the user's UI_style (Midnight, Plasmafire, Retro, etc)
 //Includes sanity.checks
-/proc/openToolTip(mob/user = null, atom/movable/tip_src = null, params = null, title = "", content = "", theme = "")
+/proc/openToolTip(mob/user = null, atom/movable/tip_src = null, params = null,title = "",content = "",theme = "")
 	if(istype(user))
 		if(user.client && user.client.tooltips)
-			if(!theme && user.client.prefs && user.client.prefs.tooltip_style)
-				theme = lowertext(user.client.prefs.tooltip_style)
+			var/ui_style = user?.client?.prefs?.tooltip_style
+			if(!theme && ui_style)
+				theme = lowertext(ui_style)
 			if(!theme)
-				theme = "midnight"
-			user.client.tooltips.show(tip_src, params, title, content, theme)
+				theme = "default"
+			user.client.tooltips.show(tip_src, params,title,content,theme)
+
 
 //Arbitrarily close a user's tooltip
 //Includes sanity checks.
@@ -113,3 +120,4 @@ Notes:
 	if(istype(user))
 		if(user.client && user.client.tooltips)
 			user.client.tooltips.hide()
+

--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -54,9 +54,6 @@
 		.cult .wrap {border-color: #292222;}
 		.cult .content {color: #FF0000; border-color: #4C4343; background-color: #3C3434;}
 
-		.clockcult .wrap {border-color: #170800;}
-		.clockcult .content {color: #B18B25; border-color: #000000; background-color: #5F380E;}
-
 		.pod .wrap {border-color: #052401;}
 		.pod .content {border-color: #326D29; background-color: #569F4B;}
 
@@ -65,12 +62,12 @@
 
 		.hisgrace .wrap {border-color: #7C1414;}
 		.hisgrace .content {color: #15D512; border-color: #9D1414; background-color: #861414;}
-	
+
 		/* TG: Themes */
 		/* ScreenUI */
 		.midnight .wrap {border-color: #2B2B33;}
 		.midnight .content {color: #6087A0; border-color: #2B2B33; background-color: #36363C;}
-		
+
 		.plasmafire .wrap {border-color: #21213D;}
 		.plasmafire .content {color: #FFA800 ; border-color: #21213D; background-color:#1D1D36;}
 
@@ -83,9 +80,6 @@
 		.operative .wrap {border-color: #1E0101;}
 		.operative .content {color: #FFFFFF; border-color: #750000; background-color: #350000;}
 
-		.clockwork .wrap {border-color: #170800;}
-		.clockwork .content {color: #B18B25; border-color: #000000; background-color: #5F380E;}
-		
 
 	</style>
 </head>
@@ -93,7 +87,7 @@
 	<div id="wrap" class="wrap">
 		<div id="content" class="content"></div>
 	</div>
-	<script type="text/javascript" src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
+	<script type="text/javascript" src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
 	<script type="text/javascript">
 		var tooltip = {
 			'tileSize': 32,
@@ -120,32 +114,45 @@
 				window.location = 'byond://winset?id='+tooltip.control+';anchor1=0,0;size=999x999';
 
 				//Get the real icon size according to the client view
+				//FYI, this bit is even more borrowed from goon, our widescreen broke tooltips so I took a look at how they do it
+				//To improve our code. Thanks gooncoders, very cool
 				var mapWidth 		= map['view-size'].x,
 					mapHeight 		= map['view-size'].y,
-					tilesShown 		= tooltip.client_view_w
-					realIconSize 	= mapWidth / tilesShown,
-					resizeRatio		= realIconSize / tooltip.tileSize,
-					//Calculate letterboxing offsets	
+					tilesShownX 	= tooltip.client_view_w
+					tilesShownY 	= tooltip.client_view_h
+					realIconSizeX 	= mapWidth / tilesShownX,
+					realIconSizeY 	= mapHeight / tilesShownY,
+					resizeRatioX	= realIconSizeX / tooltip.tileSize,
+					resizeRatioY	= realIconSizeY / tooltip.tileSize,
+					//Calculate letterboxing offsets
 					leftOffset 		= (map.size.x - mapWidth) / 2,
 					topOffset 		= (map.size.y - mapHeight) / 2;
 
 				//alert(realIconSize + ' | ' +tooltip.tileSize + ' | ' + resizeRatio); //DEBUG
 
-				//Parse out the tile and cursor locations from params (e.g. "icon-x=32;icon-y=29;screen-loc=3:10,15:29")
+				const parameters = new Object();
+
+				//Parse out the contents of params (e.g. "icon-x=32;icon-y=29;screen-loc=3:10,15:29")
+				//It is worth noting that params is not always ordered in the same way. We therefore need to write the code
+				//To load their values in independantly of their order
 				var paramsA = tooltip.params.cursor.split(';');
-				if (paramsA.length < 3) {return false;} //Sometimes screen-loc is never sent ahaha fuck you byond
+				for (var i = 0; i < paramsA.length; i++) {
+					var entry = paramsA[i];
+					var nameAndValue = entry.split("=");
+					parameters[nameAndValue[0]] = nameAndValue[1];
+				}
+
+				//Sometimes screen-loc is never sent ahaha fuck you byond
+				if (!parameters["icon-x"] || !parameters["icon-y"] || !parameters["screen-loc"]) {
+					return false;
+				}
 				//icon-x
-				var iconX = paramsA[0];
-				iconX = iconX.split('=');
-				iconX = parseInt(iconX[1]);
+				var iconX = parseInt(parameters["icon-x"]);
 				//icon-y
-				var iconY = paramsA[1];
-				iconY = iconY.split('=');
-				iconY = parseInt(iconY[1]);
+				var iconY = parseInt(parameters["icon-y"]);
 				//screen-loc
-				var screenLoc = paramsA[2];
-				screenLoc = screenLoc.split('=');
-				screenLoc = screenLoc[1].split(',');
+				var screenLoc = parameters["screen-loc"];
+				screenLoc = screenLoc.split(',');
 				if (screenLoc.length < 2) {return false;}
 				var left = screenLoc[0];
 				var top = screenLoc[1];
@@ -168,7 +175,7 @@
 						if ((iconX + westOffset) !== enteredX) { //Cursor entered on the offset tile
 							left = left + (westOffset < 0 ? 1 : -1);
 						}
-						leftOffset = leftOffset + (westOffset * resizeRatio);
+						leftOffset = leftOffset + (westOffset * resizeRatioX);
 					}
 				}
 
@@ -179,13 +186,13 @@
 						if (northOffset !== 0) {
 							if ((iconY + northOffset) === enteredY) { //Cursor entered on the original tile
 								top--;
-								topOffset = topOffset - ((tooltip.tileSize + northOffset) * resizeRatio);
+								topOffset = topOffset - ((tooltip.tileSize + northOffset) * resizeRatioY);
 							} else { //Cursor entered on the offset tile
 								if (northOffset < 0) { //Offset southwards
-									topOffset = topOffset - ((tooltip.tileSize + northOffset) * resizeRatio);
+									topOffset = topOffset - ((tooltip.tileSize + northOffset) * resizeRatioY);
 								} else { //Offset northwards
 									top--;
-									topOffset = topOffset - (northOffset * resizeRatio);
+									topOffset = topOffset - (northOffset * resizeRatioY);
 								}
 							}
 						}
@@ -198,12 +205,12 @@
 				}
 
 				//Clamp values
-				left = (left < 0 ? 0 : (left > tilesShown ? tilesShown : left));
-				top = (top < 0 ? 0 : (top > tilesShown ? tilesShown : top));
+				left = (left < 0 ? 0 : (left > tilesShownX ? tilesShownX : left));
+				top = (top < 0 ? 0 : (top > tilesShownY ? tilesShownY : top));
 
 				//Calculate where on the screen the popup should appear (below the hovered tile)
-				var posX = Math.round(((left - 1) * realIconSize) + leftOffset + tooltip.padding); //-1 to position at the left of the target tile
-				var posY = Math.round(((tilesShown - top + 1) * realIconSize) + topOffset + tooltip.padding); //+1 to position at the bottom of the target tile
+				var posX = Math.round(((left - 1) * realIconSizeX) + leftOffset + tooltip.padding); //-1 to position at the left of the target tile
+				var posY = Math.round(((tilesShownY - top + 1) * realIconSizeY) + topOffset + tooltip.padding); //+1 to position at the bottom of the target tile
 
 				//alert(mapWidth+' | '+mapHeight+' | '+tilesShown+' | '+realIconSize+' | '+leftOffset+' | '+topOffset+' | '+left+' | '+top+' | '+posX+' | '+posY); //DEBUG
 
@@ -217,11 +224,16 @@
 
 				$wrap.width($wrap.width() + 2); //Dumb hack to fix a bizarre sizing bug
 
-				var docWidth	= $wrap.outerWidth(),
-					docHeight	= $wrap.outerHeight();
+				var pixelRatio = 1;
+				if (window.devicePixelRatio) {
+					pixelRatio = window.devicePixelRatio;
+				}
+
+				var docWidth	= Math.floor($wrap.outerWidth() * pixelRatio),
+					docHeight	= Math.floor($wrap.outerHeight() * pixelRatio);
 
 				if (posY + docHeight > map.size.y) { //Is the bottom edge below the window? Snap it up if so
-					posY = (posY - docHeight) - realIconSize - tooltip.padding;
+					posY = (posY - docHeight) - realIconSizeY - tooltip.padding;
 				}
 
 				//Actually size, move and show the tooltip box

--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -241,7 +241,7 @@
 				tooltip.special = special;
 
 				//Go get the map details
-				window.location = 'byond://winget?callback=tooltip.updateCallback;id=mapwindow.map;property=size,view-size';
+				window.location = 'byond://winget?callback=tooltip.updateCallback;id=window_map.map;property=size,view-size';
 			},
 		};
 	</script>

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -439,7 +439,7 @@ RADIATION_LOWER_LIMIT 0.15
 #PANIC_BUNKER
 
 ## A message when user did not pass the panic bunker.
-#PANIC_BUNKER_MESSAGE Sorry! The panic bunker is enabled. Please head to our Discord or forum to get yourself added to the panic bunker bypass.
+#PANIC_BUNKER_MESSAGE Sorry! The panic bunker is enabled. Please head to our staff to get yourself added to the panic bunker bypass.
 
 ##Clients will be unable to connect unless their version is equal to or higher than this (a number, e.g. 511)
 #MINIMUM_BYOND_VERSION

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -201,11 +201,8 @@ GUEST_BAN
 ## Unlike SERVER, this one shouldn't break auto-reconnect
 #SERVERURL server.net:port
 
-## forum address
-# FORUMURL http://example.com
-
-## discord server permanent invite address
-# DISCORDURL https://discord.gg/example
+## community address
+# COMMUNITYURL http://example.com
 
 ## Wiki address
 # WIKIURL http://example.com
@@ -439,7 +436,7 @@ RADIATION_LOWER_LIMIT 0.15
 #PANIC_BUNKER
 
 ## A message when user did not pass the panic bunker.
-#PANIC_BUNKER_MESSAGE Sorry! The panic bunker is enabled. Please head to our staff to get yourself added to the panic bunker bypass.
+#PANIC_BUNKER_MESSAGE Sorry! The panic bunker is enabled. Please contact an admin to get yourself added to the panic bunker bypass.
 
 ##Clients will be unable to connect unless their version is equal to or higher than this (a number, e.g. 511)
 #MINIMUM_BYOND_VERSION

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -1,68 +1,42 @@
 //Please use mob or src (not usr) in these procs. This way they can be called in the same fashion as procs.
-/client/verb/wiki()
+/client/proc/open_external_page_wrap(url, title)
+	if(!url)
+		to_chat(src, SPAN_WARNING("The [title] page URL is not set in the server configuration."))
+	else if(alert("This will open the [title] page in your browser. Are you sure?",,"Yes","No") == "Yes")
+		send_link(src, url)
+
+/client/verb/open_wiki()
 	set name = "Wiki"
 	set desc = "Visit the wiki."
-	set hidden = 1
-	if(config.wikiurl)
-		if(alert("This will open the wiki in your browser. Are you sure?",,"Yes","No")=="No")
-			return
-		send_link(src, config.wikiurl)
-	else
-		to_chat(src, SPAN_WARNING("The wiki URL is not set in the server configuration."))
-	return
+	set hidden = TRUE
 
-/client/verb/github()
-	set name = "GitHub"
-	set desc = "Visit the GitHub repository."
-	set hidden = 1
-	if(config.githuburl)
-		if(alert("This will open GitHub in your browser. Are you sure?",,"Yes","No")=="No")
-			return
-		send_link(src, config.githuburl)
-	else
-		to_chat(src, SPAN_WARNING("The github URL is not set in the server configuration."))
-	return
+	open_external_page_wrap(config.wikiurl, "wiki")
 
-/client/verb/bugreport()
+/client/verb/open_codebase()
+	set name = "Source Code"
+	set desc = "Visit the codebase repository."
+	set hidden = TRUE
+
+	open_external_page_wrap(config.githuburl, "codebase")
+
+/client/verb/open_report_bug()
 	set name = "Bug Report"
-	set desc = "Visit the GitHub repository to report an issue or bug."
-	set hidden = 1
-	if(config.issuereporturl)
-		if(alert("This will open GitHub in your browser. Are you sure?",,"Yes","No")=="No")
-			return
-		send_link(src, config.issuereporturl)
-	else
-		to_chat(src, SPAN_WARNING("The issue report URL is not set in the server configuration."))
-	return
+	set desc = "Visit the codebase repository to report an issue or bug."
+	set hidden = TRUE
 
-/client/verb/forum()
-	set name = "Forum"
-	set desc = "Visit the forum."
-	set hidden = 1
-	if(config.forumurl)
-		if(alert("This will open the forum in your browser. Are you sure?",,"Yes","No")=="No")
-			return
-		send_link(src, config.forumurl)
-	else
-		to_chat(src, SPAN_WARNING("The forum URL is not set in the server configuration."))
-	return
+	open_external_page_wrap(config.issuereporturl, "codebase")
 
-/client/verb/discord()
-	set name = "Discord"
-	set desc = "Visit the Discord server."
-	set hidden = 1
-	if(config.discordurl)
-		if(alert("This will open the Discord invition link in your browser. Are you sure?",,"Yes","No")=="No")
-			return
-		send_link(src, config.discordurl)
-	else
-		to_chat(src, SPAN_WARNING("The Discord server URL is not set in the server configuration."))
-	return
+/client/verb/open_community()
+	set name = "Community"
+	set desc = "Visit the community page."
+	set hidden = TRUE
+
+	open_external_page_wrap(config.forumurl, "community")
 
 #define RULES_FILE "config/rules.html"
-/client/verb/rules()
+/client/verb/open_rules()
 	set name = "Rules"
 	set desc = "Show Server Rules."
-	set hidden = 1
+	set hidden = TRUE
 	show_browser(src, file(RULES_FILE), "window=rules;size=480x320")
 #undef RULES_FILE

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -31,7 +31,7 @@
 	set desc = "Visit the community page."
 	set category = "OOC"
 
-	open_external_page_wrap(config.forumurl, "community")
+	open_external_page_wrap(config.communityurl, "community")
 
 #define RULES_FILE "config/rules.html"
 /client/verb/open_rules()

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -8,28 +8,28 @@
 /client/verb/open_wiki()
 	set name = "Wiki"
 	set desc = "Visit the wiki."
-	set hidden = TRUE
+	set category = "OOC"
 
 	open_external_page_wrap(config.wikiurl, "wiki")
 
 /client/verb/open_codebase()
 	set name = "Source Code"
 	set desc = "Visit the codebase repository."
-	set hidden = TRUE
+	set category = "OOC"
 
 	open_external_page_wrap(config.githuburl, "codebase")
 
 /client/verb/open_report_bug()
 	set name = "Bug Report"
 	set desc = "Visit the codebase repository to report an issue or bug."
-	set hidden = TRUE
+	set category = "OOC"
 
 	open_external_page_wrap(config.issuereporturl, "codebase")
 
 /client/verb/open_community()
 	set name = "Community"
 	set desc = "Visit the community page."
-	set hidden = TRUE
+	set category = "OOC"
 
 	open_external_page_wrap(config.forumurl, "community")
 
@@ -37,6 +37,6 @@
 /client/verb/open_rules()
 	set name = "Rules"
 	set desc = "Show Server Rules."
-	set hidden = TRUE
+	set category = "OOC"
 	show_browser(src, file(RULES_FILE), "window=rules;size=480x320")
 #undef RULES_FILE

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -149,6 +149,7 @@ window "window_main"
 		is-maximized = true
 		macro = "default"
 		menu = "menu"
+		on-status = ".winset \"status_bar.text=[[*]]\" "
 	elem "split"
 		type = CHILD
 		pos = 0,0
@@ -170,9 +171,9 @@ window "window_main"
 	elem "tooltip"
 		type = BROWSER
 		pos = 0,0
-		size = 999x999
-		anchor1 = -1,-1
-		anchor2 = -1,-1
+		size = 640x440
+		anchor1 = 0,0
+		anchor2 = 100,100
 		is-visible = false
 		saved-params = ""
 
@@ -184,6 +185,7 @@ window "window_map"
 		anchor1 = -1,-1
 		anchor2 = -1,-1
 		saved-params = "pos;size;is-minimized;is-maximized"
+		statusbar = false
 		is-pane = true
 		on-status = ".winset \"status_bar.text=[[*]]\" "
 	elem "map"
@@ -227,6 +229,7 @@ window "window_output"
 		anchor1 = -1,-1
 		anchor2 = -1,-1
 		saved-params = "pos;size;is-minimized;is-maximized"
+		statusbar = false
 		is-pane = true
 		on-status = ".winset \"status_bar.text=[[*]]\" "
 	elem "output"
@@ -242,18 +245,17 @@ window "window_output"
 	elem "button_say"
 		type = BUTTON
 		pos = 0,460
-		size = 50x20
+		size = 40x20
 		anchor1 = 0,100
 		anchor2 = -1,-1
 		saved-params = "is-checked"
 		text = "Say"
 		command = ".winset \"button_say.is-checked=true?input.command=\"!say \\\"\":input.command=\""
-		is-flat = true
 		button-type = pushbox
 	elem "input"
 		type = INPUT
-		pos = 50,460
-		size = 590x20
+		pos = 40,460
+		size = 600x20
 		anchor1 = 0,100
 		anchor2 = 100,100
 		background-color = #d3b5b5
@@ -269,11 +271,13 @@ window "window_panel_right"
 		anchor1 = -1,-1
 		anchor2 = -1,-1
 		saved-params = "pos;size;is-minimized;is-maximized"
+		statusbar = false
 		is-pane = true
+		on-status = ".winset \"status_bar.text=[[*]]\" "
 	elem "panel_right_info"
 		type = CHILD
-		pos = 0,20
-		size = 640x460
+		pos = 0,30
+		size = 640x450
 		anchor1 = 0,0
 		anchor2 = 100,100
 		background-color = none
@@ -283,20 +287,20 @@ window "window_panel_right"
 		is-vert = false
 	elem "button_changelog"
 		type = BUTTON
-		pos = 100,0
-		size = 100x20
-		anchor1 = 16,0
-		anchor2 = 31,0
+		pos = 555,5
+		size = 80x20
+		anchor1 = 87,0
+		anchor2 = 99,0
 		background-color = none
 		saved-params = "is-checked"
 		text = "Changelog"
 		command = "Changelog"
 	elem "button_info_hide"
 		type = BUTTON
-		pos = 0,0
-		size = 100x20
-		anchor1 = 0,0
-		anchor2 = 16,0
+		pos = 5,5
+		size = 80x20
+		anchor1 = 1,0
+		anchor2 = 13,0
 		background-color = none
 		saved-params = "is-checked"
 		text = "Hide Verbs"
@@ -304,20 +308,20 @@ window "window_panel_right"
 		button-type = pushbox
 	elem "button_rules"
 		type = BUTTON
-		pos = 300,0
-		size = 100x20
-		anchor1 = 47,0
-		anchor2 = 63,0
+		pos = 470,5
+		size = 80x20
+		anchor1 = 73,0
+		anchor2 = 86,0
 		background-color = none
 		saved-params = "is-checked"
 		text = "Rules"
 		command = "Rules"
 	elem "button_codex"
 		type = BUTTON
-		pos = 200,0
-		size = 100x20
-		anchor1 = 31,0
-		anchor2 = 47,0
+		pos = 90,5
+		size = 80x20
+		anchor1 = 14,0
+		anchor2 = 27,0
 		background-color = none
 		saved-params = "is-checked"
 		text = "Codex"
@@ -332,6 +336,7 @@ window "window_info"
 		anchor2 = -1,-1
 		saved-params = "pos;size;is-minimized;is-maximized"
 		title = "Info"
+		statusbar = false
 		is-pane = true
 		on-status = ".winset \"status_bar.text=[[*]]\" "
 	elem "info"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -8,256 +8,252 @@ macro "default"
 		name = "SHIFT+UP"
 		command = ".winset :map.right-click=true"
 
+
 menu "menu"
-	elem
+	elem 
 		name = "&File"
 		command = ""
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Save screenshot\tF2"
 		command = ".auto"
 		category = "&File"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Save screenshot as..."
 		command = ".screenshot"
 		category = "&File"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = ""
 		command = ""
 		category = "&File"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Reconnect"
 		command = ".reconnect"
 		category = "&File"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Check ping"
 		command = ".ping"
 		category = "&File"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Quit"
 		command = ".quit"
 		category = "&File"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Size"
 		command = ""
 		saved-params = "is-checked"
-	elem "icon128"
+	elem "icon_size_128"
 		name = "&128x128"
 		command = "SetWindowIconSize 128"
 		category = "&Size"
 		can-check = true
-		group = "size"
+		group = "icon_size"
 		saved-params = "is-checked"
-	elem "icon96"
+	elem "icon_size_96"
 		name = "&96x96"
 		command = "SetWindowIconSize 96"
 		category = "&Size"
 		can-check = true
-		group = "size"
+		group = "icon_size"
 		saved-params = "is-checked"
-	elem "icon64"
+	elem "icon_size_64"
 		name = "&64x64"
 		command = "SetWindowIconSize 64"
 		category = "&Size"
 		is-checked = true
 		can-check = true
-		group = "size"
+		group = "icon_size"
 		saved-params = "is-checked"
-	elem "icon48"
+	elem "icon_size_48"
 		name = "&48x48"
 		command = "SetWindowIconSize 48"
 		category = "&Size"
 		can-check = true
-		group = "size"
+		group = "icon_size"
 		saved-params = "is-checked"
-	elem "icon32"
+	elem "icon_size_32"
 		name = "&32x32"
 		command = "SetWindowIconSize 32"
 		category = "&Size"
 		can-check = true
-		group = "size"
+		group = "icon_size"
 		saved-params = "is-checked"
-	elem
+	elem "icon_size_16"
+		name = "&16x16"
+		command = "SetWindowIconSize 16"
+		category = "&Size"
+		can-check = true
+		group = "icon_size"
+		saved-params = "is-checked"
+	elem 
 		name = "&Scaling"
 		command = ""
 		saved-params = "is-checked"
-	elem "ZM"
+	elem "icon_scale_smooth_scaling"
 		name = "&Smooth Scaling"
 		command = ".winset \"zoommode.is-checked=true?map.zoom-mode=normal:map.zoom-mode=distort\""
 		category = "&Scaling"
 		is-checked = true
 		can-check = true
-		group = "scale"
+		group = "icon_scale"
 		saved-params = "is-checked"
-	elem "NN"
+	elem "icon_scale_nearest_neighbor"
 		name = "&Nearest Neighbor"
-		command = ".winset \"mapwindow.map.zoom-mode=distort\""
+		command = ".winset \"window_map.map.zoom-mode=distort\""
 		category = "&Scaling"
 		can-check = true
-		group = "scale"
+		group = "icon_scale"
 		saved-params = "is-checked"
-	elem "PS"
+	elem "icon_scale_point_sampling"
 		name = "&Point Sampling"
-		command = ".winset \"mapwindow.map.zoom-mode=normal\""
+		command = ".winset \"window_map.map.zoom-mode=normal\""
 		category = "&Scaling"
 		can-check = true
-		group = "scale"
+		group = "icon_scale"
 		saved-params = "is-checked"
-	elem "BL"
+	elem "icon_scale_bilinear"
 		name = "&Bilinear"
-		command = ".winset \"mapwindow.map.zoom-mode=blur\""
+		command = ".winset \"window_map.map.zoom-mode=blur\""
 		category = "&Scaling"
 		can-check = true
-		group = "scale"
+		group = "icon_scale"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Help"
 		command = ""
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Admin help\tF1"
 		command = "adminhelp"
 		category = "&Help"
 		saved-params = "is-checked"
 
-window "mainwindow"
-	elem "mainwindow"
+
+window "window_main"
+	elem "window_main"
 		type = MAIN
 		pos = 281,0
 		size = 640x440
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		is-default = true
-		background-color = #000000
 		saved-params = "pos;size;is-minimized;is-maximized"
 		on-size = "OnResize"
+		statusbar = false
 		is-maximized = true
-		icon = 'icons\\ss13_64.png'
 		macro = "default"
 		menu = "menu"
 	elem "split"
 		type = CHILD
-		pos = 3,0
+		pos = 0,0
 		size = 640x440
 		anchor1 = 0,0
 		anchor2 = 100,100
 		saved-params = "splitter"
-		right = "rpane"
+		left = "window_map"
+		right = "window_panel_right"
 		is-vert = true
 	elem "asset_cache_browser"
 		type = BROWSER
 		pos = 0,0
 		size = 200x200
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		is-visible = false
 		saved-params = ""
 	elem "tooltip"
 		type = BROWSER
 		pos = 0,0
 		size = 999x999
-		anchor1 = none
-		anchor2 = none
-		background-color = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		is-visible = false
 		saved-params = ""
 
-window "mapwindow"
-	elem "mapwindow"
+window "window_map"
+	elem "window_map"
 		type = MAIN
 		pos = 281,0
 		size = 640x480
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		saved-params = "pos;size;is-minimized;is-maximized"
-		titlebar = false
-		statusbar = false
-		can-close = false
-		can-minimize = false
-		can-resize = false
 		is-pane = true
+		on-status = ".winset \"status_bar.text=[[*]]\" "
 	elem "map"
 		type = MAP
 		pos = 0,0
-		size = 640x480
+		size = 640x460
 		anchor1 = 0,0
 		anchor2 = 100,100
 		font-family = "Arial Rounded MT Bold,Arial Black,Arial,sans-serif"
 		font-size = 7
 		is-default = true
-		saved-params = "icon-size;zoom-mode"
-		on-show = ".winset\"mainwindow.split.left=mapwindow\""
-		on-hide = ".winset\"mainwindow.split.left=\""
-	elem "lobbybrowser"
+		saved-params = "icon-size;letterbox;zoom-mode"
+	elem "browser_lobby"
 		type = BROWSER
 		pos = 0,0
-		size = 640x480
+		size = 640x460
 		anchor1 = 0,0
 		anchor2 = 100,100
+		background-color = #000000
 		is-visible = false
 		is-disabled = true
 		saved-params = ""
 	elem "status_bar"
 		type = LABEL
-		pos = 0,464
-		size = 280x16
+		pos = 0,460
+		size = 640x20
 		anchor1 = 0,100
-		anchor2 = none
+		anchor2 = 100,100
 		text-color = #ffffff
 		background-color = #222222
-		is-visible = false
 		border = line
 		saved-params = ""
 		text = ""
 		align = left
 
-window "outputwindow"
-	elem "outputwindow"
+window "window_output"
+	elem "window_output"
 		type = MAIN
-		pos = 281,-30
+		pos = 281,0
 		size = 640x480
-		anchor1 = none
-		anchor2 = none
-		background-color = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		saved-params = "pos;size;is-minimized;is-maximized"
-		titlebar = false
-		statusbar = false
-		can-close = false
-		can-minimize = false
-		can-resize = false
 		is-pane = true
-		outer-size = 654x494
 	elem "output"
 		type = OUTPUT
 		pos = 0,0
-		size = 640x456
+		size = 640x460
 		anchor1 = 0,0
 		anchor2 = 100,100
 		is-default = true
 		saved-params = "max-lines"
 		style = ".system {color:#ff0000;}"
 		max-lines = 0
-	elem "saybutton"
+	elem "button_say"
 		type = BUTTON
-		pos = 600,460
-		size = 40x20
-		anchor1 = 100,100
-		anchor2 = none
-		background-color = none
+		pos = 0,460
+		size = 50x20
+		anchor1 = 0,100
+		anchor2 = -1,-1
+		background-color = #c0c0c0
 		saved-params = "is-checked"
-		text = "Chat"
-		command = ".winset \"saybutton.is-checked=true?input.command=\"!say \\\"\" macrobutton.is-checked=false:input.command=\""
+		text = "Say"
+		command = ".winset \"button_say.is-checked=true?input.command=\"!say \\\"\":input.command=\""
+		is-flat = true
 		button-type = pushbox
 	elem "input"
 		type = INPUT
-		pos = 1,460
-		size = 600x20
+		pos = 50,460
+		size = 590x20
 		anchor1 = 0,100
 		anchor2 = 100,100
 		background-color = #d3b5b5
@@ -265,173 +261,205 @@ window "outputwindow"
 		border = sunken
 		saved-params = "command"
 
-window "rpane"
-	elem "rpane"
+window "window_panel_right"
+	elem "window_panel_right"
 		type = MAIN
 		pos = 281,0
 		size = 640x480
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		saved-params = "pos;size;is-minimized;is-maximized"
 		is-pane = true
-	elem "rpanewindow"
+	elem "panel_right_info"
 		type = CHILD
-		pos = 0,0
-		size = 640x474
+		pos = 0,40
+		size = 640x440
 		anchor1 = 0,0
 		anchor2 = 100,100
-		saved-params = "splitter"
-		right = "outputwindow"
+		background-color = none
+		saved-params = "splitter;left"
+		left = "window_info"
+		right = "window_output"
 		is-vert = false
-	elem "github"
+	elem "button_changelog"
 		type = BUTTON
-		pos = 520,0
-		size = 60x15
-		anchor1 = none
-		anchor2 = none
-		saved-params = "is-checked"
-		text = "GitHub"
-		command = "GitHub"
-	elem "BugReport"
-		type = BUTTON
-		pos = 580,0
-		size = 60x15
-		anchor1 = none
-		anchor2 = none
-		saved-params = "is-checked"
-		text = "Bug Report"
-		command = "Bug-Report"
-	elem "rulesb"
-		type = BUTTON
-		pos = 205,0
-		size = 60x15
-		anchor1 = none
-		anchor2 = none
-		saved-params = "is-checked"
-		text = "Rules"
-		command = "rules"
-		group = "rpanemode"
-	elem "changelog"
-		type = BUTTON
-		pos = 460,0
-		size = 60x15
-		anchor1 = none
-		anchor2 = none
+		pos = 0,0
+		size = 100x20
+		anchor1 = 0,0
+		anchor2 = 16,0
+		background-color = none
 		saved-params = "is-checked"
 		text = "Changelog"
 		command = "Changelog"
-		group = "rpanemode"
-	elem "Lore"
+	elem "button_info_hide"
 		type = BUTTON
-		pos = 265,0
-		size = 60x15
-		anchor1 = none
-		anchor2 = none
-		saved-params = "is-checked"
-		text = "Lore"
-		command = "Lore"
-		group = "rpanemode"
-	elem "forumb"
-		type = BUTTON
-		pos = 385,0
-		size = 60x15
-		anchor1 = none
-		anchor2 = none
-		saved-params = "is-checked"
-		text = "Forum"
-		command = "forum"
-		group = "rpanemode"
-	elem "wikib"
-		type = BUTTON
-		pos = 325,0
-		size = 60x15
-		anchor1 = none
-		anchor2 = none
-		saved-params = "is-checked"
-		text = "Wiki"
-		command = "wiki"
-		group = "rpanemode"
-	elem "textb"
-		type = BUTTON
-		pos = 0,0
-		size = 60x15
-		anchor1 = none
-		anchor2 = none
-		is-visible = false
-		saved-params = "is-checked"
-		text = "Text"
-		command = ".winset \"rpanewindow.left=;\""
-		is-checked = true
-		group = "rpanemode"
-		button-type = pushbox
-	elem "infob"
-		type = BUTTON
-		pos = 60,0
-		size = 60x15
-		anchor1 = none
-		anchor2 = none
-		is-visible = false
-		saved-params = "is-checked"
-		text = "Info"
-		command = ".winset \"rpanewindow.left=infowindow\""
-		group = "rpanemode"
-		button-type = pushbox
-	elem "button_codex"
-		type = BUTTON
-		pos = 133,0
-		size = 60x15
-		anchor1 = none
-		anchor2 = none
-		saved-params = "is-checked"
-		text = "Codex"
-		command = "Codex"
-		group = "rpanemode"
-
-window "preferences_window"
-	elem "preferences_window"
-		type = MAIN
-		pos = 281,0
-		size = 1000x800
-		anchor1 = none
-		anchor2 = none
-		is-visible = false
-		saved-params = "pos;size;is-minimized;is-maximized"
-		statusbar = false
-	elem "preferences_browser"
-		type = BROWSER
-		pos = 0,0
-		size = 800x800
+		pos = 0,20
+		size = 100x20
 		anchor1 = 0,0
-		anchor2 = 80,100
-		saved-params = ""
-	elem "character_preview_map"
-		type = MAP
-		pos = 800,0
-		size = 200x800
-		anchor1 = 80,0
-		anchor2 = 100,100
-		right-click = true
-		saved-params = "zoom;letterbox;zoom-mode"
+		anchor2 = 16,0
+		background-color = #c0c0c0
+		saved-params = "is-checked"
+		text = "Hide Verbs"
+		command = ".winset \"button_info_hide.is-checked!=true ? panel_right_info.left=window_info : panel_right_info.left=\""
+		button-type = pushbox
+	elem "tab_buttons"
+		type = TAB
+		pos = 100,0
+		size = 540x40
+		anchor1 = 16,0
+		anchor2 = 100,0
+		background-color = none
+		saved-params = "current-tab"
+		tabs = "tab_window_community,tab_window_references"
+		current-tab = "tab_window_community"
+		multi-line = false
 
-window "infowindow"
-	elem "infowindow"
+window "window_info"
+	elem "window_info"
 		type = MAIN
 		pos = 281,0
 		size = 640x480
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		saved-params = "pos;size;is-minimized;is-maximized"
 		title = "Info"
 		is-pane = true
 	elem "info"
 		type = INFO
 		pos = 0,0
-		size = 638x477
+		size = 640x480
 		anchor1 = 0,0
 		anchor2 = 100,100
 		is-default = true
 		saved-params = ""
 		highlight-color = #00aa00
-		on-show = ".winset\"rpane.infob.is-visible=true;rpane.textb.is-visible=true rpane.infob.is-checked=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0 rpane.rpanewindow.left=infowindow\""
-		on-hide = ".winset\"rpane.infob.is-visible=false;rpane.textb.is-visible=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0 rpane.rpanewindow.left=\""
+		prefix-color = #002eb8
+
+window "window_preferences"
+	elem "window_preferences"
+		type = MAIN
+		pos = 281,0
+		size = 1280x1000
+		anchor1 = -1,-1
+		anchor2 = -1,-1
+		is-visible = false
+		saved-params = "pos;size;is-minimized;is-maximized"
+		statusbar = false
+	elem "preferences_browser"
+		type = BROWSER
+		pos = 0,0
+		size = 960x1000
+		anchor1 = 0,0
+		anchor2 = 75,100
+		saved-params = ""
+	elem "character_preview_map"
+		type = MAP
+		pos = 960,0
+		size = 320x1000
+		anchor1 = 75,0
+		anchor2 = 100,100
+		right-click = true
+		saved-params = "zoom;letterbox;zoom-mode"
+
+window "tab_window_community"
+	elem "tab_window_community"
+		type = MAIN
+		pos = 281,0
+		size = 480x14
+		anchor1 = -1,-1
+		anchor2 = -1,-1
+		saved-params = "pos;size;is-minimized;is-maximized"
+		title = "Community"
+		titlebar = false
+		statusbar = false
+		can-close = false
+		can-minimize = false
+		can-resize = false
+		is-pane = true
+	elem "button_rules"
+		type = BUTTON
+		pos = 80,0
+		size = 80x14
+		anchor1 = 17,0
+		anchor2 = 33,0
+		background-color = #c0c0c0
+		saved-params = "is-checked"
+		text = "Rules"
+		command = "Rules"
+	elem "button_community"
+		type = BUTTON
+		pos = 0,0
+		size = 80x14
+		anchor1 = 0,0
+		anchor2 = 17,0
+		background-color = #c0c0c0
+		saved-params = "is-checked"
+		text = "Community"
+		command = "Community"
+	elem "button_codebase"
+		type = BUTTON
+		pos = 160,0
+		size = 80x14
+		anchor1 = 33,0
+		anchor2 = 50,0
+		background-color = #c0c0c0
+		saved-params = "is-checked"
+		text = "Codebase"
+		command = "Source-Code"
+	elem "button_report_bug"
+		type = BUTTON
+		pos = 240,0
+		size = 80x14
+		anchor1 = 50,0
+		anchor2 = 67,0
+		background-color = #c0c0c0
+		saved-params = "is-checked"
+		text = "Bug Report"
+		command = "Bug-Report"
+
+window "tab_window_references"
+	elem "tab_window_references"
+		type = MAIN
+		pos = 281,0
+		size = 480x14
+		anchor1 = -1,-1
+		anchor2 = -1,-1
+		saved-params = "pos;size;is-minimized;is-maximized"
+		title = "Game References"
+		titlebar = false
+		statusbar = false
+		can-close = false
+		can-minimize = false
+		can-resize = false
+		is-pane = true
+	elem "button_lore"
+		type = BUTTON
+		pos = 80,0
+		size = 80x14
+		anchor1 = 17,0
+		anchor2 = 33,0
+		background-color = #c0c0c0
+		saved-params = "is-checked"
+		text = "Lore"
+		command = "Lore"
+	elem "button_wiki"
+		type = BUTTON
+		pos = 160,0
+		size = 80x14
+		anchor1 = 33,0
+		anchor2 = 50,0
+		background-color = #c0c0c0
+		saved-params = "is-checked"
+		text = "Wiki"
+		command = "Wiki"
+	elem "button_codex"
+		type = BUTTON
+		pos = 0,0
+		size = 80x14
+		anchor1 = 0,0
+		anchor2 = 17,0
+		background-color = #c0c0c0
+		saved-params = "is-checked"
+		text = "Codex"
+		command = "Codex"
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -188,6 +188,7 @@ window "window_map"
 		statusbar = false
 		is-pane = true
 		on-status = ".winset \"status_bar.text=[[*]]\" "
+		on-size = "OnResize"
 	elem "map"
 		type = MAP
 		pos = 0,0

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -244,7 +244,6 @@ window "window_output"
 		size = 50x20
 		anchor1 = 0,100
 		anchor2 = -1,-1
-		background-color = #c0c0c0
 		saved-params = "is-checked"
 		text = "Say"
 		command = ".winset \"button_say.is-checked=true?input.command=\"!say \\\"\":input.command=\""
@@ -272,8 +271,8 @@ window "window_panel_right"
 		is-pane = true
 	elem "panel_right_info"
 		type = CHILD
-		pos = 0,40
-		size = 640x440
+		pos = 0,20
+		size = 640x460
 		anchor1 = 0,0
 		anchor2 = 100,100
 		background-color = none
@@ -283,36 +282,45 @@ window "window_panel_right"
 		is-vert = false
 	elem "button_changelog"
 		type = BUTTON
-		pos = 0,0
+		pos = 100,0
 		size = 100x20
-		anchor1 = 0,0
-		anchor2 = 16,0
+		anchor1 = 16,0
+		anchor2 = 31,0
 		background-color = none
 		saved-params = "is-checked"
 		text = "Changelog"
 		command = "Changelog"
 	elem "button_info_hide"
 		type = BUTTON
-		pos = 0,20
+		pos = 0,0
 		size = 100x20
 		anchor1 = 0,0
 		anchor2 = 16,0
-		background-color = #c0c0c0
+		background-color = none
 		saved-params = "is-checked"
 		text = "Hide Verbs"
 		command = ".winset \"button_info_hide.is-checked!=true ? panel_right_info.left=window_info : panel_right_info.left=\""
 		button-type = pushbox
-	elem "tab_buttons"
-		type = TAB
-		pos = 100,0
-		size = 540x40
-		anchor1 = 16,0
-		anchor2 = 100,0
+	elem "button_rules"
+		type = BUTTON
+		pos = 300,0
+		size = 100x20
+		anchor1 = 47,0
+		anchor2 = 63,0
 		background-color = none
-		saved-params = "current-tab"
-		tabs = "tab_window_community,tab_window_references"
-		current-tab = "tab_window_community"
-		multi-line = false
+		saved-params = "is-checked"
+		text = "Rules"
+		command = "Rules"
+	elem "button_codex"
+		type = BUTTON
+		pos = 200,0
+		size = 100x20
+		anchor1 = 31,0
+		anchor2 = 47,0
+		background-color = none
+		saved-params = "is-checked"
+		text = "Codex"
+		command = "Codex"
 
 window "window_info"
 	elem "window_info"
@@ -360,106 +368,4 @@ window "window_preferences"
 		anchor2 = 100,100
 		right-click = true
 		saved-params = "zoom;letterbox;zoom-mode"
-
-window "tab_window_community"
-	elem "tab_window_community"
-		type = MAIN
-		pos = 281,0
-		size = 480x14
-		anchor1 = -1,-1
-		anchor2 = -1,-1
-		saved-params = "pos;size;is-minimized;is-maximized"
-		title = "Community"
-		titlebar = false
-		statusbar = false
-		can-close = false
-		can-minimize = false
-		can-resize = false
-		is-pane = true
-	elem "button_rules"
-		type = BUTTON
-		pos = 80,0
-		size = 80x14
-		anchor1 = 17,0
-		anchor2 = 33,0
-		background-color = #c0c0c0
-		saved-params = "is-checked"
-		text = "Rules"
-		command = "Rules"
-	elem "button_community"
-		type = BUTTON
-		pos = 0,0
-		size = 80x14
-		anchor1 = 0,0
-		anchor2 = 17,0
-		background-color = #c0c0c0
-		saved-params = "is-checked"
-		text = "Community"
-		command = "Community"
-	elem "button_codebase"
-		type = BUTTON
-		pos = 160,0
-		size = 80x14
-		anchor1 = 33,0
-		anchor2 = 50,0
-		background-color = #c0c0c0
-		saved-params = "is-checked"
-		text = "Codebase"
-		command = "Source-Code"
-	elem "button_report_bug"
-		type = BUTTON
-		pos = 240,0
-		size = 80x14
-		anchor1 = 50,0
-		anchor2 = 67,0
-		background-color = #c0c0c0
-		saved-params = "is-checked"
-		text = "Bug Report"
-		command = "Bug-Report"
-
-window "tab_window_references"
-	elem "tab_window_references"
-		type = MAIN
-		pos = 281,0
-		size = 480x14
-		anchor1 = -1,-1
-		anchor2 = -1,-1
-		saved-params = "pos;size;is-minimized;is-maximized"
-		title = "Game References"
-		titlebar = false
-		statusbar = false
-		can-close = false
-		can-minimize = false
-		can-resize = false
-		is-pane = true
-	elem "button_lore"
-		type = BUTTON
-		pos = 80,0
-		size = 80x14
-		anchor1 = 17,0
-		anchor2 = 33,0
-		background-color = #c0c0c0
-		saved-params = "is-checked"
-		text = "Lore"
-		command = "Lore"
-	elem "button_wiki"
-		type = BUTTON
-		pos = 160,0
-		size = 80x14
-		anchor1 = 33,0
-		anchor2 = 50,0
-		background-color = #c0c0c0
-		saved-params = "is-checked"
-		text = "Wiki"
-		command = "Wiki"
-	elem "button_codex"
-		type = BUTTON
-		pos = 0,0
-		size = 80x14
-		anchor1 = 0,0
-		anchor2 = 17,0
-		background-color = #c0c0c0
-		saved-params = "is-checked"
-		text = "Codex"
-		command = "Codex"
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -228,6 +228,7 @@ window "window_output"
 		anchor2 = -1,-1
 		saved-params = "pos;size;is-minimized;is-maximized"
 		is-pane = true
+		on-status = ".winset \"status_bar.text=[[*]]\" "
 	elem "output"
 		type = OUTPUT
 		pos = 0,0
@@ -332,6 +333,7 @@ window "window_info"
 		saved-params = "pos;size;is-minimized;is-maximized"
 		title = "Info"
 		is-pane = true
+		on-status = ".winset \"status_bar.text=[[*]]\" "
 	elem "info"
 		type = INFO
 		pos = 0,0

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -344,18 +344,18 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 /datum/map/proc/show_titlescreen(client/C)
 	set waitfor = FALSE
 
-	winset(C, "lobbybrowser", "is-disabled=false;is-visible=true")
+	winset(C, "browser_lobby", "is-disabled=false;is-visible=true")
 
 	show_browser(C, current_lobby_screen, "file=titlescreen.gif;display=0")
 
 	if(isnewplayer(C.mob))
 		var/mob/new_player/player = C.mob
-		show_browser(C, player.get_lobby_browser_html(), "window=lobbybrowser")
+		show_browser(C, player.get_lobby_browser_html(), "window=browser_lobby")
 
 /datum/map/proc/hide_titlescreen(client/C)
 	if(C.mob) // Check if the client is still connected to something
 		// Hide title screen, allowing player to see the map
-		winset(C, "lobbybrowser", "is-disabled=true;is-visible=false")
+		winset(C, "browser_lobby", "is-disabled=true;is-visible=false")
 
 /datum/map/proc/update_titlescreen(new_screen)
 	current_lobby_screen = new_screen || pick(lobby_screens)


### PR DESCRIPTION
## Description of changes
![изображение](https://user-images.githubusercontent.com/44920739/168700749-7c24292e-6b8c-4b5e-a6e1-5cc9b88da35a.png)

* Cleanups skin.dmf and interface related things:
  * All skins elements renamed in flavor of name standardization.
  * Fixes weird elements offset on the right side of the screen.
  * Most buttons are gone now, only four left.
![изображение](https://user-images.githubusercontent.com/44920739/168700656-1406db57-f914-44d7-b325-5e93c849c3d1.png)
  * Replaces default status bar with alternative implementation using label element.
  * Prefix in the info panel use blue color now.

* Not skin related changes:
  * Kills discord button.
  * Renames forum button to community.
  * Shuffles Show Server Revision. Now it prints everything, but if server don't have the repository link set, the link won't be created. The output style will look like `branch-example | 2022-04-28 | hash`.
![изображение](https://user-images.githubusercontent.com/44920739/165672279-34c65e03-e06a-4f17-9b00-b8957e0dd905.png)
  * Fixes tooltips offsets. Removes clockcult theme. Updates jquery script link.

## Why and what will this PR improve
I wanted to redesign interface to be more Antimonium-like fullscreen interface with dark layout without borders, yet I'm only able to cleanup things right now!

## Authorship
tgstation: status bar label code.
me: everything else.