### PR TITLE
October Downstream Sync - Glitch City RP

### DIFF
--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -775,7 +775,11 @@ var/global/list/json_cache = list()
 			if(islist(decoded)) // To prevent cache mutation.
 				return deepCopyList(decoded)
 			else if(decoded)
-				return decoded	
+				return decoded
 		catch(var/exception/e)
 			log_error("Exception during JSON decoding ([json_to_decode]): [e]")
 	return list()
+
+/// Is this a dense (all keys have non-null values) associative list with at least one entry?
+/proc/is_dense_assoc(var/list/L)
+	return length(L) > 0 && !isnull(L[L[1]])

--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -8,7 +8,7 @@
 	else if (isnull(minutes))
 		PRINT_STACK_TRACE("Null minutes value supplied to minutes_to_readable().")
 		return "BAD INPUT"
-	
+
 	var/hours = 0
 	var/days = 0
 	var/weeks = 0
@@ -104,6 +104,21 @@ var/global/round_start_time = 0
 	round_start_time = world.time
 	return 1
 
+/proc/ticks2readable(tick_time)
+	var/hours = round(tick_time / (1 HOUR))
+	var/minutes = round((tick_time % (1 HOUR)) / (1 MINUTE))
+	var/seconds = round((tick_time % (1 MINUTE)) / (1 SECOND))
+	var/out = list()
+	if(hours > 0)
+		out += "[hours] hour\s"
+	if(minutes > 0)
+		out += "[minutes] minute\s"
+	if(seconds > 0)
+		out += "[seconds] second\s"
+	if(length(out))
+		return english_list(out)
+	return null
+
 /proc/roundduration2text()
 	if(!round_start_time)
 		return "00:00"
@@ -134,7 +149,7 @@ var/global/rollovercheck_last_timeofday = 0
 	global.rollovercheck_last_timeofday = world.timeofday
 	return global.midnight_rollovers
 
-/// Increases delay as the server gets more overloaded 
+/// Increases delay as the server gets more overloaded
 /// as sleeps aren't cheap and sleeping only to wake up and sleep again is wasteful
 #define DELTA_CALC max(((max(TICK_USAGE, world.cpu) / 100) * max(Master.sleep_delta-1,1)), 1)
 

--- a/code/datums/observation/examine.dm
+++ b/code/datums/observation/examine.dm
@@ -1,0 +1,25 @@
+//	Observer Pattern Implementation: Atom Examined
+//		Registration type: /atom
+//
+//		Raised when: A mob examines an atom.
+//
+//		Arguments that the called proc should expect:
+//			/mob/examiner:  The mob that examined the atom.
+//			/atom/examined: The examined atom.
+
+/decl/observ/atom_examined
+	name = "Atom Examined"
+	expected_type = /atom
+
+//	Observer Pattern Implementation: Mob Examining
+//		Registration type: /mob
+//
+//		Raised when: A mob examines an atom.
+//
+//		Arguments that the called proc should expect:
+//			/atom/examined: The examined atom.
+//			/mob/examiner:  The mob that examined the atom.
+
+/decl/observ/mob_examining
+	name = "Mob Examining"
+	expected_type = /mob

--- a/code/datums/observation/ingested.dm
+++ b/code/datums/observation/ingested.dm
@@ -1,0 +1,16 @@
+//	Observer Pattern Implementation: Ingested
+//		Registration type: /mob/living
+//
+//		Raised when: A living mob ingests reagents.
+//
+//		Arguments that the called proc should expect:
+//			/mob/living/ingester:   The mob that has ingested something
+//			/datum/reagents/source: The reagent holder being ingested from.
+//			/datum/reagents/target: The reagent holder the ingested reagents move into.
+//			amount:                 The number of reagents ingested from the reagent source.
+//			multiplier:             The multiplier determining the ratio of reagents removed from the source to reagents added to the target.
+//			copy:                   If true, reagents are copied from the source rather than transferred.
+
+/decl/observ/ingested
+	name = "Ingested"
+	expected_type = /mob/living

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -146,6 +146,7 @@
 
 	to_chat(user, "[html_icon(src)] That's [f_name] [suffix]")
 	to_chat(user, desc)
+	events_repository.raise_event(/decl/observ/atom_examined, src, user, distance)
 	return TRUE
 
 // called by mobs when e.g. having the atom as their machine, loc (AKA mob being inside the atom) or buckled var set.

--- a/code/modules/mob/living/carbon/taste.dm
+++ b/code/modules/mob/living/carbon/taste.dm
@@ -1,4 +1,5 @@
 /mob/living/proc/ingest(var/datum/reagents/from, var/datum/reagents/target, var/amount = 1, var/multiplier = 1, var/copy = 0)
+	events_repository.raise_event(/decl/observ/ingested, src, from, target, amount, multiplier, copy)
 	. = from.trans_to_holder(target,amount,multiplier,copy)
 
 /mob/living/carbon/ingest(var/datum/reagents/from, var/datum/reagents/target, var/amount = 1, var/multiplier = 1, var/copy = 0) //we kind of 'sneak' a proc in here for ingesting stuff so we can play with it.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -351,6 +351,8 @@
 		if(source_turf && source_turf.z == target_turf?.z)
 			distance = get_dist(source_turf, target_turf)
 
+	events_repository.raise_event(/decl/observ/mob_examining, src, A)
+
 	if(!A.examine(src, distance))
 		PRINT_STACK_TRACE("Improper /examine() override: [log_info_line(A)]")
 

--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -125,7 +125,8 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 			LAZYADD(extra_text, GE.glass_desc)
 		else if(istype(extra, /obj/item/chems/food/fruit_slice))
 			LAZYADD(extra_text, "There is \a [extra] on the rim.")
-	to_chat(user, SPAN_NOTICE(jointext(extra_text," ")))
+	if(length(extra_text))
+		to_chat(user, SPAN_NOTICE(jointext(extra_text," ")))
 
 
 /obj/item/chems/drinks/glass2/proc/get_filling_overlay(amount, overlay)

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -38,6 +38,12 @@
 /obj/item/chems/food/standard_pour_into(mob/user, atom/target)
 	return FALSE
 
+/obj/item/chems/food/update_container_name()
+	return FALSE
+
+/obj/item/chems/food/update_container_desc()
+	return FALSE
+
 /obj/item/chems/food/Initialize()
 	.=..()
 	amount_per_transfer_from_this = bitesize

--- a/code/modules/reagents/reagent_containers/food/lunch.dm
+++ b/code/modules/reagents/reagent_containers/food/lunch.dm
@@ -60,7 +60,12 @@ var/global/list/lunchables_drink_reagents_ = list(
 											/decl/material/liquid/drink/dry_ramen,
 											/decl/material/liquid/drink/hell_ramen,
 											/decl/material/liquid/drink/hot_ramen,
-											/decl/material/liquid/drink/mutagencola
+											/decl/material/liquid/drink/mutagencola,
+											/decl/material/liquid/drink/syrup,
+											/decl/material/liquid/drink/syrup/mint,
+											/decl/material/liquid/drink/syrup/chocolate,
+											/decl/material/liquid/drink/syrup/caramel,
+											/decl/material/liquid/drink/syrup/vanilla
 										)
 
 // This default list is a bit different, it contains items we don't want

--- a/nebula.dme
+++ b/nebula.dme
@@ -406,6 +406,7 @@
 #include "code\datums\observation\examine.dm"
 #include "code\datums\observation\exited.dm"
 #include "code\datums\observation\helpers.dm"
+#include "code\datums\observation\ingested.dm"
 #include "code\datums\observation\life.dm"
 #include "code\datums\observation\logged_in.dm"
 #include "code\datums\observation\logged_out.dm"

--- a/nebula.dme
+++ b/nebula.dme
@@ -403,6 +403,7 @@
 #include "code\datums\observation\dismembered.dm"
 #include "code\datums\observation\entered.dm"
 #include "code\datums\observation\equipped.dm"
+#include "code\datums\observation\examine.dm"
 #include "code\datums\observation\exited.dm"
 #include "code\datums\observation\helpers.dm"
 #include "code\datums\observation\life.dm"


### PR DESCRIPTION
## Description of changes
Contains a number of fixes and helper/observation additions made downstream that I'm too lazy to bundle into separate PRs.
Spoooooky PR! Will be undrafted on Halloween, probably.

## Why and what will this PR improve
- Adds an `is_dense_assoc` helper for checking if something is an associative list with no null values + at least one value. This is mainly useful for things like checking if a list has already been converted to a typecache, for example.
- Adds a helper for outputting human-readable durations, like "10 hours, 3 minutes, and 59 seconds".
- Adds four observations:
    - 'Atom Examined', for when the registered atom is examined by a mob.
    - 'Mob Examining', for when the registered mob examines an atom.
    - 'Entering', a counterpart to the Entered observation but fired on the movable doing the entering, instead of the entered atom.
    - 'Ingested', for when the registered living mob ingests reagents.
- Adds flavored syrups to the flask reagent exception list.
- Fixes a runtime when `glass2` drinking glasses are examined.
- Fixes fruits and other foods losing name changes made after Initialize, i.e. "apple" becoming "fruit".

## Authorship
Me.