### PR TITLE
Fix machines regaining power on area change

### DIFF
--- a/code/game/machinery/_machines_base/machinery_power.dm
+++ b/code/game/machinery/_machines_base/machinery_power.dm
@@ -114,13 +114,10 @@ This is /obj/machinery level code to properly manage power usage from the area.
 	if(old_area == new_area)
 		return
 	var/power = get_power_usage()
-	if(!power)
-		return // This is the most likely case anyway.
-
 	if(old_area)
 		old_area.power_use_change(power, 0, power_channel)
 		if(MACHINE_UPDATES_FROM_AREA_POWER)
-			events_repository.unregister(/decl/observ/area_power_change, old_area, src, .proc/power_change)	
+			events_repository.unregister(/decl/observ/area_power_change, old_area, src, .proc/power_change)
 	if(new_area)
 		new_area.power_use_change(0, power, power_channel)
 		if(MACHINE_UPDATES_FROM_AREA_POWER)


### PR DESCRIPTION
## Description of changes
Removes an early return that prevents `power_change()` from being called on machines that don't use power every tick.

## Why and what will this PR improve
This fixes lights and airlocks not updating after their area changes while the power is out. This is an issue with changing an area via blueprints, since you remove the APC before deleting and remaking the area.