### PR TITLE
Allow mobile ladders to be placed on exoplanets

### DIFF
--- a/code/modules/multiz/mobile_ladder.dm
+++ b/code/modules/multiz/mobile_ladder.dm
@@ -27,7 +27,7 @@
 		else if(T.CanZPass(T, DOWN))
 			to_chat(user, SPAN_WARNING("You can't find anything to support \the [src] on!"))
 			return FALSE
-	else if (istype(T, /turf/simulated/floor) || istype(T, /turf/unsimulated/floor))
+	else if (T.is_floor())
 		target = GetAbove(A)
 		if(!istype(target) || !target.is_open() || target.contains_dense_objects())
 			to_chat(user, SPAN_WARNING("There is something above \the [T]. You can't deploy \the [src]!"))


### PR DESCRIPTION
## Description of changes
Replaces two istypes with an `is_floor()` call.

## Why and what will this PR improve
You can now place mobile ladders on exoplanets.