### PR TITLE
Minor maintenance/construction drone tweaks

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -16,6 +16,7 @@
 	active_power_usage = 5000
 
 	var/fabricator_tag
+	var/fab_tag_modifier = "-maintenance"
 	var/drone_progress = 0
 	var/produce_drones = 1
 	var/time_last_drone = 500
@@ -27,11 +28,12 @@
 /obj/machinery/drone_fabricator/Initialize()
 	. = ..()
 	if(isnull(fabricator_tag))
-		fabricator_tag = global.using_map.station_short
+		fabricator_tag = "[global.using_map.station_short][fab_tag_modifier]"
 
-/obj/machinery/drone_fabricator/derelict
+/obj/machinery/drone_fabricator/construction
 	name = "construction drone fabricator"
-	fabricator_tag = "Derelict"
+	desc = "A large automated factory for producing construction drones."
+	fab_tag_modifier = "-construction"
 	drone_type = /mob/living/silicon/robot/drone/construction
 
 /obj/machinery/drone_fabricator/power_change()

--- a/code/modules/mob/living/silicon/robot/modules/module_maintenance_drone.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_maintenance_drone.dm
@@ -18,7 +18,7 @@
 		/obj/item/t_scanner,
 		/obj/item/lightreplacer,
 		/obj/item/gripper,
-		/obj/item/soap,
+		/obj/item/mop/advanced,
 		/obj/item/gripper/no_use/loader,
 		/obj/item/extinguisher/mini,
 		/obj/item/paint_sprayer,

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -1901,7 +1901,7 @@
 /turf/simulated/floor/bluegrid/airless,
 /area/constructionsite/ai)
 "gw" = (
-/obj/machinery/drone_fabricator/derelict,
+/obj/machinery/drone_fabricator/construction,
 /turf/simulated/floor/tiled/dark/airless,
 /area/constructionsite/ai)
 "gx" = (


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Replaced soap module with advanced mop on maintenance/construction drones.

Renamed construction drone fabricator object from drone_fabricator/derelict to drone_fabricator/construction and updated object on derelict station map to match new name.

Tweaked fabricator naming in drone spawn selection so you can tell which fabricator is which if both happen to be on the same map

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Mop change is to allow drones to mop up liquids. The rest is just polish.

## Authorship
Qumefox

## Changelog
:cl:
tweak: tweaked a few things regarding maintenance drones
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->