### PR TITLE
Add feedback when wiring zcable + tweaks

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -167,13 +167,8 @@
 	else if( istype(M, /mob/living/silicon/robot ))
 		new /obj/effect/decal/cleanable/blood/oil(src)
 
-/turf/simulated/proc/can_build_cable(var/mob/user)
-	return 0
-
 /turf/simulated/attackby(var/obj/item/thing, var/mob/user)
-	if(isCoil(thing) && can_build_cable(user))
-		var/obj/item/stack/cable_coil/coil = thing
-		coil.turf_place(src, user)
+	if(isCoil(thing) && try_build_cable(thing, user))
 		return TRUE
 	return ..()
 

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -173,15 +173,19 @@
 	update_icon()
 	return 1
 
-/turf/simulated/floor/try_build_cable(obj/item/stack/cable_coil/C, mob/user)
-	if(!can_build_cable(user))
-		if(!is_plating() || flooring)
+/turf/simulated/floor/why_cannot_build_cable(var/mob/user, var/cable_error)
+	switch(cable_error)
+		if(0)
+			return
+		if(1)
 			to_chat(user, SPAN_WARNING("Removing the tiling first."))
-		if(broken || burnt)
+		if(2)
 			to_chat(user, SPAN_WARNING("This section is too damaged to support anything. Use a welder to fix the damage."))
-		return FALSE
-	return ..()
+		else //Fallback
+			. = ..()
 
-/turf/simulated/floor/can_build_cable(var/mob/user)
-	//Need to check 'flooring' again since some floor types override is_plating to check for something else than flooring..
-	return is_plating() && !flooring && !broken && !burnt
+/turf/simulated/floor/cannot_build_cable()
+	if(broken || burnt)
+		return 2
+	if(!is_plating())
+		return 1

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -173,11 +173,15 @@
 	update_icon()
 	return 1
 
+/turf/simulated/floor/try_build_cable(obj/item/stack/cable_coil/C, mob/user)
+	if(!can_build_cable(user))
+		if(!is_plating() || flooring)
+			to_chat(user, SPAN_WARNING("Removing the tiling first."))
+		if(broken || burnt)
+			to_chat(user, SPAN_WARNING("This section is too damaged to support anything. Use a welder to fix the damage."))
+		return FALSE
+	return ..()
+
 /turf/simulated/floor/can_build_cable(var/mob/user)
-	if(!is_plating() || flooring)
-		to_chat(user, "<span class='warning'>Removing the tiling first.</span>")
-		return 0
-	if(broken || burnt)
-		to_chat(user, "<span class='warning'>This section is too damaged to support anything. Use a welder to fix the damage.</span>")
-		return 0
-	return 1
+	//Need to check 'flooring' again since some floor types override is_plating to check for something else than flooring..
+	return is_plating() && !flooring && !broken && !burnt

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -438,12 +438,20 @@ var/global/const/enterloopsanity = 100
 	if(flooded)
 		LAZYADD(., global.flood_object)
 
-/**Whether we can place a cable here */
-/turf/proc/can_build_cable(var/mob/user)
-	return FALSE
+/**Whether we can place a cable here 
+ * If you cannot build a cable will return an error code explaining why you cannot.
+*/
+/turf/proc/cannot_build_cable()
+	return 1
+
+/**Sends a message to the user explaining why they can't build a cable here */
+/turf/proc/why_cannot_build_cable(var/mob/user, var/cable_error)
+	to_chat(user, SPAN_WARNING("You cannot place a cable here!"))
 
 /**Place a cable if possible, if not warn the user appropriately */
 /turf/proc/try_build_cable(var/obj/item/stack/cable_coil/C, var/mob/user)
-	if(!can_build_cable(user))
+	var/cable_error = cannot_build_cable(user)
+	if(cable_error)
+		why_cannot_build_cable(user, cable_error)
 		return FALSE
 	return C.turf_place(src, user)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -437,3 +437,13 @@ var/global/const/enterloopsanity = 100
 		LAZYADD(., weather)
 	if(flooded)
 		LAZYADD(., global.flood_object)
+
+/**Whether we can place a cable here */
+/turf/proc/can_build_cable(var/mob/user)
+	return FALSE
+
+/**Place a cable if possible, if not warn the user appropriately */
+/turf/proc/try_build_cable(var/obj/item/stack/cable_coil/C, var/mob/user)
+	if(!can_build_cable(user))
+		return FALSE
+	return C.turf_place(src, user)

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -128,8 +128,8 @@
 /turf/simulated/open/is_plating()
 	return TRUE
 
-/turf/simulated/open/can_build_cable()
-	return TRUE
+/turf/simulated/open/cannot_build_cable()
+	return 0
 
 ////////////////////////////////
 // Open EXTERIOR
@@ -223,5 +223,5 @@
 		if(M.movable_flags & MOVABLE_FLAG_Z_INTERACT)
 			return M.attack_hand(user)
 
-/turf/exterior/open/can_build_cable()
-	return TRUE
+/turf/exterior/open/cannot_build_cable()
+	return 0

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -218,7 +218,7 @@
 		if(M.movable_flags & MOVABLE_FLAG_Z_INTERACT)
 			return M.attackby(C, user)
 
-/turf/simulated/open/attack_hand(mob/user)
+/turf/exterior/open/attack_hand(mob/user)
 	for(var/atom/movable/M in below)
 		if(M.movable_flags & MOVABLE_FLAG_Z_INTERACT)
 			return M.attack_hand(user)

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -16,6 +16,9 @@
 			return 0
 	return 1
 
+////////////////////////////////
+// Open SIMULATED
+////////////////////////////////
 /turf/simulated/open
 	name = "open space"
 	icon = 'icons/turf/space.dmi'
@@ -23,6 +26,10 @@
 	density = 0
 	pathweight = 100000 //Seriously, don't try and path over this one numbnuts
 	z_flags = ZM_MIMIC_DEFAULTS | ZM_MIMIC_OVERWRITE | ZM_MIMIC_NO_AO | ZM_ALLOW_ATMOS
+
+/turf/simulated/open/flooded
+	name = "open water"
+	flooded = TRUE
 
 /turf/simulated/open/CanZPass(atom/A, direction)
 	if(locate(/obj/structure/catwalk, src))
@@ -105,9 +112,7 @@
 		return TRUE
 
 	//To lay cable.
-	if(isCoil(C))
-		var/obj/item/stack/cable_coil/coil = C
-		coil.turf_place(src, user)
+	if(isCoil(C) && try_build_cable(C, user))
 		return TRUE
 
 	for(var/atom/movable/M in below)
@@ -121,13 +126,14 @@
 
 //Most things use is_plating to test if there is a cover tile on top (like regular floors)
 /turf/simulated/open/is_plating()
-	return 1
+	return TRUE
 
-/turf/simulated/open/flooded
-	name = "open water"
-	flooded = TRUE
+/turf/simulated/open/can_build_cable()
+	return TRUE
 
-// Whole lot of copypaste below sorry.
+////////////////////////////////
+// Open EXTERIOR
+////////////////////////////////
 /turf/exterior/open
 	name = "open space"
 	icon = 'icons/turf/space.dmi'
@@ -205,9 +211,7 @@
 		return TRUE
 
 	//To lay cable.
-	if(isCoil(C))
-		var/obj/item/stack/cable_coil/coil = C
-		coil.turf_place(src, user)
+	if(isCoil(C) && try_build_cable(C, user))
 		return TRUE
 
 	for(var/atom/movable/M in below)
@@ -218,3 +222,6 @@
 	for(var/atom/movable/M in below)
 		if(M.movable_flags & MOVABLE_FLAG_Z_INTERACT)
 			return M.attack_hand(user)
+
+/turf/exterior/open/can_build_cable()
+	return TRUE

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -87,9 +87,9 @@ By design, d1 is the smallest direction and d2 is the highest
 		user.examinate(src)
 		// following code taken from attackby (multitool)
 		if(powernet && (powernet.avail > 0))
-			to_chat(user, "<span class='warning'>[get_wattage()] in power network.</span>")
+			to_chat(user, SPAN_WARNING("[get_wattage()] in power network."))
 		else
-			to_chat(user, "<span class='warning'>The cable is not powered.</span>")
+			to_chat(user, SPAN_WARNING("\The [src] is not powered."))
 	return
 
 ///////////////////////////////////
@@ -97,10 +97,10 @@ By design, d1 is the smallest direction and d2 is the highest
 ///////////////////////////////////
 
 /obj/structure/cable/proc/get_wattage()
-	if(powernet.avail >= 1000000000)
-		return "[round(powernet.avail/1000000, 0.01)] MW"
-	if(powernet.avail >= 1000000)
-		return "[round(powernet.avail/1000, 0.01)] kW"
+	if(powernet.avail >=  1 GIGAWATTS)
+		return "[round(powernet.avail/(1 MEGAWATTS), 0.01)] MW"
+	if(powernet.avail >= 1 MEGAWATTS)
+		return "[round(powernet.avail/(1 KILOWATTS), 0.01)] kW"
 	return "[round(powernet.avail)] W"
 
 //If underfloor, hide the cable
@@ -153,10 +153,10 @@ By design, d1 is the smallest direction and d2 is the highest
 	else if(isMultitool(W))
 
 		if(powernet && (powernet.avail > 0))		// is it powered?
-			to_chat(user, "<span class='warning'>[get_wattage()] in power network.</span>")
+			to_chat(user, SPAN_WARNING("[get_wattage()] in power network."))
 
 		else
-			to_chat(user, "<span class='warning'>The cable is not powered.</span>")
+			to_chat(user, SPAN_WARNING("\The [src] is not powered."))
 
 		shock(user, 5, 0.2)
 
@@ -166,10 +166,10 @@ By design, d1 is the smallest direction and d2 is the highest
 		var/delay_holder
 
 		if(W.force < 5)
-			visible_message("<span class='warning'>[user] starts sawing away roughly at the cable with \the [W].</span>")
+			visible_message(SPAN_WARNING("[user] starts sawing away roughly at \the [src] with \the [W]."))
 			delay_holder = 8 SECONDS
 		else
-			visible_message("<span class='warning'>[user] begins to cut through the cable with \the [W].</span>")
+			visible_message(SPAN_WARNING("[user] begins to cut through \the [src] with \the [W]."))
 			delay_holder = 3 SECONDS
 
 		if(user.do_skilled(delay_holder, SKILL_ELECTRICAL, src))
@@ -177,7 +177,7 @@ By design, d1 is the smallest direction and d2 is the highest
 			if(W.obj_flags & OBJ_FLAG_CONDUCTIBLE)
 				shock(user, 66, 0.7)
 		else
-			visible_message("<span class='warning'>[user] stops cutting before any damage is done.</span>")
+			visible_message(SPAN_WARNING("[user] stops cutting before any damage is done."))
 
 	src.add_fingerprint(user)
 
@@ -187,11 +187,11 @@ By design, d1 is the smallest direction and d2 is the highest
 		return
 
 	if(d1 == UP || d2 == UP)
-		to_chat(user, "<span class='warning'>You must cut this cable from above.</span>")
+		to_chat(user, SPAN_WARNING("You must cut this [src] from above."))
 		return
 
 	if(breaker_box)
-		to_chat(user, "<span class='warning'>This cable is connected to a nearby breaker box. Use the breaker box to interact with it.</span>")
+		to_chat(user, SPAN_WARNING("This [src] is connected to a nearby breaker box. Use the breaker box to interact with it."))
 		return
 
 	if (shock(user, 50))
@@ -199,7 +199,7 @@ By design, d1 is the smallest direction and d2 is the highest
 
 	new/obj/item/stack/cable_coil(T, (src.d1 ? 2 : 1), color)
 
-	visible_message("<span class='warning'>[user] cuts the cable.</span>")
+	visible_message(SPAN_WARNING("[user] cuts \the [src]."))
 
 	if(HasBelow(z))
 		for(var/turf/turf in GetBelow(src))
@@ -535,7 +535,7 @@ By design, d1 is the smallest direction and d2 is the highest
 			return ..()
 
 		if(BP_IS_BRITTLE(S))
-			to_chat(user, "<span class='warning'>\The [H]'s [S.name] is hard and brittle - \the [src] cannot repair it.</span>")
+			to_chat(user, SPAN_WARNING("\The [H]'s [S.name] is hard and brittle - \the [src] cannot repair it."))
 			return 1
 
 		var/use_amt = min(src.amount, CEILING(S.burn_dam/3), 5)
@@ -573,7 +573,7 @@ By design, d1 is the smallest direction and d2 is the highest
 		selected_color = "Red"
 		final_color = possible_cable_colours[selected_color]
 	color = final_color
-	to_chat(user, "<span class='notice'>You change \the [src]'s color to [lowertext(selected_color)].</span>")
+	to_chat(user, SPAN_NOTICE("You change \the [src]'s color to [lowertext(selected_color)]."))
 
 /obj/item/stack/cable_coil/proc/update_wclass()
 	if(amount == 1)
@@ -587,11 +587,11 @@ By design, d1 is the smallest direction and d2 is the highest
 		return
 
 	if(get_amount() == 1)
-		to_chat(user, "A short piece of power cable.")
+		to_chat(user, "A [singular_name] of cable.")
 	else if(get_amount() == 2)
-		to_chat(user, "A piece of power cable.")
+		to_chat(user, "Two [plural_name] of cable.")
 	else
-		to_chat(user, "A coil of power cable. There are [get_amount()] lengths of cable in the coil.")
+		to_chat(user, "A coil of power cable. There are [get_amount()] [plural_name] of cable in the coil.")
 
 
 /obj/item/stack/cable_coil/verb/make_restraint()
@@ -602,13 +602,13 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(ishuman(M) && !M.incapacitated())
 		if(!isturf(usr.loc)) return
 		if(!src.use(15))
-			to_chat(usr, "<span class='warning'>You need at least 15 lengths to make restraints!</span>")
+			to_chat(usr, SPAN_WARNING("You need at least 15 [singular_name] of cable to make restraints!"))
 			return
 		var/obj/item/handcuffs/cable/B = new /obj/item/handcuffs/cable(usr.loc)
 		B.color = color
-		to_chat(usr, "<span class='notice'>You wind some cable together to make some restraints.</span>")
+		to_chat(usr, SPAN_NOTICE("You wind some [plural_name] of cable together to make some restraints."))
 	else
-		to_chat(usr, "<span class='notice'>You cannot do that.</span>")
+		to_chat(usr, SPAN_NOTICE("You cannot do that."))
 
 /obj/item/stack/cable_coil/cyborg/verb/set_colour()
 	set name = "Change Colour"
@@ -644,15 +644,15 @@ By design, d1 is the smallest direction and d2 is the highest
 		return
 
 	if(get_amount() < 1) // Out of cable
-		to_chat(user, "There is no cable left.")
+		to_chat(user, SPAN_WARNING("There is no [plural_name] of cable left."))
 		return
 
 	if(get_dist(F,user) > 1) // Too far
-		to_chat(user, "You can't lay cable at a place that far away.")
+		to_chat(user, SPAN_WARNING("You can't lay cable at a place that far away."))
 		return
 
 	if(!F.is_plating())		// Ff floor is intact, complain
-		to_chat(user, "You can't lay cable there unless the floor tiles are removed.")
+		to_chat(user, SPAN_WARNING("You can't lay cable there unless the floor tiles are removed."))
 		return
 
 	var/dirn
@@ -664,13 +664,13 @@ By design, d1 is the smallest direction and d2 is the highest
 	var/end_dir = 0
 	if(istype(F) && F.is_open())
 		if(!can_use(2))
-			to_chat(user, "You don't have enough cable to do this!")
+			to_chat(user, SPAN_WARNING("You don't have enough [plural_name] of cable to do this!"))
 			return
 		end_dir = DOWN
 
 	for(var/obj/structure/cable/LC in F)
 		if((LC.d1 == dirn && LC.d2 == end_dir ) || ( LC.d2 == dirn && LC.d1 == end_dir))
-			to_chat(user, "<span class='warning'>There's already a cable at that position.</span>")
+			to_chat(user, SPAN_WARNING("There's already a cable at that position."))
 			return
 
 	put_cable(F, user, end_dir, dirn)
@@ -691,7 +691,7 @@ By design, d1 is the smallest direction and d2 is the highest
 		return
 
 	if(get_dist(C, user) > 1)		// make sure it's close enough
-		to_chat(user, "You can't lay cable at a place that far away.")
+		to_chat(user, SPAN_WARNING("You can't lay cable at a place that far away."))
 		return
 
 	if(U == T) //if clicked on the turf we're standing on, try to put a cable in the direction we're facing
@@ -702,7 +702,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	// one end of the clicked cable is pointing towards us
 	if(C.d1 == dirn || C.d2 == dirn)
 		if(!U.is_plating())						// can't place a cable if the floor is complete
-			to_chat(user, "You can't lay cable there unless the floor tiles are removed.")
+			to_chat(user, SPAN_WARNING("You can't lay cable there unless the floor tiles are removed."))
 			return
 		else
 			// cable is pointing at us, we're standing on an open tile
@@ -712,7 +712,7 @@ By design, d1 is the smallest direction and d2 is the highest
 
 			for(var/obj/structure/cable/LC in U)		// check to make sure there's not a cable there already
 				if(LC.d1 == fdirn || LC.d2 == fdirn)
-					to_chat(user, "There's already a cable at that position.")
+					to_chat(user, SPAN_WARNING("There's already a cable at that position."))
 					return
 			put_cable(U,user,0,fdirn)
 			return TRUE
@@ -733,7 +733,7 @@ By design, d1 is the smallest direction and d2 is the highest
 			if(LC == C)			// skip the cable we're interacting with
 				continue
 			if((LC.d1 == nd1 && LC.d2 == nd2) || (LC.d1 == nd2 && LC.d2 == nd1) )	// make sure no cable matches either direction
-				to_chat(user, "There's already a cable at that position.")
+				to_chat(user, SPAN_WARNING("There's already a cable at that position."))
 				return
 
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -187,11 +187,11 @@ By design, d1 is the smallest direction and d2 is the highest
 		return
 
 	if(d1 == UP || d2 == UP)
-		to_chat(user, SPAN_WARNING("You must cut this [src] from above."))
+		to_chat(user, SPAN_WARNING("You must cut this [name] from above."))
 		return
 
 	if(breaker_box)
-		to_chat(user, SPAN_WARNING("This [src] is connected to a nearby breaker box. Use the breaker box to interact with it."))
+		to_chat(user, SPAN_WARNING("This [name] is connected to a nearby breaker box. Use the breaker box to interact with it."))
 		return
 
 	if (shock(user, 50))
@@ -602,7 +602,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(ishuman(M) && !M.incapacitated())
 		if(!isturf(usr.loc)) return
 		if(!src.use(15))
-			to_chat(usr, SPAN_WARNING("You need at least 15 [singular_name] of cable to make restraints!"))
+			to_chat(usr, SPAN_WARNING("You need at least 15 [plural_name] of cable to make restraints!"))
 			return
 		var/obj/item/handcuffs/cable/B = new /obj/item/handcuffs/cable(usr.loc)
 		B.color = color

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -767,6 +767,11 @@ By design, d1 is the smallest direction and d2 is the highest
 		C.denode()// this call may have disconnected some cables that terminated on the centre of the turf, if so split the powernets.
 		return TRUE
 
+	else if(C.d1 == UP) //Special cases for zcables, since they behave weirdly
+		. = turf_place(T, user)
+		if(.)
+			to_chat(user, SPAN_NOTICE("You connect the cable hanging from the ceiling."))
+		return .
 
 /obj/item/stack/cable_coil/proc/put_cable(turf/F, mob/user, d1, d2)
 	if(!istype(F))

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -676,6 +676,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	put_cable(F, user, end_dir, dirn)
 	if(end_dir == DOWN)
 		put_cable(GetBelow(F), user, UP, 0)
+	return TRUE
 
 // called when cable_coil is click on an installed obj/cable
 // or click on a turf that already contains a "node" cable
@@ -694,8 +695,7 @@ By design, d1 is the smallest direction and d2 is the highest
 		return
 
 	if(U == T) //if clicked on the turf we're standing on, try to put a cable in the direction we're facing
-		turf_place(T,user)
-		return
+		return turf_place(T,user)
 
 	var/dirn = get_dir(C, user)
 
@@ -715,7 +715,7 @@ By design, d1 is the smallest direction and d2 is the highest
 					to_chat(user, "There's already a cable at that position.")
 					return
 			put_cable(U,user,0,fdirn)
-			return
+			return TRUE
 
 	// exisiting cable doesn't point at our position, so see if it's a stub
 	else if(C.d1 == 0)
@@ -765,11 +765,12 @@ By design, d1 is the smallest direction and d2 is the highest
 				return
 
 		C.denode()// this call may have disconnected some cables that terminated on the centre of the turf, if so split the powernets.
-		return
+		return TRUE
+
 
 /obj/item/stack/cable_coil/proc/put_cable(turf/F, mob/user, d1, d2)
 	if(!istype(F))
-		return
+		return FALSE
 
 	var/obj/structure/cable/C = new(F)
 	C.cableColor(color)
@@ -792,11 +793,12 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(C.d2 & (C.d2 - 1))// if the cable is layed diagonally, check the others 2 possible directions
 		C.mergeDiagonalsNetworks(C.d2)
 
-	use(1)
+	. = use(1)
 	if (C.shock(user, 50))
 		if (prob(50)) //fail
 			new/obj/item/stack/cable_coil(C.loc, 1, C.color)
 			qdel(C)
+			return FALSE
 
 //////////////////////////////
 // Misc.

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -88,7 +88,7 @@
 	if(isCoil(W))
 		var/obj/item/stack/cable_coil/coil = W
 		var/turf/T = user.loc
-		if(!istype(T) || T.density || !T.can_build_cable(user))
+		if(!istype(T) || T.density || T.cannot_build_cable())
 			return
 		if(get_dist(src, user) > 1)
 			return

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -88,7 +88,7 @@
 	if(isCoil(W))
 		var/obj/item/stack/cable_coil/coil = W
 		var/turf/T = user.loc
-		if(!istype(T) || T.density || !T.is_plating())
+		if(!istype(T) || T.density || !T.can_build_cable(user))
 			return
 		if(get_dist(src, user) > 1)
 			return


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
* Added a message when connecting a upward pointing zcable, to let users know they connected it properly.
* Made it so connecting a upward pointing zcable calls turf_place instead, to make them a bit more coherent with the regular cables.
* Made all turfs hit with a cable coil use the same code, condition check, and error message procs This makes the checks usable elsewhere. (aka in my tweaks)
* Did some misc text string cleanup.

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
tweak: Upward pointing cable stubs now give proper feedback, and install properly when clicked on with a cable coil in hands. You used to need to click on the turf instead before, which was a bit confusing.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
