### PR TITLE
Fixes issues with tails not updating on pref change.

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -237,7 +237,7 @@ var/global/list/time_prefs_fixed = list()
 /datum/preferences/proc/update_setup_window(mob/user)
 	send_output(user, url_encode(get_content(user)), "preferences_browser:update_content")
 
-/datum/preferences/proc/update_character_previews(mutable_appearance/MA)
+/datum/preferences/proc/update_character_previews(mob/living/mannequin)
 	if(!client)
 		return
 
@@ -258,6 +258,8 @@ var/global/list/time_prefs_fixed = list()
 			O.pref = src
 			LAZYSET(char_render_holders, "[D]", O)
 			client.screen |= O
+		mannequin.set_dir(D) // necessary to update direction-dependent over/underlays like tails.
+		var/mutable_appearance/MA = new /mutable_appearance(mannequin)
 		O.appearance = MA
 		O.dir = D
 		O.screen_loc = preview_screen_locs["[D]"]

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -103,7 +103,7 @@
 	if(mannequin)
 		mannequin.delete_inventory(TRUE)
 		dress_preview_mob(mannequin)
-		update_character_previews(new /mutable_appearance(mannequin))
+		update_character_previews(mannequin)
 
 /datum/preferences/proc/get_random_name()
 	var/decl/cultural_info/culture/check_culture = cultural_info[TAG_CULTURE]


### PR DESCRIPTION
## Description of changes
Mannequins now set dir between setting appearances on the prefs preview page.

## Why and what will this PR improve
Fixes tails being inconsistent because set_dir() was never called on the owner.
Fixes #2075 

## Authorship
Myself.

## Changelog
Nothing player-facing.