### PR TITLE
Fixes network-pipeline relationship

### DIFF
--- a/code/modules/atmospherics/datum_pipe_network.dm
+++ b/code/modules/atmospherics/datum_pipe_network.dm
@@ -11,7 +11,8 @@
 /datum/pipe_network/Destroy()
 	STOP_PROCESSING_PIPENET(src)
 	for(var/datum/pipeline/line_member in line_members)
-		line_member.network = null
+		if(line_member.network == src)
+			line_member.network = null
 	for(var/obj/machinery/atmospherics/normal_member in normal_members)
 		normal_member.reassign_network(src, null)
 	gases.Cut()  // Do not qdel the gases, we don't own them


### PR DESCRIPTION
## Description of changes
Adds a check to make sure a pipe network owns a line member before nulling the member's ``network`` var in Destroy
## Why and what will this PR improve
Fixes a bug where pipelines would have their network variable erroneously nulled. For the specific case of merging networks with a valve, this was probably introduced in https://github.com/NebulaSS13/Nebula/pull/118. I'm unsure if there's other cases where this would occur, or what (if any) player visible effects it'd have.

## Authorship
Myself