### PR TITLE
Fixes the direction of lighting

### DIFF
--- a/code/_helpers/maths.dm
+++ b/code/_helpers/maths.dm
@@ -137,12 +137,12 @@
 	mid = (mid - start) < 0 ? mid - start + 360 : mid - start
 	return mid <= end
 
-#define POLAR_TO_CART_X(R,T) ((R) * sin(T))
-#define POLAR_TO_CART_Y(R,T) ((R) * cos(T))
+#define POLAR_TO_BYOND_X(R,T) ((R) * sin(T))
+#define POLAR_TO_BYOND_Y(R,T) ((R) * cos(T))
 
 /proc/polar2turf(x, y, z, angle, distance)
-	var/x_offset = POLAR_TO_CART_X(distance, angle)
-	var/y_offset = POLAR_TO_CART_Y(distance, angle)
+	var/x_offset = POLAR_TO_BYOND_X(distance, angle)
+	var/y_offset = POLAR_TO_BYOND_Y(distance, angle)
 	return locate(CEILING(x + x_offset), CEILING(y + y_offset), z)
 
 /proc/get_turf_from_angle(x, y, z, angle, ideal_distance)

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -144,6 +144,8 @@
 		lum_g = 1
 		lum_b = 1
 
+#define POLAR_TO_CART_X(R,T) ((R) * cos(T))
+#define POLAR_TO_CART_Y(R,T) ((R) * sin(T))
 #define DETERMINANT(A_X,A_Y,B_X,B_Y) ((A_X)*(B_Y) - (A_Y)*(B_X))
 #define MINMAX(NUM) ((NUM) < 0 ? -round(-(NUM)) : round(NUM))
 #define ARBITRARY_NUMBER 10
@@ -196,9 +198,9 @@
 	limit_b_y = MINMAX(limit_b_y)
 
 #undef ARBITRARY_NUMBER
-#undef POLAR_TO_CART_X
-#undef POLAR_TO_CART_Y
 #undef MINMAX
+#undef POLAR_TO_CART_Y
+#undef POLAR_TO_CART_X
 
 /datum/light_source/proc/remove_lum(now = FALSE)
 	applied = FALSE


### PR DESCRIPTION
## Description of changes
BYOND and normal cartesian coordinates have different axes of rotation or whatever, it's weird. This resulted in the turret rewrite PR rotating lighting by 90 degrees.

## Why and what will this PR improve
Makes lighting go the correct direction.