### PR TITLE
Add Helping Hands

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -183,8 +183,8 @@
 			inv_box = sublist[2]
 			inv_box.screen_loc = "CENTER:[world.icon_size/2],BOTTOM:[hand_y_offset]"
 		hand_y_offset += world.icon_size
-		if(mymob.client)
-			mymob.client.screen |= inv_box
+	if(mymob.client)
+		mymob.client.screen |= hand_hud_objects
 
 	// Make sure all held items are on the screen and set to the correct screen loc.
 	var/datum/inventory_slot/inv_slot

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -138,13 +138,13 @@
 				break
 		if(!inv_box)
 			inv_box = new /obj/screen/inventory()
-		var/datum/inventory_slot/inv_slot = mymob.get_inventory_slot_datum(hand_tag)
+		var/datum/inventory_slot/gripper/inv_slot = mymob.get_inventory_slot_datum(hand_tag)
 		inv_box.SetName(hand_tag)
 		inv_box.icon = ui_style
 		inv_box.icon_state = "hand_base"
 
 		inv_box.cut_overlays()
-		inv_box.add_overlay("hand_[hand_tag]")
+		inv_box.add_overlay("hand_[(istype(inv_slot) && inv_slot.hand_overlay) || hand_tag]")
 		if(inv_slot.ui_label)
 			inv_box.add_overlay("hand_[inv_slot.ui_label]")
 		if(mymob.get_active_held_item_slot() == hand_tag)

--- a/code/datums/inventory_slots/inventory_gripper.dm
+++ b/code/datums/inventory_slots/inventory_gripper.dm
@@ -1,5 +1,7 @@
 /datum/inventory_slot/gripper
 	var/can_use_held_item = TRUE
+	/// If set, use this icon_state for the hand slot overlay; otherwise, use slot_id.
+	var/hand_overlay
 	// For reference, grippers do not use ui_loc, they have it set dynamically during /datum/hud/proc/rebuild_hands()
 
 /datum/inventory_slot/gripper/GetCloneArgs()

--- a/code/modules/augment/helping_hands.dm
+++ b/code/modules/augment/helping_hands.dm
@@ -1,0 +1,47 @@
+/obj/item/helpinghands
+	name = "back-mounted arms"
+	desc = "A pair of arms with an included harness worn on the back, controlled by a noninvasive spinal prosthesis."
+	icon = 'icons/mecha/mech_parts_held.dmi'
+	icon_state = "light_arms"
+	material = /decl/material/solid/metal/steel
+	slot_flags = SLOT_BACK
+	var/list/slot_types = list(
+		/datum/inventory_slot/gripper/left_hand/no_organ/helping,
+		/datum/inventory_slot/gripper/right_hand/no_organ/helping
+	)
+
+/obj/item/helpinghands/proc/add_hands(mob/user)
+	for (var/gripper_type in slot_types)
+		user.add_held_item_slot(new gripper_type)
+
+/obj/item/helpinghands/proc/remove_hands(mob/user)
+	for (var/datum/inventory_slot/gripper_type as anything in slot_types)
+		user.remove_held_item_slot(initial(gripper_type.slot_id))
+
+/obj/item/helpinghands/equipped(mob/user, slot)
+	. = ..()
+	if(!user)
+		return
+	switch(slot)
+		if(slot_back_str)
+			add_hands(user)
+		else
+			remove_hands(user)
+
+/obj/item/helpinghands/dropped(mob/user)
+	. = ..()
+	if(user)
+		remove_hands(user)
+
+/datum/inventory_slot/gripper/left_hand/no_organ
+	requires_organ_tag = null
+/datum/inventory_slot/gripper/right_hand/no_organ
+	requires_organ_tag = null
+
+/datum/inventory_slot/gripper/left_hand/no_organ/helping
+	slot_id = "helping_hand_l"
+	hand_overlay = BP_L_HAND
+
+/datum/inventory_slot/gripper/right_hand/no_organ/helping
+	slot_id = "helping_hand_r"
+	hand_overlay = BP_R_HAND

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1208,6 +1208,10 @@
 	if(getBrainLoss() && getBrainLoss() > config.dex_malus_brainloss_threshold) ///brainloss shouldn't instantly cripple you, so the effects only start once past the threshold and escalate from there.
 		dex_malus = round(clamp(round(getBrainLoss()-config.dex_malus_brainloss_threshold)/10, DEXTERITY_NONE, DEXTERITY_FULL))
 	if(!active_hand)
+		// todo: move dexterity onto inventory slot?
+		var/datum/inventory_slot/gripper/gripper = get_inventory_slot_datum(force_active_hand)
+		if(istype(gripper) && isnull(gripper.requires_organ_tag))
+			return species.get_manual_dexterity(src)
 		if(!silent)
 			to_chat(src, SPAN_WARNING("Your hand is missing!"))
 		return FALSE

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -172,7 +172,7 @@
 	for(var/hand_slot in get_held_item_slots())
 		var/datum/inventory_slot/inv_slot = get_inventory_slot_datum(hand_slot)
 		var/holding = inv_slot?.get_equipped_item()
-		if(holding)
+		if(holding && inv_slot.requires_organ_tag)
 			var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(src, hand_slot)
 			if((!E || !E.is_usable() || E.is_parent_dislocated()) && try_unequip(holding))
 				grasp_damage_disarm(E)

--- a/code/modules/mob/living/inventory.dm
+++ b/code/modules/mob/living/inventory.dm
@@ -30,7 +30,7 @@
 		qdel(existing_slot)
 	LAZYDISTINCTADD(_held_item_slots, held_slot.slot_id)
 	add_inventory_slot(held_slot)
-	if(!get_active_hand())
+	if(!get_active_held_item_slot())
 		select_held_item_slot(held_slot.slot_id)
 	queue_hand_rebuild()
 

--- a/code/modules/mob/living/inventory.dm
+++ b/code/modules/mob/living/inventory.dm
@@ -143,4 +143,4 @@
 		if(held)
 			drop_from_inventory(held)
 		qdel(inv_slot)
-	LAZYREMOVE(_inventory_slots, slot)
+	LAZYREMOVE(_inventory_slots, inv_slot.slot_id)

--- a/nebula.dme
+++ b/nebula.dme
@@ -1590,6 +1590,7 @@
 #include "code\modules\atmospherics\components\unary\vent_scrubber.dm"
 #include "code\modules\augment\active.dm"
 #include "code\modules\augment\augment.dm"
+#include "code\modules\augment\helping_hands.dm"
 #include "code\modules\augment\simple.dm"
 #include "code\modules\augment\active\armblades.dm"
 #include "code\modules\augment\active\circuit.dm"


### PR DESCRIPTION
## Description of changes
Adds Helping Hands from Caves of Qud, currently just called "back-mounted arms". The description and name are completely just placeholders. Mostly opening this for review and so that others can see how cool it is.

<details>
<summary> Screenshots </summary>

![image](https://github.com/NebulaSS13/Nebula/assets/110272328/b8a3c4f5-8b1f-458c-9355-d296c07a40dd)
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/40bdefb3-692b-4abe-9e3e-d39a981e7275)
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/598dca96-83d3-45a6-a404-5eb46d8fb7a4)
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/9f8d3d6c-0c2f-4d80-bc11-69a8339e0368)
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/1fe235e1-6b6f-4270-a3f9-4cc03e71b296)
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/692a57c5-938e-4555-bfa5-138445e8d1c6)
</details>

### TODO:
- [ ] Add worn sprite
- [ ] Maybe replace placeholder mech sprite with something original?

#### Optional:
- [ ] Figure out how to make held items display on the mob?
- [ ] Make it obtainable somehow?

## Why and what will this PR improve
Mostly a proof-of-concept for organless hand slots, and adding hand slots with items.

## Changelog
:cl:
add: Adds back-mounted arms, which provide an extra two hand slots but take up a back slot.
/:cl: