### PR TITLE
Fix human species mob spawning manually with no language

### DIFF
--- a/code/modules/culture_descriptor/culture/cultures_human.dm
+++ b/code/modules/culture_descriptor/culture/cultures_human.dm
@@ -1,6 +1,7 @@
 /decl/cultural_info/culture/other
 	name = "Other Culture"
 	description = "You are from one of the many small, relatively unknown cultures scattered across the galaxy."
+	language = /decl/language/human/common
 	secondary_langs = list(
 		/decl/language/human/common,
 		/decl/language/sign
@@ -9,6 +10,7 @@
 /decl/cultural_info/culture/human
 	name = "Human Culture"
 	description = "You are from one of various planetary cultures of humankind."
+	language = /decl/language/human/common
 	secondary_langs = list(
 		/decl/language/human/common,
 		/decl/language/sign


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Basically, if you create a human mob without going through the job init stuff, it won't have any language set. Because the job equip() proc is hardcoded to add human/common to all mobs it process, and it seems nothing else does it besides prefs:

_job.dm, line 92:
```dm
/datum/job/proc/equip(var/mob/living/carbon/human/H, var/alt_title, var/datum/mil_branch/branch, var/datum/mil_rank/grade)

	if (required_language)
		H.add_language(required_language)
		H.set_default_language(required_language)

	H.add_language(/decl/language/human/common)
	H.set_default_language(/decl/language/human/common)
...
```

Other alien cutlures have a language defined unlike humans. So I set human/common as the language to stay coherent and fix the problem.

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
bugfix: Manually spawned human mobs of the "human" species now spawn with a language.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
