### PR TITLE
Fix missing heating points for reagents with defined heating products

### DIFF
--- a/code/modules/materials/definitions/gasses/material_gas_mundane.dm
+++ b/code/modules/materials/definitions/gasses/material_gas_mundane.dm
@@ -3,8 +3,8 @@
 	uid = "gas_oxygen"
 	lore_text = "An ubiquitous oxidizing agent."
 	flags = MAT_FLAG_FUSION_FUEL
-	gas_specific_heat = 20	
-	molar_mass = 0.032	
+	gas_specific_heat = 20
+	molar_mass = 0.032
 	latent_heat = 213
 	boiling_point = -183 CELSIUS
 	gas_flags = XGM_GAS_OXIDIZER
@@ -36,10 +36,10 @@
 	name = "carbon dioxide"
 	uid = "gas_carbon_dioxide"
 	lore_text = "A byproduct of respiration."
-	gas_specific_heat = 30	
+	gas_specific_heat = 30
 	molar_mass = 0.044
 	latent_heat = 380
-	boiling_point = -78 CELSIUS	
+	boiling_point = -78 CELSIUS
 	gas_symbol_html = "CO<sub>2</sub>"
 	gas_symbol = "CO2"
 
@@ -50,7 +50,7 @@
 	gas_specific_heat = 30
 	molar_mass = 0.028
 	latent_heat = 216
-	boiling_point = -192 CELSIUS	
+	boiling_point = -192 CELSIUS
 	gas_symbol_html = "CO"
 	gas_symbol = "CO"
 	taste_description = "stale air"
@@ -90,10 +90,10 @@
 	name = "methyl bromide"
 	uid = "gas_methyl_bromide"
 	lore_text = "A once-popular fumigant and weedkiller."
-	gas_specific_heat = 42.59 
+	gas_specific_heat = 42.59
 	molar_mass = 0.095
 	latent_heat = 253
-	boiling_point = 4 CELSIUS		  
+	boiling_point = 4 CELSIUS
 	gas_symbol_html = "CH<sub>3</sub>Br"
 	gas_symbol = "CH3Br"
 	taste_description = "pestkiller"
@@ -119,10 +119,10 @@
 	name = "sleeping agent"
 	uid = "gas_sleeping_agent"
 	lore_text = "A mild sedative. Also known as laughing gas."
-	gas_specific_heat = 40	
+	gas_specific_heat = 40
 	molar_mass = 0.044
 	latent_heat = 376
-	boiling_point = -90 CELSIUS	
+	boiling_point = -90 CELSIUS
 	gas_tile_overlay = "sleeping_agent"
 	gas_overlay_limit = 1
 	gas_flags = XGM_GAS_OXIDIZER //N2O is a powerful oxidizer
@@ -149,7 +149,7 @@
 	name = "nitrogen"
 	uid = "gas_nitrogen"
 	lore_text = "An ubiquitous noble gas."
-	gas_specific_heat = 20	
+	gas_specific_heat = 20
 	molar_mass = 0.028
 	latent_heat = 199
 	boiling_point = -195 CELSIUS
@@ -183,7 +183,7 @@
 /decl/material/gas/methane
 	name = "methane"
 	uid = "gas_methane"
-	gas_specific_heat = 30	
+	gas_specific_heat = 30
 	molar_mass = 0.016
 	latent_heat = 510
 	boiling_point = -162 CELSIUS
@@ -280,8 +280,6 @@
 	gas_symbol = "Cl"
 	taste_description = "bleach"
 	metabolism = REM
-	heating_point = null
-	heating_products = null
 	toxicity = 15
 
 /decl/material/gas/sulfur_dioxide

--- a/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
@@ -129,10 +129,11 @@
 	metabolism = REM
 	toxicity = 3
 	toxicity_targets_organ = BP_BRAIN
+	heating_point = 100 CELSIUS
 	heating_message = "melts into a liquid slurry."
 	heating_products = list(
-		/decl/material/liquid/carpotoxin = 0.2, 
-		/decl/material/liquid/sedatives = 0.4, 
+		/decl/material/liquid/carpotoxin = 0.2,
+		/decl/material/liquid/sedatives = 0.4,
 		/decl/material/solid/metal/copper = 0.4
 	)
 	taste_mult = 1.2
@@ -172,9 +173,10 @@
 	color = "#49002e"
 	toxicity = 4
 	heating_products = list(
-		/decl/material/liquid/bromide = 0.4, 
+		/decl/material/liquid/bromide = 0.4,
 		/decl/material/liquid/water = 0.6
 	)
+	heating_point = 100 CELSIUS
 	metabolism = REM * 0.25
 	defoliant = TRUE
 	exoplanet_rarity = MAT_RARITY_NOWHERE
@@ -188,7 +190,7 @@
 	toxicity = 4
 	heating_products = list(
 		/decl/material/liquid/acetone = 0.4,
-		/decl/material/solid/carbon = 0.4, 
+		/decl/material/solid/carbon = 0.4,
 		/decl/material/liquid/ethanol = 0.2
 	)
 	heating_point = 145 CELSIUS

--- a/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
@@ -6,8 +6,6 @@
 	taste_mult = null
 	color = "#808080"
 	metabolism = REM
-	heating_products = null
-	heating_point = null
 	toxicity_targets_organ = null
 	toxicity = 0
 	hidden_from_codex = TRUE
@@ -164,8 +162,6 @@
 	taste_mult = 0.5
 	toxicity = 0.5 // It's not THAT poisonous.
 	color = "#664330"
-	heating_point = null
-	heating_products = null
 	metabolism = REM * 0.25
 
 /decl/material/liquid/weedkiller
@@ -208,8 +204,6 @@
 	color = "#d9ffb3"
 	toxicity = 1
 	overdose = REAGENTS_OVERDOSE
-	heating_products = null
-	heating_point = null
 	taste_mult = 1.2
 	metabolism = REM * 0.25
 


### PR DESCRIPTION
## Description of changes
Adds heating points for weedkiller and zombie powder, which were lost when they stopped being subtypes of `/datum/reagent/toxin`.
Removes unnecessary `heating_point = null` overrides that stopped being necessary with the same repath.

## Why and what will this PR improve
Fixes weedkiller and zombie powder not being able to be decomposed by heating.
Cleans up unnecessary var overrides.

## Authorship
Me.