### PR TITLE
Sword and steel tweaks

### DIFF
--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -19,9 +19,12 @@
 	pickup_sound = 'sound/foley/knife1.ogg' 
 	drop_sound = 'sound/foley/knifedrop3.ogg'
 
-	var/draw_handle
+	var/draw_handle = TRUE
 
 /obj/item/sword/update_force()
+	sharp = initial(sharp)
+	edge = initial(edge)
+	hitsound = initial(hitsound)
 	if(material?.hardness < MAT_VALUE_HARD)
 		edge = 0
 		attack_verb = list("attacked", "stabbed", "jabbed", "smacked", "prodded")

--- a/code/modules/materials/definitions/solids/materials_solid_metal.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_metal.dm
@@ -172,6 +172,7 @@
 	lore_text = "A strong, flexible alloy of iron and carbon. Probably the single most fundamentally useful and ubiquitous substance in human space."
 	weight = MAT_VALUE_NORMAL
 	wall_support_value = MAT_VALUE_VERY_HEAVY // Ideal construction material.
+	hardness = MAT_VALUE_HARD
 	integrity = 150
 	brute_armor = 5
 	icon_base = 'icons/turf/walls/solid.dmi'

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -60,7 +60,6 @@
 			. += new/datum/stack_recipe/key(src)
 			. += new/datum/stack_recipe/rod(src)
 
-	if(hardness > MAT_VALUE_RIGID + 10)
 		. += new/datum/stack_recipe/fork(src)
 		. += new/datum/stack_recipe/knife(src)
 		. += new/datum/stack_recipe/bell(src)


### PR DESCRIPTION
## Description of changes
Made swords handle setting material better (can handle going from blunt to sharp, not one way)
Buffed steel hardness a bit.
Lowered hardness requirements on a bunch of stack recipies

## Why and what will this PR improve
It fixes katana part of https://github.com/NebulaSS13/Nebula/issues/2304
With new hardness steel is still below plasteel etc, but it's not losing out to bronze
A lot of recipies were locked away before pretty high hardness reqs, so you couldn't make forks of anything weaker titanium. Now it's plastic/wood and up

## Authorship
me

## Changelog
:cl:
bugfix: Steel katanas were woefully underpowered, they are now actually sharp
tweak: Steel is harder now
/:cl:

