### PR TITLE
Fix two descriptions and some accidental "scare quotes"

### DIFF
--- a/code/game/machinery/_machines_base/stock_parts/shielding.dm
+++ b/code/game/machinery/_machines_base/stock_parts/shielding.dm
@@ -8,7 +8,7 @@
 /obj/item/stock_parts/shielding/electric
 	name = "fuse box"
 	icon_state = "fusebox"
-	desc = "A bloc of multi-use fuses, protecting the machine against the electrical current spikes."
+	desc = "A bloc of multi-use fuses, used to protect components against electrical current spikes."
 	protection_types = list(ELECTROCUTE)
 	material = /decl/material/solid/metal/steel
 	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
@@ -16,14 +16,14 @@
 /obj/item/stock_parts/shielding/kinetic
 	name = "internal armor"
 	icon_state = "armor"
-	desc = "Kinetic resistant armor plates to line the machine with."
+	desc = "An impact-resistant armor plate used to shield delicate machine components."
 	protection_types = list(BRUTE)
 	material = /decl/material/solid/metal/steel
 
 /obj/item/stock_parts/shielding/heat
 	name = "heatsink"
 	icon_state = "heatsink"
-	desc = "Active cooling system protecting machinery against the high temperatures."
+	desc = "An active cooling system used to safeguard machinery against high temperatures."
 	protection_types = list(BURN)
 	material = /decl/material/solid/metal/steel
 	matter = list(/decl/material/solid/metal/aluminium = MATTER_AMOUNT_REINFORCEMENT)

--- a/code/modules/materials/material_sheets_mapping.dm
+++ b/code/modules/materials/material_sheets_mapping.dm
@@ -1,6 +1,6 @@
 #define STACK_SUBTYPES(MAT_ID, MAT_NAME, MAT_TYPE, STACK_TYPE, REINF_TYPE) \
 /obj/item/stack/material/##STACK_TYPE/mapped/##MAT_ID {                    \
-	name = "1 " + #MAT_NAME;                                               \
+	name = "1 " + MAT_NAME;                                               \
 	material = /decl/material/MAT_TYPE;                                    \
 	reinf_material = REINF_TYPE;                                           \
 	amount = 1;                                                            \

--- a/code/modules/overmap/ships/machines/ion_thruster.dm
+++ b/code/modules/overmap/ships/machines/ion_thruster.dm
@@ -31,7 +31,7 @@
 
 /obj/machinery/ion_thruster
 	name = "ion thruster"
-	desc = "An advanced propulsion device, using energy and minutes amount of gas to generate thrust."
+	desc = "An advanced propulsion device, using energy and minute amounts of gas to generate thrust."
 	icon = 'icons/obj/ship_engine.dmi'
 	icon_state = "nozzle2"
 	density = 1


### PR DESCRIPTION
## Description of changes
- Improves the descriptions for shielding parts.
- Fixes a typo in the ion thruster description.
- Fixes "scare quotes" in mapped sheets of amount 1.

## Why and what will this PR improve
Improvements to various strings, just correcting typos that bothered me.