### PR TITLE
Organ healing.

### DIFF
--- a/code/game/machinery/vitals_monitor.dm
+++ b/code/game/machinery/vitals_monitor.dm
@@ -18,7 +18,7 @@
 /obj/machinery/vitals_monitor/Destroy()
 	victim = null
 	. = ..()
-	
+
 /obj/machinery/vitals_monitor/examine(mob/user)
 	. = ..()
 	if(victim)
@@ -29,7 +29,7 @@
 		to_chat(user, SPAN_NOTICE("Pulse: [victim.get_pulse(GETPULSE_TOOL)]"))
 
 		var/brain_activity = "none"
-		var/obj/item/organ/internal/brain/brain = victim.get_organ(BP_BRAIN, /obj/item/organ/internal/brain)
+		var/obj/item/organ/internal/brain = GET_INTERNAL_ORGAN(victim, BP_BRAIN)
 		if(brain && victim.stat != DEAD && !(victim.status_flags & FAKEDEATH))
 			if(user.skill_check(SKILL_MEDICAL, SKILL_BASIC))
 				switch(brain.get_current_damage_threshold())
@@ -50,7 +50,7 @@
 				breathing = "normal"
 			else if(lungs.breath_fail_ratio < 1)
 				breathing = "shallow"
-		
+
 		to_chat(user, SPAN_NOTICE("Breathing: [breathing]"))
 
 /obj/machinery/vitals_monitor/Process()
@@ -63,7 +63,7 @@
 		update_icon()
 	if(beep && victim && victim.pulse())
 		playsound(src, 'sound/machines/quiet_beep.ogg')
-	
+
 /obj/machinery/vitals_monitor/handle_mouse_drop(var/atom/over, var/mob/user)
 	if(ishuman(over))
 		if(victim)
@@ -83,7 +83,7 @@
 
 	if(!victim)
 		return
-	
+
 	switch(victim.pulse())
 		if(PULSE_NONE)
 			overlays += image(icon, icon_state = "pulse_flatline")
@@ -96,7 +96,7 @@
 			overlays += image(icon, icon_state = "pulse_thready")
 			overlays += image(icon, icon_state = "pulse_warning")
 
-	var/obj/item/organ/internal/brain/brain = victim.get_organ(BP_BRAIN, /obj/item/organ/internal/brain)
+	var/obj/item/organ/internal/brain = GET_INTERNAL_ORGAN(victim, BP_BRAIN)
 	if(istype(brain) && victim.stat != DEAD && !(victim.status_flags & FAKEDEATH))
 		switch(brain.get_current_damage_threshold())
 			if(0 to 2)
@@ -128,11 +128,11 @@
 	var/mob/user = usr
 	if(!istype(user))
 		return
-	
+
 	if(CanPhysicallyInteract(user))
 		beep = !beep
 		to_chat(user, SPAN_NOTICE("You turn the sound on \the [src] [beep ? "on" : "off"]."))
-		
+
 /obj/item/stock_parts/circuitboard/vitals_monitor
 	name = "circuit board (Vitals Monitor)"
 	build_path = /obj/machinery/vitals_monitor

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -82,7 +82,7 @@
 	// Brain activity.
 	var/brain_result = "normal"
 	if(H.should_have_organ(BP_BRAIN))
-		var/obj/item/organ/internal/brain/brain = H.get_organ(BP_BRAIN, /obj/item/organ/internal/brain)
+		var/obj/item/organ/internal/brain = GET_INTERNAL_ORGAN(H, BP_BRAIN)
 		if(!brain || H.stat == DEAD || (H.status_flags & FAKEDEATH))
 			brain_result = "<span class='scan_danger'>none, patient is braindead</span>"
 		else if(H.stat != DEAD)

--- a/code/modules/augment/active/cyberbrain.dm
+++ b/code/modules/augment/active/cyberbrain.dm
@@ -67,15 +67,16 @@
 	. = ..()
 
 /obj/item/organ/internal/augment/active/cyberbrain/Process()
-	var/datum/extension/assembly/assembly = get_extension(src, /datum/extension/assembly)
-	if(assembly)
-		assembly.Process()
-		if(!assembly.enabled)
-			return
-
-	var/datum/extension/interactive/os/os = get_extension(src, /datum/extension/interactive/os)
-	if(os)
-		os.Process()
+	..()
+	if(!is_broken() && !(status & ORGAN_DEAD))
+		var/datum/extension/assembly/assembly = get_extension(src, /datum/extension/assembly)
+		if(assembly)
+			assembly.Process()
+			if(!assembly.enabled)
+				return
+		var/datum/extension/interactive/os/os = get_extension(src, /datum/extension/interactive/os)
+		if(os)
+			os.Process()
 
 /*
  *

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -16,14 +16,14 @@
 /mob/living/carbon/human/adjustBrainLoss(var/amount)
 	if(status_flags & GODMODE)	return 0	//godmode
 	if(should_have_organ(BP_BRAIN))
-		var/obj/item/organ/internal/brain/sponge = get_organ(BP_BRAIN, /obj/item/organ/internal/brain)
+		var/obj/item/organ/internal/sponge = GET_INTERNAL_ORGAN(src, BP_BRAIN)
 		if(sponge)
 			sponge.take_internal_damage(amount)
 
 /mob/living/carbon/human/setBrainLoss(var/amount)
 	if(status_flags & GODMODE)	return 0	//godmode
 	if(should_have_organ(BP_BRAIN))
-		var/obj/item/organ/internal/brain/sponge = get_organ(BP_BRAIN, /obj/item/organ/internal/brain)
+		var/obj/item/organ/internal/sponge = GET_INTERNAL_ORGAN(src, BP_BRAIN)
 		if(sponge)
 			sponge.damage = min(max(amount, 0),sponge.species.total_health)
 			updatehealth()
@@ -31,7 +31,7 @@
 /mob/living/carbon/human/getBrainLoss()
 	if(status_flags & GODMODE)	return 0	//godmode
 	if(should_have_organ(BP_BRAIN))
-		var/obj/item/organ/internal/brain/sponge = get_organ(BP_BRAIN, /obj/item/organ/internal/brain)
+		var/obj/item/organ/internal/sponge = GET_INTERNAL_ORGAN(src, BP_BRAIN)
 		if(sponge)
 			if(sponge.status & ORGAN_DEAD)
 				return sponge.species.total_health

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -468,7 +468,7 @@ default behaviour is:
 /mob/living/carbon/basic_revival(var/repair_brain = TRUE)
 	if(repair_brain && should_have_organ(BP_BRAIN))
 		repair_brain = FALSE
-		var/obj/item/organ/internal/brain/brain = get_organ(BP_BRAIN, /obj/item/organ/internal/brain)
+		var/obj/item/organ/internal/brain = GET_INTERNAL_ORGAN(src, BP_BRAIN)
 		if(brain)
 			if(brain.damage > (brain.max_damage/2))
 				brain.damage = (brain.max_damage/2)

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -184,7 +184,7 @@
 	if(owner.get_blood_oxygenation() < BLOOD_VOLUME_SAFE)
 		return FALSE
 	// Our owner is under stress.
-	if(GET_CHEMICAL_EFFECT(owner, CE_TOXIN) || owner.is_asystole())
+	if(GET_CHEMICAL_EFFECT(owner, CE_TOXIN) || owner.radiation || owner.is_asystole())
 		return FALSE
 	// If we haven't hit the regeneration cutoff point, heal.
 	if(!min_regeneration_cutoff_threshold || !past_damage_threshold(min_regeneration_cutoff_threshold))

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -19,6 +19,8 @@
 
 	var/can_use_mmi = TRUE
 	var/mob/living/carbon/brain/brainmob = null
+	var/should_announce_brain_damage = TRUE
+
 	var/oxygen_reserve = 6
 
 /obj/item/organ/internal/brain/getToxLoss()
@@ -90,7 +92,7 @@
 
 /obj/item/organ/internal/brain/proc/handle_severe_damage()
 	set waitfor = FALSE
-	healed_threshold = 0
+	should_announce_brain_damage = FALSE
 	to_chat(owner, "<span class = 'notice' font size='10'><B>Where am I...?</B></span>")
 	sleep(5 SECONDS)
 	if(!owner)
@@ -107,8 +109,10 @@
 
 /obj/item/organ/internal/brain/Process()
 	if(owner)
-		if(damage > max_damage / 2 && healed_threshold)
+		if(damage >= round(max_damage / 2) && should_announce_brain_damage)
 			handle_severe_damage()
+		else if(damage < (max_damage / 4))
+			should_announce_brain_damage = TRUE
 
 		handle_disabilities()
 		handle_damage_effects()

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -86,10 +86,8 @@
 /obj/item/organ/internal/brain/can_recover()
 	return ~status & ORGAN_DEAD
 
-/obj/item/organ/internal/brain/handle_severe_damage()
-	..()
-	if(!should_announce_brain_damage)
-		return
+/obj/item/organ/internal/brain/proc/handle_severe_damage()
+	set waitfor = FALSE
 	should_announce_brain_damage = FALSE
 	to_chat(owner, "<span class = 'notice' font size='10'><B>Where am I...?</B></span>")
 	sleep(5 SECONDS)
@@ -103,7 +101,10 @@
 	alert(owner, "You have taken massive brain damage! You will not be able to remember the events leading up to your injury.", "Brain Damaged")
 
 /obj/item/organ/internal/brain/organ_can_heal()
-	return (damage && !(status & ORGAN_DEAD) && GET_CHEMICAL_EFFECT(owner, CE_BRAIN_REGEN)) || ..()
+	return (damage && GET_CHEMICAL_EFFECT(owner, CE_BRAIN_REGEN)) || ..()
+
+/obj/item/organ/internal/brain/get_organ_heal_amount()
+	return 1
 
 /obj/item/organ/internal/brain/Process()
 	if(owner)
@@ -195,8 +196,13 @@
 	else if((owner.disabilities & NERVOUS) && prob(10))
 		SET_STATUS_MAX(owner, STAT_STUTTER, 10)
 
+
 /obj/item/organ/internal/brain/handle_damage_effects()
 	..()
+
+	if(damage >= round(max_damage / 2) && should_announce_brain_damage)
+		handle_severe_damage()
+
 	if(!BP_IS_PROSTHETIC(src) && prob(1))
 		owner.custom_pain("Your head feels numb and painful.",10)
 	if(is_bruised() && prob(1) && !HAS_STATUS(owner, STAT_BLURRY))

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -11,6 +11,12 @@
 	max_damage = 70
 	relative_size = 60
 
+/obj/item/organ/internal/liver/organ_can_heal()
+	// We're busy processing other stuff.
+	if(GET_CHEMICAL_EFFECT(owner, CE_ALCOHOL) || GET_CHEMICAL_EFFECT(owner, CE_TOXIN) || owner?.radiation)
+		return FALSE
+	return ..()
+
 /obj/item/organ/internal/liver/Process()
 
 	..()
@@ -48,13 +54,6 @@
 
 	if(alcotox)
 		take_internal_damage(alcotox, prob(90)) // Chance to warn them
-
-	// Heal a bit if needed and we're not busy. This allows recovery from low amounts of toxloss.
-	if(!alco && !GET_CHEMICAL_EFFECT(owner, CE_TOXIN) && !owner.radiation && damage > 0)
-		if(damage < min_broken_damage)
-			heal_damage(0.2)
-		if(damage < min_bruised_damage)
-			heal_damage(0.3)
 
 	//Blood regeneration if there is some space
 	owner.regenerate_blood(0.1 + GET_CHEMICAL_EFFECT(owner, CE_BLOODRESTORE))

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -13,7 +13,7 @@
 
 /obj/item/organ/internal/liver/organ_can_heal()
 	// We're busy processing other stuff.
-	if(GET_CHEMICAL_EFFECT(owner, CE_ALCOHOL) || GET_CHEMICAL_EFFECT(owner, CE_TOXIN) || owner?.radiation)
+	if(GET_CHEMICAL_EFFECT(owner, CE_ALCOHOL))
 		return FALSE
 	return ..()
 

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -66,7 +66,3 @@
 			owner.adjust_nutrition(-10)
 		else if(owner.nutrition >= 200)
 			owner.adjust_nutrition(-3)
-
-//We got it covered in Process with more detailed thing
-/obj/item/organ/internal/liver/handle_regeneration()
-	return

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -10,12 +10,12 @@
 	min_broken_damage = 45
 	max_damage = 70
 	relative_size = 60
+	// Liver recovers a lot better than most meat.
+	min_regeneration_cutoff_threshold = 2
+	max_regeneration_cutoff_threshold = 5
 
 /obj/item/organ/internal/liver/organ_can_heal()
-	// We're busy processing other stuff.
-	if(GET_CHEMICAL_EFFECT(owner, CE_ALCOHOL))
-		return FALSE
-	return ..()
+	return !GET_CHEMICAL_EFFECT(owner, CE_ALCOHOL) && ..()
 
 /obj/item/organ/internal/liver/Process()
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -330,7 +330,7 @@
 	CRASH("Not Implemented")
 
 /obj/item/organ/proc/heal_damage(amount)
-	if (can_recover())
+	if(can_recover())
 		damage = clamp(0, damage - round(amount, 0.1), max_damage)
 
 /obj/item/organ/proc/robotize(var/company = /decl/prosthetics_manufacturer/basic_human, var/skip_prosthetics = 0, var/keep_organs = 0, var/apply_material = /decl/material/solid/metal/steel, var/check_bodytype, var/check_species)

--- a/mods/content/psionics/items/brain.dm
+++ b/mods/content/psionics/items/brain.dm
@@ -1,4 +1,4 @@
-/obj/item/organ/internal/brain/handle_severe_brain_damage()
+/obj/item/organ/internal/brain/handle_severe_damage()
 	. = ..()
 	if(owner.psi)
 		owner.psi.check_latency_trigger(20, "physical trauma")

--- a/mods/mobs/borers/mob/organ.dm
+++ b/mods/mobs/borers/mob/organ.dm
@@ -10,7 +10,7 @@
 	var/list/chemical_types
 
 /obj/item/organ/internal/borer/Process()
-
+	SHOULD_CALL_PARENT(FALSE)
 	// Borer husks regenerate health, feel no pain, and are resistant to stuns and brainloss.
 	for(var/chem_name in chemical_types)
 		var/chem = chemical_types[chem_name]


### PR DESCRIPTION
## Description of changes
- Livers and brains now share their regeneration behavior with the base internal organ type. In other words, all internal organs will naturally slowly heal damage to the closest threshold based on their vars.
- Since the behavior has been migrated down the chain, a fair bit of other code is now type-agnostic when dealing with the brain.

Still need to test this, tweak numbers, and clean up the redundant checking in the procs.

## Why and what will this PR improve
Minor organ damage being permanent has been an issue for awhile (welding eye damage, for example) and we had three different methods of organs healing themselves. This also clears the field for some changes I want to make in #1447, namely MMIs being an organ subtype.

## Authorship
Myself.

## Changelog
:cl:
tweak: Liver and brain regeneration has been tweaked, and all internal organs will now regenerate slowly to a point.
/:cl: