### PR TITLE
Fix tooltips being drawn offscreen.

### DIFF
--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -65,12 +65,12 @@
 
 		.hisgrace .wrap {border-color: #7C1414;}
 		.hisgrace .content {color: #15D512; border-color: #9D1414; background-color: #861414;}
-	
+
 		/* TG: Themes */
 		/* ScreenUI */
 		.midnight .wrap {border-color: #2B2B33;}
 		.midnight .content {color: #6087A0; border-color: #2B2B33; background-color: #36363C;}
-		
+
 		.plasmafire .wrap {border-color: #21213D;}
 		.plasmafire .content {color: #FFA800 ; border-color: #21213D; background-color:#1D1D36;}
 
@@ -85,7 +85,7 @@
 
 		.clockwork .wrap {border-color: #170800;}
 		.clockwork .content {color: #B18B25; border-color: #000000; background-color: #5F380E;}
-		
+
 
 	</style>
 </head>
@@ -122,14 +122,15 @@
 				//Get the real icon size according to the client view
 				var mapWidth 		= map['view-size'].x,
 					mapHeight 		= map['view-size'].y,
-					tilesShown 		= tooltip.client_view_w
-					realIconSize 	= mapWidth / tilesShown,
-					resizeRatio		= realIconSize / tooltip.tileSize,
-					//Calculate letterboxing offsets	
+					tilesShownX 	= tooltip.client_view_w
+					tilesShownY 	= tooltip.client_view_h
+					realIconSizeX 	= mapWidth / tilesShownX,
+					realIconSizeY 	= mapHeight / tilesShownY,
+					resizeRatioX	= realIconSizeX / tooltip.tileSize,
+					resizeRatioY	= realIconSizeY / tooltip.tileSize,
+					//Calculate letterboxing offsets
 					leftOffset 		= (map.size.x - mapWidth) / 2,
 					topOffset 		= (map.size.y - mapHeight) / 2;
-
-				//alert(realIconSize + ' | ' +tooltip.tileSize + ' | ' + resizeRatio); //DEBUG
 
 				//Parse out the tile and cursor locations from params (e.g. "icon-x=32;icon-y=29;screen-loc=3:10,15:29")
 				var paramsA = tooltip.params.cursor.split(';');
@@ -168,7 +169,7 @@
 						if ((iconX + westOffset) !== enteredX) { //Cursor entered on the offset tile
 							left = left + (westOffset < 0 ? 1 : -1);
 						}
-						leftOffset = leftOffset + (westOffset * resizeRatio);
+						leftOffset = leftOffset + (westOffset * resizeRatioX);
 					}
 				}
 
@@ -179,13 +180,13 @@
 						if (northOffset !== 0) {
 							if ((iconY + northOffset) === enteredY) { //Cursor entered on the original tile
 								top--;
-								topOffset = topOffset - ((tooltip.tileSize + northOffset) * resizeRatio);
+								topOffset = topOffset - ((tooltip.tileSize + northOffset) * resizeRatioY);
 							} else { //Cursor entered on the offset tile
 								if (northOffset < 0) { //Offset southwards
-									topOffset = topOffset - ((tooltip.tileSize + northOffset) * resizeRatio);
+									topOffset = topOffset - ((tooltip.tileSize + northOffset) * resizeRatioY);
 								} else { //Offset northwards
 									top--;
-									topOffset = topOffset - (northOffset * resizeRatio);
+									topOffset = topOffset - (northOffset * resizeRatioY);
 								}
 							}
 						}
@@ -198,14 +199,12 @@
 				}
 
 				//Clamp values
-				left = (left < 0 ? 0 : (left > tilesShown ? tilesShown : left));
-				top = (top < 0 ? 0 : (top > tilesShown ? tilesShown : top));
+				left = (left < 0 ? 0 : (left > tilesShownX ? tilesShownX : left));
+				top = (top < 0 ? 0 : (top > tilesShownY ? tilesShownY : top));
 
 				//Calculate where on the screen the popup should appear (below the hovered tile)
-				var posX = Math.round(((left - 1) * realIconSize) + leftOffset + tooltip.padding); //-1 to position at the left of the target tile
-				var posY = Math.round(((tilesShown - top + 1) * realIconSize) + topOffset + tooltip.padding); //+1 to position at the bottom of the target tile
-
-				//alert(mapWidth+' | '+mapHeight+' | '+tilesShown+' | '+realIconSize+' | '+leftOffset+' | '+topOffset+' | '+left+' | '+top+' | '+posX+' | '+posY); //DEBUG
+				var posX = Math.round(((left - 1) * realIconSizeX) + leftOffset + tooltip.padding); //-1 to position at the left of the target tile
+				var posY = Math.round(((tilesShownY - top + 1) * realIconSizeY) + topOffset + tooltip.padding); //+1 to position at the bottom of the target tile
 
 				$('body').attr('class', tooltip.theme);
 
@@ -221,7 +220,7 @@
 					docHeight	= $wrap.outerHeight();
 
 				if (posY + docHeight > map.size.y) { //Is the bottom edge below the window? Snap it up if so
-					posY = (posY - docHeight) - realIconSize - tooltip.padding;
+					posY = (posY - docHeight) - realIconSizeY - tooltip.padding;
 				}
 
 				//Actually size, move and show the tooltip box
@@ -231,11 +230,11 @@
 					tooltip.hide();
 				});
 			},
-			update: function(params, client_vw , clien_vh , text, theme, special) {
+			update: function(params, client_vw, client_vh, text, theme, special) {
 				//Assign our global object
 				tooltip.params = $.parseJSON(params);
 				tooltip.client_view_w = parseInt(client_vw);
-				tooltip.client_view_h = parseInt(clien_vh);
+				tooltip.client_view_h = parseInt(client_vh);
 				tooltip.text = text;
 				tooltip.theme = theme;
 				tooltip.special = special;


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Tooltips now properly take into account differing X and Y view sizes.
- [x] Tested
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
Tooltips were formerly drawn offscreen.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Goonstation and TGstation, taken from the following commit: https://github.com/tgstation/tgstation/commit/1614501d23e55c212a5a3db16f67b0c886c427ef
<!-- Describe original authors of changes to credit them. -->

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
bugfix: Tooltips are now drawn properly.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
