### PR TITLE
Attempting to address some performance issues seen on Scav testing.

### DIFF
--- a/code/__defines/temperature.dm
+++ b/code/__defines/temperature.dm
@@ -6,17 +6,7 @@
 #define ADJUST_ATOM_TEMPERATURE(_atom, _temp) \
 	_atom.temperature = _temp; \
 	HANDLE_REACTIONS(_atom.reagents); \
-	QUEUE_TEMPERATURE_ATOMS(_atom);
-
-#define QUEUE_TEMPERATURE_ATOMS(_atoms) \
-	if(islist(_atoms)) { \
-		for(var/thing in _atoms) { \
-			var/atom/A = thing; \
-			QUEUE_TEMPERATURE_ATOM(A); \
-		} \
-	} else { \
-		QUEUE_TEMPERATURE_ATOM(_atoms); \
-	}
+	queue_temperature_atoms(_atom);
 
 #define QUEUE_TEMPERATURE_ATOM(_atom) \
 	if(ATOM_SHOULD_TEMPERATURE_ENQUEUE(_atom)) { \
@@ -37,3 +27,13 @@
 	if(ATOM_IS_TEMPERATURE_SENSITIVE(_atom)) { \
 		SStemperature.processing -= _atom; \
 	}
+
+
+// This is a proc primarily for profiling purposes.
+/proc/queue_temperature_atoms(var/atom/atom)
+	if(islist(atom))
+		for(var/thing in atom)
+			var/atom/A = thing
+			QUEUE_TEMPERATURE_ATOM(A)
+	else
+		QUEUE_TEMPERATURE_ATOM(atom)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -77,7 +77,12 @@
 // If you want to use this, the atom must have the PROXMOVE flag, and the moving
 // atom must also have the PROXMOVE flag currently to help with lag. ~ ComicIronic
 /atom/proc/HasProximity(atom/movable/AM)
-	return
+	SHOULD_CALL_PARENT(TRUE)
+	set waitfor = FALSE
+	if(!istype(AM))
+		PRINT_STACK_TRACE("DEBUG: HasProximity called with [AM] on [src] ([usr]).")
+		return FALSE
+	return TRUE
 
 /atom/proc/emp_act(var/severity)
 	return

--- a/code/game/atoms_temperature.dm
+++ b/code/game/atoms_temperature.dm
@@ -7,7 +7,7 @@
 
 /atom/movable/Entered(var/atom/movable/atom, var/atom/old_loc)
 	. = ..()
-	QUEUE_TEMPERATURE_ATOMS(atom)
+	queue_temperature_atoms(atom)
 
 /obj
 	temperature_coefficient = null

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -159,7 +159,8 @@
 	return TRUE
 
 /obj/machinery/camera/HasProximity(atom/movable/AM)
-	if(isliving(AM))
+	. = ..()
+	if(. && isliving(AM))
 		newTarget(AM)
 
 /obj/machinery/camera/emp_act(severity)

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -110,14 +110,13 @@
 	density = 1
 
 /obj/machinery/flasher/portable/HasProximity(atom/movable/AM)
-	if(!anchored || disable || last_flash && world.time < last_flash + 150)
+	. = ..()
+	if(!. || !anchored || disable || last_flash && world.time < last_flash + 150)
 		return
-
 	if(istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M = AM
 		if(!MOVING_DELIBERATELY(M))
 			flash()
-
 	if(isanimal(AM))
 		flash()
 

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -23,6 +23,9 @@
 	var/attack_cooldown = DEFAULT_WEAPON_COOLDOWN
 	var/melee_accuracy_bonus = 0
 
+	/// Flag for ZAS based contamination (chlorine etc)
+	var/contaminated = FALSE
+
 	var/heat_protection = 0 //flags which determine which body parts are protected from heat. Use the SLOT_HEAD, SLOT_UPPER_BODY, SLOT_LOWER_BODY, etc. flags. See setup.dm
 	var/cold_protection = 0 //flags which determine which body parts are protected from cold. Use the SLOT_HEAD, SLOT_UPPER_BODY, SLOT_LOWER_BODY, etc. flags. See setup.dm
 	var/max_heat_protection_temperature //Set this variable to determine up to which temperature (IN KELVIN) the item protects against heat damage. Keep at null to disable protection. Only protects areas set by heat_protection flags
@@ -87,6 +90,9 @@
 	var/tmp/has_inventory_icon	// do not set manually
 	var/tmp/use_single_icon
 	var/center_of_mass = @"{'x':16,'y':16}" //can be null for no exact placement behaviour
+
+/obj/item/proc/can_contaminate()
+	return !(obj_flags & ITEM_FLAG_NO_CONTAMINATION)
 
 // Foley sound callbacks
 /obj/item/proc/equipped_sound_callback()

--- a/code/game/objects/item_materials.dm
+++ b/code/game/objects/item_materials.dm
@@ -5,6 +5,8 @@
 		alpha = 100 + material.opacity * 255
 	if(blood_overlay)
 		overlays += blood_overlay
+	if(global.contamination_overlay && contaminated)
+		overlays += global.contamination_overlay
 
 /obj/item/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone)
 	. = ..()

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -68,10 +68,9 @@
 
 
 /obj/item/transfer_valve/HasProximity(atom/movable/AM)
-	if(!attached_device)	return
-	attached_device.HasProximity(AM)
-	return
-
+	. = ..()
+	if(. && attached_device)
+		attached_device.HasProximity(AM)
 
 /obj/item/transfer_valve/attack_self(mob/user)
 	ui_interact(user)

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -15,6 +15,10 @@
 	open_sound = 'sound/effects/storage/unzip.ogg'
 	material = /decl/material/solid/leather/synth
 
+//Cannot be washed :(
+/obj/item/storage/backpack/can_contaminate()
+	return FALSE
+
 /obj/item/storage/backpack/equipped()
 	if(!has_extension(src, /datum/extension/appearance))
 		set_extension(src, /datum/extension/appearance/cardborg)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -583,7 +583,8 @@ var/global/list/global/tank_gauge_cache = list()
 	tank.update_icon()
 
 /obj/item/tankassemblyproxy/HasProximity(atom/movable/AM)
-	if(assembly)
+	. = ..()
+	if(. && assembly)
 		assembly.HasProximity(AM)
 
 //Fragmentation projectiles

--- a/code/game/turfs/simulated/footsteps.dm
+++ b/code/game/turfs/simulated/footsteps.dm
@@ -26,12 +26,6 @@
 		else
 			return get_footstep(flooring.footstep_type, caller)
 
-/turf/Entered(var/mob/living/carbon/human/H)
-	..()
-	if(istype(H))
-		H.handle_footsteps()
-		H.step_count++
-
 /mob/living/carbon/human/proc/has_footsteps()
 	if(species.silent_steps || buckled || lying || throwing)
 		return //people flying, lying down or sitting do not step
@@ -45,6 +39,7 @@
 	return TRUE
 
 /mob/living/carbon/human/proc/handle_footsteps()
+	step_count++
 	if(!has_footsteps())
 		return
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -237,30 +237,6 @@
 				return 0
 	return 1 //Nothing found to block so return success!
 
-var/global/const/enterloopsanity = 100
-/turf/Entered(var/atom/atom, var/atom/old_loc)
-
-	..()
-
-	QUEUE_TEMPERATURE_ATOMS(atom)
-
-	if(!istype(atom, /atom/movable))
-		return
-
-	var/atom/movable/A = atom
-
-	var/objects = 0
-	if(A && (A.movable_flags & MOVABLE_FLAG_PROXMOVE))
-		for(var/atom/movable/thing in range(1))
-			if(objects > enterloopsanity) break
-			objects++
-			spawn(0)
-				if(A)
-					A.HasProximity(thing, 1)
-					if ((thing && A) && (thing.movable_flags & MOVABLE_FLAG_PROXMOVE))
-						thing.HasProximity(A, 1)
-	return
-
 /turf/proc/adjacent_fire_act(turf/simulated/floor/source, exposed_temperature, exposed_volume)
 	return
 

--- a/code/game/turfs/turf_enter.dm
+++ b/code/game/turfs/turf_enter.dm
@@ -1,0 +1,54 @@
+#define ENTER_PROXIMITY_LOOP_SANITY 100
+// Splitting this into its own proc for profiling purposes.
+/turf/proc/handle_proximity_update(var/atom/movable/mover)
+	var/objects = 0
+	if(!istype(mover) || !(mover.movable_flags & MOVABLE_FLAG_PROXMOVE))
+		return
+	for(var/atom/movable/neighbor in range(1))
+		if(objects > ENTER_PROXIMITY_LOOP_SANITY) 
+			break // Don't let ore piles kill the server as well as the client.
+		objects++
+		mover.HasProximity(neighbor)
+		if(!QDELETED(neighbor) && !QDELETED(mover) && (neighbor.movable_flags & MOVABLE_FLAG_PROXMOVE))
+			neighbor.HasProximity(mover)
+
+#undef ENTER_PROXIMITY_LOOP_SANITY
+/turf/Entered(var/atom/atom, var/atom/old_loc)
+
+	..()
+
+	if(!istype(atom, /atom/movable))
+		return
+
+	if(ishuman(atom))
+		var/mob/living/carbon/human/H = atom
+		H.handle_footsteps()
+
+	queue_temperature_atoms(atom)
+
+	var/atom/movable/A = atom
+// If an opaque movable atom moves around we need to potentially update visibility.
+	if(A?.opacity && !has_opaque_atom)
+		has_opaque_atom = TRUE // Make sure to do this before reconsider_lights(), incase we're on instant updates. Guaranteed to be on in this case.
+		reconsider_lights()
+#ifdef AO_USE_LIGHTING_OPACITY
+		// Hook for AO.
+		regenerate_ao()
+#endif
+
+	//Items that are in ZAS contaminants, but not on a mob, can still be contaminated.
+	if(isitem(A))
+		var/obj/item/I = A
+		if(vsc?.contaminant_control.CLOTH_CONTAMINATION && I.can_contaminate())
+			var/datum/gas_mixture/env = return_air(1)
+			if(!env)
+				return
+			for(var/g in env.gas)
+				var/decl/material/mat = GET_DECL(g)
+				if((mat.gas_flags & XGM_GAS_CONTAMINANT) && env.gas[g] > mat.gas_overlay_limit + 1)
+					I.contaminate()
+					break
+
+	// Handle zmimic
+	if(!A.bound_overlay && !(A.z_flags & ZMM_IGNORE) && TURF_IS_MIMICKING(above))
+		above.update_mimic()

--- a/code/game/turfs/turf_enter.dm
+++ b/code/game/turfs/turf_enter.dm
@@ -7,10 +7,11 @@
 	for(var/atom/movable/neighbor in range(1))
 		if(objects > ENTER_PROXIMITY_LOOP_SANITY) 
 			break // Don't let ore piles kill the server as well as the client.
-		objects++
-		mover.HasProximity(neighbor)
-		if(!QDELETED(neighbor) && !QDELETED(mover) && (neighbor.movable_flags & MOVABLE_FLAG_PROXMOVE))
-			neighbor.HasProximity(mover)
+		if(neighbor.movable_flags & MOVABLE_FLAG_PROXMOVE)
+			objects++
+			mover.HasProximity(neighbor)
+			if(!QDELETED(neighbor) && !QDELETED(mover))
+				neighbor.HasProximity(mover)
 
 #undef ENTER_PROXIMITY_LOOP_SANITY
 /turf/Entered(var/atom/atom, var/atom/old_loc)

--- a/code/game/turfs/turf_enter.dm
+++ b/code/game/turfs/turf_enter.dm
@@ -14,20 +14,19 @@
 				neighbor.HasProximity(mover)
 
 #undef ENTER_PROXIMITY_LOOP_SANITY
-/turf/Entered(var/atom/atom, var/atom/old_loc)
+/turf/Entered(var/atom/movable/A, var/atom/old_loc)
 
 	..()
 
-	if(!istype(atom, /atom/movable))
+	if(!istype(A))
 		return
 
-	if(ishuman(atom))
-		var/mob/living/carbon/human/H = atom
+	if(ishuman(A))
+		var/mob/living/carbon/human/H = A
 		H.handle_footsteps()
 
-	queue_temperature_atoms(atom)
+	queue_temperature_atoms(A)
 
-	var/atom/movable/A = atom
 // If an opaque movable atom moves around we need to potentially update visibility.
 	if(A?.opacity && !has_opaque_atom)
 		has_opaque_atom = TRUE // Make sure to do this before reconsider_lights(), incase we're on instant updates. Guaranteed to be on in this case.

--- a/code/modules/ZAS/Contaminants.dm
+++ b/code/modules/ZAS/Contaminants.dm
@@ -141,16 +141,3 @@ var/global/image/contamination_overlay = image('icons/effects/contamination.dmi'
 	if(shoes) shoes.contaminate()
 	if(gloves) gloves.contaminate()
 
-
-/turf/Entered(obj/item/I)
-	. = ..()
-	//Items that are in contaminants, but not on a mob, can still be contaminated.
-	if(istype(I) && vsc?.contaminant_control.CLOTH_CONTAMINATION && I.can_contaminate())
-		var/datum/gas_mixture/env = return_air(1)
-		if(!env)
-			return
-		for(var/g in env.gas)
-			var/decl/material/mat = GET_DECL(g)
-			if((mat.gas_flags & XGM_GAS_CONTAMINANT) && env.gas[g] > mat.gas_overlay_limit + 1)
-				I.contaminate()
-				break

--- a/code/modules/ZAS/Contaminants.dm
+++ b/code/modules/ZAS/Contaminants.dm
@@ -37,25 +37,15 @@ var/global/image/contamination_overlay = image('icons/effects/contamination.dmi'
 	var/N2O_HALLUCINATION_NAME = "N2O Hallucination"
 	var/N2O_HALLUCINATION_DESC = "Does being in sleeping gas cause you to hallucinate?"
 
-
-/obj/var/contaminated = 0
-
-
-/obj/item/proc/can_contaminate()
-	//Clothing and backpacks can be contaminated.
-	if(obj_flags & ITEM_FLAG_NO_CONTAMINATION) return 0
-	else if(istype(src,/obj/item/storage/backpack)) return 0 //Cannot be washed :(
-	else if(istype(src,/obj/item/clothing)) return 1
-
 /obj/item/proc/contaminate()
 	//Do a contamination overlay? Temporary measure to keep contamination less deadly than it was.
 	if(!contaminated)
-		contaminated = 1
-		overlays += contamination_overlay
+		contaminated = TRUE
+		queue_icon_update()
 
 /obj/item/proc/decontaminate()
-	contaminated = 0
-	overlays -= contamination_overlay
+	contaminated = FALSE
+	queue_icon_update()
 
 /mob/proc/contaminate()
 
@@ -155,7 +145,7 @@ var/global/image/contamination_overlay = image('icons/effects/contamination.dmi'
 /turf/Entered(obj/item/I)
 	. = ..()
 	//Items that are in contaminants, but not on a mob, can still be contaminated.
-	if(istype(I) && vsc && vsc.contaminant_control.CLOTH_CONTAMINATION && I.can_contaminate())
+	if(istype(I) && vsc?.contaminant_control.CLOTH_CONTAMINATION && I.can_contaminate())
 		var/datum/gas_mixture/env = return_air(1)
 		if(!env)
 			return

--- a/code/modules/ZAS/Zone.dm
+++ b/code/modules/ZAS/Zone.dm
@@ -173,7 +173,7 @@ Class Procs:
 			for(var/check_atom in T.contents)
 				var/atom/checking = check_atom
 				if(checking.simulated)
-					QUEUE_TEMPERATURE_ATOMS(checking)
+					queue_temperature_atoms(checking)
 			CHECK_TICK
 
 /zone/proc/handle_condensation()

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -88,16 +88,18 @@
 */
 	return
 
-/obj/item/assembly_holder/HasProximity(atom/movable/AM as mob|obj)
-	if(a_left)
-		a_left.HasProximity(AM)
-	if(a_right)
-		a_right.HasProximity(AM)
-	if(special_assembly)
-		special_assembly.HasProximity(AM)
+/obj/item/assembly_holder/HasProximity(atom/movable/AM)
+	. = ..()
+	if(.)
+		if(a_left)
+			a_left.HasProximity(AM)
+		if(a_right)
+			a_right.HasProximity(AM)
+		if(special_assembly)
+			special_assembly.HasProximity(AM)
 
 
-/obj/item/assembly_holder/Crossed(atom/movable/AM as mob|obj)
+/obj/item/assembly_holder/Crossed(atom/movable/AM)
 	if(a_left)
 		a_left.Crossed(AM)
 	if(a_right)

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -41,15 +41,10 @@
 	update_icon()
 	return secured
 
-
 /obj/item/assembly/prox_sensor/HasProximity(atom/movable/AM)
-	if(!istype(AM))
-		log_debug("DEBUG: HasProximity called with [AM] on [src] ([usr]).")
-		return
-	if (istype(AM, /obj/effect/beam))	return
-	if (AM.move_speed < 12)	sense()
-	return
-
+	. = ..()
+	if(. && !istype(AM, /obj/effect/beam) && AM.move_speed < 12)
+		sense()
 
 /obj/item/assembly/prox_sensor/sense()
 	var/turf/mainloc = get_turf(src)

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -28,6 +28,9 @@
 	if(markings_icon && markings_color)
 		update_icon()
 
+/obj/item/clothing/can_contaminate()
+	return TRUE
+
 // Sort of a placeholder for proper tailoring.
 #define RAG_COUNT(X) CEILING((LAZYACCESS(X.matter, /decl/material/solid/cloth) * 0.65) / SHEET_MATERIAL_AMOUNT)
 

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -1,5 +1,6 @@
 /obj/effect/vine/HasProximity(var/atom/movable/AM)
-	if(!is_mature() || seed.get_trait(TRAIT_SPREAD) != 2)
+	. = ..()
+	if(!. || !is_mature() || seed.get_trait(TRAIT_SPREAD) != 2)
 		return
 
 	var/mob/living/M = AM

--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -589,7 +589,7 @@
 
 			// begin processing temperature
 			if(active)
-				QUEUE_TEMPERATURE_ATOMS(src)
+				queue_temperature_atoms(src)
 		if(3)
 			set_pin_data(IC_OUTPUT, 4, weakref(src))
 			push_data()

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -114,22 +114,6 @@
 		regenerate_ao()
 #endif
 
-// If an opaque movable atom moves around we need to potentially update visibility.
-/turf/Entered(atom/movable/Obj, atom/OldLoc)
-	. = ..()
-
-	if (!Obj)
-		return
-
-	if (Obj.opacity && !has_opaque_atom)
-		has_opaque_atom = TRUE // Make sure to do this before reconsider_lights(), incase we're on instant updates. Guaranteed to be on in this case.
-		reconsider_lights()
-
-#ifdef AO_USE_LIGHTING_OPACITY
-		// Hook for AO.
-		regenerate_ao()
-#endif
-
 /turf/Exited(atom/movable/Obj, atom/newloc)
 	. = ..()
 

--- a/code/modules/mining/machinery/material_extractor.dm
+++ b/code/modules/mining/machinery/material_extractor.dm
@@ -77,7 +77,7 @@ var/global/list/material_extractor_items_whitelist = list(/obj/item/ore)
 	if(!input_buffer)
 		input_buffer = new(src)
 		input_buffer.create_reagents(GAS_EXTRACTOR_REAGENTS_INPUT_TANK) //Did this here because reimplementing that in the new() proc failed a test for some reasons
-	QUEUE_TEMPERATURE_ATOMS(src)
+	queue_temperature_atoms(src)
 
 /obj/machinery/atmospherics/unary/material/extractor/Destroy()
 	output_container = null
@@ -153,7 +153,8 @@ var/global/list/material_extractor_items_whitelist = list(/obj/item/ore)
 
 /obj/machinery/atmospherics/unary/material/extractor/power_change()
 	. = ..()
-	QUEUE_TEMPERATURE_ATOMS(src)
+	if(.)
+		queue_temperature_atoms(src)
 
 /obj/machinery/atmospherics/unary/material/extractor/on_update_icon()
 	cut_overlays()

--- a/code/modules/mining/machinery/material_smelter.dm
+++ b/code/modules/mining/machinery/material_smelter.dm
@@ -22,7 +22,7 @@
 	show_materials = always_show_materials.Copy()
 	. = ..()
 	create_reagents(INFINITY)
-	QUEUE_TEMPERATURE_ATOMS(src)
+	queue_temperature_atoms(src)
 
 // Outgas anything that is in gas form. Check what you put into the smeltery, nerds.
 /obj/machinery/material_processing/smeltery/on_reagent_change()
@@ -64,7 +64,8 @@
 
 /obj/machinery/material_processing/smeltery/power_change()
 	. = ..()
-	QUEUE_TEMPERATURE_ATOMS(src)
+	if(.)
+		queue_temperature_atoms(src)
 
 /obj/machinery/material_processing/smeltery/proc/can_eat(var/obj/item/eating)
 	for(var/mtype in eating.matter)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -998,31 +998,31 @@
 			var/list/status = list()
 
 			var/feels = 1 + round(org.pain/100, 0.1)
-			var/brutedamage = org.brute_dam * feels
-			var/burndamage = org.burn_dam * feels
-
-			switch(brutedamage)
-				if(1 to 20)
+			switch((org.brute_dam * feels) / org.max_damage)
+				if(0 to 0.35)
 					status += "slightly sore"
-				if(20 to 40)
+				if(0.35 to 0.65)
 					status += "very sore"
-				if(40 to INFINITY)
+				if(0.65 to INFINITY)
 					status += "throbbing with agony"
 
-			switch(burndamage)
-				if(1 to 10)
+			switch((org.burn_dam * feels) / org.max_damage)
+				if(0 to 0.35)
 					status += "tingling"
-				if(10 to 40)
+				if(0.35 to 0.65)
 					status += "stinging"
-				if(40 to INFINITY)
+				if(0.65 to INFINITY)
 					status += "burning fiercely"
 
 			if(org.status & ORGAN_MUTATED)
 				status += "misshapen"
+			if(org.status & ORGAN_BLEEDING)
+				status += "<b>bleeding</b>"
 			if(org.is_dislocated())
 				status += "dislocated"
 			if(org.status & ORGAN_BROKEN)
 				status += "hurts when touched"
+
 			if(org.status & ORGAN_DEAD)
 				if(BP_IS_PROSTHETIC(org) || BP_IS_CRYSTAL(org))
 					status += "is irrecoverably damaged"

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -46,10 +46,11 @@
 
 //Straight pain values, not affected by painkillers etc
 /mob/living/carbon/human/getHalLoss()
-	var/amount = 0
-	for(var/obj/item/organ/external/E in get_external_organs())
-		amount += E.get_pain()
-	return amount
+	if(isnull(last_pain))
+		last_pain = 0
+		for(var/obj/item/organ/external/E in get_external_organs())
+			last_pain += E.get_pain()
+	return last_pain
 
 /mob/living/carbon/human/setHalLoss(var/amount)
 	adjustHalLoss(getHalLoss()-amount)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -92,6 +92,9 @@
 
 	var/list/smell_cooldown
 
+	/// var for caching last getHalloss() run to avoid looping through organs over and over and over again
+	var/last_pain
+
 	ai = /datum/ai/human
 
 /mob/living/carbon/human/proc/get_age()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -69,6 +69,8 @@
 		//Updates the number of stored chemicals for powers
 		handle_changeling()
 
+		last_pain = null // Clear the last cached pain value so further getHalloss() calls won't use an old value.
+
 		//Organs and blood
 		handle_organs()
 		stabilize_body_temperature() //Body temperature adjusts itself (self-regulation)

--- a/code/modules/multiz/zmimic/mimic_turf.dm
+++ b/code/modules/multiz/zmimic/mimic_turf.dm
@@ -20,22 +20,14 @@
 	var/tmp/z_depth
 	var/tmp/z_generation = 0
 
-/turf/Entered(atom/movable/thing, turf/oldLoc)
-	. = ..()
-	if (thing.bound_overlay || (thing.z_flags & ZMM_IGNORE) || !TURF_IS_MIMICKING(above))
-		return
-	above.update_mimic()
-
 /turf/update_above()
 	if (TURF_IS_MIMICKING(above))
 		above.update_mimic()
 
 /turf/proc/update_mimic()
-	if (!(z_flags & ZM_MIMIC_BELOW))
-		return
-
-	z_queued += 1
-	SSzcopy.queued_turfs += src
+	if(z_flags & ZM_MIMIC_BELOW)
+		z_queued += 1
+		SSzcopy.queued_turfs |= src
 
 /// Enables Z-mimic for a turf that didn't already have it enabled.
 /turf/proc/enable_zmimic(additional_flags = 0)

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -206,7 +206,11 @@
 
 // Geneloss/cloneloss.
 /obj/item/organ/external/proc/get_genetic_damage()
-	return ((species && (species.species_flags & SPECIES_FLAG_NO_SCAN)) || BP_IS_PROSTHETIC(src)) ? 0 : genetic_degradation
+	if(species?.species_flags & SPECIES_FLAG_NO_SCAN)
+		return 0
+	if(BP_IS_PROSTHETIC(src))
+		return 0
+	return genetic_degradation
 
 /obj/item/organ/external/proc/remove_genetic_damage(var/amount)
 	if((species.species_flags & SPECIES_FLAG_NO_SCAN) || BP_IS_PROSTHETIC(src))
@@ -247,7 +251,7 @@
 
 // Pain/halloss
 /obj/item/organ/external/proc/get_pain()
-	if(!can_feel_pain() || BP_IS_PROSTHETIC(src))
+	if(!can_feel_pain())
 		return 0
 	var/lasting_pain = 0
 	if(is_broken())

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -31,15 +31,15 @@
 	return 0
 
 /obj/machinery/containment_field/HasProximity(atom/movable/AM)
-	if(istype(AM,/mob/living/silicon) && prob(40))
-		shock(AM)
-		return 1
-	if(istype(AM,/mob/living/carbon) && prob(50))
-		shock(AM)
-		return 1
-	return 0
-
-
+	. = ..()
+	if(.)
+		if(istype(AM,/mob/living/silicon) && prob(40))
+			shock(AM)
+			return TRUE
+		if(istype(AM,/mob/living/carbon) && prob(50))
+			shock(AM)
+			return TRUE
+		return FALSE
 
 /obj/machinery/containment_field/shock(mob/living/user)
 	if(hasShocked)

--- a/code/modules/reagents/heat_sources/_heat_source.dm
+++ b/code/modules/reagents/heat_sources/_heat_source.dm
@@ -77,7 +77,7 @@
 			temperature = max(target_temperature, temperature - heating_power)
 		if(temperature != last_temperature)
 			if(container)
-				QUEUE_TEMPERATURE_ATOMS(container)
+				queue_temperature_atoms(container)
 			queue_icon_update()
 		return TRUE // Don't kill this processing loop unless we're not powered.
 	. = ..()
@@ -176,7 +176,7 @@
 		return TOPIC_HANDLED
 
 	update_use_power(use_power <= POWER_USE_IDLE ? POWER_USE_ACTIVE : POWER_USE_IDLE)
-	QUEUE_TEMPERATURE_ATOMS(src)
+	queue_temperature_atoms(src)
 	update_icon()
 
 	return TOPIC_REFRESH

--- a/mods/species/vox/gear/gun_slugsling.dm
+++ b/mods/species/vox/gear/gun_slugsling.dm
@@ -19,15 +19,15 @@
 	squish()
 
 /obj/item/slugegg/HasProximity(var/atom/movable/AM)
-	if(isliving(AM))
-		if(istype(AM,/mob/living/carbon/human))
+	. = ..()
+	if(. && isliving(AM))
+		if(ishuman(AM))
 			var/mob/living/carbon/human/H = AM
-			if(H.get_bodytype_category() == SPECIES_VOX)
-				return
-		else
-			var/mob/living/L = AM
-			if(L.faction == SPECIES_VOX)
-				return
+			if(H.get_bodytype_category() == BODYTYPE_VOX)
+				return FALSE
+		var/mob/living/L = AM
+		if(L.faction == SPECIES_VOX)
+			return FALSE
 		squish()
 
 /obj/item/slugegg/proc/squish()

--- a/nebula.dme
+++ b/nebula.dme
@@ -1294,6 +1294,7 @@
 #include "code\game\turfs\turf.dm"
 #include "code\game\turfs\turf_ao.dm"
 #include "code\game\turfs\turf_changing.dm"
+#include "code\game\turfs\turf_enter.dm"
 #include "code\game\turfs\turf_flick_animations.dm"
 #include "code\game\turfs\turf_fluids.dm"
 #include "code\game\turfs\unsimulated.dm"


### PR DESCRIPTION
## Description of changes
- Breaks temperature queuing and proximity updates into their own procs for profiling purposes.
- Removes a `spawn(0)` from proximity updates in favour of `waitfor = FALSE`.
- Refactors some pain handling code with a view towards optimizing it somewhat.
- Condenses /turf/Entered() overrides into a single proc to avoid multiple parent call overhead and make it a bit easier to read.
- Human pain now uses a cache var to avoid multiple loops over organs each tick. The var is cleared in human Life() and updated on getHalLoss() call if null.

## Why and what will this PR improve
Hoping it addresses some lagspikes and general overhead issues on Scav.

## Authorship
Myself.

## Changelog
Nothing player-facing.