### PR TITLE
Network check_connection fix

### DIFF
--- a/code/modules/modular_computers/networking/device_types/_network_device.dm
+++ b/code/modules/modular_computers/networking/device_types/_network_device.dm
@@ -68,7 +68,7 @@
 	if(!net)
 		// We should already be queued for reconnect if it went down, so do nothing.
 		return FALSE
-	if(!net.devices_by_tag[network_tag] != src)
+	if(net.devices_by_tag[network_tag] != src)
 		// The connection has failed but the network is still up, so we try to reconnect.
 		if(!connect())
 			return FALSE


### PR DESCRIPTION

## Description of changes
Fixes an if statement in the ``check_connection()`` proc of network devices
## Why and what will this PR improve
Since ``connect()`` returns TRUE if a device is already in a network, this bug causes issues for devices which implement additional behavior in ``connect()``, which is a problem for Loaf's network telecomms.
## Authorship
Myself
