### PR TITLE
Fix lighting not multiplying for ghosts

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -15,9 +15,6 @@
 		hud_used = new hud_type(src)
 	else
 		hud_used = new /datum/hud(src)
-
-/mob/living/InitializeHud()
-	..()
 	refresh_lighting_master()
 
 /datum/hud

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -724,7 +724,6 @@ default behaviour is:
 	if(auras)
 		for(var/a in auras)
 			remove_aura(a)
-	QDEL_NULL(lighting_master)
 	return ..()
 
 /mob/living/proc/melee_accuracy_mods()
@@ -1081,8 +1080,3 @@ default behaviour is:
 /mob/living/get_speech_bubble_state_modifier()
 	return isSynthetic() ? "synth" : ..()
 
-/mob/living/proc/refresh_lighting_master()
-	if(!lighting_master)
-		lighting_master = new
-	if(client)
-		client.screen |= lighting_master

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -47,5 +47,3 @@
 	var/list/chem_doses
 	var/last_pain_message
 	var/next_pain_time = 0
-
-	var/obj/screen/lighting_plane_master/lighting_master

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -19,4 +19,3 @@
 		weather.mob_shown_weather -=     mob_ref
 		weather.mob_shown_wind -=        mob_ref
 	global.current_mob_ambience -= mob_ref
-	refresh_lighting_master()

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -102,6 +102,8 @@
 		client.screen = list()	//remove hud items just in case
 		client.set_right_click_menu_mode(shift_to_open_context_menu)
 		InitializeHud()
+	else
+		refresh_lighting_master()
 
 	refresh_client_images()
 	reload_fullscreen() // Reload any fullscreen overlays this mob has.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -21,6 +21,7 @@
 	clear_fullscreen()
 	if(istype(ai))
 		QDEL_NULL(ai)
+	QDEL_NULL(lighting_master)
 	remove_screen_obj_references()
 	if(client)
 		for(var/atom/movable/AM in client.screen)
@@ -1211,3 +1212,10 @@
 		SStyping.set_indicator_state(client, FALSE)
 	if (message)
 		whisper(message)
+
+// Darksight procs.
+/mob/proc/refresh_lighting_master()
+	if(!lighting_master)
+		lighting_master = new
+	if(client)
+		client.screen |= lighting_master

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -180,3 +180,6 @@
 	var/atom/movable/typing_indicator/typing_indicator
 	/// Whether this mob is currently typing, if piloted by a player.
 	var/is_typing
+
+	/// Used for darksight, required on all mobs to ensure lighting renders properly.
+	var/obj/screen/lighting_plane_master/lighting_master

--- a/code/modules/mob/observer/observer.dm
+++ b/code/modules/mob/observer/observer.dm
@@ -98,3 +98,7 @@ var/global/const/GHOST_IMAGE_ALL = ~GHOST_IMAGE_NONE
 
 /mob/observer/get_speech_bubble_state_modifier()
 	return "ghost"
+
+/mob/observer/refresh_lighting_master()
+	..()
+	lighting_master.alpha = 255 // don't bother animating it


### PR DESCRIPTION
## Description of changes
Moves the lighting planemaster to `/mob` level so that it's always present on mobs.
The lighting planemaster is responsible for properly turning the `BLEND_OVERLAY` lighting overlays (which is necessary because of darksight) into a multiplicative overlay that darkens the map. It was only applied on `/mob/living`, however, meaning `/mob/observer` would see the lighting colors overlaid on the map instead of properly darkening it.

## Why and what will this PR improve
![image](https://cdn.discordapp.com/attachments/678826323728400394/1076098627975528559/image.png)

## Authorship
Me.