### PR TITLE
Allow small/tiny equipped items when ventcrawling

### DIFF
--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -45,10 +45,11 @@ var/global/list/ventcrawl_machinery = list(
 		return TRUE
 	if(carried_item in get_external_organs())
 		return TRUE
-	for(var/slot in list(slot_w_uniform_str, slot_glasses_str, slot_glasses_str, slot_wear_mask_str, slot_l_ear_str, slot_r_ear_str, slot_belt_str, slot_l_store_str, slot_r_store_str))
-		if(get_equipped_item(slot) == carried_item)
-			return TRUE
-	if(carried_item in get_held_items())
+	var/slot = get_inventory_slot(carried_item)
+	var/static/allowed_inventory_slots = list(slot_w_uniform_str, slot_gloves_str, slot_glasses_str, slot_wear_mask_str, slot_l_ear_str, slot_r_ear_str, slot_belt_str, slot_l_store_str, slot_r_store_str)
+	if(slot in allowed_inventory_slots)
+		return TRUE
+	else if (slot || (carried_item in get_held_items()))
 		return carried_item.w_class <= ITEM_SIZE_NORMAL
 	return ..()
 

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -45,7 +45,7 @@ var/global/list/ventcrawl_machinery = list(
 		return TRUE
 	if(carried_item in get_external_organs())
 		return TRUE
-	var/slot = get_inventory_slot(carried_item)
+	var/slot = get_equipped_slot_for_item(carried_item)
 	var/static/allowed_inventory_slots = list(slot_w_uniform_str, slot_gloves_str, slot_glasses_str, slot_wear_mask_str, slot_l_ear_str, slot_r_ear_str, slot_belt_str, slot_l_store_str, slot_r_store_str)
 	if(slot in allowed_inventory_slots)
 		return TRUE


### PR DESCRIPTION
## Description of changes
Expands the held item check in ventcrawling to include items equipped in other slots as well.
Replaces a duplicate `slot_glasses_str` with `slot_gloves_str`.

## Why and what will this PR improve
You'll be able to ventcrawl with small/tiny items like a hairbow on your head now.

Note that this will also let you ventcrawl with an ID. Not entirely sure if that's wanted or not, but I don't see it as too much of an issue especially with how rare humantype ventcrawling is.

## Authorship
Me, on my Signalis-themed fork/branch.