### PR TITLE
Lowered gibbing throwforce.

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -147,7 +147,7 @@
 #define FIRE_MAX_STACKS           25
 #define FIRE_MAX_FIRESUIT_STACKS  20 // If the number of stacks goes above this firesuits won't protect you anymore. If not, you can walk around while on fire like a badass.
 
-#define THROWFORCE_GIBS 10             // Throw speed for gibbed or dismembered organs.
+#define THROWFORCE_GIBS 3              // Throw speed for gibbed or dismembered organs.
 #define THROWFORCE_SPEED_DIVISOR    12 // The throwing speed value at which the throwforce multiplier is exactly 1.
 #define THROWNOBJ_KNOCKBACK_SPEED   15 // The minumum speed of a w_class 2 thrown object that will cause living mobs it hits to be knocked back. Heavier objects can cause knockback at lower speeds.
 #define THROWNOBJ_KNOCKBACK_DIVISOR 2  // Affects how much speed the mob is knocked back with.

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1074,17 +1074,17 @@ Note that amputating the affected organ does in fact remove the infection from t
 					G.basecolor =  use_blood_color
 					G.update_icon()
 
-			gore.throw_at(get_edge_target_turf(src,pick(global.alldirs)),rand(1,3),30)
+			gore.throw_at(get_edge_target_turf(src,pick(global.alldirs)), rand(1,3), THROWFORCE_GIBS)
 
 			for(var/obj/item/organ/I in internal_organs)
 				I.do_uninstall() //No owner so run uninstall directly
 				I.dropInto(get_turf(loc))
 				if(!QDELETED(I) && isturf(loc))
-					I.throw_at(get_edge_target_turf(src,pick(global.alldirs)),rand(1,3),30)
+					I.throw_at(get_edge_target_turf(src,pick(global.alldirs)), rand(1,3), THROWFORCE_GIBS)
 
 			for(var/obj/item/I in src)
 				I.dropInto(loc)
-				I.throw_at(get_edge_target_turf(src,pick(global.alldirs)),rand(1,3),30)
+				I.throw_at(get_edge_target_turf(src,pick(global.alldirs)), rand(1,3), THROWFORCE_GIBS)
 
 			qdel(src)
 


### PR DESCRIPTION
## Description of changes
Lowers throwforce of gibs to be about on par with throwing something from your hand.

## Why and what will this PR improve
Resolves #2306.
Should prevent gibbed bodies from damaging walls and doors.

## Authorship
Myself.

## Changelog
:cl:
tweak: Gibbed bodies now throw the limbs around with less force.
/:cl: