### PR TITLE
Codex entries generated per atom will be kept on the atom.

### DIFF
--- a/code/controllers/subsystems/initialization/codex.dm
+++ b/code/controllers/subsystems/initialization/codex.dm
@@ -9,6 +9,7 @@ SUBSYSTEM_DEF(codex)
 
 	var/list/all_entries =       list()
 	var/list/entries_by_path =   list()
+	var/list/entries_by_ref =    list()
 	var/list/entries_by_string = list()
 	var/list/index_file =        list()
 	var/list/search_cache =      list()
@@ -65,8 +66,9 @@ SUBSYSTEM_DEF(codex)
 /datum/controller/subsystem/codex/proc/get_codex_entry(var/entry)
 	if(istype(entry, /atom))
 		var/atom/entity = entry
-		if(entity.get_specific_codex_entry())
-			return entity.get_specific_codex_entry()
+		var/specific_codex_entry = entity.get_specific_codex_entry()
+		if(specific_codex_entry)
+			return specific_codex_entry
 		return get_entry_by_string(entity.name) || entries_by_path[entity.type]
 	if(ispath(entry))
 		return entries_by_path[entry]

--- a/code/controllers/subsystems/initialization/codex.dm
+++ b/code/controllers/subsystems/initialization/codex.dm
@@ -9,7 +9,6 @@ SUBSYSTEM_DEF(codex)
 
 	var/list/all_entries =       list()
 	var/list/entries_by_path =   list()
-	var/list/entries_by_ref =    list()
 	var/list/entries_by_string = list()
 	var/list/index_file =        list()
 	var/list/search_cache =      list()

--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -83,7 +83,8 @@
 
 	if(opacity)
 		updateVisibility(src)
-
+	if(atom_codex_ref && atom_codex_ref != TRUE) // may be null, TRUE or a datum instance
+		QDEL_NULL(atom_codex_ref)
 	return ..()
 
 // Called if an atom is deleted before it initializes. Only call Destroy in this if you know what you're doing.

--- a/code/modules/codex/codex_atom.dm
+++ b/code/modules/codex/codex_atom.dm
@@ -1,18 +1,29 @@
+/atom
+	var/atom_codex_ref
+
+/obj
+	atom_codex_ref = TRUE
+
+/mob
+	atom_codex_ref = TRUE
+
+/turf
+	atom_codex_ref = TRUE
+
 /atom/proc/get_codex_value()
 	return src
 
 /atom/proc/get_specific_codex_entry()
-	if(SScodex.entries_by_path[type])
-		return SScodex.entries_by_path[type]
-
-	var/lore = get_lore_info()
-	var/mechanics = get_mechanics_info()
-	var/antag = get_antag_info()
-	if(!lore && !mechanics && !antag)
-		return FALSE
-		
-	var/datum/codex_entry/entry = new(name, list(type), _lore_text = lore, _mechanics_text = mechanics, _antag_text = antag)
-	return entry
+	if(!atom_codex_ref)
+		return
+	if(!istype(atom_codex_ref, /datum/codex_entry))
+		var/lore = get_lore_info()
+		var/mechanics = get_mechanics_info()
+		var/antag = get_antag_info()
+		if(!lore && !mechanics && !antag)
+			return
+		atom_codex_ref = new /datum/codex_entry/temporary(name, list(type), _lore_text = lore, _mechanics_text = mechanics, _antag_text = antag)
+	return atom_codex_ref
 
 /atom/proc/get_mechanics_info()
 	return

--- a/code/modules/codex/entries/_codex_entry.dm
+++ b/code/modules/codex/entries/_codex_entry.dm
@@ -60,7 +60,19 @@
 	..()
 
 /datum/codex_entry/Destroy(force)
-	SScodex.all_entries -= src
+	if(store_codex_entry) // Gating here to avoid unnecessary list checking overhead.
+		SScodex.all_entries -= src
+		for(var/associated_string in associated_strings)
+			SScodex.entries_by_string -= associated_string
+		for(var/associated_path in associated_paths)
+			SScodex.entries_by_path -= associated_path
+		for(var/thing in SScodex.index_file)
+			if(src == SScodex.index_file[thing])
+				SScodex.index_file -= thing
+		for(var/thing in SScodex.search_cache)
+			var/list/cached = SScodex.search_cache[thing]
+			if(src in cached)
+				cached -= src
 	. = ..()
 
 /datum/codex_entry/proc/get_codex_header(var/mob/presenting_to)

--- a/code/modules/codex/entries/_codex_entry.dm
+++ b/code/modules/codex/entries/_codex_entry.dm
@@ -3,6 +3,7 @@
 
 /datum/codex_entry
 	var/name
+	var/store_codex_entry = TRUE
 	var/list/associated_strings
 	var/list/associated_paths
 	var/lore_text
@@ -11,9 +12,10 @@
 	var/disambiguator
 	var/list/categories
 
-/datum/codex_entry/New(var/_display_name, var/list/_associated_paths, var/list/_associated_strings, var/_lore_text, var/_mechanics_text, var/_antag_text)
+/datum/codex_entry/temporary
+	store_codex_entry = FALSE
 
-	SScodex.all_entries += src
+/datum/codex_entry/New(var/_display_name, var/list/_associated_paths, var/list/_associated_strings, var/_lore_text, var/_mechanics_text, var/_antag_text)
 
 	if(_display_name)       name =               _display_name
 	if(_associated_paths)   associated_paths =   _associated_paths
@@ -22,7 +24,7 @@
 	if(_mechanics_text)     mechanics_text =     _mechanics_text
 	if(_antag_text)         antag_text =         _antag_text
 
-	if(length(associated_paths))
+	if(store_codex_entry && length(associated_paths))
 		for(var/tpath in associated_paths)
 			var/atom/thing = tpath
 			var/thing_name = codex_sanitize(initial(thing.name))
@@ -40,18 +42,20 @@
 		else
 			CRASH("Attempted to instantiate unnamed codex entry with no associated strings!")
 
-	LAZYDISTINCTADD(associated_strings, codex_sanitize(name))
-	for(var/associated_string in associated_strings)
-		var/clean_string = codex_sanitize(associated_string)
-		if(!clean_string)
-			associated_strings -= associated_string
-			continue
-		if(clean_string != associated_string)
-			associated_strings -= associated_string
-			associated_strings |= clean_string
-		if(SScodex.entries_by_string[clean_string])
-			PRINT_STACK_TRACE("Trying to save codex entry for [name] by string [clean_string] but one already exists!")
-		SScodex.entries_by_string[clean_string] = src
+	if(store_codex_entry)
+		SScodex.all_entries += src
+		LAZYDISTINCTADD(associated_strings, codex_sanitize(name))
+		for(var/associated_string in associated_strings)
+			var/clean_string = codex_sanitize(associated_string)
+			if(!clean_string)
+				associated_strings -= associated_string
+				continue
+			if(clean_string != associated_string)
+				associated_strings -= associated_string
+				associated_strings |= clean_string
+			if(SScodex.entries_by_string[clean_string])
+				PRINT_STACK_TRACE("Trying to save codex entry for [name] by string [clean_string] but one already exists!")
+			SScodex.entries_by_string[clean_string] = src
 
 	..()
 

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -447,8 +447,8 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	hidden_from_codex = TRUE
 	exoplanet_rarity = MAT_RARITY_NOWHERE
 
-// Generic material product (sheets, bricks, etc). Used ALL THE TIME.
-// May return an instance list, a single instance, or nothing if there is no instance produced.
+/// Generic material product (sheets, bricks, etc). Used ALL THE TIME.
+/// May return an instance list, a single instance, or nothing if there is no instance produced.
 /decl/material/proc/create_object(var/atom/target, var/amount = 1, var/object_type, var/reinf_type)
 
 	if(!object_type)


### PR DESCRIPTION
## Description of changes
- Atoms will keep a ref to any specific codex entry they generate instead of caching them on the subsystem.
- The subsystem will no longer track atom-specific codex entries and will not run uniqueness checks on them.

## Why and what will this PR improve
Examining two MREs causes the codex to complain.

## Authorship
@out-of-phaze for pointing out the issue, me for the code.

## Changelog
Nothing player-facing.