### PR TITLE
Tweaking turf air stuff.

### DIFF
--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -17,11 +17,6 @@
 	///If this turf is on a level that belongs to a planetoid, this is a reference to that planetoid.
 	var/datum/planetoid_data/owner
 
-// Bit faster than return_air() for exoplanet exterior turfs
-/turf/exterior/get_air_graphic()
-	var/datum/level_data/level = SSmapping.levels_by_z[z]
-	return level?.exterior_atmosphere?.graphic
-
 /turf/exterior/Initialize(mapload, no_update_icon = FALSE)
 
 	if(base_color)
@@ -47,10 +42,6 @@
 			ChangeArea(src, L.get_base_area_instance())
 
 	. = ..(mapload)	// second param is our own, don't pass to children
-
-	var/air_graphic = get_air_graphic()
-	if(length(air_graphic))
-		add_vis_contents(src, air_graphic)
 
 	if (no_update_icon)
 		return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -494,6 +494,11 @@
 	return TRUE
 
 /turf/proc/get_air_graphic()
+	if(zone && !zone.invalid)
+		return zone.air?.graphic
+	if(external_atmosphere_participation && is_outside())
+		var/datum/level_data/level = SSmapping.levels_by_z[z]
+		return level.exterior_atmosphere.graphic
 	var/datum/gas_mixture/environment = return_air()
 	return environment?.graphic
 

--- a/code/modules/ZAS/Turf.dm
+++ b/code/modules/ZAS/Turf.dm
@@ -4,12 +4,6 @@
 /turf/var/tmp/verbose = FALSE
 #endif
 
-/turf/proc/update_graphic(list/graphic_add = null, list/graphic_remove = null)
-	if(graphic_add && graphic_add.len)
-		add_vis_contents(src, graphic_add)
-	if(graphic_remove && graphic_remove.len)
-		remove_vis_contents(src, graphic_remove)
-
 /turf/proc/update_air_properties()
 
 	if(zone?.invalid) //this turf's zone is in the process of being rebuilt

--- a/code/modules/ZAS/Turf.dm
+++ b/code/modules/ZAS/Turf.dm
@@ -230,14 +230,12 @@
 	if((!air && isnull(initial_gas)) || (external_atmosphere_participation && is_outside()))
 		var/datum/level_data/level = SSmapping.levels_by_z[z]
 		var/datum/gas_mixture/gas = level.get_exterior_atmosphere()
-		var/initial_temperature = gas.temperature
-		if(weather)
-			initial_temperature = weather.adjust_temperature(initial_temperature)
-		for(var/thing in affecting_heat_sources)
-			if((gas.temperature - initial_temperature) >= 100)
-				break
-			var/obj/structure/fire_source/heat_source = thing
-			gas.temperature = gas.temperature + heat_source.exterior_temperature / max(1, get_dist(src, get_turf(heat_source)))
+		var/initial_temperature = weather ? weather.adjust_temperature(gas.temperature) : gas.temperature
+		if(length(affecting_heat_sources))
+			for(var/obj/structure/fire_source/heat_source as anything in affecting_heat_sources)
+				gas.temperature = gas.temperature + heat_source.exterior_temperature / max(1, get_dist(src, get_turf(heat_source)))
+				if(abs(gas.temperature - initial_temperature) >= 100)
+					break
 		return gas
 
 	// Base behavior

--- a/code/modules/ZAS/Zone.dm
+++ b/code/modules/ZAS/Zone.dm
@@ -74,7 +74,7 @@ Class Procs:
 	if(T.fire)
 		fire_tiles.Add(T)
 		SSair.active_fire_zones |= src
-	T.update_graphic(air.graphic)
+	T.refresh_vis_contents()
 
 /zone/proc/remove(turf/T)
 #ifdef ZASDBG
@@ -87,7 +87,7 @@ Class Procs:
 	contents.Remove(T)
 	fire_tiles.Remove(T)
 	T.zone = null
-	T.update_graphic(graphic_remove = air.graphic)
+	T.refresh_vis_contents()
 	if(contents.len)
 		air.group_multiplier = contents.len
 	else
@@ -105,7 +105,7 @@ Class Procs:
 		if(!T.zone_membership_candidate)
 			continue
 		into.add(T)
-		T.update_graphic(graphic_remove = air.graphic)
+		T.refresh_vis_contents()
 		#ifdef ZASDBG
 		T.dbg(zasdbgovl_merged)
 		#endif
@@ -130,7 +130,7 @@ Class Procs:
 	if(invalid) return //Short circuit for explosions where rebuild is called many times over.
 	c_invalidate()
 	for(var/turf/T as anything in contents)
-		T.update_graphic(graphic_remove = air.graphic) //we need to remove the overlays so they're not doubled when the zone is rebuilt
+		T.refresh_vis_contents()
 		T.needs_air_update = 0 //Reset the marker so that it will be added to the list.
 		SSair.mark_for_update(T)
 		CHECK_TICK
@@ -154,7 +154,7 @@ Class Procs:
 	// Update gas overlays.
 	if(air.check_tile_graphic(graphic_add, graphic_remove))
 		for(var/turf/T as anything in contents)
-			T.update_graphic(graphic_add, graphic_remove)
+			T.refresh_vis_contents()
 			CHECK_TICK
 		graphic_add.len = 0
 		graphic_remove.len = 0


### PR DESCRIPTION
- Exterior turfs no longer duplicate gas overlays.
- Base turf get_air_graphic() how handles both zones and exterior.
- Exterior temperature change somewhat optimized.

Cheers to @out-of-phaze for these.