### PR TITLE
Fix runtime in humans.dm:112

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -109,7 +109,7 @@ var/global/list/image/splatter_cache=list()
 		if(l_foot)
 			l_foot.add_coating(chemical, amount, transferred_data)
 		if(r_foot)
-			l_foot.add_coating(chemical, amount, transferred_data)
+			r_foot.add_coating(chemical, amount, transferred_data)
 	else if (perp.buckled && istype(perp.buckled, /obj/structure/bed/chair/wheelchair))
 		var/obj/structure/bed/chair/wheelchair/W = perp.buckled
 		W.bloodiness = 4


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
The wrong var was used, so now it uses the right one.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
Fixes a runtime in humans.dm:112 that occurred any time someone missing a left foot walked on a blood decal.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Me.
<!-- Describe original authors of changes to credit them. -->
