### PR TITLE
Add bodytype argument to change_species/set_species

### DIFF
--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -19,6 +19,7 @@
 	//Handle spawning stuff
 	species.handle_pre_spawn(src)
 	species.create_missing_organs(src, TRUE) //Not fully replacing would cause problem with organs not being updated
+	UpdateAppearance()
 	apply_species_appearance()
 	apply_species_cultural_info()
 	species.handle_post_spawn(src)

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -3,7 +3,7 @@
 	AC.flags = flags
 	AC.ui_interact(user, state = state)
 
-/mob/living/carbon/human/proc/change_species(var/new_species)
+/mob/living/carbon/human/proc/change_species(var/new_species, var/new_bodytype = null)
 	if(!new_species)
 		return
 
@@ -13,7 +13,7 @@
 	if(!(new_species in get_all_species()))
 		return
 
-	set_species(new_species)
+	set_species(new_species, new_bodytype)
 	dna.ready_dna(src)
 
 	//Handle spawning stuff
@@ -23,7 +23,7 @@
 	apply_species_cultural_info()
 	species.handle_post_spawn(src)
 	reset_blood()
-	full_prosthetic = null	
+	full_prosthetic = null
 	apply_species_inventory_restrictions()
 
 	var/decl/special_role/antag = mind && player_is_antag(mind)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -646,7 +646,7 @@
 //set_species should not handle the entirety of initing the mob, and should not trigger deep updates
 //It focuses on setting up species-related data, without force applying them uppon organs and the mob's appearance.
 // For transforming an existing mob, look at change_species()
-/mob/living/carbon/human/proc/set_species(var/new_species_name)
+/mob/living/carbon/human/proc/set_species(var/new_species_name, var/new_bodytype = null)
 	if(!new_species_name)
 		CRASH("set_species on mob '[src]' was passed a null species name '[new_species_name]'!")
 	var/new_species = get_species_by_key(new_species_name)
@@ -679,7 +679,9 @@
 		set_gender(new_pronouns.name)
 
 	//Handle bodytype
-	set_bodytype(species.get_bodytype_by_pronouns(new_pronouns), FALSE)
+	if(!new_bodytype)
+		new_bodytype = species.get_bodytype_by_pronouns(new_pronouns)
+	set_bodytype(new_bodytype, FALSE)
 
 	available_maneuvers = species.maneuvers.Copy()
 

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -455,9 +455,11 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 
 //Checks if an existing limbs is the species default
 /decl/species/proc/is_default_limb(var/obj/item/organ/external/E)
-	if((species_flags & SPECIES_FLAG_CRYSTALLINE) && !BP_IS_CRYSTAL(E))
+	// Crystalline/synthetic species should only count crystalline/synthetic limbs as default.
+	// DO NOT change to (species_flags & SPECIES_FLAG_X) && !BP_IS_X(E)
+	if(!(species_flags & SPECIES_FLAG_CRYSTALLINE) != !BP_IS_CRYSTAL(E))
 		return FALSE
-	if((species_flags & SPECIES_FLAG_SYNTHETIC) && !BP_IS_PROSTHETIC(E))
+	if(!(species_flags & SPECIES_FLAG_SYNTHETIC) != !BP_IS_PROSTHETIC(E))
 		return FALSE
 	for(var/tag in has_limbs)
 		if(E.organ_tag == tag)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds a bodytype argument to change_species/set_species.
Fixes a regression with is_default_limb.
Adds a missing UpdateAppearance call to change_species, to mirror copy_to; otherwise, apply_species_organ_modifications doesn't get called.

## Why and what will this PR improve
For changing species to bodytypes with specific limbs this should prevent unnecessary organ rebuilds.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
<!-- Describe original authors of changes to credit them. -->
Me.