### PR TITLE
Nullcaf coffee

### DIFF
--- a/code/game/machinery/vending/food.dm
+++ b/code/game/machinery/vending/food.dm
@@ -192,6 +192,7 @@
 	vend_power_usage = 85000 //85 kJ to heat a 250 mL cup of coffee
 	products = list(
 		/obj/item/chems/drinks/coffee = 15,
+		/obj/item/chems/drinks/coffee/nullcaf = 10,
 		/obj/item/chems/drinks/tea/black = 15,
 		/obj/item/chems/drinks/tea/green = 15,
 		/obj/item/chems/drinks/tea/chai = 15,

--- a/code/modules/reagents/chems/chems_drinks.dm
+++ b/code/modules/reagents/chems/chems_drinks.dm
@@ -317,6 +317,7 @@
 	exoplanet_rarity = MAT_RARITY_NOWHERE
 	uid = "chem_drink_coffee"
 	var/list/flavour_modifiers = list()
+	var/od_jitter = 5
 
 /decl/material/liquid/drink/coffee/Initialize()
 	. = ..()
@@ -352,7 +353,7 @@
 	M.add_chemical_effect(CE_PULSE, 2)
 
 /decl/material/liquid/drink/coffee/affect_overdose(var/mob/living/M)
-	ADJ_STATUS(M, STAT_JITTER, 5)
+	ADJ_STATUS(M, STAT_JITTER, od_jitter)
 	M.add_chemical_effect(CE_PULSE, 1)
 
 /decl/material/liquid/drink/coffee/build_presentation_name_from_reagents(var/obj/item/prop, var/supplied)
@@ -369,14 +370,41 @@
 	var/chai =  REAGENT_VOLUME(prop.reagents, /decl/material/liquid/drink/tea/chai) ? "dirty " : ""
 	if(!soy && !milk && !cream)
 		if(is_flavoured)
-			. = "[.]flavoured [chai]coffee"
+			. = "[.]flavoured [chai][name]"
 		else
-			. = "[.][chai]coffee"
+			. = "[.][chai][name]"
 	else if((milk+cream) > soy)
 		. = "[.][chai]latte"
 	else
 		. = "[.][chai]soy latte"
 	. = ..(prop, .)
+
+/decl/material/liquid/drink/coffee/nullcaf
+	name = "nullcaf"
+	codex_name = null
+	lore_text = "Extra bitter coffee purged by a patented neutron bombing process. Guaranteed to contain no more than 2% inert dust."
+	taste_description = "pointless bitterness"
+	color = "#0d001a"
+	overdose = 30
+	glass_name = "nullcaf"
+	glass_desc = "Don't drop it."
+	uid = "chem_drink_nullcaf"
+	adj_dizzy = 0
+	adj_drowsy = -1
+	adj_sleepy = -1
+	od_jitter = 0
+
+/decl/material/liquid/drink/coffee/nullcaf/affect_overdose(var/mob/living/M)
+	if(prob(10) && M.can_feel_pain())
+		M.custom_pain(SPAN_NOTICE("A sudden spike of pain through your temples jolts you awake."), 5)
+		M.apply_effect(10, PAIN, 0)
+		ADJ_STATUS(M, STAT_DROWSY, -10)
+		ADJ_STATUS(M, STAT_ASLEEP, -10)
+
+/decl/material/liquid/drink/coffee/nullcaf/build_presentation_name_from_reagents(var/obj/item/prop, var/supplied)
+	. = ..()
+	if(!findtext(.,name))
+		return "evil [.]"
 
 /decl/material/liquid/drink/hot_coco
 	name = "hot chocolate"

--- a/code/modules/reagents/reagent_containers/drinks.dm
+++ b/code/modules/reagents/reagent_containers/drinks.dm
@@ -176,6 +176,13 @@
 /obj/item/chems/drinks/coffee/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/coffee, reagents.maximum_volume)
 
+/obj/item/chems/drinks/coffee/nullcaf
+	name = "cup of null"
+	desc = "Careful."
+
+/obj/item/chems/drinks/coffee/nullcaf/populate_reagents()
+	reagents.add_reagent(/decl/material/liquid/drink/coffee/nullcaf, reagents.maximum_volume)
+
 /obj/item/chems/drinks/ice
 	name = "cup of ice"
 	desc = "Careful, cold ice, do not chew."

--- a/mods/content/psionics/datum/chems.dm
+++ b/mods/content/psionics/datum/chems.dm
@@ -7,6 +7,9 @@
 	if(M.psi)
 		M.psi.check_latency_trigger(30, "a [name] overdose")
 
+/decl/material/liquid/drink/coffee/nullcaf
+	is_psionic_nullifier = TRUE
+
 /decl/chemical_reaction/synthesis/nullglass
 	name = "Soulstone"
 	result = null
@@ -28,3 +31,20 @@
 	else
 		for(var/i = 1, i <= created_volume*2, i++)
 			new /obj/item/shard(location, /decl/material/solid/gemstone/crystal)
+
+/datum/reagents/proc/disrupts_psionics()
+	. = FALSE
+	for(var/reagent_type in reagent_volumes)
+		var/decl/material/R = GET_DECL(reagent_type)
+		if(R.is_psi_null())
+			return R
+
+/decl/material/proc/on_psionic_stress(datum/reagents/metabolism/holder, stress, atom/source)
+	return
+
+/decl/material/liquid/drink/coffee/nullcaf/on_psionic_stress(datum/reagents/metabolism/holder, stress, atom/source)
+	var/used = min(stress, holder.reagent_volumes[type])
+	holder.remove_reagent(type, used)
+	if(ATOM_IS_TEMPERATURE_SENSITIVE(holder.my_atom))
+		ADJUST_ATOM_TEMPERATURE(holder.my_atom, holder.my_atom.temperature + 5*used)
+	return stress - used

--- a/mods/content/psionics/items/_items.dm
+++ b/mods/content/psionics/items/_items.dm
@@ -7,3 +7,16 @@
 		health -= .
 		. = max(0, -(health))
 		check_health(consumed = TRUE)
+
+/obj/item/chems/disrupts_psionics()
+	. = ..()
+	if(!. && reagents.disrupts_psionics())
+		return src
+
+/obj/item/chems/withstand_psi_stress(var/stress, var/atom/source)
+	if(reagents.disrupts_psionics())
+		for(var/reagent_type in reagents.reagent_volumes)
+			var/decl/material/R = GET_DECL(reagent_type)
+			. += R.on_psionic_stress(reagents, stress, source)
+	if(. > 0)
+		. = ..(stress, source)


### PR DESCRIPTION
## Description of changes
Adds null caffeine coffee drink
Can be bought in vendomats with normal coffee.
Doesn't give you jitters but gives you pain instead. It's also psi disrupting.

Added  support for chems blocking psi, they will be consumed when stress check is done (though usually vessels break first)


## Why and what will this PR improve
I think it's funny and also more tie ins with psionic system and ways to screw with them

## Authorship
Me

## Changelog
:cl:
add: Added nullcaf, a type of coffee. It doesnt' give jitters, just hurts. It's also psi inert, but will evaporate when withstanding psionic stress.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->