### PR TITLE
Allows HE pipes to interact with exterior turfs

### DIFF
--- a/code/modules/atmospherics/datum_pipeline.dm
+++ b/code/modules/atmospherics/datum_pipeline.dm
@@ -201,59 +201,65 @@
 	var/total_heat_capacity = air.heat_capacity()
 	var/partial_heat_capacity = total_heat_capacity*(share_volume/air.volume)
 
-	if(istype(target, /turf/simulated))
+	if(istype(target, /turf/simulated) && !target.blocks_air)
 		var/turf/simulated/modeled_location = target
 
-		if(modeled_location.blocks_air)
+		var/delta_temperature = 0
+		var/sharer_heat_capacity = 0
 
-			if((modeled_location.heat_capacity>0) && (partial_heat_capacity>0))
-				var/delta_temperature = air.temperature - modeled_location.temperature
-
-				var/heat = thermal_conductivity*delta_temperature* \
-					(partial_heat_capacity*modeled_location.heat_capacity/(partial_heat_capacity+modeled_location.heat_capacity))
-
-				air.temperature -= heat/total_heat_capacity
-				modeled_location.temperature += heat/modeled_location.heat_capacity
-
+		if(modeled_location.zone)
+			delta_temperature = (air.temperature - modeled_location.zone.air.temperature)
+			sharer_heat_capacity = modeled_location.zone.air.heat_capacity()
 		else
-			var/delta_temperature = 0
-			var/sharer_heat_capacity = 0
+			delta_temperature = (air.temperature - modeled_location.air.temperature)
+			sharer_heat_capacity = modeled_location.air.heat_capacity()
 
-			if(modeled_location.zone)
-				delta_temperature = (air.temperature - modeled_location.zone.air.temperature)
-				sharer_heat_capacity = modeled_location.zone.air.heat_capacity()
-			else
-				delta_temperature = (air.temperature - modeled_location.air.temperature)
-				sharer_heat_capacity = modeled_location.air.heat_capacity()
+		var/self_temperature_delta = 0
+		var/sharer_temperature_delta = 0
 
-			var/self_temperature_delta = 0
-			var/sharer_temperature_delta = 0
+		if((sharer_heat_capacity > 0) && (partial_heat_capacity > 0))
+			var/heat = thermal_conductivity*delta_temperature* \
+				(partial_heat_capacity*sharer_heat_capacity/(partial_heat_capacity+sharer_heat_capacity))
 
-			if((sharer_heat_capacity>0) && (partial_heat_capacity>0))
-				var/heat = thermal_conductivity*delta_temperature* \
-					(partial_heat_capacity*sharer_heat_capacity/(partial_heat_capacity+sharer_heat_capacity))
+			self_temperature_delta = -heat/total_heat_capacity
+			sharer_temperature_delta = heat/sharer_heat_capacity
+		else
+			return 1
 
-				self_temperature_delta = -heat/total_heat_capacity
-				sharer_temperature_delta = heat/sharer_heat_capacity
-			else
-				return 1
+		air.temperature += self_temperature_delta
 
-			air.temperature += self_temperature_delta
+		if(modeled_location.zone)
+			modeled_location.zone.air.temperature += sharer_temperature_delta/modeled_location.zone.air.group_multiplier
+		else
+			modeled_location.air.temperature += sharer_temperature_delta
 
-			if(modeled_location.zone)
-				modeled_location.zone.air.temperature += sharer_temperature_delta/modeled_location.zone.air.group_multiplier
-			else
-				modeled_location.air.temperature += sharer_temperature_delta
+	else if(istype(target, /turf/exterior) && !target.blocks_air)
+		var/turf/exterior/modeled_location = target
+		var/datum/gas_mixture/target_air = modeled_location.return_air()
 
+		var/delta_temperature = air.temperature - target_air.temperature
+		var/sharer_heat_capacity = target_air.heat_capacity()
+
+		if((sharer_heat_capacity > 0) && (partial_heat_capacity > 0))
+			var/heat = thermal_conductivity*delta_temperature* \
+				(partial_heat_capacity*sharer_heat_capacity/(partial_heat_capacity+sharer_heat_capacity))
+
+			air.temperature += -heat/total_heat_capacity
+		else
+			return 1
 
 	else
-		if((target.heat_capacity>0) && (partial_heat_capacity>0))
+		if((target.heat_capacity > 0) && (partial_heat_capacity > 0))
 			var/delta_temperature = air.temperature - target.temperature
 
 			var/heat = thermal_conductivity*delta_temperature* \
 				(partial_heat_capacity*target.heat_capacity/(partial_heat_capacity+target.heat_capacity))
 
 			air.temperature -= heat/total_heat_capacity
+			// Only increase the temperature of the target if it's simulated.
+			if(istype(target, /turf/simulated))
+				target.temperature += heat/target.heat_capacity
+
 	if(network)
 		network.update = 1
 

--- a/code/modules/atmospherics/he_pipes.dm
+++ b/code/modules/atmospherics/he_pipes.dm
@@ -57,16 +57,17 @@
 		..()
 	else
 		var/datum/gas_mixture/pipe_air = return_air()
-		if(istype(loc, /turf/simulated/))
+		if(istype(loc, /turf/simulated) || istype(loc, /turf/exterior))
+			var/turf/pipe_turf = loc
 			var/environment_temperature = 0
-			if(loc:blocks_air)
-				environment_temperature = loc:temperature
+			if(pipe_turf.blocks_air)
+				environment_temperature = pipe_turf.temperature
 			else
-				var/datum/gas_mixture/environment = loc.return_air()
+				var/datum/gas_mixture/environment = pipe_turf.return_air()
 				environment_temperature = environment.temperature
 			if(abs(environment_temperature-pipe_air.temperature) > minimum_temperature_difference)
-				parent.temperature_interact(loc, volume, thermal_conductivity)
-		else if(istype(loc, /turf/space/))
+				parent.temperature_interact(pipe_turf, volume, thermal_conductivity)
+		else if(istype(loc, /turf/space))
 			parent.radiate_heat_to_space(surface, 1)
 
 		if(buckled_mob)


### PR DESCRIPTION
## Description of changes
Allows HE pipes to interact with exterior turfs, losing heat to their surroundings. Also cleans up some of the code and removes unnecessary uses of the colon operator,

## Why and what will this PR improve
HE pipes are critical for most power setups, and various engineering projects. These changes will allow them to be utilized on exoplanets, which is particularly useful for us downstream.
## Authorship
Myself.

## Changelog
:cl:
add: Heat exchange pipes can now interact with exoplanet environments.
/:cl: