### PR TITLE
Update carnage landmark to avoid throwing qdeleted items

### DIFF
--- a/code/modules/maps/helper_landmarks.dm
+++ b/code/modules/maps/helper_landmarks.dm
@@ -32,11 +32,11 @@ INITIALIZE_IMMEDIATE(/obj/abstract/landmark/map_load_mark/non_template)
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/abstract/landmark/carnage_mark/LateInitialize()
-	var/area/A = get_area(src)
-	for(var/atom/movable/AM in A)
-		if(AM && !AM.anchored && AM.simulated && prob(movement_prob))
-			spawn()
-				AM.throw_at_random(FALSE, movement_range, 1)
+	var/area/our_area = get_area(src)
+	spawn()
+		for(var/atom/movable/throw_candidate in our_area)
+			if(!QDELETED(throw_candidate) && !throw_candidate.anchored && throw_candidate.simulated && prob(movement_prob))
+				throw_candidate.throw_at_random(FALSE, movement_range, 1)
 	qdel(src)
 
 //Clears walls

--- a/code/modules/maps/helper_landmarks.dm
+++ b/code/modules/maps/helper_landmarks.dm
@@ -32,11 +32,15 @@ INITIALIZE_IMMEDIATE(/obj/abstract/landmark/map_load_mark/non_template)
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/abstract/landmark/carnage_mark/LateInitialize()
+	do_throw()
+
+/obj/abstract/landmark/carnage_mark/proc/do_throw()
+	set waitfor = FALSE
+	sleep(0)
 	var/area/our_area = get_area(src)
-	spawn()
-		for(var/atom/movable/throw_candidate in our_area)
-			if(!QDELETED(throw_candidate) && !throw_candidate.anchored && throw_candidate.simulated && prob(movement_prob))
-				throw_candidate.throw_at_random(FALSE, movement_range, 1)
+	for(var/atom/movable/throw_candidate in our_area)
+		if(!QDELETED(throw_candidate) && !throw_candidate.anchored && throw_candidate.simulated && prob(movement_prob))
+			throw_candidate.throw_at_random(FALSE, movement_range, 1)
 	qdel(src)
 
 //Clears walls


### PR DESCRIPTION
## Description of changes
Makes the carnage landmark spawn before the for loop instead of inside it, and adds a QDELETED check to the thing being thrown.

## Why and what will this PR improve
Avoids runtimes from the carnage landmark trying to throw something that's been deleted.