### PR TITLE
June 5, 2022 Bugfixes

### DIFF
--- a/code/datums/extensions/assembly/assembly.dm
+++ b/code/datums/extensions/assembly/assembly.dm
@@ -52,7 +52,7 @@
 	else
 		var/atom/movable/H = holder
 		P.dropInto(H.loc)
-	if(P.type in critical_parts)
+	if(enabled && (P.type in critical_parts))
 		critical_shutdown()
 
 /datum/extension/assembly/proc/add_replace_component(var/mob/living/user, var/part_type, var/obj/item/stock_parts/P)

--- a/code/datums/observation/~cleanup.dm
+++ b/code/datums/observation/~cleanup.dm
@@ -44,7 +44,7 @@ var/global/list/event_listen_count = list()
 	for(var/entry in global.all_observable_events)
 		var/decl/observ/event = entry
 		if(event.unregister_global(listener))
-			log_debug("[event] - [listener] was deleted while still registered to global events.")
+			log_debug("[event] ([event.type]) - [log_info_line(listener)] was deleted while still registered to global events.")
 			if(!(--listen_count))
 				return
 
@@ -56,7 +56,7 @@ var/global/list/event_listen_count = list()
 		if(proc_owners)
 			for(var/proc_owner in proc_owners)
 				if(event.unregister(event_source, proc_owner))
-					log_debug("[event] - [event_source] was deleted while still being listened to by [proc_owner].")
+					log_debug("[event] ([event.type]) - [log_info_line(event_source)] was deleted while still being listened to by [log_info_line(proc_owner)].")
 					if(!(--source_listener_count))
 						return
 
@@ -66,6 +66,6 @@ var/global/list/event_listen_count = list()
 		var/decl/observ/event = entry
 		for(var/event_source in event.event_sources)
 			if(event.unregister(event_source, listener))
-				log_debug("[event] - [listener] was deleted while still listening to [event_source].")
+				log_debug("[event] ([event.type]) - [log_info_line(listener)] was deleted while still listening to [log_info_line(event_source)].")
 				if(!(--listener_count))
 					return

--- a/code/datums/sound_player.dm
+++ b/code/datums/sound_player.dm
@@ -80,7 +80,7 @@
 */
 /datum/sound_token
 	var/atom/source    // Where the sound originates from
-	var/list/listeners // Assoc: Atoms hearing this sound, and their sound datum
+	var/list/listeners // Atoms hearing this sound
 	var/range          // How many turfs away the sound will stop playing completely
 	var/prefer_mute    // If sound should be muted instead of stopped when mob moves out of range. In the general case this should be avoided because listeners will remain tracked.
 	var/sound/sound    // Sound datum, holds most sound relevant data
@@ -204,7 +204,7 @@
 	PrivUpdateListeners()
 
 /datum/sound_token/proc/PrivAddListener(var/atom/listener)
-	if(!check_preference(listener))
+	if(QDELETED(listener) || !check_preference(listener))
 		return
 
 	if(isvirtualmob(listener))
@@ -259,8 +259,8 @@
 	for(var/listener in listeners)
 		PrivUpdateListener(listener)
 
-/datum/sound_token/proc/PrivUpdateListener(var/listener, var/update_sound = TRUE)
-	if(!check_preference(listener))
+/datum/sound_token/proc/PrivUpdateListener(var/atom/listener, var/update_sound = TRUE)
+	if(QDELETED(listener) || !check_preference(listener))
 		PrivRemoveListener(listener)
 		return
 
@@ -271,7 +271,7 @@
 		sound.status |= SOUND_UPDATE
 	sound_to(listener, sound)
 
-/datum/sound_token/proc/PrivGetEnvironment(var/listener)
+/datum/sound_token/proc/PrivGetEnvironment(var/atom/listener)
 	var/area/A = get_area(listener)
 	return A && PrivIsValidEnvironment(A.sound_env) ? A.sound_env : sound.environment
 

--- a/code/game/gamemodes/objectives/_objective.dm
+++ b/code/game/gamemodes/objectives/_objective.dm
@@ -14,6 +14,8 @@ var/global/list/all_objectives = list()
 
 /datum/objective/Destroy()
 	global.all_objectives -= src
+	owner = null
+	target = null
 	. = ..()
 
 /datum/objective/proc/find_target()

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -128,7 +128,7 @@
 	. = ..()
 
 /obj/machinery/alarm/Destroy()
-	events_repository.unregister(/decl/observ/name_set, src, get_area(src), .proc/change_area_name)
+	events_repository.unregister(/decl/observ/name_set, get_area(src), src, .proc/change_area_name)
 	unregister_radio(src, frequency)
 	return ..()
 

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -141,10 +141,11 @@
 			LAZYREMOVE(organ.implants, src)
 		M.drop_from_inventory(src)
 
+	// TODO: CONVERT TO USE OBSERVATIONS
 	var/obj/item/storage/storage = loc
 	if(istype(storage))
 		// some ui cleanup needs to be done
-		storage.on_item_pre_deletion(src) // must be done before deletion
+		storage.on_item_pre_deletion(src) // must be done before deletion // TODO: ADD PRE_DELETION OBSERVATION
 		. = ..()
 		storage.on_item_post_deletion(src) // must be done after deletion
 	else

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -131,6 +131,7 @@
 
 	STOP_PROCESSING(SSobj, src)
 	QDEL_NULL(hidden_uplink)
+	QDEL_NULL(coating)
 
 	if(ismob(loc))
 		var/mob/M = loc

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -18,6 +18,11 @@
 	. = ..()
 	create_reagents(1000)
 
+/obj/item/grenade/chem_grenade/Destroy()
+	QDEL_NULL(detonator)
+	QDEL_NULL_LIST(beakers)
+	. = ..()
+
 /obj/item/grenade/chem_grenade/attack_self(mob/user)
 	if(!stage || stage==1)
 		if(detonator)
@@ -112,7 +117,7 @@
 	update_icon()
 
 /obj/item/grenade/chem_grenade/activate(mob/user)
-	if(active) 
+	if(active)
 		return
 	if(detonator)
 		if(!isigniter(detonator.a_left))
@@ -127,12 +132,12 @@
 
 /obj/item/grenade/chem_grenade/detonate()
 	set waitfor = 0
-	if(!stage || stage < 2) 
+	if(!stage || stage < 2)
 		return
 
 	var/has_reagents = 0
 	for(var/obj/item/chems/glass/G in beakers)
-		if(G.reagents.total_volume) 
+		if(G.reagents.total_volume)
 			has_reagents = TRUE
 			break
 
@@ -162,7 +167,7 @@
 	set_invisibility(INVISIBILITY_MAXIMUM)
 
 	// Visual effect to show the grenade going off.
-	if(reagents.total_volume) 
+	if(reagents.total_volume)
 		var/datum/effect/effect/system/steam_spread/steam = new
 		steam.set_up(10, 0, get_turf(src))
 		steam.attach(src)

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -120,6 +120,8 @@
 		if(liquid_temporary)
 			liquid_temporary.trans_to(loc, liquid_temporary.total_volume)
 			liquid_temporary = null
+	if(leaking)
+		STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 	. = ..()
 
 /obj/machinery/atmospherics/pipe/deconstruction_pressure_check()

--- a/code/modules/augment/active/cyberbrain.dm
+++ b/code/modules/augment/active/cyberbrain.dm
@@ -27,8 +27,14 @@
 	set_extension(src, /datum/extension/assembly/modular_computer/cyberbrain)
 
 	update_icon()
-	
+
 	install_default_hardware()
+
+/obj/item/organ/internal/augment/active/cyberbrain/get_contained_external_atoms()
+	. = ..()
+	var/datum/extension/assembly/assembly = get_extension(src, /datum/extension/assembly)
+	if(assembly)
+		LAZYREMOVE(., assembly.parts)
 
 // Used to perform preset-specific hardware changes.
 /obj/item/organ/internal/augment/active/cyberbrain/proc/install_default_hardware()

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -1,3 +1,9 @@
+/obj/item/modular_computer/get_contained_external_atoms()
+	. = ..()
+	var/datum/extension/assembly/assembly = get_extension(src, /datum/extension/assembly)
+	if(assembly)
+		LAZYREMOVE(., assembly.parts)
+
 /obj/item/modular_computer/Process()
 	var/datum/extension/assembly/assembly = get_extension(src, /datum/extension/assembly)
 	if(assembly)

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -67,7 +67,7 @@
 	install_default_programs()
 
 /obj/item/modular_computer/Destroy()
-	QDEL_NULL_LIST(terminals)
+	shutdown_computer(loud = FALSE)
 	STOP_PROCESSING(SSobj, src)
 	if(istype(stored_pen))
 		QDEL_NULL(stored_pen)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
- Fix incorrect comments, argument definitions, and missing qdeleted checks in sound_tokens
- Add additional debugging info for events that aren't cleaned up properly
- PDAs will no longer give a critical shutdown message when equipped on a character that goes to cryo, because assemblies now shut down properly (and quietly) on destroy instead of remaining online.
- Offline assemblies can no longer have critical shutdowns.
- Adds several get_contained_external_atom overrides to fix things like cryo pulling internal components out of assemblies. (This *also* fixes the PDA cryo issue, I'm pretty sure.)
- Fix hanging refs to detonators and beakers on chem grenades.
- Fix hanging refs to owner/target on objectives.
- Fix improperly ordered arguments to event_repository.unregister in air alarms.
- Fix coating preventing items from GCing.
- Fix leaking pipes continuing to process after GC.
- Add some notes via comment on future refactors.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
Bugfix roundup!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Me, on Hearth of Hestia several months ago.
<!-- Describe original authors of changes to credit them. -->