### PR TITLE
Fix cocktail descriptions, add sprite support

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -92,3 +92,7 @@ The latter will result in a linter warning and will not work correctly.
 #define OVERMAP_SECTOR_KNOWN              BITFLAG(1) // Makes the sector show up on nav computers
 #define OVERMAP_SECTOR_IN_SPACE           BITFLAG(2) // If the sector can be accessed by drifting off the map edge
 #define OVERMAP_SECTOR_UNTARGETABLE       BITFLAG(3) // If the sector is untargetable by missiles.
+
+// Flags for reagent presentation (/obj/item/chems/var/presentation_flags)
+#define PRESENTATION_FLAG_NAME            BITFLAG(0) // This chems subtype presents the name of its main reagent/cocktail.
+#define PRESENTATION_FLAG_DESC            BITFLAG(1) // This chems subtype presents the description of its main reagent/cocktail.

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -687,6 +687,19 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	if(prop.reagents.has_reagent(/decl/material/solid/ice))
 		. = "iced [.]"
 
+/decl/material/proc/get_presentation_desc(var/obj/item/prop)
+	. = glass_desc
+	if(prop?.reagents?.total_volume)
+		. = build_presentation_desc_from_reagents(prop, .)
+
+/decl/material/proc/build_presentation_desc_from_reagents(var/obj/item/prop, var/supplied)
+	. = supplied
+
+	if(cocktail_ingredient)
+		for(var/decl/cocktail/cocktail in SSmaterials.get_cocktails_by_primary_ingredient(type))
+			if(cocktail.matches(prop))
+				return cocktail.get_presentation_desc(prop)
+
 /decl/material/proc/neutron_interact(var/neutron_energy, var/total_interacted_units, var/total_units)
 	. = list() // Returns associative list of interaction -> interacted units
 	if(!length(neutron_interactions))

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -68,7 +68,7 @@
 		to_chat(user, SPAN_NOTICE("You add the pill bottle into the dispenser slot!"))
 		updateUsrDialog()
 		return TRUE
-	
+
 	return ..()
 
 /obj/machinery/chem_master/Topic(href, href_list, state)
@@ -236,7 +236,7 @@
 	if(!name)
 		name = reagents.get_primary_reagent_name()
 	P.label_text = name
-	P.update_name_label()
+	P.update_container_name()
 	P.lid_color = bottle_lid_color
 	P.label_color = bottle_label_color
 	reagents.trans_to_obj(P,60)

--- a/code/modules/reagents/cocktails.dm
+++ b/code/modules/reagents/cocktails.dm
@@ -18,6 +18,12 @@
 	var/order_specific = FALSE
 	/// If TRUE, doesn't generate a codex entry.
 	var/hidden_from_codex
+	/// The icon to use for the cocktail. May be null, in which case no custom icon is used.
+	var/icon/glass_icon
+	/// The icon_state to use for the cocktail. May be null, in which case the first state in the icon is used.
+	var/glass_icon_state
+	/// A list of types (incl. subtypes) to display this cocktail's glass sprite on.
+	var/display_types = list(/obj/item/chems/drinks/glass2)
 
 	// Impurity tolerance gives a buffer for imprecise mixing, avoiding finnicky measurements
 	// and allowing for things like spiked drinks. The default is 0.3, meaning aside from ice,
@@ -44,6 +50,10 @@
 	if(prop?.reagents?.has_reagent(/decl/material/solid/ice) && !(/decl/material/solid/ice in ratios))
 		. = "[name], on the rocks"
 
+/decl/cocktail/proc/get_presentation_desc(var/obj/item/prop)
+	. = description
+	// placeholder for future functionality (vapor/fizz/etc. descriptions)
+
 /decl/cocktail/proc/mix_priority()
 	. = length(ratios)
 
@@ -65,6 +75,14 @@
 		if((REAGENT_VOLUME(prop.reagents, rtype) / effective_volume) < check_ratios[rtype])
 			return FALSE
 	return TRUE
+
+/decl/cocktail/proc/has_sprite(obj/item/prop)
+	// assumes we match, checks if we have (compatible) sprites
+	return !(isnull(glass_icon) || isnull(glass_icon_state))
+
+/decl/cocktail/proc/can_use_sprite(obj/item/prop)
+	// assume we already match; just check types
+	return is_type_in_list(prop, display_types)
 
 /decl/cocktail/grog
 	name = "grog"

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -6,11 +6,12 @@
 	w_class = ITEM_SIZE_SMALL
 
 	var/base_name
+	var/base_desc
 	var/amount_per_transfer_from_this = 5
 	var/possible_transfer_amounts = @"[5,10,15,25,30]"
 	var/volume = 30
 	var/label_text
-	var/show_reagent_name = FALSE
+	var/presentation_flags = 0
 
 /obj/item/chems/proc/cannot_interact(mob/user)
 	if(!CanPhysicallyInteract(user))
@@ -26,14 +27,33 @@
 		base_name = initial(name)
 	. = base_name
 
-/obj/item/chems/on_reagent_change()
-	if(show_reagent_name)
+/obj/item/chems/proc/update_container_name()
+	var/newname = get_base_name()
+	if(presentation_flags & PRESENTATION_FLAG_NAME)
 		var/decl/material/R = reagents?.get_primary_reagent_decl()
-		var/newname = get_base_name()
 		if(R)
-			newname = "[newname] of [R.get_presentation_name(src)]"
-		if(newname != name)
-			SetName(newname)
+			newname += " of [R.get_presentation_name(src)]"
+	if(length(label_text))
+		newname += " ([label_text])"
+	if(newname != name)
+		SetName(newname)
+
+/obj/item/chems/proc/get_base_desc()
+	if(!base_desc)
+		base_desc = initial(desc)
+	. = base_desc
+
+/obj/item/chems/proc/update_container_desc()
+	var/list/new_desc_list = list(get_base_desc())
+	if(presentation_flags & PRESENTATION_FLAG_DESC)
+		var/decl/material/R = reagents?.get_primary_reagent_decl()
+		if(R)
+			new_desc_list += R.get_presentation_desc(src)
+	desc = new_desc_list.Join("\n")
+
+/obj/item/chems/on_reagent_change()
+	update_container_name()
+	update_container_desc()
 	update_icon()
 
 /obj/item/chems/verb/set_amount_per_transfer_from_this()
@@ -66,15 +86,9 @@
 		else
 			to_chat(user, "<span class='notice'>You set the label to \"[tmp_label]\".</span>")
 			label_text = tmp_label
-			update_name_label()
+			update_container_name()
 	else
 		return ..()
-
-/obj/item/chems/proc/update_name_label()
-	if(!label_text || label_text == "")
-		SetName(get_base_name())
-	else
-		SetName("[get_base_name()] ([label_text])")
 
 /obj/item/chems/proc/standard_dispenser_refill(var/mob/user, var/obj/structure/reagent_dispensers/target) // This goes into afterattack
 	if(!istype(target))

--- a/code/modules/reagents/reagent_containers/beaker.dm
+++ b/code/modules/reagents/reagent_containers/beaker.dm
@@ -10,7 +10,7 @@
 	applies_material_colour = TRUE
 	material_force_multiplier = 0.25
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	show_reagent_name = TRUE
+	presentation_flags = PRESENTATION_FLAG_NAME
 	var/lid_color = COLOR_BEASTY_BROWN
 
 /obj/item/chems/glass/beaker/Initialize()
@@ -99,7 +99,7 @@
 	volume = 60
 	amount_per_transfer_from_this = 10
 	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_OPEN_CONTAINER | ATOM_FLAG_NO_REACT
-	show_reagent_name = TRUE
+	presentation_flags = PRESENTATION_FLAG_NAME
 	material = /decl/material/solid/metal/steel
 	applies_material_name = FALSE
 	applies_material_colour = FALSE
@@ -149,7 +149,7 @@
 	matter = list(/decl/material/solid/plastic = MATTER_AMOUNT_REINFORCEMENT)
 	possible_transfer_amounts = @"[5,10,15,30]"
 	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_OPEN_CONTAINER
-	show_reagent_name = TRUE
+	presentation_flags = PRESENTATION_FLAG_NAME
 	applies_material_colour = FALSE
 	temperature_coefficient = 1
 	material = /decl/material/solid/metal/steel

--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -29,7 +29,7 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = @"[5,10,15,30]"
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	show_reagent_name = TRUE
+	presentation_flags = PRESENTATION_FLAG_NAME | PRESENTATION_FLAG_DESC
 	temperature_coefficient = 4
 	item_flags = ITEM_FLAG_HOLLOW
 
@@ -99,11 +99,12 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 /obj/item/chems/drinks/glass2/get_base_name()
 	. = base_name
 
+/obj/item/chems/drinks/glass2/get_base_desc()
+	. = custom_desc || ..()
+
 /obj/item/chems/drinks/glass2/on_reagent_change()
 	temperature_coefficient = 4 / max(1, reagents.total_volume)
 	..()
-	var/decl/material/R = reagents.get_primary_reagent_decl()
-	desc = R?.glass_desc || custom_desc || initial(desc)
 
 /obj/item/chems/drinks/glass2/proc/can_add_extra(obj/item/glass_extra/GE)
 	if(!("[base_icon]_[GE.glass_addition]left" in icon_states(icon)))
@@ -127,9 +128,17 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 /obj/item/chems/drinks/glass2/on_update_icon()
 	. = ..()
 	underlays.Cut()
+	icon_state = base_icon
 
 	if (LAZYLEN(reagents?.reagent_volumes) > 0)
 		var/decl/material/R = reagents.get_primary_reagent_decl()
+		if(R.cocktail_ingredient)
+			for(var/decl/cocktail/cocktail in SSmaterials.get_cocktails_by_primary_ingredient(R.type))
+				if(cocktail.matches(src) && cocktail.has_sprite(src) && cocktail.can_use_sprite(src))
+					icon_state = null // hide the main sprite
+					add_overlay(image(cocktail.glass_icon, cocktail.glass_icon_state))
+					return // don't do the rest--todo semiprocedural cocktail sprites with fizz/ice/vapor
+
 		var/list/under_liquid = list()
 		var/list/over_liquid = list()
 

--- a/code/modules/reagents/reagent_containers/drinks.dm
+++ b/code/modules/reagents/reagent_containers/drinks.dm
@@ -102,19 +102,11 @@
 /obj/item/chems/drinks/get_base_name()
 	. = base_name
 
-/obj/item/chems/drinks/on_reagent_change()
-	. = ..()
-	var/decl/material/R = reagents.get_primary_reagent_decl()
-	desc = R?.glass_desc || initial(desc)
-
 /obj/item/chems/drinks/on_update_icon()
 	. = ..()
 	if(LAZYLEN(reagents.reagent_volumes))
 		if(filling_states)
 			add_overlay(overlay_image(icon, "[base_icon][get_filling_state()]", reagents.get_color()))
-	else
-		SetName(initial(name))
-		desc = initial(desc)
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -117,7 +117,7 @@
 	possible_transfer_amounts = @"[10,20,30,60,120,150,180]"
 	volume = 180
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	show_reagent_name = TRUE
+	presentation_flags = PRESENTATION_FLAG_NAME
 	unacidable = 0
 	material = /decl/material/solid/plastic
 	material_force_multiplier = 0.2

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -38,7 +38,7 @@
 /obj/item/chems/glass/bottle/on_update_icon()
 	..()
 	cut_overlays()
-	
+
 	if(reagents?.total_volume)
 		var/percent = round(reagents.total_volume / volume * 100, 25)
 		add_overlay(mutable_appearance(icon, "[icon_state]_filling_[percent]", reagents.get_color()))
@@ -57,7 +57,7 @@
 
 	if (!ATOM_IS_OPEN_CONTAINER(src))
 		add_overlay(mutable_appearance(icon, "[icon_state]_lid", lid_color))
-	
+
 	compile_overlays()
 
 /obj/item/chems/glass/bottle/Initialize()
@@ -68,8 +68,7 @@
 		if(autolabel && !label_text) // don't override preset labels
 			var/decl/material/R = GET_DECL(initial_reagents[1])
 			label_text = R.name
-	if(label_text)
-		update_name_label()
+	update_container_name()
 	update_icon()
 
 /obj/item/chems/glass/bottle/stabilizer

--- a/mods/content/bigpharma/_bigpharma.dm
+++ b/mods/content/bigpharma/_bigpharma.dm
@@ -43,9 +43,9 @@ var/global/list/reagent_names_to_icon_state
 		if(istype(thing, /obj/item/chems))
 			var/obj/item/chems/chems = thing
 			chems.label_text = new_name
-			chems.update_name_label()
+			chems.update_container_name()
 		else
 			thing.SetName(new_name)
 	if(meds.container_description)
 		thing.desc = meds.container_description
-	thing.update_icon()	
+	thing.update_icon()


### PR DESCRIPTION
## Description of changes
Refactors `show_reagent_name` into `presentation_flags`, with support for name and description (currently).

Adds helpers and functionality for showing cocktail and reagent descriptions on containers, and adds a framework for cocktails to have sprites.

## Why and what will this PR improve
Needed for downstream, and also cocktail descriptions weren't used, only set.

## Authorship
Me.

## Changelog
:cl:
add: Drinking glasses now show the description of either their cocktail or their primary reagent, if applicable.
/:cl: