### PR TITLE
new radial menu for rig [WIP]

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -282,6 +282,11 @@
 		client.screen -= hud_used.hotkeybuttons
 		hud_used.hotkey_ui_hidden = 1
 
+/mob/living/carbon/human/AltClick(var/mob/user)
+	if(user != src || !wearing_rig || wearing_rig.canremove)
+		return ..()
+	wearing_rig.open_rig_ui(user)
+
 // Yes, these use icon state. Yes, these are terrible. The alternative is duplicating
 // a bunch of fairly blobby logic for every click override on these objects.
 

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -223,6 +223,13 @@
 
 	return 1
 
+//Proc for toggling abilities
+/obj/item/rig_module/proc/toggle_module()
+	if(active)
+		deactivate()
+	else
+		activate()
+
 //Proc for selecting module
 /obj/item/rig_module/proc/select()
 
@@ -242,6 +249,42 @@
 		suit_overlay = null
 	holder.update_icon()
 	return 1
+
+/obj/item/rig_module/proc/toogle_select()
+	if(!selectable)
+		return FALSE
+
+	if(holder.selected_module == src)
+		return FALSE
+
+	select()
+	to_chat(usr, "<font color='blue'><b>Primary system is now: [src].</b></font>")
+
+	return TRUE
+
+/obj/item/rig_module/proc/select_charge(mob/user)
+	if(!LAZYLEN(charges))
+		return TRUE
+
+	var/list/choices
+	var/new_charge
+
+	for(var/thing in charges)
+		var/ui = thing
+		var/image/radial_button = new
+		radial_button.name = capitalize(ui)
+		LAZYSET(choices, ui, radial_button)
+	if(LAZYLEN(choices) > 1)
+		new_charge = show_radial_menu(user, user, choices, "defmenu_[any2ref(user)]_[any2ref(user)]_outer", radius = 42, use_labels = TRUE)
+	else
+		new_charge = choices[1]
+	charge_selected = new_charge
+
+	if(!charge_selected)
+		return FALSE
+	return TRUE
+
+
 
 // Called when the module is uninstalled from a suit.
 /obj/item/rig_module/proc/removed()

--- a/code/modules/clothing/spacesuits/rig/modules/vision.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/vision.dm
@@ -201,3 +201,29 @@
 		processed_vision += vision_datum
 
 	vision_modes = processed_vision
+
+/obj/item/rig_module/vision/proc/select_vision(mob/user)
+	if(!vision_modes)
+		return TRUE
+
+	var/list/choices
+	var/list/modeName2mode = list()
+	var/list/modes = list("Toggle")
+
+	var/datum/rig_vision/A = null
+
+	for (var/datum/rig_vision/vision as anything in vision_modes)
+		modeName2mode[vision.mode] = vision
+	//modes += modeName2mode
+
+	for(var/thing in modes)
+		var/ui = thing
+		var/image/radial_button = new
+		radial_button.name = capitalize(ui)
+		LAZYSET(choices, ui, radial_button)
+	A = show_radial_menu(user, user, choices, "defmenu_[any2ref(user)]_[any2ref(user)]_outer", radius = 42, tooltips = TRUE)
+
+	if(A == "Toggle")
+		src.toggle_module()
+	else
+		vision = modeName2mode[A]

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -105,7 +105,7 @@
 	gloves = /obj/item/clothing/gloves/rig/light/ninja
 	cell =   /obj/item/cell/hyper
 
-	req_access = list(access_syndicate)
+	req_access = list(access_armory)
 
 	initial_modules = list(
 		/obj/item/rig_module/teleporter,

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -7099,6 +7099,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/item/rig/light/ninja,
 /turf/simulated/floor/tiled/dark,
 /area/ship/trade/command/bridge)
 "YN" = (


### PR DESCRIPTION
## Description of changes

**A new, more convenient and simply beautiful radial menu for rig**

## Why and what will this PR improve

Now, in order to use the capabilities of the modular suit, you do not need to open a bulky menu.

**WIP**

![ezgif com-gif-maker](https://user-images.githubusercontent.com/87154286/171277484-e4ad883b-23b2-4ee0-bb3d-cdde1d78953c.gif)


## Authorship
@keIgaras 

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
rscadd: new radial menu for rig
/:cl:



