### PR TITLE
Fix post rejuv +adherents

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -39,15 +39,17 @@
 #define ORGAN_BROKEN     BITFLAG(2)  // The organ is broken.
 #define ORGAN_DEAD       BITFLAG(3)  // The organ is necrotic.
 #define ORGAN_MUTATED    BITFLAG(4)  // The organ is unusable due to genetic damage.
-#define ORGAN_ARTERY_CUT BITFLAG(6)  // The organ has had its artery cut.
-#define ORGAN_TENDON_CUT BITFLAG(7)  // The organ has had its tendon cut.
-#define ORGAN_DISFIGURED BITFLAG(8)  // The organ is scarred/disfigured. Alters whether or not the face can be recognised.
-#define ORGAN_SABOTAGED  BITFLAG(9)  // The organ will explode if exposed to EMP, if prosthetic.
-#define ORGAN_ASSISTED   BITFLAG(10) // The organ is partially prosthetic. No mechanical effect.
-#define ORGAN_PROSTHETIC BITFLAG(11) // The organ is prosthetic. Changes numerous behaviors, search BP_IS_PROSTHETIC for checks.
-#define ORGAN_BRITTLE    BITFLAG(12) // The organ takes additional blunt damage. If robotic, cannot be repaired through normal means.
-#define ORGAN_CRYSTAL    BITFLAG(13) // The organ does not suffer laser damage, but shatters on droplimb.
-#define ORGAN_DISLOCATED BITFLAG(14)
+#define ORGAN_ARTERY_CUT BITFLAG(5)  // The organ has had its artery cut.
+#define ORGAN_TENDON_CUT BITFLAG(6)  // The organ has had its tendon cut.
+#define ORGAN_DISFIGURED BITFLAG(7)  // The organ is scarred/disfigured. Alters whether or not the face can be recognised.
+#define ORGAN_SABOTAGED  BITFLAG(8)  // The organ will explode if exposed to EMP, if prosthetic.
+#define ORGAN_BRITTLE    BITFLAG(9)  // The organ takes additional blunt damage. If robotic, cannot be repaired through normal means.
+#define ORGAN_DISLOCATED BITFLAG(10) //The organ is dislocated and will cause pain until set back in place.
+
+// Organ Properties
+#define ORGAN_PROP_ASSISTED   BITFLAG(0) // The organ is partially prosthetic. No mechanical effect.
+#define ORGAN_PROP_PROSTHETIC BITFLAG(1) // The organ is prosthetic. Changes numerous behaviors, search BP_IS_PROSTHETIC for checks.
+#define ORGAN_PROP_CRYSTAL    BITFLAG(2) // The organ does not suffer laser damage, but shatters on droplimb.
 
 // Organ flag defines.
 #define ORGAN_FLAG_CAN_AMPUTATE   BITFLAG(0) // The organ can be amputated.

--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -47,9 +47,8 @@
 #define ORGAN_DISLOCATED BITFLAG(10) //The organ is dislocated and will cause pain until set back in place.
 
 // Organ Properties
-#define ORGAN_PROP_ASSISTED   BITFLAG(0) // The organ is partially prosthetic. No mechanical effect.
-#define ORGAN_PROP_PROSTHETIC BITFLAG(1) // The organ is prosthetic. Changes numerous behaviors, search BP_IS_PROSTHETIC for checks.
-#define ORGAN_PROP_CRYSTAL    BITFLAG(2) // The organ does not suffer laser damage, but shatters on droplimb.
+#define ORGAN_PROP_PROSTHETIC BITFLAG(0) // The organ is prosthetic. Changes numerous behaviors, search BP_IS_PROSTHETIC for checks.
+#define ORGAN_PROP_CRYSTAL    BITFLAG(1) // The organ does not suffer laser damage, but shatters on droplimb.
 
 // Organ flag defines.
 #define ORGAN_FLAG_CAN_AMPUTATE   BITFLAG(0) // The organ can be amputated.

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -206,14 +206,12 @@
 
 // Prosthetic helpers.
 #define BP_IS_PROSTHETIC(org) (!QDELETED(org) && (org.organ_properties & ORGAN_PROP_PROSTHETIC))
-#define BP_IS_ASSISTED(org)   (!QDELETED(org) && (org.organ_properties & ORGAN_PROP_ASSISTED))
 #define BP_IS_BRITTLE(org)    (!QDELETED(org) && (org.status           & ORGAN_BRITTLE))
 #define BP_IS_CRYSTAL(org)    (!QDELETED(org) && (org.organ_properties & ORGAN_PROP_CRYSTAL))
 
 //Prosthetics setter
 //Since assisted and prosthetic are mutually exclusive set them using this helper for convenience
-#define BP_SET_PROSTHETIC(org) org.organ_properties = ((org.organ_properties & (~ORGAN_PROP_ASSISTED))   | ORGAN_PROP_PROSTHETIC);
-#define BP_SET_ASSISTED(org)   org.organ_properties = ((org.organ_properties & (~ORGAN_PROP_PROSTHETIC)) | ORGAN_PROP_ASSISTED);
+#define BP_SET_PROSTHETIC(org) org.organ_properties |= ORGAN_PROP_PROSTHETIC;
 #define BP_SET_CRYSTAL(org)    org.organ_properties |= ORGAN_PROP_CRYSTAL;
 
 // Limb flag helpers

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -209,8 +209,7 @@
 #define BP_IS_BRITTLE(org)    (!QDELETED(org) && (org.status           & ORGAN_BRITTLE))
 #define BP_IS_CRYSTAL(org)    (!QDELETED(org) && (org.organ_properties & ORGAN_PROP_CRYSTAL))
 
-//Prosthetics setter
-//Since assisted and prosthetic are mutually exclusive set them using this helper for convenience
+//Organ Properties Setters
 #define BP_SET_PROSTHETIC(org) org.organ_properties |= ORGAN_PROP_PROSTHETIC;
 #define BP_SET_CRYSTAL(org)    org.organ_properties |= ORGAN_PROP_CRYSTAL;
 

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -205,10 +205,16 @@
 #define AUGMENTATION_ORGANIC  2
 
 // Prosthetic helpers.
-#define BP_IS_PROSTHETIC(org) (!QDELETED(org) && (org.status & ORGAN_PROSTHETIC))
-#define BP_IS_ASSISTED(org)   (!QDELETED(org) && (org.status & ORGAN_ASSISTED))
-#define BP_IS_BRITTLE(org)    (!QDELETED(org) && (org.status & ORGAN_BRITTLE))
-#define BP_IS_CRYSTAL(org)    (!QDELETED(org) && (org.status & ORGAN_CRYSTAL))
+#define BP_IS_PROSTHETIC(org) (!QDELETED(org) && (org.organ_properties & ORGAN_PROP_PROSTHETIC))
+#define BP_IS_ASSISTED(org)   (!QDELETED(org) && (org.organ_properties & ORGAN_PROP_ASSISTED))
+#define BP_IS_BRITTLE(org)    (!QDELETED(org) && (org.status           & ORGAN_BRITTLE))
+#define BP_IS_CRYSTAL(org)    (!QDELETED(org) && (org.organ_properties & ORGAN_PROP_CRYSTAL))
+
+//Prosthetics setter
+//Since assisted and prosthetic are mutually exclusive set them using this helper for convenience
+#define BP_SET_PROSTHETIC(org) org.organ_properties = ((org.organ_properties & (~ORGAN_PROP_ASSISTED))   | ORGAN_PROP_PROSTHETIC);
+#define BP_SET_ASSISTED(org)   org.organ_properties = ((org.organ_properties & (~ORGAN_PROP_PROSTHETIC)) | ORGAN_PROP_ASSISTED);
+#define BP_SET_CRYSTAL(org)    org.organ_properties |= ORGAN_PROP_CRYSTAL;
 
 // Limb flag helpers
 #define BP_IS_DEFORMED(org) (org.limb_flags & ORGAN_FLAG_DEFORMED)

--- a/code/_helpers/medical_scans.dm
+++ b/code/_helpers/medical_scans.dm
@@ -178,22 +178,26 @@
 			dat+= "<tr><td colspan='2'><span class='average'>Patient is bradycardic.</span></td></tr>"
 
 
-	var/ratio = scan["blood_volume"]/scan["blood_volume_max"]
-	dat += "<tr><td><strong>Blood pressure:</strong></td><td>[scan["blood_pressure"]]"
-	if(scan["blood_o2"] <= 70)
-		dat += "(<span class='bad'>[scan["blood_o2"]]% blood oxygenation</span>)</td></tr>"
-	else if(scan["blood_o2"] <= 85)
-		dat += "(<span class='average'>[scan["blood_o2"]]% blood oxygenation</span>)</td></tr>"
-	else if(scan["blood_o2"] <= 90)
-		dat += "(<span class='oxyloss'>[scan["blood_o2"]]% blood oxygenation</span>)</td></tr>"
-	else
-		dat += "([scan["blood_o2"]]% blood oxygenation)</td></tr>"
+	if(scan["blood_volume_max"] > 0)
+		var/ratio = scan["blood_volume"]/scan["blood_volume_max"]
+		dat += "<tr><td><strong>Blood pressure:</strong></td><td>[scan["blood_pressure"]]"
+		if(scan["blood_o2"] <= 70)
+			dat += "(<span class='bad'>[scan["blood_o2"]]% blood oxygenation</span>)</td></tr>"
+		else if(scan["blood_o2"] <= 85)
+			dat += "(<span class='average'>[scan["blood_o2"]]% blood oxygenation</span>)</td></tr>"
+		else if(scan["blood_o2"] <= 90)
+			dat += "(<span class='oxyloss'>[scan["blood_o2"]]% blood oxygenation</span>)</td></tr>"
+		else
+			dat += "([scan["blood_o2"]]% blood oxygenation)</td></tr>"
 
-	dat += "<tr><td><strong>Blood volume:</strong></td><td>[scan["blood_volume"]]u/[scan["blood_volume_max"]]u</td></tr>"
+		dat += "<tr><td><strong>Blood volume:</strong></td><td>[scan["blood_volume"]]u/[scan["blood_volume_max"]]u</td></tr>"
 
-	if(skill_level >= SKILL_ADEPT)
-		if(ratio <= 0.70)
-			dat += "<tr><td colspan='2'><span class='bad'>Patient is in Hypovolemic Shock. Transfusion highly recommended.</span></td></tr>"
+		if(skill_level >= SKILL_ADEPT)
+			if(ratio <= 0.70)
+				dat += "<tr><td colspan='2'><span class='bad'>Patient is in Hypovolemic Shock. Transfusion highly recommended.</span></td></tr>"
+	else 
+		dat += "<tr><td><strong>Blood pressure:</strong></td><td><span class='average'>ERROR - Patient has lacks a circulatory system.</span></td></tr>"
+		dat += "<tr><td><strong>Blood volume:</strong></td><td><span class='average'>ERROR - Patient has lacks a circulatory system.</span></td></tr>"
 
 	// Body temperature.
 	/*

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -460,7 +460,7 @@ var/global/list/slot_flags_enumeration = list(
 //Set disable_warning to 1 if you wish it to not give you outputs.
 //Should probably move the bulk of this into mob code some time, as most of it is related to the definition of slots and not item-specific
 //set force to ignore blocking overwear and occupied slots
-/obj/item/proc/mob_can_equip(M, slot, disable_warning = 0, force = 0)
+/obj/item/proc/mob_can_equip(M, slot, disable_warning = FALSE, force = FALSE)
 
 	if(!slot || !M || !ishuman(M))
 		return FALSE

--- a/code/modules/augment/augment.dm
+++ b/code/modules/augment/augment.dm
@@ -3,7 +3,7 @@
 	desc = "An embedded augment."
 	icon = 'icons/obj/augment.dmi'
 	//By default these fit on both flesh and robotic organs and are robotic
-	status = ORGAN_PROSTHETIC
+	organ_properties = ORGAN_PROP_PROSTHETIC
 	default_action_type = /datum/action/item_action/organ/augment
 	material = /decl/material/solid/metal/steel
 	origin_tech = "{'materials':1,'magnets':2,'engineering':2,'biotech':1}"

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -128,7 +128,7 @@
 	if(markings_color && markings_icon)
 		update_icon()
 
-/obj/item/clothing/mob_can_equip(mob/living/M, slot, disable_warning = 0)
+/obj/item/clothing/mob_can_equip(mob/living/M, slot, disable_warning = FALSE, force = FALSE)
 	. = ..()
 	if(. && !isnull(bodytype_equip_flags) && ishuman(M) && !(slot in list(slot_l_store_str, slot_r_store_str, slot_s_store_str)) && !(slot in M.held_item_slots))
 		var/mob/living/carbon/human/H = M

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -266,7 +266,7 @@
 					hidden_bleeders[hidden] = list()
 				hidden_bleeders[hidden] += E.name
 		else
-			if(!is_synth && BP_IS_PROSTHETIC(E) && (E.parent && !BP_IS_PROSTHETIC(E.parent) && !BP_IS_ASSISTED(E.parent)))
+			if(!is_synth && BP_IS_PROSTHETIC(E) && (E.parent && !BP_IS_PROSTHETIC(E.parent)))
 				wound_flavor_text[E.name] = "[G.He] [G.has] a [E.name].\n"
 			var/wounddesc = E.get_wounds_desc()
 			if(wounddesc != "nothing")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -718,9 +718,9 @@
 
 	//recheck species-restricted clothing
 	for(var/slot in global.all_inventory_slots)
-		var/obj/item/clothing/C = get_equipped_item(slot)
+		var/obj/item/C = get_equipped_item(slot)
 		if(istype(C) && !C.mob_can_equip(src, slot, TRUE, TRUE))
-			unEquip(C)
+			drop_from_inventory(C)
 
 //This handles actually updating our visual appearance
 // Triggers deep update of limbs and hud

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -66,7 +66,7 @@
 			add_clothing_protection(mask)
 
 		var/obj/item/rig/rig = get_equipped_item(slot_back_str)
-		if(rig)
+		if(istype(rig))
 			process_rig(rig)
 
 /mob/living/carbon/human/proc/process_glasses(var/obj/item/clothing/glasses/G)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -224,10 +224,7 @@
 
 /mob/living/carbon/human/proc/sync_organ_dna()
 	for(var/obj/item/organ/O in get_organs())
-		if(!BP_IS_PROSTHETIC(O))
-			O.setup_as_organic(dna)
-		else
-			O.setup_as_prosthetic()
+		O.set_dna(dna)
 
 /mob/living/proc/is_asystole()
 	return FALSE

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -80,9 +80,7 @@ var/global/arrest_security_status =  "Arrest"
 				if(BP_IS_PROSTHETIC(E))
 					organ_data += "[E.model ? "[E.model] " : null][E.name] prosthetic"
 			for(var/obj/item/organ/internal/I in H.get_internal_organs())
-				if(BP_IS_ASSISTED(I))
-					organ_data += I.get_mechanical_assisted_descriptor()
-				else if (BP_IS_PROSTHETIC(I))
+				if (BP_IS_PROSTHETIC(I))
 					organ_data += "[I.name] prosthetic"
 			set_implants(jointext(organ_data, "\[*\]"))
 

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -35,6 +35,7 @@
 
 	if(!should_have_organ(BP_HEART))
 		vessel.clear_reagents()
+		vessel.maximum_volume = 0
 		return
 
 	if(vessel.total_volume < species.blood_volume)

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -163,6 +163,8 @@
 
 //Transfers blood from container ot vessels
 /mob/living/carbon/proc/inject_blood(var/amount, var/datum/reagents/donor)
+	if(!species.blood_volume)
+		return //Don't divide by 0
 	var/injected_data = REAGENT_DATA(donor, species.blood_reagent)
 	var/chems = LAZYACCESS(injected_data, "trace_chem")
 	for(var/C in chems)
@@ -286,7 +288,7 @@
 
 //Percentage of maximum blood volume.
 /mob/living/carbon/human/proc/get_blood_volume()
-	return round((vessel.total_volume/species.blood_volume)*100)
+	return species.blood_volume? round((vessel.total_volume/species.blood_volume)*100) : 0
 
 //Percentage of maximum blood volume, affected by the condition of circulation organs
 /mob/living/carbon/human/proc/get_blood_circulation()

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -155,9 +155,6 @@
 		if (3)
 			burn_damage = 7.5
 
-	var/mult = 1 + !!(BP_IS_ASSISTED(src)) // This macro returns (large) bitflags.
-	burn_damage *= mult/species.get_burn_mod(owner) //ignore burn mod for EMP damage
-
 	var/power = 4 - severity //stupid reverse severity
 	for(var/obj/item/I in implants)
 		if(I.obj_flags & OBJ_FLAG_CONDUCTIBLE)

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -138,8 +138,6 @@
 			. = "necrotic [.]"
 	if(BP_IS_CRYSTAL(src))
 		. = "crystalline "
-	else if(BP_IS_ASSISTED(src))
-		. = "assisted "
 	else if(BP_IS_PROSTHETIC(src))
 		. = "mechanical "
 	. = "[.][name]"

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -3,10 +3,12 @@
 ****************************************************/
 /obj/item/organ/internal
 	scale_max_damage_to_species_health = TRUE
+	var/tmp/prosthetic_name //Name given to the organ when robotized. Null means no changes
 	var/tmp/alive_icon //icon to use when the organ is alive
 	var/tmp/dead_icon // Icon to use when the organ has died.
 	var/tmp/prosthetic_icon //Icon to use when the organ is robotic
 	var/tmp/prosthetic_dead_icon //Icon to use when the organ is robotic and dead
+	var/tmp/prosthetic_icon_file //The path to the icon file for the prosthetic icons. Null means use the current 'icon' value.
 	var/surface_accessible = FALSE
 	var/relative_size = 25   // Relative size of the organ. Roughly % of space they take in the target projection :D
 	var/min_bruised_damage = 10       // Damage before considered bruised
@@ -72,8 +74,14 @@
 
 /obj/item/organ/internal/robotize(var/company = /decl/prosthetics_manufacturer, var/skip_prosthetics = 0, var/keep_organs = 0, var/apply_material = /decl/material/solid/metal/steel, var/check_bodytype, var/check_species)
 	. = ..()
+	if(length(prosthetic_name))
+		SetName(prosthetic_name)
+	if(prosthetic_icon_file)
+		icon = prosthetic_icon_file
+
 	min_bruised_damage += 5
 	min_broken_damage += 10
+	queue_icon_update()
 
 /obj/item/organ/internal/proc/getToxLoss()
 	if(BP_IS_PROSTHETIC(src))

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -26,9 +26,6 @@
 /obj/item/organ/internal/brain/robotize(var/company = /decl/prosthetics_manufacturer, var/skip_prosthetics = 0, var/keep_organs = 0, var/apply_material = /decl/material/solid/metal/steel, var/check_bodytype, var/check_species)
 	replace_self_with(/obj/item/organ/internal/posibrain)
 
-/obj/item/organ/internal/brain/mechassist()
-	replace_self_with(/obj/item/organ/internal/mmi_holder)
-
 /obj/item/organ/internal/brain/getToxLoss()
 	return 0
 

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -1,16 +1,18 @@
 
 /obj/item/organ/internal/eyes
-	name = "eyeballs"
-	icon_state = "eyes"
-	prosthetic_icon = "camera"
+	name                 = "eyeballs"
+	icon_state           = "eyes"
+	prosthetic_name      = "optical sensor"
+	prosthetic_icon_file = 'icons/obj/robot_component.dmi'
+	prosthetic_icon      = "camera"
 	prosthetic_dead_icon = "camera_broken"
-	gender = PLURAL
-	organ_tag = BP_EYES
-	parent_organ = BP_HEAD
-	surface_accessible = TRUE
-	relative_size = 5
-	max_damage = 45
-	z_flags = ZMM_MANGLE_PLANES
+	gender               = PLURAL
+	organ_tag            = BP_EYES
+	parent_organ         = BP_HEAD
+	surface_accessible   = TRUE
+	relative_size        = 5
+	max_damage           = 45
+	z_flags              = ZMM_MANGLE_PLANES
 
 	var/contaminant_guard = 0
 	var/eye_colour = COLOR_BLACK
@@ -24,7 +26,6 @@
 	var/eye_blend = ICON_ADD
 
 /obj/item/organ/internal/eyes/robot
-	name = "optical sensor"
 	organ_properties = ORGAN_PROP_PROSTHETIC
 
 /obj/item/organ/internal/eyes/proc/get_eye_cache_key()
@@ -100,9 +101,6 @@
 
 /obj/item/organ/internal/eyes/robotize(var/company = /decl/prosthetics_manufacturer, var/skip_prosthetics = 0, var/keep_organs = 0, var/apply_material = /decl/material/solid/metal/steel, var/check_bodytype, var/check_species)
 	. = ..()
-	name = "optical sensor"
-	icon = 'icons/obj/robot_component.dmi'
-
 	if(owner)
 		verbs |= /obj/item/organ/internal/eyes/proc/change_eye_color
 		verbs |= /obj/item/organ/internal/eyes/proc/toggle_eye_glow

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -25,7 +25,7 @@
 
 /obj/item/organ/internal/eyes/robot
 	name = "optical sensor"
-	status = ORGAN_PROSTHETIC
+	organ_properties = ORGAN_PROP_PROSTHETIC
 
 /obj/item/organ/internal/eyes/proc/get_eye_cache_key()
 	last_cached_eye_colour = eye_colour

--- a/code/modules/organs/internal/posibrain.dm
+++ b/code/modules/organs/internal/posibrain.dm
@@ -22,7 +22,7 @@
 	)
 	relative_size = 60
 	req_access = list(access_robotics)
-	status = ORGAN_PROSTHETIC //triggers robotization on init
+	organ_properties = ORGAN_PROP_PROSTHETIC //triggers robotization on init
 	scale_max_damage_to_species_health = FALSE
 
 	var/mob/living/silicon/sil_brainmob/brainmob = null
@@ -215,7 +215,7 @@
 	organ_tag = BP_CELL
 	parent_organ = BP_CHEST
 	vital = 1
-	status = ORGAN_PROSTHETIC //triggers robotization on init
+	organ_properties = ORGAN_PROP_PROSTHETIC //triggers robotization on init
 	var/open
 	var/obj/item/cell/cell = /obj/item/cell/hyper
 	//at 0.8 completely depleted after 60ish minutes of constant walking or 130 minutes of standing still
@@ -313,7 +313,7 @@
 	organ_tag = BP_BRAIN
 	parent_organ = BP_HEAD
 	vital = TRUE
-	status = ORGAN_PROSTHETIC //triggers robotization on init
+	organ_properties = ORGAN_PROP_PROSTHETIC //triggers robotization on init
 	scale_max_damage_to_species_health = FALSE
 	var/obj/item/mmi/stored_mmi
 	var/datum/mind/persistantMind //Mind that the organ will hold on to after being removed, used for transfer_and_delete

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -14,6 +14,7 @@
 
 	// Status tracking.
 	var/status = 0                         // Various status flags (such as robotic)
+	var/organ_properties = 0               // A flag for telling what capabilities this organ has. ORGAN_PROP_PROSTHETIC, ORGAN_PROP_CRYSTAL, etc..
 	var/vital                              // Lose a vital limb, die immediately.
 
 	// Reference data.
@@ -322,7 +323,7 @@
 		damage = between(0, damage - round(amount, 0.1), max_damage)
 
 /obj/item/organ/proc/robotize(var/company = /decl/prosthetics_manufacturer, var/skip_prosthetics = 0, var/keep_organs = 0, var/apply_material = /decl/material/solid/metal/steel, var/check_bodytype, var/check_species)
-	status = ORGAN_PROSTHETIC
+	BP_SET_PROSTHETIC(src) //Can't be assisted and prosthetic at the same time
 	QDEL_NULL(dna)
 	reagents?.clear_reagents()
 	material = GET_DECL(apply_material)
@@ -330,10 +331,10 @@
 	create_matter()
 
 /obj/item/organ/proc/mechassist() //Used to add things like pacemakers, etc
-	status = ORGAN_ASSISTED
+	BP_SET_ASSISTED(src) //Can't be assisted and prosthetic at the same time
 
 /obj/item/organ/attack(var/mob/target, var/mob/user)
-	if(status & ORGAN_PROSTHETIC || !istype(target) || !istype(user) || (user != target && user.a_intent == I_HELP))
+	if(BP_IS_PROSTHETIC(src) || !istype(target) || !istype(user) || (user != target && user.a_intent == I_HELP))
 		return ..()
 
 	if(alert("Do you really want to use this organ as food? It will be useless for anything else afterwards.",,"Ew, no.","Bon appetit!") == "Ew, no.")

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -330,9 +330,6 @@
 	matter = null
 	create_matter()
 
-/obj/item/organ/proc/mechassist() //Used to add things like pacemakers, etc
-	BP_SET_ASSISTED(src) //Can't be assisted and prosthetic at the same time
-
 /obj/item/organ/attack(var/mob/target, var/mob/user)
 	if(BP_IS_PROSTHETIC(src) || !istype(target) || !istype(user) || (user != target && user.a_intent == I_HELP))
 		return ..()
@@ -370,8 +367,6 @@
 	. = list()
 	if(BP_IS_CRYSTAL(src))
 		. += tag ? "<span class='average'>Crystalline</span>" : "Crystalline"
-	else if(BP_IS_ASSISTED(src))
-		. += tag ? "<span class='average'>Assisted</span>" : "Assisted"
 	else if(BP_IS_PROSTHETIC(src))
 		. += tag ? "<span class='average'>Mechanical</span>" : "Mechanical"
 	if(status & ORGAN_CUT_AWAY)

--- a/code/modules/reagents/chems/chems_compounds.dm
+++ b/code/modules/reagents/chems/chems_compounds.dm
@@ -411,7 +411,7 @@
 					E.dismember(0, DISMEMBER_METHOD_BLUNT)
 				else
 					E.take_external_damage(rand(20,30), 0)
-					E.status |= ORGAN_CRYSTAL
+					BP_SET_CRYSTAL(E)
 					E.status |= ORGAN_BRITTLE
 				break
 

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -867,7 +867,7 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 
 /**Runs extra processing after any organs member of this species goes through rejuvenation. */
 /decl/species/proc/post_organ_rejuvenate(var/obj/item/organ/org, var/mob/living/carbon/human/H)
-		org.status |= (ORGAN_BRITTLE|ORGAN_CRYSTAL)
+	return
 
 /decl/species/proc/check_no_slip(var/mob/living/carbon/human/H)
 	if(can_overcome_gravity(H))

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -865,8 +865,8 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 		if(31 to 45)	. = 4
 		else			. = 8
 
+/**Runs extra processing after any organs member of this species goes through rejuvenation. */
 /decl/species/proc/post_organ_rejuvenate(var/obj/item/organ/org, var/mob/living/carbon/human/H)
-	if(org && (org.species ? (org.species.species_flags & SPECIES_FLAG_CRYSTALLINE) : (species_flags & SPECIES_FLAG_CRYSTALLINE)))
 		org.status |= (ORGAN_BRITTLE|ORGAN_CRYSTAL)
 
 /decl/species/proc/check_no_slip(var/mob/living/carbon/human/H)

--- a/mods/species/ascent/datum/species.dm
+++ b/mods/species/ascent/datum/species.dm
@@ -92,28 +92,28 @@
 	)
 
 	has_limbs = list(
-		BP_CHEST =  list("path" = /obj/item/organ/external/chest/insectoid),
+		BP_CHEST =  list("path" = /obj/item/organ/external/chest/insectoid/mantid),
 		BP_GROIN =  list("path" = /obj/item/organ/external/groin/insectoid/mantid),
-		BP_HEAD =   list("path" = /obj/item/organ/external/head/insectoid),
-		BP_L_ARM =  list("path" = /obj/item/organ/external/arm/insectoid),
-		BP_L_HAND = list("path" = /obj/item/organ/external/hand/insectoid),
-		BP_R_ARM =  list("path" = /obj/item/organ/external/arm/right/insectoid),
-		BP_R_HAND = list("path" = /obj/item/organ/external/hand/right/insectoid),
-		BP_M_HAND = list("path" = /obj/item/organ/external/hand/insectoid/midlimb),
-		BP_R_LEG =  list("path" = /obj/item/organ/external/leg/right/insectoid),
-		BP_L_LEG =  list("path" = /obj/item/organ/external/leg/insectoid),
-		BP_L_FOOT = list("path" = /obj/item/organ/external/foot/insectoid),
-		BP_R_FOOT = list("path" = /obj/item/organ/external/foot/right/insectoid)
+		BP_HEAD =   list("path" = /obj/item/organ/external/head/insectoid/mantid),
+		BP_L_ARM =  list("path" = /obj/item/organ/external/arm/insectoid/mantid),
+		BP_L_HAND = list("path" = /obj/item/organ/external/hand/insectoid/mantid),
+		BP_R_ARM =  list("path" = /obj/item/organ/external/arm/right/insectoid/mantid),
+		BP_R_HAND = list("path" = /obj/item/organ/external/hand/right/insectoid/mantid),
+		BP_M_HAND = list("path" = /obj/item/organ/external/hand/insectoid/midlimb/mantid),
+		BP_R_LEG =  list("path" = /obj/item/organ/external/leg/right/insectoid/mantid),
+		BP_L_LEG =  list("path" = /obj/item/organ/external/leg/insectoid/mantid),
+		BP_L_FOOT = list("path" = /obj/item/organ/external/foot/insectoid/mantid),
+		BP_R_FOOT = list("path" = /obj/item/organ/external/foot/right/insectoid/mantid)
 	)
 
 	has_organ = list(
-		BP_HEART =             /obj/item/organ/internal/heart/insectoid,
-		BP_STOMACH =           /obj/item/organ/internal/stomach/insectoid,
-		BP_LUNGS =             /obj/item/organ/internal/lungs/insectoid,
-		BP_LIVER =             /obj/item/organ/internal/liver/insectoid,
-		BP_KIDNEYS =           /obj/item/organ/internal/kidneys/insectoid,
-		BP_BRAIN =             /obj/item/organ/internal/brain/insectoid,
-		BP_EYES =              /obj/item/organ/internal/eyes/insectoid,
+		BP_HEART =             /obj/item/organ/internal/heart/insectoid/mantid,
+		BP_STOMACH =           /obj/item/organ/internal/stomach/insectoid/mantid,
+		BP_LUNGS =             /obj/item/organ/internal/lungs/insectoid/mantid,
+		BP_LIVER =             /obj/item/organ/internal/liver/insectoid/mantid,
+		BP_KIDNEYS =           /obj/item/organ/internal/kidneys/insectoid/mantid,
+		BP_BRAIN =             /obj/item/organ/internal/brain/insectoid/mantid,
+		BP_EYES =              /obj/item/organ/internal/eyes/insectoid/mantid,
 		BP_SYSTEM_CONTROLLER = /obj/item/organ/internal/controller
 	)
 
@@ -139,9 +139,6 @@
 
 /decl/species/mantid/handle_sleeping(var/mob/living/carbon/human/H)
 	return
-
-/decl/species/mantid/post_organ_rejuvenate(var/obj/item/organ/org, var/mob/living/carbon/human/H)
-	org.status |= ORGAN_CRYSTAL
 
 /decl/species/mantid/equip_survival_gear(var/mob/living/carbon/human/H, var/extendedtank = 1)
 	return

--- a/mods/species/ascent/datum/species.dm
+++ b/mods/species/ascent/datum/species.dm
@@ -73,7 +73,7 @@
 	available_pronouns = list(/decl/pronouns/male)
 
 	appearance_flags =        0
-	species_flags =           SPECIES_FLAG_NO_SCAN  | SPECIES_FLAG_NO_SLIP        | SPECIES_FLAG_NO_MINOR_CUT
+	species_flags =           SPECIES_FLAG_NO_SCAN  | SPECIES_FLAG_NO_SLIP        | SPECIES_FLAG_NO_MINOR_CUT | SPECIES_FLAG_CRYSTALLINE
 	spawn_flags =             SPECIES_IS_RESTRICTED
 
 	heat_discomfort_strings = list(

--- a/mods/species/ascent/items/id_control.dm
+++ b/mods/species/ascent/items/id_control.dm
@@ -34,7 +34,7 @@
 	parent_organ = BP_CHEST
 	organ_tag = BP_SYSTEM_CONTROLLER
 	surface_accessible = TRUE
-	status = ORGAN_PROSTHETIC
+	organ_properties = ORGAN_PROP_PROSTHETIC
 	var/obj/item/card/id/id_card = /obj/item/card/id/ascent
 
 /obj/item/organ/internal/controller/do_install(mob/living/carbon/human/target, obj/item/organ/external/affected, in_place, update_icon, detached)

--- a/mods/species/ascent/mobs/bodyparts.dm
+++ b/mods/species/ascent/mobs/bodyparts.dm
@@ -88,3 +88,27 @@
 /obj/item/organ/external/head/insectoid/mantid/proc/reset_cooldown()
 	cooldown = FALSE
 	refresh_action_button()
+
+//Basically appends the crystal flag to all the types specified
+#define MANTIDIFY_ORGAN(ORGAN_PATH) ##ORGAN_PATH/Initialize(){BP_SET_CRYSTAL(src) . = ..();}
+//External organs
+MANTIDIFY_ORGAN(/obj/item/organ/external/groin/insectoid/mantid)
+MANTIDIFY_ORGAN(/obj/item/organ/external/head/insectoid/mantid)
+MANTIDIFY_ORGAN(/obj/item/organ/external/arm/insectoid/mantid)
+MANTIDIFY_ORGAN(/obj/item/organ/external/hand/insectoid/mantid)
+MANTIDIFY_ORGAN(/obj/item/organ/external/arm/right/insectoid/mantid)
+MANTIDIFY_ORGAN(/obj/item/organ/external/hand/right/insectoid/mantid)
+MANTIDIFY_ORGAN(/obj/item/organ/external/hand/insectoid/midlimb/mantid)
+MANTIDIFY_ORGAN(/obj/item/organ/external/leg/right/insectoid/mantid)
+MANTIDIFY_ORGAN(/obj/item/organ/external/leg/insectoid/mantid)
+MANTIDIFY_ORGAN(/obj/item/organ/external/foot/insectoid/mantid)
+MANTIDIFY_ORGAN(/obj/item/organ/external/foot/right/insectoid/mantid)
+//Internal organs
+MANTIDIFY_ORGAN(/obj/item/organ/internal/heart/insectoid/mantid)
+MANTIDIFY_ORGAN(/obj/item/organ/internal/stomach/insectoid/mantid)
+MANTIDIFY_ORGAN(/obj/item/organ/internal/lungs/insectoid/mantid)
+MANTIDIFY_ORGAN(/obj/item/organ/internal/liver/insectoid/mantid)
+MANTIDIFY_ORGAN(/obj/item/organ/internal/kidneys/insectoid/mantid)
+MANTIDIFY_ORGAN(/obj/item/organ/internal/brain/insectoid/mantid)
+MANTIDIFY_ORGAN(/obj/item/organ/internal/eyes/insectoid/mantid)
+#undef MANTIDIFY_ORGAN

--- a/mods/species/ascent/mobs/bodyparts.dm
+++ b/mods/species/ascent/mobs/bodyparts.dm
@@ -92,6 +92,7 @@
 //Basically appends the crystal flag to all the types specified
 #define MANTIDIFY_ORGAN(ORGAN_PATH) ##ORGAN_PATH/Initialize(){BP_SET_CRYSTAL(src) . = ..();}
 //External organs
+MANTIDIFY_ORGAN(/obj/item/organ/external/chest/insectoid/mantid)
 MANTIDIFY_ORGAN(/obj/item/organ/external/groin/insectoid/mantid)
 MANTIDIFY_ORGAN(/obj/item/organ/external/head/insectoid/mantid)
 MANTIDIFY_ORGAN(/obj/item/organ/external/arm/insectoid/mantid)

--- a/mods/species/bayliens/adherent/datum/species.dm
+++ b/mods/species/bayliens/adherent/datum/species.dm
@@ -108,6 +108,7 @@
 
 	move_trail = /obj/effect/decal/cleanable/blood/tracks/snake
 	max_players = 3
+	blood_volume = 0
 
 /decl/species/adherent/can_overcome_gravity(var/mob/living/carbon/human/H)
 	. = FALSE

--- a/mods/species/bayliens/adherent/datum/species.dm
+++ b/mods/species/bayliens/adherent/datum/species.dm
@@ -157,6 +157,3 @@
 		"id" =    list("loc" = ui_id,        "name" = "ID",       "slot" = slot_wear_id_str, "state" = "id"),
 		"belt" =  list("loc" = ui_belt,      "name" = "Belt",     "slot" = slot_belt_str,    "state" = "belt")
 	)
-
-/decl/species/adherent/post_organ_rejuvenate(var/obj/item/organ/org, var/mob/living/carbon/human/H)
-	org.status |= (ORGAN_BRITTLE|ORGAN_CRYSTAL|ORGAN_PROSTHETIC)

--- a/mods/species/bayliens/adherent/datum/species.dm
+++ b/mods/species/bayliens/adherent/datum/species.dm
@@ -98,7 +98,7 @@
 	)
 
 	has_organ = list(
-		BP_BRAIN =        /obj/item/organ/internal/brain/adherent,
+		BP_POSIBRAIN =    /obj/item/organ/internal/posibrain/adherent,
 		BP_EYES =         /obj/item/organ/internal/eyes/adherent,
 		BP_JETS =         /obj/item/organ/internal/powered/jets,
 		BP_FLOAT =        /obj/item/organ/internal/powered/float,

--- a/mods/species/bayliens/adherent/organs/organs_external.dm
+++ b/mods/species/bayliens/adherent/organs/organs_external.dm
@@ -1,3 +1,5 @@
+#define ADHERENT_LIMB_PROP_FLAG (ORGAN_PROP_PROSTHETIC | ORGAN_PROP_CRYSTAL) //Flag we use on all adherent limbs
+
 /obj/item/organ/external/chest/crystal
 	name =                    "tendril junction"
 	amputation_point =        "axis"
@@ -12,7 +14,7 @@
 	arterial_bleed_severity = 0
 	encased = "ceramic hull"
 	icon = 'mods/species/bayliens/adherent/icons/body_turquoise.dmi'
-	status = ORGAN_PROSTHETIC
+	organ_properties = ADHERENT_LIMB_PROP_FLAG
 	limb_flags = ORGAN_FLAG_CAN_BREAK | ORGAN_FLAG_HEALS_OVERKILL
 
 /obj/item/organ/external/chest/crystal/update_limb_icon_file()
@@ -26,7 +28,7 @@
 	min_broken_damage =       25
 	encased = "ceramic hull"
 	icon = 'mods/species/bayliens/adherent/icons/body_turquoise.dmi'
-	status = ORGAN_PROSTHETIC
+	organ_properties = ADHERENT_LIMB_PROP_FLAG
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_CAN_BREAK
 
 /obj/item/organ/external/groin/crystal/update_limb_icon_file()
@@ -43,7 +45,7 @@
 	cavity_max_w_class =      ITEM_SIZE_NORMAL // Apparently their brains change w_class to this.
 	encased = "ceramic hull"
 	icon = 'mods/species/bayliens/adherent/icons/body_turquoise.dmi'
-	status = ORGAN_PROSTHETIC
+	organ_properties = ADHERENT_LIMB_PROP_FLAG
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_HEALS_OVERKILL | ORGAN_FLAG_CAN_BREAK
 
 /obj/item/organ/external/head/crystal/update_limb_icon_file()
@@ -56,7 +58,7 @@
 	arterial_bleed_severity = 0
 	max_damage =              20
 	min_broken_damage =       10
-	status = ORGAN_PROSTHETIC
+	organ_properties = ADHERENT_LIMB_PROP_FLAG
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_CAN_BREAK
 
 /obj/item/organ/external/arm/crystal/update_limb_icon_file()
@@ -70,7 +72,7 @@
 	max_damage =              20
 	min_broken_damage =       10
 	icon = 'mods/species/bayliens/adherent/icons/body_turquoise.dmi'
-	status = ORGAN_PROSTHETIC
+	organ_properties = ADHERENT_LIMB_PROP_FLAG
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_CAN_BREAK
 
 /obj/item/organ/external/arm/right/crystal/update_limb_icon_file()
@@ -84,7 +86,7 @@
 	max_damage =              20
 	min_broken_damage =       10
 	icon = 'mods/species/bayliens/adherent/icons/body_turquoise.dmi'
-	status = ORGAN_PROSTHETIC
+	organ_properties = ADHERENT_LIMB_PROP_FLAG
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_CAN_BREAK
 
 /obj/item/organ/external/hand/crystal/update_limb_icon_file()
@@ -98,7 +100,7 @@
 	max_damage =              20
 	min_broken_damage =       10
 	icon = 'mods/species/bayliens/adherent/icons/body_turquoise.dmi'
-	status = ORGAN_PROSTHETIC
+	organ_properties = ADHERENT_LIMB_PROP_FLAG
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_CAN_BREAK
 
 /obj/item/organ/external/hand/right/crystal/update_limb_icon_file()
@@ -115,7 +117,7 @@
 	max_damage =              20
 	min_broken_damage =       10
 	icon = 'mods/species/bayliens/adherent/icons/body_turquoise.dmi'
-	status = ORGAN_PROSTHETIC
+	organ_properties = ADHERENT_LIMB_PROP_FLAG
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_CAN_BREAK
 
 /obj/item/organ/external/tendril/update_limb_icon_file()
@@ -135,3 +137,5 @@
 	name =                    "fourth tendril"
 	icon_name =               "r_foot"
 	organ_tag =               BP_R_FOOT
+
+#undef ADHERENT_LIMB_PROP_FLAG

--- a/mods/species/bayliens/adherent/organs/organs_internal.dm
+++ b/mods/species/bayliens/adherent/organs/organs_internal.dm
@@ -1,6 +1,6 @@
 #define PROTOCOL_ARTICLE "Protocol article [rand(100,999)]-[uppertext(pick(global.alphabet))] subsection #[rand(10,99)]"
 
-/obj/item/organ/internal/brain/adherent
+/obj/item/organ/internal/posibrain/adherent
 	name = "mentality matrix"
 	desc = "The self-contained, self-supporting internal 'brain' of an Adherent unit."
 	icon = 'mods/species/bayliens/adherent/icons/organs.dmi'
@@ -10,13 +10,17 @@
 	var/next_rename
 	var/rename_delay = 15 MINUTES
 
-/obj/item/organ/internal/brain/adherent/refresh_action_button()
+/obj/item/organ/internal/posibrain/adherent/Initialize()
+	BP_SET_CRYSTAL(src)
+	. = ..()
+
+/obj/item/organ/internal/posibrain/adherent/refresh_action_button()
 	. = ..()
 	if(.)
 		action.button_icon_state = "adherent-brain"
 		if(action.button) action.button.UpdateIcon()
 
-/obj/item/organ/internal/brain/adherent/attack_self(var/mob/user)
+/obj/item/organ/internal/posibrain/adherent/attack_self(var/mob/user)
 	. = ..()
 	if(.)
 

--- a/mods/species/bayliens/adherent/organs/organs_internal.dm
+++ b/mods/species/bayliens/adherent/organs/organs_internal.dm
@@ -114,6 +114,7 @@
 
 /obj/item/organ/internal/eyes/adherent
 	name = "receptor prism"
+	prosthetic_name = null //We don't replace the name when we're a prosthetic
 	icon = 'mods/species/bayliens/adherent/icons/organs.dmi'
 	eye_icon = 'mods/species/bayliens/adherent/icons/eyes.dmi'
 	icon_state = "eyes"

--- a/mods/species/bayliens/adherent/organs/organs_internal.dm
+++ b/mods/species/bayliens/adherent/organs/organs_internal.dm
@@ -45,6 +45,7 @@
 
 /obj/item/organ/internal/powered
 	icon = 'mods/species/bayliens/adherent/icons/organs.dmi'
+	organ_properties = ORGAN_PROP_PROSTHETIC | ORGAN_PROP_CRYSTAL
 	var/maintenance_cost = 1
 	var/base_action_state
 	var/active = FALSE
@@ -116,7 +117,7 @@
 	icon = 'mods/species/bayliens/adherent/icons/organs.dmi'
 	eye_icon = 'mods/species/bayliens/adherent/icons/eyes.dmi'
 	icon_state = "eyes"
-	status = ORGAN_PROSTHETIC
+	organ_properties = ORGAN_PROP_PROSTHETIC | ORGAN_PROP_CRYSTAL
 	contaminant_guard = TRUE
 	innate_flash_protection = FLASH_PROTECTION_MAJOR
 

--- a/mods/species/utility_frames/limbs.dm
+++ b/mods/species/utility_frames/limbs.dm
@@ -8,3 +8,9 @@
 	modular_prosthetic_tier = MODULAR_BODYPART_CYBERNETIC
 
 DEFINE_ROBOLIMB_DESIGNS(/decl/prosthetics_manufacturer/utility_frame, utility_frame)
+
+/obj/item/organ/external/head/utility_frame
+	glowing_eyes = TRUE
+
+ /obj/item/organ/internal/eyes/robot/utility_frame
+	eye_icon = 'mods/species/utility_frames/icons/eyes.dmi'

--- a/mods/species/utility_frames/limbs.dm
+++ b/mods/species/utility_frames/limbs.dm
@@ -12,5 +12,5 @@ DEFINE_ROBOLIMB_DESIGNS(/decl/prosthetics_manufacturer/utility_frame, utility_fr
 /obj/item/organ/external/head/utility_frame
 	glowing_eyes = TRUE
 
- /obj/item/organ/internal/eyes/robot/utility_frame
+/obj/item/organ/internal/eyes/robot/utility_frame
 	eye_icon = 'mods/species/utility_frames/icons/eyes.dmi'

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -73,16 +73,6 @@
 	)
 
 /decl/species/utility_frame/post_organ_rejuvenate(obj/item/organ/org, mob/living/carbon/human/H)
-	var/obj/item/organ/external/E = org
-	if(istype(E) && !BP_IS_PROSTHETIC(E))
-		E.robotize(/decl/prosthetics_manufacturer/utility_frame)
-	var/obj/item/organ/external/head/head = org
-	if(istype(head))
-		head.glowing_eyes = TRUE
-	var/obj/item/organ/internal/eyes/eyes = org
-	if(istype(eyes))
-		eyes.eye_icon = 'mods/species/utility_frames/icons/eyes.dmi'
-	H.refresh_visible_overlays()
 
 /decl/species/utility_frame/disfigure_msg(var/mob/living/carbon/human/H)
 	. = SPAN_DANGER("The faceplate is dented and cracked!\n")

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -36,7 +36,7 @@
 	body_temperature =      null
 	passive_temp_gain =     5  // stabilize at ~80 C in a 20 C environment.
 	heat_discomfort_level = 373.15
-	blood_volume = 0 //Could have been oil, but make_blood clears blood whe there'sn no heart
+	blood_volume = 0
 
 	base_color = "#333355"
 	base_eye_color = "#00ccff"

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -36,6 +36,7 @@
 	body_temperature =      null
 	passive_temp_gain =     5  // stabilize at ~80 C in a 20 C environment.
 	heat_discomfort_level = 373.15
+	blood_volume = 0 //Could have been oil, but make_blood clears blood whe there'sn no heart
 
 	base_color = "#333355"
 	base_eye_color = "#00ccff"

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -63,7 +63,8 @@
 	)
 	has_organ = list(
 		BP_POSIBRAIN = /obj/item/organ/internal/posibrain,
-		BP_EYES = /obj/item/organ/internal/eyes/robot/utility_frame, //Eyes got a different icon file 
+		BP_EYES      = /obj/item/organ/internal/eyes/robot/utility_frame, //Eyes got a different icon file 
+		BP_CELL      = /obj/item/organ/internal/cell,
 	)
 	override_limb_types = list(
 		BP_HEAD = /obj/item/organ/external/head/utility_frame, //Needed for glowing eyes shennanigans

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -62,7 +62,10 @@
 	)
 	has_organ = list(
 		BP_POSIBRAIN = /obj/item/organ/internal/posibrain,
-		BP_EYES = /obj/item/organ/internal/eyes/robot
+		BP_EYES = /obj/item/organ/internal/eyes/robot/utility_frame, //Eyes got a different icon file 
+	)
+	override_limb_types = list(
+		BP_HEAD = /obj/item/organ/external/head/utility_frame, //Needed for glowing eyes shennanigans
 	)
 
 	exertion_effect_chance = 10
@@ -73,6 +76,7 @@
 	)
 
 /decl/species/utility_frame/post_organ_rejuvenate(obj/item/organ/org, mob/living/carbon/human/H)
+	org.robotize(/decl/prosthetics_manufacturer/utility_frame) //utility frames are 100% robot guaranteed
 
 /decl/species/utility_frame/disfigure_msg(var/mob/living/carbon/human/H)
 	. = SPAN_DANGER("The faceplate is dented and cracked!\n")

--- a/mods/species/vox/organs_vox.dm
+++ b/mods/species/vox/organs_vox.dm
@@ -153,7 +153,7 @@
 	parent_organ = BP_HEAD
 	icon_state = "cortical-stack"
 	organ_tag = BP_STACK
-	status = ORGAN_PROSTHETIC
+	organ_properties = ORGAN_PROP_PROSTHETIC
 	vital = 1
 	origin_tech = @"{'biotech':4,'materials':4,'magnets':2,'programming':3}"
 	relative_size = 10


### PR DESCRIPTION
## Description of changes
The main fix is preventing adherents from dying instantly on spawn from the main screen.
That in turn required changing how organ properties are kept on organs.
Which in turn meant I had to define some subtypes for some races not behaving like everything else.

Moved organ properties such as prosthetic, assisted and crystal into their own var instead of being stored into the organ status flag to avoid complications with having to constantly approximately restoring the original state in post-rejuv.

Just made limbs overrides for the mantid to set their property to crystal, since not everything in the mob is crystaline.
Also made sub-types for the head and eyes of utility frames to set their glowing eye and eye icon instead of doing it in post-rejuv.

## Changelog
:cl:
fix: Adherents no longer die immediately on spawn.
fix: No more random runtime spam with some backpacks. 
fix: Synthetic races now properly show they don't have blood on the health scanner.
fix: Fixed some synthetic eyes not having the right icon or name.
/:cl:
