### PR TITLE
Fix dynamic lights on ambiently-lit turfs

### DIFF
--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -39,7 +39,7 @@
 		ambient_b = (HEX_BLUE(ambient_light) / 255) * ambient_light_multiplier
 
 	if (!corners || (null in corners))
-		generate_missing_corners()
+		lighting_build_overlay()
 
 	for (var/thing in corners)
 		var/datum/lighting_corner/C = thing


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Fix dynamic lights on ambiently-lit turfs by calling lighting_build_overlay instead of generate_missing_corners; this still calls that eventually, but also does important other steps too, like setting the corners to active.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
Flashlights not working on exoplanets at night was... pretty weird.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
<!-- Describe original authors of changes to credit them. -->

## Changelog
:cl: Noelle Lavenza
bugfix: Dynamic lights now work on ambiently-lit turfs.
/:cl: