### PR TITLE
Overdosing is now cumulative across reagent holders.

### DIFF
--- a/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
@@ -111,7 +111,7 @@
 	..()
 	ADJ_STATUS(M, STAT_CONFUSE, 1.5)
 
-/decl/material/liquid/heartstopper/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
+/decl/material/liquid/heartstopper/affect_overdose(var/mob/living/M)
 	..()
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -49,13 +49,6 @@
 			return stomach.ingested
 	return get_contact_reagents() // Kind of a shitty hack, but makes more sense to me than digesting them.
 
-/mob/living/carbon/human/metabolize_ingested_reagents()
-	if(should_have_organ(BP_STOMACH))
-		var/obj/item/organ/internal/stomach/stomach = get_organ(BP_STOMACH, /obj/item/organ/internal/stomach)
-		if(stomach)
-			stomach.metabolize()
-		return stomach?.ingested
-
 /mob/living/carbon/human/get_fullness()
 	if(!should_have_organ(BP_STOMACH))
 		return ..()

--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -86,14 +86,8 @@
 /obj/item/organ/internal/stomach/return_air()
 	return null
 
-// This call needs to be split out to make sure that all the ingested things are metabolised
-// before the process call is made on any of the other organs
-/obj/item/organ/internal/stomach/proc/metabolize()
-	if(is_usable())
-		ingested.metabolize()
-	
 #define STOMACH_VOLUME 65
-	
+
 /obj/item/organ/internal/stomach/Process()
 	..()
 
@@ -121,14 +115,14 @@
 			owner.custom_pain("Your stomach cramps agonizingly!",1)
 
 		var/alcohol_volume = REAGENT_VOLUME(ingested, /decl/material/liquid/ethanol)
-		
+
 		var/alcohol_threshold_met = alcohol_volume > STOMACH_VOLUME / 2
 		if(alcohol_threshold_met && (owner.disabilities & EPILEPSY) && prob(20))
 			owner.seizure()
-		
+
 		// Alcohol counts as double volume for the purposes of vomit probability
 		var/effective_volume = ingested.total_volume + alcohol_volume
-		
+
 		// Just over the limit, the probability will be low. It rises a lot such that at double ingested it's 64% chance.
 		var/vomit_probability = (effective_volume / STOMACH_VOLUME) ** 6
 		if(prob(vomit_probability))

--- a/code/modules/reagents/Chemistry-Metabolism.dm
+++ b/code/modules/reagents/Chemistry-Metabolism.dm
@@ -1,7 +1,6 @@
 /datum/reagents/metabolism
 	var/metabolism_class //CHEM_TOUCH, CHEM_INGEST, or CHEM_INJECT
 	var/mob/living/parent
-	var/last_metabolize_time = 0
 
 /datum/reagents/metabolism/clear_reagent(var/reagent_type, var/defer_update = FALSE, var/force = FALSE)
 	. = ..()
@@ -16,10 +15,10 @@
 	if(istype(parent_mob))
 		parent = parent_mob
 
-/datum/reagents/metabolism/proc/metabolize()
-	if(parent && world.time > last_metabolize_time)
-		last_metabolize_time = world.time // prevents mobs that reuse a holder between functions (ingested/injected) from metabolizing twice in a tick
-		for(var/rtype in reagent_volumes)
-			var/decl/material/current = GET_DECL(rtype)
-			current.on_mob_life(parent, metabolism_class, src)
-		update_total()
+/datum/reagents/metabolism/proc/metabolize(var/list/dosage_tracker)
+	if(!parent || total_volume < MINIMUM_CHEMICAL_VOLUME || !length(reagent_volumes))
+		return
+	for(var/rtype in reagent_volumes)
+		var/decl/material/current = GET_DECL(rtype)
+		current.on_mob_life(parent, metabolism_class, src, dosage_tracker)
+	update_total()

--- a/code/modules/reagents/chems/chems_compounds.dm
+++ b/code/modules/reagents/chems/chems_compounds.dm
@@ -34,7 +34,7 @@
 		addtimer(CALLBACK(H, /mob/living/carbon/human/proc/update_eyes), 5 SECONDS)
 	. = ..()
 
-/decl/material/liquid/glowsap/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
+/decl/material/liquid/glowsap/affect_overdose(var/mob/living/M)
 	. = ..()
 	M.add_chemical_effect(CE_TOXIN, 1)
 	M.set_hallucination(60, 20)

--- a/code/modules/reagents/chems/chems_drinks.dm
+++ b/code/modules/reagents/chems/chems_drinks.dm
@@ -346,7 +346,7 @@
 	..()
 	M.add_chemical_effect(CE_PULSE, 2)
 
-/decl/material/liquid/drink/coffee/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
+/decl/material/liquid/drink/coffee/affect_overdose(var/mob/living/M)
 	ADJ_STATUS(M, STAT_JITTER, 5)
 	M.add_chemical_effect(CE_PULSE, 1)
 

--- a/code/modules/reagents/chems/chems_drugs.dm
+++ b/code/modules/reagents/chems/chems_drugs.dm
@@ -55,7 +55,7 @@
 		LAZYSET(holder.reagent_data, type, world.time)
 		to_chat(M, "<span class='notice'>You feel invigorated and calm.</span>")
 
-/decl/material/liquid/nicotine/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
+/decl/material/liquid/nicotine/affect_overdose(var/mob/living/M)
 	..()
 	M.add_chemical_effect(CE_PULSE, 2)
 
@@ -221,7 +221,7 @@
 	if(istype(M))
 		M.remove_client_color(/datum/client_color/noir/thirdeye)
 
-/decl/material/liquid/glowsap/gleam/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
+/decl/material/liquid/glowsap/gleam/affect_overdose(var/mob/living/M)
 	M.adjustBrainLoss(rand(1, 5))
 	if(ishuman(M) && prob(10))
 		var/mob/living/carbon/human/H = M

--- a/code/modules/reagents/chems/chems_ethanol.dm
+++ b/code/modules/reagents/chems/chems_ethanol.dm
@@ -199,7 +199,7 @@
 	if(M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 
-/decl/material/liquid/ethanol/coffee/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
+/decl/material/liquid/ethanol/coffee/affect_overdose(var/mob/living/M)
 	ADJ_STATUS(M, STAT_JITTER, 5)
 
 /decl/material/liquid/ethanol/melonliquor

--- a/code/modules/reagents/chems/chems_medicines.dm
+++ b/code/modules/reagents/chems/chems_medicines.dm
@@ -150,7 +150,7 @@
 		var/mob/living/carbon/human/H = M
 		H.immunity = min(H.immunity_norm * 0.5, removed + H.immunity) // Rapidly brings someone up to half immunity.
 
-/decl/material/liquid/immunobooster/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
+/decl/material/liquid/immunobooster/affect_overdose(var/mob/living/M)
 	..()
 	M.add_chemical_effect(CE_TOXIN, 1)
 	var/mob/living/carbon/human/H = M
@@ -226,7 +226,7 @@
 	if(LAZYACCESS(H.chem_doses, type) > 15)
 		H.immunity = max(H.immunity - 0.25, 0)
 
-/decl/material/liquid/antibiotics/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
+/decl/material/liquid/antibiotics/affect_overdose(var/mob/living/M)
 	..()
 	var/mob/living/carbon/human/H = M
 	if(!istype(H))

--- a/code/modules/reagents/chems/chems_painkillers.dm
+++ b/code/modules/reagents/chems/chems_painkillers.dm
@@ -93,7 +93,7 @@
 		M.add_chemical_effect(CE_ALCOHOL_TOXIC, 1)
 		M.add_chemical_effect(CE_BREATHLOSS, 1 * boozed) //drinking and opiating suppresses breathing.
 
-/decl/material/liquid/painkillers/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
+/decl/material/liquid/painkillers/affect_overdose(var/mob/living/M)
 	..()
 	if(!narcotic)
 		return

--- a/mods/content/psionics/datum/chems.dm
+++ b/mods/content/psionics/datum/chems.dm
@@ -2,7 +2,7 @@
 	var/decl/special_role/wizard/wizards = GET_DECL(/decl/special_role/wizard)
 	. = (M.psi || (M.mind && wizards.is_antagonist(M.mind))) ? MAT_NULLGLASS : ..()
 
-/decl/material/liquid/glowsap/gleam/affect_overdose(var/mob/living/M, var/datum/reagents/holder)
+/decl/material/liquid/glowsap/gleam/affect_overdose(var/mob/living/M)
 	..()
 	if(M.psi)
 		M.psi.check_latency_trigger(30, "a [name] overdose")

--- a/mods/content/xenobiology/slime/life.dm
+++ b/mods/content/xenobiology/slime/life.dm
@@ -51,7 +51,7 @@
 			adjustBruteLoss(-1)
 
 /mob/living/slime/proc/handle_turf_contents()
-	// If we're standing on top of a dead mob or small items, we can 
+	// If we're standing on top of a dead mob or small items, we can
 	// ingest it (or just melt it a little if we're too small)
 	// Also helps to keep our cell tidy!
 	if(!length(loc?.contents))
@@ -98,7 +98,7 @@
 					adjust_nutrition(M.eaten_by_slime(src))
 					queue_icon_update()
 				break
-			
+
 			if(istype(AM, /obj/item/remains))
 				if(prob(5))
 					adjust_nutrition(rand(2,3))


### PR DESCRIPTION
## Description of changes
- Unique metabolism holders will only call `metabolize()` once each during life ticks.
- Overdosing values are checked against total reagents across all holders, not per holder.

Thanks to @yawet330 for pointing out the issue with the inhaled reagent holder.

## Why and what will this PR improve
Simplifies some reagent processing logic and removes the balance problems with splitting dosage between holders.

## Authorship
Myself.

## Changelog
:cl:
tweak: Overdosing is now calculated across all reagent holders (blood and ingested) rather than per holder.
/:cl:
