### PR TITLE
Fixes setting IDs on network devices

### DIFF
--- a/code/modules/modular_computers/networking/device_types/_network_device.dm
+++ b/code/modules/modular_computers/networking/device_types/_network_device.dm
@@ -132,7 +132,7 @@
 /datum/extension/network_device/proc/set_new_id(new_id, user)
 	var/list/networks = get_nearby_networks()
 	if(new_id in networks)
-		if(!SSnetworking[network_id]) // old network is down, so we should unqueue from its reconnect list
+		if(!SSnetworking.networks[network_id]) // old network is down, so we should unqueue from its reconnect list
 			SSnetworking.unqueue_reconnect(src, network_id)
 		disconnect()
 		network_id = new_id


### PR DESCRIPTION
## Description of changes
Fixes a runtime caused when setting IDs on network devices, preventing connection to networks that were not connected automatically.

## Authorship
Myself.

## Changelog
:cl:
fix: Fixed a bug preventing network devices from changing network IDs.
/:cl: