### PR TITLE
Makes serpentids not permanently transform into snails upon losing blood.

### DIFF
--- a/mods/species/ascent/mobs/bodyparts_serpentid.dm
+++ b/mods/species/ascent/mobs/bodyparts_serpentid.dm
@@ -103,6 +103,8 @@
 
 	//Effects of bloodloss
 	switch(blood_volume)
+		if(BLOOD_VOLUME_SAFE to (INFINITY))
+			lowblood_tally = 0
 		if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)
 			lowblood_tally = 2
 			if(prob(1))


### PR DESCRIPTION
## Description of changes
Adds check for serpentids having fully recovered from blood loss, restoring their normal movement speed.

## Why and what will this PR improve
Serpentids should not permanently transform into snails.

## Authorship
Both lines of code: Alceris

## Changelog
:cl:
bugfix: Fixed serpentids being permanently transformed into snails upon losing blood.
/:cl: