### PR TITLE
Fixes bugs with can_use_power_oneoff

### DIFF
--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -121,7 +121,7 @@
 /obj/machinery/mining/drill/physical_attack_hand(mob/user)
 	check_supports()
 	if(need_player_check)
-		if(can_use_power_oneoff(10 KILOWATTS) <= 0)
+		if(can_use_power_oneoff(10 KILOWATTS) > 0)
 			system_error("insufficient charge")
 		else if(anchored)
 			get_resource_field()

--- a/code/modules/power/fission/core.dm
+++ b/code/modules/power/fission/core.dm
@@ -221,7 +221,7 @@
 	. = ..()
 
 /obj/machinery/atmospherics/unary/fission_core/proc/jump_start()
-	if((stat & (BROKEN|NOPOWER)) || (can_use_power_oneoff(5 KILOWATTS) <= 0))
+	if((stat & (BROKEN|NOPOWER)) || (can_use_power_oneoff(5 KILOWATTS) > 0))
 		visible_message("\The [src] flashes an 'Insufficient Power' error.")
 		return
 	use_power_oneoff(5 KILOWATTS)

--- a/code/modules/power/fusion/gyrotron/gyrotron.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron.dm
@@ -51,7 +51,7 @@
 	return E
 
 /obj/machinery/emitter/gyrotron/on_update_icon()
-	if (active && can_use_power_oneoff(active_power_usage))
+	if (active && (can_use_power_oneoff(active_power_usage) <= 0))
 		icon_state = "emitter-on"
 	else
 		icon_state = "emitter-off"


### PR DESCRIPTION
## Description of changes
Fixes a couple sign errors on references to ``can_use_power_oneoff()`` caused by me misinterpreting the proc's return. This fixes a bug where drills and fission cores could not be started, and a bug with the gyrotron's icon.

## Authorship
Myself

## Changelog
:cl:
fix: Fission cores and mining drills can now be started instead of showing no power errors
fix: The gyrotron icon now properly updates when powered
/:cl: