### PR TITLE
Fix mapload consuming arguments passed in new()

### DIFF
--- a/code/controllers/subsystems/atoms.dm
+++ b/code/controllers/subsystems/atoms.dm
@@ -38,9 +38,14 @@ SUBSYSTEM_DEF(atoms)
 	var/count = created_atoms.len
 	while(created_atoms.len)
 		var/atom/A = created_atoms[created_atoms.len]
+		var/list/atom_args = created_atoms[A]
 		created_atoms.len--
 		if(!QDELETED(A) && !(A.atom_flags & ATOM_FLAG_INITIALIZED))
-			InitAtom(A, mapload_arg)
+			if(atom_args)
+				atom_args.Insert(1, TRUE)
+				InitAtom(A, atom_args)
+			else
+				InitAtom(A, mapload_arg)
 			CHECK_TICK
 
 	// If wondering why not just store all atoms in created_atoms and use the block above: that turns out unbearably expensive.


### PR DESCRIPTION
## Description of changes
Mapload formerly assumed that arguments passed in New() to atoms created prior to SSatoms init could be safely ignored, but INITIALIZE_IMMEDIATE violates this assumption, since it can pass important arguments.
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
Fixes #2623.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Me.
<!-- Describe original authors of changes to credit them. -->