### PR TITLE
Adds plastic wall variants and mapped wall preview colors

### DIFF
--- a/code/game/turfs/simulated/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types.dm
@@ -57,6 +57,11 @@
 	icon_state = "metal"
 	material = /decl/material/solid/metal/iron
 
+/turf/simulated/wall/plastic
+	color = COLOR_EGGSHELL
+	icon_state = "plastic"
+	material = /decl/material/solid/plastic
+
 /turf/simulated/wall/sandstone
 	color = COLOR_GOLD
 	icon_state = "stone"

--- a/code/game/turfs/simulated/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types.dm
@@ -1,26 +1,24 @@
 //Commonly used
 /turf/simulated/wall/prepainted
-	paint_color = COLOR_GUNMETAL
-
+	color = COLOR_GUNMETAL
+	paint_color = COLOR_WALL_GUNMETAL
+	stripe_color = COLOR_GUNMETAL
 /turf/simulated/wall/r_wall/prepainted
-	paint_color = COLOR_GUNMETAL
+	color = COLOR_GUNMETAL
+	paint_color = COLOR_WALL_GUNMETAL
+	stripe_color = COLOR_GUNMETAL
 
 /turf/simulated/wall/r_wall
+	color = "#a8a9b2"
 	icon_state = "reinforced_solid"
 	material = /decl/material/solid/metal/plasteel
 	reinf_material = /decl/material/solid/metal/plasteel
 
 /turf/simulated/wall/r_wall/hull
 	name = "hull"
+	color = COLOR_HULL
 	paint_color = COLOR_HULL
 	stripe_color = COLOR_HULL
-
-/turf/simulated/wall/prepainted
-	paint_color = COLOR_WALL_GUNMETAL
-	stripe_color = COLOR_GUNMETAL
-/turf/simulated/wall/r_wall/prepainted
-	paint_color = COLOR_WALL_GUNMETAL
-	stripe_color = COLOR_GUNMETAL
 
 /turf/simulated/wall/r_wall/hull/Initialize()
 	. = ..()
@@ -44,6 +42,7 @@
 	material = /decl/material/solid/metal/titanium
 
 /turf/simulated/wall/r_titanium
+	color = "#d1e6e3"
 	icon_state = "reinforced_solid"
 	material = /decl/material/solid/metal/titanium
 	reinf_material = /decl/material/solid/metal/titanium
@@ -54,6 +53,7 @@
 	reinf_material = /decl/material/solid/metal/plasteel/ocp
 
 /turf/simulated/wall/iron
+	color = "#5c5454"
 	icon_state = "metal"
 	material = /decl/material/solid/metal/iron
 
@@ -61,6 +61,10 @@
 	color = COLOR_EGGSHELL
 	icon_state = "plastic"
 	material = /decl/material/solid/plastic
+
+// A plastic wall with a plastic girder. Very flimsy but very easy to move or remove with just a crowbar.
+/turf/simulated/wall/plastic/facade
+	girder_material = /decl/material/solid/plastic
 
 /turf/simulated/wall/sandstone
 	color = COLOR_GOLD

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -26,7 +26,7 @@ var/global/list/wall_fullblend_objects = list(
 	thermal_conductivity = WALL_HEAT_TRANSFER_COEFFICIENT
 	heat_capacity = 312500 //a little over 5 cm thick , 312500 for 1 m by 2.5 m by 0.25 m plasteel wall
 	explosion_resistance = 10
-	color = COLOR_GRAY40
+	color = COLOR_STEEL
 	atom_flags = ATOM_FLAG_CAN_BE_PAINTED
 	turf_flags = TURF_IS_HOLOMAP_OBSTACLE
 


### PR DESCRIPTION
## Description of changes
Fixes duplicated/conflicting wall color definitions.
Adds mapping preview colors to walls, based on the material colors.
Adds premade plastic walls for mapping. These are useful because they can be removed with just a crowbar instead of a welder.
Also adds a 'facade' type.

## Why and what will this PR improve
Makes it clearer what walls will look like in-game when mapping stuff.
Also, more options for material walls.