### PR TITLE
Minimal support for mutable areas.

### DIFF
--- a/code/datums/repositories/areas.dm
+++ b/code/datums/repositories/areas.dm
@@ -1,15 +1,9 @@
 var/global/repository/area/area_repository = new()
 
 /repository/area
-	var/list/by_name_coords_cache_data
-	var/list/by_name_cache_data
-	var/list/by_z_level_cache_data
-
-/repository/area/New()
-	by_name_coords_cache_data = list()
-	by_name_cache_data        = list()
-	by_z_level_cache_data     = list()
-	..()
+	var/list/by_name_coords_cache_data = list()
+	var/list/by_name_cache_data        = list()
+	var/list/by_z_level_cache_data     = list()
 
 /repository/area/proc/get_areas_by_name(var/list/area_predicates = /proc/is_not_space_area)
 	return priv_get_cached_areas(by_name_cache_data, /proc/group_areas_by_z_level, area_predicates, /proc/get_area_proper_name)
@@ -51,3 +45,9 @@ var/global/repository/area/area_repository = new()
 	var/datum/cache_entry/cache_entry = cache_data[key]
 	cache_entry.timestamp = world.time + 3 MINUTES
 	cache_entry.data = data
+
+/repository/area/proc/clear_cache()
+	for(var/list/L in list(by_name_coords_cache_data, by_name_cache_data, by_z_level_cache_data))
+		for(var/key in L)
+			qdel(L[key])
+		L.Cut()

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -82,12 +82,20 @@ var/global/list/areas = list()
 	icon_state = "white"
 	blend_mode = BLEND_MULTIPLY
 
-/area/Del()
-	global.areas -= src
-	. = ..()
+// qdel(area) should not be attempted on an area with turfs in contents. ChangeArea every turf in it first.
 
 /area/Destroy()
 	global.areas -= src
+	var/failure = FALSE
+	for(var/atom/A in contents)
+		if(isturf(A))
+			failure = TRUE
+			contents.Remove(A) // note: A.loc == null after this
+		else
+			qdel(A)
+	if(failure)
+		PRINT_STACK_TRACE("Area [log_info_line(src)] was qdeleted with turfs in contents.")
+	area_repository.clear_cache()
 	..()
 	return QDEL_HINT_HARDDEL
 

--- a/code/game/machinery/_machines_base/machinery_power.dm
+++ b/code/game/machinery/_machines_base/machinery_power.dm
@@ -107,12 +107,15 @@ This is /obj/machinery level code to properly manage power usage from the area.
 /obj/machinery/proc/update_power_on_move(atom/movable/mover, atom/old_loc, atom/new_loc)
 	area_changed(get_area(old_loc), get_area(new_loc))
 
+// An event that should be accurately triggered whenever our area changes. Returns TRUE if area changed and we have completed init, FALSE otherwise.
 /obj/machinery/proc/area_changed(area/old_area, area/new_area)
+	SHOULD_CALL_PARENT(TRUE)
 	if(!power_init_complete)
-		return // this is possible if called externally
+		return FALSE // this is possible if called externally
 
 	if(old_area == new_area)
-		return
+		return FALSE
+	. = TRUE
 	var/power = get_power_usage()
 	if(!power)
 		return // This is the most likely case anyway.

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -79,6 +79,7 @@
 	var/screen = AALARM_SCREEN_MAIN
 	var/area_uid
 	var/area/alarm_area
+	var/custom_alarm_name
 
 	var/target_temperature = T0C+20
 	var/regulating_temperature = 0
@@ -128,19 +129,19 @@
 	. = ..()
 
 /obj/machinery/alarm/Destroy()
-	events_repository.unregister(/decl/observ/name_set, get_area(src), src, .proc/change_area_name)
+	reset_area(alarm_area, null)
 	unregister_radio(src, frequency)
 	return ..()
 
 /obj/machinery/alarm/Initialize(mapload, var/dir)
 	. = ..()
+	if (name != "alarm")
+		custom_alarm_name = TRUE // this will prevent us from messing with alarms with names set on map
 
-	alarm_area = get_area(src)
+	set_frequency(frequency)
+	reset_area(null, get_area(src))
 	if(!alarm_area)
 		return // spawned in nullspace, presumably as a prototype for construction purposes.
-	area_uid = alarm_area.uid
-	if (name == "alarm")
-		SetName("[alarm_area.proper_name] Air Alarm")
 
 	// breathable air according to human/Life()
 	TLV[/decl/material/gas/oxygen] =			list(16, 19, 135, 140) // Partial pressure, kpa
@@ -154,10 +155,6 @@
 		if(!env_info.important_gasses[g])
 			trace_gas += g
 
-	events_repository.register(/decl/observ/name_set, alarm_area, src, .proc/change_area_name)
-	set_frequency(frequency)
-	for(var/device_tag in alarm_area.air_scrub_names + alarm_area.air_vent_names)
-		send_signal(device_tag, list()) // ask for updates; they initialized before us and we didn't get the data
 	queue_icon_update()
 
 /obj/machinery/alarm/modify_mapped_vars(map_hash)
@@ -790,9 +787,31 @@
 	return ..()
 
 /obj/machinery/alarm/proc/change_area_name(var/area/A, var/old_area_name, var/new_area_name)
-	if(A != get_area(src))
+	if(A != alarm_area)
 		return
-	SetName(replacetext(name,old_area_name,new_area_name))
+	if (!custom_alarm_name)
+		SetName("[A.proper_name] Air Alarm")
+
+/obj/machinery/alarm/area_changed(area/old_area, area/new_area)
+	. = ..()
+	if(.)
+		reset_area(old_area, new_area)
+
+/obj/machinery/alarm/proc/reset_area(area/old_area, area/new_area)
+	if(old_area == new_area)
+		return
+	if(old_area && old_area == alarm_area)
+		alarm_area = null
+		area_uid = null
+		events_repository.register(/decl/observ/name_set, old_area, src, .proc/change_area_name)
+	if(new_area)
+		ASSERT(isnull(alarm_area))
+		alarm_area = new_area
+		area_uid = new_area.uid
+		change_area_name(alarm_area, null, alarm_area.name)
+		events_repository.register(/decl/observ/name_set, alarm_area, src, .proc/change_area_name)
+		for(var/device_tag in alarm_area.air_scrub_names + alarm_area.air_vent_names)
+			send_signal(device_tag, list()) // ask for updates; they initialized before us and we didn't get the data
 
 /*
 FIRE ALARM

--- a/code/modules/alarm/alarm.dm
+++ b/code/modules/alarm/alarm.dm
@@ -13,6 +13,10 @@
 	start_time = world.time
 	source_name = source.get_source_name()
 
+/datum/alarm_source/Destroy()
+	source = null
+	. = ..()
+
 /datum/alarm
 	var/atom/origin					//Used to identify the alarm area.
 	var/list/sources = new()		//List of sources triggering the alarm. Used to determine when the alarm should be cleared.
@@ -61,6 +65,7 @@
 	var/datum/alarm_source/AS = sources_assoc[source]
 	sources -= AS
 	sources_assoc -= source
+	qdel(source)
 
 /datum/alarm/proc/alarm_z()
 	if(origin)

--- a/code/modules/atmospherics/components/unary/unary_base.dm
+++ b/code/modules/atmospherics/components/unary/unary_base.dm
@@ -7,6 +7,9 @@
 	var/datum/gas_mixture/air_contents
 	pipe_class = PIPE_CLASS_UNARY
 
+	// code sharing between scrubbers and vents
+	var/controlled = TRUE	// if true, report to air alarm, if false, probably in direct contact with something else by radio (e.g. airlocks)
+
 /obj/machinery/atmospherics/unary/get_single_monetary_worth()
 	. = ..()
 	for(var/gas in air_contents?.gas)
@@ -17,6 +20,12 @@
 /obj/machinery/atmospherics/unary/Initialize()
 	air_contents = new
 	air_contents.volume = 200
+	if(controlled)
+		reset_area(null, get_area(src))
+	. = ..()
+
+/obj/machinery/atmospherics/unary/Destroy()
+	reset_area(get_area(src), null)
 	. = ..()
 
 /obj/machinery/atmospherics/unary/get_mass()
@@ -36,3 +45,11 @@
 	for(var/node in nodes_to_networks)
 		if(nodes_to_networks[node] == reference)
 			return list(air_contents)
+
+/obj/machinery/atmospherics/unary/area_changed(area/old_area, area/new_area)
+	. = ..()
+	if(. && controlled)
+		reset_area(old_area, new_area)
+		toggle_input_toggle() // this sends an update to nearby air alarms
+
+/obj/machinery/atmospherics/unary/proc/reset_area(area/old_area, area/new_area)

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -61,16 +61,30 @@
 	icon_state = "map_scrubber_on"
 
 /obj/machinery/atmospherics/unary/vent_scrubber/Initialize()
+	if (!id_tag)
+		id_tag = "[sequential_id("obj/machinery")]"
+	if(!scrubbing_gas)
+		scrubbing_gas = list()
+		for(var/g in subtypesof(/decl/material/gas))
+			if(g != /decl/material/gas/oxygen && g != /decl/material/gas/nitrogen)
+				scrubbing_gas += g
 	. = ..()
 	air_contents.volume = ATMOS_DEFAULT_VOLUME_FILTER
 
-/obj/machinery/atmospherics/unary/vent_scrubber/Destroy()
-	var/area/A = get_area(src)
-	if(A)
-		events_repository.unregister(/decl/observ/name_set, A, src, .proc/change_area_name)
-		A.air_scrub_info -= id_tag
-		A.air_scrub_names -= id_tag
-	. = ..()
+/obj/machinery/atmospherics/unary/vent_scrubber/reset_area(area/old_area, area/new_area)
+	if(old_area == new_area)
+		return
+	if(old_area)
+		events_repository.unregister(/decl/observ/name_set, old_area, src, .proc/change_area_name)
+		old_area.air_scrub_info -= id_tag
+		old_area.air_scrub_names -= id_tag
+	if(new_area && new_area == get_area(src))
+		events_repository.register(/decl/observ/name_set, new_area, src, .proc/change_area_name)
+		if(!new_area.air_scrub_names[id_tag])
+			var/new_name = "[new_area.proper_name] Vent Scrubber #[new_area.air_scrub_names.len+1]"
+			new_area.air_scrub_names[id_tag] = new_name
+			SetName(new_name)
+
 
 /obj/machinery/atmospherics/unary/vent_scrubber/on_update_icon()
 	if(welded)
@@ -81,22 +95,6 @@
 		icon_state = "[scrubbing ? "on" : "in"]"
 
 	build_device_underlays()
-
-/obj/machinery/atmospherics/unary/vent_scrubber/Initialize()
-	if (!id_tag)
-		id_tag = "[sequential_id("obj/machinery")]"
-	if(!scrubbing_gas)
-		scrubbing_gas = list()
-		for(var/g in subtypesof(/decl/material/gas))
-			if(g != /decl/material/gas/oxygen && g != /decl/material/gas/nitrogen)
-				scrubbing_gas += g
-	var/area/A = get_area(src)
-	if(A && !A.air_scrub_names[id_tag])
-		var/new_name = "[A.proper_name] Vent Scrubber #[A.air_scrub_names.len+1]"
-		A.air_scrub_names[id_tag] = new_name
-		SetName(new_name)
-		events_repository.register(/decl/observ/name_set, A, src, .proc/change_area_name)
-	. = ..()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/proc/change_area_name(var/area/A, var/old_area_name, var/new_area_name)
 	if(get_area(src) != A)

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -24,7 +24,7 @@ exactly() { # exactly N name search [mode] [filter]
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 # Additional exception August 2020: \b is a regex symbol as well as a BYOND macro.
 exactly 1 "escapes" '\\\\(red|blue|green|black|b|i[^mc])'
-exactly 4 "Del()s" '\WDel\('
+exactly 3 "Del()s" '\WDel\('
 exactly 2 "/atom text paths" '"/atom'
 exactly 2 "/area text paths" '"/area'
 exactly 2 "/datum text paths" '"/datum'


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes

Attempts to add minimal support to changing the area of a turf during normal gameplay (as opposed to only in pre-init stages or during shuttle movement).

Likely breaks machinery-shuttle interactions. Has some minor side effects for non-movable machines being moved (e.g. by legacy effects like sm pull).

Deleting areas with turfs in them should be considered unsupported. Deleting areas without turfs should "work," though they will almost certainly not GC.

## Why and what will this PR improve

Blueprints clearly assume such support exists, whereas it does not. Note that this PR does not attempt to fix blueprints, though it will make them slightly less buggy some of the time.

## Authorship

me