### PR TITLE
Prevent materials from generating recipes by default if they aren't solid at room temperature.

### DIFF
--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -17,8 +17,11 @@
 		. += new recipe_type(src)
 
 /decl/material/proc/generate_recipes(var/reinforce_material)
-	. = list()
 
+	if(phase_at_stp() != MAT_PHASE_SOLID)
+		return list()
+
+	. = list()
 	if(opacity < 0.6)
 		. += new/datum/stack_recipe/furniture/borderwindow(src, reinforce_material)
 		. += new/datum/stack_recipe/furniture/fullwindow(src, reinforce_material)


### PR DESCRIPTION
Should drastically reduce the creation and deletion of atoms during startup.