### PR TITLE
Adding safety checking to fluid turf and overlay queuing.

### DIFF
--- a/code/__defines/fluids.dm
+++ b/code/__defines/fluids.dm
@@ -8,11 +8,11 @@
 #define FLUID_PUSH_THRESHOLD 20      // Amount of flow needed to push items.
 
 // Expects /turf for T.
-#define ADD_ACTIVE_FLUID_SOURCE(T)    SSfluids.water_sources[T] = TRUE
+#define ADD_ACTIVE_FLUID_SOURCE(T)    if(!T.changing_turf) { SSfluids.water_sources[T] = TRUE; }
 #define REMOVE_ACTIVE_FLUID_SOURCE(T) SSfluids.water_sources -= T
 
 // Expects /obj/effect/fluid for F.
-#define ADD_ACTIVE_FLUID(F)           SSfluids.active_fluids[F] = TRUE
+#define ADD_ACTIVE_FLUID(F)           if(!QDELETED(F)) { SSfluids.active_fluids[F] = TRUE; }
 #define REMOVE_ACTIVE_FLUID(F)        SSfluids.active_fluids -= F
 
 // Expects turf for T,


### PR DESCRIPTION
## Description of changes
Adds QDELETED and changing_turf checks to fluid macros.

## Why and what will this PR improve
Avoids dangling references preventing GC.

## Authorship
Jade pointed the issue out, I authored the change.

## Changelog
Nothing player-facing.