### PR TITLE
Auditing attack_hand() and adding dexterity checks.

### DIFF
--- a/code/_onclick/ghost.dm
+++ b/code/_onclick/ghost.dm
@@ -70,16 +70,3 @@
 		user.forceMove(stationgate.loc)
 	else
 		to_chat(user, "[src] has no destination.")
-
-// -------------------------------------------
-// This was supposed to be used by adminghosts
-// I think it is a *terrible* idea
-// but I'm leaving it here anyway
-// commented out, of course.
-/*
-/atom/proc/attack_admin(mob/user)
-	if(!user || !user.client || !user.client.holder)
-		return
-	attack_hand(user)
-
-*/

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -105,4 +105,4 @@
 
 // Attack hand but for simple animals
 /atom/proc/attack_animal(mob/user)
-	return attack_hand(user)
+	return CanPhysicallyInteract(user) && attack_hand(user)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -26,16 +26,16 @@
 	return FALSE
 
 /atom/proc/attack_hand(mob/user)
-
+	SHOULD_CALL_PARENT(TRUE)
 	if(handle_grab_interaction(user))
 		return TRUE
-
-	if(LAZYLEN(climbers) && !(user in climbers))
-		user.visible_message(
-			SPAN_DANGER("\The [user] shakes \the [src]!"),
-			SPAN_DANGER("You shake \the [src]!"))
-		object_shaken()
-		return TRUE
+	if(!LAZYLEN(climbers) || (user in climbers) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return FALSE
+	user.visible_message(
+		SPAN_DANGER("\The [user] shakes \the [src]!"),
+		SPAN_DANGER("You shake \the [src]!"))
+	object_shaken()
+	return TRUE
 
 /mob/proc/attack_empty_hand()
 	return

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -105,4 +105,8 @@
 
 // Attack hand but for simple animals
 /atom/proc/attack_animal(mob/user)
+	return attack_hand_with_interaction_checks(user)
+
+// Used to check for physical interactivity in case of nonstandard attack_hand calls.
+/atom/proc/attack_hand_with_interaction_checks(var/mob/user)
 	return CanPhysicallyInteract(user) && attack_hand(user)

--- a/code/datums/ai/monkey.dm
+++ b/code/datums/ai/monkey.dm
@@ -7,7 +7,7 @@
 	)
 
 /datum/ai/monkey/do_process(var/time_elapsed)
-	if(body.stat != CONSCIOUS)
+	if(body.incapacitated())
 		return
 
 	if(prob(33) && isturf(body.loc) && !LAZYLEN(body.grabbed_by)) //won't move if being pulled
@@ -28,8 +28,8 @@
 	if(!held && !body.restrained() && prob(5))
 		var/list/touchables = list()
 		for(var/obj/O in range(1,get_turf(body)))
-			if(O.simulated && O.Adjacent(body) && !is_type_in_list(O, no_touchie))
+			if(O.simulated && CanPhysicallyInteractWith(body, O) && !is_type_in_list(O, no_touchie))
 				touchables += O
 		if(touchables.len)
 			var/obj/touchy = pick(touchables)
-			touchy.attack_hand(body)
+			touchy.attack_hand(body) // No need for paranoid as we check physical interactivity above.

--- a/code/datums/extensions/on_click/turf_hand.dm
+++ b/code/datums/extensions/on_click/turf_hand.dm
@@ -7,14 +7,9 @@
 */
 /datum/extension/turf_hand
 	base_type = /datum/extension/turf_hand
-	var/priority = 1
 	expected_type = /atom
+	var/intercept_priority = 1
 
-/datum/extension/turf_hand/New(var/holder, var/priority = 1)
+/datum/extension/turf_hand/New(var/holder, var/_priority = 1)
 	..()
-	src.priority = priority
-
-
-/datum/extension/turf_hand/proc/OnHandInterception(var/mob/user)
-	var/atom/A = holder
-	return A.attack_hand(user)
+	intercept_priority = _priority

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -82,10 +82,10 @@
 
 /atom/movable/attack_hand(mob/user)
 	// Unbuckle anything buckled to us.
-	if(can_buckle && buckled_mob)
-		user_unbuckle_mob(user)
-		return TRUE
-	return ..()
+	if(!can_buckle || !buckled_mob || !user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
+		return ..()
+	user_unbuckle_mob(user)
+	return TRUE
 
 /atom/movable/hitby(var/atom/movable/AM, var/datum/thrownthing/TT)
 	..()
@@ -321,8 +321,10 @@
 		return master.attackby(I, user)
 
 /atom/movable/overlay/attack_hand(mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	if (master)
 		return master.attack_hand(user)
+	return FALSE
 
 /atom/movable/proc/touch_map_edge(var/overmap_id)
 	if(!simulated)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -322,9 +322,7 @@
 
 /atom/movable/overlay/attack_hand(mob/user)
 	SHOULD_CALL_PARENT(FALSE)
-	if (master)
-		return master.attack_hand(user)
-	return FALSE
+	return master?.attack_hand(user)
 
 /atom/movable/proc/touch_map_edge(var/overmap_id)
 	if(!simulated)

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -25,7 +25,9 @@
 	light_color = "#3e0000"
 
 /obj/structure/cult/pylon/attack_hand(mob/M)
+	SHOULD_CALL_PARENT(FALSE)
 	attackpylon(M, 5)
+	return TRUE
 
 /obj/structure/cult/pylon/attack_generic(var/mob/user, var/damage)
 	attackpylon(user, damage)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -56,17 +56,19 @@
 		return
 
 /obj/effect/rune/attack_hand(var/mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	if(!iscultist(user))
 		to_chat(user, "You can't mouth the arcane scratchings without fumbling over them.")
-		return
+		return TRUE
 	if(user.is_silenced())
 		to_chat(user, "You are unable to speak the words of the rune.")
-		return
+		return TRUE
 	var/decl/special_role/cultist/cult = GET_DECL(/decl/special_role/cultist)
 	if(cult.powerless)
 		to_chat(user, "You read the words, but nothing happens.")
 		return fizzle(user)
 	cast(user)
+	return TRUE
 
 /obj/effect/rune/attack_ai(var/mob/user) // Cult borgs!
 	if(Adjacent(user))
@@ -295,11 +297,13 @@
 			to_chat(user, "<span class='danger'>It is about to dissipate.</span>")
 
 /obj/effect/cultwall/attack_hand(var/mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	if(iscultist(user))
 		user.visible_message("<span class='notice'>\The [user] touches \the [src], and it fades.</span>", "<span class='notice'>You touch \the [src], whispering the old ritual, making it disappear.</span>")
 		qdel(src)
 	else
 		to_chat(user, "<span class='notice'>You touch \the [src]. It feels wet and becomes harder the further you push your arm.</span>")
+	return TRUE
 
 /obj/effect/cultwall/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/nullrod))
@@ -806,26 +810,27 @@
 		qdel(src)
 
 /obj/effect/rune/tearreality/attack_hand(var/mob/user)
-	..()
-	if(summoning_entity && !iscultist(user))
-		var/input = input(user, "Are you SURE you want to sacrifice yourself?", "DO NOT DO THIS") in list("Yes", "No")
-		if(input != "Yes")
-			return
-		speak_incantation(user, "Uhrast ka'hfa heldsagen ver[pick("'","`")]lot!")
-		to_chat(user, "<span class='warning'>In the last moment of your humble life, you feel an immense pain as fabric of reality mends... with your blood.</span>")
-		for(var/mob/M in global.living_mob_list_)
-			if(iscultist(M))
-				var/decl/pronouns/G = user.get_pronouns()
-				to_chat(M, "You see a vision of \the [user] keeling over dead, his blood glowing blue as it escapes [G.his] body and dissipates into thin air; you hear an otherwordly scream and feel that a great disaster has just been averted.")
-			else
-				to_chat(M, "You see a vision of [name] keeling over dead, his blood glowing blue as it escapes his body and dissipates into thin air; you hear an otherwordly scream and feel very weak for a moment.")
-		log_and_message_admins("mended reality with the greatest sacrifice", user)
-		user.dust()
-		var/decl/special_role/cultist/cult = GET_DECL(/decl/special_role/cultist)
-		cult.powerless = 1
-		qdel(summoning_entity)
-		qdel(src)
-		return
+	SHOULD_CALL_PARENT(FALSE)
+	if(!summoning_entity || iscultist(user))
+		return FALSE
+	var/input = input(user, "Are you SURE you want to sacrifice yourself?", "DO NOT DO THIS") in list("Yes", "No")
+	if(input != "Yes")
+		return TRUE
+	speak_incantation(user, "Uhrast ka'hfa heldsagen ver[pick("'","`")]lot!")
+	to_chat(user, "<span class='warning'>In the last moment of your humble life, you feel an immense pain as fabric of reality mends... with your blood.</span>")
+	for(var/mob/M in global.living_mob_list_)
+		if(iscultist(M))
+			var/decl/pronouns/G = user.get_pronouns()
+			to_chat(M, "You see a vision of \the [user] keeling over dead, his blood glowing blue as it escapes [G.his] body and dissipates into thin air; you hear an otherwordly scream and feel that a great disaster has just been averted.")
+		else
+			to_chat(M, "You see a vision of [name] keeling over dead, his blood glowing blue as it escapes his body and dissipates into thin air; you hear an otherwordly scream and feel very weak for a moment.")
+	log_and_message_admins("mended reality with the greatest sacrifice", user)
+	user.dust()
+	var/decl/special_role/cultist/cult = GET_DECL(/decl/special_role/cultist)
+	cult.powerless = 1
+	qdel(summoning_entity)
+	qdel(src)
+	return TRUE
 
 /obj/effect/rune/tearreality/attackby()
 	if(the_end_comes)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -66,13 +66,15 @@
 	var/decl/special_role/cultist/cult = GET_DECL(/decl/special_role/cultist)
 	if(cult.powerless)
 		to_chat(user, "You read the words, but nothing happens.")
-		return fizzle(user)
+		fizzle(user)
+		return TRUE
 	cast(user)
 	return TRUE
 
 /obj/effect/rune/attack_ai(var/mob/user) // Cult borgs!
 	if(Adjacent(user))
-		attack_hand(user)
+		return attack_hand(user)
+	return FALSE
 
 /obj/effect/rune/proc/cast(var/mob/living/user)
 	fizzle(user)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -72,9 +72,7 @@
 	return TRUE
 
 /obj/effect/rune/attack_ai(var/mob/user) // Cult borgs!
-	if(Adjacent(user))
-		return attack_hand(user)
-	return FALSE
+	return attack_hand_with_interaction_checks(user)
 
 /obj/effect/rune/proc/cast(var/mob/living/user)
 	fizzle(user)

--- a/code/game/gamemodes/endgame/supermatter_cascade/cascade_blob.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/cascade_blob.dm
@@ -50,9 +50,9 @@
 			T.ChangeTurf(type)
 
 /turf/unsimulated/wall/cascade/attack_robot(mob/user)
-	if(CanPhysicallyInteract(user))
-		return attack_hand(user)
-	user.examinate(src)
+	. = attack_hand_with_interaction_checks(user)
+	if(!.)
+		user.examinate(src)
 
 // /vg/: Don't let ghosts fuck with this.
 /turf/unsimulated/wall/cascade/attack_ghost(mob/user)

--- a/code/game/gamemodes/godmode/form_items/narsie_structures.dm
+++ b/code/game/gamemodes/godmode/form_items/narsie_structures.dm
@@ -20,18 +20,17 @@
 
 /obj/structure/deity/blood_forge/attack_hand(var/mob/user)
 	if(!linked_god || !linked_god.is_follower(user, silent = 1) || !ishuman(user))
-		return
-
+		return ..()
 	var/list/recipes = linked_god.feats[recipe_feat_list]
 	if(!recipes)
-		return
-
+		return TRUE
 	var/dat = "<center><b>Recipes</b></center><br><br><i>Item - [text_modifications["Cost"]] Cost</i><br>"
 	for(var/type in recipes)
 		var/atom/a = type
 		var/cost = recipes[type]
 		dat += "<A href='?src=\ref[src];make_recipe=\ref[type];'>[initial(a.name)]</a> - [cost]<br><i>[initial(a.desc)]</i><br><br>"
 	show_browser(user, dat, "window=forge")
+	return TRUE
 
 /obj/structure/deity/blood_forge/CanUseTopic(var/user)
 	if(!linked_god || !linked_god.is_follower(user, silent = 1) || !ishuman(user))
@@ -80,8 +79,7 @@
 
 /obj/structure/deity/blood_stone/attack_hand(var/mob/user)
 	if(!linked_god || !linked_god.is_follower(user, silent = 1) || !ishuman(user))
-		return
-
+		return ..()
 	var/mob/living/carbon/human/H = user
 	user.visible_message("<span class='warning'>\The [user] calmly slices their finger on \the [src], smeering it over the black stone.</span>","<span class='warning'>You slowly slide your finger down one of \the [src]'s sharp edges, smeering it over its smooth surface.</span>")
 	while(do_after(H,50,src))
@@ -91,3 +89,4 @@
 		else
 			H.adjustBruteLoss(5)
 		linked_god.adjust_power_min(1,1)
+	return TRUE

--- a/code/game/gamemodes/godmode/form_items/starlight_structures.dm
+++ b/code/game/gamemodes/godmode/form_items/starlight_structures.dm
@@ -179,8 +179,7 @@
 				. += M.current
 
 /obj/structure/deity/radiant_statue/attack_hand(var/mob/L)
-	if(!istype(L))
-		return
+	SHOULD_CALL_PARENT(FALSE)
 	var/obj/O = L.get_equipped_item(slot_wear_suit_str)
 	if(O && has_extension(O,/datum/extension/deity_be_near))
 		if(activate_charging())
@@ -189,6 +188,7 @@
 			to_chat(L, "<span class='warning'>\The [src] is already activated</span>")
 	else
 		to_chat(L, "<span class='warning'>\The [src] does not recognize you as a herald of \the [linked_god]. You must wear a full set of herald's armor.</span>")
+	return TRUE
 
 /obj/structure/deity/radiant_statue/attack_deity(var/mob/living/deity/deity)
 	if(activate_charging())

--- a/code/game/gamemodes/godmode/form_items/wizard_structures.dm
+++ b/code/game/gamemodes/godmode/form_items/wizard_structures.dm
@@ -9,15 +9,17 @@
 	build_cost = 700
 
 /obj/structure/deity/wizard_recharger/attack_hand(var/mob/hitter)
-	if(!hitter.mind || !hitter.mind.learned_spells || !hitter.mind.learned_spells.len)
-		to_chat(hitter, "<span class='warning'>You don't feel as if this will do anything for you.</span>")
-		return
+	SHOULD_CALL_PARENT(FALSE)
+	if(!length(hitter.mind?.learned_spells))
+		to_chat(hitter, SPAN_WARNING("You don't feel as if this will do anything for you."))
+		return TRUE
 
-	hitter.visible_message("<span class='notice'>\The [hitter] dips their hands into \the [src], a soft glow emanating from them.</span>")
+	hitter.visible_message(SPAN_NOTICE("\The [hitter] dips their hands into \the [src], a soft glow emanating from them."))
 	if(do_after(hitter,300,src,check_holding=0))
 		for(var/s in hitter.mind.learned_spells)
 			var/spell/spell = s
 			spell.charge_counter = spell.charge_max
-		to_chat(hitter, "<span class='notice'>You feel refreshed!</span>")
-		return
-	to_chat(hitter,"<span class='warning'>You need to keep in contact with \the [src]!</span>")
+		to_chat(hitter, SPAN_NOTICE("You feel refreshed!"))
+	else
+		to_chat(hitter, SPAN_WARNING("You need to keep in contact with \the [src]!"))
+	return TRUE

--- a/code/game/gamemodes/godmode/god_pylon.dm
+++ b/code/game/gamemodes/godmode/god_pylon.dm
@@ -19,12 +19,14 @@
 	return ..()
 
 /obj/structure/deity/pylon/attack_hand(var/mob/L)
+	SHOULD_CALL_PARENT(FALSE)
 	if(!linked_god)
-		return
+		return FALSE
 	if(L in intuned)
 		remove_intuned(L)
 	else
 		add_intuned(L)
+	return TRUE
 
 /obj/structure/deity/pylon/proc/add_intuned(var/mob/living/L)
 	if(L in intuned)

--- a/code/game/machinery/_machines_base/machine_construction/_construction.dm
+++ b/code/game/machinery/_machines_base/machine_construction/_construction.dm
@@ -81,10 +81,11 @@
 	return MCS_CONTINUE
 
 /decl/machine_construction/proc/attack_hand(mob/user, obj/machinery/machine)
-	if(!validate_state(machine))
-		PRINT_STACK_TRACE("Machine [log_info_line(machine)] violated the state assumptions of the construction state [type]!")
-		machine.attack_hand(user)
+	if(validate_state(machine))
 		return TRUE
+	PRINT_STACK_TRACE("Machine [log_info_line(machine)] violated the state assumptions of the construction state [type]!")
+	machine.attack_hand(user)
+	return TRUE
 
 /decl/machine_construction/proc/attackby(obj/item/I, mob/user, obj/machinery/machine)
 	if(!validate_state(machine))

--- a/code/game/machinery/_machines_base/machine_construction/_construction.dm
+++ b/code/game/machinery/_machines_base/machine_construction/_construction.dm
@@ -81,11 +81,9 @@
 	return MCS_CONTINUE
 
 /decl/machine_construction/proc/attack_hand(mob/user, obj/machinery/machine)
-	if(validate_state(machine))
-		return TRUE
-	PRINT_STACK_TRACE("Machine [log_info_line(machine)] violated the state assumptions of the construction state [type]!")
-	machine.attack_hand(user)
-	return TRUE
+	if(!validate_state(machine))
+		PRINT_STACK_TRACE("Machine [log_info_line(machine)] violated the state assumptions of the construction state [type]!")
+		machine.attack_hand(user)
 
 /decl/machine_construction/proc/attackby(obj/item/I, mob/user, obj/machinery/machine)
 	if(!validate_state(machine))

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -268,7 +268,7 @@ var/global/list/machine_path_to_circuit_type
 			continue
 		if((. = part.attack_hand(user)))
 			return
-	return construct_state && construct_state.attack_hand(user, src)
+	return construct_state?.attack_hand(user, src)
 
 /*
 Standard helpers for users interacting with machinery parts.

--- a/code/game/machinery/_machines_base/stock_parts/power/battery.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/battery.dm
@@ -183,7 +183,7 @@
 	return ..()
 
 /obj/item/stock_parts/power/battery/attack_hand(mob/user)
-	if(cell && istype(loc, /obj/machinery))
+	if(cell && istype(loc, /obj/machinery) && user.check_dexterity(DEXTERITY_GRIP))
 		user.put_in_hands(cell)
 		extract_cell(user)
 		return TRUE

--- a/code/game/machinery/ai_slipper.dm
+++ b/code/game/machinery/ai_slipper.dm
@@ -82,7 +82,7 @@
 		. = TOPIC_REFRESH
 
 	if(. == TOPIC_REFRESH)
-		attack_hand(user)
+		ui_interact(user)
 
 /obj/machinery/ai_slipper/proc/slip_process()
 	while(cooldown_time - world.timeofday > 0)

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -172,18 +172,14 @@
 	name = "[name] (ID [id])"
 
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/attack_hand(mob/user)
-	if((. = ..()))
-		return
-	to_chat(user, "<span class='notice'>You can't directly interact with this machine. Use the scrubber control console.</span>")
-	return TRUE
+	. = ..() // Buckling, climbers, grab interactions, component attack_hand; unlikely to return true.
+	if(!.)
+		to_chat(user, SPAN_WARNING("You can't directly interact with this machine. Use the scrubber control console."))
+		return TRUE
 
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/on_update_icon()
-	overlays.Cut()
-
-	if((use_power == POWER_USE_ACTIVE) && !(stat & (NOPOWER|BROKEN)))
-		icon_state = "scrubber:1"
-	else
-		icon_state = "scrubber:0"
+	cut_overlays()
+	icon_state = "scrubber:[!!((use_power == POWER_USE_ACTIVE) && !(stat & (NOPOWER|BROKEN)))]"
 
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/attackby(var/obj/item/I, var/mob/user)
 	if(IS_WRENCH(I))

--- a/code/game/machinery/bodyscanner_console.dm
+++ b/code/game/machinery/bodyscanner_console.dm
@@ -42,10 +42,10 @@
 	return !!connected_displays.len
 
 /obj/machinery/body_scanconsole/attack_hand(mob/user)
-	if(!connected || (connected.stat & (NOPOWER|BROKEN)))
-		to_chat(user, "<span class='warning'>This console is not connected to a functioning body scanner.</span>")
-		return TRUE
-	return ..()
+	if(connected && !(connected.stat & (NOPOWER|BROKEN)))
+		return ..()
+	to_chat(user, "<span class='warning'>This console is not connected to a functioning body scanner.</span>")
+	return TRUE
 
 /obj/machinery/body_scanconsole/interface_interact(mob/user)
 	ui_interact(user)

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -42,7 +42,7 @@
 
 /obj/machinery/button/attackby(obj/item/W, mob/user)
 	if(!(. = component_attackby(W, user)))
-		return attack_hand(user)
+		return attack_hand_with_interaction_checks(user)
 
 /obj/machinery/button/interface_interact(user)
 	if(!CanInteract(user, DefaultTopicState()))

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -266,10 +266,9 @@
 		enemy_mp = 20
 		gameover = 0
 		blocked = 0
-		emagged = 1
-
+		emagged = TRUE
 		enemy_name = "Cuban Pete"
 		name = "Outbomb Cuban Pete"
-
-		attack_hand(user)
-		return 1
+		attack_hand_with_interaction_checks(user)
+		return TRUE
+	return ..()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -559,11 +559,14 @@
 	var/remains_type = /obj/item/remains/human
 
 /obj/structure/broken_cryo/attack_hand(mob/user)
-	..()
-	if (closed)
-		to_chat(user, SPAN_NOTICE("You tug at the glass but can't open it with your hands alone."))
+	. = ..()
+	if(.)
+		return
+	if(closed)
+		to_chat(user, SPAN_NOTICE("You tug at the glass, but can't open it further without a crowbar."))
 	else
 		to_chat(user, SPAN_NOTICE("The glass is already open."))
+	return TRUE
 
 /obj/structure/broken_cryo/attackby(obj/item/W, mob/user)
 	if (busy)

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -71,7 +71,7 @@ var/global/bomb_set
 		return
 
 	if(panel_open && (IS_MULTITOOL(O) || IS_WIRECUTTER(O)))
-		return attack_hand(user)
+		return attack_hand_with_interaction_checks(user)
 
 	if(extended)
 		if(istype(O, /obj/item/disk/nuclear))
@@ -79,7 +79,7 @@ var/global/bomb_set
 				return
 			auth = O
 			add_fingerprint(user)
-			return attack_hand(user)
+			return attack_hand_with_interaction_checks(user)
 
 	if(anchored)
 		switch(removal_stage)

--- a/code/game/machinery/pager.dm
+++ b/code/game/machinery/pager.dm
@@ -18,9 +18,6 @@
 	if(!location)
 		location = get_area(src)
 
-/obj/machinery/network/pager/attackby(obj/item/W, mob/user)
-	return attack_hand(user)
-
 /obj/machinery/network/pager/interface_interact(mob/living/user)
 	if(!CanInteract(user, global.default_topic_state))
 		return FALSE

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -802,23 +802,25 @@ var/global/list/turret_icons
 
 
 /obj/machinery/porta_turret_construct/attack_hand(mob/user)
-	switch(build_step)
-		if(4)
-			if(!installation)
-				return
-			build_step = 3
-
-			var/obj/item/gun/energy/Gun = new installation(loc)
-			Gun.power_supply.charge = gun_charge
-			Gun.update_icon()
-			installation = null
-			gun_charge = 0
-			to_chat(user, "<span class='notice'>You remove [Gun] from the turret frame.</span>")
-
-		if(5)
-			to_chat(user, "<span class='notice'>You remove the prox sensor from the turret frame.</span>")
-			new /obj/item/assembly/prox_sensor(loc)
-			build_step = 4
+	if(!user.check_dexterity(DEXTERITY_GRIP))
+		return ..()
+	if(build_step == 4)
+		if(!installation)
+			return TRUE
+		build_step = 3
+		var/obj/item/gun/energy/Gun = new installation(loc)
+		Gun.power_supply.charge = gun_charge
+		Gun.update_icon()
+		installation = null
+		gun_charge = 0
+		to_chat(user, SPAN_NOTICE("You remove [Gun] from the turret frame."))
+		return TRUE
+	if(build_step == 5)
+		to_chat(user, SPAN_NOTICE("You remove the prox sensor from the turret frame."))
+		new /obj/item/assembly/prox_sensor(loc)
+		build_step = 4
+		return TRUE
+	return ..()
 
 /obj/machinery/porta_turret_construct/attack_ai()
 	return

--- a/code/game/machinery/suit_cycler.dm
+++ b/code/game/machinery/suit_cycler.dm
@@ -162,7 +162,7 @@
 	//Hacking init.
 	if(IS_MULTITOOL(I) || IS_WIRECUTTER(I))
 		if(panel_open)
-			attack_hand(user)
+			physical_attack_hand(user)
 		return
 	//Other interface stuff.
 	if(istype(I, /obj/item/grab))
@@ -245,9 +245,9 @@
 	return 1
 
 /obj/machinery/suit_cycler/physical_attack_hand(mob/user)
-	if(electrified != 0)
-		if(shock(user, 100))
-			return TRUE
+	if(electrified != 0 && shock(user, 100))
+		return TRUE
+	return ..()
 
 /obj/machinery/suit_cycler/interface_interact(mob/user)
 	interact(user)

--- a/code/game/machinery/supplybeacon.dm
+++ b/code/game/machinery/supplybeacon.dm
@@ -57,15 +57,14 @@
 	return ..()
 
 /obj/structure/supply_beacon/attack_hand(var/mob/user)
-
+	if(!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
+		return ..()
 	if(expended)
 		to_chat(user, SPAN_WARNING("\The [src] has used up its charge."))
 		return TRUE
-
 	if(!anchored)
 		to_chat(user, SPAN_WARNING("You need to secure \the [src] with a wrench first!"))
 		return TRUE
-
 	if(activated)
 		deactivate(user)
 	else

--- a/code/game/machinery/telecomms/telemonitor.dm
+++ b/code/game/machinery/telecomms/telemonitor.dm
@@ -19,9 +19,9 @@
 
 	var/temp = ""				// temporary feedback messages
 
-/obj/machinery/computer/telecomms/monitor/attack_hand(mob/user as mob)
-	if(stat & (BROKEN|NOPOWER))
-		return
+/obj/machinery/computer/telecomms/monitor/attack_hand(mob/user)
+	if((stat & (BROKEN|NOPOWER)) || !user.check_dexterity(DEXTERITY_KEYBOARDS))
+		return ..()
 	user.set_machine(src)
 	var/list/dat = list()
 	dat += "<TITLE>Telecommunications Monitor</TITLE><center><b>Telecommunications Monitor</b></center>"

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -50,34 +50,30 @@
 
 
 /obj/machinery/computer/teleporter/attackby(var/obj/I, var/mob/user)
-	if(istype(I, /obj/item/card/data))
-		var/obj/item/card/data/C = I
-		if(stat & (NOPOWER|BROKEN) & (C.function != "teleporter"))
-			attack_hand(user)
 
-		var/obj/L = null
+	var/obj/item/card/data/C = I
+	if(!istype(C) || (stat & (NOPOWER|BROKEN)) || C.function != "teleporter")
+		return ..()
 
-		for(var/obj/abstract/landmark/sloc in global.landmarks_list)
-			if(sloc.name != C.data || (locate(/mob/living) in sloc.loc))
-				continue
-			L = sloc
-			break
+	var/obj/L = null
+	for(var/obj/abstract/landmark/sloc in global.landmarks_list)
+		if(sloc.name != C.data || (locate(/mob/living) in sloc.loc))
+			continue
+		L = sloc
+		break
 
-		if(!L)
-			L = locate("landmark*[C.data]") // use old stype
+	if(!L)
+		L = locate("landmark*[C.data]") // use old stype
 
-		if(istype(L, /obj/abstract/landmark) && isturf(L.loc) && user.try_unequip(I))
-			to_chat(usr, "You insert the coordinates into the machine.")
-			to_chat(usr, "A message flashes across the screen reminding the traveller that the nuclear authentication disk is to remain on the [station_name()] at all times.")
-			qdel(I)
-			audible_message(SPAN_NOTICE("Locked in."))
-			src.locked = L
-			one_time_use = 1
-			add_fingerprint(usr)
-	else
-		..()
-
-	return
+	if(istype(L, /obj/abstract/landmark) && isturf(L.loc) && user.try_unequip(I))
+		to_chat(usr, "You insert the coordinates into the machine.")
+		to_chat(usr, "A message flashes across the screen reminding the traveller that the nuclear authentication disk is to remain on the [station_name()] at all times.")
+		qdel(I)
+		audible_message(SPAN_NOTICE("Locked in."))
+		src.locked = L
+		one_time_use = 1
+		add_fingerprint(usr)
+	return TRUE
 
 /obj/machinery/computer/teleporter/interface_interact(var/mob/user)
 	/* Run full check because it's a direct selection */
@@ -262,7 +258,7 @@
 		z_flags &= ~ZMM_MANGLE_PLANES
 
 /obj/machinery/teleport/station/attackby(var/obj/item/W, var/mob/user)
-	attack_hand(user)
+	return attack_hand_with_interaction_checks(user) || ..()
 
 /obj/machinery/teleport/station/interface_interact(var/mob/user)
 	if(!CanInteract(user, DefaultTopicState()))

--- a/code/game/machinery/vending/_vending.dm
+++ b/code/game/machinery/vending/_vending.dm
@@ -172,11 +172,11 @@
 			return TRUE // don't smack that machine with your $2
 
 	if (istype(W, /obj/item/cash))
-		attack_hand(user)
+		attack_hand_with_interaction_checks(user)
 		return TRUE
 	if(IS_MULTITOOL(W) || IS_WIRECUTTER(W))
 		if(panel_open)
-			attack_hand(user)
+			attack_hand_with_interaction_checks(user)
 			return TRUE
 	if((user.a_intent == I_HELP) && attempt_to_stock(W, user))
 		return TRUE

--- a/code/game/objects/effects/chem/foam.dm
+++ b/code/game/objects/effects/chem/foam.dm
@@ -157,12 +157,13 @@
 		qdel(src)
 
 /obj/structure/foamedmetal/attack_hand(var/mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	if (prob(75 - metal * 25))
 		user.visible_message("<span class='warning'>[user] smashes through the foamed metal.</span>", "<span class='notice'>You smash through the metal foam wall.</span>")
 		qdel(src)
 	else
 		to_chat(user, "<span class='notice'>You hit the metal foam but bounce off it.</span>")
-	return
+	return TRUE
 
 /obj/structure/foamedmetal/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/grab))

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -124,17 +124,18 @@ var/global/list/image/splatter_cache=list()
 	STOP_PROCESSING(SSobj, src)
 
 /obj/effect/decal/cleanable/blood/attack_hand(mob/user)
-	..()
-	if (amount && length(blood_data) && ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.get_equipped_item(slot_gloves_str))
-			return
-		var/taken = rand(1,amount)
-		amount -= taken
-		to_chat(user, SPAN_NOTICE("You get some of \the [src] on your hands."))
-		for(var/bloodthing in blood_data)
-			user.add_blood(null, max(1, amount/length(blood_data)), blood_data[bloodthing])
-		user.verbs += /mob/living/carbon/human/proc/bloody_doodle
+	if(!amount || !length(blood_data) || !ishuman(user))
+		return ..()
+	var/mob/living/carbon/human/H = user
+	if(H.get_equipped_item(slot_gloves_str))
+		return ..()
+	var/taken = rand(1,amount)
+	amount -= taken
+	to_chat(user, SPAN_NOTICE("You get some of \the [src] on your hands."))
+	for(var/bloodthing in blood_data)
+		user.add_blood(null, max(1, amount/length(blood_data)), blood_data[bloodthing])
+	user.verbs += /mob/living/carbon/human/proc/bloody_doodle
+	return TRUE
 
 /obj/effect/decal/cleanable/blood/splatter
 	random_icon_states = list("mgibbl1", "mgibbl2", "mgibbl3", "mgibbl4", "mgibbl5")

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -13,11 +13,13 @@
 	icon_state = "ash"
 
 /obj/effect/decal/cleanable/ash/attack_hand(var/mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	to_chat(user, "<span class='notice'>[src] sifts through your fingers.</span>")
 	var/turf/simulated/floor/F = get_turf(src)
 	if (istype(F))
 		F.dirt += 4
 	qdel(src)
+	return TRUE
 
 /obj/effect/decal/cleanable/dirt
 	name = "dirt"

--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -121,22 +121,20 @@
 
 
 /obj/structure/sign/poster/attack_hand(mob/user)
-
-	if(ruined)
-		return
-
-	if(alert("Do I want to rip the poster from the wall?","You think...","Yes","No") == "Yes")
-
-		if(ruined || !user.Adjacent(src))
-			return
-
-		visible_message("<span class='warning'>\The [user] rips \the [src] in a single, decisive motion!</span>" )
-		playsound(src.loc, 'sound/items/poster_ripped.ogg', 100, 1)
-		ruined = 1
-		icon_state = "poster_ripped"
-		SetName("ripped poster")
-		desc = "You can't make out anything from the poster's original print. It's ruined."
-		add_fingerprint(user)
+	if(ruined || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	if(!alert("Do I want to rip the poster from the wall?","You think...","Yes","No") == "Yes")
+		return TRUE
+	if(ruined || !CanPhysicallyInteract(user) || !user.check_dexterity(DEXTERITY_GRIP))
+		return TRUE
+	visible_message("<span class='warning'>\The [user] rips \the [src] in a single, decisive motion!</span>" )
+	playsound(src.loc, 'sound/items/poster_ripped.ogg', 100, 1)
+	ruined = 1
+	icon_state = "poster_ripped"
+	SetName("ripped poster")
+	desc = "You can't make out anything from the poster's original print. It's ruined."
+	add_fingerprint(user)
+	return TRUE
 
 /obj/structure/sign/poster/proc/roll_and_drop(turf/newloc)
 	new /obj/item/contraband/poster(newloc, null, poster_type)

--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -129,7 +129,7 @@
 		return TRUE
 	visible_message("<span class='warning'>\The [user] rips \the [src] in a single, decisive motion!</span>" )
 	playsound(src.loc, 'sound/items/poster_ripped.ogg', 100, 1)
-	ruined = 1
+	ruined = TRUE
 	icon_state = "poster_ripped"
 	SetName("ripped poster")
 	desc = "You can't make out anything from the poster's original print. It's ruined."

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -17,6 +17,7 @@
 	teleport(AM)
 
 /obj/effect/portal/attack_hand(mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	teleport(user)
 	return TRUE
 

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -14,14 +14,13 @@
 		qdel(src)
 
 /obj/effect/spider/attack_hand(mob/user)
-
+	SHOULD_CALL_PARENT(FALSE)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(src)
 	if(prob(50))
 		visible_message(SPAN_WARNING("\The [user] tries to squash \the [src], but misses!"))
 		disturbed()
-		return
-
+		return TRUE
 	var/showed_msg = FALSE
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -31,8 +30,8 @@
 			showed_msg = TRUE
 	if(!showed_msg)
 		visible_message(SPAN_DANGER("\The [user] squashes \the [src] flat!"))
-
 	die()
+	return TRUE
 
 /obj/effect/spider/attackby(var/obj/item/W, var/mob/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -283,7 +283,7 @@
 /obj/item/attack_hand(mob/user)
 
 	if(!user)
-		return
+		return FALSE
 
 	if(anchored)
 		return ..()
@@ -298,24 +298,24 @@
 					user.drop_from_inventory(src)
 				else
 					to_chat(user, SPAN_WARNING("You fail to remove \the [src]!"))
-				return
+				return TRUE
 
 			if(isturf(loc))
 				if(loc == get_turf(user))
 					attack_self(user)
 				else
 					dropInto(get_turf(user))
-				return
+				return TRUE
 
 			if(istype(loc, /obj/item/storage))
 				visible_message(SPAN_NOTICE("\The [user] fumbles \the [src] out of \the [loc]."))
 				var/obj/item/storage/bag = loc
 				bag.remove_from_storage(src)
 				dropInto(get_turf(bag))
-				return
+				return TRUE
 
 		to_chat(user, SPAN_WARNING("You are not dexterous enough to pick up \the [src]."))
-		return
+		return TRUE
 
 	var/old_loc = loc
 	if (istype(loc, /obj/item/storage))
@@ -327,15 +327,11 @@
 
 	if (loc == user)
 		if(!user.try_unequip(src))
-			return
-	else
-		if(isliving(loc))
-			return
+			return TRUE
+	else if(isliving(loc))
+		return TRUE
 
-	if(QDELETED(src))
-		return // Unequipping changes our state, so must check here.
-
-	if(user.put_in_active_hand(src))
+	if(!QDELETED(src) && user.put_in_active_hand(src))
 		on_picked_up(user)
 		if (isturf(old_loc))
 			var/obj/effect/temporary/item_pickup_ghost/ghost = new(old_loc, src)
@@ -347,6 +343,7 @@
 		else if(randpixel == 0)
 			pixel_x = 0
 			pixel_y = 0
+	return TRUE
 
 /obj/item/attack_ai(mob/living/silicon/ai/user)
 	if (istype(src.loc, /obj/item/robot_module))

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -278,7 +278,7 @@
 	. = ..()
 
 /obj/item/proc/dragged_onto(var/mob/user)
-	attack_hand(user)
+	return attack_hand_with_interaction_checks(user)
 
 /obj/item/attack_hand(mob/user)
 

--- a/code/game/objects/item_interactions.dm
+++ b/code/game/objects/item_interactions.dm
@@ -20,7 +20,7 @@
 	expected_target_type = /obj/item
 
 /decl/interaction_handler/pick_up/invoked(atom/target, mob/user, obj/item/prop)
-	target.attack_hand(user)
+	target.attack_hand_with_interaction_checks(user)
 
 /decl/interaction_handler/drop
 	name = "Drop"

--- a/code/game/objects/items/devices/auto_cpr.dm
+++ b/code/game/objects/items/devices/auto_cpr.dm
@@ -46,7 +46,7 @@
 
 /obj/item/auto_cpr/attack_hand(mob/user)
 	skilled_setup = user.skill_check(SKILL_ANATOMY, SKILL_BASIC) && user.skill_check(SKILL_MEDICAL, SKILL_BASIC)
-	..()
+	return ..()
 
 /obj/item/auto_cpr/dropped(mob/user)
 	STOP_PROCESSING(SSobj,src)

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -107,9 +107,11 @@
 	master.disrupt()
 
 /obj/effect/dummy/chameleon/attack_hand()
+	SHOULD_CALL_PARENT(FALSE)
 	for(var/mob/M in src)
-		to_chat(M, "<span class='warning'>Your chameleon-projector deactivates.</span>")
+		to_chat(M, SPAN_DANGER("Your chameleon-projector deactivates."))
 	master.disrupt()
+	return TRUE
 
 /obj/effect/dummy/chameleon/explosion_act()
 	SHOULD_CALL_PARENT(FALSE)

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -97,28 +97,28 @@
 	return
 
 /obj/item/powersink/attack_hand(var/mob/user)
-	. = ..()
-	if(.)
-		return
-	switch(mode)
-		if(DISCONNECTED)
-			..()
+	if(!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
+		return ..()
+	if(mode == CLAMPED_OFF)
+		user.visible_message(
+			"[user] activates \the [src]!",
+			SPAN_NOTICE("You activate \the [src]."),
+			SPAN_ITALIC("You hear a click.")
+		)
+		message_admins("Power sink activated by [key_name_admin(user)] at (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)")
+		log_game("Power sink activated by [key_name(user)] at [get_area_name(src)]")
+		set_mode(OPERATING)
+		return TRUE
 
-		if(CLAMPED_OFF)
-			user.visible_message( \
-				"[user] activates \the [src]!", \
-				"<span class='notice'>You activate \the [src].</span>",
-				"<span class='italics'>You hear a click.</span>")
-			message_admins("Power sink activated by [key_name_admin(user)] at (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)")
-			log_game("Power sink activated by [key_name(user)] at [get_area_name(src)]")
-			set_mode(OPERATING)
+	if(mode == OPERATING)
+		user.visible_message( \
+			"[user] deactivates \the [src]!", \
+			"<span class='notice'>You deactivate \the [src].</span>",
+			"<span class='italics'>You hear a click.</span>")
+		set_mode(CLAMPED_OFF)
+		return TRUE
 
-		if(OPERATING)
-			user.visible_message( \
-				"[user] deactivates \the [src]!", \
-				"<span class='notice'>You deactivate \the [src].</span>",
-				"<span class='italics'>You hear a click.</span>")
-			set_mode(CLAMPED_OFF)
+	return ..()
 
 /obj/item/powersink/pwr_drain()
 	if(!attached)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -113,14 +113,11 @@
 	return ..()
 
 /obj/item/radio/intercom/attack_ai(mob/living/silicon/ai/user)
-	src.add_fingerprint(user)
-	spawn (0)
-		attack_self(user)
+	return attack_self(user)
 
 /obj/item/radio/intercom/attack_hand(mob/user)
-	src.add_fingerprint(user)
-	spawn (0)
-		attack_self(user)
+	SHOULD_CALL_PARENT(FALSE)
+	return attack_self(user)
 
 /obj/item/radio/intercom/receive_range(freq, level)
 	if (!on)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -75,7 +75,10 @@
 	return ..()
 
 /obj/item/radio/attack_self(mob/user)
+	if(!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES))
+		return
 	user.set_machine(src)
+	add_fingerprint(user)
 	interact(user)
 	return TRUE
 

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -420,12 +420,12 @@
 
 
 /obj/item/magnetic_tape/proc/ruin()
-	ruined = 1
+	ruined = TRUE
 	update_icon()
 
 
 /obj/item/magnetic_tape/proc/fix()
-	ruined = 0
+	ruined = FALSE
 	update_icon()
 
 
@@ -535,7 +535,7 @@
 	desc = "Quantum-enriched self-repairing nanotape, used for magnetic storage of information."
 	icon = 'icons/obj/items/device/tape_casette.dmi'
 	icon_state = "magtape"
-	ruined = 1
+	ruined = TRUE
 
 /obj/item/magnetic_tape/loose/fix()
 	return

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -70,10 +70,10 @@
 
 
 /obj/item/taperecorder/attack_hand(mob/user)
-	if(user.is_holding_offhand(src) && mytape)
+	if(user.is_holding_offhand(src) && mytape && user.check_dexterity(DEXTERITY_SIMPLE_MACHINES))
 		eject()
-		return
-	..()
+		return TRUE
+	return ..()
 
 
 /obj/item/taperecorder/verb/eject()

--- a/code/game/objects/items/remains.dm
+++ b/code/game/objects/items/remains.dm
@@ -36,11 +36,14 @@
 	icon_state = "lizard"
 
 /obj/item/remains/attack_hand(mob/user)
-	to_chat(user, "<span class='notice'>[src] sinks together into a pile of ash.</span>")
+	SHOULD_CALL_PARENT(FALSE)
+	to_chat(user, SPAN_NOTICE("\The [src] sinks together into a pile of ash."))
 	var/turf/simulated/floor/F = get_turf(src)
 	if (istype(F))
 		new /obj/effect/decal/cleanable/ash(F)
 	qdel(src)
+	return TRUE
 
 /obj/item/remains/robot/attack_hand(mob/user)
-	return
+	SHOULD_CALL_PARENT(FALSE)
+	return TRUE

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -28,10 +28,10 @@
 
 /obj/item/target/attack_hand(var/mob/user)
 	// taking pinned targets off!
-	if (stake)
-		stake.attack_hand(user)
-	else
+	if(!stake || !user.check_dexterity(DEXTERITY_GRIP))
 		return ..()
+	stake.attack_hand(user)
+	return TRUE
 
 /obj/item/target/syndicate
 	icon_state = "target_s"

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -30,8 +30,7 @@
 	// taking pinned targets off!
 	if(!stake || !user.check_dexterity(DEXTERITY_GRIP))
 		return ..()
-	stake.attack_hand(user)
-	return TRUE
+	return stake.attack_hand(user)
 
 /obj/item/target/syndicate
 	icon_state = "target_s"

--- a/code/game/objects/items/spirit_board.dm
+++ b/code/game/objects/items/spirit_board.dm
@@ -14,11 +14,10 @@
 	to_chat(user, "The planchette is sitting at \"[planchette]\".")
 
 /obj/item/spirit_board/attack_hand(mob/user)
-	if (user.a_intent == I_GRAB)
+	if(user.a_intent == I_GRAB || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
 		return ..()
-	else
-		spirit_board_pick_letter(user)
-
+	spirit_board_pick_letter(user)
+	return TRUE
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
 /obj/item/spirit_board/attack_ghost(var/mob/observer/ghost/user)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -378,21 +378,22 @@
 		. = CEILING(. * amount / max_amount)
 
 /obj/item/stack/attack_hand(mob/user)
-	if(user.is_holding_offhand(src) && can_split())
-		var/N = input("How many stacks of [src] would you like to split off?", "Split stacks", 1) as num|null
-		if(N)
-			var/obj/item/stack/F = src.split(N)
-			if (F)
-				user.put_in_hands(F)
-				src.add_fingerprint(user)
-				F.add_fingerprint(user)
-				spawn(0)
-					if (src && usr.machine==src)
-						src.interact(usr)
-				return TRUE
-		return FALSE
-	return ..()
+	if(!user.is_holding_offhand(src) || !can_split())
+		return ..()
 
+	var/N = input("How many stacks of [src] would you like to split off?", "Split stacks", 1) as num|null
+	if(!N)
+		return TRUE
+
+	var/obj/item/stack/F = src.split(N)
+	if(F)
+		user.put_in_hands(F)
+		src.add_fingerprint(user)
+		F.add_fingerprint(user)
+		spawn(0)
+			if (src && usr.machine==src)
+				src.interact(usr)
+	return TRUE
 
 /obj/item/stack/attackby(obj/item/W, mob/user)
 	if (istype(W, /obj/item/stack) && can_merge())

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -561,7 +561,7 @@
 		user.visible_message("<span class='warning'><b>\The [user]</b> attempts to strangle [src]!</span>","<span class='warning'>You attempt to strangle [src]!</span>")
 	else
 		user.visible_message("<span class='notice'><b>\The [user]</b> pokes the [src].</span>","<span class='notice'>You poke the [src].</span>")
-		audible_message("<span class='game say'><span class='name'>\The [src]</span> says, <span class='message'><span class='body'>\"[phrase]\"</span></span>")
+		audible_message("<span class='game say'><span class='name'>\The [src]</span> says, <span class='message'><span class='body'>\"[phrase]\"</span></span></span>")
 	return TRUE
 
 /obj/structure/plushie/ian

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -226,18 +226,17 @@
 //all credit to skasi for toy mech fun ideas
 /obj/item/toy/prize/attack_self(mob/user)
 	if(cooldown < world.time - 8)
-		to_chat(user, "<span class='notice'>You play with [src].</span>")
+		to_chat(user, SPAN_NOTICE("You play with \the [src]."))
 		playsound(user, 'sound/mecha/mechstep.ogg', 20, 1)
 		cooldown = world.time
 
 /obj/item/toy/prize/attack_hand(mob/user)
-	if(loc == user)
-		if(cooldown < world.time - 8)
-			to_chat(user, "<span class='notice'>You play with [src].</span>")
-			playsound(user, 'sound/mecha/mechturn.ogg', 20, 1)
-			cooldown = world.time
-			return
-	..()
+	if(loc != user || cooldown >= world.time - 8)
+		return ..()
+	to_chat(user, SPAN_NOTICE("You play with \the [src]."))
+	playsound(user, 'sound/mecha/mechturn.ogg', 20, 1)
+	cooldown = world.time
+	return TRUE
 
 /obj/item/toy/prize/powerloader
 	name = "toy ripley"
@@ -551,6 +550,8 @@
 	var/phrase = "I don't want to exist anymore!"
 
 /obj/structure/plushie/attack_hand(mob/user)
+	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
 	playsound(src.loc, 'sound/effects/rustle1.ogg', 100, 1)
 	if(user.a_intent == I_HELP)
 		user.visible_message("<span class='notice'><b>\The [user]</b> hugs [src]!</span>","<span class='notice'>You hug [src]!</span>")
@@ -561,6 +562,7 @@
 	else
 		user.visible_message("<span class='notice'><b>\The [user]</b> pokes the [src].</span>","<span class='notice'>You poke the [src].</span>")
 		visible_message("[src] says, \"[phrase]\"")
+	return TRUE
 
 /obj/structure/plushie/ian
 	name = "plush corgi"
@@ -692,6 +694,8 @@
 	anchored = 1
 
 /obj/item/toy/ringbell/attack_hand(mob/user)
+	if(!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
+		return ..()
 	if (user.a_intent == I_HELP)
 		user.visible_message("<span class='notice'>[user] rings \the [src], signalling the beginning of the contest.</span>")
 		playsound(user.loc, 'sound/items/oneding.ogg', 60)
@@ -701,6 +705,7 @@
 	else if (user.a_intent == I_HURT)
 		user.visible_message("<span class='warning'>[user] rings \the [src] repeatedly, signalling a disqualification!</span>")
 		playsound(user.loc, 'sound/items/manydings.ogg', 60)
+	return TRUE
 
 //Office Desk Toys
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -561,7 +561,7 @@
 		user.visible_message("<span class='warning'><b>\The [user]</b> attempts to strangle [src]!</span>","<span class='warning'>You attempt to strangle [src]!</span>")
 	else
 		user.visible_message("<span class='notice'><b>\The [user]</b> pokes the [src].</span>","<span class='notice'>You poke the [src].</span>")
-		visible_message("[src] says, \"[phrase]\"")
+		audible_message("<span class='game say'><span class='name'>\The [src]</span> says, <span class='message'><span class='body'>\"[phrase]\"</span></span>")
 	return TRUE
 
 /obj/structure/plushie/ian

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -68,10 +68,10 @@
 	toggle_paddles()
 
 /obj/item/defibrillator/attack_hand(mob/user)
-	if(loc == user)
-		toggle_paddles()
-	else
-		..()
+	if(loc != user || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	toggle_paddles()
+	return TRUE
 
 // what is this proc doing?
 /obj/item/defibrillator/handle_mouse_drop(var/atom/over, var/mob/user)

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -181,14 +181,14 @@
 			to_chat(user, SPAN_WARNING("\The [src] does not have a battery installed."))
 
 /obj/item/clothing/mask/smokable/ecig/attack_hand(mob/user)//eject cartridge
-	if(user.is_holding_offhand(src) && ec_cartridge)
-		lit = FALSE
-		user.put_in_hands(ec_cartridge)
-		to_chat(user, SPAN_NOTICE("You remove \the [ec_cartridge] from \the [src]."))
-		ec_cartridge = null
-		update_icon()
-	else
-		..()
+	if(!user.is_holding_offhand(src) || !ec_cartridge || !user.check_dexterity(DEXTERITY_GRIP))
+		return ..()
+	lit = FALSE
+	user.put_in_hands(ec_cartridge)
+	to_chat(user, SPAN_NOTICE("You remove \the [ec_cartridge] from \the [src]."))
+	ec_cartridge = null
+	update_icon()
+	return TRUE
 
 /obj/item/chems/ecig_cartridge
 	name = "tobacco flavour cartridge"

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -104,4 +104,4 @@
 
 /obj/item/grenade/attack_hand()
 	walk(src, null, null)
-	..()
+	return ..()

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -89,19 +89,16 @@
 		switch(det_time)
 			if (1)
 				det_time = 10
-				to_chat(user, "<span class='notice'>You set the [name] for 1 second detonation time.</span>")
+				to_chat(user, SPAN_NOTICE("You set the \the [src] for 1 second detonation time."))
 			if (10)
 				det_time = 30
-				to_chat(user, "<span class='notice'>You set the [name] for 3 second detonation time.</span>")
+				to_chat(user, SPAN_NOTICE("You set the \the [src] for 3 second detonation time."))
 			if (30)
 				det_time = 50
-				to_chat(user, "<span class='notice'>You set the [name] for 5 second detonation time.</span>")
+				to_chat(user, SPAN_NOTICE("You set the \the [src] for 5 second detonation time."))
 			if (50)
 				det_time = 1
-				to_chat(user, "<span class='notice'>You set the [name] for instant detonation.</span>")
+				to_chat(user, SPAN_NOTICE("You set the \the [src] for instant detonation."))
 		add_fingerprint(user)
-	..()
-
-/obj/item/grenade/attack_hand()
-	walk(src, null, null)
+		return TRUE
 	return ..()

--- a/code/game/objects/items/weapons/implants/implantpad.dm
+++ b/code/game/objects/items/weapons/implants/implantpad.dm
@@ -13,14 +13,14 @@
 		add_overlay("[icon_state]-imp")
 
 /obj/item/implantpad/attack_hand(mob/user)
-	if(imp && !(src in user.get_held_items()))
-		user.put_in_active_hand(imp)
-		imp.add_fingerprint(user)
-		add_fingerprint(user)
-		imp = null
-		update_icon()
-	else
+	if(!imp || (src in user.get_held_items()) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
 		return ..()
+	user.put_in_active_hand(imp)
+	imp.add_fingerprint(user)
+	add_fingerprint(user)
+	imp = null
+	update_icon()
+	return TRUE
 
 /obj/item/implantpad/attackby(obj/item/I, mob/user)
 	..()

--- a/code/game/objects/items/weapons/material/bell.dm
+++ b/code/game/objects/items/weapons/material/bell.dm
@@ -11,15 +11,17 @@
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME
 
 /obj/item/bell/attack_hand(mob/user)
-	if (user.a_intent == I_GRAB)
+	if(user.a_intent == I_GRAB)
 		return ..()
-	else if (user.a_intent == I_HURT)
+
+	if(user.a_intent == I_HURT)
 		user.visible_message("<span class='warning'>\The [user] hammers \the [src]!</span>")
 		playsound(user.loc, 'sound/items/manydings.ogg', 60)
 	else
 		user.visible_message("<span class='notice'>\The [user] rings \the [src].</span>")
 		playsound(user.loc, 'sound/items/oneding.ogg', 20)
 	flick("bell_dingeth", src)
+	return TRUE
 
 /obj/item/bell/apply_hit_effect()
 	. = ..()

--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -306,21 +306,22 @@ var/global/list/image/hazard_overlays //Cached hazard floor overlays for the bar
 		add_overlay(ovr)
 
 /obj/structure/tape_barricade/attack_hand(mob/user)
-	if (user.a_intent == I_HELP && allowed(user))
-		if(TAPE_BARRICADE_IS_CORNER_NEIGHBORS(neighbors) || (TAPE_BARRICADE_GET_NB_NEIGHBORS(neighbors) > 2))
-			to_chat(user, SPAN_WARNING("You can't lift up the pole. Try lifting the line itself."))
-			return
+	if (user.a_intent != I_HELP || !allowed(user) || !user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
+		return ..()
 
-		if(!allowed(user))
-			user.visible_message(SPAN_NOTICE("\The [user] carelessly pulls \the [src] out of the way."))
-			crumple()
-		else
-			user.visible_message(SPAN_NOTICE("\The [user] lifts \the [src], officially allowing passage."))
-
-		for(var/obj/structure/tape_barricade/B in get_tape_line())
-			B.lift(10 SECONDS) //~10 seconds
+	if(TAPE_BARRICADE_IS_CORNER_NEIGHBORS(neighbors) || (TAPE_BARRICADE_GET_NB_NEIGHBORS(neighbors) > 2))
+		to_chat(user, SPAN_WARNING("You can't lift up the pole. Try lifting the line itself."))
 		return TRUE
-	. = ..()
+
+	if(!allowed(user))
+		user.visible_message(SPAN_NOTICE("\The [user] carelessly pulls \the [src] out of the way."))
+		crumple()
+	else
+		user.visible_message(SPAN_NOTICE("\The [user] lifts \the [src], officially allowing passage."))
+
+	for(var/obj/structure/tape_barricade/B in get_tape_line())
+		B.lift(10 SECONDS) //~10 seconds
+	return TRUE
 
 /obj/structure/tape_barricade/dismantle()
 	for (var/obj/structure/tape_barricade/B in get_tape_line())

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -30,7 +30,7 @@
 				LAZYADD(cur_overlays, I.get_on_belt_overlay())
 			else
 				LAZYADD(cur_overlays, overlay_image('icons/obj/clothing/obj_belt_overlays.dmi', I.icon_state))
-				
+
 		if(LAZYLEN(cur_overlays))
 			add_overlay(cur_overlays)
 	update_clothing_icon()
@@ -75,11 +75,12 @@
 		. = ..(W, user)
 
 /obj/item/storage/belt/holster/attack_hand(mob/user)
+	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
 	var/datum/extension/holster/H = get_extension(src, /datum/extension/holster)
 	if(H.unholster(user))
-		return
-	else
-		. = ..(user)
+		return TRUE
+	return ..()
 
 /obj/item/storage/belt/holster/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -20,7 +20,8 @@
 	. = ..()
 
 /obj/item/storage/internal/attack_hand()
-	return		//make sure this is never picked up
+	SHOULD_CALL_PARENT(FALSE)
+	return TRUE //make sure this is never picked up
 
 /obj/item/storage/internal/mob_can_equip()
 	return FALSE //make sure this is never picked up

--- a/code/game/objects/items/weapons/storage/laundry_basket.dm
+++ b/code/game/objects/items/weapons/storage/laundry_basket.dm
@@ -23,15 +23,16 @@
 	var/linked
 
 /obj/item/storage/laundry_basket/attack_hand(mob/user)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		var/obj/item/organ/external/temp = GET_EXTERNAL_ORGAN(H, H.get_active_held_item_slot())
-		if(!temp)
-			to_chat(user, SPAN_WARNING("You need two hands to pick this up!"))
-			return
+	if(!ishuman(user))
+		return ..()
+	var/mob/living/carbon/human/H = user
+	var/obj/item/organ/external/temp = GET_EXTERNAL_ORGAN(H, H.get_active_held_item_slot())
+	if(!temp)
+		to_chat(user, SPAN_WARNING("You need two hands to pick this up!"))
+		return TRUE
 	if(!user.get_empty_hand_slot())
 		to_chat(user, SPAN_WARNING("You need a hand to be empty."))
-		return
+		return TRUE
 	return ..()
 
 /obj/item/storage/laundry_basket/attack_self(mob/user)

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -92,18 +92,17 @@
 	matter = list(/decl/material/solid/plastic = MATTER_AMOUNT_REINFORCEMENT)
 
 /obj/item/storage/secure/briefcase/attack_hand(mob/user as mob)
+	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
 	var/datum/extension/lockable/lock = get_extension(src, /datum/extension/lockable)
 	if (loc == user && lock.locked)
 		to_chat(user, SPAN_WARNING("[src] is locked and cannot be opened!"))
-	else if (loc == user && !lock.locked)
-		src.open(user)
-	else
-		..()
-		for(var/mob/M in range(1))
-			if (M.active_storage == src)
-				src.close(M)
-	src.add_fingerprint(user)
-	return
+		return TRUE
+	if (loc == user && !lock.locked)
+		open(user)
+		add_fingerprint(user)
+		return TRUE
+	return ..()
 
 // -----------------------------
 //        Secure Safe

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -264,22 +264,21 @@
 	return handle_item_insertion(W)
 
 /obj/item/storage/attack_hand(mob/user)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		for(var/slot in global.pocket_slots)
-			var/obj/item/pocket = H.get_equipped_item(slot)
-			if(pocket == src && !H.get_active_hand()) //Prevents opening if it's in a pocket.
-				H.try_unequip(src)
-				H.put_in_hands(src)
-				return
-
-	if (src.loc == user)
-		src.open(user)
-	else
-		..()
-		storage_ui.on_hand_attack(user)
-	src.add_fingerprint(user)
-	return
+	if(!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
+		return ..()
+	for(var/slot in global.pocket_slots)
+		var/obj/item/pocket = user.get_equipped_item(slot)
+		if(pocket == src && !user.get_active_hand()) //Prevents opening if it's in a pocket.
+			if(user.try_unequip(src))
+				user.put_in_hands(src)
+			return TRUE
+	if(loc == user)
+		open(user)
+		add_fingerprint(user)
+		return TRUE
+	. = ..()
+	storage_ui.on_hand_attack(user)
+	add_fingerprint(user)
 
 /obj/item/storage/attack_ghost(mob/user)
 	var/mob/observer/ghost/G = user

--- a/code/game/objects/items/weapons/storage/wall_mirror.dm
+++ b/code/game/objects/items/weapons/storage/wall_mirror.dm
@@ -71,7 +71,9 @@
 	..()
 
 /obj/structure/mirror/attack_hand(mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	use_mirror(user)
+	return TRUE
 
 /obj/structure/mirror/proc/use_mirror(var/mob/living/carbon/human/user)
 	if(shattered)

--- a/code/game/objects/items/weapons/tech_disks.dm
+++ b/code/game/objects/items/weapons/tech_disks.dm
@@ -29,7 +29,7 @@
 
 	var/datum/computer_file/existing = LAZYACCESS(stored_files, F.filename)
 	if(existing && existing != F)
-		delete_file(F.filename) 
+		delete_file(F.filename)
 
 	LAZYSET(stored_files, F.filename, F)
 	free_blocks = clamp(round(free_blocks - F.block_size), 0, block_capacity)
@@ -111,9 +111,9 @@
 	var/datum/fabricator_recipe/blueprint
 
 /obj/item/disk/design_disk/attack_hand(mob/user)
-	if(user.a_intent == I_HURT && blueprint)
-		blueprint = null
-		SetName(initial(name))
-		to_chat(user, SPAN_DANGER("You flick the erase switch and wipe \the [src]."))
-		return TRUE
-	. = ..()
+	if(user.a_intent != I_HURT || !blueprint || !user.has_dexterity(DEXTERITY_KEYBOARDS))
+		return ..()
+	blueprint = null
+	SetName(initial(name))
+	to_chat(user, SPAN_DANGER("You flick the erase switch and wipe \the [src]."))
+	return TRUE

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -162,7 +162,7 @@
 	return ..()
 
 /obj/item/weldingtool/attack_hand(mob/user)
-	if (tank && user.is_holding_offhand(src))
+	if (tank && user.is_holding_offhand(src) && user.check_dexterity(DEXTERITY_GRIP, TRUE))
 		return remove_tank(user)
 	return ..()
 

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -50,24 +50,27 @@
 			anchored = 1
 
 /obj/item/beartrap/attack_hand(mob/user)
+	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
 	if(buckled_mob)
 		user_unbuckle_mob(user)
-	else if(deployed && can_use(user))
+		return TRUE
+	if(!deployed || !can_use(user))
+		return FALSE
+	user.visible_message(
+		SPAN_DANGER("\The [user] starts to disarm \the [src]."),
+		SPAN_NOTICE("You begin disarming \the [src]!"),
+		"You hear a latch click followed by the slow creaking of a spring."
+	)
+	if(do_after(user, 60, src))
 		user.visible_message(
-			"<span class='danger'>[user] starts to disarm \the [src].</span>",
-			"<span class='notice'>You begin disarming \the [src]!</span>",
-			"You hear a latch click followed by the slow creaking of a spring."
-			)
-		if(do_after(user, 60, src))
-			user.visible_message(
-				"<span class='danger'>[user] has disarmed \the [src].</span>",
-				"<span class='notice'>You have disarmed \the [src]!</span>"
-				)
-			deployed = 0
-			anchored = 0
-			update_icon()
-	else
-		..()
+			SPAN_DANGER("\The [user] has disarmed \the [src]."),
+			SPAN_NOTICE("You have disarmed \the [src]!")
+		)
+		deployed = 0
+		anchored = 0
+		update_icon()
+	return TRUE
 
 /obj/item/beartrap/proc/attack_mob(mob/L)
 

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -204,21 +204,20 @@
 		healthcheck()
 
 /obj/effect/energy_net/attack_hand(var/mob/user)
-
-	var/mob/living/carbon/human/H = user
-	if(istype(H))
-		if(H.species.can_shred(H))
+	if(user.a_intent != I_HURT)
+		return ..()
+	var/decl/species/my_species = user.get_species()
+	if(my_species)
+		if(my_species.can_shred(user))
 			playsound(src.loc, 'sound/weapons/slash.ogg', 80, 1)
 			health -= rand(10, 20)
 		else
 			health -= rand(1,3)
 	else
 		health -= rand(5,8)
-
-	to_chat(H,"<span class='danger'>You claw at the energy net.</span>")
-
+	to_chat(user, SPAN_DANGER("You claw at the energy net."))
 	healthcheck()
-	return
+	return TRUE
 
 /obj/effect/energy_net/attackby(obj/item/W, mob/user)
 	health -= W.force

--- a/code/game/objects/items/weapons/weldbackpack.dm
+++ b/code/game/objects/items/weapons/weldbackpack.dm
@@ -130,14 +130,15 @@
 	return ..()
 
 /obj/item/chems/weldpack/attack_hand(mob/user)
-	if(is_welder_attached())
-		if(user.is_holding_offhand(src))
-			detach_gun(user)
-			return TRUE
-		var/curslot = user.get_equipped_slot_for_item(src)
-		if(curslot == slot_back_str || curslot == slot_s_store_str)
-			detach_gun(user)
-			return TRUE
+	if(!is_welder_attached() || !user.check_dexterity(DEXTERITY_GRIP))
+		return ..()
+	if(user.is_holding_offhand(src))
+		detach_gun(user)
+		return TRUE
+	var/curslot = user.get_equipped_slot_for_item(src)
+	if(curslot == slot_back_str || curslot == slot_s_store_str)
+		detach_gun(user)
+		return TRUE
 	return ..()
 
 /obj/item/chems/weldpack/check_mousedrop_adjacency(atom/over, mob/user)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -138,7 +138,7 @@
 /obj/attack_hand(mob/user)
 	if(Adjacent(user))
 		add_fingerprint(user)
-	..()
+	return ..()
 
 /obj/is_fluid_pushable(var/amt)
 	return ..() && w_class <= round(amt/20)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -162,10 +162,12 @@ LINEN BINS
 
 /obj/structure/bedsheetbin/attack_hand(var/mob/user)
 	var/obj/item/bedsheet/B = remove_sheet()
-	if(B)
-		user.put_in_hands(B)
-		to_chat(user, SPAN_NOTICE("You take \a [B] out of \the [src]."))
-		add_fingerprint(user)
+	if(!B)
+		return ..()
+	user.put_in_hands(B)
+	to_chat(user, SPAN_NOTICE("You take \a [B] out of \the [src]."))
+	add_fingerprint(user)
+	return TRUE
 
 /obj/structure/bedsheetbin/do_simple_ranged_interaction(var/mob/user)
 	remove_sheet()

--- a/code/game/objects/structures/bookcase.dm
+++ b/code/game/objects/structures/bookcase.dm
@@ -31,7 +31,7 @@ var/global/list/station_bookcases = list()
 	return ..()
 
 /obj/structure/bookcase/attack_hand(var/mob/user)
-	if(!length(contents))
+	if(!length(contents) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
 		return ..()
 	var/obj/item/book/choice = input("Which book would you like to remove from the shelf?") as null|obj in contents
 	if(choice && (choice in contents) && CanPhysicallyInteract(user))

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -93,8 +93,7 @@
 		return TRUE
 
 /obj/structure/catwalk/attack_robot(var/mob/user)
-	if(CanPhysicallyInteract(user))
-		return attack_hand(user)
+	return attack_hand_with_interaction_checks(user)
 
 /obj/structure/catwalk/attackby(obj/item/C, mob/user)
 	. = ..()

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -184,10 +184,13 @@
 	return 0
 
 /obj/effect/catwalk_plated/attack_hand()
+	SHOULD_CALL_PARENT(FALSE)
 	activate()
+	return TRUE
 
 /obj/effect/catwalk_plated/attack_ghost()
 	activate()
+	return TRUE
 
 /obj/effect/catwalk_plated/proc/activate()
 	if(activated) return

--- a/code/game/objects/structures/charge_pylon.dm
+++ b/code/game/objects/structures/charge_pylon.dm
@@ -10,10 +10,13 @@
 
 /obj/structure/charge_pylon/attack_ai(var/mob/user)
 	if(Adjacent(user))
-		attack_hand(user)
+		return attack_hand(user)
+	return ..()
 
 /obj/structure/charge_pylon/attack_hand(var/mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	charge_user(user)
+	return TRUE
 
 /obj/structure/charge_pylon/proc/charge_user(var/mob/living/user)
 	if(next_use > world.time) return

--- a/code/game/objects/structures/charge_pylon.dm
+++ b/code/game/objects/structures/charge_pylon.dm
@@ -9,9 +9,7 @@
 	var/next_use
 
 /obj/structure/charge_pylon/attack_ai(var/mob/user)
-	if(Adjacent(user))
-		return attack_hand(user)
-	return ..()
+	return attack_hand_with_interaction_checks(user) || ..()
 
 /obj/structure/charge_pylon/attack_hand(var/mob/user)
 	SHOULD_CALL_PARENT(FALSE)

--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -36,17 +36,17 @@
 				break
 
 /obj/structure/coatrack/attack_hand(mob/user)
-	if(length(contents))
-		var/obj/item/removing = contents[contents.len]
-		user.visible_message( \
-			SPAN_NOTICE("\The [user] takes \the [removing] off \the [src]."), \
-			SPAN_NOTICE("You take \the [removing] off the \the [src].") \
-		)
-		removing.dropInto(loc)
-		user.put_in_active_hand(removing)
-		update_icon()
-		return TRUE
-	. = ..()
+	if(!length(contents) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	var/obj/item/removing = contents[contents.len]
+	user.visible_message( \
+		SPAN_NOTICE("\The [user] takes \the [removing] off \the [src]."),
+		SPAN_NOTICE("You take \the [removing] off the \the [src].")
+	)
+	removing.dropInto(loc)
+	user.put_in_active_hand(removing)
+	update_icon()
+	return TRUE
 
 /obj/structure/coatrack/examine(mob/user, distance)
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -329,8 +329,11 @@ var/global/list/closets = list()
 		to_chat(user, "<span class='notice'>It won't budge!</span>")
 
 /obj/structure/closet/attack_hand(mob/user)
-	src.add_fingerprint(user)
-	src.toggle(user)
+	if(!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
+		return ..()
+	add_fingerprint(user)
+	toggle(user)
+	return TRUE
 
 /obj/structure/closet/attack_ghost(mob/ghost)
 	if(ghost.client && ghost.client.inquisitive_ghost)

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -111,7 +111,8 @@
 	return
 
 /obj/structure/closet/statue/attack_hand()
-	return
+	SHOULD_CALL_PARENT(FALSE)
+	return TRUE
 
 /obj/structure/closet/statue/verb_toggleopen()
 	return

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -15,7 +15,10 @@
 		I.forceMove(src)
 
 /obj/structure/largecrate/attack_hand(mob/user)
+	if(user.a_intent == I_HURT)
+		return ..()
 	to_chat(user, SPAN_WARNING("You need a crowbar to pry this open!"))
+	return TRUE
 
 /obj/structure/largecrate/attackby(obj/item/W, mob/user)
 	if(IS_CROWBAR(W))

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -29,7 +29,7 @@
 		)
 		physically_destroyed()
 		return TRUE
-	return attack_hand(user)
+	return attack_hand_with_interaction_checks(user)
 
 /obj/structure/largecrate/animal
 	name = "animal crate"

--- a/code/game/objects/structures/crematorium.dm
+++ b/code/game/objects/structures/crematorium.dm
@@ -79,16 +79,16 @@
 	update_icon()
 
 /obj/structure/crematorium/attack_hand(mob/user)
+	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
 	if(locked)
 		to_chat(usr, SPAN_WARNING("It's currently locked."))
-		return
-
+		return TRUE
 	if(open)
 		close()
 	else
 		open()
-
-	return ..()
+	return TRUE
 
 /obj/structure/crematorium/attack_robot(mob/user)
 	if(CanPhysicallyInteract(user))

--- a/code/game/objects/structures/crematorium.dm
+++ b/code/game/objects/structures/crematorium.dm
@@ -91,8 +91,7 @@
 	return TRUE
 
 /obj/structure/crematorium/attack_robot(mob/user)
-	if(CanPhysicallyInteract(user))
-		return attack_hand(user)
+	return attack_hand_with_interaction_checks(user)
 
 /obj/structure/crematorium/relaymove(mob/user)
 	if(user.incapacitated() || locked)
@@ -206,13 +205,10 @@
 	return ..()
 
 /obj/structure/crematorium_tray/attack_hand(mob/user)
-	if(Adjacent(user))
-		connected_crematorium.attack_hand(user)
-	return ..()
+	return connected_crematorium.attack_hand_with_interaction_checks(user) || ..()
 
 /obj/structure/crematorium_tray/attack_robot(mob/user)
-	if(CanPhysicallyInteract(user))
-		return attack_hand(user)
+	return attack_hand_with_interaction_checks(user)
 
 /obj/structure/crematorium_tray/receive_mouse_drop(atom/dropping, mob/user)
 	. = ..()

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -105,7 +105,7 @@
 
 /obj/structure/curtain/attack_hand(mob/user)
 	toggle()
-	..()
+	return ..()
 
 /obj/structure/curtain/attackby(obj/item/W, mob/user)
 	if(IS_SCREWDRIVER(W))

--- a/code/game/objects/structures/defensive_barrier.dm
+++ b/code/game/objects/structures/defensive_barrier.dm
@@ -101,6 +101,9 @@
 
 /obj/structure/defensive_barrier/attack_hand(mob/user)
 
+	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+
 	var/decl/species/species = user.get_species()
 	if(ishuman(user) && species?.can_shred(user) && user.a_intent == I_HURT)
 		take_damage(20)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -112,6 +112,10 @@
 	. = ..()
 
 /obj/structure/displaycase/attack_hand(mob/user)
+
+	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	add_fingerprint(user)
 

--- a/code/game/objects/structures/doors/_door.dm
+++ b/code/game/objects/structures/doors/_door.dm
@@ -47,7 +47,9 @@
 	changing_state = FALSE
 
 /obj/structure/door/attack_hand(mob/user)
-	return density ? open() : close()
+	if(user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
+		return density ? open() : close()
+	return ..()
 
 /obj/structure/door/proc/close()
 	set waitfor = 0

--- a/code/game/objects/structures/doors/_door.dm
+++ b/code/game/objects/structures/doors/_door.dm
@@ -92,9 +92,8 @@
 	if(distance <= 1 && lock)
 		to_chat(user, SPAN_NOTICE("It appears to have a lock."))
 
-/obj/structure/door/attack_ai(mob/living/silicon/ai/user)
-	if(Adjacent(user) && isrobot(user))
-		return attack_hand(user)
+/obj/structure/door/attack_ai(mob/living/user)
+	return attack_hand_with_interaction_checks(user)
 
 /obj/structure/door/explosion_act(severity)
 	. = ..()

--- a/code/game/objects/structures/drain.dm
+++ b/code/game/objects/structures/drain.dm
@@ -70,10 +70,12 @@
 	var/closed = FALSE
 
 /obj/structure/hygiene/drain/bath/attack_hand(mob/user)
-	. = ..()
-	if(!welded)
-		closed = !closed
-		user.visible_message(SPAN_NOTICE("\The [user] has [closed ? "closed" : "opened"] the drain."))
+	if(!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
+		return ..()
+	if(welded)
+		return ..()
+	closed = !closed
+	user.visible_message(SPAN_NOTICE("\The [user] has [closed ? "closed" : "opened"] the drain."))
 	update_icon()
 	return TRUE
 

--- a/code/game/objects/structures/emergency_dispenser.dm
+++ b/code/game/objects/structures/emergency_dispenser.dm
@@ -12,9 +12,11 @@
 	var/amount = 3 // spawns each items X times.
 
 /obj/structure/emergency_dispenser/attack_hand(mob/user)
-	if(!CanPhysicallyInteract(user))	//Added by Strumpetplaya - AI shouldn't be able to  (you're both stupid, need CanPhysicallyInteract --Chinsky)
-		return							//activate emergency lockers.  This fixes that.  (Does this make sense, the AI can't call attack_hand, can it? --Mloc) 
-	. = TRUE
+	//Added by Strumpetplaya - AI shouldn't be able to  (you're both stupid, need CanPhysicallyInteract --Chinsky)
+	//activate emergency lockers.  This fixes that.  (Does this make sense, the AI can't call attack_hand, can it? --Mloc)
+	//(It uses the Nano helper and a dexterity check now anyway. --Loaf)
+	if(!CanPhysicallyInteract(user) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
 	if(!amount)
 		to_chat(user, SPAN_WARNING("It's empty."))
 	else
@@ -23,6 +25,7 @@
 		for(var/path in spawnitems)
 			new path(src.loc)
 		amount--
+	return TRUE
 
 /obj/structure/emergency_dispenser/north
 	pixel_y = 32

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -30,23 +30,22 @@
 
 
 /obj/structure/extinguisher_cabinet/attack_hand(mob/user)
-	if(isrobot(user))
-		return
-	if (ishuman(user))
-		var/mob/living/carbon/human/H = user
-		var/obj/item/organ/external/temp = GET_EXTERNAL_ORGAN(H, H.get_active_held_item_slot())
-		if(temp && !temp.is_usable())
-			to_chat(user, "<span class='notice'>You try to move your [temp.name], but cannot!</span>")
-			return
-	if(has_extinguisher)
+
+	if(user.check_dexterity(DEXTERITY_GRIP, TRUE) && has_extinguisher)
 		user.put_in_hands(has_extinguisher)
-		to_chat(user, "<span class='notice'>You take [has_extinguisher] from [src].</span>")
+		to_chat(user, SPAN_NOTICE("You take [has_extinguisher] from [src]."))
 		playsound(src.loc, 'sound/effects/extout.ogg', 50, 0)
 		has_extinguisher = null
-		opened = 1
-	else
+		opened = TRUE
+		update_icon()
+		return TRUE
+
+	if(user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
 		opened = !opened
-	update_icon()
+		update_icon()
+		return TRUE
+
+	return ..()
 
 /obj/structure/extinguisher_cabinet/on_update_icon()
 	..()

--- a/code/game/objects/structures/fireaxe_cabinet.dm
+++ b/code/game/objects/structures/fireaxe_cabinet.dm
@@ -32,10 +32,13 @@
 	toggle_lock(user)
 
 /obj/structure/fireaxecabinet/attack_hand(var/mob/user)
+	if(!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
+		return ..()
 	if(!unlocked)
-		to_chat(user, "<span class='warning'>\The [src] is locked.</span>")
-		return
-	toggle_open(user)
+		to_chat(user, SPAN_WARNING("\The [src] is locked."))
+	else
+		toggle_open(user)
+	return TRUE
 
 /obj/structure/fireaxecabinet/handle_mouse_drop(atom/over, mob/user)
 	if(over == user)

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -140,7 +140,7 @@
 
 /obj/structure/fire_source/attack_hand(var/mob/user)
 
-	if(length(contents))
+	if(length(contents) && user.check_dexterity(DEXTERITY_GRIP, TRUE))
 		var/obj/item/removing = pick(contents)
 		removing.dropInto(loc)
 		user.put_in_hands(removing)
@@ -158,7 +158,7 @@
 			qdel(src)
 		return TRUE
 
-	. = ..()
+	return ..()
 
 /obj/structure/fire_source/grab_attack(var/obj/item/grab/G)
 	var/mob/living/affecting_mob = G.get_affecting_mob()

--- a/code/game/objects/structures/fishtanks.dm
+++ b/code/game/objects/structures/fishtanks.dm
@@ -63,7 +63,10 @@ var/global/list/fishtank_cache = list()
 	reagents.add_reagent(fill_type, reagents.maximum_volume)
 
 /obj/structure/glass_tank/attack_hand(var/mob/user)
+	if(user.a_intent == I_HURT)
+		return ..()
 	visible_message(SPAN_NOTICE("\The [user] taps on \the [src]."))
+	return TRUE
 
 /obj/structure/glass_tank/attackby(var/obj/item/W, var/mob/user)
 	if(W.force < 5 || user.a_intent != I_HURT)

--- a/code/game/objects/structures/fitness.dm
+++ b/code/game/objects/structures/fitness.dm
@@ -12,22 +12,25 @@
 
 /obj/structure/fitness/punchingbag/attack_hand(mob/user)
 	if(!ishuman(user))
-		..()
-		return
+		return ..()
+
 	var/mob/living/carbon/human/H = user
 	var/synth = H.isSynthetic()
 	if(!synth && H.nutrition < 20)
 		to_chat(H, SPAN_WARNING("You [synth ? "need more energy" : "are too tired"] to use the punching bag. Go [synth ? "recharge" : "eat something"]."))
-	else
-		if(H.a_intent == I_HURT)
-			H.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-			flick("[icon_state]_hit", src)
-			playsound(src.loc, 'sound/effects/woodhit.ogg', 25, 1, -1)
-			H.do_attack_animation(src)
-			if(!synth)
-				H.adjust_nutrition(-(5 * DEFAULT_HUNGER_FACTOR))
-				H.adjust_hydration(-(5 * DEFAULT_THIRST_FACTOR))
-			to_chat(H, SPAN_NOTICE("You [pick(hit_message)] \the [src]."))
+		return TRUE
+
+	if(H.a_intent == I_HURT)
+		H.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		flick("[icon_state]_hit", src)
+		playsound(src.loc, 'sound/effects/woodhit.ogg', 25, 1, -1)
+		H.do_attack_animation(src)
+		if(!synth)
+			H.adjust_nutrition(-(5 * DEFAULT_HUNGER_FACTOR))
+			H.adjust_hydration(-(5 * DEFAULT_THIRST_FACTOR))
+		to_chat(H, SPAN_NOTICE("You [pick(hit_message)] \the [src]."))
+		return TRUE
+	return ..()
 
 /obj/structure/fitness/weightlifter
 	name = "weightlifting machine"
@@ -47,49 +50,51 @@
 
 /obj/structure/fitness/weightlifter/attack_hand(mob/user)
 	if(!ishuman(user))
-		return
+		return ..()
 	var/mob/living/carbon/human/H = user
 	var/synth = H.isSynthetic()
 	if(H.loc != src.loc)
 		to_chat(H, SPAN_WARNING("You must be on the weight machine to use it."))
-		return
+		return TRUE
 	if(!synth && H.nutrition < 50)
 		to_chat(H, SPAN_WARNING("You need more energy to lift weights. Go eat something."))
-		return
+		return TRUE
 	if(being_used)
 		to_chat(H, SPAN_WARNING("The weight machine is already in use by somebody else."))
-		return
-	else
-		being_used = 1
-		playsound(src.loc, 'sound/effects/weightlifter.ogg', 50, 1)
-		H.set_dir(SOUTH)
-		flick("[icon_state]_[weight]", src)
-		if(do_after(H, 20 + (weight * 10)))
-			playsound(src.loc, 'sound/effects/weightdrop.ogg', 25, 1)
-			var/skill = max_weight * H.get_skill_value(SKILL_HAULING)/SKILL_MAX
-			var/message
-			if(skill < weight)
-				if(weight - skill > max_weight/2)
-					if(prob(50))
-						message = ", getting hurt in the process"
-						H.apply_damage(5)
-					else
-						message = "; this does not look safe"
-				else
-					message = fail_message[min(1 + round(weight - skill), fail_message.len)]
-				H.visible_message( \
-					SPAN_NOTICE("\The [H] fails to lift the weights[message]."), \
-					SPAN_NOTICE("You fail to lift the weights[message]."))
+		return TRUE
+
+	being_used = TRUE
+	playsound(src.loc, 'sound/effects/weightlifter.ogg', 50, 1)
+	H.set_dir(SOUTH)
+	flick("[icon_state]_[weight]", src)
+	if(!do_after(H, 20 + (weight * 10)))
+		to_chat(H, SPAN_NOTICE("Against your previous judgement, perhaps working out is not for you."))
+		being_used = FALSE
+		return TRUE
+
+	playsound(src.loc, 'sound/effects/weightdrop.ogg', 25, 1)
+	var/skill = max_weight * H.get_skill_value(SKILL_HAULING)/SKILL_MAX
+	var/message
+	if(skill < weight)
+		if(weight - skill > max_weight/2)
+			if(prob(50))
+				message = ", getting hurt in the process"
+				H.apply_damage(5)
 			else
-				if(!synth)
-					var/adj_weight = weight * 5
-					H.adjust_nutrition(-(adj_weight * DEFAULT_HUNGER_FACTOR))
-					H.adjust_hydration(-(adj_weight * DEFAULT_THIRST_FACTOR))
-				message = success_message[min(1 + round(skill - weight), fail_message.len)]
-				H.visible_message( \
-					SPAN_NOTICE("\The [H] lift\s the weights [message]."), \
-					SPAN_NOTICE("You lift the weights [message]."))
-			being_used = 0
+				message = "; this does not look safe"
 		else
-			to_chat(H, SPAN_NOTICE("Against your previous judgement, perhaps working out is not for you."))
-			being_used = 0
+			message = fail_message[min(1 + round(weight - skill), fail_message.len)]
+		H.visible_message( \
+			SPAN_NOTICE("\The [H] fails to lift the weights[message]."), \
+			SPAN_NOTICE("You fail to lift the weights[message]."))
+	else
+		if(!synth)
+			var/adj_weight = weight * 5
+			H.adjust_nutrition(-(adj_weight * DEFAULT_HUNGER_FACTOR))
+			H.adjust_hydration(-(adj_weight * DEFAULT_THIRST_FACTOR))
+		message = success_message[min(1 + round(skill - weight), fail_message.len)]
+		H.visible_message( \
+			SPAN_NOTICE("\The [H] lift\s the weights [message]."), \
+			SPAN_NOTICE("You lift the weights [message]."))
+	being_used = FALSE
+	return TRUE

--- a/code/game/objects/structures/flora/plant.dm
+++ b/code/game/objects/structures/flora/plant.dm
@@ -81,20 +81,21 @@
 	. = ..()
 
 /obj/structure/flora/plant/attack_hand(mob/user)
+	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
 
 	if(dead)
 		user.visible_message(SPAN_NOTICE("\The [user] uproots the dead [name]!"))
 		physically_destroyed()
 		return TRUE
+	if(harvestable <= 0)
+		return ..()
 
-	if(harvestable > 0)
-		var/harvested = plant.harvest(user, force_amount = 1)
-		if(harvested)
-			harvestable -= length(harvested)
-			for(var/thing in harvested)
-				user.put_in_hands(thing)
-			if(!harvestable)
-				update_icon()
-		return TRUE
-
-	. = ..()
+	var/harvested = plant.harvest(user, force_amount = 1)
+	if(harvested)
+		harvestable -= length(harvested)
+		for(var/thing in harvested)
+			user.put_in_hands(thing)
+		if(!harvestable)
+			update_icon()
+	return TRUE

--- a/code/game/objects/structures/fountain.dm
+++ b/code/game/objects/structures/fountain.dm
@@ -18,26 +18,30 @@
 	set_light(5, 0.5, light_color)
 
 /obj/structure/fountain/attack_hand(var/mob/user)
-	if(user.incapacitated())
-		return
-	if(!CanPhysicallyInteract(user))
-		return
+
+	if(user.a_intent == I_HURT)
+		return ..()
+
 	if(used)
 		to_chat(user,  SPAN_WARNING("\The [src] is still and lifeless..."))
-		return
+		return TRUE
 
 	var/mob/living/carbon/human/H = user
-	var/decl/species/species = user.get_species()
-	var/datum/appearance_descriptor/age/age = species && LAZYACCESS(species.appearance_descriptors, "age")
-	if(!ishuman(H) || H.isSynthetic() || !species || !age)
-		to_chat(user, SPAN_WARNING("A feeling of foreboding stills your hand. The fountain is not for your kind."))
+	var/decl/species/my_species = istype(H) && H.get_species()
+	if(!istype(my_species))
+		return ..()
+
+	var/datum/appearance_descriptor/age/age = my_species && LAZYACCESS(my_species.appearance_descriptors, "age")
+	if(H.isSynthetic() || !my_species || !age)
+		to_chat(H, SPAN_WARNING("A feeling of foreboding stills your hand. The fountain is not for your kind."))
 		return
 
 	if(alert("As you reach out to touch the fountain, a feeling of doubt overcomes you. Steel yourself and proceed?",,"Yes", "No") == "Yes")
-		visible_message("\The [user] touches \the [src].")
-		time_dilation(user)
+		visible_message("\The [H] touches \the [src].")
+		time_dilation(H)
 	else
-		visible_message("\The [user] retracts their hand suddenly.")
+		visible_message("\The [H] retracts their hand suddenly.")
+	return TRUE
 
 /obj/structure/fountain/proc/time_dilation(var/mob/living/carbon/human/user)
 
@@ -86,7 +90,7 @@
 	icon_state             = "fountain_g"
 	tool_interaction_flags = TOOL_INTERACTION_DECONSTRUCT
 	w_class                = ITEM_SIZE_STRUCTURE
-	material               = /decl/material/solid/stone/marble 
+	material               = /decl/material/solid/stone/marble
 	used                   = TRUE
 
 /obj/structure/fountain/mundane/Initialize(ml, _mat, _reinf_mat)
@@ -97,9 +101,11 @@
 /obj/structure/fountain/mundane/initialize_reagents(populate = TRUE)
 	create_reagents(500)
 	. = ..()
-	
+
 /obj/structure/fountain/mundane/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/water, reagents.maximum_volume) //Don't give free water when building one
 
 /obj/structure/fountain/mundane/attack_hand(mob/user)
-	return
+	if(user.a_intent == I_HURT)
+		return ..()
+	return TRUE

--- a/code/game/objects/structures/fuel_port.dm
+++ b/code/game/objects/structures/fuel_port.dm
@@ -27,15 +27,16 @@
 	return locate(/obj/item/tank) in contents
 
 /obj/structure/fuel_port/attack_hand(mob/user)
+	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
 	if(!open)
 		to_chat(user, SPAN_WARNING("The door is secured tightly. You'll need a crowbar to open it."))
-		return
-	else
-		var/obj/item/tank/tank = locate_tank()
-		if(tank)
-			user.put_in_hands(tank)
-
+		return TRUE
+	var/obj/item/tank/tank = locate_tank()
+	if(tank)
+		user.put_in_hands(tank)
 	update_icon()
+	return TRUE
 
 /obj/structure/fuel_port/on_update_icon()
 	..()

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -89,12 +89,15 @@
 
 /obj/structure/grille/attack_hand(mob/user)
 
+	if(user.a_intent != I_HURT)
+		return ..()
+
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	playsound(loc, 'sound/effects/grillehit.ogg', 80, 1)
 	user.do_attack_animation(src)
 
 	if(shock(user, 70))
-		return
+		return TRUE
 
 	var/damage_dealt = 1
 	var/attack_message = "kicks"
@@ -103,8 +106,8 @@
 		if(H.species.can_shred(H))
 			attack_message = "mangles"
 			damage_dealt = 5
-
 	attack_generic(user,damage_dealt,attack_message)
+	return TRUE
 
 /obj/structure/grille/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(air_group || (height==0)) return 1

--- a/code/game/objects/structures/hand_cart.dm
+++ b/code/game/objects/structures/hand_cart.dm
@@ -44,9 +44,10 @@
 	. = ..()
 
 /obj/structure/hand_cart/attack_hand(mob/user)
-	if(carrying)
-		unload_item(user)
-	. = ..()
+	if(!carrying || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	unload_item(user)
+	return TRUE
 
 /obj/structure/hand_cart/proc/load_item(var/obj/A, var/user)
 	if(!A.anchored && (A.w_class > min_object_size))

--- a/code/game/objects/structures/handrail.dm
+++ b/code/game/objects/structures/handrail.dm
@@ -11,7 +11,7 @@
 	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 
 /obj/structure/handrail/attack_hand(mob/user)
-	if(can_buckle && !buckled_mob && istype(user))
-		user_buckle_mob(user, user)
-		return
-	. = ..()
+	if(!can_buckle || buckled_mob || !istype(user) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	user_buckle_mob(user, user)
+	return TRUE

--- a/code/game/objects/structures/holosigns.dm
+++ b/code/game/objects/structures/holosigns.dm
@@ -20,10 +20,10 @@
 
 /obj/structure/holosign/attack_hand(mob/user)
 	. =  ..()
-	if(.)
-		return
-	visible_message(SPAN_NOTICE("\The [user] waves through \the [src], causing it to dissipate."))
-	deactivate(user)
+	if(!.)
+		visible_message(SPAN_NOTICE("\The [user] waves through \the [src], causing it to dissipate."))
+		deactivate(user)
+		return TRUE
 
 /obj/structure/holosign/attackby(obj/W, mob/user)
 	visible_message(SPAN_NOTICE("\The [user] waves \a [W] through \the [src], causing it to dissipate."))

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -106,9 +106,6 @@
 		else if(severity == 2 || (severity == 3 && prob(50)))
 			deflate(TRUE)
 
-/obj/structure/inflatable/attack_hand(mob/user)
-	add_fingerprint(user)
-
 /obj/structure/inflatable/can_repair_with(obj/item/tool)
 	. = istype(tool, /obj/item/stack/tape_roll/duct_tape) && (health < maxhealth)
 
@@ -199,6 +196,8 @@
 			return TryToSwitchState(user)
 
 /obj/structure/inflatable/door/attack_hand(mob/user)
+	if(user.a_intent == I_HURT || !user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
+		return ..()
 	return TryToSwitchState(user)
 
 /obj/structure/inflatable/door/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)

--- a/code/game/objects/structures/ironing_board.dm
+++ b/code/game/objects/structures/ironing_board.dm
@@ -118,13 +118,15 @@
 	..()
 
 /obj/structure/bed/roller/ironingboard/attack_hand(var/mob/user)
+	if(!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
+		return ..()	//Takes care of unbuckling.
 	if(density) // check if it's deployed
 		if(holding && user.put_in_hands(holding))
 			remove_item(holding)
-			return
+			return TRUE
 		if(cloth && user.put_in_hands(cloth))
 			remove_item(cloth)
-			return
+			return TRUE
 		if(!buckled_mob)
 			to_chat(user, "You fold the ironing table down.")
 			set_density(0)
@@ -132,7 +134,7 @@
 		to_chat(user, "You deploy the ironing table.")
 		set_density(1)
 	update_icon()
-	. = ..()	//Takes care of unbuckling.
+	return TRUE
 
 /obj/structure/bed/roller/ironingboard/collapse()
 	var/turf/T = get_turf(src)

--- a/code/game/objects/structures/ironing_board.dm
+++ b/code/game/objects/structures/ironing_board.dm
@@ -118,7 +118,7 @@
 	..()
 
 /obj/structure/bed/roller/ironingboard/attack_hand(var/mob/user)
-	if(!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
+	if(!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE) || buckled_mob)
 		return ..()	//Takes care of unbuckling.
 	if(density) // check if it's deployed
 		if(holding && user.put_in_hands(holding))

--- a/code/game/objects/structures/iv_drip.dm
+++ b/code/game/objects/structures/iv_drip.dm
@@ -152,8 +152,7 @@
 	return TRUE
 
 /obj/structure/iv_drip/attack_robot(var/mob/user)
-	if(CanPhysicallyInteract(user))
-		return attack_hand(user)
+	return attack_hand_with_interaction_checks(user)
 
 /obj/structure/iv_drip/verb/drip_detach()
 	set category = "Object"

--- a/code/game/objects/structures/iv_drip.dm
+++ b/code/game/objects/structures/iv_drip.dm
@@ -141,14 +141,15 @@
 			queue_icon_update()
 
 /obj/structure/iv_drip/attack_hand(mob/user)
+	if(!user.check_dexterity(DEXTERITY_COMPLEX_TOOLS))
+		return ..()
 	if(attached)
 		drip_detach()
 	else if(beaker)
 		beaker.dropInto(loc)
 		beaker = null
 		queue_icon_update()
-	else
-		return ..()
+	return TRUE
 
 /obj/structure/iv_drip/attack_robot(var/mob/user)
 	if(CanPhysicallyInteract(user))

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -85,8 +85,10 @@
 
 
 /obj/structure/janitorialcart/attack_hand(mob/user)
+	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
 	ui_interact(user)
-	return
+	return TRUE
 
 /obj/structure/janitorialcart/ui_interact(var/mob/user, var/ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	var/data[0]
@@ -229,11 +231,11 @@
 	. = ..()
 
 /obj/structure/bed/chair/janicart/attack_hand(mob/user)
-	if(mybag)
-		user.put_in_hands(mybag)
-		mybag = null
-	else
-		..()
+	if(!mybag || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	user.put_in_hands(mybag)
+	mybag = null
+	return TRUE
 
 /obj/structure/bed/chair/janicart/handle_buckled_relaymove(var/datum/movement_handler/mh, var/mob/mob, var/direction, var/mover)
 	if(isspaceturf(loc))

--- a/code/game/objects/structures/mineral_bath.dm
+++ b/code/game/objects/structures/mineral_bath.dm
@@ -66,7 +66,10 @@
 	return TRUE
 
 /obj/structure/mineral_bath/attack_hand(var/mob/user)
+	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
 	eject_occupant()
+	return TRUE
 
 /obj/structure/mineral_bath/proc/eject_occupant()
 	if(occupant)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -82,8 +82,7 @@
 	return TRUE
 
 /obj/structure/morgue/attack_robot(mob/user)
-	if(CanPhysicallyInteract(user))
-		return attack_hand(user)
+	return attack_hand_with_interaction_checks(user)
 
 /obj/structure/morgue/relaymove(mob/user)
 	if(user.incapacitated())
@@ -110,13 +109,10 @@
 	return ..()
 
 /obj/structure/morgue_tray/attack_hand(mob/user)
-	if(Adjacent(user))
-		return connected_morgue.attack_hand(user)
-	return ..()
+	return connected_morgue.attack_hand_with_interaction_checks(user) || ..()
 
 /obj/structure/morgue_tray/attack_robot(mob/user)
-	if(CanPhysicallyInteract(user))
-		return attack_hand(user)
+	return attack_hand_with_interaction_checks(user)
 
 /obj/structure/morgue_tray/receive_mouse_drop(atom/dropping, mob/user)
 	. = ..()

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -73,12 +73,13 @@
 	update_icon()
 
 /obj/structure/morgue/attack_hand(mob/user)
+	if(!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
+		return ..()
 	if(open)
 		close()
 	else
 		open()
-
-	return ..()
+	return TRUE
 
 /obj/structure/morgue/attack_robot(mob/user)
 	if(CanPhysicallyInteract(user))
@@ -110,7 +111,7 @@
 
 /obj/structure/morgue_tray/attack_hand(mob/user)
 	if(Adjacent(user))
-		connected_morgue.attack_hand(user)
+		return connected_morgue.attack_hand(user)
 	return ..()
 
 /obj/structure/morgue_tray/attack_robot(mob/user)

--- a/code/game/objects/structures/rubble.dm
+++ b/code/game/objects/structures/rubble.dm
@@ -47,21 +47,24 @@
 		add_overlay("twinkle[rand(1,3)]")
 
 /obj/structure/rubble/attack_hand(mob/user)
+	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
 	if(!is_rummaging)
 		if(!lootleft)
-			to_chat(user, "<span class='warning'>There's nothing left in this one but unusable garbage...</span>")
+			to_chat(user, SPAN_NOTICE("There's nothing left in this one but unusable garbage..."))
 			return
-		visible_message("[user] starts rummaging through \the [src].")
-		is_rummaging = 1
+		visible_message(SPAN_NOTICE("\The [user] starts rummaging through \the [src]."))
+		is_rummaging = TRUE
 		if(do_after(user, 30))
 			var/obj/item/booty = pickweight(loot)
 			booty = new booty(loc)
 			lootleft--
 			update_icon()
-			to_chat(user, "<span class='notice'>You find something and pull it carefully out of \the [src].</span>")
-		is_rummaging = 0
+			to_chat(user, SPAN_NOTICE("You find something and pull it carefully out of \the [src]."))
+		is_rummaging = FALSE
 	else
-		to_chat(user, "<span class='warning'>Someone is already rummaging here!</span>")
+		to_chat(user, SPAN_WARNING("Someone is already rummaging here!"))
+	return TRUE
 
 /obj/structure/rubble/attackby(var/obj/item/I, var/mob/user)
 	if (istype(I, /obj/item/pickaxe))

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -69,6 +69,9 @@ FLOOR SAFES
 		icon_state = initial(icon_state)
 
 /obj/structure/safe/attack_hand(mob/user)
+	if(!user.check_dexterity(DEXTERITY_COMPLEX_TOOLS, TRUE))
+		return ..()
+
 	user.set_machine(src)
 	var/dat = "<center>"
 	dat += "<a href='?src=\ref[src];open=1'>[open ? "Close" : "Open"] [src]</a> | <a href='?src=\ref[src];decrement=1'>-</a> [dial * 5] <a href='?src=\ref[src];increment=1'>+</a>"
@@ -79,7 +82,7 @@ FLOOR SAFES
 			dat += "<tr><td><a href='?src=\ref[src];retrieve=\ref[P]'>[P.name]</a></td></tr>"
 		dat += "</table></center>"
 	show_browser(user, "<html><head><title>[name]</title></head><body>[dat]</body></html>", "window=safe;size=350x300")
-
+	return TRUE
 
 /obj/structure/safe/Topic(href, href_list)
 	if(!ishuman(usr))	return

--- a/code/game/objects/structures/skele_stand.dm
+++ b/code/game/objects/structures/skele_stand.dm
@@ -31,15 +31,18 @@
 	playsound(loc, 'sound/effects/bonerattle.ogg', 40)
 
 /obj/structure/skele_stand/attack_hand(mob/user)
-	if(swag.len)
+	if(length(swag) && user.check_dexterity(DEXTERITY_GRIP, TRUE))
 		var/obj/item/clothing/C = input("What piece of clothing do you want to remove?", "Skeleton Undressing") as null|anything in list_values(swag)
 		if(C)
 			swag -= get_key_by_value(swag, C)
 			user.put_in_hands(C)
 			to_chat(user, SPAN_NOTICE("You take \the [C] off \the [src]."))
 			update_icon()
-	else
+		return TRUE
+	if(user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
 		rattle_bones(user, null)
+		return TRUE
+	return ..()
 
 /obj/structure/skele_stand/Bumped(atom/thing)
 	rattle_bones(null, thing)

--- a/code/game/objects/structures/stasis_cage.dm
+++ b/code/game/objects/structures/stasis_cage.dm
@@ -21,7 +21,10 @@
 	. = ..()
 
 /obj/structure/stasis_cage/attack_hand(var/mob/user)
+	if(!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
+		return ..()
 	try_release(user)
+	return TRUE
 
 /obj/structure/stasis_cage/attack_robot(var/mob/user)
 	if(CanPhysicallyInteract(user))

--- a/code/game/objects/structures/stool_bed_chair_nest_sofa/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest_sofa/bed.dm
@@ -182,10 +182,10 @@
 	..()
 
 /obj/structure/bed/roller/attack_hand(mob/user)
-	if(beaker && !buckled_mob)
-		remove_beaker(user)
-	else
-		..()
+	if(!beaker || buckled_mob || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	remove_beaker(user)
+	return TRUE
 
 /obj/structure/bed/roller/proc/collapse()
 	visible_message("[usr] collapses [src].")

--- a/code/game/objects/structures/stool_bed_chair_nest_sofa/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest_sofa/wheelchair.dm
@@ -28,7 +28,10 @@
 	..()
 
 /obj/structure/bed/chair/wheelchair/attack_hand(mob/user)
+	if(!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
+		return ..()
 	user_unbuckle_mob(user)
+	return TRUE
 
 /obj/structure/bed/chair/wheelchair/Bump(atom/A)
 	..()
@@ -145,6 +148,6 @@
 
 /obj/item/wheelchair_kit/physically_destroyed(skip_qdel)
 	//Make sure if the kit is destroyed to drop the same stuff as the actual wheelchair
-	var/obj/structure/S = new structure_form_type(get_turf(src)) 
+	var/obj/structure/S = new structure_form_type(get_turf(src))
 	S.physically_destroyed()
 	. = ..()

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -67,6 +67,8 @@
 		return attack_hand(user)
 
 /obj/structure/tank_rack/attack_hand(mob/user)
+	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
 	var/list/dat = list()
 	var/oxycount = LAZYLEN(oxygen_tanks)
 	dat += "Oxygen tanks: [oxycount] - [oxycount ? "<A href='?src=\ref[src];oxygen=1'>Dispense</A>" : "empty"]<br>"
@@ -75,6 +77,7 @@
 	var/datum/browser/popup = new(user, "window=tank_rack")
 	popup.set_content(jointext(dat, "<br>"))
 	popup.open()
+	return TRUE
 
 /obj/structure/tank_rack/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/tank))

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -63,8 +63,7 @@
 			add_overlay("hydrogen-5")
 
 /obj/structure/tank_rack/attack_robot(mob/user)
-	if(CanPhysicallyInteract(user))
-		return attack_hand(user)
+	return attack_hand_with_interaction_checks(user)
 
 /obj/structure/tank_rack/attack_hand(mob/user)
 	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
@@ -97,7 +96,7 @@
 		LAZYADD(adding_to_list, weakref(I))
 		to_chat(user, SPAN_NOTICE("You put [I] in [src]."))
 		update_icon()
-		attack_hand(user)
+		attack_hand_with_interaction_checks(user)
 		return TRUE
 	return ..()
 
@@ -119,7 +118,7 @@
 			O.dropInto(loc)
 			to_chat(user, SPAN_NOTICE("You take \the [O] out of \the [src]."))
 			update_icon()
-			attack_hand(user)
+			attack_hand_with_interaction_checks(user)
 		return TOPIC_REFRESH
 
 /*

--- a/code/game/objects/structures/target_stake.dm
+++ b/code/game/objects/structures/target_stake.dm
@@ -14,12 +14,13 @@
 		set_target(W)
 
 /obj/structure/target_stake/attack_hand(var/mob/user)
-	. = ..()
-	if (pinned_target && ishuman(user))
-		var/obj/item/target/T = pinned_target
-		to_chat(user, "<span class='notice'>You take [T] out of the stake.</span>")
-		set_target(null)
-		user.put_in_hands(T)
+	if (!pinned_target || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	var/obj/item/target/T = pinned_target
+	to_chat(user, SPAN_NOTICE("You take [T] off the stake."))
+	set_target(null)
+	user.put_in_hands(T)
+	return TRUE
 
 /obj/structure/target_stake/proc/set_target(var/obj/item/target/T)
 	if (T)

--- a/code/game/objects/structures/target_stake.dm
+++ b/code/game/objects/structures/target_stake.dm
@@ -16,10 +16,9 @@
 /obj/structure/target_stake/attack_hand(var/mob/user)
 	if (!pinned_target || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
 		return ..()
-	var/obj/item/target/T = pinned_target
-	to_chat(user, SPAN_NOTICE("You take [T] off the stake."))
+	to_chat(user, SPAN_NOTICE("You take \the [pinned_target] off the stake."))
+	user.put_in_hands(pinned_target)
 	set_target(null)
-	user.put_in_hands(T)
 	return TRUE
 
 /obj/structure/target_stake/proc/set_target(var/obj/item/target/T)

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -90,16 +90,15 @@
 				AM.forceMove(pod)
 
 /obj/structure/transit_tube/station/attack_hand(mob/user)
-	if(!pod_moving)
-		for(var/obj/structure/transit_tube_pod/pod in loc)
-			if(!pod.moving && (pod.dir in directions()))
-				if(icon_state == "closed")
-					open_animation()
-
-				else if(icon_state == "open")
-					close_animation()
-
-
+	if(pod_moving || !user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
+		return ..()
+	for(var/obj/structure/transit_tube_pod/pod in loc)
+		if(!pod.moving && (pod.dir in directions()))
+			if(icon_state == "closed")
+				open_animation()
+			else if(icon_state == "open")
+				close_animation()
+	return TRUE
 
 /obj/structure/transit_tube/station/proc/open_animation()
 	if(icon_state == "closed")

--- a/code/game/objects/structures/under_wardrobe.dm
+++ b/code/game/objects/structures/under_wardrobe.dm
@@ -40,9 +40,9 @@
 
 /obj/structure/undies_wardrobe/attack_hand(var/mob/user)
 	if(!human_who_can_use_underwear(user))
-		to_chat(user, "<span class='warning'>Sadly there's nothing in here for you to wear.</span>")
-		return
+		return ..()
 	interact(user)
+	return TRUE
 
 /obj/structure/undies_wardrobe/interact(var/mob/living/carbon/human/H)
 	var/id = H.GetIdCard()

--- a/code/game/objects/structures/wallframe_spawner.dm
+++ b/code/game/objects/structures/wallframe_spawner.dm
@@ -14,7 +14,9 @@
 	return 0
 
 /obj/effect/wallframe_spawn/attack_hand()
+	SHOULD_CALL_PARENT(FALSE)
 	activate()
+	return TRUE
 
 /obj/effect/wallframe_spawn/attack_ghost()
 	activate()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -144,6 +144,7 @@
 	take_damage(tforce)
 
 /obj/structure/window/attack_hand(mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if (user.a_intent && user.a_intent == I_HURT)
 
@@ -163,6 +164,7 @@
 		user.visible_message("[user.name] knocks on the [src.name].",
 							"You knock on the [src.name].",
 							"You hear a knocking sound.")
+	return TRUE
 
 /obj/structure/window/do_simple_ranged_interaction(var/mob/user)
 	visible_message(SPAN_NOTICE("Something knocks on \the [src]."))
@@ -574,8 +576,9 @@
 	icon_state = "light[active]"
 
 //Centcomm windows
-/obj/structure/window/reinforced/crescent/attack_hand()
-	return
+/obj/structure/window/reinforced/crescent/attack_hand(mob/user)
+	SHOULD_CALL_PARENT(FALSE)
+	return TRUE
 
 /obj/structure/window/reinforced/crescent/attackby()
 	return

--- a/code/game/objects/structures/window_spawner.dm
+++ b/code/game/objects/structures/window_spawner.dm
@@ -18,7 +18,9 @@
 	return 0
 
 /obj/effect/wingrille_spawn/attack_hand()
+	SHOULD_CALL_PARENT(FALSE)
 	activate()
+	return TRUE
 
 /obj/effect/wingrille_spawn/attack_ghost()
 	activate()

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -1,10 +1,11 @@
 /turf/simulated/floor/attack_hand(mob/user)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		var/obj/item/hand = GET_EXTERNAL_ORGAN(H, H.get_active_held_item_slot())
-		if(hand && try_graffiti(H, hand))
-			return TRUE
-	. = ..()
+	if(!ishuman(user))
+		return ..()
+	var/mob/living/carbon/human/H = user
+	var/obj/item/hand = GET_EXTERNAL_ORGAN(H, H.get_active_held_item_slot())
+	if(hand && try_graffiti(H, hand))
+		return TRUE
+	return ..()
 
 /turf/simulated/floor/attackby(var/obj/item/C, var/mob/user)
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -145,20 +145,16 @@
 
 /turf/attack_hand(mob/user)
 	SHOULD_CALL_PARENT(FALSE)
-	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
-	if(user.restrained())
-		return FALSE
-	return handle_hand_interception(user)
-
-/turf/proc/handle_hand_interception(var/mob/user)
-	var/datum/extension/turf_hand/THE
-	for (var/A in src)
-		var/datum/extension/turf_hand/TH = get_extension(A, /datum/extension/turf_hand)
-		if (istype(TH) && TH.priority > THE?.priority) //Only overwrite if the new one is higher. For matching values, its first come first served
-			THE = TH
-
-	if (THE)
-		return THE.OnHandInterception(user)
+	var/datum/extension/turf_hand/highest_priority_intercept
+	for(var/atom/thing in contents)
+		var/datum/extension/turf_hand/intercept = get_extension(thing, /datum/extension/turf_hand)
+		if(intercept?.intercept_priority > highest_priority_intercept?.intercept_priority)
+			highest_priority_intercept = intercept
+	if(highest_priority_intercept)
+		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+		var/atom/intercepting_atom = highest_priority_intercept.holder
+		return intercepting_atom.attack_hand(user)
+	return FALSE
 
 /turf/attack_robot(var/mob/user)
 	if(CanPhysicallyInteract(user))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -144,12 +144,11 @@
 		. += weather.get_movement_delay(return_air(), travel_dir)
 
 /turf/attack_hand(mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
-
 	if(user.restrained())
-		return 0
-
-	. = handle_hand_interception(user)
+		return FALSE
+	return handle_hand_interception(user)
 
 /turf/proc/handle_hand_interception(var/mob/user)
 	var/datum/extension/turf_hand/THE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -157,8 +157,7 @@
 	return FALSE
 
 /turf/attack_robot(var/mob/user)
-	if(CanPhysicallyInteract(user))
-		return attack_hand(user)
+	return attack_hand_with_interaction_checks(user)
 
 /turf/attackby(obj/item/W, mob/user)
 

--- a/code/modules/acting/acting_items.dm
+++ b/code/modules/acting/acting_items.dm
@@ -8,13 +8,17 @@
 	var/active = 1
 
 /obj/machinery/acting/wardrobe/attack_hand(var/mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	user.show_message("You push a button and watch patiently as the machine begins to hum.")
 	if(active)
-		active = 0
-		spawn(30)
-			new /obj/item/storage/backpack/chameleon/sydie_kit(src.loc)
-			src.visible_message("\The [src] beeps, dispensing a small box onto the floor.", "You hear a beeping sound followed by a thumping noise of some kind.")
-			active = 1
+		active = FALSE
+		addtimer(CALLBACK(src, .proc/dispense), 3 SECONDS)
+	return TRUE
+
+/obj/machinery/acting/wardrobe/proc/dispense()
+	new /obj/item/storage/backpack/chameleon/sydie_kit(src.loc)
+	src.visible_message("\The [src] beeps, dispensing a small box onto the floor.", "You hear a beeping sound followed by a thumping noise of some kind.")
+	active = TRUE
 
 /obj/machinery/acting/changer
 	name = "Quickee's Plastic Surgeon"
@@ -25,16 +29,19 @@
 	density = 1
 
 /obj/machinery/acting/changer/attack_hand(var/mob/user)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		H.change_appearance(APPEARANCE_ALL, H.loc, H, H.generate_valid_species(), state = global.z_topic_state)
-		var/getName = sanitize(input(H, "Would you like to change your name to something else?", "Name change") as null|text, MAX_NAME_LEN)
-		if(getName)
-			H.real_name = getName
-			H.SetName(getName)
-			H.dna.real_name = getName
-			if(H.mind)
-				H.mind.name = H.name
+	SHOULD_CALL_PARENT(FALSE)
+	if(!ishuman(user))
+		return ..()
+	var/mob/living/carbon/human/H = user
+	H.change_appearance(APPEARANCE_ALL, H.loc, H, H.generate_valid_species(), state = global.z_topic_state)
+	var/getName = sanitize(input(H, "Would you like to change your name to something else?", "Name change") as null|text, MAX_NAME_LEN)
+	if(getName)
+		H.real_name = getName
+		H.SetName(getName)
+		H.dna.real_name = getName
+		if(H.mind)
+			H.mind.name = H.name
+	return TRUE
 
 /obj/machinery/acting/changer/mirror
 	name = "Mirror of Many Faces"

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -120,10 +120,10 @@
 			S.on_found(finder)
 
 /obj/item/assembly_holder/Move()
-	if(a_left && a_right)
+	. = ..()
+	if(. && a_left && a_right)
 		a_left.holder_movement()
 		a_right.holder_movement()
-	return ..()
 
 /obj/item/assembly_holder/attack_hand()//Perhapse this should be a holder_pickup proc instead, can add if needbe I guess
 	if(a_left && a_right)

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -119,28 +119,19 @@
 			var/obj/item/S = special_assembly
 			S.on_found(finder)
 
-
 /obj/item/assembly_holder/Move()
-	..()
 	if(a_left && a_right)
 		a_left.holder_movement()
 		a_right.holder_movement()
-//	if(special_assembly)
-//		special_assembly:holder_movement()
-	return
-
+	return ..()
 
 /obj/item/assembly_holder/attack_hand()//Perhapse this should be a holder_pickup proc instead, can add if needbe I guess
 	if(a_left && a_right)
 		a_left.holder_movement()
 		a_right.holder_movement()
-//	if(special_assembly)
-//		special_assembly:Holder_Movement()
-	..()
-	return
+	return ..()
 
-
-/obj/item/assembly_holder/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/assembly_holder/attackby(obj/item/W, mob/user)
 	if(IS_SCREWDRIVER(W))
 		if(!a_left || !a_right)
 			to_chat(user, "<span class='warning'>BUG:Assembly part missing, please report this!</span>")

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -106,14 +106,16 @@
 
 
 /obj/machinery/gateway/centerstation/attack_hand(mob/user)
+	if(!user.check_dexterity(DEXTERITY_COMPLEX_TOOLS, TRUE))
+		return ..()
 	if(!ready)
 		detect()
-		return
+		return TRUE
 	if(!active)
 		toggleon(user)
-		return
+		return TRUE
 	toggleoff()
-
+	return TRUE
 
 //okay, here's the good teleporting stuff
 /obj/machinery/gateway/centerstation/Bumped(atom/movable/M)
@@ -198,13 +200,16 @@
 
 
 /obj/machinery/gateway/centeraway/attack_hand(mob/user)
+	if(!user.check_dexterity(DEXTERITY_COMPLEX_TOOLS, TRUE))
+		return ..()
 	if(!ready)
 		detect()
-		return
+		return TRUE
 	if(!active)
 		toggleon(user)
-		return
+		return TRUE
 	toggleoff()
+	return TRUE
 
 /obj/machinery/gateway/centeraway/Bumped(atom/movable/M)
 	if(!ready)	return

--- a/code/modules/butchery/butchery.dm
+++ b/code/modules/butchery/butchery.dm
@@ -90,7 +90,7 @@
 
 /obj/structure/kitchenspike/attack_hand(var/mob/user)
 
-	if(!occupant)
+	if(!occupant || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
 		return ..()
 
 	if(occupant_state == CARCASS_FRESH)
@@ -102,7 +102,7 @@
 		update_icon()
 	else
 		to_chat(user, SPAN_WARNING("\The [occupant] is so badly mangled that removing them from \the [src] would be pointless."))
-		return
+	return TRUE
 
 /obj/structure/kitchenspike/receive_mouse_drop(var/atom/dropping, var/mob/user)
 	. = ..()

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -41,11 +41,11 @@
 
 /obj/item/clothing/attack_hand(var/mob/user)
 	//only forward to the attached accessory if the clothing is equipped (not in a storage)
-	if(accessories.len && src.loc == user)
-		for(var/obj/item/clothing/accessory/A in accessories)
-			A.attack_hand(user)
-		return
-	return ..()
+	if(!length(accessories) || loc != user)
+		return ..()
+	for(var/obj/item/clothing/accessory/A in accessories)
+		. = A.attack_hand(user) || .
+	return TRUE
 
 /obj/item/clothing/check_mousedrop_adjacency(var/atom/over, var/mob/user)
 	. = (loc == user && istype(over, /obj/screen)) || ..()

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -11,9 +11,8 @@
 // Override for action buttons.
 /obj/item/clothing/attack_self(mob/user)
 	if(loc == user && user.get_active_hand() != src)
-		attack_hand(user)
-	else
-		. = ..()
+		return attack_hand_with_interaction_checks(user)
+	return ..()
 
 /obj/item/clothing/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/clothing/accessory))

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -22,9 +22,10 @@
 
 // Clumsy folks can't take the mask off themselves.
 /obj/item/clothing/mask/muzzle/attack_hand(mob/user)
-	if(user.get_equipped_item(slot_wear_mask_str) == src && !user.check_dexterity(DEXTERITY_GRIP))
-		return 0
-	..()
+	if(user.get_equipped_item(slot_wear_mask_str) != src || user.check_dexterity(DEXTERITY_GRIP))
+		return ..()
+	to_chat(user, SPAN_WARNING("You cannot remove \the [src]."))
+	return TRUE
 
 /obj/item/clothing/mask/surgical
 	name = "sterile mask"

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -24,7 +24,7 @@
 /obj/item/clothing/mask/muzzle/attack_hand(mob/user)
 	if(user.get_equipped_item(slot_wear_mask_str) != src || user.check_dexterity(DEXTERITY_GRIP))
 		return ..()
-	to_chat(user, SPAN_WARNING("You cannot remove \the [src]."))
+	to_chat(user, SPAN_WARNING("You cannot remove \the [src] without help."))
 	return TRUE
 
 /obj/item/clothing/mask/surgical

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -48,9 +48,9 @@
 			to_chat(user, SPAN_ITALIC("Something is hidden inside."))
 
 /obj/item/clothing/shoes/attack_hand(var/mob/user)
-	if (remove_hidden(user))
-		return
-	..()
+	if(user.check_dexterity(DEXTERITY_GRIP, TRUE) && remove_hidden(user))
+		return TRUE
+	return ..()
 
 /obj/item/clothing/shoes/attack_self(var/mob/user)
 	remove_cuffs(user)

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -471,13 +471,11 @@
 	device = /obj/item/paper_bin
 
 /obj/item/rig_module/device/paperdispenser/engage(atom/target)
-
 	if(!..() || !device)
-		return 0
-
+		return FALSE
 	if(!target)
-		device.attack_hand(holder.wearer)
-		return 1
+		device.attack_hand_with_interaction_checks(holder.wearer)
+		return TRUE
 
 /obj/item/rig_module/device/pen
 	name = "mounted pen"

--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -203,11 +203,9 @@
 
 
 /obj/item/rig/attack_hand(var/mob/user)
-
-	if(electrified != 0)
-		if(shock(user)) //Handles removing charge from the cell, as well. No need to do that here.
-			return
-	..()
+	if(electrified != 0 && shock(user)) //Handles removing charge from the cell, as well. No need to do that here.
+		return TRUE
+	return ..()
 
 /obj/item/rig/emag_act(var/remaining_charges, var/mob/user)
 	if(!subverted)

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -12,7 +12,8 @@
 
 /obj/item/clothing/suit/storage/attack_hand(mob/user)
 	if(pockets.handle_attack_hand(user))
-		. = ..(user)
+		return ..(user)
+	return TRUE
 
 /obj/item/clothing/suit/storage/handle_mouse_drop(atom/over, mob/user)
 	. = pockets?.handle_storage_internal_mouse_drop(user, over) && ..()

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -83,13 +83,6 @@
 		to_chat(usr, SPAN_NOTICE("You roll [rolled_sleeves ? "up" : "down"] the sleeves of \the [src]."))
 		update_clothing_icon()
 
-/obj/item/clothing/under/attack_hand(var/mob/user)
-	if(accessories && accessories.len)
-		..()
-	if ((ishuman(usr) || issmall(usr)) && src.loc == user)
-		return
-	..()
-
 /obj/item/clothing/under/update_clothing_icon()
 	if(ismob(src.loc))
 		var/mob/M = src.loc

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -43,10 +43,9 @@
 
 //default attack_hand behaviour
 /obj/item/clothing/accessory/attack_hand(mob/user)
-	var/obj/item/clothing/suit = loc
-	if(istype(suit))
+	if(istype(loc, /obj/item/clothing))
 		return TRUE //we aren't an object on the ground so don't call parent
-	..()
+	return ..()
 
 /obj/item/clothing/accessory/get_pressure_weakness(pressure,zone)
 	if(body_parts_covered & zone)

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -21,11 +21,12 @@
 		. = ..(W, user)
 
 /obj/item/clothing/accessory/storage/holster/attack_hand(mob/user)
+	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
 	var/datum/extension/holster/H = get_extension(src, /datum/extension/holster)
 	if(H.unholster(user))
-		return
-	else
-		. = ..(user)
+		return TRUE
+	return ..()
 
 /obj/item/clothing/accessory/storage/holster/examine(mob/user)
 	. = ..(user)

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -22,13 +22,14 @@
 	hold = new/obj/item/storage/internal/pockets(src, slots, max_w_class)
 
 /obj/item/clothing/accessory/storage/attack_hand(mob/user)
-	var/obj/item/clothing/suit = loc
-	if(istype(suit) && hold)	//if we are part of a suit
+	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE) || !hold)
+		return ..()
+	if(istype(loc, /obj/item/clothing))
 		hold.open(user)
-		return
-
-	if(hold && hold.handle_attack_hand(user))	//otherwise interact as a regular storage item
-		..(user)
+		return TRUE
+	if(hold.handle_attack_hand(user))	//otherwise interact as a regular storage item
+		return ..(user)
+	return TRUE
 
 /obj/item/clothing/accessory/storage/handle_mouse_drop(atom/over, mob/user)
 	if(!istype(loc, /obj/item/clothing) && hold?.handle_storage_internal_mouse_drop(user, over))

--- a/code/modules/economy/cael/ATM.dm
+++ b/code/modules/economy/cael/ATM.dm
@@ -92,7 +92,7 @@
 			held_card = idcard
 			if(authenticated_account && held_card.associated_account_number != authenticated_account.account_number)
 				authenticated_account = null
-			attack_hand(user)
+			attack_hand_with_interaction_checks(user)
 
 	else if(authenticated_account)
 		if(istype(I,/obj/item/cash))
@@ -103,7 +103,7 @@
 				playsound(loc, pick('sound/items/polaroid1.ogg', 'sound/items/polaroid2.ogg'), 50, 1)
 
 				to_chat(user, "<span class='info'>You insert [I] into [src].</span>")
-				src.attack_hand(user)
+				attack_hand_with_interaction_checks(user)
 				qdel(I)
 
 		if(istype(I,/obj/item/charge_stick))
@@ -116,7 +116,7 @@
 					playsound(loc, pick('sound/items/polaroid1.ogg', 'sound/items/polaroid2.ogg'), 50, 1)
 
 					to_chat(user, "<span class='info'>You insert [I] into [src].</span>")
-					src.attack_hand(user)
+					attack_hand_with_interaction_checks(user)
 					qdel(I)
 	else
 		..()

--- a/code/modules/economy/cael/Accounts_DB.dm
+++ b/code/modules/economy/cael/Accounts_DB.dm
@@ -30,17 +30,12 @@
 	machine_id = "[station_name()] Acc. DB #[num_financial_terminals++]"
 
 /obj/machinery/computer/account_database/attackby(obj/O, mob/user)
-	if(!istype(O, /obj/item/card/id))
-		return ..()
-
-	if(!held_card)
-		if(!user.try_unequip(O, src))
-			return
-		held_card = O
-
-		SSnano.update_uis(src)
-
-	attack_hand(user)
+	if(istype(O, /obj/item/card/id) && !held_card)
+		if(user.try_unequip(O, src))
+			held_card = O
+			ui_interact(user)
+		return TRUE
+	return ..()
 
 /obj/machinery/computer/account_database/interface_interact(mob/user)
 	ui_interact(user)

--- a/code/modules/economy/cael/Accounts_DB.dm
+++ b/code/modules/economy/cael/Accounts_DB.dm
@@ -33,7 +33,7 @@
 	if(istype(O, /obj/item/card/id) && !held_card)
 		if(user.try_unequip(O, src))
 			held_card = O
-			ui_interact(user)
+			SSnano.update_uis(src)
 		return TRUE
 	return ..()
 
@@ -135,13 +135,14 @@
 					if(ishuman(usr) && !usr.get_active_hand())
 						usr.put_in_hands(held_card)
 					held_card = null
-
+					SSnano.update_uis(src)
 				else
 					var/obj/item/I = usr.get_active_hand()
 					if (istype(I, /obj/item/card/id))
 						if(!usr.try_unequip(I, src))
 							return
 						held_card = I
+						SSnano.update_uis(src)
 
 			if("view_account_detail")
 				var/index = text2num(href_list["account_index"])

--- a/code/modules/fabrication/fabricator_intake.dm
+++ b/code/modules/fabrication/fabricator_intake.dm
@@ -92,7 +92,7 @@
 	if(component_attackby(O, user))
 		return TRUE
 	if(panel_open && (IS_MULTITOOL(O) || IS_WIRECUTTER(O)))
-		attack_hand(user)
+		attack_hand_with_interaction_checks(user)
 		return TRUE
 	if((obj_flags & OBJ_FLAG_ANCHORABLE) && IS_WRENCH(O))
 		return ..()

--- a/code/modules/games/boardgame.dm
+++ b/code/modules/games/boardgame.dm
@@ -20,8 +20,8 @@
 /obj/item/board/attack_hand(mob/M)
 	if(M.machine == src)
 		return ..()
-	else
-		M.examinate(src)
+	M.examinate(src)
+	return TRUE
 
 /obj/item/board/attackby(obj/item/I, mob/user)
 	if(!addPiece(I,user))

--- a/code/modules/holomap/holomap.dm
+++ b/code/modules/holomap/holomap.dm
@@ -63,6 +63,8 @@
 	update_icon()
 
 /obj/machinery/holomap/attack_hand(var/mob/user)
+	if(user.a_intent == I_HURT)
+		return ..()
 	if(watching_mob && (watching_mob != user))
 		to_chat(user, SPAN_WARNING("Someone else is currently watching the holomap."))
 		return
@@ -70,6 +72,7 @@
 		to_chat(user, SPAN_WARNING("You need to stand in front of \the [src]."))
 		return
 	startWatching(user)
+	return TRUE
 
 // Let people bump up against it to watch
 /obj/machinery/holomap/Bumped(var/atom/movable/AM)

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -29,7 +29,9 @@
 	color = DEAD_PLANT_COLOUR
 
 /obj/effect/dead_plant/attack_hand()
+	SHOULD_CALL_PARENT(FALSE)
 	qdel(src)
+	return TRUE
 
 /obj/effect/dead_plant/attackby()
 	..()

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -15,7 +15,10 @@
 				entangle(M)
 
 /obj/effect/vine/attack_hand(var/mob/user)
+	if(!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES))
+		return ..()
 	manual_unbuckle(user)
+	return TRUE
 
 /obj/effect/vine/Crossed(atom/movable/O)
 	if(isliving(O))

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -476,8 +476,7 @@
 
 	else if (istype(O, /obj/item/storage/plants))
 
-		attack_hand(user)
-
+		physical_attack_hand(user) // Harvests and clears out dead plants.
 		var/obj/item/storage/plants/S = O
 		for (var/obj/item/chems/food/grown/G in locate(user.x,user.y,user.z))
 			if(!S.can_be_inserted(G, user))

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -512,10 +512,10 @@
 	return src
 
 /obj/item/electronic_assembly/attack_hand(mob/user)
-	if(anchored)
-		attack_self(user)
-		return
-	..()
+	if(!anchored)
+		return ..()
+	attack_self(user)
+	return TRUE
 
 /obj/item/electronic_assembly/default //The /default electronic_assemblys are to allow the introduction of the new naming scheme without breaking old saves.
   name = "type-a electronic assembly"

--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -14,18 +14,15 @@
 	return ..()
 
 /obj/item/mech_equipment/clamp/attack_hand(mob/user)
-	if(owner && LAZYISIN(owner.pilots, user))
-		if(!owner.hatch_closed && length(carrying))
-			var/obj/chosen_obj = input(user, "Choose an object to grab.", "Clamp Claw") as null|anything in carrying
-			if(!chosen_obj)
-				return
-			if(!do_after(user, 20, owner)) return
-			if(owner.hatch_closed || !chosen_obj) return
-			if(user.put_in_active_hand(chosen_obj))
-				owner.visible_message(SPAN_NOTICE("\The [user] carefully grabs \the [chosen_obj] from \the [src]."))
-				playsound(src, 'sound/mecha/hydraulic.ogg', 50, 1)
-				carrying -= chosen_obj
-	. = ..()
+	if(!owner || !LAZYISIN(owner.pilots, user) || owner.hatch_closed || !length(carrying) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	var/obj/chosen_obj = input(user, "Choose an object to grab.", "Clamp Claw") as null|anything in carrying
+	if(chosen_obj && do_after(user, 20, owner) && !owner.hatch_closed && !QDELETED(chosen_obj) && (chosen_obj in carrying))
+		owner.visible_message(SPAN_NOTICE("\The [user] carefully grabs \the [chosen_obj] from \the [src]."))
+		playsound(src, 'sound/mecha/hydraulic.ogg', 50, 1)
+		carrying -= chosen_obj
+		user.put_in_active_hand(chosen_obj)
+	return TRUE
 
 /obj/item/mech_equipment/clamp/afterattack(var/atom/target, var/mob/living/user, var/inrange, var/params)
 	. = ..()

--- a/code/modules/mechs/mech_wreckage.dm
+++ b/code/modules/mechs/mech_wreckage.dm
@@ -49,11 +49,10 @@
 
 
 /obj/structure/mech_wreckage/attack_hand(var/mob/user)
-	if(!length(contents) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	var/list/contained_atoms = get_contained_external_atoms()
+	if(!length(contained_atoms) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
 		return ..()
-	var/obj/item/thing = pick(contents)
-	if(!istype(thing))
-		return ..()
+	var/obj/item/thing = pick(contained_atoms)
 	thing.forceMove(get_turf(user))
 	user.put_in_hands(thing)
 	to_chat(user, "You retrieve \the [thing] from \the [src].")

--- a/code/modules/mechs/mech_wreckage.dm
+++ b/code/modules/mechs/mech_wreckage.dm
@@ -49,14 +49,15 @@
 
 
 /obj/structure/mech_wreckage/attack_hand(var/mob/user)
-	if(contents.len)
-		var/obj/item/thing = pick(contents)
-		if(istype(thing))
-			thing.forceMove(get_turf(user))
-			user.put_in_hands(thing)
-			to_chat(user, "You retrieve \the [thing] from \the [src].")
-			return
-	return ..()
+	if(!length(contents) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	var/obj/item/thing = pick(contents)
+	if(!istype(thing))
+		return ..()
+	thing.forceMove(get_turf(user))
+	user.put_in_hands(thing)
+	to_chat(user, "You retrieve \the [thing] from \the [src].")
+	return TRUE
 
 /obj/structure/mech_wreckage/attackby(var/obj/item/W, var/mob/user)
 

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -217,11 +217,11 @@
 	return ..()
 
 /obj/item/stack/flag/attack_hand(var/mob/user)
-	if(upright)
-		knock_down()
-		user.visible_message("\The [user] knocks down \the [singular_name].")
-		return
-	return ..()
+	if(!upright)
+		return ..()
+	knock_down()
+	user.visible_message("\The [user] knocks down \the [singular_name].")
+	return TRUE
 
 /obj/item/stack/flag/attack_self(var/mob/user)
 	var/turf/T = get_turf(src)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -212,8 +212,7 @@
 
 /obj/item/stack/flag/attackby(var/obj/item/W, var/mob/user)
 	if(upright)
-		attack_hand(user)
-		return
+		return attack_hand_with_interaction_checks(user)
 	return ..()
 
 /obj/item/stack/flag/attack_hand(var/mob/user)

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -18,12 +18,13 @@
 	var/list/stored_ore
 
 /obj/structure/ore_box/attack_hand(mob/user)
-	if(total_ores > 0)
-		var/obj/item/stack/material/ore/O = pick(get_contained_external_atoms())
-		if(remove_ore(O, user))
-			to_chat(user, SPAN_NOTICE("You grab a random ore pile from \the [src]."))
-			return TRUE
-	. = ..()
+	if(total_ores <= 0 || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	var/obj/item/stack/material/ore/O = pick(get_contained_external_atoms())
+	if(!remove_ore(O, user))
+		return ..()
+	to_chat(user, SPAN_NOTICE("You grab a random ore pile from \the [src]."))
+	return TRUE
 
 /obj/structure/ore_box/attackby(obj/item/W, mob/user)
 	if (istype(W, /obj/item/stack/material/ore))

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -6,7 +6,7 @@
 		if(istype(W))
 			E.attackby(W,src)
 		else
-			E.attack_hand(src)
+			E.attack_hand(src) // We can assume it's physically accessible if it's on our person.
 	else
 		equip_to_slot_if_possible(W, slot)
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -175,7 +175,7 @@
 				H.do_attack_animation(src)
 				return TRUE
 
-	. = ..()
+	return ..()
 
 /mob/living/carbon/human/proc/start_compressions(mob/living/carbon/human/H, starting = FALSE, cpr_mode)
 	if(length(H.get_held_items()))

--- a/code/modules/mob/living/living_attackhand.dm
+++ b/code/modules/mob/living/living_attackhand.dm
@@ -1,6 +1,5 @@
 /mob/living/attack_hand(mob/user)
-	SHOULD_CALL_PARENT(TRUE)
-	. = ..() || (user && default_interaction(user))
+	return ..() || (user && default_interaction(user))
 
 /mob/living/proc/default_interaction(var/mob/user)
 

--- a/code/modules/mob/living/living_attackhand.dm
+++ b/code/modules/mob/living/living_attackhand.dm
@@ -40,7 +40,7 @@
 	SHOULD_CALL_PARENT(TRUE)
 	return (scoop_check(user) && get_scooped(user, user)) || try_make_grab(user)
 
-// This proc is where movable atoms handle being grabbed, but we handle it additionally in 
+// This proc is where movable atoms handle being grabbed, but we handle it additionally in
 // default_grab_interaction, so we override it here to return FALSE and avoid double-grabbing.
 /mob/living/handle_grab_interaction(var/mob/user)
 	return FALSE

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -88,7 +88,7 @@
 		/decl/material/solid/metal/steel  = MATTER_AMOUNT_SECONDARY,
 		/decl/material/solid/glass        = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/metal/copper = MATTER_AMOUNT_TRACE,
-		/decl/material/solid/silicon      = MATTER_AMOUNT_TRACE, 
+		/decl/material/solid/silicon      = MATTER_AMOUNT_TRACE,
 	)
 	var/activated = 0
 	var/strobe_effect = null
@@ -198,7 +198,7 @@
 /obj/item/pen/robopen/attack_self(mob/user)
 
 	var/choice = input("Would you like to change colour or mode?") as null|anything in list("Colour","Mode")
-	if(!choice) 
+	if(!choice)
 		return
 
 	playsound(src.loc, 'sound/effects/pop.ogg', 50, 0)
@@ -207,7 +207,7 @@
 
 		if("Colour")
 			var/newcolour = input("Which colour would you like to use?") as null|anything in list("black","blue","red","green","yellow")
-			if(newcolour) 
+			if(newcolour)
 				set_medium_color(newcolour, newcolour)
 
 		if("Mode")
@@ -432,8 +432,7 @@
 		to_chat(user, "<span class='notice'>\The [src] is full and can't store any more items.</span>")
 		return
 	if(istype(O, interact_type))
-		O.attack_hand(user)
-		return
+		return O.attack_hand(user)
 	. = ..()
 
 /obj/item/bioreactor

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -89,7 +89,7 @@
 					else
 						set_dir(SOUTH)
 
-					if(isturf(movement_target.loc) )
+					if(isturf(movement_target.loc) && Adjacent(movement_target))
 						UnarmedAttack(movement_target)
 					else if(ishuman(movement_target.loc) && prob(20))
 						visible_emote("stares at the [movement_target] that [movement_target.loc] has with sad puppy eyes.")

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -35,6 +35,9 @@
 	var/body_color //brown, gray and white, leave blank for random
 	var/splatted = FALSE
 
+/mob/living/simple_animal/mouse/check_dexterity(dex_level, silent)
+	return FALSE // Mice are troll bait, give them no power.
+
 /mob/living/simple_animal/mouse/Life()
 	. = ..()
 	if(!.)

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -98,7 +98,7 @@
 		stance = HOSTILE_STANCE_ALERT
 		stance_step = 6
 		target_mob = user
-	. = ..()
+	return ..()
 
 /mob/living/simple_animal/hostile/bear/FindTarget()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -161,7 +161,7 @@ var/global/list/protected_objects = list(/obj/machinery,
 
 /mob/living/simple_animal/hostile/mimic/sleeping/attack_hand()
 	trigger()
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/mimic/sleeping/DestroySurroundings()
 	if(awake)

--- a/code/modules/mob/stripping.dm
+++ b/code/modules/mob/stripping.dm
@@ -91,7 +91,7 @@
 		if(!istype(target_slot))  // They aren't holding anything valid and there's nothing to remove, why are we even here?
 			return
 		if(!target_slot.mob_can_unequip(src, slot_to_strip_text, disable_warning=1))
-			to_chat(user, "<span class='warning'>You cannot remove \the [src]'s [target_slot.name].</span>")
+			to_chat(user, SPAN_WARNING("You cannot remove \the [src]'s [target_slot.name]."))
 			return
 
 		visible_message("<span class='danger'>\The [user] is trying to remove \the [src]'s [target_slot.name]!</span>")

--- a/code/modules/multiz/hoist.dm
+++ b/code/modules/multiz/hoist.dm
@@ -38,18 +38,20 @@
 	var/obj/structure/hoist/source_hoist
 
 /obj/effect/hoist_hook/attack_hand(mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	if (user.incapacitated())
 		to_chat(user, SPAN_WARNING("You can't do that while incapacitated."))
-		return
+		return TRUE
 
 	if (!user.check_dexterity(DEXTERITY_GRIP))
-		return
+		return TRUE
 
 	if(source_hoist && source_hoist.hoistee)
 		source_hoist.check_consistency()
 		source_hoist.hoistee.forceMove(get_turf(src))
 		user.visible_message(SPAN_NOTICE("[user] detaches \the [source_hoist.hoistee] from the hoist clamp."), SPAN_NOTICE("You detach \the [source_hoist.hoistee] from the hoist clamp."), SPAN_NOTICE("You hear something unclamp."))
 		source_hoist.release_hoistee()
+	return TRUE
 
 /obj/effect/hoist_hook/receive_mouse_drop(atom/dropping, mob/user)
 	// skip the parent buckle logic, handle climbing directly
@@ -184,25 +186,23 @@
 		source_hoist.break_hoist()
 
 /obj/structure/hoist/attack_hand(mob/user)
-	if (!ishuman(user))
-		return
+	if (!ishuman(user) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
 
 	if (user.incapacitated())
 		to_chat(user, SPAN_WARNING("You can't do that while incapacitated."))
-		return
-
-	if (!user.check_dexterity(DEXTERITY_GRIP))
-		return
+		return TRUE
 
 	if(broken)
 		to_chat(user, SPAN_WARNING("The hoist is broken!"))
-		return
+		return TRUE
+
 	var/can = can_move_dir(movedir)
 	var/movtext = movedir == UP ? "raise" : "lower"
 	if (!can) // If you can't...
 		movedir = movedir == UP ? DOWN : UP // switch directions!
 		to_chat(user, SPAN_NOTICE("You switch the direction of the pulley."))
-		return
+		return TRUE
 
 	if (!hoistee)
 		user.visible_message(
@@ -210,7 +210,7 @@
 			SPAN_NOTICE("You begin to [movtext] the clamp."),
 			SPAN_NOTICE("You hear the sound of a crank."))
 		move_dir(movedir, 0)
-		return
+		return TRUE
 
 	check_consistency()
 
@@ -228,6 +228,7 @@
 		SPAN_NOTICE("You hear the sound of a crank."))
 	if (do_after(user, (1 SECONDS) * size / 4, src))
 		move_dir(movedir, 1)
+	return TRUE
 
 /obj/structure/hoist/proc/collapse_kit(mob/user)
 	var/obj/item/hoist_kit/kit = new (get_turf(src))

--- a/code/modules/multiz/hoist.dm
+++ b/code/modules/multiz/hoist.dm
@@ -38,19 +38,12 @@
 	var/obj/structure/hoist/source_hoist
 
 /obj/effect/hoist_hook/attack_hand(mob/user)
-	SHOULD_CALL_PARENT(FALSE)
-	if (user.incapacitated())
-		to_chat(user, SPAN_WARNING("You can't do that while incapacitated."))
-		return TRUE
-
-	if (!user.check_dexterity(DEXTERITY_GRIP))
-		return TRUE
-
-	if(source_hoist && source_hoist.hoistee)
-		source_hoist.check_consistency()
-		source_hoist.hoistee.forceMove(get_turf(src))
-		user.visible_message(SPAN_NOTICE("[user] detaches \the [source_hoist.hoistee] from the hoist clamp."), SPAN_NOTICE("You detach \the [source_hoist.hoistee] from the hoist clamp."), SPAN_NOTICE("You hear something unclamp."))
-		source_hoist.release_hoistee()
+	if(user.incapacitated() || !user.check_dexterity(DEXTERITY_GRIP) || !source_hoist?.hoistee)
+		return ..()
+	source_hoist.check_consistency()
+	source_hoist.hoistee.forceMove(get_turf(src))
+	user.visible_message(SPAN_NOTICE("[user] detaches \the [source_hoist.hoistee] from the hoist clamp."), SPAN_NOTICE("You detach \the [source_hoist.hoistee] from the hoist clamp."), SPAN_NOTICE("You hear something unclamp."))
+	source_hoist.release_hoistee()
 	return TRUE
 
 /obj/effect/hoist_hook/receive_mouse_drop(atom/dropping, mob/user)

--- a/code/modules/multiz/ladder.dm
+++ b/code/modules/multiz/ladder.dm
@@ -249,7 +249,7 @@
 			var/atom/movable/M = A
 			if(istype(M) && M.movable_flags & MOVABLE_FLAG_Z_INTERACT)
 				if(isnull(I) || istype(I, /obj/item/grab))
-					M.attack_hand(user)
+					M.attack_hand_with_interaction_checks(user)
 				else
 					M.attackby(I, user)
 			return FALSE

--- a/code/modules/multiz/ladder.dm
+++ b/code/modules/multiz/ladder.dm
@@ -134,8 +134,11 @@
 		I.forceMove(landing)
 		landing.visible_message(SPAN_DANGER("\The [I] falls from the top of \the [target_down]!"))
 
-/obj/structure/ladder/attack_hand(var/mob/M)
-	climb(M)
+/obj/structure/ladder/attack_hand(var/mob/user)
+	if(user.a_intent == I_HURT || !user.check_dexterity(DEXTERITY_SIMPLE_MACHINES))
+		return ..()
+	climb(user)
+	return TRUE
 
 /obj/structure/ladder/attack_ai(var/mob/M)
 	var/mob/living/silicon/ai/ai = M

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -2,7 +2,7 @@
 /proc/shared_open_turf_attackhand(var/turf/target, var/mob/user)
 	for(var/atom/movable/M in target.below)
 		if(M.movable_flags & MOVABLE_FLAG_Z_INTERACT)
-			return M.attack_hand(user)
+			return M.attack_hand_with_interaction_checks(user)
 
 /proc/shared_open_turf_attackby(var/turf/target, obj/item/thing, mob/user)
 

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -107,6 +107,7 @@
 	return shared_open_turf_attackby(src, C, user)
 
 /turf/simulated/open/attack_hand(mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	return shared_open_turf_attackhand(src, user)
 
 //Most things use is_plating to test if there is a cover tile on top (like regular floors)
@@ -155,6 +156,7 @@
 	return shared_open_turf_attackby(src, C, user)
 
 /turf/exterior/open/attack_hand(mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	return shared_open_turf_attackhand(src, user)
 
 /turf/exterior/open/cannot_build_cable()

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -154,7 +154,9 @@
 	to_chat(user, SPAN_NOTICE("\The [src] is too far away."))
 
 /atom/movable/openspace/mimic/attack_hand(mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	to_chat(user, SPAN_NOTICE("You cannot reach \the [src] from here."))
+	return TRUE
 
 /atom/movable/openspace/mimic/examine(...)
 	SHOULD_CALL_PARENT(FALSE)
@@ -186,7 +188,8 @@
 	loc.attackby(W, user)
 
 /atom/movable/openspace/turf_proxy/attack_hand(mob/user as mob)
-	loc.attack_hand(user)
+	SHOULD_CALL_PARENT(FALSE)
+	return loc.attack_hand(user)
 
 /atom/movable/openspace/turf_proxy/attack_generic(mob/user as mob)
 	loc.attack_generic(user)
@@ -213,7 +216,9 @@
 	loc.attackby(W, user)
 
 /atom/movable/openspace/turf_mimic/attack_hand(mob/user as mob)
+	SHOULD_CALL_PARENT(FALSE)
 	to_chat(user, SPAN_NOTICE("You cannot reach \the [src] from here."))
+	return TRUE
 
 /atom/movable/openspace/turf_mimic/attack_generic(mob/user as mob)
 	to_chat(user, SPAN_NOTICE("You cannot reach \the [src] from here."))

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -47,6 +47,7 @@
 	show_browser(user, "<html><head><title>[name]</title></head><body>[dat]</body></html>", "window=filingcabinet;size=350x300")
 
 /obj/structure/filing_cabinet/attack_hand(mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	return interact(user)
 
 /obj/structure/filing_cabinet/OnTopic(mob/user, href_list, datum/topic_state/state)

--- a/code/modules/paperwork/paper_sticky.dm
+++ b/code/modules/paperwork/paper_sticky.dm
@@ -58,19 +58,19 @@
 /obj/item/sticky_pad/attack_hand(var/mob/user)
 	if(user.a_intent == I_GRAB)
 		return ..()
-	else if(top)
-		user.put_in_active_hand(top)
-		top = null
-		papers--
-		update_top_paper()
-		to_chat(user, SPAN_NOTICE("You pull \the [top] off \the [src]."))
-
-		if(papers <= 0)
-			qdel(src)
-		else
-			update_top_paper()
-			update_icon()
+	if(!top)
 		return TRUE
+	user.put_in_active_hand(top)
+	top = null
+	papers--
+	update_top_paper()
+	to_chat(user, SPAN_NOTICE("You pull \the [top] off \the [src]."))
+	if(papers <= 0)
+		qdel(src)
+	else
+		update_top_paper()
+		update_icon()
+	return TRUE
 
 /**Creates the paper the user can write on, if there's any paper left. */
 /obj/item/sticky_pad/proc/update_top_paper()

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -37,7 +37,7 @@
 		return ..()
 
 	if(LAZYLEN(papers) < 1 && amount < 1)
-		to_chat(user, SPAN_WARNING("[src] is empty!"))
+		to_chat(user, SPAN_WARNING("\The [src] is empty!"))
 		return TRUE
 
 	var/obj/item/paper/P

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -29,6 +29,10 @@
 
 /obj/item/paper_bin/attack_hand(mob/user)
 
+	// This is required due to the mousedrop code calling attack_hand directly.
+	if(!CanPhysicallyInteract(user))
+		return FALSE
+
 	if(user.a_intent == I_HURT || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
 		return ..()
 

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -28,20 +28,13 @@
 	. = ..()
 
 /obj/item/paper_bin/attack_hand(mob/user)
-	if(!Adjacent(user))
-		to_chat(user, SPAN_WARNING("You're too far!"))
-		return
 
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		var/obj/item/organ/external/temp = GET_EXTERNAL_ORGAN(H, H.get_active_held_item_slot())
-		if(temp && !temp.is_usable())
-			to_chat(user, SPAN_NOTICE("You try to move your [temp.name], but cannot!"))
-			return
+	if(user.a_intent == I_HURT || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
 
 	if(LAZYLEN(papers) < 1 && amount < 1)
 		to_chat(user, SPAN_WARNING("[src] is empty!"))
-		return
+		return TRUE
 
 	var/obj/item/paper/P
 	if(LAZYLEN(papers) > 0)	//If there's any custom paper on the stack, use that instead of creating a new paper.
@@ -74,7 +67,7 @@
 	amount--
 	update_icon()
 	add_fingerprint(user)
-	return
+	return TRUE
 
 /obj/item/paper_bin/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/paper))

--- a/code/modules/paperwork/printer.dm
+++ b/code/modules/paperwork/printer.dm
@@ -73,9 +73,9 @@
 	. = ..()
 
 /obj/item/stock_parts/printer/attack_hand(mob/user)
-	if(toner && istype(loc, /obj/machinery))
+	if(toner && istype(loc, /obj/machinery) && user.check_dexterity(DEXTERITY_GRIP, TRUE))
 		return remove_toner(user)
-	. = ..()
+	return ..()
 
 /obj/item/stock_parts/printer/attack_self(mob/user)
 	if(toner)

--- a/code/modules/persistence/noticeboards.dm
+++ b/code/modules/persistence/noticeboards.dm
@@ -82,6 +82,8 @@
 	return TRUE
 
 /obj/structure/noticeboard/attack_hand(var/mob/user)
+	if(user.a_intent == I_HURT)
+		return ..()
 	interact(user)
 	return TRUE
 

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -22,6 +22,7 @@
 	. = ..()
 
 /obj/effect/containment_field/attack_hand(mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	return shock(user)
 
 /obj/effect/containment_field/explosion_act(severity)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -299,6 +299,7 @@ var/global/list/singularities = list()
 
 // Various overrides used to consume things interacting with the singularity.
 /obj/effect/singularity/attack_hand(mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	consume(user)
 	return TRUE
 

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -211,10 +211,6 @@ var/global/list/solars_list = list()
 	var/glass_type
 	var/glass_reinforced
 
-/obj/item/solar_assembly/attack_hand(var/mob/user)
-	if(!anchored && isturf(loc)) // You can't pick it up
-		..()
-
 // Give back the glass type we were supplied with
 /obj/item/solar_assembly/proc/give_glass()
 	if(glass_type)

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -196,18 +196,20 @@
 
 
 /obj/item/ammo_magazine/attack_hand(mob/user)
-	if(user.is_holding_offhand(src))
-		if(!stored_ammo.len)
-			to_chat(user, "<span class='notice'>[src] is already empty!</span>")
-		else
-			var/obj/item/ammo_casing/C = stored_ammo[stored_ammo.len]
-			stored_ammo-=C
-			user.put_in_hands(C)
-			user.visible_message("\The [user] removes \a [C] from [src].", "<span class='notice'>You remove \a [C] from [src].</span>")
-			update_icon()
-	else
-		..()
-		return
+	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	if(!stored_ammo.len)
+		to_chat(user, SPAN_NOTICE("\The [src] is already empty!"))
+		return TRUE
+	var/obj/item/ammo_casing/C = stored_ammo[stored_ammo.len]
+	stored_ammo-=C
+	user.put_in_hands(C)
+	user.visible_message(
+		"\The [user] removes \a [C] from [src].",
+		SPAN_NOTICE("You remove \a [C] from [src].")
+	)
+	update_icon()
+	return TRUE
 
 /obj/item/ammo_magazine/on_update_icon()
 	. = ..()

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -62,14 +62,17 @@
 		overlays += I
 
 /obj/item/ammo_magazine/shotholder/attack_hand(mob/user)
-	if((user.a_intent == I_HURT) && (stored_ammo.len))
-		var/obj/item/ammo_casing/C = stored_ammo[stored_ammo.len]
-		stored_ammo-=C
-		user.put_in_hands(C)
-		user.visible_message("\The [user] removes \a [C] from [src].", "<span class='notice'>You remove \a [C] from [src].</span>")
-		update_icon()
-	else
-		..()
+	if(loc != user || !length(stored_ammo) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	var/obj/item/ammo_casing/C = stored_ammo[stored_ammo.len]
+	stored_ammo-=C
+	user.put_in_hands(C)
+	user.visible_message(
+		"\The [user] removes \a [C] from [src].",
+		SPAN_NOTICE("You remove \a [C] from [src].")
+	)
+	update_icon()
+	return TRUE
 
 /obj/item/ammo_magazine/shotholder/shell
 	name = "shotgun shell holder"

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -62,10 +62,10 @@
 		overlays += I
 
 /obj/item/ammo_magazine/shotholder/attack_hand(mob/user)
-	if(loc != user || !length(stored_ammo) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(loc != user || user.a_intent != I_HURT || !length(stored_ammo) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
 		return ..()
 	var/obj/item/ammo_casing/C = stored_ammo[stored_ammo.len]
-	stored_ammo-=C
+	stored_ammo -= C
 	user.put_in_hands(C)
 	user.visible_message(
 		"\The [user] removes \a [C] from [src].",

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -145,13 +145,14 @@ var/global/list/registered_cyborg_weapons = list()
 
 //For removable cells.
 /obj/item/gun/energy/attack_hand(mob/user)
-	if(!user.is_holding_offhand(src)|| isnull(accepts_cell_type) || isnull(power_supply) )
+	if(!user.is_holding_offhand(src) || isnull(accepts_cell_type) || isnull(power_supply) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
 		return ..()
 	user.put_in_hands(power_supply)
 	power_supply = null
 	user.visible_message(SPAN_NOTICE("\The [user] unloads \the [src]."))
 	playsound(src,'sound/weapons/guns/interaction/smg_magout.ogg' , 50)
 	update_icon()
+	return TRUE
 
 /obj/item/gun/energy/attackby(var/obj/item/A, mob/user)
 

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -85,10 +85,10 @@
 		..()
 
 /obj/item/gun/launcher/grenade/attack_hand(mob/user)
-	if(user.is_holding_offhand(src))
-		unload(user)
-	else
-		..()
+	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	unload(user)
+	return TRUE
 
 /obj/item/gun/launcher/grenade/consume_next_projectile()
 	if(chambered)

--- a/code/modules/projectiles/guns/launcher/money_cannon.dm
+++ b/code/modules/projectiles/guns/launcher/money_cannon.dm
@@ -106,10 +106,10 @@
 	to_chat(user, "<span class='notice'>You set [src] to dispense [dispensing] [cur.name_singular] at a time.</span>")
 
 /obj/item/gun/launcher/money/attack_hand(mob/user)
-	if(user.is_holding_offhand(src))
-		unload_receptacle(user)
-	else
+	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
 		return ..()
+	unload_receptacle(user)
+	return TRUE
 
 /obj/item/gun/launcher/money/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/cash/))

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -60,10 +60,10 @@
 		to_chat(user, "There is nothing to remove in \the [src].")
 
 /obj/item/gun/launcher/pneumatic/attack_hand(mob/user)
-	if(user.is_holding_offhand(src))
-		unload_hopper(user)
-	else
+	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
 		return ..()
+	unload_hopper(user)
+	return TRUE
 
 /obj/item/gun/launcher/pneumatic/attackby(obj/item/W, mob/user)
 	if(!tank && istype(W,/obj/item/tank) && user.try_unequip(W, src))

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -103,19 +103,22 @@
 	add_fingerprint(user)
 
 /obj/item/gun/launcher/syringe/attack_hand(mob/user)
-	if(user.is_holding_offhand(src))
-		if(!darts.len)
-			to_chat(user, "<span class='warning'>[src] is empty.</span>")
-			return
-		if(next)
-			to_chat(user, "<span class='warning'>[src]'s cover is locked shut.</span>")
-			return
-		var/obj/item/syringe_cartridge/C = darts[1]
-		darts -= C
-		user.put_in_hands(C)
-		user.visible_message("[user] removes \a [C] from [src].", "<span class='notice'>You remove \a [C] from [src].</span>")
-	else
-		..()
+	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	if(!darts.len)
+		to_chat(user, SPAN_WARNING("\The [src] is empty."))
+		return TRUE
+	if(next)
+		to_chat(user, SPAN_WARNING("\The [src]'s cover is locked shut."))
+		return TRUE
+	var/obj/item/syringe_cartridge/C = darts[1]
+	darts -= C
+	user.put_in_hands(C)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] removes \a [C] from \the [src]."),
+		SPAN_NOTICE("You remove \a [C] from \the [src].")
+	)
+	return TRUE
 
 /obj/item/gun/launcher/syringe/attackby(var/obj/item/A, mob/user)
 	if(istype(A, /obj/item/syringe_cartridge))

--- a/code/modules/projectiles/guns/magnetic/magnetic.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic.dm
@@ -190,23 +190,21 @@
 	. = ..()
 
 /obj/item/gun/magnetic/attack_hand(var/mob/user)
-	if(user.is_holding_offhand(src))
-		var/obj/item/removing
-
-		if(loaded)
-			removing = loaded
-			loaded = null
-		else if(cell && removable_components)
-			removing = cell
-			cell = null
-
-		if(removing)
-			user.put_in_hands(removing)
-			user.visible_message("<span class='notice'>\The [user] removes \the [removing] from \the [src].</span>")
-			playsound(loc, 'sound/machines/click.ogg', 10, 1)
-			update_icon()
-			return
-	. = ..()
+	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	var/obj/item/removing
+	if(loaded)
+		removing = loaded
+		loaded = null
+	else if(cell && removable_components)
+		removing = cell
+		cell = null
+	if(removing)
+		user.put_in_hands(removing)
+		user.visible_message(SPAN_NOTICE("\The [user] removes \the [removing] from \the [src]."))
+		playsound(loc, 'sound/machines/click.ogg', 10, 1)
+		update_icon()
+	return TRUE
 
 /obj/item/gun/magnetic/proc/check_ammo()
 	return loaded

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -224,10 +224,10 @@
 		to_chat(user, SPAN_WARNING("You can't unload \the [src] manually. Maybe try a crowbar?"))
 
 /obj/item/gun/projectile/attack_hand(mob/user)
-	if(user.is_holding_offhand(src) && manual_unload)
-		unload_ammo(user, allow_dump=0)
-	else
+	if(!user.is_holding_offhand(src) || !manual_unload || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
 		return ..()
+	unload_ammo(user, allow_dump=0)
+	return TRUE
 
 /obj/item/gun/projectile/afterattack(atom/A, mob/living/user)
 	..()

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -105,10 +105,10 @@
 		..()
 
 /obj/item/gun/projectile/automatic/assault_rifle/grenade/attack_hand(mob/user)
-	if(user.is_holding_offhand(src) && use_launcher)
-		launcher.unload(user)
-	else
-		..()
+	if(!user.is_holding_offhand(src) || !use_launcher || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	launcher.unload(user)
+	return TRUE
 
 /obj/item/gun/projectile/automatic/assault_rifle/grenade/Fire(atom/target, mob/living/user, params, pointblank=0, reflex=0)
 	if(use_launcher)

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -37,14 +37,14 @@
 	allowed_magazines = /obj/item/ammo_magazine/pistol/small
 
 /obj/item/gun/projectile/pistol/holdout/attack_hand(mob/user)
-	if(silenced && user.is_holding_offhand(src))
-		to_chat(user, SPAN_NOTICE("You unscrew \the [silenced] from \the [src]."))
-		user.put_in_hands(silenced)
-		silenced = initial(silenced)
-		w_class = initial(w_class)
-		update_icon()
-		return
-	..()
+	if(!silenced || !user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_COMPLEX_TOOLS, TRUE))
+		return ..()
+	to_chat(user, SPAN_NOTICE("You unscrew \the [silenced] from \the [src]."))
+	user.put_in_hands(silenced)
+	silenced = initial(silenced)
+	w_class = initial(w_class)
+	update_icon()
+	return TRUE
 
 /obj/item/gun/projectile/pistol/holdout/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/silencer))

--- a/code/modules/random_map/drop/droppod_doors.dm
+++ b/code/modules/random_map/drop/droppod_doors.dm
@@ -34,15 +34,15 @@
 
 	if(user)
 		to_chat(user, SPAN_DANGER("You prime the explosive bolts. Better get clear!"))
+	deployed = TRUE
 
 	if(delay)
 		sleep(delay)
 
-	if(deployed || QDELETED(src))
+	if(QDELETED(src))
 		return
 
-	deployed = 1
-	visible_message("<span class='danger'>The explosive bolts on \the [src] detonate, throwing it open!</span>")
+	visible_message(SPAN_DANGER("The explosive bolts on \the [src] detonate, throwing it open!"))
 	playsound(src.loc, 'sound/effects/bang.ogg', 50, 1, 5)
 
 	// This is shit but it will do for the sake of testing.

--- a/code/modules/random_map/drop/droppod_doors.dm
+++ b/code/modules/random_map/drop/droppod_doors.dm
@@ -13,8 +13,7 @@
 /obj/structure/droppod_door/Initialize(mapload, var/autoopen)
 	. = ..(mapload)
 	if(autoopen)
-		spawn(10 SECONDS)
-			deploy()
+		deploy(null, 10 SECONDS)
 
 /obj/structure/droppod_door/attack_ai(var/mob/user)
 	if(!user.Adjacent(src))
@@ -22,13 +21,24 @@
 	attack_hand(user)
 
 /obj/structure/droppod_door/attack_hand(var/mob/user)
-	if(deploying) return
-	to_chat(user, "<span class='danger'>You prime the explosive bolts. Better get clear!</span>")
-	sleep(30)
-	deploy()
+	if(deploying)
+		return ..()
+	deploy(user, 3 SECONDS)
+	return TRUE
 
-/obj/structure/droppod_door/proc/deploy()
+/obj/structure/droppod_door/proc/deploy(var/mob/user, var/delay)
+	set waitfor = FALSE
+
 	if(deployed)
+		return
+
+	if(user)
+		to_chat(user, SPAN_DANGER("You prime the explosive bolts. Better get clear!"))
+
+	if(delay)
+		sleep(delay)
+
+	if(deployed || QDELETED(src))
 		return
 
 	deployed = 1
@@ -39,7 +49,7 @@
 	for(var/obj/structure/droppod_door/D in orange(1,src))
 		if(D.deployed)
 			continue
-		D.deploy()
+		D.deploy(null, 0)
 
 	// Overwrite turfs.
 	var/turf/origin = get_turf(src)

--- a/code/modules/random_map/drop/droppod_doors.dm
+++ b/code/modules/random_map/drop/droppod_doors.dm
@@ -16,9 +16,7 @@
 		deploy(null, 10 SECONDS)
 
 /obj/structure/droppod_door/attack_ai(var/mob/user)
-	if(!user.Adjacent(src))
-		return
-	attack_hand(user)
+	return attack_hand_with_interaction_checks(user)
 
 /obj/structure/droppod_door/attack_hand(var/mob/user)
 	if(deploying)

--- a/code/modules/reagents/reagent_containers/beaker.dm
+++ b/code/modules/reagents/reagent_containers/beaker.dm
@@ -17,19 +17,19 @@
 	to_chat(user, " It can hold up to [volume] units.")
 
 /obj/item/chems/glass/beaker/on_picked_up(mob/user)
-	..()
+	. = ..()
 	update_icon()
 
 /obj/item/chems/glass/beaker/dropped(mob/user)
-	..()
+	. = ..()
 	update_icon()
 
 /obj/item/chems/glass/beaker/attack_hand()
-	..()
+	. = ..()
 	update_icon()
 
 /obj/item/chems/glass/beaker/on_update_icon()
-	..()
+	. = ..()
 	cut_overlays()
 
 	if(reagents?.total_volume)

--- a/code/modules/reagents/reagent_containers/drinkingglass/extras.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/extras.dm
@@ -26,24 +26,22 @@
 		return ..()
 
 /obj/item/chems/drinks/glass2/attack_hand(mob/user)
-	if(!user.is_holding_offhand(src))
+	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
 		return ..()
 
 	if(!extras.len)
-		to_chat(user, "<span class=warning>There's nothing on the glass to remove!</span>")
-		return
+		to_chat(user, SPAN_WARNING("There's nothing on the glass to remove!"))
+		return TRUE
 
 	var/choice = input(user, "What would you like to remove from the glass?") as null|anything in extras
 	if(!choice || !(choice in extras))
-		return
+		return TRUE
 
-	if(user.put_in_active_hand(choice))
-		to_chat(user, "<span class=notice>You remove \the [choice] from \the [src].</span>")
-		extras -= choice
-	else
-		to_chat(user, "<span class=warning>Something went wrong, please try again.</span>")
-
+	user.put_in_active_hand(choice)
+	to_chat(user, SPAN_NOTICE("You remove \the [choice] from \the [src]."))
+	extras -= choice
 	update_icon()
+	return TRUE
 
 /obj/item/glass_extra
 	name = "generic glass addition"

--- a/code/modules/reagents/reagent_containers/food/sliceable/pizza.dm
+++ b/code/modules/reagents/reagent_containers/food/sliceable/pizza.dm
@@ -188,26 +188,23 @@
 
 /obj/item/pizzabox/attack_hand(mob/user)
 
-	if( open && pizza )
-		user.put_in_hands( pizza )
-
-		to_chat(user, "<span class='warning'>You take \the [src.pizza] out of \the [src].</span>")
-		src.pizza = null
-		update_icon()
+	if(open && pizza)
+		if(user.check_dexterity(DEXTERITY_GRIP))
+			user.put_in_hands(pizza)
+			to_chat(user, SPAN_NOTICE("You take \the [src.pizza] out of \the [src]."))
+			pizza = null
+			update_icon()
 		return TRUE
 
-	if( boxes.len > 0 )
-		if(!user.is_holding_offhand(src))
-			return ..()
-
+	if(length(boxes) && user.is_holding_offhand(src) && user.check_dexterity(DEXTERITY_GRIP))
 		var/obj/item/pizzabox/box = boxes[boxes.len]
 		boxes -= box
-
-		user.put_in_hands( box )
-		to_chat(user, "<span class='warning'>You remove the topmost [src] from your hand.</span>")
+		user.put_in_hands(box)
+		to_chat(user, SPAN_WARNING("You remove the topmost [src] from your hand."))
 		box.update_icon()
 		update_icon()
 		return TRUE
+
 	return ..()
 
 /obj/item/pizzabox/attack_self(mob/user)

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -23,19 +23,19 @@
 	var/autolabel = TRUE  		// if set, will add label with the name of the first initial reagent
 
 /obj/item/chems/glass/bottle/on_picked_up(mob/user)
-	..()
+	. = ..()
 	update_icon()
 
 /obj/item/chems/glass/bottle/dropped(mob/user)
-	..()
+	. = ..()
 	update_icon()
 
 /obj/item/chems/glass/bottle/attack_hand()
-	..()
+	. = ..()
 	update_icon()
 
 /obj/item/chems/glass/bottle/on_update_icon()
-	..()
+	. = ..()
 	cut_overlays()
 
 	if(reagents?.total_volume)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -142,13 +142,13 @@
 	return TRUE
 
 /obj/item/chems/hypospray/vial/attack_hand(mob/user)
-	if(user.is_holding_offhand(src))
-		if(!loaded_vial)
-			to_chat(user, SPAN_NOTICE("There is no vial loaded in the [src]."))
-			return
+	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	if(!loaded_vial)
+		to_chat(user, SPAN_NOTICE("There is no vial loaded in \the [src]."))
+	else
 		remove_vial(user)
-		return TRUE
-	return ..()
+	return TRUE
 
 /obj/item/chems/hypospray/vial/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/chems/glass/beaker/vial))

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -31,14 +31,15 @@
 	update_icon()
 
 /obj/item/chems/syringe/on_reagent_change()
+	. = ..()
 	update_icon()
 
 /obj/item/chems/syringe/on_picked_up(mob/user)
-	..()
+	. = ..()
 	update_icon()
 
 /obj/item/chems/syringe/dropped(mob/user)
-	..()
+	. = ..()
 	update_icon()
 
 /obj/item/chems/syringe/attack_self(mob/user)
@@ -52,7 +53,7 @@
 	update_icon()
 
 /obj/item/chems/syringe/attack_hand()
-	..()
+	. = ..()
 	update_icon()
 
 /obj/item/chems/syringe/attackby(obj/item/I, mob/user)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -159,13 +159,16 @@
 		to_chat(user, SPAN_WARNING("There is some kind of device rigged to the tank."))
 
 /obj/structure/reagent_dispensers/fueltank/attack_hand(var/mob/user)
-	if (rig)
-		visible_message(SPAN_NOTICE("\The [user] begins to detach \the [rig] from \the [src]."))
-		if(user.do_skilled(2 SECONDS, SKILL_ELECTRICAL, src))
-			visible_message(SPAN_NOTICE("\The [user] detaches \the [rig] from \the [src]."))
-			rig.dropInto(loc)
-			rig = null
-			update_icon()
+	if (!rig || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	visible_message(SPAN_NOTICE("\The [user] begins to detach \the [rig] from \the [src]."))
+	if(!user.do_skilled(2 SECONDS, SKILL_ELECTRICAL, src))
+		return TRUE
+	visible_message(SPAN_NOTICE("\The [user] detaches \the [rig] from \the [src]."))
+	rig.dropInto(loc)
+	rig = null
+	update_icon()
+	return TRUE
 
 /obj/structure/reagent_dispensers/fueltank/attackby(obj/item/W, mob/user)
 	add_fingerprint(user)
@@ -248,7 +251,9 @@
 	reagents.add_reagent(/decl/material/liquid/water, reagents.maximum_volume)
 
 /obj/structure/reagent_dispensers/water_cooler/attack_hand(var/mob/user)
-	return dispense_cup(user)
+	if(user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return dispense_cup(user)
+	return ..()
 
 /obj/structure/reagent_dispensers/water_cooler/proc/dispense_cup(var/mob/user, var/skip_text = FALSE)
 	if(cups > 0)

--- a/code/modules/recycling/wrapped_package.dm
+++ b/code/modules/recycling/wrapped_package.dm
@@ -173,9 +173,9 @@
 	unwrap(user)
 
 /obj/item/parcel/attack_hand(mob/user)
-	//Prevent picking up furnitures and human mobs
-	if(w_class < ITEM_SIZE_NO_CONTAINER)
-		. = ..()
+	if(w_class >= ITEM_SIZE_NO_CONTAINER)
+		return TRUE
+	return ..()
 
 /obj/item/parcel/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/destTagger))

--- a/code/modules/sealant_gun/sealant.dm
+++ b/code/modules/sealant_gun/sealant.dm
@@ -32,6 +32,7 @@
 		hardened = TRUE
 
 /obj/item/clothing/sealant/attack_hand(mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	break_apart(user)
 	return TRUE
 

--- a/code/modules/sealant_gun/sealant_gun.dm
+++ b/code/modules/sealant_gun/sealant_gun.dm
@@ -46,10 +46,10 @@
 	. = ..()
 
 /obj/item/gun/launcher/sealant/attack_hand(mob/user)
-	if((src in user.get_held_items()) && loaded_tank)
-		unload_tank(user)
-		return TRUE
-	. = ..()
+	if(!(src in user.get_held_items()) || !loaded_tank || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
+	unload_tank(user)
+	return TRUE
 
 /obj/item/gun/launcher/sealant/examine(mob/user, distance)
 	. = ..()

--- a/code/modules/sealant_gun/sealant_injector.dm
+++ b/code/modules/sealant_gun/sealant_injector.dm
@@ -79,14 +79,14 @@
 		playsound(loc, 'sound/effects/refill.ogg', 50, 1)
 
 /obj/structure/sealant_injector/attack_hand(mob/user)
-
+	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
 	if(loaded_tank)
 		loaded_tank.dropInto(get_turf(src))
 		user.put_in_hands(loaded_tank)
 		loaded_tank = null
 		update_icon()
 		return TRUE
-
 	if(length(cartridges))
 		var/obj/cartridge = pick(cartridges)
 		cartridges -= cartridge
@@ -94,8 +94,7 @@
 		user.put_in_hands(cartridge)
 		update_icon()
 		return TRUE
-
-	. = ..()
+	return ..()
 
 /obj/structure/sealant_injector/get_alt_interactions(var/mob/user)
 	. = ..()

--- a/code/modules/sealant_gun/sealant_rack.dm
+++ b/code/modules/sealant_gun/sealant_rack.dm
@@ -27,14 +27,14 @@
 		add_overlay("tanks[length(tanks)]")
 
 /obj/structure/sealant_rack/attack_hand(mob/user)
-
+	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+		return ..()
 	if(loaded_gun)
 		loaded_gun.dropInto(loc)
 		user.put_in_hands(loaded_gun)
 		loaded_gun = null
 		update_icon()
 		return TRUE
-
 	if(length(tanks))
 		var/obj/tank = tanks[length(tanks)]
 		LAZYREMOVE(tanks, tank)
@@ -42,8 +42,7 @@
 		user.put_in_hands(tank)
 		update_icon()
 		return TRUE
-
-	. = ..()
+	return ..()
 
 /obj/structure/sealant_rack/attackby(obj/item/O, mob/user)
 

--- a/code/modules/security levels/keycard_authentication.dm
+++ b/code/modules/security levels/keycard_authentication.dm
@@ -111,7 +111,7 @@
 		. = TOPIC_REFRESH
 
 	if(. == TOPIC_REFRESH)
-		attack_hand(user)
+		attack_hand_with_interaction_checks(user)
 
 /obj/machinery/keycard_auth/proc/reset()
 	active = 0

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -334,4 +334,4 @@
 
 /obj/effect/shield/attack_hand(var/mob/user)
 	impact_effect(3) // Harmless, but still produces the 'impact' effect.
-	..()
+	return ..()

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -223,7 +223,7 @@
 
 /obj/machinery/shield_generator/attackby(obj/item/O, mob/user)
 	if(panel_open && (IS_MULTITOOL(O) || IS_WIRECUTTER(O)))
-		attack_hand(user)
+		attack_hand_with_interaction_checks(user)
 		return TRUE
 	return component_attackby(O, user)
 

--- a/code/modules/species/outsider/random.dm
+++ b/code/modules/species/outsider/random.dm
@@ -152,20 +152,21 @@
 	anchored = 1
 
 /obj/structure/aliumizer/attack_hand(mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	if(!ishuman(user))
 		to_chat(user, SPAN_WARNING("You've got no business touching this."))
-		return
+		return TRUE
 	var/decl/species/species = user.get_species()
 	if(!species)
-		return
+		return TRUE
 	if(species.name == SPECIES_ALIEN)
 		to_chat(user, SPAN_WARNING("You're already a [SPECIES_ALIEN]."))
-		return
+		return TRUE
 	if(alert("Are you sure you want to be an alien?", "Mom Look I'm An Alien!", "Yes", "No") == "No")
 		to_chat(user, SPAN_NOTICE("<b>You are now a [SPECIES_ALIEN]!</b>"))
-		return
+		return TRUE
 	if(species.name == SPECIES_ALIEN) //no spamming it to get free implants
-		return
+		return TRUE
 	to_chat(user, "You're now an alien humanoid of some undiscovered species. Make up what lore you want, no one knows a thing about your species! You can check info about your traits with Check Species Info verb in IC tab.")
 	to_chat(user, "You can't speak any other languages by default. You can use translator implant that spawns on top of this monolith - it will give you knowledge of any language if you hear it enough times.")
 	var/mob/living/carbon/human/H = user
@@ -174,3 +175,4 @@
 	var/decl/cultural_info/culture = H.get_cultural_value(TAG_CULTURE)
 	H.fully_replace_character_name(culture.get_random_name(H, H.gender))
 	H.rename_self("Humanoid Alien", 1)
+	return TRUE

--- a/code/modules/spells/artifacts/spellbound_servants.dm
+++ b/code/modules/spells/artifacts/spellbound_servants.dm
@@ -207,13 +207,15 @@
 	stype = new spell_type()
 
 /obj/effect/cleanable/spellbound/attack_hand(var/mob/user)
-	if(last_called > world.time )
-		return
+	SHOULD_CALL_PARENT(FALSE)
+	if(last_called > world.time)
+		return TRUE
 	last_called = world.time + 30 SECONDS
 	var/decl/ghosttrap/G = GET_DECL(/decl/ghosttrap/wizard_familiar)
 	for(var/mob/observer/ghost/ghost in global.player_list)
 		if(G.assess_candidate(ghost,null,FALSE))
-			to_chat(ghost,"<span class='notice'><b>A wizard is requesting a Spell-Bound Servant!</b></span> (<a href='?src=\ref[src];master=\ref[user]'>Join</a>)")
+			to_chat(ghost, "[SPAN_NOTICE("<b>A wizard is requesting a Spell-Bound Servant!</b>")] (<a href='?src=\ref[src];master=\ref[user]'>Join</a>)")
+	return TRUE
 
 /obj/effect/cleanable/spellbound/CanUseTopic(var/mob)
 	if(isliving(mob))

--- a/code/modules/spells/general/mark_recall.dm
+++ b/code/modules/spells/general/mark_recall.dm
@@ -70,10 +70,11 @@
 	..()
 
 /obj/effect/cleanable/wizard_mark/attack_hand(var/mob/user)
-	if(user == spell.holder)
-		user.visible_message("\The [user] mutters an incantation and \the [src] disappears!")
-		qdel(src)
-	..()
+	if(user != spell.holder)
+		return ..()
+	user.visible_message("\The [user] mutters an incantation and \the [src] disappears!")
+	qdel(src)
+	return TRUE
 
 /obj/effect/cleanable/wizard_mark/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/nullrod) || istype(I, /obj/item/spellbook))

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -582,16 +582,16 @@ var/global/list/supermatter_delam_accent_sounds = list(
 	return 0
 
 /obj/machinery/power/supermatter/attack_robot(mob/user)
-	if(CanPhysicallyInteract(user))
-		return attack_hand(user)
 	ui_interact(user)
 	return TRUE
 
 /obj/machinery/power/supermatter/attack_ai(mob/living/silicon/ai/user)
 	ui_interact(user)
+	return TRUE
 
 /obj/machinery/power/supermatter/attack_ghost(mob/user)
 	ui_interact(user)
+	return TRUE
 
 /obj/machinery/power/supermatter/attack_hand(mob/user)
 	return Consume(null, user, TRUE) || ..()

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -594,9 +594,7 @@ var/global/list/supermatter_delam_accent_sounds = list(
 	ui_interact(user)
 
 /obj/machinery/power/supermatter/attack_hand(mob/user)
-	if(Consume(null, user, TRUE))
-		return TRUE
-	return ..()
+	return Consume(null, user, TRUE) || ..()
 
 // This is purely informational UI that may be accessed by AIs or robots
 /obj/machinery/power/supermatter/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)

--- a/code/modules/synthesized_instruments/real_instruments.dm
+++ b/code/modules/synthesized_instruments/real_instruments.dm
@@ -223,8 +223,9 @@
 
 
 /obj/structure/synthesized_instrument/attack_hand(mob/user)
-	src.interact(user)
-
+	SHOULD_CALL_PARENT(FALSE)
+	interact(user)
+	return TRUE
 
 /obj/structure/synthesized_instrument/interact(mob/user) // CONDITIONS ..(user) that shit in subclasses
 	src.ui_interact(user)

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -26,6 +26,7 @@
 	return attack_hand(user)
 
 /obj/structure/lift/attack_hand(var/mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	return interact(user)
 
 /obj/structure/lift/interact(var/mob/user)

--- a/code/modules/vehicles/bike.dm
+++ b/code/modules/vehicles/bike.dm
@@ -132,9 +132,11 @@
 		return TRUE
 
 /obj/vehicle/bike/attack_hand(var/mob/user)
-	if(user == load)
-		unload(load)
-		to_chat(user, "You unbuckle yourself from \the [src].")
+	if(user != load)
+		return ..()
+	unload(load)
+	to_chat(user, "You unbuckle yourself from \the [src].")
+	return TRUE
 
 /obj/vehicle/bike/relaymove(mob/user, direction)
 	if(user != load || !on)

--- a/code/modules/vehicles/train.dm
+++ b/code/modules/vehicles/train.dm
@@ -118,17 +118,14 @@
 		return TRUE
 
 /obj/vehicle/train/attack_hand(mob/user)
-	if(user.stat || user.restrained() || !Adjacent(user))
-		return 0
-
+	SHOULD_CALL_PARENT(FALSE)
 	if(user != load && (user in src))
-		user.forceMove(loc)			//for handling players stuck in src
+		user.forceMove(loc)
 	else if(load)
-		unload(user)			//unload if loaded
+		unload(user)
 	else if(!load && !user.buckled)
-		load(user)				//else try climbing on board
-	else
-		return 0
+		load(user)
+	return TRUE
 
 /obj/vehicle/train/verb/unlatch_v()
 	set name = "Unlatch"

--- a/code/modules/vehicles/train.dm
+++ b/code/modules/vehicles/train.dm
@@ -119,6 +119,8 @@
 
 /obj/vehicle/train/attack_hand(mob/user)
 	SHOULD_CALL_PARENT(FALSE)
+	if(!CanPhysicallyInteract(user))
+		return FALSE
 	if(user != load && (user in src))
 		user.forceMove(loc)
 	else if(load)

--- a/code/modules/xenoarcheaology/tools/anomaly_container.dm
+++ b/code/modules/xenoarcheaology/tools/anomaly_container.dm
@@ -14,6 +14,7 @@
 		contain(A)
 
 /obj/structure/anomaly_container/attack_hand(var/mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	release()
 	return TRUE
 

--- a/code/modules/xenoarcheaology/tools/anomaly_container.dm
+++ b/code/modules/xenoarcheaology/tools/anomaly_container.dm
@@ -19,8 +19,7 @@
 	return TRUE
 
 /obj/structure/anomaly_container/attack_robot(var/mob/user)
-	if(CanPhysicallyInteract(user))
-		return attack_hand(user)
+	return attack_hand_with_interaction_checks(user)
 
 /obj/structure/anomaly_container/proc/contain(var/obj/structure/artifact/artifact)
 	if(contained)

--- a/maps/away/casino/casino.dm
+++ b/maps/away/casino/casino.dm
@@ -94,27 +94,37 @@
 	var/busy=0
 
 /obj/structure/casino/roulette/attack_hand(mob/user)
-	if (busy)
-		to_chat(user,"<span class='notice'>You cannot spin now! \The [src] is already spinning.</span> ")
-		return
-	visible_message("<span class='notice'>\ [user]  spins the roulette and throws inside little ball.</span>")
-	busy = 1
+
+	if(user.a_intent == I_HURT || !user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
+		return ..()
+
+	if(busy)
+		to_chat(user, SPAN_WARNING("\The [src] is already spinning."))
+		return TRUE
+
+	visible_message(SPAN_NOTICE("\The [user] spins \the [src] and tosses the ball inside."))
+	busy = TRUE
 	var/n = rand(0,36)
-	var/color = "green"
+	var/result_color = "green"
 	add_fingerprint(user)
 	if ((n>0 && n<11) || (n>18 && n<29))
 		if (n%2)
-			color="red"
+			result_color="red"
 	else
-		color="black"
+		result_color="black"
 	if ( (n>10 && n<19) || (n>28) )
 		if (n%2)
-			color="black"
+			result_color="black"
 	else
-		color="red"
-	spawn(5 SECONDS)
-		visible_message("<span class='notice'>\The [src] stops spinning, the ball landing on [n], [color].</span>")
-		busy=0
+		result_color="red"
+	announce_result(n, result_color)
+	return TRUE
+
+/obj/structure/casino/roulette/proc/announce_result(n, result_color)
+	set waitfor = FALSE
+	sleep(5 SECONDS)
+	visible_message("<span class='notice'>\The [src] stops spinning, the ball landing on [n], [result_color].</span>")
+	busy = FALSE
 
 /obj/structure/casino/roulette_chart
 	name = "roulette chart"

--- a/maps/away/magshield/magshield.dm
+++ b/maps/away/magshield/magshield.dm
@@ -71,7 +71,7 @@
 		var/area/A = get_area(src)
 		log_game("EMP with size ([heavy_range], [lighter_range]) in area [A.proper_name] ([T.x], [T.y], [T.z])")
 		visible_message(
-			SPAN_DANGER("\the [src] suddenly activates!"),
+			SPAN_DANGER("\The [src] suddenly activates!"),
 			SPAN_DANGER("Electricity arcs between \the [src]'s rotating spokes as a powerful magnetic field tugs on every metallic object nearby.")
 		)
 		for(var/mob/living/carbon/M in hear(10, get_turf(src)))

--- a/maps/away/magshield/magshield.dm
+++ b/maps/away/magshield/magshield.dm
@@ -70,7 +70,10 @@
 		var/turf/T = get_turf(src)
 		var/area/A = get_area(src)
 		log_game("EMP with size ([heavy_range], [lighter_range]) in area [A.proper_name] ([T.x], [T.y], [T.z])")
-		visible_message("<span class='notice'>\the [src] suddenly activates.</span>", "<span class='notice'>Few lightnings jump between [src]'s rotating hands. You feel everything metal being pulled towards \the [src].</span>")
+		visible_message(
+			SPAN_DANGER("\the [src] suddenly activates!"),
+			SPAN_DANGER("Electricity arcs between \the [src]'s rotating spokes as a powerful magnetic field tugs on every metallic object nearby.")
+		)
 		for(var/mob/living/carbon/M in hear(10, get_turf(src)))
 			eye_safety = M.eyecheck()
 			if(eye_safety < FLASH_PROTECTION_MODERATE)
@@ -78,33 +81,36 @@
 				SET_STATUS_MAX(M, STAT_STUN, 2)
 
 /obj/structure/magshield/maggen/attack_hand(mob/user)
-	..()
-	to_chat(user, "<span class='notice'> You don't see how you could turn off \the [src]. You can try to stick something in rotating hands.</span>")
+	SHOULD_CALL_PARENT(FALSE)
+	to_chat(user, SPAN_NOTICE("You don't see how you could turn off \the [src]. You could possibly jam something into the rotating spokes."))
+	return TRUE
 
 /obj/structure/magshield/maggen/attackby(obj/item/W, mob/user)
 	if (being_stopped)
-		to_chat(user, "<span class='notice'> Somebody is already interacting with \the [src].</span>")
-		return
+		to_chat(user, SPAN_WARNING("Somebody is already interacting with \the [src]."))
+		return TRUE
 	if(istype(W, /obj/item/stack/material/rods))
 		var/obj/item/stack/material/rods/R = W
-		to_chat(user, "<span class='notice'> You start to stick [R.singular_name] into rotating hands to make them stuck.</span>")
+		to_chat(user, SPAN_NOTICE("You start to jam \a [R.singular_name] into the rotating spokes."))
 		being_stopped = 1
 		if (!do_after(user, 100, src))
-			to_chat(user, "<span class='notice'> You pull back [R.singular_name].</span>")
+			to_chat(user, SPAN_NOTICE("You pull \the [R.singular_name] away."))
 			being_stopped = 0
-			return
+			return TRUE
 		R.use(1)
-		visible_message("<span class='warning'>\The [src] stops rotating and releases cloud of sparks. Better get to safe distance!</span>")
+		visible_message(SPAN_DANGER("\The [src] stops rotating and releases a cloud of sparks. Better get to a safe distance!"))
 		spark_at(src, amount=10)
 		sleep(50)
-		visible_message("<span class='warning'>\The [src] explodes!</span>")
+		visible_message(SPAN_DANGER("\The [src] explodes!"))
 		var/turf/T = get_turf(src)
 		explosion(T, 2, 3, 4, 10, 1)
 		empulse(src, heavy_range*2, lighter_range*2, 1)
 		qdel(src)
 	if(istype(W, /obj/item/mop))
-		to_chat(user, "<span class='notice'> You stick [W] into rotating hands. It breaks to smallest pieces.</span>")
+		to_chat(user, SPAN_NOTICE("You stick \the [W] into the rotating spokes, and it immediately breaks into tiny pieces."))
 		qdel(W)
+		return TRUE
+	return ..()
 
 /obj/structure/magshield/rad_sensor
 	name = "radiation sensor"

--- a/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
+++ b/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
@@ -45,25 +45,35 @@
 		add_overlay(I)
 
 /obj/structure/monolith/attack_hand(mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	visible_message("\The [user] touches \the [src].")
-	if(istype(user, /mob/living/carbon/human))
-		var/datum/planetoid_data/E = SSmapping.planetoid_data_by_z[z]
-		if(istype(E))
-			var/mob/living/carbon/human/H = user
-			if(!H.isSynthetic())
-				playsound(src, 'sound/effects/zapbeep.ogg', 100, 1)
-				active = 1
-				update_icon()
-				if(prob(70))
-					to_chat(H, SPAN_NOTICE("As you touch \the [src], you suddenly get a vivid image - [E.engraving_generator.generate_engraving_text()]"))
-				else
-					to_chat(H, SPAN_WARNING("An overwhelming stream of information invades your mind!"))
-					to_chat(H, SPAN_DANGER("<font size=2>[uppertext(E.engraving_generator.generate_violent_vision_text())]</font>"))
-					SET_STATUS_MAX(H, STAT_PARA, 2)
-					H.set_hallucination(20, 100)
-				return
-	to_chat(user, "<span class='notice'>\The [src] is still.</span>")
-	return ..()
+
+	if(!iscarbon(user))
+		to_chat(user, SPAN_NOTICE("\The [src] is still."))
+		return TRUE
+
+	var/datum/planetoid_data/E = SSmapping.planetoid_data_by_z[z]
+	if(!istype(E))
+		to_chat(user, SPAN_NOTICE("\The [src] is still."))
+		return TRUE
+
+	var/mob/living/carbon/C = user
+	if(C.isSynthetic())
+		to_chat(user, SPAN_NOTICE("\The [src] is still."))
+		return TRUE
+
+	playsound(src, 'sound/effects/zapbeep.ogg', 100, 1)
+	active = 1
+	update_icon()
+	if(prob(70))
+		to_chat(user, SPAN_NOTICE("As you touch \the [src], you suddenly get a vivid image - [E.engraving_generator.generate_engraving_text()]"))
+		return TRUE
+
+	to_chat(user, SPAN_DANGER("An overwhelming stream of information invades your mind!"))
+	to_chat(user, SPAN_DANGER("<font size=2>[uppertext(E.engraving_generator.generate_violent_vision_text())]</font>"))
+	SET_STATUS_MAX(user, STAT_PARA, 2)
+	C.set_hallucination(20, 100)
+	return TRUE
 
 /turf/simulated/floor/fixed/alium/ruin
 	name = "ancient alien plating"

--- a/mods/content/corporate/items/wristcomp.dm
+++ b/mods/content/corporate/items/wristcomp.dm
@@ -28,12 +28,8 @@
 	. = ..()
 
 /obj/item/modular_computer/pda/wrist/attack_hand(var/mob/user)
-	if(loc == user)
-		if(user.incapacitated() || user.restrained())
-			return
-		var/mob/living/carbon/human/H = user
-		if(istype(H) && src == H.get_equipped_item(slot_wear_id_str))
-			return attack_self(user)
+	if(user.check_dexterity(DEXTERITY_KEYBOARDS, TRUE) && loc == user && !user.restrained() && src == user.get_equipped_item(slot_wear_id_str))
+		return attack_self(user)
 	return ..()
 
 /obj/item/modular_computer/pda/wrist/handle_mouse_drop(atom/over, mob/user)

--- a/mods/content/psionics/system/psionics/faculties/psychokinesis.dm
+++ b/mods/content/psionics/system/psionics/faculties/psychokinesis.dm
@@ -77,17 +77,17 @@
 			var/obj/item/psychic_power/telekinesis/tk = new(user)
 			if(tk.set_focus(target))
 				tk.sparkle()
-				user.visible_message("<span class='notice'>\The [user] reaches out.</span>")
+				user.visible_message(SPAN_NOTICE("\The [user] reaches out."))
 				return tk
 		else if(istype(target, /obj/structure))
-			user.visible_message("<span class='notice'>\The [user] makes a strange gesture.</span>")
+			user.visible_message(SPAN_NOTICE("\The [user] makes a strange gesture."))
 			var/obj/O = target
-			O.attack_hand(user)
+			O.attack_hand(user) // We bypass adjacency checks due to telekinetics.
 			return TRUE
 		else if(istype(target, /obj/machinery))
 			for(var/mtype in valid_machine_types)
 				if(istype(target, mtype))
 					var/obj/machinery/machine = target
-					machine.attack_hand(user)
+					machine.attack_hand(user) // We bypass adjacency checks due to telekinetics.
 					return TRUE
 	return FALSE

--- a/mods/content/xenobiology/slime/_slime.dm
+++ b/mods/content/xenobiology/slime/_slime.dm
@@ -263,7 +263,8 @@
 			visible_message(SPAN_DANGER("\The [user] has punched \the [src]!"))
 			adjustBruteLoss(damage)
 			return TRUE
-	. = ..()
+
+	return ..()
 
 /mob/living/slime/attackby(var/obj/item/W, var/mob/user)
 	if(W.force > 0)

--- a/mods/content/xenobiology/slime/items.dm
+++ b/mods/content/xenobiology/slime/items.dm
@@ -87,6 +87,7 @@
 		icon_state = "golem"
 
 /obj/effect/golemrune/attack_hand(mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	var/mob/observer/ghost/ghost
 	for(var/mob/observer/ghost/O in src.loc)
 		if(!O.client)
@@ -97,7 +98,7 @@
 		break
 	if(!ghost)
 		to_chat(user, SPAN_WARNING("The rune fizzles uselessly."))
-		return
+		return TRUE
 	visible_message(SPAN_WARNING("A craggy humanoid figure coalesces into being!"))
 
 	var/mob/living/carbon/human/G = new(src.loc)
@@ -115,7 +116,7 @@
 	to_chat(G, FONT_LARGE(SPAN_BOLD("You are a golem. Serve [user] and assist them at any cost.")))
 	to_chat(G, SPAN_ITALIC("You move slowly and are vulnerable to trauma, but are resistant to heat and cold."))
 	qdel(src)
-
+	return TRUE
 
 /obj/effect/golemrune/proc/announce_to_ghosts()
 	for(var/mob/observer/ghost/G in global.player_list)

--- a/mods/content/xenobiology/slime/items.dm
+++ b/mods/content/xenobiology/slime/items.dm
@@ -77,8 +77,8 @@
 /obj/effect/golemrune/Process()
 	var/mob/observer/ghost/ghost
 	for(var/mob/observer/ghost/O in src.loc)
-		if(!O.client)	continue
-		if(O.mind && O.mind.current && O.mind.current.stat != DEAD)	continue
+		if(!O.client || (O.mind && O.mind.current && O.mind.current.stat != DEAD))
+			continue
 		ghost = O
 		break
 	if(ghost)

--- a/mods/species/ascent/effects/razorweb.dm
+++ b/mods/species/ascent/effects/razorweb.dm
@@ -72,9 +72,11 @@
 	qdel_self()
 
 /obj/effect/razorweb/attack_hand(mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	user.visible_message(SPAN_DANGER("\The [user] yanks on \the [src]!"))
 	entangle(user, TRUE)
 	qdel_self()
+	return TRUE
 
 /obj/effect/razorweb/attackby(var/obj/item/thing, var/mob/user)
 

--- a/mods/species/ascent/machines/magnetotron.dm
+++ b/mods/species/ascent/machines/magnetotron.dm
@@ -15,8 +15,11 @@
 			to_chat(M, "\icon[src] " + SPAN_WARNING("\The [src] flashes in a variety of ") + make_rainbow("rainbow hues") + SPAN_WARNING("."))
 
 /obj/machinery/ascent_magnetotron/attack_hand(var/mob/user)
-	var/mob/living/carbon/human/target = locate() in contents
 
+	if(!user.check_dexterity(DEXTERITY_COMPLEX_TOOLS, TRUE))
+		return ..()
+
+	var/mob/living/carbon/human/target = locate() in contents
 	if(isnull(target))
 		display_message("No biological signature detected in [src].")
 		return TRUE
@@ -50,6 +53,9 @@
 				E.add_pain(rand(15,40))
 		visible_message(SPAN_NOTICE("\icon[src] [src] shuts down with a loud bang, signaling the end of the process."))
 		playsound(src, 'sound/weapons/flashbang.ogg', 100)
+	return TRUE
+
+
 
 /obj/machinery/ascent_magnetotron/proc/get_total_gynes()
 	for(var/mob/living/carbon/human/H in global.living_mob_list_)

--- a/mods/species/ascent/machines/ship_machines.dm
+++ b/mods/species/ascent/machines/ship_machines.dm
@@ -160,20 +160,20 @@ MANTIDIFY(/obj/item/chems/chem_disp_cartridge, "canister", "chemical storage")
 	var/image/field_image
 
 /obj/machinery/power/ascent_reactor/attack_hand(mob/user)
-	. = ..()
-
+	if(!user.check_dexterity(DEXTERITY_COMPLEX_TOOLS, TRUE))
+		return ..()
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(!(H.species.name in ALL_ASCENT_SPECIES))
 			to_chat(H, SPAN_WARNING("You have no idea how to use \the [src]."))
-			return
+			return TRUE
 	else if(!istype(user, /mob/living/silicon/robot/flying/ascent))
 		to_chat(user, SPAN_WARNING("You have no idea how to interface with \the [src]."))
-		return
-
+		return TRUE
 	user.visible_message(SPAN_NOTICE("\The [user] switches \the [src] [on ? "off" : "on"]."))
 	on = !on
 	update_icon()
+	return TRUE
 
 /obj/machinery/power/ascent_reactor/on_update_icon()
 	. = ..()


### PR DESCRIPTION
## Description of changes
This is going to be a bastard to review. I went through every `attack_hand()` override to add parent calls, truthy returns, and dexterity checks. This is split out from #3027 which will need to make `attack_hand()` callable by `/mob/living/UnarmedAttack()`.

## Why and what will this PR improve
Consistency and generally informative return values for `attack_hand()`. Also should allow for things like implementing unarmed damage against structures down the track.

## Authorship
Myself.

## Changelog
:cl:
tweak: Many interactions with empty hands now have dexterity checks associated.
/:cl: