### PR TITLE
Set default solid form for plastic to panel

### DIFF
--- a/code/modules/materials/definitions/solids/materials_solid_organic.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_organic.dm
@@ -21,7 +21,7 @@
 	fuel_value = 0.6
 	burn_product = /decl/material/gas/carbon_monoxide // placeholder for more appropriate toxins
 	dooropen_noise = 'sound/effects/doorcreaky.ogg'
-	default_solid_form = /obj/item/stack/material/sheet
+	default_solid_form = /obj/item/stack/material/panel
 	sound_manipulate = 'sound/foley/paperpickup2.ogg'
 	sound_dropped = 'sound/foley/paperpickup1.ogg'
 


### PR DESCRIPTION
## Description of changes
Plastic sheets now have `/obj/item/stack/material/panel` as their `default_solid_form`, matching the frequent use of `/obj/item/stack/material/panel/mapped/plastic`.

Targeting staging because it looks like this was just an oversight; even the iconstate names point to that. If not, it's trivial to rebase. Not targeting stable because lol merge conflicts, I just wanted to cherrypick.

## Why and what will this PR improve
Every single use of plastic material stack objects in the codebase is panels, except for one case where struts are used instead. However, ejecting plastic from an autolathe currently just gives ugly grey sheets instead of panels (which also happen to have the icon_state `"sheet-plastic"`, huh!). This makes it consistent.

## Changelog
:cl:
tweak: Stacks of plastic will now be printed from autolathes as panels instead of sheets.
/:cl: