### PR TITLE
Fix APC being deleted in power alarm clear

### DIFF
--- a/code/modules/alarm/alarm.dm
+++ b/code/modules/alarm/alarm.dm
@@ -65,7 +65,7 @@
 	var/datum/alarm_source/AS = sources_assoc[source]
 	sources -= AS
 	sources_assoc -= source
-	qdel(source)
+	qdel(AS)
 
 /datum/alarm/proc/alarm_z()
 	if(origin)


### PR DESCRIPTION
## Description of changes
Deletes the alarm source datum instead of the APC when a power alarm is cleared.

## Why and what will this PR improve
Fixes #2715.

## Authorship
Me.