### PR TITLE
Removing some reliance on /datum/dna.

### DIFF
--- a/code/_global_vars/lists/objects.dm
+++ b/code/_global_vars/lists/objects.dm
@@ -4,7 +4,6 @@ var/global/list/jani_hud_users = list()
 var/global/list/hud_icon_reference = list()
 var/global/list/listening_objects = list() // List of objects that need to be able to hear, used to avoid recursive searching through contents.
 var/global/list/global_mutations = list() // List of hidden mutation things.
-var/global/list/reg_dna = list()
 var/global/list/global_map = list()
 
 var/global/host = null //only here until check @ code\modules\ghosttrap\trap.dm:112 is fixed

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -59,9 +59,9 @@ var/global/list/assigned_blocks[DNA_SE_LENGTH]
 /datum/dna
 	// READ-ONLY, GETS OVERWRITTEN
 	// DO NOT FUCK WITH THESE OR BYOND WILL EAT YOUR FACE
-	var/uni_identity="" // Encoded UI
-	var/struc_enzymes="" // Encoded SE
-	var/unique_enzymes="" // MD5 of player genetic marker value
+	var/uni_identity=""   // Encoded UI
+	var/struc_enzymes=""  // Encoded SE
+	var/unique_enzymes="" // MD5 of mob genetic marker value
 
 	var/fingerprint
 

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -151,7 +151,7 @@ var/global/list/assigned_blocks[DNA_SE_LENGTH]
 		if(LAZYLEN(E.markings))
 			body_markings[E.organ_tag] = E.markings.Copy()
 
-	b_type = character.b_type
+	b_type = character.blood_type
 
 	UpdateUI()
 

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -61,7 +61,7 @@ var/global/list/assigned_blocks[DNA_SE_LENGTH]
 	// DO NOT FUCK WITH THESE OR BYOND WILL EAT YOUR FACE
 	var/uni_identity="" // Encoded UI
 	var/struc_enzymes="" // Encoded SE
-	var/unique_enzymes="" // MD5 of player name
+	var/unique_enzymes="" // MD5 of player genetic marker value
 
 	var/fingerprint
 
@@ -141,7 +141,8 @@ var/global/list/assigned_blocks[DNA_SE_LENGTH]
 
 	SetUIState(DNA_UI_GENDER, character.gender!=MALE, 1)
 
-	fingerprint = md5(character.unique_mob_number)
+	fingerprint    = character.get_full_print(ignore_blockers = TRUE)
+	unique_enzymes = character.get_unique_enzymes()
 
 	// Hair
 	var/list/hair_types = decls_repository.get_decl_paths_of_subtype(/decl/sprite_accessory/hair)
@@ -156,7 +157,7 @@ var/global/list/assigned_blocks[DNA_SE_LENGTH]
 		if(LAZYLEN(E.markings))
 			body_markings[E.organ_tag] = E.markings.Copy()
 
-	b_type = character.blood_type
+	b_type = character.get_blood_type()
 
 	UpdateUI()
 
@@ -356,7 +357,7 @@ var/global/list/assigned_blocks[DNA_SE_LENGTH]
 			ResetSE()
 
 		if(length(unique_enzymes) != 32)
-			unique_enzymes = md5(character.real_name)
+			unique_enzymes = md5(num2text(character.original_genetic_seed))
 	else
 		if(!species)
 			species = global.using_map.default_species
@@ -370,5 +371,4 @@ var/global/list/assigned_blocks[DNA_SE_LENGTH]
 /datum/dna/proc/ready_dna(mob/living/carbon/human/character)
 	ResetUIFrom(character)
 	ResetSE()
-	unique_enzymes = md5(character.real_name)
-	global.reg_dna[unique_enzymes] = character.real_name
+	unique_enzymes = character.get_unique_enzymes()

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -63,6 +63,8 @@ var/global/list/assigned_blocks[DNA_SE_LENGTH]
 	var/struc_enzymes="" // Encoded SE
 	var/unique_enzymes="" // MD5 of player name
 
+	var/fingerprint
+
 	// Internal dirtiness checks
 	var/dirtyUI=0
 	var/dirtySE=0
@@ -87,6 +89,7 @@ var/global/list/assigned_blocks[DNA_SE_LENGTH]
 	clone = ..()
 	clone.lineage        = lineage
 	clone.unique_enzymes = unique_enzymes
+	clone.fingerprint    = fingerprint
 	clone.b_type         = b_type
 	clone.real_name      = real_name
 	clone.species        = species || global.using_map.default_species
@@ -137,6 +140,8 @@ var/global/list/assigned_blocks[DNA_SE_LENGTH]
 	SetUIValueRange(DNA_UI_SKIN_TONE, 35-character.skin_tone, 220,           1) // Value can be negative.
 
 	SetUIState(DNA_UI_GENDER, character.gender!=MALE, 1)
+
+	fingerprint = md5(character.unique_mob_number)
 
 	// Hair
 	var/list/hair_types = decls_repository.get_decl_paths_of_subtype(/decl/sprite_accessory/hair)
@@ -320,7 +325,6 @@ var/global/list/assigned_blocks[DNA_SE_LENGTH]
 			newBlock+=copytext(oldBlock,i,i+1)
 	//testing("SetSESubBlock([block],[subBlock],[newSubBlock],[defer]): [oldBlock] -> [newBlock]")
 	SetSEBlock(block,newBlock,defer)
-
 
 /proc/EncodeDNABlock(var/value)
 	return add_zero2(num2hex(value,1), 3)

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -150,7 +150,6 @@
 	skin_colour        = rgb(dna.GetUIValueRange(DNA_UI_SKIN_R,255),  dna.GetUIValueRange(DNA_UI_SKIN_G,255),  dna.GetUIValueRange(DNA_UI_SKIN_B,255))
 	eye_colour         = rgb(dna.GetUIValueRange(DNA_UI_EYES_R,255),  dna.GetUIValueRange(DNA_UI_EYES_G,255),  dna.GetUIValueRange(DNA_UI_EYES_B,255))
 	skin_tone          = 35 - dna.GetUIValueRange(DNA_UI_SKIN_TONE, 220) // Value can be negative.
-	update_eyes()
 
 	// TODO: update DNA gender to not be a bool - use bodytype and pronouns
 	//Body markings
@@ -180,9 +179,8 @@
 		f_style = beard_subtypes[beard]
 
 	force_update_limbs()
-	update_body()
+	update_hair(update_icons = FALSE)
 	update_eyes()
-	update_hair()
 	return TRUE
 
 // Used below, simple injection modifier.

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -133,61 +133,55 @@
 
 // Simpler. Don't specify UI in order for the mob to use its own.
 /mob/proc/UpdateAppearance(var/list/UI=null)
-	if(istype(src, /mob/living/carbon/human) && dna)
-		if(UI!=null)
-			src.dna.UI=UI
-			src.dna.UpdateUI()
-		dna.check_integrity()
-		var/mob/living/carbon/human/H = src
-		H.hair_colour =        rgb(dna.GetUIValueRange(DNA_UI_HAIR_R,255),  dna.GetUIValueRange(DNA_UI_HAIR_G,255),  dna.GetUIValueRange(DNA_UI_HAIR_B,255))
-		H.facial_hair_colour = rgb(dna.GetUIValueRange(DNA_UI_BEARD_R,255), dna.GetUIValueRange(DNA_UI_BEARD_G,255), dna.GetUIValueRange(DNA_UI_BEARD_B,255))
-		H.skin_colour =        rgb(dna.GetUIValueRange(DNA_UI_SKIN_R,255),  dna.GetUIValueRange(DNA_UI_SKIN_G,255),  dna.GetUIValueRange(DNA_UI_SKIN_B,255))
-		H.eye_colour =         rgb(dna.GetUIValueRange(DNA_UI_EYES_R,255),  dna.GetUIValueRange(DNA_UI_EYES_G,255),  dna.GetUIValueRange(DNA_UI_EYES_B,255))
-		H.skin_tone   = 35 - dna.GetUIValueRange(DNA_UI_SKIN_TONE, 220) // Value can be negative.
+	return FALSE
 
-		// TODO: update DNA gender to not be a bool - use bodytype and pronouns
-		/*
-		if(H.gender != NEUTER)
-			if (dna.GetUIState(DNA_UI_GENDER))
-				H.set_gender(FEMALE)
+/mob/living/carbon/human/UpdateAppearance(var/list/UI=null)
+
+	if(UI!=null)
+		src.dna.UI=UI
+		src.dna.UpdateUI()
+
+	dna.check_integrity()
+	fingerprint        = dna.fingerprint
+	hair_colour        = rgb(dna.GetUIValueRange(DNA_UI_HAIR_R,255),  dna.GetUIValueRange(DNA_UI_HAIR_G,255),  dna.GetUIValueRange(DNA_UI_HAIR_B,255))
+	facial_hair_colour = rgb(dna.GetUIValueRange(DNA_UI_BEARD_R,255), dna.GetUIValueRange(DNA_UI_BEARD_G,255), dna.GetUIValueRange(DNA_UI_BEARD_B,255))
+	skin_colour        = rgb(dna.GetUIValueRange(DNA_UI_SKIN_R,255),  dna.GetUIValueRange(DNA_UI_SKIN_G,255),  dna.GetUIValueRange(DNA_UI_SKIN_B,255))
+	eye_colour         = rgb(dna.GetUIValueRange(DNA_UI_EYES_R,255),  dna.GetUIValueRange(DNA_UI_EYES_G,255),  dna.GetUIValueRange(DNA_UI_EYES_B,255))
+	skin_tone          = 35 - dna.GetUIValueRange(DNA_UI_SKIN_TONE, 220) // Value can be negative.
+	update_eyes()
+
+	// TODO: update DNA gender to not be a bool - use bodytype and pronouns
+	//Body markings
+	for(var/tag in dna.body_markings)
+		var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(src, tag)
+		if(E)
+			var/list/marklist = dna.body_markings[tag]
+			if(length(marklist))
+				E.markings = marklist.Copy()
 			else
-				H.set_gender(MALE)
-		*/
+				LAZYCLEARLIST(E.markings)
 
-		//Body markings
-		for(var/tag in dna.body_markings)
-			var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(H, tag)
-			if(E)
-				var/list/marklist = dna.body_markings[tag]
-				if(length(marklist))
-					E.markings = marklist.Copy()
-				else
-					LAZYCLEARLIST(E.markings)
+	//Base skin and blend
+	for(var/obj/item/organ/organ in get_organs())
+		organ.set_dna(dna)
 
-		//Base skin and blend
-		for(var/obj/item/organ/organ in H.get_organs())
-			organ.set_dna(H.dna)
+	//Hair
+	var/list/hair_subtypes = decls_repository.get_decl_paths_of_subtype(/decl/sprite_accessory/hair)
+	var/hair = dna.GetUIValueRange(DNA_UI_HAIR_STYLE, length(hair_subtypes))
+	if(hair > 0 && hair <= length(hair_subtypes))
+		h_style = hair_subtypes[hair]
 
-		//Hair
-		var/list/hair_subtypes = decls_repository.get_decl_paths_of_subtype(/decl/sprite_accessory/hair)
-		var/hair = dna.GetUIValueRange(DNA_UI_HAIR_STYLE, length(hair_subtypes))
-		if(hair > 0 && hair <= length(hair_subtypes))
-			H.h_style = hair_subtypes[hair]
+	//Facial Hair
+	var/list/beard_subtypes = decls_repository.get_decl_paths_of_subtype(/decl/sprite_accessory/facial_hair)
+	var/beard = dna.GetUIValueRange(DNA_UI_BEARD_STYLE, length(beard_subtypes))
+	if((0 < beard) && (beard <= length(beard_subtypes)))
+		f_style = beard_subtypes[beard]
 
-		//Facial Hair
-		var/list/beard_subtypes = decls_repository.get_decl_paths_of_subtype(/decl/sprite_accessory/facial_hair)
-		var/beard = dna.GetUIValueRange(DNA_UI_BEARD_STYLE, length(beard_subtypes))
-		if((0 < beard) && (beard <= length(beard_subtypes)))
-			H.f_style = beard_subtypes[beard]
-
-		H.force_update_limbs()
-		H.update_body()
-		H.update_eyes()
-		H.update_hair()
-
-		return 1
-	else
-		return 0
+	force_update_limbs()
+	update_body()
+	update_eyes()
+	update_hair()
+	return TRUE
 
 // Used below, simple injection modifier.
 /proc/probinj(var/pr, var/inj)

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -142,7 +142,9 @@
 		src.dna.UpdateUI()
 
 	dna.check_integrity()
+
 	fingerprint        = dna.fingerprint
+	unique_enzymes     = dna.unique_enzymes
 	hair_colour        = rgb(dna.GetUIValueRange(DNA_UI_HAIR_R,255),  dna.GetUIValueRange(DNA_UI_HAIR_G,255),  dna.GetUIValueRange(DNA_UI_HAIR_B,255))
 	facial_hair_colour = rgb(dna.GetUIValueRange(DNA_UI_BEARD_R,255), dna.GetUIValueRange(DNA_UI_BEARD_G,255), dna.GetUIValueRange(DNA_UI_BEARD_B,255))
 	skin_colour        = rgb(dna.GetUIValueRange(DNA_UI_SKIN_R,255),  dna.GetUIValueRange(DNA_UI_SKIN_G,255),  dna.GetUIValueRange(DNA_UI_SKIN_B,255))

--- a/code/game/machinery/doors/_door.dm
+++ b/code/game/machinery/doors/_door.dm
@@ -521,8 +521,8 @@
 			success = 1
 		else
 			for(var/obj/O in T)
-				for(var/b_type in blend_objects)
-					if( istype(O, b_type))
+				for(var/blend_type in blend_objects)
+					if( istype(O, blend_type))
 						success = 1
 
 					if(success)

--- a/code/game/machinery/doors/double.dm
+++ b/code/game/machinery/doors/double.dm
@@ -42,8 +42,8 @@
 			success = 1
 		else
 			for(var/obj/O in T)
-				for(var/b_type in blend_objects)
-					if( istype(O, b_type))
+				for(var/blend_type in blend_objects)
+					if( istype(O, blend_type))
 						success = 1
 
 					if(success)

--- a/code/game/objects/effects/gibs.dm
+++ b/code/game/objects/effects/gibs.dm
@@ -1,5 +1,5 @@
-/proc/gibs(atom/location, var/datum/dna/MobDNA, gibber_type = /obj/effect/gibspawner/generic, var/fleshcolor, var/bloodcolor)
-	new gibber_type(location,MobDNA,fleshcolor,bloodcolor)
+/proc/gibs(var/atom/location, var/gibber_type = /obj/effect/gibspawner/generic, var/_blood_type, var/_unique_enzymes, var/_fleshcolor, var/_bloodcolor)
+	new gibber_type(location, _blood_type, _unique_enzymes, _fleshcolor, _bloodcolor)
 
 /obj/effect/gibspawner
 	var/sparks = 0 //whether sparks spread on Gib()
@@ -8,14 +8,19 @@
 	var/list/gibdirections = list() //of lists
 	var/fleshcolor //Used for gibbed humans.
 	var/bloodcolor //Used for gibbed humans.
-	var/datum/dna/MobDNA
+	var/blood_type
+	var/unique_enzymes
 
-/obj/effect/gibspawner/Initialize(mapload, var/datum/dna/MobDNA, var/fleshcolor, var/bloodcolor)
+/obj/effect/gibspawner/Initialize(mapload, var/_blood_type, var/_unique_enzymes, var/_fleshcolor, var/_bloodcolor)
 	..(mapload)
-
-	if(fleshcolor) src.fleshcolor = fleshcolor
-	if(bloodcolor) src.bloodcolor = bloodcolor
-	if(MobDNA)     src.MobDNA = MobDNA
+	if(_fleshcolor)
+		fleshcolor = _fleshcolor
+	if(_bloodcolor)
+		bloodcolor = _bloodcolor
+	if(_blood_type)
+		blood_type = _blood_type
+	if(_unique_enzymes)
+		unique_enzymes = _unique_enzymes
 	Gib(loc)
 	return INITIALIZE_HINT_QDEL
 
@@ -42,11 +47,10 @@
 
 				gib.update_icon()
 
-				gib.blood_DNA = list()
-				if(MobDNA)
-					gib.blood_DNA[MobDNA.unique_enzymes] = MobDNA.b_type
+				if(unique_enzymes && blood_type)
+					LAZYSET(gib.blood_DNA, unique_enzymes, blood_type)
 				else if(istype(src, /obj/effect/gibspawner/human)) // Probably a monkey
-					gib.blood_DNA["Non-human DNA"] = "A+"
+					LAZYSET(gib.blood_DNA, "Non-human DNA", "A+")
 				if(istype(location,/turf/))
 					var/list/directions = gibdirections[i]
 					if(directions.len)

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -593,8 +593,10 @@
 		forensics.add_data(/datum/forensics/blood_dna, sample_dna)
 	add_coating(/decl/material/liquid/blood, amount, blood_data)
 
-	if(!LAZYACCESS(blood_DNA, M.dna.unique_enzymes))
-		LAZYSET(blood_DNA, M.dna.unique_enzymes, M.dna.b_type)
+	var/unique_enzymes = M.get_unique_enzymes()
+	var/blood_type = M.get_blood_type()
+	if(unique_enzymes && blood_type && !LAZYACCESS(blood_DNA, unique_enzymes))
+		LAZYSET(blood_DNA, unique_enzymes, blood_type)
 
 	return TRUE
 

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -246,14 +246,14 @@ var/global/list/pai_cards = list()
 	if(href_list["setdna"])
 		if(pai.master_dna)
 			return
-		var/mob/M = usr
-		if(!istype(M, /mob/living/carbon))
-			to_chat(usr, "<span class='notice'>You don't have any DNA, or your DNA is incompatible with this device.</span>")
+		var/unique_enzymes = usr.get_unique_enzymes()
+		if(unique_enzymes)
+			pai.master     = usr.real_name
+			pai.master_dna = unique_enzymes
+			to_chat(pai, SPAN_NOTICE("You have been bound to a new master."))
 		else
-			var/datum/dna/dna = usr.dna
-			pai.master = M.real_name
-			pai.master_dna = dna.unique_enzymes
-			to_chat(pai, "<span class='warning'>You have been bound to a new master.</span>")
+			to_chat(usr, SPAN_WARNING("You don't have any DNA, or your DNA is incompatible with this device."))
+
 	if(href_list["request"])
 		src.looking_for_personality = 1
 		paiController.findPAI(src, usr)

--- a/code/game/objects/items/devices/pinpointer.dm
+++ b/code/game/objects/items/devices/pinpointer.dm
@@ -217,9 +217,7 @@
 			var/DNAstring = input("Input DNA string to search for." , "Please Enter String." , "")
 			if(!DNAstring)
 				return
-			for(var/mob/living/carbon/M in SSmobs.mob_list)
-				if(!M.dna)
-					continue
-				if(M.dna.unique_enzymes == DNAstring)
+			for(var/mob/living/M in SSmobs.mob_list)
+				if(M.get_unique_enzymes() == DNAstring)
 					target = weakref(M)
 					break

--- a/code/game/objects/items/dog_tags.dm
+++ b/code/game/objects/items/dog_tags.dm
@@ -31,4 +31,4 @@
 
 	badge_string = pob
 
-	desc = "[initial(desc)]\nName: [H.real_name] ([H.get_species_name()])[H.char_branch ? "\nBranch: [H.char_branch.name]" : ""]\nReligion: [religion]\nBlood type: [H.b_type]"
+	desc = "[initial(desc)]\nName: [H.real_name] ([H.get_species_name()])[H.char_branch ? "\nBranch: [H.char_branch.name]" : ""]\nReligion: [religion]\nBlood type: [H.get_blood_type()]"

--- a/code/game/objects/items/passport.dm
+++ b/code/game/objects/items/passport.dm
@@ -19,10 +19,7 @@
 	var/decl/cultural_info/culture = H.get_cultural_value(TAG_HOMEWORLD)
 	var/pob = culture ? culture.name : "Unset"
 
-	var/fingerprint = "N/A"
-	if(H.dna)
-		fingerprint = md5(H.dna.uni_identity)
-
+	var/fingerprint = H.get_full_print(ignore_blockers = TRUE) || "N/A"
 	var/decl/pronouns/G = H.get_pronouns(ignore_coverings = TRUE)
 	info = "\icon[src] [src]:\nName: [H.real_name]\nSpecies: [H.get_species_name()]\nGender: [capitalize(G.name)]\nAge: [H.get_age()]\nPlace of Birth: [pob]\nFingerprint: [fingerprint]"
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -259,10 +259,9 @@ var/global/const/NO_EMAG_ACT = -50
 		id_card.card_gender = "Unset"
 	id_card.set_id_photo(src)
 
-	id_card.blood_type		= get_blood_type()     || "Unset"
-	id_card.dna_hash		= get_unique_enzymes() || "Unset"
-	if(dna)
-		id_card.fingerprint_hash= md5(dna.uni_identity)
+	id_card.blood_type       = get_blood_type()                       || "Unset"
+	id_card.dna_hash         = get_unique_enzymes()                   || "Unset"
+	id_card.fingerprint_hash = get_full_print(ignore_blockers = TRUE) || "Unset"
 
 /mob/living/carbon/human/set_id_info(var/obj/item/card/id/id_card)
 	..()

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -259,9 +259,9 @@ var/global/const/NO_EMAG_ACT = -50
 		id_card.card_gender = "Unset"
 	id_card.set_id_photo(src)
 
+	id_card.blood_type		= get_blood_type()     || "Unset"
+	id_card.dna_hash		= get_unique_enzymes() || "Unset"
 	if(dna)
-		id_card.blood_type		= dna.b_type
-		id_card.dna_hash		= dna.unique_enzymes
 		id_card.fingerprint_hash= md5(dna.uni_identity)
 
 /mob/living/carbon/human/set_id_info(var/obj/item/card/id/id_card)

--- a/code/game/objects/items/weapons/cards_ids_syndicate.dm
+++ b/code/game/objects/items/weapons/cards_ids_syndicate.dm
@@ -170,8 +170,7 @@
 				var/default = fingerprint_hash
 				if(default == initial(fingerprint_hash) && ishuman(user))
 					var/mob/living/carbon/human/H = user
-					if(H.dna)
-						default = md5(H.dna.uni_identity)
+					default = H.get_full_print(ignore_blockers = TRUE)
 				var/new_fingerprint_hash = sanitize(input(user,"What fingerprint hash would you like to be written on this card?","Agent Card Fingerprint Hash",default) as null|text)
 				if(!isnull(new_fingerprint_hash) && CanUseTopic(user, state))
 					src.fingerprint_hash = new_fingerprint_hash

--- a/code/game/objects/items/weapons/cards_ids_syndicate.dm
+++ b/code/game/objects/items/weapons/cards_ids_syndicate.dm
@@ -158,8 +158,9 @@
 				var/default = dna_hash
 				if(default == initial(dna_hash) && ishuman(user))
 					var/mob/living/carbon/human/H = user
-					if(H.dna)
-						default = H.dna.unique_enzymes
+					var/unique_enzymes = H.get_unique_enzymes()
+					if(unique_enzymes)
+						default = unique_enzymes
 				var/new_dna_hash = sanitize(input(user,"What DNA hash would you like to be written on this card?","Agent Card DNA Hash",default) as null|text)
 				if(!isnull(new_dna_hash) && CanUseTopic(user, state))
 					src.dna_hash = new_dna_hash

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -147,11 +147,13 @@
 
 	if(istype(M))
 		for(var/obj/effect/decal/cleanable/blood/B in contents)
-			if(M.dna?.unique_enzymes && !LAZYACCESS(B.blood_DNA, M.dna.unique_enzymes))
-				LAZYSET(B.blood_DNA, M.dna.unique_enzymes, M.dna.b_type)
-				LAZYSET(B.blood_data, M.dna.unique_enzymes, REAGENT_DATA(M.vessel, M.species.blood_reagent))
+			var/unique_enzymes = M.get_unique_enzymes()
+			var/blood_type     = M.get_blood_type()
+			if(unique_enzymes && blood_type && !LAZYACCESS(B.blood_DNA, unique_enzymes))
+				LAZYSET(B.blood_DNA, unique_enzymes, blood_type)
+				LAZYSET(B.blood_data, unique_enzymes, REAGENT_DATA(M.vessel, M.species.blood_reagent))
 				var/datum/extension/forensic_evidence/forensics = get_or_create_extension(B, /datum/extension/forensic_evidence)
-				forensics.add_data(/datum/forensics/blood_dna, M.dna.unique_enzymes)
+				forensics.add_data(/datum/forensics/blood_dna, unique_enzymes)
 			return 1 //we bloodied the floor
 		blood_splatter(src, M, 1)
 		return 1 //we bloodied the floor

--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -101,8 +101,8 @@
 			if(handle_structure_blending)
 				var/success = 0
 				for(var/O in T)
-					for(var/b_type in global.wall_blend_objects)
-						if(istype(O, b_type))
+					for(var/blend_type in global.wall_blend_objects)
+						if(istype(O, blend_type))
 							success = TRUE
 							break
 					for(var/nb_type in global.wall_noblend_objects)

--- a/code/modules/admin/secrets/admin_secrets/list_dna.dm
+++ b/code/modules/admin/secrets/admin_secrets/list_dna.dm
@@ -9,6 +9,6 @@
 	dat += "<table cellspacing=5><tr><th>Name</th><th>DNA</th><th>Blood Type</th></tr>"
 	for(var/mob/living/carbon/human/H in SSmobs.mob_list)
 		if(H.dna && H.ckey)
-			dat += "<tr><td>[H]</td><td>[H.dna.unique_enzymes]</td><td>[H.b_type]</td></tr>"
+			dat += "<tr><td>[H]</td><td>[H.get_unique_enzymes() || "NULL"]</td><td>[H.get_blood_type() || "NULL"]</td></tr>"
 	dat += "</table>"
 	show_browser(user, dat, "window=DNA;size=440x410")

--- a/code/modules/admin/secrets/admin_secrets/list_fingerprints.dm
+++ b/code/modules/admin/secrets/admin_secrets/list_fingerprints.dm
@@ -9,11 +9,6 @@
 	dat += "<table cellspacing=5><tr><th>Name</th><th>Fingerprints</th></tr>"
 	for(var/mob/living/carbon/human/H in SSmobs.mob_list)
 		if(H.ckey)
-			if(H.dna && H.dna.uni_identity)
-				dat += "<tr><td>[H]</td><td>[md5(H.dna.uni_identity)]</td></tr>"
-			else if(H.dna && !H.dna.uni_identity)
-				dat += "<tr><td>[H]</td><td>H.dna.uni_identity = null</td></tr>"
-			else if(!H.dna)
-				dat += "<tr><td>[H]</td><td>H.dna = null</td></tr>"
+			dat += "<tr><td>[H]</td><td>[H.get_full_print(ignore_blockers = TRUE) || "null"]</td></tr>"
 	dat += "</table>"
 	show_browser(user, dat, "window=fingerprints;size=440x410")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -450,7 +450,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		new_character.real_name = record_found.get_name()
 		new_character.set_gender(record_found.get_gender())
 		new_character.set_age(record_found.get_age())
-		new_character.b_type = record_found.get_bloodtype()
+		new_character.blood_type = record_found.get_bloodtype()
 	else
 		new_character.set_gender(pick(MALE,FEMALE))
 		var/datum/preferences/A = new()

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -475,7 +475,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	//DNA
 	new_character.dna.ready_dna(new_character)
 	if(record_found)//Pull up their name from database records if they did have a mind.
-		new_character.dna.unique_enzymes = record_found.get_dna()//Enzymes are based on real name but we'll use the record for conformity.
+		new_character.dna.unique_enzymes = record_found.get_dna()
 	new_character.key = G_found.key
 
 	/*

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -27,7 +27,7 @@
 	pref.skin_colour =            R.read("skin_colour")
 	pref.eye_colour =             R.read("eye_colour")
 	pref.skin_tone =              R.read("skin_tone")
-	pref.blood_type =                 R.read("b_type")
+	pref.blood_type =             R.read("b_type")
 	pref.appearance_descriptors = R.read("appearance_descriptors")
 	pref.bgstate =                R.read("bgstate")
 

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -1,6 +1,6 @@
 /datum/preferences
 	var/species
-	var/b_type                           //blood type
+	var/blood_type                           //blood type
 
 	var/h_style = /decl/sprite_accessory/hair/bald
 	var/f_style = /decl/sprite_accessory/facial_hair/shaved
@@ -27,7 +27,7 @@
 	pref.skin_colour =            R.read("skin_colour")
 	pref.eye_colour =             R.read("eye_colour")
 	pref.skin_tone =              R.read("skin_tone")
-	pref.b_type =                 R.read("b_type")
+	pref.blood_type =                 R.read("b_type")
 	pref.appearance_descriptors = R.read("appearance_descriptors")
 	pref.bgstate =                R.read("bgstate")
 
@@ -67,7 +67,7 @@
 	W.write("facial_hair_colour",     pref.facial_hair_colour)
 	W.write("skin_colour",            pref.skin_colour)
 	W.write("eye_colour",             pref.eye_colour)
-	W.write("b_type",                 pref.b_type)
+	W.write("b_type",                 pref.blood_type)
 	W.write("appearance_descriptors", pref.appearance_descriptors)
 	W.write("bgstate",                pref.bgstate)
 
@@ -89,14 +89,14 @@
 	pref.facial_hair_colour = pref.facial_hair_colour || COLOR_BLACK
 	pref.eye_colour  =        pref.eye_colour         || COLOR_BLACK
 
-	pref.b_type = sanitize_text(pref.b_type, initial(pref.b_type))
+	pref.blood_type = sanitize_text(pref.blood_type, initial(pref.blood_type))
 
 	if(!pref.species || !(pref.species in get_playable_species()))
 		pref.species = global.using_map.default_species
 
 	var/decl/species/mob_species = get_species_by_key(pref.species)
-	if(!pref.b_type || !(pref.b_type in mob_species.blood_types))
-		pref.b_type = pickweight(mob_species.blood_types)
+	if(!pref.blood_type || !(pref.blood_type in mob_species.blood_types))
+		pref.blood_type = pickweight(mob_species.blood_types)
 
 	var/decl/bodytype/mob_bodytype = mob_species.get_bodytype_by_name(pref.bodytype) || mob_species.default_bodytype
 	var/low_skin_tone = mob_bodytype ? (35 - mob_bodytype.max_skin_tone()) : -185
@@ -135,7 +135,7 @@
 
 	var/decl/species/mob_species = get_species_by_key(pref.species)
 	var/decl/bodytype/mob_bodytype = mob_species.get_bodytype_by_name(pref.bodytype) || mob_species.default_bodytype
-	. += "Blood Type: <a href='?src=\ref[src];blood_type=1'>[pref.b_type]</a><br>"
+	. += "Blood Type: <a href='?src=\ref[src];blood_type=1'>[pref.blood_type]</a><br>"
 	. += "<a href='?src=\ref[src];random=1'>Randomize Appearance</A><br>"
 
 	if(mob_bodytype.appearance_flags & HAS_A_SKIN_TONE)
@@ -232,7 +232,7 @@
 		if(new_b_type && CanUseTopic(user))
 			mob_species = get_species_by_key(pref.species)
 			if(new_b_type in mob_species.blood_types)
-				pref.b_type = new_b_type
+				pref.blood_type = new_b_type
 				return TOPIC_REFRESH
 
 	else if(href_list["hair_color"])

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -414,7 +414,7 @@ var/global/list/time_prefs_fixed = list()
 		character.appearance_descriptors = appearance_descriptors.Copy()
 
 	character.dna.ready_dna(character)
-	character.dna.b_type = client.prefs.b_type
+	character.dna.b_type = client.prefs.blood_type
 	character.force_update_limbs()
 	character.update_mutations(0)
 	character.update_body(0)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -87,7 +87,7 @@ var/global/list/time_prefs_fixed = list()
 	real_name = get_random_name()
 
 	var/decl/species/species = get_species_by_key(global.using_map.default_species)
-	b_type = pickweight(species.blood_types)
+	blood_type = pickweight(species.blood_types)
 
 	if(client)
 		if(IsGuestKey(client.key))
@@ -365,7 +365,7 @@ var/global/list/time_prefs_fixed = list()
 	character.fully_replace_character_name(real_name)
 
 	character.set_gender(gender)
-	character.b_type = b_type
+	character.blood_type = blood_type
 
 	character.eye_colour = eye_colour
 

--- a/code/modules/detectivework/evidence/fingerprints.dm
+++ b/code/modules/detectivework/evidence/fingerprints.dm
@@ -82,18 +82,19 @@
 	return TRUE
 
 // Mob fingerprint getters
-/mob/proc/get_full_print()
+/mob/proc/get_full_print(var/ignore_blockers = FALSE)
 	return FALSE
 
-/mob/living/carbon/get_full_print()
-	if (!dna || (mFingerprints in mutations))
+/mob/living/carbon/get_full_print(var/ignore_blockers = FALSE)
+	if (!dna || (!ignore_blockers && (mFingerprints in mutations)))
 		return FALSE
 	return md5(dna.uni_identity)
 
-/mob/living/carbon/human/get_full_print()
-	if(!..())
+/mob/living/carbon/human/get_full_print(var/ignore_blockers = FALSE)
+	. = ..()
+	if(!.)
 		return FALSE
-
-	var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(src, get_active_held_item_slot())
-	if(E)
-		return E.get_fingerprint()
+	if(!ignore_blockers)
+		var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(src, get_active_held_item_slot())
+		if(E)
+			return E.get_fingerprint()

--- a/code/modules/detectivework/evidence/fingerprints.dm
+++ b/code/modules/detectivework/evidence/fingerprints.dm
@@ -90,7 +90,7 @@
 		var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(src, get_active_held_item_slot())
 		if(E)
 			return E.get_fingerprint()
-	return md5(unique_mob_number)
+	return fingerprint
 
 /mob/living/carbon/get_full_print(var/ignore_blockers = FALSE)
 	if (!ignore_blockers && (mFingerprints in mutations))

--- a/code/modules/detectivework/evidence/fingerprints.dm
+++ b/code/modules/detectivework/evidence/fingerprints.dm
@@ -82,19 +82,17 @@
 	return TRUE
 
 // Mob fingerprint getters
-/mob/proc/get_full_print(var/ignore_blockers = FALSE)
-	return FALSE
+/mob/proc/get_full_print(ignore_blockers)
+	return null
 
-/mob/living/carbon/get_full_print(var/ignore_blockers = FALSE)
-	if (!dna || (!ignore_blockers && (mFingerprints in mutations)))
-		return FALSE
-	return md5(dna.uni_identity)
-
-/mob/living/carbon/human/get_full_print(var/ignore_blockers = FALSE)
-	. = ..()
-	if(!.)
-		return FALSE
+/mob/living/get_full_print(var/ignore_blockers = FALSE)
 	if(!ignore_blockers)
 		var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(src, get_active_held_item_slot())
 		if(E)
 			return E.get_fingerprint()
+	return md5(unique_mob_number)
+
+/mob/living/carbon/get_full_print(var/ignore_blockers = FALSE)
+	if (!ignore_blockers && (mFingerprints in mutations))
+		return null
+	return ..()

--- a/code/modules/detectivework/evidence/trace_dna.dm
+++ b/code/modules/detectivework/evidence/trace_dna.dm
@@ -7,5 +7,6 @@
 		return
 	if(M.isSynthetic())
 		return
-	if(istype(M.dna))
-		add_data(M.dna.unique_enzymes)
+	var/unique_enzymes = M.get_unique_enzymes()
+	if(unique_enzymes)
+		add_data(unique_enzymes)

--- a/code/modules/detectivework/tools/sample_kits/swabs.dm
+++ b/code/modules/detectivework/tools/sample_kits/swabs.dm
@@ -32,7 +32,8 @@
 			to_chat(user, SPAN_WARNING("\The [H]'s [cover] is in the way."))
 			return
 
-		if(!H.dna || !H.dna.unique_enzymes)
+		var/unique_enzymes = H.get_unique_enzymes()
+		if(!unique_enzymes)
 			to_chat(user, SPAN_WARNING("They don't seem to have DNA!"))
 			return
 
@@ -42,7 +43,7 @@
 
 		user.visible_message(SPAN_NOTICE("[user] swabs \the [H]'s mouth for a saliva sample."))
 		var/datum/forensics/trace_dna/trace = new()
-		trace.data = list(H.dna.unique_enzymes)
+		trace.data = list(unique_enzymes)
 		var/obj/item/forensics/sample/swab/S = new(get_turf(user))
 		S.merge_evidence_list(list(trace))
 		S.update_icon()

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -16,7 +16,7 @@
 
 	flick(anim, animation)
 	if(do_gibs)
-		gibs(loc, dna)
+		gibs(loc, _blood_type = dna.b_type, _unique_enzymes = get_unique_enzymes())
 
 	QDEL_IN(animation, 15)
 	QDEL_IN(src, 15)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -17,7 +17,7 @@
 	var/last_loc = loc
 	..(species.gibbed_anim, do_gibs = FALSE)
 	if(last_loc)
-		gibs(last_loc, dna, null, species.get_flesh_colour(src), species.get_blood_color(src))
+		gibs(last_loc, dna, _fleshcolor = species.get_flesh_colour(src), _bloodcolor = species.get_blood_color(src))
 
 /mob/living/carbon/human/dust()
 	if(species)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1250,8 +1250,8 @@
 	if(!eye_colour)
 		eye_colour = root_bodytype.base_eye_color
 	root_bodytype.set_default_hair(src, override_existing = FALSE, defer_update_hair = TRUE)
-	if(!b_type && length(species?.blood_types))
-		b_type = pickweight(species.blood_types)
+	if(!blood_type && length(species?.blood_types))
+		blood_type = pickweight(species.blood_types)
 
 	if(new_dna)
 		set_real_name(new_dna.real_name)
@@ -1290,3 +1290,6 @@
 		if(safety > FLASH_PROTECTION_NONE)
 			flash_strength = (flash_strength / 2)
 	. = ..()
+
+/mob/living/carbon/human/get_blood_type()
+	return blood_type || ..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1290,6 +1290,3 @@
 		if(safety > FLASH_PROTECTION_NONE)
 			flash_strength = (flash_strength / 2)
 	. = ..()
-
-/mob/living/carbon/human/get_blood_type()
-	return blood_type || ..()

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -16,7 +16,7 @@
 
 	var/lip_style = null	//no lipstick by default- arguably misleading, as it could be used for general makeup
 
-	var/b_type	//Player's bloodtype
+	var/blood_type	//Player's bloodtype
 
 	var/list/worn_underwear = list()
 

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -16,8 +16,6 @@
 
 	var/lip_style = null	//no lipstick by default- arguably misleading, as it could be used for general makeup
 
-	var/blood_type	//Player's bloodtype
-
 	var/list/worn_underwear = list()
 
 	var/datum/backpack_setup/backpack_setup

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1,4 +1,6 @@
 /mob/living/Initialize()
+	unique_mob_number = sequential_id(/mob)
+	fingerprint = md5(unique_mob_number)
 	. = ..()
 	if(stat == DEAD)
 		add_to_dead_mob_list()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1,6 +1,10 @@
 /mob/living/Initialize()
-	unique_mob_number = sequential_id(/mob)
-	fingerprint = md5(unique_mob_number)
+
+	original_fingerprint_seed = sequential_id(/mob)
+	fingerprint               = md5(num2text(original_fingerprint_seed))
+	original_genetic_seed     = sequential_id(/mob)
+	unique_enzymes            = md5(num2text(original_genetic_seed))
+
 	. = ..()
 	if(stat == DEAD)
 		add_to_dead_mob_list()
@@ -1143,6 +1147,12 @@ default behaviour is:
 /mob/living/proc/handle_some_updates()
 	//We are long dead, or we're junk mobs spawned like the clowns on the clown shuttle
 	return life_tick <= 5 || !timeofdeath || (timeofdeath >= 5 && (world.time-timeofdeath) <= 10 MINUTES)
+
+/mob/living/get_unique_enzymes()
+	return unique_enzymes
+
+/mob/living/get_blood_type()
+	return blood_type
 
 /mob/living/proc/get_mob_footstep(var/footstep_type)
 	var/decl/species/my_species = get_species()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -57,5 +57,8 @@
 	var/list/stasis_sources
 	var/stasis_value
 
-	var/unique_mob_number
+	var/original_fingerprint_seed
 	var/fingerprint
+	var/original_genetic_seed
+	var/unique_enzymes
+	var/blood_type = "A+"

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -56,3 +56,6 @@
 	var/life_tick
 	var/list/stasis_sources
 	var/stasis_value
+
+	var/unique_mob_number
+	var/fingerprint

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -78,7 +78,7 @@
 			var/obj/item/radio/radio = thing.get_radio(message_mode)
 			if(istype(radio))
 				LAZYDISTINCTADD(., radio)
-
+me
 // This proc takes in a string (message_mode) which maps to a radio key in global.department_radio_keys
 // It then processes the message_mode to implement an additional behavior needed for the message, such
 // as retrieving radios or looking for an intercom nearby.

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -78,7 +78,7 @@
 			var/obj/item/radio/radio = thing.get_radio(message_mode)
 			if(istype(radio))
 				LAZYDISTINCTADD(., radio)
-me
+
 // This proc takes in a string (message_mode) which maps to a radio key in global.department_radio_keys
 // It then processes the message_mode to implement an additional behavior needed for the message, such
 // as retrieving radios or looking for an intercom nearby.

--- a/code/modules/mob/living/silicon/death.dm
+++ b/code/modules/mob/living/silicon/death.dm
@@ -1,6 +1,6 @@
 /mob/living/silicon/gib()
 	..("gibbed-r")
-	gibs(loc, null, /obj/effect/gibspawner/robot)
+	gibs(loc, gibber_type = /obj/effect/gibspawner/robot)
 
 /mob/living/silicon/dust()
 	..("dust-r", /obj/item/remains/robot)

--- a/code/modules/mob/living/silicon/pai/software_modules.dm
+++ b/code/modules/mob/living/silicon/pai/software_modules.dm
@@ -72,9 +72,9 @@
 				P.visible_message( \
 					message = SPAN_NOTICE("\The [M] presses [G.his] thumb against \the [P]."), \
 					blind_message = SPAN_NOTICE("\The [P] makes a sharp clicking sound as it extracts DNA material from \the [M]."))
-				var/datum/dna/dna = M.dna
-				to_chat(P, SPAN_NOTICE("<h3>[M]'s UE string : [dna.unique_enzymes]</h3>"))
-				if(dna.unique_enzymes == P.master_dna)
+				var/unique_enzymes = M.get_unique_enzymes()
+				to_chat(P, SPAN_NOTICE("<h3>[M]'s UE string : [unique_enzymes || "NULL"]</h3>"))
+				if(unique_enzymes == P.master_dna)
 					to_chat(P, "<b>DNA is a match to stored Master DNA.</b>")
 				else
 					to_chat(P, "<b>DNA does not match stored Master DNA.</b>")
@@ -95,7 +95,7 @@
 	data["listening"] = user.silicon_radio.broadcasting
 	data["frequency"] = format_frequency(user.silicon_radio.frequency)
 	var/channels[0]
-	var/list/pai_channels = user.silicon_radio.get_available_channels() 
+	var/list/pai_channels = user.silicon_radio.get_available_channels()
 	for(var/datum/radio_channel/channel in pai_channels)
 		var/ch_dat[0]
 		ch_dat["name"] = channel.name || format_frequency(channel.frequency)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1350,3 +1350,6 @@
 
 /mob/proc/get_unique_enzymes()
 	return dna?.unique_enzymes
+
+/mob/proc/get_blood_type()
+	return dna?.b_type

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1349,7 +1349,7 @@
 			CRASH("base get_temperature_threshold() called with invalid threshold value.")
 
 /mob/proc/get_unique_enzymes()
-	return dna?.unique_enzymes
+	return
 
 /mob/proc/get_blood_type()
-	return dna?.b_type
+	return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1347,3 +1347,6 @@
 			return 1000
 		else
 			CRASH("base get_temperature_threshold() called with invalid threshold value.")
+
+/mob/proc/get_unique_enzymes()
+	return dna?.unique_enzymes

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -36,7 +36,7 @@
 
 	var/list/all_backpacks = decls_repository.get_decls_of_subtype(/decl/backpack_outfit)
 	backpack = all_backpacks[pick(all_backpacks)]
-	b_type = pickweight(current_species.blood_types)
+	blood_type = pickweight(current_species.blood_types)
 	if(H)
 		copy_to(H)
 

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -87,7 +87,7 @@ var/global/arrest_security_status =  "Arrest"
 	// Security record
 	set_criminalStatus(global.default_security_status)
 	set_dna(H?.get_unique_enzymes() || "")
-	set_fingerprint(H ? md5(H.dna.uni_identity) : "")
+	set_fingerprint(H?.get_full_print(ignore_blockers = TRUE) || "")
 
 	var/security_record = records[PREF_SEC_RECORD]
 	set_security_record((security_record && !jobban_isbanned(H, "Records")) ? html_decode(security_record) : "No record supplied")

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -86,7 +86,7 @@ var/global/arrest_security_status =  "Arrest"
 
 	// Security record
 	set_criminalStatus(global.default_security_status)
-	set_dna(H ? H.dna.unique_enzymes : "")
+	set_dna(H?.get_unique_enzymes() || "")
 	set_fingerprint(H ? md5(H.dna.uni_identity) : "")
 
 	var/security_record = records[PREF_SEC_RECORD]

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -69,7 +69,7 @@ var/global/arrest_security_status =  "Arrest"
 	set_public_record((public_record && !jobban_isbanned(H, "Records")) ? html_decode(public_record) : "No record supplied")
 
 	// Medical record
-	set_bloodtype(H ? H.b_type : "Unset")
+	set_bloodtype(H?.get_blood_type() || "Unset")
 	var/medical_record = records[PREF_MED_RECORD]
 	set_medical_record((medical_record && !jobban_isbanned(H, "Records")) ? html_decode(medical_record) : "No record supplied")
 

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -46,12 +46,12 @@
 		vessel.maximum_volume = species.blood_volume
 
 	LAZYSET(vessel.reagent_data, species.blood_reagent, list(
-		"donor" =        weakref(src),
-		"species" =      species.name,
-		"blood_DNA" =    dna?.unique_enzymes,
+		"donor"       = weakref(src),
+		"species"     = get_species_name(),
+		"blood_DNA"   = get_unique_enzymes(),
 		"blood_color" = species.get_blood_color(src),
-		"blood_type" =   dna?.b_type,
-		"trace_chem" = null
+		"blood_type"  = get_blood_type(),
+		"trace_chem"  = null
 	))
 
 //Makes a blood drop, leaking amt units of blood from the mob
@@ -203,19 +203,30 @@
 		adjust_blood(amount, get_blood_data())
 	return amount
 
-/mob/living/carbon/proc/get_blood_data()
+/mob/living/proc/get_blood_data()
+
 	var/data = list()
-	data["donor"] = weakref(src)
-	data["blood_DNA"] = dna.unique_enzymes
-	data["blood_type"] = dna.b_type
-	data["species"] = species.name
-	data["has_oxy"] = species.blood_oxy
+	data["donor"]      = weakref(src)
+	data["blood_DNA"]  = get_unique_enzymes()
+	data["blood_type"] = get_blood_type()
+	data["species"]    = get_species_name()
+
 	var/list/temp_chem = list()
 	for(var/R in reagents.reagent_volumes)
 		temp_chem[R] = REAGENT_VOLUME(reagents, R)
-	data["trace_chem"] = temp_chem
-	data["dose_chem"] = chem_doses ? chem_doses.Copy() : list()
-	data["blood_color"] = species.get_blood_color(src)
+	data["trace_chem"]  = temp_chem
+	data["dose_chem"]   = chem_doses ? chem_doses.Copy() : list()
+
+	var/decl/species/my_species = get_species()
+	if(my_species)
+		data["has_oxy"]     = my_species.blood_oxy
+		data["blood_color"] = my_species.get_blood_color(src)
+	else if(isSynthetic())
+		data["has_oxy"]     = FALSE
+		data["blood_color"] = SYNTH_BLOOD_COLOR
+	else
+		data["has_oxy"]     = TRUE
+		data["blood_color"] = COLOR_BLOOD_HUMAN
 	return data
 
 /proc/blood_splatter(var/target, var/source, var/large, var/spray_dir)

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -263,7 +263,7 @@
 	if(ishuman(source))
 		var/mob/living/carbon/human/donor = source
 		blood_data = REAGENT_DATA(donor.vessel, donor.species.blood_reagent)
-		blood_type = donor.b_type
+		blood_type = donor.get_blood_type()
 	else if(isatom(source))
 		var/atom/donor = source
 		blood_data = REAGENT_DATA(donor.reagents, /decl/material/liquid/blood)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -78,11 +78,14 @@
 
 	// HUD element variable, see organ_icon.dm get_damage_hud_image()
 	var/image/hud_damage_image
+	var/fingerprint
 
 /obj/item/organ/external/proc/get_fingerprint()
 
-	if((limb_flags & ORGAN_FLAG_FINGERPRINT) && dna && !BP_IS_PROSTHETIC(src))
-		return md5(dna.uni_identity)
+	if((limb_flags & ORGAN_FLAG_FINGERPRINT) && !BP_IS_PROSTHETIC(src))
+		if(!owner) // We need to generate a fingerprint as we've never been supplied one before.
+			fingerprint = md5(sequential_id(/mob))
+		return fingerprint
 
 	for(var/obj/item/organ/external/E in children)
 		var/print = E.get_fingerprint()
@@ -423,6 +426,11 @@
 
 	//If attached to an owner mob
 	if(istype(owner))
+
+		// Initialize fingerprints if we don't already have some (TODO: we're assuming this is our first owner, maybe check for this elsewhere?).
+		if((limb_flags & ORGAN_FLAG_FINGERPRINT) && !fingerprint && !BP_IS_PROSTHETIC(src))
+			fingerprint = owner.get_full_print(ignore_blockers = TRUE)
+
 		//If we expect a parent organ set it up here
 		if(!affected && parent_organ)
 			parent = GET_EXTERNAL_ORGAN(owner, parent_organ)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -122,7 +122,7 @@
 	if(new_dna != dna) // Hacky. Is this ever used? Do any organs ever have DNA set before setup_as_organic?
 		QDEL_NULL(dna)
 		dna = new_dna.Clone()
-	LAZYSET(blood_DNA, dna.unique_enzymes, dna.b_type)
+	blood_DNA = list(dna.unique_enzymes = dna.b_type)
 	set_species(dna.species)
 
 /obj/item/organ/proc/set_bodytype(decl/bodytype/new_bodytype, override_material = null)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -122,10 +122,7 @@
 	if(new_dna != dna) // Hacky. Is this ever used? Do any organs ever have DNA set before setup_as_organic?
 		QDEL_NULL(dna)
 		dna = new_dna.Clone()
-	if(!blood_DNA)
-		blood_DNA = list()
-	blood_DNA.Cut()
-	blood_DNA[dna.unique_enzymes] = dna.b_type
+	LAZYSET(blood_DNA, dna.unique_enzymes, dna.b_type)
 	set_species(dna.species)
 
 /obj/item/organ/proc/set_bodytype(decl/bodytype/new_bodytype, override_material = null)

--- a/code/modules/xenoarcheaology/finds/find_types/statuette.dm
+++ b/code/modules/xenoarcheaology/finds/find_types/statuette.dm
@@ -111,8 +111,10 @@
 		to_chat(M, "<span class='warning'>The skin on your [parse_zone(target.organ_tag)] feels like it's ripping apart, and a stream of blood flies out.</span>")
 		var/obj/effect/decal/cleanable/blood/splatter/animated/B = new(M.loc)
 		B.target_turf = pick(range(1, src))
-		B.blood_DNA = list()
-		B.blood_DNA[M.dna.unique_enzymes] = M.dna.b_type
+		var/blood_type = M.get_blood_type()
+		var/unique_enzymes = M.get_unique_enzymes()
+		if(blood_type && unique_enzymes)
+			LAZYSET(B.blood_DNA, unique_enzymes, blood_type)
 		M.vessel.remove_any(rand(25,50))
 
 //animated blood 2 SPOOKY


### PR DESCRIPTION
## Description of changes
- adds a `/mob/proc/get_unique_enzymes()` helper and uses it where possible..
- adds a `/mob/proc/get_blood_type()` helper and uses it where possible. Also renames `b_type` in a bunch of spots for clarity.
- made fingerprints use `get_full_print()` where possible.
- converts pAIs and gibs to not rely directly on `/datum/dna`.

## Why and what will this PR improve
Less deps on DNA, easier to remove/rewrite it.

## Authorship
Myself.

## Changelog
Nothing player-facing.