### PR TITLE
Adding a roleplay summary var to species preview.

### DIFF
--- a/code/modules/client/preference_setup/background/01_species.dm
+++ b/code/modules/client/preference_setup/background/01_species.dm
@@ -66,7 +66,10 @@
 	else
 		. += "<td width = '200px' align='center'>No preview available.</td>"
 		
-	var/desc = current_species.description || "No additional details."
+	var/desc = current_species.description ? "<h3>Species Summary</h3><p>[current_species.description]</p>" : null
+	if(current_species.roleplay_summary)
+		desc = "[desc]<h3>Roleplaying Summary</h3><p>[current_species.roleplay_summary]</p>"
+		
 	if(hide_species && length(desc) > 200)
 		desc = "[copytext(desc, 1, 194)] <small>\[...\]</small>"
 	. += "<td width>[desc]</td>"

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -10,6 +10,7 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	var/name_plural                           // Pluralized name (since "[name]s" is not always valid)
 	var/description
 	var/codex_description
+	var/roleplay_summary
 	var/ooc_codex_information
 	var/cyborg_noun = "Cyborg"
 	var/hidden_from_codex = TRUE


### PR DESCRIPTION
## Description of changes
Adds an optional var to the species datum that can be used to provide some roleplaying tips.

## Why and what will this PR improve
Nice option for providing more info. Needed for some downstream stuff I'm doing.

## Authorship
Myself.

## Changelog
Nothing player-facing.