### PR TITLE
Ambient lights v2

### DIFF
--- a/code/controllers/subsystems/lighting.dm
+++ b/code/controllers/subsystems/lighting.dm
@@ -7,6 +7,7 @@ SUBSYSTEM_DEF(lighting)
 
 	var/total_lighting_overlays = 0
 	var/total_lighting_sources = 0
+	var/total_ambient_turfs = 0
 	var/list/lighting_corners = list()	// List of all lighting corners in the world.
 
 	var/list/light_queue   = list() // lighting sources  queued for update.
@@ -33,7 +34,7 @@ SUBSYSTEM_DEF(lighting)
 #ifdef USE_INTELLIGENT_LIGHTING_UPDATES
 		"IUR: [total_ss_updates ? round(total_instant_updates/(total_instant_updates+total_ss_updates)*100, 0.1) : "NaN"]%\n",
 #endif
-		"\tT:{L:[total_lighting_sources] C:[lighting_corners.len] O:[total_lighting_overlays]}\n",
+		"\tT:{L:[total_lighting_sources] C:[lighting_corners.len] O:[total_lighting_overlays] A:[total_ambient_turfs]}\n",
 		"\tP:{L:[light_queue.len - (lq_idex - 1)]|C:[corner_queue.len - (cq_idex - 1)]|O:[overlay_queue.len - (oq_idex - 1)]}\n",
 		"\tL:{L:[processed_lights]|C:[processed_corners]|O:[processed_overlays]}\n"
 	)
@@ -81,6 +82,8 @@ SUBSYSTEM_DEF(lighting)
 		if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(T) && !T.lighting_overlay)	// Can't assume that one hasn't already been created on bay/neb.
 			new /atom/movable/lighting_overlay(T)
 			. += 1
+			if (T.ambient_light)
+				T.generate_missing_corners()	// Forcibly generate corners.
 
 		CHECK_TICK
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -62,11 +62,7 @@
 	atom_flags |= ATOM_FLAG_INITIALIZED
 
 	if (light_range && light_power)
-		if (ambient_light)
-			update_ambient_light(TRUE)
 		update_light()
-	else if (ambient_light)
-		update_ambient_light(FALSE)
 
 	if(dynamic_lighting)
 		luminosity = 0

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -51,8 +51,12 @@
 	var/old_flooded =          flooded
 	var/old_outside =          is_outside
 	var/old_is_open =          is_open()
+
 	var/old_ambience =         ambient_light
 	var/old_ambience_mult =    ambient_light_multiplier
+	var/old_ambient_light_old_r = ambient_light_old_r
+	var/old_ambient_light_old_g = ambient_light_old_g
+	var/old_ambient_light_old_b = ambient_light_old_b
 
 	changing_turf = TRUE
 
@@ -97,6 +101,10 @@
 	lighting_overlay = old_lighting_overlay
 
 	recalc_atom_opacity()
+
+	ambient_light_old_r = old_ambient_light_old_r
+	ambient_light_old_g = old_ambient_light_old_g
+	ambient_light_old_b = old_ambient_light_old_b
 
 	if (old_ambience != ambient_light || old_ambience_mult != ambient_light_multiplier)
 		update_ambient_light(FALSE)
@@ -169,7 +177,7 @@
 	construction_stage = other.construction_stage
 
 	damage = other.damage
-	
+
 	// Do not set directly to other.can_open since it may be in the WALL_OPENING state.
 	if(other.can_open)
 		can_open = WALL_CAN_OPEN

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -39,10 +39,15 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	var/below_g = 0
 	var/below_b = 0
 
-	// Ambient turf lighting that's not inherited from a dynamic light source.
+	// Ambient turf lighting that's not inherited from a light source. These are updated as absolute values.
 	var/ambient_r = 0
 	var/ambient_g = 0
 	var/ambient_b = 0
+
+	// The turf above us' ambient
+	var/above_ambient_r = 0
+	var/above_ambient_g = 0
+	var/above_ambient_b = 0
 
 	// The final intensity, all things considered.
 	var/apparent_r = 0
@@ -59,9 +64,14 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 /datum/lighting_corner/New(turf/new_turf, diagonal, oi)
 	SSlighting.lighting_corners += src
 
+	var/has_ambience = FALSE
+
 	t1 = new_turf
 	z = new_turf.z
 	t1i = oi
+
+	if (new_turf.ambient_light)
+		has_ambience = TRUE
 
 	var/vertical   = diagonal & ~(diagonal - 1) // The horizontal directions (4 and 8) are bigger than the vertical ones (1 and 2), so we can reliably say the lsb is the horizontal direction.
 	var/horizontal = diagonal & ~vertical       // Now that we know the horizontal one we can get the vertical one.
@@ -74,6 +84,7 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	// So we'll have this hardcode instead.
 	var/turf/T
 
+
 	// Diagonal one is easy.
 	T = get_step(new_turf, diagonal)
 	if (T) // In case we're on the map's border.
@@ -83,6 +94,8 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 		t2 = T
 		t2i = REVERSE_LIGHTING_CORNER_DIAGONAL[diagonal]
 		T.corners[t2i] = src
+		if (T.ambient_light)
+			has_ambience = TRUE
 
 	// Now the horizontal one.
 	T = get_step(new_turf, horizontal)
@@ -93,6 +106,8 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 		t3 = T
 		t3i = REVERSE_LIGHTING_CORNER_DIAGONAL[((T.x > x) ? EAST : WEST) | ((T.y > y) ? NORTH : SOUTH)] // Get the dir based on coordinates.
 		T.corners[t3i] = src
+		if (T.ambient_light)
+			has_ambience = TRUE
 
 	// And finally the vertical one.
 	T = get_step(new_turf, vertical)
@@ -103,8 +118,12 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 		t4 = T
 		t4i = REVERSE_LIGHTING_CORNER_DIAGONAL[((T.x > x) ? EAST : WEST) | ((T.y > y) ? NORTH : SOUTH)] // Get the dir based on coordinates.
 		T.corners[t4i] = src
+		if (T.ambient_light)
+			has_ambience = TRUE
 
 	update_active()
+	if (has_ambience)
+		init_ambient()
 
 #define OVERLAY_PRESENT(T) (T && T.lighting_overlay)
 
@@ -117,8 +136,36 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 #undef OVERLAY_PRESENT
 
 #define GET_ABOVE(T) (HasAbove(T:z) ? get_step(T, UP) : null)
+#define GET_BELOW(T) (HasBelow(T:z) ? get_step(T, DOWN) : null)
 
-#define UPDATE_APPARENT apparent_r = self_r + below_r + ambient_r; apparent_b = self_b + below_b + ambient_b; apparent_g = self_g + below_g + ambient_g
+#define UPDATE_APPARENT(T, CH) T.apparent_##CH = T.self_##CH + T.below_##CH + T.ambient_##CH + T.above_ambient_##CH
+
+/datum/lighting_corner/proc/init_ambient()
+	var/sum_r = 0
+	var/sum_g = 0
+	var/sum_b = 0
+
+	var/turf/T
+	for (var/i in 1 to 4)
+		// this is ugly as fuck, but it's still more legible than doing this with a macro
+		switch (i)
+			if (1) T = t1
+			if (2) T = t2
+			if (3) T = t3
+			if (4) T = t4
+
+		if (!T || !T.ambient_light)
+			continue
+
+		sum_r += (HEX_RED(T.ambient_light) / 255) * T.ambient_light_multiplier
+		sum_g += (HEX_GREEN(T.ambient_light) / 255) * T.ambient_light_multiplier
+		sum_b += (HEX_BLUE(T.ambient_light) / 255) * T.ambient_light_multiplier
+
+	sum_r /= 4
+	sum_g /= 4
+	sum_b /= 4
+
+	update_ambient_lumcount(sum_r, sum_g, sum_b)
 
 // God that was a mess, now to do the rest of the corner code! Hooray!
 /datum/lighting_corner/proc/update_lumcount(delta_r, delta_g, delta_b, now = FALSE)
@@ -129,7 +176,9 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	self_g += delta_g
 	self_b += delta_b
 
-	UPDATE_APPARENT
+	UPDATE_APPARENT(src, r)
+	UPDATE_APPARENT(src, g)
+	UPDATE_APPARENT(src, b)
 
 	var/turf/T
 	var/Ti
@@ -145,7 +194,7 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	else	// Nothing above us that cares about below light.
 		T = null
 
-	if (T)
+	if (TURF_IS_DYNAMICALLY_LIT(T))
 		if (!T.corners || !T.corners[Ti])
 			T.generate_missing_corners()
 		var/datum/lighting_corner/above = T.corners[Ti]
@@ -155,13 +204,11 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	if (needs_update)
 		return
 
-	if (!now)
+	if (now)
+		update_overlays(TRUE)
+	else
 		needs_update = TRUE
 		SSlighting.corner_queue += src
-	else
-		update_overlays(TRUE)
-
-#undef GET_ABOVE
 
 /datum/lighting_corner/proc/update_below_lumcount(delta_r, delta_g, delta_b, now = FALSE)
 	if (!(delta_r + delta_g + delta_b))
@@ -171,7 +218,9 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	below_g += delta_g
 	below_b += delta_b
 
-	UPDATE_APPARENT
+	UPDATE_APPARENT(src, r)
+	UPDATE_APPARENT(src, g)
+	UPDATE_APPARENT(src, b)
 
 	// This needs to be down here instead of the above if so the lum values are properly updated.
 	if (needs_update)
@@ -183,16 +232,59 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	else
 		update_overlays(TRUE)
 
-// Note: unlike the above setters, this works with absolute values rather than deltas.
-/datum/lighting_corner/proc/set_ambient_lumcount(ar, ag, ab, skip_update = FALSE)
-	if (!(ar + ag + ab))
-		return
+/datum/lighting_corner/proc/update_ambient_lumcount(delta_r, delta_g, delta_b, skip_update = FALSE)
+	ambient_r += delta_r
+	ambient_g += delta_g
+	ambient_b += delta_b
 
-	ambient_r = ar
-	ambient_g = ag
-	ambient_b = ab
+	UPDATE_APPARENT(src, r)
+	UPDATE_APPARENT(src, g)
+	UPDATE_APPARENT(src, b)
 
-	UPDATE_APPARENT
+	var/turf/T
+	var/Ti
+
+	if (t1)
+		T = t1
+		Ti = t1i
+	else if (t2)
+		T = t2
+		Ti = t2i
+	else if (t3)
+		T = t3
+		Ti = t3i
+	else if (t4)
+		T = t4
+		Ti = t4i
+	else
+		// This should be impossible to reach -- how do we exist without at least one master turf?
+		CRASH("Corner has no masters!")
+
+	var/datum/lighting_corner/below = src
+
+	var/turf/lasT
+
+	// We init before Z-Mimic, cannot rely on above/below.
+	while ((lasT = T) && (T = GET_BELOW(T)) && (lasT.z_flags & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+		T.ambient_has_indirect = TRUE
+
+		if (!T.corners || !T.corners[Ti])
+			T.generate_missing_corners()
+
+		ASSERT(T.corners?.len)
+
+		below = T.corners[Ti]
+		below.above_ambient_r += delta_r
+		below.above_ambient_g += delta_g
+		below.above_ambient_b += delta_b
+
+		UPDATE_APPARENT(below, r)
+		UPDATE_APPARENT(below, g)
+		UPDATE_APPARENT(below, b)
+
+		if (!skip_update && !below.needs_update)
+			below.needs_update = TRUE
+			SSlighting.corner_queue += below
 
 	if (needs_update || skip_update)
 		return

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -25,6 +25,10 @@
 	T.lighting_overlay = src
 	T.luminosity       = 0
 
+	if (T.corners && T.corners.len)
+		for (var/datum/lighting_corner/C in T.corners)
+			C.active = TRUE
+
 	if (update_now)
 		update_overlay()
 		needs_update = FALSE

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -10,6 +10,13 @@
 	var/tmp/atom/movable/lighting_overlay/lighting_overlay // Our lighting overlay.
 	var/tmp/list/datum/lighting_corner/corners
 	var/tmp/has_opaque_atom = FALSE // Not to be confused with opacity, this will be TRUE if there's any opaque atom on the tile.
+	var/tmp/ambient_has_indirect = FALSE // If this is TRUE, an above turf's ambient light is affecting this turf.
+
+	// Record-keeping, do not touch -- that means you, admins.
+	var/tmp/ambient_light_old
+	var/tmp/ambient_light_old_r = 0
+	var/tmp/ambient_light_old_g = 0
+	var/tmp/ambient_light_old_b = 0
 
 /turf/proc/set_ambient_light(color, multiplier)
 	if (color == ambient_light && multiplier == ambient_light_multiplier)
@@ -30,21 +37,43 @@
 	update_ambient_light()
 
 /turf/proc/update_ambient_light(no_corner_update = FALSE)
+	// These are deltas.
 	var/ambient_r = 0
 	var/ambient_g = 0
 	var/ambient_b = 0
+
 	if (ambient_light)
-		ambient_r = (HEX_RED(ambient_light) / 255) * ambient_light_multiplier
-		ambient_g = (HEX_GREEN(ambient_light) / 255) * ambient_light_multiplier
-		ambient_b = (HEX_BLUE(ambient_light) / 255) * ambient_light_multiplier
+		ambient_r = ((HEX_RED(ambient_light) / 255) * ambient_light_multiplier)/4 - ambient_light_old_r
+		ambient_g = ((HEX_GREEN(ambient_light) / 255) * ambient_light_multiplier)/4 - ambient_light_old_g
+		ambient_b = ((HEX_BLUE(ambient_light) / 255) * ambient_light_multiplier)/4 - ambient_light_old_b
+	else
+		ambient_r = -ambient_light_old_r
+		ambient_g = -ambient_light_old_g
+		ambient_b = -ambient_light_old_b
 
-	if (!corners || (null in corners))
-		generate_missing_corners()
+	ambient_light_old_r += ambient_r
+	ambient_light_old_g += ambient_g
+	ambient_light_old_b += ambient_b
 
-	for (var/thing in corners)
-		var/datum/lighting_corner/C = thing
-		C.set_ambient_lumcount(ambient_r, ambient_g, ambient_b, no_corner_update)
+	if (ambient_r + ambient_g + ambient_b == 0)
+		return
 
+	if (!corners)
+		if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(src))
+			generate_missing_corners()
+		else
+			return
+
+	// This list can contain nulls on things like space turfs -- they only have their neighbors' corners.
+	for (var/datum/lighting_corner/C in corners)
+		C.update_ambient_lumcount(ambient_r, ambient_g, ambient_b, no_corner_update)
+
+	if (ambient_light_old == null && ambient_light != ambient_light_old)
+		SSlighting.total_ambient_turfs += 1
+	else if (ambient_light_old != null && ambient_light == null)
+		SSlighting.total_ambient_turfs -= 1
+
+	ambient_light_old = ambient_light
 
 // Causes any affecting light sources to be queued for a visibility update, for example a door got opened.
 /turf/proc/reconsider_lights()
@@ -173,7 +202,7 @@
 // This is inlined in lighting_source.dm.
 // Update it too if you change this.
 /turf/proc/generate_missing_corners()
-	if (!TURF_IS_DYNAMICALLY_LIT_UNSAFE(src) && !light_source_solo && !light_source_multi && !(z_flags & ZM_ALLOW_LIGHTING) && !ambient_light)
+	if (!TURF_IS_DYNAMICALLY_LIT_UNSAFE(src) && !light_source_solo && !light_source_multi && !(z_flags & ZM_ALLOW_LIGHTING) && !ambient_light && !ambient_has_indirect)
 		return
 
 	lighting_corners_initialised = TRUE

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -58,11 +58,22 @@
 	if (ambient_r + ambient_g + ambient_b == 0)
 		return
 
+	// Unlit turfs will have corners if they have a lit neighbor -- don't generate corners for them, but do update them if they're there.
+	// if (!corners)
+	// 	var/force_build_corners = FALSE
+	// 	for (var/turf/T in RANGE_TURFS(src, 1))
+	// 		if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+	// 			force_build_corners = TRUE
+	// 			break
+
+	// 	if (force_build_corners || TURF_IS_DYNAMICALLY_LIT_UNSAFE(src))
+	// 		generate_missing_corners()
+	// 	else
+	// 		return
+
+	// inefficient :(
 	if (!corners)
-		if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(src))
-			generate_missing_corners()
-		else
-			return
+		generate_missing_corners()
 
 	// This list can contain nulls on things like space turfs -- they only have their neighbors' corners.
 	for (var/datum/lighting_corner/C in corners)


### PR DESCRIPTION
This is essentially a rewrite (whoops) of ambient lights with different init behavior -- it should generally behave a lot saner.

Changes:
- Ambient lights can now propagate down Z-levels
- Dynamic lighting is no longer broken by ambient lights
- Ambient lights no longer generate pointless corners on space
- Adjacent ambient lights will properly mix colors
- Ambient lights are now initialized during SSlighting init rather than SSatoms