### PR TITLE
Fix network power cycle race conditions

### DIFF
--- a/code/modules/modular_computers/networking/device_types/relay.dm
+++ b/code/modules/modular_computers/networking/device_types/relay.dm
@@ -1,7 +1,6 @@
 /datum/extension/network_device/broadcaster/relay
 	connection_type = NETWORK_CONNECTION_STRONG_WIRELESS
 	expected_type = /obj/machinery
-	var/reconnect_time
 
 /datum/extension/network_device/broadcaster/relay/get_nearby_networks()
 	if(long_range)
@@ -22,22 +21,7 @@
 		return FALSE
 	if(!long_range && !(network_id in get_nearby_networks()))
 		return FALSE
-	. = net.add_device(src)
-	if(.)	
-		reconnect_time = null
+	return net.add_device(src)
 
-/datum/extension/network_device/broadcaster/relay/disconnect(net_down)
-	. = ..()
-	// Router went down, we should try to hook back up when it's up
-	if(net_down)
-		reconnect_time = world.time + 30 SECONDS
-		START_PROCESSING(SSprocessing, src)
-
-/datum/extension/network_device/broadcaster/relay/Process()
-	if(world.time > reconnect_time)
-		if(connect())
-			return PROCESS_KILL
-		reconnect_time = world.time + 30 SECONDS
-	
 /datum/extension/network_device/broadcaster/relay/long_range
 	long_range = TRUE

--- a/code/modules/modular_computers/networking/device_types/router.dm
+++ b/code/modules/modular_computers/networking/device_types/router.dm
@@ -6,6 +6,12 @@
 	..()
 	broadcast()
 
+/datum/extension/network_device/broadcaster/router/connect()
+	. = ..()
+	if(!.)
+		broadcast()
+		return TRUE
+
 /datum/extension/network_device/broadcaster/router/proc/broadcast()
 	var/datum/computer_network/net = SSnetworking.networks[network_id]
 	if(!net)

--- a/code/modules/modular_computers/networking/machinery/_network_machine.dm
+++ b/code/modules/modular_computers/networking/machinery/_network_machine.dm
@@ -36,7 +36,7 @@
 /obj/machinery/network/on_update_icon()
 	icon_state = initial(icon_state)
 	if(panel_open)
-		icon_state = "[icon_state]_o" 
+		icon_state = "[icon_state]_o"
 	if(!operable())
 		icon_state = "[icon_state]_off"
 
@@ -116,7 +116,10 @@
 	if(!D)
 		return
 	if(operable())
-		D.connect()
+		if (D.connect())
+			return
+		else
+			SSnetworking.queue_connection(D)
 	else
 		D.disconnect()
 

--- a/code/modules/modular_computers/networking/machinery/relay.dm
+++ b/code/modules/modular_computers/networking/machinery/relay.dm
@@ -16,7 +16,6 @@
 	if(!istype(R))
 		return data
 	data["wifi"] = R.allow_wifi
-	data["reconnect"] = R.reconnect_time && round((R.reconnect_time - world.time)/10)
 	return data
 
 /obj/machinery/network/relay/OnTopic(mob/user, href_list, datum/topic_state/state)
@@ -24,11 +23,6 @@
 		var/datum/extension/network_device/broadcaster/relay/R = get_extension(src, /datum/extension/network_device)
 		if(R)
 			R.allow_wifi = !R.allow_wifi
-			return TOPIC_REFRESH
-	if(href_list["reconnect"])
-		var/datum/extension/network_device/broadcaster/relay/R = get_extension(src, /datum/extension/network_device)
-		if(R)
-			R.connect()
 			return TOPIC_REFRESH
 	. = ..()
 

--- a/nano/templates/network_router.tmpl
+++ b/nano/templates/network_router.tmpl
@@ -30,14 +30,6 @@
 			BACKUP ROUTER / RELAY
 		</div>
 	{{/if}}
-	{{if data.reconnect}}
-		<div class="item">
-			<span class="bad">CONNECTION LOST, ATTEMPTING RECONNECT IN {{:data.reconnect}}s</span>
-		</div>
-		<div class="item">
-			{{:helper.link("RECONNECT NOW", null, { "reconnect" : 1 })}}
-		</div>
-	{{/if}}
 	<div class="itemLabel">
 		Wi-Fi Connections:
 	</div>
@@ -49,4 +41,4 @@
 	</div>
 	<hr>
 	<i>EXONET Firmware v110.04.4h Copyright EXONETWORKS INC</i>
-{{/if}} 
+{{/if}}


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Routers will now broadcast when they try to connect to a nonexistent network.
Other machines will instead queue their connection.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
No more power cycle race conditions, which means #733 has one less blocking issue.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Me.
<!-- Describe original authors of changes to credit them. -->

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl: Noelle Lavenza
bugfix: Network devices now work after you turn them off and back on again.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
