### PR TITLE
Allow premapped decal offset

### DIFF
--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -26,13 +26,15 @@ var/global/list/floor_decals = list()
 	var/turf/T = get_turf(src)
 	if(istype(T))
 		layer = T.is_plating() ? DECAL_PLATING_LAYER : DECAL_LAYER
-		var/cache_key = "[alpha]-[color]-[dir]-[icon_state]-[plane]-[layer]-[detail_overlay]-[detail_color]"
+		var/cache_key = "[alpha]-[color]-[dir]-[icon_state]-[plane]-[layer]-[detail_overlay]-[detail_color]-[pixel_x]-[pixel_y]"
 		if(!floor_decals[cache_key])
 			var/image/I = image(icon = src.icon, icon_state = src.icon_state, dir = src.dir)
 			I.layer = layer
 			I.appearance_flags = appearance_flags
 			I.color = src.color
 			I.alpha = src.alpha
+			I.pixel_x = src.pixel_x
+			I.pixel_y = src.pixel_y
 			if(detail_overlay)
 				I.overlays |= overlay_image(icon, "[detail_overlay]", color = detail_color, flags=RESET_COLOR)
 			floor_decals[cache_key] = I


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
![image](https://user-images.githubusercontent.com/44920739/190869588-1cd96ed9-eb0b-4d7a-b5aa-83dba542389e.png)
~Haha look I shitporting small things like before.~

Stole another QoL for mappers from OnyxBay.
Allows mappers to set pixel_x/y on decals and actually spawn them with offset.

## Why and what will this PR improve
Sometimes you really want to shift on-floor decals, like hatches, medical signs (or anything that less 32x32).
Thought there should be support for such scenarios.

## Authorship
https://github.com/ChaoticOnyx/OnyxBay/pull/9358