### PR TITLE
Temporarily swaps multitools out for variable tools.

### DIFF
--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -26,7 +26,7 @@
 		default_pixel_y = rand(0, 4)
 		reset_offsets(0)
 	create_reagents(5)
-	set_extension(src, /datum/extension/tool, list(
+	set_extension(src, /datum/extension/tool/variable, list(
 		TOOL_RETRACTOR = TOOL_QUALITY_BAD,
 		TOOL_HEMOSTAT =  TOOL_QUALITY_MEDIOCRE
 	))

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -25,7 +25,7 @@
 /obj/item/knife/Initialize(ml, material_key)
 	. = ..()
 	if(!has_extension(src, /datum/extension/tool))
-		set_extension(src, /datum/extension/tool, list( 
+		set_extension(src, /datum/extension/tool/variable, list( 
 			TOOL_SCALPEL =     TOOL_QUALITY_MEDIOCRE,
 			TOOL_SAW =         TOOL_QUALITY_BAD,
 			TOOL_RETRACTOR =   TOOL_QUALITY_BAD, 

--- a/code/game/objects/items/weapons/material/swiss.dm
+++ b/code/game/objects/items/weapons/material/swiss.dm
@@ -25,7 +25,7 @@
 	var/static/list/sharp_tools = list(SWISSKNF_LBLADE, SWISSKNF_SBLADE, SWISSKNF_GBLADE, SWISSKNF_WBLADE)
 
 /obj/item/knife/folding/swiss/Initialize(ml, material_key)
-	set_extension(src, /datum/extension/tool, list(
+	set_extension(src, /datum/extension/tool/variable, list(
 		TOOL_CROWBAR =     TOOL_QUALITY_MEDIOCRE,
 		TOOL_SCREWDRIVER = TOOL_QUALITY_MEDIOCRE,
 		TOOL_WIRECUTTERS = TOOL_QUALITY_MEDIOCRE,

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -179,7 +179,7 @@
 
 /obj/item/incision_manager/Initialize()
 	. = ..()
-	set_extension(src, /datum/extension/tool, list(
+	set_extension(src, /datum/extension/tool/variable, list(
 		TOOL_SAW =       TOOL_QUALITY_GOOD,
 		TOOL_SCALPEL =   TOOL_QUALITY_GOOD, 
 		TOOL_RETRACTOR = TOOL_QUALITY_GOOD, 

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -7,7 +7,7 @@
 
 /obj/item/ducttape/Initialize()
 	. = ..()
-	set_extension(src, /datum/extension/tool, list(
+	set_extension(src, /datum/extension/tool/variable, list(
 		TOOL_BONE_GEL = TOOL_QUALITY_MEDIOCRE,
 		TOOL_SUTURES =  TOOL_QUALITY_BAD
 	))

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -496,7 +496,7 @@ By design, d1 is the smallest direction and d2 is the highest
 
 /obj/item/stack/cable_coil/Initialize()
 	. = ..()
-	set_extension(src, /datum/extension/tool, list(
+	set_extension(src, /datum/extension/tool/variable, list(
 		TOOL_CABLECOIL = TOOL_QUALITY_DEFAULT,
 		TOOL_SUTURES =   TOOL_QUALITY_MEDIOCRE
 	))


### PR DESCRIPTION
## Description of changes
Temporary workaround for multiple-use tools not being useful due to linear interaction checks.

## Why and what will this PR improve
Currently if you try to use a a tool which functions as both wirecutters and a screwdriver, to interact with an APC, the first interaction is the only one that you can access due to the way attackby is structured. This PR changes those tools to need to be used in hand to swap between tool types, which sucks as far as UX goes, but does allow them to be used. In the future when we move to interaction handlers or something instead of the monolithic IS_TOOL checks in attackby() this won't be necessary.

## Authorship
Myself.

## Changelog
:cl:
tweak: Tools with multiple uses can be used in hand to switch between each type of tool.
/:cl: