### PR TITLE
Fix glass2/coffee cup icon issues

### DIFF
--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -11,6 +11,8 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 	icon = 'icons/obj/drink_glasses/square.dmi'
 	icon_state = null
 	base_icon = "square" // Base icon name
+	/// The icon state prefix used for overlay/addon sprites. If unset, defaults to base_icon.
+	var/overlay_base_icon = null
 	filling_states = @"[20,40,60,80,100]"
 	volume = 30
 	material = /decl/material/solid/glass
@@ -95,6 +97,8 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 	. = ..()
 	if(!icon_state)
 		icon_state = base_icon
+	if(!overlay_base_icon)
+		overlay_base_icon = base_icon
 
 /obj/item/chems/drinks/glass2/get_base_name()
 	. = base_name
@@ -107,9 +111,9 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 	..()
 
 /obj/item/chems/drinks/glass2/proc/can_add_extra(obj/item/glass_extra/GE)
-	if(!("[base_icon]_[GE.glass_addition]left" in icon_states(icon)))
+	if(!("[overlay_base_icon]_[GE.glass_addition]left" in icon_states(icon)))
 		return 0
-	if(!("[base_icon]_[GE.glass_addition]right" in icon_states(icon)))
+	if(!("[overlay_base_icon]_[GE.glass_addition]right" in icon_states(icon)))
 		return 0
 
 	return 1
@@ -131,13 +135,13 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 
 /obj/item/chems/drinks/glass2/proc/get_filling_overlay(amount, overlay)
 	var/image/I = new()
-	if(!filling_icons_cache["[base_icon][amount][overlay]"])
-		var/icon/base = new/icon(icon, "[base_icon][amount]")
+	if(!filling_icons_cache["[overlay_base_icon][amount][overlay]"])
+		var/icon/base = new/icon(icon, "[overlay_base_icon][amount]")
 		if(overlay)
 			var/icon/extra = new/icon('icons/obj/drink_glasses/extras.dmi', overlay)
 			base.Blend(extra, ICON_MULTIPLY)
-		filling_icons_cache["[base_icon][amount][overlay]"] = image(base)
-	I.appearance = filling_icons_cache["[base_icon][amount][overlay]"]
+		filling_icons_cache["[overlay_base_icon][amount][overlay]"] = image(base)
+	I.appearance = filling_icons_cache["[overlay_base_icon][amount][overlay]"]
 	return I
 
 /obj/item/chems/drinks/glass2/on_update_icon()
@@ -160,19 +164,19 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 		var/amnt = get_filling_state()
 
 		if(has_ice())
-			over_liquid |= image(icon, src, "[base_icon][amnt]_ice")
+			over_liquid |= image(icon, src, "[overlay_base_icon][amnt]_ice")
 
 		if(has_fizz())
 			over_liquid |= get_filling_overlay(amnt, "fizz")
 
 		if(has_vapor())
-			over_liquid |= image(icon, src, "[base_icon]_vapor")
+			over_liquid |= image(icon, src, "[overlay_base_icon]_vapor")
 
 		for(var/S in R.glass_special)
-			if("[base_icon]_[S]" in icon_states(icon))
-				under_liquid |= image(icon, src, "[base_icon]_[S]")
-			else if("[base_icon][amnt]_[S]" in icon_states(icon))
-				over_liquid |= image(icon, src, "[base_icon][amnt]_[S]")
+			if("[overlay_base_icon]_[S]" in icon_states(icon))
+				under_liquid |= image(icon, src, "[overlay_base_icon]_[S]")
+			else if("[overlay_base_icon][amnt]_[S]" in icon_states(icon))
+				over_liquid |= image(icon, src, "[overlay_base_icon][amnt]_[S]")
 
 		underlays += under_liquid
 
@@ -189,7 +193,7 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 	for(var/item in extras)
 		if(istype(item, /obj/item/glass_extra))
 			var/obj/item/glass_extra/GE = item
-			var/image/I = image(icon, src, "[base_icon]_[GE.glass_addition][side]")
+			var/image/I = image(icon, src, "[overlay_base_icon]_[GE.glass_addition][side]")
 			I.color = GE.color
 			underlays += I
 		else if(rim_pos && istype(item, /obj/item/chems/food/fruit_slice))

--- a/code/modules/reagents/reagent_containers/drinkingglass/glass_types.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/glass_types.dm
@@ -2,6 +2,7 @@
 	name = "half-pint glass"
 	base_name = "glass"
 	base_icon = "square"
+	icon_state = "square"
 	icon = 'icons/obj/drink_glasses/square.dmi'
 	desc = "Your standard drinking glass."
 	filling_states = @"[20,40,60,80,100]"
@@ -14,6 +15,7 @@
 	desc = "A robust tumbler with a thick, weighted bottom."
 	base_name = "glass"
 	base_icon = "rocks"
+	icon_state = "rocks"
 	icon = 'icons/obj/drink_glasses/rocks.dmi'
 	filling_states = @"[25,50,75,100]"
 	volume = 20
@@ -25,6 +27,7 @@
 	desc = "Stemware with an untapered conical bowl."
 	base_name = "glass"
 	base_icon = "shake"
+	icon_state = "shake"
 	icon = 'icons/obj/drink_glasses/shake.dmi'
 	filling_states = @"[25,50,75,100]"
 	volume = 30
@@ -36,6 +39,7 @@
 	desc = "Fragile stemware with a stout conical bowl. Don't spill."
 	base_name = "glass"
 	base_icon = "cocktail"
+	icon_state = "cocktail"
 	icon = 'icons/obj/drink_glasses/cocktail.dmi'
 	filling_states = @"[33,66,100]"
 	volume = 15
@@ -47,6 +51,7 @@
 	desc = "A small glass, designed so that its contents can be consumed in one gulp."
 	base_name = "shot"
 	base_icon = "shot"
+	icon_state = "shot"
 	icon = 'icons/obj/drink_glasses/shot.dmi'
 	filling_states = @"[33,66,100]"
 	volume = 5
@@ -58,6 +63,7 @@
 	name = "pint glass"
 	base_name = "pint"
 	base_icon = "pint"
+	icon_state = "pint"
 	icon = 'icons/obj/drink_glasses/pint.dmi'
 	filling_states = @"[16,33,50,66,83,100]"
 	volume = 60
@@ -70,6 +76,7 @@
 	desc = "A heavy mug with thick walls."
 	base_name = "mug"
 	base_icon = "mug"
+	icon_state = "mug"
 	icon = 'icons/obj/drink_glasses/mug.dmi'
 	filling_states = @"[25,50,75,100]"
 	volume = 40
@@ -81,6 +88,7 @@
 	desc = "A piece of elegant stemware."
 	base_name = "glass"
 	base_icon = "wine"
+	icon_state = "wine"
 	icon = 'icons/obj/drink_glasses/wine.dmi'
 	filling_states = @"[20,40,60,80,100]"
 	volume = 25
@@ -92,6 +100,7 @@
 	desc = "A piece of very elegant stemware."
 	base_name = "glass"
 	base_icon = "flute"
+	icon_state = "flute"
 	icon = 'icons/obj/drink_glasses/flute.dmi'
 	volume = 25
 	filling_states = @"[20,40,60,80,100]"
@@ -103,6 +112,7 @@
 	desc = "A handled glass pitcher."
 	base_name = "pitcher"
 	base_icon = "carafe"
+	icon_state = "carafe"
 	icon = 'icons/obj/drink_glasses/carafe.dmi'
 	filling_states = @"[10,20,30,40,50,60,70,80,90,100]"
 	volume = 120
@@ -122,42 +132,42 @@
 	filling_states = @"[40,80,100]"
 	base_name = "cup"
 	base_icon = "coffeecup"
+	overlay_base_icon = "coffeecup" // so that subtypes work properly
 	rim_pos = @"{'y':22,'x_left':12,'x_right':20}"
 	filling_overlayed = TRUE
-
-/obj/item/chems/drinks/glass2/coffeecup/foundation
-	name = "\improper Foundation coffee cup"
-	desc = "A white coffee cup with the Cuchulain Foundation logo stencilled onto it."
-	icon_state = "coffeecup_foundation"
-	base_name = "\improper Foundation cup"
 
 /obj/item/chems/drinks/glass2/coffeecup/black
 	name = "black coffee cup"
 	desc = "A sleek black coffee cup."
+	base_icon = "coffeecup_black"
 	icon_state = "coffeecup_black"
 	base_name = "black cup"
 
 /obj/item/chems/drinks/glass2/coffeecup/green
 	name = "green coffee cup"
 	desc = "A pale green and pink coffee cup."
+	base_icon = "coffeecup_green"
 	icon_state = "coffeecup_green"
 	base_name = "green cup"
 
 /obj/item/chems/drinks/glass2/coffeecup/heart
 	name = "heart coffee cup"
 	desc = "A white coffee cup, it prominently features a red heart."
+	base_icon = "coffeecup_heart"
 	icon_state = "coffeecup_heart"
 	base_name = "heart cup"
 
 /obj/item/chems/drinks/glass2/coffeecup/one
 	name = "#1 coffee cup"
 	desc = "A white coffee cup, prominently featuring a #1."
+	base_icon = "coffeecup_one"
 	icon_state = "coffeecup_one"
 	base_name = "#1 cup"
 
 /obj/item/chems/drinks/glass2/coffeecup/punitelli
 	name = "#1 monkey coffee cup"
 	desc = "A white coffee cup, prominently featuring a \"#1 monkey\" decal."
+	base_icon = "coffeecup_punitelli"
 	icon_state = "coffeecup_punitelli"
 	base_name = "#1 monkey cup"
 
@@ -167,12 +177,14 @@
 /obj/item/chems/drinks/glass2/coffeecup/rainbow
 	name = "rainbow coffee cup"
 	desc = "A rainbow coffee cup. The colors are almost as blinding as a welder."
+	base_icon = "coffeecup_rainbow"
 	icon_state = "coffeecup_rainbow"
 	base_name = "rainbow cup"
 
 /obj/item/chems/drinks/glass2/coffeecup/metal
 	name = "metal coffee cup"
 	desc = "A metal coffee cup. You're not sure which metal."
+	base_icon = "coffeecup_metal"
 	icon_state = "coffeecup_metal"
 	base_name = "metal cup"
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
@@ -181,18 +193,21 @@
 /obj/item/chems/drinks/glass2/coffeecup/STC
 	name = "\improper ICCG coffee cup"
 	desc = "A coffee cup adorned with the flag of the Gilgamesh Colonial Confederation, for when you need some espionage charges to go with your morning coffee."
+	base_icon = "coffeecup_STC"
 	icon_state = "coffeecup_STC"
 	base_name = "\improper ICCG cup"
 
 /obj/item/chems/drinks/glass2/coffeecup/pawn
 	name = "pawn coffee cup"
 	desc = "A black coffee cup adorned with the image of a red chess pawn."
+	base_icon = "coffeecup_pawn"
 	icon_state = "coffeecup_pawn"
 	base_name = "pawn cup"
 
 /obj/item/chems/drinks/glass2/coffeecup/britcup
 	name = "british coffee cup"
 	desc = "A coffee cup with the British flag emblazoned on it."
+	base_icon = "coffeecup_brit"
 	icon_state = "coffeecup_brit"
 	base_name = "british cup"
 
@@ -206,6 +221,7 @@
 	filling_states = @"[50,70,90,100]"
 	base_name = "tall cup"
 	base_icon = "coffeecup_tall"
+	overlay_base_icon = null
 
 /obj/item/chems/drinks/glass2/coffeecup/teacup
 	name = "teacup"
@@ -222,5 +238,9 @@
 	. = ..()
 	if(citem.additional_data["base_name"])
 		base_name = citem.additional_data["base_name"] || base_name
+	if(citem.additional_data["base_icon"])
+		base_icon = citem.additional_data["base_icon"] || base_icon
+	if(citem.additional_data["overlay_base_icon"])
+		overlay_base_icon = citem.additional_data["overlay_base_icon"] || overlay_base_icon
 	custom_name = citem.item_name
 	custom_desc = citem.item_desc

--- a/mods/content/corporate/items/cups.dm
+++ b/mods/content/corporate/items/cups.dm
@@ -1,17 +1,20 @@
 /obj/item/chems/drinks/glass2/coffeecup/NT
 	name = "\improper NT coffee cup"
 	desc = "A red NanoTrasen coffee cup."
+	base_icon = "coffeecup_NT"
 	icon_state = "coffeecup_NT"
 	base_name = "\improper NT cup"
 
 /obj/item/chems/drinks/glass2/coffeecup/corp
 	name = "\improper EXO coffee cup"
 	desc = "A tasteful coffee cup in Expeditionary Corps Organisation corporate colours."
+	base_icon = "coffeecup_corp"
 	icon_state = "coffeecup_corp"
 	base_name = "\improper EXO cup"
 
 /obj/item/chems/drinks/glass2/coffeecup/dais
 	name = "\improper DAIS coffee cup"
 	desc = "A coffee cup imprinted with the stylish logo of Deimos Advanced Information Systems."
+	base_icon = "coffeecup_dais"
 	icon_state = "coffeecup_dais"
 	base_name = "\improper DAIS cup"

--- a/mods/content/government/items/cups.dm
+++ b/mods/content/government/items/cups.dm
@@ -1,5 +1,6 @@
 /obj/item/chems/drinks/glass2/coffeecup/SCG
 	name = "\improper SCG coffee cup"
 	desc = "A blue coffee cup emblazoned with the crest of the Sol Central Government."
+	base_icon = "coffeecup_SCG"
 	icon_state = "coffeecup_SCG"
 	base_name = "\improper SCG cup"

--- a/mods/content/psionics/items/coffee_cup.dm
+++ b/mods/content/psionics/items/coffee_cup.dm
@@ -1,5 +1,6 @@
 /obj/item/chems/drinks/glass2/coffeecup/foundation
 	name = "\improper Foundation coffee cup"
 	desc = "A white coffee cup with the Cuchulain Foundation logo stencilled onto it."
+	base_icon = "coffeecup_foundation"
 	icon_state = "coffeecup_foundation"
 	base_name = "\improper Foundation cup"

--- a/mods/mobs/dionaea/items/cup.dm
+++ b/mods/mobs/dionaea/items/cup.dm
@@ -1,5 +1,6 @@
 /obj/item/chems/drinks/glass2/coffeecup/diona
 	name = "diona nymph coffee cup"
 	desc = "A green coffee cup featuring the image of a diona nymph."
+	base_icon = "coffeecup_diona"
 	icon_state = "coffeecup_diona"
 	base_name = "diona cup"


### PR DESCRIPTION
## Description of changes
Coffee cups lost their sprite because of some changes I made to glass2. Oops. This adds `overlay_base_icon`, similar to `base_icon` but used only to determine overlays rather than to set the icon state.

## Why and what will this PR improve
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/f1acf890-52ba-4fc4-b6b3-4f746be6c1f5)
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/c525d3ee-0e76-46e4-a06e-a0eccfc9d11d)