### PR TITLE
Whitelist underwear in ventcrawling

### DIFF
--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -46,6 +46,8 @@ var/global/list/ventcrawl_machinery = list(
 		return TRUE
 	if(carried_item in get_external_organs())
 		return TRUE
+	if(carried_item in worn_underwear)
+		return TRUE
 	if(carried_item in list(w_uniform, gloves, glasses, wear_mask, l_ear, r_ear, belt, l_store, r_store))
 		return TRUE
 	if(carried_item in get_held_items())


### PR DESCRIPTION
## Description of changes
Adds `worn_underwear` to the ventcrawl item whitelist.

## Why and what will this PR improve
![image](https://i.imgur.com/3QoZF8T.png)
Being able to ventcrawl while wearing overclothes but not underwear is kind of odd.

## Authorship
Me.

## Changelog
:cl:
balance: You can now ventcrawl with underwear on.
/:cl: