### PR TITLE
Faz-World Sync 04/22/2022

### DIFF
--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -25,6 +25,10 @@ var/global/list/floor_light_cache = list()
 /obj/machinery/floor_light/prebuilt
 	anchored = 1
 
+/obj/machinery/floor_light/Initialize()
+	. = ..()
+	update_icon()
+
 /obj/machinery/floor_light/attackby(var/obj/item/W, var/mob/user)
 	if(isScrewdriver(W))
 		anchored = !anchored
@@ -100,7 +104,7 @@ var/global/list/floor_light_cache = list()
 			set_light(0)
 
 /obj/machinery/floor_light/on_update_icon()
-	overlays.Cut()
+	cut_overlays()
 	if((use_power == POWER_USE_ACTIVE) && !(stat & (NOPOWER | BROKEN)))
 		if(isnull(damaged))
 			var/cache_key = "floorlight-[default_light_color]"
@@ -110,7 +114,7 @@ var/global/list/floor_light_cache = list()
 				I.plane = plane
 				I.layer = layer+0.001
 				floor_light_cache[cache_key] = I
-			overlays |= floor_light_cache[cache_key]
+			add_overlay(floor_light_cache[cache_key])
 		else
 			if(damaged == 0) //Needs init.
 				damaged = rand(1,4)
@@ -121,7 +125,7 @@ var/global/list/floor_light_cache = list()
 				I.plane = plane
 				I.layer = layer+0.001
 				floor_light_cache[cache_key] = I
-			overlays |= floor_light_cache[cache_key]
+			add_overlay(floor_light_cache[cache_key])
 	update_brightness()
 
 /obj/machinery/floor_light/explosion_act(severity)

--- a/code/game/objects/structures/stool_bed_chair_nest_sofa/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest_sofa/chairs.dm
@@ -273,7 +273,7 @@
 	desc = "Old is never too old to not be in fashion."
 	icon_state = "wooden_chair"
 	color = WOOD_COLOR_GENERIC
-	var/chair_material = /decl/material/solid/wood
+	material = /decl/material/solid/wood
 
 /obj/structure/bed/chair/wood/attackby(obj/item/W, mob/user)
 	if(istype(W,/obj/item/stack) || isWirecutter(W))

--- a/code/game/objects/structures/tables.dm
+++ b/code/game/objects/structures/tables.dm
@@ -693,6 +693,7 @@
 	icon_state = "solid_preview"
 	color = WOOD_COLOR_GENERIC
 	material = /decl/material/solid/wood
+	reinf_material = /decl/material/solid/wood
 
 /obj/structure/table/woodentable/mahogany
 	color = WOOD_COLOR_RICH

--- a/code/modules/client/preference_setup/global/03_pai.dm
+++ b/code/modules/client/preference_setup/global/03_pai.dm
@@ -4,8 +4,8 @@
 
 	var/icon/pai_preview
 	var/datum/paiCandidate/candidate
-	var/icon/bgstate = DEFAULT_WALL_MATERIAL
-	var/list/bgstate_options = list("FFF", DEFAULT_WALL_MATERIAL, "white")
+	var/icon/bgstate = "steel"
+	var/list/bgstate_options = list("FFF", "steel", "white")
 
 /datum/category_item/player_setup_item/player_global/pai/load_preferences(datum/pref_record_reader/R)
 	if(!candidate)
@@ -81,7 +81,7 @@
 				bgstate = next_in_list(bgstate, bgstate_options)
 				update_pai_preview(user)
 				. = TOPIC_HARD_REFRESH
-		return 
+		return
 
 	return ..()
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -374,8 +374,6 @@ var/global/list/time_prefs_fixed = list()
 	character.h_style = h_style
 	character.f_style = f_style
 
-	character.species.handle_limbs_setup(character)
-
 	QDEL_NULL_LIST(character.worn_underwear)
 	character.worn_underwear = list()
 

--- a/code/modules/mob/living/carbon/carbon_organs.dm
+++ b/code/modules/mob/living/carbon/carbon_organs.dm
@@ -12,7 +12,7 @@
 
 /mob/living/carbon/has_external_organs()
 	return LAZYLEN(external_organs) > 0
-	
+
 /mob/living/carbon/has_internal_organs()
 	return LAZYLEN(internal_organs) > 0
 
@@ -56,7 +56,7 @@
 //Should handle vital organ checks, icon updates, events
 /mob/living/carbon/on_lost_organ(var/obj/item/organ/O)
 	if(!(. = ..()))
-		return 
+		return
 
 	//Check if we should die
 	if(species.is_vital_organ(src, O))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -106,7 +106,7 @@
 				coating = E.coating
 				break
 		if(coating)
-			msg += "There's something <font color='[coating.get_color()]'>something on [G.his] hands</font>!\n"
+			msg += "There's <font color='[coating.get_color()]'>something on [G.his] hands</font>!\n"
 
 	//belt
 	if(belt)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1327,10 +1327,10 @@
 		dna.ready_dna(src) //regen dna filler only if we haven't forced the dna already
 
 	species.handle_pre_spawn(src)
-	apply_species_cultural_info()
-	apply_species_appearance()
 	if(!LAZYLEN(get_external_organs()))
 		species.create_missing_organs(src) //Syncs DNA when adding organs
+	apply_species_cultural_info()
+	apply_species_appearance()
 	species.handle_post_spawn(src)
 
 	UpdateAppearance() //Apply dna appearance to mob, causes DNA to change because filler values are regenerated

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -217,6 +217,9 @@ meteor_act
 	if(W.damtype != BRUTE)
 		return
 
+	if(!should_have_organ(BP_HEART))
+		return
+
 	//make non-sharp low-force weapons less likely to be bloodied
 	if(W.sharp || prob(effective_force*4))
 		if(!(W.atom_flags & ATOM_FLAG_NO_BLOOD))

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -45,7 +45,7 @@
 /mob/living/carbon/human/dummy/mannequin/add_to_dead_mob_list()
 	return FALSE
 
-/mob/living/carbon/human/dummy/mannequin/fully_replace_character_name(new_name)
+/mob/living/carbon/human/dummy/mannequin/fully_replace_character_name(new_name, in_depth = TRUE)
 	..("[new_name] (mannequin)", FALSE)
 
 /mob/living/carbon/human/dummy/mannequin/InitializeHud()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -851,7 +851,8 @@ default behaviour is:
 	if(!has_gravity())
 		return
 	if(isturf(loc) && pull_damage() && prob(getBruteLoss() / 6))
-		blood_splatter(loc, src, large = TRUE)
+		if (!should_have_organ(BP_HEART))
+			blood_splatter(loc, src, large = TRUE)
 		if(prob(25))
 			adjustBruteLoss(1)
 			visible_message(SPAN_DANGER("\The [src]'s [isSynthetic() ? "state worsens": "wounds open more"] from being dragged!"))

--- a/code/modules/organs/internal/posibrain.dm
+++ b/code/modules/organs/internal/posibrain.dm
@@ -177,7 +177,7 @@
 	return ..()
 
 /obj/item/organ/internal/posibrain/do_install(var/mob/living/target)
-	if(!(. = ..())) 
+	if(!(. = ..()))
 		return
 	if(istype(owner))
 		SetName(initial(name)) //Reset the organ's name to stay coherent if we're put back into someone's skull
@@ -248,7 +248,7 @@
 		return 0
 	return cell && cell.use(amount)
 
-/obj/item/organ/internal/cell/proc/get_power_drain()	
+/obj/item/organ/internal/cell/proc/get_power_drain()
 	var/damage_factor = 1 + 10 * damage/max_damage
 	return servo_cost * damage_factor
 
@@ -321,10 +321,13 @@
 
 /obj/item/organ/internal/mmi_holder/Destroy()
 	stored_mmi = null
+	persistantMind = null
 	return ..()
 
-/obj/item/organ/internal/mmi_holder/Initialize(mapload, var/internal)
-	. = ..()
+/obj/item/organ/internal/mmi_holder/do_install(mob/living/carbon/human/target, obj/item/organ/external/affected, in_place)
+	if(status & ORGAN_CUT_AWAY || !(. = ..()))
+		return
+
 	if(!stored_mmi)
 		stored_mmi = new(src)
 	update_from_mmi()

--- a/code/modules/shuttles/shuttle_engines.dm
+++ b/code/modules/shuttles/shuttle_engines.dm
@@ -6,13 +6,10 @@
 	name = "shuttle window"
 	icon = 'icons/obj/structures/podwindows.dmi'
 	icon_state = "1"
-	density = 1
-	opacity = 0
-	anchored = 1
-
-/obj/structure/shuttle/window/CanPass(atom/movable/mover, turf/target, height, air_group)
-		if(!height || air_group) return 0
-		else return ..()
+	density = TRUE
+	opacity = FALSE
+	anchored = TRUE
+	atmos_canpass = CANPASS_DENSITY
 
 /obj/structure/shuttle/engine
 	name = "engine"

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -513,7 +513,7 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 		var/limb_path = organ_data["path"]
 		var/obj/item/organ/external/E = new limb_path(H, null, H.dna) //explicitly specify the dna
 		H.add_organ(E, null, FALSE, FALSE)
-		post_organ_rejuvenate(E, H) // FAZ-WORLD EDIT
+		post_organ_rejuvenate(E, H)
 
 	//Create missing internal organs
 	for(var/organ_tag in has_organ)

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -513,6 +513,7 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 		var/limb_path = organ_data["path"]
 		var/obj/item/organ/external/E = new limb_path(H, null, H.dna) //explicitly specify the dna
 		H.add_organ(E, null, FALSE, FALSE)
+		post_organ_rejuvenate(E, H) // FAZ-WORLD EDIT
 
 	//Create missing internal organs
 	for(var/organ_tag in has_organ)
@@ -719,11 +720,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 
 /decl/species/proc/handle_death_check(var/mob/living/carbon/human/H)
 	return FALSE
-
-//Mostly for toasters
-/decl/species/proc/handle_limbs_setup(var/mob/living/carbon/human/H)
-	for(var/thing in H.get_external_organs())
-		post_organ_rejuvenate(thing, H)
 
 // Impliments different trails for species depending on if they're wearing shoes.
 /decl/species/proc/get_move_trail(var/mob/living/carbon/human/H)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Ports a number of fixes from downstream.
## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Various bugfixes from downstream.

## Authorship
Me.

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
bugfix: Fixed prebuilt floor lights starting with the wrong icon/status.
bugfix: Fixed base wood tables and chairs not having materials set.
bugfix: Fixed an improper usage of DEFAULT_WALL_MATERIAL in place of "steel".
bugfix: Made shuttle windows block air
bugfix: Fixed things without hearts bleeding/making blood splatters
bugfix: Fixed "something something on their hands" message
bugfix: Fixed runtimes with species cultural info and appearance being called before organs
bugfix: Fixes MMI installation
bugfix: Fixes certain limbs not being set up properly on spawn
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
