### PR TITLE
Improve exoplanet generation sanity

### DIFF
--- a/code/game/turfs/exterior/exterior_sand.dm
+++ b/code/game/turfs/exterior/exterior_sand.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/turf/exterior/sand.dmi'
 	icon_edge_layer = EXT_EDGE_SAND 
 	icon_has_corners = TRUE
-	possible_states = 5
+	possible_states = 4
 
 /turf/exterior/sand/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if((temperature > T0C + 1700 && prob(5)) || temperature > T0C + 3000)

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -389,7 +389,7 @@
 	display_name = "[name] plant"
 
 //Creates a random seed. MAKE SURE THE LINE HAS DIVERGED BEFORE THIS IS CALLED.
-/datum/seed/proc/randomize(var/temperature = T20C)
+/datum/seed/proc/randomize(var/temperature = T20C, var/pressure = 1 ATM)
 
 	roundstart = 0
 	mysterious = 1
@@ -428,14 +428,21 @@
 	var/list/all_materials = decls_repository.get_decls_of_subtype(/decl/material)
 	for(var/mat_type in all_materials)
 		var/decl/material/mat = all_materials[mat_type]
-		if(mat.exoplanet_rarity == MAT_RARITY_NOWHERE)
+		if(mat.exoplanet_rarity_plant == MAT_RARITY_NOWHERE)
 			continue
 		if(skip_toxins && mat.toxicity)
 			continue
-		if(!isnull(mat.boiling_point) && mat.boiling_point <= temperature && (isnull(mat.gas_condensation_point) || mat.gas_condensation_point > temperature))
-			gasses[mat.type] = mat.exoplanet_rarity
-		else if(!isnull(mat.melting_point) && mat.melting_point <= temperature)
-			liquids[mat.type] = mat.exoplanet_rarity
+		if(!isnull(mat.heating_point) && length(mat.heating_products) && temperature >= mat.heating_point)
+			// TODO: Maybe add products, but that could lead to having a lot of water or something.
+			continue
+		if(!isnull(mat.chilling_point) && length(mat.chilling_products) && temperature <= mat.chilling_point)
+			continue
+		switch(mat.phase_at_temperature(temperature, pressure))
+			if(MAT_PHASE_GAS)
+				if(isnull(mat.gas_condensation_point) || mat.gas_condensation_point > temperature)
+					gasses[mat.type] = mat.exoplanet_rarity_plant
+			if(MAT_PHASE_LIQUID)
+				liquids[mat.type] = mat.exoplanet_rarity_plant
 	liquids -= /decl/material/liquid/nutriment
 
 	if(length(gasses))

--- a/code/modules/maps/template_types/random_exoplanet/flora_generator.dm
+++ b/code/modules/maps/template_types/random_exoplanet/flora_generator.dm
@@ -136,7 +136,7 @@
 		if(color == "RANDOM")
 			color = get_random_colour(0, 75, 190)
 
-		S.randomize(atmos.temperature)
+		S.randomize(atmos.temperature, atmos.return_pressure())
 		S.set_trait(TRAIT_PRODUCT_ICON, planticon)
 		S.set_trait(TRAIT_PLANT_ICON,   planticon)
 		S.set_trait(TRAIT_PLANT_COLOUR, color)
@@ -155,7 +155,7 @@
 		if(color == "RANDOM")
 			color = get_random_colour(0, 75, 190)
 
-		S.randomize(atmos.temperature)
+		S.randomize(atmos.temperature, atmos.return_pressure())
 		S.set_trait(TRAIT_PRODUCT_ICON,   "alien[rand(1,5)]")
 		S.set_trait(TRAIT_PLANT_ICON,     "tree")
 		S.set_trait(TRAIT_SPREAD,         0)

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/shrouded.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/shrouded.dm
@@ -115,7 +115,7 @@
 
 /datum/random_map/noise/exoplanet/shrouded/get_additional_spawns(var/value, var/turf/T)
 	..()
-	if(prob(2))
+	if(!T.density && prob(0.045)) // about 1 in 10 screens or so
 		new/obj/structure/leech_spawner(T)
 
 ////////////////////////////////////////////////////////////////////////////

--- a/code/modules/maps/template_types/random_exoplanet/planetoid_data.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planetoid_data.dm
@@ -581,7 +581,16 @@
 					continue
 
 				current_merged_flags |= mat.gas_flags
-				var/part = available_moles * (rand(10,90)/100) //allocate percentage to it
+				var/min_percent = 10
+				var/max_percent = 90
+				switch(mat.exoplanet_rarity_gas)
+					if(MAT_RARITY_UNCOMMON)
+						min_percent = 5
+						max_percent = 60
+					if(MAT_RARITY_EXOTIC)
+						min_percent = 1
+						max_percent = 10
+				var/part = available_moles * (rand(min_percent, max_percent)/100) //allocate percentage to it
 				if(i == number_gases || !length(candidate_gases)) //if it's last gas, let it have all remaining moles
 					part = available_moles
 				new_atmos.gas[picked_gas] += part

--- a/code/modules/maps/template_types/random_exoplanet/planetoid_data.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planetoid_data.dm
@@ -576,16 +576,16 @@
 
 				// Make sure atmosphere is not flammable
 				var/decl/material/mat = GET_DECL(picked_gas)
-				if((!(mat.gas_flags & XGM_GAS_OXIDIZER) && !(mat.gas_flags & XGM_GAS_FUEL)) || \
-					((current_merged_flags & XGM_GAS_OXIDIZER) && !(mat.gas_flags & XGM_GAS_FUEL)) || \
-					((current_merged_flags & XGM_GAS_FUEL) && !(mat.gas_flags & XGM_GAS_OXIDIZER)))
+				if(((current_merged_flags & XGM_GAS_OXIDIZER) && (mat.gas_flags & XGM_GAS_FUEL)) || \
+					((current_merged_flags & XGM_GAS_FUEL) && (mat.gas_flags & XGM_GAS_OXIDIZER)))
+					continue
 
-					current_merged_flags |= mat.gas_flags
-					var/part = available_moles * (rand(10,90)/100) //allocate percentage to it
-					if(i == number_gases || !length(candidate_gases)) //if it's last gas, let it have all remaining moles
-						part = available_moles
-					new_atmos.gas[picked_gas] += part
-					available_moles = max(available_moles - part, 0)
+				current_merged_flags |= mat.gas_flags
+				var/part = available_moles * (rand(10,90)/100) //allocate percentage to it
+				if(i == number_gases || !length(candidate_gases)) //if it's last gas, let it have all remaining moles
+					part = available_moles
+				new_atmos.gas[picked_gas] += part
+				available_moles = max(available_moles - part, 0)
 				i++
 
 	new_atmos.update_values()

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -113,8 +113,10 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	var/list/stack_origin_tech = "{'materials':1}" // Research level for stacks.
 
 	// Attributes
-	/// How rare is this material generally?
-	var/exoplanet_rarity = MAT_RARITY_MUNDANE
+	/// How rare is this material in exoplanet xenoflora?
+	var/exoplanet_rarity_plant = MAT_RARITY_MUNDANE
+	/// How rare is this material in exoplanet atmospheres?
+	var/exoplanet_rarity_gas = MAT_RARITY_MUNDANE
 	/// Delay in ticks when cutting through this wall.
 	var/cut_delay = 0
 	/// Radiation var. Used in wall and object processing to irradiate surroundings.
@@ -446,7 +448,8 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	name = "placeholder"
 	uid = "mat_placeholder"
 	hidden_from_codex = TRUE
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /// Generic material product (sheets, bricks, etc). Used ALL THE TIME.
 /// May return an instance list, a single instance, or nothing if there is no instance produced.

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -439,7 +439,8 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	//#TODO: implement plasma temperature and do pressure checks
 	if(!isnull(boiling_point) && temperature >= get_boiling_temp(pressure))
 		return MAT_PHASE_GAS
-	else if(!isnull(heating_point) && temperature >= heating_point)
+	else if(!isnull(heating_point) && temperature >= heating_point || \
+			!isnull(melting_point) && temperature >= melting_point)
 		return MAT_PHASE_LIQUID
 	return MAT_PHASE_SOLID
 

--- a/code/modules/materials/definitions/gasses/material_gas_alien.dm
+++ b/code/modules/materials/definitions/gasses/material_gas_alien.dm
@@ -5,7 +5,8 @@
 	gas_symbol_html = "X"
 	gas_symbol = "X"
 	value = 0.6
-	exoplanet_rarity = MAT_RARITY_EXOTIC
+	exoplanet_rarity_plant = MAT_RARITY_EXOTIC
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 
 /decl/material/gas/alien/Initialize()
 	var/num = rand(100,999)

--- a/code/modules/materials/definitions/gasses/material_gas_mundane.dm
+++ b/code/modules/materials/definitions/gasses/material_gas_mundane.dm
@@ -329,7 +329,8 @@
 	value = 0.45
 	gas_symbol_html = "T"
 	gas_symbol = "T"
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_UNCOMMON
 
 /decl/material/gas/hydrogen/deuterium
 	name = "deuterium"
@@ -343,7 +344,8 @@
 	gas_symbol_html = "D"
 	gas_symbol = "D"
 	value = 0.5
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_UNCOMMON
 
 	neutron_interactions = list(
 		INTERACTION_ABSORPTION = 1250

--- a/code/modules/materials/definitions/liquids/materials_liquid_chemistry.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_chemistry.dm
@@ -1,6 +1,6 @@
 /decl/material/liquid/surfactant // Foam precursor
-	name = "surfacant"
-	uid = "liquid_surfacant"
+	name = "surfactant"
+	uid = "liquid_surfactant"
 	lore_text = "A isocyanate liquid that forms a foam when mixed with water."
 	taste_description = "metal"
 	color = "#9e6b38"

--- a/code/modules/materials/definitions/liquids/materials_liquid_chemistry.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_chemistry.dm
@@ -5,6 +5,7 @@
 	taste_description = "metal"
 	color = "#9e6b38"
 	value = 0.1
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 
 /decl/material/liquid/foaming_agent // Metal foaming agent. This is lithium hydride. Add other recipes (e.g. LiH + H2O -> LiOH + H2) eventually.
 	name = "foaming agent"
@@ -13,6 +14,7 @@
 	taste_description = "metal"
 	color = "#664b63"
 	value = 0.1
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 
 /decl/material/liquid/lube
 	name = "lubricant"
@@ -22,3 +24,4 @@
 	color = SYNTH_BLOOD_COLOR
 	value = 0.1
 	slipperiness = 80
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC

--- a/code/modules/materials/definitions/liquids/materials_liquid_solvents.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_solvents.dm
@@ -38,7 +38,8 @@
 	solvent_melt_dose = 4
 	solvent_max_damage = 60
 	value = 1.8
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_UNCOMMON
 
 /decl/material/liquid/acid/stomach
 	name = "stomach acid"
@@ -48,7 +49,8 @@
 	color = "#d8ff00"
 	hidden_from_codex = TRUE
 	value = 0
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 
 /decl/material/liquid/acetone
 	name = "acetone"

--- a/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
@@ -9,7 +9,8 @@
 	toxicity_targets_organ = null
 	toxicity = 0
 	hidden_from_codex = TRUE
-	exoplanet_rarity = MAT_RARITY_NOWHERE // It's useless, don't use it.
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE // It's useless, don't use it.
 
 /decl/material/liquid/plasticide
 	name = "plasticide"
@@ -20,7 +21,8 @@
 	toxicity = 5
 	taste_mult = 1.2
 	metabolism = REM * 0.25
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 
 /decl/material/liquid/amatoxin
 	name = "amatoxin"
@@ -36,7 +38,8 @@
 	heating_message = "becomes clear."
 	taste_mult = 1.2
 	metabolism = REM * 0.25
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 
 /decl/material/liquid/carpotoxin
 	name = "carpotoxin"
@@ -53,7 +56,8 @@
 	heating_message = "becomes clear."
 	taste_mult = 1.2
 	metabolism = REM * 0.25
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 
 /decl/material/liquid/venom
 	name = "spider venom"
@@ -70,7 +74,8 @@
 	heating_message = "becomes clear."
 	taste_mult = 1.2
 	metabolism = REM * 0.25
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 
 /decl/material/liquid/venom/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(prob(REAGENT_VOLUME(holder, type)*2))
@@ -86,7 +91,8 @@
 	toxicity = 20
 	metabolism = REM * 2
 	toxicity_targets_organ = BP_HEART
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 
 /decl/material/liquid/cyanide/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
@@ -103,7 +109,8 @@
 	metabolism = REM * 2
 	toxicity_targets_organ = BP_HEART
 	taste_mult = 1.2
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 
 /decl/material/liquid/heartstopper/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
@@ -137,7 +144,8 @@
 		/decl/material/solid/metal/copper = 0.4
 	)
 	taste_mult = 1.2
-	exoplanet_rarity = MAT_RARITY_EXOTIC
+	exoplanet_rarity_plant = MAT_RARITY_EXOTIC
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 
 /decl/material/liquid/zombiepowder/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
@@ -164,6 +172,7 @@
 	toxicity = 0.5 // It's not THAT poisonous.
 	color = "#664330"
 	metabolism = REM * 0.25
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 
 /decl/material/liquid/weedkiller
 	name = "weedkiller"
@@ -179,7 +188,8 @@
 	heating_point = 100 CELSIUS
 	metabolism = REM * 0.25
 	defoliant = TRUE
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/liquid/tar
 	name = "tar"
@@ -197,6 +207,7 @@
 	heating_message = "separates"
 	taste_mult = 1.2
 	metabolism = REM * 0.25
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/liquid/hair_remover
 	name = "hair remover"
@@ -207,6 +218,7 @@
 	toxicity = 1
 	overdose = REAGENTS_OVERDOSE
 	taste_mult = 1.2
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE // i am so tired of seeing hair remover planets
 	metabolism = REM * 0.25
 
 /decl/material/liquid/hair_remover/affect_touch(var/mob/M, var/removed, var/datum/reagents/holder)
@@ -224,7 +236,8 @@
 	metabolism = REM * 5
 	overdose = 30
 	hidden_from_codex = TRUE
-	exoplanet_rarity = MAT_RARITY_EXOTIC
+	exoplanet_rarity_plant = MAT_RARITY_EXOTIC
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	var/amount_to_zombify = 5
 
 /decl/material/liquid/zombie/affect_touch(var/mob/living/M, var/removed, var/datum/reagents/holder)

--- a/code/modules/materials/definitions/solids/materials_solid_alien.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_alien.dm
@@ -10,7 +10,8 @@
 	hidden_from_codex = TRUE
 	value = 2.5
 	default_solid_form = /obj/item/stack/material/cubes
-	exoplanet_rarity = MAT_RARITY_EXOTIC
+	exoplanet_rarity_plant = MAT_RARITY_EXOTIC
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/solid/metal/aliumium/Initialize()
 	icon_base = 'icons/turf/walls/metal.dmi'

--- a/code/modules/materials/definitions/solids/materials_solid_exotic.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_exotic.dm
@@ -29,7 +29,8 @@
 		/decl/material/liquid/fuel/hydrazine = 1
 	)
 	default_solid_form = /obj/item/stack/material/segment
-	exoplanet_rarity = MAT_RARITY_EXOTIC
+	exoplanet_rarity_plant = MAT_RARITY_EXOTIC
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/solid/exotic_matter
 	name = "exotic matter"
@@ -63,4 +64,5 @@
 		/decl/material/solid/exotic_matter = 1
 	)
 	default_solid_form = /obj/item/stack/material/segment
-	exoplanet_rarity = MAT_RARITY_EXOTIC
+	exoplanet_rarity_plant = MAT_RARITY_EXOTIC
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE

--- a/code/modules/materials/definitions/solids/materials_solid_fission.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_fission.dm
@@ -10,7 +10,8 @@
 	icon_reinf = 'icons/turf/walls/reinforced_stone.dmi'
 	wall_flags = 0 //Since we're using an unpaintable icon_base and icon_reinf
 	value = 1.5
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 	neutron_cross_section = 5
 	neutron_interactions = list(
@@ -42,7 +43,8 @@
 	wall_flags = 0 //Since we're using an unpaintable icon_base and icon_reinf
 	color = "#404c53"
 	value = 0.5
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 	neutron_cross_section = 4 // Difficult to use as fuel.
 	neutron_interactions = list(
@@ -65,7 +67,8 @@
 	wall_flags = 0 //Since we're using an unpaintable icon_base and icon_reinf
 	color = "#b5c5a2"
 	value = 3
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 	neutron_cross_section = 10
 	neutron_interactions = list(
@@ -92,7 +95,8 @@
 	wall_flags = 0 //Since we're using an unpaintable icon_base and icon_reinf
 	color = "#98be30"
 	value = 0.5
-	exoplanet_rarity = MAT_RARITY_NOWHERE // Don't spawn this in plants.
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE // Don't spawn this in plants.
 
 	dissolves_into = list(
 		/decl/material/solid/metal/radium = 0.5,

--- a/code/modules/materials/definitions/solids/materials_solid_gemstones.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_gemstones.dm
@@ -33,7 +33,8 @@
 	rich_material_weight = 5
 	ore_type_value = ORE_PRECIOUS
 	ore_data_value = 2
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/solid/gemstone/crystal
 	name = "crystal"
@@ -42,4 +43,5 @@
 	reflectiveness = MAT_VALUE_VERY_SHINY
 	hidden_from_codex = TRUE
 	value = 2
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE

--- a/code/modules/materials/definitions/solids/materials_solid_metal.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_metal.dm
@@ -38,7 +38,8 @@
 	reflectiveness = MAT_VALUE_MATTE
 	value = 1.5
 	default_solid_form = /obj/item/stack/material/puck
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 	neutron_cross_section = 10
 	neutron_interactions = list(
@@ -117,7 +118,8 @@
 	wall_flags = PAINT_PAINTABLE|PAINT_STRIPABLE|WALL_HAS_EDGES
 	use_reinf_state = null
 	value = 1.4
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/solid/metal/redgold
 	name = "red gold"
@@ -126,7 +128,8 @@
 	color = "#ff7a59"
 	reflectiveness = MAT_VALUE_SHINY
 	value = 1.4
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/solid/metal/brass
 	name = "brass"
@@ -136,7 +139,8 @@
 	reflectiveness = MAT_VALUE_VERY_SHINY
 	value = 1.2
 	default_solid_form = /obj/item/stack/material/sheet
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/solid/metal/copper
 	name = "copper"
@@ -218,7 +222,8 @@
 	conductive = 0
 	hidden_from_codex = TRUE
 	value = 0
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/solid/metal/steel/holographic/get_recipes(reinf_mat)
 	return list()
@@ -239,7 +244,8 @@
 	construction_difficulty = MAT_VALUE_VERY_HARD_DIY
 	reflectiveness = MAT_VALUE_MIRRORED
 	value = 1.3
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/solid/metal/aluminium
 	name = "aluminium"
@@ -268,7 +274,8 @@
 	shard_type = SHARD_NONE
 	conductive = 0
 	hidden_from_codex = TRUE
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/solid/metal/aluminium/holographic/get_recipes(reinf_mat)
 	return list()
@@ -294,7 +301,8 @@
 	value = 1.4
 	reflectiveness = MAT_VALUE_MATTE
 	default_solid_form = /obj/item/stack/material/reinforced
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/solid/metal/plasteel/generate_recipes(var/reinforce_material)
 	. = ..()
@@ -351,7 +359,8 @@
 	stack_origin_tech = "{'materials':3}"
 	construction_difficulty = MAT_VALUE_VERY_HARD_DIY
 	value = 1.8
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/solid/metal/osmium
 	name = "osmium"
@@ -458,7 +467,8 @@
 	hidden_from_codex = TRUE
 	value = 3
 	default_solid_form = /obj/item/stack/material/cubes
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	icon_base = 'icons/turf/walls/solid.dmi'
 	icon_reinf = 'icons/turf/walls/reinforced.dmi'
 	use_reinf_state = null
@@ -471,7 +481,8 @@
 	color = "#666666"
 	hidden_from_codex = TRUE
 	default_solid_form = /obj/item/stack/material/sheet
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/solid/metal/tungsten
 	name = "tungsten"

--- a/code/modules/materials/definitions/solids/materials_solid_metal.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_metal.dm
@@ -18,6 +18,7 @@
 	abstract_type = /decl/material/solid/metal
 	icon_base = 'icons/turf/walls/metal.dmi'
 	icon_reinf = 'icons/turf/walls/reinforced_metal.dmi'
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/solid/metal/uranium
 	name = "uranium"

--- a/code/modules/materials/definitions/solids/materials_solid_mundane.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_mundane.dm
@@ -18,7 +18,8 @@
 	)
 	value = 0.1
 	default_solid_form = /obj/item/stack/material/lump
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 	// Slag can be reclaimed into more useful forms by grinding it up and mixing it with strong acid.
 	dissolves_in = MAT_SOLVENT_STRONG

--- a/code/modules/materials/definitions/solids/materials_solid_organic.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_organic.dm
@@ -42,7 +42,8 @@
 	uid = "solid_holographic_plastic"
 	shard_type = SHARD_NONE
 	hidden_from_codex = TRUE
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/solid/plastic/holographic/get_recipes(reinf_mat)
 	return list()
@@ -71,7 +72,8 @@
 	reflectiveness = MAT_VALUE_DULL
 	wall_support_value = MAT_VALUE_EXTREMELY_LIGHT
 	default_solid_form = /obj/item/stack/material/cardstock
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	sound_manipulate = 'sound/foley/paperpickup2.ogg'
 	sound_dropped = 'sound/foley/paperpickup1.ogg'
 
@@ -110,7 +112,8 @@
 	value                   = 0.25
 	default_solid_form      = /obj/item/stack/material/bolt
 	shard_type              = /obj/item/shreddedp
-	exoplanet_rarity        = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant  = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas    = MAT_RARITY_NOWHERE
 	sound_manipulate        = 'sound/foley/paperpickup2.ogg'
 	sound_dropped           = 'sound/foley/paperpickup1.ogg'
 
@@ -139,7 +142,8 @@
 	weight = MAT_VALUE_EXTREMELY_LIGHT
 	wall_support_value = MAT_VALUE_EXTREMELY_LIGHT
 	default_solid_form = /obj/item/stack/material/bolt
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	sound_manipulate = 'sound/foley/paperpickup2.ogg'
 	sound_dropped = 'sound/foley/paperpickup1.ogg'
 
@@ -220,7 +224,8 @@
 	wall_support_value = MAT_VALUE_EXTREMELY_LIGHT
 	hidden_from_codex = TRUE
 	default_solid_form = /obj/item/stack/material/bolt
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	sound_manipulate = 'sound/foley/paperpickup2.ogg'
 	sound_dropped = 'sound/foley/paperpickup1.ogg'
 
@@ -305,7 +310,8 @@
 	tans_to = /decl/material/solid/leather/lizard
 	hardness = MAT_VALUE_FLEXIBLE
 	weight = MAT_VALUE_VERY_LIGHT
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/solid/skin/insect
 	name = "chitin"
@@ -430,14 +436,16 @@
 	uid = "solid_fishbone"
 	hardness = MAT_VALUE_FLEXIBLE
 	weight = MAT_VALUE_VERY_LIGHT
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/solid/bone/cartilage
 	name = "cartilage"
 	uid = "solid_cartilage"
 	hardness = 0
 	weight = MAT_VALUE_EXTREMELY_LIGHT
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/solid/leather
 	name = "leather"
@@ -456,7 +464,8 @@
 	reflectiveness = MAT_VALUE_MATTE
 	wall_support_value = MAT_VALUE_EXTREMELY_LIGHT
 	default_solid_form = /obj/item/stack/material/skin
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	sound_manipulate = 'sound/foley/paperpickup2.ogg'
 	sound_dropped = 'sound/foley/paperpickup1.ogg'
 

--- a/code/modules/materials/definitions/solids/materials_solid_organic.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_organic.dm
@@ -293,6 +293,7 @@
 	sound_manipulate = 'sound/foley/meat1.ogg'
 	sound_dropped = 'sound/foley/meat2.ogg'
 	hitsound = "punch"
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	var/tans_to = /decl/material/solid/leather
 
 /decl/material/solid/skin/generate_recipes(var/reinforce_material)

--- a/code/modules/materials/definitions/solids/materials_solid_stone.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_stone.dm
@@ -34,17 +34,18 @@
 	value = 1.5
 
 /decl/material/solid/stone/granite
-	name                 = "granite"
-	uid                  = "solid_granite"
-	lore_text            = "A coarse-grained igneous rock formed by magma containing sillicon and alkali metal oxides."
-	color                = "#615f5f"
-	exoplanet_rarity     = MAT_RARITY_MUNDANE
-	hardness             = MAT_VALUE_HARD + 5
-	melting_point        = T0C + 1260
-	brute_armor          = 15
-	explosion_resistance = 15
-	integrity            = 500 //granite is very strong
-	dissolves_into          = list(
+	name                   = "granite"
+	uid                    = "solid_granite"
+	lore_text              = "A coarse-grained igneous rock formed by magma containing sillicon and alkali metal oxides."
+	color                  = "#615f5f"
+	exoplanet_rarity_plant = MAT_RARITY_MUNDANE
+	exoplanet_rarity_gas   = MAT_RARITY_MUNDANE
+	hardness               = MAT_VALUE_HARD + 5
+	melting_point          = T0C + 1260
+	brute_armor            = 15
+	explosion_resistance   = 15
+	integrity              = 500 //granite is very strong
+	dissolves_into         = list(
 		/decl/material/solid/silicon = 0.75,
 		/decl/material/solid/bauxite = 0.15,
 		/decl/material/solid/slag    = 0.10,
@@ -86,7 +87,8 @@
 	lore_text = "The most ubiquitous building material of old Earth, now in space. Consists of mineral aggregate bound with some sort of cementing solution."
 	color = COLOR_GRAY
 	value = 0.9
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	var/image/texture
 
 /decl/material/solid/stone/concrete/Initialize()
@@ -108,7 +110,8 @@
 	construction_difficulty = MAT_VALUE_NORMAL_DIY
 	hidden_from_codex = TRUE
 	reflectiveness = MAT_VALUE_DULL
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/solid/stone/cult/place_dismantled_girder(var/turf/target)
 	return list(new /obj/structure/girder/cult(target))

--- a/code/modules/materials/definitions/solids/materials_solid_wood.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_wood.dm
@@ -106,7 +106,8 @@
 	shard_type = SHARD_NONE
 	value = 0
 	hidden_from_codex = TRUE
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/solid/wood/holographic/get_recipes(reinf_mat)
 	return list()

--- a/code/modules/reagents/chems/chems_blood.dm
+++ b/code/modules/reagents/chems/chems_blood.dm
@@ -95,3 +95,4 @@
 	hidden_from_codex = TRUE
 	toxicity = 4
 	value = 0
+	exoplanet_rarity_gas = MAT_RARITY_UNCOMMON

--- a/code/modules/reagents/chems/chems_cleaner.dm
+++ b/code/modules/reagents/chems/chems_cleaner.dm
@@ -8,3 +8,4 @@
 	dirtiness = DIRTINESS_CLEAN
 	turf_touch_threshold = 0.1
 	uid = "chem_cleaner"
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC

--- a/code/modules/reagents/chems/chems_compounds.dm
+++ b/code/modules/reagents/chems/chems_compounds.dm
@@ -4,7 +4,8 @@
 	lore_text = "A compound that interacts with blood on the molecular level."
 	taste_description = "metal"
 	color = "#f2f3f4"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/liquid/luminol/touch_obj(var/obj/O, var/amount, var/datum/reagents/holder)
 	O.reveal_blood()
@@ -17,6 +18,7 @@
 	lore_text = "A popular party drug for adventurous types who want to BE the glowstick. Rumoured to be hallucinogenic in high doses."
 	overdose = 15
 	color = "#9eefff"
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE // No sap air.
 	uid = "chem_glowsap"
 
 /decl/material/liquid/glowsap/affect_ingest(mob/living/M, removed, var/datum/reagents/holder)
@@ -65,6 +67,7 @@
 	color = "#07aab2"
 	value = 2
 	fruit_descriptor = "numbing"
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_frostoil"
 
 /decl/material/liquid/frostoil/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -81,6 +84,7 @@
 	color = "#b31008"
 	fruit_descriptor = "spicy"
 	uid = "chem_capsaicin"
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 
 	heating_point = T100C
 	heating_message = "darkens and thickens as it seperates from its water content"
@@ -134,6 +138,7 @@
 	heating_message = null
 	heating_products = null
 	heating_point = null
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/liquid/capsaicin/condensed/affect_touch(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/eyes_covered = 0
@@ -210,6 +215,8 @@
 	taste_description = "slime"
 	taste_mult = 0.9
 	color = "#13bc5e"
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_mutagenics"
 
 /decl/material/liquid/mutagenics/affect_touch(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -248,7 +255,8 @@
 	scannable = 1
 	overdose = REAGENTS_OVERDOSE
 	metabolism = REM*2
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_lactate"
 
 /decl/material/liquid/lactate/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -269,7 +277,8 @@
 	scannable = 1
 	overdose = 5
 	metabolism = 1
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nanoblood"
 
 /decl/material/liquid/nanoblood/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -328,7 +337,8 @@
 	scent_intensity = null
 	scent_descriptor = null
 	scent_range = null
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nicotinesolution"
 
 /decl/material/liquid/menthol
@@ -340,6 +350,7 @@
 	overdose = REAGENTS_OVERDOSE * 0.25
 	scannable = 1
 	hidden_from_codex = TRUE
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_tobacco_menthol"
 
 /decl/material/liquid/menthol/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -354,6 +365,8 @@
 	color = "#c2c2d6"
 	scannable = 1
 	flags = IGNORE_MOB_SIZE
+	exoplanet_rarity_plant = MAT_RARITY_EXOTIC
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_nanite_fluid"
 
 /decl/material/liquid/nanitefluid/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -374,12 +387,14 @@
 	touch_met = 5
 	dirtiness = DIRTINESS_STERILE
 	turf_touch_threshold = 0.1
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_antiseptic"
 
 /decl/material/liquid/crystal_agent
 	name = "crystallizing agent"
 	taste_description = "sharpness"
 	color = "#13bc5e"
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_crystalizing_agent"
 
 /decl/material/liquid/crystal_agent/proc/do_material_check(var/mob/living/carbon/M)

--- a/code/modules/reagents/chems/chems_compounds.dm
+++ b/code/modules/reagents/chems/chems_compounds.dm
@@ -58,6 +58,7 @@
 	taste_mult = 0.7
 	color = "#365e30"
 	overdose = REAGENTS_OVERDOSE
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 
 /decl/material/liquid/frostoil
 	name = "chilly oil"

--- a/code/modules/reagents/chems/chems_drinks.dm
+++ b/code/modules/reagents/chems/chems_drinks.dm
@@ -4,6 +4,7 @@
 	color = "#e78108"
 	value = 0.4
 	abstract_type = /decl/material/liquid/drink
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE // Please, no more berry juice atmosphere planets.
 
 	var/nutrition = 0 // Per unit
 	var/hydration = 6 // Per unit
@@ -147,6 +148,7 @@
 	taste_description = "berries"
 	color = "#863353"
 	toxicity = 5
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE // No more juice air.
 	uid = "chem_drink_berry_poison"
 
 	glass_name = "poison berry juice"
@@ -262,7 +264,8 @@
 	lore_text = "A mixture of perfectly healthy milk and delicious chocolate."
 	taste_description = "chocolate milk"
 	color = "#74533b"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_milk_chocolate"
 
 	glass_name = "chocolate milk"
@@ -314,7 +317,8 @@
 	overdose = 60
 	glass_name = "coffee"
 	glass_desc = "Don't drop it, or you'll send scalding liquid and glass shards everywhere."
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_coffee"
 	var/list/flavour_modifiers = list()
 
@@ -385,7 +389,8 @@
 	color = "#403010"
 	nutrition = 2
 	adj_temp = 5
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_hot_chocolate"
 
 	glass_name = "hot chocolate"
@@ -399,7 +404,8 @@
 	adj_dizzy = -5
 	adj_drowsy = -3
 	adj_temp = -5
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_sodawater"
 
 	glass_name = "soda water"
@@ -412,7 +418,8 @@
 	taste_description = "grape soda"
 	color = "#421c52"
 	adj_drowsy = -3
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_grapesoda"
 
 	glass_name = "grape soda"
@@ -428,7 +435,8 @@
 	adj_drowsy = -3
 	adj_sleepy = -2
 	adj_temp = -5
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_tonicwater"
 
 	glass_name = "tonic water"
@@ -440,7 +448,8 @@
 	taste_description = "tartness"
 	color = "#ffff00"
 	adj_temp = -5
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_lemonade"
 
 	glass_name = "lemonade"
@@ -453,7 +462,8 @@
 	taste_description = "tart and tasty"
 	color = "#cccc99"
 	adj_temp = -5
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_citrus_seltzer"
 
 	glass_name = "citrus seltzer"
@@ -466,7 +476,8 @@
 	taste_description = "orange and cola"
 	color = "#9f3400"
 	adj_temp = -2
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_orangecola"
 
 	glass_name = "orange cola"
@@ -478,7 +489,8 @@
 	taste_description = "creamy vanilla"
 	color = "#aee5e4"
 	adj_temp = -9
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_milkshake"
 
 	glass_name = "milkshake"
@@ -492,7 +504,8 @@
 	adj_temp = -5
 	adj_sleepy = -2
 	euphoriant = 30
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_mutagencola"
 
 	glass_name = "mutagen cola"
@@ -517,7 +530,8 @@
 	lore_text = "Made in the modern day with proper pomegranate substitute. Who uses real fruit, anyways?"
 	taste_description = "100% pure pomegranate"
 	color = "#ff004f"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_grenadine"
 
 	glass_name = "grenadine syrup"
@@ -531,7 +545,8 @@
 	color = "#100800"
 	adj_drowsy = -3
 	adj_temp = -5
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_cola"
 
 	glass_name = "cola"
@@ -546,7 +561,8 @@
 	adj_drowsy = -7
 	adj_sleepy = -1
 	adj_temp = -5
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_citrussoda"
 
 	glass_name = "citrus soda"
@@ -560,7 +576,8 @@
 	color = "#102000"
 	adj_drowsy = -6
 	adj_temp = -5
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_cherrysoda"
 
 	glass_name = "cherry soda"
@@ -572,7 +589,8 @@
 	taste_description = "a hull breach"
 	color = "#202800"
 	adj_temp = -8
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_lemonade"
 
 	glass_name = "lemonade"
@@ -585,7 +603,8 @@
 	taste_description = "tangy lime and lemon soda"
 	color = "#878f00"
 	adj_temp = -8
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_lemonlimesoda"
 
 	glass_name = "lemon lime soda"
@@ -598,7 +617,8 @@
 	taste_description = "dry and cheap noodles"
 	nutrition = 1
 	color = "#302000"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_dryramen"
 
 /decl/material/liquid/drink/hot_ramen
@@ -608,7 +628,8 @@
 	color = "#302000"
 	nutrition = 5
 	adj_temp = 5
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_hotramen"
 
 /decl/material/liquid/drink/hell_ramen
@@ -617,7 +638,8 @@
 	taste_description = "wet and cheap noodles on fire"
 	color = "#302000"
 	nutrition = 5
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_hellramen"
 
 /decl/material/liquid/drink/hell_ramen/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -658,7 +680,8 @@
 	adj_temp = 20
 	glass_name = "black tea"
 	glass_desc = "Tasty black tea, it has antioxidants, it's good for you!"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_blacktea"
 
 /decl/material/liquid/drink/tea/black/build_presentation_name_from_reagents(var/obj/item/prop, var/supplied)
@@ -677,7 +700,8 @@
 	lore_text = "Subtle green tea, it has antioxidants, it's good for you!"
 	taste_description = "subtle green tea"
 	color = "#b4cd94"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_greentea"
 
 	glass_name = "green tea"
@@ -688,7 +712,8 @@
 	lore_text = "A spiced, dark tea. Goes great with milk."
 	taste_description = "spiced black tea"
 	color = "#151000"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_chai"
 
 	glass_name = "chai"
@@ -706,7 +731,8 @@
 	lore_text = "A caffeine-free dark red tea, flavorful and full of antioxidants."
 	taste_description = "nutty red tea"
 	color = "#ab4c3a"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_redtea"
 
 	glass_name = "redbush tea"
@@ -728,7 +754,8 @@
 	taste_description = "mint"
 	color = "#07aab2"
 	coffee_priority = 1
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_mint"
 
 	glass_name = "mint flavouring"
@@ -741,7 +768,8 @@
 	color = "#542a0c"
 	coffee_modifier = "mocha"
 	coffee_priority = 5
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_chocolatesyrup"
 
 	glass_name = "chocolate syrup"
@@ -753,7 +781,8 @@
 	taste_description = "caramel"
 	color = "#85461e"
 	coffee_priority = 2
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_caramelsyrup"
 
 	glass_name = "caramel syrup"
@@ -765,7 +794,8 @@
 	taste_description = "vanilla"
 	color = "#f3e5ab"
 	coffee_priority = 3
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_vanillasyrup"
 
 	glass_name = "vanilla syrup"
@@ -777,7 +807,8 @@
 	taste_description = "pumpkin spice"
 	color = "#d88b4c"
 	coffee_priority = 4
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_pumpkinsyrup"
 
 	glass_name = "pumpkin spice syrup"
@@ -790,7 +821,8 @@
 	color = "#44371f"
 	glass_name = "ginger beer"
 	glass_desc = "A hearty, non-alcoholic beverage brewed from ginger."
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_gingerbeer"
 
 /decl/material/liquid/drink/beastenergy
@@ -800,7 +832,8 @@
 	color = "#d69115"
 	glass_name = "beast energy"
 	glass_desc = "Why would you drink this without mixer?"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_energydrink"
 
 /decl/material/liquid/drink/beastenergy/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -820,7 +853,8 @@
 	color = "#ece4e3"
 	glass_name = "Kefir"
 	glass_desc = "Fermented milk, looks a lot like yougurt."
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_kefir"
 
 /decl/material/liquid/drink/compote
@@ -828,7 +862,8 @@
 	lore_text = "Traditional dessert drink made from fruits or berries. Grandma would be proud."
 	taste_description = "sweet-sour berries"
 	color = "#9e4b00"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_drink_compote"
 
 	glass_name = "Compote"

--- a/code/modules/reagents/chems/chems_drugs.dm
+++ b/code/modules/reagents/chems/chems_drugs.dm
@@ -7,6 +7,7 @@
 	metabolism = REM * 0.15
 	overdose = REAGENTS_OVERDOSE * 0.5
 	value = 2
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_amphetamines"
 
 /decl/material/liquid/amphetamines/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -22,6 +23,7 @@
 	color = "#c8a5dc"
 	overdose = REAGENTS_OVERDOSE
 	value = 2
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_narcotics"
 
 /decl/material/liquid/narcotics/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -42,6 +44,7 @@
 	overdose = 6
 	scannable = 1
 	value = 2
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_nicotine"
 
 /decl/material/liquid/nicotine/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -67,6 +70,7 @@
 	metabolism = REM * 0.5
 	overdose = REAGENTS_OVERDOSE
 	value = 2
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_sedatives"
 
 /decl/material/liquid/sedatives/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -101,6 +105,7 @@
 	narcosis = 7
 	fruit_descriptor = "rich"
 	euphoriant = 15
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_psychoactives"
 
 /decl/material/liquid/psychoactives/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -116,6 +121,7 @@
 	metabolism = REM * 0.25
 	overdose = REAGENTS_OVERDOSE
 	value = 2
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_hallucinogenics"
 
 /decl/material/liquid/hallucinogenics/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -132,6 +138,7 @@
 	value = 2
 	euphoriant = 30
 	fruit_descriptor = "hallucinogenic"
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_psychotropics"
 
 /decl/material/liquid/psychotropics/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -166,6 +173,7 @@
 	color = "#ccccff"
 	metabolism = REM
 	overdose = 25
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_gleam"
 
 	// M A X I M U M C H E E S E

--- a/code/modules/reagents/chems/chems_ethanol.dm
+++ b/code/modules/reagents/chems/chems_ethanol.dm
@@ -92,7 +92,8 @@
 	taste_mult = 1.5
 	color = "#33ee00"
 	strength = 12
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 	glass_name = "absinthe"
 	glass_desc = "Wormwood, anise, oh my."
@@ -104,7 +105,8 @@
 	taste_description = "hearty barley ale"
 	color = "#4c3100"
 	strength = 50
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 	glass_name = "ale"
 	glass_desc = "A freezing container of delicious ale"
@@ -118,7 +120,8 @@
 	color = "#ffd300"
 	strength = 50
 	nutriment_factor = 1
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 	glass_name = "beer"
 	glass_desc = "A freezing container of beer"
@@ -142,7 +145,8 @@
 	taste_mult = 1.1
 	color = "#0000cd"
 	strength = 15
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_bluecuracao"
 
 	glass_name = "blue curacao"
@@ -155,7 +159,8 @@
 	taste_mult = 1.1
 	color = "#ab3c05"
 	strength = 15
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_cognac"
 
 	glass_name = "cognac"
@@ -167,7 +172,8 @@
 	taste_description = "an alcoholic christmas tree"
 	color = "#0064c6"
 	strength = 15
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_gin"
 
 	glass_name = "gin"
@@ -181,7 +187,8 @@
 	taste_mult = 1.1
 	color = "#4c3100"
 	strength = 15
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_coffee"
 	glass_name = "coffee liqueur"
 	glass_desc = "Guaranteed to perk you up."
@@ -208,7 +215,8 @@
 	taste_description = "fruity alcohol"
 	color = "#138808" // rgb: 19, 136, 8
 	strength = 50
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_melon"
 
 	glass_name = "melon liqueur"
@@ -221,7 +229,8 @@
 	taste_mult = 1.1
 	color = "#ecb633"
 	strength = 15
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_rum"
 
 	glass_name = "rum"
@@ -233,7 +242,8 @@
 	taste_description = "dry alcohol"
 	color = "#dddddd"
 	strength = 25
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_sake"
 
 	glass_name = "sake"
@@ -245,7 +255,8 @@
 	taste_description = "paint stripper"
 	color = "#ffff91"
 	strength = 25
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_tequila"
 
 	glass_name = "tequila"
@@ -258,7 +269,8 @@
 	color = "#102000"
 	strength = 25
 	nutriment_factor = 1
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_thirteenloko"
 
 	glass_name = "Thirteen Loko"
@@ -283,7 +295,8 @@
 	taste_mult = 1.3
 	color = "#91ff91" // rgb: 145, 255, 145
 	strength = 15
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_vermouth"
 
 	glass_name = "vermouth"
@@ -296,7 +309,8 @@
 	taste_description = "grain alcohol"
 	color = "#0064c8" // rgb: 0, 100, 200
 	strength = 15
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_vodka"
 
 	glass_name = "vodka"
@@ -309,7 +323,8 @@
 	taste_description = "clear kvass"
 	color = "#aaddff" // rgb: 170, 221, 255 - very light blue.
 	strength = 10
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_premiumvodka"
 
 /decl/material/liquid/ethanol/whiskey
@@ -318,7 +333,8 @@
 	taste_description = "molasses"
 	color = "#4c3100"
 	strength = 25
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_whiskey"
 
 	glass_name = "whiskey"
@@ -330,7 +346,8 @@
 	taste_description = "bitter sweetness"
 	color = "#7e4043" // rgb: 126, 64, 67
 	strength = 15
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_wine"
 
 	glass_name = "red wine"
@@ -342,7 +359,8 @@
 	taste_description = "white velvet"
 	color = "#ffddaa" // rgb: 255, 221, 170 - a light cream
 	strength = 20
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_whitewine"
 
 /decl/material/liquid/ethanol/herbal
@@ -351,7 +369,8 @@
 	taste_description = "a sweet summer garden"
 	color = "#dfff00"
 	strength = 13
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_herbal"
 
 	glass_name = "herbal liquor"
@@ -364,7 +383,8 @@
 	color = "#4c3100"
 	strength = 25
 	alcohol_toxicity = 2
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_hooch"
 
 	glass_name = "Hooch"
@@ -376,7 +396,8 @@
 	taste_description = "creamy alcohol"
 	color = "#dddd9a"
 	strength = 25
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_irishcream"
 
 	glass_name = "Irish cream"
@@ -389,7 +410,8 @@
 	color = "#ffbb00"
 	strength = 30
 	nutriment_factor = 1
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_mead"
 
 	glass_name = "mead"
@@ -402,7 +424,8 @@
 	taste_mult = 2.5
 	color = "#0064c8"
 	strength = 12
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_moonshine"
 
 	glass_name = "moonshine"
@@ -418,7 +441,8 @@
 	glass_name = "???"
 	glass_desc = "A black ichor with an oily purple sheer on top. Are you sure you should drink this?"
 	euphoriant = 50
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_poisonwine"
 
 /decl/material/liquid/ethanol/pwine/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -444,7 +468,8 @@
 	lore_text = "A well-aged whiskey of high quality. Probably imported. Just a sip'll do it, but that burn will leave you wanting more."
 	color = "#523600"
 	strength = 25
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_agedwhiskey"
 
 	glass_name = "aged whiskey"
@@ -456,7 +481,8 @@
 	taste_description = "cool apple cider"
 	color = "#cac089"
 	strength = 50
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_applecider"
 
 	glass_name = "apple cider"
@@ -468,7 +494,8 @@
 	taste_description = "cool pear cider"
 	color = "#cac089"
 	strength = 50
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_pearcider"
 
 	glass_name = "pear cider"
@@ -480,7 +507,8 @@
 	taste_description = "a superior taste of sparkling wine"
 	color = "#e8dfc1"
 	strength = 25
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_champagne"
 
 	glass_name = "champagne"
@@ -492,7 +520,8 @@
 	taste_description = "herbs, spices, and alcohol"
 	color = "#596e3e"
 	strength = 20
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_jagermeister"
 
 	glass_name = "jagermeister"
@@ -504,7 +533,8 @@
 	taste_description = "vkusnyy kvas, ypa!"
 	color = "#362f22"
 	strength = 30
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_ethanol_kvass"
 
 	glass_name = "kvass"

--- a/code/modules/reagents/chems/chems_explosives.dm
+++ b/code/modules/reagents/chems/chems_explosives.dm
@@ -3,7 +3,8 @@
 	lore_text = "Ammonia Nitrate Fuel Oil mix, an explosive compound known for centuries. Safe to handle, can be set off with a small explosion."
 	taste_description = "fertilizer and fuel"
 	color = "#dbc3c3"
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_anfo"
 	var/boompower = 1
 
@@ -36,5 +37,6 @@
 	lore_text = "Ammonia Nitrate Fuel Oil, with aluminium powder, an explosive compound known for centuries. Safe to handle, can be set off with a small explosion."
 	color = "#ffe8e8"
 	boompower = 2
-	exoplanet_rarity = MAT_RARITY_EXOTIC
+	exoplanet_rarity_plant = MAT_RARITY_EXOTIC
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_anfoplus"

--- a/code/modules/reagents/chems/chems_fuel.dm
+++ b/code/modules/reagents/chems/chems_fuel.dm
@@ -7,7 +7,8 @@
 	fuel_value = 1
 	burn_product = /decl/material/gas/carbon_monoxide
 	gas_flags = XGM_GAS_FUEL
-	exoplanet_rarity = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
+	exoplanet_rarity_gas = MAT_RARITY_UNCOMMON
 	uid = "chem_fuel"
 
 	glass_name = "welder fuel"

--- a/code/modules/reagents/chems/chems_medicines.dm
+++ b/code/modules/reagents/chems/chems_medicines.dm
@@ -7,6 +7,7 @@
 	scannable = 1
 	flags = IGNORE_MOB_SIZE
 	value = 1.5
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_eyedrops"
 
 /decl/material/liquid/eyedrops/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -28,6 +29,7 @@
 	scannable = 1
 	flags = IGNORE_MOB_SIZE
 	value = 1.5
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_antirads"
 
 /decl/material/liquid/antirads/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -44,6 +46,7 @@
 	flags = IGNORE_MOB_SIZE
 	value = 1.5
 	fruit_descriptor = "medicinal"
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_styptic"
 	var/effectiveness = 1
 
@@ -73,6 +76,7 @@
 	scannable = 1
 	flags = IGNORE_MOB_SIZE
 	value = 1.5
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_synthskin"
 	var/effectiveness = 1
 
@@ -89,7 +93,8 @@
 	taste_description = "100% abuse"
 	color = "#c8a5dc"
 	flags = AFFECTS_DEAD //This can even heal dead people.
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_adminorazine"
 
 	glass_name = "liquid gold"
@@ -110,6 +115,7 @@
 	flags = IGNORE_MOB_SIZE
 	value = 1.5
 	fruit_descriptor = "astringent"
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_antitoxins"
 	var/remove_generic = 1
 	var/list/remove_toxins = list(
@@ -145,6 +151,7 @@
 	overdose = REAGENTS_OVERDOSE
 	value = 1.5
 	scannable = 1
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_immunobooster"
 
 /decl/material/liquid/immunobooster/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -167,6 +174,7 @@
 	scannable = 1
 	metabolism = 0.01
 	value = 1.5
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_stimulants"
 
 /decl/material/liquid/stimulants/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -191,6 +199,7 @@
 	scannable = 1
 	metabolism = 0.01
 	value = 1.5
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_antidepressants"
 
 /decl/material/liquid/antidepressants/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -214,6 +223,7 @@
 	overdose = REAGENTS_OVERDOSE/2
 	scannable = 1
 	value = 1.5
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_antibiotics"
 
 /decl/material/liquid/antibiotics/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -245,6 +255,7 @@
 	scannable = 1
 	overdose = REAGENTS_OVERDOSE
 	value = 1.5
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_retrovirals"
 
 /decl/material/liquid/retrovirals/affect_overdose(mob/living/M, datum/reagents/holder)
@@ -309,6 +320,7 @@
 	scannable = 1
 	metabolism = 0.5 * REM
 	value = 1.5
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_stabilizer"
 
 /decl/material/liquid/stabilizer/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -323,6 +335,7 @@
 	scannable = 1
 	flags = IGNORE_MOB_SIZE
 	value = 1.5
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_regenerative_serum"
 
 /decl/material/liquid/regenerator/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -341,6 +354,7 @@
 	scannable = 1
 	flags = IGNORE_MOB_SIZE
 	value = 1.5
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_neuroannealer"
 
 /decl/material/liquid/neuroannealer/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -357,6 +371,7 @@
 	taste_description = "tasteless slickness"
 	scannable = 1
 	color = COLOR_GRAY80
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_oxygel"
 
 /decl/material/liquid/oxy_meds/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -410,6 +425,7 @@
 	affect_blood_on_inhale = TRUE
 	affect_blood_on_ingest = FALSE
 	value = 1.5
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_detoxifier"
 
 /decl/material/liquid/detoxifier/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)

--- a/code/modules/reagents/chems/chems_nutriment.dm
+++ b/code/modules/reagents/chems/chems_nutriment.dm
@@ -8,6 +8,7 @@
 	value = 1.2
 	fruit_descriptor = "nutritious"
 	uid = "chem_nutriment"
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE // Please, no more animal protein or glowsap or corn oil atmosphere.
 
 	var/nutriment_factor = 10 // Per unit
 	var/hydration_factor = 0 // Per unit
@@ -141,7 +142,8 @@
 	nutriment_factor = 3
 	color = "#ffd592"
 	slipperiness = -1
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_batter"
 
 /decl/material/liquid/nutriment/batter/touch_turf(var/turf/T, var/amount, var/datum/reagents/holder)
@@ -173,7 +175,8 @@
 /decl/material/liquid/nutriment/coffee/instant
 	name = "instant coffee powder"
 	lore_text = "A bitter powder made by processing coffee beans."
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_instantcoffee"
 
 /decl/material/liquid/nutriment/tea
@@ -204,7 +207,8 @@
 	lore_text = "Dehydrated, powdered juice of some kind."
 	taste_mult = 1.3
 	nutriment_factor = 1
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_juice"
 
 /decl/material/liquid/nutriment/instantjuice/grape
@@ -212,7 +216,8 @@
 	lore_text = "Dehydrated, powdered grape juice."
 	taste_description = "dry grapes"
 	color = "#863333"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_juice_grape"
 
 /decl/material/liquid/nutriment/instantjuice/orange
@@ -220,7 +225,8 @@
 	lore_text = "Dehydrated, powdered orange juice."
 	taste_description = "dry oranges"
 	color = "#e78108"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_juice_orange"
 
 /decl/material/liquid/nutriment/instantjuice/watermelon
@@ -228,7 +234,8 @@
 	lore_text = "Dehydrated, powdered watermelon juice."
 	taste_description = "dry sweet watermelon"
 	color = "#b83333"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_juice_watermelon"
 
 /decl/material/liquid/nutriment/instantjuice/apple
@@ -236,7 +243,8 @@
 	lore_text = "Dehydrated, powdered apple juice."
 	taste_description = "dry sweet apples"
 	color = "#c07c40"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_juice_apple"
 
 /decl/material/liquid/nutriment/soysauce
@@ -246,7 +254,8 @@
 	taste_mult = 1.1
 	nutriment_factor = 2
 	color = "#792300"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_soysauce"
 
 /decl/material/liquid/nutriment/ketchup
@@ -255,7 +264,8 @@
 	taste_description = "ketchup"
 	nutriment_factor = 5
 	color = "#731008"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_ketchup"
 
 /decl/material/liquid/nutriment/banana_cream
@@ -263,7 +273,8 @@
 	lore_text = "A creamy confection that tastes of banana."
 	taste_description = "banana"
 	color = "#f6dfaa"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_bananacream"
 
 /decl/material/liquid/nutriment/barbecue
@@ -272,7 +283,8 @@
 	taste_description = "barbecue"
 	nutriment_factor = 5
 	color = "#4f330f"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_bbqsauce"
 
 /decl/material/liquid/nutriment/garlicsauce
@@ -281,7 +293,8 @@
 	taste_description = "garlic"
 	nutriment_factor = 4
 	color = "#d8c045"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_garlicsauce"
 
 /decl/material/liquid/nutriment/rice
@@ -300,7 +313,8 @@
 	taste_mult = 0.4
 	nutriment_factor = 1
 	color = "#f1ffdb"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_chazuke"
 
 /decl/material/liquid/nutriment/cherryjelly
@@ -329,7 +343,8 @@
 	taste_description = "childhood whimsy"
 	nutriment_factor = 1
 	color = "#ff00ff"
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_sprinkles"
 
 /decl/material/liquid/nutriment/sugar
@@ -361,5 +376,6 @@
 	taste_description = "mayo"
 	color = "#efede8"
 	taste_mult = 2
-	exoplanet_rarity = MAT_RARITY_NOWHERE
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_mayonnaise"

--- a/code/modules/reagents/chems/chems_painkillers.dm
+++ b/code/modules/reagents/chems/chems_painkillers.dm
@@ -10,6 +10,7 @@
 	ingest_met = 0.02
 	flags = IGNORE_MOB_SIZE
 	value = 1.8
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	/// Magnitude of painkilling effect
 	var/pain_power = 35
 	/// How many units it need to process to reach max power

--- a/code/modules/reagents/chems/chems_pigments.dm
+++ b/code/modules/reagents/chems/chems_pigments.dm
@@ -5,6 +5,7 @@
 	color = "#888888"
 	overdose = 5
 	hidden_from_codex = TRUE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_pigment"
 
 /decl/material/liquid/pigment/red
@@ -70,6 +71,7 @@
 	overdose = REAGENTS_OVERDOSE * 0.5
 	color_weight = 0
 	uid = "chem_pigment_paint"
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
 /decl/material/liquid/paint/proc/apply_paint(var/atom/painting, var/datum/reagents/holder)
 	if(istype(painting) && istype(holder))

--- a/code/modules/reagents/chems/chems_poisons.dm
+++ b/code/modules/reagents/chems/chems_poisons.dm
@@ -6,6 +6,7 @@
 	metabolism = REM * 0.5
 	overdose = REAGENTS_OVERDOSE * 0.5
 	value = 1.5
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_pigment_paralytics"
 
 /decl/material/liquid/paralytics/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
@@ -40,6 +41,7 @@
 		/decl/material/liquid/nutriment/sugar = 0.4
 	)
 	value = 1.5
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_pigment_presyncopics"
 
 /decl/material/liquid/presyncopics/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)

--- a/mods/content/psionics/system/psionics/null/material.dm
+++ b/mods/content/psionics/system/psionics/null/material.dm
@@ -19,6 +19,8 @@
 	destruction_desc = "shatters"
 	hitsound = 'sound/effects/Glasshit.ogg'
 	is_psionic_nullifier = TRUE
+	exoplanet_rarity_plant = MAT_RARITY_EXOTIC
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "solid_nullglass"
 
 /decl/material/nullglass/generate_recipes()

--- a/mods/content/xenobiology/slime/slime_reagents.dm
+++ b/mods/content/xenobiology/slime/slime_reagents.dm
@@ -12,6 +12,7 @@
 	heating_message = "becomes clear."
 	color = "#cf3600"
 	metabolism = REM * 0.25
+	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 
 /decl/material/liquid/water/affect_touch(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()


### PR DESCRIPTION
## Description of changes
- Removes a desert turf sprite that had footprints on it.
- Splits exoplanet rarity into plant/gas vars.
- Fixes a bug where an exoplanet could have fewer gases than intended due to skipping gases with incompatible flags.
- Fixes surfacant.
- Adjusts phase_at_temperature to check melting_point.
- Makes leech spawners much rarer since they spawn 12 leeches each.
- Adjusts atmosphere generation to treat materials above their ignition_point as if they have XGM_GAS_FUEL. TODO: Actually make those flammable.
- Lower the max percentage of exotic chems in planet atmospheres.
- Adjust the exoplanet gas rarity of a lot of misc. materials.

## Why and what will this PR improve
Resolves #2908.