### PR TITLE
OS and assembly tweaks and customization

### DIFF
--- a/code/modules/modular_computers/file_system/computer_file.dm
+++ b/code/modules/modular_computers/file_system/computer_file.dm
@@ -8,7 +8,7 @@ var/global/file_uid = 0
 	var/filename = "NewFile" 								// Placeholder. No spacebars
 	var/filetype = "XXX" 									// File full names are [filename].[filetype] so like NewFile.XXX in this case
 	var/size = 1											// File size in GQ. Integers only!
-	var/weakref/holder								// Holder that contains this file. Refers to a obj/item/stock_parts/computer/hard_drive.
+	var/weakref/holder										// Holder that contains this file. Refers to a obj/item/stock_parts/computer/hard_drive.
 	var/unsendable = 0										// Whether the file may be sent to someone via file transfer or other means.
 	var/undeletable = 0										// Whether the file may be deleted. Setting to 1 prevents deletion/renaming/etc.
 	var/unrenamable = 0										// Whether the file may be renamed. Setting to 1 prevents renaming.

--- a/code/modules/modular_computers/file_system/programs/generic/configurator.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/configurator.dm
@@ -18,9 +18,11 @@
 	category = PROG_UTIL
 
 /datum/nano_module/program/computer_configurator
-	name = "GOOSE Computer Configuration Tool"
+	name = "Computer Configuration Tool"
 
 /datum/nano_module/program/computer_configurator/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = global.default_topic_state)
+	name = "[program.computer.os_name] [initial(name)]" // i.e. GOOSE Computer Configuration Tool
+
 	var/list/data = list()
 
 	data = program.get_header_data()
@@ -62,9 +64,11 @@
 
 	data["receives_updates"] = program.computer.receives_updates
 
+	data["os_full_name"] = program.computer.os_full_name
+
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "laptop_configuration.tmpl", "OS Configuration Utility", 575, 700, state = state)
+		ui = new(user, src, ui_key, "laptop_configuration.tmpl", "[program.computer.os_name] Configuration Utility", 575, 700, state = state)
 		ui.auto_update_layout = 1
 		ui.set_initial_data(data)
 		ui.open()

--- a/code/modules/modular_computers/networking/device_types/mainframe.dm
+++ b/code/modules/modular_computers/networking/device_types/mainframe.dm
@@ -1,7 +1,7 @@
 var/global/list/all_mainframe_roles = list(
 	MF_ROLE_SOFTWARE,
 	MF_ROLE_FILESERVER,
-	MF_ROLE_LOG_SERVER, 
+	MF_ROLE_LOG_SERVER,
 	MF_ROLE_CREW_RECORDS,
 	MF_ROLE_ACCOUNT_SERVER
 )
@@ -51,14 +51,14 @@ var/global/list/all_mainframe_roles = list(
 	var/obj/item/stock_parts/computer/hard_drive/HDD = get_storage()
 	if(!HDD)
 		return OS_HARDDRIVE_ERROR
-	
+
 	return HDD.store_file(file, directory, create_directories, accesses, user, overwrite)
 
 /datum/extension/network_device/mainframe/proc/try_store_file(datum/computer_file/file, directory, list/accesses, mob/user)
 	var/obj/item/stock_parts/computer/hard_drive/HDD = get_storage()
 	if(!HDD)
 		return OS_HARDDRIVE_ERROR
-	
+
 	return HDD.try_store_file(file, directory, accesses, user)
 
 /datum/extension/network_device/mainframe/proc/save_file(newname, directory, new_data, list/metadata, list/accesses, mob/user)
@@ -71,7 +71,7 @@ var/global/list/all_mainframe_roles = list(
 	var/obj/item/stock_parts/computer/hard_drive/HDD = get_storage()
 	if(!HDD)
 		return OS_HARDDRIVE_ERROR
-	
+
 	return HDD.parse_directory(directory_path, create_directories)
 
 /datum/extension/network_device/mainframe/proc/append_to_file(filename, directory, data)
@@ -102,18 +102,22 @@ var/global/list/all_mainframe_roles = list(
 	var/obj/item/stock_parts/computer/hard_drive/HDD = get_storage()
 	if(!HDD)
 		return 0
-	return HDD.used_capacity 
+	return HDD.used_capacity
 
 // Disk that spawns with everything old system had
 /obj/item/stock_parts/computer/hard_drive/cluster/fullhouse/Initialize()
 	. = ..()
-	
+
 	for(var/F in subtypesof(/datum/computer_file/report))
 		var/datum/computer_file/report/type = F
+		if(TYPE_IS_ABSTRACT(type))
+			continue
 		if(initial(type.available_on_network))
 			store_file(new type, "reports", TRUE)
 
 	for(var/F in subtypesof(/datum/computer_file/program))
 		var/datum/computer_file/program/type = F
+		if(TYPE_IS_ABSTRACT(type))
+			continue
 		if(initial(type.available_on_network))
 			store_file(new type, OS_PROGRAMS_DIR, TRUE)

--- a/code/modules/modular_computers/os/_os.dm
+++ b/code/modules/modular_computers/os/_os.dm
@@ -19,7 +19,7 @@
 	var/os_full_name = "GOOSE v2.0.4b"
 
 	// Used for deciding if various tray icons need to be updated
-	var/last_battery_percent							
+	var/last_battery_percent
 	var/last_world_time
 	var/list/last_header_icons
 
@@ -64,7 +64,7 @@
 	var/datum/computer_file/data/account/access_account = get_account()
 	if(access_account)
 		var/datum/computer_network/network = get_network()
-		if(network) 	
+		if(network)
 			var/location = "[network.network_id]"
 			. += "[access_account.login]@[location]" // User access uses '@'
 			for(var/group in access_account.groups)
@@ -75,7 +75,7 @@
 		var/obj/item/card/id/I = user.GetIdCard()
 		if(I)
 			. += I.GetAccess(access_account?.login) // Ignore any access that's already on the user account.
-	
+
 // Returns the current account, if possible. User var is passed only for updating program access from ID, if no account is found.
 /datum/extension/interactive/os/proc/get_account(var/mob/user)
 	if(!current_account)
@@ -139,7 +139,7 @@
 	var/new_password = sanitize(input(user, "Enter your account password:", "Account password", default_password) as text|null)
 	if(!new_password || !CanUseTopic(user, global.default_topic_state))
 		return
-	
+
 	if(login_account(new_login, new_password, user))
 		to_chat(user, SPAN_NOTICE("Account login successful: Welcome [new_login]!"))
 	else
@@ -149,7 +149,7 @@
 	on = FALSE
 	for(var/datum/computer_file/program/P in running_programs)
 		kill_program(P, 1)
-	
+
 	var/obj/item/stock_parts/computer/network_card/network_card = get_component(PART_NETWORK)
 	if(network_card)
 		var/datum/extension/network_device/D = get_extension(network_card, /datum/extension/network_device)
@@ -217,8 +217,8 @@
 		P.program_state = PROGRAM_STATE_ACTIVE
 		active_program = P
 	else if(P.can_run(get_access(user), user, TRUE))
-		P.on_startup(user, src)
 		active_program = P
+		P.on_startup(user, src)
 	else
 		return
 	running_programs |= P

--- a/code/modules/modular_computers/os/_os.dm
+++ b/code/modules/modular_computers/os/_os.dm
@@ -15,6 +15,8 @@
 	var/menu_icon = "menu"									// Icon state overlay when the computer is turned on, but no program is loaded that would override the screen.
 	var/screensaver_icon = "standby"
 	var/default_icon = "generic"							//Overlay icon for programs that have a screen overlay the host doesn't have.
+	var/os_name = "GOOSE"
+	var/os_full_name = "GOOSE v2.0.4b"
 
 	// Used for deciding if various tray icons need to be updated
 	var/last_battery_percent							

--- a/code/modules/modular_computers/os/files.dm
+++ b/code/modules/modular_computers/os/files.dm
@@ -201,7 +201,7 @@
 
 /datum/file_storage/proc/check_errors()
 	if(!istype(os))
-		return "No GOOSE compatible device found."
+		return "No compatible device found."
 
 /datum/file_storage/proc/get_transfer_speed()
 	return 1

--- a/code/modules/modular_computers/os/ui.dm
+++ b/code/modules/modular_computers/os/ui.dm
@@ -42,7 +42,7 @@
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "laptop_mainscreen.tmpl", "GOOSE Main Menu ", 400, 500)
+		ui = new(user, src, ui_key, "laptop_mainscreen.tmpl", "[os_name] Main Menu ", 400, 500)
 		ui.auto_update_layout = 1
 		ui.set_initial_data(data)
 		ui.open()
@@ -119,7 +119,7 @@
 	if( href_list["PC_terminal"] )
 		open_terminal(usr)
 		return TOPIC_HANDLED
-	
+
 	if( href_list["PC_login"])
 		login_prompt(usr)
 		return TOPIC_REFRESH

--- a/code/modules/nano/modules/nano_module.dm
+++ b/code/modules/nano/modules/nano_module.dm
@@ -54,7 +54,7 @@
 	if(os)
 		os.print_paper(text)
 	else
-		to_chat(user, "Error: Unable to detect compatible printer interface. Are you running a GOOSEv2 compatible system?")
+		to_chat(user, "Error: Unable to detect compatible printer interface. Are you running a compatible system?")
 
 /datum/proc/initial_data()
 	return list()

--- a/nano/templates/laptop_configuration.tmpl
+++ b/nano/templates/laptop_configuration.tmpl
@@ -1,20 +1,20 @@
 <i>Welcome to computer configuration utility. Please consult your system administrator if you have any questions about your device.</i><hr>
 <h2>Power Supply</h2>
 <div class="itemLabel">
-	Battery Status: 
+	Battery Status:
 </div>
 {{if data.battery_exists}}
 	<div class="itemContent">
 		Active
 	</div>
 	<div class="itemLabel">
-		Battery Rating: 
+		Battery Rating:
 	</div>
 	<div class="itemContent">
 		{{:data.battery_rating}}
 	</div>
 	<div class="itemLabel">
-		Battery Charge: 
+		Battery Charge:
 	</div>
 	<div class="itemContent">
 		{{:helper.displayBar(data.battery_percent, 0, 100, (data.battery_percent <= 25) ? 'bad' : (data.battery_percent <= 50) ? 'average' : 'good')}}
@@ -26,7 +26,7 @@
 	</div>
 {{/if}}
 <div class="itemLabel">
-	Power Usage: 
+	Power Usage:
 </div>
 <div class="itemContent">
 	{{:data.power_usage}}W
@@ -68,7 +68,7 @@
 		Not Available
 	</div>
 {{/if}}
-<h2>File System</h2>	
+<h2>File System</h2>
 <div class="itemLabel">
 	Used Capacity:
 </div>
@@ -81,13 +81,13 @@
 	<h3>{{:value.name}}</h3>
 	<i>{{:value.desc}}</i><br>
 	<div class="itemLabel">
-		State: 
+		State:
 	</div>
 	<div class="itemContent">
 		{{:value.enabled ? "Enabled" : "Disabled"}}
-	</div>	
+	</div>
 	<div class="itemLabel">
-		Power Usage: 
+		Power Usage:
 	</div>
 	<div class="itemContent">
 		{{:value.powerusage}}W
@@ -100,25 +100,25 @@
 	</div>
 	{{if !value.critical}}
 	<div class="itemLabel">
-		Toggle Component: 
+		Toggle Component:
 	</div>
 	<div class="itemContent">
 		{{:helper.link("ON", null, {'PC_enable_component' : value.ref}, value.enabled ? 'disabled' : null)}}
 		{{:helper.link("OFF", null, {'PC_disable_component' : value.ref}, value.enabled ? null : 'disabled')}}
-	</div>			
+	</div>
 	{{/if}}
 	<br><br>
 {{/for}}
 	<h3>Auto-Updater</h3>
 	<i>Automatically downloads and installs critical OS upgrades if network is reachable. Disabling voids warranty.</i><br>
 	<div class="itemLabel">
-		State: 
+		State:
 	</div>
 	<div class="itemContent">
 		{{:data.receives_updates ? "Enabled" : "Disabled"}}
-	</div>	
+	</div>
 	<div class="itemLabel">
-		Toggle Updates: 
+		Toggle Updates:
 	</div>
 	<div class="itemContent">
 		{{:helper.link("ON", null, {'PC_enable_update' : 1}, data.receives_updates ? 'disabled' : null)}}
@@ -126,4 +126,4 @@
 	</div>
 	<br><br>
 <hr><hr>
-<i>GOOSE v2.0.4b</i>
+<i>{{:data.os_full_name}}</i>


### PR DESCRIPTION
## Description of changes
Some various fixes to OS and modular computer assembly stuff.
- The fullhouse hard drive (starts preloaded with all downloadable programs) respects `TYPE_IS_ABSTRACT`.
- Fixes a potential infinite loop in programs that minimize themselves on startup.
- OS name is specified on the OS datum via `os_name` and `os_full_name`. Cases where the OS datum is null will no longer refer to an OS name at all.
- Fixes indentation in computer_file.dm while I'm at it.

## Why and what will this PR improve
Fixes for some issues encountered downstream.