### PR TITLE
Overmap movement fixes

### DIFF
--- a/code/modules/overmap/overmap_object.dm
+++ b/code/modules/overmap/overmap_object.dm
@@ -79,14 +79,16 @@ var/global/list/overmap_unknown_ids = list()
 	var/datum/overmap/overmap = global.overmaps_by_z["[T.z]"]
 	var/nx = x
 	var/ny = y
+	
+	var/heading_dir = get_heading_dir()
 
-	if((dir & WEST) && x == 1)
+	if((heading_dir & WEST) && x == 1)
 		nx = overmap.map_size_y - 1
-	else if((dir & EAST) && x == overmap.map_size_y)
+	else if((heading_dir & EAST) && x == overmap.map_size_y)
 		nx = 2
-	if((dir & SOUTH)  && y == 1)
+	if((heading_dir & SOUTH)  && y == 1)
 		ny = overmap.map_size_y - 1
-	else if((dir & NORTH) && y == overmap.map_size_y)
+	else if((heading_dir & NORTH) && y == overmap.map_size_y)
 		ny = 2
 	if((x == nx) && (y == ny))
 		return //we're not flying off anywhere
@@ -154,6 +156,8 @@ var/global/list/overmap_unknown_ids = list()
 	if(can_burn())
 		last_burn = world.time
 		var/delta_v = get_delta_v() / KM_OVERMAP_RATE
+		if(delta_v == 0)
+			return
 		var/partial_power = Clamp(actual_accel_limit / delta_v, 0, 1)
 		var/acceleration = min(get_delta_v(TRUE, partial_power) / KM_OVERMAP_RATE, actual_accel_limit)
 		if(direction & EAST)


### PR DESCRIPTION
## Description of changes
Fixes a divide by zero runtime in overmap movement. Also fixes the wraparound effect on the overmap, which was previously broken as the logic used the direction of the ship object rather than the heading of the ship.

## Authorship
Myself

## Changelog
:cl:
fix: The overmap wraparound effect is functional again
/:cl: