### PR TITLE
Fix reattaching external organs with internal organs

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -452,6 +452,13 @@
 				// we can't use implanted() here since it's often interactive
 				imp_device.imp_in = owner
 				imp_device.implanted = TRUE
+
+			//Since limbs attached during surgery have their internal organs detached, we want to re-attach them if we're doing the proper install of the parent limb
+			else if(istype(implant, /obj/item/organ) && !detached)
+				var/obj/item/organ/O = implant
+				if(O.parent_organ == organ_tag)
+					//The add_organ chain will automatically handle properly removing the detached flag, and moving it to the proper lists
+					owner.add_organ(O, src, in_place, update_icon, detached)
 	else
 		//Handle installing into a stand-alone parent limb to keep dropped limbs in some kind of coherent state
 		if(!affected)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Attaching a head via surgery would turn all internal organs in the head into detached organ. And completing the surgery wouldn't attach them. So added a case where when properly attaching the organs during surgery would actually grab the detached organs in the implant list of the head and attach them properly.

## Changelog
:cl:
bugfix: Fix limb reattachment surgery not properly installing any contained internal organs once the last step was completed. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->