### PR TITLE
Renamed health on hydro tray to plant_health

### DIFF
--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -159,7 +159,7 @@
 	var/trays = 0
 	for(var/obj/machinery/portable_atmospherics/hydroponics/H in view(7, src))
 		if(H.seed && !H.dead)
-			H.health += 0.05 * coef
+			H.plant_health += 0.05 * coef
 			++trays
 	honeycombs = min(honeycombs + 0.1 * coef * min(trays, 5), frames * 100)
 

--- a/code/modules/hydroponics/trays/tray_process.dm
+++ b/code/modules/hydroponics/trays/tray_process.dm
@@ -67,9 +67,9 @@
 	// water and nutrients will cause a plant to become healthier.
 	var/healthmod = rand(1,3) * HYDRO_SPEED_MULTIPLIER
 	if(seed.get_trait(TRAIT_REQUIRES_NUTRIENTS) && prob(35))
-		health += (nutrilevel < 2 ? -healthmod : healthmod)
+		plant_health += (nutrilevel < 2 ? -healthmod : healthmod)
 	if(seed.get_trait(TRAIT_REQUIRES_WATER) && prob(35))
-		health += (waterlevel < 10 ? -healthmod : healthmod)
+		plant_health += (waterlevel < 10 ? -healthmod : healthmod)
 
 	// Check that pressure, heat and light are all within bounds.
 	// First, handle an open system or an unconnected closed system.
@@ -84,9 +84,9 @@
 
 	// Seed datum handles gasses, light and pressure.
 	if(mechanical && closed_system)
-		health -= seed.handle_environment(T,environment,tray_light)
+		plant_health -= seed.handle_environment(T,environment,tray_light)
 	else
-		health -= seed.handle_environment(T,environment)
+		plant_health -= seed.handle_environment(T,environment)
 
 	// If we're attached to a pipenet, then we should let the pipenet know we might have modified some gasses
 	if (closed_system && connected_port)
@@ -97,29 +97,29 @@
 	if(toxins > 0)
 		var/toxin_uptake = max(1,round(toxins/10))
 		if(toxins > seed.get_trait(TRAIT_TOXINS_TOLERANCE))
-			health -= toxin_uptake
+			plant_health -= toxin_uptake
 		toxins -= toxin_uptake
 
 	// Check for pests and weeds.
 	// Some carnivorous plants happily eat pests.
 	if(pestlevel > 0)
 		if(seed.get_trait(TRAIT_CARNIVOROUS))
-			health += HYDRO_SPEED_MULTIPLIER
+			plant_health += HYDRO_SPEED_MULTIPLIER
 			pestlevel -= HYDRO_SPEED_MULTIPLIER
 		else if (pestlevel >= seed.get_trait(TRAIT_PEST_TOLERANCE))
-			health -= HYDRO_SPEED_MULTIPLIER
+			plant_health -= HYDRO_SPEED_MULTIPLIER
 
 	// Some plants thrive and live off of weeds.
 	if(weedlevel > 0)
 		if(seed.get_trait(TRAIT_PARASITE))
-			health += HYDRO_SPEED_MULTIPLIER
+			plant_health += HYDRO_SPEED_MULTIPLIER
 			weedlevel -= HYDRO_SPEED_MULTIPLIER
 		else if (weedlevel >= seed.get_trait(TRAIT_WEED_TOLERANCE))
-			health -= HYDRO_SPEED_MULTIPLIER
+			plant_health -= HYDRO_SPEED_MULTIPLIER
 
 	// Handle life and death.
 	// When the plant dies, weeds thrive and pests die off.
-	check_health(0)
+	check_plant_health(0)
 
 	// If enough time (in cycles, not ticks) has passed since the plant was harvested, we're ready to harvest again.
 	if((age > seed.get_trait(TRAIT_MATURATION)) && \
@@ -144,5 +144,5 @@
 	if(seed && seed.can_self_harvest && harvest && !closed_system && prob(5))
 		harvest()
 
-	check_health(needs_icon_update)
+	check_plant_health(needs_icon_update)
 	return

--- a/code/modules/hydroponics/trays/tray_soil.dm
+++ b/code/modules/hydroponics/trays/tray_soil.dm
@@ -38,7 +38,7 @@
 	seed = newseed
 	dead = 0
 	age = start_mature ? seed.get_trait(TRAIT_MATURATION) : 1
-	health = seed.get_trait(TRAIT_ENDURANCE)
+	plant_health = seed.get_trait(TRAIT_ENDURANCE)
 	lastcycle = world.time
 	if(isnull(default_pixel_y))
 		default_pixel_y = rand(-12,12)
@@ -47,7 +47,7 @@
 	reset_offsets(0)
 	if(seed)
 		name = seed.display_name
-	check_health()
+	check_plant_health()
 	connected_zlevels = GetConnectedZlevels(z)
 
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible/Process()

--- a/code/modules/hydroponics/trays/tray_update_icons.dm
+++ b/code/modules/hydroponics/trays/tray_update_icons.dm
@@ -21,7 +21,7 @@
 		//Draw the cover.
 		if(closed_system)
 			new_overlays += "hydrocover2"
-		if(seed && health <= (seed.get_trait(TRAIT_ENDURANCE) / 2))
+		if(seed && plant_health <= (seed.get_trait(TRAIT_ENDURANCE) / 2))
 			new_overlays += "over_lowhealth3"
 		if(waterlevel <= 10)
 			new_overlays += "over_lowwater3"

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -271,7 +271,7 @@
 		set_pin_data(IC_OUTPUT, 13, H.nutrilevel)
 		set_pin_data(IC_OUTPUT, 14, H.harvest)
 		set_pin_data(IC_OUTPUT, 15, H.dead)
-		set_pin_data(IC_OUTPUT, 16, H.health)
+		set_pin_data(IC_OUTPUT, 16, H.plant_health)
 	push_data()
 	activate_pin(2)
 

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -273,7 +273,7 @@
 			if(2)
 				if(TR.seed) //Could be that they're just using it as a de-weeder
 					TR.age = 0
-					TR.health = 0
+					TR.plant_health = 0
 					if(TR.harvest)
 						TR.harvest = FALSE //To make sure they can't just put in another seed and insta-harvest it
 					qdel(TR.seed)
@@ -292,7 +292,7 @@
 						TR.dead = 0
 						TR.seed = O
 						TR.age = 1
-						TR.health = TR.seed.get_trait(TRAIT_ENDURANCE)
+						TR.plant_health = TR.seed.get_trait(TRAIT_ENDURANCE)
 						TR.lastcycle = world.time
 						O.forceMove(TR)
 						TR.update_icon()

--- a/mods/species/ascent/machines/ship_machines.dm
+++ b/mods/species/ascent/machines/ship_machines.dm
@@ -30,7 +30,7 @@ MANTIDIFY(/obj/machinery/door/airlock/external/bolted, "mantid airlock", "door")
 	pestlevel = 0
 	weedlevel = 0
 	mutation_level = 0
-	health = 100
+	plant_health = 100
 	sampled = 0
 	. = ..()
 


### PR DESCRIPTION
## Description of changes
Hydro trays having a var called "health" for holding the plant health would cause name collision in my obj damage handling PR. So I renamed it to plant_health here instead.
