### PR TITLE
Fix runtime from random darkness sounds

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -833,7 +833,7 @@
 	if(isturf(loc) && rand(1,1000) == 1)
 		var/turf/T = loc
 		if(T.get_lumcount() <= LIGHTING_SOFT_THRESHOLD)
-			playsound_local(src,pick(global.scarySounds),50, 1, -1)
+			playsound_local(T,pick(global.scarySounds),50, 1, -1)
 
 	var/area/A = get_area(src)
 	if(client && world.time >= client.played + 600)


### PR DESCRIPTION
## Description of changes
`turf_source` should be null or a turf, not a mob.

## Why and what will this PR improve
Fixes a runtime with a 1/1000 chance of occurring every tick when in complete darkness.