### PR TITLE
Fix job items replaced by loadout being deleted

### DIFF
--- a/code/datums/inventory_slots/_inventory_slot.dm
+++ b/code/datums/inventory_slots/_inventory_slot.dm
@@ -134,7 +134,7 @@
 	return TRUE
 
 /datum/inventory_slot/proc/can_equip_to_slot(var/mob/user, var/obj/item/prop, var/disable_warning, var/ignore_equipped)
-	return ((!_holding || (ignore_equipped && _holding == prop)) && prop && slot_id && prop_can_fit_in_slot(prop))
+	return ((!_holding || (ignore_equipped || _holding == prop)) && prop && slot_id && prop_can_fit_in_slot(prop))
 
 /datum/inventory_slot/proc/prop_can_fit_in_slot(var/obj/item/prop)
 	return (isnull(requires_slot_flags) || (requires_slot_flags & prop.slot_flags))

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -475,15 +475,8 @@
 	if(!inv_slot)
 		return FALSE
 
-	var/already_equipped = inv_slot.get_equipped_item()
-	if(!ignore_equipped || already_equipped != src)
-		if(already_equipped)
-			if(!force)
-				return FALSE
-			inv_slot.clear_slot()
-			qdel(already_equipped)
-
-		if(!inv_slot.is_accessible(M, src, disable_warning))
+	if(!force)
+		if(!ignore_equipped && !inv_slot.is_accessible(M, src, disable_warning))
 			return FALSE
 
 	if(!inv_slot.can_equip_to_slot(M, src, disable_warning, ignore_equipped))

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -23,7 +23,7 @@
 	SHOULD_CALL_PARENT(FALSE)
 	return TRUE //make sure this is never picked up
 
-/obj/item/storage/internal/mob_can_equip()
+/obj/item/storage/internal/mob_can_equip(mob/M, slot, disable_warning = FALSE, force = FALSE, ignore_equipped = FALSE)
 	return FALSE //make sure this is never picked up
 
 //Helper procs to cleanly implement internal storages - storage items that provide inventory slots for other items.

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -427,7 +427,6 @@ var/global/list/gear_datums = list()
 		. = item
 		if(!old_item)
 			return
-		wearer.unequip(old_item)
 		if(old_item.type != item.type)
 			place_in_storage_or_drop(wearer, old_item)
 		else

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -30,7 +30,7 @@
 	var/mob/living/carbon/human/H = M
 	var/obj/item/gloves = M.get_equipped_item(slot_gloves_str)
 	if(slot == slot_gloves_str && istype(H) && gloves)
-		if(!ignore_equipped || gloves != src)
+		if(!ignore_equipped && gloves != src)
 			check_ring = gloves
 			if(!istype(check_ring) || !check_ring.can_fit_under_gloves || !H.try_unequip(check_ring, src))
 				if(!disable_warning)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -68,7 +68,7 @@
 	var/mob/living/carbon/human/H = M
 	if(slot == slot_shoes_str && istype(H))
 		check_shoes = H.get_equipped_item(slot_shoes_str)
-		if(!ignore_equipped || check_shoes != src)
+		if(!ignore_equipped && check_shoes != src)
 			if(istype(check_shoes) && (!check_shoes.can_fit_under_magboots || !H.try_unequip(check_shoes, src)))
 				if(!disable_warning)
 					to_chat(M, SPAN_WARNING("You are unable to wear \the [src] as \the [check_shoes] are in the way."))

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -18,7 +18,7 @@
 /mob/proc/equip_to_slot_if_possible(obj/item/W, slot, del_on_fail = 0, disable_warning = 0, redraw_mob = 1, force = FALSE, delete_old_item = TRUE)
 	if(!istype(W) || !slot)
 		return FALSE
-	. = (canUnEquip(W) && can_equip_anything_to_slot(slot) && has_organ_for_slot(slot) && W.mob_can_equip(src, slot, disable_warning, force))
+	. = (canUnEquip(W) && can_equip_anything_to_slot(slot) && has_organ_for_slot(slot) && W.mob_can_equip(src, slot, disable_warning, force, ignore_equipped = TRUE))
 	if(.)
 		equip_to_slot(W, slot, redraw_mob, delete_old_item = delete_old_item) //This proc should not ever fail.
 	else if(del_on_fail)

--- a/mods/species/ascent/items/rig.dm
+++ b/mods/species/ascent/items/rig.dm
@@ -228,7 +228,7 @@
 		/obj/item/rig_module/maneuvering_jets
 	)
 
-/obj/item/rig/mantid/mob_can_equip(var/mob/M, var/slot)
+/obj/item/rig/mantid/mob_can_equip(var/mob/M, var/slot, ignore_equipped = FALSE)
 	. = ..()
 	if(. && slot == slot_back_str)
 		var/mob/living/carbon/human/H = M

--- a/mods/species/bayliens/skrell/gear/gear_mask.dm
+++ b/mods/species/bayliens/skrell/gear/gear_mask.dm
@@ -10,7 +10,7 @@
 	flags_inv = 0
 	body_parts_covered = 0
 
-/obj/item/clothing/mask/gas/skrell/mob_can_equip(mob/living/M, slot, disable_warning = 0)
+/obj/item/clothing/mask/gas/skrell/mob_can_equip(mob/living/M, slot, disable_warning = 0, ignore_equipped = FALSE)
 	. = ..()
 	if(. && M?.get_bodytype()?.name != BODYTYPE_SKRELL)
 		return FALSE


### PR DESCRIPTION
## Description of changes
Removes some duplicate item deletion code that ran in `mob_can_equip`, which should ideally be pure even with the force var set.

## Why and what will this PR improve
Fixes a runtime on dev when a character is loaded/spawns in with loadout items selected.