### PR TITLE
Pause subsystems during random_map auto-apply

### DIFF
--- a/code/modules/random_map/random_map.dm
+++ b/code/modules/random_map/random_map.dm
@@ -136,7 +136,9 @@ var/global/list/map_count = list()
 	if(check_map_sanity())
 		cleanup()
 		if(auto_apply)
+			Master.StartLoadingMap()
 			apply_to_map()
+			Master.StopLoadingMap()
 		return 1
 	return 0
 


### PR DESCRIPTION
## Description of changes
Uses `Master.StartLoadingMap()` and `Master.StopLoadingMap()` to pause certain subsystems during map generation, which should prevent unnecessary light and AO updates while applying random maps.

## Why and what will this PR improve
Will hopefully improve the speed of exoplanet generation?