### PR TITLE
Makes multi-z tools producible

### DIFF
--- a/code/modules/fabrication/designs/general/designs_tools.dm
+++ b/code/modules/fabrication/designs/general/designs_tools.dm
@@ -44,3 +44,9 @@
 /datum/fabricator_recipe/tool/welder_industrial
 	path = /obj/item/weldingtool/largetank
 	hidden = TRUE
+
+/datum/fabricator_recipe/tool/hoist_kit
+	path = /obj/item/hoist_kit
+
+/datum/fabricator_recipe/tool/mobile_ladder
+	path = /obj/item/mobile_ladder

--- a/code/modules/multiz/hoist.dm
+++ b/code/modules/multiz/hoist.dm
@@ -10,6 +10,10 @@
 	icon = 'icons/obj/hoists.dmi'
 	icon_state = "hoist_case"
 
+	material = /decl/material/solid/metal/steel
+	matter = list(/decl/material/solid/plastic = MATTER_AMOUNT_REINFORCEMENT, /decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
+
+
 /obj/item/hoist_kit/attack_self(mob/user)
 	if (!do_after(usr, (2 SECONDS), src))
 		return

--- a/code/modules/multiz/mobile_ladder.dm
+++ b/code/modules/multiz/mobile_ladder.dm
@@ -2,6 +2,9 @@
 	name = "mobile ladder"
 	desc = "A lightweight deployable ladder, which you can use to move up or down. Or alternatively, you can bash some faces in."
 	icon = 'icons/obj/mobile_ladder.dmi'
+	
+	material = /decl/material/solid/metal/steel
+	matter = list(/decl/material/solid/plastic = MATTER_AMOUNT_SECONDARY)
 	icon_state = ICON_STATE_WORLD
 	throw_range = 3
 	force = 10


### PR DESCRIPTION
## Description of changes
Adds fabricator designs and materials for the mobile ladder and hoist tool

## Why and what will this PR improve
These items are neat, and aren't obtainable elsewhere. They're useful for the multi-z construction which we need downstream as well.

## Authorship
Myself

## Changelog
:cl:
add: Hoists and mobile ladders can now be produced in the general fabricator
/:cl:
