### PR TITLE
Fix nymph held item screen_loc getting unset

### DIFF
--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -993,7 +993,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 		screen_loc = null
 	else if(client)
 		client.screen |= src
-		if(!client.mob || !client.mob.hud_used || !slot || (!client.mob.hud_used.inventory_shown && (slot in client.mob.hud_used.hidden_inventory_slots)))
+		if(!client.mob?.item_should_have_screen_presence(src, slot))
 			screen_loc = null
 
 /obj/item/proc/gives_weather_protection()

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -73,7 +73,7 @@ var/global/list/slot_equipment_priority = list( \
 //puts the item "W" into an appropriate slot in a human's inventory
 //returns 0 if it cannot, 1 if successful
 /mob/proc/equip_to_appropriate_slot(obj/item/W, var/skip_store = 0)
-	if(!istype(W)) 
+	if(!istype(W))
 		return FALSE
 	for(var/slot in slot_equipment_priority)
 		if(skip_store)
@@ -275,9 +275,9 @@ var/global/list/slot_equipment_priority = list( \
 /mob/proc/get_equipped_item(var/slot)
 	SHOULD_CALL_PARENT(TRUE)
 	switch(slot)
-		if(slot_back_str) 
+		if(slot_back_str)
 			return back
-		if(slot_wear_mask_str) 
+		if(slot_wear_mask_str)
 			return wear_mask
 
 /mob/proc/get_equipped_items(var/include_carried = 0)
@@ -327,3 +327,7 @@ var/global/list/slot_equipment_priority = list( \
 
 /mob/proc/can_be_buckled(var/mob/user)
 	. = user.Adjacent(src) && !istype(user, /mob/living/silicon/pai)
+
+/// If this proc returns false, reconsider_client_screen_presence will set the item's screen_loc to null.
+/mob/proc/item_should_have_screen_presence(obj/item/item, slot)
+	return hud_used && slot && (client.mob.hud_used.inventory_shown || !(slot in client.mob.hud_used.hidden_inventory_slots))

--- a/mods/mobs/dionaea/mob/nymph_inventory.dm
+++ b/mods/mobs/dionaea/mob/nymph_inventory.dm
@@ -57,3 +57,7 @@
 		visible_message(SPAN_NOTICE("\The [src] regurgitates \the [item]."))
 		return TRUE
 	. = ..()
+
+// Makes it so that the held item's screen_loc isn't unset.
+/mob/living/carbon/alien/diona/item_should_have_screen_presence(obj/item/item, slot)
+	return (item == holding_item) || ..()

--- a/mods/species/ascent/mobs/nymph/nymph_inventory.dm
+++ b/mods/species/ascent/mobs/nymph/nymph_inventory.dm
@@ -81,3 +81,7 @@
 		visible_message(SPAN_NOTICE("\The [src] regurgitates \the [item]."))
 		return TRUE
 	. = ..()
+
+// Makes it so that the held item's screen_loc isn't unset.
+/mob/living/carbon/alien/ascent_nymph/item_should_have_screen_presence(obj/item/item, slot)
+	return (item == holding_item) || ..()


### PR DESCRIPTION
## Description of changes
Fixes `/obj/item/proc/reconsider_client_screen_presence` removing nymph held items' `screen_loc`.

## Why and what will this PR improve
Fixes #2974.

## Authorship
Me.