### PR TITLE
Fix gas overlays not showing on exterior turfs

### DIFF
--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -137,6 +137,7 @@
 	cut_overlays()
 	if(LAZYLEN(decals))
 		add_overlay(decals)
+	refresh_vis_contents()
 
 	if(icon_edge_layer < 0)
 		return


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Base exterior turfs were missing the call to update their vis contents. And that meant their gas overlay wouldn't show at all.

## Changelog
:cl:
bugfix: exterior turfs now update their gas overlay properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->