### PR TITLE
Make close_uis (and datum/Destroy) faster during init

### DIFF
--- a/code/controllers/subsystems/processing/nano.dm
+++ b/code/controllers/subsystems/processing/nano.dm
@@ -75,6 +75,9 @@ PROCESSING_SUBSYSTEM_DEF(nano)
   */
 /datum/controller/subsystem/processing/nano/proc/close_uis(src_object)
 	. = 0
+	if (!length(open_uis))
+		return
+
 	var/src_object_key = "\ref[src_object]"
 	if (!open_uis[src_object_key])
 		return


### PR DESCRIPTION
## Description of changes
Avoids an unnecessary \ref (which potentially causes slowdown due to string tree stuff) in /datum/Destroy by avoiding any of the close_ui logic if no NanoUI windows are open to begin with. This should make Destroy calls during init faster.

## Why and what will this PR improve
Faster datum/Destroy in init means ChangeTurf is marginally less expensive, which helps exoplanet gen go faster.