### PR TITLE
[MDB IGNORE] Fix simple pipes with wrong dir on generic tanker map

### DIFF
--- a/maps/away_sites_testing/away_sites_testing.dm
+++ b/maps/away_sites_testing/away_sites_testing.dm
@@ -5,6 +5,7 @@
 
 	#include "../../mods/content/government/away_sites/icarus/icarus.dm"
 	#include "../../mods/content/government/ruins/ec_old_crash/ec_old_crash.dm"
+	#include "../../mods/content/generic_shuttles/tanker/tanker.dm"
 	#include "../../mods/content/corporate/away_sites/lar_maria/lar_maria.dm"
 
 	#include "../away/bearcat/bearcat.dm"

--- a/mods/content/generic_shuttles/tanker/tanker.dmm
+++ b/mods/content/generic_shuttles/tanker/tanker.dmm
@@ -83,7 +83,7 @@
 /area/tanker)
 "fi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/reinforced/oxygen,
 /area/tanker)
@@ -441,7 +441,7 @@
 "Sf" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/tanker)


### PR DESCRIPTION
## Description of changes
This map isn't tested in unit testing because it's defined as an away site. I accidentally included it and it got caught.
Also adds it to the away sites unit testing map.

As an aside, I'm really against this unit test existing, and considering making a precommit hook to parse the map and correct the dirs at commit-time instead.

## Why and what will this PR improve
Better unit testing coverage and unit test compliance on this map.

## Authorship
Me.