### PR TITLE
Fixes network stock parts not getting holder machine methods

### DIFF
--- a/code/modules/modular_computers/networking/device_types/stock_part.dm
+++ b/code/modules/modular_computers/networking/device_types/stock_part.dm
@@ -19,3 +19,13 @@
 	var/obj/machinery/M = A.loc
 	if(istype(M))
 		return M
+
+/datum/extension/network_device/stock_part/get_holder_methods()
+	var/obj/machinery/M = get_command_target()
+	if(istype(M))
+		return M.public_methods?.Copy()
+
+/datum/extension/network_device/stock_part/get_holder_variables()
+	var/obj/machinery/M = get_command_target()
+	if(istype(M))
+		return M.public_variables?.Copy()


### PR DESCRIPTION
## Description of changes
Network devices query their holder for list of public methods etc to expose to terminal
But stock part devices reside on a stock part item, not the machine, so they never got the actual methods.
Made it look deep enough 

## Why and what will this PR improve
Controlling arbitrary machinery over wifi is funny

## Authorship
me

## Changelog
:cl:
bugfix: Machines with network connector stock parts now expose all of their functions over network
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->