### PR TITLE
Fix ChangeTurf overwriting ambient lights improperly

### DIFF
--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -36,7 +36,8 @@
 			ChangeArea(src, owner.planetary_area)
 
 	. = ..(mapload)	// second param is our own, don't pass to children
-	setup_environmental_lighting()
+	if (mapload)
+		setup_environmental_lighting()
 
 	var/air_graphic = get_air_graphic()
 	if(length(air_graphic))

--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -227,6 +227,16 @@
 		//Otherwise the right side of the exoplanet can get stuck in a forever day.
 		daycycle = rand(10 MINUTES, 40 MINUTES)
 
+	// This was formerly done in Initialize, but that caused problems with ChangeTurf. The initialize logic is now
+	// mapload-only, and so the exoplanet step (which uses ChangeTurf) has to be done here.
+	for(var/target_z in map_z)
+		for(var/turf/exterior/exterior_turf in block(
+			locate(TRANSITIONEDGE, TRANSITIONEDGE, target_z),
+			locate(world.maxx - TRANSITIONEDGE, world.maxy - TRANSITIONEDGE, target_z)
+		))
+			exterior_turf.setup_environmental_lighting()
+			CHECK_TICK
+
 //Tries to generate num landmarks, but avoids repeats.
 /obj/effect/overmap/visitable/sector/exoplanet/proc/generate_landing()
 	var/places = list()


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Splits the code that calls `setup_environmental_lighting()` up into two separate locations:
- /turf/exterior/Initialize() when `mapload` is `TRUE` (compiled or loaded maps)
- `/obj/effect/overmap/visitable/sector/exoplanet/proc/generate_daycycle()` for exoplanet generation

This prevents improper overwrites of ambient lights due to ChangeTurf calls in map loading, which caused desyncs of turf and corner lighting values and ugly lighting artifacts.
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
Fixes lighting artifacts and improper `setup_environmental_lighting()` calls.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Me.
<!-- Describe original authors of changes to credit them. -->