### PR TITLE
Added godmode checks to fall damage + dislocating + shock

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -844,7 +844,7 @@
 		mind.changeling.regenerate()
 
 /mob/living/carbon/human/proc/handle_shock()
-	if(!can_feel_pain() || status_flags & GODMODE)
+	if(!can_feel_pain() || (status_flags & GODMODE))
 		shock_stage = 0
 		return
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -844,8 +844,7 @@
 		mind.changeling.regenerate()
 
 /mob/living/carbon/human/proc/handle_shock()
-	if(status_flags & GODMODE)	return 0	//godmode
-	if(!can_feel_pain())
+	if(!can_feel_pain() || status_flags & GODMODE)
 		shock_stage = 0
 		return
 

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -228,6 +228,8 @@
 	return BASE_STORAGE_COST(w_class)
 
 /mob/living/carbon/human/apply_fall_damage(var/turf/landing)
+	if(status_flags & GODMODE)
+		return
 	if(species && species.handle_fall_special(src, landing))
 		return
 	var/min_damage = 7

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -385,7 +385,7 @@
 		internal_organs_size += org.get_storage_cost()
 
 /obj/item/organ/external/proc/dislocate()
-	if(owner && owner.status_flags & GODMODE)
+	if(owner && (owner.status_flags & GODMODE))
 		return
 	if(dislocated == -1)
 		return

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -385,6 +385,8 @@
 		internal_organs_size += org.get_storage_cost()
 
 /obj/item/organ/external/proc/dislocate()
+	if(owner && owner.status_flags & GODMODE)
+		return
 	if(dislocated == -1)
 		return
 


### PR DESCRIPTION
## Description of changes
Godmode wouldn't prevent shock, dislocation or fall damage specific effects.
So I added more godmode checks!

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
bugfix: Godmode human now properly ignore fall damage, shock, and dislocation effects.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
