### PR TITLE
Fixes for mob offset adjustment procs.

### DIFF
--- a/code/game/objects/item_mob_overlay.dm
+++ b/code/game/objects/item_mob_overlay.dm
@@ -1,6 +1,6 @@
-// This is a temporary workaround for the slot => bodypart 
-// changes. In the long term this should be removed after 
-// all the `slot_l/r_hand-foo` states are renamed to just 
+// This is a temporary workaround for the slot => bodypart
+// changes. In the long term this should be removed after
+// all the `slot_l/r_hand-foo` states are renamed to just
 // `l/r_hand-foo`. TODO: check if this is still here in 2025.
 var/global/list/bodypart_to_slot_lookup_table = list(
 	BP_L_HAND = "slot_l_hand",
@@ -25,7 +25,7 @@ var/global/list/bodypart_to_slot_lookup_table = list(
 var/global/list/icon_state_cache = list()
 /proc/check_state_in_icon(var/checkstate, var/checkicon, var/high_accuracy = FALSE)
 	// isicon() is apparently quite expensive so short-circuit out early if we can.
-	if(!istext(checkstate) || isnull(checkicon) || !(isfile(checkicon) || isicon(checkicon))) 
+	if(!istext(checkstate) || isnull(checkicon) || !(isfile(checkicon) || isicon(checkicon)))
 		return FALSE
 	var/checkkey = "\ref[checkicon]"
 	var/list/check = global.icon_state_cache[checkkey]
@@ -106,10 +106,13 @@ var/global/list/icon_state_cache = list()
 /obj/item/proc/get_icon_for_bodytype(var/bodytype)
 	. = LAZYACCESS(sprite_sheets, bodytype) || icon
 
+// Ensure ..() is called only at the end of this proc, and that `overlay` is mutated rather than replaced.
+// This is necessary to ensure that all the overlays are generated and tracked prior to being passed to
+// the bodytype offset proc, which can scrub icon/icon_state information as part of the offset process.
 /obj/item/proc/adjust_mob_overlay(var/mob/living/user_mob, var/bodytype,  var/image/overlay, var/slot, var/bodypart)
 	if(ishuman(user_mob))
 		var/mob/living/carbon/human/H = user_mob
-		if(H.get_bodytype_category() != bodytype) 
+		if(H.get_bodytype_category() != bodytype)
 			var/list/overlays_to_offset = overlay.overlays
 			overlay = H.bodytype.get_offset_overlay_image(FALSE, overlay.icon, overlay.icon_state, color, (bodypart || slot))
 			for(var/thing in overlays_to_offset)

--- a/code/game/objects/items/umbrella.dm
+++ b/code/game/objects/items/umbrella.dm
@@ -29,10 +29,9 @@
 /obj/item/umbrella/on_update_icon()
 	icon_state = get_world_inventory_state()
 	if(is_open)
-		icon_state = "[icon_state]-open" 
+		icon_state = "[icon_state]-open"
 
 /obj/item/umbrella/adjust_mob_overlay(mob/living/user_mob, bodytype, image/overlay, slot, bodypart)
-	. = ..()
 	if(overlay && is_open && check_state_in_icon("[overlay.icon_state]-open", overlay.icon))
 		overlay.icon_state = "[overlay.icon_state]-open"
-	return overlay
+	return ..()

--- a/code/game/objects/items/weapons/melee/energy_sword.dm
+++ b/code/game/objects/items/weapons/melee/energy_sword.dm
@@ -12,7 +12,7 @@
 		COLOR_LIME =   COLOR_SABER_GREEN,
 		COLOR_VIOLET = COLOR_SABER_PURPLE
 	)
-	
+
 /obj/item/energy_blade/sword/Initialize()
 	if(!blade_color)
 		blade_color = pick(blade_colors)
@@ -44,11 +44,11 @@
 		add_overlay(I)
 
 /obj/item/energy_blade/sword/adjust_mob_overlay(mob/living/user_mob, bodytype, image/overlay, slot, bodypart)
-	. = ..()
 	if(overlay && active && check_state_in_icon("[overlay.icon_state]-extended-glow", overlay.icon))
 		var/image/I = emissive_overlay(overlay.icon, "[overlay.icon_state]-extended-glow")
 		I.color = blade_color
 		overlay.overlays += I
+	return ..()
 
 // Subtypes
 /obj/item/energy_blade/sword/green

--- a/code/modules/clothing/gloves/thick.dm
+++ b/code/modules/clothing/gloves/thick.dm
@@ -13,11 +13,11 @@
 	icon_state = ICON_STATE_WORLD
 	force = 5
 	armor = list(
-		melee = ARMOR_MELEE_RESISTANT, 
-		bullet = ARMOR_BALLISTIC_PISTOL, 
+		melee = ARMOR_MELEE_RESISTANT,
+		bullet = ARMOR_BALLISTIC_PISTOL,
 		laser = ARMOR_LASER_HANDGUNS,
-		energy = ARMOR_ENERGY_SMALL, 
-		bomb = ARMOR_BOMB_RESISTANT, 
+		energy = ARMOR_ENERGY_SMALL,
+		bomb = ARMOR_BOMB_RESISTANT,
 		bio = ARMOR_BIO_MINOR)
 	material = /decl/material/solid/leather
 
@@ -46,11 +46,11 @@
 	overlays = list(I)
 
 /obj/item/clothing/gloves/thick/botany/adjust_mob_overlay(var/mob/living/user_mob, var/bodytype,  var/image/overlay, var/slot, var/bodypart)
-	. = ..()
 	if(overlay && slot == slot_gloves_str)
 		var/image/I = image(overlay.icon, "[overlay.icon_state]-botany_fingertips")
 		I.appearance_flags |= RESET_COLOR
 		overlay.overlays += I
+	return ..()
 
 /obj/item/clothing/gloves/thick/duty
 	desc = "These brown duty gloves are made from a durable synthetic."

--- a/code/modules/species/species_bodytype_offsets.dm
+++ b/code/modules/species/species_bodytype_offsets.dm
@@ -33,6 +33,7 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 			var/icon/final_I = new(icon_template)
 			var/list/shifts = equip_adjust[slot]
 
+			// TODO: consider adding all icons offset from the same base icon to the same cached icon.
 			// Apply all pixel shifts for each direction.
 			for(var/shift_facing in shifts)
 				var/list/facing_list = shifts[shift_facing]
@@ -40,8 +41,10 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 				var/icon/equip = new(mob_icon, icon_state = mob_state, dir = use_dir)
 				var/icon/canvas = new(icon_template)
 				canvas.Blend(equip, ICON_OVERLAY, facing_list["x"]+1, facing_list["y"]+1)
-				final_I.Insert(canvas, dir = use_dir)
-			equip_overlays[image_key] = overlay_image(final_I, color = color, flags = RESET_COLOR)
+				final_I.Insert(canvas, mob_state, dir = use_dir)
+
+			equip_overlays[image_key] = overlay_image(final_I, mob_state, color = color, flags = RESET_COLOR)
+
 		var/image/I = new() // We return a copy of the cached image, in case downstream procs mutate it.
 		I.appearance = equip_overlays[image_key]
 		return I

--- a/code/modules/species/species_bodytype_offsets.dm
+++ b/code/modules/species/species_bodytype_offsets.dm
@@ -19,33 +19,27 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 
 /decl/bodytype
 	var/list/equip_adjust = list()
-	var/list/equip_overlays = list()
+	var/list/equip_icons =  list()
 
 /decl/bodytype/proc/get_offset_overlay_image(var/spritesheet, var/mob_icon, var/mob_state, var/color, var/slot)
-
 	// If we don't actually need to offset this, don't bother with any of the generation/caching.
 	if(!spritesheet && length(equip_adjust) && equip_adjust[slot] && length(equip_adjust[slot]))
-
-		// Check the cache for previously made icons.
-		var/image_key = "[mob_icon]-[mob_state]-[color]-[slot]"
-		if(!equip_overlays[image_key])
-
-			var/icon/final_I = new(icon_template)
+		// Grab our collected offsets for this base icon.
+		var/icon/offset_icon = equip_icons[mob_icon]
+		// If we haven't gone one yet, generate a blank one.
+		if(!offset_icon)
+			offset_icon = new(icon_template)
+			equip_icons[mob_icon] = offset_icon
+		// If we haven't got this state yet, generate and insert it.
+		if(!check_state_in_icon(mob_state, offset_icon) && check_state_in_icon(mob_state, mob_icon))
 			var/list/shifts = equip_adjust[slot]
-
-			// TODO: consider adding all icons offset from the same base icon to the same cached icon.
-			// Apply all pixel shifts for each direction.
 			for(var/shift_facing in shifts)
 				var/list/facing_list = shifts[shift_facing]
 				var/use_dir = text2num(shift_facing)
 				var/icon/equip = new(mob_icon, icon_state = mob_state, dir = use_dir)
 				var/icon/canvas = new(icon_template)
 				canvas.Blend(equip, ICON_OVERLAY, facing_list["x"]+1, facing_list["y"]+1)
-				final_I.Insert(canvas, mob_state, dir = use_dir)
-
-			equip_overlays[image_key] = overlay_image(final_I, mob_state, color = color, flags = RESET_COLOR)
-
-		var/image/I = new() // We return a copy of the cached image, in case downstream procs mutate it.
-		I.appearance = equip_overlays[image_key]
-		return I
+				offset_icon.Insert(canvas, mob_state, dir = use_dir)
+		// Replace our mob icon with the offset icon.
+		mob_icon = offset_icon
 	return overlay_image(mob_icon, mob_state, color, RESET_COLOR)


### PR DESCRIPTION
## Description of changes
- Makes offset procs call ..() last.
- Reworks the bodytype offset proc so it collects overlays in the same icon and preserves state information.
 
## Why and what will this PR improve
Fixes issues with offset icons losing access to icon and icon_state information useful for applying mob overlays.

## Authorship
Myself.

## Changelog
Nothing player-facing.