### PR TITLE
Reworking vital organ checking and effects.

### DIFF
--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -74,7 +74,7 @@
 	if(prob(grow_chance))
 		for(var/limb_type in H.species.has_limbs)
 			var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(H, limb_type)
-			if(E && E.organ_tag != BP_HEAD && !E.vital && !E.is_usable())	//Skips heads and vital bits...
+			if(E && E.organ_tag != BP_HEAD && !(E.organ_tag in H.species.vital_organs) && !E.is_usable())	//Skips heads and vital bits...
 				if (H.nutrition > grow_threshold)
 					H.remove_organ(E) 		//...because no one wants their head to explode to make way for a new one.
 					qdel(E)

--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -74,7 +74,7 @@
 	if(prob(grow_chance))
 		for(var/limb_type in H.species.has_limbs)
 			var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(H, limb_type)
-			if(E && E.organ_tag != BP_HEAD && !(E.organ_tag in H.species.vital_organs) && !E.is_usable())	//Skips heads and vital bits...
+			if(E && E.organ_tag != BP_HEAD && !E.is_vital_to_owner() && !E.is_usable())	//Skips heads and vital bits...
 				if (H.nutrition > grow_threshold)
 					H.remove_organ(E) 		//...because no one wants their head to explode to make way for a new one.
 					qdel(E)

--- a/code/modules/mob/living/carbon/carbon_organs.dm
+++ b/code/modules/mob/living/carbon/carbon_organs.dm
@@ -44,7 +44,7 @@
 	. = ..()
 
 /mob/living/carbon/remove_organ(var/obj/item/organ/O, var/drop_organ = TRUE, var/detach = TRUE, var/ignore_children = FALSE,  var/in_place = FALSE, var/update_icon = TRUE)
-	if(istype(O) && !in_place && (O.organ_tag in species.vital_organs) && usr)
+	if(istype(O) && !in_place && O.is_vital_to_owner() && usr)
 		admin_attack_log(usr, src, "Removed a vital organ ([src]).", "Had a vital organ ([src]) removed.", "removed a vital organ ([src]) from")
 	if(!(. = ..()))
 		return

--- a/code/modules/mob/living/carbon/carbon_organs.dm
+++ b/code/modules/mob/living/carbon/carbon_organs.dm
@@ -44,23 +44,12 @@
 	. = ..()
 
 /mob/living/carbon/remove_organ(var/obj/item/organ/O, var/drop_organ = TRUE, var/detach = TRUE, var/ignore_children = FALSE,  var/in_place = FALSE, var/update_icon = TRUE)
-	if(!in_place && species.is_vital_organ(src, O) && usr)
+	if(istype(O) && !in_place && (O.organ_tag in species.vital_organs) && usr)
 		admin_attack_log(usr, src, "Removed a vital organ ([src]).", "Had a vital organ ([src]) removed.", "removed a vital organ ([src]) from")
-
 	if(!(. = ..()))
 		return
-
 	LAZYREMOVE(organs_by_tag, O.organ_tag)
 	if(O.is_internal())
 		LAZYREMOVE(internal_organs, O)
 	else
 		LAZYREMOVE(external_organs, O)
-
-//Should handle vital organ checks, icon updates, events
-/mob/living/carbon/on_lost_organ(var/obj/item/organ/O)
-	if(!(. = ..()))
-		return
-
-	//Check if we should die
-	if(species.is_vital_organ(src, O))
-		death()

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -74,7 +74,7 @@
 /mob/living/carbon/human/getBruteLoss()
 	var/amount = 0
 	for(var/obj/item/organ/external/O in get_external_organs())
-		if(BP_IS_PROSTHETIC(O) && !(O.organ_tag in species.vital_organs))
+		if(BP_IS_PROSTHETIC(O) && !O.is_vital_to_owner())
 			continue //robot limbs don't count towards shock and crit
 		amount += O.brute_dam
 	return amount
@@ -82,7 +82,7 @@
 /mob/living/carbon/human/getFireLoss()
 	var/amount = 0
 	for(var/obj/item/organ/external/O in get_external_organs())
-		if(BP_IS_PROSTHETIC(O) && !(O.organ_tag in species.vital_organs))
+		if(BP_IS_PROSTHETIC(O) && !O.is_vital_to_owner())
 			continue //robot limbs don't count towards shock and crit
 		amount += O.burn_dam
 	return amount

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -74,7 +74,7 @@
 /mob/living/carbon/human/getBruteLoss()
 	var/amount = 0
 	for(var/obj/item/organ/external/O in get_external_organs())
-		if(BP_IS_PROSTHETIC(O) && !O.vital)
+		if(BP_IS_PROSTHETIC(O) && !(O.organ_tag in species.vital_organs))
 			continue //robot limbs don't count towards shock and crit
 		amount += O.brute_dam
 	return amount
@@ -82,7 +82,7 @@
 /mob/living/carbon/human/getFireLoss()
 	var/amount = 0
 	for(var/obj/item/organ/external/O in get_external_organs())
-		if(BP_IS_PROSTHETIC(O) && !O.vital)
+		if(BP_IS_PROSTHETIC(O) && !(O.organ_tag in species.vital_organs))
 			continue //robot limbs don't count towards shock and crit
 		amount += O.burn_dam
 	return amount

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -94,6 +94,8 @@
 	/// var for caching last getHalloss() run to avoid looping through organs over and over and over again
 	var/last_pain
 
+	var/vital_organ_missing_time
+
 	ai = /datum/ai/human
 
 /mob/living/carbon/human/proc/get_age()

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -26,6 +26,22 @@
 // Takes care of organ related updates, such as broken and missing limbs
 /mob/living/carbon/human/proc/handle_organs()
 
+	// Check for the presence (or lack of) vital organs like the brain.
+	// Set a timer after this point, since we want a little bit of
+	// wiggle room before the body dies for good (brain transplants).
+	if(stat != DEAD)
+		if(species.check_vital_organ_missing(src))
+			SET_STATUS_MAX(src, STAT_PARA, 5)
+			if(vital_organ_missing_time)
+				if(world.time >= vital_organ_missing_time)
+					death()
+			else
+				vital_organ_missing_time = world.time + species.vital_organ_failure_death_delay
+		else
+			vital_organ_missing_time = null
+
+
+
 	//processing internal organs is pretty cheap, do that first.
 	for(var/obj/item/organ/I in internal_organs)
 		I.Process()
@@ -291,7 +307,7 @@
 
 /mob/living/carbon/human/on_lost_organ(var/obj/item/organ/O)
 	if(!(. = ..()))
-		return 
+		return
 	//Move some blood over to the organ
 	if(!BP_IS_PROSTHETIC(O) && O.species && O.reagents?.total_volume < 5)
 		vessel.trans_to(O, 5 - O.reagents.total_volume, 1, 1)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -535,14 +535,6 @@
 		update_eyes()
 		return TRUE
 
-// Check if we should die.
-/mob/living/carbon/human/proc/handle_death_check()
-	if(should_have_organ(BP_BRAIN))
-		var/obj/item/organ/internal/brain = GET_INTERNAL_ORGAN(src, BP_BRAIN)
-		if(!brain || (brain.status & ORGAN_DEAD))
-			return TRUE
-	return species.handle_death_check(src)
-
 /mob/living/carbon/human/handle_regular_status_updates()
 	if(!handle_some_updates())
 		return 0
@@ -555,12 +547,6 @@
 		set_status(STAT_SILENCE, 0)
 	else				//ALIVE. LIGHTS ARE ON
 		updatehealth()	//TODO
-
-		if(handle_death_check())
-			death()
-			blinded = 1
-			set_status(STAT_SILENCE, 0)
-			return 1
 
 		if(hallucination_power)
 			handle_hallucinations()

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -274,7 +274,6 @@
 		adjust_blood(species.blood_volume - vessel.total_volume)
 	for (var/o in get_external_organs())
 		var/obj/item/organ/organ = o
-		organ.vital = 0
 		if (!BP_IS_PROSTHETIC(organ))
 			organ.rejuvenate(1)
 			organ.max_damage *= 3

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1322,7 +1322,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 		if(!keep_organs)
 			for(var/obj/item/organ/thing in internal_organs)
-				if(!thing.vital && !BP_IS_PROSTHETIC(thing))
+				if(!(thing.organ_tag in owner.species.vital_organs) && !BP_IS_PROSTHETIC(thing))
 					qdel(thing)
 
 		owner.refresh_modular_limb_verbs()

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1322,7 +1322,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 		if(!keep_organs)
 			for(var/obj/item/organ/thing in internal_organs)
-				if(!(thing.organ_tag in owner.species.vital_organs) && !BP_IS_PROSTHETIC(thing))
+				if(!thing.is_vital_to_owner() && !BP_IS_PROSTHETIC(thing))
 					qdel(thing)
 
 		owner.refresh_modular_limb_verbs()
@@ -1619,3 +1619,13 @@ Note that amputating the affected organ does in fact remove the infection from t
 			owner.gib()
 	else
 		return ..()
+
+/obj/item/organ/external/is_vital_to_owner()
+	if(isnull(vital_to_owner))
+		. = ..()
+		if(!.)
+			for(var/obj/item/organ/O in children)
+				if(O.is_vital_to_owner())
+					vital_to_owner = TRUE
+					break
+	return vital_to_owner

--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -13,7 +13,6 @@
 	w_class = ITEM_SIZE_HUGE //Used for dismembering thresholds, in addition to storage. Humans are w_class 6, so it makes sense that chest is w_class 5.
 	cavity_max_w_class = ITEM_SIZE_NORMAL
 	body_part = SLOT_UPPER_BODY
-	vital = 1
 	amputation_point = "spine"
 	joint = "neck"
 	parent_organ = null
@@ -31,8 +30,8 @@
 	if( L && L.is_bruised())
 		. += "Lung ruptured"
 
-/obj/item/organ/external/chest/die() 
-	//Special handling for synthetics 
+/obj/item/organ/external/chest/die()
+	//Special handling for synthetics
 	if(BP_IS_PROSTHETIC(src) || BP_IS_CRYSTAL(src))
 		return
 	. = ..()
@@ -53,8 +52,8 @@
 	cavity_name = "abdominal"
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_BREAK
 
-/obj/item/organ/external/groin/die() 
-	//Special handling for synthetics 
+/obj/item/organ/external/groin/die()
+	//Special handling for synthetics
 	if(BP_IS_PROSTHETIC(src) || BP_IS_CRYSTAL(src))
 		return
 	. = ..()

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -246,3 +246,17 @@
 
 /obj/item/organ/internal/proc/past_damage_threshold(var/threshold)
 	return (get_current_damage_threshold() > threshold)
+
+/obj/item/organ/internal/on_add_effects()
+	. = ..()
+	if(parent_organ && owner)
+		var/obj/item/organ/O = owner.get_organ(parent_organ)
+		if(O)
+			O.vital_to_owner = null
+
+/obj/item/organ/internal/on_remove_effects(mob/living/last_owner)
+	. = ..()
+	if(parent_organ && last_owner)
+		var/obj/item/organ/O = last_owner.get_organ(parent_organ)
+		if(O)
+			O.vital_to_owner = null

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -3,7 +3,6 @@
 	desc = "A piece of juicy meat found in a person's head."
 	organ_tag = BP_BRAIN
 	parent_organ = BP_HEAD
-	vital = 1
 	icon_state = "brain2"
 	force = 1.0
 	w_class = ITEM_SIZE_SMALL

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -35,7 +35,7 @@
 	..()
 
 /obj/item/organ/internal/heart/proc/handle_pulse()
-	if(BP_IS_PROSTHETIC(src))
+	if(BP_IS_PROSTHETIC(src) || !owner || owner.vital_organ_missing_time)
 		pulse = PULSE_NONE	//that's it, you're dead (or your metal heart is), nothing can influence your pulse
 		return
 
@@ -186,10 +186,7 @@
 			owner.drip(blood_max)
 
 /obj/item/organ/internal/heart/proc/is_working()
-	if(!is_usable())
-		return FALSE
-
-	return pulse > PULSE_NONE || BP_IS_PROSTHETIC(src) || (owner.status_flags & FAKEDEATH)
+	return is_usable() && (pulse > PULSE_NONE || BP_IS_PROSTHETIC(src) || (owner.status_flags & FAKEDEATH)
 
 /obj/item/organ/internal/heart/listen()
 	if(BP_IS_PROSTHETIC(src) && is_working())

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -186,7 +186,7 @@
 			owner.drip(blood_max)
 
 /obj/item/organ/internal/heart/proc/is_working()
-	return is_usable() && (pulse > PULSE_NONE || BP_IS_PROSTHETIC(src) || (owner.status_flags & FAKEDEATH)
+	return is_usable() && (pulse > PULSE_NONE || BP_IS_PROSTHETIC(src) || (owner.status_flags & FAKEDEATH))
 
 /obj/item/organ/internal/heart/listen()
 	if(BP_IS_PROSTHETIC(src) && is_working())

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -92,6 +92,10 @@
 	if(!owner)
 		return
 
+	if(owner.vital_organ_missing_time)
+		owner.losebreath = max(10, owner.losebreath)
+		return
+
 	if (germ_level > INFECTION_LEVEL_ONE && active_breathing)
 		if(prob(5))
 			owner.cough()		//respitory tract infection

--- a/code/modules/organs/internal/posibrain.dm
+++ b/code/modules/organs/internal/posibrain.dm
@@ -5,7 +5,6 @@
 	icon_state = "posibrain"
 	organ_tag = BP_POSIBRAIN
 	parent_organ = BP_CHEST
-	vital = 0
 	force = 1.0
 	w_class = ITEM_SIZE_NORMAL
 	throwforce = 1
@@ -214,7 +213,6 @@
 	dead_icon = "cell_bork"
 	organ_tag = BP_CELL
 	parent_organ = BP_CHEST
-	vital = 1
 	organ_properties = ORGAN_PROP_PROSTHETIC //triggers robotization on init
 	var/open
 	var/obj/item/cell/cell = /obj/item/cell/hyper
@@ -312,7 +310,6 @@
 	icon_state = "mmi-empty"
 	organ_tag = BP_BRAIN
 	parent_organ = BP_HEAD
-	vital = TRUE
 	organ_properties = ORGAN_PROP_PROSTHETIC //triggers robotization on init
 	scale_max_damage_to_species_health = FALSE
 	var/obj/item/mmi/stored_mmi

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -16,6 +16,7 @@
 	// Status tracking.
 	var/status = 0                         // Various status flags (such as robotic)
 	var/organ_properties = 0               // A flag for telling what capabilities this organ has. ORGAN_PROP_PROSTHETIC, ORGAN_PROP_CRYSTAL, etc..
+	var/vital_to_owner                     // Cache var for vitality to current owner.
 
 	// Reference data.
 	var/mob/living/carbon/human/owner      // Current mob owning the organ.
@@ -127,6 +128,7 @@
 	set_species(dna.species)
 
 /obj/item/organ/proc/set_species(var/specie_name)
+	vital_to_owner = null // This generally indicates the owner mob is having species set, and this value may be invalidated.
 	if(istext(specie_name))
 		species = get_species_by_key(specie_name)
 	else
@@ -168,6 +170,7 @@
 
 	if(loc != owner) //#FIXME: looks like someone was trying to hide a bug :P That probably could break organs placed inside a wrapper though
 		owner = null
+		vital_to_owner = null
 
 	//dead already, no need for more processing
 	if(status & ORGAN_DEAD)
@@ -334,6 +337,7 @@
 		damage = clamp(0, damage - round(amount, 0.1), max_damage)
 
 /obj/item/organ/proc/robotize(var/company = /decl/prosthetics_manufacturer/basic_human, var/skip_prosthetics = 0, var/keep_organs = 0, var/apply_material = /decl/material/solid/metal/steel, var/check_bodytype, var/check_species)
+	vital_to_owner = null
 	BP_SET_PROSTHETIC(src)
 	QDEL_NULL(dna)
 	reagents?.clear_reagents()
@@ -506,6 +510,7 @@ var/global/list/ailment_reference_cache = list()
 	set_detached(detached)
 
 	owner = target
+	vital_to_owner = null
 	action_button_name = initial(action_button_name)
 	if(owner)
 		forceMove(owner)
@@ -537,15 +542,18 @@ var/global/list/ailment_reference_cache = list()
 		set_detached(TRUE)
 	else
 		owner = null
+		vital_to_owner = null
 	return src
 
 //Events handling for checks and effects that should happen when removing the organ through interactions. Called by the owner mob.
 /obj/item/organ/proc/on_remove_effects(var/mob/living/last_owner)
 	START_PROCESSING(SSobj, src)
+	vital_to_owner = null
 
 //Events handling for checks and effects that should happen when installing the organ through interactions. Called by the owner mob.
 /obj/item/organ/proc/on_add_effects()
 	STOP_PROCESSING(SSobj, src)
+	vital_to_owner = null
 
 //Since some types of organs completely ignore being detached, moved it to an overridable organ proc for external prosthetics
 /obj/item/organ/proc/set_detached(var/is_detached)
@@ -561,3 +569,11 @@ var/global/list/ailment_reference_cache = list()
 // If an organ is inside a holder, the holder should be handling damage in their explosion_act() proc.
 /obj/item/organ/explosion_act(severity)
 	return !owner && ..()
+
+/obj/item/organ/proc/is_vital_to_owner()
+	if(isnull(vital_to_owner))
+		if(!owner?.species)
+			vital_to_owner = null
+			return FALSE
+		vital_to_owner = (organ_tag in owner.species.vital_organs)
+	return vital_to_owner

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -16,7 +16,6 @@
 	// Status tracking.
 	var/status = 0                         // Various status flags (such as robotic)
 	var/organ_properties = 0               // A flag for telling what capabilities this organ has. ORGAN_PROP_PROSTHETIC, ORGAN_PROP_CRYSTAL, etc..
-	var/vital                              // Lose a vital limb, die immediately.
 
 	// Reference data.
 	var/mob/living/carbon/human/owner      // Current mob owning the organ.
@@ -163,8 +162,6 @@
 	STOP_PROCESSING(SSobj, src)
 	QDEL_NULL_LIST(ailments)
 	death_time = REALTIMEOFDAY
-	if(owner?.species?.is_vital_organ(owner, src))
-		owner.death()
 	update_icon()
 
 /obj/item/organ/Process()

--- a/code/modules/organs/prosthetics/_prosthetics.dm
+++ b/code/modules/organs/prosthetics/_prosthetics.dm
@@ -18,7 +18,7 @@
 // Checks if a limb could theoretically be removed.
 // Note that this does not currently bother checking if a child or internal organ is vital.
 /obj/item/organ/external/proc/can_remove_modular_limb(var/mob/living/carbon/human/user)
-	if(vital || !(limb_flags & ORGAN_FLAG_CAN_AMPUTATE))
+	if((owner?.species && (organ_tag in owner.species.vital_organs)) || !(limb_flags & ORGAN_FLAG_CAN_AMPUTATE))
 		return FALSE
 	var/bodypart_cat = get_modular_limb_category()
 	if(bodypart_cat == MODULAR_BODYPART_CYBERNETIC)
@@ -55,7 +55,7 @@
 	. =  damage >= min_broken_damage || (status & ORGAN_BROKEN) // can't use is_broken() as the limb has ORGAN_CUT_AWAY
 
 // Human mob procs:
-// Checks the organ list for limbs meeting a predicate. Way overengineered for such a limited use 
+// Checks the organ list for limbs meeting a predicate. Way overengineered for such a limited use
 // case but I can see it being expanded in the future if meat limbs or doona limbs use it.
 /mob/living/carbon/human/proc/get_modular_limbs(var/return_first_found = FALSE, var/validate_proc)
 	for(var/bp in get_external_organs())
@@ -63,7 +63,7 @@
 		if(!validate_proc || call(E, validate_proc)(src) > MODULAR_BODYPART_INVALID)
 			LAZYADD(., E)
 			if(return_first_found)
-				return 
+				return
 	// Prune children so we can't remove every individual component of an entire prosthetic arm
 	// piece by piece. Technically a circular dependency here would remove the limb entirely but
 	// if there's a parent whose child is also its parent, there's something wrong regardless.

--- a/code/modules/organs/prosthetics/_prosthetics.dm
+++ b/code/modules/organs/prosthetics/_prosthetics.dm
@@ -18,7 +18,7 @@
 // Checks if a limb could theoretically be removed.
 // Note that this does not currently bother checking if a child or internal organ is vital.
 /obj/item/organ/external/proc/can_remove_modular_limb(var/mob/living/carbon/human/user)
-	if((owner?.species && (organ_tag in owner.species.vital_organs)) || !(limb_flags & ORGAN_FLAG_CAN_AMPUTATE))
+	if((owner?.species && is_vital_to_owner()) || !(limb_flags & ORGAN_FLAG_CAN_AMPUTATE))
 		return FALSE
 	var/bodypart_cat = get_modular_limb_category()
 	if(bodypart_cat == MODULAR_BODYPART_CYBERNETIC)

--- a/code/modules/species/outsider/starlight.dm
+++ b/code/modules/species/outsider/starlight.dm
@@ -27,11 +27,6 @@
 		TAG_CULTURE = /decl/cultural_info/culture/other
 	)
 
-/decl/species/starlight/handle_death_check(var/mob/living/carbon/human/H)
-	if(H.health == 0)
-		return TRUE
-	return FALSE
-
 /decl/species/starlight/handle_death(var/mob/living/carbon/human/H)
 	addtimer(CALLBACK(H,/mob/proc/dust),0)
 

--- a/mods/mobs/borers/mob/organ.dm
+++ b/mods/mobs/borers/mob/organ.dm
@@ -6,7 +6,6 @@
 	organ_tag = BP_BRAIN
 	desc = "A disgusting space slug."
 	parent_organ = BP_HEAD
-	vital = 1
 	var/list/chemical_types
 
 /obj/item/organ/internal/borer/Process()

--- a/mods/species/ascent/effects/razorweb.dm
+++ b/mods/species/ascent/effects/razorweb.dm
@@ -143,12 +143,7 @@
 		for(var/obj/item/organ/external/limb in shuffle(limbs))
 			if(!istype(limb) || !(limb.limb_flags & ORGAN_FLAG_CAN_AMPUTATE))
 				continue
-			var/is_vital = FALSE
-			for(var/obj/item/organ/internal/I in limb.internal_organs)
-				if(I.organ_tag in H.species.vital_organs)
-					is_vital = TRUE
-					break
-			if(!is_vital)
+			if(!limb.is_vital_to_owner())
 				E = limb
 				break
 		if(E && !armour_prob)

--- a/mods/species/ascent/effects/razorweb.dm
+++ b/mods/species/ascent/effects/razorweb.dm
@@ -135,7 +135,7 @@
 
 	var/severed = FALSE
 	var/armour_prob = prob(100 * L.get_blocked_ratio(null, BRUTE, damage = ARMOR_MELEE_RESISTANT))
-	if(H && prob(35))
+	if(H?.species && prob(35))
 		var/obj/item/organ/external/E
 		var/list/limbs = H.get_external_organs()
 		if(limbs)
@@ -145,7 +145,7 @@
 				continue
 			var/is_vital = FALSE
 			for(var/obj/item/organ/internal/I in limb.internal_organs)
-				if(H.species?.is_vital_organ(H, I))
+				if(I.organ_tag in H.species.vital_organs)
 					is_vital = TRUE
 					break
 			if(!is_vital)

--- a/mods/species/bayliens/adherent/datum/species.dm
+++ b/mods/species/bayliens/adherent/datum/species.dm
@@ -25,7 +25,10 @@
 	skin_material = null
 
 	blood_types = list(/decl/blood_type/coolant)
-
+	vital_organs = list(
+		BP_BRAIN,
+		BP_CELL
+	)
 	available_pronouns = list(/decl/pronouns)
 	available_bodytypes = list(
 		/decl/bodytype/adherent,

--- a/mods/species/serpentid/mobs/bodyparts_serpentid.dm
+++ b/mods/species/serpentid/mobs/bodyparts_serpentid.dm
@@ -163,7 +163,6 @@
 
 /obj/item/organ/external/head/insectoid/serpentid
 	name = "head"
-	vital = 0
 
 /obj/item/organ/external/head/insectoid/serpentid/get_eye_overlay()
 	var/obj/item/organ/internal/eyes/eyes = owner.get_organ((owner.species.vision_organ || BP_EYES), /obj/item/organ/internal/eyes)

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -17,6 +17,10 @@
 	base_prosthetics_model = null
 
 	blood_types = list(/decl/blood_type/coolant)
+	vital_organs = list(
+		BP_BRAIN,
+		BP_CELL
+	)
 
 	available_bodytypes = list(/decl/bodytype/utility_frame)
 	age_descriptor =        /datum/appearance_descriptor/age/utility_frame

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -18,7 +18,7 @@
 
 	blood_types = list(/decl/blood_type/coolant)
 	vital_organs = list(
-		BP_BRAIN,
+		BP_POSIBRAIN,
 		BP_CELL
 	)
 

--- a/mods/species/vox/datum/species.dm
+++ b/mods/species/vox/datum/species.dm
@@ -24,6 +24,11 @@
 	name_plural = SPECIES_VOX
 	base_prosthetics_model = /decl/prosthetics_manufacturer/vox/crap
 
+	vital_organs = list(
+		BP_STACK,
+		BP_BRAIN
+	)
+
 	default_emotes = list(
 		/decl/emote/audible/vox_shriek
 	)
@@ -50,19 +55,19 @@
 
 	rarity_value = 4
 
-	description = {"The Vox are the broken remnants of a once-proud race, now reduced to little more 
-	than scavenging vermin who prey on isolated stations, ships or planets to keep their own ancient 
-	arkships alive. They are four to five feet tall, reptillian, beaked, tailed and quilled; human 
-	crews often refer to them as 'shitbirds' for their violent and offensive nature, as well as their 
+	description = {"The Vox are the broken remnants of a once-proud race, now reduced to little more
+	than scavenging vermin who prey on isolated stations, ships or planets to keep their own ancient
+	arkships alive. They are four to five feet tall, reptillian, beaked, tailed and quilled; human
+	crews often refer to them as 'shitbirds' for their violent and offensive nature, as well as their
 	horrible smell.
 	<br/><br/>
-	Most humans will never meet a Vox raider, instead learning of this insular species through dealing 
+	Most humans will never meet a Vox raider, instead learning of this insular species through dealing
 	with their traders and merchants; those that do rarely enjoy the experience."}
 
-	codex_description = {"The Vox are a hostile, deeply untrustworthy species from the edges of human 
-	space. They prey on isolated stations, ships or settlements without any apparent logic or reason, 
-	and tend to refuse communications or negotiations except when their backs are to the wall or they 
-	are in dire need of resources. They are four to five feet tall, reptillian, beaked, tailed and 
+	codex_description = {"The Vox are a hostile, deeply untrustworthy species from the edges of human
+	space. They prey on isolated stations, ships or settlements without any apparent logic or reason,
+	and tend to refuse communications or negotiations except when their backs are to the wall or they
+	are in dire need of resources. They are four to five feet tall, reptillian, beaked, tailed and
 	quilled."}
 
 	hidden_from_codex = FALSE

--- a/mods/species/vox/organs_vox.dm
+++ b/mods/species/vox/organs_vox.dm
@@ -154,7 +154,6 @@
 	icon_state = "cortical-stack"
 	organ_tag = BP_STACK
 	organ_properties = ORGAN_PROP_PROSTHETIC
-	vital = 1
 	origin_tech = @"{'biotech':4,'materials':4,'magnets':2,'programming':3}"
 	relative_size = 10
 


### PR DESCRIPTION
## Description of changes
Split off from #1447.
- Vital organ tags are set per species but checked per organ.
- Missing a vital organ paralyzes you and after a grace period, straight up kills you.

## Why and what will this PR improve
Vital organ code is a bit cleaner and more centralized, and is easier to override and manipulate per species. Also allows for brain transplants and decapitation fixes if the surgeon is quick.

## Authorship
Myself.

## Changelog
:cl:
tweak: There is now a grace period on losing your brain before your mob will die.
/:cl: