### PR TITLE
shuffles character preview code

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -351,22 +351,31 @@
 	return 1
 
 // Character setup stuff
-/obj/screen/setup_preview
+/obj/screen/character_preview
 	plane = DEFAULT_PLANE
 	layer = MOB_LAYER
 
-	var/datum/preferences/pref
-
-/obj/screen/setup_preview/Destroy()
-	pref = null
+/obj/screen/character_preview/background/Destroy()
+	preferences = null
 	return ..()
 
+/obj/screen/character_preview/background/Click(location, control, params)
+	var/list/modifiers = params2list(params)
+	if(modifiers["right"])
+		RightClick()
+		return TRUE
+
+	if(preferences)
+		preferences.background_state = next_in_list(preferences.background_state, preferences.background_options)
+		preferences.update_character_preview_background()
+
+/obj/screen/character_preview/background/RightClick()
+	if(preferences)
+		preferences.background_state = previous_in_list(preferences.background_state, preferences.background_options)
+		preferences.update_character_preview_background()
+
 // Background 'floor'
-/obj/screen/setup_preview/bg
+/obj/screen/character_preview/background
 	layer = TURF_LAYER
 	mouse_over_pointer = MOUSE_HAND_POINTER
-
-/obj/screen/setup_preview/bg/Click(params)
-	if(pref)
-		pref.bgstate = next_in_list(pref.bgstate, pref.bgstate_options)
-		pref.update_preview_icon()
+	var/datum/preferences/preferences

--- a/code/client_macros.dm
+++ b/code/client_macros.dm
@@ -1,6 +1,3 @@
-/client
-	control_freak = CONTROL_FREAK_ALL | CONTROL_FREAK_MACROS | CONTROL_FREAK_SKIN
-
 var/global/list/registered_macros_by_ckey_
 
 // Disables click and double-click macros, as per http://www.byond.com/forum/?post=2219001

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -41,7 +41,7 @@
 	var/warned_about_multikeying = 0
 
 	// comment out the line below when debugging locally to enable the options & messages menu
-	//control_freak = 1
+	control_freak = CONTROL_FREAK_ALL | CONTROL_FREAK_MACROS | CONTROL_FREAK_SKIN
 
 	// * Database related things *
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -235,7 +235,7 @@ var/global/list/localhost_addresses = list(
 		tooltips = new /datum/tooltip(src)
 
 	if(holder)
-		src.control_freak = 0 //Devs need 0 for profiler access
+		control_freak = 0 //Devs need 0 for profiler access
 
 	if(prefs && !istype(mob, world.mob))
 		prefs.apply_post_login_preferences()

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -14,9 +14,6 @@
 	var/list/appearance_descriptors = list()
 	var/equip_preview_mob = EQUIP_PREVIEW_ALL
 
-	var/icon/bgstate = "000"
-	var/list/bgstate_options = list("000", "midgrey", "FFF", "white", "steel", "techmaint", "dark", "plating", "reinforced")
-
 /datum/category_item/player_setup_item/physical/body
 	name = "Body"
 	sort_order = 2
@@ -29,7 +26,6 @@
 	pref.skin_tone =              R.read("skin_tone")
 	pref.b_type =                 R.read("b_type")
 	pref.appearance_descriptors = R.read("appearance_descriptors")
-	pref.bgstate =                R.read("bgstate")
 
 	pref.h_style =                R.read("hair_style_name")
 	pref.f_style =                R.read("facial_style_name")
@@ -69,7 +65,6 @@
 	W.write("eye_colour",             pref.eye_colour)
 	W.write("b_type",                 pref.b_type)
 	W.write("appearance_descriptors", pref.appearance_descriptors)
-	W.write("bgstate",                pref.bgstate)
 
 	// Get names of sprite accessories to serialize.
 	var/decl/sprite_accessory/sprite = GET_DECL(pref.h_style)
@@ -126,8 +121,8 @@
 			else
 				pref.appearance_descriptors[descriptor.name] = descriptor.sanitize_value(last_descriptors[descriptor.name])
 
-	if(!pref.bgstate || !(pref.bgstate in pref.bgstate_options))
-		pref.bgstate = "000"
+	if(!pref.background_state || !(pref.background_state in pref.background_options))
+		pref.background_state = initial(pref.background_state)
 
 /datum/category_item/player_setup_item/physical/body/content(var/mob/user)
 	. = list()

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -12,6 +12,25 @@ var/global/list/valid_icon_sizes = list(32, 48, 64, 96, 128)
 	//Style for popup tooltips
 	var/tooltip_style = "Midnight"
 
+	var/list/background_options = list(
+		"Void" = list(
+			"icon" = 'icons/turf/areas.dmi',
+			"icon_state" = "dark",
+			"color" = null
+		),
+		"Dark" = list(
+			"icon" = 'icons/turf/flooring/techfloor.dmi',
+			"icon_state" = "techfloor_gray",
+			"color" = null
+		),
+		"Rusty" = list(
+			"icon" = 'icons/turf/flooring/tiles.dmi',
+			"icon_state" = "steel_dirty",
+			"color" = null
+		)
+	)
+	var/background_state = "Void"
+
 /datum/category_item/player_setup_item/player_global/ui
 	name = "UI"
 	sort_order = 1
@@ -25,6 +44,7 @@ var/global/list/valid_icon_sizes = list(32, 48, 64, 96, 128)
 	pref.UI_style_alpha =     R.read("UI_style_alpha")
 	pref.ooccolor =           R.read("ooccolor")
 	pref.clientfps =          R.read("clientfps")
+	pref.background_state =   R.read("background_state")
 
 /datum/category_item/player_setup_item/player_global/ui/save_preferences(datum/pref_record_writer/W)
 	W.write("icon_size",          pref.icon_size)
@@ -35,6 +55,7 @@ var/global/list/valid_icon_sizes = list(32, 48, 64, 96, 128)
 	W.write("UI_style_alpha",     pref.UI_style_alpha)
 	W.write("ooccolor",           pref.ooccolor)
 	W.write("clientfps",          pref.clientfps)
+	W.write("background_state",   pref.background_state)
 
 /datum/category_item/player_setup_item/player_global/ui/sanitize_preferences()
 	pref.UI_style		    = sanitize_inlist(pref.UI_style, all_ui_styles, initial(pref.UI_style))

--- a/code/modules/client/preference_setup/global/03_pai.dm
+++ b/code/modules/client/preference_setup/global/03_pai.dm
@@ -2,10 +2,7 @@
 	name = "pAI"
 	sort_order = 3
 
-	var/icon/pai_preview
 	var/datum/paiCandidate/candidate
-	var/icon/bgstate = "steel"
-	var/list/bgstate_options = list("FFF", "steel", "white")
 
 /datum/category_item/player_setup_item/player_global/pai/load_preferences(datum/pref_record_reader/R)
 	if(!candidate)
@@ -30,8 +27,7 @@
 	if(!candidate)
 		candidate = new()
 
-	if (!pai_preview)
-		update_pai_preview(user)
+	update_pai_preview()
 
 	. += "<b>pAI:</b><br>"
 	if(!candidate)
@@ -43,8 +39,6 @@
 	. += "OOC Comments: <a href='?src=\ref[src];option=ooc'>[candidate.comments ? TextPreview(candidate.comments, 40) : "None Set"]</a><br>"
 	. += "<div>Chassis: <a href='?src=\ref[src];option=chassis'>[candidate.chassis]</a><br>"
 	. += "<div>Say Verb: <a href='?src=\ref[src];option=say'>[candidate.say_verb]</a><br>"
-	. += "<table><tr style='vertical-align:top'><td><div class='statusDisplay'><center><img src=pai_preview.png width=[pai_preview.Width()] height=[pai_preview.Height()]></center><a href='?src=\ref[src];option=cyclebg'>Cycle Background</a></div>"
-	. += "</td></tr></table>"
 
 /datum/category_item/player_setup_item/player_global/pai/OnTopic(var/href,var/list/href_list, var/mob/user)
 	if(href_list["option"])
@@ -71,31 +65,18 @@
 				t = input(usr,"What would you like to use for your mobile chassis icon?") as null|anything in global.possible_chassis
 				if(!isnull(t) && CanUseTopic(user))
 					candidate.chassis = t
-				update_pai_preview(user)
+				update_pai_preview()
 				. = TOPIC_HARD_REFRESH
 			if("say")
 				t = input(usr,"What theme would you like to use for your speech verbs?") as null|anything in global.possible_say_verbs
 				if(!isnull(t) && CanUseTopic(user))
 					candidate.say_verb = t
-			if("cyclebg")
-				bgstate = next_in_list(bgstate, bgstate_options)
-				update_pai_preview(user)
-				. = TOPIC_HARD_REFRESH
 		return
 
 	return ..()
 
-/datum/category_item/player_setup_item/player_global/pai/proc/update_pai_preview(mob/user)
-	pai_preview = icon('icons/effects/128x48.dmi', bgstate)
-	var/icon/pai = icon(global.possible_chassis[candidate.chassis], ICON_STATE_WORLD, NORTH)
-	pai_preview.Scale(48+32, 16+32)
-
-	pai_preview.Blend(pai, ICON_OVERLAY, 25, 22)
-	pai = icon(global.possible_chassis[candidate.chassis], ICON_STATE_WORLD, WEST)
-	pai_preview.Blend(pai, ICON_OVERLAY, 1, 9)
-	pai = icon(global.possible_chassis[candidate.chassis], ICON_STATE_WORLD, SOUTH)
-	pai_preview.Blend(pai, ICON_OVERLAY, 49, 5)
-
-	pai_preview.Scale(pai_preview.Width() * 2, pai_preview.Height() * 2)
-
-	send_rsc(user, pai_preview, "pai_preview.png")
+/datum/category_item/player_setup_item/player_global/pai/proc/update_pai_preview()
+	var/mutable_appearance/MA = mutable_appearance(global.possible_chassis[candidate.chassis], ICON_STATE_WORLD)
+	MA.invisibility = 0 // Byond makes pAI icon with visibility = 0; this is the workaround
+	pref.update_character_preview_mannequin(MA)
+	pref.update_character_preview_background()

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -248,7 +248,7 @@ var/global/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 	if(!pref_mob || !pref_mob.client)
 		return 1
 	if(. & TOPIC_UPDATE_PREVIEW)
-		pref_mob.client.prefs.update_preview_icon()
+		pref_mob.client.prefs.update_character_preview_map()
 
 	// And again: above operation is slow/may sleep, clients disappear whenever.
 	pref_mob = preference_mob()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -46,22 +46,22 @@ var/global/list/time_prefs_fixed = list()
 	//Saved changlog filesize to detect if there was a change
 	var/lastchangelog = ""
 
-	//Mob preview
-	//Should only be a key-value list of north/south/east/west = obj/screen.
-	var/list/char_render_holders
-	var/static/list/preview_screen_locs = list(
-		"1" = "character_preview_map:1,5:-12",
-		"2" = "character_preview_map:1,3:15",
-		"4"  = "character_preview_map:1,2:10",
-		"8"  = "character_preview_map:1,1:5",
-		"BG" = "character_preview_map:1,1 to 1,5"
-	)
-
 	var/client/client = null
 	var/client_ckey = null
 
 	var/datum/category_collection/player_setup_collection/player_setup
 	var/datum/browser/panel
+
+	/// A key-value list of associated screens
+	var/list/char_render_holders
+	/// A key-value list of associated map locations
+	var/static/list/character_preview_screen_locs = list(
+		"1" = "character_preview_map:2,8",
+		"2" = "character_preview_map:2,6",
+		"4"  = "character_preview_map:2,4",
+		"8"  = "character_preview_map:2,2",
+		"background" = "character_preview_map:1,1 to 3,9"
+	)
 
 /datum/preferences/New(client/C)
 	if(istype(C))
@@ -95,7 +95,7 @@ var/global/list/time_prefs_fixed = list()
 			is_byond_member = client.IsByondMember()
 
 	sanitize_preferences()
-	update_preview_icon()
+	update_character_preview_map()
 
 /datum/preferences/proc/load_data()
 	load_failed = null
@@ -183,9 +183,7 @@ var/global/list/time_prefs_fixed = list()
 		close_load_dialog(user)
 		return
 
-	if(!char_render_holders)
-		update_preview_icon()
-	show_character_previews()
+	show_character_preview()
 
 	var/dat = list("<center>")
 	if(is_guest)
@@ -217,7 +215,7 @@ var/global/list/time_prefs_fixed = list()
 		return
 
 	winshow(user, "preferences_window", TRUE)
-	var/datum/browser/popup = new(user, "preferences_browser", "Character Setup", 800, 800)
+	var/datum/browser/popup = new(user, "preferences_browser", "<div align='center'>Character Setup</div>", 712, 864)
 	var/content = {"
 	<script type='text/javascript'>
 		function update_content(data){
@@ -235,44 +233,52 @@ var/global/list/time_prefs_fixed = list()
 /datum/preferences/proc/update_setup_window(mob/user)
 	send_output(user, url_encode(get_content(user)), "preferences_browser:update_content")
 
-/datum/preferences/proc/update_character_previews(mutable_appearance/MA)
+/// Updates character preview mannequins.
+/datum/preferences/proc/update_character_preview_mannequin(mutable_appearance/MA, loc_group)
+	for(var/D in global.cardinal)
+		var/obj/screen/character_preview/O = LAZYACCESS(char_render_holders, "[D]")
+		if(!O)
+			O = new
+			LAZYSET(char_render_holders, "[D]", O)
+
+		O.appearance = MA
+		O.dir = D
+		O.reset_plane_and_layer()
+		O.screen_loc = character_preview_screen_locs["[D]"]
+
+#define CHAR_RENDER_BG "background"
+/// Updates character preview background.
+/datum/preferences/proc/update_character_preview_background()
+	var/obj/screen/character_preview/background/bg = LAZYACCESS(char_render_holders, CHAR_RENDER_BG)
+	if(!bg)
+		bg = new
+		LAZYSET(char_render_holders, CHAR_RENDER_BG, bg)
+		bg.preferences = src
+
+	bg.icon = background_options[background_state]["icon"]
+	bg.icon_state = background_options[background_state]["icon_state"]
+	bg.color = background_options[background_state]["color"]
+	bg.screen_loc = character_preview_screen_locs[CHAR_RENDER_BG]
+#undef CHAR_RENDER_BG
+
+/// Use this if you want to show cached renders without updating them.
+/datum/preferences/proc/show_character_preview()
 	if(!client)
 		return
 
-	var/obj/screen/setup_preview/bg/BG = LAZYACCESS(char_render_holders, "BG")
-	if(!BG)
-		BG = new
-		BG.icon = 'icons/effects/32x32.dmi'
-		BG.pref = src
-		LAZYSET(char_render_holders, "BG", BG)
-		client.screen |= BG
-	BG.icon_state = bgstate
-	BG.screen_loc = preview_screen_locs["BG"]
+	if(!char_render_holders)
+		update_character_preview_map()
 
-	for(var/D in global.cardinal)
-		var/obj/screen/setup_preview/O = LAZYACCESS(char_render_holders, "[D]")
-		if(!O)
-			O = new
-			O.pref = src
-			LAZYSET(char_render_holders, "[D]", O)
-			client.screen |= O
-		O.appearance = MA
-		O.dir = D
-		O.screen_loc = preview_screen_locs["[D]"]
-	update_setup_window(usr)
-
-/datum/preferences/proc/show_character_previews()
-	if(!client || !char_render_holders)
-		return
 	for(var/render_holder in char_render_holders)
-		client.screen |= char_render_holders[render_holder]
+		client?.screen |= char_render_holders[render_holder]
 
-/datum/preferences/proc/clear_character_previews()
+/datum/preferences/proc/clear_character_preview_map()
 	for(var/index in char_render_holders)
-		var/obj/screen/S = char_render_holders[index]
+		var/obj/screen/character_preview/S = char_render_holders[index]
 		client?.screen -= S
 		qdel(S)
-	char_render_holders = null
+
+	QDEL_NULL_LIST(char_render_holders)
 
 /datum/preferences/proc/process_link(mob/user, list/href_list)
 
@@ -317,18 +323,14 @@ var/global/list/time_prefs_fixed = list()
 			return FALSE
 		load_character(SAVE_RESET)
 		sanitize_preferences()
-	else if(href_list["close"])
-		// User closed preferences window, cleanup anything we need to.
-		clear_character_previews()
-		return TRUE
 	else if(href_list["toggle_preview_value"])
 		equip_preview_mob ^= text2num(href_list["toggle_preview_value"])
 	else if(href_list["cycle_bg"])
-		bgstate = next_in_list(bgstate, bgstate_options)
+		background_state = next_in_list(background_state, background_options)
 	else
 		return FALSE
 
-	update_preview_icon()
+	update_character_preview_map()
 	update_setup_window(usr)
 	return 1
 

--- a/code/modules/client/preferences_persist.dm
+++ b/code/modules/client/preferences_persist.dm
@@ -70,7 +70,7 @@
 			R = new /datum/pref_record_reader/null_reader(PREF_SER_VERSION)
 		player_setup.load_character(R)
 
-	update_preview_icon()
+	update_character_preview_map()
 
 /datum/preferences/proc/save_character(override_key=null)
 	var/datum/pref_record_writer/json_list/W = new(PREF_SER_VERSION)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -51,7 +51,7 @@
 
 	output += "</div>"
 
-	panel = new(src, "Welcome","Welcome to [global.using_map.full_name]", 560, 280, src)
+	panel = new(src, "Welcome","<div align='center'>Welcome to [global.using_map.full_name]</div>", 560, 280, src)
 	panel.set_window_options("can_close=0")
 	panel.set_content(JOINTEXT(output))
 	panel.open()

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -98,12 +98,15 @@
 	if(update_icon)
 		mannequin.update_icon()
 
-/datum/preferences/proc/update_preview_icon()
+/// Updates character preview map.
+/// If you don't need to update renders, use [/datum/preferences/proc/update_character_preview_background].
+/datum/preferences/proc/update_character_preview_map()
+	update_character_preview_background()
 	var/mob/living/carbon/human/dummy/mannequin/mannequin = get_mannequin(client_ckey)
 	if(mannequin)
 		mannequin.delete_inventory(TRUE)
 		dress_preview_mob(mannequin)
-		update_character_previews(new /mutable_appearance(mannequin))
+		update_character_preview_mannequin(new /mutable_appearance(mannequin))
 
 /datum/preferences/proc/get_random_name()
 	var/decl/cultural_info/culture/check_culture = cultural_info[TAG_CULTURE]

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -390,25 +390,25 @@ window "rpane"
 window "preferences_window"
 	elem "preferences_window"
 		type = MAIN
-		pos = 281,0
-		size = 1000x800
 		anchor1 = none
 		anchor2 = none
+		pos = 281,-30
+		size = 1200x864
 		is-visible = false
 		saved-params = "pos;size;is-minimized;is-maximized"
 		statusbar = false
 	elem "preferences_browser"
 		type = BROWSER
 		pos = 0,0
-		size = 800x800
+		size = 900x864
 		anchor1 = 0,0
-		anchor2 = 80,100
+		anchor2 = 75,100
 		saved-params = ""
 	elem "character_preview_map"
 		type = MAP
-		pos = 800,0
-		size = 200x800
-		anchor1 = 80,0
+		pos = 900,0
+		size = 300x864
+		anchor1 = 75,0
 		anchor2 = 100,100
 		right-click = true
 		saved-params = "zoom;letterbox;zoom-mode"


### PR DESCRIPTION
## Description of changes
The current positions for the character preview mannequins on preview map didn't satisfy me and I got stuck for awhile rewriting it.
I can say I finally start to understand a code I ported a year ago!

![изображение](https://user-images.githubusercontent.com/44920739/167248142-1a2fb310-0b8e-4d7d-a829-53954ea51219.png)

## Why and what will this PR improve
The only noticeable differences is that closing the window won't clear render objects; the backgrounds list become more flexible and can contain icon, icon state and color; and a pAI chassis will display on the map window as a mannequins, somehow.

## Authorship
https://github.com/Haven-13/Haven-Urist/pull/85 gave me inspiration to kick this code and update, so I basically rewrited it after investigating how this feature is work.