### PR TITLE
Adds basic shuttle-modifying blueprints

### DIFF
--- a/code/datums/extensions/eye/blueprints.dm
+++ b/code/datums/extensions/eye/blueprints.dm
@@ -30,3 +30,8 @@
 	procname = "remove_area"
 	button_icon_state = "remove_area"
 	target_type = EYE_TARGET
+
+// Shuttle blueprints subtype (handles shuttle.shuttle_area)
+/datum/extension/eye/blueprints/shuttle
+	expected_type = /obj/item/blueprints/shuttle
+	eye_type = /mob/observer/eye/blueprints/shuttle

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -58,6 +58,8 @@ var/global/list/areas = list()
 
 	var/tmp/is_outside = OUTSIDE_NO
 
+	var/tmp/saved_map_hash // Used for cleanup when loaded via map templates.
+
 /area/New()
 	icon_state = ""
 	uid = ++global_uid

--- a/code/modules/maps/_map_template.dm
+++ b/code/modules/maps/_map_template.dm
@@ -101,8 +101,16 @@
 		LAZYSET(SSshuttle.shuttles_to_initialize, shuttle_type, map_hash) // queue up for init.
 	if(map_hash)
 		SSshuttle.map_hash_to_areas[map_hash] = initialized_areas_by_type
+		for(var/area/A in initialized_areas_by_type)
+			A.saved_map_hash = map_hash
+			events_repository.register(/decl/observ/destroyed, A, src, .proc/cleanup_lateloaded_area)
 	SSshuttle.block_queue = pre_init_state
 	SSshuttle.clear_init_queue() // We will flush the queue unless there were other blockers, in which case they will do it.
+
+/datum/map_template/proc/cleanup_lateloaded_area(area/destroyed_area)
+	events_repository.unregister(/decl/observ/destroyed, destroyed_area, src, .proc/cleanup_lateloaded_area)
+	if(destroyed_area.saved_map_hash)
+		SSshuttle.map_hash_to_areas[destroyed_area.saved_map_hash] -= destroyed_area
 
 /datum/map_template/proc/load_new_z(no_changeturf = TRUE, centered=TRUE)
 	var/x = max(round((world.maxx - width)/2), 1)

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -45,18 +45,19 @@
 	if(!isnull(shuttle_area))
 		if(!islist(shuttle_area))
 			shuttle_area = list(shuttle_area)
-		for(var/T in shuttle_area)
-			if(istype(T, /area)) // If the shuttle area is already a type, it does not need to be located.
-				areas += T
+		for(var/area_type in shuttle_area)
+			if(istype(area_type, /area)) // If the shuttle area is already an instance, it does not need to be located.
+				areas += area_type
 				continue
 			var/area/A
 			if(map_hash && islist(SSshuttle.map_hash_to_areas[map_hash]))
-				A = SSshuttle.map_hash_to_areas[map_hash][T] // We try to find the correct area of the given type.
+				A = SSshuttle.map_hash_to_areas[map_hash][area_type] // We try to find the correct area of the given type.
 			else
-				A = locate(T) // But if this is a mainmap shuttle, there is only one anyway so just find it.
+				A = locate(area_type) // But if this is a mainmap shuttle, there is only one anyway so just find it.
 			if(!istype(A))
-				CRASH("Shuttle \"[name]\" couldn't locate area [T].")
+				CRASH("Shuttle \"[name]\" couldn't locate area [area_type].")
 			areas += A
+			events_repository.register(/decl/observ/destroyed, A, src, .proc/remove_shuttle_area)
 		shuttle_area = areas
 
 	if(initial_location)
@@ -77,6 +78,13 @@
 		if(SSsupply.shuttle)
 			CRASH("A supply shuttle is already defined.")
 		SSsupply.shuttle = src
+
+/datum/shuttle/proc/remove_shuttle_area(area/area_to_remove)
+	events_repository.unregister(/decl/observ/destroyed, area_to_remove, src, .proc/remove_shuttle_area)
+	SSshuttle.shuttle_areas -= area_to_remove
+	shuttle_area -= area_to_remove
+	if(!length(shuttle_area))
+		qdel(src)
 
 /datum/shuttle/Destroy()
 	current_location = null

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -48,6 +48,7 @@
 		for(var/area_type in shuttle_area)
 			if(istype(area_type, /area)) // If the shuttle area is already an instance, it does not need to be located.
 				areas += area_type
+				events_repository.register(/decl/observ/destroyed, area_type, src, .proc/remove_shuttle_area)
 				continue
 			var/area/A
 			if(map_hash && islist(SSshuttle.map_hash_to_areas[map_hash]))


### PR DESCRIPTION
## Description of changes
Adds shuttle blueprints that can add, remove, and rename shuttle areas.
Adds a Destroy hook to remove areas from shuttles on area deletion.
Adds some Destroy hooks to reduce references left on area deletion.
Blueprints now delete areas if the last turf that uses them is removed.

TODO (potentially for future PRs):
- [ ] Check that new areas are contiguous with the rest of the shuttle
- [ ] Rework blueprint UX (allow removing specific turfs from an area instead of deleting the whole thing? allow overwriting areas without deleting first if the turfs don't contain APCs?)
- [ ] Add length of shuttle name to the allowed length of area names (`Mining Vessel Operations Bay` was sadly two characters over in my testing, despite being the name the area had before I deleted it!)

## Why and what will this PR improve
Provides an easy way to modify an existing shuttle without needing a docking port.

## Authorship
Me.

## Changelog
:cl:
add: Added shuttle blueprints that can be used to add, remove, or rename shuttle areas.
/:cl: