### PR TITLE
Make overmap list indexed

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -197,7 +197,7 @@ var/global/log_end= world.system_type == UNIX ? ascii2text(13) : ""
 	return "[..()] ([isnum(z) ? "[x],[y],[z]" : "0,0,0"])"
 
 /turf/get_log_info_line()
-	var/obj/effect/overmap/visitable/O = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/O = global.overmap_sectors[z]
 	if(istype(O))
 		return "[..()] ([x],[y],[z] - [O.name]) ([loc ? loc.type : "NULL"])"
 	else
@@ -206,7 +206,7 @@ var/global/log_end= world.system_type == UNIX ? ascii2text(13) : ""
 /atom/movable/get_log_info_line()
 	var/turf/t = get_turf(src)
 	if(t)
-		var/obj/effect/overmap/visitable/O = global.overmap_sectors[num2text(t.z)]
+		var/obj/effect/overmap/visitable/O = global.overmap_sectors[t.z]
 		if(istype(O))
 			return "[..()] ([t]) ([t.x],[t.y],[t.z] - [O.name]) ([t.type])"
 		return "[..()] ([t]) ([t.x],[t.y],[t.z]) ([t.type])"

--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -197,7 +197,7 @@ var/global/log_end= world.system_type == UNIX ? ascii2text(13) : ""
 	return "[..()] ([isnum(z) ? "[x],[y],[z]" : "0,0,0"])"
 
 /turf/get_log_info_line()
-	var/obj/effect/overmap/visitable/O = global.overmap_sectors[z]
+	var/obj/effect/overmap/visitable/O = global.overmap_sectors_by_z[z]
 	if(istype(O))
 		return "[..()] ([x],[y],[z] - [O.name]) ([loc ? loc.type : "NULL"])"
 	else
@@ -206,7 +206,7 @@ var/global/log_end= world.system_type == UNIX ? ascii2text(13) : ""
 /atom/movable/get_log_info_line()
 	var/turf/t = get_turf(src)
 	if(t)
-		var/obj/effect/overmap/visitable/O = global.overmap_sectors[t.z]
+		var/obj/effect/overmap/visitable/O = global.overmap_sectors_by_z[t.z]
 		if(istype(O))
 			return "[..()] ([t]) ([t.x],[t.y],[t.z] - [O.name]) ([t.type])"
 		return "[..()] ([t]) ([t.x],[t.y],[t.z]) ([t.type])"

--- a/code/_helpers/overmap.dm
+++ b/code/_helpers/overmap.dm
@@ -1,3 +1,5 @@
-var/global/list/overmap_sectors =  list()
+///List of all the z levels, and the  /obj/effect/overmap/visitable/sector that's associated with it, if any.
+var/global/list/overmap_sectors_by_z =  list()
 var/global/list/overmaps_by_name = list()
+///List of all z levels and the /datum/overmap associated to them if any.
 var/global/list/overmaps_by_z =    list()

--- a/code/controllers/subsystems/initialization/materials.dm
+++ b/code/controllers/subsystems/initialization/materials.dm
@@ -136,7 +136,7 @@ SUBSYSTEM_DEF(materials)
 /datum/controller/subsystem/materials/proc/get_strata(var/turf/exterior/wall/location)
 	if(!istype(location))
 		return
-	var/obj/effect/overmap/visitable/sector/exoplanet/planet = global.overmap_sectors_by_z[num2text(location.z)]
+	var/obj/effect/overmap/visitable/sector/exoplanet/planet = global.overmap_sectors_by_z[location.z]
 	if(istype(planet))
 		return planet.get_strata(location)
 	var/s_key = "[location.z]"

--- a/code/controllers/subsystems/initialization/materials.dm
+++ b/code/controllers/subsystems/initialization/materials.dm
@@ -136,7 +136,7 @@ SUBSYSTEM_DEF(materials)
 /datum/controller/subsystem/materials/proc/get_strata(var/turf/exterior/wall/location)
 	if(!istype(location))
 		return
-	var/obj/effect/overmap/visitable/sector/exoplanet/planet = global.overmap_sectors[num2text(location.z)]
+	var/obj/effect/overmap/visitable/sector/exoplanet/planet = global.overmap_sectors_by_z[num2text(location.z)]
 	if(istype(planet))
 		return planet.get_strata(location)
 	var/s_key = "[location.z]"

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -159,8 +159,9 @@ SUBSYSTEM_DEF(mapping)
 	connected_z_cache.Cut()
 
 	//Overmap stuff gotta stay up to date
-	global.overmap_sectors.len = world.maxz
-	global.overmaps_by_z.len   = world.maxz
+	global.overmap_sectors_by_z.len = world.maxz
+	global.overmaps_by_z.len        = world.maxz
+
 /datum/controller/subsystem/mapping/proc/increment_world_z_size(var/new_level_type, var/defer_setup = FALSE)
 
 	world.maxz++

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -158,6 +158,9 @@ SUBSYSTEM_DEF(mapping)
 	base_turf_by_z.len = world.maxz
 	connected_z_cache.Cut()
 
+	//Overmap stuff gotta stay up to date
+	global.overmap_sectors.len = world.maxz
+	global.overmaps_by_z.len   = world.maxz
 /datum/controller/subsystem/mapping/proc/increment_world_z_size(var/new_level_type, var/defer_setup = FALSE)
 
 	world.maxz++

--- a/code/controllers/subsystems/shuttle.dm
+++ b/code/controllers/subsystems/shuttle.dm
@@ -80,7 +80,7 @@ SUBSYSTEM_DEF(shuttle)
 			try_add_landmark_tag(shuttle_landmark_tag, O)
 			landmarks_still_needed -= shuttle_landmark_tag
 		else if(istype(shuttle_landmark, /obj/effect/shuttle_landmark/automatic)) //These find their sector automatically
-			O = global.overmap_sectors[num2text(shuttle_landmark.z)]
+			O = global.overmap_sectors[shuttle_landmark.z]
 			O ? O.add_landmark(shuttle_landmark, shuttle_landmark.shuttle_restricted) : (landmarks_awaiting_sector += shuttle_landmark)
 
 /datum/controller/subsystem/shuttle/proc/unregister_landmark(shuttle_landmark_tag)

--- a/code/controllers/subsystems/shuttle.dm
+++ b/code/controllers/subsystems/shuttle.dm
@@ -80,7 +80,7 @@ SUBSYSTEM_DEF(shuttle)
 			try_add_landmark_tag(shuttle_landmark_tag, O)
 			landmarks_still_needed -= shuttle_landmark_tag
 		else if(istype(shuttle_landmark, /obj/effect/shuttle_landmark/automatic)) //These find their sector automatically
-			O = global.overmap_sectors[shuttle_landmark.z]
+			O = global.overmap_sectors_by_z[shuttle_landmark.z]
 			O ? O.add_landmark(shuttle_landmark, shuttle_landmark.shuttle_restricted) : (landmarks_awaiting_sector += shuttle_landmark)
 
 /datum/controller/subsystem/shuttle/proc/unregister_landmark(shuttle_landmark_tag)

--- a/code/controllers/subsystems/skybox.dm
+++ b/code/controllers/subsystems/skybox.dm
@@ -104,7 +104,7 @@ SUBSYSTEM_DEF(skybox)
 /datum/controller/subsystem/skybox/proc/get_skybox(z)
 	if(!skybox_cache[num2text(z)])
 		skybox_cache[num2text(z)] = generate_skybox(z)
-		var/obj/effect/overmap/visitable/O = global.overmap_sectors[num2text(z)]
+		var/obj/effect/overmap/visitable/O = global.overmap_sectors[z]
 		if(istype(O))
 			for(var/zlevel in O.map_z)
 				skybox_cache["[zlevel]"] = skybox_cache[num2text(z)]
@@ -123,7 +123,7 @@ SUBSYSTEM_DEF(skybox)
 	res.overlays += base
 
 	if(use_overmap_details)
-		var/obj/effect/overmap/visitable/O = global.overmap_sectors[num2text(z)]
+		var/obj/effect/overmap/visitable/O = global.overmap_sectors[z]
 		if(istype(O))
 			var/image/overmap = image(skybox_icon)
 			overmap.overlays += O.generate_skybox()

--- a/code/controllers/subsystems/skybox.dm
+++ b/code/controllers/subsystems/skybox.dm
@@ -104,7 +104,7 @@ SUBSYSTEM_DEF(skybox)
 /datum/controller/subsystem/skybox/proc/get_skybox(z)
 	if(!skybox_cache[num2text(z)])
 		skybox_cache[num2text(z)] = generate_skybox(z)
-		var/obj/effect/overmap/visitable/O = global.overmap_sectors[z]
+		var/obj/effect/overmap/visitable/O = global.overmap_sectors_by_z[z]
 		if(istype(O))
 			for(var/zlevel in O.map_z)
 				skybox_cache["[zlevel]"] = skybox_cache[num2text(z)]
@@ -123,7 +123,7 @@ SUBSYSTEM_DEF(skybox)
 	res.overlays += base
 
 	if(use_overmap_details)
-		var/obj/effect/overmap/visitable/O = global.overmap_sectors[z]
+		var/obj/effect/overmap/visitable/O = global.overmap_sectors_by_z[z]
 		if(istype(O))
 			var/image/overmap = image(skybox_icon)
 			overmap.overlays += O.generate_skybox()

--- a/code/controllers/subsystems/statistics.dm
+++ b/code/controllers/subsystems/statistics.dm
@@ -162,7 +162,7 @@ SUBSYSTEM_DEF(statistics)
 		death.brainloss = dead.getBrainLoss()
 		death.oxyloss =   dead.getOxyLoss()
 		death.using_map_name = global.using_map.full_name
-		var/obj/effect/overmap/visitable/cell = global.overmap_sectors[num2text(dead.z)]
+		var/obj/effect/overmap/visitable/cell = global.overmap_sectors[dead.z]
 		death.overmap_location_name = cell?.name || "Unknown"
 		LAZYADD(deaths, death)
 

--- a/code/controllers/subsystems/statistics.dm
+++ b/code/controllers/subsystems/statistics.dm
@@ -162,7 +162,7 @@ SUBSYSTEM_DEF(statistics)
 		death.brainloss = dead.getBrainLoss()
 		death.oxyloss =   dead.getOxyLoss()
 		death.using_map_name = global.using_map.full_name
-		var/obj/effect/overmap/visitable/cell = global.overmap_sectors[dead.z]
+		var/obj/effect/overmap/visitable/cell = global.overmap_sectors_by_z[dead.z]
 		death.overmap_location_name = cell?.name || "Unknown"
 		LAZYADD(deaths, death)
 

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -25,7 +25,7 @@
 		return isAdminLevel(tz) || isStationLevel(tz) || isContactLevel(tz)
 
 	var/list/accessible_z_levels = SSmapping.get_connected_levels(oz)
-	var/obj/effect/overmap/sector = global.overmap_sectors[num2text(oz)]
+	var/obj/effect/overmap/sector = global.overmap_sectors[oz]
 	if(sector)
 
 		var/list/neighbors_to_add = list()

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -25,7 +25,7 @@
 		return isAdminLevel(tz) || isStationLevel(tz) || isContactLevel(tz)
 
 	var/list/accessible_z_levels = SSmapping.get_connected_levels(oz)
-	var/obj/effect/overmap/sector = global.overmap_sectors[oz]
+	var/obj/effect/overmap/sector = global.overmap_sectors_by_z[oz]
 	if(sector)
 
 		var/list/neighbors_to_add = list()

--- a/code/datums/trading/trade_hub_overmap.dm
+++ b/code/datums/trading/trade_hub_overmap.dm
@@ -66,7 +66,7 @@ var/global/list/trading_hub_names = list()
 
 /datum/trade_hub/overmap/is_accessible_from(var/turf/check)
 	if(istype(check))
-		var/obj/effect/overmap/customer = global.overmap_sectors[num2text(check.z)]
+		var/obj/effect/overmap/customer = global.overmap_sectors[check.z]
 		return customer && owner && get_turf(customer) == get_turf(owner)
 
 /datum/trade_hub/overmap/proc/update_hub(var/obj/effect/overmap/trade_hub/hub)

--- a/code/datums/trading/trade_hub_overmap.dm
+++ b/code/datums/trading/trade_hub_overmap.dm
@@ -66,7 +66,7 @@ var/global/list/trading_hub_names = list()
 
 /datum/trade_hub/overmap/is_accessible_from(var/turf/check)
 	if(istype(check))
-		var/obj/effect/overmap/customer = global.overmap_sectors[check.z]
+		var/obj/effect/overmap/customer = global.overmap_sectors_by_z[check.z]
 		return customer && owner && get_turf(customer) == get_turf(owner)
 
 /datum/trade_hub/overmap/proc/update_hub(var/obj/effect/overmap/trade_hub/hub)

--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -86,7 +86,7 @@
 	if(state != AWAITING_ACTIVATION)
 		to_chat(user, "<span class='warning'>\The [src] won't activate again.</span>")
 		return
-	var/obj/effect/overmap/visitable/O = global.overmap_sectors[num2text(get_z(src))]
+	var/obj/effect/overmap/visitable/O = global.overmap_sectors[get_z(src)]
 	var/choice = alert(user, "This will only affect your current location[istype(O) ? " ([O])" : ""]. Proceed?","Confirmation", "Yes", "No")
 	if(choice != "Yes")
 		return

--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -86,7 +86,7 @@
 	if(state != AWAITING_ACTIVATION)
 		to_chat(user, "<span class='warning'>\The [src] won't activate again.</span>")
 		return
-	var/obj/effect/overmap/visitable/O = global.overmap_sectors[get_z(src)]
+	var/obj/effect/overmap/visitable/O = global.overmap_sectors_by_z[get_z(src)]
 	var/choice = alert(user, "This will only affect your current location[istype(O) ? " ([O])" : ""]. Proceed?","Confirmation", "Yes", "No")
 	if(choice != "Yes")
 		return

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -214,7 +214,7 @@
 	var/newz
 	if(prob(10))
 		var/list/possible_locations
-		var/obj/effect/overmap/visitable/O = global.overmap_sectors[z]
+		var/obj/effect/overmap/visitable/O = global.overmap_sectors_by_z[z]
 		if(istype(O))
 			for(var/obj/effect/overmap/visitable/OO in range(O,2))
 				if((OO.sector_flags & OVERMAP_SECTOR_IN_SPACE) || istype(OO,/obj/effect/overmap/visitable/sector/exoplanet))

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -214,7 +214,7 @@
 	var/newz
 	if(prob(10))
 		var/list/possible_locations
-		var/obj/effect/overmap/visitable/O = global.overmap_sectors[num2text(z)]
+		var/obj/effect/overmap/visitable/O = global.overmap_sectors[z]
 		if(istype(O))
 			for(var/obj/effect/overmap/visitable/OO in range(O,2))
 				if((OO.sector_flags & OVERMAP_SECTOR_IN_SPACE) || istype(OO,/obj/effect/overmap/visitable/sector/exoplanet))

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -111,7 +111,7 @@ var/global/const/HOLOPAD_MODE = RANGE_BASED
 				var/zlevels_long = list()
 				if(holopadType == HOLOPAD_LONG_RANGE && length(reachable_overmaps))
 					for(var/zlevel in global.overmap_sectors)
-						var/obj/effect/overmap/visitable/O = global.overmap_sectors[num2text(zlevel)]
+						var/obj/effect/overmap/visitable/O = global.overmap_sectors[zlevel]
 						if(!isnull(O) && (O.overmap_id in reachable_overmaps))
 							zlevels_long |= O.map_z
 				for(var/obj/machinery/hologram/holopad/H in SSmachines.machinery)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -110,8 +110,8 @@ var/global/const/HOLOPAD_MODE = RANGE_BASED
 				var/zlevels = SSmapping.get_connected_levels(z)
 				var/zlevels_long = list()
 				if(holopadType == HOLOPAD_LONG_RANGE && length(reachable_overmaps))
-					for(var/zlevel in global.overmap_sectors)
-						var/obj/effect/overmap/visitable/O = global.overmap_sectors[zlevel]
+					for(var/zlevel in global.overmap_sectors_by_z)
+						var/obj/effect/overmap/visitable/O = global.overmap_sectors_by_z[zlevel]
 						if(!isnull(O) && (O.overmap_id in reachable_overmaps))
 							zlevels_long |= O.map_z
 				for(var/obj/machinery/hologram/holopad/H in SSmachines.machinery)

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -43,7 +43,7 @@
 
 	var/turf/T = get_turf(src)
 	if(istype(T) && length(global.using_map.overmap_ids))
-		var/obj/effect/overmap/visitable/sector/S = global.overmap_sectors[num2text(T.z)]
+		var/obj/effect/overmap/visitable/sector/S = global.overmap_sectors[T.z]
 		if(!S) // The blueprints are useless now, but keep them around for fluff.
 			desc = "Some dusty old blueprints. The markings are old, and seem entirely irrelevant for your wherabouts."
 			return FALSE
@@ -65,14 +65,14 @@
 	icon_state = "blueprints2"
 
 /obj/item/blueprints/outpost/attack_self(mob/user)
-	var/obj/effect/overmap/visitable/sector/S = global.overmap_sectors[num2text(get_z(user))]
+	var/obj/effect/overmap/visitable/sector/S = global.overmap_sectors[get_z(user)]
 	area_prefix = S.name
 	. = ..()
 
 /obj/item/blueprints/outpost/set_valid_z_levels()
 	var/turf/T = get_turf(src)
 	if(istype(T) && length(global.using_map.overmap_ids))
-		var/obj/effect/overmap/visitable/sector/S = global.overmap_sectors[num2text(T.z)]
+		var/obj/effect/overmap/visitable/sector/S = global.overmap_sectors[T.z]
 		if(istype(S))
 			T = locate(1, 1, S.z)
 			var/area/overmap/map = T && get_area(T)

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -43,7 +43,7 @@
 
 	var/turf/T = get_turf(src)
 	if(istype(T) && length(global.using_map.overmap_ids))
-		var/obj/effect/overmap/visitable/sector/S = global.overmap_sectors[T.z]
+		var/obj/effect/overmap/visitable/sector/S = global.overmap_sectors_by_z[T.z]
 		if(!S) // The blueprints are useless now, but keep them around for fluff.
 			desc = "Some dusty old blueprints. The markings are old, and seem entirely irrelevant for your wherabouts."
 			return FALSE
@@ -65,14 +65,14 @@
 	icon_state = "blueprints2"
 
 /obj/item/blueprints/outpost/attack_self(mob/user)
-	var/obj/effect/overmap/visitable/sector/S = global.overmap_sectors[get_z(user)]
+	var/obj/effect/overmap/visitable/sector/S = global.overmap_sectors_by_z[get_z(user)]
 	area_prefix = S.name
 	. = ..()
 
 /obj/item/blueprints/outpost/set_valid_z_levels()
 	var/turf/T = get_turf(src)
 	if(istype(T) && length(global.using_map.overmap_ids))
-		var/obj/effect/overmap/visitable/sector/S = global.overmap_sectors[T.z]
+		var/obj/effect/overmap/visitable/sector/S = global.overmap_sectors_by_z[T.z]
 		if(istype(S))
 			T = locate(1, 1, S.z)
 			var/area/overmap/map = T && get_area(T)

--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -30,7 +30,7 @@
 
 	if(possible_states > 0)
 		icon_state = "[rand(0, possible_states)]"
-	owner = LAZYACCESS(global.overmap_sectors_by_z, num2text(z))
+	owner = LAZYACCESS(global.overmap_sectors_by_z, z)
 	if(!istype(owner))
 		owner = null
 	else

--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -30,7 +30,7 @@
 
 	if(possible_states > 0)
 		icon_state = "[rand(0, possible_states)]"
-	owner = LAZYACCESS(global.overmap_sectors, num2text(z))
+	owner = LAZYACCESS(global.overmap_sectors_by_z, num2text(z))
 	if(!istype(owner))
 		owner = null
 	else

--- a/code/game/turfs/exterior/exterior_grass.dm
+++ b/code/game/turfs/exterior/exterior_grass.dm
@@ -16,7 +16,7 @@
 
 /turf/exterior/wildgrass/Initialize()
 	. = ..()
-	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[num2text(z)]
+	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[z]
 	if(istype(E) && E.grass_color)
 		color = E.grass_color
 

--- a/code/game/turfs/exterior/exterior_grass.dm
+++ b/code/game/turfs/exterior/exterior_grass.dm
@@ -16,7 +16,7 @@
 
 /turf/exterior/wildgrass/Initialize()
 	. = ..()
-	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[num2text(z)]
 	if(istype(E) && E.grass_color)
 		color = E.grass_color
 

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -53,7 +53,7 @@
 		return
 
 	for(var/i in affecting_z)
-		var/obj/effect/overmap/visitable/sector = global.overmap_sectors[num2text(i)]
+		var/obj/effect/overmap/visitable/sector = global.overmap_sectors[i]
 		if(istype(sector))
 			overmap_sectors |= sector
 		else

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -53,7 +53,7 @@
 		return
 
 	for(var/i in affecting_z)
-		var/obj/effect/overmap/visitable/sector = global.overmap_sectors[i]
+		var/obj/effect/overmap/visitable/sector = global.overmap_sectors_by_z[i]
 		if(istype(sector))
 			overmap_sectors |= sector
 		else

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -165,5 +165,5 @@
 /datum/event/proc/location_name()
 	if(!length(global.using_map.overmap_ids))
 		return station_name()
-	var/obj/effect/overmap/visitable/O = global.overmap_sectors[num2text(pick(affecting_z))]
+	var/obj/effect/overmap/visitable/O = global.overmap_sectors[pick(affecting_z)]
 	return O?.name || "Unknown Location"

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -165,5 +165,5 @@
 /datum/event/proc/location_name()
 	if(!length(global.using_map.overmap_ids))
 		return station_name()
-	var/obj/effect/overmap/visitable/O = global.overmap_sectors[pick(affecting_z)]
+	var/obj/effect/overmap/visitable/O = global.overmap_sectors_by_z[pick(affecting_z)]
 	return O?.name || "Unknown Location"

--- a/code/modules/holomap/holomap.dm
+++ b/code/modules/holomap/holomap.dm
@@ -315,7 +315,7 @@
 
 	//This is where the fun begins
 	if(length(global.using_map.overmap_ids))
-		var/obj/effect/overmap/visitable/O = global.overmap_sectors["[z]"]
+		var/obj/effect/overmap/visitable/O = global.overmap_sectors[z]
 
 		var/current_z_offset_x = (HOLOMAP_ICON_SIZE / 2) - world.maxx / 2
 		var/current_z_offset_y = (HOLOMAP_ICON_SIZE / 2) - world.maxy / 2

--- a/code/modules/holomap/holomap.dm
+++ b/code/modules/holomap/holomap.dm
@@ -315,7 +315,7 @@
 
 	//This is where the fun begins
 	if(length(global.using_map.overmap_ids))
-		var/obj/effect/overmap/visitable/O = global.overmap_sectors[z]
+		var/obj/effect/overmap/visitable/O = global.overmap_sectors_by_z[z]
 
 		var/current_z_offset_x = (HOLOMAP_ICON_SIZE / 2) - world.maxx / 2
 		var/current_z_offset_y = (HOLOMAP_ICON_SIZE / 2) - world.maxy / 2

--- a/code/modules/modular_computers/networking/device_types/_network_device.dm
+++ b/code/modules/modular_computers/networking/device_types/_network_device.dm
@@ -211,7 +211,7 @@
 	// Overmap isn't used, a modem alone provides internet connection.
 	if(!length(global.using_map.overmap_ids))
 		return TRUE
-	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[get_z(holder)]
+	var/obj/effect/overmap/visitable/sector = global.overmap_sectors_by_z[get_z(holder)]
 	if(!istype(sector))
 		return
 	return sector.has_internet_connection(connecting_network)

--- a/code/modules/modular_computers/networking/device_types/_network_device.dm
+++ b/code/modules/modular_computers/networking/device_types/_network_device.dm
@@ -211,7 +211,7 @@
 	// Overmap isn't used, a modem alone provides internet connection.
 	if(!length(global.using_map.overmap_ids))
 		return TRUE
-	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[num2text(get_z(holder))]
+	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[get_z(holder)]
 	if(!istype(sector))
 		return
 	return sector.has_internet_connection(connecting_network)

--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -358,7 +358,7 @@
 
 /datum/level_data/proc/get_display_name()
 	if(!name)
-		var/obj/effect/overmap/overmap_entity = global.overmap_sectors[num2text(level_z)]
+		var/obj/effect/overmap/overmap_entity = global.overmap_sectors[level_z]
 		if(overmap_entity?.name)
 			name = overmap_entity.name
 		else

--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -358,7 +358,7 @@
 
 /datum/level_data/proc/get_display_name()
 	if(!name)
-		var/obj/effect/overmap/overmap_entity = global.overmap_sectors[level_z]
+		var/obj/effect/overmap/overmap_entity = global.overmap_sectors_by_z[level_z]
 		if(overmap_entity?.name)
 			name = overmap_entity.name
 		else

--- a/code/modules/overmap/_defines.dm
+++ b/code/modules/overmap/_defines.dm
@@ -22,7 +22,7 @@
 	name = "[x]-[y]"
 	var/list/numbers = list()
 
-	var/datum/overmap/overmap = global.overmaps_by_z[num2text(z)]
+	var/datum/overmap/overmap = global.overmaps_by_z[z]
 	if(x == 1 || x == overmap.map_size_x)
 		numbers += list("[round(y/10)]","[round(y%10)]")
 		if(y == 1 || y == overmap.map_size_y)

--- a/code/modules/overmap/_overmap.dm
+++ b/code/modules/overmap/_overmap.dm
@@ -33,9 +33,9 @@
 	if(!assigned_z)
 		PRINT_STACK_TRACE("Overmap datum generated null assigned z_level.")
 
-	if(global.overmaps_by_z["[assigned_z]"])
+	if(global.overmaps_by_z[assigned_z])
 		PRINT_STACK_TRACE("Duplicate overmap datum instantiated for z-level: [type], [assigned_z], [overmaps_by_name[name]]")
-	global.overmaps_by_z["[assigned_z]"] = src
+	global.overmaps_by_z[assigned_z] = src
 
 	for(var/event_type in subtypesof(/datum/overmap_event))
 		var/datum/overmap_event/event = event_type
@@ -67,7 +67,7 @@
 	if (!T || !A)
 		return
 
-	var/obj/effect/overmap/visitable/M = global.overmap_sectors[num2text(T.z)]
+	var/obj/effect/overmap/visitable/M = global.overmap_sectors[T.z]
 	if (!M)
 		return
 

--- a/code/modules/overmap/_overmap.dm
+++ b/code/modules/overmap/_overmap.dm
@@ -67,7 +67,7 @@
 	if (!T || !A)
 		return
 
-	var/obj/effect/overmap/visitable/M = global.overmap_sectors[T.z]
+	var/obj/effect/overmap/visitable/M = global.overmap_sectors_by_z[T.z]
 	if (!M)
 		return
 

--- a/code/modules/overmap/contacts/contact_sensors.dm
+++ b/code/modules/overmap/contacts/contact_sensors.dm
@@ -69,7 +69,7 @@
 	// Find all sectors with a tracker on their z-level. Only works on ships when they are in space.
 	for(var/obj/item/ship_tracker/tracker in trackers)
 		if(tracker.enabled)
-			var/obj/effect/overmap/visitable/tracked_effect = global.overmap_sectors[get_z(tracker)]
+			var/obj/effect/overmap/visitable/tracked_effect = global.overmap_sectors_by_z[get_z(tracker)]
 			if(tracked_effect && istype(tracked_effect) && tracked_effect != linked && tracked_effect.requires_contact)
 				objects_in_current_view[tracked_effect] = TRUE
 				objects_in_view[tracked_effect] = 100

--- a/code/modules/overmap/contacts/contact_sensors.dm
+++ b/code/modules/overmap/contacts/contact_sensors.dm
@@ -69,7 +69,7 @@
 	// Find all sectors with a tracker on their z-level. Only works on ships when they are in space.
 	for(var/obj/item/ship_tracker/tracker in trackers)
 		if(tracker.enabled)
-			var/obj/effect/overmap/visitable/tracked_effect = global.overmap_sectors[num2text(get_z(tracker))]
+			var/obj/effect/overmap/visitable/tracked_effect = global.overmap_sectors[get_z(tracker)]
 			if(tracked_effect && istype(tracked_effect) && tracked_effect != linked && tracked_effect.requires_contact)
 				objects_in_current_view[tracked_effect] = TRUE
 				objects_in_view[tracked_effect] = 100

--- a/code/modules/overmap/exoplanets/exoplanet_fauna.dm
+++ b/code/modules/overmap/exoplanets/exoplanet_fauna.dm
@@ -85,7 +85,7 @@
 
 /obj/abstract/landmark/exoplanet_spawn/LateInitialize()
 	. = ..()
-	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[num2text(z)]
+	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[z]
 	if(istype(E))
 		do_spawn(E)
 

--- a/code/modules/overmap/exoplanets/exoplanet_fauna.dm
+++ b/code/modules/overmap/exoplanets/exoplanet_fauna.dm
@@ -85,7 +85,7 @@
 
 /obj/abstract/landmark/exoplanet_spawn/LateInitialize()
 	. = ..()
-	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[num2text(z)]
 	if(istype(E))
 		do_spawn(E)
 

--- a/code/modules/overmap/exoplanets/turfs.dm
+++ b/code/modules/overmap/exoplanets/turfs.dm
@@ -14,7 +14,7 @@
 
 /turf/exterior/planet_edge/Initialize()
 	. = ..()
-	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[num2text(z)]
 	if(!istype(E))
 		return
 	mimicx = x
@@ -37,7 +37,7 @@
 
 /turf/exterior/planet_edge/Bumped(atom/movable/A)
 	. = ..()
-	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[num2text(z)]
 	if(!istype(E))
 		return
 	if(E.planetary_area && istype(loc, world.area))

--- a/code/modules/overmap/exoplanets/turfs.dm
+++ b/code/modules/overmap/exoplanets/turfs.dm
@@ -14,7 +14,7 @@
 
 /turf/exterior/planet_edge/Initialize()
 	. = ..()
-	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[num2text(z)]
+	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[z]
 	if(!istype(E))
 		return
 	mimicx = x
@@ -37,7 +37,7 @@
 
 /turf/exterior/planet_edge/Bumped(atom/movable/A)
 	. = ..()
-	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[num2text(z)]
+	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[z]
 	if(!istype(E))
 		return
 	if(E.planetary_area && istype(loc, world.area))

--- a/code/modules/overmap/ftl_shunt/computer.dm
+++ b/code/modules/overmap/ftl_shunt/computer.dm
@@ -24,7 +24,7 @@
 /obj/machinery/computer/ship/ftl/proc/recalc_cost()
 	if(!linked_core)
 		return INFINITY
-	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[z]
+	var/obj/effect/overmap/visitable/sector = global.overmap_sectors_by_z[z]
 	if(!istype(sector))
 		return INFINITY
 	var/jump_dist = get_dist(linked, locate(linked_core.shunt_x, linked_core.shunt_y, sector.z))
@@ -35,7 +35,7 @@
 	if(!linked_core)
 		return INFINITY
 
-	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[z]
+	var/obj/effect/overmap/visitable/sector = global.overmap_sectors_by_z[z]
 	if(!istype(sector))
 		return INFINITY
 

--- a/code/modules/overmap/ftl_shunt/computer.dm
+++ b/code/modules/overmap/ftl_shunt/computer.dm
@@ -24,7 +24,7 @@
 /obj/machinery/computer/ship/ftl/proc/recalc_cost()
 	if(!linked_core)
 		return INFINITY
-	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[z]
 	if(!istype(sector))
 		return INFINITY
 	var/jump_dist = get_dist(linked, locate(linked_core.shunt_x, linked_core.shunt_y, sector.z))
@@ -35,7 +35,7 @@
 	if(!linked_core)
 		return INFINITY
 
-	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[z]
 	if(!istype(sector))
 		return INFINITY
 

--- a/code/modules/overmap/ftl_shunt/core.dm
+++ b/code/modules/overmap/ftl_shunt/core.dm
@@ -238,7 +238,7 @@
 	return FTL_START_CONFIRMED
 
 /obj/machinery/ftl_shunt/core/proc/calculate_jump_requirements()
-	var/obj/effect/overmap/visitable/O = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/O = global.overmap_sectors[z]
 	if(O)
 		var/shunt_distance
 		var/vessel_mass = ftl_computer.linked.get_vessel_mass()
@@ -275,7 +275,7 @@
 		cancel_shunt()
 		return //If for some reason we don't have fuel now, just return.
 
-	var/obj/effect/overmap/visitable/O = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/O = global.overmap_sectors[z]
 	if(O)
 		var/destination = locate(shunt_x, shunt_y, O.z)
 		var/jumpdist = get_dist(get_turf(ftl_computer.linked), destination)

--- a/code/modules/overmap/ftl_shunt/core.dm
+++ b/code/modules/overmap/ftl_shunt/core.dm
@@ -238,7 +238,7 @@
 	return FTL_START_CONFIRMED
 
 /obj/machinery/ftl_shunt/core/proc/calculate_jump_requirements()
-	var/obj/effect/overmap/visitable/O = global.overmap_sectors[z]
+	var/obj/effect/overmap/visitable/O = global.overmap_sectors_by_z[z]
 	if(O)
 		var/shunt_distance
 		var/vessel_mass = ftl_computer.linked.get_vessel_mass()
@@ -275,7 +275,7 @@
 		cancel_shunt()
 		return //If for some reason we don't have fuel now, just return.
 
-	var/obj/effect/overmap/visitable/O = global.overmap_sectors[z]
+	var/obj/effect/overmap/visitable/O = global.overmap_sectors_by_z[z]
 	if(O)
 		var/destination = locate(shunt_x, shunt_y, O.z)
 		var/jumpdist = get_dist(get_turf(ftl_computer.linked), destination)

--- a/code/modules/overmap/internet/internet_repeater.dm
+++ b/code/modules/overmap/internet/internet_repeater.dm
@@ -51,7 +51,7 @@ var/global/list/internet_repeaters = list()
 	var/data = list()
 	data["powered"] = (use_power == POWER_USE_ACTIVE)
 
-	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[num2text(get_z(src))]
+	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[get_z(src)]
 
 	if(sector)
 		var/list/internet_connections = sector.get_internet_connections()

--- a/code/modules/overmap/internet/internet_repeater.dm
+++ b/code/modules/overmap/internet/internet_repeater.dm
@@ -51,7 +51,7 @@ var/global/list/internet_repeaters = list()
 	var/data = list()
 	data["powered"] = (use_power == POWER_USE_ACTIVE)
 
-	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[get_z(src)]
+	var/obj/effect/overmap/visitable/sector = global.overmap_sectors_by_z[get_z(src)]
 
 	if(sector)
 		var/list/internet_connections = sector.get_internet_connections()

--- a/code/modules/overmap/overmap_object.dm
+++ b/code/modules/overmap/overmap_object.dm
@@ -88,10 +88,10 @@ var/global/list/overmap_unknown_ids = list()
 /obj/effect/overmap/proc/handle_wraparound()
 
 	var/turf/T = get_turf(src)
-	if(!istype(T) || !global.overmaps_by_z["[T.z]"])
+	if(!istype(T) || !global.overmaps_by_z[T.z])
 		PRINT_STACK_TRACE("Overmap effect handling wraparound on a non-overmap z-level.")
 
-	var/datum/overmap/overmap = global.overmaps_by_z["[T.z]"]
+	var/datum/overmap/overmap = global.overmaps_by_z[T.z]
 	var/nx = x
 	var/ny = y
 

--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -1,4 +1,4 @@
-#define waypoint_sector(waypoint) global.overmap_sectors[waypoint.z]
+#define waypoint_sector(waypoint) global.overmap_sectors_by_z[waypoint.z]
 
 /datum/shuttle/autodock/overmap
 	warmup_time = 10

--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -1,4 +1,4 @@
-#define waypoint_sector(waypoint) global.overmap_sectors[num2text(waypoint.z)]
+#define waypoint_sector(waypoint) global.overmap_sectors[waypoint.z]
 
 /datum/shuttle/autodock/overmap
 	warmup_time = 10

--- a/code/modules/overmap/radio_beacon.dm
+++ b/code/modules/overmap/radio_beacon.dm
@@ -46,7 +46,7 @@
 		to_chat(user, SPAN_NOTICE("You deactivate \the [src], cutting short it's radio broadcast."))
 		QDEL_NULL(signal)
 		return
-	var/obj/effect/overmap/visitable/O = global.overmap_sectors[get_z(src)]
+	var/obj/effect/overmap/visitable/O = global.overmap_sectors_by_z[get_z(src)]
 	if(!O)
 		to_chat(user, SPAN_WARNING("You cannot deploy \the [src] here."))
 		return

--- a/code/modules/overmap/radio_beacon.dm
+++ b/code/modules/overmap/radio_beacon.dm
@@ -46,7 +46,7 @@
 		to_chat(user, SPAN_NOTICE("You deactivate \the [src], cutting short it's radio broadcast."))
 		QDEL_NULL(signal)
 		return
-	var/obj/effect/overmap/visitable/O = global.overmap_sectors[num2text(get_z(src))]
+	var/obj/effect/overmap/visitable/O = global.overmap_sectors[get_z(src)]
 	if(!O)
 		to_chat(user, SPAN_WARNING("You cannot deploy \the [src] here."))
 		return

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -128,10 +128,10 @@ var/global/list/known_overmap_sectors
 	map_z = SSmapping.get_connected_levels(z)
 
 /obj/effect/overmap/visitable/proc/register_z_levels()
-	var/datum/overmap/overmap = global.overmaps_by_z[num2text(z)]
+	var/datum/overmap/overmap = global.overmaps_by_z[z]
 	if(istype(overmap))
 		for(var/zlevel in map_z)
-			global.overmap_sectors[num2text(zlevel)] = src
+			global.overmap_sectors[zlevel] = src
 
 	SSmapping.player_levels |= map_z
 	if(!(sector_flags & OVERMAP_SECTOR_IN_SPACE))
@@ -149,7 +149,7 @@ var/global/list/known_overmap_sectors
 // Returns the /obj/effect/overmap/visitable to which the atom belongs based on localtion, or null
 /atom/proc/get_owning_overmap_object()
 	var/z = get_z(src)
-	var/initial_sector = global.overmap_sectors[num2text(z)]
+	var/initial_sector = global.overmap_sectors[z]
 	if(!initial_sector)
 		return
 

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -131,7 +131,7 @@ var/global/list/known_overmap_sectors
 	var/datum/overmap/overmap = global.overmaps_by_z[z]
 	if(istype(overmap))
 		for(var/zlevel in map_z)
-			global.overmap_sectors[zlevel] = src
+			global.overmap_sectors_by_z[zlevel] = src
 
 	SSmapping.player_levels |= map_z
 	if(!(sector_flags & OVERMAP_SECTOR_IN_SPACE))
@@ -149,7 +149,7 @@ var/global/list/known_overmap_sectors
 // Returns the /obj/effect/overmap/visitable to which the atom belongs based on localtion, or null
 /atom/proc/get_owning_overmap_object()
 	var/z = get_z(src)
-	var/initial_sector = global.overmap_sectors[z]
+	var/initial_sector = global.overmap_sectors_by_z[z]
 	if(!initial_sector)
 		return
 

--- a/code/modules/overmap/ships/computers/shuttle.dm
+++ b/code/modules/overmap/ships/computers/shuttle.dm
@@ -61,7 +61,7 @@
 		to_chat(usr, SPAN_WARNING("The manual controls look hopelessly complex to you!"))
 
 /obj/machinery/computer/shuttle_control/explore/proc/start_landing(var/mob/user, var/datum/shuttle/autodock/overmap/shuttle)
-	var/obj/effect/overmap/visitable/current_sector = global.overmap_sectors[z]
+	var/obj/effect/overmap/visitable/current_sector = global.overmap_sectors_by_z[z]
 	var/obj/effect/overmap/visitable/target_sector
 	if(current_sector && istype(current_sector))
 
@@ -100,7 +100,7 @@
 	var/mob/observer/eye/landing/landing_eye = eye_extension.extension_eye
 	var/turf/lz_turf = eye_extension.get_eye_turf()
 
-	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[lz_turf.z]
+	var/obj/effect/overmap/visitable/sector = global.overmap_sectors_by_z[lz_turf.z]
 	if(!sector.allow_free_landing())	// Additional safety check to ensure the sector permits landing.
 		to_chat(user, SPAN_WARNING("Invalid landing zone!"))
 		return

--- a/code/modules/overmap/ships/computers/shuttle.dm
+++ b/code/modules/overmap/ships/computers/shuttle.dm
@@ -61,7 +61,7 @@
 		to_chat(usr, SPAN_WARNING("The manual controls look hopelessly complex to you!"))
 
 /obj/machinery/computer/shuttle_control/explore/proc/start_landing(var/mob/user, var/datum/shuttle/autodock/overmap/shuttle)
-	var/obj/effect/overmap/visitable/current_sector = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/current_sector = global.overmap_sectors[z]
 	var/obj/effect/overmap/visitable/target_sector
 	if(current_sector && istype(current_sector))
 
@@ -100,7 +100,7 @@
 	var/mob/observer/eye/landing/landing_eye = eye_extension.extension_eye
 	var/turf/lz_turf = eye_extension.get_eye_turf()
 
-	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[num2text(lz_turf.z)]
+	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[lz_turf.z]
 	if(!sector.allow_free_landing())	// Additional safety check to ensure the sector permits landing.
 		to_chat(user, SPAN_WARNING("Invalid landing zone!"))
 		return

--- a/code/modules/overmap/ships/landable.dm
+++ b/code/modules/overmap/ships/landable.dm
@@ -53,7 +53,7 @@
 	if(!child_shuttle || !istype(child_shuttle))
 		return
 	if(child_shuttle.current_location.flags & SLANDMARK_FLAG_DISCONNECTED) // Keep an eye on the distance between the shuttle and the sector if we aren't fully docked.
-		var/obj/effect/overmap/visitable/ship/landable/encounter = global.overmap_sectors[num2text(child_shuttle.current_location.z)]
+		var/obj/effect/overmap/visitable/ship/landable/encounter = global.overmap_sectors[child_shuttle.current_location.z]
 		if((get_dist(src, encounter) > min(child_shuttle.range, 1))) // Some leeway so 0 range shuttles are still able to chase.
 			child_shuttle.attempt_force_move(landmark)
 		if(istype(encounter))
@@ -141,7 +141,7 @@
 	. = ..()
 
 /obj/effect/shuttle_landmark/ship/Destroy()
-	var/obj/effect/overmap/visitable/ship/landable/ship = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/ship/landable/ship = global.overmap_sectors[z]
 	if(istype(ship) && ship.landmark == src)
 		ship.landmark = null
 	. = ..()
@@ -205,7 +205,7 @@
 	on_landing(from, into)
 
 /obj/effect/overmap/visitable/ship/landable/proc/on_landing(obj/effect/shuttle_landmark/from, obj/effect/shuttle_landmark/into)
-	var/obj/effect/overmap/visitable/target = global.overmap_sectors[num2text(into.z)]
+	var/obj/effect/overmap/visitable/target = global.overmap_sectors[into.z]
 	var/datum/shuttle/shuttle_datum = SSshuttle.shuttles[shuttle]
 	if(into.landmark_tag == shuttle_datum.motherdock) // If our motherdock is a landable ship, it won't be found properly here so we need to find it manually.
 		for(var/obj/effect/overmap/visitable/ship/landable/landable in SSshuttle.ships)
@@ -233,7 +233,7 @@
 			return "Docked with an unknown object."
 		if(SHIP_STATUS_ENCOUNTER)
 			var/datum/shuttle/autodock/overmap/child_shuttle = SSshuttle.shuttles[shuttle]
-			var/obj/effect/overmap/visitable/location = global.overmap_sectors[num2text(child_shuttle.current_location.z)]
+			var/obj/effect/overmap/visitable/location = global.overmap_sectors[child_shuttle.current_location.z]
 			return "Maneuvering nearby \the [location.name]."
 		if(SHIP_STATUS_TRANSIT)
 			return "Maneuvering under secondary thrust."

--- a/code/modules/overmap/ships/landable.dm
+++ b/code/modules/overmap/ships/landable.dm
@@ -53,7 +53,7 @@
 	if(!child_shuttle || !istype(child_shuttle))
 		return
 	if(child_shuttle.current_location.flags & SLANDMARK_FLAG_DISCONNECTED) // Keep an eye on the distance between the shuttle and the sector if we aren't fully docked.
-		var/obj/effect/overmap/visitable/ship/landable/encounter = global.overmap_sectors[child_shuttle.current_location.z]
+		var/obj/effect/overmap/visitable/ship/landable/encounter = global.overmap_sectors_by_z[child_shuttle.current_location.z]
 		if((get_dist(src, encounter) > min(child_shuttle.range, 1))) // Some leeway so 0 range shuttles are still able to chase.
 			child_shuttle.attempt_force_move(landmark)
 		if(istype(encounter))
@@ -141,7 +141,7 @@
 	. = ..()
 
 /obj/effect/shuttle_landmark/ship/Destroy()
-	var/obj/effect/overmap/visitable/ship/landable/ship = global.overmap_sectors[z]
+	var/obj/effect/overmap/visitable/ship/landable/ship = global.overmap_sectors_by_z[z]
 	if(istype(ship) && ship.landmark == src)
 		ship.landmark = null
 	. = ..()
@@ -205,7 +205,7 @@
 	on_landing(from, into)
 
 /obj/effect/overmap/visitable/ship/landable/proc/on_landing(obj/effect/shuttle_landmark/from, obj/effect/shuttle_landmark/into)
-	var/obj/effect/overmap/visitable/target = global.overmap_sectors[into.z]
+	var/obj/effect/overmap/visitable/target = global.overmap_sectors_by_z[into.z]
 	var/datum/shuttle/shuttle_datum = SSshuttle.shuttles[shuttle]
 	if(into.landmark_tag == shuttle_datum.motherdock) // If our motherdock is a landable ship, it won't be found properly here so we need to find it manually.
 		for(var/obj/effect/overmap/visitable/ship/landable/landable in SSshuttle.ships)
@@ -233,7 +233,7 @@
 			return "Docked with an unknown object."
 		if(SHIP_STATUS_ENCOUNTER)
 			var/datum/shuttle/autodock/overmap/child_shuttle = SSshuttle.shuttles[shuttle]
-			var/obj/effect/overmap/visitable/location = global.overmap_sectors[child_shuttle.current_location.z]
+			var/obj/effect/overmap/visitable/location = global.overmap_sectors_by_z[child_shuttle.current_location.z]
 			return "Maneuvering nearby \the [location.name]."
 		if(SHIP_STATUS_TRANSIT)
 			return "Maneuvering under secondary thrust."

--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -16,7 +16,7 @@
 /obj/effect/overmap/visitable/sector/temporary/Destroy()
 
 	for(var/num in map_z)
-		global.overmap_sectors -= num
+		global.overmap_sectors_by_z -= num
 
 	var/datum/overmap/overmap = global.overmaps_by_z[z]
 	if(istype(overmap))

--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -16,9 +16,9 @@
 /obj/effect/overmap/visitable/sector/temporary/Destroy()
 
 	for(var/num in map_z)
-		global.overmap_sectors -= "[num]"
+		global.overmap_sectors -= num
 
-	var/datum/overmap/overmap = global.overmaps_by_z[num2text(z)]
+	var/datum/overmap/overmap = global.overmaps_by_z[z]
 	if(istype(overmap))
 		overmap.discard_temporary_sector(src)
 

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -173,7 +173,7 @@ var/global/list/solars_list = list()
 	// On planets, we take fewer steps because the light is mostly up
 	// Also, many planets barely have any spots with enough clear space around
 	if(isturf(loc))
-		var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors[loc.z]
+		var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[loc.z]
 		if(istype(E))
 			steps = 5
 

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -173,7 +173,7 @@ var/global/list/solars_list = list()
 	// On planets, we take fewer steps because the light is mostly up
 	// Also, many planets barely have any spots with enough clear space around
 	if(isturf(loc))
-		var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors[num2text(loc.z)]
+		var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors[loc.z]
 		if(istype(E))
 			steps = 5
 

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -70,8 +70,8 @@
 	damaged_segments = null
 	mode_list = null
 	events_repository.unregister(/decl/observ/moved, src, src)
+	update_overmap_shield_list() //Must be called before we get moved to nullspace!
 	. = ..()
-	update_overmap_shield_list()
 
 /obj/machinery/shield_generator/proc/update_overmap_shield_list()
 	var/obj/effect/overmap/visitable/current_overmap_object = get_owning_overmap_object()

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -55,7 +55,7 @@ var/global/list/shuttle_landmarks = list()
 	if(!istype(docking_controller))
 		log_error("Could not find docking controller for shuttle waypoint '[name]', docking tag was '[docking_tag]'.")
 
-	var/obj/effect/overmap/visitable/location = global.overmap_sectors[z]
+	var/obj/effect/overmap/visitable/location = global.overmap_sectors_by_z[z]
 	if(location && location.docking_codes)
 		docking_controller.docking_codes = location.docking_codes
 
@@ -66,9 +66,9 @@ var/global/list/shuttle_landmarks = list()
 		ADJUST_TAG_VAR(docking_controller, map_hash)
 
 /obj/effect/shuttle_landmark/forceMove()
-	var/obj/effect/overmap/visitable/map_origin = global.overmap_sectors[z]
+	var/obj/effect/overmap/visitable/map_origin = global.overmap_sectors_by_z[z]
 	. = ..()
-	var/obj/effect/overmap/visitable/map_destination = global.overmap_sectors[z]
+	var/obj/effect/overmap/visitable/map_destination = global.overmap_sectors_by_z[z]
 	if(map_origin != map_destination)
 		if(map_origin)
 			map_origin.remove_landmark(src, shuttle_restricted)

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -55,7 +55,7 @@ var/global/list/shuttle_landmarks = list()
 	if(!istype(docking_controller))
 		log_error("Could not find docking controller for shuttle waypoint '[name]', docking tag was '[docking_tag]'.")
 
-	var/obj/effect/overmap/visitable/location = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/location = global.overmap_sectors[z]
 	if(location && location.docking_codes)
 		docking_controller.docking_codes = location.docking_codes
 
@@ -66,9 +66,9 @@ var/global/list/shuttle_landmarks = list()
 		ADJUST_TAG_VAR(docking_controller, map_hash)
 
 /obj/effect/shuttle_landmark/forceMove()
-	var/obj/effect/overmap/visitable/map_origin = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/map_origin = global.overmap_sectors[z]
 	. = ..()
-	var/obj/effect/overmap/visitable/map_destination = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/map_destination = global.overmap_sectors[z]
 	if(map_origin != map_destination)
 		if(map_origin)
 			map_origin.remove_landmark(src, shuttle_restricted)

--- a/code/modules/shuttles/shuttle_autodock.dm
+++ b/code/modules/shuttles/shuttle_autodock.dm
@@ -33,7 +33,7 @@
 	if(active_docking_controller)
 		set_docking_codes(active_docking_controller.docking_codes)
 	else if(current_location?.overmap_id)
-		var/obj/effect/overmap/visitable/location = global.overmap_sectors[num2text(current_location.z)]
+		var/obj/effect/overmap/visitable/location = global.overmap_sectors[current_location.z]
 		if(location && location.docking_codes)
 			set_docking_codes(location.docking_codes)
 	dock()

--- a/code/modules/shuttles/shuttle_autodock.dm
+++ b/code/modules/shuttles/shuttle_autodock.dm
@@ -33,7 +33,7 @@
 	if(active_docking_controller)
 		set_docking_codes(active_docking_controller.docking_codes)
 	else if(current_location?.overmap_id)
-		var/obj/effect/overmap/visitable/location = global.overmap_sectors[current_location.z]
+		var/obj/effect/overmap/visitable/location = global.overmap_sectors_by_z[current_location.z]
 		if(location && location.docking_codes)
 			set_docking_codes(location.docking_codes)
 	dock()

--- a/code/modules/submaps/_submap.dm
+++ b/code/modules/submaps/_submap.dm
@@ -45,7 +45,7 @@
 		qdel(src)
 		return
 
-	var/obj/effect/overmap/visitable/cell = global.overmap_sectors[num2text(associated_z)]
+	var/obj/effect/overmap/visitable/cell = global.overmap_sectors[associated_z]
 	if(istype(cell))
 		sync_cell(cell)
 

--- a/code/modules/submaps/_submap.dm
+++ b/code/modules/submaps/_submap.dm
@@ -45,7 +45,7 @@
 		qdel(src)
 		return
 
-	var/obj/effect/overmap/visitable/cell = global.overmap_sectors[associated_z]
+	var/obj/effect/overmap/visitable/cell = global.overmap_sectors_by_z[associated_z]
 	if(istype(cell))
 		sync_cell(cell)
 

--- a/code/modules/xenoarcheaology/finds/find_types/_find.dm
+++ b/code/modules/xenoarcheaology/finds/find_types/_find.dm
@@ -73,7 +73,7 @@ var/global/list/responsive_carriers = list(
 	return
 
 /decl/archaeological_find/proc/generate_engravings(obj/item/I)
-	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors[num2text(get_z(I))]
+	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[num2text(get_z(I))]
 	. = "[pick("Engraved","Carved","Etched")] on the item is [pick("an image of","a frieze of","a depiction of")] "
 	if(istype(E))
 		. += E.get_engravings()

--- a/code/modules/xenoarcheaology/finds/find_types/_find.dm
+++ b/code/modules/xenoarcheaology/finds/find_types/_find.dm
@@ -73,7 +73,7 @@ var/global/list/responsive_carriers = list(
 	return
 
 /decl/archaeological_find/proc/generate_engravings(obj/item/I)
-	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[num2text(get_z(I))]
+	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[get_z(I)]
 	. = "[pick("Engraved","Carved","Etched")] on the item is [pick("an image of","a frieze of","a depiction of")] "
 	if(istype(E))
 		. += E.get_engravings()

--- a/code/unit_tests/shuttle_tests.dm
+++ b/code/unit_tests/shuttle_tests.dm
@@ -4,8 +4,8 @@
 /datum/unit_test/generic_shuttle_landmarks_shall_not_appear_in_restricted_list/start_test()
 	var/fail = FALSE
 
-	for(var/sz in global.overmap_sectors)
-		var/obj/effect/overmap/visitable/sector = global.overmap_sectors[sz]
+	for(var/sz in global.overmap_sectors_by_z)
+		var/obj/effect/overmap/visitable/sector = global.overmap_sectors_by_z[sz]
 		if(!istype(sector))
 			continue
 		var/list/failures = list()

--- a/maps/exodus/exodus_setup.dm
+++ b/maps/exodus/exodus_setup.dm
@@ -15,6 +15,8 @@
 
 		for(var/zlevel in global.overmap_sectors_by_z)
 			var/obj/effect/overmap/visitable/O = global.overmap_sectors_by_z[zlevel]
+			if(!O)
+				continue
 			if(O.name == exodus.name)
 				continue
 			if(istype(O, /obj/effect/overmap/visitable/ship/landable)) //Don't show shuttles

--- a/maps/exodus/exodus_setup.dm
+++ b/maps/exodus/exodus_setup.dm
@@ -13,8 +13,8 @@
 		welcome_text += "Time since last port visit:<br /><b>[rand(60,180)] days</b><br /><hr>"
 		welcome_text += "Scan results show the following points of interest:<br />"
 
-		for(var/zlevel in global.overmap_sectors)
-			var/obj/effect/overmap/visitable/O = global.overmap_sectors[zlevel]
+		for(var/zlevel in global.overmap_sectors_by_z)
+			var/obj/effect/overmap/visitable/O = global.overmap_sectors_by_z[zlevel]
 			if(O.name == exodus.name)
 				continue
 			if(istype(O, /obj/effect/overmap/visitable/ship/landable)) //Don't show shuttles

--- a/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
+++ b/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
@@ -22,7 +22,7 @@
 	. = ..()
 	icon_state = "jaggy[rand(1,4)]"
 
-	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[num2text(z)]
+	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[z]
 	if(istype(E))
 		desc += "\nThere are images on it: [E.get_engravings()]"
 	update_icon()
@@ -47,7 +47,7 @@
 /obj/structure/monolith/attack_hand(mob/user)
 	visible_message("\The [user] touches \the [src].")
 	if(istype(user, /mob/living/carbon/human))
-		var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[num2text(z)]
+		var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[z]
 		if(istype(E))
 			var/mob/living/carbon/human/H = user
 			if(!H.isSynthetic())

--- a/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
+++ b/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
@@ -22,7 +22,7 @@
 	. = ..()
 	icon_state = "jaggy[rand(1,4)]"
 
-	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[num2text(z)]
 	if(istype(E))
 		desc += "\nThere are images on it: [E.get_engravings()]"
 	update_icon()
@@ -47,7 +47,7 @@
 /obj/structure/monolith/attack_hand(mob/user)
 	visible_message("\The [user] touches \the [src].")
 	if(istype(user, /mob/living/carbon/human))
-		var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors[num2text(z)]
+		var/obj/effect/overmap/visitable/sector/exoplanet/E = global.overmap_sectors_by_z[num2text(z)]
 		if(istype(E))
 			var/mob/living/carbon/human/H = user
 			if(!H.isSynthetic())

--- a/maps/tradeship/jobs/command.dm
+++ b/maps/tradeship/jobs/command.dm
@@ -48,8 +48,8 @@
 	global.using_map.station_short = ship
 	global.using_map.station_name = "Tradeship [ship]"
 
-	for(var/sz in global.overmap_sectors)
-		var/obj/effect/overmap/visitable/ship/tradeship/B = global.overmap_sectors[sz]
+	for(var/sz in global.overmap_sectors_by_z)
+		var/obj/effect/overmap/visitable/ship/tradeship/B = global.overmap_sectors_by_z[sz]
 		if(istype(B))
 			B.SetName(global.using_map.station_name)
 			command_announcement.Announce("Attention all hands on [global.using_map.station_name]! Thank you for your attention.", "Ship Re-Christened")


### PR DESCRIPTION
## Description of changes
Since we've recently made a bunch of z-level related lists be z indexed instead of using text string keys, I made ``overmap_by_z`` and ``overmap_sectors``  also use the actual z index number instead of having to convert the number to string each times.
It's less confusing, and you don't need to go code reading each times you want to know if you need a number or string for accessing that list.

I also renamed ``overmap_sectors`` to ``overmap_sectors_by_z`` for clarity and to match the other lists indexed by z levels.

**Note** : The ``overmap_by_z`` list probably didn't need that since it will always only have one or two entries. But, turns out, it's called in the overmap turfs's initialize proc. So I'm guessing that it might actually be worth it to skip the cost of string conversion for several hundred turfs.

## Why and what will this PR improve
Slightly improve clarity, makes accessing those lists a tiny bit faster.
