### PR TITLE
Fixes structure double parent call.

### DIFF
--- a/code/game/objects/structures/__structure.dm
+++ b/code/game/objects/structures/__structure.dm
@@ -7,7 +7,6 @@
 	var/health = 0
 	var/maxhealth = 50
 	var/hitsound = 'sound/weapons/smash.ogg'
-	var/breakable
 	var/parts_type
 	var/parts_amount
 	var/footstep_type
@@ -178,18 +177,6 @@
 			for(var/atom/movable/AM in T)
 				AM.reset_offsets()	
 				AM.reset_plane_and_layer()
-
-/obj/structure/attack_hand(mob/user)
-	..()
-	if(breakable)
-		if(MUTATION_HULK in user.mutations)
-			user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
-			attack_generic(user,1,"smashes")
-		else if(istype(user,/mob/living/carbon/human))
-			var/mob/living/carbon/human/H = user
-			if(H.species.can_shred(user))
-				attack_generic(user,1,"slices")
-	return ..()
 
 /obj/structure/grab_attack(var/obj/item/grab/G)
 	if (!G.force_danger())

--- a/code/game/objects/structures/_structure_construction.dm
+++ b/code/game/objects/structures/_structure_construction.dm
@@ -138,3 +138,19 @@
 	if(.)
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		add_fingerprint(user)
+
+/obj/structure/attack_generic(var/mob/user, var/damage, var/attack_verb, var/environment_smash)
+	if(environment_smash >= 1)
+		damage = max(damage, 10)
+
+	if(istype(user))
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.do_attack_animation(src)
+	if(!damage)
+		return FALSE
+	if(damage >= 10)
+		visible_message(SPAN_DANGER("\The [user] [attack_verb] into [src]!"))
+		take_damage(damage)
+	else
+		visible_message(SPAN_NOTICE("\The [user] bonks \the [src] harmlessly."))
+	return TRUE

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -170,23 +170,6 @@
 		user.visible_message("[user.name] knocks on the [src.name].",
 							"You knock on the [src.name].",
 							"You hear a knocking sound.")
-	return
-
-/obj/structure/window/attack_generic(var/mob/user, var/damage, var/attack_verb, var/environment_smash)
-	if(environment_smash >= 1)
-		damage = max(damage, 10)
-
-	if(istype(user))
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		user.do_attack_animation(src)
-	if(!damage)
-		return
-	if(damage >= 10)
-		visible_message(SPAN_DANGER("[user] [attack_verb] into [src]!"))
-		take_damage(damage)
-	else
-		visible_message(SPAN_NOTICE("\The [user] bonks \the [src] harmlessly."))
-	return 1
 
 /obj/structure/window/do_simple_ranged_interaction(var/mob/user)
 	visible_message(SPAN_NOTICE("Something knocks on \the [src]."))

--- a/mods/species/ascent/mobs/insectoid_egg.dm
+++ b/mods/species/ascent/mobs/insectoid_egg.dm
@@ -10,7 +10,6 @@ var/global/default_gyne
 
 /obj/structure/insectoid_egg
 	name = "alien egg"
-	breakable = TRUE
 	desc = "A semi-translucent alien egg."
 	health = 100
 	maxhealth = 100


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Removes some code from `structure/attack_hand`.

## Why and what will this PR improve
The double parent call leads to some duplicated messages. The other code appears dead; almost no structures implement `attack_generic`, and none of the ones that do set `breakable` anyway.

Now also moves `attack_generic` logic back to structure level. Didn't test all interactions, but seems to be OK.

## Authorship
me

## Changelog

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
