### PR TITLE
Add feline bodytype to suit cycler

### DIFF
--- a/mods/species/bayliens/tajaran/machinery/suit_cycler.dm
+++ b/mods/species/bayliens/tajaran/machinery/suit_cycler.dm
@@ -1,0 +1,5 @@
+/obj/machinery/suit_cycler/Initialize()
+	. = ..()
+	available_bodytypes += BODYTYPE_FELINE
+
+// todo: add spritesheets here


### PR DESCRIPTION
## Description of changes
Adds the feline bodytype to the suit cycler, so Tajara can actually wear voidsuits.

## Why and what will this PR improve
Tajara can now wear voidsuits. Unfortunately, they don't have sprites, so they kind of look like ass? I don't really have a solution for that.