### PR TITLE
Porting LemonInTheDark's roundstart subsystem optimizations.

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -259,7 +259,7 @@ var/global/datum/controller/master/Master = new
 		SS.state = SS_IDLE
 		if (SS.flags & SS_TICKER)
 			tickersubsystems += SS
-			timer += world.tick_lag * rand(1, 5)
+			timer += world.tick_lag * rand(0,1)
 			SS.next_fire = timer
 			continue
 
@@ -334,14 +334,16 @@ var/global/datum/controller/master/Master = new
 			var/checking_runlevel = current_runlevel
 			if(cached_runlevel != checking_runlevel)
 				//resechedule subsystems
+				var/list/old_subsystems = current_runlevel_subsystems
 				cached_runlevel = checking_runlevel
 				current_runlevel_subsystems = runlevel_sorted_subsystems[cached_runlevel]
-				var/stagger = world.time
-				for(var/I in current_runlevel_subsystems)
-					var/datum/controller/subsystem/SS = I
-					if(SS.next_fire <= world.time)
-						stagger += world.tick_lag * rand(1, 5)
-						SS.next_fire = stagger
+
+				//now we'll go through all the subsystems we want to offset and give them a next_fire
+				for(var/datum/controller/subsystem/SS as anything in current_runlevel_subsystems)
+					//we only want to offset it if it's new and also behind
+					if(SS.next_fire > world.time || (SS in old_subsystems))
+						continue
+					SS.next_fire = world.time + world.tick_lag * rand(0, DS2TICKS(min(SS.wait, 2 SECONDS)))
 
 			subsystems_to_check = current_runlevel_subsystems
 		else

--- a/maps/antag_spawn/mercenary/mercenary.dm
+++ b/maps/antag_spawn/mercenary/mercenary.dm
@@ -3,7 +3,6 @@
 	id = "mercenary_spawn"
 	suffixes = list("mercenary/mercenary_base.dmm")
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/merc_shuttle)
-	template_flags = TEMPLATE_FLAG_TEST_DUPLICATES
 	apc_test_exempt_areas = list(
 		/area/map_template/merc_spawn = NO_SCRUBBER|NO_VENT
 	)


### PR DESCRIPTION
## Description of changes
Optimizes the delay offset on subsystems during runlevel change to account for a large number of subsystems causing a long delay. Full details in the original PR body: https://github.com/tgstation/tgstation/pull/71730

## Why and what will this PR improve
Removes the lengthy delay at roundstart, rounds start almost immediately now.

## Authorship
@LemonInTheDark for the code I stole (with many thanks).
@Kapu1178 for pointing out the optimization.

## Changelog
Nothing player-facing.