### PR TITLE
Fix sensor computer printout

### DIFF
--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -155,7 +155,7 @@
 
 	if (href_list["print"])
 		playsound(loc, "sound/machines/dotprinter.ogg", 30, 1)
-		new/obj/item/paper/(get_turf(src), last_scan["data"], "paper (Sensor Scan - [last_scan["name"]])")
+		new/obj/item/paper/(get_turf(src), null, last_scan["data"], "paper (Sensor Scan - [last_scan["name"]])")
 		return TOPIC_HANDLED
 
 /obj/machinery/shipsensors


### PR DESCRIPTION
## Description of changes
Fixes a missing material key argument that caused the text and title of sensor scans to be messed up.

## Why and what will this PR improve
~~It poses reputational risks to the organization, in particular the executive.~~
It's a bugfix.

## Authorship
Me.