### PR TITLE
Fix cached reagents color and fluid dehydration

### DIFF
--- a/code/controllers/subsystems/fluids.dm
+++ b/code/controllers/subsystems/fluids.dm
@@ -122,6 +122,7 @@ SUBSYSTEM_DEF(fluids)
 		// Evaporation: todo, move liquid into current_turf.zone air contents if applicable.
 		if(current_depth <= FLUID_MINIMUM_TRANSFER && prob(15))
 			current_turf.remove_fluids(min(current_depth, 1), defer_update = TRUE)
+			current_depth = current_turf.get_fluid_depth()
 		if(current_depth <= FLUID_QDEL_POINT)
 			qdel(current_fluid)
 			continue
@@ -132,6 +133,7 @@ SUBSYSTEM_DEF(fluids)
 				current_turf.remove_fluids(removing, defer_update = TRUE)
 			else
 				reagent_holder.clear_reagents()
+			current_depth = current_turf.get_fluid_depth()
 			if(current_depth <= FLUID_QDEL_POINT)
 				qdel(current_fluid)
 				continue
@@ -146,6 +148,7 @@ SUBSYSTEM_DEF(fluids)
 						other_fluid = new(below)
 					if(!QDELETED(other_fluid) && other_fluid.reagents.total_volume < FLUID_MAX_DEPTH)
 						current_turf.transfer_fluids_to(below, min(FLOOR(current_depth*0.5), FLUID_MAX_DEPTH - other_fluid.reagents.total_volume), defer_update = TRUE)
+						current_depth = current_turf.get_fluid_depth()
 
 		if(current_depth <= FLUID_PUDDLE)
 			continue

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -198,11 +198,13 @@ var/global/obj/temp_reagents_holder = new
 		var/tmp_data = newreagent.initialize_data(data)
 		if(tmp_data)
 			LAZYSET(reagent_data, reagent_type, tmp_data)
+		if(reagent_volumes.len == 1) // if this is the first reagent, uncache color
+			cached_color = null
 	else
 		reagent_volumes[reagent_type] += amount
 		if(!isnull(data))
 			LAZYSET(reagent_data, reagent_type, newreagent.mix_data(src, data, amount))
-	if(reagent_volumes.len > 1)
+	if(reagent_volumes.len > 1) // otherwise if we have a mix of reagents, uncache as well
 		cached_color = null
 	UNSETEMPTY(reagent_volumes)
 


### PR DESCRIPTION
## Description of changes
Depth is now updated during dehydration so that empty puddles are properly deleted.
Cached reagent holder color is now properly invalidated when going from 0 to 1 reagents.

## Why and what will this PR improve
Some fluid overlays would turn or flash white, which looked bad. The cause was twofold:
- Empty puddles wouldn't get deleted, having their color set to `#FFFFFF` because they were empty.
- If a puddle goes down to 0 reagents during transfer but then has more added before the deletion check, it wouldn't regenerate its color, making it `#FFFFFF`.