### PR TITLE
fixes pressure tank volume init

### DIFF
--- a/code/modules/atmospherics/components/unary/tank.dm
+++ b/code/modules/atmospherics/components/unary/tank.dm
@@ -25,10 +25,10 @@
 
 /obj/machinery/atmospherics/unary/tank/Initialize()
 	. = ..()
+	air_contents.volume = volume
+	air_contents.temperature = T20C
+	
 	if(filling)
-		air_contents.volume = volume
-		air_contents.temperature = T20C
-
 		var/list/gases = list()
 		for(var/gas in filling)
 			gases += gas


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Moves base pressure tank volume and temp value init out of the filling if statement.

## Why and what will this PR improve
When crafting a pressure tank, it's volume ended up as 200 instead of the correct value of 10000.  This ended up being due to the volume and temp vars getting set in the if statement that handles tank filling for the tank variants, which didn't get applied to the base tank because it starts empty.

## Authorship
Qumefox

## Changelog
:cl:
bugfix: fixed base pressure tank volume initialization
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->