### PR TITLE
fix: grabbed dead mobs now able to move after the grabber

### DIFF
--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -13,12 +13,15 @@
 		control_object.set_dir(direction)
 
 // Death handling
-/datum/movement_handler/mob/death/DoMove()
-	if(mob.stat != DEAD)
+/datum/movement_handler/mob/death/DoMove(var/direction, var/mob/mover)
+	if(mob != mover || mob.stat != DEAD)
 		return
+
 	. = MOVEMENT_HANDLED
+
 	if(!mob.client)
 		return
+
 	mob.ghostize()
 
 // Incorporeal/Ghost movement


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

It's was impossible to make dead mob move after the grabber. Now it is.

## Why and what will this PR improve

fix the bug with grab-moving dead mob

## Authorship

@Gaxeer

## Changelog

:cl:
bugfix: fix the bug with grab-moving dead mob
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
