### PR TITLE
Fixing up weather updates.

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -96,6 +96,7 @@ var/global/list/areas = list()
 /proc/ChangeArea(var/turf/T, var/area/A)
 	if(!istype(A))
 		CRASH("Area change attempt failed: invalid area supplied.")
+	var/old_outside = T.is_outside()
 	var/area/old_area = get_area(T)
 	if(old_area == A)
 		return
@@ -110,6 +111,9 @@ var/global/list/areas = list()
 
 	for(var/obj/machinery/M in T)
 		M.area_changed(old_area, A) // They usually get moved events, but this is the one way an area can change without triggering one.
+
+	if(T.is_outside() != old_outside)
+		T.update_weather()
 
 /area/proc/alert_on_fall(var/mob/living/carbon/human/H)
 	return

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -112,7 +112,7 @@ var/global/list/areas = list()
 	for(var/obj/machinery/M in T)
 		M.area_changed(old_area, A) // They usually get moved events, but this is the one way an area can change without triggering one.
 
-	if(T.is_outside() != old_outside)
+	if(T.is_outside == OUTSIDE_AREA && T.is_outside() != old_outside)
 		T.update_weather()
 
 /area/proc/alert_on_fall(var/mob/living/carbon/human/H)

--- a/code/game/machinery/floorlayer.dm
+++ b/code/game/machinery/floorlayer.dm
@@ -12,7 +12,7 @@
 
 /obj/machinery/floorlayer/Initialize()
 	. = ..()	
-	T = new/obj/item/stack/tile/floor(src)
+	T = new /obj/item/stack/tile/floor(src)
 
 /obj/machinery/floorlayer/Move(new_turf,M_Dir)
 	..()

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -119,7 +119,7 @@
 				to_chat(user, SPAN_WARNING("\The [ladder] is in the way."))
 				return TRUE
 
-			var/obj/item/stack/tile/floor/ST = C
+			var/obj/item/stack/tile/ST = C
 			if(!ST.in_use)
 				to_chat(user, "<span class='notice'>Placing tile...</span>")
 				ST.in_use = 1

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -58,7 +58,7 @@
 
 /obj/structure/lattice/attackby(obj/item/C, mob/user)
 
-	if (istype(C, /obj/item/stack/tile/floor))
+	if (istype(C, /obj/item/stack/tile))
 		var/turf/T = get_turf(src)
 		T.attackby(C, user) //BubbleWrap - hand this off to the underlying turf instead
 		return

--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -48,7 +48,7 @@
 /turf/exterior/is_floor()
 	return !density && !is_open()
 
-/turf/exterior/ChangeTurf(var/turf/N, var/tell_universe = TRUE, var/force_lighting_update = FALSE, var/keep_air = FALSE, var/keep_outside = FALSE)
+/turf/exterior/ChangeTurf(var/turf/N, var/tell_universe = TRUE, var/force_lighting_update = FALSE, var/keep_air = FALSE)
 	var/last_affecting_heat_sources = affecting_heat_sources
 	var/turf/exterior/ext = ..()
 	if(istype(ext))

--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -122,9 +122,7 @@
 
 	if(istype(C, /obj/item/stack/tile))
 		var/obj/item/stack/tile/T = C
-		if(T.use(1))
-			playsound(src, 'sound/items/Deconstruct.ogg', 80, 1)
-			ChangeTurf(/turf/simulated/floor, FALSE, FALSE, TRUE)
+		T.try_build_turf(user, src)
 		return TRUE
 
 	. = ..()

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -1,11 +1,10 @@
 /turf/simulated
 	name = "station"
 	initial_gas = list(
-		/decl/material/gas/oxygen = MOLES_O2STANDARD, 
+		/decl/material/gas/oxygen = MOLES_O2STANDARD,
 		/decl/material/gas/nitrogen = MOLES_N2STANDARD
 	)
 	open_turf_type = /turf/simulated/open
-	is_outside = OUTSIDE_NO
 
 	var/wet = 0
 	var/image/wet_overlay = null
@@ -110,12 +109,11 @@
 /mob/living/carbon/human/HandleBloodTrail(turf/simulated/T)
 	// Tracking blood
 	var/obj/item/source
-	if(shoes)
-		var/obj/item/clothing/shoes/S = shoes
-		if(istype(S))
-			S.handle_movement(src, MOVING_QUICKLY(src))
-			if(S.coating && S.coating.total_volume > 1)
-				source = S
+	var/obj/item/clothing/shoes/shoes = get_equipped_item(slot_shoes_str)
+	if(istype(shoes))
+		shoes.handle_movement(src, MOVING_QUICKLY(src))
+		if(shoes.coating && shoes.coating.total_volume > 1)
+			source = shoes
 	else
 		for(var/bp in list(BP_L_FOOT, BP_R_FOOT))
 			var/obj/item/organ/external/stomper = GET_EXTERNAL_ORGAN(src, bp)
@@ -168,7 +166,7 @@
 		new /obj/effect/decal/cleanable/blood/oil(src)
 
 /turf/simulated/attackby(var/obj/item/thing, var/mob/user)
-	if(isCoil(thing) && try_build_cable(thing, user))
+	if(IS_COIL(thing) && try_build_cable(thing, user))
 		return TRUE
 	return ..()
 
@@ -177,10 +175,6 @@
 	holy = istype(A) && (A.area_flags & AREA_FLAG_HOLY)
 	levelupdate()
 	. = ..()
-
-/turf/simulated/initialize_ambient_light(var/mapload)
-	for(var/turf/T AS_ANYTHING in RANGE_TURFS(src, 1))
-		T.update_ambient_light(mapload)
 
 /turf/simulated/Destroy()
 	if (zone)

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -109,11 +109,12 @@
 /mob/living/carbon/human/HandleBloodTrail(turf/simulated/T)
 	// Tracking blood
 	var/obj/item/source
-	var/obj/item/clothing/shoes/shoes = get_equipped_item(slot_shoes_str)
-	if(istype(shoes))
-		shoes.handle_movement(src, MOVING_QUICKLY(src))
-		if(shoes.coating && shoes.coating.total_volume > 1)
-			source = shoes
+	if(shoes)
+		var/obj/item/clothing/shoes/S = shoes
+		if(istype(S))
+			S.handle_movement(src, MOVING_QUICKLY(src))
+			if(S.coating && S.coating.total_volume > 1)
+				source = S
 	else
 		for(var/bp in list(BP_L_FOOT, BP_R_FOOT))
 			var/obj/item/organ/external/stomper = GET_EXTERNAL_ORGAN(src, bp)
@@ -175,6 +176,10 @@
 	holy = istype(A) && (A.area_flags & AREA_FLAG_HOLY)
 	levelupdate()
 	. = ..()
+
+/turf/simulated/initialize_ambient_light(var/mapload)
+	for(var/turf/T AS_ANYTHING in RANGE_TURFS(src, 1))
+		T.update_ambient_light(mapload)
 
 /turf/simulated/Destroy()
 	if (zone)

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -166,7 +166,7 @@
 		new /obj/effect/decal/cleanable/blood/oil(src)
 
 /turf/simulated/attackby(var/obj/item/thing, var/mob/user)
-	if(IS_COIL(thing) && try_build_cable(thing, user))
+	if(isCoil(thing) && try_build_cable(thing, user))
 		return TRUE
 	return ..()
 

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -11,6 +11,11 @@
 	if(!C || !user)
 		return 0
 
+	if(istype(C, /obj/item/stack/tile/roof))
+		var/obj/item/stack/tile/roof/T = C
+		T.try_build_turf(user, src)
+		return TRUE
+
 	if(isCoil(C) || (flooring && istype(C, /obj/item/stack/material/rods)))
 		return ..(C, user)
 

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -102,6 +102,9 @@
 
 /turf/simulated/wall/attackby(var/obj/item/W, var/mob/user, click_params)
 
+	if(istype(W, /obj/item/stack/tile/roof))
+		return ..()
+
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 
 	if(!construction_stage && try_graffiti(user, W))

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -150,7 +150,7 @@ var/global/list/wall_fullblend_objects = list(
 			plant.update_icon()
 			plant.reset_offsets(0)
 
-/turf/simulated/wall/ChangeTurf(var/turf/N, var/tell_universe = TRUE, var/force_lighting_update = FALSE, var/keep_air = FALSE, var/keep_outside = FALSE)
+/turf/simulated/wall/ChangeTurf(var/turf/N, var/tell_universe = TRUE, var/force_lighting_update = FALSE, var/keep_air = FALSE)
 	clear_plants()
 	. = ..()
 

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -249,8 +249,8 @@
 					A.loc.Entered(A)
 	return
 
-/turf/space/ChangeTurf(var/turf/N, var/tell_universe = TRUE, var/force_lighting_update = FALSE, var/keep_air = FALSE, var/keep_outside = FALSE)
-	return ..(N, tell_universe, TRUE, keep_air, keep_outside)
+/turf/space/ChangeTurf(var/turf/N, var/tell_universe = TRUE, var/force_lighting_update = FALSE, var/keep_air = FALSE)
+	return ..(N, tell_universe, TRUE, keep_air)
 
 /turf/space/is_open()
 	return TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -36,6 +36,20 @@
 
 	var/tmp/changing_turf
 	var/tmp/prev_type // Previous type of the turf, prior to turf translation.
+
+	// Some quick notes on the vars below: is_outside should be left set to OUTSIDE_AREA unless you 
+	// EXPLICITLY NEED a turf to have a different outside state to its area (ie. you have used a
+	// roofing tile). By default, it will ask the area for the state to use, and will update on 
+	// area change. When dealing with weather, it will check the entire z-column for interruptions 
+	// that will prevent it from using its own state, so a floor above a level will generally 
+	// override both area is_outside, and turf is_outside. The only time the base value will be used
+	// by itself is if you are dealing with a non-multiz level, or the top level of a multiz chunk.
+
+	// Weather relies on is_outside to determine if it should apply to a turf or not and will be
+	// automatically updated on ChangeTurf set_outside etc. Don't bother setting it manually, it will
+	// get overridden almost immediately.
+
+	// TL;DR: just leave these vars alone.
 	var/tmp/obj/abstract/weather_system/weather
 	var/tmp/is_outside = OUTSIDE_AREA
 
@@ -429,14 +443,14 @@ var/global/const/enterloopsanity = 100
 	// turfs must match effective is_outside value if the turf
 	// should get to use the is_outside value it wants to. If it
 	// doesn't line up, we invert the outside value (roof is not 
-	// open but turf wants to be outside, invert to outside_no).
+	// open but turf wants to be outside, invert to OUTSIDE_NO).
 
 	// Do we have a roof over our head? Should we care?
 	if(HasAbove(z))
 		var/turf/top_of_stack = src
 		while(HasAbove(top_of_stack.z))
 			top_of_stack = GetAbove(top_of_stack)
-			if(top_of_stack.is_open() != .)
+			if(top_of_stack.is_open() != . || (top_of_stack.is_outside != OUTSIDE_AREA && top_of_stack.is_outside != .))
 				return !.
 
 /turf/proc/set_outside(var/new_outside, var/skip_weather_update = FALSE)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -55,14 +55,15 @@
 	else
 		luminosity = 1
 
-	if (mapload && permit_ao)
-		queue_ao()
 
 	if (opacity)
 		has_opaque_atom = TRUE
 
 	if (!mapload)
 		SSair.mark_for_update(src)
+		update_weather(force_update_below = TRUE)
+	else if (permit_ao)
+		queue_ao()
 
 	updateVisibility(src, FALSE)
 
@@ -384,51 +385,65 @@ var/global/const/enterloopsanity = 100
 /turf/proc/get_footstep_sound(var/mob/caller)
 	return
 
-/turf/proc/update_weather(var/obj/abstract/weather_system/new_weather)
+/turf/proc/update_weather(var/obj/abstract/weather_system/new_weather, var/force_update_below = FALSE)
 
 	if(isnull(new_weather))
 		new_weather = global.weather_by_z["[z]"]
 
 	// We have a weather system and we are exposed to it; update our vis contents.
-	var/old_weather = weather
 	if(istype(new_weather) && is_outside())
 		if(weather != new_weather)
 			if(weather)
 				remove_vis_contents(src, weather.vis_contents_additions)
 			weather = new_weather
 			add_vis_contents(src, weather.vis_contents_additions)
+			. = TRUE
 
 	// We are indoors or there is no local weather system, clear our vis contents.
 	else if(weather)
 		remove_vis_contents(src, weather.vis_contents_additions)
 		weather = null
+		. = TRUE
 
 	// Propagate our weather downwards if we permit it.
-	if(is_open() && old_weather != weather)
+	if(force_update_below || (is_open() && .))
 		var/turf/below = GetBelow(src)
 		if(below)
 			below.update_weather(new_weather)
 
 /turf/proc/is_outside()
 
+	// Can't rain inside or through solid walls.
+	// TODO: dense structures like full windows should probably also block weather.
 	if(density)
 		return OUTSIDE_NO
 
-	var/turf/above = GetAbove(src)
-	if(above && above.is_open())
-		return above.is_outside()
+	// What would we like to return in an ideal world?
+	if(is_outside == OUTSIDE_AREA)
+		var/area/A = get_area(src)
+		. = A ? A.is_outside : OUTSIDE_NO
+	else
+		. = is_outside
 
-	if(is_outside != OUTSIDE_AREA)
-		return is_outside
-	var/area/A = get_area(src)
-	if(A)
-		return A.is_outside
-	return OUTSIDE_NO
+	// Notes for future self when confused: is_open() on higher
+	// turfs must match effective is_outside value if the turf
+	// should get to use the is_outside value it wants to. If it
+	// doesn't line up, we invert the outside value (roof is not 
+	// open but turf wants to be outside, invert to outside_no).
 
-/turf/proc/set_outside(var/new_outside)
+	// Do we have a roof over our head? Should we care?
+	if(HasAbove(z))
+		var/turf/top_of_stack = src
+		while(HasAbove(top_of_stack.z))
+			top_of_stack = GetAbove(top_of_stack)
+			if(top_of_stack.is_open() != .)
+				return !.
+
+/turf/proc/set_outside(var/new_outside, var/skip_weather_update = FALSE)
 	if(is_outside != new_outside)
 		is_outside = new_outside
-		update_weather()
+		if(!skip_weather_update)
+			update_weather()
 		return TRUE
 	return FALSE
 

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -22,7 +22,7 @@
 	SHOULD_CALL_PARENT(FALSE)
 	. = TRUE
 
-/turf/proc/ChangeTurf(var/turf/N, var/tell_universe = TRUE, var/force_lighting_update = FALSE, var/keep_air = FALSE, var/keep_outside = FALSE)
+/turf/proc/ChangeTurf(var/turf/N, var/tell_universe = TRUE, var/force_lighting_update = FALSE, var/keep_air = FALSE)
 
 	if (!N)
 		return
@@ -48,6 +48,7 @@
 	var/old_dynamic_lighting = TURF_IS_DYNAMICALLY_LIT_UNSAFE(src)
 	var/old_flooded =          flooded
 	var/old_outside =          is_outside
+	var/old_is_open =          is_open()
 
 	changing_turf = TRUE
 
@@ -105,10 +106,10 @@
 
 	// end of lighting stuff
 
-	// Outside/weather stuff. set_outside() updates weather already
-	// so only call it again if it doesn't already handle it.
-	if(!keep_outside || !W.set_outside(old_outside))
-		W.update_weather()
+	// we check the var rather than the proc, because area outside values usually shouldn't be set on turfs
+	if(W.is_outside != old_outside) 
+		W.set_outside(old_outside, skip_weather_update = TRUE)
+	W.update_weather(force_update_below = W.is_open() != old_is_open)
 
 /turf/proc/transport_properties_from(turf/other)
 	if(!istype(other, src.type))

--- a/code/modules/materials/recipes_stacks.dm
+++ b/code/modules/materials/recipes_stacks.dm
@@ -32,6 +32,10 @@
 	title = "regular floor tile"
 	result_type = /obj/item/stack/tile/floor
 
+/datum/stack_recipe/tile/metal/floor
+	title = "roofing tile"
+	result_type = /obj/item/stack/tile/roof
+
 /datum/stack_recipe/tile/metal/mono
 	title = "mono floor tile"
 	result_type = /obj/item/stack/tile/mono

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_repair.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_repair.dm
@@ -36,6 +36,7 @@
 		/obj/item/stack/material/rods/cyborg,
 		/obj/item/stack/material/strut/cyborg,
 		/obj/item/stack/tile/floor/cyborg,
+		/obj/item/stack/tile/roof/cyborg,
 		/obj/item/stack/material/cyborg/glass,
 		/obj/item/stack/material/cyborg/glass/reinforced,
 		/obj/item/stack/material/cyborg/fiberglass,
@@ -71,6 +72,7 @@
 		 /obj/item/stack/material/rods/cyborg,
 		 /obj/item/stack/material/strut/cyborg,
 		 /obj/item/stack/tile/floor/cyborg,
+		 /obj/item/stack/tile/roof/cyborg,
 		 /obj/item/stack/material/cyborg/glass/reinforced
 		))
 		var/obj/item/stack/stack = locate(thing) in equipment

--- a/code/modules/mob/living/silicon/robot/modules/module_engineering.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_engineering.dm
@@ -49,6 +49,7 @@
 		/obj/item/stack/material/rods/cyborg,
 		/obj/item/stack/material/strut/cyborg,
 		/obj/item/stack/tile/floor/cyborg,
+		/obj/item/stack/tile/roof/cyborg,
 		/obj/item/stack/material/cyborg/glass,
 		/obj/item/stack/material/cyborg/glass/reinforced,
 		/obj/item/stack/material/cyborg/fiberglass,
@@ -88,6 +89,7 @@
 		 /obj/item/stack/material/rods/cyborg,
 		 /obj/item/stack/material/strut/cyborg,
 		 /obj/item/stack/tile/floor/cyborg,
+		 /obj/item/stack/tile/roof/cyborg,
 		 /obj/item/stack/material/cyborg/glass/reinforced
 		))
 		var/obj/item/stack/stack = locate(thing) in equipment

--- a/code/modules/mob/living/silicon/robot/modules/module_maintenance_drone.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_maintenance_drone.dm
@@ -33,6 +33,7 @@
 		/obj/item/stack/material/rods/cyborg,
 		/obj/item/stack/material/strut/cyborg,
 		/obj/item/stack/tile/floor/cyborg,
+		/obj/item/stack/tile/roof/cyborg,
 		/obj/item/stack/material/cyborg/glass,
 		/obj/item/stack/material/cyborg/glass/reinforced,
 		/obj/item/stack/material/cyborg/fiberglass,
@@ -85,6 +86,7 @@
 		 /obj/item/stack/material/rods/cyborg,
 		 /obj/item/stack/material/strut/cyborg,
 		 /obj/item/stack/tile/floor/cyborg,
+		 /obj/item/stack/tile/roof/cyborg,
 		 /obj/item/stack/material/cyborg/glass/reinforced
 		))
 		var/obj/item/stack/stack = locate(thing) in equipment

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1079,27 +1079,34 @@
 		LAZYADD(., check_head)
 		LAZYADD(., check_body)
 
-/mob/proc/get_weather_exposure(var/obj/abstract/weather_system/weather)
-	var/turf/T = loc
+/mob/proc/get_weather_exposure()
 
 	// We're inside something else.
-	if(!istype(T))
+	if(!isturf(loc))
 		return WEATHER_PROTECTED
 
-	// Either we're outside being rained on, or we're in turf-local weather being rained on.
-	if(T.is_outside() || T.weather == weather)
-		var/list/weather_protection = get_weather_protection()
-		if(LAZYLEN(weather_protection))
+	var/turf/T = loc
+	// We're under a roof or otherwise shouldn't be being rained on.
+	if(!T.is_outside())
+
+		// For non-multiz we'll give everyone some nice ambience.
+		if(!HasAbove(T.z))
 			return WEATHER_PROTECTED
-		return WEATHER_EXPOSED
 
-	// The z-level has weather, but we aren't standing in it, so it's probably above us.
-	T = GetAbove(T)
-	if(!T || !T.is_open())
+		// For multi-z, check the actual weather on the turf above.
+		// TODO: maybe make this a property of the z-level marker.
+		var/turf/above = GetAbove(T)
+		if(above.weather)
+			return WEATHER_PROTECTED
+
+		// Being more than one level down should exempt us from ambience.
+		return WEATHER_IGNORE
+
+	// Nothing's protecting us from the rain here
+	var/list/weather_protection = get_weather_protection()
+	if(LAZYLEN(weather_protection))
 		return WEATHER_PROTECTED
-
-	// We're inside, and more than one z-level below the roof, so ignore it.
-	return WEATHER_IGNORE
+	return WEATHER_EXPOSED
 
 /mob/proc/IsMultiZAdjacent(var/atom/neighbor)
 

--- a/code/modules/weather/_weather.dm
+++ b/code/modules/weather/_weather.dm
@@ -77,7 +77,8 @@ var/global/list/weather_by_z = list()
 	var/decl/state/weather/weather_state = weather_system.current_state
 	if(istype(weather_state))
 		to_chat(user, weather_state.descriptor)
-
+	show_wind(user, force = TRUE)
+	
 // Called by /decl/state/weather to assess validity of a state in the weather FSM.
 /obj/abstract/weather_system/proc/supports_weather_state(var/decl/state/weather/next_state)
 	// Exoplanet stuff for the future:

--- a/code/modules/weather/weather_effects.dm
+++ b/code/modules/weather/weather_effects.dm
@@ -13,7 +13,7 @@
 
 	// Never spit into the wind.
 	var/reversed_wind = global.reverse_dir[wind_direction]
-	if(wind_direction == reversed_wind)
+	if(reversed_wind == travel_dir)
 		return current_wind_strength
 	if(travel_dir & reversed_wind)
 		return round(current_wind_strength * 0.5)

--- a/code/modules/weather/weather_fsm_states.dm
+++ b/code/modules/weather/weather_fsm_states.dm
@@ -60,7 +60,7 @@
 /decl/state/weather/proc/handle_exposure(var/mob/living/M, var/exposure, var/obj/abstract/weather_system/weather)
 
 	// Send strings if we're outside.
-	if(M.is_outside())
+	if(M.is_outside() && M.client)
 		if(!weather.show_weather(M))
 			weather.show_wind(M)
 

--- a/code/modules/weather/weather_wind.dm
+++ b/code/modules/weather/weather_wind.dm
@@ -21,11 +21,11 @@
 		if(old_strength != wind_strength)
 			mob_shown_wind.Cut()
 
-/obj/abstract/weather_system/proc/show_wind(var/mob/M)
+/obj/abstract/weather_system/proc/show_wind(var/mob/M, var/force = FALSE)
 	var/mob_ref = weakref(M)
-	if(mob_shown_wind[mob_ref])
+	if(mob_shown_wind[mob_ref] && !force)
 		return FALSE
-	mob_shown_wind[weakref(M)] = TRUE
+	mob_shown_wind[mob_ref] = TRUE
 	. = TRUE
 	var/turf/T = get_turf(M)
 	if(istype(T))

--- a/mods/species/ascent/mobs/drone.dm
+++ b/mods/species/ascent/mobs/drone.dm
@@ -37,6 +37,7 @@
 		/obj/item/stack/material/rods/cyborg,
 		/obj/item/stack/material/strut/cyborg,
 		/obj/item/stack/tile/floor/cyborg,
+		/obj/item/stack/tile/roof/cyborg,
 		/obj/item/stack/material/cyborg/glass,
 		/obj/item/stack/material/cyborg/glass/reinforced,
 		/obj/item/stack/material/cyborg/fiberglass,
@@ -97,6 +98,7 @@
 		 /obj/item/stack/material/rods/cyborg,
 		 /obj/item/stack/material/strut/cyborg,
 		 /obj/item/stack/tile/floor/cyborg,
+		 /obj/item/stack/tile/roof/cyborg,
 		 /obj/item/stack/material/cyborg/glass/reinforced
 		))
 		var/obj/item/stack/stack = locate(thing) in equipment


### PR DESCRIPTION
- `is_outside()` is now a bit more robust with regards to checking if the turf has a ceiling or not.
- `ChangeArea()` refreshes weather.
- `turf/Initialize()` refreshes weather for non-maploaded turfs.
- `ChangeTurf()` refreshes weather for other turfs.
- Wind is shown on turf examine.
- Wind is not shown to clientless mobs.
- Wind direction checking is less wonky.
- Roofs are now buildable.

Fixes #2551.