### PR TITLE
Fix infinite transition loop next to two edges

### DIFF
--- a/code/modules/multiz/turf_mimic_edge.dm
+++ b/code/modules/multiz/turf_mimic_edge.dm
@@ -286,13 +286,13 @@
 	var/new_y = AM.y
 
 	//Get the position inside the destination level's bounds to teleport the thing to
-	if(T.x <= LDsrc.level_inner_min_x)
+	if(T.x < LDsrc.level_inner_min_x)
 		new_x = LDdst.level_inner_max_x
-	else if (T.x >= LDsrc.level_inner_max_x)
+	else if (T.x > LDsrc.level_inner_max_x)
 		new_x = LDdst.level_inner_min_x
-	else if (T.y <= LDsrc.level_inner_min_y)
+	else if (T.y < LDsrc.level_inner_min_y)
 		new_y = LDdst.level_inner_max_y
-	else if (T.y >= LDsrc.level_inner_max_y)
+	else if (T.y > LDsrc.level_inner_max_y)
 		new_y = LDdst.level_inner_min_y
 	else
 		return //If we're teleporting into the same spot just quit early


### PR DESCRIPTION
## Description of changes
A check used `<=` and `>=` instead of `<` and `>`, resulting in an infinite loop if you crossed a world edge in a corner, i.e. while adjacent to a second edge.

## Why and what will this PR improve
Fixes an occasional CI fail in planet testing due to a mob crossing a world edge. I also encountered it a few times in local testing.