### PR TITLE
Reworking mech wrecks to allow for mapped wrecks.

### DIFF
--- a/code/modules/mechs/mech_life.dm
+++ b/code/modules/mechs/mech_life.dm
@@ -34,7 +34,7 @@
 			var/obj/item/mech_equipment/M = hardpoints[hardpoint]
 			if(istype(M) && M.active && M.passive_power_use)
 				M.deactivate()
-		
+
 	updatehealth()
 	if(health <= 0 && stat != DEAD)
 		death()
@@ -97,23 +97,8 @@
 		hatch_locked = 0 // So they can get out.
 		for(var/pilot in pilots)
 			eject(pilot, silent=1)
-
-	// Salvage moves into the wreck unless we're exploding violently.
-	var/obj/wreck = new wreckage_path(get_turf(src), src, gibbed)
-	wreck.name = "wreckage of \the [name]"
-	if(!gibbed)
-		if(arms.loc != src)
-			arms = null
-		if(legs.loc != src)
-			legs = null
-		if(head.loc != src)
-			head = null
-		if(body.loc != src)
-			body = null
-
-	// Handle the rest of things.
+	new wreckage_path(get_turf(src), src, gibbed)
 	..(gibbed, (gibbed ? "explodes!" : "grinds to a halt before collapsing!"))
-	if(!gibbed) qdel(src)
 
 /mob/living/exosuit/gib(anim="gibbed-m",do_gibs)
 	death(1)

--- a/code/modules/mechs/premade/combat.dm
+++ b/code/modules/mechs/premade/combat.dm
@@ -4,17 +4,13 @@
 
 /mob/living/exosuit/premade/combat/Initialize()
 	if(!arms)
-		arms = new /obj/item/mech_component/manipulators/combat(src)
-		arms.color = COLOR_DARK_GUNMETAL
+		arms = new /obj/item/mech_component/manipulators/combat/painted(src)
 	if(!legs)
-		legs = new /obj/item/mech_component/propulsion/combat(src)
-		legs.color = COLOR_DARK_GUNMETAL
+		legs = new /obj/item/mech_component/propulsion/combat/painted(src)
 	if(!head)
-		head = new /obj/item/mech_component/sensors/combat(src)
-		head.color = COLOR_DARK_GUNMETAL
+		head = new /obj/item/mech_component/sensors/combat/painted(src)
 	if(!body)
-		body = new /obj/item/mech_component/chassis/combat(src)
-		body.color = COLOR_DARK_GUNMETAL
+		body = new /obj/item/mech_component/chassis/combat/painted(src)
 
 	. = ..()
 
@@ -44,6 +40,9 @@
 	action_delay = 10
 	power_use = 50
 
+/obj/item/mech_component/manipulators/combat/painted
+	color = COLOR_DARK_GUNMETAL
+
 /obj/item/mech_component/propulsion/combat
 	name = "combat legs"
 	exosuit_desc_string = "sleek hydraulic legs"
@@ -51,6 +50,9 @@
 	move_delay = 3
 	turn_delay = 3
 	power_use = 20
+
+/obj/item/mech_component/propulsion/combat/painted
+	color = COLOR_DARK_GUNMETAL
 
 /obj/item/mech_component/sensors/combat
 	name = "combat sensors"
@@ -61,6 +63,9 @@
 	see_invisible = SEE_INVISIBLE_NOLIGHTING
 	power_use = 200
 	material = /decl/material/solid/metal/steel
+
+/obj/item/mech_component/sensors/combat/painted
+	color = COLOR_DARK_GUNMETAL
 
 /obj/item/mech_component/sensors/combat/prebuild()
 	..()
@@ -76,6 +81,9 @@
 	power_use = 40
 	material = /decl/material/solid/metal/steel
 
+/obj/item/mech_component/chassis/combat/painted
+	color = COLOR_DARK_GUNMETAL
+
 /obj/item/mech_component/chassis/combat/prebuild()
 	. = ..()
 	m_armour = new /obj/item/robot_parts/robot_component/armour/exosuit/combat(src)
@@ -89,5 +97,18 @@
 			"[WEST]"  = list("x" = 12, "y" = 8)
 		)
 	)
-	
+
 	. = ..()
+
+/obj/structure/mech_wreckage/military
+	name = "military exosuit wreckage"
+	loot_pool = list(
+		/obj/item/mech_equipment/mounted_system/taser =        80,
+		/obj/item/mech_equipment/mounted_system/taser/ion =    80,
+		/obj/item/mech_equipment/flash =                       50,
+		/obj/item/mech_equipment/light =                       50,
+		/obj/item/mech_component/manipulators/combat/painted = 40,
+		/obj/item/mech_component/propulsion/combat/painted =   40,
+		/obj/item/mech_component/sensors/combat/painted =      40,
+		/obj/item/mech_component/chassis/combat/painted =      40
+	)

--- a/code/modules/mechs/premade/exploration.dm
+++ b/code/modules/mechs/premade/exploration.dm
@@ -2,16 +2,22 @@
 	name = "exploration mech"
 	desc = "It looks a bit charred."
 
+/obj/item/mech_component/manipulators/powerloader/exploration
+	color = COLOR_PURPLE
+
+/obj/item/mech_component/chassis/pod/exploration
+	color = COLOR_GUNMETAL
+
+/obj/item/mech_component/propulsion/tracks/exploration
+	color = COLOR_GUNMETAL
+
 /mob/living/exosuit/premade/light/exploration/Initialize()
 	if(!body)
-		body = new /obj/item/mech_component/chassis/pod(src)
-		body.color = COLOR_GUNMETAL
+		body = new /obj/item/mech_component/chassis/pod/exploration(src)
 	if(!legs)
-		legs = new /obj/item/mech_component/propulsion/tracks(src)
-		legs.color = COLOR_GUNMETAL
+		legs = new /obj/item/mech_component/propulsion/tracks/exploration(src)
 	if(!arms)
-		arms = new /obj/item/mech_component/manipulators/powerloader(src)
-		arms.color = COLOR_PURPLE
+		arms = new /obj/item/mech_component/manipulators/powerloader/exploration(src)
 
 	. = ..()
 
@@ -28,3 +34,15 @@
 	install_system(new /obj/item/mech_equipment/light(src), HARDPOINT_HEAD)
 	install_system(new /obj/item/mech_equipment/clamp(src), HARDPOINT_RIGHT_HAND)
 	install_system(new /obj/item/mech_equipment/mounted_system/taser/plasma(src), HARDPOINT_LEFT_HAND)
+
+/obj/structure/mech_wreckage/exploration
+	name = "exploration exosuit wreckage"
+	loot_pool = list(
+		/obj/item/mech_component/manipulators/powerloader/exploration = 40,
+		/obj/item/mech_component/chassis/pod/exploration =              40,
+		/obj/item/mech_component/propulsion/tracks/exploration =        40,
+		/obj/item/mech_component/sensors/light/painted =                40,
+		/obj/item/mech_equipment/light =                                50,
+		/obj/item/mech_equipment/clamp =                                80,
+		/obj/item/mech_equipment/mounted_system/taser/plasma =          80
+	)

--- a/code/modules/mechs/premade/heavy.dm
+++ b/code/modules/mechs/premade/heavy.dm
@@ -2,20 +2,27 @@
 	name = "Heavy exosuit"
 	desc = "A heavily armored combat exosuit."
 
+/obj/item/mech_component/manipulators/heavy/painted
+	color = COLOR_TITANIUM
+
+/obj/item/mech_component/propulsion/heavy/painted
+	color = COLOR_TITANIUM
+
+/obj/item/mech_component/sensors/heavy/painted
+	color = COLOR_TITANIUM
+
+/obj/item/mech_component/chassis/heavy/painted
+	color = COLOR_TITANIUM
+
 /mob/living/exosuit/premade/heavy/Initialize()
 	if(!arms)
-		arms = new /obj/item/mech_component/manipulators/heavy(src)
-		arms.color = COLOR_TITANIUM
+		arms = new /obj/item/mech_component/manipulators/heavy/painted(src)
 	if(!legs)
-		legs = new /obj/item/mech_component/propulsion/heavy(src)
-		legs.color = COLOR_TITANIUM
+		legs = new /obj/item/mech_component/propulsion/heavy/painted(src)
 	if(!head)
-		head = new /obj/item/mech_component/sensors/heavy(src)
-		head.color = COLOR_TITANIUM
+		head = new /obj/item/mech_component/sensors/heavy/painted(src)
 	if(!body)
-		body = new /obj/item/mech_component/chassis/heavy(src)
-		body.color = COLOR_TITANIUM
-
+		body = new /obj/item/mech_component/chassis/heavy/painted(src)
 	. = ..()
 
 /mob/living/exosuit/premade/heavy/spawn_mech_equipment()
@@ -85,7 +92,7 @@
 	)
 
 	. = ..()
-		
+
 /obj/item/mech_component/chassis/heavy/prebuild()
 	. = ..()
 	m_armour = new /obj/item/robot_parts/robot_component/armour/exosuit/combat(src)
@@ -105,3 +112,15 @@
 	install_system(new /obj/item/mech_equipment/mounted_system/taser(src), HARDPOINT_LEFT_HAND)
 	install_system(new /obj/item/mech_equipment/mounted_system/taser/laser(src), HARDPOINT_RIGHT_HAND)
 	install_system(new /obj/item/mech_equipment/shields(src), HARDPOINT_BACK)
+
+/obj/structure/mech_wreckage/heavy
+	name = "heavy exosuit wreckage"
+	loot_pool = list(
+		/obj/item/mech_equipment/mounted_system/taser =       80,
+		/obj/item/mech_equipment/mounted_system/taser/laser = 80,
+		/obj/item/mech_equipment/shields =                    80,
+		/obj/item/mech_component/manipulators/heavy/painted = 40,
+		/obj/item/mech_component/propulsion/heavy/painted =   40,
+		/obj/item/mech_component/sensors/heavy/painted =      40,
+		/obj/item/mech_component/chassis/heavy/painted =      40
+	)

--- a/code/modules/mechs/premade/light.dm
+++ b/code/modules/mechs/premade/light.dm
@@ -2,19 +2,27 @@
 	name = "light exosuit"
 	desc = "A light and agile exosuit."
 
+/obj/item/mech_component/manipulators/light/painted
+	color = COLOR_OFF_WHITE
+
+/obj/item/mech_component/propulsion/light/painted
+	color = COLOR_OFF_WHITE
+
+/obj/item/mech_component/sensors/light/painted
+	color = COLOR_OFF_WHITE
+
+/obj/item/mech_component/chassis/light/painted
+	color = COLOR_OFF_WHITE
+
 /mob/living/exosuit/premade/light/Initialize()
 	if(!arms)
-		arms = new /obj/item/mech_component/manipulators/light(src)
-		arms.color = COLOR_OFF_WHITE
+		arms = new /obj/item/mech_component/manipulators/light/painted(src)
 	if(!legs)
-		legs = new /obj/item/mech_component/propulsion/light(src)
-		legs.color = COLOR_OFF_WHITE
+		legs = new /obj/item/mech_component/propulsion/light/painted(src)
 	if(!head)
-		head = new /obj/item/mech_component/sensors/light(src)
-		head.color = COLOR_OFF_WHITE
+		head = new /obj/item/mech_component/sensors/light/painted(src)
 	if(!body)
-		body = new /obj/item/mech_component/chassis/light(src)
-		body.color = COLOR_OFF_WHITE
+		body = new /obj/item/mech_component/chassis/light/painted(src)
 
 	. = ..()
 

--- a/code/modules/mechs/premade/powerloader.dm
+++ b/code/modules/mechs/premade/powerloader.dm
@@ -2,20 +2,27 @@
 	name = "power loader"
 	desc = "An ancient, but well-liked cargo handling exosuit."
 
-/mob/living/exosuit/premade/powerloader/Initialize()
-	if(!arms) 
-		arms = new /obj/item/mech_component/manipulators/powerloader(src)
-		arms.color = "#ffbc37"
-	if(!legs) 
-		legs = new /obj/item/mech_component/propulsion/powerloader(src)
-		legs.color = "#ffbc37"
-	if(!head) 
-		head = new /obj/item/mech_component/sensors/powerloader(src)
-		head.color = "#ffbc37"
-	if(!body) 
-		body = new /obj/item/mech_component/chassis/powerloader(src)
-		body.color = "#ffdc37"
+/obj/item/mech_component/manipulators/powerloader/painted
+	color = "#ffbc37"
 
+/obj/item/mech_component/propulsion/powerloader/painted
+	color = "#ffbc37"
+
+/obj/item/mech_component/sensors/powerloader/painted
+	color = "#ffbc37"
+
+/obj/item/mech_component/chassis/powerloader/painted
+	color = "#ffdc37"
+
+/mob/living/exosuit/premade/powerloader/Initialize()
+	if(!arms)
+		arms = new /obj/item/mech_component/manipulators/powerloader/painted(src)
+	if(!legs)
+		legs = new /obj/item/mech_component/propulsion/powerloader/painted(src)
+	if(!head)
+		head = new /obj/item/mech_component/sensors/powerloader/painted(src)
+	if(!body)
+		body = new /obj/item/mech_component/chassis/powerloader/painted(src)
 	. = ..()
 
 /mob/living/exosuit/premade/powerloader/spawn_mech_equipment()
@@ -86,7 +93,7 @@
 
 /mob/living/exosuit/premade/powerloader/mechete/Initialize()
 	. = ..()
-	
+
 	if (arms)
 		arms.color = "#6c8aaf"
 	if (legs)
@@ -117,16 +124,16 @@
 
 /mob/living/exosuit/premade/firefighter/Initialize()
 	. = ..()
-	if(!arms) 
+	if(!arms)
 		arms = new /obj/item/mech_component/manipulators/powerloader(src)
 		arms.color = "#385b3c"
-	if(!legs) 
+	if(!legs)
 		legs = new /obj/item/mech_component/propulsion/powerloader(src)
 		legs.color = "#385b3c"
-	if(!head) 
+	if(!head)
 		head = new /obj/item/mech_component/sensors/powerloader(src)
 		head.color = "#385b3c"
-	if(!body) 
+	if(!body)
 		body = new /obj/item/mech_component/chassis/heavy(src)
 		body.color = "#385b3c"
 
@@ -164,3 +171,14 @@
 	install_system(new /obj/item/mech_equipment/light(src), HARDPOINT_HEAD)
 	install_system(new /obj/item/mech_equipment/clamp(src), HARDPOINT_LEFT_HAND)
 	install_system(new /obj/item/mech_equipment/clamp(src), HARDPOINT_RIGHT_HAND)
+
+/obj/structure/mech_wreckage/powerloader
+	name = "powerloader wrecakge"
+	loot_pool = list(
+		/obj/item/mech_component/manipulators/powerloader/painted = 40,
+		/obj/item/mech_component/propulsion/powerloader/painted =   40,
+		/obj/item/mech_component/sensors/powerloader/painted =      40,
+		/obj/item/mech_component/chassis/powerloader/painted =      40,
+		/obj/item/mech_equipment/drill/steel =                      80,
+		/obj/item/mech_equipment/clamp =                            80
+	)

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -2437,7 +2437,7 @@
 /area/map_template/merc_spawn)
 "Ko" = (
 /obj/machinery/mech_recharger,
-/obj/structure/mech_wreckage,
+/obj/structure/mech_wreckage/military,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_spawn)
 "Kz" = (


### PR DESCRIPTION
## Description of changes
Cleaned up some mech wreckage stuff, added loot list handling for mapped subtypes.

## Why and what will this PR improve
Wrecks can be overridden/mapped more freely.

## Authorship
Myself.

## Changelog
Nothing player-facing.