### PR TITLE
Fix uneven row width in latejoin menu

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -312,7 +312,7 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 				added_job = TRUE
 
 	if(!added_job)
-		dat += "<tr><td>No available positions.</td></tr>"
+		dat += "<tr><td colspan = 3>No available positions.</td></tr>"
 	// END MAIN MAP JOBS
 
 	// SUBMAP JOBS


### PR DESCRIPTION
## Description of changes
The entry for when no jobs are available on the main map had an incorrect column width, meaning it was uneven and left an ugly blank space.

## Why and what will this PR improve
Fills the empty space and makes the latejoin menu not look broken and buggy.