### PR TITLE
Cups now shatter and spill contents when phyiscally destroyed

### DIFF
--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -227,3 +227,10 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 	. = ..()
 	if(old_temp != temperature)
 		update_icon()
+
+/obj/item/chems/drinks/glass2/physically_destroyed(var/skip_qdel)
+	reagents.splash(loc, reagents.total_volume)
+	if(istype(material))
+		playsound(src, "shatter", 30, 1)
+		material.place_shards(get_turf(src), w_class)
+	return ..()


### PR DESCRIPTION
## Description of changes
What it says on the tin. They splash contents on their loc, and drop material shards depending on their size

## Why and what will this PR improve
Better than them suddenly popping out of existence when taking too much damage

## Authorship
<!-- Describe original authors of changes to credit them. -->
