### PR TITLE
You can force move mob on catwalk in passive grab

### DIFF
--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -79,6 +79,19 @@
 	if(!QDELETED(src) && severity != 3)
 		physically_destroyed()
 
+/obj/structure/catwalk/grab_attack(var/obj/item/grab/G)
+	var/mob/living/affecting_mob = G.get_affecting_mob()
+	if(atom_flags & ATOM_FLAG_CLIMBABLE)
+		var/obj/occupied = turf_is_crowded()
+		if (occupied)
+			to_chat(G.assailant, SPAN_WARNING("There's \a [occupied] in the way."))
+			return TRUE
+		G.affecting.forceMove(src.loc)
+		if(affecting_mob)
+			SET_STATUS_MAX(affecting_mob, STAT_WEAK, rand(2,5))
+		visible_message(SPAN_DANGER("[G.assailant] puts [G.affecting] on \the [src]."))
+		return TRUE
+
 /obj/structure/catwalk/attack_robot(var/mob/user)
 	if(Adjacent(user))
 		attack_hand(user)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
You can force move mob on catwalk in passive grab
## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The catwalk has no logic for moving characters on it in a passive grab, and it is subject to the logic for the table, this pr fixes this
## Authorship
<!-- Describe original authors of changes to credit them. -->
keIgaras
## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
bugfix: You can force move mob on catwalk in passive grab
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
