### PR TITLE
Gasmix consistency tweaks

### DIFF
--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -234,7 +234,7 @@ var/global/datum/controller/radio/radio_controller
 	var/encryption
 	var/frequency = 0
 
-/datum/signal/proc/copy_from(datum/signal/model)
+/datum/signal/proc/copy_from_model(datum/signal/model)
 	source = model.source
 	data = model.data
 	encryption = model.encryption

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -88,7 +88,7 @@
 */
 /atom/proc/return_air()
 	RETURN_TYPE(/datum/gas_mixture)
-	return loc?.return_air()
+	return loc?.return_air() || new /datum/gas_mixture
 
 /**
 	Get the flags that should be added to the `users` sight var.

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -40,9 +40,7 @@
 		target = null
 
 /obj/machinery/meter/return_air()
-	if(target)
-		return target.return_air()
-	return ..()
+	return target?.return_air() || ..()
 
 /obj/machinery/meter/Destroy()
 	clear_target()

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -136,7 +136,7 @@
 	return ..()
 
 /obj/machinery/portable_atmospherics/return_air()
-	return air_contents
+	return air_contents || ..()
 
 /obj/machinery/portable_atmospherics/powered
 	uncreated_component_parts = null

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -200,7 +200,7 @@
 	airtank.adjust_gas(/decl/material/gas/nitrogen, MOLES_N2STANDARD)
 
 /obj/machinery/cryopod/lifepod/return_air()
-	return airtank
+	return airtank || ..()
 
 /obj/machinery/cryopod/lifepod/proc/launch()
 	launched = 1

--- a/code/game/objects/effects/projectile/projectile_effects.dm
+++ b/code/game/objects/effects/projectile/projectile_effects.dm
@@ -18,7 +18,7 @@
 	alpha = 0
 	invisibility = INVISIBILITY_MAXIMUM
 
-/obj/effect/projectile/invislight/proc/copy_from(var/obj/effect/projectile/owner)
+/obj/effect/projectile/invislight/proc/copy_from_owner(var/obj/effect/projectile/owner)
 	light_range = initial(owner.light_range)
 	light_power = initial(owner.light_power)
 	light_color = initial(owner.light_color)

--- a/code/game/objects/items/cryobag.dm
+++ b/code/game/objects/items/cryobag.dm
@@ -97,9 +97,7 @@
 		H.SetStasis(stasis_power, STASIS_CRYOBAG)
 
 /obj/structure/closet/body_bag/cryobag/return_air() //Used to make stasis bags protect from vacuum.
-	if(airtank)
-		return airtank
-	..()
+	return airtank || ..()
 
 /obj/structure/closet/body_bag/cryobag/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/rescuebag.dm
+++ b/code/game/objects/items/rescuebag.dm
@@ -123,7 +123,7 @@
 		pump_gas_passive(airtank, airtank.air_contents, atmo, transfer_moles)
 
 /obj/structure/closet/body_bag/rescue/return_air() //Used to make stasis bags protect from vacuum.
-	return atmo
+	return atmo || ..()
 
 /obj/structure/closet/body_bag/rescue/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -319,13 +319,13 @@
 	var/orig_amount = src.amount
 	if (transfer && src.use(transfer))
 		var/obj/item/stack/newstack = new src.type(loc, transfer, material?.type)
-		newstack.copy_from(src)
+		newstack.copy_from_stack(src)
 		if (prob(transfer/orig_amount * 100))
 			transfer_fingerprints_to(newstack)
 		return newstack
 	return null
 
-/obj/item/stack/proc/copy_from(var/obj/item/stack/other)
+/obj/item/stack/proc/copy_from_stack(var/obj/item/stack/other)
 	color = other.color
 
 /obj/item/stack/proc/get_amount()

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -217,7 +217,7 @@
 			return
 
 /obj/item/flamethrower/return_air()
-	return tank?.return_air()
+	return tank?.return_air() || ..()
 
 /obj/item/flamethrower/proc/attempt_lighting(var/mob/user, var/external)
 	if(!external) // if it's external input, we can't unlight it, but we don't need to check for an igniter either

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -351,7 +351,7 @@ var/global/list/global/tank_gauge_cache = list()
 		queue_icon_update()
 
 /obj/item/tank/return_air()
-	return air_contents
+	return air_contents || ..()
 
 /obj/item/tank/assume_air(datum/gas_mixture/giver)
 	. = air_contents.merge(giver)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -43,9 +43,6 @@
 /obj/remove_air(amount)
 	return loc?.remove_air(amount)
 
-/obj/return_air()
-	return loc?.return_air()
-
 /obj/proc/updateUsrDialog()
 	if(in_use)
 		var/is_in_use = 0

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -138,7 +138,7 @@
 	if(!.)
 		return new /datum/gas_mixture
 	var/datum/gas_mixture/newgas = new
-	newgas.copy_from(.)
+	newgas.copy_from_gasmix(.)
 	if(newgas.temperature <= target_temp)	return
 
 	if((newgas.temperature - cooling_power) > target_temp)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -134,17 +134,18 @@
 	var/cooling_power = 40
 
 /obj/structure/closet/crate/freezer/return_air()
-	var/datum/gas_mixture/gas = (..())
-	if(!gas)	return null
-	var/datum/gas_mixture/newgas = new/datum/gas_mixture()
-	newgas.copy_from(gas)
+	. = ..()
+	if(!.)
+		return new /datum/gas_mixture
+	var/datum/gas_mixture/newgas = new
+	newgas.copy_from(.)
 	if(newgas.temperature <= target_temp)	return
 
 	if((newgas.temperature - cooling_power) > target_temp)
 		newgas.temperature -= cooling_power
 	else
 		newgas.temperature = target_temp
-	return newgas
+	. = newgas
 
 /obj/structure/closet/crate/freezer/ProcessAtomTemperature()
 	return PROCESS_KILL

--- a/code/game/objects/structures/mineral_bath.dm
+++ b/code/game/objects/structures/mineral_bath.dm
@@ -13,6 +13,7 @@
 	. = ..()
 
 /obj/structure/mineral_bath/return_air()
+	SHOULD_CALL_PARENT(FALSE)
 	var/datum/gas_mixture/venus = new(CELL_VOLUME, SYNTH_HEAT_LEVEL_1 - 10)
 	venus.adjust_multi(/decl/material/gas/chlorine, MOLES_N2STANDARD, /decl/material/gas/hydrogen, MOLES_O2STANDARD)
 	return venus

--- a/code/game/objects/structures/pit.dm
+++ b/code/game/objects/structures/pit.dm
@@ -68,10 +68,7 @@
 	update_icon()
 
 /obj/structure/pit/return_air()
-	if(open && loc)
-		return loc.return_air()
-	else
-		return null
+	return open ? ..() : new /datum/gas_mixture
 
 /obj/structure/pit/proc/digout(mob/escapee)
 	var/breakout_time = 1 //2 minutes by default

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -318,7 +318,7 @@
 		moving = 0
 
 /obj/structure/transit_tube_pod/return_air()
-	return air_contents
+	return air_contents || ..()
 
 /obj/structure/transit_tube_pod/assume_air(datum/gas_mixture/giver)
 	return air_contents.merge(giver)

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -135,7 +135,7 @@
 	if(other.zone)
 		if(!air)
 			make_air()
-		air.copy_from(other.zone.air)
+		air.copy_from_gasmix(other.zone.air)
 		other.zone.remove(other)
 	if(!istype(other, src.type))
 		return 0

--- a/code/modules/ZAS/ConnectionGroup.dm
+++ b/code/modules/ZAS/ConnectionGroup.dm
@@ -230,7 +230,7 @@ Class Procs:
 		flow(A.movables(), abs(differential), differential < 0)
 
 	if(equiv)
-		A.air.copy_from(air)
+		A.air.copy_from_gasmix(air)
 		SSair.mark_edge_sleeping(src)
 
 	SSair.mark_zone_update(A)

--- a/code/modules/ZAS/Turf.dm
+++ b/code/modules/ZAS/Turf.dm
@@ -231,7 +231,7 @@
 		var/datum/level_data/level = SSmapping.levels_by_z[z]
 		var/datum/gas_mixture/gas = level?.get_exterior_atmosphere()
 		if(!gas)
-			return
+			return new /datum/gas_mixture
 		var/initial_temperature = gas.temperature
 		if(weather)
 			initial_temperature = weather.adjust_temperature(initial_temperature)
@@ -246,8 +246,9 @@
 	. = air
 	if(!.)
 		. = make_air()
-		if(zone)
+		if(zone && SHOULD_PARTICIPATE_IN_ZONES(src))
 			c_copy_air()
+	return . || new /datum/gas_mixture
 
 /turf/remove_air(amount as num)
 	var/datum/gas_mixture/GM = return_air()
@@ -264,7 +265,7 @@
 	return FALSE
 
 /turf/proc/make_air()
-	air = new/datum/gas_mixture
+	air = new /datum/gas_mixture
 	air.temperature = temperature
 	if(initial_gas)
 		air.gas = initial_gas.Copy()
@@ -273,6 +274,6 @@
 
 /turf/proc/c_copy_air()
 	if(!air)
-		air = new/datum/gas_mixture
+		air = new /datum/gas_mixture
 	air.copy_from(zone.air)
 	air.group_multiplier = 1

--- a/code/modules/ZAS/Turf.dm
+++ b/code/modules/ZAS/Turf.dm
@@ -275,5 +275,5 @@
 /turf/proc/c_copy_air()
 	if(!air)
 		air = new /datum/gas_mixture
-	air.copy_from(zone.air)
+	air.copy_from_gasmix(zone.air)
 	air.group_multiplier = 1

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -106,10 +106,8 @@ Thus, the two variables affect pump operation are set in New():
 	return 1
 
 /obj/machinery/atmospherics/binary/pump/return_air()
-	if(air1.return_pressure() > air2.return_pressure())
-		return air1
-	else
-		return air2
+	SHOULD_CALL_PARENT(FALSE)
+	return (air1.return_pressure() > air2.return_pressure()) ? air1 : air2
 
 /obj/machinery/atmospherics/binary/pump/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	if(stat & (BROKEN|NOPOWER))

--- a/code/modules/atmospherics/components/unary/tank.dm
+++ b/code/modules/atmospherics/components/unary/tank.dm
@@ -46,6 +46,7 @@
 	update_icon()
 
 /obj/machinery/atmospherics/unary/tank/return_air()
+	SHOULD_CALL_PARENT(FALSE)
 	return air_contents
 
 /obj/machinery/atmospherics/unary/tank/deconstruction_pressure_check()

--- a/code/modules/atmospherics/datum_pipeline.dm
+++ b/code/modules/atmospherics/datum_pipeline.dm
@@ -64,7 +64,7 @@
 
 		if(air?.volume)
 			member.air_temporary = new
-			member.air_temporary.copy_from(air)
+			member.air_temporary.copy_from_gasmix(air)
 			member.air_temporary.volume = member.volume
 			member.air_temporary.multiply(member.volume / air.volume)
 
@@ -174,7 +174,7 @@
 		//Have to consider preservation of group statuses
 		var/datum/gas_mixture/turf_copy = new
 
-		turf_copy.copy_from(target.zone.air)
+		turf_copy.copy_from_gasmix(target.zone.air)
 		turf_copy.volume = target.zone.air.volume //Copy a good representation of the turf from parent group
 
 		equalize_gases(list(air_sample, turf_copy))

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -83,10 +83,10 @@
 		hide(1)
 
 /obj/machinery/atmospherics/pipe/return_air()
+	SHOULD_CALL_PARENT(FALSE)
 	if(!parent)
 		parent = new /datum/pipeline()
 		parent.build_pipeline(src)
-
 	return parent.air
 
 /obj/machinery/atmospherics/pipe/build_network()

--- a/code/modules/butchery/butchery.dm
+++ b/code/modules/butchery/butchery.dm
@@ -78,11 +78,6 @@
 	var/secures_occupant = TRUE
 	var/busy =             FALSE
 
-/obj/structure/kitchenspike/return_air()
-	var/turf/T = get_turf(src)
-	if(istype(T))
-		return T.return_air()
-
 /obj/structure/kitchenspike/improvised
 	name = "truss"
 	icon_state = "improvised"

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -106,7 +106,7 @@
 	if(!QDELETED(M))
 		M.update_strings()
 
-/obj/item/stack/material/copy_from(var/obj/item/stack/material/other)
+/obj/item/stack/material/copy_from_stack(var/obj/item/stack/material/other)
 	..()
 	if(istype(other))
 		material = other.material

--- a/code/modules/mechs/mech.dm
+++ b/code/modules/mechs/mech.dm
@@ -206,7 +206,9 @@
 	to_chat(user, "It menaces with reinforcements of [material].")
 
 /mob/living/exosuit/return_air()
-	return (body && body.pilot_coverage >= 100 && hatch_closed && body.cockpit) ? body.cockpit : loc.return_air()
+	if(body && body.pilot_coverage >= 100 && hatch_closed && body.cockpit)
+		return body.cockpit || new /datum/gas_mixture
+	return ..()
 
 /mob/living/exosuit/GetIdCards()
 	. = ..()

--- a/code/modules/mining/machinery/material_extractor.dm
+++ b/code/modules/mining/machinery/material_extractor.dm
@@ -187,7 +187,8 @@ var/global/list/material_extractor_items_whitelist = list(/obj/item/stack/materi
 
 //For some reasons that's not in the unary base class...
 /obj/machinery/atmospherics/unary/material/extractor/return_air()
-	return air_contents
+	SHOULD_CALL_PARENT(FALSE)
+	return air_contents || new /datum/gas_mixture
 
 //Remove trace amounts of reagents from the input tank, to prevent that from causing problems
 /obj/machinery/atmospherics/unary/material/extractor/proc/input_clear_remainder()

--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -383,11 +383,12 @@
 //
 // Accessors
 //
+// FIXME: this seems to be called with null `exterior_atmosphere` under some turf arrangements.
 /datum/level_data/proc/get_exterior_atmosphere()
-	if(exterior_atmosphere)
-		var/datum/gas_mixture/gas = new
+	var/datum/gas_mixture/gas = new
+	if(istype(exterior_atmosphere))
 		gas.copy_from_gasmix(exterior_atmosphere)
-		return gas
+	return gas
 
 /datum/level_data/proc/get_display_name()
 	if(!name)

--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -169,10 +169,10 @@
 
 ///Handle a new level_data datum overwriting us.
 /datum/level_data/proc/replace_with(var/datum/level_data/new_level)
-	new_level.copy_from(src)
+	new_level.copy_from_level(src)
 
 ///Handle copying data from a previous level_data we're replacing.
-/datum/level_data/proc/copy_from(var/datum/level_data/old_level)
+/datum/level_data/proc/copy_from_level(var/datum/level_data/old_level)
 	return
 
 ///Initialize the turfs on the z-level.
@@ -386,7 +386,7 @@
 /datum/level_data/proc/get_exterior_atmosphere()
 	if(exterior_atmosphere)
 		var/datum/gas_mixture/gas = new
-		gas.copy_from(exterior_atmosphere)
+		gas.copy_from_gasmix(exterior_atmosphere)
 		return gas
 
 /datum/level_data/proc/get_display_name()

--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -86,7 +86,7 @@
 		owner.vomit(deliberate = TRUE)
 
 /obj/item/organ/internal/stomach/return_air()
-	return null
+	return new /datum/gas_mixture
 
 #define STOMACH_VOLUME 65
 

--- a/code/modules/overmap/ships/device_types/gas_thruster.dm
+++ b/code/modules/overmap/ships/device_types/gas_thruster.dm
@@ -32,7 +32,7 @@
 	var/datum/gas_mixture/removed = E.air_contents.remove_ratio((volume_per_burn * thrust_limit * partial) / E.air_contents.volume)
 	if(sample_only)
 		var/datum/gas_mixture/sample = new(removed.volume)
-		sample.copy_from(removed)
+		sample.copy_from_gasmix(removed)
 		E.air_contents.merge(removed)
 		return sample
 	return removed

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -161,7 +161,7 @@ var/global/list/rad_collectors = list()
 	update_icon()
 
 /obj/machinery/rad_collector/return_air()
-	. =loaded_tank?.return_air()
+	return loaded_tank?.return_air() || new /datum/gas_mixture
 
 /obj/machinery/rad_collector/proc/eject()
 	locked = 0

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -325,7 +325,7 @@
 	if(hitscan && tracer_type && !(locate(/obj/effect/projectile) in loc))
 		var/obj/effect/projectile/invislight/light = new
 		light.forceMove(loc)
-		light.copy_from(tracer_type)
+		light.copy_from_owner(tracer_type)
 		QDEL_IN(light, 3)
 
 /obj/item/projectile/after_wounding(obj/item/organ/external/organ, datum/wound/wound)

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -313,7 +313,7 @@
 			. += gas[g]
 
 //Copies gas and temperature from another gas_mixture.
-/datum/gas_mixture/proc/copy_from(const/datum/gas_mixture/sample)
+/datum/gas_mixture/proc/copy_from_gasmix(datum/gas_mixture/sample)
 	gas = sample.gas.Copy()
 	graphic = sample.graphic.Copy()
 	temperature = sample.temperature


### PR DESCRIPTION
## Description of changes
Should hopefully guarantee that return_air always returns a gas datum, to try and get ZAS to cooperate.
I'm not actually sure if this should be merged or not.

## Why and what will this PR improve
ZAS seems to expect to never have to deal with null gas datums.

## Authorship
Myself.

## Changelog
Nothing player-facing.