### PR TITLE
Fix bad limb max damage scaling

### DIFF
--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -167,7 +167,7 @@
 
 		//Base skin and blend
 		for(var/obj/item/organ/external/E in H.get_external_organs())
-			E.set_dna(E.dna)
+			E.set_dna(H.dna)
 
 		//Hair
 		var/list/hair_subtypes = subtypesof(/decl/sprite_accessory/hair)

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -14,6 +14,7 @@
 		return
 
 	set_species(new_species)
+	dna.ready_dna(src)
 
 	//Handle spawning stuff
 	species.handle_pre_spawn(src)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -86,7 +86,8 @@
 				given_dna = owner.dna //Grab our owner's dna if we don't have any, and they have
 			else
 				//The owner having no DNA can be a valid reason to keep our dna null in some cases
-				dna = null
+				log_debug("obj/item/organ/setup_as_organic(): [src] had null dna, with a owner with null dna!")
+				dna = null //#TODO: Not sure that's really legal
 				return
 		else
 			//If we have NO OWNER and given_dna, just make one up for consistency
@@ -120,8 +121,7 @@
 	reagents.add_reagent(/decl/material/liquid/nutriment/protein, reagents.maximum_volume)
 
 /obj/item/organ/proc/set_dna(var/datum/dna/new_dna)
-	if(!new_dna)
-		return
+	QDEL_NULL(dna)
 	dna = new_dna.Clone()
 	if(!blood_DNA)
 		blood_DNA = list()
@@ -142,6 +142,12 @@
 
 	// Adjust limb health proportinate to total species health.
 	var/total_health_coefficient = scale_max_damage_to_species_health ? (species.total_health / DEFAULT_SPECIES_HEALTH) : 1
+
+	//Use initial value to prevent scaling down each times we change the species during init
+	absolute_max_damage = initial(absolute_max_damage)
+	min_broken_damage = initial(min_broken_damage)
+	max_damage = initial(max_damage)
+
 	if(absolute_max_damage)
 		absolute_max_damage = max(1, FLOOR(absolute_max_damage * total_health_coefficient))
 		min_broken_damage = max(1, FLOOR(absolute_max_damage * 0.5))

--- a/mods/species/neoavians/datum/language.dm
+++ b/mods/species/neoavians/datum/language.dm
@@ -49,6 +49,7 @@
 	name = "Neo-Avian Milieu"
 	description = "Neo-avians form a loose coalition of family and flock groupings, and are usually in an extreme minority in human settlements. \
 	They tend to cope poorly with confined, crowded spaces like human habs, and often make their homes in hab domes or other spacious facilities."
+	language = /decl/language/neoavian
 	secondary_langs = list(
 		/decl/language/corvid,
 		/decl/language/neoavian,


### PR DESCRIPTION
## Description of changes
Fix the problem with limbs getting inconsistent damage values depending on how they were created. 
Turns out the values were scaled down on each call of set_species.
Also fix neo-avian no spawning with any languages when created in-game or when changing a mob's species.

I dunno if it'll be useful since loaf has been fixing it too. But here it is in any cases.

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
bugfix: Fix incoherent max damage scaling on human mob limbs. Also fix things depending on it.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
