### PR TITLE
Fix QDELETED looping timers being reinserted

### DIFF
--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -172,7 +172,9 @@ SUBSYSTEM_DEF(timer)
 				callBack.InvokeAsync()
 				last_invoke_tick = world.time
 
-			if (timer.flags & TIMER_LOOP) // Prepare looping timers to re-enter the queue
+			if (timer.flags & TIMER_LOOP) // Prepare valid looping timers to re-enter the queue
+				if(QDELETED(timer)) // If we were deleted in the callback, don't re-insert.
+					continue
 				timer.spent = 0
 				timer.timeToRun = world.time + timer.wait
 				timer.bucketJoin()
@@ -487,6 +489,8 @@ SUBSYSTEM_DEF(timer)
  * If the timed event is tracking client time, it will be added to a special bucket.
  */
 /datum/timedevent/proc/bucketJoin()
+	if(QDELETED(src))
+		CRASH("QDELETED timer in bucketJoin! [name]")
 	// Generate debug-friendly name for timer
 	var/static/list/bitfield_flags = list("TIMER_UNIQUE", "TIMER_OVERRIDE", "TIMER_CLIENT_TIME", "TIMER_STOPPABLE", "TIMER_NO_HASH_WAIT", "TIMER_LOOP")
 	name = "Timer: [id] (\ref[src]), TTR: [timeToRun], wait:[wait] Flags: [jointext(bitfield2list(flags, bitfield_flags), ", ")], \


### PR DESCRIPTION
## Description of changes
Fixes a timer runtime that can currently be reproduced by mouse highlighting an object one tile away and moving out of range while still holding shift. This was because the timer was qdeleted inside its callback, which wasn't handled properly.
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
Closes #2517.
Also adds a more informative message if something else causes the same problem through a different method.

## Authorship
LemonInTheDark from /tg/station for pointing out the issue, me for the fix.