### PR TITLE
Add missing cell organ to utility frame

### DIFF
--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -8,7 +8,7 @@
 		"nearing end-of-life" = 16,
 		"entirely obsolete" =   20
 	)
-	
+
 /decl/species/utility_frame
 	name =                  SPECIES_FRAME
 	name_plural =           "Utility Frames"
@@ -62,7 +62,8 @@
 	)
 	has_organ = list(
 		BP_POSIBRAIN = /obj/item/organ/internal/posibrain,
-		BP_EYES = /obj/item/organ/internal/eyes/robot
+		BP_EYES      = /obj/item/organ/internal/eyes/robot,
+		BP_CELL      = /obj/item/organ/internal/cell,
 	)
 
 	exertion_effect_chance = 10


### PR DESCRIPTION
## Description of changes
Add missing cell organ to utility frame

## Why and what will this PR improve
Battery good.

## Changelog
:cl:
fix: Fixed utility frames not spawning with a power cell organ.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->