### PR TITLE
Fix dropping inventory on species change

### DIFF
--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -456,7 +456,7 @@ var/global/list/slot_flags_enumeration = list(
 //Set disable_warning to 1 if you wish it to not give you outputs.
 //Should probably move the bulk of this into mob code some time, as most of it is related to the definition of slots and not item-specific
 //set force to ignore blocking overwear and occupied slots
-/obj/item/proc/mob_can_equip(M, slot, disable_warning = 0, force = 0)
+/obj/item/proc/mob_can_equip(M, slot, disable_warning = FALSE, force = FALSE)
 
 	if(!slot || !M || !ishuman(M))
 		return FALSE

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -128,7 +128,7 @@
 	if(markings_color && markings_icon)
 		update_icon()
 
-/obj/item/clothing/mob_can_equip(mob/living/M, slot, disable_warning = 0)
+/obj/item/clothing/mob_can_equip(mob/living/M, slot, disable_warning = FALSE, force = FALSE)
 	. = ..()
 	if(. && !isnull(bodytype_equip_flags) && ishuman(M) && !(slot in list(slot_l_store_str, slot_r_store_str, slot_s_store_str)) && !(slot in M.held_item_slots))
 		var/mob/living/carbon/human/H = M

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -722,9 +722,9 @@
 
 	//recheck species-restricted clothing
 	for(var/slot in global.all_inventory_slots)
-		var/obj/item/clothing/C = get_equipped_item(slot)
+		var/obj/item/C = get_equipped_item(slot)
 		if(istype(C) && !C.mob_can_equip(src, slot, TRUE, TRUE))
-			unEquip(C)
+			drop_from_inventory(C)
 
 //This handles actually updating our visual appearance
 // Triggers deep update of limbs and hud


### PR DESCRIPTION
## Description of changes
Now everything in non-existent slots gets dropped.

The old proc was dropping exclusively clothing, and it would obey user inventory access rules, which made some things undroppable. 

## Changelog
:cl:
fix: Fixed items staying in non-existent inventory slots when changing species.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->