### PR TITLE
Give engi borgs a brace jack

### DIFF
--- a/code/modules/mob/living/silicon/robot/modules/module_engineering.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_engineering.dm
@@ -28,7 +28,7 @@
 		/obj/item/weldingtool/largetank,
 		/obj/item/screwdriver,
 		/obj/item/wrench,
-		/obj/item/crowbar,
+		/obj/item/crowbar/brace_jack,
 		/obj/item/wirecutters,
 		/obj/item/multitool,
 		/obj/item/t_scanner,


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Since engineer borgs can't deal with airlock braces in any ways, gave them a bracejack for now. Ideally maybe working something out with the airlocks could be interesting, but that might require some thinking, since you probably don't want the AI to access remotely brace jacks via the airlock UI among others, and require it to be a physical interaction. 


## Changelog
:cl:
tweak: Engineer borgs now have upgraded from a crowbar to a brace jack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->