### PR TITLE
Fix candystripe styling on crew manifest

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -415,6 +415,7 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 	dat += html_crew_manifest(OOC = 1)
 	//show_browser(src, dat, "window=manifest;size=370x420;can_close=1")
 	var/datum/browser/popup = new(src, "Crew Manifest", "Crew Manifest", 370, 420, src)
+	popup.add_stylesheet("nano_shared", 'nano/css/shared.css')
 	popup.set_content(dat)
 	popup.open()
 

--- a/code/modules/modular_computers/file_system/manifest.dm
+++ b/code/modules/modular_computers/file_system/manifest.dm
@@ -11,11 +11,10 @@
 	var/dat = {"
 	<head><style>
 		.manifest {border-collapse:collapse;width:100%;}
-		.manifest td, th {border:1px solid [monochrome?"black":"[OOC?"black; background-color:#272727; color:white":"#DEF; background-color:white; color:black"]"]; padding:.25em}
+		.manifest td, th {border:1px solid [monochrome?"black":"[OOC?"black; color:white":"#DEF; color:black"]"]; padding:.25em}
 		.manifest th {height: 2em; [monochrome?"border-top-width: 3px":"background-color: [OOC?"#40628a":"#48C"]; color:white"]}
 		.manifest tr.head th { [monochrome?"border-top-width: 1px":"background-color: [OOC?"#013D3B;":"#488;"]"] }
 		.manifest td:first-child {text-align:right}
-		.manifest tr.alt td {[monochrome?"border-top-width: 2px":"background-color: [OOC?"#373737; color:white":"#DEF"]"]}
 	</style></head>
 	<table class="manifest" width='350px'>
 	<tr class='head'><th>Name</th><th>Position</th><th>Activity</th></tr>


### PR DESCRIPTION
## Description of changes
Fixes the candystripe styling on the crew manifest, which used to be done via a `tr.alt td` style, but is now done via the `candystripe` class. It was being overridden by the background-color set on the `td` element, which isn't necessary anymore.

## Why and what will this PR improve
Before:
![image](https://i.imgur.com/Lkvc8fb.png)
After:
![image](https://i.imgur.com/5M2DJG0.png)
(The alternating color of rows continues, I just only had two characters prepped.)

## Authorship
Me.