### PR TITLE
Fixes runtime in area/Entered

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -319,24 +319,20 @@ var/global/list/areas = list()
 var/global/list/mob/living/forced_ambiance_list = new
 
 /area/Entered(A)
-	if(!istype(A,/mob/living))	return
-
+	if(!istype(A,/mob/living))
+		return
 	var/mob/living/L = A
-
 	if(!L.lastarea)
 		L.lastarea = get_area(L.loc)
-	var/area/newarea = get_area(L.loc)
 	var/area/oldarea = L.lastarea
-	if(oldarea.has_gravity != newarea.has_gravity)
-		if(newarea.has_gravity == 1 && !MOVING_DELIBERATELY(L)) // Being ready when you change areas allows you to avoid falling.
+	if(!oldarea || oldarea.has_gravity != has_gravity)
+		if(has_gravity == 1 && !MOVING_DELIBERATELY(L)) // Being ready when you change areas allows you to avoid falling.
 			thunk(L)
 		L.update_floating()
-
 	if(L.ckey)
 		play_ambience(L)
 		do_area_blurb(L)
-
-	L.lastarea = newarea
+	L.lastarea = src
 
 
 /area/Exited(A)


### PR DESCRIPTION
## Description of changes
Fixes a runtime observed in CI by nullchecking the mob's previous area. I am assuming this is happening when mobs move out of nullspace when created inside another atom but I'm not sure.

Runtime is:
````
[00:00:00] Runtime in areas.dm,330: Cannot read null.has_gravity
  proc name: Entered (/area/Entered)
  src: the Space (/area/space)
  call stack:
  the Space (/area/space): Entered( (/mob/living/carbon/human/corpse), the airless plating (69,108,25) (/turf/simulated/floor/airless/ceiling))
   (/mob/living/carbon/human/corpse): forceMove(space (136,6,25) (/turf/space))
   (/mob/living/carbon/human/corpse): forceMove(space (136,6,25) (/turf/space))
   (/mob/living/carbon/human/corpse): forceMove(space (136,6,25) (/turf/space))
   (/mob/living/carbon/human/corpse): forceMove(space (136,6,25) (/turf/space))
  teleport (/datum/artifact_effect/teleport): teleport away( (/mob/living/carbon/human/corpse))
  teleport (/datum/artifact_effect/teleport): DoEffectAura()
  teleport (/datum/artifact_effect/teleport): process()
  the alien computer (/obj/structure/artifact): Process(10, 0, Objs (/datum/controller/subsystem/processing/obj))
  Objs (/datum/controller/subsystem/processing/obj): fire(1)
  Objs (/datum/controller/subsystem/processing/obj): ignite(1)
  Master (/datum/controller/master): RunQueue()
  Master (/datum/controller/master): Loop()
  Master (/datum/controller/master): StartProcessing(0)
````

## Why and what will this PR improve
Bugfix.

## Authorship
Myself.

## Changelog
Nothing player-facing.