### PR TITLE
Add better message when putting wrong thing in omni device tags

### DIFF
--- a/code/modules/atmospherics/components/omni_devices/omni_base.dm
+++ b/code/modules/atmospherics/components/omni_devices/omni_base.dm
@@ -50,28 +50,36 @@
 		switch(d)
 			if(NORTH)
 				new_port.mode = tag_north
-				if(new_port.mode == ATM_FILTER)
+				if(new_port.mode == ATM_FILTER && tag_filter_gas_north)
+					if(!istext(tag_filter_gas_north))
+						CRASH("The tag_filter_gas_north var of [src] ([x],[y],[z]) was not set to a material uid string! Got : '[tag_filter_gas_north]'.")
 					new_port.filtering = decls_repository.get_decl_by_id(tag_filter_gas_north)
 				if(tag_north >= 3 && tag_north < 8)
 					new_port.filtering = handle_legacy_gas_filtering(tag_north)
 					new_port.mode = ATM_FILTER
 			if(SOUTH)
 				new_port.mode = tag_south
-				if(new_port.mode == ATM_FILTER)
+				if(new_port.mode == ATM_FILTER && tag_filter_gas_south)
+					if(!istext(tag_filter_gas_south))
+						CRASH("The tag_filter_gas_south var of [src] ([x],[y],[z]) was not set to a material uid string! Got : '[tag_filter_gas_south]'.")
 					new_port.filtering = decls_repository.get_decl_by_id(tag_filter_gas_south)
 				if(tag_south >= 3 && tag_south < 8)
 					new_port.filtering = handle_legacy_gas_filtering(tag_south)
 					new_port.mode = ATM_FILTER
 			if(EAST)
 				new_port.mode = tag_east
-				if(new_port.mode == ATM_FILTER)
+				if(new_port.mode == ATM_FILTER && tag_filter_gas_east)
+					if(!istext(tag_filter_gas_east))
+						CRASH("The tag_filter_gas_east var of [src] ([x],[y],[z]) was not set to a material uid string! Got : '[tag_filter_gas_east]'.")
 					new_port.filtering = decls_repository.get_decl_by_id(tag_filter_gas_east)
 				if(tag_east >= 3 && tag_east < 8)
 					new_port.filtering = handle_legacy_gas_filtering(tag_east)
 					new_port.mode = ATM_FILTER
 			if(WEST)
 				new_port.mode = tag_west
-				if(new_port.mode == ATM_FILTER)
+				if(new_port.mode == ATM_FILTER && tag_filter_gas_west)
+					if(!istext(tag_filter_gas_west))
+						CRASH("The tag_filter_gas_west var of [src] ([x],[y],[z]) was not set to a material uid string! Got : '[tag_filter_gas_west]'.")
 					new_port.filtering = decls_repository.get_decl_by_id(tag_filter_gas_west)
 				if(tag_west >= 3 && tag_west < 8)
 					new_port.filtering = handle_legacy_gas_filtering(tag_west)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Add better message when putting wrong thing in omni device tags.
It specifically wants material uids, not material paths. This should prevent some future headaches hopefully.

## Changelog
:cl:
code: Now crash with a clear warning when putting a path in the omni devices filtered gases uid field.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->