### PR TITLE
Fix /decl/machine_construction/wall_frame not checking wires

### DIFF
--- a/code/game/machinery/_machines_base/machine_construction/wall_frame.dm
+++ b/code/game/machinery/_machines_base/machine_construction/wall_frame.dm
@@ -113,7 +113,7 @@
 /decl/machine_construction/wall_frame/no_wires
 
 /decl/machine_construction/wall_frame/no_wires/state_is_valid(obj/machinery/machine)
-	return machine.panel_open && machine.get_component_of_type(/obj/item/stock_parts/circuitboard)
+	return machine.panel_open && machine.get_component_of_type(/obj/item/stock_parts/circuitboard) && (machine.reason_broken == MACHINE_BROKEN_CONSTRUCT)
 
 /decl/machine_construction/wall_frame/no_wires/validate_state(obj/machinery/machine)
 	. = ..()
@@ -194,6 +194,7 @@
 			return TRUE
 		if(!user.canUnEquip(board))
 			return TRUE
+		machine.set_broken(TRUE, MACHINE_BROKEN_CONSTRUCT)
 		TRANSFER_STATE(diconnected_state)
 		user.unEquip(board, machine)
 		machine.install_component(board)


### PR DESCRIPTION
## Description of changes
The machine state wouldn't toggle to broken like expected after leaving the no_circuit state and moving into the no_wire state. Prevents wall machines from working after placing a circuit board in them until the wire has been installed.

## Changelog
:cl:
bugfix: Fixed some wall-mounted machines acting as fully constructed, when a circuitboard was installed and no wiring installed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->