### PR TITLE
Stole a bunch of tweaks from Naxodile's wyverm branch.

### DIFF
--- a/code/__defines/unit_tests.dm
+++ b/code/__defines/unit_tests.dm
@@ -1,0 +1,8 @@
+
+#define UT_NORMAL 1                   // Standard one atmosphere 20celsius
+#define UT_VACUUM 2                   // Vacume on simulated turfs
+#define UT_NORMAL_COLD 3              // Cold but standard atmosphere.
+
+#define FAILURE 0
+#define SUCCESS 1
+#define SKIP 2

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -128,9 +128,6 @@ SUBSYSTEM_DEF(jobs)
 	syndicate_code_phrase = generate_code_phrase()
 	syndicate_code_response	= generate_code_phrase()
 
-	// Set up AI spawn locations
-	spawn_empty_ai()
-
 	. = ..()
 
 /datum/controller/subsystem/jobs/proc/guest_jobbans(var/job)

--- a/code/game/machinery/suit_cycler.dm
+++ b/code/game/machinery/suit_cycler.dm
@@ -463,8 +463,15 @@
 	if(suit)   suit.refit_for_bodytype(target_flags)
 	if(boots)  boots.refit_for_bodytype(target_flags)
 
-	target_modification.RefitItem(helmet)
-	target_modification.RefitItem(suit)
+
+	if(helmet)
+		target_modification.RefitItem(helmet)
+		helmet.refit_for_bodytype(target_bodytype)
+	if(suit)
+		suit.refit_for_bodytype(target_bodytype)
+		target_modification.RefitItem(suit)
+	if(boots)
+		boots.refit_for_bodytype(target_bodytype)
 
 	if(helmet) helmet.SetName("refitted [helmet.name]")
 	if(suit)   suit.SetName("refitted [suit.name]")

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -334,10 +334,10 @@
 	if(check_blood_level(H))
 		make_announcement("buzzes, \"Warning - Patient is in hypovolemic shock and may require a blood transfusion.\"", "warning") //also includes heart damage
 
-	if(H.get_organ(BP_HEART)) //People may need more direct instruction
-		var/obj/item/organ/internal/heart/heart = H.get_organ(BP_HEART)
-		if(heart.is_bruised())
-			make_announcement("buzzes, \"Danger! The patient has sustained a cardiac contusion and will require surgical treatment for full recovery!\"", "danger")
+	//People may need more direct instruction
+	var/obj/item/organ/internal/heart/heart = H.get_organ(BP_HEART)
+	if(heart?.is_bruised())
+		make_announcement("buzzes, \"Danger! The patient has sustained a cardiac contusion and will require surgical treatment for full recovery!\"", "danger")
 
 	//placed on chest and short delay to shock for dramatic effect, revive time is 5sec total
 	if(!do_after(user, chargetime, H))

--- a/code/game/objects/items/weapons/storage/med_pouch.dm
+++ b/code/game/objects/items/weapons/storage/med_pouch.dm
@@ -69,8 +69,9 @@ Single Use Emergency Pouches
 
 	startswith = list(
 	/obj/item/chems/hypospray/autoinjector/pouch_auto/stabilizer,
+	/obj/item/chems/hypospray/autoinjector/pouch_auto/painkillers,
 	/obj/item/chems/pill/pouch_pill/stabilizer,
-	/obj/item/chems/pill/pouch_pill/painkillers,
+	/obj/item/chems/pill/pouch_pill/brute_meds,
 	/obj/item/stack/medical/bruise_pack = 2,
 		)
 	instructions = {"
@@ -89,10 +90,10 @@ Single Use Emergency Pouches
 	color = COLOR_SEDONA
 
 	startswith = list(
-	/obj/item/chems/hypospray/autoinjector/pouch_auto/stabilizer,
+	/obj/item/chems/hypospray/autoinjector/pouch_auto/nanoblood,
 	/obj/item/chems/hypospray/autoinjector/pouch_auto/painkillers,
 	/obj/item/chems/hypospray/autoinjector/pouch_auto/adrenaline,
-	/obj/item/chems/pill/pouch_pill/painkillers,
+	/obj/item/chems/pill/pouch_pill/burn_meds,
 	/obj/item/stack/medical/ointment = 2,
 		)
 	instructions = {"
@@ -183,6 +184,12 @@ Single Use Emergency Pouches
 /obj/item/chems/pill/pouch_pill/painkillers
 	chem_type = /decl/material/liquid/painkillers
 
+/obj/item/chems/pill/pouch_pill/brute_meds
+	chem_type = /decl/material/liquid/brute_meds
+
+/obj/item/chems/pill/pouch_pill/burn_meds
+	chem_type = /decl/material/liquid/burn_meds
+
 /obj/item/chems/pill/pouch_pill/initialize_reagents()
 	reagents.add_reagent(chem_type, chem_amount)
 	var/decl/material/reagent = GET_DECL(chem_type)
@@ -212,3 +219,7 @@ Single Use Emergency Pouches
 	name = "emergency adrenaline autoinjector"
 	amount_per_transfer_from_this = 8
 	starts_with = list(/decl/material/liquid/adrenaline = 8)
+
+/obj/item/chems/hypospray/autoinjector/pouch_auto/nanoblood
+	name = "emergency nanoblood autoinjector"
+	starts_with = list(/decl/material/liquid/nanoblood = 5)

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -67,7 +67,7 @@
 	startswith = list(/obj/item/clothing/gloves/insulated, /obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/wirecutters, /obj/item/multitool)
 
 /obj/item/storage/toolbox/repairs
-	name = "electrician toolbox"
+	name = "electronics toolbox"
 	desc = "A box full of boxes, with electrical machinery parts and tools needed to get them where they're needed."
 	icon_state = "yellow_striped"
 	item_state = "toolbox_yellow"

--- a/code/modules/atmospherics/components/unary/tank.dm
+++ b/code/modules/atmospherics/components/unary/tank.dm
@@ -90,7 +90,8 @@
 	desc = "A large vessel containing pressurized gas."
 	color =  PIPE_COLOR_WHITE
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_REGULAR|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL	
-	w_class = ITEM_SIZE_HUGE
+	w_class = ITEM_SIZE_STRUCTURE
+	density = 1
 	level = 1
 	dir = SOUTH
 	constructed_path = /obj/machinery/atmospherics/unary/tank

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -185,6 +185,9 @@
 					skill_link = "<a href='?src=\ref[src];set_skills=[title]'>View Skills</a>"
 				skill_link = "<td>[skill_link]</td>"
 
+				if(!user.skillset.skills_transferable)
+					skill_link = ""
+
 				// Begin assembling the actual HTML.
 				index += 1
 				if((index >= limit) || (job.title in splitJobs))

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -143,6 +143,8 @@
 
 /obj/item/clothing/proc/refit_for_bodytype(var/target_bodytype)
 	bodytype_equip_flags = target_bodytype
+	if(sprite_sheets[target_bodytype])
+		icon = sprite_sheets[target_bodytype]
 
 /obj/item/clothing/get_examine_line()
 	. = ..()

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -287,3 +287,12 @@ else if(##equipment_var) {\
 	if(overlay && tank && slot == slot_back_str)
 		overlay.overlays += tank.get_mob_overlay(user_mob, slot_back_str)
 	. = ..()
+/obj/item/clothing/suit/space/void/refit_for_bodytype(target_bodytype)
+	..()
+	icon = get_icon_for_bodytype(target_bodytype)
+	queue_icon_update()
+
+/obj/item/clothing/head/helmet/space/void/refit_for_bodytype(target_bodytype)
+	..()
+	icon = get_icon_for_bodytype(target_bodytype)
+	queue_icon_update()

--- a/code/modules/detectivework/tools/sample_kits/_sample_kit.dm
+++ b/code/modules/detectivework/tools/sample_kits/_sample_kit.dm
@@ -32,7 +32,7 @@
 /obj/item/forensics/sample_kit/afterattack(var/atom/A, var/mob/user, var/proximity)
 	if(!proximity)
 		return
-	if(user.skill_check(SKILL_FORENSICS, SKILL_ADEPT) && can_take_sample(user, A))
+	if(user.skill_check(SKILL_FORENSICS, SKILL_BASIC) && can_take_sample(user, A))
 		take_sample(user,A)
 		. = 1
 	else

--- a/code/modules/materials/definitions/solids/materials_solid_metal.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_metal.dm
@@ -193,7 +193,7 @@
 	. += new/datum/stack_recipe/furniture/canister(src)
 	. += new/datum/stack_recipe/furniture/tank(src)
 	. += new/datum/stack_recipe/cannon(src)
-	. += create_recipe_list(/datum/stack_recipe/tile/metal)
+	. += new/datum/stack_recipe_list("tiling", create_recipe_list(/datum/stack_recipe/tile/metal))
 	. += new/datum/stack_recipe/furniture/computerframe(src)
 	. += new/datum/stack_recipe/furniture/machine(src)
 	. += new/datum/stack_recipe/furniture/turret(src)

--- a/code/modules/mob/language/alien/monkey.dm
+++ b/code/modules/mob/language/alien/monkey.dm
@@ -5,6 +5,7 @@
 	ask_verb = "chimpers"
 	exclaim_verb = "screeches"
 	key = ""
+	flags = RESTRICTED
 	syllables = list("ook", "eek", "hiss", "gronk")
 	shorthand = "Ook"
 	hidden_from_codex = 1

--- a/code/modules/mob/language/human/human.dm
+++ b/code/modules/mob/language/human/human.dm
@@ -5,7 +5,7 @@
 	speech_verb = "says"
 	whisper_verb = "whispers"
 	colour = "solcom"
-	flags = WHITELISTED
+	flags = WHITELISTED | RESTRICTED
 	shorthand = "???"
 	space_chance = 40
 	abstract_type = /decl/language/human

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -26,3 +26,11 @@
 
 	//Handle job slot/tater cleanup.
 	clear_client()
+
+/obj/effect/landmark/start/ai
+	name = "AI"
+
+/obj/effect/landmark/start/ai/Initialize()
+	. = ..()
+	//The job subsystem does its thing before we can, so we've got to handle this
+	empty_playable_ai_cores += new /obj/structure/aicore/deactivated(get_turf(loc))

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1568,7 +1568,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(!BP_IS_PROSTHETIC(src) && !BP_IS_CRYSTAL(src))
 		var/decay_rate = damage/(max_damage*2)
 		germ_level += round(rand(decay_rate,decay_rate*1.5)) //So instead, we're going to say the damage is so severe its functions are slowly failing due to the extensive damage
-	else
+	else //TODO: more advanced system for synths
+		if(istype(src,/obj/item/organ/external/chest) || istype(src,/obj/item/organ/external/groin))
+			return
 		status |= ORGAN_DEAD
 	if(status & ORGAN_DEAD) //The organic dying part is covered in germ handling
 		STOP_PROCESSING(SSobj, src)

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -35,6 +35,7 @@
 		/obj/effect,
 		/obj/structure/cable,
 		/obj/machinery/atmospherics,
+		/obj/machinery/air_sensor,
 		/obj/machinery/power/terminal
 		)
 

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -33,6 +33,9 @@
 		/obj/item/chems/drinks		
 	)
 
+	var/beaker_offset = 0
+	var/beaker_positions = list(0,1)
+
 /obj/machinery/chemical_dispenser/Initialize(mapload, d=0, populate_parts = TRUE)
 	. = ..()
 	if(spawn_cartridges && populate_parts)
@@ -196,5 +199,6 @@
 	if(container)
 		var/mutable_appearance/beaker_overlay
 		beaker_overlay = image(src, src, "lil_beaker")
-		beaker_overlay.pixel_x = rand(-10, 5)
+		beaker_overlay.pixel_y = beaker_offset
+		beaker_overlay.pixel_x = pick(beaker_positions)
 		overlays += beaker_overlay

--- a/code/modules/reagents/dispenser/dispenser_presets.dm
+++ b/code/modules/reagents/dispenser/dispenser_presets.dm
@@ -44,7 +44,7 @@
 			/obj/item/chems/chem_disp_cartridge/antibiotics,
 			/obj/item/chems/chem_disp_cartridge/sedatives
 		)
-	
+
 	buildable = FALSE
 
 
@@ -57,6 +57,8 @@
 	core_skill = SKILL_COOKING
 	can_contaminate = FALSE //It's not a complex panel, and I'm fairly sure that most people don't haymaker the control panel on a soft drinks machine. -- Chaoko99
 	base_type = /obj/machinery/chemical_dispenser/bar_soft
+	beaker_offset = -2
+	beaker_positions = list(-1,3,7,11,15)
 
 /obj/machinery/chemical_dispenser/bar_soft/full
 	spawn_cartridges = list(
@@ -93,6 +95,8 @@
 	core_skill = SKILL_COOKING
 	can_contaminate = FALSE //See above.
 	base_type = /obj/machinery/chemical_dispenser/bar_alc
+	beaker_offset = -2
+	beaker_positions = list(-3,2,7,12,17)
 
 
 /obj/machinery/chemical_dispenser/bar_alc/full
@@ -116,7 +120,7 @@
 			/obj/item/chems/chem_disp_cartridge/ale,
 			/obj/item/chems/chem_disp_cartridge/mead
 		)
-	
+
 	buildable = FALSE
 
 /obj/machinery/chemical_dispenser/bar_coffee
@@ -128,6 +132,8 @@
 	core_skill = SKILL_COOKING
 	can_contaminate = FALSE //See above.
 	base_type = /obj/machinery/chemical_dispenser/bar_coffee
+	beaker_offset = -2
+	beaker_positions = list(0,14)
 
 
 /obj/machinery/chemical_dispenser/bar_coffee/full

--- a/code/modules/reagents/storage/pill_bottle_subtypes.dm
+++ b/code/modules/reagents/storage/pill_bottle_subtypes.dm
@@ -74,7 +74,7 @@
 	desc = "Commonly found on paramedics, these assorted pill bottles contain all the basics."
 
 	startswith = list(
-			/obj/item/chems/pill/adrenaline = 6,
+			/obj/item/chems/pill/stabilizer = 6,
 			/obj/item/chems/pill/antitoxins = 6,
 			/obj/item/chems/pill/sugariron = 2,
 			/obj/item/chems/pill/painkillers = 2,

--- a/code/modules/surgery/necrotic.dm
+++ b/code/modules/surgery/necrotic.dm
@@ -53,7 +53,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/target_organ = LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone)
 	user.visible_message("\The [user] slowly starts removing necrotic tissue from \the [target]'s [target_organ] with \the [tool].", \
-	"You slowly start removing necrotic tissue from \the [target]'s [target_organ)] with \the [tool].")
+	"You slowly start removing necrotic tissue from \the [target]'s [target_organ] with \the [tool].")
 	target.custom_pain("You feel sporadic spikes of pain from points around your [affected.name]!",20, affecting = affected)
 	..()
 

--- a/code/unit_tests/equipment_tests.dm
+++ b/code/unit_tests/equipment_tests.dm
@@ -1,7 +1,3 @@
-#define SUCCESS 1
-#define FAILURE 0
-
-
 /datum/unit_test/vision_glasses
 	name = "EQUIPMENT: Vision Template"
 	template = /datum/unit_test/vision_glasses
@@ -101,7 +97,3 @@
 		bad_tests++
 
 	return bad_tests
-
-#undef SUCCESS
-#undef FAILURE
-

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -5,11 +5,6 @@
  *
  *
  */
-
-#define FAILURE 0
-#define SUCCESS 1
-
-
 /datum/unit_test/apc_area_test
 	name = "MAP: Area Test APC / Scrubbers / Vents"
 
@@ -836,6 +831,3 @@
 	else
 		pass("All doors are on appropriate turfs")
 	return TRUE
-
-#undef SUCCESS
-#undef FAILURE

--- a/code/unit_tests/mob_tests.dm
+++ b/code/unit_tests/mob_tests.dm
@@ -8,9 +8,6 @@
  *
  */
 
-#define SUCCESS 1
-#define FAILURE 0
-
 //
 // Tests Life() and mob breathing in space.
 //
@@ -293,8 +290,6 @@ var/global/default_mobloc = null
 	return 1
 
 #undef IMMUNE
-#undef SUCCESS
-#undef FAILURE
 
 /datum/unit_test/mob_nullspace
 	name = "MOB: Mob in nullspace shall not cause runtimes"

--- a/code/unit_tests/zas_tests.dm
+++ b/code/unit_tests/zas_tests.dm
@@ -153,7 +153,7 @@
 	if(world.time < testtime)
 		return 0
 	for(var/area/A in shuttle.shuttle_area)
-		var/list/test = test_air_in_area(A.type)
+		var/list/test = test_air_in_area(A.type, global.using_map.shuttle_atmos_expectation)
 		if(isnull(test))
 			fail("Check Runtimed")
 			return 1

--- a/code/unit_tests/zas_tests.dm
+++ b/code/unit_tests/zas_tests.dm
@@ -6,14 +6,6 @@
  *
  */
 
-#define UT_NORMAL 1                   // Standard one atmosphere 20celsius
-#define UT_VACUUM 2                   // Vacume on simulated turfs
-#define UT_NORMAL_COLD 3              // Cold but standard atmosphere.
-
-#define FAILURE 0
-#define SUCCESS 1
-#define SKIP 2
-
 //
 // Generic check for an area.
 //
@@ -163,9 +155,3 @@
 			if(SKIP)    skip(test["msg"])
 			else        fail(test["msg"])
 	return 1
-
-#undef UT_NORMAL
-#undef UT_VACUUM
-#undef UT_NORMAL_COLD
-#undef SUCCESS
-#undef FAILURE

--- a/maps/~mapsystem/maps_unit_testing.dm
+++ b/maps/~mapsystem/maps_unit_testing.dm
@@ -3,7 +3,8 @@
 	var/const/NO_VENT = 2
 	var/const/NO_SCRUBBER = 4
 
-	var/shuttle_atmos_expectation = TRUE
+	/// Defines the expected result of the atmospherics shuttle unit test for atmosphere.
+	var/shuttle_atmos_expectation = UT_NORMAL
 
 	// Unit test vars
 	var/list/apc_test_exempt_areas = list(

--- a/maps/~mapsystem/maps_unit_testing.dm
+++ b/maps/~mapsystem/maps_unit_testing.dm
@@ -3,6 +3,8 @@
 	var/const/NO_VENT = 2
 	var/const/NO_SCRUBBER = 4
 
+	var/shuttle_atmos_expectation = TRUE
+
 	// Unit test vars
 	var/list/apc_test_exempt_areas = list(
 		/area/space = NO_SCRUBBER|NO_VENT|NO_APC,

--- a/nebula.dme
+++ b/nebula.dme
@@ -85,6 +85,7 @@
 #include "code\__defines\tools.dm"
 #include "code\__defines\topic.dm"
 #include "code\__defines\turfs.dm"
+#include "code\__defines\unit_tests.dm"
 #include "code\__defines\webhooks.dm"
 #include "code\__defines\xenoarcheaology.dm"
 #include "code\__defines\ZAS.dm"


### PR DESCRIPTION
## Description of changes
Not sure if I can make these associated with @Naxodile to avoid stealing authorship, but in any case these are ganked from their wyverm branch. I did a reset and individual commit after a large rebase, hence new commits.

## Why and what will this PR improve
- Implements missing voidsuit refit behavior for icons.
- Changes AI core spawn to use a landmark.
- Removes a redundant organ check from defibrilators.
- Tweaks medicine paths (adrenaline to stabilizer, etc) in a few spots.
- Handful of grammar/name tweaks.
- Adds a skill_transferrable check to prefs setup.
- Tweaks forensics to use SKILL_BASIC for taking samples.
- Fixes metal tile recipe creation.
- Restricts monkey language.
- Prevents prosthetic chests and groins becoming necrotic (ORGAN_DEAD).
- Adds air sensors to the RUST field exception list.
- Fixes beaker overlay positions on chem dispensers.
- Adds a global map setting for shuttle atmos checking in CI.

## Authorship
@Naxodile other than a few cleanup/tweak edits.

## Changelog
:cl:
tweak: Forensic samples now require basic skill.
tweak: Some medical storage contents have been tweaked to be more appropriate.
/:cl:
