### PR TITLE
Fix readying up not refreshing

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -102,6 +102,7 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 	if(href_list["lobby_ready"])
 		if(GAME_STATE <= RUNLEVEL_LOBBY)
 			ready = !ready
+		show_lobby_menu()
 
 	if(href_list["refresh"])
 		show_lobby_menu()


### PR DESCRIPTION
## Description of changes
Fixes a regression in #3174. The unconditional refresh was removed, but I forgot to readd one when you ready up.

## Why and what will this PR improve
Readying up should refresh.