### PR TITLE
Makes engines use less power, adds debug output to tally test

### DIFF
--- a/code/modules/overmap/ships/machines/gas_thruster.dm
+++ b/code/modules/overmap/ships/machines/gas_thruster.dm
@@ -14,7 +14,7 @@
 	base_type = /obj/machinery/atmospherics/unary/engine
 	use_power = POWER_USE_OFF
 	power_channel = EQUIP
-	idle_power_usage = 11600
+	idle_power_usage = 2320
 	var/engine_extension = /datum/extension/ship_engine/gas
 
 /obj/machinery/atmospherics/unary/engine/Initialize()

--- a/code/unit_tests/power_tests.dm
+++ b/code/unit_tests/power_tests.dm
@@ -83,6 +83,10 @@
 			if(abs(old_values[i] - new_values[i]) > 1) // Round because there can in fact be roundoff error here apparently.
 				failed = TRUE
 				log_bad("The area [A.name] had improper power use values on the [channel_names[i]] channel: was [old_values[i]] but should be [new_values[i]].")
+				log_bad("This area contained the following power-using machines on this channel:")
+				for(var/obj/machinery/machine in A)
+					if(machine.power_channel == i)
+						log_bad(log_info_line(machine) + " with power use [machine.get_power_usage()]")
 
 	if(failed)
 		fail("At least one area had improper power use values")


### PR DESCRIPTION
## Description of changes

Makes rocket nozzles use 1/5 the current power.
Adds debug output to power tally accuracy unit test, which has been failing sometimes on exoplanets.

## Why and what will this PR improve

Engines have other balance mechanisms, and it's impossible to recover from no power without engines working for most shuttles.

## Authorship
me

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
tweak: Engine power use has been decreased substantially.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
