### PR TITLE
Fixed R-UST radiation leaks on Tradeship map

### DIFF
--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -4262,6 +4262,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/window/borosilicate_reinforced{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/engine/aft)
 "kR" = (
@@ -4289,6 +4292,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/window/borosilicate_reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/engine/aft)
 "lu" = (
@@ -4333,6 +4339,9 @@
 	dir = 5
 	},
 /obj/machinery/meter,
+/obj/structure/window/borosilicate_reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/engine/aft)
 "me" = (
@@ -6744,6 +6753,9 @@
 "TB" = (
 /obj/machinery/atmospherics/valve/open{
 	dir = 4
+	},
+/obj/structure/window/borosilicate_reinforced{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/engine/aft)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Added reinforced borosilicate windows to the corners of the shield around the R-UST
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
Stops the R-UST from leaking radiation at the corners.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Qumefox
<!-- Describe original authors of changes to credit them. -->

## Changelog
:cl:
fix: Radiation leaks on the R-UST
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->