### PR TITLE
fix: fix blast door opening/closing issue. Adjust opening/closing to animation time

### DIFF
--- a/code/game/machinery/doors/_door.dm
+++ b/code/game/machinery/doors/_door.dm
@@ -393,52 +393,57 @@
 				flick("door_deny", src)
 				playsound(src.loc, 'sound/machines/buzz-two.ogg', 50, 0)
 
-/obj/machinery/door/proc/open(var/forced = 0)
+/obj/machinery/door/proc/open(forced = FALSE)
 	if(!can_open(forced))
 		return
+
 	operating = 1
 
 	do_animate("opening")
 	icon_state = "door0"
-	set_opacity(0)
-	sleep(3)
-	src.set_density(0)
+	set_opacity(FALSE)
+
+	sleep(0.5 SECONDS)
+	src.set_density(FALSE)
 	update_nearby_tiles()
-	sleep(7)
+
+	sleep(0.5 SECONDS)
 	src.layer = open_layer
 	update_icon()
-	set_opacity(0)
+	set_opacity(FALSE)
 	operating = 0
 
 	if(autoclose)
 		close_door_at = next_close_time()
 
-	return 1
+	return TRUE
 
 /obj/machinery/door/proc/next_close_time()
 	return world.time + (normalspeed ? 150 : 5)
 
-/obj/machinery/door/proc/close(var/forced = 0)
+/obj/machinery/door/proc/close(forced = FALSE)
 	if(!can_close(forced))
 		return
+
 	operating = 1
 
 	close_door_at = 0
 	do_animate("closing")
-	sleep(3)
-	src.set_density(1)
-	src.layer = closed_layer
+
+	sleep(0.5 SECONDS)
+	src.set_density(TRUE)
 	update_nearby_tiles()
-	sleep(7)
+	src.layer = closed_layer
+
+	sleep(0.5 SECONDS)
 	update_icon()
 	if(visible && !glass)
-		set_opacity(1)	//caaaaarn!
+		set_opacity(TRUE)
 	operating = 0
 
 	//I shall not add a check every x ticks if a door has closed over some fire.
 	var/obj/fire/fire = locate() in loc
-	if(fire)
-		qdel(fire)
+	qdel(fire)
 
 /obj/machinery/door/proc/toggle(to_open = density)
 	if(to_open)

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -110,11 +110,12 @@
 	operating = 1
 	playsound(src.loc, open_sound, 100, 1)
 	flick(icon_state_opening, src)
-	set_density(0)
+
+	sleep(0.6 SECONDS)
+	set_density(FALSE)
 	update_nearby_tiles()
 	update_icon()
-	set_opacity(0)
-	sleep(15)
+	set_opacity(FALSE)
 	layer = open_layer
 	operating = 0
 
@@ -126,11 +127,12 @@
 	playsound(src.loc, close_sound, 100, 1)
 	layer = closed_layer
 	flick(icon_state_closing, src)
-	set_density(1)
+
+	sleep(0.6 SECONDS)
+	set_density(TRUE)
 	update_nearby_tiles()
 	update_icon()
-	set_opacity(1)
-	sleep(15)
+	set_opacity(TRUE)
 	operating = 0
 
 // Proc: force_toggle()
@@ -186,20 +188,23 @@
 // Parameters: None
 // Description: Opens the door. Does necessary checks. Automatically closes if autoclose is true
 /obj/machinery/door/blast/open()
-	if (operating || (stat & BROKEN || stat & NOPOWER))
+	if (!can_open() || (stat & BROKEN || stat & NOPOWER))
 		return
+
 	force_open()
+
 	if(autoclose)
-		spawn(150)
-			close()
-	return 1
+		addtimer(CALLBACK(src, .proc/close), 15 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
+
+	return TRUE
 
 // Proc: close()
 // Parameters: None
 // Description: Closes the door. Does necessary checks.
 /obj/machinery/door/blast/close()
-	if (operating || (stat & BROKEN || stat & NOPOWER))
+	if (!can_close() || (stat & BROKEN || stat & NOPOWER))
 		return
+
 	force_close()
 
 /obj/machinery/door/blast/toggle(to_open = density)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -103,11 +103,8 @@
 	icon_state = "[src.base_state]open"
 	flick("[src.base_state]opening", src)
 	playsound(src.loc, 'sound/machines/windowdoor.ogg', 100, 1)
-	addtimer(CALLBACK(src, .proc/open_final), 10, TIMER_UNIQUE | TIMER_OVERRIDE)
 
-	return 1
-
-/obj/machinery/door/window/proc/open_final()
+	sleep(0.9 SECONDS)
 	explosion_resistance = 0
 	set_density(FALSE)
 	update_icon()
@@ -116,22 +113,24 @@
 	if(operating == 1) //emag again
 		operating = 0
 
+	return TRUE
+
 /obj/machinery/door/window/close()
 	if (src.operating)
 		return 0
+
 	operating = 1
 	flick(text("[]closing", src.base_state), src)
 	playsound(src.loc, 'sound/machines/windowdoor.ogg', 100, 1)
-	set_density(1)
+	set_density(TRUE)
 	update_icon()
 	explosion_resistance = initial(explosion_resistance)
 	update_nearby_tiles()
 
-	addtimer(CALLBACK(src, .proc/close_final), 10, TIMER_UNIQUE | TIMER_OVERRIDE)
-	return 1
-
-/obj/machinery/door/window/proc/close_final()
+	sleep(0.9 SECONDS)
 	operating = 0
+
+	return TRUE
 
 /obj/machinery/door/window/take_damage(var/damage)
 	src.health = max(0, src.health - damage)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Move open_final and close_final procs to /obj/machinery/door. Fix bug with blast door won't open/close if you click too fast.
Move open_final and close_final procs to /obj/machinery/door.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fix annoying visual bug with blast door, shatters (animation is too fast, so closing/opening finishes before actual door closing/opening). Add proper check for blast door state (closed/open) via calling can_close and can_open.

## Authorship
<!-- Describe original authors of changes to credit them. -->

Until now only me:
@Gaxeer 

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
bugfix: Adjust calling to update of Door icon to right after the animation finish
bugfix: Fix bug with blast door won't open/close if you click too fast
refactor: Move open_final and close_final procs to /obj/machinery/door. 
/:cl: