### PR TITLE
Fixes generator icon

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -1,6 +1,7 @@
 /obj/machinery/generator
 	name = "thermoelectric generator"
 	desc = "It's a high efficiency thermoelectric generator."
+	icon = 'icons/obj/power.dmi'
 	icon_state = "teg-unassembled"
 	density = 1
 	anchored = 0


### PR DESCRIPTION
Fixes the missing generator icon caused by the power rework. I failed to realize the icon was not redefined on the generator machine, as it is with the rest of the power machinery.

Thanks to Jade for pointing out this bug.

## Changelog
:cl:
bugfix: Fixed missing TEG icon
/:cl: