### PR TITLE
Makes door leak damage to components when damaged

### DIFF
--- a/code/game/machinery/doors/airlock_subtypes.dm
+++ b/code/game/machinery/doors/airlock_subtypes.dm
@@ -217,6 +217,8 @@
 	frame_type = /obj/structure/door_assembly/door_assembly_highsecurity
 	paintable = 0
 
+/obj/machinery/door/airlock/highsecurity/get_damage_leakthrough(var/damage, damtype=BRUTE)
+	return 0
 /obj/machinery/door/airlock/highsecurity/bolted
 	locked = TRUE
 
@@ -256,5 +258,7 @@
 	frame_type = /obj/structure/door_assembly/door_assembly_highsecurity //Until somebody makes better sprites.
 	paintable = PAINT_PAINTABLE|PAINT_STRIPABLE
 
+/obj/machinery/door/airlock/vault/get_damage_leakthrough(var/damage, damtype=BRUTE)
+	return 0
 /obj/machinery/door/airlock/vault/bolted
 	locked = TRUE


### PR DESCRIPTION
## Description of changes
Previously doors would soak all damage up to its health and only then start passing it to components. This made whole thing kinda meaningless because by the time you start damaging copmonents the door is gone, you can just crowbar it open

Now if door is at 75% health or if it's 10 damage in single hit, some damage can leak through. It's scaled to how broken door is, so you're not going to be crunching locks with first few lucky hits. Secure airlocks override that to keep older behaviour because that's more secure

## Why and what will this PR improve
I think you should be able to bash access locks out of doors without completely destroying the airlock
It opens up access to the components hatch which is kinda pointless if machine is dead

## Authorship
Me

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->