### PR TITLE
Make broken and burn floor vars into strings

### DIFF
--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -159,7 +159,8 @@
 	icon = 'icons/turf/flooring/tiles.dmi'
 	icon_base = "tiled"
 	color = COLOR_DARK_GUNMETAL
-	has_damage_range = 4
+	has_damage_range = 2
+	has_burn_range = 2
 	damage_temperature = T0C+1400
 	flags = TURF_REMOVE_CROWBAR | TURF_CAN_BREAK | TURF_CAN_BURN
 	build_type = /obj/item/stack/tile/floor

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -9,6 +9,7 @@
 	turf_flags = TURF_IS_HOLOMAP_PATH
 
 	// Damage to flooring.
+	// These are icon state suffixes, NOT booleans!
 	var/broken
 	var/burnt
 	// Plating data.

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -176,11 +176,14 @@
 
 /turf/simulated/floor/proc/welder_melt()
 	if(!(is_plating()) || broken || burnt)
-		return 0
-	burnt = 1
+		return FALSE
+	// if burnt/broken is nonzero plating just chooses a random icon
+	// so it doesn't really matter what we set this to as long as it's truthy
+	// let's keep it a string for consistency with the other uses of it
+	burnt = "1"
 	remove_decals()
 	update_icon()
-	return 1
+	return TRUE
 
 /turf/simulated/floor/why_cannot_build_cable(var/mob/user, var/cable_error)
 	switch(cable_error)

--- a/code/game/turfs/simulated/floor_damage.dm
+++ b/code/game/turfs/simulated/floor_damage.dm
@@ -10,9 +10,9 @@
 	if(!flooring || !(flooring.flags & TURF_CAN_BREAK) || !isnull(broken))
 		return
 	if(flooring.has_damage_range)
-		broken = rand(0,flooring.has_damage_range)
+		broken = text2num(rand(0,flooring.has_damage_range))
 	else
-		broken = 0
+		broken = "0"
 	remove_decals()
 	update_icon()
 
@@ -20,8 +20,8 @@
 	if(!flooring || !(flooring.flags & TURF_CAN_BURN) || !isnull(burnt))
 		return
 	if(flooring.has_burn_range)
-		burnt = rand(0,flooring.has_burn_range)
+		burnt = text2num(rand(0,flooring.has_burn_range))
 	else
-		burnt = 0
+		burnt = "0"
 	remove_decals()
 	update_icon()


### PR DESCRIPTION
## Description of changes
Some things were checking `!burnt`, but `burnt = 0` means the tile should use the burn state named `"burned0"`. Rather than turn it all into `isnull(burnt)` I decided to make it use `burnt = "0"` instead. Now, `burnt` and `broken` are strings.

## Why and what will this PR improve
`!burnt` should function properly.