### PR TITLE
Improve and fix lobby menu/character setup

### DIFF
--- a/code/_helpers/cmp.dm
+++ b/code/_helpers/cmp.dm
@@ -124,3 +124,9 @@
 	. = istype(b, /datum/computer_file/directory) - istype(a, /datum/computer_file/directory) // Prioritize directories over other files.
 	if(!.)
 		return sorttext(b.filename, a.filename)
+
+/proc/cmp_submap_archetype_asc(var/decl/submap_archetype/A, var/decl/submap_archetype/B)
+	return A.sort_priority - B.sort_priority
+
+/proc/cmp_submap_asc(var/datum/submap/A, var/datum/submap/B)
+	return A.archetype.sort_priority - B.archetype.sort_priority

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -102,7 +102,7 @@ SUBSYSTEM_DEF(jobs)
 				LAZYADD(submap_job_datums, job)
 		if(LAZYLEN(submap_job_datums))
 			submap_job_datums = sortTim(submap_job_datums, /proc/cmp_job_desc)
-			job_lists_by_map_name[arch.descriptor] = list("jobs" = submap_job_datums, "default_to_hidden" = TRUE)
+			job_lists_by_map_name[arch.descriptor] = list("jobs" = submap_job_datums, "default_to_hidden" = arch.default_to_hidden)
 
 	// Update global map blacklists and whitelists.
 	for(var/mappath in global.all_maps)

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -88,8 +88,9 @@ SUBSYSTEM_DEF(jobs)
 
 	// Update title and path tracking, submap list, etc.
 	// Populate/set up map job lists.
-	primary_job_datums = sortTim(primary_job_datums, /proc/cmp_job_desc)
-	job_lists_by_map_name = list("[global.using_map.full_name]" = list("jobs" = primary_job_datums, "default_to_hidden" = FALSE))
+	if(length(primary_job_datums))
+		primary_job_datums = sortTim(primary_job_datums, /proc/cmp_job_desc)
+		job_lists_by_map_name = list("[global.using_map.full_name]" = list("jobs" = primary_job_datums, "default_to_hidden" = FALSE))
 
 	for(var/atype in submap_archetypes)
 		var/list/submap_job_datums

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -57,6 +57,7 @@ SUBSYSTEM_DEF(jobs)
 				job = get_by_path(jobtype)
 			if(job)
 				archetype_job_datums |= job
+	submap_archetypes = sortTim(submap_archetypes, /proc/cmp_submap_archetype_asc, TRUE)
 
 	// Load job configuration (is this even used anymore?)
 	if(job_config_file && config.load_jobs_from_txt)

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -33,7 +33,10 @@ SUBSYSTEM_DEF(jobs)
 
 	// Create main map jobs.
 	primary_job_datums.Cut()
-	for(var/jobtype in (list(global.using_map.default_job_type) | global.using_map.allowed_jobs))
+	var/list/available_jobs = global.using_map.allowed_jobs.Copy()
+	if(global.using_map.default_job_type)
+		LAZYDISTINCTADD(available_jobs, global.using_map.default_job_type)
+	for(var/jobtype in available_jobs)
 		var/datum/job/job = get_by_path(jobtype)
 		if(!job)
 			job = new jobtype

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -96,16 +96,16 @@
 		if(isnull(pref.hiding_maps[job_map]))
 			pref.hiding_maps[job_map] = map_data["default_to_hidden"]
 
-		. += "<hr><table width = '100%''><tr>"
-		. += "<td width = '50%' align = 'right'><font size = 3><b>[capitalize(job_map)]</b></td>"
-		. += "<td width = '50%' align = 'left''><a href='?src=\ref[src];toggle_map=[job_map]'>[pref.hiding_maps[job_map] ? "Show" : "Hide"]</a></font></td>"
+		. += "<hr><table style='text-align:center'><tr>"
+		. += "<td style='max-width:50%;text-align:right'><font size = 3><b>[capitalize_words(job_map)]</b></font></td>"
+		. += "<td style='max-width:50%;text-align:left'><font size = 3><a href='?src=\ref[src];toggle_map=[job_map]'>[pref.hiding_maps[job_map] ? "Show" : "Hide"]</a></font></td>"
 		. += "</tr></table>"
 
 		if(!pref.hiding_maps[job_map])
 
 			. += "<hr/>"
-			. += "<table width='100%' cellpadding='1' cellspacing='0'><tr><td width='20%'>" // Table within a table for alignment, also allows you to easily add more columns.
-			. += "<table width='100%' cellpadding='1' cellspacing='0'>"
+			. += "<table style='width:100%;height:100%' cellpadding='1' cellspacing='0'><tr><td style='width:50%;height:100%'>" // Table within a table for alignment, also allows you to easily add more columns.
+			. += "<table style='width:100%;height:100%' cellpadding='1' cellspacing='0'>"
 
 			//The job before the current job. I only use this to get the previous jobs color when I'm filling in blank rows.
 			var/datum/job/lastJob
@@ -124,9 +124,9 @@
 					player_branch = mil_branches.get_branch(pref.branches[job.title])
 					if(player_branch)
 						if(LAZYLEN(branch_rank) > 1)
-							branch_string += "<td width='10%' align='left'><a href='?src=\ref[src];char_branch=1;checking_job=\ref[job]'>[player_branch.name_short || player_branch.name]</a></td>"
+							branch_string += "<td style='width:10%;text-align:left'><a href='?src=\ref[src];char_branch=1;checking_job=\ref[job]'>[player_branch.name_short || player_branch.name]</a></td>"
 						else
-							branch_string += "<td width='10%' align='left'><span class='linkOff'>[player_branch.name_short || player_branch.name]</span></td>"
+							branch_string += "<td style='width:10%;text-align:left'><span class='linkOff'>[player_branch.name_short || player_branch.name]</span></td>"
 				if(!branch_string)
 					branch_string = "<td>-</td>"
 				if(player_branch)
@@ -135,9 +135,9 @@
 						player_rank = mil_branches.get_rank(player_branch.name, pref.ranks[job.title])
 						if(player_rank)
 							if(LAZYLEN(ranks) > 1)
-								rank_branch_string += "<td width='10%' align='left'><a href='?src=\ref[src];char_rank=1;checking_job=\ref[job]'>[player_rank.name_short || player_rank.name]</a></td>"
+								rank_branch_string += "<td style='width:10%;text-align:left'><a href='?src=\ref[src];char_rank=1;checking_job=\ref[job]'>[player_rank.name_short || player_rank.name]</a></td>"
 							else
-								rank_branch_string += "<td width='10%' align='left'><span class='linkOff'>[player_rank.name_short || player_rank.name]</span></td>"
+								rank_branch_string += "<td style='width:10%;text-align:left'><span class='linkOff'>[player_rank.name_short || player_rank.name]</span></td>"
 				if(!rank_branch_string)
 					rank_branch_string = "<td>-</td>"
 				rank_branch_string = "[branch_string][rank_branch_string]"
@@ -195,14 +195,14 @@
 						//If the cells were broken up by a job in the splitJob list then it will fill in the rest of the cells with
 						//the last job's selection color. Creating a rather nice effect.
 						for(var/i = 0, i < (limit - index), i += 1)
-							. += "<tr bgcolor='[lastJob.selection_color]'><td width='40%' align='right'><a>&nbsp</a></td><td><a>&nbsp</a></td></tr>"
-					. += "</table></td><td width='20%'><table width='100%' cellpadding='1' cellspacing='0'>"
+							. += "<tr bgcolor='[lastJob.selection_color]'><td style='width:40%;text-align:right'><a>&nbsp</a></td><td><a>&nbsp</a></td></tr>"
+					. += "</table></td><td style='width:50%;height:100%'><table style='width:100%;height:100%' cellpadding='1' cellspacing='0'>"
 					index = 0
 
 				. += "<tr bgcolor='[job.selection_color]'>"
 				if(rank_branch_string && rank_branch_string != "")
 					. += "[rank_branch_string]"
-				. += "<td width='30%' align='left'>"
+				. += "<td style='width:30%;text-align:left'>"
 
 				if(bad_message)
 					. += "<del>[title_link]</del>[help_link][skill_link]<td>[bad_message]</td></tr>"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -173,8 +173,6 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 	if(!ready && href_list["preference"])
 		if(client)
 			client.prefs.process_link(src, href_list)
-	else if(!href_list["late_join"])
-		show_lobby_menu()
 
 	if(href_list["invalid_jobs"])
 		show_invalid_jobs = !show_invalid_jobs

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -326,7 +326,7 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 			if(LAZYLEN(job_summaries))
 				dat += job_summaries
 			else
-				dat += "No available positions."
+				dat += "<tr><td colspan = 3>No available positions.</td></tr>"
 	// END SUBMAP JOBS
 
 	dat += "</table></center>"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -269,43 +269,44 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 	dat += "Choose from the following open/valid positions:<br>"
 	dat += "<a href='byond://?src=\ref[src];invalid_jobs=1'>[show_invalid_jobs ? "Hide":"Show"] unavailable jobs</a><br>"
 	dat += "<table>"
-	dat += "<tr><td colspan = 3><b>[global.using_map.station_name]:</b></td></tr>"
-
-	// MAIN MAP JOBS
 	var/list/job_summaries = list()
 	var/list/hidden_reasons = list()
-	for(var/datum/job/job in SSjobs.primary_job_datums)
+	if(length(SSjobs.primary_job_datums))
+		dat += "<tr><td colspan = 3><b>[global.using_map.station_name]:</b></td></tr>"
 
-		var/summary = job.get_join_link(client, "byond://?src=\ref[src];SelectedJob=[job.title]", show_invalid_jobs)
-		if(summary)
+		// MAIN MAP JOBS
+		for(var/datum/job/job in SSjobs.primary_job_datums)
 
-			var/decl/department/dept = job.primary_department && SSjobs.get_department_by_type(job.primary_department)
-			var/summary_key = (dept || "No Department")
-			var/list/existing_summaries = job_summaries[summary_key]
-			if(!existing_summaries)
-				existing_summaries = list()
-				job_summaries[summary_key] = existing_summaries
-			if(job.head_position)
-				existing_summaries.Insert(1, summary)
+			var/summary = job.get_join_link(client, "byond://?src=\ref[src];SelectedJob=[job.title]", show_invalid_jobs)
+			if(summary)
+
+				var/decl/department/dept = job.primary_department && SSjobs.get_department_by_type(job.primary_department)
+				var/summary_key = (dept || "No Department")
+				var/list/existing_summaries = job_summaries[summary_key]
+				if(!existing_summaries)
+					existing_summaries = list()
+					job_summaries[summary_key] = existing_summaries
+				if(job.head_position)
+					existing_summaries.Insert(1, summary)
+				else
+					existing_summaries.Add(summary)
 			else
-				existing_summaries.Add(summary)
-		else
-			for(var/raisin in job.get_unavailable_reasons(client))
-				hidden_reasons[raisin] = TRUE
+				for(var/raisin in job.get_unavailable_reasons(client))
+					hidden_reasons[raisin] = TRUE
 
-	var/added_job = FALSE
-	if(length(job_summaries))
-		job_summaries = sortTim(job_summaries, /proc/cmp_departments_dsc, FALSE)
-		for(var/job_category in job_summaries)
-			if(length(job_summaries[job_category]))
-				var/decl/department/job_dept = job_category
-				// TODO: use bgcolor='[job_dept.display_color]' when less pastel/bright colours are chosen.
-				dat += "<tr><td bgcolor='#333333' colspan = 3><b><font color = '#ffffff'><center>[istype(job_dept) ? job_dept.name : job_dept]</center></font></b></td></tr>"
-				dat += job_summaries[job_category]
-				added_job = TRUE
+		var/added_job = FALSE
+		if(length(job_summaries))
+			job_summaries = sortTim(job_summaries, /proc/cmp_departments_dsc, FALSE)
+			for(var/job_category in job_summaries)
+				if(length(job_summaries[job_category]))
+					var/decl/department/job_dept = job_category
+					// TODO: use bgcolor='[job_dept.display_color]' when less pastel/bright colours are chosen.
+					dat += "<tr><td bgcolor='#333333' colspan = 3><b><font color = '#ffffff'><center>[istype(job_dept) ? job_dept.name : job_dept]</center></font></b></td></tr>"
+					dat += job_summaries[job_category]
+					added_job = TRUE
 
-	if(!added_job)
-		dat += "<tr><td colspan = 3>No available positions.</td></tr>"
+		if(!added_job)
+			dat += "<tr><td colspan = 3>No available positions.</td></tr>"
 	// END MAIN MAP JOBS
 
 	// SUBMAP JOBS

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -416,6 +416,8 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 /mob/new_player/proc/close_spawn_windows()
 	close_browser(src, "window=latechoices") //closes late choices window
 	close_browser(src, "window=preferences_window") //closes preferences window
+	if(client?.prefs)
+		client.prefs.close_load_dialog(src)
 	panel.close()
 
 /mob/new_player/proc/check_species_allowed(var/decl/species/S, var/show_alert=1)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -53,7 +53,8 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 		output += lobby_footer
 	output += "</div>"
 
-	panel = new(src, "Welcome","Welcome to [global.using_map.full_name]", 560, 280, src)
+	if(!panel)
+		panel = new(src, "Welcome","Welcome to [global.using_map.full_name]", 560, 280, src)
 	panel.set_window_options("can_close=0")
 	panel.set_content(JOINTEXT(output))
 	panel.open()
@@ -103,7 +104,6 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 			ready = !ready
 
 	if(href_list["refresh"])
-		panel.close()
 		show_lobby_menu()
 
 	if(href_list["lobby_observe"])

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -309,9 +309,11 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 	// END MAIN MAP JOBS
 
 	// SUBMAP JOBS
-	for(var/thing in SSmapping.submaps)
-		var/datum/submap/submap = thing
-		if(submap && submap.available())
+	var/list/ordered_submaps = null
+	if(length(SSmapping.submaps))
+		ordered_submaps = sortTim(SSmapping.submaps.Copy(), /proc/cmp_submap_asc)
+	for(var/datum/submap/submap as anything in ordered_submaps)
+		if(submap?.available())
 			dat += "<tr><td colspan = 3><b>[submap.name] ([submap.archetype.descriptor]):</b></td></tr>"
 			job_summaries = list()
 			for(var/otherthing in submap.jobs)

--- a/code/modules/submaps/submap_archetype.dm
+++ b/code/modules/submaps/submap_archetype.dm
@@ -7,6 +7,8 @@
 	var/list/crew_jobs = list(
 		/datum/job/submap
 	)
+	/// Used to order submaps on the occupation preference menu.
+	var/sort_priority = 0
 
 /decl/submap_archetype/Initialize()
 	if(islist(whitelisted_species) && !length(whitelisted_species))

--- a/code/modules/submaps/submap_archetype.dm
+++ b/code/modules/submaps/submap_archetype.dm
@@ -9,6 +9,8 @@
 	)
 	/// Used to order submaps on the occupation preference menu.
 	var/sort_priority = 0
+	/// Whether the job preferences for this submap archetype are collapsed by default.
+	var/default_to_hidden = TRUE
 
 /decl/submap_archetype/Initialize()
 	if(islist(whitelisted_species) && !length(whitelisted_species))


### PR DESCRIPTION
## Description of changes
- Fixes the lobby menu refreshing after a new menu is open, covering that menu.
- Fixes the lobby menu browser being deleted and remade unnecessarily instead of just being updated.
- Fixes the 'no positions available' message for submaps showing up in the wrong spot
- Fixes a runtime when the main map has no available jobs
- Hides various things related to main map jobs when none exist (for submap-only maps like Shiptesting, for example)
- Allows submaps to opt out of being hidden by default in the occupations menu.
- Fixes the formatting and layout of the occupation preferences tab (NEEDS TESTING!)
- Closes some more menus when you spawn in, to avoid confusion.
- Adds optional sorting to submap (job) lists.

## Why and what will this PR improve
Various code quality, performance, and visual improvements.