### PR TITLE
Make geothermal generator work

### DIFF
--- a/code/modules/fabrication/designs/imprinter/designs_misc_circuits.dm
+++ b/code/modules/fabrication/designs/imprinter/designs_misc_circuits.dm
@@ -493,3 +493,6 @@
 
 /datum/fabricator_recipe/imprinter/circuit/holomap
 	path = /obj/item/stock_parts/circuitboard/holomap
+
+/datum/fabricator_recipe/imprinter/circuit/geothermal_generator
+	path = /obj/item/stock_parts/circuitboard/geothermal

--- a/code/modules/power/geothermal/_geothermal.dm
+++ b/code/modules/power/geothermal/_geothermal.dm
@@ -192,17 +192,17 @@ var/global/const/MAX_GEOTHERMAL_PRESSURE =               12000
 		var/consumed_pressure = current_pressure * GEOTHERMAL_PRESSURE_CONSUMED_PER_TICK
 		current_pressure -= consumed_pressure
 		var/remaining_pressure = consumed_pressure
-		consumed_pressure = round(consumed_pressure * efficiency)
+		consumed_pressure = round(consumed_pressure * efficiency, 0.01)
 		remaining_pressure -= consumed_pressure
 
-		last_generated = round(consumed_pressure * GEOTHERMAL_PRESSURE_TO_POWER)
+		last_generated = round(consumed_pressure * GEOTHERMAL_PRESSURE_TO_POWER, 0.01)
 		if(last_generated)
 			generate_power(last_generated)
 		remaining_pressure = round(remaining_pressure * GEOTHERMAL_PRESSURE_LOSS)
 		if(remaining_pressure)
 			addtimer(CALLBACK(src, .proc/propagate_pressure, remaining_pressure), 5)
 	update_icon()
-	if(current_pressure <= 10)
+	if(current_pressure <= 1)
 		return PROCESS_KILL
 
 /obj/machinery/geothermal/proc/propagate_pressure(var/remaining_pressure)

--- a/code/modules/power/geothermal/_geothermal.dm
+++ b/code/modules/power/geothermal/_geothermal.dm
@@ -130,9 +130,7 @@ var/global/const/MAX_GEOTHERMAL_PRESSURE =               12000
 	. = ..()
 	if(get_turf(loc))
 		refresh_neighbors()
-		for(var/turf/T as anything in RANGE_TURFS(loc, 1))
-			for(var/obj/machinery/geothermal/neighbor in T)
-				neighbor.refresh_neighbors()
+		propagate_refresh_neighbors()
 	STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 	return INITIALIZE_HINT_LATELOAD
 
@@ -145,9 +143,14 @@ var/global/const/MAX_GEOTHERMAL_PRESSURE =               12000
 	unset_vent()
 	. = ..()
 	if(istype(last_loc))
-		for(var/turf/T as anything in RANGE_TURFS(last_loc, 1))
-			for(var/obj/machinery/geothermal/neighbor in T)
-				neighbor.refresh_neighbors()
+		propagate_refresh_neighbors(last_loc)
+
+///Tell all neighbors of the center atom to call update neighbors
+/obj/machinery/geothermal/proc/propagate_refresh_neighbors(var/atom/center = src)
+	for(var/adir in global.alldirs)
+		var/obj/machinery/geothermal/G = locate(/obj/machinery/geothermal) in get_step(center, adir)
+		if(G?.anchored)
+			G.refresh_neighbors()
 
 /obj/machinery/geothermal/examine(mob/user, distance)
 	. = ..()

--- a/code/modules/power/geothermal/_geothermal.dm
+++ b/code/modules/power/geothermal/_geothermal.dm
@@ -40,6 +40,7 @@ var/global/const/MAX_GEOTHERMAL_PRESSURE =               12000
 	anchored   = TRUE
 	layer      = TURF_LAYER + 0.01
 	level      = 1 //Goes under floor/plating
+	///The particle emitter that will generate the steam column effect for this geyser
 	var/particles/geyser_steam/steamfx
 
 /obj/effect/geyser/Initialize(ml)
@@ -51,6 +52,7 @@ var/global/const/MAX_GEOTHERMAL_PRESSURE =               12000
 	set_extension(src, /datum/extension/geothermal_vent)
 	steamfx = new //Prepare our FX
 
+///Async proc that enables the particle emitter for the steam column for a few seconds
 /obj/effect/geyser/proc/do_spout()
 	set waitfor = FALSE
 	particles = steamfx
@@ -158,6 +160,7 @@ var/global/const/MAX_GEOTHERMAL_PRESSURE =               12000
 		to_chat(user, SPAN_INFO("Pressure: [current_pressure]kPa"))
 		to_chat(user, SPAN_INFO("Output:   [last_generated]W"))
 
+///Attempts to connect to any existing geothermal vents in our turf.
 /obj/machinery/geothermal/proc/setup_vent()
 	var/turf/T = get_turf(src)
 	for(var/obj/O in T)
@@ -168,6 +171,7 @@ var/global/const/MAX_GEOTHERMAL_PRESSURE =               12000
 		vent.set_my_generator(src)
 		return TRUE
 
+///Disconnect from any geothermal vents we may be connected to
 /obj/machinery/geothermal/proc/unset_vent()
 	if(QDELETED(vent))
 		return

--- a/code/modules/power/geothermal/_geothermal.dm
+++ b/code/modules/power/geothermal/_geothermal.dm
@@ -4,12 +4,16 @@ var/global/const/GEOTHERMAL_PRESSURE_CONSUMED_PER_TICK = 0.05
 var/global/const/GEOTHERMAL_PRESSURE_TO_POWER =          800
 var/global/const/MAX_GEOTHERMAL_PRESSURE =               12000
 
-//
+//////////////////////////////////////////////////////////////////////
+// Geyser Steam Particle Emitter
+//////////////////////////////////////////////////////////////////////
+
+///Particle emitter that emits a ~64 pixels by ~192 pixels high column of steam while active.
 /particles/geyser_steam
 	icon_state = "smallsmoke"
 	icon       = 'icons/effects/effects.dmi'
-	width      = WORLD_ICON_SIZE * 2
-	height     = WORLD_ICON_SIZE * 6 //Needs to be really tall, otherwise particles stop being drawn outside of the canvas.
+	width      = WORLD_ICON_SIZE * 2 //Particles expand a bit as they climb, so need a bit of space on the width
+	height     = WORLD_ICON_SIZE * 6 //Needs to be really tall, because particles stop being drawn outside of the canvas.
 	count      = 64
 	spawning   = 5
 	lifespan   = generator("num", 1 SECOND, 2.5 SECONDS, LINEAR_RAND)
@@ -18,14 +22,16 @@ var/global/const/MAX_GEOTHERMAL_PRESSURE =               12000
 	grow       = 0.1
 	velocity   = generator("vector", list(0, 0), list(0, 0.2))
 	position   = generator("circle", -6, 6, NORMAL_RAND)
-	//drift      = generator("vector", list(0, -0.2), list(0, 0.2))
 	gravity    = list(0, 0.40)
 	scale      = generator("vector", list(0.3, 0.3), list(1,1), NORMAL_RAND)
 	rotation   = generator("num", -45, 45)
 	spin       = generator("num", -20, 20)
 
 //////////////////////////////////////////////////////////////////////
+// Geyser Object
 //////////////////////////////////////////////////////////////////////
+
+///A prop that periodically emit steam spouts and can have a geothermal generator placed on top to generate power.
 /obj/effect/geyser
 	name       = "geothermal vent"
 	desc       = "A vent leading to an underground geothermally heated reservoir, which periodically spew superheated liquid."
@@ -46,10 +52,11 @@ var/global/const/MAX_GEOTHERMAL_PRESSURE =               12000
 	steamfx = new //Prepare our FX
 
 /obj/effect/geyser/proc/do_spout()
+	set waitfor = FALSE
 	particles = steamfx
 	particles.spawning = initial(particles.spawning)
-	spawn(6 SECONDS)
-		particles.spawning = 0
+	sleep(6 SECONDS)
+	particles.spawning = 0
 
 /obj/effect/geyser/explosion_act(severity)
 	. = ..()
@@ -64,7 +71,9 @@ var/global/const/MAX_GEOTHERMAL_PRESSURE =               12000
 	update_icon()
 
 //////////////////////////////////////////////////////////////////////
+// Underwater Geyser Variant
 //////////////////////////////////////////////////////////////////////
+
 /obj/effect/geyser/underwater
 	desc = "A crack in the ocean floor that occasionally vents gouts of superheated water and steam."
 
@@ -81,12 +90,10 @@ var/global/const/MAX_GEOTHERMAL_PRESSURE =               12000
 	//Do some bubbles or something
 
 //////////////////////////////////////////////////////////////////////
+// Geothermal Generator
 //////////////////////////////////////////////////////////////////////
-/obj/machinery/geothermal/buildable
-	anchored                  = FALSE
-	uncreated_component_parts = null
-	stock_part_presets        = null
 
+///A power generator that can create power from being placed on top of a geyser.
 /obj/machinery/geothermal
 	name                           = "geothermal generator"
 	icon                           = 'icons/obj/machines/power/geothermal.dmi'
@@ -100,12 +107,11 @@ var/global/const/MAX_GEOTHERMAL_PRESSURE =               12000
 	required_interaction_dexterity = DEXTERITY_SIMPLE_MACHINES
 	construct_state                = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts      = list(
-		/obj/item/stock_parts/power/terminal = 1
+		/obj/item/stock_parts/power/terminal,
 	)
 	stock_part_presets             = list(
 		/decl/stock_part_preset/terminal_setup/offset_dir,
 	)
-	base_type = /obj/machinery/geothermal/buildable
 	var/tmp/neighbors              = 0
 	var/tmp/current_pressure       = 0
 	var/tmp/efficiency             = 0.5
@@ -116,7 +122,7 @@ var/global/const/MAX_GEOTHERMAL_PRESSURE =               12000
 	var/tmp/list/neighbor_connectors
 	var/tmp/list/neighbor_connectors_glow
 
-//#TODO: should cache neighbors and put listeners on neighbors
+//#TODO: Maybe should cache neighbors and put listeners on them?
 
 /obj/machinery/geothermal/Initialize(mapload, d, populate_parts = TRUE)
 	. = ..()
@@ -243,7 +249,6 @@ var/global/const/MAX_GEOTHERMAL_PRESSURE =               12000
 	add_overlay("geothermal-turbine-[clamp(round(output_ratio * 3), 0, 3)]")
 	glow.alpha = glow_alpha
 	add_overlay(glow)
-
 
 /obj/machinery/geothermal/dismantle()
 	. = ..()

--- a/code/modules/power/geothermal/_geothermal.dm
+++ b/code/modules/power/geothermal/_geothermal.dm
@@ -34,7 +34,7 @@ var/global/const/MAX_GEOTHERMAL_PRESSURE =               12000
 ///A prop that periodically emit steam spouts and can have a geothermal generator placed on top to generate power.
 /obj/effect/geyser
 	name       = "geothermal vent"
-	desc       = "A vent leading to an underground geothermally heated reservoir, which periodically spew superheated liquid."
+	desc       = "A vent leading to an underground geothermally heated reservoir, which periodically spews superheated liquid."
 	icon       = 'icons/effects/geyser.dmi'
 	icon_state = "geyser"
 	anchored   = TRUE
@@ -87,7 +87,9 @@ var/global/const/MAX_GEOTHERMAL_PRESSURE =               12000
 			new /obj/random/seaweed(T)
 
 /obj/effect/geyser/underwater/do_spout()
-	//Do some bubbles or something
+	set waitfor = FALSE
+	var/turf/T = get_turf(src)
+	T.show_bubbles()
 
 //////////////////////////////////////////////////////////////////////
 // Geothermal Generator
@@ -164,7 +166,7 @@ var/global/const/MAX_GEOTHERMAL_PRESSURE =               12000
 		return TRUE
 
 /obj/machinery/geothermal/proc/unset_vent()
-	if(!vent || QDELETED(vent))
+	if(QDELETED(vent))
 		return
 	vent.set_my_generator(null)
 	vent = null

--- a/code/modules/power/geothermal/_geothermal.dm
+++ b/code/modules/power/geothermal/_geothermal.dm
@@ -1,24 +1,75 @@
 var/global/const/GEOTHERMAL_EFFICIENCY_MOD =             0.2
 var/global/const/GEOTHERMAL_PRESSURE_LOSS =              0.3
-var/global/const/GEOTHERMAL_PRESSURE_CONSUMED_PER_TICK = 0.5
-var/global/const/GEOTHERMAL_PRESSURE_TO_POWER =        100
-var/global/const/MAX_GEOTHERMAL_PRESSURE =            2000
+var/global/const/GEOTHERMAL_PRESSURE_CONSUMED_PER_TICK = 0.05
+var/global/const/GEOTHERMAL_PRESSURE_TO_POWER =          800
+var/global/const/MAX_GEOTHERMAL_PRESSURE =               12000
 
+//
+/particles/geyser_steam
+	icon_state = "smallsmoke"
+	icon       = 'icons/effects/effects.dmi'
+	width      = WORLD_ICON_SIZE * 2
+	height     = WORLD_ICON_SIZE * 6 //Needs to be really tall, otherwise particles stop being drawn outside of the canvas.
+	count      = 64
+	spawning   = 5
+	lifespan   = generator("num", 1 SECOND, 2.5 SECONDS, LINEAR_RAND)
+	fade       = 3 SECONDS
+	fadein     = 0.25 SECONDS
+	grow       = 0.1
+	velocity   = generator("vector", list(0, 0), list(0, 0.2))
+	position   = generator("circle", -6, 6, NORMAL_RAND)
+	//drift      = generator("vector", list(0, -0.2), list(0, 0.2))
+	gravity    = list(0, 0.40)
+	scale      = generator("vector", list(0.3, 0.3), list(1,1), NORMAL_RAND)
+	rotation   = generator("num", -45, 45)
+	spin       = generator("num", -20, 20)
+
+//////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////
 /obj/effect/geyser
-	name = "geothermal vent"
-	desc = "A crack in the ocean floor that occasionally vents gouts of superheated water and steam."
-	icon = 'icons/effects/geyser.dmi'
+	name       = "geothermal vent"
+	desc       = "A vent leading to an underground geothermally heated reservoir, which periodically spew superheated liquid."
+	icon       = 'icons/effects/geyser.dmi'
 	icon_state = "geyser"
-	anchored = TRUE
-	layer = TURF_LAYER + 0.01
+	anchored   = TRUE
+	layer      = TURF_LAYER + 0.01
+	level      = 1 //Goes under floor/plating
+	var/particles/geyser_steam/steamfx
 
-/obj/effect/geyser/Initialize()
+/obj/effect/geyser/Initialize(ml)
 	. = ..()
 	if(prob(50))
 		var/matrix/M = matrix()
 		M.Scale(-1, 1)
 		transform = M
 	set_extension(src, /datum/extension/geothermal_vent)
+	steamfx = new //Prepare our FX
+
+/obj/effect/geyser/proc/do_spout()
+	particles = steamfx
+	particles.spawning = initial(particles.spawning)
+	spawn(6 SECONDS)
+		particles.spawning = 0
+
+/obj/effect/geyser/explosion_act(severity)
+	. = ..()
+	if(!QDELETED(src) && prob(100 - (25 * severity)))
+		physically_destroyed()
+
+/obj/effect/geyser/hide(hide)
+	var/datum/extension/geothermal_vent/E = get_extension(src, /datum/extension/geothermal_vent)
+	if(istype(E))
+		E.set_obstructed(hide)
+	. = ..()
+	update_icon()
+
+//////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////
+/obj/effect/geyser/underwater
+	desc = "A crack in the ocean floor that occasionally vents gouts of superheated water and steam."
+
+/obj/effect/geyser/underwater/Initialize(ml)
+	. = ..()
 	for(var/turf/exterior/seafloor/T in RANGE_TURFS(loc, 5))
 		var/dist = get_dist(loc, T)-1
 		if(prob(100 - (dist * 20)))
@@ -26,38 +77,116 @@ var/global/const/MAX_GEOTHERMAL_PRESSURE =            2000
 		if(prob(50 - (dist * 10)))
 			new /obj/random/seaweed(T)
 
-/obj/effect/geyser/explosion_act(severity)
-	. = ..()
-	if(!QDELETED(src) && prob(100 - (25 * severity)))
-		physically_destroyed()
+/obj/effect/geyser/underwater/do_spout()
+	//Do some bubbles or something
+
+//////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////
+/obj/machinery/geothermal/buildable
+	anchored                  = FALSE
+	uncreated_component_parts = null
+	stock_part_presets        = null
 
 /obj/machinery/geothermal
-	icon = 'icons/obj/machines/power/geothermal.dmi'
-	icon_state = "geothermal-base"
-	var/tmp/neighbors = 0
-	var/tmp/current_pressure = 0
-	var/efficiency = 0.5
+	name                           = "geothermal generator"
+	icon                           = 'icons/obj/machines/power/geothermal.dmi'
+	icon_state                     = "geothermal-base"
+	density                        = TRUE
+	anchored                       = TRUE
+	waterproof                     = TRUE
+	interact_offline               = TRUE
+	stat_immune                    = NOSCREEN | NOINPUT | NOPOWER
+	core_skill                     = SKILL_ENGINES
+	required_interaction_dexterity = DEXTERITY_SIMPLE_MACHINES
+	construct_state                = /decl/machine_construction/default/panel_closed
+	uncreated_component_parts      = list(
+		/obj/item/stock_parts/power/terminal = 1
+	)
+	stock_part_presets             = list(
+		/decl/stock_part_preset/terminal_setup/offset_dir,
+	)
+	base_type = /obj/machinery/geothermal/buildable
+	var/tmp/neighbors              = 0
+	var/tmp/current_pressure       = 0
+	var/tmp/efficiency             = 0.5
+	var/tmp/last_generated         = 0
+	var/tmp/datum/extension/geothermal_vent/vent
+	var/tmp/obj/item/stock_parts/power/terminal/connector
+	var/tmp/image/glow
+	var/tmp/list/neighbor_connectors
+	var/tmp/list/neighbor_connectors_glow
+
+//#TODO: should cache neighbors and put listeners on neighbors
+
+/obj/machinery/geothermal/Initialize(mapload, d, populate_parts = TRUE)
+	. = ..()
+	if(get_turf(loc))
+		refresh_neighbors()
+		for(var/turf/T as anything in RANGE_TURFS(loc, 1))
+			for(var/obj/machinery/geothermal/neighbor in T)
+				neighbor.refresh_neighbors()
+	STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/geothermal/LateInitialize()
+	. = ..()
+	setup_vent()
+
+/obj/machinery/geothermal/Destroy()
+	var/atom/last_loc = loc
+	unset_vent()
+	. = ..()
+	if(istype(last_loc))
+		for(var/turf/T as anything in RANGE_TURFS(last_loc, 1))
+			for(var/obj/machinery/geothermal/neighbor in T)
+				neighbor.refresh_neighbors()
+
+/obj/machinery/geothermal/examine(mob/user, distance)
+	. = ..()
+	if(distance < 2)
+		to_chat(user, SPAN_INFO("Pressure: [current_pressure]kPa"))
+		to_chat(user, SPAN_INFO("Output:   [last_generated]W"))
+
+/obj/machinery/geothermal/proc/setup_vent()
+	var/turf/T = get_turf(src)
+	for(var/obj/O in T)
+		var/datum/extension/geothermal_vent/GV = get_extension(O, /datum/extension/geothermal_vent)
+		if(!GV || QDELETED(GV))
+			continue
+		vent = GV
+		vent.set_my_generator(src)
+		return TRUE
+
+/obj/machinery/geothermal/proc/unset_vent()
+	if(!vent || QDELETED(vent))
+		return
+	vent.set_my_generator(null)
+	vent = null
 
 /obj/machinery/geothermal/RefreshParts()
 	..()
 	efficiency = clamp(total_component_rating_of_type(/obj/item/stock_parts/capacitor) * GEOTHERMAL_EFFICIENCY_MOD, GEOTHERMAL_EFFICIENCY_MOD, 1)
+	connector = get_component_of_type(/obj/item/stock_parts/power/terminal)
 
 /obj/machinery/geothermal/proc/add_pressure(var/pressure)
 	current_pressure = clamp(current_pressure + pressure, 0, MAX_GEOTHERMAL_PRESSURE)
-	if(!is_processing)
-		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
+	var/leftover = round(pressure - current_pressure)
+	if(leftover > 0)
+		addtimer(CALLBACK(src, .proc/propagate_pressure, leftover), 5)
+	update_icon()
+	START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 
 /obj/machinery/geothermal/Process()
-	if(anchored && !(stat & BROKEN) && loc)
+	if(loc && anchored && !(stat & BROKEN))
 		var/consumed_pressure = current_pressure * GEOTHERMAL_PRESSURE_CONSUMED_PER_TICK
 		current_pressure -= consumed_pressure
 		var/remaining_pressure = consumed_pressure
 		consumed_pressure = round(consumed_pressure * efficiency)
 		remaining_pressure -= consumed_pressure
 
-		var/generated_power = round(consumed_pressure * GEOTHERMAL_PRESSURE_TO_POWER)
-		if(generated_power)
-			generate_power(generated_power)
+		last_generated = round(consumed_pressure * GEOTHERMAL_PRESSURE_TO_POWER)
+		if(last_generated)
+			generate_power(last_generated)
 		remaining_pressure = round(remaining_pressure * GEOTHERMAL_PRESSURE_LOSS)
 		if(remaining_pressure)
 			addtimer(CALLBACK(src, .proc/propagate_pressure, remaining_pressure), 5)
@@ -86,46 +215,42 @@ var/global/const/MAX_GEOTHERMAL_PRESSURE =            2000
 	if(last_neighbors != neighbors)
 		update_icon()
 
-/obj/machinery/geothermal/Initialize()
-	. = ..()
-	refresh_neighbors()
-	for(var/turf/T as anything in RANGE_TURFS(loc, 1))
-		for(var/obj/machinery/geothermal/neighbor in T)
-			neighbor.refresh_neighbors()
-	STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
-
-/obj/machinery/geothermal/Destroy()
-	var/atom/last_loc = loc
-	. = ..()
-	if(istype(last_loc))
-		for(var/turf/T as anything in RANGE_TURFS(last_loc, 1))
-			for(var/obj/machinery/geothermal/neighbor in T)
-				neighbor.refresh_neighbors()
-
 /obj/machinery/geothermal/on_update_icon()
-
-	. = ..()
-
 	cut_overlays()
+	var/output_ratio = current_pressure / 3000
+	var/glow_alpha   = clamp(round((current_pressure / MAX_GEOTHERMAL_PRESSURE) * 255), 10, 255)
+	if(!glow)
+		glow = emissive_overlay(icon, "geothermal-glow")
+	if(!length(neighbor_connectors))
+		for(var/neighbordir in global.cardinal)
+			LAZYSET(neighbor_connectors,      "[neighbordir]", image(icon, "geothermal-connector",      dir = neighbordir))
+			LAZYSET(neighbor_connectors_glow, "[neighbordir]", image(icon, "geothermal-connector-glow", dir = neighbordir))
 
 	if(neighbors)
 		for(var/neighbordir in global.cardinal)
 			if(neighbors & neighbordir)
-				add_overlay(image(icon, "geothermal-connector", dir = neighbordir))
+				add_overlay(neighbor_connectors["[neighbordir]"])
+				// emissive_overlay is not setting dir and setting plane/layer directly also causes dir to break :(
+				var/image/neighborglow = neighbor_connectors_glow["[neighbordir]"]
+				neighborglow.alpha = glow_alpha
+				add_overlay(neighborglow)
 
-	if(current_pressure > 0)
-		set_light(2, 0.5, COLOR_RED)
-		add_overlay(image(icon, "geothermal-turbine-[clamp(round(current_pressure / 200), 0, 3)]"))
-		var/glow_alpha = clamp(round((current_pressure / 500) * 255), 20, 255)
-		var/image/I = emissive_overlay(icon, "geothermal-glow")
-		I.alpha = glow_alpha
-		add_overlay(I)
-		if(neighbors)
-			for(var/neighbordir in global.cardinal)
-				if(neighbors & neighbordir)
-					// emissive_overlay is not setting dir and setting plane/layer directly also causes dir to break :(
-					I = image(icon, "geothermal-connector-glow", dir = neighbordir)
-					I.alpha = glow_alpha
-					add_overlay(I)
-	else
+	if(round(current_pressure, 0.1) <= 0)
 		set_light(0)
+		return
+
+	set_light(1, clamp(output_ratio, 0.2, 1.0), COLOR_RED)
+	add_overlay("geothermal-turbine-[clamp(round(output_ratio * 3), 0, 3)]")
+	glow.alpha = glow_alpha
+	add_overlay(glow)
+
+
+/obj/machinery/geothermal/dismantle()
+	. = ..()
+	unset_vent()
+
+/obj/machinery/geothermal/get_powernet()
+	return connector?.terminal?.get_powernet()
+
+/obj/machinery/geothermal/drain_power()
+	return -1

--- a/code/modules/power/geothermal/geothermal_circuit.dm
+++ b/code/modules/power/geothermal/geothermal_circuit.dm
@@ -1,6 +1,6 @@
 /obj/item/stock_parts/circuitboard/geothermal
-	name = "circuitboard (geothermal turbine)"
-	build_path = /obj/machinery/geothermal
+	name = "circuitboard (geothermal generator)"
+	build_path = /obj/machinery/geothermal/buildable
 	board_type = "machine"
 	origin_tech = "{'magnets':3,'powerstorage':3}"
 	req_components = list(
@@ -8,3 +8,4 @@
 		/obj/item/stock_parts/manipulator = 2,
 		/obj/item/stack/cable_coil =        5
 	)
+	additional_spawn_components = null

--- a/code/modules/power/geothermal/geothermal_circuit.dm
+++ b/code/modules/power/geothermal/geothermal_circuit.dm
@@ -1,6 +1,6 @@
 /obj/item/stock_parts/circuitboard/geothermal
 	name = "circuitboard (geothermal generator)"
-	build_path = /obj/machinery/geothermal/buildable
+	build_path = /obj/machinery/geothermal
 	board_type = "machine"
 	origin_tech = "{'magnets':3,'powerstorage':3}"
 	req_components = list(

--- a/code/modules/power/geothermal/geothermal_extension.dm
+++ b/code/modules/power/geothermal/geothermal_extension.dm
@@ -1,34 +1,45 @@
 /datum/extension/geothermal_vent
 	base_type = /datum/extension/geothermal_vent
-	expected_type = /atom
+	expected_type = /obj/effect/geyser
 	flags = EXTENSION_FLAG_IMMEDIATE
 	var/pressure_min = 1000
 	var/pressure_max = 2000
-	var/steam_min = 30 SECONDS
-	var/steam_max = 1 MINUTE
+	var/steam_min = 20 SECONDS
+	var/steam_max = 60 SECONDS
 	var/tmp/next_steam = 0
-	var/datum/effect/effect/system/steam_spread/steam
+	var/tmp/obstructed = FALSE
+	var/obj/machinery/geothermal/my_machine
+	var/obj/effect/geyser/my_vent
 
-/datum/extension/geothermal_vent/New()
+/datum/extension/geothermal_vent/New(datum/holder)
 	..()
 	START_PROCESSING(SSprocessing, src)
+	my_vent = holder
 
 /datum/extension/geothermal_vent/Destroy()
+	my_machine = null
+	my_vent = null
 	. = ..()
 	STOP_PROCESSING(SSprocessing, src)
-	
+
+/datum/extension/geothermal_vent/proc/set_my_generator(var/obj/machinery/geothermal/G)
+	my_machine = G
+
+/datum/extension/geothermal_vent/proc/set_obstructed(var/state)
+	obstructed = state
+	if(obstructed)
+		STOP_PROCESSING(SSprocessing, src)
+	else
+		START_PROCESSING(SSprocessing, src)
+
 /datum/extension/geothermal_vent/Process()
-	..()
+	if(obstructed && !my_machine) //If we have a machine, don't care about obstruction, or it might cause problems
+		return PROCESS_KILL
+
 	if(world.time >= next_steam)
 		next_steam = world.time + rand(steam_min, steam_max)
-		var/turf/T = get_turf(holder)
-		if(!istype(T))
-			return
-		var/obj/machinery/geothermal/geothermal = locate() in T
-		if(geothermal?.anchored)
-			geothermal.add_pressure(rand(pressure_min, pressure_max))
-			return
-		if(!steam)
-			steam = new
-			steam.set_up(5, 0, holder)
-		steam.start()
+		//If we cached something, make it work
+		if(my_machine?.anchored)
+			my_machine.add_pressure(rand(pressure_min, pressure_max))
+		else
+			my_vent.do_spout() //Let the holder decide what to do when spewing steam


### PR DESCRIPTION
## Description of changes
Ported this from downstream. We needed geothermals for our map, and had to fix them. So I thought you guys might want them here too.

* Now uses a terminal in an adjacent turf, so it can actually be installed.
* Now provides a steadier power output.
* Now has everything a machine needs to not crash unit tests, and function.
* Now uses particles for geyser steam jets. Used steam spread before, but that effect caused massive lag and timer problems, while this one is much simpler and faster.

## Changelog
:cl:
add: Added geothermal generator circuit design to imprinter.
add: New, less laggy visual effect for steam geyser spout.
bugfix: Fixed geothermal generators.
/:cl: