### PR TITLE
Fix duplicate datum regarding steel tiles

### DIFF
--- a/code/modules/materials/recipes_stacks.dm
+++ b/code/modules/materials/recipes_stacks.dm
@@ -32,7 +32,7 @@
 	title = "regular floor tile"
 	result_type = /obj/item/stack/tile/floor
 
-/datum/stack_recipe/tile/metal/floor
+/datum/stack_recipe/tile/metal/roof
 	title = "roofing tile"
 	result_type = /obj/item/stack/tile/roof
 


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Changes the roofing tile datum name from /datum/stack_recipe/tile/metal/floor to /datum/stack_recipe/tile/metal/roof

## Why and what will this PR improve
Duplicate datum name was preventing regular steel floor tiles from being craftable. Only the last entry with that datum name was showing up in the list (which was the roofing tile)

## Authorship
Qumefox

## Changelog
:cl:
bugfix: roofing tile datum name
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->