### PR TITLE
Tweaked warning signs auto-offset

### DIFF
--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -46,7 +46,7 @@
 			var/obj/structure/sign/S = new(user.loc)
 			S.SetName(name)
 			S.desc = desc
-			S.icon_state = sign_state			
+			S.icon_state = sign_state
 			switch(direction)
 				if("North")
 					S.set_dir(NORTH)
@@ -86,6 +86,7 @@
 /obj/structure/sign/warning
 	name = "\improper WARNING"
 	icon_state = "securearea"
+	directional_offset = "{'NORTH':{'y':-32}, 'SOUTH':{'y':32}, 'WEST':{'x':34}, 'EAST':{'x':-34}}"
 
 /obj/structure/sign/warning/detailed
 	icon_state = "securearea2"


### PR DESCRIPTION
## Description of changes
They now align to adjacent walls properly.


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->