### PR TITLE
Fix de-braining not renaming the brain

### DIFF
--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -85,10 +85,10 @@
 		SetName(initial(name)) //Reset the organ's name to stay coherent if we're putting it back into someone's skull
 
 /obj/item/organ/internal/brain/do_uninstall(in_place, detach, ignore_children, update_icon)
-	if(!(. = ..()))
-		return
 	if(!in_place && istype(owner) && name == initial(name))
 		SetName("\the [owner.real_name]'s [initial(name)]")
+	if(!(. = ..()))
+		return
 
 /obj/item/organ/internal/brain/on_remove_effects()
 	if(istype(owner))


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Renaming the brain during removal from mob now happens before its removed, so it actually happens. Used to be done after it was removed which meant the check done before renaming was always false.

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
bugfix: Brains removed from someone's head now properly gets renamed to whoever the brain owner was.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
