### PR TITLE
Welderpack rewrite + welder tanks now chems

### DIFF
--- a/code/datums/extensions/assembly/assembly_interaction.dm
+++ b/code/datums/extensions/assembly/assembly_interaction.dm
@@ -20,7 +20,7 @@
 			return TRUE
 
 		to_chat(user, "You begin repairing damage to \the [holder]...")
-		if(WT.remove_fuel(round(damage/75)) && do_after(usr, damage/10))
+		if(WT.weld(round(damage/75)) && do_after(usr, damage/10))
 			damage = 0
 			to_chat(user, "You repair \the [holder].")
 		return TRUE

--- a/code/game/machinery/_machines_base/machine_construction/frame.dm
+++ b/code/game/machinery/_machines_base/machine_construction/frame.dm
@@ -20,7 +20,7 @@
 			machine.anchored = TRUE
 	if(IS_WELDER(I))
 		var/obj/item/weldingtool/WT = I
-		if(!WT.remove_fuel(0, user))
+		if(!WT.weld(0, user))
 			to_chat(user, "The welding tool must be on to complete this task.")
 			return TRUE
 		playsound(machine.loc, 'sound/items/Welder.ogg', 50, 1)

--- a/code/game/machinery/_machines_base/machine_construction/pipe.dm
+++ b/code/game/machinery/_machines_base/machine_construction/pipe.dm
@@ -28,7 +28,7 @@
 		var/obj/item/weldingtool/WT = I
 		if(!WT.isOn())
 			return FALSE
-		if(!WT.remove_fuel(0,user))
+		if(!WT.weld(0,user))
 			return FALSE
 		var/fail = machine.cannot_transition_to(/decl/machine_construction/default/deconstructed, user)
 		if(istext(fail))

--- a/code/game/machinery/doors/_door.dm
+++ b/code/game/machinery/doors/_door.dm
@@ -279,7 +279,7 @@
 			return TRUE
 
 		var/obj/item/weldingtool/welder = I
-		if(welder.remove_fuel(0,user))
+		if(welder.weld(0,user))
 			to_chat(user, "<span class='notice'>You start to fix dents and weld \the [repairing] into place.</span>")
 			playsound(src, 'sound/items/Welder.ogg', 100, 1)
 			if(do_after(user, 5 * repairing.amount, src) && welder && welder.isOn())

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -633,7 +633,7 @@ About the new airlock wires panel:
 
 	if(IS_WELDER(item))
 		var/obj/item/weldingtool/WT = item
-		if(!WT.remove_fuel(0,user))
+		if(!WT.weld(0,user))
 			return FALSE
 		cut_verb = "cutting"
 		cut_sound = 'sound/items/Welder.ogg'
@@ -742,7 +742,7 @@ About the new airlock wires panel:
 
 	if(!repairing && IS_WELDER(C) && !operating && density)
 		var/obj/item/weldingtool/W = C
-		if(!W.remove_fuel(0,user))
+		if(!W.weld(0,user))
 			to_chat(user, SPAN_NOTICE("Your [W.name] doesn't have enough fuel."))
 			return TRUE
 		playsound(src, 'sound/items/Welder.ogg', 50, 1)

--- a/code/game/machinery/doors/braces.dm
+++ b/code/game/machinery/doors/braces.dm
@@ -105,7 +105,7 @@
 		if(health == max_health)
 			to_chat(user, "\The [src] does not require repairs.")
 			return
-		if(C.remove_fuel(0,user))
+		if(C.weld(0,user))
 			playsound(src, 'sound/items/Welder.ogg', 100, 1)
 			health = min(health + rand(20,30), max_health)
 			if(health == max_health)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -212,7 +212,7 @@
 		return//Already doing something.
 	if(IS_WELDER(C) && !repairing)
 		var/obj/item/weldingtool/W = C
-		if(W.remove_fuel(0, user))
+		if(W.weld(0, user))
 			playsound(src, 'sound/items/Welder.ogg', 100, 1)
 			if(do_after(user, 2 SECONDS, src))
 				if(!W.isOn()) return

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -37,7 +37,7 @@ var/global/list/floor_light_cache = list()
 		visible_message("<span class='notice'>\The [user] has [anchored ? "attached" : "detached"] \the [src].</span>")
 	else if(IS_WELDER(W) && (damaged || (stat & BROKEN)))
 		var/obj/item/weldingtool/WT = W
-		if(!WT.remove_fuel(0, user))
+		if(!WT.weld(0, user))
 			to_chat(user, "<span class='warning'>\The [src] must be on to complete this task.</span>")
 			return
 		playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -94,7 +94,7 @@ var/global/bomb_set
 					user.visible_message("[user] starts cutting loose the anchoring bolt covers on [src].", "You start cutting loose the anchoring bolt covers with [O]...")
 
 					if(do_after(user,40, src))
-						if(!src || !user || !WT.remove_fuel(5, user)) return
+						if(!src || !user || !WT.weld(5, user)) return
 						user.visible_message("\The [user] cuts through the bolt covers on \the [src].", "You cut through the bolt cover.")
 						removal_stage = 1
 				return
@@ -120,7 +120,7 @@ var/global/bomb_set
 					user.visible_message("[user] starts cutting apart the anchoring system sealant on [src].", "You start cutting apart the anchoring system's sealant with [O]...")
 
 					if(do_after(user, 40, src))
-						if(!src || !user || !WT.remove_fuel(5, user)) return
+						if(!src || !user || !WT.weld(5, user)) return
 						user.visible_message("\The [user] cuts apart the anchoring system sealant on \the [src].", "You cut apart the anchoring system's sealant.")
 						removal_stage = 3
 				return

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -686,7 +686,7 @@ var/global/list/turret_icons
 
 				playsound(loc, pick('sound/items/Welder.ogg', 'sound/items/Welder2.ogg'), 50, 1)
 				if(do_after(user, 20, src))
-					if(!src || !WT.remove_fuel(5, user)) return
+					if(!src || !WT.weld(5, user)) return
 					build_step = 1
 					to_chat(user, "You remove the turret's interior metal armor.")
 					SSmaterials.create_object(/decl/material/solid/metal/steel, loc, 2)
@@ -763,7 +763,7 @@ var/global/list/turret_icons
 
 				playsound(loc, pick('sound/items/Welder.ogg', 'sound/items/Welder2.ogg'), 50, 1)
 				if(do_after(user, 30, src))
-					if(!src || !WT.remove_fuel(5, user))
+					if(!src || !WT.weld(5, user))
 						return
 					build_step = 8
 					to_chat(user, "<span class='notice'>You weld the turret's armor down.</span>")

--- a/code/game/machinery/self_destruct.dm
+++ b/code/game/machinery/self_destruct.dm
@@ -14,8 +14,8 @@
 		if(damaged)
 			user.visible_message("[user] begins to repair [src].", "You begin repairing [src].")
 			if(do_after(usr, 100, src))
-				var/obj/item/weldingtool/w
-				if(w.burn_fuel(10))
+				var/obj/item/weldingtool/w = W
+				if(w.weld(10))
 					damaged = 0
 					user.visible_message("[user] repairs [src].", "You repair [src].")
 				else

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -50,7 +50,7 @@
 	if(IS_WELDER(W))
 		var/obj/item/weldingtool/WT = W
 
-		if(WT.remove_fuel(0, user))
+		if(WT.weld(0, user))
 			damage = 15
 			playsound(loc, 'sound/items/Welder.ogg', 100, 1)
 

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -19,7 +19,7 @@
 /obj/item/target/attackby(var/obj/item/W, var/mob/user)
 	if(IS_WELDER(W))
 		var/obj/item/weldingtool/WT = W
-		if(WT.remove_fuel(0, user))
+		if(WT.weld(0, user))
 			overlays.Cut()
 			bulletholes.Cut()
 			hp = initial(hp)

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -62,7 +62,7 @@
 			to_chat(user, "<span class='warning'>You need at least two rods to do this.</span>")
 			return
 
-		if(WT.remove_fuel(0,user))
+		if(WT.weld(0,user))
 			visible_message(SPAN_NOTICE("\The [src] is fused together by \the [user] with \the [WT]."), 3, SPAN_NOTICE("You hear welding."), 2)
 			for(var/obj/item/stack/material/new_item in SSmaterials.create_object((material?.type || /decl/material/solid/metal/steel), usr.loc, 1))
 				new_item.add_to_stacks(usr)

--- a/code/game/objects/items/weapons/electric_welder.dm
+++ b/code/game/objects/items/weapons/electric_welder.dm
@@ -40,14 +40,11 @@
 			. = module.holder.get_cell()
 
 /obj/item/weldingtool/electric/get_fuel()
-	return get_available_charge()
-
-/obj/item/weldingtool/electric/proc/get_available_charge()
 	var/obj/item/cell/cell = get_cell()
 	return cell ? cell.charge : 0
 
 /obj/item/weldingtool/electric/attackby(var/obj/item/W, var/mob/user)
-	if(istype(W,/obj/item/stack/material/rods) || istype(W, /obj/item/welder_tank))
+	if(istype(W,/obj/item/stack/material/rods) || istype(W, /obj/item/chems/welder_tank))
 		return
 	if(IS_SCREWDRIVER(W))
 		if(cell)
@@ -71,18 +68,13 @@
 		return
 	. = ..()
 
-/obj/item/weldingtool/electric/burn_fuel(var/amount)
-	spend_charge(amount * fuel_cost_multiplier)
-	var/turf/T = get_turf(src)
-	if(T) 
-		T.hotspot_expose(700, 5)
+/obj/item/weldingtool/electric/use_fuel(var/amount)
+	var/obj/item/cell/cell = get_cell()
+	if(cell)
+		return cell.use(amount * CELLRATE) > 0
+	return FALSE
 
 /obj/item/weldingtool/electric/on_update_icon()
 	. = ..()
 	if(cell)
 		add_overlay("[icon_state]-cell")
-
-/obj/item/weldingtool/electric/proc/spend_charge(var/amount)
-	var/obj/item/cell/cell = get_cell()
-	if(cell)
-		cell.use(amount * CELLRATE)

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -66,7 +66,7 @@
 /obj/item/shard/attackby(obj/item/W, mob/user)
 	if(IS_WELDER(W) && material.shard_can_repair)
 		var/obj/item/weldingtool/WT = W
-		if(WT.remove_fuel(0, user))
+		if(WT.weld(0, user))
 			material.create_object(get_turf(src))
 			qdel(src)
 			return

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -26,7 +26,7 @@
 		/obj/item/extinguisher/mini,
 		/obj/item/radio,
 		/obj/item/weldingtool/mini,
-		/obj/item/welder_tank/mini
+		/obj/item/chems/welder_tank/mini
 	)
 
 /obj/item/storage/toolbox/emergency/Initialize()

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -191,7 +191,7 @@ var/global/list/global/tank_gauge_cache = list()
 
 	if(IS_WELDER(W))
 		var/obj/item/weldingtool/WT = W
-		if(WT.remove_fuel(1,user))
+		if(WT.weld(1,user))
 			if(!valve_welded)
 				to_chat(user, "<span class='notice'>You begin welding the \the [src] emergency pressure relief valve.</span>")
 				if(do_after(user, 40,src))

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -1,41 +1,46 @@
+#define WELDING_TOOL_HOTSPOT_TEMP_ACTIVE 700
+#define WELDING_TOOL_HOTSPOT_TEMP_IDLE   400
+
 /obj/item/weldingtool
-	name = "welding tool"
-	icon = 'icons/obj/items/tool/welders/welder.dmi'
-	icon_state = ICON_STATE_WORLD
-	desc = "A portable welding gun with a port for attaching fuel tanks."
-	obj_flags = OBJ_FLAG_CONDUCTIBLE
-	slot_flags = SLOT_LOWER_BODY
-	center_of_mass = @"{'x':14,'y':15}"
-	force = 5
-	throwforce = 5
-	throw_speed = 1
-	throw_range = 5
-	w_class = ITEM_SIZE_SMALL
-	material = /decl/material/solid/metal/steel
-	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
-	origin_tech = "{'engineering':1}"
-	drop_sound = 'sound/foley/tooldrop1.ogg'
-	z_flags = ZMM_MANGLE_PLANES
-
-	var/lit_colour = COLOR_PALE_ORANGE
-	var/waterproof = FALSE
-	var/welding = 0 	//Whether or not the welding tool is off(0), on(1) or currently welding(2)
-	var/status = 1 		//Whether the welder is secured or unsecured (able to attach rods to it to make a flamethrower)
-	var/welding_resource = "welding fuel"
-	var/obj/item/welder_tank/tank = /obj/item/welder_tank // where the fuel is stored
-
-	var/activate_sound = 'sound/items/welderactivate.ogg'
-	var/deactivate_sound = 'sound/items/welderdeactivate.ogg'
+	name                                = "welding tool"
+	desc                                = "A portable welding gun with a port for attaching fuel tanks."
+	icon                                = 'icons/obj/items/tool/welders/welder.dmi'
+	icon_state                          = ICON_STATE_WORLD
+	obj_flags                           = OBJ_FLAG_CONDUCTIBLE
+	slot_flags                          = SLOT_LOWER_BODY
+	center_of_mass                      = @"{'x':14,'y':15}"
+	force                               = 5
+	throwforce                          = 5
+	throw_speed                         = 1
+	throw_range                         = 5
+	w_class                             = ITEM_SIZE_SMALL
+	material                            = /decl/material/solid/metal/steel
+	matter                              = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
+	origin_tech                         = "{'engineering':1}"
+	drop_sound                          = 'sound/foley/tooldrop1.ogg'
+	z_flags                             = ZMM_MANGLE_PLANES
+	attack_cooldown                     = DEFAULT_ATTACK_COOLDOWN
+	var/lit_colour                      = COLOR_PALE_ORANGE
+	var/waterproof                      = FALSE
+	var/welding                         = FALSE 	//Whether or not the welding tool is off(0), on(1) or currently welding(2)
+	var/status                          = TRUE 		//Whether the welder is secured or unsecured (able to attach rods to it to make a flamethrower)
+	var/tmp/welding_resource            = "welding fuel"
+	var/obj/item/chems/welder_tank/tank = /obj/item/chems/welder_tank // where the fuel is stored
+	var/tmp/activate_sound              = 'sound/items/welderactivate.ogg'
+	var/tmp/deactivate_sound            = 'sound/items/welderdeactivate.ogg'
 
 /obj/item/weldingtool/Initialize()
 	if(ispath(tank))
-		tank = new tank
-		w_class = tank.size_in_use
-		force = tank.unlit_force
+		insert_tank(new tank, null, TRUE, TRUE)
 	set_extension(src, /datum/extension/tool, list(TOOL_WELDER = TOOL_QUALITY_DEFAULT))
 	set_extension(src, /datum/extension/base_icon_state, icon_state)
-	update_icon()
 	. = ..()
+	update_icon()
+
+/obj/item/weldingtool/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	QDEL_NULL(tank)
+	return ..()
 
 /obj/item/weldingtool/dropped(mob/user)
 	. = ..()
@@ -46,12 +51,6 @@
 	. = ..()
 	if(welding)
 		update_icon()
-
-/obj/item/weldingtool/Destroy()
-	if(welding)
-		STOP_PROCESSING(SSobj, src)
-	QDEL_NULL(tank)
-	return ..()
 
 /obj/item/weldingtool/adjust_mob_overlay(var/mob/living/user_mob, var/bodytype,  var/image/overlay, var/slot, var/bodypart)
 	if(overlay && welding && check_state_in_icon("[overlay.icon_state]-lit", overlay.icon))
@@ -66,46 +65,78 @@
 
 /obj/item/weldingtool/examine(mob/user, distance)
 	. = ..()
-	if (!tank)
-		to_chat(user, "There is no [welding_resource] source attached.")
-	else
-		to_chat(user, (distance <= 1 ? "It has [get_fuel()] [welding_resource] remaining. " : "") + "[tank] is attached.")
+	if (tank)
+		to_chat(user, (distance <= 1 ? "It has [round(get_fuel(), 0.1)] [welding_resource] remaining. " : "") + "[tank] is attached.")
 
-/obj/item/weldingtool/handle_mouse_drop(atom/over, mob/user)
-	if(istype(over, /obj/item/weldpack))
-		var/obj/item/weldpack/wp = over
-		if(wp.welder)
-			to_chat(user, SPAN_WARNING("\The [wp] already has \a [wp.welder] attached."))
-			return TRUE
-		if(user.unEquip(src, wp))
-			wp.welder = src
-			user.visible_message( \
-				SPAN_NOTICE("\The [user] attaches \the [src] to \the [wp]."), \
-				SPAN_NOTICE("You attach \the [src] to \the [wp]."))
-			wp.update_icon()
-			return TRUE
-	. = ..()
-
-/obj/item/weldingtool/attackby(obj/item/W, mob/user)
-	if(welding)
-		to_chat(user, SPAN_WARNING("Stop welding first!"))
+/obj/item/weldingtool/proc/insert_tank(var/obj/item/chems/welder_tank/T, var/mob/user, var/no_updates = FALSE, var/quiet = FALSE)
+	if(tank && !ispath(tank))
+		if(user && !quiet)
+			to_chat(user, SPAN_WARNING("\The [src] already has a tank attached - remove it first."))
 		return
 
-	if(IS_SCREWDRIVER(W))
-		if(isrobot(loc))
-			to_chat(user, SPAN_WARNING("You cannot modify your own welder!"))
-			return
+	if(user && !(src in user.get_held_items()))
+		if(user && !quiet)
+			to_chat(user, SPAN_WARNING("You must hold the welder in your hands to attach a tank."))
+		return
+	
+	if(user && !user.unEquip(T, src))
+		return
 
-		status = !status
-		
+	tank    = T
+	w_class = tank.size_in_use
+	force   = tank.unlit_force
+	if(user && !quiet)
+		user.visible_message("[user] slots \a [T] into \the [src].", "You slot \a [T] into \the [src].")
+
+	if(!quiet)
+		playsound(loc, 'sound/effects/hypospray.ogg', 50, TRUE)
+	if(!no_updates)
+		update_icon()
+	return TRUE
+
+/obj/item/weldingtool/proc/remove_tank(var/mob/user)
+	if(!tank || ispath(tank))
+		if(user)
+			to_chat(user, SPAN_WARNING("\The [src] doesn't have a tank attached."))
+		return
+
+	if(welding)
+		if(user)
+			to_chat(user, SPAN_WARNING("Stop welding first."))
+		return 
+
+	if(user && !user.is_holding_offhand(src))
+		if(user)
+			to_chat(user, SPAN_WARNING("You must hold the welder in your hands to detach its tank."))
+		return
+
+	if(user)
+		user.put_in_hands(tank)
+		user.visible_message("[user] removes \the [tank] from \the [src].", "You remove \the [tank] from \the [src].")
+	else
+		tank.dropInto(get_turf(src))
+
+	tank    = null
+	w_class = initial(w_class)
+	force   = initial(force)
+	update_icon()
+	return TRUE
+
+/obj/item/weldingtool/proc/toggle_unscrewed(var/mob/user)
+	if(isrobot(loc))
+		if(user)
+			to_chat(user, SPAN_WARNING("You cannot modify your own welder!"))
+		return
+
+	status = !status
+	if(user)
 		if(status)
 			to_chat(user, SPAN_NOTICE("You secure the welder."))
 		else
 			to_chat(user, SPAN_NOTICE("The welder can now be attached and modified."))
+	return TRUE
 
-		add_fingerprint(user)
-		return
-
+/obj/item/weldingtool/proc/attempt_modify(var/obj/item/W, var/mob/user)
 	if(!status && istype(W, /obj/item/stack/material/rods))
 		var/obj/item/stack/material/rods/R = W
 		R.use(1)
@@ -114,127 +145,123 @@
 		qdel(src)
 		return TRUE
 
-	if (istype(W, /obj/item/welder_tank))
-		if(tank)
-			to_chat(user, SPAN_WARNING("\The [src] already has a tank attached - remove it first."))
-			return
-
-		if(!(src in user.get_held_items()))
-			to_chat(user, SPAN_WARNING("You must hold the welder in your hands to attach a tank."))
-			return
-		
-		if(!user.unEquip(W, src))
-			return
-
-		tank = W
-		user.visible_message("[user] slots \a [W] into \the [src].", "You slot \a [W] into \the [src].")
-		w_class = tank.size_in_use
-		force = tank.unlit_force
-		update_icon()
+/obj/item/weldingtool/attackby(obj/item/W, mob/user)
+	if(welding)
+		to_chat(user, SPAN_WARNING("Stop welding first!"))
 		return
 
-	..()
+	if (istype(W, /obj/item/chems/welder_tank))
+		return insert_tank(W, user)
 
+	if(IS_SCREWDRIVER(W))
+		return toggle_unscrewed(user)
+
+	if(attempt_modify(W, user))
+		return TRUE
+
+	return ..()
 
 /obj/item/weldingtool/attack_hand(mob/user)
 	if (tank && user.is_holding_offhand(src))
-		if (!welding)
-			user.visible_message("[user] removes \the [tank] from \the [src].", "You remove \the [tank] from \the [src].")
-			user.put_in_hands(tank)
-			tank = null
-			w_class = initial(w_class)
-			force = initial(force)
-			update_icon()
-		else
-			to_chat(user, SPAN_DANGER("Turn off the welder first!"))
-
-	else
-		..()
+		return remove_tank(user)
+	return ..()
 
 /obj/item/weldingtool/fluid_act(var/datum/reagents/fluids)
 	..()
 	if(welding && !waterproof)
-		setWelding(0)
+		turn_off()
 
 /obj/item/weldingtool/Process()
-	if(welding)
-		if((!waterproof && submerged()) || !remove_fuel(0.05))
-			setWelding(0)
+	if(!(welding && idling()))
+		return PROCESS_KILL
 
-/obj/item/weldingtool/afterattack(var/obj/O, var/mob/user, proximity)
+/obj/item/weldingtool/afterattack(var/obj/O, var/mob/user, proximity, click_parameters)
 	if(!proximity)
 		return
 
-	if(istype(O, /obj/structure/reagent_dispensers/fueltank) && get_dist(src,O) <= 1 && !welding)
+	if(istype(O, /obj/structure/reagent_dispensers/fueltank) && !welding)
 		if(!tank)
 			to_chat(user, SPAN_WARNING("\The [src] has no tank attached!"))
 			return
-		if (!tank.can_refuel)
-			to_chat(user, SPAN_WARNING("\The [tank] does not have a refuelling port."))
-			return
-		O.reagents.trans_to_obj(tank, tank.max_fuel)
-		to_chat(user, SPAN_NOTICE("You refuel \the [tank]."))
-		playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
-		return
+		return tank.afterattack(O, user, proximity, click_parameters)
 
 	if(welding)
-		remove_fuel(1)
+		weld(1)
 		var/turf/location = get_turf(user)
 		if(isliving(O))
 			var/mob/living/L = O
 			L.IgniteMob()
 		else if(istype(O))
-			O.HandleObjectHeating(src, user, 700)
+			O.HandleObjectHeating(src, user, WELDING_TOOL_HOTSPOT_TEMP_ACTIVE)
 		if (isturf(location))
-			location.hotspot_expose(700, 50, 1)
-	return
+			location.hotspot_expose(WELDING_TOOL_HOTSPOT_TEMP_ACTIVE, 50, 1)
+		spark_at(get_turf(O), 3, FALSE, O)
+		user.setClickCooldown(attack_cooldown + w_class) //Prevent spam
+		return TRUE
+	return ..()
 
 /obj/item/weldingtool/attack_self(mob/user)
-	setWelding(!welding, usr)
-	return
+	toggle(user)
+	return TRUE
 
 //Returns the amount of fuel in the welder
 /obj/item/weldingtool/proc/get_fuel()
 	return tank ? REAGENT_VOLUME(tank.reagents, /decl/material/liquid/fuel) : 0
 
-//Removes fuel from the welding tool. If a mob is passed, it will perform an eyecheck on the mob. This should probably be renamed to use()
-/obj/item/weldingtool/proc/remove_fuel(var/amount = 1, var/mob/M = null)
+//Removes fuel from the welding tool. If a mob is passed, it will perform an eyecheck on the mob. 
+/obj/item/weldingtool/proc/weld(var/fuel_usage = 1, var/mob/user = null)
 	if(!welding)
-		return 0
-	if(get_fuel() >= amount)
-		burn_fuel(amount)
-		if(M)
-			M.welding_eyecheck()//located in mob_helpers.dm
-			set_light(5, 0.7, COLOR_LIGHT_CYAN)
-			addtimer(CALLBACK(src, /atom/proc/update_icon), 5)
-		return 1
-	else
-		if(M)
-			to_chat(M, SPAN_NOTICE("You need more [welding_resource] to complete this task."))
-		return 0
-
-/obj/item/weldingtool/proc/burn_fuel(var/amount)
-	if(!tank)
+		return 
+	if(get_fuel() < fuel_usage)
+		if(user)
+			to_chat(user, SPAN_NOTICE("You need more [welding_resource] to complete this task."))
 		return
 
-	var/mob/living/in_mob = null
+	use_fuel(fuel_usage)
+	if(user)
+		user.welding_eyecheck()
+
+	var/turf/location = get_turf(src)
+	if(location)
+		location.hotspot_expose(WELDING_TOOL_HOTSPOT_TEMP_ACTIVE, 5)
+	set_light(5, 0.7, COLOR_LIGHT_CYAN)
+	addtimer(CALLBACK(src, /atom/proc/update_icon), 5)
+	return TRUE
+
+/**Handle the flame burning fuel while the welder is on */
+/obj/item/weldingtool/proc/idling(var/fuel_usage = 0.5)
+	if(!welding)
+		return 
+	if((!waterproof && submerged()) || (get_fuel() < fuel_usage))
+		turn_off()
+		return
 
 	//consider ourselves in a mob if we are in the mob's contents and not in their hands
-	if(isliving(src.loc))
-		var/mob/living/L = src.loc
+	if(isliving(loc))
+		var/mob/living/L = loc
 		if(!(src in L.get_held_items()))
-			in_mob = L
+			fuel_usage = max(fuel_usage, 2)
+			L.IgniteMob()
 
-	if(in_mob)
-		amount = max(amount, 2)
-		tank.reagents.trans_type_to(in_mob, /decl/material/liquid/fuel, amount)
-		in_mob.IgniteMob()
+	else if(isobj(loc))
+		var/obj/O = loc
+		O.HandleObjectHeating(src, null, WELDING_TOOL_HOTSPOT_TEMP_IDLE)
+	
+	else if(isturf(loc))
+		var/turf/location = get_turf(src)
+		location.hotspot_expose(WELDING_TOOL_HOTSPOT_TEMP_IDLE, 5) //a bit colder when idling
 
+	if(use_fuel(fuel_usage))
+		return TRUE
 	else
+		turn_off()
+
+/obj/item/weldingtool/proc/use_fuel(var/amount)
+	. = TRUE
+	if(get_fuel() < amount)
+		. = FALSE //Try to burn as much as possible anyways
+	if(tank)
 		tank.reagents.remove_reagent(/decl/material/liquid/fuel, amount)
-		var/turf/location = get_turf(src.loc)
-		if(location)
-			location.hotspot_expose(700, 5)
 
 //Returns whether or not the welding tool is currently on.
 /obj/item/weldingtool/proc/isOn()
@@ -259,54 +286,58 @@
 		set_light(0)
 	update_held_icon()
 
-//Sets the welding state of the welding tool. If you see W.welding = 1 anywhere, please change it to W.setWelding(1)
-//so that the welding tool updates accordingly
-/obj/item/weldingtool/proc/setWelding(var/set_welding, var/mob/M)
+/**Handles updating damage depening on whether the welder is on or off */
+/obj/item/weldingtool/proc/update_physical_damage()
+	if(isOn())
+		force   = tank ? tank.lit_force : initial(force)
+		damtype = BURN
+	else
+		damtype = BRUTE
+		force   = tank? tank.unlit_force : initial(force)
+
+/obj/item/weldingtool/proc/turn_on(var/mob/user)
 	if (!status)
 		return
-
-	if(!welding && !waterproof && submerged())
-		if(M)
-			to_chat(M, SPAN_WARNING("You cannot light \the [src] underwater."))
+	if(!waterproof && submerged())
+		if(user)
+			to_chat(user, SPAN_WARNING("You cannot light \the [src] underwater."))
+		return
+	if(get_fuel() <= 0)
+		if(user)
+			to_chat(user, SPAN_NOTICE("You need [welding_resource] to light \the [src]."))
 		return
 
-	var/turf/T = get_turf(src)
-	//If we're turning it on
-	if(set_welding && !welding)
-		if (get_fuel() > 0)
-			if(M)
-				to_chat(M, SPAN_NOTICE("You switch the [src] on."))
-			else if(T)
-				T.visible_message(SPAN_WARNING("\The [src] turns on."))
-			if (istype(src, /obj/item/weldingtool/electric))
-				src.force = 11
-				src.damtype = ELECTROCUTE
-			else
-				src.force = tank.lit_force
-				src.damtype = BURN
-			playsound(src, activate_sound, 50, 1)
-			welding = 1
-			update_icon()
-			START_PROCESSING(SSobj, src)
-		else
-			if(M)
-				to_chat(M, SPAN_NOTICE("You need more [welding_resource] to complete this task."))
-			return
-	//Otherwise
-	else if(!set_welding && welding)
-		STOP_PROCESSING(SSobj, src)
-		if(M)
-			to_chat(M, SPAN_NOTICE("You switch \the [src] off."))
-		else if(T)
-			T.visible_message(SPAN_WARNING("\The [src] turns off."))
-		if (istype(src, /obj/item/weldingtool/electric))
-			src.force = initial(force)
-		else
-			src.force = tank.unlit_force
-		playsound(src, deactivate_sound, 50, 1)
-		src.damtype = BRUTE
-		src.welding = 0
-		update_icon()
+	if(user)
+		user.visible_message(SPAN_NOTICE("\The [user] turns \the [src] on."), SPAN_NOTICE("You turn on \the [src]."))
+	else
+		visible_message(SPAN_WARNING("\The [src] turns on."))
+	
+	update_physical_damage()
+	playsound(src, activate_sound, 50, TRUE)
+	welding = TRUE
+	update_icon()
+	START_PROCESSING(SSobj, src)
+	return TRUE
+
+/obj/item/weldingtool/proc/turn_off(var/mob/user)
+	STOP_PROCESSING(SSobj, src)
+
+	if(user)
+		user.visible_message(SPAN_NOTICE("\The [user] turns \the [src] off."), SPAN_NOTICE("You switch \the [src] off."))
+	else
+		visible_message(SPAN_WARNING("\The [src] turns off."))
+
+	update_physical_damage()
+	playsound(src, deactivate_sound, 50, TRUE)
+	welding = FALSE
+	update_icon()
+	return TRUE
+
+/obj/item/weldingtool/proc/toggle(var/mob/user)
+	if(welding)
+		return turn_off(user)
+	else
+		return turn_on(user)
 
 /obj/item/weldingtool/attack(mob/living/M, mob/living/user, target_zone)
 	if(ishuman(M))
@@ -318,15 +349,15 @@
 
 		if(BP_IS_BRITTLE(S))
 			to_chat(user, SPAN_WARNING("\The [M]'s [S.name] is hard and brittle - \the [src]  cannot repair it."))
-			return 1
+			return TRUE
 
 		if(!welding)
 			to_chat(user, SPAN_WARNING("You'll need to turn [src] on to patch the damage on [M]'s [S.name]!"))
-			return 1
+			return TRUE
 
 		if(S.robo_repair(15, BRUTE, "some dents", src, user))
-			remove_fuel(1, user)
-
+			weld(1, user)
+			return TRUE
 	else
 		return ..()
 
@@ -335,110 +366,171 @@
 		return list("jet of flame")
 	return ..()
 
+//////////////////////////////////////////////////////////////////
+// Welding Tool Variants
+//////////////////////////////////////////////////////////////////
 /obj/item/weldingtool/mini
-	tank = /obj/item/welder_tank/mini
+	tank = /obj/item/chems/welder_tank/mini
 
 /obj/item/weldingtool/largetank
-	tank = /obj/item/welder_tank/large
+	tank = /obj/item/chems/welder_tank/large
 
 /obj/item/weldingtool/hugetank
-	tank = /obj/item/welder_tank/huge
+	tank = /obj/item/chems/welder_tank/huge
 
 /obj/item/weldingtool/experimental
-	tank = /obj/item/welder_tank/experimental
+	tank     = /obj/item/chems/welder_tank/experimental
 	material = /decl/material/solid/metal/steel
-	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
+	matter   = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
 
-///////////////////////
-//Welding tool tanks//
-/////////////////////
-/obj/item/welder_tank
-	name = "\improper welding fuel tank"
-	desc = "An interchangeable fuel tank meant for a welding tool."
-	icon = 'icons/obj/items/tool/welders/welder_tanks.dmi'
-	icon_state = "tank_normal"
-	w_class = ITEM_SIZE_SMALL
-	force = 5
-	throwforce = 5
-	material = /decl/material/solid/metal/steel
-	var/max_fuel = 20
-	var/can_refuel = 1
-	var/size_in_use = ITEM_SIZE_NORMAL
-	var/unlit_force = 7
-	var/lit_force = 11
+//////////////////////////////////////////////////////////////////
+// Welding tool tanks
+//////////////////////////////////////////////////////////////////
+/obj/item/chems/welder_tank
+	name              = "welding tank"
+	base_name         = "welding tank"
+	desc              = "An interchangeable fuel tank meant for a welding tool."
+	icon              = 'icons/obj/items/tool/welders/welder_tanks.dmi'
+	icon_state        = "tank_normal"
+	w_class           = ITEM_SIZE_SMALL
+	item_flags        = ITEM_FLAG_HOLLOW
+	force             = 5
+	throwforce        = 5
+	volume            = 20
+	show_reagent_name = TRUE
+	health            = 40
+	max_health        = 40
+	material          = /decl/material/solid/metal/steel
+	var/can_refuel    = TRUE
+	var/size_in_use   = ITEM_SIZE_NORMAL
+	var/unlit_force   = 7
+	var/lit_force     = 11
 
-/obj/item/welder_tank/Initialize()
-	create_reagents(max_fuel)
-	reagents.add_reagent(/decl/material/liquid/fuel, max_fuel)
+/obj/item/chems/welder_tank/populate_reagents()
+	reagents.add_reagent(/decl/material/liquid/fuel, reagents.maximum_volume)
+
+/obj/item/chems/welder_tank/examine(mob/user, distance)
+	. = ..()
+	if(distance > 1)
+		return
+	if(reagents.total_volume <= 0)
+		to_chat(user, "It is empty.")
+	else
+		to_chat(user, "It contains [reagents.total_volume] units of liquid.")
+	to_chat(user, " It can hold up to [reagents.maximum_volume] units.")
+
+/obj/item/chems/welder_tank/afterattack(obj/O, mob/user, proximity, click_parameters)
+	if (!ATOM_IS_OPEN_CONTAINER(src) || !proximity)
+		return
+	if(standard_dispenser_refill(user, O))
+		return TRUE
+	if(standard_pour_into(user, O))
+		return TRUE
+	if(standard_feed_mob(user, O))
+		return TRUE
+	if(user.a_intent == I_HURT)
+		if(standard_splash_mob(user, O))
+			return TRUE
+		if(reagents && reagents.total_volume)
+			to_chat(user, SPAN_DANGER("You splash the contents of \the [src] onto \the [O]."))
+			reagents.splash(O, reagents.total_volume)
+			return TRUE
+	return ..()
+
+/obj/item/chems/welder_tank/standard_dispenser_refill(mob/user, obj/structure/reagent_dispensers/target)
+	if(!can_refuel)
+		to_chat(user, SPAN_DANGER("\The [src] does not have a refuelling port."))
+		return FALSE
+	. = ..()
+	if(.)
+		playsound(src.loc, 'sound/effects/refill.ogg', 50, TRUE, -6)
+
+/obj/item/chems/welder_tank/standard_pour_into(mob/user, atom/target)
+	if(!can_refuel)
+		to_chat(user, SPAN_DANGER("\The [src] is sealed shut."))
+		return FALSE
 	. = ..()
 
-/obj/item/welder_tank/afterattack(obj/O, mob/user, proximity)
-	if (!proximity)
-		return
-	if (istype(O, /obj/structure/reagent_dispensers/fueltank) && get_dist(src, O) <= 1)
-		if (!can_refuel)
-			to_chat(user, SPAN_DANGER("\The [src] does not have a refuelling port."))
-			return
-		O.reagents.trans_to_obj(src, max_fuel)
-		to_chat(user, SPAN_NOTICE("You refuel \the [src]."))
-		playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
+/obj/item/chems/welder_tank/standard_splash_mob(mob/user, mob/target)
+	if(!can_refuel)
+		to_chat(user, SPAN_DANGER("\The [src] is sealed shut."))
+		return FALSE
+	. = ..()
 
-/obj/item/welder_tank/mini
-	name = "small welding fuel tank"
-	icon_state = "tank_small"
-	w_class = ITEM_SIZE_TINY
-	max_fuel = 5
-	force = 4
-	throwforce = 4
+/obj/item/chems/welder_tank/standard_feed_mob(mob/user, mob/target)
+	if(!can_refuel)
+		to_chat(user, SPAN_DANGER("\The [src] is sealed shut."))
+		return FALSE
+	. = ..()
+
+/obj/item/chems/welder_tank/get_alt_interactions(var/mob/user)
+	. = ..()
+	if(!can_refuel)
+		LAZYREMOVE(., /decl/interaction_handler/set_transfer/chems)
+
+/obj/item/chems/welder_tank/mini
+	name        = "small welding tank"
+	base_name   = "small welding tank"
+	icon_state  = "tank_small"
+	w_class     = ITEM_SIZE_TINY
+	volume      = 5
+	force       = 4
+	throwforce  = 4
 	size_in_use = ITEM_SIZE_SMALL
 	unlit_force = 5
-	lit_force = 7
+	lit_force   = 7
 
-/obj/item/welder_tank/large
-	name = "large welding fuel tank"
-	icon_state = "tank_large"
-	w_class = ITEM_SIZE_SMALL
-	max_fuel = 40
-	force = 6
-	throwforce = 6
+/obj/item/chems/welder_tank/large
+	name        = "large welding tank"
+	base_name   = "large welding tank"
+	icon_state  = "tank_large"
+	w_class     = ITEM_SIZE_SMALL
+	volume      = 40
+	force       = 6
+	throwforce  = 6
 	size_in_use = ITEM_SIZE_NORMAL
 
-
-/obj/item/welder_tank/huge
-	name = "huge welding fuel tank"
-	icon_state = "tank_huge"
-	w_class = ITEM_SIZE_NORMAL
-	max_fuel = 80
-	force = 8
-	throwforce = 8
+/obj/item/chems/welder_tank/huge
+	name        = "huge welding tank"
+	base_name   = "huge welding tank"
+	icon_state  = "tank_huge"
+	w_class     = ITEM_SIZE_NORMAL
+	volume      = 80
+	force       = 8
+	throwforce  = 8
 	size_in_use = ITEM_SIZE_LARGE
 	unlit_force = 9
-	lit_force = 15
+	lit_force   = 15
 
-/obj/item/welder_tank/experimental
-	name = "experimental welding fuel tank"
-	icon_state = "tank_experimental"
-	w_class = ITEM_SIZE_NORMAL
-	max_fuel = 40
-	can_refuel = 0
-	force = 8
-	throwforce = 8
-	size_in_use = ITEM_SIZE_LARGE
-	unlit_force = 9
-	lit_force = 15
-	var/last_gen = 0
+/obj/item/chems/welder_tank/experimental
+	name              = "experimental welding tank"
+	base_name         = "experimental welding tank"
+	icon_state        = "tank_experimental"
+	w_class           = ITEM_SIZE_NORMAL
+	volume            = 40
+	can_refuel        = FALSE
+	force             = 8
+	throwforce        = 8
+	size_in_use       = ITEM_SIZE_LARGE
+	unlit_force       = 9
+	lit_force         = 15
+	show_reagent_name = FALSE
+	var/tmp/last_gen  = 0
 
-/obj/item/welder_tank/experimental/Initialize()
+/obj/item/chems/welder_tank/experimental/Initialize(ml, material_key)
 	. = ..()
+	atom_flags &= ~ATOM_FLAG_OPEN_CONTAINER
 	START_PROCESSING(SSobj, src)
 
-/obj/item/welder_tank/experimental/Destroy()
+/obj/item/chems/welder_tank/experimental/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 
-/obj/item/welder_tank/experimental/Process()
-	var/cur_fuel = REAGENT_VOLUME(reagents, /decl/material/liquid/fuel)
-	if(cur_fuel < max_fuel)
+/obj/item/chems/welder_tank/experimental/Process()
+	if(REAGENT_VOLUME(reagents, /decl/material/liquid/fuel) < reagents.maximum_volume)
 		var/gen_amount = ((world.time-last_gen)/25)
 		reagents.add_reagent(/decl/material/liquid/fuel, gen_amount)
 		last_gen = world.time
+
+#undef WELDING_TOOL_HOTSPOT_TEMP_ACTIVE
+#undef WELDING_TOOL_HOTSPOT_TEMP_IDLE

--- a/code/game/objects/items/weapons/weldbackpack.dm
+++ b/code/game/objects/items/weapons/weldbackpack.dm
@@ -12,6 +12,7 @@
 	drop_sound   = 'sound/effects/holster/holsterin.ogg'
 	pickup_sound = 'sound/effects/holster/holsterout.ogg'
 	tank         = null
+	randpixel    = 0 //Prevent randpixel from screwing with backpack overlays
 
 	var/obj/item/chems/weldpack/linked_pack
 
@@ -184,7 +185,8 @@
 		welder.turn_off(user)
 
 	if(user && (user == welder.loc))
-		user.unEquip(welder, src)
+		if(!user.unEquip(welder, src))
+			return
 	else
 		welder.forceMove(src)
 	update_icon()

--- a/code/game/objects/items/weapons/weldbackpack.dm
+++ b/code/game/objects/items/weapons/weldbackpack.dm
@@ -153,11 +153,10 @@
 	. = ..()
 	if(is_welder_attached())
 		var/mutable_appearance/welder_image = new(welder)
+		welder_image.appearance_flags |= RESET_COLOR
+		welder_image.plane = FLOAT_PLANE //Use parent plane
 		welder_image.pixel_y = 0
 		welder_image.pixel_x = 15
-		welder_image.pixel_z = 0  //For some reasons, the mutalbe_appearence starts with pixel_z == 6? Might be a really obscure bug in the inventory system?
-		welder_image.plane = HUD_PLANE
-		welder_image.layer = HUD_ABOVE_HUD_LAYER
 		add_overlay(welder_image)
 
 /obj/item/chems/weldpack/examine(mob/user)
@@ -190,6 +189,7 @@
 	else
 		welder.forceMove(src)
 	update_icon()
+	update_held_icon()
 	return TRUE
 
 /obj/item/chems/weldpack/proc/detach_gun(var/mob/user)
@@ -200,6 +200,7 @@
 	to_chat(user, SPAN_NOTICE("You detach \the [welder] from \the [src]."))
 	user.put_in_active_hand(welder)
 	update_icon()
+	update_held_icon()
 	return TRUE
 
 //Empty variant

--- a/code/game/objects/items/weapons/weldbackpack.dm
+++ b/code/game/objects/items/weapons/weldbackpack.dm
@@ -1,85 +1,209 @@
-/obj/item/weldpack
-	name = "welding kit"
-	desc = "An unwieldy, heavy backpack with two massive fuel tanks. Includes a connector for most models of portable welding tools."
-	slot_flags = SLOT_BACK
-	icon = 'icons/obj/items/welderpack.dmi'
-	icon_state = ICON_STATE_WORLD
-	w_class = ITEM_SIZE_HUGE
-	material = /decl/material/solid/metal/steel
-	var/max_fuel = 350
-	var/obj/item/weldingtool/welder
+////////////////////////////////////////////////////////////
+//Welder gun
+////////////////////////////////////////////////////////////
+/obj/item/weldingtool/weldpack
+	name         = "welding gun"
+	desc         = "A welding gun connected to a welder pack."
+	slot_flags   = SLOT_HANDS
+	throw_speed  = 0
+	throw_range  = 0
+	drop_sound   = 'sound/effects/holster/holsterin.ogg'
+	pickup_sound = 'sound/effects/holster/holsterout.ogg'
+	tank         = null
 
-/obj/item/weldpack/Initialize()
-	create_reagents(max_fuel)
-	reagents.add_reagent(/decl/material/liquid/fuel, max_fuel)
+	var/obj/item/chems/weldpack/linked_pack
 
+/obj/item/weldingtool/weldpack/Initialize(ml, material_key, var/obj/item/chems/weldpack/pack)
 	. = ..()
+	if(pack)
+		linked_pack = pack
+	if(linked_pack)
+		linked_pack.register_welder_callbacks(src, /obj/item/weldingtool/weldpack/proc/on_pack_dropped, /obj/item/weldingtool/weldpack/proc/on_pack_deleted)
 
-/obj/item/weldpack/Destroy()
+/obj/item/weldingtool/weldpack/insert_tank(obj/item/chems/welder_tank/T, mob/user, no_updates, quiet)
+	return FALSE
+
+/obj/item/weldingtool/weldpack/remove_tank(mob/user)
+	return FALSE
+
+/obj/item/weldingtool/weldpack/toggle_unscrewed(mob/user)
+	return FALSE
+
+/obj/item/weldingtool/weldpack/attempt_modify(obj/item/W, mob/user)
+	return FALSE
+
+/obj/item/weldingtool/weldpack/dropped(mob/user)
+	. = ..()
+	if(linked_pack)
+		linked_pack.reattach_gun(user)
+
+/obj/item/weldingtool/weldpack/get_fuel()
+	return linked_pack? linked_pack.get_fuel() : 0
+
+/obj/item/weldingtool/weldpack/use_fuel(amount)
+	. = TRUE
+	if(get_fuel() < amount)
+		. = FALSE //Try to burn as much as possible anyways
+	if(linked_pack)
+		linked_pack.reagents.remove_reagent(/decl/material/liquid/fuel, amount)
+
+/**Called by the parent when the welderpack is dropped */
+/obj/item/weldingtool/weldpack/proc/on_pack_dropped(var/mob/user)
+	if(!linked_pack.is_welder_attached())
+		linked_pack.reattach_gun(user)
+
+/**Called by the parent when the welderpack is deleting */
+/obj/item/weldingtool/weldpack/proc/on_pack_deleted()
+	if(!linked_pack.is_welder_attached())
+		linked_pack.reattach_gun()
+
+/obj/item/weldingtool/weldpack/get_storage_cost()
+	if(loc != linked_pack)
+		return ITEM_SIZE_NO_CONTAINER
+	return ..()
+
+////////////////////////////////////////////////////////////
+//Welder Pack
+////////////////////////////////////////////////////////////
+/obj/item/chems/weldpack
+	name              = "welding kit"
+	desc              = "An unwieldy, heavy backpack with two massive fuel tanks. Includes a connector for most models of portable welding tools."
+	icon              = 'icons/obj/items/welderpack.dmi'
+	icon_state        = ICON_STATE_WORLD
+	slot_flags        = SLOT_BACK
+	w_class           = ITEM_SIZE_HUGE
+	volume            = 350
+	var/obj/item/weldingtool/weldpack/welder
+	var/datum/callback/call_on_pack_dropped
+	var/datum/callback/call_on_pack_deleting
+
+/obj/item/chems/weldpack/populate_reagents()
+	reagents.add_reagent(/decl/material/liquid/fuel, reagents.maximum_volume)
+
+/obj/item/chems/weldpack/Initialize()
+	. = ..()
+	if(!welder)
+		welder = new(src, null, src)
+
+/obj/item/chems/weldpack/Destroy()
+	if(call_on_pack_deleting)
+		call_on_pack_deleting.Invoke()
+	QDEL_NULL(call_on_pack_deleting)
+	QDEL_NULL(call_on_pack_dropped)
 	QDEL_NULL(welder)
 
 	. = ..()
 
-/obj/item/weldpack/attackby(obj/item/W, mob/user)
+/obj/item/chems/weldpack/proc/register_welder_callbacks(var/obj/item/weldingtool/weldpack/W, var/ondropped, var/ondelete)
+	call_on_pack_dropped  = CALLBACK(W, ondropped)
+	call_on_pack_deleting = CALLBACK(W, ondelete)
+
+/obj/item/chems/weldpack/attackby(obj/item/W, mob/user)
+	if(W.isflamesource() && get_fuel() && W.get_heat() >= 700 && prob(50))
+		try_detonate_reagents()
+		log_and_message_admins("triggered a fueltank explosion.", user)
+		to_chat(user, SPAN_DANGER("That was stupid of you."))
+		return TRUE
+
 	if(IS_WELDER(W))
 		var/obj/item/weldingtool/T = W
-		if(T.welding & prob(50))
-			log_and_message_admins("triggered a fueltank explosion.", user)
-			to_chat(user, "<span class='danger'>That was stupid of you.</span>")
-			explosion(get_turf(src),-1,0,2)
-			if(src)
-				qdel(src)
-			return
-		else
-			if(T.welding)
-				to_chat(user, "<span class='danger'>That was close!</span>")
-			if(!T.tank)
-				to_chat(user, "\The [T] has no tank attached!")
-			src.reagents.trans_to_obj(T.tank, T.tank.reagents.maximum_volume)
-			to_chat(user, "<span class='notice'>You refuel \the [W].</span>")
-			playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
-			return
-	else if(istype(W, /obj/item/welder_tank))
-		var/obj/item/welder_tank/tank = W
+		if(T.welding)
+			user.visible_message(SPAN_DANGER("\The [user] singes \his [src] with \his [W]!"), SPAN_DANGER("You singed your [src] with your [W]!"))
+
+		if(W == welder)
+			return reattach_gun(user)
+		if(!T.tank)
+			to_chat(user, "\The [T] has no tank attached!")
+		src.reagents.trans_to_obj(T.tank, T.tank.reagents.maximum_volume)
+		to_chat(user, SPAN_NOTICE("You refuel \the [W]."))
+		playsound(src.loc, 'sound/effects/refill.ogg', 50, TRUE, -6)
+		return TRUE
+
+	else if(istype(W, /obj/item/chems/welder_tank))
+		var/obj/item/chems/welder_tank/tank = W
 		src.reagents.trans_to_obj(tank, tank.reagents.maximum_volume)
-		to_chat(user, "<span class='notice'>You refuel \the [W].</span>")
-		playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
-		return
+		to_chat(user, SPAN_NOTICE("You refuel \the [W]."))
+		playsound(src.loc, 'sound/effects/refill.ogg', 50, TRUE, -6)
+		return TRUE
 
-	to_chat(user, "<span class='warning'>The tank will accept only a welding tool or cartridge.</span>")
-	return
+	return ..()
 
-/obj/item/weldpack/afterattack(obj/O, mob/user, proximity)
-	if(!proximity) // this replaces and improves the get_dist(src,O) <= 1 checks used previously
+/obj/item/chems/weldpack/afterattack(obj/O, mob/user, proximity)
+	if (!ATOM_IS_OPEN_CONTAINER(src) || !proximity)
 		return
-	if (istype(O, /obj/structure/reagent_dispensers/fueltank) && src.reagents.total_volume < max_fuel)
-		O.reagents.trans_to_obj(src, max_fuel)
-		to_chat(user, "<span class='notice'>You crack the cap off the top of the pack and fill it back up again from the tank.</span>")
-		playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
-		return
-	else if (istype(O, /obj/structure/reagent_dispensers/fueltank) && src.reagents.total_volume == max_fuel)
-		to_chat(user, "<span class='warning'>The pack is already full!</span>")
-		return
+	if(standard_dispenser_refill(user, O))
+		return TRUE
+	if(standard_pour_into(user, O))
+		return TRUE
+	return ..()
 
-/obj/item/weldpack/attack_hand(mob/user)
-	if(welder && user.is_holding_offhand(src))
-		user.put_in_hands(welder)
-		user.visible_message("[user] removes \the [welder] from \the [src].", "You remove \the [welder] from \the [src].")
-		welder = null
-		update_icon()
-	else
-		..()
+/obj/item/chems/weldpack/attack_hand(mob/user)
+	if(is_welder_attached())
+		var/curslot = user.get_inventory_slot(src)
+		if(curslot == slot_back_str || curslot == slot_s_store_str || user.is_holding_offhand(src))
+			detach_gun(user)
+			update_icon()
+			return TRUE
+	return ..()
 
-/obj/item/weldpack/on_update_icon()
+/obj/item/chems/weldpack/check_mousedrop_adjacency(atom/over, mob/user)
+	return (loc == user && istype(over, /obj/screen)) || ..()
+
+/obj/item/chems/weldpack/handle_mouse_drop(atom/over, mob/user)
+	if(loc == user && !user.incapacitated())
+		if(istype(over, /obj/screen/inventory))
+			var/obj/screen/inventory/I = over
+			if(user.unEquip(src))
+				user.equip_to_slot_if_possible(src, I.slot_id)
+				return TRUE
+	return ..()
+
+/obj/item/chems/weldpack/on_update_icon()
 	. = ..()
-	if(welder)
+	if(is_welder_attached())
 		var/mutable_appearance/welder_image = new(welder)
 		welder_image.pixel_x = 16
 		add_overlay(welder_image)
 
-/obj/item/weldpack/examine(mob/user)
+/obj/item/chems/weldpack/examine(mob/user)
 	. = ..()
 	to_chat(user, "[html_icon(src)] [reagents.total_volume] unit\s of fuel left!")
 
-	if(welder)
-		to_chat(user, "\The [welder] is attached.")
+/obj/item/chems/weldpack/dropped(mob/user)
+	. = ..()
+	if(call_on_pack_dropped)
+		call_on_pack_dropped.Invoke(user)
+
+/obj/item/chems/weldpack/proc/get_fuel()
+	return REAGENT_VOLUME(reagents, /decl/material/liquid/fuel)
+
+/obj/item/chems/weldpack/proc/is_welder_attached()
+	return welder && (welder.loc == src)
+
+/**Re-attach the welder gun to the pack.*/
+/obj/item/chems/weldpack/proc/reattach_gun(var/mob/user)
+	if(is_welder_attached())
+		return
+	if(user)
+		to_chat(user, SPAN_NOTICE("You re-attach \the [welder] to \the [src]."))
+	if(welder.isOn())
+		welder.turn_off(user)
+
+	if(user && (user == welder.loc))
+		user.unEquip(welder, src)
+	else
+		welder.forceMove(src)
+	return TRUE
+
+/obj/item/chems/weldpack/proc/detach_gun(var/mob/user)
+	if(!is_welder_attached())
+		return
+	if(!user)
+		return
+	to_chat(user, SPAN_NOTICE("You detach \the [welder] from \the [src]."))
+	user.put_in_active_hand(welder)
+	return TRUE
+
+//Empty variant
+/obj/item/chems/weldpack/empty/populate_reagents()
+	return

--- a/code/game/objects/items/weapons/weldbackpack.dm
+++ b/code/game/objects/items/weapons/weldbackpack.dm
@@ -79,9 +79,9 @@
 	reagents.add_reagent(/decl/material/liquid/fuel, reagents.maximum_volume)
 
 /obj/item/chems/weldpack/Initialize(ml, material_key)
-	. = ..()
 	if(ispath(welder))
 		welder = new welder(src, null, src)
+	. = ..()
 
 /obj/item/chems/weldpack/Destroy()
 	if(welder)

--- a/code/game/objects/structures/_structure_construction.dm
+++ b/code/game/objects/structures/_structure_construction.dm
@@ -28,7 +28,7 @@
 			return TRUE
 		playsound(loc, pick('sound/items/Welder.ogg', 'sound/items/Welder2.ogg'), 50, 1)
 		visible_message(SPAN_NOTICE("\The [user] starts slicing apart \the [src] with \the [welder]."))
-		if(!do_after(user, 3 SECONDS, src) || QDELETED(src) || !welder.remove_fuel(5, user))
+		if(!do_after(user, 3 SECONDS, src) || QDELETED(src) || !welder.weld(5, user))
 			return TRUE
 		playsound(loc, pick('sound/items/Welder.ogg', 'sound/items/Welder2.ogg'), 50, 1)
 		visible_message(SPAN_NOTICE("\The [user] completely dismantles \the [src] with \the [welder]."))

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -251,7 +251,7 @@ var/global/list/closets = list()
 			return 0
 		if(IS_WELDER(W))
 			var/obj/item/weldingtool/WT = W
-			if(WT.remove_fuel(0,user))
+			if(WT.weld(0,user))
 				slice_into_parts(WT, user)
 				return
 		if(istype(W, /obj/item/gun/energy/plasmacutter))
@@ -287,7 +287,7 @@ var/global/list/closets = list()
 		return
 	else if(IS_WELDER(W) && (setup & CLOSET_CAN_BE_WELDED))
 		var/obj/item/weldingtool/WT = W
-		if(!WT.remove_fuel(0,user))
+		if(!WT.weld(0,user))
 			if(!WT.isOn())
 				return
 			else

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -47,9 +47,9 @@
 	return list(
 		/obj/item/clothing/head/welding = 3,
 		/obj/item/weldingtool/largetank = 3,
-		/obj/item/weldpack = 3,
+		/obj/item/chems/weldpack = 3,
 		/obj/item/clothing/glasses/welding = 3,
-		/obj/item/welder_tank = 6
+		/obj/item/chems/welder_tank = 6
 	)
 
 /obj/structure/closet/secure_closet/engineering_personal

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -136,7 +136,7 @@
 
 	if(IS_WELDER(W) && (glass == 1 || !anchored))
 		var/obj/item/weldingtool/WT = W
-		if (WT.remove_fuel(0, user))
+		if (WT.weld(0, user))
 			playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
 			if(glass == 1)
 				var/decl/material/glass_material_datum = GET_DECL(glass_material)

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -64,7 +64,7 @@
 		return
 	if(IS_WELDER(C))
 		var/obj/item/weldingtool/WT = C
-		if(WT.remove_fuel(0, user))
+		if(WT.weld(0, user))
 			deconstruct(user)
 		return
 	if(istype(C, /obj/item/gun/energy/plasmacutter))

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -144,7 +144,7 @@
 			var/obj/item/weldingtool/welder = C
 			if(welder.isOn() && (is_plating()))
 				if(broken || burnt)
-					if(welder.remove_fuel(0, user))
+					if(welder.weld(0, user))
 						to_chat(user, "<span class='notice'>You fix some dents on the broken plating.</span>")
 						playsound(src, 'sound/items/Welder.ogg', 80, 1)
 						icon_state = "plating"
@@ -152,7 +152,7 @@
 						broken = null
 						return TRUE
 				else
-					if(welder.remove_fuel(0, user))
+					if(welder.weld(0, user))
 						playsound(src, 'sound/items/Welder.ogg', 80, 1)
 						visible_message("<span class='notice'>[user] has started melting the plating's reinforcements!</span>")
 						. = TRUE

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -117,7 +117,7 @@
 	if(locate(/obj/effect/overlay/wallrot) in src)
 		if(IS_WELDER(W))
 			var/obj/item/weldingtool/WT = W
-			if( WT.remove_fuel(0,user) )
+			if( WT.weld(0,user) )
 				to_chat(user, "<span class='notice'>You burn away the fungi with \the [WT].</span>")
 				playsound(src, 'sound/items/Welder.ogg', 10, 1)
 				for(var/obj/effect/overlay/wallrot/WR in src)
@@ -134,7 +134,7 @@
 
 		var/obj/item/weldingtool/WT = W
 
-		if(WT.remove_fuel(0,user))
+		if(WT.weld(0,user))
 			to_chat(user, "<span class='notice'>You start repairing the damage to [src].</span>")
 			playsound(src, 'sound/items/Welder.ogg', 100, 1)
 			if(do_after(user, max(5, damage / 5), src) && WT && WT.isOn())
@@ -156,7 +156,7 @@
 				return TRUE
 
 			var/obj/item/weldingtool/WT = W
-			if(!WT.remove_fuel(0,user))
+			if(!WT.weld(0,user))
 				return
 			dismantle_verb = "cutting"
 			dismantle_sound = 'sound/items/Welder.ogg'
@@ -251,7 +251,7 @@
 				var/cut_cover
 				if(istype(W,/obj/item/weldingtool))
 					var/obj/item/weldingtool/WT = W
-					if(WT.remove_fuel(0,user))
+					if(WT.weld(0,user))
 						cut_cover=1
 					else
 						return
@@ -297,7 +297,7 @@
 				var/cut_cover
 				if(istype(W, /obj/item/weldingtool))
 					var/obj/item/weldingtool/WT = W
-					if( WT.remove_fuel(0,user) )
+					if( WT.weld(0,user) )
 						cut_cover=1
 					else
 						return

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -289,7 +289,7 @@
 			to_chat(user, "<span class='notice'>The welding tool needs to be on to start this task.</span>")
 			return 1
 
-		if(!WT.remove_fuel(0,user))
+		if(!WT.weld(0,user))
 			to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 			return 1
 

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -213,7 +213,7 @@
 			to_chat(user, "<span class='notice'>The welding tool needs to be on to start this task.</span>")
 			return 1
 
-		if(!WT.remove_fuel(0,user))
+		if(!WT.weld(0,user))
 			to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 			return 1
 

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -221,7 +221,7 @@
 			return
 
 		var/obj/item/weldingtool/WT = W
-		if(!WT.remove_fuel(5))
+		if(!WT.weld(5))
 			to_chat(user, SPAN_WARNING("You need more welding fuel to repair this suit."))
 			return
 

--- a/code/modules/codex/entries/engineering.dm
+++ b/code/modules/codex/entries/engineering.dm
@@ -29,7 +29,7 @@
 	mechanics_text = "Inflate by using it in your hand.  The inflatable barrier will inflate on your tile.  To deflate it, use the 'deflate' verb. Hitting this with any object will probably puncture and break it forever.<br>Walls are static, but doors may be clicked to open or close them. They only stop air while closed."
 
 /datum/codex_entry/welding_pack
-	associated_paths = list(/obj/item/weldpack)
+	associated_paths = list(/obj/item/chems/weldpack)
 	mechanics_text = "This pack acts as a portable source of welding fuel. Use a welder on it to refill its tank - but make sure it's not lit! You can use this kit on a fuel tank or appropriate reagent dispenser to replenish its reserves."
 	lore_text = "The Shenzhen Chain of 2133 was an industrial accident of noteworthy infamy that occurred at Earth's L3 Lagrange Point. An apprentice welder, working for the Shenzhen Space Fabrication Group, failed to properly seal her fuel port, triggering a chain reaction that spread from laborer to laborer, instantly vaporizing a crew of fourteen. Don't let this happen to you!"
 	antag_text = "In theory, you could hold an open flame to this pack and produce some pretty catastrophic results. The trick is getting out of the blast radius."

--- a/code/modules/crafting/_crafting_stage.dm
+++ b/code/modules/crafting/_crafting_stage.dm
@@ -71,7 +71,7 @@
 
 /decl/crafting_stage/welding/consume(var/mob/user, var/obj/item/thing, var/obj/item/target)
 	var/obj/item/weldingtool/T = thing
-	. = istype(T) && T.remove_fuel(0, user) && T.isOn()
+	. = istype(T) && T.weld(0, user) && T.isOn()
 
 /decl/crafting_stage/welding
 	consume_completion_trigger = FALSE

--- a/code/modules/fabrication/designs/general/designs_engineering.dm
+++ b/code/modules/fabrication/designs/general/designs_engineering.dm
@@ -148,3 +148,6 @@
 
 /datum/fabricator_recipe/engineering/stirling_piston
 	path = /obj/item/tank/stirling/empty
+
+/datum/fabricator_recipe/engineering/welderpack
+	path = /obj/item/chems/weldpack/empty

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -120,7 +120,7 @@
 	if(reinf_material && reinf_material.default_solid_form && IS_WELDER(W))
 		var/obj/item/weldingtool/WT = W
 		if(WT.isOn() && WT.get_fuel() > 2 && use(2))
-			WT.remove_fuel(2, user)
+			WT.weld(2, user)
 			to_chat(user, SPAN_NOTICE("You recover some [reinf_material.use_name] from \the [src]."))
 			reinf_material.create_object(get_turf(user), 1)
 			return TRUE

--- a/code/modules/mechs/components/_components.dm
+++ b/code/modules/mechs/components/_components.dm
@@ -142,7 +142,7 @@
 	if(!WT.isOn())
 		to_chat(user, SPAN_WARNING("Turn \the [WT] on, first."))
 		return
-	if(WT.remove_fuel((SKILL_MAX + 1) - user.get_skill_value(SKILL_CONSTRUCTION), user))
+	if(WT.weld((SKILL_MAX + 1) - user.get_skill_value(SKILL_CONSTRUCTION), user))
 		user.visible_message(
 			SPAN_NOTICE("\The [user] begins welding the damage on \the [src]..."),
 			SPAN_NOTICE("You begin welding the damage on \the [src]...")

--- a/code/modules/mechs/components/frame.dm
+++ b/code/modules/mechs/components/frame.dm
@@ -252,7 +252,7 @@
 		if(!WT.isOn())
 			to_chat(user, SPAN_WARNING("Turn \the [WT] on, first."))
 			return
-		if(WT.remove_fuel(1, user))
+		if(WT.weld(1, user))
 
 			var/last_reinforced_state = is_reinforced
 			visible_message("\The [user] begins welding the metal reinforcement inside \the [src].")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -500,7 +500,7 @@
 			to_chat(user, "Nothing to fix here!")
 			return
 		var/obj/item/weldingtool/WT = W
-		if (WT.remove_fuel(0))
+		if (WT.weld(0))
 			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 			adjustBruteLoss(-30)
 			updatehealth()

--- a/code/modules/persistence/graffiti.dm
+++ b/code/modules/persistence/graffiti.dm
@@ -40,7 +40,7 @@
 /obj/effect/decal/writing/attackby(var/obj/item/thing, var/mob/user)
 	if(IS_WELDER(thing))
 		var/obj/item/weldingtool/welder = thing
-		if(welder.isOn() && welder.remove_fuel(0,user) && do_after(user, 5, src) && !QDELETED(src))
+		if(welder.isOn() && welder.weld(0,user) && do_after(user, 5, src) && !QDELETED(src))
 			playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
 			user.visible_message("<span class='notice'>\The [user] clears away some graffiti.</span>")
 			qdel(src)

--- a/code/modules/persistence/graffiti.dm
+++ b/code/modules/persistence/graffiti.dm
@@ -39,12 +39,13 @@
 
 /obj/effect/decal/writing/attackby(var/obj/item/thing, var/mob/user)
 	if(IS_WELDER(thing))
-		var/obj/item/weldingtool/welder = thing
-		if(welder.isOn() && welder.weld(0,user) && do_after(user, 5, src) && !QDELETED(src))
-			playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
-			user.visible_message("<span class='notice'>\The [user] clears away some graffiti.</span>")
+		if(thing.do_tool_interaction(TOOL_WELDER, user, src, 3 SECONDS))
+			playsound(src, 'sound/items/Welder2.ogg', 50, TRUE)
+			user.visible_message(SPAN_NOTICE("\The [user] clears away some graffiti."))
 			qdel(src)
-	else if(thing.sharp)
+			return TRUE
+
+	else if(thing.sharp && user.a_intent != I_HELP) //Check intent so you don't go insane trying to unscrew a light fixture over a graffiti
 
 		if(jobban_isbanned(user, "Graffiti"))
 			to_chat(user, SPAN_WARNING("You are banned from leaving persistent information across rounds."))
@@ -52,12 +53,12 @@
 
 		var/_message = sanitize(input("Enter an additional message to engrave.", "Graffiti") as null|text, trim = TRUE)
 		if(_message && loc && user && !user.incapacitated() && user.Adjacent(loc) && thing.loc == user)
-			user.visible_message("<span class='warning'>\The [user] begins carving something into \the [loc].</span>")
+			user.visible_message(SPAN_WARNING("\The [user] begins carving something into \the [loc]."))
 			if(do_after(user, max(20, length(_message)), src) && loc)
-				user.visible_message("<span class='danger'>\The [user] carves some graffiti into \the [loc].</span>")
+				user.visible_message(SPAN_DANGER("\The [user] carves some graffiti into \the [loc]."))
 				message = "[message] [_message]"
 				author = user.ckey
 				if(lowertext(message) == "elbereth")
-					to_chat(user, "<span class='notice'>You feel much safer.</span>")
+					to_chat(user, SPAN_NOTICE("You feel much safer."))
 	else
 		. = ..()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -167,7 +167,7 @@
 			if(0)
 				to_chat(user, "<span class='warning'>\The [src] needs to be wrenched to the floor.</span>")
 			if(1)
-				if (WT.remove_fuel(0,user))
+				if (WT.weld(0,user))
 					playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
 					user.visible_message("[user.name] starts to weld [src] to the floor.", \
 						"You start to weld [src] to the floor.", \
@@ -179,7 +179,7 @@
 				else
 					to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
 			if(2)
-				if (WT.remove_fuel(0,user))
+				if (WT.weld(0,user))
 					playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
 					user.visible_message("[user.name] starts to cut [src] free from the floor.", \
 						"You start to cut [src] free from the floor.", \

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -126,7 +126,7 @@ field_generator power level display
 				to_chat(user, "<span class='warning'>The [src.name] needs to be wrenched to the floor.</span>")
 				return
 			if(1)
-				if (WT.remove_fuel(0,user))
+				if (WT.weld(0,user))
 					playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
 					user.visible_message("[user.name] starts to weld the [src.name] to the floor.", \
 						"You start to weld the [src] to the floor.", \
@@ -138,7 +138,7 @@ field_generator power level display
 				else
 					return
 			if(2)
-				if (WT.remove_fuel(0,user))
+				if (WT.weld(0,user))
 					playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
 					user.visible_message("[user.name] starts to cut the [src.name] free from the floor.", \
 						"You start to cut the [src] free from the floor.", \

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -147,7 +147,7 @@
 	else if(istype(I, /obj/item/weldingtool))
 		if(anchored)
 			var/obj/item/weldingtool/W = I
-			if(W.remove_fuel(0,user))
+			if(W.weld(0,user))
 				playsound(src.loc, 'sound/items/Welder2.ogg', 100, 1)
 				to_chat(user, "Welding \the [src] in place.")
 				if(do_after(user, 20, src))

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -587,7 +587,7 @@ var/global/list/diversion_junctions = list()
 			return
 	else if(istype(I,/obj/item/weldingtool) && mode==1)
 		var/obj/item/weldingtool/W = I
-		if(W.remove_fuel(0,user))
+		if(W.weld(0,user))
 			playsound(src.loc, 'sound/items/Welder2.ogg', 100, 1)
 			to_chat(user, "You start slicing the floorweld off the disposal outlet.")
 			if(do_after(user,20, src))

--- a/code/modules/recycling/disposalpipe.dm
+++ b/code/modules/recycling/disposalpipe.dm
@@ -206,7 +206,7 @@
 	src.add_fingerprint(user, 0, I)
 	if(istype(I, /obj/item/weldingtool))
 		var/obj/item/weldingtool/W = I
-		if(W.remove_fuel(0,user))
+		if(W.weld(0,user))
 			playsound(src.loc, 'sound/items/Welder2.ogg', 100, 1)
 			// check if anything changed over 2 seconds
 			var/turf/uloc = user.loc
@@ -763,7 +763,7 @@
 	if(istype(I, /obj/item/weldingtool))
 		var/obj/item/weldingtool/W = I
 
-		if(W.remove_fuel(0,user))
+		if(W.weld(0,user))
 			playsound(src.loc, 'sound/items/Welder2.ogg', 100, 1)
 			// check if anything changed over 2 seconds
 			var/turf/uloc = user.loc

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -486,7 +486,7 @@
 			return
 	else if(IS_WELDER(I) && c_mode==1)
 		var/obj/item/weldingtool/W = I
-		if(W.remove_fuel(1,user))
+		if(W.weld(1,user))
 			to_chat(user, "You start slicing the floorweld off the delivery chute.")
 			if(do_after(user,20, src))
 				playsound(src.loc, 'sound/items/Welder2.ogg', 100, 1)

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -119,7 +119,7 @@
 		return FALSE
 	if(IS_WELDER(tool))
 		var/obj/item/weldingtool/welder = tool
-		if(!welder.isOn() || !welder.remove_fuel(1,user))
+		if(!welder.isOn() || !welder.weld(1,user))
 			return FALSE
 	var/obj/item/rig/rig = target.get_equipped_item(slot_back_str)
 	return (target_zone == BP_CHEST) && istype(rig) && !(rig.canremove)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -193,7 +193,7 @@
 			return FALSE
 		if(IS_WELDER(tool))
 			var/obj/item/weldingtool/welder = tool
-			if(!welder.isOn() || !welder.remove_fuel(1,user))
+			if(!welder.isOn() || !welder.weld(1,user))
 				return FALSE
 		if(istype(tool, /obj/item/gun/energy/plasmacutter))
 			var/obj/item/gun/energy/plasmacutter/cutter = tool

--- a/code/modules/tools/tool_archetype_definitions_welder.dm
+++ b/code/modules/tools/tool_archetype_definitions_welder.dm
@@ -11,7 +11,7 @@
 	if(!welder.isOn())
 		to_chat(user, SPAN_WARNING("\The [welder] needs to be turned on to begin this task."))
 		return TOOL_USE_FAILURE
-	if(!welder.remove_fuel(expend_fuel, user))
+	if(!welder.weld(expend_fuel, user))
 		to_chat(user, SPAN_WARNING("You need more fuel to begin this task."))
 		return TOOL_USE_FAILURE
 	return TOOL_USE_SUCCESS
@@ -23,7 +23,7 @@
 	if(!welder.isOn())
 		to_chat(user, SPAN_WARNING("\The [welder] needs to be turned on to finish this task."))
 		return TOOL_USE_FAILURE
-	if(!welder.remove_fuel(expend_fuel, user))
+	if(!welder.weld(expend_fuel, user))
 		to_chat(user, SPAN_WARNING("You need more fuel to finish this task."))
 		return TOOL_USE_FAILURE
 	return TOOL_USE_SUCCESS

--- a/code/modules/xenoarcheaology/finds/strange_rock.dm
+++ b/code/modules/xenoarcheaology/finds/strange_rock.dm
@@ -30,7 +30,7 @@
 	if(IS_WELDER(I))
 		var/obj/item/weldingtool/W = I
 		if(W.isOn())
-			if(W.remove_fuel(2))
+			if(W.weld(2))
 				if(inside)
 					inside.dropInto(loc)
 					visible_message(SPAN_NOTICE("\The [src] burns away revealing \the [inside]."))


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Moved the welderpack stuff from #2573 to here. Depends on #2573.
* Makes the welderpack have its own mounted welding gun.
* Fix the welderpack getting stuck in the inventory.
* Adds a welderpack recipe to the fabricator.
* Welder tanks are now chems subclasses.

## Why and what will this PR improve
The welderpack was kinda useless before. So this makes it somewhat more useful.

## Authorship
<!-- Describe original authors of changes to credit them. -->

## Changelog
:cl:
bugfix: Fixed welderpack getting stuck in the inventory.
tweak: Welderpack now has its own attached welding gun, which works a lot like defibrillator paddles.
add: Added welderpack recipe to engineering fabricator.
refactor: Welder tanks are now inheriting /obj/item/chems.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->