### PR TITLE
Fix GC issues with temperature (+ maybe reactions)

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -47,7 +47,7 @@
 #define IGNORE_MOB_SIZE BITFLAG(0)
 #define AFFECTS_DEAD    BITFLAG(1)
 
-#define HANDLE_REACTIONS(_reagents)  SSmaterials.active_holders[_reagents] = TRUE
+#define HANDLE_REACTIONS(_reagents)  if(!QDELETED(_reagents)) { SSmaterials.active_holders[_reagents] = TRUE; }
 #define UNQUEUE_REACTIONS(_reagents) SSmaterials.active_holders -= _reagents
 
 #define REAGENT_LIST(R) (R.reagents?.get_reagents() || "No reagent holder")

--- a/code/__defines/temperature.dm
+++ b/code/__defines/temperature.dm
@@ -1,22 +1,39 @@
-#define ATOM_IS_TEMPERATURE_SENSITIVE(A) (A && !QDELETED(A) && !(A.atom_flags & ATOM_FLAG_NO_TEMP_CHANGE))
+#define ATOM_IS_TEMPERATURE_SENSITIVE(A) (A && !(A.atom_flags & ATOM_FLAG_NO_TEMP_CHANGE))
+#define ATOM_SHOULD_TEMPERATURE_ENQUEUE(A) (ATOM_IS_TEMPERATURE_SENSITIVE(A) && !QDELETED(A))
 #define ATOM_TEMPERATURE_EQUILIBRIUM_THRESHOLD 5
 #define ATOM_TEMPERATURE_EQUILIBRIUM_CONSTANT 0.25
 
 #define ADJUST_ATOM_TEMPERATURE(_atom, _temp) \
 	_atom.temperature = _temp; \
-	if(_atom.reagents) { \
-		HANDLE_REACTIONS(_atom.reagents); \
-	} \
+	HANDLE_REACTIONS(_atom.reagents); \
 	QUEUE_TEMPERATURE_ATOMS(_atom);
 
 #define QUEUE_TEMPERATURE_ATOMS(_atoms) \
 	if(islist(_atoms)) { \
 		for(var/thing in _atoms) { \
 			var/atom/A = thing; \
-			if(ATOM_IS_TEMPERATURE_SENSITIVE(A)) { \
-				SStemperature.processing[A] = TRUE; \
-			} \
+			QUEUE_TEMPERATURE_ATOM(A); \
 		} \
-	} else if(ATOM_IS_TEMPERATURE_SENSITIVE(_atoms)) { \
-		SStemperature.processing[_atoms] = TRUE; \
+	} else { \
+		QUEUE_TEMPERATURE_ATOM(_atoms); \
+	}
+
+#define QUEUE_TEMPERATURE_ATOM(_atom) \
+	if(ATOM_SHOULD_TEMPERATURE_ENQUEUE(_atom)) { \
+		SStemperature.processing[_atom] = TRUE; \
+	}
+
+#define UNQUEUE_TEMPERATURE_ATOMS(_atoms) \
+	if(islist(_atoms)) { \
+		for(var/thing in _atoms) { \
+			var/atom/A = thing; \
+			UNQUEUE_TEMPERATURE_ATOM(A); \
+		} \
+	} else { \
+		UNQUEUE_TEMPERATURE_ATOM(_atoms); \
+	}
+
+#define UNQUEUE_TEMPERATURE_ATOM(_atom) \
+	if(ATOM_IS_TEMPERATURE_SENSITIVE(_atom)) { \
+		SStemperature.processing -= _atom; \
 	}

--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -66,6 +66,8 @@
 	return
 
 /atom/Destroy()
+	UNQUEUE_TEMPERATURE_ATOM(src)
+
 	QDEL_NULL(reagents)
 
 	LAZYCLEARLIST(our_overlays)

--- a/code/game/atoms_temperature.dm
+++ b/code/game/atoms_temperature.dm
@@ -24,7 +24,7 @@
 	create_matter()
 
 /obj/proc/HandleObjectHeating(var/obj/item/heated_by, var/mob/user, var/adjust_temp)
-	if(ATOM_IS_TEMPERATURE_SENSITIVE(src))
+	if(ATOM_SHOULD_TEMPERATURE_ENQUEUE(src))
 		visible_message(SPAN_NOTICE("\The [user] carefully heats \the [src] with \the [heated_by]."))
 		var/diff_temp = (adjust_temp - temperature)
 		if(diff_temp >= 0)

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -180,7 +180,7 @@
 
 /obj/structure/fire_source/attackby(var/obj/item/thing, var/mob/user)
 
-	if(ATOM_IS_TEMPERATURE_SENSITIVE(thing) && user.a_intent != I_HURT)
+	if(ATOM_SHOULD_TEMPERATURE_ENQUEUE(thing) && user.a_intent != I_HURT)
 		thing.HandleObjectHeating(src, user, DIRECT_HEAT)
 		return TRUE
 

--- a/code/modules/reagents/reactions/_reaction.dm
+++ b/code/modules/reagents/reactions/_reaction.dm
@@ -37,7 +37,7 @@
 
 /decl/chemical_reaction/proc/on_reaction(var/datum/reagents/holder, var/created_volume, var/reaction_flags)
 	var/atom/location = holder.get_reaction_loc()
-	if(thermal_product && location && ATOM_IS_TEMPERATURE_SENSITIVE(location))
+	if(thermal_product && location && ATOM_SHOULD_TEMPERATURE_ENQUEUE(location))
 		ADJUST_ATOM_TEMPERATURE(location, thermal_product)
 
 // This proc returns a list of all reagents it wants to use; if the holder has several reactions that use the same reagent, it will split the reagent evenly between them


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Supersedes #2361.
Atoms will now remove themselves from `SStemperature.processing` when qdeleted.
Qdeleted reagent holders will no longer be queued for updating.
Renames and rewrites a few temperature macros.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
Fixes that cascade of GC fails approximately 2 minutes after the atoms info repository inits.
May also fix a bunch of other GC fails as well.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Me.
<!-- Describe original authors of changes to credit them. -->