### PR TITLE
Reimplement waddling as an extension

### DIFF
--- a/code/modules/admin/secrets/fun_secrets/waddle.dm
+++ b/code/modules/admin/secrets/fun_secrets/waddle.dm
@@ -5,12 +5,43 @@
 /datum/admin_secret_item/fun_secret/waddle/do_execute(var/mob/user)
 	waddling = !waddling
 	if(waddling)
-		events_repository.register_global(/decl/observ/moved, src, .proc/waddle)
+		for(var/mob/living/living_mob in global.living_mob_list_)
+			set_extension(living_mob, /datum/extension/waddle)
+		events_repository.register_global(/decl/observ/life, src, .proc/enroll_in_waddling)
+		events_repository.register_global(/decl/observ/death, src, .proc/cure_waddling)
 	else
-		events_repository.unregister_global(/decl/observ/moved, src, .proc/waddle)
+		for(var/mob/living/living_mob in global.living_mob_list_)
+			cure_waddling(living_mob)
+		events_repository.unregister_global(/decl/observ/life, src)
+		events_repository.unregister_global(/decl/observ/death, src)
 
-/datum/admin_secret_item/fun_secret/waddle/proc/waddle(atom/movable/AM)
-	var/mob/living/L = AM
+/datum/admin_secret_item/fun_secret/waddle/proc/enroll_in_waddling(mob/living/waddler)
+	if(!istype(waddler))
+		return
+	set_extension(waddler, /datum/extension/waddle)
+
+/datum/admin_secret_item/fun_secret/waddle/proc/cure_waddling(mob/living/patient)
+	if(!istype(patient))
+		return
+	remove_extension(patient, /datum/extension/waddle)
+
+/datum/extension/waddle
+	base_type = /datum/extension/waddle
+	expected_type = /mob
+	flags = EXTENSION_FLAG_IMMEDIATE
+
+/datum/extension/waddle/New(datum/holder)
+	. = ..()
+	events_repository.register(/decl/observ/moved, holder, src, .proc/waddle)
+	events_repository.register(/decl/observ/destroyed, holder, src, .proc/qdel_self)
+
+/datum/extension/event_registration/Destroy()
+	events_repository.unregister(/decl/observ/destroyed, holder, src)
+	events_repository.unregister(/decl/observ/moved, holder, src)
+	return ..()
+
+/datum/extension/waddle/proc/waddle()
+	var/mob/living/L = holder
 	if(!istype(L) || L.incapacitated() || L.lying)
 		return
 	animate(L, pixel_z = 4, time = 0)


### PR DESCRIPTION
## Description of changes
Reimplements waddling as an extension, so that it could be reused outside of the admin secret if needed and also so that it doesn't require setting/unsetting observation flags.

## Why and what will this PR improve
Alternative to #2836 that doesn't touch observation flag vars at all, and doesn't use a global moved registration.

## Authorship
Me.