### PR TITLE
Added some value clamping to reagent total updates.

### DIFF
--- a/code/modules/reagents/reactions/_reaction.dm
+++ b/code/modules/reagents/reactions/_reaction.dm
@@ -54,7 +54,7 @@
 
 	var/reaction_volume = holder.maximum_volume
 	for(var/reactant in required_reagents)
-		var/A = REAGENT_VOLUME(holder, reactant) / required_reagents[reactant] / limit // How much of this reagent we are allowed to use
+		var/A = round(REAGENT_VOLUME(holder, reactant) / required_reagents[reactant] / limit, MINIMUM_CHEMICAL_VOLUME)  // How much of this reagent we are allowed to use
 		if(reaction_volume > A)
 			reaction_volume = A
 


### PR DESCRIPTION
## Description of changes
Adds some more aggressive clamping and rounding to chemical values.
Fixes a value inversion in `update_total()`.
~~This is not a proper fix for the current reaction bugs but I am hoping it makes the game slightly more functional at least.~~ The rounding issue in `trans_to_holder` may have been causing the reaction bugs.

## Why and what will this PR improve
Bugs.

## Authorship
Alceris identified the `update_total()` issue.

## Changelog
Nothing player-facing.