### PR TITLE
Prevent inserting a part twice into component_parts

### DIFF
--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -148,7 +148,7 @@ var/global/list/machine_path_to_circuit_type
 		. = part
 
 	if(istype(part))
-		LAZYADD(component_parts, part)
+		LAZYDISTINCTADD(component_parts, part)
 		part.on_install(src)
 		events_repository.register(/decl/observ/destroyed, part, src, .proc/component_destroyed)
 	else if(ispath(part))

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -148,7 +148,9 @@ var/global/list/machine_path_to_circuit_type
 		. = part
 
 	if(istype(part))
-		LAZYDISTINCTADD(component_parts, part)
+		if(part in component_parts)
+			CRASH("Tried to insert \a '[part]' twice in \the [src] ([x], [y], [z])!")
+		LAZYADD(component_parts, part)
 		part.on_install(src)
 		events_repository.register(/decl/observ/destroyed, part, src, .proc/component_destroyed)
 	else if(ispath(part))


### PR DESCRIPTION
## Description of changes
If a part is already in the component_parts list, don't let anyone add another reference to it. 
It doesn't happen in regular usage, but downstream its been quite annoying at times. 
Plus, it probably should be clearly enforced that this list must not have duplicates.