### PR TITLE
Make loadout items targeting full slots go in storage

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -408,7 +408,7 @@ SUBSYSTEM_DEF(jobs)
 	if(!H || !H.client)
 		return
 
-	// Equip custom gear loadout, replacing any job items
+	// Equip custom gear loadout, going into storage if the slot is full
 	var/list/spawn_in_storage = list()
 	var/list/loadout_taken_slots = list()
 	if(H.client.prefs.Gear() && job.loadout_allowed)

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -417,12 +417,15 @@ var/global/list/gear_datums = list()
 	if(metadata && !islist(metadata))
 		PRINT_STACK_TRACE("Loadout spawn_item() proc received non-null non-list metadata: '[json_encode(metadata)]'")
 
-/decl/loadout_option/proc/spawn_on_mob(var/mob/living/carbon/human/H, var/metadata)
-	var/obj/item/item = spawn_and_validate_item(H, metadata)
+/decl/loadout_option/proc/spawn_on_mob(mob/living/carbon/human/wearer, metadata, replace_existing = FALSE)
+	var/obj/item/item = spawn_and_validate_item(wearer, metadata)
 	if(!item)
 		return
 
-	if(H.equip_to_slot_if_possible(item, slot, del_on_fail = 1, force = 1))
+	if(!replace_existing && wearer.get_equipped_item(slot))
+		return
+
+	if(wearer.equip_to_slot_if_possible(item, slot, del_on_fail = TRUE, force = TRUE))
 		. = item
 
 /decl/loadout_option/proc/spawn_in_storage_or_drop(var/mob/living/carbon/human/H, var/metadata)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -200,9 +200,8 @@ This saves us from having to call add_fingerprint() any time something is put in
 			update_inv_back(redraw_mob)
 		if(slot_wear_mask_str)
 			_wear_mask = W
-			if(_wear_mask.flags_inv & BLOCK_ALL_HAIR)
-				update_hair(redraw_mob)	//rebuild hair
-				update_inv_ears(0)
+			update_hair(redraw_mob)	//rebuild hair
+			update_inv_ears(0)
 			W.equipped(src, slot)
 			update_inv_wear_mask(redraw_mob)
 		if(slot_handcuffed_str)
@@ -235,10 +234,9 @@ This saves us from having to call add_fingerprint() any time something is put in
 			update_inv_gloves(redraw_mob)
 		if(slot_head_str)
 			_head = W
-			if(_head.flags_inv & (BLOCK_ALL_HAIR|HIDEMASK))
-				update_hair(redraw_mob)	//rebuild hair
-				update_inv_ears(0)
-				update_inv_wear_mask(0)
+			update_hair(redraw_mob)	//rebuild hair
+			update_inv_ears(0)
+			update_inv_wear_mask(0)
 			if(istype(W,/obj/item/clothing/head/kitty))
 				W.update_icon(src)
 			W.equipped(src, slot)

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -72,7 +72,7 @@
 			all_underwear.Cut()
 
 	if((equip_preview_mob & EQUIP_PREVIEW_LOADOUT) && !(previewJob && (equip_preview_mob & EQUIP_PREVIEW_JOB) && previewJob.skip_loadout_preview))
-		// Equip custom gear loadout, replacing any job items
+		// Equip custom gear loadout, replacing any job items for the preview
 		var/list/loadout_taken_slots = list()
 		for(var/thing in Gear())
 			var/decl/loadout_option/G = global.gear_datums[thing]
@@ -92,7 +92,7 @@
 				if(!permitted)
 					continue
 
-				if(G.slot && G.slot != slot_tie_str && !(G.slot in loadout_taken_slots) && G.spawn_on_mob(mannequin, gear_list[gear_slot][G.name]))
+				if(G.slot && G.slot != slot_tie_str && !(G.slot in loadout_taken_slots) && G.spawn_on_mob(mannequin, gear_list[gear_slot][G.name], replace_existing = TRUE))
 					loadout_taken_slots.Add(G.slot)
 					update_icon = TRUE
 


### PR DESCRIPTION
## Description of changes
Alternative PR to #2902.
Loadout items targeting a full slot (filled due to job equipment) will now go in storage (or be equipped, or put in hands, or dropped on the floor) instead of destroying the job equipment.

## Why and what will this PR improve
Some jobs in the shiptesting modpack I'm working on start with important safety equipment which disappears completely (it actually gets qdeleted) just because my character has a loadout item that takes the same slot.

The alternative to this PR would be to make the job item go in storage instead; see #2902.

In theory this sounded nicer, but I kind of dislike it because it means you'll have to find somewhere to change out of your jumpsuit every round if you select one in your loadout.

## Authorship
Me.

## Changelog
:cl:
add: Loadout items now default to going into storage if they take the same slot as a job item.
/:cl: