### PR TITLE
Fix fabricator recipe typo fuel manifold

### DIFF
--- a/code/modules/fabrication/designs/pipe/pipe_datums.dm
+++ b/code/modules/fabrication/designs/pipe/pipe_datums.dm
@@ -191,7 +191,7 @@
 	rotate_class = PIPE_ROTATE_STANDARD
 
 /datum/fabricator_recipe/pipe/fuel/manifold4w
-	name = "four-way supply pipe manifold fitting"
+	name = "four-way fuel pipe manifold fitting"
 	desc = "a four-way fuel pipe manifold segment"
 	build_icon_state = "manifold4w"
 	constructed_path = /obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
The 4 way fuel manifold was named "supply manifold" in the recipe name. So changed it to fuel manifold.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
<!-- Describe original authors of changes to credit them. -->

## Changelog
:cl:
spellcheck: Properly named the 4-ways fuel manifold fabricator recipe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->