### PR TITLE
Unified storage contents init

### DIFF
--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -393,11 +393,13 @@ var/global/bomb_set
 //====the nuclear football (holds the disk and instructions)====
 /obj/item/storage/secure/briefcase/nukedisk
 	desc = "A large briefcase with a digital locking system."
-	startswith = list(
+
+/obj/item/storage/secure/briefcase/WillContain()
+	return list(
 		/obj/item/disk/nuclear,
 		/obj/item/pinpointer,
 		/obj/item/folder/envelope/nuke_instructions,
-		/obj/item/modular_computer/laptop/preset/custom_loadout/cheap/
+		/obj/item/modular_computer/laptop/preset/custom_loadout/cheap
 	)
 
 /obj/item/storage/secure/briefcase/nukedisk/examine(mob/user)

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -394,7 +394,7 @@ var/global/bomb_set
 /obj/item/storage/secure/briefcase/nukedisk
 	desc = "A large briefcase with a digital locking system."
 
-/obj/item/storage/secure/briefcase/WillContain()
+/obj/item/storage/secure/briefcase/nukedisk/WillContain()
 	return list(
 		/obj/item/disk/nuclear,
 		/obj/item/pinpointer,

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -17,9 +17,9 @@
 	name       = "body bags"
 	desc       = "This box contains body bags."
 	icon_state = "bodybags"
-	startswith = list(
-		/obj/item/bodybag = 7,
-	)
+
+/obj/item/storage/box/bodybags/WillContain()
+	return list(/obj/item/bodybag = 7)
 
 /obj/structure/closet/body_bag
 	name = "body bag"

--- a/code/game/objects/items/contraband.dm
+++ b/code/game/objects/items/contraband.dm
@@ -5,19 +5,25 @@
 	name = "bottle of Happy pills"
 	desc = "Highly illegal drug. When you want to see the rainbow."
 	wrapper_color = COLOR_PINK
-	startswith = list(/obj/item/chems/pill/happy = 10)
+
+/obj/item/storage/pill_bottle/happy/WillContain()
+	return list(/obj/item/chems/pill/happy = 10)
 
 /obj/item/storage/pill_bottle/zoom
 	name = "bottle of Zoom pills"
 	desc = "Highly illegal drug. Trade brain for speed."
 	wrapper_color = COLOR_BLUE
-	startswith = list(/obj/item/chems/pill/zoom = 10)
+
+/obj/item/storage/pill_bottle/zoom/WillContain()
+	return list(/obj/item/chems/pill/zoom = 10)
 
 /obj/item/storage/pill_bottle/gleam
 	name = "bottle of Gleam pills"
 	desc = "Highly illegal drug. Stimulates rarely used portions of the brain."
 	wrapper_color = COLOR_BLUE
-	startswith = list(/obj/item/chems/pill/gleam = 10)
+
+/obj/item/storage/pill_bottle/gleam/WillContain()
+	return list(/obj/item/chems/pill/gleam = 10)
 
 /obj/item/chems/glass/beaker/vial/random
 	atom_flags = 0

--- a/code/game/objects/items/weapons/candle/candle.dm
+++ b/code/game/objects/items/weapons/candle/candle.dm
@@ -87,4 +87,6 @@
 	max_storage_space = 7
 	slot_flags = SLOT_LOWER_BODY
 	material = /decl/material/solid/cardboard
-	startswith = list(/obj/item/flame/candle = 7)
+	
+/obj/item/storage/candle_box/WillContain()
+	return list(/obj/item/flame/candle = 7)

--- a/code/game/objects/items/weapons/candle/incense.dm
+++ b/code/game/objects/items/weapons/candle/incense.dm
@@ -22,4 +22,5 @@
 	icon_state = "incensebox"
 	max_storage_space = 9
 
-	startswith = list(/obj/item/flame/candle/scented/incense = 9)
+/obj/item/storage/candle_box/incense/WillContain()
+	return list(/obj/item/flame/candle/scented/incense = 9)

--- a/code/game/objects/items/weapons/candle/scented.dm
+++ b/code/game/objects/items/weapons/candle/scented.dm
@@ -43,4 +43,5 @@
 	desc = "An unbranded pack of scented candles, in a variety of scents."
 	max_storage_space = 5
 
-	startswith = list(/obj/item/flame/candle/scented = 5)
+/obj/item/storage/candle_box/scented/WillContain()
+	return list(/obj/item/flame/candle/scented = 5)

--- a/code/game/objects/items/weapons/secrets_disk.dm
+++ b/code/game/objects/items/weapons/secrets_disk.dm
@@ -67,7 +67,9 @@
 /obj/item/storage/box/secret_project_disks
 	name = "box of classified data disks"
 	desc = "A box full of disks. Marked with a red 'Top Secret' label. Looks rather ominous."
-	startswith = list(/obj/item/disk/secret_project = 5)
 
-/obj/item/storage/box/secret_project_disks/science
-	startswith = list(/obj/item/disk/secret_project/science = 5)
+/obj/item/storage/box/secret_project_disks/WillContain()
+	return list(/obj/item/disk/secret_project = 5)
+
+/obj/item/storage/box/secret_project_disks/science/WillContain()
+	return list(/obj/item/disk/secret_project/science = 5)

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -219,8 +219,8 @@
 	desc = "A large dufflebag for holding extra tools and supplies."
 	icon = 'icons/obj/items/storage/backpack/dufflebag_eng.dmi'
 
-/obj/item/storage/backpack/dufflebag/firefighter
-	startswith = list(
+/obj/item/storage/backpack/dufflebag/firefighter/WillContain()
+	return list(
 		/obj/item/storage/belt/fire_belt/full,
 		/obj/item/clothing/suit/fire,
 		/obj/item/extinguisher,
@@ -242,8 +242,8 @@
 /obj/item/storage/backpack/satchel/grey
 	name = "grey satchel"
 
-/obj/item/storage/backpack/satchel/grey/withwallet
-	startswith = list(/obj/item/storage/wallet/random)
+/obj/item/storage/backpack/satchel/grey/withwallet/WillContain()
+	return /obj/item/storage/wallet/random
 
 /obj/item/storage/backpack/satchel/leather //brown, master type
 	name = "brown leather satchel"
@@ -339,7 +339,9 @@
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = 15
 	cant_hold = list(/obj/item/storage/backpack/satchel/flat) //muh recursive backpacks
-	startswith = list(
+
+/obj/item/storage/backpack/satchel/flat/WillContain()
+	return list(
 		/obj/item/stack/tile/floor,
 		/obj/item/crowbar
 	)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -134,25 +134,25 @@
 		)
 	material = /decl/material/solid/leather
 
-/obj/item/storage/belt/utility/full/Initialize()
-	. = ..()
-	new /obj/item/screwdriver(src)
-	new /obj/item/wrench(src)
-	new /obj/item/weldingtool(src)
-	new /obj/item/crowbar(src)
-	new /obj/item/wirecutters(src)
-	new /obj/item/stack/cable_coil/random(src, 30)
-	update_icon()
+/obj/item/storage/belt/utility/full/WillContain()
+	return list(
+		/obj/item/screwdriver,
+		/obj/item/wrench,
+		/obj/item/weldingtool,
+		/obj/item/crowbar,
+		/obj/item/wirecutters,
+		/obj/item/stack/cable_coil/random,
+	)
 
-/obj/item/storage/belt/utility/atmostech/Initialize()
-	. = ..()
-	new /obj/item/screwdriver(src)
-	new /obj/item/wrench(src)
-	new /obj/item/weldingtool(src)
-	new /obj/item/crowbar(src)
-	new /obj/item/wirecutters(src)
-	new /obj/item/t_scanner(src)
-	update_icon()
+/obj/item/storage/belt/utility/atmostech/WillContain()
+	return list(
+		/obj/item/screwdriver,
+		/obj/item/wrench,
+		/obj/item/weldingtool,
+		/obj/item/crowbar,
+		/obj/item/wirecutters,
+		/obj/item/t_scanner,
+	)
 
 /obj/item/storage/belt/medical
 	name = "medical belt"
@@ -409,16 +409,8 @@
 		/obj/item/soulstone
 	)
 
-/obj/item/storage/belt/soulstone/full/Initialize()
-	. = ..()
-	new /obj/item/soulstone(src)
-	new /obj/item/soulstone(src)
-	new /obj/item/soulstone(src)
-	new /obj/item/soulstone(src)
-	new /obj/item/soulstone(src)
-	new /obj/item/soulstone(src)
-	new /obj/item/soulstone(src)
-
+/obj/item/storage/belt/soulstone/full/WillContain()
+	return list(/obj/item/soulstone = storage_slots)
 
 /obj/item/storage/belt/champion
 	name = "championship belt"
@@ -436,7 +428,7 @@
 	icon = 'icons/clothing/belt/swatbelt.dmi'
 	storage_slots = 10
 
-/obj/item/storage/belt/holster/security/tactical/Initialize()
+/obj/item/storage/belt/holster/security/tactical/Initialize(ml, material_key)
 	.=..()
 	LAZYSET(slowdown_per_slot, slot_belt_str, 1)
 
@@ -459,7 +451,7 @@
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = ITEM_SIZE_NORMAL * 4
 
-/obj/item/storage/belt/waistpack/big/Initialize()
+/obj/item/storage/belt/waistpack/big/Initialize(ml, material_key)
 	.=..()
 	LAZYSET(slowdown_per_slot, slot_belt_str, 1)
 
@@ -477,11 +469,9 @@
 		)
 	material = /decl/material/solid/fiberglass //need something that doesn't burn
 
-
-/obj/item/storage/belt/fire_belt/full
-	startswith = list(
-		/obj/item/inflatable,
-		/obj/item/inflatable,
+/obj/item/storage/belt/fire_belt/full/WillContain()
+	return list(
+		/obj/item/inflatable = 2,
 		/obj/item/inflatable/door,
 		/obj/item/extinguisher/mini,
 		/obj/item/grenade/chem_grenade/water = 2

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -14,7 +14,7 @@
 
 /obj/item/storage/bible/Initialize()
 	. = ..()
-	if(length(startswith))
+	if(length(contents))
 		make_exact_fit()
 
 /obj/item/storage/bible/booze
@@ -22,7 +22,8 @@
 	desc = "To be applied to the head repeatedly."
 	icon_state ="bible"
 
-	startswith = list(
+/obj/item/storage/bible/booze/WillContain()
+	return list(
 		/obj/item/chems/drinks/bottle/small/beer,
 		/obj/item/cash/c50,
 		/obj/item/cash/c50,

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -41,12 +41,16 @@
 /obj/item/storage/box/union_cards
 	name = "box of union cards"
 	desc = "A box of spare unsigned union membership cards."
-	startswith = list(/obj/item/card/union = 7)
+
+/obj/item/storage/box/union_cards/WillContain()
+	return list(/obj/item/card/union = 7)
 
 /obj/item/storage/box/large/union_cards
 	name = "large box of union cards"
 	desc = "A large box of spare unsigned union membership cards."
-	startswith = list(/obj/item/card/union = 14)
+
+/obj/item/storage/box/large/union_cards/WillContain()
+	return list(/obj/item/card/union = 14)
 
 // BubbleWrap - A box can be folded up to make card
 /obj/item/storage/box/attack_self(mob/user)
@@ -73,63 +77,85 @@
 	name = "crew survival kit"
 	desc = "A box decorated in warning colors that contains a limited supply of survival tools. The panel and white stripe indicate this one contains oxygen."
 	icon_state = "survival"
-	startswith = list(/obj/item/clothing/mask/breath = 1,
-					/obj/item/tank/emergency/oxygen = 1,
-					/obj/item/chems/hypospray/autoinjector = 1,
-					/obj/item/stack/medical/bruise_pack = 1,
-					/obj/item/flashlight/flare/glowstick = 1,
-					/obj/item/chems/food/candy/proteinbar = 1,
-					/obj/item/oxycandle = 1,
-					/obj/item/crowbar/cheap = 1)
+
+/obj/item/storage/box/survival/WillContain()
+	return list(
+				/obj/item/clothing/mask/breath,
+				/obj/item/tank/emergency/oxygen,
+				/obj/item/chems/hypospray/autoinjector,
+				/obj/item/stack/medical/bruise_pack,
+				/obj/item/flashlight/flare/glowstick,
+				/obj/item/chems/food/candy/proteinbar,
+				/obj/item/oxycandle,
+				/obj/item/crowbar/cheap
+			)
 
 /obj/item/storage/box/engineer
 	name = "engineer survival kit"
 	desc = "A box decorated in warning colors that contains a limited supply of survival tools. The panel and orange stripe indicate this one as the engineering variant."
 	icon_state = "survivaleng"
-	startswith = list(/obj/item/clothing/mask/breath/scba = 1,
-					/obj/item/tank/emergency/oxygen/engi = 1,
-					/obj/item/chems/hypospray/autoinjector = 1,
-					/obj/item/chems/hypospray/autoinjector/antirad = 1,
-					/obj/item/stack/medical/bruise_pack = 1,
-					/obj/item/flashlight/flare/glowstick = 1,
-					/obj/item/chems/food/candy/proteinbar = 1,
-					/obj/item/oxycandle = 1)
+
+/obj/item/storage/box/engineer/WillContain()
+	return list(
+				/obj/item/clothing/mask/breath/scba,
+				/obj/item/tank/emergency/oxygen/engi,
+				/obj/item/chems/hypospray/autoinjector,
+				/obj/item/chems/hypospray/autoinjector/antirad,
+				/obj/item/stack/medical/bruise_pack,
+				/obj/item/flashlight/flare/glowstick,
+				/obj/item/chems/food/candy/proteinbar,
+				/obj/item/oxycandle
+			)
 
 /obj/item/storage/box/gloves
 	name = "box of sterile gloves"
 	desc = "Contains sterile gloves."
 	icon_state = "latex"
-	startswith = list(/obj/item/clothing/gloves/latex = 5,
-					/obj/item/clothing/gloves/latex/nitrile = 2)
+
+/obj/item/storage/box/gloves/WillContain()
+	return list(
+				/obj/item/clothing/gloves/latex = 5,
+				/obj/item/clothing/gloves/latex/nitrile = 2
+			)
 
 /obj/item/storage/box/masks
 	name = "box of sterile masks"
 	desc = "This box contains masks of sterility."
 	icon_state = "sterile"
-	startswith = list(/obj/item/clothing/mask/surgical = 7)
+
+/obj/item/storage/box/masks/WillContain()
+	return list(/obj/item/clothing/mask/surgical = 7)
 
 
 /obj/item/storage/box/syringes
 	name = "box of syringes"
 	desc = "A box full of syringes."
 	icon_state = "syringe"
-	startswith = list(/obj/item/chems/syringe = 7)
+
+/obj/item/storage/box/syringes/WillContain()
+	return list(/obj/item/chems/syringe = 7)
 
 /obj/item/storage/box/syringegun
 	name = "box of syringe gun cartridges"
 	desc = "A box full of compressed gas cartridges."
 	icon_state = "syringe"
-	startswith = list(/obj/item/syringe_cartridge = 7)
+
+/obj/item/storage/box/syringegun/WillContain()
+	return list(/obj/item/syringe_cartridge = 7)
 
 
 /obj/item/storage/box/beakers
 	name = "box of beakers"
 	icon_state = "beaker"
-	startswith = list(/obj/item/chems/glass/beaker = 7)
+
+/obj/item/storage/box/beakers/WillContain()
+	return list(/obj/item/chems/glass/beaker = 7)
 
 /obj/item/storage/box/beakers/insulated
 	name = "box of insulated beakers"
-	startswith = list(/obj/item/chems/glass/beaker/insulated = 7)
+
+/obj/item/storage/box/beakers/insulated/WillContain()
+	return list(/obj/item/chems/glass/beaker/insulated = 7)
 
 /obj/item/storage/box/ammo
 	name = "ammo box"
@@ -141,105 +167,126 @@
 /obj/item/storage/box/ammo/blanks
 	name = "box of blank shells"
 	desc = "It has a picture of a gun and several warning symbols on the front."
-	startswith = list(/obj/item/ammo_casing/shotgun/blank = 8)
+
+/obj/item/storage/box/ammo/blanks/WillContain()
+	return list(/obj/item/ammo_casing/shotgun/blank = 8)
 
 /obj/item/storage/box/ammo/practiceshells
 	name = "box of practice shells"
-	startswith = list(/obj/item/ammo_casing/shotgun/practice = 8)
+/obj/item/storage/box/ammo/practiceshells/WillContain()
+	return list(/obj/item/ammo_casing/shotgun/practice = 8)
 
 /obj/item/storage/box/ammo/beanbags
 	name = "box of beanbag shells"
-	startswith = list(/obj/item/ammo_magazine/shotholder/beanbag = 2)
+/obj/item/storage/box/ammo/beanbags/WillContain()
+	return list(/obj/item/ammo_magazine/shotholder/beanbag = 2)
 
 /obj/item/storage/box/ammo/shotgunammo
 	name = "box of shotgun slugs"
-	startswith = list(/obj/item/ammo_magazine/shotholder = 2)
+/obj/item/storage/box/ammo/shotgunammo/WillContain()
+	return list(/obj/item/ammo_magazine/shotholder = 2)
 
 /obj/item/storage/box/ammo/shotgunshells
 	name = "box of shotgun shells"
-	startswith = list(/obj/item/ammo_magazine/shotholder/shell = 2)
+/obj/item/storage/box/ammo/shotgunshells/WillContain()
+	return list(/obj/item/ammo_magazine/shotholder/shell = 2)
 
 /obj/item/storage/box/ammo/flashshells
 	name = "box of illumination shells"
-	startswith = list(/obj/item/ammo_magazine/shotholder/flash = 2)
+/obj/item/storage/box/ammo/flashshells/WillContain()
+	return list(/obj/item/ammo_magazine/shotholder/flash = 2)
 
 /obj/item/storage/box/ammo/stunshells
 	name = "box of stun shells"
-	startswith = list(/obj/item/ammo_magazine/shotholder/stun = 2)
+/obj/item/storage/box/ammo/stunshells/WillContain()
+	return list(/obj/item/ammo_magazine/shotholder/stun = 2)
 
 /obj/item/storage/box/ammo/sniperammo
 	name = "box of sniper shells"
-	startswith = list(/obj/item/ammo_casing/shell = 7)
+/obj/item/storage/box/ammo/sniperammo/WillContain()
+	return list(/obj/item/ammo_casing/shell = 7)
 
 /obj/item/storage/box/ammo/sniperammo/apds
 	name = "box of sniper APDS shells"
-	startswith = list(/obj/item/ammo_casing/shell/apds = 3)
+/obj/item/storage/box/ammo/sniperammo/apds/WillContain()
+	return list(/obj/item/ammo_casing/shell/apds = 3)
 
 /obj/item/storage/box/flashbangs
 	name = "box of flashbangs"
 	desc = "A box containing 7 antipersonnel flashbang grenades.<br> WARNING: These devices are extremely dangerous and can cause blindness or deafness from repeated use."
 	icon_state = "flashbang"
-	startswith = list(/obj/item/grenade/flashbang = 7)
+/obj/item/storage/box/flashbangs/WillContain()
+	return list(/obj/item/grenade/flashbang = 7)
 
 /obj/item/storage/box/teargas
 	name = "box of pepperspray grenades"
 	desc = "A box containing 7 tear gas grenades. A gas mask is printed on the label.<br> WARNING: Exposure carries risk of serious injury or death. Keep away from persons with lung conditions."
 	icon_state = "flashbang"
-	startswith = list(/obj/item/grenade/chem_grenade/teargas = 7)
+/obj/item/storage/box/teargas/WillContain()
+	return list(/obj/item/grenade/chem_grenade/teargas = 7)
 
 /obj/item/storage/box/emps
 	name = "box of EMP grenades"
 	desc = "A box containing 5 military grade EMP grenades.<br> WARNING: Do not use near unshielded electronics or biomechanical augmentations, death or permanent paralysis may occur."
 	icon_state = "flashbang"
-	startswith = list(/obj/item/grenade/empgrenade = 5)
+/obj/item/storage/box/emps/WillContain()
+	return list(/obj/item/grenade/empgrenade = 5)
 
 /obj/item/storage/box/empslite
 	name = "box of low-yield EMP grenades"
 	desc = "A box containing 5 low yield EMP grenades.<br> WARNING: Do not use near unshielded electronics or biomechanical augmentations, death or permanent paralysis may occur."
 	icon_state = "flashbang"
-	startswith = list(/obj/item/grenade/empgrenade/low_yield = 5)
+/obj/item/storage/box/empslite/WillContain()
+	return list(/obj/item/grenade/empgrenade/low_yield = 5)
 
 /obj/item/storage/box/frags
 	name = "box of frag grenades"
 	desc = "A box containing 5 military grade fragmentation grenades.<br> WARNING: Live explosives. Misuse may result in serious injury or death."
 	icon_state = "flashbang"
-	startswith = list(/obj/item/grenade/frag = 5)
+/obj/item/storage/box/frags/WillContain()
+	return list(/obj/item/grenade/frag = 5)
 
 /obj/item/storage/box/fragshells
 	name = "box of frag shells"
 	desc = "A box containing 5 military grade fragmentation shells.<br> WARNING: Live explosive munitions. Misuse may result in serious injury or death."
 	icon_state = "flashbang"
-	startswith = list(/obj/item/grenade/frag/shell = 5)
+/obj/item/storage/box/fragshells/WillContain()
+	return list(/obj/item/grenade/frag/shell = 5)
 
 /obj/item/storage/box/smokes
 	name = "box of smoke bombs"
 	desc = "A box containing 5 smoke bombs."
 	icon_state = "flashbang"
-	startswith = list(/obj/item/grenade/smokebomb = 5)
+/obj/item/storage/box/smokes/WillContain()
+	return list(/obj/item/grenade/smokebomb = 5)
 
 /obj/item/storage/box/anti_photons
 	name = "box of anti-photon grenades"
 	desc = "A box containing 5 experimental photon disruption grenades."
 	icon_state = "flashbang"
-	startswith = list(/obj/item/grenade/anti_photon = 5)
+/obj/item/storage/box/anti_photons/WillContain()
+	return list(/obj/item/grenade/anti_photon = 5)
 
 /obj/item/storage/box/supermatters
 	name = "box of supermatter grenades"
 	desc = "A box containing 5 highly experimental supermatter grenades."
 	icon_state = "radbox"
-	startswith = list(/obj/item/grenade/supermatter = 5)
+/obj/item/storage/box/supermatters/WillContain()
+	return list(/obj/item/grenade/supermatter = 5)
 
 /obj/item/storage/box/decompilers
 	name = "box of decompiler grenades"
 	desc = "A box containing 5 experimental decompiler grenades."
 	icon_state = "flashbang"
-	startswith = list(/obj/item/grenade/decompiler = 5)
+/obj/item/storage/box/decompilers/WillContain()
+	return list(/obj/item/grenade/decompiler = 5)
 
 /obj/item/storage/box/trackimp
 	name = "boxed tracking implant kit"
 	desc = "Box full of scum-bag tracking utensils."
 	icon_state = "implant"
-	startswith = list(/obj/item/implantcase/tracking = 4,
+/obj/item/storage/box/trackimp/WillContain()
+	return list(/obj/item/implantcase/tracking = 4,
 		/obj/item/implanter = 1,
 		/obj/item/implantpad = 1,
 		/obj/item/locator = 1)
@@ -248,7 +295,8 @@
 	name = "boxed chemical implant kit"
 	desc = "Box of stuff used to implant chemicals."
 	icon_state = "implant"
-	startswith = list(/obj/item/implantcase/chem = 5,
+/obj/item/storage/box/chemimp/WillContain()
+	return list(/obj/item/implantcase/chem = 5,
 					/obj/item/implanter = 1,
 					/obj/item/implantpad = 1)
 
@@ -256,37 +304,43 @@
 	name = "box of prescription glasses"
 	desc = "This box contains nerd glasses."
 	icon_state = "glasses"
-	startswith = list(/obj/item/clothing/glasses/prescription = 7)
+/obj/item/storage/box/rxglasses/WillContain()
+	return list(/obj/item/clothing/glasses/prescription = 7)
 
 /obj/item/storage/box/cdeathalarm_kit
 	name = "death alarm kit"
 	desc = "Box of stuff used to implant death alarms."
 	icon_state = "implant"
 	item_state = "syringe_kit"
-	startswith = list(/obj/item/implanter = 1,
+/obj/item/storage/box/cdeathalarm_kit/WillContain()
+	return list(/obj/item/implanter = 1,
 				/obj/item/implantcase/death_alarm = 6)
 
 /obj/item/storage/box/condimentbottles
 	name = "box of condiment bottles"
 	desc = "It has a large ketchup smear on it."
-	startswith = list(/obj/item/chems/condiment = 6)
+/obj/item/storage/box/condimentbottles/WillContain()
+	return list(/obj/item/chems/condiment = 6)
 
 /obj/item/storage/box/cups
 	name = "box of paper cups"
 	desc = "It has pictures of paper cups on the front."
-	startswith = list(/obj/item/chems/drinks/sillycup = 7)
+/obj/item/storage/box/cups/WillContain()
+	return list(/obj/item/chems/drinks/sillycup = 7)
 
 /obj/item/storage/box/donkpockets
 	name = "box of donk-pockets"
 	desc = "<B>Instructions:</B> <I>Heat in microwave. Product will cool if not eaten within seven minutes.</I>"
 	icon_state = "donk_kit"
-	startswith = list(/obj/item/chems/food/donkpocket = 6)
+/obj/item/storage/box/donkpockets/WillContain()
+	return list(/obj/item/chems/food/donkpocket = 6)
 
 /obj/item/storage/box/sinpockets
 	name = "box of sin-pockets"
 	desc = "<B>Instructions:</B> <I>Crush bottom of package to initiate chemical heating. Wait for 20 seconds before consumption. Product will cool if not eaten within seven minutes.</I>"
 	icon_state = "donk_kit"
-	startswith = list(/obj/item/chems/food/donkpocket/sinpocket = 6)
+/obj/item/storage/box/sinpockets/WillContain()
+	return list(/obj/item/chems/food/donkpocket/sinpocket = 6)
 
 //cubed animals
 
@@ -296,43 +350,55 @@
 	icon = 'icons/obj/food.dmi'
 	icon_state = "monkeycubebox"
 	can_hold = list(/obj/item/chems/food/monkeycube)
-	startswith = list(/obj/item/chems/food/monkeycube/wrapped = 5)
+/obj/item/storage/box/monkeycubes/WillContain()
+	return list(/obj/item/chems/food/monkeycube/wrapped = 5)
 
 /obj/item/storage/box/monkeycubes/spidercubes
 	name = "spiderling cube box"
 	desc = "Drymate brand Instant spiders. WHY WOULD YOU ORDER THIS!?"
-	startswith = list(/obj/item/chems/food/monkeycube/wrapped/spidercube = 5)
+/obj/item/storage/box/monkeycubes/spidercubes/WillContain()
+	return list(/obj/item/chems/food/monkeycube/wrapped/spidercube = 5)
 
 /obj/item/storage/box/ids
 	name = "box of spare IDs"
 	desc = "Has so many empty IDs."
 	icon_state = "id"
-	startswith = list(/obj/item/card/id = 7)
+
+/obj/item/storage/box/ids/WillContain()
+	return list(/obj/item/card/id = 7)
 
 /obj/item/storage/box/large/ids
 	name = "box of spare IDs"
 	desc = "Has so, so many empty IDs."
 	icon_state = "id_large"
-	startswith = list(/obj/item/card/id = 14)
+
+/obj/item/storage/box/large/ids/WillContain()
+	return list(/obj/item/card/id = 14)
 
 /obj/item/storage/box/handcuffs
 	name = "box of spare handcuffs"
 	desc = "A box full of handcuffs."
 	icon_state = "handcuff"
-	startswith = list(/obj/item/handcuffs = 7)
+
+/obj/item/storage/box/handcuffs/WillContain()
+	return list(/obj/item/handcuffs = 7)
 
 /obj/item/storage/box/mousetraps
 	name = "box of Pest-B-Gon rat traps"
 	desc = "<B><FONT color='red'>WARNING:</FONT></B> <I>Keep out of reach of children</I>."
-	startswith = list(/obj/item/assembly/mousetrap = 6)
 
-/obj/item/storage/box/mousetraps/empty
-	startswith = null
+/obj/item/storage/box/mousetraps/WillContain()
+	return list(/obj/item/assembly/mousetrap = 6)
+
+/obj/item/storage/box/mousetraps/empty/WillContain()
+	return null
 
 /obj/item/storage/box/pillbottles
 	name = "box of pill bottles"
 	desc = "It has pictures of pill bottles on its front."
-	startswith = list(/obj/item/storage/pill_bottle = 7)
+
+/obj/item/storage/box/pillbottles/WillContain()
+	return list(/obj/item/storage/pill_bottle = 7)
 
 /obj/item/storage/box/snappops
 	name = "snap pop box"
@@ -340,7 +406,9 @@
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "spbox"
 	can_hold = list(/obj/item/toy/snappop)
-	startswith = list(/obj/item/toy/snappop = 8)
+
+/obj/item/storage/box/snappops/WillContain()
+	return list(/obj/item/toy/snappop = 8)
 
 /obj/item/storage/box/matches
 	name = "matchbox"
@@ -351,7 +419,9 @@
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_LOWER_BODY
 	can_hold = list(/obj/item/flame/match)
-	startswith = list(/obj/item/flame/match = 10)
+
+/obj/item/storage/box/matches/WillContain()
+	return list(/obj/item/flame/match = 10)
 
 /obj/item/storage/box/matches/attackby(obj/item/flame/match/W, mob/user)
 	if(istype(W) && !W.lit && !W.burnt)
@@ -369,7 +439,8 @@
 	desc = "Contains autoinjectors."
 	icon_state = "syringe"
 
-	startswith = list(/obj/item/chems/hypospray/autoinjector = 7)
+/obj/item/storage/box/autoinjectors/WillContain()
+	return list(/obj/item/chems/hypospray/autoinjector = 7)
 
 /obj/item/storage/box/lights
 	name = "box of replacement bulbs"
@@ -382,48 +453,64 @@
 	. = ..()
 	make_exact_fit()
 
-/obj/item/storage/box/lights/bulbs
-	startswith = list(/obj/item/light/bulb = 21)
+/obj/item/storage/box/lights/bulbs/WillContain()
+	return list(/obj/item/light/bulb = 21)
 
-/obj/item/storage/box/lights/bulbs/empty
-	startswith = null
+/obj/item/storage/box/lights/bulbs/empty/WillContain()
+	return null
 
 /obj/item/storage/box/lights/tubes
 	name = "box of replacement tubes"
 	icon_state = "lighttube"
-	startswith = list(/obj/item/light/tube = 17,
-					/obj/item/light/tube/large = 4)
+/obj/item/storage/box/lights/tubes/WillContain()
+	return list(
+			/obj/item/light/tube       = 17,
+			/obj/item/light/tube/large = 4
+		)
 
 /obj/item/storage/box/lights/tubes/random
 	name = "box of replacement tubes -- party pack"
 	icon_state = "lighttube"
-	startswith = list(/obj/item/light/tube/party = 17,
-					/obj/item/light/tube/large/party = 4)
+/obj/item/storage/box/lights/tubes/random/WillContain()
+	return list(
+			/obj/item/light/tube/party       = 17,
+			/obj/item/light/tube/large/party = 4
+		)
 
-/obj/item/storage/box/lights/tubes/empty
-	startswith = null
+/obj/item/storage/box/lights/tubes/empty/WillContain()
+	return null
 
 /obj/item/storage/box/lights/mixed
 	name = "box of replacement lights"
 	icon_state = "lightmixed"
-	startswith = list(/obj/item/light/tube = 12,
-					/obj/item/light/tube/large = 4,
-					/obj/item/light/bulb = 5)
+/obj/item/storage/box/lights/mixed/WillContain()
+	return list(
+			/obj/item/light/tube       = 12,
+			/obj/item/light/tube/large = 4,
+			/obj/item/light/bulb       = 5
+		)
 
-/obj/item/storage/box/lights/mixed/empty
-	startswith = null
+/obj/item/storage/box/lights/mixed/empty/WillContain()
+	return null
 
 /obj/item/storage/box/glowsticks
 	name = "box of mixed glowsticks"
 	icon_state = "box"
-	startswith = list(/obj/item/flashlight/flare/glowstick = 1, /obj/item/flashlight/flare/glowstick/red = 1,
-					/obj/item/flashlight/flare/glowstick/blue = 1, /obj/item/flashlight/flare/glowstick/orange = 1,
-					/obj/item/flashlight/flare/glowstick/yellow = 1, /obj/item/flashlight/flare/glowstick/random = 1)
+/obj/item/storage/box/glowsticks/WillContain()
+	return list(
+			/obj/item/flashlight/flare/glowstick        = 1, 
+			/obj/item/flashlight/flare/glowstick/red    = 1,
+			/obj/item/flashlight/flare/glowstick/blue   = 1,
+			/obj/item/flashlight/flare/glowstick/orange = 1,
+			/obj/item/flashlight/flare/glowstick/yellow = 1, 
+			/obj/item/flashlight/flare/glowstick/random = 1
+		)
 
 /obj/item/storage/box/greenglowsticks
 	name = "box of green glowsticks"
 	icon_state = "box"
-	startswith = list(/obj/item/flashlight/flare/glowstick = 6)
+/obj/item/storage/box/greenglowsticks/WillContain()
+	return list(/obj/item/flashlight/flare/glowstick = 6)
 
 /obj/item/storage/box/freezer
 	name = "portable freezer"
@@ -449,53 +536,66 @@
 	max_storage_space = 24
 	foldable = null
 	can_hold = list(/obj/item/chems/food/checker)
-	startswith = list(/obj/item/chems/food/checker = 12,
-					/obj/item/chems/food/checker/red = 12)
+/obj/item/storage/box/checkers/WillContain()
+	return list(
+			/obj/item/chems/food/checker = 12,
+			/obj/item/chems/food/checker/red = 12
+		)
 
 /obj/item/storage/box/checkers/chess
 	name = "black chess box"
 	desc = "This box holds all the pieces needed for the black side of the chess board."
 	icon_state = "chess_b"
-	startswith = list(/obj/item/chems/food/checker/pawn = 8,
-				/obj/item/chems/food/checker/knight = 2,
-				/obj/item/chems/food/checker/bishop = 2,
-				/obj/item/chems/food/checker/rook = 2,
-				/obj/item/chems/food/checker/queen = 1,
-				/obj/item/chems/food/checker/king = 1)
+/obj/item/storage/box/checkers/chess/WillContain()
+	return list(
+			/obj/item/chems/food/checker/pawn   = 8,
+			/obj/item/chems/food/checker/knight = 2,
+			/obj/item/chems/food/checker/bishop = 2,
+			/obj/item/chems/food/checker/rook   = 2,
+			/obj/item/chems/food/checker/queen  = 1,
+			/obj/item/chems/food/checker/king   = 1
+		)
 
 /obj/item/storage/box/checkers/chess/red
 	name = "red chess box"
 	desc = "This box holds all the pieces needed for the red side of the chess board."
 	icon_state = "chess_r"
-	startswith = list(/obj/item/chems/food/checker/pawn/red = 8,
-				/obj/item/chems/food/checker/knight/red = 2,
-				/obj/item/chems/food/checker/bishop/red = 2,
-				/obj/item/chems/food/checker/rook/red = 2,
-				/obj/item/chems/food/checker/queen/red = 1,
-				/obj/item/chems/food/checker/king/red = 1)
+/obj/item/storage/box/checkers/chess/red/WillContain()
+	return list(
+			/obj/item/chems/food/checker/pawn/red   = 8,
+			/obj/item/chems/food/checker/knight/red = 2,
+			/obj/item/chems/food/checker/bishop/red = 2,
+			/obj/item/chems/food/checker/rook/red   = 2,
+			/obj/item/chems/food/checker/queen/red  = 1,
+			/obj/item/chems/food/checker/king/red   = 1
+		)
 
 
 /obj/item/storage/box/headset
 	name = "box of spare headsets"
 	desc = "A box full of headsets."
-	startswith = list(/obj/item/radio/headset = 7)
+/obj/item/storage/box/headset/WillContain()
+	return list(/obj/item/radio/headset = 7)
 
 //Spare Armbands
 
 /obj/item/storage/box/armband/engine
 	name = "box of spare engineering armbands"
 	desc = "A box full of engineering armbands. For use in emergencies when provisional engineering peronnel are needed."
-	startswith = list(/obj/item/clothing/accessory/armband/engine = 5)
+/obj/item/storage/box/armband/engine/WillContain()
+	return list(/obj/item/clothing/accessory/armband/engine = 5)
 
 /obj/item/storage/box/armband/med
 	name = "box of spare medical armbands"
 	desc = "A box full of medical armbands. For use in emergencies when provisional medical personnel are needed."
-	startswith = list(/obj/item/clothing/accessory/armband/med = 5)
+/obj/item/storage/box/armband/med/WillContain()
+	return list(/obj/item/clothing/accessory/armband/med = 5)
 
 /obj/item/storage/box/imprinting
 	name = "box of education implants"
 	desc = "A box full of neural implants for on-job training."
-	startswith = list(
+/obj/item/storage/box/imprinting/WillContain()
+	return list(
 		/obj/item/implanter,
 		/obj/item/implantpad,
 		/obj/item/implantcase/imprinting = 3
@@ -506,99 +606,109 @@
 	desc = "A bag full of juicy, yummy detergent pods. This bag has been labeled: Tod Pods, a Waffle Co. product."
 	icon = 'icons/obj/items/storage/detergent.dmi'
 	icon_state = "detergent"
-	startswith = list(/obj/item/chems/pill/detergent = 10)
+/obj/item/storage/box/detergent/WillContain()
+	return list(/obj/item/chems/pill/detergent = 10)
 
 //cargosia supply boxes - Primarily for restocking
 
 /obj/item/storage/box/tapes
 	name = "box of spare tapes"
 	desc = "A box full of blank tapes."
-	startswith = list(/obj/item/magnetic_tape/random = 14)
+/obj/item/storage/box/tapes/WillContain()
+	return list(/obj/item/magnetic_tape/random = 14)
 
 /obj/item/storage/box/taperolls
 	name = "box of spare taperolls"
 	desc = "A box full of mixed barricade tapes."
-	startswith = list(  /obj/item/stack/tape_roll/barricade_tape/police,
-						/obj/item/stack/tape_roll/barricade_tape/engineering,
-						/obj/item/stack/tape_roll/barricade_tape/atmos,
-						/obj/item/stack/tape_roll/barricade_tape/research,
-						/obj/item/stack/tape_roll/barricade_tape/medical,
-						/obj/item/stack/tape_roll/barricade_tape/bureaucracy
-					)
+/obj/item/storage/box/taperolls/WillContain()
+	return list(
+			/obj/item/stack/tape_roll/barricade_tape/police,
+			/obj/item/stack/tape_roll/barricade_tape/engineering,
+			/obj/item/stack/tape_roll/barricade_tape/atmos,
+			/obj/item/stack/tape_roll/barricade_tape/research,
+			/obj/item/stack/tape_roll/barricade_tape/medical,
+			/obj/item/stack/tape_roll/barricade_tape/bureaucracy
+		)
 
 /obj/item/storage/box/bogrolls
 	name = "box of spare bogrolls"
 	desc = "A box full of toilet paper."
-	startswith = list(/obj/item/stack/tape_roll/barricade_tape/toilet = 6)
+/obj/item/storage/box/bogrolls/WillContain()
+	return list(/obj/item/stack/tape_roll/barricade_tape/toilet = 6)
 
 /obj/item/storage/box/cola
 	name = "box of sodas"
 	desc = "A box full of soda cans."
-	startswith = list(/obj/item/chems/drinks/cans/cola = 7)
+/obj/item/storage/box/cola/WillContain()
+	return list(/obj/item/chems/drinks/cans/cola = 7)
 
 /obj/item/storage/box/water
 	name = "box of water bottles"
 	desc = "A box full of bottled water."
-	startswith = list(/obj/item/chems/drinks/cans/waterbottle = 7)
+/obj/item/storage/box/water/WillContain()
+	return list(/obj/item/chems/drinks/cans/waterbottle = 7)
 
-/obj/item/storage/box/cola/spacewind
-	startswith = list(/obj/item/chems/drinks/cans/space_mountain_wind = 7)
+/obj/item/storage/box/cola/spacewind/WillContain()
+	return list(/obj/item/chems/drinks/cans/space_mountain_wind = 7)
 
-/obj/item/storage/box/cola/drgibb
-	startswith = list(/obj/item/chems/drinks/cans/dr_gibb = 7)
+/obj/item/storage/box/cola/drgibb/WillContain()
+	return list(/obj/item/chems/drinks/cans/dr_gibb = 7)
 
-/obj/item/storage/box/cola/starkist
-	startswith = list(/obj/item/chems/drinks/cans/starkist = 7)
+/obj/item/storage/box/cola/starkist/WillContain()
+	return list(/obj/item/chems/drinks/cans/starkist = 7)
 
-/obj/item/storage/box/cola/spaceup
-	startswith = list(/obj/item/chems/drinks/cans/space_up = 7)
+/obj/item/storage/box/cola/spaceup/WillContain()
+	return list(/obj/item/chems/drinks/cans/space_up = 7)
 
-/obj/item/storage/box/cola/lemonlime
-	startswith = list(/obj/item/chems/drinks/cans/lemon_lime = 7)
+/obj/item/storage/box/cola/lemonlime/WillContain()
+	return list(/obj/item/chems/drinks/cans/lemon_lime = 7)
 
-/obj/item/storage/box/cola/icedtea
-	startswith = list(/obj/item/chems/drinks/cans/iced_tea = 7)
+/obj/item/storage/box/cola/icedtea/WillContain()
+	return list(/obj/item/chems/drinks/cans/iced_tea = 7)
 
-/obj/item/storage/box/cola/grapejuice
-	startswith = list(/obj/item/chems/drinks/cans/grape_juice = 7)
+/obj/item/storage/box/cola/grapejuice/WillContain()
+	return list(/obj/item/chems/drinks/cans/grape_juice = 7)
 
-/obj/item/storage/box/cola/sodawater
-	startswith = list(/obj/item/chems/drinks/cans/sodawater = 7)
+/obj/item/storage/box/cola/sodawater/WillContain()
+	return list(/obj/item/chems/drinks/cans/sodawater = 7)
 
 /obj/item/storage/box/snack
 	name = "box of snack food"
 	desc = "A box full of snack foods."
-	startswith = list(/obj/item/chems/food/sosjerky = 7)
 
-/obj/item/storage/box/snack/noraisin
-	startswith = list(/obj/item/chems/food/no_raisin = 7)
+/obj/item/storage/box/snack/WillContain()
+	return list(/obj/item/chems/food/sosjerky = 7)
 
-/obj/item/storage/box/snack/cheesehonks
-	startswith = list(/obj/item/chems/food/cheesiehonkers = 7)
+/obj/item/storage/box/snack/noraisin/WillContain()
+	return list(/obj/item/chems/food/no_raisin = 7)
 
-/obj/item/storage/box/snack/tastybread
-	startswith = list(/obj/item/chems/food/tastybread = 7)
+/obj/item/storage/box/snack/cheesehonks/WillContain()
+	return list(/obj/item/chems/food/cheesiehonkers = 7)
 
-/obj/item/storage/box/snack/candy
-	startswith = list(/obj/item/chems/food/candy = 7)
+/obj/item/storage/box/snack/tastybread/WillContain()
+	return list(/obj/item/chems/food/tastybread = 7)
 
-/obj/item/storage/box/snack/chips
-	startswith = list(/obj/item/chems/food/chips = 7)
+/obj/item/storage/box/snack/candy/WillContain()
+	return list(/obj/item/chems/food/candy = 7)
+
+/obj/item/storage/box/snack/chips/WillContain()
+	return list(/obj/item/chems/food/chips = 7)
 
 //canned goods in cardboard
 /obj/item/storage/box/canned
 	name = "box of canned food"
 	desc = "A box full of canned foods."
-	startswith = list(/obj/item/chems/food/can/spinach = 1)
+/obj/item/storage/box/canned/WillContain()
+	return list(/obj/item/chems/food/can/spinach = 1)
 
-/obj/item/storage/box/canned/beef
-	startswith = list(/obj/item/chems/food/can/beef = 6)
+/obj/item/storage/box/canned/beef/WillContain()
+	return list(/obj/item/chems/food/can/beef = 6)
 
-/obj/item/storage/box/canned/beans
-	startswith = list(/obj/item/chems/food/can/beans = 6)
+/obj/item/storage/box/canned/beans/WillContain()
+	return list(/obj/item/chems/food/can/beans = 6)
 
-/obj/item/storage/box/canned/tomato
-	startswith = list(/obj/item/chems/food/can/tomato = 6)
+/obj/item/storage/box/canned/tomato/WillContain()
+	return list(/obj/item/chems/food/can/tomato = 6)
 
 // machinery stock parts
 /obj/item/storage/box/parts
@@ -608,7 +718,9 @@
 	icon_state = "part"
 	w_class = ITEM_SIZE_NORMAL
 	max_storage_space = DEFAULT_BOX_STORAGE
-	startswith = list(
+
+/obj/item/storage/box/parts/WillContain()
+	return list(
 		/obj/item/stock_parts/power/apc/buildable = 3,
 		/obj/item/stock_parts/console_screen = 2,
 		/obj/item/stock_parts/matter_bin = 2
@@ -622,24 +734,32 @@
 	w_class = ITEM_SIZE_SMALL
 	max_storage_space = BASE_STORAGE_CAPACITY(ITEM_SIZE_SMALL)
 
-/obj/item/storage/box/parts_pack/Initialize()
-	if(length(startswith))
-		var/obj/item/I = startswith[1]
-		SetName("[initial(I.name)] pack")
+/obj/item/storage/box/parts_pack/Initialize(ml, material_key)
+	setup_name()
 	return ..()
+
+/obj/item/storage/box/parts_pack/proc/setup_name()
+	var/list/cnt = WillContain()
+	if((islist(cnt) || ispath(cnt)) && length(cnt))
+		var/atom/movable/AM = ispath(cnt)? cnt : cnt[1]
+		SetName("[initial(AM.name)] pack")
 
 /obj/item/storage/box/parts_pack/manipulator
 	icon_state = "mainpulator"
-	startswith = list(/obj/item/stock_parts/manipulator = 7)
+/obj/item/storage/box/parts_pack/manipulator/WillContain()
+	return list(/obj/item/stock_parts/manipulator = 7)
 
 /obj/item/storage/box/parts_pack/laser
 	icon_state = "laser"
-	startswith = list(/obj/item/stock_parts/micro_laser = 7)
+/obj/item/storage/box/parts_pack/laser/WillContain()
+	return list(/obj/item/stock_parts/micro_laser = 7)
 
 /obj/item/storage/box/parts_pack/capacitor
 	icon_state = "capacitor"
-	startswith = list(/obj/item/stock_parts/capacitor = 7)
+/obj/item/storage/box/parts_pack/capacitor/WillContain()
+	return list(/obj/item/stock_parts/capacitor = 7)
 
 /obj/item/storage/box/parts_pack/keyboard
 	icon_state = "keyboard"
-	startswith = list(/obj/item/stock_parts/keyboard = 7)
+/obj/item/storage/box/parts_pack/keyboard/WillContain()
+	return list(/obj/item/stock_parts/keyboard = 7)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -449,9 +449,10 @@
 	item_state = "syringe_kit"
 	use_to_pickup = 1 // for picking up broken bulbs, not that most people will try
 
-/obj/item/storage/box/lights/Initialize()
+/obj/item/storage/box/lights/Initialize(ml, material_key)
 	. = ..()
-	make_exact_fit()
+	if(length(contents))
+		make_exact_fit()
 
 /obj/item/storage/box/lights/bulbs/WillContain()
 	return list(/obj/item/light/bulb = 21)

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -52,11 +52,13 @@
 		/obj/item/chems/food/egg,
 		/obj/item/chems/food/boiledegg
 		)
-	startswith = list(/obj/item/chems/food/egg = 12)
 	material = /decl/material/solid/cardboard
 
-/obj/item/storage/fancy/egg_box/empty
-	startswith = null
+/obj/item/storage/fancy/egg_box/WillContain()
+	return list(/obj/item/chems/food/egg = 12)
+
+/obj/item/storage/fancy/egg_box/empty/WillContain()
+	return
 
 /*
  * Cracker Packet
@@ -71,8 +73,10 @@
 	w_class = ITEM_SIZE_SMALL
 	key_type = /obj/item/chems/food/cracker
 	can_hold = list(/obj/item/chems/food/cracker)
-	startswith = list(/obj/item/chems/food/cracker = 6)
 	material = /decl/material/solid/cardboard
+
+/obj/item/storage/fancy/crackers/WillContain()
+	return list(/obj/item/chems/food/cracker = 6)
 
 /*
  * Crayon Box
@@ -87,15 +91,18 @@
 	max_w_class = ITEM_SIZE_TINY
 	max_storage_space = 6
 	key_type = /obj/item/pen/crayon
-	startswith = list(
-		/obj/item/pen/crayon/red,
-		/obj/item/pen/crayon/orange,
-		/obj/item/pen/crayon/yellow,
-		/obj/item/pen/crayon/green,
-		/obj/item/pen/crayon/blue,
-		/obj/item/pen/crayon/purple,
-		)
 	material = /decl/material/solid/cardboard
+
+/obj/item/storage/fancy/crayons/WillContain()
+	return list(
+			/obj/item/pen/crayon/red,
+			/obj/item/pen/crayon/orange,
+			/obj/item/pen/crayon/yellow,
+			/obj/item/pen/crayon/green,
+			/obj/item/pen/crayon/blue,
+			/obj/item/pen/crayon/purple,
+		)
+
 
 /obj/item/storage/fancy/crayons/on_update_icon()
 	. = ..()
@@ -122,12 +129,18 @@
 	slot_flags = SLOT_LOWER_BODY
 	material = /decl/material/solid/cardboard
 	key_type = /obj/item/clothing/mask/smokable/cigarette
-	startswith = list(/obj/item/clothing/mask/smokable/cigarette = 6)
+	atom_flags = ATOM_FLAG_NO_REACT | ATOM_FLAG_OPEN_CONTAINER | ATOM_FLAG_NO_TEMP_CHANGE
 
-/obj/item/storage/fancy/cigarettes/Initialize()
+/obj/item/storage/fancy/cigarettes/WillContain()
+	return list(/obj/item/clothing/mask/smokable/cigarette = 6)
+
+/obj/item/storage/fancy/cigarettes/Initialize(ml, material_key)
 	. = ..()
-	atom_flags |= ATOM_FLAG_NO_REACT|ATOM_FLAG_OPEN_CONTAINER
+	initialize_reagents()
+
+/obj/item/storage/fancy/cigarettes/initialize_reagents(populate)
 	create_reagents(5 * max_storage_space)//so people can inject cigarettes without opening a packet, now with being able to inject the whole one
+	. = ..()
 
 /obj/item/storage/fancy/cigarettes/remove_from_storage(obj/item/W, atom/new_location)
 	// Don't try to transfer reagents to lighters
@@ -172,18 +185,21 @@
 	desc = "A packet of six imported Dromedary Company cancer sticks. A label on the packaging reads, \"Wouldn't a slow death make a change?\"."
 	icon = 'icons/obj/items/storage/cigpack/dromedary.dmi'
 	icon_state = "Dpacket"
-	startswith = list(/obj/item/clothing/mask/smokable/cigarette/dromedaryco = 6)
+
+/obj/item/storage/fancy/cigarettes/dromedaryco/WillContain()
+	return list(/obj/item/clothing/mask/smokable/cigarette/dromedaryco = 6)
 
 /obj/item/storage/fancy/cigarettes/killthroat
 	name = "pack of Acme Co. cigarettes"
 	desc = "A packet of six Acme Company cigarettes. For those who somehow want to obtain the record for the most amount of cancerous tumors."
 	icon = 'icons/obj/items/storage/cigpack/acme.dmi'
 	icon_state = "Bpacket"
-	startswith = list(/obj/item/clothing/mask/smokable/cigarette/killthroat = 6)
 
-/obj/item/storage/fancy/cigarettes/killthroat/Initialize()
-	. = ..()
-	fill_cigarre_package(src,list(/decl/material/liquid/fuel = 4))
+/obj/item/storage/fancy/cigarettes/killthroat/WillContain()
+	return list(/obj/item/clothing/mask/smokable/cigarette/killthroat = 6)
+
+/obj/item/storage/fancy/cigarettes/killthroat/populate_reagents()
+	reagents.add_reagent(/decl/material/liquid/fuel, (max_storage_space * 4))
 
 // New exciting ways to kill your lungs! - Earthcrusher //
 
@@ -193,7 +209,9 @@
 	icon = 'icons/obj/items/storage/cigpack/lucky_stars.dmi'
 	icon_state = "LSpacket"
 	item_state = "Dpacket" //I actually don't mind cig packs not showing up in the hand. whotf doesn't just keep them in their pockets/coats //
-	startswith = list(/obj/item/clothing/mask/smokable/cigarette/luckystars = 6)
+
+/obj/item/storage/fancy/cigarettes/luckystars/WillContain()
+	return list(/obj/item/clothing/mask/smokable/cigarette/luckystars = 6)
 
 /obj/item/storage/fancy/cigarettes/jerichos
 	name = "pack of Jerichos"
@@ -201,7 +219,9 @@
 	icon = 'icons/obj/items/storage/cigpack/jerichos.dmi'
 	icon_state = "Jpacket"
 	item_state = "Dpacket"
-	startswith = list(/obj/item/clothing/mask/smokable/cigarette/jerichos = 6)
+
+/obj/item/storage/fancy/cigarettes/jerichos/WillContain()
+	return list(/obj/item/clothing/mask/smokable/cigarette/jerichos = 6)
 
 /obj/item/storage/fancy/cigarettes/menthols
 	name = "pack of Temperamento Menthols"
@@ -209,9 +229,10 @@
 	icon = 'icons/obj/items/storage/cigpack/menthol.dmi'
 	icon_state = "TMpacket"
 	item_state = "Dpacket"
-
 	key_type = /obj/item/clothing/mask/smokable/cigarette/menthol
-	startswith = list(/obj/item/clothing/mask/smokable/cigarette/menthol = 6)
+
+/obj/item/storage/fancy/cigarettes/menthols/WillContain()
+	return list(/obj/item/clothing/mask/smokable/cigarette/menthol = 6)
 
 /obj/item/storage/fancy/cigarettes/carcinomas
 	name = "pack of Carcinoma Angels"
@@ -219,7 +240,9 @@
 	icon = 'icons/obj/items/storage/cigpack/carcinoma.dmi'
 	icon_state = "CApacket"
 	item_state = "Dpacket"
-	startswith = list(/obj/item/clothing/mask/smokable/cigarette/carcinomas = 6)
+
+/obj/item/storage/fancy/cigarettes/carcinomas/WillContain()
+	return list(/obj/item/clothing/mask/smokable/cigarette/carcinomas = 6)
 
 /obj/item/storage/fancy/cigarettes/professionals
 	name = "pack of Professional 120s"
@@ -227,7 +250,9 @@
 	icon_state = "P100packet"
 	icon = 'icons/obj/items/storage/cigpack/professionals.dmi'
 	item_state = "Dpacket"
-	startswith = list(/obj/item/clothing/mask/smokable/cigarette/professionals = 6)
+
+/obj/item/storage/fancy/cigarettes/professionals/WillContain()
+	return list(/obj/item/clothing/mask/smokable/cigarette/professionals = 6)
 
 //cigarellos
 /obj/item/storage/fancy/cigarettes/cigarello
@@ -238,26 +263,36 @@
 	item_state = "Dpacket"
 	max_storage_space = 5
 	key_type = /obj/item/clothing/mask/smokable/cigarette/trident
-	startswith = list(/obj/item/clothing/mask/smokable/cigarette/trident = 5)
+
+/obj/item/storage/fancy/cigarettes/cigarello/WillContain()
+	return list(/obj/item/clothing/mask/smokable/cigarette/trident = 5)
 
 /obj/item/storage/fancy/cigarettes/cigarello/variety
 	name = "pack of Trident Fruit cigars"
 	desc = "The Trident brand's wood tipped little cigar, favored by the Sol corps diplomatique for their pleasant aroma. Machine made on Mars for over 100 years. This is a fruit variety pack."
 	icon = 'icons/obj/items/storage/cigpack/cigarillo_fruity.dmi'
 	icon_state = "CRFpacket"
-	startswith = list(	/obj/item/clothing/mask/smokable/cigarette/trident/watermelon,
-						/obj/item/clothing/mask/smokable/cigarette/trident/orange,
-						/obj/item/clothing/mask/smokable/cigarette/trident/grape,
-						/obj/item/clothing/mask/smokable/cigarette/trident/cherry,
-						/obj/item/clothing/mask/smokable/cigarette/trident/berry)
+
+/obj/item/storage/fancy/cigarettes/cigarello/variety/WillContain()
+	return list(
+				/obj/item/clothing/mask/smokable/cigarette/trident/watermelon,
+				/obj/item/clothing/mask/smokable/cigarette/trident/orange,
+				/obj/item/clothing/mask/smokable/cigarette/trident/grape,
+				/obj/item/clothing/mask/smokable/cigarette/trident/cherry,
+				/obj/item/clothing/mask/smokable/cigarette/trident/berry
+			)
 
 /obj/item/storage/fancy/cigarettes/cigarello/mint
 	name = "pack of Trident Menthol cigars"
 	desc = "The Trident brand's wood tipped little cigar, favored by the Sol corps diplomatique for their pleasant aroma. Machine made on Mars for over 100 years. These are the menthol variety."
 	icon = 'icons/obj/items/storage/cigpack/cigarillo_menthol.dmi'
 	icon_state = "CRMpacket"
-	startswith = list(/obj/item/clothing/mask/smokable/cigarette/trident/mint = 5)
 
+/obj/item/storage/fancy/cigarettes/cigarello/mint/WillContain()
+	return list(/obj/item/clothing/mask/smokable/cigarette/trident/mint = 5)
+/*
+ * Cigar
+*/
 /obj/item/storage/fancy/cigar
 	name = "cigar case"
 	desc = "A case for holding your cigars when you are not smoking them."
@@ -271,23 +306,29 @@
 	storage_slots = 7
 	material = /decl/material/solid/wood/mahogany
 	key_type = /obj/item/clothing/mask/smokable/cigarette/cigar
-	startswith = list(/obj/item/clothing/mask/smokable/cigarette/cigar = 6)
+	atom_flags = ATOM_FLAG_NO_REACT | ATOM_FLAG_NO_TEMP_CHANGE
 
-/obj/item/storage/fancy/cigar/Initialize()
+/obj/item/storage/fancy/cigar/Initialize(ml, material_key)
 	. = ..()
-	atom_flags |= ATOM_FLAG_NO_REACT
+	initialize_reagents()
+
+/obj/item/storage/fancy/cigar/initialize_reagents(populate)
 	create_reagents(10 * storage_slots)
+	. = ..()
+
+/obj/item/storage/fancy/cigar/WillContain()
+	return list(/obj/item/clothing/mask/smokable/cigarette/cigar = 6)
 
 /obj/item/storage/fancy/cigar/remove_from_storage(obj/item/W, atom/new_location)
 	var/obj/item/clothing/mask/smokable/cigarette/cigar/C = W
-	if(!istype(C)) return
+	if(!istype(C)) 
+		return
 	reagents.trans_to_obj(C, (reagents.total_volume/contents.len))
-	..()
+	return ..()
 
 /*
  * Vial Box
  */
-
 /obj/item/storage/fancy/vials
 	icon = 'icons/obj/vialbox.dmi'
 	icon_state = "vialbox"
@@ -297,7 +338,9 @@
 	storage_slots = 12
 	material = /decl/material/solid/plastic
 	key_type = /obj/item/chems/glass/beaker/vial
-	startswith = list(/obj/item/chems/glass/beaker/vial = 12)
+
+/obj/item/storage/fancy/vials/WillContain()
+	return list(/obj/item/chems/glass/beaker/vial = 12)
 
 /obj/item/storage/fancy/vials/on_update_icon()
 	. = ..()
@@ -338,3 +381,45 @@
 /obj/item/storage/lockbox/vials/attackby(obj/item/W, mob/user)
 	. = ..()
 	update_icon()
+
+////////////////////////////////////////////////////////////////////////////////
+// Syndie Cigs
+////////////////////////////////////////////////////////////////////////////////
+
+// Flash Powder Pack
+/obj/item/storage/fancy/cigarettes/flash_powder/Initialize(ml, material_key)
+	. = ..()
+	desc = "[initial(desc)] 'F' has been scribbled on it."
+
+/obj/item/storage/fancy/cigarettes/flash_powder/populate_reagents()
+	reagents.add_reagent(/decl/material/solid/metal/aluminium, max_storage_space)
+	reagents.add_reagent(/decl/material/solid/potassium,       max_storage_space)
+	reagents.add_reagent(/decl/material/solid/sulfur,          max_storage_space)
+
+//Chemsmoke Pack
+/obj/item/storage/fancy/cigarettes/chemsmoke/Initialize(ml, material_key)
+	. = ..()
+	desc = "[initial(desc)] 'S' has been scribbled on it."
+
+/obj/item/storage/fancy/cigarettes/chemsmoke/populate_reagents()
+	reagents.add_reagent(/decl/material/solid/potassium,        max_storage_space)
+	reagents.add_reagent(/decl/material/liquid/nutriment/sugar, max_storage_space)
+	reagents.add_reagent(/decl/material/solid/phosphorus,       max_storage_space)
+
+//Mindbreak Pack (now called /decl/chemical_reaction/hallucinogenics)
+/obj/item/storage/fancy/cigarettes/mindbreak/Initialize(ml, material_key)
+	. = ..()
+	desc = "[initial(desc)] 'MB' has been scribbled on it." //#TODO: maybe fix the lore for that?
+
+/obj/item/storage/fancy/cigarettes/mindbreak/populate_reagents()
+	reagents.add_reagent(/decl/material/solid/silicon,         max_storage_space)
+	reagents.add_reagent(/decl/material/liquid/fuel/hydrazine, max_storage_space)
+	reagents.add_reagent(/decl/material/liquid/antitoxins,     max_storage_space)
+
+//Tricord pack (now called /decl/material/liquid/regenerator)
+/obj/item/storage/fancy/cigarettes/tricord/Initialize(ml, material_key)
+	. = ..()
+	desc = "[initial(desc)] 'T' has been scribbled on it." //#TODO: maybe fix the lore for that?
+
+/obj/item/storage/fancy/cigarettes/tricord/populate_reagents()
+	reagents.add_reagent(/decl/material/liquid/regenerator, (4 * max_storage_space))

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -394,8 +394,10 @@
 	. = ..()
 	//Reset the name to the default cig pack. Done for codex reasons, since it indexes things by initial names
 	var/obj/item/storage/fancy/cigarettes/C = /obj/item/storage/fancy/cigarettes
-	SetName(initial(C.name))
-	desc = "[initial(desc)] 'F' has been scribbled on it."
+	if(name == initial(name))
+		SetName(initial(C.name))
+	if(desc == initial(desc))
+		desc = "[initial(desc)] 'F' has been scribbled on it."
 
 /obj/item/storage/fancy/cigarettes/flash_powder/populate_reagents()
 	reagents.add_reagent(/decl/material/solid/metal/aluminium, max_storage_space)
@@ -410,8 +412,10 @@
 	. = ..()
 	//Reset the name to the default cig pack. Done for codex reasons, since it indexes things by initial names
 	var/obj/item/storage/fancy/cigarettes/C = /obj/item/storage/fancy/cigarettes
-	SetName(initial(C.name))
-	desc = "[initial(desc)] 'S' has been scribbled on it."
+	if(name == initial(name))
+		SetName(initial(C.name))
+	if(desc == initial(desc))
+		desc = "[initial(desc)] 'S' has been scribbled on it."
 
 /obj/item/storage/fancy/cigarettes/chemsmoke/populate_reagents()
 	reagents.add_reagent(/decl/material/solid/potassium,        max_storage_space)
@@ -426,8 +430,10 @@
 	. = ..()
 	//Reset the name to the default cig pack. Done for codex reasons, since it indexes things by initial names
 	var/obj/item/storage/fancy/cigarettes/C = /obj/item/storage/fancy/cigarettes
-	SetName(initial(C.name))
-	desc = "[initial(desc)] 'MB' has been scribbled on it." //#TODO: maybe fix the lore for that?
+	if(name == initial(name))
+		SetName(initial(C.name))
+	if(desc == initial(desc))
+		desc = "[initial(desc)] 'MB' has been scribbled on it." //#TODO: maybe fix the lore for that?
 
 /obj/item/storage/fancy/cigarettes/mindbreak/populate_reagents()
 	reagents.add_reagent(/decl/material/solid/silicon,         max_storage_space)
@@ -442,8 +448,10 @@
 	. = ..()
 	//Reset the name to the default cig pack. Done for codex reasons, since it indexes things by initial names
 	var/obj/item/storage/fancy/cigarettes/C = /obj/item/storage/fancy/cigarettes
-	SetName(initial(C.name))
-	desc = "[initial(desc)] 'T' has been scribbled on it." //#TODO: maybe fix the lore for that?
+	if(name == initial(name))
+		SetName(initial(C.name))
+	if(desc == initial(desc))
+		desc = "[initial(desc)] 'T' has been scribbled on it." //#TODO: maybe fix the lore for that?
 
 /obj/item/storage/fancy/cigarettes/tricord/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/regenerator, (4 * max_storage_space))

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -387,8 +387,14 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // Flash Powder Pack
+/obj/item/storage/fancy/cigarettes/flash_powder
+	name = "pack of flash powder laced Trans-Stellar Duty-frees"
+
 /obj/item/storage/fancy/cigarettes/flash_powder/Initialize(ml, material_key)
 	. = ..()
+	//Reset the name to the default cig pack. Done for codex reasons, since it indexes things by initial names
+	var/obj/item/storage/fancy/cigarettes/C = /obj/item/storage/fancy/cigarettes
+	SetName(initial(C.name))
 	desc = "[initial(desc)] 'F' has been scribbled on it."
 
 /obj/item/storage/fancy/cigarettes/flash_powder/populate_reagents()
@@ -397,8 +403,14 @@
 	reagents.add_reagent(/decl/material/solid/sulfur,          max_storage_space)
 
 //Chemsmoke Pack
+/obj/item/storage/fancy/cigarettes/chemsmoke
+	name = "pack of smoke powder laced Trans-Stellar Duty-frees"
+
 /obj/item/storage/fancy/cigarettes/chemsmoke/Initialize(ml, material_key)
 	. = ..()
+	//Reset the name to the default cig pack. Done for codex reasons, since it indexes things by initial names
+	var/obj/item/storage/fancy/cigarettes/C = /obj/item/storage/fancy/cigarettes
+	SetName(initial(C.name))
 	desc = "[initial(desc)] 'S' has been scribbled on it."
 
 /obj/item/storage/fancy/cigarettes/chemsmoke/populate_reagents()
@@ -407,8 +419,14 @@
 	reagents.add_reagent(/decl/material/solid/phosphorus,       max_storage_space)
 
 //Mindbreak Pack (now called /decl/chemical_reaction/hallucinogenics)
+/obj/item/storage/fancy/cigarettes/mindbreak
+	name = "pack of mindbreak toxin laced Trans-Stellar Duty-frees" //#TODO: maybe fix the lore for that?
+
 /obj/item/storage/fancy/cigarettes/mindbreak/Initialize(ml, material_key)
 	. = ..()
+	//Reset the name to the default cig pack. Done for codex reasons, since it indexes things by initial names
+	var/obj/item/storage/fancy/cigarettes/C = /obj/item/storage/fancy/cigarettes
+	SetName(initial(C.name))
 	desc = "[initial(desc)] 'MB' has been scribbled on it." //#TODO: maybe fix the lore for that?
 
 /obj/item/storage/fancy/cigarettes/mindbreak/populate_reagents()
@@ -417,8 +435,14 @@
 	reagents.add_reagent(/decl/material/liquid/antitoxins,     max_storage_space)
 
 //Tricord pack (now called /decl/material/liquid/regenerator)
+/obj/item/storage/fancy/cigarettes/tricord
+	name = "pack of tricordazine laced Trans-Stellar Duty-frees" //#TODO: maybe fix the lore for that?
+
 /obj/item/storage/fancy/cigarettes/tricord/Initialize(ml, material_key)
 	. = ..()
+	//Reset the name to the default cig pack. Done for codex reasons, since it indexes things by initial names
+	var/obj/item/storage/fancy/cigarettes/C = /obj/item/storage/fancy/cigarettes
+	SetName(initial(C.name))
 	desc = "[initial(desc)] 'T' has been scribbled on it." //#TODO: maybe fix the lore for that?
 
 /obj/item/storage/fancy/cigarettes/tricord/populate_reagents()

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -27,7 +27,8 @@
 /obj/item/storage/firstaid/regular
 	icon_state = "firstaid"
 
-	startswith = list(
+/obj/item/storage/firstaid/regular/WillContain()
+	return list(
 		/obj/item/stack/medical/bruise_pack = 2,
 		/obj/item/stack/medical/ointment = 2,
 		/obj/item/storage/pill_bottle/antibiotics,
@@ -41,11 +42,10 @@
 	icon_state = "radfirstaid"
 	item_state = "firstaid-ointment"
 
-	startswith = list(
-		/obj/item/storage/med_pouch/trauma = 4
-		)
+/obj/item/storage/firstaid/trauma/WillContain()
+	return list(/obj/item/storage/med_pouch/trauma = 4)
 
-/obj/item/storage/firstaid/trauma/Initialize()
+/obj/item/storage/firstaid/trauma/Initialize(ml, material_key)
 	. = ..()
 	icon_state = pick("radfirstaid", "radfirstaid2", "radfirstaid3")
 
@@ -55,11 +55,10 @@
 	icon_state = "ointment"
 	item_state = "firstaid-ointment"
 
-	startswith = list(
-		/obj/item/storage/med_pouch/burn = 4
-		)
+/obj/item/storage/firstaid/fire/WillContain()
+	return list(/obj/item/storage/med_pouch/burn = 4)
 
-/obj/item/storage/firstaid/fire/Initialize()
+/obj/item/storage/firstaid/fire/Initialize(ml, material_key)
 	. = ..()
 	icon_state = pick("ointment","firefirstaid")
 
@@ -69,11 +68,10 @@
 	icon_state = "antitoxin"
 	item_state = "firstaid-toxin"
 
-	startswith = list(
-		/obj/item/storage/med_pouch/toxin = 4
-		)
+/obj/item/storage/firstaid/toxin/WillContain()
+	return list(/obj/item/storage/med_pouch/toxin = 4)
 
-/obj/item/storage/firstaid/toxin/Initialize()
+/obj/item/storage/firstaid/toxin/Initialize(ml, material_key)
 	. = ..()
 	icon_state = pick("antitoxin","antitoxfirstaid","antitoxfirstaid2","antitoxfirstaid3")
 
@@ -83,9 +81,8 @@
 	icon_state = "o2"
 	item_state = "firstaid-o2"
 
-	startswith = list(
-		/obj/item/storage/med_pouch/oxyloss = 4
-		)
+/obj/item/storage/firstaid/o2/WillContain()
+	return list(/obj/item/storage/med_pouch/oxyloss = 4)
 
 /obj/item/storage/firstaid/adv
 	name = "advanced first-aid kit"
@@ -93,7 +90,8 @@
 	icon_state = "purplefirstaid"
 	item_state = "firstaid-advanced"
 
-	startswith = list(
+/obj/item/storage/firstaid/adv/WillContain()
+	return list(
 		/obj/item/storage/pill_bottle/assorted,
 		/obj/item/stack/medical/advanced/bruise_pack = 3,
 		/obj/item/stack/medical/advanced/ointment = 2,
@@ -106,7 +104,8 @@
 	icon_state = "bezerk"
 	item_state = "firstaid-advanced"
 
-	startswith = list(
+/obj/item/storage/firstaid/combat/WillContain()
+	return list(
 		/obj/item/storage/pill_bottle/brute_meds,
 		/obj/item/storage/pill_bottle/burn_meds,
 		/obj/item/storage/pill_bottle/oxygen,
@@ -122,7 +121,8 @@
 	icon_state = "stabfirstaid"
 	item_state = "firstaid-advanced"
 
-	startswith = list(
+/obj/item/storage/firstaid/stab/WillContain()
+	return list(
 		/obj/item/storage/med_pouch/trauma,
 		/obj/item/storage/med_pouch/burn,
 		/obj/item/storage/med_pouch/oxyloss,
@@ -156,7 +156,8 @@
 		/obj/item/stack/nanopaste
 	)
 
-	startswith = list(
+/obj/item/storage/firstaid/surgery/WillContain()
+	return list(
 		/obj/item/bonesetter,
 		/obj/item/cautery,
 		/obj/item/circular_saw,
@@ -181,7 +182,8 @@
 		/obj/item/stack/cable_coil
 	)
 
-	startswith = list(
+/obj/item/storage/firstaid/surgery/ghetto/WillContain()
+	return list(
 		/obj/item/screwdriver,
 		/obj/item/wrench,
 		/obj/item/hatchet,

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -77,18 +77,16 @@
 	name = "lockbox of loyalty implants"
 	req_access = list(access_security)
 
-/obj/item/storage/lockbox/loyalty/Initialize()
-	. = ..()
-	new /obj/item/implantcase/loyalty(src)
-	new /obj/item/implantcase/loyalty(src)
-	new /obj/item/implantcase/loyalty(src)
-	new /obj/item/implanter/loyalty(src)
+/obj/item/storage/lockbox/loyalty/WillContain()
+	return list(
+		/obj/item/implantcase/loyalty = 3,
+		/obj/item/implanter/loyalty
+	)
 
 /obj/item/storage/lockbox/clusterbang
 	name = "lockbox of clusterbangs"
 	desc = "You have a bad feeling about opening this."
 	req_access = list(access_security)
 
-/obj/item/storage/lockbox/clusterbang/Initialize()
-	. = ..()
-	new /obj/item/grenade/flashbang/clusterbang(src)
+/obj/item/storage/lockbox/clusterbang/WillContain()
+	return list(/obj/item/grenade/flashbang/clusterbang)

--- a/code/game/objects/items/weapons/storage/lunchbox.dm
+++ b/code/game/objects/items/weapons/storage/lunchbox.dm
@@ -7,24 +7,22 @@
 	desc = "A little lunchbox. This one is the colors of the rainbow!"
 	w_class = ITEM_SIZE_NORMAL
 	max_w_class = ITEM_SIZE_SMALL
-	var/filled = FALSE
 	attack_verb = list("lunched")
 	material = /decl/material/solid/plastic
+	var/tmp/filled = FALSE
 
-/obj/item/storage/lunchbox/Initialize()
-	. = ..()
-	if(filled)
-		var/list/lunches = lunchables_lunches()
-		var/lunch = lunches[pick(lunches)]
-		new lunch(src)
-
-		var/list/snacks = lunchables_snacks()
-		var/snack = snacks[pick(snacks)]
-		new snack(src)
-
-		var/list/drinks = lunchables_drinks()
-		var/drink = drinks[pick(drinks)]
-		new drink(src)
+/obj/item/storage/lunchbox/WillContain()
+	if(!filled)
+		return
+	//#TODO: Those procs and that code is so overcomplicated for some reasons.
+	var/list/lunches = lunchables_lunches()
+	var/list/snacks  = lunchables_snacks()
+	var/list/drinks  = lunchables_drinks()
+	return list(
+		lunches[pick(lunches)],
+		snacks[pick(snacks)],
+		drinks[pick(drinks)],
+	)
 
 /obj/item/storage/lunchbox/filled
 	filled = TRUE

--- a/code/game/objects/items/weapons/storage/med_pouch.dm
+++ b/code/game/objects/items/weapons/storage/med_pouch.dm
@@ -15,7 +15,6 @@ Single Use Emergency Pouches
 	material = /decl/material/solid/plastic
 	var/injury_type = "generic"
 	var/static/image/cross_overlay
-
 	var/instructions = {"
 	1) Tear open the emergency medical pack using the easy open tab at the top.\n\
 	\t2) Carefully remove all items from the pouch and discard the pouch.\n\
@@ -27,7 +26,7 @@ Single Use Emergency Pouches
 	8) Stay in place once they respond.\
 		"}
 
-/obj/item/storage/med_pouch/Initialize()
+/obj/item/storage/med_pouch/Initialize(ml, material_key)
 	. = ..()
 	name = "emergency [injury_type] pouch"
 	make_exact_fit()
@@ -65,14 +64,6 @@ Single Use Emergency Pouches
 	name = "trauma pouch"
 	injury_type = "trauma"
 	color = COLOR_RED
-
-	startswith = list(
-	/obj/item/chems/hypospray/autoinjector/pouch_auto/stabilizer,
-	/obj/item/chems/hypospray/autoinjector/pouch_auto/painkillers,
-	/obj/item/chems/pill/pouch_pill/stabilizer,
-	/obj/item/chems/pill/pouch_pill/brute_meds,
-	/obj/item/stack/medical/bruise_pack = 2,
-		)
 	instructions = {"
 	1) Tear open the emergency medical pack using the easy open tab at the top.\n\
 	\t2) Carefully remove all items from the pouch and discard the pouch.\n\
@@ -83,18 +74,19 @@ Single Use Emergency Pouches
 	7) Stay in place once they respond.\
 		"}
 
+/obj/item/storage/med_pouch/trauma/WillContain()
+	return list(
+			/obj/item/chems/hypospray/autoinjector/pouch_auto/stabilizer,
+			/obj/item/chems/hypospray/autoinjector/pouch_auto/painkillers,
+			/obj/item/chems/pill/pouch_pill/stabilizer,
+			/obj/item/chems/pill/pouch_pill/brute_meds,
+			/obj/item/stack/medical/bruise_pack = 2,
+		)
+
 /obj/item/storage/med_pouch/burn
 	name = "burn pouch"
 	injury_type = "burn"
 	color = COLOR_SEDONA
-
-	startswith = list(
-	/obj/item/chems/hypospray/autoinjector/pouch_auto/nanoblood,
-	/obj/item/chems/hypospray/autoinjector/pouch_auto/painkillers,
-	/obj/item/chems/hypospray/autoinjector/pouch_auto/adrenaline,
-	/obj/item/chems/pill/pouch_pill/burn_meds,
-	/obj/item/stack/medical/ointment = 2,
-		)
 	instructions = {"
 	1) Tear open the emergency medical pack using the easy open tab at the top.\n\
 	\t2) Carefully remove all items from the pouch and discard the pouch.\n\
@@ -105,18 +97,19 @@ Single Use Emergency Pouches
 	7) Stay in place once they respond.\
 		"}
 
+/obj/item/storage/med_pouch/burn/WillContain()
+	return list(
+			/obj/item/chems/hypospray/autoinjector/pouch_auto/nanoblood,
+			/obj/item/chems/hypospray/autoinjector/pouch_auto/painkillers,
+			/obj/item/chems/hypospray/autoinjector/pouch_auto/adrenaline,
+			/obj/item/chems/pill/pouch_pill/burn_meds,
+			/obj/item/stack/medical/ointment = 2,
+		)
+
 /obj/item/storage/med_pouch/oxyloss
 	name = "low oxygen pouch"
 	injury_type = "low oxygen"
 	color = COLOR_BLUE
-
-	startswith = list(
-		/obj/item/chems/hypospray/autoinjector/pouch_auto/stabilizer,
-		/obj/item/chems/inhaler/pouch_auto/oxy_meds,
-		/obj/item/chems/hypospray/autoinjector/pouch_auto/adrenaline,
-		/obj/item/chems/pill/pouch_pill/stabilizer,
-		/obj/item/chems/pill/pouch_pill/oxy_meds
-	)
 	instructions = {"
 	1) Tear open the emergency medical pack using the easy open tab at the top.\n\
 	\t2) Carefully remove all items from the pouch and discard the pouch.\n\
@@ -128,15 +121,19 @@ Single Use Emergency Pouches
 	8) Stay in place once they respond.\
 		"}
 
+/obj/item/storage/med_pouch/oxyloss/WillContain()
+	return list(
+		/obj/item/chems/hypospray/autoinjector/pouch_auto/stabilizer,
+		/obj/item/chems/inhaler/pouch_auto/oxy_meds,
+		/obj/item/chems/hypospray/autoinjector/pouch_auto/adrenaline,
+		/obj/item/chems/pill/pouch_pill/stabilizer,
+		/obj/item/chems/pill/pouch_pill/oxy_meds
+	)
+
 /obj/item/storage/med_pouch/toxin
 	name = "toxin pouch"
 	injury_type = "toxin"
 	color = COLOR_GREEN
-
-	startswith = list(
-	/obj/item/chems/hypospray/autoinjector/pouch_auto/antitoxins,
-	/obj/item/chems/pill/pouch_pill/antitoxins
-		)
 	instructions = {"
 	1) Tear open the emergency medical pack using the easy open tab at the top.\n\
 	\t2) Carefully remove all items from the pouch and discard the pouch.\n\
@@ -145,16 +142,17 @@ Single Use Emergency Pouches
 	\t5) Contact the medical team with your location.
 	6) Stay in place once they respond.\
 		"}
+
+/obj/item/storage/med_pouch/toxin/WillContain()
+	return list(
+			/obj/item/chems/hypospray/autoinjector/pouch_auto/antitoxins,
+			/obj/item/chems/pill/pouch_pill/antitoxins
+		)
 
 /obj/item/storage/med_pouch/radiation
 	name = "radiation pouch"
 	injury_type = "radiation"
 	color = COLOR_AMBER
-
-	startswith = list(
-	/obj/item/chems/hypospray/autoinjector/antirad,
-	/obj/item/chems/pill/pouch_pill/antitoxins
-		)
 	instructions = {"
 	1) Tear open the emergency medical pack using the easy open tab at the top.\n\
 	\t2) Carefully remove all items from the pouch and discard the pouch.\n\
@@ -164,17 +162,16 @@ Single Use Emergency Pouches
 	6) Stay in place once they respond.\
 		"}
 
+/obj/item/storage/med_pouch/radiation/WillContain()
+	return list(
+			/obj/item/chems/hypospray/autoinjector/antirad,
+			/obj/item/chems/pill/pouch_pill/antitoxins
+		)
+
 /obj/item/storage/med_pouch/overdose
 	name = "overdose treatment pouch"
 	injury_type = "overdose"
 	color = COLOR_PALE_BLUE_GRAY
-
-	startswith = list(
-		/obj/item/chems/hypospray/autoinjector/pouch_auto/stabilizer,
-		/obj/item/chems/inhaler/pouch_auto/oxy_meds,
-		/obj/item/chems/inhaler/pouch_auto/detoxifier,
-		/obj/item/chems/hypospray/autoinjector/pouch_auto/adrenaline
-	)
 	instructions = {"
 	1) Tear open the emergency medical pack using the easy open tab at the top.\n\
 	\t2) Carefully remove all items from the pouch and discard the pouch.\n\
@@ -185,6 +182,14 @@ Single Use Emergency Pouches
 	8) Stay in place once they respond.\
 		"}
 
+/obj/item/storage/med_pouch/overdose/WillContain()
+	return list(
+		/obj/item/chems/hypospray/autoinjector/pouch_auto/stabilizer,
+		/obj/item/chems/inhaler/pouch_auto/oxy_meds,
+		/obj/item/chems/inhaler/pouch_auto/detoxifier,
+		/obj/item/chems/hypospray/autoinjector/pouch_auto/adrenaline
+	)
+
 // Pills
 
 /obj/item/chems/pill/pouch_pill
@@ -194,7 +199,7 @@ Single Use Emergency Pouches
 	volume     = 15
 	abstract_type = /obj/item/chems/pill/pouch_pill
 
-/obj/item/chems/pill/pouch_pill/Initialize()
+/obj/item/chems/pill/pouch_pill/Initialize(ml, material_key)
 	. = ..()
 	if(!reagents?.total_volume)
 		return INITIALIZE_HINT_QDEL

--- a/code/game/objects/items/weapons/storage/med_pouch.dm
+++ b/code/game/objects/items/weapons/storage/med_pouch.dm
@@ -28,8 +28,9 @@ Single Use Emergency Pouches
 
 /obj/item/storage/med_pouch/Initialize(ml, material_key)
 	. = ..()
-	name = "emergency [injury_type] pouch"
-	make_exact_fit()
+	SetName("emergency [injury_type] pouch")
+	if(length(contents))
+		make_exact_fit()
 	for(var/obj/item/chems/C in contents)
 		C.set_detail_color(color)
 

--- a/code/game/objects/items/weapons/storage/med_pouch.dm
+++ b/code/game/objects/items/weapons/storage/med_pouch.dm
@@ -203,6 +203,7 @@ Single Use Emergency Pouches
 /obj/item/chems/pill/pouch_pill/Initialize(ml, material_key)
 	. = ..()
 	if(!reagents?.total_volume)
+		log_warning("[log_info_line(src)] was deleted for containing no reagents during init!")
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/chems/pill/pouch_pill/initialize_reagents(populate = TRUE)

--- a/code/game/objects/items/weapons/storage/misc.dm
+++ b/code/game/objects/items/weapons/storage/misc.dm
@@ -5,10 +5,8 @@
 	icon_state = "dicebag"
 	material = /decl/material/solid/cloth
 
-/obj/item/storage/pill_bottle/dice/Initialize()
-	. = ..()
-	for(var/i = 1 to 7)
-		new /obj/item/dice( src )
+/obj/item/storage/pill_bottle/dice/WillContain()
+	return list(/obj/item/dice = 7)
 
 /obj/item/storage/pill_bottle/dice_nerd	//DnD dice
 	name = "bag of gaming dice"
@@ -16,16 +14,16 @@
 	icon = 'icons/obj/dice.dmi'
 	icon_state = "magicdicebag"
 
-/obj/item/storage/pill_bottle/dice_nerd/Initialize()
-	. = ..()
-	new /obj/item/dice/d4( src )
-	new /obj/item/dice( src )
-	new /obj/item/dice/d8( src )
-	new /obj/item/dice/d10( src )
-	new /obj/item/dice/d12( src )
-	new /obj/item/dice/d20( src )
-	new /obj/item/dice/d100( src )
-
+/obj/item/storage/pill_bottle/dice_nerd/WillContain()
+	return list(
+		/obj/item/dice/d4,
+		/obj/item/dice,
+		/obj/item/dice/d8,
+		/obj/item/dice/d10,
+		/obj/item/dice/d12,
+		/obj/item/dice/d20,
+		/obj/item/dice/d100,
+	)
 
 /obj/item/storage/box/donut
 	icon = 'icons/obj/food.dmi'
@@ -34,7 +32,8 @@
 	can_hold = list(/obj/item/chems/food/donut)
 	foldable = /obj/item/stack/material/cardstock
 
-	startswith = list(/obj/item/chems/food/donut = 6)
+/obj/item/storage/box/donut/WillContain()
+	return list(/obj/item/chems/food/donut = 6)
 
 /obj/item/storage/box/donut/on_update_icon()
 	. = ..()
@@ -47,8 +46,8 @@
 	if(LAZYLEN(cur_overlays))
 		add_overlay(cur_overlays)
 
-/obj/item/storage/box/donut/empty
-	startswith = null
+/obj/item/storage/box/donut/empty/WillContain()
+	return null
 
 //misc tobacco nonsense
 /obj/item/storage/cigpaper
@@ -62,20 +61,27 @@
 	max_storage_space = 10
 	throwforce = 2
 	slot_flags = SLOT_LOWER_BODY
-	startswith = list(/obj/item/paper/cig = 10)
 	material = /decl/material/solid/plastic
+
+/obj/item/storage/cigpaper/WillContain()
+	return list(/obj/item/paper/cig = 10)
 
 /obj/item/storage/cigpaper/fancy
 	name = "\improper Trident cigarette paper"
 	desc = "A fancy brand of Trident cigarette paper, for rolling your own cigarettes. Like a person who appreciates the finer things in life."
 	icon_state = "fancycigpaperbook"
-	startswith = list(/obj/item/paper/cig/fancy = 10)
+
+/obj/item/storage/cigpaper/fancy/WillContain()
+	return list(/obj/item/paper/cig/fancy = 10)
 
 /obj/item/storage/cigpaper/filters
 	name = "box of cigarette filters"
 	desc = "A box of generic cigarette filters for those who rolls their own but prefers others to inhale the fumes. Not endorsed by Late General Osmundsun."
 	icon_state = "filterbin"
-	startswith = list(/obj/item/paper/cig/filter = 10)
+
+/obj/item/storage/cigpaper/filters/WillContain()
+	return list(/obj/item/paper/cig/filter = 10)
+
 /obj/item/storage/chewables
 	name = "box of chewing wads master"
 	desc = "A generic brands of Waffle Co Wads, unflavored chews. Why do these exist?"
@@ -87,8 +93,10 @@
 	max_storage_space = 6
 	throwforce = 2
 	slot_flags = SLOT_LOWER_BODY
-	startswith = list(/obj/item/clothing/mask/chewable/tobacco = 6)
 	material = /decl/material/solid/metal/tin
+
+/obj/item/storage/chewables/WillContain()
+	return list(/obj/item/clothing/mask/chewable/tobacco = 6)
 
 //loose leaf
 /obj/item/storage/chewables/rollable
@@ -98,20 +106,26 @@
 /obj/item/storage/chewables/rollable/bad
 	name = "bag of Men at Arms tobacco"
 	desc = "A bag of coarse gritty tobacco marketed towards leather-necks."
-	startswith = list(/obj/item/chems/food/grown/dried_tobacco/bad = 8)
 	icon_state = "rollcoarse"
+
+/obj/item/storage/chewables/rollable/bad/WillContain()
+	return list(/obj/item/chems/food/grown/dried_tobacco/bad = 8)
 
 /obj/item/storage/chewables/rollable/generic
 	name = "bag of BluSpace tobacco"
 	desc = "Decent quality tobacco for mid-income earners and long haul space sailors."
-	startswith = list(/obj/item/chems/food/grown/dried_tobacco = 8)
 	icon_state = "rollgeneric"
+
+/obj/item/storage/chewables/rollable/generic/WillContain()
+	return list(/obj/item/chems/food/grown/dried_tobacco = 8)
 
 /obj/item/storage/chewables/rollable/fine
 	name = "bag of Golden Sol tobacco"
 	desc = "A exclusive brand of overpriced tobacco, allegedly grown at a lagrange point station in Sol system."
-	startswith = list(/obj/item/chems/food/grown/dried_tobacco/fine = 8)
 	icon_state = "rollfine"
+
+/obj/item/storage/chewables/rollable/fine/WillContain()
+	return list(/obj/item/chems/food/grown/dried_tobacco/fine = 8)
 
 //chewing tobacco
 /obj/item/storage/chewables/tobacco
@@ -119,20 +133,26 @@
 	desc = "A generic brand of chewing tobacco, for when you can't even be assed to light up."
 	icon_state = "chew_levi"
 	item_state = "Dpacket"
-	startswith = list(/obj/item/clothing/mask/chewable/tobacco/lenni = 6)
+
+/obj/item/storage/chewables/tobacco/WillContain()
+	return list(/obj/item/clothing/mask/chewable/tobacco/lenni = 6)
 
 /obj/item/storage/chewables/tobacco2
 	name = "tin of Red Lady chewing tobacco"
 	desc = "A finer grade of chewing tobacco."
 	icon_state = "chew_redman"
 	item_state = "redlady"
-	startswith = list(/obj/item/clothing/mask/chewable/tobacco/redlady = 6)
+
+/obj/item/storage/chewables/tobacco2/WillContain()
+	return list(/obj/item/clothing/mask/chewable/tobacco/redlady = 6)
 
 /obj/item/storage/chewables/tobacco3
 	name = "box of Nico-Tine gum"
 	desc = "A Sol-approved brand of nicotine gum. Cut out the middleman for your addiction fix."
 	icon_state = "chew_nico"
-	startswith = list(/obj/item/clothing/mask/chewable/tobacco/nico = 6)
+
+/obj/item/storage/chewables/tobacco3/WillContain()
+	return list(/obj/item/clothing/mask/chewable/tobacco/nico = 6)
 
 //non-tobacco
 /obj/item/storage/chewables/candy
@@ -143,21 +163,27 @@
 	desc = "A pack of delicious cookies, and possibly the only product in Getmores Chocolate Corp lineup that has any trace of chocolate in it."
 	icon_state = "cookiebag"
 	max_storage_space = 6
-	startswith = list(/obj/item/chems/food/cookie = 6)
+
+/obj/item/storage/chewables/candy/cookies/WillContain()
+	return list(/obj/item/chems/food/cookie = 6)
 
 /obj/item/storage/chewables/candy/gum
 	name = "pack of Rainbo-Gums"
 	desc = "A mixed pack of delicious fruit flavored bubble-gums!"
 	icon_state = "gumpack"
 	max_storage_space = 8
-	startswith = list(/obj/item/clothing/mask/chewable/candy/gum = 8)
+
+/obj/item/storage/chewables/candy/gum/WillContain()
+	return list(/obj/item/clothing/mask/chewable/candy/gum = 8)
 
 /obj/item/storage/chewables/candy/medicallollis
 	name = "pack of medicinal lollipops"
 	desc = "A mixed pack of medicinal flavored lollipops. These have no business being on store shelves."
 	icon_state = "lollipack"
 	max_storage_space = 20
-	startswith = list(/obj/item/clothing/mask/chewable/candy/lolli/meds = 20)
+
+/obj/item/storage/chewables/candy/medicallollis/WillContain()
+	return list(/obj/item/clothing/mask/chewable/candy/lolli/meds = 20)
 
 /obj/item/storage/medical_lolli_jar
 	name = "lollipops jar"
@@ -165,14 +191,16 @@
 	icon = 'icons/obj/items/storage/lollijar.dmi'
 	icon_state = "lollijar"
 	max_storage_space = 20
-	startswith = list(/obj/item/clothing/mask/chewable/candy/lolli/weak_meds = 15)
 	drop_sound = 'sound/foley/bottledrop1.ogg'
 	pickup_sound = 'sound/foley/bottlepickup1.ogg'
 	material = /decl/material/solid/glass
 
+/obj/item/storage/medical_lolli_jar/WillContain()
+	return list(/obj/item/clothing/mask/chewable/candy/lolli/weak_meds = 15)
+
 /obj/item/storage/medical_lolli_jar/on_update_icon()
 	. = ..()
-	if(contents.len)
+	if(length(contents))
 		icon_state = "lollijar"
 	else
 		icon_state = "lollijar_empty"

--- a/code/game/objects/items/weapons/storage/mre.dm
+++ b/code/game/objects/items/weapons/storage/mre.dm
@@ -29,7 +29,8 @@ MRE Stuff
 
 /obj/item/storage/mre/Initialize(ml, material_key)
 	. = ..()
-	make_exact_fit()
+	if(length(contents))
+		make_exact_fit()
 
 /obj/item/storage/mre/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/weapons/storage/mre.dm
+++ b/code/game/objects/items/weapons/storage/mre.dm
@@ -15,17 +15,19 @@ MRE Stuff
 	item_flags = ITEM_FLAG_HOLLOW
 	var/main_meal = /obj/item/storage/mrebag
 	var/meal_desc = "This one is menu 1, meat pizza."
-	startswith = list(
-	/obj/item/storage/mrebag/dessert,
-	/obj/item/storage/fancy/crackers,
-	/obj/random/mre/spread,
-	/obj/random/mre/drink,
-	/obj/random/mre/sauce,
-	/obj/item/kitchen/utensil/spork/plastic
+
+/obj/item/storage/mre/WillContain()
+	. = list(
+		main_meal,
+		/obj/item/storage/mrebag/dessert,
+		/obj/item/storage/fancy/crackers,
+		/obj/random/mre/spread,
+		/obj/random/mre/drink,
+		/obj/random/mre/sauce,
+		/obj/item/kitchen/utensil/spork/plastic
 	)
 
-/obj/item/storage/mre/Initialize()
-	create_objects_in_loc(src, main_meal)
+/obj/item/storage/mre/Initialize(ml, material_key)
 	. = ..()
 	make_exact_fit()
 
@@ -79,13 +81,16 @@ MRE Stuff
 	meal_desc = "This one is menu 9, boiled rice."
 	icon_state = "vegmre"
 	main_meal = /obj/item/storage/mrebag/menu9
-	startswith = list(
-	/obj/item/storage/mrebag/dessert/menu9,
-	/obj/item/storage/fancy/crackers,
-	/obj/random/mre/spread/vegan,
-	/obj/random/mre/drink,
-	/obj/random/mre/sauce/vegan,
-	/obj/item/kitchen/utensil/spoon/plastic
+
+/obj/item/storage/mre/menu9/WillContain()
+	. = list(
+		main_meal,
+		/obj/item/storage/mrebag/dessert/menu9,
+		/obj/item/storage/fancy/crackers,
+		/obj/random/mre/spread/vegan,
+		/obj/random/mre/drink,
+		/obj/random/mre/sauce/vegan,
+		/obj/item/kitchen/utensil/spoon/plastic
 	)
 
 /obj/item/storage/mre/menu10
@@ -93,11 +98,14 @@ MRE Stuff
 	meal_desc = "This one is menu 10, protein."
 	icon_state = "meatmre"
 	main_meal = /obj/item/storage/mrebag/menu10
-	startswith = list(
-	/obj/item/chems/food/candy/proteinbar,
-	/obj/item/chems/condiment/small/packet/protein,
-	/obj/random/mre/sauce/sugarfree,
-	/obj/item/kitchen/utensil/spoon/plastic
+
+/obj/item/storage/mre/menu10/WillContain()
+	. = list(
+		main_meal,
+		/obj/item/chems/food/candy/proteinbar,
+		/obj/item/chems/condiment/small/packet/protein,
+		/obj/random/mre/sauce/sugarfree,
+		/obj/item/kitchen/utensil/spoon/plastic
 	)
 
 /obj/item/storage/mre/menu11
@@ -105,11 +113,14 @@ MRE Stuff
 	meal_desc = "This one doesn't have a menu listing. How very odd."
 	icon_state = "crayonmre"
 	main_meal = /obj/item/storage/fancy/crayons
-	startswith = list(
-	/obj/item/storage/mrebag/dessert/menu11,
-	/obj/random/mre/sauce/crayon,
-	/obj/random/mre/sauce/crayon,
-	/obj/random/mre/sauce/crayon
+
+/obj/item/storage/mre/menu11/WillContain()
+	return list(
+		main_meal,
+		/obj/item/storage/mrebag/dessert/menu11,
+		/obj/random/mre/sauce/crayon,
+		/obj/random/mre/sauce/crayon,
+		/obj/random/mre/sauce/crayon
 	)
 
 /obj/item/storage/mre/menu11/special
@@ -129,9 +140,11 @@ MRE Stuff
 	max_w_class = ITEM_SIZE_SMALL
 	opened = FALSE
 	open_sound = 'sound/effects/bubbles.ogg'
-	startswith = list(/obj/item/chems/food/slice/meatpizza/filled)
 	material = /decl/material/solid/plastic
 	matter = list(/decl/material/solid/metal/aluminium = MATTER_AMOUNT_TRACE)
+
+/obj/item/storage/mrebag/WillContain()
+	return list(/obj/item/chems/food/slice/meatpizza/filled)
 
 /obj/item/storage/mrebag/on_update_icon()
 	. = ..()
@@ -146,42 +159,44 @@ MRE Stuff
 		to_chat(usr, "<span class='notice'>The pouch heats up as you break the vaccum seal.</span>")
 	. = ..()
 
-/obj/item/storage/mrebag/menu2
-	startswith = list(/obj/item/chems/food/slice/margherita/filled)
+/obj/item/storage/mrebag/menu2/WillContain()
+	return list(/obj/item/chems/food/slice/margherita/filled)
 
-/obj/item/storage/mrebag/menu3
-	startswith = list(/obj/item/chems/food/slice/vegetablepizza/filled)
+/obj/item/storage/mrebag/menu3/WillContain()
+	return list(/obj/item/chems/food/slice/vegetablepizza/filled)
 
-/obj/item/storage/mrebag/menu4
-	startswith = list(/obj/item/chems/food/hamburger)
+/obj/item/storage/mrebag/menu4/WillContain()
+	return list(/obj/item/chems/food/hamburger)
 
-/obj/item/storage/mrebag/menu5
-	startswith = list(/obj/item/chems/food/taco)
+/obj/item/storage/mrebag/menu5/WillContain()
+	return list(/obj/item/chems/food/taco)
 
-/obj/item/storage/mrebag/menu6
-	startswith = list(/obj/item/chems/food/slice/meatbread/filled)
+/obj/item/storage/mrebag/menu6/WillContain()
+	return list(/obj/item/chems/food/slice/meatbread/filled)
 
-/obj/item/storage/mrebag/menu7
-	startswith = list(/obj/item/chems/food/tossedsalad)
+/obj/item/storage/mrebag/menu7/WillContain()
+	return list(/obj/item/chems/food/tossedsalad)
 
-/obj/item/storage/mrebag/menu8
-	startswith = list(/obj/item/chems/food/hotchili)
+/obj/item/storage/mrebag/menu8/WillContain()
+	return list(/obj/item/chems/food/hotchili)
 
-/obj/item/storage/mrebag/menu9
-	startswith = list(/obj/item/chems/food/boiledrice)
+/obj/item/storage/mrebag/menu9/WillContain()
+	return list(/obj/item/chems/food/boiledrice)
 
-/obj/item/storage/mrebag/menu10
-	startswith = list(/obj/item/chems/food/meatcube)
+/obj/item/storage/mrebag/menu10/WillContain()
+	return list(/obj/item/chems/food/meatcube)
 
 /obj/item/storage/mrebag/dessert
 	name = "dessert"
 	desc = "A vacuum-sealed bag containing the MRE's dessert."
 	icon_state = "pouch_small"
 	open_sound = 'sound/effects/rip1.ogg'
-	startswith = list(/obj/random/mre/dessert)
 
-/obj/item/storage/mrebag/dessert/menu9
-	startswith = list(/obj/item/chems/food/plumphelmetbiscuit)
+/obj/item/storage/mrebag/dessert/WillContain()
+	return list(/obj/random/mre/dessert)
 
-/obj/item/storage/mrebag/dessert/menu11
-	startswith = list(/obj/item/pen/crayon/rainbow)
+/obj/item/storage/mrebag/dessert/menu9/WillContain()
+	return list(/obj/item/chems/food/plumphelmetbiscuit)
+
+/obj/item/storage/mrebag/dessert/menu11/WillContain()
+	return list(/obj/item/pen/crayon/rainbow)

--- a/code/game/objects/items/weapons/storage/picnic_basket.dm
+++ b/code/game/objects/items/weapons/storage/picnic_basket.dm
@@ -9,22 +9,19 @@
 	max_storage_space = DEFAULT_BOX_STORAGE
 	attack_verb = list("picnics")
 	material = /decl/material/solid/plastic
-	var/filled = FALSE
+	var/tmp/filled = FALSE
 
-/obj/item/storage/picnic_basket/Initialize()
-	. = ..()
-	if(filled)
-		var/list/lunches = lunchables_lunches()
-		var/lunch = lunches[pick(lunches)]
-		new lunch(src)
-
-		var/list/snacks = lunchables_snacks()
-		var/snack = snacks[pick(snacks)]
-		new snack(src)
-
-		var/list/drinks = lunchables_drinks()
-		var/drink = drinks[pick(drinks)]
-		new drink(src)
+/obj/item/storage/picnic_basket/WillContain()
+	if(!filled)
+		return
+	var/list/lunches = lunchables_lunches()
+	var/list/snacks  = lunchables_snacks()
+	var/list/drinks  = lunchables_drinks()
+	return list(
+		lunches[pick(lunches)],
+		snacks[pick(snacks)],
+		drinks[pick(drinks)],
+	)
 
 /obj/item/storage/picnic_basket/filled
 	filled = TRUE

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -124,10 +124,8 @@
 	icon_locking = "safeb"
 	icon_opened = "safe0"
 
-/obj/item/storage/secure/safe/Initialize()
-	. = ..()
-	new /obj/item/paper(src)
-	new /obj/item/pen(src)
-
-/obj/item/storage/secure/safe/attack_hand(mob/user)
-	return attack_self(user)
+/obj/item/storage/secure/safe/WillContain()
+	return list(
+		/obj/item/pen,
+		/obj/item/paper
+	)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -24,9 +24,6 @@
 	var/collection_mode = TRUE //FALSE = pick one at a time, TRUE = pick all on tile
 	var/use_sound = "rustle" //sound played when used. null for no sound.
 
-	//initializes the contents of the storage with some items based on an assoc list. The assoc key must be an item path,
-	//the assoc value can either be the quantity, or a list whose first value is the quantity and the rest are args.
-	var/list/startswith
 	var/datum/storage_ui/storage_ui = /datum/storage_ui/default
 	var/opened = null
 	var/open_sound = null
@@ -362,7 +359,7 @@
 
 	return FALSE
 
-/obj/item/storage/Initialize()
+/obj/item/storage/Initialize(ml, material_key)
 	. = ..()
 	if(allow_quick_empty)
 		verbs += /obj/item/storage/verb/quick_empty
@@ -380,18 +377,9 @@
 	storage_ui = new storage_ui(src)
 	prepare_ui()
 
-	if(startswith)
-		for(var/item_path in startswith)
-			var/list/data = startswith[item_path]
-			if(islist(data))
-				var/qty = data[1]
-				var/list/argsl = data.Copy()
-				argsl[1] = src
-				for(var/i in 1 to qty)
-					new item_path(arglist(argsl))
-			else
-				for(var/i in 1 to (isnull(data)? 1 : data))
-					new item_path(src)
+	var/list/will_contain = WillContain()
+	if(length(will_contain))
+		create_objects_in_loc(src, will_contain)
 		update_icon()
 
 /obj/item/storage/emp_act(severity)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -396,6 +396,8 @@
 			return 1
 
 /obj/item/storage/proc/make_exact_fit()
+	if(length(contents) <= 0)
+		log_warning("[type] is calling make_exact_fit() while completely empty! This is likely a mistake.")
 	storage_slots = contents.len
 
 	can_hold.Cut()

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -21,7 +21,10 @@
 
 /obj/item/storage/toolbox/emergency
 	name = "emergency toolbox"
-	startswith = list(
+
+/obj/item/storage/toolbox/emergency/WillContain()
+	return list(
+		new /datum/atom_creator/weighted(list(/obj/item/flashlight, /obj/item/flashlight/flare,  /obj/item/flashlight/flare/glowstick/red)),
 		/obj/item/crowbar/red,
 		/obj/item/extinguisher/mini,
 		/obj/item/radio,
@@ -29,34 +32,37 @@
 		/obj/item/welder_tank/mini
 	)
 
-/obj/item/storage/toolbox/emergency/Initialize()
-	. = ..()
-	var/item = pick(list(/obj/item/flashlight, /obj/item/flashlight/flare,  /obj/item/flashlight/flare/glowstick/red))
-	new item(src)
-
-
 /obj/item/storage/toolbox/mechanical
 	name = "mechanical toolbox"
 	desc = "Bright blue toolboxes like these are one of the most common sights in maintenance corridors on virtually every ship in the galaxy."
 	icon_state = "blue"
 	item_state = "toolbox_blue"
-	startswith = list(/obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/scanner/gas, /obj/item/wirecutters)
+
+/obj/item/storage/toolbox/mechanical/WillContain()
+	return list(
+			/obj/item/screwdriver, 
+			/obj/item/wrench, 
+			/obj/item/weldingtool, 
+			/obj/item/crowbar, 
+			/obj/item/scanner/gas, 
+			/obj/item/wirecutters
+		)
 
 /obj/item/storage/toolbox/electrical
 	name = "electrical toolbox"
 	desc = "Bright yellow toolboxes like these are one of the most common sights in maintenance corridors on virtually every ship in the galaxy."
 	icon_state = "yellow"
 	item_state = "toolbox_yellow"
-	startswith = list(/obj/item/screwdriver, /obj/item/wirecutters, /obj/item/t_scanner, /obj/item/crowbar)
 
-/obj/item/storage/toolbox/electrical/Initialize()
-	. = ..()
-	new /obj/item/stack/cable_coil/random(src,30)
-	new /obj/item/stack/cable_coil/random(src,30)
-	if(prob(5))
-		new /obj/item/clothing/gloves/insulated(src)
-	else
-		new /obj/item/stack/cable_coil/random(src,30)
+/obj/item/storage/toolbox/electrical/WillContain()
+	return list(
+			new /datum/atom_creator/weighted(list(/obj/item/clothing/gloves/insulated = 5, /obj/item/stack/cable_coil/random = 95)),
+			/obj/item/stack/cable_coil/random = 2,
+			/obj/item/screwdriver, 
+			/obj/item/wirecutters, 
+			/obj/item/t_scanner, 
+			/obj/item/crowbar
+		)
 
 /obj/item/storage/toolbox/syndicate
 	name = "black and red toolbox"
@@ -65,17 +71,35 @@
 	item_state = "toolbox_syndi"
 	origin_tech = "{'combat':1,'esoteric':1}"
 	attack_cooldown = 10
-	startswith = list(/obj/item/clothing/gloves/insulated, /obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/wirecutters, /obj/item/multitool)
 
-/obj/item/storage/toolbox/syndicate/powertools
-	startswith = list(/obj/item/clothing/gloves/insulated, /obj/item/power_drill, /obj/item/weldingtool/electric, /obj/item/hydraulic_cutter, /obj/item/multitool)
+/obj/item/storage/toolbox/syndicate/WillContain()
+	return list(
+			/obj/item/clothing/gloves/insulated, 
+			/obj/item/screwdriver, 
+			/obj/item/wrench, 
+			/obj/item/weldingtool, 
+			/obj/item/crowbar, 
+			/obj/item/wirecutters, 
+			/obj/item/multitool
+		)
+
+/obj/item/storage/toolbox/syndicate/powertools/WillContain()
+	return list(
+			/obj/item/clothing/gloves/insulated, 
+			/obj/item/power_drill, 
+			/obj/item/weldingtool/electric, 
+			/obj/item/hydraulic_cutter, 
+			/obj/item/multitool
+		)
 
 /obj/item/storage/toolbox/repairs
 	name = "electronics toolbox"
 	desc = "A box full of boxes, with electrical machinery parts and tools needed to get them where they're needed."
 	icon_state = "yellow_striped"
 	item_state = "toolbox_yellow"
-	startswith = list(
+
+/obj/item/storage/toolbox/repairs/WillContain()
+	return list(
 		/obj/item/stack/cable_coil,
 		/obj/item/screwdriver,
 		/obj/item/wrench,

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -1,3 +1,7 @@
+/proc/fill_cigarre_package(var/obj/item/storage/fancy/cigarettes/C, var/list/reagents)
+	for(var/reagent in reagents)
+		C.reagents.add_reagent(reagent, reagents[reagent] * C.max_storage_space)
+
 /obj/item/storage/box/syndie_kit
 	name = "box"
 	desc = "A sleek, sturdy box."
@@ -14,50 +18,39 @@
 	desc = "A sleek, sturdy dufflebag."
 	icon = 'icons/obj/items/storage/backpack/dufflebag_syndie.dmi'
 
-/obj/item/storage/box/syndie_kit/imp_freedom
-	startswith = list(/obj/item/implanter/freedom)
+/obj/item/storage/box/syndie_kit/imp_freedom/WillContain()
+	return list(/obj/item/implanter/freedom)
 
-/obj/item/storage/box/syndie_kit/imp_uplink
-	startswith = list(/obj/item/implanter/uplink)
+/obj/item/storage/box/syndie_kit/imp_uplink/WillContain()
+	return list(/obj/item/implanter/uplink)
 
-/obj/item/storage/box/syndie_kit/imp_compress
-	startswith = list(/obj/item/implanter/compressed)
+/obj/item/storage/box/syndie_kit/imp_compress/WillContain()
+	return list(/obj/item/implanter/compressed)
 
-/obj/item/storage/box/syndie_kit/imp_explosive
-	startswith = list(
-		/obj/item/implanter/explosive,
-		/obj/item/implantpad
+/obj/item/storage/box/syndie_kit/imp_explosive/WillContain()
+	return list(
+			/obj/item/implanter/explosive,
+			/obj/item/implantpad
 		)
 
-/obj/item/storage/box/syndie_kit/imp_imprinting
-	startswith = list(
-		/obj/item/implanter/imprinting,
-		/obj/item/implantpad,
-		/obj/item/chems/hypospray/autoinjector/hallucinogenics
+/obj/item/storage/box/syndie_kit/imp_imprinting/WillContain()
+	return list(
+			/obj/item/implanter/imprinting,
+			/obj/item/implantpad,
+			/obj/item/chems/hypospray/autoinjector/hallucinogenics
 		)
 
 // Space suit uplink kit
-/obj/item/storage/backpack/satchel/syndie_kit/space
-	//name = "\improper EVA gear pack"
-
-	startswith = list(
-		/obj/item/clothing/suit/space/void/merc,
-		/obj/item/clothing/head/helmet/space/void/merc,
-		/obj/item/clothing/mask/gas/syndicate,
-		/obj/item/tank/emergency/oxygen/double,
+/obj/item/storage/backpack/satchel/syndie_kit/space/WillContain()
+	return list(
+			/obj/item/clothing/suit/space/void/merc,
+			/obj/item/clothing/head/helmet/space/void/merc,
+			/obj/item/clothing/mask/gas/syndicate,
+			/obj/item/tank/emergency/oxygen/double,
 		)
 
 // Chameleon uplink kit
 /obj/item/storage/backpack/chameleon/sydie_kit
-	startswith = list(
-		/obj/item/clothing/under/chameleon,
-		/obj/item/clothing/suit/chameleon,
-		/obj/item/clothing/shoes/chameleon,
-		/obj/item/clothing/head/chameleon,
-		/obj/item/clothing/mask/chameleon,
-		/obj/item/storage/box/syndie_kit/chameleon,
-		/obj/item/gun/energy/chameleon,
-		)
 	material = /decl/material/solid/metal/gold
 	matter = list(
 		/decl/material/solid/gemstone/diamond = MATTER_AMOUNT_REINFORCEMENT,
@@ -66,53 +59,64 @@
 		/decl/material/solid/metal/uranium = MATTER_AMOUNT_TRACE
 	) 
 
-/obj/item/storage/box/syndie_kit/chameleon
-	startswith = list(
-		/obj/item/clothing/gloves/chameleon,
-		/obj/item/clothing/glasses/chameleon,
-		/obj/item/radio/headset/chameleon,
-		/obj/item/clothing/accessory/chameleon,
-		/obj/item/clothing/accessory/chameleon,
-		/obj/item/clothing/accessory/chameleon
+/obj/item/storage/backpack/chameleon/sydie_kit/WillContain()
+	return list(
+			/obj/item/clothing/under/chameleon,
+			/obj/item/clothing/suit/chameleon,
+			/obj/item/clothing/shoes/chameleon,
+			/obj/item/clothing/head/chameleon,
+			/obj/item/clothing/mask/chameleon,
+			/obj/item/storage/box/syndie_kit/chameleon,
+			/obj/item/gun/energy/chameleon,
+		)
+
+/obj/item/storage/box/syndie_kit/chameleon/WillContain()
+	return list(
+			/obj/item/clothing/gloves/chameleon,
+			/obj/item/clothing/glasses/chameleon,
+			/obj/item/radio/headset/chameleon,
+			/obj/item/clothing/accessory/chameleon,
+			/obj/item/clothing/accessory/chameleon,
+			/obj/item/clothing/accessory/chameleon
 		)
 
 // Clerical uplink kit
-/obj/item/storage/backpack/satchel/syndie_kit/clerical
-	startswith = list(
-		/obj/item/stack/package_wrap/twenty_five,
-		/obj/item/hand_labeler,
-		/obj/item/stamp/chameleon,
-		/obj/item/pen/chameleon,
-		/obj/item/destTagger,
+/obj/item/storage/backpack/satchel/syndie_kit/clerical/WillContain()
+	return list(
+			/obj/item/stack/package_wrap/twenty_five,
+			/obj/item/hand_labeler,
+			/obj/item/stamp/chameleon,
+			/obj/item/pen/chameleon,
+			/obj/item/destTagger,
 		)
 
-/obj/item/storage/box/syndie_kit/spy
-	startswith = list(
+/obj/item/storage/box/syndie_kit/spy/WillContain()
+	return list(
 		/obj/item/spy_bug = 6,
 		/obj/item/spy_monitor
 	)
 
-/obj/item/storage/box/syndie_kit/silenced
-	startswith = list(
+/obj/item/storage/box/syndie_kit/silenced/WillContain()
+	return list(
 		/obj/item/gun/projectile/pistol/holdout,
 		/obj/item/silencer,
 		/obj/item/ammo_magazine/pistol/small
 	)
 
-/obj/item/storage/backpack/satchel/syndie_kit/revolver
-	startswith = list(
+/obj/item/storage/backpack/satchel/syndie_kit/revolver/WillContain()
+	return list(
 		/obj/item/gun/projectile/revolver,
 		/obj/item/ammo_magazine/speedloader
 	)
 
-/obj/item/storage/box/syndie_kit/toxin
-	startswith = list(
+/obj/item/storage/box/syndie_kit/toxin/WillContain()
+	return list(
 		/obj/item/chems/glass/beaker/vial/random/toxin,
 		/obj/item/chems/syringe
 	)
 
-/obj/item/storage/box/syndie_kit/syringegun
-	startswith = list(
+/obj/item/storage/box/syndie_kit/syringegun/WillContain()
+	return list(
 		/obj/item/gun/launcher/syringe/disguised,
 		/obj/item/syringe_cartridge = 4,
 		/obj/item/chems/syringe = 4
@@ -122,62 +126,37 @@
 	name = "\improper Tricky smokes"
 	desc = "Smokes so good, you'd think it was a trick!"
 
-/obj/item/storage/box/syndie_kit/cigarette/Initialize()
-	. = ..()
-	var/obj/item/storage/fancy/cigarettes/pack
-	pack = new /obj/item/storage/fancy/cigarettes(src)
-	fill_cigarre_package(pack, list(/decl/material/solid/metal/aluminium = 1, /decl/material/solid/potassium = 1, /decl/material/solid/sulfur = 1))
-	pack.desc += " 'F' has been scribbled on it."
-
-	pack = new /obj/item/storage/fancy/cigarettes(src)
-	fill_cigarre_package(pack, list(/decl/material/solid/metal/aluminium = 1, /decl/material/solid/potassium = 1, /decl/material/solid/sulfur = 1))
-	pack.desc += " 'F' has been scribbled on it."
-
-	pack = new /obj/item/storage/fancy/cigarettes(src)
-	fill_cigarre_package(pack, list(/decl/material/solid/potassium = 1, /decl/material/liquid/nutriment/sugar = 1, /decl/material/solid/phosphorus = 1))
-	pack.desc += " 'S' has been scribbled on it."
-
-	pack = new /obj/item/storage/fancy/cigarettes(src)
-	fill_cigarre_package(pack, list(/decl/material/solid/potassium = 1, /decl/material/liquid/nutriment/sugar = 1, /decl/material/solid/phosphorus = 1))
-	pack.desc += " 'S' has been scribbled on it."
-
-	pack = new /obj/item/storage/fancy/cigarettes(src)
-	fill_cigarre_package(pack, list(/decl/material/liquid/antitoxins = 1, /decl/material/solid/silicon = 1, /decl/material/liquid/fuel/hydrazine = 1))
-	pack.desc += " 'MB' has been scribbled on it."
-
-	pack = new /obj/item/storage/fancy/cigarettes(src)
-	fill_cigarre_package(pack, list(/decl/material/liquid/regenerator = 4))
-	pack.desc += " 'T' has been scribbled on it."
-
-	new /obj/item/flame/lighter/zippo(src)
-
-/proc/fill_cigarre_package(var/obj/item/storage/fancy/cigarettes/C, var/list/reagents)
-	for(var/reagent in reagents)
-		C.reagents.add_reagent(reagent, reagents[reagent] * C.max_storage_space)
-
-//Rig Electrowarfare and Voice Synthesiser kit
-/obj/item/storage/backpack/satchel/syndie_kit/ewar_voice
-	startswith = list(
-		/obj/item/rig_module/electrowarfare_suite,
-		/obj/item/rig_module/voice,
+/obj/item/storage/box/syndie_kit/cigarette/WillContain()
+	return list(
+		/obj/item/storage/fancy/cigarettes/flash_powder = 2,
+		/obj/item/storage/fancy/cigarettes/chemsmoke = 2,
+		/obj/item/storage/fancy/cigarettes/mindbreak,
+		/obj/item/storage/fancy/cigarettes/tricord,
+		/obj/item/flame/lighter/zippo/random,
 		)
 
-/obj/item/storage/secure/briefcase/heavysniper
-	startswith = list(
+//Rig Electrowarfare and Voice Synthesiser kit
+/obj/item/storage/backpack/satchel/syndie_kit/ewar_voice/WillContain()
+	return list(
+			/obj/item/rig_module/electrowarfare_suite,
+			/obj/item/rig_module/voice,
+		)
+
+/obj/item/storage/secure/briefcase/heavysniper/WillContain()
+	return list(
 		/obj/item/gun/projectile/bolt_action/sniper,
 		/obj/item/storage/box/ammo/sniperammo
 	)
 
-/obj/item/storage/secure/briefcase/heavysniper/Initialize()
+/obj/item/storage/secure/briefcase/heavysniper/Initialize(ml, material_key)
 	. = ..()
 	make_exact_fit()
 
-/obj/item/storage/secure/briefcase/money
+/obj/item/storage/secure/briefcase/money/WillContain()
+	return list(/obj/item/cash/c1000 = 10)
 
-	startswith = list(/obj/item/cash/c1000 = 10)
-
-/obj/item/storage/backpack/satchel/syndie_kit/armor
-	startswith = list(
+/obj/item/storage/backpack/satchel/syndie_kit/armor/WillContain()
+	return list(
 		/obj/item/clothing/suit/armor/pcarrier/merc,
 		/obj/item/clothing/head/helmet/merc
 	)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -150,7 +150,8 @@
 
 /obj/item/storage/secure/briefcase/heavysniper/Initialize(ml, material_key)
 	. = ..()
-	make_exact_fit()
+	if(length(contents))
+		make_exact_fit()
 
 /obj/item/storage/secure/briefcase/money/WillContain()
 	return list(/obj/item/cash/c1000 = 10)

--- a/code/game/objects/items/weapons/storage/wall_mirror.dm
+++ b/code/game/objects/items/weapons/storage/wall_mirror.dm
@@ -28,15 +28,18 @@
 	use_sound = 'sound/effects/closet_open.ogg'
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = DEFAULT_LARGEBOX_STORAGE
-	startswith = list(
-		/obj/item/haircomb/random,
-		/obj/item/haircomb/brush,
-		/obj/random/medical/lite,
-		/obj/item/lipstick,
-		/obj/random/lipstick,
-		/obj/random/soap,
-		/obj/item/chems/spray/cleaner/deodorant,
-		/obj/item/towel/random)
+
+/obj/item/storage/internal/mirror_storage/WillContain()
+	return list(
+			/obj/item/haircomb/random,
+			/obj/item/haircomb/brush,
+			/obj/random/medical/lite,
+			/obj/item/lipstick,
+			/obj/random/lipstick,
+			/obj/random/soap,
+			/obj/item/chems/spray/cleaner/deodorant,
+			/obj/item/towel/random
+		)
 
 /obj/structure/mirror/Destroy()
 	QDEL_NULL(mirror_storage)

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -95,27 +95,22 @@
 /obj/item/storage/wallet/GetChargeStick()
 	return front_stick
 
-/obj/item/storage/wallet/random/Initialize()
-	. = ..()
-	var/item1_type = pick( /obj/item/cash/c10,/obj/item/cash/c100,/obj/item/cash/c1000,/obj/item/cash/c20,/obj/item/cash/c200,/obj/item/cash/c50, /obj/item/cash/c500)
-	var/item2_type
-	if(prob(50))
-		item2_type = pick( /obj/item/cash/c10,/obj/item/cash/c100,/obj/item/cash/c1000,/obj/item/cash/c20,/obj/item/cash/c200,/obj/item/cash/c50, /obj/item/cash/c500)
-	var/item3_type = pick( /obj/item/coin/silver, /obj/item/coin/silver, /obj/item/coin/gold, /obj/item/coin/iron, /obj/item/coin/iron, /obj/item/coin/iron )
+/obj/item/storage/wallet/random/WillContain()
+	return list(
+		new /datum/atom_creator/weighted(list(/obj/item/cash/c10,/obj/item/cash/c100,/obj/item/cash/c1000,/obj/item/cash/c20,/obj/item/cash/c200,/obj/item/cash/c50, /obj/item/cash/c500)),
+		new /datum/atom_creator/simple(list(/obj/item/cash/c10,/obj/item/cash/c100,/obj/item/cash/c1000,/obj/item/cash/c20,/obj/item/cash/c200,/obj/item/cash/c50, /obj/item/cash/c500), 50),
+		new /datum/atom_creator/weighted(list(/obj/item/coin/silver, /obj/item/coin/silver, /obj/item/coin/gold, /obj/item/coin/iron, /obj/item/coin/iron, /obj/item/coin/iron)),
+	)
 
-	if(item1_type)
-		new item1_type(src)
-	if(item2_type)
-		new item2_type(src)
-	if(item3_type)
-		new item3_type(src)
+/obj/item/storage/wallet/random/Initialize(ml, material_key)
+	. = ..()
 	update_icon()
 
 /obj/item/storage/wallet/poly
 	name = "polychromic wallet"
 	desc = "You can recolor it! Fancy! The future is NOW!"
 
-/obj/item/storage/wallet/poly/Initialize()
+/obj/item/storage/wallet/poly/Initialize(ml, material_key)
 	. = ..()
 	color = get_random_colour()
 	update_icon()

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -96,11 +96,12 @@
 	return front_stick
 
 /obj/item/storage/wallet/random/WillContain()
-	return list(
+	. = list(
 		new /datum/atom_creator/weighted(list(/obj/item/cash/c10,/obj/item/cash/c100,/obj/item/cash/c1000,/obj/item/cash/c20,/obj/item/cash/c200,/obj/item/cash/c50, /obj/item/cash/c500)),
-		new /datum/atom_creator/simple(list(/obj/item/cash/c10,/obj/item/cash/c100,/obj/item/cash/c1000,/obj/item/cash/c20,/obj/item/cash/c200,/obj/item/cash/c50, /obj/item/cash/c500), 50),
 		new /datum/atom_creator/weighted(list(/obj/item/coin/silver, /obj/item/coin/silver, /obj/item/coin/gold, /obj/item/coin/iron, /obj/item/coin/iron, /obj/item/coin/iron)),
 	)
+	if(prob(50))
+		. += new /datum/atom_creator/weighted(list(/obj/item/cash/c10,/obj/item/cash/c100,/obj/item/cash/c1000,/obj/item/cash/c20,/obj/item/cash/c200,/obj/item/cash/c50, /obj/item/cash/c500))
 
 /obj/item/storage/wallet/random/Initialize(ml, material_key)
 	. = ..()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -254,7 +254,7 @@
 
 /**
  * Returns a list with the contents that may be spawned in this object.
- * This shouldn't include things that are neccessary for the object to operate, like machine components. 
+ * This shouldn't include things that are necessary for the object to operate, like machine components. 
  * Its mainly for populating storage and the like.
  */
 /obj/proc/WillContain()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -252,6 +252,12 @@
 /obj/proc/populate_reagents()
 	return
 
+/**
+ * Returns a list with the contents that may be spawned in this object.
+ */
+/obj/proc/WillContain()
+	return
+
 ////////////////////////////////////////////////////////////////
 // Interactions
 ////////////////////////////////////////////////////////////////

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -254,6 +254,8 @@
 
 /**
  * Returns a list with the contents that may be spawned in this object.
+ * This shouldn't include things that are neccessary for the object to operate, like machine components. 
+ * Its mainly for populating storage and the like.
  */
 /obj/proc/WillContain()
 	return

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -55,9 +55,6 @@ var/global/list/closets = list()
 	if(!opened && mapload) // if closed and it's the map loading phase, relevant items at the crate's loc are put in the contents
 		store_contents()
 
-/obj/structure/closet/proc/WillContain()
-	return null
-
 /obj/structure/closet/examine(mob/user, distance)
 	. = ..()
 	if(distance <= 1 && !opened)

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -41,8 +41,8 @@
 	closet_appearance = null
 	req_access = list(access_heads_vault)
 
-/obj/structure/closet/secure_closet/freezer/money/Initialize()
-	. = ..()
+/obj/structure/closet/secure_closet/freezer/money/WillContain()
+	. = list()
 	//let's make hold a substantial amount.
 	var/created_size = 0
 	for(var/i = 1 to 200) //sanity loop limit
@@ -50,6 +50,6 @@
 		var/bundle_size = initial(cash_type.w_class) / 2
 		if(created_size + bundle_size <= storage_capacity)
 			created_size += bundle_size
-			new cash_type(src)
+			. += cash_type
 		else
 			break

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -47,8 +47,6 @@
 		/obj/item/flashlight
 		)
 
-/obj/structure/closet/firecloset/chief
-
 /obj/structure/closet/firecloset/chief/WillContain()
 	return list(
 		/obj/item/storage/med_pouch/burn,
@@ -67,38 +65,24 @@
 	desc = "It's a storage unit for tools."
 	closet_appearance = /decl/closet_appearance/secure_closet/engineering/tools
 
-/obj/structure/closet/toolcloset/Initialize()
-	. = ..()
-	if(prob(40))
-		new /obj/item/clothing/suit/storage/hazardvest(src)
-	if(prob(70))
-		new /obj/item/flashlight(src)
-	if(prob(70))
-		new /obj/item/screwdriver(src)
-	if(prob(70))
-		new /obj/item/wrench(src)
-	if(prob(70))
-		new /obj/item/weldingtool(src)
-	if(prob(70))
-		new /obj/item/crowbar(src)
-	if(prob(70))
-		new /obj/item/wirecutters(src)
-	if(prob(70))
-		new /obj/item/t_scanner(src)
-	if(prob(20))
-		new /obj/item/storage/belt/utility(src)
-	if(prob(30))
-		new /obj/item/stack/cable_coil/random(src)
-	if(prob(30))
-		new /obj/item/stack/cable_coil/random(src)
-	if(prob(30))
-		new /obj/item/stack/cable_coil/random(src)
-	if(prob(20))
-		new /obj/item/multitool(src)
-	if(prob(5))
-		new /obj/item/clothing/gloves/insulated(src)
-	if(prob(40))
-		new /obj/item/clothing/head/hardhat(src)
+/obj/structure/closet/firecloset/chief/WillContain()
+	return list(
+		new /datum/atom_creator/simple(/obj/item/clothing/suit/storage/hazardvest, 40),
+		new /datum/atom_creator/simple(/obj/item/flashlight,                70),
+		new /datum/atom_creator/simple(/obj/item/screwdriver,               70),
+		new /datum/atom_creator/simple(/obj/item/wrench,                    70),
+		new /datum/atom_creator/simple(/obj/item/weldingtool,               70),
+		new /datum/atom_creator/simple(/obj/item/crowbar,                   70),
+		new /datum/atom_creator/simple(/obj/item/wirecutters,               70),
+		new /datum/atom_creator/simple(/obj/item/t_scanner,                 70),
+		new /datum/atom_creator/simple(/obj/item/storage/belt/utility,      20),
+		new /datum/atom_creator/simple(/obj/item/stack/cable_coil/random,   30),
+		new /datum/atom_creator/simple(/obj/item/stack/cable_coil/random,   30),
+		new /datum/atom_creator/simple(/obj/item/stack/cable_coil/random,   30),
+		new /datum/atom_creator/simple(/obj/item/multitool,                 20),
+		new /datum/atom_creator/simple(/obj/item/clothing/gloves/insulated,  5),
+		new /datum/atom_creator/simple(/obj/item/clothing/head/hardhat,     40),
+	)
 
 
 /*
@@ -112,10 +96,8 @@
 /obj/structure/closet/radiation/WillContain()
 	return list(
 		/obj/item/storage/med_pouch/radiation = 2,
-		/obj/item/clothing/suit/radiation,
-		/obj/item/clothing/head/radiation,
-		/obj/item/clothing/suit/radiation,
-		/obj/item/clothing/head/radiation,
+		/obj/item/clothing/suit/radiation = 2,
+		/obj/item/clothing/head/radiation = 2,
 		/obj/item/geiger = 2)
 
 /*
@@ -161,7 +143,7 @@
 	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'EAST':{'x':-32}, 'WEST':{'x':32}}"
 	
-/obj/structure/closet/hydrant/Initialize()
+/obj/structure/closet/hydrant/Initialize(ml, _mat, _reinf_mat)
 	. = ..()
 	tool_interaction_flags &= ~TOOL_INTERACTION_ANCHOR
 

--- a/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
@@ -7,382 +7,313 @@
 	name = "security wardrobe"
 	closet_appearance = /decl/closet_appearance/wardrobe/red
 
-/obj/structure/closet/wardrobe/red/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/security(src)
-	new /obj/item/clothing/under/security(src)
-	new /obj/item/clothing/under/security(src)
-	new /obj/item/clothing/under/security2(src)
-	new /obj/item/clothing/under/security2(src)
-	new /obj/item/clothing/under/security2(src)
-	new /obj/item/clothing/shoes/jackboots(src)
-	new /obj/item/clothing/shoes/jackboots(src)
-	new /obj/item/clothing/shoes/jackboots(src)
-	new /obj/item/clothing/head/soft/sec(src)
-	new /obj/item/clothing/head/soft/sec(src)
-	new /obj/item/clothing/head/soft/sec(src)
+/obj/structure/closet/wardrobe/red/WillContain()
+	return list(
+		/obj/item/clothing/under/security  = 3,
+		/obj/item/clothing/under/security2 = 3,
+		/obj/item/clothing/shoes/jackboots = 3,
+		/obj/item/clothing/head/soft/sec   = 3,
+	)
 
 /obj/structure/closet/wardrobe/pink
 	name = "pink wardrobe"
 	closet_appearance = /decl/closet_appearance/wardrobe/pink
 
 
-/obj/structure/closet/wardrobe/pink/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/color/pink(src)
-	new /obj/item/clothing/under/color/pink(src)
-	new /obj/item/clothing/under/color/pink(src)
-	new /obj/item/clothing/shoes/color/brown(src)
-	new /obj/item/clothing/shoes/color/brown(src)
-	new /obj/item/clothing/shoes/color/brown(src)
+/obj/structure/closet/wardrobe/pink/WillContain()
+	return list(
+		/obj/item/clothing/under/color/pink  = 3,
+		/obj/item/clothing/shoes/color/brown = 3,
+	)
 
 /obj/structure/closet/wardrobe/black
 	name = "black wardrobe"
 	closet_appearance = /decl/closet_appearance/wardrobe/black
 
-/obj/structure/closet/wardrobe/black/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/color/black(src)
-	new /obj/item/clothing/under/color/black(src)
-	new /obj/item/clothing/under/color/black(src)
-	new /obj/item/clothing/shoes/color/black(src)
-	new /obj/item/clothing/shoes/color/black(src)
-	new /obj/item/clothing/shoes/color/black(src)
-	new /obj/item/clothing/head/that(src)
-	new /obj/item/clothing/head/that(src)
-	new /obj/item/clothing/head/that(src)
-	new /obj/item/clothing/head/soft/black(src)
-	new /obj/item/clothing/head/soft/black(src)
-	new /obj/item/clothing/head/soft/black(src)
+/obj/structure/closet/wardrobe/black/WillContain()
+	return list(
+		/obj/item/clothing/under/color/black = 3,
+		/obj/item/clothing/shoes/color/black = 3,
+		/obj/item/clothing/head/that         = 3,
+		/obj/item/clothing/head/soft/black   = 3,
+	)
 
 /obj/structure/closet/wardrobe/chaplain_black
 	name = "chapel wardrobe"
 	desc = "It's a storage unit for approved religious attire."
 	closet_appearance = /decl/closet_appearance/wardrobe/black
 
-/obj/structure/closet/wardrobe/chaplain_black/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/chaplain(src)
-	new /obj/item/clothing/shoes/color/black(src)
-	new /obj/item/clothing/suit/nun(src)
-	new /obj/item/clothing/head/nun_hood(src)
-	new /obj/item/clothing/suit/chaplain_hoodie(src)
-	new /obj/item/clothing/head/chaplain_hood(src)
-	new /obj/item/clothing/suit/holidaypriest(src)
-	new /obj/item/clothing/under/wedding/bride_white(src)
-	new /obj/item/storage/backpack/cultpack (src)
-	new /obj/item/storage/candle_box(src)
-	new /obj/item/storage/candle_box(src)
-	new /obj/item/deck/tarot(src)
+/obj/structure/closet/wardrobe/chaplain_black/WillContain()
+	return list(
+		/obj/item/storage/candle_box = 2,
+		/obj/item/clothing/under/chaplain,
+		/obj/item/clothing/shoes/color/black,
+		/obj/item/clothing/suit/nun,
+		/obj/item/clothing/head/nun_hood,
+		/obj/item/clothing/suit/chaplain_hoodie,
+		/obj/item/clothing/head/chaplain_hood,
+		/obj/item/clothing/suit/holidaypriest,
+		/obj/item/clothing/under/wedding/bride_white,
+		/obj/item/storage/backpack/cultpack,
+		/obj/item/deck/tarot,
+	)
 
 /obj/structure/closet/wardrobe/green
 	name = "green wardrobe"
 	closet_appearance = /decl/closet_appearance/wardrobe/green
 
-/obj/structure/closet/wardrobe/green/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/color/green(src)
-	new /obj/item/clothing/under/color/green(src)
-	new /obj/item/clothing/under/color/green(src)
-	new /obj/item/clothing/shoes/color/black(src)
-	new /obj/item/clothing/shoes/color/black(src)
-	new /obj/item/clothing/shoes/color/black(src)
+/obj/structure/closet/wardrobe/green/WillContain()
+	return list(
+		/obj/item/clothing/under/color/green = 3,
+		/obj/item/clothing/shoes/color/black = 3,
+	)
 
 /obj/structure/closet/wardrobe/xenos
 	name = "xenos wardrobe"
 	closet_appearance = /decl/closet_appearance/wardrobe/green
 
-/obj/structure/closet/wardrobe/xenos/Initialize()
-	. = ..()
-	new /obj/item/clothing/suit/robe(src)
-	new /obj/item/clothing/shoes/sandal(src)
-	new /obj/item/clothing/shoes/sandal(src)
-	new /obj/item/clothing/shoes/sandal(src)
+/obj/structure/closet/wardrobe/xenos/WillContain()
+	return list(
+		/obj/item/clothing/suit/robe    = 3,
+		/obj/item/clothing/shoes/sandal = 3,
+	)
 
 /obj/structure/closet/wardrobe/orange
 	name = "prison wardrobe"
 	desc = "It's a storage unit for regulation prisoner attire."
 	closet_appearance = /decl/closet_appearance/wardrobe/orange
 
-/obj/structure/closet/wardrobe/orange/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/color/orange(src)
-	new /obj/item/clothing/under/color/orange(src)
-	new /obj/item/clothing/under/color/orange(src)
-	new /obj/item/clothing/shoes/color/orange(src)
-	new /obj/item/clothing/shoes/color/orange(src)
-	new /obj/item/clothing/shoes/color/orange(src)
-	new /obj/item/radio/headset(src)
-	new /obj/item/radio/headset(src)
-	new /obj/item/radio/headset(src)
+/obj/structure/closet/wardrobe/orange/WillContain()
+	return list(
+		/obj/item/clothing/under/color/orange = 3,
+		/obj/item/clothing/shoes/color/orange = 3,
+		/obj/item/radio/headset = 3,
+	)
 
 /obj/structure/closet/wardrobe/yellow
 	name = "yellow wardrobe"
 	closet_appearance = /decl/closet_appearance/wardrobe/yellow
 
-/obj/structure/closet/wardrobe/yellow/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/color/yellow(src)
-	new /obj/item/clothing/under/color/yellow(src)
-	new /obj/item/clothing/under/color/yellow(src)
-	new /obj/item/clothing/shoes/color/orange(src)
-	new /obj/item/clothing/shoes/color/orange(src)
-	new /obj/item/clothing/shoes/color/orange(src)
+/obj/structure/closet/wardrobe/yellow/WillContain()
+	return list(
+		/obj/item/clothing/under/color/yellow = 3,
+		/obj/item/clothing/shoes/color/orange = 3,
+	)
 
 /obj/structure/closet/wardrobe/atmospherics_yellow
 	name = "atmospherics wardrobe"
 	closet_appearance = /decl/closet_appearance/wardrobe/yellow
 
-/obj/structure/closet/wardrobe/atmospherics_yellow/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/atmospheric_technician(src)
-	new /obj/item/clothing/under/atmospheric_technician(src)
-	new /obj/item/clothing/under/atmospheric_technician(src)
-	new /obj/item/clothing/shoes/workboots(src)
-	new /obj/item/clothing/shoes/workboots(src)
-	new /obj/item/clothing/shoes/workboots(src)
-	new /obj/item/clothing/head/hardhat/red(src)
-	new /obj/item/clothing/head/hardhat/red(src)
-	new /obj/item/clothing/head/hardhat/red(src)
+/obj/structure/closet/wardrobe/atmospherics_yellow/WillContain()
+	return list(
+		/obj/item/clothing/under/atmospheric_technician = 3,
+		/obj/item/clothing/shoes/workboots = 3,
+		/obj/item/clothing/head/hardhat/red = 3,
+	)
 
 /obj/structure/closet/wardrobe/engineering_yellow
 	name = "engineering wardrobe"
 	closet_appearance = /decl/closet_appearance/wardrobe/yellow
 
-/obj/structure/closet/wardrobe/engineering_yellow/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/engineer(src)
-	new /obj/item/clothing/under/engineer(src)
-	new /obj/item/clothing/under/engineer(src)
-	new /obj/item/clothing/shoes/workboots(src)
-	new /obj/item/clothing/shoes/workboots(src)
-	new /obj/item/clothing/shoes/workboots(src)
-	new /obj/item/clothing/head/hardhat(src)
-	new /obj/item/clothing/head/hardhat(src)
-	new /obj/item/clothing/head/hardhat(src)
+/obj/structure/closet/wardrobe/engineering_yellow/WillContain()
+	return list(
+		/obj/item/clothing/under/engineer  = 3,
+		/obj/item/clothing/shoes/workboots = 3,
+		/obj/item/clothing/head/hardhat    = 3,
+	)
 
 /obj/structure/closet/wardrobe/white
 	name = "white wardrobe"
 	closet_appearance = /decl/closet_appearance/wardrobe/white
 
-/obj/structure/closet/wardrobe/white/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/color/white(src)
-	new /obj/item/clothing/under/color/white(src)
-	new /obj/item/clothing/under/color/white(src)
-	new /obj/item/clothing/shoes/color/white(src)
-	new /obj/item/clothing/shoes/color/white(src)
-	new /obj/item/clothing/shoes/color/white(src)
+/obj/structure/closet/wardrobe/white/WillContain()
+	return list(
+		/obj/item/clothing/under/color/white = 3,
+		/obj/item/clothing/shoes/color/white = 3,
+	)
 
 /obj/structure/closet/wardrobe/pjs
 	name = "pajama wardrobe"
 	closet_appearance = /decl/closet_appearance/wardrobe/white
 
-/obj/structure/closet/wardrobe/pjs/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/pj(src)
-	new /obj/item/clothing/under/pj(src)
-	new /obj/item/clothing/under/pj/blue(src)
-	new /obj/item/clothing/under/pj/blue(src)
-	new /obj/item/clothing/shoes/color/white(src)
-	new /obj/item/clothing/shoes/color/white(src)
-	new /obj/item/clothing/shoes/slippers(src)
-	new /obj/item/clothing/shoes/slippers(src)
+/obj/structure/closet/wardrobe/pjs/WillContain()
+	return list(
+		/obj/item/clothing/under/pj = 2,
+		/obj/item/clothing/under/pj/blue = 2,
+		/obj/item/clothing/shoes/color/white = 2,
+		/obj/item/clothing/shoes/slippers = 2,
+	)
 
 /obj/structure/closet/wardrobe/science_white
 	name = "science wardrobe"
 	closet_appearance = /decl/closet_appearance/wardrobe/white
 
-/obj/structure/closet/wardrobe/science_white/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/color/white(src)
-	new /obj/item/clothing/under/color/white(src)
-	new /obj/item/clothing/under/color/white(src)
-	new /obj/item/clothing/suit/storage/toggle/labcoat(src)
-	new /obj/item/clothing/suit/storage/toggle/labcoat(src)
-	new /obj/item/clothing/suit/storage/toggle/labcoat(src)
-	new /obj/item/clothing/shoes/color/white(src)
-	new /obj/item/clothing/shoes/color/white(src)
-	new /obj/item/clothing/shoes/color/white(src)
+/obj/structure/closet/wardrobe/science_white/WillContain()
+	return list(
+		/obj/item/clothing/under/color/white = 3,
+		/obj/item/clothing/suit/storage/toggle/labcoat = 3,
+		/obj/item/clothing/shoes/color/white = 3,
+	)
 
 /obj/structure/closet/wardrobe/robotics_black
 	name = "robotics wardrobe"
 	closet_appearance = /decl/closet_appearance/wardrobe/black
 
-/obj/structure/closet/wardrobe/robotics_black/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/roboticist(src)
-	new /obj/item/clothing/under/roboticist(src)
-	new /obj/item/clothing/suit/storage/toggle/labcoat(src)
-	new /obj/item/clothing/suit/storage/toggle/labcoat(src)
-	new /obj/item/clothing/shoes/color/black(src)
-	new /obj/item/clothing/shoes/color/black(src)
-	new /obj/item/clothing/gloves/thick(src)
-	new /obj/item/clothing/gloves/thick(src)
+/obj/structure/closet/wardrobe/robotics_black/WillContain()
+	return list(
+		/obj/item/clothing/under/roboticist = 2,
+		/obj/item/clothing/suit/storage/toggle/labcoat = 2,
+		/obj/item/clothing/shoes/color/black = 2,
+		/obj/item/clothing/gloves/thick = 2,
+	)
 
 /obj/structure/closet/wardrobe/chemistry_white
 	name = "chemistry wardrobe"
 	closet_appearance = /decl/closet_appearance/wardrobe/white
 
-/obj/structure/closet/wardrobe/chemistry_white/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/chemist(src)
-	new /obj/item/clothing/under/chemist(src)
-	new /obj/item/clothing/shoes/color/white(src)
-	new /obj/item/clothing/shoes/color/white(src)
-	new /obj/item/clothing/suit/storage/toggle/labcoat/chemist(src)
-	new /obj/item/clothing/suit/storage/toggle/labcoat/chemist(src)
+/obj/structure/closet/wardrobe/chemistry_white/WillContain()
+	return list(
+		/obj/item/clothing/under/chemist = 2,
+		/obj/item/clothing/shoes/color/white = 2,
+		/obj/item/clothing/suit/storage/toggle/labcoat/chemist = 2,
+	)
 
 /obj/structure/closet/wardrobe/genetics_white
 	name = "genetics wardrobe"
 	closet_appearance = /decl/closet_appearance/wardrobe/white
 
-/obj/structure/closet/wardrobe/genetics_white/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/geneticist(src)
-	new /obj/item/clothing/under/geneticist(src)
-	new /obj/item/clothing/shoes/color/white(src)
-	new /obj/item/clothing/shoes/color/white(src)
-	new /obj/item/clothing/suit/storage/toggle/labcoat/genetics(src)
-	new /obj/item/clothing/suit/storage/toggle/labcoat/genetics(src)
+/obj/structure/closet/wardrobe/genetics_white/WillContain()
+	return list(
+		/obj/item/clothing/under/geneticist  = 2,
+		/obj/item/clothing/shoes/color/white = 2,
+		/obj/item/clothing/suit/storage/toggle/labcoat/genetics = 2,
+	)
 
 /obj/structure/closet/wardrobe/virology_white
 	name = "virology wardrobe"
 	closet_appearance = /decl/closet_appearance/wardrobe/white
 
-/obj/structure/closet/wardrobe/virology_white/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/virologist(src)
-	new /obj/item/clothing/under/virologist(src)
-	new /obj/item/clothing/shoes/color/white(src)
-	new /obj/item/clothing/shoes/color/white(src)
-	new /obj/item/clothing/suit/storage/toggle/labcoat/virologist(src)
-	new /obj/item/clothing/suit/storage/toggle/labcoat/virologist(src)
-	new /obj/item/clothing/mask/surgical(src)
-	new /obj/item/clothing/mask/surgical(src)
+/obj/structure/closet/wardrobe/virology_white/WillContain()
+	return list(
+		/obj/item/clothing/under/virologist = 2,
+		/obj/item/clothing/shoes/color/white = 2,
+		/obj/item/clothing/suit/storage/toggle/labcoat/virologist = 2,
+		/obj/item/clothing/mask/surgical = 2,
+	)
 
 /obj/structure/closet/wardrobe/medic_white
 	name = "medical wardrobe"
 	closet_appearance = /decl/closet_appearance/wardrobe/white
 
-/obj/structure/closet/wardrobe/medic_white/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/medical(src)
-	new /obj/item/clothing/under/medical(src)
-	new /obj/item/clothing/under/medical/scrubs/blue(src)
-	new /obj/item/clothing/under/medical/scrubs/green(src)
-	new /obj/item/clothing/under/medical/scrubs/purple(src)
-	new /obj/item/clothing/under/medical/scrubs/black(src)
-	new /obj/item/clothing/under/medical/scrubs/navyblue(src)
-	new /obj/item/clothing/head/surgery/navyblue(src)
-	new /obj/item/clothing/head/surgery/purple(src)
-	new /obj/item/clothing/head/surgery/blue(src)
-	new /obj/item/clothing/head/surgery/green(src)
-	new /obj/item/clothing/head/surgery/black(src)
-	new /obj/item/clothing/shoes/color/white(src)
-	new /obj/item/clothing/shoes/color/white(src)
-	new /obj/item/clothing/suit/storage/toggle/labcoat(src)
-	new /obj/item/clothing/suit/storage/toggle/labcoat(src)
-	new /obj/item/clothing/mask/surgical(src)
-	new /obj/item/clothing/mask/surgical(src)
+/obj/structure/closet/wardrobe/medic_white/WillContain()
+	return list(
+		/obj/item/clothing/under/medical = 2,
+		/obj/item/clothing/shoes/color/white = 3,
+		/obj/item/clothing/suit/storage/toggle/labcoat = 2,
+		/obj/item/clothing/mask/surgical = 2,
+		/obj/item/clothing/under/medical/scrubs/blue,
+		/obj/item/clothing/under/medical/scrubs/green,
+		/obj/item/clothing/under/medical/scrubs/purple,
+		/obj/item/clothing/under/medical/scrubs/black,
+		/obj/item/clothing/under/medical/scrubs/navyblue,
+		/obj/item/clothing/head/surgery/navyblue,
+		/obj/item/clothing/head/surgery/purple,
+		/obj/item/clothing/head/surgery/blue,
+		/obj/item/clothing/head/surgery/green,
+		/obj/item/clothing/head/surgery/black,
+	)
 
 /obj/structure/closet/wardrobe/grey
 	name = "grey wardrobe"
 	closet_appearance = /decl/closet_appearance/wardrobe/grey
 
-/obj/structure/closet/wardrobe/grey/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/color/grey(src)
-	new /obj/item/clothing/under/color/grey(src)
-	new /obj/item/clothing/under/color/grey(src)
-	new /obj/item/clothing/shoes/color/black(src)
-	new /obj/item/clothing/shoes/color/black(src)
-	new /obj/item/clothing/shoes/color/black(src)
-	new /obj/item/clothing/head/soft/grey(src)
-	new /obj/item/clothing/head/soft/grey(src)
-	new /obj/item/clothing/head/soft/grey(src)
+/obj/structure/closet/wardrobe/grey/WillContain()
+	return list(
+		/obj/item/clothing/under/color/grey  = 3,
+		/obj/item/clothing/shoes/color/black = 3,
+		/obj/item/clothing/head/soft/grey    = 3,
+	)
 
 /obj/structure/closet/wardrobe/mixed
 	name = "mixed wardrobe"
 	closet_appearance = /decl/closet_appearance/wardrobe/mixed
 
-/obj/structure/closet/wardrobe/mixed/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/color/blue(src)
-	new /obj/item/clothing/under/color/yellow(src)
-	new /obj/item/clothing/under/color/green(src)
-	new /obj/item/clothing/under/color/orange(src)
-	new /obj/item/clothing/under/color/pink(src)
-	new /obj/item/clothing/under/dress/plaid_blue(src)
-	new /obj/item/clothing/under/dress/plaid_red(src)
-	new /obj/item/clothing/under/dress/plaid_purple(src)
-	new /obj/item/clothing/shoes/color/blue(src)
-	new /obj/item/clothing/shoes/color/yellow(src)
-	new /obj/item/clothing/shoes/color/green(src)
-	new /obj/item/clothing/shoes/color/orange(src)
-	new /obj/item/clothing/shoes/color/purple(src)
-	new /obj/item/clothing/shoes/color/red(src)
-	new /obj/item/clothing/shoes/craftable(src)
-	new /obj/item/clothing/accessory/toggleable/hawaii/random(src)
+/obj/structure/closet/wardrobe/mixed/WillContain()
+	return list(
+		/obj/item/clothing/under/color/blue,
+		/obj/item/clothing/under/color/yellow,
+		/obj/item/clothing/under/color/green,
+		/obj/item/clothing/under/color/orange,
+		/obj/item/clothing/under/color/pink,
+		/obj/item/clothing/under/dress/plaid_blue,
+		/obj/item/clothing/under/dress/plaid_red,
+		/obj/item/clothing/under/dress/plaid_purple,
+		/obj/item/clothing/shoes/color/blue,
+		/obj/item/clothing/shoes/color/yellow,
+		/obj/item/clothing/shoes/color/green,
+		/obj/item/clothing/shoes/color/orange,
+		/obj/item/clothing/shoes/color/purple,
+		/obj/item/clothing/shoes/color/red,
+		/obj/item/clothing/shoes/craftable,
+		/obj/item/clothing/accessory/toggleable/hawaii/random,
+	)
 
 /obj/structure/closet/wardrobe/tactical
 	name = "tactical equipment"
 	closet_appearance = /decl/closet_appearance/tactical
 
-/obj/structure/closet/wardrobe/tactical/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/tactical(src)
-	new /obj/item/clothing/suit/armor/pcarrier/tactical(src)
-	new /obj/item/clothing/head/helmet/tactical(src)
-	new /obj/item/clothing/mask/balaclava/tactical(src)
-	new /obj/item/clothing/glasses/tacgoggles(src)
-	new /obj/item/storage/belt/holster/security/tactical(src)
-	new /obj/item/clothing/shoes/jackboots/tactical(src)
-	new /obj/item/clothing/gloves/tactical(src)
+/obj/structure/closet/wardrobe/tactical/WillContain()
+	return list(
+		/obj/item/clothing/under/tactical,
+		/obj/item/clothing/suit/armor/pcarrier/tactical,
+		/obj/item/clothing/head/helmet/tactical,
+		/obj/item/clothing/mask/balaclava/tactical,
+		/obj/item/clothing/glasses/tacgoggles,
+		/obj/item/storage/belt/holster/security/tactical,
+		/obj/item/clothing/shoes/jackboots/tactical,
+		/obj/item/clothing/gloves/tactical,
+	)
 
 /obj/structure/closet/wardrobe/suit
 	name = "formal clothing locker"
 	closet_appearance = /decl/closet_appearance/wardrobe/mixed
 
-/obj/structure/closet/wardrobe/suit/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/suit_jacket/charcoal(src)
-	new /obj/item/clothing/under/suit_jacket/navy(src)
-	new /obj/item/clothing/under/suit_jacket/burgundy(src)
-	new /obj/item/clothing/under/suit_jacket/checkered(src)
-	new /obj/item/clothing/under/suit_jacket/tan(src)
-	new /obj/item/clothing/under/sl_suit(src)
-	new /obj/item/clothing/under/suit_jacket(src)
-	new /obj/item/clothing/under/suit_jacket/female(src)
-	new /obj/item/clothing/under/suit_jacket/really_black(src)
-	new /obj/item/clothing/under/suit_jacket/red(src)
-	new /obj/item/clothing/under/scratch(src)
-	new /obj/item/clothing/under/internalaffairs/plain(src)
-	new /obj/item/clothing/suit/storage/toggle/suit/black(src)
-	new /obj/item/clothing/under/assistantformal(src)
-	new /obj/item/clothing/under/lawyer/female(src)
-	new /obj/item/clothing/under/lawyer(src)
-	new /obj/item/clothing/under/lawyer/red(src)
-	new /obj/item/clothing/under/lawyer/bluesuit(src)
-	new /obj/item/clothing/suit/storage/toggle/suit/blue(src)
-	new /obj/item/clothing/under/lawyer/purpsuit(src)
-	new /obj/item/clothing/suit/storage/toggle/suit/purple(src)
-	new /obj/item/clothing/shoes/color/brown(src)
-	new /obj/item/clothing/shoes/dress(src)
+/obj/structure/closet/wardrobe/suit/WillContain()
+	return list(
+		/obj/item/clothing/under/suit_jacket/charcoal,
+		/obj/item/clothing/under/suit_jacket/navy,
+		/obj/item/clothing/under/suit_jacket/burgundy,
+		/obj/item/clothing/under/suit_jacket/checkered,
+		/obj/item/clothing/under/suit_jacket/tan,
+		/obj/item/clothing/under/sl_suit,
+		/obj/item/clothing/under/suit_jacket,
+		/obj/item/clothing/under/suit_jacket/female,
+		/obj/item/clothing/under/suit_jacket/really_black,
+		/obj/item/clothing/under/suit_jacket/red,
+		/obj/item/clothing/under/scratch,
+		/obj/item/clothing/under/internalaffairs/plain,
+		/obj/item/clothing/suit/storage/toggle/suit/black,
+		/obj/item/clothing/under/assistantformal,
+		/obj/item/clothing/under/lawyer/female,
+		/obj/item/clothing/under/lawyer,
+		/obj/item/clothing/under/lawyer/red,
+		/obj/item/clothing/under/lawyer/bluesuit,
+		/obj/item/clothing/suit/storage/toggle/suit/blue,
+		/obj/item/clothing/under/lawyer/purpsuit,
+		/obj/item/clothing/suit/storage/toggle/suit/purple,
+		/obj/item/clothing/shoes/color/brown,
+		/obj/item/clothing/shoes/dress,
+	)
 
 /obj/structure/closet/wardrobe/lawyer_black
 	name = "internal affairs wardrobe"
 	closet_appearance = /decl/closet_appearance/wardrobe/black
 
-/obj/structure/closet/wardrobe/lawyer_black/Initialize()
-	. = ..()
-	new /obj/item/clothing/under/internalaffairs(src)
-	new /obj/item/clothing/under/internalaffairs(src)
-	new /obj/item/clothing/suit/storage/toggle/suit/black(src)
-	new /obj/item/clothing/suit/storage/toggle/suit/black(src)
-	new /obj/item/clothing/shoes/color/brown(src)
-	new /obj/item/clothing/shoes/color/brown(src)
-	new /obj/item/clothing/glasses/sunglasses/big(src)
-	new /obj/item/clothing/glasses/sunglasses/big(src)
-	new /obj/item/storage/briefcase(src)
-	new /obj/item/storage/briefcase(src)
+/obj/structure/closet/wardrobe/lawyer_black/WillContain()
+	return list(
+		/obj/item/clothing/under/internalaffairs = 2,
+		/obj/item/clothing/suit/storage/toggle/suit/black = 2,
+		/obj/item/clothing/shoes/color/brown = 2,
+		/obj/item/clothing/glasses/sunglasses/big = 2,
+		/obj/item/storage/briefcase = 2,
+	)

--- a/code/game/objects/structures/crates_lockers/med_crate.dm
+++ b/code/game/objects/structures/crates_lockers/med_crate.dm
@@ -9,7 +9,7 @@
 		/obj/item/stack/medical/advanced/bruise_pack = 10,
 		/obj/item/chems/pill/sugariron = 6,
 		/obj/item/storage/pill_bottle/painkillers = 2,
-		/obj/item/storage/pill_bottle/adrenaline
+		/obj/item/storage/pill_bottle/stabilizer
 		)
 
 /obj/structure/closet/crate/med_crate/burn
@@ -35,7 +35,7 @@
 	return list(
 		/obj/item/scanner/breath = 2,
 		/obj/item/storage/pill_bottle/oxygen = 2,
-		/obj/item/storage/pill_bottle/adrenaline
+		/obj/item/storage/pill_bottle/stabilizer
 	)
 /obj/structure/closet/crate/med_crate/toxin
 	name = "\improper Toxin crate"

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -305,4 +305,9 @@
 	w_class = ITEM_SIZE_LARGE
 	max_storage_space = DEFAULT_LARGEBOX_STORAGE
 	can_hold = list(/obj/item/inflatable)
-	startswith = list(/obj/item/inflatable/door = 2, /obj/item/inflatable = 3)
+
+/obj/item/storage/briefcase/inflatable/WillContain()
+	return list(
+			/obj/item/inflatable/door = 2, 
+			/obj/item/inflatable      = 3
+		)

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -119,8 +119,12 @@
 /obj/item/storage/box/holobadge
 	name = "holobadge box"
 	desc = "A box containing security holobadges."
-	startswith = list(/obj/item/clothing/accessory/badge/holo = 4,
-					  /obj/item/clothing/accessory/badge/holo/cord = 2)
+
+/obj/item/storage/box/holobadge/WillContain()
+	return list(
+			/obj/item/clothing/accessory/badge/holo      = 4,
+			/obj/item/clothing/accessory/badge/holo/cord = 2
+		)
 
 /obj/item/clothing/accessory/badge/old
 	name = "faded badge"

--- a/code/modules/detectivework/tools/crimekit.dm
+++ b/code/modules/detectivework/tools/crimekit.dm
@@ -5,7 +5,11 @@
 	icon = 'icons/obj/forensics.dmi'
 	icon_state = "case"
 	item_state = "case"
-	startswith = list(
+	material = /decl/material/solid/leather/synth
+	matter = list(/decl/material/solid/metal/stainlesssteel = MATTER_AMOUNT_REINFORCEMENT)
+
+/obj/item/storage/briefcase/crimekit/WillContain()
+	return list(
 		/obj/item/storage/box/fingerprints,
 		/obj/item/chems/spray/luminol,
 		/obj/item/uv_light,
@@ -14,5 +18,3 @@
 		/obj/item/forensics/sample_kit/powder,
 		/obj/item/storage/csi_markers
 		)
-	material = /decl/material/solid/leather/synth
-	matter = list(/decl/material/solid/metal/stainlesssteel = MATTER_AMOUNT_REINFORCEMENT)

--- a/code/modules/detectivework/tools/scene_cards.dm
+++ b/code/modules/detectivework/tools/scene_cards.dm
@@ -18,7 +18,8 @@
 
 /obj/item/storage/csi_markers/Initialize(ml, material_key)
 	. = ..()
-	make_exact_fit()
+	if(length(contents))
+		make_exact_fit()
 
 /obj/item/csi_marker
 	name = "crime scene marker"

--- a/code/modules/detectivework/tools/scene_cards.dm
+++ b/code/modules/detectivework/tools/scene_cards.dm
@@ -4,17 +4,19 @@
 	icon = 'icons/obj/forensics.dmi'
 	icon_state = "cards"
 	w_class = ITEM_SIZE_TINY
-	startswith = list(
-		/obj/item/csi_marker/n1 = 1,
-		/obj/item/csi_marker/n2 = 1,
-		/obj/item/csi_marker/n3 = 1,
-		/obj/item/csi_marker/n4 = 1,
-		/obj/item/csi_marker/n5 = 1,
-		/obj/item/csi_marker/n6 = 1,
-		/obj/item/csi_marker/n7 = 1
+
+/obj/item/storage/csi_markers/WillContain()
+	return list(
+		/obj/item/csi_marker/n1,
+		/obj/item/csi_marker/n2,
+		/obj/item/csi_marker/n3,
+		/obj/item/csi_marker/n4,
+		/obj/item/csi_marker/n5,
+		/obj/item/csi_marker/n6,
+		/obj/item/csi_marker/n7
 	)
 
-/obj/item/storage/csi_markers/Initialize()
+/obj/item/storage/csi_markers/Initialize(ml, material_key)
 	. = ..()
 	make_exact_fit()
 

--- a/code/modules/detectivework/tools/storage.dm
+++ b/code/modules/detectivework/tools/storage.dm
@@ -3,16 +3,22 @@
 	desc = "Sterilized equipment within. Do not contaminate."
 	icon = 'icons/obj/forensics.dmi'
 	icon_state = "dnakit"
-	startswith = list(/obj/item/forensics/sample/swab = DEFAULT_BOX_STORAGE)
+	
+/obj/item/storage/box/swabs/WillContain()
+	return list(/obj/item/forensics/sample/swab = DEFAULT_BOX_STORAGE)
 
 /obj/item/storage/box/evidence
 	name = "evidence bag box"
 	desc = "A box claiming to contain evidence bags."
-	startswith = list(/obj/item/evidencebag = 7)
+
+/obj/item/storage/box/swabs/WillContain()
+	return list(/obj/item/evidencebag = 7)
 
 /obj/item/storage/box/fingerprints
 	name = "box of fingerprint cards"
 	desc = "Sterilized equipment within. Do not contaminate."
 	icon = 'icons/obj/forensics.dmi'
 	icon_state = "dnakit"
-	startswith = list(/obj/item/forensics/sample/print = DEFAULT_BOX_STORAGE)
+
+/obj/item/storage/box/swabs/WillContain()
+	return list(/obj/item/forensics/sample/print = DEFAULT_BOX_STORAGE)

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -20,7 +20,9 @@
 /obj/item/storage/box/botanydisk
 	name = "flora disk box"
 	desc = "A box of flora data disks, apparently."
-	startswith = list(/obj/item/disk/botany = 14)
+	
+/obj/item/storage/box/botanydisk/WillContain()
+	return list(/obj/item/disk/botany = 14)
 
 /obj/machinery/botany
 	icon = 'icons/obj/hydroponics/hydroponics_machines.dmi'

--- a/code/modules/modular_computers/computers/subtypes/dev_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_pda.dm
@@ -34,10 +34,5 @@
 	desc = "A box of spare PDA microcomputers."
 	icon_state = "pdabox"
 
-/obj/item/storage/box/PDAs/Initialize()
-	. = ..()
-	new /obj/item/modular_computer/pda(src)
-	new /obj/item/modular_computer/pda(src)
-	new /obj/item/modular_computer/pda(src)
-	new /obj/item/modular_computer/pda(src)
-	new /obj/item/modular_computer/pda(src)
+/obj/item/storage/box/PDAs/WillContain()
+	return list(/obj/item/modular_computer/pda = 5)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -496,13 +496,6 @@ By design, d1 is the smallest direction and d2 is the highest
 	stack_merge_type = /obj/item/stack/cable_coil
 	matter_multiplier = 0.15
 
-/obj/item/stack/cable_coil/Initialize()
-	. = ..()
-	set_extension(src, /datum/extension/tool/variable, list(
-		TOOL_CABLECOIL = TOOL_QUALITY_DEFAULT,
-		TOOL_SUTURES =   TOOL_QUALITY_MEDIOCRE
-	))
-
 /obj/item/stack/cable_coil/single
 	amount = 1
 
@@ -517,6 +510,10 @@ By design, d1 is the smallest direction and d2 is the highest
 
 /obj/item/stack/cable_coil/Initialize(mapload, c_length = MAXCOIL, var/param_color = null)
 	. = ..(mapload, c_length)
+	set_extension(src, /datum/extension/tool/variable, list(
+		TOOL_CABLECOIL = TOOL_QUALITY_DEFAULT,
+		TOOL_SUTURES =   TOOL_QUALITY_MEDIOCRE
+	))
 	src.amount = c_length
 	if (param_color) // It should be red by default, so only recolor it if parameter was specified.
 		color = param_color
@@ -845,7 +842,7 @@ By design, d1 is the smallest direction and d2 is the highest
 /obj/item/stack/cable_coil/lime
 	color = COLOR_LIME
 
-/obj/item/stack/cable_coil/random/Initialize()
+/obj/item/stack/cable_coil/random/Initialize(mapload, c_length, param_color)
 	var/list/possible_cable_colours = get_global_cable_colors()
 	color = possible_cable_colours[pick(possible_cable_colours)]
 	. = ..()

--- a/code/modules/projectiles/guns/launcher/foam_gun.dm
+++ b/code/modules/projectiles/guns/launcher/foam_gun.dm
@@ -114,7 +114,9 @@
 	desc = "It's a box of offical Jorf brand foam darts, for use only with offical Jorf brand products."
 	icon = 'icons/obj/guns/foam/boxes.dmi'
 	icon_state = "dart_box"
-	startswith = list(/obj/item/foam_dart = 14)
+
+/obj/item/storage/box/foam_darts/WillContain()
+	return list(/obj/item/foam_dart = 14)
 
 //preset boxes
 /obj/item/storage/box/large/foam_gun
@@ -122,22 +124,38 @@
 	desc = "It's an official Jorf brand blaster, with three official Jorf brand darts!"
 	icon = 'icons/obj/guns/foam/boxes.dmi'
 	icon_state = "blaster_box"
-	startswith = list(/obj/item/gun/launcher/foam,
-					  /obj/item/foam_dart = 3)
+
+/obj/item/storage/box/large/foam_gun/WillContain()
+	return list(
+			/obj/item/gun/launcher/foam,
+			/obj/item/foam_dart = 3
+		)
 
 /obj/item/storage/box/large/foam_gun/burst
 	name = "\improper Jorf Outlander set"
 	desc = "It's an official Jorf brand Outlander, with six official Jorf brand darts!"
-	startswith = list(/obj/item/gun/launcher/foam/burst,
-					  /obj/item/foam_dart = 6)
+
+/obj/item/storage/box/large/foam_gun/burst/WillContain()
+	return list(
+			/obj/item/gun/launcher/foam/burst,
+			/obj/item/foam_dart = 6
+		)
 
 /obj/item/storage/box/large/foam_gun/revolver
 	name = "\improper Jorf Desperado set"
 	desc = "It's an official Jorf brand Desperado, with eight official Jorf brand darts!"
-	startswith = list(/obj/item/gun/launcher/foam/revolver,
-					  /obj/item/foam_dart = 8)
+
+/obj/item/storage/box/large/foam_gun/revolver/WillContain()
+	return list(
+			/obj/item/gun/launcher/foam/revolver,
+			/obj/item/foam_dart = 8
+		)
 
 /obj/item/storage/box/large/foam_gun/revolver/tampered
 	desc = "It's a Jorf brand Desperado, with fourteen Jorf brand darts!"
-	startswith = list(/obj/item/gun/launcher/foam/revolver/tampered,
-					  /obj/item/foam_dart/tampered = 14)
+
+/obj/item/storage/box/large/foam_gun/revolver/tampered/WillContain()
+	return list(
+			/obj/item/gun/launcher/foam/revolver/tampered,
+			/obj/item/foam_dart/tampered = 14
+		)

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -2,7 +2,9 @@
 	name = "blood packs box"
 	desc = "This box contains blood packs."
 	icon_state = "sterile"
-	startswith = list(/obj/item/chems/ivbag = 7)
+	
+/obj/item/storage/box/bloodpacks/WillContain()
+	return list(/obj/item/chems/ivbag = 7)
 
 /obj/item/chems/ivbag
 	name = "\improper IV bag"

--- a/code/modules/reagents/reagent_containers/drinkingglass/glass_boxes.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/glass_boxes.dm
@@ -20,7 +20,8 @@
 
 /obj/item/storage/box/mixedglasses/Initialize(ml, material_key)
 	. = ..()
-	make_exact_fit()
+	if(length(contents))
+		make_exact_fit()
 
 ////////////////////////////////////////////////////////////////////
 // Box of Glasses
@@ -34,7 +35,8 @@
 	. = ..()
 	//Name the box accordingly
 	setup_name()
-	make_exact_fit()
+	if(length(contents))
+		make_exact_fit()
 
 /obj/item/storage/box/glasses/proc/setup_name()
 	var/list/cnt = WillContain()
@@ -77,7 +79,8 @@
 /obj/item/storage/box/glass_extras/Initialize(ml, material_key)
 	. = ..()
 	setup_name()
-	make_exact_fit()
+	if(length(contents))
+		make_exact_fit()
 
 /obj/item/storage/box/glass_extras/proc/setup_name()
 	var/list/cnt = WillContain()

--- a/code/modules/reagents/reagent_containers/drinkingglass/glass_boxes.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/glass_boxes.dm
@@ -39,10 +39,11 @@
 		make_exact_fit()
 
 /obj/item/storage/box/glasses/proc/setup_name()
+	//#TODO: This really should handle atom_creator stuff too..
 	var/list/cnt = WillContain()
 	if((islist(cnt) || ispath(cnt)) && length(cnt))
 		var/atom/movable/O = ispath(cnt) ? cnt : cnt[1]
-		SetName("box of [initial(O.name)]\s") //#FIXME: Can't get plural from name.
+		SetName("box of [initial(O.name)]") //#FIXME: Can't get plural from name.
 
 /obj/item/storage/box/glasses/square/WillContain()
 	return list(/obj/item/chems/drinks/glass2/square = storage_slots)
@@ -83,10 +84,11 @@
 		make_exact_fit()
 
 /obj/item/storage/box/glass_extras/proc/setup_name()
+	//#TODO: This really should handle atom_creator stuff too..
 	var/list/cnt = WillContain()
 	if((islist(cnt) || ispath(cnt)) && length(cnt))
 		var/atom/movable/O = ispath(cnt) ? cnt : cnt[1]
-		SetName("box of [initial(O.name)]\s")  //#FIXME: Can't get plural from name.
+		SetName("box of [initial(O.name)]")  //#FIXME: Can't get plural from name.
 
 /obj/item/storage/box/glass_extras/straws/WillContain()
 	return list(/obj/item/glass_extra/straw = storage_slots)

--- a/code/modules/reagents/reagent_containers/drinkingglass/glass_boxes.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/glass_boxes.dm
@@ -1,8 +1,13 @@
+////////////////////////////////////////////////////////////////////
+// Box of Mixed Glasses
+////////////////////////////////////////////////////////////////////
 /obj/item/storage/box/mixedglasses
 	name = "glassware box"
 	desc = "A box of assorted glassware"
 	can_hold = list(/obj/item/chems/drinks/glass2)
-	startswith = list(
+
+/obj/item/storage/box/mixedglasses/WillContain()
+	return list(
 		/obj/item/chems/drinks/glass2/square,
 		/obj/item/chems/drinks/glass2/rocks,
 		/obj/item/chems/drinks/glass2/shake,
@@ -13,69 +18,75 @@
 		/obj/item/chems/drinks/glass2/wine
 	)
 
-/obj/item/storage/box/mixedglasses/Initialize()
+/obj/item/storage/box/mixedglasses/Initialize(ml, material_key)
 	. = ..()
 	make_exact_fit()
 
+////////////////////////////////////////////////////////////////////
+// Box of Glasses
+////////////////////////////////////////////////////////////////////
 /obj/item/storage/box/glasses
-	name = "box of glasses"
-	var/glass_type = /obj/item/chems/drinks/glass2
-	can_hold = list(/obj/item/chems/drinks/glass2)
+	name          = "box of glasses"
+	can_hold      = list(/obj/item/chems/drinks/glass2)
+	storage_slots = 7
 
-/obj/item/storage/box/glasses/Initialize()
+/obj/item/storage/box/glasses/Initialize(ml, material_key)
 	. = ..()
-
-	for(var/i = 1 to 7)
-		new glass_type(src)
+	//Name the box accordingly
+	setup_name()
 	make_exact_fit()
 
-/obj/item/storage/box/glasses/square
-	name = "box of half-pint glasses"
-	glass_type = /obj/item/chems/drinks/glass2/square
+/obj/item/storage/box/glasses/proc/setup_name()
+	var/list/cnt = WillContain()
+	if((islist(cnt) || ispath(cnt)) && length(cnt))
+		var/atom/movable/O = ispath(cnt) ? cnt : cnt[1]
+		SetName("box of [initial(O.name)]\s") //#FIXME: Can't get plural from name.
 
-/obj/item/storage/box/glasses/rocks
-	name = "box of rocks glasses"
-	glass_type = /obj/item/chems/drinks/glass2/rocks
+/obj/item/storage/box/glasses/square/WillContain()
+	return list(/obj/item/chems/drinks/glass2/square = storage_slots)
 
-/obj/item/storage/box/glasses/shake
-	name = "box of milkshake glasses"
-	glass_type = /obj/item/chems/drinks/glass2/shake
+/obj/item/storage/box/glasses/rocks/WillContain()
+	return list(/obj/item/chems/drinks/glass2/rocks = storage_slots)
 
-/obj/item/storage/box/glasses/cocktail
-	name = "box of cocktail glasses"
-	glass_type = /obj/item/chems/drinks/glass2/cocktail
+/obj/item/storage/box/glasses/shake/WillContain()
+	return list(/obj/item/chems/drinks/glass2/shake = storage_slots)
 
-/obj/item/storage/box/glasses/shot
-	name = "box of shot glasses"
-	glass_type = /obj/item/chems/drinks/glass2/shot
+/obj/item/storage/box/glasses/cocktail/WillContain()
+	return list(/obj/item/chems/drinks/glass2/cocktail = storage_slots)
 
-/obj/item/storage/box/glasses/pint
-	name = "box of pint glasses"
-	glass_type = /obj/item/chems/drinks/glass2/pint
+/obj/item/storage/box/glasses/shot/WillContain()
+	return list(/obj/item/chems/drinks/glass2/shot = storage_slots)
 
-/obj/item/storage/box/glasses/mug
-	name = "box of glass mugs"
-	glass_type = /obj/item/chems/drinks/glass2/mug
+/obj/item/storage/box/glasses/pint/WillContain()
+	return list(/obj/item/chems/drinks/glass2/pint = storage_slots)
 
-/obj/item/storage/box/glasses/wine
-	name = "box of wine glasses"
-	glass_type = /obj/item/chems/drinks/glass2/wine
+/obj/item/storage/box/glasses/mug/WillContain()
+	return list(/obj/item/chems/drinks/glass2/mug = storage_slots)
 
+/obj/item/storage/box/glasses/wine/WillContain()
+	return list(/obj/item/chems/drinks/glass2/wine = storage_slots)
+
+////////////////////////////////////////////////////////////////////
+// Extras
+////////////////////////////////////////////////////////////////////
 /obj/item/storage/box/glass_extras
 	name = "box of cocktail garnishings"
-	var/extra_type = /obj/item/glass_extra
 	can_hold = list(/obj/item/glass_extra)
 	storage_slots = 14
 
-/obj/item/storage/box/glass_extras/Initialize()
-	for(var/i = 1 to 14)
-		new extra_type(src)
+/obj/item/storage/box/glass_extras/Initialize(ml, material_key)
 	. = ..()
+	setup_name()
+	make_exact_fit()
 
-/obj/item/storage/box/glass_extras/straws
-	name = "box of straws"
-	extra_type = /obj/item/glass_extra/straw
+/obj/item/storage/box/glass_extras/proc/setup_name()
+	var/list/cnt = WillContain()
+	if((islist(cnt) || ispath(cnt)) && length(cnt))
+		var/atom/movable/O = ispath(cnt) ? cnt : cnt[1]
+		SetName("box of [initial(O.name)]\s")  //#FIXME: Can't get plural from name.
 
-/obj/item/storage/box/glass_extras/sticks
-	name = "box of drink sticks"
-	extra_type = /obj/item/glass_extra/stick
+/obj/item/storage/box/glass_extras/straws/WillContain()
+	return list(/obj/item/glass_extra/straw = storage_slots)
+
+/obj/item/storage/box/glass_extras/sticks/WillContain()
+	return list(/obj/item/glass_extra/stick = storage_slots)

--- a/code/modules/reagents/reagent_containers/food/sliceable/pizza.dm
+++ b/code/modules/reagents/reagent_containers/food/sliceable/pizza.dm
@@ -134,6 +134,11 @@
 	var/list/boxes = list()// If the boxes are stacked, they come here
 	var/boxtag = ""
 
+/obj/item/pizzabox/Initialize(ml, material_key)
+	. = ..()
+	if(ispath(pizza))
+		pizza = new pizza(src)
+
 /obj/item/pizzabox/on_update_icon()
 	. = ..()
 
@@ -189,12 +194,11 @@
 		to_chat(user, "<span class='warning'>You take \the [src.pizza] out of \the [src].</span>")
 		src.pizza = null
 		update_icon()
-		return
+		return TRUE
 
 	if( boxes.len > 0 )
 		if(!user.is_holding_offhand(src))
-			..()
-			return
+			return ..()
 
 		var/obj/item/pizzabox/box = boxes[boxes.len]
 		boxes -= box
@@ -203,8 +207,8 @@
 		to_chat(user, "<span class='warning'>You remove the topmost [src] from your hand.</span>")
 		box.update_icon()
 		update_icon()
-		return
-	..()
+		return TRUE
+	return ..()
 
 /obj/item/pizzabox/attack_self(mob/user)
 
@@ -231,7 +235,7 @@
 
 			if( (boxes.len+1) + boxestoadd.len <= 5 )
 				if(!user.unEquip(box, src))
-					return
+					return TRUE
 				box.boxes = list()// clear the box boxes so we don't have boxes inside boxes. - Xzibit
 				src.boxes.Add( boxestoadd )
 
@@ -244,13 +248,13 @@
 		else
 			to_chat(user, "<span class='warning'>Close \the [box] first!</span>")
 
-		return
+		return TRUE
 
 	if( istype(I, /obj/item/chems/food/sliceable/pizza/) )
 
 		if( src.open )
 			if(!user.unEquip(I, src))
-				return
+				return TRUE
 			src.pizza = I
 
 			update_icon()
@@ -258,12 +262,12 @@
 			to_chat(user, "<span class='warning'>You put \the [I] in \the [src]!</span>")
 		else
 			to_chat(user, "<span class='warning'>You try to push \the [I] through the lid but it doesn't work!</span>")
-		return
+		return TRUE
 
 	if(IS_PEN(I))
 
 		if( src.open )
-			return
+			return TRUE
 
 		var/t = sanitize(input("Enter what you want to add to the tag:", "Write", null, null) as text, 30)
 
@@ -274,25 +278,21 @@
 		boxtotagto.boxtag = copytext("[boxtotagto.boxtag][t]", 1, 30)
 
 		update_icon()
-		return
-	..()
+		return TRUE
+	return ..()
 
-/obj/item/pizzabox/margherita/Initialize()
-	. = ..()
-	pizza = new /obj/item/chems/food/sliceable/pizza/margherita(src)
+/obj/item/pizzabox/margherita
+	pizza = /obj/item/chems/food/sliceable/pizza/margherita
 	boxtag = "Margherita Deluxe"
 
-/obj/item/pizzabox/vegetable/Initialize()
-	. = ..()
-	pizza = new /obj/item/chems/food/sliceable/pizza/vegetablepizza(src)
+/obj/item/pizzabox/vegetable
+	pizza = /obj/item/chems/food/sliceable/pizza/vegetablepizza
 	boxtag = "Gourmet Vegatable"
 
-/obj/item/pizzabox/mushroom/Initialize()
-	. = ..()
-	pizza = new /obj/item/chems/food/sliceable/pizza/mushroompizza(src)
+/obj/item/pizzabox/mushroom
+	pizza = /obj/item/chems/food/sliceable/pizza/mushroompizza
 	boxtag = "Mushroom Special"
 
-/obj/item/pizzabox/meat/Initialize()
-	. = ..()
-	pizza = new /obj/item/chems/food/sliceable/pizza/meatpizza(src)
+/obj/item/pizzabox/meat
+	pizza = /obj/item/chems/food/sliceable/pizza/meatpizza
 	boxtag = "Meatlover's Supreme"

--- a/code/modules/reagents/storage/pill_bottle_subtypes.dm
+++ b/code/modules/reagents/storage/pill_bottle_subtypes.dm
@@ -1,68 +1,90 @@
 /obj/item/storage/pill_bottle/antitox
 	name = "pill bottle (antitoxins)"
 	desc = "Contains pills used to counter toxins."
-	startswith = list(/obj/item/chems/pill/antitox = 21)
 	wrapper_color = COLOR_GREEN
+
+/obj/item/storage/pill_bottle/antitox/WillContain()
+	return list(/obj/item/chems/pill/antitox = 21)
 
 /obj/item/storage/pill_bottle/brute_meds
 	name = "pill bottle (styptic)"
 	desc = "Contains pills used to stabilize the severely injured."
-	startswith = list(/obj/item/chems/pill/brute_meds = 21)
 	wrapper_color = COLOR_MAROON
+
+/obj/item/storage/pill_bottle/brute_meds/WillContain()
+	return list(/obj/item/chems/pill/brute_meds = 21)
 
 /obj/item/storage/pill_bottle/oxygen
 	name = "pill bottle (oxygen)"
 	desc = "Contains pills used to treat oxygen deprivation."
-	startswith = list(/obj/item/chems/pill/oxygen = 21)
 	wrapper_color = COLOR_LIGHT_CYAN
+
+/obj/item/storage/pill_bottle/oxygen/WillContain()
+	return list(/obj/item/chems/pill/oxygen = 21)
 
 /obj/item/storage/pill_bottle/antitoxins
 	name = "pill bottle (antitoxins)"
 	desc = "Contains pills used to treat toxic substances in the blood."
-	startswith = list(/obj/item/chems/pill/antitoxins = 21)
 	wrapper_color = COLOR_GREEN
+
+/obj/item/storage/pill_bottle/antitoxins/WillContain()
+	return list(/obj/item/chems/pill/antitoxins = 21)
 
 /obj/item/storage/pill_bottle/adrenaline
 	name = "pill bottle (adrenaline)"
 	desc = "Contains pills used to stabilize patients."
-	startswith = list(/obj/item/chems/pill/stabilizer = 21)
 	wrapper_color = COLOR_PALE_BLUE_GRAY
+
+/obj/item/storage/pill_bottle/adrenaline/WillContain()
+	return list(/obj/item/chems/pill/stabilizer = 21)
 
 /obj/item/storage/pill_bottle/burn_meds
 	name = "pill bottle (synthskin)"
 	desc = "Contains pills used to treat burns."
-	startswith = list(/obj/item/chems/pill/burn_meds = 21)
 	wrapper_color = COLOR_SUN
+
+/obj/item/storage/pill_bottle/burn_meds/WillContain()
+	return list(/obj/item/chems/pill/burn_meds = 21)
 
 /obj/item/storage/pill_bottle/antibiotics
 	name = "pill bottle (antibiotics)"
 	desc = "A theta-lactam antibiotic. Effective against many diseases likely to be encountered in space."
-	startswith = list(/obj/item/chems/pill/antibiotics = 14)
 	wrapper_color = COLOR_PALE_GREEN_GRAY
+
+/obj/item/storage/pill_bottle/antibiotics/WillContain()
+	return list(/obj/item/chems/pill/antibiotics = 14)
 
 /obj/item/storage/pill_bottle/painkillers
 	name = "pill bottle (painkillers)"
 	desc = "Contains pills used to relieve pain."
-	startswith = list(/obj/item/chems/pill/painkillers = 14)
 	wrapper_color = COLOR_PURPLE_GRAY
+
+/obj/item/storage/pill_bottle/painkillers/WillContain()
+	return list(/obj/item/chems/pill/painkillers = 14)
 
 //Baycode specific Psychiatry pills.
 /obj/item/storage/pill_bottle/antidepressants
 	name = "pill bottle (antidepressants)"
 	desc = "Mild antidepressant. For use in individuals suffering from depression or anxiety. 15u dose per pill."
-	startswith = list(/obj/item/chems/pill/antidepressants = 21)
 	wrapper_color = COLOR_GRAY
+
+/obj/item/storage/pill_bottle/antidepressants/WillContain()
+	return list(/obj/item/chems/pill/antidepressants = 21)
 
 /obj/item/storage/pill_bottle/stimulants
 	name = "pill bottle (stimulants)"
 	desc = "Mental stimulant. For use in individuals suffering from ADHD, or general concentration issues. 15u dose per pill."
-	startswith = list(/obj/item/chems/pill/stimulants = 21)
 	wrapper_color = COLOR_GRAY
+
+/obj/item/storage/pill_bottle/stimulants/WillContain()
+	return list(/obj/item/chems/pill/stimulants = 21)
 
 /obj/item/storage/pill_bottle/assorted
 	name = "pill bottle (assorted)"
 	desc = "Commonly found on paramedics, these assorted pill bottles contain all the basics."
-	startswith = list(
+	
+/obj/item/storage/pill_bottle/assorted/WillContain()
+	return list(
 			/obj/item/chems/pill/stabilizer = 6,
 			/obj/item/chems/pill/antitoxins = 6,
 			/obj/item/chems/pill/sugariron = 2,

--- a/code/modules/reagents/storage/pill_bottle_subtypes.dm
+++ b/code/modules/reagents/storage/pill_bottle_subtypes.dm
@@ -30,12 +30,12 @@
 /obj/item/storage/pill_bottle/antitoxins/WillContain()
 	return list(/obj/item/chems/pill/antitoxins = 21)
 
-/obj/item/storage/pill_bottle/adrenaline
-	name = "pill bottle (adrenaline)"
+/obj/item/storage/pill_bottle/stabilizer
+	name = "pill bottle (stabilizer)"
 	desc = "Contains pills used to stabilize patients."
 	wrapper_color = COLOR_PALE_BLUE_GRAY
 
-/obj/item/storage/pill_bottle/adrenaline/WillContain()
+/obj/item/storage/pill_bottle/stabilizer/WillContain()
 	return list(/obj/item/chems/pill/stabilizer = 21)
 
 /obj/item/storage/pill_bottle/burn_meds

--- a/code/modules/spells/artifacts/storage.dm
+++ b/code/modules/spells/artifacts/storage.dm
@@ -17,8 +17,8 @@
 
 /obj/structure/closet/wizard/armor/WillContain()
 	return list(
-		/obj/item/clothing/shoes/sandal, //In case they've lost them.
-		/obj/item/clothing/gloves/wizard, //To complete the outfit
+		/obj/item/clothing/shoes/sandal,
+		/obj/item/clothing/gloves/wizard,
 		/obj/item/clothing/suit/space/void/wizard,
 		/obj/item/clothing/head/helmet/space/void/wizard
 	)

--- a/code/modules/spells/artifacts/storage.dm
+++ b/code/modules/spells/artifacts/storage.dm
@@ -15,27 +15,30 @@
 	name = "Mastercrafted Armor Set"
 	desc = "An artefact suit of armor that allows you to cast spells while providing more protection against attacks and the void of space."
 
-/obj/structure/closet/wizard/armor/Initialize()
-	. = ..()
-	new /obj/item/clothing/shoes/sandal(src) //In case they've lost them.
-	new /obj/item/clothing/gloves/wizard(src)//To complete the outfit
-	new /obj/item/clothing/suit/space/void/wizard(src)
-	new /obj/item/clothing/head/helmet/space/void/wizard(src)
+/obj/structure/closet/wizard/armor/WillContain()
+	return list(
+		/obj/item/clothing/shoes/sandal, //In case they've lost them.
+		/obj/item/clothing/gloves/wizard, //To complete the outfit
+		/obj/item/clothing/suit/space/void/wizard,
+		/obj/item/clothing/head/helmet/space/void/wizard
+	)
 
 /obj/structure/closet/wizard/scrying
 	name = "Scrying Orb"
 	desc = "An incandescent orb of crackling energy, using it will allow you to ghost while alive, allowing you to reconnoiter with ease. In addition, buying it will permanently grant you x-ray vision."
 
-/obj/structure/closet/wizard/scrying/Initialize()
-	. = ..()
-	new /obj/item/scrying(src)
-	new /obj/item/contract/wizard/xray(src)
+/obj/structure/closet/wizard/scrying/WillContain()
+	return list(
+		/obj/item/scrying,
+		/obj/item/contract/wizard/xray,
+	)
 
 /obj/structure/closet/wizard/souls
 	name = "Soul Shard Belt"
 	desc = "Soul Stone Shards are ancient tools capable of capturing and harnessing the spirits of the dead and dying. The spell Artificer allows you to create arcane machines for the captured souls to pilot. This also includes the spell Artificer, used to create the shells used in construct creation."
 
-/obj/structure/closet/wizard/souls/Initialize()
-	. = ..()
-	new /obj/item/contract/boon/wizard/artificer(src)
-	new /obj/item/storage/belt/soulstone/full(src)
+/obj/structure/closet/wizard/souls/WillContain()
+	return list(
+		/obj/item/contract/boon/wizard/artificer,
+		/obj/item/storage/belt/soulstone/full,
+	)

--- a/code/modules/spells/racial_wizard.dm
+++ b/code/modules/spells/racial_wizard.dm
@@ -35,8 +35,8 @@
 	to_chat(user, "\The [src] crumbles in your hands.")
 	qdel(src)
 
-/obj/item/storage/bag/cash/infinite
-	startswith = list(/obj/item/cash/c1000 = 1)
+/obj/item/storage/bag/cash/infinite/WillContain()
+	return /obj/item/cash/c1000
 
 //HUMAN
 /obj/item/storage/bag/cash/infinite/remove_from_storage(obj/item/W, atom/new_location)

--- a/code/modules/xenoarcheaology/tools/misc.dm
+++ b/code/modules/xenoarcheaology/tools/misc.dm
@@ -1,59 +1,59 @@
 /obj/structure/bookcase/manuals/xenoarchaeology
 	name = "Xenoarchaeology Manuals bookcase"
 
-/obj/structure/bookcase/manuals/xenoarchaeology/Initialize()
-	. = ..()
-	new /obj/item/book/manual/excavation(src)
-	new /obj/item/book/manual/mass_spectrometry(src)
-	new /obj/item/book/manual/materials_chemistry_analysis(src)
-	new /obj/item/book/manual/anomaly_testing(src)
-	new /obj/item/book/manual/anomaly_spectroscopy(src)
-	new /obj/item/book/manual/stasis(src)
-	update_icon()
+/obj/structure/bookcase/manuals/xenoarchaeology/WillContain()
+	return list(
+		/obj/item/book/manual/excavation,
+		/obj/item/book/manual/mass_spectrometry,
+		/obj/item/book/manual/materials_chemistry_analysis,
+		/obj/item/book/manual/anomaly_testing,
+		/obj/item/book/manual/anomaly_spectroscopy,
+		/obj/item/book/manual/stasis,
+	)
 
 /obj/structure/closet/secure_closet/xenoarchaeologist
 	name = "Xenoarchaeologist Locker"
 	req_access = list(access_xenoarch)
 	closet_appearance = /decl/closet_appearance/secure_closet/expedition/science
 
-/obj/structure/closet/secure_closet/xenoarchaeologist/Initialize()
-	. = ..()
-	if(prob(50))
-		new /obj/item/storage/backpack/toxins(src)
-	if(prob(50))
-		new /obj/item/storage/backpack/dufflebag(src)
-	new /obj/item/clothing/under/color/white(src)
-	new /obj/item/clothing/suit/storage/toggle/labcoat(src)
-	new /obj/item/clothing/shoes/color/white(src)
-	new /obj/item/clothing/glasses/science(src)
-	new /obj/item/radio/headset/headset_sci(src)
-	new /obj/item/clothing/mask/gas(src)
-	new /obj/item/clipboard(src)
-	new /obj/item/storage/belt/archaeology(src)
-	new /obj/item/storage/excavation(src)
-	new /obj/item/stack/tape_roll/barricade_tape/research(src)
+/obj/structure/closet/secure_closet/xenoarchaeologist/WillContain()
+	return list(
+		new /datum/atom_creator/simple(/obj/item/storage/backpack/toxins,    50),
+		new /datum/atom_creator/simple(/obj/item/storage/backpack/dufflebag, 50),
+		/obj/item/clothing/under/color/white,
+		/obj/item/clothing/suit/storage/toggle/labcoat,
+		/obj/item/clothing/shoes/color/white,
+		/obj/item/clothing/glasses/science,
+		/obj/item/radio/headset/headset_sci,
+		/obj/item/clothing/mask/gas,
+		/obj/item/clipboard,
+		/obj/item/storage/belt/archaeology,
+		/obj/item/storage/excavation,
+		/obj/item/stack/tape_roll/barricade_tape/research,
+	)
 
 /obj/structure/closet/excavation
 	name = "excavation tools"
 	closet_appearance = /decl/closet_appearance/secure_closet/engineering/tools
 
-/obj/structure/closet/excavation/Initialize()
-	. = ..()
-	new /obj/item/storage/belt/archaeology(src)
-	new /obj/item/storage/excavation(src)
-	new /obj/item/flashlight/lantern(src)
-	new /obj/item/ano_scanner(src)
-	new /obj/item/depth_scanner(src)
-	new /obj/item/core_sampler(src)
-	new /obj/item/gps(src)
-	new /obj/item/pinpointer/radio(src)
-	new /obj/item/clothing/glasses/meson(src)
-	new /obj/item/pickaxe(src)
-	new /obj/item/measuring_tape(src)
-	new /obj/item/pickaxe/xeno/hand(src)
-	new /obj/item/storage/bag/fossils(src)
-	new /obj/item/hand_labeler(src)
-	new /obj/item/stack/tape_roll/barricade_tape/research(src)
+/obj/structure/closet/excavation/WillContain()
+	return list(
+		/obj/item/storage/belt/archaeology,
+		/obj/item/storage/excavation,
+		/obj/item/flashlight/lantern,
+		/obj/item/ano_scanner,
+		/obj/item/depth_scanner,
+		/obj/item/core_sampler,
+		/obj/item/gps,
+		/obj/item/pinpointer/radio,
+		/obj/item/clothing/glasses/meson,
+		/obj/item/pickaxe,
+		/obj/item/measuring_tape,
+		/obj/item/pickaxe/xeno/hand,
+		/obj/item/storage/bag/fossils,
+		/obj/item/hand_labeler,
+		/obj/item/stack/tape_roll/barricade_tape/research,
+	)
 
 /obj/machinery/alarm/isolation
 	req_access = list(list(access_research, access_atmospherics, access_engine_equip))

--- a/code/modules/xenoarcheaology/tools/picks.dm
+++ b/code/modules/xenoarcheaology/tools/picks.dm
@@ -99,18 +99,21 @@
 	max_storage_space = 18
 	max_w_class = ITEM_SIZE_NORMAL
 	use_to_pickup = 1
-	startswith = list(
-		/obj/item/pickaxe/xeno/brush,
-		/obj/item/pickaxe/xeno/one_pick,
-		/obj/item/pickaxe/xeno/two_pick,
-		/obj/item/pickaxe/xeno/three_pick,
-		/obj/item/pickaxe/xeno/four_pick,
-		/obj/item/pickaxe/xeno/five_pick,
-		/obj/item/pickaxe/xeno/six_pick)
 	material = /decl/material/solid/leather/synth
 
-/obj/item/storage/excavation/empty
-	startswith = null
+/obj/item/storage/excavation/WillContain()
+	return list(
+			/obj/item/pickaxe/xeno/brush,
+			/obj/item/pickaxe/xeno/one_pick,
+			/obj/item/pickaxe/xeno/two_pick,
+			/obj/item/pickaxe/xeno/three_pick,
+			/obj/item/pickaxe/xeno/four_pick,
+			/obj/item/pickaxe/xeno/five_pick,
+			/obj/item/pickaxe/xeno/six_pick
+		)
+
+/obj/item/storage/excavation/empty/WillContain()
+	return
 
 /obj/item/storage/excavation/handle_item_insertion()
 	..()

--- a/mods/content/corporate/items/badges.dm
+++ b/mods/content/corporate/items/badges.dm
@@ -1,7 +1,9 @@
 /obj/item/storage/box/holobadgeNT
 	name = "corporate holobadge box"
 	desc = "A box containing corporate security holobadges."
-	startswith = list(
+
+/obj/item/storage/box/holobadgeNT/WillContain()
+	return list(
 		/obj/item/clothing/accessory/badge/holo/NT = 4,
 		/obj/item/clothing/accessory/badge/holo/NT/cord = 2
 	)

--- a/mods/content/corporate/items/wristcomp.dm
+++ b/mods/content/corporate/items/wristcomp.dm
@@ -49,4 +49,6 @@
 	name = "box of spare wrist computers"
 	desc = "A box of spare wrist microcomputers."
 	icon_state = "pda"
-	startswith = list(/obj/item/modular_computer/pda/wrist = 5)
+
+/obj/item/storage/box/wrist/WillContain()
+	return list(/obj/item/modular_computer/pda/wrist = 5)

--- a/mods/content/psionics/items/foundation_weapon.dm
+++ b/mods/content/psionics/items/foundation_weapon.dm
@@ -17,8 +17,12 @@
 /obj/item/storage/briefcase/foundation/disrupts_psionics()
 	return FALSE
 
-/obj/item/storage/briefcase/foundation/Initialize()
+/obj/item/storage/briefcase/foundation/WillContain()
+	return list(
+		/obj/item/ammo_magazine/speedloader/nullglass,
+		/obj/item/gun/projectile/revolver/foundation,
+	)
+
+/obj/item/storage/briefcase/foundation/Initialize(ml, material_key)
 	. = ..()
-	new /obj/item/ammo_magazine/speedloader/nullglass(src)
-	new /obj/item/gun/projectile/revolver/foundation(src)
 	make_exact_fit()

--- a/mods/content/psionics/items/foundation_weapon.dm
+++ b/mods/content/psionics/items/foundation_weapon.dm
@@ -25,4 +25,5 @@
 
 /obj/item/storage/briefcase/foundation/Initialize(ml, material_key)
 	. = ..()
-	make_exact_fit()
+	if(length(contents))
+		make_exact_fit()

--- a/mods/species/ascent/items/tools.dm
+++ b/mods/species/ascent/items/tools.dm
@@ -58,4 +58,6 @@ MANTIDIFY(/obj/item/tank/jetpack/carbondioxide, "maneuvering pack",          "pr
 	desc = "A box full of bottled water."
 	icon = 'mods/species/ascent/icons/ascent_doodads.dmi'
 	icon_state = "box"
-	startswith = list(/obj/item/chems/drinks/cans/waterbottle/ascent = 7)
+
+/obj/item/storage/box/water/ascent/WillContain()
+	return list(/obj/item/chems/drinks/cans/waterbottle/ascent = 7)

--- a/mods/species/vox/gear/gear.dm
+++ b/mods/species/vox/gear/gear.dm
@@ -6,12 +6,16 @@
 	name = "vox survival kit"
 	desc = "A box decorated in warning colors that contains a limited supply of survival tools. The panel and black stripe indicate this one contains nitrogen."
 	icon_state = "survivalvox"
-	startswith = list(/obj/item/clothing/mask/breath = 1,
-					/obj/item/tank/emergency/nitrogen = 1,
-					/obj/item/chems/hypospray/autoinjector/pouch_auto/stabilizer = 1,
-					/obj/item/stack/medical/bruise_pack = 1,
-					/obj/item/flashlight/flare/glowstick = 1,
-					/obj/item/chems/food/candy/proteinbar = 1)
+
+/obj/item/storage/box/vox/WillContain()
+	return list(
+			/obj/item/clothing/mask/breath = 1,
+			/obj/item/tank/emergency/nitrogen = 1,
+			/obj/item/chems/hypospray/autoinjector/pouch_auto/stabilizer = 1,
+			/obj/item/stack/medical/bruise_pack = 1,
+			/obj/item/flashlight/flare/glowstick = 1,
+			/obj/item/chems/food/candy/proteinbar = 1
+		)
 
 /obj/item/tank/emergency/nitrogen
 	name = "emergency nitrogen tank"


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Basically makes all containers and things that just contain things which don't contribute to their inner workings use ``WillContain()`` to define what they're meant to spawn with. 
It changes mainly things that had a "startswith" list. 

Machinery and anything that spawn things for ensuring their own functionality weren't touched, since those always require custom handling. 

## Why and what will this PR improve
* Cuts down on single use list instances per atom.
* Allow overriding the spawn contents list.
* A bit better for downstream serialization.

## Changelog
:cl:
refactor: Refactored storage obj and some structures to implement WillContain() to populate their contents.
refactor: Tweaked pizzaboxes a bit, so they don't override initialize to set their contained pizza.
bugfix: Fixed some empty box variants having no storage slots on spawn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->