### PR TITLE
Fix: you can't move yourself with a grab

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -173,6 +173,9 @@
 
 	if(istype(W, /obj/item/grab))
 		var/obj/item/grab/G = W
+		if (G.affecting == G.assailant)
+			return TRUE
+
 		step(G.affecting, get_dir(G.affecting.loc, src))
 		return TRUE
 
@@ -438,7 +441,7 @@ var/global/const/enterloopsanity = 100
 	if(flooded)
 		LAZYADD(., global.flood_object)
 
-/**Whether we can place a cable here 
+/**Whether we can place a cable here
  * If you cannot build a cable will return an error code explaining why you cannot.
 */
 /turf/proc/cannot_build_cable()


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Remove ability to move yourself with grab
fix https://github.com/NebulaSS13/Nebula/issues/2412

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

I suppose SS13 isn't a Fight Club, where Narrator could move himself with a grab :D
So, if you think so too, this should be restricted.

## Authorship
<!-- Describe original authors of changes to credit them. -->
@Gaxeer  <-- Ye, that's me

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
bugfix: disable ability to move yourself with grab
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
