### PR TITLE
fix: put beaker in hands, when ejected from ChemDispenser, or drop if used by silicon

### DIFF
--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -30,7 +30,7 @@
 	var/static/list/acceptable_containers = list(
 		/obj/item/chems/glass,
 		/obj/item/chems/condiment,
-		/obj/item/chems/drinks		
+		/obj/item/chems/drinks
 	)
 
 /obj/machinery/chemical_dispenser/Initialize(mapload, d=0, populate_parts = TRUE)
@@ -117,7 +117,7 @@
 		to_chat(user, "<span class='notice'>You set \the [RC] on \the [src].</span>")
 		SSnano.update_uis(src) // update all UIs attached to src
 		return TRUE
-	
+
 	return ..()
 
 /obj/machinery/chemical_dispenser/ui_interact(mob/user, ui_key = "main",var/datum/nanoui/ui = null, var/force_open = 1)
@@ -179,13 +179,18 @@
 		return TOPIC_HANDLED
 
 	else if(href_list["ejectBeaker"])
-		if(container)
-			var/obj/item/chems/B = container
+		if(!container)
+			return TOPIC_HANDLED
+
+		var/obj/item/chems/B = container
+		if(CanPhysicallyInteract(user))
+			user.put_in_hands(B)
+		else
 			B.dropInto(loc)
-			container = null
-			update_icon()
-			return TOPIC_REFRESH
-		return TOPIC_HANDLED
+
+		container = null
+		update_icon()
+		return TOPIC_REFRESH
 
 /obj/machinery/chemical_dispenser/interface_interact(mob/user)
 	ui_interact(user)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Put beaker in hands instead of drop to ChemDispenser turf, when ejecting from it


## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

QoL

## Authorship
<!-- Describe original authors of changes to credit them. -->

@Gaxeer 

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
tweak: put beaker in hands instead of drop to ChemDispenser turf, when ejecting from it
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
