### PR TITLE
Lazyaccesses reagent_amounts when filling grown foods

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -46,7 +46,7 @@
 		if(LAZYLEN(reagent_amounts))
 			var/rtotal = reagent_amounts[1]
 			var/list/data = null
-			if(reagent_amounts?[2] && potency > 0)
+			if(LAZYACCESS(reagent_amounts,2) && potency > 0)
 				rtotal += round(potency/reagent_amounts[2])
 			if(rid == /decl/material/liquid/nutriment)
 				LAZYSET(data, seed.seed_name, max(1,rtotal))


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Makes a traditional list use `LAZYACCESS(L,x)` instead of `L?[x]` to prevent out-of-bound index runtimes when filling grown food items with relevant reagents.

## Why and what will this PR improve
Prevents potential index out-of-bound index runtimes. Observed during latest devmerge on [Hearth/Stella Nova #237](https://github.com/HearthOfHestia/Nebula/pull/237).

## Authorship
`@herma#0001` / @hermaplusplus

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
bugfix: Fixes potential index out-of-bound error when filling grown foods with reagents.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
