### PR TITLE
Allow decompiler grenade to consume structures and contents

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -84,6 +84,12 @@
 	LAZYREMOVE(., loaded_canisters)
 	LAZYREMOVE(., beaker)
 
+/obj/machinery/sleeper/get_contained_matter()
+	. = ..()
+	. = MERGE_ASSOCS_WITH_NUM_VALUES(., beaker.get_contained_matter())
+	for(var/obj/canister in loaded_canisters)
+		. = MERGE_ASSOCS_WITH_NUM_VALUES(., canister.get_contained_matter())
+
 /obj/machinery/sleeper/Initialize(mapload, d = 0, populate_parts = TRUE)
 	. = ..()
 	if(populate_parts)

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -486,6 +486,12 @@ Class Procs:
 	. = ..()
 	LAZYREMOVE(., component_parts)
 
+// This only includes external atoms by default, so we need to add components back.
+/obj/machinery/get_contained_matter()
+	. = ..()
+	for(var/obj/component in component_parts)
+		. = MERGE_ASSOCS_WITH_NUM_VALUES(., component.get_contained_matter())
+
 /obj/machinery/proc/get_auto_access()
 	var/area/A = get_area(src)
 	return A?.req_access?.Copy()

--- a/code/game/objects/items/weapons/grenades/decompiler.dm
+++ b/code/game/objects/items/weapons/grenades/decompiler.dm
@@ -85,7 +85,7 @@
 
 		while(length(eating))
 			var/atom/movable/thing = pick_n_take(eating)
-			if((thing == src) || thing.anchored || prob(15))
+			if(QDELETED(thing) || (thing == src) || thing.anchored || prob(15))
 				continue
 
 			if(prob(30))

--- a/code/game/objects/items/weapons/grenades/decompiler.dm
+++ b/code/game/objects/items/weapons/grenades/decompiler.dm
@@ -80,14 +80,12 @@
 	playsound(loc, 'sound/magic/lightningshock.ogg', 30, FALSE)
 
 	var/list/eaten
-	for(var/eat_turf in RANGE_TURFS(loc, eat_range))
-
-		var/turf/T = eat_turf
-		var/list/eating = T.contents?.Copy()
+	for(var/turf/eat_turf as anything in RANGE_TURFS(loc, eat_range))
+		var/list/eating = eat_turf.get_contained_external_atoms()
 
 		while(length(eating))
 			var/atom/movable/thing = pick_n_take(eating)
-			if(QDELETED(thing) || !istype(thing) || !thing.simulated || thing.anchored || prob(15))
+			if((thing == src) || thing.anchored || prob(15))
 				continue
 
 			if(prob(30))
@@ -107,10 +105,16 @@
 							thing = limb
 							break
 
-			if(isitem(thing))
-				var/obj/item/eating_obj = thing
-				for(var/mat in eating_obj.matter)
-					decompiled_matter[mat] += eating_obj.matter[mat]
+			if(isobj(thing))
+				var/obj/eating_obj = thing
+				// some loose objects fall out and evade getting eaten this time
+				for(var/obj/recursive_obj in eating_obj.get_contained_external_atoms())
+					if(prob(15))
+						recursive_obj.dropInto(eating_obj.loc)
+					else
+						LAZYADD(eaten, recursive_obj)
+				// whatever's left is cubified
+				decompiled_matter = MERGE_ASSOCS_WITH_NUM_VALUES(decompiled_matter, eating_obj.get_contained_matter())
 				LAZYADD(eaten, eating_obj)
 
 	if(length(eaten))

--- a/code/game/objects/items/weapons/storage/wall_mirror.dm
+++ b/code/game/objects/items/weapons/storage/wall_mirror.dm
@@ -20,9 +20,8 @@
 /obj/structure/mirror/get_contained_external_atoms()
 	. = ..()
 	if(mirror_storage)
-		if(.) // don't use lazyremove to avoid list churn
-			. -= mirror_storage // abstract object, don't yoink it out
-		LAZYADD(., mirror_storage.contents) // do add these though, we're pretending this is a storage object
+		LAZYADD(., mirror_storage.get_contained_external_atoms()) // add these, we're pretending this is a storage object
+		LAZYREMOVE(., mirror_storage) // abstract object, don't yoink it out. do this second to avoid list churn
 
 /obj/item/storage/internal/mirror_storage
 	use_sound = 'sound/effects/closet_open.ogg'

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -272,6 +272,16 @@
 /obj/proc/WillContain()
 	return
 
+/**
+ * Returns the sum of this obj's matter plus the matter of all its contents.
+ * Overrides may add extra handling for things like material storage.
+ * Most useful for calculating worth or deconstructing something along with its contents.
+ */
+/obj/proc/get_contained_matter()
+	. = matter?.Copy()
+	for(var/obj/contained_obj in get_contained_external_atoms()) // machines handle component parts separately
+		. = MERGE_ASSOCS_WITH_NUM_VALUES(., contained_obj.get_contained_matter())
+
 ////////////////////////////////////////////////////////////////
 // Interactions
 ////////////////////////////////////////////////////////////////

--- a/code/modules/augment/active/cyberbrain.dm
+++ b/code/modules/augment/active/cyberbrain.dm
@@ -78,6 +78,12 @@
 		if(os)
 			os.Process()
 
+/obj/item/organ/internal/augment/active/cyberbrain/get_contained_matter()
+	. = ..()
+	var/datum/extension/assembly/assembly = get_extension(src, /datum/extension/assembly)
+	for(var/obj/part in assembly?.parts)
+		. = MERGE_ASSOCS_WITH_NUM_VALUES(., part.get_contained_matter())
+
 /*
  *
  * Section for assembly override for the cyberbrain.

--- a/code/modules/fabrication/_fabricator.dm
+++ b/code/modules/fabrication/_fabricator.dm
@@ -228,3 +228,8 @@
 
 /obj/machinery/fabricator/proc/get_color_list()
 	return pipe_colors //override with null for hex color selections
+
+// Our stored_material is just the right format to be added to the matter list.
+/obj/machinery/fabricator/get_contained_matter()
+	. = ..()
+	. = MERGE_ASSOCS_WITH_NUM_VALUES(., stored_material)

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -4,6 +4,12 @@
 	if(assembly)
 		LAZYREMOVE(., assembly.parts)
 
+/obj/item/modular_computer/get_contained_matter()
+	. = ..()
+	var/datum/extension/assembly/assembly = get_extension(src, /datum/extension/assembly)
+	for(var/obj/part in assembly?.parts)
+		. = MERGE_ASSOCS_WITH_NUM_VALUES(., part.get_contained_matter())
+
 /obj/item/modular_computer/Process()
 	var/datum/extension/assembly/assembly = get_extension(src, /datum/extension/assembly)
 	if(assembly)


### PR DESCRIPTION
## Description of changes
REQUIRES #3129.

The contents of objects eaten by a decompiler grenade will be consumed as well. (Like other consumed objects, there is a 15% chance for them to be skipped for a tick, in which case they'll be dropped into the eaten object's loc.)

Also, (unanchored) structures can be consumed as well. This means they will be able to consume the entire contents of lockers and crates. Scary!

## Why and what will this PR improve
Decompilers produced a pitiful output because they didn't even consume unanchored structures, and would also ignore the material worth of contents.

## Authorship
Me.

## Changelog
:cl:
add: Decompiler grenades can now consume unanchored structures.
bugfix: Decompiler grenades will no longer waste the contents of consumed objects.
/:cl: