### PR TITLE
Fix gamemode rolling

### DIFF
--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -8,7 +8,7 @@
 		if(player.current.faction != MOB_FACTION_NEUTRAL)
 			return FALSE
 
-	if(!player.assigned_job || is_type_in_list(player.assigned_job, blacklisted_jobs))
+	if(player.assigned_job && is_type_in_list(player.assigned_job, blacklisted_jobs))
 		return FALSE
 
 	if(!ignore_role)

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -8,20 +8,18 @@
 		if(player.current.faction != MOB_FACTION_NEUTRAL)
 			return FALSE
 
-	if(player.assigned_job && is_type_in_list(player.assigned_job, blacklisted_jobs))
-		return FALSE
-
 	if(!ignore_role)
 		if(player.current && player.current.client)
 			var/client/C = player.current.client
 			// Limits antag status to clients above player age, if the age system is being used.
 			if(C && config.use_age_restriction_for_jobs && isnum(C.player_age) && isnum(min_player_age) && (C.player_age < min_player_age))
 				return FALSE
-		if(is_type_in_list(player.assigned_job, restricted_jobs))
-			return FALSE
-		for(var/event_tag in blocked_job_event_categories)
-			if(event_tag in player.assigned_job.event_categories)
+		if(player.assigned_job)
+			if(is_type_in_list(player.assigned_job, blacklisted_jobs) || is_type_in_list(player.assigned_job, restricted_jobs))
 				return FALSE
+			for(var/event_tag in blocked_job_event_categories)
+				if(event_tag in player.assigned_job.event_categories)
+					return FALSE
 		if(player.current && (player.current.status_flags & NO_ANTAG))
 			return FALSE
 	return TRUE


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Players without a job, i.e. before gamemode start, were blacklisted from becoming antags. This means startRequirements will always fail in the lobby for all gamemodes with antagonists.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
Secret will now select gamemodes other than Extended.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Me.
<!-- Describe original authors of changes to credit them. -->

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
bugfix: Gamemodes with antagonists can now roll in Secret.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
