### PR TITLE
Attempt to address unit testing issues with random lunches.

### DIFF
--- a/code/game/objects/random/subtypes/misc.dm
+++ b/code/game/objects/random/subtypes/misc.dm
@@ -78,10 +78,12 @@
 	desc = "This is some random junk."
 	icon = 'icons/obj/items/storage/trashbag.dmi'
 	icon_state = "trashbag3"
+	var/spawn_choice
 
 /obj/random/junk/spawn_choices()
-	var/static/list/spawnable_choices = list(get_random_junk_type())
-	return spawnable_choices
+	if(!spawn_choice)
+		spawn_choice = get_random_junk_type()
+	return list(spawn_choice)
 
 /obj/random/trash //Mostly remains and cleanable decals. Stuff a janitor could clean up
 	name = "random trash"

--- a/code/unit_tests/~unit_test_overrides.dm
+++ b/code/unit_tests/~unit_test_overrides.dm
@@ -23,7 +23,7 @@
 
 var/global/atom/movable/unit_test_last_obj_random_creation
 /obj/random/proc/unit_test_spawn_item()
-	global.unit_test_last_obj_random_creation = create_instance(unit_test_select_heaviest(spawn_choices()))
+	global.unit_test_last_obj_random_creation = create_instance(unit_test_select_heaviest(spawn_choices()), loc)
 
 /proc/unit_test_select_heaviest(var/list/choices)
 	if(ispath(choices) || istype(choices, /datum))

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -913,7 +913,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "bX" = (
-/obj/structure/closet/crate,
+/obj/structure/closet/crate/large,
 /obj/random/handgun,
 /obj/random/handgun,
 /obj/random/handgun,
@@ -953,18 +953,8 @@
 /obj/item/chems/drinks/milk,
 /obj/item/trash/liquidfood,
 /obj/item/trash/liquidfood,
-/obj/item/trash/liquidfood,
-/obj/item/trash/liquidfood,
 /obj/item/beartrap,
 /obj/item/knife/kitchen/cleaver,
-/obj/item/chems/food/liquidfood,
-/obj/item/chems/food/liquidfood,
-/obj/item/chems/food/liquidfood,
-/obj/item/chems/food/liquidfood,
-/obj/item/chems/food/liquidfood,
-/obj/item/chems/food/liquidfood,
-/obj/item/chems/food/liquidfood,
-/obj/item/chems/food/liquidfood,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "bZ" = (


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes

For reference: https://github.com/NebulaSS13/Nebula/actions/runs/3796571891/jobs/6456787308

Proc static var init competes with global list init (as in assignment to `L` in `var/global/list/L = list(...)`) in world init order, apparently. This means that sometimes the random junk type call can, with low probability, runtime, resulting in the var being set to `list(null)`. This runtimes in unit test code specifically, and is undesirable in general.

Or at least, that's my best guess here. In any event, the static setup here doesn't seem essential; these are temporary objs with low total number and memory overhead.

I also feel there is a bug with the unit test spawning the random item in nullspace, though this is not related.

I cannot reproduce the error consistently, so don't know if this is an actual fix.

## Why and what will this PR improve

Might fix random items breaking occasionally.

## Authorship

me