### PR TITLE
Make ambience a lazylist

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -360,7 +360,7 @@ var/global/list/mob/living/forced_ambiance_list = new
 	if(LAZYLEN(forced_ambience) && !(L in forced_ambiance_list))
 		forced_ambiance_list += L
 		L.playsound_local(T,sound(pick(forced_ambience), repeat = 1, wait = 0, volume = 25, channel = sound_channels.lobby_channel))
-	if(ambience.len && prob(5) && (world.time >= L.client.played + 3 MINUTES))
+	if(LAZYLEN(ambience) && prob(5) && (world.time >= L.client.played + 3 MINUTES))
 		L.playsound_local(T, sound(pick(ambience), repeat = 0, wait = 0, volume = 15, channel = sound_channels.ambience_channel))
 		L.client.played = world.time
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -828,7 +828,7 @@
 			playsound_local(src,pick(global.scarySounds),50, 1, -1)
 
 	var/area/A = get_area(src)
-	if(client && world.time >= client.played + 600)
+	if(client && world.time >= client.played + 60 SECONDS)
 		A.play_ambience(src)
 	if(stat == UNCONSCIOUS && world.time - l_move_time < 5 && prob(10))
 		to_chat(src,"<span class='notice'>You feel like you're [pick("moving","flying","floating","falling","hovering")].</span>")


### PR DESCRIPTION
## Description of changes
Makes ambience a proper lazylist so that you can set it to null safely.
The only other code that touches it actually already assumed it was a lazylist and used LAZYDISTINCTADD.
Also changes the cooldown from `600` to `60 SECONDS`. They're equivalent but one is nicer. Could also do `1 MINUTE`?

## Why and what will this PR improve
IIRC Psy complained about it and also we should just remove `.len` entirely.