### PR TITLE
Add handling for lightswitch area change

### DIFF
--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -84,3 +84,14 @@
 		to_chat(user, SPAN_NOTICE("You flick \the [src] with \the [I]."))
 		interface_interact(user)
 		return TRUE
+
+/obj/machinery/light_switch/area_changed(area/old_area, area/new_area)
+	. = ..()
+	if(QDELETED(src))
+		return
+	if(other_area)
+		return
+	if(!new_area || old_area == new_area)
+		return
+	connected_area = new_area
+	sync_state()


### PR DESCRIPTION
## Description of changes
Makes lightswitches change their connected area and sync their state when their area changes.

## Why and what will this PR improve
Fixes lightswitches becoming out of sync/not working after an area change (via blueprints, for example).