### PR TITLE
When spawning, the greeting messages check if you have a headset

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -549,7 +549,8 @@ SUBSYSTEM_DEF(jobs)
 	if(job.supervisors)
 		to_chat(H, "<b>As the [alt_title ? alt_title : rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>")
 
-	to_chat(H, "<b>To speak on your department's radio channel use :h. For the use of other channels, examine your headset.</b>")
+	if(H.has_headset_in_ears())
+		to_chat(H, "<b>To speak on your department's radio channel use :h. For the use of other channels, examine your headset.</b>")
 
 	if(job.req_admin_notify)
 		to_chat(H, "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>")


### PR DESCRIPTION
## Description of changes
Greeting message now check if your starting loadout actually gives you a headset before advising you on how to talk through your headset..

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
tweak: Greeting message now check if your starting loadout actually gives you a headset before advising you on how to talk through your headset..
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
