### PR TITLE
Mapload now passes the hash to init_atoms() instead of doing it in the loader

### DIFF
--- a/code/controllers/subsystems/atoms.dm
+++ b/code/controllers/subsystems/atoms.dm
@@ -65,7 +65,8 @@ SUBSYSTEM_DEF(atoms)
 	if(late_loaders.len)
 		for(var/I in late_loaders)
 			var/atom/A = I
-			A.LateInitialize(arglist(late_loaders[A]))
+			if(A.LateInitialize(arglist(late_loaders[A])) == INITIALIZE_HINT_QDEL)
+				qdel(A)
 		report_progress("Late initialized [late_loaders.len] atom\s")
 		late_loaders.Cut()
 
@@ -89,8 +90,10 @@ SUBSYSTEM_DEF(atoms)
 			if(INITIALIZE_HINT_LATELOAD)
 				if(arguments[1])	//mapload
 					late_loaders[A] = arguments
-				else
-					A.LateInitialize(arglist(arguments))
+				else if(A.LateInitialize(arglist(arguments)) == INITIALIZE_HINT_QDEL)
+					A.atom_flags |= ATOM_FLAG_INITIALIZED // never call EarlyDestroy if we return this hint
+					qdel(A)
+					qdeleted = TRUE
 			if(INITIALIZE_HINT_QDEL)
 				A.atom_flags |= ATOM_FLAG_INITIALIZED // never call EarlyDestroy if we return this hint
 				qdel(A)

--- a/code/modules/maps/reader.dm
+++ b/code/modules/maps/reader.dm
@@ -510,7 +510,6 @@ var/global/dmm_suite/preloader/_preloader = new
 	parent_type = /datum
 	var/list/attributes
 	var/target_path
-	var/current_map_hash
 
 /dmm_suite/preloader/proc/setup(list/the_attributes, path)
 	global.use_preloader = TRUE
@@ -534,8 +533,6 @@ var/global/dmm_suite/preloader/_preloader = new
 					break
 			if (!found)
 				throw ex
-	if(current_map_hash)
-		what.modify_mapped_vars(current_map_hash)
 	global.use_preloader = FALSE
 
 /area/template_noop

--- a/code/modules/submaps/_submap.dm
+++ b/code/modules/submaps/_submap.dm
@@ -13,7 +13,7 @@
 	SSmapping.submaps -= src
 	. = ..()
 
-/datum/submap/proc/setup_submap(var/decl/submap_archetype/_archetype)
+/datum/submap/proc/setup_submap(var/decl/submap_archetype/_archetype, var/submap_hash)
 	if(!istype(_archetype))
 		testing( "Submap error - [name] - null or invalid archetype supplied ([_archetype]).")
 		qdel(src)
@@ -52,7 +52,7 @@
 	// Add the spawn points to the appropriate job list.
 	var/registered_spawnpoint
 	for(var/check_z in SSmapping.get_connected_levels(associated_z))
-		for(var/obj/abstract/submap_landmark/spawnpoint/landmark in LAZYACCESS(global.submap_spawnpoints_by_z, "[check_z]"))
+		for(var/obj/abstract/submap_landmark/spawnpoint/landmark in LAZYACCESS(global.submap_spawnpoints_by_hash, submap_hash))
 			var/datum/job/submap/job = jobs[landmark.name]
 			if(istype(job))
 				job.spawnpoints += landmark

--- a/code/modules/submaps/submap_landmark.dm
+++ b/code/modules/submaps/submap_landmark.dm
@@ -16,7 +16,12 @@
 	submap_hash = map_hash
 	. = ..()
 
-/obj/abstract/submap_landmark/joinable_submap/Initialize(var/mapload)
+/obj/abstract/submap_landmark/joinable_submap/Initialize(mapload)
+	..()
+	return INITIALIZE_HINT_LATELOAD
+
+// Initialize late so landmarks have registered.
+/obj/abstract/submap_landmark/joinable_submap/LateInitialize(var/mapload)
 	. = ..(mapload)
 	if(!SSmapping.submaps[name] && ispath(archetype, /decl/submap_archetype))
 		var/datum/submap/submap = new submap_datum_type(z)

--- a/code/modules/submaps/submap_landmark.dm
+++ b/code/modules/submaps/submap_landmark.dm
@@ -10,13 +10,18 @@
 	icon_state = "x4"
 	var/archetype
 	var/submap_datum_type = /datum/submap
+	var/submap_hash
+
+/obj/abstract/submap_landmark/joinable_submap/modify_mapped_vars(map_hash)
+	submap_hash = map_hash
+	. = ..()
 
 /obj/abstract/submap_landmark/joinable_submap/Initialize(var/mapload)
 	. = ..(mapload)
 	if(!SSmapping.submaps[name] && ispath(archetype, /decl/submap_archetype))
 		var/datum/submap/submap = new submap_datum_type(z)
 		submap.name = name
-		submap.setup_submap(GET_DECL(archetype))
+		submap.setup_submap(GET_DECL(archetype), (submap_hash || "[z]"))
 	else
 		if(SSmapping.submaps[name])
 			to_world_log( "Submap error - mapped landmark is duplicate of existing.")
@@ -24,18 +29,26 @@
 			to_world_log( "Submap error - mapped landmark had invalid archetype.")
 	return INITIALIZE_HINT_QDEL
 
-var/global/list/submap_spawnpoints_by_z = list()
+var/global/list/submap_spawnpoints_by_hash = list()
 INITIALIZE_IMMEDIATE(/obj/abstract/submap_landmark/spawnpoint)
 /obj/abstract/submap_landmark/spawnpoint
 	movable_flags = MOVABLE_FLAG_ALWAYS_SHUTTLEMOVE
 	icon_state = "x3"
+	var/submap_hash
+
+/obj/abstract/submap_landmark/spawnpoint/modify_mapped_vars(map_hash)
+	submap_hash = map_hash
+	. = ..()
+
 
 /obj/abstract/submap_landmark/spawnpoint/Initialize()
 	. = ..()
-	LAZYADD(global.submap_spawnpoints_by_z[num2text(z)], src)
+	if(!submap_hash)
+		submap_hash = "[z]"
+	LAZYADD(global.submap_spawnpoints_by_hash[submap_hash], src)
 
 /obj/abstract/submap_landmark/spawnpoint/Destroy()
-	LAZYREMOVE(global.submap_spawnpoints_by_z[num2text(z)], src)
+	LAZYREMOVE(global.submap_spawnpoints_by_hash[submap_hash], src)
 	. = ..()
 
 /obj/abstract/submap_landmark/spawnpoint/survivor


### PR DESCRIPTION
## Description of changes
- Passes the map hash into `init_atoms()` instead of relying on a global and doing it during the loading process.
- Passes the map hash through the submap landmark and setup proc to allow multiple submaps on the same level without job interference.

## Why and what will this PR improve
Fixes some issues with maploading.

## Authorship
Myself and @out-of-phaze.

## Changelog
Nothing player-facing.