### PR TITLE
Added some restrictions to base mob dexterity.

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -98,7 +98,8 @@
 		slip_dist = 4
 		slip_stun = 10
 
-	if(slip("the [floor_type] floor", slip_stun))
+	// Dir check to avoid slipping up and down via ladders.
+	if(slip("the [floor_type] floor", slip_stun) && (dir in global.cardinal))
 		for(var/i = 1 to slip_dist)
 			step(src, dir)
 			sleep(1)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -963,8 +963,9 @@
 		return 0
 	return 1
 
+// Let simple mobs press buttons and levers but nothing more complex.
 /mob/proc/has_dexterity(var/dex_level)
-	. = TRUE
+	. = dex_level <= DEXTERITY_SIMPLE_MACHINES
 
 /mob/proc/check_dexterity(var/dex_level, var/silent)
 	. = has_dexterity(dex_level)


### PR DESCRIPTION
Partially addresses #2518 - mice can no longer freely interact with all machines and items. Some interactions do not check dexterity (such as unloading emergency lockers) are are still exploitable though.