### PR TITLE
Clothing with storage can be picked up now

### DIFF
--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -63,7 +63,7 @@
 			if(pocket == master_item && !H.get_active_hand())
 				H.unEquip(master_item)
 				H.put_in_hands(master_item)
-			return FALSE
+				return FALSE
 
 	src.add_fingerprint(user)
 	if (master_item.loc == user)

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -13,7 +13,7 @@
 
 /obj/item/clothing/suit/storage/attack_hand(mob/user)
 	if (pockets.handle_attack_hand(user))
-		..(user)
+		. = ..(user)
 
 /obj/item/clothing/suit/storage/handle_mouse_drop(atom/over, mob/user)
 	. = pockets?.handle_storage_internal_mouse_drop(user, over) && ..()


### PR DESCRIPTION
## Description of changes
A bad indentation caused clothing with storage pockets to become impossible to pick back up.

## Changelog
:cl:
fix: Clothing with internal pockets can be picked up again.
/:cl: