### PR TITLE
Replace pill bottle names with labels + fix pod/pill bottle bigpharma interactions

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -260,6 +260,10 @@
 	icon_state = "pod21"
 	var/smell_clean_time = 10 MINUTES
 
+// Don't overwrite the custom name.
+/obj/item/chems/pill/detergent/update_container_name()
+	return
+
 /obj/item/chems/pill/detergent/populate_reagents()
 	reagents.add_reagent(/decl/material/gas/ammonia, 30)
 
@@ -267,7 +271,10 @@
 	name = "master flavorpod item"
 	desc = "A cellulose pod containing some kind of flavoring."
 	icon_state = "pill4"
-	presentation_flags = PRESENTATION_FLAG_NAME
+
+// Don't overwrite the custom names.
+/obj/item/chems/pill/pod/update_container_name()
+	return
 
 /obj/item/chems/pill/pod/cream
 	name = "creamer pod"

--- a/code/modules/reagents/storage/pill_bottle.dm
+++ b/code/modules/reagents/storage/pill_bottle.dm
@@ -23,6 +23,8 @@
 
 	var/pop_sound = 'sound/effects/peelz.ogg'
 	var/wrapper_color
+	/// If a string, a label with this value will be added.
+	var/labeled_name = null
 
 /obj/item/storage/pill_bottle/remove_from_storage(obj/item/W, atom/new_location, NoUpdate)
 	. = ..()
@@ -68,6 +70,8 @@
 /obj/item/storage/pill_bottle/Initialize()
 	. = ..()
 	update_icon()
+	if(istext(labeled_name))
+		attach_label(null, null, labeled_name)
 
 /obj/item/storage/pill_bottle/on_update_icon()
 	. = ..()

--- a/code/modules/reagents/storage/pill_bottle_subtypes.dm
+++ b/code/modules/reagents/storage/pill_bottle_subtypes.dm
@@ -1,5 +1,5 @@
 /obj/item/storage/pill_bottle/antitox
-	name = "pill bottle (antitoxins)"
+	labeled_name = "antitoxins"
 	desc = "Contains pills used to counter toxins."
 	wrapper_color = COLOR_GREEN
 
@@ -7,7 +7,7 @@
 	return list(/obj/item/chems/pill/antitox = 21)
 
 /obj/item/storage/pill_bottle/brute_meds
-	name = "pill bottle (styptic)"
+	labeled_name = "styptic"
 	desc = "Contains pills used to stabilize the severely injured."
 	wrapper_color = COLOR_MAROON
 
@@ -15,7 +15,7 @@
 	return list(/obj/item/chems/pill/brute_meds = 21)
 
 /obj/item/storage/pill_bottle/oxygen
-	name = "pill bottle (oxygen)"
+	labeled_name = "oxygen"
 	desc = "Contains pills used to treat oxygen deprivation."
 	wrapper_color = COLOR_LIGHT_CYAN
 
@@ -23,7 +23,7 @@
 	return list(/obj/item/chems/pill/oxygen = 21)
 
 /obj/item/storage/pill_bottle/antitoxins
-	name = "pill bottle (antitoxins)"
+	labeled_name = "antitoxins"
 	desc = "Contains pills used to treat toxic substances in the blood."
 	wrapper_color = COLOR_GREEN
 
@@ -31,7 +31,7 @@
 	return list(/obj/item/chems/pill/antitoxins = 21)
 
 /obj/item/storage/pill_bottle/stabilizer
-	name = "pill bottle (stabilizer)"
+	labeled_name = "stabilizer"
 	desc = "Contains pills used to stabilize patients."
 	wrapper_color = COLOR_PALE_BLUE_GRAY
 
@@ -39,7 +39,7 @@
 	return list(/obj/item/chems/pill/stabilizer = 21)
 
 /obj/item/storage/pill_bottle/burn_meds
-	name = "pill bottle (synthskin)"
+	labeled_name = "synthskin"
 	desc = "Contains pills used to treat burns."
 	wrapper_color = COLOR_SUN
 
@@ -47,7 +47,7 @@
 	return list(/obj/item/chems/pill/burn_meds = 21)
 
 /obj/item/storage/pill_bottle/antibiotics
-	name = "pill bottle (antibiotics)"
+	labeled_name = "antibiotics"
 	desc = "A theta-lactam antibiotic. Effective against many diseases likely to be encountered in space."
 	wrapper_color = COLOR_PALE_GREEN_GRAY
 
@@ -55,7 +55,7 @@
 	return list(/obj/item/chems/pill/antibiotics = 14)
 
 /obj/item/storage/pill_bottle/painkillers
-	name = "pill bottle (painkillers)"
+	labeled_name = "painkillers"
 	desc = "Contains pills used to relieve pain."
 	wrapper_color = COLOR_PURPLE_GRAY
 
@@ -64,7 +64,7 @@
 
 //Baycode specific Psychiatry pills.
 /obj/item/storage/pill_bottle/antidepressants
-	name = "pill bottle (antidepressants)"
+	labeled_name = "antidepressants"
 	desc = "Mild antidepressant. For use in individuals suffering from depression or anxiety. 15u dose per pill."
 	wrapper_color = COLOR_GRAY
 
@@ -72,7 +72,7 @@
 	return list(/obj/item/chems/pill/antidepressants = 21)
 
 /obj/item/storage/pill_bottle/stimulants
-	name = "pill bottle (stimulants)"
+	labeled_name = "stimulants"
 	desc = "Mental stimulant. For use in individuals suffering from ADHD, or general concentration issues. 15u dose per pill."
 	wrapper_color = COLOR_GRAY
 
@@ -80,9 +80,9 @@
 	return list(/obj/item/chems/pill/stimulants = 21)
 
 /obj/item/storage/pill_bottle/assorted
-	name = "pill bottle (assorted)"
+	labeled_name = "assorted"
 	desc = "Commonly found on paramedics, these assorted pill bottles contain all the basics."
-	
+
 /obj/item/storage/pill_bottle/assorted/WillContain()
 	return list(
 			/obj/item/chems/pill/stabilizer = 6,

--- a/mods/content/bigpharma/_bigpharma.dm
+++ b/mods/content/bigpharma/_bigpharma.dm
@@ -53,6 +53,9 @@ var/global/list/reagent_names_to_icon_state
 			chems.label_text = new_name
 			chems.update_container_name()
 		else
+			if(has_extension(thing, /datum/extension/labels))
+				var/datum/extension/labels/L = get_extension(thing, /datum/extension/labels)
+				L.RemoveAllLabels()
 			thing.attach_label(null, null, new_name)
 	if(meds.container_description)
 		thing.desc = meds.container_description

--- a/mods/content/bigpharma/overrides.dm
+++ b/mods/content/bigpharma/overrides.dm
@@ -27,3 +27,12 @@
 
 /obj/item/chems/pill/gleam
 	obfuscated_meds_type = null
+
+/obj/item/storage/pill_bottle/assorted
+	obfuscated_meds_type = null
+
+/obj/item/chems/pill/detergent
+	obfuscated_meds_type = null
+
+/obj/item/chems/pill/pod
+	obfuscated_meds_type = null


### PR DESCRIPTION
## Description of changes
- The fake labels in the names of preset pill bottles are now actual labels.
- Bigpharma will no longer change the name and appearance of the following:
 - Assorted pill bottles
 - Detergent pods
 - Flavorpods
- The reagent presentation system will no longer change the name and appearance of flavorpods.

Potential TODO: Unify detergent pods and flavorpods somehow?

## Why and what will this PR improve
No more `pill bottle (kelotane) (Dormiprezivir©)`.
Detergent pods and flavorpods are no longer made into branded pills when bigpharma is enabled.
Detergent pods are no longer replaced with generic `pills` when bigpharma isn't enabled.
Flavorpods are no longer auto-renamed to `pod of milk` when bigpharma isn't enabled.