### PR TITLE
Remove redundant sector name from navpoint names

### DIFF
--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -127,10 +127,11 @@ var/global/list/shuttle_landmarks = list()
 
 /obj/effect/shuttle_landmark/automatic/sector_set(var/obj/effect/overmap/visitable/O)
 	..()
-	SetName("[O.name] - [initial(name)] ([x],[y])")
+	SetName("[initial(name)] ([x],[y])")
 
 //Subtype that calls explosion on init to clear space for shuttles
 /obj/effect/shuttle_landmark/automatic/clearing
+	name = "clearing"
 	var/radius = 10
 
 /obj/effect/shuttle_landmark/automatic/clearing/Initialize(var/ml, var/supplied_radius)


### PR DESCRIPTION
## Description of changes
Automatic shuttle landmarks included the sector name in their name, but that's already included in the popup when landing and in the shuttle console UI. That made it run off the screen and look really bad. This fixes that.

## Why and what will this PR improve
You can actually see the name and coordinates of the navpoint.