### PR TITLE
Adjust suit refitting code to be less broken.

### DIFF
--- a/code/datums/item_modifiers/item_modifier.dm
+++ b/code/datums/item_modifiers/item_modifier.dm
@@ -27,5 +27,9 @@
 
 	I.SetName(type_setup[SETUP_NAME])
 	I.icon = type_setup[SETUP_ICON]
+	if(istype(I, /obj/item/clothing))
+		var/list/type_spritesheets = type_setup[SETUP_SPRITE_SHEETS]
+		var/obj/item/clothing/C = I
+		C.sprite_sheets = type_spritesheets?.Copy()
 	I.reconsider_single_icon(TRUE)
 	return TRUE

--- a/code/game/machinery/suit_cycler.dm
+++ b/code/game/machinery/suit_cycler.dm
@@ -43,7 +43,7 @@
 	)
 
 	//Bodytypes that the suits can be configured to fit.
-	var/list/available_bodytypes = list(BODYTYPE_HUMANOID = BODY_FLAG_HUMANOID)
+	var/list/available_bodytypes = list(BODYTYPE_HUMANOID)
 
 	var/decl/item_modifier/target_modification
 	var/target_bodytype
@@ -458,21 +458,15 @@
 /obj/machinery/suit_cycler/proc/apply_paintjob()
 	if(!target_bodytype || !target_modification)
 		return
-	var/target_flags = available_bodytypes[target_bodytype]
-	if(helmet) helmet.refit_for_bodytype(target_flags)
-	if(suit)   suit.refit_for_bodytype(target_flags)
-	if(boots)  boots.refit_for_bodytype(target_flags)
-
 
 	if(helmet)
 		target_modification.RefitItem(helmet)
 		helmet.refit_for_bodytype(target_bodytype)
+		helmet.SetName("refitted [helmet.name]")
 	if(suit)
-		suit.refit_for_bodytype(target_bodytype)
 		target_modification.RefitItem(suit)
+		suit.refit_for_bodytype(target_bodytype)
+		suit.SetName("refitted [suit.name]")
 	if(boots)
 		boots.refit_for_bodytype(target_bodytype)
-
-	if(helmet) helmet.SetName("refitted [helmet.name]")
-	if(suit)   suit.SetName("refitted [suit.name]")
-	if(boots)  boots.SetName("refitted [initial(boots.name)]")
+		boots.SetName("refitted [initial(boots.name)]")

--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -8,7 +8,7 @@
 	icon = 'icons/obj/items/modkit.dmi'
 	icon_state = "modkit"
 	var/parts = MODKIT_FULL
-	var/target_bodytype
+	var/target_bodytype = BODYTYPE_HUMANOID
 
 	var/list/permitted_types = list(
 		/obj/item/clothing/head/helmet/space/void,

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -26,6 +26,7 @@
 		/obj/item/flame,
 		/obj/item/paper,
 		/obj/item/paper_bundle,
+		/obj/item/passport,
 		/obj/item/pen,
 		/obj/item/photo,
 		/obj/item/chems/dropper,

--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -45,6 +45,9 @@
 			else
 				T.update_icon()
 
+/turf/exterior/is_floor()
+	return !density && !is_open()
+
 /turf/exterior/ChangeTurf(var/turf/N, var/tell_universe = TRUE, var/force_lighting_update = FALSE, var/keep_air = FALSE, var/keep_outside = FALSE)
 	var/last_affecting_heat_sources = affecting_heat_sources
 	var/turf/exterior/ext = ..()

--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -120,7 +120,7 @@ var/global/list/flooring_cache = list()
 				is_linked = TRUE
 
 		//If we get here then its a normal floor
-		else if (T.is_floor())
+		else if (istype(T, /turf/simulated/floor))
 			var/turf/simulated/floor/t = T
 			//Check for window frames.
 			if(wall_smooth == SMOOTH_ALL)

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -142,9 +142,20 @@
 	return ..()
 
 /obj/item/clothing/proc/refit_for_bodytype(var/target_bodytype)
-	bodytype_equip_flags = target_bodytype
-	if(sprite_sheets[target_bodytype])
-		icon = sprite_sheets[target_bodytype]
+
+	bodytype_equip_flags = 0
+	for(var/decl/bodytype/bod in global.bodytypes_by_category[target_bodytype])
+		bodytype_equip_flags |= bod.bodytype_flag
+
+	var/last_icon = icon
+	var/species_icon = LAZYACCESS(sprite_sheets, target_bodytype)
+	if(species_icon && (check_state_in_icon(ICON_STATE_INV, species_icon) || check_state_in_icon(ICON_STATE_WORLD, species_icon)))
+		icon = species_icon
+	else
+		icon = initial(icon)
+	if(last_icon != icon)
+		reconsider_single_icon()
+		update_clothing_icon()
 
 /obj/item/clothing/get_examine_line()
 	. = ..()

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -144,6 +144,7 @@
 /obj/item/clothing/proc/refit_for_bodytype(var/target_bodytype)
 
 	bodytype_equip_flags = 0
+	decls_repository.get_decls_of_subtype(/decl/bodytype) // Make sure they're prefetched so the below list is populated
 	for(var/decl/bodytype/bod in global.bodytypes_by_category[target_bodytype])
 		bodytype_equip_flags |= bod.bodytype_flag
 

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -287,12 +287,3 @@ else if(##equipment_var) {\
 	if(overlay && tank && slot == slot_back_str)
 		overlay.overlays += tank.get_mob_overlay(user_mob, slot_back_str)
 	. = ..()
-/obj/item/clothing/suit/space/void/refit_for_bodytype(target_bodytype)
-	..()
-	icon = get_icon_for_bodytype(target_bodytype)
-	queue_icon_update()
-
-/obj/item/clothing/head/helmet/space/void/refit_for_bodytype(target_bodytype)
-	..()
-	icon = get_icon_for_bodytype(target_bodytype)
-	queue_icon_update()

--- a/code/modules/fabrication/designs/general/designs_general.dm
+++ b/code/modules/fabrication/designs/general/designs_general.dm
@@ -116,6 +116,15 @@
 		/decl/material/solid/metal/steel =   CEILING((SHEET_MATERIAL_AMOUNT * FABRICATOR_EXTRA_COST_FACTOR)),
 	)
 
+/datum/fabricator_recipe/struts/plastic
+	name = "strut, plastic"
+	path = /obj/item/stack/material/strut/mapped/plastic
+
+/datum/fabricator_recipe/struts/plastic/get_resources()
+	resources = list(
+		/decl/material/solid/plastic =   CEILING((SHEET_MATERIAL_AMOUNT * FABRICATOR_EXTRA_COST_FACTOR)),
+	)
+
 /datum/fabricator_recipe/struts/aluminium
 	name = "strut, aluminium"
 	path = /obj/item/stack/material/strut/mapped/aluminium

--- a/code/modules/materials/definitions/solids/materials_solid_organic.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_organic.dm
@@ -351,6 +351,12 @@
 	wall_support_value = MAT_VALUE_NORMAL
 	default_solid_form = /obj/item/stack/material/bone
 
+/decl/material/solid/bone/generate_recipes(var/reinforce_material)
+	. = ..()
+	if(!reinforce_material && wall_support_value >= 10)
+		. += new/datum/stack_recipe/furniture/girder(src)
+		. += new/datum/stack_recipe/furniture/ladder(src)
+
 /decl/material/solid/bone/fish
 	name = "fishbone"
 	uid = "solid_fishbone"

--- a/code/modules/materials/definitions/solids/materials_solid_stone.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_stone.dm
@@ -22,6 +22,8 @@
 	. = ..()
 	if(reinforce_material)	//recipes below don't support composite materials
 		return
+	if(wall_support_value >= 10)
+		. += new/datum/stack_recipe/furniture/girder(src)
 	. += new/datum/stack_recipe/furniture/planting_bed(src)
 
 /decl/material/solid/stone/sandstone

--- a/code/modules/materials/definitions/solids/materials_solid_wood.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_wood.dm
@@ -43,6 +43,11 @@
 	. = ..()
 	if(reinforce_material)	//recipes below don't support composite materials
 		return
+
+	if(wall_support_value >= 10)
+		. += new/datum/stack_recipe/furniture/girder(src)
+		. += new/datum/stack_recipe/furniture/ladder(src)
+
 	. += new/datum/stack_recipe/sandals(src)
 	. += new/datum/stack_recipe/tile/wood(src)
 	. += create_recipe_list(/datum/stack_recipe/furniture/chair/wood)

--- a/code/modules/materials/material_sheets_mapping.dm
+++ b/code/modules/materials/material_sheets_mapping.dm
@@ -95,7 +95,9 @@ STACK_SUBTYPES(blue,           "blue cloth",                    solid/cloth/blue
 STACK_SUBTYPES(beige,          "beige cloth",                   solid/cloth/beige,          bolt,       null)
 STACK_SUBTYPES(lime,           "lime cloth",                    solid/cloth/lime,           bolt,       null)
 STACK_SUBTYPES(red,            "red cloth",                     solid/cloth/red,            bolt,       null)
+
 STACK_SUBTYPES(steel,          "steel",                         solid/metal/steel,          strut,      null)
+STACK_SUBTYPES(plastic,        "plastic",                       solid/plastic,              strut,      null)
 STACK_SUBTYPES(aluminium,      "aluminium",                     solid/metal/aluminium,      strut,      null)
 STACK_SUBTYPES(titanium,       "titanium",                      solid/metal/titanium,       strut,      null)
 

--- a/code/modules/species/species_bodytype.dm
+++ b/code/modules/species/species_bodytype.dm
@@ -63,9 +63,10 @@ var/global/list/bodytypes_by_category = list()
 
 /decl/bodytype/Initialize()
 	. = ..()
-	LAZYDISTINCTADD(global.bodytypes_by_category[bodytype_category], src)
 	if(!icon_deformed)
 		icon_deformed = icon_base
+	if(!is_abstract())
+		LAZYDISTINCTADD(global.bodytypes_by_category[bodytype_category], src)
 
 /decl/bodytype/proc/apply_limb_colouration(var/obj/item/organ/external/E, var/icon/applying)
 	return applying

--- a/code/modules/species/species_bodytype.dm
+++ b/code/modules/species/species_bodytype.dm
@@ -1,3 +1,5 @@
+var/global/list/bodytypes_by_category = list()
+
 /decl/bodytype
 	var/name = "default"
 	var/icon_base
@@ -61,6 +63,7 @@
 
 /decl/bodytype/Initialize()
 	. = ..()
+	LAZYDISTINCTADD(global.bodytypes_by_category[bodytype_category], src)
 	if(!icon_deformed)
 		icon_deformed = icon_base
 


### PR DESCRIPTION
## Description of changes
- Refitting now expects both bodytype and body flags.
- Refitting now copies sprite_sheets.
- Refitting now only sets icons if the icon has a world/inventory state to use.
- Removes a merge artifact.

Accidentally included some fixes:
- Allows girders to be built from wood, bone and plastic.
- Exterior turfs now count as floors for the purposes of movement and crafting.

## Why and what will this PR improve
Existing code is busted all to heck.

## Authorship
Myself.

## Changelog
Nothing player-facing.