### PR TITLE
Repathed submap landmarks to /abstract, optimized submap spawn regis.

### DIFF
--- a/code/modules/submaps/_submap.dm
+++ b/code/modules/submaps/_submap.dm
@@ -41,7 +41,7 @@
 		jobs[job.title] = job
 
 	if(!associated_z)
-		testing( "Submap error - [name]/[archetype ? archetype.descriptor : "NO ARCHETYPE"] could not find an associated z-level for spawnpoint placement.")
+		testing( "Submap error - [name]/[archetype ? archetype.descriptor : "NO ARCHETYPE"] could not find an associated z-level for spawnpoint registration.")
 		qdel(src)
 		return
 
@@ -50,16 +50,15 @@
 		sync_cell(cell)
 
 	// Add the spawn points to the appropriate job list.
-	var/added_spawnpoint
+	var/registered_spawnpoint
 	for(var/check_z in GetConnectedZlevels(associated_z))
-		for(var/thing in block(locate(1, 1, check_z), locate(world.maxx, world.maxy, check_z)))
-			for(var/obj/effect/submap_landmark/spawnpoint/landmark in thing)
-				var/datum/job/submap/job = jobs[landmark.name]
-				if(istype(job))
-					job.spawnpoints += landmark
-					added_spawnpoint = TRUE
+		for(var/obj/abstract/submap_landmark/spawnpoint/landmark in LAZYACCESS(global.submap_spawnpoints_by_z, "[check_z]"))
+			var/datum/job/submap/job = jobs[landmark.name]
+			if(istype(job))
+				job.spawnpoints += landmark
+				registered_spawnpoint = TRUE
 
-	if(!added_spawnpoint)
+	if(!registered_spawnpoint)
 		testing( "Submap error - [name]/[archetype ? archetype.descriptor : "NO ARCHETYPE"] has no job spawn points.")
 		qdel(src)
 		return

--- a/code/modules/submaps/submap_landmark.dm
+++ b/code/modules/submaps/submap_landmark.dm
@@ -1,4 +1,4 @@
-/obj/effect/submap_landmark
+/obj/abstract/submap_landmark
 	icon = 'icons/misc/mark.dmi'
 	invisibility = INVISIBILITY_MAXIMUM
 	anchored = TRUE
@@ -6,12 +6,12 @@
 	density = FALSE
 	opacity = FALSE
 
-/obj/effect/submap_landmark/joinable_submap
+/obj/abstract/submap_landmark/joinable_submap
 	icon_state = "x4"
 	var/archetype
 	var/submap_datum_type = /datum/submap
 
-/obj/effect/submap_landmark/joinable_submap/Initialize(var/mapload)
+/obj/abstract/submap_landmark/joinable_submap/Initialize(var/mapload)
 	. = ..(mapload)
 	if(!SSmapping.submaps[name] && ispath(archetype, /decl/submap_archetype))
 		var/datum/submap/submap = new submap_datum_type(z)
@@ -24,8 +24,18 @@
 			to_world_log( "Submap error - mapped landmark had invalid archetype.")
 	return INITIALIZE_HINT_QDEL
 
-/obj/effect/submap_landmark/spawnpoint
+var/global/list/submap_spawnpoints_by_z = list()
+INITIALIZE_IMMEDIATE(/obj/abstract/submap_landmark/spawnpoint)
+/obj/abstract/submap_landmark/spawnpoint
 	icon_state = "x3"
 
-/obj/effect/submap_landmark/spawnpoint/survivor
+/obj/abstract/submap_landmark/spawnpoint/Initialize()
+	. = ..()
+	LAZYADD(global.submap_spawnpoints_by_z["[z]"], src)
+
+/obj/abstract/submap_landmark/spawnpoint/Destroy()
+	LAZYREMOVE(global.submap_spawnpoints_by_z["[z]"], src)
+	. = ..()
+
+/obj/abstract/submap_landmark/spawnpoint/survivor
 	name = "Survivor"

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -293,7 +293,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/item/gun/projectile/pistol/holdout,
 /obj/structure/bed/padded,
-/obj/effect/submap_landmark/spawnpoint/captain,
+/obj/abstract/submap_landmark/spawnpoint/captain,
 /turf/simulated/floor/wood,
 /area/ship/scrap/command/captain)
 "aM" = (
@@ -646,7 +646,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/submap_landmark/joinable_submap/bearcat,
+/obj/abstract/submap_landmark/joinable_submap/bearcat,
 /turf/simulated/floor/tiled/usedup,
 /area/ship/scrap/dock)
 "bs" = (
@@ -1366,7 +1366,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	level = 2
 	},
-/obj/effect/submap_landmark/spawnpoint/crewman,
+/obj/abstract/submap_landmark/spawnpoint/crewman,
 /turf/simulated/floor/tiled/white,
 /area/ship/scrap/crew/cryo)
 "cP" = (
@@ -1566,7 +1566,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/effect/submap_landmark/spawnpoint/crewman,
+/obj/abstract/submap_landmark/spawnpoint/crewman,
 /turf/simulated/floor/tiled/white,
 /area/ship/scrap/crew/cryo)
 "dg" = (
@@ -1744,7 +1744,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/submap_landmark/spawnpoint/crewman,
+/obj/abstract/submap_landmark/spawnpoint/crewman,
 /turf/simulated/floor/tiled/white,
 /area/ship/scrap/crew/cryo)
 "dv" = (

--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -2,7 +2,7 @@
 #include "bearcat_jobs.dm"
 #include "bearcat_access.dm"
 
-/obj/effect/submap_landmark/joinable_submap/bearcat
+/obj/abstract/submap_landmark/joinable_submap/bearcat
 	name = "FTV Bearcat"
 	archetype = /decl/submap_archetype/derelict/bearcat
 

--- a/maps/away/bearcat/bearcat_jobs.dm
+++ b/maps/away/bearcat/bearcat_jobs.dm
@@ -45,8 +45,8 @@
 		else
 			qdel(eyegore)
 
-/obj/effect/submap_landmark/spawnpoint/captain
+/obj/abstract/submap_landmark/spawnpoint/captain
 	name = "Independant Captain"
 
-/obj/effect/submap_landmark/spawnpoint/crewman
+/obj/abstract/submap_landmark/spawnpoint/crewman
 	name = "Independant Crewman"

--- a/maps/away/liberia/liberia.dm
+++ b/maps/away/liberia/liberia.dm
@@ -29,7 +29,7 @@
 		/datum/shuttle/autodock/overmap/mule = list("nav_mule_start")
 	)
 
-/obj/effect/submap_landmark/joinable_submap/liberia
+/obj/abstract/submap_landmark/joinable_submap/liberia
 	name = "Liberia"
 	archetype = /decl/submap_archetype/liberia
 

--- a/maps/away/liberia/liberia.dmm
+++ b/maps/away/liberia/liberia.dmm
@@ -27,7 +27,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/blue/mono,
-/obj/effect/submap_landmark/joinable_submap/liberia,
+/obj/abstract/submap_landmark/joinable_submap/liberia,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/liberia/bridge)
 "ae" = (
@@ -68,7 +68,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
 	},
-/obj/effect/submap_landmark/spawnpoint/liberia,
+/obj/abstract/submap_landmark/spawnpoint/liberia,
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
@@ -88,7 +88,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
 	},
-/obj/effect/submap_landmark/spawnpoint/liberia,
+/obj/abstract/submap_landmark/spawnpoint/liberia,
 /turf/simulated/floor/carpet,
 /area/liberia/personellroom2)
 "ak" = (
@@ -420,7 +420,7 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
-/obj/effect/submap_landmark/spawnpoint/liberia,
+/obj/abstract/submap_landmark/spawnpoint/liberia,
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/cryo)
 "aY" = (
@@ -639,7 +639,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 9
 	},
-/obj/effect/submap_landmark/spawnpoint/liberia,
+/obj/abstract/submap_landmark/spawnpoint/liberia,
 /turf/simulated/floor/tiled,
 /area/liberia/hallway)
 "bo" = (
@@ -2965,7 +2965,7 @@
 /obj/structure/cable/blue{
 	icon_state = "4-8"
 	},
-/obj/effect/submap_landmark/spawnpoint/liberia,
+/obj/abstract/submap_landmark/spawnpoint/liberia,
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/cryo)
 "fi" = (
@@ -2975,7 +2975,7 @@
 /obj/structure/cable/blue{
 	icon_state = "2-8"
 	},
-/obj/effect/submap_landmark/spawnpoint/liberia,
+/obj/abstract/submap_landmark/spawnpoint/liberia,
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/cryo)
 "fk" = (
@@ -3328,7 +3328,7 @@
 /obj/machinery/alarm/liberia{
 	pixel_y = 24
 	},
-/obj/effect/submap_landmark/spawnpoint/liberia,
+/obj/abstract/submap_landmark/spawnpoint/liberia,
 /turf/simulated/floor/wood/ebony,
 /area/liberia/bar)
 "fS" = (
@@ -3351,7 +3351,7 @@
 /obj/structure/cable/blue{
 	icon_state = "0-2"
 	},
-/obj/effect/submap_landmark/spawnpoint/liberia,
+/obj/abstract/submap_landmark/spawnpoint/liberia,
 /turf/simulated/floor/wood/ebony,
 /area/liberia/bar)
 "fU" = (
@@ -3513,7 +3513,7 @@
 "gj" = (
 /obj/structure/bed/chair/wood/walnut,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/submap_landmark/spawnpoint/liberia,
+/obj/abstract/submap_landmark/spawnpoint/liberia,
 /turf/simulated/floor/wood/ebony,
 /area/liberia/bar)
 "gk" = (
@@ -3971,20 +3971,20 @@
 /obj/effect/floor_decal/spline/plain/brown{
 	dir = 10
 	},
-/obj/effect/submap_landmark/spawnpoint/liberia,
+/obj/abstract/submap_landmark/spawnpoint/liberia,
 /turf/simulated/floor/wood/ebony,
 /area/liberia/bar)
 "gY" = (
 /obj/item/stool/padded,
 /obj/effect/floor_decal/spline/plain/brown,
-/obj/effect/submap_landmark/spawnpoint/liberia,
+/obj/abstract/submap_landmark/spawnpoint/liberia,
 /turf/simulated/floor/wood/ebony,
 /area/liberia/bar)
 "gZ" = (
 /obj/item/stool/padded,
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/spline/plain/brown,
-/obj/effect/submap_landmark/spawnpoint/liberia,
+/obj/abstract/submap_landmark/spawnpoint/liberia,
 /turf/simulated/floor/wood/ebony,
 /area/liberia/bar)
 "ha" = (
@@ -5435,7 +5435,7 @@
 /obj/structure/cable/blue{
 	icon_state = "2-8"
 	},
-/obj/effect/submap_landmark/spawnpoint/liberia,
+/obj/abstract/submap_landmark/spawnpoint/liberia,
 /turf/simulated/floor/carpet,
 /area/liberia/library)
 "kr" = (
@@ -6230,7 +6230,7 @@
 /area/liberia/atmos)
 "nH" = (
 /obj/structure/bed/chair/wood/walnut,
-/obj/effect/submap_landmark/spawnpoint/liberia,
+/obj/abstract/submap_landmark/spawnpoint/liberia,
 /turf/simulated/floor/tiled,
 /area/liberia/hallway)
 "nO" = (
@@ -7615,7 +7615,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/effect/submap_landmark/spawnpoint/liberia,
+/obj/abstract/submap_landmark/spawnpoint/liberia,
 /turf/simulated/floor/carpet/blue,
 /area/liberia/personellroom1)
 "HQ" = (
@@ -7708,7 +7708,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 6
 	},
-/obj/effect/submap_landmark/spawnpoint/liberia,
+/obj/abstract/submap_landmark/spawnpoint/liberia,
 /turf/simulated/floor/tiled,
 /area/liberia/hallway)
 "Jf" = (
@@ -8489,7 +8489,7 @@
 	},
 /obj/structure/bed/padded,
 /obj/item/bedsheet/hos,
-/obj/effect/submap_landmark/spawnpoint/liberia,
+/obj/abstract/submap_landmark/spawnpoint/liberia,
 /turf/simulated/floor/carpet/blue,
 /area/liberia/personellroom1)
 "Xe" = (
@@ -8572,7 +8572,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringstorage)
 "YW" = (
-/obj/effect/submap_landmark/spawnpoint/liberia,
+/obj/abstract/submap_landmark/spawnpoint/liberia,
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/cryo)
 "YX" = (

--- a/maps/away/liberia/liberia_jobs.dm
+++ b/maps/away/liberia/liberia_jobs.dm
@@ -34,7 +34,7 @@
 	return ..()
 
 // Spawn points.
-/obj/effect/submap_landmark/spawnpoint/liberia
+/obj/abstract/submap_landmark/spawnpoint/liberia
 	name = "Merchant"
 	movable_flags = MOVABLE_FLAG_EFFECTMOVE
 

--- a/maps/away/unishi/unishi-3.dmm
+++ b/maps/away/unishi/unishi-3.dmm
@@ -9,7 +9,7 @@
 /turf/space,
 /area/space)
 "ac" = (
-/obj/effect/submap_landmark/joinable_submap/unishi,
+/obj/abstract/submap_landmark/joinable_submap/unishi,
 /turf/space,
 /area/space)
 "ad" = (
@@ -109,18 +109,18 @@
 /turf/simulated/floor/tiled,
 /area/unishi/bridge)
 "ax" = (
-/obj/effect/submap_landmark/spawnpoint/unishi_crew,
+/obj/abstract/submap_landmark/spawnpoint/unishi_crew,
 /turf/simulated/floor/tiled,
 /area/unishi/bridge)
 "ay" = (
-/obj/effect/submap_landmark/spawnpoint/unishi_crew,
+/obj/abstract/submap_landmark/spawnpoint/unishi_crew,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/unishi/bridge)
 "az" = (
-/obj/effect/submap_landmark/spawnpoint/unishi_crew,
+/obj/abstract/submap_landmark/spawnpoint/unishi_crew,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -996,7 +996,7 @@
 /turf/simulated/floor/tiled,
 /area/unishi/living)
 "cU" = (
-/obj/effect/submap_landmark/spawnpoint/unishi_researcher,
+/obj/abstract/submap_landmark/spawnpoint/unishi_researcher,
 /turf/simulated/floor/tiled,
 /area/unishi/living)
 "cV" = (

--- a/maps/away/unishi/unishi.dm
+++ b/maps/away/unishi/unishi.dm
@@ -2,7 +2,7 @@
 #include "unishi_jobs.dm"
 #include "../../../mods/content/xenobiology/_xenobiology.dme"
 
-/obj/effect/submap_landmark/joinable_submap/unishi
+/obj/abstract/submap_landmark/joinable_submap/unishi
 	name = "SRV Verne"
 	archetype = /decl/submap_archetype/derelict/unishi
 

--- a/maps/away/unishi/unishi_jobs.dm
+++ b/maps/away/unishi/unishi_jobs.dm
@@ -39,8 +39,8 @@
 	r_pocket = /obj/item/radio
 	l_pocket = /obj/item/crowbar
 
-/obj/effect/submap_landmark/spawnpoint/unishi_crew
+/obj/abstract/submap_landmark/spawnpoint/unishi_crew
 	name = "Unishi Crew"
 
-/obj/effect/submap_landmark/spawnpoint/unishi_researcher
+/obj/abstract/submap_landmark/spawnpoint/unishi_researcher
 	name = "Unishi Researcher"

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
@@ -37,15 +37,15 @@ var/global/list/crashed_pod_areas = list()
 		signal might draw help, but even if you should be so lucky, you must survive long \
 		enough for it to arrive."
 
-/obj/effect/submap_landmark/spawnpoint/crashed_pod_survivor
+/obj/abstract/submap_landmark/spawnpoint/crashed_pod_survivor
 	name = "Stranded Survivor"
 
-/obj/effect/submap_landmark/joinable_submap/crashed_pod
+/obj/abstract/submap_landmark/joinable_submap/crashed_pod
 	name = "Crashed Survival Pod"
 	archetype = /decl/submap_archetype/crashed_pod
 	submap_datum_type = /datum/submap/crashed_pod
 
-/obj/effect/submap_landmark/joinable_submap/crashed_pod/Initialize(mapload)
+/obj/abstract/submap_landmark/joinable_submap/crashed_pod/Initialize(mapload)
 	var/list/possible_ship_names = list(
 		"Hornet",		"Witchmoth",	"Planthopper",
 		"Mayfly",		"Locust",		"Cicada",

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -17,7 +17,7 @@
 /obj/structure/wall_frame,
 /obj/structure/grille,
 /obj/structure/window/borosilicate_reinforced/full,
-/obj/effect/submap_landmark/joinable_submap/crashed_pod,
+/obj/abstract/submap_landmark/joinable_submap/crashed_pod,
 /turf/simulated/floor/plating,
 /area/map_template/crashed_pod)
 "ae" = (
@@ -447,7 +447,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "aZ" = (
-/obj/effect/submap_landmark/spawnpoint/crashed_pod_survivor,
+/obj/abstract/submap_landmark/spawnpoint/crashed_pod_survivor,
 /obj/structure/bed/chair/shuttle/black,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -471,7 +471,7 @@
 /turf/simulated/floor/plating,
 /area/map_template/crashed_pod)
 "bc" = (
-/obj/effect/submap_landmark/spawnpoint/crashed_pod_survivor,
+/obj/abstract/submap_landmark/spawnpoint/crashed_pod_survivor,
 /obj/structure/bed/chair/shuttle/black,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -499,7 +499,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "bf" = (
-/obj/effect/submap_landmark/spawnpoint/crashed_pod_survivor,
+/obj/abstract/submap_landmark/spawnpoint/crashed_pod_survivor,
 /obj/structure/bed/chair/shuttle/black,
 /obj/structure/window/reinforced{
 	dir = 4

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -95,7 +95,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/command)
 "aq" = (
-/obj/effect/submap_landmark/joinable_submap/colony,
+/obj/abstract/submap_landmark/joinable_submap/colony,
 /turf/template_noop,
 /area/template_noop)
 "ar" = (
@@ -406,7 +406,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/command)
 "bg" = (
-/obj/effect/submap_landmark/spawnpoint/colonist_spawn,
+/obj/abstract/submap_landmark/spawnpoint/colonist_spawn,
 /obj/structure/bed/padded,
 /obj/item/bedsheet/hop,
 /obj/machinery/light/small{
@@ -1526,7 +1526,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/colony/engineering)
 "dB" = (
-/obj/effect/submap_landmark/spawnpoint/colonist_spawn,
+/obj/abstract/submap_landmark/spawnpoint/colonist_spawn,
 /obj/structure/bed/padded,
 /obj/item/bedsheet/hos,
 /turf/simulated/floor/carpet,
@@ -2292,7 +2292,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/dorms)
 "eX" = (
-/obj/effect/submap_landmark/spawnpoint/colonist_spawn,
+/obj/abstract/submap_landmark/spawnpoint/colonist_spawn,
 /obj/structure/bed/padded,
 /obj/item/gun/energy/gun/small,
 /obj/item/flashlight/upgraded,

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
@@ -42,10 +42,10 @@
 	id_type = null
 	pda_type = null
 
-/obj/effect/submap_landmark/spawnpoint/colonist_spawn
+/obj/abstract/submap_landmark/spawnpoint/colonist_spawn
 	name = "Colonist"
 
-/obj/effect/submap_landmark/joinable_submap/colony
+/obj/abstract/submap_landmark/joinable_submap/colony
 	name = "Established Colony"
 	archetype = /decl/submap_archetype/playablecolony
 


### PR DESCRIPTION
## Description of changes
- Repathed submap landmarks from /effect to /abstract to line them up with other landmarks.
- Added a global list per z to optimize submap spawnpoint to job registration.

## Why and what will this PR improve
Previous code is checking the entire submap turf by turf. Not great.

## Authorship
Myself.

## Changelog
Nothing player facing.