### PR TITLE
Add alternate button frames and misc frames

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -142,6 +142,12 @@
 /obj/machinery/button/alternate
 	icon = 'icons/obj/machines/button_door.dmi'
 	icon_state = "doorctrl"
+	frame_type = /obj/item/frame/button/alternate
+
+/obj/machinery/button/alternate/buildable
+	uncreated_component_parts = list(
+		/obj/item/stock_parts/radio/transmitter/basic = 1,
+	)
 
 /obj/machinery/button/alternate/on_update_icon()
 	if(operating)
@@ -170,6 +176,7 @@
 /obj/machinery/button/toggle/alternate
 	icon = 'icons/obj/machines/button_door.dmi'
 	icon_state = "doorctrl"
+	frame_type = /obj/item/frame/button/alternate
 
 /obj/machinery/button/toggle/alternate/on_update_icon()
 	if(active)

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -190,7 +190,14 @@
 		/obj/item/stock_parts/radio/transmitter/on_event/buildable
 	)
 	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':32}, 'WEST':{'x':-32}}"
+	frame_type = /obj/item/frame/button/access
+	base_type = /obj/machinery/button/access/buildable
 	var/command = "cycle"
+
+/obj/machinery/button/access/buildable
+	uncreated_component_parts = list(
+		/obj/item/stock_parts/power/apc,
+	)
 
 /obj/machinery/button/access/on_update_icon()
 	if(stat & (NOPOWER | BROKEN))

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -268,6 +268,13 @@
 		/obj/item/stock_parts/radio/transmitter/on_event/buildable,
 		/obj/item/stock_parts/radio/receiver/buildable
 	)
+	base_type = /obj/machinery/button/blast_door/buildable
+	frame_type = /obj/item/frame/button/blastdoor
+
+/obj/machinery/button/blast_door/buildable
+	uncreated_component_parts = list(
+		/obj/item/stock_parts/power/apc
+	)
 
 /obj/machinery/button/blast_door/Initialize(mapload)
 	. = ..()

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -256,6 +256,7 @@
 	icon_state = "airlock_sensor_off"
 	name = "airlock sensor"
 	desc = "An airlock sensor frame."
+	build_machine_type = /obj/machinery/airlock_sensor/buildable
 
 /obj/item/frame/button/airlock_sensor/kit
 	fully_construct = TRUE

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -137,6 +137,48 @@
 	material = /decl/material/solid/metal/steel
 	build_machine_type = /obj/machinery/button/buildable
 
+/obj/item/frame/button/kit
+	fully_construct = TRUE
+	name = "radio button kit"
+	desc = "An all-in-one wall-mounted button kit, comes preassembled and equipped with a radio transmitter."
+	build_machine_type = /obj/machinery/button
+
+/obj/item/frame/button/alternate
+	name = "button frame (door)"
+	icon = 'icons/obj/machines/button_door.dmi'
+	icon_state = "doorctrl"
+	build_machine_type = /obj/machinery/button/alternate/buildable
+
+/obj/item/frame/button/alternate/kit
+	fully_construct = TRUE
+	name = "button kit (door)"
+	desc = "An all-in-one wall-mounted button kit, comes preassembled and equipped with a radio transmitter."
+	build_machine_type = /obj/machinery/button/alternate
+
+/obj/item/frame/button/access
+	name = "button frame (airlock)"
+	icon = 'icons/obj/airlock_machines.dmi'
+	icon_state = "access_button_standby"
+	build_machine_type = /obj/machinery/button/access/buildable
+
+/obj/item/frame/button/access/kit
+	fully_construct = TRUE
+	name = "button kit (airlock)"
+	desc = "An all-in-one wall-mounted button kit, comes preassembled and equipped with a radio transmitter."
+	build_machine_type = /obj/machinery/button/access
+
+/obj/item/frame/button/blastdoor
+	name = "button frame (blast doors)"
+	icon = 'icons/obj/machines/button_blastdoor.dmi'
+	icon_state = "blastctrl"
+	build_machine_type = /obj/machinery/button/blast_door/buildable
+
+/obj/item/frame/button/blastdoor/kit
+	fully_construct = TRUE
+	name = "button kit (blast doors)"
+	desc = "An all-in-one wall-mounted button kit, comes preassembled and equipped with a radio transmitter."
+	build_machine_type = /obj/machinery/button/blast_door
+
 /obj/item/frame/camera
 	name = "security camera frame"
 	icon = 'icons/obj/monitors.dmi'

--- a/code/modules/fabrication/designs/general/designs_engineering.dm
+++ b/code/modules/fabrication/designs/general/designs_engineering.dm
@@ -43,6 +43,23 @@
 
 /datum/fabricator_recipe/engineering/button_frame
 	path = /obj/item/frame/button
+/datum/fabricator_recipe/engineering/button_kit
+	path = /obj/item/frame/button/kit
+
+/datum/fabricator_recipe/engineering/button_frame_door
+	path = /obj/item/frame/button/alternate
+/datum/fabricator_recipe/engineering/button_kit_door
+	path = /obj/item/frame/button/alternate/kit
+
+/datum/fabricator_recipe/engineering/button_frame_blast
+	path = /obj/item/frame/button/blastdoor
+/datum/fabricator_recipe/engineering/button_kit_blast
+	path = /obj/item/frame/button/blastdoor/kit
+
+/datum/fabricator_recipe/engineering/airlock_button
+	path = /obj/item/frame/button/access
+/datum/fabricator_recipe/engineering/airlock_button_kit
+	path = /obj/item/frame/button/access/kit
 
 /datum/fabricator_recipe/engineering/airlock_sensor
 	path = /obj/item/frame/button/airlock_sensor

--- a/code/modules/fabrication/designs/general/designs_engineering.dm
+++ b/code/modules/fabrication/designs/general/designs_engineering.dm
@@ -64,6 +64,9 @@
 /datum/fabricator_recipe/engineering/airlock_sensor
 	path = /obj/item/frame/button/airlock_sensor
 
+/datum/fabricator_recipe/engineering/airlock_sensor_kit
+	path = /obj/item/frame/button/airlock_sensor/kit
+
 /datum/fabricator_recipe/engineering/airlock_controller
 	path = /obj/item/stock_parts/circuitboard/airlock_controller
 


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Extra stuff that didn't fit in #2607.
Depends on #2607.

Made an item frame, kit, and recipe for the door control button, the airlock button and blast door button. Previously you couldn't build button with those appearences. 

They behave exactly like the regular button. This is mostly cosmetic, and to get access to the default part preset.

## Changelog
:cl:
add: Added wall frame item, kit, and fabricator recipe for building door, airlock, and blast door control button. They behave just like the current button frame and kit, except they have the expected icon, and stock part presets
add: Added a kit for building an airlock sensor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->