### PR TITLE
Fixes items appearing heavily damaged

### DIFF
--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -208,7 +208,7 @@
 	var/desc_comp = "" //For "description composite"
 	desc_comp += "It is a [w_class_description()] item."
 
-	var/desc_damage = get_examined_damage_string()
+	var/desc_damage = get_examined_damage_string(health / max_health)
 	if(length(desc_damage))
 		desc_comp += "<BR/>[desc_damage]"
 


### PR DESCRIPTION
## Description of changes
Fixes items appearing heavily damaged regardless of their actual health.

## Changelog
:cl:
bugfix: Items no longer appear heavily damaged regardless of their health
/:cl: