### PR TITLE
File system fixes and additions

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/file_manager.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/file_manager.dm
@@ -1,3 +1,9 @@
+#define FM_NONE 0
+#define FM_READ 1
+#define FM_PERM 2
+
+#define MAX_FILE_PATTERNS 5
+
 /datum/computer_file/program/filemanager
 	filename = "filemanager"
 	filedesc = "OS File Manager"
@@ -10,12 +16,28 @@
 	undeletable = 1
 	usage_flags = PROGRAM_ALL
 	category = PROG_UTIL
+
 	var/open_file
-	var/error
+	var/file_mode = FM_NONE
+	var/error // Generic error, wiped on any action
+
+	var/file_error // File error, closes open_file once cleared
+	var/disk_error // Disk error, removes current disk once cleared
+
 	var/list/disks = list() // List of list(/datum/file_storage, weakref(directory file)).
 	var/current_index
 
 	var/datum/file_transfer/current_transfer	//ongoing file transfer between file_storage datums
+
+	// Variables for modifying file perms
+	var/list/f_read_access = list()
+	var/list/f_write_access = list()
+	var/list/f_mod_access = list()
+
+	var/current_perm = OS_READ_ACCESS
+
+	var/selected_pattern // Index of the current pattern being accessed.
+	var/selected_parent_group
 
 /datum/computer_file/program/filemanager/on_shutdown()
 	disks.Cut()
@@ -23,6 +45,14 @@
 	current_index = null
 	if(current_transfer)
 		qdel(current_transfer)
+
+	error = null
+	file_error = null
+	disk_error = null
+	open_file = null
+	file_mode = FM_NONE
+	reset_perm_mod()
+
 	return ..()
 
 /datum/computer_file/program/filemanager/Topic(href, href_list, state)
@@ -32,6 +62,20 @@
 
 	var/mob/user = usr
 	var/list/accesses = computer.get_access(user)
+
+	error = null
+	if(file_error)
+		file_error = null
+		open_file = null
+		file_mode = FM_NONE
+
+	if(disk_error)
+		disk_error = null
+		disks -= list(disks[current_index])
+		current_index = null
+
+	if(href_list["PRG_clear_error"])
+		return TOPIC_REFRESH
 
 	if(href_list["PRG_select_disk"])
 		var/disk_name = href_list["PRG_select_disk"]
@@ -55,35 +99,70 @@
 		var/fileserver_tag = input(user, "Choose a mainframe you would like to mount as a disk:", "Mainframe Mount") as null|anything in available_mainframes
 		if(!fileserver_tag)
 			return TOPIC_HANDLED
-		var/root_name = sanitize(input(user, "Enter the name of the root directory for the newly mounted disk.", "Root directory") as null|text)
+		var/root_name = sanitize_for_file(input(user, "Enter the name of the root directory for the newly mounted disk.", "Root directory") as null|text)
 		if(!root_name)
 			return TOPIC_HANDLED
 		var/feedback = computer.mount_mainframe(root_name, fileserver_tag)
 		to_chat(user, SPAN_NOTICE(feedback))
 		return TOPIC_REFRESH
 
-	if(href_list["PRG_unmount_network"])
-		var/root_name = href_list["PRG_unmount_network"]
+	if(href_list["PRG_mount_settings"])
+		var/root_name = href_list["PRG_mount_settings"]
 		var/datum/file_storage/network/avail_disk = computer.mounted_storage[root_name]
 		if(!istype(avail_disk))
 			return TOPIC_REFRESH
-		if(!avail_disk.hidden && avail_disk.check_access(accesses))
-			computer.unmount_storage(root_name)
-			return TOPIC_REFRESH
+		if(avail_disk.hidden || !avail_disk.check_access(accesses))
+			to_chat(user, SPAN_WARNING("You don't have permission to modify this network drive!"))
+			return TOPIC_HANDLED
 
-		to_chat(user, SPAN_WARNING("You lack permission to unmount this network drive!"))
-		return TOPIC_HANDLED
+		var/datum/computer_file/data/automount_file = get_file("automount", "local")
+		var/automount_str = "[root_name]|[avail_disk.server];"
+
+		var/automounted = istype(automount_file) ? findtext(automount_file.stored_data, automount_str) : FALSE
+
+		var/prompt = alert(user, "What would you like to do?", "Mount settings", "Cancel", "Unmount", automounted ? "Disable auto mount" : "Enable auto mount")
+
+		if(!CanInteract(user, state))
+			return TOPIC_HANDLED
+
+		switch(prompt)
+			if("Unmount")
+				computer.unmount_storage(root_name)
+				to_chat(user, SPAN_NOTICE("Unmounted the network drive [root_name]."))
+				return TOPIC_REFRESH
+			if("Disable auto mount")
+				if(!automounted || !istype(automount_file))
+					return TOPIC_REFRESH
+
+				// Remove the auto mount string
+				automount_file.stored_data = replacetextEx(automount_file.stored_data, automount_str, "")
+				to_chat(user, SPAN_NOTICE("The network drive [root_name] will no longer auto mount on startup."))
+				return TOPIC_REFRESH
+
+			if("Enable auto mount")
+				if(automounted)
+					return TOPIC_REFRESH
+
+				if(!istype(automount_file))
+					// Create the automount file.
+					automount_file = create_file("automount", "local", file_type = /datum/computer_file/data)
+					if(!istype(automount_file))
+						return TOPIC_REFRESH
+
+				automount_file.stored_data += automount_str
+				to_chat(user, SPAN_NOTICE("The network drive [root_name] will now auto mount on startup."))
+				return TOPIC_REFRESH
 
 	if(href_list["PRG_change_disk"])
 		var/disk_index = text2num(href_list["PRG_change_disk"])
 		if(disk_index == 0 || disk_index > disks.len)
-			current_index = 0
+			current_index = null
 			return TOPIC_REFRESH
 		current_index = disk_index
 		return TOPIC_REFRESH
 
 	if(!current_index || current_index > disks.len)
-		current_index = 0
+		current_index = null
 		return TOPIC_REFRESH
 
 	var/datum/file_storage/current_disk = disks[current_index]?[1]
@@ -97,10 +176,9 @@
 		current_index--
 		return TOPIC_REFRESH
 
-	var/errors = current_disk.check_errors()
-	if(errors)
-		error = errors
-		return TOPIC_REFRESH
+	var/disk_errors = current_disk.check_errors()
+	if(disk_errors)
+		return TOPIC_REFRESH // ui_interact refreshs the disk errors anyway.
 
 	var/weakref/dir_ref = disks[current_index][2]
 	var/datum/computer_file/directory/current_directory
@@ -130,19 +208,35 @@
 				disks[current_index][2] = weakref(F)
 				return TOPIC_REFRESH
 			else
-				to_chat(user, SPAN_WARNING("You do not have permission to read this file."))
+				to_chat(user, SPAN_WARNING("You do not have permission to open this directory."))
 				return TOPIC_HANDLED
 
 		if(istype(F, /datum/computer_file/data))
 			if(F.get_file_perms(accesses, user) & OS_READ_ACCESS)
 				open_file = href_list["PRG_openfile"]
+				file_mode = FM_READ
 				return TOPIC_REFRESH
 			else
-				to_chat(user, SPAN_WARNING("You do not have permission to open this directory."))
+				to_chat(user, SPAN_WARNING("You do not have permission to open this file."))
 				return TOPIC_HANDLED
 
 		to_chat(user, SPAN_WARNING("This file is not in a readable format."))
 		return TOPIC_HANDLED
+
+	if(href_list["PRG_modifyperms"])
+		var/datum/computer_file/mod_file = current_disk.get_file(href_list["PRG_modifyperms"], current_directory, accesses, user)
+		if(!(mod_file?.get_file_perms(accesses, user) & OS_MOD_ACCESS))
+			to_chat(user, SPAN_WARNING("You lack access to modify the permissions of '[mod_file.filename].[mod_file.filetype]'."))
+			return TOPIC_HANDLED
+
+		open_file = href_list["PRG_modifyperms"]
+		file_mode = FM_PERM
+
+		f_read_access = LAZYLEN(mod_file.read_access) ? mod_file.read_access.Copy() : list()
+		f_write_access = LAZYLEN(mod_file.write_access) ? mod_file.write_access.Copy() : list()
+		f_mod_access = LAZYLEN(mod_file.mod_access) ? mod_file.mod_access.Copy() : list()
+
+		return TOPIC_REFRESH
 
 	if(href_list["PRG_newtextfile"])
 		. = TOPIC_REFRESH
@@ -203,7 +297,10 @@
 	if(href_list["PRG_closefile"])
 		. = TOPIC_REFRESH
 		open_file = null
-		error = null
+		if(file_mode == FM_PERM)
+			reset_perm_mod()
+		file_mode = FM_NONE
+		file_error = null
 
 	if(href_list["PRG_clone"])
 		var/cloned = current_disk.clone_file(href_list["PRG_clone"], current_directory, accesses, user)
@@ -243,7 +340,7 @@
 
 	if(href_list["PRG_edit"])
 		. = TOPIC_HANDLED
-		if(!open_file)
+		if(!open_file || file_mode != FM_READ)
 			return
 		var/datum/computer_file/data/F = current_disk.get_file(open_file, current_directory)
 		if(!F || !istype(F))
@@ -251,10 +348,10 @@
 		if(F.do_not_edit && (alert("WARNING: This file is not compatible with editor. Editing it may result in permanently corrupted formatting or damaged data consistency. Edit anyway?", "Incompatible File", "No", "Yes") == "No"))
 			return
 		if(F.read_only)
-			error = "This file is read only. You cannot edit it."
+			file_error = "This file is read only. You cannot edit it."
 			return
 		if(!(F.get_file_perms(accesses, user) & OS_WRITE_ACCESS))
-			error = "You do not have write access to this file."
+			file_error = "You do not have write access to this file."
 			return
 		var/oldtext = html_decode(F.stored_data)
 		oldtext = replacetext(oldtext, "\[br\]", "\n")
@@ -269,16 +366,16 @@
 
 	if(href_list["PRG_printfile"])
 		. = 1
-		if(!open_file)
+		if(!open_file || file_mode != FM_READ)
 			return
 		var/datum/computer_file/data/F = current_disk.get_file(open_file, current_directory)
 		if(!F || !istype(F))
 			return
 		if(!(F.get_file_perms(accesses, user) & OS_READ_ACCESS))
-			error = "You do not have read access to this file."
+			file_error = "You do not have read access to this file."
 			return
 		if(!computer.print_paper(digitalPencode2html(F.stored_data), F.filename))
-			error = "Hardware error: Unable to print the file."
+			file_error = "Hardware error: Unable to print the file."
 			return TOPIC_REFRESH
 
 	if(href_list["PRG_stoptransfer"])
@@ -290,7 +387,7 @@
 		. = TOPIC_REFRESH
 		var/datum/computer_file/F = current_disk.get_file(href_list["PRG_transferto"], current_directory)
 		if(!F || !istype(F) || F.unsendable)
-			error = "I/O ERROR: Unable to transfer file."
+			to_chat(user, SPAN_WARNING("I/O ERROR: Unable to transfer file."))
 			return
 
 		var/copying = alert(usr, "Would you like to copy the file or transfer it? Transfering files requires write access.", "Copying file", "Copy", "Transfer")
@@ -325,7 +422,7 @@
 
 			var/error = check_file_transfer(dst_dir, F, copying == "Copy", accesses, user)
 			if(error)
-				to_chat(user, SPAN_WARNING("Cannot transfer file. [error]."))
+				to_chat(user, SPAN_WARNING("Cannot transfer file: [error]."))
 				return TOPIC_HANDLED
 			current_transfer = new(current_disk, dst, dst_dir, F, copying == "Copy" ? TRUE : FALSE)
 			ui_header = "downloader_running.gif"
@@ -344,6 +441,130 @@
 		computer.run_script(usr, F)
 		return TOPIC_HANDLED
 
+	// Permission modifying.
+	if(file_mode == FM_PERM)
+		if(!open_file)
+			file_mode = FM_NONE
+			return TOPIC_REFRESH
+
+		var/datum/computer_network/network = computer.get_network()
+		var/datum/extension/network_device/acl/access_controller = network?.access_controller
+		if(!access_controller)
+			file_error = "No access controller was found on the network."
+			return TOPIC_REFRESH
+
+		var/datum/computer_file/F = current_disk.get_file(open_file, current_directory)
+		if(!F || !istype(F))
+			file_error = "Unable to open file"
+			return TOPIC_REFRESH
+		if(!(F.get_file_perms(accesses, user) & OS_MOD_ACCESS))
+			file_error = "You do not have access to modify this file's permissions."
+			return TOPIC_REFRESH
+
+		if(href_list["PRG_change_perm"])
+			switch(href_list["PRG_change_perm"])
+				if("read")
+					current_perm = OS_READ_ACCESS
+				if("write")
+					current_perm = OS_WRITE_ACCESS
+				if("mod")
+					current_perm = OS_MOD_ACCESS
+
+			selected_pattern = null
+			return TOPIC_REFRESH
+
+		var/list/current_perm_list
+		switch(current_perm)
+			if(OS_READ_ACCESS)
+				current_perm_list = f_read_access
+			if(OS_WRITE_ACCESS)
+				current_perm_list = f_write_access
+			if(OS_MOD_ACCESS)
+				current_perm_list = f_mod_access
+
+		if(href_list["PRG_add_pattern"])
+			if(length(current_perm_list) >= MAX_FILE_PATTERNS)
+				to_chat(usr, SPAN_WARNING("You cannot add more than [MAX_FILE_PATTERNS] patterns to a file's permissions."))
+				return TOPIC_HANDLED
+			current_perm_list += list(list()) // Add a plank pattern to the access list.
+			return TOPIC_REFRESH
+
+		if(href_list["PRG_remove_pattern"])
+			var/pattern_index = text2num(href_list["PRG_remove_pattern"])
+			if(pattern_index == 0 || pattern_index > length(current_perm_list))
+				return TOPIC_HANDLED
+			current_perm_list -= list(current_perm_list[pattern_index]) // We have to encapsulate the pattern in another list to actually delete it.
+			if(selected_pattern == pattern_index)
+				selected_pattern = null
+			else if(selected_pattern > pattern_index)
+				selected_pattern--
+			return TOPIC_REFRESH
+
+		if(href_list["PRG_select_pattern"])
+			var/pattern_index = text2num(href_list["PRG_select_pattern"])
+			if(pattern_index > length(current_perm_list))
+				return TOPIC_HANDLED
+			selected_pattern = pattern_index
+			return TOPIC_REFRESH
+
+		if(href_list["PRG_select_parent_group"])
+			// The parent group actually existing is verified in ui_interact()
+			selected_parent_group = href_list["PRG_select_parent_group"]
+			return TOPIC_REFRESH
+
+		if(selected_pattern > length(current_perm_list))
+			selected_pattern = null
+			return TOPIC_REFRESH
+
+		var/list/pattern_list = current_perm_list[selected_pattern]
+
+		if(href_list["PRG_assign_group"])
+			var/group = href_list["PRG_assign_group"]
+			if(!(group in access_controller.all_groups))
+				return TOPIC_REFRESH
+			if(!pattern_list)
+				to_chat(user, SPAN_WARNING("Select a pattern first!"))
+				return TOPIC_HANDLED
+			pattern_list |= href_list["PRG_assign_group"] + ".[network.network_id]"
+			return TOPIC_REFRESH
+
+		if(href_list["PRG_remove_group"])
+			if(!pattern_list)
+				to_chat(user, SPAN_WARNING("Select a pattern first!"))
+				return TOPIC_HANDLED
+			pattern_list -= href_list["PRG_remove_group"] + ".[network.network_id]"
+			return TOPIC_REFRESH
+
+		if(href_list["PRG_apply_perms"])
+			if(!has_access(f_mod_access, accesses))
+				var/confirm = alert(user, "You will no longer be able to modify the permissions of this file. Are you sure?", "Permission Modification", "No", "Yes")
+				if(!CanInteract(user, state) || confirm != "Yes")
+					return TOPIC_HANDLED
+
+			F.read_access = f_read_access.Copy()
+			F.write_access = f_write_access.Copy()
+			F.mod_access = f_mod_access.Copy()
+
+			UNSETEMPTY(F.read_access)
+			UNSETEMPTY(F.write_access)
+			UNSETEMPTY(F.mod_access)
+
+			to_chat(user, SPAN_NOTICE("Successfully changed permissions for '[F.filename].[F.filetype]'."))
+			open_file = null
+			file_mode = FM_NONE
+
+			reset_perm_mod()
+			return TOPIC_REFRESH
+
+/datum/computer_file/program/filemanager/proc/reset_perm_mod()
+	f_read_access.Cut()
+	f_write_access.Cut()
+	f_mod_access.Cut()
+	current_perm = OS_READ_ACCESS
+
+	selected_pattern = null
+	selected_parent_group = null
+
 /datum/computer_file/program/filemanager/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = global.default_topic_state)
 	. = ..()
 	if(!.)
@@ -352,7 +573,7 @@
 	var/list/accesses = computer.get_access(user)
 
 	if(current_index > disks.len) // Safety check.
-		current_index = 0
+		current_index = null
 
 	var/datum/file_storage/current_disk
 	var/datum/computer_file/directory/current_directory
@@ -367,12 +588,12 @@
 		else
 			current_disk_list[2] = null
 
-	if(error)
-		data["error"] = error
-	else if(current_disk)
-		data["error"] = current_disk.check_errors()
+	// Disk errors can occur without user error, so check them when the UI refreshes.
+	if(current_disk)
+		disk_error = current_disk.check_errors()
+		data["disk_error"] = disk_error
 
-	if(!data["error"])
+	if(!disk_error)
 		var/list/ui_disks[0]
 		var/disk_index = 1
 		for(var/list/ui_disk_list in disks)
@@ -392,19 +613,26 @@
 			)))
 			disk_index++
 		data["disks"] = ui_disks
-
+		data["file_mode"] = file_mode
 		if(current_disk)
 			data["up_directory"] = !!current_directory
 			data["current_disk"] = current_disk.get_dir_path(current_directory, TRUE)
 
 			if(open_file)
-				var/datum/computer_file/data/F
+				var/datum/computer_file/F
 				F = current_disk.get_file(open_file, current_directory)
 				if(!istype(F))
-					data["error"] = "I/O ERROR: Unable to open file."
+					file_error = "I/O ERROR: Unable to open file."
 				else
-					data["filedata"] = F.generate_file_data(user)
 					data["filename"] = "[F.filename].[F.filetype]"
+					if(file_mode == FM_READ)
+						var/datum/computer_file/data/data_file = F
+						if(!istype(data_file))
+							file_error = "I/O ERROR: Unable to open file."
+						else
+							data["filedata"] = data_file.generate_file_data(user)
+					if(file_mode == FM_PERM)
+						data |= permmod_data()
 			else
 				var/list/files[0]
 				for(var/datum/computer_file/F in current_disk.get_dir_files(current_directory))
@@ -423,6 +651,7 @@
 
 			for(var/root_name in computer.mounted_storage)
 				var/datum/file_storage/avail_disk = computer.mounted_storage[root_name]
+
 				if(!avail_disk.hidden && avail_disk.check_access(accesses))
 					avail_disks.Add(list(list(
 						"name" = root_name,
@@ -435,6 +664,9 @@
 		if(current_transfer && current_transfer.get_eta() > 2)
 			data |= current_transfer.get_ui_data()
 
+	if(file_error)
+		data["file_error"] = file_error
+
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "file_manager.tmpl", "OS File Manager", 900, 700, state = state)
@@ -442,6 +674,71 @@
 		ui.set_initial_data(data)
 		ui.set_auto_update(1)
 		ui.open()
+
+/datum/computer_file/program/filemanager/proc/permmod_data()
+	var/data = list()
+
+	var/list/current_perm_list // Whatever permissions list we're currently modifying
+
+	var/datum/computer_network/network = computer.get_network()
+	var/datum/extension/network_device/acl/access_controller = network?.access_controller
+	if(!access_controller)
+		file_error = "No access controller was found on the network."
+		return data
+
+	switch(current_perm)
+		if(OS_READ_ACCESS)
+			current_perm_list = f_read_access
+			data["current_perm"] = "read"
+		if(OS_WRITE_ACCESS)
+			current_perm_list = f_write_access
+			data["current_perm"] = "write"
+		if(OS_MOD_ACCESS)
+			current_perm_list = f_mod_access
+			data["current_perm"] = "mod"
+
+	var/list/patterns = list()
+	var/pattern_index = 0
+	for(var/list/pattern in current_perm_list)
+		pattern_index++
+		patterns.Add(list(list(
+			"index" = "[pattern_index]",
+			"perm_list" = english_list(pattern, "No groups assigned!", and_text = " or ")
+			)))
+
+	data["patterns"] = patterns
+
+	var/list/group_dictionary = access_controller.get_group_dict()
+	var/list/parent_groups_data
+	var/list/child_groups_data
+
+	var/list/pattern = LAZYACCESS(current_perm_list, selected_pattern)
+
+	if(selected_parent_group)
+		if(!(selected_parent_group in group_dictionary))
+			selected_parent_group = null
+		else
+			var/list/child_groups = group_dictionary[selected_parent_group]
+			if(child_groups)
+				child_groups_data = list()
+				for(var/child_group in child_groups)
+					child_groups_data.Add(list(list(
+						"child_group" = child_group,
+						"assigned" = (LAZYISIN(pattern, "[child_group].[network.network_id]"))
+					)))
+	if(!selected_parent_group) // Check again in case we ended up with a non-existent selected parent group instead of breaking the UI.
+		parent_groups_data = list()
+		for(var/parent_group in group_dictionary)
+			parent_groups_data.Add(list(list(
+				"parent_group" = parent_group,
+				"assigned" = (LAZYISIN(pattern,"[parent_group].[network.network_id]"))
+			)))
+	data["parent_groups"] = parent_groups_data
+	data["child_groups"] = child_groups_data
+	data["selected_parent_group"] = selected_parent_group
+	data["selected_pattern"] = "[selected_pattern]"
+
+	return data
 
 /datum/computer_file/program/filemanager/process_tick()
 	if(!current_transfer)
@@ -461,7 +758,7 @@
 		ui_header = null
 
 /datum/computer_file/program/filemanager/on_file_storage_removal(datum/file_storage/removed)
-	var/list/current_disk_list = disks[current_index]
+	var/list/current_disk_list = current_index != null ? disks[current_index] : null
 	for(var/list/disk_list in disks)
 		var/datum/file_storage/disk = disk_list[1]
 		if(disk == removed)
@@ -469,3 +766,8 @@
 				current_index = null
 
 			disks -= list(disk_list)
+
+#undef MAX_FILE_PATTERNS
+#undef FM_NONE
+#undef FM_READ
+#undef FM_PERM

--- a/code/modules/modular_computers/file_system/programs/generic/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntdownloader.dm
@@ -151,7 +151,7 @@
 				// Only those programs our user can run will show in the list
 				if(!P.can_run(get_access(user), user, FALSE) && P.requires_access_to_download)
 					continue
-				if(!P.is_supported_by_hardware(program.computer.get_hardware_flag(), user, TRUE))
+				if(!P.is_supported_by_hardware(program.computer.get_hardware_flag(), user, FALSE))
 					continue
 				category_list.Add(list(list(
 				"filename" = P.filename,

--- a/nano/templates/file_manager.tmpl
+++ b/nano/templates/file_manager.tmpl
@@ -15,18 +15,17 @@
 	<h2>An error has occured:</h2>
 	Additional information: {{:data.error}}<br>
 	<i>Please try again. If the problem persists contact your system administrator for assistance.</i>
-	{{:helper.link('Back to menu', null, { "PRG_exit_disk" : 1 })}}
+	{{:helper.link('Back to menu', null, { "PRG_clear_error" : 1 })}}
+{{else data.file_error}}
+	<h2>An error with the selected file has occured:</h2>
+	Additional information: {{:data.file_error}}<br>
+	{{:helper.link('Back to menu', null, { "PRG_clear_error" : 1 })}}
+{{else data.disk_error}}
+	<h2>An error with the selected disk has occured:</h2>
+	Additional information: {{:data.disk_error}}<br>
+	{{:helper.link('Back to menu', null, { "PRG_clear_error" : 1 })}}
 {{else}}
-	{{if data.filename}}
-		<h2>Viewing file {{:data.filename}}</h2>
-		<div class='item'>
-		{{:helper.link('CLOSE', null, { "PRG_closefile" : 1 })}}
-		{{:helper.link('EDIT', null, { "PRG_edit" : 1 })}}
-		{{:helper.link('PRINT', null, { "PRG_printfile" : 1 })}}
-		{{:helper.link('RUN', null, { "PRG_runfile" : 1 })}}
-		</div><hr>
-		{{:data.filedata}}
-	{{else}}
+	{{if data.file_mode == 0}}
 		<table><tr>
 		{{for data.disks}}
 			{{:helper.link(value.name, null, { "PRG_change_disk" : value.index }, value.selected ? 'selected' : null)}}
@@ -50,21 +49,24 @@
 						<tr><td>{{:helper.link(value.name, 'folder-collapsed', { "PRG_openfile" : value.name})}}
 						<td>
 						<td>
-						<td>{{:helper.link('RENAME', null, { "PRG_rename" : value.name}, value.unrenamable ? 'disabled' : null)}}
+						<td>
+							{{:helper.link('RENAME', null, { "PRG_rename" : value.name}, value.unrenamable ? 'disabled' : null)}}
 							{{:helper.link('DELETE', null, { "PRG_deletefile" : value.name}, value.undeletable ? 'disabled' : null)}}
 							{{:helper.link('CLONE', null, { "PRG_clone" : value.name}, value.undeletable ? 'disabled' : null)}}
 							{{:helper.link('TRANSFER TO', null, { "PRG_transferto" : value.name}, value.unsendable ? 'disabled' : null)}}
-					{{else}}
+							{{:helper.link('MANAGE PERMS', null, { "PRG_modifyperms" : value.name})}}
+						{{else}}
 						<tr><td>{{:value.name}}
 						<td>.{{:value.type}}
 						<td>{{:value.size}}GQ
 						<td>
 							{{:helper.link('VIEW', null, { "PRG_openfile" : value.name})}}
-							{{:helper.link('DELETE', null, { "PRG_deletefile" : value.name}, value.undeletable ? 'disabled' : null)}}
 							{{:helper.link('RENAME', null, { "PRG_rename" : value.name}, value.undeletable ? 'disabled' : null)}}
+							{{:helper.link('DELETE', null, { "PRG_deletefile" : value.name}, value.undeletable ? 'disabled' : null)}}
 							{{:helper.link('CLONE', null, { "PRG_clone" : value.name}, value.undeletable ? 'disabled' : null)}}
 							{{:helper.link('TRANSFER TO', null, { "PRG_transferto" : value.name}, value.unsendable ? 'disabled' : null)}}
-					{{/if}}
+							{{:helper.link('MANAGE PERMS', null, { "PRG_modifyperms" : value.name})}}
+						{{/if}}
 				{{/for}}
 			</table>
 			{{:helper.link('NEW DATA FILE', null, { "PRG_newtextfile" : 1 })}}
@@ -74,16 +76,93 @@
 			<table>
 			<tr><th>Disk
 			<th>Description
-			<th>Action</th>
+			<th>Actions</th>
 			{{for data.avail_disks}}
 				<tr><td>{{:helper.link(value.name, null, { "PRG_select_disk" : value.name})}}
 				<td>{{:value.desc}}
 				{{if value.is_network}}
-					<td>{{:helper.link('UNMOUNT', null, { "PRG_unmount_network" : value.name})}}
+				<td>{{:helper.link('MOUNT SETTINGS', null, { "PRG_mount_settings" : value.name})}}
 				{{/if}}
 				{{/for}}
 			</table>
 			{{:helper.link('MOUNT NETWORK DRIVE', null, { "PRG_mount_network" : 1 })}}
 		{{/if}}
+	{{else data.file_mode == 1}}<!--Viewing file data-->
+		<h2>Viewing file {{:data.filename}}</h2>
+		<div class='item'>
+		{{:helper.link('CLOSE', null, { "PRG_closefile" : 1 })}}
+		{{:helper.link('EDIT', null, { "PRG_edit" : 1 })}}
+		{{:helper.link('PRINT', null, { "PRG_printfile" : 1 })}}
+		{{:helper.link('RUN', null, { "PRG_runfile" : 1 })}}
+		</div><hr>
+		{{:data.filedata}}
+	{{else data.file_mode == 2}} <!--Modifying Permissions-->
+		<h2>Modifying permissions for {{:data.filename}}</h2>
+		<i>Users must be a member of at least one group in every access pattern to have file access</i>
+		<br>
+		{{:helper.link('READ ACCESS', null, {"PRG_change_perm" : "read"}, (data.current_perm == "read") ? 'selected' : null)}}
+		{{:helper.link('WRITE ACCESS', null, {"PRG_change_perm" : "write"}, (data.current_perm == "write") ? 'selected' : null)}}
+		{{:helper.link('PERMISSION MODIFICATION ACCESS', null, {"PRG_change_perm" : "mod"}, (data.current_perm == "mod") ? 'selected' : null)}}
+		<br><hr>
+		<table>
+			<tr><th>Pattern
+			<th>Groups
+			<th>Operations
+			</tr>
+			{{for data.patterns}}
+				<tr class="candystripe">
+				<td>{{:helper.link("Pattern " + value.index, null, { "PRG_select_pattern" : value.index}, (data.selected_pattern == value.index) ? 'selected' : null)}}
+				<td>{{:value.perm_list}}
+				<td>{{:helper.link('Delete pattern', null, { "PRG_remove_pattern" : value.index})}}
+			{{/for}}
+		</table>
+		{{:helper.link('Add pattern', null, { "PRG_add_pattern" : 1}, null)}}
+		<br>
+		{{if data.selected_pattern}}
+			<hr>
+			{{if data.parent_groups}}
+				<h2>Parent Groups:</h2>
+				<table>
+					<tr><th>Group
+					<th>Operations
+					{{for data.parent_groups}}
+						<tr><td>{{:helper.link(value.parent_group, null, { "PRG_select_parent_group" : value.parent_group })}}
+						<td>
+							{{if value.assigned}}
+								{{:helper.link('REMOVE', null, { "PRG_remove_group" : value.parent_group })}}
+							{{else}}
+								{{:helper.link('ASSIGN', null, { "PRG_assign_group" : value.parent_group })}}
+							{{/if}}
+					{{/for}}
+				</table>
+			{{else data.selected_parent_group}}
+				<h2>Viewing Child Groups for: {{:data.selected_parent_group}}</h2>
+				{{if data.child_groups}}
+					<h2>Child Groups:</h2>
+					<table>
+						<tr><th>Group
+						<th>Operations
+						{{for data.child_groups}}
+							<tr><td>{{:value.child_group}}
+							<td>
+								{{if value.assigned}}
+									{{:helper.link('REMOVE', null, { "PRG_remove_group" : value.child_group })}}
+								{{else}}
+									{{:helper.link('ASSIGN', null, { "PRG_assign_group" : value.child_group })}}
+								{{/if}}
+						{{/for}}
+					</table>
+				{{else}}
+					<i> No child groups found! </i>
+				{{/if}}
+				<div class='item'>
+					{{:helper.link('Back to parent group listing', null, { "PRG_select_parent_group" : null })}}
+				</div>
+			{{else}}
+				<i>No groups found on network!</i>
+			{{/if}}
+		{{/if}}
+		<hr>
+		{{:helper.link('CLOSE', null, { "PRG_closefile" : 1 })}}{{:helper.link('SAVE CHANGES', null, { "PRG_apply_perms" : 1})}}
 	{{/if}}
 {{/if}}


### PR DESCRIPTION
## Description of changes
A few file system fixes and additions
* Fixes a bug where file transfers were not cloning files
* Reworks the file manager program error handling, fixing a bug with portable drives bricking the program
* Adds an option for automounting network drives from the file manager program
* Adds an option to adjust directory/file permissions from the file manager program

## Why and what will this PR improve
Additional options for the file system, hopefully making it a bit more intuitive

## Authorship
Myself, thanks to Chinsky for the bug reports

## Changelog
:cl:
add: File permissions can now be modified from the file manager program
add: Network drives can now be set to automount from the file manager program
/:cl: