### PR TITLE
fix: fix looping APC sound

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -99,7 +99,7 @@ var/global/list/all_apcs = list()
 	initial_access = list(access_engine_equip)
 	clicksound = "switch"
 	layer = ABOVE_WINDOW_LAYER
-	var/needs_powerdown_sound
+	var/powered_down = FALSE
 	var/area/area
 	var/areastring = null
 	var/shorted = 0
@@ -612,12 +612,13 @@ var/global/list/all_apcs = list()
 		area.power_change()
 
 	var/obj/item/cell/cell = get_cell()
-	if(!cell || cell.charge <= 0)
-		if(needs_powerdown_sound == TRUE)
+	if(!powered_down)
+		if(!cell || cell.charge <= 0)
 			playsound(src, 'sound/machines/apc_nopower.ogg', 75, 0)
-			needs_powerdown_sound = FALSE
-		else
-			needs_powerdown_sound = TRUE
+			powered_down  = TRUE
+
+	else if(cell?.charge > 0)
+		powered_down  = FALSE
 
 /obj/machinery/power/apc/proc/isWireCut(var/wireIndex)
 	return wires.IsIndexCut(wireIndex)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

Add proper logic into APC status check before playing power down sound.

## Why and what will this PR improve

Remove annoying infinite APC power down sound.

## Authorship

@MarinaGryphon @Gaxeer

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
bugfix: fix looping APC power down sound
/:cl:

