### PR TITLE
Fix humans not getting default species settings

### DIFF
--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -141,15 +141,10 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	SetUIState(DNA_UI_GENDER, character.gender!=MALE, 1)
 
 	// Hair
-	// FIXME:  Species-specific defaults pls
-	if(!character.h_style)
-		character.h_style = /decl/sprite_accessory/hair/bald
 	var/list/hair_types = decls_repository.get_decl_paths_of_subtype(/decl/sprite_accessory/hair)
 	SetUIValueRange(DNA_UI_HAIR_STYLE,  hair_types.Find(character.h_style),  length(hair_types), 1)
 
 	// Facial Hair
-	if(!character.f_style)
-		character.f_style = /decl/sprite_accessory/facial_hair/shaved
 	var/list/beard_types = decls_repository.get_decl_paths_of_subtype(/decl/sprite_accessory/facial_hair)
 	SetUIValueRange(DNA_UI_BEARD_STYLE, beard_types.Find(character.f_style), length(beard_types), 1)
 
@@ -157,6 +152,8 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	for(var/obj/item/organ/external/E in character.get_external_organs())
 		if(LAZYLEN(E.markings))
 			body_markings[E.organ_tag] = E.markings.Copy()
+
+	b_type = character.b_type
 
 	UpdateUI()
 

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -68,13 +68,13 @@
 		h_style = pick(valid_hairstyles)
 	else
 		//this shouldn't happen
-		h_style = /decl/sprite_accessory/hair/bald
+		h_style = species?.default_h_style || /decl/sprite_accessory/hair/bald
 
 	if(length(valid_facial_hairstyles))
 		f_style = pick(valid_facial_hairstyles)
 	else
 		//this shouldn't happen
-		f_style = /decl/sprite_accessory/facial_hair/shaved
+		f_style = species?.default_f_style || /decl/sprite_accessory/facial_hair/shaved
 
 	update_hair()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1359,6 +1359,18 @@
 
 	set_species(species_name)
 
+	if(!skin_colour)
+		skin_colour = species.base_color
+	if(!hair_colour)
+		hair_colour = species.base_hair_color
+	if(!facial_hair_colour)
+		facial_hair_colour = species.base_hair_color
+	if(!eye_colour)
+		eye_colour = species.base_eye_color
+	species.set_default_hair(src, override_existing = FALSE, defer_update_hair = TRUE)
+	if(!b_type && length(species?.blood_types))
+		b_type = pickweight(species.blood_types)
+
 	if(new_dna)
 		set_real_name(new_dna.real_name)
 	else

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -1,12 +1,12 @@
 /mob/living/carbon/human
 
-	var/h_style = /decl/sprite_accessory/hair/bald
-	var/f_style = /decl/sprite_accessory/facial_hair/shaved
+	var/h_style
+	var/f_style
 
-	var/hair_colour =        COLOR_BLACK
-	var/facial_hair_colour = COLOR_BLACK
-	var/skin_colour =        COLOR_BLACK
-	var/eye_colour =         COLOR_BLACK
+	var/hair_colour
+	var/facial_hair_colour
+	var/skin_colour
+	var/eye_colour
 
 	var/regenerate_body_icon = FALSE // If true, the next icon update will also regenerate the body.
 
@@ -16,7 +16,7 @@
 
 	var/lip_style = null	//no lipstick by default- arguably misleading, as it could be used for general makeup
 
-	var/b_type = "A+"	//Player's bloodtype
+	var/b_type	//Player's bloodtype
 
 	var/list/worn_underwear = list()
 

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -4,6 +4,7 @@
 var/global/const/DEFAULT_SPECIES_HEALTH = 200
 
 /decl/species
+	abstract_type = /decl/species
 
 	// Descriptors and strings.
 	var/name
@@ -539,7 +540,7 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 		if(heat_level_2 < heat_level_1)
 			. += "heat_level_2 ([heat_level_2]) was not higher than heat_level_1 ([heat_level_1])"
 
-	if(max(cold_level_1, cold_level_2, cold_level_3) <= min(heat_level_1, heat_level_2, heat_level_3))
+	if(min(heat_level_1, heat_level_2, heat_level_3) <= max(cold_level_1, cold_level_2, cold_level_3))
 		. += "heat and cold damage level thresholds overlap"
 
 	if(taste_sensitivity < 0)

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -475,7 +475,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 		if(!T.validate_level(trait_level))
 			. += "invalid levels for species trait [trait_type]"
 
-
 	if(base_low_light_vision > 1)
 		. += "base low light vision is greater than 1 (over 100%)"
 	else if(base_low_light_vision < 0)
@@ -495,6 +494,56 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 		. += "low light vision adjustment speed is greater than 1 (over 100%)"
 	else if(low_light_vision_adjustment_speed < 0)
 		. += "low light vision adjustment speed is less than 0 (below 0%)"
+
+	if((appearance_flags & HAS_SKIN_COLOR) && isnull(base_color))
+		. += "uses skin color but missing base_color"
+	if((appearance_flags & HAS_HAIR_COLOR) && isnull(base_hair_color))
+		. += "uses hair color but missing base_hair_color"
+	if((appearance_flags & HAS_EYE_COLOR) && isnull(base_eye_color))
+		. += "uses eye color but missing base_eye_color"
+	if(isnull(default_h_style))
+		. += "null default_h_style (use a bald/hairless hairstyle if 'no hair' is intended)"
+	if(isnull(default_f_style))
+		. += "null default_f_style (use a shaved/hairless facial hair style if 'no facial hair' is intended)"
+	if(!length(blood_types))
+		. += "missing at least one blood type"
+	if(default_bodytype && !(default_bodytype in available_bodytypes))
+		. += "default bodytype is not in available bodytypes list"
+	if(!length(available_bodytypes))
+		. += "missing at least one bodytype"
+	// TODO: Maybe make age descriptors optional, in case someone wants a 'timeless entity' species?
+	if(isnull(age_descriptor))
+		. += "age descriptor was unset"
+	else if(!ispath(age_descriptor, /datum/appearance_descriptor/age))
+		. += "age descriptor was not a /datum/appearance_descriptor/age subtype"
+
+	if(cold_level_3)
+		if(cold_level_2)
+			if(cold_level_3 > cold_level_2)
+				. += "cold_level_3 ([cold_level_3]) was not lower than cold_level_2 ([cold_level_2])"
+			if(cold_level_1)
+				if(cold_level_3 > cold_level_1)
+					. += "cold_level_3 ([cold_level_3]) was not lower than cold_level_1 ([cold_level_1])"
+	if(cold_level_2 && cold_level_1)
+		if(cold_level_2 > cold_level_1)
+			. += "cold_level_2 ([cold_level_2]) was not lower than cold_level_1 ([cold_level_1])"
+
+	if(heat_level_3 != INFINITY)
+		if(heat_level_2 != INFINITY)
+			if(heat_level_3 < heat_level_2)
+				. += "heat_level_3 ([heat_level_3]) was not higher than heat_level_2 ([heat_level_2])"
+			if(heat_level_1 != INFINITY)
+				if(heat_level_3 < heat_level_1)
+					. += "heat_level_3 ([heat_level_3]) was not higher than heat_level_1 ([heat_level_1])"
+	if((heat_level_2 != INFINITY) && (heat_level_1 != INFINITY))
+		if(heat_level_2 < heat_level_1)
+			. += "heat_level_2 ([heat_level_2]) was not higher than heat_level_1 ([heat_level_1])"
+
+	if(max(cold_level_1, cold_level_2, cold_level_3) <= min(heat_level_1, heat_level_2, heat_level_3))
+		. += "heat and cold damage level thresholds overlap"
+
+	if(taste_sensitivity < 0)
+		. += "taste_sensitivity ([taste_sensitivity]) was negative"
 
 /decl/species/proc/equip_survival_gear(var/mob/living/carbon/human/H, var/box_type = /obj/item/storage/box/survival)
 	var/obj/item/storage/backpack/backpack = H.get_equipped_item(slot_back_str)

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -733,15 +733,15 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 					light -= H.equipment_light_protection
 	return clamp(max(prescriptions, light), 0, 7)
 
-/decl/species/proc/set_default_hair(var/mob/living/carbon/human/H)
-	if(H.h_style != H.species.default_h_style)
-		H.h_style = H.species.default_h_style
+/decl/species/proc/set_default_hair(mob/living/carbon/human/organism, override_existing = TRUE, defer_update_hair = FALSE)
+	if(!organism.h_style || (override_existing && (organism.h_style != default_h_style)))
+		organism.h_style = default_h_style
 		. = TRUE
-	if(H.f_style != H.species.default_f_style)
-		H.f_style = H.species.default_f_style
+	if(!organism.h_style || (override_existing && (organism.f_style != default_f_style)))
+		organism.f_style = default_f_style
 		. = TRUE
-	if(.)
-		H.update_hair()
+	if(. && !defer_update_hair)
+		organism.update_hair()
 
 /decl/species/proc/handle_additional_hair_loss(var/mob/living/carbon/human/H, var/defer_body_update = TRUE)
 	return FALSE


### PR DESCRIPTION
## Description of changes
Reshuffles a lot of human/carbon default variables, including setting them to null by default so species vars override them.
Adds `override_existing` as an argument to `set_default_hairstyle()`. Sometimes you want to use it to fix invalid hairstyles, otherwise you want to force the hairstyle instead.
Species/mob defaults are now applied in `/mob/living/carbon/human/proc/setup` rather than `/datum/dna/proc/ResetUIFrom`.

Targeting dev because while I've tested the changes, it's nothing exhaustive.

## Why and what will this PR improve
Fixes blood type not being set properly on non-player mobs, i.e. mapped in or spawned with the spawn verb.
Fixes species defaults not being applied to spawned/mapped non-player mobs.
Properly integrates support for species-specific (facial) hair defaults.

## Authorship
Me, on my Signalis-themed fork/branch.