### PR TITLE
Fixes multiplier stack crafting in submenus

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -113,9 +113,9 @@
 				var/list/multipliers = list(5,10,25)
 				for (var/n in multipliers)
 					if (max_multiplier>=n)
-						t1 += " <A href='?src=\ref[src];make=[i];multiplier=[n]'>[n*R.res_amount]x</A>"
+						t1 += " <A href='?src=\ref[src];make=[i];sublist=[recipes_sublist];multiplier=[n]'>[n*R.res_amount]x</A>"
 				if (!(max_multiplier in multipliers))
-					t1 += " <A href='?src=\ref[src];make=[i];multiplier=[max_multiplier]'>[max_multiplier*R.res_amount]x</A>"
+					t1 += " <A href='?src=\ref[src];make=[i];sublist=[recipes_sublist];multiplier=[max_multiplier]'>[max_multiplier*R.res_amount]x</A>"
 
 	t1 += "</TT></body></HTML>"
 	show_browser(user, JOINTEXT(t1), "window=stack")


### PR DESCRIPTION
## Description of changes
Adds some missing references to the sublist in the stack recipe menu. This was causing the incorrect recipe to be created when attempting to craft multiples (10x, 20x, etc.) of items in submenus, such as tiles.
## Why and what will this PR improve
Creating improvised armor accidentally is bad
## Changelog
:cl:
fix: Stackcrafting multiples of tiles and other objects in submenus will no longer produce incorrect objects
/:cl: