### PR TITLE
Added a prefilled vault cash bag.

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -114,3 +114,21 @@
 	w_class = ITEM_SIZE_SMALL
 	can_hold = list(/obj/item/coin, /obj/item/cash)
 	material = /decl/material/solid/leather/synth
+
+/obj/item/storage/bag/cash/filled/Initialize()
+	. = ..()
+	new /obj/item/cash/c1000(src)
+	new /obj/item/cash/c1000(src)
+	new /obj/item/cash/c1000(src)
+	new /obj/item/cash/c1000(src)
+	new /obj/item/cash/c1000(src)
+	new /obj/item/cash/c1000(src)
+	new /obj/item/cash/c1000(src)
+	new /obj/item/cash/c1000(src)
+	new /obj/item/cash/c1000(src)
+	new /obj/item/cash/c1000(src)
+	new /obj/item/cash/c1000(src)
+	new /obj/item/cash/c1000(src)
+	new /obj/item/cash/c1000(src)
+	new /obj/item/cash/c1000(src)
+	make_exact_fit()


### PR DESCRIPTION
## Description of changes
Adds a subtype of the cash bag filled with money.

## Why and what will this PR improve
Need for vaults on some maps, generally a fun thing to have available to spawn.

## Authorship
Myself.

## Changelog
Nothing player-facing.