### PR TITLE
Removing now-deprecated reagent_tag setting and passing.

### DIFF
--- a/code/modules/materials/definitions/gasses/material_gas_mundane.dm
+++ b/code/modules/materials/definitions/gasses/material_gas_mundane.dm
@@ -3,8 +3,8 @@
 	uid = "gas_oxygen"
 	lore_text = "An ubiquitous oxidizing agent."
 	flags = MAT_FLAG_FUSION_FUEL
-	gas_specific_heat = 20	
-	molar_mass = 0.032	
+	gas_specific_heat = 20
+	molar_mass = 0.032
 	latent_heat = 213
 	boiling_point = -183 CELSIUS
 	gas_flags = XGM_GAS_OXIDIZER
@@ -28,7 +28,7 @@
 	metabolism = 0.05
 	value = 0.3
 
-/decl/material/gas/helium/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/gas/helium/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	M.add_chemical_effect(CE_SQUEAKY, 1)
 
@@ -36,10 +36,10 @@
 	name = "carbon dioxide"
 	uid = "gas_carbon_dioxide"
 	lore_text = "A byproduct of respiration."
-	gas_specific_heat = 30	
+	gas_specific_heat = 30
 	molar_mass = 0.044
 	latent_heat = 380
-	boiling_point = -78 CELSIUS	
+	boiling_point = -78 CELSIUS
 	gas_symbol_html = "CO<sub>2</sub>"
 	gas_symbol = "CO2"
 
@@ -50,13 +50,13 @@
 	gas_specific_heat = 30
 	molar_mass = 0.028
 	latent_heat = 216
-	boiling_point = -192 CELSIUS	
+	boiling_point = -192 CELSIUS
 	gas_symbol_html = "CO"
 	gas_symbol = "CO"
 	taste_description = "stale air"
 	metabolism = 0.05 // As with helium.
 
-/decl/material/gas/carbon_monoxide/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/gas/carbon_monoxide/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(!istype(M))
 		return
 	var/warning_message
@@ -90,10 +90,10 @@
 	name = "methyl bromide"
 	uid = "gas_methyl_bromide"
 	lore_text = "A once-popular fumigant and weedkiller."
-	gas_specific_heat = 42.59 
+	gas_specific_heat = 42.59
 	molar_mass = 0.095
 	latent_heat = 253
-	boiling_point = 4 CELSIUS		  
+	boiling_point = 4 CELSIUS
 	gas_symbol_html = "CH<sub>3</sub>Br"
 	gas_symbol = "CH3Br"
 	taste_description = "pestkiller"
@@ -102,7 +102,7 @@
 	)
 	value = 0.25
 
-/decl/material/gas/methyl_bromide/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/gas/methyl_bromide/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	. = ..()
 	if(!ishuman(M))
 		return
@@ -119,10 +119,10 @@
 	name = "sleeping agent"
 	uid = "gas_sleeping_agent"
 	lore_text = "A mild sedative. Also known as laughing gas."
-	gas_specific_heat = 40	
+	gas_specific_heat = 40
 	molar_mass = 0.044
 	latent_heat = 376
-	boiling_point = -90 CELSIUS	
+	boiling_point = -90 CELSIUS
 	gas_tile_overlay = "sleeping_agent"
 	gas_overlay_limit = 1
 	gas_flags = XGM_GAS_OXIDIZER //N2O is a powerful oxidizer
@@ -131,7 +131,7 @@
 	metabolism = 0.05 // So that low dosages have a chance to build up in the body.
 	value = 0.25
 
-/decl/material/gas/nitrous_oxide/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/gas/nitrous_oxide/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/dosage = LAZYACCESS(M.chem_doses, type)
 	if(dosage >= 1)
 		if(prob(5)) SET_STATUS_MAX(M, STAT_ASLEEP, 3)
@@ -149,7 +149,7 @@
 	name = "nitrogen"
 	uid = "gas_nitrogen"
 	lore_text = "An ubiquitous noble gas."
-	gas_specific_heat = 20	
+	gas_specific_heat = 20
 	molar_mass = 0.028
 	latent_heat = 199
 	boiling_point = -195 CELSIUS
@@ -183,7 +183,7 @@
 /decl/material/gas/methane
 	name = "methane"
 	uid = "gas_methane"
-	gas_specific_heat = 30	
+	gas_specific_heat = 30
 	molar_mass = 0.016
 	latent_heat = 510
 	boiling_point = -162 CELSIUS
@@ -254,7 +254,7 @@
 	gas_symbol = "Xe"
 	value = 0.25
 
-/decl/material/gas/xenon/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/gas/xenon/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/dosage = LAZYACCESS(M.chem_doses, type)
 	if(dosage >= 1)
 		if(prob(5)) SET_STATUS_MAX(M, STAT_ASLEEP, 3)

--- a/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
@@ -74,7 +74,7 @@
 	metabolism = REM * 0.25
 	exoplanet_rarity = MAT_RARITY_UNCOMMON
 
-/decl/material/liquid/venom/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/venom/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(prob(REAGENT_VOLUME(holder, type)*2))
 		SET_STATUS_MAX(M, STAT_CONFUSE, 3)
 	..()
@@ -90,7 +90,7 @@
 	toxicity_targets_organ = BP_HEART
 	exoplanet_rarity = MAT_RARITY_UNCOMMON
 
-/decl/material/liquid/cyanide/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/cyanide/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	ADJ_STATUS(M, STAT_ASLEEP, 1)
 
@@ -107,11 +107,11 @@
 	taste_mult = 1.2
 	exoplanet_rarity = MAT_RARITY_UNCOMMON
 
-/decl/material/liquid/heartstopper/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/heartstopper/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	ADJ_STATUS(M, STAT_CONFUSE, 1.5)
 
-/decl/material/liquid/heartstopper/affect_overdose(var/mob/living/M, var/alien, var/datum/reagents/holder)
+/decl/material/liquid/heartstopper/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
 	..()
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -133,14 +133,14 @@
 	toxicity_targets_organ = BP_BRAIN
 	heating_message = "melts into a liquid slurry."
 	heating_products = list(
-		/decl/material/liquid/carpotoxin = 0.2, 
-		/decl/material/liquid/sedatives = 0.4, 
+		/decl/material/liquid/carpotoxin = 0.2,
+		/decl/material/liquid/sedatives = 0.4,
 		/decl/material/solid/metal/copper = 0.4
 	)
 	taste_mult = 1.2
 	exoplanet_rarity = MAT_RARITY_EXOTIC
 
-/decl/material/liquid/zombiepowder/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/zombiepowder/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	M.status_flags |= FAKEDEATH
 	M.adjustOxyLoss(3 * removed)
@@ -176,7 +176,7 @@
 	color = "#49002e"
 	toxicity = 4
 	heating_products = list(
-		/decl/material/liquid/bromide = 0.4, 
+		/decl/material/liquid/bromide = 0.4,
 		/decl/material/liquid/water = 0.6
 	)
 	metabolism = REM * 0.25
@@ -192,7 +192,7 @@
 	toxicity = 4
 	heating_products = list(
 		/decl/material/liquid/acetone = 0.4,
-		/decl/material/solid/carbon = 0.4, 
+		/decl/material/solid/carbon = 0.4,
 		/decl/material/liquid/ethanol = 0.2
 	)
 	heating_point = 145 CELSIUS
@@ -213,7 +213,7 @@
 	taste_mult = 1.2
 	metabolism = REM * 0.25
 
-/decl/material/liquid/hair_remover/affect_touch(var/mob/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/hair_remover/affect_touch(var/mob/M, var/removed, var/datum/reagents/holder)
 	M.lose_hair()
 	holder.remove_reagent(type, REAGENT_VOLUME(holder, type))
 
@@ -231,10 +231,10 @@
 	exoplanet_rarity = MAT_RARITY_EXOTIC
 	var/amount_to_zombify = 5
 
-/decl/material/liquid/zombie/affect_touch(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
-	affect_blood(M, alien, removed * 0.5, holder)
+/decl/material/liquid/zombie/affect_touch(var/mob/living/M, var/removed, var/datum/reagents/holder)
+	affect_blood(M, removed * 0.5, holder)
 
-/decl/material/liquid/zombie/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/zombie/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M

--- a/code/modules/materials/definitions/liquids/materials_liquid_water.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_water.dm
@@ -28,7 +28,7 @@
 		/decl/material/solid/ice = 1
 	)
 
-/decl/material/liquid/water/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/water/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	if(ishuman(M))
 		var/list/data = REAGENT_DATA(holder, type)
@@ -49,10 +49,10 @@
 						if(prob(10)) //Only annoy them a /bit/
 							to_chat(M,"<span class='danger'>You feel your insides curdle and burn!</span> \[<a href='?src=\ref[holder];deconvert=\ref[M]'>Give Into Purity</a>\]")
 
-/decl/material/liquid/water/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/water/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	M.adjust_hydration(removed * 10)
-	affect_blood(M, alien, removed, holder)
+	affect_blood(M, removed, holder)
 
 #define WATER_LATENT_HEAT 9500 // How much heat is removed when applied to a hot turf, in J/unit (9500 makes 120 u of water roughly equivalent to 2L
 /decl/material/liquid/water/touch_turf(var/turf/T, var/amount, var/datum/reagents/holder)

--- a/code/modules/materials/definitions/solids/materials_solid_elements.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_elements.dm
@@ -34,7 +34,7 @@
 	value = 0.5
 	dirtiness = 30
 
-/decl/material/solid/carbon/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/solid/carbon/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/datum/reagents/ingested = M.get_ingested_reagents()
 	if(ingested && LAZYLEN(ingested.reagent_volumes) > 1)
 		var/effect = 1 / (LAZYLEN(ingested.reagent_volumes) - 1)
@@ -81,7 +81,7 @@
 	color = "#a0a0a0"
 	value = 0.5
 
-/decl/material/solid/potassium/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/solid/potassium/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/volume = REAGENT_VOLUME(holder, type)
 	if(volume > 3)
 		M.add_chemical_effect(CE_PULSE, 1)

--- a/code/modules/materials/definitions/solids/materials_solid_metal.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_metal.dm
@@ -389,7 +389,7 @@
 	reflectiveness = MAT_VALUE_MATTE
 	taste_description = "metal"
 
-/decl/material/solid/metal/iron/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/solid/metal/iron/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(M.HasTrait(/decl/trait/metabolically_inert))
 		return
 

--- a/code/modules/materials/definitions/solids/materials_solid_mineral.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_mineral.dm
@@ -89,7 +89,7 @@
 	rich_material_weight = 1
 	dissolves_into = list(
 		/decl/material/solid/sulfur = 0.75,
-		/decl/material/solid/metal/iron = 0.25		
+		/decl/material/solid/metal/iron = 0.25
 	)
 
 /decl/material/solid/spodumene
@@ -179,7 +179,7 @@
 		/decl/material/solid/potassium = 1
 	)
 
-/decl/material/solid/potassium/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/solid/potassium/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/volume = REAGENT_VOLUME(holder, type)
 	if(volume > 3)
 		M.add_chemical_effect(CE_PULSE, 1)

--- a/code/modules/reagents/Chemistry-Metabolism.dm
+++ b/code/modules/reagents/Chemistry-Metabolism.dm
@@ -19,11 +19,7 @@
 /datum/reagents/metabolism/proc/metabolize()
 	if(parent && world.time > last_metabolize_time)
 		last_metabolize_time = world.time // prevents mobs that reuse a holder between functions (ingested/injected) from metabolizing twice in a tick
-		var/metabolism_type = 0 //non-human mobs
-		if(ishuman(parent))
-			var/mob/living/carbon/human/H = parent
-			metabolism_type = H.species.reagent_tag
 		for(var/rtype in reagent_volumes)
 			var/decl/material/current = GET_DECL(rtype)
-			current.on_mob_life(parent, metabolism_type, metabolism_class, src)
+			current.on_mob_life(parent, metabolism_class, src)
 		update_total()

--- a/code/modules/reagents/chems/chems_blood.dm
+++ b/code/modules/reagents/chems/chems_blood.dm
@@ -32,7 +32,7 @@
 	if(.)
 		.["species"] = .["species"] || global.using_map.default_species
 
-/decl/material/liquid/blood/mix_data(var/datum/reagents/reagents, var/list/newdata, var/amount)	
+/decl/material/liquid/blood/mix_data(var/datum/reagents/reagents, var/list/newdata, var/amount)
 	var/list/data = REAGENT_DATA(reagents, type)
 	if(LAZYACCESS(newdata, "trace_chem"))
 		var/list/other_chems = LAZYACCESS(newdata, "trace_chem")
@@ -62,7 +62,7 @@
 		if(B)
 			B.blood_DNA["UNKNOWN DNA STRUCTURE"] = "X*"
 
-/decl/material/liquid/blood/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/blood/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(M.HasTrait(/decl/trait/metabolically_inert))
 		return
 	if(LAZYACCESS(M.chem_doses, type) > 5)
@@ -70,13 +70,13 @@
 	if(LAZYACCESS(M.chem_doses, type) > 15)
 		M.adjustToxLoss(removed)
 
-/decl/material/liquid/blood/affect_touch(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/blood/affect_touch(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.isSynthetic())
 			return
 
-/decl/material/liquid/blood/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/blood/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(ishuman(M))
 		var/volume = REAGENT_VOLUME(holder, type)
 		var/mob/living/carbon/H = M

--- a/code/modules/reagents/chems/chems_compounds.dm
+++ b/code/modules/reagents/chems/chems_compounds.dm
@@ -19,10 +19,10 @@
 	color = "#9eefff"
 	uid = "chem_glowsap"
 
-/decl/material/liquid/glowsap/affect_ingest(mob/living/M, alien, removed, var/datum/reagents/holder)
-	affect_blood(M, alien, removed, holder)
+/decl/material/liquid/glowsap/affect_ingest(mob/living/M, removed, var/datum/reagents/holder)
+	affect_blood(M, removed, holder)
 
-/decl/material/liquid/glowsap/affect_blood(mob/living/M, alien, removed, var/datum/reagents/holder)
+/decl/material/liquid/glowsap/affect_blood(mob/living/M, removed, var/datum/reagents/holder)
 	M.add_chemical_effect(CE_GLOWINGEYES, 1)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -34,7 +34,7 @@
 		addtimer(CALLBACK(H, /mob/living/carbon/human/proc/update_eyes), 5 SECONDS)
 	. = ..()
 
-/decl/material/liquid/glowsap/affect_overdose(var/mob/living/M, var/alien, var/datum/reagents/holder)
+/decl/material/liquid/glowsap/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
 	. = ..()
 	M.add_chemical_effect(CE_TOXIN, 1)
 	M.set_hallucination(60, 20)
@@ -67,7 +67,7 @@
 	fruit_descriptor = "numbing"
 	uid = "chem_frostoil"
 
-/decl/material/liquid/frostoil/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/frostoil/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	M.bodytemperature = max(M.bodytemperature - 10 * TEMPERATURE_DAMAGE_COEFFICIENT, 0)
 	if(prob(1))
 		M.emote("shiver")
@@ -94,10 +94,10 @@
 	var/discomfort_message = "<span class='danger'>Your insides feel uncomfortably hot!</span>"
 	var/slime_temp_adj = 10
 
-/decl/material/liquid/capsaicin/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/capsaicin/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	M.adjustToxLoss(0.5 * removed)
 
-/decl/material/liquid/capsaicin/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/capsaicin/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	holder.remove_reagent(/decl/material/liquid/frostoil, 5)
 
 	if(M.HasTrait(/decl/trait/metabolically_inert))
@@ -132,7 +132,7 @@
 	value = 2
 	uid = "chem_capsaicin_condensed"
 
-/decl/material/liquid/capsaicin/condensed/affect_touch(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/capsaicin/condensed/affect_touch(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/eyes_covered = 0
 	var/mouth_covered = 0
 	var/partial_mouth_covered = 0
@@ -182,7 +182,7 @@
 			M.custom_emote(2, "[pick("coughs!","coughs hysterically!","splutters!")]")
 			SET_STATUS_MAX(M, STAT_STUN, 3)
 
-/decl/material/liquid/capsaicin/condensed/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/capsaicin/condensed/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	holder.remove_reagent(/decl/material/liquid/frostoil, 5)
 
 	if(M.HasTrait(/decl/trait/metabolically_inert))
@@ -209,15 +209,15 @@
 	color = "#13bc5e"
 	uid = "chem_mutagenics"
 
-/decl/material/liquid/mutagenics/affect_touch(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/mutagenics/affect_touch(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(prob(33))
-		affect_blood(M, alien, removed, holder)
+		affect_blood(M, removed, holder)
 
-/decl/material/liquid/mutagenics/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/mutagenics/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(prob(67))
-		affect_blood(M, alien, removed, holder)
+		affect_blood(M, removed, holder)
 
-/decl/material/liquid/mutagenics/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/mutagenics/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 
 	if(M.isSynthetic())
 		return
@@ -248,7 +248,7 @@
 	exoplanet_rarity = MAT_RARITY_NOWHERE
 	uid = "chem_lactate"
 
-/decl/material/liquid/lactate/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/lactate/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/volume = REAGENT_VOLUME(holder, type)
 	M.add_chemical_effect(CE_PULSE, 1)
 	if(volume >= 10)
@@ -269,7 +269,7 @@
 	exoplanet_rarity = MAT_RARITY_NOWHERE
 	uid = "chem_nanoblood"
 
-/decl/material/liquid/nanoblood/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/nanoblood/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/mob/living/carbon/human/H = M
 	if(!istype(H))
 		return
@@ -294,7 +294,7 @@
 
 	var/nicotine = REM * 0.2
 
-/decl/material/solid/tobacco/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/solid/tobacco/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	M.reagents.add_reagent(/decl/material/liquid/nicotine, nicotine)
 
@@ -339,7 +339,7 @@
 	hidden_from_codex = TRUE
 	uid = "chem_tobacco_menthol"
 
-/decl/material/liquid/menthol/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/menthol/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(world.time > REAGENT_DATA(holder, type) + 3 MINUTES)
 		LAZYSET(holder.reagent_data, type, world.time)
 		to_chat(M, SPAN_NOTICE("You feel faintly sore in the throat."))
@@ -353,7 +353,7 @@
 	flags = IGNORE_MOB_SIZE
 	uid = "chem_nanite_fluid"
 
-/decl/material/liquid/nanitefluid/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/nanitefluid/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	M.add_chemical_effect(CE_CRYO, 1)
 	if(M.bodytemperature < 170)
 		M.heal_organ_damage(30 * removed, 30 * removed, affect_robo = 1)
@@ -382,7 +382,7 @@
 /decl/material/liquid/crystal_agent/proc/do_material_check(var/mob/living/carbon/M)
 	. = /decl/material/solid/gemstone/crystal
 
-/decl/material/liquid/crystal_agent/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/crystal_agent/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/result_mat = do_material_check(M)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M

--- a/code/modules/reagents/chems/chems_drinks.dm
+++ b/code/modules/reagents/chems/chems_drinks.dm
@@ -13,10 +13,10 @@
 	var/adj_sleepy = 0
 	var/adj_temp = 0
 
-/decl/material/liquid/drink/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/drink/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	M.adjustToxLoss(removed) // Probably not a good idea; not very deadly though
 
-/decl/material/liquid/drink/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/drink/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(M.HasTrait(/decl/trait/metabolically_inert))
 		return
 
@@ -38,7 +38,7 @@
 	uid = "chem_drink_juice"
 	fruit_descriptor = "sweet"
 
-/decl/material/liquid/drink/juice/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/drink/juice/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	if(M.HasTrait(/decl/trait/metabolically_inert))
 		return
@@ -76,7 +76,7 @@
 	glass_name = "carrot juice"
 	glass_desc = "It is just like a carrot but without crunching."
 
-/decl/material/liquid/drink/juice/carrot/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/drink/juice/carrot/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	M.reagents.add_reagent(/decl/material/liquid/eyedrops, removed * 0.2)
 
@@ -114,7 +114,7 @@
 	glass_name = "lime juice"
 	glass_desc = "A glass of sweet-sour lime juice"
 
-/decl/material/liquid/drink/juice/lime/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/drink/juice/lime/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 
 	if(M.HasTrait(/decl/trait/metabolically_inert))
@@ -133,7 +133,7 @@
 	glass_name = "orange juice"
 	glass_desc = "Vitamins! Yay!"
 
-/decl/material/liquid/drink/juice/orange/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/drink/juice/orange/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 
 	if(M.HasTrait(/decl/trait/metabolically_inert))
@@ -195,7 +195,7 @@
 	glass_name = "tomato juice"
 	glass_desc = "Are you sure this is tomato juice?"
 
-/decl/material/liquid/drink/juice/tomato/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/drink/juice/tomato/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 
 	if(M.HasTrait(/decl/trait/metabolically_inert))
@@ -266,7 +266,7 @@
 	glass_name = "chocolate milk"
 	glass_desc = "Deliciously fattening!"
 
-/decl/material/liquid/drink/milk/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/drink/milk/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 
 	holder.remove_reagent(/decl/material/liquid/capsaicin, 10 * removed)
@@ -328,7 +328,7 @@
 		if(!inserted)
 			flavour_modifiers += syrup
 
-/decl/material/liquid/drink/coffee/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/drink/coffee/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	if(adj_temp > 0)
 		holder.remove_reagent(/decl/material/liquid/frostoil, 10 * removed)
@@ -342,11 +342,11 @@
 	if(volume > 45)
 		M.add_chemical_effect(CE_PULSE, 1)
 
-/decl/material/liquid/drink/coffee/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/drink/coffee/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	M.add_chemical_effect(CE_PULSE, 2)
 
-/decl/material/liquid/drink/coffee/affect_overdose(var/mob/living/M, var/alien, var/datum/reagents/holder)
+/decl/material/liquid/drink/coffee/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
 	ADJ_STATUS(M, STAT_JITTER, 5)
 	M.add_chemical_effect(CE_PULSE, 1)
 
@@ -494,7 +494,7 @@
 	glass_desc = "The unstable energy of a radioactive isotope in beverage form."
 	glass_special = list(DRINK_FIZZ)
 
-/decl/material/liquid/drink/mutagencola/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/drink/mutagencola/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 
 	if(M.HasTrait(/decl/trait/metabolically_inert))
@@ -614,7 +614,7 @@
 	exoplanet_rarity = MAT_RARITY_NOWHERE
 	uid = "chem_drink_hellramen"
 
-/decl/material/liquid/drink/hell_ramen/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/drink/hell_ramen/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 
 	if(M.HasTrait(/decl/trait/metabolically_inert))
@@ -633,9 +633,9 @@
 		. = "mint [.]"
 	. = ..(prop, .)
 
-/decl/material/liquid/drink/tea/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/drink/tea/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
-	
+
 	if(M.HasTrait(/decl/trait/metabolically_inert))
 		return
 
@@ -797,9 +797,9 @@
 	exoplanet_rarity = MAT_RARITY_NOWHERE
 	uid = "chem_drink_energydrink"
 
-/decl/material/liquid/drink/beastenergy/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/drink/beastenergy/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
-	
+
 	if(M.HasTrait(/decl/trait/metabolically_inert))
 		return
 

--- a/code/modules/reagents/chems/chems_drugs.dm
+++ b/code/modules/reagents/chems/chems_drugs.dm
@@ -1,7 +1,7 @@
 
 /decl/material/liquid/amphetamines
 	name = "amphetamines"
-	lore_text = "A powerful, long-lasting stimulant." 
+	lore_text = "A powerful, long-lasting stimulant."
 	taste_description = "acid"
 	color = "#ff3300"
 	metabolism = REM * 0.15
@@ -9,7 +9,7 @@
 	value = 2
 	uid = "chem_amphetamines"
 
-/decl/material/liquid/amphetamines/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/amphetamines/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(prob(5))
 		M.emote(pick("twitch", "blink_r", "shiver"))
 	M.add_chemical_effect(CE_SPEEDBOOST, 1)
@@ -24,7 +24,7 @@
 	value = 2
 	uid = "chem_narcotics"
 
-/decl/material/liquid/narcotics/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/narcotics/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	ADJ_STATUS(M, STAT_JITTER, -5)
 	if(prob(80))
 		M.adjustBrainLoss(5.25 * removed)
@@ -44,7 +44,7 @@
 	value = 2
 	uid = "chem_nicotine"
 
-/decl/material/liquid/nicotine/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/nicotine/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/volume = REAGENT_VOLUME(holder, type)
 	if(prob(volume*20))
 		M.add_chemical_effect(CE_PULSE, 1)
@@ -55,7 +55,7 @@
 		LAZYSET(holder.reagent_data, type, world.time)
 		to_chat(M, "<span class='notice'>You feel invigorated and calm.</span>")
 
-/decl/material/liquid/nicotine/affect_overdose(var/mob/living/M, var/alien, var/datum/reagents/holder)
+/decl/material/liquid/nicotine/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
 	..()
 	M.add_chemical_effect(CE_PULSE, 2)
 
@@ -69,7 +69,7 @@
 	value = 2
 	uid = "chem_sedatives"
 
-/decl/material/liquid/sedatives/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/sedatives/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	ADJ_STATUS(M, STAT_JITTER, -50)
 	var/threshold = 1
 	var/dose = LAZYACCESS(M.chem_doses, type)
@@ -103,7 +103,7 @@
 	euphoriant = 15
 	uid = "chem_psychoactives"
 
-/decl/material/liquid/psychoactives/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/psychoactives/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	SET_STATUS_MAX(M, STAT_DRUGGY, 15)
 	M.add_chemical_effect(CE_PULSE, -1)
@@ -118,7 +118,7 @@
 	value = 2
 	uid = "chem_hallucinogenics"
 
-/decl/material/liquid/hallucinogenics/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/hallucinogenics/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	M.add_chemical_effect(CE_MIND, -2)
 	M.set_hallucination(50, 50)
 
@@ -134,7 +134,7 @@
 	fruit_descriptor = "hallucinogenic"
 	uid = "chem_psychotropics"
 
-/decl/material/liquid/psychotropics/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/psychotropics/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/threshold = 1
 	var/dose = LAZYACCESS(M.chem_doses, type)
 	if(dose < 1 * threshold)
@@ -200,7 +200,7 @@
 		"THE LIGHT THE DARK A STAR IN CHAINS"
 	)
 
-/decl/material/liquid/glowsap/gleam/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/glowsap/gleam/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	. = ..()
 	M.add_client_color(/datum/client_color/noir/thirdeye)
 	M.add_chemical_effect(CE_THIRDEYE, 1)
@@ -221,7 +221,7 @@
 	if(istype(M))
 		M.remove_client_color(/datum/client_color/noir/thirdeye)
 
-/decl/material/liquid/glowsap/gleam/affect_overdose(var/mob/living/M, var/alien, var/datum/reagents/holder)
+/decl/material/liquid/glowsap/gleam/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
 	M.adjustBrainLoss(rand(1, 5))
 	if(ishuman(M) && prob(10))
 		var/mob/living/carbon/human/H = M

--- a/code/modules/reagents/chems/chems_ethanol.dm
+++ b/code/modules/reagents/chems/chems_ethanol.dm
@@ -37,12 +37,12 @@
 	glass_desc = "A well-known alcohol with a variety of applications."
 	value = 1.2
 
-/decl/material/liquid/ethanol/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/ethanol/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	M.adjustToxLoss(removed * 2 * alcohol_toxicity)
 	M.add_chemical_effect(CE_ALCOHOL_TOXIC, alcohol_toxicity)
 
-/decl/material/liquid/ethanol/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/ethanol/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 
 	if(M.HasTrait(/decl/trait/metabolically_inert))
@@ -129,7 +129,7 @@
 	codex_name = "premium beer"
 	taste_description = "beer"
 
-/decl/material/liquid/ethanol/beer/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/ethanol/beer/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	if(M.HasTrait(/decl/trait/metabolically_inert))
 		return
@@ -187,7 +187,7 @@
 	glass_desc = "Guaranteed to perk you up."
 	overdose = 45
 
-/decl/material/liquid/ethanol/coffee/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/ethanol/coffee/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 
 	if(M.HasTrait(/decl/trait/metabolically_inert))
@@ -199,7 +199,7 @@
 	if(M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 
-/decl/material/liquid/ethanol/coffee/affect_overdose(var/mob/living/M, var/alien, var/datum/reagents/holder)
+/decl/material/liquid/ethanol/coffee/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
 	ADJ_STATUS(M, STAT_JITTER, 5)
 
 /decl/material/liquid/ethanol/melonliquor
@@ -264,7 +264,7 @@
 	glass_name = "Thirteen Loko"
 	glass_desc = "This is a glass of Thirteen Loko, it appears to be of the highest quality. The drink, not the glass."
 
-/decl/material/liquid/ethanol/thirteenloko/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/ethanol/thirteenloko/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 
 	if(M.HasTrait(/decl/trait/metabolically_inert))
@@ -421,7 +421,7 @@
 	exoplanet_rarity = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_poisonwine"
 
-/decl/material/liquid/ethanol/pwine/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/ethanol/pwine/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 
 	if(M.HasTrait(/decl/trait/metabolically_inert))
@@ -439,7 +439,7 @@
 			else
 				heart.take_internal_damage(100, 0)
 
-/decl/material/liquid/ethanol/aged_whiskey // I have no idea what this is and where it comes from.  //It comes from Dinnlan now 
+/decl/material/liquid/ethanol/aged_whiskey // I have no idea what this is and where it comes from.  //It comes from Dinnlan now
 	name = "aged whiskey"
 	lore_text = "A well-aged whiskey of high quality. Probably imported. Just a sip'll do it, but that burn will leave you wanting more."
 	color = "#523600"

--- a/code/modules/reagents/chems/chems_fuel.dm
+++ b/code/modules/reagents/chems/chems_fuel.dm
@@ -14,7 +14,7 @@
 	glass_desc = "Unless you are an industrial tool, this is probably not safe for consumption."
 	value = 1.5
 
-/decl/material/liquid/fuel/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/fuel/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	M.adjustToxLoss(2 * removed)
 
 /decl/material/liquid/fuel/explosion_act(obj/item/chems/holder, severity)

--- a/code/modules/reagents/chems/chems_medicines.dm
+++ b/code/modules/reagents/chems/chems_medicines.dm
@@ -9,12 +9,12 @@
 	value = 1.5
 	uid = "chem_eyedrops"
 
-/decl/material/liquid/eyedrops/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/eyedrops/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/internal/E = GET_INTERNAL_ORGAN(H, BP_EYES)
 		if(E && istype(E) && !E.is_broken())
-			ADJ_STATUS(M, STAT_BLURRY, -5) 
+			ADJ_STATUS(M, STAT_BLURRY, -5)
 			ADJ_STATUS(M, STAT_BLIND, -5)
 			E.damage = max(E.damage - 5 * removed, 0)
 
@@ -30,7 +30,7 @@
 	value = 1.5
 	uid = "chem_antirads"
 
-/decl/material/liquid/antirads/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/antirads/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	M.radiation = max(M.radiation - 30 * removed, 0)
 
 /decl/material/liquid/brute_meds
@@ -47,7 +47,7 @@
 	uid = "chem_styptic"
 	var/effectiveness = 1
 
-/decl/material/liquid/brute_meds/affect_overdose(mob/living/M, alien, var/datum/reagents/holder)
+/decl/material/liquid/brute_meds/affect_overdose(mob/living/M, var/datum/reagents/holder)
 	..()
 	if(ishuman(M))
 		M.add_chemical_effect(CE_BLOCKAGE, (15 + REAGENT_VOLUME(holder, type))/100)
@@ -58,7 +58,7 @@
 
 //This is a logistic function that effectively doubles the healing rate as brute amounts get to around 200. Any injury below 60 is essentially unaffected and there's a scaling inbetween.
 #define ADJUSTED_REGEN_VAL(X) (6+(6/(1+200*2.71828**(-0.05*(X)))))
-/decl/material/liquid/brute_meds/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/brute_meds/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	M.add_chemical_effect_max(CE_REGEN_BRUTE, round(effectiveness*ADJUSTED_REGEN_VAL(M.getBruteLoss())))
 	M.add_chemical_effect(CE_PAINKILLER, 10)
@@ -75,7 +75,7 @@
 	uid = "chem_synthskin"
 	var/effectiveness = 1
 
-/decl/material/liquid/burn_meds/affect_blood(mob/living/M, alien, removed, var/datum/reagents/holder)
+/decl/material/liquid/burn_meds/affect_blood(mob/living/M, removed, var/datum/reagents/holder)
 	..()
 	M.add_chemical_effect_max(CE_REGEN_BURN, round(effectiveness*ADJUSTED_REGEN_VAL(M.getFireLoss())))
 	M.add_chemical_effect(CE_PAINKILLER, 10)
@@ -93,10 +93,10 @@
 	glass_name = "liquid gold"
 	glass_desc = "It's magic. We don't have to explain it."
 
-/decl/material/liquid/adminordrazine/affect_touch(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
-	affect_blood(M, alien, removed, holder)
+/decl/material/liquid/adminordrazine/affect_touch(var/mob/living/M, var/removed, var/datum/reagents/holder)
+	affect_blood(M, removed, holder)
 
-/decl/material/liquid/adminordrazine/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/adminordrazine/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	M.rejuvenate()
 
 /decl/material/liquid/antitoxins
@@ -114,7 +114,7 @@
 		/decl/material/liquid/zombiepowder
 	)
 
-/decl/material/liquid/antitoxins/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/antitoxins/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(remove_generic)
 		ADJ_STATUS(M, STAT_DROWSY, -6 * removed)
 		M.adjust_hallucination(-9 * removed)
@@ -145,12 +145,12 @@
 	scannable = 1
 	uid = "chem_immunobooster"
 
-/decl/material/liquid/immunobooster/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/immunobooster/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(ishuman(M) && REAGENT_VOLUME(holder, type) < REAGENTS_OVERDOSE)
 		var/mob/living/carbon/human/H = M
 		H.immunity = min(H.immunity_norm * 0.5, removed + H.immunity) // Rapidly brings someone up to half immunity.
 
-/decl/material/liquid/immunobooster/affect_overdose(var/mob/living/M, var/alien, var/datum/reagents/holder)
+/decl/material/liquid/immunobooster/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
 	..()
 	M.add_chemical_effect(CE_TOXIN, 1)
 	var/mob/living/carbon/human/H = M
@@ -167,7 +167,7 @@
 	value = 1.5
 	uid = "chem_stimulants"
 
-/decl/material/liquid/stimulants/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/stimulants/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/volume = REAGENT_VOLUME(holder, type)
 	if(volume <= 0.1 && LAZYACCESS(M.chem_doses, type) >= 0.5 && world.time > REAGENT_DATA(holder, type) + 5 MINUTES)
 		LAZYSET(holder.reagent_data, type, world.time)
@@ -191,7 +191,7 @@
 	value = 1.5
 	uid = "chem_antidepressants"
 
-/decl/material/liquid/antidepressants/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/antidepressants/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/volume = REAGENT_VOLUME(holder, type)
 	if(volume <= 0.1 && LAZYACCESS(M.chem_doses, type) >= 0.5 && world.time > REAGENT_DATA(holder, type) + 5 MINUTES)
 		LAZYSET(holder.reagent_data, type, world.time)
@@ -214,7 +214,7 @@
 	value = 1.5
 	uid = "chem_antibiotics"
 
-/decl/material/liquid/antibiotics/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/antibiotics/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/mob/living/carbon/human/H = M
 	if(!istype(H))
 		return
@@ -226,7 +226,7 @@
 	if(LAZYACCESS(H.chem_doses, type) > 15)
 		H.immunity = max(H.immunity - 0.25, 0)
 
-/decl/material/liquid/antibiotics/affect_overdose(var/mob/living/M, var/alien, var/datum/reagents/holder)
+/decl/material/liquid/antibiotics/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
 	..()
 	var/mob/living/carbon/human/H = M
 	if(!istype(H))
@@ -245,7 +245,7 @@
 	value = 1.5
 	uid = "chem_retrovirals"
 
-/decl/material/liquid/retrovirals/affect_overdose(mob/living/M, alien, datum/reagents/holder)
+/decl/material/liquid/retrovirals/affect_overdose(mob/living/M, datum/reagents/holder)
 	. = ..()
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -253,8 +253,8 @@
 			if(!BP_IS_PROSTHETIC(E) && prob(25) && !(E.status & ORGAN_MUTATED))
 				E.mutate()
 				E.limb_flags |= ORGAN_FLAG_DEFORMED
-	
-/decl/material/liquid/retrovirals/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+
+/decl/material/liquid/retrovirals/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	M.adjustCloneLoss(-20 * removed)
 	if(LAZYACCESS(M.chem_doses, type) > 10)
 		ADJ_STATUS(M, STAT_DIZZY, 5)
@@ -280,7 +280,7 @@
 	value = 1.5
 	uid = "chem_adrenaline"
 
-/decl/material/liquid/adrenaline/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/adrenaline/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/volume = REAGENT_VOLUME(holder, type)
 	var/dose = LAZYACCESS(M.chem_doses, type)
 	if(dose < 0.2)	//not that effective after initial rush
@@ -309,7 +309,7 @@
 	value = 1.5
 	uid = "chem_stabilizer"
 
-/decl/material/liquid/stabilizer/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/stabilizer/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	M.add_chemical_effect(CE_STABLE)
 
@@ -323,7 +323,7 @@
 	value = 1.5
 	uid = "chem_regenerative_serum"
 
-/decl/material/liquid/regenerator/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/regenerator/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	M.add_chemical_effect_max(CE_REGEN_BRUTE, 3 * removed)
 	M.add_chemical_effect_max(CE_REGEN_BURN, 3 * removed)
@@ -340,7 +340,7 @@
 	value = 1.5
 	uid = "chem_neuroannealer"
 
-/decl/material/liquid/neuroannealer/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/neuroannealer/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	M.add_chemical_effect(CE_PAINKILLER, 10)
 	M.add_chemical_effect(CE_BRAIN_REGEN, 1)
 	if(ishuman(M))
@@ -356,6 +356,6 @@
 	color = COLOR_GRAY80
 	uid = "chem_oxygel"
 
-/decl/material/liquid/oxy_meds/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/oxy_meds/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	M.add_chemical_effect(CE_OXYGENATED, 1)
 	holder.remove_reagent(/decl/material/gas/carbon_monoxide, 2 * removed)

--- a/code/modules/reagents/chems/chems_nutriment.dm
+++ b/code/modules/reagents/chems/chems_nutriment.dm
@@ -38,22 +38,22 @@
 				data -= taste
 	. = data
 
-/decl/material/liquid/nutriment/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/nutriment/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(!injectable)
 		M.adjustToxLoss(0.2 * removed)
 		return
-	affect_ingest(M, alien, removed, holder)
+	affect_ingest(M, removed, holder)
 
-/decl/material/liquid/nutriment/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
-	adjust_nutrition(M, alien, removed)
+/decl/material/liquid/nutriment/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
+	adjust_nutrition(M, removed)
 
 	if(M.HasTrait(/decl/trait/metabolically_inert))
 		return
 
-	M.heal_organ_damage(0.5 * removed, 0) //what	
+	M.heal_organ_damage(0.5 * removed, 0) //what
 	M.add_chemical_effect(CE_BLOODRESTORE, 4 * removed)
 
-/decl/material/liquid/nutriment/proc/adjust_nutrition(var/mob/living/carbon/M, var/alien, var/removed)
+/decl/material/liquid/nutriment/proc/adjust_nutrition(var/mob/living/carbon/M, var/removed)
 	var/nut_removed = removed
 	var/hyd_removed = removed
 	if(nutriment_factor)
@@ -91,10 +91,9 @@
 	color = "#440000"
 	uid = "chem_nutriment_protein"
 
-/decl/material/liquid/nutriment/protein/adjust_nutrition(mob/living/carbon/M, alien, removed)
+/decl/material/liquid/nutriment/protein/adjust_nutrition(mob/living/carbon/M, removed)
 	var/malus_level = M.GetTraitLevel(/decl/trait/malus/animal_protein)
 	var/malus_factor = malus_level ? malus_level * 0.25 : 0
-
 	M.adjustToxLoss(removed * malus_factor)
 	M.adjust_nutrition(nutriment_factor * removed * (1 - malus_factor))
 
@@ -166,7 +165,7 @@
 	fruit_descriptor = "bitter"
 	uid = "chem_nutriment_coffeepowder"
 
-/decl/material/liquid/nutriment/coffee/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/nutriment/coffee/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	M.add_chemical_effect(CE_PULSE, 2)
 

--- a/code/modules/reagents/chems/chems_painkillers.dm
+++ b/code/modules/reagents/chems/chems_painkillers.dm
@@ -24,7 +24,7 @@
 	var/dizziness_severity = 1
 	var/narcotic = TRUE
 
-/decl/material/liquid/painkillers/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/painkillers/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/volume = REAGENT_VOLUME(holder, type)
 	var/effectiveness = 1
 	var/dose = LAZYACCESS(M.chem_doses, type)
@@ -93,7 +93,7 @@
 		M.add_chemical_effect(CE_ALCOHOL_TOXIC, 1)
 		M.add_chemical_effect(CE_BREATHLOSS, 1 * boozed) //drinking and opiating suppresses breathing.
 
-/decl/material/liquid/painkillers/affect_overdose(var/mob/living/M, var/alien, var/datum/reagents/holder)
+/decl/material/liquid/painkillers/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
 	..()
 	if(!narcotic)
 		return

--- a/code/modules/reagents/chems/chems_poisons.dm
+++ b/code/modules/reagents/chems/chems_poisons.dm
@@ -8,7 +8,7 @@
 	value = 1.5
 	uid = "chem_pigment_paralytics"
 
-/decl/material/liquid/paralytics/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/paralytics/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/threshold = 2
 	var/dose = LAZYACCESS(M.chem_doses, type)
 	if(dose >= metabolism * threshold * 0.5)
@@ -35,14 +35,14 @@
 	overdose = REAGENTS_OVERDOSE
 	heating_point = 61 CELSIUS
 	heating_products = list(
-		/decl/material/solid/potassium =        0.3, 
-		/decl/material/liquid/acetone =         0.3, 
+		/decl/material/solid/potassium =        0.3,
+		/decl/material/liquid/acetone =         0.3,
 		/decl/material/liquid/nutriment/sugar = 0.4
 	)
 	value = 1.5
 	uid = "chem_pigment_presyncopics"
 
-/decl/material/liquid/presyncopics/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/presyncopics/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/drug_strength = 4
 	ADJ_STATUS(M, STAT_DIZZY, drug_strength)
 	SET_STATUS_MAX(M, STAT_CONFUSE, drug_strength * 5)

--- a/code/modules/reagents/chems/random/chems_random.dm
+++ b/code/modules/reagents/chems/random/chems_random.dm
@@ -30,12 +30,12 @@ var/global/list/random_chem_interaction_blacklist = list(
 		shuffle(effects_to_get)
 		effects_to_get.Cut(max_effect_number + 1)
 	effects_to_get += subtypesof(/decl/random_chem_effect/general_properties)
-	
+
 	var/list/decls = decls_repository.get_decls_unassociated(effects_to_get)
 	for(var/item in decls)
 		var/decl/random_chem_effect/effect = item
 		effect.prototype_process(src, temperature)
-	
+
 	var/whitelist = subtypesof(/decl/material)
 	for(var/bad_type in global.random_chem_interaction_blacklist)
 		whitelist -= typesof(bad_type)
@@ -56,10 +56,10 @@ var/global/list/random_chem_interaction_blacklist = list(
 	if(temperature > chilling_point && temperature < heating_point)
 		return TRUE
 
-/decl/material/liquid/random/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/random/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	FOR_ALL_EFFECTS
 		var/data = REAGENT_DATA(holder, type)
-		effect.affect_blood(M, alien, removed, LAZYACCESS(data, effect.type))
+		effect.affect_blood(M, removed, LAZYACCESS(data, effect.type))
 
 /decl/material/liquid/random/proc/on_chemicals_analyze(mob/user)
 	to_chat(user, get_scan_data(user))

--- a/code/modules/reagents/chems/random/random_effects.dm
+++ b/code/modules/reagents/chems/random/random_effects.dm
@@ -25,7 +25,7 @@
 
 /decl/random_chem_effect/proc/on_property_recompute(var/decl/material/liquid/random/reagent, var/value)
 
-/decl/random_chem_effect/proc/affect_blood(var/mob/living/M, var/alien, var/removed, var/value)
+/decl/random_chem_effect/proc/affect_blood(var/mob/living/M, var/removed, var/value)
 
 // This is referring to monetary value.
 /decl/random_chem_effect/proc/get_value(var/value)
@@ -96,7 +96,7 @@
 /decl/random_chem_effect/random_properties
 	var/chem_effect_define                //If it corresponds to a CE_WHATEVER define, place here and it will do generic affect blood based on it
 
-/decl/random_chem_effect/random_properties/affect_blood(var/mob/living/M, var/alien, var/removed, var/value)
+/decl/random_chem_effect/random_properties/affect_blood(var/mob/living/M, var/removed, var/value)
 	if(chem_effect_define)
 		M.add_chemical_effect(chem_effect_define, value)
 
@@ -227,7 +227,7 @@
 	mode = RANDOM_CHEM_EFFECT_INT
 	desc = "acute toxicity"
 
-/decl/random_chem_effect/random_properties/heal_brute/affect_blood(var/mob/living/M, var/alien, var/removed, var/value)
+/decl/random_chem_effect/random_properties/heal_brute/affect_blood(var/mob/living/M, var/removed, var/value)
 	M.adjustToxLoss(value * removed)
 
 /decl/random_chem_effect/random_properties/heal_brute
@@ -235,7 +235,7 @@
 	maximum = 10
 	desc = "tissue repair"
 
-/decl/random_chem_effect/random_properties/heal_brute/affect_blood(var/mob/living/M, var/alien, var/removed, var/value)
+/decl/random_chem_effect/random_properties/heal_brute/affect_blood(var/mob/living/M, var/removed, var/value)
 	M.heal_organ_damage(removed * value, 0)
 
 /decl/random_chem_effect/random_properties/heal_burns
@@ -243,7 +243,7 @@
 	maximum = 10
 	desc = "burn repair"
 
-/decl/random_chem_effect/random_properties/heal_brute/affect_blood(var/mob/living/M, var/alien, var/removed, var/value)
+/decl/random_chem_effect/random_properties/heal_brute/affect_blood(var/mob/living/M, var/removed, var/value)
 	M.heal_organ_damage(0, removed * value)
 
 #undef RANDOM_CHEM_EFFECT_TRUE

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -111,8 +111,8 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	var/sniff_message_1p = "You sniff the air."
 
 	var/spawns_with_stack = 0
+
 	// Environment tolerance/life processes vars.
-	var/reagent_tag                                             // Used for metabolizing reagents.
 	var/breath_pressure = 16                                    // Minimum partial pressure safe for breathing, kPa
 	var/breath_type = /decl/material/gas/oxygen                                  // Non-oxygen gas breathed, if any.
 	var/poison_types = list(/decl/material/gas/chlorine = TRUE) // Noticeably poisonous air - ie. updates the toxins indicator on the HUD.

--- a/mods/content/psionics/datum/chems.dm
+++ b/mods/content/psionics/datum/chems.dm
@@ -1,8 +1,8 @@
 /decl/material/liquid/crystal_agent/do_material_check(var/mob/living/carbon/M)
 	var/decl/special_role/wizard/wizards = GET_DECL(/decl/special_role/wizard)
 	. = (M.psi || (M.mind && wizards.is_antagonist(M.mind))) ? MAT_NULLGLASS : ..()
-	
-/decl/material/liquid/glowsap/gleam/affect_overdose(var/mob/living/M, var/alien, var/datum/reagents/holder)
+
+/decl/material/liquid/glowsap/gleam/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
 	..()
 	if(M.psi)
 		M.psi.check_latency_trigger(30, "a [name] overdose")

--- a/mods/content/xenobiology/slime/slime_reagents.dm
+++ b/mods/content/xenobiology/slime/slime_reagents.dm
@@ -13,7 +13,7 @@
 	color = "#cf3600"
 	metabolism = REM * 0.25
 
-/decl/material/liquid/water/affect_touch(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/water/affect_touch(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	if(isslime(M))
 		M.adjustToxLoss(10 * removed)
@@ -32,22 +32,22 @@
 			if(istype(slime_ai))
 				slime_ai.attacked = max(slime_ai.attacked, rand(7,10)) // angery
 
-/decl/material/liquid/water/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/water/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	if(isslime(M))
 		M.adjustToxLoss(2 * removed)
 
-/decl/material/liquid/frostoil/affect_blood(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/frostoil/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	if(isslime(M))
 		M.bodytemperature = max(M.bodytemperature - rand(10,20), 0)
 
-/decl/material/liquid/capsaicin/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/capsaicin/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	if(isslime(M))
 		M.bodytemperature += rand(0, 15) + slime_temp_adj
 
-/decl/material/liquid/capsaicin/condensed/affect_ingest(var/mob/living/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/capsaicin/condensed/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	if(isslime(M))
 		M.bodytemperature += rand(15, 30)

--- a/mods/species/ascent/ascent.dm
+++ b/mods/species/ascent/ascent.dm
@@ -8,8 +8,6 @@
 #define BODY_FLAG_ALATE BITFLAG(4)
 #define BODY_FLAG_GYNE  BITFLAG(5)
 
-#define IS_MANTID    "mantid"
-
 #define BP_L_HAND_UPPER "l_u_hand"
 #define BP_R_HAND_UPPER "r_u_hand"
 #define BP_M_HAND       "midlimb"

--- a/mods/species/ascent/datum/species.dm
+++ b/mods/species/ascent/datum/species.dm
@@ -69,7 +69,6 @@
 	exhale_type =             /decl/material/gas/methane
 	poison_types =            list(/decl/material/gas/chlorine)
 
-	reagent_tag =             IS_MANTID
 	available_pronouns = list(/decl/pronouns/male)
 
 	appearance_flags =        0

--- a/mods/species/bayliens/skrell/_skrell.dm
+++ b/mods/species/bayliens/skrell/_skrell.dm
@@ -1,5 +1,4 @@
 #define SPECIES_SKRELL "Skrell"
-#define IS_SKRELL "skrell"
 #define BODYTYPE_SKRELL "skrellian body"
 
 /mob/living/carbon/human/skrell/Initialize(mapload)

--- a/mods/species/bayliens/skrell/datum/species.dm
+++ b/mods/species/bayliens/skrell/datum/species.dm
@@ -75,8 +75,6 @@
 	cold_discomfort_level = 292 //Higher than perhaps it should be, to avoid big speed reduction at normal room temp
 	heat_discomfort_level = 368
 
-	reagent_tag = IS_SKRELL
-
 	appearance_descriptors = list(
 		/datum/appearance_descriptor/height = 1,
 		/datum/appearance_descriptor/build = 0.8,

--- a/mods/species/bayliens/unathi/_lizard.dm
+++ b/mods/species/bayliens/unathi/_lizard.dm
@@ -1,6 +1,5 @@
 #define SPECIES_LIZARD  "Unathi"
 #define LANGUAGE_LIZARD "Sinta'unathi"
-#define IS_LIZARD       "lizard"
 
 /mob/living/carbon/human/lizard/Initialize(mapload)
 	..(mapload, SPECIES_LIZARD)

--- a/mods/species/bayliens/unathi/datum/species.dm
+++ b/mods/species/bayliens/unathi/datum/species.dm
@@ -58,8 +58,6 @@
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_ROBOTIC_INTERNAL_ORGANS
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
 
-	reagent_tag = IS_LIZARD
-
 	flesh_color = "#34af10"
 	base_color = "#066000"
 	default_h_style = /decl/sprite_accessory/hair/lizard/frills_long

--- a/mods/species/neoavians/_neoavians.dm
+++ b/mods/species/neoavians/_neoavians.dm
@@ -1,6 +1,5 @@
 #define SPECIES_AVIAN            "Neo-Avian"
 #define BODYTYPE_AVIAN           "avian body"
-#define IS_AVIAN                 "avian"
 #define BODY_FLAG_AVIAN          BITFLAG(6)
 
 /decl/modpack/neoavians

--- a/mods/species/neoavians/datum/species.dm
+++ b/mods/species/neoavians/datum/species.dm
@@ -30,8 +30,6 @@
 
 	preview_outfit = /decl/hierarchy/outfit/job/generic/assistant/avian
 
-	reagent_tag = IS_AVIAN
-
 	available_bodytypes = list(
 		/decl/bodytype/avian,
 		/decl/bodytype/avian/additive,

--- a/mods/species/serpentid/datum/species.dm
+++ b/mods/species/serpentid/datum/species.dm
@@ -65,7 +65,6 @@
 	body_temperature = null
 	flesh_color = "#525252"
 	blood_oxy = 0
-	reagent_tag = IS_SERPENTID
 
 	available_bodytypes = list(
 		/decl/bodytype/serpentid,

--- a/mods/species/serpentid/serpentid.dm
+++ b/mods/species/serpentid/serpentid.dm
@@ -1,4 +1,3 @@
 #define SPECIES_SERPENTID "Serpentid"
 #define BODYTYPE_SNAKE    "snakelike body"
-#define IS_SERPENTID      "serpentid"
 #define BODY_FLAG_SNAKE   BITFLAG(3)

--- a/mods/species/vox/datum/species.dm
+++ b/mods/species/vox/datum/species.dm
@@ -11,8 +11,6 @@
 		"withered" =        65
 	)
 
-#define IS_VOX "vox"
-
 /decl/blood_type/vox
 	name = "vox ichor"
 	antigen_category = "vox"
@@ -81,7 +79,6 @@
 	flesh_color = "#808d11"
 
 	default_h_style = /decl/sprite_accessory/hair/vox
-	reagent_tag = IS_VOX
 	maneuvers = list(/decl/maneuver/leap/grab)
 	standing_jump_range = 5
 


### PR DESCRIPTION
## Description of changes
Removes `reagent_tag` and associated passing as an arg.

## Why and what will this PR improve
`reagent_tag` was deprecated by mob traits months ago.

## Authorship
Myself.

## Changelog
Nothing player-facing.