### PR TITLE
Fixes up some exterior turf logic.

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -75,6 +75,7 @@ var/global/list/areas = list()
 
 	icon = 'icons/turf/areas.dmi'
 	icon_state = "white"
+	color = null
 	blend_mode = BLEND_MULTIPLY
 
 // qdel(area) should not be attempted on an area with turfs in contents. ChangeArea every turf in it first.

--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -6,6 +6,7 @@
 	layer = PLATING_LAYER
 	open_turf_type = /turf/exterior/open
 	turf_flags = TURF_FLAG_BACKGROUND
+	var/base_color
 	var/diggable = 1
 	var/dirt_color = "#7c5e42"
 	var/possible_states = 0
@@ -23,7 +24,10 @@
 
 /turf/exterior/Initialize(mapload, no_update_icon = FALSE)
 
-	color = null
+	if(base_color)
+		color = base_color
+	else
+		color = null
 
 	if(possible_states > 0)
 		icon_state = "[rand(0, possible_states)]"
@@ -44,13 +48,12 @@
 	if (no_update_icon)
 		return
 
-	if (mapload)	// If this is a mapload, then our neighbors will be updating their own icons too -- doing it for them is rude.
+	// If this is a mapload, then our neighbors will be updating their own icons too -- doing it for them is rude.
+	if(mapload)
 		update_icon()
 	else
 		for (var/turf/T in RANGE_TURFS(src, 1))
-			if (T == src)
-				continue
-			if (TICK_CHECK)	// not CHECK_TICK -- only queue if the server is overloaded
+			if(TICK_CHECK) // not CHECK_TICK -- only queue if the server is overloaded
 				T.queue_icon_update()
 			else
 				T.update_icon()

--- a/code/game/turfs/exterior/exterior_chlorine.dm
+++ b/code/game/turfs/exterior/exterior_chlorine.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/turf/exterior/water_still.dmi'
 	color = "#d2e0b7"
 	dirt_color = "#d2e0b7"
+	base_color = "#d2e0b7"
 	reagent_type = /decl/material/gas/chlorine
 
 /turf/exterior/chlorine_sand

--- a/code/game/turfs/exterior/exterior_grass.dm
+++ b/code/game/turfs/exterior/exterior_grass.dm
@@ -11,6 +11,7 @@
 	icon_edge_layer = EXT_EDGE_GRASS_WILD
 	icon_has_corners = TRUE
 	color = "#799c4b"
+	base_color = "#799c4b"
 	footstep_type = /decl/footsteps/grass
 
 /turf/exterior/wildgrass/Initialize()

--- a/code/game/turfs/exterior/exterior_tar.dm
+++ b/code/game/turfs/exterior/exterior_tar.dm
@@ -5,4 +5,5 @@
 	movement_delay = 12
 	reagent_type = /decl/material/liquid/tar
 	color = "#3e3960"
+	base_color = "#3e3960"
 	dirt_color = "#3e3960"

--- a/code/modules/overmap/exoplanets/planet_types/meat.dm
+++ b/code/modules/overmap/exoplanets/planet_types/meat.dm
@@ -66,7 +66,7 @@
 	desc = "It's disgustingly soft to the touch. And warm. Too warm."
 	dirt_color = "#c40031"
 	footstep_type = /decl/footsteps/mud
-	
+
 /turf/exterior/water/stomach
 	name = "juices"
 	desc = "Half-digested chunks of vines are floating in the puddle of some liquid."
@@ -74,4 +74,5 @@
 	icon = 'icons/turf/exterior/water_still.dmi'
 	reagent_type = /decl/material/liquid/acid/stomach
 	color = "#c7c27c"
+	base_color = "#c7c27c"
 	dirt_color = "#c40031"


### PR DESCRIPTION
## Description of changes
- Fixes exterior turfs never updating their own icon on init.
- Fixes exterior turfs like wildgrass losing colour.
- Nulls out area colour on init.

## Why and what will this PR improve
Nicer looking exoplanets mainly.

## Authorship
Myself.

## Changelog
Nothing player-facing.