### PR TITLE
Tweak lightswitch layering so they don't go under windows

### DIFF
--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -12,6 +12,7 @@
 	power_channel = LIGHT
 	required_interaction_dexterity = DEXTERITY_SIMPLE_MACHINES
 	z_flags = ZMM_MANGLE_PLANES
+	layer = ABOVE_WINDOW_LAYER
 
 	var/on = 0
 	var/area/connected_area = null


### PR DESCRIPTION
## Description of changes
Adjusts lightswitches to be on `ABOVE_WINDOW_LAYER`.

## Why and what will this PR improve
They would be under windows before.