### PR TITLE
Fix data and arguments for on_leaving_metabolism

### DIFF
--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -523,7 +523,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 /decl/material/proc/get_wall_texture()
 	return
 
-/decl/material/proc/on_leaving_metabolism(var/atom/parent, var/metabolism_class)
+/decl/material/proc/on_leaving_metabolism(datum/reagents/metabolism/holder)
 	return
 
 #define ACID_MELT_DOSE 10

--- a/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
@@ -149,8 +149,8 @@
 		M.timeofdeath = world.time
 	M.add_chemical_effect(CE_NOPULSE, 1)
 
-/decl/material/liquid/zombiepowder/on_leaving_metabolism(atom/parent, metabolism_class)
-	var/mob/M = parent
+/decl/material/liquid/zombiepowder/on_leaving_metabolism(datum/reagents/metabolism/holder)
+	var/mob/M = holder?.my_atom
 	if(istype(M))
 		M.status_flags &= ~FAKEDEATH
 	. = ..()

--- a/code/modules/reagents/Chemistry-Metabolism.dm
+++ b/code/modules/reagents/Chemistry-Metabolism.dm
@@ -3,10 +3,11 @@
 	var/mob/living/parent
 
 /datum/reagents/metabolism/clear_reagent(var/reagent_type, var/defer_update = FALSE, var/force = FALSE)
-	. = ..()
-	if(.)
+	// Duplicated check so that reagent data is accessible in on_leaving_metabolism.
+	if(force || !!(REAGENT_VOLUME(src, reagent_type) || REAGENT_DATA(src, reagent_type)))
 		var/decl/material/current = GET_DECL(reagent_type)
-		current.on_leaving_metabolism(parent, metabolism_class)
+		current.on_leaving_metabolism(src)
+	. = ..()
 
 /datum/reagents/metabolism/New(var/max = 100, mob/living/parent_mob, var/met_class)
 	..(max, parent_mob)

--- a/code/modules/reagents/chems/chems_compounds.dm
+++ b/code/modules/reagents/chems/chems_compounds.dm
@@ -28,9 +28,9 @@
 		var/mob/living/carbon/human/H = M
 		H.update_eyes()
 
-/decl/material/liquid/glowsap/on_leaving_metabolism(atom/parent, metabolism_class)
-	if(ishuman(parent))
-		var/mob/living/carbon/human/H = parent
+/decl/material/liquid/glowsap/on_leaving_metabolism(datum/reagents/metabolism/holder)
+	if(ishuman(holder?.my_atom))
+		var/mob/living/carbon/human/H = holder.my_atom
 		addtimer(CALLBACK(H, /mob/living/carbon/human/proc/update_eyes), 5 SECONDS)
 	. = ..()
 

--- a/code/modules/reagents/chems/chems_drugs.dm
+++ b/code/modules/reagents/chems/chems_drugs.dm
@@ -215,9 +215,9 @@
 	if(prob(5))
 		to_chat(M, SPAN_WARNING("<font size = [rand(1,3)]>[pick(dose_messages)]</font>"))
 
-/decl/material/liquid/glowsap/gleam/on_leaving_metabolism(var/atom/parent, var/metabolism_class)
+/decl/material/liquid/glowsap/gleam/on_leaving_metabolism(datum/reagents/metabolism/holder)
 	. = ..()
-	var/mob/M = parent
+	var/mob/M = holder?.my_atom
 	if(istype(M))
 		M.remove_client_color(/datum/client_color/noir/thirdeye)
 


### PR DESCRIPTION
## Description of changes
Pass holder to on_leaving_metabolism instead of just my_atom and metabolism_class, since passing holder lets us get the data *and* both my_atom and metabolism_class anyway.

Also reorders it so that you can actually access REAGENT_DATA in on_leaving_metabolism. If done after the parent call, the data has already been cleared.

## Why and what will this PR improve
On a downstream I needed to access REAGENT_DATA inside on_leaving_metabolism in order to clear an effect. Also, not having access to the metabolism datum it's being called from is kind of weird anyway.

## Authorship
Me.