### PR TITLE
Adds remote commands to security cameras

### DIFF
--- a/code/game/machinery/camera/_camera_device.dm
+++ b/code/game/machinery/camera/_camera_device.dm
@@ -10,6 +10,7 @@
 	var/view_range = 7
 
 	var/xray_enabled = FALSE
+	has_commands = TRUE
 
 /datum/extension/network_device/camera/New(datum/holder, n_id, n_key, c_type, autojoin, list/preset_channels, camera_name, camnet_enabled = TRUE, req_connection = TRUE)
 	if(length(preset_channels))
@@ -100,7 +101,7 @@
 		added_channels = list(added_channels)
 	added_channels -= channels
 	channels += added_channels
-	var/datum/computer_network/net = get_network()	
+	var/datum/computer_network/net = get_network()
 	if(net)
 		net.add_camera_to_channels(src, added_channels)
 	camera_repository.add_camera_to_channels(src, added_channels)
@@ -110,7 +111,7 @@
 		removed_channels = list(removed_channels)
 	removed_channels &= channels
 	channels -= removed_channels
-	var/datum/computer_network/net = get_network()	
+	var/datum/computer_network/net = get_network()
 	if(net)
 		net.remove_camera_from_channels(src, removed_channels)
 	camera_repository.remove_camera_from_channels(src, removed_channels)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -250,7 +250,7 @@
 				add_hiddenprint(user)
 			else
 				visible_message(SPAN_NOTICE("\The [src] clicks and reactivates itself."))
-			playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
+			playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 			icon_state = initial(icon_state)
 			add_hiddenprint(user)
 		else
@@ -259,7 +259,7 @@
 				add_hiddenprint(user)
 			else
 				visible_message(SPAN_NOTICE("\The [src] clicks and shuts down."))
-			playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
+			playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 			icon_state = "[initial(icon_state)]1"
 		update_coverage()
 
@@ -343,3 +343,51 @@
 
 /decl/stock_part_preset/network_lock/camera/do_apply(obj/machinery/camera/machine, obj/item/stock_parts/network_receiver/network_lock/part)
 	part.auto_deny_all = TRUE
+
+/obj/machinery/camera
+	public_methods = list(
+		/decl/public_access/public_method/toggle_camera
+	)
+
+	public_variables = list(
+		/decl/public_access/public_variable/camera_state,
+		/decl/public_access/public_variable/camera_name,
+		/decl/public_access/public_variable/camera_channels
+	)
+
+/obj/machinery/camera/proc/toggle_status()
+	set_status(!status)
+
+/decl/public_access/public_method/toggle_camera
+	name = "toggle camera"
+	desc = "Toggles camera on or off."
+	call_proc = /obj/machinery/camera/proc/toggle_status
+
+/decl/public_access/public_variable/camera_state
+	expected_type = /obj/machinery/camera
+	name = "camera status"
+	desc = "Status of the camera."
+	can_write = FALSE
+
+/decl/public_access/public_variable/camera_state/access_var(obj/machinery/camera/C)
+	return C.status ? "enabled" : "disabled"
+
+/decl/public_access/public_variable/camera_name
+	expected_type = /obj/machinery/camera
+	name = "camera name"
+	desc = "Displayed name of the camera."
+	can_write = FALSE
+
+/decl/public_access/public_variable/camera_name/access_var(obj/machinery/camera/C)
+	var/datum/extension/network_device/camera/camera_device = get_extension(C, /datum/extension/network_device/)
+	return camera_device?.display_name
+
+/decl/public_access/public_variable/camera_channels
+	expected_type = /obj/machinery/camera
+	name = "camera channels"
+	desc = "List of the channels this camera broadcasts on."
+	can_write = FALSE
+
+/decl/public_access/public_variable/camera_channels/access_var(obj/machinery/camera/C)
+	var/datum/extension/network_device/camera/camera_device = get_extension(C, /datum/extension/network_device/)
+	return english_list(camera_device?.channels)

--- a/code/modules/modular_computers/networking/device_types/_network_device.dm
+++ b/code/modules/modular_computers/networking/device_types/_network_device.dm
@@ -292,7 +292,7 @@
 		return src
 	if(device_methods && (public_thing.type in device_methods))
 		return src
-	if((public_thing.type in get_holder_variables()) || (public_thing in get_holder_methods()))
+	if((public_thing.type in get_holder_variables()) || (public_thing.type in get_holder_methods()))
 		return holder
 
 // Return the public methods and variables available for commands.


### PR DESCRIPTION


## Description of changes
Can toggle it remotely now, and check name/channels

## Why and what will this PR improve
More uses for network hijinks, disabling cameras remotely

## Authorship
Me

## Changelog
:cl:
add: Security cameras can now be toggled with terminal commands over network
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->