### PR TITLE
Allow rotating docking beacons

### DIFF
--- a/code/modules/shuttles/docking_beacon.dm
+++ b/code/modules/shuttles/docking_beacon.dm
@@ -13,6 +13,7 @@
 	uncreated_component_parts = null
 	stat_immune = NOPOWER
 	base_type = /obj/machinery/docking_beacon
+	obj_flags = OBJ_FLAG_ROTATABLE
 	var/display_name					 // Display name of the docking beacon, editable on the docking control program.
 	var/list/permitted_shuttles = list() // Shuttles that are always permitted by the docking beacon.
 	


### PR DESCRIPTION
## Description of changes
Allow rotating docking beacons.

## Changelog
:cl:
bugfix: Allow rotating docking beacons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->