### PR TITLE
Automatically set wall offset for wall mounted objects

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -22,6 +22,7 @@
 	var/tmp/default_pixel_x
 	var/tmp/default_pixel_y
 	var/tmp/default_pixel_z
+	var/tmp/default_pixel_w
 
 // This is called by the maploader prior to Initialize to perform static modifications to vars set on the map. Intended use case: adjust tag vars on duplicate templates.
 /atom/proc/modify_mapped_vars(map_hash)

--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -49,6 +49,10 @@
 		default_pixel_z = pixel_z
 	else
 		pixel_z = default_pixel_z
+	if(isnull(default_pixel_w))
+		default_pixel_w = pixel_w
+	else
+		pixel_w = default_pixel_w
 
 	if(light_power && light_range)
 		update_light()

--- a/code/game/atoms_layering.dm
+++ b/code/game/atoms_layering.dm
@@ -16,6 +16,7 @@
 	layer = initial(layer)
 
 /atom/proc/reset_offsets(var/anim_time = 2)
+	pixel_w = default_pixel_w
 	pixel_x = default_pixel_x
 	pixel_y = default_pixel_y
 	pixel_z = default_pixel_z

--- a/code/game/atoms_temperature.dm
+++ b/code/game/atoms_temperature.dm
@@ -18,10 +18,13 @@
 /turf
 	temperature_coefficient = MIN_TEMPERATURE_COEFFICIENT
 
-/obj/Initialize()
+/obj/Initialize(mapload)
 	. = ..()
 	temperature_coefficient = isnull(temperature_coefficient) ? Clamp(MAX_TEMPERATURE_COEFFICIENT - w_class, MIN_TEMPERATURE_COEFFICIENT, MAX_TEMPERATURE_COEFFICIENT) : temperature_coefficient
 	create_matter()
+	//Only apply directional offsets if the mappers haven't set any offsets already
+	if(!pixel_x && !pixel_y && !pixel_w && !pixel_z)
+		update_directional_offset()
 
 /obj/proc/HandleObjectHeating(var/obj/item/heated_by, var/mob/user, var/adjust_temp)
 	if(ATOM_SHOULD_TEMPERATURE_ENQUEUE(src))

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -61,7 +61,7 @@
 	uncreated_component_parts = list(/obj/item/stock_parts/power/apc = 1)
 	construct_state = /decl/machine_construction/wall_frame/panel_closed
 	wires = /datum/wires/alarm
-
+	directional_offset = "{'NORTH':{'y':-21}, 'SOUTH':{'y':21}, 'EAST':{'x':-21}, 'WEST':{'x':21}}"
 
 	var/alarm_id = null
 	var/breach_detection = 1 // Whether to use automatic breach detection or not
@@ -309,21 +309,6 @@
 	return 0
 
 /obj/machinery/alarm/on_update_icon()
-	// Set pixel offsets
-	default_pixel_x = 0
-	default_pixel_y = 0
-	var/turf/T = get_step(get_turf(src), turn(dir, 180))
-	if(istype(T) && T.density)
-		if(dir == NORTH)
-			default_pixel_y = -21
-		else if(dir == SOUTH)
-			default_pixel_y = 21
-		else if(dir == WEST)
-			default_pixel_x = 21
-		else if(dir == EAST)
-			default_pixel_x = -21
-	reset_offsets(0)
-
 	// Broken or deconstructed states
 	if(!istype(construct_state, /decl/machine_construction/wall_frame/panel_closed))
 		icon_state = "alarmx"
@@ -838,6 +823,7 @@ FIRE ALARM
 	frame_type = /obj/item/frame/fire_alarm
 	uncreated_component_parts = list(/obj/item/stock_parts/power/apc = 1)
 	construct_state = /decl/machine_construction/wall_frame/panel_closed
+	directional_offset = "{'NORTH':{'y':-21}, 'SOUTH':{'y':21}, 'EAST':{'x':21}, 'WEST':{'x':-21}}"
 
 	var/detecting =    TRUE
 	var/working =      TRUE
@@ -874,22 +860,6 @@ FIRE ALARM
 
 /obj/machinery/firealarm/on_update_icon()
 	overlays.Cut()
-
-	default_pixel_x = 0
-	default_pixel_y = 0
-	var/walldir = (dir & (NORTH|SOUTH)) ? global.reverse_dir[dir] : dir
-	var/turf/T = get_step(get_turf(src), walldir)
-	if(istype(T) && T.density)
-		if(dir == SOUTH)
-			default_pixel_y = 21
-		else if(dir == NORTH)
-			default_pixel_y = -21
-		else if(dir == EAST)
-			default_pixel_x = 21
-		else if(dir == WEST)
-			default_pixel_x = -21
-	reset_offsets(0)
-
 	icon_state = "casing"
 	if(construct_state && !istype(construct_state, /decl/machine_construction/wall_frame/panel_closed))
 		overlays += get_cached_overlay(construct_state.type)
@@ -1066,6 +1036,8 @@ FIRE ALARM
 	anchored = TRUE
 	idle_power_usage = 2
 	active_power_usage = 6
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':-21}, 'SOUTH':{'y':21}, 'EAST':{'x':21}, 'WEST':{'x':-21}}"
 	var/time =         1 SECOND
 	var/timing =       FALSE
 	var/lockdownbyai = FALSE

--- a/code/game/machinery/bodyscanner_display.dm
+++ b/code/game/machinery/bodyscanner_display.dm
@@ -12,6 +12,8 @@
 	uncreated_component_parts = null
 	stat_immune = 0
 	w_class = ITEM_SIZE_HUGE
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':32}, 'WEST':{'x':-32}}"
 	var/list/bodyscans = list()
 	var/selected = 0
 

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -24,6 +24,7 @@
 	construct_state = /decl/machine_construction/wall_frame/panel_closed/simple
 	frame_type = /obj/item/frame/button
 	required_interaction_dexterity = DEXTERITY_SIMPLE_MACHINES
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':30}, 'EAST':{'x':-24}, 'WEST':{'x':24}}"
 
 	var/active = FALSE
 	var/operating = FALSE

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -10,7 +10,7 @@
 	anchored = 1
 	movable_flags = MOVABLE_FLAG_PROXMOVE
 	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
-
+	directional_offset = "{'SOUTH':{'y':21}, 'EAST':{'x':-10}, 'WEST':{'x':10}}"
 	base_type = /obj/machinery/camera
 	uncreated_component_parts = null
 	construct_state = /decl/machine_construction/wall_frame/panel_closed
@@ -261,19 +261,6 @@
 		update_coverage()
 
 /obj/machinery/camera/on_update_icon()
-	default_pixel_x = 0
-	default_pixel_y = 0
-
-	var/turf/T = get_step(get_turf(src), turn(src.dir, 180))
-	if(istype(T, /turf/simulated/wall))
-		if(dir == SOUTH)
-			default_pixel_y = 21
-		else if(dir == WEST)
-			default_pixel_x = 10
-		else if(dir == EAST)
-			default_pixel_x = -10
-	reset_offsets(0)
-
 	if (!status || (stat & BROKEN))
 		icon_state = "[initial(icon_state)]1"
 	else if (stat & EMPED)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -15,6 +15,8 @@
 	icon_state = "cellconsole"
 	density = 0
 	interact_offline = 1
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':32}, 'SOUTH':{'y':-32}, 'EAST':{'x':32}, 'WEST':{'x':-32}}"
 	var/mode = null
 
 	//Used for logging people entering cryosleep and important items they are carrying.

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -111,7 +111,7 @@
 	base_type = /obj/machinery/airlock_sensor/buildable
 	construct_state = /decl/machine_construction/wall_frame/panel_closed/simple
 	frame_type = /obj/item/frame/button/airlock_sensor
-
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':32}, 'WEST':{'x':-32}}"
 	var/alert = 0
 	var/pressure
 
@@ -189,6 +189,7 @@
 		/obj/item/stock_parts/power/apc,
 		/obj/item/stock_parts/radio/transmitter/on_event/buildable
 	)
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':32}, 'WEST':{'x':-32}}"
 	var/command = "cycle"
 
 /obj/machinery/button/access/on_update_icon()

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -5,6 +5,8 @@
 	desc = "A wall-mounted flashbulb device."
 	icon = 'icons/obj/machines/flash_mounted.dmi'
 	icon_state = "mflash1"
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':32}, 'WEST':{'x':-32}}"
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 	var/range = 2 //this is roughly the size of brig cell
 	var/disable = 0
 	var/last_flash = 0 //Don't want it getting spammed like regular flashes

--- a/code/game/machinery/holosign.dm
+++ b/code/game/machinery/holosign.dm
@@ -8,6 +8,8 @@
 	idle_power_usage = 2
 	active_power_usage = 70
 	anchored = 1
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':32}, 'WEST':{'x':-32}}"
 	var/lit = 0
 	var/on_icon = "sign_on"
 

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -106,6 +106,7 @@
 	construct_state = /decl/machine_construction/wall_frame/panel_closed/simple
 	frame_type = /obj/item/frame/button/sparker
 	base_type = /obj/machinery/sparker/buildable
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':32}, 'WEST':{'x':-32}}"
 
 /obj/machinery/sparker/buildable
 	uncreated_component_parts = null

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -23,6 +23,7 @@
 		/obj/item/stock_parts/power/apc
 	)
 	base_type = /obj/machinery/light_switch
+	directional_offset = "{'NORTH':{'y':-20}, 'SOUTH':{'y':25}, 'EAST':{'x':-24}, 'WEST':{'x':24}}"
 
 /obj/machinery/light_switch/on
 	on = TRUE

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -157,6 +157,7 @@ var/global/list/allCasters = list() //Global list that will contain reference to
 	uncreated_component_parts = null
 	stat_immune = 0
 	frame_type = /obj/item/frame/stock_offset/newscaster
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':32}, 'WEST':{'x':-32}}"
 
 /obj/machinery/newscaster/Initialize()
 	. = ..()

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -132,3 +132,4 @@
 
 	construct_state = /decl/machine_construction/wall_frame/panel_closed
 	frame_type = /obj/item/frame/button/wall_charger
+	directional_offset = "{'NORTH':{'y':-24}, 'SOUTH':{'y':32}, 'EAST':{'x':-28}, 'WEST':{'x':28}}"

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -48,6 +48,7 @@ var/global/req_console_information = list()
 	uncreated_component_parts = null
 	construct_state = /decl/machine_construction/wall_frame/panel_closed
 	frame_type = /obj/item/frame/stock_offset/request_console
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':32}, 'WEST':{'x':-32}}"
 
 /obj/machinery/network/requests_console/on_update_icon()
 	if(stat & NOPOWER)

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -14,9 +14,11 @@
 	icon_state = "frame"
 	name = "status display"
 	layer = ABOVE_WINDOW_LAYER
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 	anchored = 1
 	density = 0
 	idle_power_usage = 10
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':32}, 'WEST':{'x':-32}}"
 	var/mode = 1	// 0 = Blank
 					// 1 = Shuttle timer
 					// 2 = Arbitrary message(s)

--- a/code/game/machinery/status_light.dm
+++ b/code/game/machinery/status_light.dm
@@ -3,6 +3,8 @@
 	desc = "A status indicator for a combustion chamber, based on temperature."
 	icon = 'icons/obj/machines/door_timer.dmi'
 	icon_state = "doortimer-p"
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':32}, 'WEST':{'x':-32}}"
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 	var/frequency = 1441
 	var/alert_temperature = 10000
 	var/alert = 1

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -13,6 +13,8 @@
 	icon_state = "control_standby"
 	anchored = 1
 	density = 0
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':32}, 'WEST':{'x':-32}}"
 	var/enabled = 0
 	var/lethal = 0
 	var/locked = 1

--- a/code/game/machinery/vending/medical.dm
+++ b/code/game/machinery/vending/medical.dm
@@ -52,6 +52,8 @@
 		/obj/item/storage/med_pouch/toxin
 	)
 	contraband = list(/obj/item/chems/syringe/antitoxin = 4,/obj/item/chems/syringe/antibiotic = 4,/obj/item/chems/pill/bromide = 1)
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':32}, 'WEST':{'x':-32}}"
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 
 /obj/machinery/vending/wallmed2
 	name = "NanoMed Mini"
@@ -73,3 +75,5 @@
 		/obj/item/storage/med_pouch/radiation
 	)
 	contraband = list(/obj/item/chems/pill/bromide = 3, /obj/item/chems/hypospray/autoinjector/pain = 2)
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':32}, 'WEST':{'x':-32}}"
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -149,27 +149,6 @@
 	name = "security camera kit"
 	desc = "An all-in-one wall-mounted security camera kit, comes preassembled."
 
-/obj/item/frame/button/modify_positioning(var/obj/machinery/button/product, _dir, click_params)
-	var/list/params = params2list(click_params)
-	var/_pixel_x = text2num(params["icon-x"]) - WORLD_ICON_SIZE/2 //Make it relative to center instead of bottom left
-	var/_pixel_y = text2num(params["icon-y"]) - WORLD_ICON_SIZE/2
-	switch(_dir)
-		if(NORTH)
-			_pixel_y = max(_pixel_y, WORLD_ICON_SIZE/4)
-			_pixel_y -= WORLD_ICON_SIZE
-		if(SOUTH)
-			_pixel_y = min(_pixel_y, WORLD_ICON_SIZE/4)
-			_pixel_y += WORLD_ICON_SIZE
-		if(EAST)
-			_pixel_x = max(_pixel_x, 0)
-			_pixel_x -= WORLD_ICON_SIZE
-		if(WEST)
-			_pixel_x = min(_pixel_x, 0)
-			_pixel_x += WORLD_ICON_SIZE
-	product.default_pixel_x = _pixel_x
-	product.default_pixel_y = _pixel_y
-	product.reset_offsets(0)
-
 /obj/item/frame/button/wall_charger
 	name = "wall charger frame"
 	icon = 'icons/obj/machines/recharger_wall.dmi'
@@ -194,16 +173,7 @@
 	reverse = TRUE
 
 /obj/item/frame/stock_offset/modify_positioning(var/obj/machinery/product, _dir, click_params)
-	switch(_dir)
-		if(NORTH)
-			product.default_pixel_y = WORLD_ICON_SIZE
-		if(SOUTH)
-			product.default_pixel_y = - WORLD_ICON_SIZE
-		if(EAST)
-			product.default_pixel_x = WORLD_ICON_SIZE
-		if(WEST)
-			product.default_pixel_x = - WORLD_ICON_SIZE
-	reset_offsets(0)
+	product.update_directional_offset()
 
 /obj/item/frame/stock_offset/request_console
 	name = "request console frame"

--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -80,7 +80,8 @@
 	name = "poster"
 	desc = "A large piece of space-resistant printed paper."
 	icon = 'icons/obj/contraband.dmi'
-	anchored = 1
+	anchored = TRUE
+	directional_offset = "{'NORTH':{'y':32}, 'SOUTH':{'y':-32}, 'EAST':{'x':32}, 'WEST':{'x':-32}}"
 	var/poster_type
 	var/ruined = 0
 
@@ -98,19 +99,6 @@
 		else
 			poster_type = pick(decls_repository.get_decl_paths_of_subtype(/decl/poster))
 	set_poster(poster_type)
-
-	pixel_x = 0
-	pixel_y = 0
-	switch (placement_dir)
-		if (NORTH)
-			default_pixel_y = 32
-		if (SOUTH)
-			default_pixel_y = -32
-		if (EAST)
-			default_pixel_x = 32
-		if (WEST)
-			default_pixel_x = -32
-	reset_offsets(0)
 
 /obj/structure/sign/poster/proc/set_poster(var/poster_type)
 	var/decl/poster/design = GET_DECL(poster_type)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -8,12 +8,13 @@
 	w_class = ITEM_SIZE_STRUCTURE
 	canhear_range = 2
 	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_NO_BLOOD
-	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	obj_flags = OBJ_FLAG_CONDUCTIBLE | OBJ_FLAG_MOVES_UNSUPPORTED
 	layer = ABOVE_WINDOW_LAYER
 	cell = null
 	power_usage = 0
 	intercom = TRUE
 	intercom_handling = TRUE
+	directional_offset = "{'NORTH':{'y':-30}, 'SOUTH':{'y':20}, 'EAST':{'x':-22}, 'WEST':{'x':22}}"
 	var/number = 0
 	var/last_tick //used to delay the powercheck
 	

--- a/code/game/objects/items/weapons/storage/wall_mirror.dm
+++ b/code/game/objects/items/weapons/storage/wall_mirror.dm
@@ -1,4 +1,6 @@
 //wip wip wup
+
+//#TODO: Should definitely be a structure!
 /obj/item/storage/mirror
 	name = "mirror"
 	desc = "A SalonPro Nano-Mirror(TM) mirror! The leading brand in hair salon products, utilizing nano-machinery to style your hair just right. The black box inside warns against attempting to release the nanomachines."
@@ -21,6 +23,8 @@
 		/obj/random/soap,
 		/obj/item/chems/spray/cleaner/deodorant,
 		/obj/item/towel/random)
+	directional_offset = "{'NORTH':{'y':-29}, 'SOUTH':{'y':29}, 'EAST':{'x':29}, 'WEST':{'x':-29}}"
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 
 /obj/item/storage/mirror/handle_mouse_drop(atom/over, mob/user)
 	. = ..()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -15,6 +15,7 @@
 	var/armor_penetration = 0
 	var/anchor_fall = FALSE
 	var/holographic = 0 //if the obj is a holographic object spawned by the holodeck
+	var/tmp/directional_offset ///JSON list of directions to x,y offsets to be applied to the object depending on its direction EX: {'NORTH':{'x':12,'y':5}, 'EAST':{'x':10,'y':50}}
 
 /obj/hitby(atom/movable/AM, var/datum/thrownthing/TT)
 	..()
@@ -205,6 +206,52 @@
 /obj/get_mob()
 	return buckled_mob
 
+/obj/set_dir(ndir)
+	. = ..()
+	if(directional_offset)
+		update_directional_offset()
+
+/obj/Move()
+	. = ..()
+	if(directional_offset)
+		update_directional_offset()
+
+/obj/forceMove(atom/dest)
+	. = ..()
+	if(directional_offset)
+		update_directional_offset()
+
+/** Applies the offset stored in the directional_offset json list depending on the current direction.  */
+/obj/proc/update_directional_offset()
+	if(!length(directional_offset))
+		return
+
+	//If this flag is on, and we have an offset, we're most likely wall mounted
+	if(obj_flags & OBJ_FLAG_MOVES_UNSUPPORTED)
+		var/turf/forward = get_step(get_turf(src), dir)
+		var/turf/reverse = get_step(get_turf(src), global.reverse_dir[dir])
+		//If we're wall mounted and don't have a wall either facing us, or in the opposite direction, don't apply the offset. 
+		// This is mainly for things that can be both wall mounted and floor mounted. 
+		// Its sort of a hack for now. But objects don't handle being on a wall or not. (They don't change their flags, layer, etc when on a wall or anything)
+		if(!forward && !reverse)
+			return
+
+	default_pixel_x = 0
+	default_pixel_y = 0
+	default_pixel_w = 0
+	default_pixel_z = 0
+	var/list/diroff = cached_json_decode(directional_offset)
+	var/list/curoff = diroff["[uppertext(dir2text(dir))]"]
+	if(length(curoff))
+		default_pixel_x = curoff["x"] || 0
+		default_pixel_y = curoff["y"] || 0
+		default_pixel_w = curoff["w"] || 0
+		default_pixel_z = curoff["z"] || 0
+	reset_offsets(0)
+
+////////////////////////////////////////////////////////////////
+// Interactions
+////////////////////////////////////////////////////////////////
 /obj/get_alt_interactions(var/mob/user)
 	. = ..()
 	LAZYADD(., /decl/interaction_handler/rotate)

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -4,6 +4,8 @@
 	icon_state = "empty"
 	appearance_flags = 0
 	anchored = 1
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':-32}, 'WEST':{'x':32}}"
 	var/cult = 0
 
 /obj/structure/sign/double/barsign/proc/get_valid_states(initial=1)

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -150,7 +150,7 @@
  * Hydrant
  */
 /obj/structure/closet/hydrant //wall mounted fire closet
-	name = "fire-safety closet"
+	name = "fire-safety wall closet"
 	desc = "It's a storage unit for fire-fighting supplies."
 	closet_appearance = /decl/closet_appearance/wall/hydrant
 	anchored = 1
@@ -158,6 +158,8 @@
 	wall_mounted = 1
 	storage_types = CLOSET_STORAGE_ITEMS
 	setup = 0
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':-32}, 'WEST':{'x':32}}"
 	
 /obj/structure/closet/hydrant/Initialize()
 	. = ..()
@@ -176,7 +178,7 @@
  * First Aid
  */
 /obj/structure/closet/medical_wall //wall mounted medical closet
-	name = "first-aid closet"
+	name = "first-aid wall closet"
 	desc = "It's a wall-mounted storage unit for first aid supplies."
 	closet_appearance = /decl/closet_appearance/wall/medical
 	anchored = 1
@@ -184,6 +186,8 @@
 	wall_mounted = 1
 	storage_types = CLOSET_STORAGE_ITEMS
 	setup = 0
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':-32}, 'WEST':{'x':32}}"
 
 /obj/structure/closet/medical_wall/Initialize()
 	. = ..()
@@ -195,7 +199,7 @@
 		/obj/random/medical/lite = 12)
 
 /obj/structure/closet/shipping_wall
-	name = "shipping supplies closet"
+	name = "shipping supplies wall closet"
 	desc = "It's a wall-mounted storage unit containing supplies for preparing shipments."
 	closet_appearance = /decl/closet_appearance/wall/shipping
 	anchored = 1
@@ -203,6 +207,8 @@
 	wall_mounted = 1
 	storage_types = CLOSET_STORAGE_ITEMS
 	setup = 0
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':-32}, 'WEST':{'x':32}}"
 
 /obj/structure/closet/shipping_wall/Initialize()
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/closets/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/closets/walllocker.dm
@@ -10,6 +10,8 @@
 	wall_mounted = 1
 	storage_types = CLOSET_STORAGE_ITEMS
 	setup = 0
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':-32}, 'WEST':{'x':32}}"
 
 /obj/structure/closet/walllocker/Initialize()
 	. = ..()

--- a/code/game/objects/structures/crematorium.dm
+++ b/code/game/objects/structures/crematorium.dm
@@ -196,6 +196,7 @@
 	anchored = TRUE
 	throwpass = TRUE
 	layer = BELOW_OBJ_LAYER
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED | OBJ_FLAG_NOFALL
 
 	var/obj/structure/crematorium/connected_crematorium
 

--- a/code/game/objects/structures/emergency_dispenser.dm
+++ b/code/game/objects/structures/emergency_dispenser.dm
@@ -6,6 +6,8 @@
 	icon = 'icons/obj/structures/emergency_dispenser.dmi'
 	icon_state = "world"
 	anchored = TRUE
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':-32}, 'WEST':{'x':32}}"
 	var/static/list/spawnitems = list(/obj/item/tank/emergency/oxygen,/obj/item/clothing/mask/breath)
 	var/amount = 3 // spawns each items X times.
 

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -5,6 +5,8 @@
 	icon_state = "extinguisher_closed"
 	anchored = 1
 	density = 0
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':-29}, 'SOUTH':{'y':29}, 'EAST':{'x':-29}, 'WEST':{'x':29}}"
 	var/obj/item/extinguisher/has_extinguisher
 	var/opened = 0
 

--- a/code/game/objects/structures/fireaxe_cabinet.dm
+++ b/code/game/objects/structures/fireaxe_cabinet.dm
@@ -5,6 +5,8 @@
 	icon_state = "fireaxe"
 	anchored = 1
 	density = 0
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':-32}, 'WEST':{'x':32}}"
 
 	var/damage_threshold = 15
 	var/open

--- a/code/game/objects/structures/fuel_port.dm
+++ b/code/game/objects/structures/fuel_port.dm
@@ -6,6 +6,8 @@
 
 	density = FALSE
 	anchored = TRUE
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':-32}, 'WEST':{'x':32}}"
 
 	var/open = FALSE
 	var/parent_shuttle

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -99,6 +99,7 @@
 	anchored = TRUE
 	throwpass = TRUE
 	layer = BELOW_OBJ_LAYER
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED | OBJ_FLAG_NOFALL
 
 	var/obj/structure/morgue/connected_morgue
 

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -5,6 +5,8 @@
 	density = FALSE
 	layer = ABOVE_WINDOW_LAYER
 	w_class = ITEM_SIZE_NORMAL
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'WEST':{'x':-32}, 'EAST':{'x':32}}"
 
 /obj/structure/sign/explosion_act(severity)
 	..()
@@ -39,24 +41,24 @@
 		var/direction = input("In which direction?", "Select direction.") in list("North", "East", "South", "West", "Cancel")
 		if(direction == "Cancel")
 			return
-		if(!QDELETED(src) && do_after(user, 30, src))
+		if(!QDELETED(src) && do_after(user, 3 SECONDS, src))
 			var/obj/structure/sign/S = new(user.loc)
-			switch(direction)
-				if("North")
-					S.default_pixel_y = 32
-				if("East")
-					S.default_pixel_x = 32
-				if("South")
-					S.default_pixel_y = -32
-				if("West")
-					S.default_pixel_x = -32
-				else
-					return
-			S.reset_offsets(0)
 			S.SetName(name)
 			S.desc = desc
-			S.icon_state = sign_state
+			S.icon_state = sign_state			
+			switch(direction)
+				if("North")
+					S.set_dir(NORTH)
+				if("East")
+					S.set_dir(EAST)
+				if("South")
+					S.set_dir(SOUTH)
+				if("West")
+					S.set_dir(WEST)
+				else
+					return
 			to_chat(user, "You fasten \the [S] with your [W].")
+			user.unEquip(src)
 			qdel(src)
 		return
 	else ..()

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -201,6 +201,8 @@ var/global/list/hygiene_props = list()
 	icon_state = "urinal"
 	density = 0
 	anchored = 1
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':-32}, 'WEST':{'x':32}}"
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 
 /obj/structure/hygiene/urinal/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/grab))

--- a/code/modules/economy/cael/ATM.dm
+++ b/code/modules/economy/cael/ATM.dm
@@ -10,6 +10,9 @@
 	icon_state = "atm"
 	anchored = 1
 	idle_power_usage = 10
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':-32}, 'WEST':{'x':32}}"
+
 	var/datum/money_account/authenticated_account
 	var/number_incorrect_tries = 0
 	var/previous_account_number = 0

--- a/code/modules/modular_computers/computers/subtypes/dev_telescreen.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_telescreen.dm
@@ -8,6 +8,8 @@
 	light_strength = 4
 	w_class = ITEM_SIZE_HUGE
 	computer_type = /datum/extension/assembly/modular_computer/telescreen
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':-32}, 'WEST':{'x':32}}"
 
 /obj/item/modular_computer/telescreen/Initialize()
 	. = ..()

--- a/code/modules/modular_computers/networking/machinery/wall_router.dm
+++ b/code/modules/modular_computers/networking/machinery/wall_router.dm
@@ -7,24 +7,8 @@
 	density = 0
 	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 	base_type = /obj/machinery/network/router/wall_mounted
+	directional_offset = "{'NORTH':{'y':-21}, 'SOUTH':{'y':21}, 'EAST':{'x':-21}, 'WEST':{'x':21}}"
 
 /obj/machinery/network/router/wall_mounted/Initialize()
 	. = ..()
 	queue_icon_update()
-
-/obj/machinery/network/router/wall_mounted/on_update_icon()
-	. = ..()
-	// Set pixel offsets
-	pixel_x = 0
-	pixel_y = 0
-	var/turf/T = get_step(get_turf(src), turn(dir, 180))
-	if(istype(T) && T.density)
-		if(dir == NORTH)
-			default_pixel_y = -21
-		else if(dir == SOUTH)
-			default_pixel_y = 21
-		else if(dir == WEST)
-			default_pixel_x = 21
-		else if(dir == EAST)
-			default_pixel_x = -21
-		reset_offsets(0)

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -34,6 +34,8 @@
 	icon_state = "wallcabinet"
 	density = 0
 	obj_flags = 0
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':-32}, 'WEST':{'x':32}}"
 
 
 /obj/structure/filingcabinet/filingcabinet	//not changing the path to avoid unecessary map issues, but please don't name stuff like this in the future -Pete

--- a/code/modules/persistence/noticeboards.dm
+++ b/code/modules/persistence/noticeboards.dm
@@ -7,12 +7,14 @@
 	anchored = 1
 	layer = ABOVE_WINDOW_LAYER
 	tool_interaction_flags = TOOL_INTERACTION_DECONSTRUCT
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'SOUTH':{'y':32}, 'EAST':{'x':-32}, 'WEST':{'x':32}}"
 
 	var/list/notices
 	var/base_icon_state = "nboard0"
 	var/const/max_notices = 5
 
-/obj/structure/noticeboard/Initialize(var/ml)
+/obj/structure/noticeboard/Initialize(ml)
 	. = ..()
 
 	// Grab any mapped notices.
@@ -32,20 +34,6 @@
 				break
 
 	update_icon()
-
-/obj/structure/noticeboard/set_dir(var/ndir)
-	. = ..()
-	if(dir & SOUTH)
-		default_pixel_y = 32
-	else // NORTH is also 0-offset due to the icon.
-		default_pixel_y = 0
-	if(dir & WEST)
-		default_pixel_x = 32
-	else if(dir & EAST)
-		default_pixel_x = -32
-	else
-		default_pixel_x = 0
-	reset_offsets(0)
 
 /obj/structure/noticeboard/proc/add_paper(var/atom/movable/paper, var/skip_icon_update)
 	if(istype(paper))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -100,6 +100,7 @@ var/global/list/all_apcs = list()
 	initial_access = list(access_engine_equip)
 	clicksound = "switch"
 	layer = ABOVE_WINDOW_LAYER
+	directional_offset = "{'NORTH':{'y':22}, 'SOUTH':{'y':-22}, 'EAST':{'x':22}, 'WEST':{'x':-22}}"
 
 	var/powered_down = FALSE
 	var/area/area
@@ -292,21 +293,6 @@ var/global/list/all_apcs = list()
 			channel_leds[POWERCHAN_ON + 1] = overlay_image(icon,"apco[channel]",COLOR_LIME)
 			channel_leds[POWERCHAN_ON_AUTO + 1] = overlay_image(icon,"apco[channel]",COLOR_BLUE)
 			channel++
-
-	if(update_state < 0)
-		default_pixel_x = 0
-		default_pixel_y = 0
-		var/turf/T = get_step(get_turf(src), dir)
-		if(istype(T) && T.density)
-			if(dir == SOUTH)
-				default_pixel_y = -22
-			else if(dir == NORTH)
-				default_pixel_y = 22
-			else if(dir == EAST)
-				default_pixel_x = 22
-			else if(dir == WEST)
-				default_pixel_x = -22
-		reset_offsets()
 
 	var/update = check_updates() 		//returns 0 if no need to update icons.
 						// 1 if we need to update the icon_state

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -37,6 +37,7 @@
 	construct_state = /decl/machine_construction/wall_frame/panel_closed/simple
 	base_type = /obj/machinery/light
 	frame_type = /obj/item/frame/light
+	directional_offset = "{'NORTH':{'y':21}, 'EAST':{'x':10}, 'WEST':{'x':-10}}"
 
 	var/on = 0					// 1 if on, 0 if off
 	var/flickering = 0
@@ -108,18 +109,6 @@
 
 /obj/machinery/light/on_update_icon(var/trigger = 1)
 	atom_flags = atom_flags & ~ATOM_FLAG_CAN_BE_PAINTED
-	// Handle pixel offsets
-	default_pixel_y = 0
-	default_pixel_x = 0
-	var/turf/T = get_step(get_turf(src), src.dir)
-	if(istype(T) && T.density)
-		if(src.dir == NORTH)
-			default_pixel_y = 21
-		else if(src.dir == EAST)
-			default_pixel_x = 10
-		else if(src.dir == WEST)
-			default_pixel_x = -10
-	reset_offsets(0)
 
 	// Update icon state
 	cut_overlays()

--- a/code/modules/security levels/keycard_authentication.dm
+++ b/code/modules/security levels/keycard_authentication.dm
@@ -8,6 +8,8 @@
 	idle_power_usage = 2
 	active_power_usage = 6
 	power_channel = ENVIRON
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':-32}, 'WEST':{'x':32}}"
 
 	var/active = 0 //This gets set to 1 on all devices except the one where the initial request was made.
 	var/event = ""

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -5,22 +5,9 @@
 	anchored = 1
 	density = 0
 	layer = ABOVE_OBJ_LAYER
-
+	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':-32}, 'WEST':{'x':32}}"
 	var/datum/turbolift/lift
-
-/obj/structure/lift/set_dir(var/newdir)
-	. = ..()
-	default_pixel_x = 0
-	default_pixel_y = 0
-	if(dir & NORTH)
-		default_pixel_y = -32
-	else if(dir & SOUTH)
-		default_pixel_y = 32
-	else if(dir & EAST)
-		default_pixel_x = -32
-	else if(dir & WEST)
-		default_pixel_x = 32
-	reset_offsets(0)
 
 /obj/structure/lift/proc/pressed(var/mob/user)
 	if(!istype(user, /mob/living/silicon))
@@ -102,6 +89,8 @@
 
 /obj/structure/lift/panel/standalone
 	icon_state = "standing_panel"
+	obj_flags = 0
+	directional_offset = null
 
 /obj/structure/lift/panel/attack_ghost(var/mob/user)
 	return interact(user)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Added a json list for specifying an offset for each directions for any subclasses of ``/obj``.
The offsets in the list are overridden by mapper set values.

## Why and what will this PR improve
No more need to write a bunch of custom handling for wall offsets. Anything built in game is automatically correctly offset. Mappers don't need to set the pixel offsets in every single wall mounted obj now.

## Authorship
<!-- Describe original authors of changes to credit them. -->

## Changelog
:cl:
code: Objects can now specify an offset for each direction they may be facing, via a json encoded list. The offset is automatically applied to the object and updated. Unless the object has any mapper set offset.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->