### PR TITLE
Attempting to fix issues with non-owned limb robotize().

### DIFF
--- a/code/modules/fabrication/designs/_design.dm
+++ b/code/modules/fabrication/designs/_design.dm
@@ -46,6 +46,9 @@
 			check_tech -= tech
 	return !length(check_tech)
 
+/datum/fabricator_recipe/proc/is_available_to_fab(var/obj/machinery/fabricator/fab)
+	return TRUE
+
 /datum/fabricator_recipe/proc/get_resources()
 	resources = list()
 	var/list/building_cost = atom_info_repository.get_matter_for(path)

--- a/code/modules/fabrication/designs/robotics/designs_prosthetics.dm
+++ b/code/modules/fabrication/designs/robotics/designs_prosthetics.dm
@@ -48,6 +48,23 @@
 		category = "Unbranded Prosthetics"
 	..()
 
+/datum/fabricator_recipe/robotics/prosthetic/is_available_to_fab(var/obj/machinery/fabricator/fab)
+	. = ..() && model
+	if(.)
+		var/obj/machinery/fabricator/robotics/robofab = fab
+		if(!istype(robofab))
+			return FALSE
+		var/decl/prosthetics_manufacturer/company = GET_DECL(model)
+		if(!istype(company))
+			return FALSE
+		var/decl/species/species = get_species_by_key(robofab.picked_prosthetic_species)
+		if(!istype(species))
+			return FALSE
+		var/obj/item/organ/target_limb = path
+		if(!ispath(target_limb, /obj/item/organ))
+			return FALSE
+		return company.check_can_install(initial(target_limb.organ_tag), species.default_bodytype.bodytype_category, robofab.picked_prosthetic_species)
+
 /datum/fabricator_recipe/robotics/prosthetic/get_resources()
 	. = ..()
 	for(var/key in resources)
@@ -69,10 +86,12 @@
 
 /datum/fabricator_recipe/robotics/prosthetic/build(var/turf/location, var/datum/fabricator_build_order/order)
 	. = ..()
-	var/species = order.get_data("species", global.using_map.default_species)
-	for(var/obj/item/organ/external/E in .)
-		E.set_species(species)
-		E.robotize(model)
-		E.status |= ORGAN_CUT_AWAY
+	var/species_name = order.get_data("species", global.using_map.default_species)
+	var/decl/species/species = get_species_by_key(species_name)
+	if(species)
+		for(var/obj/item/organ/external/E in .)
+			E.set_species(species_name)
+			E.robotize(model, check_species = species_name)
+			E.status |= ORGAN_CUT_AWAY
 
 DEFINE_ROBOLIMB_DESIGNS(/decl/prosthetics_manufacturer, generic)

--- a/code/modules/fabrication/fabricator_robotics.dm
+++ b/code/modules/fabrication/fabricator_robotics.dm
@@ -34,7 +34,7 @@
 /obj/machinery/fabricator/robotics/OnTopic(user, href_list, state)
 	. = ..()
 	if(href_list["pick_species"])
-		var/chosen_species = input(user, "Choose a specie to produce prosthetics for", "Target Species", null) in get_playable_species()
+		var/chosen_species = input(user, "Choose a species to produce prosthetics for", "Target Species", null) in get_playable_species()
 		if(chosen_species)
 			picked_prosthetic_species = chosen_species
 		. = TOPIC_REFRESH

--- a/code/modules/fabrication/fabricator_ui.dm
+++ b/code/modules/fabrication/fabricator_ui.dm
@@ -57,6 +57,8 @@
 /obj/machinery/fabricator/proc/ui_fabricator_build_options_data()
 	var/list/build_options
 	for(var/datum/fabricator_recipe/R in design_cache)
+		if(!R.is_available_to_fab(src))
+			continue
 		if(R.hidden && !(fab_status_flags & FAB_HACKED))
 			continue
 		if(show_category != "All" && show_category != R.category)

--- a/code/modules/materials/recipes_items.dm
+++ b/code/modules/materials/recipes_items.dm
@@ -236,13 +236,15 @@
 
 /datum/stack_recipe/prosthetic
 	difficulty = 0
+	var/prosthetic_species = SPECIES_HUMAN
 	var/prosthetic_model = /decl/prosthetics_manufacturer/wooden
 
 /datum/stack_recipe/prosthetic/spawn_result(mob/user, location, amount)
 	var/obj/item/organ/external/limb = ..()
 	if(limb)
-		limb.species = get_species_by_key(SPECIES_HUMAN)
-		limb.robotize(prosthetic_model, apply_material = use_material)
+		limb.set_species(prosthetic_species)
+		limb.robotize(prosthetic_model, apply_material = use_material, check_species = prosthetic_species)
+		limb.status |= ORGAN_CUT_AWAY
 	return limb
 
 /datum/stack_recipe/prosthetic/left_arm

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1270,8 +1270,20 @@ Note that amputating the affected organ does in fact remove the infection from t
 			company = /decl/prosthetics_manufacturer
 		R = GET_DECL(company)
 
-	//If can't install fallback to default
-	if(!R.check_can_install(organ_tag, (check_bodytype || owner?.get_bodytype_category() || global.using_map.default_bodytype), (check_species || owner?.get_species_name() || global.using_map.default_species)))
+	if(!check_species)
+		check_species = owner?.get_species_name() || global.using_map.default_species
+	if(!check_bodytype)
+		if(owner)
+			check_bodytype = owner.get_bodytype_category()
+		else
+			var/decl/species/species_data = get_species_by_key(check_species)
+			if(species_data)
+				check_bodytype = species_data.default_bodytype.bodytype_category
+			else
+				check_bodytype = global.using_map.default_bodytype
+
+	//If can't install fallback to defaults.
+	if(!R.check_can_install(organ_tag, check_bodytype, check_species))
 		company = /decl/prosthetics_manufacturer
 		R = GET_DECL(/decl/prosthetics_manufacturer)
 


### PR DESCRIPTION
- Prosthetic recipes and crafting now supply a species.
- Species and bodytype checking on robotize() is a bit more nuanced.
- Robotics fabricators will not display prosthetic models that are invalid with the selected species (previously would cause them to spawn as unbranded).