### PR TITLE
fix nullspace splash crash on /obj/item/chems

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -246,7 +246,9 @@
 		to_chat(user, SPAN_NOTICE("Using your chemistry knowledge, you identify the following reagents in \the [src]: [reagents.get_reagents(!user.skill_check(SKILL_CHEMISTRY, SKILL_PROF), 5)]."))
 
 /obj/item/chems/shatter(consumed)
-	reagents.splash(get_turf(src), reagents.total_volume)
+	//Skip splashing if we are in nullspace, since splash isn't null guarded
+	if(loc)
+		reagents.splash(get_turf(src), reagents.total_volume)
 	. = ..()
 
 /obj/item/chems/initialize_reagents(populate = TRUE)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
The shatter proc called on destruction of the /obj/item/chems would call splash on a null loc, and splash isn't null-guarded. Since I'm not sure if that's intentional or not, I just check in shatter if we're in nullspace before splashing.

## Changelog
:cl:
bugfix: Fixed /obj/item/chems being shattered in nullspace causing a runtime.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->