### PR TITLE
Turbolifts are now handled on SSmapping.

### DIFF
--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -46,6 +46,8 @@ SUBSYSTEM_DEF(mapping)
 	var/base_floor_area
 	/// A list of connected z-levels to avoid repeatedly rebuilding connections
 	var/list/connected_z_cache = list()
+	/// A list of turbolift holders to initialize.
+	var/list/turbolifts_to_initialize = list()
 
 /datum/controller/subsystem/mapping/PreInit()
 	reindex_lists()
@@ -72,6 +74,10 @@ SUBSYSTEM_DEF(mapping)
 		world.maxx = new_maxx
 	if (new_maxy > world.maxy)
 		world.maxy = new_maxy
+
+	// Generate turbolifts.
+	for(var/obj/abstract/turbolift_spawner/turbolift as anything in turbolifts_to_initialize)
+		turbolift.build_turbolift()
 
 	// Populate overmap.
 	if(length(global.using_map.overmap_ids))

--- a/code/controllers/subsystems/misc_late.dm
+++ b/code/controllers/subsystems/misc_late.dm
@@ -3,9 +3,17 @@ SUBSYSTEM_DEF(misc_late)
 	name = "Late Initialization"
 	init_order = SS_INIT_MISC_LATE
 	flags = SS_NO_FIRE
+	var/list/turbolifts_to_open = list()
 
 /datum/controller/subsystem/misc_late/Initialize()
 	global.using_map.build_exoplanets()
 	var/decl/asset_cache/asset_cache = GET_DECL(/decl/asset_cache)
 	asset_cache.load()
+
+	// This is gross but I'm not sure where else to handle it. Sorry.
+	for(var/datum/turbolift/lift in turbolifts_to_open)
+		if(!QDELETED(lift))
+			lift.open_doors()
+	turbolifts_to_open.Cut()
+
 	. = ..()

--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -1,7 +1,7 @@
 /*
  * Turbolifts! Sort of like multishuttles-lite.
  *
- * How-to: Map /obj/turbolift_map_holder in at the bottom of the shaft, give it a depth
+ * How-to: Map /obj/abstract/turbolift_spawner in at the bottom of the shaft, give it a depth
  * value equivalent to the number of floors it should span (inclusive of the first),
  * and at runtime it will update the map, set areas and create control panels and
  * wifi-set doors appropriate to itself. You will save time at init if you map the

--- a/code/modules/turbolift/turbolift_map.dm
+++ b/code/modules/turbolift/turbolift_map.dm
@@ -1,5 +1,5 @@
 // Map object.
-/obj/turbolift_map_holder
+/obj/abstract/turbolift_spawner
 	name = "turbolift map placeholder"
 	icon = 'icons/obj/turbolift_preview_3x3.dmi'
 	dir = SOUTH         // Direction of the holder determines the placement of the lift control panel and doors.
@@ -21,9 +21,19 @@
 	var/floor_departure_sound
 	var/floor_arrival_sound
 
-
-/obj/turbolift_map_holder/Initialize()
+INITIALIZE_IMMEDIATE(/obj/abstract/turbolift_spawner)
+/obj/abstract/turbolift_spawner/Initialize()
 	. = ..()
+	if(SSmapping.initialized)
+		build_turbolift()
+	else
+		SSmapping.turbolifts_to_initialize += src
+
+/obj/abstract/turbolift_spawner/Destroy()
+	SSmapping.turbolifts_to_initialize -= src
+	return ..()
+
+/obj/abstract/turbolift_spawner/proc/build_turbolift()
 	// Create our system controller.
 	var/datum/turbolift/lift = new()
 	if(floor_departure_sound)
@@ -62,7 +72,7 @@
 
 		if(NORTH)
 
-			int_panel_x = ux + FLOOR(lift_size_x/2) 
+			int_panel_x = ux + FLOOR(lift_size_x/2)
 			int_panel_y = uy + 1
 			ext_panel_x = ux
 			ext_panel_y = ey + 2
@@ -79,7 +89,7 @@
 
 		if(SOUTH)
 
-			int_panel_x = ux + FLOOR(lift_size_x/2) 
+			int_panel_x = ux + FLOOR(lift_size_x/2)
 			int_panel_y = ey - 1
 			ext_panel_x = ex
 			ext_panel_y = uy - 2
@@ -234,6 +244,9 @@
 			light1.set_dir(SOUTH)
 			light2.set_dir(NORTH)
 
-	lift.open_doors()
+	if(SSmisc_late.initialized)
+		lift.open_doors()
+	else
+		SSmisc_late.turbolifts_to_open += lift
 
 	qdel(src) // We're done.

--- a/maps/example/example-1.dmm
+++ b/maps/example/example-1.dmm
@@ -427,7 +427,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/example/first)
 "tA" = (
-/obj/turbolift_map_holder/example,
+/obj/abstract/turbolift_spawner/example,
 /turf/simulated/floor,
 /area/turbolift/example/first)
 "uD" = (

--- a/maps/example/example_shuttles.dm
+++ b/maps/example/example_shuttles.dm
@@ -29,7 +29,7 @@
 	)
 	ceiling_type = /turf/simulated/floor/shuttle_ceiling
 
-/obj/turbolift_map_holder/example
+/obj/abstract/turbolift_spawner/example
 	name = "Testing Site elevator placeholder"
 	icon = 'icons/obj/turbolift_preview_nowalls_3x3.dmi'
 	depth = 3

--- a/maps/exodus/exodus-1.dmm
+++ b/maps/exodus/exodus-1.dmm
@@ -167,7 +167,7 @@
 /turf/simulated/floor/plating,
 /area/exodus/maintenance/sub/fore)
 "aB" = (
-/obj/turbolift_map_holder/exodus/sec,
+/obj/abstract/turbolift_spawner/exodus/sec,
 /turf/space,
 /area/exodus/maintenance/sub/fore)
 "aC" = (
@@ -1312,7 +1312,7 @@
 /turf/simulated/floor/plating,
 /area/exodus/maintenance/sub/starboard)
 "eh" = (
-/obj/turbolift_map_holder/exodus/cargo,
+/obj/abstract/turbolift_spawner/exodus/cargo,
 /turf/space,
 /area/exodus/maintenance/sub/port)
 "ei" = (
@@ -1989,7 +1989,7 @@
 /turf/simulated/floor/plating,
 /area/exodus/maintenance/sub/starboard)
 "fN" = (
-/obj/turbolift_map_holder/exodus/research,
+/obj/abstract/turbolift_spawner/exodus/research,
 /turf/space,
 /area/exodus/maintenance/sub/starboard)
 "fO" = (
@@ -4433,7 +4433,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/engineering/atmos)
 "lM" = (
-/obj/turbolift_map_holder/exodus/engineering,
+/obj/abstract/turbolift_spawner/exodus/engineering,
 /turf/space,
 /area/exodus/maintenance/sub/aft)
 "lN" = (

--- a/maps/exodus/exodus_elevator.dm
+++ b/maps/exodus/exodus_elevator.dm
@@ -1,9 +1,9 @@
-/obj/turbolift_map_holder/exodus
+/obj/abstract/turbolift_spawner/exodus
 	depth = 2
 	lift_size_x = 3
 	lift_size_y = 3
 
-/obj/turbolift_map_holder/exodus/sec
+/obj/abstract/turbolift_spawner/exodus/sec
 	name = "Exodus turbolift map placeholder - Securiy"
 	dir = EAST
 
@@ -12,7 +12,7 @@
 		/area/turbolift/security_station
 		)
 
-/obj/turbolift_map_holder/exodus/research
+/obj/abstract/turbolift_spawner/exodus/research
 	name = "Exodus turbolift map placeholder - Research"
 	dir = WEST
 
@@ -21,7 +21,7 @@
 		/area/turbolift/research_station
 		)
 
-/obj/turbolift_map_holder/exodus/engineering
+/obj/abstract/turbolift_spawner/exodus/engineering
 	name = "Exodus turbolift map placeholder - Engineering"
 	icon = 'icons/obj/turbolift_preview_3x3.dmi'
 	dir = EAST
@@ -33,7 +33,7 @@
 		/area/turbolift/engineering_station
 		)
 
-/obj/turbolift_map_holder/exodus/cargo
+/obj/abstract/turbolift_spawner/exodus/cargo
 	name = "Exodus turbolift map placeholder - Cargo"
 
 	areas_to_use = list(

--- a/maps/tradeship/tradeship-0.dmm
+++ b/maps/tradeship/tradeship-0.dmm
@@ -2020,7 +2020,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/loading_bay)
 "Qy" = (
-/obj/turbolift_map_holder/tradeship{
+/obj/abstract/turbolift_spawner/tradeship{
 	dir = 1;
 	icon_state = ""
 	},

--- a/maps/tradeship/tradeship_shuttles.dm
+++ b/maps/tradeship/tradeship_shuttles.dm
@@ -43,7 +43,7 @@
 	landmark_tag = "nav_tradeship_below_starboardastern"
 
 // Essentially a bare platform that moves up and down.
-/obj/turbolift_map_holder/tradeship
+/obj/abstract/turbolift_spawner/tradeship
 	name = "Tradeship cargo elevator placeholder"
 	depth = 4
 	lift_size_x = 3


### PR DESCRIPTION
## Description of changes
Moves turbolift init onto `SSmapping` instead of handling it during `SSatoms` init..

## Why and what will this PR improve
Should avoid weirdness from things like decals overlapping with the elevator area getting deleted and then complaining about it when they try to initialize.

## Authorship
Myself.

## Changelog
Nothing player-facing.