### PR TITLE
corporate content modpack: adds missing loadout and lockers include

### DIFF
--- a/mods/content/corporate/_corporate.dme
+++ b/mods/content/corporate/_corporate.dme
@@ -26,6 +26,7 @@
 #include "clothing\under\uniforms.dm"
 #include "datum\ai_icons.dm"
 #include "datum\ai_laws.dm"
+#include "datum\loadout.dm"
 #include "datum\robolimbs.dm"
 #include "datum\antagonists\commando.dm"
 #include "datum\antagonists\deathsquad.dm"
@@ -38,5 +39,6 @@
 #include "items\medals.dm"
 #include "items\wristcomp.dm"
 #include "machines\machines.dm"
+#include "structures\lockers.dm"
 // END_INCLUDE
 #endif

--- a/mods/content/corporate/datum/loadout.dm
+++ b/mods/content/corporate/datum/loadout.dm
@@ -15,7 +15,7 @@
 
 /decl/loadout_option/accessory/armband_nt
 	name = "corporate armband"
-	path = /obj/item/clothing/accessory/armband/whitered
+	path = /obj/item/clothing/accessory/armband/whitegreen
 
 /decl/loadout_option/suit/labcoat_corp
 	name = "labcoat, corporate colors"
@@ -23,7 +23,7 @@
 	flags = GEAR_HAS_TYPE_SELECTION
 
 /decl/loadout_option/uniform/corporate
-	namename = "corporate uniform selection"
+	name = "corporate uniform selection"
 	path = /obj/item/clothing/under
 
 /decl/loadout_option/uniform/corporate/get_gear_tweak_options()


### PR DESCRIPTION
## Description of changes
Both loadout.dm and lockers.dm are not included in _corporate.dme file.
This fixes the issue.

## Why and what will this PR improve
Stuff in modpack will compile now
