### PR TITLE
Fix closets that start open containing objects

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -50,7 +50,7 @@ var/global/list/closets = list()
 /obj/structure/closet/LateInitialize(mapload, ...)
 	var/list/will_contain = WillContain()
 	if(will_contain)
-		create_objects_in_loc(opened && loc || src, will_contain)
+		create_objects_in_loc(opened ? loc : src, will_contain)
 
 	if(!opened && mapload) // if closed and it's the map loading phase, relevant items at the crate's loc are put in the contents
 		store_contents()
@@ -419,9 +419,7 @@ var/global/list/closets = list()
 	open()
 
 /obj/structure/closet/onDropInto(var/atom/movable/AM)
-	if(opened)
-		return loc
-	return null
+	return opened ? loc : null
 
 // If we use the /obj/structure/closet/proc/togglelock variant BYOND asks the user to select an input for id_card, which is then mostly irrelevant.
 /obj/structure/closet/proc/togglelock_verb()

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -50,7 +50,7 @@ var/global/list/closets = list()
 /obj/structure/closet/LateInitialize(mapload, ...)
 	var/list/will_contain = WillContain()
 	if(will_contain)
-		create_objects_in_loc(src, will_contain)
+		create_objects_in_loc(opened && loc || src, will_contain)
 
 	if(!opened && mapload) // if closed and it's the map loading phase, relevant items at the crate's loc are put in the contents
 		store_contents()
@@ -106,7 +106,7 @@ var/global/list/closets = list()
 		stored_units += store_mobs(stored_units)
 	if(storage_types & CLOSET_STORAGE_STRUCTURES)
 		stored_units += store_structures(stored_units)
-		
+
 /obj/structure/closet/proc/open()
 	if(src.opened)
 		return 0
@@ -237,7 +237,7 @@ var/global/list/closets = list()
 		take_damage(proj_damage)
 
 /obj/structure/closet/attackby(obj/item/W, mob/user)
-	
+
 	if(user.a_intent == I_HURT && W.force)
 		return ..()
 
@@ -419,7 +419,9 @@ var/global/list/closets = list()
 	open()
 
 /obj/structure/closet/onDropInto(var/atom/movable/AM)
-	return
+	if(opened)
+		return loc
+	return null
 
 // If we use the /obj/structure/closet/proc/togglelock variant BYOND asks the user to select an input for id_card, which is then mostly irrelevant.
 /obj/structure/closet/proc/togglelock_verb()


### PR DESCRIPTION
## Description of changes
Closets that start open will now spawn their WillContain items inside their loc rather than inside them.
Also modifies closet onDropInto logic to hopefully prevent similar potential issues where things end up inside an open closet.

## Why and what will this PR improve
This means you won't have closets in an inconsistent state, i.e. "sprite is open, items mapped in are outside the closet, items defined in WillContain are inside the closet".