### PR TITLE
Comments most of Atom.dm

### DIFF
--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -354,10 +354,10 @@ var/global/list/global/tank_gauge_cache = list()
 	return air_contents
 
 /obj/item/tank/assume_air(datum/gas_mixture/giver)
-	air_contents.merge(giver)
+	. = air_contents.merge(giver)
 	check_status()
 	queue_icon_update()
-	return 1
+	return .
 
 /obj/item/tank/proc/remove_air_volume(volume_to_return)
 	if(!air_contents)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -357,7 +357,6 @@ var/global/list/global/tank_gauge_cache = list()
 	. = air_contents.merge(giver)
 	check_status()
 	queue_icon_update()
-	return .
 
 /obj/item/tank/proc/remove_air_volume(volume_to_return)
 	if(!air_contents)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -38,22 +38,13 @@
 	. = CEILING(w_class * BASE_OBJECT_MATTER_MULTPLIER)
 
 /obj/assume_air(datum/gas_mixture/giver)
-	if(loc)
-		return loc.assume_air(giver)
-	else
-		return FALSE
+	return loc?.assume_air(giver)
 
 /obj/remove_air(amount)
-	if(loc)
-		return loc.remove_air(amount)
-	else
-		return null
+	return loc?.remove_air(amount)
 
 /obj/return_air()
-	if(loc)
-		return loc.return_air()
-	else
-		return null
+	return loc?.return_air()
 
 /obj/proc/updateUsrDialog()
 	if(in_use)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -41,7 +41,7 @@
 	if(loc)
 		return loc.assume_air(giver)
 	else
-		return null
+		return FALSE
 
 /obj/remove_air(amount)
 	if(loc)

--- a/code/modules/ZAS/Turf.dm
+++ b/code/modules/ZAS/Turf.dm
@@ -263,7 +263,7 @@
 	if(connections) connections.update_all()
 
 /turf/assume_air(datum/gas_mixture/giver) //use this for machines to adjust air
-	return 0
+	return FALSE
 
 /turf/proc/assume_gas(gasid, moles, temp = 0)
 	return 0
@@ -285,7 +285,7 @@
 
 /turf/simulated/assume_air(datum/gas_mixture/giver)
 	var/datum/gas_mixture/my_air = return_air()
-	my_air.merge(giver)
+	return my_air.merge(giver)
 
 /turf/simulated/assume_gas(gasid, moles, temp = null)
 	var/datum/gas_mixture/my_air = return_air()

--- a/code/modules/ZAS/Turf.dm
+++ b/code/modules/ZAS/Turf.dm
@@ -285,7 +285,7 @@
 
 /turf/simulated/assume_air(datum/gas_mixture/giver)
 	var/datum/gas_mixture/my_air = return_air()
-	return my_air.merge(giver)
+	return my_air?.merge(giver)
 
 /turf/simulated/assume_gas(gasid, moles, temp = null)
 	var/datum/gas_mixture/my_air = return_air()

--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -34,6 +34,10 @@
 	add_hiddenprint(M)
 	return 1
 
+/// Reveal any blood on the item and update its color to that of luminol
+/atom/proc/reveal_blood()
+	return
+
 /atom/proc/add_fibers(obj/item/clothing/source)
 	if(!istype(source) || (source.item_flags & ITEM_FLAG_NO_PRINT))
 		return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -818,6 +818,9 @@ default behaviour is:
 /mob/living/proc/get_digestion_product()
 	return null
 
+/mob/living/proc/handle_additional_vomit_reagents(var/obj/effect/decal/cleanable/vomit/vomit)
+	vomit.reagents.add_reagent(/decl/material/liquid/acid/stomach, 5)
+
 /mob/living/proc/eyecheck()
 	return FLASH_PROTECTION_NONE
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -542,6 +542,16 @@
 /mob/proc/is_ready()
 	return client && !!mind
 
+/mob/proc/can_touch(var/atom/touching)
+	if(!touching.Adjacent(src) || incapacitated())
+		return FALSE
+	if(restrained())
+		to_chat(src, SPAN_WARNING("You are restrained."))
+		return FALSE
+	if (buckled)
+		to_chat(src, SPAN_WARNING("You are buckled down."))
+	return TRUE
+
 /mob/proc/see(message)
 	if(!is_active())
 		return 0

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -86,11 +86,11 @@
 	update_values()
 
 
-//Merges all the gas from another mixture into this one.  Respects group_multipliers and adjusts temperature correctly.
-//Does not modify giver in any way.
+/// Merges all the gas from another mixture into this one.  Respects group_multipliers and adjusts temperature correctly.
+/// Does not modify giver in any way.
 /datum/gas_mixture/proc/merge(const/datum/gas_mixture/giver)
 	if(!giver)
-		return
+		return FALSE
 
 	if(abs(temperature-giver.temperature)>MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER)
 		var/self_heat_capacity = heat_capacity()
@@ -107,6 +107,7 @@
 			gas[g] += giver.gas[g]
 
 	update_values()
+	return TRUE
 
 // Used to equalize the mixture between two zones before sleeping an edge.
 /datum/gas_mixture/proc/equalize(datum/gas_mixture/sharer)


### PR DESCRIPTION
## Description of changes
Adds doc comments to most of atom.dm, moves reveal_blood() to forensics.dm and handle_additional_vomit_reagents() to living.dm. This commit shouldn't change any functionality.

Variables have their expected values/type listed. For example:
```
/// (1|2|3) If it shows up under UV light. 0 doesn't, 1 does, 2 is currently glowing due to UV light.
/// (DICTIONARY) A lazy map. The `key` is a MD5 playername and the `value` is the blood type.
```
When hovered over, this looks like:
![image](https://user-images.githubusercontent.com/12163281/229383297-c91e965b-e55f-454c-b0ca-e0872734011b.png)

Procs have a short description of functionality followed by a larger description and nuances. They then list parameters, expected return, raised events, see file, and TODO. For example:
```
/**
	Set the direction of this atom to `new_dir`
	- `new_dir`: The new direction the atom should face.
	- Returns: `TRUE` if the direction has been changed.
	- Events: `dir_set`
*/
```
When hovered over, this looks like:
![image](https://user-images.githubusercontent.com/12163281/229383206-a352183b-1d66-46af-9dd9-78f8d983499c.png)

I'm open to style changes to make things clearer :V

## Why and what will this PR improve
Helps future contributors implement and maintain consistent functionality.

## Authorship
Myself