### PR TITLE
Minor inflatable refactor.

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -455,17 +455,20 @@
 	name = "firefighting equipment belt"
 	desc = "A belt specially designed for firefighting."
 	icon = 'icons/clothing/belt/firefighter.dmi'
-	storage_slots = 5
+	storage_slots = 6
 	overlay_flags = BELT_OVERLAY_ITEMS
 	can_hold = list(
 		/obj/item/grenade/chem_grenade/water,
 		/obj/item/extinguisher/mini,
+		/obj/item/inflatable,
 		/obj/item/inflatable/door
 		)
 
 
 /obj/item/storage/belt/fire_belt/full
 	startswith = list(
+		/obj/item/inflatable,
+		/obj/item/inflatable,
 		/obj/item/inflatable/door,
 		/obj/item/extinguisher/mini,
 		/obj/item/grenade/chem_grenade/water = 2

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -24,7 +24,7 @@
 	. = list(/obj/item/tank/emergency/oxygen = 2,
 			/obj/item/clothing/mask/breath = 2)
 
-	. += new/datum/atom_creator/simple(list(/obj/item/storage/toolbox/emergency, /obj/item/inflatable/wall = 2), 75)
+	. += new/datum/atom_creator/simple(list(/obj/item/storage/toolbox/emergency, /obj/item/inflatable = 2, /obj/item/inflatable/door = 1), 75)
 	. += new/datum/atom_creator/simple(list(/obj/item/tank/emergency/oxygen/engi, /obj/item/clothing/mask/gas/half), 10)
 	. += new/datum/atom_creator/simple(/obj/item/oxycandle, 15)
 	. += new/datum/atom_creator/simple(/obj/item/storage/firstaid/o2, 25)
@@ -165,6 +165,7 @@
 
 /obj/structure/closet/hydrant/WillContain()
 	return list(
+		/obj/item/inflatable = 2,
 		/obj/item/inflatable/door = 2,
 		/obj/item/storage/med_pouch/burn = 2,
 		/obj/item/clothing/mask/gas/half,

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -1,8 +1,11 @@
 /obj/item/inflatable
-	name = "inflatable item"
-	w_class = ITEM_SIZE_NORMAL
+	name = "inflatable wall"
+	desc = "A folded membrane which rapidly expands into a large cubical shape on activation."
 	icon = 'icons/obj/structures/inflatable.dmi'
-	var/deploy_path = null
+	icon_state = "folded_wall"
+	material = /decl/material/solid/plastic
+	w_class = ITEM_SIZE_NORMAL
+	var/deploy_path = /obj/structure/inflatable/wall
 	var/inflatable_health
 
 /obj/item/inflatable/attack_self(mob/user)
@@ -23,12 +26,6 @@
 		R.health = inflatable_health
 	qdel(src)
 
-/obj/item/inflatable/wall
-	name = "inflatable wall"
-	desc = "A folded membrane which rapidly expands into a large cubical shape on activation."
-	icon_state = "folded_wall"
-	deploy_path = /obj/structure/inflatable/wall
-
 /obj/item/inflatable/door
 	name = "inflatable door"
 	desc = "A folded membrane which rapidly expands into a simple door on activation."
@@ -47,6 +44,7 @@
 	maxhealth = 20
 	hitsound = 'sound/effects/Glasshit.ogg'
 	atmos_canpass = CANPASS_DENSITY
+	material = /decl/material/solid/plastic
 
 	var/undeploy_path = null
 	var/taped
@@ -56,7 +54,7 @@
 
 /obj/structure/inflatable/wall
 	name = "inflatable wall"
-	undeploy_path = /obj/item/inflatable/wall
+	undeploy_path = /obj/item/inflatable
 
 /obj/structure/inflatable/Initialize()
 	. = ..()
@@ -154,7 +152,7 @@
 	playsound(loc, 'sound/machines/hiss.ogg', 75, 1)
 	if(violent)
 		visible_message("[src] rapidly deflates!")
-		var/obj/item/inflatable/torn/R = new /obj/item/inflatable/torn(loc)
+		var/obj/item/inflatable/torn/R = new(loc)
 		src.transfer_fingerprints_to(R)
 		qdel(src)
 	else
@@ -301,4 +299,4 @@
 	w_class = ITEM_SIZE_LARGE
 	max_storage_space = DEFAULT_LARGEBOX_STORAGE
 	can_hold = list(/obj/item/inflatable)
-	startswith = list(/obj/item/inflatable/door = 2, /obj/item/inflatable/wall = 3)
+	startswith = list(/obj/item/inflatable/door = 2, /obj/item/inflatable = 3)

--- a/code/modules/fabrication/designs/general/designs_tools.dm
+++ b/code/modules/fabrication/designs/general/designs_tools.dm
@@ -35,6 +35,12 @@
 /datum/fabricator_recipe/tool/minihoe
 	path = /obj/item/minihoe
 
+/datum/fabricator_recipe/tool/inflatable_wall
+	path = /obj/item/inflatable
+
+/datum/fabricator_recipe/tool/inflatable_door
+	path = /obj/item/inflatable/door
+
 /datum/fabricator_recipe/tool/welder_industrial
 	path = /obj/item/weldingtool/largetank
 	hidden = TRUE

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -348,17 +348,17 @@
 		visible_message("\The [user] deflates \the [A] with \the [src]!")
 		return
 	if(istype(A, /obj/item/inflatable))
-		if(istype(A, /obj/item/inflatable/wall))
-			if(stored_walls >= max_walls)
-				to_chat(user, "\The [src] is full.")
-				return
-			stored_walls++
-			qdel(A)
-		else
+		if(istype(A, /obj/item/inflatable/door))
 			if(stored_doors >= max_doors)
 				to_chat(usr, "\The [src] is full!")
 				return
 			stored_doors++
+			qdel(A)
+		else
+			if(stored_walls >= max_walls)
+				to_chat(user, "\The [src] is full.")
+				return
+			stored_walls++
 			qdel(A)
 		visible_message("\The [user] picks up \the [A] with \the [src]!")
 		return


### PR DESCRIPTION
## Description of changes
Makes inflatables use two types instead of 3, adds them to some belts and lockers, and makes them craftable.

## Why and what will this PR improve
Inflatables are useful and previously had a pointless abstract root path, now they don't.

## Authorship
Me.

## Changelog
:cl:
tweak: Inflatables are now craftable.
/:cl:

Depends on https://github.com/NebulaSS13/Nebula/pull/2324