### PR TITLE
Generalizes grab-carrying across z-levels.

### DIFF
--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -188,47 +188,6 @@
 		mob.moving = FALSE
 		return
 
-	var/turf/new_loc = mob.loc
-	if(istype(new_loc))
-		for(var/atom/movable/AM AS_ANYTHING in mob.ret_grab())
-			if(AM != src && AM.loc != mob.loc && !AM.anchored && old_turf.Adjacent(AM))
-				AM.glide_size = mob.glide_size // This is adjusted by grabs again from events/some of the procs below, but doing it here makes it more likely to work with recursive movement.
-				AM.DoMove(get_dir(get_turf(AM), old_turf), mob, TRUE)
-
-	for(var/obj/item/grab/G AS_ANYTHING in mob.get_active_grabs())
-		if(G.assailant_reverse_facing())
-			mob.set_dir(global.reverse_dir[direction])
-		G.assailant_moved()
-		G.adjust_position()
-
-	if(length(mob.grabbed_by))
-		mob.reset_offsets()
-		mob.reset_plane_and_layer()
-
-	if(direction & (UP|DOWN))
-		var/txt_dir = (direction & UP) ? "upwards" : "downwards"
-		old_turf.visible_message(SPAN_NOTICE("[mob] moves [txt_dir]."))
-		for(var/obj/item/grab/G AS_ANYTHING in mob.get_active_grabs())
-			if(!G.affecting)
-				continue
-			var/turf/start = G.affecting.loc
-			var/turf/destination = (direction == UP) ? GetAbove(G.affecting) : GetBelow(G.affecting)
-			if(!start.CanZPass(G.affecting, direction))
-				to_chat(mob, SPAN_WARNING("\The [start] blocked your pulled object!"))
-				qdel(G)
-				continue
-			if(!destination.CanZPass(G.affecting, direction))
-				to_chat(mob, SPAN_WARNING("The [G.affecting] you were pulling bumps up against \the [destination]."))
-				qdel(G)
-				continue
-			for(var/atom/A in destination)
-				if(!A.CanMoveOnto(G.affecting, start, 1.5, direction))
-					to_chat(mob, SPAN_WARNING("\The [A] blocks the [G.affecting] you were pulling."))
-					qdel(G)
-					continue
-			G.affecting.forceMove(destination)
-			continue
-
 	// Sprinting uses up stamina and causes exertion effects.
 	if(MOVING_QUICKLY(mob))
 		mob.last_quick_move_time = world.time

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -242,11 +242,14 @@
 	current_grab.handle_resist(src)
 
 /obj/item/grab/proc/adjust_position(var/force = 0)
-	if(force)
+
+	if(!QDELETED(assailant) && force)
 		affecting.forceMove(assailant.loc)
-	if(!assailant || !affecting || !assailant.Adjacent(affecting))
+
+	if(QDELETED(assailant) || QDELETED(affecting) || !assailant.IsMultiZAdjacent(affecting))
 		qdel(src)
 		return 0
+
 	var/adir = get_dir(assailant, affecting)
 	if(assailant)
 		assailant.set_dir(adir)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -513,7 +513,6 @@ default behaviour is:
 		if(G.assailant_reverse_facing())
 			set_dir(global.reverse_dir[direction])
 		G.assailant_moved()
-		G.adjust_position()
 		if(QDELETED(G) || QDELETED(G.affecting))
 			mygrabs -= G
 
@@ -561,7 +560,7 @@ default behaviour is:
 /mob/living/Move(NewLoc, Dir)
 	if (buckled)
 		return
-	var/old_loc = loc
+	var/turf/old_loc = loc
 	. = ..()
 	if(.)
 		handle_grabs_after_move(old_loc, Dir)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -493,21 +493,80 @@ default behaviour is:
 /mob/living/proc/UpdateDamageIcon()
 	return
 
-/mob/living/handle_grabs_after_move()
+/mob/living/handle_grabs_after_move(var/turf/old_loc, var/direction)
+
 	..()
-	if(!skill_check(SKILL_MEDICAL, SKILL_BASIC))
-		for(var/obj/item/grab/grab in get_active_grabs())
+
+	if(!isturf(loc))
+		for(var/G in get_active_grabs())
+			qdel(G)
+			return
+
+	if(isturf(old_loc))
+		for(var/atom/movable/AM AS_ANYTHING in ret_grab())
+			if(AM != src && AM.loc != loc && !AM.anchored && old_loc.Adjacent(AM))
+				AM.glide_size = glide_size // This is adjusted by grabs again from events/some of the procs below, but doing it here makes it more likely to work with recursive movement.
+				AM.DoMove(get_dir(get_turf(AM), old_loc), src, TRUE)
+
+	var/list/mygrabs = get_active_grabs()
+	for(var/obj/item/grab/G AS_ANYTHING in mygrabs)
+		if(G.assailant_reverse_facing())
+			set_dir(global.reverse_dir[direction])
+		G.assailant_moved()
+		G.adjust_position()
+		if(QDELETED(G) || QDELETED(G.affecting))
+			mygrabs -= G
+
+	if(!length(mygrabs))
+		return
+
+	if(length(grabbed_by))
+		reset_offsets()
+		reset_plane_and_layer()
+
+	if(direction & (UP|DOWN))
+		var/txt_dir = (direction & UP) ? "upwards" : "downwards"
+		if(old_loc)
+			old_loc.visible_message(SPAN_NOTICE("\The [src] moves [txt_dir]."))
+		for(var/obj/item/grab/G AS_ANYTHING in mygrabs)
+			var/turf/start = G.affecting.loc
+			var/turf/destination = (direction == UP) ? GetAbove(G.affecting) : GetBelow(G.affecting)
+			if(!start.CanZPass(G.affecting, direction))
+				to_chat(src, SPAN_WARNING("\The [start] blocked your pulled object!"))
+				mygrabs -= G
+				qdel(G)
+				continue
+			if(!destination.CanZPass(G.affecting, direction))
+				to_chat(src, SPAN_WARNING("The [G.affecting] you were pulling bumps up against \the [destination]."))
+				mygrabs -= G
+				qdel(G)
+				continue
+			for(var/atom/A in destination)
+				if(!A.CanMoveOnto(G.affecting, start, 1.5, direction))
+					to_chat(src, SPAN_WARNING("\The [A] blocks the [G.affecting] you were pulling."))
+					mygrabs -= G
+					qdel(G)
+					continue
+			G.affecting.forceMove(destination)
+			if(QDELETED(G) || QDELETED(G.affecting))
+				mygrabs -= G
+			continue
+
+	if(length(mygrabs) && !skill_check(SKILL_MEDICAL, SKILL_BASIC))
+		for(var/obj/item/grab/grab AS_ANYTHING in mygrabs)
 			var/mob/living/affecting_mob = grab.get_affecting_mob()
 			if(affecting_mob)
 				affecting_mob.handle_grab_damage()
 
-/mob/living/Move(a, b, flag)
+/mob/living/Move(NewLoc, Dir)
 	if (buckled)
 		return
+	var/old_loc = loc
 	. = ..()
-	handle_grabs_after_move()
-	if (s_active && !( s_active in contents ) && get_turf(s_active) != get_turf(src))	//check !( s_active in contents ) first so we hopefully don't have to call get_turf() so much.
-		s_active.close(src)
+	if(.)
+		handle_grabs_after_move(old_loc, Dir)
+		if (s_active && !( s_active in contents ) && get_turf(s_active) != get_turf(src))	//check !( s_active in contents ) first so we hopefully don't have to call get_turf() so much.
+			s_active.close(src)
 
 /mob/living/verb/resist()
 	set name = "Resist"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1100,3 +1100,36 @@
 
 	// We're inside, and more than one z-level below the roof, so ignore it.
 	return WEATHER_IGNORE
+
+/mob/proc/IsMultiZAdjacent(var/atom/neighbor)
+
+	var/turf/T = get_turf(src)
+	var/turf/N = get_turf(neighbor)
+
+	// Not on valid turfs.
+	if(QDELETED(src) || QDELETED(neighbor) || !istype(T) || !istype(N))
+		return FALSE
+
+	// On the same z-level, we don't need to care about multiz.
+	if(N.z == T.z)
+		return Adjacent(neighbor)
+
+	// More than one z-level away from each other.
+	if(abs(N.x - T.x) > 1 || abs(N.y - T.y) > 1 || abs(N.z - T.z) > 1)
+		return FALSE
+
+	// Not in a connected z-volume.
+	if(!(N.z in GetConnectedZlevels(T.z)))
+		return FALSE
+
+	// Are they below us?
+	if(N.z < T.z && HasBelow(T.z))
+		var/turf/B = GetBelow(T)
+		return T.is_open() && neighbor.Adjacent(B)
+
+	// Are they above us?
+	if(HasAbove(T.z))
+		var/turf/A = GetAbove(T)
+		return A.is_open() && neighbor.Adjacent(A)
+
+	return FALSE

--- a/code/modules/mob/mob_grabs.dm
+++ b/code/modules/mob/mob_grabs.dm
@@ -32,7 +32,7 @@
 /mob/proc/handle_grab_damage()
 	set waitfor = FALSE
 
-/mob/proc/handle_grabs_after_move()
+/mob/proc/handle_grabs_after_move(var/turf/old_loc, var/direction)
 	set waitfor = FALSE
 
 /mob/proc/add_grab(var/obj/item/grab/grab, var/defer_hand = FALSE)

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -188,7 +188,7 @@
 
 /atom/movable/proc/handle_fall(var/turf/landing)
 	var/turf/previous = get_turf(loc)
-	forceMove(landing)
+	Move(landing, get_dir(previous, landing))
 	if(locate(/obj/structure/stairs) in landing)
 		return 1
 	if(landing.get_fluid_depth() >= FLUID_DEEP)


### PR DESCRIPTION
## Description of changes
Implements remaining aspects of #183.
- Grab move logic has been centralized in Move(), which should mean it behaves more consistently between methods of traversing z-levels.
- Falling now uses Move() rather than forceMove() to propagate grabs. Pulled mobs are still injured by the fall.
- Ladders will allow you to carry 75% of your pull strength up them (100% if you are in zero-G).

Tested stairs, ladders, falling through several levels, and spacemoves. Everything appears to work.

## Why and what will this PR improve
Consistent handling of grabs.

## Authorship
Myself.

## Changelog
:cl:
tweak: You can now carry things up ladders and through space with grabs.
/:cl:
