### PR TITLE
Fix elevator spawning lights on each floors

### DIFF
--- a/code/modules/turbolift/turbolift_map.dm
+++ b/code/modules/turbolift/turbolift_map.dm
@@ -208,19 +208,6 @@
 		panel_ext.set_dir(udir)
 		cfloor.ext_panel = panel_ext
 
-		// Place lights
-		if(light_type)
-			var/turf/placing1 = locate(light_x1, light_y1, cz)
-			var/turf/placing2 = locate(light_x2, light_y2, cz)
-			var/obj/machinery/light/light1 = new light_type(placing1, light)
-			var/obj/machinery/light/light2 = new light_type(placing2, light)
-			if(udir == NORTH || udir == SOUTH)
-				light1.set_dir(WEST)
-				light2.set_dir(EAST)
-			else
-				light1.set_dir(SOUTH)
-				light2.set_dir(NORTH)
-
 		// Update area.
 		if(az > areas_to_use.len)
 			log_debug("Insufficient defined areas in turbolift datum, aborting.")
@@ -233,6 +220,19 @@
 	lift.control_panel_interior = new panel_type(T, lift)
 	lift.control_panel_interior.set_dir(udir)
 	lift.current_floor = lift.floors[1]
+
+	// Place interior lights
+	if(light_type)
+		var/turf/placing1 = locate(light_x1, light_y1, uz)
+		var/turf/placing2 = locate(light_x2, light_y2, uz)
+		var/obj/machinery/light/light1 = new light_type(placing1, light)
+		var/obj/machinery/light/light2 = new light_type(placing2, light)
+		if(udir == NORTH || udir == SOUTH)
+			light1.set_dir(WEST)
+			light2.set_dir(EAST)
+		else
+			light1.set_dir(SOUTH)
+			light2.set_dir(NORTH)
 
 	lift.open_doors()
 


### PR DESCRIPTION
## Description of changes
The turbolift code for elevator shafts generates a set of lights on every floors of the shaft on map start currently. Which is a bit counter-productive considering how elevator turf moving works.
Changed it so it only spawns lights in the elevator cabin instead. 

## Why and what will this PR improve
Creates less useless lights.