### PR TITLE
Made cryopod despawn checking into a movable atom proc.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -37,6 +37,10 @@
 	var/inertia_move_delay = 5
 	var/atom/movable/inertia_ignore
 
+// This proc determines if the instance is preserved when the process() despawn of crypods occurs.
+/atom/movable/proc/preserve_in_cryopod(var/obj/machinery/cryopod/pod)
+	return FALSE
+
 //call this proc to start space drifting
 /atom/movable/proc/space_drift(direction)//move this down
 	if(!loc || direction & (UP|DOWN) || Process_Spacemove(0))

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -161,23 +161,6 @@
 	var/obj/machinery/computer/cryopod/control_computer
 	var/applies_stasis = 1
 
-	// These items are preserved when the process() despawn proc occurs.
-	var/list/preserve_items = list(
-		/obj/item/integrated_circuit/manipulation/wormhole,
-		/obj/item/integrated_circuit/input/teleporter_locator,
-		/obj/item/card/id/captains_spare,
-		/obj/item/aicard,
-		/obj/item/mmi,
-		/obj/item/paicard,
-		/obj/item/gun,
-		/obj/item/pinpointer,
-		/obj/item/clothing/suit,
-		/obj/item/clothing/shoes/magboots,
-		/obj/item/blueprints,
-		/obj/item/clothing/head/helmet/space,
-		/obj/item/storage/internal
-	)
-
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
@@ -355,28 +338,14 @@
 
 	for(var/obj/item/W in items)
 
-		var/preserve = null
-		// Snowflaaaake.
-		if(istype(W, /obj/item/mmi))
-			var/obj/item/mmi/brain = W
-			if(brain.brainmob && brain.brainmob.client && brain.brainmob.key)
-				preserve = 1
-			else
-				continue
-		else
-			for(var/T in preserve_items)
-				if(istype(W,T))
-					preserve = 1
-					break
-
-		if(!preserve)
+		if(!W.preserve_in_cryopod())
 			qdel(W)
+			continue
+		if(control_computer && control_computer.allow_items)
+			control_computer.frozen_items += W
+			W.forceMove(null)
 		else
-			if(control_computer && control_computer.allow_items)
-				control_computer.frozen_items += W
-				W.forceMove(null)
-			else
-				W.forceMove(get_turf(src))
+			W.forceMove(get_turf(src))
 
 	//Update any existing objectives involving this mob.
 	for(var/datum/objective/O in global.all_objectives)

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -15,6 +15,9 @@
 	if(set_valid_z_levels())
 		set_extension(src, /datum/extension/eye/blueprints)
 
+/obj/item/blueprints/preserve_in_cryopod(var/obj/machinery/cryopod/pod)
+	return TRUE
+
 /obj/item/blueprints/attack_self(mob/user)
 	if (!ishuman(user) || !user.check_dexterity(DEXTERITY_COMPLEX_TOOLS)) // Monkeys et al. cannot blueprint.
 		to_chat(user, SPAN_WARNING("This stack of blue paper means nothing to you."))

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -11,8 +11,10 @@
 	var/flush
 	var/mob/living/silicon/ai/carded_ai
 
-/obj/item/aicard/attack_self(mob/user)
+/obj/item/aicard/preserve_in_cryopod(var/obj/machinery/cryopod/pod)
+	return TRUE
 
+/obj/item/aicard/attack_self(mob/user)
 	ui_interact(user)
 
 /obj/item/aicard/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = global.inventory_topic_state)

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -26,6 +26,9 @@ var/global/list/pai_cards = list()
 	overlays += "pai-off"
 	global.pai_cards += src
 
+/obj/item/paicard/preserve_in_cryopod(var/obj/machinery/cryopod/pod)
+	return TRUE
+
 /obj/item/paicard/Destroy()
 	global.pai_cards -= src
 	//Will stop people throwing friend pAIs into the singularity so they can respawn

--- a/code/game/objects/items/devices/pinpointer.dm
+++ b/code/game/objects/items/devices/pinpointer.dm
@@ -15,6 +15,9 @@
 	target = null
 	. = ..()
 
+/obj/item/pinpointer/preserve_in_cryopod(var/obj/machinery/cryopod/pod)
+	return TRUE
+
 /obj/item/pinpointer/attack_self(mob/user)
 	toggle(user)
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -395,6 +395,9 @@ var/global/const/NO_EMAG_ACT = -50
 	. = ..()
 	access = get_all_station_access()
 
+/obj/item/card/id/captains_spare/preserve_in_cryopod(var/obj/machinery/cryopod/pod)
+	return TRUE
+
 /obj/item/card/id/synthetic
 	name = "\improper Synthetic ID"
 	desc = "Access module for lawed synthetics."

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -12,6 +12,9 @@
 	name = master_item.name
 	verbs -= /obj/item/verb/verb_pickup
 
+/obj/item/storage/internal/preserve_in_cryopod(var/obj/machinery/cryopod/pod)
+	return TRUE
+
 /obj/item/storage/internal/Destroy()
 	master_item = null
 	. = ..()

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -16,6 +16,9 @@
 	var/obj/item/clothing/shoes/covering_shoes
 	var/online_slowdown = 3
 
+/obj/item/clothing/shoes/magboots/preserve_in_cryopod(var/obj/machinery/cryopod/pod)
+	return TRUE
+
 /obj/item/clothing/shoes/magboots/proc/set_slowdown()
 	LAZYSET(slowdown_per_slot, slot_shoes_str, (covering_shoes ? max(0, LAZYACCESS(covering_shoes.slowdown_per_slot, slot_shoes_str)) : 0))	//So you can't put on magboots to make you walk faster.
 	if(magpulse)

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -46,6 +46,9 @@
 		verbs += /obj/item/clothing/head/helmet/space/proc/toggle_tint
 		update_tint()
 
+/obj/item/clothing/head/helmet/space/preserve_in_cryopod(var/obj/machinery/cryopod/pod)
+	return TRUE
+
 /obj/item/clothing/head/helmet/space/proc/toggle_camera()
 	set name = "Toggle Helmet Camera"
 	set category = "Object"

--- a/code/modules/clothing/suits/_suit.dm
+++ b/code/modules/clothing/suits/_suit.dm
@@ -17,6 +17,9 @@
 		var/mob/M = src.loc
 		M.update_inv_wear_suit()
 
+/obj/item/clothing/suit/preserve_in_cryopod(var/obj/machinery/cryopod/pod)
+	return TRUE
+
 /obj/item/clothing/suit/adjust_mob_overlay(var/mob/living/user_mob, var/bodytype,  var/image/overlay, var/slot, var/bodypart)
 	if(overlay && item_state)
 		overlay.icon_state = item_state

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -757,6 +757,9 @@
 	spawn_flags = IC_SPAWN_RESEARCH
 	action_flags = IC_ACTION_LONG_RANGE
 
+/obj/item/integrated_circuit/input/teleporter_locator/preserve_in_cryopod(var/obj/machinery/cryopod/pod)
+	return TRUE
+
 /obj/item/integrated_circuit/input/teleporter_locator/get_topic_data(mob/user)
 	var/datum/integrated_io/O = outputs[1]
 	var/obj/machinery/computer/teleporter/current_console = O.data_as_type(/obj/machinery/computer/teleporter)

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -562,6 +562,9 @@
 		/decl/material/solid/metal/gold = MATTER_AMOUNT_TRACE
 	)
 
+/obj/item/integrated_circuit/manipulation/wormhole/preserve_in_cryopod(var/obj/machinery/cryopod/pod)
+	return TRUE
+
 /obj/item/integrated_circuit/manipulation/wormhole/do_work()
 	var/obj/machinery/computer/teleporter/tporter = get_pin_data_as_type(IC_INPUT, 1, /obj/machinery/computer/teleporter)
 	var/step_dir = get_pin_data(IC_INPUT, 2)

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -115,6 +115,9 @@
 	update_icon()
 	locked = 1
 
+/obj/item/mmi/preserve_in_cryopod(obj/machinery/cryopod/pod)
+	return brainmob && brainmob.client && brainmob.key
+
 /obj/item/mmi/relaymove(var/mob/user, var/direction)
 	if(user.incapacitated(INCAPACITATION_KNOCKOUT))
 		return

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -106,6 +106,9 @@
 	autofiring_by = null
 	. = ..()
 
+/obj/item/gun/preserve_in_cryopod(var/obj/machinery/cryopod/pod)
+	return TRUE
+
 /obj/item/gun/proc/set_autofire(var/atom/fire_at, var/mob/fire_by)
 	. = TRUE
 	if(!istype(fire_at) || !istype(fire_by))


### PR DESCRIPTION
## Description of changes
Makes crypods use an atom/movable proc instead of a list.
Split out of #1447 for ease of review.

## Why and what will this PR improve
Allows modpacks to override this behavior.

## Authorship
Myself.

## Changelog
Nothing player-facing.