### PR TITLE
Improve radiation-bombed exoplanet generation

### DIFF
--- a/code/modules/overmap/exoplanets/planet_themes/radiation_bombing.dm
+++ b/code/modules/overmap/exoplanets/planet_themes/radiation_bombing.dm
@@ -9,19 +9,20 @@
 /datum/exoplanet_theme/radiation_bombing/get_sensor_data()
 	return "Hotspots of radiation detected."
 
-/datum/exoplanet_theme/radiation_bombing/after_map_generation(obj/effect/overmap/visitable/sector/exoplanet/E)
+/datum/exoplanet_theme/radiation_bombing/after_map_generation(obj/effect/overmap/visitable/sector/exoplanet/our_exoplanet)
 	var/radiation_power = rand(10, 37.5)
-	var/num_craters = round(min(0.5, rand()) * 0.02 * E.maxx * E.maxy)
+	var/num_craters = round(min(0.5, rand()) * 0.02 * our_exoplanet.maxx * our_exoplanet.maxy)
+	var/area_turfs = get_area_turfs(our_exoplanet.planetary_area, list(/proc/not_turf_contains_dense_objects))
 	for(var/i = 1 to num_craters)
-		var/turf/simulated/T = pick_area_turf(E.planetary_area, list(/proc/not_turf_contains_dense_objects))
-		if(!T) // ran out of space somehow
+		var/turf/simulated/crater_center = pick_n_take(area_turfs)
+		if(!crater_center) // ran out of space somehow
 			return
-		new/obj/structure/rubble/war(T)
-		var/datum/radiation_source/S = new(T, radiation_power, FALSE)
-		S.range = 4
-		SSradiation.add_source(S)
-		T.set_light(2, 0.4, PIPE_COLOR_GREEN)
-		for(var/turf/exterior/crater in circlerangeturfs(T, 3))
+		new/obj/structure/rubble/war(crater_center)
+		var/datum/radiation_source/source = new(crater_center, radiation_power, FALSE)
+		source.range = 4
+		SSradiation.add_source(source)
+		crater_center.set_light(2, 0.4, PIPE_COLOR_GREEN)
+		for(var/turf/exterior/crater in circlerangeturfs(crater_center, 3))
 			if(prob(10))
 				new/obj/item/remains/xeno/charred(crater)
 			crater.melt()


### PR DESCRIPTION
## Description of changes
So this was doing, like, 350 implicit in world loops during init? Not totally sure how much this will improve performance but it's worth a shot.

## Why and what will this PR improve
Avoids redundant area contents checks (which are implicit in world loops) by caching the results from the first call to `get_area_turfs` and removing turfs as they get used. This takes it from like 350 in-worlds for a 255x255 map down to 1.