### PR TITLE
fix organs not being removed properly during surgery STAGING

### DIFF
--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -57,7 +57,7 @@
 
 	//Remove it from the implants if we are fully removing, or add it to the implants if we are detaching
 	if(affected)
-		if(status & ORGAN_CUT_AWAY)
+		if((status & ORGAN_CUT_AWAY) && detach)
 			LAZYDISTINCTADD(affected.implants, src)
 		else
 			LAZYREMOVE(affected.implants, src) 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -519,7 +519,6 @@ var/global/list/ailment_reference_cache = list()
 /obj/item/organ/proc/do_uninstall(var/in_place = FALSE, var/detach = FALSE, var/ignore_children = FALSE, var/update_icon = TRUE)
 	action_button_name = null
 	screen_loc = null
-	owner = null
 	rejecting = null
 	for(var/datum/ailment/ailment in ailments)
 		if(ailment.timer_id)
@@ -529,6 +528,8 @@ var/global/list/ailment_reference_cache = list()
 	//When we detach, we set the ORGAN_CUT_AWAY flag on, depending on whether the organ supports it or not
 	if(detach)
 		set_detached(TRUE)
+	else 
+		owner = null
 	return src
 
 //Events handling for checks and effects that should happen when removing the organ through interactions. Called by the owner mob.


### PR DESCRIPTION
Things would not get removed from the implants list on the second call to do_uninstall.

## Changelog
:cl:
fix: fixed organs not being removed correctly during surgery.
/:cl:
