### PR TITLE
Maps can now abstain from announcing job arrivals.

### DIFF
--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -243,7 +243,9 @@
 		new_record.set_skillset(jointext(skills,"\n"))
 
 	if(istype(job) && job.announced)
-		AnnounceArrivalSimple(new_record.get_name(), new_record.get_job(), "has completed cryogenic revival", get_announcement_frequency(job))
+		var/announce_channel = get_announcement_frequency(job)
+		if(announce_channel)
+			AnnounceArrivalSimple(new_record.get_name(), new_record.get_job(), "has completed cryogenic revival", announce_channel)
 	. = ..()
 
 #undef COPY_VALUE

--- a/code/procs/announce.dm
+++ b/code/procs/announce.dm
@@ -138,8 +138,9 @@ var/global/datum/announcement/minor/minor_announcement = new(new_sound = 'sound/
 	var/rank = job.title
 	if(character.mind.role_alt_title)
 		rank = character.mind.role_alt_title
-
-	AnnounceArrivalSimple(character.real_name, rank, join_message, get_announcement_frequency(job))
+	var/announce_channel = get_announcement_frequency(job)
+	if(announce_channel)
+		AnnounceArrivalSimple(character.real_name, rank, join_message, announce_channel)
 
 /proc/AnnounceArrivalSimple(var/name, var/rank = "visitor", var/join_message = "has arrived on the [station_name()]", var/frequency)
 	var/obj/item/radio/announcer = get_global_announcer()
@@ -148,9 +149,10 @@ var/global/datum/announcement/minor/minor_announcement = new(new_sound = 'sound/
 /proc/get_announcement_frequency(var/datum/job/job)
 	// During red alert all jobs are announced on main frequency.
 	var/decl/security_state/security_state = GET_DECL(global.using_map.security_state)
-	if (security_state.current_security_level_is_same_or_higher_than(security_state.high_security_level))
-		return "Common"
-	var/decl/department/dept = SSjobs.get_department_by_type(job.primary_department)
-	if(dept?.announce_channel)
-		return dept.announce_channel
-	return "Common"
+	if(!security_state.current_security_level_is_same_or_higher_than(security_state.high_security_level))
+		var/decl/department/dept = SSjobs.get_department_by_type(job.primary_department)
+		if(dept?.announce_channel)
+			return dept.announce_channel
+	return global.using_map.default_announcement_frequency
+
+

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -42,6 +42,8 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	var/system_name = "Uncharted System"
 	var/ground_noun = "ground"
 
+	var/default_announcement_frequency = "Common"
+
 	// Current game year. Uses current system year + game_year num.
 	var/game_year = 288
 


### PR DESCRIPTION
## Description of changes
Jobs will not announce if they have no supplied channel.
Maps can be told to supply a default channel other than Common.
A null channel can be supplied.

## Why and what will this PR improve
Allows maps to refrain from announcing joins.

## Authorship
Myself.

## Changelog
Nothing player-facing.