### PR TITLE
Remove shuttle console damage invulnerabilities

### DIFF
--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -117,13 +117,3 @@
 		hacked = 1
 		to_chat(user, "You short out the console's ID checking system. It's now available to everyone!")
 		return 1
-
-/obj/machinery/computer/shuttle_control/bullet_act(var/obj/item/projectile/Proj)
-	visible_message("\The [Proj] ricochets off \the [src]!")
-
-/obj/machinery/computer/shuttle_control/explosion_act()
-	SHOULD_CALL_PARENT(FALSE)
-	return
-
-/obj/machinery/computer/shuttle_control/emp_act()
-	return


### PR DESCRIPTION
## Description of changes
Shuttle consoles are no longer immune to damage, because they can be rebuilt.

## Why and what will this PR improve
I dropped a giant bomb on a ship and the only thing left was the shuttle console, which was pretty jarring. Also, you could just take it apart and then the circuitboard (with the data) would still be able to be destroyed, so the original rationale no longer really applies either.