### PR TITLE
Fixes anchored mobs being impossible to mousedrag in any circumstances.

### DIFF
--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -71,7 +71,7 @@
 /proc/get_exposed_defense_zone(var/atom/movable/target)
 	return pick(BP_HEAD, BP_L_HAND, BP_R_HAND, BP_L_FOOT, BP_R_FOOT, BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG, BP_CHEST, BP_GROIN)
 
-/proc/do_mob(mob/user , mob/target, time = 30, target_zone = 0, uninterruptible = 0, progress = 1, var/incapacitation_flags = INCAPACITATION_DEFAULT)
+/proc/do_mob(mob/user , mob/target, time = 30, target_zone = 0, uninterruptible = 0, progress = 1, incapacitation_flags = INCAPACITATION_DEFAULT, check_holding = TRUE)
 	if(!user || !target)
 		return 0
 	var/user_loc = user.loc
@@ -82,7 +82,7 @@
 
 	var/target_loc = target.loc
 
-	var/holding = user.get_active_hand()
+	var/holding = check_holding && user.get_active_hand()
 	var/datum/progressbar/progbar
 	if (progress)
 		progbar = new(user, time, target)
@@ -112,7 +112,7 @@
 			. = 0
 			break
 
-		if(user.get_active_hand() != holding)
+		if(check_holding && user.get_active_hand() != holding)
 			. = 0
 			break
 
@@ -123,7 +123,7 @@
 	if (progbar)
 		qdel(progbar)
 
-/proc/do_after(mob/user, delay, atom/target = null, needhand = 1, progress = 1, var/incapacitation_flags = INCAPACITATION_DEFAULT, var/same_direction = 0, var/can_move = 0)
+/proc/do_after(mob/user, delay, atom/target = null, check_holding = 1, progress = 1, var/incapacitation_flags = INCAPACITATION_DEFAULT, var/same_direction = 0, var/can_move = 0)
 	if(!user)
 		return 0
 	var/atom/target_loc = null
@@ -167,7 +167,7 @@
 			. = 0
 			break
 
-		if(needhand)
+		if(check_holding)
 			if(user.get_active_hand() != holding)
 				. = 0
 				break

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -26,14 +26,11 @@
 /atom/proc/check_mousedrop_adjacency(var/atom/over, var/mob/user)
 	. = (Adjacent(user) && over.Adjacent(user))
 
-/mob/can_mouse_drop(var/atom/over, var/mob/user = usr, var/incapacitation_flags = INCAPACITATION_DEFAULT)
-	. = !anchored && ..()
-
 // Receive a mouse drop.
 // Returns false if the atom is valid for dropping further up the chain, true if the drop has been handled.
 /atom/proc/receive_mouse_drop(var/atom/dropping, var/mob/user)
 	var/mob/living/H = user
-	if(istype(H) && can_climb(H) && dropping == user)
+	if(istype(H) && !H.anchored && can_climb(H) && dropping == user)
 		do_climb(dropping)
 		return TRUE
 	return FALSE

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -384,7 +384,7 @@
 	return buckled_mob
 
 /atom/movable/proc/can_buckle_mob(var/mob/living/dropping)
-	. = (can_buckle && istype(dropping) && !dropping.buckled && !dropping.buckled_mob && !buckled_mob)
+	. = (can_buckle && istype(dropping) && !dropping.buckled && !dropping.anchored && !dropping.buckled_mob && !buckled_mob)
 
 /atom/movable/receive_mouse_drop(atom/dropping, mob/living/user)
 	. = ..()

--- a/code/game/gamemodes/godmode/form_items/wizard_structures.dm
+++ b/code/game/gamemodes/godmode/form_items/wizard_structures.dm
@@ -14,7 +14,7 @@
 		return
 
 	hitter.visible_message("<span class='notice'>\The [hitter] dips their hands into \the [src], a soft glow emanating from them.</span>")
-	if(do_after(hitter,300,src,needhand=0))
+	if(do_after(hitter,300,src,check_holding=0))
 		for(var/s in hitter.mind.learned_spells)
 			var/spell/spell = s
 			spell.charge_counter = spell.charge_max

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -127,11 +127,13 @@
 	check_victim()
 	if(src.victim && get_turf(victim) == get_turf(src) && victim.lying)
 		to_chat(usr, "<span class='warning'>\The [src] is already occupied!</span>")
-		return 0
+		return FALSE
 	if(patient.buckled)
 		to_chat(usr, "<span class='notice'>Unbuckle \the [patient] first!</span>")
-		return 0
-	return 1
+		return FALSE
+	if(patient.anchored)
+		return FALSE
+	return TRUE
 
 /obj/machinery/optable/power_change()
 	. = ..()

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -272,7 +272,7 @@
 			to_chat(user, SPAN_WARNING("Unbuckle the subject before attempting to move them."))
 		else if(panel_open)
 			to_chat(user, SPAN_WARNING("Close the maintenance panel before attempting to place the subject in the sleeper."))
-		else 
+		else
 			go_in(target, user)
 		return TRUE
 
@@ -306,7 +306,7 @@
 	pump = !pump
 
 /obj/machinery/sleeper/proc/go_in(var/mob/M, var/mob/user)
-	if(!M)
+	if(!M || M.anchored)
 		return
 	if(stat & (BROKEN|NOPOWER))
 		return

--- a/code/game/machinery/bodyscanner.dm
+++ b/code/game/machinery/bodyscanner.dm
@@ -77,7 +77,7 @@
 	return ..()
 
 /obj/machinery/bodyscanner/proc/user_can_move_target_inside(var/mob/target, var/mob/user)
-	if(!istype(user) || !istype(target))
+	if(!istype(user) || !istype(target) || target.anchored)
 		return FALSE
 	if(occupant)
 		to_chat(user, "<span class='warning'>The scanner is already occupied!</span>")
@@ -113,6 +113,9 @@
 /obj/machinery/bodyscanner/receive_mouse_drop(var/atom/dropping, var/mob/user)
 	. = ..()
 	if(!. && isliving(dropping))
+		var/mob/living/M = dropping
+		if(M.anchored)
+			return FALSE
 		user.visible_message( \
 			SPAN_NOTICE("\The [user] begins placing \the [dropping] into \the [src]."), \
 			SPAN_NOTICE("You start placing \the [dropping] into \the [src]."))

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -278,19 +278,24 @@
 		control_computer = null
 
 /obj/machinery/cryopod/proc/check_occupant_allowed(mob/M)
+
+	if(!istype(M) || M.anchored)
+		return FALSE
+
 	var/correct_type = 0
 	for(var/type in allow_occupant_types)
 		if(istype(M, type))
 			correct_type = 1
 			break
 
-	if(!correct_type) return 0
+	if(!correct_type)
+		return FALSE
 
 	for(var/type in disallow_occupant_types)
 		if(istype(M, type))
-			return 0
+			return FALSE
 
-	return 1
+	return TRUE
 
 /obj/machinery/cryopod/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -30,6 +30,9 @@
 /obj/machinery/recharge_station/receive_mouse_drop(var/atom/dropping, var/mob/user)
 	. = ..()
 	if(!. && isliving(dropping))
+		var/mob/living/M = dropping
+		if(M.anchored)
+			return FALSE
 		user.visible_message( \
 			SPAN_NOTICE("\The [user] begins placing \the [dropping] into \the [src]."), \
 			SPAN_NOTICE("You start placing \the [dropping] into \the [src]."))
@@ -178,10 +181,7 @@
 
 /obj/machinery/recharge_station/proc/go_in(var/mob/M)
 
-	if(occupant)
-		return
-
-	if(!hascell(M))
+	if(occupant || M.anchored || !hascell(M))
 		return
 
 	add_fingerprint(M)

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -61,7 +61,7 @@
 			else
 				user.visible_message("<span class='warning'>[user] begins to do [H]'s lips with \the [src].</span>", \
 									 "<span class='notice'>You begin to apply \the [src].</span>")
-				if(do_after(user, 20, H) && do_after(H, 20, needhand = 0, progress = 0, incapacitation_flags = INCAPACITATION_NONE))	//user needs to keep their active hand, H does not.
+				if(do_after(user, 20, H) && do_after(H, 20, check_holding = 0, progress = 0, incapacitation_flags = INCAPACITATION_NONE))	//user needs to keep their active hand, H does not.
 					user.visible_message("<span class='notice'>[user] does [H]'s lips with \the [src].</span>", \
 										 "<span class='notice'>You apply \the [src].</span>")
 					H.lip_style = color

--- a/code/game/objects/structures/mineral_bath.dm
+++ b/code/game/objects/structures/mineral_bath.dm
@@ -27,7 +27,7 @@
 
 /obj/structure/mineral_bath/proc/enter_bath(var/mob/living/patient, var/mob/user)
 
-	if(!istype(patient))
+	if(!istype(patient) || patient.anchored)
 		return FALSE
 
 	var/self_drop = (user == patient)

--- a/code/modules/butchery/butchery.dm
+++ b/code/modules/butchery/butchery.dm
@@ -111,7 +111,7 @@
 		return TRUE
 
 /obj/structure/kitchenspike/proc/try_spike(var/mob/living/target, var/mob/living/user)
-	if(!istype(target) || !Adjacent(user) || user.incapacitated())
+	if(!istype(target) || !Adjacent(user) || user.incapacitated() || target.anchored)
 		return
 
 	if(!anchored)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -285,7 +285,7 @@
 
 				if(!failed_to_seal && wearer.back == src && piece == compare_piece)
 
-					if(seal_delay && !instant && !do_after(wearer,seal_delay,src,needhand=0))
+					if(seal_delay && !instant && !do_after(wearer,seal_delay,src,check_holding=0))
 						failed_to_seal = 1
 
 					switch(msg_type)

--- a/code/modules/mob/living/bot/mulebot.dm
+++ b/code/modules/mob/living/bot/mulebot.dm
@@ -249,7 +249,7 @@
 	return beaconlist
 
 /mob/living/bot/mulebot/proc/load(var/atom/movable/C)
-	if(busy || load || get_dist(C, src) > 1 || !isturf(C.loc))
+	if(busy || load || get_dist(C, src) > 1 || !isturf(C.loc) || C.anchored)
 		return
 
 	for(var/obj/structure/plasticflaps/P in src.loc)//Takes flaps into account

--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -69,7 +69,7 @@
 			
 			visible_message("<span class='danger'>\The [user] is trying to remove \the [src]'s [A.name]!</span>")
 
-			if(!do_after(user, HUMAN_STRIP_DELAY, src, progress = 0))
+			if(!do_after(user, HUMAN_STRIP_DELAY, src, check_holding = FALSE, progress = FALSE))
 				return
 
 			if(!A || holder.loc != src || !(A in holder.accessories))
@@ -98,7 +98,7 @@
 	else
 		visible_message("<span class='danger'>\The [user] is trying to put \a [held] on \the [src]!</span>")
 
-	if(!do_mob(user, src, HUMAN_STRIP_DELAY))
+	if(!do_mob(user, src, HUMAN_STRIP_DELAY, check_holding = FALSE))
 		return
 
 	if(stripping)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -948,7 +948,7 @@ default behaviour is:
 	return "Living"
 
 /mob/living/handle_mouse_drop(atom/over, mob/user)
-	if(user == src && user != over)
+	if(!anchored && user == src && user != over)
 
 		if(isturf(over))
 			var/turf/T = over

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -510,7 +510,7 @@
 	if(over == user && user != src && !istype(user, /mob/living/silicon/ai))
 		show_inv(user)
 		return TRUE
-	if(istype(over, /obj/vehicle/train))
+	if(!anchored && istype(over, /obj/vehicle/train))
 		var/obj/vehicle/train/beep = over
 		if(!beep.load(src))
 			to_chat(user, SPAN_WARNING("You were unable to load \the [src] onto \the [over]."))

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -152,7 +152,7 @@
 			else
 				user.visible_message("<span class='warning'>[user] begins to wipe [H]'s lipstick off with \the [src].</span>", \
 								 	 "<span class='notice'>You begin to wipe off [H]'s lipstick.</span>")
-				if(do_after(user, 10, H) && do_after(H, 10, needhand = 0))	//user needs to keep their active hand, H does not.
+				if(do_after(user, 10, H) && do_after(H, 10, check_holding = 0))	//user needs to keep their active hand, H does not.
 					user.visible_message("<span class='notice'>[user] wipes [H]'s lipstick off with \the [src].</span>", \
 										 "<span class='notice'>You wipe off [H]'s lipstick.</span>")
 					H.lip_style = null

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -129,6 +129,9 @@ var/global/list/diversion_junctions = list()
 
 		// Todo rewrite all of this.
 		var/atom/movable/AM = dropping
+		if(AM.anchored)
+			return FALSE 
+
 		// Determine object type and run necessary checks
 		var/mob/M = AM
 		var/is_dangerous // To determine css style in messages

--- a/code/modules/vehicles/bike.dm
+++ b/code/modules/vehicles/bike.dm
@@ -95,7 +95,7 @@
 /obj/vehicle/bike/load(var/atom/movable/C)
 	var/mob/living/M = C
 	if(!istype(M)) return 0
-	if(M.buckled || M.restrained() || !Adjacent(M) || !M.Adjacent(src))
+	if(M.buckled || M.anchored || M.restrained() || !Adjacent(M) || !M.Adjacent(src))
 		return 0
 	return ..(M)
 


### PR DESCRIPTION
## Description of changes
- Removes anchored check from base mouse drop proc, adds it back in where appropriate.
- Adds a hand check to do_mob, renames arg in do_after to match.
- Fixes #2113.
- Fixes #1609.

## Why and what will this PR improve
Allows for mousedragging anchored mobs in some circumstances and restores stripping to expected Bay behavior.

## Authorship
Myself.

## Changelog
Nothing player-facing.