### PR TITLE
Some event tweaks, addition of update icon event.

### DIFF
--- a/code/__defines/observ.dm
+++ b/code/__defines/observ.dm
@@ -1,0 +1,4 @@
+// This also works, and removes the need for the _REPEAT variant, but the linter hates it:
+//   #define RAISE_EVENT(OBS, args...) (GET_DECL(OBS))?.raise_event(args);
+#define RAISE_EVENT(OBS, args...) var/decl/observ/__event = GET_DECL(OBS); __event?.raise_event(args);
+#define RAISE_EVENT_REPEAT(OBS, args...) __event = GET_DECL(OBS); __event?.raise_event(args);

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -44,7 +44,7 @@
 	var/decl/observ/destroyed/destroyed_event = GET_DECL(/decl/observ/destroyed)
 	// Typecheck is needed (rather than nullchecking) due to oddness with new() ordering during world creation.
 	if(istype(events_repository) && destroyed_event.global_listeners.len || destroyed_event.event_sources[src])
-		events_repository.raise_event(/decl/observ/destroyed, src)
+		RAISE_EVENT(/decl/observ/destroyed, src)
 
 	if (!isturf(src))	// Not great, but the 'correct' way to do it would add overhead for little benefit.
 		cleanup_events(src)

--- a/code/datums/extensions/label.dm
+++ b/code/datums/extensions/label.dm
@@ -26,7 +26,7 @@
 
 	var/old_name = atom_holder.name
 	atom_holder.name = "[atom_holder.name] ([label])"
-	events_repository.raise_event(/decl/observ/name_set, src, old_name, atom_holder.name)
+	RAISE_EVENT(/decl/observ/name_set, src, old_name, atom_holder.name)
 	return TRUE
 
 /datum/extension/labels/proc/RemoveLabel(var/mob/user, var/label)
@@ -41,7 +41,7 @@
 	var/index = findtextEx(atom_holder.name, full_label)
 	if(!index) // Playing it safe, something might not have set the name properly
 		return
-	
+
 	if(user)
 		user.visible_message(SPAN_NOTICE("\The [user] removes a label from \the [atom_holder]."), \
 							 SPAN_NOTICE("You remove a label, '[label]', from \the [atom_holder]."))
@@ -49,7 +49,7 @@
 	var/old_name = atom_holder.name
 	// We find and replace the first instance, since that's the one we removed from the list
 	atom_holder.name = replacetext(atom_holder.name, full_label, "", index, index + length(full_label))
-	events_repository.raise_event(/decl/observ/name_set, src, old_name, atom_holder.name)
+	RAISE_EVENT(/decl/observ/name_set, src, old_name, atom_holder.name)
 	return TRUE
 
 /datum/extension/labels/proc/RemoveAllLabels()

--- a/code/datums/observation/death.dm
+++ b/code/datums/observation/death.dm
@@ -17,4 +17,4 @@
 /mob/living/add_to_dead_mob_list()
 	. = ..()
 	if(.)
-		events_repository.raise_event(/decl/observ/death, src)
+		RAISE_EVENT(/decl/observ/death, src)

--- a/code/datums/observation/entered.dm
+++ b/code/datums/observation/entered.dm
@@ -19,4 +19,4 @@
 
 /atom/Entered(atom/movable/enterer, atom/old_loc)
 	..()
-	events_repository.raise_event(/decl/observ/entered, src, enterer, old_loc)
+	RAISE_EVENT(/decl/observ/entered, src, enterer, old_loc)

--- a/code/datums/observation/exited.dm
+++ b/code/datums/observation/exited.dm
@@ -19,4 +19,4 @@
 
 /atom/Exited(atom/movable/exitee, atom/new_loc)
 	. = ..()
-	events_repository.raise_event(/decl/observ/exited, src, exitee, new_loc)
+	RAISE_EVENT(/decl/observ/exited, src, exitee, new_loc)

--- a/code/datums/observation/helpers.dm
+++ b/code/datums/observation/helpers.dm
@@ -1,5 +1,5 @@
 /atom/movable/proc/recursive_move(var/atom/movable/am, var/old_loc, var/new_loc)
-	events_repository.raise_event(/decl/observ/moved, src, old_loc, new_loc)
+	RAISE_EVENT(/decl/observ/moved, src, old_loc, new_loc)
 
 /atom/movable/proc/move_to_turf(var/atom/movable/am, var/old_loc, var/new_loc)
 	var/turf/T = get_turf(new_loc)

--- a/code/datums/observation/life.dm
+++ b/code/datums/observation/life.dm
@@ -17,4 +17,4 @@
 /mob/add_to_living_mob_list()
 	. = ..()
 	if(.)
-		events_repository.raise_event(/decl/observ/life, src)
+		RAISE_EVENT(/decl/observ/life, src)

--- a/code/datums/observation/moved.dm
+++ b/code/datums/observation/moved.dm
@@ -26,7 +26,7 @@
 
 /atom/Entered(var/atom/movable/am, var/atom/old_loc)
 	. = ..()
-	events_repository.raise_event(/decl/observ/moved, am, old_loc, am.loc)
+	RAISE_EVENT(/decl/observ/moved, am, old_loc, am.loc)
 
 /atom/movable/Entered(var/atom/movable/am, atom/old_loc)
 	. = ..()

--- a/code/datums/observation/name_set.dm
+++ b/code/datums/observation/name_set.dm
@@ -23,5 +23,5 @@
 		if(has_extension(src, /datum/extension/labels))
 			var/datum/extension/labels/L = get_extension(src, /datum/extension/labels)
 			name = L.AppendLabelsToName(name)
-		events_repository.raise_event(/decl/observ/name_set, src, old_name, new_name)
+		RAISE_EVENT(/decl/observ/name_set, src, old_name, new_name)
 		update_above()

--- a/code/datums/observation/observation.dm
+++ b/code/datums/observation/observation.dm
@@ -212,10 +212,10 @@
 
 /decl/observ/proc/raise_event()
 	// Sanity
-	if (!args.len)
+	if(!length(args))
 		return FALSE
 
-	if (global_listeners.len)
+	if(length(global_listeners))
 		// Call the global listeners.
 		for (var/listener in global_listeners)
 			var/list/callbacks = global_listeners[listener]
@@ -231,12 +231,11 @@
 
 	// Call the listeners for this specific event source, if they exist.
 	var/source = args[1]
-	if (source && event_sources[source])
-		var/list/listeners = event_sources[source]
+	var/list/listeners = event_sources[source]
+	if(length(listeners))
 		for (var/listener in listeners)
 			var/list/callbacks = listeners[listener]
 			for (var/proc_call in callbacks)
-
 				// If the callback crashes, record the error and remove it.
 				try
 					call(listener, proc_call)(arglist(args))
@@ -244,5 +243,4 @@
 					error("[e.name] - [e.file] - [e.line]")
 					error(e.desc)
 					unregister(source, listener, proc_call)
-
 	return TRUE

--- a/code/datums/observation/opacity_set.dm
+++ b/code/datums/observation/opacity_set.dm
@@ -19,7 +19,7 @@
 	if(new_opacity != opacity)
 		var/old_opacity = opacity
 		opacity = new_opacity
-		events_repository.raise_event(/decl/observ/opacity_set, src, old_opacity, new_opacity)
+		RAISE_EVENT(/decl/observ/opacity_set, src, old_opacity, new_opacity)
 		return TRUE
 	else
 		return FALSE

--- a/code/datums/observation/see_in_dark_set.dm
+++ b/code/datums/observation/see_in_dark_set.dm
@@ -20,4 +20,4 @@
 	var/old_see_in_dark = sight
 	if(old_see_in_dark != new_see_in_dark)
 		see_in_dark = new_see_in_dark
-		events_repository.raise_event(/decl/observ/see_in_dark_set, src, old_see_in_dark, new_see_in_dark)
+		RAISE_EVENT(/decl/observ/see_in_dark_set, src, old_see_in_dark, new_see_in_dark)

--- a/code/datums/observation/see_invisible_set.dm
+++ b/code/datums/observation/see_invisible_set.dm
@@ -20,4 +20,4 @@
 	var/old_see_invisible = see_invisible
 	if(old_see_invisible != new_see_invisible)
 		see_invisible = new_see_invisible
-		events_repository.raise_event(/decl/observ/see_invisible_set, src, old_see_invisible, new_see_invisible)
+		RAISE_EVENT(/decl/observ/see_invisible_set, src, old_see_invisible, new_see_invisible)

--- a/code/datums/observation/set_invisibility.dm
+++ b/code/datums/observation/set_invisibility.dm
@@ -20,5 +20,5 @@
 	var/old_invisibility = invisibility
 	if(old_invisibility != new_invisibility)
 		invisibility = new_invisibility
-		events_repository.raise_event(/decl/observ/invisibility_set, src, old_invisibility, new_invisibility)
+		RAISE_EVENT(/decl/observ/invisibility_set, src, old_invisibility, new_invisibility)
 		update_above()

--- a/code/datums/observation/shuttle_added.dm
+++ b/code/datums/observation/shuttle_added.dm
@@ -17,4 +17,4 @@
 /datum/controller/subsystem/shuttle/initialize_shuttle()
 	. = ..()
 	if(.)
-		events_repository.raise_event(/decl/observ/shuttle_added, .)
+		RAISE_EVENT(/decl/observ/shuttle_added, .)

--- a/code/datums/observation/sight_set.dm
+++ b/code/datums/observation/sight_set.dm
@@ -24,4 +24,4 @@
 		new_sight &= ~SEE_BLACKNESS
 	if(old_sight != new_sight)
 		sight = new_sight
-		events_repository.raise_event(/decl/observ/sight_set, src, old_sight, new_sight)
+		RAISE_EVENT(/decl/observ/sight_set, src, old_sight, new_sight)

--- a/code/datums/observation/stat_set.dm
+++ b/code/datums/observation/stat_set.dm
@@ -19,4 +19,4 @@
 	var/old_stat = stat
 	. = ..()
 	if(stat != old_stat)
-		events_repository.raise_event(/decl/observ/stat_set, src, old_stat, new_stat)
+		RAISE_EVENT(/decl/observ/stat_set, src, old_stat, new_stat)

--- a/code/datums/observation/updated_icon.dm
+++ b/code/datums/observation/updated_icon.dm
@@ -1,0 +1,13 @@
+//	Observer Pattern Implementation: Updated Icon
+//		Registration type: /atom
+//
+//		Raised when: An /atom updates its icon via the on_update_icon() proc.
+//
+//		Arguments that the called proc should expect:
+//			/atom: The atom who update icons.
+//
+//      Refer to /atom/proc/update_icon() for event calling logic.
+
+/decl/observ/updated_icon
+	name = "Updated Icon"
+	expected_type = /atom

--- a/code/datums/observation/updated_icon.dm
+++ b/code/datums/observation/updated_icon.dm
@@ -4,9 +4,9 @@
 //		Raised when: An /atom updates its icon via the on_update_icon() proc.
 //
 //		Arguments that the called proc should expect:
-//			/atom: The atom who update icons.
+//			/atom: The atom who updated icon.
 //
-//      Refer to /atom/proc/update_icon() for event calling logic.
+//      Refer to /atom update_icon() proc for event calling logic.
 
 /decl/observ/updated_icon
 	name = "Updated Icon"

--- a/code/datums/observation/zone_selected.dm
+++ b/code/datums/observation/zone_selected.dm
@@ -20,4 +20,4 @@
 /obj/screen/zone_sel/set_selected_zone(bodypart)
 	var/old_selecting = selecting
 	if((. = ..()))
-		events_repository.raise_event(/decl/observ/zone_selected, src, old_selecting, selecting)
+		RAISE_EVENT(/decl/observ/zone_selected, src, old_selecting, selecting)

--- a/code/datums/repositories/events.dm
+++ b/code/datums/repositories/events.dm
@@ -1,12 +1,5 @@
 // Essentially just a wrapper for /decl/observ to preserve init order/make sure they aren't new'd at runtime.
-
 var/global/repository/events/events_repository = new
-
-/repository/events/proc/raise_event(var/event_type)
-	var/decl/observ/event = GET_DECL(event_type)
-	if(event)
-		event.raise_event(arglist(args.Copy(2)))
-
 /repository/events/proc/register(var/event_type, var/datum/event_source, var/datum/listener, var/proc_call)
 	var/decl/observ/event = GET_DECL(event_type)
 	if(event)

--- a/code/game/area/area_power.dm
+++ b/code/game/area/area_power.dm
@@ -23,7 +23,7 @@
 
 // called when power status changes
 /area/proc/power_change()
-	events_repository.raise_event(/decl/observ/area_power_change, src)
+	RAISE_EVENT(/decl/observ/area_power_change, src)
 	if (atmosalm || fire || eject || party)
 		update_icon()
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -195,6 +195,7 @@
 /atom/proc/update_icon()
 	SHOULD_CALL_PARENT(TRUE)
 	on_update_icon(arglist(args))
+	events_repository.raise_event(/decl/observ/updated_icon, src)
 
 /atom/proc/on_update_icon()
 	SHOULD_CALL_PARENT(FALSE) //Don't call the stub plz

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -92,7 +92,7 @@
 /atom/proc/set_density(var/new_density)
 	if(density != new_density)
 		density = !!new_density
-		events_repository.raise_event(/decl/observ/density_set, src, !density, density)
+		RAISE_EVENT(/decl/observ/density_set, src, !density, density)
 
 /atom/proc/bullet_act(obj/item/projectile/P, def_zone)
 	P.on_hit(src, 0, def_zone)
@@ -147,7 +147,7 @@
 
 	to_chat(user, "[html_icon(src)] That's [f_name] [suffix]")
 	to_chat(user, desc)
-	events_repository.raise_event(/decl/observ/atom_examined, src, user, distance)
+	RAISE_EVENT(/decl/observ/atom_examined, src, user, distance)
 	return TRUE
 
 // called by mobs when e.g. having the atom as their machine, loc (AKA mob being inside the atom) or buckled var set.
@@ -181,7 +181,7 @@
 			if(L.light_angle)
 				L.source_atom.update_light()
 
-	events_repository.raise_event(/decl/observ/dir_set, src, old_dir, new_dir)
+	RAISE_EVENT(/decl/observ/dir_set, src, old_dir, new_dir)
 
 /atom/proc/set_icon_state(var/new_icon_state)
 	SHOULD_CALL_PARENT(TRUE)
@@ -195,7 +195,7 @@
 /atom/proc/update_icon()
 	SHOULD_CALL_PARENT(TRUE)
 	on_update_icon(arglist(args))
-	events_repository.raise_event(/decl/observ/updated_icon, src)
+	RAISE_EVENT(/decl/observ/updated_icon, src)
 
 /atom/proc/on_update_icon()
 	SHOULD_CALL_PARENT(FALSE) //Don't call the stub plz

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -186,7 +186,7 @@
 
 	// observ
 	if(!loc)
-		events_repository.raise_event(/decl/observ/moved, src, origin, null)
+		RAISE_EVENT(/decl/observ/moved, src, origin, null)
 
 	// freelook
 	if(opacity)
@@ -238,7 +238,7 @@
 				unbuckle_mob()
 
 		if(!loc)
-			events_repository.raise_event(/decl/observ/moved, src, old_loc, null)
+			RAISE_EVENT(/decl/observ/moved, src, old_loc, null)
 
 		// freelook
 		if(opacity)

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -207,7 +207,7 @@
 /obj/item/examine(mob/user, distance)
 	var/desc_comp = "" //For "description composite"
 	desc_comp += "It is a [w_class_description()] item."
-	
+
 	var/desc_damage = get_examined_damage_string()
 	if(length(desc_damage))
 		desc_comp += "<BR/>[desc_damage]"
@@ -395,8 +395,8 @@
 	if(user && (z_flags & ZMM_MANGLE_PLANES))
 		addtimer(CALLBACK(user, /mob/proc/check_emissive_equipment), 0, TIMER_UNIQUE)
 
-	events_repository.raise_event(/decl/observ/mob_unequipped, user, src)
-	events_repository.raise_event(/decl/observ/item_unequipped, src, user)
+	RAISE_EVENT(/decl/observ/mob_unequipped, user, src)
+	RAISE_EVENT_REPEAT(/decl/observ/item_unequipped, src, user)
 
 // called just as an item is picked up (loc is not yet changed)
 /obj/item/proc/pickup(mob/user)
@@ -444,8 +444,8 @@
 	if(user && (z_flags & ZMM_MANGLE_PLANES))
 		addtimer(CALLBACK(user, /mob/proc/check_emissive_equipment), 0, TIMER_UNIQUE)
 
-	events_repository.raise_event(/decl/observ/mob_equipped, user, src, slot)
-	events_repository.raise_event(/decl/observ/item_equipped, src, user, slot)
+	RAISE_EVENT(/decl/observ/mob_equipped, user, src, slot)
+	RAISE_EVENT_REPEAT(/decl/observ/item_equipped, src, user, slot)
 
 // As above but for items being equipped to an active module on a robot.
 /obj/item/proc/equipped_robot(var/mob/user)

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -91,7 +91,7 @@
 		global.universe.OnTurfChange(W)
 
 	if(W.density != old_density)
-		events_repository.raise_event(/decl/observ/density_set, W, old_density, W.density)
+		RAISE_EVENT(/decl/observ/density_set, W, old_density, W.density)
 
 	// lighting stuff
 

--- a/code/modules/mob/living/carbon/taste.dm
+++ b/code/modules/mob/living/carbon/taste.dm
@@ -1,5 +1,5 @@
 /mob/living/proc/ingest(var/datum/reagents/from, var/datum/reagents/target, var/amount = 1, var/multiplier = 1, var/copy = 0)
-	events_repository.raise_event(/decl/observ/ingested, src, from, target, amount, multiplier, copy)
+	RAISE_EVENT(/decl/observ/ingested, src, from, target, amount, multiplier, copy)
 	. = from.trans_to_holder(target,amount,multiplier,copy)
 
 /mob/living/carbon/ingest(var/datum/reagents/from, var/datum/reagents/target, var/amount = 1, var/multiplier = 1, var/copy = 0) //we kind of 'sneak' a proc in here for ingesting stuff so we can play with it.

--- a/code/modules/mob/living/living_organs.dm
+++ b/code/modules/mob/living/living_organs.dm
@@ -55,7 +55,7 @@
 /mob/living/proc/on_lost_organ(var/obj/item/organ/O)
 	if(QDELETED(src))
 		return FALSE //When deleting don't bother running effects
-	events_repository.raise_event(/decl/observ/dismembered, src, O)
+	RAISE_EVENT(/decl/observ/dismembered, src, O)
 	O.on_remove_effects(src)
 	return TRUE
 

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -85,7 +85,7 @@
 	if(eyeobj)
 		eyeobj.possess(src)
 
-	events_repository.raise_event(/decl/observ/logged_in, src)
+	RAISE_EVENT(/decl/observ/logged_in, src)
 
 	hud_reset(TRUE)
 

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -1,6 +1,6 @@
 /mob/Logout()
 
-	events_repository.raise_event(/decl/observ/logged_out, src, my_client)
+	RAISE_EVENT(/decl/observ/logged_out, src, my_client)
 	SSnano.user_logout(src) // this is used to clean up (remove) this user's Nano UIs
 	global.player_list -= src
 	log_access("Logout: [key_name(src)]")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -353,7 +353,7 @@
 		if(source_turf && source_turf.z == target_turf?.z)
 			distance = get_dist(source_turf, target_turf)
 
-	events_repository.raise_event(/decl/observ/mob_examining, src, A)
+	RAISE_EVENT(/decl/observ/mob_examining, src, A)
 
 	if(!A.examine(src, distance))
 		PRINT_STACK_TRACE("Improper /examine() override: [log_info_line(A)]")

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -46,7 +46,7 @@
 		if(!islist(shuttle_area))
 			shuttle_area = list(shuttle_area)
 		for(var/T in shuttle_area)
-			if(istype(T, /area)) // If the shuttle area is already a type, it does not need to be located. 
+			if(istype(T, /area)) // If the shuttle area is already a type, it does not need to be located.
 				areas += T
 				continue
 			var/area/A
@@ -163,9 +163,9 @@
 		testing("Moving [A]")
 		translation += get_turf_translation(get_turf(current_location), get_turf(destination), A.contents)
 	var/obj/effect/shuttle_landmark/old_location = current_location
-	events_repository.raise_event(/decl/observ/shuttle_pre_move, src, old_location, destination)
+	RAISE_EVENT(/decl/observ/shuttle_pre_move, src, old_location, destination)
 	shuttle_moved(destination, translation)
-	events_repository.raise_event(/decl/observ/shuttle_moved, src, old_location, destination)
+	RAISE_EVENT_REPEAT(/decl/observ/shuttle_moved, src, old_location, destination)
 	if(istype(old_location))
 		old_location.shuttle_departed(src)
 	destination.shuttle_arrived(src)
@@ -186,9 +186,9 @@
 		testing("Moving [A]")
 		translation += get_turf_translation(get_turf(current_location), get_turf(destination), A.contents)
 	var/obj/effect/shuttle_landmark/old_location = current_location
-	events_repository.raise_event(/decl/observ/shuttle_pre_move, src, old_location, destination)
+	RAISE_EVENT(/decl/observ/shuttle_pre_move, src, old_location, destination)
 	shuttle_moved(destination, translation)
-	events_repository.raise_event(/decl/observ/shuttle_moved, src, old_location, destination)
+	RAISE_EVENT_REPEAT(/decl/observ/shuttle_moved, src, old_location, destination)
 	if(istype(old_location))
 		old_location.shuttle_departed(src)
 	destination.shuttle_arrived(src)
@@ -264,7 +264,7 @@
 
 // Remove all powernets and pipenets that were affected, and rebuild them.
 /datum/shuttle/proc/handle_pipes_and_power_on_move(var/list/new_turfs)
-	var/list/powernets = list()	
+	var/list/powernets = list()
 	var/list/cables = list()
 	var/list/pipes = list()
 

--- a/nebula.dme
+++ b/nebula.dme
@@ -64,6 +64,7 @@
 #include "code\__defines\mob_status.dm"
 #include "code\__defines\mobs.dm"
 #include "code\__defines\movement.dm"
+#include "code\__defines\observ.dm"
 #include "code\__defines\organs.dm"
 #include "code\__defines\overmap.dm"
 #include "code\__defines\paperwork.dm"

--- a/nebula.dme
+++ b/nebula.dme
@@ -424,6 +424,7 @@
 #include "code\datums\observation\sight_set.dm"
 #include "code\datums\observation\stat_set.dm"
 #include "code\datums\observation\unequipped.dm"
+#include "code\datums\observation\updated_icon.dm"
 #include "code\datums\observation\zone_selected.dm"
 #include "code\datums\observation\~cleanup.dm"
 #include "code\datums\observation\~defines.dm"


### PR DESCRIPTION
## Description of changes
- Inlines `event_repository.raise_event()`
- Removes some redundant checks/list access from event raising.
- Adds an event raised when an atom updates icon.

## Why and what will this PR improve
Should improve performance generally, and I need the update_icon event for some fork stuff.

## Authorship
Myself.

## Changelog
Nothing player-facing.