### PR TITLE
Reimplemented adaptive darksight.

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -16,6 +16,10 @@
 	else
 		hud_used = new /datum/hud(src)
 
+/mob/living/InitializeHud()
+	..()
+	refresh_lighting_master()
+
 /datum/hud
 	var/mob/mymob
 

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -373,3 +373,15 @@
 	if(pref)
 		pref.bgstate = next_in_list(pref.bgstate, pref.bgstate_options)
 		pref.update_preview_icon()
+
+/obj/screen/lighting_plane_master
+	screen_loc = "CENTER"
+	appearance_flags = PLANE_MASTER
+	mouse_opacity = 0
+	plane = LIGHTING_PLANE
+	blend_mode = BLEND_MULTIPLY
+	alpha = 255
+
+/obj/screen/lighting_plane_master/proc/set_alpha(var/newalpha)
+	if(alpha != newalpha)
+		animate(src, alpha = newalpha, time = SSmobs.wait)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -910,9 +910,9 @@ var/global/list/gamemode_cache = list()
 				if("grant_default_darksight")
 					config.grant_default_darksight = TRUE
 				if("default_darksight_range")
-					config.default_darksight_range = text2num(value)
+					config.default_darksight_range = max(text2num(value), 0)
 				if("default_darksight_effectiveness")
-					config.default_darksight_effectiveness = text2num(value)
+					config.default_darksight_effectiveness = clamp(text2num(value), 0, 1)
 				else
 					log_misc("Unknown setting in configuration: '[name]'")
 

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -253,7 +253,9 @@ var/global/list/gamemode_cache = list()
 	var/no_throttle_localhost
 
 	var/dex_malus_brainloss_threshold = 30 //The threshold of when brainloss begins to affect dexterity.
-	var/grant_basic_darksight = FALSE
+	var/grant_default_darksight = FALSE
+	var/default_darksight_range = 2
+	var/default_darksight_effectiveness = 0.05
 
 	var/static/list/protected_vars = list(
 		"comms_password",
@@ -905,8 +907,12 @@ var/global/list/gamemode_cache = list()
 					config.use_loyalty_implants = 1
 				if("dexterity_malus_brainloss_threshold")
 					config.dex_malus_brainloss_threshold = text2num(value)
-				if("grant_basic_darksight")
-					config.grant_basic_darksight = TRUE
+				if("grant_default_darksight")
+					config.grant_default_darksight = TRUE
+				if("default_darksight_range")
+					config.default_darksight_range = text2num(value)
+				if("default_darksight_effectiveness")
+					config.default_darksight_effectiveness = text2num(value)
 				else
 					log_misc("Unknown setting in configuration: '[name]'")
 

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -253,6 +253,7 @@ var/global/list/gamemode_cache = list()
 	var/no_throttle_localhost
 
 	var/dex_malus_brainloss_threshold = 30 //The threshold of when brainloss begins to affect dexterity.
+	var/grant_basic_darksight = FALSE
 
 	var/static/list/protected_vars = list(
 		"comms_password",
@@ -904,7 +905,8 @@ var/global/list/gamemode_cache = list()
 					config.use_loyalty_implants = 1
 				if("dexterity_malus_brainloss_threshold")
 					config.dex_malus_brainloss_threshold = text2num(value)
-
+				if("grant_basic_darksight")
+					config.grant_basic_darksight = TRUE
 				else
 					log_misc("Unknown setting in configuration: '[name]'")
 

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -9,7 +9,7 @@
 	plane         = LIGHTING_PLANE
 	invisibility  = INVISIBILITY_LIGHTING
 	simulated     = FALSE
-	blend_mode    = BLEND_MULTIPLY
+	blend_mode    = BLEND_OVERLAY
 
 	var/needs_update = FALSE
 

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -186,8 +186,36 @@
 
 	handle_hud_icons()
 	handle_vision()
+	handle_low_light_vision()
 
 	return 1
+
+/mob/living/proc/handle_low_light_vision()
+
+	// No client means nothing to update.
+	if(!client || !lighting_master)
+		return
+
+	// No loc or species means we should just assume no adjustment.
+	var/decl/species/species = get_species()
+	var/turf/my_turf = get_turf(src)
+	if(!isturf(my_turf) || !species)
+		lighting_master.set_alpha(255)
+		return
+
+	// TODO: handling for being inside atoms.
+	var/target_value = 255 * (1-species.base_low_light_vision)
+	var/loc_lumcount = my_turf.get_lumcount()
+	if(loc_lumcount < species.low_light_vision_threshold)
+		target_value = round(target_value * (1-species.low_light_vision_effectiveness))
+
+	if(lighting_master.alpha == target_value)
+		return
+
+	var/difference = round((target_value-lighting_master.alpha) * species.low_light_vision_adjustment_speed)
+	if(abs(difference) > 1)
+		target_value = lighting_master.alpha + difference
+	lighting_master.set_alpha(target_value)
 
 /mob/living/proc/handle_vision()
 	update_sight()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -724,6 +724,7 @@ default behaviour is:
 	if(auras)
 		for(var/a in auras)
 			remove_aura(a)
+	QDEL_NULL(lighting_master)
 	return ..()
 
 /mob/living/proc/melee_accuracy_mods()
@@ -1079,3 +1080,9 @@ default behaviour is:
 
 /mob/living/get_speech_bubble_state_modifier()
 	return isSynthetic() ? "synth" : ..()
+
+/mob/living/proc/refresh_lighting_master()
+	if(!lighting_master)
+		lighting_master = new
+	if(client)
+		client.screen |= lighting_master

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -47,3 +47,5 @@
 	var/list/chem_doses
 	var/last_pain_message
 	var/next_pain_time = 0
+
+	var/obj/screen/lighting_plane_master/lighting_master

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -19,3 +19,4 @@
 		weather.mob_shown_weather -=     mob_ref
 		weather.mob_shown_wind -=        mob_ref
 	global.current_mob_ambience -= mob_ref
+	refresh_lighting_master()

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -99,6 +99,7 @@
 	appearance = LO
 	layer = MIMICED_LIGHTING_LAYER
 	plane = OPENTURF_MAX_PLANE
+	blend_mode = BLEND_MULTIPLY
 	invisibility = 0
 
 	if (icon_state == LIGHTING_BASE_ICON_STATE)

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -35,6 +35,12 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	var/flesh_color = "#ffc896"             // Pink.
 	var/blood_oxy = 1
 
+	// Darksight handling
+	var/base_low_light_vision = 0
+	var/low_light_vision_threshold = 0.3
+	var/low_light_vision_effectiveness = 0
+	var/low_light_vision_adjustment_speed = 0.15
+
 	// Used for initializing prefs/preview
 	var/base_color =      COLOR_BLACK
 	var/base_eye_color =  COLOR_BLACK
@@ -348,6 +354,10 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 /decl/species/Initialize()
 
 	. = ..()
+
+	if(config.grant_basic_darksight)
+		darksight_range = max(darksight_range, 2)
+		low_light_vision_effectiveness = max(low_light_vision_effectiveness, 0.05)
 
 	// Populate blood type table.
 	for(var/blood_type in blood_types)

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -36,9 +36,13 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	var/blood_oxy = 1
 
 	// Darksight handling
+	/// Fractional multiplier (0 to 1) for the base alpha of the darkness overlay. A value of 1 means darkness is completely invisible.
 	var/base_low_light_vision = 0
+	/// The lumcount (turf luminosity) threshold under which adaptive low light vision will begin processing.
 	var/low_light_vision_threshold = 0.3
+	/// Fractional multiplier for the overall effectiveness of low light vision for this species. Caps the final alpha value of the darkness plane.
 	var/low_light_vision_effectiveness = 0
+	/// The rate at which low light vision adjusts towards the final value, as a fractional multiplier of the difference between the current and target alphas. ie. set to 0.15 for a 15% shift towards the target value each tick.
 	var/low_light_vision_adjustment_speed = 0.15
 
 	// Used for initializing prefs/preview
@@ -355,9 +359,9 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 
 	. = ..()
 
-	if(config.grant_basic_darksight)
-		darksight_range = max(darksight_range, 2)
-		low_light_vision_effectiveness = max(low_light_vision_effectiveness, 0.05)
+	if(config.grant_default_darksight)
+		darksight_range = max(darksight_range, config.default_darksight_range)
+		low_light_vision_effectiveness = max(low_light_vision_effectiveness, config.default_darksight_effectiveness)
 
 	// Populate blood type table.
 	for(var/blood_type in blood_types)
@@ -470,6 +474,27 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 		var/decl/trait/T = GET_DECL(trait_type)
 		if(!T.validate_level(trait_level))
 			. += "invalid levels for species trait [trait_type]"
+
+
+	if(base_low_light_vision > 1)
+		. += "base low light vision is greater 1 (over 100%)"
+	else if(base_low_light_vision < 0)
+		. += "base low light vision is less than 0 (below 0%)"
+
+	if(low_light_vision_threshold > 1)
+		. += "low light vision threshold is greater 1 (over 100%)"
+	else if(low_light_vision_threshold < 0)
+		. += "low light vision threshold is less than 0 (below 0%)"
+
+	if(low_light_vision_effectiveness > 1)
+		. += "low light vision effectiveness is greater 1 (over 100%)"
+	else if(low_light_vision_effectiveness < 0)
+		. += "low light vision effectiveness is less than 0 (below 0%)"
+
+	if(low_light_vision_adjustment_speed > 1)
+		. += "low light vision adjustment speed is greater 1 (over 100%)"
+	else if(low_light_vision_adjustment_speed < 0)
+		. += "low light vision adjustment speed is less than 0 (below 0%)"
 
 /decl/species/proc/equip_survival_gear(var/mob/living/carbon/human/H, var/box_type = /obj/item/storage/box/survival)
 	var/obj/item/storage/backpack/backpack = H.get_equipped_item(slot_back_str)

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -477,22 +477,22 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 
 
 	if(base_low_light_vision > 1)
-		. += "base low light vision is greater 1 (over 100%)"
+		. += "base low light vision is greater than 1 (over 100%)"
 	else if(base_low_light_vision < 0)
 		. += "base low light vision is less than 0 (below 0%)"
 
 	if(low_light_vision_threshold > 1)
-		. += "low light vision threshold is greater 1 (over 100%)"
+		. += "low light vision threshold is greater than 1 (over 100%)"
 	else if(low_light_vision_threshold < 0)
 		. += "low light vision threshold is less than 0 (below 0%)"
 
 	if(low_light_vision_effectiveness > 1)
-		. += "low light vision effectiveness is greater 1 (over 100%)"
+		. += "low light vision effectiveness is greater than 1 (over 100%)"
 	else if(low_light_vision_effectiveness < 0)
 		. += "low light vision effectiveness is less than 0 (below 0%)"
 
 	if(low_light_vision_adjustment_speed > 1)
-		. += "low light vision adjustment speed is greater 1 (over 100%)"
+		. += "low light vision adjustment speed is greater than 1 (over 100%)"
 	else if(low_light_vision_adjustment_speed < 0)
 		. += "low light vision adjustment speed is less than 0 (below 0%)"
 

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -93,4 +93,8 @@ MAX_CLIENT_VIEW_Y 30
 #DEXTERITY_MALUS_BRAINLOSS_THRESHOLD 30
 
 ## Whether or not all human mobs have very basic darksight by default.
-#GRANT_BASIC_DARKSIGHT
+#GRANT_DEFAULT_DARKSIGHT
+
+## The range and effectiveness of default darksight if above is uncommented.
+#DEFAULT_DARKSIGHT_EFFECTIVENESS 0.05
+#DEFAULT_DARKSIGHT_RANGE 2

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -47,7 +47,7 @@ REVIVAL_BRAIN_LIFE -1
 ## These values get directly added to values and totals in-game. To speed things up make the number negative, to slow things down, make the number positive.
 
 
-## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied. 
+## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied.
 RUN_DELAY 2
 WALK_DELAY 4
 CREEP_DELAY 6
@@ -91,3 +91,6 @@ MAX_CLIENT_VIEW_Y 30
 
 ## Threshold of where brain damage begins to affect dexterity (70 brainloss above this means zero dexterity). Default is 30.
 #DEXTERITY_MALUS_BRAINLOSS_THRESHOLD 30
+
+## Whether or not all human mobs have very basic darksight by default.
+#GRANT_BASIC_DARKSIGHT

--- a/mods/species/bayliens/tajaran/datum/species.dm
+++ b/mods/species/bayliens/tajaran/datum/species.dm
@@ -16,6 +16,9 @@
 	name_plural = "Tajaran"
 	base_prosthetics_model = null
 
+	low_light_vision_effectiveness = 0.15
+	low_light_vision_adjustment_speed = 0.3
+
 	description = "A small mammalian carnivore. If you are reading this, you are probably a Tajaran."
 	hidden_from_codex = FALSE
 


### PR DESCRIPTION
## Description of changes
This is a super super barebones implementation of adaptive darksight. Being a Tajaran (or enabling base darksight in the config) will allow you to slowly see better in the dark, up to a point. This just sets alpha on a plane master, an overlay based implementation would be desirable but I am hacking this out to get the functionality in place.

## Why and what will this PR improve
This was a feature on Neb prior to O7lights and it turned out it was removed by default rather than for a functional or technical reason, so I'm re-adding it because several people including me are missing it.

## Authorship
Myself, with reference to Citadel-RP's implementation.

## Changelog
:cl:
add: Tajarans can now see better in the dark, after an adjustment period.
/:cl: