### PR TITLE
Fixed bad use of matter list in errant pisces

### DIFF
--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -176,7 +176,8 @@
 	throwforce = 5
 	throw_speed = 5
 	throw_range = 10
-	matter = list("cloth" = 1875, "plasteel" = 350)
+	material = /decl/material/solid/cloth
+	matter = list(/decl/material/solid/metal/plasteel = MATTER_AMOUNT_REINFORCEMENT)
 	max_amount = 30
 	center_of_mass = null
 	attack_verb = list("hit", "bludgeoned", "whacked")


### PR DESCRIPTION
## Description of changes
That matter list used material names instead of material paths. So I fixed it.
