### PR TITLE
Fix BUCKET_POS for ticklags with non-integer reciprocals

### DIFF
--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -1,7 +1,7 @@
 /// Controls how many buckets should be kept, each representing a tick. (1 minutes worth)
 #define BUCKET_LEN (world.fps*1*60)
 /// Helper for getting the correct bucket for a given timer
-#define BUCKET_POS(timer) (((round((timer.timeToRun - timer.timer_subsystem.head_offset) / world.tick_lag)+1) % BUCKET_LEN)||BUCKET_LEN)
+#define BUCKET_POS(timer) (((CEILING((timer.timeToRun - timer.timer_subsystem.head_offset) / world.tick_lag)+1) % BUCKET_LEN)||BUCKET_LEN)
 /// Gets the maximum time at which timers will be invoked from buckets, used for deferring to secondary queue
 #define TIMER_MAX(timer_ss) (timer_ss.head_offset + TICKS2DS(BUCKET_LEN + timer_ss.practical_offset - 1))
 /// Max float with integer precision


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
If the ticklag setting has a non-integer reciprocal, like 0.4, timers will be inserted into the past because the fractional component gets rounded down. This is bad.

Probably no real impact on most servers because the commonly-used ticklags like 0.2, 0.25, 0.33333, 0.5, etc. have integer reciprocals, so dividing by them always just multiplies by an integer. I have 42MB of logs from an hour long round with a ticklag of 0.4, though, so... yikes.

Targeting dev because I don't really trust me mucking about with SStimer enough to send it to stable, but my local testing made it seem like it worked fine.

## Why and what will this PR improve
Inserting timers into a bucket in the past (behind the `practical_offset`) causes a warning/unexpected behavior and should probably be avoided; the best fix I can think of for it is just rounding up so that it's placed in the closest future bucket.

## Authorship
Me.