### PR TITLE
Makes firedoors slightly more performant with area changing.

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -120,8 +120,18 @@ var/global/list/areas = list()
 	for(var/obj/machinery/M in T)
 		M.area_changed(old_area, A) // They usually get moved events, but this is the one way an area can change without triggering one.
 
+	T.update_registrations_on_adjacent_area_change()
+	for(var/direction in global.cardinal)
+		var/turf/adjacent_turf = get_step(T, direction)
+		if(adjacent_turf)
+			T.update_registrations_on_adjacent_area_change()
+
 	if(T.is_outside == OUTSIDE_AREA && T.is_outside() != old_outside)
 		T.update_weather()
+
+/turf/proc/update_registrations_on_adjacent_area_change()
+	for(var/obj/machinery/door/firedoor/door in src)
+		door.update_area_registrations()
 
 /area/proc/alert_on_fall(var/mob/living/carbon/human/H)
 	return

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -85,10 +85,8 @@
 	if(A && !(A in areas_added))
 		LAZYADD(A.all_doors, src)
 		LAZYADD(areas_added, A)
-		events_repository.register(/decl/observ/exited, A, src, .proc/update_area_registrations)
 
 /obj/machinery/door/firedoor/proc/unregister_area(area/A)
-		events_repository.unregister(/decl/observ/exited, A, src)
 		LAZYREMOVE(A.all_doors, src)
 		LAZYREMOVE(areas_added, A)
 


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes

What it says on the tin. The event it was using didn't filter for what had its area changed, so if e.g. you mass-changed an area with a lot of turfs and 5 things per turf, it would fire 5 * (number of turfs) * (number of doors) times. This hook will fire 5 * number of turfs changed, doing most of the work only when a door is adjacent, so something like 5 * (number of doors) + (small constant) * (number of turfs). I'd guess this is like ~10 to 100 times less with shuttles, but haven't tested.

That said, it's not pretty and it's not super efficient.

## Why and what will this PR improve

Apparently current version is awful. This might be slightly better.

## Authorship

me
