### PR TITLE
Make async tests await subsystems properly

### DIFF
--- a/code/unit_tests/proximity_tests.dm
+++ b/code/unit_tests/proximity_tests.dm
@@ -10,6 +10,7 @@
 	name = "PROXIMITY: " + name
 
 /datum/unit_test/proximity/setup_test()
+	..()
 	proximity_listener = new(get_turf(locate(/obj/abstract/landmark/proximity_spawner)))
 	wall = get_turf(locate(/obj/abstract/landmark/proximity_wall))
 

--- a/code/unit_tests/unit_test.dm
+++ b/code/unit_tests/unit_test.dm
@@ -61,6 +61,7 @@ var/global/ascii_reset = "[ascii_esc]\[0m"
 	var/static/safe_landmark
 	var/static/space_landmark
 	var/check_cleanup
+	var/list/times_fired_at_setup
 
 /datum/unit_test/proc/log_debug(var/message)
 	log_unit_test("[ascii_yellow]---  DEBUG  --- \[[name]\]: [message][ascii_reset]")
@@ -85,6 +86,11 @@ var/global/ascii_reset = "[ascii_esc]\[0m"
 
 // Executed before the test runs - Primarily intended for shared setup (generally in templates)
 /datum/unit_test/proc/setup_test()
+	SHOULD_CALL_PARENT(TRUE)
+	if(async)
+		LAZYINITLIST(times_fired_at_setup)
+		for(var/datum/controller/subsystem/subsystem_to_await in subsystems_to_await())
+			times_fired_at_setup[subsystem_to_await] = subsystem_to_await.times_fired
 	return
 
 /datum/unit_test/proc/start_test()

--- a/code/unit_tests/~unit_test_subsystems.dm
+++ b/code/unit_tests/~unit_test_subsystems.dm
@@ -108,7 +108,7 @@ SUBSYSTEM_DEF(unit_tests)
 		var/datum/unit_test/test = current_async[async.len]
 		for(var/S in test.subsystems_to_await())
 			var/datum/controller/subsystem/subsystem = S
-			if(subsystem.times_fired < 1)
+			if(subsystem.times_fired <= test.times_fired_at_setup[subsystem])
 				return
 		async.len--
 		if(check_unit_test(test, end_unit_tests))


### PR DESCRIPTION
## Description of changes
Ensures any awaited subsystems will fire at least once *after* the async test begins, rather than once *overall.*

## Why and what will this PR improve
This should fix the intermittent Desperado CI fails, which were due to weirdness with the timer subsystem falling behind IIRC.

~~watch this fail CI with Desperado issue it's supposed to solve~~