### PR TITLE
Fix ice being named water

### DIFF
--- a/code/modules/codex/categories/category_cocktails.dm
+++ b/code/modules/codex/categories/category_cocktails.dm
@@ -22,7 +22,7 @@
 			// which we normalize internally for calculations.
 			var/decl/material/mixer = GET_DECL(rtype)
 			var/minimum_amount = cocktail.display_ratios[rtype]
-			var/ingredient = "<span codexlink='[mixer.codex_name || mixer.name] (substance)'>[mixer.name]</span>"
+			var/ingredient = "<span codexlink='[mixer.codex_name || mixer.name] (substance)'>[mixer.use_name]</span>"
 			if(minimum_amount)
 				ingredient = "[minimum_amount] part\s [ingredient]"
 			else

--- a/code/modules/materials/definitions/solids/materials_solid_ice.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_ice.dm
@@ -4,6 +4,7 @@
 		/decl/material/liquid/water = 1
 	)
 	name = "water"
+	use_name = "ice"
 	codex_name = "water ice"
 	taste_description = "ice"
 	ore_spread_chance = 25
@@ -24,12 +25,15 @@
 		gas_name = name
 	if(!solid_name)
 		solid_name = "[name] ice"
+	if(!use_name)
+		use_name = solid_name
 	if(!ore_name)
 		ore_name = solid_name
 	. = ..()
-	
+
 /decl/material/solid/ice/aspium
 	name = "aspium"
+	use_name = null
 	codex_name = null
 	heating_products = list(
 		/decl/material/liquid/fuel/hydrazine = 0.3,
@@ -42,6 +46,7 @@
 
 /decl/material/solid/ice/lukrite
 	name = "lukrite"
+	use_name = null
 	codex_name = null
 	heating_products = list(
 		/decl/material/solid/sulfur = 0.4,
@@ -55,6 +60,7 @@
 
 /decl/material/solid/ice/rubenium
 	name = "rubenium"
+	use_name = null
 	codex_name = null
 	heating_products = list(
 		/decl/material/solid/metal/radium  = 0.4,
@@ -68,6 +74,7 @@
 
 /decl/material/solid/ice/trigarite
 	name = "trigarite"
+	use_name = null
 	codex_name = null
 	heating_products = list(
 		/decl/material/liquid/acid/hydrochloric = 0.2,
@@ -81,6 +88,7 @@
 
 /decl/material/solid/ice/ediroite
 	name = "ediroite"
+	use_name = null
 	codex_name = null
 	heating_products = list(
 		/decl/material/gas/ammonia  = 0.4,
@@ -94,6 +102,7 @@
 
 /decl/material/solid/ice/hydrogen
 	name = "hydrogen ice"
+	use_name = null
 	codex_name = null
 	uid = "solid_ice_hydrogen"
 	heating_products = list(
@@ -113,6 +122,7 @@
 //Hydrates gas are basically bubbles of gas trapped in water ice lattices
 /decl/material/solid/ice/hydrate
 	codex_name = null
+	use_name = null
 	uid = "solid_hydrate"
 	heating_point = T0C //the melting point is always water's
 	abstract_type = /decl/material/solid/ice/hydrate
@@ -126,7 +136,7 @@
 	heating_products = list(PATH = 0.2, /decl/material/liquid/water = 0.8); \
 	. = ..();                                                               \
 }                                                                           \
-/decl/material/solid/ice/hydrate/##NAME 
+/decl/material/solid/ice/hydrate/##NAME
 
 #define DECLARE_HYDRATE_DNAME(NAME, DISPLAY_NAME) DECLARE_HYDRATE_DNAME_PATH(/decl/material/gas/##NAME, NAME, DISPLAY_NAME)
 #define DECLARE_HYDRATE(NAME) DECLARE_HYDRATE_DNAME(NAME, #NAME)

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -220,7 +220,7 @@
 		return
 	. = list()
 	. += "<TITLE>[name]</TITLE>"
-	. += "[heading]:<BR><BR>Name:<BR>[reagent.name]"
+	. += "[heading]:<BR><BR>Name:<BR>[reagent.use_name]"
 	. += "<BR><BR>Description:<BR>"
 	if(detailed_blood && istype(reagent, /decl/material/liquid/blood))
 		var/blood_data = REAGENT_DATA(beaker?.reagents, /decl/material/liquid/blood)
@@ -280,7 +280,7 @@
 			dat += "Add to buffer:<BR>"
 			for(var/rtype in R.reagent_volumes)
 				var/decl/material/G = GET_DECL(rtype)
-				dat += "[G.name], [REAGENT_VOLUME(R, rtype)] Units - "
+				dat += "[G.use_name], [REAGENT_VOLUME(R, rtype)] Units - "
 				dat += "<A href='?src=\ref[src];analyze=\ref[G]'>(Analyze)</A> "
 				dat += "<A href='?src=\ref[src];add=\ref[G];amount=1'>(1)</A> "
 				dat += "<A href='?src=\ref[src];add=\ref[G];amount=5'>(5)</A> "
@@ -292,7 +292,7 @@
 		if(reagents.total_volume)
 			for(var/rtype in reagents.reagent_volumes)
 				var/decl/material/N = GET_DECL(rtype)
-				dat += "[N.name], [REAGENT_VOLUME(reagents, rtype)] Units - "
+				dat += "[N.use_name], [REAGENT_VOLUME(reagents, rtype)] Units - "
 				dat += "<A href='?src=\ref[src];analyze=\ref[N]'>(Analyze)</A> "
 				dat += "<A href='?src=\ref[src];remove=\ref[N];amount=1'>(1)</A> "
 				dat += "<A href='?src=\ref[src];remove=\ref[N];amount=5'>(5)</A> "

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -150,7 +150,7 @@
 	if(LAZYLEN(container?.reagents?.reagent_volumes))
 		for(var/rtype in container.reagents.reagent_volumes)
 			var/decl/material/R = GET_DECL(rtype)
-			beakerD[++beakerD.len] = list("name" = R.name, "volume" = REAGENT_VOLUME(container.reagents, rtype))
+			beakerD[++beakerD.len] = list("name" = R.use_name, "volume" = REAGENT_VOLUME(container.reagents, rtype))
 	data["beakerContents"] = beakerD
 
 	if(container) // Container has had null reagents in the past; may be due to qdel without clearing reference.


### PR DESCRIPTION
## Description of changes
- Fixes ice being named water.
- Makes the codex, chem dispensers, and chemmasters/condimasters use `use_name` rather than `name`.
Targeting dev due to making potentially-breaking changes to things like the codex/dispenser/chemmaster; despite being told to use `use_name` it doesn't seem like much uses or sets it, so this might make things have funky names.

## Why and what will this PR improve
ice should be named ice and not water

## Authorship
Me.