### PR TITLE
chemdart properly init its reagents

### DIFF
--- a/code/modules/projectiles/ammunition/chemdart.dm
+++ b/code/modules/projectiles/ammunition/chemdart.dm
@@ -10,9 +10,9 @@
 
 	muzzle_type = null
 
-/obj/item/projectile/bullet/chemdart/Initialize()
-	. = ..()
+/obj/item/projectile/bullet/chemdart/initialize_reagents(populate)
 	create_reagents(reagent_amount)
+	. = ..()
 
 /obj/item/projectile/bullet/chemdart/on_hit(var/atom/target, var/blocked = 0, var/def_zone = null)
 	if(blocked < 100 && isliving(target))


### PR DESCRIPTION
## Description of changes
Seems like it was happening too late, so I moved it to initialize_reagents.
