### PR TITLE
Remove undef for chem cartridge helper macro

### DIFF
--- a/code/modules/reagents/dispenser/cartridge_presets.dm
+++ b/code/modules/reagents/dispenser/cartridge_presets.dm
@@ -98,5 +98,3 @@ DEFINE_CARTRIDGE_FOR_CHEM(amphetamines,   /decl/material/liquid/amphetamines)
 DEFINE_CARTRIDGE_FOR_CHEM(antibiotics,    /decl/material/liquid/antibiotics)
 DEFINE_CARTRIDGE_FOR_CHEM(sedatives,      /decl/material/liquid/sedatives)
 DEFINE_CARTRIDGE_FOR_CHEM(stabilizer,     /decl/material/liquid/stabilizer)
-
-#undef DEFINE_CARTRIDGE_FOR_CHEM


### PR DESCRIPTION
## Description of changes
Removes an `#undef DEFINE_CARTRIDGE_FOR_CHEM` to make it easier for modpacks to define new chem cartridges.

## Why and what will this PR improve
The stupid fucking changes in #2573 broke stuff for no gain in functionality, style, etc. and then had the gall to undefine the fucking helpers to get around the aggravating, pointless changes it made. This removes that `#undef` to restore at least a handful of my brain cells.

## Authorship
Me.