### PR TITLE
Unifying turf atmos.

### DIFF
--- a/code/__defines/ZAS.dm
+++ b/code/__defines/ZAS.dm
@@ -38,7 +38,7 @@
 #define WESTDOWN (WEST|DOWN)
 
 #define TURF_HAS_VALID_ZONE(T) (isturf(T) && T:zone && !T:zone:invalid)
-#define SHOULD_PARTICIPATE_IN_ZAS(T) (isturf(T) && T:zone_membership_candidate && (!T:external_atmosphere_participation || !T:is_outside()))
+#define SHOULD_PARTICIPATE_IN_ZONES(T) (isturf(T) && T:zone_membership_candidate && (!T:external_atmosphere_participation || !T:is_outside()))
 
 #ifdef MULTIZAS
 

--- a/code/__defines/ZAS.dm
+++ b/code/__defines/ZAS.dm
@@ -37,7 +37,8 @@
 #define SOUTHDOWN (SOUTH|DOWN)
 #define WESTDOWN (WEST|DOWN)
 
-#define TURF_HAS_VALID_ZONE(T) (istype(T, /turf/simulated) && T:zone && !T:zone:invalid)
+#define TURF_HAS_VALID_ZONE(T) (isturf(T) && T:zone && !T:zone:invalid)
+#define SHOULD_PARTICIPATE_IN_ZAS(T) (isturf(T) && T:zone_membership_candidate && (!T:external_atmosphere_participation || !T:is_outside()))
 
 #ifdef MULTIZAS
 

--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -278,6 +278,7 @@
 #define OUTSIDE_AREA null
 #define OUTSIDE_NO   FALSE
 #define OUTSIDE_YES  TRUE
+#define OUTSIDE_UNCERTAIN null
 
 // Weather exposure values for being rained on or hailed on.
 #define WEATHER_IGNORE   -1

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -445,14 +445,11 @@
 	var/minp=16777216;
 	var/maxp=0;
 	for(var/dir in global.cardinal)
-		var/turf/simulated/T=get_turf(get_step(loc,dir))
+		var/turf/T=get_turf(get_step(loc,dir))
 		var/cp=0
-		if(T && istype(T) && T.zone)
+		if(isturf(T) && T.zone)
 			var/datum/gas_mixture/environment = T.return_air()
-			cp = environment.return_pressure()
-		else
-			if(istype(T,/turf/simulated))
-				continue
+			cp = environment?.return_pressure()
 		if(cp<minp)minp=cp
 		if(cp>maxp)maxp=cp
 	return abs(minp-maxp)
@@ -465,6 +462,7 @@
 
 /proc/getCardinalAirInfo(var/turf/loc, var/list/stats=list("temperature"))
 	var/list/temps = new/list(4)
+	var/statslen = length(stats)
 	for(var/dir in global.cardinal)
 		var/direction
 		switch(dir)
@@ -476,25 +474,16 @@
 				direction = 3
 			if(WEST)
 				direction = 4
-		var/turf/simulated/T=get_turf(get_step(loc,dir))
-		var/list/rstats = new /list(stats.len)
-		if(T && istype(T) && T.zone)
+		var/turf/T=get_turf(get_step(loc,dir))
+		var/list/rstats = new /list(statslen)
+		if(isturf(T))
 			var/datum/gas_mixture/environment = T.return_air()
-			for(var/i=1;i<=stats.len;i++)
-				if(stats[i] == "pressure")
-					rstats[i] = environment.return_pressure()
-				else
-					rstats[i] = environment.vars[stats[i]]
-		else if(istype(T, /turf/simulated))
-			rstats = null // Exclude zone (wall, door, etc).
-		else if(isturf(T))
-			// Should still work.  (/turf/return_air())
-			var/datum/gas_mixture/environment = T.return_air()
-			for(var/i=1;i<=stats.len;i++)
-				if(stats[i] == "pressure")
-					rstats[i] = environment.return_pressure()
-				else
-					rstats[i] = environment.vars[stats[i]]
+			if(environment)
+				for(var/i= 1 to statslen)
+					if(stats[i] == "pressure")
+						rstats[i] = environment.return_pressure()
+					else
+						rstats[i] = environment.vars[stats[i]]
 		temps[direction] = rstats
 	return temps
 

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -445,9 +445,9 @@
 	var/minp=16777216;
 	var/maxp=0;
 	for(var/dir in global.cardinal)
-		var/turf/T=get_turf(get_step(loc,dir))
+		var/turf/T = get_step(loc,dir)
 		var/cp=0
-		if(isturf(T) && T.zone)
+		if(T?.zone)
 			var/datum/gas_mixture/environment = T.return_air()
 			cp = environment?.return_pressure()
 		if(cp<minp)minp=cp
@@ -474,16 +474,15 @@
 				direction = 3
 			if(WEST)
 				direction = 4
-		var/turf/T=get_turf(get_step(loc,dir))
+		var/turf/T = get_step(loc,dir)
 		var/list/rstats = new /list(statslen)
-		if(isturf(T))
-			var/datum/gas_mixture/environment = T.return_air()
-			if(environment)
-				for(var/i= 1 to statslen)
-					if(stats[i] == "pressure")
-						rstats[i] = environment.return_pressure()
-					else
-						rstats[i] = environment.vars[stats[i]]
+		var/datum/gas_mixture/environment = T?.return_air()
+		if(environment)
+			for(var/i= 1 to statslen)
+				if(stats[i] == "pressure")
+					rstats[i] = environment.return_pressure()
+				else
+					rstats[i] = environment.vars[stats[i]]
 		temps[direction] = rstats
 	return temps
 

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -649,11 +649,8 @@ Turf and target are seperate in case you want to teleport some distance from a t
 					refined_trg -= B
 					continue moving
 
-
-
-
 	if(toupdate.len)
-		for(var/turf/simulated/T1 in toupdate)
+		for(var/turf/T1 in toupdate)
 			SSair.mark_for_update(T1)
 
 	return copiedobjs

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -48,9 +48,10 @@
 	if(!. && a_intent == I_GRAB && length(available_maneuvers))
 		. = perform_maneuver(prepared_maneuver || available_maneuvers[1], A)
 
+
 /mob/living/carbon/human/RangedAttack(var/atom/A, var/params)
 	//Climbing up open spaces
-	if((istype(A, /turf/simulated/floor) || istype(A, /turf/unsimulated/floor) || istype(A, /obj/structure/lattice) || istype(A, /obj/structure/catwalk)) && isturf(loc) && bound_overlay && !is_physically_disabled()) //Climbing through openspace
+	if(isturf(loc) && bound_overlay && !is_physically_disabled() && istype(A) && A.can_climb_from_below(src))
 		return climb_up(A)
 
 	var/obj/item/clothing/gloves/G = get_equipped_item(slot_gloves_str)

--- a/code/controllers/subsystems/air.dm
+++ b/code/controllers/subsystems/air.dm
@@ -133,8 +133,8 @@ SUBSYSTEM_DEF(air)
 	report_progress("Processing Geometry...")
 
 	var/simulated_turf_count = 0
-	for(var/turf/T)
-		if(!SHOULD_PARTICIPATE_IN_ZAS(T))
+	for(var/turf/T in world)
+		if(!SHOULD_PARTICIPATE_IN_ZONES(T))
 			continue
 		simulated_turf_count++
 		T.update_air_properties()
@@ -322,11 +322,15 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 	ASSERT(A != B)
 	#endif
 
-	var/block = air_blocked(A,B) || !SHOULD_PARTICIPATE_IN_ZAS(A)
-	if(block & AIR_BLOCKED) return
+	if(!SHOULD_PARTICIPATE_IN_ZONES(A))
+		return
+
+	var/block = air_blocked(A,B)
+	if(block & AIR_BLOCKED)
+		return
 
 	var/direct = !(block & ZONE_BLOCKED)
-	var/space = !SHOULD_PARTICIPATE_IN_ZAS(B)
+	var/space = !SHOULD_PARTICIPATE_IN_ZONES(B)
 
 	if(!space)
 		if(min(A.zone.contents.len, B.zone.contents.len) < ZONE_MIN_SIZE || (direct && (equivalent_pressure(A.zone,B.zone) || times_fired == 0)))
@@ -358,7 +362,7 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 	#ifdef ZASDBG
 	ASSERT(isturf(T))
 	#endif
-	if(T.needs_air_update || !SHOULD_PARTICIPATE_IN_ZAS(T))
+	if(T.needs_air_update || !SHOULD_PARTICIPATE_IN_ZONES(T))
 		return
 	tiles_to_update += T
 	#ifdef ZASDBG

--- a/code/controllers/subsystems/air.dm
+++ b/code/controllers/subsystems/air.dm
@@ -36,13 +36,13 @@ Class Procs:
 		Called when zones have a direct connection and equivalent pressure and temperature.
 		Merges the zones to create a single zone.
 
-	connect(turf/simulated/A, turf/B)
-		Called by turf/update_air_properties(). The first argument must be simulated.
+	connect(turf/A, turf/B)
+		Called by turf/update_air_properties(). The first argument must participate in ZAS.
 		Creates a connection between A and B.
 
 	mark_zone_update(zone/Z)
 		Adds zone to the update list. Unlike mark_for_update(), this one is called automatically whenever
-		air is returned from a simulated turf.
+		air is returned from a turf.
 
 	equivalent_pressure(zone/A, zone/B)
 		Currently identical to A.air.compare(B.air). Returns 1 when directly connected zones are ready to be merged.
@@ -133,10 +133,11 @@ SUBSYSTEM_DEF(air)
 	report_progress("Processing Geometry...")
 
 	var/simulated_turf_count = 0
-	for(var/turf/simulated/S)
+	for(var/turf/T)
+		if(!SHOULD_PARTICIPATE_IN_ZAS(T))
+			continue
 		simulated_turf_count++
-		S.update_air_properties()
-
+		T.update_air_properties()
 		CHECK_TICK
 
 	report_progress({"Total Simulated Turfs: [simulated_turf_count]
@@ -312,21 +313,20 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 		B.c_merge(A)
 		mark_zone_update(A)
 
-/datum/controller/subsystem/air/proc/connect(turf/simulated/A, turf/simulated/B)
+/datum/controller/subsystem/air/proc/connect(turf/A, turf/B)
 	#ifdef ZASDBG
-	ASSERT(istype(A))
+	ASSERT(isturf(A))
 	ASSERT(isturf(B))
 	ASSERT(A.zone)
 	ASSERT(!A.zone.invalid)
-	//ASSERT(B.zone)
 	ASSERT(A != B)
 	#endif
 
-	var/block = air_blocked(A,B)
+	var/block = air_blocked(A,B) || !SHOULD_PARTICIPATE_IN_ZAS(A)
 	if(block & AIR_BLOCKED) return
 
 	var/direct = !(block & ZONE_BLOCKED)
-	var/space = !istype(B)
+	var/space = !SHOULD_PARTICIPATE_IN_ZAS(B)
 
 	if(!space)
 		if(min(A.zone.contents.len, B.zone.contents.len) < ZONE_MIN_SIZE || (direct && (equivalent_pressure(A.zone,B.zone) || times_fired == 0)))
@@ -358,7 +358,7 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 	#ifdef ZASDBG
 	ASSERT(isturf(T))
 	#endif
-	if(T.needs_air_update)
+	if(T.needs_air_update || !SHOULD_PARTICIPATE_IN_ZAS(T))
 		return
 	tiles_to_update += T
 	#ifdef ZASDBG

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -125,6 +125,7 @@ var/global/list/areas = list()
 		if(adjacent_turf)
 			T.update_registrations_on_adjacent_area_change()
 
+	T.last_outside_check = OUTSIDE_UNCERTAIN
 	if(T.is_outside == OUTSIDE_AREA && T.is_outside() != old_outside)
 		T.update_weather()
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -844,6 +844,9 @@
 	RETURN_TYPE(/list)
 	return list()
 
+/atom/proc/can_climb_from_below(var/mob/climber)
+	return FALSE
+
 /atom/proc/singularity_act()
 	return 0
 

--- a/code/game/atoms_temperature.dm
+++ b/code/game/atoms_temperature.dm
@@ -43,18 +43,14 @@
 
 	// Get our location temperature if possible.
 	// Nullspace is room temperature, clearly.
-	var/adjust_temp
-	if(loc)
-		if(!istype(loc, /turf/simulated))
-			adjust_temp = loc.temperature
-		else
-			var/turf/simulated/T = loc
-			if(T.zone && T.zone.air)
-				adjust_temp = T.zone.air.temperature
-			else
-				adjust_temp = T20C
-	else
-		adjust_temp = T20C
+	var/adjust_temp = T20C
+	if(isturf(loc))
+		var/turf/T = loc
+		var/datum/gas_mixture/environment = T.return_air()
+		if(environment)
+			adjust_temp = environment.temperature
+	else if(loc)
+		adjust_temp = loc.temperature
 
 	var/diff_temp = adjust_temp - temperature
 	if(abs(diff_temp) >= ATOM_TEMPERATURE_EQUILIBRIUM_THRESHOLD)

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -41,6 +41,9 @@
 	update_connections(1)
 	update_icon()
 
+/obj/structure/catwalk/can_climb_from_below(var/mob/climber)
+	return TRUE
+
 /obj/structure/catwalk/Destroy()
 	var/turf/oldloc = loc
 	redraw_nearby_catwalks()

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -53,21 +53,20 @@
 
 	if(lit != FIRE_LIT)
 		for(var/thing in affected_exterior_turfs)
-			var/turf/exterior/T = thing
+			var/turf/T = thing
 			LAZYREMOVE(T.affecting_heat_sources, src)
 		affected_exterior_turfs = null
 	else
 		var/list/new_affecting
-		for(var/turf/exterior/T in RANGE_TURFS(loc, light_range_high))
-			LAZYADD(new_affecting, T)
-		for(var/thing in affected_exterior_turfs)
-			var/turf/exterior/T = thing
-			if(!(thing in new_affecting))
+		for(var/turf/T as anything in RANGE_TURFS(loc, light_range_high))
+			if(T.external_atmosphere_participation)
+				LAZYADD(new_affecting, T)
+		for(var/turf/T as anything in affected_exterior_turfs)
+			if(!(T in new_affecting) || !T.external_atmosphere_participation)
 				LAZYREMOVE(T.affecting_heat_sources, src)
 				LAZYREMOVE(affected_exterior_turfs, T)
 			LAZYREMOVE(new_affecting, T)
-		for(var/thing in new_affecting)
-			var/turf/exterior/T = thing
+		for(var/turf/T as anything in new_affecting)
 			LAZYDISTINCTADD(T.affecting_heat_sources, src)
 			LAZYDISTINCTADD(affected_exterior_turfs, T)
 

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -27,6 +27,9 @@
 	. = ..()
 	update_neighbors()
 
+/obj/structure/lattice/can_climb_from_below(var/mob/climber)
+	return TRUE
+
 /obj/structure/lattice/update_material_desc()
 	if(material)
 		desc = "A lightweight support [material.solid_name] lattice."
@@ -99,7 +102,7 @@
 		if(locate(/obj/structure/lattice, T) || locate(/obj/structure/catwalk, T))
 			dir_sum += direction
 		else
-			var/turf/O = get_step(src, direction) 
+			var/turf/O = get_step(src, direction)
 			if(!istype(O) || !O.is_open())
 				dir_sum += direction
 	icon_state = "lattice[dir_sum]"

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -55,12 +55,8 @@ var/global/const/FALLOFF_SOUNDS = 0.5
 
 	volume *= pressure_factor
 
-	//Dense turfs are not in the zones, so they shouldn't be penalized here when source
-	if(!turf_source.blocks_air && istype(T,/turf/simulated) && istype(turf_source,/turf/simulated))
-		var/turf/simulated/sim_source = turf_source
-		var/turf/simulated/sim_destination = T
-		if(sim_destination.zone != sim_source.zone)
-			volume -= 30
+	if(!turf_source.blocks_air && (T.zone || turf_source.zone) && T.zone != turf_source.zone)
+		volume -= 30
 	return volume
 
 /mob/proc/playsound_local(var/turf/turf_source, soundin, vol as num, vary, frequency, falloff, is_global, extrarange, override_env, envdry, envwet)

--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -6,6 +6,7 @@
 	layer = PLATING_LAYER
 	open_turf_type = /turf/exterior/open
 	turf_flags = TURF_FLAG_BACKGROUND | TURF_IS_HOLOMAP_PATH
+	zone_membership_candidate = TRUE
 	var/base_color
 	var/diggable = 1
 	var/dirt_color = "#7c5e42"
@@ -13,7 +14,6 @@
 	var/icon_edge_layer = -1
 	var/icon_edge_states
 	var/icon_has_corners = FALSE
-	var/list/affecting_heat_sources
 	///If this turf is on a level that belongs to a planetoid, this is a reference to that planetoid.
 	var/datum/planetoid_data/owner
 
@@ -68,13 +68,6 @@
 /turf/exterior/is_floor()
 	return !density && !is_open()
 
-/turf/exterior/ChangeTurf(var/turf/N, var/tell_universe = TRUE, var/force_lighting_update = FALSE, var/keep_air = FALSE)
-	var/last_affecting_heat_sources = affecting_heat_sources
-	var/turf/exterior/ext = ..()
-	if(istype(ext))
-		ext.affecting_heat_sources = last_affecting_heat_sources
-	return ext
-
 /turf/exterior/is_plating()
 	return !density
 
@@ -83,26 +76,7 @@
 
 /turf/exterior/Destroy()
 	owner = null
-	for(var/thing in affecting_heat_sources)
-		var/obj/structure/fire_source/heat_source = thing
-		LAZYREMOVE(heat_source.affected_exterior_turfs, src)
-	affecting_heat_sources = null
 	. = ..()
-
-/turf/exterior/return_air()
-	var/datum/level_data/level = SSmapping.levels_by_z[z]
-	var/datum/gas_mixture/gas = level?.get_exterior_atmosphere()
-	if(!gas)
-		return
-	var/initial_temperature = gas.temperature
-	if(weather)
-		initial_temperature = weather.adjust_temperature(initial_temperature)
-	for(var/thing in affecting_heat_sources)
-		if((gas.temperature - initial_temperature) >= 100)
-			break
-		var/obj/structure/fire_source/heat_source = thing
-		gas.temperature = gas.temperature + heat_source.exterior_temperature / max(1, get_dist(src, get_turf(heat_source)))
-	return gas
 
 /turf/exterior/levelupdate()
 	for(var/obj/O in src)

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -5,6 +5,7 @@
 		/decl/material/gas/nitrogen = MOLES_N2STANDARD
 	)
 	open_turf_type = /turf/simulated/open
+	zone_membership_candidate = TRUE
 
 	var/wet = 0
 	var/image/wet_overlay = null
@@ -173,13 +174,4 @@
 	var/area/A = loc
 	holy = istype(A) && (A.area_flags & AREA_FLAG_HOLY)
 	levelupdate()
-	. = ..()
-
-/turf/simulated/Destroy()
-	if (zone)
-		if (can_safely_remove_from_zone())
-			c_copy_air()
-			zone.remove(src)
-		else
-			zone.rebuild()
 	. = ..()

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -24,6 +24,9 @@
 	var/decl/flooring/flooring
 	var/lava = 0
 
+/turf/simulated/floor/can_climb_from_below(var/mob/climber)
+	return TRUE
+
 /turf/simulated/floor/is_plating()
 	return !flooring
 

--- a/code/game/turfs/simulated/floor_acts.dm
+++ b/code/game/turfs/simulated/floor_acts.dm
@@ -12,7 +12,7 @@
 			if(2)
 				ChangeTurf(get_base_turf_by_area(src))
 			if(3)
-				if(prob(33)) 
+				if(prob(33))
 					var/decl/material/mat = GET_DECL(/decl/material/solid/metal/steel)
 					mat.place_shards(src)
 				if(prob(80))
@@ -38,7 +38,7 @@
 /turf/simulated/floor/proc/get_damage_temperature()
 	return flooring ? flooring.damage_temperature : null
 
-/turf/simulated/floor/adjacent_fire_act(turf/simulated/floor/adj_turf, datum/gas_mixture/adj_air, adj_temp, adj_volume)
+/turf/simulated/floor/adjacent_fire_act(turf/adj_turf, datum/gas_mixture/adj_air, adj_temp, adj_volume)
 	var/dir_to = get_dir(src, adj_turf)
 
 	for(var/obj/structure/window/W in src)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -206,11 +206,10 @@ var/global/list/wall_fullblend_objects = list(
 /turf/simulated/wall/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)//Doesn't fucking work because walls don't interact with air :(
 	burn(exposed_temperature)
 
-/turf/simulated/wall/adjacent_fire_act(turf/simulated/floor/adj_turf, datum/gas_mixture/adj_air, adj_temp, adj_volume)
+/turf/simulated/wall/adjacent_fire_act(turf/adj_turf, datum/gas_mixture/adj_air, adj_temp, adj_volume)
 	burn(adj_temp)
 	if(adj_temp > material.melting_point)
 		take_damage(log(RAND_F(0.9, 1.1) * (adj_temp - material.melting_point)))
-
 	return ..()
 
 /turf/simulated/wall/proc/dismantle_wall(var/devastated, var/explode, var/no_product)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -5,6 +5,11 @@
 	is_spawnable_type = TRUE
 	layer = TURF_LAYER
 
+	/// Will participate in ZAS, join zones, etc.
+	var/zone_membership_candidate = FALSE
+	/// Will participate in external atmosphere simulation if the turf is outside and no zone is set.
+	var/external_atmosphere_participation = TRUE
+
 	var/turf_flags
 
 	var/holy = 0
@@ -51,6 +56,23 @@
 	// TL;DR: just leave these vars alone.
 	var/tmp/obj/abstract/weather_system/weather
 	var/tmp/is_outside = OUTSIDE_AREA
+	var/tmp/last_outside_check = OUTSIDE_UNCERTAIN
+
+	///The cached air mixture of a turf. Never directly access, use `return_air()`.
+	//This exists to store air during zone rebuilds, as well as for unsimulated turfs.
+	//They are never deleted to not overwhelm the garbage collector.
+	var/datum/gas_mixture/air
+	///Is this turf queued in the TURFS cycle of SSair?
+	var/needs_air_update = 0
+
+	///The turf's current zone.
+	var/zone/zone
+	///All directions in which a turf that can contain air is present.
+	var/airflow_open_directions
+
+	/// Used by exterior turfs to determine the warming effect of campfires and such.
+	var/list/affecting_heat_sources
+
 
 /turf/Initialize(mapload, ...)
 	. = null && ..()	// This weird construct is to shut up the 'parent proc not called' warning without disabling the lint for child types. We explicitly return an init hint so this won't change behavior.
@@ -98,6 +120,19 @@
 
 /turf/Destroy()
 
+	if(zone)
+		if(can_safely_remove_from_zone())
+			c_copy_air()
+			zone.remove(src)
+		else
+			zone.rebuild()
+
+	if(LAZYLEN(affecting_heat_sources))
+		for(var/thing in affecting_heat_sources)
+			var/obj/structure/fire_source/heat_source = thing
+			LAZYREMOVE(heat_source.affected_exterior_turfs, src)
+		affecting_heat_sources = null
+
 	if (!changing_turf)
 		PRINT_STACK_TRACE("Improper turf qdel. Do not qdel turfs directly.")
 
@@ -126,6 +161,7 @@
 		weather = null
 
 	..()
+
 	return QDEL_HINT_IWILLGC
 
 /turf/explosion_act(severity)
@@ -227,7 +263,7 @@
 				return 0
 	return 1 //Nothing found to block so return success!
 
-/turf/proc/adjacent_fire_act(turf/simulated/floor/source, exposed_temperature, exposed_volume)
+/turf/proc/adjacent_fire_act(turf/adj_turf, datum/gas_mixture/adj_air, adj_temp, adj_volume)
 	return
 
 /turf/proc/is_plating()
@@ -398,6 +434,9 @@
 	if(density)
 		return OUTSIDE_NO
 
+	if(last_outside_check != OUTSIDE_UNCERTAIN)
+		return last_outside_check
+
 	// What is our local outside value?
 	// Some turfs can be roofed irrespective of the turf above them in multiz.
 	// I have the feeling this is redundat as a roofed turf below max z will
@@ -418,16 +457,41 @@
 				return OUTSIDE_NO
 			top_of_stack = next_turf
 		// If we hit the top of the stack without finding a roof, we ask the upmost turf if we're outside.
-		return top_of_stack.is_outside()
+		. = top_of_stack.is_outside()
+	last_outside_check = . // Cache this for later calls.
 
 /turf/proc/set_outside(var/new_outside, var/skip_weather_update = FALSE)
-	if(is_outside != new_outside)
-		is_outside = new_outside
-		if(!skip_weather_update)
-			update_weather()
-		SSambience.queued += src
+	if(is_outside == new_outside)
+		return FALSE
+
+	is_outside = new_outside
+	if(!skip_weather_update)
+		update_weather()
+	SSambience.queued += src
+
+	last_outside_check = OUTSIDE_UNCERTAIN
+	if(is_outside())
+		if(zone && external_atmosphere_participation)
+			if(can_safely_remove_from_zone())
+				zone.remove(src)
+			else
+				zone.rebuild()
+	else if(zone_membership_candidate)
+		SSair.mark_for_update(src)
+
+	if(!HasBelow(z))
 		return TRUE
-	return FALSE
+
+	// Invalidate the outside check cache for turfs below us.
+	var/turf/checking = src
+	while(HasBelow(checking.z))
+		checking = GetBelow(checking)
+		if(!isturf(checking))
+			break
+		checking.last_outside_check = OUTSIDE_UNCERTAIN
+		if(!checking.is_open())
+			break
+	return TRUE
 
 /turf/proc/get_air_graphic()
 	var/datum/gas_mixture/environment = return_air()

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -51,6 +51,7 @@
 	var/old_flooded =          flooded
 	var/old_outside =          is_outside
 	var/old_is_open =          is_open()
+	var/old_affecting_heat_sources = affecting_heat_sources
 
 	var/old_ambience =         ambient_light
 	var/old_ambience_mult =    ambient_light_multiplier
@@ -60,12 +61,15 @@
 
 	changing_turf = TRUE
 
+
 	qdel(src)
 	. = new N(src)
 
 	var/turf/W = .
 	W.above =            old_above     // Multiz ref tracking.
 	W.prev_type =        old_prev_type // Shuttle transition turf tracking.
+
+	W.affecting_heat_sources = old_affecting_heat_sources
 
 	if (permit_ao)
 		regenerate_ao()
@@ -122,11 +126,17 @@
 	// end of lighting stuff
 
 	// we check the var rather than the proc, because area outside values usually shouldn't be set on turfs
+	W.last_outside_check = OUTSIDE_UNCERTAIN
 	if(W.is_outside != old_outside)
 		W.set_outside(old_outside, skip_weather_update = TRUE)
 	W.update_weather(force_update_below = W.is_open() != old_is_open)
 
 /turf/proc/transport_properties_from(turf/other)
+	if(other.zone)
+		if(!air)
+			make_air()
+		air.copy_from(other.zone.air)
+		other.zone.remove(other)
 	if(!istype(other, src.type))
 		return 0
 	src.set_dir(other.dir)
@@ -148,18 +158,6 @@
 	if(broken || burnt)
 		queue_icon_update()
 	set_flooring(other.flooring)
-	return TRUE
-
-//I would name this copy_from() but we remove the other turf from their air zone for some reason
-/turf/simulated/transport_properties_from(turf/simulated/other)
-	if(!..())
-		return FALSE
-
-	if(other.zone)
-		if(!src.air)
-			src.make_air()
-		src.air.copy_from(other.zone.air)
-		other.zone.remove(other)
 	return TRUE
 
 /turf/simulated/wall/transport_properties_from(turf/simulated/wall/other)

--- a/code/game/turfs/unsimulated/floor.dm
+++ b/code/game/turfs/unsimulated/floor.dm
@@ -4,6 +4,9 @@
 	icon_state = "Floor3"
 	turf_flags = TURF_IS_HOLOMAP_PATH
 
+/turf/unsimulated/floor/can_climb_from_below(var/mob/climber)
+	return TRUE
+
 /turf/unsimulated/floor/infinity //non-doomsday version for transit and wizden
 	name = "\proper infinity"
 	icon = 'icons/turf/space.dmi'

--- a/code/modules/ZAS/Airflow.dm
+++ b/code/modules/ZAS/Airflow.dm
@@ -158,7 +158,7 @@ Contains helper procs for airflow, called by /connection_group.
 
 /zone/proc/movables()
 	. = list()
-	for(var/turf/T in contents)
+	for(var/turf/T as anything in contents)
 		for(var/atom/movable/A in T)
 			if(!A.simulated || A.anchored || istype(A, /obj/effect) || isobserver(A))
 				continue

--- a/code/modules/ZAS/Connection.dm
+++ b/code/modules/ZAS/Connection.dm
@@ -50,8 +50,8 @@ Class Procs:
 */
 
 /connection
-	var/turf/simulated/A
-	var/turf/simulated/B
+	var/turf/A
+	var/turf/B
 	var/zone/zoneA
 	var/zone/zoneB
 
@@ -65,14 +65,14 @@ Class Procs:
 	var/tmp/verbose = FALSE
 	#endif
 
-/connection/New(turf/simulated/A, turf/simulated/B)
+/connection/New(turf/A, turf/B)
 	#ifdef ZASDBG
 	ASSERT(TURF_HAS_VALID_ZONE(A))
 	#endif
 	src.A = A
 	src.B = B
 	zoneA = A.zone
-	if(!istype(B))
+	if(!SHOULD_PARTICIPATE_IN_ZAS(B))
 		mark_space()
 		edge = SSair.get_edge(A.zone,B)
 		edge.add_connection(src)
@@ -82,7 +82,7 @@ Class Procs:
 		edge.add_connection(src)
 
 #ifdef ZASDBG
-/connection/simulated/New(turf/simulated/A, turf/simulated/B)
+/connection/simulated/New(turf/A, turf/B)
 	. = ..()
 	ASSERT(TURF_HAS_VALID_ZONE(B))
 #endif
@@ -131,7 +131,7 @@ Class Procs:
 		zas_log("Updated, \...")
 	#endif
 
-	if(!istype(A,/turf/simulated))
+	if(!SHOULD_PARTICIPATE_IN_ZAS(A))
 		#ifdef ZASDBG
 		if(verbose)
 			zas_log("Invalid A. Erasing...")
@@ -154,7 +154,7 @@ Class Procs:
 	else
 		mark_direct()
 
-	var/b_is_space = !istype(B,/turf/simulated)
+	var/b_is_space = !SHOULD_PARTICIPATE_IN_ZAS(B)
 
 	if(state & CONNECTION_SPACE)
 		if(!b_is_space)

--- a/code/modules/ZAS/Connection.dm
+++ b/code/modules/ZAS/Connection.dm
@@ -72,7 +72,7 @@ Class Procs:
 	src.A = A
 	src.B = B
 	zoneA = A.zone
-	if(!SHOULD_PARTICIPATE_IN_ZAS(B))
+	if(!SHOULD_PARTICIPATE_IN_ZONES(B))
 		mark_space()
 		edge = SSair.get_edge(A.zone,B)
 		edge.add_connection(src)
@@ -131,7 +131,7 @@ Class Procs:
 		zas_log("Updated, \...")
 	#endif
 
-	if(!SHOULD_PARTICIPATE_IN_ZAS(A))
+	if(!SHOULD_PARTICIPATE_IN_ZONES(A))
 		#ifdef ZASDBG
 		if(verbose)
 			zas_log("Invalid A. Erasing...")
@@ -154,7 +154,7 @@ Class Procs:
 	else
 		mark_direct()
 
-	var/b_is_space = !SHOULD_PARTICIPATE_IN_ZAS(B)
+	var/b_is_space = !SHOULD_PARTICIPATE_IN_ZONES(B)
 
 	if(state & CONNECTION_SPACE)
 		if(!b_is_space)

--- a/code/modules/ZAS/Diagnostic.dm
+++ b/code/modules/ZAS/Diagnostic.dm
@@ -2,17 +2,16 @@
 	set category = "Debug"
 	if(!T)
 		return
-	if(istype(T,/turf/simulated) && T:zone)
-		T:zone:dbg_data(src)
+	if(isturf(T) && T.zone)
+		T.zone.dbg_data(src)
+		if(length(T.zone.contents) < ZONE_MIN_SIZE)
+			to_chat(mob, SPAN_NOTICE("This turf's zone is below the minimum size, and will merge over zone blockers."))
 	else
 		to_chat(mob, "ZONE: No zone here.")
 		var/datum/gas_mixture/mix = T.return_air()
 		to_chat(mob, "ZONE: [mix.return_pressure()] kPa [mix.temperature] k")
 		for(var/g in mix.gas)
 			to_chat(mob, "ZONE GASES: [g]: [mix.gas[g]]\n")
-
-		if((T:zone && (length(T:zone:contents) > ZONE_MIN_SIZE)))
-			to_chat(mob, SPAN_NOTICE("This turf's zone is below the minimum size, and will merge over zone blockers."))
 
 /client/proc/Test_ZAS_Connection(var/turf/simulated/T)
 	set category = "Debug"

--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -21,9 +21,6 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 	return simulated
 
 /turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
-	return
-
-/turf/simulated/hotspot_expose(exposed_temperature, exposed_volume, soh)
 	if(fire_protection > world.time-300)
 		return 0
 	if(locate(/obj/fire) in src)
@@ -57,7 +54,7 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 			else
 				fire_tiles -= T
 	else
-		for(var/turf/simulated/T in fire_tiles)
+		for(var/turf/T in fire_tiles)
 			if(istype(T.fire))
 				qdel(T.fire)
 		fire_tiles.Cut()
@@ -66,9 +63,6 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 		SSair.active_fire_zones.Remove(src)
 
 /turf/proc/create_fire(fl)
-	return 0
-
-/turf/simulated/create_fire(fl)
 
 	if(submerged())
 		return 1
@@ -104,7 +98,7 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 /obj/fire/Process()
 	. = 1
 
-	var/turf/simulated/my_tile = loc
+	var/turf/my_tile = loc
 	if(!istype(my_tile) || !my_tile.zone || my_tile.submerged())
 		if(my_tile && my_tile.fire == src)
 			my_tile.fire = null
@@ -132,16 +126,16 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 
 	// prioritize nearby fuel overlays first
 	for(var/direction in global.cardinal)
-		var/turf/simulated/enemy_tile = get_step(my_tile, direction)
+		var/turf/enemy_tile = get_step(my_tile, direction)
 		if(istype(enemy_tile) && (locate(/obj/effect/fluid) in enemy_tile))
 			enemy_tile.hotspot_expose(air_contents.temperature, air_contents.volume)
 
 	//spread
 	for(var/direction in global.cardinal)
-		var/turf/simulated/enemy_tile = get_step(my_tile, direction)
+		var/turf/enemy_tile = get_step(my_tile, direction)
 
 		if(istype(enemy_tile))
-			if(my_tile.open_directions & direction) //Grab all valid bordering tiles
+			if(my_tile.airflow_open_directions & direction) //Grab all valid bordering tiles
 				if(!enemy_tile.zone || enemy_tile.fire)
 					continue
 
@@ -193,13 +187,13 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 	SSair.active_hotspots.Remove(src)
 	. = ..()
 
-/turf/simulated/var/fire_protection = 0 //Protects newly extinguished tiles from being overrun again.
+/turf
+	var/fire_protection = 0 //Protects newly extinguished tiles from being overrun again.
 /turf/proc/apply_fire_protection()
-/turf/simulated/apply_fire_protection()
 	fire_protection = world.time
 
 //Returns the firelevel
-/datum/gas_mixture/proc/react(zone/zone, force_burn, no_check = 0)
+/datum/gas_mixture/proc/react(var/zone/zone, force_burn, no_check = 0)
 	. = 0
 	if((temperature > FLAMMABLE_GAS_MINIMUM_BURN_TEMPERATURE || force_burn) && (no_check ||check_recombustibility()))
 

--- a/code/modules/ZAS/Turf.dm
+++ b/code/modules/ZAS/Turf.dm
@@ -1,121 +1,18 @@
-
-
 ////Turf Vars////
-///The cached air mixture of a turf. Never directly access, use `return_air()`.
-//This exists to store air during zone rebuilds, as well as for unsimulated turfs.
-//They are never deleted to not overwhelm the garbage collector.
-/turf/var/datum/gas_mixture/air
-///Is this turf queued in the TURFS cycle of SSair?
-/turf/var/needs_air_update = 0
-
-////Simulated Turf Vars////
-///The turf's current zone.
-/turf/simulated/var/zone/zone
-///All directions in which a turf that can contain air is present.
-/turf/simulated/var/open_directions
-
 #ifdef ZASDBG
 ///Set to TRUE during debugging to get descriptive to_chats of the object. Works for all atmos-related datums.
 /turf/var/tmp/verbose = FALSE
 #endif
 
-/turf/simulated/proc/update_graphic(list/graphic_add = null, list/graphic_remove = null)
+/turf/proc/update_graphic(list/graphic_add = null, list/graphic_remove = null)
 	if(graphic_add && graphic_add.len)
 		add_vis_contents(src, graphic_add)
 	if(graphic_remove && graphic_remove.len)
 		remove_vis_contents(src, graphic_remove)
 
 /turf/proc/update_air_properties()
-	var/block = c_airblock(src)
-	if(block & AIR_BLOCKED)
-		#ifdef ZASDBG
-		if(verbose)
-			zas_log("Self-blocked.")
-		dbg(zasdbgovl_blocked)
-		#endif
-		return 1
 
-	#ifdef MULTIZAS
-	for(var/d = 1, d < 64, d *= 2)
-	#else
-	for(var/d = 1, d < 16, d *= 2)
-	#endif
-
-		var/turf/unsim = get_step(src, d)
-
-		if(!unsim)
-			continue
-
-		block = unsim.c_airblock(src)
-
-		if(block & AIR_BLOCKED)
-			#ifdef ZASDBG
-			//target.dbg(ZAS_DIRECTIONAL_BLOCKER(turn(d, 180)))
-			#endif
-			continue
-
-		var/r_block = c_airblock(unsim)
-
-		if(r_block & AIR_BLOCKED)
-			continue
-
-		if(istype(unsim, /turf/simulated))
-
-			var/turf/simulated/sim = unsim
-			if(TURF_HAS_VALID_ZONE(sim))
-				SSair.connect(sim, src)
-
-/*
-	Simple heuristic for determining if removing the turf from it's zone will not partition the zone (A very bad thing).
-	Instead of analyzing the entire zone, we only check the nearest 3x3 turfs surrounding the src turf.
-	This implementation may produce false negatives but it (hopefully) will not produce any false postiives.
-*/
-
-/turf/simulated/proc/can_safely_remove_from_zone()
-	if(!zone) return 1
-
-	var/check_dirs = get_zone_neighbours(src)
-	var/unconnected_dirs = check_dirs
-
-	//src is only connected to the zone by a single direction, this is a safe removal.
-	if (!(check_dirs & (check_dirs - 1))) //Equivalent to: if(IsInteger(log(2, .)))
-		return TRUE
-
-	#ifdef MULTIZAS
-	var/to_check = global.cornerdirsz
-	#else
-	var/to_check = global.cornerdirs
-	#endif
-
-	for(var/dir in to_check)
-
-		//for each pair of "adjacent" cardinals (e.g. NORTH and WEST, but not NORTH and SOUTH)
-		if((dir & check_dirs) == dir)
-			//check that they are connected by the corner turf
-			var/connected_dirs = get_zone_neighbours(get_step(src, dir))
-			if(connected_dirs && (dir & global.reverse_dir[connected_dirs]) == dir)
-				unconnected_dirs &= ~dir //they are, so unflag the cardinals in question
-
-	//it is safe to remove src from the zone if all cardinals are connected by corner turfs
-	return !unconnected_dirs
-
-//helper for can_safely_remove_from_zone()
-/turf/simulated/proc/get_zone_neighbours(turf/simulated/T)
-	. = 0
-	if(istype(T) && T.zone)
-		#ifdef MULTIZAS
-		var/to_check = global.cardinalz
-		#else
-		var/to_check = global.cardinal
-		#endif
-		for(var/dir in to_check)
-			var/turf/simulated/other = get_step(T, dir)
-			if(istype(other) && other.zone == T.zone && !(other.c_airblock(T) & AIR_BLOCKED) && get_dist(src, other) <= 1)
-				. |= dir
-
-/turf/simulated/update_air_properties()
-
-	if(zone && zone.invalid) //this turf's zone is in the process of being rebuilt
+	if(zone?.invalid) //this turf's zone is in the process of being rebuilt
 		c_copy_air() //not very efficient :(
 		zone = null //Easier than iterating through the list at the zone.
 
@@ -137,8 +34,8 @@
 
 		return 1
 
-	var/previously_open = open_directions
-	open_directions = 0
+	var/previously_open = airflow_open_directions
+	airflow_open_directions = 0
 
 	var/list/postponed
 	#ifdef MULTIZAS
@@ -174,22 +71,20 @@
 
 			//Check that our zone hasn't been cut off recently.
 			//This happens when windows move or are constructed. We need to rebuild.
-			if((previously_open & d) && istype(unsim, /turf/simulated))
-				var/turf/simulated/sim = unsim
-				if(zone && sim.zone == zone)
+			if((previously_open & d) && unsim.zone_membership_candidate)
+				if(zone && unsim.zone == zone)
 					zone.rebuild()
 					return
 
 			continue
 
-		open_directions |= d
+		airflow_open_directions |= d
 
-		if(istype(unsim, /turf/simulated))
+		if(unsim.zone_membership_candidate)
 
-			var/turf/simulated/sim = unsim
-			sim.open_directions |= global.reverse_dir[d]
+			unsim.airflow_open_directions |= global.reverse_dir[d]
 
-			if(TURF_HAS_VALID_ZONE(sim))
+			if(TURF_HAS_VALID_ZONE(unsim))
 
 				//Might have assigned a zone, since this happens for each direction.
 				if(!zone)
@@ -206,11 +101,11 @@
 
 						//Postpone this tile rather than exit, since a connection can still be made.
 						if(!postponed) postponed = list()
-						postponed.Add(sim)
+						postponed.Add(unsim)
 
 					else
 
-						sim.zone.add(src)
+						unsim.zone.add(src)
 
 						#ifdef ZASDBG
 						dbg(zasdbgovl_assigned)
@@ -218,14 +113,14 @@
 							zas_log("Added to [zone]")
 						#endif
 
-				else if(sim.zone != zone)
+				else if(unsim.zone != zone)
 
 					#ifdef ZASDBG
 					if(verbose)
-						zas_log("Connecting to [sim.zone]")
+						zas_log("Connecting to [unsim.zone]")
 					#endif
 
-					SSair.connect(src, sim)
+					SSair.connect(src, unsim)
 
 
 			#ifdef ZASDBG
@@ -259,58 +154,114 @@
 	for(var/turf/T in postponed)
 		SSair.connect(src, T)
 
+
+
+
+
+
+
+
+/*
+	Simple heuristic for determining if removing the turf from it's zone will not partition the zone (A very bad thing).
+	Instead of analyzing the entire zone, we only check the nearest 3x3 turfs surrounding the src turf.
+	This implementation may produce false negatives but it (hopefully) will not produce any false postiives.
+*/
+
+/turf/proc/can_safely_remove_from_zone()
+	if(!zone) return 1
+
+	var/check_dirs = get_zone_neighbours(src)
+	var/unconnected_dirs = check_dirs
+
+	//src is only connected to the zone by a single direction, this is a safe removal.
+	if (!(check_dirs & (check_dirs - 1))) //Equivalent to: if(IsInteger(log(2, .)))
+		return TRUE
+
+	#ifdef MULTIZAS
+	var/to_check = global.cornerdirsz
+	#else
+	var/to_check = global.cornerdirs
+	#endif
+
+	for(var/dir in to_check)
+
+		//for each pair of "adjacent" cardinals (e.g. NORTH and WEST, but not NORTH and SOUTH)
+		if((dir & check_dirs) == dir)
+			//check that they are connected by the corner turf
+			var/connected_dirs = get_zone_neighbours(get_step(src, dir))
+			if(connected_dirs && (dir & global.reverse_dir[connected_dirs]) == dir)
+				unconnected_dirs &= ~dir //they are, so unflag the cardinals in question
+
+	//it is safe to remove src from the zone if all cardinals are connected by corner turfs
+	return !unconnected_dirs
+
+//helper for can_safely_remove_from_zone()
+/turf/proc/get_zone_neighbours(turf/T)
+	. = 0
+	if(istype(T) && T.zone)
+		#ifdef MULTIZAS
+		var/to_check = global.cardinalz
+		#else
+		var/to_check = global.cardinal
+		#endif
+		for(var/dir in to_check)
+			var/turf/other = get_step(T, dir)
+			if(isturf(other) && other.zone_membership_candidate && other.zone == T.zone && !(other.c_airblock(T) & AIR_BLOCKED) && get_dist(src, other) <= 1)
+				. |= dir
+
 /turf/proc/post_update_air_properties()
 	if(connections) connections.update_all()
 
 /turf/assume_air(datum/gas_mixture/giver) //use this for machines to adjust air
+	var/datum/gas_mixture/my_air = return_air()
+	if(my_air)
+		my_air.merge(giver)
+		return TRUE
 	return FALSE
 
-/turf/proc/assume_gas(gasid, moles, temp = 0)
-	return 0
-
 /turf/return_air()
-	//Create gas mixture to hold data for passing
-	var/datum/gas_mixture/GM = new
 
-	if(initial_gas)
-		GM.gas = initial_gas.Copy()
-	GM.temperature = temperature
-	GM.update_values()
+	// ZAS participation
+	if(zone && !zone.invalid)
+		SSair.mark_zone_update(zone)
+		return zone.air
 
-	return GM
+	// Exterior turf global atmosphere
+	if(external_atmosphere_participation && is_outside())
+		var/datum/level_data/level = SSmapping.levels_by_z[z]
+		var/datum/gas_mixture/gas = level?.get_exterior_atmosphere()
+		if(!gas)
+			return
+		var/initial_temperature = gas.temperature
+		if(weather)
+			initial_temperature = weather.adjust_temperature(initial_temperature)
+		for(var/thing in affecting_heat_sources)
+			if((gas.temperature - initial_temperature) >= 100)
+				break
+			var/obj/structure/fire_source/heat_source = thing
+			gas.temperature = gas.temperature + heat_source.exterior_temperature / max(1, get_dist(src, get_turf(heat_source)))
+		return gas
+
+	// Base behavior
+	. = air
+	if(!.)
+		. = make_air()
+		if(zone)
+			c_copy_air()
 
 /turf/remove_air(amount as num)
 	var/datum/gas_mixture/GM = return_air()
 	return GM.remove(amount)
 
-/turf/simulated/assume_air(datum/gas_mixture/giver)
+/turf/proc/assume_gas(gasid, moles, temp = null)
 	var/datum/gas_mixture/my_air = return_air()
-	return my_air?.merge(giver)
-
-/turf/simulated/assume_gas(gasid, moles, temp = null)
-	var/datum/gas_mixture/my_air = return_air()
-
-	if(isnull(temp))
-		my_air.adjust_gas(gasid, moles)
-	else
-		my_air.adjust_gas_temp(gasid, moles, temp)
-
-	return 1
-
-/turf/simulated/return_air()
-	if(zone)
-		if(!zone.invalid)
-			SSair.mark_zone_update(zone)
-			return zone.air
+	if(my_air)
+		if(isnull(temp))
+			my_air.adjust_gas(gasid, moles)
 		else
-			if(!air)
-				make_air()
-			c_copy_air()
-			return air
-	else
-		if(!air)
-			make_air()
-		return air
+			my_air.adjust_gas_temp(gasid, moles, temp)
+		return TRUE
+	return FALSE
 
 /turf/proc/make_air()
 	air = new/datum/gas_mixture
@@ -318,8 +269,10 @@
 	if(initial_gas)
 		air.gas = initial_gas.Copy()
 	air.update_values()
+	return air
 
-/turf/simulated/proc/c_copy_air()
-	if(!air) air = new/datum/gas_mixture
+/turf/proc/c_copy_air()
+	if(!air)
+		air = new/datum/gas_mixture
 	air.copy_from(zone.air)
 	air.group_multiplier = 1

--- a/code/modules/ZAS/Zone.dm
+++ b/code/modules/ZAS/Zone.dm
@@ -101,7 +101,7 @@ Class Procs:
 	ASSERT(!into.invalid)
 #endif
 	c_invalidate()
-	for(var/turf/T in contents)
+	for(var/turf/T as anything in contents)
 		if(!T.zone_membership_candidate)
 			continue
 		into.add(T)
@@ -121,7 +121,7 @@ Class Procs:
 	invalid = 1
 	SSair.remove_zone(src)
 	#ifdef ZASDBG
-	for(var/turf/T in contents)
+	for(var/turf/T as anything in contents)
 		T.dbg(zasdbgovl_invalid_zone)
 	#endif
 
@@ -129,7 +129,7 @@ Class Procs:
 	set waitfor = 0
 	if(invalid) return //Short circuit for explosions where rebuild is called many times over.
 	c_invalidate()
-	for(var/turf/T in contents)
+	for(var/turf/T as anything in contents)
 		T.update_graphic(graphic_remove = air.graphic) //we need to remove the overlays so they're not doubled when the zone is rebuilt
 		T.needs_air_update = 0 //Reset the marker so that it will be added to the list.
 		SSair.mark_for_update(T)
@@ -153,7 +153,7 @@ Class Procs:
 
 	// Update gas overlays.
 	if(air.check_tile_graphic(graphic_add, graphic_remove))
-		for(var/turf/T in contents)
+		for(var/turf/T as anything in contents)
 			T.update_graphic(graphic_add, graphic_remove)
 			CHECK_TICK
 		graphic_add.len = 0
@@ -172,7 +172,7 @@ Class Procs:
 	// Update atom temperature.
 	if(abs(air.temperature - last_air_temperature) >= ATOM_TEMPERATURE_EQUILIBRIUM_THRESHOLD)
 		last_air_temperature = air.temperature
-		for(var/turf/T in contents)
+		for(var/turf/T as anything in contents)
 			for(var/check_atom in T.contents)
 				var/atom/checking = check_atom
 				if(checking.simulated)

--- a/code/modules/admin/verbs/grief_fixers.dm
+++ b/code/modules/admin/verbs/grief_fixers.dm
@@ -39,7 +39,7 @@
 		var/decl/material/mat = all_gasses[id]
 		unsorted_overlays |= mat.gas_tile_overlay
 
-	for(var/turf/T)
+	for(var/turf/T in world)
 		T.air = null
 		T.overlays.Remove(unsorted_overlays)
 		T.zone = null

--- a/code/modules/admin/verbs/grief_fixers.dm
+++ b/code/modules/admin/verbs/grief_fixers.dm
@@ -39,7 +39,7 @@
 		var/decl/material/mat = all_gasses[id]
 		unsorted_overlays |= mat.gas_tile_overlay
 
-	for(var/turf/simulated/T in world)
+	for(var/turf/T)
 		T.air = null
 		T.overlays.Remove(unsorted_overlays)
 		T.zone = null

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -207,13 +207,9 @@ var/global/list/debug_verbs = list (
 	if(!check_rights(R_DEBUG)) return
 	testZAScolors_remove()
 
-	var/turf/simulated/location = get_turf(usr)
+	var/turf/location = get_turf(usr)
 
-	if(!istype(location, /turf/simulated))
-		to_chat(src, SPAN_WARNING("This debug tool can only be used while on a simulated turf."))
-		return
-
-	if(!location.zone)
+	if(!isturf(location) && !location.zone)
 		to_chat(src, SPAN_WARNING("The turf you are standing on does not have a zone."))
 		return
 

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -208,8 +208,7 @@ var/global/list/debug_verbs = list (
 	testZAScolors_remove()
 
 	var/turf/location = get_turf(usr)
-
-	if(!isturf(location) && !location.zone)
+	if(!location?.zone)
 		to_chat(src, SPAN_WARNING("The turf you are standing on does not have a zone."))
 		return
 

--- a/code/modules/atmospherics/datum_pipeline.dm
+++ b/code/modules/atmospherics/datum_pipeline.dm
@@ -201,7 +201,7 @@
 	var/total_heat_capacity = air.heat_capacity()
 	var/partial_heat_capacity = total_heat_capacity*(share_volume/air.volume)
 
-	if(SHOULD_PARTICIPATE_IN_ZAS(target) && !target.blocks_air)
+	if(SHOULD_PARTICIPATE_IN_ZONES(target) && !target.blocks_air)
 		var/delta_temperature = 0
 		var/sharer_heat_capacity = 0
 

--- a/code/modules/atmospherics/datum_pipeline.dm
+++ b/code/modules/atmospherics/datum_pipeline.dm
@@ -162,7 +162,7 @@
 
 	return network
 
-/datum/pipeline/proc/mingle_with_turf(turf/simulated/target, mingle_volume)
+/datum/pipeline/proc/mingle_with_turf(turf/target, mingle_volume)
 
 	if(!isturf(target))
 		return
@@ -170,7 +170,7 @@
 	var/datum/gas_mixture/air_sample = air.remove_ratio(mingle_volume/air.volume)
 	air_sample.volume = mingle_volume
 
-	if(istype(target) && target.zone)
+	if(target.zone)
 		//Have to consider preservation of group statuses
 		var/datum/gas_mixture/turf_copy = new
 
@@ -201,18 +201,16 @@
 	var/total_heat_capacity = air.heat_capacity()
 	var/partial_heat_capacity = total_heat_capacity*(share_volume/air.volume)
 
-	if(istype(target, /turf/simulated) && !target.blocks_air)
-		var/turf/simulated/modeled_location = target
-
+	if(SHOULD_PARTICIPATE_IN_ZAS(target) && !target.blocks_air)
 		var/delta_temperature = 0
 		var/sharer_heat_capacity = 0
 
-		if(modeled_location.zone)
-			delta_temperature = (air.temperature - modeled_location.zone.air.temperature)
-			sharer_heat_capacity = modeled_location.zone.air.heat_capacity()
+		if(target.zone)
+			delta_temperature = (air.temperature - target.zone.air.temperature)
+			sharer_heat_capacity = target.zone.air.heat_capacity()
 		else
-			delta_temperature = (air.temperature - modeled_location.air.temperature)
-			sharer_heat_capacity = modeled_location.air.heat_capacity()
+			delta_temperature = (air.temperature - target.air.temperature)
+			sharer_heat_capacity = target.air.heat_capacity()
 
 		var/self_temperature_delta = 0
 		var/sharer_temperature_delta = 0
@@ -228,10 +226,10 @@
 
 		air.temperature += self_temperature_delta
 
-		if(modeled_location.zone)
-			modeled_location.zone.air.temperature += sharer_temperature_delta/modeled_location.zone.air.group_multiplier
+		if(target.zone)
+			target.zone.air.temperature += sharer_temperature_delta/target.zone.air.group_multiplier
 		else
-			modeled_location.air.temperature += sharer_temperature_delta
+			target.air.temperature += sharer_temperature_delta
 
 	else if(istype(target, /turf/exterior) && !target.blocks_air)
 		var/turf/exterior/modeled_location = target

--- a/code/modules/overmap/ships/ship_physics.dm
+++ b/code/modules/overmap/ships/ship_physics.dm
@@ -37,7 +37,7 @@
 /obj/effect/overmap/visitable/ship/proc/recalculate_vessel_mass()
 	var/list/zones = list()
 	for(var/area/A in get_areas())
-		for(var/turf/simulated/T in A)
+		for(var/turf/T in A)
 			if(T.is_open())
 				continue
 
@@ -51,7 +51,9 @@
 				if(W.girder_material)
 					. += W.girder_material.weight * 5
 
-			zones |= T.zone
+			if(T.zone)
+				zones |= T.zone
+
 			for(var/atom/movable/C in T)
 				if(!C.simulated)
 					continue

--- a/code/unit_tests/mob_tests.dm
+++ b/code/unit_tests/mob_tests.dm
@@ -65,7 +65,7 @@ var/global/default_mobloc = null
 	if(isnull(mobloc))
 		if(!default_mobloc)
 			for(var/turf/simulated/floor/tiled/T in world)
-				if(!T.zone || !T.zone.air)
+				if(!T.zone?.air)
 					continue
 				var/pressure = T.zone.air.return_pressure()
 				if(90 < pressure && pressure < 120) // Find a turf between 90 and 120

--- a/code/unit_tests/zas_tests.dm
+++ b/code/unit_tests/zas_tests.dm
@@ -46,9 +46,9 @@
 
 	var/list/GM_checked = list()
 
-	for(var/turf/simulated/T in A)
+	for(var/turf/T in A)
 
-		if(!istype(T) || isnull(T.zone) || istype(T, /turf/simulated/floor/airless))
+		if(isnull(T.zone) || istype(T, /turf/simulated/floor/airless))
 			continue
 		if(T.zone.air in GM_checked)
 			continue

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -32,7 +32,7 @@ exactly 2 "/mob text paths" '"/mob'
 exactly 6 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
 exactly 1 "world<< uses" 'world<<|world[[:space:]]<<'
-exactly 90 "'in world' uses" 'in world'
+exactly 92 "'in world' uses" 'in world'
 exactly 1 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
 exactly 18 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 10 ">> uses" '>>(?!>)' -P

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -32,7 +32,7 @@ exactly 2 "/mob text paths" '"/mob'
 exactly 6 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
 exactly 1 "world<< uses" 'world<<|world[[:space:]]<<'
-exactly 91 "'in world' uses" 'in world'
+exactly 90 "'in world' uses" 'in world'
 exactly 1 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
 exactly 18 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 10 ">> uses" '>>(?!>)' -P


### PR DESCRIPTION
## Description of changes
- Removes a bunch of typechecking of turfs in favour of `SHOULD_PARTICIPATE_IN_ZAS()` which checks some turf vars/state.
- Moves a bunch of atmos handling (including `zone`) onto `/turf`.
- Unifies several air return procs such as exterior turf's global atmos on `/turf`. Turfs will use zone if present, global atmos if allowed, and their own air value if all else fails.

## Why and what will this PR improve
Steps towards unifying turfs to cut down on redundant or dead code and make turfs behave more consistently and interestingly.

## Authorship
Myself, with help from @Lohikar and @Kapu1178.

## Changelog
:cl:
tweak: Some significant changes to the core atmospherics simulation; please report bugs.
/:cl: