### PR TITLE
Attempting to generalize ambient light.

### DIFF
--- a/code/__defines/subsystem-priority.dm
+++ b/code/__defines/subsystem-priority.dm
@@ -20,6 +20,7 @@
 #define SS_PRIORITY_SPACEDRIFT     40  // Drifting things.
 #define SS_PRIORITY_INPUT          20  // Input things.
 #define SS_PRIORITY_ICON_UPDATE    20  // Queued icon updates. Mostly used by APCs and tables.
+#define SS_PRIORITY_AMBIENCE       20  // Queued ambient lighting updates.
 #define SS_PRIORITY_ALARM          20  // Alarm processing.
 #define SS_PRIORITY_EVENT          20  // Event processing and queue handling.
 #define SS_PRIORITY_SHUTTLE        20  // Shuttle movement.

--- a/code/controllers/subsystems/ambience.dm
+++ b/code/controllers/subsystems/ambience.dm
@@ -1,0 +1,56 @@
+SUBSYSTEM_DEF(ambience)
+	name = "Ambient Lighting"
+	wait = 1
+	priority = SS_PRIORITY_LIGHTING
+	init_order = SS_INIT_LIGHTING
+	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT // Copied from icon update subsystem.
+	flags = SS_NO_INIT
+	var/list/queued = list()
+
+/datum/controller/subsystem/ambience/stat_entry()
+	..("P:[length(queued)]")
+
+/datum/controller/subsystem/ambience/fire(resumed = FALSE, no_mc_tick = FALSE)
+	var/list/curr = queued
+	while (curr.len)
+		var/turf/target = curr[curr.len]
+		curr.len--
+		if(!QDELETED(target))
+			target.update_ambient_light_from_z()
+		if (no_mc_tick)
+			CHECK_TICK
+		else if (MC_TICK_CHECK)
+			return
+
+/turf/proc/update_ambient_light_from_z()
+
+	// If we're not outside, we don't show ambient light.
+	if(!is_outside())
+		clear_ambient_light()
+		return FALSE
+
+	// If we're dynamically lit, we want ambient light regardless of neighbors.
+	. = TURF_IS_DYNAMICALLY_LIT_UNSAFE(src)
+	// If we're not, we want ambient light if one of our neighbors needs to show spillover from corners.
+	if(!.)
+		for(var/turf/T in RANGE_TURFS(src, 1))
+			// Fuck if I know how these turfs are located in an area that is not an area.
+			if(isloc(T.loc) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+				. = TRUE
+				break
+
+	if(.)
+		// Grab what we need to set ambient light.
+		// TODO: z-level data handlers should store this information in a cheaply accessible way.
+		var/obj/effect/overmap/visitable/sector/exoplanet/planet = global.overmap_sectors["[z]"]
+		if(istype(planet))
+			if(planet.lightlevel)
+				set_ambient_light(COLOR_WHITE, planet.lightlevel)
+				return TRUE
+		else
+			if(config.starlight)
+				set_ambient_light(SSskybox.background_color, config.starlight)
+				return TRUE
+
+	clear_ambient_light()
+	return FALSE

--- a/code/game/area/area_space.dm
+++ b/code/game/area/area_space.dm
@@ -12,7 +12,6 @@ var/global/area/space_area
 	has_gravity = 0
 	area_flags = AREA_FLAG_EXTERNAL | AREA_FLAG_IS_NOT_PERSISTENT | AREA_FLAG_IS_BACKGROUND
 	ambience = list('sound/ambience/ambispace1.ogg','sound/ambience/ambispace2.ogg','sound/ambience/ambispace3.ogg','sound/ambience/ambispace4.ogg','sound/ambience/ambispace5.ogg')
-	show_starlight = TRUE
 	is_outside = OUTSIDE_YES
 
 /area/space/Initialize()

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -33,7 +33,6 @@ var/global/list/areas = list()
 	var/oneoff_environ =      0
 	var/has_gravity =         TRUE
 	var/air_doors_activated = FALSE
-	var/show_starlight =      FALSE
 
 	var/obj/machinery/power/apc/apc
 	var/list/all_doors		//Added by Strumpetplaya - Alarm Change - Contains a list of doors adjacent to this area

--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -36,8 +36,6 @@
 			ChangeArea(src, owner.planetary_area)
 
 	. = ..(mapload)	// second param is our own, don't pass to children
-	if (mapload)
-		setup_environmental_lighting()
 
 	var/air_graphic = get_air_graphic()
 	if(length(air_graphic))
@@ -66,21 +64,6 @@
 	if(istype(ext))
 		ext.affecting_heat_sources = last_affecting_heat_sources
 	return ext
-
-/turf/exterior/proc/setup_environmental_lighting()
-	if (is_outside())
-		if (owner)
-			set_ambient_light(COLOR_WHITE, owner.lightlevel)
-			return
-
-		if (config.starlight)
-			var/area/A = loc
-			if (A.show_starlight)
-				set_ambient_light(SSskybox.background_color)
-			else if (ambient_light)
-				clear_ambient_light()
-	else if (ambient_light)
-		clear_ambient_light()
 
 /turf/exterior/is_plating()
 	return !density
@@ -139,7 +122,7 @@
 	SHOULD_CALL_PARENT(FALSE)
 	if(!istype(src, get_base_turf_by_area(src)) && (severity == 1 || (severity == 2 && prob(40))))
 		ChangeTurf(get_base_turf_by_area(src))
-	
+
 /turf/exterior/on_update_icon()
 	. = ..() // Recalc AO and flooding overlay.
 	cut_overlays()

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -21,7 +21,7 @@
 	SHOULD_CALL_PARENT(FALSE)
 	atom_flags |= ATOM_FLAG_INITIALIZED
 
-	update_ambient_light_from_z()
+	SSambience.queued += src
 
 	//We might be an edge
 	if(y == world.maxy || forced_dirs & NORTH)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -16,25 +16,12 @@
 	/// Force this one to pretend it's an overedge turf.
 	var/forced_dirs = 0
 
-/turf/space/proc/update_starlight()
-	for (var/turf/T in RANGE_TURFS(src, 1))
-		// Fuck if I know how these turfs are located in an area that is not an area.
-		if (!isloc(T.loc) || !TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
-			continue
-
-		set_ambient_light(SSskybox.background_color)
-		return
-
-	if (ambient_light)
-		clear_ambient_light()
-
 /turf/space/Initialize()
 
 	SHOULD_CALL_PARENT(FALSE)
 	atom_flags |= ATOM_FLAG_INITIALIZED
 
-	if (config.starlight)
-		update_starlight()
+	update_ambient_light_from_z()
 
 	//We might be an edge
 	if(y == world.maxy || forced_dirs & NORTH)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -67,7 +67,7 @@
 	else
 		luminosity = 1
 
-	update_ambient_light_from_z()
+	SSambience.queued += src
 
 	if (opacity)
 		has_opaque_atom = TRUE
@@ -427,10 +427,7 @@
 		is_outside = new_outside
 		if(!skip_weather_update)
 			update_weather()
-		if(is_outside)
-			update_ambient_light_from_z()
-		else
-			clear_ambient_light()
+		SSambience.queued += src
 		return TRUE
 	return FALSE
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -35,11 +35,11 @@
 	var/tmp/changing_turf
 	var/tmp/prev_type // Previous type of the turf, prior to turf translation.
 
-	// Some quick notes on the vars below: is_outside should be left set to OUTSIDE_AREA unless you 
+	// Some quick notes on the vars below: is_outside should be left set to OUTSIDE_AREA unless you
 	// EXPLICITLY NEED a turf to have a different outside state to its area (ie. you have used a
-	// roofing tile). By default, it will ask the area for the state to use, and will update on 
-	// area change. When dealing with weather, it will check the entire z-column for interruptions 
-	// that will prevent it from using its own state, so a floor above a level will generally 
+	// roofing tile). By default, it will ask the area for the state to use, and will update on
+	// area change. When dealing with weather, it will check the entire z-column for interruptions
+	// that will prevent it from using its own state, so a floor above a level will generally
 	// override both area is_outside, and turf is_outside. The only time the base value will be used
 	// by itself is if you are dealing with a non-multiz level, or the top level of a multiz chunk.
 
@@ -67,6 +67,7 @@
 	else
 		luminosity = 1
 
+	update_ambient_light_from_z()
 
 	if (opacity)
 		has_opaque_atom = TRUE
@@ -410,7 +411,7 @@
 	// Notes for future self when confused: is_open() on higher
 	// turfs must match effective is_outside value if the turf
 	// should get to use the is_outside value it wants to. If it
-	// doesn't line up, we invert the outside value (roof is not 
+	// doesn't line up, we invert the outside value (roof is not
 	// open but turf wants to be outside, invert to OUTSIDE_NO).
 
 	// Do we have a roof over our head? Should we care?
@@ -426,6 +427,10 @@
 		is_outside = new_outside
 		if(!skip_weather_update)
 			update_weather()
+		if(is_outside)
+			update_ambient_light_from_z()
+		else
+			clear_ambient_light()
 		return TRUE
 	return FALSE
 

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -122,7 +122,7 @@
 	// end of lighting stuff
 
 	// we check the var rather than the proc, because area outside values usually shouldn't be set on turfs
-	if(W.is_outside != old_outside) 
+	if(W.is_outside != old_outside)
 		W.set_outside(old_outside, skip_weather_update = TRUE)
 	W.update_weather(force_update_below = W.is_open() != old_is_open)
 

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -225,37 +225,3 @@
 			continue
 
 		corners[i] = new/datum/lighting_corner(src, LIGHTING_CORNER_DIAGONAL[i], i)
-
-/turf/proc/update_ambient_light_from_z()
-
-	// If we're not outside, we don't show ambient light.
-	if(!is_outside())
-		clear_ambient_light()
-		return FALSE
-
-	// If we're dynamically lit, we want ambient light regardless of neighbors.
-	. = TURF_IS_DYNAMICALLY_LIT_UNSAFE(src)
-	// If we're not, we want ambient light if one of our neighbors needs to show spillover from corners.
-	if(!.)
-		for(var/turf/T in RANGE_TURFS(src, 1))
-			// Fuck if I know how these turfs are located in an area that is not an area.
-			if(isloc(T.loc) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
-				. = TRUE
-				break
-
-	if(.)
-		// Grab what we need to set ambient light.
-		// Also fail out early if necessary.
-		// TODO: z-level data handlers should store this information in a cheaply accessible way.
-		var/obj/effect/overmap/visitable/sector/exoplanet/planet = global.overmap_sectors["[z]"]
-		if(istype(planet))
-			if(planet.lightlevel)
-				set_ambient_light(COLOR_WHITE, planet.lightlevel)
-				return TRUE
-		else
-			if(config.starlight)
-				set_ambient_light(SSskybox.background_color, config.starlight)
-				return TRUE
-
-	clear_ambient_light()
-	return FALSE

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -225,3 +225,37 @@
 			continue
 
 		corners[i] = new/datum/lighting_corner(src, LIGHTING_CORNER_DIAGONAL[i], i)
+
+/turf/proc/update_ambient_light_from_z()
+
+	// If we're not outside, we don't show ambient light.
+	if(!is_outside())
+		clear_ambient_light()
+		return FALSE
+
+	// If we're dynamically lit, we want ambient light regardless of neighbors.
+	. = TURF_IS_DYNAMICALLY_LIT_UNSAFE(src)
+	// If we're not, we want ambient light if one of our neighbors needs to show spillover from corners.
+	if(!.)
+		for(var/turf/T in RANGE_TURFS(src, 1))
+			// Fuck if I know how these turfs are located in an area that is not an area.
+			if(isloc(T.loc) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+				. = TRUE
+				break
+
+	if(.)
+		// Grab what we need to set ambient light.
+		// Also fail out early if necessary.
+		// TODO: z-level data handlers should store this information in a cheaply accessible way.
+		var/obj/effect/overmap/visitable/sector/exoplanet/planet = global.overmap_sectors["[z]"]
+		if(istype(planet))
+			if(planet.lightlevel)
+				set_ambient_light(COLOR_WHITE, planet.lightlevel)
+				return TRUE
+		else
+			if(config.starlight)
+				set_ambient_light(SSskybox.background_color, config.starlight)
+				return TRUE
+
+	clear_ambient_light()
+	return FALSE

--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -229,11 +229,14 @@
 	// This was formerly done in Initialize, but that caused problems with ChangeTurf. The initialize logic is now
 	// mapload-only, and so the exoplanet step (which uses ChangeTurf) has to be done here.
 	for(var/target_z in map_z)
-		for(var/turf/exterior/exterior_turf in block(
+		for(var/turf/exterior_turf in block(
 			locate(TRANSITIONEDGE, TRANSITIONEDGE, target_z),
 			locate(world.maxx - TRANSITIONEDGE, world.maxy - TRANSITIONEDGE, target_z)
 		))
-			exterior_turf.setup_environmental_lighting()
+			if(lightlevel)
+				exterior_turf.update_ambient_light_from_z()
+			else
+				exterior_turf.clear_ambient_light()
 			CHECK_TICK
 
 //Tries to generate num landmarks, but avoids repeats.
@@ -308,5 +311,4 @@
 	ambience = list('sound/effects/wind/wind_2_1.ogg','sound/effects/wind/wind_2_2.ogg','sound/effects/wind/wind_3_1.ogg','sound/effects/wind/wind_4_1.ogg','sound/effects/wind/wind_4_2.ogg','sound/effects/wind/wind_5_1.ogg')
 	always_unpowered = 1
 	area_flags = AREA_FLAG_IS_BACKGROUND | AREA_FLAG_EXTERNAL
-	show_starlight = TRUE
 	is_outside = OUTSIDE_YES

--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -226,19 +226,6 @@
 		//Otherwise the right side of the exoplanet can get stuck in a forever day.
 		daycycle = rand(10 MINUTES, 40 MINUTES)
 
-	// This was formerly done in Initialize, but that caused problems with ChangeTurf. The initialize logic is now
-	// mapload-only, and so the exoplanet step (which uses ChangeTurf) has to be done here.
-	for(var/target_z in map_z)
-		for(var/turf/exterior_turf in block(
-			locate(TRANSITIONEDGE, TRANSITIONEDGE, target_z),
-			locate(world.maxx - TRANSITIONEDGE, world.maxy - TRANSITIONEDGE, target_z)
-		))
-			if(lightlevel)
-				exterior_turf.update_ambient_light_from_z()
-			else
-				exterior_turf.clear_ambient_light()
-			CHECK_TICK
-
 //Tries to generate num landmarks, but avoids repeats.
 /obj/effect/overmap/visitable/sector/exoplanet/proc/generate_landing()
 	var/places = list()

--- a/nebula.dme
+++ b/nebula.dme
@@ -195,6 +195,7 @@
 #include "code\controllers\evacuation\~evac.dm"
 #include "code\controllers\subsystems\air.dm"
 #include "code\controllers\subsystems\alarm.dm"
+#include "code\controllers\subsystems\ambience.dm"
 #include "code\controllers\subsystems\ao.dm"
 #include "code\controllers\subsystems\atoms.dm"
 #include "code\controllers\subsystems\circuit_component.dm"


### PR DESCRIPTION
## Description of changes
Moves ambient light checking on `Initialize()` down to `/turf`.
Adds an ambient light update to `set_outside()`.
Adds a subsystem to queue and handle ambient lighting updates based on z-level.

This has some performance considerations for `Initialize()` due to the number of turfs, so if anyone has any suggestions for the following, I'm all ears:
- How to gate the proc call to avoid proc overhead.
- How to streamline z-level ambience to not require a list lookup/istype for exoplanets.

Testing on Exodus hasn't shown a variance in init time, but the ambient light procs do profile very highly for self CPU.

## Why and what will this PR improve
Currently non-space and non-exterior turfs don't handle any kind of ambient light (exoplanet or starlight). Building on an exoplanet or looking at the highest z-level of the tradeship results in black holes.

## Authorship
Myself.

## Changelog
:cl:
tweak: Ambient light will now apply to simulated turfs.
/:cl:
