### PR TITLE
Fix firemode issues in staging

### DIFF
--- a/code/modules/mechs/equipment/combat_projectile.dm
+++ b/code/modules/mechs/equipment/combat_projectile.dm
@@ -13,7 +13,7 @@
 	. = ..()
 	if(. && holding)
 		var/obj/item/gun/M = holding
-		return M.switch_firemodes(user)
+		return M.switch_firemodes()
 
 /obj/item/gun/projectile/automatic/get_hardpoint_status_value()
 	if(!isnull(ammo_magazine))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -92,9 +92,11 @@
 	var/last_fire_message_time
 
 /obj/item/gun/Initialize()
-	. = ..()
+	// must have firemodes initialized prior to any update_icon_calls
+	// including reconsider_single_icon(), which is done in ..()
 	for(var/i in 1 to firemodes.len)
 		firemodes[i] = new /datum/firemode(src, firemodes[i])
+	. = ..()
 	if(isnull(scoped_accuracy))
 		scoped_accuracy = accuracy
 	if(scope_zoom)
@@ -628,9 +630,9 @@
 		. = 1
 
 /obj/item/gun/attack_self(mob/user)
-	var/datum/firemode/new_mode = switch_firemodes(user)
+	var/datum/firemode/new_mode = switch_firemodes()
 	if(prob(20) && !user.skill_check(SKILL_WEAPONS, SKILL_BASIC))
-		new_mode = switch_firemodes(user)
+		new_mode = switch_firemodes()
 	if(new_mode)
 		to_chat(user, "<span class='notice'>\The [src] is now set to [new_mode.name].</span>")
 

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -54,12 +54,10 @@
 /obj/item/gun/energy/gun/nuclear/on_update_icon()
 	indicator_color = get_charge_color()
 	. = ..()
-	var/list/new_overlays = list()
 	var/reactor_icon = fail_counter ? "danger" : "clean"
-	new_overlays += mutable_appearance(icon, "[get_world_inventory_state()]_[reactor_icon]")
+	add_overlay("[get_world_inventory_state()]_[reactor_icon]")
 	var/datum/firemode/current_mode = firemodes[sel_mode]
-	new_overlays += mutable_appearance(icon, "[get_world_inventory_state()]_[current_mode.name]")
-	overlays += new_overlays
+	add_overlay("[get_world_inventory_state()]_[current_mode.name]")
 
 /obj/item/gun/energy/gun/nuclear/get_charge_state(var/initial_state)
 	return "[initial_state]_charge"


### PR DESCRIPTION
## Description of changes
`switch_firemode` formerly didn't take an argument, making passing a useless `user` argument harmless. Now, it takes the firemode index, which makes that problematic. Replaces all uses of `switch_firemode(user)` with `switch_firemode()`, which should be identical.
`reconsider_single_icon()` could result in a gun triggering an icon update prior to its firemodes being created, which sometimes (always on BYOND 515, occasionally on 514?) causes a runtime error.
Makes nuclear energy guns use managed overlays so they don't flash and disappear.

## Why and what will this PR improve
Fixes several runtimes and issues with gun firemodes in r3 staging. Initial firemode state should be more sane, including icon updates that depend on it.