### PR TITLE
Removed post_changeturf() call and associated warning from DMMS.

### DIFF
--- a/code/modules/maps/map_template.dm
+++ b/code/modules/maps/map_template.dm
@@ -73,17 +73,14 @@
 	if(notsuspended)
 		SSmachines.wake()
 
-	for (var/i in machines)
-		var/obj/machinery/machine = i
+	for (var/obj/machinery/machine as anything in machines)
 		machine.power_change()
 
-	for (var/i in turfs)
-		var/turf/T = i
-		T.post_change()
+	for (var/turf/T as anything in turfs)
 		if(template_flags & TEMPLATE_FLAG_NO_RUINS)
 			T.turf_flags |= TURF_FLAG_NORUINS
 		if(template_flags & TEMPLATE_FLAG_NO_RADS)
-			qdel(SSradiation.sources_assoc[i])
+			qdel(SSradiation.sources_assoc[T])
 		if(istype(T,/turf/simulated))
 			var/turf/simulated/sim = T
 			sim.update_air_properties()

--- a/code/modules/maps/reader.dm
+++ b/code/modules/maps/reader.dm
@@ -115,8 +115,6 @@ var/global/dmm_suite/preloader/_preloader = new
 					continue
 				else
 					world.maxz = zcrd //create a new z_level if needed
-				if(!no_changeturf)
-					WARNING("Z-level expansion occurred without no_changeturf set, this may cause problems when /turf/post_change is called.")
 
 			bounds[MAP_MINX] = min(bounds[MAP_MINX], Clamp(xcrdStart, x_lower, x_upper))
 			bounds[MAP_MINZ] = min(bounds[MAP_MINZ], zcrd)


### PR DESCRIPTION
## Description of changes
- Removes `post_change()` call from DMMS procs.
- Removes warning about `no_changeturf` being unset causing issues with `post_change()`.

## Why and what will this PR improve
Sites loaded without `no_changeturf` set are causing warnings and failing CI on dev. The actual `post_change()` proc handles level and zmimic updates and can reasonably be expected to be handled by anything setting `no_changeturf` IMO.

## Authorship
Myself.

## Changelog
Nothing player-facing.