### PR TITLE
Add ZM_PARTITION_STACK for weather/outsideness/sky

### DIFF
--- a/code/__defines/zmimic.dm
+++ b/code/__defines/zmimic.dm
@@ -7,9 +7,10 @@
 #define ZM_MIMIC_OVERWRITE 2	//! If this turf is Z-mimicking, overwrite the turf's appearance instead of using a movable. This is faster, but means the turf cannot have its own appearance (say, edges or a translucent sprite).
 #define ZM_ALLOW_LIGHTING  4	//! If this turf should permit passage of lighting.
 #define ZM_ALLOW_ATMOS     8	//! If this turf permits passage of air.
-#define ZM_MIMIC_NO_AO    16	//! If the turf shouldn't apply regular turf AO and only do Z-mimic AO.
-#define ZM_NO_OCCLUDE     32	//! Don't occlude below atoms if we're a non-mimic z-turf.
-#define ZM_MIMIC_BASETURF 64	//! Mimic baseturf instead of the below atom. Sometimes useful for elevators.
+#define ZM_MIMIC_NO_AO     16	//! If the turf shouldn't apply regular turf AO and only do Z-mimic AO.
+#define ZM_NO_OCCLUDE      32	//! Don't occlude below atoms if we're a non-mimic z-turf.
+#define ZM_MIMIC_BASETURF  64	//! Mimic baseturf instead of the below atom. Sometimes useful for elevators.
+#define ZM_PARTITION_STACK 128	//! If this turf counts as the top of its z-stack for some checks (e.g. is_outside).
 
 // Convenience flag.
 #define ZM_MIMIC_DEFAULTS (ZM_MIMIC_BELOW|ZM_ALLOW_LIGHTING)

--- a/code/game/turfs/exterior/exterior_sky.dm
+++ b/code/game/turfs/exterior/exterior_sky.dm
@@ -2,7 +2,11 @@
 	name = "sky"
 	desc = "Hope you don't have a fear of heights..."
 	icon = 'icons/turf/exterior/sky_static.dmi'
-	z_flags = 0
+	z_flags = ZM_PARTITION_STACK
+
+// No matter what, the sky will never be 'inside'.
+/turf/exterior/open/sky/is_outside()
+	return TRUE // you can't take the sky from meee
 
 /turf/exterior/open/sky/north
 	dir = NORTH

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -456,6 +456,10 @@
 			if(!next_turf.is_open())
 				return OUTSIDE_NO
 			top_of_stack = next_turf
+			// ZM_PARTITION_STACK partitions the z-stack such that
+			// for the purposes of this check, the z-stack ends with it.
+			if(top_of_stack.z_flags & ZM_PARTITION_STACK)
+				break
 		// If we hit the top of the stack without finding a roof, we ask the upmost turf if we're outside.
 		. = top_of_stack.is_outside()
 	last_outside_check = . // Cache this for later calls.


### PR DESCRIPTION
## Description of changes
Adds a turf z_flag that terminates outsideness z-stack traversal when the turf is reached.

## Why and what will this PR improve
For cases where you have a surface level, a sky level, and a space level all connected in a z-stack, surface weather should only consider being blocked up to the sky level; something in space is not going to stop the weather.