### PR TITLE
Tool interactions now support skill checks.

### DIFF
--- a/code/modules/mob/skills/skillset.dm
+++ b/code/modules/mob/skills/skillset.dm
@@ -118,8 +118,8 @@ var/global/list/all_skill_verbs
 		else
 			return max(0, 1 + (SKILL_DEFAULT - points) * factor)
 
-/mob/proc/do_skilled(base_delay, skill_path , atom/target = null, factor = 0.3)
-	return do_after(src, base_delay * skill_delay_mult(skill_path, factor), target)
+/mob/proc/do_skilled(base_delay, skill_path , atom/target = null, factor = 0.3, check_holding = FALSE)
+	return do_after(src, base_delay * skill_delay_mult(skill_path, factor), target, check_holding)
 
 // A generic way of modifying success probabilities via skill values. Higher factor means skills have more effect. fail_chance is the chance at SKILL_NONE.
 /mob/proc/skill_fail_chance(skill_path, fail_chance, no_more_fail = SKILL_MAX, factor = 1)

--- a/code/modules/tools/tool_item.dm
+++ b/code/modules/tools/tool_item.dm
@@ -6,15 +6,15 @@
 	var/datum/extension/tool/tool = get_extension(src, /datum/extension/tool)
 	. = tool?.get_tool_speed(archetype)
 
-/obj/item/proc/do_tool_interaction(var/archetype, var/mob/user, var/atom/target, var/delay = (1 SECOND), var/start_message, var/success_message, var/failure_message, var/fuel_expenditure = 0)
+/obj/item/proc/do_tool_interaction(var/archetype, var/mob/user, var/atom/target, var/delay = (1 SECOND), var/start_message, var/success_message, var/failure_message, var/fuel_expenditure = 0, var/check_skill = SKILL_CONSTRUCTION, var/check_skill_threshold, var/check_skill_prob = 50)
 
 	if(get_tool_quality(archetype) <= 0)
 		return FALSE
 
 	var/datum/extension/tool/tool = get_extension(src, /datum/extension/tool)
-	. = tool.do_tool_interaction(archetype, user, target, delay, fuel_expenditure, start_message)
+	. = tool.do_tool_interaction(archetype, user, target, delay, start_message, success_message, failure_message, fuel_expenditure, check_skill, check_skill_threshold, check_skill_prob)
 
-	if(QDELETED(user))
+	if(QDELETED(user) || QDELETED(target))
 		return FALSE
 
 	if(. == TOOL_USE_SUCCESS)


### PR DESCRIPTION
## Description of changes
You can now supply a failure chance, skill type, and threshold to `do_tool_interaction()`.
Tool interactions will now be instant with a delay of 0.
Tool interaction arguments have been standardized.

## Why and what will this PR improve
Allows for more skill integration and improves some existing code.

## Authorship
Myself.

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
tweak: Construction skill will now speed up some tool interactions.
/:cl: