### PR TITLE
Replace AI radio announcer with unsimulated mob; Fix #2463

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -156,7 +156,6 @@
 	var/mob/occupant = null       // Person waiting to be despawned.
 	var/time_till_despawn = 9000  // Down to 15 minutes //30 minutes-ish is too long
 	var/time_entered = 0          // Used to keep track of the safe period.
-	var/obj/item/radio/intercom/announce //
 
 	var/obj/machinery/computer/cryopod/control_computer
 	var/last_no_computer_message = 0
@@ -262,7 +261,6 @@
 
 /obj/machinery/cryopod/Initialize()
 	. = ..()
-	announce = new /obj/item/radio/intercom(src)
 	find_control_computer()
 
 /obj/machinery/cryopod/proc/find_control_computer()
@@ -329,7 +327,7 @@
 
 	qdel(R.mmi)
 	for(var/obj/item/I in R.module) // the tools the borg has; metal, glass, guns etc
-		for(var/obj/item/O in I) // the things inside the tools, if anything; mainly for janiborg trash bags
+		for(var/obj/item/O in I.get_contained_external_atoms()) // the things inside the tools, if anything; mainly for janiborg trash bags
 			O.forceMove(R)
 		qdel(I)
 	qdel(R.module)
@@ -340,20 +338,19 @@
 // Also make sure there is a valid control computer
 /obj/machinery/cryopod/proc/despawn_occupant()
 	//Drop all items into the pod.
-	for(var/obj/item/W in occupant)
+	for(var/obj/item/W in occupant.get_equipped_items(include_carried = TRUE))
 		occupant.drop_from_inventory(W)
 		W.forceMove(src)
 
-		if(W.contents.len) //Make sure we catch anything not handled by qdel() on the items.
-			for(var/obj/item/O in W.contents)
-				if(istype(O,/obj/item/storage/internal)) //Stop eating pockets, you fuck!
-					continue
-				O.forceMove(src)
+		//Make sure we catch anything not handled by qdel() on the items.
+		for(var/obj/item/O in W.get_contained_external_atoms())
+			if(istype(O,/obj/item/storage/internal)) //Stop eating pockets, you fuck!
+				continue
+			O.forceMove(src)
 
 	//Delete all items not on the preservation list.
 	var/list/items = src.contents.Copy()
 	items -= occupant // Don't delete the occupant
-	items -= announce // or the autosay radio.
 	items -= component_parts
 
 	for(var/obj/item/W in items)
@@ -379,7 +376,7 @@
 				control_computer.frozen_items += W
 				W.forceMove(null)
 			else
-				W.forceMove(src.loc)
+				W.forceMove(get_turf(src))
 
 	//Update any existing objectives involving this mob.
 	for(var/datum/objective/O in global.all_objectives)
@@ -422,8 +419,8 @@
 		control_computer._admin_logs += "[key_name(occupant)] ([role_alt_title]) at [stationtime2text()]"
 	log_and_message_admins("[key_name(occupant)] ([role_alt_title]) entered cryostorage.")
 
-	announce.autosay("[occupant.real_name], [role_alt_title], [on_store_message]", "[on_store_name]")
-	visible_message("<span class='notice'>\The [initial(name)] hums and hisses as it moves [occupant.real_name] into storage.</span>", range = 3)
+	var/obj/item/radio/announcer = get_global_announcer()
+	announcer.autosay("[occupant.real_name], [role_alt_title], [on_store_message]", "[on_store_name]")
 
 	//This should guarantee that ghosts don't spawn.
 	occupant.ckey = null
@@ -493,7 +490,6 @@
 	//Eject any items that aren't meant to be in the pod.
 	var/list/items = contents - component_parts
 	if(occupant) items -= occupant
-	if(announce) items -= announce
 
 	for(var/obj/item/W in items)
 		W.dropInto(loc)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -229,6 +229,9 @@
 	if(.)
 		SSnano.update_uis(src)
 
+/mob/announcer // used only for autosay
+	simulated = FALSE
+
 /obj/item/radio/proc/autosay(var/message, var/from, var/channel, var/sayverb = "states") //BS12 EDIT
 	var/datum/radio_frequency/connection = null
 	if(channel && channels && channels.len > 0)
@@ -240,7 +243,7 @@
 		channel = null
 	if (!istype(connection))
 		return
-	var/mob/living/silicon/ai/A = new /mob/living/silicon/ai(src, null, null, 1)
+	var/mob/announcer/A = new()
 	A.fully_replace_character_name(from)
 	talk_into(A, message, channel, sayverb)
 	qdel(A)
@@ -344,7 +347,7 @@
 		jobname = "No id"
 
 	// --- AI ---
-	else if (isAI(M))
+	else if (isAI(M) || istype(M, /mob/announcer))
 		jobname = ASSIGNMENT_COMPUTER
 
 	// --- Cyborg ---
@@ -818,7 +821,7 @@
 
 /obj/item/radio/phone/medbay
 	frequency = MED_I_FREQ
-	
+
 /obj/item/radio/phone/medbay/Initialize()
 	. = ..()
 	internal_channels = global.default_medbay_channels.Copy()

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -60,6 +60,8 @@
 	if(!speaking)
 		if(istype(other, /mob/living/silicon))
 			return TRUE
+		if(istype(other, /mob/announcer))
+			return TRUE
 		if(istype(other, /mob/living/carbon/brain))
 			return TRUE
 	return ..()


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Replaces the silicon-based radio announcer with an unsimulated mob announcer, to prevent weirdness.
Also some misc. cryopod tweaks while I was in the area.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
No more 50kW power spikes!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Me.
<!-- Describe original authors of changes to credit them. -->