### PR TITLE
Radial menu atom helper

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -337,3 +337,19 @@ var/global/list/radial_menus = list()
 	return answer
 
 #define RADIAL_INPUT(user, choices) show_radial_menu(user, user, choices)
+
+/*
+	Helper to make a radial menu button with a name and icon for a given atom.
+*/
+/proc/make_item_radial_menu_button(var/atom/movable/AM, var/name_prefix = "", var/name_suffix = "")
+	var/image/radial_button = image(icon = AM.icon, icon_state = AM.icon_state)
+	radial_button.name = "[name_prefix][AM.name][name_suffix]"
+	return radial_button
+
+/*
+	Helper to make a radial menu button for a set of atoms with their names and icons.
+*/
+/proc/make_item_radial_menu_choices(var/list/items, var/name_prefix = "", var/name_suffix = "")
+	for(var/atom/movable/AM in items)
+		LAZYSET(., AM, make_item_radial_menu_button(AM, name_prefix, name_suffix))
+	

--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -342,7 +342,7 @@ var/global/list/radial_menus = list()
 	Helper to make a radial menu button with a name and icon for a given atom.
 */
 /proc/make_item_radial_menu_button(var/atom/movable/AM, var/name_prefix = "", var/name_suffix = "")
-	var/image/radial_button = image()
+	var/image/radial_button = new()
 	radial_button.appearance = AM
 	radial_button.plane = FLOAT_PLANE
 	radial_button.layer = FLOAT_LAYER

--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -342,7 +342,10 @@ var/global/list/radial_menus = list()
 	Helper to make a radial menu button with a name and icon for a given atom.
 */
 /proc/make_item_radial_menu_button(var/atom/movable/AM, var/name_prefix = "", var/name_suffix = "")
-	var/image/radial_button = image(icon = AM.icon, icon_state = AM.icon_state)
+	var/image/radial_button = image()
+	radial_button.appearance = AM
+	radial_button.plane = FLOAT_PLANE
+	radial_button.layer = FLOAT_LAYER
 	radial_button.name = "[name_prefix][AM.name][name_suffix]"
 	return radial_button
 

--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -342,7 +342,7 @@ var/global/list/radial_menus = list()
 	Helper to make a radial menu button with a name and icon for a given atom.
 */
 /proc/make_item_radial_menu_button(var/atom/movable/AM, var/name_prefix = "", var/name_suffix = "")
-	var/image/radial_button = new()
+	var/image/radial_button = new
 	radial_button.appearance = AM
 	radial_button.plane = FLOAT_PLANE
 	radial_button.layer = FLOAT_LAYER

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -117,13 +117,7 @@
 
 	if(!locked || destroyed)
 		var/obj/item/selected_item
-		var/list/options = list()
-
-		for(var/atom/movable/AM in src)
-			var/image/radial_button = image(icon = AM.icon, icon_state = AM.icon_state)
-			options[AM] = radial_button
-
-		selected_item = show_radial_menu(user, src, options, radius = 42, require_near = TRUE, use_labels = TRUE)
+		selected_item = show_radial_menu(user, src, make_item_radial_menu_choices(src), radius = 42, require_near = TRUE, use_labels = TRUE)
 		if(QDELETED(selected_item) || !contents.Find(selected_item) || !Adjacent(user) || user.incapacitated())
 			return
 

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -109,11 +109,7 @@
 
 	var/obj/item/clothing/accessory/A
 	if(LAZYLEN(accessories) > 1)
-		var/list/options = list()
-		for(var/obj/item/clothing/accessory/i in accessories)
-			var/image/radial_button = image(icon = i.icon, icon_state = i.icon_state)
-			options[i] = radial_button
-		A = show_radial_menu(M, M, options, radius = 42, tooltips = TRUE)
+		A = show_radial_menu(M, M, make_item_radial_menu_choices(accessories), radius = 42, tooltips = TRUE)
 	else
 		A = accessories[1]
 

--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -60,11 +60,7 @@
 	
 			var/obj/item/clothing/accessory/A
 			if(LAZYLEN(holder.accessories) > 1)
-				var/list/options = list()
-				for(var/obj/item/clothing/accessory/i in holder.accessories)
-					var/image/radial_button = image(icon = i.icon, icon_state = i.icon_state)
-					options[i] = radial_button
-				A = show_radial_menu(user, user, options, radius = 42, tooltips = TRUE)
+				A = show_radial_menu(user, user, make_item_radial_menu_choices(holder.accessories), radius = 42, tooltips = TRUE)
 			else
 				A = holder.accessories[1]
 			

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -288,9 +288,9 @@
 				return TRUE
 		if(2)
 			if(W.sharp || istype(W,/obj/item/hemostat) || isWirecutter(W))
-				var/list/removables = get_contents_recursive()
-				if(LAZYLEN(removables))
-					var/obj/item/removing = show_radial_menu(user, src, removables, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(src))
+				var/list/radial_buttons = make_item_radial_menu_choices(get_contents_recursive())
+				if(LAZYLEN(radial_buttons))
+					var/obj/item/removing = show_radial_menu(user, src, radial_buttons, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(src))
 					if(removing)
 						if(istype(removing, /obj/item/organ))
 							var/obj/item/organ/O = removing
@@ -307,22 +307,25 @@
 
 //Handles removing child limbs from the detached limb.
 /obj/item/organ/external/proc/try_saw_off_child(var/obj/item/W, var/mob/user)
-	var/list/removables = get_limbs_recursive(TRUE)
-	if(!LAZYLEN(removables))
-		return 
-	var/obj/item/organ/external/removing = show_radial_menu(user, src, removables, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(src))
+
+	//Add icons to radial menu
+	var/list/radial_buttons = make_item_radial_menu_choices(get_limbs_recursive(TRUE))
+	if(!LAZYLEN(radial_buttons))
+		return
+
+	//Display radial menu
+	var/obj/item/organ/external/removing = show_radial_menu(user, src, radial_buttons, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(src))
 	if(!istype(removing))
 		return TRUE
 
 	var/cutting_result = !W.do_tool_interaction(TOOL_SAW, user, src, W.get_tool_speed(TOOL_SAW) * 3 SECONDS, SPAN_DANGER("<b>[user]</b> starts cutting off \the [removing] from [src] with \the [W]!") )
-
 	//Check if the limb is still in the hierarchy
-	removables = get_limbs_recursive(TRUE)
-	if(cutting_result == 1 || !(removing in removables))
+	if(cutting_result == 1 || !(removing in get_limbs_recursive(TRUE)))
 		if(cutting_result != -1)
 			user.visible_message(SPAN_DANGER("<b>[user]</b> stops trying to cut \the [removing]."))
 		return TRUE
 	
+	//Actually remove it
 	removing.do_uninstall()
 	removing.forceMove(get_turf(user))
 	compile_icon()


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Depends on #2303 
Added a helper to build radial menu options directly from atoms, and replaced all instances of duplicate code doing that with it.
