### PR TITLE
Fixes dropping inventory on species change

### DIFF
--- a/code/datums/inventory_slots/_inventory_slot.dm
+++ b/code/datums/inventory_slots/_inventory_slot.dm
@@ -133,8 +133,8 @@
 		return FALSE
 	return TRUE
 
-/datum/inventory_slot/proc/can_equip_to_slot(var/mob/user, var/obj/item/prop, var/disable_warning)
-	return (!_holding && prop && slot_id && prop_can_fit_in_slot(prop))
+/datum/inventory_slot/proc/can_equip_to_slot(var/mob/user, var/obj/item/prop, var/disable_warning, var/ignore_equipped)
+	return ((!_holding || ignore_equipped && _holding == prop) && prop && slot_id && prop_can_fit_in_slot(prop))
 
 /datum/inventory_slot/proc/prop_can_fit_in_slot(var/obj/item/prop)
 	return (isnull(requires_slot_flags) || (requires_slot_flags & prop.slot_flags))

--- a/code/datums/inventory_slots/_inventory_slot.dm
+++ b/code/datums/inventory_slots/_inventory_slot.dm
@@ -134,7 +134,7 @@
 	return TRUE
 
 /datum/inventory_slot/proc/can_equip_to_slot(var/mob/user, var/obj/item/prop, var/disable_warning, var/ignore_equipped)
-	return ((!_holding || ignore_equipped && _holding == prop) && prop && slot_id && prop_can_fit_in_slot(prop))
+	return ((!_holding || (ignore_equipped && _holding == prop)) && prop && slot_id && prop_can_fit_in_slot(prop))
 
 /datum/inventory_slot/proc/prop_can_fit_in_slot(var/obj/item/prop)
 	return (isnull(requires_slot_flags) || (requires_slot_flags & prop.slot_flags))

--- a/code/datums/inventory_slots/inventory_gripper.dm
+++ b/code/datums/inventory_slots/inventory_gripper.dm
@@ -29,7 +29,7 @@
 	requires_organ_tag = null
 	can_use_held_item = FALSE
 
-/datum/inventory_slot/gripper/mouth/can_equip_to_slot(mob/user, obj/item/prop, disable_warning)
+/datum/inventory_slot/gripper/mouth/can_equip_to_slot(mob/user, obj/item/prop, disable_warning, ignore_equipped)
 	. = ..() && prop.w_class <= user.can_pull_size
 
 /datum/inventory_slot/gripper/mouth/equipped(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE, var/delete_old_item = TRUE)

--- a/code/datums/inventory_slots/slots/slot_belt.dm
+++ b/code/datums/inventory_slots/slots/slot_belt.dm
@@ -9,7 +9,7 @@
 /datum/inventory_slot/belt/update_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
 	user.update_inv_belt(redraw_mob)
 
-/datum/inventory_slot/belt/can_equip_to_slot(var/mob/user, var/obj/item/prop, var/disable_warning)
+/datum/inventory_slot/belt/can_equip_to_slot(var/mob/user, var/obj/item/prop, var/disable_warning, var/ignore_equipped)
 	. = ..()
 	if(.)
 		// If they have a uniform slot, they need a uniform to wear a belt.

--- a/code/datums/inventory_slots/slots/slot_cuffs.dm
+++ b/code/datums/inventory_slots/slots/slot_cuffs.dm
@@ -21,7 +21,7 @@
 	if(. && user.buckled?.buckle_require_restraints)
 		user.buckled.unbuckle_mob()
 
-/datum/inventory_slot/handcuffs/can_equip_to_slot(var/mob/user, var/obj/item/prop, var/disable_warning)
+/datum/inventory_slot/handcuffs/can_equip_to_slot(var/mob/user, var/obj/item/prop, var/disable_warning, var/ignore_equipped)
 	. = ..() && istype(prop, /obj/item/handcuffs)
 
 /datum/inventory_slot/handcuffs/get_examined_string(mob/owner, mob/user, distance, hideflags, decl/pronouns/pronouns)

--- a/code/datums/inventory_slots/slots/slot_id.dm
+++ b/code/datums/inventory_slots/slots/slot_id.dm
@@ -8,7 +8,7 @@
 /datum/inventory_slot/id/update_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
 	user.update_inv_wear_id(redraw_mob)
 
-/datum/inventory_slot/id/can_equip_to_slot(var/mob/user, var/obj/item/prop, var/disable_warning)
+/datum/inventory_slot/id/can_equip_to_slot(var/mob/user, var/obj/item/prop, var/disable_warning, var/ignore_equipped)
 	. = ..()
 	if(.)
 		// If they have a uniform slot, they need a uniform to wear an ID card.

--- a/code/datums/inventory_slots/slots/slot_pockets.dm
+++ b/code/datums/inventory_slots/slots/slot_pockets.dm
@@ -14,7 +14,7 @@
 /datum/inventory_slot/pocket/prop_can_fit_in_slot(var/obj/item/prop)
 	return ..() || prop.w_class <= ITEM_SIZE_SMALL
 
-/datum/inventory_slot/pocket/can_equip_to_slot(var/mob/user, var/obj/item/prop, var/disable_warning)
+/datum/inventory_slot/pocket/can_equip_to_slot(var/mob/user, var/obj/item/prop, var/disable_warning, var/ignore_equipped)
 	. = ..()
 	if(.)
 		// If they have a uniform slot, they need a uniform to have pockets.

--- a/code/datums/inventory_slots/slots/slot_suit_storage.dm
+++ b/code/datums/inventory_slots/slots/slot_suit_storage.dm
@@ -8,7 +8,7 @@
 /datum/inventory_slot/suit_storage/update_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
 	user.update_inv_s_store(redraw_mob)
 
-/datum/inventory_slot/suit_storage/can_equip_to_slot(var/mob/user, var/obj/item/prop, var/disable_warning)
+/datum/inventory_slot/suit_storage/can_equip_to_slot(var/mob/user, var/obj/item/prop, var/disable_warning, var/ignore_equipped)
 	. = ..()
 	if(.)
 		// They need a suit to use suit storage.

--- a/code/game/objects/items/devices/auto_cpr.dm
+++ b/code/game/objects/items/devices/auto_cpr.dm
@@ -17,7 +17,7 @@
 	var/last_pump
 	var/skilled_setup
 
-/obj/item/auto_cpr/mob_can_equip(mob/living/carbon/human/H, slot, disable_warning = 0, force = 0)
+/obj/item/auto_cpr/mob_can_equip(mob/living/carbon/human/H, slot, disable_warning = 0, force = 0, ignore_equipped = 0)
 	. = ..()
 	if(. && slot == slot_wear_suit_str)
 		. = H.get_bodytype_category() == BODYTYPE_HUMANOID

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -133,7 +133,7 @@
 	if(markings_color && markings_icon)
 		update_icon()
 
-/obj/item/clothing/mob_can_equip(mob/living/M, slot, disable_warning = FALSE, force = FALSE)
+/obj/item/clothing/mob_can_equip(mob/living/M, slot, disable_warning = FALSE, force = FALSE, ignore_equipped = FALSE)
 	. = ..()
 	if(. && !isnull(bodytype_equip_flags) && ishuman(M) && !(slot in list(slot_l_store_str, slot_r_store_str, slot_s_store_str)) && !(slot in M.get_held_item_slots()))
 		var/mob/living/carbon/human/H = M

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -25,17 +25,19 @@
 /obj/item/clothing/gloves/get_fibers()
 	return "material from a pair of [name]."
 
-/obj/item/clothing/gloves/mob_can_equip(mob/M, slot, disable_warning = 0, force = 0)
+/obj/item/clothing/gloves/mob_can_equip(mob/M, slot, disable_warning = 0, force = 0, ignore_equipped = 0)
 	var/obj/item/clothing/ring/check_ring
 	var/mob/living/carbon/human/H = M
 	var/obj/item/gloves = M.get_equipped_item(slot_gloves_str)
 	if(slot == slot_gloves_str && istype(H) && gloves)
-		check_ring = gloves
-		if(!istype(check_ring) || !check_ring.can_fit_under_gloves || !H.try_unequip(check_ring, src))
-			to_chat(M, SPAN_WARNING("You are unable to wear \the [src] as \the [gloves] are in the way."))
-			return FALSE
+		if(!ignore_equipped || gloves != src)
+			check_ring = gloves
+			if(!istype(check_ring) || !check_ring.can_fit_under_gloves || !H.try_unequip(check_ring, src))
+				if(!disable_warning)
+					to_chat(M, SPAN_WARNING("You are unable to wear \the [src] as \the [gloves] are in the way."))
+				return FALSE
 	. = ..()
-	if(check_ring)
+	if(check_ring && check_ring != src)
 		if(.)
 			covering_ring = check_ring
 			to_chat(M, SPAN_NOTICE("You slip \the [src] on over \the [covering_ring]."))

--- a/code/modules/clothing/masks/monitor.dm
+++ b/code/modules/clothing/masks/monitor.dm
@@ -71,7 +71,7 @@
 	canremove = 1
 	return ..()
 
-/obj/item/clothing/mask/monitor/mob_can_equip(var/mob/living/carbon/human/user, var/slot)
+/obj/item/clothing/mask/monitor/mob_can_equip(var/mob/living/carbon/human/user, var/slot, var/disable_warning, var/force, var/ignore_equipped)
 	. = ..()
 	if(. && (slot == slot_head_str || slot == slot_wear_mask_str))
 		var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(user, BP_HEAD)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -63,16 +63,18 @@
 			overlay.icon_state = new_state
 	. = ..()
 
-/obj/item/clothing/shoes/magboots/mob_can_equip(mob/M, slot, disable_warning = 0, force = 0)
+/obj/item/clothing/shoes/magboots/mob_can_equip(mob/M, slot, disable_warning = 0, force = 0, ignore_equipped = 0)
 	var/obj/item/clothing/shoes/check_shoes
 	var/mob/living/carbon/human/H = M
 	if(slot == slot_shoes_str && istype(H))
 		check_shoes = H.get_equipped_item(slot_shoes_str)
-		if(istype(check_shoes) && (!check_shoes.can_fit_under_magboots || !H.try_unequip(check_shoes, src)))
-			to_chat(M, SPAN_WARNING("You are unable to wear \the [src] as \the [check_shoes] are in the way."))
-			return FALSE
+		if(!ignore_equipped || check_shoes != src)
+			if(istype(check_shoes) && (!check_shoes.can_fit_under_magboots || !H.try_unequip(check_shoes, src)))
+				if(!disable_warning)
+					to_chat(M, SPAN_WARNING("You are unable to wear \the [src] as \the [check_shoes] are in the way."))
+				return FALSE
 	. = ..()
-	if(check_shoes)
+	if(check_shoes && check_shoes != src)
 		if(.)
 			covering_shoes = check_shoes
 			to_chat(M, SPAN_NOTICE("You slip \the [src] on over \the [covering_shoes]."))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -688,7 +688,7 @@
 
 	//recheck species-restricted clothing
 	for(var/obj/item/carrying in get_equipped_items(include_carried = TRUE))
-		if(!carrying.mob_can_equip(src, get_equipped_slot_for_item(carrying), TRUE, TRUE))
+		if(!carrying.mob_can_equip(src, get_equipped_slot_for_item(carrying), TRUE, TRUE, TRUE))
 			drop_from_inventory(carrying)
 
 //This handles actually updating our visual appearance

--- a/code/modules/mob/living/inventory.dm
+++ b/code/modules/mob/living/inventory.dm
@@ -122,16 +122,29 @@
 		for(var/slot in get_held_item_slots())
 			if(slot in old_slots)
 				LAZYSET(_inventory_slots, slot, old_slots[slot])
+				old_slots -= slot
 
 	// Check if we need to replace any existing slots.
 	for(var/new_slot_id in new_slots)
 		var/datum/inventory_slot/new_slot = new_slots[new_slot_id]
 		var/datum/inventory_slot/old_slot = LAZYACCESS(old_slots, new_slot_id)
-		if(old_slot && new_slot != old_slot)
-			new_slot.set_slot(old_slot.get_equipped_item())
-			old_slot.clear_slot()
-			qdel(old_slot)
+		if(old_slot)
+			if(old_slot != new_slot)
+				// Transfer the item from the old slot to the new slot
+				new_slot.set_slot(old_slot.get_equipped_item())
+				old_slot.clear_slot()
+				qdel(old_slot)
+
+			old_slots -= new_slot_id
+
 		LAZYSET(_inventory_slots, new_slot.slot_id, new_slot)
+
+	// For any old slots which had no equivalent, drop the item into the world
+	for(var/old_slot_id in old_slots)
+		var/datum/inventory_slot/old_slot = old_slots[old_slot_id]
+		drop_from_inventory(old_slot.get_equipped_item())
+		old_slot.clear_slot() // Call this manually since it is no longer in _inventory_slots
+		qdel(old_slot)
 
 /mob/living/add_inventory_slot(var/datum/inventory_slot/inv_slot)
 	LAZYSET(_inventory_slots, inv_slot.slot_id, inv_slot)

--- a/mods/species/bayliens/skrell/gear/gear_ears.dm
+++ b/mods/species/bayliens/skrell/gear/gear_ears.dm
@@ -2,7 +2,7 @@
 	name = "skrell tentacle wear"
 	desc = "Some stuff worn by skrell to adorn their head tentacles."
 
-/obj/item/clothing/ears/skrell/mob_can_equip(mob/living/M, slot, disable_warning = 0)
+/obj/item/clothing/ears/skrell/mob_can_equip(mob/living/M, slot, disable_warning = 0, ignore_equipped = 0)
 	. = ..()
 	var/mob/living/carbon/human/H = M
 	if(. && istype(H) && H.bodytype.name != BODYTYPE_SKRELL)

--- a/mods/species/bayliens/skrell/gear/gear_head.dm
+++ b/mods/species/bayliens/skrell/gear/gear_head.dm
@@ -12,7 +12,7 @@
 		ARMOR_RAD = ARMOR_RAD_SHIELDED
 		)
 
-/obj/item/clothing/head/helmet/space/void/skrell/mob_can_equip(mob/living/M, slot, disable_warning = 0)
+/obj/item/clothing/head/helmet/space/void/skrell/mob_can_equip(mob/living/M, slot, disable_warning = 0, force = 0, ignore_equipped = 0)
 	. = ..()
 	var/mob/living/carbon/human/H = M
 	if(. && istype(H) && H.bodytype.name != BODYTYPE_SKRELL)
@@ -26,7 +26,7 @@
 	desc = "A helmet built for use by a Skrell. This one appears to be fairly standard and reliable."
 	icon = 'mods/species/bayliens/skrell/icons/clothing/head/helmet_skrell.dmi'
 
-/obj/item/clothing/head/helmet/skrell/mob_can_equip(mob/living/M, slot, disable_warning = 0)
+/obj/item/clothing/head/helmet/skrell/mob_can_equip(mob/living/M, slot, disable_warning = 0, force = 0, ignore_equipped = 0)
 	. = ..()
 	var/mob/living/carbon/human/H = M
 	if(. && istype(H) && H.bodytype.name != BODYTYPE_SKRELL)


### PR DESCRIPTION
## Description of changes
Reworks the ``mob_can_equip`` proc to accommodate checking for equipment already on the mob by adding the argument ``ignore_equipped``. This previously caused items to be deleted when changing species (and also caused an issue when deserializing downstream).

Adjusts the ``set_inventory_slots`` proc to drop items in ``old_slots`` into the world if no equivalent slot exists in ``new_slots``, rather then keeping them in mob contents. Currently items in hands will still be dropped on species transform, presumably due to the way organs are changed, but I think that's out of scope to fix for this PR.

## Why and what will this PR improve
Fixes bugs with species transformation

## Authorship
Myself