### PR TITLE
Make turfs with null initial gas use level data

### DIFF
--- a/code/modules/ZAS/Turf.dm
+++ b/code/modules/ZAS/Turf.dm
@@ -227,11 +227,9 @@
 		return zone.air
 
 	// Exterior turf global atmosphere
-	if(external_atmosphere_participation && is_outside())
+	if((!air && isnull(initial_gas)) || (external_atmosphere_participation && is_outside()))
 		var/datum/level_data/level = SSmapping.levels_by_z[z]
-		var/datum/gas_mixture/gas = level?.get_exterior_atmosphere()
-		if(!gas)
-			return
+		var/datum/gas_mixture/gas = level.get_exterior_atmosphere()
 		var/initial_temperature = gas.temperature
 		if(weather)
 			initial_temperature = weather.adjust_temperature(initial_temperature)


### PR DESCRIPTION
## Description of changes
Turfs with null initial gas use level data atmosphere as their initial gas.

## Why and what will this PR improve
Makes mapping substantially easier; you can use simulated turfs outside without accidentally contaminating the atmosphere and creating, for example, an extremely potent burnmix. Oops.