### PR TITLE
Converting dexterity to a bitflag system.

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -307,13 +307,27 @@
 #define MARKING_TARGET_HAIR 1 // Draw a /decl/sprite_accessory/marking to the mob's hair, eg. ears & horns
 
 #define DEXTERITY_NONE            0
-#define DEXTERITY_SIMPLE_MACHINES 1
-#define DEXTERITY_KEYBOARDS       2
-#define DEXTERITY_TOUCHSCREENS    3
-#define DEXTERITY_GRIP            4
-#define DEXTERITY_WEAPONS         5
-#define DEXTERITY_COMPLEX_TOOLS   6
-#define DEXTERITY_FULL            7
+#define DEXTERITY_SIMPLE_MACHINES BITFLAG(0)
+#define DEXTERITY_HOLD_ITEM       BITFLAG(1)
+#define DEXTERITY_EQUIP_ITEM      BITFLAG(2)
+#define DEXTERITY_KEYBOARDS       BITFLAG(3)
+#define DEXTERITY_TOUCHSCREENS    BITFLAG(4)
+// TODO: actually get grab code to check this one.
+#define DEXTERITY_GRAPPLE         BITFLAG(5)
+#define DEXTERITY_WEAPONS         BITFLAG(6)
+#define DEXTERITY_COMPLEX_TOOLS   BITFLAG(7)
+#define DEXTERITY_BASE (DEXTERITY_SIMPLE_MACHINES|DEXTERITY_HOLD_ITEM|DEXTERITY_EQUIP_ITEM)
+#define DEXTERITY_FULL (DEXTERITY_BASE|DEXTERITY_KEYBOARDS|DEXTERITY_TOUCHSCREENS|DEXTERITY_GRAPPLE|DEXTERITY_WEAPONS|DEXTERITY_COMPLEX_TOOLS)
+
+// List of dexterity flags ordered by 'complexity' for use in brainloss dex malus checking.
+var/global/list/dexterity_levels = list(
+	"[DEXTERITY_COMPLEX_TOOLS]",
+	"[DEXTERITY_WEAPONS]",
+	"[DEXTERITY_GRAPPLE]",
+	"[DEXTERITY_TOUCHSCREENS]",
+	"[DEXTERITY_KEYBOARDS]",
+	"[DEXTERITY_BASE]"
+)
 
 // used in /mob/living/carbon/human/can_inject, and by various callers of that proc
 #define CAN_INJECT 1

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -14,7 +14,7 @@
 
 // Can the user drop something onto this atom?
 /atom/proc/user_can_mousedrop_onto(var/mob/user, var/atom/being_dropped, var/incapacitation_flags)
-	return !user.incapacitated(incapacitation_flags) && check_mousedrop_interactivity(user) && user.check_dexterity(DEXTERITY_GRIP)
+	return !user.incapacitated(incapacitation_flags) && check_mousedrop_interactivity(user) && user.check_dexterity(DEXTERITY_HOLD_ITEM)
 
 /atom/proc/check_mousedrop_interactivity(var/mob/user)
 	return CanPhysicallyInteract(user)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -29,7 +29,7 @@
 	SHOULD_CALL_PARENT(TRUE)
 	if(handle_grab_interaction(user))
 		return TRUE
-	if(!LAZYLEN(climbers) || (user in climbers) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!LAZYLEN(climbers) || (user in climbers) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return FALSE
 	user.visible_message(
 		SPAN_DANGER("\The [user] shakes \the [src]!"),

--- a/code/game/machinery/_machines_base/stock_parts/power/battery.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/battery.dm
@@ -183,7 +183,7 @@
 	return ..()
 
 /obj/item/stock_parts/power/battery/attack_hand(mob/user)
-	if(cell && istype(loc, /obj/machinery) && user.check_dexterity(DEXTERITY_GRIP))
+	if(cell && istype(loc, /obj/machinery) && user.check_dexterity(DEXTERITY_HOLD_ITEM))
 		user.put_in_hands(cell)
 		extract_cell(user)
 		return TRUE

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -802,7 +802,7 @@ var/global/list/turret_icons
 
 
 /obj/machinery/porta_turret_construct/attack_hand(mob/user)
-	if(!user.check_dexterity(DEXTERITY_GRIP))
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM))
 		return ..()
 	if(build_step == 4)
 		if(!installation)

--- a/code/game/machinery/self_destruct_storage.dm
+++ b/code/game/machinery/self_destruct_storage.dm
@@ -6,7 +6,7 @@
 	anchored = TRUE
 	density = FALSE
 
-	required_interaction_dexterity = DEXTERITY_GRIP
+	required_interaction_dexterity = DEXTERITY_HOLD_ITEM
 	construct_state = /decl/machine_construction/default/panel_closed
 	base_type = /obj/machinery/nuclear_cylinder_storage/buildable
 

--- a/code/game/objects/effects/decals/posters/_poster.dm
+++ b/code/game/objects/effects/decals/posters/_poster.dm
@@ -72,7 +72,7 @@
 /obj/structure/sign/poster/attack_hand(mob/user)
 	if(user.a_intent != I_HURT || ruined)
 		return ..()
-	if(!CanPhysicallyInteract(user) || !user.check_dexterity(DEXTERITY_GRIP))
+	if(!CanPhysicallyInteract(user) || !user.check_dexterity(DEXTERITY_HOLD_ITEM))
 		return TRUE
 	add_fingerprint(user)
 	visible_message(SPAN_WARNING("\The [user] rips \the '[src]' in a single, decisive motion!"))

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -288,9 +288,9 @@
 	if(anchored)
 		return ..()
 
-	if(!user.check_dexterity(DEXTERITY_GRIP, silent = TRUE))
+	if(!user.check_dexterity(DEXTERITY_EQUIP_ITEM, silent = TRUE))
 
-		if(user.check_dexterity(DEXTERITY_KEYBOARDS, silent = TRUE))
+		if(user.check_dexterity(DEXTERITY_HOLD_ITEM, silent = TRUE))
 
 			if(loc == user)
 				to_chat(user, SPAN_NOTICE("You begin trying to remove \the [src]..."))

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -28,7 +28,7 @@
 
 /obj/item/target/attack_hand(var/mob/user)
 	// taking pinned targets off!
-	if(!stake || !user.check_dexterity(DEXTERITY_GRIP))
+	if(!stake || !user.check_dexterity(DEXTERITY_HOLD_ITEM))
 		return ..()
 	return stake.attack_hand(user)
 

--- a/code/game/objects/items/spirit_board.dm
+++ b/code/game/objects/items/spirit_board.dm
@@ -14,7 +14,7 @@
 	to_chat(user, "The planchette is sitting at \"[planchette]\".")
 
 /obj/item/spirit_board/attack_hand(mob/user)
-	if(user.a_intent == I_GRAB || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(user.a_intent == I_GRAB || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	spirit_board_pick_letter(user)
 	return TRUE

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -550,7 +550,7 @@
 	var/phrase = "I don't want to exist anymore!"
 
 /obj/structure/plushie/attack_hand(mob/user)
-	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	playsound(src.loc, 'sound/effects/rustle1.ogg', 100, 1)
 	if(user.a_intent == I_HELP)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -68,7 +68,7 @@
 	toggle_paddles()
 
 /obj/item/defibrillator/attack_hand(mob/user)
-	if(loc != user || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(loc != user || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	toggle_paddles()
 	return TRUE

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -181,7 +181,7 @@
 			to_chat(user, SPAN_WARNING("\The [src] does not have a battery installed."))
 
 /obj/item/clothing/mask/smokable/ecig/attack_hand(mob/user)//eject cartridge
-	if(!user.is_holding_offhand(src) || !ec_cartridge || !user.check_dexterity(DEXTERITY_GRIP))
+	if(!user.is_holding_offhand(src) || !ec_cartridge || !user.check_dexterity(DEXTERITY_HOLD_ITEM))
 		return ..()
 	lit = FALSE
 	user.put_in_hands(ec_cartridge)

--- a/code/game/objects/items/weapons/implants/implantpad.dm
+++ b/code/game/objects/items/weapons/implants/implantpad.dm
@@ -13,7 +13,7 @@
 		add_overlay("[icon_state]-imp")
 
 /obj/item/implantpad/attack_hand(mob/user)
-	if(!imp || (src in user.get_held_items()) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!imp || (src in user.get_held_items()) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	user.put_in_active_hand(imp)
 	imp.add_fingerprint(user)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -75,7 +75,7 @@
 		. = ..(W, user)
 
 /obj/item/storage/belt/holster/attack_hand(mob/user)
-	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	var/datum/extension/holster/H = get_extension(src, /datum/extension/holster)
 	if(H.unholster(user))

--- a/code/game/objects/items/weapons/storage/parachute.dm
+++ b/code/game/objects/items/weapons/storage/parachute.dm
@@ -18,7 +18,7 @@
 			to_chat(user, SPAN_DANGER("The parachute is unpacked."))
 
 /obj/item/storage/backpack/parachute/attack_self(mob/user)
-	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	var/initial_pack = packed
 	var/pack_msg = packed ? "unpack" : "pack"

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -92,7 +92,7 @@
 	matter = list(/decl/material/solid/plastic = MATTER_AMOUNT_REINFORCEMENT)
 
 /obj/item/storage/secure/briefcase/attack_hand(mob/user as mob)
-	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	var/datum/extension/lockable/lock = get_extension(src, /datum/extension/lockable)
 	if (loc == user && lock.locked)

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -168,7 +168,7 @@
 	return 0.2
 
 /obj/item/duct_tape/attack_hand(var/mob/user)
-	if(user.has_dexterity(DEXTERITY_GRIP))
+	if(user.check_dexterity(DEXTERITY_HOLD_ITEM))
 		anchored = FALSE // Unattach it from whereever it's on, if anything.
 	return ..()
 

--- a/code/game/objects/items/weapons/tech_disks.dm
+++ b/code/game/objects/items/weapons/tech_disks.dm
@@ -111,7 +111,7 @@
 	var/datum/fabricator_recipe/blueprint
 
 /obj/item/disk/design_disk/attack_hand(mob/user)
-	if(user.a_intent != I_HURT || !blueprint || !user.has_dexterity(DEXTERITY_KEYBOARDS))
+	if(user.a_intent != I_HURT || !blueprint || !user.check_dexterity(DEXTERITY_KEYBOARDS))
 		return ..()
 	blueprint = null
 	SetName(initial(name))

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -162,7 +162,7 @@
 	return ..()
 
 /obj/item/weldingtool/attack_hand(mob/user)
-	if (tank && user.is_holding_offhand(src) && user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if (tank && user.is_holding_offhand(src) && user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return remove_tank(user)
 	return ..()
 

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -50,7 +50,7 @@
 			anchored = 1
 
 /obj/item/beartrap/attack_hand(mob/user)
-	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	if(buckled_mob)
 		user_unbuckle_mob(user)

--- a/code/game/objects/items/weapons/weldbackpack.dm
+++ b/code/game/objects/items/weapons/weldbackpack.dm
@@ -130,7 +130,7 @@
 	return ..()
 
 /obj/item/chems/weldpack/attack_hand(mob/user)
-	if(!is_welder_attached() || !user.check_dexterity(DEXTERITY_GRIP))
+	if(!is_welder_attached() || !user.check_dexterity(DEXTERITY_HOLD_ITEM))
 		return ..()
 	if(user.is_holding_offhand(src))
 		detach_gun(user)

--- a/code/game/objects/structures/banners.dm
+++ b/code/game/objects/structures/banners.dm
@@ -35,7 +35,7 @@
 	update_icon()
 
 /obj/structure/banner_frame/attack_hand(mob/user)
-	if(banner && user.check_dexterity(DEXTERITY_GRIP))
+	if(banner && user.check_dexterity(DEXTERITY_HOLD_ITEM))
 		user.put_in_hands(banner)
 		var/old_banner = banner
 		set_banner(null)

--- a/code/game/objects/structures/bookcase.dm
+++ b/code/game/objects/structures/bookcase.dm
@@ -31,7 +31,7 @@ var/global/list/station_bookcases = list()
 	return ..()
 
 /obj/structure/bookcase/attack_hand(var/mob/user)
-	if(!length(contents) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!length(contents) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	var/obj/item/book/choice = input("Which book would you like to remove from the shelf?") as null|obj in contents
 	if(choice && (choice in contents) && CanPhysicallyInteract(user))

--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -36,7 +36,7 @@
 				break
 
 /obj/structure/coatrack/attack_hand(mob/user)
-	if(!length(contents) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!length(contents) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	var/obj/item/removing = contents[contents.len]
 	user.visible_message( \

--- a/code/game/objects/structures/crematorium.dm
+++ b/code/game/objects/structures/crematorium.dm
@@ -79,7 +79,7 @@
 	update_icon()
 
 /obj/structure/crematorium/attack_hand(mob/user)
-	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	if(locked)
 		to_chat(usr, SPAN_WARNING("It's currently locked."))

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -104,7 +104,9 @@
 		..(P, def_zone)
 
 /obj/structure/curtain/attack_hand(mob/user)
-	toggle()
+	if(user.check_dexterity(DEXTERITY_HOLD_ITEM))
+		toggle()
+		return TRUE
 	return ..()
 
 /obj/structure/curtain/attackby(obj/item/W, mob/user)

--- a/code/game/objects/structures/defensive_barrier.dm
+++ b/code/game/objects/structures/defensive_barrier.dm
@@ -101,7 +101,7 @@
 
 /obj/structure/defensive_barrier/attack_hand(mob/user)
 
-	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 
 	var/decl/species/species = user.get_species()

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -113,7 +113,7 @@
 
 /obj/structure/displaycase/attack_hand(mob/user)
 
-	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)

--- a/code/game/objects/structures/emergency_dispenser.dm
+++ b/code/game/objects/structures/emergency_dispenser.dm
@@ -15,7 +15,7 @@
 	//Added by Strumpetplaya - AI shouldn't be able to  (you're both stupid, need CanPhysicallyInteract --Chinsky)
 	//activate emergency lockers.  This fixes that.  (Does this make sense, the AI can't call attack_hand, can it? --Mloc)
 	//(It uses the Nano helper and a dexterity check now anyway. --Loaf)
-	if(!CanPhysicallyInteract(user) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!CanPhysicallyInteract(user) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	if(!amount)
 		to_chat(user, SPAN_WARNING("It's empty."))

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -31,7 +31,7 @@
 
 /obj/structure/extinguisher_cabinet/attack_hand(mob/user)
 
-	if(user.check_dexterity(DEXTERITY_GRIP, TRUE) && has_extinguisher)
+	if(user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE) && has_extinguisher)
 		user.put_in_hands(has_extinguisher)
 		to_chat(user, SPAN_NOTICE("You take [has_extinguisher] from [src]."))
 		playsound(src.loc, 'sound/effects/extout.ogg', 50, 0)

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -139,7 +139,7 @@
 
 /obj/structure/fire_source/attack_hand(var/mob/user)
 
-	if(length(contents) && user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(length(contents) && user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		var/obj/item/removing = pick(contents)
 		removing.dropInto(loc)
 		user.put_in_hands(removing)

--- a/code/game/objects/structures/flora/plant.dm
+++ b/code/game/objects/structures/flora/plant.dm
@@ -81,7 +81,7 @@
 	. = ..()
 
 /obj/structure/flora/plant/attack_hand(mob/user)
-	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 
 	if(dead)

--- a/code/game/objects/structures/fuel_port.dm
+++ b/code/game/objects/structures/fuel_port.dm
@@ -27,7 +27,7 @@
 	return locate(/obj/item/tank) in contents
 
 /obj/structure/fuel_port/attack_hand(mob/user)
-	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	if(!open)
 		to_chat(user, SPAN_WARNING("The door is secured tightly. You'll need a crowbar to open it."))

--- a/code/game/objects/structures/hand_cart.dm
+++ b/code/game/objects/structures/hand_cart.dm
@@ -44,7 +44,7 @@
 	. = ..()
 
 /obj/structure/hand_cart/attack_hand(mob/user)
-	if(!carrying || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!carrying || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	unload_item(user)
 	return TRUE

--- a/code/game/objects/structures/handrail.dm
+++ b/code/game/objects/structures/handrail.dm
@@ -11,7 +11,7 @@
 	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 
 /obj/structure/handrail/attack_hand(mob/user)
-	if(!can_buckle || buckled_mob || !istype(user) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!can_buckle || buckled_mob || !istype(user) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	user_buckle_mob(user, user)
 	return TRUE

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -85,7 +85,7 @@
 
 
 /obj/structure/janitorialcart/attack_hand(mob/user)
-	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	ui_interact(user)
 	return TRUE
@@ -231,7 +231,7 @@
 	. = ..()
 
 /obj/structure/bed/chair/janicart/attack_hand(mob/user)
-	if(!mybag || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!mybag || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	user.put_in_hands(mybag)
 	mybag = null

--- a/code/game/objects/structures/mineral_bath.dm
+++ b/code/game/objects/structures/mineral_bath.dm
@@ -66,7 +66,7 @@
 	return TRUE
 
 /obj/structure/mineral_bath/attack_hand(var/mob/user)
-	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	eject_occupant()
 	return TRUE

--- a/code/game/objects/structures/rubble.dm
+++ b/code/game/objects/structures/rubble.dm
@@ -47,7 +47,7 @@
 		add_overlay("twinkle[rand(1,3)]")
 
 /obj/structure/rubble/attack_hand(mob/user)
-	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	if(!is_rummaging)
 		if(!lootleft)

--- a/code/game/objects/structures/skele_stand.dm
+++ b/code/game/objects/structures/skele_stand.dm
@@ -31,7 +31,7 @@
 	playsound(loc, 'sound/effects/bonerattle.ogg', 40)
 
 /obj/structure/skele_stand/attack_hand(mob/user)
-	if(length(swag) && user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(length(swag) && user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		var/obj/item/clothing/C = input("What piece of clothing do you want to remove?", "Skeleton Undressing") as null|anything in list_values(swag)
 		if(C)
 			swag -= get_key_by_value(swag, C)

--- a/code/game/objects/structures/stool_bed_chair_nest_sofa/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest_sofa/bed.dm
@@ -183,7 +183,7 @@
 	..()
 
 /obj/structure/bed/roller/attack_hand(mob/user)
-	if(!beaker || buckled_mob || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!beaker || buckled_mob || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	remove_beaker(user)
 	return TRUE

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -66,7 +66,7 @@
 	return attack_hand_with_interaction_checks(user)
 
 /obj/structure/tank_rack/attack_hand(mob/user)
-	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	var/list/dat = list()
 	var/oxycount = LAZYLEN(oxygen_tanks)

--- a/code/game/objects/structures/target_stake.dm
+++ b/code/game/objects/structures/target_stake.dm
@@ -14,7 +14,7 @@
 		set_target(W)
 
 /obj/structure/target_stake/attack_hand(var/mob/user)
-	if (!pinned_target || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if (!pinned_target || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	to_chat(user, SPAN_NOTICE("You take \the [pinned_target] off the stake."))
 	user.put_in_hands(pinned_target)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -115,7 +115,7 @@ var/global/list/hygiene_props = list()
 	update_icon()
 
 /obj/structure/hygiene/toilet/attack_hand(var/mob/user)
-	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 
 	if(swirlie)

--- a/code/modules/butchery/butchery.dm
+++ b/code/modules/butchery/butchery.dm
@@ -90,7 +90,7 @@
 
 /obj/structure/kitchenspike/attack_hand(var/mob/user)
 
-	if(!occupant || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!occupant || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 
 	if(occupant_state == CARCASS_FRESH)

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -22,7 +22,7 @@
 
 // Clumsy folks can't take the mask off themselves.
 /obj/item/clothing/mask/muzzle/attack_hand(mob/user)
-	if(user.get_equipped_item(slot_wear_mask_str) != src || user.check_dexterity(DEXTERITY_GRIP))
+	if(user.get_equipped_item(slot_wear_mask_str) != src || user.check_dexterity(DEXTERITY_HOLD_ITEM))
 		return ..()
 	to_chat(user, SPAN_WARNING("You cannot remove \the [src] without help."))
 	return TRUE

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -48,7 +48,7 @@
 			to_chat(user, SPAN_ITALIC("Something is hidden inside."))
 
 /obj/item/clothing/shoes/attack_hand(var/mob/user)
-	if(user.check_dexterity(DEXTERITY_GRIP, TRUE) && remove_hidden(user))
+	if(user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE) && remove_hidden(user))
 		return TRUE
 	return ..()
 

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -21,7 +21,7 @@
 		. = ..(W, user)
 
 /obj/item/clothing/accessory/storage/holster/attack_hand(mob/user)
-	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	var/datum/extension/holster/H = get_extension(src, /datum/extension/holster)
 	if(H.unholster(user))

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -22,7 +22,7 @@
 	hold = new/obj/item/storage/internal/pockets(src, slots, max_w_class)
 
 /obj/item/clothing/accessory/storage/attack_hand(mob/user)
-	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE) || !hold)
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE) || !hold)
 		return ..()
 	if(istype(loc, /obj/item/clothing))
 		hold.open(user)

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -137,7 +137,7 @@ var/global/list/card_decks = list()
 			cards += P
 
 /obj/item/deck/attack_hand(mob/user)
-	if(user.a_intent == I_GRAB || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(user.a_intent == I_GRAB || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	draw_card(user)
 	return TRUE
@@ -307,7 +307,7 @@ var/global/list/card_decks = list()
 	user.visible_message("\The [user] [concealed ? "conceals" : "reveals"] their hand.")
 
 /obj/item/hand/attack_hand(mob/user)
-	if(loc != user && !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(loc != user && !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 
 	// build the list of cards in the hand

--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -14,7 +14,7 @@
 	return ..()
 
 /obj/item/mech_equipment/clamp/attack_hand(mob/user)
-	if(!owner || !LAZYISIN(owner.pilots, user) || owner.hatch_closed || !length(carrying) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!owner || !LAZYISIN(owner.pilots, user) || owner.hatch_closed || !length(carrying) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	var/obj/chosen_obj = input(user, "Choose an object to grab.", "Clamp Claw") as null|anything in carrying
 	if(chosen_obj && do_after(user, 20, owner) && !owner.hatch_closed && !QDELETED(chosen_obj) && (chosen_obj in carrying))

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -86,8 +86,8 @@
 		return STATUS_INTERACTIVE
 	return ..()
 
-/mob/living/exosuit/has_dexterity(dex_level)
-	return TRUE
+/mob/living/exosuit/get_dexterity(var/silent = FALSE)
+	return DEXTERITY_FULL
 
 /mob/living/exosuit/ClickOn(var/atom/A, var/params, var/mob/user)
 

--- a/code/modules/mechs/mech_wreckage.dm
+++ b/code/modules/mechs/mech_wreckage.dm
@@ -50,7 +50,7 @@
 
 /obj/structure/mech_wreckage/attack_hand(var/mob/user)
 	var/list/contained_atoms = get_contained_external_atoms()
-	if(!length(contained_atoms) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!length(contained_atoms) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	var/obj/item/thing = pick(contained_atoms)
 	thing.forceMove(get_turf(user))

--- a/code/modules/mining/ore_box.dm
+++ b/code/modules/mining/ore_box.dm
@@ -18,7 +18,7 @@
 	var/list/stored_ore
 
 /obj/structure/ore_box/attack_hand(mob/user)
-	if(total_ores <= 0 || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(total_ores <= 0 || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	var/obj/item/stack/material/ore/O = pick(get_contained_external_atoms())
 	if(!remove_ore(O, user))
@@ -87,7 +87,7 @@
 		if(user)
 			to_chat(user, SPAN_WARNING("\The [src] is empty!"))
 		return FALSE
-	if(user && !user.check_dexterity(DEXTERITY_GRIP))
+	if(user && !user.check_dexterity(DEXTERITY_HOLD_ITEM))
 		to_chat(user, SPAN_WARNING("You lack the dexterity to empty \the [src]!"))
 		return FALSE
 
@@ -106,7 +106,7 @@
 		if(user)
 			to_chat(user, SPAN_WARNING("\The [src] is empty!"))
 		return FALSE
-	if(user && !user.check_dexterity(DEXTERITY_GRIP))
+	if(user && !user.check_dexterity(DEXTERITY_HOLD_ITEM))
 		to_chat(user, SPAN_WARNING("You lack the dexterity to empty \the [src]!"))
 		return FALSE
 	if(user)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -343,9 +343,6 @@
 /mob/living/carbon/adjust_hydration(var/amt)
 	set_hydration(hydration + amt)
 
-/mob/living/carbon/has_dexterity(var/dex_level)
-	. = ..() && (species.get_manual_dexterity() >= dex_level)
-
 /mob/living/carbon/fluid_act(var/datum/reagents/fluids)
 	var/saturation =  min(fluids.total_volume, round(mob_size * 1.5 * reagent_permeability()) - touching.total_volume)
 	if(saturation > 0)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1197,31 +1197,26 @@
 
 				new /obj/effect/temp_visual/bloodsplatter(loc, hit_dir, species.get_blood_color(src))
 
-/mob/living/carbon/human/has_dexterity(var/dex_level)
-	. = check_dexterity(dex_level, silent = TRUE)
-
-/mob/living/carbon/human/check_dexterity(var/dex_level = DEXTERITY_FULL, var/silent, var/force_active_hand)
-	if(isnull(force_active_hand))
-		force_active_hand = get_active_held_item_slot()
-	var/obj/item/organ/external/active_hand = GET_EXTERNAL_ORGAN(src, force_active_hand)
-	var/dex_malus = 0
-	if(getBrainLoss() && getBrainLoss() > config.dex_malus_brainloss_threshold) ///brainloss shouldn't instantly cripple you, so the effects only start once past the threshold and escalate from there.
-		dex_malus = round(clamp(round(getBrainLoss()-config.dex_malus_brainloss_threshold)/10, DEXTERITY_NONE, DEXTERITY_FULL))
+/mob/living/carbon/human/get_dexterity(var/silent = FALSE)
+	var/check_slot = get_active_held_item_slot()
+	var/obj/item/organ/external/active_hand = check_slot && GET_EXTERNAL_ORGAN(src, check_slot)
 	if(!active_hand)
 		if(!silent)
-			to_chat(src, SPAN_WARNING("Your hand is missing!"))
-		return FALSE
+			to_chat(src, SPAN_WARNING("Your [check_slot ? parse_zone(check_slot) : "hand"] is missing!"))
+		return DEXTERITY_NONE
 	if(!active_hand.is_usable())
-		to_chat(src, SPAN_WARNING("Your [active_hand.name] is unusable!"))
-		return
-	if((active_hand.get_dexterity()-dex_malus) < dex_level)
-		if(!silent && !dex_malus)
-			to_chat(src, SPAN_WARNING("Your [active_hand.name] doesn't have the dexterity to use that!"))
-		else if(!silent)
-			to_chat(src, SPAN_WARNING("Your [active_hand.name] doesn't respond properly!"))
-		return FALSE
-	return TRUE
-
+		if(!silent)
+			to_chat(src, SPAN_WARNING("Your [active_hand.name] is unusable!"))
+		return DEXTERITY_NONE
+	var/dex_malus = 0
+	if(getBrainLoss() && getBrainLoss() > config.dex_malus_brainloss_threshold) ///brainloss shouldn't instantly cripple you, so the effects only start once past the threshold and escalate from there.
+		dex_malus = clamp(CEILING((getBrainLoss()-config.dex_malus_brainloss_threshold)/10), 0, length(global.dexterity_levels))
+		if(dex_malus > 0)
+			dex_malus = global.dexterity_levels[dex_malus]
+			if(!silent)
+				to_chat(src, SPAN_WARNING("Your [active_hand.name] doesn't respond properly!"))
+			return (active_hand.get_manual_dexterity() & ~dex_malus)
+	return active_hand.get_manual_dexterity()
 
 /mob/living/carbon/human/lose_hair()
 	if(species.set_default_hair(src))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1201,6 +1201,10 @@
 	var/check_slot = get_active_held_item_slot()
 	var/obj/item/organ/external/active_hand = check_slot && GET_EXTERNAL_ORGAN(src, check_slot)
 	if(!active_hand)
+		// todo: move dexterity onto inventory slot?
+		var/datum/inventory_slot/gripper/gripper = get_inventory_slot_datum(check_slot)
+		if(istype(gripper) && isnull(gripper.requires_organ_tag))
+			return species.get_manual_dexterity(src)
 		if(!silent)
 			to_chat(src, SPAN_WARNING("Your [check_slot ? parse_zone(check_slot) : "hand"] is missing!"))
 		return DEXTERITY_NONE

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -46,9 +46,6 @@
 	#define SEC_HUD 1 //Security HUD mode
 	#define MED_HUD 2 //Medical HUD mode
 
-/mob/living/silicon/has_dexterity(var/dex_level)
-	return dexterity >= dex_level
-
 /mob/living/silicon/Initialize()
 	global.silicon_mob_list += src
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -35,8 +35,8 @@
 	var/body_color //brown, gray and white, leave blank for random
 	var/splatted = FALSE
 
-/mob/living/simple_animal/mouse/check_dexterity(dex_level, silent)
-	return FALSE // Mice are troll bait, give them no power.
+/mob/living/simple_animal/mouse/get_dexterity(var/silent = FALSE)
+	return DEXTERITY_NONE // Mice are troll bait, give them no power.
 
 /mob/living/simple_animal/mouse/Life()
 	. = ..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1063,11 +1063,14 @@
 	return 1
 
 // Let simple mobs press buttons and levers but nothing more complex.
-/mob/proc/has_dexterity(var/dex_level)
-	. = dex_level <= DEXTERITY_SIMPLE_MACHINES
+/mob/proc/get_dexterity(var/silent = FALSE)
+	var/decl/species/my_species = get_species()
+	if(my_species)
+		return my_species.get_manual_dexterity()
+	return DEXTERITY_BASE
 
-/mob/proc/check_dexterity(var/dex_level, var/silent)
-	. = has_dexterity(dex_level)
+/mob/proc/check_dexterity(var/dex_level = DEXTERITY_FULL, var/silent = FALSE)
+	. = !!(get_dexterity(silent) & dex_level)
 	if(!. && !silent)
 		to_chat(src, FEEDBACK_YOU_LACK_DEXTERITY)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1070,7 +1070,7 @@
 	return DEXTERITY_BASE
 
 /mob/proc/check_dexterity(var/dex_level = DEXTERITY_FULL, var/silent = FALSE)
-	. = !!(get_dexterity(silent) & dex_level)
+	. = (get_dexterity(silent) & dex_level) == dex_level
 	if(!. && !silent)
 		to_chat(src, FEEDBACK_YOU_LACK_DEXTERITY)
 

--- a/code/modules/multiz/hoist.dm
+++ b/code/modules/multiz/hoist.dm
@@ -38,7 +38,7 @@
 	var/obj/structure/hoist/source_hoist
 
 /obj/effect/hoist_hook/attack_hand(mob/user)
-	if(user.incapacitated() || !user.check_dexterity(DEXTERITY_GRIP) || !source_hoist?.hoistee)
+	if(user.incapacitated() || !user.check_dexterity(DEXTERITY_HOLD_ITEM) || !source_hoist?.hoistee)
 		return ..()
 	source_hoist.check_consistency()
 	source_hoist.hoistee.forceMove(get_turf(src))
@@ -64,7 +64,7 @@
 		if (user.incapacitated())
 			to_chat(user, SPAN_WARNING("You can't do that while incapacitated."))
 			return
-		if (!user.check_dexterity(DEXTERITY_GRIP))
+		if (!user.check_dexterity(DEXTERITY_HOLD_ITEM))
 			return
 		source_hoist.attach_hoistee(AM)
 		user.visible_message(
@@ -87,7 +87,7 @@
 
 /obj/effect/hoist_hook/handle_mouse_drop(atom/over, mob/user)
 	if(source_hoist.hoistee && isturf(over) && over.Adjacent(source_hoist.hoistee))
-		if(!user.check_dexterity(DEXTERITY_GRIP))
+		if(!user.check_dexterity(DEXTERITY_HOLD_ITEM))
 			return TRUE
 
 		source_hoist.check_consistency()
@@ -182,7 +182,7 @@
 		source_hoist.break_hoist()
 
 /obj/structure/hoist/attack_hand(mob/user)
-	if (!ishuman(user) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if (!ishuman(user) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 
 	if (user.incapacitated())
@@ -242,7 +242,7 @@
 
 	if (isobserver(usr) || usr.incapacitated())
 		return
-	if (!usr.check_dexterity(DEXTERITY_GRIP))
+	if (!usr.check_dexterity(DEXTERITY_HOLD_ITEM))
 		return
 
 	if (hoistee)

--- a/code/modules/multiz/mobile_ladder.dm
+++ b/code/modules/multiz/mobile_ladder.dm
@@ -2,7 +2,7 @@
 	name = "mobile ladder"
 	desc = "A lightweight deployable ladder, which you can use to move up or down. Or alternatively, you can bash some faces in."
 	icon = 'icons/obj/mobile_ladder.dmi'
-	
+
 	material = /decl/material/solid/metal/steel
 	matter = list(/decl/material/solid/plastic = MATTER_AMOUNT_SECONDARY)
 	icon_state = ICON_STATE_WORLD
@@ -97,7 +97,7 @@
 			to_chat(user, SPAN_WARNING("You can't do that right now!"))
 			return
 
-		if(!user.check_dexterity(DEXTERITY_GRIP))
+		if(!user.check_dexterity(DEXTERITY_HOLD_ITEM))
 			return
 
 		user.visible_message(

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1253,7 +1253,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		return 1
 	return 0
 
-/obj/item/organ/external/proc/get_dexterity()
+/obj/item/organ/external/proc/get_manual_dexterity()
 	if(model)
 		var/decl/prosthetics_manufacturer/R = GET_DECL(model)
 		if(R)

--- a/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
+++ b/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
@@ -14,7 +14,7 @@
 	var/list/allowed_bodytypes                                    // Determines which bodytypes can apply the limb.
 	var/modifier_string = "robotic"                               // Used to alter the name of the limb.
 	var/hardiness = 1                                             // Modifies min and max broken damage for the limb.
-	var/manual_dexterity = DEXTERITY_FULL                         // For hands, determines the dexterity value passed to get_dexterity().
+	var/manual_dexterity = DEXTERITY_FULL                         // For hands, determines the dexterity value passed to get_manual_dexterity().
 	var/movement_slowdown = 0                                     // Applies a slowdown value to this limb.
 	var/is_robotic = TRUE                                         // Determines if EMP damage is applied to this prosthetic.
 	var/modular_prosthetic_tier = MODULAR_BODYPART_INVALID        // Determines how the limb behaves as a prosthetic with regards to manual attachment/detachment.

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -33,7 +33,7 @@
 	if(!CanPhysicallyInteract(user))
 		return FALSE
 
-	if(user.a_intent == I_HURT || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(user.a_intent == I_HURT || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 
 	if(LAZYLEN(papers) < 1 && amount < 1)

--- a/code/modules/paperwork/printer.dm
+++ b/code/modules/paperwork/printer.dm
@@ -73,7 +73,7 @@
 	. = ..()
 
 /obj/item/stock_parts/printer/attack_hand(mob/user)
-	if(toner && istype(loc, /obj/machinery) && user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(toner && istype(loc, /obj/machinery) && user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return remove_toner(user)
 	return ..()
 

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -196,7 +196,7 @@
 
 
 /obj/item/ammo_magazine/attack_hand(mob/user)
-	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	if(!stored_ammo.len)
 		to_chat(user, SPAN_NOTICE("\The [src] is already empty!"))

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -62,7 +62,7 @@
 		overlays += I
 
 /obj/item/ammo_magazine/shotholder/attack_hand(mob/user)
-	if(loc != user || user.a_intent != I_HURT || !length(stored_ammo) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(loc != user || user.a_intent != I_HURT || !length(stored_ammo) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	var/obj/item/ammo_casing/C = stored_ammo[stored_ammo.len]
 	stored_ammo -= C

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -145,7 +145,7 @@ var/global/list/registered_cyborg_weapons = list()
 
 //For removable cells.
 /obj/item/gun/energy/attack_hand(mob/user)
-	if(!user.is_holding_offhand(src) || isnull(accepts_cell_type) || isnull(power_supply) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.is_holding_offhand(src) || isnull(accepts_cell_type) || isnull(power_supply) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	user.put_in_hands(power_supply)
 	power_supply = null

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -85,7 +85,7 @@
 		..()
 
 /obj/item/gun/launcher/grenade/attack_hand(mob/user)
-	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	unload(user)
 	return TRUE

--- a/code/modules/projectiles/guns/launcher/money_cannon.dm
+++ b/code/modules/projectiles/guns/launcher/money_cannon.dm
@@ -106,7 +106,7 @@
 	to_chat(user, "<span class='notice'>You set [src] to dispense [dispensing] [cur.name_singular] at a time.</span>")
 
 /obj/item/gun/launcher/money/attack_hand(mob/user)
-	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	unload_receptacle(user)
 	return TRUE

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -60,7 +60,7 @@
 		to_chat(user, "There is nothing to remove in \the [src].")
 
 /obj/item/gun/launcher/pneumatic/attack_hand(mob/user)
-	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	unload_hopper(user)
 	return TRUE

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -103,7 +103,7 @@
 	add_fingerprint(user)
 
 /obj/item/gun/launcher/syringe/attack_hand(mob/user)
-	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	if(!darts.len)
 		to_chat(user, SPAN_WARNING("\The [src] is empty."))

--- a/code/modules/projectiles/guns/magnetic/magnetic.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic.dm
@@ -190,7 +190,7 @@
 	. = ..()
 
 /obj/item/gun/magnetic/attack_hand(var/mob/user)
-	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	var/obj/item/removing
 	if(loaded)

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -225,7 +225,7 @@
 		to_chat(user, SPAN_WARNING("You can't unload \the [src] manually. Maybe try a crowbar?"))
 
 /obj/item/gun/projectile/attack_hand(mob/user)
-	if(!user.is_holding_offhand(src) || !manual_unload || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.is_holding_offhand(src) || !manual_unload || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	unload_ammo(user, allow_dump=0)
 	return TRUE

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -105,7 +105,7 @@
 		..()
 
 /obj/item/gun/projectile/automatic/assault_rifle/grenade/attack_hand(mob/user)
-	if(!user.is_holding_offhand(src) || !use_launcher || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.is_holding_offhand(src) || !use_launcher || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	launcher.unload(user)
 	return TRUE

--- a/code/modules/reagents/reagent_containers/drinkingglass/extras.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/extras.dm
@@ -26,7 +26,7 @@
 		return ..()
 
 /obj/item/chems/drinks/glass2/attack_hand(mob/user)
-	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 
 	if(!extras.len)

--- a/code/modules/reagents/reagent_containers/food/sliceable/pizza.dm
+++ b/code/modules/reagents/reagent_containers/food/sliceable/pizza.dm
@@ -189,14 +189,14 @@
 /obj/item/pizzabox/attack_hand(mob/user)
 
 	if(open && pizza)
-		if(user.check_dexterity(DEXTERITY_GRIP))
+		if(user.check_dexterity(DEXTERITY_HOLD_ITEM))
 			user.put_in_hands(pizza)
 			to_chat(user, SPAN_NOTICE("You take \the [src.pizza] out of \the [src]."))
 			pizza = null
 			update_icon()
 		return TRUE
 
-	if(length(boxes) && user.is_holding_offhand(src) && user.check_dexterity(DEXTERITY_GRIP))
+	if(length(boxes) && user.is_holding_offhand(src) && user.check_dexterity(DEXTERITY_HOLD_ITEM))
 		var/obj/item/pizzabox/box = boxes[boxes.len]
 		boxes -= box
 		user.put_in_hands(box)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -142,7 +142,7 @@
 	return TRUE
 
 /obj/item/chems/hypospray/vial/attack_hand(mob/user)
-	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	if(!loaded_vial)
 		to_chat(user, SPAN_NOTICE("There is no vial loaded in \the [src]."))

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -159,7 +159,7 @@
 		to_chat(user, SPAN_WARNING("There is some kind of device rigged to the tank."))
 
 /obj/structure/reagent_dispensers/fueltank/attack_hand(var/mob/user)
-	if (!rig || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if (!rig || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	visible_message(SPAN_NOTICE("\The [user] begins to detach \the [rig] from \the [src]."))
 	if(!user.do_skilled(2 SECONDS, SKILL_ELECTRICAL, src))
@@ -251,7 +251,7 @@
 	reagents.add_reagent(/decl/material/liquid/water, reagents.maximum_volume)
 
 /obj/structure/reagent_dispensers/water_cooler/attack_hand(var/mob/user)
-	if(user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return dispense_cup(user)
 	return ..()
 

--- a/code/modules/sealant_gun/sealant_gun.dm
+++ b/code/modules/sealant_gun/sealant_gun.dm
@@ -46,7 +46,7 @@
 	. = ..()
 
 /obj/item/gun/launcher/sealant/attack_hand(mob/user)
-	if(!(src in user.get_held_items()) || !loaded_tank || !user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!(src in user.get_held_items()) || !loaded_tank || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	unload_tank(user)
 	return TRUE

--- a/code/modules/sealant_gun/sealant_injector.dm
+++ b/code/modules/sealant_gun/sealant_injector.dm
@@ -79,7 +79,7 @@
 		playsound(loc, 'sound/effects/refill.ogg', 50, 1)
 
 /obj/structure/sealant_injector/attack_hand(mob/user)
-	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	if(loaded_tank)
 		loaded_tank.dropInto(get_turf(src))

--- a/code/modules/sealant_gun/sealant_rack.dm
+++ b/code/modules/sealant_gun/sealant_rack.dm
@@ -27,7 +27,7 @@
 		add_overlay("tanks[length(tanks)]")
 
 /obj/structure/sealant_rack/attack_hand(mob/user)
-	if(!user.check_dexterity(DEXTERITY_GRIP, TRUE))
+	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	if(loaded_gun)
 		loaded_gun.dropInto(loc)

--- a/mods/mobs/dionaea/mob/_nymph.dm
+++ b/mods/mobs/dionaea/mob/_nymph.dm
@@ -85,6 +85,3 @@
 	var/datum/extension/hattable/hattable = get_extension(src, /datum/extension/hattable)
 	if(hattable?.hat)
 		to_chat(user, SPAN_NOTICE("It is wearing [html_icon(hattable.hat)] \a [hattable.hat]."))
-
-/mob/living/carbon/alien/diona/has_dexterity()
-	return FALSE

--- a/mods/mobs/dionaea/mob/_nymph.dm
+++ b/mods/mobs/dionaea/mob/_nymph.dm
@@ -85,3 +85,6 @@
 	var/datum/extension/hattable/hattable = get_extension(src, /datum/extension/hattable)
 	if(hattable?.hat)
 		to_chat(user, SPAN_NOTICE("It is wearing [html_icon(hattable.hat)] \a [hattable.hat]."))
+
+/mob/living/carbon/alien/diona/get_dexterity(var/silent = FALSE)
+	return DEXTERITY_NONE

--- a/mods/species/ascent/mobs/bodyparts_insectoid.dm
+++ b/mods/species/ascent/mobs/bodyparts_insectoid.dm
@@ -66,10 +66,8 @@
 	organ_tag = BP_L_HAND_UPPER
 	gripper_type = /datum/inventory_slot/gripper/upper_left_hand
 
-/obj/item/organ/external/hand/insectoid/upper/get_dexterity()
-	. = DEXTERITY_GRIP
-	if(model)
-		. = min(., ..())
+/obj/item/organ/external/hand/insectoid/upper/get_manual_dexterity()
+	return (..() & ~(DEXTERITY_WEAPONS|DEXTERITY_COMPLEX_TOOLS))
 
 /obj/item/organ/external/hand/right/insectoid
 	name = "right grasper"
@@ -90,10 +88,8 @@
 	organ_tag = BP_R_HAND_UPPER
 	gripper_type = /datum/inventory_slot/gripper/upper_right_hand
 
-/obj/item/organ/external/hand/right/insectoid/upper/get_dexterity()
-	. = DEXTERITY_GRIP
-	if(model)
-		. = min(., ..())
+/obj/item/organ/external/hand/right/insectoid/upper/get_manual_dexterity()
+	return (..() & ~(DEXTERITY_WEAPONS|DEXTERITY_COMPLEX_TOOLS))
 
 /obj/item/organ/external/groin/insectoid
 	name = "abdomen"

--- a/mods/species/ascent/mobs/nymph/_nymph.dm
+++ b/mods/species/ascent/mobs/nymph/_nymph.dm
@@ -58,9 +58,6 @@
 	if(holding_item)
 		to_chat(user, SPAN_NOTICE("It is holding \icon[holding_item] \a [holding_item]."))
 
-/mob/living/carbon/alien/ascent_nymph/has_dexterity()
-	return FALSE
-
 /mob/living/carbon/alien/ascent_nymph/death(gibbed)
 	if(holding_item)
 		try_unequip(holding_item)

--- a/mods/species/ascent/mobs/nymph/_nymph.dm
+++ b/mods/species/ascent/mobs/nymph/_nymph.dm
@@ -58,6 +58,9 @@
 	if(holding_item)
 		to_chat(user, SPAN_NOTICE("It is holding \icon[holding_item] \a [holding_item]."))
 
+/mob/living/carbon/alien/ascent_nymph/get_dexterity(var/silent = FALSE)
+	return DEXTERITY_NONE
+
 /mob/living/carbon/alien/ascent_nymph/death(gibbed)
 	if(holding_item)
 		try_unequip(holding_item)


### PR DESCRIPTION
## Description of changes
- Cleans up some dexterity checking infrastructure.
- Switches dexterity to use bitflags instead of a linear value comparison.
- Adds a check to shower curtains so mice can't close or open them.
 
## Why and what will this PR improve
Makes it much easier to handle mob inventory and equipment without having to juggle linear dexterity values.

## Authorship
Myself.

## Changelog
Hopefully nothing player-facing.