### PR TITLE
Let the tool interactions properly play the defined tool sounds

### DIFF
--- a/code/modules/tools/tool_extension.dm
+++ b/code/modules/tools/tool_extension.dm
@@ -59,6 +59,8 @@
 			use_sound = pick(use_sound)
 		else 
 			use_sound = null
+	if(use_sound)
+		playsound(user.loc, use_sound, 100)
 
 	if(!do_after(user, max(5, CEILING(delay * get_tool_speed(archetype))), holder))
 		return TOOL_USE_FAILURE_NOMESSAGE

--- a/code/modules/tools/tool_extension.dm
+++ b/code/modules/tools/tool_extension.dm
@@ -51,10 +51,14 @@
 
 	user.visible_message(SPAN_NOTICE("\The [user] begins [start_message || tool_archetype.use_message] \the [target] with \the [holder]."), SPAN_NOTICE("You begin [start_message || tool_archetype.use_message] \the [target] with \the [holder]."))
 	var/use_sound = LAZYACCESS(tool_use_sounds, archetype)
-	if(islist(use_sound) && length(use_sound))
-		use_sound = pick(use_sound)
-	if(use_sound)
-		playsound(user.loc, use_sound, 100)
+	 //If no sound overrides, grab the archetype's sound/sound list
+	if(!use_sound) 
+		use_sound = tool_archetype.use_sound
+	if(islist(use_sound))
+		if(length(use_sound))
+			use_sound = pick(use_sound)
+		else 
+			use_sound = null
 
 	if(!do_after(user, max(5, CEILING(delay * get_tool_speed(archetype))), holder))
 		return TOOL_USE_FAILURE_NOMESSAGE


### PR DESCRIPTION
## Description of changes
The tool extension would completely ignore the use_sound defined in the tool archetypes and instead just grab the overrides. Changed that so if there's no overrides it grabs the sound from the archetype. 

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
bugfix: Fixed how some tool interactions wouldn't play tool sounds.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
