### PR TITLE
deltheworld prints full exception data when catching one

### DIFF
--- a/code/unit_tests/del_the_world.dm
+++ b/code/unit_tests/del_the_world.dm
@@ -44,7 +44,7 @@
 			if(!QDELETED(AM)) // could have returned the qdel hint
 				qdel(AM, force = TRUE) // must qdel prior to anything it spawns, just in case
 		catch(var/exception/e)
-			failures += "Runtime during creation of [path]: [e]"
+			failures += "Runtime during creation of [path]: [e.file]:[e.line], [e]\n[e.desc]"
 		// If it spawned anything else, delete that.
 		var/list/del_candidates = spawn_loc.contents - cached_contents
 		if(length(del_candidates)) // explicit length check is faster here

--- a/code/unit_tests/items.dm
+++ b/code/unit_tests/items.dm
@@ -20,7 +20,7 @@
 				continue
 			obj_test_instances[path] = I
 		catch(var/exception/e)
-			failures += "Runtime during creation of [path]: [e]"
+			failures += "Runtime during creation of [path]: [e.file]:[e.line], [e]\n[e.desc]"
 
 	// Create tests + sort by type name so the test can run in alphabetical order
 	var/list/constant_tests = list()


### PR DESCRIPTION
## Description of changes
The "del the world" unit test wouldn't print the line number or filename when it caught an exception, which makes troubleshooting pretty hard. So, I added the missing bits to the failure output.
