### PR TITLE
random loot: removes artifact from spawn chance

### DIFF
--- a/code/game/objects/random/subtypes/misc.dm
+++ b/code/game/objects/random/subtypes/misc.dm
@@ -350,7 +350,6 @@
 		/obj/item/storage/firstaid/surgery =                      4,
 		/obj/item/cell/infinite =                                 1,
 		/obj/random/archaeological_find =                         2,
-		/obj/structure/artifact =                                 1,
 		/obj/item/multitool/hacktool =                            2,
 		/obj/item/surgicaldrill =                                 7,
 		/obj/item/sutures =                                       7,


### PR DESCRIPTION
## Description of changes
Artifact has been removed from a random loot spawn pool.

## Why and what will this PR improve
The artifact can be spawned and placed inside closets, but it will 100% fail unit test checks due regular closets lack of special closet flag `CLOSET_STORAGE_STRUCTURES` which allow store structures on closing. I'm not sure how mapped or spawned by a loot landmark items transfer into closets, so this is one of numerous solution I suggest right now.