### PR TITLE
Add eye offset to bodytype

### DIFF
--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -41,13 +41,15 @@
 
 /obj/item/organ/internal/eyes/proc/get_eye_cache_key()
 	last_cached_eye_colour = eye_colour
-	last_eye_cache_key = "[type]-[eye_icon]-[last_cached_eye_colour]"
+	last_eye_cache_key = "[type]-[eye_icon]-[last_cached_eye_colour]-[bodytype.eye_offset]"
 	return last_eye_cache_key
 
 /obj/item/organ/internal/eyes/proc/get_onhead_icon()
 	var/cache_key = get_eye_cache_key()
 	if(!human_icon_cache[cache_key])
 		var/icon/eyes_icon = icon(icon = eye_icon, icon_state = "")
+		if(bodytype.eye_offset)
+			eyes_icon.Shift(NORTH, bodytype.eye_offset)
 		if(apply_eye_colour)
 			eyes_icon.Blend(last_cached_eye_colour, eye_blend)
 		human_icon_cache[cache_key] = eyes_icon

--- a/code/modules/species/species_bodytype.dm
+++ b/code/modules/species/species_bodytype.dm
@@ -30,6 +30,8 @@ var/global/list/bodytypes_by_category = list()
 	var/antaghud_offset_x = 0                 // As above, but specifically for the antagHUD indicator.
 	var/antaghud_offset_y = 0                 // As above, but specifically for the antagHUD indicator.
 
+	var/eye_offset = 0                        // Amount to shift eyes on the Y axis to correct for non-32px height.
+
 	var/list/prone_overlay_offset = list(0, 0) // amount to shift overlays when lying
 
 	// Per-bodytype per-zone message strings, see /mob/proc/get_hug_zone_messages


### PR DESCRIPTION
## Description of changes
Shifts eye overlays up or down based on bodytype. Requires #3023.

## Why and what will this PR improve
Allows you to change where the eye overlay is drawn vertically for a bodytype, since currently:
- eye icon is determined by the eye organ
- the eye organ is determined by the species
- bodytypes within a species may not have the same eye height

An example use-case of this is a bodytype that just has taller legs than others, meaning their eyes would need to be shifted up to draw on their face properly.

In the future, maybe bodytypes could be given organ overrides, but I just wanted something simple for this visual option. Also, tying where the eye overlay is to the eye organ itself feels like a bad pattern to begin with.

## Authorship
Me.