### PR TITLE
Reworks handle_message_mode

### DIFF
--- a/code/datums/extensions/radio_provider.dm
+++ b/code/datums/extensions/radio_provider.dm
@@ -25,5 +25,13 @@
 	if(istype(radio_provider))
 		return radio_provider.GetRadios(message_mode)
 
-/atom/movable/proc/GetRadio(message_mode)
+/*
+// Example implementation if extension is desired.
+/atom/movable/Initialize()
+	. = ..()
+	var/datum/extension/radio_provider/radio = get_or_create_extension(src, /datum/extension/radio_provider)
+	radio.register_radio(some_radio)
+
+/atom/movable/get_radio(message_mode)
 	return LAZYACCESS(GetRadios(message_mode), 1)
+*/

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -494,6 +494,13 @@
 /atom/proc/get_cell()
 	return
 
+// This proc will retrieve any radios associated with this atom,
+// for use in handle_message_mode or other radio-based logic.
+// The message_mode argument is used to determine what subset of
+// radios are relevant to the current call (ie. intercoms or ear radios)
+/atom/proc/get_radio(var/message_mode)
+	return
+
 /atom/proc/building_cost()
 	. = list()
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -130,7 +130,7 @@
 
 /obj/machinery/alarm/Destroy()
 	reset_area(alarm_area, null)
-	unregister_radio(src, frequency)
+	unregister_radio_to_controller(src, frequency)
 	return ..()
 
 /obj/machinery/alarm/Initialize(mapload, var/dir)

--- a/code/game/machinery/status_light.dm
+++ b/code/game/machinery/status_light.dm
@@ -13,7 +13,7 @@
 /obj/machinery/status_light/Initialize()
 	. = ..()
 	update_icon()
-	radio_connection = register_radio(src, frequency, frequency, RADIO_ATMOSIA)
+	radio_connection = register_radio_to_controller(src, frequency, frequency, RADIO_ATMOSIA)
 
 
 /obj/machinery/status_light/on_update_icon()

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -48,13 +48,12 @@
 	to_chat(user, "The following channels are available:")
 	to_chat(user, radio_desc)
 
-/obj/item/radio/headset/handle_message_mode(mob/living/M, message, channel)
-	if (channel == "special")
+/obj/item/radio/headset/get_connection_from_message_mode(mob/living/M, message, message_mode)
+	if (message_mode == "special")
 		if (translate_binary)
 			var/decl/language/binary = GET_DECL(/decl/language/binary)
 			binary.broadcast(M, message)
 		return null
-
 	return ..()
 
 /obj/item/radio/headset/receive_range(freq, level, aiOverride = 0)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -42,6 +42,9 @@
 
 	var/intercom_handling = FALSE
 
+/obj/item/radio/get_radio(var/message_mode)
+	return src
+
 /obj/item/radio/proc/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)
 	frequency = new_frequency
@@ -248,7 +251,7 @@
 	qdel(A)
 
 // Interprets the message mode when talking into a radio, possibly returning a connection datum
-/obj/item/radio/proc/handle_message_mode(mob/living/M, message, message_mode)
+/obj/item/radio/proc/get_connection_from_message_mode(mob/living/M, message, message_mode)
 	// If a channel isn't specified, send to common.
 	if(!message_mode || message_mode == "headset")
 		return radio_connection
@@ -317,7 +320,7 @@
 	*/
 
 	//#### Grab the connection datum ####//
-	var/datum/radio_frequency/connection = handle_message_mode(M, message, channel)
+	var/datum/radio_frequency/connection = get_connection_from_message_mode(M, message, channel)
 	if (!istype(connection))
 		return 0
 

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -114,46 +114,10 @@
 	return ..(message_data)
 
 /mob/living/carbon/human/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
-	var/use_mode = null
-	switch(message_mode)
-
-		if("intercom")
-			if(!restrained())
-				for(var/obj/item/radio/I in view(1))
-					if(I.intercom_handling)
-						used_radios += I
-
-		if("right ear", "left ear")
-			var/use_right = message_mode == "right ear"
-			var/obj/item/radio/R = get_equipped_item(use_right ? slot_r_ear_str : slot_l_ear_str)
-			if(!istype(R))
-				R = null
-				var/datum/inventory_slot/inv_slot = LAZYACCESS(held_item_slots, (use_right ? BP_R_HAND : BP_L_HAND))
-				if(istype(inv_slot?.holding, /obj/item/radio))
-					R = inv_slot.holding
-			if(R)
-				used_radios += R
-
-		if("whisper") //It's going to get sanitized again immediately, so decode.
-			whisper_say(html_decode(message), speaking, alt_name)
-			return 1
-
-		else
-			// Headsets are default.
-			if(message_mode)
-				var/obj/item/radio/R
-				for(var/slot in global.ear_slots)
-					R = get_equipped_item(slot)
-					if(istype(R))
-						break
-				if(!istype(R))
-					R = GetRadio()
-				if(istype(R))
-					used_radios += R
-
-	for(var/obj/item/radio in used_radios)
-		radio.add_fingerprint(src)
-		radio.talk_into(src,message,use_mode,verb,speaking)
+	if(message_mode == "whisper") //It's going to get sanitized again immediately, so decode.
+		whisper_say(html_decode(message), speaking, alt_name)
+		return TRUE
+	return ..()
 
 /mob/living/carbon/human/handle_speech_sound()
 	if(species.speech_sounds && prob(species.speech_chance))

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -5,33 +5,33 @@
 	log_say("[key_name(src)] : [message]")
 
 /mob/living/silicon/robot/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
-	..()
 	if(message_mode)
 		if(!is_component_functioning("radio"))
-			to_chat(src, "<span class='warning'>Your radio isn't functional at this time.</span>")
-			return 0
+			to_chat(src, SPAN_WARNING("Your radio isn't functional at this time."))
+			return FALSE
 		if(message_mode == "general")
 			message_mode = null
-		return silicon_radio.talk_into(src,message,message_mode,verb,speaking)
+		return silicon_radio.talk_into(src, message, message_mode, verb, speaking)
+	return ..()
 
 /mob/living/silicon/ai/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
-	..()
-	if(message_mode == "department")
-		return holopad_talk(message, verb, speaking)
-	else if(message_mode)
+	if(message_mode)
+		if(message_mode == "department")
+			return holopad_talk(message, verb, speaking)
 		if (ai_radio.disabledAi || !has_power() || stat)
 			to_chat(src, "<span class='danger'>System Error - Transceiver Disabled.</span>")
-			return 0
+			return FALSE
 		if(message_mode == "general")
 			message_mode = null
 		return ai_radio.talk_into(src,message,message_mode,verb,speaking)
+	return ..()
 
 /mob/living/silicon/pai/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
-	..()
 	if(message_mode)
 		if(message_mode == "general")
 			message_mode = null
 		return silicon_radio.talk_into(src,message,message_mode,verb,speaking)
+	return ..()
 
 /mob/living/silicon/say_quote(var/text)
 	var/ending = copytext(text, length(text))

--- a/code/procs/radio.dm
+++ b/code/procs/radio.dm
@@ -1,10 +1,10 @@
-/proc/register_radio(source, old_frequency, new_frequency, radio_filter)
+/proc/register_radio_to_controller(source, old_frequency, new_frequency, radio_filter)
 	if(old_frequency)
 		radio_controller.remove_object(source, old_frequency)
 	if(new_frequency)
 		return radio_controller.add_object(source, new_frequency, radio_filter)
 
-/proc/unregister_radio(source, frequency)
+/proc/unregister_radio_to_controller(source, frequency)
 	if(radio_controller)
 		radio_controller.remove_object(source, frequency)
 


### PR DESCRIPTION
## Description of changes
- Moves the main body of `handle_message_mode()` down to `/mob/living` other than `whisper_say()`.
- Renames the radio version of the proc to `get_connection_from_message_mode()` for clarity/searchability.
- Migrates `GetRadio()` to `/atom/proc/get_radio()` next to `get_cell()`, overrides it on radios to return the radio and reworks `handle_message_mode` to be consistent in how it's called.

## Why and what will this PR improve
Fixes an issue Andrew identified with use_mode/message_mode, fixes unintended clobbering of the GetRadio() changes to handle_message_mode, integrates `get_radio()` in a way that will make the extension more or less drag and drop downstream if desired (such as on Faz-World).

## Authorship
@Andrew-Fall for spotting the use_mode issue.

## Changelog
Nothing player-facing.