### PR TITLE
Modernize various old/unmaintained bits of code

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -319,21 +319,21 @@ var/global/list/areas = list()
 
 var/global/list/mob/living/forced_ambiance_list = new
 
-/area/Entered(A)
-	if(!istype(A,/mob/living))
+/area/Entered(atom/movable/enterer)
+	if(!istype(enterer,/mob/living))
 		return
-	var/mob/living/L = A
-	if(!L.lastarea)
-		L.lastarea = get_area(L.loc)
-	var/area/oldarea = L.lastarea
+	var/mob/living/living_enterer = enterer
+	if(!living_enterer.lastarea)
+		living_enterer.lastarea = get_area(living_enterer.loc)
+	var/area/oldarea = living_enterer.lastarea
 	if(!oldarea || oldarea.has_gravity != has_gravity)
-		if(has_gravity == 1 && !MOVING_DELIBERATELY(L)) // Being ready when you change areas allows you to avoid falling.
-			thunk(L)
-		L.update_floating()
-	if(L.ckey)
-		play_ambience(L)
-		do_area_blurb(L)
-	L.lastarea = src
+		if(has_gravity == 1 && !MOVING_DELIBERATELY(living_enterer)) // Being ready when you change areas allows you to avoid falling.
+			thunk(living_enterer)
+		living_enterer.update_floating()
+	if(living_enterer.ckey)
+		play_ambience(living_enterer)
+		do_area_blurb(living_enterer)
+	living_enterer.lastarea = src
 
 
 /area/Exited(A)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -320,7 +320,7 @@ var/global/list/areas = list()
 var/global/list/mob/living/forced_ambiance_list = new
 
 /area/Entered(atom/movable/enterer)
-	if(!istype(enterer,/mob/living))
+	if(!isliving(enterer))
 		return
 	var/mob/living/living_enterer = enterer
 	if(!living_enterer.lastarea)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1048,7 +1048,7 @@ FIRE ALARM
 	return TRUE
 
 /obj/machinery/partyalarm/interact(mob/user)
-	user.machine = src
+	user.set_machine(src)
 	var/area/A = get_area(src)
 	ASSERT(isarea(A))
 	var/d1

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -151,7 +151,7 @@ var/global/const/HOLOPAD_MODE = RANGE_BASED
 
 /obj/machinery/hologram/holopad/proc/take_call(mob/living/carbon/user)
 	incoming_connection = 0
-	caller_id.machine = sourcepad
+	caller_id.set_machine(sourcepad)
 	caller_id.reset_view(src)
 	if(!masters[caller_id])//If there is no hologram, possibly make one.
 		activate_holocall(caller_id)

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -121,22 +121,21 @@
 
 /obj/machinery/media/jukebox/proc/emag_play()
 	playsound(loc, 'sound/items/AirHorn.ogg', 100, 1)
-	for(var/mob/living/carbon/M in ohearers(6, src))
-		if(istype(M, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = M
-			if(H.get_sound_volume_multiplier() < 0.2)
+	for(var/mob/living/carbon/carbon_hearer in ohearers(6, src))
+		if(istype(carbon_hearer, /mob/living/carbon/human))
+			var/mob/living/carbon/human/human_hearer = carbon_hearer
+			if(human_hearer.get_sound_volume_multiplier() < 0.2)
 				continue
-		M.set_status(STAT_ASLEEP,    0)
-		ADJ_STATUS(M, STAT_STUTTER,  20)
-		SET_STATUS_MAX(M, STAT_DEAF, 30)
-		SET_STATUS_MAX(M, STAT_WEAK,  3)
+		carbon_hearer.set_status(STAT_ASLEEP,    0)
+		ADJ_STATUS(carbon_hearer, STAT_STUTTER,  20)
+		SET_STATUS_MAX(carbon_hearer, STAT_DEAF, 30)
+		SET_STATUS_MAX(carbon_hearer, STAT_WEAK,  3)
 		if(prob(30))
-			SET_STATUS_MAX(M, STAT_STUN, 10)
-			SET_STATUS_MAX(M, STAT_PARA,  4)
+			SET_STATUS_MAX(carbon_hearer, STAT_STUN, 10)
+			SET_STATUS_MAX(carbon_hearer, STAT_PARA,  4)
 		else
-			M.set_status(STAT_JITTER, 400)
-	spawn(15)
-		explode()
+			carbon_hearer.set_status(STAT_JITTER, 400)
+	addtimer(CALLBACK(src, .proc/explode), 1.5 SECONDS)
 
 /obj/machinery/media/jukebox/interface_interact(var/mob/user)
 	ui_interact(user)

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -122,7 +122,7 @@
 /obj/machinery/media/jukebox/proc/emag_play()
 	playsound(loc, 'sound/items/AirHorn.ogg', 100, 1)
 	for(var/mob/living/carbon/carbon_hearer in ohearers(6, src))
-		if(istype(carbon_hearer, /mob/living/carbon/human))
+		if(ishuman(carbon_hearer))
 			var/mob/living/carbon/human/human_hearer = carbon_hearer
 			if(human_hearer.get_sound_volume_multiplier() < 0.2)
 				continue

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -31,7 +31,7 @@
 	var/turf/our_turf = get_turf(src)
 	if(!istype(our_turf)) // don't fire in nullspace or in a closet etc
 		return
-	for(var/atom/movable/movable_to_throw in our_turf.get_contained_external_atoms())
+	for(var/atom/movable/movable_to_throw as anything in our_turf.get_contained_external_atoms())
 		if(!movable_to_throw.anchored)
 			if(++thrown_count >= 20)
 				audible_message(SPAN_NOTICE("The mass driver lets out a screech, it must not be able to handle any more items."), SPAN_NOTICE("The mass driver shudders and strains!"))

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -26,17 +26,18 @@
 	if(stat & (BROKEN|NOPOWER))
 		return
 	use_power_oneoff(500)
-	var/O_limit
+	var/thrown_count
 	var/atom/target = get_edge_target_turf(src, dir)
-	for(var/atom/movable/O in loc)
-		if(!O.anchored)
-			O_limit++
-			if(O_limit >= 20)
-				visible_message(SPAN_NOTICE("\The [src] lets out a mechanical groan and refuses to budge!"))
+	var/turf/our_turf = get_turf(src)
+	if(!istype(our_turf)) // don't fire in nullspace or in a closet etc
+		return
+	for(var/atom/movable/movable_to_throw in our_turf.get_contained_external_atoms())
+		if(!movable_to_throw.anchored)
+			if(++thrown_count >= 20)
+				audible_message(SPAN_NOTICE("The mass driver lets out a screech, it must not be able to handle any more items."), SPAN_NOTICE("The mass driver shudders and strains!"))
 				break
 			use_power_oneoff(500)
-			spawn( 0 )
-				O.throw_at(target, drive_range * power, power)
+			movable_to_throw.throw_at(target, drive_range * power, power)
 	flick("mass_driver1", src)
 	return
 

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -124,9 +124,19 @@ var/global/list/allCasters = list() //Global list that will contain reference to
 		// 6 = ERROR: Cannot create feed story
 		// 7 = ERROR: Cannot create feed channel
 		// 8 = print newspaper
-		// 9 = viewing channel feeds
-		// 10 = censor feed story
-		// 11 = censor feed channel
+		// 9 = viewing channel stories
+		// 10 = select feed to censor story from
+		// 11 = d-notice channel list
+		// 12 = censor feed story
+		// 13 = d-notice feed view
+		// 14 = wanted issue menu
+		// 15 = wanted issue created successfully
+		// 16 = ERROR: Cannot create wanted issue
+		// 17 = wanted issue cancelled successfully
+		// 18 = view wanted issue
+		// 19 = edit wanted issue
+		// 20 = print successful
+		// 21 = ERROR: Printer out of paper
 		//Holy shit this is outdated, made this when I was still starting newscasters :3
 	var/paper_remaining = 0
 	var/securityCaster = 0
@@ -888,7 +898,7 @@ var/global/list/allCasters = list() //Global list that will contain reference to
 				src.scribble = s
 				src.attack_self(user)
 				return TRUE
-			return 
+			return
 	return ..()
 
 ////////////////////////////////////helper procs

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -692,9 +692,12 @@ var/global/list/_item_blood_mask = icon('icons/effects/blood.dmi', "itemblood")
 	global._blood_overlay_cache[cache_key] = blood_overlay
 
 /obj/item/proc/showoff(mob/user)
-	for(var/mob/M in view(user))
-		if(!user.is_invisible_to(M))
-			M.show_message("[user] holds up [src]. <a HREF=?src=\ref[M];lookitem=\ref[src]>Take a closer look.</a>", 1)
+	for(var/mob/mob_viewer in view(user))
+		if(mob_viewer == src)
+			to_chat(mob_viewer, "You hold up \the [src].")
+			continue
+		if(!user.is_invisible_to(mob_viewer))
+			mob_viewer.show_message("<b>\The [user]</b> holds up \the [src]. <a HREF=?src=\ref[mob_viewer];lookitem=\ref[src]>Take a closer look.</a>", 1)
 
 /*
 For zooming with scope or binoculars. This is called from

--- a/code/game/objects/items/devices/spy_bug.dm
+++ b/code/game/objects/items/devices/spy_bug.dm
@@ -17,8 +17,8 @@
 	origin_tech = "{'programming':1,'engineering':1,'esoteric':3}"
 	material = /decl/material/solid/plastic
 	matter = list(
-		/decl/material/solid/metal/copper    = MATTER_AMOUNT_REINFORCEMENT, 
-		/decl/material/solid/silicon         = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/metal/copper    = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/silicon         = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/glass           = MATTER_AMOUNT_TRACE,
 	)
 
@@ -128,7 +128,7 @@
 	view_camera(user)
 
 /obj/item/spy_monitor/proc/view_camera(mob/user)
-	user.machine = src
+	user.set_machine(src)
 	user.reset_view(selected_camera)
 
 /obj/item/spy_monitor/check_eye(mob/user)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -210,8 +210,8 @@
 
 		src.produce_recipe(R, multiplier, usr)
 
-	if(!QDELETED(src))
-		interact(usr)
+	if (!QDELETED(src) && usr.machine == src) // refresh our window if it's open
+		list_recipes(usr)
 
 /**
  * Return 1 if an immediate subsequent call to use() would succeed.
@@ -386,9 +386,8 @@
 				user.put_in_hands(F)
 				src.add_fingerprint(user)
 				F.add_fingerprint(user)
-				spawn(0)
-					if (src && usr.machine==src)
-						src.interact(usr)
+				if (!QDELETED(src) && user.machine == src)
+					list_recipes(user)
 				return TRUE
 		return FALSE
 	return ..()
@@ -399,11 +398,11 @@
 		var/obj/item/stack/S = W
 		. = src.transfer_to(S)
 
-		spawn(0) //give the stacks a chance to delete themselves if necessary
-			if (S && usr.machine==S)
-				S.interact(usr)
-			if (src && usr.machine==src)
-				src.interact(usr)
+		//give the stacks a chance to delete themselves if necessary
+		if (!QDELETED(S) && usr.machine == S)
+			S.list_recipes(user)
+		if (!QDELETED(src) && usr.machine == src)
+			list_recipes(user)
 		return
 
 	return ..()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -50,13 +50,13 @@
 	if(in_use)
 		var/is_in_use = 0
 		var/list/nearby = viewers(1, src) | usr
-		for(var/mob/M in nearby)
-			if ((M.client && M.machine == src))
-				if(CanUseTopic(M, DefaultTopicState()) > STATUS_CLOSE)
+		for(var/mob/mob_viewer in nearby)
+			if ((mob_viewer.client && mob_viewer.machine == src))
+				if(CanUseTopic(mob_viewer, DefaultTopicState()) > STATUS_CLOSE)
 					is_in_use = 1
-					interact(M)
+					interact(mob_viewer)
 				else
-					M.unset_machine()
+					mob_viewer.unset_machine()
 		in_use = is_in_use
 
 /obj/proc/updateDialog()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -51,7 +51,7 @@
 		var/is_in_use = 0
 		var/list/nearby = viewers(1, src) | usr
 		for(var/mob/mob_viewer in nearby)
-			if ((mob_viewer.client && mob_viewer.machine == src))
+			if (mob_viewer.client && mob_viewer.machine == src)
 				if(CanUseTopic(mob_viewer, DefaultTopicState()) > STATUS_CLOSE)
 					is_in_use = 1
 					interact(mob_viewer)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -10,7 +10,7 @@
 		return
 
 	if(machine && (machine.CanUseTopic(src, machine.DefaultTopicState()) == STATUS_CLOSE)) // unsure if this is a good idea, but using canmousedrop was ???
-		machine = null
+		unset_machine()
 
 	//Handle temperature/pressure differences between body and environment
 	handle_environment(loc.return_air())

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -95,13 +95,15 @@
 						visible_emote("stares at the [movement_target] that [movement_target.loc] has with sad puppy eyes.")
 
 		if(prob(1))
-			INVOKE_ASYNC(src, .proc/dance)
+			dance(18)
 
 /mob/living/simple_animal/corgi/proc/dance(ticks)
+	set waitfor = FALSE
 	visible_emote(pick("dances around.","chases their tail."))
-	var/static/list/routine = list(1,2,4,8,4,2) // repeats
-	for(var/i in 1 to ticks)
-		set_dir(routine[i % length(routine)])
+	var/static/list/routine = list(NORTH,SOUTH,EAST,WEST,EAST,SOUTH) // repeats
+	var/step_count = length(routine)
+	for(var/i in 0 to ticks)
+		set_dir(routine[1 + (i % step_count)])
 		sleep(1)
 		if(QDELETED(src) || client) // stop dancing if we don't exist or are player controlled
 			return

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -48,11 +48,12 @@
 	OnDeathInLife()
 
 /mob/living/simple_animal/shade/proc/OnDeathInLife()
-	if(stat == 2)
-		new /obj/item/ectoplasm (src.loc)
-		for(var/mob/M in viewers(src, null))
-			if((M.client && !( M.blinded )))
-				M.show_message("<span class='warning'>[src] lets out a contented sigh as their form unwinds.</span>")
-				ghostize()
-		qdel(src)
+	if(stat != DEAD)
 		return
+	var/obj/item/ectoplasm/dropped_ectoplasm = new
+	dropped_ectoplasm.dropInto(loc)
+	audible_message(SPAN_WARNING("[src] lets out a contented sigh as their form unwinds."),
+		SPAN_NOTICE("You let out a contented sigh as your form unwinds."),
+		SPAN_WARNING("The [src] unravels before your very eyes."))
+	ghostize()
+	qdel(src)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -116,30 +116,26 @@
 	var/list/objs = list()
 	get_mobs_and_objs_in_view_fast(T, range, mobs, objs, checkghosts)
 
-	for(var/o in objs)
-		var/obj/O = o
-		O.show_message(message, VISIBLE_MESSAGE, blind_message, AUDIBLE_MESSAGE)
+	for(var/obj/obj_viewer as anything in objs)
+		obj_viewer.show_message(message, VISIBLE_MESSAGE, blind_message, AUDIBLE_MESSAGE)
 
-	for(var/m in mobs)
-		var/mob/M = m
+	for(var/mob/mob_viewer as anything in mobs)
 		var/mob_message = message
 
-		if(isghost(M))
-			if(ghost_skip_message(M))
+		if(isghost(mob_viewer))
+			if(ghost_skip_message(mob_viewer))
 				continue
-			mob_message = add_ghost_track(mob_message, M)
+			mob_message = add_ghost_track(mob_message, mob_viewer)
 
-		if(self_message && M == src)
-			M.show_message(self_message, VISIBLE_MESSAGE, blind_message, AUDIBLE_MESSAGE)
+		if(self_message && mob_viewer == src)
+			mob_viewer.show_message(self_message, VISIBLE_MESSAGE, blind_message, AUDIBLE_MESSAGE)
 			continue
 
-		if(!M.is_blind() || narrate)
-			M.show_message(mob_message, VISIBLE_MESSAGE, blind_message, AUDIBLE_MESSAGE)
+		if(!narrate && (mob_viewer.is_blind() || is_invisible_to(mob_viewer)) && blind_message)
+			mob_viewer.show_message(blind_message, AUDIBLE_MESSAGE)
 			continue
 
-		if(blind_message)
-			M.show_message(blind_message, AUDIBLE_MESSAGE)
-			continue
+		mob_viewer.show_message(mob_message, VISIBLE_MESSAGE, blind_message, AUDIBLE_MESSAGE)
 	//Multiz, have shadow do same
 	if(bound_overlay)
 		bound_overlay.visible_message(message, self_message, blind_message)

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -57,7 +57,7 @@
 		ui.set_initial_data(data)
 		ui.open()
 
-	user.machine = nano_host()
+	user.set_machine(nano_host())
 
 /datum/nano_module/program/camera_monitor/Topic(href, href_list)
 	if(..())

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -156,11 +156,11 @@
 /obj/machinery/turbine/interact(mob/user)
 
 	if ( (get_dist(src, user) > 1 ) || (stat & (NOPOWER|BROKEN)) && (!istype(user, /mob/living/silicon/ai)) )
-		user.machine = null
+		user.unset_machine()
 		close_browser(user, "window=turbine")
 		return
 
-	user.machine = src
+	user.set_machine(src)
 
 	var/t = "<TT><B>Gas Turbine Generator</B><HR><PRE>"
 
@@ -221,7 +221,7 @@
 	return TRUE
 
 /obj/machinery/computer/turbine_computer/interact(var/mob/user)
-	user.machine = src
+	user.set_machine(src)
 	var/dat
 	if(src.compressor)
 		dat += {"<BR><B>Gas turbine remote control system</B><HR>

--- a/mods/mobs/borers/mob/borer/borer.dm
+++ b/mods/mobs/borers/mob/borer/borer.dm
@@ -94,7 +94,7 @@
 	generation = gen
 	set_borer_name()
 
-	if(!roundstart) 
+	if(!roundstart)
 		request_player()
 
 /mob/living/simple_animal/borer/Destroy()
@@ -257,10 +257,10 @@
 	dropInto(host.loc)
 
 	reset_view(null)
-	machine = null
+	unset_machine()
 
 	host.reset_view(null)
-	host.machine = null
+	host.unset_machine()
 
 	var/mob/living/H = host
 	H.status_flags &= ~PASSEMOTES


### PR DESCRIPTION
## Description of changes
Modularizes code that stuck out to me as particularly unmaintained.
Currently entirely untested.

## Why and what will this PR improve
- Documents all the newscaster screens in preparation for migrating it to NanoUI.
- Updates the mass driver /drive proc to meet code quality standards.
    - [ ] Tested
- Modernize corgi code to avoid unnecessary blocking/sleeps in attackby and reduce code duplication.
    - [ ] Tested
- Modernize shade code to use audible_message instead of a bespoke reimplementation + meet code quality standards
    - [ ] Tested
- Modernize the jukebox emag code to use a timer instead of a spawn + have better variable names.
    - [ ] Tested
- Rename/repath variables in the mob ambience /area/Entered override to be clearer.
- Update /mob/visible_message for cleaner control flow and readability
    - [ ] Tested
- Update /obj/item/proc/showoff to be more readable, give the user a second-person message, and make it appear more like any other emote.
    - [ ] Tested
- Replaced all instances of `mob.machine = ` with `set_machine()` and `unset_machine()` so that code using machine actually works.
    - [ ] Tested
- Rewrote broken stack recipe list auto-refresh code to actually work.
    - [ ] Tested

## Authorship
Me.

## Changelog
No changelog. None of this should be user-facing except for bugfixes.