### PR TITLE
Fix mmi_holder qdel loop and switch langserver warning

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -244,13 +244,10 @@ var/global/list/global/organ_rel_size = list(
 			if(lowertext(newletter)=="a")	newletter="ah"
 			if(lowertext(newletter)=="c")	newletter="k"
 		switch(rand(1,15))
-			if(1,3,5,8)	newletter="[lowertext(newletter)]"
-			if(2,4,6,15)	newletter="[uppertext(newletter)]"
-			if(7)	newletter+="'"
-			//if(9 to 14) do nothing
-			//if(9,10)	newletter="<b>[newletter]</b>"
-			//if(11,12)	newletter="<big>[newletter]</big>"
-			//if(13)	newletter="<small>[newletter]</small>"
+			if(1 to 4)	newletter="[lowertext(newletter)]"
+			if(5 to 8)	newletter="[uppertext(newletter)]"
+			if(9)	newletter+="'"
+			else	newletter = newletter
 		newphrase+="[newletter]";counter-=1
 	return newphrase
 

--- a/code/modules/organs/internal/posibrain.dm
+++ b/code/modules/organs/internal/posibrain.dm
@@ -380,4 +380,5 @@
 //Since the mmi_holder is an horrible hacky pos we turn it into a mmi on drop, since it shouldn't exist outside a mob
 /obj/item/organ/internal/mmi_holder/dropInto(atom/destination)
 	. = ..()
-	transfer_and_delete()
+	if (!QDELETED(src))
+		transfer_and_delete()


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
- Fixes qdel loop in mmi_holder
- Fixes langserver warning for unused switch condition
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Warnings are bad, qdel loops worse.

## Authorship
Me.
<!-- Describe original authors of changes to credit them. -->