### PR TITLE
Blast doors now autoset direction from neighbors.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -295,10 +295,12 @@ About the new airlock wires panel:
 		return 0
 
 /obj/machinery/door/airlock/on_update_icon(state=0, override=0)
-	if(connections & (NORTH|SOUTH))
-		set_dir(EAST)
-	else
-		set_dir(SOUTH)
+
+	if(set_dir_on_update)
+		if(connections & (NORTH|SOUTH))
+			set_dir(EAST)
+		else
+			set_dir(SOUTH)
 
 	switch(state)
 		if(0)

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -82,6 +82,13 @@
 // Parameters: None
 // Description: Updates icon of this object. Uses icon state variables.
 /obj/machinery/door/blast/on_update_icon()
+
+	if(set_dir_on_update)
+		if(connections & (NORTH|SOUTH))
+			set_dir(EAST)
+		else
+			set_dir(SOUTH)
+
 	if(density)
 		if(stat & BROKEN)
 			icon_state = icon_state_closed_broken


### PR DESCRIPTION
Implements #132, firedoors already do this.
Airlocks will also now respect set_dir_on_update.