### PR TITLE
Make design database constructable

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/research.dm
@@ -240,3 +240,15 @@
 		/obj/item/stock_parts/keyboard            = 1,
 		/obj/item/stock_parts/power/apc/buildable = 1,
 	)
+
+/obj/item/stock_parts/circuitboard/design_database
+	name = "circuitboard (design database)"
+	build_path = /obj/machinery/design_database
+	board_type = "machine"
+	origin_tech = "{'programming':2, 'engineering':2}"
+	req_components = list()
+	additional_spawn_components = list(
+		/obj/item/stock_parts/power/apc/buildable = 1,
+		/obj/item/stock_parts/console_screen = 1,
+		/obj/item/stock_parts/keyboard = 1
+	)

--- a/code/modules/fabrication/designs/imprinter/designs_misc_circuits.dm
+++ b/code/modules/fabrication/designs/imprinter/designs_misc_circuits.dm
@@ -266,6 +266,9 @@
 /datum/fabricator_recipe/imprinter/circuit/design_console
 	path = /obj/item/stock_parts/circuitboard/design_console
 
+/datum/fabricator_recipe/imprinter/circuit/design_database
+	path = /obj/item/stock_parts/circuitboard/design_database
+
 /datum/fabricator_recipe/imprinter/circuit/sensors
 	path = /obj/item/stock_parts/circuitboard/sensors
 

--- a/code/modules/research/design_database.dm
+++ b/code/modules/research/design_database.dm
@@ -14,6 +14,9 @@ var/global/list/default_initial_tech_levels
 	icon_state = "blackbox"
 	density = TRUE
 	anchored = TRUE
+	construct_state = /decl/machine_construction/default/panel_closed
+	uncreated_component_parts = null
+	stat_immune = 0
 
 	var/initial_network_id
 	var/initial_network_key


### PR DESCRIPTION
## Description of changes
Adds a circuit, circuit design, and construct_state for the design database.

## Why and what will this PR improve
You can't currently create a new design database for, say, a ship or whatever. This fixes that.

## Authorship
Me.