### PR TITLE
Airlock panel opens with wrench

### DIFF
--- a/code/game/machinery/_machines_base/machine_construction/airlock.dm
+++ b/code/game/machinery/_machines_base/machine_construction/airlock.dm
@@ -27,7 +27,7 @@
 /decl/machine_construction/default/panel_closed/door/mechanics_info()
 	. = list()
 	. += "Use a screwdriver to open a small hatch and expose some logic wires."
-	. += "Use a crowbar on the secured (bolted, welded or braced) airlock to pry open the main cover."
+	. += "Use a wrench to open the main cover."
 	. += "Use a parts replacer to view installed parts."
 
 /decl/machine_construction/default/panel_closed/door/hacking

--- a/code/game/machinery/_machines_base/machine_construction/airlock.dm
+++ b/code/game/machinery/_machines_base/machine_construction/airlock.dm
@@ -10,7 +10,7 @@
 		to_chat(user, SPAN_NOTICE("You release some of the logic wiring on \the [machine]. The cover panel remains closed."))
 		machine.update_icon()
 		return
-	if(IS_CROWBAR(I))
+	if(IS_WRENCH(I))
 		TRANSFER_STATE(down_state)
 		playsound(get_turf(machine), 'sound/items/Crowbar.ogg', 50, 1)
 		machine.panel_open = TRUE


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Airlock panel opens with wrench instead crowbar
## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
to open the panel with a crowbar, the airlock had to be welded or boled. Wrench doesn't have this problem.
## Authorship
<!-- Describe original authors of changes to credit them. -->
me
## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
tweak: Airlock components panel now opens with wrench
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
