### PR TITLE
Reverts mob offset changes.

### DIFF
--- a/code/modules/species/species_bodytype_offsets.dm
+++ b/code/modules/species/species_bodytype_offsets.dm
@@ -19,27 +19,29 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 
 /decl/bodytype
 	var/list/equip_adjust = list()
-	var/list/equip_icons =  list()
+	var/list/equip_overlays = list()
 
 /decl/bodytype/proc/get_offset_overlay_image(var/spritesheet, var/mob_icon, var/mob_state, var/color, var/slot)
 	// If we don't actually need to offset this, don't bother with any of the generation/caching.
 	if(!spritesheet && length(equip_adjust) && equip_adjust[slot] && length(equip_adjust[slot]))
-		// Grab our collected offsets for this base icon.
-		var/icon/offset_icon = equip_icons[mob_icon]
-		// If we haven't gone one yet, generate a blank one.
-		if(!offset_icon)
-			offset_icon = new(icon_template)
-			equip_icons[mob_icon] = offset_icon
-		// If we haven't got this state yet, generate and insert it.
-		if(!check_state_in_icon(mob_state, offset_icon) && check_state_in_icon(mob_state, mob_icon))
+
+		// Check the cache for previously made icons.
+		var/image_key = "[mob_icon]-[mob_state]-[color]-[slot]"
+		if(!equip_overlays[image_key])
+
+			var/icon/final_I = new(icon_template)
 			var/list/shifts = equip_adjust[slot]
+
+			// Apply all pixel shifts for each direction.
 			for(var/shift_facing in shifts)
 				var/list/facing_list = shifts[shift_facing]
 				var/use_dir = text2num(shift_facing)
 				var/icon/equip = new(mob_icon, icon_state = mob_state, dir = use_dir)
 				var/icon/canvas = new(icon_template)
 				canvas.Blend(equip, ICON_OVERLAY, facing_list["x"]+1, facing_list["y"]+1)
-				offset_icon.Insert(canvas, mob_state, dir = use_dir)
-		// Replace our mob icon with the offset icon.
-		mob_icon = offset_icon
+				final_I.Insert(canvas, dir = use_dir)
+			equip_overlays[image_key] = overlay_image(final_I, color = color, flags = RESET_COLOR)
+		var/image/I = new() // We return a copy of the cached image, in case downstream procs mutate it.
+		I.appearance = equip_overlays[image_key]
+		return I
 	return overlay_image(mob_icon, mob_state, color, RESET_COLOR)


### PR DESCRIPTION
Apparently BYOND will corrupt icons if they are the target of repeated icon procs. This is fixable with icon cloning but I'm reverting the changes on stable and will push the reworked proc to dev for proper testing.