### PR TITLE
Update Github actions to fix deprecation warnings

### DIFF
--- a/.github/workflows/changelog_generation.yml
+++ b/.github/workflows/changelog_generation.yml
@@ -11,13 +11,13 @@ jobs:
     if: github.repository == 'NebulaSS13/Nebula' # to prevent this running on forks
     steps:
       - name: Checkout
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Otherwise, we will fail to push refs
           ref: dev
           token: ${{ secrets.BOT_TOKEN }}
       - name: Python setup
-        uses: actions/setup-python@3105fb18c05ddd93efea5f9e0bef7a03a6e9e7df
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
       - name: Install depends

--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: gen-docs
     steps:
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+      - uses: actions/checkout@v3
       - name: Setup Cache
-        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6
+        uses: actions/cache@v3
         with:
           path: $HOME/spaceman_dmm/$SPACEMAN_DMM_VERSION
           key: ${{ runner.os }}-spacemandmm-${{ env.SPACEMAN_DMM_VERSION }}
@@ -28,7 +28,7 @@ jobs:
           ~/dmdoc
           touch dmdoc/.nojekyll
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@da91e735be5cabb471a4b8afe367d10606da4683
+        uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages-dmdoc

--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -12,11 +12,11 @@ jobs:
     if: github.repository == 'NebulaSS13/Nebula' # to prevent this running on forks
     steps:
       - name: Checkout
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        uses: actions/checkout@v3
         with:
           fetch-depth: 25
       - name: Python setup
-        uses: actions/setup-python@3105fb18c05ddd93efea5f9e0bef7a03a6e9e7df
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
       - name: Install depends

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,9 @@ jobs:
   DreamChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+      - uses: actions/checkout@v3
       - name: Setup Cache
-        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6
+        uses: actions/cache@v3
         with:
           path: $HOME/spaceman_dmm/$SPACEMAN_DMM_VERSION
           key: ${{ runner.os }}-spacemandmm-${{ env.SPACEMAN_DMM_VERSION }}
@@ -35,7 +35,7 @@ jobs:
           set -o pipefail
           ~/dreamchecker 2>&1 | tee ${GITHUB_WORKSPACE}/output-annotations.txt
       - name: Annotate Lints
-        uses: yogstation13/DreamAnnotate@34029606cd7c22a08a589e084f860c1cc287363c
+        uses: yogstation13/DreamAnnotate@v2
         if: always()
         with:
           outputFile: output-annotations.txt
@@ -53,9 +53,9 @@ jobs:
   Code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+      - uses: actions/checkout@v3
       - name: Setup Cache
-        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6
+        uses: actions/cache@v3
         with:
           path: $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}
           key: ${{ runner.os }}-byond-${{ env.BYOND_MAJOR }}-${{ env.BYOND_MINOR }}
@@ -82,9 +82,9 @@ jobs:
       matrix:
         map_path: [example, tradeship, nexus, exodus, ministation, away_sites_testing, modpack_testing]
     steps:
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+      - uses: actions/checkout@v3
       - name: Setup Cache
-        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6
+        uses: actions/cache@v3
         with:
           path: $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}
           key: ${{ runner.os }}-byond-${{ env.BYOND_MAJOR }}-${{ env.BYOND_MINOR }}


### PR DESCRIPTION
## Description of changes
Updates Github actions versions from pinned commit hashes to more recent pinned versions.

## Why and what will this PR improve
If we don't do this soon, the actions might just stop working outright. Also, human-readable version tags are preferable to pinned hashes.

## Authorship
Took most of the versions used from TG.