### PR TITLE
Fixes and refactors for radio message_mode code.

### DIFF
--- a/code/__defines/radio.dm
+++ b/code/__defines/radio.dm
@@ -1,0 +1,7 @@
+#define MESSAGE_MODE_LEFT       "left"
+#define MESSAGE_MODE_RIGHT      "right"
+#define MESSAGE_MODE_INTERCOM   "intercom"
+#define MESSAGE_MODE_DEFAULT    "default"
+#define MESSAGE_MODE_WHISPER    "whisper"
+#define MESSAGE_MODE_DEPARTMENT "department"
+#define MESSAGE_MODE_SPECIAL    "special"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -49,12 +49,11 @@
 	to_chat(user, radio_desc)
 
 /obj/item/radio/headset/get_connection_from_message_mode(mob/living/M, message, message_mode)
-	if (message_mode == "special")
-		if (translate_binary)
-			var/decl/language/binary = GET_DECL(/decl/language/binary)
-			binary.broadcast(M, message)
-		return null
-	return ..()
+	if(message_mode == MESSAGE_MODE_SPECIAL && translate_binary)
+		var/decl/language/binary = GET_DECL(/decl/language/binary)
+		binary.broadcast(M, message)
+	else
+		return ..()
 
 /obj/item/radio/headset/receive_range(freq, level, aiOverride = 0)
 	if (aiOverride)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -238,7 +238,7 @@
 /obj/item/radio/proc/autosay(var/message, var/from, var/channel, var/sayverb = "states") //BS12 EDIT
 	var/datum/radio_frequency/connection = null
 	if(channel && channels && channels.len > 0)
-		if (channel == "department")
+		if (channel == MESSAGE_MODE_DEPARTMENT)
 			channel = channels[1]
 		connection = secure_radio_connections[channel]
 	else
@@ -254,12 +254,12 @@
 // Interprets the message mode when talking into a radio, possibly returning a connection datum
 /obj/item/radio/proc/get_connection_from_message_mode(mob/living/M, message, message_mode)
 	// If a channel isn't specified, send to common.
-	if(!message_mode || message_mode == "headset")
+	if(!message_mode || global.nondepartmental_message_modes[message_mode])
 		return radio_connection
 
 	// Otherwise, if a channel is specified, look for it.
 	if(channels && channels.len > 0)
-		if (message_mode == "department") // Department radio shortcut
+		if (message_mode == MESSAGE_MODE_DEPARTMENT) // Department radio shortcut
 			message_mode = channels[1]
 
 		if (channels[message_mode]) // only broadcast if the channel is set on
@@ -287,7 +287,8 @@
 			to_chat(M, SPAN_WARNING("You're disrupted as you reach for \the [src]."))
 			return 0
 
-		if(istype(M)) M.trigger_aiming(TARGET_CAN_RADIO)
+		if(istype(M))
+			M.trigger_aiming(TARGET_CAN_RADIO)
 
 	//  Uncommenting this. To the above comment:
 	// 	The permacell radios aren't suppose to be able to transmit, this isn't a bug and this "fix" is just making radio wires useless. -Giacom
@@ -296,7 +297,6 @@
 
 	if(!radio_connection)
 		set_frequency(frequency)
-
 
 	if(power_usage)
 		var/obj/item/cell/has_cell = get_cell()

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -114,7 +114,7 @@
 	return ..(message_data)
 
 /mob/living/carbon/human/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
-	if(message_mode == "whisper") //It's going to get sanitized again immediately, so decode.
+	if(message_mode == MESSAGE_MODE_WHISPER) //It's going to get sanitized again immediately, so decode.
 		whisper_say(html_decode(message), speaking, alt_name)
 		return TRUE
 	return ..()

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -1,79 +1,87 @@
 var/global/list/department_radio_keys = list(
-	  ":r" = "right ear",	".r" = "right ear",
-	  ":l" = "left ear",	".l" = "left ear",
-	  ":i" = "intercom",	".i" = "intercom",
-	  ":h" = "department",	".h" = "department",
-	  ":+" = "special",		".+" = "special", //activate radio-specific special functions
-	  ":c" = "Command",		".c" = "Command",
-	  ":n" = "Science",		".n" = "Science",
-	  ":m" = "Medical",		".m" = "Medical",
-	  ":e" = "Engineering", ".e" = "Engineering",
-	  ":s" = "Security",	".s" = "Security",
-	  ":w" = "whisper",		".w" = "whisper",
-	  ":t" = "Mercenary",	".t" = "Mercenary",
-	  ":x" = "Raider",		".x" = "Raider",
-	  ":u" = "Supply",		".u" = "Supply",
-	  ":v" = "Service",		".v" = "Service",
-	  ":p" = "AI Private",	".p" = "AI Private",
-	  ":z" = "Entertainment",".z" = "Entertainment",
-	  ":y" = "Exploration",		".y" = "Exploration",
+	":r" = MESSAGE_MODE_RIGHT,      ".r" = MESSAGE_MODE_RIGHT,
+	":l" = MESSAGE_MODE_LEFT,       ".l" = MESSAGE_MODE_LEFT,
+	":i" = MESSAGE_MODE_INTERCOM,   ".i" = MESSAGE_MODE_INTERCOM,
+	":h" = MESSAGE_MODE_DEPARTMENT, ".h" = MESSAGE_MODE_DEPARTMENT,
+	":+" = MESSAGE_MODE_SPECIAL,    ".+" = MESSAGE_MODE_SPECIAL, //activate radio-specific special functions
+	":w" = MESSAGE_MODE_WHISPER,    ".w" = MESSAGE_MODE_WHISPER,
+	":c" = "Command",               ".c" = "Command",
+	":n" = "Science",               ".n" = "Science",
+	":m" = "Medical",               ".m" = "Medical",
+	":e" = "Engineering",           ".e" = "Engineering",
+	":s" = "Security",              ".s" = "Security",
+	":t" = "Mercenary",             ".t" = "Mercenary",
+	":x" = "Raider",                ".x" = "Raider",
+	":u" = "Supply",                ".u" = "Supply",
+	":v" = "Service",               ".v" = "Service",
+	":p" = "AI Private",            ".p" = "AI Private",
+	":z" = "Entertainment",         ".z" = "Entertainment",
+	":y" = "Exploration",           ".y" = "Exploration",
 
-	  ":R" = "right ear",	".R" = "right ear",
-	  ":L" = "left ear",	".L" = "left ear",
-	  ":I" = "intercom",	".I" = "intercom",
-	  ":H" = "department",	".H" = "department",
-	  ":C" = "Command",		".C" = "Command",
-	  ":N" = "Science",		".N" = "Science",
-	  ":M" = "Medical",		".M" = "Medical",
-	  ":E" = "Engineering",	".E" = "Engineering",
-	  ":S" = "Security",	".S" = "Security",
-	  ":W" = "whisper",		".W" = "whisper",
-	  ":T" = "Mercenary",	".T" = "Mercenary",
-	  ":X" = "Raider",		".X" = "Raider",
-	  ":U" = "Supply",		".U" = "Supply",
-	  ":V" = "Service",		".V" = "Service",
-	  ":P" = "AI Private",	".P" = "AI Private",
-	  ":Z" = "Entertainment",".Z" = "Entertainment",
-	  ":Y" = "Exploration",		".Y" = "Exploration",
+	":R" = MESSAGE_MODE_RIGHT,      ".R" = MESSAGE_MODE_RIGHT,
+	":L" = MESSAGE_MODE_LEFT,       ".L" = MESSAGE_MODE_LEFT,
+	":I" = MESSAGE_MODE_INTERCOM,   ".I" = MESSAGE_MODE_INTERCOM,
+	":H" = MESSAGE_MODE_DEPARTMENT, ".H" = MESSAGE_MODE_DEPARTMENT,
+	":W" = MESSAGE_MODE_WHISPER,    ".W" = MESSAGE_MODE_WHISPER,
+	":C" = "Command",               ".C" = "Command",
+	":N" = "Science",               ".N" = "Science",
+	":M" = "Medical",               ".M" = "Medical",
+	":E" = "Engineering",           ".E" = "Engineering",
+	":S" = "Security",              ".S" = "Security",
+	":T" = "Mercenary",             ".T" = "Mercenary",
+	":X" = "Raider",                ".X" = "Raider",
+	":U" = "Supply",                ".U" = "Supply",
+	":V" = "Service",               ".V" = "Service",
+	":P" = "AI Private",            ".P" = "AI Private",
+	":Z" = "Entertainment",         ".Z" = "Entertainment",
+	":Y" = "Exploration",           ".Y" = "Exploration",
 
 //russian version below
-	  ":к" = "right ear",	".к" = "right ear",
-	  ":д" = "left ear",	".д" = "left ear",
-	  ":ш" = "intercom",	".ш" = "intercom",
-	  ":р" = "department",	".р" = "department",
-	  ":с" = "Command",		".с" = "Command",
-	  ":т" = "Science",		".т" = "Science",
-	  ":ь" = "Medical",		".ь" = "Medical",
-	  ":у" = "Engineering",	".у" = "Engineering",
-	  ":ы" = "Security",	".ы" = "Security",
-	  ":ц" = "whisper",		".ц" = "whisper",
-	  ":е" = "Mercenary",	".е" = "Mercenary",
-	  ":г" = "Supply",		".г" = "Supply",
-	  ":ч" = "Raider",		".ч" = "Raider",
-	  ":м" = "Service",		".м" = "Service",
-	  ":з" = "AI Private",	".з" = "AI Private",
-	  ":я" = "Entertainment",".я" = "Entertainment",
-	  ":н" = "Exploration",		".н" = "Exploration",
+	":к" = MESSAGE_MODE_RIGHT,         ".к" = MESSAGE_MODE_RIGHT,
+	":д" = MESSAGE_MODE_LEFT,          ".д" = MESSAGE_MODE_LEFT,
+	":ш" = MESSAGE_MODE_INTERCOM,      ".ш" = MESSAGE_MODE_INTERCOM,
+	":р" = MESSAGE_MODE_DEPARTMENT,    ".р" = MESSAGE_MODE_DEPARTMENT,
+	":ц" = MESSAGE_MODE_WHISPER,       ".ц" = MESSAGE_MODE_WHISPER,
+	":с" = "Command",                  ".с" = "Command",
+	":т" = "Science",                  ".т" = "Science",
+	":ь" = "Medical",                  ".ь" = "Medical",
+	":у" = "Engineering",              ".у" = "Engineering",
+	":ы" = "Security",                 ".ы" = "Security",
+	":е" = "Mercenary",                ".е" = "Mercenary",
+	":г" = "Supply",                   ".г" = "Supply",
+	":ч" = "Raider",                   ".ч" = "Raider",
+	":м" = "Service",                  ".м" = "Service",
+	":з" = "AI Private",               ".з" = "AI Private",
+	":я" = "Entertainment",            ".я" = "Entertainment",
+	":н" = "Exploration",              ".н" = "Exploration",
 
-	  ":К" = "right ear",	".К" = "right ear",
-	  ":Д" = "left ear",	".Д" = "left ear",
-	  ":Ш" = "intercom",	".Ш" = "intercom",
-	  ":Р" = "department",	".Р" = "department",
-	  ":С" = "Command",		".С" = "Command",
-	  ":Т" = "Science",		".Т" = "Science",
-	  ":Ь" = "Medical",		".Ь" = "Medical",
-	  ":У" = "Engineering",	".У" = "Engineering",
-	  ":Ы" = "Security",	".Ы" = "Security",
-	  ":Ц" = "whisper",		".Ц" = "whisper",
-	  ":Е" = "Mercenary",	".Е" = "Mercenary",
-	  ":Г" = "Supply",		".Г" = "Supply",
-	  ":Ч" = "Raider",		".Ч" = "Raider",
-	  ":М" = "Service",		".М" = "Service",
-	  ":З" = "AI Private",	".З" = "AI Private",
-	  ":Я" = "Entertainment",".Я" = "Entertainment",
-	  ":Н" = "Exploration",		".Н" = "Exploration",
+	":К" = MESSAGE_MODE_RIGHT,         ".К" = MESSAGE_MODE_RIGHT,
+	":Д" = MESSAGE_MODE_LEFT,          ".Д" = MESSAGE_MODE_LEFT,
+	":Ш" = MESSAGE_MODE_INTERCOM,	   ".Ш" = MESSAGE_MODE_INTERCOM,
+	":Р" = MESSAGE_MODE_DEPARTMENT,    ".Р" = MESSAGE_MODE_DEPARTMENT,
+	":Ц" = MESSAGE_MODE_WHISPER,       ".Ц" = MESSAGE_MODE_WHISPER,
+	":С" = "Command",                  ".С" = "Command",
+	":Т" = "Science",                  ".Т" = "Science",
+	":Ь" = "Medical",                  ".Ь" = "Medical",
+	":У" = "Engineering",              ".У" = "Engineering",
+	":Ы" = "Security",                 ".Ы" = "Security",
+	":Е" = "Mercenary",                ".Е" = "Mercenary",
+	":Г" = "Supply",                   ".Г" = "Supply",
+	":Ч" = "Raider",                   ".Ч" = "Raider",
+	":М" = "Service",                  ".М" = "Service",
+	":З" = "AI Private",               ".З" = "AI Private",
+	":Я" = "Entertainment",            ".Я" = "Entertainment",
+	":Н" = "Exploration",              ".Н" = "Exploration",
 )
 
+// Assoc for lookup speed since this is in potentially semihot code
+var/global/list/nondepartmental_message_modes = list(
+	MESSAGE_MODE_LEFT =     TRUE,
+	MESSAGE_MODE_RIGHT =    TRUE,
+	MESSAGE_MODE_INTERCOM = TRUE,
+	MESSAGE_MODE_DEFAULT =  TRUE,
+	MESSAGE_MODE_WHISPER =  TRUE
+)
 
 var/global/list/channel_to_radio_key = new
 /proc/get_radio_key_from_channel(var/channel)
@@ -143,12 +151,9 @@ var/global/list/channel_to_radio_key = new
 // determine relevancy. See handle_message_mode below.
 /mob/living/proc/get_radios(var/message_mode)
 
-	if(!message_mode)
-		return
-
 	var/list/possible_radios
-	if(message_mode == "right ear" || message_mode == "left ear")
-		var/use_right = message_mode == "right ear"
+	if(message_mode == MESSAGE_MODE_RIGHT || message_mode == MESSAGE_MODE_LEFT)
+		var/use_right = (message_mode == MESSAGE_MODE_RIGHT)
 		var/obj/item/thing = get_equipped_item(use_right ? slot_r_ear_str : slot_l_ear_str)
 		if(thing)
 			LAZYDISTINCTADD(possible_radios, thing)
@@ -156,13 +161,18 @@ var/global/list/channel_to_radio_key = new
 			thing = get_equipped_item(use_right ? BP_R_HAND : BP_L_HAND)
 			if(thing)
 				LAZYDISTINCTADD(possible_radios, thing)
-	else
+	else if(message_mode == MESSAGE_MODE_INTERCOM)
+		if(!restrained())
+			for(var/obj/item/radio/I in view(1))
+				if(I.intercom_handling)
+					LAZYDISTINCTADD(possible_radios, I)
+	else if(message_mode != MESSAGE_MODE_WHISPER)
 		for(var/slot in global.ear_slots)
 			var/thing = get_equipped_item(slot)
 			if(thing)
 				LAZYDISTINCTADD(possible_radios, thing)
 
-	if(length(possible_radios))
+	if(LAZYLEN(possible_radios))
 		for(var/atom/movable/thing as anything in possible_radios)
 			var/obj/item/radio/radio = thing.get_radio(message_mode)
 			if(istype(radio))
@@ -172,16 +182,15 @@ var/global/list/channel_to_radio_key = new
 // It then processes the message_mode to implement an additional behavior needed for the message, such
 // as retrieving radios or looking for an intercom nearby.
 /mob/living/proc/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
+	if(!message_mode)
+		return
 	var/list/assess_items_as_radios = get_radios(message_mode)
-	if(message_mode == "intercom" && !restrained())
-		for(var/obj/item/radio/I in view(1))
-			if(I.intercom_handling)
-				LAZYDISTINCTADD(assess_items_as_radios, I)
-	for(var/obj/item/radio/radio as anything in assess_items_as_radios)
-		used_radios += radio
+	if(!LAZYLEN(assess_items_as_radios))
+		return
+	used_radios |= assess_items_as_radios
+	for(var/obj/item/radio/radio as anything in used_radios)
 		radio.add_fingerprint(src)
 		radio.talk_into(src, message, message_mode, verb, speaking)
-		. = TRUE
 
 /mob/living/proc/handle_speech_sound()
 	var/list/returns[2]
@@ -227,9 +236,9 @@ var/global/list/channel_to_radio_key = new
 		return custom_emote(1, copytext(message,2))
 
 	//parse the radio code and consume it
-	var/message_mode = parse_message_mode(message, "headset")
+	var/message_mode = parse_message_mode(message)
 	if (message_mode)
-		if (message_mode == "headset")
+		if (message_mode == MESSAGE_MODE_DEFAULT)
 			message = copytext_char(message,2)	//it would be really nice if the parse procs could do this for us.
 		else
 			message = copytext_char(message,3)
@@ -281,7 +290,7 @@ var/global/list/channel_to_radio_key = new
 	if(!message || message == "")
 		return 0
 
-	var/list/obj/item/used_radios = new
+	var/list/obj/item/used_radios = list()
 	if(handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name))
 		return 1
 

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -8,30 +8,27 @@
 	if(message_mode)
 		if(!is_component_functioning("radio"))
 			to_chat(src, SPAN_WARNING("Your radio isn't functional at this time."))
-			return FALSE
-		if(message_mode == "general")
-			message_mode = null
-		return silicon_radio.talk_into(src, message, message_mode, verb, speaking)
+		else
+			used_radios += silicon_radio
+		. = TRUE
 	return ..()
 
 /mob/living/silicon/ai/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
 	if(message_mode)
-		if(message_mode == "department")
-			return holopad_talk(message, verb, speaking)
-		if (ai_radio.disabledAi || !has_power() || stat)
-			to_chat(src, "<span class='danger'>System Error - Transceiver Disabled.</span>")
-			return FALSE
-		if(message_mode == "general")
-			message_mode = null
-		return ai_radio.talk_into(src,message,message_mode,verb,speaking)
-	return ..()
+		if(message_mode == MESSAGE_MODE_DEPARTMENT)
+			holopad_talk(message, verb, speaking)
+		else if (ai_radio.disabledAi || !has_power() || stat)
+			to_chat(src, SPAN_DANGER("System Error - Transceiver Disabled."))
+		else
+			used_radios += ai_radio
+		. = TRUE
+	..()
 
 /mob/living/silicon/pai/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
 	if(message_mode)
-		if(message_mode == "general")
-			message_mode = null
-		return silicon_radio.talk_into(src,message,message_mode,verb,speaking)
-	return ..()
+		used_radios += silicon_radio
+		. = TRUE
+	..()
 
 /mob/living/silicon/say_quote(var/text)
 	var/ending = copytext(text, length(text))

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
@@ -668,9 +668,9 @@
 		verb = pick(speak_emote)
 
 
-	var/message_mode=""
+	var/message_mode
 	if(copytext(message,1,2) == get_prefix_key(/decl/prefix/radio_main_channel))
-		message_mode = "headset"
+		message_mode = MESSAGE_MODE_DEFAULT
 		message = copytext(message,2)
 
 	if(length(message) >= 2)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -67,15 +67,13 @@
 //parses the message mode code (e.g. :h, :w) from text, such as that supplied to say.
 //returns the message mode string or null for no message mode.
 //standard mode is the mode returned for the special ';' radio code.
-/mob/proc/parse_message_mode(var/message, var/standard_mode="headset")
-	if(length(message) >= 1 && copytext_char(message,1,2) == get_prefix_key(/decl/prefix/radio_main_channel))
-		return standard_mode
-
-	if(length(message) >= 2)
-		var/channel_prefix = copytext_char(message, 1 ,3)
-		return department_radio_keys[channel_prefix]
-
-	return null
+/mob/proc/parse_message_mode(var/message)
+	if(length(message) >= 1)
+		if(copytext_char(message,1,2) == get_prefix_key(/decl/prefix/radio_main_channel))
+			return MESSAGE_MODE_DEFAULT
+		if(length(message) >= 2)
+			var/channel_prefix = copytext_char(message, 1, 3)
+			return department_radio_keys[channel_prefix]
 
 //parses the language code (e.g. :j) from text, such as that supplied to say.
 //returns the language object only if the code corresponds to a language that src can speak, otherwise null.

--- a/nebula.dme
+++ b/nebula.dme
@@ -71,6 +71,7 @@
 #include "code\__defines\power.dm"
 #include "code\__defines\proc_presets.dm"
 #include "code\__defines\qdel.dm"
+#include "code\__defines\radio.dm"
 #include "code\__defines\research.dm"
 #include "code\__defines\ruin_tags.dm"
 #include "code\__defines\shields.dm"


### PR DESCRIPTION
## Description of changes
- Replaces non-departmental message modes with constants.
- Fixes message mode handling/erroneous `TRUE` return.

## Why and what will this PR improve
Fixes radios being cooked from when I clobbered and tried to fix the message mode handling.

## Authorship
Myself, @out-of-phaze and @noelle-lavenza.

## Changelog
Nothing player-facing.