### PR TITLE
Added missing circuit designs for internet machines

### DIFF
--- a/code/modules/fabrication/designs/imprinter/designs_misc_circuits.dm
+++ b/code/modules/fabrication/designs/imprinter/designs_misc_circuits.dm
@@ -473,6 +473,9 @@
 /datum/fabricator_recipe/imprinter/circuit/router_wall_mounted
 	path = /obj/item/stock_parts/circuitboard/router/wall_mounted
 
+/datum/fabricator_recipe/imprinter/circuit/modem
+	path = /obj/item/stock_parts/circuitboard/modem
+
 /datum/fabricator_recipe/imprinter/circuit/relay
 	path = /obj/item/stock_parts/circuitboard/relay
 

--- a/code/modules/overmap/internet/internet_circuitboards.dm
+++ b/code/modules/overmap/internet/internet_circuitboards.dm
@@ -34,3 +34,12 @@
 		/obj/item/stock_parts/keyboard = 1,
 		/obj/item/stock_parts/power/terminal = 1
 	)
+
+/datum/fabricator_recipe/imprinter/circuit/internet_uplink
+	path = /obj/item/stock_parts/circuitboard/internet_uplink
+
+/datum/fabricator_recipe/imprinter/circuit/internet_uplink_computer
+	path = /obj/item/stock_parts/circuitboard/internet_uplink_computer
+
+/datum/fabricator_recipe/imprinter/circuit/internet_repeater
+	path = /obj/item/stock_parts/circuitboard/internet_repeater

--- a/code/modules/overmap/internet/internet_circuitboards.dm
+++ b/code/modules/overmap/internet/internet_circuitboards.dm
@@ -8,11 +8,7 @@
 		/obj/item/stock_parts/micro_laser = 2,
 		/obj/item/stock_parts/smes_coil = 1
 	)
-	additional_spawn_components = list(
-		/obj/item/stock_parts/console_screen = 1,
-		/obj/item/stock_parts/keyboard = 1,
-		/obj/item/stock_parts/power/terminal = 1
-	)
+	additional_spawn_components = null
 
 /obj/item/stock_parts/circuitboard/internet_uplink_computer
 	name = "circuitboard (PLEXUS uplink controller)"
@@ -29,11 +25,7 @@
 		/obj/item/stock_parts/capacitor = 2,
 		/obj/item/stock_parts/micro_laser = 1
 	)
-	additional_spawn_components = list(
-		/obj/item/stock_parts/console_screen = 1,
-		/obj/item/stock_parts/keyboard = 1,
-		/obj/item/stock_parts/power/terminal = 1
-	)
+	additional_spawn_components = null
 
 /datum/fabricator_recipe/imprinter/circuit/internet_uplink
 	path = /obj/item/stock_parts/circuitboard/internet_uplink

--- a/code/modules/overmap/internet/internet_repeater.dm
+++ b/code/modules/overmap/internet/internet_repeater.dm
@@ -7,11 +7,16 @@ var/global/list/internet_repeaters = list()
 	icon_state = "bus"
 	density = 1
 	anchored = 1
-	stat_immune = 0
 	use_power = POWER_USE_ACTIVE
 	idle_power_usage = 50
 	active_power_usage = 5000
 	construct_state = /decl/machine_construction/default/panel_closed
+	stock_part_presets = list(
+		/decl/stock_part_preset/terminal_setup,
+	)
+	uncreated_component_parts = list(
+		/obj/item/stock_parts/power/terminal,
+	)
 
 /obj/machinery/internet_repeater/Initialize()
 	. = ..()

--- a/code/modules/overmap/internet/internet_repeater.dm
+++ b/code/modules/overmap/internet/internet_repeater.dm
@@ -11,6 +11,7 @@ var/global/list/internet_repeaters = list()
 	use_power = POWER_USE_ACTIVE
 	idle_power_usage = 50
 	active_power_usage = 5000
+	construct_state = /decl/machine_construction/default/panel_closed
 
 /obj/machinery/internet_repeater/Initialize()
 	. = ..()

--- a/code/modules/overmap/internet/internet_uplink.dm
+++ b/code/modules/overmap/internet/internet_uplink.dm
@@ -13,6 +13,7 @@ var/global/list/internet_uplinks = list()
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = list(/obj/item/stock_parts/power/terminal)
 	stock_part_presets = list(/decl/stock_part_preset/terminal_setup)
+	base_type = /obj/machinery/internet_uplink
 
 	var/overmap_range = BASE_INTERNET_RANGE
 	var/max_overmap_range = BASE_INTERNET_RANGE
@@ -161,6 +162,7 @@ var/global/list/internet_uplinks = list()
 	light_color = COLOR_GREEN
 	idle_power_usage = 250
 	active_power_usage = 500
+	base_type = /obj/machinery/computer/internet_uplink
 	var/initial_id_tag = "plexus"
 
 	var/current_uplink = 1

--- a/code/modules/overmap/internet/internet_uplink.dm
+++ b/code/modules/overmap/internet/internet_uplink.dm
@@ -8,12 +8,13 @@ var/global/list/internet_uplinks = list()
 	icon_state = "unpowered"
 	density = 1
 	anchored = 1
-	stat_immune = 0
-
 	construct_state = /decl/machine_construction/default/panel_closed
-	uncreated_component_parts = list(/obj/item/stock_parts/power/terminal)
-	stock_part_presets = list(/decl/stock_part_preset/terminal_setup)
-	base_type = /obj/machinery/internet_uplink
+	uncreated_component_parts = list(
+		/obj/item/stock_parts/power/terminal,
+	)
+	stock_part_presets = list(
+		/decl/stock_part_preset/terminal_setup,
+	)
 
 	var/overmap_range = BASE_INTERNET_RANGE
 	var/max_overmap_range = BASE_INTERNET_RANGE
@@ -162,9 +163,7 @@ var/global/list/internet_uplinks = list()
 	light_color = COLOR_GREEN
 	idle_power_usage = 250
 	active_power_usage = 500
-	base_type = /obj/machinery/computer/internet_uplink
 	var/initial_id_tag = "plexus"
-
 	var/current_uplink = 1
 
 /obj/machinery/computer/internet_uplink/Initialize()


### PR DESCRIPTION
## Description of changes
A few things were missing a recipe for their circuitboards. And it seems unit tests didn't pick those up.
Also fixed the internet repeater having no construct state.

## Changelog
:cl:
add: Added missing recipes for internet modem, uplink, uplink computer, and repeater.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->