### PR TITLE
Clean up some strings and sensor defines

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -75,7 +75,7 @@
 
 /datum/uplink_item/item/ammo/flechette
 	name = "Flechette Rifle Magazine"
-	desc = "A  rifle magazine loaded with flechette rounds. Contains 9 rounds."
+	desc = "A rifle magazine loaded with flechette rounds. Contains 9 rounds."
 	item_cost = 8
 	path = /obj/item/magnetic_ammo
 	antag_roles = list(/decl/special_role/mercenary)

--- a/code/game/objects/items/weapons/electric_welder.dm
+++ b/code/game/objects/items/weapons/electric_welder.dm
@@ -2,7 +2,6 @@
 	name = "arc welder"
 	desc = "A man-portable arc welding tool."
 	icon = 'icons/obj/items/tool/welders/welder_arc.dmi'
-	icon_state = "welder_arc"
 	welding_resource = "stored charge"
 	tank = null
 	waterproof = TRUE

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -22,7 +22,7 @@
 	permeability_coefficient = 0.01
 
 /obj/item/clothing/mask/breath/emergency
-	desc = "A close-fitting  mask that is used by the wallmounted emergency oxygen pump."
+	desc = "A close-fitting mask that is used by the wallmounted emergency oxygen pump."
 	name = "emergency mask"
 	permeability_coefficient = 0.50
 

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -29,13 +29,8 @@
 		ACCESSORY_SLOT_OVER
 		)
 
-	var/has_sensor = SUIT_HAS_SENSORS //For the crew computer 2 = unable to change mode
-	var/sensor_mode = 0
-		/*
-		1 = Report living/dead
-		2 = Report detailed damages
-		3 = Report location
-		*/
+	var/has_sensor = SUIT_HAS_SENSORS
+	var/sensor_mode = SUIT_SENSOR_OFF
 	var/displays_id = 1
 	var/rolled_down = FALSE
 	var/rolled_sleeves = FALSE

--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -9,8 +9,8 @@
 	name = "orange jumpsuit"
 	desc = "It's standardised prisoner-wear. Its suit sensor controls are permanently set to the \"Fully On\" position."
 	icon = 'icons/clothing/under/jumpsuits/jumpsuit_prisoner.dmi'
-	has_sensor = 2
-	sensor_mode = 3
+	has_sensor = SUIT_LOCKED_SENSORS
+	sensor_mode = SUIT_SENSOR_TRACKING
 
 /obj/item/clothing/under/color/blackjumpshorts
 	name = "black jumpsuit shorts"

--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -2,7 +2,7 @@
 	name = "tactical turtleneck"
 	desc = "It's some non-descript, slightly suspicious looking, civilian clothing."
 	icon = 'icons/clothing/under/uniform_tacticool.dmi'
-	has_sensor = 0
+	has_sensor = SUIT_NO_SENSORS
 	armor = list(
 		ARMOR_MELEE = ARMOR_MELEE_SMALL,
 		ARMOR_BULLET = ARMOR_BALLISTIC_MINOR,

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -172,7 +172,7 @@
 	// Other incidentals.
 	if(istype(suit))
 		dat += "<BR><b>Pockets:</b> <A href='?src=\ref[src];item=pockets'>Empty or Place Item</A>"
-		if(suit.has_sensor == 1)
+		if(suit.has_sensor == SUIT_HAS_SENSORS)
 			dat += "<BR><A href='?src=\ref[src];item=sensors'>Set sensors</A>"
 		if (suit.has_sensor && user.get_multitool())
 			dat += "<BR><A href='?src=\ref[src];item=lock_sensors'>[suit.has_sensor == SUIT_LOCKED_SENSORS ? "Unl" : "L"]ock sensors</A>"

--- a/code/modules/modular_computers/computers/subtypes/dev_telescreen.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_telescreen.dm
@@ -11,8 +11,8 @@
 		/obj/item/stock_parts/computer/processor_unit = 1
 	)
 	additional_spawn_components = list(
-		/obj/item/stock_parts/power/apc/buildable = 1, 
-		/obj/item/stock_parts/computer/network_card = 1, 
+		/obj/item/stock_parts/power/apc/buildable = 1,
+		/obj/item/stock_parts/computer/network_card = 1,
 		/obj/item/stock_parts/computer/hard_drive/super = 1
 	)
 
@@ -29,7 +29,7 @@
 
 /obj/item/frame/modular_telescreen/kit
 	fully_construct = TRUE
-	name = "modular telescreen  kit"
+	name = "modular telescreen kit"
 	desc = "An all-in-one wall-mounted modular telescreen computer kit, comes preassembled."
 	icon_state = "frame_kit"
 
@@ -72,7 +72,7 @@
 	os_type            = /datum/extension/interactive/os/console/telescreen
 
 /obj/machinery/computer/modular/telescreen/update_directional_offset(force = FALSE)
-	if(!force && (!length(directional_offset) || !is_wall_mounted())) 
+	if(!force && (!length(directional_offset) || !is_wall_mounted()))
 		return
 	. = ..()
 
@@ -100,7 +100,7 @@
 
 	if(!panel_open && (reason_broken & MACHINE_BROKEN_GENERIC))
 		add_overlay("panel_broken")
-	
+
 	if(inoperable())
 		set_light(0)
 		var/screen = get_component_of_type(/obj/item/stock_parts/console_screen)

--- a/code/modules/spells/targeted/equip/seed.dm
+++ b/code/modules/spells/targeted/equip/seed.dm
@@ -6,7 +6,7 @@
 
 	spell_flags = INCLUDEUSER | NEEDSCLOTHES
 	invocation_type = SpI_WHISPER
-	invocation = "Ria'li  akta."
+	invocation = "Ria'li akta."
 
 	equipped_summons = list("active hand" = /obj/item/seeds/random)
 	compatible_mobs = list(/mob/living/carbon/human)

--- a/mods/species/vox/gear/gear_under.dm
+++ b/mods/species/vox/gear/gear_under.dm
@@ -1,5 +1,5 @@
 /obj/item/clothing/under/vox
-	has_sensor = 0
+	has_sensor = SUIT_NO_SENSORS
 	bodytype_equip_flags = BODY_FLAG_VOX
 
 /obj/item/clothing/under/vox/vox_casual


### PR DESCRIPTION
## Description of changes
Fixes some double spaces in strings. Did *not* touch double spaces after punctuation/for formatting, only between words.
Fixes a nonexistent icon_state override for electrical welders that made them have no sprite in map editors.
Makes `has_sensor` and `sensor_mode` consistently use the corresponding defines instead of magic numbers.

## Why and what will this PR improve
Just some generic code quality cleanup stuff.