### PR TITLE
QDELETED check for net devices

### DIFF
--- a/code/modules/modular_computers/networking/_network.dm
+++ b/code/modules/modular_computers/networking/_network.dm
@@ -49,6 +49,8 @@
 	. = ..()
 
 /datum/computer_network/proc/add_device(datum/extension/network_device/D)
+	if(QDELETED(D))
+		return FALSE
 	if(D.network_id != network_id)
 		return FALSE
 	if(D.key != network_key)


### PR DESCRIPTION
## Description of changes
QDELETED devices return FALSE when attempting to connect

## Why and what will this PR improve
Encountered a bug where the ``connected_radios`` list on networks contained a null item. Since this is supposed to be a list of weakrefs, the only way I can imagine this happening is a QDELETED radio attempting to connect to the network. In that case the ``weakref()`` call in the network device's ``connect()`` proc would add the null entry. This should prevent that.