### PR TITLE
Fix duplicate air alarm naming code

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -135,7 +135,7 @@
 
 /obj/machinery/alarm/Initialize(mapload, var/dir)
 	. = ..()
-	if (name != "alarm")
+	if (name != BASE_ALARM_NAME)
 		custom_alarm_name = TRUE // this will prevent us from messing with alarms with names set on map
 
 	set_frequency(frequency)
@@ -143,7 +143,6 @@
 	if(!alarm_area)
 		return // spawned in nullspace, presumably as a prototype for construction purposes.
 	area_uid = alarm_area.uid
-	update_name(FALSE)
 
 	// breathable air according to human/Life()
 	var/decl/material/gas_mat = GET_DECL(/decl/material/gas/oxygen)
@@ -160,16 +159,6 @@
 			trace_gas += g
 
 	queue_icon_update()
-
-/obj/machinery/alarm/area_changed(area/old_area, area/new_area)
-	. = ..()
-	alarm_area = get_area(src)
-	update_name(TRUE)
-
-/obj/machinery/alarm/proc/update_name(var/reset = TRUE)
-	name = initial(name)
-	if(name == BASE_ALARM_NAME && alarm_area && alarm_area != global.space_area)
-		SetName("[alarm_area.proper_name] [BASE_ALARM_NAME]")
 
 /obj/machinery/alarm/modify_mapped_vars(map_hash)
 	..()
@@ -793,7 +782,7 @@
 	if(A != alarm_area)
 		return
 	if (!custom_alarm_name)
-		SetName("[A.proper_name] Air Alarm")
+		SetName("[A.proper_name] [BASE_ALARM_NAME]")
 
 /obj/machinery/alarm/area_changed(area/old_area, area/new_area)
 	. = ..()
@@ -806,7 +795,7 @@
 	if(old_area && old_area == alarm_area)
 		alarm_area = null
 		area_uid = null
-		events_repository.register(/decl/observ/name_set, old_area, src, .proc/change_area_name)
+		events_repository.unregister(/decl/observ/name_set, old_area, src, .proc/change_area_name)
 	if(new_area)
 		ASSERT(isnull(alarm_area))
 		alarm_area = new_area


### PR DESCRIPTION
## Description of changes
For some reason there were two entirely separate systems for naming air alarms; this makes it so there's just one.

## Why and what will this PR improve
Automatic air alarm naming should work properly now.