### PR TITLE
Add additional preset modular computer consoles

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/preset_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_console.dm
@@ -47,6 +47,21 @@
 		/datum/computer_file/program/shields_monitor
 	)
 
+/obj/machinery/computer/modular/preset/engineering/power
+	default_software = list(
+		/datum/computer_file/program/power_monitor,
+		/datum/computer_file/program/alarm_monitor,
+		/datum/computer_file/program/wordprocessor
+	)
+	autorun_program = /datum/computer_file/program/power_monitor
+
+/obj/machinery/computer/modular/preset/engineering/rcon
+	default_software = list(
+		/datum/computer_file/program/rcon_console,
+		/datum/computer_file/program/wordprocessor
+	)
+	autorun_program = /datum/computer_file/program/rcon_console
+
 /obj/machinery/computer/modular/preset/medical
 	default_software = list(
 		/datum/computer_file/program/suit_sensors,
@@ -83,6 +98,14 @@
 		/datum/computer_file/program/email_client,
 		/datum/computer_file/program/records,
 		/datum/computer_file/program/docking,
+		/datum/computer_file/program/wordprocessor,
+		/datum/computer_file/program/accounts
+	)
+
+/obj/machinery/computer/modular/preset/cardslot/personnel
+	default_software = list(
+		/datum/computer_file/program/card_mod,
+		/datum/computer_file/program/email_client,
 		/datum/computer_file/program/records,
 		/datum/computer_file/program/wordprocessor,
 		/datum/computer_file/program/accounts


### PR DESCRIPTION
## Description of changes
- Adds two more preset consoles with autorun programs, for RCON and power monitoring, intended to parallel the medical computer with autorun suit sensors monitoring.
- Adds a preset console with the `card_mod` program, the only one I could find.

## Why and what will this PR improve
Additional consoles for variety/etc.