### PR TITLE
Moved examine alt interaction to /atom/movable.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -596,6 +596,3 @@ its easier to just keep the beam vertical.
 
 /atom/proc/get_alt_interactions(var/mob/user)
 	SHOULD_CALL_PARENT(TRUE)
-	. = list()
-	if(config.expanded_alt_interactions)
-		. += /decl/interaction_handler/look

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -497,3 +497,4 @@
 	. = ..()
 	if(config.expanded_alt_interactions)
 		. += /decl/interaction_handler/grab
+		. += /decl/interaction_handler/look


### PR DESCRIPTION
`Fixes` alt-click not working on turfs to show contents.