### PR TITLE
Fixes drinks and flavorpods name generation

### DIFF
--- a/code/modules/reagents/reagent_containers/drinks.dm
+++ b/code/modules/reagents/reagent_containers/drinks.dm
@@ -17,9 +17,9 @@
 	var/base_icon = null // Base icon name for fill states
 
 /obj/item/chems/drinks/Initialize()
-	. = ..()
 	if(!base_name)
 		base_name = name
+	. = ..()
 
 /obj/item/chems/drinks/dragged_onto(var/mob/user)
 	attack_self(user)
@@ -296,6 +296,7 @@
 	base_name = "cup"
 	base_icon = "cup"
 	volume = 30
+	presentation_flags = PRESENTATION_FLAG_NAME
 
 /obj/item/chems/drinks/tea/black
 	name = "cup of black tea"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -267,6 +267,7 @@
 	name = "master flavorpod item"
 	desc = "A cellulose pod containing some kind of flavoring."
 	icon_state = "pill4"
+	presentation_flags = PRESENTATION_FLAG_NAME
 
 /obj/item/chems/pill/pod/cream
 	name = "creamer pod"


### PR DESCRIPTION


<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Tea cups and flavor pods just needed a presentation flag. Drinks in general needed their base name set before reagents are added, because reagent update find it unset and name them null

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fixes #2933

## Authorship
<!-- Describe original authors of changes to credit them. -->

## Changelog
Not a bug on stable yet

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->