### PR TITLE
Paperwork clone proc

### DIFF
--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -751,7 +751,7 @@ proc/dd_sortedObjectList(list/incoming)
 			.[i] = .(.[i])
 
 ///Same as deepCopyList but actually Clone() datums, and sub-lists. Will leave atom refs alone.
-/proc/listdeeperCopy(list/L)
+/proc/listDeeperCopy(list/L)
 	if(isatom(L))
 		return L //Atom refs returns as-is
 	if(istype(L, /datum))
@@ -762,8 +762,9 @@ proc/dd_sortedObjectList(list/incoming)
 		return L
 	. = L.Copy()
 	for(var/i = 1 to length(L))
-		if(islist(.[i]))
-			.[i] = listdeeperCopy(.[i])
+		var/I = .[i]
+		if(islist(I) || istype(I, /datum))
+			.[i] = listDeeperCopy(I)
 
 #define IS_VALID_INDEX(list, index) (list.len && index > 0 && index <= list.len)
 

--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -750,6 +750,21 @@ proc/dd_sortedObjectList(list/incoming)
 		if(islist(.[i]))
 			.[i] = .(.[i])
 
+///Same as deepCopyList but actually Clone() datums, and sub-lists. Will leave atom refs alone.
+/proc/listdeeperCopy(list/L)
+	if(isatom(L))
+		return L //Atom refs returns as-is
+	if(istype(L, /datum))
+		var/datum/D = L
+		return D.Clone()
+	//Anything else that's not a list just return the ref
+	if(!islist(L))
+		return L
+	. = L.Copy()
+	for(var/i = 1 to length(L))
+		if(islist(.[i]))
+			.[i] = listdeeperCopy(.[i])
+
 #define IS_VALID_INDEX(list, index) (list.len && index > 0 && index <= list.len)
 
 // Returns the first key where T fulfills ispath

--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -750,10 +750,13 @@ proc/dd_sortedObjectList(list/incoming)
 		if(islist(.[i]))
 			.[i] = .(.[i])
 
-///Same as deepCopyList but actually Clone() datums, and sub-lists. Will leave atom refs alone.
-/proc/listDeeperCopy(list/L)
-	if(isatom(L))
-		return L //Atom refs returns as-is, since we do cannot own them
+/**
+ * Deep copy/clone everything in the list, or reference things that cannot be cloned. Use with caution.
+ * atom_refs_only: If true, the proc will only reference /atom subtypes, and will not clone them.
+ */
+/proc/listDeepClone(var/list/L, var/atom_refs_only = FALSE)
+	if(atom_refs_only && isatom(L))
+		return L
 	if(istype(L, /datum))
 		var/datum/D = L
 		return D.CanClone()? D.Clone() : D //If the datum can be cloned, clone it, or just reference it otherwise
@@ -765,7 +768,7 @@ proc/dd_sortedObjectList(list/incoming)
 	for(var/i = 1 to length(L))
 		var/I = .[i]
 		if(islist(I) || istype(I, /datum))
-			.[i] = listDeeperCopy(I)
+			.[i] = listDeepClone(I)
 
 #define IS_VALID_INDEX(list, index) (list.len && index > 0 && index <= list.len)
 

--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -753,13 +753,14 @@ proc/dd_sortedObjectList(list/incoming)
 ///Same as deepCopyList but actually Clone() datums, and sub-lists. Will leave atom refs alone.
 /proc/listDeeperCopy(list/L)
 	if(isatom(L))
-		return L //Atom refs returns as-is
+		return L //Atom refs returns as-is, since we do cannot own them
 	if(istype(L, /datum))
 		var/datum/D = L
-		return D.Clone()
+		return D.CanClone()? D.Clone() : D //If the datum can be cloned, clone it, or just reference it otherwise
 	//Anything else that's not a list just return the ref
 	if(!islist(L))
 		return L
+
 	. = L.Copy()
 	for(var/i = 1 to length(L))
 		var/I = .[i]

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -88,7 +88,7 @@
  * Override this, instead of Clone() itself.
  */
 /datum/proc/GetCloneArgs()
-    return
+	return
 
 /**
  * Used to allow sub-classes to do further processing on the cloned instance returned by Clone().
@@ -96,4 +96,4 @@
  * ** Please avoid running update code in here if possible. You could always override Clone() for this kind of things, so we don't end up with 50 calls to update_icon in the chain. **
  */
 /datum/proc/PopulateClone(var/datum/clone)
-    return clone
+	return clone

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -69,9 +69,31 @@
 	CRASH("get_recursive_loc_of_type() called on datum type [type] - this proc should only be called on /atom.")
 
 /**
- * This proc returns a copy of the src datum.
- * Copy here implies a copy as similar in terms of look and contents, but internally may differ a bit. 
- * copy_instance is an optional parameter with the instance to copy the content of the src datum into. It's expected to be of a subtype of the src of the proc being called on.
+ * This proc returns a clone of the src datum.
+ * Clone here implies a copy similar in terms of look and contents, but internally may differ a bit.
+ * The clone shall not keep references onto instances owned by the original, in most cases.
+ * Try to avoid overriding this proc directly and instead override GetCloneArgs() and PopulateClone().
  */
-/datum/proc/Clone(var/datum/copy_instance = null)
-	return
+/datum/proc/Clone()
+	SHOULD_CALL_PARENT(TRUE)
+	var/list/newargs = GetCloneArgs()
+	if(newargs)
+		. = new type(arglist(newargs))
+	else
+		. = new type
+	return PopulateClone(.)
+
+/**
+ * Returns a list with the arguments passed to the new() of a cloned instance.
+ * Override this, instead of Clone() itself.
+ */
+/datum/proc/GetCloneArgs()
+    return
+
+/**
+ * Used to allow sub-classes to do further processing on the cloned instance returned by Clone().
+ * Override this, instead of Clone() itself.
+ * ** Please avoid running update code in here if possible. You could always override Clone() for this kind of things, so we don't end up with 50 calls to update_icon in the chain. **
+ */
+/datum/proc/PopulateClone(var/datum/clone)
+    return clone

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -69,6 +69,13 @@
 	CRASH("get_recursive_loc_of_type() called on datum type [type] - this proc should only be called on /atom.")
 
 /**
+ * Returns whether the object supports being cloned.
+ * This is useful for things that should only ever exist once in the world.
+ */
+/datum/proc/CanClone()
+	return TRUE
+
+/**
  * This proc returns a clone of the src datum.
  * Clone here implies a copy similar in terms of look and contents, but internally may differ a bit.
  * The clone shall not keep references onto instances owned by the original, in most cases.
@@ -76,6 +83,8 @@
  */
 /datum/proc/Clone()
 	SHOULD_CALL_PARENT(TRUE)
+	if(!CanClone())
+		CRASH("Called clone on ``[type]`` which does not support cloning!")
 	var/list/newargs = GetCloneArgs()
 	if(newargs)
 		. = new type(arglist(newargs))

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -67,3 +67,11 @@
 /datum/proc/get_recursive_loc_of_type(var/loc_type)
 	SHOULD_CALL_PARENT(FALSE)
 	CRASH("get_recursive_loc_of_type() called on datum type [type] - this proc should only be called on /atom.")
+
+/**
+ * This proc returns a copy of the src datum.
+ * Copy here implies a copy as similar in terms of look and contents, but internally may differ a bit. 
+ * copy_instance is an optional parameter with the instance to copy the content of the src datum into. It's expected to be of a subtype of the src of the proc being called on.
+ */
+/datum/proc/Clone(var/datum/copy_instance = null)
+	return

--- a/code/datums/repositories/decls.dm
+++ b/code/datums/repositories/decls.dm
@@ -127,6 +127,5 @@ var/global/repository/decls/decls_repository = new
 	PRINT_STACK_TRACE("Prevented attempt to delete a /decl instance: [log_info_line(src)]")
 	return QDEL_HINT_LETMELIVE
 
-/decl/Clone()
-	SHOULD_CALL_PARENT(FALSE)
-	return src //Return a reference, since we're a singleton
+/decl/CanClone()
+	return FALSE //Don't allow cloning since we're singletons

--- a/code/datums/repositories/decls.dm
+++ b/code/datums/repositories/decls.dm
@@ -126,3 +126,6 @@ var/global/repository/decls/decls_repository = new
 	SHOULD_CALL_PARENT(FALSE)
 	PRINT_STACK_TRACE("Prevented attempt to delete a /decl instance: [log_info_line(src)]")
 	return QDEL_HINT_LETMELIVE
+
+/decl/Clone(datum/copy_instance)
+	CRASH("You can't clone a singleton!")

--- a/code/datums/repositories/decls.dm
+++ b/code/datums/repositories/decls.dm
@@ -127,5 +127,6 @@ var/global/repository/decls/decls_repository = new
 	PRINT_STACK_TRACE("Prevented attempt to delete a /decl instance: [log_info_line(src)]")
 	return QDEL_HINT_LETMELIVE
 
-/decl/Clone(datum/copy_instance)
-	CRASH("You can't clone a singleton!")
+/decl/Clone()
+	SHOULD_CALL_PARENT(FALSE)
+	return src //Return a reference, since we're a singleton

--- a/code/datums/type_cloning.dm
+++ b/code/datums/type_cloning.dm
@@ -1,0 +1,8 @@
+/*
+ * A bunch of Clone implementation for system types, so they're compatible with the
+ * Clone() proc used on other datums.
+ */
+
+/matrix/GetCloneArgs()
+	return list(src) //Matrices handle copies themselves
+

--- a/code/datums/weakref.dm
+++ b/code/datums/weakref.dm
@@ -39,3 +39,10 @@
 
 /weakref/get_log_info_line()
 	return "[ref_name] ([ref_type]) ([ref]) (WEAKREF)"
+
+//Allow cloning weakrefs
+/weakref/PopulateClone(weakref/clone)
+	clone.ref = ref
+	clone.ref_name = ref_name
+	clone.ref_type = ref_type
+	return clone

--- a/code/datums/weakref.dm
+++ b/code/datums/weakref.dm
@@ -40,9 +40,5 @@
 /weakref/get_log_info_line()
 	return "[ref_name] ([ref_type]) ([ref]) (WEAKREF)"
 
-//Allow cloning weakrefs
-/weakref/PopulateClone(weakref/clone)
-	clone.ref = ref
-	clone.ref_name = ref_name
-	clone.ref_type = ref_type
-	return clone
+/weakref/CanClone()
+	return FALSE //Pass weakref as references since they're unique per atom instance

--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -132,3 +132,35 @@
 
 	vis_locs = null //clears this atom out of all vis_contents
 	clear_vis_contents(src)
+
+/atom/GetCloneArgs()
+	return list(loc)
+
+/atom/PopulateClone(atom/clone)
+	//Not entirely sure about icon stuff. Some legacy things would need it copied, but not more recently coded atoms..
+	clone.appearance = appearance
+	clone.set_invisibility(invisibility)
+
+	clone.SetName(name)
+	clone.set_density(density)
+	clone.set_opacity(opacity)
+	clone.set_gender(gender, FALSE)
+	clone.set_dir(dir)
+
+	clone.blood_DNA    = listdeeperCopy(blood_DNA)
+	clone.was_bloodied = was_bloodied
+	clone.blood_color  = blood_color
+	clone.germ_level   = germ_level
+	clone.temperature  = temperature
+
+	//Setup reagents
+	QDEL_NULL(clone.reagents)
+	clone.reagents = reagents?.Clone()
+	if(clone.reagents)
+		clone.reagents.set_holder(clone) //Holder MUST be set after cloning reagents
+	return clone
+
+/atom/movable/PopulateClone(atom/movable/clone)
+	clone = ..()
+	clone.anchored = anchored
+	return clone

--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -147,7 +147,7 @@
 	clone.set_gender(gender, FALSE)
 	clone.set_dir(dir)
 
-	clone.blood_DNA    = listDeeperCopy(blood_DNA)
+	clone.blood_DNA    = listDeepClone(blood_DNA, TRUE)
 	clone.was_bloodied = was_bloodied
 	clone.blood_color  = blood_color
 	clone.germ_level   = germ_level

--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -147,7 +147,7 @@
 	clone.set_gender(gender, FALSE)
 	clone.set_dir(dir)
 
-	clone.blood_DNA    = listdeeperCopy(blood_DNA)
+	clone.blood_DNA    = listDeeperCopy(blood_DNA)
 	clone.was_bloodied = was_bloodied
 	clone.blood_color  = blood_color
 	clone.germ_level   = germ_level

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -86,21 +86,23 @@ var/global/list/datum/dna/gene/dna_genes[0]
 
 // Make a copy of this strand.
 // USE THIS WHEN COPYING STUFF OR YOU'LL GET CORRUPTION!
-/datum/dna/proc/Clone()
-	var/datum/dna/new_dna = new()
-	new_dna.lineage=lineage
-	new_dna.unique_enzymes=unique_enzymes
-	new_dna.b_type=b_type
-	new_dna.real_name=real_name
-	new_dna.species=species || global.using_map.default_species
-	new_dna.body_markings=body_markings.Copy()
-	for(var/b=1;b<=DNA_SE_LENGTH;b++)
-		new_dna.SE[b]=SE[b]
-		if(b<=DNA_UI_LENGTH)
-			new_dna.UI[b]=UI[b]
-	new_dna.UpdateUI()
-	new_dna.UpdateSE()
-	return new_dna
+/datum/dna/Clone(datum/dna/copy_instance = null)
+	if(!copy_instance)
+		copy_instance = new type
+	copy_instance.lineage        = lineage
+	copy_instance.unique_enzymes = unique_enzymes
+	copy_instance.b_type         = b_type
+	copy_instance.real_name      = real_name
+	copy_instance.species        = species || global.using_map.default_species
+	copy_instance.body_markings  = body_markings.Copy()
+	for(var/b=1; b<=DNA_SE_LENGTH; b++)
+		copy_instance.SE[b] = SE[b]
+		if(b <= DNA_UI_LENGTH)
+			copy_instance.UI[b] = UI[b]
+	copy_instance.UpdateUI()
+	copy_instance.UpdateSE()
+	return copy_instance
+
 ///////////////////////////////////////
 // UNIQUE IDENTITY
 ///////////////////////////////////////

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -92,7 +92,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	clone.b_type         = b_type
 	clone.real_name      = real_name
 	clone.species        = species || global.using_map.default_species
-	clone.body_markings  = listDeeperCopy(body_markings)
+	clone.body_markings  = deepCopyList(body_markings)
 	for(var/b in 1 to DNA_SE_LENGTH)
 		clone.SE[b] = SE[b]
 		if(b <= DNA_UI_LENGTH)

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -95,7 +95,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	copy_instance.real_name      = real_name
 	copy_instance.species        = species || global.using_map.default_species
 	copy_instance.body_markings  = body_markings.Copy()
-	for(var/b=1; b<=DNA_SE_LENGTH; b++)
+	for(var/b in 1 to DNA_SE_LENGTH)
 		copy_instance.SE[b] = SE[b]
 		if(b <= DNA_UI_LENGTH)
 			copy_instance.UI[b] = UI[b]

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -92,7 +92,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	clone.b_type         = b_type
 	clone.real_name      = real_name
 	clone.species        = species || global.using_map.default_species
-	clone.body_markings  = listdeeperCopy(body_markings)
+	clone.body_markings  = listDeeperCopy(body_markings)
 	for(var/b in 1 to DNA_SE_LENGTH)
 		clone.SE[b] = SE[b]
 		if(b <= DNA_UI_LENGTH)

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -85,23 +85,21 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	//#TODO: Keep track of bodytype!!!!!
 
 // Make a copy of this strand.
-// USE THIS WHEN COPYING STUFF OR YOU'LL GET CORRUPTION!
-/datum/dna/Clone(datum/dna/copy_instance = null)
-	if(!copy_instance)
-		copy_instance = new type
-	copy_instance.lineage        = lineage
-	copy_instance.unique_enzymes = unique_enzymes
-	copy_instance.b_type         = b_type
-	copy_instance.real_name      = real_name
-	copy_instance.species        = species || global.using_map.default_species
-	copy_instance.body_markings  = body_markings.Copy()
+/datum/dna/PopulateClone(datum/dna/clone)
+	clone = ..()
+	clone.lineage        = lineage
+	clone.unique_enzymes = unique_enzymes
+	clone.b_type         = b_type
+	clone.real_name      = real_name
+	clone.species        = species || global.using_map.default_species
+	clone.body_markings  = listdeeperCopy(body_markings)
 	for(var/b in 1 to DNA_SE_LENGTH)
-		copy_instance.SE[b] = SE[b]
+		clone.SE[b] = SE[b]
 		if(b <= DNA_UI_LENGTH)
-			copy_instance.UI[b] = UI[b]
-	copy_instance.UpdateUI()
-	copy_instance.UpdateSE()
-	return copy_instance
+			clone.UI[b] = UI[b]
+	clone.UpdateUI()
+	clone.UpdateSE()
+	return clone
 
 ///////////////////////////////////////
 // UNIQUE IDENTITY

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -151,7 +151,7 @@
 
 /obj/item/GetCloneArgs()
 	. = ..()
-	LAZYADD(., material)
+	LAZYADD(., material?.type)
 
 //#TODO: Implement this for all the sub class that need it
 /obj/item/PopulateClone(obj/item/clone)

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -149,22 +149,32 @@
 	else
 		return ..()
 
-/obj/item/Clone(obj/item/copy_instance = null)
-	if(!copy_instance)
-		copy_instance = new type(null, material)
-	copy_instance.contaminated = contaminated
-	copy_instance.blood_overlay = image(blood_overlay)
+/obj/item/GetCloneArgs()
+	. = ..()
+	LAZYADD(., material)
 
-	//Health
-	copy_instance.health = health
+//#TODO: Implement this for all the sub class that need it
+/obj/item/PopulateClone(obj/item/clone)
+	clone = ..()
+	clone.contaminated = contaminated
+	clone.blood_overlay = image(blood_overlay)
+
+	clone.health = health
 	//#TODO: once item damage in, check health!
 
 	//Coating
-	copy_instance.coating = coating?.Clone()
-	if(copy_instance.coating)
-		copy_instance.coating.set_holder(copy_instance)
+	clone.coating = coating?.Clone()
+	if(clone.coating)
+		clone.coating.set_holder(clone)
+	return clone
 
-	return ..(copy_instance) //Calls update_icon()
+//Run some updates
+/obj/item/Clone()
+	var/obj/item/clone = ..()
+	if(clone)
+		clone.update_icon()
+		clone.update_held_icon()
+	return clone
 
 //Checks if the item is being held by a mob, and if so, updates the held icons
 /obj/item/proc/update_twohanding()

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -149,6 +149,23 @@
 	else
 		return ..()
 
+/obj/item/Clone(obj/item/copy_instance = null)
+	if(!copy_instance)
+		copy_instance = new type(null, material)
+	copy_instance.contaminated = contaminated
+	copy_instance.blood_overlay = image(blood_overlay)
+
+	//Health
+	copy_instance.health = health
+	//#TODO: once item damage in, check health!
+
+	//Coating
+	copy_instance.coating = coating?.Clone()
+	if(copy_instance.coating)
+		copy_instance.coating.set_holder(copy_instance)
+
+	return ..(copy_instance) //Calls update_icon()
+
 //Checks if the item is being held by a mob, and if so, updates the held icons
 /obj/item/proc/update_twohanding()
 	update_held_icon()

--- a/code/game/objects/items/weapons/tech_disks.dm
+++ b/code/game/objects/items/weapons/tech_disks.dm
@@ -23,7 +23,7 @@
 /obj/item/disk/proc/write_file(var/datum/computer_file/data/F, var/new_name = null)
 	if(F.block_size > free_blocks)
 		return FALSE
-	F = F.clone()
+	F = F.Clone()
 	if(length(new_name))
 		F.filename = new_name
 
@@ -42,7 +42,7 @@
 /**Clone the file. */
 /obj/item/disk/proc/copy_file(var/name)
 	var/datum/computer_file/F = LAZYACCESS(stored_files, name)
-	return F?.clone()
+	return F?.Clone()
 
 /**Delete a specific file. Fails if file is write protected, and force is FALSE. */
 /obj/item/disk/proc/delete_file(var/name, var/force = FALSE)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -263,6 +263,36 @@
 /obj/proc/populate_reagents()
 	return
 
+//#TODO: Implement me for all other objects!
+/obj/Clone(obj/copy_instance = null)
+	if(!copy_instance)
+		copy_instance = new type
+	
+	//Obj stuff
+	copy_instance.color      = color
+	copy_instance.opacity    = opacity
+	copy_instance.alpha      = alpha
+	copy_instance.req_access = req_access?.Copy()
+	copy_instance.matter     = matter?.Copy()
+
+	//#TODO: once item damage in, check health!
+
+	//Atom stuff
+	copy_instance.SetName(name)
+	copy_instance.blood_DNA    = blood_DNA
+	copy_instance.was_bloodied = was_bloodied
+	copy_instance.blood_color  = blood_color
+	copy_instance.germ_level   = germ_level
+	copy_instance.temperature  = temperature
+
+	//Setup reagents
+	copy_instance.reagents = reagents?.Clone()
+	if(copy_instance.reagents)
+		copy_instance.reagents.set_holder(copy_instance)
+
+	update_icon()
+	return copy_instance
+
 /**
  * Returns a list with the contents that may be spawned in this object.
  * This shouldn't include things that are necessary for the object to operate, like machine components. 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -266,8 +266,8 @@
 //#TODO: Implement me for all other objects!
 /obj/PopulateClone(obj/clone)
 	clone = ..()
-	clone.req_access  = listdeeperCopy(req_access)
-	clone.matter      = listdeeperCopy(matter)
+	clone.req_access  = listDeeperCopy(req_access)
+	clone.matter      = listDeeperCopy(matter)
 	clone.anchor_fall = anchor_fall
 
 	//#TODO: once item damage in, check health!

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -266,8 +266,8 @@
 //#TODO: Implement me for all other objects!
 /obj/PopulateClone(obj/clone)
 	clone = ..()
-	clone.req_access  = listDeeperCopy(req_access)
-	clone.matter      = listDeeperCopy(matter)
+	clone.req_access  = deepCopyList(req_access)
+	clone.matter      = deepCopyList(matter)
 	clone.anchor_fall = anchor_fall
 
 	//#TODO: once item damage in, check health!

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -205,7 +205,7 @@
 	if(directional_offset)
 		update_directional_offset()
 
-/** 
+/**
  * Applies the offset stored in the directional_offset json list depending on the current direction.
  * force will force the default offset to be 0 if there are no directional_offset string.
  */
@@ -227,8 +227,8 @@
 		default_pixel_z = curoff["z"] || 0
 	reset_offsets(0)
 
-/** 
- * Returns whether the object should be considered as hanging off a wall. 
+/**
+ * Returns whether the object should be considered as hanging off a wall.
  * This is userful because wall-mounted things are actually on the adjacent floor tile offset towards the wall.
  * Which means we have to deal with directional offsets differently. Such as with buttons mounted on a table, or on a wall.
  */
@@ -237,7 +237,7 @@
 	if(obj_flags & OBJ_FLAG_MOVES_UNSUPPORTED || anchor_fall)
 		var/turf/forward = get_step(get_turf(src), dir)
 		var/turf/reverse = get_step(get_turf(src), global.reverse_dir[dir])
-		//If we're wall mounted and don't have a wall either facing us, or in the opposite direction, don't apply the offset. 
+		//If we're wall mounted and don't have a wall either facing us, or in the opposite direction, don't apply the offset.
 		// This is mainly for things that can be both wall mounted and floor mounted. Like buttons, which mappers seem to really like putting on tables.
 		// Its sort of a hack for now. But objects don't handle being on a wall or not. (They don't change their flags, layer, etc when on a wall or anything)
 		if(!forward?.is_wall() && !reverse?.is_wall())
@@ -264,38 +264,18 @@
 	return
 
 //#TODO: Implement me for all other objects!
-/obj/Clone(obj/copy_instance = null)
-	if(!copy_instance)
-		copy_instance = new type
-	
-	//Obj stuff
-	copy_instance.color      = color
-	copy_instance.opacity    = opacity
-	copy_instance.alpha      = alpha
-	copy_instance.req_access = req_access?.Copy()
-	copy_instance.matter     = matter?.Copy()
+/obj/PopulateClone(obj/clone)
+	clone = ..()
+	clone.req_access  = listdeeperCopy(req_access)
+	clone.matter      = listdeeperCopy(matter)
+	clone.anchor_fall = anchor_fall
 
 	//#TODO: once item damage in, check health!
-
-	//Atom stuff
-	copy_instance.SetName(name)
-	copy_instance.blood_DNA    = blood_DNA
-	copy_instance.was_bloodied = was_bloodied
-	copy_instance.blood_color  = blood_color
-	copy_instance.germ_level   = germ_level
-	copy_instance.temperature  = temperature
-
-	//Setup reagents
-	copy_instance.reagents = reagents?.Clone()
-	if(copy_instance.reagents)
-		copy_instance.reagents.set_holder(copy_instance)
-
-	update_icon()
-	return copy_instance
+	return clone
 
 /**
  * Returns a list with the contents that may be spawned in this object.
- * This shouldn't include things that are necessary for the object to operate, like machine components. 
+ * This shouldn't include things that are necessary for the object to operate, like machine components.
  * Its mainly for populating storage and the like.
  */
 /obj/proc/WillContain()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -267,7 +267,7 @@
 /obj/PopulateClone(obj/clone)
 	clone = ..()
 	clone.req_access  = deepCopyList(req_access)
-	clone.matter      = deepCopyList(matter)
+	clone.matter      = matter?.Copy()
 	clone.anchor_fall = anchor_fall
 
 	//#TODO: once item damage in, check health!

--- a/code/modules/modular_computers/file_system/computer_file.dm
+++ b/code/modules/modular_computers/file_system/computer_file.dm
@@ -34,24 +34,31 @@ var/global/file_uid = 0
 		hard_drive.remove_file(src, forced = TRUE)
 	. = ..()
 
-// Returns independent copy of this file.
-/datum/computer_file/Clone(datum/computer_file/copy_instance = null, var/rename = FALSE)
-	if(!copy_instance)
-		copy_instance = new type
-	copy_instance.unsendable  = unsendable
-	copy_instance.undeletable = undeletable
-	copy_instance.size        = size
+/datum/computer_file/PopulateClone(datum/computer_file/clone)
+	clone = ..()
+	clone.unsendable  = unsendable
+	clone.undeletable = undeletable
+	clone.size        = size
 	if(metadata)
-		copy_instance.metadata = metadata.Copy()
-	if(rename)
-		copy_instance.filename = filename + copy_string
-	else
-		copy_instance.filename = filename
-	copy_instance.filetype     = filetype
-	copy_instance.read_access  = read_access
-	copy_instance.write_access = write_access
-	copy_instance.mod_access   = mod_access
-	return copy_instance
+		clone.metadata = listdeeperCopy(metadata)
+	clone.filetype     = filetype
+	clone.read_access  = listdeeperCopy(read_access)
+	clone.write_access = listdeeperCopy(write_access)
+	clone.mod_access   = listdeeperCopy(mod_access)
+	return clone
+
+/**
+ * Returns independent copy of this file.
+ * rename: Whether the clone shold be auto-renamed.
+ */
+/datum/computer_file/Clone(var/rename = FALSE)
+	var/datum/computer_file/clone = ..(null) //Don't propagate our rename param
+	if(clone)
+		if(rename)
+			clone.filename = filename + copy_string
+		else
+			clone.filename = filename
+	return clone
 
 /datum/computer_file/proc/get_file_perms(var/list/accesses, var/mob/user)
 	. = 0

--- a/code/modules/modular_computers/file_system/computer_file.dm
+++ b/code/modules/modular_computers/file_system/computer_file.dm
@@ -40,11 +40,11 @@ var/global/file_uid = 0
 	clone.undeletable = undeletable
 	clone.size        = size
 	if(metadata)
-		clone.metadata = listdeeperCopy(metadata)
+		clone.metadata = listDeeperCopy(metadata)
 	clone.filetype     = filetype
-	clone.read_access  = listdeeperCopy(read_access)
-	clone.write_access = listdeeperCopy(write_access)
-	clone.mod_access   = listdeeperCopy(mod_access)
+	clone.read_access  = listDeeperCopy(read_access)
+	clone.write_access = listDeeperCopy(write_access)
+	clone.mod_access   = listDeeperCopy(mod_access)
 	return clone
 
 /**

--- a/code/modules/modular_computers/file_system/computer_file.dm
+++ b/code/modules/modular_computers/file_system/computer_file.dm
@@ -35,22 +35,23 @@ var/global/file_uid = 0
 	. = ..()
 
 // Returns independent copy of this file.
-/datum/computer_file/proc/clone(var/rename = 0)
-	var/datum/computer_file/temp = new type
-	temp.unsendable = unsendable
-	temp.undeletable = undeletable
-	temp.size = size
+/datum/computer_file/Clone(datum/computer_file/copy_instance = null, var/rename = FALSE)
+	if(!copy_instance)
+		copy_instance = new type
+	copy_instance.unsendable  = unsendable
+	copy_instance.undeletable = undeletable
+	copy_instance.size        = size
 	if(metadata)
-		temp.metadata = metadata.Copy()
+		copy_instance.metadata = metadata.Copy()
 	if(rename)
-		temp.filename = filename + copy_string
+		copy_instance.filename = filename + copy_string
 	else
-		temp.filename = filename
-	temp.filetype = filetype
-	temp.read_access = read_access
-	temp.write_access = write_access
-	temp.mod_access = mod_access
-	return temp
+		copy_instance.filename = filename
+	copy_instance.filetype     = filetype
+	copy_instance.read_access  = read_access
+	copy_instance.write_access = write_access
+	copy_instance.mod_access   = mod_access
+	return copy_instance
 
 /datum/computer_file/proc/get_file_perms(var/list/accesses, var/mob/user)
 	. = 0

--- a/code/modules/modular_computers/file_system/computer_file.dm
+++ b/code/modules/modular_computers/file_system/computer_file.dm
@@ -40,11 +40,11 @@ var/global/file_uid = 0
 	clone.undeletable = undeletable
 	clone.size        = size
 	if(metadata)
-		clone.metadata = listDeeperCopy(metadata)
+		clone.metadata = listDeepClone(metadata, TRUE)
 	clone.filetype     = filetype
-	clone.read_access  = listDeeperCopy(read_access)
-	clone.write_access = listDeeperCopy(write_access)
-	clone.mod_access   = listDeeperCopy(mod_access)
+	clone.read_access  = deepCopyList(read_access)
+	clone.write_access = deepCopyList(write_access)
+	clone.mod_access   = deepCopyList(mod_access)
 	return clone
 
 /**

--- a/code/modules/modular_computers/file_system/data.dm
+++ b/code/modules/modular_computers/file_system/data.dm
@@ -7,12 +7,10 @@
 	var/do_not_edit = 0				// Whether the user will be reminded that the file probably shouldn't be edited.
 	var/read_only = 0				// Protects files that should never be edited by the user due to special properties.
 
-/datum/computer_file/data/Clone(datum/computer_file/data/copy_instance = null, rename = FALSE)
-	if(!copy_instance)
-		copy_instance = new type
-	copy_instance = ..(copy_instance, rename)
-	copy_instance.stored_data = stored_data
-	return copy_instance
+/datum/computer_file/data/PopulateClone(datum/computer_file/data/clone)
+	clone = ..()
+	clone.stored_data = stored_data
+	return clone
 
 // Calculates file size from amount of characters in saved string
 /datum/computer_file/data/proc/calculate_size()

--- a/code/modules/modular_computers/file_system/data.dm
+++ b/code/modules/modular_computers/file_system/data.dm
@@ -7,10 +7,12 @@
 	var/do_not_edit = 0				// Whether the user will be reminded that the file probably shouldn't be edited.
 	var/read_only = 0				// Protects files that should never be edited by the user due to special properties.
 
-/datum/computer_file/data/clone()
-	var/datum/computer_file/data/temp = ..()
-	temp.stored_data = stored_data
-	return temp
+/datum/computer_file/data/Clone(datum/computer_file/data/copy_instance = null, rename = FALSE)
+	if(!copy_instance)
+		copy_instance = new type
+	copy_instance = ..(copy_instance, rename)
+	copy_instance.stored_data = stored_data
+	return copy_instance
 
 // Calculates file size from amount of characters in saved string
 /datum/computer_file/data/proc/calculate_size()

--- a/code/modules/modular_computers/file_system/directory.dm
+++ b/code/modules/modular_computers/file_system/directory.dm
@@ -76,17 +76,15 @@
 		return parent_paths + "/" + filename
 	return filename
 
-/datum/computer_file/directory/Clone(datum/computer_file/directory/copy_instance, rename = FALSE)
-	if(!copy_instance)
-		copy_instance = new type
-	copy_instance = ..(copy_instance, rename)
-	copy_instance.inherit_perms = inherit_perms
+/datum/computer_file/directory/PopulateClone(datum/computer_file/directory/clone)
+	clone = ..()
+	clone.inherit_perms = inherit_perms
 	// Add copies of all of our stored files
 	for(var/datum/computer_file/stored in get_held_files())
 		// Do not rename cloned files.
-		var/datum/computer_file/stored_clone = stored.Clone(null, FALSE)
+		var/datum/computer_file/stored_clone = stored.Clone(FALSE)
 		if(stored_clone)
-			copy_instance.held_files += weakref(stored_clone)
-			copy_instance.temp_file_refs += stored_clone
+			clone.held_files += weakref(stored_clone)
+			clone.temp_file_refs += stored_clone
 
-	return copy_instance
+	return clone

--- a/code/modules/modular_computers/file_system/directory.dm
+++ b/code/modules/modular_computers/file_system/directory.dm
@@ -76,15 +76,17 @@
 		return parent_paths + "/" + filename
 	return filename
 
-/datum/computer_file/directory/clone(var/rename = 0)
-	var/datum/computer_file/directory/temp = ..()
-	temp.inherit_perms = inherit_perms
+/datum/computer_file/directory/Clone(datum/computer_file/directory/copy_instance, rename = FALSE)
+	if(!copy_instance)
+		copy_instance = new type
+	copy_instance = ..(copy_instance, rename)
+	copy_instance.inherit_perms = inherit_perms
 	// Add copies of all of our stored files
 	for(var/datum/computer_file/stored in get_held_files())
 		// Do not rename cloned files.
-		var/datum/computer_file/stored_clone = stored.clone(FALSE)
+		var/datum/computer_file/stored_clone = stored.Clone(null, FALSE)
 		if(stored_clone)
-			temp.held_files += weakref(stored_clone)
-			temp.temp_file_refs += stored_clone
+			copy_instance.held_files += weakref(stored_clone)
+			copy_instance.temp_file_refs += stored_clone
 
-	return temp
+	return copy_instance

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -34,16 +34,18 @@
 /datum/computer_file/program/nano_host()
 	return computer && computer.nano_host()
 
-/datum/computer_file/program/clone()
-	var/datum/computer_file/program/temp = ..()
-	temp.read_access = read_access
-	temp.nanomodule_path = nanomodule_path
-	temp.filedesc = filedesc
-	temp.program_icon_state = program_icon_state
-	temp.requires_network = requires_network
-	temp.requires_network_feature = requires_network_feature
-	temp.usage_flags = usage_flags
-	return temp
+/datum/computer_file/program/Clone(datum/computer_file/program/copy_instance = null, rename = FALSE)
+	if(!copy_instance)
+		copy_instance = new type
+	copy_instance = ..(copy_instance, rename)
+	copy_instance.read_access        = read_access
+	copy_instance.nanomodule_path    = nanomodule_path
+	copy_instance.filedesc           = filedesc
+	copy_instance.program_icon_state = program_icon_state
+	copy_instance.requires_network   = requires_network
+	copy_instance.requires_network_feature = requires_network_feature
+	copy_instance.usage_flags        = usage_flags
+	return copy_instance
 
 // Used by programs that manipulate files.
 /datum/computer_file/program/proc/get_file(var/filename, var/directory, var/list/accesses, var/mob/user)

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -36,7 +36,7 @@
 
 /datum/computer_file/program/PopulateClone(datum/computer_file/program/clone)
 	clone = ..()
-	clone.read_access        = listDeeperCopy(read_access)
+	clone.read_access        = deepCopyList(read_access)
 	clone.nanomodule_path    = nanomodule_path
 	clone.filedesc           = filedesc
 	clone.program_icon_state = program_icon_state

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -34,18 +34,16 @@
 /datum/computer_file/program/nano_host()
 	return computer && computer.nano_host()
 
-/datum/computer_file/program/Clone(datum/computer_file/program/copy_instance = null, rename = FALSE)
-	if(!copy_instance)
-		copy_instance = new type
-	copy_instance = ..(copy_instance, rename)
-	copy_instance.read_access        = read_access
-	copy_instance.nanomodule_path    = nanomodule_path
-	copy_instance.filedesc           = filedesc
-	copy_instance.program_icon_state = program_icon_state
-	copy_instance.requires_network   = requires_network
-	copy_instance.requires_network_feature = requires_network_feature
-	copy_instance.usage_flags        = usage_flags
-	return copy_instance
+/datum/computer_file/program/PopulateClone(datum/computer_file/program/clone)
+	clone = ..()
+	clone.read_access        = listdeeperCopy(read_access)
+	clone.nanomodule_path    = nanomodule_path
+	clone.filedesc           = filedesc
+	clone.program_icon_state = program_icon_state
+	clone.requires_network   = requires_network
+	clone.requires_network_feature = requires_network_feature
+	clone.usage_flags        = usage_flags
+	return clone
 
 // Used by programs that manipulate files.
 /datum/computer_file/program/proc/get_file(var/filename, var/directory, var/list/accesses, var/mob/user)

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -36,7 +36,7 @@
 
 /datum/computer_file/program/PopulateClone(datum/computer_file/program/clone)
 	clone = ..()
-	clone.read_access        = listdeeperCopy(read_access)
+	clone.read_access        = listDeeperCopy(read_access)
 	clone.nanomodule_path    = nanomodule_path
 	clone.filedesc           = filedesc
 	clone.program_icon_state = program_icon_state

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -44,12 +44,10 @@
 					break
 	return 1
 
-/datum/computer_file/program/revelation/Clone(datum/computer_file/program/revelation/copy_instance = null, rename = FALSE)
-	if(!copy_instance)
-		copy_instance = new type
-	copy_instance = ..(copy_instance, rename)
-	copy_instance.armed = armed
-	return copy_instance
+/datum/computer_file/program/revelation/PopulateClone(datum/computer_file/program/revelation/clone)
+	clone = ..()
+	clone.armed = armed
+	return clone
 
 /datum/nano_module/program/revelation
 	name = "Revelation Virus"

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -44,10 +44,12 @@
 					break
 	return 1
 
-/datum/computer_file/program/revelation/clone()
-	var/datum/computer_file/program/revelation/temp = ..()
-	temp.armed = armed
-	return temp
+/datum/computer_file/program/revelation/Clone(datum/computer_file/program/revelation/copy_instance = null, rename = FALSE)
+	if(!copy_instance)
+		copy_instance = new type
+	copy_instance = ..(copy_instance, rename)
+	copy_instance.armed = armed
+	return copy_instance
 
 /datum/nano_module/program/revelation
 	name = "Revelation Virus"

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -23,7 +23,7 @@
 /datum/computer_file/program/comm/PopulateClone(datum/computer_file/program/comm/clone)
 	clone = ..()
 	clone.message_core.messages = null
-	clone.message_core.messages = listdeeperCopy(message_core.messages)
+	clone.message_core.messages = listDeeperCopy(message_core.messages)
 	return clone
 
 /datum/nano_module/program/comm

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -20,13 +20,11 @@
 	category = PROG_COMMAND
 	var/datum/comm_message_listener/message_core = new
 
-/datum/computer_file/program/comm/Clone(datum/computer_file/program/comm/copy_instance = null, rename = FALSE)
-	if(!copy_instance)
-		copy_instance = new type
-	copy_instance = ..(copy_instance, rename)
-	copy_instance.message_core.messages = null
-	copy_instance.message_core.messages = message_core.messages.Copy()
-	return copy_instance
+/datum/computer_file/program/comm/PopulateClone(datum/computer_file/program/comm/clone)
+	clone = ..()
+	clone.message_core.messages = null
+	clone.message_core.messages = listdeeperCopy(message_core.messages)
+	return clone
 
 /datum/nano_module/program/comm
 	name = "Command and Communications Program"

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -20,11 +20,13 @@
 	category = PROG_COMMAND
 	var/datum/comm_message_listener/message_core = new
 
-/datum/computer_file/program/comm/clone()
-	var/datum/computer_file/program/comm/temp = ..()
-	temp.message_core.messages = null
-	temp.message_core.messages = message_core.messages.Copy()
-	return temp
+/datum/computer_file/program/comm/Clone(datum/computer_file/program/comm/copy_instance = null, rename = FALSE)
+	if(!copy_instance)
+		copy_instance = new type
+	copy_instance = ..(copy_instance, rename)
+	copy_instance.message_core.messages = null
+	copy_instance.message_core.messages = message_core.messages.Copy()
+	return copy_instance
 
 /datum/nano_module/program/comm
 	name = "Command and Communications Program"

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -22,8 +22,7 @@
 
 /datum/computer_file/program/comm/PopulateClone(datum/computer_file/program/comm/clone)
 	clone = ..()
-	clone.message_core.messages = null
-	clone.message_core.messages = listDeeperCopy(message_core.messages)
+	clone.message_core = message_core.Clone()
 	return clone
 
 /datum/nano_module/program/comm
@@ -318,6 +317,11 @@ var/global/last_message_id = 0
 
 /datum/comm_message_listener/proc/Remove(var/list/message)
 	messages -= list(message)
+
+/datum/comm_message_listener/PopulateClone(datum/comm_message_listener/clone)
+	clone = ..()
+	clone.messages = listDeepClone(messages)
+	return clone
 
 /proc/post_status(var/command, var/data1, var/data2)
 

--- a/code/modules/modular_computers/file_system/programs/generic/deck_management.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/deck_management.dm
@@ -265,7 +265,7 @@
 			if(href_list["flight_plan"])
 				prog_state = DECK_REPORT_EDIT
 				if(selected_mission.flight_plan)
-					selected_report = selected_mission.flight_plan.clone()//We always make a new one to buffer changes until submitted.
+					selected_report = selected_mission.flight_plan.Clone()//We always make a new one to buffer changes until submitted.
 				else
 					selected_report = create_report(/datum/computer_file/report/flight_plan, selected_shuttle)
 			else
@@ -278,9 +278,9 @@
 				prog_state = DECK_REPORT_EDIT
 				var/datum/computer_file/report/old_report = locate(prototype.type) in selected_mission.other_reports
 				if(old_report)
-					selected_report = old_report.clone()
+					selected_report = old_report.Clone()
 				else
-					var/datum/computer_file/report/recipient/shuttle/new_report = prototype.clone()
+					var/datum/computer_file/report/recipient/shuttle/new_report = prototype.Clone()
 					new_report.shuttle.set_value(selected_shuttle.name)
 					new_report.mission.set_value(selected_mission.name)
 					selected_report = new_report

--- a/code/modules/modular_computers/file_system/programs/generic/email_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/email_client.dm
@@ -434,7 +434,7 @@
 			if(CF.unsendable)
 				continue
 			if(CF.filename == picked_file)
-				msg_attachment = CF.clone()
+				msg_attachment = CF.Clone()
 				break
 		if(!istype(msg_attachment))
 			msg_attachment = null
@@ -455,7 +455,7 @@
 		if(!drive)
 			return 1
 
-		downloading = current_message.attachment.clone()
+		downloading = current_message.attachment.Clone()
 		download_progress = 0
 		return 1
 

--- a/code/modules/modular_computers/file_system/programs/generic/game.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/game.dm
@@ -27,12 +27,10 @@
 	filedesc = "Defeat [picked_enemy_name]"
 
 // Important in order to ensure that copied versions will have the same enemy name.
-/datum/computer_file/program/game/Clone(datum/computer_file/program/game/copy_instance = null, rename = FALSE)
-	if(!copy_instance)
-		copy_instance = new type
-	copy_instance = ..(copy_instance, rename)
-	copy_instance.picked_enemy_name = picked_enemy_name
-	return copy_instance
+/datum/computer_file/program/game/PopulateClone(datum/computer_file/program/game/clone)
+	clone = ..()
+	clone.picked_enemy_name = picked_enemy_name
+	return clone
 
 // When running the program, we also want to pass our enemy name to the nano module.
 /datum/computer_file/program/game/on_startup()

--- a/code/modules/modular_computers/file_system/programs/generic/game.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/game.dm
@@ -27,10 +27,12 @@
 	filedesc = "Defeat [picked_enemy_name]"
 
 // Important in order to ensure that copied versions will have the same enemy name.
-/datum/computer_file/program/game/clone()
-	var/datum/computer_file/program/game/G = ..()
-	G.picked_enemy_name = picked_enemy_name
-	return G
+/datum/computer_file/program/game/Clone(datum/computer_file/program/game/copy_instance = null, rename = FALSE)
+	if(!copy_instance)
+		copy_instance = new type
+	copy_instance = ..(copy_instance, rename)
+	copy_instance.picked_enemy_name = picked_enemy_name
+	return copy_instance
 
 // When running the program, we also want to pass our enemy name to the nano module.
 /datum/computer_file/program/game/on_startup()

--- a/code/modules/modular_computers/file_system/programs/generic/reports.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/reports.dm
@@ -69,7 +69,7 @@
 		selected_report.rename_file()
 	if(program.computer.store_file(selected_report))
 		saved_report = selected_report
-		selected_report = saved_report.clone()
+		selected_report = saved_report.Clone()
 		to_chat(user, "The report has been saved as '[saved_report.filename].[saved_report.filetype]'.")
 	else
 		to_chat(user, "Error storing file. Please check your hard drive.")
@@ -96,7 +96,7 @@
 				return
 			can_view_only = 0
 		saved_report = chosen_report
-		selected_report = chosen_report.clone()
+		selected_report = chosen_report.Clone()
 		return 1
 
 /datum/nano_module/program/reports/Topic(href, href_list)
@@ -174,7 +174,7 @@
 		var/datum/computer_network/net = program.computer.get_network()
 		for(var/datum/computer_file/report/report in net.fetch_reports(get_access(user), user))
 			if(report.uid == uid)
-				selected_report = report.clone()
+				selected_report = report.Clone()
 				can_view_only = 0
 				switch_state(REPORTS_VIEW)
 				return 1

--- a/code/modules/modular_computers/file_system/reports/report.dm
+++ b/code/modules/modular_computers/file_system/reports/report.dm
@@ -11,7 +11,7 @@
 	var/list/datum/report_field/fields = list()            //A list of fields the report comes with, in order that they should be displayed.
 	var/available_on_network = 0                           //Whether this report type should show up for download.
 	var/logo                                               //Can be set to a pencode logo for use with some display methods.
-	var/list/searchable_fields = list()                    //The names of fields in the report which are searchable. 
+	var/list/searchable_fields = list()                    //The names of fields in the report which are searchable.
 
 /datum/computer_file/report/New()
 	..()
@@ -98,19 +98,16 @@ The recursive option resets access to all fields in the report as well.
 	fields += field
 	return field
 
-/datum/computer_file/report/Clone(datum/computer_file/report/copy_instance = null, rename = FALSE)
-	if(!copy_instance)
-		copy_instance = new type
-	copy_instance = ..(copy_instance, rename)
-
-	copy_instance.title     = title
-	copy_instance.form_name = form_name
-	copy_instance.creator   = creator
-	copy_instance.file_time = file_time
+/datum/computer_file/report/PopulateClone(datum/computer_file/report/clone)
+	clone = ..()
+	clone.title     = title
+	clone.form_name = form_name
+	clone.creator   = creator
+	clone.file_time = file_time
 	for(var/i = 1, i <= length(fields), i++)
-		var/datum/report_field/new_field = copy_instance.fields[i]
+		var/datum/report_field/new_field = clone.fields[i]
 		new_field.copy_value(fields[i])
-	return copy_instance
+	return clone
 
 /datum/computer_file/report/proc/display_name()
 	return "Form [form_name]: [title]"

--- a/code/modules/modular_computers/file_system/reports/report.dm
+++ b/code/modules/modular_computers/file_system/reports/report.dm
@@ -98,16 +98,19 @@ The recursive option resets access to all fields in the report as well.
 	fields += field
 	return field
 
-/datum/computer_file/report/clone()
-	var/datum/computer_file/report/temp = ..()
-	temp.title = title
-	temp.form_name = form_name
-	temp.creator = creator
-	temp.file_time = file_time
+/datum/computer_file/report/Clone(datum/computer_file/report/copy_instance = null, rename = FALSE)
+	if(!copy_instance)
+		copy_instance = new type
+	copy_instance = ..(copy_instance, rename)
+
+	copy_instance.title     = title
+	copy_instance.form_name = form_name
+	copy_instance.creator   = creator
+	copy_instance.file_time = file_time
 	for(var/i = 1, i <= length(fields), i++)
-		var/datum/report_field/new_field = temp.fields[i]
+		var/datum/report_field/new_field = copy_instance.fields[i]
 		new_field.copy_value(fields[i])
-	return temp
+	return copy_instance
 
 /datum/computer_file/report/proc/display_name()
 	return "Form [form_name]: [title]"

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -194,7 +194,7 @@
 	//Try to save file, possibly won't fit size-wise
 	var/datum/computer_file/backup
 	if(istype(F))
-		backup = F.clone()
+		backup = F.Clone()
 		remove_file(F)
 	else
 		F = new file_type()

--- a/code/modules/modular_computers/networking/accounts/account.dm
+++ b/code/modules/modular_computers/networking/accounts/account.dm
@@ -68,23 +68,22 @@
 
 /datum/computer_file/data/account/proc/receive_mail(var/datum/computer_file/data/email_message/received_message, var/datum/computer_network/network)
 
-/datum/computer_file/data/account/clone()
-	var/datum/computer_file/data/account/copy = ..(TRUE) // We always rename the file since a copied account is always a backup.
-	copy.backup = TRUE
-
-	copy.login = login
-	copy.password = password
-	copy.can_login = can_login
-	copy.suspended = suspended
-
-	copy.groups = groups.Copy()
-	copy.parent_groups = parent_groups.Copy()
-
-	copy.fullname = fullname
+/datum/computer_file/data/account/Clone(datum/computer_file/data/account/copy_instance = null, rename = TRUE)
+	if(!copy_instance)
+		copy_instance = new type
+	copy_instance = ..(copy_instance, TRUE) // We always rename the file since a copied account is always a backup.
+	copy_instance.backup        = TRUE
+	copy_instance.login         = login
+	copy_instance.password      = password
+	copy_instance.can_login     = can_login
+	copy_instance.suspended     = suspended
+	copy_instance.groups        = groups.Copy()
+	copy_instance.parent_groups = parent_groups.Copy()
+	copy_instance.fullname      = fullname
 
 	// TODO: Don't backup e-mails for now - they are themselves other files which makes this complicated. In the future
 	// accounts will point to e-mails stored seperately on a server.
-	return copy
+	return copy_instance
 
 // Address namespace (@internal-services.net) for email addresses with special purpose only!.
 /datum/computer_file/data/account/service

--- a/code/modules/modular_computers/networking/accounts/account.dm
+++ b/code/modules/modular_computers/networking/accounts/account.dm
@@ -78,8 +78,8 @@
 	clone.password      = password
 	clone.can_login     = can_login
 	clone.suspended     = suspended
-	clone.groups        = listdeeperCopy(groups)
-	clone.parent_groups = listdeeperCopy(parent_groups)
+	clone.groups        = listDeeperCopy(groups)
+	clone.parent_groups = listDeeperCopy(parent_groups)
 	clone.fullname      = fullname
 
 	// TODO: Don't backup e-mails for now - they are themselves other files which makes this complicated. In the future

--- a/code/modules/modular_computers/networking/accounts/account.dm
+++ b/code/modules/modular_computers/networking/accounts/account.dm
@@ -78,8 +78,8 @@
 	clone.password      = password
 	clone.can_login     = can_login
 	clone.suspended     = suspended
-	clone.groups        = listDeeperCopy(groups)
-	clone.parent_groups = listDeeperCopy(parent_groups)
+	clone.groups        = groups.Copy()
+	clone.parent_groups = parent_groups.Copy()
 	clone.fullname      = fullname
 
 	// TODO: Don't backup e-mails for now - they are themselves other files which makes this complicated. In the future

--- a/code/modules/modular_computers/networking/accounts/account.dm
+++ b/code/modules/modular_computers/networking/accounts/account.dm
@@ -7,7 +7,7 @@
 	var/suspended = FALSE	// Whether the account is banned by the SA.
 	var/list/logged_in_os = list() // OS which are currently logged into this account. Used for e-mail notifications, currently.
 
-	var/list/groups = list() // Groups which this account is a member of. 
+	var/list/groups = list() // Groups which this account is a member of.
 	var/list/parent_groups = list() // Parent groups with a child/children which this account is a member of.
 
 	var/fullname	= "N/A"
@@ -53,7 +53,7 @@
 	logged_in_os.Cut()
 	groups.Cut()
 	parent_groups.Cut()
-	
+
 	QDEL_NULL_LIST(inbox)
 	QDEL_NULL_LIST(outbox)
 	QDEL_NULL_LIST(spam)
@@ -68,22 +68,23 @@
 
 /datum/computer_file/data/account/proc/receive_mail(var/datum/computer_file/data/email_message/received_message, var/datum/computer_network/network)
 
-/datum/computer_file/data/account/Clone(datum/computer_file/data/account/copy_instance = null, rename = TRUE)
-	if(!copy_instance)
-		copy_instance = new type
-	copy_instance = ..(copy_instance, TRUE) // We always rename the file since a copied account is always a backup.
-	copy_instance.backup        = TRUE
-	copy_instance.login         = login
-	copy_instance.password      = password
-	copy_instance.can_login     = can_login
-	copy_instance.suspended     = suspended
-	copy_instance.groups        = groups.Copy()
-	copy_instance.parent_groups = parent_groups.Copy()
-	copy_instance.fullname      = fullname
+/datum/computer_file/data/account/Clone(rename)
+	. = ..(TRUE) // We always rename the file since a copied account is always a backup.
+
+/datum/computer_file/data/account/PopulateClone(datum/computer_file/data/account/clone)
+	clone = ..()
+	clone.backup        = TRUE
+	clone.login         = login
+	clone.password      = password
+	clone.can_login     = can_login
+	clone.suspended     = suspended
+	clone.groups        = listdeeperCopy(groups)
+	clone.parent_groups = listdeeperCopy(parent_groups)
+	clone.fullname      = fullname
 
 	// TODO: Don't backup e-mails for now - they are themselves other files which makes this complicated. In the future
 	// accounts will point to e-mails stored seperately on a server.
-	return copy_instance
+	return clone
 
 // Address namespace (@internal-services.net) for email addresses with special purpose only!.
 /datum/computer_file/data/account/service

--- a/code/modules/modular_computers/networking/emails/_email.dm
+++ b/code/modules/modular_computers/networking/emails/_email.dm
@@ -25,7 +25,7 @@
 	if(!(recipient in get_accounts_unsorted()))
 		return FALSE
 	
-	var/datum/computer_file/data/email_message/received_copy = received.clone()
+	var/datum/computer_file/data/email_message/received_copy = received.Clone()
 	received_copy.set_timestamp()
 	recipient.inbox.Add(received_copy)
 	
@@ -40,6 +40,6 @@
 		for(var/datum/computer_file/data/account/email_account in get_accounts_unsorted())
 			if(email_account.broadcaster)
 				continue
-			var/datum/computer_file/data/email_message/new_message = received.clone()
+			var/datum/computer_file/data/email_message/new_message = received.Clone()
 			send_email(recipient, "[email_account.login]@[network_id]", new_message)
 	return TRUE

--- a/code/modules/modular_computers/networking/emails/email_message.dm
+++ b/code/modules/modular_computers/networking/emails/email_message.dm
@@ -11,17 +11,14 @@
 	. = ..()
 	QDEL_NULL(attachment)
 
-/datum/computer_file/data/email_message/Clone(datum/computer_file/data/email_message/copy_instance = null, rename = FALSE)
-	if(!copy_instance)
-		copy_instance = new type
-	copy_instance = ..(copy_instance, rename)
-	copy_instance.title = title
-	copy_instance.source = source
-	copy_instance.spam = spam
-	copy_instance.timestamp = timestamp
-	if(attachment)
-		copy_instance.attachment = attachment.Clone()
-	return copy_instance
+/datum/computer_file/data/email_message/PopulateClone(datum/computer_file/data/email_message/clone)
+	clone = ..()
+	clone.title      = title
+	clone.source     = source
+	clone.spam       = spam
+	clone.timestamp  = timestamp
+	clone.attachment = attachment?.Clone()
+	return clone
 
 // Turns /email_message/ file into regular /data/ file.
 /datum/computer_file/data/email_message/proc/export()

--- a/code/modules/modular_computers/networking/emails/email_message.dm
+++ b/code/modules/modular_computers/networking/emails/email_message.dm
@@ -11,15 +11,17 @@
 	. = ..()
 	QDEL_NULL(attachment)
 
-/datum/computer_file/data/email_message/clone()
-	var/datum/computer_file/data/email_message/temp = ..()
-	temp.title = title
-	temp.source = source
-	temp.spam = spam
-	temp.timestamp = timestamp
+/datum/computer_file/data/email_message/Clone(datum/computer_file/data/email_message/copy_instance = null, rename = FALSE)
+	if(!copy_instance)
+		copy_instance = new type
+	copy_instance = ..(copy_instance, rename)
+	copy_instance.title = title
+	copy_instance.source = source
+	copy_instance.spam = spam
+	copy_instance.timestamp = timestamp
 	if(attachment)
-		temp.attachment = attachment.clone()
-	return temp
+		copy_instance.attachment = attachment.Clone()
+	return copy_instance
 
 // Turns /email_message/ file into regular /data/ file.
 /datum/computer_file/data/email_message/proc/export()

--- a/code/modules/modular_computers/os/files.dm
+++ b/code/modules/modular_computers/os/files.dm
@@ -264,7 +264,7 @@
 	if(!(F.get_file_perms(accesses, user) & OS_READ_ACCESS))
 		return OS_FILE_NO_READ
 	
-	var/datum/computer_file/cloned_file = F.clone(TRUE)
+	var/datum/computer_file/cloned_file = F.Clone(null, TRUE)
 	if(!istype(cloned_file))
 		return OS_FILE_NO_READ
 	

--- a/code/modules/modular_computers/os/files.dm
+++ b/code/modules/modular_computers/os/files.dm
@@ -7,7 +7,7 @@
 	var/obj/item/stock_parts/computer/hard_drive = get_component(PART_HDD)
 	if(hard_drive)
 		mounted_storage["local"] = new /datum/file_storage/disk(src, "local")
-		programs_dir = "local" + "/" + OS_PROGRAMS_DIR	
+		programs_dir = "local" + "/" + OS_PROGRAMS_DIR
 	var/obj/item/stock_parts/computer/drive_slot/drive_slot = get_component(PART_D_SLOT)
 	if(drive_slot)
 		mounted_storage["media"] = new /datum/file_storage/disk/removable(src, "media")
@@ -20,13 +20,13 @@
 /datum/extension/interactive/os/proc/mount_storage(storage_type, root_name, hidden)
 	if(!ispath(storage_type, /datum/file_storage) || !length(root_name))
 		return
-	
+
 	var/mount_name = root_name
 	var/i = 0
 	while(mounted_storage[mount_name])
 		i++
 		mount_name = root_name + "_[i]"
-	
+
 	var/datum/file_storage/new_storage = new storage_type(src, mount_name, hidden)
 	mounted_storage[mount_name] = new_storage
 	return new_storage
@@ -35,11 +35,11 @@
 	var/datum/file_storage/removed = mounted_storage[root_name]
 	if(!removed)
 		return FALSE
-	
+
 	// Tell programs to clean up any lingering references.
 	for(var/datum/computer_file/program/P in running_programs)
 		P.on_file_storage_removal(removed)
-	
+
 	mounted_storage[root_name] = null
 	mounted_storage -= root_name
 
@@ -53,7 +53,7 @@
 	var/datum/extension/network_device/mainframe/mainframe = network.get_device_by_tag(mainframe_tag)
 	if(!istype(mainframe))
 		return "NETWORK ERROR: No mainframe with network tag '[mainframe_tag]' found."
-	
+
 	var/datum/file_storage/network/created_storage = mount_storage(/datum/file_storage/network, root_name, FALSE)
 	if(!created_storage)
 		return "I/O ERROR: Unable to mount mainframe as file system with root directory '[root_name]'."
@@ -76,7 +76,7 @@
 		directories.Cut(1, 2)
 	if(!length(directories[directories.len]))
 		directories.Cut(directories.len)
-	
+
 	var/datum/file_storage/storage = mounted_storage[directories[1]]
 	if(!storage)
 		return OS_DIR_NOT_FOUND
@@ -122,7 +122,7 @@
 	var/list/file_loc = parse_directory(dir_path, create_directories)
 	if(!islist(file_loc))
 		return file_loc
-	
+
 	var/datum/file_storage/storage = file_loc[1]
 	return storage.store_file(file, file_loc[2], create_directories, accesses, user, overwrite)
 
@@ -131,7 +131,7 @@
 	var/list/file_loc = parse_directory(dir_path)
 	if(!islist(file_loc))
 		return file_loc
-	
+
 	var/datum/file_storage/storage = file_loc[1]
 	return storage.try_store_file(file, file_loc[2], accesses, user)
 
@@ -140,21 +140,21 @@
 	filename = sanitize_for_file(filename)
 	if(!length(filename))
 		return OS_BAD_NAME
-	
+
 	var/list/file_loc = parse_directory(dir_path)
 	if(!islist(file_loc))
 		return file_loc
 
 	var/datum/file_storage/storage = file_loc[1]
-	
+
 	return storage.create_file(filename, file_loc[2], data, file_type, metadata, accesses, user)
 
 // Saves or creates the file with the given name in the passed directory. Returns file on success, error code on failure.
-/datum/extension/interactive/os/proc/save_file(filename, dir_path, new_data, file_type = /datum/computer_file/data/text, list/metadata, list/accesses, mob/user)	
+/datum/extension/interactive/os/proc/save_file(filename, dir_path, new_data, file_type = /datum/computer_file/data/text, list/metadata, list/accesses, mob/user)
 	filename = sanitize_for_file(filename)
 	if(!length(filename))
 		return OS_BAD_NAME
-	
+
 	var/list/file_loc = parse_directory(dir_path)
 	if(!islist(file_loc))
 		return file_loc
@@ -220,7 +220,7 @@
 		for(var/file in all_files)
 			if(!all_files[file]) // No directory associated with the file.
 				. += file
-	
+
 	return sortTim(., /proc/cmp_files_sort)
 
 // The following procs should return OS_FILE_SUCCESS on success (or the target file), or error codes on failure.
@@ -237,7 +237,7 @@
 /datum/file_storage/proc/create_file(filename, directory, data, file_type = /datum/computer_file/data, list/metadata, list/accesses, mob/user)
 	if(check_errors())
 		return OS_HARDDRIVE_ERROR
-	
+
 	filename = sanitize_for_file(filename)
 	if(!length(filename))
 		return OS_BAD_NAME
@@ -263,11 +263,11 @@
 		return F
 	if(!(F.get_file_perms(accesses, user) & OS_READ_ACCESS))
 		return OS_FILE_NO_READ
-	
-	var/datum/computer_file/cloned_file = F.Clone(null, TRUE)
+
+	var/datum/computer_file/cloned_file = F.Clone(TRUE)
 	if(!istype(cloned_file))
 		return OS_FILE_NO_READ
-	
+
 	var/success = store_file(cloned_file, directory, accesses, user)
 	if(success != OS_FILE_SUCCESS)
 		qdel(cloned_file) // Clean up after ourselves
@@ -277,7 +277,7 @@
 	if(current_directory)
 		if(full)
 			return "[root_name]/" + current_directory.get_file_path()
-		return current_directory.filename	
+		return current_directory.filename
 	return root_name
 
 /datum/file_storage/proc/parse_directory(directory_path, create_directories = FALSE)
@@ -591,7 +591,7 @@
 	if(file)
 		var/req_access = copy ? OS_READ_ACCESS : OS_WRITE_ACCESS
 		var/move_string = copy ? "copy" : "transfer"
-			
+
 		if(istype(file, /datum/computer_file/directory))
 			var/datum/computer_file/directory/dir = file
 			if(!copy)

--- a/code/modules/modular_computers/terminal/terminal_commands.dm
+++ b/code/modules/modular_computers/terminal/terminal_commands.dm
@@ -394,7 +394,7 @@ Subtypes
 	var/datum/file_storage/disk = file_loc[1]
 	var/datum/computer_file/file = file_loc[3]
 	
-	var/datum/computer_file/copy = file.clone(TRUE)
+	var/datum/computer_file/copy = file.Clone(null, TRUE)
 	if(!istype(copy))
 		return
 	var/success = disk.store_file(copy, file_loc[2], FALSE, terminal.get_access(user), user)

--- a/code/modules/modular_computers/terminal/terminal_commands.dm
+++ b/code/modules/modular_computers/terminal/terminal_commands.dm
@@ -37,7 +37,7 @@ var/global/list/terminal_commands
 
 	var/cur_string = ""
 	var/list/arguments = list()
-	
+
 	var/last_was_escape = FALSE
 	for(var/i in 1 to length(argtext)) // Allow players to escape spaces by using '\'.
 		var/char = argtext[i]
@@ -312,7 +312,7 @@ Subtypes
 			file_data += "[F.filename] - DIR"
 		else
 			file_data += "[F.filename].[F.filetype] - [F.size] GQ"
-	
+
 	return print_as_page(file_data, "file", selected_page, terminal.history_max_length - 1)
 
 /datum/terminal_command/remove
@@ -366,7 +366,7 @@ Subtypes
 	var/error = check_file_transfer(destination[2], F, copying, terminal.get_access(user), user)
 	if(error)
 		return "mv: [error]."
-	
+
 	terminal.current_move = new(file_loc[1], destination[1], destination[2], F, copying)
 	return "mv: Beginning file move..."
 
@@ -393,8 +393,8 @@ Subtypes
 
 	var/datum/file_storage/disk = file_loc[1]
 	var/datum/computer_file/file = file_loc[3]
-	
-	var/datum/computer_file/copy = file.Clone(null, TRUE)
+
+	var/datum/computer_file/copy = file.Clone(TRUE)
 	if(!istype(copy))
 		return
 	var/success = disk.store_file(copy, file_loc[2], FALSE, terminal.get_access(user), user)
@@ -417,7 +417,7 @@ Subtypes
 	// Errored!
 	if(!islist(file_loc))
 		return "rename: [get_terminal_error(file_path, file_loc)]."
-	
+
 	var/datum/computer_file/F = file_loc[3]
 	var/new_name = sanitize_for_file(rename_args[2])
 
@@ -441,7 +441,7 @@ Subtypes
 	var/list/file_loc = terminal.parse_directory(mkdir_args[1], TRUE)
 	if(!islist(file_loc) || (length(file_loc) > 1 && file_loc[2] == null)) // Don't return the error directly since we're attempting to create a directory, not just parse one.
 		return "mkdir: Unable to create directory '[mkdir_args[1]]'."
-	
+
 	var/datum/computer_file/directory/created_dir = file_loc[2]
 	return "mkdir: Successfully created directory '[created_dir.get_file_path()]'."
 
@@ -513,7 +513,7 @@ Subtypes
 	var/list/file_loc = terminal.parse_file(file_path)
 	if(!islist(file_loc))
 		return "permmod: [get_terminal_error(file_path, file_loc)]."
-	
+
 	var/datum/computer_file/F = file_loc[3]
 
 	if(length(permmod_args) < 3)

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -509,7 +509,7 @@ var/global/list/adminfaxes     = list()	//cache for faxes that have been sent to
 
 	//Call receive on the target machine
 	var/decl/public_access/public_method/send_method = GET_DECL(/decl/public_access/public_method/fax_receive_document)
-	if(send_method.perform(target, clone_paper_work_item(scanner_item), "[get_area(src)]'s [src]", sender_dev.get_network_URI()))
+	if(send_method.perform(target, scanner_item.Clone(), "[get_area(src)]'s [src]", sender_dev.get_network_URI()))
 		log_history("Outgoing", "'[scanner_item]', from '[get_area(src)]'s [src]' @ '[sender_dev.get_network_URI()]' to '[get_area(target)]'s [target]' @ '[target_dev.get_network_URI()]'.")
 		//#TODO: sync the animation, sound and message together when I got enough patience.
 		ping("Message transmitted successfully.")
@@ -661,7 +661,7 @@ var/global/list/adminfaxes     = list()	//cache for faxes that have been sent to
 
 /**Helper for sending a fax from a fax machine to an admin destination. */
 /proc/send_fax_to_admin(var/mob/sender, var/obj/item/doc, var/network_URI, var/obj/machinery/faxmachine/source_fax)
-	var/obj/item/rcvdcopy = clone_paper_work_item(doc)
+	var/obj/item/rcvdcopy = doc.Clone()
 	if(!rcvdcopy)
 		return
 	rcvdcopy.forceMove(null)

--- a/code/modules/paperwork/helpers.dm
+++ b/code/modules/paperwork/helpers.dm
@@ -33,15 +33,3 @@
 			var/obj/item/paper_bundle/PP = P
 			PP.attack_self(user)
 			. = TOPIC_HANDLED
-
-/**Call the clone proc on a paperwork item, if its a valid paperwork item. */
-/proc/clone_paper_work_item(var/obj/item/I)
-	if(istype(I, /obj/item/paper))
-		var/obj/item/paper/P = I
-		return P.Clone()
-	if(istype(I, /obj/item/photo))
-		var/obj/item/photo/P = I
-		return P.Clone()
-	if(istype(I, /obj/item/paper_bundle))
-		var/obj/item/paper_bundle/P = I
-		return P.Clone()

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -61,8 +61,8 @@
 	clone.rigged             = rigged
 	clone.is_crumpled        = is_crumpled
 	clone.stamp_text         = stamp_text
-	clone.applied_stamps     = LAZYLEN(applied_stamps)? listdeeperCopy(applied_stamps) : null
-	clone.metadata           = LAZYLEN(metadata)?       listdeeperCopy(metadata)       : null
+	clone.applied_stamps     = LAZYLEN(applied_stamps)? listDeeperCopy(applied_stamps) : null
+	clone.metadata           = LAZYLEN(metadata)?       listDeeperCopy(metadata)       : null
 	return clone
 
 /obj/item/paper/Clone()

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -51,22 +51,19 @@
 	if(!mapload && persist_on_init)
 		SSpersistence.track_value(src, /decl/persistence_handler/paper)
 
-/**Creates a complete copy of this object */
-/obj/item/paper/proc/Clone()
-	var/obj/item/paper/P = new(loc, , info, name)
-	P.fields             = fields
-	P.last_modified_ckey = last_modified_ckey
-	P.rigged             = rigged
-	P.is_crumpled        = is_crumpled
-	P.stamp_text         = stamp_text
-	P.applied_stamps     = LAZYLEN(applied_stamps)? applied_stamps.Copy() : null
-	P.metadata           = LAZYLEN(metadata)?       metadata.Copy()       : null
-
-	P.set_color(color)
-	P.set_opacity(opacity)
-	P.updateinfolinks()
-	P.update_icon()
-	return P
+/obj/item/paper/Clone(obj/item/paper/copy_instance = null)
+	if(!copy_instance)
+		copy_instance = new type(null, material, info, name)
+	
+	copy_instance.fields             = fields
+	copy_instance.last_modified_ckey = last_modified_ckey
+	copy_instance.rigged             = rigged
+	copy_instance.is_crumpled        = is_crumpled
+	copy_instance.stamp_text         = stamp_text
+	copy_instance.applied_stamps     = LAZYLEN(applied_stamps)? applied_stamps.Copy() : null
+	copy_instance.metadata           = LAZYLEN(metadata)?       metadata.Copy()       : null
+	copy_instance.updateinfolinks()
+	return ..(copy_instance) //Calls update_icon()
 
 /obj/item/paper/get_matter_amount_modifier()
 	return 0.2

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -51,19 +51,25 @@
 	if(!mapload && persist_on_init)
 		SSpersistence.track_value(src, /decl/persistence_handler/paper)
 
-/obj/item/paper/Clone(obj/item/paper/copy_instance = null)
-	if(!copy_instance)
-		copy_instance = new type(null, material, info, name)
-	
-	copy_instance.fields             = fields
-	copy_instance.last_modified_ckey = last_modified_ckey
-	copy_instance.rigged             = rigged
-	copy_instance.is_crumpled        = is_crumpled
-	copy_instance.stamp_text         = stamp_text
-	copy_instance.applied_stamps     = LAZYLEN(applied_stamps)? applied_stamps.Copy() : null
-	copy_instance.metadata           = LAZYLEN(metadata)?       metadata.Copy()       : null
-	copy_instance.updateinfolinks()
-	return ..(copy_instance) //Calls update_icon()
+/obj/item/paper/GetCloneArgs()
+	return list(null, material, info, name)
+
+/obj/item/paper/PopulateClone(obj/item/paper/clone)
+	clone = ..()
+	clone.fields             = fields
+	clone.last_modified_ckey = last_modified_ckey
+	clone.rigged             = rigged
+	clone.is_crumpled        = is_crumpled
+	clone.stamp_text         = stamp_text
+	clone.applied_stamps     = LAZYLEN(applied_stamps)? listdeeperCopy(applied_stamps) : null
+	clone.metadata           = LAZYLEN(metadata)?       listdeeperCopy(metadata)       : null
+	return clone
+
+/obj/item/paper/Clone()
+	var/obj/item/paper/clone = ..()
+	if(clone)
+		clone.updateinfolinks()
+	return clone
 
 /obj/item/paper/get_matter_amount_modifier()
 	return 0.2
@@ -406,7 +412,7 @@
 		if(!user.canUnEquip(other))
 			to_chat(user, SPAN_WARNING("You can't unequip \the [other]!"))
 			return
-		user.unEquip(src, B) 
+		user.unEquip(src, B)
 		user.unEquip(other, B)
 
 	if (name != initial(name))

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -61,8 +61,8 @@
 	clone.rigged             = rigged
 	clone.is_crumpled        = is_crumpled
 	clone.stamp_text         = stamp_text
-	clone.applied_stamps     = LAZYLEN(applied_stamps)? listDeeperCopy(applied_stamps) : null
-	clone.metadata           = LAZYLEN(metadata)?       listDeeperCopy(metadata)       : null
+	clone.applied_stamps     = LAZYLEN(applied_stamps)? listDeepClone(applied_stamps) : null
+	clone.metadata           = LAZYLEN(metadata)?       listDeepClone(metadata, TRUE) : null
 	return clone
 
 /obj/item/paper/Clone()

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -459,16 +459,11 @@
 	LAZYADD(., /decl/interaction_handler/rename/paper_bundle)
 	LAZYADD(., /decl/interaction_handler/unbundle/paper_bundle)
 
-/obj/item/paper_bundle/Clone(obj/item/paper_bundle/copy_instance = null)
-	if(!copy_instance)
-		copy_instance = new type(null, material)
-	copy_instance = ..(copy_instance) //Calls update_icon()
-
+/obj/item/paper_bundle/PopulateClone(obj/item/paper_bundle/clone)
+	clone = ..()
 	for(var/obj/item/I in pages)
-		copy_instance.merge(I.Clone())
-		
-	return copy_instance
-
+		clone.merge(I.Clone())
+	return clone
 
 /obj/item/paper_bundle/verb/rename()
 	set name = "Rename Bundle"

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -459,18 +459,16 @@
 	LAZYADD(., /decl/interaction_handler/rename/paper_bundle)
 	LAZYADD(., /decl/interaction_handler/unbundle/paper_bundle)
 
-/obj/item/paper_bundle/proc/Clone()
-	var/obj/item/paper_bundle/copy = new
+/obj/item/paper_bundle/Clone(obj/item/paper_bundle/copy_instance = null)
+	if(!copy_instance)
+		copy_instance = new type(null, material)
+	copy_instance = ..(copy_instance) //Calls update_icon()
+
 	for(var/obj/item/I in pages)
-		if(istype(I, /obj/item/paper))
-			var/obj/item/paper/P = I
-			copy.merge(P.Clone())
-		else if(istype(I, /obj/item/photo))
-			var/obj/item/photo/Ph = I
-			copy.merge(Ph.Clone())
-		else
-			CRASH("Tried to clone a bundle with an invalid item type inside '[I.type]'")
-	return copy
+		copy_instance.merge(I.Clone())
+		
+	return copy_instance
+
 
 /obj/item/paper_bundle/verb/rename()
 	set name = "Rename Bundle"

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -251,7 +251,7 @@
 
 /**Creates a clone of the specified item. Returns a list of cloned items. */
 /obj/machinery/photocopier/proc/scan_item(var/obj/item/I)
-	LAZYADD(., clone_paper_work_item(I))
+	LAZYADD(., I.Clone())
 
 /**Check if the amount of toner and paper are available */
 /obj/machinery/photocopier/proc/has_enough_to_print(var/req_toner = TONER_USAGE_PAPER, var/req_paper = 1)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -80,11 +80,13 @@
 		scribble = _scribble
 	update_icon()
 
-/obj/item/photo/Clone(obj/item/photo/copy_instance = null)
-	if(!copy_instance)
-		copy_instance = new type(null, material, img, scribble)
-	copy_instance.photo_size = photo_size
-	return ..(copy_instance) //Calls update_icon()
+/obj/item/photo/GetCloneArgs()
+	return list(null, material, img, scribble)
+
+/obj/item/photo/PopulateClone(obj/item/photo/clone)
+	clone = ..()
+	clone.photo_size = photo_size
+	return clone
 
 /obj/item/photo/attack_self(mob/user)
 	user.examinate(src)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -80,11 +80,11 @@
 		scribble = _scribble
 	update_icon()
 
-/obj/item/photo/proc/Clone()
-	var/obj/item/photo/copy = new(null, null, img, scribble)
-	copy.photo_size = photo_size
-	copy.update_icon()
-	return copy
+/obj/item/photo/Clone(obj/item/photo/copy_instance = null)
+	if(!copy_instance)
+		copy_instance = new type(null, material, img, scribble)
+	copy_instance.photo_size = photo_size
+	return ..(copy_instance) //Calls update_icon()
 
 /obj/item/photo/attack_self(mob/user)
 	user.examinate(src)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -26,17 +26,18 @@ var/global/obj/temp_reagents_holder = new
 			my_atom.reagents = null
 		my_atom = null
 
-//Don't forget to call set_holder() after getting the copy!
-/datum/reagents/Clone(datum/reagents/copy_instance = null)
-	if(!copy_instance)
-		copy_instance = new type(maximum_volume, global.temp_reagents_holder)
-	copy_instance = ..(copy_instance)
+/datum/reagents/GetCloneArgs()
+	return list(maximum_volume, global.temp_reagents_holder) //Always clone with the dummy holder to prevent things being done on the owner atom
 
-	for(var/rtype in reagent_volumes)
-		var/list/rdata = LAZYACCESS(reagent_data, rtype)
-		copy_instance.add_reagent(rtype, reagent_volumes[rtype], rdata?.Copy(), TRUE, TRUE)
-	copy_instance.handle_update(TRUE) //No reacting
-	return copy_instance
+//Don't forget to call set_holder() after getting the copy!
+/datum/reagents/PopulateClone(datum/reagents/clone)
+	clone.primary_reagent = primary_reagent
+	clone.reagent_volumes = listdeeperCopy(reagent_volumes)
+	clone.reagent_data    = listdeeperCopy(reagent_data)
+	clone.total_volume    = total_volume
+	clone.maximum_volume  = maximum_volume
+	clone.cached_color    = cached_color
+	return clone
 
 /datum/reagents/proc/get_reaction_loc()
 	return my_atom
@@ -176,8 +177,10 @@ var/global/obj/temp_reagents_holder = new
 	if(my_atom)
 		my_atom.on_reagent_change()
 
-///Set and call updates on the target holder. 
+///Set and call updates on the target holder.
 /datum/reagents/proc/set_holder(var/obj/new_holder)
+	if(my_atom == new_holder)
+		return
 	my_atom = new_holder
 	if(my_atom)
 		my_atom.on_reagent_change()

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -26,6 +26,18 @@ var/global/obj/temp_reagents_holder = new
 			my_atom.reagents = null
 		my_atom = null
 
+//Don't forget to call set_holder() after getting the copy!
+/datum/reagents/Clone(datum/reagents/copy_instance = null)
+	if(!copy_instance)
+		copy_instance = new type(maximum_volume, global.temp_reagents_holder)
+	copy_instance = ..(copy_instance)
+
+	for(var/rtype in reagent_volumes)
+		var/list/rdata = LAZYACCESS(reagent_data, rtype)
+		copy_instance.add_reagent(rtype, reagent_volumes[rtype], rdata?.Copy(), TRUE, TRUE)
+	copy_instance.handle_update(TRUE) //No reacting
+	return copy_instance
+
 /datum/reagents/proc/get_reaction_loc()
 	return my_atom
 
@@ -164,8 +176,14 @@ var/global/obj/temp_reagents_holder = new
 	if(my_atom)
 		my_atom.on_reagent_change()
 
-/datum/reagents/proc/add_reagent(var/reagent_type, var/amount, var/data = null, var/safety = 0, var/defer_update = FALSE)
+///Set and call updates on the target holder. 
+/datum/reagents/proc/set_holder(var/obj/new_holder)
+	my_atom = new_holder
+	if(my_atom)
+		my_atom.on_reagent_change()
+	handle_update()
 
+/datum/reagents/proc/add_reagent(var/reagent_type, var/amount, var/data = null, var/safety = 0, var/defer_update = FALSE)
 	amount = NONUNIT_FLOOR(min(amount, REAGENTS_FREE_SPACE(src)), MINIMUM_CHEMICAL_VOLUME)
 	if(amount <= 0)
 		return FALSE

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -32,8 +32,8 @@ var/global/obj/temp_reagents_holder = new
 //Don't forget to call set_holder() after getting the copy!
 /datum/reagents/PopulateClone(datum/reagents/clone)
 	clone.primary_reagent = primary_reagent
-	clone.reagent_volumes = listdeeperCopy(reagent_volumes)
-	clone.reagent_data    = listdeeperCopy(reagent_data)
+	clone.reagent_volumes = listDeeperCopy(reagent_volumes)
+	clone.reagent_data    = listDeeperCopy(reagent_data)
 	clone.total_volume    = total_volume
 	clone.maximum_volume  = maximum_volume
 	clone.cached_color    = cached_color

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -32,7 +32,7 @@ var/global/obj/temp_reagents_holder = new
 //Don't forget to call set_holder() after getting the copy!
 /datum/reagents/PopulateClone(datum/reagents/clone)
 	clone.primary_reagent = primary_reagent
-	clone.reagent_volumes = reagent_volumes.Copy()
+	clone.reagent_volumes = reagent_volumes?.Copy()
 	clone.reagent_data    = listDeepClone(reagent_data, TRUE)
 	clone.total_volume    = total_volume
 	clone.maximum_volume  = maximum_volume

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -32,8 +32,8 @@ var/global/obj/temp_reagents_holder = new
 //Don't forget to call set_holder() after getting the copy!
 /datum/reagents/PopulateClone(datum/reagents/clone)
 	clone.primary_reagent = primary_reagent
-	clone.reagent_volumes = listDeeperCopy(reagent_volumes)
-	clone.reagent_data    = listDeeperCopy(reagent_data)
+	clone.reagent_volumes = reagent_volumes.Copy()
+	clone.reagent_data    = listDeepClone(reagent_data, TRUE)
 	clone.total_volume    = total_volume
 	clone.maximum_volume  = maximum_volume
 	clone.cached_color    = cached_color

--- a/nebula.dme
+++ b/nebula.dme
@@ -284,6 +284,7 @@
 #include "code\datums\suit_sensor_jammer_method.dm"
 #include "code\datums\sun.dm"
 #include "code\datums\track.dm"
+#include "code\datums\type_cloning.dm"
 #include "code\datums\weakref.dm"
 #include "code\datums\ai\ai.dm"
 #include "code\datums\ai\ai_holo.dm"


### PR DESCRIPTION
## Description of changes
Depends on #2552. 
Implement the Clone() proc at the datum level, so it can be standardized and used across all entities as needed.
This is mainly a stub implementation mainly for paperwork items, reagent datum, dna datum, and other datum that used a proc named clone() in order to keep things coherent.

## Why and what will this PR improve
Allow a standardized and overridable way to clone datums/objects. As discussed on #2552.
