### PR TITLE
Ports Kapu's ZAS Debug Tune-up

### DIFF
--- a/code/__defines/ZAS.dm
+++ b/code/__defines/ZAS.dm
@@ -1,3 +1,18 @@
+
+/*
+	Uncomment this to enable ZAS debugging tools. While ghosted, you will see a visualization of the atmos status of turfs.
+	Green turfs are zones that are existing happily.
+	Yellow-orange turfs are a zone that has recently been merged into another zone.
+	Red turfs are turfs are an invalidated zone. Invalid zones are zones that were destroyed.
+	White/overlay-less turfs are turfs that are the origin point of a zone. This is completely useless information.
+	Purple outlines indicate the turf was marked for an update by SSair, and is in its processing list.
+	In addition, all ZAS-related datums and turfs will have a "verbose" var. Set this to 1 using View Variables to get robust to_chat()s about activity.
+	Finally, this is a friendly reminder that using Debug Verbs gives access to the Zone Info and Test ZAS Connection verbs when you right click a turf.
+
+	Addendum:
+		There are additional debug overlays that use ZAS_ZONE_BLOCKER and ZAS_DIRECTIONAL_BLOCKER.
+		They take priority over standard overlays, displaying directional airflow, and are generally not needed so they are commented out by default.
+*/
 //#define ZASDBG
 #define MULTIZAS
 

--- a/code/controllers/subsystems/air.dm
+++ b/code/controllers/subsystems/air.dm
@@ -198,8 +198,7 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 		T.post_update_air_properties()
 		T.needs_air_update = 0
 		#ifdef ZASDBG
-		T.cut_overlay(mark, TRUE)
-		updated++
+		T.vis_contents -= zasdbgovl_mark
 		#endif
 
 		if (no_mc_tick)
@@ -215,8 +214,7 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 		T.post_update_air_properties()
 		T.needs_air_update = 0
 		#ifdef ZASDBG
-		T.cut_overlay(mark, TRUE)
-		updated++
+		T.vis_contents -= zasdbgovl_mark
 		#endif
 
 		if (no_mc_tick)
@@ -364,7 +362,7 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 		return
 	tiles_to_update += T
 	#ifdef ZASDBG
-	T.add_overlay(mark, TRUE)
+	T.vis_contents += zasdbgovl_mark
 	#endif
 	T.needs_air_update = 1
 

--- a/code/controllers/subsystems/air.dm
+++ b/code/controllers/subsystems/air.dm
@@ -198,7 +198,7 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 		T.post_update_air_properties()
 		T.needs_air_update = 0
 		#ifdef ZASDBG
-		T.vis_contents -= zasdbgovl_mark
+		remove_vis_contents(T, zasdbgovl_mark)
 		#endif
 
 		if (no_mc_tick)
@@ -214,7 +214,7 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 		T.post_update_air_properties()
 		T.needs_air_update = 0
 		#ifdef ZASDBG
-		T.vis_contents -= zasdbgovl_mark
+		remove_vis_contents(T, zasdbgovl_mark)
 		#endif
 
 		if (no_mc_tick)
@@ -362,7 +362,7 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 		return
 	tiles_to_update += T
 	#ifdef ZASDBG
-	T.vis_contents += zasdbgovl_mark
+	add_vis_contents(T, zasdbgovl_mark)
 	#endif
 	T.needs_air_update = 1
 

--- a/code/modules/ZAS/ConnectionGroup.dm
+++ b/code/modules/ZAS/ConnectionGroup.dm
@@ -58,13 +58,18 @@ Class Procs:
 */
 
 
-/connection_edge/var/zone/A
+/connection_edge
+	var/zone/A
 
-/connection_edge/var/list/connecting_turfs = list()
-/connection_edge/var/direct = 0
-/connection_edge/var/sleeping = 1
+	var/list/connecting_turfs = list()
+	var/direct = 0
+	var/sleeping = 1
+	var/coefficient = 0
 
-/connection_edge/var/coefficient = 0
+	#ifdef ZASDBG
+	///Set this to TRUE during testing to get verbose debug information.
+	var/tmp/verbose = FALSE
+	#endif
 
 /connection_edge/New()
 	CRASH("Cannot make connection edge without specifications.")
@@ -72,23 +77,33 @@ Class Procs:
 /connection_edge/proc/add_connection(connection/c)
 	coefficient++
 	if(c.direct()) direct++
-//	log_debug("Connection added: [type] Coefficient: [coefficient]")
+
+	#ifdef ZASDBG
+	if(verbose)
+		zas_log("Connection added: [type] Coefficient: [coefficient]")
+	#endif
 
 
 /connection_edge/proc/remove_connection(connection/c)
-//	log_debug("Connection removed: [type] Coefficient: [coefficient-1]")
-
 	coefficient--
 	if(coefficient <= 0)
 		erase()
 	if(c.direct()) direct--
 
+	#ifdef ZASDBG
+	if(verbose)
+		zas_log("Connection removed: [type] Coefficient: [coefficient-1]")
+	#endif
+
 /connection_edge/proc/contains_zone(zone/Z)
 
 /connection_edge/proc/erase()
 	SSair.remove_edge(src)
-//	log_debug("[type] Erased.")
 
+	#ifdef ZASDBG
+	if(verbose)
+		zas_log("[type] Erased.")
+	#endif
 
 /connection_edge/proc/tick()
 
@@ -107,9 +122,11 @@ Class Procs:
 	src.B = B
 	A.edges.Add(src)
 	B.edges.Add(src)
-	//id = edge_id(A,B)
-//	log_debug("New edge between [A] and [B]")
 
+	#ifdef ZASDBG
+	if(verbose)
+		zas_log("New edge between [A] and [B]")
+	#endif
 
 /connection_edge/zone/add_connection(connection/c)
 	. = ..()
@@ -178,9 +195,11 @@ Class Procs:
 	src.B = B
 	A.edges.Add(src)
 	air = B.return_air()
-	//id = 52*A.id
-//	log_debug("New edge from [A] to [B].")
 
+	#ifdef ZASDBG
+	if(verbose)
+		zas_log("New edge from [A] to [B] ([B.x], [B.y], [B.z]).")
+	#endif
 
 /connection_edge/unsimulated/add_connection(connection/c)
 	. = ..()

--- a/code/modules/ZAS/Debug.dm
+++ b/code/modules/ZAS/Debug.dm
@@ -72,8 +72,8 @@ var/global/list/zasdbgovl_dirzoneblock = list(
 
 /turf/var/tmp/obj/effect/zasdbg/dbg_img
 /turf/proc/dbg(obj/effect/zasdbg/img)
-	vis_contents -= dbg_img
-	vis_contents += img
+	remove_vis_contents(src, dbg_img)
+	add_vis_contents(src, img)
 	dbg_img = img
 
 /proc/soft_assert(thing,fail)

--- a/code/modules/ZAS/Debug.dm
+++ b/code/modules/ZAS/Debug.dm
@@ -1,20 +1,93 @@
-var/global/image/assigned = image('icons/Testing/Zone.dmi', icon_state = "assigned")
-var/global/image/created = image('icons/Testing/Zone.dmi', icon_state = "created")
-var/global/image/merged = image('icons/Testing/Zone.dmi', icon_state = "merged")
-var/global/image/invalid_zone = image('icons/Testing/Zone.dmi', icon_state = "invalid")
-var/global/image/air_blocked = image('icons/Testing/Zone.dmi', icon_state = "block")
-var/global/image/zone_blocked = image('icons/Testing/Zone.dmi', icon_state = "zoneblock")
-var/global/image/blocked = image('icons/Testing/Zone.dmi', icon_state = "fullblock")
-var/global/image/mark = image('icons/Testing/Zone.dmi', icon_state = "mark")
+#ifdef ZASDBG
 
-/connection_edge/var/dbg_out = 0
+var/global/obj/effect/zasdbg/assigned/zasdbgovl_assigned = new
+var/global/obj/effect/zasdbg/created/zasdbgovl_created = new
+var/global/obj/effect/zasdbg/merged/zasdbgovl_merged = new
+var/global/obj/effect/zasdbg/invalid_zone/zasdbgovl_invalid_zone = new
+var/global/obj/effect/zasdbg/blocked/zasdbgovl_blocked = new
+var/global/obj/effect/zasdbg/mark/zasdbgovl_mark = new
 
-/turf/var/tmp/dbg_img
-/turf/proc/dbg(image/img, d = 0)
-	if(d > 0) img.dir = d
-	overlays -= dbg_img
-	overlays += img
+var/global/list/zasdbgovl_dirblock = list(
+	"north" = new /obj/effect/zasdbg/air_blocked/north,
+	"east" = new /obj/effect/zasdbg/air_blocked/east,
+	"south" = new /obj/effect/zasdbg/air_blocked/south,
+	"west" = new /obj/effect/zasdbg/air_blocked/west,
+)
+///Retrives the directional block indicator overlay for a given direction
+#define ZAS_DIRECTIONAL_BLOCKER(d) (zasdbgovl_dirblock[dir2text(d)])
+
+var/global/list/zasdbgovl_dirzoneblock = list(
+	"north" = new /obj/effect/zasdbg/zone_blocked/north,
+	"east" = new /obj/effect/zasdbg/zone_blocked/east,
+	"south" = new /obj/effect/zasdbg/zone_blocked/south,
+	"west" = new /obj/effect/zasdbg/zone_blocked/west,
+)
+///Retrieves the zone blocked debug overlay for a given direction
+#define ZAS_ZONE_BLOCKER(d) (zasdbgovl_dirzoneblock[dir2text(d)])
+
+/obj/effect/zasdbg
+	icon = 'icons/Testing/Zone.dmi'
+	invisibility = INVISIBILITY_OBSERVER
+	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
+	plane = EFFECTS_ABOVE_LIGHTING_PLANE
+	layer = FLY_LAYER
+
+/obj/effect/zasdbg/assigned
+	icon_state = "assigned"
+/obj/effect/zasdbg/created
+	icon_state = "created"
+/obj/effect/zasdbg/merged
+	icon_state = "merged"
+/obj/effect/zasdbg/invalid_zone
+	icon_state = "invalid"
+/obj/effect/zasdbg/blocked
+	icon_state = "fullblock"
+/obj/effect/zasdbg/mark
+	icon_state = "mark"
+
+/obj/effect/zasdbg/zone_blocked
+	icon_state = "zoneblock"
+
+/obj/effect/zasdbg/zone_blocked/north
+	dir = NORTH
+/obj/effect/zasdbg/zone_blocked/east
+	dir = EAST
+/obj/effect/zasdbg/zone_blocked/south
+	dir = SOUTH
+/obj/effect/zasdbg/zone_blocked/west
+	dir = WEST
+
+/obj/effect/zasdbg/air_blocked
+	icon_state = "block"
+
+/obj/effect/zasdbg/air_blocked/north
+	dir = NORTH
+/obj/effect/zasdbg/air_blocked/east
+	dir = EAST
+/obj/effect/zasdbg/air_blocked/south
+	dir = SOUTH
+/obj/effect/zasdbg/air_blocked/west
+	dir = WEST
+
+
+/turf/var/tmp/obj/effect/zasdbg/dbg_img
+/turf/proc/dbg(obj/effect/zasdbg/img)
+	vis_contents -= dbg_img
+	vis_contents += img
 	dbg_img = img
 
 /proc/soft_assert(thing,fail)
 	if(!thing) message_admins(fail)
+
+/datum/proc/zas_log(string)
+	return
+
+/turf/zas_log(string)
+	to_chat(world, "[SPAN_DEBUG("ZAS:")] ([src.x], [src.y], [src.z]): [string]")
+
+/connection/zas_log(string)
+	to_chat(world, "[SPAN_DEBUG("ZAS:")] connection output: [string]")
+
+/connection_edge/zas_log(string)
+	to_chat(world, "[SPAN_DEBUG("ZAS:")] connection edge output: [string]")
+#endif

--- a/code/modules/ZAS/Diagnostic.dm
+++ b/code/modules/ZAS/Diagnostic.dm
@@ -1,21 +1,18 @@
 /client/proc/Zone_Info(turf/T as null|turf)
 	set category = "Debug"
-	if(T)
-		if(istype(T,/turf/simulated) && T:zone)
-			T:zone:dbg_data(src)
-		else
-			to_chat(mob, "No zone here.")
-			var/datum/gas_mixture/mix = T.return_air()
-			to_chat(mob, "[mix.return_pressure()] kPa [mix.temperature]C")
-			for(var/g in mix.gas)
-				to_chat(mob, "[g]: [mix.gas[g]]\n")
+	if(!T)
+		return
+	if(istype(T,/turf/simulated) && T:zone)
+		T:zone:dbg_data(src)
 	else
-		if(zone_debug_images)
-			for(var/zone in  zone_debug_images)
-				images -= zone_debug_images[zone]
-			zone_debug_images = null
+		to_chat(mob, "ZONE: No zone here.")
+		var/datum/gas_mixture/mix = T.return_air()
+		to_chat(mob, "ZONE: [mix.return_pressure()] kPa [mix.temperature] k")
+		for(var/g in mix.gas)
+			to_chat(mob, "ZONE GASES: [g]: [mix.gas[g]]\n")
 
-/client/var/list/zone_debug_images
+		if((T:zone && (length(T:zone:contents) > ZONE_MIN_SIZE)))
+			to_chat(mob, SPAN_NOTICE("This turf's zone is below the minimum size, and will merge over zone blockers."))
 
 /client/proc/Test_ZAS_Connection(var/turf/simulated/T)
 	set category = "Debug"
@@ -37,6 +34,7 @@
 		return
 
 	if(direction == "N/A")
+		to_chat(mob, "Testing self-blocking...")
 		if(!(T.c_airblock(T) & AIR_BLOCKED))
 			to_chat(mob, "The turf can pass air! :D")
 		else
@@ -50,6 +48,7 @@
 	var/t_block = T.c_airblock(other_turf)
 	var/o_block = other_turf.c_airblock(T)
 
+	to_chat(mob, "Testing connection between ([T.x], [T.y], [T.z]) and ([other_turf.x], [other_turf.y], [other_turf.z])...")
 	if(o_block & AIR_BLOCKED)
 		if(t_block & AIR_BLOCKED)
 			to_chat(mob, "Neither turf can connect. :(")

--- a/code/modules/ZAS/Zone.dm
+++ b/code/modules/ZAS/Zone.dm
@@ -63,7 +63,7 @@ Class Procs:
 #ifdef ZASDBG
 	ASSERT(!invalid)
 	ASSERT(istype(T))
-	ASSERT(!SSair.has_valid_zone(T))
+	ASSERT(!TURF_HAS_VALID_ZONE(T))
 #endif
 
 	var/datum/gas_mixture/turf_air = T.return_air()
@@ -103,7 +103,7 @@ Class Procs:
 		into.add(T)
 		T.update_graphic(graphic_remove = air.graphic)
 		#ifdef ZASDBG
-		T.dbg(merged)
+		T.dbg(zasdbgovl_merged)
 		#endif
 
 	//rebuild the old zone's edges so that they will be possessed by the new zone
@@ -118,7 +118,7 @@ Class Procs:
 	SSair.remove_zone(src)
 	#ifdef ZASDBG
 	for(var/turf/simulated/T in contents)
-		T.dbg(invalid_zone)
+		T.dbg(zasdbgovl_invalid_zone)
 	#endif
 
 /zone/proc/rebuild()
@@ -127,7 +127,6 @@ Class Procs:
 	c_invalidate()
 	for(var/turf/simulated/T in contents)
 		T.update_graphic(graphic_remove = air.graphic) //we need to remove the overlays so they're not doubled when the zone is rebuilt
-		//T.dbg(invalid_zone)
 		T.needs_air_update = 0 //Reset the marker so that it will be added to the list.
 		SSair.mark_for_update(T)
 		CHECK_TICK
@@ -204,8 +203,7 @@ Class Procs:
 	to_chat(M, "P: [air.return_pressure()] kPa V: [air.volume]L T: [air.temperature]°K ([air.temperature - T0C]°C)")
 	to_chat(M, "O2 per N2: [(air.gas[/decl/material/gas/nitrogen] ? air.gas[/decl/material/gas/oxygen]/air.gas[/decl/material/gas/nitrogen] : "N/A")] Moles: [air.total_moles]")
 	to_chat(M, "Simulated: [contents.len] ([air.group_multiplier])")
-//	to_chat(M, "Unsimulated: [unsimulated_contents.len]")
-//	to_chat(M, "Edges: [edges.len]")
+	to_chat(M, "Edges: [length(edges)]")
 	if(invalid) to_chat(M, "Invalid!")
 	var/zone_edges = 0
 	var/space_edges = 0

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -211,7 +211,11 @@ var/global/list/debug_verbs = list (
 	var/turf/simulated/location = get_turf(usr)
 
 	if(!istype(location, /turf/simulated))
-		to_chat(src, "<Span class='warning'>This debug tool can only be used while on a simulated turf.</span>")
+		to_chat(src, SPAN_WARNING("This debug tool can only be used while on a simulated turf."))
+		return
+
+	if(!location.zone)
+		to_chat(src, SPAN_WARNING("The turf you are standing on does not have a zone."))
 		return
 
 	if(!usedZAScolors)


### PR DESCRIPTION
## Description of changes
Ports @Kapu1178's ZAS Debug modernization from https://github.com/Baystation12/Baystation12/pull/32294, with very minor adjustments by myself. Changes ZAS debug verb to use visual contents instead of overlays, removes some commented out code, and documents various parts of both ZAS and the debug verbs.

## Why and what will this PR improve
Improved documentation, code cleanup, and performance of ZAS debug verbs. Also fixes a runtime caused by using the ZAS debug verb on a zoneless simulated turf.

## Authorship
Code by Kapu except for the runtime fix. Port done by myself
## Changelog
:cl:
refactor: Ports Kapu's modernization of ZAS debug verbs
/:cl: