### PR TITLE
Fixing busted path on AI start landmark.

### DIFF
--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -27,10 +27,10 @@
 	//Handle job slot/tater cleanup.
 	clear_client()
 
-/obj/effect/landmark/start/ai
+/obj/abstract/landmark/start/ai
 	name = "AI"
 
-/obj/effect/landmark/start/ai/Initialize()
+/obj/abstract/landmark/start/ai/Initialize()
 	. = ..()
 	//The job subsystem does its thing before we can, so we've got to handle this
 	empty_playable_ai_cores += new /obj/structure/aicore/deactivated(get_turf(loc))


### PR DESCRIPTION
Was missed in the /abstract changes.