### PR TITLE
Fix incorrect pressure readings on firedoors

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -405,10 +405,8 @@
 	var/maxp=0;
 	for(var/dir in global.cardinal)
 		var/turf/T = get_step(loc,dir)
-		var/cp=0
-		if(T?.zone)
-			var/datum/gas_mixture/environment = T.return_air()
-			cp = environment?.return_pressure()
+		var/datum/gas_mixture/environment = T.return_air()
+		var/cp = environment?.return_pressure()
 		if(cp<minp)minp=cp
 		if(cp>maxp)maxp=cp
 	return abs(minp-maxp)


### PR DESCRIPTION
## Description of changes
Fixes some incorrect logic introduced by #3040.

## Why and what will this PR improve
Firedoors bordering turfs not participating in a zone would always read as having the maximum possible pressure difference. That's a bug! :bug: