### PR TITLE
Fix backpack runtime

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -66,7 +66,7 @@
 			add_clothing_protection(mask)
 
 		var/obj/item/rig/rig = get_equipped_item(slot_back_str)
-		if(rig)
+		if(istype(rig))
 			process_rig(rig)
 
 /mob/living/carbon/human/proc/process_glasses(var/obj/item/clothing/glasses/G)


### PR DESCRIPTION
## Description of changes
The typecheck on rigs when updating vision was apparently removed, which resulted in the game trying to access non-existent variables on whatever was in the back slot under some circumstances.

Fix #2526

## Changelog
:cl:
fix: Fixes runtimes on the game somtimes treating backpacks as a rig.
/:cl:
