### PR TITLE
Add HideAltAppearance functions and clean up appearance manager code

### DIFF
--- a/code/datums/appearances/appearance_manager.dm
+++ b/code/datums/appearances/appearance_manager.dm
@@ -1,10 +1,6 @@
 /decl/appearance_manager
 	var/list/appearances_ = list()
 
-/decl/appearance_manager/proc/get_appearance_handler(var/handler_type)
-	var/list/appearance_handlers = decls_repository.get_decls_of_subtype(/decl/appearance_handler)
-	return appearance_handlers[handler_type]
-
 /decl/appearance_manager/proc/add_appearance(var/mob/viewer, var/datum/appearance_data/ad)
 	var/datum/priority_queue/pq = appearances_[viewer]
 	if(!pq)

--- a/code/datums/appearances/automatic/_base.dm
+++ b/code/datums/appearances/automatic/_base.dm
@@ -23,3 +23,12 @@
 /decl/appearance_handler/proc/DisplayAllAltAppearancesTo(var/viewer)
 	for(var/entry in appearance_sources)
 		DisplayAltAppearanceTo(entry, viewer)
+
+/decl/appearance_handler/proc/HideAltAppearanceFrom(source, viewer)
+	var/datum/appearance_data/ad = appearance_sources[source]
+	if(ad)
+		ad.RemoveViewer(viewer)
+
+/decl/appearance_handler/proc/HideAllAltAppearancesFrom(viewer)
+	for(var/entry in appearance_sources)
+		HideAltAppearanceFrom(entry, viewer)

--- a/code/datums/extensions/appearance/appearance.dm
+++ b/code/datums/extensions/appearance/appearance.dm
@@ -7,8 +7,7 @@
 	var/item_removal_proc
 
 /datum/extension/appearance/New(var/holder)
-	var/decl/appearance_manager/appearance_manager = GET_DECL(/decl/appearance_manager)
-	var/appearance_handler = appearance_manager.get_appearance_handler(appearance_handler_type)
+	var/decl/appearance_handler/appearance_handler = GET_DECL(appearance_handler_type)
 	if(!appearance_handler)
 		CRASH("Unable to acquire the [appearance_handler_type] appearance handler.")
 
@@ -17,8 +16,7 @@
 	..()
 
 /datum/extension/appearance/Destroy()
-	var/decl/appearance_manager/appearance_manager = GET_DECL(/decl/appearance_manager)
-	var/appearance_handler = appearance_manager.get_appearance_handler(appearance_handler_type)
+	var/decl/appearance_handler/appearance_handler = GET_DECL(appearance_handler_type)
 	events_repository.unregister(/decl/observ/item_equipped, holder, appearance_handler, item_equipment_proc)
 	events_repository.unregister(/decl/observ/item_unequipped, holder, appearance_handler, item_removal_proc)
 	. = ..()


### PR DESCRIPTION
## Description of changes
- Removes `appearance_manager.get_appearance_handler` since it's now just plain overengineered. It was replaced with just `GET_DECL(handler_type)`.
- Adds `HideAltAppearanceFrom` and `HideAllAltAppearancesFrom` to appearance handlers as a corollary to `DisplayAltAppearanceTo` and `DisplayAllAltAppearancesTo`. This is distinct from `RemoveAltAppearance` which removes an appearance entirely, instead of just hiding it from one specific viewer.

## Why and what will this PR improve
Expands the alt appearance system slightly and cleans it up.