### PR TITLE
Fix headphones not playing music

### DIFF
--- a/code/modules/clothing/head/headphones.dm
+++ b/code/modules/clothing/head/headphones.dm
@@ -67,9 +67,10 @@
 	stop_music(user)
 
 /obj/item/clothing/head/headphones/proc/play_music(mob/user)
+	var/static/list/allowed_slots = list(slot_l_ear_str, slot_r_ear_str, slot_head_str)
 	if(!user || !user.client)
 		return
-	if(!(user.get_inventory_slot(src) in list(slot_l_ear_str, slot_r_ear_str)))
+	if(!(user.get_inventory_slot(src) in allowed_slots))
 		return
 	if(current_track)
 		var/decl/music_track/track = GET_DECL(global.music_tracks[current_track])


### PR DESCRIPTION
## Description of changes
Headphones apparently used to be equipped on left/right ears rather than the head slot, but when this was changed this check was never updated. For now I'm keeping the left/right ear stuff since maybe there's a reason it was left, but adding `slot_head_str` to it should make it work without any potential regressions.

## Why and what will this PR improve
Headphones now play music when equipped.

## Authorship
Me.