### PR TITLE
ventcrawl: diagonal direction no longer breaks movement

### DIFF
--- a/code/__defines/directions.dm
+++ b/code/__defines/directions.dm
@@ -16,6 +16,8 @@
 #define CORNER_EASTWEST         CORNER_COUNTERCLOCKWISE
 #define CORNER_NORTHSOUTH       CORNER_CLOCKWISE
 
+#define FIRST_DIR(X) ((X) & -(X))
+
 /*
 	turn() is weird:
 		turn(icon, angle) turns icon by angle degrees clockwise

--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -18,10 +18,8 @@
 	if(!config.allow_diagonal_movement)
 		if(movement_dir & user.last_move_dir_pressed)
 			movement_dir = user.last_move_dir_pressed
-		else if (movement_dir == NORTHEAST || movement_dir == NORTHWEST)
-			movement_dir = NORTH
-		else if (movement_dir == SOUTHEAST || movement_dir == SOUTHWEST)
-			movement_dir = SOUTH
+		else
+			movement_dir = FIRST_DIR(movement_dir)
 
 	if(movement_dir) //If we're not moving, don't compensate, as byond will auto-fill dir otherwise
 		movement_dir = turn(movement_dir, -dir2angle(user.dir)) //By doing this we ensure that our input direction is offset by the client (camera) direction

--- a/code/modules/ventcrawl/ventcrawl_atmospherics.dm
+++ b/code/modules/ventcrawl/ventcrawl_atmospherics.dm
@@ -15,7 +15,10 @@
 /obj/machinery/atmospherics/relaymove(mob/living/user, direction)
 	if(user.loc != src || !(direction & initialize_directions)) //can't go in a way we aren't connecting to
 		return
-	ventcrawl_to(user,findConnecting(direction),direction)
+
+	// Only cardinals allowed.
+	direction = FIRST_DIR(direction)
+	ventcrawl_to(user,findConnecting(direction), direction)
 
 /obj/machinery/atmospherics/proc/ventcrawl_to(var/mob/living/user, var/obj/machinery/atmospherics/target_move, var/direction)
 	if(target_move)


### PR DESCRIPTION
## Description of changes
Strips diagonal directions on move.

## Why and what will this PR improve
Bugfix. Mobs should not leave pipes because of diagonal move.

## Authorship
https://github.com/ss220-space/Baystation12/pull/95
