### PR TITLE
Fix trailing space on ore chunk name

### DIFF
--- a/code/modules/materials/materials_ore.dm
+++ b/code/modules/materials/materials_ore.dm
@@ -87,7 +87,7 @@
 
 /obj/item/stack/material/ore/update_strings()
 	. = ..()
-	SetName("[(material.ore_name ? material.ore_name : "[material.name] chunk")] [(amount > 1? "pile" : "")]")
+	SetName("[(material.ore_name ? material.ore_name : "[material.name] chunk")][(amount > 1? " pile" : "")]")
 	desc = material.ore_desc ? material.ore_desc : "A lump of ore."
 
 /obj/item/stack/material/ore/get_recipes()


### PR DESCRIPTION
## Description of changes
The string had a space where it would always show up. That's fixed now.

## Why and what will this PR improve
`water chunk ` <<<<<< `water chunk`