### PR TITLE
Make some of the fields init on carbon and human override easier

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1,7 +1,8 @@
 /mob/living/carbon/Initialize()
 	//setup reagent holders
-	if(!bloodstr && !reagents)
+	if(!bloodstr)
 		bloodstr = new/datum/reagents/metabolism(120, src, CHEM_INJECT)
+	if(!reagents)
 		reagents = bloodstr
 	if(!touching)
 		touching = new/datum/reagents/metabolism(1000, src, CHEM_TOUCH)
@@ -12,7 +13,8 @@
 
 /mob/living/carbon/Destroy()
 	QDEL_NULL(touching)
-	bloodstr = null // We don't qdel(bloodstr) because it's the same as qdel(reagents)
+	QDEL_NULL(bloodstr)
+	reagents = null //We assume reagents is a reference to bloodstr here
 	delete_organs()
 	QDEL_NULL_LIST(hallucinations)
 	if(loc)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1,8 +1,10 @@
 /mob/living/carbon/Initialize()
 	//setup reagent holders
-	bloodstr = new/datum/reagents/metabolism(120, src, CHEM_INJECT)
-	touching = new/datum/reagents/metabolism(1000, src, CHEM_TOUCH)
-	reagents = bloodstr
+	if(!bloodstr && !reagents)
+		bloodstr = new/datum/reagents/metabolism(120, src, CHEM_INJECT)
+		reagents = bloodstr
+	if(!touching)
+		touching = new/datum/reagents/metabolism(1000, src, CHEM_TOUCH)
 
 	if (!default_language && species_language)
 		default_language = species_language

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1334,7 +1334,9 @@
 	species.handle_post_spawn(src)
 
 	UpdateAppearance() //Apply dna appearance to mob, causes DNA to change because filler values are regenerated
-	reset_blood()
+	//Prevent attempting to create blood container if its already setup
+	if(!vessel)
+		reset_blood()
 
 //If the mob has its default name it'll try to generate /obtain a proper one
 /mob/living/carbon/human/proc/try_generate_default_name()


### PR DESCRIPTION

<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Prevent carbon and human from initializing bloodstr, reagents, touching and vessel if they're already set beforehand. So that we don't end up doing the work twice if we override it.

## Why and what will this PR improve
This makes overriding initializing those much easier down the line. Extremely handy downstream to avoid doing temporary var swap bs among other things.
