### PR TITLE
Moving temperature thresholds into a helper proc.

### DIFF
--- a/code/game/gamemodes/cult/ghosts.dm
+++ b/code/game/gamemodes/cult/ghosts.dm
@@ -246,8 +246,9 @@
 		return
 
 	to_chat(choice, "<span class='danger'>You feel as if something cold passed through you!</span>")
-	if(choice.bodytemperature >= choice.species.cold_level_1 + 1)
-		choice.bodytemperature = max(choice.species.cold_level_1 + 1, choice.bodytemperature - 30)
+	var/temp_threshold = choice.get_temperature_threshold(COLD_LEVEL_1)
+	if(choice.bodytemperature >= temp_threshold + 1)
+		choice.bodytemperature = max(temp_threshold + 1, choice.bodytemperature - 30)
 	to_chat(src, "<span class='notice'>You pass through \the [choice], giving them a sudden chill.</span>")
 
 	log_and_message_admins("used ghost magic to chill \the [choice] - [x]-[y]-[z]")

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -335,9 +335,9 @@ var/global/list/hygiene_props = list()
 	M.bodytemperature += temp_adj
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(water_temperature >= H.species.heat_level_1)
+		if(water_temperature >= H.get_temperature_threshold(HEAT_LEVEL_1))
 			to_chat(H, SPAN_DANGER("The water is searing hot!"))
-		else if(water_temperature <= H.species.cold_level_1)
+		else if(water_temperature <= H.get_temperature_threshold(COLD_LEVEL_1))
 			to_chat(H, SPAN_DANGER("The water is freezing cold!"))
 
 /obj/item/bikehorn/rubberducky

--- a/code/modules/atmospherics/he_pipes.dm
+++ b/code/modules/atmospherics/he_pipes.dm
@@ -79,7 +79,7 @@
 
 			var/mob/living/carbon/human/H = buckled_mob
 			if(istype(H) && H.species)
-				heat_limit = H.species.heat_level_3
+				heat_limit = H.get_temperature_threshold(HEAT_LEVEL_3)
 
 			if(pipe_air.temperature > heat_limit + 1)
 				buckled_mob.apply_damage(4 * log(pipe_air.temperature - heat_limit), BURN, BP_CHEST, used_weapon = "Excessive Heat")

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -123,24 +123,6 @@
 	if(wearing_rig && wearing_rig.update_visible_name)
 		wearing_rig.visible_name = real_name
 
-
-//Get species or synthetic temp if the mob is a FBP. Used when a synthetic type human mob is exposed to a temp check.
-//Essentially, used when a synthetic human mob should act diffferently than a normal type mob.
-/mob/living/carbon/human/proc/getSpeciesOrSynthTemp(var/temptype)
-	switch(temptype)
-		if(COLD_LEVEL_1)
-			return isSynthetic()? SYNTH_COLD_LEVEL_1 : species.cold_level_1
-		if(COLD_LEVEL_2)
-			return isSynthetic()? SYNTH_COLD_LEVEL_2 : species.cold_level_2
-		if(COLD_LEVEL_3)
-			return isSynthetic()? SYNTH_COLD_LEVEL_3 : species.cold_level_3
-		if(HEAT_LEVEL_1)
-			return isSynthetic()? SYNTH_HEAT_LEVEL_1 : species.heat_level_1
-		if(HEAT_LEVEL_2)
-			return isSynthetic()? SYNTH_HEAT_LEVEL_2 : species.heat_level_2
-		if(HEAT_LEVEL_3)
-			return isSynthetic()? SYNTH_HEAT_LEVEL_3 : species.heat_level_3
-
 /mob/living/carbon/human
 	var/next_sonar_ping = 0
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1114,7 +1114,30 @@ default behaviour is:
 /mob/living/proc/get_seconds_until_next_special_ability_string()
 	return ticks2readable(next_special_ability - world.time)
 
+//Get species or synthetic temp if the mob is a FBP/robot. Used when a synthetic mob is exposed to a temp check.
+//Essentially, used when a synthetic mob should act diffferently than a normal type mob.
+/mob/living/get_temperature_threshold(var/threshold)
+	if(isSynthetic())
+		switch(threshold)
+			if(COLD_LEVEL_1)
+				return SYNTH_COLD_LEVEL_1
+			if(COLD_LEVEL_2)
+				return SYNTH_COLD_LEVEL_2
+			if(COLD_LEVEL_3)
+				return SYNTH_COLD_LEVEL_3
+			if(HEAT_LEVEL_1)
+				return SYNTH_HEAT_LEVEL_1
+			if(HEAT_LEVEL_2)
+				return SYNTH_HEAT_LEVEL_2
+			if(HEAT_LEVEL_3)
+				return SYNTH_HEAT_LEVEL_3
+			else
+				CRASH("synthetic get_temperature_threshold() called with invalid threshold value.")
+	var/decl/species/my_species = get_species()
+	if(my_species)
+		return my_species.get_species_temperature_threshold(threshold)
+	return ..()
+
 /mob/living/proc/handle_some_updates()
 	//We are long dead, or we're junk mobs spawned like the clowns on the clown shuttle
 	return life_tick <= 5 || !timeofdeath || (timeofdeath >= 5 && (world.time-timeofdeath) <= 10 MINUTES)
-

--- a/code/modules/mob/living/stasis.dm
+++ b/code/modules/mob/living/stasis.dm
@@ -21,10 +21,9 @@
 	if(isSynthetic())
 		return 0
 
-	var/decl/species/my_species = get_species()
-	var/cold_1 = my_species ? my_species.cold_level_1 : 243
-	var/cold_2 = my_species ? my_species.cold_level_2 : 200
-	var/cold_3 = my_species ? my_species.cold_level_3 : 120
+	var/cold_1 = get_temperature_threshold(COLD_LEVEL_1)
+	var/cold_2 = get_temperature_threshold(COLD_LEVEL_2)
+	var/cold_3 = get_temperature_threshold(COLD_LEVEL_3)
 
 	if(bodytemperature > cold_1)
 		return 0

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1320,3 +1320,20 @@
 
 /mob/proc/get_target_zone()
 	return zone_sel?.selecting
+
+/mob/proc/get_temperature_threshold(var/threshold)
+	switch(threshold)
+		if(COLD_LEVEL_1)
+			return 243
+		if(COLD_LEVEL_2)
+			return 200
+		if(COLD_LEVEL_3)
+			return 120
+		if(HEAT_LEVEL_1)
+			return 360
+		if(HEAT_LEVEL_2)
+			return 400
+		if(HEAT_LEVEL_3)
+			return 1000
+		else
+			CRASH("base get_temperature_threshold() called with invalid threshold value.")

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -271,14 +271,16 @@
 
 /obj/item/organ/internal/lungs/proc/handle_temperature_effects(datum/gas_mixture/breath)
 	// Hot air hurts :(
-	if((breath.temperature < species.cold_level_1 || breath.temperature > species.heat_level_1) && !(MUTATION_COLD_RESISTANCE in owner.mutations))
+	var/cold_1 = species.get_species_temperature_threshold(COLD_LEVEL_1)
+	var/heat_1 = species.get_species_temperature_threshold(HEAT_LEVEL_1)
+	if((breath.temperature < cold_1 || breath.temperature > heat_1) && !(MUTATION_COLD_RESISTANCE in owner.mutations))
 		var/damage = 0
-		if(breath.temperature <= species.cold_level_1)
+		if(breath.temperature <= cold_1)
 			if(prob(20))
 				to_chat(owner, "<span class='danger'>You feel your face freezing and icicles forming in your lungs!</span>")
-			if(breath.temperature < species.cold_level_3)
+			if(breath.temperature < species.get_species_temperature_threshold(COLD_LEVEL_3))
 				damage = COLD_GAS_DAMAGE_LEVEL_3
-			else if(breath.temperature < species.cold_level_2)
+			else if(breath.temperature < species.get_species_temperature_threshold(COLD_LEVEL_2))
 				damage = COLD_GAS_DAMAGE_LEVEL_2
 			else
 				damage = COLD_GAS_DAMAGE_LEVEL_1
@@ -288,13 +290,13 @@
 			else
 				src.damage += damage
 			owner.fire_alert = 1
-		else if(breath.temperature >= species.heat_level_1)
+		else if(breath.temperature >= heat_1)
 			if(prob(20))
 				to_chat(owner, "<span class='danger'>You feel your face burning and a searing heat in your lungs!</span>")
 
-			if(breath.temperature < species.heat_level_2)
+			if(breath.temperature < species.get_species_temperature_threshold(HEAT_LEVEL_2))
 				damage = HEAT_GAS_DAMAGE_LEVEL_1
-			else if(breath.temperature < species.heat_level_3)
+			else if(breath.temperature < species.get_species_temperature_threshold(HEAT_LEVEL_3))
 				damage = HEAT_GAS_DAMAGE_LEVEL_2
 			else
 				damage = HEAT_GAS_DAMAGE_LEVEL_3

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -252,7 +252,7 @@
 				germ_level += 10
 
 	if(germ_level >= INFECTION_LEVEL_ONE)
-		var/fever_temperature = (owner.species.heat_level_1 - owner.species.body_temperature - 5)* min(germ_level/INFECTION_LEVEL_TWO, 1) + owner.species.body_temperature
+		var/fever_temperature = (owner.get_temperature_threshold(HEAT_LEVEL_1) - owner.species.body_temperature - 5)* min(germ_level/INFECTION_LEVEL_TWO, 1) + owner.species.body_temperature
 		owner.bodytemperature += clamp(0, (fever_temperature - T20C)/BODYTEMP_COLD_DIVISOR + 1, fever_temperature - owner.bodytemperature)
 
 	if (germ_level >= INFECTION_LEVEL_TWO)

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -126,9 +126,9 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 
 	// Environment tolerance/life processes vars.
 	var/breath_pressure = 16                                    // Minimum partial pressure safe for breathing, kPa
-	var/breath_type = /decl/material/gas/oxygen                                  // Non-oxygen gas breathed, if any.
+	var/breath_type = /decl/material/gas/oxygen                 // Non-oxygen gas breathed, if any.
 	var/poison_types = list(/decl/material/gas/chlorine = TRUE) // Noticeably poisonous air - ie. updates the toxins indicator on the HUD.
-	var/exhale_type = /decl/material/gas/carbon_dioxide                          // Exhaled gas type.
+	var/exhale_type = /decl/material/gas/carbon_dioxide         // Exhaled gas type.
 	var/blood_reagent = /decl/material/liquid/blood
 
 	var/max_pressure_diff = 60                                  // Maximum pressure difference that is safe for lungs
@@ -1067,3 +1067,20 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 			if(!O || (O.status & ORGAN_DEAD))
 				return TRUE
 	return FALSE
+
+/decl/species/proc/get_species_temperature_threshold(var/threshold)
+	switch(threshold)
+		if(COLD_LEVEL_1)
+			return cold_level_1
+		if(COLD_LEVEL_2)
+			return cold_level_2
+		if(COLD_LEVEL_3)
+			return cold_level_3
+		if(HEAT_LEVEL_1)
+			return heat_level_1
+		if(HEAT_LEVEL_2)
+			return heat_level_2
+		if(HEAT_LEVEL_3)
+			return heat_level_3
+		else
+			CRASH("get_species_temperature_threshold() called with invalid threshold value.")

--- a/code/modules/spells/targeted/blood_boil.dm
+++ b/code/modules/spells/targeted/blood_boil.dm
@@ -20,6 +20,6 @@
 	H.bodytemperature += 40
 	if(prob(10))
 		to_chat(H,"<span class='warning'>\The [user] seems to radiate an uncomfortable amount of heat your direction.</span>")
-	if(H.bodytemperature > H.getSpeciesOrSynthTemp(HEAT_LEVEL_3)) //Burst into flames
+	if(H.bodytemperature > H.get_temperature_threshold(HEAT_LEVEL_3)) //Burst into flames
 		H.fire_stacks += 50
 		H.IgniteMob()

--- a/nebula.dme
+++ b/nebula.dme
@@ -2185,7 +2185,6 @@
 #include "code\modules\maps\template_types\random_exoplanet\random_map.dm"
 #include "code\modules\maps\template_types\random_exoplanet\random_planet.dm"
 #include "code\modules\maps\template_types\random_exoplanet\random_planet_areas.dm"
-#include "code\modules\maps\template_types\random_exoplanet\random_planet_atmosphere.dm"
 #include "code\modules\maps\template_types\random_exoplanet\random_planet_landmarks.dm"
 #include "code\modules\maps\template_types\random_exoplanet\random_planet_level_data.dm"
 #include "code\modules\maps\template_types\random_exoplanet\random_planet_subtemplates.dm"


### PR DESCRIPTION
## Description of changes
Moves temperature thresholds onto a proc at /mob/living instead of doing it all in place with species member vars.

## Why and what will this PR improve
Easier to get temperature thresholds, cleaner code, support for eventually killing /carbon.

## Authorship
Myself.

## Changelog
Nothing player-facing.