### PR TITLE
Making tables not have borders by default.

### DIFF
--- a/html/browser/common.css
+++ b/html/browser/common.css
@@ -78,15 +78,13 @@ a.icon img, .linkOn.icon img
 	height: 18px;
 }
 
-table, th, td 
+table, th, td
 {
-	border: 1px solid;
-	border-color: #48656c;
 	border-collapse: collapse;
-	padding: 3px;
+	padding: 1px;
 }
 
-th 
+th
 {
 	background-color: #48656c;
 }


### PR DESCRIPTION
## Description of changes
Removes the default border from tables, lowers the padding.

## Why and what will this PR improve
Currently looks very ugly. Now looks less ugly.

## Authorship
Myself.

## Changelog
:cl:
tweak: Tables now default to having no borders in browser pages.
/:cl:
