### PR TITLE
Chem fixes

### DIFF
--- a/code/modules/reagents/reactions/reaction_drugs.dm
+++ b/code/modules/reagents/reactions/reaction_drugs.dm
@@ -34,7 +34,7 @@
 	name = "Lubricant"
 	result = /decl/material/liquid/lube
 	required_reagents = list(/decl/material/liquid/water = 1, /decl/material/solid/silicon = 1, /decl/material/liquid/acetone = 1)
-	result_amount = 4
+	result_amount = 3
 	mix_message = "The solution becomes thick and slimy."
 
 /decl/chemical_reaction/pacid

--- a/code/modules/reagents/reactions/reaction_grenade_reaction.dm
+++ b/code/modules/reagents/reactions/reaction_grenade_reaction.dm
@@ -1,5 +1,6 @@
 /decl/chemical_reaction/grenade_reaction
 	result = null
+	result_amount = 1
 
 /decl/chemical_reaction/grenade_reaction/explosion_potassium
 	name = "Explosion"

--- a/code/modules/reagents/reactions/reaction_synthesis.dm
+++ b/code/modules/reagents/reactions/reaction_synthesis.dm
@@ -62,10 +62,10 @@
 /decl/chemical_reaction/synthesis/aerogel
 	name = "Aerogel"
 	mix_message = "The solution solidifies into a translucent suspension of gas within gel."
-	required_reagents = list(/decl/material/solid/silicon = 1)
-	inhibitors = list(
-		/decl/material/liquid/crystal_agent
-	) // Interferes with resin globules.
+	required_reagents = list(/decl/material/solid/silicon = 1, /decl/material/liquid/plasticide = 1)
+	minimum_temperature = 150 CELSIUS
+	maximum_temperature = 200 CELSIUS
+	inhibitors = list(/decl/material/liquid/crystal_agent)
 
 /decl/chemical_reaction/synthesis/aerogel/can_happen(datum/reagents/holder)
 	. = ..() && length(holder.reagent_volumes) > 1


### PR DESCRIPTION
- Fixes https://github.com/ScavStation/ScavStation/issues/621
- Fixes potassium and EMP not working.

## Description of changes
Defaults grenade reactions to have a result_amount of 1, and adds temperature to aerogel synth avoid overlap.

## Why and what will this PR improve
Fixes some busted chem stuff.

## Authorship
Myself.

## Changelog
:cl:
tweak: Aerogel synthesis now requires plasticide and heating.
/:cl:
