### PR TITLE
Comments out waitfor=FALSE in submap template load.

### DIFF
--- a/code/modules/maps/helper_landmarks.dm
+++ b/code/modules/maps/helper_landmarks.dm
@@ -15,7 +15,9 @@
 	. = LAZYLEN(map_template_names) && pick(map_template_names)
 
 /obj/abstract/landmark/map_load_mark/proc/load_subtemplate()
-	set waitfor = FALSE
+	// Commenting this out temporarily as DMMS breaks when asychronously
+	// loading overlapping map templates. TODO: more robust queuing behavior
+	//set waitfor = FALSE
 
 	var/datum/map_template/template = get_subtemplate()
 	var/turf/spawn_loc = get_turf(src)


### PR DESCRIPTION
## Description of changes
Temporary workaround for a problem I introduced with the SSmapping rework.

## Why and what will this PR improve
Stops an assert failing due to overlapping map template loads.

## Authorship
@afterthought2 pointed out the issue.

## Changelog
Nothing player-facing.