### PR TITLE
Fix strange rocks always deleting finds

### DIFF
--- a/code/modules/xenoarcheaology/finds/strange_rock.dm
+++ b/code/modules/xenoarcheaology/finds/strange_rock.dm
@@ -16,12 +16,13 @@
 /obj/item/strangerock/Destroy()
 	QDEL_NULL(inside)
 	. = ..()
-	
+
 /obj/item/strangerock/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/pickaxe/xeno/brush))
 		if(inside)
 			inside.dropInto(loc)
 			visible_message(SPAN_NOTICE("\The [src] is brushed away, revealing \the [inside]."))
+			inside = null
 		else
 			visible_message(SPAN_NOTICE("\The [src] is brushed away into nothing."))
 		physically_destroyed()
@@ -34,6 +35,7 @@
 				if(inside)
 					inside.dropInto(loc)
 					visible_message(SPAN_NOTICE("\The [src] burns away revealing \the [inside]."))
+					inside = null
 				else
 					visible_message(SPAN_NOTICE("\The [src] burns away into nothing."))
 				physically_destroyed()


### PR DESCRIPTION
## Description of changes
Sets `inside` to null to avoid deleting it when the rock is destroyed.
Targets staging because of minor conflicts with stable.

## Why and what will this PR improve
Fixes #3070.