### PR TITLE
More intuitive airlock/blast door construction

### DIFF
--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -225,6 +225,15 @@
 	sleep(5 SECONDS)
 	close()
 
+/obj/machinery/door/blast/dismantle()
+	var/obj/structure/door_assembly/da = ..()
+	. = da
+
+	da.anchored = 1
+	da.state = 1
+	da.created_name = name
+	da.update_icon()
+
 /decl/public_access/public_method/close_door_delayed
 	name = "delayed close door"
 	desc = "Closes the door if possible, after a short delay."

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -45,6 +45,28 @@
 		bound_width = world.icon_size
 		bound_height = width * world.icon_size
 
+/obj/structure/door_assembly/examine(mob/user)
+	. = ..()
+	switch(state)
+		if(0)
+			to_chat(user, "Use a wrench to [anchored ? "un" : ""]anchor it.")
+			if(!anchored)
+				if(glass == 1)
+					var/decl/material/glass_material_datum = GET_DECL(glass_material)
+					if(glass_material_datum)
+						var/mat_name = glass_material_datum.solid_name || glass_material_datum.name
+						to_chat(user, "Use a welder to remove the [mat_name] plating currently attached.")
+				else
+					to_chat(user, "Use a welder to disassemble completely.")
+			else
+				to_chat(user, "Use a cable coil to wire in preparation for electronics.")
+		if(1)
+			to_chat(user, "Use a wirecutter to remove the wiring and expose the frame.")
+			to_chat(user, "Insert electronics to proceed with construction.")
+		if(2)
+			to_chat(user, "Use a crowbar to remove the electronics.")
+			to_chat(user, "Use a screwdriver to complete assembly.")
+
 /obj/structure/door_assembly/door_assembly_hatch
 	icon = 'icons/obj/doors/hatch/door.dmi'
 	panel_icon = 'icons/obj/doors/hatch/panel.dmi'


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Makes blast doors deconstruct into wired assemblies for more intuitive state transition (airlocks already do this). Adds examine text with mechanics info to airlock assemblies.

## Why and what will this PR improve

Do you remember the order of operations to construct airlocks? I don't.

## Authorship
me

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
