### PR TITLE
Adjust pool turfs to more sensible depths

### DIFF
--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -424,4 +424,7 @@
 	floor_smooth = SMOOTH_NONE
 	wall_smooth = SMOOTH_NONE
 	space_smooth = SMOOTH_NONE
-	height = -FLUID_OVER_MOB_HEAD * 2
+	height = -FLUID_OVER_MOB_HEAD - 50
+
+/decl/flooring/pool/deep
+	height = -FLUID_DEEP - 50

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -171,9 +171,9 @@
 //Tiled floor + sub-types
 
 /turf/simulated/floor/tiled
-	name = "steel floor"
+	name = "floor"
 	icon = 'icons/turf/flooring/tiles.dmi'
-	icon_state = "steel"
+	icon_state = "tiled"
 	initial_flooring = /decl/flooring/tiling
 
 /turf/simulated/floor/tiled/dark
@@ -386,3 +386,9 @@
 	icon = 'icons/turf/flooring/pool.dmi'
 	icon_state = "pool"
 	initial_flooring = /decl/flooring/pool
+
+/turf/simulated/floor/pool/deep
+	name = "deep pool floor"
+	icon = 'icons/turf/flooring/pool.dmi'
+	icon_state = "pool"
+	initial_flooring = /decl/flooring/pool/deep


### PR DESCRIPTION
## Description of changes
Lowers the depth of pool turfs to be around half of what it was before, adds a deeper variant to compensate.

## Why and what will this PR improve
Pools were kind of hilariously deep, you'd instantly drown when entering them. This changes them to sane depths; I might even add a shallow variant at some point in the future.