### PR TITLE
Make CO2 metabolically inert

### DIFF
--- a/code/modules/materials/definitions/gasses/material_gas_mundane.dm
+++ b/code/modules/materials/definitions/gasses/material_gas_mundane.dm
@@ -42,6 +42,7 @@
 	boiling_point = -78 CELSIUS
 	gas_symbol_html = "CO<sub>2</sub>"
 	gas_symbol = "CO2"
+	gas_metabolically_inert = TRUE
 
 /decl/material/gas/carbon_monoxide
 	name = "carbon monoxide"


### PR DESCRIPTION
## Description of changes
No idea if this affects anything other than CO2 disappearing in tanks, so I'm calling this a "tweak" rather than a "fix".

## Why and what will this PR improve
CO2 will no longer permanently disappear out of the air and into your bloodstream, meaning it can build up in tanks that are below ambient pressure. This stops you from popping your lungs from draining your internals outside of a vacuum; you'll just suffocate instead, which is easier to treat. This was supposed to be the case already due to a PR by @noelle-lavenza a while back but it didn't work because of CO2 metabolism.

(I also have a massively-overengineered alternative solution for this ready to go if we *want* CO2 to have on-inhale effects.)