### PR TITLE
Improve shuttle console display

### DIFF
--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -77,7 +77,7 @@
 /datum/shuttle/autodock/overmap/get_location_name()
 	if(moving_status == SHUTTLE_INTRANSIT)
 		return "In transit"
-	return "[waypoint_sector(current_location)] - [current_location]"
+	return "\the [waypoint_sector(current_location)] - [current_location]"
 
 /datum/shuttle/autodock/overmap/get_destination_name()
 	if(!next_location)

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -325,7 +325,7 @@
 /datum/shuttle/autodock/proc/get_location_name()
 	if(moving_status == SHUTTLE_INTRANSIT)
 		return "In transit"
-	return current_location.name
+	return "\the [current_location]"
 
 /datum/shuttle/autodock/proc/get_destination_name()
 	if(!next_location)

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -34,7 +34,7 @@
 			else if(cannot_depart)
 				shuttle_status = cannot_depart
 			else
-				shuttle_status = "Standing-by at \the [shuttle.get_location_name()]."
+				shuttle_status = "Standing-by at [shuttle.get_location_name()]."
 
 		if(WAIT_LAUNCH, FORCE_LAUNCH)
 			shuttle_status = "Shuttle has recieved command and will depart shortly."

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -193,7 +193,7 @@ abbr {
 }
 
 .idle {
-	color: #272727;
+	color: #666666;
 	font-weight: bold;
 }
 


### PR DESCRIPTION
## Description of changes
Makes idle shuttle console text readable with our current theme.
Fixes incorrect capitalization of shuttle current location—it was (implicitly) using `\The` instead of `\the`.

## Why and what will this PR improve
The old color was too dark to read on our NanoUI theme.
`Standing-by at The exoplanet` is also unpleasant to read.