### PR TITLE
Fix strata spawning in unsuitable environments

### DIFF
--- a/code/modules/materials/geology/_strata.dm
+++ b/code/modules/materials/geology/_strata.dm
@@ -28,6 +28,6 @@
 	else if(isnull(ores_rich) && islist(ores_sparse))
 		ores_rich = ores_sparse.Copy()
 
-	for(var/mat_type in (ores_sparse|ores_rich))
+	for(var/mat_type in (base_materials|ores_sparse|ores_rich))
 		var/decl/material/mat = GET_DECL(mat_type)
 		maximum_temperature = min((mat.melting_point-1), maximum_temperature)

--- a/code/modules/materials/geology/strata_permafrost.dm
+++ b/code/modules/materials/geology/strata_permafrost.dm
@@ -18,3 +18,4 @@
 		/decl/material/solid/ice/hydrate/krypton,
 		/decl/material/solid/ice/hydrate/xenon,
 	)
+	maximum_temperature = T0C


### PR DESCRIPTION
## Description of changes
Checks base material melting point when automatically setting strata max temperature.
Sets the permafrost strata's max temperature to 0C since the melting point is set to 30C instead.

Note: `default_strata_candidate` is currently not checked. Checking that as well would also eliminate permafrost from spawning anywhere but snow planets, if that's desirable.

## Why and what will this PR improve
I was tired of seeing ice planets everywhere, honestly. More consistency with material compatibility and strata stuff is also good.