### PR TITLE
Fix runtime in throw_at_random

### DIFF
--- a/code/_helpers/atom_movables.dm
+++ b/code/_helpers/atom_movables.dm
@@ -28,12 +28,13 @@
 		return locate(final_x, final_y, T.z)
 
 /atom/movable/proc/throw_at_random(var/include_own_turf, var/maxrange, var/speed)
-	var/list/turfs = RANGE_TURFS(src, maxrange)
+	var/turf/own_turf = get_turf(src)
+	var/list/turfs = RANGE_TURFS(own_turf, maxrange)
 	if(!maxrange)
 		maxrange = 1
 
 	if(!include_own_turf)
-		turfs -= get_turf(src)
+		turfs -= own_turf
 	src.throw_at(pick(turfs), maxrange, speed)
 
 /atom/movable/proc/do_simple_ranged_interaction(var/mob/user)


### PR DESCRIPTION
## Description of changes
Things inside containers were being selected by the carnage mark and thrown, which meant their x, y, and z (used by RANGE_TURFS) were null. This uses the x, y, and z of their turf instead, which works properly. (Also, it means that containers *could,* though probably don't, react to their contents being thrown while inside them.)

## Why and what will this PR improve
Fixes a runtime from throw_at_random trying to throw something without coordinates, i.e. something inside a non-turf atom. Throwing those atoms is probably valid, so it should be handled instead of runtiming.