### PR TITLE
Fix chlorine exoplanets showing up as desert

### DIFF
--- a/code/modules/maps/template_types/random_exoplanet/planet_types/chlorine.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/chlorine.dm
@@ -63,7 +63,7 @@
 
 /datum/map_template/planetoid/exoplanet/chlorine
 	name                       = "chlorine exoplanet"
-	overmap_marker_type        = /obj/effect/overmap/visitable/sector/planetoid/exoplanet/desert
+	overmap_marker_type        = /obj/effect/overmap/visitable/sector/planetoid/exoplanet/chlorine
 	flora_generator_type       = /datum/flora_generator/chlorine
 	fauna_generator_type       = /datum/fauna_generator/chlorine
 	ruin_tags_blacklist        = RUIN_HABITAT|RUIN_WATER


### PR DESCRIPTION
## Description of changes
I mentioned this on #2999 (which introduced the issue, AFAIK) but merged it anyway since it's not gamebreaking and it's easy enough to fix after. I honestly kind of just assumed it was intentional until I saw that the chlorine exoplanet object existed.

## Why and what will this PR improve
Chlorine and desert exoplanets can now be distinguished visually.