### PR TITLE
`shock_stage` rework.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -110,8 +110,6 @@ var/global/list/gamemode_cache = list()
 	var/organ_regeneration_multiplier = 0.25
 	var/organs_decay
 
-	//Paincrit knocks someone down once they hit 60 shock_stage, so by default make it so that close to 100 additional damage needs to be dealt,
-	//so that it's similar to PAIN. Lowered it a bit since hitting paincrit takes much longer to wear off than a halloss stun.
 	var/organ_damage_spillover_multiplier = 0.5
 
 	var/bones_can_break = 1

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -168,7 +168,7 @@
 	// Traumatic shock.
 	if(H.is_asystole())
 		dat += "<span class='scan_danger'>Patient is suffering from cardiovascular shock. Administer CPR immediately.</span>"
-	else if(H.shock_stage > 80)
+	else if(H.shock_stage > H.species.fibrillation_threshold * 0.8)
 		dat += "<span class='scan_warning'>Patient is at serious risk of going into shock. Pain relief recommended.</span>"
 
 	// Other general warnings.

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1057,7 +1057,7 @@
 			var/decl/pronouns/G = get_pronouns()
 			visible_message(SPAN_NOTICE("\The [src] twitches a bit as [G.his] [heart.name] restarts!"))
 
-		shock_stage = min(shock_stage, 100) // 120 is the point at which the heart stops.
+		shock_stage = min(shock_stage, FLOOR(species.fibrillation_threshold * 0.8))
 		if(getOxyLoss() >= 75)
 			setOxyLoss(75)
 		heart.pulse = PULSE_NORM

--- a/code/modules/mob/living/carbon/human/human_verbs.dm
+++ b/code/modules/mob/living/carbon/human/human_verbs.dm
@@ -311,7 +311,6 @@
 		)
 		current_limb.add_pain(30)
 		current_limb.take_external_damage(5)
-		shock_stage += 20
 	else
 		visible_message( \
 		"<span class='danger'>[U] pops [self ? "[G.his]" : "[S]'s"] [current_limb.joint] back in!</span>", \

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -725,9 +725,8 @@
 		for(var/datum/wound/wound in affected.wounds)
 			LAZYREMOVE(wound.embedded_objects, implant)
 		if(!surgical_removal)
-			shock_stage+=20
 			affected.take_external_damage((implant.w_class * 3), 0, DAM_EDGE, "Embedded object extraction")
-			if(!BP_IS_PROSTHETIC(affected) && prob(implant.w_class * 5) && affected.sever_artery()) //I'M SO ANEMIC I COULD JUST -DIE-.
+			if(!BP_IS_PROSTHETIC(affected) && prob(implant.w_class * 5) && affected.sever_artery())
 				custom_pain("Something tears wetly in your [affected.name] as [implant] is pulled free!", 50, affecting = affected)
 	. = ..()
 

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -77,8 +77,7 @@
 	pulse = Clamp(PULSE_NORM + pulse_mod, PULSE_SLOW, PULSE_2FAST)
 
 	// If fibrillation, then it can be PULSE_THREADY
-	var/fibrillation = oxy <= BLOOD_VOLUME_SURVIVE || (prob(30) && owner.shock_stage > 120)
-	if(pulse && fibrillation)	//I SAID MOAR OXYGEN
+	if(pulse && (oxy <= BLOOD_VOLUME_SURVIVE || (prob(30) && owner.shock_stage > species.fibrillation_threshold)))
 		pulse = PULSE_THREADY
 
 	// Stablising chemicals pull the heartbeat towards the center

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -69,6 +69,8 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 
 	// Combat vars.
 	var/total_health = DEFAULT_SPECIES_HEALTH  // Point at which the mob will enter crit.
+	var/fibrillation_threshold                 // shock_stage at which the mob will have a chance of heart disruption.
+
 	var/list/unarmed_attacks = list(           // Possible unarmed attacks that the mob will use in combat,
 		/decl/natural_attack,
 		/decl/natural_attack/bite
@@ -283,6 +285,9 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 /decl/species/Initialize()
 
 	. = ..()
+
+	if(isnull(fibrillation_threshold))
+		fibrillation_threshold = FLOOR(total_health * 0.6)
 
 	if(!codex_description)
 		codex_description = description


### PR DESCRIPTION
## Description of changes
Bit of a work in progress. Main goals:
- Make shock thresholds respect species values.
- Make crit more consistent.

## Why and what will this PR improve
Should make gameplay more consistent for species with variant health totals and should fix #2378

## Authorship
Myself with @comma advising.

## Changelog
:cl:
tweak: Pain values and the effects of shock have been reworked, please report inconsistencies or problems.
/:cl:
