### PR TITLE
Make smaller sips increase taste sensitivity

### DIFF
--- a/code/modules/mob/living/carbon/taste.dm
+++ b/code/modules/mob/living/carbon/taste.dm
@@ -20,7 +20,9 @@ calculate text size per text.
 	var/minimum_percent = 15
 	if(ishuman(taster))
 		var/mob/living/carbon/human/H = taster
-		minimum_percent = round(15/ (H.isSynthetic() ? TASTE_DULL : H.species.taste_sensitivity))
+		// the taste bonus makes it so that sipping a drink lets you taste it better
+		var/taste_bonus = clamp(1 + (1/total_volume), 1, 2) // 1u makes it 2x as strong, 2u makes it 1.5x, 5u makes it 1.2x, etc
+		minimum_percent = round(15/ (H.isSynthetic() ? TASTE_DULL : H.species.taste_sensitivity / taste_bonus)) // divide because we're lowering the minimum
 
 	var/list/out = list()
 	var/list/tastes = list() //descriptor = strength


### PR DESCRIPTION
## Description of changes
Smaller sips increase taste sensitivity; drinking 1u of a mixture will increase sensitivity 2x, 2u will increase it 1.5x, 5u will increase it 1.2x, etc.

## Why and what will this PR improve
You can be a cocktail snob and comment on the subtle differences in how someone mixed a drink if you take really small sips.
TODO: Let drinking glasses transfer smaller amounts?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Me.
<!-- Describe original authors of changes to credit them. -->

## Changelog
:cl:
tweak: Drinking smaller amounts makes you more sensitive to tastes
/:cl:
