### PR TITLE
Make replaced job items go in storage

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -425,9 +425,13 @@ var/global/list/gear_datums = list()
 	var/obj/item/old_item = wearer.get_equipped_item(slot)
 	if(wearer.equip_to_slot_if_possible(item, slot, del_on_fail = TRUE, force = TRUE, delete_old_item = FALSE))
 		. = item
-		if(old_item && old_item.type != item.type)
-			wearer.u_equip(old_item)
+		if(!old_item)
+			return
+		wearer.u_equip(old_item)
+		if(old_item.type != item.type)
 			place_in_storage_or_drop(wearer, old_item)
+		else
+			qdel(old_item)
 
 /decl/loadout_option/proc/spawn_in_storage_or_drop(mob/living/carbon/human/wearer, metadata)
 	var/obj/item/item = spawn_and_validate_item(wearer, metadata)

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -417,28 +417,35 @@ var/global/list/gear_datums = list()
 	if(metadata && !islist(metadata))
 		PRINT_STACK_TRACE("Loadout spawn_item() proc received non-null non-list metadata: '[json_encode(metadata)]'")
 
-/decl/loadout_option/proc/spawn_on_mob(var/mob/living/carbon/human/H, var/metadata)
-	var/obj/item/item = spawn_and_validate_item(H, metadata)
+/decl/loadout_option/proc/spawn_on_mob(mob/living/carbon/human/wearer, metadata)
+	var/obj/item/item = spawn_and_validate_item(wearer, metadata)
 	if(!item)
 		return
 
-	if(H.equip_to_slot_if_possible(item, slot, del_on_fail = 1, force = 1))
+	var/obj/item/old_item = wearer.get_equipped_item(slot)
+	if(wearer.equip_to_slot_if_possible(item, slot, del_on_fail = TRUE, force = TRUE, delete_old_item = FALSE))
 		. = item
+		if(old_item && old_item.type != item.type)
+			wearer.u_equip(old_item)
+			place_in_storage_or_drop(wearer, old_item)
 
-/decl/loadout_option/proc/spawn_in_storage_or_drop(var/mob/living/carbon/human/H, var/metadata)
-	var/obj/item/item = spawn_and_validate_item(H, metadata)
+/decl/loadout_option/proc/spawn_in_storage_or_drop(mob/living/carbon/human/wearer, metadata)
+	var/obj/item/item = spawn_and_validate_item(wearer, metadata)
 	if(!item)
 		return
 
-	var/atom/placed_in = H.equip_to_storage(item)
+	place_in_storage_or_drop(wearer, item)
+
+/decl/loadout_option/proc/place_in_storage_or_drop(mob/living/carbon/human/wearer, obj/item/item)
+	var/atom/placed_in = wearer.equip_to_storage(item)
 	if(placed_in)
-		to_chat(H, "<span class='notice'>Placing \the [item] in your [placed_in.name]!</span>")
-	else if(H.equip_to_appropriate_slot(item))
-		to_chat(H, "<span class='notice'>Placing \the [item] in your inventory!</span>")
-	else if(H.put_in_hands(item))
-		to_chat(H, "<span class='notice'>Placing \the [item] in your hands!</span>")
+		to_chat(wearer, SPAN_NOTICE("Placing \the [item] in your [placed_in.name]!"))
+	else if(wearer.equip_to_appropriate_slot(item))
+		to_chat(wearer, SPAN_NOTICE("Placing \the [item] in your inventory!"))
+	else if(wearer.put_in_hands(item))
+		to_chat(wearer, SPAN_NOTICE("Placing \the [item] in your hands!"))
 	else
-		to_chat(H, "<span class='danger'>Dropping \the [item] on the ground!</span>")
+		to_chat(wearer, SPAN_DANGER("Dropping \the [item] on the ground!"))
 
 /decl/loadout_option/proc/spawn_and_validate_item(mob/living/carbon/human/H, metadata)
 	PRIVATE_PROC(TRUE)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -15,7 +15,7 @@
 //set disable_warning to disable the 'you are unable to equip that' warning.
 //unset redraw_mob to prevent the mob from being redrawn at the end.
 //set force to replace items in the slot and ignore blocking overwear
-/mob/proc/equip_to_slot_if_possible(obj/item/W, slot, del_on_fail = 0, disable_warning = 0, redraw_mob = 1, force = 0)
+/mob/proc/equip_to_slot_if_possible(obj/item/W, slot, del_on_fail = 0, disable_warning = 0, redraw_mob = 1, force = FALSE, delete_old_item = TRUE)
 	if(!istype(W) || !slot)
 		return FALSE
 
@@ -27,12 +27,12 @@
 		return FALSE
 
 	if(canUnEquip(W))
-		equip_to_slot(W, slot, redraw_mob) //This proc should not ever fail.
+		equip_to_slot(W, slot, redraw_mob, delete_old_item = delete_old_item) //This proc should not ever fail.
 		return TRUE
 
 //This is an UNSAFE proc. It merely handles the actual job of equipping. All the checks on whether you can or can't eqip need to be done before! Use mob_can_equip() for that task.
 //In most cases you will want to use equip_to_slot_if_possible()
-/mob/proc/equip_to_slot(obj/item/W, slot)
+/mob/proc/equip_to_slot(obj/item/W, slot, delete_old_item = TRUE)
 	SHOULD_CALL_PARENT(TRUE)
 	return istype(W) && !isnull(slot)
 

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -162,7 +162,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 // Post hands rewrite I plan to conver the rest of the inventory system to a string-based inventory slot system
 // so at that point the numerical flags will be removed and this proc (and the rest of the chain) can be rewritten.
 
-/mob/living/carbon/human/equip_to_slot(obj/item/W, slot, redraw_mob = 1)
+/mob/living/carbon/human/equip_to_slot(obj/item/W, slot, redraw_mob = TRUE, delete_old_item = TRUE)
 
 	. = ..()
 	if(!. || !has_organ_for_slot(slot))
@@ -185,7 +185,9 @@ This saves us from having to call add_fingerprint() any time something is put in
 			if(W.action_button_name)
 				update_action_buttons()
 			if(old_item)
-				qdel(old_item)
+				u_equip(old_item)
+				if(delete_old_item)
+					qdel(old_item)
 			return TRUE
 	// End boilerplate.
 
@@ -200,9 +202,8 @@ This saves us from having to call add_fingerprint() any time something is put in
 			update_inv_back(redraw_mob)
 		if(slot_wear_mask_str)
 			_wear_mask = W
-			if(_wear_mask.flags_inv & BLOCK_ALL_HAIR)
-				update_hair(redraw_mob)	//rebuild hair
-				update_inv_ears(0)
+			update_hair(redraw_mob)	//rebuild hair
+			update_inv_ears(0)
 			W.equipped(src, slot)
 			update_inv_wear_mask(redraw_mob)
 		if(slot_handcuffed_str)
@@ -235,9 +236,9 @@ This saves us from having to call add_fingerprint() any time something is put in
 			update_inv_gloves(redraw_mob)
 		if(slot_head_str)
 			_head = W
-			if(_head.flags_inv & (BLOCK_ALL_HAIR|HIDEMASK))
-				update_hair(redraw_mob)	//rebuild hair
-				update_inv_ears(0)
+			update_hair(redraw_mob)	//rebuild hair
+			update_inv_ears(0)
+			if(_head.flags_inv & HIDEMASK)
 				update_inv_wear_mask(0)
 			if(istype(W,/obj/item/clothing/head/kitty))
 				W.update_icon(src)
@@ -296,9 +297,12 @@ This saves us from having to call add_fingerprint() any time something is put in
 	if(W.action_button_name)
 		update_action_buttons()
 
-	// if we replaced an item, delete the old item. do this at the end to make the replacement seamless
+	// seamless replacement deletes the old item by default, but can be disabled for special handling
+	// like job items going into storage when replaced by loadout items
 	if(old_item)
-		qdel(old_item)
+		u_equip(old_item)
+		if(delete_old_item)
+			qdel(old_item)
 
 	return 1
 


### PR DESCRIPTION
## Description of changes
Job items replaced by loadout items will now go in storage (or be equipped, or put in hands, or dropped on the floor) instead of vanishing.

## Why and what will this PR improve
Some jobs in the shiptesting modpack I'm working on start with important safety equipment which disappears completely (it actually gets qdeleted) just because my character has a loadout item that takes the same slot.

The alternative to this PR would be to make the loadout item go in storage instead, which I kind of like. Might open it alongside this one.

## Authorship
Me.

## Changelog
:cl:
add: Job items replaced by loadout items now go into storage.
/:cl: