### PR TITLE
Backport STP phase check fixes from dev to stable

### DIFF
--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -112,7 +112,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 
 	// Attributes
 	/// How rare is this material generally?
-	var/exoplanet_rarity = MAT_RARITY_MUNDANE 
+	var/exoplanet_rarity = MAT_RARITY_MUNDANE
 	/// Delay in ticks when cutting through this wall.
 	var/cut_delay = 0
 	/// Radiation var. Used in wall and object processing to irradiate surroundings.
@@ -125,7 +125,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	var/boiling_point = 3000
 	/// kJ/kg, enthalpy of vaporization
 	var/latent_heat = 7000
-	/// kg/mol, 
+	/// kg/mol,
 	var/molar_mass = 0.06
 	/// Brute damage to a wall is divided by this value if the wall is reinforced by this material.
 	var/brute_armor = 2
@@ -144,15 +144,15 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	/// Used for checking if a material can function as a wall support.
 	var/wall_support_value = 30
 	/// Ore generation constant for rare materials.
-	var/sparse_material_weight                
+	var/sparse_material_weight
 	/// Ore generation constant for common materials.
-	var/rich_material_weight                  
+	var/rich_material_weight
 	/// How transparent can fluids be?
-	var/min_fluid_opacity = FLUID_MIN_ALPHA   
+	var/min_fluid_opacity = FLUID_MIN_ALPHA
 	/// How opaque can fluids be?
 	var/max_fluid_opacity = FLUID_MAX_ALPHA
 	/// Point at which the fluid will proc turf interaction logic. Workaround for mops being ruined forever by 1u of anything else being added.
-	var/turf_touch_threshold = FLUID_QDEL_POINT 
+	var/turf_touch_threshold = FLUID_QDEL_POINT
 
 	// Damage values.
 	var/hardness = MAT_VALUE_HARD            // Prob of wall destruction by hulk, used for edge damage in weapons.
@@ -362,18 +362,15 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 /decl/material/proc/get_boiling_temp(var/pressure = ONE_ATMOSPHERE)
 	return (1 / (1/max(boiling_point, TCMB)) - ((R_IDEAL_GAS_EQUATION * log(pressure / ONE_ATMOSPHERE)) / (latent_heat * molar_mass)))
 
-// Returns the phase of the matterial at the given temperature and pressure
-/decl/material/proc/phase_at_temperature(var/temperature, var/pressure = ONE_ATMOSPHERE)
+/// Returns the phase of the matterial at the given temperature and pressure
+/// Defaults to standard temperature and pressure (20c at one atmosphere)
+/decl/material/proc/phase_at_temperature(var/temperature = T20C, var/pressure = ONE_ATMOSPHERE)
 	//#TODO: implement plasma temperature and do pressure checks
-	if(temperature >= get_boiling_temp(pressure))
+	if(!isnull(boiling_point) && temperature >= get_boiling_temp(pressure))
 		return MAT_PHASE_GAS
-	else if(temperature >= heating_point)
+	else if(!isnull(heating_point) && temperature >= heating_point)
 		return MAT_PHASE_LIQUID
 	return MAT_PHASE_SOLID
-
-// Returns the phase of matter this material is a standard temperature and pressure (20c at one atmosphere)
-/decl/material/proc/phase_at_stp()
-	return phase_at_temperature(T20C, ONE_ATMOSPHERE)
 
 // Used by walls when qdel()ing to avoid neighbor merging.
 /decl/material/placeholder

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -18,7 +18,7 @@
 
 /decl/material/proc/generate_recipes(var/reinforce_material)
 
-	if(phase_at_stp() != MAT_PHASE_SOLID)
+	if(phase_at_temperature() != MAT_PHASE_SOLID)
 		return list()
 
 	. = list()


### PR DESCRIPTION
## Description of changes
Backports some `isnull(boiling_point)` and `isnull(heating_point)` checks in `phase_at_temperature()` from dev to stable.

## Why and what will this PR improve
Fixes materials not getting recipes because they have a null boiling or heating point.

## Authorship
@MistakeNot4892