### PR TITLE
Small perf fix for area turf initializers

### DIFF
--- a/code/game/turfs/initialization/init.dm
+++ b/code/game/turfs/initialization/init.dm
@@ -4,9 +4,9 @@
 /area
 	var/turf_initializer = null
 
-/area/Initialize()
+/area/Initialize(mapload)
 	. = ..()
-	for(var/turf/T in src)
-		if(turf_initializer)
-			var/decl/turf_initializer/ti = GET_DECL(turf_initializer)
+	if(ispath(turf_initializer))
+		var/decl/turf_initializer/ti = GET_DECL(turf_initializer)
+		for(var/turf/T in src)
 			ti.InitializeTurf(T)


### PR DESCRIPTION
## Description of changes
The turf initializer code was making all areas always iterate all their turfs on init even if the area didn't have an initializer.

## Why and what will this PR improve
Gotta go fast!