### PR TITLE
Fix hoist for non-mobs

### DIFF
--- a/code/modules/multiz/hoist.dm
+++ b/code/modules/multiz/hoist.dm
@@ -78,6 +78,8 @@
 	hoistee = AM
 	if(ismob(AM))
 		source_hook.buckle_mob(AM)
+	else
+		AM.anchored = TRUE // can't buckle non-mobs at the moment
 	source_hook.layer = AM.layer + 0.1
 	if (get_turf(AM) != get_turf(source_hook))
 		AM.forceMove(get_turf(source_hook))
@@ -150,6 +152,7 @@
 		source_hook.unbuckle_mob(hoistee)
 	else
 		hoistee.anchored = FALSE
+		hoistee.fall(get_turf(source_hook || hoistee))
 	events_repository.unregister(/decl/observ/destroyed, hoistee, src)
 	hoistee = null
 	layer = initial(layer)


### PR DESCRIPTION
## Description of changes
Fixes non-mob atoms falling when attached to a hoist (`anchored = TRUE` was removed when it shouldn't have been).
Fixes non-mob atoms not falling when detached from a hoist (`fall()` was only called for mobs)

## Why and what will this PR improve
Fixes the two aforementioned issues.

Known issues not addressed in this PR:
- Hoist kits can place the hook inside a wall.
- Controls are just kind of unintuitive? TODO: Radial menus for choosing up/down
- You can only change the direction of the hoist when the current direction is obstructed (also kind of falls under unintuitive controls).