### PR TITLE
Fix carbon paper copy issue

### DIFF
--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -106,3 +106,10 @@
  */
 /datum/proc/PopulateClone(var/datum/clone)
 	return clone
+
+/////////////////////////////////////////////////////////////
+//Common implementations
+/////////////////////////////////////////////////////////////
+
+/image/GetCloneArgs()
+	return list(icon, loc, icon_state, layer, dir)

--- a/code/modules/paperwork/carbonpaper.dm
+++ b/code/modules/paperwork/carbonpaper.dm
@@ -11,8 +11,12 @@
 		add_overlay("paper_stack_words")
 
 /obj/item/paper/carbon/proc/remove_copy(var/mob/user)
-	var/obj/item/paper/original = Clone()
-	var/obj/item/paper/copy     = Clone()
+	//Make a new paper that copies our contents
+	var/obj/item/paper/original = new
+	original.PopulateClone(src)
+	original.updateinfolinks()
+	var/obj/item/paper/copy = original.Clone()
+
 	LAZYSET(copy.metadata, "is_copy", TRUE)
 	copy.set_color("#ffccff")
 
@@ -27,7 +31,7 @@
 	user.put_in_hands(copy)
 	return copy
 
-/obj/item/paint_sprayer/get_alt_interactions(mob/user)
+/obj/item/paper/carbon/get_alt_interactions(mob/user)
 	. = ..()
 	LAZYADD(., /decl/interaction_handler/carbon_paper_remove)
 

--- a/code/modules/paperwork/carbonpaper.dm
+++ b/code/modules/paperwork/carbonpaper.dm
@@ -26,7 +26,7 @@
 	var/copycontents = copy.info
 	copycontents = replacetext(copycontents, "<font face=\"[original.deffont]\" color=", "<font face=\"[original.deffont]\" nocolor=")
 	copycontents = replacetext(copycontents, "<font face=\"[original.crayonfont]\" color=", "<font face=\"[original.crayonfont]\" nocolor=")
-	copy.set_content("<font color = #101010>[copycontents]</font>", "Copy - [original.name]")
+	copy.set_content("<font color = #101010>[copycontents]</font>", (original.name != initial(original.name))? "Copy - [original.name]" : null)
 	original.update_icon()
 
 	qdel(src)
@@ -36,7 +36,9 @@
 
 ///Copy our contents to a regular sheet of paper
 /obj/item/paper/carbon/proc/copy_to(var/obj/item/paper/other)
-	other.SetName(name)
+	//Don't copy the default name of the carbon paper
+	if(name != initial(name))
+		other.SetName(name)
 	other.fields             = fields
 	other.last_modified_ckey = last_modified_ckey
 	other.free_space         = free_space

--- a/code/modules/paperwork/carbonpaper.dm
+++ b/code/modules/paperwork/carbonpaper.dm
@@ -17,6 +17,11 @@
 	LAZYSET(copy.metadata, "is_copy", TRUE)
 	copy.set_color("#ffccff")
 
+	//Make all stamps on the copy be grayscale
+	for(var/image/stamp in copy.applied_stamps)
+		stamp.filters += filter(type = "color", color = list(1,0,0, 0,0,0, 0,0,1), space = FILTER_COLOR_HSV)
+		stamp.appearance_flags |= RESET_COLOR
+
 	//Silly hack to make all the text grayscale, since nobody is using standard css classes for pens we could override instead. Also, all using deprecated tags as well.
 	var/copycontents = copy.info
 	copycontents = replacetext(copycontents, "<font face=\"[original.deffont]\" color=", "<font face=\"[original.deffont]\" nocolor=")

--- a/code/modules/paperwork/carbonpaper.dm
+++ b/code/modules/paperwork/carbonpaper.dm
@@ -12,11 +12,8 @@
 
 /obj/item/paper/carbon/proc/remove_copy(var/mob/user)
 	//Make a new paper that copies our contents
-	var/obj/item/paper/original = new (arglist(GetCloneArgs()))
-	original.PopulateClone(src)
-	original.updateinfolinks()
-	var/obj/item/paper/copy = original.Clone()
-
+	var/obj/item/paper/original = copy_to(new /obj/item/paper)
+	var/obj/item/paper/copy     = original.Clone()
 	LAZYSET(copy.metadata, "is_copy", TRUE)
 	copy.set_color("#ffccff")
 
@@ -25,11 +22,27 @@
 	copycontents = replacetext(copycontents, "<font face=\"[original.deffont]\" color=", "<font face=\"[original.deffont]\" nocolor=")
 	copycontents = replacetext(copycontents, "<font face=\"[original.crayonfont]\" color=", "<font face=\"[original.crayonfont]\" nocolor=")
 	copy.set_content("<font color = #101010>[copycontents]</font>", "Copy - [original.name]")
+	original.update_icon()
 
 	qdel(src)
 	user.put_in_active_hand(original)
 	user.put_in_hands(copy)
 	return copy
+
+///Copy our contents to a regular sheet of paper
+/obj/item/paper/carbon/proc/copy_to(var/obj/item/paper/other)
+	other.SetName(name)
+	other.fields             = fields
+	other.last_modified_ckey = last_modified_ckey
+	other.free_space         = free_space
+	other.rigged             = rigged
+	other.is_crumpled        = is_crumpled
+	other.info               = info
+	other.stamp_text         = stamp_text
+	other.applied_stamps     = LAZYLEN(applied_stamps)? listDeepClone(applied_stamps) : null
+	other.metadata           = LAZYLEN(metadata)?       listDeepClone(metadata, TRUE) : null
+	other.updateinfolinks()
+	return other
 
 /obj/item/paper/carbon/get_alt_interactions(mob/user)
 	. = ..()

--- a/code/modules/paperwork/carbonpaper.dm
+++ b/code/modules/paperwork/carbonpaper.dm
@@ -12,7 +12,7 @@
 
 /obj/item/paper/carbon/proc/remove_copy(var/mob/user)
 	//Make a new paper that copies our contents
-	var/obj/item/paper/original = new
+	var/obj/item/paper/original = new (arglist(GetCloneArgs()))
 	original.PopulateClone(src)
 	original.updateinfolinks()
 	var/obj/item/paper/copy = original.Clone()

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -56,7 +56,9 @@
 
 /obj/item/paper/PopulateClone(obj/item/paper/clone)
 	clone = ..()
+	clone.info               = info
 	clone.fields             = fields
+	clone.free_space         = free_space
 	clone.last_modified_ckey = last_modified_ckey
 	clone.rigged             = rigged
 	clone.is_crumpled        = is_crumpled

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -56,9 +56,7 @@
 
 /obj/item/paper/PopulateClone(obj/item/paper/clone)
 	clone = ..()
-	clone.info               = info
 	clone.fields             = fields
-	clone.free_space         = free_space
 	clone.last_modified_ckey = last_modified_ckey
 	clone.rigged             = rigged
 	clone.is_crumpled        = is_crumpled

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -313,7 +313,7 @@
 	var/obj/item/paper/P = pages[1]
 	icon       = P.icon
 	icon_state = P.icon_state
-	set_overlays(P.overlays)
+	copy_overlays(P.overlays)
 
 	var/paper_count = 0
 	var/photo_count = 0


### PR DESCRIPTION

<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
* The carbon paper would just create 2 copies of itself because it called Clone() on itself expecting to get a regular sheet of paper...
* Fixed path for the get_alt_interactions(mob/user) proc for carbon paper.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Thanks to @out-of-phaze for pointing that mistake I made.

## Changelog
:cl:
bugfix: fixed carbon paper creating a copy of itself when trying to split the original and copy.
bugfix: fixed the paint spray having an interaction to remove a carbon copy from it for reasons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->