### PR TITLE
Fix mapped values on network machines + mapped net tag

### DIFF
--- a/code/modules/modular_computers/networking/machinery/_network_machine.dm
+++ b/code/modules/modular_computers/networking/machinery/_network_machine.dm
@@ -17,8 +17,18 @@
 	var/heat_threshold = 90 CELSIUS	// At what temperature the machine will lock up.
 	var/overheated = FALSE
 
+	var/tmp/tag_network_tag //The name of this device on the network set by mapper
+
+/obj/machinery/network/modify_mapped_vars(map_hash)
+	..()
+	ADJUST_TAG_VAR(initial_network_id, map_hash)
+	ADJUST_TAG_VAR(initial_network_key, map_hash)
+	ADJUST_TAG_VAR(tag_network_tag, map_hash)
+
 /obj/machinery/network/Initialize()
-	set_extension(src, network_device_type, initial_network_id, initial_network_key, RECEIVER_STRONG_WIRELESS)
+	var/datum/extension/network_device/ND = get_or_create_extension(src, network_device_type, initial_network_id, initial_network_key, RECEIVER_STRONG_WIRELESS)
+	if(length(tag_network_tag))
+		ND.set_network_tag(tag_network_tag)
 	. = ..()
 
 /obj/machinery/network/populate_parts(full_populate)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Some vars set on the map wouldn't get set properly. Using ADJUST_TAG_VAR seems to have fixed that. 
Also added a mapped network id to network machinery, so network can be configured to a preset network.

## Changelog
:cl:
add: Allow setting a network id via mapping tool on network machinery.
bugfix: Fix mapped network machinery fields.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->