### PR TITLE
Make tablets, laptops, and telescreen buildable at fab only

### DIFF
--- a/code/modules/fabrication/designs/protolathe/designs_computer_accessories.dm
+++ b/code/modules/fabrication/designs/protolathe/designs_computer_accessories.dm
@@ -31,3 +31,16 @@
 
 /datum/fabricator_recipe/protolathe/comp_acc/medical_scanner
 	path = /obj/item/stock_parts/computer/scanner/medical
+
+//////////////////////////////////////////////////////////////////
+// Frames
+//////////////////////////////////////////////////////////////////
+/datum/fabricator_recipe/protolathe/comp_frames
+	category = "Computer Frames"
+	path = /obj/item/modular_computer/laptop
+
+/datum/fabricator_recipe/protolathe/comp_frames/tablet_frame
+	path = /obj/item/modular_computer/tablet
+
+/datum/fabricator_recipe/protolathe/comp_frames/telescreen_frame
+	path = /obj/item/modular_computer/telescreen

--- a/code/modules/materials/definitions/solids/materials_solid_metal.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_metal.dm
@@ -206,7 +206,6 @@
 	. += new/datum/stack_recipe/apc(src)
 	. += new/datum/stack_recipe/air_alarm(src)
 	. += new/datum/stack_recipe/fire_alarm(src)
-	. += new/datum/stack_recipe_list("modular computer frames", create_recipe_list(/datum/stack_recipe/computer))
 
 /decl/material/solid/metal/steel/holographic
 	name = "holographic steel"

--- a/code/modules/materials/recipes_items.dm
+++ b/code/modules/materials/recipes_items.dm
@@ -123,21 +123,6 @@
 	result_type = /obj/item/frame/fire_alarm
 	difficulty = 2
 
-/datum/stack_recipe/computer/telescreen
-	title = "modular telescreen frame"
-	result_type = /obj/item/modular_computer/telescreen
-	difficulty = 2
-
-/datum/stack_recipe/computer/laptop
-	title = "modular laptop frame"
-	result_type = /obj/item/modular_computer/laptop
-	difficulty = 2
-
-/datum/stack_recipe/computer/tablet
-	title = "modular tablet frame"
-	result_type = /obj/item/modular_computer/tablet
-	difficulty = 2
-
 /datum/stack_recipe/hazard_cone
 	title = "hazard cone"
 	result_type = /obj/item/caution/cone


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Seemed like it was a bit weird that you were still able to craft those from scratch with just a sheet of metal. Plus its causing issues with some of the item damage stuff in another PR.

## Why and what will this PR improve
Helps uncluttering the material crafting menus.

## Authorship
<!-- Describe original authors of changes to credit them. -->

## Changelog
:cl:
tweak: Laptops, tablets, and telescreen are now only buildable at the protolathe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->