### PR TITLE
Fix air alarm connectivity test with desperado

### DIFF
--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -112,7 +112,7 @@
 	. = ..()
 
 /obj/machinery/atmospherics/unary/vent_pump/reset_area(area/old_area, area/new_area)
-	if(controlled)
+	if(!controlled)
 		return
 	if(old_area == new_area)
 		return
@@ -232,7 +232,7 @@
 	return controlled ? ..() : "NONE"
 
 /obj/machinery/atmospherics/unary/vent_pump/proc/change_area_name(var/area/A, var/old_area_name, var/new_area_name)
-	if(controlled)
+	if(!controlled)
 		return
 	if(get_area(src) != A)
 		return

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -112,6 +112,8 @@
 	. = ..()
 
 /obj/machinery/atmospherics/unary/vent_pump/reset_area(area/old_area, area/new_area)
+	if(controlled)
+		return
 	if(old_area == new_area)
 		return
 	if(old_area)
@@ -230,6 +232,8 @@
 	return controlled ? ..() : "NONE"
 
 /obj/machinery/atmospherics/unary/vent_pump/proc/change_area_name(var/area/A, var/old_area_name, var/new_area_name)
+	if(controlled)
+		return
 	if(get_area(src) != A)
 		return
 	var/new_name = replacetext(A.air_vent_names[id_tag], old_area_name, new_area_name)

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -72,6 +72,8 @@
 	air_contents.volume = ATMOS_DEFAULT_VOLUME_FILTER
 
 /obj/machinery/atmospherics/unary/vent_scrubber/reset_area(area/old_area, area/new_area)
+	if(controlled)
+		return
 	if(old_area == new_area)
 		return
 	if(old_area)
@@ -99,6 +101,8 @@
 	build_device_underlays()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/proc/change_area_name(var/area/A, var/old_area_name, var/new_area_name)
+	if(controlled)
+		return
 	if(get_area(src) != A)
 		return
 	var/new_name = replacetext(A.air_scrub_names[id_tag], old_area_name, new_area_name)

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -72,7 +72,7 @@
 	air_contents.volume = ATMOS_DEFAULT_VOLUME_FILTER
 
 /obj/machinery/atmospherics/unary/vent_scrubber/reset_area(area/old_area, area/new_area)
-	if(controlled)
+	if(!controlled)
 		return
 	if(old_area == new_area)
 		return
@@ -101,7 +101,7 @@
 	build_device_underlays()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/proc/change_area_name(var/area/A, var/old_area_name, var/new_area_name)
-	if(controlled)
+	if(!controlled)
 		return
 	if(get_area(src) != A)
 		return

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -84,11 +84,21 @@
 		if(alarm.stat & (NOPOWER | BROKEN))
 			continue
 
-		for(var/tag in A.air_vent_names) // The point of this test is that while the names list is registered at init, the info is transmitted by radio.
+		//Make a list of devices that are being controlled by their air alarms
+		var/list/vents_in_area = list()
+		var/list/scrubbers_in_area = list()
+		for(var/obj/machinery/atmospherics/unary/vent_pump/V in A.contents)
+			if(V.controlled)
+				vents_in_area[V.id_tag] = V
+		for(var/obj/machinery/atmospherics/unary/vent_scrubber/V in A.contents)
+			if(V.controlled)
+				scrubbers_in_area[V.id_tag] = V
+
+		for(var/tag in vents_in_area) // The point of this test is that while the names list is registered at init, the info is transmitted by radio.
 			if(!A.air_vent_info[tag])
 				log_bad("Vent [A.air_vent_names[tag]] with id_tag [tag] did not update the air alarm in area [A].")
 				failed = TRUE
-		for(var/tag in A.air_scrub_names)
+		for(var/tag in scrubbers_in_area)
 			if(!A.air_scrub_info[tag])
 				log_bad("Scrubber [A.air_scrub_names[tag]] with id_tag [tag] did not update the air alarm in area [A].")
 				failed = TRUE

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -69,7 +69,7 @@
 	return 1
 
 /datum/unit_test/air_alarm_connectivity/subsystems_to_await()
-	return list(SStimer)
+	return list(SStimer, SSalarm, SSmachines)
 
 /datum/unit_test/air_alarm_connectivity/check_result()
 	var/failed = FALSE

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -96,11 +96,13 @@
 
 		for(var/tag in vents_in_area) // The point of this test is that while the names list is registered at init, the info is transmitted by radio.
 			if(!A.air_vent_info[tag])
-				log_bad("Vent [A.air_vent_names[tag]] with id_tag [tag] did not update the air alarm in area [A].")
+				var/obj/machinery/atmospherics/unary/vent_pump/V = vents_in_area[tag]
+				log_bad("Vent [A.air_vent_names[tag]] ([V.x], [V.y], [V.z]) with id_tag [tag] did not update the air alarm in area [A].")
 				failed = TRUE
 		for(var/tag in scrubbers_in_area)
 			if(!A.air_scrub_info[tag])
-				log_bad("Scrubber [A.air_scrub_names[tag]] with id_tag [tag] did not update the air alarm in area [A].")
+				var/obj/machinery/atmospherics/unary/vent_scrubber/V = scrubbers_in_area[tag]
+				log_bad("Scrubber [A.air_scrub_names[tag]] ([V.x], [V.y], [V.z]) with id_tag [tag] did not update the air alarm in area [A].")
 				failed = TRUE
 
 	if(failed)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
This modifies the air alarm connectivity test to check if the vent or scrubber being tested is actually allowed to be controlled by air alarms.
Seems to work locally.

For reference, uncontrolled vents would get listed by the air alarms. But then when the alarm would handle received message it would have its area uid set to area "NONE" which would get the messages ignored and cause the alarm to not fill the vent info list, which would fail the test.
```
/obj/machinery/atmospherics/unary/vent_pump/area_uid()
	return controlled ? ..() : "NONE"
```

The area uid is sent as a public var to the air alarm via radio signal, and ends up in this check, where it compares the area name with the one of the air alarm. That check fails so it never writes the message's data to the info list in the air alarm.
```
/obj/machinery/alarm/receive_signal(datum/signal/signal)
	if(!signal || signal.encryption)
		return
	if(alarm_id == signal.data["alarm_id"] && signal.data["command"] == "shutdown")
		mode = AALARM_MODE_OFF
		report_danger_level = FALSE
		apply_mode()
		return

	var/id_tag = signal.data["tag"]
	if (!id_tag)
		return
	if (signal.data["area"] != area_uid)
		return
```

## Changelog
:cl:
code: Made the air alarm connectivity unit test check if the vents and scrubbers it tests are allowed to be controlled via air alarms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->