### PR TITLE
Fix grab interaction showing up for anchored atoms

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -521,6 +521,9 @@
 	expected_target_type = /atom/movable
 	interaction_flags = INTERACTION_NEEDS_PHYSICAL_INTERACTION | INTERACTION_NEEDS_TURF
 
+/decl/interaction_handler/grab/is_possible(atom/movable/target, mob/user, obj/item/prop)
+	return ..() && !target.anchored
+
 /decl/interaction_handler/grab/invoked(atom/target, mob/user, obj/item/prop)
 	var/atom/movable/AM = target
 	AM.try_make_grab(user, defer_hand = TRUE)


### PR DESCRIPTION
## Description of changes
Fixes the grab interaction (with extended alt interactions on) showing up for anchored atoms.

## Why and what will this PR improve
You can't grab anchored atoms anyway. Extended alt interactions are still not that great and I eventually disabled them after a few rounds, but this makes it much easier to use since it doesn't interfere with alt-clicking on catwalks or tables to view their contents. (The examine interaction still does, but I had that removed from alt interactions entirely during the testing.)