### PR TITLE
Fabs now generate their capacity list from available recipes.

### DIFF
--- a/code/modules/fabrication/_fabricator.dm
+++ b/code/modules/fabrication/_fabricator.dm
@@ -145,7 +145,7 @@
 		for(var/species_type in R.species_locked)
 			if(!(ispath(species_variation, species_type)))
 				design_cache.Remove(R)
-				return
+				continue
 
 	design_cache = sortTim(design_cache, /proc/cmp_name_asc)
 	ui_nb_categories = LAZYLEN(unique_categories)
@@ -155,9 +155,8 @@
 		for(var/mat in add_mat_to_storage_cap)
 			if(mat in base_storage_capacity)
 				continue
-			if(!(mat in base_storage_capacity))
-				base_storage_capacity[mat] = (SHEET_MATERIAL_AMOUNT * base_storage_capacity_mult)
-				need_storage_recalc = TRUE
+			need_storage_recalc = TRUE
+			base_storage_capacity[mat] = (SHEET_MATERIAL_AMOUNT * base_storage_capacity_mult)
 			if(!(mat in stored_material))
 				stored_material[mat] = 0
 

--- a/code/modules/fabrication/designs/_design.dm
+++ b/code/modules/fabrication/designs/_design.dm
@@ -64,7 +64,7 @@
 				.[M.type] = matter[material]
 	if(reagents && length(reagents.reagent_volumes))
 		for(var/R in reagents.reagent_volumes)
-			.[R] = REAGENT_VOLUME(reagents, R)
+			.[R] = FLOOR(REAGENT_VOLUME(reagents, R) / REAGENT_UNITS_PER_MATERIAL_UNIT)
 
 /datum/fabricator_recipe/proc/build(var/turf/location, var/datum/fabricator_build_order/order)
 	. = list()

--- a/code/modules/fabrication/designs/imprinter/_designs_imprinter.dm
+++ b/code/modules/fabrication/designs/imprinter/_designs_imprinter.dm
@@ -4,4 +4,5 @@
 
 /datum/fabricator_recipe/imprinter/get_resources()
 	. = ..()
-	LAZYSET(resources, /decl/material/liquid/acid, 20)
+	// 1 sheet of matter is 20u of reagents, which is converted during fabricator input
+	LAZYSET(resources, /decl/material/liquid/acid, SHEET_MATERIAL_AMOUNT)

--- a/code/modules/fabrication/fabricator_bioprinter.dm
+++ b/code/modules/fabrication/fabricator_bioprinter.dm
@@ -8,9 +8,6 @@
 	base_icon_state = "bioprinter"
 	base_type = /obj/machinery/fabricator/bioprinter
 	fabricator_class = FABRICATOR_CLASS_MEAT
-	base_storage_capacity = list(
-		/decl/material/solid/meat = SHEET_MATERIAL_AMOUNT * 100
-	)
 	var/datum/dna/loaded_dna //DNA for biological organs
 
 /obj/machinery/fabricator/bioprinter/get_nano_template()

--- a/code/modules/fabrication/fabricator_books.dm
+++ b/code/modules/fabrication/fabricator_books.dm
@@ -8,10 +8,6 @@
 	active_power_usage = 1000
 	base_type = /obj/machinery/fabricator/book
 	fabricator_class = FABRICATOR_CLASS_BOOKS
-	base_storage_capacity = list(
-		/decl/material/solid/wood =      SHEET_MATERIAL_AMOUNT * 20,
-		/decl/material/solid/plastic =   SHEET_MATERIAL_AMOUNT * 20
-	)
 	color_selectable = TRUE
 
 /obj/machinery/fabricator/book/make_order(datum/fabricator_recipe/recipe, multiplier)

--- a/code/modules/fabrication/fabricator_food.dm
+++ b/code/modules/fabrication/fabricator_food.dm
@@ -5,10 +5,8 @@
 	icon = 'icons/obj/machines/fabricators/replicator.dmi'
 	icon_state = "replicator"
 	base_icon_state = "replicator"
+	base_storage_capacity_mult = 5
 	has_recycler = FALSE
-	base_storage_capacity = list(
-		/decl/material/liquid/nutriment = 100
-	)
 
 /obj/machinery/fabricator/replicator/hear_talk(var/mob/M, var/text, var/verb, var/decl/language/speaking)
 	if(speaking && !speaking.machine_understands)

--- a/code/modules/fabrication/fabricator_imprinter.dm
+++ b/code/modules/fabrication/fabricator_imprinter.dm
@@ -9,13 +9,4 @@
 	base_type = /obj/machinery/fabricator/imprinter
 	has_recycler = FALSE
 	fabricator_class = FABRICATOR_CLASS_IMPRINTER
-	base_storage_capacity = list(
-		/decl/material/solid/glass =              SHEET_MATERIAL_AMOUNT * 50,
-		/decl/material/solid/fiberglass =         SHEET_MATERIAL_AMOUNT * 50,
-		/decl/material/solid/metal/gold =         SHEET_MATERIAL_AMOUNT * 50,
-		/decl/material/solid/metal/silver =       SHEET_MATERIAL_AMOUNT * 50,
-		/decl/material/solid/gemstone/diamond =   SHEET_MATERIAL_AMOUNT * 50,
-		/decl/material/liquid/acid =              120,
-		/decl/material/liquid/acid/hydrochloric = 120,
-		/decl/material/liquid/acid/polyacid =     120
-	)
+	base_storage_capacity_mult = 50

--- a/code/modules/fabrication/fabricator_industrial.dm
+++ b/code/modules/fabrication/fabricator_industrial.dm
@@ -8,18 +8,5 @@
 	active_power_usage = 5000
 	base_type = /obj/machinery/fabricator/industrial
 	fabricator_class = FABRICATOR_CLASS_INDUSTRIAL
-	base_storage_capacity = list(
-		/decl/material/solid/metal/steel =      SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/plasteel =   SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/fiberglass =       SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/osmium =     SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/aluminium =  SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/plastic =          SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/glass =            SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/gold =       SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/silver =     SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/uranium =    SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/gemstone/diamond = SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/titanium =   SHEET_MATERIAL_AMOUNT * 100
-	)
+	base_storage_capacity_mult = 100
 	output_dir = EAST

--- a/code/modules/fabrication/fabricator_intake.dm
+++ b/code/modules/fabrication/fabricator_intake.dm
@@ -9,11 +9,14 @@
 	for(var/R in thing.reagents.reagent_volumes)
 		if(!base_storage_capacity[R])
 			continue
-		var/taking_reagent = min(REAGENT_VOLUME(thing.reagents, R), storage_capacity[R] - stored_material[R])
+		var/taking_reagent = min(REAGENT_VOLUME(thing.reagents, R), FLOOR((storage_capacity[R] - stored_material[R]) * REAGENT_UNITS_PER_MATERIAL_UNIT))
 		if(taking_reagent <= 0)
 			continue
+		var/reagent_matter = round(taking_reagent / REAGENT_UNITS_PER_MATERIAL_UNIT)
+		if(reagent_matter <= 0)
+			continue
 		thing.reagents.remove_reagent(R, taking_reagent)
-		stored_material[R] += taking_reagent
+		stored_material[R] += reagent_matter
 		// If we're destroying this, take everything.
 		if(destructive)
 			. = SUBSTANCE_TAKEN_ALL

--- a/code/modules/fabrication/fabricator_microlathe.dm
+++ b/code/modules/fabrication/fabricator_microlathe.dm
@@ -8,12 +8,7 @@
 	active_power_usage = 1000
 	base_type = /obj/machinery/fabricator/micro
 	fabricator_class = FABRICATOR_CLASS_MICRO
-	base_storage_capacity = list(
-		/decl/material/solid/metal/aluminium = SHEET_MATERIAL_AMOUNT * 5,
-		/decl/material/solid/plastic =         SHEET_MATERIAL_AMOUNT * 5,
-		/decl/material/solid/glass   =         SHEET_MATERIAL_AMOUNT * 5,
-		/decl/material/solid/fiberglass =      SHEET_MATERIAL_AMOUNT * 5
-	)
+	base_storage_capacity_mult = 5
 
 //Subtype for mapping, starts preloaded with glass and set to print glasses
 /obj/machinery/fabricator/micro/bartender

--- a/code/modules/fabrication/fabricator_microlathe.dm
+++ b/code/modules/fabrication/fabricator_microlathe.dm
@@ -10,10 +10,7 @@
 	fabricator_class = FABRICATOR_CLASS_MICRO
 	base_storage_capacity_mult = 5
 
-//Subtype for mapping, starts preloaded with glass and set to print glasses
+//Subtype for mapping, starts preloaded and set to print glasses
 /obj/machinery/fabricator/micro/bartender
 	show_category = "Drinking Glasses"
-
-/obj/machinery/fabricator/micro/bartender/Initialize()
-	. = ..()
-	stored_material[/decl/material/solid/glass] = base_storage_capacity[/decl/material/solid/glass]
+	prefilled = TRUE

--- a/code/modules/fabrication/fabricator_protolathe.dm
+++ b/code/modules/fabrication/fabricator_protolathe.dm
@@ -8,14 +8,4 @@
 	active_power_usage = 5000
 	base_type = /obj/machinery/fabricator/protolathe
 	fabricator_class = FABRICATOR_CLASS_PROTOLATHE
-	base_storage_capacity = list(
-		/decl/material/solid/metal/steel =      SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/aluminium =  SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/plastic =          SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/glass =            SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/fiberglass =       SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/gold =       SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/silver =     SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/uranium =    SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/gemstone/diamond = SHEET_MATERIAL_AMOUNT * 100
-	)
+	base_storage_capacity_mult = 100

--- a/code/modules/fabrication/fabricator_robotics.dm
+++ b/code/modules/fabrication/fabricator_robotics.dm
@@ -8,17 +8,7 @@
 	active_power_usage = 5000
 	base_type = /obj/machinery/fabricator/robotics
 	fabricator_class = FABRICATOR_CLASS_ROBOTICS
-	base_storage_capacity = list(
-		/decl/material/solid/metal/steel =      SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/aluminium =  SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/plastic =          SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/glass =            SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/fiberglass =       SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/gold =       SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/silver =     SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/uranium =    SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/gemstone/diamond = SHEET_MATERIAL_AMOUNT * 100
-	)
+	base_storage_capacity_mult = 100
 	var/picked_prosthetic_species //Prosthetics will be printed with this species
 
 /obj/machinery/fabricator/robotics/Initialize()

--- a/code/modules/fabrication/fabricator_textile.dm
+++ b/code/modules/fabrication/fabricator_textile.dm
@@ -8,20 +8,4 @@
 	active_power_usage = 5000
 	base_type = /obj/machinery/fabricator/textile
 	fabricator_class = FABRICATOR_CLASS_TEXTILE
-	base_storage_capacity = list(
-		/decl/material/solid/metal/steel =      SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/aluminium =  SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/plastic =          SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/glass =            SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/fiberglass =       SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/gold =       SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/silver =     SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/uranium =    SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/gemstone/diamond = SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/cloth =            SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/leather =          SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/cardboard =        SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/titanium =   SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/metal/plasteel =   SHEET_MATERIAL_AMOUNT * 100,
-		/decl/material/solid/leather/synth = 	SHEET_MATERIAL_AMOUNT * 100
-	)
+	base_storage_capacity_mult = 100

--- a/code/modules/fabrication/fabricator_topic.dm
+++ b/code/modules/fabrication/fabricator_topic.dm
@@ -66,7 +66,8 @@
 	if(!mat_path || !stored_material[mat_path])
 		return
 	// TODO: proper liquid reagent ejection checks (acid sheet ejection...).
-	if(ispath(mat_path, /decl/material/gas) || ispath(mat_path, /decl/material/liquid))
+	var/decl/material/mat = GET_DECL(mat_path)
+	if(mat?.phase_at_stp() != MAT_PHASE_SOLID)
 		stored_material[mat_path] = 0
 	else
 		var/sheet_count = FLOOR(stored_material[mat_path]/SHEET_MATERIAL_AMOUNT)

--- a/code/modules/fabrication/fabricator_ui.dm
+++ b/code/modules/fabrication/fabricator_ui.dm
@@ -20,12 +20,13 @@
 	for(var/material in storage_capacity)
 		var/decl/material/mat = GET_DECL(material)
 		var/list/material_data = list()
+		// TODO proper state checks
+		var/is_solid = !ispath(material, /decl/material/liquid) && !ispath(material, /decl/material/gas)
 		material_data["name"]        = capitalize(mat.use_name)
 		material_data["stored"]      = stored_material[material] ? stored_material[material] : 0
 		material_data["max"]         = storage_capacity[material]
-		material_data["unit"]        = SHEET_UNIT
+		material_data["unit"]        = is_solid ? SHEET_UNIT : "ml"
 		material_data["eject_key"]   = "\ref[GET_DECL(material)]"
-		material_data["eject_label"] = ispath(material, /decl/material/liquid) ? "Flush" : "Eject"
 		material_storage += list(material_data)
 	return material_storage
 

--- a/code/modules/fabrication/fabricator_ui.dm
+++ b/code/modules/fabrication/fabricator_ui.dm
@@ -20,8 +20,7 @@
 	for(var/material in storage_capacity)
 		var/decl/material/mat = GET_DECL(material)
 		var/list/material_data = list()
-		// TODO proper state checks
-		var/is_solid = !ispath(material, /decl/material/liquid) && !ispath(material, /decl/material/gas)
+		var/is_solid = (mat.phase_at_stp() == MAT_PHASE_SOLID)
 		material_data["name"]        = capitalize(mat.use_name)
 		material_data["stored"]      = stored_material[material] ? stored_material[material] : 0
 		material_data["max"]         = storage_capacity[material]

--- a/code/modules/fabrication/fabricator_ui.dm
+++ b/code/modules/fabrication/fabricator_ui.dm
@@ -18,14 +18,14 @@
 /obj/machinery/fabricator/proc/ui_fabricator_resource_data()
 	var/material_storage =  list()
 	for(var/material in storage_capacity)
+		var/decl/material/mat = GET_DECL(material)
 		var/list/material_data = list()
-		var/mat_name = capitalize(stored_substances_to_names[material])
-		material_data["name"]        = mat_name
+		material_data["name"]        = capitalize(mat.use_name)
 		material_data["stored"]      = stored_material[material] ? stored_material[material] : 0
 		material_data["max"]         = storage_capacity[material]
 		material_data["unit"]        = SHEET_UNIT
-		material_data["eject_key"]   = stored_substances_to_names[material]
-		material_data["eject_label"] = ispath(material, /decl/material) ? "Eject" : "Flush"
+		material_data["eject_key"]   = "\ref[GET_DECL(material)]"
+		material_data["eject_label"] = ispath(material, /decl/material/liquid) ? "Flush" : "Eject"
 		material_storage += list(material_data)
 	return material_storage
 
@@ -94,9 +94,12 @@
 	var/max_sheets          = (!length(R.resources)) ? 100 : null
 	var/has_missing_resource = FALSE
 	for(var/material_path in R.resources)
+
 		var/required_amount = round(R.resources[material_path] * mat_efficiency)
 		var/sheets          = round(stored_material[material_path] / required_amount)
 		var/has_enough      = TRUE
+
+		var/decl/material/mat = GET_DECL(material_path)
 
 		if(isnull(max_sheets) || max_sheets > sheets)
 			max_sheets = sheets
@@ -106,7 +109,7 @@
 
 		//Must make it a double list here or the fields are just overwriting eachothers
 		material_components += list(list(
-				"name"       = stored_substances_to_names[material_path],
+				"name"       = capitalize(mat.use_name),
 				"amount"     = required_amount,
 				"has_enough" = has_enough, 
 			))

--- a/code/unit_tests/machine_tests.dm
+++ b/code/unit_tests/machine_tests.dm
@@ -66,24 +66,3 @@
 	else
 		pass("All machines had valid construction states.")
 	return  1
-
-
-/datum/unit_test/fabricator_recipes_shall_be_buildable
-	name = "MACHINE: All fabricators will be able to produce all of their recipes"
-
-/datum/unit_test/fabricator_recipes_shall_be_buildable/start_test()
-	var/failed = list()
-	for(var/thing in typesof(/obj/machinery/fabricator))
-		var/obj/machinery/fabricator/fab = new thing
-		for(var/datum/fabricator_recipe/recipe in SSfabrication.get_all_recipes(fab.fabricator_class))
-			for(var/mat in recipe.resources)
-				if(isnull(fab.storage_capacity[mat]))
-					log_bad("[fab.name] ([fab.type]) could not print [recipe.name] due to lacking [mat].")
-					failed += thing
-					break
-		qdel(fab)
-	if(length(failed))
-		fail("One or more fabricators could not produce an associated recipe.")
-	else
-		pass("All fabricators could produce their associated recipes.")
-	return  1


### PR DESCRIPTION
## Description of changes
- Fabricators populate base_storage_capacity in refresh_design_cache using the materials required by recipes.
- Fabricators convert reagent units to matter units during intake.

## Why and what will this PR improve
Less manual definition needed for fabs, more compatibility with arbitrary recipes.

## Authorship
@NataKilar's suggestion, my code.

## Changelog
:cl:
tweak: Fabricator recipes now use matter units universally, including for reagent requirements.
/:cl: