### PR TITLE
Fixes runtime with seed scannable results.

### DIFF
--- a/code/modules/hydroponics/seed_packets.dm
+++ b/code/modules/hydroponics/seed_packets.dm
@@ -27,8 +27,10 @@ var/global/list/plant_seed_sprites = list()
 /obj/item/seeds/proc/update_seed()
 	if(!seed && seed_type && !isnull(SSplants.seeds) && SSplants.seeds[seed_type])
 		seed = SSplants.seeds[seed_type]
-		if(seed.scannable_result)
+		if(seed?.scannable_result)
 			set_extension(src, /datum/extension/scannable, seed.scannable_result)
+		else if(has_extension(src, /datum/extension/scannable))
+			remove_extension(src, /datum/extension/scannable)
 	update_appearance()
 
 //Updates strings and icon appropriately based on seed datum.

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -120,16 +120,14 @@
 	)
 
 /obj/machinery/portable_atmospherics/hydroponics/proc/set_seed(var/new_seed)
-	if(seed)
-		clear_seed()
+	if(seed == new_seed)
+		return
 	seed = new_seed
-	if(seed.scannable_result)
+	if(seed?.scannable_result)
 		set_extension(src, /datum/extension/scannable, seed.scannable_result)
-
-/obj/machinery/portable_atmospherics/hydroponics/proc/clear_seed()
-	seed = null
-	if(has_extension(src, /datum/extension/scannable))
+	else if(has_extension(src, /datum/extension/scannable))
 		remove_extension(src, /datum/extension/scannable)
+	update_icon()
 
 /obj/machinery/portable_atmospherics/hydroponics/attack_ghost(var/mob/observer/ghost/user)
 	if(!(harvest && seed && ispath(seed.product_type, /mob)))
@@ -280,7 +278,7 @@
 
 	if(!seed.get_trait(TRAIT_HARVEST_REPEAT))
 		yield_mod = 0
-		clear_seed()
+		set_seed(null)
 		dead = 0
 		age = 0
 		sampled = 0
@@ -301,7 +299,7 @@
 	if(!silent)
 		to_chat(user, SPAN_NOTICE("You remove the dead [seed.display_name]."))
 
-	clear_seed()
+	set_seed(null)
 
 	dead = 0
 	sampled = 0
@@ -315,9 +313,6 @@
 // If a weed growth is sufficient, this proc is called.
 /obj/machinery/portable_atmospherics/hydroponics/proc/weed_invasion()
 
-	//Remove the seed if something is already planted.
-	if(seed)
-		clear_seed()
 	set_seed(SSplants.seeds[pick(list("reishi", "nettles", "amanita", "mushrooms", "plumphelmet", "towercap", "harebells", "weeds"))])
 
 	if(!seed)


### PR DESCRIPTION
## Description of changes
Fixes an issue with scannable extension being set on seeds for trays with no seed.

## Why and what will this PR improve
Seeeeds.

## Authorship
Myself.

## Changelog
Nothing player-facing.