### PR TITLE
Migrate some computer part behavior upwards

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -136,15 +136,16 @@ var/global/defer_powernet_rebuild = 0      // True if net rebuild will be called
 #define MESSAGE_RESEND_TIME 5	//how long (in seconds) do we wait before resending a message
 
 // obj/item/stock_parts status flags
-#define PART_STAT_INSTALLED  1
-#define PART_STAT_PROCESSING 2
-#define PART_STAT_ACTIVE     4
-#define PART_STAT_CONNECTED  8
+#define PART_STAT_INSTALLED  BITFLAG(0)
+#define PART_STAT_PROCESSING BITFLAG(1)
+#define PART_STAT_ACTIVE     BITFLAG(2)
+#define PART_STAT_CONNECTED  BITFLAG(3)
 
 // part_flags
-#define PART_FLAG_LAZY_INIT   1 // Will defer init on stock parts until machine is destroyed or parts are otherwise queried.
-#define PART_FLAG_QDEL        2 // Will delete on uninstall
-#define PART_FLAG_HAND_REMOVE 4 // Can be removed by hand
+#define PART_FLAG_LAZY_INIT       BITFLAG(0) // Will defer init on stock parts until machine is destroyed or parts are otherwise queried.
+#define PART_FLAG_QDEL            BITFLAG(1) // Will delete on uninstall
+#define PART_FLAG_HAND_REMOVE     BITFLAG(2) // Can be removed by hand
+#define PART_FLAG_INTERACT_CLOSED BITFLAG(3) // Attackby will be passed to this part even with a closed panel
 
 // Machinery process flags, for use with START_PROCESSING_MACHINE
 #define MACHINERY_PROCESS_SELF       1
@@ -176,3 +177,4 @@ var/global/defer_powernet_rebuild = 0      // True if net rebuild will be called
 #define  PART_SCANNER  	/obj/item/stock_parts/computer/scanner							// One of several optional scanner attachments.
 #define  PART_D_SLOT	/obj/item/stock_parts/computer/drive_slot				// Portable drive slot.
 #define  PART_MSTICK	/obj/item/stock_parts/computer/charge_stick_slot		// Charge-slot component for transactions /w charge sticks.
+#define  PART_DSKSLOT	/obj/item/stock_parts/item_holder/disk_reader

--- a/code/datums/extensions/assembly/assembly.dm
+++ b/code/datums/extensions/assembly/assembly.dm
@@ -36,7 +36,7 @@
 			var/existing_parts = get_components_by_type(max_part_type)
 			if(length(existing_parts) >= max_parts[max_part_type])
 				if(user)
-					to_chat(user, "This [assembly_name]'s does not have room for additional [P].")
+					to_chat(user, "This [assembly_name] does not have room for \the [P].")
 				return
 	parts += P
 	if(user)
@@ -52,7 +52,7 @@
 	else
 		var/atom/movable/H = holder
 		P.dropInto(H.loc)
-	if(enabled && (P.type in critical_parts))
+	if(enabled && is_type_in_list(P, critical_parts))
 		critical_shutdown()
 
 /datum/extension/assembly/proc/add_replace_component(var/mob/living/user, var/part_type, var/obj/item/stock_parts/P)
@@ -84,16 +84,16 @@
 
 /datum/extension/assembly/proc/shutdown_device()
 	enabled = FALSE
-	for(var/obj/item/stock_parts/computer/P in parts)
-		P.enabled = FALSE
+	for(var/obj/item/stock_parts/P in parts)
+		P.unset_status(holder, PART_STAT_ACTIVE)
 
 /datum/extension/assembly/proc/critical_shutdown()
 	shutdown_device()
 
 /datum/extension/assembly/proc/turn_on(var/mob/user)
 	enabled = TRUE
-	for(var/obj/item/stock_parts/computer/P in parts)
-		P.enabled = TRUE
+	for(var/obj/item/stock_parts/P in parts)
+		P.set_status(holder, PART_STAT_ACTIVE)
 
 /datum/extension/assembly/Process()
 	if(!enabled) // The computer is turned off

--- a/code/datums/extensions/assembly/assembly_damage.dm
+++ b/code/datums/extensions/assembly/assembly_damage.dm
@@ -28,7 +28,7 @@
 		damage = clamp(0, damage, max_damage)
 
 	if(component_probability)
-		for(var/obj/item/stock_parts/computer/H in get_all_components())
+		for(var/obj/item/stock_parts/H in get_all_components())
 			if(prob(component_probability))
 				H.take_damage(round(amount / 2))
 

--- a/code/datums/extensions/assembly/assembly_interaction.dm
+++ b/code/datums/extensions/assembly/assembly_interaction.dm
@@ -30,7 +30,7 @@
 			to_chat(user, "This device doesn't have any components installed.")
 			return TRUE
 		var/list/component_names = list()
-		for(var/obj/item/stock_parts/computer/H in parts)
+		for(var/obj/item/stock_parts/H in parts)
 			component_names.Add(H.name)
 
 		var/choice = input(usr, "Which component do you want to uninstall?", "[assembly_name] maintenance", null) as null|anything in component_names

--- a/code/datums/extensions/assembly/assembly_power.dm
+++ b/code/datums/extensions/assembly/assembly_power.dm
@@ -43,7 +43,7 @@
 /datum/extension/assembly/proc/calculate_power_usage()
 	var/power_usage = screen_on ? base_active_power_usage : base_idle_power_usage
 	for(var/obj/item/stock_parts/computer/P in parts)
-		if(P.enabled)
+		if(P.status & PART_STAT_ACTIVE)
 			power_usage += P.power_usage
 	return power_usage
 

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -222,10 +222,10 @@ var/global/list/machine_path_to_circuit_type
 		. += comps[path]
 
 // Use to block interactivity if panel is not open, etc.
-/obj/machinery/proc/components_are_accessible(var/path)
+/obj/machinery/proc/components_are_accessible(var/obj/item/stock_parts/path)
 	if(ispath(path, /obj/item/stock_parts/access_lock) || ispath(path, /obj/item/stock_parts/item_holder))
 		return TRUE
-	return panel_open
+	return panel_open || (initial(path.part_flags) & PART_FLAG_INTERACT_CLOSED)
 
 // Installation. Returns number of such components which can be inserted, or 0.
 /obj/machinery/proc/can_add_component(var/obj/item/stock_parts/component, var/mob/user)

--- a/code/modules/augment/active/cyberbrain.dm
+++ b/code/modules/augment/active/cyberbrain.dm
@@ -91,7 +91,7 @@
  */
 /datum/extension/assembly/modular_computer/cyberbrain
 	hardware_flag = PROGRAM_PDA
-	max_hardware_size = 1
+	max_hardware_size = ITEM_SIZE_TINY
 	enabled_by_default = TRUE
 	max_parts = list(
 		PART_BATTERY 	= 1,

--- a/code/modules/modular_computers/computers/modular_computer/assembly_computer.dm
+++ b/code/modules/modular_computers/computers/modular_computer/assembly_computer.dm
@@ -23,19 +23,19 @@
 		PART_SCANNER	= 1,
 		PART_MSTICK		= 1
 	)
-	critical_parts = list(PART_CPU, PART_HDD, PART_NETWORK)
+	critical_parts = list(PART_CPU, PART_HDD, PART_BATTERY)
 
-/datum/extension/assembly/modular_computer/try_install_component(var/mob/living/user, var/obj/item/stock_parts/computer/P)
-	if(!istype(P) || !(P.usage_flags & hardware_flag))
-		to_chat(user, "This computer isn't compatible with [P].")
+/datum/extension/assembly/modular_computer/try_install_component(var/mob/living/user, var/obj/item/stock_parts/computer/computer_part)
+	if(istype(computer_part) && !(computer_part.usage_flags & hardware_flag))
+		to_chat(user, "This computer isn't compatible with [computer_part].")
 		return
-	var/obj/item/stock_parts/computer/C = P
-	if(istype(C) && C.hardware_size > max_hardware_size)
+	var/obj/item/stock_parts/stock_part = computer_part
+	if(istype(stock_part) && stock_part.w_class > max_hardware_size)
 		to_chat(user, "This component is too large for \the [holder].")
 		return
 	. = ..()
-	if(.)
-		P.do_after_install(holder, !!user)
+	if(. && istype(computer_part))
+		computer_part.do_after_install(holder, !!user)
 		return TRUE
 
 /datum/extension/assembly/modular_computer/uninstall_component(var/mob/living/user, var/obj/item/stock_parts/P)

--- a/code/modules/modular_computers/computers/modular_computer/assembly_holo.dm
+++ b/code/modules/modular_computers/computers/modular_computer/assembly_holo.dm
@@ -1,7 +1,12 @@
 /datum/extension/assembly/modular_computer/holo
 	hardware_flag = PROGRAM_PDA
-	max_hardware_size = 1
-	critical_parts = list(PART_CPU, PART_HDD)
+	max_hardware_size = ITEM_SIZE_TINY
+	max_parts = list(
+		PART_BATTERY 	= 1,
+		PART_CPU		= 1,
+		PART_HDD		= 1,
+		PART_TESLA		= 1
+	)
 
 	base_active_power_usage = 30
 	base_idle_power_usage = 0

--- a/code/modules/modular_computers/computers/modular_computer/assembly_laptop.dm
+++ b/code/modules/modular_computers/computers/modular_computer/assembly_laptop.dm
@@ -1,6 +1,6 @@
 /datum/extension/assembly/modular_computer/laptop
 	hardware_flag = PROGRAM_LAPTOP
-	max_hardware_size = 2
+	max_hardware_size = ITEM_SIZE_SMALL
 	base_idle_power_usage = 25
 	base_active_power_usage = 200
 	max_damage = 200

--- a/code/modules/modular_computers/computers/modular_computer/assembly_pda.dm
+++ b/code/modules/modular_computers/computers/modular_computer/assembly_pda.dm
@@ -1,4 +1,4 @@
 /datum/extension/assembly/modular_computer/pda
 	hardware_flag = PROGRAM_PDA
-	max_hardware_size = 1
+	max_hardware_size = ITEM_SIZE_TINY
 	enabled_by_default = TRUE

--- a/code/modules/modular_computers/computers/modular_computer/assembly_tablet.dm
+++ b/code/modules/modular_computers/computers/modular_computer/assembly_tablet.dm
@@ -1,3 +1,3 @@
 /datum/extension/assembly/modular_computer/tablet
 	hardware_flag = PROGRAM_TABLET
-	max_hardware_size = 1
+	max_hardware_size = ITEM_SIZE_TINY

--- a/code/modules/modular_computers/computers/subtypes/dev_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_console.dm
@@ -5,7 +5,7 @@
 	icon_state = "console-off"
 	var/list/interact_sounds  = list("keyboard", "keystroke")
 	var/wired_connection      = FALSE // Whether or not this console will start with a wired connection beneath it.
-	var/tmp/max_hardware_size = 3 //Enum to tell whether computer parts are too big to fit in this machine.
+	var/tmp/max_hardware_size = ITEM_SIZE_NORMAL //Enum to tell whether computer parts are too big to fit in this machine.
 	var/tmp/os_type           = /datum/extension/interactive/os/console //The type of the OS extension to create for this machine.
 
 /obj/machinery/computer/modular/Initialize()
@@ -57,15 +57,6 @@
 	var/obj/item/stock_parts/circuitboard/modular_computer/MB = get_component_of_type(/obj/item/stock_parts/circuitboard/modular_computer)
 	return MB && MB.emag_act(remaining_charges, user)
 
-/obj/machinery/computer/modular/components_are_accessible(var/path)
-	. = ..()
-	if(.)
-		return
-	if(!ispath(path, /obj/item/stock_parts/computer))
-		return FALSE
-	var/obj/item/stock_parts/computer/P = path
-	return initial(P.external_slot)
-
 /obj/machinery/computer/modular/CouldUseTopic(var/mob/user)
 	..()
 	if(LAZYLEN(interact_sounds) && CanPhysicallyInteract(user))
@@ -75,7 +66,7 @@
 	..()
 	var/extra_power = 0
 	for(var/obj/item/stock_parts/computer/part in component_parts)
-		if(part.enabled)
+		if((part.status & PART_STAT_ACTIVE))
 			extra_power += part.power_usage
 	change_power_consumption(initial(active_power_usage) + extra_power, POWER_USE_ACTIVE)
 
@@ -90,7 +81,7 @@
 /obj/machinery/computer/modular/can_add_component(obj/item/stock_parts/component, mob/user)
 	var/obj/item/stock_parts/computer/C = component
 	if(istype(C))
-		if(C.hardware_size > max_hardware_size)
+		if(C.w_class > max_hardware_size)
 			to_chat(user, "This component is too large for \the [src].")
 			return 0
 	. = ..()

--- a/code/modules/modular_computers/computers/subtypes/dev_holo.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_holo.dm
@@ -1,6 +1,6 @@
 /obj/item/modular_computer/holotablet
 	name = "holotablet"
-	desc = "An holoemitter-fitted device designed for writing reports and notes."
+	desc = "A holoemitter-fitted device designed for writing reports and notes."
 	icon = 'icons/obj/modular_computers/holo/basic.dmi'
 	icon_state = ICON_STATE_WORLD
 

--- a/code/modules/modular_computers/computers/subtypes/dev_telescreen.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_telescreen.dm
@@ -59,7 +59,7 @@
 	directional_offset = "{'NORTH':{'y':-20}, 'SOUTH':{'y':24}, 'EAST':{'x':-24}, 'WEST':{'x':24}}"
 	idle_power_usage   = 75
 	active_power_usage = 300
-	max_hardware_size  = 2 //make sure we can only put smaller components in here
+	max_hardware_size  = ITEM_SIZE_SMALL //make sure we can only put smaller components in here
 	construct_state    = /decl/machine_construction/wall_frame/panel_closed
 	base_type          = /obj/machinery/computer/modular/telescreen
 	frame_type         = /obj/item/frame/modular_telescreen

--- a/code/modules/modular_computers/computers/subtypes/preset_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_console.dm
@@ -5,22 +5,19 @@
 
 /obj/machinery/computer/modular/preset/full
 	uncreated_component_parts = list(
-		/obj/item/stock_parts/power/apc,
 		/obj/item/stock_parts/computer/card_slot,
 		/obj/item/stock_parts/computer/ai_slot,
-		)
+	)
 
 /obj/machinery/computer/modular/preset/aislot
 	uncreated_component_parts = list(
-		/obj/item/stock_parts/power/apc,
 		/obj/item/stock_parts/computer/ai_slot
-		)
+	)
 
 /obj/machinery/computer/modular/preset/cardslot
 	uncreated_component_parts = list(
-		/obj/item/stock_parts/power/apc,
 		/obj/item/stock_parts/computer/card_slot
-		)
+	)
 
 /obj/machinery/computer/modular/preset/Initialize()
 	. = ..()

--- a/code/modules/modular_computers/file_system/programs/generic/configurator.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/configurator.dm
@@ -50,15 +50,17 @@
 
 	var/list/all_entries[0]
 	var/list/hardware = program.computer.get_all_components()
-	for(var/obj/item/stock_parts/computer/H in hardware)
-		all_entries.Add(list(list(
-		"name" = H.name,
-		"desc" = H.desc,
-		"enabled" = H.enabled,
-		"critical" = H.critical,
-		"powerusage" = H.power_usage,
-		"ref" = "\ref[H]"
-		)))
+	for(var/obj/item/stock_parts/computer/computer_part in hardware)
+		var/list/entry = list(
+			"name" = computer_part.name,
+			"desc" = computer_part.desc,
+			"enabled" = (computer_part.status & PART_STAT_ACTIVE),
+			"critical" = computer_part.critical,
+			"powerusage" = computer_part.power_usage,
+			"ref" = "\ref[computer_part]"
+		)
+		// this saves an extra list alloc because list.Add(list()) adds the list's contents, not the list
+		all_entries[++all_entries.len] = entry
 
 	data["hardware"] = all_entries
 

--- a/code/modules/modular_computers/file_system/programs/generic/scanner.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/scanner.dm
@@ -94,7 +94,7 @@
 	var/obj/item/stock_parts/computer/scanner/scanner = prog.computer.get_component(PART_SCANNER)
 	if(scanner)
 		data["scanner_name"] = scanner.name
-		data["scanner_enabled"] = scanner.enabled
+		data["scanner_enabled"] = (scanner.status & PART_STAT_ACTIVE)
 		data["can_view_scan"] = scanner.can_view_scan
 		data["can_save_scan"] = (scanner.can_save_scan && prog.data_buffer)
 	data["using_scanner"] = prog.using_scanner

--- a/code/modules/modular_computers/file_system/programs/research/ai_restorer.dm
+++ b/code/modules/modular_computers/file_system/programs/research/ai_restorer.dm
@@ -15,7 +15,7 @@
 /datum/computer_file/program/aidiag/proc/get_ai()
 	var/obj/item/stock_parts/computer/ai_slot/ai_slot = computer.get_component(PART_AI)
 
-	if(ai_slot && ai_slot.check_functionality() && ai_slot.enabled && ai_slot.stored_card)
+	if(ai_slot && ai_slot.check_functionality() && (ai_slot.status & PART_STAT_ACTIVE) && ai_slot.stored_card)
 		return ai_slot.stored_card.carded_ai
 
 /datum/computer_file/program/aidiag/Topic(href, href_list)

--- a/code/modules/modular_computers/hardware/_hardware.dm
+++ b/code/modules/modular_computers/hardware/_hardware.dm
@@ -1,14 +1,13 @@
-/obj/item/stock_parts/computer/
+/obj/item/stock_parts/computer
 	name = "Hardware"
 	desc = "Unknown Hardware."
 	icon = 'icons/obj/items/stock_parts/modular_components.dmi'
 	part_flags = PART_FLAG_HAND_REMOVE
-	var/power_usage = 0 			// If the hardware uses extra power, change this.
-	var/enabled = 1					// If the hardware is turned off set this to 0.
-	var/critical = 1				// Prevent disabling for important component, like the HDD.
-	var/hardware_size = 1			// Limits which devices can contain this component. 1: Tablets/Laptops/Consoles, 2: Laptops/Consoles, 3: Consoles only
+	status = PART_STAT_ACTIVE			// Computer parts start enabled.
+	w_class = ITEM_SIZE_TINY			// Limits which devices can contain this component. 1: Tablets/Laptops/Consoles, 2: Laptops/Consoles, 3: Consoles only
+	var/critical = TRUE					// Prevent disabling for important component, like the HDD.
+	var/power_usage = 0 				// If the hardware uses extra power, change this.
 	var/usage_flags = PROGRAM_ALL
-	var/external_slot				// Whether attackby will be passed on it even with a closed panel
 
 /obj/item/stock_parts/computer/attackby(var/obj/item/W, var/mob/user)
 	// Multitool. Runs diagnostics
@@ -31,10 +30,6 @@
 /obj/item/stock_parts/computer/proc/diagnostics()
 	return list("Hardware Integrity Test... (Corruption: [get_percent_damage()]%)")
 
-/obj/item/stock_parts/computer/Initialize()
-	. = ..()
-	w_class = hardware_size
-
 /obj/item/stock_parts/computer/Destroy()
 	if(istype(loc, /obj/item/modular_computer))
 		var/datum/extension/assembly/modular_computer/assembly = get_extension(loc, /datum/extension/assembly)
@@ -45,7 +40,7 @@
 // Handles damage checks
 /obj/item/stock_parts/computer/proc/check_functionality()
 	// Turned off
-	if(!enabled)
+	if(!(status & PART_STAT_ACTIVE))
 		return 0
 	return is_functional()
 

--- a/code/modules/modular_computers/hardware/ai_slot.dm
+++ b/code/modules/modular_computers/hardware/ai_slot.dm
@@ -3,11 +3,11 @@
 	name = "inteliCard slot"
 	desc = "An IIS interlink with connection uplinks that allow the device to interface with most common inteliCard models. Too large to fit into tablets. Uses a lot of power when active."
 	icon_state = "aislot"
-	hardware_size = 1
-	critical = 0
+	w_class = ITEM_SIZE_TINY
+	critical = FALSE
 	power_usage = 100
 	origin_tech = "{'powerstorage':2,'programming':3}"
-	external_slot = TRUE
+	part_flags = PART_FLAG_HAND_REMOVE | PART_FLAG_INTERACT_CLOSED
 	material = /decl/material/solid/metal/steel
 
 	var/obj/item/aicard/stored_card

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -4,7 +4,7 @@
 	name = "standard battery"
 	desc = "A standard power cell, commonly seen in high-end portable microcomputers or low-end laptops. It's rating is 75 Wh."
 	icon_state = "battery_normal"
-	critical = 1
+	critical = TRUE
 	origin_tech = "{'powerstorage':1,'engineering':1}"
 	material = /decl/material/solid/metal/steel
 
@@ -16,7 +16,7 @@
 	desc = "An advanced power cell, often used in most laptops. It is too large to be fitted into smaller devices. It's rating is 110 Wh."
 	icon_state = "battery_advanced"
 	origin_tech = "{'powerstorage':2,'engineering':2}"
-	hardware_size = 2
+	w_class = ITEM_SIZE_SMALL
 	battery_rating = 110
 	material = /decl/material/solid/metal/steel
 
@@ -25,7 +25,7 @@
 	desc = "A very advanced power cell, often used in high-end devices, or as uninterruptable power supply for important consoles or servers. It's rating is 150 Wh."
 	icon_state = "battery_super"
 	origin_tech = "{'powerstorage':3,'engineering':3}"
-	hardware_size = 2
+	w_class = ITEM_SIZE_SMALL
 	battery_rating = 150
 	material = /decl/material/solid/metal/steel
 
@@ -34,7 +34,7 @@
 	desc = "A very advanced large power cell. It's often used as uninterruptable power supply for critical consoles or servers. It's rating is 200 Wh."
 	icon_state = "battery_ultra"
 	origin_tech = "{'powerstorage':5,'engineering':4}"
-	hardware_size = 3
+	w_class = ITEM_SIZE_NORMAL
 	battery_rating = 200
 	material = /decl/material/solid/metal/steel
 
@@ -60,7 +60,7 @@
 	name = "lambda coil"
 	desc = "A very complex power source compatible with various computers. It is capable of providing power for nearly unlimited duration."
 	icon_state = "battery_lambda"
-	hardware_size = 1
+	w_class = ITEM_SIZE_TINY
 	battery_rating = 3000
 	battery = /obj/item/cell/infinite
 

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -2,12 +2,12 @@
 	name = "RFID card slot"
 	desc = "Slot that allows this computer to write data on RFID cards. Necessary for some programs to run properly."
 	power_usage = 10 //W
-	critical = 0
+	critical = FALSE
 	icon_state = "cardreader"
-	hardware_size = 1
+	w_class = ITEM_SIZE_TINY
 	origin_tech = "{'programming':2}"
 	usage_flags = PROGRAM_ALL & ~PROGRAM_PDA
-	external_slot = TRUE
+	part_flags = PART_FLAG_HAND_REMOVE | PART_FLAG_INTERACT_CLOSED
 	material = /decl/material/solid/metal/steel
 
 	// TODO: reimplment RFID card write access and can_write

--- a/code/modules/modular_computers/hardware/charge_stick_slot.dm
+++ b/code/modules/modular_computers/hardware/charge_stick_slot.dm
@@ -2,12 +2,12 @@
 	name = "charge-stick slot"
 	desc = "Slot that allows this computer to pay for transactions using an inserted charge-stick."
 	power_usage = 10 //W
-	critical = 0
+	critical = FALSE
 	icon_state = "cardreader"
-	hardware_size = 1
+	w_class = ITEM_SIZE_TINY
 	origin_tech = "{'programming':2}"
 	usage_flags = PROGRAM_ALL & ~PROGRAM_PDA
-	external_slot = TRUE
+	part_flags = PART_FLAG_HAND_REMOVE | PART_FLAG_INTERACT_CLOSED
 	material = /decl/material/solid/metal/steel
 
 	var/can_broadcast = FALSE

--- a/code/modules/modular_computers/hardware/drive_slot.dm
+++ b/code/modules/modular_computers/hardware/drive_slot.dm
@@ -2,12 +2,12 @@
 	name = "removable drive slot"
 	desc = "Slot that allows this computer to accept removable drives."
 	power_usage = 10 //W
-	critical = 0
+	critical = FALSE
 	icon_state = "cardreader"
-	hardware_size = 1
+	w_class = ITEM_SIZE_TINY
 	origin_tech = "{'programming':2}"
 	usage_flags = PROGRAM_ALL
-	external_slot = TRUE
+	part_flags = PART_FLAG_HAND_REMOVE | PART_FLAG_INTERACT_CLOSED
 	material = /decl/material/solid/metal/steel
 
 	var/obj/item/stock_parts/computer/hard_drive/portable/stored_drive = null

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -3,7 +3,7 @@
 	desc = "A small power efficient solid state drive, with 128GQ of storage capacity for use in basic computers where power efficiency is desired."
 	power_usage = 25					// SSD or something with low power usage
 	icon_state = "hdd_normal"
-	hardware_size = 1
+	w_class = ITEM_SIZE_TINY
 	origin_tech = "{'programming':1,'engineering':1}"
 	material = /decl/material/solid/metal/steel
 	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
@@ -18,7 +18,7 @@
 	origin_tech = "{'programming':2,'engineering':2}"
 	power_usage = 50 					// Hybrid, medium capacity and medium power storage
 	icon_state = "hdd_advanced"
-	hardware_size = 2
+	w_class = ITEM_SIZE_SMALL
 	material = /decl/material/solid/metal/steel
 	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
 
@@ -29,7 +29,7 @@
 	origin_tech = "{'programming':3,'engineering':3}"
 	power_usage = 100					// High-capacity but uses lots of power, shortening battery life. Best used with APC link.
 	icon_state = "hdd_super"
-	hardware_size = 2
+	w_class = ITEM_SIZE_SMALL
 	material = /decl/material/solid/metal/steel
 	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
 
@@ -40,7 +40,7 @@
 	origin_tech = "{'programming':4,'engineering':4}"
 	max_capacity = 2048
 	icon_state = "hdd_cluster"
-	hardware_size = 3
+	w_class = ITEM_SIZE_NORMAL
 	material = /decl/material/solid/metal/steel
 	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
 
@@ -52,7 +52,7 @@
 	origin_tech = "{'programming':2,'engineering':2}"
 	max_capacity = 64
 	icon_state = "hdd_small"
-	hardware_size = 1
+	w_class = ITEM_SIZE_TINY
 	material = /decl/material/solid/metal/steel
 	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
 
@@ -63,7 +63,7 @@
 	origin_tech = "{'programming':1,'engineering':1}"
 	max_capacity = 32
 	icon_state = "hdd_micro"
-	hardware_size = 1
+	w_class = ITEM_SIZE_TINY
 	material = /decl/material/solid/metal/steel
 	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
 

--- a/code/modules/modular_computers/hardware/lan_port.dm
+++ b/code/modules/modular_computers/hardware/lan_port.dm
@@ -4,7 +4,7 @@
 	power_usage = 30
 	origin_tech = "{'programming':1,'engineering':1}"
 	icon_state = "netcard_ethernet"
-	hardware_size = 3
+	w_class = ITEM_SIZE_NORMAL
 	material = /decl/material/solid/glass
 	var/obj/structure/network_cable/terminal/terminal
 

--- a/code/modules/modular_computers/hardware/nano_printer.dm
+++ b/code/modules/modular_computers/hardware/nano_printer.dm
@@ -3,9 +3,9 @@
 	desc = "Small integrated printer with paper recycling module."
 	power_usage = 50
 	origin_tech = "{'programming':2,'engineering':2}"
-	critical = 0
+	critical = FALSE
 	icon_state = "printer"
-	hardware_size = 1
+	w_class = ITEM_SIZE_TINY
 	material = /decl/material/solid/metal/steel
 
 	var/stored_paper = 50
@@ -29,7 +29,7 @@
 /obj/item/stock_parts/computer/nano_printer/proc/printer_ready()
 	if(!stored_paper)
 		return 0
-	if(!enabled)
+	if(!(status & PART_STAT_ACTIVE))
 		return 0
 	if(!check_functionality())
 		return 0

--- a/code/modules/modular_computers/hardware/network_card.dm
+++ b/code/modules/modular_computers/hardware/network_card.dm
@@ -3,9 +3,9 @@
 	desc = "A basic network card for usage with standard network protocols."
 	power_usage = 50
 	origin_tech = "{'programming':2,'engineering':1}"
-	critical = 0
+	critical = FALSE
 	icon_state = "netcard_basic"
-	hardware_size = 1
+	w_class = ITEM_SIZE_TINY
 	material = /decl/material/solid/fiberglass
 
 	var/long_range = 0
@@ -36,7 +36,7 @@
 	origin_tech = "{'programming':4,'engineering':2}"
 	power_usage = 100 // Better range but higher power usage.
 	icon_state = "netcard_advanced"
-	hardware_size = 1
+	w_class = ITEM_SIZE_TINY
 
 // Returns a string identifier of this network card
 /obj/item/stock_parts/computer/network_card/proc/get_network_tag()
@@ -54,7 +54,7 @@
 // 0 - No signal, 1 - Low signal, 2 - High signal. 3 - Wired Connection
 /obj/item/stock_parts/computer/network_card/proc/get_signal(var/specific_action = 0)
 	. = 0
-	if(!enabled)
+	if(!(status & PART_STAT_ACTIVE))
 		return
 
 	var/datum/extension/network_device/D = get_extension(src, /datum/extension/network_device)

--- a/code/modules/modular_computers/hardware/portable_hard_drive.dm
+++ b/code/modules/modular_computers/hardware/portable_hard_drive.dm
@@ -4,7 +4,7 @@
 	desc = "Small crystal with imprinted photonic circuits that can be used to store data. Its capacity is 16 GQ."
 	power_usage = 10
 	icon_state = "flashdrive_basic"
-	hardware_size = 1
+	w_class = ITEM_SIZE_TINY
 	max_capacity = 16
 	origin_tech = "{'programming':1}"
 	material = /decl/material/solid/fiberglass
@@ -14,7 +14,7 @@
 	desc = "Small crystal with imprinted high-density photonic circuits that can be used to store data. Its capacity is 64 GQ."
 	power_usage = 20
 	icon_state = "flashdrive_advanced"
-	hardware_size = 1
+	w_class = ITEM_SIZE_TINY
 	max_capacity = 64
 	origin_tech = "{'programming':2}"
 
@@ -23,7 +23,7 @@
 	desc = "Small crystal with imprinted ultra-density photonic circuits that can be used to store data. Its capacity is 256 GQ."
 	power_usage = 40
 	icon_state = "flashdrive_super"
-	hardware_size = 1
+	w_class = ITEM_SIZE_TINY
 	max_capacity = 256
 	origin_tech = "{'programming':4}"
 

--- a/code/modules/modular_computers/hardware/processor_unit.dm
+++ b/code/modules/modular_computers/hardware/processor_unit.dm
@@ -5,9 +5,9 @@
 	name = "standard processor"
 	desc = "A standard CPU used in most computers."
 	icon_state = "cpu_normal"
-	hardware_size = 2
+	w_class = ITEM_SIZE_SMALL
 	power_usage = 100
-	critical = 1
+	critical = TRUE
 	origin_tech = "{'programming':3,'engineering':2}"
 	material = /decl/material/solid/metal/steel
 
@@ -17,7 +17,7 @@
 	name = "standard microprocessor"
 	desc = "A standard miniaturised CPU used in portable devices. It can run up to two programs simultaneously."
 	icon_state = "cpu_small"
-	hardware_size = 1
+	w_class = ITEM_SIZE_TINY
 	power_usage = 25
 	processing_power = 1
 	origin_tech = "{'programming':2,'engineering':2}"
@@ -27,7 +27,7 @@
 	name = "photonic processor"
 	desc = "An advanced experimental CPU that uses photonic core instead of regular circuitry. It is more power efficient than its elecron analog."
 	icon_state = "cpu_normal_photonic"
-	hardware_size = 2
+	w_class = ITEM_SIZE_SMALL
 	power_usage = 50
 	processing_power = 4
 	origin_tech = "{'programming':5,'engineering':4}"
@@ -38,7 +38,7 @@
 	name = "photonic microprocessor"
 	desc = "An advanced miniaturised CPU for use in portable devices. It uses photonic core instead of regular circuitry. It is more power efficient than its elecron analog."
 	icon_state = "cpu_small_photonic"
-	hardware_size = 1
+	w_class = ITEM_SIZE_TINY
 	power_usage = 10
 	processing_power = 2
 	origin_tech = "{'programming':4,'engineering':3}"

--- a/code/modules/modular_computers/hardware/scanners/scanner.dm
+++ b/code/modules/modular_computers/hardware/scanners/scanner.dm
@@ -5,8 +5,8 @@
 	desc = "A generic scanner module. This one doesn't seem to do anything."
 	power_usage = 50
 	icon_state = "printer"
-	hardware_size = 1
-	critical = 0
+	w_class = ITEM_SIZE_TINY
+	critical = FALSE
 	origin_tech = "{'programming':2,'engineering':2}"
 
 	var/datum/computer_file/program/scanner/driver_type = /datum/computer_file/program/scanner		// A program type that the scanner interfaces with and attempts to install on insertion.

--- a/code/modules/modular_computers/hardware/scanners/scanner_paper.dm
+++ b/code/modules/modular_computers/hardware/scanners/scanner_paper.dm
@@ -1,7 +1,7 @@
 /obj/item/stock_parts/computer/scanner/paper
 	name = "paper scanner module"
 	desc = "A paper scanning module. It can scan writing and save it to a file."
-	external_slot = TRUE
+	part_flags = PART_FLAG_HAND_REMOVE | PART_FLAG_INTERACT_CLOSED
 	material = /decl/material/solid/metal/steel
 	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
 

--- a/code/modules/modular_computers/hardware/tesla_link.dm
+++ b/code/modules/modular_computers/hardware/tesla_link.dm
@@ -1,10 +1,9 @@
 /obj/item/stock_parts/computer/tesla_link
 	name = "tesla link"
 	desc = "An advanced tesla link that wirelessly recharges connected device from nearby area power controller."
-	critical = 0
-	enabled = 1
+	critical = FALSE
 	icon_state = "teslalink"
-	hardware_size = 1
+	w_class = ITEM_SIZE_TINY
 	origin_tech = "{'programming':2,'powerstorage':3,'engineering':2}"
 	material = /decl/material/solid/metal/steel
 

--- a/code/modules/modular_computers/os/ui.dm
+++ b/code/modules/modular_computers/os/ui.dm
@@ -74,14 +74,14 @@
 		return TOPIC_REFRESH
 	if(href_list["PC_enable_component"] )
 		var/obj/item/stock_parts/computer/H = locate(href_list["PC_enable_component"]) in holder
-		if(H && istype(H) && !H.enabled)
-			H.enabled = 1
+		if(H && istype(H) && !(H.status & PART_STAT_ACTIVE))
+			H.set_status(holder, PART_STAT_ACTIVE)
 			H.on_enable(src)
 		return TOPIC_REFRESH
 	if(href_list["PC_disable_component"] )
 		var/obj/item/stock_parts/computer/H = locate(href_list["PC_disable_component"]) in holder
-		if(H && istype(H) && H.enabled)
-			H.enabled = 0
+		if(H && istype(H) && (H.status & PART_STAT_ACTIVE))
+			H.unset_status(holder, PART_STAT_ACTIVE)
 			H.on_disable()
 		return TOPIC_REFRESH
 	if( href_list["PC_enable_update"] )
@@ -195,7 +195,7 @@
 		data["PC_showbatteryicon"] = battery_module ? 1 : 0
 
 	var/obj/item/stock_parts/computer/tesla_link/tesla_link = get_component(PART_TESLA)
-	if(tesla_link && tesla_link.enabled)
+	if(tesla_link && (tesla_link.status & PART_STAT_ACTIVE))
 		data["PC_apclinkicon"] = "charging.gif"
 
 	var/obj/item/stock_parts/computer/network_card/network_card = get_component(PART_NETWORK)


### PR DESCRIPTION
## Description of changes
- Moves `external_slot` on computer parts to `PART_FLAG_INTERACT_CLOSED` on stock parts.
- Replaces `enabled` on computer parts with `PART_STAT_ACTIVE`.
- Replaces `hardware_size` with `w_class` since they were already synonymous.
- Adds supporting code for installing stock parts into assemblies (currently no non-computer parts are allowed anyway).
- Fixes duplicate tesla relays on modular consoles.

## Why and what will this PR improve
Lays some of the necessary groundwork for combining stock parts and computer parts.

## Future issues:
- It's unclear how stock parts should be displayed and interacted with in the computer configuration menu's hardware list.
- The usage and behavior of `PART_STAT_ACTIVE` is not standardized, leading to odd results when the user is made able to toggle it at will in the configuration menu.
- `power_usage` should probably be moved to stock parts so that part selection can affect power usage without bespoke per-machine code.
- stock part `on_install` always expects a machine—may need to be split into `on_install`, `on_install_machine`, and `on_install_assembly`?
- `critical` should probably be replaced with something else—maybe an 'in use' stat flag that prevents it from being disabled while active, so if network boot is added, you should be able to disable a local hard drive if it's not the OS drive?
- `critical_parts` should be replaced with things like OS drive checks, power supply checks, etc.