### PR TITLE
Fix duplicate reagent init warning

### DIFF
--- a/code/modules/clothing/rings/rings.dm
+++ b/code/modules/clothing/rings/rings.dm
@@ -75,10 +75,6 @@
 	desc = "A ring made from what appears to be silver."
 	origin_tech = "{'materials':2,'esoteric':5}"
 
-/obj/item/clothing/ring/reagent/Initialize(ml, material_key)
-	. = ..()
-	initialize_reagents()
-
 /obj/item/clothing/ring/reagent/sleepy/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/paralytics, 10)
 	reagents.add_reagent(/decl/material/liquid/sedatives,   5)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
The reagent ring would initialize reagents twice and produce a warning.
This was introduced in #2573, nobody spotted it at the time, probably since the rings were never instantiated during unit testing. So it probably doesn't need to go to staging.

## Changelog
:cl:
bugfix: Fix possible duplicate reagent init for reagent containing rings.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->