### PR TITLE
Replace make_floating with start/stop calls, removes floatiness

### DIFF
--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -1,31 +1,22 @@
 /mob/proc/do_jitter(amplitude)
 	pixel_x = default_pixel_x + rand(-amplitude, amplitude)
 	pixel_y = default_pixel_y + rand(-amplitude/3, amplitude/3)
-	
+
 //handles up-down floaty effect in space and zero-gravity
 /mob/var/is_floating = 0
-/mob/var/floatiness = 0
 
 /mob/proc/update_floating()
 
 	if(anchored || buckled || has_gravity())
-		make_floating(0)
+		stop_floating()
 		return
 
 	if(check_space_footing())
-		make_floating(0)
+		stop_floating()
 		return
 
-	make_floating(1)
+	start_floating()
 	return
-
-/mob/proc/make_floating(var/n)
-	floatiness = n
-
-	if(floatiness && !is_floating)
-		start_floating()
-	else if(!floatiness && is_floating)
-		stop_floating()
 
 /mob/proc/start_floating()
 

--- a/code/modules/mob/living/silicon/robot/flying/flying.dm
+++ b/code/modules/mob/living/silicon/robot/flying/flying.dm
@@ -31,7 +31,7 @@
 /mob/living/silicon/robot/flying/proc/start_flying()
 	pass_flags |= PASS_FLAG_TABLE
 	default_pixel_y = 0
-	make_floating(10)
+	start_floating()
 
 /mob/living/silicon/robot/flying/proc/stop_flying()
 	pass_flags &= ~PASS_FLAG_TABLE

--- a/mods/species/bayliens/adherent/organs/organs_internal.dm
+++ b/mods/species/bayliens/adherent/organs/organs_internal.dm
@@ -107,10 +107,10 @@
 	if(owner)
 		if(active)
 			owner.pass_flags |= PASS_FLAG_TABLE
-			if(owner.floatiness <= 5)
-				owner.make_floating(5)
+			owner.start_floating()
 		else
 			owner.pass_flags &= ~PASS_FLAG_TABLE
+			owner.update_floating() // stops conditionally, i.e. on solid ground but not in space
 
 /obj/item/organ/internal/eyes/adherent
 	name = "receptor prism"


### PR DESCRIPTION
## Description of changes
Removes the obsolete `floatiness` var from mobs.
Replaces `make_floating(0)` with `stop_floating()` and `make_floating(>0)` with `start_floating()`.
Adds an `update_floating()` call to adherent levitation plate code so that they stop floating only when nothing else is causing them to float.

PR is targeting dev because this is a relatively large change, and I don't feel comfortable targeting stable with it.

## Why and what will this PR improve
Fixes #2921. Removes a redundant var and proc that just made floating unnecessarily complicated.