### PR TITLE
Limb dislocation fix + improvements

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -49,6 +49,7 @@
 #define ORGAN_PROSTHETIC BITFLAG(11) // The organ is prosthetic. Changes numerous behaviors, search BP_IS_PROSTHETIC for checks.
 #define ORGAN_BRITTLE    BITFLAG(12) // The organ takes additional blunt damage. If robotic, cannot be repaired through normal means.
 #define ORGAN_CRYSTAL    BITFLAG(13) // The organ does not suffer laser damage, but shatters on droplimb.
+#define ORGAN_DISLOCATED BITFLAG(14)
 
 // Organ flag defines.
 #define ORGAN_FLAG_CAN_AMPUTATE   BITFLAG(0) // The organ can be amputated.

--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -58,6 +58,7 @@
 #define ORGAN_FLAG_FINGERPRINT    BITFLAG(4) // The organ has a fingerprint.
 #define ORGAN_FLAG_HEALS_OVERKILL BITFLAG(5) // The organ heals from overkill damage.
 #define ORGAN_FLAG_DEFORMED       BITFLAG(6) // The organ is permanently disfigured.
+#define ORGAN_FLAG_CAN_DISLOCATE  BITFLAG(7) // The organ can be dislocated.
 
 // Droplimb types.
 #define DISMEMBER_METHOD_EDGE  0

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -205,7 +205,7 @@
 		var/found_disloc
 		for(var/obj/item/organ/external/e in H.get_external_organs())
 			if(e)
-				if(!found_disloc && e.dislocated == 2)
+				if(!found_disloc && e.is_dislocated())
 					dat += "<span class='scan_warning'>Dislocation detected. Advanced scanner required for location.</span>"
 					found_disloc = TRUE
 				if(!found_bleed && (e.status & ORGAN_ARTERY_CUT))

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -52,7 +52,7 @@
 		return FALSE
 
 	if(!assailant.skill_check(SKILL_COMBAT, SKILL_ADEPT))
-		to_chat(assailant, SPAN_WARNING("You attempt clumsily but struggle to do a proper jointlock with \the [affecting]'s [O.name]!"))
+		to_chat(assailant, SPAN_WARNING("You clumsily attempt to jointlock \the [affecting]'s [O.name], but fail!"))
 		return FALSE
 
 	assailant.visible_message(SPAN_DANGER("\The [assailant] begins to [pick("bend", "twist")] \the [affecting]'s [O.name] into a jointlock!"))
@@ -85,7 +85,7 @@
 		return  FALSE
 
 	if(!assailant.skill_check(SKILL_COMBAT, SKILL_ADEPT))
-		to_chat(assailant, SPAN_WARNING("You attempt clumsily but can't seem to dislocate \the [affecting]'s [O.joint]!"))
+		to_chat(assailant, SPAN_WARNING("You clumsily attempt to dislocate \the [affecting]'s [O.name], but fail!"))
 		return FALSE
 
 	if(!O.is_dislocated() && (O.limb_flags & ORGAN_FLAG_CAN_DISLOCATE))

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -98,7 +98,7 @@
 			return TRUE
 		affecting.visible_message(SPAN_WARNING("\The [assailant] fails to dislocate \the [affecting]'s [O.joint]."))
 		return FALSE
-		
+
 	if(O.limb_flags & ORGAN_FLAG_CAN_DISLOCATE)
 		to_chat(assailant, SPAN_WARNING("\The [affecting]'s [O.joint] is already dislocated!"))
 	else

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -90,8 +90,8 @@
 			return TRUE
 		affecting.visible_message(SPAN_WARNING("\The [assailant] fails to dislocate \the [affecting]'s [O.joint]."))
 		return FALSE
-
-	if (O.dislocated > 0)
+		
+	if(O.limb_flags & ORGAN_FLAG_CAN_DISLOCATE)
 		to_chat(assailant, SPAN_WARNING("\The [affecting]'s [O.joint] is already dislocated!"))
 	else
 		to_chat(assailant, SPAN_WARNING("You can't dislocate \the [affecting]'s [O.joint]!"))

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -43,12 +43,16 @@
 		return FALSE
 
 	var/mob/living/assailant = G.assailant
-	if(!assailant || !assailant.skill_check(SKILL_COMBAT, SKILL_ADEPT))
+	if(!assailant)
 		return FALSE
 
 	var/obj/item/organ/external/O = G.get_targeted_organ()
 	if(!O)
 		to_chat(assailant, SPAN_WARNING("\The [affecting] is missing that body part!"))
+		return FALSE
+
+	if(!assailant.skill_check(SKILL_COMBAT, SKILL_ADEPT))
+		to_chat(assailant, SPAN_WARNING("You attempt clumsily but struggle to do a proper jointlock with \the [affecting]'s [O.name]!"))
 		return FALSE
 
 	assailant.visible_message(SPAN_DANGER("\The [assailant] begins to [pick("bend", "twist")] \the [affecting]'s [O.name] into a jointlock!"))
@@ -72,7 +76,7 @@
 		return FALSE
 
 	var/mob/living/assailant = G.assailant
-	if(!assailant || !assailant.skill_check(SKILL_COMBAT, SKILL_ADEPT))
+	if(!assailant)
 		return FALSE
 
 	var/obj/item/organ/external/O = G.get_targeted_organ()
@@ -80,11 +84,15 @@
 		to_chat(assailant, SPAN_WARNING("\The [affecting] is missing that body part!"))
 		return  FALSE
 
-	if(!O.is_dislocated())
+	if(!assailant.skill_check(SKILL_COMBAT, SKILL_ADEPT))
+		to_chat(assailant, SPAN_WARNING("You attempt clumsily but can't seem to dislocate \the [affecting]'s [O.joint]!"))
+		return FALSE
+
+	if(!O.is_dislocated() && (O.limb_flags & ORGAN_FLAG_CAN_DISLOCATE))
 		assailant.visible_message(SPAN_DANGER("\The [assailant] begins to dislocate \the [affecting]'s [O.joint]!"))
 		if(do_mob(assailant, affecting, action_cooldown - 1))
 			G.action_used()
-			O.dislocate(1)
+			O.dislocate()
 			assailant.visible_message(SPAN_DANGER("\The [affecting]'s [O.joint] [pick("gives way","caves in","crumbles","collapses")]!"))
 			playsound(assailant.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 			return TRUE

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -80,7 +80,7 @@
 		to_chat(assailant, SPAN_WARNING("\The [affecting] is missing that body part!"))
 		return  FALSE
 
-	if(!O.dislocated)
+	if(!O.is_dislocated())
 		assailant.visible_message(SPAN_DANGER("\The [assailant] begins to dislocate \the [affecting]'s [O.joint]!"))
 		if(do_mob(assailant, affecting, action_cooldown - 1))
 			G.action_used()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -267,7 +267,7 @@
 				if(wounddesc != "nothing")
 					wound_flavor_text[E.name] += "[G.He] [G.has] [wounddesc] on [G.his] [E.name].<br>"
 		if(!hidden || distance <=1)
-			if(E.dislocated > 0)
+			if(E.is_dislocated())
 				wound_flavor_text[E.name] += "[G.His] [E.joint] is dislocated!<br>"
 			if(((E.status & ORGAN_BROKEN) && E.brute_dam > E.min_broken_damage) || (E.status & ORGAN_MUTATED))
 				wound_flavor_text[E.name] += "[G.His] [E.name] is dented and swollen!<br>"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1019,7 +1019,7 @@
 				status += "MISSING"
 			if(org.status & ORGAN_MUTATED)
 				status += "misshapen"
-			if(org.dislocated == 2)
+			if(org.is_dislocated())
 				status += "dislocated"
 			if(org.status & ORGAN_BROKEN)
 				status += "hurts when touched"

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -269,7 +269,7 @@ meteor_act
 			C.update_clothing_icon()
 
 /mob/living/carbon/human/proc/attack_joint(var/obj/item/organ/external/organ, var/obj/item/W, var/effective_force, var/dislocate_mult, var/blocked)
-	if(!organ || organ.is_dislocated() || !(E.limb_flags & ORGAN_FLAG_CAN_DISLOCATE) || blocked >= 100)
+	if(!organ || organ.is_dislocated() || !(organ.limb_flags & ORGAN_FLAG_CAN_DISLOCATE) || blocked >= 100)
 		return 0
 	if(W.damtype != BRUTE)
 		return 0

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -269,7 +269,7 @@ meteor_act
 			C.update_clothing_icon()
 
 /mob/living/carbon/human/proc/attack_joint(var/obj/item/organ/external/organ, var/obj/item/W, var/effective_force, var/dislocate_mult, var/blocked)
-	if(!organ || (organ.dislocated == 2) || (organ.dislocated == -1) || blocked >= 100)
+	if(!organ || organ.is_dislocated() || (organ.dislocated == -1) || blocked >= 100)
 		return 0
 	if(W.damtype != BRUTE)
 		return 0

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -269,7 +269,7 @@ meteor_act
 			C.update_clothing_icon()
 
 /mob/living/carbon/human/proc/attack_joint(var/obj/item/organ/external/organ, var/obj/item/W, var/effective_force, var/dislocate_mult, var/blocked)
-	if(!organ || organ.is_dislocated() || (organ.dislocated == -1) || blocked >= 100)
+	if(!organ || organ.is_dislocated() || !(E.limb_flags & ORGAN_FLAG_CAN_DISLOCATE) || blocked >= 100)
 		return 0
 	if(W.damtype != BRUTE)
 		return 0

--- a/code/modules/mob/living/carbon/human/human_verbs.dm
+++ b/code/modules/mob/living/carbon/human/human_verbs.dm
@@ -284,7 +284,7 @@
 
 	var/list/limbs = list()
 	for(var/obj/item/organ/external/current_limb in get_external_organs())
-		if(current_limb && current_limb.dislocated > 0 && !current_limb.is_parent_dislocated()) //if the parent is also dislocated you will have to relocate that first
+		if(current_limb && current_limb.is_dislocated() && !current_limb.is_parent_dislocated()) //if the parent is also dislocated you will have to relocate that first
 			limbs |= current_limb
 	var/obj/item/organ/external/current_limb = input(usr,"Which joint do you wish to relocate?") as null|anything in limbs
 

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -248,7 +248,7 @@
 		var/list/victims = list()
 		for(var/tag in list(BP_L_FOOT, BP_R_FOOT, BP_L_ARM, BP_R_ARM))
 			var/obj/item/organ/external/E = get_organ(tag)
-			if(E && !E.is_stump() && !E.is_dislocated() && E.dislocated != -1 && !BP_IS_PROSTHETIC(E))
+			if(E && !E.is_stump() && !E.is_dislocated() && (E.limb_flags & ORGAN_FLAG_CAN_DISLOCATE) && !BP_IS_PROSTHETIC(E))
 				victims += E
 		if(victims.len)
 			var/obj/item/organ/external/victim = pick(victims)

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -248,7 +248,7 @@
 		var/list/victims = list()
 		for(var/tag in list(BP_L_FOOT, BP_R_FOOT, BP_L_ARM, BP_R_ARM))
 			var/obj/item/organ/external/E = get_organ(tag)
-			if(E && !E.is_stump() && !E.dislocated && !BP_IS_PROSTHETIC(E))
+			if(E && !E.is_stump() && !E.is_dislocated() && E.dislocated != -1 && !BP_IS_PROSTHETIC(E))
 				victims += E
 		if(victims.len)
 			var/obj/item/organ/external/victim = pick(victims)

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -151,7 +151,7 @@
 		for(var/atom/A in below)
 			if(!A.CanPass(src, location_override))
 				return FALSE
-		
+
 		//We cannot sink if we can swim
 		if(location_override.get_fluid_depth() >= FLUID_DEEP && (below == loc))
 			if(!(below.get_fluid_depth() >= 0.95 * FLUID_MAX_DEPTH)) //No salmon skipping up a stream of falling water
@@ -325,7 +325,7 @@
 
 /mob/living/simple_animal/aquatic/can_float()
 	return TRUE
-	
+
 /mob/living/simple_animal/hostile/aquatic/can_float()
 	return TRUE
 

--- a/code/modules/organs/ailments/ailments_medical.dm
+++ b/code/modules/organs/ailments/ailments_medical.dm
@@ -111,7 +111,7 @@
 
 /datum/ailment/sore_joint/can_apply_to(obj/item/organ/_organ)
 	var/obj/item/organ/external/E = _organ
-	. = ..() && !isnull(E.joint) && E.dislocated > -1
+	. = ..() && !isnull(E.joint) && (E.limb_flags & ORGAN_FLAG_CAN_DISLOCATE)
 
 /datum/ailment/sore_back
 	name = "sore back"

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -26,7 +26,7 @@
 	var/pain_disability_threshold      // Point at which a limb becomes unusable due to pain.
 
 	// A bitfield for a collection of limb behavior flags.
-	var/limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_BREAK
+	var/limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_BREAK | ORGAN_FLAG_CAN_DISLOCATE
 
 	// Appearance vars.
 	var/icon_name = null               // Icon state base.
@@ -58,7 +58,7 @@
 	// Joint/state stuff.
 	var/joint = "joint"                // Descriptive string used in dislocation.
 	var/amputation_point               // Descriptive string used in amputation.
-	var/dislocated = 0                 // If you target a joint, you can dislocate the limb, causing temporary damage to the organ.
+	var/dislocated = 0                 // If you target a joint, you can dislocate the limb, causing temporary damage to the organ. Boolean.
 	var/encased                        // Needs to be opened with a saw to access the organs.
 	var/artery_name = "artery"         // Flavour text for cartoid artery, aorta, etc.
 	var/arterial_bleed_severity = 1    // Multiplier for bleeding in a limb.
@@ -100,12 +100,12 @@
 		F.completeness = rand(10,90)
 		forensics.add_data(/datum/forensics/fingerprints, F)
 
-/obj/item/organ/external/Initialize(mapload, material_key, datum/dna/given_dna)	
+/obj/item/organ/external/Initialize(mapload, material_key, datum/dna/given_dna)
 	. = ..()
 	if(. == INITIALIZE_HINT_QDEL)
 		return
 	if(isnull(pain_disability_threshold))
-		pain_disability_threshold = (max_damage * 0.75)	
+		pain_disability_threshold = (max_damage * 0.75)
 
 /obj/item/organ/external/Destroy()
 	//Update the hierarchy BEFORE clearing all the vars and refs
@@ -327,7 +327,7 @@
 		if(cutting_result != -1)
 			user.visible_message(SPAN_DANGER("<b>[user]</b> stops trying to cut \the [removing]."))
 		return TRUE
-	
+
 	//Actually remove it
 	removing.do_uninstall()
 	removing.forceMove(get_turf(user))
@@ -372,8 +372,8 @@
 
 /obj/item/organ/external/proc/is_parent_dislocated()
 	var/obj/item/organ/external/O = parent
-	while(O && O.dislocated != -1)
-		if(O.dislocated == 1)
+	while(O && (O.limb_flags & ORGAN_FLAG_CAN_DISLOCATE))
+		if(O.dislocated > 0)
 			return TRUE
 		O = O.parent
 	return FALSE
@@ -386,15 +386,15 @@
 /obj/item/organ/external/proc/dislocate()
 	if(owner && (owner.status_flags & GODMODE))
 		return
-	if(dislocated == -1)
+	if(!(limb_flags & ORGAN_FLAG_CAN_DISLOCATE))
 		return
 
 	dislocated = 1
 	if(owner)
 		owner.verbs |= /mob/living/carbon/human/proc/undislocate
 
-/obj/item/organ/external/proc/undislocate()
-	if(dislocated == -1)
+/obj/item/organ/external/proc/undislocate(var/skip_pain = FALSE)
+	if(!(limb_flags & ORGAN_FLAG_CAN_DISLOCATE))
 		return
 
 	dislocated = 0
@@ -461,7 +461,7 @@
 		if(istype(affected))
 			if(parent_organ != affected.organ_tag)
 				log_warning("obj/item/organ/external/do_install(): The parent organ in the parameters '[affected]'('[affected.organ_tag]') doesn't match the expected parent organ ('[parent_organ]') for '[src]'!")
-			parent = affected 
+			parent = affected
 
 		//When no owner, make sure we update all our children. Everything else should be implicitely at the right place
 		for(var/obj/item/organ/external/organ in children)
@@ -481,7 +481,7 @@
 			if(W.limb_tag == organ_tag)
 				qdel(W) //Removes itself from parent.wounds
 				break
-		
+
 		if(!in_place)
 			parent.update_wounds()
 
@@ -1257,18 +1257,18 @@ Note that amputating the affected organ does in fact remove the infection from t
 		//Handling for decl
 		R = company
 		company = R.type
-	else 
+	else
 		//Handling for paths
 		if(!ispath(company))
 			PRINT_STACK_TRACE("Limb [type] robotize() was supplied a null or non-decl manufacturer: '[company]'")
 			company = /decl/prosthetics_manufacturer
 		R = GET_DECL(company)
-	
+
 	//If can't install fallback to default
 	if(!R.check_can_install(organ_tag, (check_bodytype || owner?.get_bodytype_category() || global.using_map.default_bodytype), (check_species || owner?.get_species_name() || global.using_map.default_species)))
 		company = /decl/prosthetics_manufacturer
 		R = GET_DECL(/decl/prosthetics_manufacturer)
-		
+
 	model = company
 	name = "[R ? R.modifier_string : "robotic"] [initial(name)]"
 	desc = "[R.desc] It looks like it was produced by [R.name]."
@@ -1276,7 +1276,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	slowdown = R.movement_slowdown
 	max_damage *= R.hardiness
 	min_broken_damage *= R.hardiness
-	dislocated = -1
+	dislocated = 0
+	limb_flags &= (~ORGAN_FLAG_CAN_DISLOCATE)
 	remove_splint()
 	update_icon(1)
 	unmutate()
@@ -1355,7 +1356,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	var/mob/living/carbon/human/victim = owner //parent proc clears owner
 	if(!(. = ..()))
 		return
-	
+
 	if(victim)
 		if(in_place)
 			//When removing in place, we don't bother with moving child organs and implants, we just clear the refs

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -587,8 +587,6 @@ This function completely restores a damaged organ to perfect condition.
 
 	undislocate(TRUE)
 
-	undislocate(TRUE)
-
 	if(!QDELETED(src) && species)
 		species.post_organ_rejuvenate(src, owner)
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -383,6 +383,8 @@
 		internal_organs_size += org.get_storage_cost()
 
 /obj/item/organ/external/proc/dislocate()
+	if(owner && (owner.status_flags & GODMODE))
+		return
 	if(!(limb_flags & ORGAN_FLAG_CAN_DISLOCATE))
 		return
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -399,7 +399,8 @@
 
 	dislocated = 0
 	if(owner)
-		owner.shock_stage += 20
+		if(!skip_pain)
+			owner.shock_stage += 20 //#FIXME: use add_pain instead
 
 		//check to see if we still need the verb
 		for(var/obj/item/organ/external/limb in owner.get_external_organs())
@@ -581,6 +582,8 @@ This function completely restores a damaged organ to perfect condition.
 			if(aspect.applies_to_organ(organ_tag))
 				aspect.apply(owner)
 		owner.updatehealth()
+	
+	undislocate(TRUE)
 
 	if(!QDELETED(src) && species)
 		species.post_organ_rejuvenate(src, owner)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -384,8 +384,6 @@
 		internal_organs_size += org.get_storage_cost()
 
 /obj/item/organ/external/proc/dislocate()
-	if(owner && (owner.status_flags & GODMODE))
-		return
 	if(!(limb_flags & ORGAN_FLAG_CAN_DISLOCATE))
 		return
 
@@ -586,7 +584,7 @@ This function completely restores a damaged organ to perfect condition.
 			if(aspect.applies_to_organ(organ_tag))
 				aspect.apply(owner)
 		owner.updatehealth()
-	
+
 	undislocate(TRUE)
 
 	if(!QDELETED(src) && species)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -588,6 +588,8 @@ This function completely restores a damaged organ to perfect condition.
 
 	undislocate(TRUE)
 
+	undislocate(TRUE)
+
 	if(!QDELETED(src) && species)
 		species.post_organ_rejuvenate(src, owner)
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -393,7 +393,7 @@
 	if(owner)
 		if(owner.can_feel_pain(src))
 			add_pain(20)
-			owner.apply_effect(5, WEAKEN)
+			owner.apply_effect(5, STUN)
 		owner.verbs |= /mob/living/carbon/human/proc/undislocate
 
 /obj/item/organ/external/proc/undislocate(var/skip_pain = FALSE)
@@ -404,7 +404,7 @@
 	if(owner)
 		if(!skip_pain && owner.can_feel_pain(src))
 			add_pain(20)
-			owner.apply_effect(2, WEAKEN)
+			owner.apply_effect(2, STUN)
 
 		//check to see if we still need the verb
 		for(var/obj/item/organ/external/limb in owner.get_external_organs())

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -368,19 +368,15 @@
 	return all_limbs
 
 /obj/item/organ/external/proc/is_dislocated()
-	if(dislocated > 0)
-		return 1
-	if(is_parent_dislocated())
-		return 1//if any parent is dislocated, we are considered dislocated as well
-	return 0
+	return (dislocated > 0) || is_parent_dislocated() //if any parent is dislocated, we are considered dislocated as well
 
 /obj/item/organ/external/proc/is_parent_dislocated()
 	var/obj/item/organ/external/O = parent
 	while(O && O.dislocated != -1)
 		if(O.dislocated == 1)
-			return 1
+			return TRUE
 		O = O.parent
-	return 0
+	return FALSE
 
 /obj/item/organ/external/proc/update_internal_organs_cost()
 	internal_organs_size = 0
@@ -407,7 +403,7 @@
 
 		//check to see if we still need the verb
 		for(var/obj/item/organ/external/limb in owner.get_external_organs())
-			if(limb.dislocated == 1)
+			if(limb.is_dislocated())
 				return
 		owner.verbs -= /mob/living/carbon/human/proc/undislocate
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -390,7 +390,7 @@
 
 	status |= ORGAN_DISLOCATED
 	if(owner)
-		if(owner.can_feel_pain(src))
+		if(can_feel_pain())
 			add_pain(20)
 			owner.apply_effect(5, STUN)
 		owner.verbs |= /mob/living/carbon/human/proc/undislocate
@@ -401,7 +401,7 @@
 
 	status &= (~ORGAN_DISLOCATED)
 	if(owner)
-		if(!skip_pain && owner.can_feel_pain(src))
+		if(!skip_pain && can_feel_pain())
 			add_pain(20)
 			owner.apply_effect(2, STUN)
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -566,7 +566,6 @@ This function completely restores a damaged organ to perfect condition.
 		qdel(wound)
 	number_wounds = 0
 
-	dislocated = initial(dislocated)
 	damage = 0
 	pain = 0
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -58,7 +58,6 @@
 	// Joint/state stuff.
 	var/joint = "joint"                // Descriptive string used in dislocation.
 	var/amputation_point               // Descriptive string used in amputation.
-	var/dislocated = 0                 // If you target a joint, you can dislocate the limb, causing temporary damage to the organ. Boolean.
 	var/encased                        // Needs to be opened with a saw to access the organs.
 	var/artery_name = "artery"         // Flavour text for cartoid artery, aorta, etc.
 	var/arterial_bleed_severity = 1    // Multiplier for bleeding in a limb.
@@ -368,12 +367,12 @@
 	return all_limbs
 
 /obj/item/organ/external/proc/is_dislocated()
-	return (dislocated > 0) || is_parent_dislocated() //if any parent is dislocated, we are considered dislocated as well
+	return (status & ORGAN_DISLOCATED) || is_parent_dislocated() //if any parent is dislocated, we are considered dislocated as well
 
 /obj/item/organ/external/proc/is_parent_dislocated()
 	var/obj/item/organ/external/O = parent
 	while(O && (O.limb_flags & ORGAN_FLAG_CAN_DISLOCATE))
-		if(O.dislocated > 0)
+		if(O.status & ORGAN_DISLOCATED)
 			return TRUE
 		O = O.parent
 	return FALSE
@@ -387,7 +386,7 @@
 	if(!(limb_flags & ORGAN_FLAG_CAN_DISLOCATE))
 		return
 
-	dislocated = TRUE
+	status |= ORGAN_DISLOCATED
 	if(owner)
 		if(owner.can_feel_pain(src))
 			add_pain(20)
@@ -398,7 +397,7 @@
 	if(!(limb_flags & ORGAN_FLAG_CAN_DISLOCATE))
 		return
 
-	dislocated = FALSE
+	status &= (~ORGAN_DISLOCATED)
 	if(owner)
 		if(!skip_pain && owner.can_feel_pain(src))
 			add_pain(20)
@@ -1281,7 +1280,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	slowdown = R.movement_slowdown
 	max_damage *= R.hardiness
 	min_broken_damage *= R.hardiness
-	dislocated = 0
+	status &= (~ORGAN_DISLOCATED)
 	limb_flags &= (~ORGAN_FLAG_CAN_DISLOCATE)
 	remove_splint()
 	update_icon(1)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -389,18 +389,22 @@
 	if(!(limb_flags & ORGAN_FLAG_CAN_DISLOCATE))
 		return
 
-	dislocated = 1
+	dislocated = TRUE
 	if(owner)
+		if(owner.can_feel_pain(src))
+			add_pain(20)
+			owner.apply_effect(5, WEAKEN)
 		owner.verbs |= /mob/living/carbon/human/proc/undislocate
 
 /obj/item/organ/external/proc/undislocate(var/skip_pain = FALSE)
 	if(!(limb_flags & ORGAN_FLAG_CAN_DISLOCATE))
 		return
 
-	dislocated = 0
+	dislocated = FALSE
 	if(owner)
-		if(!skip_pain)
-			owner.shock_stage += 20 //#FIXME: use add_pain instead
+		if(!skip_pain && owner.can_feel_pain(src))
+			add_pain(20)
+			owner.apply_effect(2, WEAKEN)
 
 		//check to see if we still need the verb
 		for(var/obj/item/organ/external/limb in owner.get_external_organs())

--- a/code/modules/organs/external/diagnostics.dm
+++ b/code/modules/organs/external/diagnostics.dm
@@ -84,7 +84,7 @@
 		. += "[capitalize(artery_name)] ruptured"
 	if(status & ORGAN_TENDON_CUT)
 		. += "Severed [tendon_name]"
-	if(dislocated == 2) // non-magical constants when
+	if(is_dislocated())
 		. += "Dislocated"
 	if(splinted)
 		. += "Splinted"
@@ -163,7 +163,7 @@
 
 	if(status & ORGAN_TENDON_CUT)
 		to_chat(user, "<span class='warning'>The tendons in [name] are severed!</span>")
-	if(dislocated == 2)
+	if(is_dislocated())
 		to_chat(user, "<span class='warning'>The [joint] is dislocated!</span>")
 	return 1
 

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -15,7 +15,7 @@
 	artery_name = "carotid artery"
 	cavity_name = "cranial"
 
-	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_HEALS_OVERKILL | ORGAN_FLAG_CAN_BREAK
+	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_HEALS_OVERKILL | ORGAN_FLAG_CAN_BREAK | ORGAN_FLAG_CAN_DISLOCATE
 
 	var/draw_eyes = TRUE
 	var/glowing_eyes = FALSE

--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -16,7 +16,6 @@
 	vital = 1
 	amputation_point = "spine"
 	joint = "neck"
-	dislocated = -1
 	parent_organ = null
 	encased = "ribcage"
 	artery_name = "aorta"
@@ -54,7 +53,6 @@
 	parent_organ = BP_CHEST
 	amputation_point = "lumbar"
 	joint = "hip"
-	dislocated = -1
 	artery_name = "iliac artery"
 	cavity_name = "abdominal"
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_BREAK
@@ -79,7 +77,7 @@
 	tendon_name = "palmaris longus tendon"
 	artery_name = "basilic vein"
 	arterial_bleed_severity = 0.75
-	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK
+	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK | ORGAN_FLAG_CAN_DISLOCATE
 
 /obj/item/organ/external/arm/right
 	organ_tag = BP_R_ARM
@@ -104,7 +102,7 @@
 	tendon_name = "cruciate ligament"
 	artery_name = "femoral artery"
 	arterial_bleed_severity = 0.75
-	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK
+	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK | ORGAN_FLAG_CAN_DISLOCATE
 
 /obj/item/organ/external/leg/right
 	organ_tag = BP_R_LEG
@@ -129,7 +127,7 @@
 	amputation_point = "left ankle"
 	tendon_name = "Achilles tendon"
 	arterial_bleed_severity = 0.5
-	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK
+	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK | ORGAN_FLAG_CAN_DISLOCATE
 
 /obj/item/organ/external/foot/right
 	organ_tag = BP_R_FOOT
@@ -155,7 +153,7 @@
 	amputation_point = "left wrist"
 	tendon_name = "carpal ligament"
 	arterial_bleed_severity = 0.5
-	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_FINGERPRINT | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK
+	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_FINGERPRINT | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK | ORGAN_FLAG_CAN_DISLOCATE
 	var/gripper_ui_label = "L"
 	var/gripper_ui_loc = ui_lhand
 	var/overlay_slot_id = BP_L_HAND

--- a/code/modules/organs/external/stump.dm
+++ b/code/modules/organs/external/stump.dm
@@ -1,7 +1,6 @@
 /obj/item/organ/external/stump
 	name = "limb stump"
 	icon_name = ""
-	dislocated = -1
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE //Needs this for limb replacement surgery. Since you need to remove stumps first
 
 /obj/item/organ/external/stump/Initialize(mapload, var/internal, var/obj/item/organ/external/limb)

--- a/code/modules/organs/external/tail.dm
+++ b/code/modules/organs/external/tail.dm
@@ -12,7 +12,7 @@
 	amputation_point = "tail"
 	artery_name = "vein"
 	arterial_bleed_severity = 0.3
-	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_BREAK
+	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_BREAK | ORGAN_FLAG_CAN_DISLOCATE
 
 	var/tail                                  // Name of tail state in species effects icon file.
 	var/tail_animation                        // If set, the icon to obtain tail animation states from.

--- a/code/modules/organs/external/unbreakable.dm
+++ b/code/modules/organs/external/unbreakable.dm
@@ -1,55 +1,44 @@
 // Slime/xeno limbs.
 /obj/item/organ/external/chest/unbreakable
-	dislocated = -1
 	arterial_bleed_severity = 0
 	limb_flags = 0
 
 /obj/item/organ/external/groin/unbreakable
-	dislocated = -1
 	arterial_bleed_severity = 0
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE
 
 /obj/item/organ/external/arm/unbreakable
-	dislocated = -1
 	arterial_bleed_severity = 0
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE
 
 /obj/item/organ/external/arm/right/unbreakable
-	dislocated = -1
 	arterial_bleed_severity = 0
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE
 
 /obj/item/organ/external/leg/unbreakable
-	dislocated = -1
 	arterial_bleed_severity = 0
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND
 
 /obj/item/organ/external/leg/right/unbreakable
-	dislocated = -1
 	arterial_bleed_severity = 0
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE
 
 /obj/item/organ/external/foot/unbreakable
-	dislocated = -1
 	arterial_bleed_severity = 0
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND
 
 /obj/item/organ/external/foot/right/unbreakable
-	dislocated = -1
 	arterial_bleed_severity = 0
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE
 
 /obj/item/organ/external/hand/unbreakable
-	dislocated = -1
 	arterial_bleed_severity = 0
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE
 
 /obj/item/organ/external/hand/right/unbreakable
-	dislocated = -1
 	arterial_bleed_severity = 0
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE
 
 /obj/item/organ/external/head/unbreakable
-	dislocated = -1
 	arterial_bleed_severity = 0
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE

--- a/mods/species/adherent/organs/organs_external.dm
+++ b/mods/species/adherent/organs/organs_external.dm
@@ -7,7 +7,6 @@
 	body_part =               SLOT_LOWER_BODY
 	organ_tag =               BP_CHEST
 	parent_organ =            null
-	dislocated =              -1
 	max_damage =              50
 	min_broken_damage =       25
 	arterial_bleed_severity = 0
@@ -23,7 +22,6 @@
 	name =                    "trailing tendrils"
 	joint =                   "base"
 	arterial_bleed_severity = 0
-	dislocated =              -1
 	max_damage =              50
 	min_broken_damage =       25
 	encased = "ceramic hull"
@@ -40,7 +38,6 @@
 	joint =                   "connector socket"
 	glowing_eyes =            TRUE
 	arterial_bleed_severity = 0
-	dislocated =              -1
 	max_damage =              50
 	min_broken_damage =       25
 	cavity_max_w_class =      ITEM_SIZE_NORMAL // Apparently their brains change w_class to this.
@@ -57,7 +54,6 @@
 	amputation_point =        "midpoint"
 	joint =                   "base"
 	arterial_bleed_severity = 0
-	dislocated =              -1
 	max_damage =              20
 	min_broken_damage =       10
 	status = ORGAN_PROSTHETIC
@@ -71,7 +67,6 @@
 	amputation_point =        "midpoint"
 	joint =                   "base"
 	arterial_bleed_severity = 0
-	dislocated =              -1
 	max_damage =              20
 	min_broken_damage =       10
 	icon = 'mods/species/adherent/icons/body_turquoise.dmi'
@@ -86,7 +81,6 @@
 	amputation_point =        "midpoint"
 	joint =                   "base"
 	arterial_bleed_severity = 0
-	dislocated =              -1
 	max_damage =              20
 	min_broken_damage =       10
 	icon = 'mods/species/adherent/icons/body_turquoise.dmi'
@@ -101,7 +95,6 @@
 	amputation_point =        "midpoint"
 	joint =                   "base"
 	arterial_bleed_severity = 0
-	dislocated =              -1
 	max_damage =              20
 	min_broken_damage =       10
 	icon = 'mods/species/adherent/icons/body_turquoise.dmi'
@@ -119,7 +112,6 @@
 	organ_tag =               BP_L_LEG
 	parent_organ =            BP_CHEST
 	arterial_bleed_severity = 0
-	dislocated =              -1
 	max_damage =              20
 	min_broken_damage =       10
 	icon = 'mods/species/adherent/icons/body_turquoise.dmi'


### PR DESCRIPTION
## Description of changes
Dislocation effects wouldn't work properly, so fixed that. Now dislocated limbs show in medical scans again. 
Dislocating people's limbs using grabs, or anything else really, didn't cause any pain at all. Now it does once again.
Now use a limb_flag to tell if a limb can be dislocated instead of a magic number, so it works a bit more like other limb "capabilities".
Added a message during grabs when trying to dislocate or joint lock someone if you don't have the necessary skills.

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
bugfix: Dislocated limbs now show in medical scans again.
bugfix: Dislocating someone's limb now causes pain again.
tweak: Now get feedback when trying to use a jointlock or dislocate someone's limbs and don't have the required skills.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
