### PR TITLE
Fixes supply program not populating categories.

### DIFF
--- a/code/datums/hierarchy.dm
+++ b/code/datums/hierarchy.dm
@@ -17,7 +17,7 @@
 	. = ..()
 
 /decl/hierarchy/proc/is_category()
-	return INSTANCE_IS_ABSTRACT(src) && length(children)
+	return length(children)
 
 /decl/hierarchy/proc/get_descendents()
 	if(!children)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes

Changes what the `is_category` decl proc does to make its (sole) use in supply code result in the expected behavior.

## Why and what will this PR improve

Currently the supply controller does not register any supply packs existing: since the supply first-layer hierarchy members are not marked as abstract, they are not categories, and are ignored.

This targets dev because while I think stable has a similar issue, the implementation there appears different.

It's possible that the correct fix is to instead mark the first layer as abstract (does that work correctly with the rest of the decl infrastructure?) or to remove this helper entirely.

## Authorship

me
