### PR TITLE
Fix BLOCK_HEAD_HAIR making hair bald instead of short

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -448,14 +448,6 @@ var/global/list/damage_icon_parts = list()
 			queue_icon_update()
 		return
 
-	//masks and helmets can obscure our hair.
-	for(var/slot in global.airtight_slots)
-		var/obj/item/gear = get_equipped_item(slot)
-		if(gear && (gear.flags_inv & BLOCK_ALL_HAIR))
-			if(update_icons)
-				queue_icon_update()
-			return
-
 	overlays_standing[HO_HAIR_LAYER] = head_organ.get_hair_icon()
 	if(update_icons)
 		queue_icon_update()


### PR DESCRIPTION
## Description of changes
Removes code that stops hair from drawing with `BLOCK_HEAD_HAIR`. It was added ~11 years ago, and the code that changes the drawn style to the short style if you have `BLOCK_HEAD_HAIR` was added around 4 or 5 years ago, so the newer stuff wins out (and also it looks better).

Targets staging because the code on stable is substantially different, and removing it twice might cause weird conflicts.

## Why and what will this PR improve
This "feature" is unnecessary because `BLOCK_HEAD_HAIR` already sets the drawn hairstyle to short hair if it lacks the VERY_SHORT flag, which visually distinguishes between bald and not-bald individuals better than the current system.