### PR TITLE
Moving exoplanet building to SSmapping.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -248,14 +248,14 @@ var/global/list/gamemode_cache = list()
 
 	var/lock_client_view_x
 	var/lock_client_view_y
-	var/max_client_view_x
-	var/max_client_view_y
+	var/max_client_view_x = MAX_VIEW
+	var/max_client_view_y = MAX_VIEW
 
 	var/allow_diagonal_movement = FALSE
 
 	var/no_throttle_localhost
 
-	var/dex_malus_brainloss_threshold = 30 //The threshold of when brainloss begins to affect dexterity. 
+	var/dex_malus_brainloss_threshold = 30 //The threshold of when brainloss begins to affect dexterity.
 
 	var/static/list/protected_vars = list(
 		"comms_password",

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -36,6 +36,9 @@ SUBSYSTEM_DEF(mapping)
 	// Build away sites.
 	global.using_map.build_away_sites()
 
+	// Build exoplanet
+	global.using_map.build_exoplanets()
+
 	. = ..()
 
 /datum/controller/subsystem/mapping/Recover()
@@ -65,7 +68,7 @@ SUBSYSTEM_DEF(mapping)
 		PRINT_STACK_TRACE("Duplicate map name '[map_template.name]' on type [map_template.type]!")
 		return FALSE
 	return TRUE
-	
+
 /datum/controller/subsystem/mapping/proc/get_all_template_instances()
 	. = list()
 	for(var/template_type in subtypesof(/datum/map_template))

--- a/code/controllers/subsystems/misc_late.dm
+++ b/code/controllers/subsystems/misc_late.dm
@@ -5,7 +5,6 @@ SUBSYSTEM_DEF(misc_late)
 	flags = SS_NO_FIRE
 
 /datum/controller/subsystem/misc_late/Initialize()
-	global.using_map.build_exoplanets()
 	var/decl/asset_cache/asset_cache = GET_DECL(/decl/asset_cache)
 	asset_cache.load()
 	. = ..()

--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -86,6 +86,9 @@
 /atom/proc/EarlyDestroy(force = FALSE)
 	return QDEL_HINT_QUEUE
 
+/atom/movable/EarlyDestroy(force)
+	loc = null // Do this without forceMove to avoid event triggering.
+	return ..()
 
 // Movable level stuff
 

--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -93,12 +93,9 @@
 	if(length(possible_strata))
 		crust_strata = pick(possible_strata)
 
-/obj/effect/overmap/visitable/sector/exoplanet/Initialize(mapload, z_level)
-	if(global.overmaps_by_name[overmap_id])
-		forceMove(locate(1, 1, z_level))
-	return ..()
-
 /obj/effect/overmap/visitable/sector/exoplanet/proc/build_level(max_x, max_y)
+
+	find_z_levels()
 
 	maxx = max_x || world.maxx
 	maxy = max_y || world.maxy

--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -100,8 +100,8 @@
 
 /obj/effect/overmap/visitable/sector/exoplanet/proc/build_level(max_x, max_y)
 
-	maxx = max_x ? max_x : world.maxx
-	maxy = max_y ? max_y : world.maxy
+	maxx = max_x || world.maxx
+	maxy = max_y || world.maxy
 	x_origin = TRANSITIONEDGE + 1
 	y_origin = TRANSITIONEDGE + 1
 	x_size = maxx - 2 * (TRANSITIONEDGE + 1)

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -98,7 +98,11 @@ var/global/list/known_overmap_sectors
 			initial_restricted_waypoints[shuttle_type] = new_restricted
 
 /obj/effect/overmap/visitable/proc/move_to_starting_location()
+
 	var/datum/overmap/overmap = global.overmaps_by_name[overmap_id]
+	if(!overmap)
+		return
+
 	var/location
 
 	if(start_x && start_y)

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -100,9 +100,6 @@ var/global/list/known_overmap_sectors
 /obj/effect/overmap/visitable/proc/move_to_starting_location()
 
 	var/datum/overmap/overmap = global.overmaps_by_name[overmap_id]
-	if(!overmap)
-		return
-
 	var/location
 
 	if(start_x && start_y)

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -29,7 +29,7 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	var/list/player_levels =  list() // Z-levels a character can typically reach
 	var/list/sealed_levels =  list() // Z-levels that don't allow random transit at edge
 
-	var/list/map_levels              // Z-levels available to various consoles, such as the crew monitor. Defaults to station_levels if unset.
+	var/list/map_levels =     list() // Z-levels available to various consoles, such as the crew monitor. Defaults to station_levels if unset.
 
 	var/list/base_turf_by_z = list() // Custom base turf by Z-level. Defaults to world.turf for unlisted Z-levels
 
@@ -195,8 +195,7 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 		allowed_spawns -= spawn_type
 		allowed_spawns += GET_DECL(spawn_type)
 
-	if(!map_levels)
-		map_levels = station_levels.Copy()
+	map_levels |= station_levels.Copy()
 
 	if(!LAZYLEN(planet_size))
 		planet_size = list(world.maxx, world.maxy)
@@ -260,6 +259,7 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 		var/exoplanet_type = pick_exoplanet()
 		INCREMENT_WORLD_Z_SIZE
 		var/obj/effect/overmap/visitable/sector/exoplanet/new_planet = new exoplanet_type(null, world.maxz)
+		new_planet.map_z = GetConnectedZlevels(world.maxz)
 		new_planet.build_level(planet_size[1], planet_size[2])
 
 /datum/map/proc/pick_exoplanet()

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -195,7 +195,7 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 		allowed_spawns -= spawn_type
 		allowed_spawns += GET_DECL(spawn_type)
 
-	map_levels |= station_levels.Copy()
+	map_levels |= station_levels
 
 	if(!LAZYLEN(planet_size))
 		planet_size = list(world.maxx, world.maxy)
@@ -258,8 +258,7 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	for(var/i = 0, i < num_exoplanets, i++)
 		var/exoplanet_type = pick_exoplanet()
 		INCREMENT_WORLD_Z_SIZE
-		var/obj/effect/overmap/visitable/sector/exoplanet/new_planet = new exoplanet_type(null, world.maxz)
-		new_planet.map_z = GetConnectedZlevels(world.maxz)
+		var/obj/effect/overmap/visitable/sector/exoplanet/new_planet = new exoplanet_type(locate(1, 1, world.maxz))
 		new_planet.build_level(planet_size[1], planet_size[2])
 
 /datum/map/proc/pick_exoplanet()

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -47,7 +47,7 @@ exactly 3 "unmarked globally scoped variables" -P '^(/|)var/(?!global)'
 exactly 0 "global-marked member variables" -P '\t(/|)var.*/global/.+'
 exactly 0 "static-marked globally scoped variables" -P '^(/|)var.*/static/.+'
 exactly 1 "direct usage of decls_repository.get_decl()" 'decls_repository\.get_decl\('
-exactly 18 "direct loc set" -P '(\t|;|\.)loc\s*=(?!=)'
+exactly 19 "direct loc set" -P '(\t|;|\.)loc\s*=(?!=)'
 
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 


### PR DESCRIPTION
## Description of changes
Moves exoplanet generation down to pre-SSatoms alongside the other away site and map template based init behaviors.

## Why and what will this PR improve
Centralizes map loading logic and minimizes potential for ordering problems.

## Authorship
Myself.

## Changelog
Nothing player-facing.