### PR TITLE
Fix invalid paper material keys

### DIFF
--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -158,7 +158,7 @@ SUBSYSTEM_DEF(supply)
 			info +="[shoppinglist.len] PACKAGES IN THIS SHIPMENT<br>"
 			info +="CONTENTS:<br><ul>"
 
-			slip = new /obj/item/paper/manifest(A, JOINTEXT(info))
+			slip = new /obj/item/paper/manifest(A, null, JOINTEXT(info))
 			LAZYSET(slip.metadata, "order_total", SP.cost)
 			LAZYSET(slip.metadata, "is_copy",     FALSE)
 

--- a/code/game/objects/items/devices/scanners/_scanner.dm
+++ b/code/game/objects/items/devices/scanners/_scanner.dm
@@ -91,7 +91,7 @@
 		to_chat(user, "There is no scan data to print.")
 		return
 	playsound(loc, "sound/machines/dotprinter.ogg", 20, 1)
-	var/obj/item/paper/P = new(get_turf(src), scan_data, "paper - [scan_title]")
+	var/obj/item/paper/P = new(get_turf(src), null, scan_data, "paper - [scan_title]")
 	if(printout_color)
 		P.color = printout_color
 	user.put_in_hands(P)

--- a/code/modules/detectivework/microscope/_forensic_machine.dm
+++ b/code/modules/detectivework/microscope/_forensic_machine.dm
@@ -89,11 +89,11 @@
 			. += F.get_formatted_data()
 		else
 			. += "No [F.name] detected."
-	
+
 	. = jointext(., "<br>")
 
 /obj/machinery/forensic/proc/print_report()
-	var/obj/item/paper/report = new(get_turf(src), get_report(), "[src] report #[++report_num]: [sample.name]")
+	var/obj/item/paper/report = new(get_turf(src), null, get_report(), "[src] report #[++report_num]: [sample.name]")
 	playsound(loc, "sound/machines/dotprinter.ogg", 30, 1)
 	report.apply_custom_stamp(overlay_image('icons/obj/bureaucracy.dmi', icon_state = "paper_stamp-brig", flags = RESET_COLOR), "by \the [src]")
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -53,7 +53,7 @@
 
 /**Creates a complete copy of this object */
 /obj/item/paper/proc/Clone()
-	var/obj/item/paper/P = new(loc, , info, name)
+	var/obj/item/paper/P = new(loc, material?.type, info, name)
 	P.fields             = fields
 	P.last_modified_ckey = last_modified_ckey
 	P.rigged             = rigged
@@ -409,7 +409,7 @@
 		if(!user.canUnEquip(other))
 			to_chat(user, SPAN_WARNING("You can't unequip \the [other]!"))
 			return
-		user.unEquip(src, B) 
+		user.unEquip(src, B)
 		user.unEquip(other, B)
 
 	if (name != initial(name))


### PR DESCRIPTION
## Description of changes
Fixes some off-by-one errors in paper new() arguments.
Adds material?.type as the material key in paper/Clone().

## Why and what will this PR improve
Fixes some runtimes due to passing paper data as a material key, title as paper data, and null as title.