### PR TITLE
pickup() -> on_picked_up()

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -34,7 +34,7 @@
 
 	return 1
 
-/obj/item/sword/cultblade/pickup(mob/living/user)
+/obj/item/sword/cultblade/on_picked_up(mob/living/user)
 	if(!iscultist(user))
 		to_chat(user, "<span class='warning'>An overwhelming feeling of dread comes over you as you pick up the cultist's sword. It would be wise to be rid of this blade quickly.</span>")
 		SET_STATUS_MAX(user, STAT_DIZZY, 120)

--- a/code/game/gamemodes/wizard/servant_items/champion.dm
+++ b/code/game/gamemodes/wizard/servant_items/champion.dm
@@ -60,7 +60,7 @@
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "cleaved", "sundered")
 	material_alteration = MAT_FLAG_ALTERATION_NONE
 
-/obj/item/sword/excalibur/pickup(var/mob/living/user)
+/obj/item/sword/excalibur/on_picked_up(var/mob/living/user)
 	if(user.mind)
 		var/decl/special_role/wizard/wizards = GET_DECL(/decl/special_role/wizard)
 		if(!wizards.is_antagonist(user.mind) || user.mind.assigned_special_role != "Spellbound Servant")

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -318,7 +318,6 @@
 		return
 
 	var/old_loc = loc
-	on_picked_up(user)
 	if (istype(loc, /obj/item/storage))
 		var/obj/item/storage/S = loc
 		S.remove_from_storage(src)
@@ -337,6 +336,7 @@
 		return // Unequipping changes our state, so must check here.
 
 	if(user.put_in_active_hand(src))
+		on_picked_up(user)
 		if (isturf(old_loc))
 			var/obj/effect/temporary/item_pickup_ghost/ghost = new(old_loc, src)
 			ghost.animate_towards(user)

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -398,7 +398,7 @@
 	RAISE_EVENT(/decl/observ/mob_unequipped, user, src)
 	RAISE_EVENT_REPEAT(/decl/observ/item_unequipped, src, user)
 
-// called just as an item is picked up (loc is not yet changed)
+// called just after an item is picked up, after it has been equipped to the mob.
 /obj/item/proc/on_picked_up(mob/user)
 	return
 

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -318,7 +318,7 @@
 		return
 
 	var/old_loc = loc
-	pickup(user)
+	on_picked_up(user)
 	if (istype(loc, /obj/item/storage))
 		var/obj/item/storage/S = loc
 		S.remove_from_storage(src)
@@ -399,7 +399,7 @@
 	RAISE_EVENT_REPEAT(/decl/observ/item_unequipped, src, user)
 
 // called just as an item is picked up (loc is not yet changed)
-/obj/item/proc/pickup(mob/user)
+/obj/item/proc/on_picked_up(mob/user)
 	return
 
 // called when this item is removed from a storage item, which is passed on as S. The loc variable is already set to the new destination before this is called.

--- a/code/game/objects/items/weapons/melee/energy_ninja.dm
+++ b/code/game/objects/items/weapons/melee/energy_ninja.dm
@@ -40,7 +40,7 @@
 	. = ..()
 	check_loc()
 
-/obj/item/energy_blade/ninja/pickup(mob/user)
+/obj/item/energy_blade/ninja/on_picked_up(mob/user)
 	. = ..()
 	check_loc()
 

--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -84,7 +84,7 @@ var/global/list/image/hazard_overlays //Cached hazard floor overlays for the bar
 	update_icon()
 	return ..()
 
-/obj/item/stack/tape_roll/barricade_tape/pickup(mob/user)
+/obj/item/stack/tape_roll/barricade_tape/on_picked_up(mob/user)
 	stop_unrolling()
 	update_icon()
 	return ..()

--- a/code/game/objects/items/weapons/storage/laundry_basket.dm
+++ b/code/game/objects/items/weapons/storage/laundry_basket.dm
@@ -39,7 +39,7 @@
 	to_chat(user, "<span class='notice'>You dump the [src]'s contents onto \the [T].</span>")
 	return ..()
 
-/obj/item/storage/laundry_basket/pickup(mob/user)
+/obj/item/storage/laundry_basket/on_picked_up(mob/user)
 	var/obj/item/storage/laundry_basket/offhand/O = new(user)
 	O.SetName("[name] - second hand")
 	O.desc = "Your second grip on the [name]."

--- a/code/game/objects/items/weapons/towels.dm
+++ b/code/game/objects/items/weapons/towels.dm
@@ -56,7 +56,7 @@
 		pixel_y = 0
 		pixel_z = 0
 
-/obj/item/towel/pickup(mob/user)
+/obj/item/towel/on_picked_up(mob/user)
 	..()
 	if(icon != initial(icon))
 		icon = initial(icon)

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -175,7 +175,7 @@ else if(##equipment_var) {\
 			to_chat(H, "<span class='danger'>You cannot deploy your helmet while wearing \the [head].</span>")
 			return
 		if(H.equip_to_slot_if_possible(helmet, slot_head_str))
-			helmet.pickup(H)
+			helmet.on_picked_up(H)
 			helmet.canremove = 0
 			playsound(loc, helmet_deploy_sound, 30)
 			to_chat(H, "<span class='info'>You deploy your suit helmet, sealing you off from the world.</span>")

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -410,7 +410,7 @@ var/global/list/card_decks = list()
 	else
 		update_icon()
 
-/obj/item/hand/pickup(mob/user)
+/obj/item/hand/on_picked_up(mob/user)
 	src.update_icon()
 
 /*** A special thing that steals a card from a deck, probably lost in maint somewhere. ***/

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -295,7 +295,7 @@ var/global/list/_wood_materials = list(
 		qdel(src)
 		return
 
-/obj/item/chems/food/grown/pickup(mob/user)
+/obj/item/chems/food/grown/on_picked_up(mob/user)
 	..()
 	if(!seed)
 		return

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -703,7 +703,7 @@
 	max_complexity = IC_COMPLEXITY_BASE
 
 /obj/item/electronic_assembly/on_picked_up()
-	transform = matrix() //Reset the matrix.
+	transform = null //Reset the matrix.
 
 /obj/item/electronic_assembly/wallmount/proc/mount_assembly(turf/on_wall, mob/user) //Yeah, this is admittedly just an abridged and kitbashed version of the wallframe attach procs.
 	var/ndir = get_dir(on_wall, user)

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -702,7 +702,7 @@
 	max_components = IC_MAX_SIZE_BASE
 	max_complexity = IC_COMPLEXITY_BASE
 
-/obj/item/electronic_assembly/pickup()
+/obj/item/electronic_assembly/on_picked_up()
 	transform = matrix() //Reset the matrix.
 
 /obj/item/electronic_assembly/wallmount/proc/mount_assembly(turf/on_wall, mob/user) //Yeah, this is admittedly just an abridged and kitbashed version of the wallframe attach procs.

--- a/code/modules/mob/living/bot/remotebot.dm
+++ b/code/modules/mob/living/bot/remotebot.dm
@@ -57,7 +57,7 @@
 		holding = null
 	return ..()
 
-/mob/living/bot/remotebot/proc/on_picked_up(var/obj/item/I)
+/mob/living/bot/remotebot/proc/pickup(var/obj/item/I)
 	if(holding || get_dist(src,I) > 1)
 		return
 	src.visible_message("<b>\The [src]</b> picks up \the [I].")
@@ -87,7 +87,7 @@
 	if(isturf(a) || get_dist(src,a) > 1)
 		walk_to(src,a,0,get_movement_delay(get_dir(src, a)))
 	else if(istype(a, /obj/item))
-		on_picked_up(a)
+		pickup(a)
 	else
 		hit(a)
 

--- a/code/modules/mob/living/bot/remotebot.dm
+++ b/code/modules/mob/living/bot/remotebot.dm
@@ -57,7 +57,7 @@
 		holding = null
 	return ..()
 
-/mob/living/bot/remotebot/proc/pickup(var/obj/item/I)
+/mob/living/bot/remotebot/proc/on_picked_up(var/obj/item/I)
 	if(holding || get_dist(src,I) > 1)
 		return
 	src.visible_message("<b>\The [src]</b> picks up \the [I].")
@@ -87,7 +87,7 @@
 	if(isturf(a) || get_dist(src,a) > 1)
 		walk_to(src,a,0,get_movement_delay(get_dir(src, a)))
 	else if(istype(a, /obj/item))
-		pickup(a)
+		on_picked_up(a)
 	else
 		hit(a)
 

--- a/code/modules/reagents/reagent_containers/beaker.dm
+++ b/code/modules/reagents/reagent_containers/beaker.dm
@@ -16,7 +16,7 @@
 	. = ..()
 	to_chat(user, " It can hold up to [volume] units.")
 
-/obj/item/chems/glass/beaker/pickup(mob/user)
+/obj/item/chems/glass/beaker/on_picked_up(mob/user)
 	..()
 	update_icon()
 

--- a/code/modules/reagents/reagent_containers/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/drinks/bottle.dm
@@ -215,7 +215,7 @@
 			stop_spin_bottle = FALSE
 
 /obj/item/chems/drinks/bottle/on_picked_up(mob/living/user)
-	animate(src, transform = null, time = 0) //Restore bottle to its original position
+	animate(src, transform = null, time = 0) //Restore bottle to its original position - animate() is needed to interrupt SpinAnimation()
 
 //Keeping this here for now, I'll ask if I should keep it here.
 /obj/item/broken_bottle

--- a/code/modules/reagents/reagent_containers/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/drinks/bottle.dm
@@ -214,7 +214,7 @@
 			sleep(sleep_not_stacking) //Not stacking
 			stop_spin_bottle = FALSE
 
-/obj/item/chems/drinks/bottle/pickup(mob/living/user)
+/obj/item/chems/drinks/bottle/on_picked_up(mob/living/user)
 	animate(src, transform = null, time = 0) //Restore bottle to its original position
 
 //Keeping this here for now, I'll ask if I should keep it here.

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -22,7 +22,7 @@
 	var/lid_color = COLOR_GRAY80
 	var/autolabel = TRUE  		// if set, will add label with the name of the first initial reagent
 
-/obj/item/chems/glass/bottle/pickup(mob/user)
+/obj/item/chems/glass/bottle/on_picked_up(mob/user)
 	..()
 	update_icon()
 

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -33,7 +33,7 @@
 /obj/item/chems/syringe/on_reagent_change()
 	update_icon()
 
-/obj/item/chems/syringe/pickup(mob/user)
+/obj/item/chems/syringe/on_picked_up(mob/user)
 	..()
 	update_icon()
 

--- a/code/modules/spells/targeted/equip/burning_touch.dm
+++ b/code/modules/spells/targeted/equip/burning_touch.dm
@@ -25,7 +25,7 @@
 	var/burn_power = 0
 	var/burn_timer
 
-/obj/item/flame/hands/pickup(var/mob/user)
+/obj/item/flame/hands/on_picked_up(var/mob/user)
 	burn_power = 0
 	burn_timer = world.time + 10 SECONDS
 	START_PROCESSING(SSobj,src)

--- a/code/modules/spells/targeted/equip/equip.dm
+++ b/code/modules/spells/targeted/equip/equip.dm
@@ -24,7 +24,7 @@
 				if(delete_old)
 					qdel(old_item)
 			L.equip_to_slot(new_item, slot_id)
-			new_item.pickup(L)
+			new_item.on_picked_up(L)
 
 			if(duration)
 				summoned_items += new_item //we store it in a list to remove later


### PR DESCRIPTION
- Renames `pickup()` to `on_picked_up()`
- Moved `on_picked_up()` call in item pickup to after `put_in_active_hand()` so it doesn't apply even if you fail to pick the item up.
- Tweaks a couple of `on_picked_up()` overrides.