### PR TITLE
'Fixes' waddling.

### DIFF
--- a/code/datums/observation/moved.dm
+++ b/code/datums/observation/moved.dm
@@ -11,7 +11,7 @@
 /decl/observ/moved
 	name = "Moved"
 	expected_type = /atom/movable
-	flags = OBSERVATION_NO_GLOBAL_REGISTRATIONS
+	//flags = OBSERVATION_NO_GLOBAL_REGISTRATIONS // Uncomment this line when waddling does not rely on global moved
 
 /decl/observ/moved/register(var/atom/movable/mover, var/datum/listener, var/proc_call)
 	. = ..()


### PR DESCRIPTION
## Description of changes
Comments out the line that sets the moved event to unavailable for global registration. This should not be a long-term fix, waddling needs to be rewritten to use some other method.

## Why and what will this PR improve
Fixes waddling.

## Authorship
Myself.

## Changelog
Nothing player-facing.