### PR TITLE
Fix bad switch case in robot components

### DIFF
--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -220,7 +220,7 @@
 
 /obj/item/robot_parts/robot_component/take_damage(amount, damtype, silent)
 	switch(damtype)
-		if(BURN || ELECTROCUTE)
+		if(BURN, ELECTROCUTE)
 			burn += amount
 		if(BRUTE)
 			brute += amount


### PR DESCRIPTION


<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Fix bad switch case in code\modules\mob\living\silicon\robot\component.dm

## Changelog
:cl:
bugfix: Fixed bad switch case in robot_component/take_damage() causing BURN and ELECTROCUTE damage to get ignored.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->