### PR TITLE
Adapted airlock radio fixes.

### DIFF
--- a/code/game/machinery/embedded_controller/airlock_program.dm
+++ b/code/game/machinery/embedded_controller/airlock_program.dm
@@ -89,24 +89,30 @@
 	if(!receive_tag) return
 
 	if(receive_tag==tag_chamber_sensor)
-		if(signal.data["pressure"])
+		if("pressure" in signal.data)
 			memory["chamber_sensor_pressure"] = text2num(signal.data["pressure"])
 
 	else if(receive_tag==tag_exterior_sensor)
-		memory["external_sensor_pressure"] = text2num(signal.data["pressure"])
+		if("pressure" in signal.data)
+			memory["external_sensor_pressure"] = text2num(signal.data["pressure"])
 
 	else if(receive_tag==tag_interior_sensor)
-		memory["internal_sensor_pressure"] = text2num(signal.data["pressure"])
+		if("pressure" in signal.data)
+			memory["internal_sensor_pressure"] = text2num(signal.data["pressure"])
 
 	else if(receive_tag==tag_exterior_door)
-		memory["exterior_status"]["state"] = signal.data["door_status"]
-		memory["exterior_status"]["lock"] = signal.data["lock_status"]
+		if("door_status" in signal.data)
+			memory["exterior_status"]["state"] = signal.data["door_status"]
+		if("lock_status" in signal.data)
+			memory["exterior_status"]["lock"] = signal.data["lock_status"]
 
 	else if(receive_tag==tag_interior_door)
-		memory["interior_status"]["state"] = signal.data["door_status"]
-		memory["interior_status"]["lock"] = signal.data["lock_status"]
+		if("door_status" in signal.data)
+			memory["interior_status"]["state"] = signal.data["door_status"]
+		if("lock_status" in signal.data)
+			memory["interior_status"]["lock"] = signal.data["lock_status"]
 
-	else if(receive_tag==tag_airpump || receive_tag==tag_pump_out_internal)
+	else if((receive_tag==tag_airpump || receive_tag==tag_pump_out_internal) && ("power" in signal.data))
 		if(signal.data["power"])
 			memory["pump_status"] = signal.data["direction"]
 		else

--- a/code/game/machinery/embedded_controller/simple_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/simple_docking_controller.dm
@@ -55,8 +55,10 @@
 	if(!receive_tag) return
 
 	if(receive_tag==tag_door)
-		memory["door_status"]["state"] = signal.data["door_status"]
-		memory["door_status"]["lock"] = signal.data["lock_status"]
+		if("door_status" in signal.data)
+			memory["door_status"]["state"] = signal.data["door_status"]
+		if("lock_status" in signal.data)
+			memory["door_status"]["lock"] = signal.data["lock_status"]
 
 	..(signal, receive_method, receive_param)
 


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes

This is an adaptation of the fix in #3004. 

There, @PsyCommando observed that the radio signal check used by airlock controllers, `data["pressure"]`, is incorrect when a `null` or `0` pressure is transmitted, and these are valid values; this leads to some potential bugs with the internal logic.

I then torpedoed that PR by requesting the check you see here, `("pressure" in data)`, be used instead, arguing that having _no check at all_ leads to undesirable behavior if one modifies the now-modifiable radio signalling hardware in the pumps or elsewhere. @PsyCommando noted that there are a bunch of similar places directly below that receive boolean or numerical variables but make no checks at all. This updates all of them.

I remark that #3004 makes an additional change to pump code that I do not reproduce here; it seems unnecessary to me, but that is purely from code inspection.

## Why and what will this PR improve

It may help address intermittent airlock issues with cycling to/from vacuum, and make modifying pump radio keys in round behave more intuitively with airlock controllers.

## Authorship
@PsyCommando, me
