### PR TITLE
Add airlock tags for cycling to external airmix

### DIFF
--- a/code/game/machinery/embedded_controller/airlock_controllers.dm
+++ b/code/game/machinery/embedded_controller/airlock_controllers.dm
@@ -13,6 +13,8 @@
 	var/tag_air_alarm
 	var/list/dummy_terminals = list() // Internal use only; set id_tag on the dummy terminal to be added.
 	var/cycle_to_external_air = 0
+	var/tag_pump_out_external
+	var/tag_pump_out_internal
 
 /obj/machinery/embedded_controller/radio/airlock/modify_mapped_vars(map_hash)
 	..()
@@ -23,6 +25,8 @@
 	ADJUST_TAG_VAR(tag_exterior_sensor, map_hash)
 	ADJUST_TAG_VAR(tag_interior_sensor, map_hash)
 	ADJUST_TAG_VAR(tag_air_alarm, map_hash)
+	ADJUST_TAG_VAR(tag_pump_out_external, map_hash)
+	ADJUST_TAG_VAR(tag_pump_out_internal, map_hash)
 
 /obj/machinery/embedded_controller/radio/airlock/Destroy()
 	for(var/obj/machinery/dummy_airlock_controller/terminal in dummy_terminals)

--- a/code/game/machinery/embedded_controller/airlock_program.dm
+++ b/code/game/machinery/embedded_controller/airlock_program.dm
@@ -48,11 +48,11 @@
 
 /datum/computer/file/embedded_program/airlock/reset_id_tags(base_tag)
 	. = ..()
-	if(cycle_to_external_air)
-		tag_pump_out_external = "[id_tag]_pump_out_external"
-		tag_pump_out_internal = "[id_tag]_pump_out_internal"
 	if(istype(master, /obj/machinery/embedded_controller/radio/airlock))	//if our controller is an airlock controller than we can auto-init our tags
 		var/obj/machinery/embedded_controller/radio/airlock/controller = master
+		if(cycle_to_external_air)
+			tag_pump_out_external = SET_AIRLOCK_TAG(controller.tag_pump_out_external, "[id_tag]_pump_out_external")
+			tag_pump_out_internal = SET_AIRLOCK_TAG(controller.tag_pump_out_internal, "[id_tag]_pump_out_internal")
 		tag_exterior_door = SET_AIRLOCK_TAG(controller.tag_exterior_door, "[id_tag]_outer")
 		tag_interior_door = SET_AIRLOCK_TAG(controller.tag_interior_door, "[id_tag]_inner")
 		tag_airpump = SET_AIRLOCK_TAG(controller.tag_airpump, "[id_tag]_pump")


### PR DESCRIPTION
## Description of changes
Mapping airlocks that cycle to external air on maps that can be duplicated (and thus use map hashes) is currently impossible because the required tags are only ever defined on the program, and autoset handles map hashes improperly. This fixes that by letting you define them on the controller.

## Why and what will this PR improve
Lets me map these in on map templates without headaches.