### PR TITLE
Convert many mob view loops to visible/audible message 

### DIFF
--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -32,8 +32,7 @@
 		if(!O.anchored)
 			O_limit++
 			if(O_limit >= 20)
-				for(var/mob/M in hearers(src, null))
-					to_chat(M, "<span class='notice'>The mass driver lets out a screech, it mustn't be able to handle any more items.</span>")
+				visible_message(SPAN_NOTICE("\The [src] lets out a mechanical groan and refuses to budge!"))
 				break
 			use_power_oneoff(500)
 			spawn( 0 )

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -8,13 +8,13 @@
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	material = /decl/material/solid/plastic
 	matter = list(
-		/decl/material/solid/metal/copper    = MATTER_AMOUNT_REINFORCEMENT, 
-		/decl/material/solid/silicon         = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/metal/copper    = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/silicon         = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_SECONDARY,
 	)
-	var/spamcheck = 0
-	var/emagged = 0
-	var/insults = 0
+	var/spamcheck = FALSE
+	var/emagged = FALSE
+	var/insults = FALSE
 	var/list/insultmsg = list("FUCK EVERYONE!", "I'M A TATER!", "ALL SECURITY TO SHOOT ME ON SIGHT!", "I HAVE A BOMB!", "CAPTAIN IS A COMDOM!", "FOR THE SYNDICATE!")
 
 /obj/item/megaphone/attack_self(mob/user)
@@ -35,23 +35,22 @@
 	if ((src.loc == user && usr.stat == 0))
 		if(emagged)
 			if(insults)
-				for(var/mob/O in (viewers(user)))
-					O.show_message("<B>[user]</B> broadcasts, <FONT size=3>\"[pick(insultmsg)]\"</FONT>",2) // 2 stands for hearable message
+				var/insult = pick(insultmsg)
+				user.audible_message("<B>[user]</B> broadcasts, <FONT size=3>\"[insult]\"</FONT>", "You broadcast, <FONT size=3>\"[insult]\"</FONT>")
 				insults--
 			else
-				to_chat(user, "<span class='warning'>*BZZZZzzzzzt*</span>")
+				to_chat(user, SPAN_WARNING("*BZZZZzzzzzt*"))
 		else
-			for(var/mob/O in (viewers(user)))
-				O.show_message("<B>[user]</B> broadcasts, <FONT size=3>\"[message]\"</FONT>",2) // 2 stands for hearable message
+			user.audible_message("<B>[user]</B> broadcasts, <FONT size=3>\"[message]\"</FONT>", "You broadcast, <FONT size=3>\"[message]\"</FONT>")
 
-		spamcheck = 1
+		spamcheck = TRUE
 		spawn(20)
-			spamcheck = 0
+			spamcheck = FALSE
 		return
 
 /obj/item/megaphone/emag_act(var/remaining_charges, var/mob/user)
 	if(!emagged)
-		to_chat(user, "<span class='warning'>You overload \the [src]'s voice synthesizer.</span>")
-		emagged = 1
+		to_chat(user, SPAN_WARNING("You overload \the [src]'s voice synthesizer."))
+		emagged = TRUE
 		insults = rand(1, 3)//to prevent dickflooding
-		return 1
+		return TRUE

--- a/code/modules/ZAS/Airflow.dm
+++ b/code/modules/ZAS/Airflow.dm
@@ -119,16 +119,14 @@ Contains helper procs for airflow, called by /connection_group.
 	airborne_acceleration = 0
 
 /mob/airflow_hit(atom/A)
-	for(var/mob/M in hearers(src))
-		M.show_message("<span class='danger'>\The [src] slams into \a [A]!</span>",1,"<span class='danger'>You hear a loud slam!</span>",2)
+	visible_message(SPAN_DANGER("\The [src] slams into \the [A]!"), SPAN_DANGER("You slam into \the [A]!"), SPAN_DANGER("You hear a loud slam!"))
 	playsound(src.loc, "smash.ogg", 25, 1, -1)
 	var/weak_amt = istype(A,/obj/item) ? A:w_class : rand(1,5) //Heheheh
 	SET_STATUS_MAX(src, STAT_WEAK, weak_amt)
 	. = ..()
 
 /obj/airflow_hit(atom/A)
-	for(var/mob/M in hearers(src))
-		M.show_message("<span class='danger'>\The [src] slams into \a [A]!</span>",1,"<span class='danger'>You hear a loud slam!</span>",2)
+	visible_message(SPAN_DANGER("\The [src] slams into \the [A]!"), null, SPAN_DANGER("You hear a loud slam!"))
 	playsound(src.loc, "smash.ogg", 25, 1, -1)
 	. = ..()
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -605,11 +605,13 @@ var/global/list/admin_verbs_mod = list(
 	set category = "Special Verbs"
 	set name = "oSay"
 	set desc = "Display a message to everyone who can hear the target"
+
+	msg = sanitize(msg)
+
 	if(mob.control_object)
 		if(!msg)
 			return
-		for (var/mob/V in hearers(mob.control_object))
-			V.show_message("<b>[mob.control_object.name]</b> says: \"" + msg + "\"", 2)
+		mob.control_object.audible_message("<b>[mob.control_object]</b> says, \"[msg]\"")
 	SSstatistics.add_field_details("admin_verb","OT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/readmin_self()
@@ -926,7 +928,7 @@ var/global/list/admin_verbs_mod = list(
 		if("Upload custom")
 			var/file = input(usr) as icon|null
 
-			if(!file) 
+			if(!file)
 				return
 
 			global.using_map.update_titlescreen(file)

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -201,9 +201,7 @@
 			loadProgram(global.using_map.holodeck_programs["turnoff"], 0)
 			active = 0
 			update_use_power(POWER_USE_IDLE)
-			for(var/mob/M in range(10,src))
-				M.show_message("The holodeck overloads!")
-
+			visible_message("The holodeck overloads!", null, "You hear electricity arcing!", range = 10)
 
 			for(var/turf/T in linkedholodeck)
 				if(prob(30))
@@ -254,10 +252,9 @@
 		if(world.time < (last_change + 25))
 			if(world.time < (last_change + 15))//To prevent super-spam clicking, reduced process size and annoyance -Sieve
 				return
-			for(var/mob/M in range(3,src))
-				M.show_message("<span class='warning'>ERROR. Recalibrating projection apparatus.</span>")
-				last_change = world.time
-				return
+			visible_message(SPAN_WARNING("ERROR. Recalibrating projection apparatus."), range = 3)
+			last_change = world.time
+			return
 
 	last_change = world.time
 	active = 1
@@ -312,10 +309,9 @@
 	if(world.time < (last_gravity_change + 25))
 		if(world.time < (last_gravity_change + 15))//To prevent super-spam clicking
 			return
-		for(var/mob/M in range(3,src))
-			M.show_message("<span class='warning'>ERROR. Recalibrating gravity field.</span>")
-			last_change = world.time
-			return
+		visible_message(SPAN_WARNING("ERROR. Recalibrating gravity field."), range = 3)
+		last_change = world.time
+		return
 
 	last_gravity_change = world.time
 	active = 1

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -114,11 +114,10 @@
 
 	var/obj/machinery/hologram/holopad/T = src.holo
 	if(T && T.masters[src])
+		var/turf/our_turf = get_turf(T)
 		var/rendered = "<span class='game say'><span class='name'>[name]</span> <span class='message'>[message]</span></span>"
 		to_chat(src, "<i><span class='game say'>Holopad action relayed, <span class='name'>[real_name]</span> <span class='message'>[message]</span></span></i>")
-
-		for(var/mob/M in viewers(T.loc))
-			M.show_message(rendered, 2)
+		our_turf.audible_message(rendered)
 	else //This shouldn't occur, but better safe then sorry.
 		to_chat(src, "No holopad connected.")
 		return 0

--- a/code/modules/overmap/ftl_shunt/core.dm
+++ b/code/modules/overmap/ftl_shunt/core.dm
@@ -392,15 +392,14 @@
 		if(SHUNT_SABOTAGE_MINOR)
 			announcetxt = shunt_sabotage_text_minor
 			for(var/mob/living/carbon/human/H in view(7))
-				to_chat(H, SPAN_DANGER("[src] emits a flash of incredibly bright, searing light!"))
+				H.show_message(SPAN_DANGER("\The [src] emits a flash of incredibly bright, searing light!"), VISIBLE_MESSAGE)
 				H.flash_eyes(FLASH_PROTECTION_NONE)
 			empulse(src, 8, 10)
 
 		if(SHUNT_SABOTAGE_MAJOR)
 			announcetxt = shunt_sabotage_text_major
 
-			for(var/mob/living/carbon/human/H in view(7)) //Effect One: scary text.
-				to_chat(H, SPAN_DANGER("[src] hisses and sparks, before coolant lines burst and spew superheated coolant!"))
+			visible_message(SPAN_DANGER("\The [src] hisses and sparks, before the coolant lines burst and spew superheated coolant!")) //Effect One: scary text.
 
 			explosion(get_turf(src),-1,-1,8,10) //Effect Two: blow the windows out.
 
@@ -418,7 +417,7 @@
 				A.energy_fail(rand(100,120))
 
 			for(var/mob/living/carbon/human/H in view(7)) //scary text if you're in view, because you're fucked now boy.
-				to_chat(H, SPAN_DANGER("The light around [src] warps before it emits a flash of incredibly bright, searing light!"))
+				H.show_message(SPAN_DANGER("The light around \the [src] warps before it emits a flash of incredibly bright, searing light!"), VISIBLE_MESSAGE)
 				H.flash_eyes(FLASH_PROTECTION_NONE)
 
 			new /obj/singularity/(get_turf(src))

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -208,8 +208,7 @@ field_generator power level display
 	if(draw_power(round(power_draw)) >= power_draw)
 		return 1
 	else
-		for(var/mob/M in viewers(src))
-			M.show_message("<span class='warning'>\The [src] shuts down!</span>")
+		visible_message(SPAN_WARNING("\The [src] shuts down!"))
 		turn_off()
 		investigate_log("ran out of power and <font color='red'>deactivated</font>","singulo")
 		src.power = 0

--- a/code/modules/reagents/reactions/reaction_grenade_reaction.dm
+++ b/code/modules/reagents/reactions/reaction_grenade_reaction.dm
@@ -111,10 +111,9 @@
 
 /decl/chemical_reaction/grenade_reaction/foam/on_reaction(var/datum/reagents/holder, var/created_volume, var/reaction_flags)
 	..()
-	var/location = get_turf(holder.get_reaction_loc())
+	var/turf/location = get_turf(holder.get_reaction_loc())
 	if(location)
-		for(var/mob/M in viewers(5, location))
-			to_chat(M, "<span class='warning'>The solution spews out foam!</span>")
+		location.visible_message(SPAN_WARNING("The solution spews out foam!"), range = 5)
 		var/datum/effect/effect/system/foam_spread/s = new()
 		s.set_up(created_volume, location, holder, 0)
 		s.start()
@@ -129,7 +128,7 @@
 
 /decl/chemical_reaction/grenade_reaction/metalfoam/on_reaction(var/datum/reagents/holder, var/created_volume, var/reaction_flags)
 	..()
-	var/location = holder.get_reaction_loc()
+	var/atom/location = holder.get_reaction_loc()
 	if(location)
 		if(istype(location, /obj/item/sealant_tank))
 			var/obj/item/sealant_tank/foam = location
@@ -137,8 +136,7 @@
 			return
 		location = get_turf(location)
 		if(location)
-			for(var/mob/M in viewers(5, location))
-				to_chat(M, "<span class='warning'>The solution spews out a metalic foam!</span>")
+			location.visible_message(SPAN_WARNING("The solution spews out a metallic foam!"), range = 5)
 			var/datum/effect/effect/system/foam_spread/s = new()
 			s.set_up(created_volume, location, holder, 1)
 			s.start()
@@ -152,10 +150,9 @@
 
 /decl/chemical_reaction/grenade_reaction/ironfoam/on_reaction(var/datum/reagents/holder, var/created_volume, var/reaction_flags)
 	..()
-	var/location = get_turf(holder.get_reaction_loc())
+	var/turf/location = get_turf(holder.get_reaction_loc())
 	if(location)
-		for(var/mob/M in viewers(5, location))
-			to_chat(M, "<span class='warning'>The solution spews out a metalic foam!</span>")
+		location.visible_message(SPAN_WARNING("The solution spews out a metallic foam!"), range = 5)
 		var/datum/effect/effect/system/foam_spread/s = new()
 		s.set_up(created_volume, location, holder, 2)
 		s.start()

--- a/code/modules/recycling/disposalholder.dm
+++ b/code/modules/recycling/disposalholder.dm
@@ -138,11 +138,10 @@
 
 	U.last_special = world.time+100
 
-	if (src.loc)
-		for (var/mob/M in hearers(src.loc.loc))
-			to_chat(M, "<FONT size=[max(0, 5 - get_dist(src, M))]>CLONG, clong!</FONT>")
-
-	playsound(src.loc, 'sound/effects/clang.ogg', 50, 0, 0)
+	var/turf/our_turf = get_turf(src)
+	if (our_turf)
+		our_turf.audible_message("You hear a clanging noise.")
+		playsound(our_turf, 'sound/effects/clang.ogg', 50, 0, 0)
 
 // called to vent all gas in holder to a location
 /obj/structure/disposalholder/proc/vent_gas(var/atom/location)

--- a/code/modules/sealant_gun/sealant_tank.dm
+++ b/code/modules/sealant_gun/sealant_tank.dm
@@ -28,7 +28,7 @@
 	if(foam_charges)
 		var/turf/T = get_turf(src)
 		if(T)
-			T.visible_message(SPAN_WARNING("The ruptured [src.name] spews out metalic foam!"))
+			T.visible_message(SPAN_WARNING("The ruptured [src.name] spews out metallic foam!"))
 			var/datum/effect/effect/system/foam_spread/s = new()
 			s.set_up(foam_charges, T, reagents, 1)
 			s.start()


### PR DESCRIPTION
## Description of changes
Converts old code that didn't use these helpers (and instead reimplemented them, but slower) to use `visible_message` and `audible_message` instead of just doing `show_message` for every viewer/hearer.

Also fixes a few typos and does general code cleanup in the areas I touched. Some code also didn't function because of improper indentation and, as a side effect, was fixed due to removing the badly-indented loops.

Converts some cases of to_chat loops that should've been show_message loops to those, too. TODO: Allow passing a callback to visible/audible message to run per viewer?

## Why and what will this PR improve
Better code quality, using helpers, typo fixes.

## Authorship
Moi.