### PR TITLE
Fix weather and exoplanet weather selection

### DIFF
--- a/code/datums/extensions/state_machine.dm
+++ b/code/datums/extensions/state_machine.dm
@@ -93,7 +93,10 @@ var/global/list/state_machines = list()
 	var/datum/holder_instance = get_holder()
 	if(istype(current_state))
 		current_state.exited_state(holder_instance)
-	current_state = GET_DECL(new_state_type)
+	if(ispath(new_state_type))
+		current_state = GET_DECL(new_state_type)
+	else // need to include null here, so we can't do an istype
+		current_state = new_state_type
 	if(istype(current_state))
 		current_state.entered_state(holder_instance)
 		return current_state

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/barren.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/barren.dm
@@ -46,6 +46,7 @@
 	atmosphere_gen_pressure_max    = 0.05 ATM
 	atmosphere_gen_temperature_min = -240 CELSIUS //-240c is about the surface temp of pluto for ref
 	atmosphere_gen_temperature_max = 450 CELSIUS //450c is the temperature at the surface of mercury for ref
+	initial_weather_state          = null // No weather.
 	possible_rock_colors           = list(
 		COLOR_BEIGE,
 		COLOR_GRAY80,

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/desert.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/desert.dm
@@ -74,6 +74,7 @@
 	habitability_class             = null //Generate randomly
 	atmosphere_gen_temperature_min = 40 CELSIUS
 	atmosphere_gen_temperature_max = 120 CELSIUS
+	initial_weather_state          = null // No weather.
 	surface_light_gen_level_min    = 0.5
 	surface_light_gen_level_max    = 0.95
 	flora                          = /datum/planet_flora/random/desert

--- a/code/modules/maps/template_types/random_exoplanet/planetoid_data.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planetoid_data.dm
@@ -34,8 +34,8 @@
 	var/temperature_min = 0 CELSIUS
 	///The maximum temperature that can be reached on the planet.(For instance via meteo or sunlight/shade or whatever)
 	var/temperature_max = 25 CELSIUS
-	///What weather state to use for this planet initially. If null, will not initialize any weather system. May be type path at definition or instance at runtime.
-	var/decl/state/weather/initial_weather_state
+	///What weather state to use for this planet initially. If null, will not initialize any weather system. Must be a typepath rather than an instance.
+	var/decl/state/weather/initial_weather_state = /decl/state/weather/calm
 
 	// *** Appearence ***
 	///A weak reference to the overmap marker for this template instance if any exists. Or at definition the type path of the marker to use
@@ -156,8 +156,6 @@
 
 ///Resets the given weather state to our planet replacing the old one, and trigger updates. Can be a type path or instance.
 /datum/planetoid_data/proc/reset_weather(var/decl/state/weather/W)
-	if(ispath(W))
-		W = GET_DECL(W)
 	initial_weather_state = W
 	if(!(topmost_level_id in SSmapping.levels_by_id))
 		return //It's entire possible the levels weren't initialized yet, so don't bother.

--- a/code/modules/maps/template_types/random_exoplanet/random_planet.dm
+++ b/code/modules/maps/template_types/random_exoplanet/random_planet.dm
@@ -234,7 +234,7 @@
 
 ///Make sure all levels of this planet have the weather system setup.
 /datum/map_template/planetoid/random/proc/generate_weather(var/datum/planetoid_data/gen_data, var/datum/level_data/topmost_level_data)
-	if(!ispath(gen_data.initial_weather_state, /decl/state/weather))
+	if(!gen_data.initial_weather_state)
 		return
 	gen_data.reset_weather(gen_data.initial_weather_state)
 

--- a/code/modules/weather/_weather.dm
+++ b/code/modules/weather/_weather.dm
@@ -96,4 +96,7 @@
 	icon = 'icons/effects/weather.dmi'
 	icon_state = "full"
 	alpha = 0
-	invisibility = 0
+
+/obj/abstract/lightning_overlay/Initialize()
+	. = ..()
+	invisibility = 0 // This is set to maximum in parent regardless of what we set, because we can't have nice things.

--- a/code/modules/weather/weather_init.dm
+++ b/code/modules/weather/weather_init.dm
@@ -4,6 +4,8 @@ INITIALIZE_IMMEDIATE(/obj/abstract/weather_system)
 
 	. = ..()
 
+	invisibility = 0
+
 	// Bookkeeping/rightclick guards.
 	verbs.Cut()
 	forceMove(null)


### PR DESCRIPTION
## Description of changes
Readds calm initial weather state to most planets, except for barren and desert planets which still have no weather.
Removes a lot of incorrect ispath(initial_weather_state) gating that was preventing exoplanet weather init.
Fixes errors from passing a state decl to set_state instead of a state typepath.
#2827 made all abstract objects invisible which made weather effects invisible; they now set themselves to visible in init to get around this. :(

## Why and what will this PR improve
Weather is back, and visible now!