### PR TITLE
Allow /datum/mind/get_client() to actually return the client

### DIFF
--- a/code/modules/client/client_helpers.dm
+++ b/code/modules/client/client_helpers.dm
@@ -1,6 +1,9 @@
 /datum/proc/get_client()
 	return null
 
+/datum/mind/get_client()
+	return current?.client
+
 /client/get_client()
 	return src
 


### PR DESCRIPTION
## Description of changes
Allow mind datum to return their client with get_client(). It seems to have been a weird oversight, considering that get_client is defined at the datum level..

## Changelog
:cl:
code: /datum/mind/get_client() now returns the mind's client instead of null.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->