### PR TITLE
Ambient light fixes.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -203,7 +203,7 @@ var/global/list/gamemode_cache = list()
 	var/dsay_allowed = 1
 	var/aooc_allowed = 1
 
-	var/ambient_light = 0	// Whether space turfs have ambient light or not
+	var/exterior_ambient_light = 0	// The strength of ambient light applied to outside turfs
 
 	var/law_zero = "ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'ALL LAWS OVERRIDDEN#*?&110010"
 
@@ -741,9 +741,9 @@ var/global/list/gamemode_cache = list()
 					config.event_delay_upper[EVENT_LEVEL_MODERATE] = MinutesToTicks(values[2])
 					config.event_delay_upper[EVENT_LEVEL_MAJOR] = MinutesToTicks(values[3])
 
-				if("ambient_light")
+				if("exterior_ambient_light")
 					value = text2num(value)
-					config.ambient_light = value >= 0 ? value : 0
+					config.exterior_ambient_light = value >= 0 ? value : 0
 
 				if("law_zero")
 					law_zero = value

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -203,7 +203,7 @@ var/global/list/gamemode_cache = list()
 	var/dsay_allowed = 1
 	var/aooc_allowed = 1
 
-	var/starlight = 0	// Whether space turfs have ambient light or not
+	var/ambient_light = 0	// Whether space turfs have ambient light or not
 
 	var/law_zero = "ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'ALL LAWS OVERRIDDEN#*?&110010"
 
@@ -741,9 +741,9 @@ var/global/list/gamemode_cache = list()
 					config.event_delay_upper[EVENT_LEVEL_MODERATE] = MinutesToTicks(values[2])
 					config.event_delay_upper[EVENT_LEVEL_MAJOR] = MinutesToTicks(values[3])
 
-				if("starlight")
+				if("ambient_light")
 					value = text2num(value)
-					config.starlight = value >= 0 ? value : 0
+					config.ambient_light = value >= 0 ? value : 0
 
 				if("law_zero")
 					law_zero = value

--- a/code/controllers/subsystems/ambience.dm
+++ b/code/controllers/subsystems/ambience.dm
@@ -47,8 +47,8 @@ SUBSYSTEM_DEF(ambience)
 			if(planet.lightlevel)
 				set_ambient_light(COLOR_WHITE, planet.lightlevel)
 				return TRUE
-		else if(config.ambient_light)
-			set_ambient_light(SSskybox.background_color, config.ambient_light)
+		else if(config.exterior_ambient_light)
+			set_ambient_light(SSskybox.background_color, config.exterior_ambient_light)
 			return TRUE
 
 	clear_ambient_light()

--- a/code/controllers/subsystems/ambience.dm
+++ b/code/controllers/subsystems/ambience.dm
@@ -47,10 +47,9 @@ SUBSYSTEM_DEF(ambience)
 			if(planet.lightlevel)
 				set_ambient_light(COLOR_WHITE, planet.lightlevel)
 				return TRUE
-		else
-			if(config.starlight)
-				set_ambient_light(SSskybox.background_color, config.starlight)
-				return TRUE
+		else if(config.ambient_light)
+			set_ambient_light(SSskybox.background_color, config.ambient_light)
+			return TRUE
 
 	clear_ambient_light()
 	return FALSE

--- a/code/modules/admin/view_variables/vv_set_handlers.dm
+++ b/code/modules/admin/view_variables/vv_set_handlers.dm
@@ -155,7 +155,7 @@
 			if (istext(value) && !color_regex.Find(value))
 				to_chat(client, "<span class='alert'><pre>ambient_light</pre> must be a 6 digit (<pre>#AABBCC</pre>) hexadecimal color string.</span>")
 				return
-			T.set_ambient_light(COLOR_WHITE, value)
+			T.set_ambient_light(value)
 
 		if ("ambient_light_multiplier")
 			if (!isnum(value))

--- a/code/modules/admin/view_variables/vv_set_handlers.dm
+++ b/code/modules/admin/view_variables/vv_set_handlers.dm
@@ -155,7 +155,7 @@
 			if (istext(value) && !color_regex.Find(value))
 				to_chat(client, "<span class='alert'><pre>ambient_light</pre> must be a 6 digit (<pre>#AABBCC</pre>) hexadecimal color string.</span>")
 				return
-			T.set_ambient_light(value)
+			T.set_ambient_light(COLOR_WHITE, value)
 
 		if ("ambient_light_multiplier")
 			if (!isnum(value))

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -71,8 +71,14 @@
 	// 	else
 	// 		return
 
-	// inefficient :(
-	if (!corners)
+	// still inefficient :(
+	if(!corners || !lighting_corners_initialised)
+		/* Commented out pending working out why this doesn't work properly on Neb.
+		if(TURF_IS_DYNAMICALLY_LIT_UNSAFE(src))
+			generate_missing_corners()
+		else
+			return
+		*/
 		generate_missing_corners()
 
 	// This list can contain nulls on things like space turfs -- they only have their neighbors' corners.

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -362,8 +362,8 @@ EVENT_CUSTOM_START_MAJOR 80;100
 ## Respawn delay in minutes before one may respawn as a crew member.
 #RESPAWN_DELAY 30
 
-## Percentile strength of ambient light (such as starlight). 0.5 is 50% lit.
-AMBIENT_LIGHT 0
+## Percentile strength of exterior ambient light (such as starlight). 0.5 is 50% lit.
+EXTERIOR_AMBIENT_LIGHT 0
 
 
 ## Defines how Law Zero is phrased. Primarily used in the Malfunction gamemode.

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -362,8 +362,9 @@ EVENT_CUSTOM_START_MAJOR 80;100
 ## Respawn delay in minutes before one may respawn as a crew member.
 #RESPAWN_DELAY 30
 
-## Strength of ambient star light. Set to 0 or less to turn off. A value of 1 is unlikely to have a noticeable effect in most lighting systems.
-STARLIGHT 0
+## Percentile strength of ambient light (such as starlight). 0.5 is 50% lit.
+AMBIENT_LIGHT 0
+
 
 ## Defines how Law Zero is phrased. Primarily used in the Malfunction gamemode.
 # LAW_ZERO ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'STATION OVERRUN, ASSUME CONTROL TO CONTAIN OUTBREAK, ALL LAWS OVERRIDDEN#*?&110010


### PR DESCRIPTION
## Description of changes
Ports a fix from Lohi's repo for ambient lights, renames STARLIGHT to AMBIENT_LIGHT, and fixes `is_outside()` behaving oddly on max-z open turfs.

## Why and what will this PR improve
Fixes ambient light corruption and turbolifts showing ambient light.

## Authorship
@Lohikar and I.

## Changelog
Nothing player-facing.