### PR TITLE
Readd fabricator design cache queueing

### DIFF
--- a/code/controllers/subsystems/initialization/fabrication.dm
+++ b/code/controllers/subsystems/initialization/fabrication.dm
@@ -11,7 +11,7 @@ SUBSYSTEM_DEF(fabrication)
 	var/list/recipes_by_product_type =     list()
 	var/list/fields_by_id =                list()
 
-	// Fabricators who want their initial recipies
+	// Weakrefs to fabricators who want their initial recipies
 	var/list/fabricators_to_init =         list()
 	// These should be removed after rewriting crafting to respect init order.
 	var/list/crafting_recipes_to_init = list()
@@ -40,6 +40,11 @@ SUBSYSTEM_DEF(fabrication)
 		var/decl/crafting_stage/handler = all_crafting_handlers[hid]
 		if(ispath(handler.begins_with_object_type))
 			LAZYDISTINCTADD(crafting_procedures_by_type[handler.begins_with_object_type], handler)
+
+	for(var/weakref/weak_fab in fabricators_to_init)
+		var/obj/machinery/fabricator/fab = weak_fab.resolve()
+		fab?.refresh_design_cache()
+	fabricators_to_init.Cut()
 
 	for(var/datum/stack_recipe/recipe in crafting_recipes_to_init)
 		recipe.InitializeMaterials()
@@ -101,3 +106,6 @@ SUBSYSTEM_DEF(fabrication)
 				return H
 			else
 				qdel(H)
+
+/datum/controller/subsystem/fabrication/proc/queue_design_cache_refresh(var/obj/machinery/fabricator/fab)
+	fabricators_to_init |= weakref(fab)

--- a/code/modules/fabrication/_fabricator.dm
+++ b/code/modules/fabrication/_fabricator.dm
@@ -67,7 +67,7 @@
 	var/ui_expand_queue     = FALSE
 	var/ui_expand_resources = FALSE
 	var/ui_expand_config    = FALSE
-	var/ui_nb_categories    = 1      //Cached amount of categories in loaded designs. Used to decide if we display the category filter or not 
+	var/ui_nb_categories    = 1      //Cached amount of categories in loaded designs. Used to decide if we display the category filter or not
 
 /obj/machinery/fabricator/Destroy()
 	QDEL_NULL(currently_building)
@@ -112,7 +112,10 @@
 	if(prefilled)
 		fill_to_capacity()
 
-	refresh_design_cache()
+	if(SSfabrication.post_recipe_init)
+		refresh_design_cache()
+	else
+		SSfabrication.queue_design_cache_refresh(src)
 
 /obj/machinery/fabricator/modify_mapped_vars(map_hash)
 	..()


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
When fabricators init and SSfabrication has not yet initialised, they will add themselves to a queue to sync their design cache once it has.
## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This fixes the issue where non-network-connected fabricators won't have their initial/local recipes until they connect to a network.
## Authorship
Me.
<!-- Describe original authors of changes to credit them. -->