### PR TITLE
Move submap spawnpoints with shuttles

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -53,7 +53,7 @@ The latter will result in a linter warning and will not work correctly.
 // Movable-level flags (/atom/movable/movable_flags)
 #define MOVABLE_FLAG_PROXMOVE             BITFLAG(0) // Does this object require proximity checking in Enter()?
 #define MOVABLE_FLAG_Z_INTERACT           BITFLAG(1) // Should attackby and attack_hand be relayed through ladders and open spaces?
-#define MOVABLE_FLAG_EFFECTMOVE           BITFLAG(2) // Is this an effect that should move?
+#define MOVABLE_FLAG_ALWAYS_SHUTTLEMOVE   BITFLAG(2) // Is this an effect that should move?
 #define MOVABLE_FLAG_DEL_SHUTTLE          BITFLAG(3) // Shuttle transistion will delete this.
 #define MOVABLE_FLAG_WHEELED              BITFLAG(4) // Movable has reduced stamina cost/speed reduction when pulled.
 

--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -133,7 +133,7 @@
 	var/supported = FALSE // Whether or not there's an object in the turf which can support other objects.
 	if(is_background)
 		new_turf = target
-	else	
+	else
 		new_turf = target.ChangeTurf(source.type, 1, 1)
 		new_turf.transport_properties_from(source)
 		new_turf.prev_type = target_type
@@ -144,12 +144,8 @@
 			break
 
 	for(var/obj/O in source)
-		if(O.simulated && (!is_background || supported || O.obj_flags & OBJ_FLAG_MOVES_UNSUPPORTED))
+		if((O.movable_flags & MOVABLE_FLAG_ALWAYS_SHUTTLEMOVE) || (O.simulated && (!is_background || supported || (O.obj_flags & OBJ_FLAG_MOVES_UNSUPPORTED))))
 			O.forceMove(new_turf)
-		else if(istype(O,/obj/effect)) // This is used for non-game objects like spawnpoints, so ignore the background check.
-			var/obj/effect/E = O
-			if(E.movable_flags & MOVABLE_FLAG_EFFECTMOVE)
-				E.forceMove(new_turf)
 
 	for(var/mob/M in source)
 		if(is_background && !supported)
@@ -160,5 +156,5 @@
 
 	if(is_background)
 		return list(new_turf, source)
-	
+
 	return new_turf

--- a/code/modules/submaps/submap_landmark.dm
+++ b/code/modules/submaps/submap_landmark.dm
@@ -27,6 +27,7 @@
 var/global/list/submap_spawnpoints_by_z = list()
 INITIALIZE_IMMEDIATE(/obj/abstract/submap_landmark/spawnpoint)
 /obj/abstract/submap_landmark/spawnpoint
+	movable_flags = MOVABLE_FLAG_ALWAYS_SHUTTLEMOVE
 	icon_state = "x3"
 
 /obj/abstract/submap_landmark/spawnpoint/Initialize()

--- a/maps/away/liberia/liberia_jobs.dm
+++ b/maps/away/liberia/liberia_jobs.dm
@@ -36,7 +36,6 @@
 // Spawn points.
 /obj/abstract/submap_landmark/spawnpoint/liberia
 	name = "Merchant"
-	movable_flags = MOVABLE_FLAG_EFFECTMOVE
 
 /decl/hierarchy/outfit/job/merchant
 	name = "Job - Merchant - Liberia"


### PR DESCRIPTION
## Description of changes
Renames `MOVABLE_FLAG_EFFECTMOVE` to `MOVABLE_FLAG_ALWAYS_SHUTTLEMOVE`.
Removes the `/obj/effect` check in translate turf contents and checks the flag on all objects now.
Applies the flag to all submap spawnpoints rather than just the Liberia's.

## Why and what will this PR improve
Fixes latejoiners on landable shuttle submaps spawning in space. Also, code cleanup.