### PR TITLE
Use get_contained_external_atoms instead of bespoke checks

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -79,6 +79,11 @@
 	to_chat(user, SPAN_NOTICE("You remove \the [canister] from \the [src]."))
 	return TRUE
 
+/obj/machinery/sleeper/get_contained_external_atoms()
+	. = ..()
+	LAZYREMOVE(., loaded_canisters)
+	LAZYREMOVE(., beaker)
+
 /obj/machinery/sleeper/Initialize(mapload, d = 0, populate_parts = TRUE)
 	. = ..()
 	if(populate_parts)
@@ -371,9 +376,7 @@
 	if(open_sound)
 		playsound(src, open_sound, 40)
 
-	for(var/obj/O in (contents - (component_parts + loaded_canisters))) // In case an object was dropped inside or something. Excludes the beaker and component parts.
-		if(O != beaker)
-			O.dropInto(loc)
+	dump_contents() // In case an object was dropped inside or something. Excludes the beaker and component parts.
 	toggle_filter()
 
 /obj/machinery/sleeper/proc/set_occupant(var/mob/living/carbon/occupant)

--- a/code/game/machinery/bodyscanner.dm
+++ b/code/game/machinery/bodyscanner.dm
@@ -44,14 +44,10 @@
 	usr.client.perspective = EYE_PERSPECTIVE
 	usr.client.eye = src
 
-/obj/machinery/bodyscanner/proc/drop_contents()
-	for(var/obj/O in (contents - component_parts))
-		O.dropInto(loc)
-
 /obj/machinery/bodyscanner/proc/go_out()
 	if ((!( src.occupant ) || src.locked))
 		return
-	drop_contents()
+	dump_contents()
 	if (src.occupant.client)
 		src.occupant.client.eye = src.occupant.client.mob
 		src.occupant.client.perspective = MOB_PERSPECTIVE
@@ -93,7 +89,7 @@
 	src.occupant = target
 
 	update_use_power(POWER_USE_ACTIVE)
-	drop_contents()
+	dump_contents()
 	SetName("[name] ([occupant])")
 
 	src.add_fingerprint(user)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -461,7 +461,7 @@
 	icon_state = base_icon_state
 
 	//Eject any items that aren't meant to be in the pod.
-	var/list/items = contents - component_parts
+	var/list/items = get_contained_external_atoms()
 	if(occupant) items -= occupant
 
 	for(var/obj/item/W in items)

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -143,7 +143,7 @@
 /obj/machinery/gibber/proc/go_out()
 	if(operating || !src.occupant)
 		return
-	for(var/obj/O in (contents - component_parts))
+	for(var/obj/O in get_contained_external_atoms())
 		O.dropInto(loc)
 	if (src.occupant.client)
 		src.occupant.client.eye = src.occupant.client.mob
@@ -211,7 +211,7 @@
 	qdel(occupant)
 
 	playsound(loc, 'sound/effects/splat.ogg', 50, 1)
-	for (var/obj/thing in (contents - component_parts))
+	for (var/obj/thing in get_contained_external_atoms())
 		// There's a chance that the gibber will fail to destroy some evidence.
 		if(istype(thing,/obj/item/organ) && prob(80))
 			qdel(thing)

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -67,7 +67,7 @@
 	addtimer(CALLBACK(src, /obj/machinery/washing_machine/proc/wash), 20 SECONDS)
 
 /obj/machinery/washing_machine/proc/wash()
-	for(var/atom/A in (contents - component_parts))
+	for(var/atom/A as anything in get_contained_external_atoms())
 		if(detergent)
 			A.clean_blood()
 		if(isitem(A))
@@ -200,8 +200,7 @@
 			var/mob/M = locate(/mob/living) in src
 			if(M)
 				M.gib()
-		for(var/atom/movable/O in (contents - component_parts))
-			O.dropInto(loc)
+		dump_contents()
 		state &= ~WASHER_STATE_FULL
 		update_icon()
 		crayon = null

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1106,8 +1106,7 @@
 
 /mob/get_contained_external_atoms()
 	. = ..()
-	if(.)
-		LAZYREMOVE(., get_organs())
+	LAZYREMOVE(., get_organs())
 
 /mob/explosion_act(var/severity)
 	. = ..()

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -295,7 +295,7 @@ var/global/list/diversion_junctions = list()
 
 // eject the contents of the disposal unit
 /obj/machinery/disposal/proc/eject()
-	for(var/atom/movable/AM in (contents - component_parts))
+	for(var/atom/movable/AM in get_contained_external_atoms())
 		AM.forceMove(src.loc)
 		AM.pipe_eject(0)
 	update_icon()
@@ -380,7 +380,7 @@ var/global/list/diversion_junctions = list()
 	var/wrapcheck = 0
 	var/obj/structure/disposalholder/H = new()	// virtual holder object which actually
 												// travels through the pipes.
-	var/list/stuff = contents - component_parts
+	var/list/stuff = get_contained_external_atoms()
 	//Hacky test to get drones to mail themselves through disposals.
 	for(var/mob/living/silicon/robot/drone/D in stuff)
 		wrapcheck = 1

--- a/code/modules/recycling/disposalholder.dm
+++ b/code/modules/recycling/disposalholder.dm
@@ -20,7 +20,7 @@
 	// initialize a holder from the contents of a disposal unit
 /obj/structure/disposalholder/proc/init(var/obj/machinery/disposal/D, var/datum/gas_mixture/flush_gas)
 	gas = flush_gas// transfer gas resv. into holder object -- let's be explicit about the data this proc consumes, please.
-	var/stuff = D.contents - D.component_parts
+	var/stuff = D.get_contained_external_atoms()
 	//Check for any living mobs trigger hasmob.
 	//hasmob effects whether the package goes to cargo or its tagged destination.
 	hasmob = length(check_mob(stuff))


### PR DESCRIPTION
## Description of changes
Replaces a bunch of `(contents - foo)` checks with `get_contained_external_atoms()` with possible, including outright replacing some loops with `dump_contents()`.

## Why and what will this PR improve
Better code quality! Also necessary for a future PR.