### PR TITLE
Fix pulse-taking using the wrong pronouns

### DIFF
--- a/code/modules/mob/living/carbon/human/human_verbs.dm
+++ b/code/modules/mob/living/carbon/human/human_verbs.dm
@@ -175,7 +175,7 @@
 	var/self = (usr == src)
 	var/decl/pronouns/G = usr.get_pronouns()
 	if(!self)
-		var/decl/pronouns/target_gender = usr.get_pronouns()
+		var/decl/pronouns/target_gender = src.get_pronouns()
 		usr.visible_message( \
 			SPAN_NOTICE("\The [usr] kneels down, puts [G.his] hand on \the [src]'s wrist, and begins counting [target_gender.his] pulse."), \
 			SPAN_NOTICE("You begin counting \the [src]'s pulse."))


### PR DESCRIPTION
## Description of changes
target_gender used the wrong mob's pronouns.

## Why and what will this PR improve
The pronouns of the mob having their pulse taken will now be used properly, instead of using the pulse-taker's pronouns for both.