### PR TITLE
Fix mobs not exhaling without internals on

### DIFF
--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -98,7 +98,7 @@
 		//by default, exhale
 		var/datum/gas_mixture/internals_air = internal?.return_air()
 		var/datum/gas_mixture/loc_air = loc?.return_air()
-		if(internals_air?.return_pressure() < loc_air.return_pressure()) // based on the assumption it has a one-way valve for gas release
+		if(internals_air && (internals_air.return_pressure() < loc_air.return_pressure())) // based on the assumption it has a one-way valve for gas release
 			internals_air?.merge(breath)
 		else
 			loc_air?.merge(breath)


### PR DESCRIPTION
## Description of changes
My bad, I abused the null operator there and didn't realise the logic would allow `null < 101.325`. Explicitly checking them separately fixes it.

## Why and what will this PR improve
Fixes mobs not exhaling if internals are off, which would make you suffocate much faster than normal due to unused oxygen being removed from the air as well, creating a vacuum. Wild!

## Authorship
Me.