### PR TITLE
Updates heart pulse on death.

### DIFF
--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -54,6 +54,9 @@
 	if(!gibbed && deathmessage != "no message") // This is gross, but reliable. Only brains use it.
 		src.visible_message("<b>\The [src.name]</b> [deathmessage]")
 
+	for(var/obj/item/organ/O in get_organs())
+		O.on_holder_death(gibbed)
+
 	set_stat(DEAD)
 	adjust_stamina(-100)
 	reset_plane_and_layer()

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -15,6 +15,10 @@
 	var/open
 	var/list/external_pump
 
+/obj/item/organ/internal/heart/on_holder_death(var/gibbed)
+	pulse = PULSE_NONE
+	update_icon()
+
 /obj/item/organ/internal/heart/open
 	open = 1
 
@@ -38,13 +42,13 @@
 	// pulse mod starts out as just the chemical effect amount
 	var/pulse_mod = GET_CHEMICAL_EFFECT(owner, CE_PULSE)
 	var/is_stable = GET_CHEMICAL_EFFECT(owner, CE_STABLE)
-		
+
 	// If you have enough heart chemicals to be over 2, you're likely to take extra damage.
 	if(pulse_mod > 2 && !is_stable)
 		var/damage_chance = (pulse_mod - 2) ** 2
 		if(prob(damage_chance))
 			take_internal_damage(0.5)
-	
+
 	// Now pulse mod is impacted by shock stage and other things too
 	if(owner.shock_stage > 30)
 		pulse_mod++
@@ -220,5 +224,5 @@
 	. = ..()
 	if(!BP_IS_PROSTHETIC(src))
 		pulse = PULSE_NORM
-	else 
+	else
 		pulse = PULSE_NONE

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -44,6 +44,9 @@
 	QDEL_NULL_LIST(ailments)
 	return ..()
 
+/obj/item/organ/proc/on_holder_death(var/gibbed)
+	return
+
 /obj/item/organ/proc/refresh_action_button()
 	return action
 


### PR DESCRIPTION
## Description of changes
Adds a holder death proc to organs, causes hearts to unset pulse when it is called.

## Why and what will this PR improve
Prevents mobs showing up as having a pulse after death.

## Authorship
Myself.

## Changelog
Bugfix, nothing player-facing.