### PR TITLE
Fix APCs resetting twice on in-round construction

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -180,9 +180,9 @@ var/global/list/all_apcs = list()
 	global.all_apcs += src
 	if(areastring)
 		reset_area(null, get_area_by_name(strip_improper(areastring)))
-	else
+	else if (mapload) //if area isn't specified during mapload use current
 		reset_area(null, get_area(src))
-		//if area isn't specified use current
+	// otherwise, it'll be handled by Entered/area_changed
 	if(!area)
 		return ..() // Spawned in nullspace means it's a test entity or prototype.
 


### PR DESCRIPTION
## Description of changes
Puts the `reset_area()` call in `apc/Initialize()` behind a `mapload` check, since APCs constructed during the round will trigger an area changed event on creation.

## Why and what will this PR improve
Fixes a runtime from an assert in APC area reset code failing.