### PR TITLE
Hollow flag to obj

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -63,6 +63,7 @@ The latter will result in a linter warning and will not work correctly.
 #define OBJ_FLAG_ROTATABLE                BITFLAG(2) // Can be rotated with alt-click
 #define OBJ_FLAG_NOFALL                   BITFLAG(3) // Will prevent mobs from falling
 #define OBJ_FLAG_MOVES_UNSUPPORTED        BITFLAG(4) // Object moves with shuttle transition even if turf below is a background turf.
+#define OBJ_FLAG_HOLLOW                   BITFLAG(5) // Modifies initial matter values to be lower than w_class normally sets.
 
 // Item-level flags (/obj/item/item_flags)
 #define ITEM_FLAG_NO_BLUDGEON             BITFLAG(0) // When an item has this it produces no "X has been hit by Y with Z" message with the default handler.
@@ -79,8 +80,7 @@ The latter will result in a linter warning and will not work correctly.
 #define ITEM_FLAG_NOCUFFS                 BITFLAG(11) // Gloves that have this flag prevent cuffs being applied
 #define ITEM_FLAG_CAN_HIDE_IN_SHOES       BITFLAG(12) // Items that can be hidden in shoes that permit it
 #define ITEM_FLAG_PADDED                  BITFLAG(13) // When set on gloves, will act like pulling punches in unarmed combat.
-#define ITEM_FLAG_HOLLOW                  BITFLAG(14) // Modifies initial matter values to be lower than w_class normally sets.
-#define ITEM_FLAG_CAN_TAPE                BITFLAG(15) //Whether the item can be be taped onto something using tape
+#define ITEM_FLAG_CAN_TAPE                BITFLAG(14) //Whether the item can be be taped onto something using tape
 
 // Flags for pass_flags (/atom/var/pass_flags)
 #define PASS_FLAG_TABLE                   BITFLAG(0)

--- a/code/game/objects/item_materials.dm
+++ b/code/game/objects/item_materials.dm
@@ -80,7 +80,7 @@
 			new_force = material.get_edge_damage()
 		else
 			new_force = material.get_blunt_damage()
-			if(item_flags & ITEM_FLAG_HOLLOW)
+			if(obj_flags & OBJ_FLAG_HOLLOW)
 				new_force *= HOLLOW_OBJECT_MATTER_MULTIPLIER
 
 		new_force = round(new_force*material_force_multiplier)
@@ -93,7 +93,7 @@
 	if(material)
 		armor_penetration += 2*max(0, material.brute_armor - 2)
 		throwforce = material.get_blunt_damage() * thrown_material_force_multiplier
-		if(item_flags & ITEM_FLAG_HOLLOW)
+		if(obj_flags & OBJ_FLAG_HOLLOW)
 			throwforce *= HOLLOW_OBJECT_MATTER_MULTIPLIER
 		throwforce = round(throwforce)
 		attack_cooldown += material.get_attack_cooldown()
@@ -132,7 +132,7 @@
 
 /obj/item/get_matter_amount_modifier()
 	. = ..()
-	if(item_flags & ITEM_FLAG_HOLLOW)
+	if(obj_flags & OBJ_FLAG_HOLLOW)
 		. *= HOLLOW_OBJECT_MATTER_MULTIPLIER
 
 /obj/item/create_matter()

--- a/code/game/objects/items/glassjar.dm
+++ b/code/game/objects/items/glassjar.dm
@@ -6,7 +6,8 @@
 	w_class = ITEM_SIZE_SMALL
 	material = /decl/material/solid/glass
 	material_force_multiplier = 0.1
-	item_flags = ITEM_FLAG_NO_BLUDGEON | ITEM_FLAG_HOLLOW
+	item_flags = ITEM_FLAG_NO_BLUDGEON
+	obj_flags = OBJ_FLAG_HOLLOW
 	drop_sound = 'sound/foley/bottledrop1.ogg'
 	pickup_sound = 'sound/foley/bottlepickup1.ogg'
 	var/list/accept_mobs = list(

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -41,7 +41,8 @@
 	icon_state                    = "waterballoon-e"
 	item_state                    = "balloon-empty"
 	w_class                       = ITEM_SIZE_TINY
-	item_flags                    = ITEM_FLAG_NO_BLUDGEON | ITEM_FLAG_HOLLOW
+	item_flags                    = ITEM_FLAG_NO_BLUDGEON
+	obj_flags                     = OBJ_FLAG_HOLLOW
 	atom_flags                    = ATOM_FLAG_OPEN_CONTAINER
 	hitsound                      = 'sound/weapons/throwtap.ogg'
 	throw_speed                   = 4

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -29,7 +29,7 @@
 	matter = list( 
 		/decl/material/solid/plastic = MATTER_AMOUNT_SECONDARY
 	)
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 	var/spam_flag = 0
 	var/audio_files = list("sound/items/bikehorn.ogg")
 
@@ -49,4 +49,4 @@
 	item_state = "air_horn"
 	audio_files = list("sound/items/air_horn_1.ogg", "sound/items/air_horn_2.ogg")
 	material = /decl/material/solid/metal/aluminium
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -4,7 +4,7 @@
 	desc = "An unbranded tube of lipstick."
 	icon = 'icons/obj/items/lipstick.dmi'
 	icon_state = "lipstick_0"
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
 	color = "#e00606"

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -7,7 +7,7 @@
 	hitsound                      = 'sound/weapons/smash.ogg'
 	atom_flags                    = ATOM_FLAG_OPEN_CONTAINER
 	obj_flags                     = OBJ_FLAG_CONDUCTIBLE
-	item_flags                    = ITEM_FLAG_HOLLOW
+	obj_flags                     = OBJ_FLAG_HOLLOW
 	w_class                       = ITEM_SIZE_NORMAL
 	throw_speed                   = 2
 	throw_range                   = 10
@@ -76,7 +76,7 @@
 	//#TODO: That could definitely be improved. Would suggest to use process_momentum but its only for thrownthing
 	var/list/move_speed = list(1, 1, 1, 2, 2, 3)
 	for(var/i in 1 to 6)
-		if(C) 
+		if(C)
 			C.propelled = (6-i)
 		O.Move(get_step(user,movementdirection), movementdirection)
 		sleep(move_speed[i])

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -9,7 +9,7 @@
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_LOWER_BODY
 	z_flags = ZMM_MANGLE_PLANES
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 	material = /decl/material/solid/metal/steel
 	var/active
 	var/det_time = 50

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -7,7 +7,7 @@
 	w_class = ITEM_SIZE_TINY
 	throwforce = 4
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 	slot_flags = SLOT_LOWER_BODY
 	attack_verb = list("burnt", "singed")
 	lit_heat = 1500

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -7,7 +7,7 @@
 	use_to_pickup = 1
 	slot_flags = SLOT_LOWER_BODY
 	material = /decl/material/solid/plastic
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 
 /obj/item/storage/bag/handle_item_insertion(obj/item/W, prevent_warning = 0)
 	. = ..()

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -28,7 +28,7 @@
 	max_storage_space = DEFAULT_BOX_STORAGE
 	use_sound = 'sound/effects/storage/box.ogg'
 	material = /decl/material/solid/cardboard
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 	var/foldable = /obj/item/stack/material/cardstock	// BubbleWrap - if set, can be folded (when empty) into a sheet of cardboard
 
 /obj/item/storage/box/large

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -12,7 +12,7 @@
 /obj/item/storage/fancy
 	item_state = "syringe_kit" //placeholder, many of these don't have inhands
 	opened = 0 //if an item has been removed from this container
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 	material = /decl/material/solid/cardboard
 	var/obj/item/key_type //path of the key item that this "fancy" container is meant to store
 

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -17,7 +17,7 @@
 	max_w_class = ITEM_SIZE_SMALL
 	max_storage_space = DEFAULT_BOX_STORAGE
 	use_sound = 'sound/effects/storage/box.ogg'
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 	material = /decl/material/solid/plastic
 
 /obj/item/storage/firstaid/empty

--- a/code/game/objects/items/weapons/storage/laundry_basket.dm
+++ b/code/game/objects/items/weapons/storage/laundry_basket.dm
@@ -19,7 +19,7 @@
 	allow_quick_gather = 1
 	collection_mode = 1
 	material = /decl/material/solid/plastic
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 	var/linked
 
 /obj/item/storage/laundry_basket/attack_hand(mob/user)

--- a/code/game/objects/items/weapons/storage/mre.dm
+++ b/code/game/objects/items/weapons/storage/mre.dm
@@ -12,7 +12,7 @@ MRE Stuff
 	opened = FALSE
 	open_sound = 'sound/effects/rip1.ogg'
 	material = /decl/material/solid/plastic
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 	var/main_meal = /obj/item/storage/mrebag
 	var/meal_desc = "This one is menu 1, meat pizza."
 

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -224,7 +224,8 @@
 	icon_state = "bone-gel"
 	force = 0
 	w_class = ITEM_SIZE_SMALL
-	item_flags = ITEM_FLAG_HOLLOW | ITEM_FLAG_NO_BLUDGEON
+	item_flags = ITEM_FLAG_NO_BLUDGEON
+	obj_flags = OBJ_FLAG_HOLLOW
 	throwforce = 1
 	material = /decl/material/solid/plastic
 

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -393,7 +393,7 @@
 	icon              = 'icons/obj/items/tool/welders/welder_tanks.dmi'
 	icon_state        = "tank_normal"
 	w_class           = ITEM_SIZE_SMALL
-	item_flags        = ITEM_FLAG_HOLLOW
+	obj_flags         = OBJ_FLAG_HOLLOW
 	force             = 5
 	throwforce        = 5
 	volume            = 20

--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -8,7 +8,7 @@
 	item_state = ""
 	w_class = ITEM_SIZE_SMALL
 	material = /decl/material/solid/plastic
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 	var/obj/item/stored_item = null
 
 /obj/item/evidencebag/handle_mouse_drop(atom/over, mob/user)

--- a/code/modules/detectivework/tools/sample_kits/fingerprinting.dm
+++ b/code/modules/detectivework/tools/sample_kits/fingerprinting.dm
@@ -8,7 +8,7 @@
 	possible_evidence_types = list(
 		/datum/forensics/fingerprints
 	)
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 	material = /decl/material/solid/glass
 	matter = list(/decl/material/solid/metal/aluminium = MATTER_AMOUNT_SECONDARY)
 

--- a/code/modules/mob/living/bot/remotebot.dm
+++ b/code/modules/mob/living/bot/remotebot.dm
@@ -165,7 +165,7 @@
 	desc = "The cover says 'control your own cardboard nuclear powered robot. Comes with real plutonium!"
 	icon = 'icons/obj/items/bot_kit.dmi'
 	icon_state = "remotebot"
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 	material = /decl/material/solid/cardboard
 
 /obj/item/bot_kit/attack_self(var/mob/user)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -472,7 +472,7 @@
 	w_class = ITEM_SIZE_TINY
 	material = /decl/material/solid/metal/steel
 	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CAN_BE_PAINTED
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 
 	var/status = 0		// LIGHT_OK, LIGHT_BURNED or LIGHT_BROKEN
 	var/base_state

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -8,7 +8,7 @@
 	slot_flags = SLOT_LOWER_BODY | SLOT_EARS
 	throwforce = 1
 	w_class = ITEM_SIZE_TINY
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 	material = /decl/material/solid/metal/brass
 
 	var/leaves_residue = 1

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -5,7 +5,7 @@
 	icon_state = null
 	w_class = ITEM_SIZE_SMALL
 	material = /decl/material/solid/plastic
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 
 	var/base_name
 	var/base_desc

--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -31,7 +31,7 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	presentation_flags = PRESENTATION_FLAG_NAME | PRESENTATION_FLAG_DESC
 	temperature_coefficient = 4
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 
 	var/custom_name
 	var/custom_desc

--- a/code/modules/reagents/reagent_containers/drinks.dm
+++ b/code/modules/reagents/reagent_containers/drinks.dm
@@ -7,7 +7,7 @@
 	icon = 'icons/obj/drinks.dmi'
 	icon_state = null
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 	possible_transfer_amounts = null
 	amount_per_transfer_from_this = 5
 	randpixel = 6

--- a/code/modules/reagents/reagent_containers/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/drinks/bottle.dm
@@ -231,7 +231,7 @@
 	attack_verb = list("stabbed", "slashed", "attacked")
 	sharp = 1
 	edge = 0
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 	material = /decl/material/solid/glass
 	var/icon/broken_outline = icon('icons/obj/drinks.dmi', "broken")
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -12,7 +12,7 @@
 	volume = 60
 	w_class = ITEM_SIZE_SMALL
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 	unacidable = 1 //glass doesn't dissolve in acid
 
 	drop_sound = 'sound/foley/bottledrop1.ogg'

--- a/code/modules/reagents/storage/pill_bottle.dm
+++ b/code/modules/reagents/storage/pill_bottle.dm
@@ -9,7 +9,7 @@
 	item_state = "contsolid"
 	w_class = ITEM_SIZE_SMALL
 	max_w_class = ITEM_SIZE_TINY
-	item_flags =  ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 	max_storage_space = 21
 	can_hold = list(
 		/obj/item/chems/pill,

--- a/code/modules/recycling/package_wrapper.dm
+++ b/code/modules/recycling/package_wrapper.dm
@@ -190,4 +190,4 @@
 	throw_speed = 4
 	throw_range = 5
 	material    = /decl/material/solid/cardboard
-	item_flags  = ITEM_FLAG_HOLLOW
+	obj_flags   = OBJ_FLAG_HOLLOW

--- a/code/modules/recycling/wrapped_package.dm
+++ b/code/modules/recycling/wrapped_package.dm
@@ -10,7 +10,7 @@
 	desc              = "A wrapped package."
 	icon              = 'icons/obj/items/storage/deliverypackage.dmi'
 	icon_state        = "parcel"
-	item_flags        = ITEM_FLAG_HOLLOW
+	obj_flags         = OBJ_FLAG_HOLLOW
 	material          = /decl/material/solid/paper
 	attack_verb       = list("delivered a hit", "expedited on", "shipped at", "went postal on")
 	base_parry_chance = 40 //Boxes tend to be good at parrying

--- a/mods/content/xenobiology/slime/items_extract_enhancer.dm
+++ b/mods/content/xenobiology/slime/items_extract_enhancer.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/items/chem/bottle.dmi'
 	icon_state = "bottle17"
 	material = /decl/material/solid/plastic
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 
 /obj/item/slime_extract_enhancer/afterattack(obj/target, mob/user , flag)
 	if(!istype(target, /obj/item/slime_extract))

--- a/mods/content/xenobiology/slime/items_potion.dm
+++ b/mods/content/xenobiology/slime/items_potion.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/items/chem/bottle.dmi'
 	icon_state = "bottle19"
 	material = /decl/material/solid/glass
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 	var/slime_type = /mob/living/simple_animal/slime
 	var/can_tame_adults = FALSE
 

--- a/mods/content/xenobiology/slime/items_steroid.dm
+++ b/mods/content/xenobiology/slime/items_steroid.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/items/chem/bottle.dmi'
 	icon_state = "bottle16"
 	material = /decl/material/solid/glass
-	item_flags = ITEM_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_HOLLOW
 	var/grant_cores = 3
 
 /obj/item/slime_steroid/attack(mob/living/slime/M, mob/user)


### PR DESCRIPTION
## Description of changes
Moved the ITEM_FLAG_HOLLOW flag to the /obj level. It's now called OBJ_FLAG_HOLLOW, and is set on the obj_flags var. 
Made the change because some structures and machines, like dispensers will be using it for matter calculation in an upcoming PR. 