### PR TITLE
Hotfix the pipe leak CI fails

### DIFF
--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -544,7 +544,7 @@
 /datum/unit_test/pipes_shall_not_leak/start_test()
 	var/failures = 0
 	for(var/obj/machinery/atmospherics/pipe/P in SSmachines.machinery)
-		if(P.leaking && isPlayerLevel(P.z) && !(locate(/obj/abstract/landmark/allowed_leak) in get_turf(P)))
+		if(P.leaking && !(locate(/obj/abstract/landmark/allowed_leak) in get_turf(P)))
 			failures++
 			log_bad("Following pipe is leaking: [log_info_line(P)]")
 

--- a/maps/antag_spawn/ert/ert_base.dmm
+++ b/maps/antag_spawn/ert/ert_base.dmm
@@ -2968,11 +2968,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/map_template/rescue_base/start)
-"gn" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
+/obj/machinery/sleeper/standard{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/rescue_base/start)
 "go" = (
@@ -3009,18 +3007,6 @@
 /turf/simulated/floor/tiled/white,
 /area/map_template/rescue_base/start)
 "gw" = (
-/turf/simulated/floor/tiled/white,
-/area/map_template/rescue_base/start)
-"gx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/map_template/rescue_base/start)
-"gy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/rescue_base/start)
 "gz" = (
@@ -3066,12 +3052,6 @@
 /area/map_template/rescue_base/start)
 "gE" = (
 /obj/machinery/body_scanconsole{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/map_template/rescue_base/start)
-"gF" = (
-/obj/machinery/sleeper/standard{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -5452,7 +5432,7 @@ eQ
 eQ
 eU
 gm
-gx
+gw
 gw
 gw
 gR
@@ -5516,8 +5496,8 @@ eQ
 eQ
 eQ
 eU
-gn
-gy
+gw
+gw
 gw
 gw
 gw
@@ -5583,7 +5563,7 @@ eQ
 eU
 go
 gw
-gF
+gw
 gO
 gS
 ha

--- a/maps/antag_spawn/ninja/ninja_base.dmm
+++ b/maps/antag_spawn/ninja/ninja_base.dmm
@@ -92,13 +92,6 @@
 	icon_state = "white"
 	},
 /area/map_template/ninja_dojo/dojo)
-"ap" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
-/area/map_template/ninja_dojo/dojo)
 "aq" = (
 /obj/structure/table/glass,
 /turf/unsimulated/floor{
@@ -124,22 +117,6 @@
 	},
 /obj/structure/window/reinforced/crescent{
 	dir = 4
-	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
-/area/map_template/ninja_dojo/dojo)
-"au" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/turf/unsimulated/floor{
-	icon_state = "white"
-	},
-/area/map_template/ninja_dojo/dojo)
-"av" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
 	},
 /turf/unsimulated/floor{
 	icon_state = "white"
@@ -1922,7 +1899,7 @@ ad
 ad
 aj
 ao
-au
+ao
 ao
 aK
 aT
@@ -1964,8 +1941,8 @@ ad
 ad
 ad
 aj
-ap
-av
+ao
+ao
 ao
 aL
 aG

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -394,14 +394,14 @@
 /turf/exterior/concrete,
 /area/template_noop)
 "bf" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/command)
@@ -441,15 +441,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony)
 "bk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/command)
 "bl" = (
@@ -7855,6 +7853,19 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/colony/hydroponics)
+"CM" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/effect/floor_decal/techfloor/hole/right{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/colony/command)
 "Dj" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/light{
@@ -9139,7 +9150,7 @@ os
 (28,1,1) = {"
 ad
 aD
-aV
+CM
 bk
 bC
 ac

--- a/mods/content/government/ruins/ec_old_crash/ec_old_crash.dmm
+++ b/mods/content/government/ruins/ec_old_crash/ec_old_crash.dmm
@@ -79,6 +79,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless,
 /area/map_template/ecship/cockpit)
 "ao" = (
@@ -310,6 +311,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless,
 /area/map_template/ecship/cryo)
 "aT" = (
@@ -405,6 +407,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled/airless,
 /area/map_template/ecship/cryo)
 "bf" = (
@@ -479,6 +482,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/cryo)
 "bm" = (
@@ -509,6 +513,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/airless,
 /area/map_template/ecship/crew)
 "bp" = (
@@ -788,6 +793,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor,
 /area/map_template/ecship/crew)
 "bQ" = (
@@ -970,6 +976,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor,
 /area/map_template/ecship/science)
 "ci" = (
@@ -1222,6 +1229,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/abstract/landmark/allowed_leak,
 /turf/simulated/floor/tiled/lowpressure,
 /area/map_template/ecship/engineering)
 "cJ" = (
@@ -1352,14 +1360,14 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
 	},
 /obj/structure/emergency_dispenser/west,
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/map_template/ecship/engineering)
 "cZ" = (
@@ -1914,6 +1922,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/abstract/landmark/clear,
+/obj/abstract/landmark/allowed_leak,
 /turf/template_noop,
 /area/template_noop)
 "mD" = (
@@ -1962,6 +1971,15 @@
 /obj/abstract/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
+"XP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/abstract/landmark/allowed_leak,
+/turf/simulated/floor/tiled/airless,
+/area/map_template/ecship/crew)
 "YW" = (
 /obj/structure/catwalk,
 /obj/abstract/landmark/scorcher,
@@ -2742,7 +2760,7 @@ aO
 bf
 by
 bB
-bf
+XP
 cu
 cC
 cI


### PR DESCRIPTION
## Description of changes
Mark 18 intended leaks on the crashed Expeditionary Ship ruin and fix 1 unintentional one.
Remove the isPlayerLevel check from the test so that loaded exoplanet ruins are consistently found.

## Why and what will this PR improve
Dev is currently failing CI :(