### PR TITLE
Fix material processors breaking on (shuttle) move

### DIFF
--- a/code/modules/mining/machinery/_material_processing.dm
+++ b/code/modules/mining/machinery/_material_processing.dm
@@ -90,6 +90,7 @@
 /obj/machinery/material_processing/Destroy()
 	input_turf = null
 	output_turf = null
+	events_repository.unregister(/decl/observ/moved, src, src, .proc/on_moved)
 	. = ..()
 
 /obj/machinery/material_processing/Initialize()

--- a/code/modules/mining/machinery/_material_processing.dm
+++ b/code/modules/mining/machinery/_material_processing.dm
@@ -27,13 +27,13 @@
 /obj/machinery/material_processing/on_update_icon()
 
 	cut_overlays()
-	
+
 	icon_state = initial(icon_state)
 	if(panel_open)
 		add_overlay("[icon_state]-open")
 	if(!use_power || (stat & (BROKEN|NOPOWER)))
 		icon_state = "[icon_state]-off"
-	
+
 	var/overlay_dir = 0
 	if(input_turf)
 		overlay_dir = get_dir(src, input_turf)
@@ -98,6 +98,13 @@
 	SET_OUTPUT(output_turf)
 	. = ..()
 	queue_icon_update()
+	events_repository.register(/decl/observ/moved, src, src, .proc/on_moved)
+
+/obj/machinery/material_processing/proc/on_moved(atom/moving, atom/old_loc, atom/new_loc)
+	if(istype(input_turf, /turf))
+		input_turf = get_step(get_turf(src), get_dir(get_turf(old_loc), input_turf))
+	if(istype(output_turf, /turf))
+		output_turf = get_step(get_turf(src), get_dir(get_turf(old_loc), output_turf))
 
 /obj/machinery/material_processing/OnTopic(var/user, var/list/href_list)
 	if(href_list["toggle_power"])


### PR DESCRIPTION
## Description of changes
Material processors start with `input_turf` and `output_turf` as directions. These are then changed to actual turf references.
However, these aren't updated when they move, which is an issue mainly for shuttles. By using the moved observation we can update it properly on move.

## Why and what will this PR improve
Material processors will now input and output from the right turfs relative to them after moving in a shuttle.