### PR TITLE
Fix issues found via incorrect arg type lint

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -266,7 +266,7 @@
 /datum/ai_laws/proc/set_state_law(var/datum/ai_law/law, var/state)
 	law.set_state_law(src, state)
 
-/datum/ai_law/proc/set_state_law(var/datum/ai_law/law, var/state)
+/datum/ai_law/proc/set_state_law(var/datum/ai_laws/laws, var/state)
 
 /datum/ai_law/zero/set_state_law(var/datum/ai_laws/laws, var/state)
 	if(src == laws.zeroth_law)

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -67,7 +67,7 @@
 	can_write = FALSE
 	has_updates = FALSE
 
-/decl/public_access/public_variable/holosign_on/access_var(obj/machinery/igniter/igniter)
+/decl/public_access/public_variable/igniter_on/access_var(obj/machinery/igniter/igniter)
 	return igniter.on
 
 /decl/public_access/public_method/igniter_toggle

--- a/code/modules/modular_computers/networking/device_types/stock_part.dm
+++ b/code/modules/modular_computers/networking/device_types/stock_part.dm
@@ -1,18 +1,7 @@
 // Attached to a stock part for issuing commands to machinery via networks.
 /datum/extension/network_device/stock_part
 	has_commands = TRUE
-	internet_allowed = TRUE // GOOSE devices, network locks, etc. can all connect over PLEXUS 
-
-// Network receivers check the access of the parent machine, and do not check for network administrator access.
-/datum/extension/network_device/stock_part/has_access(mob/user)
-	var/datum/computer_network/network = get_network()
-	if(!network)
-		return TRUE // If not on network, always TRUE for access, as there isn't anything to access.
-	if(!user)
-		return FALSE
-	var/atom/H = holder
-	var/obj/M = H.loc
-	return M.check_access(user)
+	internet_allowed = TRUE // GOOSE devices, network locks, etc. can all connect over PLEXUS
 
 /datum/extension/network_device/stock_part/get_wired_connection()
 	var/atom/H = holder


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
- Removes a broken/unnecessary `has_access` override for `/datum/extension/network_device/stock_part`, which had and passed incorrect args.
- Fixes an incorrect arg type hint for `/datum/ai_law/proc/set_state_law`, although this entire system looks pretty awful and should probably be redone.
- Fixes a mispathed proc for igniter public variable access.

## Why and what will this PR improve
Fixes one proc with invalid arg type hints, fixes one invalid override, fixes one mispathed proc.

## Authorship
Me.