### PR TITLE
Fix infinite recursion in get_all_connected_level_z

### DIFF
--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -448,7 +448,7 @@
 		if(LD.level_z in _connected_siblings)
 			continue
 		. |= LD.level_z
-		. |= LD.get_all_connected_level_z()
+		. |= LD.get_all_connected_level_z(_connected_siblings)
 
 
 /datum/level_data/proc/find_connected_levels(var/list/found)


### PR DESCRIPTION
## Description of changes
Fixes infinite recursion in `get_all_connected_level_z` due to missing the deduplication argument. This fixes issues with level_data not being initialized properly leading to null exterior atmosphere.

## Why and what will this PR improve
Alternative to #3106. The runtime that PR is attempting to solve only happened because of this runtime leading to level_data setup procs not getting called; see the FIXME comment about exterior_atmosphere somehow being null.