### PR TITLE
Sorts the spawn material stack verb type list

### DIFF
--- a/code/controllers/subsystems/initialization/materials.dm
+++ b/code/controllers/subsystems/initialization/materials.dm
@@ -59,6 +59,8 @@ SUBSYSTEM_DEF(materials)
 	// Various other material functions.
 	build_material_lists()       // Build core material lists.
 	build_fusion_reaction_list() // Build fusion reaction tree.
+	materials = sortTim(SSmaterials.materials, /proc/cmp_name_asc)
+	materials_by_name = sortTim(SSmaterials.materials_by_name, /proc/cmp_name_or_type_asc, TRUE)
 
 	var/alpha_inc = 256 / DAMAGE_OVERLAY_COUNT
 	for(var/i = 1; i <= DAMAGE_OVERLAY_COUNT; i++)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -472,7 +472,8 @@
 	var/material = input("Select material to spawn") as null|anything in mat_types
 	if(!material)
 		return
-	SSmaterials.create_object(material.type, get_turf(mob), 50)
+	var/decl/material/M = SSmaterials.materials_by_name[material]
+	SSmaterials.create_object(M.type, get_turf(mob), 50)
 
 /client/proc/force_ghost_trap_trigger()
 	set category = "Debug"

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -468,7 +468,8 @@
 	set name = "Spawn Material Stack"
 	if(!check_rights(R_DEBUG)) return
 
-	var/decl/material/material = input("Select material to spawn") as null|anything in SSmaterials.materials
+	var/list/mat_types = sortTim(SSmaterials.materials_by_name, /proc/cmp_name_or_type_asc, TRUE)
+	var/material = input("Select material to spawn") as null|anything in mat_types
 	if(!material)
 		return
 	SSmaterials.create_object(material.type, get_turf(mob), 50)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -468,12 +468,11 @@
 	set name = "Spawn Material Stack"
 	if(!check_rights(R_DEBUG)) return
 
-	var/list/mat_types = sortTim(SSmaterials.materials_by_name, /proc/cmp_name_or_type_asc, TRUE)
-	var/material = input("Select material to spawn") as null|anything in mat_types
+	var/material = input("Select material to spawn") as null|anything in SSmaterials.materials_by_name
 	if(!material)
 		return
 	var/decl/material/M = SSmaterials.materials_by_name[material]
-	SSmaterials.create_object(M.type, get_turf(mob), 50)
+	M.create_object(get_turf(mob), 50)
 
 /client/proc/force_ghost_trap_trigger()
 	set category = "Debug"


### PR DESCRIPTION
## Description of changes
The material list shown when clicking the "spawn material stack" verb is sorted now. So you can actually find something in that overcrowded listbox.
A browser window might work better in the future though.

## Changelog
:cl:
admin: The list for spawning material stacks is now sorted by type name. So its a bit more useful.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->