### PR TITLE
Add testing for + fix away site pipe leaks

### DIFF
--- a/code/modules/atmospherics/components/unary/heat_source.dm
+++ b/code/modules/atmospherics/components/unary/heat_source.dm
@@ -15,6 +15,7 @@
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
+	connect_types = CONNECT_TYPE_REGULAR | CONNECT_TYPE_FUEL
 
 	var/max_temperature = T20C + 680
 	var/internal_volume = 600	//L

--- a/code/modules/maps/_map_template.dm
+++ b/code/modules/maps/_map_template.dm
@@ -104,14 +104,13 @@
 	SSshuttle.block_queue = pre_init_state
 	SSshuttle.clear_init_queue() // We will flush the queue unless there were other blockers, in which case they will do it.
 
-/datum/map_template/proc/load_new_z(no_changeturf = TRUE)
-
-	var/x = round((world.maxx - width)/2)
-	var/y = round((world.maxy - height)/2)
+/datum/map_template/proc/load_new_z(no_changeturf = TRUE, centered=TRUE)
+	var/x = max(round((world.maxx - width)/2), 1)
+	var/y = max(round((world.maxy - height)/2), 1)
+	if(!centered)
+		x = 1
+		y = 1
 	var/initial_z = world.maxz + 1
-
-	if (x < 1) x = 1
-	if (y < 1) y = 1
 
 	var/list/bounds = list(1.#INF, 1.#INF, 1.#INF, -1.#INF, -1.#INF, -1.#INF)
 	var/list/atoms_to_initialise = list()

--- a/code/modules/maps/helper_landmarks.dm
+++ b/code/modules/maps/helper_landmarks.dm
@@ -99,3 +99,9 @@
 	if(shuttle_datum)
 		events_repository.unregister(/decl/observ/shuttle_moved, shuttle_datum, src, .proc/delete_everything)
 	. = ..()
+
+/// Used to tell pipe leak unit tests that a leak is intentional. Placed over the pipe that leaks, not the tile missing a pipe.
+/obj/abstract/landmark/allowed_leak
+#ifndef UNIT_TEST
+	delete_me = TRUE
+#endif

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -538,20 +538,20 @@
 
 //=======================================================================================
 
-/datum/unit_test/station_pipes_shall_not_leak
-	name = "MAP: Station pipes shall not leak"
+/datum/unit_test/pipes_shall_not_leak
+	name = "MAP: Pipes shall not leak unless allowed"
 
-/datum/unit_test/station_pipes_shall_not_leak/start_test()
+/datum/unit_test/pipes_shall_not_leak/start_test()
 	var/failures = 0
 	for(var/obj/machinery/atmospherics/pipe/P in SSmachines.machinery)
-		if(P.leaking && isStationLevel(P.z))
+		if(P.leaking && isPlayerLevel(P.z) && !(locate(/obj/abstract/landmark/allowed_leak) in get_turf(P)))
 			failures++
 			log_bad("Following pipe is leaking: [log_info_line(P)]")
 
 	if(failures)
-		fail("[failures] station pipe\s leak.")
+		fail("[failures] pipe\s leaking without allowed leak landmark!")
 	else
-		pass("No station pipes are leaking")
+		pass("No pipes are leaking.")
 	return 1
 
 //=======================================================================================

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -3735,6 +3735,7 @@
 	},
 /obj/effect/floor_decal/corner/blue,
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled/airless,
 /area/ship/scrap/maintenance/atmos)
 "hi" = (
@@ -3749,6 +3750,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled/airless,
 /area/ship/scrap/maintenance/atmos)
 "hj" = (
@@ -3771,6 +3773,7 @@
 	dir = 1
 	},
 /mob/living/simple_animal/hostile/carp,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled/airless,
 /area/ship/scrap/maintenance/atmos)
 "hl" = (
@@ -4445,6 +4448,7 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/tiled/airless,
 /area/ship/scrap/maintenance/atmos)
 "iu" = (
@@ -4526,14 +4530,14 @@
 /turf/simulated/floor/tiled/airless,
 /area/ship/scrap/maintenance/atmos)
 "iE" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/blue{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/blue,
 /obj/effect/floor_decal/corner/yellow{
 	dir = 4
 	},
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/blue{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/airless,
 /area/ship/scrap/maintenance/atmos)
 "iF" = (
@@ -4857,6 +4861,7 @@
 "js" = (
 /obj/machinery/atmospherics/valve/open,
 /obj/item/shard/borosilicate,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless,
 /area/ship/scrap/maintenance/engine/aft)
 "jt" = (
@@ -4969,6 +4974,7 @@
 /area/ship/scrap/maintenance/engine/aft)
 "jH" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless,
 /area/ship/scrap/maintenance/engine/aft)
 "jI" = (
@@ -5020,6 +5026,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /mob/living/simple_animal/hostile/carp,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless,
 /area/ship/scrap/maintenance/engine/aft)
 "jQ" = (

--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -1860,6 +1860,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/casino/casino_maintenance)
 "fq" = (
@@ -2814,6 +2817,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/casino/casino_crew_atmos)
 "ij" = (
@@ -3106,6 +3110,7 @@
 /obj/machinery/atmospherics/omni/filter{
 	dir = 8
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/plating,
 /area/casino/casino_crew_atmos)
 "iY" = (
@@ -3116,6 +3121,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/plating,
 /area/casino/casino_crew_atmos)
 "iZ" = (
@@ -3173,6 +3179,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 9
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/plating,
 /area/casino/casino_crew_atmos)
 "ji" = (
@@ -5338,6 +5345,11 @@
 	},
 /turf/simulated/floor/airless,
 /area/casino/casino_bow)
+"TO" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/red,
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/plating,
+/area/casino/casino_crew_atmos)
 "Ub" = (
 /obj/structure/window/basic{
 	dir = 4
@@ -9506,7 +9518,7 @@ gM
 gg
 ix
 iI
-iW
+TO
 iV
 jy
 jN

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -2382,6 +2382,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless,
 /area/constructionsite/atmospherics)
 "iv" = (
@@ -2717,6 +2718,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless,
 /area/constructionsite/atmospherics)
 "jr" = (
@@ -3420,6 +3422,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/constructionsite/teleporter)
+"nn" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/tiled/dark/airless,
+/area/constructionsite/atmospherics)
 "ob" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "constructionsite_vent"
@@ -3454,6 +3461,11 @@
 /obj/structure/wall_frame,
 /turf/simulated/floor/airless,
 /area/constructionsite/hallway/fore)
+"Yw" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/airless,
+/area/constructionsite/atmospherics)
 
 (1,1,1) = {"
 aa
@@ -24565,9 +24577,9 @@ hr
 hr
 hr
 hr
-hV
+nn
 ie
-ie
+Yw
 hr
 hs
 hr
@@ -25974,10 +25986,10 @@ hr
 hr
 hs
 hr
-hV
+nn
 hV
 ie
-ie
+Yw
 hs
 hr
 hs

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -2062,6 +2062,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/errant_pisces/solar_starboard)
 "fp" = (
@@ -2080,6 +2083,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/errant_pisces/solar_starboard)
 "fq" = (
@@ -2089,6 +2095,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -2167,6 +2176,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -2576,7 +2588,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/errant_pisces/hallway)
 "gA" = (
@@ -2768,6 +2782,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/wood,
 /area/errant_pisces/rooms)
 "hg" = (
@@ -2779,17 +2796,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/errant_pisces/rooms)
-"hh" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/errant_pisces/hallway)
+/area/errant_pisces/rooms)
+"hh" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/errant_pisces/bridge)
 "hi" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -2813,6 +2832,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/errant_pisces/dorms)
 "hk" = (
@@ -2821,6 +2843,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/errant_pisces/dorms)
@@ -2872,6 +2897,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/errant_pisces/rooms)
 "hu" = (
@@ -4777,6 +4803,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/errant_pisces/general_storage)
 "nb" = (
@@ -4787,6 +4814,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/freezer,
 /obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/freezer,
 /area/errant_pisces/prod_storage)
 "nc" = (
@@ -5198,6 +5226,12 @@
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/errant_pisces/aux_power)
 "nN" = (
@@ -5206,6 +5240,12 @@
 	},
 /obj/machinery/door/airlock,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/errant_pisces/aux_power)
 "nO" = (
@@ -5215,8 +5255,12 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/errant_pisces/aft_hallway)
 "nP" = (
@@ -5564,6 +5608,9 @@
 	},
 /obj/structure/cable/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled,
 /area/errant_pisces/bridge)
 "oM" = (
@@ -5692,6 +5739,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/errant_pisces/bridge)
 "ph" = (
@@ -5789,6 +5839,9 @@
 	pixel_x = -25;
 	rcon_setting = 3
 	},
+/obj/structure/cable/green{
+	icon_state = "1-6"
+	},
 /turf/simulated/floor/tiled,
 /area/errant_pisces/bridge)
 "py" = (
@@ -5847,6 +5900,9 @@
 	},
 /obj/structure/table/steel,
 /obj/random/snack,
+/obj/structure/cable/green{
+	icon_state = "6-9"
+	},
 /turf/simulated/floor/tiled,
 /area/errant_pisces/bridge)
 "pK" = (
@@ -5980,6 +6036,9 @@
 "qa" = (
 /obj/machinery/computer/ship/sensors{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "2-9"
 	},
 /turf/simulated/floor/tiled,
 /area/errant_pisces/bridge)
@@ -6118,6 +6177,7 @@
 /area/errant_pisces/fishing_wing)
 "qx" = (
 /obj/machinery/shipsensors,
+/obj/structure/cable/green,
 /turf/simulated/floor/reinforced/airless,
 /area/errant_pisces/bridge)
 "qy" = (
@@ -26267,7 +26327,7 @@ gd
 gk
 gy
 fZ
-hh
+gd
 fZ
 fZ
 fZ
@@ -26671,7 +26731,7 @@ gd
 gm
 gA
 fZ
-hh
+gd
 fZ
 fZ
 hM
@@ -28920,7 +28980,7 @@ oS
 oS
 pK
 qa
-po
+hh
 qx
 pp
 qH

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -800,12 +800,14 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/plating,
 /area/errant_pisces/atmos)
 "cw" = (
 /obj/machinery/atmospherics/omni/mixer{
 	dir = 1
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/plating,
 /area/errant_pisces/atmos)
 "cx" = (
@@ -903,6 +905,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/plating,
 /area/errant_pisces/atmos)
 "cN" = (
@@ -6432,6 +6435,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/errant_pisces/head_m)
+"QS" = (
+/obj/machinery/atmospherics/pipe/simple/visible/blue,
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/plating,
+/area/errant_pisces/atmos)
 "Ti" = (
 /obj/machinery/computer/modular{
 	dir = 4
@@ -25299,7 +25307,7 @@ aY
 bh
 bA
 bV
-bV
+QS
 cw
 cM
 cZ

--- a/maps/away/lost_supply_base/lost_supply_base.dmm
+++ b/maps/away/lost_supply_base/lost_supply_base.dmm
@@ -761,6 +761,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless,
 /area/lost_supply_base)
 "cf" = (
@@ -941,6 +942,7 @@
 /area/lost_supply_base)
 "cG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless,
 /area/lost_supply_base)
 "cH" = (
@@ -1002,6 +1004,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless,
 /area/lost_supply_base)
 "cT" = (
@@ -1026,12 +1029,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless,
 /area/lost_supply_base)
 "cY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless,
 /area/lost_supply_base)
 "cZ" = (
@@ -1041,6 +1046,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/wall,
 /area/lost_supply_base)
 "da" = (
@@ -1849,6 +1855,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled/airless{
 	icon_state = "steel_burned1"
 	},
@@ -1897,6 +1904,7 @@
 	pixel_x = 5;
 	pixel_y = -3
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled/airless,
 /area/lost_supply_base)
 "fT" = (
@@ -2008,6 +2016,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled/airless,
 /area/lost_supply_base)
 "gh" = (
@@ -2109,6 +2118,14 @@
 	icon_state = "steel_broken0"
 	},
 /area/lost_supply_base/supply)
+"nL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/airless,
+/area/lost_supply_base)
 "Jd" = (
 /obj/machinery/computer/modular{
 	dir = 1
@@ -8474,7 +8491,7 @@ bg
 bB
 bN
 bU
-bU
+nL
 cr
 aG
 cS

--- a/maps/away/magshield/magshield.dmm
+++ b/maps/away/magshield/magshield.dmm
@@ -400,6 +400,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless,
 /area/magshield/smes_storage)
 "bj" = (
@@ -1046,6 +1047,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless,
 /area/magshield/smes_storage)
 "cV" = (
@@ -1428,6 +1430,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless,
 /area/magshield/north)
 "ej" = (
@@ -1483,6 +1486,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless,
 /area/magshield/north)
 "eo" = (
@@ -2054,12 +2058,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/magshield/east)
-"fV" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/magshield/east)
 "fW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -2146,12 +2144,6 @@
 "gk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 5
-	},
-/turf/simulated/floor/airless,
-/area/magshield/east)
-"gl" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 9
 	},
 /turf/simulated/floor/airless,
 /area/magshield/east)
@@ -2444,6 +2436,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless,
 /area/magshield/east)
 "hh" = (
@@ -2730,6 +2723,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled,
 /area/magshield/west)
 "hZ" = (
@@ -2765,6 +2759,7 @@
 /area/magshield/west)
 "ie" = (
 /obj/machinery/seed_storage,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/magshield/east)
 "if" = (
@@ -3394,6 +3389,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless,
 /area/magshield/south)
 "kb" = (
@@ -3755,13 +3751,13 @@
 /turf/simulated/floor/tiled,
 /area/magshield/south)
 "le" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
-/area/magshield/south)
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/airless,
+/area/magshield/smes_storage)
 "lf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -3897,6 +3893,11 @@
 /obj/effect/shuttle_landmark/nav_magshield/nav3,
 /turf/space,
 /area/space)
+"qp" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/abstract/landmark/allowed_leak,
+/turf/space,
+/area/space)
 "uL" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/tiled,
@@ -3909,6 +3910,51 @@
 	},
 /turf/simulated/floor/airless,
 /area/magshield/east)
+"JW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/tiled,
+/area/magshield/south)
+"KZ" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
+	},
+/obj/abstract/landmark/allowed_leak,
+/turf/space,
+/area/space)
+"Oa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/tiled/dark,
+/area/magshield/west)
+"TY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/airless,
+/area/magshield/north)
+"Uw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/tiled,
+/area/magshield/south)
 
 (1,1,1) = {"
 aa
@@ -19371,7 +19417,7 @@ hM
 hM
 hM
 hM
-it
+Oa
 it
 it
 iK
@@ -20144,7 +20190,7 @@ bc
 bc
 bO
 bc
-bc
+qp
 aa
 ao
 aa
@@ -20346,10 +20392,10 @@ bc
 bc
 bc
 bc
-bc
+qp
 aa
 aa
-bN
+KZ
 ab
 de
 de
@@ -20547,7 +20593,7 @@ bc
 bc
 bc
 bc
-bc
+qp
 aa
 aa
 aa
@@ -21165,7 +21211,7 @@ dl
 dj
 dH
 dg
-ej
+TY
 dg
 dj
 de
@@ -23574,7 +23620,7 @@ aD
 aU
 bi
 bg
-aU
+le
 aU
 aU
 bZ
@@ -27058,7 +27104,7 @@ iq
 iq
 iq
 iq
-le
+kz
 iq
 ip
 ip
@@ -27865,7 +27911,7 @@ iq
 iq
 iq
 iq
-kx
+JW
 ip
 jl
 jl
@@ -28066,7 +28112,7 @@ jg
 ix
 jZ
 kt
-ix
+Uw
 ku
 kc
 jD
@@ -28446,7 +28492,7 @@ fi
 fi
 fU
 fi
-fU
+fi
 fi
 fi
 gF
@@ -28646,9 +28692,9 @@ fh
 fi
 fi
 fi
-fV
-ge
-gl
+fU
+fi
+fi
 fi
 fi
 fi

--- a/maps/away/mining/mining-signal.dmm
+++ b/maps/away/mining/mining-signal.dmm
@@ -1426,6 +1426,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "eR" = (
@@ -1516,6 +1517,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/plating{
 	icon_state = "dmg1"
 	},
@@ -2439,6 +2441,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/pistol/magnum,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/abandoned)
 "rb" = (

--- a/maps/away/slavers/slavers_base.dmm
+++ b/maps/away/slavers/slavers_base.dmm
@@ -371,6 +371,9 @@
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/airless,
 /area/slavers_base/cells)
 "bp" = (
@@ -457,9 +460,10 @@
 /turf/simulated/floor/tiled/airless,
 /area/slavers_base/cells)
 "by" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/tiled/airless,
-/area/slavers_base/cells)
+/obj/machinery/atmospherics/pipe/manifold/visible/black,
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/airless/ceiling,
+/area/slavers_base/powatm)
 "bz" = (
 /obj/structure/closet/crate/freezer/rations,
 /obj/effect/decal/cleanable/dirt,
@@ -727,11 +731,11 @@
 "cc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/airless,
 /area/slavers_base/cells)
 "cd" = (
@@ -2102,12 +2106,14 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless/ceiling,
 /area/slavers_base/powatm)
 "fN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 10
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless/ceiling,
 /area/slavers_base/powatm)
 "fO" = (
@@ -2218,6 +2224,7 @@
 /obj/machinery/atmospherics/omni/filter{
 	dir = 8
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless/ceiling,
 /area/slavers_base/powatm)
 "gf" = (
@@ -3884,6 +3891,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/slavers_base/dorms)
+"nm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/airless,
+/area/slavers_base/demo)
+"EJ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/airless/ceiling,
+/area/slavers_base/powatm)
 
 (1,1,1) = {"
 aa
@@ -14907,7 +14926,7 @@ eF
 da
 da
 fL
-gc
+by
 da
 da
 da
@@ -15513,7 +15532,7 @@ eH
 da
 da
 da
-gd
+EJ
 da
 da
 da
@@ -20138,7 +20157,7 @@ aM
 aM
 aM
 bo
-by
+cx
 aM
 aM
 aM
@@ -20975,7 +20994,7 @@ hr
 hH
 ie
 hd
-iI
+nm
 iZ
 jm
 jx

--- a/maps/away/smugglers/smugglers.dmm
+++ b/maps/away/smugglers/smugglers.dmm
@@ -83,6 +83,7 @@
 	icon_state = "door_closed";
 	name = "Internal Airlock"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/black,
 /turf/simulated/floor,
 /area/smugglers/base)
 "ar" = (

--- a/maps/away/unishi/unishi-3.dmm
+++ b/maps/away/unishi/unishi-3.dmm
@@ -1272,11 +1272,11 @@
 /area/unishi/living)
 "dE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/caution,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/unishi/living)
 "dF" = (
@@ -1959,6 +1959,12 @@
 /obj/random/clothing,
 /turf/simulated/floor/tiled,
 /area/unishi/living)
+"yC" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/unishi/living)
 "zD" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/random/cash,
@@ -1967,6 +1973,14 @@
 /obj/random/clothing,
 /obj/random/hat,
 /turf/simulated/floor/wood,
+/area/unishi/living)
+"AF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
 /area/unishi/living)
 "AK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -1980,8 +1994,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/unishi/living)
@@ -6230,9 +6244,9 @@ aO
 aO
 aO
 aO
-aO
-aO
-aO
+aP
+aP
+aP
 aO
 aO
 aO
@@ -6940,7 +6954,7 @@ bn
 ds
 bn
 dE
-bn
+AF
 dR
 dU
 dY
@@ -7659,7 +7673,7 @@ aP
 aP
 aP
 aP
-aP
+yC
 aP
 aP
 aP
@@ -7862,9 +7876,9 @@ aO
 aO
 aO
 aO
-aO
-aO
-aO
+aP
+aP
+aP
 aO
 aO
 aO

--- a/maps/away/unishi/unishi-3.dmm
+++ b/maps/away/unishi/unishi-3.dmm
@@ -872,9 +872,7 @@
 /area/unishi/living)
 "cD" = (
 /obj/structure/bed/chair/padded/black,
-/obj/machinery/computer/modular/telescreen/preset/generic{
-	dir = 2
-	},
+/obj/machinery/computer/modular/telescreen/preset/generic,
 /turf/simulated/floor/tiled,
 /area/unishi/living)
 "cE" = (
@@ -1975,6 +1973,16 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/unishi/living)
+"RG" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/unishi/living)
 "Um" = (
@@ -7549,7 +7557,7 @@ bf
 dW
 ea
 bf
-bq
+RG
 bf
 es
 be

--- a/maps/away_sites_testing/away_sites_testing_define.dm
+++ b/maps/away_sites_testing/away_sites_testing_define.dm
@@ -12,10 +12,10 @@
 	var/list/unsorted_sites = list_values(SSmapping.get_templates_by_category(MAP_TEMPLATE_CATEGORY_AWAYSITE))
 	var/list/sorted_sites = sortTim(unsorted_sites, /proc/cmp_sort_templates_tallest_to_shortest)
 	for (var/datum/map_template/A in sorted_sites)
-		A.load_new_z()
+		A.load_new_z(centered = FALSE)
 		testing("Spawning [A] in [english_list(GetConnectedZlevels(world.maxz))]")
 		if(A.template_flags & TEMPLATE_FLAG_TEST_DUPLICATES)
-			A.load_new_z()
+			A.load_new_z(centered = FALSE)
 			testing("Spawning [A] in [english_list(GetConnectedZlevels(world.maxz))]")
 
 /proc/cmp_sort_templates_tallest_to_shortest(var/datum/map_template/a, var/datum/map_template/b)

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -33,6 +33,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 6
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/wall/r_wall,
 /area/map_template/crashed_pod)
 "ag" = (
@@ -98,11 +99,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "an" = (
 /obj/machinery/atmospherics/omni/filter,
 /obj/effect/decal/cleanable/dirt,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "ao" = (
@@ -112,6 +115,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/tastybread,
 /obj/item/chems/drinks/cans/speer,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "ap" = (
@@ -180,11 +184,13 @@
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "av" = (
 /obj/machinery/atmospherics/omni/filter,
 /obj/effect/decal/cleanable/dirt,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "aw" = (
@@ -192,6 +198,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "ax" = (
@@ -234,6 +241,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 5
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/wall,
 /area/map_template/crashed_pod)
 "aE" = (
@@ -452,7 +460,6 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
 	dir = 1
 	},

--- a/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
@@ -46,6 +46,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/plating,
 /area/map_template/oldpod)
 "ai" = (
@@ -62,6 +63,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/plating,
 /area/map_template/oldpod)
 "ak" = (
@@ -147,6 +149,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled/monotile,
 /area/map_template/oldpod)
 "av" = (
@@ -155,6 +158,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aw" = (

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -2405,6 +2405,7 @@
 /area/map_template/colony/atmospherics)
 "fi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
+/obj/abstract/landmark/allowed_leak,
 /turf/exterior/concrete,
 /area/template_noop)
 "fj" = (
@@ -3662,6 +3663,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/exterior/concrete,
 /area/template_noop)
 "hr" = (

--- a/mods/content/corporate/away_sites/lar_maria/lar_maria-2.dmm
+++ b/mods/content/corporate/away_sites/lar_maria/lar_maria-2.dmm
@@ -1108,10 +1108,12 @@
 /obj/machinery/atmospherics/omni/filter{
 	dir = 4
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/plating,
 /area/lar_maria/atmos)
 "dr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/plating,
 /area/lar_maria/atmos)
 "ds" = (
@@ -1177,10 +1179,12 @@
 /area/lar_maria/atmos)
 "dD" = (
 /obj/machinery/atmospherics/binary/oxyregenerator,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/plating,
 /area/lar_maria/atmos)
 "dE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/plating,
 /area/lar_maria/atmos)
 "dF" = (
@@ -3090,6 +3094,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/lar_maria/solar_control)
+"ok" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/plating,
+/area/lar_maria/atmos)
 "pb" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
@@ -3183,12 +3194,31 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_f)
+"Ag" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/plating,
+/area/lar_maria/atmos)
 "DG" = (
 /obj/machinery/computer/modular{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/lar_maria/office)
+"FZ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/plating,
+/area/lar_maria/atmos)
+"YS" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 10
+	},
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/plating,
+/area/lar_maria/atmos)
 
 (1,1,1) = {"
 aa
@@ -22470,7 +22500,7 @@ pb
 ci
 cA
 cR
-cR
+ok
 dB
 tb
 bx
@@ -22671,7 +22701,7 @@ bx
 bM
 ci
 cn
-cl
+YS
 dn
 dB
 bM
@@ -22874,7 +22904,7 @@ bN
 ci
 cn
 cn
-cR
+ok
 dC
 dO
 bx
@@ -23480,7 +23510,7 @@ bQ
 ck
 bQ
 cU
-cU
+Ag
 bQ
 dR
 bG
@@ -24085,7 +24115,7 @@ bx
 qb
 cl
 cB
-cB
+FZ
 dp
 dF
 ub

--- a/mods/content/government/away_sites/icarus/icarus-1.dmm
+++ b/mods/content/government/away_sites/icarus/icarus-1.dmm
@@ -1149,6 +1149,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled,
 /area/icarus/open)
 "dX" = (
@@ -1996,6 +1997,7 @@
 "gy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/plating,
 /area/icarus/vessel)
 "gz" = (
@@ -2096,6 +2098,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/plating,
 /area/icarus/open)
 "gR" = (
@@ -2383,6 +2386,9 @@
 	dir = 4;
 	id_tag = "d1starboardnacelle"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/reinforced,
 /area/icarus/vessel)
 "hH" = (
@@ -2525,7 +2531,9 @@
 /turf/unsimulated/beach/sand,
 /area/icarus/open)
 "id" = (
-/obj/machinery/atmospherics/unary/engine,
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
 /turf/simulated/wall/r_wall,
 /area/icarus/open)
 "ie" = (
@@ -2661,6 +2669,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/icarus/vessel)
+"rK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/tiled,
+/area/icarus/open)
+"sK" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/plating,
+/area/icarus/open)
 
 (1,1,1) = {"
 aa
@@ -22008,7 +22029,7 @@ en
 en
 ei
 et
-hD
+sK
 eA
 hX
 et
@@ -22124,7 +22145,7 @@ dD
 dK
 dD
 dD
-dD
+rK
 ee
 ei
 ei
@@ -22207,7 +22228,7 @@ aq
 gR
 hd
 eA
-hD
+sK
 et
 aq
 hD
@@ -25760,7 +25781,7 @@ cf
 dL
 dY
 dD
-dD
+rK
 eA
 ei
 ei

--- a/mods/content/government/away_sites/icarus/icarus-2.dmm
+++ b/mods/content/government/away_sites/icarus/icarus-2.dmm
@@ -962,12 +962,12 @@
 /turf/simulated/floor/tiled,
 /area/icarus/vessel)
 "df" = (
-/obj/machinery/door/airlock,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled,
-/area/icarus/vessel)
+/area/icarus/open)
 "dg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -1271,6 +1271,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless{
 	icon_state = "dmg2"
 	},
@@ -1343,6 +1344,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled,
 /area/icarus/vessel)
 "el" = (
@@ -1813,6 +1815,12 @@
 /obj/structure/wall_frame,
 /turf/simulated/floor/plating,
 /area/icarus/vessel)
+"MC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/tiled,
+/area/icarus/open)
 "RQ" = (
 /obj/machinery/computer/modular{
 	dir = 4
@@ -21288,7 +21296,7 @@ dw
 dU
 dw
 dw
-dw
+MC
 ac
 cR
 ac
@@ -24921,7 +24929,7 @@ bY
 bY
 dN
 dw
-dU
+df
 dR
 cR
 cR
@@ -26126,7 +26134,7 @@ ap
 cu
 cJ
 ap
-df
+bw
 ap
 ap
 ap


### PR DESCRIPTION
## Description of changes
- Allows gas heaters to connect to fuel pipes.
- Adds testing for (unintended) leaking pipes on away sites.
- Adds a landmark to mark pipe leaks as intentional.
- Fixes all the reported pipe leaks on all the away sites.

Targeting dev because cherry-picking onto staging or stable might break my map edits.

## Why and what will this PR improve
There was a catastrophic overpressure leak in the Errant Pisces fuel bay that screwed up my round.

## Authorship
Me.