### PR TITLE
Fix storage items handling pixel offsets

### DIFF
--- a/code/game/objects/items/weapons/storage/storage_ui/default.dm
+++ b/code/game/objects/items/weapons/storage/storage_ui/default.dm
@@ -235,8 +235,7 @@
 		storage_start.overlays += stored_continue
 		storage_start.overlays += stored_end
 
-		O.reset_offsets()
-		O.screen_loc = "LEFT+[SCREEN_LOC_MOD_FIRST]:[round((startpoint+endpoint)/2)+2-O.pixel_x],BOTTOM+[SCREEN_LOC_MOD_SECOND]:[SCREEN_LOC_MOD_DIVIDED-O.pixel_y]"
+		O.screen_loc = "LEFT+[SCREEN_LOC_MOD_FIRST]:[round((startpoint+endpoint)/2)+2],BOTTOM+[SCREEN_LOC_MOD_SECOND]:[SCREEN_LOC_MOD_DIVIDED]"
 		O.maptext = ""
 		O.hud_layerise()
 


### PR DESCRIPTION
## Description of changes
Removes an erroneous reset_offsets() call that broke trays.
Removes some code that overcorrected for pixel offsets when setting screen_loc, inadvertently breaking it where it worked before. (Pixel offsets don't affect screen items, it's why this isn't an issue with the inventory.)
## Why and what will this PR improve
Fixes trays, prevents items in storage from having a pixel offset when they shouldn't.