### PR TITLE
Fixes airflow direction

### DIFF
--- a/code/modules/ZAS/Airflow.dm
+++ b/code/modules/ZAS/Airflow.dm
@@ -17,7 +17,11 @@ Contains helper procs for airflow, called by /connection_group.
 				LAZYADD(close_turfs, connecting_turf)
 			if(LAZYLEN(close_turfs))
 				airflow_dest = pick(close_turfs) //Pick a random midpoint to fly towards.
-				addtimer(CALLBACK(src, .proc/RepelAirflowDest, differential / (repelled ? 5 : 10)), 0)
+
+				if(repelled)
+					addtimer(CALLBACK(src, .proc/RepelAirflowDest, differential / 5), 0)
+				else
+					addtimer(CALLBACK(src, .proc/GotoAirflowDest, differential / 10), 0)
 
 /atom/movable/proc/handle_airflow_stun(var/differential)
 	return


### PR DESCRIPTION
## Description of changes
Fixes the direction of airflow acting on movables, which previously always repelled regardless of airflow direction. This was most likely introduced in https://github.com/NebulaSS13/Nebula/pull/2155, where the only call to ``GotoAirflowDest`` was replaced by mistake.

## Authorship
Myself

## Changelog
:cl:
fix: Fixed the direction of airflow acting on movables. Movables will no longer fly away from a vacuum.
/:cl: