### PR TITLE
Adding various variant ammo types.

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -186,6 +186,9 @@
 /obj/item/storage/box/ammo/shotgunammo/WillContain()
 	return list(/obj/item/ammo_magazine/shotholder = 2)
 
+/obj/item/storage/box/ammo/shotgunammo/large/WillContain()
+	return list(/obj/item/ammo_magazine/shotholder = 4)
+
 /obj/item/storage/box/ammo/shotgunshells
 	name = "box of shotgun shells"
 /obj/item/storage/box/ammo/shotgunshells/WillContain()
@@ -200,6 +203,9 @@
 	name = "box of stun shells"
 /obj/item/storage/box/ammo/stunshells/WillContain()
 	return list(/obj/item/ammo_magazine/shotholder/stun = 2)
+
+/obj/item/storage/box/ammo/stunshells/large/WillContain()
+	return list(/obj/item/ammo_magazine/shotholder/stun = 4)
 
 /obj/item/storage/box/ammo/sniperammo
 	name = "box of sniper shells"

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -148,6 +148,10 @@
 	labels = list("flash")
 	ammo_type = /obj/item/ammo_casing/pistol/flash
 
+/obj/item/ammo_magazine/pistol/emp
+	labels = list("haywire")
+	ammo_type = /obj/item/ammo_casing/pistol/emp
+
 /obj/item/ammo_magazine/pistol/small
 	icon_state = "holdout"
 	material = /decl/material/solid/metal/steel
@@ -242,6 +246,14 @@
 	material = /decl/material/solid/metal/steel
 	max_ammo = 7
 	multiple_sprites = 1
+
+/obj/item/ammo_magazine/speedloader/rubber
+	labels = list("rubber")
+	ammo_type = /obj/item/ammo_casing/pistol/magnum/rubber
+
+/obj/item/ammo_magazine/speedloader/practice
+	labels = list("practice")
+	ammo_type = /obj/item/ammo_casing/pistol/magnum/practice
 
 /obj/item/ammo_magazine/speedloader/laser_revolver
 	caliber = CALIBER_PISTOL_LASBULB

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -63,6 +63,28 @@
 	projectile_type = /obj/item/projectile/bullet/pistol/strong
 	icon = 'icons/obj/ammo/casings/magnum.dmi'
 
+/obj/item/ammo_casing/pistol/magnum/rubber
+	desc = "A rubber bullet casing."
+	projectile_type = /obj/item/projectile/bullet/pistol/rubber/strong
+	bullet_color = COLOR_GRAY40
+
+/obj/item/ammo_casing/pistol/magnum/practice
+	desc = "A practice bullet casing."
+	projectile_type = /obj/item/projectile/bullet/pistol/practice
+	bullet_color = COLOR_OFF_WHITE
+	marking_color = COLOR_SUN
+
+/obj/item/ammo_casing/pistol/magnum/stun
+	name = "stun round"
+	desc = "An energy stun cartridge."
+	icon_state = "stunshell"
+	spent_icon = "stunshell-spent"
+	projectile_type = /obj/item/projectile/energy/electrode/stunshot
+	leaves_residue = 0
+	material = /decl/material/solid/metal/steel
+	matter = list(/decl/material/solid/glass = MATTER_AMOUNT_REINFORCEMENT)
+	origin_tech = "{'combat':3,'materials':3}"
+
 /obj/item/ammo_casing/shotgun
 	name = "shotgun slug"
 	desc = "A shotgun slug."

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -12,6 +12,9 @@
 /obj/item/gun/projectile/pistol/rubber
 	magazine_type = /obj/item/ammo_magazine/pistol/rubber
 
+/obj/item/gun/projectile/pistol/emp
+	magazine_type = /obj/item/ammo_magazine/pistol/emp
+
 /obj/item/gun/projectile/pistol/update_base_icon()
 	var/base_state = get_world_inventory_state()
 	if(!length(ammo_magazine?.stored_ammo) && check_state_in_icon("[base_state]-e", icon))

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -41,6 +41,9 @@
 	chamber_offset = 0
 	return ..()
 
+/obj/item/gun/projectile/revolver/stun
+	ammo_type = /obj/item/ammo_casing/pistol/magnum/stun
+
 /obj/item/gun/projectile/revolver/capgun
 	name = "cap gun"
 	desc = "Looks almost like the real thing! Ages 8 and up."

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -91,6 +91,10 @@
 	agony = 30
 	embed = 0
 
+/obj/item/projectile/bullet/pistol/rubber/strong
+	damage = 8
+	agony = 38
+
 /obj/item/projectile/bullet/pistol/rubber/holdout
 	agony = 20
 


### PR DESCRIPTION
## Description of changes
- Adds large boxes of shotgun shells and stun shotgun shells.
- Added haywire pistol magazine.
- Added practice and rubber revolver ammo, as well as speedloaders.
- Readded stun revolver as a ballistic weapon with preloaded stun rounds.

## Why and what will this PR improve
Useful for mapping, bit of variety for ballistics, needed for Polaris map port.

## Authorship
Myself.

## Changelog
:cl:
add: Added several new subtypes of ammunition for shotguns and pistols.
/:cl:
