### PR TITLE
More work on chem rounding/remove_any().

### DIFF
--- a/code/__defines/maths.dm
+++ b/code/__defines/maths.dm
@@ -13,3 +13,6 @@
 // Will filter out extra rotations and negative rotations
 // E.g: 540 becomes 180. -180 becomes 180.
 #define SIMPLIFY_DEGREES(degrees) (MODULUS_FLOAT((degrees), 360))
+
+// Float-aware floor since round() will round upwards when given a second arg
+#define FLOAT_FLOOR(X, N) (round(X/N)*N)

--- a/code/__defines/maths.dm
+++ b/code/__defines/maths.dm
@@ -1,7 +1,11 @@
 // Macro functions.
 #define RAND_F(LOW, HIGH) (rand() * (HIGH - LOW) + LOW)
 #define CEILING(x) (-round(-(x)))
+
+// Float-aware floor and ceiling since round() will round upwards when given a second arg.
+#define NONUNIT_FLOOR(x, y)    (round( (x) / (y)) * (y))
 #define NONUNIT_CEILING(x, y) (-round(-(x) / (y)) * (y))
+
 #define MULT_BY_RANDOM_COEF(VAR,LO,HI) VAR =  round((VAR * rand(LO * 100, HI * 100))/100, 0.1)
 
 #define ROUND(x) (((x) >= 0) ? round((x)) : -round(-(x)))
@@ -13,6 +17,3 @@
 // Will filter out extra rotations and negative rotations
 // E.g: 540 becomes 180. -180 becomes 180.
 #define SIMPLIFY_DEGREES(degrees) (MODULUS_FLOAT((degrees), 360))
-
-// Float-aware floor since round() will round upwards when given a second arg
-#define FLOAT_FLOOR(X, N) (round(X/N)*N)

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -38,6 +38,12 @@
 /turf/check_fluid_depth(var/min)
 	. = (get_fluid_depth() >= min)
 
+/turf/proc/get_fluid_name()
+	var/obj/effect/fluid/F = return_fluid()
+	if(istype(F) && F.reagents?.primary_reagent)
+		return F.reagents.get_primary_reagent_name()
+	return "liquid"
+
 /turf/get_fluid_depth()
 	if(is_flooded(absolute=1))
 		return FLUID_MAX_DEPTH

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -192,7 +192,7 @@
 	if(locate(/obj/structure/stairs) in landing)
 		return 1
 	if(landing.get_fluid_depth() >= FLUID_DEEP)
-		var/primary_fluid = landing.reagents.get_primary_reagent_name()
+		var/primary_fluid = landing.get_fluid_name()
 		if(previous.get_fluid_depth() >= FLUID_DEEP) //We're sinking further
 			visible_message(SPAN_NOTICE("\The [src] sinks deeper down into \the [primary_fluid]!"), SPAN_NOTICE("\The [primary_fluid] rushes around you as you sink!"))
 			playsound(previous, pick(SSfluids.gurgles), 50, 1)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -164,7 +164,7 @@ var/global/obj/temp_reagents_holder = new
 
 /datum/reagents/proc/add_reagent(var/reagent_type, var/amount, var/data = null, var/safety = 0, var/defer_update = FALSE)
 
-	amount = FLOAT_FLOOR(min(amount, REAGENTS_FREE_SPACE(src)), MINIMUM_CHEMICAL_VOLUME)
+	amount = NONUNIT_FLOOR(min(amount, REAGENTS_FREE_SPACE(src)), MINIMUM_CHEMICAL_VOLUME)
 	if(amount <= 0)
 		return FALSE
 
@@ -190,7 +190,7 @@ var/global/obj/temp_reagents_holder = new
 	return TRUE
 
 /datum/reagents/proc/remove_reagent(var/reagent_type, var/amount, var/safety = 0, var/defer_update = FALSE)
-	amount = FLOAT_FLOOR(amount, MINIMUM_CHEMICAL_VOLUME)
+	amount = NONUNIT_FLOOR(amount, MINIMUM_CHEMICAL_VOLUME)
 	if(!isnum(amount) || amount <= 0 || REAGENT_VOLUME(src, reagent_type) <= 0)
 		return FALSE
 	reagent_volumes[reagent_type] -= amount
@@ -276,7 +276,7 @@ var/global/obj/temp_reagents_holder = new
 		clear_reagents()
 		return
 
-	var/removing = Clamp(FLOAT_FLOOR(amount, MINIMUM_CHEMICAL_VOLUME), 0, max(0, total_volume)) // not ideal but something is making total_volume become NaN
+	var/removing = Clamp(NONUNIT_FLOOR(amount, MINIMUM_CHEMICAL_VOLUME), 0, total_volume) // not ideal but something is making total_volume become NaN
 	if(!removing || total_volume <= 0)
 		. = 0
 		clear_reagents()
@@ -289,7 +289,7 @@ var/global/obj/temp_reagents_holder = new
 	while(removing >= MINIMUM_CHEMICAL_VOLUME && total_volume >= MINIMUM_CHEMICAL_VOLUME && !failed_remove)
 		failed_remove = TRUE
 		for(var/current in reagent_volumes)
-			var/removing_amt = min(FLOAT_FLOOR(REAGENT_VOLUME(src, current) * part, MINIMUM_CHEMICAL_VOLUME), removing)
+			var/removing_amt = min(NONUNIT_FLOOR(REAGENT_VOLUME(src, current) * part, MINIMUM_CHEMICAL_VOLUME), removing)
 			if(removing_amt <= 0)
 				continue
 			failed_remove = FALSE
@@ -315,7 +315,7 @@ var/global/obj/temp_reagents_holder = new
 	var/part = amount / total_volume
 	. = 0
 	for(var/rtype in reagent_volumes)
-		var/amount_to_transfer = FLOAT_FLOOR(REAGENT_VOLUME(src, rtype) * part, MINIMUM_CHEMICAL_VOLUME)
+		var/amount_to_transfer = NONUNIT_FLOOR(REAGENT_VOLUME(src, rtype) * part, MINIMUM_CHEMICAL_VOLUME)
 		target.add_reagent(rtype, amount_to_transfer * multiplier, REAGENT_DATA(src, rtype), TRUE, TRUE) // We don't react until everything is in place
 		. += amount_to_transfer
 		if(!copy)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -49,6 +49,7 @@ var/global/obj/temp_reagents_holder = new
 			total_volume += vol
 			if(!primary_reagent || reagent_volumes[primary_reagent] < vol)
 				primary_reagent = R
+
 	if(total_volume > maximum_volume)
 		remove_any(total_volume-maximum_volume)
 
@@ -163,7 +164,7 @@ var/global/obj/temp_reagents_holder = new
 
 /datum/reagents/proc/add_reagent(var/reagent_type, var/amount, var/data = null, var/safety = 0, var/defer_update = FALSE)
 
-	amount = round(min(amount, REAGENTS_FREE_SPACE(src)), MINIMUM_CHEMICAL_VOLUME)
+	amount = FLOAT_FLOOR(min(amount, REAGENTS_FREE_SPACE(src)), MINIMUM_CHEMICAL_VOLUME)
 	if(amount <= 0)
 		return FALSE
 
@@ -189,7 +190,7 @@ var/global/obj/temp_reagents_holder = new
 	return TRUE
 
 /datum/reagents/proc/remove_reagent(var/reagent_type, var/amount, var/safety = 0, var/defer_update = FALSE)
-	amount = round(amount, MINIMUM_CHEMICAL_VOLUME)
+	amount = FLOAT_FLOOR(amount, MINIMUM_CHEMICAL_VOLUME)
 	if(!isnum(amount) || amount <= 0 || REAGENT_VOLUME(src, reagent_type) <= 0)
 		return FALSE
 	reagent_volumes[reagent_type] -= amount
@@ -269,13 +270,35 @@ var/global/obj/temp_reagents_holder = new
 
 /* Holder-to-holder and similar procs */
 /datum/reagents/proc/remove_any(var/amount = 1, var/defer_update = FALSE) // Removes up to [amount] of reagents from [src]. Returns actual amount removed.
-	. = Clamp(amount, 0, max(0, total_volume)) // not ideal but something is making total_volume become NaN
-	if(.)
-		var/part = . / total_volume
+
+	if(amount >= total_volume)
+		. = total_volume
+		clear_reagents()
+		return
+
+	var/removing = Clamp(FLOAT_FLOOR(amount, MINIMUM_CHEMICAL_VOLUME), 0, max(0, total_volume)) // not ideal but something is making total_volume become NaN
+	if(!removing || total_volume <= 0)
+		. = 0
+		clear_reagents()
+		return
+
+	// Some reagents may be too low to remove from, so do multiple passes.
+	. = 0
+	var/part = removing / total_volume
+	var/failed_remove = FALSE
+	while(removing >= MINIMUM_CHEMICAL_VOLUME && total_volume >= MINIMUM_CHEMICAL_VOLUME && !failed_remove)
+		failed_remove = TRUE
 		for(var/current in reagent_volumes)
-			remove_reagent(current, REAGENT_VOLUME(src, current) * part, TRUE, TRUE)
-		if(!defer_update)
-			handle_update()
+			var/removing_amt = min(FLOAT_FLOOR(REAGENT_VOLUME(src, current) * part, MINIMUM_CHEMICAL_VOLUME), removing)
+			if(removing_amt <= 0)
+				continue
+			failed_remove = FALSE
+			removing -= removing_amt
+			. += removing_amt
+			remove_reagent(current, removing_amt, TRUE, TRUE)
+
+	if(!defer_update)
+		handle_update()
 
 // Transfers [amount] reagents from [src] to [target], multiplying them by [multiplier].
 // Returns actual amount removed from [src] (not amount transferred to [target]).
@@ -292,7 +315,7 @@ var/global/obj/temp_reagents_holder = new
 	var/part = amount / total_volume
 	. = 0
 	for(var/rtype in reagent_volumes)
-		var/amount_to_transfer = round(REAGENT_VOLUME(src, rtype) * part, MINIMUM_CHEMICAL_VOLUME)
+		var/amount_to_transfer = FLOAT_FLOOR(REAGENT_VOLUME(src, rtype) * part, MINIMUM_CHEMICAL_VOLUME)
 		target.add_reagent(rtype, amount_to_transfer * multiplier, REAGENT_DATA(src, rtype), TRUE, TRUE) // We don't react until everything is in place
 		. += amount_to_transfer
 		if(!copy)

--- a/code/modules/reagents/reactions/_reaction.dm
+++ b/code/modules/reagents/reactions/_reaction.dm
@@ -54,7 +54,7 @@
 
 	var/reaction_volume = holder.maximum_volume
 	for(var/reactant in required_reagents)
-		var/A = FLOAT_FLOOR(REAGENT_VOLUME(holder, reactant) / required_reagents[reactant] / limit, MINIMUM_CHEMICAL_VOLUME)  // How much of this reagent we are allowed to use
+		var/A = NONUNIT_FLOOR(REAGENT_VOLUME(holder, reactant) / required_reagents[reactant] / limit, MINIMUM_CHEMICAL_VOLUME)  // How much of this reagent we are allowed to use
 		if(reaction_volume > A)
 			reaction_volume = A
 

--- a/code/modules/reagents/reactions/_reaction.dm
+++ b/code/modules/reagents/reactions/_reaction.dm
@@ -54,7 +54,7 @@
 
 	var/reaction_volume = holder.maximum_volume
 	for(var/reactant in required_reagents)
-		var/A = round(REAGENT_VOLUME(holder, reactant) / required_reagents[reactant] / limit, MINIMUM_CHEMICAL_VOLUME)  // How much of this reagent we are allowed to use
+		var/A = FLOAT_FLOOR(REAGENT_VOLUME(holder, reactant) / required_reagents[reactant] / limit, MINIMUM_CHEMICAL_VOLUME)  // How much of this reagent we are allowed to use
 		if(reaction_volume > A)
 			reaction_volume = A
 


### PR DESCRIPTION
## Description of changes
- Swaps out `round()` in reagent rounding for a macro that always floors.
- Reworks `remove_any()` to avoid failing to remove anything, which may cause loops 

## Why and what will this PR improve
Trying to hammer out the recursion crashes in SSmaterials.

## Authorship
Myself and @out-of-phaze

## Changelog
Nothing player-facing.