### PR TITLE
Fix OS attempting autorun prior to disk mount

### DIFF
--- a/code/modules/modular_computers/os/_os.dm
+++ b/code/modules/modular_computers/os/_os.dm
@@ -172,9 +172,6 @@
 
 /datum/extension/interactive/os/proc/system_boot()
 	on = TRUE
-	var/datum/computer_file/data/autorun = get_file("autorun", "local")
-	if(istype(autorun))
-		run_program(autorun.stored_data)
 	var/obj/item/stock_parts/computer/network_card/network_card = get_component(PART_NETWORK)
 	if(network_card)
 		var/datum/extension/network_device/D = get_extension(network_card, /datum/extension/network_device)

--- a/code/modules/modular_computers/os/files.dm
+++ b/code/modules/modular_computers/os/files.dm
@@ -12,6 +12,11 @@
 	if(drive_slot)
 		mounted_storage["media"] = new /datum/file_storage/disk/removable(src, "media")
 
+	// Auto-run: must happen after storage mount above
+	var/datum/computer_file/data/autorun = get_file("autorun", "local")
+	if(istype(autorun))
+		run_program(autorun.stored_data)
+
 	// Auto-mounted mainframes.
 	var/datum/computer_file/data/automount_file = get_file("automount", "local")
 	if(istype(automount_file))


### PR DESCRIPTION
## Description of changes
Moves autorun to after disk mount so that the `"local"` disk can be properly searched.

## Why and what will this PR improve
Fixes autorun files not being found.