### PR TITLE
Fix codex nexus header

### DIFF
--- a/code/modules/codex/entries/codex.dm
+++ b/code/modules/codex/entries/codex.dm
@@ -21,7 +21,7 @@
 	mechanics_text = "The place to start with <span codexlink='the codex'>The Codex</span><br>"
 
 /datum/codex_entry/nexus/get_codex_body(mob/presenting_to, include_header, include_footer)
-	. = list(get_codex_header(presenting_to))
+	. = get_codex_header(presenting_to)
 	. += "[mechanics_text]"
 	. += "<h3>Categories</h3>"
 	var/list/category_strings


### PR DESCRIPTION
## Description of changes
Fixes the codex nexus header just saying `/list` instead of having the buttons.

## Why and what will this PR improve
It makes you able to actually use the header buttons.