### PR TITLE
Add per-floor elevator move time

### DIFF
--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -16,7 +16,7 @@
 	var/list/doors = list()                             // Doors inside the lift structure.
 	var/list/queued_floors = list()                     // Where are we moving to next?
 	var/list/floors = list()                            // All floors in this system.
-	var/move_delay = 3 SECONDS                          // Time between floor changes.
+	var/move_delay = 3 SECONDS                          // Default time between floor changes, can be overridden per-floor
 	var/floor_wait_delay = 9 SECONDS                    // Time to wait at floor stops.
 	var/obj/structure/lift/panel/control_panel_interior // Lift control panel.
 	var/doors_closing = 0								// Whether doors are in the process of closing
@@ -59,7 +59,7 @@
 				queued_floors.Cut()
 				return PROCESS_KILL
 			else if(!next_process)
-				next_process = world.time + move_delay
+				next_process = world.time + (isnull(current_floor?.delay_time) ?  move_delay : current_floor.delay_time)
 		if(LIFT_WAITING_A)
 			var/area/turbolift/origin = locate(current_floor.area_ref)
 			if(origin.lift_announce_str)

--- a/code/modules/turbolift/turbolift_areas.dm
+++ b/code/modules/turbolift/turbolift_areas.dm
@@ -10,3 +10,4 @@
 	var/lift_floor_name = null
 	var/lift_announce_str = "Ding!"
 	var/arrival_sound = 'sound/machines/ding.ogg'
+	var/delay_time

--- a/code/modules/turbolift/turbolift_floor.dm
+++ b/code/modules/turbolift/turbolift_floor.dm
@@ -5,6 +5,7 @@
 	var/name
 	var/announce_str
 	var/arrival_sound
+	var/delay_time
 
 	var/list/doors = list()
 	var/obj/structure/lift/button/ext_panel
@@ -20,6 +21,7 @@
 	name = A.lift_floor_name ? A.lift_floor_name : A.proper_name
 	announce_str = A.lift_announce_str
 	arrival_sound = A.arrival_sound
+	delay_time = A.delay_time
 
 //called when a lift has queued this floor as a destination
 /datum/turbolift_floor/proc/pending_move(var/datum/turbolift/lift)


### PR DESCRIPTION
## Description of changes
Turbolift areas can now specify the time it takes for the elevator to move through them.

Possible future TODO: Unify this with fall damage by using some kind of `virtual_height` variable on level data, to pretend that it's actually multiple z-levels tall.

## Why and what will this PR improve
This lets you fake some z-levels being 'taller' than they actually are.