### PR TITLE
Fixes a couple wall properties not transferring

### DIFF
--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -158,6 +158,12 @@
 	floor_type = other.floor_type
 	construction_stage = other.construction_stage
 
+	damage = other.damage
+	
+	// Do not set directly to other.can_open since it may be in the WALL_OPENING state.
+	if(other.can_open)
+		can_open = WALL_CAN_OPEN
+
 	update_material()
 	return TRUE
 


### PR DESCRIPTION
## Description of changes
Fixes wall damage and the false walls not transferring on shuttle movement etc. False walls will always be moved into their "closed" position.
## Why and what will this PR improve
Shuttles shouldn't be able to be repaired just by moving it.

## Authorship
Myself. 

## Changelog
:cl:
bugfix: Fixed a bug where wall damage would not be retained when moving a shuttle
/:cl:

