### PR TITLE
Item Dmg: Give material or health to a million items

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -281,3 +281,6 @@
 
 #define DECL_TYPE_IS_ABSTRACT(DECL) (initial(DECL.abstract_type) == DECL)
 #define DECL_INSTANCE_IS_ABSTRACT(DECL) (DECL.abstract_type == DECL.type)
+
+//Damage stuff
+#define ITEM_HEALTH_NO_DAMAGE -1

--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -61,6 +61,7 @@
 	w_class = ITEM_SIZE_TINY
 	icon = 'icons/obj/items/device/flash_synthetic.dmi'
 	icon_state = ICON_STATE_WORLD
+	health = ITEM_HEALTH_NO_DAMAGE
 	var/state = AWAITING_ACTIVATION
 	var/service_label = "Unnamed Service"
 	var/service_duration = 0 SECONDS

--- a/code/game/machinery/computer/arcade_orion.dm
+++ b/code/game/machinery/computer/arcade_orion.dm
@@ -476,7 +476,16 @@
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "ship"
 	w_class = ITEM_SIZE_SMALL
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/metal/steel   = MATTER_AMOUNT_SECONDARY,
+		/decl/material/solid/metal/copper  = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/lead    = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/uranium = MATTER_AMOUNT_TRACE,
+		/decl/material/solid/silicon       = MATTER_AMOUNT_TRACE,
+	)
 	var/active = 0 //if the ship is on
+
 /obj/item/orion_ship/examine(mob/user)
 	. = ..()
 	if(!(in_range(user, src)))

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -745,6 +745,7 @@ var/global/list/allCasters = list() //Global list that will contain reference to
 	w_class = ITEM_SIZE_SMALL	//Let's make it fit in trashbags!
 	attack_verb = list("bapped","thwapped","smacked")
 	force = 0
+	material = /decl/material/solid/cardboard //#TODO: replace with paper material
 
 	var/screen = 0
 	var/pages = 0

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -17,6 +17,7 @@ Buildable meters
 	level = 2
 	obj_flags = OBJ_FLAG_ROTATABLE
 	dir = SOUTH
+	material = /decl/material/solid/metal/steel
 	var/constructed_path = /obj/machinery/atmospherics/pipe/simple/hidden
 	var/pipe_class = PIPE_CLASS_BINARY
 	var/rotate_class = PIPE_ROTATE_STANDARD
@@ -110,6 +111,7 @@ Buildable meters
 	qdel(src)	// remove the pipe item
 
 /obj/item/machine_chassis
+	material = /decl/material/solid/metal/steel
 	var/build_type
 
 /obj/item/machine_chassis/Initialize()

--- a/code/game/machinery/slide_projector.dm
+++ b/code/game/machinery/slide_projector.dm
@@ -6,6 +6,7 @@
 	max_w_class = ITEM_SIZE_SMALL
 	max_storage_space = BASE_STORAGE_CAPACITY(ITEM_SIZE_SMALL)
 	use_sound = 'sound/effects/storage/toolbox.ogg'
+	material = /decl/material/solid/metal/steel
 	var/static/list/projection_types = list(
 		/obj/item/photo = /obj/effect/projection/photo,
 		/obj/item/paper = /obj/effect/projection/paper,

--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -6,6 +6,7 @@
 	desc = "You probably shouldn't be holding this."
 	icon = 'icons/obj/contraband.dmi'
 	force = 0
+	material = /decl/material/solid/cardboard //#TODO: Change to paper or something
 
 
 /obj/item/contraband/poster

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "remains"
 	anchored = 0
+	material = /decl/material/solid/bone
 
 /obj/item/remains/human
 	desc = "They look like human remains. They have a strange aura about them."
@@ -24,6 +25,7 @@
 	desc = "They look like the remains of something mechanical. They have a strange aura about them."
 	icon = 'icons/mob/robots/_gibs.dmi'
 	icon_state = "remainsrobot"
+	material = /decl/material/solid/metal/steel
 
 /obj/item/remains/mouse
 	desc = "They look like the remains of a small rodent."

--- a/code/game/objects/items/blackout.dm
+++ b/code/game/objects/items/blackout.dm
@@ -12,7 +12,7 @@
 	desc = "A complicated eletronic device of unknown purpose"
 	icon = 'icons/obj/items/blackout.dmi'
 	icon_state = "device_blackout-off"
-
+	health = ITEM_HEALTH_NO_DAMAGE
 	var/severity = 2
 	var/shots = 1
 	var/last_use = 0

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/items/blueprints.dmi'
 	icon_state = "blueprints"
 	attack_verb = list("attacked", "bapped", "hit")
-
+	material = /decl/material/solid/cardboard
 	var/valid_z_levels = list()
 	var/area_prefix
 

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -6,6 +6,7 @@
 	icon = 'icons/obj/closets/bodybag.dmi'
 	icon_state = "bodybag_folded"
 	w_class = ITEM_SIZE_SMALL
+	material = /decl/material/solid/plastic
 	
 /obj/item/bodybag/attack_self(mob/user)
 	var/obj/structure/closet/body_bag/R = new /obj/structure/closet/body_bag(user.loc)

--- a/code/game/objects/items/christmas.dm
+++ b/code/game/objects/items/christmas.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/obj/christmas.dmi'
 	icon_state = "cracker"
 	desc = "Directions for use: Requires two people, one to pull each end."
+	material = /decl/material/solid/cardboard
 	var/cracked = 0
 
 /obj/item/toy/xmas_cracker/attack(mob/target, mob/user)
@@ -41,6 +42,7 @@
 	desc = "A crappy paper crown that you are REQUIRED to wear."
 	flags_inv = 0
 	body_parts_covered = 0
+	material = /decl/material/solid/cardboard
 	var/list/permitted_colors = list(COLOR_RED, COLOR_ORANGE, COLOR_YELLOW, COLOR_GREEN, COLOR_BLUE, COLOR_INDIGO, COLOR_VIOLET)
 
 /obj/item/clothing/head/festive/Initialize()

--- a/code/game/objects/items/cryobag.dm
+++ b/code/game/objects/items/cryobag.dm
@@ -7,7 +7,6 @@
 	icon_state = "bodybag_folded"
 	origin_tech = "{'biotech':4}"
 	material = /decl/material/solid/plastic
-	material = /decl/material/solid/plastic
 	matter = list(
 		/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/metal/silver = MATTER_AMOUNT_TRACE,
@@ -115,6 +114,12 @@
 	desc = "Pretty useless now.."
 	icon_state = "bodybag_used"
 	icon = 'icons/obj/closets/cryobag.dmi'
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/silver = MATTER_AMOUNT_TRACE,
+		/decl/material/solid/metal/gold = MATTER_AMOUNT_TRACE
+	)
 
 /obj/structure/closet/body_bag/cryobag/blank
 	stasis_power = 60

--- a/code/game/objects/items/devices/auto_cpr.dm
+++ b/code/game/objects/items/devices/auto_cpr.dm
@@ -6,6 +6,14 @@
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = "{'magnets':2,'biotech':2}"
 	slot_flags = SLOT_OVER_BODY
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_SECONDARY,
+		/decl/material/solid/metal/copper    = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/silicon         = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/uranium   = MATTER_AMOUNT_TRACE,
+		/decl/material/solid/metal/lead      = MATTER_AMOUNT_TRACE,
+	)
 	var/last_pump
 	var/skilled_setup
 

--- a/code/game/objects/items/devices/binoculars.dm
+++ b/code/game/objects/items/devices/binoculars.dm
@@ -4,14 +4,14 @@
 	zoomdevicename = "eyepieces"
 	icon = 'icons/obj/items/binoculars.dmi'
 	icon_state = "binoculars"
-
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	force = 5.0
 	w_class = ITEM_SIZE_SMALL
 	throwforce = 5
 	throw_range = 15
 	throw_speed = 3
-
+	material = /decl/material/solid/plastic
+	matter = list(/decl/material/solid/glass = MATTER_AMOUNT_SECONDARY)
 
 /obj/item/binoculars/attack_self(mob/user)
 	if(zoom)

--- a/code/game/objects/items/devices/boombox.dm
+++ b/code/game/objects/items/devices/boombox.dm
@@ -7,6 +7,12 @@
 	force = 7
 	w_class = ITEM_SIZE_HUGE //forbid putting something that emits loud sounds forever into a backpack
 	origin_tech = "{'magnets':2,'combat':1}"
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/metal/copper    = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/silicon         = MATTER_AMOUNT_TRACE,
+	)
 	var/playing = 0
 	var/track_num = 1
 	var/volume = 20
@@ -193,4 +199,4 @@
 /obj/random_multi/single_item/boombox
 	name = "boombox spawnpoint"
 	id = "boomtastic"
-	item_path = /obj/item/boombox/
+	item_path = /obj/item/boombox

--- a/code/game/objects/items/devices/cable_painter.dm
+++ b/code/game/objects/items/devices/cable_painter.dm
@@ -7,6 +7,7 @@
 	var/color_selection
 	var/list/modes
 	w_class = ITEM_SIZE_SMALL
+	material = /decl/material/solid/plastic
 
 /obj/item/cable_painter/Initialize()
 	. = ..()

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -9,6 +9,7 @@
 	throw_range = 5
 	w_class = ITEM_SIZE_SMALL
 	origin_tech = "{'esoteric':4,'magnets':4}"
+	material = /decl/material/solid/plastic
 	var/can_use = 1
 	var/obj/effect/dummy/chameleon/active_dummy = null
 	var/saved_item = /obj/item/trash/cigbutt

--- a/code/game/objects/items/devices/dociler.dm
+++ b/code/game/objects/items/devices/dociler.dm
@@ -6,6 +6,8 @@
 	icon = 'icons/obj/items/device/animal_tagger.dmi'
 	icon_state = ICON_STATE_WORLD
 	force = 1
+	material = /decl/material/solid/plastic
+	matter = list(/decl/material/solid/metal/copper = MATTER_AMOUNT_REINFORCEMENT, /decl/material/solid/silicon = MATTER_AMOUNT_REINFORCEMENT)
 	var/loaded = 1
 	var/mode = "completely"
 

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -12,6 +12,13 @@
 	item_state = "multitool"
 	w_class = ITEM_SIZE_SMALL
 	action_button_name = "Toggle geiger counter"
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/metal/copper    = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/silicon         = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/glass           = MATTER_AMOUNT_TRACE,
+	)
 	var/scanning = 0
 	var/radiation_count = 0
 	var/datum/sound_token/sound_token

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -11,6 +11,13 @@
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_LOWER_BODY
 	req_access = list(list(access_heads, access_security))
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/metal/copper    = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/silicon         = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/glass           = MATTER_AMOUNT_TRACE,
+	)
 	var/datum/computer_file/report/warrant/active
 
 /obj/item/holowarrant/Initialize(ml, material_key)

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -6,7 +6,12 @@
 	item_state = "radio"
 	w_class = ITEM_SIZE_SMALL
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
-
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/metal/copper    = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/silicon         = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_SECONDARY,
+	)
 	var/spamcheck = 0
 	var/emagged = 0
 	var/insults = 0

--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -7,6 +7,7 @@
 	desc = "A kit containing all the needed tools and parts to modify a hardsuit for another user."
 	icon = 'icons/obj/items/modkit.dmi'
 	icon_state = "modkit"
+	material = /decl/material/solid/plastic
 	var/parts = MODKIT_FULL
 	var/target_bodytype = BODYTYPE_HUMANOID
 

--- a/code/game/objects/items/devices/paint_sprayer.dm
+++ b/code/game/objects/items/devices/paint_sprayer.dm
@@ -7,7 +7,7 @@
 	icon = 'icons/obj/items/device/paint_sprayer.dmi'
 	icon_state = ICON_STATE_WORLD
 	desc = "A slender and none-too-sophisticated device capable of applying paint on floors, walls, exosuits and certain airlocks."
-
+	material = /decl/material/solid/metal/stainlesssteel
 	var/decal =        "Quarter-turf"
 	var/paint_dir =    "Precise"
 	var/paint_color = COLOR_GRAY15

--- a/code/game/objects/items/devices/personal_shield.dm
+++ b/code/game/objects/items/devices/personal_shield.dm
@@ -3,6 +3,13 @@
 	desc = "Truely a life-saver: this device protects its user from being hit by objects moving very, very fast, though only for a few shots."
 	icon = 'icons/obj/items/weapon/batterer.dmi'
 	icon_state = "batterer"
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/metal/gold     = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/silicon        = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/metal/titanium = MATTER_AMOUNT_SECONDARY,
+		/decl/material/solid/metal/uranium  = MATTER_AMOUNT_TRACE,
+	)
 	var/uses = 5
 	var/obj/aura/personal_shield/device/shield
 

--- a/code/game/objects/items/devices/spy_bug.dm
+++ b/code/game/objects/items/devices/spy_bug.dm
@@ -15,6 +15,12 @@
 	throw_speed = 3
 
 	origin_tech = "{'programming':1,'engineering':1,'esoteric':3}"
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/metal/copper    = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/silicon         = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/glass           = MATTER_AMOUNT_TRACE,
+	)
 
 	var/obj/item/radio/spy/radio
 	var/obj/machinery/camera/spy/camera
@@ -56,10 +62,14 @@
 	icon = 'icons/obj/modular_computers/pda/pda.dmi'
 	icon_state = ICON_STATE_WORLD
 	color = COLOR_GRAY80
-
 	w_class = ITEM_SIZE_SMALL
-
 	origin_tech = "{'programming':1,'engineering':1,'esoteric':3}"
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/metal/copper = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/silicon = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/glass = MATTER_AMOUNT_TRACE,
+	)
 
 	var/obj/item/radio/spy/radio
 	var/obj/item/spy_bug/selected_camera

--- a/code/game/objects/items/devices/suit_sensor_jammer.dm
+++ b/code/game/objects/items/devices/suit_sensor_jammer.dm
@@ -7,6 +7,13 @@
 	icon = 'icons/obj/items/device/jammer.dmi'
 	icon_state = "jammer"
 	w_class = ITEM_SIZE_SMALL
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/metal/copper    = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/silicon         = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/metal/steel     = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/plutonium = MATTER_AMOUNT_TRACE,
+	)
 	var/active = FALSE
 	var/range = 2 // This is a radius, thus a range of 7 covers the entire visible screen
 	var/obj/item/cell/bcell = /obj/item/cell/high

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -25,6 +25,13 @@ effective or pretty fucking useless.
 	throw_range = 10
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	origin_tech = "{'magnets':3,'combat':3,'esoteric':3}"
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/metal/gold     = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/silicon        = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/metal/titanium = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/uranium  = MATTER_AMOUNT_TRACE,
+	)
 
 	var/times_used = 0 //Number of times it's been used.
 	var/max_uses = 2

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -3,6 +3,7 @@
 	desc = "A small, versatile valve with dual-headed heat-resistant pipes. This mechanism is the standard size for coupling with portable gas tanks."
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "valve_1"
+	material = /decl/material/solid/metal/stainlesssteel
 	var/obj/item/tank/tank_one
 	var/obj/item/tank/tank_two
 	var/obj/item/attached_device

--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -6,6 +6,13 @@
 	item_state = null
 	w_class = ITEM_SIZE_LARGE
 	slot_flags = SLOT_LOWER_BODY
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/metal/copper    = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/silicon         = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/glass           = MATTER_AMOUNT_TRACE,
+	)
 	var/channel = "General News Feed"
 	var/video_enabled = FALSE
 	var/obj/item/radio/radio
@@ -110,6 +117,7 @@ Using robohead because of restricting to roboticist */
 	item_state = "head"
 	var/buildstep = 0
 	w_class = ITEM_SIZE_LARGE
+	material = /decl/material/solid/metal/steel
 
 /obj/item/TVAssembly/attackby(var/obj/item/W, var/mob/user)
 	switch(buildstep)

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -13,6 +13,13 @@
 /obj/item/uplink
 	name = "hidden uplink"
 	desc = "There is something wrong if you're examining this."
+	health = ITEM_HEALTH_NO_DAMAGE
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/metal/copper    = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/silicon         = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_REINFORCEMENT,
+	)
 	var/active = 0
 	var/datum/uplink_category/category 	= 0		// The current category we are in
 	var/exploit_id								// Id of the current exploit record we are viewing

--- a/code/game/objects/items/devices/whistle.dm
+++ b/code/game/objects/items/devices/whistle.dm
@@ -5,7 +5,12 @@
 	icon_state = ICON_STATE_WORLD
 	w_class = ITEM_SIZE_TINY
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
-
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/metal/copper    = MATTER_AMOUNT_TRACE, 
+		/decl/material/solid/silicon         = MATTER_AMOUNT_TRACE, 
+		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_REINFORCEMENT,
+	)
 	var/use_message = "Halt! Security!"
 	var/spamcheck = 0
 	var/insults

--- a/code/game/objects/items/documents.dm
+++ b/code/game/objects/items/documents.dm
@@ -7,6 +7,7 @@
 	throwforce = 0
 	w_class = ITEM_SIZE_TINY
 	throw_range = 1
+	material = /decl/material/solid/cardboard //#TODO: Replace with paper
 	var/description_antag = "These conversations contain a massive amount of dirt on major figures: drugs, sex, money..."
 
 /obj/item/documents/examine(mob/user)

--- a/code/game/objects/items/dog_tags.dm
+++ b/code/game/objects/items/dog_tags.dm
@@ -6,7 +6,7 @@
 	slot_flags = SLOT_FACE | SLOT_TIE
 	badge_string = null
 	hide_on_uniform_rolldown = FALSE
-
+	material = /decl/material/solid/metal/stainlesssteel
 	var/owner_rank
 	var/owner_name
 	var/owner_branch

--- a/code/game/objects/items/instruments.dm
+++ b/code/game/objects/items/instruments.dm
@@ -9,6 +9,7 @@
 	desc = "An antique musical instrument made of wood, originating from Earth.	It has six metal strings of different girth and tension. When moved, they vibrate and the waves resonate in the guitar's open body, producing sounds. Obtained notes can be altered by pressing the strings to the neck, affecting the vibration's frequency."
 	icon = 'icons/obj/items/guitar.dmi'
 	icon_state = "guitar"
+	material = /decl/material/solid/wood
 
 /obj/item/instrument/guitar/attack_self(mob/user)
 	user.visible_message("<span class='notice'><b>\The [user]</b> strums [src]!</span>","<span class='notice'>You strum [src]!</span>")

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -9,6 +9,7 @@
 	w_class = ITEM_SIZE_SMALL
 	throw_speed = 1
 	throw_range = 15
+	material = /decl/material/solid/plastic
 	var/state
 	var/datum/gas_mixture/air_contents = null
 

--- a/code/game/objects/items/paintkit.dm
+++ b/code/game/objects/items/paintkit.dm
@@ -1,6 +1,7 @@
 /obj/item/kit
 	icon_state = "modkit"
 	icon = 'icons/obj/items/modkit.dmi'
+	material = /decl/material/solid/plastic
 	var/new_name = "exosuit"     // What is the variant called?
 	var/new_desc = "An exosuit." // How is the new exosuit described?
 	var/new_icon                 // What base icon will the new exosuit use?

--- a/code/game/objects/items/paper_fortune_teller.dm
+++ b/code/game/objects/items/paper_fortune_teller.dm
@@ -4,6 +4,7 @@
 	desc = "Origami, for children."
 	icon_state = "fortune"
 	icon = 'icons/obj/items/fortune_teller.dmi'
+	material = /decl/material/solid/cardboard //#TODO: change to paper
 	var/choice_counter = 0
 	var/busy = FALSE
 	var/list/fortunes = new(8)

--- a/code/game/objects/items/passport.dm
+++ b/code/game/objects/items/passport.dm
@@ -8,6 +8,8 @@
 	attack_verb = list("whipped")
 	hitsound = 'sound/weapons/towelwhip.ogg'
 	desc = "A set of identifying documents."
+	material = /decl/material/solid/cardboard
+	matter = list(/decl/material/solid/leather = MATTER_AMOUNT_REINFORCEMENT)
 	var/info
 
 /obj/item/passport/proc/set_info(mob/living/carbon/human/H)

--- a/code/game/objects/items/rescuebag.dm
+++ b/code/game/objects/items/rescuebag.dm
@@ -6,6 +6,8 @@
 	icon = 'icons/obj/closets/rescuebag.dmi'
 	icon_state = "folded"
 	origin_tech = "{'biotech':2}"
+	material = /decl/material/solid/plastic
+	matter = list(/decl/material/solid/silicon = MATTER_AMOUNT_SECONDARY)
 	var/obj/item/tank/airtank
 
 /obj/item/bodybag/rescue/loaded

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -1,4 +1,6 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:32
+/obj/item/borg
+	health = ITEM_HEALTH_NO_DAMAGE
 
 /**********************************************************************
 						Cyborg Spec Items

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "target_h"
 	density = 0
+	material = /decl/material/solid/plastic
 	var/obj/structure/target_stake/stake
 	var/hp = 1800
 	var/icon/virtualIcon

--- a/code/game/objects/items/spirit_board.dm
+++ b/code/game/objects/items/spirit_board.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "spirit_board"
 	density = TRUE
+	material = /decl/material/solid/wood
 	var/next_use = 0
 	var/planchette = "A"
 	var/lastuser = null

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -37,6 +37,7 @@
 	matter = null
 	uses_charge = 1
 	charge_costs = list(500)
+	health = ITEM_HEALTH_NO_DAMAGE
 
 /obj/item/stack/material/rods/Initialize()
 	. = ..()

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -12,7 +12,8 @@
 /obj/item/stack
 	gender = PLURAL
 	origin_tech = "{'materials':1}"
-
+	health = 32      //Stacks should take damage even if no materials
+	max_health = 32
 	/// A copy of initial matter list when this atom initialized. Stack matter should always assume a single tile.
 	var/list/matter_per_piece
 	var/singular_name

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -72,6 +72,7 @@
 	charge_costs = list(250)
 	stack_merge_type = /obj/item/stack/tile/wood
 	build_type = /obj/item/stack/tile/wood
+	health = ITEM_HEALTH_NO_DAMAGE
 
 /obj/item/stack/tile/mahogany
 	name = "mahogany floor tile"
@@ -223,6 +224,7 @@
 	charge_costs = list(250)
 	stack_merge_type = /obj/item/stack/tile/floor
 	build_type = /obj/item/stack/tile/floor
+	health = ITEM_HEALTH_NO_DAMAGE
 
 /obj/item/stack/tile/roof/cyborg
 	name = "roofing tile synthesizer"
@@ -233,7 +235,7 @@
 	charge_costs = list(500)
 	stack_merge_type = /obj/item/stack/tile/roof
 	build_type = /obj/item/stack/tile/roof
-
+	health = ITEM_HEALTH_NO_DAMAGE
 
 /obj/item/stack/tile/linoleum
 	name = "linoleum"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -29,6 +29,7 @@
 	throw_speed = 4
 	throw_range = 20
 	force = 0
+	material = /decl/material/solid/plastic
 
 /*
  * Balloons
@@ -617,14 +618,15 @@
 	edge = 0
 	sharp = 0
 
-/obj/item/inflatable_duck
+/obj/item/inflatable_duck //#TODO: Move under obj/item/toy ?
 	name = "inflatable duck"
 	desc = "No bother to sink or swim when you can just float!"
 	icon = 'icons/clothing/belt/inflatable.dmi'
 	icon_state = ICON_STATE_WORLD
 	slot_flags = SLOT_LOWER_BODY
+	material = /decl/material/solid/plastic
 
-/obj/item/marshalling_wand
+/obj/item/marshalling_wand //#TODO: Move under obj/item/toy ?
 	name = "marshalling wand"
 	desc = "An illuminated, hand-held baton used by hangar personnel to visually signal shuttle pilots. The signal changes depending on your intent."
 	icon_state = "marshallingwand"
@@ -634,6 +636,7 @@
 	w_class = ITEM_SIZE_SMALL
 	force = 1
 	attack_verb = list("attacked", "whacked", "jabbed", "poked", "marshalled")
+	material = /decl/material/solid/plastic
 
 /obj/item/marshalling_wand/Initialize()
 	set_light(1.5, 1.5, "#ff0000")

--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -15,6 +15,12 @@ RSF
 	var/stored_matter = 30
 	var/mode = 1
 	w_class = ITEM_SIZE_NORMAL
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/metal/steel  = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/glass        = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/silver = MATTER_AMOUNT_TRACE
+	)
 
 /obj/item/rsf/examine(mob/user, distance)
 	. = ..()

--- a/code/game/objects/items/weapons/beachball.dm
+++ b/code/game/objects/items/weapons/beachball.dm
@@ -11,6 +11,7 @@
 	throw_speed = 1
 	throw_range = 20
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	material = /decl/material/solid/plastic
 
 /obj/item/beach_ball/afterattack(atom/target, mob/user)
 	if(user.unEquip(src))

--- a/code/game/objects/items/weapons/candle/candle.dm
+++ b/code/game/objects/items/weapons/candle/candle.dm
@@ -87,5 +87,5 @@
 	max_w_class = ITEM_SIZE_TINY
 	max_storage_space = 7
 	slot_flags = SLOT_LOWER_BODY
-
+	material = /decl/material/solid/cardboard
 	startswith = list(/obj/item/flame/candle = 7)

--- a/code/game/objects/items/weapons/clothingbag.dm
+++ b/code/game/objects/items/weapons/clothingbag.dm
@@ -3,6 +3,7 @@
 	desc = "A cheap plastic bag that contains a fresh set of clothes."
 	icon = 'icons/obj/items/storage/trashbag.dmi'
 	icon_state = "trashbag3"
+	material = /decl/material/solid/plastic
 
 	var/icon_used = "trashbag0"
 	var/opened = 0

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -25,6 +25,11 @@
 	throw_speed = 3
 	throw_range = 15
 	attack_verb = list("HONKED")
+	material = /decl/material/solid/metal/steel
+	matter = list( 
+		/decl/material/solid/plastic = MATTER_AMOUNT_SECONDARY
+	)
+	item_flags = ITEM_FLAG_HOLLOW
 	var/spam_flag = 0
 	var/audio_files = list("sound/items/bikehorn.ogg")
 
@@ -43,3 +48,5 @@
 	icon_state = "air_horn"
 	item_state = "air_horn"
 	audio_files = list("sound/items/air_horn_1.ogg", "sound/items/air_horn_2.ogg")
+	material = /decl/material/solid/metal/aluminium
+	item_flags = ITEM_FLAG_HOLLOW

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -7,11 +7,13 @@
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
 	color = "#e00606"
+	material = /decl/material/solid/plastic
 	var/color_desc = "ruby"
 	var/open = FALSE
 
 /obj/item/lipstick/Initialize()
 	. = ..()
+	item_flags |= ITEM_FLAG_HOLLOW
 	if(color_desc)
 		desc += " This one is in [color_desc]."
 	update_icon()

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -4,6 +4,7 @@
 	desc = "An unbranded tube of lipstick."
 	icon = 'icons/obj/items/lipstick.dmi'
 	icon_state = "lipstick_0"
+	item_flags = ITEM_FLAG_HOLLOW
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
 	color = "#e00606"
@@ -13,7 +14,6 @@
 
 /obj/item/lipstick/Initialize()
 	. = ..()
-	item_flags |= ITEM_FLAG_HOLLOW
 	if(color_desc)
 		desc += " This one is in [color_desc]."
 	update_icon()

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -13,6 +13,12 @@
 	w_class = ITEM_SIZE_LARGE
 	origin_tech = "{'biotech':4,'powerstorage':2}"
 	action_button_name = "Remove/Replace Paddles"
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/metal/copper = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/steel  = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/silicon      = MATTER_AMOUNT_TRACE,
+	)
 
 	var/obj/item/shockpaddles/linked/paddles
 	var/obj/item/cell/bcell = null
@@ -196,6 +202,9 @@
 	force = 2
 	throwforce = 6
 	w_class = ITEM_SIZE_LARGE
+	material = /decl/material/solid/plastic
+	matter = list(/decl/material/solid/metal/copper = MATTER_AMOUNT_SECONDARY, /decl/material/solid/metal/steel = MATTER_AMOUNT_SECONDARY)
+	health = ITEM_HEALTH_NO_DAMAGE
 
 	var/safety = 1 //if you can zap people with the paddles on harm mode
 	var/combat = 0 //If it can be used to revive people wearing thick clothing (e.g. spacesuits)

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -6,6 +6,7 @@
 	w_class = ITEM_SIZE_TINY
 	var/sides = 6
 	attack_verb = list("diced")
+	material = /decl/material/solid/plastic
 
 /obj/item/dice/Initialize()
 	. = ..()

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -7,6 +7,7 @@
 	attack_verb = list("attacked", "poked", "battered")
 	body_parts_covered = 0
 	chem_volume = 0 //ecig has no storage on its own but has reagent container created by parent obj
+	material = /decl/material/solid/plastic
 
 	var/brightness_on = 1
 	var/obj/item/cell/cigcell

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -8,6 +8,11 @@
 	item_flags = ITEM_FLAG_NO_BLUDGEON
 	w_class = ITEM_SIZE_SMALL
 	origin_tech = "{'esoteric':2}"
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/silicon = MATTER_AMOUNT_TRACE,
+		//No RDX or explosive stuff to put in there.. :c
+	)
 	var/datum/wires/explosive/c4/wires = null
 	var/timer = 10
 	var/atom/target = null

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -11,7 +11,7 @@
 	material = /decl/material/solid/plastic
 	matter = list(
 		/decl/material/solid/silicon = MATTER_AMOUNT_TRACE,
-		//No RDX or explosive stuff to put in there.. :c
+		/decl/material/liquid/anfo = MATTER_AMOUNT_REINFORCEMENT, //#TODO: Slap RDX in here
 	)
 	var/datum/wires/explosive/c4/wires = null
 	var/timer = 10

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -43,6 +43,7 @@
 
 /obj/item/extinguisher/Initialize()
 	. = ..()
+	item_flags |= ITEM_FLAG_HOLLOW
 	create_reagents(max_water)
 	if(starting_water > 0)
 		reagents.add_reagent(/decl/material/liquid/water, starting_water)

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -6,6 +6,7 @@
 	item_state = "fire_extinguisher"
 	hitsound = 'sound/weapons/smash.ogg'
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	item_flags = ITEM_FLAG_HOLLOW
 	throwforce = 10
 	w_class = ITEM_SIZE_NORMAL
 	throw_speed = 2
@@ -43,7 +44,6 @@
 
 /obj/item/extinguisher/Initialize()
 	. = ..()
-	item_flags |= ITEM_FLAG_HOLLOW
 	create_reagents(max_water)
 	if(starting_water > 0)
 		reagents.add_reagent(/decl/material/liquid/water, starting_water)

--- a/code/game/objects/items/weapons/flame.dm
+++ b/code/game/objects/items/weapons/flame.dm
@@ -3,6 +3,7 @@
 	var/lit_heat = 1000
 	var/waterproof = FALSE
 	var/lit = 0
+	material = /decl/material/solid/wood
 
 /obj/item/flame/afterattack(var/obj/O, var/mob/user, proximity)
 	..()

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -14,6 +14,7 @@
 	icon_state = "gift1"
 	item_state = "gift1"
 	randpixel = 10
+	material = /decl/material/solid/cardboard
 
 /obj/item/a_gift/Initialize()
 	. = ..()
@@ -116,6 +117,7 @@
 	var/obj/item/gift = null
 	item_state = "gift"
 	w_class = ITEM_SIZE_HUGE
+	material = /decl/material/solid/cardboard
 
 /obj/item/gift/Initialize(mapload, obj/item/wrapped = null)
 	. = ..(mapload)
@@ -148,6 +150,7 @@
 	desc = "You can use this to wrap items in."
 	icon = 'icons/obj/items/gift_wrapper.dmi'
 	icon_state = "wrap_paper"
+	material = /decl/material/solid/cardboard //#TODO: Replace with paper
 	var/amount = 2.5*BASE_STORAGE_COST(ITEM_SIZE_HUGE)
 
 /obj/item/wrapping_paper/attackby(obj/item/W, mob/user)

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -9,6 +9,8 @@
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_LOWER_BODY
 	z_flags = ZMM_MANGLE_PLANES
+	item_flags = ITEM_FLAG_HOLLOW
+	material = /decl/material/solid/metal/steel
 	var/active
 	var/det_time = 50
 	var/fail_det_time = 5 // If you are clumsy and fail, you get this time.

--- a/code/game/objects/items/weapons/hair_care.dm
+++ b/code/game/objects/items/weapons/hair_care.dm
@@ -7,6 +7,7 @@
 	icon = 'icons/obj/items/comb.dmi'
 	icon_state = "comb"
 	item_state = "comb"
+	material = /decl/material/solid/plastic
 
 /obj/item/haircomb/random/Initialize()
 	. = ..()
@@ -25,6 +26,7 @@
 	slot_flags = null
 	icon_state = "brush"
 	item_state = "brush"
+	material = /decl/material/solid/plastic
 
 /obj/item/haircomb/brush/attack_self(mob/user)
 	if(ishuman(user) && !user.incapacitated())

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -4,7 +4,7 @@
 	gender = PLURAL
 	icon = 'icons/obj/items/handcuffs.dmi'
 	icon_state = ICON_STATE_WORLD
-	health = 0
+	health = ITEM_HEALTH_NO_DAMAGE
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_LOWER_BODY
 	throwforce = 5
@@ -130,6 +130,8 @@ var/global/last_chew = 0
 	cuff_type = "cable restraints"
 	elastic = 1
 	health = 75
+	max_health = 75
+	material = /decl/material/solid/plastic
 
 /obj/item/handcuffs/cable/red
 	color = COLOR_MAROON
@@ -167,3 +169,5 @@ var/global/last_chew = 0
 	breakouttime = 200
 	cuff_type = "duct tape"
 	health = 50
+	max_health = 50
+	material = /decl/material/solid/plastic

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -7,6 +7,7 @@
 	icon = 'icons/obj/items/implant/implant.dmi'
 	icon_state = "implant"
 	w_class = ITEM_SIZE_TINY
+	material = /decl/material/solid/metal/titanium
 	var/implanted = null
 	var/mob/imp_in = null
 	var/obj/item/organ/external/part = null

--- a/code/game/objects/items/weapons/implants/implantpad.dm
+++ b/code/game/objects/items/weapons/implants/implantpad.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/items/implant/implantpad.dmi'
 	icon_state = ICON_STATE_WORLD
 	w_class = ITEM_SIZE_SMALL
+	material = /decl/material/solid/metal/steel
 	var/obj/item/implant/imp
 
 /obj/item/implantpad/on_update_icon()

--- a/code/game/objects/items/weapons/ironing_iron.dm
+++ b/code/game/objects/items/weapons/ironing_iron.dm
@@ -10,7 +10,7 @@
 	throw_range = 10
 	force = 8.0
 	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
-
+	material = /decl/material/solid/metal/steel
 	var/enabled = 0
 
 /obj/item/ironingiron/attack_self(var/mob/user)

--- a/code/game/objects/items/weapons/janitor_sign.dm
+++ b/code/game/objects/items/weapons/janitor_sign.dm
@@ -9,6 +9,7 @@
 	throw_range = 5
 	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("warned", "cautioned", "smashed")
+	material = /decl/material/solid/plastic
 
 /obj/item/caution/cone
 	desc = "This cone is trying to warn you of something!"

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -13,32 +13,13 @@
 	lit_heat = 1500
 	material = /decl/material/solid/plastic
 	matter = list(/decl/material/solid/metal/steel = MATTER_AMOUNT_TRACE)
-	var/max_fuel = 5
-	var/random_colour = FALSE
-	var/list/available_colors = list(
-		COLOR_WHITE,
-		COLOR_BLUE_GRAY,
-		COLOR_GREEN_GRAY,
-		COLOR_BOTTLE_GREEN,
-		COLOR_DARK_GRAY,
-		COLOR_RED_GRAY,
-		COLOR_GUNMETAL,
-		COLOR_RED,
-		COLOR_YELLOW,
-		COLOR_CYAN,
-		COLOR_GREEN,
-		COLOR_VIOLET,
-		COLOR_NAVY_BLUE,
-		COLOR_PINK
-	)
+	var/tmp/max_fuel = 5
 
 /obj/item/flame/lighter/Initialize()
 	. = ..()
 	create_reagents(max_fuel)
 	reagents.add_reagent(/decl/material/liquid/fuel, max_fuel)
 	set_extension(src, /datum/extension/base_icon_state, icon_state)
-	if(random_colour)
-		color = pick(available_colors)
 	update_icon()
 	set_extension(src, /datum/extension/tool, list(TOOL_CAUTERY = TOOL_QUALITY_BAD))
 
@@ -146,7 +127,26 @@
 	name = "pink lighter"
 
 /obj/item/flame/lighter/random
-	random_colour = TRUE
+	var/static/list/available_colors = list(
+		COLOR_WHITE,
+		COLOR_BLUE_GRAY,
+		COLOR_GREEN_GRAY,
+		COLOR_BOTTLE_GREEN,
+		COLOR_DARK_GRAY,
+		COLOR_RED_GRAY,
+		COLOR_GUNMETAL,
+		COLOR_RED,
+		COLOR_YELLOW,
+		COLOR_CYAN,
+		COLOR_GREEN,
+		COLOR_VIOLET,
+		COLOR_NAVY_BLUE,
+		COLOR_PINK
+	)
+
+/obj/item/flame/lighter/random/Initialize(ml, material_key)
+	. = ..()
+	set_color(pick(available_colors))
 
 /******
  Zippo
@@ -157,15 +157,6 @@
 	icon_state = "zippo"
 	item_state = "zippo"
 	max_fuel = 10
-	available_colors = list(
-		COLOR_WHITE,
-		COLOR_WHITE,
-		COLOR_WHITE,
-		COLOR_DARK_GRAY,
-		COLOR_GUNMETAL,
-		COLOR_BRONZE,
-		COLOR_BRASS
-	)
 	material = /decl/material/solid/metal/stainlesssteel
 
 /obj/item/flame/lighter/zippo/on_update_icon()
@@ -203,14 +194,14 @@
 	name = "gunmetal zippo"
 
 /obj/item/flame/lighter/zippo/brass
-	color = COLOR_BRASS
 	name = "brass zippo"
 	material = /decl/material/solid/metal/brass
+	applies_material_colour = TRUE
 
 /obj/item/flame/lighter/zippo/bronze
-	color = COLOR_BRONZE
 	name = "bronze zippo"
 	material = /decl/material/solid/metal/bronze
+	applies_material_colour = TRUE
 
 /obj/item/flame/lighter/zippo/pink
 	color = COLOR_PINK
@@ -218,18 +209,34 @@
 
 //Spawn using the colour list in the master type
 /obj/item/flame/lighter/zippo/random
-	random_colour = TRUE
-/obj/item/flame/lighter/zippo/random/Initialize()
-	. = ..()
-	if(color == COLOR_BRASS)
-		set_material(/decl/material/solid/metal/brass)
-	else if(color == COLOR_BRONZE)
-		set_material(/decl/material/solid/metal/bronze)
+	var/static/list/available_materials = list(
+		/decl/material/solid/metal/brass,
+		/decl/material/solid/metal/bronze,
+		/decl/material/solid/metal/blackbronze,
+		/decl/material/solid/metal/stainlesssteel = list(null, COLOR_WHITE, COLOR_DARK_GRAY, COLOR_GUNMETAL), //null color is the natural material color
+	)
+	applies_material_colour = TRUE
+	applies_material_name = TRUE
+
+/obj/item/flame/lighter/zippo/random/Initialize(ml, material_key)
+	var/picked_mat = pick(available_materials)
+	var/picked_color
+	if(length(available_materials[picked_mat]))
+		var/list/available = available_materials[picked_mat]
+		picked_color = pick(available)
+		log_debug("Picked color : '[picked_color]' out of [length(available)]")
+		if(picked_color)
+			applies_material_colour = FALSE
+
+	. = ..(ml, picked_mat)
+
+	if(picked_color)
+		set_color(picked_color)
 
 //Legacy icon states for custom items
-/obj/item/flame/lighter/zippo/custom/Initialize()
+/obj/item/flame/lighter/zippo/custom/Initialize(ml, material_key)
 	. = ..()
-	color = null
+	set_color(null)
 
 /obj/item/flame/lighter/zippo/custom/on_update_icon()
 	. = ..()

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -7,6 +7,7 @@
 	w_class = ITEM_SIZE_TINY
 	throwforce = 4
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	item_flags = ITEM_FLAG_HOLLOW
 	slot_flags = SLOT_LOWER_BODY
 	attack_verb = list("burnt", "singed")
 	lit_heat = 1500
@@ -33,7 +34,6 @@
 
 /obj/item/flame/lighter/Initialize()
 	. = ..()
-	item_flags |= ITEM_FLAG_HOLLOW
 	create_reagents(max_fuel)
 	reagents.add_reagent(/decl/material/liquid/fuel, max_fuel)
 	set_extension(src, /datum/extension/base_icon_state, icon_state)

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -10,6 +10,8 @@
 	slot_flags = SLOT_LOWER_BODY
 	attack_verb = list("burnt", "singed")
 	lit_heat = 1500
+	material = /decl/material/solid/plastic
+	matter = list(/decl/material/solid/metal/steel = MATTER_AMOUNT_TRACE)
 	var/max_fuel = 5
 	var/random_colour = FALSE
 	var/list/available_colors = list(
@@ -31,6 +33,7 @@
 
 /obj/item/flame/lighter/Initialize()
 	. = ..()
+	item_flags |= ITEM_FLAG_HOLLOW
 	create_reagents(max_fuel)
 	reagents.add_reagent(/decl/material/liquid/fuel, max_fuel)
 	set_extension(src, /datum/extension/base_icon_state, icon_state)
@@ -163,6 +166,7 @@
 		COLOR_BRONZE,
 		COLOR_BRASS
 	)
+	material = /decl/material/solid/metal/stainlesssteel
 
 /obj/item/flame/lighter/zippo/on_update_icon()
 	. = ..()
@@ -201,10 +205,12 @@
 /obj/item/flame/lighter/zippo/brass
 	color = COLOR_BRASS
 	name = "brass zippo"
+	material = /decl/material/solid/metal/brass
 
 /obj/item/flame/lighter/zippo/bronze
 	color = COLOR_BRONZE
 	name = "bronze zippo"
+	material = /decl/material/solid/metal/bronze
 
 /obj/item/flame/lighter/zippo/pink
 	color = COLOR_PINK
@@ -213,6 +219,12 @@
 //Spawn using the colour list in the master type
 /obj/item/flame/lighter/zippo/random
 	random_colour = TRUE
+/obj/item/flame/lighter/zippo/random/Initialize()
+	. = ..()
+	if(color == COLOR_BRASS)
+		set_material(/decl/material/solid/metal/brass)
+	else if(color == COLOR_BRONZE)
+		set_material(/decl/material/solid/metal/bronze)
 
 //Legacy icon states for custom items
 /obj/item/flame/lighter/zippo/custom/Initialize()

--- a/code/game/objects/items/weapons/material/coins.dm
+++ b/code/game/objects/items/weapons/material/coins.dm
@@ -12,7 +12,7 @@
 	thrown_material_force_multiplier = 0.1
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
-
+	material = /decl/material/solid/metal/steel
 	var/can_flip = TRUE
 	var/datum/denomination/denomination
 

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -17,6 +17,15 @@
 	edge =              0
 	armor_penetration = 0
 
+	material = /decl/material/solid/metal/steel
+	matter = list(
+		/decl/material/solid/plastic          = MATTER_AMOUNT_SECONDARY,
+		/decl/material/solid/glass            = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/copper     = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/plutonium  = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/gemstone/diamond = MATTER_AMOUNT_REINFORCEMENT,
+	)
+
 	var/lighting_color = COLOR_SABER_GREEN
 
 	var/active = FALSE

--- a/code/game/objects/items/weapons/melee/energy_cutlass.dm
+++ b/code/game/objects/items/weapons/melee/energy_cutlass.dm
@@ -4,3 +4,4 @@
 	icon = 'icons/obj/items/weapon/e_cutlass.dmi'
 	lighting_color = COLOR_SABER_CUTLASS
 	active_parry_chance = 50
+	material = /decl/material/solid/metal/brass

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -11,6 +11,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = "{'combat':4}"
 	attack_verb = list("flicked", "whipped", "lashed")
+	material = /decl/material/solid/leather
 
 /obj/item/whip/abyssal
 	name = "abyssal whip"
@@ -34,6 +35,7 @@
 	force = 19
 	edge = TRUE
 	origin_tech = "{'combat':6,'materials':5}"
+	material = /decl/material/solid/leather/lizard
 
 /obj/item/whip/chainofcommand
 	name = "chain of command"
@@ -41,6 +43,7 @@
 	attack_verb = list("flogged", "whipped", "lashed", "disciplined")
 	icon_state = "chain"
 	item_state = "whip"
+	material = /decl/material/solid/metal/steel
 
 /obj/item/sword/replica/officersword
 	name = "fleet officer's sword"

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -9,6 +9,10 @@
 	throw_range = 10
 	w_class = ITEM_SIZE_NORMAL
 	attack_verb = list("mopped", "bashed", "bludgeoned", "whacked")
+	material = /decl/material/solid/wood
+	matter = list(
+		/decl/material/solid/cloth = MATTER_AMOUNT_SECONDARY,
+	)
 	var/mopping = 0
 	var/mopcount = 0
 	var/mopspeed = 40

--- a/code/game/objects/items/weapons/nuclear_cylinder.dm
+++ b/code/game/objects/items/weapons/nuclear_cylinder.dm
@@ -11,3 +11,4 @@
 	throw_speed = 2
 	throw_range = 4
 	origin_tech = "{'materials':3,'engineering':4}"
+	health = ITEM_HEALTH_NO_DAMAGE

--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -9,6 +9,7 @@
 	throw_speed = 4
 	throw_range = 20
 	origin_tech = "{'wormholes':4}"
+	material = /decl/material/solid/cardboard //#TODO: Replace with paper
 
 /obj/item/teleportation_scroll/attack_self(mob/user)
 	var/decl/special_role/wizard/wizards = GET_DECL(/decl/special_role/wizard)

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -152,6 +152,13 @@
 	w_class = ITEM_SIZE_SMALL
 	origin_tech = "{'materials':4,'magnets':3,'esoteric':4}"
 	attack_verb = list("shoved", "bashed")
+	material = /decl/material/solid/metal/titanium
+	matter = list(
+		/decl/material/solid/fiberglass       = MATTER_AMOUNT_SECONDARY,
+		/decl/material/solid/metal/gold       = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/silicon          = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/gemstone/diamond = MATTER_AMOUNT_TRACE,
+	)
 	var/active = 0
 	var/shield_light_color = "#006aff"
 

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -9,6 +9,9 @@
 	throwforce = 0
 	throw_speed = 4
 	throw_range = 20
+	material = /decl/material/liquid/cleaner
+	health = 5
+	max_health = 5
 	var/key_data
 
 	var/list/valid_colors = list(COLOR_GREEN_GRAY, COLOR_RED_GRAY, COLOR_BLUE_GRAY, COLOR_BROWN, COLOR_PALE_PINK, COLOR_PALE_BTL_GREEN, COLOR_OFF_WHITE, COLOR_GRAY40, COLOR_GOLD)

--- a/code/game/objects/items/weapons/staff.dm
+++ b/code/game/objects/items/weapons/staff.dm
@@ -26,4 +26,4 @@
 	icon_state = "cane"
 	item_state = "stick"
 	material = /decl/material/solid/wood/ebony
-	matter = list(/decl/material/solid/plastic = MATTER_AMOUNT_TRACE) //No ivory material :c
+	matter = list(/decl/material/solid/bone = MATTER_AMOUNT_TRACE) //No ivory material :c

--- a/code/game/objects/items/weapons/staff.dm
+++ b/code/game/objects/items/weapons/staff.dm
@@ -9,12 +9,15 @@
 	throw_range = 5
 	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("bludgeoned", "whacked", "disciplined")
+	material = /decl/material/solid/wood
 
 /obj/item/staff/broom
 	name = "broom"
 	desc = "Used for sweeping, and flying into the night while cackling. Black cat not included."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "broom"
+	material = /decl/material/solid/wood
+	matter = list(/decl/material/solid/cloth = MATTER_AMOUNT_SECONDARY)
 
 /obj/item/staff/gentcane
 	name = "gentleman's cane"
@@ -22,3 +25,5 @@
 	icon = 'icons/obj/items/cane.dmi'
 	icon_state = "cane"
 	item_state = "stick"
+	material = /decl/material/solid/wood/ebony
+	matter = list(/decl/material/solid/plastic = MATTER_AMOUNT_TRACE) //No ivory material :c

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -6,6 +6,8 @@
 	allow_quick_empty = 1
 	use_to_pickup = 1
 	slot_flags = SLOT_LOWER_BODY
+	material = /decl/material/solid/plastic
+	item_flags = ITEM_FLAG_HOLLOW
 
 /obj/item/storage/bag/handle_item_insertion(obj/item/W, prevent_warning = 0)
 	. = ..()

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -12,6 +12,7 @@
 	slot_flags = SLOT_LOWER_BODY
 	var/overlay_flags
 	attack_verb = list("whipped", "lashed", "disciplined")
+	material = /decl/material/solid/leather/synth
 
 /obj/item/storage/belt/verb/toggle_layer()
 	set name = "Switch Belt Layer"
@@ -445,6 +446,8 @@
 	max_w_class = ITEM_SIZE_SMALL
 	max_storage_space = ITEM_SIZE_SMALL * 4
 	slot_flags = SLOT_LOWER_BODY | SLOT_BACK
+	material = /decl/material/solid/cloth
+	matter = list(/decl/material/solid/plastic = MATTER_AMOUNT_REINFORCEMENT)
 
 /obj/item/storage/belt/waistpack/big
 	name = "large waist pack"
@@ -470,6 +473,7 @@
 		/obj/item/inflatable,
 		/obj/item/inflatable/door
 		)
+	material = /decl/material/solid/fiberglass //need something that doesn't burn
 
 
 /obj/item/storage/belt/fire_belt/full

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -8,6 +8,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	max_w_class = ITEM_SIZE_SMALL
 	max_storage_space = 4
+	material = /decl/material/solid/cardboard
 	var/mob/affecting = null
 	var/deity_name = "Christ"
 	var/renamed = 0

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -28,6 +28,7 @@
 	max_storage_space = DEFAULT_BOX_STORAGE
 	use_sound = 'sound/effects/storage/box.ogg'
 	material = /decl/material/solid/cardboard
+	item_flags = ITEM_FLAG_HOLLOW
 	var/foldable = /obj/item/stack/material/cardstock	// BubbleWrap - if set, can be folded (when empty) into a sheet of cardboard
 
 /obj/item/storage/box/large

--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -11,3 +11,5 @@
 	w_class = ITEM_SIZE_HUGE
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = DEFAULT_BACKPACK_STORAGE
+	material = /decl/material/solid/leather/synth
+	matter = list(/decl/material/solid/plastic = MATTER_AMOUNT_SECONDARY)

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -12,6 +12,8 @@
 /obj/item/storage/fancy
 	item_state = "syringe_kit" //placeholder, many of these don't have inhands
 	opened = 0 //if an item has been removed from this container
+	item_flags = ITEM_FLAG_HOLLOW
+	material = /decl/material/solid/cardboard
 	var/obj/item/key_type //path of the key item that this "fancy" container is meant to store
 
 /obj/item/storage/fancy/on_update_icon()
@@ -45,14 +47,13 @@
 	storage_slots = 12
 	max_w_class = ITEM_SIZE_SMALL
 	w_class = ITEM_SIZE_NORMAL
-
 	key_type = /obj/item/chems/food/egg
 	can_hold = list(
 		/obj/item/chems/food/egg,
 		/obj/item/chems/food/boiledegg
 		)
-
 	startswith = list(/obj/item/chems/food/egg = 12)
+	material = /decl/material/solid/cardboard
 
 /obj/item/storage/fancy/egg_box/empty
 	startswith = null
@@ -71,6 +72,7 @@
 	key_type = /obj/item/chems/food/cracker
 	can_hold = list(/obj/item/chems/food/cracker)
 	startswith = list(/obj/item/chems/food/cracker = 6)
+	material = /decl/material/solid/cardboard
 
 /*
  * Crayon Box
@@ -84,7 +86,6 @@
 	w_class = ITEM_SIZE_SMALL
 	max_w_class = ITEM_SIZE_TINY
 	max_storage_space = 6
-
 	key_type = /obj/item/pen/crayon
 	startswith = list(
 		/obj/item/pen/crayon/red,
@@ -94,6 +95,7 @@
 		/obj/item/pen/crayon/blue,
 		/obj/item/pen/crayon/purple,
 		)
+	material = /decl/material/solid/cardboard
 
 /obj/item/storage/fancy/crayons/on_update_icon()
 	. = ..()
@@ -118,7 +120,7 @@
 	max_storage_space = 6
 	throwforce = 2
 	slot_flags = SLOT_LOWER_BODY
-
+	material = /decl/material/solid/cardboard
 	key_type = /obj/item/clothing/mask/smokable/cigarette
 	startswith = list(/obj/item/clothing/mask/smokable/cigarette = 6)
 
@@ -267,7 +269,7 @@
 	throwforce = 2
 	slot_flags = SLOT_LOWER_BODY
 	storage_slots = 7
-
+	material = /decl/material/solid/wood/mahogany
 	key_type = /obj/item/clothing/mask/smokable/cigarette/cigar
 	startswith = list(/obj/item/clothing/mask/smokable/cigarette/cigar = 6)
 
@@ -293,7 +295,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	max_w_class = ITEM_SIZE_TINY
 	storage_slots = 12
-
+	material = /decl/material/solid/plastic
 	key_type = /obj/item/chems/glass/beaker/vial
 	startswith = list(/obj/item/chems/glass/beaker/vial = 12)
 
@@ -316,6 +318,7 @@
 	max_storage_space = null
 	storage_slots = 12
 	req_access = list(access_virology)
+	material = /decl/material/solid/metal/stainlesssteel
 
 /obj/item/storage/lockbox/vials/Initialize()
 	. = ..()

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -17,6 +17,8 @@
 	max_w_class = ITEM_SIZE_SMALL
 	max_storage_space = DEFAULT_BOX_STORAGE
 	use_sound = 'sound/effects/storage/box.ogg'
+	item_flags = ITEM_FLAG_HOLLOW
+	material = /decl/material/solid/plastic
 
 /obj/item/storage/firstaid/empty
 	icon_state = "firstaid"

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -1,6 +1,7 @@
 //A storage item intended to be used by other items to provide storage functionality.
 //Types that use this should consider overriding emp_act() and hear_talk(), unless they shield their contents somehow.
 /obj/item/storage/internal
+	health = ITEM_HEALTH_NO_DAMAGE
 	var/obj/item/master_item
 
 /obj/item/storage/internal/Initialize()

--- a/code/game/objects/items/weapons/storage/laundry_basket.dm
+++ b/code/game/objects/items/weapons/storage/laundry_basket.dm
@@ -18,6 +18,8 @@
 	allow_quick_empty = 1
 	allow_quick_gather = 1
 	collection_mode = 1
+	material = /decl/material/solid/plastic
+	item_flags = ITEM_FLAG_HOLLOW
 	var/linked
 
 /obj/item/storage/laundry_basket/attack_hand(mob/user)

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -10,6 +10,7 @@
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = 32 //The sum of the w_classes of all the items in this storage item.
 	req_access = list(access_armory)
+	material = /decl/material/solid/metal/stainlesssteel
 	var/locked = 1
 	var/broken = 0
 	var/icon_locked = "lockbox+l"

--- a/code/game/objects/items/weapons/storage/lunchbox.dm
+++ b/code/game/objects/items/weapons/storage/lunchbox.dm
@@ -9,6 +9,7 @@
 	max_w_class = ITEM_SIZE_SMALL
 	var/filled = FALSE
 	attack_verb = list("lunched")
+	material = /decl/material/solid/plastic
 
 /obj/item/storage/lunchbox/Initialize()
 	. = ..()

--- a/code/game/objects/items/weapons/storage/med_pouch.dm
+++ b/code/game/objects/items/weapons/storage/med_pouch.dm
@@ -12,6 +12,7 @@ Single Use Emergency Pouches
 	icon_state = "pack0"
 	opened = FALSE
 	open_sound = 'sound/effects/rip1.ogg'
+	material = /decl/material/solid/plastic
 	var/injury_type = "generic"
 	var/static/image/cross_overlay
 

--- a/code/game/objects/items/weapons/storage/misc.dm
+++ b/code/game/objects/items/weapons/storage/misc.dm
@@ -3,6 +3,7 @@
 	desc = "It's a small bag with dice inside."
 	icon = 'icons/obj/dice.dmi'
 	icon_state = "dicebag"
+	material = /decl/material/solid/cloth
 
 /obj/item/storage/pill_bottle/dice/Initialize()
 	. = ..()
@@ -62,6 +63,7 @@
 	throwforce = 2
 	slot_flags = SLOT_LOWER_BODY
 	startswith = list(/obj/item/paper/cig = 10)
+	material = /decl/material/solid/plastic
 
 /obj/item/storage/cigpaper/fancy
 	name = "\improper Trident cigarette paper"
@@ -86,6 +88,7 @@
 	throwforce = 2
 	slot_flags = SLOT_LOWER_BODY
 	startswith = list(/obj/item/clothing/mask/chewable/tobacco = 6)
+	material = /decl/material/solid/metal/tin
 
 //loose leaf
 /obj/item/storage/chewables/rollable
@@ -132,6 +135,9 @@
 	startswith = list(/obj/item/clothing/mask/chewable/tobacco/nico = 6)
 
 //non-tobacco
+/obj/item/storage/chewables/candy
+	material = /decl/material/solid/plastic
+
 /obj/item/storage/chewables/candy/cookies
 	name = "pack of Getmore Cookies"
 	desc = "A pack of delicious cookies, and possibly the only product in Getmores Chocolate Corp lineup that has any trace of chocolate in it."
@@ -162,6 +168,7 @@
 	startswith = list(/obj/item/clothing/mask/chewable/candy/lolli/weak_meds = 15)
 	drop_sound = 'sound/foley/bottledrop1.ogg'
 	pickup_sound = 'sound/foley/bottlepickup1.ogg'
+	material = /decl/material/solid/glass
 
 /obj/item/storage/medical_lolli_jar/on_update_icon()
 	. = ..()

--- a/code/game/objects/items/weapons/storage/mre.dm
+++ b/code/game/objects/items/weapons/storage/mre.dm
@@ -11,6 +11,8 @@ MRE Stuff
 	max_w_class = ITEM_SIZE_SMALL
 	opened = FALSE
 	open_sound = 'sound/effects/rip1.ogg'
+	material = /decl/material/solid/plastic
+	item_flags = ITEM_FLAG_HOLLOW
 	var/main_meal = /obj/item/storage/mrebag
 	var/meal_desc = "This one is menu 1, meat pizza."
 	startswith = list(
@@ -128,6 +130,8 @@ MRE Stuff
 	opened = FALSE
 	open_sound = 'sound/effects/bubbles.ogg'
 	startswith = list(/obj/item/chems/food/slice/meatpizza/filled)
+	material = /decl/material/solid/plastic
+	matter = list(/decl/material/solid/metal/aluminium = MATTER_AMOUNT_TRACE)
 
 /obj/item/storage/mrebag/on_update_icon()
 	. = ..()

--- a/code/game/objects/items/weapons/storage/picnic_basket.dm
+++ b/code/game/objects/items/weapons/storage/picnic_basket.dm
@@ -8,7 +8,7 @@
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = DEFAULT_BOX_STORAGE
 	attack_verb = list("picnics")
-
+	material = /decl/material/solid/plastic
 	var/filled = FALSE
 
 /obj/item/storage/picnic_basket/Initialize()

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -15,6 +15,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	max_w_class = ITEM_SIZE_SMALL
 	max_storage_space = DEFAULT_BOX_STORAGE
+	material = /decl/material/solid/metal/steel
 	var/lock_type = /datum/extension/lockable/storage
 	var/icon_locking = "secureb"
 	var/icon_opened = "secure0"
@@ -88,6 +89,7 @@
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = DEFAULT_BACKPACK_STORAGE
 	use_sound = 'sound/effects/storage/briefcase.ogg'
+	matter = list(/decl/material/solid/plastic = MATTER_AMOUNT_REINFORCEMENT)
 
 /obj/item/storage/secure/briefcase/attack_hand(mob/user as mob)
 	var/datum/extension/lockable/lock = get_extension(src, /datum/extension/lockable)

--- a/code/game/objects/items/weapons/storage/specialized.dm
+++ b/code/game/objects/items/weapons/storage/specialized.dm
@@ -47,6 +47,8 @@
 	allow_quick_gather = TRUE
 	allow_quick_empty = TRUE
 	use_to_pickup = TRUE
+	material = /decl/material/solid/metal/stainlesssteel
+	matter = list(/decl/material/solid/plastic = MATTER_AMOUNT_REINFORCEMENT)
 
 // -----------------------------
 //          Plant bag
@@ -84,7 +86,7 @@
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "sheetsnatcher"
 	desc = "A patented storage system designed for any kind of mineral sheet."
-
+	material = /decl/material/solid/plastic
 	storage_ui = /datum/storage_ui/default/sheetsnatcher
 
 	var/capacity = 300; //the number of sheets it can carry.

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -17,6 +17,7 @@
 	origin_tech = "{'combat':1}"
 	attack_verb = list("robusted")
 	use_sound = 'sound/effects/storage/toolbox.ogg'
+	material = /decl/material/solid/metal/aluminium
 
 /obj/item/storage/toolbox/emergency
 	name = "emergency toolbox"

--- a/code/game/objects/items/weapons/storage/wall_mirror.dm
+++ b/code/game/objects/items/weapons/storage/wall_mirror.dm
@@ -11,6 +11,8 @@
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = DEFAULT_LARGEBOX_STORAGE
 	use_sound = 'sound/effects/closet_open.ogg'
+	material = /decl/material/solid/glass
+	matter = list(/decl/material/solid/metal/aluminium = MATTER_AMOUNT_SECONDARY)
 	var/shattered = 0
 	var/list/ui_users
 
@@ -74,6 +76,11 @@
 	desc = "A SalonPro Nano-Mirror(TM) brand mirror! Now a portable version."
 	icon = 'icons/obj/items/mirror.dmi'
 	icon_state = "mirror"
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/glass = MATTER_AMOUNT_SECONDARY, 
+		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_SECONDARY
+	)
 	var/list/ui_users
 
 /obj/item/mirror/attack_self(mob/user)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -13,6 +13,12 @@
 	origin_tech = "{'combat':2}"
 	attack_verb = list("beaten")
 	base_parry_chance = 30
+	material = /decl/material/solid/metal/aluminium
+	matter = list(
+		/decl/material/solid/plastic      = MATTER_AMOUNT_SECONDARY,
+		/decl/material/solid/metal/copper = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/silicon      = MATTER_AMOUNT_REINFORCEMENT,
+	)
 	var/stunforce = 0
 	var/agonyforce = 30
 	var/status = 0		//whether the thing is on or not
@@ -248,3 +254,4 @@
 	hitcost = 25
 	attack_verb = list("poked")
 	slot_flags = null
+	matter = list(/decl/material/solid/plastic = MATTER_AMOUNT_TRACE, /decl/material/solid/metal/copper = MATTER_AMOUNT_TRACE)

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -224,7 +224,9 @@
 	icon_state = "bone-gel"
 	force = 0
 	w_class = ITEM_SIZE_SMALL
+	item_flags = ITEM_FLAG_HOLLOW | ITEM_FLAG_NO_BLUDGEON
 	throwforce = 1
+	material = /decl/material/solid/plastic
 
 /obj/item/bonegel/Initialize()
 	. = ..()

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -14,6 +14,7 @@
 	icon_state = ICON_STATE_WORLD
 	slot_flags = SLOT_LOWER_BODY
 	force = 10
+	material = /decl/material/solid/wood
 
 /obj/item/classic_baton/attack(mob/M, mob/living/user)
 	if ((MUTATION_CLUMSY in user.mutations) && prob(50))
@@ -36,6 +37,7 @@
 	slot_flags = SLOT_LOWER_BODY
 	w_class = ITEM_SIZE_SMALL
 	force = 3
+	material = /decl/material/solid/metal/aluminium
 	var/on = 0
 
 /obj/item/telebaton/attack_self(mob/user)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -39,6 +39,7 @@ var/global/list/global/tank_gauge_cache = list()
 	throwforce = 10.0
 	throw_speed = 1
 	throw_range = 4
+	material = /decl/material/solid/metal/steel
 
 	var/datum/gas_mixture/air_contents = null
 	var/distribute_pressure = ONE_ATMOSPHERE

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -11,6 +11,8 @@
 	max_amount       = 32
 	w_class          = ITEM_SIZE_SMALL
 	material         = /decl/material/solid/plastic
+	health           = 10
+	max_health       = 10
 
 /obj/item/stack/tape_roll/can_split()
 	return FALSE

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -360,6 +360,7 @@
 	w_class = ITEM_SIZE_SMALL
 	force = 5
 	throwforce = 5
+	material = /decl/material/solid/metal/steel
 	var/max_fuel = 20
 	var/can_refuel = 1
 	var/size_in_use = ITEM_SIZE_NORMAL

--- a/code/game/objects/items/weapons/towels.dm
+++ b/code/game/objects/items/weapons/towels.dm
@@ -9,6 +9,7 @@
 	attack_verb = list("whipped")
 	hitsound = 'sound/weapons/towelwhip.ogg'
 	desc = "A soft cotton towel."
+	material = /decl/material/solid/cloth
 
 /obj/item/towel/attack_self(mob/user)
 	if(user.a_intent == I_GRAB)
@@ -24,10 +25,12 @@
 /obj/item/towel/black
 	name = "black towel"
 	color = "#222222"
+	material = /decl/material/solid/cloth/black
 
 /obj/item/towel/brown
 	name = "black towel"
 	color = "#854636"
+	material = /decl/material/solid/cloth/beige
 
 /obj/item/towel/fleece // loot from the king of goats. it's a golden towel
 	name = "golden fleece"
@@ -35,6 +38,7 @@
 	color = "#ffd700"
 	force = 1
 	attack_verb = list("smote")
+	material = /decl/material/solid/metal/gold
 
 /obj/item/towel/verb/lay_out()
 	set name = "Lay Out Towel"

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -10,6 +10,8 @@
 	throw_range = 4
 	throwforce = 7
 	w_class = ITEM_SIZE_NORMAL
+	material = /decl/material/solid/glass
+	health = ITEM_HEALTH_NO_DAMAGE
 
 /obj/item/nullrod/attack(mob/M, mob/living/user) //Paste from old-code to decult with a null rod.
 	admin_attack_log(user, M, "Attacked using \a [src]", "Was attacked with \a [src]", "used \a [src] to attack")
@@ -68,6 +70,8 @@
 	icon_state = "energynet"
 	throwforce = 0
 	force = 0
+	health = 100
+	max_health = 100
 	var/net_type = /obj/effect/energy_net
 
 /obj/item/energy_net/safari

--- a/code/game/objects/items/weapons/weldbackpack.dm
+++ b/code/game/objects/items/weapons/weldbackpack.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/items/welderpack.dmi'
 	icon_state = ICON_STATE_WORLD
 	w_class = ITEM_SIZE_HUGE
+	material = /decl/material/solid/metal/steel
 	var/max_fuel = 350
 	var/obj/item/weldingtool/welder
 

--- a/code/game/objects/structures/drain.dm
+++ b/code/game/objects/structures/drain.dm
@@ -50,7 +50,7 @@
 	desc = "You probably can't get sucked down the plughole."
 	icon = 'icons/obj/drain.dmi'
 	icon_state = "drain"
-
+	material = /decl/material/solid/metal/brass
 	var/constructed_type = /obj/structure/hygiene/drain
 
 /obj/item/drain/attackby(var/obj/item/thing, var/mob/user)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -264,3 +264,5 @@
 	icon = 'icons/obj/vehicles.dmi'
 	icon_state = "keys"
 	w_class = ITEM_SIZE_TINY
+	material = /decl/material/solid/metal/steel
+	matter = list(/decl/material/solid/plastic = MATTER_AMOUNT_TRACE)

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -34,6 +34,7 @@
 	desc = ""
 	icon = 'icons/obj/decals.dmi'
 	w_class = ITEM_SIZE_NORMAL		//big
+	material = /decl/material/solid/plastic
 	var/sign_state = ""
 
 /obj/item/sign/attackby(obj/item/W, mob/user)	//construction
@@ -420,6 +421,11 @@
 	icon = 'icons/obj/decals.dmi'
 	icon_state = "goldenplaque"
 	sign_state = "goldenplaque"
+	material = /decl/material/solid/wood
+	matter = list(
+		/decl/material/solid/glass     = MATTER_AMOUNT_SECONDARY,
+		/decl/material/solid/cardboard = MATTER_AMOUNT_REINFORCEMENT, //#TODO: Change to paper
+	)
 	var/claimant
 
 /obj/item/sign/medipolma/attack_self(mob/user)

--- a/code/game/objects/structures/stool_bed_chair_nest_sofa/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest_sofa/bed.dm
@@ -260,6 +260,11 @@
 	slot_flags = SLOT_BACK
 	w_class = ITEM_SIZE_LARGE
 	pickup_sound = 'sound/foley/pickup2.ogg'
+	material = /decl/material/solid/metal/steel
+	matter = list(
+		/decl/material/solid/plastic = MATTER_AMOUNT_SECONDARY, 
+		/decl/material/solid/cloth = MATTER_AMOUNT_REINFORCEMENT,
+	)
 	var/structure_form_type = /obj/structure/bed/roller	//The deployed form path.
 
 /obj/item/roller/get_single_monetary_worth()

--- a/code/game/objects/structures/stool_bed_chair_nest_sofa/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest_sofa/wheelchair.dm
@@ -122,7 +122,8 @@
 	icon_state = "wheelchair-item"
 	item_state = "rbed"
 	w_class = ITEM_SIZE_LARGE
-
+	health = 50
+	max_health = 50
 	var/structure_form_type = /obj/structure/bed/chair/wheelchair
 
 /obj/item/wheelchair_kit/attack_self(mob/user)
@@ -135,3 +136,9 @@
 		user.visible_message(SPAN_NOTICE("<b>[user]</b> lays out \the [W.name]."))
 		W.add_fingerprint(user)
 		qdel(src)
+
+/obj/item/wheelchair_kit/physically_destroyed(skip_qdel)
+	//Make sure if the kit is destroyed to drop the same stuff as the actual wheelchair
+	var/obj/structure/S = new structure_form_type(get_turf(src)) 
+	S.physically_destroyed()
+	. = ..()

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -349,6 +349,7 @@ regen() will cover update_icon() for this proc
 	item_state = "blob_tendril"
 	w_class = ITEM_SIZE_LARGE
 	attack_verb = list("smacked", "smashed", "whipped")
+	material = /decl/material/solid/plantmatter
 	var/is_tendril = TRUE
 	var/types_of_tendril = list("solid", "fire")
 

--- a/code/modules/butchery/remains.dm
+++ b/code/modules/butchery/remains.dm
@@ -1,5 +1,6 @@
 /obj/item/bone
 	icon = 'icons/obj/items/bone.dmi'
+	material = /decl/material/solid/bone
 	var/bone_amt = 1
 
 /obj/item/bone/skull

--- a/code/modules/clothing/masks/voice.dm
+++ b/code/modules/clothing/masks/voice.dm
@@ -1,6 +1,7 @@
 /obj/item/voice_changer
 	name = "voice changer"
 	desc = "A voice scrambling module. If you can see this, report it as a bug on the tracker."
+	health = ITEM_HEALTH_NO_DAMAGE
 	var/voice //If set and item is present in mask/suit, this name will be used for the wearer's speech.
 	var/active
 

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -34,6 +34,14 @@
 	siemens_coefficient = 0.2
 	permeability_coefficient = 0.1
 	unacidable = 1
+	material = /decl/material/solid/metal/titanium
+	matter = list(
+		/decl/material/solid/fiberglass           = MATTER_AMOUNT_SECONDARY,
+		/decl/material/solid/plastic              = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/copper         = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/silicon              = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/stainlesssteel = MATTER_AMOUNT_TRACE,
+	)
 
 	var/equipment_overlay_icon = 'icons/mob/onmob/onmob_rig_modules.dmi'
 	var/hides_uniform = 1 	//used to determinate if uniform should be visible whenever the suit is sealed or not

--- a/code/modules/clothing/underwear/base.dm
+++ b/code/modules/clothing/underwear/base.dm
@@ -1,5 +1,6 @@
 /obj/item/underwear
 	w_class = ITEM_SIZE_TINY
+	material = /decl/material/solid/cloth
 	var/required_slot_flags
 	var/required_free_body_parts
 	var/slot_offset_str

--- a/code/modules/crafting/crafting_recipes/bot_crafting/crafting_farmbot.dm
+++ b/code/modules/crafting/crafting_recipes/bot_crafting/crafting_farmbot.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/mob/bot/farmbot.dmi'
 	icon_state = "water_arm"
 	w_class = ITEM_SIZE_NORMAL
+	material = /decl/material/solid/metal/steel
 	var/obj/tank
 
 /obj/item/farmbot_arm_assembly/Initialize(var/ml, var/theTank)

--- a/code/modules/crafting/crafting_recipes/gun_crafting/crafting_cannon.dm
+++ b/code/modules/crafting/crafting_recipes/gun_crafting/crafting_cannon.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/crafting_icons.dmi'
 	icon_state = "pneumatic0"
 	item_state = "pneumatic"
+	material = /decl/material/solid/metal/steel
 
 /decl/crafting_stage/pipe/cannon
 	descriptor = "pneumatic cannon"

--- a/code/modules/crafting/crafting_recipes/gun_crafting/crafting_coilgun.dm
+++ b/code/modules/crafting/crafting_recipes/gun_crafting/crafting_coilgun.dm
@@ -4,6 +4,7 @@
 	desc = "It might be a coilgun, someday."
 	icon = 'icons/obj/crafting_icons.dmi'
 	icon_state = "coilgun_construction_1"
+	material = /decl/material/solid/metal/steel
 
 /decl/crafting_stage/material/coilgun_body
 	descriptor = "coilgun"

--- a/code/modules/crafting/crafting_recipes/gun_crafting/crafting_zipgun.dm
+++ b/code/modules/crafting/crafting_recipes/gun_crafting/crafting_zipgun.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/crafting_icons.dmi'
 	icon_state = "zipgun0"
 	item_state = "zipgun-solid"
+	material = /decl/material/solid/metal/steel
 
 /decl/crafting_stage/pipe/zipgun
 	descriptor = "zipgun"

--- a/code/modules/crafting/crafting_recipes/improvised_crafting/crafting_butterflyknife.dm
+++ b/code/modules/crafting/crafting_recipes/improvised_crafting/crafting_butterflyknife.dm
@@ -5,6 +5,7 @@
 	icon_state = "butterfly2"
 	material_force_multiplier = 0.1
 	thrown_material_force_multiplier = 0.1
+	material = /decl/material/solid/metal/steel
 
 /obj/item/butterflyhandle
 	name = "concealed knife grip"
@@ -13,6 +14,7 @@
 	icon_state = "butterfly1"
 	material_force_multiplier = 0.1
 	thrown_material_force_multiplier = 0.1
+	material = /decl/material/solid/metal/steel
 
 /decl/crafting_stage/balisong_blade
 	descriptor = "balisong"

--- a/code/modules/crafting/crafting_recipes/improvised_crafting/crafting_crossbow.dm
+++ b/code/modules/crafting/crafting_recipes/improvised_crafting/crafting_crossbow.dm
@@ -4,6 +4,7 @@
 	icon_state = "crossbowframe0"
 	item_state = "crossbow-solid"
 	icon = 'icons/obj/crafting_icons.dmi'
+	material = /decl/material/solid/metal/steel
 
 /decl/crafting_stage/material/crossbow_rods
 	descriptor = "crossbow"

--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -7,6 +7,8 @@
 	icon_state = "evidenceobj"
 	item_state = ""
 	w_class = ITEM_SIZE_SMALL
+	material = /decl/material/solid/plastic
+	item_flags = ITEM_FLAG_HOLLOW
 	var/obj/item/stored_item = null
 
 /obj/item/evidencebag/handle_mouse_drop(atom/over, mob/user)

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -11,6 +11,7 @@
 	item_flags = ITEM_FLAG_NO_BLUDGEON
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	unacidable = 0
+	material = /decl/material/solid/cloth
 
 	var/on_fire = 0
 	var/burn_time = 20 //if the rag burns for too long it turns to ashes

--- a/code/modules/detectivework/tools/sample_kits/_sample.dm
+++ b/code/modules/detectivework/tools/sample_kits/_sample.dm
@@ -2,6 +2,8 @@
 /obj/item/forensics/sample
 	name = "forensic sample"
 	icon = 'icons/obj/forensics.dmi'
+	health = 1
+	max_health = 1
 	var/object
 	var/list/possible_evidence_types = list(/datum/forensics/fibers)
 	var/list/evidence

--- a/code/modules/detectivework/tools/sample_kits/_sample_kit.dm
+++ b/code/modules/detectivework/tools/sample_kits/_sample_kit.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/forensics.dmi'
 	w_class = ITEM_SIZE_TINY
 	item_flags = ITEM_FLAG_NO_PRINT
+	material = /decl/material/solid/glass
 
 // Sampling kits
 

--- a/code/modules/detectivework/tools/sample_kits/fingerprinting.dm
+++ b/code/modules/detectivework/tools/sample_kits/fingerprinting.dm
@@ -8,6 +8,9 @@
 	possible_evidence_types = list(
 		/datum/forensics/fingerprints
 	)
+	item_flags = ITEM_FLAG_HOLLOW
+	material = /decl/material/solid/glass
+	matter = list(/decl/material/solid/metal/aluminium = MATTER_AMOUNT_SECONDARY)
 
 // Fingerprint card
 
@@ -18,6 +21,7 @@
 	icon_state = "fingerprint0"
 	item_state = "paper"
 	possible_evidence_types = list(/datum/forensics/fingerprints)
+	material = /decl/material/solid/cardboard
 
 /obj/item/forensics/sample/print/on_update_icon()
 	. = ..()

--- a/code/modules/detectivework/tools/sample_kits/swabs.dm
+++ b/code/modules/detectivework/tools/sample_kits/swabs.dm
@@ -10,6 +10,11 @@
 		/datum/forensics/trace_dna,
 		/datum/forensics/blood_dna
 	)
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/cloth = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/glass = MATTER_AMOUNT_REINFORCEMENT,
+	)
 
 /obj/item/forensics/sample_kit/swabs/attack(var/mob/living/carbon/human/H, var/mob/user)
 	if(!istype(H))

--- a/code/modules/detectivework/tools/scene_cards.dm
+++ b/code/modules/detectivework/tools/scene_cards.dm
@@ -26,6 +26,7 @@
 	w_class = ITEM_SIZE_TINY
 	randpixel = 1
 	layer = ABOVE_HUMAN_LAYER  //so you can mark bodies
+	material = /decl/material/solid/plastic
 	var/number = 1
 
 /obj/item/csi_marker/Initialize(mapload)

--- a/code/modules/economy/cael/EFTPOS.dm
+++ b/code/modules/economy/cael/EFTPOS.dm
@@ -3,6 +3,8 @@
 	desc = "Swipe your ID card to make purchases electronically."
 	icon = 'icons/obj/items/device/eftpos.dmi'
 	icon_state = "eftpos"
+	material = /decl/material/solid/plastic
+	matter = list(/decl/material/solid/silicon = MATTER_AMOUNT_REINFORCEMENT, /decl/material/solid/metal/copper = MATTER_AMOUNT_REINFORCEMENT)
 	var/machine_id = ""
 	var/eftpos_name = "Default EFTPOS scanner"
 	var/transaction_locked = 0

--- a/code/modules/economy/worth_cash.dm
+++ b/code/modules/economy/worth_cash.dm
@@ -11,6 +11,7 @@
 	throw_speed = 1
 	throw_range = 2
 	w_class = ITEM_SIZE_TINY
+	material = /decl/material/solid/cardboard //#TODO: Replace with paper
 	var/currency
 	var/absolute_worth = 0
 	var/can_flip = TRUE // Cooldown tracker for single-coin flips.
@@ -173,7 +174,8 @@
 	icon_state = ICON_STATE_WORLD
 	desc = "A digital stick that holds an amount of money."
 	w_class = ITEM_SIZE_TINY
-
+	material = /decl/material/solid/plastic
+	matter = list(/decl/material/solid/metal/copper = MATTER_AMOUNT_TRACE, /decl/material/solid/silicon = MATTER_AMOUNT_TRACE)
 	var/max_worth = 5000
 	var/loaded_worth = 0
 	var/creator			// Who originally created this card. Mostly for book-keeping purposes. In game these cards are 'anonymous'.

--- a/code/modules/games/boardgame.dm
+++ b/code/modules/games/boardgame.dm
@@ -3,6 +3,7 @@
 	desc = "A standard 16\" checkerboard. Well used." //Goddamn imperial system.
 	icon = 'icons/obj/pieces.dmi'
 	icon_state = "board"
+	material = /decl/material/solid/wood
 
 	var/num = 0
 	var/board_icons = list()

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -21,6 +21,7 @@ var/global/list/card_decks = list()
 /obj/item/deck
 	w_class = ITEM_SIZE_SMALL
 	icon = 'icons/obj/items/playing_cards.dmi'
+	material = /decl/material/solid/cardboard
 	var/list/cards = list()
 
 /obj/item/deck/Initialize()
@@ -62,6 +63,7 @@ var/global/list/card_decks = list()
 	name = "card box"
 	desc = "A small leather case to show how classy you are compared to everyone else."
 	icon_state = "card_holder"
+	material = /decl/material/solid/leather
 
 /obj/item/deck/cards
 	name = "deck of cards"
@@ -274,10 +276,10 @@ var/global/list/card_decks = list()
 /obj/item/pack
 	name = "card pack"
 	desc = "For those with disposible income."
-
 	icon_state = "card_pack"
 	icon = 'icons/obj/items/playing_cards.dmi'
 	w_class = ITEM_SIZE_TINY
+	material = /decl/material/solid/cardboard
 	var/list/cards = list()
 
 
@@ -298,7 +300,7 @@ var/global/list/card_decks = list()
 	icon = 'icons/obj/items/playing_cards.dmi'
 	icon_state = "empty"
 	w_class = ITEM_SIZE_TINY
-
+	material = /decl/material/solid/cardboard
 	var/concealed = 0
 	var/list/datum/playingcard/cards = list()
 

--- a/code/modules/goals/definitions/department_clerical.dm
+++ b/code/modules/goals/definitions/department_clerical.dm
@@ -100,6 +100,7 @@
 	desc = "This densely typed sheaf of documents is filled with legalese and jargon. You can't make heads or tails of them."
 	icon = 'icons/obj/goal_paperwork.dmi'
 	icon_state = "generic"
+	material = /decl/material/solid/cardboard //#TODO: replace with paper
 
 	var/datum/goal/department/paperwork/associated_goal
 	var/list/all_signatories

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -213,6 +213,7 @@
 /obj/item/holo
 	damtype = PAIN
 	no_attack_log = 1
+	health = ITEM_HEALTH_NO_DAMAGE
 
 /obj/item/holo/esword
 	name = "holosword"

--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -223,6 +223,7 @@
 	icon = 'icons/obj/items/weapon/batterer.dmi'
 	icon_state = "battererburnt"
 	w_class = ITEM_SIZE_SMALL
+	material = /decl/material/solid/metal/steel
 
 /obj/item/honey_frame
 	name = "beehive frame"
@@ -230,13 +231,14 @@
 	icon = 'icons/obj/beekeeping.dmi'
 	icon_state = "honeyframe"
 	w_class = ITEM_SIZE_SMALL
-
+	material = /decl/material/solid/wood
 	var/honey = 0
 
 /obj/item/honey_frame/filled
 	name = "filled beehive frame"
 	desc = "A frame for the beehive that the bees have filled with honeycombs."
 	honey = 20
+	material = /decl/material/solid/wood
 
 /obj/item/honey_frame/filled/Initialize()
 	. = ..()
@@ -247,6 +249,7 @@
 	desc = "Contains everything you need to build a beehive."
 	icon = 'icons/obj/apiary_bees_etc.dmi'
 	icon_state = "apiary"
+	material = /decl/material/solid/wood
 
 /obj/item/beehive_assembly/attack_self(var/mob/user)
 	to_chat(user, "<span class='notice'>You start assembling \the [src]...</span>")
@@ -271,6 +274,7 @@ var/global/list/wax_recipes = list(new /datum/stack_recipe/candle)
 	desc = "Contains a queen bee and some worker bees. Everything you'll need to start a hive!"
 	icon = 'icons/obj/beekeeping.dmi'
 	icon_state = "beepack"
+	material = /decl/material/solid/plastic
 	var/full = 1
 
 /obj/item/bee_pack/Initialize()

--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -4,6 +4,7 @@
 
 /obj/item/grown // Grown weapons
 	name = "grown_weapon"
+	material = /decl/material/solid/plantmatter
 	var/plantname
 	var/potency = 1
 
@@ -38,6 +39,7 @@
 	throwforce = 0
 	throw_speed = 4
 	throw_range = 20
+	material = /decl/material/solid/plantmatter
 
 /obj/item/corncob/attackby(obj/item/W, mob/user)
 	..()
@@ -57,3 +59,5 @@
 	throwforce = 0
 	throw_speed = 4
 	throw_range = 20
+	material = /decl/material/solid/plantmatter
+	

--- a/code/modules/hydroponics/trays/tray_reagents.dm
+++ b/code/modules/hydroponics/trays/tray_reagents.dm
@@ -8,6 +8,7 @@
 	w_class = ITEM_SIZE_SMALL
 	throw_speed = 2
 	throw_range = 10
+	material = /decl/material/solid/plastic
 	var/toxicity = 4
 	var/pest_kill_str = 0
 	var/weed_kill_str = 0
@@ -52,10 +53,12 @@
 // Weedkiller defines for hydroponics
 // *************************************
 
+//TODO: Remove those, they're completely unused
 /obj/item/weedkiller
 	name = "bottle of weedkiller"
 	icon = 'icons/obj/items/chem/bottle.dmi'
 	icon_state = "bottle16"
+	material = /decl/material/solid/plastic
 	var/toxicity = 0
 	var/weed_kill_str = 0
 

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -566,6 +566,7 @@
 	max_components = IC_MAX_SIZE_BASE * 2
 	max_complexity = IC_COMPLEXITY_BASE * 2
 	health = 20
+	max_health = 20
 
 /obj/item/electronic_assembly/medium/default
 	name = "type-a electronic mechanism"
@@ -605,6 +606,7 @@
 	max_components = IC_MAX_SIZE_BASE * 4
 	max_complexity = IC_COMPLEXITY_BASE * 4
 	health = 30
+	max_health = 30
 
 /obj/item/electronic_assembly/large/default
 	name = "type-a electronic machine"
@@ -644,6 +646,7 @@
 	allowed_circuit_action_flags = IC_ACTION_MOVEMENT | IC_ACTION_COMBAT | IC_ACTION_LONG_RANGE
 	circuit_flags = 0
 	health = 50
+	max_health = 50
 
 /obj/item/electronic_assembly/drone/can_move()
 	return TRUE
@@ -684,6 +687,7 @@
 	max_components = IC_MAX_SIZE_BASE * 2
 	max_complexity = IC_COMPLEXITY_BASE * 2
 	health = 10
+	max_health = 10
 
 /obj/item/electronic_assembly/wallmount/afterattack(var/atom/a, var/mob/user, var/proximity)
 	if(proximity && istype(a ,/turf) && a.density)

--- a/code/modules/integrated_electronics/core/detailer.dm
+++ b/code/modules/integrated_electronics/core/detailer.dm
@@ -6,6 +6,12 @@
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	item_flags = ITEM_FLAG_NO_BLUDGEON
 	w_class = ITEM_SIZE_SMALL
+	material = /decl/material/solid/metal/aluminium
+	matter = list(
+		/decl/material/solid/metal/steel = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/fiberglass = MATTER_AMOUNT_TRACE,
+		/decl/material/solid/plastic = MATTER_AMOUNT_TRACE
+	)
 	var/data_to_write = null
 	var/accepting_refs = FALSE
 	var/detail_color = COLOR_ASSEMBLY_WHITE

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -78,7 +78,7 @@ a creative player the means to solve many problems.  Circuits are held inside an
 	outputs_default = null
 	setup_io(activators, /datum/integrated_io/activate, null, IC_ACTIVATOR)
 	if(!matter[/decl/material/solid/metal/steel])
-		matter[/decl/material/solid/metal/steel] = w_class * SScircuit.cost_multiplier // Default cost.
+		matter[/decl/material/solid/metal/steel] = w_class * SScircuit.cost_multiplier // Default cost. //#TODO: Maybe move that stuff to the new material system that does essentially the same thing?
 	. = ..()
 
 /obj/item/integrated_circuit/proc/on_data_written() //Override this for special behaviour when new data gets pushed to the circuit.

--- a/code/modules/locks/key.dm
+++ b/code/modules/locks/key.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/items/key.dmi'
 	icon_state = "keys"
 	w_class = ITEM_SIZE_TINY
-	material = /decl/material/solid/metal/steel
+	material = DEFAULT_FURNITURE_MATERIAL
 	var/key_data = ""
 
 /obj/item/key/Initialize(mapload,var/data)

--- a/code/modules/locks/key.dm
+++ b/code/modules/locks/key.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/items/key.dmi'
 	icon_state = "keys"
 	w_class = ITEM_SIZE_TINY
+	material = /decl/material/solid/metal/steel
 	var/key_data = ""
 
 /obj/item/key/Initialize(mapload,var/data)
@@ -17,6 +18,7 @@
 /obj/item/key/soap
 	name = "soap key"
 	desc = "a fragile key made using a bar of soap."
+	material = /decl/material/liquid/cleaner
 	var/uses = 0
 
 /obj/item/key/soap/get_data(var/mob/user)

--- a/code/modules/materials/definitions/solids/materials_solid_metal.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_metal.dm
@@ -188,7 +188,6 @@
 	. = ..()
 	if(reinforce_material)	//recipes below don't support composite materials
 		return
-	. += new/datum/stack_recipe/key(src)
 	. += new/datum/stack_recipe/furniture/closet(src)
 	. += new/datum/stack_recipe/furniture/canister(src)
 	. += new/datum/stack_recipe/furniture/tank(src)

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -345,6 +345,7 @@
 	uses_charge = 1
 	charge_costs = list(500)
 	material = /decl/material/solid/metal/steel
+	health = ITEM_HEALTH_NO_DAMAGE
 
 /obj/item/stack/material/strut/get_recipes()
 	return material.get_strut_recipes(reinf_material && reinf_material.type)

--- a/code/modules/materials/material_synth.dm
+++ b/code/modules/materials/material_synth.dm
@@ -5,6 +5,7 @@
 	charge_costs = list(1000)
 	gender = NEUTER
 	matter = null // Don't shove it in the autholathe.
+	health = ITEM_HEALTH_NO_DAMAGE
 
 /obj/item/stack/material/cyborg/Initialize()
 	. = ..()

--- a/code/modules/materials/materials_ore.dm
+++ b/code/modules/materials/materials_ore.dm
@@ -4,6 +4,8 @@
 	icon = 'icons/obj/materials/ore.dmi'
 	randpixel = 8
 	w_class = ITEM_SIZE_SMALL
+	material = /decl/material/solid/stone/sandstone //By default is just a rock
+	material_health_multiplier = 0.5
 
 /obj/item/ore/set_material(var/new_material)
 	. = ..()

--- a/code/modules/mechs/components/body.dm
+++ b/code/modules/mechs/components/body.dm
@@ -4,6 +4,7 @@
 	storage_slots = 4
 	use_sound = 'sound/effects/storage/toolbox.ogg'
 	anchored = 1
+	health = ITEM_HEALTH_NO_DAMAGE
 
 /obj/item/mech_component/chassis/Adjacent(var/atom/neighbor, var/recurse = 1) //For interaction purposes we consider body to be adjacent to whatever holder mob is adjacent
 	var/mob/living/exosuit/E = loc

--- a/code/modules/mob/living/bot/remotebot.dm
+++ b/code/modules/mob/living/bot/remotebot.dm
@@ -99,6 +99,12 @@
 	icon_state = ICON_STATE_WORLD
 	w_class = ITEM_SIZE_SMALL
 	slot_flags = SLOT_LOWER_BODY
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/silicon      = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/copper = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/steel  = MATTER_AMOUNT_REINFORCEMENT,
+	)
 	var/mob/living/bot/remotebot/bot
 
 /obj/item/bot_controller/attack_self(var/mob/user)
@@ -160,6 +166,8 @@
 	desc = "The cover says 'control your own cardboard nuclear powered robot. Comes with real plutonium!"
 	icon = 'icons/obj/items/bot_kit.dmi'
 	icon_state = "remotebot"
+	item_flags = ITEM_FLAG_HOLLOW
+	material = /decl/material/solid/cardboard
 
 /obj/item/bot_kit/attack_self(var/mob/user)
 	to_chat(user, "You quickly dismantle the box and retrieve the controller and the remote bot itself.")

--- a/code/modules/mob/living/silicon/pai/paiwire.dm
+++ b/code/modules/mob/living/silicon/pai/paiwire.dm
@@ -3,7 +3,8 @@
 	name = "data cable"
 	icon = 'icons/obj/power.dmi'
 	icon_state = "wire1"
-
+	material = /decl/material/solid/metal/copper
+	matter = list(/decl/material/solid/plastic = MATTER_AMOUNT_REINFORCEMENT)
 	var/obj/machinery/machine
 
 /obj/item/pai_cable/proc/plugin(obj/machinery/M, mob/user)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -5,7 +5,7 @@
 	desc = "A simple grasping tool specialized in construction and engineering work."
 	icon = 'icons/obj/items/borg_module/borg_gripper.dmi'
 	icon_state = "gripper"
-
+	health = ITEM_HEALTH_NO_DAMAGE
 	item_flags = ITEM_FLAG_NO_BLUDGEON
 
 	//Has a list of items that it can hold.
@@ -271,11 +271,11 @@
 
 //TODO: Matter decompiler.
 /obj/item/matter_decompiler
-
 	name = "matter decompiler"
 	desc = "Eating trash, bits of glass, or other debris will replenish your stores."
 	icon = 'icons/obj/items/borg_module/decompiler.dmi'
 	icon_state = "decompiler"
+	health = ITEM_HEALTH_NO_DAMAGE
 
 	//Metal, glass, wood, plastic.
 	var/datum/matter_synth/metal = null

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -4,6 +4,12 @@
 	icon = 'icons/obj/items/borg_module/borg_rnd_analyser.dmi'
 	icon_state = "portable_analyzer"
 	desc = "Similar to the stationary version, this rather unwieldy device allows you to break down objects in the name of science."
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/metal/copper = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/steel  = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/silicon      = MATTER_AMOUNT_REINFORCEMENT,
+	)
 	var/obj/item/loaded_item
 	var/list/saved_tech_levels = list()
 
@@ -77,6 +83,13 @@
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "partylight-off"
 	item_state = "partylight-off"
+	material = /decl/material/solid/plastic
+	matter = list(
+		/decl/material/solid/metal/steel  = MATTER_AMOUNT_SECONDARY,
+		/decl/material/solid/glass        = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/copper = MATTER_AMOUNT_TRACE,
+		/decl/material/solid/silicon      = MATTER_AMOUNT_TRACE, 
+	)
 	var/activated = 0
 	var/strobe_effect = null
 
@@ -148,6 +161,7 @@
 	desc = "A hand-held harvest tool that resembles a sickle.  It uses energy to cut plant matter very efficently."
 	icon = 'icons/obj/items/borg_module/autoharvester.dmi'
 	icon_state = "autoharvester"
+	health = ITEM_HEALTH_NO_DAMAGE
 
 /obj/item/robot_harvester/afterattack(var/atom/target, var/mob/living/user, proximity)
 	if(!target)
@@ -229,6 +243,7 @@
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "paper_bin1"
 	item_state = "sheet-metal"
+	health = ITEM_HEALTH_NO_DAMAGE
 
 /obj/item/form_printer/attack(mob/living/carbon/M, mob/living/carbon/user)
 	return
@@ -278,6 +293,7 @@
 	icon = 'icons/obj/items/inflatable_dispenser.dmi'
 	icon_state = "inf_deployer"
 	w_class = ITEM_SIZE_LARGE
+	health = ITEM_HEALTH_NO_DAMAGE
 
 	var/stored_walls = 5
 	var/stored_doors = 2
@@ -379,6 +395,7 @@
 /obj/item/robot_rack
 	name = "a generic robot rack"
 	desc = "A rack for carrying large items as a robot."
+	health = ITEM_HEALTH_NO_DAMAGE
 	var/object_type                    //The types of object the rack holds (subtypes are allowed).
 	var/interact_type                  //Things of this type will trigger attack_hand when attacked by this.
 	var/capacity = 1                   //How many objects can be held.
@@ -423,6 +440,7 @@
 	desc = "An integrated power generator that runs on most kinds of biomass."
 	icon = 'icons/obj/power.dmi'
 	icon_state = "portgen0"
+	health = ITEM_HEALTH_NO_DAMAGE
 
 	var/base_power_generation = 75 KILOWATTS
 	var/max_fuel_items = 5

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -94,6 +94,7 @@
 	gender = PLURAL
 	icon = 'icons/obj/items/ectoplasm.dmi'
 	icon_state = ICON_STATE_WORLD
+	material = /decl/material/liquid/drink/compote
 
 /////////////////Juggernaut///////////////
 

--- a/code/modules/mob/living/simple_animal/constructs/soulstone.dm
+++ b/code/modules/mob/living/simple_animal/constructs/soulstone.dm
@@ -6,7 +6,7 @@
 	w_class = ITEM_SIZE_SMALL
 	slot_flags = SLOT_LOWER_BODY
 	origin_tech = "{'wormholes':4,'materials':4}"
-
+	material = /decl/material/solid/gemstone/crystal
 	var/full = SOULSTONE_EMPTY
 	var/is_evil = 1
 	var/mob/living/simple_animal/shade = null

--- a/code/modules/mob/living/simple_animal/crow/crow.dm
+++ b/code/modules/mob/living/simple_animal/crow/crow.dm
@@ -6,6 +6,7 @@
 	storage_slots = 7
 	w_class = ITEM_SIZE_SMALL
 	max_w_class = ITEM_SIZE_SMALL
+	material = /decl/material/solid/cloth
 
 /mob/living/simple_animal/crow
 	name = "crow"

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -138,6 +138,7 @@
 	desc = "The by-product of cat farming."
 	icon = 'icons/obj/items/sheet_hide.dmi'
 	icon_state = "sheet-cat"
+	material = /decl/material/solid/leather/fur
 
 //Basic friend AI
 /mob/living/simple_animal/cat/fluff

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -41,6 +41,7 @@
 	desc = "The by-product of corgi farming."
 	icon = 'icons/obj/items/sheet_hide.dmi'
 	icon_state = "sheet-corgi"
+	material = /decl/material/solid/skin/fur/orange
 
 //IAN! SQUEEEEEEEEE~
 /mob/living/simple_animal/corgi/Ian

--- a/code/modules/modular_computers/computers/modular_computer/variables.dm
+++ b/code/modules/modular_computers/computers/modular_computer/variables.dm
@@ -6,6 +6,7 @@
 	icon_state = ICON_STATE_WORLD
 	center_of_mass = null
 	randpixel = 0
+	material = /decl/material/solid/plastic
 
 	var/screen_icon
 	var/list/decals

--- a/code/modules/modular_computers/computers/subtypes/dev_laptop.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_laptop.dm
@@ -9,6 +9,11 @@
 	interact_sounds = list("keyboard", "keystroke")
 	interact_sound_volume = 20
 	computer_type = /datum/extension/assembly/modular_computer/laptop
+	matter = list(
+		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_SECONDARY,
+		/decl/material/solid/metal/copper    = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/silicon         = MATTER_AMOUNT_REINFORCEMENT,
+	)
 	var/icon_state_closed = "laptop-closed"
 	
 /obj/item/modular_computer/laptop/on_update_icon()

--- a/code/modules/modular_computers/computers/subtypes/dev_tablet.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_tablet.dm
@@ -3,13 +3,16 @@
 	desc = "A small, portable microcomputer."
 	icon = 'icons/obj/modular_computers/modular_tablet.dmi'
 	icon_state = "tablet"
-
 	w_class = ITEM_SIZE_SMALL
 	light_strength = 2 // same as PDAs
-
 	interact_sounds = list('sound/machines/pda_click.ogg')
 	interact_sound_volume = 20
 	computer_type = /datum/extension/assembly/modular_computer/tablet
+	matter = list(
+		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_SECONDARY,
+		/decl/material/solid/metal/copper    = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/silicon         = MATTER_AMOUNT_REINFORCEMENT,
+	)
 
 /obj/item/modular_computer/tablet/lease
 	desc = "A small, portable microcomputer. This one has a gold and blue stripe, and a serial number stamped into the case."

--- a/code/modules/modular_computers/computers/subtypes/dev_telescreen.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_telescreen.dm
@@ -10,6 +10,11 @@
 	computer_type = /datum/extension/assembly/modular_computer/telescreen
 	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':-32}, 'WEST':{'x':32}}"
+	matter = list(
+		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_SECONDARY,
+		/decl/material/solid/metal/copper    = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/silicon         = MATTER_AMOUNT_REINFORCEMENT,
+	)
 
 /obj/item/modular_computer/telescreen/Initialize()
 	. = ..()

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -6,6 +6,7 @@
 	w_class = ITEM_SIZE_SMALL
 	drop_sound = 'sound/foley/paperpickup1.ogg'
 	pickup_sound = 'sound/foley/paperpickup2.ogg'
+	material = /decl/material/solid/cardboard
 
 /obj/item/folder/blue
 	desc = "A blue folder."

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -11,6 +11,8 @@
 	throw_speed = 1
 	layer = ABOVE_OBJ_LAYER
 	attack_verb = list("bapped")
+	health = 10
+	max_health = 10
 	var/page = 1    // current page
 	var/list/pages = list()  // Ordered list of pages as they are to be displayed. Can be different order than src.contents.
 

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -9,6 +9,7 @@
 	throw_speed = 3
 	throw_range = 7
 	layer = BELOW_OBJ_LAYER
+	material = /decl/material/solid/plastic
 	var/amount = 30					//How much paper is in the bin.
 	var/list/papers = new/list()	//List of papers put in the bin for reference.
 

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -219,4 +219,5 @@
 	name = "toner cartridge"
 	icon = 'icons/obj/items/tonercartridge.dmi'
 	icon_state = "tonercartridge"
+	material = /decl/material/solid/plastic
 	var/toner_amount = 30

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -16,7 +16,7 @@
 	icon_state = "film"
 	item_state = "electropack"
 	w_class = ITEM_SIZE_TINY
-
+	material = /decl/material/solid/plastic
 
 /********
 * photo *
@@ -30,6 +30,7 @@ var/global/photo_count = 0
 	item_state = "paper"
 	randpixel = 10
 	w_class = ITEM_SIZE_TINY
+	material = /decl/material/solid/plastic
 	var/id
 	var/icon/img	//Big photo image
 	var/scribble	//Scribble on the back.
@@ -112,6 +113,7 @@ var/global/photo_count = 0
 	w_class = ITEM_SIZE_NORMAL //same as book
 	storage_slots = DEFAULT_BOX_STORAGE //yes, that's storage_slots. Photos are w_class 1 so this has as many slots equal to the number of photos you could put in a box
 	can_hold = list(/obj/item/photo)
+	material = /decl/material/solid/cardboard
 
 /obj/item/storage/photo_album/handle_mouse_drop(atom/over, mob/user)
 	if(istype(over, /obj/screen/inventory))

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -513,6 +513,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	matter = null
 	uses_charge = 1
 	charge_costs = list(1)
+	health = ITEM_HEALTH_NO_DAMAGE
 
 /obj/item/stack/cable_coil/Initialize(mapload, c_length = MAXCOIL, var/param_color = null)
 	. = ..(mapload, c_length)

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -8,6 +8,8 @@
 	slot_flags = SLOT_LOWER_BODY | SLOT_EARS
 	throwforce = 1
 	w_class = ITEM_SIZE_TINY
+	item_flags = ITEM_FLAG_HOLLOW
+	material = /decl/material/solid/metal/brass
 
 	var/leaves_residue = 1
 	var/caliber = ""					//Which kind of guns it can be loaded into

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -11,6 +11,7 @@
 	sharp = 1
 	edge = 0
 	lock_picking_level = 3
+	material = /decl/material/solid/wood
 
 /obj/item/arrow/proc/removed() //Helper for metal rods falling apart.
 	return
@@ -25,11 +26,13 @@
 	icon = 'icons/obj/items/weapon/crossbow_bolt.dmi'
 	icon_state = "metal-rod"
 	item_state = "bolt"
+	material = /decl/material/solid/metal/alienalloy
 
 /obj/item/arrow/rod
 	name = "metal rod"
 	desc = "Don't cry for me, Orithena."
 	icon_state = "metal-rod"
+	material = /decl/material/solid/metal/steel
 
 /obj/item/arrow/rod/removed(mob/user)
 	if(throwforce == 15) // The rod has been superheated - we don't want it to be useable when removed from the bow.
@@ -209,6 +212,7 @@
 	name = "flashforged bolt"
 	desc = "The ultimate ghetto deconstruction implement."
 	throwforce = 4
+	material = /decl/material/solid/slag
 
 /obj/item/gun/launcher/crossbow/rapidcrossbowdevice
 	name = "rapid crossbow device"

--- a/code/modules/projectiles/guns/launcher/foam_gun.dm
+++ b/code/modules/projectiles/guns/launcher/foam_gun.dm
@@ -89,6 +89,7 @@
 	throwforce = 0
 	throw_range = 3
 	does_spin = FALSE
+	material = /decl/material/solid/plastic
 
 /obj/item/foam_dart/Initialize()
 	mix_up()

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -70,3 +70,4 @@
 	icon = 'icons/obj/guns/holdout_pistol_silencer.dmi'
 	icon_state = ICON_STATE_WORLD
 	w_class = ITEM_SIZE_SMALL
+	material = /decl/material/solid/metal/steel

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -170,6 +170,14 @@
 	icon_state = ICON_STATE_WORLD
 	var/primed = null
 	throwforce = 15
+	material = /decl/material/solid/fiberglass
+	matter = list(
+		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/metal/copper    = MATTER_AMOUNT_TRACE,
+		/decl/material/solid/silicon         = MATTER_AMOUNT_TRACE,
+		/decl/material/liquid/anfo           = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/liquid/fuel           = MATTER_AMOUNT_REINFORCEMENT,
+	)
 
 /obj/item/missile/throw_impact(atom/hit_atom)
 	..()

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -4,6 +4,8 @@
 	icon = 'icons/obj/items/chem/container.dmi'
 	icon_state = null
 	w_class = ITEM_SIZE_SMALL
+	material = /decl/material/solid/plastic
+	item_flags = ITEM_FLAG_HOLLOW
 
 	var/base_name
 	var/base_desc

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -7,6 +7,7 @@
 	amount_per_transfer_from_this = 5
 	volume = 30
 	possible_transfer_amounts = null
+	health = ITEM_HEALTH_NO_DAMAGE
 
 	var/mode = 1
 	var/charge_cost = 50

--- a/code/modules/reagents/reagent_containers/drinkingglass/extras.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/extras.dm
@@ -52,6 +52,7 @@
 	var/glass_desc
 	w_class = ITEM_SIZE_TINY
 	icon = 'icons/obj/drink_glasses/extras.dmi'
+	material = /decl/material/solid/plastic
 
 /obj/item/glass_extra/stick
 	name = "stick"

--- a/code/modules/reagents/reagent_containers/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/drinks/bottle.dm
@@ -230,6 +230,8 @@
 	attack_verb = list("stabbed", "slashed", "attacked")
 	sharp = 1
 	edge = 0
+	item_flags = ITEM_FLAG_HOLLOW
+	material = /decl/material/solid/glass
 	var/icon/broken_outline = icon('icons/obj/drinks.dmi', "broken")
 
 /obj/item/broken_bottle/Initialize(ml, material_key)

--- a/code/modules/reagents/reagent_containers/food/fish.dm
+++ b/code/modules/reagents/reagent_containers/food/fish.dm
@@ -85,6 +85,10 @@
 	icon = 'icons/obj/molluscs.dmi'
 	icon_state = "mollusc"
 	w_class = ITEM_SIZE_TINY
+	material = /decl/material/liquid/nutriment/slime_meat
+	matter = list(
+		/decl/material/solid/bone/fish = MATTER_AMOUNT_SECONDARY,
+	)
 	var/meat_type = /obj/item/chems/food/fish/mollusc
 	var/shell_type = /obj/item/trash/mollusc_shell
 

--- a/code/modules/reagents/reagent_containers/food/sliceable/pizza.dm
+++ b/code/modules/reagents/reagent_containers/food/sliceable/pizza.dm
@@ -127,7 +127,7 @@
 	desc = "A box suited for pizzas."
 	icon = 'icons/obj/food.dmi'
 	icon_state = "pizzabox1"
-
+	material = /decl/material/solid/cardboard
 	var/open = 0 // Is the box open?
 	var/ismessy = 0 // Fancy mess on the lid
 	var/obj/item/chems/food/sliceable/pizza/pizza // content pizza

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -15,6 +15,7 @@
 	possible_transfer_amounts = null
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	slot_flags = SLOT_LOWER_BODY
+	material = /decl/material/solid/metal/steel
 
 	// autoinjectors takes less time than a normal syringe (overriden for hypospray).
 	// This delay is only applied when injecting concious mobs, and is not applied for self-injection
@@ -153,6 +154,8 @@
 	origin_tech = "{'materials':2,'biotech':2}"
 	slot_flags = SLOT_LOWER_BODY | SLOT_EARS
 	w_class = ITEM_SIZE_TINY
+	material = /decl/material/solid/plastic
+	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
 	var/list/starts_with = list(/decl/material/liquid/adrenaline = 5)
 	var/band_color = COLOR_CYAN
 
@@ -202,5 +205,3 @@
 	name = "autoinjector"
 	band_color = COLOR_WHITE
 	starts_with = list()
-	material = /decl/material/solid/plastic
-	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -13,6 +13,7 @@
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
 	volume = 30
+	material = /decl/material/solid/plantmatter
 	var/static/list/colorizable_icon_states = list("pill1", "pill2", "pill3", "pill4", "pill5") // if using an icon state from here, color will be derived from reagents
 
 /obj/item/chems/pill/Initialize()

--- a/code/modules/reagents/storage/pill_bottle.dm
+++ b/code/modules/reagents/storage/pill_bottle.dm
@@ -9,6 +9,7 @@
 	item_state = "contsolid"
 	w_class = ITEM_SIZE_SMALL
 	max_w_class = ITEM_SIZE_TINY
+	item_flags =  ITEM_FLAG_HOLLOW
 	max_storage_space = 21
 	can_hold = list(
 		/obj/item/chems/pill,

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -500,6 +500,7 @@ var/global/list/diversion_junctions = list()
 	icon = 'icons/obj/recycling.dmi'
 	icon_state = "switch-off"
 	w_class = ITEM_SIZE_LARGE
+	material = /decl/material/solid/metal/steel
 	var/id_tag
 
 /obj/item/disposal_switch_construct/Initialize(var/id)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -126,6 +126,7 @@
 	name = "small parcel"
 	icon = 'icons/obj/items/storage/deliverypackage.dmi'
 	icon_state = "deliverycrate3"
+	material = /decl/material/solid/cardboard
 	var/obj/item/wrapped = null
 	var/sortTag = null
 	var/examtext = null
@@ -253,6 +254,7 @@
 	w_class = ITEM_SIZE_SMALL
 	throw_speed = 4
 	throw_range = 5
+	material = /decl/material/solid/cardboard
 
 /obj/item/stack/package_wrap/afterattack(var/obj/target, mob/user, proximity)
 	if(!proximity) return
@@ -512,3 +514,4 @@
 	uses_charge = 1
 	charge_costs = list(1)
 	stack_merge_type = /obj/item/stack/package_wrap
+	health = ITEM_HEALTH_NO_DAMAGE

--- a/code/modules/research/design_database_analyzer.dm
+++ b/code/modules/research/design_database_analyzer.dm
@@ -148,3 +148,4 @@
 	icon = 'icons/obj/items/stock_parts/stock_parts.dmi'
 	icon_state = "smes_coil"
 	origin_tech = "{'materials':19,'engineering':19,'exoticmatter':19,'powerstorage':19,'wormholes':19,'biotech':19,'combat':19,'magnets':19,'programming':19,'esoteric':19}"
+	health = ITEM_HEALTH_NO_DAMAGE

--- a/code/modules/sealant_gun/sealant_tank.dm
+++ b/code/modules/sealant_gun/sealant_tank.dm
@@ -3,6 +3,7 @@
 	desc = "A sealed tank used to keep hull sealant foam contained under pressure."
 	icon = 'icons/obj/sealant_tank.dmi'
 	icon_state = "tank"
+	material = /decl/material/solid/metal/steel
 	var/foam_charges = 0
 	var/max_foam_charges = 60
 

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -173,6 +173,7 @@ var/global/list/shuttle_landmarks = list()
 	icon = 'icons/obj/items/device/long_range_flare.dmi'
 	icon_state = "bluflare"
 	light_color = "#3728ff"
+	material = /decl/material/solid/plastic
 	var/active
 
 /obj/item/spaceflare/attack_self(var/mob/user)

--- a/code/modules/spells/artifacts.dm
+++ b/code/modules/spells/artifacts.dm
@@ -11,6 +11,7 @@
 	damtype = BURN
 	force = 10
 	hitsound = 'sound/magic/forcewall.ogg'
+	health = ITEM_HEALTH_NO_DAMAGE
 
 /obj/item/scrying/attack_self(mob/user)
 	var/decl/special_role/wizard/wizards = GET_DECL(/decl/special_role/wizard)

--- a/code/modules/spells/artifacts/spellbound_servants.dm
+++ b/code/modules/spells/artifacts/spellbound_servants.dm
@@ -239,6 +239,7 @@
 	throw_speed = 5
 	throw_range = 10
 	w_class = ITEM_SIZE_TINY
+	material = /decl/material/solid/stone/cult
 
 /obj/item/summoning_stone/attack_self(var/mob/user)
 	if(isAdminLevel(user.z))

--- a/code/modules/spells/contracts.dm
+++ b/code/modules/spells/contracts.dm
@@ -3,7 +3,7 @@
 	desc = "written in the blood of some unfortunate fellow."
 	icon = 'icons/mob/screen_spells.dmi'
 	icon_state = "master_open"
-
+	material = /decl/material/solid/cardboard //#TODO: replace with paper
 	var/contract_master = null
 	var/list/contract_spells = list(/spell/contract/reward,/spell/contract/punish,/spell/contract/return_master)
 

--- a/code/modules/spells/hand/hand_item.dm
+++ b/code/modules/spells/hand/hand_item.dm
@@ -10,6 +10,7 @@ Basically: I can use it to target things where I click. I can then pass these ta
 	obj_flags = 0
 	simulated = 0
 	icon_state = "spell"
+	health = ITEM_HEALTH_NO_DAMAGE
 	var/next_spell_time = 0
 	var/spell/hand/hand_spell
 

--- a/code/modules/spells/racial_wizard.dm
+++ b/code/modules/spells/racial_wizard.dm
@@ -9,6 +9,7 @@
 	throw_speed = 1
 	throw_range = 3
 	force = 15
+	material = /decl/material/solid/stone/cult
 	var/list/potentials = list(
 		SPECIES_HUMAN = /obj/item/storage/bag/cash/infinite
 	)

--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -26,6 +26,8 @@ var/global/list/artefact_feedback = list(/obj/structure/closet/wizard/armor = 		
 	throw_speed = 1
 	throw_range = 5
 	w_class = ITEM_SIZE_NORMAL
+	material = /decl/material/solid/cardboard //#TODO: Replace with paper
+	matter = list(/decl/material/solid/leather = MATTER_AMOUNT_REINFORCEMENT)
 	var/uses = 1
 	var/temp = null
 	var/datum/spellbook/spellbook

--- a/code/modules/spells/targeted/equip/burning_touch.dm
+++ b/code/modules/spells/targeted/equip/burning_touch.dm
@@ -21,6 +21,7 @@
 	force = 10
 	damtype = BURN
 	simulated = 0
+	health = ITEM_HEALTH_NO_DAMAGE
 	var/burn_power = 0
 	var/burn_timer
 	var/obj/item/organ/external/hand/connected

--- a/code/modules/synthesized_instruments/real_instruments.dm
+++ b/code/modules/synthesized_instruments/real_instruments.dm
@@ -253,6 +253,7 @@
 /obj/item/synthesized_instrument
 	var/datum/real_instrument/real_instrument
 	icon = 'icons/obj/musician.dmi'
+	material = /decl/material/solid/plastic
 	var/list/instruments = list()
 	var/path = /datum/instrument
 	var/sound_player = /datum/sound_player

--- a/code/modules/synthesized_instruments/real_instruments/Guitar/guitar.dm
+++ b/code/modules/synthesized_instruments/real_instruments/Guitar/guitar.dm
@@ -5,7 +5,8 @@
 	icon_state = "guitar"
 	sound_player = /datum/sound_player/synthesizer
 	path = /datum/instrument/guitar/clean_crisis
-
+	material = /decl/material/solid/wood
+	matter = list(/decl/material/solid/metal/steel = MATTER_AMOUNT_TRACE)
 
 /obj/item/synthesized_instrument/guitar/multi
 	name = "Polyguitar"
@@ -14,3 +15,9 @@
 	icon_state = "eguitar"
 	sound_player = /datum/sound_player/synthesizer
 	path = /datum/instrument/guitar
+	material = /decl/material/solid/wood
+	matter = list(
+		/decl/material/solid/metal/steel  = MATTER_AMOUNT_TRACE, 
+		/decl/material/solid/metal/copper = MATTER_AMOUNT_TRACE,
+		/decl/material/solid/silicon      = MATTER_AMOUNT_TRACE,
+		)

--- a/code/modules/synthesized_instruments/real_instruments/Trumpet/trumpet.dm
+++ b/code/modules/synthesized_instruments/real_instruments/Trumpet/trumpet.dm
@@ -4,3 +4,4 @@
 	icon_state = "trumpet"
 	sound_player = /datum/sound_player/synthesizer
 	path = /datum/instrument/brass
+	material = /decl/material/solid/metal/brass

--- a/code/modules/synthesized_instruments/real_instruments/Violin/violin.dm
+++ b/code/modules/synthesized_instruments/real_instruments/Violin/violin.dm
@@ -8,6 +8,8 @@
 	icon_state = "violin"
 	sound_player = /datum/sound_player/violin
 	path = /datum/instrument/obsolete/violin
+	material = /decl/material/solid/wood
+	matter = list(/decl/material/solid/metal/steel = MATTER_AMOUNT_TRACE)
 
 /obj/structure/synthesized_instrument/synthesizer/shouldStopPlaying(mob/user)
 	return !(src && in_range(src, user))

--- a/code/modules/vehicles/engine.dm
+++ b/code/modules/vehicles/engine.dm
@@ -3,6 +3,7 @@
 	desc = "An engine used to power a small vehicle."
 	icon = 'icons/obj/objects.dmi'
 	w_class = ITEM_SIZE_HUGE
+	material = /decl/material/solid/metal/steel
 	var/stat = 0
 	var/trail_type
 	var/cost_per_move = 5

--- a/code/modules/xenoarcheaology/finds/find_types/chem_containers.dm
+++ b/code/modules/xenoarcheaology/finds/find_types/chem_containers.dm
@@ -24,6 +24,7 @@
 //endless reagents!
 
 /obj/item/chems/glass/replenishing
+	material = /decl/material/solid/stone/ceramic
 	var/spawning_id
 
 /obj/item/chems/glass/replenishing/Initialize()

--- a/code/modules/xenoarcheaology/finds/find_types/fossils.dm
+++ b/code/modules/xenoarcheaology/finds/find_types/fossils.dm
@@ -29,6 +29,7 @@
 	desc = "A fossilised, pre-Stygian alien crustacean."
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "shell"
+	material = /decl/material/solid/stone/sandstone //Should probably be limestone, but whatever
 
 /obj/item/fossil/plant
 	name = "fossilised plant"

--- a/code/modules/xenoarcheaology/finds/find_types/statuette.dm
+++ b/code/modules/xenoarcheaology/finds/find_types/statuette.dm
@@ -17,6 +17,7 @@
 	name = "statuette"
 	icon_state = "statuette"
 	icon = 'icons/obj/xenoarchaeology.dmi'
+	material = /decl/material/solid/stone/cult
 	var/charges = 0
 	var/list/nearby_mobs = list()
 	var/last_bloodcall = 0

--- a/code/modules/xenoarcheaology/tools/core_sampler.dm
+++ b/code/modules/xenoarcheaology/tools/core_sampler.dm
@@ -52,6 +52,8 @@
 	randpixel = 8
 	w_class = ITEM_SIZE_TINY
 	sharp = 1
+	material = /decl/material/solid/stone/sandstone
+	material_health_multiplier = 0.25
 	
 /obj/item/rocksliver/Initialize(ml, material_key, geodata)
 	. = ..()

--- a/mods/content/government/items/clutter.dm
+++ b/mods/content/government/items/clutter.dm
@@ -7,3 +7,4 @@
 	attack_verb = list("whipped")
 	hitsound = 'sound/weapons/towelwhip.ogg'
 	desc = "The iconic flag of the Sol Central Government, a symbol with many different meanings."
+	material = /decl/material/solid/plastic

--- a/mods/content/government/ruins/ec_old_crash/ec_old_crash.dm
+++ b/mods/content/government/ruins/ec_old_crash/ec_old_crash.dm
@@ -58,6 +58,7 @@
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "docs_part"
 	item_state = "paper"
+	material = /decl/material/solid/cardboard //#TODO: Replace with paper
 
 /obj/item/ecletters/Initialize()
 	. = ..()

--- a/mods/content/xenobiology/slime/items.dm
+++ b/mods/content/xenobiology/slime/items.dm
@@ -10,6 +10,7 @@
 	throw_range = 6
 	origin_tech = "{'biotech':4}"
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
+	material = /decl/material/liquid/slimejelly
 	var/slime_type = /decl/slime_colour/grey
 	var/Uses = 1 // uses before it goes inert
 	var/enhanced = 0 //has it been enhanced before?

--- a/mods/content/xenobiology/slime/items_extract_enhancer.dm
+++ b/mods/content/xenobiology/slime/items_extract_enhancer.dm
@@ -1,8 +1,10 @@
-/obj/item/slime_extract_enhancer
+/obj/item/slime_extract_enhancer //#TODO: Probably should use /obj/item/chems with a proper reagent
 	name = "extract enhancer"
 	desc = "A potent chemical mix that will give a slime extract three uses."
 	icon = 'icons/obj/items/chem/bottle.dmi'
 	icon_state = "bottle17"
+	material = /decl/material/solid/plastic
+	item_flags = ITEM_FLAG_HOLLOW
 
 /obj/item/slime_extract_enhancer/afterattack(obj/target, mob/user , flag)
 	if(!istype(target, /obj/item/slime_extract))

--- a/mods/content/xenobiology/slime/items_potion.dm
+++ b/mods/content/xenobiology/slime/items_potion.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/items/chem/bottle.dmi'
 	icon_state = "bottle19"
 	material = /decl/material/solid/glass
-	item_state = ITEM_FLAG_HOLLOW
+	item_flags = ITEM_FLAG_HOLLOW
 	var/slime_type = /mob/living/simple_animal/slime
 	var/can_tame_adults = FALSE
 

--- a/mods/content/xenobiology/slime/items_potion.dm
+++ b/mods/content/xenobiology/slime/items_potion.dm
@@ -3,6 +3,8 @@
 	desc = "A potent chemical mix that will nullify a slime's powers, causing it to become docile and tame."
 	icon = 'icons/obj/items/chem/bottle.dmi'
 	icon_state = "bottle19"
+	material = /decl/material/solid/glass
+	item_state = ITEM_FLAG_HOLLOW
 	var/slime_type = /mob/living/simple_animal/slime
 	var/can_tame_adults = FALSE
 

--- a/mods/content/xenobiology/slime/items_steroid.dm
+++ b/mods/content/xenobiology/slime/items_steroid.dm
@@ -3,6 +3,8 @@
 	desc = "A potent chemical mix that will cause a slime to generate more extract."
 	icon = 'icons/obj/items/chem/bottle.dmi'
 	icon_state = "bottle16"
+	material = /decl/material/solid/glass
+	item_flags = ITEM_FLAG_HOLLOW
 	var/grant_cores = 3
 
 /obj/item/slime_steroid/attack(mob/living/slime/M, mob/user)

--- a/mods/species/ascent/effects/razorweb.dm
+++ b/mods/species/ascent/effects/razorweb.dm
@@ -3,6 +3,7 @@
 	desc = "A wad of crystalline monofilament."
 	icon = 'mods/species/ascent/icons/razorweb.dmi'
 	icon_state = "wad"
+	material = /decl/material/solid/quartz
 	var/web_type = /obj/effect/razorweb
 
 /obj/item/razorweb/throw_impact(var/atom/hit_atom)

--- a/mods/species/ascent/items/clustertool.dm
+++ b/mods/species/ascent/items/clustertool.dm
@@ -4,6 +4,7 @@
 	icon = 'mods/species/ascent/icons/ascent.dmi'
 	icon_state = "clustertool"
 	w_class = ITEM_SIZE_SMALL
+	material = /decl/material/solid/metal/aluminium
 
 /obj/item/clustertool/Initialize(ml, material_key)
 	. = ..()

--- a/mods/species/vox/gear/gun_slugsling.dm
+++ b/mods/species/vox/gear/gun_slugsling.dm
@@ -5,6 +5,7 @@
 	throwforce = 6
 	icon = 'mods/species/vox/icons/gear/slugegg.dmi'
 	icon_state = "slugegg"
+	material = /decl/material/solid/skin/insect
 	var/break_on_impact = 1 //There are two modes to the eggs.
 							//One breaks the egg on hit,
 

--- a/mods/species/vox/gear/gun_spikethrower.dm
+++ b/mods/species/vox/gear/gun_spikethrower.dm
@@ -59,3 +59,4 @@
 	icon_state = "quill"
 	item_state = "quill"
 	throwforce = 5
+	material = /decl/material/solid/leather/chitin


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
This is part of the item damage PR #2575 with only the material changes, and the changes to the health values. In order to make the main PR less cluttered.

* Added materials to many many things, so they can properly determine their health, and other properties. 
* Also set the health on a few items as well. However, it won't have an effect until the damage PR is merged.

## Changelog
:cl:
code: Gave a material value, and matter list to a lot of items.
code: Gave health to a bunch of things that didn't specify it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->