### PR TITLE
Fix runtime from invalid explosion_act severity

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -289,7 +289,7 @@ its easier to just keep the beam vertical.
 		. = (severity <= 3)
 		if(.)
 			for(var/atom/movable/AM in get_contained_external_atoms())
-				AM.explosion_act(severity++)
+				AM.explosion_act(severity + 1)
 			try_detonate_reagents(severity)
 		currently_exploding = FALSE
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -284,10 +284,10 @@ its easier to just keep the beam vertical.
 
 /atom/proc/explosion_act(var/severity)
 	SHOULD_CALL_PARENT(TRUE)
-	if(!currently_exploding)
+	. = !currently_exploding && severity > 0 && severity <= 3
+	if(.)
 		currently_exploding = TRUE
-		. = (severity <= 3)
-		if(.)
+		if(severity < 3)
 			for(var/atom/movable/AM in get_contained_external_atoms())
 				AM.explosion_act(severity + 1)
 			try_detonate_reagents(severity)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Incremented for each atom instead of just adding one to their args.

## Why and what will this PR improve
Fixes a runtime from explosions hitting items with a severity of 4 or above.