### PR TITLE
Increase fluid min alpha for better visibility

### DIFF
--- a/code/__defines/fluids.dm
+++ b/code/__defines/fluids.dm
@@ -33,5 +33,5 @@
 	add_overlay(SSfluids.fluid_images[img_state]);
 
 #define FLUID_MAX_ALPHA 200
-#define FLUID_MIN_ALPHA 45
+#define FLUID_MIN_ALPHA 96
 #define TANK_WATER_MULTIPLIER 5


### PR DESCRIPTION
## Description of changes
Increases the min alpha for fluids, because 300u of water in a pool was almost invisible.

## Why and what will this PR improve
Before: 
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/cf72937a-f96c-4eb0-b4a4-0e6a0628f2bd)
After:
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/3d3f8289-5c38-4848-9d59-e51d21359a9c)