### PR TITLE
Gating off a division by zero check in gas heat capacity.

### DIFF
--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -169,7 +169,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 
 	// Gas behavior.
 	var/gas_overlay_limit
-	var/gas_specific_heat
+	var/gas_specific_heat = 20    // J/(mol*K)
 	var/gas_symbol_html
 	var/gas_symbol
 	var/gas_flags = 0

--- a/code/modules/materials/definitions/gasses/_mat_gas.dm
+++ b/code/modules/materials/definitions/gasses/_mat_gas.dm
@@ -7,7 +7,6 @@
 	conductive = 0
 	value = 0.15
 	burn_product = /decl/material/gas/carbon_dioxide
-	gas_specific_heat = 20    // J/(mol*K)
 	molar_mass =    0.032 // kg/mol
 	latent_heat = 213
 	reflectiveness = 0

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -140,7 +140,7 @@
 	for(var/g in gas)
 		var/decl/material/mat = GET_DECL(g)
 		. += mat.gas_specific_heat * gas[g]
-	. *= group_multiplier
+	. *= max(1, group_multiplier)
 
 
 //Adds or removes thermal energy. Returns the actual thermal energy change, as in the case of removing energy we can't go below TCMB.
@@ -150,6 +150,9 @@
 		return 0
 
 	var/heat_capacity = heat_capacity()
+	if(heat_capacity <= 0)
+		return 0
+
 	if (thermal_energy < 0)
 		if (temperature < TCMB)
 			return 0


### PR DESCRIPTION
Got a runtime during unit testing:
````
[23:00:20] Runtime in xgm_gas_mixture.dm,158: Division by zero
  proc name: add thermal energy (/datum/gas_mixture/proc/add_thermal_energy)
  src: /datum/gas_mixture (/datum/gas_mixture)
  call stack:
  /datum/gas_mixture (/datum/gas_mixture): add thermal energy(0)
  185 (/datum/seed): handle environment(the sand (33,27,8) (/turf/exterior/sand), /datum/gas_mixture (/datum/gas_mixture), null, null)
  the senecio erreg (/obj/machinery/portable_atmospherics/hydroponics/soil): Process(60, 3, Plants (/datum/controller/subsystem/processing/plants))
  Plants (/datum/controller/subsystem/processing/plants): fire(0)
  Plants (/datum/controller/subsystem/processing/plants): ignite(0)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing(0)
````
Moved the default gas heat capacity total to the base var and made sure a zero-member zone won't break it.