### PR TITLE
Fix #2004; network tweaks

### DIFF
--- a/code/modules/modular_computers/networking/device_types/relay.dm
+++ b/code/modules/modular_computers/networking/device_types/relay.dm
@@ -1,7 +1,6 @@
 /datum/extension/network_device/broadcaster/relay
 	connection_type = NETWORK_CONNECTION_STRONG_WIRELESS
 	expected_type = /obj/machinery
-	var/reconnect_time
 
 /datum/extension/network_device/broadcaster/relay/get_nearby_networks()
 	if(long_range)
@@ -22,22 +21,7 @@
 		return FALSE
 	if(!long_range && !(network_id in get_nearby_networks()))
 		return FALSE
-	. = net.add_device(src)
-	if(.)	
-		reconnect_time = null
+	return net.add_device(src)
 
-/datum/extension/network_device/broadcaster/relay/disconnect(net_down)
-	. = ..()
-	// Router went down, we should try to hook back up when it's up
-	if(net_down)
-		reconnect_time = world.time + 30 SECONDS
-		START_PROCESSING(SSprocessing, src)
-
-/datum/extension/network_device/broadcaster/relay/Process()
-	if(world.time > reconnect_time)
-		if(connect())
-			return PROCESS_KILL
-		reconnect_time = world.time + 30 SECONDS
-	
 /datum/extension/network_device/broadcaster/relay/long_range
 	long_range = TRUE

--- a/code/modules/modular_computers/networking/device_types/router.dm
+++ b/code/modules/modular_computers/networking/device_types/router.dm
@@ -12,6 +12,7 @@
 		net = new(network_id)
 	if(!net.router)
 		net.set_router(src)
+		SSnetworking.process_reconnections(network_id)
 
 /datum/extension/network_device/broadcaster/router/proc/is_router()
 	var/datum/computer_network/net = SSnetworking.networks[network_id]

--- a/code/modules/modular_computers/networking/machinery/_network_machine.dm
+++ b/code/modules/modular_computers/networking/machinery/_network_machine.dm
@@ -36,7 +36,7 @@
 /obj/machinery/network/on_update_icon()
 	icon_state = initial(icon_state)
 	if(panel_open)
-		icon_state = "[icon_state]_o" 
+		icon_state = "[icon_state]_o"
 	if(!operable())
 		icon_state = "[icon_state]_off"
 
@@ -116,7 +116,7 @@
 	if(!D)
 		return
 	if(operable())
-		D.connect()
+		SSnetworking.queue_connection(D) // must queue, due to router race conditions
 	else
 		D.disconnect()
 

--- a/code/modules/modular_computers/networking/machinery/relay.dm
+++ b/code/modules/modular_computers/networking/machinery/relay.dm
@@ -16,7 +16,6 @@
 	if(!istype(R))
 		return data
 	data["wifi"] = R.allow_wifi
-	data["reconnect"] = R.reconnect_time && round((R.reconnect_time - world.time)/10)
 	return data
 
 /obj/machinery/network/relay/OnTopic(mob/user, href_list, datum/topic_state/state)
@@ -24,11 +23,6 @@
 		var/datum/extension/network_device/broadcaster/relay/R = get_extension(src, /datum/extension/network_device)
 		if(R)
 			R.allow_wifi = !R.allow_wifi
-			return TOPIC_REFRESH
-	if(href_list["reconnect"])
-		var/datum/extension/network_device/broadcaster/relay/R = get_extension(src, /datum/extension/network_device)
-		if(R)
-			R.connect()
 			return TOPIC_REFRESH
 	. = ..()
 

--- a/nano/templates/network_router.tmpl
+++ b/nano/templates/network_router.tmpl
@@ -30,14 +30,6 @@
 			BACKUP ROUTER / RELAY
 		</div>
 	{{/if}}
-	{{if data.reconnect}}
-		<div class="item">
-			<span class="bad">CONNECTION LOST, ATTEMPTING RECONNECT IN {{:data.reconnect}}s</span>
-		</div>
-		<div class="item">
-			{{:helper.link("RECONNECT NOW", null, { "reconnect" : 1 })}}
-		</div>
-	{{/if}}
 	<div class="itemLabel">
 		Wi-Fi Connections:
 	</div>
@@ -49,4 +41,4 @@
 	</div>
 	<hr>
 	<i>EXONET Firmware v110.04.4h Copyright EXONETWORKS INC</i>
-{{/if}} 
+{{/if}}


### PR DESCRIPTION
## Description of changes
- Routers will now broadcast when they try to connect to a nonexistent network.
- Network machines will queue for connection when repowered, to avoid race conditions if they're activated prior to their router.
- When a network goes down, devices formerly on it will queue for reconnection when a network with the same ID goes back up. This replaces, and is a generalised version of, the relay-specific fix used in #2288.
    - I didn't go with the deep-sim option of repeatedly trying to reconnect every X seconds because of the overhead of thousands of devices processing repeatedly until the network comes back online. I think the performance gains here outweigh the loss of 'realism'. If you want it to feel more 'realistic', I could add a random delay/timer to the reconnection process, but creating thousands of timers isn't great either (though I suppose I could put the delay on the queue processing instead).
- `add_device` is no longer called by devices outside of `connect()` **You will break things if a device calls `add_device` directly.**
- Routers now use `add_device` properly and are added to `devices_by_tags`.
- `device.check_connection` and `device.get_signal_strength` now take into account whether or not the device is actually connected. `network.check_connection(device)` does not, so it can be used when determining if a device is *able to* connect.

## Why and what will this PR improve
No more power cycle race conditions, which means #733 has one less blocking issue.
Also, there's just more consistency in the network connection, disconnection, shutdown, and reconnection processes.

## Authorship
Me.

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl: Noelle Lavenza
bugfix: Network devices now work after you turn them off and back on again.
/:cl: