### PR TITLE
cached_json_code() returns a copy to avoid cache mutation.

### DIFF
--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -767,12 +767,15 @@ proc/dd_sortedObjectList(list/incoming)
 
 var/global/list/json_cache = list()
 /proc/cached_json_decode(var/json_to_decode)
-	if(!json_to_decode || !length(json_to_decode))
-		return list()
-	try
-		if(isnull(global.json_cache[json_to_decode]))
-			global.json_cache[json_to_decode] = json_decode(json_to_decode)
-		. = global.json_cache[json_to_decode]
-	catch(var/exception/e)
-		log_error("Exception during JSON decoding ([json_to_decode]): [e]")
-		return list()
+	if(length(json_to_decode))
+		try
+			if(isnull(global.json_cache[json_to_decode]))
+				global.json_cache[json_to_decode] = json_decode(json_to_decode)
+			var/list/decoded = global.json_cache[json_to_decode]
+			if(islist(decoded)) // To prevent cache mutation.
+				return deepCopyList(decoded)
+			else if(decoded)
+				return decoded	
+		catch(var/exception/e)
+			log_error("Exception during JSON decoding ([json_to_decode]): [e]")
+	return list()


### PR DESCRIPTION
## Description of changes
`cached_json_decode()` now returns a copy of any cached json.

## Why and what will this PR improve
Previously anything messing with the returned json would mutate the cache, which is undesirable.

## Authorship
Myself.

## Changelog
Nothing player-facing.