### PR TITLE
Fix heal effect body temperature

### DIFF
--- a/code/modules/xenoarcheaology/artifacts/effects/heal.dm
+++ b/code/modules/xenoarcheaology/artifacts/effects/heal.dm
@@ -30,7 +30,7 @@
 		C.adjustBrainLoss(-force)
 		if(strong)
 			C.apply_radiation(-25 * weakness)
-			C.bodytemperature = initial(C.bodytemperature)
+			C.bodytemperature = C.species?.body_temperature || initial(C.bodytemperature)
 			C.adjust_nutrition(50 * weakness)
 			if(ishuman(C))
 				var/mob/living/carbon/human/H = C


### PR DESCRIPTION
## Description of changes
The heal artifact effect now properly sets body temperature to the species default.

## Why and what will this PR improve
Before, it'd just use the initial value of the mob's `bodytemperature` var. Now it still does that, but only as a fallback if there's no species.

## Authorship
Me.