### PR TITLE
Simplifies and modernizes report access.

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -47,14 +47,6 @@
 			return FALSE
 	return TRUE
 
-//Checks if the access (constant or list) is contained in one of the entries of access_patterns, a list of lists.
-/proc/has_access_pattern(list/access_patterns, access)
-	if(!islist(access))
-		access = list(access)
-	for(var/access_pattern in access_patterns)
-		if(has_access(access_pattern, access))
-			return 1
-
 // Used for retrieving required access information, if available
 /atom/movable/proc/get_req_access()
 	return null

--- a/code/modules/modular_computers/file_system/programs/generic/deck_management.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/deck_management.dm
@@ -185,11 +185,21 @@
 		prototype_shuttle = selected_shuttle
 		report_prototypes = list()
 		for(var/report_type in subtypesof(/datum/computer_file/report/recipient/shuttle))
-			var/datum/computer_file/report/recipient/shuttle/new_report = new report_type
-			if(new_report.access_shuttle)
-				new_report.set_access(null, selected_shuttle.logging_access, override = 0)
-			report_prototypes += new_report
+			report_prototypes += create_report(report_type, selected_shuttle)
 	return 1
+
+/datum/nano_module/deck_management/proc/create_report(report_type, datum/shuttle/given_shuttle)
+	var/datum/computer_file/report/recipient/shuttle/new_report = new report_type
+	if(new_report.access_shuttle && given_shuttle.logging_access)
+		var/old_access = new_report.write_access?.Copy()
+		var/new_access = list()
+		for(var/group in old_access) // We add logging_access as an OR option to every AND requirement
+			var/new_group = list()
+			new_group += group // this listifies it if it was not already a list
+			new_group |= given_shuttle.logging_access
+			new_access += list(new_group)
+		new_report.set_access(null, new_access, TRUE)
+	return new_report
 
 /datum/nano_module/deck_management/proc/set_mission(mission_ID)
 	var/datum/shuttle_log/my_log = SSshuttle.shuttle_logs[selected_shuttle]
@@ -256,8 +266,7 @@
 				if(selected_mission.flight_plan)
 					selected_report = selected_mission.flight_plan.clone()//We always make a new one to buffer changes until submitted.
 				else
-					selected_report = new /datum/computer_file/report/flight_plan
-					selected_report.set_access(null, selected_shuttle.logging_access, override = 0)
+					selected_report = create_report(/datum/computer_file/report/flight_plan, selected_shuttle)
 			else
 				if(selected_mission.stage in list(SHUTTLE_MISSION_PLANNED, SHUTTLE_MISSION_QUEUED))
 					return 1 //Hold your horses until the mission is started on these reports.

--- a/code/modules/modular_computers/file_system/reports/deck_reports.dm
+++ b/code/modules/modular_computers/file_system/reports/deck_reports.dm
@@ -6,10 +6,7 @@
 	var/datum/report_field/people/leader     //Give these a special name for easier access.
 	var/datum/report_field/people/manifest
 	var/datum/report_field/planned_depart
-
-/datum/computer_file/report/flight_plan/New()
-	..()
-	set_access(null, access_bridge)
+	write_access = list(access_bridge)
 
 /datum/computer_file/report/flight_plan/Destroy()
 	leader = null
@@ -31,11 +28,8 @@
 /datum/computer_file/report/recipient/shuttle
 	var/datum/report_field/shuttle
 	var/datum/report_field/mission
-	var/access_shuttle = 0 //Set to 1 to give the shuttle's logging access as an access_edit pattern.
-
-/datum/computer_file/report/recipient/shuttle/New()
-	..()
-	set_access(null, access_bridge)
+	var/access_shuttle = 0 //Set to 1 to give the shuttle's logging access write permissions when created
+	write_access = list(access_bridge)
 
 /datum/computer_file/report/recipient/shuttle/Destroy()
 	shuttle = null
@@ -52,10 +46,7 @@
 /datum/computer_file/report/recipient/shuttle/damage
 	form_name = "DC243"
 	title = "Post-flight Damage Assessment"
-
-/datum/computer_file/report/recipient/shuttle/damage/New()
-	..()
-	set_access(null, access_cargo, override = 0)
+	write_access = list(list(access_bridge, access_cargo))
 
 /datum/computer_file/report/recipient/shuttle/damage/generate_fields()
 	..()
@@ -68,10 +59,7 @@
 /datum/computer_file/report/recipient/shuttle/fuel
 	form_name = "DC12"
 	title = "Post-flight Refueling Report"
-
-/datum/computer_file/report/recipient/shuttle/fuel/New()
-	..()
-	set_access(null, access_cargo, override = 0)
+	write_access = list(list(access_bridge, access_cargo))
 
 /datum/computer_file/report/recipient/shuttle/fuel/generate_fields()
 	..()
@@ -83,10 +71,7 @@
 /datum/computer_file/report/recipient/shuttle/atmos
 	form_name = "DC245"
 	title = "Post-flight Atmospherics Assessment"
-
-/datum/computer_file/report/recipient/shuttle/atmos/New()
-	..()
-	set_access(null, access_cargo, override = 0)
+	write_access = list(list(access_bridge, access_cargo))
 
 /datum/computer_file/report/recipient/shuttle/atmos/generate_fields()
 	..()
@@ -98,10 +83,7 @@
 /datum/computer_file/report/recipient/shuttle/gear
 	form_name = "DC248b"
 	title = "Post-flight Emergency Supply Inventory; Summary Version"
-
-/datum/computer_file/report/recipient/shuttle/gear/New()
-	..()
-	set_access(null, access_cargo, override = 0)
+	write_access = list(list(access_bridge, access_cargo))
 
 /datum/computer_file/report/recipient/shuttle/gear/generate_fields()
 	..()

--- a/code/modules/modular_computers/file_system/reports/report_field.dm
+++ b/code/modules/modular_computers/file_system/reports/report_field.dm
@@ -21,32 +21,18 @@
 	. = ..()
 
 //Access stuff. Can be given access constants or lists. See report access procs for documentation.
-/datum/report_field/proc/set_access(read_access, write_access, override = 1, recursive = FALSE, access_group = 1)
+//For fields, the recursive argument indicates whether this access set is being propogated onto the whole report at once or not.
+/datum/report_field/proc/set_access(read_access, write_access, recursive = FALSE)
 	if(recursive && !can_mod_access)
 		return
 	if(read_access)
 		if(!islist(read_access))
 			read_access = list(read_access)
-		if(override)
-			src.read_access = read_access
-		else
-			if(access_group && access_group <= src.read_access.len)
-				if(!islist(src.read_access[access_group]))
-					src.read_access[access_group] = list(src.read_access[access_group])
-				src.read_access[access_group] += read_access
-			else
-				src.read_access += list(read_access)
+		src.read_access = read_access
 	if(write_access)
 		if(!islist(write_access))
 			write_access = list(write_access)
-		if(override)
-			src.write_access = write_access
-		else
-			if(access_group && access_group <= src.write_access.len)
-				if(!islist(src.write_access[access_group]))
-					src.write_access[access_group] = list(src.write_access[access_group])
-			else
-				src.write_access[access_group] += write_access
+		src.write_access = write_access
 
 // Analogous to get_file_perms on reports. Read access is required to have write access.
 /datum/report_field/proc/get_perms(accesses, mob/user)

--- a/code/modules/modular_computers/file_system/reports/warrant.dm
+++ b/code/modules/modular_computers/file_system/reports/warrant.dm
@@ -35,13 +35,13 @@
 /datum/computer_file/report/warrant/arrest
 	title = "Arrest Warrant"
 	form_name = "W-104-A"
+	write_access = list(access_security)
 
 /datum/computer_file/report/warrant/arrest/generate_fields()
 	add_field(/datum/report_field/text_label/header, "Arrest Warrant")
 	add_field(/datum/report_field/simple_text, "Name", "Unknown")
 	add_field(/datum/report_field/pencode_text, "Charges", "No charges")
 	add_field(/datum/report_field/signature, "Authorized by", "Unathorized")
-	set_access(write_access = access_security)
 
 /datum/computer_file/report/warrant/arrest/get_category()
 	. = ..()
@@ -74,13 +74,13 @@
 /datum/computer_file/report/warrant/search
 	title = "Search Warrant"
 	form_name = "W-104-S"
+	write_access = list(access_security)
 
 /datum/computer_file/report/warrant/search/generate_fields()
 	add_field(/datum/report_field/text_label/header, "Search Warrant")
 	add_field(/datum/report_field/simple_text, "Person/Location", "Unknown")
 	add_field(/datum/report_field/pencode_text, "Reason", "No reason")
 	add_field(/datum/report_field/signature, "Authorized by", "Unathorized")
-	set_access(write_access = access_security)
 
 /datum/computer_file/report/warrant/search/get_category()
 	. = ..()


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

Simplifies the report access setter procs.

## Why and what will this PR improve

Reports were written before the `list(list())` AND/OR access became standard. As such, they were using a different system to track access internally (access patterns/access groups). This system was a bit complicated and not familiar to anyone, so they had a complicated setter API so that people would not have to interact with the internal format directly.

As per the recent network access PR, they now use the standard `list(list())` system internally. This system is not complicated, and should be familiar to anyone who does any mapping or setting access on objs. As such, this PR simplifies the setter API: instead of making several calls with various vars set or unset to set AND access, you now just provide a `list(list())` type access that applies to the report (or a specific field).

## Authorship
me

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
:tweak: Report access setting has been reworked. Check your reports!
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
