### PR TITLE
Streamlining radio and ID creation for antags.

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -68,7 +68,6 @@
 	// ID card stuff.
 	var/default_access = list()
 	var/id_title
-	var/id_type = /obj/item/card/id
 	var/rig_type
 
 	var/default_outfit

--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -28,33 +28,6 @@
 	add_antagonist(M.mind, 1, 0, 1) // Equip them and move them to spawn.
 	return M
 
-/decl/special_role/proc/create_id(var/mob/living/carbon/human/player, var/equip = TRUE)
-	if(!id_title || !id_type)
-		return
-	var/obj/item/card/id/W = new id_type(player)
-	if(length(default_access))
-		W.access |= default_access
-	W.assignment = id_title
-	player.set_id_info(W)
-	if(equip)
-		player.equip_to_slot_or_del(W, slot_wear_id_str)
-	return W
-
-/decl/special_role/proc/create_radio(var/freq, var/mob/living/carbon/human/player)
-	var/obj/item/radio/R
-
-	switch(freq)
-		if(SYND_FREQ)
-			R = new/obj/item/radio/headset/syndicate(player)
-		if(RAID_FREQ)
-			R = new/obj/item/radio/headset/raider(player)
-		else
-			R = new/obj/item/radio/headset(player)
-			R.set_frequency(freq)
-
-	player.equip_to_slot_or_del(R, slot_l_ear_str)
-	return R
-
 /decl/special_role/proc/create_nuke(var/atom/paper_spawn_loc, var/datum/mind/code_owner)
 
 	// Decide on a code.

--- a/code/game/antagonist/antagonist_equip.dm
+++ b/code/game/antagonist/antagonist_equip.dm
@@ -4,7 +4,7 @@
 
 	if(!istype(player))
 		return FALSE
-	
+
 	if (required_language)
 		player.add_language(required_language)
 		player.set_default_language(required_language)
@@ -21,19 +21,21 @@
 		var/decl/hierarchy/outfit/outfit = GET_DECL(default_outfit)
 		outfit.equip(player)
 
-	create_id(player)
+	if(default_access)
+		var/obj/item/card/id/id = player.get_equipped_item(slot_wear_id_str)
+		if(id)
+			LAZYDISTINCTADD(id.access, default_access)
+
 	if(rig_type)
 		equip_rig(rig_type, player)
 
 	return TRUE
 
 /decl/special_role/proc/unequip(var/mob/living/carbon/human/player)
-	if(!istype(player))
-		return 0
-	return 1
+	return istype(player)
 
 /decl/special_role/proc/equip_rig(var/rig_type, var/mob/living/carbon/human/player)
-	set waitfor = 0
+	set waitfor = FALSE
 	if(istype(player) && ispath(rig_type))
 		var/obj/item/rig/rig = new rig_type(player)
 		rig.seal_delay = 0
@@ -45,4 +47,4 @@
 			rig.seal_delay = initial(rig.seal_delay)
 			if(rig.air_supply)
 				player.set_internals(rig.air_supply)
-		return rig 
+		return rig

--- a/code/game/antagonist/outsider/actors.dm
+++ b/code/game/antagonist/outsider/actors.dm
@@ -3,7 +3,6 @@
 	name_plural = "Actors"
 	welcome_text = "You've been hired to entertain people through the power of television!"
 	landmark_id = "ActorSpawn"
-	id_type = /obj/item/card/id/syndicate
 
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB | ANTAG_SET_APPEARANCE | ANTAG_CHOOSE_NAME | ANTAG_RANDOM_EXCEPTED
 
@@ -21,6 +20,7 @@
 	uniform = /obj/item/clothing/under/chameleon
 	shoes =   /obj/item/clothing/shoes/chameleon
 	l_ear =   /obj/item/radio/headset/entertainment
+	id_type = /obj/item/card/id/syndicate
 
 /decl/special_role/actor/greet(var/datum/mind/player)
 	if(!..())

--- a/code/game/antagonist/outsider/ert.dm
+++ b/code/game/antagonist/outsider/ert.dm
@@ -10,22 +10,22 @@
 	welcome_text = "You shouldn't see this"
 	leader_welcome_text = "You shouldn't see this"
 	landmark_id = "Response Team"
-	id_type = /obj/item/card/id/centcom/ERT
 
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB | ANTAG_SET_APPEARANCE | ANTAG_HAS_LEADER | ANTAG_CHOOSE_NAME | ANTAG_RANDOM_EXCEPTED
 	antaghud_indicator = "hudloyalist"
+	default_access = list(access_cent_specops)
 
 	hard_cap = 5
 	hard_cap_round = 7
 	initial_spawn_req = 5
 	initial_spawn_target = 7
 	show_objectives_on_creation = 0 //we are not antagonists, we do not need the antagonist shpiel/objectives
-
+	default_outfit = /decl/hierarchy/outfit/ert
 	base_to_load = "ERT Base"
 
 /decl/special_role/ert/create_default(var/mob/source)
 	var/mob/living/carbon/human/M = ..()
-	if(istype(M)) 
+	if(istype(M))
 		M.set_age(rand(25,45))
 
 /decl/special_role/ert/Initialize()

--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -13,7 +13,7 @@
 	initial_spawn_req = 4
 	initial_spawn_target = 6
 	min_player_age = 14
-	default_access = list(access_hacked, access_mercenary)
+	default_access = list(access_mercenary)
 
 	faction = "mercenary"
 

--- a/code/game/antagonist/outsider/ninja.dm
+++ b/code/game/antagonist/outsider/ninja.dm
@@ -5,24 +5,21 @@
 	welcome_text = "<span class='info'>You are an elite mercenary assassin of the Spider Clan. You have a variety of abilities at your disposal, thanks to your nano-enhanced cyber armor.</span>"
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_RANDSPAWN | ANTAG_VOTABLE | ANTAG_SET_APPEARANCE
 	antaghud_indicator = "hudninja"
-
 	initial_spawn_req = 1
 	initial_spawn_target = 1
 	hard_cap = 1
 	hard_cap_round = 3
 	min_player_age = 18
-
-	id_type = /obj/item/card/id/syndicate
-
+	default_access = list(access_ninja)
 	faction = "ninja"
 	base_to_load = "Ninja Base"
-
 	default_outfit = /decl/hierarchy/outfit/ninja
 	id_title = "Infiltrator"
 	rig_type = /obj/item/rig/light/ninja
 
 /decl/special_role/ninja/attempt_random_spawn()
-	if(config.ninjas_allowed) ..()
+	if(config.ninjas_allowed)
+		..()
 
 /decl/special_role/ninja/create_objectives(var/datum/mind/ninja)
 
@@ -99,6 +96,7 @@
 	uniform = /obj/item/clothing/under/color/black
 	belt =    /obj/item/flashlight
 	hands =   list(/obj/item/modular_computer/pda/ninja)
+	id_type = /obj/item/card/id/syndicate
 
 /decl/special_role/ninja/equip(var/mob/living/carbon/human/player)
 	. = ..()

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -5,7 +5,7 @@
 	welcome_text = "You will find a list of available spells in your spell book. Choose your magic arsenal carefully.<br>In your pockets you will find a teleport scroll. Use it as needed."
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_VOTABLE | ANTAG_SET_APPEARANCE
 	antaghud_indicator = "hudwizard"
-
+	default_access = list(access_wizard)
 	hard_cap = 1
 	hard_cap_round = 3
 	initial_spawn_req = 1

--- a/maps/antag_spawn/heist/heist_antag.dm
+++ b/maps/antag_spawn/heist/heist_antag.dm
@@ -6,16 +6,12 @@
 	welcome_text = "Use :H to talk on your encrypted channel."
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB | ANTAG_CLEAR_EQUIPMENT | ANTAG_CHOOSE_NAME | ANTAG_VOTABLE | ANTAG_SET_APPEARANCE | ANTAG_HAS_LEADER
 	antaghud_indicator = "hudraider"
-
 	hard_cap = 6
 	hard_cap_round = 10
 	initial_spawn_req = 4
 	initial_spawn_target = 6
 	min_player_age = 14
-
-	id_type = /obj/item/card/id/syndicate
-	default_access = list(access_hacked, access_raider)
-
+	default_access = list(access_raider)
 	faction = "pirate"
 	base_to_load = "Heist Base"
 	default_outfit = /decl/hierarchy/outfit/raider
@@ -68,18 +64,6 @@
 			return 0
 	return 1
 
-/decl/special_role/raider/create_id(mob/living/carbon/human/player, equip)
-	var/obj/item/card/id/id = ..()
-	if(player && id)
-		var/obj/item/storage/wallet/W = new(player)
-		W.handle_item_insertion(id)
-		if(player.equip_to_slot_or_del(W, slot_wear_id_str))
-			var/obj/item/cash/cash = new(get_turf(player))
-			cash.adjust_worth(rand(50,150)*10)
-			player.put_in_hands(cash)
-
 /decl/special_role/raider/equip(var/mob/living/carbon/human/player)
 	default_outfit = LAZYACCESS(outfits_per_species, player.species.name) || initial(default_outfit)
 	. = ..()
-	if(.)
-		create_radio(RAID_FREQ, player)

--- a/maps/antag_spawn/heist/heist_outfit.dm
+++ b/maps/antag_spawn/heist/heist_outfit.dm
@@ -1,5 +1,7 @@
 /decl/hierarchy/outfit/raider
 	name =    "Special Role - Raider"
+	l_ear = /obj/item/radio/headset/raider
+	id_type = /obj/item/card/id/syndicate
 	var/list/raider_uniforms = list(
 		/obj/item/clothing/under/soviet,
 		/obj/item/clothing/under/pirate,

--- a/mods/content/corporate/datum/antagonists/commando.dm
+++ b/mods/content/corporate/datum/antagonists/commando.dm
@@ -3,24 +3,20 @@
 	name = "Syndicate Commando"
 	name_plural = "Commandos"
 	welcome_text = "You are in the employ of a criminal syndicate hostile to corporate interests."
-	id_type = /obj/item/card/id/centcom/ERT
 	flags = ANTAG_RANDOM_EXCEPTED
-
 	hard_cap = 4
 	hard_cap_round = 8
 	initial_spawn_req = 4
 	initial_spawn_target = 6
 	default_outfit = /decl/hierarchy/outfit/mercenary_commando
+	default_access = list(access_mercenary)
 	rig_type = /obj/item/rig/merc
 	id_title = "Commando"
 
-/decl/special_role/deathsquad/mercenary/equip(var/mob/living/carbon/human/player)
-	. = ..()
-	if(.)
-		create_radio(SYND_FREQ, player)
-
 /decl/hierarchy/outfit/mercenary_commando
 	name =    "Special Role - Mercenary Commando"
+	l_ear =   /obj/item/radio/headset/syndicate
+	id_type = /obj/item/card/id/centcom/ERT
 	uniform = /obj/item/clothing/under/syndicate
 	shoes =   /obj/item/clothing/shoes/jackboots/swat
 	glasses = /obj/item/clothing/glasses/thermal

--- a/mods/content/corporate/datum/antagonists/deathsquad.dm
+++ b/mods/content/corporate/datum/antagonists/deathsquad.dm
@@ -11,6 +11,7 @@
 		access_cent_storage
 	)
 	antaghud_indicator = "huddeathsquad"
+	default_access = list(access_cent_specops)
 
 	hard_cap = 4
 	hard_cap_round = 8
@@ -28,6 +29,7 @@
 
 /decl/hierarchy/outfit/commando
 	name =     "Special Role - Deathsquad Commando"
+	l_ear =    /obj/item/radio/headset/deathsquad
 	uniform =  /obj/item/clothing/under/color/green
 	l_pocket = /obj/item/plastique
 	shoes =    /obj/item/clothing/shoes/jackboots/swat
@@ -53,13 +55,14 @@
 	. = ..()
 	if(.)
 		player.implant_loyalty(player)
-		create_radio(DTH_FREQ, player)
 
-/decl/special_role/deathsquad/create_id(mob/living/carbon/human/player, equip)
-	var/obj/item/card/id/id = ..()
-	if(player && id)
-		id.access |= get_all_station_access()
-		id.icon_state = "centcom"
+/obj/item/radio/headset/deathsquad
+	origin_tech = "{'esoteric':2}"
+	syndie = 1
+
+/obj/item/radio/headset/deathsquad/Initialize()
+	. = ..()
+	set_frequency(DTH_FREQ)
 
 /decl/special_role/deathsquad/update_antag_mob(var/datum/mind/player)
 

--- a/mods/content/psionics/datum/antagonists/foundation.dm
+++ b/mods/content/psionics/datum/antagonists/foundation.dm
@@ -22,7 +22,6 @@
 	initial_spawn_target = 2
 	min_player_age = 14
 	faction = "foundation"
-	id_type = /obj/item/card/id/foundation
 	default_outfit = /decl/hierarchy/outfit/foundation
 	id_title = "Foundation Agent"
 
@@ -43,4 +42,5 @@
 	hands =    list(/obj/item/storage/briefcase/foundation)
 	l_ear =    /obj/item/radio/headset/foundation
 	holster =  /obj/item/clothing/accessory/storage/holster/armpit
+	id_type = /obj/item/card/id/foundation
 	id_slot =  slot_wear_id_str

--- a/mods/content/psionics/datum/antagonists/paramount.dm
+++ b/mods/content/psionics/datum/antagonists/paramount.dm
@@ -10,7 +10,6 @@
 	hard_cap = 1
 	hard_cap_round = 3
 	min_player_age = 18
-	id_type = /obj/item/card/id/syndicate
 	faction = "paramount"
 	default_outfit = /decl/hierarchy/outfit/paramount
 
@@ -22,6 +21,7 @@
 	shoes =   /obj/item/clothing/shoes/jackboots
 	back =    /obj/item/storage/backpack/satchel
 	gloves =  /obj/item/clothing/gloves/color/grey
+	id_type = /obj/item/card/id/syndicate
 
 /decl/special_role/paramount/equip(var/mob/living/carbon/human/player)
 	. = ..()

--- a/mods/species/vox/datum/antagonism.dm
+++ b/mods/species/vox/datum/antagonism.dm
@@ -4,6 +4,7 @@
 
 /decl/hierarchy/outfit/vox_raider
 	name = "Job - Vox Raider"
+	l_ear =      /obj/item/radio/headset/raider
 	shoes =      /obj/item/clothing/shoes/magboots/vox
 	gloves =     /obj/item/clothing/gloves/vox
 	mask =       /obj/item/clothing/mask/gas/swat/vox
@@ -13,6 +14,7 @@
 	holster =    /obj/item/clothing/accessory/storage/holster/armpit
 	suit_store = /obj/item/flashlight
 	hands =      list(/obj/item/gun/launcher/alien/spikethrower)
+	id_type =    /obj/item/card/id/syndicate
 
 /decl/hierarchy/outfit/vox_raider/equip(mob/living/carbon/human/H, rank, assignment, equip_adjustments)
 	uniform = pick(/obj/item/clothing/under/vox/vox_robes, /obj/item/clothing/under/vox/vox_casual)


### PR DESCRIPTION
## Description of changes
ID and radio are now handled by outfit, with the special role adding access post-equip.
Split off from the tcomms PR, and is a dependency for it.

## Why and what will this PR improve
Streamlines and simplifies radios and access, makes it more consistent.

## Authorship
Myself.

## Changelog
Nothing player-facing.
