### PR TITLE
Apparent fix to power usage; harsher unit test

### DIFF
--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -93,6 +93,7 @@
 		virtual_mob = new virtual_mob(get_turf(src), src)
 
 	// Fire Entered events for freshly created movables.
+	// Changing this behavior will almost certainly break power; update accordingly.
 	if (!ml && loc)
 		loc.Entered(src, null)
 

--- a/code/modules/xenoarcheaology/artifacts/standalone/autocloner.dm
+++ b/code/modules/xenoarcheaology/artifacts/standalone/autocloner.dm
@@ -83,7 +83,7 @@
 
 	last_process = world.time
 
-/obj/machinery/auto_clone/get_artifact_scan_data()
+/obj/machinery/auto_cloner/get_artifact_scan_data()
 	return "Automated cloning pod - appears to rely on an artificial ecosystem formed by semi-organic nanomachines and the contained liquid.<br> \
 	The liquid resembles protoplasmic residue supportive of unicellular organism developmental conditions.<br> \
 	The structure is composed of a titanium alloy."

--- a/code/modules/xenoarcheaology/boulder.dm
+++ b/code/modules/xenoarcheaology/boulder.dm
@@ -21,7 +21,7 @@
 
 /obj/structure/boulder/Destroy()
 	QDEL_NULL(artifact_find)
-	..()
+	return ..()
 
 /obj/structure/boulder/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/depth_scanner))


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

Testing suggests #1679 completely broke power for any machines spawned after mapload (e.g. constructed in round). This is a theoretical fix. It should resolve issues with the exoplanet power unit test failures. The unit test has been upgraded to catch this type of issue more consistently.

Aiming at staging because it seems power is quite broken there; would suggest aggressive testing (monitor APC power usage while building/destroying/moving machines around; move things in shuttles).

The change in #1679 feels inconsistent (should either do it unconditionally or not at all, not just during not mapload), but I don't have the ability to test enough right now to comfortably PR something that touches that line. Changing it would allow for more robust fixes.

## Why and what will this PR improve

Power broke, I try fix.

## Authorship

me

## Changelog
<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
