### PR TITLE
Mark /decl/observ/var/flags as VAR_PROTECTED

### DIFF
--- a/code/datums/observation/observation.dm
+++ b/code/datums/observation/observation.dm
@@ -61,7 +61,7 @@
 	var/expected_type = /datum          // The expected event source for this event. register() will CRASH() if it receives an unexpected type.
 	var/list/event_sources = list()     // Associative list of event sources, each with their own associative list. This associative list contains an instance/list of procs to call when the event is raised.
 	var/list/global_listeners = list()  // Associative list of instances that listen to all events of this type (as opposed to events belonging to a specific source) and the proc to call.
-	var/flags                           // See _defines.dm for available flags and what they do
+	VAR_PROTECTED/flags                 // See _defines.dm for available flags and what they do
 
 /decl/observ/Initialize()
 	. = ..()


### PR DESCRIPTION
## Description of changes
Marks `/decl/observ/var/flags` as `VAR_PROTECTED` in lieu of a `VAR_READONLY` setting (which would honestly be really useful, and isn't apparently what `VAR_FINAL` does ☹️) to prevent things modifying flags to circumvent them.

## Why and what will this PR improve
Prevents flag modification by non-events; ideally not even events could change their flags after they're set.

## Authorship
Me.