### PR TITLE
Microopt for check_state_in_icon().

### DIFF
--- a/code/datums/item_modifiers/item_modifier.dm
+++ b/code/datums/item_modifiers/item_modifier.dm
@@ -31,5 +31,5 @@
 		var/list/type_spritesheets = type_setup[SETUP_SPRITE_SHEETS]
 		var/obj/item/clothing/C = I
 		C.sprite_sheets = type_spritesheets?.Copy()
-	I.reconsider_single_icon(TRUE)
+	I.reconsider_single_icon()
 	return TRUE

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -123,7 +123,7 @@
 	if(randpixel && (!pixel_x && !pixel_y) && isturf(loc)) //hopefully this will prevent us from messing with mapper-set pixel_x/y
 		pixel_x = rand(-randpixel, randpixel)
 		pixel_y = rand(-randpixel, randpixel)
-	reconsider_single_icon()
+	reconsider_single_icon(FALSE)
 
 /obj/item/Destroy()
 

--- a/code/game/objects/item_mob_overlay.dm
+++ b/code/game/objects/item_mob_overlay.dm
@@ -7,15 +7,17 @@ var/global/list/bodypart_to_slot_lookup_table = list(
 	BP_R_HAND = "slot_r_hand"
 )
 
-/obj/item/proc/reconsider_single_icon(var/update_icon)
-	use_single_icon = check_state_in_icon(ICON_STATE_INV, icon) || check_state_in_icon(ICON_STATE_WORLD, icon)
+/obj/item/proc/reconsider_single_icon(var/clear_preexisting = TRUE)
+	if(isnull(use_single_icon) || clear_preexisting)
+		use_single_icon = check_state_in_icon(ICON_STATE_INV, icon) || check_state_in_icon(ICON_STATE_WORLD, icon)
+		. = TRUE
 	if(use_single_icon)
 		has_inventory_icon = check_state_in_icon(ICON_STATE_INV, icon)
 		icon_state = get_world_inventory_state()
 		. = TRUE
 	else
 		has_inventory_icon = FALSE
-	if(. || update_icon)
+	if(.)
 		update_icon()
 
 // For checking if we have a specific state, for inventory icons and nonhumanoid species.
@@ -27,7 +29,7 @@ var/global/list/icon_state_cache = list()
 	// isicon() is apparently quite expensive so short-circuit out early if we can.
 	if(!istext(checkstate) || isnull(checkicon) || !(isfile(checkicon) || isicon(checkicon)))
 		return FALSE
-	var/checkkey = "\ref[checkicon]"
+	var/checkkey = "[checkicon]" || ref(checkicon)
 	var/list/check = global.icon_state_cache[checkkey]
 	if(!check)
 		check = list()

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -3,6 +3,7 @@
 	siemens_coefficient = 0.9
 	origin_tech = "{'materials':1,'engineering':1}"
 	material = /decl/material/solid/cloth
+	use_single_icon = TRUE // At time of commit, all clothing has been set up to use single icons. This saves some icon state checking in Initialize().
 
 	var/wizard_garb = 0
 	var/flash_protection = FLASH_PROTECTION_NONE	  // Sets the item's level of flash protection.


### PR DESCRIPTION
## Description of changes
- Adds an alternative faster key to `check_state_in_icon`.
- Skips single icon consideration for clothing, as AFAIK it's all converted to the single icon system already.

## Why and what will this PR improve
Optimization.

## Authorship
@Lohikar and @out-of-phaze helped with the key update.

## Changelog
Nothing player-facing.