### PR TITLE
Allow fuel pipes to be connected on the TEG circulators

### DIFF
--- a/code/modules/atmospherics/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/components/binary_devices/circulator.dm
@@ -7,6 +7,7 @@
 	icon = 'icons/obj/power.dmi'
 	icon_state = "circ-unassembled"
 	anchored = 0
+	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_FUEL
 	obj_flags = OBJ_FLAG_ANCHORABLE | OBJ_FLAG_ROTATABLE
 	layer = STRUCTURE_LAYER
 


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Allow fuel pipes to be connected on the TEG circulators. Not sure why that was forbidden before since, if there's one place that probably should allow it, its where you're likely to get really high pressures.

## Changelog
:cl:
tweak: Allowed connecting fuel pipes to TEG circulators.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->