### PR TITLE
Fix grammar in two away site-related descriptions

### DIFF
--- a/code/game/turfs/exterior/exterior_concrete.dm
+++ b/code/game/turfs/exterior/exterior_concrete.dm
@@ -38,7 +38,7 @@ var/global/exterior_broken_states = icon_states('icons/turf/exterior/broken.dmi'
 
 /turf/exterior/concrete/reinforced
 	name = "reinforced concrete"
-	desc = "Stone-like artificial material. It has been reinforced with an unknown compound"
+	desc = "Stone-like artificial material. It has been reinforced with an unknown compound."
 
 /turf/exterior/concrete/reinforced/on_update_icon()
 	. = ..()

--- a/maps/away/lost_supply_base/lost_supply_base.dm
+++ b/maps/away/lost_supply_base/lost_supply_base.dm
@@ -3,7 +3,7 @@
 
 /obj/effect/overmap/visitable/sector/lost_supply_base
 	name = "supply station"
-	desc = "This looks like abandoned and heavy damaged supply station."
+	desc = "This looks like an abandoned and heavily damaged supply station."
 	icon_state = "object"
 
 	initial_generic_waypoints = list(


### PR DESCRIPTION
## Description of changes
Fixes bad grammar in the description of the lost supply base.
Fixes a missing period in the description of reinforced concrete.

## Why and what will this PR improve
It's a grammar fix.

## Authorship
Me.