### PR TITLE
Add health and breath scanner protolathe designs

### DIFF
--- a/code/modules/fabrication/designs/protolathe/designs_tools.dm
+++ b/code/modules/fabrication/designs/protolathe/designs_tools.dm
@@ -65,6 +65,12 @@
 /datum/fabricator_recipe/protolathe/tool/adv_reagent_scanner
 	path = /obj/item/scanner/reagent/adv
 
+/datum/fabricator_recipe/protolathe/tool/health_scanner
+	path = /obj/item/scanner/health
+
+/datum/fabricator_recipe/protolathe/tool/breath_scanner
+	path = /obj/item/scanner/breath
+
 /datum/fabricator_recipe/protolathe/tool/nanopaste
 	path = /obj/item/stack/nanopaste
 


### PR DESCRIPTION
## Description of changes
Adds protolathe designs for health and breath scanners.

## Why and what will this PR improve
You can print all the other scanners, and the health scanner module for your PDA, but not these two.

## Authorship
Me.