### PR TITLE
Drone fabricator types and module swap

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -6,7 +6,7 @@
 	return drones
 
 /obj/machinery/drone_fabricator
-	name = "Drone Fabricator"
+	name = "drone fabricator"
 	desc = "A large automated factory for producing maintenance drones."
 	appearance_flags = 0
 
@@ -31,17 +31,17 @@
 		fabricator_tag = "[global.using_map.station_short][fab_tag_modifier]"
 
 /obj/machinery/drone_fabricator/maintenance
-	name = "Maintenance Drone Fabricator"
+	name = "maintenance drone fabricator"
 	fab_tag_modifier = " (Maintenance)"
 
 /obj/machinery/drone_fabricator/construction
-	name = "Construction Drone Fabricator"
+	name = "construction drone fabricator"
 	desc = "A large automated factory for producing construction drones."
 	fab_tag_modifier = " (Construction)"
 	drone_type = /mob/living/silicon/robot/drone/construction
 
 /obj/machinery/drone_fabricator/derelict
-	name = "Construction Drone Fabricator"
+	name = "construction drone fabricator"
 	fabricator_tag = "Derelict"
 	drone_type = /mob/living/silicon/robot/drone/construction
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -6,7 +6,7 @@
 	return drones
 
 /obj/machinery/drone_fabricator
-	name = "drone fabricator"
+	name = "Drone Fabricator"
 	desc = "A large automated factory for producing maintenance drones."
 	appearance_flags = 0
 
@@ -16,6 +16,7 @@
 	active_power_usage = 5000
 
 	var/fabricator_tag
+	var/fab_tag_modifier
 	var/drone_progress = 0
 	var/produce_drones = 1
 	var/time_last_drone = 500
@@ -27,10 +28,20 @@
 /obj/machinery/drone_fabricator/Initialize()
 	. = ..()
 	if(isnull(fabricator_tag))
-		fabricator_tag = global.using_map.station_short
+		fabricator_tag = "[global.using_map.station_short][fab_tag_modifier]"
+
+/obj/machinery/drone_fabricator/maintenance
+	name = "Maintenance Drone Fabricator"
+	fab_tag_modifier = " (Maintenance)"
+
+/obj/machinery/drone_fabricator/construction
+	name = "Construction Drone Fabricator"
+	desc = "A large automated factory for producing construction drones."
+	fab_tag_modifier = " (Construction)"
+	drone_type = /mob/living/silicon/robot/drone/construction
 
 /obj/machinery/drone_fabricator/derelict
-	name = "construction drone fabricator"
+	name = "Construction Drone Fabricator"
 	fabricator_tag = "Derelict"
 	drone_type = /mob/living/silicon/robot/drone/construction
 

--- a/code/modules/mob/living/silicon/robot/modules/module_maintenance_drone.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_maintenance_drone.dm
@@ -18,7 +18,7 @@
 		/obj/item/t_scanner,
 		/obj/item/lightreplacer,
 		/obj/item/gripper,
-		/obj/item/soap,
+		/obj/item/mop/advanced,
 		/obj/item/gripper/no_use/loader,
 		/obj/item/extinguisher/mini,
 		/obj/item/paint_sprayer,


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Adds maintenance and construction variants of the drone fabricator. Mostly so you can tell which is which when spawning as a drone or mapping them on a map.  Also swapped out soap for advanced mops on drones so they are able to clean up liquids.

## Why and what will this PR improve
Makes things a little more user friendly. Both in spawning as and using drones, as well as mapping in fabricators.

## Authorship
Qumefox

## Changelog
:cl:
add: Added drone fabricator types
tweak: swapped soap for advance mops on drones
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->