### PR TITLE
Add define-gated profiling code and implement a few optimizations found with it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ tags
 # ignore built libs
 lib/*.dll
 lib/*.so
+/prof.dll
 
 # python
 *.pyc

--- a/code/_helpers/profiling.dm
+++ b/code/_helpers/profiling.dm
@@ -24,15 +24,6 @@
 	var/static/list/hidden_static_list_for_fun2 = list(); \
 	INIT_COST(hidden_static_list_for_fun1, hidden_static_list_for_fun2)
 
-#define INIT_COST_GLOBAL(costs, counting) \
-	INIT_COST_STATIC() \
-	if(GLOB){\
-		costs = hidden_static_list_for_fun1; \
-		counting = hidden_static_list_for_fun2 ; \
-	} \
-	_usage = TICK_USAGE;
-
-
 #define SET_COST(category) \
 	do { \
 		var/_cost = TICK_USAGE; \

--- a/code/_helpers/profiling.dm
+++ b/code/_helpers/profiling.dm
@@ -1,0 +1,125 @@
+#define STAT_ENTRY_TIME 1
+#define STAT_ENTRY_COUNT 2
+#define STAT_ENTRY_LENGTH 2
+
+
+#define STAT_START_STOPWATCH var/STAT_STOP_WATCH = TICK_USAGE
+#define STAT_STOP_STOPWATCH var/STAT_TIME = TICK_USAGE_TO_MS(STAT_STOP_WATCH)
+#define STAT_LOG_ENTRY(entrylist, entryname) \
+	var/list/STAT_ENTRY = entrylist[entryname] || (entrylist[entryname] = new /list(STAT_ENTRY_LENGTH));\
+	STAT_ENTRY[STAT_ENTRY_TIME] += STAT_TIME;\
+	STAT_ENTRY[STAT_ENTRY_COUNT] += 1;
+
+// Cost tracking macros, to be used in one proc. If you're using this raw you'll want to use global lists
+// If you don't you'll need another way of reading it
+#define INIT_COST(costs, counting) \
+	var/list/_costs = costs; \
+	var/list/_counting = counting; \
+	var/_usage = TICK_USAGE;
+
+// STATIC cost tracking macro. Uses static lists instead of the normal global ones
+// Good for debug stuff, and for running before globals init
+#define INIT_COST_STATIC(...) \
+	var/static/list/hidden_static_list_for_fun1 = list(); \
+	var/static/list/hidden_static_list_for_fun2 = list(); \
+	INIT_COST(hidden_static_list_for_fun1, hidden_static_list_for_fun2)
+
+#define INIT_COST_GLOBAL(costs, counting) \
+	INIT_COST_STATIC() \
+	if(GLOB){\
+		costs = hidden_static_list_for_fun1; \
+		counting = hidden_static_list_for_fun2 ; \
+	} \
+	_usage = TICK_USAGE;
+
+
+#define SET_COST(category) \
+	do { \
+		var/_cost = TICK_USAGE; \
+		_costs[category] += TICK_DELTA_TO_MS(_cost - _usage);\
+		_counting[category] += 1; \
+	} while(FALSE); \
+	_usage = TICK_USAGE;
+
+#define SET_COST_LINE(...) SET_COST("[__LINE__]")
+
+/// A quick helper for running the code as a statement and profiling its cost.
+/// For example, `SET_COST_STMT(var/x = do_work())`
+#define SET_COST_STMT(code...) ##code; SET_COST("[__LINE__] - [#code]")
+
+#define EXPORT_STATS_TO_JSON_LATER(filename, costs, counts) EXPORT_STATS_TO_FILE_LATER(filename, costs, counts, stat_tracking_export_to_json_later)
+#define EXPORT_STATS_TO_CSV_LATER(filename, costs, counts) EXPORT_STATS_TO_FILE_LATER(filename, costs, counts, stat_tracking_export_to_csv_later)
+
+#define EXPORT_STATS_TO_FILE_LATER(filename, costs, counts, proc) \
+	do { \
+		var/static/last_export = 0; \
+		if (world.time - last_export > 1.1 SECONDS) { \
+			last_export = world.time; \
+			/* spawn() is used here because this is often used to track init times, where timers act oddly. */ \
+			/* I was making timers and even after init times were complete, the timers didn't run :shrug: */ \
+			spawn (1 SECONDS) { \
+				##proc(filename, costs, counts); \
+			} \
+		} \
+	} while (FALSE); \
+	_usage = TICK_USAGE;
+
+/proc/cmp_generic_stat_item_time(list/A, list/B)
+	. = B[STAT_ENTRY_TIME] - A[STAT_ENTRY_TIME]
+	if (!.)
+		. = B[STAT_ENTRY_COUNT] - A[STAT_ENTRY_COUNT]
+
+// For use with the stopwatch defines
+/proc/render_stats(list/stats, user, sort = /proc/cmp_generic_stat_item_time)
+	sortTim(stats, sort, TRUE)
+
+	var/list/lines = list()
+
+	for (var/entry in stats)
+		var/list/data = stats[entry]
+		lines += "[entry] => [num2text(data[STAT_ENTRY_TIME], 10)]ms ([data[STAT_ENTRY_COUNT]]) (avg:[num2text(data[STAT_ENTRY_TIME]/(data[STAT_ENTRY_COUNT] || 1), 99)])"
+
+	if (user)
+		direct_output(user, browse("<ol><li>[lines.Join("</li><li>")]</li></ol>", "window=[url_encode("stats:[ref(stats)]")]"))
+
+	. = lines.Join("\n")
+
+// For use with the set_cost defines
+/proc/stat_tracking_export_to_json_later(filename, costs, counts)
+	var/list/output = list()
+
+	for (var/key in costs)
+		output[key] = list(
+			"cost" = costs[key],
+			"count" = counts[key],
+		)
+
+	to_file(file("[global.log_directory]/[filename]"), json_encode(output))
+
+/proc/stat_tracking_export_to_csv_later(filename, costs, counts)
+	var/list/output = list()
+
+	output += "key, cost, count"
+	for (var/key in costs)
+		output += "[replacetext(key, ",", "")], [costs[key]], [counts[key]]"
+
+	to_file(file("[global.log_directory]/[filename]"), output.Join("\n"))
+
+// Only enable this if you have a local copy of the byond-tracy DLL.
+// DO NOT commit the DLL to the repo.
+#ifdef TRACY_PROFILE
+/proc/prof_init()
+	var/lib
+
+	switch(world.system_type)
+		if(MS_WINDOWS) lib = "prof.dll"
+		if(UNIX) lib = "libprof.so"
+		else CRASH("unsupported platform")
+
+	var/init = call(lib, "init")()
+	if("0" != init) CRASH("[lib] init error: [init]")
+
+/world/New()
+	prof_init()
+	. = ..()
+#endif

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -123,7 +123,7 @@ var/global/list/areas = list()
 	for(var/direction in global.cardinal)
 		var/turf/adjacent_turf = get_step(T, direction)
 		if(adjacent_turf)
-			T.update_registrations_on_adjacent_area_change()
+			adjacent_turf.update_registrations_on_adjacent_area_change()
 
 	T.last_outside_check = OUTSIDE_UNCERTAIN
 	if(T.is_outside == OUTSIDE_AREA && T.is_outside() != old_outside)

--- a/code/game/objects/items/devices/scanners/mining.dm
+++ b/code/game/objects/items/devices/scanners/mining.dm
@@ -4,6 +4,10 @@
 	var/list/resources
 	var/surveyed = FALSE
 
+/datum/extension/buried_resources/New(datum/holder, list/resource_list)
+	resources = resource_list
+	..()
+
 /obj/item/scanner/mining
 	name = "ore detector"
 	desc = "A complex device used to locate ore deep underground."
@@ -20,10 +24,10 @@
 	. = ..()
 	to_chat(user,"A tiny indicator on the [src] shows it holds [survey_data] good explorer points.")
 
-/obj/item/scanner/mining/is_valid_scan_target(turf/simulated/T)
+/obj/item/scanner/mining/is_valid_scan_target(turf/T)
 	return istype(T)
 
-/obj/item/scanner/mining/scan(turf/simulated/T, mob/user)
+/obj/item/scanner/mining/scan(turf/T, mob/user)
 	scan_title = "Mineral scan data"
 	var/list/scan_results = mineral_scan_results(T)
 	if(!scan_data)
@@ -71,7 +75,7 @@
 	to_chat(user,"A tiny indicator on the [src] shows it holds [data] good explorer points.")
 
 //Returns list of two elements, 1 is text output, 2 is amoutn of GEP data
-/proc/mineral_scan_results(turf/simulated/target)
+/proc/mineral_scan_results(turf/target)
 	var/list/metals = list(
 		ORE_SURFACE = 0,
 		ORE_PRECIOUS = 0,

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/barren.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/barren.dm
@@ -20,6 +20,7 @@
 	exterior_atmos_temp = null //Generate me
 	level_generators    = list(
 		/datum/random_map/noise/exoplanet/barren,
+		/datum/random_map/noise/ore/rich,
 	)
 
 ////////////////////////////////////////////////////////////////////////////
@@ -85,9 +86,6 @@
 	)
 	possible_themes = list(
 		/datum/exoplanet_theme/mountains
-	)
-	map_generators = list(
-		/datum/random_map/noise/ore/rich
 	)
 
 /datum/map_template/planetoid/random/exoplanet/barren/get_spawn_weight()

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/chlorine.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/chlorine.dm
@@ -23,6 +23,7 @@
 	exterior_atmos_temp            = null
 	level_generators               = list(
 		/datum/random_map/noise/exoplanet/chlorine,
+		/datum/random_map/noise/ore/poor,
 	)
 
 ////////////////////////////////////////////////////////////////////////////
@@ -91,9 +92,6 @@
 	prefered_level_data_per_z  = list(
 		/datum/level_data/planetoid/exoplanet/chlorine,
 		/datum/level_data/planetoid/exoplanet/underground
-	)
-	map_generators = list(
-		/datum/random_map/noise/ore/poor,
 	)
 
 ////////////////////////////////////////////////////////////////////////////

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/desert.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/desert.dm
@@ -19,7 +19,8 @@
 	exterior_atmosphere = null
 	exterior_atmos_temp = null
 	level_generators    = list(
-		/datum/random_map/noise/exoplanet/desert
+		/datum/random_map/noise/exoplanet/desert,
+		/datum/random_map/noise/ore/rich,
 	)
 
 ////////////////////////////////////////////////////////////////////////////
@@ -98,9 +99,6 @@
 	prefered_level_data_per_z  = list(
 		/datum/level_data/planetoid/exoplanet/desert,
 		/datum/level_data/planetoid/exoplanet/underground
-	)
-	map_generators = list(
-		/datum/random_map/noise/ore/rich,
 	)
 
 ////////////////////////////////////////////////////////////////////////////

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/meat.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/meat.dm
@@ -20,6 +20,7 @@
 	exterior_atmos_temp = null
 	level_generators    = list(
 		/datum/random_map/noise/exoplanet/meat,
+		/datum/random_map/noise/ore/poor,
 	)
 
 ////////////////////////////////////////////////////////////////////////////
@@ -93,9 +94,6 @@
 	template_parent_type       = /datum/map_template/planetoid/random/exoplanet
 	level_data_type            = /datum/level_data/planetoid/exoplanet/meat
 	prefered_level_data_per_z  = null
-	map_generators = list(
-		/datum/random_map/noise/ore/poor
-	)
 
 /datum/map_template/planetoid/random/exoplanet/meat/get_spawn_weight()
 	return 10

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/shrouded.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/shrouded.dm
@@ -23,6 +23,7 @@
 	exterior_atmos_temp = null
 	level_generators    = list(
 		/datum/random_map/noise/exoplanet/shrouded,
+		/datum/random_map/noise/ore/poor,
 	)
 
 ////////////////////////////////////////////////////////////////////////////
@@ -90,9 +91,6 @@
 	prefered_level_data_per_z  = list(
 		/datum/level_data/planetoid/exoplanet/shrouded,
 		/datum/level_data/planetoid/exoplanet/underground
-	)
-	map_generators = list(
-		/datum/random_map/noise/ore/poor
 	)
 
 /datum/map_template/planetoid/random/exoplanet/shrouded/get_spawn_weight()

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/snow.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/snow.dm
@@ -20,6 +20,7 @@
 	exterior_atmos_temp = null
 	level_generators = list(
 		/datum/random_map/noise/exoplanet/snow,
+		/datum/random_map/noise/ore/poor,
 	)
 
 ////////////////////////////////////////////////////////////////////////////
@@ -84,10 +85,6 @@
 	)
 	//#TODO: Do weather stuff to init properly
 	//water_material  = null // Will prevent the weather system causing rainfall.
-
-	map_generators = list(
-		/datum/random_map/noise/ore/poor
-	)
 
 ////////////////////////////////////////////////////////////////////////////
 // Map Generator Surface

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/volcanic.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/volcanic.dm
@@ -23,6 +23,7 @@
 	exterior_atmos_temp = null
 	level_generators = list(
 		/datum/random_map/noise/exoplanet/volcanic,
+		/datum/random_map/noise/ore/filthy_rich,
 	)
 
 ////////////////////////////////////////////////////////////////////////////
@@ -101,9 +102,6 @@
 		/datum/exoplanet_theme/mountains = 100,
 		/datum/exoplanet_theme = 90,
 		/datum/exoplanet_theme/robotic_guardians = 10
-	)
-	map_generators = list(
-		/datum/random_map/noise/ore/filthy_rich
 	)
 
 ////////////////////////////////////////////////////////////////////////////

--- a/code/modules/maps/template_types/random_exoplanet/random_planet.dm
+++ b/code/modules/maps/template_types/random_exoplanet/random_planet.dm
@@ -42,8 +42,6 @@
 	var/max_themes = 2
 	///List of theme types that can be picked by this planet when generating.
 	var/list/possible_themes
-	///A list of /datum/random_map types to apply to every z-level of this planet, in order.
-	var/list/map_generators
 	///Bit flag of the only ruin tags that may be picked by this planet.
 	var/ruin_tags_whitelist
 	///Bit flag of the ruin tags that may never be picked for this planet.
@@ -96,9 +94,10 @@
 		log_debug("Setting up level [LD] ([LD.level_z]).")
 		//place level transition borders and etc, but skip level gen
 		LD.setup_level_data(TRUE)
-		//Apply our own level gen and the theme's level gen (rock walls, debris, buildings, etc..)
-		LD.apply_map_generators(length(theme_generators)? (map_generators | theme_generators) : map_generators) //#TODO: Theme generators should probably selectively apply to levels
-		//Let the level apply its level-specific generators (flora/fauna/grass)
+		//Apply the theme's level gen (rock walls, debris, buildings, etc..)
+		if(length(theme_generators))
+			LD.apply_map_generators(theme_generators) //#TODO: Theme generators should probably selectively apply to levels
+		//Let the level apply its level-specific generators (terrain/flora/fauna/grass)
 		LD.generate_level()
 
 ///Build a stack that's adjacent to the specified stack.

--- a/code/modules/random_map/noise/noise.dm
+++ b/code/modules/random_map/noise/noise.dm
@@ -116,57 +116,41 @@
 		subdivide(iteration, x+hsize, y+hsize, hsize)
 
 /datum/random_map/noise/cleanup()
-	var/is_not_border_left
-	var/is_not_border_right
 	for(var/i = 1 to smoothing_iterations)
 		var/list/next_map[limit_x*limit_y]
+		// simple box blur from http://amritamaz.net/blog/understanding-box-blur
+		// basically: we do two very fast one-dimensional blurs
+		var/total
+		for(var/y = 1 to limit_y) // for each row
+			// init window for x=1
+			// for a blur with a radius >1 use a for loop instead and replace 2 with the real count
+			var/cellone = map[TRANSLATE_COORD(1, y)]
+			var/celltwo = map[TRANSLATE_COORD(2, y)]
+			total = cellone + celltwo
+			next_map[TRANSLATE_COORD(1, y)] = round(total / 2)
+			// hardcoding x=2 also, to lower checks in the loop
+			// larger radius would need to also cover all x < 1 + blur_radius
+			total += map[TRANSLATE_COORD(3, y)]
+			next_map[TRANSLATE_COORD(2, y)] = round(total / 3)
+			for(var/x = 3 to limit_x-1) // should technically be 2 + blur_radius to limit_x - blur_radius
+				total -= map[TRANSLATE_COORD(x-2, y)] // x - blur_radius - 1
+				total += map[TRANSLATE_COORD(x+1, y)] // x + blur_radius
+				next_map[TRANSLATE_COORD(x, y)] = round(total / 3) // should technically be 2*blur_radius+1
+		// now do the same in the x axis
 		for(var/x = 1 to limit_x)
-			for(var/y = 1 to limit_y)
-				var/current_cell = TRANSLATE_COORD(x,y)
-				next_map[current_cell] = map[current_cell]
-				var/val_count = 1
-				var/total = map[current_cell]
-
-				is_not_border_left = (x != 1)
-				is_not_border_right = (x != limit_x)
-
-				// Center row. Center value's already been done above.
-				if (is_not_border_left)
-					total += map[TRANSLATE_COORD(x - 1, y)]
-					++val_count
-				if (is_not_border_right)
-					total += map[TRANSLATE_COORD(x + 1, y)]
-					++val_count
-
-				if (y != 1) // top row
-					total += map[TRANSLATE_COORD(x, y - 1)]
-					++val_count
-					if (is_not_border_left)
-						total += map[TRANSLATE_COORD(x - 1, y - 1)]
-						++val_count
-					if (is_not_border_right)
-						total += map[TRANSLATE_COORD(x + 1, y - 1)]
-						++val_count
-
-				if (y != limit_y) // bottom row
-					total += map[TRANSLATE_COORD(x, y + 1)]
-					++val_count
-					if (is_not_border_left)
-						total += map[TRANSLATE_COORD(x - 1, y + 1)]
-						++val_count
-					if (is_not_border_right)
-						total += map[TRANSLATE_COORD(x + 1, y + 1)]
-						++val_count
-
-				total = round(total/val_count)
-
-				if(abs(map[current_cell]-total) <= cell_smooth_amt)
-					map[current_cell] = total
-				else if(map[current_cell] < total)
-					map[current_cell]+=cell_smooth_amt
-				else if(map[current_cell] < total)
-					map[current_cell]-=cell_smooth_amt
-				map[current_cell] = max(0,min(cell_range,map[current_cell]))
+			// see comments above
+			var/cellone = map[TRANSLATE_COORD(x, 1)]
+			var/celltwo = map[TRANSLATE_COORD(x, 2)]
+			total = cellone + celltwo
+			next_map[TRANSLATE_COORD(x, 1)] = round(total / 2)
+			// hardcoding x=2 also, to lower checks in the loop
+			// larger radius would need to also cover all x < 1 + blur_radius
+			total += map[TRANSLATE_COORD(x, 3)]
+			next_map[TRANSLATE_COORD(x, 2)] = round(total / 3)
+			for(var/y = 3 to limit_y-1)
+				total -= map[TRANSLATE_COORD(x, y-2)]
+				total += map[TRANSLATE_COORD(x, y+1)]
+				next_map[TRANSLATE_COORD(x, y)] = round(total / 3)
 		map = next_map
 
 	if(smooth_single_tiles)

--- a/code/modules/random_map/noise/noise.dm
+++ b/code/modules/random_map/noise/noise.dm
@@ -154,16 +154,17 @@
 		map = next_map
 
 	if(smooth_single_tiles)
-		var/list/buddies = list()
+		var/lonely
 		for(var/x in 1 to limit_x - 1)
 			for(var/y in 1 to limit_y - 1)
 				var/mapcell = get_map_cell(x,y)
-				var/list/neighbors = get_neighbors(x, y)
-				buddies.Cut()
+				var/list/neighbors = get_neighbors(x, y, TRUE)
+				lonely = TRUE
 				for(var/cell in neighbors)
-					if(noise2value(map[cell]) == noise2value(map[mapcell]))
-						buddies |= cell
-				if(!length(buddies))
+					if(get_appropriate_path(map[cell]) == get_appropriate_path(map[mapcell]))
+						lonely = FALSE
+						break
+				if(lonely)
 					map[mapcell] = map[pick(neighbors)]
 
 /datum/random_map/noise/proc/get_neighbors(x, y, include_diagonals)

--- a/code/modules/random_map/noise/ore.dm
+++ b/code/modules/random_map/noise/ore.dm
@@ -70,25 +70,27 @@
 		return 1
 
 /datum/random_map/noise/ore/apply_to_turf(var/x,var/y)
+	. = list()
 
 	var/tx = ((origin_x-1)+x)*chunk_size
 	var/ty = ((origin_y-1)+y)*chunk_size
 
+	for(var/T in range(locate(tx, ty, origin_z)))
 	for(var/i=0,i<chunk_size,i++)
 		for(var/j=0,j<chunk_size,j++)
 			var/turf/T = locate(tx+j, ty+i, origin_z)
 			if(!istype(T))
 				continue
 
-			LAZYADD(., T)
+			. += T
 
 			CHECK_TICK
-			var/datum/extension/buried_resources/resources = get_or_create_extension(T, /datum/extension/buried_resources)
-			LAZYINITLIST(resources.resources)
+			var/list/resources
+			LAZYINITLIST(resources)
 
 			for(var/val in common_resources)
 				var/list/ranges = common_resources[val]
-				resources.resources[val] = rand(ranges[1], ranges[2])
+				resources[val] = rand(ranges[1], ranges[2])
 
 			var/tmp_cell
 			TRANSLATE_AND_VERIFY_COORD(x, y)
@@ -103,7 +105,8 @@
 
 			for(var/val in spawning)
 				var/list/ranges = spawning[val]
-				resources.resources[val] = rand(ranges[1], ranges[2])
+				resources[val] = rand(ranges[1], ranges[2])
+			set_extension(T, /datum/extension/buried_resources, resources)
 
 /datum/random_map/noise/ore/get_map_char(var/value)
 	if(value < rare_val)

--- a/code/modules/random_map/noise/ore.dm
+++ b/code/modules/random_map/noise/ore.dm
@@ -37,7 +37,7 @@
 /datum/random_map/noise/ore/New(var/tx, var/ty, var/tz, var/tlx, var/tly, var/do_not_apply, var/do_not_announce, var/used_area)
 	rare_val = cell_range * rare_val
 	deep_val = cell_range * deep_val
-	..(tx, ty, tz, (tlx / chunk_size), (tly / chunk_size), do_not_apply, do_not_announce)
+	..(tx / chunk_size, ty / chunk_size, tz, (tlx / chunk_size), (tly / chunk_size), do_not_apply, do_not_announce)
 
 /datum/random_map/noise/ore/check_map_sanity()
 
@@ -123,7 +123,7 @@
 /datum/random_map/noise/ore/rich
 	deep_val = 0.7
 	rare_val = 0.5
-	
+
 /datum/random_map/noise/ore/poor
 	deep_val = 0.8
 	rare_val = 0.7

--- a/maps/planets_testing/planets_testing.dm
+++ b/maps/planets_testing/planets_testing.dm
@@ -1,7 +1,5 @@
 #if !defined(USING_MAP_DATUM)
 
-	#include "planets_testing_define.dm"
-
 	//Include Static Planet
 	#include "../planets/test_planet/test_planet.dm"
 

--- a/nebula.dme
+++ b/nebula.dme
@@ -3570,6 +3570,7 @@
 #include "maps\ministation\ministation_define.dm"
 #include "maps\modpack_testing\modpack_testing_define.dm"
 #include "maps\nexus\nexus_define.dm"
+#include "maps\planets_testing\planets_testing_define.dm"
 #include "maps\random_ruins\exoplanet_ruins\crashed_pod\crashed_pod.dm"
 #include "maps\random_ruins\exoplanet_ruins\datacapsule\datacapsule.dm"
 #include "maps\random_ruins\exoplanet_ruins\deserted_lab\deserted_lab.dm"

--- a/nebula.dme
+++ b/nebula.dme
@@ -133,6 +133,7 @@
 #include "code\_helpers\mobs.dm"
 #include "code\_helpers\names.dm"
 #include "code\_helpers\overmap.dm"
+#include "code\_helpers\profiling.dm"
 #include "code\_helpers\radio.dm"
 #include "code\_helpers\sanitize_values.dm"
 #include "code\_helpers\storage.dm"


### PR DESCRIPTION
## Description of changes
The profiling code is set up to support BYOND-Tracy and TG's (relatively old/outdated at this point?) profiler macros.

Aside from that, the optimizations:
- Fixes noisemap smoothing passes being wasted.
- Replaces the naive blur/smoothing implementation with one found at http://amritamaz.net/blog/understanding-box-blur
- Fixes the adjacent area registration update proc being called on the same turf five times, instead of on the adjacent ones.
- Makes it so that the buried_resources extension isn't initialized as soon as it's created.
- Fixes the ore noisemap being placed at 32, 32 instead of 8, 8.
- Merges `map_generators` into `level_generators` to fix an ordering issue with ore noisemaps being overwritten by exoplanet terrain noisemaps.
- Moves the include for `planet_testing_define.dm` out of the map and into the DME, as is standard. (TODO: document this.)
- Optimize `smooth_single_tiles` in noisemap and make it check path instead of value. Doesn't currently work but I'm not sure it did before.

## Why and what will this PR improve
Profiling support code just makes my life easier, instead of reapplying the same stash I can just have a local copy of the byond-tracy dll and then enable it with the define.
In my testing it was roughly 3-4 seconds added to init per random exoplanet z-level, with ~8 or so taking 32 seconds; doubling their height made init take ~60 seconds. 3-4 seconds per 255x255 z-level seems pretty good to me!

## Changelog
:cl:
bugfix: Some exoplanet terrain should be generated more smoothly, as intended.
/:cl: