### PR TITLE
Improving some aspects of chemsmoke code.

### DIFF
--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -34,8 +34,7 @@
 /obj/effect/effect/smoke/chem/Destroy()
 	walk(src, 0) // Because we might have called walk_to, we must stop the walk loop or BYOND keeps an internal reference to us forever.
 	set_opacity(0)
-	// TODO - fadeOut() sleeps.  Sleeping in /Destroy is Bad, this needs to be fixed.
-	fadeOut()
+	set_density(0)
 	return ..()
 
 /obj/effect/effect/smoke/chem/Move()
@@ -62,14 +61,15 @@
 				reagents.splash(AM, splash_amount, copy = 1)
 
 // Fades out the smoke smoothly using it's alpha variable.
-/obj/effect/effect/smoke/chem/proc/fadeOut(var/frames = 16)
-	if(!alpha) return //already transparent
-
-	frames = max(frames, 1) //We will just assume that by 0 frames, the coder meant "during one frame".
-	var/alpha_step = round(alpha / frames)
-	while(alpha > 0)
-		alpha = max(0, alpha - alpha_step)
-		sleep(world.tick_lag)
+/obj/effect/effect/smoke/chem/end_of_life()
+	if(QDELETED(src))
+		return
+	walk(src, 0) // Because we might have called walk_to, we must stop the walk loop or BYOND keeps an internal reference to us forever.
+	set_opacity(0)
+	set_density(0)
+	animate(src, alpha = 0, time = 0.5 SECONDS)
+	sleep(0.5 SECONDS)
+	..()
 
 /////////////////////////////////////////////
 // Chem Smoke Effect System

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -182,7 +182,11 @@ steam.start() -- spawns the effect
 	. = ..()
 	if(smoke_duration)
 		time_to_live = smoke_duration
-	QDEL_IN(src, time_to_live)
+	addtimer(CALLBACK(src, .proc/end_of_life), time_to_live)
+
+/obj/effect/effect/smoke/proc/end_of_life()
+	if(!QDELETED(src))
+		qdel(src)
 
 /obj/effect/effect/smoke/Crossed(mob/living/carbon/M)
 	..()


### PR DESCRIPTION
## Description of changes
- Smoke now clears density and opacity on cleanup.
- Chemsmoke no longer sleeps in Destroy().

## Why and what will this PR improve
General code quality.
Also appears to fix https://github.com/ScavStation/ScavStation/issues/685

## Authorship
Myself.

## Changelog
Nothing player-facing.