### PR TITLE
Reworking how language flags are handled.

### DIFF
--- a/code/__defines/languages.dm
+++ b/code/__defines/languages.dm
@@ -1,11 +1,13 @@
 // Language flags.
-#define WHITELISTED  1   // Language is available if the speaker is whitelisted.
-#define RESTRICTED   2   // Language can only be acquired by spawning or an admin.
-#define NONVERBAL    4   // Language has a significant non-verbal component. Speech is garbled without line-of-sight.
-#define SIGNLANG     8   // Language is completely non-verbal. Speech is displayed through emotes for those who can understand.
-#define HIVEMIND     16  // Broadcast to all mobs with this language.
-#define NONGLOBAL    32  // Do not add to general languages list.
-#define INNATE       64  // All mobs can be assumed to speak and understand this language. (audible emotes)
-#define NO_TALK_MSG  128 // Do not show the "\The [speaker] talks into \the [radio]" message
-#define NO_STUTTER   256 // No stuttering, slurring, or other speech problems
-#define ALT_TRANSMIT 512 // Language is not based on vision or sound (Todo: add this into the say code and use it for the rootspeak languages)
+#define LANG_FLAG_WHITELISTED  BITFLAG(0)  // Language is available if the speaker is whitelisted.
+#define LANG_FLAG_RESTRICTED   BITFLAG(1)  // Language can only be acquired by spawning or an admin.
+#define LANG_FLAG_NONVERBAL    BITFLAG(2)  // Language has a significant non-verbal component. Speech is garbled without line-of-sight.
+#define LANG_FLAG_SIGNLANG     BITFLAG(3)  // Language is completely non-verbal. Speech is displayed through emotes for those who can understand.
+#define LANG_FLAG_HIVEMIND     BITFLAG(4)  // Broadcast to all mobs with this language.
+#define LANG_FLAG_NONGLOBAL    BITFLAG(5)  // Do not add to general languages list.
+#define LANG_FLAG_INNATE       BITFLAG(6)  // All mobs can be assumed to speak and understand this language. (audible emotes)
+#define LANG_FLAG_NO_TALK_MSG  BITFLAG(7)  // Do not show the "\The [speaker] talks into \the [radio]" message
+#define LANG_FLAG_NO_STUTTER   BITFLAG(8)  // No stuttering, slurring, or other speech problems
+#define LANG_FLAG_ALT_TRANSMIT BITFLAG(9)  // Language is not based on vision or sound (Todo: add this into the say code and use it for the rootspeak languages)
+#define LANG_FLAG_FORBIDDEN    BITFLAG(10) // Language is not to be granted to a mob under any circumstances.
+

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -57,16 +57,24 @@ var/global/list/alien_whitelist = list()
 
 //todo: admin aliens
 /proc/is_alien_whitelisted(mob/M, var/species)
+
 	if(!M || !species)
 		return FALSE
+
+	// Forbidden languages do not care about admin rights.
+	if(istype(species,/decl/language))
+		var/decl/language/L = species
+		if(L.flags & LANG_FLAG_FORBIDDEN)
+			return FALSE
+
 	if(check_rights(R_ADMIN, FALSE, M))
 		return TRUE
 
 	if(istype(species,/decl/language))
 		var/decl/language/L = species
-		if(L.flags & RESTRICTED)
+		if(L.flags & LANG_FLAG_RESTRICTED)
 			return FALSE
-		if(!config.usealienwhitelist || !(L.flags & WHITELISTED))
+		if(!config.usealienwhitelist || !(L.flags & LANG_FLAG_WHITELISTED))
 			return TRUE
 		return whitelist_lookup(L.name, M.ckey)
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -271,7 +271,7 @@
 	//  Fix for permacell radios, but kinda eh about actually fixing them.
 	if(!M || !message) return 0
 
-	if(speaking && (speaking.flags & (NONVERBAL|SIGNLANG))) return 0
+	if(speaking && (speaking.flags & (LANG_FLAG_NONVERBAL|LANG_FLAG_SIGNLANG))) return 0
 
 	if (!broadcasting)
 		// Sedation chemical effect should prevent radio use.

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -205,7 +205,7 @@ var/global/floorIsLava = 0
 	var/list/language_types = decls_repository.get_decls_of_subtype(/decl/language)
 	for(var/k in language_types)
 		var/decl/language/L = language_types[k]
-		if(!(L.flags & INNATE))
+		if(!(L.flags & LANG_FLAG_INNATE))
 			if(!f)
 				body += " | "
 			else

--- a/code/modules/codex/categories/category_languages.dm
+++ b/code/modules/codex/categories/category_languages.dm
@@ -12,23 +12,23 @@
 		var/list/lang_info = list()
 		var/decl/prefix/P = /decl/prefix/language
 		lang_info += "Key to use it: '[initial(P.default_key)][L.key]'"
-		if(L.flags & NONVERBAL)
+		if(L.flags & LANG_FLAG_NONVERBAL)
 			lang_info += "It has a significant non-verbal component. Speech is garbled without line-of-sight."
-		if(L.flags & SIGNLANG)
+		if(L.flags & LANG_FLAG_SIGNLANG)
 			lang_info += "It is completely non-verbal, using gestures or signs to communicate."
-		if(L.flags & HIVEMIND)
+		if(L.flags & LANG_FLAG_HIVEMIND)
 			lang_info += "It's a 'hivemind' language, broadcast to all creatures who understand it."
-		if(L.flags & NO_STUTTER)
+		if(L.flags & LANG_FLAG_NO_STUTTER)
 			lang_info += "It will not be affected by speech impediments."
 
 		var/list/lang_lore = list(L.desc)
 		lang_lore += "Shorthand: '[L.shorthand]'"
-		if(!(L.flags & (SIGNLANG|NONVERBAL|HIVEMIND)))
+		if(!(L.flags & (LANG_FLAG_SIGNLANG|LANG_FLAG_NONVERBAL|LANG_FLAG_HIVEMIND)))
 			var/lang_example = L.format_message(L.scramble(example_line), L.speech_verb)
 			lang_lore += "It sounds like this:"
 			lang_lore += ""
 			lang_lore += "<b>CodexBot</b> [lang_example]"
-			
+
 		var/datum/codex_entry/entry = new(
 			_display_name = "[L.name] (language)",
 			_lore_text = jointext(lang_lore, "<br>"),

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -161,7 +161,7 @@
 			languages -= L
 		// Also removing any languages that won't work well over radio.
 		// A synth is unlikely to have any besides Binary, but we're playing it safe
-		else if(L.flags & (HIVEMIND|NONVERBAL|SIGNLANG))
+		else if(L.flags & (LANG_FLAG_HIVEMIND|LANG_FLAG_NONVERBAL|LANG_FLAG_SIGNLANG))
 			languages -= L
 
 	if(length(languages))

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -9,7 +9,7 @@
 			//Or someone snoring.  So we make it where they won't hear it.
 		return
 
-	if(language && (language.flags & (NONVERBAL|SIGNLANG)))
+	if(language && (language.flags & (LANG_FLAG_NONVERBAL|LANG_FLAG_SIGNLANG)))
 		sound_vol = 0
 		speech_sound = null
 
@@ -30,11 +30,11 @@
 		return
 
 	//non-verbal languages are garbled if you can't see the speaker. Yes, this includes if they are inside a closet.
-	if (language && (language.flags & NONVERBAL))
+	if (language && (language.flags & LANG_FLAG_NONVERBAL))
 		if (!speaker || (src.sdisabilities & BLINDED || src.blinded) || !(speaker in view(src)))
 			message = stars(message)
 
-	if(!(language && (language.flags & INNATE))) // skip understanding checks for INNATE languages
+	if(!(language && (language.flags & LANG_FLAG_INNATE))) // skip understanding checks for LANG_FLAG_INNATE languages
 		if(!say_understands(speaker,language))
 			if(istype(speaker,/mob/living/simple_animal))
 				var/mob/living/simple_animal/S = speaker
@@ -65,7 +65,7 @@
 			message = "<b>[message]</b>"
 
 	if(is_deaf() || get_sound_volume_multiplier() < 0.2)
-		if(!language || !(language.flags & INNATE)) // INNATE is the flag for audible-emote-language, so we don't want to show an "x talks but you cannot hear them" message if it's set
+		if(!language || !(language.flags & LANG_FLAG_INNATE)) // LANG_FLAG_INNATE is the flag for audible-emote-language, so we don't want to show an "x talks but you cannot hear them" message if it's set
 			if(speaker == src)
 				to_chat(src, SPAN_WARNING("You cannot hear yourself speak!"))
 			else if(!is_blind())
@@ -113,11 +113,11 @@
 	var/track = null
 
 	//non-verbal languages are garbled if you can't see the speaker. Yes, this includes if they are inside a closet.
-	if (language && (language.flags & NONVERBAL))
+	if (language && (language.flags & LANG_FLAG_NONVERBAL))
 		if (!speaker || (src.sdisabilities & BLINDED || src.blinded) || !(speaker in view(src)))
 			message = stars(message)
 
-	if(!(language && (language.flags & INNATE))) // skip understanding checks for INNATE languages
+	if(!(language && (language.flags & LANG_FLAG_INNATE))) // skip understanding checks for LANG_FLAG_INNATE languages
 		if(!say_understands(speaker,language))
 			if(istype(speaker,/mob/living/simple_animal))
 				var/mob/living/simple_animal/S = speaker

--- a/code/modules/mob/language/alien/antag.dm
+++ b/code/modules/mob/language/alien/antag.dm
@@ -4,7 +4,7 @@
 	speech_verb = "says"
 	colour = "changeling"
 	key = "g"
-	flags = RESTRICTED | HIVEMIND
+	flags = LANG_FLAG_RESTRICTED | LANG_FLAG_HIVEMIND
 	shorthand = "N/A"
 	hidden_from_codex = TRUE
 
@@ -23,7 +23,7 @@
 	exclaim_verb = "chants"
 	colour = "cult"
 	key = "f"
-	flags = RESTRICTED
+	flags = LANG_FLAG_RESTRICTED
 	space_chance = 100
 	syllables = list("ire","ego","nahlizet","certum","veri","jatkaa","mgar","balaq", "karazet", "geeri", \
 		"orkan", "allaq", "sas'so", "c'arta", "forbici", "tarem", "n'ath", "reth", "sh'yro", "eth", "d'raggathnor", \
@@ -44,7 +44,7 @@
 	exclaim_verb = "chants"
 	colour = "cult"
 	key = "y"
-	flags = RESTRICTED | HIVEMIND
+	flags = LANG_FLAG_RESTRICTED | LANG_FLAG_HIVEMIND
 	shorthand = "N/A"
 	hidden_from_codex = TRUE
 
@@ -53,7 +53,7 @@
 	colour = "cult"
 	speech_verb = "hisses"
 	key = "c"
-	flags = RESTRICTED
+	flags = LANG_FLAG_RESTRICTED
 	syllables = list("qy","bok","mok","yok","dy","gly","ryl","byl","dok","forbici", "tarem", "n'ath", "reth", "sh'yro", "eth", "d'raggathnor","niii",
 	"d'rekkathnor", "khari'd", "gual'te", "ki","ki","ki","ki","ya","ta","wej","nym","assah","qwssa","nieasl","qyno","shaffar",
 	"eg","bog","voijs","nekks","bollos","qoulsan","borrksakja","neemen","aka","nikka","qyegno","shafra","beolas","Byno")

--- a/code/modules/mob/language/alien/monkey.dm
+++ b/code/modules/mob/language/alien/monkey.dm
@@ -5,7 +5,7 @@
 	ask_verb = "chimpers"
 	exclaim_verb = "screeches"
 	key = ""
-	flags = RESTRICTED
+	flags = LANG_FLAG_RESTRICTED
 	syllables = list("ook", "eek", "hiss", "gronk")
 	shorthand = "Ook"
 	hidden_from_codex = 1

--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -3,7 +3,7 @@
 	name = "Noise"
 	desc = "Noises"
 	key = ""
-	flags = RESTRICTED|NONGLOBAL|INNATE|NO_TALK_MSG|NO_STUTTER
+	flags = LANG_FLAG_RESTRICTED|LANG_FLAG_NONGLOBAL|LANG_FLAG_INNATE|LANG_FLAG_NO_TALK_MSG|LANG_FLAG_NO_STUTTER
 	hidden_from_codex = 1
 
 /decl/language/noise/format_message(message, verb)
@@ -25,5 +25,5 @@
 	signlang_verb = list("gestures")
 	colour = "say_quote"
 	key = "s"
-	flags = SIGNLANG | NO_STUTTER | NONVERBAL
+	flags = LANG_FLAG_SIGNLANG | LANG_FLAG_NO_STUTTER | LANG_FLAG_NONVERBAL
 	shorthand = "HS"

--- a/code/modules/mob/language/human/human.dm
+++ b/code/modules/mob/language/human/human.dm
@@ -5,7 +5,7 @@
 	speech_verb = "says"
 	whisper_verb = "whispers"
 	colour = "solcom"
-	flags = WHITELISTED | RESTRICTED
+	flags = LANG_FLAG_WHITELISTED | LANG_FLAG_RESTRICTED
 	shorthand = "???"
 	space_chance = 40
 	abstract_type = /decl/language/human
@@ -41,7 +41,7 @@
 	whisper_verb = "whispers"
 	colour = ""
 	key = "1"
-	flags = WHITELISTED
+	flags = LANG_FLAG_WHITELISTED
 	shorthand = "C"
 	partial_understanding = list()
 	syllables = list(

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -9,7 +9,7 @@
 
 	// Short description for 'Check Languages'.
 	var/desc = "You should not have this language."
-	// list of emotes that might be displayed if this language has NONVERBAL or SIGNLANG flags
+	// list of emotes that might be displayed if this language has LANG_FLAG_NONVERBAL or LANG_FLAG_SIGNLANG flags
 	var/signlang_verb = list("signs", "gestures")
 
 	var/name                            // Fluff name of language if any.
@@ -125,7 +125,7 @@
 	scramble_cache[input] = scrambled_text
 	if(scramble_cache.len > SCRAMBLE_CACHE_LEN)
 		scramble_cache.Cut(1, scramble_cache.len-SCRAMBLE_CACHE_LEN-1)
-	
+
 	return scrambled_text
 
 /decl/language/proc/format_message(message, verb)
@@ -204,7 +204,7 @@
 	if (only_species_language && speaking != GET_DECL(species_language))
 		return 0
 
-	return (speaking.can_speak_special(src) && (universal_speak || (speaking && speaking.flags & INNATE) || (speaking in src.languages)))
+	return (speaking.can_speak_special(src) && (universal_speak || (speaking && speaking.flags & LANG_FLAG_INNATE) || (speaking in src.languages)))
 
 /mob/proc/get_language_prefix()
 	return get_prefix_key(/decl/prefix/language)
@@ -221,7 +221,7 @@
 	var/dat = "<b><font size = 5>Known Languages</font></b><br/><br/>"
 
 	for(var/decl/language/L in languages)
-		if(!(L.flags & NONGLOBAL))
+		if(!(L.flags & LANG_FLAG_NONGLOBAL))
 			dat += "<b>[L.name]([L.shorthand]) ([get_language_prefix()][L.key])</b><br/>[L.desc]<br/><br/>"
 
 	show_browser(src, dat, "window=checklanguage")
@@ -235,7 +235,7 @@
 		dat += "Current default language: [lang.name] - <a href='byond://?src=\ref[src];default_lang=reset'>reset</a><br/><br/>"
 
 	for(var/decl/language/L in languages)
-		if(!(L.flags & NONGLOBAL))
+		if(!(L.flags & LANG_FLAG_NONGLOBAL))
 			if(L == default_language)
 				dat += "<b>[L.name]([L.shorthand]) ([get_language_prefix()][L.key])</b> - default - <a href='byond://?src=\ref[src];default_lang=reset'>reset</a><br/>[L.desc]<br/><br/>"
 			else if (can_speak(L))

--- a/code/modules/mob/language/synthetic.dm
+++ b/code/modules/mob/language/synthetic.dm
@@ -7,7 +7,7 @@
 	exclaim_verb = "whistles loudly"
 	colour = "changeling"
 	key = "6"
-	flags = NO_STUTTER
+	flags = LANG_FLAG_NO_STUTTER
 	syllables = list("beep","beep","beep","beep","beep","boop","boop","boop","bop","bop","dee","dee","doo","doo","hiss","hss","buzz","buzz","bzz","ksssh","keey","wurr","wahh","tzzz")
 	space_chance = 10
 	speech_sounds = list(
@@ -20,7 +20,7 @@
 		'sound/voice/eal/eal7.ogg',
 		'sound/voice/eal/eal8.ogg'
 	)
-		
+
 /decl/language/binary
 	name = "Robot Talk"
 	desc = "Most human facilities support free-use communications protocols and routing hubs for synthetic use."
@@ -29,7 +29,7 @@
 	ask_verb = "queries"
 	exclaim_verb = "declares"
 	key = "b"
-	flags = RESTRICTED | HIVEMIND
+	flags = LANG_FLAG_RESTRICTED | LANG_FLAG_HIVEMIND
 	shorthand = "N/A"
 	var/drone_only
 
@@ -83,6 +83,6 @@
 	exclaim_verb = "transmits"
 	colour = "say_quote"
 	key = "d"
-	flags = RESTRICTED | HIVEMIND
+	flags = LANG_FLAG_RESTRICTED | LANG_FLAG_HIVEMIND
 	drone_only = 1
 	shorthand = "N/A"

--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -22,7 +22,7 @@
 /decl/species/proc/handle_autohiss(message, decl/language/lang, mode)
 	if(!autohiss_basic_map)
 		return message
-	if(lang.flags & NO_STUTTER)	// Currently prevents EAL, Sign language, and emotes from autohissing
+	if(lang.flags & LANG_FLAG_NO_STUTTER)	// Currently prevents EAL, Sign language, and emotes from autohissing
 		return message
 	if(autohiss_exempt && (lang.name in autohiss_exempt))
 		return message

--- a/code/modules/mob/living/carbon/brain/say.dm
+++ b/code/modules/mob/living/carbon/brain/say.dm
@@ -27,7 +27,7 @@
 			else
 				message = Gibberish(message, (emp_damage*6))//scrambles the message, gets worse when emp_damage is higher
 
-		if(speaking && speaking.flags & HIVEMIND)
+		if(speaking && speaking.flags & LANG_FLAG_HIVEMIND)
 			speaking.broadcast(src,trim(message))
 			return
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -769,10 +769,18 @@
 				permitted_languages |= lang
 
 	for(var/decl/language/lang in languages)
-		if(lang.type in permitted_languages)
-			continue
-		if(!(lang.flags & RESTRICTED) && (lang.flags & WHITELISTED) && is_alien_whitelisted(src, lang))
-			continue
+		// Forbidden languages are always removed.
+		if(!(lang.flags & LANG_FLAG_FORBIDDEN))
+			// Admin can have whatever available language they want.
+			if(has_admin_rights())
+				continue
+			// Whitelisted languages are fine.
+			if((lang.flags & LANG_FLAG_WHITELISTED) && is_alien_whitelisted(src, lang))
+				continue
+			// Culture-granted languages are fine.
+			if(lang.type in permitted_languages)
+				continue
+		// This language is Not Fine, remove it.
 		if(lang.type == default_language)
 			default_language = null
 		remove_language(lang.type)
@@ -782,7 +790,6 @@
 
 	if(length(default_languages) && isnull(default_language))
 		default_language = default_languages[1]
-
 
 /mob/living/carbon/human/can_inject(var/mob/user, var/target_zone)
 	var/obj/item/organ/external/affecting = GET_EXTERNAL_ORGAN(src, target_zone)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -3,7 +3,7 @@
 		var/obj/item/organ/internal/voicebox/voice = locate() in get_internal_organs()
 		// Check if the language they're speaking is vocal and not supplied by a machine, and if they are currently suffocating.
 		whispering = (whispering || has_chemical_effect(CE_VOICELOSS, 1))
-		if((!speaking || !(speaking.flags & (NONVERBAL|SIGNLANG))) && (!voice || !voice.is_usable() || !voice.assists_languages[speaking]) && !isSynthetic() && need_breathe() && failed_last_breath)
+		if((!speaking || !(speaking.flags & (LANG_FLAG_NONVERBAL|LANG_FLAG_SIGNLANG))) && (!voice || !voice.is_usable() || !voice.assists_languages[speaking]) && !isSynthetic() && need_breathe() && failed_last_breath)
 			var/obj/item/organ/internal/lungs/L = get_organ(species.breathing_organ, /obj/item/organ/internal/lungs)
 			if(!L || L.breath_fail_ratio > 0.9)
 				if(L && world.time < L.last_successful_breath + 2 MINUTES) //if we're in grace suffocation period, give it up for last words

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -217,11 +217,11 @@ var/global/list/channel_to_radio_key = new
 
 	// This is broadcast to all mobs with the language,
 	// irrespective of distance or anything else.
-	if(speaking && (speaking.flags & HIVEMIND))
+	if(speaking && (speaking.flags & LANG_FLAG_HIVEMIND))
 		speaking.broadcast(src,trim(message))
 		return 1
 
-	if((is_muzzled()) && !(speaking && (speaking.flags & SIGNLANG)))
+	if((is_muzzled()) && !(speaking && (speaking.flags & LANG_FLAG_SIGNLANG)))
 		to_chat(src, "<span class='danger'>You're muzzled and cannot speak!</span>")
 		return
 
@@ -239,7 +239,7 @@ var/global/list/channel_to_radio_key = new
 	if(speaking && !speaking.can_be_spoken_properly_by(src))
 		message = speaking.muddle(message)
 
-	if(!(speaking && (speaking.flags & NO_STUTTER)))
+	if(!(speaking && (speaking.flags & LANG_FLAG_NO_STUTTER)))
 		var/list/message_data = list(message, verb, 0)
 		if(handle_speech_problems(message_data))
 			message = message_data[1]
@@ -270,7 +270,7 @@ var/global/list/channel_to_radio_key = new
 		if(speaking)
 			message_range = speaking.get_talkinto_msg_range(message)
 		var/msg
-		if(!speaking || !(speaking.flags & NO_TALK_MSG))
+		if(!speaking || !(speaking.flags & LANG_FLAG_NO_TALK_MSG))
 			msg = "<span class='notice'>\The [src] talks into \the [used_radios[1]].</span>"
 		for(var/mob/living/M in hearers(5, src))
 			if((M != src) && msg)
@@ -284,11 +284,11 @@ var/global/list/channel_to_radio_key = new
 
 	//handle nonverbal and sign languages here
 	if (speaking)
-		if (speaking.flags & NONVERBAL)
+		if (speaking.flags & LANG_FLAG_NONVERBAL)
 			if (prob(30))
 				src.custom_emote(1, "[pick(speaking.signlang_verb)].")
 
-		if (speaking.flags & SIGNLANG)
+		if (speaking.flags & LANG_FLAG_SIGNLANG)
 			log_say("[name]/[key] : SIGN: [message]")
 			return say_signlang(message, pick(speaking.signlang_verb), speaking)
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -229,7 +229,7 @@
 		dat += "Current default language: [lang.name] - <a href='byond://?src=\ref[src];default_lang=reset'>reset</a><br/><br/>"
 
 	for(var/decl/language/L in languages)
-		if(!(L.flags & NONGLOBAL))
+		if(!(L.flags & LANG_FLAG_NONGLOBAL))
 			var/default_str
 			if(L == default_language)
 				default_str = " - default - <a href='byond://?src=\ref[src];default_lang=reset'>reset</a>"

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -49,7 +49,7 @@
 			return 1
 		return 0
 
-	if(speaking.flags & INNATE)
+	if(speaking.flags & LANG_FLAG_INNATE)
 		return 1
 
 	//Language check.

--- a/mods/content/bigpharma/language.dm
+++ b/mods/content/bigpharma/language.dm
@@ -9,6 +9,7 @@
 	space_chance = 0
 	key = "💊"
 	allow_repeated_syllables = FALSE
+	flags = LANG_FLAG_RESTRICTED | LANG_FLAG_FORBIDDEN
 	syllables = list(
 		"o", "a","flu","o","me","phyto","doce","tha","facto","bena","zeco","ni",
 		"me","pro","dize","da","le","ta","to","ba","re","mbi","no","ffi",

--- a/mods/mobs/borers/datum/language.dm
+++ b/mods/mobs/borers/datum/language.dm
@@ -6,7 +6,7 @@
 	exclaim_verb = "sings"
 	colour = "alien"
 	key = "z"
-	flags = RESTRICTED | HIVEMIND
+	flags = LANG_FLAG_RESTRICTED | LANG_FLAG_HIVEMIND
 	shorthand = "N/A"
 	hidden_from_codex = TRUE
 

--- a/mods/mobs/borers/mob/borer/say.dm
+++ b/mods/mobs/borers/mob/borer/say.dm
@@ -24,7 +24,7 @@
 		return custom_emote(1, copytext(message,2))
 
 	var/decl/language/L = parse_language(message)
-	if(L && L.flags & HIVEMIND)
+	if(L && L.flags & LANG_FLAG_HIVEMIND)
 		L.broadcast(src,trim(copytext(message,3)),src.truename)
 		return
 

--- a/mods/mobs/dionaea/datums/language.dm
+++ b/mods/mobs/dionaea/datums/language.dm
@@ -6,7 +6,7 @@
 	exclaim_verb = "rustles"
 	colour = "soghun"
 	key = "q"
-	flags = RESTRICTED
+	flags = LANG_FLAG_RESTRICTED
 	syllables = list("hs","zt","kr","st","sh")
 	shorthand = "RT"
 	machine_understands = FALSE

--- a/mods/species/adherent/datum/language.dm
+++ b/mods/species/adherent/datum/language.dm
@@ -7,7 +7,7 @@
 	exclaim_verb = "peals"
 	colour = "adherent"
 	key = "p"
-	flags = WHITELISTED
+	flags = LANG_FLAG_WHITELISTED
 	syllables = list("\[Ab\]", "\[Bb\]", "\[Cb\]", "\[Db\]", "\[Eb\]", "\[Fb\]",
 		"\[Gb\]", "\[A#\]", "\[B#\]", "\[C#\]", "\[D#\]", "\[E#\]", "\[F#\]",
 		"\[G#\]", "\[A\]", "\[B\]", "\[C\]", "\[D\]", "\[E\]", "\[F\]", "\[G\]",

--- a/mods/species/ascent/datum/languages.dm
+++ b/mods/species/ascent/datum/languages.dm
@@ -8,7 +8,7 @@
 	syllables = list("-","=","+","_","|","/")
 	space_chance = 0
 	key = "|"
-	flags = RESTRICTED
+	flags = LANG_FLAG_RESTRICTED
 	shorthand = "KV"
 	machine_understands = FALSE
 	var/list/correct_mouthbits = list(
@@ -53,7 +53,7 @@
 	speech_verb = "flashes"
 	ask_verb = "gleams"
 	exclaim_verb = "flares"
-	flags = RESTRICTED | NO_STUTTER | NONVERBAL
+	flags = LANG_FLAG_RESTRICTED | LANG_FLAG_NO_STUTTER | LANG_FLAG_NONVERBAL
 	shorthand = "KNV"
 
 #define MANTID_SCRAMBLE_CACHE_LEN 20
@@ -86,7 +86,7 @@
 	speech_verb = "flashes"
 	ask_verb = "gleams"
 	exclaim_verb = "flares"
-	flags = RESTRICTED | NO_STUTTER | NONVERBAL | HIVEMIND
+	flags = LANG_FLAG_RESTRICTED | LANG_FLAG_NO_STUTTER | LANG_FLAG_NONVERBAL | LANG_FLAG_HIVEMIND
 	shorthand = "KB"
 
 /decl/language/mantid/worldnet/check_special_condition(var/mob/living/carbon/other)

--- a/mods/species/lizard/datum/language.dm
+++ b/mods/species/lizard/datum/language.dm
@@ -6,7 +6,7 @@
 	exclaim_verb = "roars"
 	colour = "soghun"
 	key = "o"
-	flags = WHITELISTED
+	flags = LANG_FLAG_WHITELISTED
 	space_chance = 40
 	syllables = list(
 		"za", "az", "ze", "ez", "zi", "iz", "zo", "oz", "zu", "uz", "zs", "sz",

--- a/mods/species/neoavians/datum/language.dm
+++ b/mods/species/neoavians/datum/language.dm
@@ -7,7 +7,7 @@
 	exclaim_verb = "calls"
 	colour = "alien"
 	key = "v"
-	flags = WHITELISTED
+	flags = LANG_FLAG_WHITELISTED
 	space_chance = 50
 	syllables = list(
 			"ca", "ra", "ma", "sa", "na", "ta", "la", "sha",
@@ -34,7 +34,7 @@
 	exclaim_verb = "trills"
 	colour = "alien"
 	key = "i"
-	flags = WHITELISTED
+	flags = LANG_FLAG_WHITELISTED
 	space_chance = 50
 	syllables = list(
 			"ca", "ra", "ma", "sa", "na", "ta", "la", "sha", "scha", "a", "a",

--- a/mods/species/tajaran/datum/language.dm
+++ b/mods/species/tajaran/datum/language.dm
@@ -6,7 +6,7 @@
 	exclaim_verb = "howls"
 	whisper_verb = "purrs softly"
 	key = "2"
-	flags = WHITELISTED
+	flags = LANG_FLAG_WHITELISTED
 	shorthand = "T"
 	syllables = list("mrr","rr","tajr","kir","raj","kii","mir","kra","ahk","nal","vah","khaz","jri","ran","darr",
 	"mi","jri","dynh","manq","rhe","zar","rrhaz","kal","chur","eech","thaa","dra","jurl","mah","sanu","dra","ii'r",

--- a/mods/species/vox/datum/language.dm
+++ b/mods/species/vox/datum/language.dm
@@ -6,7 +6,7 @@
 	exclaim_verb = "SHRIEKS"
 	colour = "vox"
 	key = "x"
-	flags = WHITELISTED
+	flags = LANG_FLAG_WHITELISTED
 	syllables = list("ti","ti","ti","hi","hi","ki","ki","ki","ki","ya","ta","ha","ka","ya","chi","cha","kah", \
 	"SKRE","AHK","EHK","RAWK","KRA","AAA","EEE","KI","II","KRI","KA")
 	machine_understands = 0


### PR DESCRIPTION
## Description of changes
- Renames the language flags to be more obvious in purpose.
- Adds LANG_FLAG_FORBIDDEN to restrict Big Pharma from ever being used.
- Adjusts how admin rights are used to determine language availability during chargen.

## Why and what will this PR improve
Disabling the whitelist can make every language in the game available to players currently.

## Authorship
Myself.