### PR TITLE
Added flash and practice ammo for additional calibers.

### DIFF
--- a/code/modules/fabrication/designs/general/designs_arms_ammo.dm
+++ b/code/modules/fabrication/designs/general/designs_arms_ammo.dm
@@ -48,6 +48,14 @@
 	name = "ammunition (holdout)"
 	path = /obj/item/ammo_magazine/pistol/small
 
+/datum/fabricator_recipe/arms_ammo/hidden/magazine_practice
+	name = "ammunition (pistol, practice)"
+	path = /obj/item/ammo_magazine/pistol/practice
+
+/datum/fabricator_recipe/arms_ammo/hidden/magazine_flass
+	name = "ammunition (pistol, flash)"
+	path = /obj/item/ammo_magazine/pistol/flash
+
 /datum/fabricator_recipe/arms_ammo/hidden/magazine_smg_topmounted
 	name = "ammunition (SMG, top mounted)"
 	path = /obj/item/ammo_magazine/smg

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -140,6 +140,14 @@
 	labels = list("rubber")
 	ammo_type = /obj/item/ammo_casing/pistol/rubber
 
+/obj/item/ammo_magazine/pistol/practice
+	labels = list("practice")
+	ammo_type = /obj/item/ammo_casing/pistol/practice
+
+/obj/item/ammo_magazine/pistol/flash
+	labels = list("flash")
+	ammo_type = /obj/item/ammo_casing/pistol/flash
+
 /obj/item/ammo_magazine/pistol/small
 	icon_state = "holdout"
 	material = /decl/material/solid/metal/steel
@@ -149,6 +157,14 @@
 
 /obj/item/ammo_magazine/pistol/small/empty
 	initial_ammo = 0
+
+/obj/item/ammo_magazine/pistol/small/rubber
+	labels = list("rubber")
+	ammo_type = /obj/item/ammo_casing/pistol/small/rubber
+
+/obj/item/ammo_magazine/pistol/small/practice
+	labels = list("practice")
+	ammo_type = /obj/item/ammo_casing/pistol/small/practice
 
 /obj/item/ammo_magazine/box/smallpistol
 	name = "ammunition box (pistol, small)"

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -16,6 +16,11 @@
 	bullet_color = COLOR_OFF_WHITE
 	marking_color = COLOR_SUN
 
+/obj/item/ammo_casing/pistol/flash
+	desc = "A bullet casing loaded with a chemical charge."
+	projectile_type = /obj/item/projectile/energy/flash
+	marking_color = COLOR_ORANGE
+
 /obj/item/ammo_casing/pistol/emp
 	name = "haywire round"
 	desc = "A pistol bullet casing fitted with a single-use ion pulse generator."
@@ -31,7 +36,7 @@
 	icon = 'icons/obj/ammo/casings/small_pistol.dmi'
 	caliber = CALIBER_PISTOL_SMALL
 	projectile_type = /obj/item/projectile/bullet/pistol/holdout
-	
+
 /obj/item/ammo_casing/pistol/small/rubber
 	desc = "A small pistol rubber bullet casing."
 	projectile_type = /obj/item/projectile/bullet/pistol/rubber/holdout

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -1,4 +1,3 @@
-
 /obj/item/gun/projectile/pistol
 	name = "pistol"
 	icon = 'icons/obj/guns/pistol.dmi'
@@ -9,6 +8,9 @@
 	accuracy_power = 7
 	safety_icon = "safety"
 	ammo_indicator = TRUE
+
+/obj/item/gun/projectile/pistol/rubber
+	magazine_type = /obj/item/ammo_magazine/pistol/rubber
 
 /obj/item/gun/projectile/pistol/update_base_icon()
 	var/base_state = get_world_inventory_state()


### PR DESCRIPTION
## Description of changes
- Adds practice and flash pistol round crafting and a flash pistol preset.

## Why and what will this PR improve
Mapping and crafting variety.

## Authorship
Myself.

## Changelog
:cl:
add: Flash and practice pistol ammo is now craftable.
/:cl: