### PR TITLE
Fixes network stock parts not checking access on their machine

### DIFF
--- a/code/modules/modular_computers/networking/device_types/_network_device.dm
+++ b/code/modules/modular_computers/networking/device_types/_network_device.dm
@@ -274,7 +274,7 @@
 	var/datum/computer_network/network = get_network()
 	if(!network)
 		return TRUE // If not on network, always TRUE for access, as there isn't anything to access.
-	var/obj/M = holder
+	var/obj/M = get_top_holder()
 	if(!accesses)
 		accesses  = list()
 	return M.check_access_list(accesses)
@@ -309,12 +309,12 @@
 	return public_variables
 
 /datum/extension/network_device/proc/get_holder_methods()
-	var/obj/machinery/M = holder
+	var/obj/machinery/M = get_top_holder()
 	if(istype(M))
 		return M.public_methods?.Copy()
 
 /datum/extension/network_device/proc/get_holder_variables()
-	var/obj/machinery/M = holder
+	var/obj/machinery/M = get_top_holder()
 	if(istype(M))
 		return M.public_variables?.Copy()
 
@@ -453,6 +453,10 @@
 /**Returns the outward facing URI for this network device.*/
 /datum/extension/network_device/proc/get_network_URI()
 	return "[network_tag].[network_id]"
+
+/**Returns the object that should be handling access and command checks.*/
+/datum/extension/network_device/proc/get_top_holder()
+	return holder
 
 //Subtype for passive devices, doesn't init until asked for
 /datum/extension/network_device/lazy

--- a/code/modules/modular_computers/networking/device_types/stock_part.dm
+++ b/code/modules/modular_computers/networking/device_types/stock_part.dm
@@ -15,17 +15,10 @@
 	return term.get_graph()
 
 /datum/extension/network_device/stock_part/get_command_target()
+	return get_top_holder()
+
+/datum/extension/network_device/stock_part/get_top_holder()
 	var/atom/A = holder
 	var/obj/machinery/M = A.loc
 	if(istype(M))
 		return M
-
-/datum/extension/network_device/stock_part/get_holder_methods()
-	var/obj/machinery/M = get_command_target()
-	if(istype(M))
-		return M.public_methods?.Copy()
-
-/datum/extension/network_device/stock_part/get_holder_variables()
-	var/obj/machinery/M = get_command_target()
-	if(istype(M))
-		return M.public_variables?.Copy()


### PR DESCRIPTION


<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
It was more of same thing with not looking deep enough for holder
Instead of making third override I figured I'd add a proc for getting this sort of big boss holder and use it

Only thing of note is that this also means that network locks' extensions will check their machine access instead of just stock part's, but I think that's fine since machine will get part too

## Why and what will this PR improve
Fixing being able to command any machine without access over wifi (as realistic as it is)

## Authorship
me

## Changelog
:cl:
bugfix: Remote terminal commands now properly check access of the target machine 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->