### PR TITLE
Improve Supply Shuttle Unit Test

### DIFF
--- a/code/unit_tests/unit_test.dm
+++ b/code/unit_tests/unit_test.dm
@@ -184,6 +184,8 @@ var/global/ascii_reset = "[ascii_esc]\[0m"
 
 //For async tests. Returns 1 if done.
 /proc/check_unit_test(datum/unit_test/test, end_time)
+	if(test.reported)
+		return 1 //The test reported failure/success/skip already
 	if(world.time > end_time)
 		test.fail("Unit Tests Ran out of Time")// If we're going to run out of time, most likely it's here.  If you can't speed up your unit tests then add time to the timeout at the top.
 		return 1

--- a/code/unit_tests/zas_tests.dm
+++ b/code/unit_tests/zas_tests.dm
@@ -98,52 +98,62 @@
 // ==================================================================================================
 
 
-// Here we move a shuttle then test it's area once the shuttle has arrived.
-
+/// Here we move a shuttle then test it's area once the shuttle has arrived.
 /datum/unit_test/zas_supply_shuttle_moved
-	name = "ZAS: Supply Shuttle (When Moved)"
-	async=1				// We're moving the shuttle using built in procs.
+	name  = "ZAS: Supply Shuttle (When Moved)"
+	async = TRUE // We're moving the shuttle using built in procs.
 
+	///The shuttle datum of the supply shuttle
 	var/datum/shuttle/autodock/ferry/supply/shuttle = null
+	///The shuttle movetime initially set for the cargo shuttle, so we can restore it
+	var/initial_movetime
+	///The starting waypoint of the shuttle
+	var/obj/effect/shuttle_landmark/shuttle_start
+	///The destination waypoint of the shuttle
+	var/obj/effect/shuttle_landmark/shuttle_destination
 
-	var/testtime = 0	//Used as a timer.
+/datum/unit_test/zas_supply_shuttle_moved/subsystems_to_await()
+	return list(SSmapping, SSair, SStimer, SSmachines, SSsupply, SSshuttle)
 
 /datum/unit_test/zas_supply_shuttle_moved/start_test()
 
 	if(!SSshuttle)
 		fail("Shuttle Controller not setup at time of test.")
 		return 1
-	if(!SSshuttle.shuttles.len)
+	if(length(SSshuttle.shuttles) <= 0)
 		skip("No shuttles have been setup for this map.")
 		return 1
-
-	shuttle = SSsupply.shuttle
-	if(isnull(shuttle))
+	if(!SSsupply.shuttle)
+		skip("This map has no supply shuttle.")
 		return 1
+	shuttle = SSsupply.shuttle
+
+	//This test is only valid if the shuttle still works this way
+	ASSERT(shuttle.location == 0 || shuttle.location == 1)
+
+	//Setup our variables
+	initial_movetime    = SSsupply.movetime
+	SSsupply.movetime   = 5 // Speed up the shuttle movement.
+	shuttle_start       = shuttle.get_location_waypoint(shuttle.location)
+	shuttle_destination = shuttle.get_location_waypoint(!shuttle.location)
 
 	// Initiate the Move.
-	SSsupply.movetime = 5 // Speed up the shuttle movement.
-	shuttle.short_jump(shuttle.get_location_waypoint(!shuttle.location)) //TODO
-
+	shuttle.short_jump(shuttle_destination)
 	return 1
 
 /datum/unit_test/zas_supply_shuttle_moved/check_result()
-	if(!shuttle)
-		skip("This map has no supply shuttle.")
-		return 1
+	if(shuttle.moving_status == SHUTTLE_INTRANSIT || shuttle.moving_status == SHUTTLE_WARMUP)
+		return //Return null to keep checking async
 
-	if(shuttle.moving_status == SHUTTLE_IDLE && !shuttle.at_station())
+	//Restore shuttle movetime for any following tests
+	SSsupply.movetime = initial_movetime
+
+	//Check if we moved
+	if(shuttle.current_location == shuttle_start)
 		fail("Shuttle Did not Move")
 		return 1
 
-	if(!shuttle.at_station())
-		return 0
-
-	if(!testtime)
-		testtime = world.time+40                // Wait another 2 ticks then proceed.
-
-	if(world.time < testtime)
-		return 0
+	//Do the air zone test
 	for(var/area/A in shuttle.shuttle_area)
 		var/list/test = test_air_in_area(A.type, global.using_map.shuttle_atmos_expectation)
 		if(isnull(test))

--- a/code/unit_tests/zas_tests.dm
+++ b/code/unit_tests/zas_tests.dm
@@ -113,7 +113,7 @@
 	var/obj/effect/shuttle_landmark/shuttle_destination
 
 /datum/unit_test/zas_supply_shuttle_moved/subsystems_to_await()
-	return list(SSmapping, SSair, SStimer, SSmachines, SSsupply, SSshuttle)
+	return list(SSair, SStimer, SSmachines, SSsupply, SSshuttle)
 
 /datum/unit_test/zas_supply_shuttle_moved/start_test()
 
@@ -143,10 +143,9 @@
 
 /datum/unit_test/zas_supply_shuttle_moved/check_result()
 	if(shuttle.moving_status == SHUTTLE_INTRANSIT || shuttle.moving_status == SHUTTLE_WARMUP)
-		return //Return null to keep checking async
+		return 0 //Return 0 to keep checking async
 
-	//Restore shuttle movetime for any following tests
-	SSsupply.movetime = initial_movetime
+	testing("Supply shuttle is now idle.")
 
 	//Check if we moved
 	if(shuttle.current_location == shuttle_start)
@@ -165,3 +164,8 @@
 			if(SKIP)    skip(test["msg"])
 			else        fail(test["msg"])
 	return 1
+
+/datum/unit_test/zas_supply_shuttle_moved/teardown_test()
+	//Restore shuttle movetime for any following tests
+	SSsupply.movetime = initial_movetime
+	return ..()


### PR DESCRIPTION
## Description of changes
The supply shuttle unit test has some issues with maps where the shuttle begins at the station's cargo dock instead of off-map.
* It would assume being idle and at ``location != !location`` meant that it did not move before checking if some time has passed.
* It would check the boolean ``location`` var to tell if it had moved or not. 
* It didn't wait on any of the important subsystems for it to even work properly.
* It would change the transit time for supply shuttles globally and not restore it after the test is done.
* It would wait some extra 4 seconds between checks even though there's already a wait loop in place waiting 2 seconds each iteration.

So what I've done is:
* Check if it moved using ``shuttle.current_location == shuttle_start`` instead of relying on a boolean. So a different configuration won't break the unit test anymore.
* Restore the transit time after the unit test is concluded.
* Removed its redundant internal time check.
* Made it wait for all the subsystems shuttle realistically needs to work.

## Why and what will this PR improve
It makes the supply shuttle unit test more robust when a map doesn't make the shuttle start off-map. And it also brings the code a bit more up to date with the current unit test setup.
