### PR TITLE
Make small common machines less annoying to build/repair

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -58,8 +58,7 @@
 
 	base_type = /obj/machinery/alarm
 	frame_type = /obj/item/frame/air_alarm
-	stat_immune = 0
-	uncreated_component_parts = null
+	uncreated_component_parts = list(/obj/item/stock_parts/power/apc = 1)
 	construct_state = /decl/machine_construction/wall_frame/panel_closed
 	wires = /datum/wires/alarm
 
@@ -831,8 +830,7 @@ FIRE ALARM
 
 	base_type = /obj/machinery/firealarm
 	frame_type = /obj/item/frame/fire_alarm
-	stat_immune = 0
-	uncreated_component_parts = null
+	uncreated_component_parts = list(/obj/item/stock_parts/power/apc = 1)
 	construct_state = /decl/machine_construction/wall_frame/panel_closed
 
 	var/detecting =    TRUE

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -9,7 +9,7 @@
 	idle_power_usage = 15
 
 	uncreated_component_parts = list(
-		/obj/item/stock_parts/power/apc/buildable
+		/obj/item/stock_parts/power/apc
 	)
 	public_variables = list(
 		/decl/public_access/public_variable/gas,
@@ -18,9 +18,9 @@
 	)
 	stock_part_presets = list(/decl/stock_part_preset/radio/basic_transmitter/meter = 1)
 
-	frame_type = /obj/item/machine_chassis/pipe_meter/base
+	frame_type = /obj/item/machine_chassis/pipe_meter
 	construct_state = /decl/machine_construction/default/panel_closed/item_chassis
-	base_type = /obj/machinery/meter/buildable
+	base_type = /obj/machinery/meter
 
 /obj/machinery/meter/Initialize()
 	. = ..()
@@ -103,13 +103,10 @@
 		set_target(loc)
 	. = ..()
 
-/obj/machinery/meter/buildable
-	uncreated_component_parts = null
-
 /obj/machinery/meter/starts_with_radio
 	uncreated_component_parts = list(
 		/obj/item/stock_parts/radio/transmitter/basic/buildable,
-		/obj/item/stock_parts/power/apc/buildable
+		/obj/item/stock_parts/power/apc
 	)
 
 /decl/stock_part_preset/radio/basic_transmitter/meter

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -32,7 +32,7 @@
 
 /obj/machinery/button/buildable
 	uncreated_component_parts = list(
-		/obj/item/stock_parts/radio/transmitter/basic = 1,
+		/obj/item/stock_parts/power/apc = 1,
 	)
 
 /obj/machinery/button/Initialize()

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -17,10 +17,10 @@
 	public_methods = list(/decl/public_access/public_method/toggle_input_toggle)
 	stock_part_presets = list(/decl/stock_part_preset/radio/basic_transmitter/button = 1)
 	uncreated_component_parts = list(
-		/obj/item/stock_parts/power/apc/buildable,
-		/obj/item/stock_parts/radio/transmitter/basic/buildable
+		/obj/item/stock_parts/power/apc = 1,
+		/obj/item/stock_parts/radio/transmitter/basic = 1
 	)
-	base_type = /obj/machinery/button/buildable
+	base_type = /obj/machinery/button
 	construct_state = /decl/machine_construction/wall_frame/panel_closed/simple
 	frame_type = /obj/item/frame/button
 	required_interaction_dexterity = DEXTERITY_SIMPLE_MACHINES
@@ -29,9 +29,6 @@
 	var/operating = FALSE
 	var/state = FALSE
 	var/cooldown = 1 SECOND
-
-/obj/machinery/button/buildable
-	uncreated_component_parts = null
 
 /obj/machinery/button/Initialize()
 	. = ..()

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -18,9 +18,9 @@
 	stock_part_presets = list(/decl/stock_part_preset/radio/basic_transmitter/button = 1)
 	uncreated_component_parts = list(
 		/obj/item/stock_parts/power/apc = 1,
-		/obj/item/stock_parts/radio/transmitter/basic = 1
+		/obj/item/stock_parts/radio/transmitter/basic/buildable = 1
 	)
-	base_type = /obj/machinery/button
+	base_type = /obj/machinery/button/buildable
 	construct_state = /decl/machine_construction/wall_frame/panel_closed/simple
 	frame_type = /obj/item/frame/button
 	required_interaction_dexterity = DEXTERITY_SIMPLE_MACHINES
@@ -29,6 +29,11 @@
 	var/operating = FALSE
 	var/state = FALSE
 	var/cooldown = 1 SECOND
+
+/obj/machinery/button/buildable
+	uncreated_component_parts = list(
+		/obj/item/stock_parts/radio/transmitter/basic = 1,
+	)
 
 /obj/machinery/button/Initialize()
 	. = ..()

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -106,18 +106,15 @@
 	public_methods = list(/decl/public_access/public_method/toggle_input_toggle)
 	stock_part_presets = list(/decl/stock_part_preset/radio/basic_transmitter/airlock_sensor = 1)
 	uncreated_component_parts = list(
-		/obj/item/stock_parts/power/apc/buildable,
-		/obj/item/stock_parts/radio/transmitter/basic/buildable
+		/obj/item/stock_parts/power/apc,
+		/obj/item/stock_parts/radio/transmitter/basic
 	)
-	base_type = /obj/machinery/airlock_sensor/buildable
+	base_type = /obj/machinery/airlock_sensor
 	construct_state = /decl/machine_construction/wall_frame/panel_closed/simple
 	frame_type = /obj/item/frame/button/airlock_sensor
 
 	var/alert = 0
 	var/pressure
-
-/obj/machinery/airlock_sensor/buildable
-	uncreated_component_parts = null
 
 /obj/machinery/airlock_sensor/on_update_icon()
 	if(!(stat & (NOPOWER | BROKEN)))
@@ -185,8 +182,8 @@
 		/decl/stock_part_preset/radio/event_transmitter/access_button = 1
 	)
 	uncreated_component_parts = list(
-		/obj/item/stock_parts/power/apc/buildable,
-		/obj/item/stock_parts/radio/transmitter/on_event/buildable
+		/obj/item/stock_parts/power/apc,
+		/obj/item/stock_parts/radio/transmitter/on_event
 	)
 	var/command = "cycle"
 

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -95,8 +95,7 @@
 	icon = 'icons/obj/airlock_machines.dmi'
 	icon_state = "airlock_sensor_off"
 	layer = ABOVE_WINDOW_LAYER
-
-	anchored = 1
+	anchored = TRUE
 	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 	power_channel = ENVIRON
 	public_variables = list(
@@ -106,15 +105,20 @@
 	public_methods = list(/decl/public_access/public_method/toggle_input_toggle)
 	stock_part_presets = list(/decl/stock_part_preset/radio/basic_transmitter/airlock_sensor = 1)
 	uncreated_component_parts = list(
-		/obj/item/stock_parts/power/apc,
-		/obj/item/stock_parts/radio/transmitter/basic/buildable
+		/obj/item/stock_parts/power/apc = 1,
+		/obj/item/stock_parts/radio/transmitter/basic/buildable = 1
 	)
-	base_type = /obj/machinery/airlock_sensor
+	base_type = /obj/machinery/airlock_sensor/buildable
 	construct_state = /decl/machine_construction/wall_frame/panel_closed/simple
 	frame_type = /obj/item/frame/button/airlock_sensor
 
 	var/alert = 0
 	var/pressure
+
+/obj/machinery/airlock_sensor/buildable
+	uncreated_component_parts = list(
+		/obj/item/stock_parts/power/apc = 1
+	)
 
 /obj/machinery/airlock_sensor/on_update_icon()
 	if(!(stat & (NOPOWER | BROKEN)))

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -107,7 +107,7 @@
 	stock_part_presets = list(/decl/stock_part_preset/radio/basic_transmitter/airlock_sensor = 1)
 	uncreated_component_parts = list(
 		/obj/item/stock_parts/power/apc,
-		/obj/item/stock_parts/radio/transmitter/basic
+		/obj/item/stock_parts/radio/transmitter/basic/buildable
 	)
 	base_type = /obj/machinery/airlock_sensor
 	construct_state = /decl/machine_construction/wall_frame/panel_closed/simple
@@ -183,7 +183,7 @@
 	)
 	uncreated_component_parts = list(
 		/obj/item/stock_parts/power/apc,
-		/obj/item/stock_parts/radio/transmitter/on_event
+		/obj/item/stock_parts/radio/transmitter/on_event/buildable
 	)
 	var/command = "cycle"
 

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -265,8 +265,8 @@
 	)
 	uncreated_component_parts = list(
 		/obj/item/stock_parts/power/apc,
-		/obj/item/stock_parts/radio/transmitter/on_event,
-		/obj/item/stock_parts/radio/receiver
+		/obj/item/stock_parts/radio/transmitter/on_event/buildable,
+		/obj/item/stock_parts/radio/receiver/buildable
 	)
 
 /obj/machinery/button/blast_door/Initialize(mapload)

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -264,9 +264,9 @@
 		/decl/stock_part_preset/radio/receiver/blast_door_button = 1
 	)
 	uncreated_component_parts = list(
-		/obj/item/stock_parts/power/apc/buildable,
-		/obj/item/stock_parts/radio/transmitter/on_event/buildable,
-		/obj/item/stock_parts/radio/receiver/buildable
+		/obj/item/stock_parts/power/apc,
+		/obj/item/stock_parts/radio/transmitter/on_event,
+		/obj/item/stock_parts/radio/receiver
 	)
 
 /obj/machinery/button/blast_door/Initialize(mapload)

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -20,12 +20,9 @@
 	construct_state = /decl/machine_construction/wall_frame/panel_closed/simple
 	frame_type = /obj/item/frame/button/light_switch
 	uncreated_component_parts = list(
-		/obj/item/stock_parts/power/apc/buildable
+		/obj/item/stock_parts/power/apc
 	)
-	base_type = /obj/machinery/light_switch/buildable
-
-/obj/machinery/light_switch/buildable
-	uncreated_component_parts = null
+	base_type = /obj/machinery/light_switch
 
 /obj/machinery/light_switch/on
 	on = TRUE

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -80,5 +80,5 @@
 	. = ..()
 	if(!.)
 		to_chat(user, SPAN_NOTICE("You flick \the [src] with \the [I]."))
-		interface_interact(user)
+		interface_interact(user) 
 		return TRUE

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -154,9 +154,6 @@ Buildable meters
 	w_class = ITEM_SIZE_LARGE
 	build_type = /obj/machinery/meter
 
-/obj/item/machine_chassis/pipe_meter/base
-	build_type = /obj/machinery/meter/buildable
-
 /obj/item/machine_chassis/igniter
 	name = "igniter"
 	desc = "A device which will ignite surrounding gasses."

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -135,7 +135,7 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "launcherbtt"
 	material = /decl/material/solid/metal/steel
-	build_machine_type = /obj/machinery/button
+	build_machine_type = /obj/machinery/button/buildable
 
 /obj/item/frame/camera
 	name = "security camera frame"

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -244,6 +244,11 @@
 	icon_state = "airlock_sensor_off"
 	name = "airlock sensor"
 	desc = "An airlock sensor frame."
+
+/obj/item/frame/button/airlock_sensor/kit
+	fully_construct = TRUE
+	name = "airlock sensor kit"
+	desc = "An all-in-one airlock sensor kit, comes preassembled with a radio transmitter."
 	build_machine_type = /obj/machinery/airlock_sensor
 
 /obj/item/frame/button/airlock_controller

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -109,33 +109,33 @@
 	desc = "Used for building lights."
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "tube-construct-item"
-	build_machine_type = /obj/machinery/light/buildable
+	build_machine_type = /obj/machinery/light
 	reverse = 1
 
 /obj/item/frame/light/small
 	name = "small light fixture frame"
 	icon_state = "bulb-construct-item"
 	material = /decl/material/solid/metal/steel
-	build_machine_type = /obj/machinery/light/small/buildable
+	build_machine_type = /obj/machinery/light/small
 
 /obj/item/frame/light/spot
 	name = "spotlight fixture frame"
 	icon_state = "tube-construct-item"
 	material = /decl/material/solid/metal/steel
-	build_machine_type = /obj/machinery/light/spot/buildable
+	build_machine_type = /obj/machinery/light/spot
 
 /obj/item/frame/light/nav
 	name = "navigation light fixture frame"
 	icon_state = "tube-construct-item"
 	material = /decl/material/solid/metal/steel
-	build_machine_type = /obj/machinery/light/navigation/buildable
+	build_machine_type = /obj/machinery/light/navigation
 
 /obj/item/frame/button
 	name = "button frame"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "launcherbtt"
 	material = /decl/material/solid/metal/steel
-	build_machine_type = /obj/machinery/button/buildable
+	build_machine_type = /obj/machinery/button
 
 /obj/item/frame/camera
 	name = "security camera frame"
@@ -244,7 +244,7 @@
 	icon_state = "airlock_sensor_off"
 	name = "airlock sensor"
 	desc = "An airlock sensor frame."
-	build_machine_type = /obj/machinery/airlock_sensor/buildable
+	build_machine_type = /obj/machinery/airlock_sensor
 
 /obj/item/frame/button/airlock_controller
 	icon = 'icons/obj/airlock_machines.dmi'

--- a/code/game/objects/items/buttons.dm
+++ b/code/game/objects/items/buttons.dm
@@ -18,7 +18,7 @@
 	desc = "Used for building a window tint switch."
 	icon = 'icons/obj/power.dmi'
 	icon_state = "light-p"
-	build_machine_type = /obj/machinery/button/windowtint/buildable
+	build_machine_type = /obj/machinery/button/windowtint
 
 /obj/item/frame/button/light_switch/windowtint/kit
 	name = "window tint switch kit"

--- a/code/game/objects/items/buttons.dm
+++ b/code/game/objects/items/buttons.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/power.dmi'
 	icon_state = "light-p"
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
-	build_machine_type = /obj/machinery/light_switch/buildable
+	build_machine_type = /obj/machinery/light_switch
 
 /obj/item/frame/button/light_switch/kit
 	name = "light switch kit"

--- a/code/game/objects/items/weapons/circuitboards/wall.dm
+++ b/code/game/objects/items/weapons/circuitboards/wall.dm
@@ -9,11 +9,7 @@
 	board_type = "wall"
 	origin_tech = "{'programming':1,'engineering':1}"
 	req_components = list()
-	additional_spawn_components = list(
-		/obj/item/stock_parts/console_screen = 1,
-		/obj/item/stock_parts/keyboard = 1,
-		/obj/item/stock_parts/power/apc/buildable = 1
-	)
+	additional_spawn_components = null
 
 /obj/item/stock_parts/circuitboard/air_alarm
 	name = "circuitboard (air alarm)"
@@ -23,11 +19,7 @@
 	board_type = "wall"
 	origin_tech = "{'programming':1,'engineering':1}"
 	req_components = list()
-	additional_spawn_components = list(
-		/obj/item/stock_parts/console_screen = 1,
-		/obj/item/stock_parts/keyboard = 1,
-		/obj/item/stock_parts/power/apc/buildable = 1
-	)
+	additional_spawn_components = null
 
 /obj/item/stock_parts/circuitboard/apc
 	name = "circuitboard (area power controller)"

--- a/code/game/objects/items/weapons/circuitboards/wall.dm
+++ b/code/game/objects/items/weapons/circuitboards/wall.dm
@@ -70,7 +70,6 @@
 	additional_spawn_components = list(
 		/obj/item/stock_parts/console_screen = 1,
 		/obj/item/stock_parts/keyboard = 1,
-		/obj/item/stock_parts/power/apc/buildable = 1,
 	)
 	buildtype_select = TRUE
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -542,15 +542,9 @@
 	desc = "A remote control switch for electrochromic windows."
 	var/range = 7
 	stock_part_presets = null // This isn't a radio-enabled button; it communicates with nearby structures in view.
-	uncreated_component_parts = list(
-		/obj/item/stock_parts/power/apc/buildable
-	)
 	frame_type = /obj/item/frame/button/light_switch/windowtint
 	construct_state = /decl/machine_construction/wall_frame/panel_closed/simple
-	base_type = /obj/machinery/button/windowtint/buildable
-
-/obj/machinery/button/windowtint/buildable
-	uncreated_component_parts = null
+	base_type = /obj/machinery/button/windowtint
 
 /obj/machinery/button/windowtint/attackby(obj/item/W, mob/user)
 	if(IS_MULTITOOL(W))

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -32,10 +32,10 @@
 	power_channel = LIGHT //Lights are calc'd via area so they dont need to be in the machine list
 
 	uncreated_component_parts = list(
-		/obj/item/stock_parts/power/apc/buildable
+		/obj/item/stock_parts/power/apc
 	)
 	construct_state = /decl/machine_construction/wall_frame/panel_closed/simple
-	base_type = /obj/machinery/light/buildable
+	base_type = /obj/machinery/light
 	frame_type = /obj/item/frame/light
 
 	var/on = 0					// 1 if on, 0 if off
@@ -56,9 +56,6 @@
 	lightbulb.set_color(color)
 	queue_icon_update()
 
-/obj/machinery/light/buildable
-	uncreated_component_parts = null
-
 // the smaller bulb light fixture
 /obj/machinery/light/small
 	icon_state = "bulb_map"
@@ -66,11 +63,8 @@
 	desc = "A small lighting fixture."
 	light_type = /obj/item/light/bulb
 	accepts_light_type = /obj/item/light/bulb
-	base_type = /obj/machinery/light/small/buildable
+	base_type = /obj/machinery/light/small
 	frame_type = /obj/item/frame/light/small
-
-/obj/machinery/light/small/buildable
-	uncreated_component_parts = null
 
 /obj/machinery/light/small/emergency
 	light_type = /obj/item/light/bulb/red
@@ -83,11 +77,8 @@
 	desc = "A more robust socket for light tubes that demand more power."
 	light_type = /obj/item/light/tube/large
 	accepts_light_type = /obj/item/light/tube/large
-	base_type = /obj/machinery/light/spot/buildable
+	base_type = /obj/machinery/light/spot
 	frame_type = /obj/item/frame/light/spot
-
-/obj/machinery/light/spot/buildable
-	uncreated_component_parts = null
 
 // create a new lighting fixture
 /obj/machinery/light/Initialize(mapload, d=0, populate_parts = TRUE)
@@ -453,8 +444,9 @@
 	accepts_light_type = /obj/item/light/tube/large
 	on = TRUE
 	var/delay = 1
-	base_type = /obj/machinery/light/navigation/buildable
+	base_type = /obj/machinery/light/navigation
 	frame_type = /obj/item/frame/light/nav
+	stat_immune = NOPOWER | NOINPUT | NOSCREEN
 
 /obj/machinery/light/navigation/on_update_icon()
 	. = ..() // this will handle pixel offsets
@@ -468,9 +460,6 @@
 		to_chat(user, SPAN_NOTICE("You adjust the delay on \the [src]."))
 		return TRUE
 
-/obj/machinery/light/navigation/buildable
-	uncreated_component_parts = null
-
 /obj/machinery/light/navigation/delay2
 	delay = 2
 
@@ -482,10 +471,6 @@
 
 /obj/machinery/light/navigation/delay5
 	delay = 5
-
-/obj/machinery/light/navigation
-	stat_immune = NOPOWER | NOINPUT | NOSCREEN
-
 
 // the light item
 // can be tube or bulb subtypes


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
After a lot of complaints downstream, and after a station-wide EMP I decided to make some of these things be less of a massive pain in the ass to repair/build.
* Alarms have a built-in unbreakable tesla-link and don't need a console screen and keyboard part anymore to be usable.
* Pipe meters have unbreakable built-in components now.
* Buttons have unbreakable tesla-link in them now.
* Lightswitches have unbreakable tesla-links.
* Lights have unbreakable tesla-links in them now.
* Airlock sensors, and airlock access buttons have unbreakable tesla-links now.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It should help people from giving up on fixing things because it turns into a massive chore nobody wants to do. 

## Changelog
:cl:
tweak: Alarms have a built-in unbreakable tesla-link and don't need a console screen and keyboard part anymore to be usable.
tweak: Pipe meters have unbreakable built-in components now.
tweak: Buttons have unbreakable tesla-link and transmitters/receiver in them now.
tweak: Light switches have unbreakable tesla-links.
tweak: Lights have unbreakable tesla-links in them now.
tweak: Airlock sensors, and airlock access buttons have unbreakable parts now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->