### PR TITLE
Fix issues with Quantum Mechanics

### DIFF
--- a/code/modules/admin/quantum_mechanic.dm
+++ b/code/modules/admin/quantum_mechanic.dm
@@ -297,5 +297,5 @@
 /mob/living/carbon/human/quantum/restrained()
 	return FALSE
 
-/mob/living/carbon/human/quantum/can_fall()
+/mob/living/carbon/human/quantum/can_fall(anchor_bypass = FALSE, turf/location_override = loc)
 	return fall_override ? FALSE : ..()

--- a/code/modules/admin/quantum_mechanic.dm
+++ b/code/modules/admin/quantum_mechanic.dm
@@ -72,6 +72,8 @@
 	)
 
 /mob/living/carbon/human/quantum/can_inject(mob/user, target_zone)
+	if(user == src)
+		return ..()
 	to_chat(user, SPAN_DANGER("\The [src] disarms you before you can inject them."))
 	user.drop_item()
 	return FALSE
@@ -163,7 +165,7 @@
 	name = "quantum mechanic's headset"
 	desc = "A quantum mechanic's headset. The letter 'Ω' is stamped on the side."
 	encryption_keys = list(
-		/obj/item/encryptionkey/binary, 
+		/obj/item/encryptionkey/binary,
 		/obj/item/encryptionkey/ert
 	)
 


### PR DESCRIPTION
## Description of changes
- Fixes quantum mechanics being unable to inject themselves.
- Fixes a runtime due to missing kwargs in the QM override for `can_fall()`.

Targeting dev because I was too lazy to resolve conflicts over adjacent telecomms stuff to do it on stable.
## Why and what will this PR improve
Bugfixes!