### PR TITLE
fix: adjust mob's move direction, only if it is an initiator of movement

### DIFF
--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -25,9 +25,9 @@
 	mob.ghostize()
 
 // Incorporeal/Ghost movement
-/datum/movement_handler/mob/incorporeal/DoMove(var/direction)
+/datum/movement_handler/mob/incorporeal/DoMove(var/direction, var/mob/mover)
 	. = MOVEMENT_HANDLED
-	direction = mob.AdjustMovementDirection(direction)
+	direction = mob.AdjustMovementDirection(direction, mover)
 	mob.set_glide_size(0)
 
 	var/turf/T = get_step(mob, direction)
@@ -178,7 +178,7 @@
 	//We are now going to move
 	mob.moving = 1
 
-	direction = mob.AdjustMovementDirection(direction)
+	direction = mob.AdjustMovementDirection(direction, mover)
 	var/turf/old_turf = get_turf(mob)
 	step(mob, direction)
 
@@ -221,8 +221,22 @@
 /mob/proc/MayEnterTurf(var/turf/T)
 	return T && !((mob_flags & MOB_FLAG_HOLY_BAD) && check_is_holy_turf(T))
 
-/mob/proc/AdjustMovementDirection(var/direction)
+/**
+ * This proc adjusts movement direction for mobs with STAT_CONFUSE.
+ *
+ * Returns a direction, randomly adjusted if the mob had STAT_CONFUSE.
+ *
+ * Arguments:
+ * * direction: The direction, mob was going to move before adjustment
+ * * mover: The initiator of movement
+ */
+/mob/proc/AdjustMovementDirection(var/direction, var/mob/mover)
 	. = direction
+
+	// If we are moved not on our own, we don't get move debuff
+	if(src != mover)
+		return
+
 	if(!HAS_STATUS(src, STAT_CONFUSE))
 		return
 

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -236,7 +236,7 @@
 	if(isspaceturf(loc))
 		return
 	. = MOVEMENT_HANDLED
-	DoMove(mob.AdjustMovementDirection(direction), mob)
+	DoMove(mob.AdjustMovementDirection(direction, mover), mob)
 
 /obj/structure/bed/chair/janicart/relaymove(mob/user, direction)
 	if(user.incapacitated(INCAPACITATION_DISRUPTED))

--- a/code/game/objects/structures/stool_bed_chair_nest_sofa/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest_sofa/wheelchair.dm
@@ -5,8 +5,8 @@
 	anchored = FALSE
 	buckle_movable = TRUE
 	movement_handlers = list(
-		/datum/movement_handler/deny_multiz, 
-		/datum/movement_handler/delay = list(5), 
+		/datum/movement_handler/deny_multiz,
+		/datum/movement_handler/delay = list(5),
 		/datum/movement_handler/move_relay_self
 	)
 
@@ -112,7 +112,7 @@
 	if(!mob.has_held_item_slot())
 		return // No hands to drive your chair? Tough luck!
 	//drunk wheelchair driving
-	direction = mob.AdjustMovementDirection(direction)
+	direction = mob.AdjustMovementDirection(direction, mover)
 	DoMove(direction, mob)
 
 /obj/item/wheelchair_kit


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

You can now grab-move mob with STAT_CONFUSE, without him moving in random directions

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Handling of confused mob moving is now work correct, I suppose.

## Authorship
<!-- Describe original authors of changes to credit them. -->

@Gaxeer

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
prefix:
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix: mob's move direction is no longer modified by STAT_CONFUSE, if he is not mover (initiator of movement)
-->
