### PR TITLE
Fix species with no blood [IDB IGNORE] [MDB IGNORE]

### DIFF
--- a/code/_helpers/medical_scans.dm
+++ b/code/_helpers/medical_scans.dm
@@ -178,22 +178,26 @@
 			dat+= "<tr><td colspan='2'><span class='average'>Patient is bradycardic.</span></td></tr>"
 
 
-	var/ratio = scan["blood_volume"]/scan["blood_volume_max"]
-	dat += "<tr><td><strong>Blood pressure:</strong></td><td>[scan["blood_pressure"]]"
-	if(scan["blood_o2"] <= 70)
-		dat += "(<span class='bad'>[scan["blood_o2"]]% blood oxygenation</span>)</td></tr>"
-	else if(scan["blood_o2"] <= 85)
-		dat += "(<span class='average'>[scan["blood_o2"]]% blood oxygenation</span>)</td></tr>"
-	else if(scan["blood_o2"] <= 90)
-		dat += "(<span class='oxyloss'>[scan["blood_o2"]]% blood oxygenation</span>)</td></tr>"
-	else
-		dat += "([scan["blood_o2"]]% blood oxygenation)</td></tr>"
+	if(scan["blood_volume_max"] > 0)
+		var/ratio = scan["blood_volume"]/scan["blood_volume_max"]
+		dat += "<tr><td><strong>Blood pressure:</strong></td><td>[scan["blood_pressure"]]"
+		if(scan["blood_o2"] <= 70)
+			dat += "(<span class='bad'>[scan["blood_o2"]]% blood oxygenation</span>)</td></tr>"
+		else if(scan["blood_o2"] <= 85)
+			dat += "(<span class='average'>[scan["blood_o2"]]% blood oxygenation</span>)</td></tr>"
+		else if(scan["blood_o2"] <= 90)
+			dat += "(<span class='oxyloss'>[scan["blood_o2"]]% blood oxygenation</span>)</td></tr>"
+		else
+			dat += "([scan["blood_o2"]]% blood oxygenation)</td></tr>"
 
-	dat += "<tr><td><strong>Blood volume:</strong></td><td>[scan["blood_volume"]]u/[scan["blood_volume_max"]]u</td></tr>"
+		dat += "<tr><td><strong>Blood volume:</strong></td><td>[scan["blood_volume"]]u/[scan["blood_volume_max"]]u</td></tr>"
 
-	if(skill_level >= SKILL_ADEPT)
-		if(ratio <= 0.70)
-			dat += "<tr><td colspan='2'><span class='bad'>Patient is in Hypovolemic Shock. Transfusion highly recommended.</span></td></tr>"
+		if(skill_level >= SKILL_ADEPT)
+			if(ratio <= 0.70)
+				dat += "<tr><td colspan='2'><span class='bad'>Patient is in Hypovolemic Shock. Transfusion highly recommended.</span></td></tr>"
+	else 
+		dat += "<tr><td><strong>Blood pressure:</strong></td><td><span class='average'>ERROR - Patient has lacks a circulatory system.</span></td></tr>"
+		dat += "<tr><td><strong>Blood volume:</strong></td><td><span class='average'>ERROR - Patient has lacks a circulatory system.</span></td></tr>"
 
 	// Body temperature.
 	/*

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -35,6 +35,7 @@
 
 	if(!should_have_organ(BP_HEART))
 		vessel.clear_reagents()
+		vessel.maximum_volume = 0
 		return
 
 	if(vessel.total_volume < species.blood_volume)

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -162,6 +162,8 @@
 
 //Transfers blood from container ot vessels
 /mob/living/carbon/proc/inject_blood(var/amount, var/datum/reagents/donor)
+	if(!species.blood_volume)
+		return //Don't divide by 0
 	var/injected_data = REAGENT_DATA(donor, species.blood_reagent)
 	var/chems = LAZYACCESS(injected_data, "trace_chem")
 	for(var/C in chems)
@@ -285,7 +287,7 @@
 
 //Percentage of maximum blood volume.
 /mob/living/carbon/human/proc/get_blood_volume()
-	return round((vessel.total_volume/species.blood_volume)*100)
+	return species.blood_volume? round((vessel.total_volume/species.blood_volume)*100) : 0
 
 //Percentage of maximum blood volume, affected by the condition of circulation organs
 /mob/living/carbon/human/proc/get_blood_circulation()

--- a/mods/species/adherent/datum/species.dm
+++ b/mods/species/adherent/datum/species.dm
@@ -108,6 +108,7 @@
 
 	move_trail = /obj/effect/decal/cleanable/blood/tracks/snake
 	max_players = 3
+	blood_volume = 0
 
 /decl/species/adherent/can_overcome_gravity(var/mob/living/carbon/human/H)
 	. = FALSE

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -36,7 +36,7 @@
 	body_temperature =      null
 	passive_temp_gain =     5  // stabilize at ~80 C in a 20 C environment.
 	heat_discomfort_level = 373.15
-	blood_volume = 0 //Could have been oil, but make_blood clears blood whe there'sn no heart
+	blood_volume = 0
 
 	base_color = "#333355"
 	base_eye_color = "#00ccff"

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -36,6 +36,7 @@
 	body_temperature =      null
 	passive_temp_gain =     5  // stabilize at ~80 C in a 20 C environment.
 	heat_discomfort_level = 373.15
+	blood_volume = 0 //Could have been oil, but make_blood clears blood whe there'sn no heart
 
 	base_color = "#333355"
 	base_eye_color = "#00ccff"


### PR DESCRIPTION
## Description of changes
Human mobs with no blood don't show up as if they lost all their blood on the health scanner.

## Changelog
:cl:
fix: Species with no circulatory system now properly say so in the health scanner report, and don't show up as being in shock constantly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->