### PR TITLE
Removing the need for is_abstract().

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -278,3 +278,6 @@
 
 // arbitrary low pressure bound for wind weather effects
 #define MIN_WIND_PRESSURE 10
+
+#define DECL_TYPE_IS_ABSTRACT(DECL) (initial(DECL.abstract_type) == DECL)
+#define DECL_INSTANCE_IS_ABSTRACT(DECL) (DECL.abstract_type == DECL.type)

--- a/code/controllers/subsystems/initialization/materials.dm
+++ b/code/controllers/subsystems/initialization/materials.dm
@@ -76,11 +76,11 @@ SUBSYSTEM_DEF(materials)
 		return
 	materials =         list()
 	materials_by_name = list()
-	for(var/mtype in subtypesof(/decl/material))
-		var/decl/material/new_mineral = mtype
-		if(!initial(new_mineral.name))
+	var/list/material_decls = decls_repository.get_decls_of_subtype(/decl/material)
+	for(var/mtype in material_decls)
+		var/decl/material/new_mineral = material_decls[mtype]
+		if(!new_mineral.name)
 			continue
-		new_mineral = GET_DECL(mtype)
 		materials += new_mineral
 		materials_by_name[lowertext(new_mineral.name)] = new_mineral
 		if(new_mineral.sparse_material_weight)
@@ -143,7 +143,9 @@ SUBSYSTEM_DEF(materials)
 		return planet.get_strata(location)
 	var/s_key = "[location.z]"
 	if(!global.default_strata_type_by_z[s_key])
-		global.default_strata_type_by_z[s_key] = pick(subtypesof(/decl/strata))
+		var/list/all_strata = decls_repository.get_decls_of_subtype(/decl/strata)
+		if(length(all_strata))
+			global.default_strata_type_by_z[s_key] = pick(all_strata)
 	return global.default_strata_type_by_z[s_key]
 
 /datum/controller/subsystem/materials/proc/get_material_by_name(var/mat_name)

--- a/code/controllers/subsystems/initialization/materials.dm
+++ b/code/controllers/subsystems/initialization/materials.dm
@@ -79,8 +79,6 @@ SUBSYSTEM_DEF(materials)
 	var/list/material_decls = decls_repository.get_decls_of_subtype(/decl/material)
 	for(var/mtype in material_decls)
 		var/decl/material/new_mineral = material_decls[mtype]
-		if(!new_mineral.name)
-			continue
 		materials += new_mineral
 		materials_by_name[lowertext(new_mineral.name)] = new_mineral
 		if(new_mineral.sparse_material_weight)

--- a/code/controllers/subsystems/initialization/materials.dm
+++ b/code/controllers/subsystems/initialization/materials.dm
@@ -141,9 +141,7 @@ SUBSYSTEM_DEF(materials)
 		return planet.get_strata(location)
 	var/s_key = "[location.z]"
 	if(!global.default_strata_type_by_z[s_key])
-		var/list/all_strata = decls_repository.get_decls_of_subtype(/decl/strata)
-		if(length(all_strata))
-			global.default_strata_type_by_z[s_key] = pick(all_strata)
+		global.default_strata_type_by_z[s_key] = pick(decls_repository.get_decl_paths_of_subtype(/decl/strata))
 	return global.default_strata_type_by_z[s_key]
 
 /datum/controller/subsystem/materials/proc/get_material_by_name(var/mat_name)

--- a/code/datums/hierarchy.dm
+++ b/code/datums/hierarchy.dm
@@ -15,7 +15,7 @@
 	. = ..()
 
 /decl/hierarchy/proc/is_category()
-	return length(children.len)
+	return length(children)
 
 /decl/hierarchy/proc/get_descendents()
 	if(!children)

--- a/code/datums/hierarchy.dm
+++ b/code/datums/hierarchy.dm
@@ -15,7 +15,7 @@
 	. = ..()
 
 /decl/hierarchy/proc/is_category()
-	return length(children)
+	return DECL_INSTANCE_IS_ABSTRACT(src) && length(children)
 
 /decl/hierarchy/proc/get_descendents()
 	if(!children)

--- a/code/datums/hierarchy.dm
+++ b/code/datums/hierarchy.dm
@@ -1,4 +1,5 @@
 /decl/hierarchy
+	allow_abstract_init = TRUE
 	abstract_type = /decl/hierarchy
 	var/name = "Hierarchy"
 	var/decl/hierarchy/parent
@@ -14,7 +15,7 @@
 	. = ..()
 
 /decl/hierarchy/proc/is_category()
-	return is_abstract() || children.len
+	return length(children.len)
 
 /decl/hierarchy/proc/get_descendents()
 	if(!children)

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -57,8 +57,9 @@ var/global/list/outfits_decls_by_type_
 /decl/hierarchy/outfit/Initialize()
 	. = ..()
 	backpack_overrides = backpack_overrides || list()
-	outfits_decls_by_type_[type] = src
-	dd_insertObjectList(outfits_decls_, src)
+	if(!DECL_INSTANCE_IS_ABSTRACT(src))
+		outfits_decls_by_type_[type] = src
+		dd_insertObjectList(outfits_decls_, src)
 
 /decl/hierarchy/outfit/proc/pre_equip(mob/living/carbon/human/H)
 	if(flags & OUTFIT_RESET_EQUIPMENT)

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -57,9 +57,8 @@ var/global/list/outfits_decls_by_type_
 /decl/hierarchy/outfit/Initialize()
 	. = ..()
 	backpack_overrides = backpack_overrides || list()
-	if(!is_abstract())
-		outfits_decls_by_type_[type] = src
-		dd_insertObjectList(outfits_decls_, src)
+	outfits_decls_by_type_[type] = src
+	dd_insertObjectList(outfits_decls_, src)
 
 /decl/hierarchy/outfit/proc/pre_equip(mob/living/carbon/human/H)
 	if(flags & OUTFIT_RESET_EQUIPMENT)

--- a/code/datums/repositories/decls.dm
+++ b/code/datums/repositories/decls.dm
@@ -21,30 +21,31 @@
 var/global/repository/decls/decls_repository = new
 
 /repository/decls
-	var/list/fetched_decls =         list()
-	var/list/fetched_decl_ids =      list()
-	var/list/fetched_decl_types =    list()
-	var/list/fetched_decl_subtypes = list()
+	var/list/fetched_decls =                 list()
+	var/list/fetched_decl_ids =              list()
+	var/list/fetched_decl_types =            list()
+	var/list/fetched_decl_subtypes =         list()
+	var/list/fetched_decl_paths_by_type =    list()
+	var/list/fetched_decl_paths_by_subtype = list()
 
 /repository/decls/New()
 	..()
 	for(var/decl_type in typesof(/decl))
 		var/decl/decl = decl_type
 		var/decl_uid = initial(decl.uid)
-		// is_abstract() would require us to retrieve (and instantiate) the decl, so we do it manually.
-		if(decl_uid && decl_type != initial(decl.abstract_type))
-			fetched_decl_ids[decl_uid] = decl_type
+		if(decl_uid && !DECL_TYPE_IS_ABSTRACT(decl))
+			fetched_decl_ids[decl_uid] = decl
 
 /repository/decls/proc/get_decl_by_id(var/decl_id)
 	. = get_decl(fetched_decl_ids[decl_id])
 
-/repository/decls/proc/get_decl(var/decl_type)
-	ASSERT(ispath(decl_type))
+/repository/decls/proc/get_decl(var/decl/decl_type)
+	ASSERT(ispath(decl_type, /decl))
+	if(DECL_TYPE_IS_ABSTRACT(decl_type) && !initial(decl_type.allow_abstract_init))
+		return // We do not instantiate abstract decls.
 	. = fetched_decls[decl_type]
 	if(!.)
-		var/decl/decl = new decl_type()
-		if(decl.is_abstract() && decl.crash_on_abstract_init)
-			PRINT_STACK_TRACE("Banned abstract /decl type instantiated: [decl_type]")
+		var/decl/decl = new decl_type
 		fetched_decls[decl_type] = decl // This needs to be done prior to calling Initialize() to avoid circular get_decl() calls by dependencies/children.
 		// TODO: maybe implement handling for LATELOAD and QDEL init hints?
 		var/init_result = decl.Initialize()
@@ -59,12 +60,32 @@ var/global/repository/decls/decls_repository = new
 /repository/decls/proc/get_decls(var/list/decl_types)
 	. = list()
 	for(var/decl_type in decl_types)
-		.[decl_type] = get_decl(decl_type)
+		var/decl = get_decl(decl_type)
+		if(decl)
+			.[decl_type] = decl
+
+/repository/decls/proc/get_decl_paths_of_type(var/decl_prototype)
+	. = fetched_decl_paths_by_type[decl_prototype]
+	if(!.)
+		. = list()
+		for(var/decl_path in get_decls_of_type(decl_prototype))
+			. += decl_path
+		fetched_decl_paths_by_type[decl_prototype] = .
+
+/repository/decls/proc/get_decl_paths_of_subtype(var/decl_prototype)
+	. = fetched_decl_paths_by_subtype[decl_prototype]
+	if(!.)
+		. = list()
+		for(var/decl_path in get_decls_of_subtype(decl_prototype))
+			. += decl_path
+		fetched_decl_paths_by_subtype[decl_prototype] = .
 
 /repository/decls/proc/get_decls_unassociated(var/list/decl_types)
 	. = list()
 	for(var/decl_type in decl_types)
-		. += get_decl(decl_type)
+		var/decl = get_decl(decl_type)
+		if(decl)
+			. += decl
 
 /repository/decls/proc/get_decls_of_type(var/decl_prototype)
 	. = fetched_decl_types[decl_prototype]
@@ -81,8 +102,8 @@ var/global/repository/decls/decls_repository = new
 /decl
 	var/uid
 	var/abstract_type = /decl
-	var/crash_on_abstract_init = FALSE
 	var/initialized = FALSE
+	var/allow_abstract_init = FALSE
 
 /decl/proc/Initialize()
 	SHOULD_CALL_PARENT(TRUE)
@@ -96,6 +117,3 @@ var/global/repository/decls/decls_repository = new
 	SHOULD_CALL_PARENT(FALSE)
 	PRINT_STACK_TRACE("Prevented attempt to delete a /decl instance: [log_info_line(src)]")
 	return QDEL_HINT_LETMELIVE
-
-/decl/proc/is_abstract()
-	return abstract_type == type

--- a/code/datums/repositories/decls.dm
+++ b/code/datums/repositories/decls.dm
@@ -33,7 +33,7 @@ var/global/repository/decls/decls_repository = new
 	for(var/decl_type in typesof(/decl))
 		var/decl/decl = decl_type
 		var/decl_uid = initial(decl.uid)
-		if(decl_uid && !DECL_TYPE_IS_ABSTRACT(decl))
+		if(decl_uid && (!DECL_TYPE_IS_ABSTRACT(decl) || initial(decl.allow_abstract_init)))
 			fetched_decl_ids[decl_uid] = decl
 
 /repository/decls/proc/get_decl_by_id(var/decl_id)

--- a/code/datums/traits/traits.dm
+++ b/code/datums/traits/traits.dm
@@ -1,12 +1,3 @@
-var/global/list/_trait_types
-
-/proc/trait_types()
-	if(!_trait_types)
-		_trait_types = list()
-		for(var/trait_type in decls_repository.get_decl_paths_of_subtype(/decl/trait))
-			_trait_types += trait_type
-	return _trait_types
-
 /mob/living
 	var/list/traits
 

--- a/code/datums/traits/traits.dm
+++ b/code/datums/traits/traits.dm
@@ -3,11 +3,8 @@ var/global/list/_trait_types
 /proc/trait_types()
 	if(!_trait_types)
 		_trait_types = list()
-		for(var/trait_type in subtypesof(/decl/trait))
-			var/decl/trait/T = trait_type
-			if(initial(T.abstract_type) != trait_type)
-				_trait_types += trait_type
-
+		for(var/trait_type in decls_repository.get_decl_paths_of_subtype(/decl/trait))
+			_trait_types += trait_type
 	return _trait_types
 
 /mob/living
@@ -70,7 +67,6 @@ var/global/list/_trait_types
 
 /decl/trait
 	abstract_type = /decl/trait
-	crash_on_abstract_init = TRUE
 	var/name
 	var/description
 	var/list/levels = list(TRAIT_LEVEL_EXISTS) // Should either only contain TRAIT_LEVEL_EXISTS or a set of the other TRAIT_LEVEL_* levels

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -65,7 +65,7 @@
 	wizard.current.SetName(wizard.current.real_name)
 
 /decl/special_role/wizard/equip(var/mob/living/carbon/human/wizard_mob)
-	default_outfit = pick(subtypesof(/decl/hierarchy/outfit/wizard))
+	default_outfit = pick(decls_repository.get_decls_of_subtype(/decl/hierarchy/outfit/wizard))
 	. = ..()
 
 /decl/special_role/wizard/print_player_summary()

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -65,7 +65,7 @@
 	wizard.current.SetName(wizard.current.real_name)
 
 /decl/special_role/wizard/equip(var/mob/living/carbon/human/wizard_mob)
-	default_outfit = pick(decls_repository.get_decls_of_subtype(/decl/hierarchy/outfit/wizard))
+	default_outfit = pick(decls_repository.get_decl_paths_of_subtype(/decl/hierarchy/outfit/wizard))
 	. = ..()
 
 /decl/special_role/wizard/print_player_summary()

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -144,13 +144,13 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	// FIXME:  Species-specific defaults pls
 	if(!character.h_style)
 		character.h_style = /decl/sprite_accessory/hair/bald
-	var/list/hair_types = decls_repository.get_decls_of_subtype(/decl/sprite_accessory/hair)
+	var/list/hair_types = decls_repository.get_decl_paths_of_subtype(/decl/sprite_accessory/hair)
 	SetUIValueRange(DNA_UI_HAIR_STYLE,  hair_types.Find(character.h_style),  length(hair_types), 1)
 
 	// Facial Hair
 	if(!character.f_style)
 		character.f_style = /decl/sprite_accessory/facial_hair/shaved
-	var/list/beard_types = decls_repository.get_decls_of_subtype(/decl/sprite_accessory/facial_hair)
+	var/list/beard_types = decls_repository.get_decl_paths_of_subtype(/decl/sprite_accessory/facial_hair)
 	SetUIValueRange(DNA_UI_BEARD_STYLE, beard_types.Find(character.f_style), length(beard_types), 1)
 
 	body_markings.Cut()

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -144,13 +144,13 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	// FIXME:  Species-specific defaults pls
 	if(!character.h_style)
 		character.h_style = /decl/sprite_accessory/hair/bald
-	var/list/hair_types = subtypesof(/decl/sprite_accessory/hair)
+	var/list/hair_types = decls_repository.get_decls_of_subtype(/decl/sprite_accessory/hair)
 	SetUIValueRange(DNA_UI_HAIR_STYLE,  hair_types.Find(character.h_style),  length(hair_types), 1)
 
 	// Facial Hair
 	if(!character.f_style)
 		character.f_style = /decl/sprite_accessory/facial_hair/shaved
-	var/list/beard_types = subtypesof(/decl/sprite_accessory/facial_hair)
+	var/list/beard_types = decls_repository.get_decls_of_subtype(/decl/sprite_accessory/facial_hair)
 	SetUIValueRange(DNA_UI_BEARD_STYLE, beard_types.Find(character.f_style), length(beard_types), 1)
 
 	body_markings.Cut()

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -170,13 +170,13 @@
 			E.set_dna(H.dna)
 
 		//Hair
-		var/list/hair_subtypes = subtypesof(/decl/sprite_accessory/hair)
+		var/list/hair_subtypes = decls_repository.get_decls_of_subtype(/decl/sprite_accessory/hair)
 		var/hair = dna.GetUIValueRange(DNA_UI_HAIR_STYLE, length(hair_subtypes))
 		if(hair > 0 && hair <= length(hair_subtypes))
 			H.h_style = hair_subtypes[hair]
 
 		//Facial Hair
-		var/list/beard_subtypes = subtypesof(/decl/sprite_accessory/facial_hair)
+		var/list/beard_subtypes = decls_repository.get_decls_of_subtype(/decl/sprite_accessory/facial_hair)
 		var/beard = dna.GetUIValueRange(DNA_UI_BEARD_STYLE, length(beard_subtypes))
 		if((0 < beard) && (beard <= length(beard_subtypes)))
 			H.f_style = beard_subtypes[beard]

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -170,13 +170,13 @@
 			E.set_dna(H.dna)
 
 		//Hair
-		var/list/hair_subtypes = decls_repository.get_decls_of_subtype(/decl/sprite_accessory/hair)
+		var/list/hair_subtypes = decls_repository.get_decl_paths_of_subtype(/decl/sprite_accessory/hair)
 		var/hair = dna.GetUIValueRange(DNA_UI_HAIR_STYLE, length(hair_subtypes))
 		if(hair > 0 && hair <= length(hair_subtypes))
 			H.h_style = hair_subtypes[hair]
 
 		//Facial Hair
-		var/list/beard_subtypes = decls_repository.get_decls_of_subtype(/decl/sprite_accessory/facial_hair)
+		var/list/beard_subtypes = decls_repository.get_decl_paths_of_subtype(/decl/sprite_accessory/facial_hair)
 		var/beard = dna.GetUIValueRange(DNA_UI_BEARD_STYLE, length(beard_subtypes))
 		if((0 < beard) && (beard <= length(beard_subtypes)))
 			H.f_style = beard_subtypes[beard]

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -152,7 +152,7 @@
 	TLV["temperature"] =	list(T0C-26, T0C, T0C+40, T0C+66) // K
 
 	var/decl/environment_data/env_info = GET_DECL(environment_type)
-	for(var/g in subtypesof(/decl/material/gas))
+	for(var/g in decls_repository.get_decl_paths_of_subtype(/decl/material/gas))
 		if(!env_info.important_gasses[g])
 			trace_gas += g
 

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -24,7 +24,7 @@
 	. = ..()
 	if(!scrubbing_gas)
 		scrubbing_gas = list()
-		for(var/g in subtypesof(/decl/material/gas))
+		for(var/g in decls_repository.get_decl_paths_of_subtype(/decl/material/gas))
 			if(g != /decl/material/gas/oxygen && g != /decl/material/gas/nitrogen)
 				scrubbing_gas += g
 

--- a/code/game/movietitles.dm
+++ b/code/game/movietitles.dm
@@ -164,7 +164,8 @@ var/global/list/end_titles
 		if(!C.holder)
 			continue
 		if(C.holder.rights & (R_DEBUG|R_ADMIN))
-			var/decl/cultural_info/cult = GET_DECL(pick(subtypesof(/decl/cultural_info/culture)))
+			var/list/all_cultures = decls_repository.get_decls_of_subtype(/decl/cultural_info/culture)
+			var/decl/cultural_info/cult = all_cultures[pick(all_cultures)]
 			staff += "[uppertext(pick(staffjobs))] - [cult.get_random_name(pick(MALE, FEMALE))] a.k.a. '[C.key]'"
 		else if(C.holder.rights & R_MOD)
 			goodboys += "[C.key]"

--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -21,9 +21,9 @@
 
 	poster_type = given_poster_type || poster_type
 	if(!poster_type)
-		poster_type = pick(subtypesof(/decl/poster))
+		poster_type = pick(decls_repository.get_decls_of_subtype(/decl/poster))
 
-	var/list/posters = subtypesof(/decl/poster)
+	var/list/posters = decls_repository.get_decls_of_subtype(/decl/poster)
 	var/serial_number = posters.Find(poster_type)
 	name += " - No. [serial_number]"
 
@@ -97,7 +97,7 @@
 		if(give_poster_type)
 			poster_type = give_poster_type
 		else
-			poster_type = pick(subtypesof(/decl/poster))
+			poster_type = pick(decls_repository.get_decls_of_subtype(/decl/poster))
 	set_poster(poster_type)
 
 	pixel_x = 0

--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -19,11 +19,10 @@
 		. = INITIALIZE_HINT_QDEL
 		CRASH("Invalid poster type: [log_info_line(given_poster_type)]")
 
+	var/list/posters = decls_repository.get_decl_paths_of_subtype(/decl/poster)
 	poster_type = given_poster_type || poster_type
 	if(!poster_type)
-		poster_type = pick(decls_repository.get_decl_paths_of_subtype(/decl/poster))
-
-	var/list/posters = decls_repository.get_decl_paths_of_subtype(/decl/poster)
+		poster_type = pick(posters)
 	var/serial_number = posters.Find(poster_type)
 	name += " - No. [serial_number]"
 

--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -21,9 +21,9 @@
 
 	poster_type = given_poster_type || poster_type
 	if(!poster_type)
-		poster_type = pick(decls_repository.get_decls_of_subtype(/decl/poster))
+		poster_type = pick(decls_repository.get_decl_paths_of_subtype(/decl/poster))
 
-	var/list/posters = decls_repository.get_decls_of_subtype(/decl/poster)
+	var/list/posters = decls_repository.get_decl_paths_of_subtype(/decl/poster)
 	var/serial_number = posters.Find(poster_type)
 	name += " - No. [serial_number]"
 
@@ -97,7 +97,7 @@
 		if(give_poster_type)
 			poster_type = give_poster_type
 		else
-			poster_type = pick(decls_repository.get_decls_of_subtype(/decl/poster))
+			poster_type = pick(decls_repository.get_decl_paths_of_subtype(/decl/poster))
 	set_poster(poster_type)
 
 	pixel_x = 0

--- a/code/game/objects/items/weapons/paint.dm
+++ b/code/game/objects/items/weapons/paint.dm
@@ -64,5 +64,5 @@ var/global/list/cached_icons = list()
 	name = "odd paint bucket"
 
 /obj/item/chems/glass/paint/random/Initialize()
-	pigment = pick(decls_repository.get_decls_of_subtype(/decl/material/liquid/pigment))
+	pigment = pick(decls_repository.get_decl_paths_of_subtype(/decl/material/liquid/pigment))
 	. = ..()

--- a/code/game/objects/items/weapons/paint.dm
+++ b/code/game/objects/items/weapons/paint.dm
@@ -64,5 +64,5 @@ var/global/list/cached_icons = list()
 	name = "odd paint bucket"
 
 /obj/item/chems/glass/paint/random/Initialize()
-	pigment = pick(subtypesof(/decl/material/liquid/pigment))
+	pigment = pick(decls_repository.get_decls_of_subtype(/decl/material/liquid/pigment))
 	. = ..()

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1025,7 +1025,7 @@ var/global/floorIsLava = 0
 		log_admin("[key_name(usr)] mass-spawned closets (icon debug), if this is a live server you should yell at them.")
 		var/x = 0
 		var/y = 0
-		for(var/check_appearance in typesof(/decl/closet_appearance))
+		for(var/check_appearance in decls_repository.get_decl_paths_of_type(/decl/closet_appearance))
 			x++
 			if(x > 10)
 				x = 0

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -782,14 +782,14 @@ var/global/list/admin_verbs_mod = list(
 		M.skin_tone =  -M.skin_tone + 35
 
 	// hair
-	var/decl/sprite_accessory/new_hstyle = input(usr, "Select a hair style", "Grooming") as null|anything in decls_repository.get_decl_paths_of_subtype(/decl/sprite_accessory/hair)
+	var/new_hstyle = input(usr, "Select a hair style", "Grooming") as null|anything in decls_repository.get_decl_paths_of_subtype(/decl/sprite_accessory/hair)
 	if(new_hstyle)
-		M.h_style = new_hstyle.type
+		M.h_style = new_hstyle
 
 	// facial hair
-	var/decl/sprite_accessory/new_fstyle = input(usr, "Select a facial hair style", "Grooming")  as null|anything in decls_repository.get_decl_paths_of_subtype(/decl/sprite_accessory/facial_hair)
+	var/new_fstyle = input(usr, "Select a facial hair style", "Grooming")  as null|anything in decls_repository.get_decl_paths_of_subtype(/decl/sprite_accessory/facial_hair)
 	if(new_fstyle)
-		M.f_style = new_fstyle.type
+		M.f_style = new_fstyle
 
 	var/new_gender = alert(usr, "Please select gender.", "Character Generation", "Male", "Female", "Neuter")
 	if (new_gender)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -782,12 +782,12 @@ var/global/list/admin_verbs_mod = list(
 		M.skin_tone =  -M.skin_tone + 35
 
 	// hair
-	var/decl/sprite_accessory/new_hstyle = input(usr, "Select a hair style", "Grooming") as null|anything in decls_repository.get_decls_of_subtype(/decl/sprite_accessory/hair)
+	var/decl/sprite_accessory/new_hstyle = input(usr, "Select a hair style", "Grooming") as null|anything in decls_repository.get_decl_paths_of_subtype(/decl/sprite_accessory/hair)
 	if(new_hstyle)
 		M.h_style = new_hstyle.type
 
 	// facial hair
-	var/decl/sprite_accessory/new_fstyle = input(usr, "Select a facial hair style", "Grooming")  as null|anything in decls_repository.get_decls_of_subtype(/decl/sprite_accessory/facial_hair)
+	var/decl/sprite_accessory/new_fstyle = input(usr, "Select a facial hair style", "Grooming")  as null|anything in decls_repository.get_decl_paths_of_subtype(/decl/sprite_accessory/facial_hair)
 	if(new_fstyle)
 		M.f_style = new_fstyle.type
 

--- a/code/modules/admin/quantum_mechanic.dm
+++ b/code/modules/admin/quantum_mechanic.dm
@@ -33,7 +33,7 @@
 
 	Q.reload_fullscreen()
 
-	for(var/language in subtypesof(/decl/language))
+	for(var/language in decls_repository.get_decl_paths_of_subtype(/decl/language))
 		Q.add_language(language)
 
 	spark_at(Q)

--- a/code/modules/admin/secrets/fun_secrets/change_credits.dm
+++ b/code/modules/admin/secrets/fun_secrets/change_credits.dm
@@ -7,20 +7,13 @@ var/global/end_credits_title
 	name = "Change End Credits Title"
 
 /datum/admin_secret_item/fun_secret/change_credits_song/do_execute()
-	var/list/sounds = decls_repository.get_decls_of_subtype(/decl/music_track)	
-
-	var/decl/music_track/selected = input("Select a music track for the credits.", "Server music list") as null|anything in sounds
-
+	var/selected = input("Select a music track for the credits.", "Server music list") as null|anything in decls_repository.get_decl_paths_of_subtype(/decl/music_track)
 	if(selected)
 		var/decl/music_track/track = GET_DECL(selected)
 		global.end_credits_song = track.song
-	
 	SSstatistics.add_field_details("admin_verb","CECS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admin_secret_item/fun_secret/change_credits_title/do_execute()
 	global.end_credits_title = input(usr, "What title would you like for the end credits?") as null|text
-
-	if(!global.end_credits_title)
-		return
-
-	SSstatistics.add_field_details("admin_verb","CECT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	if(global.end_credits_title)
+		SSstatistics.add_field_details("admin_verb","CECT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/secrets/fun_secrets/change_credits.dm
+++ b/code/modules/admin/secrets/fun_secrets/change_credits.dm
@@ -7,7 +7,7 @@ var/global/end_credits_title
 	name = "Change End Credits Title"
 
 /datum/admin_secret_item/fun_secret/change_credits_song/do_execute()
-	var/list/sounds = subtypesof(/decl/music_track)	
+	var/list/sounds = decls_repository.get_decls_of_subtype(/decl/music_track)	
 
 	var/decl/music_track/selected = input("Select a music track for the credits.", "Server music list") as null|anything in sounds
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -477,7 +477,7 @@
 	set category = "Debug"
 	set name = "Force Ghost Trap Trigger"
 	if(!check_rights(R_DEBUG)) return
-	var/decl/ghosttrap/trap = input("Select a ghost trap.", "Force Ghost Trap Trigger") as null|anything in typesof(/decl/ghosttrap)
+	var/decl/ghosttrap/trap = input("Select a ghost trap.", "Force Ghost Trap Trigger") as null|anything in decls_repository.get_decl_paths_of_type(/decl/ghosttrap)
 	if(!trap)
 		return
 	trap = GET_DECL(trap)

--- a/code/modules/admin/verbs/fluids.dm
+++ b/code/modules/admin/verbs/fluids.dm
@@ -13,7 +13,7 @@
 	var/reagent_amount = input("How deep?", "Spawn Fluid", 1000) as num|null
 	if(!reagent_amount)
 		return
-	var/reagent_type = input("What kind of reagent?", "Spawn Fluid", /decl/material/liquid/water) as null|anything in subtypesof(/decl/material)
+	var/reagent_type = input("What kind of reagent?", "Spawn Fluid", /decl/material/liquid/water) as null|anything in decls_repository.get_decl_paths_of_subtype(/decl/material)
 	if(!reagent_type || !user || !check_rights(R_SPAWN))
 		return
 	var/turf/flooding = get_turf(user)

--- a/code/modules/admin/verbs/grief_fixers.dm
+++ b/code/modules/admin/verbs/grief_fixers.dm
@@ -34,8 +34,9 @@
 	to_chat(usr, "\[3/5\] - All ZAS Zones removed.")
 
 	var/list/unsorted_overlays = list()
-	for(var/id in subtypesof(/decl/material/gas))
-		var/decl/material/mat = GET_DECL(id)
+	var/list/all_gasses = decls_repository.get_decls_of_subtype(/decl/material/gas)
+	for(var/id in all_gasses)
+		var/decl/material/mat = all_gasses[id]
 		unsorted_overlays |= mat.gas_tile_overlay
 
 	for(var/turf/simulated/T in world)

--- a/code/modules/atmospherics/components/omni_devices/filter.dm
+++ b/code/modules/atmospherics/components/omni_devices/filter.dm
@@ -33,7 +33,7 @@
 		var/list/all_materials = decls_repository.get_decls_of_subtype(/decl/material)
 		for(var/mat_type in all_materials)
 			var/decl/material/mat = all_materials[mat_type]
-			if(!mat.hidden_from_codex && !mat.is_abstract() && !isnull(mat.boiling_point) && mat.boiling_point < T20C)
+			if(!mat.hidden_from_codex && !isnull(mat.boiling_point) && mat.boiling_point < T20C)
 				gas_decls_by_symbol_cache[mat.gas_symbol] = mat.type
 
 	rebuild_filtering_list()

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -65,7 +65,7 @@
 		id_tag = "[sequential_id("obj/machinery")]"
 	if(!scrubbing_gas)
 		scrubbing_gas = list()
-		for(var/g in subtypesof(/decl/material/gas))
+		for(var/g in decls_repository.get_decl_paths_of_subtype(/decl/material/gas))
 			if(g != /decl/material/gas/oxygen && g != /decl/material/gas/nitrogen)
 				scrubbing_gas += g
 	. = ..()

--- a/code/modules/client/preference_setup/antagonism/01_candidacy.dm
+++ b/code/modules/client/preference_setup/antagonism/01_candidacy.dm
@@ -51,8 +51,9 @@
 	. += "</table>"
 	. += "<b>Ghost Role Availability:</b>"
 	. += "<table>"
-	for(var/ghost_trap_key in subtypesof(/decl/ghosttrap))
-		var/decl/ghosttrap/ghost_trap = GET_DECL(ghost_trap_key)
+	var/list/all_ghost_traps = decls_repository.get_decls_of_subtype(/decl/ghosttrap)
+	for(var/ghost_trap_key in all_ghost_traps)
+		var/decl/ghosttrap/ghost_trap = all_ghost_traps[ghost_trap_key]
 		if(!ghost_trap.list_as_special_role)
 			continue
 
@@ -127,8 +128,9 @@
 				continue
 		private_valid_special_roles |= role.name
 
-	for(var/ghost_trap_key in subtypesof(/decl/ghosttrap))
-		var/decl/ghosttrap/ghost_trap = GET_DECL(ghost_trap_key)
+	var/list/all_ghost_traps = decls_repository.get_decls_of_subtype(/decl/ghosttrap)
+	for(var/ghost_trap_key in all_ghost_traps)
+		var/decl/ghosttrap/ghost_trap = all_ghost_traps[ghost_trap_key]
 		if(!ghost_trap.list_as_special_role)
 			continue
 		if(!include_bans)

--- a/code/modules/client/preference_setup/background/03_language.dm
+++ b/code/modules/client/preference_setup/background/03_language.dm
@@ -88,8 +88,6 @@
 	var/list/language_types = decls_repository.get_decls_of_subtype(/decl/language)
 	for(var/thing in language_types)
 		var/decl/language/lang = language_types[thing]
-		if(lang.is_abstract()) // these aren't supposed to be available to anyone, they're abstract types
-			continue
 		if(user.has_admin_rights() || (!(lang.flags & RESTRICTED) && is_alien_whitelisted(user, lang)))
 			allowed_languages[thing] = TRUE
 

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -304,8 +304,11 @@
 			disallowed_markings |= mark_style.disallows
 
 		var/list/usable_markings = list()
-		for(var/M in (subtypesof(/decl/sprite_accessory/marking) - pref.body_markings))
-			var/decl/sprite_accessory/S = GET_DECL(M)
+		var/list/all_markings = decls_repository.get_decls_of_subtype(/decl/sprite_accessory/marking)
+		for(var/M in all_markings)
+			if(M in pref.body_markings)
+				continue
+			var/decl/sprite_accessory/S = all_markings[M]
 			if(is_type_in_list(S, disallowed_markings) || (S.species_allowed && !(mob_species.get_root_species_name() in S.species_allowed)) || (S.subspecies_allowed && !(mob_species.name in S.subspecies_allowed)))
 				continue
 			usable_markings += S

--- a/code/modules/client/preference_setup/general/04_equipment.dm
+++ b/code/modules/client/preference_setup/general/04_equipment.dm
@@ -212,6 +212,6 @@
 			set_backpack_metadata(bo, bt, new_metadata)
 			return TOPIC_REFRESH_UPDATE_PREVIEW
 	else if(href_list["change_cash_choice"])
-		pref.starting_cash_choice = next_in_list(pref.starting_cash_choice, typesof(/decl/starting_cash_choice))
+		pref.starting_cash_choice = next_in_list(pref.starting_cash_choice, decls_repository.get_decls_of_type(/decl/starting_cash_choice))
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 	return ..()

--- a/code/modules/client/preference_setup/general/04_equipment.dm
+++ b/code/modules/client/preference_setup/general/04_equipment.dm
@@ -212,6 +212,6 @@
 			set_backpack_metadata(bo, bt, new_metadata)
 			return TOPIC_REFRESH_UPDATE_PREVIEW
 	else if(href_list["change_cash_choice"])
-		pref.starting_cash_choice = next_in_list(pref.starting_cash_choice, decls_repository.get_decls_of_type(/decl/starting_cash_choice))
+		pref.starting_cash_choice = next_in_list(pref.starting_cash_choice, decls_repository.get_decl_paths_of_subtype(/decl/starting_cash_choice))
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 	return ..()

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -145,8 +145,6 @@ var/global/list/gear_datums = list()
 		var/category_cost = 0
 		for(var/gear in LC.gear)
 			var/decl/loadout_option/G = LC.gear[gear]
-			if(G.is_abstract())
-				continue
 			if(gear in pref.gear_list[pref.gear_slot])
 				category_cost += G.cost
 
@@ -176,7 +174,7 @@ var/global/list/gear_datums = list()
 	for(var/gear_name in current_category_decl.gear)
 
 		var/decl/loadout_option/G = current_category_decl.gear[gear_name]
-		if(G.is_abstract() || !G.can_be_taken_by(user, pref))
+		if(!G.can_be_taken_by(user, pref))
 			continue
 
 		var/ticked = (G.name in pref.gear_list[pref.gear_slot])
@@ -350,9 +348,6 @@ var/global/list/gear_datums = list()
 
 /decl/loadout_option/Initialize()
 	. = ..()
-
-	if(is_abstract())
-		return .
 
 	if(name && (!global.using_map.loadout_blacklist || !(type in global.using_map.loadout_blacklist)))
 		global.gear_datums[name] = src

--- a/code/modules/codex/categories/category_cocktails.dm
+++ b/code/modules/codex/categories/category_cocktails.dm
@@ -10,7 +10,7 @@
 	guide_html = "<h1>Mixology 101</h1>Here's a guide for mixing decent cocktails."
 	for(var/ctype in cocktails)
 		var/decl/cocktail/cocktail = cocktails[ctype]
-		if(cocktail.hidden_from_codex || cocktail.is_abstract())
+		if(cocktail.hidden_from_codex)
 			continue
 
 		var/mechanics_text = "Cocktails will change the name of bartending glasses when mixed properly.<br><br>"

--- a/code/modules/codex/categories/category_cultures.dm
+++ b/code/modules/codex/categories/category_cultures.dm
@@ -6,7 +6,7 @@
 	var/list/all_cultural_info = decls_repository.get_decls_of_subtype(/decl/cultural_info)
 	for(var/thing in all_cultural_info)
 		var/decl/cultural_info/culture = all_cultural_info[thing]
-		if(culture.name && !culture.hidden_from_codex && !culture.is_abstract())
+		if(culture.name && !culture.hidden_from_codex)
 			var/datum/codex_entry/entry = new(
 				_display_name = "[culture.name] ([lowertext(culture.desc_type)])",
 				_lore_text = culture.description

--- a/code/modules/codex/categories/category_fusion_reaction.dm
+++ b/code/modules/codex/categories/category_fusion_reaction.dm
@@ -6,7 +6,7 @@
 	var/list/reactions = decls_repository.get_decls_of_subtype(/decl/fusion_reaction)
 	for(var/rtype in reactions)
 		var/decl/fusion_reaction/reaction = reactions[rtype]
-		if(reaction.hidden_from_codex || reaction.is_abstract())
+		if(reaction.hidden_from_codex)
 			continue
 
 		var/decl/material/p_mat = GET_DECL(reaction.p_react)

--- a/code/modules/codex/categories/category_languages.dm
+++ b/code/modules/codex/categories/category_languages.dm
@@ -7,7 +7,7 @@
 	var/language_types = decls_repository.get_decls_of_subtype(/decl/language)
 	for(var/langname in language_types)
 		var/decl/language/L = language_types[langname]
-		if(L.hidden_from_codex || L.is_abstract())
+		if(L.hidden_from_codex)
 			continue
 		var/list/lang_info = list()
 		var/decl/prefix/P = /decl/prefix/language

--- a/code/modules/codex/categories/category_reactions.dm
+++ b/code/modules/codex/categories/category_reactions.dm
@@ -25,7 +25,7 @@
 	var/list/all_reactions = decls_repository.get_decls_of_subtype(/decl/chemical_reaction)
 	for(var/reactiontype in all_reactions)
 		var/decl/chemical_reaction/reaction = all_reactions[reactiontype]
-		if(!reaction || !reaction.name || reaction.hidden_from_codex || istype(reaction, /decl/chemical_reaction/recipe) || reaction.is_abstract())
+		if(!reaction || !reaction.name || reaction.hidden_from_codex || istype(reaction, /decl/chemical_reaction/recipe))
 			continue // Food recipes are handled in category_recipes.dm.
 		var/mechanics_text = "This reaction requires the following reagents:<br>"
 		if(reaction.mechanics_text)

--- a/code/modules/codex/categories/category_recipes.dm
+++ b/code/modules/codex/categories/category_recipes.dm
@@ -19,11 +19,11 @@
 		<li>Mix flour and protein (ground meat) to make meatballs.</li>
 		</ul>"}
 
-	for(var/reactiontype in subtypesof(/decl/chemical_reaction/recipe))
-		var/decl/chemical_reaction/recipe/food = GET_DECL(reactiontype)
-		if(!food || !food.name || food.hidden_from_codex || food.is_abstract())
+	var/list/all_recipe_reactions = decls_repository.get_decls_of_subtype(/decl/chemical_reaction/recipe)
+	for(var/reactiontype in all_recipe_reactions)
+		var/decl/chemical_reaction/recipe/food = all_recipe_reactions[reactiontype]
+		if(!food || !food.name || food.hidden_from_codex)
 			continue
-
 		var/mechanics_text
 		var/lore_text
 		var/category_name
@@ -72,7 +72,7 @@
 	var/list/all_recipes = decls_repository.get_decls_of_subtype(/decl/recipe)
 	for(var/rtype in all_recipes)
 		var/decl/recipe/recipe = all_recipes[rtype]
-		if(!istype(recipe) || recipe.hidden_from_codex || !recipe.result || recipe.is_abstract())
+		if(!istype(recipe) || recipe.hidden_from_codex || !recipe.result)
 			continue
 
 		var/mechanics_text = ""

--- a/code/modules/codex/categories/category_species.dm
+++ b/code/modules/codex/categories/category_species.dm
@@ -6,7 +6,7 @@
 
 	for(var/thing in get_all_species())
 		var/decl/species/species = get_species_by_key(thing)
-		if(!species.hidden_from_codex && !species.is_abstract())
+		if(!species.hidden_from_codex)
 
 			var/entry_type = (species.secret_codex_info) ? /datum/codex_entry/scannable : /datum/codex_entry
 			var/datum/codex_entry/entry = new entry_type(

--- a/code/modules/codex/categories/category_substances.dm
+++ b/code/modules/codex/categories/category_substances.dm
@@ -5,7 +5,7 @@
 /decl/codex_category/substances/Populate()
 	for(var/thing in SSmaterials.materials)
 		var/decl/material/mat = thing
-		if(!mat.hidden_from_codex && !mat.is_abstract())
+		if(!mat.hidden_from_codex)
 			var/new_lore_text = initial(mat.lore_text) 
 			if(mat.taste_description)
 				new_lore_text = "[new_lore_text]<br>It apparently tastes of [mat.taste_description]."

--- a/code/modules/codex/categories/category_surgery.dm
+++ b/code/modules/codex/categories/category_surgery.dm
@@ -70,7 +70,7 @@
 	var/list/procedures = decls_repository.get_decls_of_subtype(/decl/surgery_step)
 	for(var/stype in procedures)
 		var/decl/surgery_step/procedure = procedures[stype]
-		if(procedure.hidden_from_codex || !procedure.name || procedure.is_abstract())
+		if(procedure.hidden_from_codex || !procedure.name)
 			continue
 
 		var/list/surgery_info = list()

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -143,16 +143,14 @@
 		return pick(players)
 	return default_if_none
 
-/datum/event/ionstorm/proc/get_random_species_name(var/default_if_none = "Humans")
-	var/list/species = list()
-	for(var/S in typesof(/decl/species))
-		var/decl/species/specimen = S
-		if(initial(specimen.spawn_flags) & SPECIES_CAN_JOIN)
-			species += initial(specimen.name_plural)
-
-	if(species.len)
-		return pick(species.len)
-	return default_if_none
+/datum/event/ionstorm/proc/get_random_species_name(var/default_if_none)
+	if(!default_if_none)
+		default_if_none = global.using_map.default_species
+	. = length(global.all_species) ? pick(global.all_species) : default_if_none
+	if(.)
+		var/decl/species/species = all_species[.]
+		if(species)
+			. = species.name_plural
 
 /datum/event/ionstorm/proc/get_random_language(var/mob/living/silicon/S)
 	var/list/languages = S.speech_synthesizer_langs.Copy()

--- a/code/modules/games/spaceball_cards.dm
+++ b/code/modules/games/spaceball_cards.dm
@@ -14,7 +14,7 @@
 			P.desc = "An autographed Spaceball Jones card!!"
 			P.card_icon = "spaceball_jones"
 		else
-			var/decl/language/L = GET_DECL(/decl/language/human)
+			var/decl/language/L = GET_DECL(/decl/language/human/common)
 			var/team = pick("Brickburn Galaxy Trekers","Mars Rovers", "Qerrbalak Saints", "Moghes Rockets", "Ahdomai Lightening")
 			P.name = "[L.get_random_name(pick(MALE,FEMALE))], [global.using_map.game_year - rand(0,50)] [team]"
 			P.card_icon = "spaceball_standard"

--- a/code/modules/goals/definitions/personal_achievement_specific_object.dm
+++ b/code/modules/goals/definitions/personal_achievement_specific_object.dm
@@ -45,9 +45,7 @@
 	completion_message = "Ahh, that hit the spot!"
 
 /datum/goal/achievement/specific_object/drink/New()
-	possible_objects = list()
-	for(var/object_type in decls_repository.get_decl_paths_of_subtype(/decl/material/liquid/drink))
-		possible_objects += object_type
+	possible_objects = decls_repository.get_decl_paths_of_subtype(/decl/material/liquid/drink)
 	..()
 
 /datum/goal/achievement/specific_object/drink/update_strings()

--- a/code/modules/goals/definitions/personal_achievement_specific_object.dm
+++ b/code/modules/goals/definitions/personal_achievement_specific_object.dm
@@ -45,7 +45,9 @@
 	completion_message = "Ahh, that hit the spot!"
 
 /datum/goal/achievement/specific_object/drink/New()
-	possible_objects = subtypesof(/decl/material/liquid/drink)
+	possible_objects = list()
+	for(var/object_type in decls_repository.get_decl_paths_of_subtype(/decl/material/liquid/drink))
+		possible_objects += object_type
 	..()
 
 /datum/goal/achievement/specific_object/drink/update_strings()

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -33,7 +33,8 @@
 		if(istype(descriptor))
 			appearance_descriptors[descriptor.name] = descriptor.randomize_value()
 
-	backpack = GET_DECL(pick(subtypesof(/decl/backpack_outfit)))
+	var/list/all_backpacks = decls_repository.get_decls_of_subtype(/decl/backpack_outfit)
+	backpack = all_backpacks[pick(all_backpacks)]
 	b_type = pickweight(current_species.blood_types)
 	if(H)
 		copy_to(H)

--- a/code/modules/mob/skills/skill.dm
+++ b/code/modules/mob/skills/skill.dm
@@ -34,7 +34,7 @@ var/global/list/skills = list()
 /decl/hierarchy/skill/Initialize()
 	. = ..()
 	GET_DECL(/decl/hierarchy/skill) // Make sure the full skill decl list is populated.
-	if(is_abstract())
+	if(DECL_INSTANCE_IS_ABSTRACT(src))
 		for(var/decl/hierarchy/skill/C in children)
 			global.skills |= C.get_descendents()
 

--- a/code/modules/overmap/exoplanets/exoplanet_atmosphere.dm
+++ b/code/modules/overmap/exoplanets/exoplanet_atmosphere.dm
@@ -37,8 +37,6 @@
 	var/list/all_materials = decls_repository.get_decls_of_subtype(/decl/material)
 	for(var/mat_type in all_materials)
 		var/decl/material/mat = all_materials[mat_type]
-		if(mat.is_abstract())
-			continue
 		if(mat.exoplanet_rarity == MAT_RARITY_NOWHERE)
 			continue
 		if(isnull(mat.boiling_point) || mat.boiling_point > target_temp)

--- a/code/modules/overmap/exoplanets/exoplanet_fauna.dm
+++ b/code/modules/overmap/exoplanets/exoplanet_fauna.dm
@@ -31,7 +31,7 @@
 		A.verbs |= /mob/living/simple_animal/proc/name_species
 	if(atmosphere)
 		//Set up gases for living things
-		var/list/all_gasses = subtypesof(/decl/material/gas)
+		var/list/all_gasses = decls_repository.get_decl_paths_of_subtype(/decl/material/gas)
 		if(!LAZYLEN(breathgas))
 			var/list/goodgases = all_gasses.Copy() 
 			var/gasnum = min(rand(1,3), goodgases.len)

--- a/code/modules/projectiles/guns/energy/capacitor.dm
+++ b/code/modules/projectiles/guns/energy/capacitor.dm
@@ -83,8 +83,9 @@ var/global/list/laser_wavelengths
 /obj/item/gun/energy/capacitor/Initialize()
 	if(!laser_wavelengths)
 		laser_wavelengths = list()
-		for(var/laser in subtypesof(/decl/laser_wavelength))
-			laser_wavelengths += GET_DECL(laser)
+		var/list/all_wavelengths = decls_repository.get_decls_of_subtype(/decl/laser_wavelength)
+		for(var/laser in all_wavelengths)
+			laser_wavelengths += all_wavelengths[laser]
 	selected_wavelength = pick(laser_wavelengths)
 	if(ispath(capacitors))
 		var/capacitor_type = capacitors

--- a/code/modules/reagents/chems/random/chems_random.dm
+++ b/code/modules/reagents/chems/random/chems_random.dm
@@ -25,18 +25,30 @@ var/global/list/random_chem_interaction_blacklist = list(
 
 /decl/material/liquid/random/proc/randomize_data(temperature)
 	data = list()
-	var/list/effects_to_get = subtypesof(/decl/random_chem_effect/random_properties)
+
+	var/list/general_effects = list()
+	for(var/effect_type in decls_repository.get_decl_paths_of_subtype(/decl/random_chem_effect/general_properties))
+		general_effects += effect_type
+
+	var/list/material_whitelist = list()
+	for(var/material_type in decls_repository.get_decl_paths_of_subtype(/decl/material))
+		material_whitelist += material_type
+
+	var/list/effects_to_get = list()
+	for(var/effect_type in decls_repository.get_decl_paths_of_subtype(/decl/random_chem_effect/random_properties))
+		effects_to_get += effect_type
+
 	if(length(effects_to_get) > max_effect_number)
 		shuffle(effects_to_get)
 		effects_to_get.Cut(max_effect_number + 1)
-	effects_to_get += subtypesof(/decl/random_chem_effect/general_properties)
+	effects_to_get += general_effects
 
 	var/list/decls = decls_repository.get_decls_unassociated(effects_to_get)
 	for(var/item in decls)
 		var/decl/random_chem_effect/effect = item
 		effect.prototype_process(src, temperature)
 
-	var/whitelist = subtypesof(/decl/material)
+	var/whitelist = material_whitelist
 	for(var/bad_type in global.random_chem_interaction_blacklist)
 		whitelist -= typesof(bad_type)
 

--- a/code/modules/reagents/chems/random/chems_random.dm
+++ b/code/modules/reagents/chems/random/chems_random.dm
@@ -26,21 +26,13 @@ var/global/list/random_chem_interaction_blacklist = list(
 /decl/material/liquid/random/proc/randomize_data(temperature)
 	data = list()
 
-	var/list/general_effects = list()
-	for(var/effect_type in decls_repository.get_decl_paths_of_subtype(/decl/random_chem_effect/general_properties))
-		general_effects += effect_type
-
-	var/list/material_whitelist = list()
-	for(var/material_type in decls_repository.get_decl_paths_of_subtype(/decl/material))
-		material_whitelist += material_type
-
-	var/list/effects_to_get = list()
-	for(var/effect_type in decls_repository.get_decl_paths_of_subtype(/decl/random_chem_effect/random_properties))
-		effects_to_get += effect_type
-
+	var/list/effects_to_get = decls_repository.get_decl_paths_of_subtype(/decl/random_chem_effect/random_properties)
+	effects_to_get = effects_to_get.Copy()
 	if(length(effects_to_get) > max_effect_number)
 		shuffle(effects_to_get)
 		effects_to_get.Cut(max_effect_number + 1)
+
+	var/list/general_effects = decls_repository.get_decl_paths_of_subtype(/decl/random_chem_effect/general_properties)
 	effects_to_get += general_effects
 
 	var/list/decls = decls_repository.get_decls_unassociated(effects_to_get)
@@ -48,7 +40,8 @@ var/global/list/random_chem_interaction_blacklist = list(
 		var/decl/random_chem_effect/effect = item
 		effect.prototype_process(src, temperature)
 
-	var/whitelist = material_whitelist
+	var/list/material_whitelist = decls_repository.get_decl_paths_of_subtype(/decl/material)
+	var/whitelist = material_whitelist.Copy()
 	for(var/bad_type in global.random_chem_interaction_blacklist)
 		whitelist -= typesof(bad_type)
 

--- a/code/modules/reagents/dispenser/cartridge_spawn.dm
+++ b/code/modules/reagents/dispenser/cartridge_spawn.dm
@@ -1,4 +1,4 @@
-/client/proc/spawn_chemdisp_cartridge(size in list("small", "medium", "large"), reagent in subtypesof(/decl/material))
+/client/proc/spawn_chemdisp_cartridge(size in list("small", "medium", "large"), reagent in decls_repository.get_decl_paths_of_subtype(/decl/material))
 	set name = "Spawn Chemical Dispenser Cartridge"
 	set category = "Admin"
 

--- a/code/modules/reagents/reagent_containers/drinks/juicebox.dm
+++ b/code/modules/reagents/reagent_containers/drinks/juicebox.dm
@@ -102,7 +102,7 @@
 	desc = "Juice in a box; who knows what flavor!"
 
 /obj/item/chems/drinks/juicebox/sensible_random/proc/juice_it()
-	var/drinktypes = subtypesof(/decl/material/liquid/drink/juice)
+	var/list/drinktypes = decls_repository.get_decls_of_subtype(/decl/material/liquid/drink/juice)
 	var/decl/material/J = pick(drinktypes)
 	reagents.add_reagent(J, 20)
 	reagents.add_reagent(pick(drinktypes - J), 5)

--- a/code/modules/reagents/reagent_containers/drinks/juicebox.dm
+++ b/code/modules/reagents/reagent_containers/drinks/juicebox.dm
@@ -102,7 +102,7 @@
 	desc = "Juice in a box; who knows what flavor!"
 
 /obj/item/chems/drinks/juicebox/sensible_random/proc/juice_it()
-	var/list/drinktypes = decls_repository.get_decls_of_subtype(/decl/material/liquid/drink/juice)
+	var/list/drinktypes = decls_repository.get_decl_paths_of_subtype(/decl/material/liquid/drink/juice)
 	var/decl/material/J = pick(drinktypes)
 	reagents.add_reagent(J, 20)
 	reagents.add_reagent(pick(drinktypes - J), 5)

--- a/code/modules/species/outsider/random.dm
+++ b/code/modules/species/outsider/random.dm
@@ -132,8 +132,9 @@
 	breath_type = pick(atmosphere.gas)
 	breath_pressure = 0.8*(atmosphere.gas[breath_type]/atmosphere.total_moles)*normal_pressure
 
-	var/list/newgases = subtypesof(/decl/material/gas)
-	newgases = newgases.Copy()
+	var/list/newgases = list()
+	for(var/gastype in decls_repository.get_decl_paths_of_subtype(/decl/material/gas))
+		newgases += gastype
 	newgases ^= atmosphere.gas
 	for(var/gas in newgases)
 		var/decl/material/mat = GET_DECL(gas)

--- a/code/modules/species/outsider/random.dm
+++ b/code/modules/species/outsider/random.dm
@@ -132,9 +132,8 @@
 	breath_type = pick(atmosphere.gas)
 	breath_pressure = 0.8*(atmosphere.gas[breath_type]/atmosphere.total_moles)*normal_pressure
 
-	var/list/newgases = list()
-	for(var/gastype in decls_repository.get_decl_paths_of_subtype(/decl/material/gas))
-		newgases += gastype
+	var/list/newgases = decls_repository.get_decl_paths_of_subtype(/decl/material/gas)
+	newgases = newgases.Copy()
 	newgases ^= atmosphere.gas
 	for(var/gas in newgases)
 		var/decl/material/mat = GET_DECL(gas)

--- a/code/modules/species/species_bodytype.dm
+++ b/code/modules/species/species_bodytype.dm
@@ -65,8 +65,7 @@ var/global/list/bodytypes_by_category = list()
 	. = ..()
 	if(!icon_deformed)
 		icon_deformed = icon_base
-	if(!is_abstract())
-		LAZYDISTINCTADD(global.bodytypes_by_category[bodytype_category], src)
+	LAZYDISTINCTADD(global.bodytypes_by_category[bodytype_category], src)
 
 /decl/bodytype/proc/apply_limb_colouration(var/obj/item/organ/external/E, var/icon/applying)
 	return applying

--- a/code/modules/weather/weather_debug.dm
+++ b/code/modules/weather/weather_debug.dm
@@ -57,7 +57,7 @@
 		to_chat(usr, SPAN_WARNING("This z-level has no weather. Use <b>Initialize Weather For Level</b> if you want to create it."))
 		return
 
-	var/use_state = input(usr, "Which state do you wish to use?", "Target State") as null|anything in subtypesof(/decl/state/weather)
+	var/use_state = input(usr, "Which state do you wish to use?", "Target State") as null|anything in decls_repository.get_decl_paths_of_subtype(/decl/state/weather)
 	if(!use_state || weather != (T.weather || global.weather_by_z["[T.z]"]))
 		return
 	weather.weather_system.set_state(use_state)

--- a/code/modules/xenoarcheaology/artifacts/effects/gas_generation.dm
+++ b/code/modules/xenoarcheaology/artifacts/effects/gas_generation.dm
@@ -5,7 +5,7 @@
 /datum/artifact_effect/gas/New()
 	..()
 	if(!spawned_gas)
-		spawned_gas = pick(decls_repository.get_decls_of_subtype(/decl/material/gas))
+		spawned_gas = pick(decls_repository.get_decl_paths_of_subtype(/decl/material/gas))
 	operation_type = pick(EFFECT_TOUCH, EFFECT_AURA)
 	origin_type = EFFECT_SYNTH
 

--- a/code/modules/xenoarcheaology/artifacts/effects/gas_generation.dm
+++ b/code/modules/xenoarcheaology/artifacts/effects/gas_generation.dm
@@ -5,7 +5,7 @@
 /datum/artifact_effect/gas/New()
 	..()
 	if(!spawned_gas)
-		spawned_gas = pick(subtypesof(/decl/material/gas))
+		spawned_gas = pick(decls_repository.get_decls_of_subtype(/decl/material/gas))
 	operation_type = pick(EFFECT_TOUCH, EFFECT_AURA)
 	origin_type = EFFECT_SYNTH
 

--- a/code/modules/xenoarcheaology/artifacts/triggers/gas.dm
+++ b/code/modules/xenoarcheaology/artifacts/triggers/gas.dm
@@ -5,7 +5,7 @@
 
 /datum/artifact_trigger/gas/New()
 	if(!gas_needed)
-		gas_needed = list(pick(subtypesof(/decl/material/gas)) = rand(1,10))
+		gas_needed = list(pick(decls_repository.get_decls_of_subtype(/decl/material/gas)) = rand(1,10))
 	var/decl/material/gas/G = GET_DECL(gas_needed[1])
 	name = "concentration of [G.name]"
 

--- a/code/modules/xenoarcheaology/artifacts/triggers/gas.dm
+++ b/code/modules/xenoarcheaology/artifacts/triggers/gas.dm
@@ -5,7 +5,7 @@
 
 /datum/artifact_trigger/gas/New()
 	if(!gas_needed)
-		gas_needed = list(pick(decls_repository.get_decls_of_subtype(/decl/material/gas)) = rand(1,10))
+		gas_needed = list(pick(decls_repository.get_decl_paths_of_subtype(/decl/material/gas)) = rand(1,10))
 	var/decl/material/gas/G = GET_DECL(gas_needed[1])
 	name = "concentration of [G.name]"
 

--- a/code/modules/xenoarcheaology/finds/find_types/mundane.dm
+++ b/code/modules/xenoarcheaology/finds/find_types/mundane.dm
@@ -56,7 +56,7 @@
 /decl/archaeological_find/tank/spawn_item(atom/loc)
 	var/obj/item/tank/new_item = ..()
 	new_item.air_contents.gas.Cut()
-	new_item.air_contents.adjust_gas(pick(subtypesof(/decl/material/gas)),15)
+	new_item.air_contents.adjust_gas(pick(decls_repository.get_decls_of_subtype(/decl/material/gas)),15)
 	return new_item
 
 /decl/archaeological_find/tank/generate_name()

--- a/code/modules/xenoarcheaology/finds/find_types/mundane.dm
+++ b/code/modules/xenoarcheaology/finds/find_types/mundane.dm
@@ -56,7 +56,7 @@
 /decl/archaeological_find/tank/spawn_item(atom/loc)
 	var/obj/item/tank/new_item = ..()
 	new_item.air_contents.gas.Cut()
-	new_item.air_contents.adjust_gas(pick(decls_repository.get_decls_of_subtype(/decl/material/gas)),15)
+	new_item.air_contents.adjust_gas(pick(decls_repository.get_decl_paths_of_subtype(/decl/material/gas)),15)
 	return new_item
 
 /decl/archaeological_find/tank/generate_name()

--- a/code/unit_tests/alt_appearances_test.dm
+++ b/code/unit_tests/alt_appearances_test.dm
@@ -2,7 +2,7 @@
 	name = "ALT APPEARANCE: Cardborg shall have base backpack variant"
 
 /datum/unit_test/alt_appearance_cardborg_shall_have_base_backpack_variant/start_test()
-	for(var/ca_type in subtypesof(/decl/cardborg_appearance))
+	for(var/ca_type in decls_repository.get_decl_paths_of_subtype(/decl/cardborg_appearance))
 		var/decl/cardborg_appearance/ca = ca_type
 		var/obj/item/storage/backpack/backpack_type = initial(ca.backpack_type)
 		if(backpack_type == /obj/item/storage/backpack)
@@ -18,7 +18,7 @@
 /datum/unit_test/alt_appearance_cardborg_all_icon_states_shall_exist/start_test()
 	var/failed = FALSE
 
-	for(var/ca_type in subtypesof(/decl/cardborg_appearance))
+	for(var/ca_type in decls_repository.get_decl_paths_of_subtype(/decl/cardborg_appearance))
 		var/decl/cardborg_appearance/ca = ca_type
 		var/list/existing_icon_states = icon_states(initial(ca.icon))
 		var/icon_state = initial(ca.icon_state)
@@ -36,7 +36,7 @@
 
 /datum/unit_test/alt_appearance_cardborg_shall_have_unique_backpack_types/start_test()
 	var/list/backpack_types = list()
-	for(var/ca_type in subtypesof(/decl/cardborg_appearance))
+	for(var/ca_type in decls_repository.get_decl_paths_of_subtype(/decl/cardborg_appearance))
 		var/decl/cardborg_appearance/ca = ca_type
 		group_by(backpack_types, initial(ca.backpack_type), ca)
 

--- a/code/unit_tests/atmospherics_tests.dm
+++ b/code/unit_tests/atmospherics_tests.dm
@@ -197,7 +197,7 @@
 	name = "ATMOS MACHINERY: scrub_gas() Conserves Moles"
 
 /datum/unit_test/atmos_machinery/conserve_moles/scrub_gas/start_test()
-	var/list/filtering = decls_repository.get_decls_of_subtype(/decl/material/gas)
+	var/list/filtering = decls_repository.get_decl_paths_of_subtype(/decl/material/gas)
 	for(var/case_name in test_cases)
 		var/gas_mix_data = test_cases[case_name]
 		var/list/before_gas_mixes = create_gas_mixes(gas_mix_data)
@@ -256,7 +256,7 @@
 		var/list/after_gas_mixes = create_gas_mixes(gas_mix_data)
 
 		var/list/mix_sources = list()
-		var/list/all_gasses = decls_repository.get_decls_of_subtype(/decl/material/gas)
+		var/list/all_gasses = decls_repository.get_decl_paths_of_subtype(/decl/material/gas)
 		var/gas_count = length(all_gasses)
 		for(var/gasid in all_gasses)
 			var/datum/gas_mixture/mix_source = after_gas_mixes["sink"]

--- a/code/unit_tests/atmospherics_tests.dm
+++ b/code/unit_tests/atmospherics_tests.dm
@@ -213,16 +213,12 @@
 	name = "ATMOS MACHINERY: filter_gas() Conserves Moles"
 
 /datum/unit_test/atmos_machinery/conserve_moles/filter_gas/start_test()
-	var/list/filtering = list()
-	for(var/filter_type in decls_repository.get_decl_paths_of_subtype(/decl/material/gas))
-		filtering += filter_type
+	var/list/filtering = decls_repository.get_decl_paths_of_subtype(/decl/material/gas)
 	for(var/case_name in test_cases)
 		var/gas_mix_data = test_cases[case_name]
 		var/list/before_gas_mixes = create_gas_mixes(gas_mix_data)
 		var/list/after_gas_mixes = create_gas_mixes(gas_mix_data)
-
 		filter_gas(null, filtering, after_gas_mixes["source"], after_gas_mixes["sink"], after_gas_mixes["source"], null, INFINITY)
-
 		check_moles_conserved(case_name, before_gas_mixes, after_gas_mixes)
 
 	return 1

--- a/code/unit_tests/atmospherics_tests.dm
+++ b/code/unit_tests/atmospherics_tests.dm
@@ -41,7 +41,7 @@
 
 /datum/unit_test/atmos_machinery/proc/check_moles_conserved(var/case_name, var/list/before_gas_mixes, var/list/after_gas_mixes)
 	var/failed = FALSE
-	for(var/gasid in subtypesof(/decl/material/gas))
+	for(var/gasid in decls_repository.get_decl_paths_of_subtype(/decl/material/gas))
 		var/before = 0
 		for(var/gasmix in before_gas_mixes)
 			var/datum/gas_mixture/G = before_gas_mixes[gasmix]
@@ -197,7 +197,7 @@
 	name = "ATMOS MACHINERY: scrub_gas() Conserves Moles"
 
 /datum/unit_test/atmos_machinery/conserve_moles/scrub_gas/start_test()
-	var/list/filtering = subtypesof(/decl/material/gas)
+	var/list/filtering = decls_repository.get_decls_of_subtype(/decl/material/gas)
 	for(var/case_name in test_cases)
 		var/gas_mix_data = test_cases[case_name]
 		var/list/before_gas_mixes = create_gas_mixes(gas_mix_data)
@@ -213,7 +213,9 @@
 	name = "ATMOS MACHINERY: filter_gas() Conserves Moles"
 
 /datum/unit_test/atmos_machinery/conserve_moles/filter_gas/start_test()
-	var/list/filtering = subtypesof(/decl/material/gas)
+	var/list/filtering = list()
+	for(var/filter_type in decls_repository.get_decl_paths_of_subtype(/decl/material/gas))
+		filtering += filter_type
 	for(var/case_name in test_cases)
 		var/gas_mix_data = test_cases[case_name]
 		var/list/before_gas_mixes = create_gas_mixes(gas_mix_data)
@@ -235,7 +237,7 @@
 		var/list/after_gas_mixes = create_gas_mixes(gas_mix_data)
 
 		var/list/filtering = list()
-		for(var/gasid in subtypesof(/decl/material/gas))
+		for(var/gasid in decls_repository.get_decl_paths_of_subtype(/decl/material/gas))
 			filtering[gasid] = after_gas_mixes["sink"] //just filter everything to sink
 
 		filter_gas_multi(null, filtering, after_gas_mixes["source"], after_gas_mixes["sink"], null, INFINITY)
@@ -254,7 +256,7 @@
 		var/list/after_gas_mixes = create_gas_mixes(gas_mix_data)
 
 		var/list/mix_sources = list()
-		var/list/all_gasses = subtypesof(/decl/material/gas)
+		var/list/all_gasses = decls_repository.get_decls_of_subtype(/decl/material/gas)
 		var/gas_count = length(all_gasses)
 		for(var/gasid in all_gasses)
 			var/datum/gas_mixture/mix_source = after_gas_mixes["sink"]

--- a/code/unit_tests/chemistry_tests.dm
+++ b/code/unit_tests/chemistry_tests.dm
@@ -131,7 +131,7 @@
 /datum/unit_test/reagent_colors_test/start_test()
 	var/list/bad_reagents = list()
 
-	for(var/T in typesof(/decl/material))
+	for(var/T in decls_repository.get_decl_paths_of_subtype(/decl/material))
 		var/decl/material/R = T
 		if(length(initial(R.color)) != 7)
 			bad_reagents += "[T] ([initial(R.color)])"

--- a/code/unit_tests/closets.dm
+++ b/code/unit_tests/closets.dm
@@ -14,12 +14,14 @@
 	var/list/bad_decal_colour
 	var/list/bad_decal_state
 
-	for(var/check_appearance in typesof(/decl/closet_appearance)-except_appearances)
-		var/decl/closet_appearance/closet = GET_DECL(check_appearance)
+	var/list/closet_appearances = decls_repository.get_decls_of_type(/decl/closet_appearance)
+	for(var/check_appearance in closet_appearances)
+		if(check_appearance in except_appearances)
+			continue
+		var/decl/closet_appearance/closet = closet_appearances[check_appearance]
 		if(!closet)
 			LAZYADD(bad_decl, "[check_appearance]")
 			continue
-
 		if(!closet.icon)
 			LAZYADD(bad_icon, "[closet.type]")
 		if(!closet.color)

--- a/code/unit_tests/decls.dm
+++ b/code/unit_tests/decls.dm
@@ -4,8 +4,6 @@
 		/decl/material
 	)
 
-// Handled manually to avoid initializing decls unnecessarily.
-#define DECL_TYPE_IS_ABSTRACT(DECL, DTYPE) (initial(DECL.abstract_type) == DTYPE)
 /datum/unit_test/decl_validation/start_test()
 
 	var/list/failures = list()
@@ -14,7 +12,7 @@
 	for(var/mandatory_type in mandatory_uid_types)
 		for(var/decl_type in typesof(mandatory_type))
 			var/decl/decl = decl_type
-			if(DECL_TYPE_IS_ABSTRACT(decl, decl_type))
+			if(DECL_TYPE_IS_ABSTRACT(decl))
 				continue
 			decl = GET_DECL(decl_type)
 			if(!istext(decl.uid))
@@ -24,7 +22,7 @@
 	var/list/seen_uids = list()
 	for(var/decl_type in typesof(/decl))
 		var/decl/decl = decl_type
-		if(DECL_TYPE_IS_ABSTRACT(decl, decl_type))
+		if(DECL_TYPE_IS_ABSTRACT(decl))
 			continue
 		decl = GET_DECL(decl_type)
 		if(isnull(decl.uid))
@@ -42,4 +40,3 @@
 	else
 		pass("All /decl UIDs were validated successfully.")
 	return 1
-#undef DECL_TYPE_IS_ABSTRACT

--- a/code/unit_tests/icon_tests.dm
+++ b/code/unit_tests/icon_tests.dm
@@ -66,8 +66,9 @@
 	var/contraband_icons = icon_states('icons/obj/contraband.dmi')
 	var/list/invalid_posters = list()
 
-	for(var/poster_type in subtypesof(/decl/poster))
-		var/decl/poster/P = GET_DECL(poster_type)
+	var/list/all_posters = decls_repository.get_decls_of_subtype(/decl/poster)
+	for(var/poster_type in all_posters)
+		var/decl/poster/P = all_posters[poster_type]
 		if(!(P.icon_state in contraband_icons))
 			invalid_posters += poster_type
 

--- a/code/unit_tests/integrated_circuits.dm
+++ b/code/unit_tests/integrated_circuits.dm
@@ -24,7 +24,7 @@
 
 /datum/unit_test/integrated_circuits/prefabs_are_valid/start_test()
 	var/list/failed_prefabs = list()
-	for(var/prefab_type in subtypesof(/decl/prefab/ic_assembly))
+	for(var/prefab_type in decls_repository.get_decl_paths_of_subtype(/decl/prefab/ic_assembly))
 		var/decl/prefab/ic_assembly/prefab = prefab_type
 		var/result = SScircuit.validate_electronic_assembly(initial(prefab.data))
 		if(istext(result)) //Returned some error
@@ -41,9 +41,9 @@
 
 /datum/unit_test/integrated_circuits/prefabs_shall_not_fail_to_create/start_test()
 	var/list/failed_prefabs = list()
-	for(var/prefab_type in subtypesof(/decl/prefab/ic_assembly))
-		var/decl/prefab/ic_assembly/prefab = GET_DECL(prefab_type)
-
+	var/list/all_prefabs = decls_repository.get_decls_of_subtype(/decl/prefab/ic_assembly)
+	for(var/prefab_type in all_prefabs)
+		var/decl/prefab/ic_assembly/prefab = all_prefabs[prefab_type]
 		try
 			var/built_item = prefab.create(get_safe_turf())
 			if(built_item)

--- a/code/unit_tests/materials.dm
+++ b/code/unit_tests/materials.dm
@@ -175,8 +175,6 @@
 	var/list/all_materials = decls_repository.get_decls_of_type(/decl/material)
 	for(var/decl_type in all_materials)
 		var/decl/material/mat = all_materials[decl_type]
-		if(mat.is_abstract())
-			continue
 		if(!mat.gas_symbol)
 			failures += "[mat.type] - false or null gas_symbol"
 		else if(mat.gas_symbol in seen)

--- a/code/unit_tests/trait_tests.dm
+++ b/code/unit_tests/trait_tests.dm
@@ -11,8 +11,9 @@
 
 /datum/unit_test/trait/all_traits_shall_have_valid_names/start_test()
 	var/list/invalid_traits = list()
-	for(var/trait in decls_repository.get_decls_unassociated(trait_types()))
-		var/decl/trait/T = trait
+	var/list/all_traits = decls_repository.get_decls_of_type(/decl/trait)
+	for(var/trait in all_traits)
+		var/decl/trait/T = all_traits[trait]
 		if(!T.name || !istext(T.name)) // Empty strings are valid texts
 			invalid_traits += T.type
 
@@ -29,9 +30,9 @@
 
 /datum/unit_test/trait/all_traits_shall_have_unique_name/start_test()
 	var/list/trait_names = list()
-
-	for(var/trait in decls_repository.get_decls_unassociated(trait_types()))
-		var/decl/trait/T = trait
+	var/list/all_traits = decls_repository.get_decls_of_type(/decl/trait)
+	for(var/trait in all_traits)
+		var/decl/trait/T = all_traits[trait]
 		group_by(trait_names, T.name, T.type)
 
 	var/number_of_issues = number_of_issues(trait_names, "Names")
@@ -47,8 +48,9 @@
 
 /datum/unit_test/trait/all_traits_shall_have_valid_levels/start_test()
 	var/list/invalid_traits = list()
-	for(var/trait in decls_repository.get_decls_unassociated(trait_types()))
-		var/decl/trait/T = trait
+	var/list/all_traits = decls_repository.get_decls_of_type(/decl/trait)
+	for(var/trait in all_traits)
+		var/decl/trait/T = all_traits[trait]
 		if(!length(T.levels) || (T.levels.len > 1 && (TRAIT_LEVEL_EXISTS in T.levels)))
 			invalid_traits += T.type
 

--- a/code/unit_tests/unique_tests.dm
+++ b/code/unit_tests/unique_tests.dm
@@ -82,7 +82,7 @@
 /datum/unit_test/languages_shall_have_unique_names/start_test()
 	var/list/languages_by_name = list()
 
-	for(var/lt in subtypesof(/decl/language))
+	for(var/lt in decls_repository.get_decl_paths_of_subtype(/decl/language))
 		var/decl/language/l = lt
 		group_by(languages_by_name, initial(l.name), lt)
 
@@ -99,7 +99,7 @@
 /datum/unit_test/languages_shall_have_no_or_unique_keys/start_test()
 	var/list/languages_by_key = list()
 
-	for(var/lt in subtypesof(/decl/language))
+	for(var/lt in decls_repository.get_decl_paths_of_subtype(/decl/language))
 		var/decl/language/l = lt
 		var/language_key = initial(l.key)
 		if(!language_key)

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -165,7 +165,7 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	else if(LAZYLEN(lobby_tracks))
 		lobby_track_type = pickweight(lobby_tracks - exclude)
 	else
-		lobby_track_type = pick(decls_repository.get_decls_of_subtype(/decl/music_track) - exclude)
+		lobby_track_type = pick(decls_repository.get_decl_paths_of_subtype(/decl/music_track) - exclude)
 	return GET_DECL(lobby_track_type)
 
 /datum/map/proc/setup_map()

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -165,7 +165,7 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	else if(LAZYLEN(lobby_tracks))
 		lobby_track_type = pickweight(lobby_tracks - exclude)
 	else
-		lobby_track_type = pick(subtypesof(/decl/music_track) - exclude)
+		lobby_track_type = pick(decls_repository.get_decls_of_subtype(/decl/music_track) - exclude)
 	return GET_DECL(lobby_track_type)
 
 /datum/map/proc/setup_map()

--- a/mods/content/psionics/system/psionics/faculties/_power.dm
+++ b/mods/content/psionics/system/psionics/faculties/_power.dm
@@ -17,9 +17,6 @@
 
 /decl/psionic_power/proc/invoke(var/mob/living/user, var/atom/target)
 
-	if(is_abstract())
-		return FALSE
-
 	if(!user.psi)
 		return FALSE
 
@@ -43,8 +40,6 @@
 	return TRUE
 
 /decl/psionic_power/proc/handle_post_power(var/mob/living/user, var/atom/target)
-	if(is_abstract())
-		return
 	if(cooldown)
 		user.psi.set_cooldown(cooldown)
 	if(admin_log && ismob(user) && ismob(target))

--- a/mods/content/psionics/system/subsystem_psi.dm
+++ b/mods/content/psionics/system/subsystem_psi.dm
@@ -30,7 +30,7 @@ PROCESSING_SUBSYSTEM_DEF(psi)
 	var/list/powers = decls_repository.get_decls_of_subtype(/decl/psionic_power)
 	for(var/ptype in powers)
 		var/decl/psionic_power/power = powers[ptype]
-		if(!power.is_abstract() && power.faculty)
+		if(power.faculty)
 			var/decl/psionic_faculty/faculty = get_faculty(power.faculty)
 			if(faculty)
 				faculty.powers |= power


### PR DESCRIPTION
## Description of changes
- Removes /decl `is_abstract()` in favour of the macro.
- Makes the vast majority of decls refuse to init when abstract and prunes them from the decl init procs.
- Replaces a bunch of typesof()/subtypesof() decl retrieval with decl repository procs.

## Why and what will this PR improve
Prunes abstract decls more consistently and avoids some init weirdness.

## Authorship
Myself and @out-of-phaze.

## Changelog
Nothing player-facing.