### PR TITLE
Fix hattable extension trying to equip non-hats

### DIFF
--- a/code/datums/extensions/hattable.dm
+++ b/code/datums/extensions/hattable.dm
@@ -11,7 +11,7 @@
 	..()
 
 /datum/extension/hattable/proc/wear_hat(var/mob/wearer, var/obj/item/clothing/head/new_hat)
-	if(hat || !new_hat)
+	if(hat || !istype(new_hat))
 		return FALSE
 	hat = new_hat
 	hat.forceMove(wearer)


### PR DESCRIPTION
## Description of changes
Replaces `!new_hat` with `!istype(new_hat)` to make sure what we're trying to wear is actually a hat.

## Why and what will this PR improve
Fixes runtimes from diona nymphs clicking anything that's not a hat.

## Authorship
Me.