### PR TITLE
Simplify new z maploading and fix lighting sanity checks

### DIFF
--- a/code/controllers/subsystems/lighting.dm
+++ b/code/controllers/subsystems/lighting.dm
@@ -79,9 +79,12 @@ SUBSYSTEM_DEF(lighting)
 /datum/controller/subsystem/lighting/proc/InitializeZlev(zlev)
 	for (var/thing in Z_ALL_TURFS(zlev))
 		var/turf/T = thing
-		if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(T) && !T.lighting_overlay)	// Can't assume that one hasn't already been created on bay/neb.
-			new /atom/movable/lighting_overlay(T)
-			. += 1
+		if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+			if (T.lighting_overlay)
+				log_ss(name, "Found unexpected lighting overlay at [T.x],[T.y],[T.z]")
+			else
+				new /atom/movable/lighting_overlay(T)
+				. += 1
 			if (T.ambient_light)
 				T.generate_missing_corners()	// Forcibly generate corners.
 

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -117,7 +117,7 @@
 	if ((old_opacity != opacity) || (tidlu != old_dynamic_lighting) || force_lighting_update)
 		reconsider_lights()
 
-	if (tidlu != old_dynamic_lighting)
+	if (SSlighting.initialized && (tidlu != old_dynamic_lighting))
 		if (tidlu)
 			lighting_build_overlay()
 		else

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -120,8 +120,7 @@
 // Builds a lighting overlay for us, but only if our area is dynamic.
 /turf/proc/lighting_build_overlay(now = FALSE)
 	if (lighting_overlay)
-		return	// shrug
-		// CRASH("Attempted to create lighting_overlay on tile that already had one.")
+		CRASH("Attempted to create lighting_overlay on tile that already had one.")
 
 	if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(src))
 		if (!lighting_corners_initialised || !corners)

--- a/code/modules/maps/_map_template.dm
+++ b/code/modules/maps/_map_template.dm
@@ -161,7 +161,7 @@
 
 	return WORLD_CENTER_TURF(world.maxz)
 
-/datum/map_template/proc/load(turf/T, centered=FALSE)
+/datum/map_template/proc/load(turf/T, centered=FALSE, no_changeturf = FALSE)
 	if(centered)
 		T = locate(T.x - (round(width/2) - 1), T.y - (round(height/2) - 1), T.z)
 	if(!T)
@@ -178,7 +178,7 @@
 
 	var/initialized_areas_by_type = list()
 	for (var/mappath in mappaths)
-		var/datum/map_load_metadata/M = load_single_path(mappath, T.x, T.y, T.z, null, initialized_areas_by_type, FALSE, TRUE)
+		var/datum/map_load_metadata/M = load_single_path(mappath, T.x, T.y, T.z, null, initialized_areas_by_type, no_changeturf, TRUE)
 		if (M)
 			atoms_to_initialise += M.atoms_to_initialise
 		else
@@ -192,7 +192,7 @@
 	init_atoms(atoms_to_initialise)
 	init_shuttles(shuttle_state, map_hash, initialized_areas_by_type)
 	after_load()
-	if (SSlighting.initialized)
+	if (no_changeturf && SSlighting.initialized)
 		SSlighting.InitializeTurfs(atoms_to_initialise)	// Hopefully no turfs get placed on new coords by SSatoms.
 
 	log_game("[name] loaded at at [T.x],[T.y],[T.z]")

--- a/code/modules/maps/_map_template.dm
+++ b/code/modules/maps/_map_template.dm
@@ -156,37 +156,8 @@
 	if(!centered)
 		x = 1
 		y = 1
-
-	var/list/bounds = list(1.#INF, 1.#INF, 1.#INF, -1.#INF, -1.#INF, -1.#INF)
-	var/list/atoms_to_initialise = list()
-	var/shuttle_state = pre_init_shuttles()
-	var/map_hash = modify_tag_vars && "[sequential_id("map_id")]"
-	ASSERT(isnull(global._preloader.current_map_hash)) // Recursive maploading is possible, but not from this block: recursive loads should be triggered in Initialize, from init_atoms below.
-	global._preloader.current_map_hash = map_hash
-
-	var/initialized_areas_by_type = list()
-	for (var/mappath in mappaths)
-		var/datum/map_load_metadata/M = load_single_path(mappath, x, y, world.maxz + 1, bounds, initialized_areas_by_type, no_changeturf, FALSE)
-		if (M)
-			atoms_to_initialise += M.atoms_to_initialise
-		else
-			//Abort if loading failed
-			global._preloader.current_map_hash = null //Clear current map hash to prevent problems if we load something else later and cause false positives
-			CRASH("Failed to load '[src]''s '[mappath]' map file!")
-
-	global._preloader.current_map_hash = null
-
-	//initialize things that are normally initialized after map load
-	init_atoms(atoms_to_initialise)
-	init_shuttles(shuttle_state, map_hash, initialized_areas_by_type)
-	after_load()
-	for(var/z_index = bounds[MAP_MINZ] to bounds[MAP_MAXZ])
-		var/datum/level_data/level = SSmapping.levels_by_z[z_index]
-		level.after_template_load(src)
-		if(SSlighting.initialized)
-			SSlighting.InitializeZlev(z_index)
-	log_game("Z-level [name] loaded at [x],[y],[world.maxz]")
-	loaded++
+	SSmapping.increment_world_z_size(/datum/level_data/space)
+	load(locate(x, y, world.maxz), FALSE, no_changeturf)
 
 	return WORLD_CENTER_TURF(world.maxz)
 

--- a/code/modules/maps/reader.dm
+++ b/code/modules/maps/reader.dm
@@ -185,8 +185,6 @@ var/global/dmm_suite/preloader/_preloader = new
 							maxx = max(maxx, xcrd)
 							++xcrd
 					--ycrd
-				if (zexpansion && SSlighting.initialized)
-					SSlighting.InitializeZlev(zcrd)
 
 			bounds[MAP_MAXX] = clamp(max(bounds[MAP_MAXX], cropMap ? min(maxx, world.maxx) : maxx), x_lower, x_upper)
 


### PR DESCRIPTION
## Description of changes
Restores some missing sanity checks in lighting init code.
Removes code that was violating those sanity checks. As far as I can tell, calling `SSlighting.InitZLev` like that is invalid and leads to the sanity check failing, and some code in ChangeTurf led to double initializations.
`load_new_z` now just calls `load` directly.

## Why and what will this PR improve
Reduces code duplication in `load_new_z`, makes lighting init more sane (and hopefully faster, since we're not wasting any update passes).