### PR TITLE
Fixes click catcher coverage.

### DIFF
--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -41,23 +41,9 @@
 	if(turfs.len)
 		return pick(turfs)
 
-/proc/screen_loc2turf(text, turf/origin)
-	if(!origin)
-		return null
-	var/tZ = splittext(text, ",")
-	var/tX = splittext(tZ[1], "-")
-	var/tY = text2num(tX[2])
-	tX = splittext(tZ[2], "-")
-	tX = text2num(tX[2])
-	tZ = origin.z
-	tX = max(1, min(origin.x + 7 - tX, world.maxx))
-	tY = max(1, min(origin.y + 7 - tY, world.maxy))
-	return locate(tX, tY, tZ)
-
 /*
 	Predicate helpers
 */
-
 
 /proc/is_holy_turf(var/turf/T)
 	return T && T.holy

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -369,7 +369,18 @@
 var/global/list/click_catchers
 /proc/get_click_catchers()
 	if(!global.click_catchers)
-		global.click_catchers = create_click_catcher()
+		global.click_catchers = list()
+		var/ox = -(round(config.max_client_view_x*0.5))
+		for(var/i = 0 to config.max_client_view_x)
+			var/oy = -(round(config.max_client_view_y*0.5))
+			var/tx = ox + i
+			for(var/j = 0 to config.max_client_view_y)
+				var/ty = oy + j
+				var/obj/screen/click_catcher/CC = new
+				CC.screen_loc = "CENTER[tx < 0 ? tx : "+[tx]"],CENTER[ty < 0 ? ty : "+[ty]"]"
+				CC.x_offset = tx
+				CC.y_offset = ty
+				global.click_catchers += CC
 	return global.click_catchers
 
 /obj/screen/click_catcher
@@ -378,18 +389,12 @@ var/global/list/click_catchers
 	plane = CLICKCATCHER_PLANE
 	mouse_opacity = 2
 	screen_loc = "CENTER-7,CENTER-7"
+	var/x_offset = 0
+	var/y_offset = 0
 
 /obj/screen/click_catcher/Destroy()
 	SHOULD_CALL_PARENT(FALSE)
 	return QDEL_HINT_LETMELIVE
-
-/proc/create_click_catcher()
-	. = list()
-	for(var/i = 0, i<15, i++)
-		for(var/j = 0, j<15, j++)
-			var/obj/screen/click_catcher/CC = new()
-			CC.screen_loc = "TOP-[i],RIGHT-[j]"
-			. += CC
 
 /obj/screen/click_catcher/Click(location, control, params)
 	var/list/modifiers = params2list(params)
@@ -397,7 +402,9 @@ var/global/list/click_catchers
 		var/mob/living/carbon/C = usr
 		C.swap_hand()
 	else
-		var/turf/T = screen_loc2turf(screen_loc, get_turf(usr))
-		if(T)
-			T.Click(location, control, params)
+		var/turf/origin = get_turf(usr)
+		if(isturf(origin))
+			var/turf/clicked = locate(origin.x + x_offset, origin.y + y_offset, origin.z)
+			if(clicked)
+				clicked.Click(location, control, params)
 	. = 1

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -333,8 +333,22 @@
 	hud_used.persistant_inventory_update()
 	update_action_buttons()
 
+/client/proc/reset_click_catchers()
+
+	var/xmin = -(round(last_view_x_dim*0.5))
+	var/xmax = last_view_x_dim - abs(xmin)
+	var/ymin = -(round(last_view_y_dim*0.5))
+	var/ymax = last_view_y_dim - abs(ymin)
+
+	var/list/click_catchers = get_click_catchers()
+	for(var/obj/screen/click_catcher/catcher in click_catchers)
+		if(catcher.x_offset <= xmin || catcher.x_offset >= xmax || catcher.y_offset <= ymin || catcher.y_offset >= ymax)
+			screen -= catcher
+		else
+			screen |= catcher
+
 /mob/proc/add_click_catcher()
-	client.screen |= get_click_catchers()
+	client.reset_click_catchers()
 
 /mob/new_player/add_click_catcher()
 	return

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -461,8 +461,8 @@ var/global/list/localhost_addresses = list(
 	OnResize()
 
 /client
-	var/last_view_x_dim = 7
-	var/last_view_y_dim = 7
+	var/last_view_x_dim = 15
+	var/last_view_y_dim = 15
 
 /client/verb/force_onresize_view_update()
 	set name = "Force Client View Update"
@@ -513,8 +513,9 @@ var/global/const/MAX_VIEW = 41
 	winset(src, "menu.icon[divisor]", "is-checked=true")
 
 	view = "[last_view_x_dim]x[last_view_y_dim]"
-
+	
 	// Reset eye/perspective
+	reset_click_catchers()
 	var/last_perspective = perspective
 	perspective = MOB_PERSPECTIVE
 	if(perspective != last_perspective)


### PR DESCRIPTION
## Description of changes
Extends click catchers to cover the entire possible view.

## Why and what will this PR improve
Currently on widescreen click catchers do not cover the left side of the screen.

## Authorship
Myself.

## Changelog
Nothing player-facing.