### PR TITLE
Fall stack does not kick off if the person cannot fall through the turf below.

### DIFF
--- a/code/datums/movement/multiz.dm
+++ b/code/datums/movement/multiz.dm
@@ -12,10 +12,6 @@
 		to_chat(mob, "<span class='warning'>\The [start] is in the way.</span>")
 		return MOVEMENT_HANDLED
 
-	if(!destination.CanZPass(mob, direction))
-		to_chat(mob, "<span class='warning'>You bump against \the [destination].</span>")
-		return MOVEMENT_HANDLED
-
 	var/area/area = get_area(mob)
 	if(direction == UP && area.has_gravity() && !mob.can_overcome_gravity())
 		to_chat(mob, "<span class='warning'>Gravity stops you from moving upward.</span>")

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -1,34 +1,26 @@
 #define NEIGHBOR_REFRESH_TIME 100
 
 /obj/effect/vine/proc/get_cardinal_neighbors()
-	var/list/cardinal_neighbors = list()
+	. = list()
 	for(var/check_dir in global.cardinal)
 		var/turf/simulated/T = get_step(get_turf(src), check_dir)
 		if(istype(T))
-			cardinal_neighbors |= T
-	return cardinal_neighbors
+			. |= T
 
 /obj/effect/vine/proc/get_zlevel_neighbors()
-	var/list/zlevel_neighbors = list()
-
+	. = list()
 	var/turf/start = loc
-	var/turf/up = GetAbove(loc)
-	var/turf/down = GetBelow(loc)
-
-	if(start && start.CanZPass(src, DOWN))
-		zlevel_neighbors += down
-	if(up && up.CanZPass(src, UP))
-		zlevel_neighbors += up
-
-	return zlevel_neighbors
+	if(isturf(start))
+		if(start.CanZPass(src, DOWN))
+			. += GetBelow(loc)
+		if(start.CanZPass(src, UP))
+			. += GetAbove(loc)
 
 /obj/effect/vine/proc/get_neighbors()
-	var/list/neighbors = list()
-
+	. = list()
 	for(var/turf/simulated/floor in get_cardinal_neighbors())
 		if(get_dist(parent, floor) > spread_distance)
 			continue
-
 		var/blocked = 0
 		for(var/obj/effect/vine/other in floor.contents)
 			if(other.seed == src.seed)
@@ -36,19 +28,14 @@
 				break
 		if(blocked)
 			continue
-
 		if(floor.density)
 			if(!isnull(seed.chems[/decl/material/liquid/acid/polyacid]))
 				spawn(rand(5,25)) floor.explosion_act(3)
 			continue
-
 		if(!Adjacent(floor) || !floor.Enter(src))
 			continue
-
-		neighbors |= floor
-
-	neighbors |= get_zlevel_neighbors()
-	return neighbors
+		. |= floor
+	. |= get_zlevel_neighbors()
 
 /obj/effect/vine/Process()
 	var/turf/simulated/T = get_turf(src)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1117,7 +1117,7 @@
 	var/turf/T = get_turf(src)
 	if(istype(T) && T.is_flooded(lying) && should_have_organ(BP_LUNGS))
 		if(T == location) //Can we surface?
-			if(!lying && T.above && !T.above.is_flooded() && T.above.CanZPass(src, UP) && can_overcome_gravity())
+			if(!lying && T.above && !T.above.is_flooded() && T.above.is_open() && can_overcome_gravity())
 				return ..(volume_needed, T.above)
 		var/can_breathe_water = (istype(wear_mask) && wear_mask.filters_water()) ? TRUE : FALSE
 		if(!can_breathe_water)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -535,11 +535,6 @@ default behaviour is:
 				mygrabs -= G
 				qdel(G)
 				continue
-			if(!destination.CanZPass(G.affecting, direction))
-				to_chat(src, SPAN_WARNING("The [G.affecting] you were pulling bumps up against \the [destination]."))
-				mygrabs -= G
-				qdel(G)
-				continue
 			for(var/atom/A in destination)
 				if(!A.CanMoveOnto(G.affecting, start, 1.5, direction))
 					to_chat(src, SPAN_WARNING("\The [A] blocks the [G.affecting] you were pulling."))
@@ -805,7 +800,7 @@ default behaviour is:
 	var/turf/T = get_turf(src)
 	if(!can_drown() || !loc.is_flooded(lying))
 		return FALSE
-	if(!lying && T.above && !T.above.is_flooded() && T.above.CanZPass(src, UP) && can_overcome_gravity())
+	if(!lying && T.above && T.above.is_open() && !T.above.is_flooded() && can_overcome_gravity())
 		return FALSE
 	if(prob(5))
 		var/obj/effect/fluid/F = locate() in loc

--- a/code/modules/multiz/mobile_ladder.dm
+++ b/code/modules/multiz/mobile_ladder.dm
@@ -24,7 +24,7 @@
 		else if(target.contains_dense_objects())
 			to_chat(user, SPAN_WARNING("Objects below block \the [src] from deploying!"))
 			return FALSE
-		else if(T.CanZPass(T,DOWN) && target.CanZPass(target,DOWN))
+		else if(T.CanZPass(T, DOWN))
 			to_chat(user, SPAN_WARNING("You can't find anything to support \the [src] on!"))
 			return FALSE
 	else if (istype(T, /turf/simulated/floor) || istype(T, /turf/unsimulated/floor))

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -104,7 +104,7 @@
 		return
 
 	var/turf/T = loc
-	if(!T.CanZPass(src, DOWN) || !below.CanZPass(src, DOWN))
+	if(!T.CanZPass(src, DOWN))
 		return
 
 	// No gravity in space, apparently.
@@ -261,8 +261,7 @@
 		return FALSE
 
 	var/turf/T = get_turf(A)
-	var/turf/above = GetAbove(src)
-	if(above && T.Adjacent(bound_overlay) && above.CanZPass(src, UP)) //Certain structures will block passage from below, others not
+	if(T.Adjacent(bound_overlay) && T.CanZPass(src, UP)) //Certain structures will block passage from below, others not
 		if(loc.has_gravity() && !can_overcome_gravity())
 			return FALSE
 

--- a/code/modules/multiz/stairs.dm
+++ b/code/modules/multiz/stairs.dm
@@ -23,10 +23,10 @@
 	return ..()
 
 /obj/structure/stairs/Bumped(atom/movable/A)
+	var/turf/myturf = get_turf(src)
 	var/turf/target = get_step(GetAbove(A), dir)
 	var/turf/source = get_turf(A)
-	var/turf/above = GetAbove(A)
-	if(above.CanZPass(source, UP) && target.Enter(A, src))
+	if(myturf.CanZPass(A, UP) && target.Enter(A, src))
 		A.forceMove(target)
 		if(isliving(A))
 			var/mob/living/L = A

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -1,20 +1,24 @@
-/turf/proc/CanZPass(atom/A, direction)
-	if(z == A.z) //moving FROM this turf
-		return direction == UP //can't go below
-	else
-		if(direction == UP) //on a turf below, trying to enter
-			return 0
-		if(direction == DOWN) //on a turf above, trying to enter
-			return !density
+/// `direction` is the direction the atom is trying to leave by.
+/turf/proc/CanZPass(atom/A, direction, check_neighbor_canzpass = TRUE)
 
-/turf/space/CanZPass(atom/A, direction)
-	if(locate(/obj/structure/catwalk, src))
-		if(z == A.z)
-			if(direction == DOWN)
-				return 0
-		else if(direction == UP)
-			return 0
-	return 1
+	if(direction == UP)
+		if(!HasAbove(z))
+			return FALSE
+		if(check_neighbor_canzpass)
+			var/turf/T = GetAbove(src)
+			if(!T.CanZPass(A, DOWN, FALSE))
+				return FALSE
+
+	else if(direction == DOWN)
+		if(!is_open() || !HasBelow(z) || (locate(/obj/structure/catwalk) in src))
+			return FALSE
+		if(check_neighbor_canzpass)
+			var/turf/T = GetBelow(src)
+			if(!T.CanZPass(A, UP, FALSE))
+				return FALSE
+
+	// Hate calling Enter() directly, but that's where obstacles are checked currently.
+	return Enter(A, A)
 
 ////////////////////////////////
 // Open SIMULATED
@@ -30,15 +34,6 @@
 /turf/simulated/open/flooded
 	name = "open water"
 	flooded = TRUE
-
-/turf/simulated/open/CanZPass(atom/A, direction)
-	if(locate(/obj/structure/catwalk, src))
-		if(z == A.z)
-			if(direction == DOWN)
-				return 0
-		else if(direction == UP)
-			return 0
-	return 1
 
 /turf/simulated/open/update_dirt()
 	return 0
@@ -145,15 +140,6 @@
 /turf/exterior/open/flooded
 	name = "open water"
 	flooded = TRUE
-
-/turf/exterior/open/CanZPass(atom/A, direction)
-	if(locate(/obj/structure/catwalk, src))
-		if(z == A.z)
-			if(direction == DOWN)
-				return 0
-		else if(direction == UP)
-			return 0
-	return 1
 
 /turf/exterior/open/Entered(var/atom/movable/mover, var/atom/oldloc)
 	..()

--- a/mods/species/ascent/datum/species.dm
+++ b/mods/species/ascent/datum/species.dm
@@ -333,9 +333,8 @@
 	if(mixture)
 		var/pressure = mixture.return_pressure()
 		if(pressure > 50)
-			var/turf/below = GetBelow(H)
 			var/turf/T = H.loc
-			if(!T.CanZPass(H, DOWN) || !below.CanZPass(H, DOWN))
+			if(istype(T) && !T.CanZPass(H, DOWN))
 				return TRUE
 
 	return FALSE


### PR DESCRIPTION
- `CanZPass()` has been collapsed into a single root definition on `/turf`.
- `CanZPass()` now takes a mover and the direction that the mover wishes to leave the turf from. It will check up and down neighbors as necessary.
- `CanZPass()` now checks the turf's `Enter()` as that is where obstacle logic lives currently. It sucks, TODO rework.

Fixes #2446.

Tested:
- Up and down stairs.
- Up and down ladders.
- Down through lattices.
- Falling.
- Walking on dense atoms.