### PR TITLE
Terminal script runner

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/file_manager.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/file_manager.dm
@@ -14,7 +14,7 @@
 	var/error
 	var/list/disks = list() // List of list(/datum/file_storage, weakref(directory file)).
 	var/current_index
-	
+
 	var/datum/file_transfer/current_transfer	//ongoing file transfer between file_storage datums
 
 /datum/computer_file/program/filemanager/on_shutdown()
@@ -70,7 +70,7 @@
 		if(!avail_disk.hidden && avail_disk.check_access(accesses))
 			computer.unmount_storage(root_name)
 			return TOPIC_REFRESH
-		
+
 		to_chat(user, SPAN_WARNING("You lack permission to unmount this network drive!"))
 		return TOPIC_HANDLED
 
@@ -81,15 +81,15 @@
 			return TOPIC_REFRESH
 		current_index = disk_index
 		return TOPIC_REFRESH
-	
+
 	if(!current_index || current_index > disks.len)
 		current_index = 0
 		return TOPIC_REFRESH
-	
+
 	var/datum/file_storage/current_disk = disks[current_index]?[1]
 	if(!current_disk)
 		return TOPIC_HANDLED
-	
+
 	if(href_list["PRG_exit_disk"])
 		if(!current_index)
 			return TOPIC_HANDLED
@@ -132,7 +132,7 @@
 			else
 				to_chat(user, SPAN_WARNING("You do not have permission to read this file."))
 				return TOPIC_HANDLED
-			
+
 		if(istype(F, /datum/computer_file/data))
 			if(F.get_file_perms(accesses, user) & OS_READ_ACCESS)
 				open_file = href_list["PRG_openfile"]
@@ -165,7 +165,7 @@
 				else
 					to_chat(user, SPAN_WARNING("Unable to create new file. The hard drive may be non-functional."))
 					return TOPIC_REFRESH
-	
+
 	if(href_list["PRG_newdir"])
 		. = TOPIC_REFRESH
 		var/newname = sanitize_for_file(input(usr, "Enter directory name or leave blank to cancel:", "New directory"))
@@ -183,7 +183,7 @@
 				else
 					to_chat(user, SPAN_WARNING("Unable to create new directory. The hard drive may be non-functional."))
 					return TOPIC_REFRESH
-	
+
 	if(href_list["PRG_deletefile"])
 		var/datum/computer_file/del_file = current_disk.get_file(href_list["PRG_deletefile"], current_directory, accesses, user)
 		var/deleted = current_disk.delete_file(del_file, accesses, user)
@@ -288,7 +288,7 @@
 			error = "I/O ERROR: Unable to transfer file."
 			return
 
-		var/copying = alert(usr, "Would you like to copy the file or transfer it? Transfering files requires write access.", "Copying file", "Copy", "Transfer")		
+		var/copying = alert(usr, "Would you like to copy the file or transfer it? Transfering files requires write access.", "Copying file", "Copy", "Transfer")
 		var/list/choices = list()
 		var/list/curr_fs_list = disks[current_index]
 		for(var/list/fs_list in disks)
@@ -299,9 +299,9 @@
 			var/datum/file_storage/FS = fs_list[1]
 			var/weakref/FS_dir_ref = fs_list[2]
 
-			var/datum/computer_file/directory/FS_dir = FS_dir_ref?.resolve() 
+			var/datum/computer_file/directory/FS_dir = FS_dir_ref?.resolve()
 			choices[FS.get_dir_path(FS_dir, TRUE)] = fs_list
-	
+
 		if(!length(choices))
 			to_chat(usr, SPAN_WARNING("You must open another disk to transfer files."))
 			return TOPIC_HANDLED
@@ -314,9 +314,9 @@
 			if(nope)
 				to_chat(user, SPAN_WARNING("Cannot transfer file to [dst] for following reason: [nope]"))
 				return
-			
+
 			var/weakref/dst_dir_ref = chosen_list[2]
-			var/datum/computer_file/directory/dst_dir = dst_dir_ref?.resolve() 
+			var/datum/computer_file/directory/dst_dir = dst_dir_ref?.resolve()
 
 			var/error = check_file_transfer(dst_dir, F, copying == "Copy", accesses, user)
 			if(error)
@@ -324,6 +324,20 @@
 				return TOPIC_HANDLED
 			current_transfer = new(current_disk, dst, dst_dir, F, copying == "Copy" ? TRUE : FALSE)
 			ui_header = "downloader_running.gif"
+
+	if(href_list["PRG_runfile"])
+		. = TOPIC_HANDLED
+		if(!open_file)
+			return
+		var/datum/computer_file/program/P = current_disk.get_file(open_file, current_directory)
+		if(istype(P))
+			computer.run_program(P.filename)
+			return TOPIC_HANDLED
+		var/datum/computer_file/data/F = current_disk.get_file(open_file, current_directory)
+		if(!F || !istype(F))
+			return
+		computer.run_script(usr, F)
+		return TOPIC_HANDLED
 
 /datum/computer_file/program/filemanager/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = global.default_topic_state)
 	. = ..()
@@ -368,12 +382,12 @@
 
 			ui_disks.Add(list(list(
 				"name" = ui_disk.get_dir_path(ui_directory),
-				"index" = disk_index, 
+				"index" = disk_index,
 				"selected" = disk_index == current_index
 			)))
 			disk_index++
 		data["disks"] = ui_disks
-		
+
 		if(current_disk)
 			data["up_directory"] = !!current_directory
 			data["current_disk"] = current_disk.get_dir_path(current_directory, TRUE)
@@ -392,7 +406,7 @@
 					files.Add(list(list(
 						"name" = F.filename,
 						"type" = F.filetype,
-						"dir" = istype(F, /datum/computer_file/directory), 
+						"dir" = istype(F, /datum/computer_file/directory),
 						"size" = F.size,
 						"undeletable" = F.undeletable,
 						"unrenamable" = F.unrenamable,
@@ -401,7 +415,7 @@
 				data["files"] = files
 		else // No disk selected, option to create a new one.
 			var/list/avail_disks[0]
-			
+
 			for(var/root_name in computer.mounted_storage)
 				var/datum/file_storage/avail_disk = computer.mounted_storage[root_name]
 				if(!avail_disk.hidden && avail_disk.check_access(accesses))
@@ -448,5 +462,5 @@
 		if(disk == removed)
 			if(current_disk_list == disk_list)
 				current_index = null
-			
+
 			disks -= list(disk_list)

--- a/code/modules/modular_computers/os/_os.dm
+++ b/code/modules/modular_computers/os/_os.dm
@@ -310,3 +310,19 @@
 	var/datum/computer_file/program/email_client/e_client = locate() in running_programs
 	if(e_client)
 		e_client.mail_received(received)
+
+/datum/extension/interactive/os/proc/run_script(mob/user, var/datum/computer_file/data/script)
+	open_terminal(user)
+	var/datum/terminal/T = has_terminal(user)
+	if(!istype(T))
+		return  TOPIC_HANDLED
+
+	T.show_terminal(user)
+	T.append_to_history(">Running '[script.filename].[script.filetype]'")
+	var/list/lines = splittext(script.stored_data, "\[br\]")
+	for(var/line in lines)
+		var/output = T.parse(line, user)
+		if(QDELETED(T)) // Check for exit.
+			return TOPIC_HANDLED
+		T.append_to_history(output)
+		CHECK_TICK

--- a/nano/templates/file_manager.tmpl
+++ b/nano/templates/file_manager.tmpl
@@ -23,6 +23,7 @@
 		{{:helper.link('CLOSE', null, { "PRG_closefile" : 1 })}}
 		{{:helper.link('EDIT', null, { "PRG_edit" : 1 })}}
 		{{:helper.link('PRINT', null, { "PRG_printfile" : 1 })}}
+		{{:helper.link('RUN', null, { "PRG_runfile" : 1 })}}
 		</div><hr>
 		{{:data.filedata}}
 	{{else}}


### PR DESCRIPTION
Adds a button to file browser to run text file as a script in terminal Just feeds it line by line to a terminal, no loops or logic

<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Adds RUN button to file viewer that starts a terminal and feeds contents of file to it line by line
Effectively very dumb scripting engine, no loops or conditions or variables, but still handy if you want to open and bolt 4 doors in timely manner.

## Why and what will this PR improve
Fun things with network commands like door manipulations would be way more useful if done faster instead of typing commands manually every time.

## Authorship
<!-- Describe original authors of changes to credit them. -->
Me

## Changelog
:cl:
add: Terminal scripts. Write a file, put a terminal command on each line, and press RUN when viewing it in file editor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->