### PR TITLE
Fix bad qdel in compass_holder destroy

### DIFF
--- a/code/game/objects/compass/compass_holder.dm
+++ b/code/game/objects/compass/compass_holder.dm
@@ -65,7 +65,8 @@ var/global/list/angle_step_to_dir = list(
 	return global.angle_step_to_dir[clamp(round(angle/45)+1, 1, length(global.angle_step_to_dir))]
 
 /obj/compass_holder/Destroy()
-	QDEL_NULL_LIST(compass_waypoints)
+	QDEL_LIST_ASSOC_VAL(compass_waypoints)
+	compass_waypoints = null
 	. = ..()
 
 /obj/compass_holder/proc/get_heading_strength()


### PR DESCRIPTION
## Description of changes
`compass_waypoints` is an associative list. `QDEL_NULL_LIST` attempted to delete the keys, which were strings, and triggered a bad qdel runtime. This now properly deletes the values in the list.

## Why and what will this PR improve
Fixes a runtime and deletes compass waypoints properly.

## Authorship
Me.