### PR TITLE
Shuttle clearing landmarks now use shuttle size properly.

### DIFF
--- a/code/game/turfs/exterior/exterior_barren.dm
+++ b/code/game/turfs/exterior/exterior_barren.dm
@@ -7,7 +7,3 @@
 	. = ..()
 	if(prob(20))
 		add_overlay(image('icons/turf/flooring/decals.dmi', "asteroid[rand(0,9)]"))
-
-/turf/exterior/barren/Initialize()
-	. = ..()
-	update_icon()

--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -230,7 +230,8 @@
 /obj/effect/overmap/visitable/sector/exoplanet/proc/generate_landing()
 	var/places = list()
 	var/attempts = 10*landing_points_to_place
-	var/border_padding = shuttle_size / 2 + 3
+	var/landing_radius = CEILING(shuttle_size / 2)
+	var/border_padding = landing_radius + 3
 
 	while(landing_points_to_place)
 		attempts--
@@ -241,7 +242,7 @@
 
 		if(attempts >= 0) // While we have the patience, try to find better spawn points. If out of patience, put them down wherever, so long as there are no repeats.
 			var/valid = 1
-			var/list/block_to_check = block(locate(T.x - shuttle_size / 2, T.y - shuttle_size / 2, T.z), locate(T.x + shuttle_size / 2, T.y + shuttle_size / 2, T.z))
+			var/list/block_to_check = block(locate(T.x - landing_radius, T.y - landing_radius, T.z), locate(T.x + landing_radius, T.y + landing_radius, T.z))
 			for(var/turf/check in block_to_check)
 				if(!istype(get_area(check), /area/exoplanet) || check.turf_flags & TURF_FLAG_NORUINS)
 					valid = 0
@@ -255,7 +256,7 @@
 
 		landing_points_to_place--
 		places += T
-		new /obj/effect/shuttle_landmark/automatic/clearing(T)
+		new /obj/effect/shuttle_landmark/automatic/clearing(T, landing_radius)
 
 /obj/effect/overmap/visitable/sector/exoplanet/get_scan_data(mob/user)
 	. = ..()

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -133,8 +133,10 @@ var/global/list/shuttle_landmarks = list()
 /obj/effect/shuttle_landmark/automatic/clearing
 	var/radius = 10
 
-/obj/effect/shuttle_landmark/automatic/clearing/Initialize()
+/obj/effect/shuttle_landmark/automatic/clearing/Initialize(var/ml, var/supplied_radius)
 	..()
+	if(!isnull(supplied_radius))
+		radius = supplied_radius
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/effect/shuttle_landmark/automatic/clearing/LateInitialize()


### PR DESCRIPTION
Shuttle clearing landmarks now use the radius of the shuttle placing them.