### PR TITLE
Generalizing stasis and life_tick to /mob/living.

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -139,9 +139,8 @@
 		else
 			toggle_lavage()
 
-
-	if(iscarbon(occupant) && stasis > 1)
-		occupant.SetStasis(stasis)
+	if(isliving(occupant) && stasis > 1)
+		occupant.set_stasis(stasis)
 
 /obj/machinery/sleeper/on_update_icon()
 	cut_overlays()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -154,7 +154,7 @@
 	var/allow_occupant_types = list(/mob/living/carbon/human)
 	var/disallow_occupant_types = list()
 
-	var/mob/occupant = null       // Person waiting to be despawned.
+	var/mob/living/occupant       // Person waiting to be despawned.
 	var/time_till_despawn = 9000  // Down to 15 minutes //30 minutes-ish is too long
 	var/time_entered = 0          // Used to keep track of the safe period.
 
@@ -291,9 +291,8 @@
 //Lifted from Unity stasis.dm and refactored.
 /obj/machinery/cryopod/Process()
 	if(occupant)
-		if(applies_stasis && isliving(occupant) && (world.time > time_entered + 20 SECONDS))
-			var/mob/living/patient = occupant
-			patient.set_stasis(2)
+		if(applies_stasis && (world.time > time_entered + 20 SECONDS))
+			occupant.set_stasis(2)
 
 		//Allow a ten minute gap between entering the pod and actually despawning.
 		// Only provide the gap if the occupant hasn't ghosted

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -291,9 +291,9 @@
 //Lifted from Unity stasis.dm and refactored.
 /obj/machinery/cryopod/Process()
 	if(occupant)
-		if(applies_stasis && iscarbon(occupant) && (world.time > time_entered + 20 SECONDS))
-			var/mob/living/carbon/C = occupant
-			C.SetStasis(2)
+		if(applies_stasis && isliving(occupant) && (world.time > time_entered + 20 SECONDS))
+			var/mob/living/patient = occupant
+			patient.set_stasis(2)
 
 		//Allow a ten minute gap between entering the pod and actually despawning.
 		// Only provide the gap if the occupant hasn't ghosted

--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -29,7 +29,7 @@
 	if(!istype(H))
 		. = 0
 		CRASH("Someone gave [user.type] a [src.type] aura. This is invalid.")
-	if(!innate_heal || H.InStasis() || H.stat == DEAD)
+	if(!innate_heal || H.is_in_stasis() || H.stat == DEAD)
 		return 0
 	if(H.nutrition < nutrition_damage_mult)
 		low_nut_warning()

--- a/code/game/objects/items/cryobag.dm
+++ b/code/game/objects/items/cryobag.dm
@@ -83,8 +83,8 @@
 /obj/structure/closet/body_bag/cryobag/Process()
 	if(stasis_power < 2)
 		return PROCESS_KILL
-	var/mob/living/carbon/human/H = locate() in src
-	if(!H)
+	var/mob/living/patient = locate() in src
+	if(!patient)
 		return PROCESS_KILL
 	degradation_time--
 	if(degradation_time < 0)
@@ -93,8 +93,8 @@
 		animate(src, color = color_matrix_saturation(get_saturation()), time = 10)
 		update_icon()
 
-	if(H.stasis_sources[STASIS_CRYOBAG] != stasis_power)
-		H.SetStasis(stasis_power, STASIS_CRYOBAG)
+	if(LAZYACCESS(patient.stasis_sources, STASIS_CRYOBAG) != stasis_power)
+		patient.set_stasis(stasis_power, STASIS_CRYOBAG)
 
 /obj/structure/closet/body_bag/cryobag/return_air() //Used to make stasis bags protect from vacuum.
 	if(airtank)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -319,25 +319,6 @@
 	// overridden in human_defense.dm
 	return null
 
-/mob/living/carbon/proc/SetStasis(var/factor, var/source = "misc")
-	if((species && (species.species_flags & SPECIES_FLAG_NO_SCAN)) || isSynthetic())
-		return
-	stasis_sources[source] = factor
-
-/mob/living/carbon/proc/InStasis()
-	if(!stasis_value)
-		return FALSE
-	return life_tick % stasis_value
-
-// call only once per run of life
-/mob/living/carbon/proc/UpdateStasis()
-	stasis_value = 0
-	if((species && (species.species_flags & SPECIES_FLAG_NO_SCAN)) || isSynthetic())
-		return
-	for(var/source in stasis_sources)
-		stasis_value += stasis_sources[source]
-	stasis_sources.Cut()
-
 /mob/living/carbon/get_max_nutrition()
 	return 400
 

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -2,8 +2,6 @@
 	gender = MALE
 	abstract_type = /mob/living/carbon
 
-	var/life_tick = 0      // The amount of life ticks that have processed on this mob.
-
 	//Surgery info
 	//Active emote/pose
 	var/pose = null
@@ -35,8 +33,5 @@
 	var/list/organs_by_tag
 	var/tmp/list/internal_organs
 	var/tmp/list/external_organs
-
-	var/list/stasis_sources = list()
-	var/stasis_value
 
 	var/player_triggered_sleeping = 0

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -141,25 +141,6 @@
 		if(HEAT_LEVEL_3)
 			return isSynthetic()? SYNTH_HEAT_LEVEL_3 : species.heat_level_3
 
-/mob/living/carbon/human/proc/getCryogenicFactor(var/bodytemperature)
-	if(isSynthetic())
-		return 0
-	if(!species)
-		return 0
-
-	if(bodytemperature > species.cold_level_1)
-		return 0
-	else if(bodytemperature > species.cold_level_2)
-		. = 5 * (1 - (bodytemperature - species.cold_level_2) / (species.cold_level_1 - species.cold_level_2))
-		. = max(2, .)
-	else if(bodytemperature > species.cold_level_3)
-		. = 20 * (1 - (bodytemperature - species.cold_level_3) / (species.cold_level_2 - species.cold_level_3))
-		. = max(5, .)
-	else
-		. = 80 * (1 - bodytemperature / species.cold_level_3)
-		. = max(20, .)
-	return round(.)
-
 /mob/living/carbon/human
 	var/next_sonar_ping = 0
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -47,10 +47,6 @@
 
 	fire_alert = 0 //Reset this here, because both breathe() and handle_environment() have a chance to set it.
 
-	//TODO: seperate this out
-	// update the current life tick, can be used to e.g. only do something every 4 ticks
-	life_tick++
-
 	// This is not an ideal place for this but it will do for now.
 	if(wearing_rig && wearing_rig.offline)
 		wearing_rig = null
@@ -63,7 +59,7 @@
 	voice = GetVoice()
 
 	//No need to update all of these procs if the guy is dead.
-	if(stat != DEAD && !InStasis())
+	if(stat != DEAD && !is_in_stasis())
 		//Updates the number of stored chemicals for powers
 		handle_changeling()
 
@@ -114,11 +110,6 @@
 	if(client && client.is_afk())
 		if(old_stat == UNCONSCIOUS && stat == CONSCIOUS)
 			playsound_local(null, 'sound/effects/bells.ogg', 100, is_global=TRUE)
-
-/mob/living/carbon/human/proc/handle_some_updates()
-	if(life_tick > 5 && timeofdeath && (timeofdeath < 5 || world.time - timeofdeath > 6000))	//We are long dead, or we're junk mobs spawned like the clowns on the clown shuttle
-		return 0
-	return 1
 
 /mob/living/carbon/human/breathe()
 	var/species_organ = species.breathing_organ
@@ -398,7 +389,7 @@
 			burn_dam = COLD_DAMAGE_LEVEL_2
 		else
 			burn_dam = COLD_DAMAGE_LEVEL_3
-		SetStasis(getCryogenicFactor(bodytemperature), STASIS_COLD)
+		set_stasis(get_cryogenic_factor(bodytemperature), STASIS_COLD)
 		if(!has_chemical_effect(CE_CRYO, 1))
 			take_overall_damage(burn=burn_dam, used_weapon = "Low Body Temperature")
 			fire_alert = max(fire_alert, 1)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -2,13 +2,11 @@
 	if(!..())
 		return
 
-	UpdateStasis()
-
 	// Increase germ_level regularly
 	if(germ_level < GERM_LEVEL_AMBIENT && prob(30))	//if you're just standing there, you shouldn't get more germs beyond an ambient level
 		germ_level++
 
-	if(stat != DEAD && !InStasis())
+	if(stat != DEAD && !is_in_stasis())
 		//Breathing, if applicable
 		handle_breathing()
 

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -6,7 +6,13 @@
 
 	if (HasMovementHandler(/datum/movement_handler/mob/transformation/))
 		return
-	if (!loc)
+
+	// update the current life tick, can be used to e.g. only do something every 4 ticks
+	// This is handled before the loc check as unit tests use this to delay until the mob
+	// has processed a few times. Not really sure why but heigh ho.
+	life_tick++
+
+	if(!loc)
 		return
 
 	if(machine && (machine.CanUseTopic(src, machine.DefaultTopicState()) == STATUS_CLOSE)) // unsure if this is a good idea, but using canmousedrop was ???
@@ -21,6 +27,7 @@
 	blinded = 0 // Placing this here just show how out of place it is.
 	// human/handle_regular_status_updates() needs a cleanup, as blindness should be handled in handle_disabilities()
 	handle_regular_status_updates() // Status & health update, are we dead or alive etc.
+	handle_stasis()
 
 	if(stat != DEAD)
 		aura_check(AURA_TYPE_LIFE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1113,3 +1113,8 @@ default behaviour is:
 
 /mob/living/proc/get_seconds_until_next_special_ability_string()
 	return ticks2readable(next_special_ability - world.time)
+
+/mob/living/proc/handle_some_updates()
+	//We are long dead, or we're junk mobs spawned like the clowns on the clown shuttle
+	return life_tick <= 5 || !timeofdeath || (timeofdeath >= 5 && (world.time-timeofdeath) <= 10 MINUTES)
+

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -52,3 +52,7 @@
 	var/stress = 0
 	var/currently_updating_stress = FALSE
 	var/list/stressors
+
+	var/life_tick
+	var/list/stasis_sources
+	var/stasis_value

--- a/code/modules/mob/living/stasis.dm
+++ b/code/modules/mob/living/stasis.dm
@@ -1,0 +1,40 @@
+/mob/living/proc/set_stasis(var/factor, var/source = "misc")
+	var/decl/species/my_species = get_species()
+	if((my_species?.species_flags & SPECIES_FLAG_NO_SCAN) || isSynthetic())
+		return
+	LAZYSET(stasis_sources, source, factor)
+
+/mob/living/proc/is_in_stasis()
+	return stasis_value ? !!(life_tick % stasis_value) : FALSE
+
+/mob/living/proc/handle_stasis()
+	stasis_value = 0
+	if(stasis_sources)
+		var/decl/species/my_species = get_species()
+		if(!(my_species?.species_flags & SPECIES_FLAG_NO_SCAN) && !isSynthetic())
+			for(var/source in stasis_sources)
+				stasis_value += stasis_sources[source]
+		stasis_sources = null
+
+/mob/living/proc/get_cryogenic_factor(var/bodytemperature)
+
+	if(isSynthetic())
+		return 0
+
+	var/decl/species/my_species = get_species()
+	var/cold_1 = my_species ? my_species.cold_level_1 : 243
+	var/cold_2 = my_species ? my_species.cold_level_2 : 200
+	var/cold_3 = my_species ? my_species.cold_level_3 : 120
+
+	if(bodytemperature > cold_1)
+		return 0
+	if(bodytemperature > cold_2)
+		. = 5 * (1 - (bodytemperature - cold_2) / (cold_1 - cold_2))
+		. = max(2, .)
+	else if(bodytemperature > cold_3)
+		. = 20 * (1 - (bodytemperature - cold_3) / (cold_2 - cold_3))
+		. = max(5, .)
+	else
+		. = 80 * (1 - bodytemperature / cold_3)
+		. = max(20, .)
+	return round(.)

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -113,7 +113,7 @@
 		return
 
 	//Dead or cryosleep people do not pump the blood.
-	if(!owner || owner.InStasis() || owner.stat == DEAD || owner.bodytemperature < 170)
+	if(!owner || owner.is_in_stasis() || owner.stat == DEAD || owner.bodytemperature < 170)
 		return
 
 	if(pulse != PULSE_NONE || BP_IS_PROSTHETIC(src))

--- a/nebula.dme
+++ b/nebula.dme
@@ -2351,6 +2351,7 @@
 #include "code\modules\mob\living\login.dm"
 #include "code\modules\mob\living\logout.dm"
 #include "code\modules\mob\living\say.dm"
+#include "code\modules\mob\living\stasis.dm"
 #include "code\modules\mob\living\stress.dm"
 #include "code\modules\mob\living\bot\bot.dm"
 #include "code\modules\mob\living\bot\cleanbot.dm"


### PR DESCRIPTION
## Description of changes
- Moves stasis procs and vars to /mob/living and renames them.
- Moves life_tick incrementing and checking to /mob/living.

## Why and what will this PR improve
Working towards killing /carbon. Also allows for the condensing/collapsing of Life() down the track.

## Authorship
Myself.

## Changelog
Nothing player-facing.