### PR TITLE
Makes casings use drop_sound instead of their own system

### DIFF
--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -102,7 +102,7 @@
 
 /obj/item/proc/dropped_sound_callback()
 	if(!ismob(loc) && drop_sound)
-		playsound(src, drop_sound, 25, 0)
+		playsound(src, pick(drop_sound), 25, 0)
 
 /obj/item/proc/get_origin_tech()
 	return origin_tech

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -18,7 +18,7 @@
 	var/spent_icon = "pistolcasing-spent"
 	var/bullet_color = COLOR_COPPER
 	var/marking_color
-	var/fall_sounds = list('sound/weapons/guns/casingfall1.ogg','sound/weapons/guns/casingfall2.ogg','sound/weapons/guns/casingfall3.ogg')
+	drop_sound = list('sound/weapons/guns/casingfall1.ogg','sound/weapons/guns/casingfall2.ogg','sound/weapons/guns/casingfall3.ogg')
 
 /obj/item/ammo_casing/Initialize()
 	if(ispath(projectile_type))
@@ -53,7 +53,7 @@
 			return
 
 		if(!MOVING_DELIBERATELY(L) && prob(10))
-			playsound(src, pick(fall_sounds), 50, 1)
+			playsound(src, pick(drop_sound), 50, 1)
 			var/turf/turf_current = get_turf(src)
 			var/turf/turf_destiinaton = get_step(turf_current, AM.dir)
 			if(turf_destiinaton.Adjacent(turf_current))
@@ -182,6 +182,7 @@
 		if(!user.unEquip(C, src))
 			return
 		stored_ammo.Add(C)
+		playsound(user, 'sound/weapons/guns/interaction/bullet_insert.ogg', 50, 1)
 		update_icon()
 	else ..()
 

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -71,7 +71,7 @@
 	caliber = CALIBER_SHOTGUN
 	projectile_type = /obj/item/projectile/bullet/shotgun
 	material = /decl/material/solid/metal/steel
-	fall_sounds = list('sound/weapons/guns/shotgun_fall.ogg')
+	drop_sound = 'sound/weapons/guns/shotgun_fall.ogg'
 
 /obj/item/ammo_casing/shotgun/pellet
 	name = "shotgun shell"

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -105,8 +105,8 @@
 		if(EJECT_CASINGS) //eject casing onto ground.
 			chambered.dropInto(loc)
 			chambered.throw_at(get_ranged_target_turf(get_turf(src),turn(loc.dir,270),1), rand(0,1), 5)
-			if(LAZYLEN(chambered.fall_sounds))
-				playsound(loc, pick(chambered.fall_sounds), 50, 1)
+			if(chambered.drop_sound)
+				playsound(loc, pick(chambered.drop_sound), 50, 1)
 		if(CYCLE_CASINGS) //cycle the casing back to the end.
 			if(ammo_magazine)
 				ammo_magazine.stored_ammo += chambered
@@ -194,8 +194,8 @@
 			var/turf/T = get_turf(user)
 			if(T)
 				for(var/obj/item/ammo_casing/C in loaded)
-					if(LAZYLEN(C.fall_sounds))
-						playsound(loc, pick(C.fall_sounds), 50, 1)
+					if(LAZYLEN(C.drop_sound))
+						playsound(loc, pick(C.drop_sound), 50, 1)
 					C.forceMove(T)
 					count++
 				loaded.Cut()

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -39,8 +39,8 @@
 
 	if(chambered)//We have a shell in the chamber
 		chambered.dropInto(loc)//Eject casing
-		if(LAZYLEN(chambered.fall_sounds))
-			playsound(loc, pick(chambered.fall_sounds), 50, 1)
+		if(chambered.drop_sound)
+			playsound(loc, pick(chambered.drop_sound), 50, 1)
 		chambered = null
 
 	if(loaded.len)


### PR DESCRIPTION
## Description of changes
Casings used to have fall_sounds, merged them into drop_sound handling Also drop_sounds now handle lists (picking non list items is fine I tried)

## Why and what will this PR improve
No two parallel systems for drop sounds for object.
Also having support for varied list sounds is nice

## Authorship
Me me me

## Changelog
NA

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->