### PR TITLE
Adding QDELETED and null loc checking to mob Bump().

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -63,7 +63,7 @@ default behaviour is:
 	// End boilerplate.
 
 	spawn(0)
-		if ((!( yes ) || now_pushing) || !loc)
+		if (!yes || now_pushing || QDELETED(src) || QDELETED(AM) || !loc || !AM.loc)
 			return
 
 		now_pushing = 1
@@ -113,6 +113,8 @@ default behaviour is:
 
 		now_pushing = 0
 		spawn(0)
+			if (QDELETED(src) || QDELETED(AM) || !loc || !AM.loc)
+				return
 			..()
 			var/saved_dir = AM.dir
 			if (!istype(AM, /atom/movable) || AM.anchored)


### PR DESCRIPTION
## Description of changes
Adds QDELETED and null loc checks to `/mob/living/Bump`

## Why and what will this PR improve
Should prevent bumping from moving atoms that are qdeleted on Bump() out of nullspace.

## Authorship
Myself.

## Changelog
Nothing player-facing.