### PR TITLE
Fix some internal organs not getting bodytype

### DIFF
--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -166,8 +166,8 @@
 					LAZYCLEARLIST(E.markings)
 
 		//Base skin and blend
-		for(var/obj/item/organ/external/E in H.get_external_organs())
-			E.set_dna(H.dna)
+		for(var/obj/item/organ/organ in H.get_organs())
+			organ.set_dna(H.dna)
 
 		//Hair
 		var/list/hair_subtypes = subtypesof(/decl/sprite_accessory/hair)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -639,8 +639,7 @@
 	if(istype(new_bodytype) && bodytype != new_bodytype)
 		bodytype = new_bodytype
 		if(bodytype && rebuild_body)
-			force_update_limbs()
-			update_body()
+			UpdateAppearance() // force_update_limbs is insufficient because of internal organs
 
 //set_species should not handle the entirety of initing the mob, and should not trigger deep updates
 //It focuses on setting up species-related data, without force applying them uppon organs and the mob's appearance.


### PR DESCRIPTION
## Description of changes
`force_update_limbs()` only updates *parts* of the DNA for external organs, meaning internal organs won't get their bodytype set or updated by `set_bodytype(rebuild_body = TRUE)`. This makes `UpdateAppearance()` sync the DNA for the whole body, not just external organs, and replaces a `force_update_limbs()` call (and a redundant `update_body()` call) with an `UpdateAppearance()` call.

## Why and what will this PR improve
Fixes an issue I observed where organs, specifically synthetic internal organs, didn't have bodytype set properly and were somehow just 'human' organs.

## Authorship
Me.