### PR TITLE
Makes dmm reader use ChangeArea

### DIFF
--- a/code/modules/maps/reader.dm
+++ b/code/modules/maps/reader.dm
@@ -338,7 +338,7 @@ var/global/dmm_suite/preloader/_preloader = new
 			instance = new atype(null)
 			initialized_areas_by_type[atype] = instance
 		if(crds)
-			instance.contents.Add(crds)
+			ChangeArea(crds, instance)
 
 	//then instance the /turf and, if multiple tiles are presents, simulates the DMM underlays piling effect
 


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

dmm suite changes the area of turfs being loaded over (some of the time). When it does, it changes area directly without firing any of the listeners currently located in ChangeArea (and is, I believe, the only remaining thing which does this).

ChangeArea doesn't really do anything itself, it just fires a lot of listeners and hooks. This might have secondary effects, but it's unclear what if any. It does come at some cost.

## Why and what will this PR improve

Power machines require perfectly accurate notification of area changes. In this case, loading one template over another in a way which changes area breaks power tracking. This is really uncommon; almost nothing does this by default apart from a weird edge case with exoplanent ruins and artifact finds. It's possible to do with adminbus, though.

## Authorship

me
