### PR TITLE
Tweak wall deconstruction and girder handling

### DIFF
--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -77,7 +77,7 @@
 	if(!can_open)
 		to_chat(user, "<span class='notice'>You push \the [src], but nothing happens.</span>")
 		playsound(src, hitsound, 25, 1)
-	else
+	else if (isnull(construction_stage) || !reinf_material)
 		toggle_open(user)
 
 /turf/simulated/wall/attack_hand(var/mob/user)

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -225,7 +225,6 @@
 				else if(IS_WIRECUTTER(W))
 					playsound(src, 'sound/items/Wirecutter.ogg', 100, 1)
 					construction_stage = 5
-					SSmaterials.create_object(/decl/material/solid/metal/steel, src, 1, /obj/item/stack/material/rods)
 					to_chat(user, "<span class='notice'>You cut the outer grille.</span>")
 					update_icon()
 					return TRUE
@@ -240,12 +239,12 @@
 					update_icon()
 					to_chat(user, "<span class='notice'>You remove the support lines.</span>")
 					return
-				else if( istype(W, /obj/item/stack/material/rods) )
-					var/obj/item/stack/O = W
-					if(O.use(1))
+				else if(istype(W,/obj/item/weldingtool))
+					var/obj/item/weldingtool/WT = W
+					if(WT.weld(0,user))
 						construction_stage = 6
 						update_icon()
-						to_chat(user, "<span class='notice'>You replace the outer grille.</span>")
+						to_chat(user, SPAN_NOTICE("You repair the outer grille."))
 						return TRUE
 			if(4)
 				var/cut_cover
@@ -315,8 +314,7 @@
 						return
 					construction_stage = 0
 					update_icon()
-					SSmaterials.create_object(/decl/material/solid/metal/steel, src, 1, /obj/item/stack/material/rods)
-					to_chat(user, "<span class='notice'>The support rods drop out as you cut them loose from the frame.</span>")
+					to_chat(user, "<span class='notice'>You cut the support rods loose from the frame.</span>")
 					return
 			if(0)
 				if(IS_CROWBAR(W))

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -217,11 +217,16 @@ var/global/list/wall_fullblend_objects = list(
 
 	playsound(src, 'sound/items/Welder.ogg', 100, 1)
 	if(!no_product)
+		var/list/obj/structure/girder/placed_girders
 		if(girder_material)
-			girder_material.place_dismantled_girder(src, reinf_material)
+			placed_girders = girder_material.place_dismantled_girder(src, reinf_material)
 			material.place_dismantled_product(src,devastated)
 		else
-			material.place_dismantled_girder(src, reinf_material)
+			placed_girders = material.place_dismantled_girder(src, reinf_material)
+		for(var/obj/structure/girder/placed_girder in placed_girders)
+			placed_girder.anchored = TRUE
+			placed_girder.prepped_for_fakewall = can_open
+			placed_girder.update_icon()
 
 	for(var/obj/O in src.contents) //Eject contents!
 		if(istype(O,/obj/structure/sign/poster))


### PR DESCRIPTION
## Description of changes
- You can no longer open false reinforced walls mid-deconstruction.
- Reinforced walls will no longer mysteriously spawn steel rods during deconstruction.
    - Reversing step 2 of rwall deconstruction (cutting the 'outer grille') is now repaired with a welder instead of adding rods.
- The girders created from dismantling walls will preserve falsewall status and be anchored.

## Why and what will this PR improve
Fixes an exploit where you could generate steel rods via deconstructing rwalls.
Makes deconstructed wall girders anchored, since they have to be anchored when constructed.
Fixes an ugly overlay conflict when opening rwalls mid-deconstruction (by disabling that).