### PR TITLE
Fix ugly black bar on NanoUI windows

### DIFF
--- a/nano/css/tgui.css
+++ b/nano/css/tgui.css
@@ -6,7 +6,6 @@ div.display {
     -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#54000000,endColorStr=#54000000)";
     filter: progid:DXImageTransform.Microsoft.gradient(startColorStr=#54000000,endColorStr=#54000000);
     background-color: rgba(0,0,0,.33);
-    box-shadow: inset 0 0 5px rgba(0,0,0,.5);
 }
 
 div.display header {


### PR DESCRIPTION
## Description of changes
Currently NanoUI has an ugly black bar on some windows. This is because of some not great looking drop shadows that are supposed to add a soft black border inside the window, but the element it's applied to doesn't always take up the same size as the window. Rather than moving it to the html element or what have you, I just decided to remove it entirely since it's hardly noticeable.

## Why and what will this PR improve
Removes a really bad-looking black bar from some NanoUI screens.