### PR TITLE
Add modcomp diskreader component

### DIFF
--- a/code/__defines/computers.dm
+++ b/code/__defines/computers.dm
@@ -74,4 +74,5 @@
 #define OS_FILE_NO_WRITE   -5
 #define OS_HARDDRIVE_SPACE -6
 #define OS_NETWORK_ERROR   -7
-#define OS_BAD_NAME        -8 
+#define OS_BAD_NAME        -8
+#define OS_BAD_TYPE        -9 // File type is unsupported on this hardware.

--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -176,3 +176,4 @@ var/global/defer_powernet_rebuild = 0      // True if net rebuild will be called
 #define  PART_SCANNER  	/obj/item/stock_parts/computer/scanner							// One of several optional scanner attachments.
 #define  PART_D_SLOT	/obj/item/stock_parts/computer/drive_slot				// Portable drive slot.
 #define  PART_MSTICK	/obj/item/stock_parts/computer/charge_stick_slot		// Charge-slot component for transactions /w charge sticks.
+#define  PART_DSKSLOT	/obj/item/stock_parts/computer/data_disk_drive			// Temporary modcomp version of the disk reader component.

--- a/code/datums/extensions/assembly/assembly_interaction.dm
+++ b/code/datums/extensions/assembly/assembly_interaction.dm
@@ -72,6 +72,15 @@
 		drive_slot.insert_drive(I, user)
 		return TRUE
 
+	if(istype(W, /obj/item/disk))
+		var/obj/item/disk/disk = W
+		var/obj/item/stock_parts/computer/data_disk_drive/disk_drive = get_component(PART_DSKSLOT)
+		if(!disk_drive)
+			to_chat(user, SPAN_WARNING("You try to insert [disk] into [holder], but it does not have a disk slot installed."))
+			return TRUE
+		disk_drive.insert_disk(disk, user)
+		return TRUE
+
 	if(istype(W, /obj/item/paper))
 		var/obj/item/paper/paper = W
 		if(paper.info)

--- a/code/game/objects/items/weapons/tech_disks.dm
+++ b/code/game/objects/items/weapons/tech_disks.dm
@@ -50,7 +50,8 @@
 	if(!F || (F.read_only && !force))
 		return FALSE
 	free_blocks = clamp(round(free_blocks + F.block_size), 0, block_capacity)
-	qdel(LAZYACCESS(stored_files, name))
+	// do not qdel; should be GC'd once it has no references anyway
+	F.holder = null
 	LAZYREMOVE(stored_files, name)
 	return TRUE
 

--- a/code/modules/modular_computers/file_system/programs/generic/file_manager.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/file_manager.dm
@@ -361,7 +361,7 @@
 			return
 
 		if(F)
-			current_disk.save_file(F.filename, current_directory, newtext, null, accesses, user)
+			current_disk.save_file(F.filename, current_directory, newtext, null, accesses, user, F.type)
 			return TOPIC_REFRESH
 
 	if(href_list["PRG_printfile"])

--- a/code/modules/modular_computers/hardware/disk_slot.dm
+++ b/code/modules/modular_computers/hardware/disk_slot.dm
@@ -1,0 +1,108 @@
+/obj/item/stock_parts/computer/data_disk_drive
+	name = "data disk slot"
+	desc = "Slot that allows this computer to accept data disks."
+	power_usage = 10 //W
+	critical = 0
+	icon_state = "cardreader"
+	hardware_size = 1
+	origin_tech = "{'programming':2}"
+	usage_flags = PROGRAM_ALL
+	external_slot = TRUE
+	material = /decl/material/solid/metal/steel
+
+	var/obj/item/disk/stored_disk = null
+	var/mount_name
+
+/obj/item/stock_parts/computer/data_disk_drive/diagnostics()
+	. = ..()
+	. += "[name] status: [stored_disk ? "Disk Inserted" : "Disk Not Present"]\n"
+
+/obj/item/stock_parts/computer/data_disk_drive/proc/verb_eject_disk()
+	set name = "Remove Disk"
+	set category = "Object"
+	set src in view(1)
+
+	if(!CanPhysicallyInteract(usr))
+		to_chat(usr, "<span class='warning'>You can't reach it.</span>")
+		return
+
+	var/obj/item/stock_parts/computer/data_disk_drive/device = src
+	if (!istype(device))
+		device = locate() in src
+
+	if(!device.stored_disk)
+		if(usr)
+			to_chat(usr, "There is no drive in \the [src].")
+		return
+
+	device.eject_disk(usr)
+
+/obj/item/stock_parts/computer/data_disk_drive/proc/eject_disk(mob/user)
+	if(!stored_disk)
+		return FALSE
+
+	if(user)
+		to_chat(user, "You remove [stored_disk] from [src].")
+		user.put_in_hands(stored_disk)
+	else
+		dropInto(loc)
+	stored_disk = null
+
+	loc.verbs -= /obj/item/stock_parts/computer/data_disk_drive/proc/verb_eject_disk
+	return TRUE
+
+/obj/item/stock_parts/computer/data_disk_drive/proc/insert_disk(obj/item/disk/new_disk, mob/user)
+	if(!istype(new_disk))
+		return FALSE
+
+	if(stored_disk)
+		to_chat(user, "You try to insert [new_disk] into [src], but its data disk slot is occupied.")
+		return FALSE
+
+	if(user && !user.try_unequip(new_disk, src))
+		return FALSE
+
+	stored_disk = new_disk
+	to_chat(user, "You insert [new_disk] into [src].")
+	if(isobj(loc))
+		loc.verbs |= /obj/item/stock_parts/computer/data_disk_drive/proc/verb_eject_disk
+	return TRUE
+
+/obj/item/stock_parts/computer/data_disk_drive/proc/mount_filesystem(datum/extension/interactive/os/os)
+	return os?.mount_storage(/datum/file_storage/disk/datadisk, "data", FALSE)
+
+/obj/item/stock_parts/computer/data_disk_drive/do_after_install(atom/device, loud)
+	var/datum/extension/interactive/os/os = get_extension(device, /datum/extension/interactive/os)
+	if(!os?.on)
+		return FALSE
+
+	var/datum/file_storage/new_storage = mount_filesystem(os)
+	if(new_storage)
+		mount_name = new_storage.root_name
+		if(loud)
+			os.visible_notification("Mounted data disk as filesystem with root directory '[new_storage.root_name]'.")
+		return TRUE
+	else
+		if(loud)
+			os.visible_error("Failed to mount data disk. Disk may be non-functional.")
+		return FALSE
+
+/obj/item/stock_parts/computer/data_disk_drive/do_before_uninstall(atom/device, loud)
+	var/datum/extension/interactive/os/os = get_extension(device, /datum/extension/interactive/os)
+	if(!os)
+		return FALSE
+
+	os.unmount_storage(mount_name)
+
+/obj/item/stock_parts/computer/data_disk_drive/attackby(obj/item/disk/new_disk, mob/user)
+	if(!istype(new_disk))
+		return
+	insert_disk(new_disk, user)
+	return TRUE
+
+/obj/item/stock_parts/computer/data_disk_drive/Destroy()
+	if(loc)
+		loc.verbs -= /obj/item/stock_parts/computer/data_disk_drive/proc/verb_eject_disk
+	if(stored_disk)
+		QDEL_NULL(stored_disk)
+	return ..()

--- a/code/modules/modular_computers/hardware/disk_slot.dm
+++ b/code/modules/modular_computers/hardware/disk_slot.dm
@@ -23,12 +23,15 @@
 	set src in view(1)
 
 	if(!CanPhysicallyInteract(usr))
-		to_chat(usr, "<span class='warning'>You can't reach it.</span>")
+		to_chat(usr, SPAN_WARNING("You can't reach it."))
 		return
 
 	var/obj/item/stock_parts/computer/data_disk_drive/device = src
 	if (!istype(device))
 		device = locate() in src
+
+	if(!istype(device))
+		return
 
 	if(!device.stored_disk)
 		if(usr)

--- a/code/modules/modular_computers/hardware/drive_slot.dm
+++ b/code/modules/modular_computers/hardware/drive_slot.dm
@@ -68,12 +68,15 @@
 		loc.verbs |= /obj/item/stock_parts/computer/drive_slot/proc/verb_eject_drive
 	return TRUE
 
+/obj/item/stock_parts/computer/drive_slot/proc/mount_filesystem(datum/extension/interactive/os/os)
+	return os?.mount_storage(/datum/file_storage/disk/removable, "media", FALSE)
+
 /obj/item/stock_parts/computer/drive_slot/do_after_install(atom/device, loud)
 	var/datum/extension/interactive/os/os = get_extension(device, /datum/extension/interactive/os)
-	if(!os)
+	if(!os?.on) // if it's off, it'll be handled on boot
 		return FALSE
 
-	var/datum/file_storage/new_storage = os.mount_storage(/datum/file_storage/disk/removable, "media", FALSE)
+	var/datum/file_storage/new_storage = mount_filesystem(os)
 	if(new_storage)
 		mount_name = new_storage.root_name
 		if(loud)

--- a/nebula.dme
+++ b/nebula.dme
@@ -2709,6 +2709,7 @@
 #include "code\modules\modular_computers\hardware\battery_module.dm"
 #include "code\modules\modular_computers\hardware\card_slot.dm"
 #include "code\modules\modular_computers\hardware\charge_stick_slot.dm"
+#include "code\modules\modular_computers\hardware\disk_slot.dm"
 #include "code\modules\modular_computers\hardware\drive_slot.dm"
 #include "code\modules\modular_computers\hardware\hard_drive.dm"
 #include "code\modules\modular_computers\hardware\lan_port.dm"


### PR DESCRIPTION
## Description of changes
Adds a temporary computer part variant of the disk reader machine component. Works a lot like the hard drive slot component. Doesn't support directories or non-data files.


TODO: Merge this into the main disk reader component after #3193 and some later changes are in.

## Why and what will this PR improve
It's good to have a way to interact with these files. (Notably, it handles access checks, so if this makes something like survey points able to be hacked, we can either do that or add an integrity check (like having the file uid as metadata) to make sure it hasn't been tampered with.

## Authorship
Me.

## Changelog
:cl:
add: Added a computer disk reader component that allows you to read and write disk contents.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->