### PR TITLE
Resets organ status when bodytype is set in sync_colour_to_human()

### DIFF
--- a/code/modules/organs/external/_external_icons.dm
+++ b/code/modules/organs/external/_external_icons.dm
@@ -18,6 +18,7 @@ var/global/list/limb_icon_cache = list()
 	skin_colour = null
 	hair_colour = human.hair_colour
 	bodytype = human.bodytype
+	reset_status() // since we may have changed bodytype
 	if(BP_IS_PROSTHETIC(src) && model)
 		var/decl/prosthetics_manufacturer/franchise = GET_DECL(model)
 		if(!(franchise && franchise.skintone))
@@ -170,7 +171,7 @@ var/global/list/robot_hud_colours = list("#ffffff","#cccccc","#aaaaaa","#888888"
 	return applying
 
 /obj/item/organ/external/proc/bandage_level()
-	if(damage_state_text() == "00") 
+	if(damage_state_text() == "00")
 		return 0
 	if(!is_bandaged())
 		return 0


### PR DESCRIPTION
## Description of changes
Resets an organ's status when bodytype is set in `sync_colour_to_human()`, in case any species organ modifications rely on it.

## Why and what will this PR improve
Fixed some bodytype-dependent species organ modifications downstream, which I don't *think* is too uncommon of a pattern. It might be worth looking into moving it onto bodytype entirely, or adding per-bodytype modification stubs upstream.

## Authorship
Me.