### PR TITLE
Added a pref for determining blocking attacks on help intent.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -92,9 +92,21 @@ avoid code duplication. This includes items that may sometimes act as a standard
 //I would prefer to rename this attack_as_weapon(), but that would involve touching hundreds of files.
 /obj/item/proc/attack(mob/living/M, mob/living/user, var/target_zone, animate = TRUE)
 	if(item_flags & ITEM_FLAG_NO_BLUDGEON)
-		return 0
-	if(M == user && user.a_intent != I_HURT)
-		return 0
+		return FALSE
+
+	// If on help, possibly don't attack.
+	if(user.a_intent == I_HELP)
+		switch(user.get_preference_value(/datum/client_preference/help_intent_attack_blocking))
+			if(PREF_ALWAYS)
+				if(user == M)
+					to_chat(user, SPAN_WARNING("You refrain from hitting yourself with \the [src] as you are on help intent."))
+				else
+					to_chat(user, SPAN_WARNING("You refrain from hitting \the [M] with \the [src] as you are on help intent."))
+				return FALSE
+			if(PREF_MYSELF)
+				if(user == M)
+					to_chat(user, SPAN_WARNING("You refrain from hitting yourself with \the [src] as you are on help intent."))
+					return FALSE
 
 	/////////////////////////
 

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -62,17 +62,10 @@
 			reagents.splash(T, FLUID_QDEL_POINT)
 			to_chat(user, SPAN_NOTICE("You scrub \the [target] clean."))
 			cleaned = TRUE
-
 	else if(istype(target,/obj/structure/hygiene/sink))
 		to_chat(user, "<span class='notice'>You wet \the [src] in the sink.</span>")
 		wet()
-	else if(ishuman(target))
-		to_chat(user, "<span class='notice'>You clean \the [target.name].</span>")
-		if(reagents)
-			reagents.trans_to(target, reagents.total_volume / 8)
-		target.clean_blood() //Clean bloodied atoms. Blood decals themselves need to be handled above.
-		cleaned = TRUE
-	else 
+	else
 		to_chat(user, "<span class='notice'>You clean \the [target.name].</span>")
 		target.clean_blood() //Clean bloodied atoms. Blood decals themselves need to be handled above.
 		cleaned = TRUE
@@ -82,13 +75,20 @@
 
 //attack_as_weapon
 /obj/item/soap/attack(mob/living/target, mob/living/user, var/target_zone)
-	if(target && user && ishuman(target) && ishuman(user) && !target.stat && !user.stat && user.zone_sel &&user.zone_sel.selecting == BP_MOUTH)
-		user.visible_message("<span class='danger'>\The [user] washes \the [target]'s mouth out with soap!</span>")
-		if(reagents)
-			reagents.trans_to_mob(target, reagents.total_volume / 2, CHEM_INGEST)
+	if(ishuman(target) && user?.a_intent != I_HURT)
+		var/mob/living/carbon/human/victim = target
+		if(user.zone_sel?.selecting == BP_MOUTH && victim.check_has_mouth())
+			user.visible_message(SPAN_DANGER("\The [user] washes \the [target]'s mouth out with soap!"))
+			if(reagents)
+				reagents.trans_to_mob(target, reagents.total_volume / 2, CHEM_INGEST)
+		else
+			user.visible_message(SPAN_NOTICE("\The [user] cleans \the [target]."))
+			if(reagents)
+				reagents.trans_to(target, reagents.total_volume / 8)
+			target.clean_blood()
 		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN) //prevent spam
-		return
-	..()
+		return TRUE
+	return ..()
 
 /obj/item/soap/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/key))

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -24,9 +24,10 @@ var/global/const/PREF_CTRL_SHIFT_CLICK = "Ctrl+shift click"
 var/global/const/PREF_HEAR = "Hear"
 var/global/const/PREF_SILENT = "Silent"
 var/global/const/PREF_SHORTHAND = "Shorthand"
-var/global/const/PREF_NEVER = "Never"
 var/global/const/PREF_NON_ANTAG = "Non-Antag Only"
+var/global/const/PREF_NEVER = "Never"
 var/global/const/PREF_ALWAYS = "Always"
+var/global/const/PREF_MYSELF = "Only Against Self"
 
 var/global/list/_client_preferences
 var/global/list/_client_preferences_by_key
@@ -349,3 +350,12 @@ var/global/list/_client_preferences_by_type
 	if(!given_client)
 		return FALSE
 	return given_client.get_byond_membership()
+/******************************
+* Help intent attack blocking *
+******************************/
+
+/datum/client_preference/help_intent_attack_blocking
+	description = "Prevent attacks on help intent"
+	key = "ATTACK_ON_HELP"
+	default_value = PREF_MYSELF
+	options = list(PREF_NEVER, PREF_MYSELF, PREF_ALWAYS)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -388,7 +388,7 @@
 				return
 
 	else
-		if(!O.force)
+		if(!O.force || (O.item_flags & ITEM_FLAG_NO_BLUDGEON))
 			visible_message(SPAN_NOTICE("\The [user] gently taps [src] with \the [O]."))
 		else
 			O.attack(src, user, user.zone_sel?.selecting || ran_zone())


### PR DESCRIPTION
## Description of changes
Probably should target `dev` for the pref component, but has been a big issue on scav for new players lately.
- Adds a new preference for the help intent attack with item logic.
- Fixes soap attack.

## Why and what will this PR improve
Fixes soap, allows more protection against accidental attacks.

## Authorship
Myself.

## Changelog
:cl:
add: You can now change your preference to prevent attacking with items when on help intent.
/:cl:
