### PR TITLE
Fixes/slightly optimizes exterior turf gas overlays.

### DIFF
--- a/code/_helpers/vis_contents.dm
+++ b/code/_helpers/vis_contents.dm
@@ -11,6 +11,3 @@
 		set_vis_contents(src, new_vis_contents)
 	else if(length(vis_contents))
 		clear_vis_contents(src)
-
-/turf/proc/get_vis_contents_to_add()
-	return

--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -14,6 +14,12 @@
 	var/list/affecting_heat_sources
 	var/obj/effect/overmap/visitable/sector/exoplanet/owner
 
+// Bit faster than return_air() for exoplanet exterior turfs
+/turf/exterior/get_air_graphic()
+	if(owner)
+		return owner.atmosphere?.graphic
+	return global.using_map.exterior_atmosphere?.graphic
+
 /turf/exterior/Initialize(mapload, no_update_icon = FALSE)
 
 	color = null
@@ -30,6 +36,10 @@
 			ChangeArea(src, owner.planetary_area)
 
 	. = ..(mapload)	// second param is our own, don't pass to children
+
+	var/air_graphic = get_air_graphic()
+	if(length(air_graphic))
+		add_vis_contents(src, air_graphic)
 
 	if (no_update_icon)
 		return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -461,10 +461,14 @@ var/global/const/enterloopsanity = 100
 		return TRUE
 	return FALSE
 
-/turf/get_vis_contents_to_add()
-	var/datum/gas_mixture/air = return_air()
-	if(air && length(air.graphic))
-		LAZYADD(., air.graphic)
+/turf/proc/get_air_graphic()
+	var/datum/gas_mixture/environment = return_air()
+	return environment?.graphic
+
+/turf/proc/get_vis_contents_to_add()
+	var/air_graphic = get_air_graphic()
+	if(length(air_graphic))
+		LAZYADD(., air_graphic)
 	if(weather)
 		LAZYADD(., weather)
 	if(flooded)


### PR DESCRIPTION
## Description of changes
- Exterior turfs no longer copy airmix to get air graphics.
- Exterior turfs now apply gas overlays on init again.

## Why and what will this PR improve
Faster and more consistent gas overlays for exoplanets.

## Authorship
Myself.

## Changelog
:cl:
bugfix: Exoplanet atmosphere overlays should be visible again.
/:cl:
