### PR TITLE
Simplifies status checking a bit, also allows same-tick checking to work.

### DIFF
--- a/code/__defines/mob_status.dm
+++ b/code/__defines/mob_status.dm
@@ -1,5 +1,4 @@
-#define PENDING_STATUS(MOB, COND)      (LAZYACCESS(MOB.pending_status_counters, COND) || LAZYACCESS(MOB.status_counters, COND))
 #define GET_STATUS(MOB, COND)          (LAZYACCESS(MOB.status_counters, COND))
 #define HAS_STATUS(MOB, COND)          (GET_STATUS(MOB, COND) > 0)
-#define ADJ_STATUS(MOB, COND, AMT)     (MOB.set_status(COND, PENDING_STATUS(MOB, COND) + AMT))
-#define SET_STATUS_MAX(MOB, COND, AMT) (MOB.set_status(COND, max(PENDING_STATUS(MOB, COND), AMT)))
+#define ADJ_STATUS(MOB, COND, AMT)     (MOB.set_status(COND, (LAZYACCESS(MOB.pending_status_counters, COND) || LAZYACCESS(MOB.status_counters, COND)) + AMT))
+#define SET_STATUS_MAX(MOB, COND, AMT) (MOB.set_status(COND, max(HAS_STATUS(MOB, COND), AMT)))

--- a/code/modules/mob/living/living_status.dm
+++ b/code/modules/mob/living/living_status.dm
@@ -10,7 +10,7 @@
 	if(!cond.check_can_set(src))
 		return FALSE
 	amount = clamp(amount, 0, 1000)
-	if(amount == PENDING_STATUS(src, condition))
+	if(amount == HAS_STATUS(src, condition))
 		return FALSE
 	LAZYSET(pending_status_counters, condition, amount)
 	addtimer(CALLBACK(src, .proc/apply_pending_status_changes), 0, TIMER_UNIQUE)


### PR DESCRIPTION
## Description of changes
Condenses PENDING_STATUS into HAS_STATUS.

## Why and what will this PR improve
Checking status on the tick that the status is adjusted will now work.

## Authorship
Myself.

## Changelog
Nothing player-facing.