### PR TITLE
Fix \improper in UI titles

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -22,6 +22,12 @@
  * Text sanitization
  */
 
+/**
+ * Strip out the special beyond characters for \proper and \improper
+ * from text that will be sent to the browser.
+ */
+#define strip_improper(input_text) replacetext(replacetext(input_text, "\proper", ""), "\improper", "")
+
 //Used for preprocessing entered text
 //Added in an additional check to alert players if input is too long
 /proc/sanitize(input, max_length = MAX_MESSAGE_LEN, encode = TRUE, trim = TRUE, extra = TRUE, ascii_only = FALSE)
@@ -34,6 +40,8 @@
 			to_chat(usr, SPAN_WARNING("Your message is too long by [input_length - max_length] character\s."))
 			return
 		input = copytext_char(input, 1, max_length + 1)
+
+	input = strip_improper(input)
 
 	if(extra)
 		input = replace_characters(input, list("\n"=" ","\t"=" "))
@@ -458,12 +466,6 @@
 	. = jointext(.,null)
 
 #define starts_with(string, substring) (copytext(string,1,1+length(substring)) == substring)
-
-/**
- * Strip out the special beyond characters for \proper and \improper
- * from text that will be sent to the browser.
- */
-#define strip_improper(input_text) replacetext(replacetext(input_text, "\proper", ""), "\improper", "")
 
 /proc/pencode2html(t)
 	t = replacetext(t, "\n", "<BR>")

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -49,7 +49,7 @@
 		add_stylesheet("common", common_stylesheet)
 
 /datum/browser/proc/set_title(ntitle)
-	title = replacetext(replacetext(ntitle,"\proper ",""),"\improper ","")
+	title = sanitize(ntitle)
 
 /datum/browser/proc/add_head_content(nhead_content)
 	head_content = nhead_content

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -152,6 +152,7 @@ I said no!
 	result = /obj/item/chems/food/pancakes
 
 /decl/recipe/donkpocket
+	display_name = "fresh Donk-pocket"
 	items = list(
 		/obj/item/chems/food/doughslice,
 		/obj/item/chems/food/meatball
@@ -167,14 +168,14 @@ I said no!
 		warm_up(being_cooked)
 
 /decl/recipe/donkpocket/rawmeatball
-	display_name = "Raw Donk-Pocket"
+	display_name = "raw Donk-pocket"
 	items = list(
 		/obj/item/chems/food/doughslice,
 		/obj/item/chems/food/rawmeatball
 	)
 
 /decl/recipe/donkpocket/warm
-	display_name = "Warm Donk-Pocket"
+	display_name = "warm Donk-pocket"
 	reagents = list() //This is necessary since this is a child object of the above recipe and we don't want donk pockets to need flour
 	items = list(
 		/obj/item/chems/food/donkpocket


### PR DESCRIPTION
## Description of changes
Adds `strip_improper` to `sanitize`, replaces a bootleg copypaste of `strip_improper` in browser datum code with `sanitize`.

## Why and what will this PR improve
Closes #2635. Should prevent this issue from happening in UI titles in the future.