### PR TITLE
Fix indoor areas becoming outside due to multiz

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -446,9 +446,9 @@
 		var/area/A = get_area(src)
 		. = A ? A.is_outside : OUTSIDE_NO
 
-	// If we are in a multiz volume, we return the outside value of
-	// the highest unenclosed turf in the stack.
-	if(HasAbove(z))
+	// If we are in a multiz volume and not already inside, we return
+	// the outside value of the highest unenclosed turf in the stack.
+	if((. != OUTSIDE_NO) && HasAbove(z))
 		. =  OUTSIDE_YES // assume for the moment we're unroofed until we learn otherwise.
 		var/turf/top_of_stack = src
 		while(HasAbove(top_of_stack.z))


### PR DESCRIPTION
## Description of changes
Makes it so that areas that are `OUTSIDE_NO` will always be treated as having a ceiling regardless of MultiZ status.

## Why and what will this PR improve
Necessary for the Tether (downstream map) to not suddenly empty itself out into space. May also help with shuttles?? IDK.