### PR TITLE
Reworking pulse procs.

### DIFF
--- a/code/_helpers/medical_scans.dm
+++ b/code/_helpers/medical_scans.dm
@@ -25,7 +25,7 @@
 		else if(H.status_flags & FAKEDEATH)
 			pulse_result = 0
 		else
-			pulse_result = H.get_pulse(GETPULSE_TOOL)
+			pulse_result = H.get_pulse_as_string(GETPULSE_TOOL)
 	else
 		pulse_result = -1
 

--- a/code/datums/repositories/crew/binary.dm
+++ b/code/datums/repositories/crew/binary.dm
@@ -4,7 +4,7 @@
 	if(!H.isSynthetic() && H.should_have_organ(BP_HEART))
 		var/obj/item/organ/internal/heart/O = H.get_organ(BP_HEART, /obj/item/organ/internal/heart)
 		if (!O || !BP_IS_PROSTHETIC(O)) // Don't make medical freak out over prosthetic hearts
-			var/pulse = H.pulse()
+			var/pulse = H.get_pulse()
 			if(pulse == PULSE_NONE || pulse == PULSE_THREADY)
 				crew_data["alert"] = TRUE
 		if(H.get_blood_oxygenation() < BLOOD_VOLUME_SAFE)

--- a/code/datums/repositories/crew/vital.dm
+++ b/code/datums/repositories/crew/vital.dm
@@ -6,8 +6,8 @@
 	if(!H.isSynthetic() && H.should_have_organ(BP_HEART))
 		var/obj/item/organ/internal/heart/O = H.get_organ(BP_HEART, /obj/item/organ/internal/heart)
 		if (!O || !BP_IS_PROSTHETIC(O)) // Don't make medical freak out over prosthetic hearts
-			crew_data["true_pulse"] = H.pulse()
-			crew_data["pulse"] = H.get_pulse(GETPULSE_TOOL)
+			crew_data["true_pulse"] = H.get_pulse()
+			crew_data["pulse"] = H.get_pulse_as_string(GETPULSE_TOOL)
 			switch(crew_data["true_pulse"])
 				if(PULSE_NONE)
 					crew_data["pulse_span"] = "bad"

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -94,7 +94,7 @@
 	icon_state = "table2-idle"
 	if(ishuman(victim))
 		var/mob/living/carbon/human/H = victim
-		if(H.pulse())
+		if(H.get_pulse())
 			icon_state = "table2-active"
 
 /obj/machinery/optable/Process()

--- a/code/game/machinery/vitals_monitor.dm
+++ b/code/game/machinery/vitals_monitor.dm
@@ -26,7 +26,7 @@
 			to_chat(user, SPAN_NOTICE("It's unpowered."))
 			return
 		to_chat(user, SPAN_NOTICE("Vitals of [victim]:"))
-		to_chat(user, SPAN_NOTICE("Pulse: [victim.get_pulse(GETPULSE_TOOL)]"))
+		to_chat(user, SPAN_NOTICE("Pulse: [victim.get_pulse_as_string(GETPULSE_TOOL)]"))
 
 		var/brain_activity = "none"
 		var/obj/item/organ/internal/brain = GET_INTERNAL_ORGAN(victim, BP_BRAIN)
@@ -61,7 +61,7 @@
 		update_use_power(POWER_USE_IDLE)
 	if(victim)
 		update_icon()
-	if(beep && victim && victim.pulse())
+	if(beep && victim && victim.get_pulse())
 		playsound(src, 'sound/machines/quiet_beep.ogg', 40)
 
 /obj/machinery/vitals_monitor/handle_mouse_drop(var/atom/over, var/mob/user)
@@ -84,7 +84,7 @@
 	if(!victim)
 		return
 
-	switch(victim.pulse())
+	switch(victim.get_pulse())
 		if(PULSE_NONE)
 			overlays += image(icon, icon_state = "pulse_flatline")
 			overlays += image(icon, icon_state = "pulse_warning")

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -117,13 +117,13 @@
 		if(H.status_flags & FAKEDEATH)
 			pulse_result = 0
 		else
-			pulse_result = H.get_pulse(GETPULSE_TOOL)
+			pulse_result = H.get_pulse_as_string(GETPULSE_TOOL)
 		pulse_result = "[pulse_result]bpm"
-		if(H.pulse() == PULSE_NONE)
+		if(H.get_pulse() == PULSE_NONE)
 			pulse_result = "<span class='scan_danger'>[pulse_result]</span>"
-		else if(H.pulse() < PULSE_NORM)
+		else if(H.get_pulse() < PULSE_NORM)
 			pulse_result = "<span class='scan_notice'>[pulse_result]</span>"
-		else if(H.pulse() > PULSE_NORM)
+		else if(H.get_pulse() > PULSE_NORM)
 			pulse_result = "<span class='scan_warning'>[pulse_result]</span>"
 	else
 		pulse_result = "<span class='scan_danger'>ERROR - Nonstandard biology</span>"

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -34,30 +34,37 @@
 		holder = null
 	return ..()
 
-/obj/item/assembly/proc/activate()									//What the device does when turned on
+/// What the device does when turned on
+/obj/item/assembly/proc/activate()
 	return
 
-/obj/item/assembly/proc/pulsed(var/radio = 0)						//Called when another assembly acts on this one, var/radio will determine where it came from for wire calcs
+/// Called when another assembly acts on this one, var/radio will determine where it came from for wire calcs
+/obj/item/assembly/proc/pulsed(var/radio = 0)
 	return
 
-/obj/item/assembly/proc/get_pulse(var/radio = 0)						//Called when this device attempts to act on another device, var/radio determines if it was sent via radio or direct
+/// Called when this device attempts to act on another device, var/radio determines if it was sent via radio or direct
+/obj/item/assembly/proc/pulse_device(var/radio = 0)
 	return
 
-/obj/item/assembly/proc/toggle_secure()								//Code that has to happen when the assembly is un\secured goes here
+/// Code that has to happen when the assembly is un\secured goes here
+/obj/item/assembly/proc/toggle_secure()
 	return
 
-/obj/item/assembly/proc/attach_assembly(var/obj/A, var/mob/user)	//Called when an assembly is attacked by another
+/// Called when an assembly is attacked by another
+/obj/item/assembly/proc/attach_assembly(var/obj/A, var/mob/user)
 	return
 
-/obj/item/assembly/proc/process_cooldown()							//Called via spawn(10) to have it count down the cooldown var
+/// Called via spawn(10) to have it count down the cooldown var
+/obj/item/assembly/proc/process_cooldown()
 	return
 
-/obj/item/assembly/proc/holder_movement()							//Called when the holder is moved
+/// Called when the holder is moved
+/obj/item/assembly/proc/holder_movement()
 	return
 
-/obj/item/assembly/interact(mob/user)				//Called when attack_self is called
+/// Called when attack_self is called
+/obj/item/assembly/interact(mob/user)
 	return
-
 
 /obj/item/assembly/process_cooldown()
 	cooldown--
@@ -75,7 +82,7 @@
 	return 1
 
 
-/obj/item/assembly/get_pulse(var/radio = 0)
+/obj/item/assembly/pulse_device(var/radio = 0)
 	if(holder && (wires & WIRE_PULSE))
 		holder.process_activation(src, 1, 0)
 	if(holder && (wires & WIRE_PULSE_SPECIAL))

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -40,7 +40,7 @@
 /obj/item/assembly/proc/pulsed(var/radio = 0)						//Called when another assembly acts on this one, var/radio will determine where it came from for wire calcs
 	return
 
-/obj/item/assembly/proc/pulse(var/radio = 0)						//Called when this device attempts to act on another device, var/radio determines if it was sent via radio or direct
+/obj/item/assembly/proc/get_pulse(var/radio = 0)						//Called when this device attempts to act on another device, var/radio determines if it was sent via radio or direct
 	return
 
 /obj/item/assembly/proc/toggle_secure()								//Code that has to happen when the assembly is un\secured goes here
@@ -75,7 +75,7 @@
 	return 1
 
 
-/obj/item/assembly/pulse(var/radio = 0)
+/obj/item/assembly/get_pulse(var/radio = 0)
 	if(holder && (wires & WIRE_PULSE))
 		holder.process_activation(src, 1, 0)
 	if(holder && (wires & WIRE_PULSE_SPECIAL))

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -111,7 +111,7 @@
 	if((ismob(enterer) && !isliving(enterer))) // Observers and their ilk don't count even if visible
 		return
 
-	get_pulse(0)
+	pulse_device(0)
 	if(!holder)
 		visible_message("[html_icon(src)] *beep* *beep*")
 	cooldown = 2

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -111,7 +111,7 @@
 	if((ismob(enterer) && !isliving(enterer))) // Observers and their ilk don't count even if visible
 		return
 
-	pulse(0)
+	get_pulse(0)
 	if(!holder)
 		visible_message("[html_icon(src)] *beep* *beep*")
 	cooldown = 2

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -51,7 +51,7 @@
 	reset_plane_and_layer()
 	armed = 0
 	update_icon()
-	get_pulse(0)
+	pulse_device(0)
 
 /obj/item/assembly/mousetrap/proc/toggle_arming(var/mob/user)
 	if((MUTATION_CLUMSY in user.mutations) && prob(50))

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -51,7 +51,7 @@
 	reset_plane_and_layer()
 	armed = 0
 	update_icon()
-	pulse(0)
+	get_pulse(0)
 
 /obj/item/assembly/mousetrap/proc/toggle_arming(var/mob/user)
 	if((MUTATION_CLUMSY in user.mutations) && prob(50))

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -51,7 +51,7 @@
 //		if(scanning && cooldown <= 0)
 //			mainloc.visible_message("[html_icon(src)] *boop* *boop*", "*boop* *boop*")
 	if((!holder && !secured)||(!scanning)||(cooldown > 0))	return 0
-	pulse(0)
+	get_pulse(0)
 	if(!holder)
 		mainloc.visible_message("[html_icon(src)] *beep* *beep*", "*beep* *beep*")
 	cooldown = 2

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -51,7 +51,7 @@
 //		if(scanning && cooldown <= 0)
 //			mainloc.visible_message("[html_icon(src)] *boop* *boop*", "*boop* *boop*")
 	if((!holder && !secured)||(!scanning)||(cooldown > 0))	return 0
-	get_pulse(0)
+	pulse_device(0)
 	if(!holder)
 		mainloc.visible_message("[html_icon(src)] *beep* *beep*", "*beep* *beep*")
 	cooldown = 2

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -102,7 +102,7 @@
 	radio_connection.post_signal(src, signal)
 
 
-/obj/item/assembly/signaler/get_pulse(var/radio = 0)
+/obj/item/assembly/signaler/pulse_device(var/radio = 0)
 	if(src.connected && src.wires)
 		connected.Pulse(src)
 	else if(holder)
@@ -116,7 +116,7 @@
 	if(!signal)	return 0
 	if(signal.encryption != code)	return 0
 	if(!(src.wires & WIRE_RADIO_RECEIVE))	return 0
-	get_pulse(1)
+	pulse_device(1)
 	if(!holder)
 		audible_message(SPAN_NOTICE("[html_icon(src)] *beep* *beep*"), null, 3)
 

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -102,7 +102,7 @@
 	radio_connection.post_signal(src, signal)
 
 
-/obj/item/assembly/signaler/pulse(var/radio = 0)
+/obj/item/assembly/signaler/get_pulse(var/radio = 0)
 	if(src.connected && src.wires)
 		connected.Pulse(src)
 	else if(holder)
@@ -116,7 +116,7 @@
 	if(!signal)	return 0
 	if(signal.encryption != code)	return 0
 	if(!(src.wires & WIRE_RADIO_RECEIVE))	return 0
-	pulse(1)
+	get_pulse(1)
 	if(!holder)
 		audible_message(SPAN_NOTICE("[html_icon(src)] *beep* *beep*"), null, 3)
 

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -41,7 +41,7 @@
 
 /obj/item/assembly/timer/timer_end()
 	if(!secured)	return 0
-	pulse(0)
+	get_pulse(0)
 	if(!holder)
 		visible_message("[html_icon(src)] *beep* *beep*", "*beep* *beep*")
 	cooldown = 2

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -41,7 +41,7 @@
 
 /obj/item/assembly/timer/timer_end()
 	if(!secured)	return 0
-	get_pulse(0)
+	pulse_device(0)
 	if(!holder)
 		visible_message("[html_icon(src)] *beep* *beep*", "*beep* *beep*")
 	cooldown = 2

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -27,7 +27,7 @@
 		T.visible_message("[html_icon(src)] beeps, \"Activation message is '[recorded]'.\"")
 	else
 		if(findtext(msg, recorded))
-			get_pulse(0)
+			pulse_device(0)
 
 /obj/item/assembly/voice/activate()
 	if(secured)

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -27,7 +27,7 @@
 		T.visible_message("[html_icon(src)] beeps, \"Activation message is '[recorded]'.\"")
 	else
 		if(findtext(msg, recorded))
-			pulse(0)
+			get_pulse(0)
 
 /obj/item/assembly/voice/activate()
 	if(secured)

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -122,7 +122,7 @@
 	else
 		new expandType(T, min(health, 30))
 
-/obj/effect/blob/proc/get_pulse(var/forceLeft, var/list/dirs)
+/obj/effect/blob/proc/do_pulse(var/forceLeft, var/list/dirs)
 	set waitfor = FALSE
 	sleep(4)
 	var/pushDir = pick(dirs)
@@ -133,7 +133,7 @@
 			expand(T)
 		return
 	if(forceLeft)
-		B.get_pulse(forceLeft - 1, dirs)
+		B.do_pulse(forceLeft - 1, dirs)
 
 /obj/effect/blob/proc/attack_living(var/mob/L)
 	if(!L)
@@ -272,7 +272,7 @@ regen() will cover update_icon() for this proc
 	process_core_health()
 	regen()
 	for(var/I in 1 to times_to_pulse)
-		get_pulse(20, global.alldirs)
+		do_pulse(20, global.alldirs)
 	attempt_attack(global.alldirs)
 	attempt_attack(global.alldirs)
 	blob_may_process = 1

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -122,7 +122,7 @@
 	else
 		new expandType(T, min(health, 30))
 
-/obj/effect/blob/proc/pulse(var/forceLeft, var/list/dirs)
+/obj/effect/blob/proc/get_pulse(var/forceLeft, var/list/dirs)
 	set waitfor = FALSE
 	sleep(4)
 	var/pushDir = pick(dirs)
@@ -133,7 +133,7 @@
 			expand(T)
 		return
 	if(forceLeft)
-		B.pulse(forceLeft - 1, dirs)
+		B.get_pulse(forceLeft - 1, dirs)
 
 /obj/effect/blob/proc/attack_living(var/mob/L)
 	if(!L)
@@ -272,7 +272,7 @@ regen() will cover update_icon() for this proc
 	process_core_health()
 	regen()
 	for(var/I in 1 to times_to_pulse)
-		pulse(20, global.alldirs)
+		get_pulse(20, global.alldirs)
 	attempt_attack(global.alldirs)
 	attempt_attack(global.alldirs)
 	blob_may_process = 1

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -66,7 +66,7 @@
 			spawn(0)
 				user.visible_message("<b>\The [user]</b> checks \the [src]'s pulse.", "You check \the [src]'s pulse.")
 				if(do_after(user, 15, src))
-					if(pulse() == PULSE_NONE)
+					if(get_pulse() == PULSE_NONE)
 						to_chat(user, "<span class='deadsay'>[use_He] [use_has] no pulse.</span>")
 					else
 						to_chat(user, "<span class='deadsay'>[use_He] [use_has] a pulse!</span>")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -854,48 +854,6 @@
 	return FALSE
 
 
-// Similar to get_pulse, but returns only integer numbers instead of text.
-/mob/living/carbon/human/proc/get_pulse_as_number()
-	var/obj/item/organ/internal/heart/heart_organ = get_organ(BP_HEART, /obj/item/organ/internal/heart)
-	if(!heart_organ)
-		return 0
-
-	switch(pulse())
-		if(PULSE_NONE)
-			return 0
-		if(PULSE_SLOW)
-			return rand(40, 60)
-		if(PULSE_NORM)
-			return rand(60, 90)
-		if(PULSE_FAST)
-			return rand(90, 120)
-		if(PULSE_2FAST)
-			return rand(120, 160)
-		if(PULSE_THREADY)
-			return PULSE_MAX_BPM
-	return 0
-
-//generates realistic-ish pulse output based on preset levels as text
-/mob/living/carbon/human/proc/get_pulse(var/method)	//method 0 is for hands, 1 is for machines, more accurate
-	var/obj/item/organ/internal/heart/heart_organ = get_organ(BP_HEART, /obj/item/organ/internal/heart)
-	if(!heart_organ)
-		// No heart, no pulse
-		return "0"
-	if(heart_organ.open && !method)
-		// Heart is a open type (?) and cannot be checked unless it's a machine
-		return "muddled and unclear; you can't seem to find a vein"
-
-	var/bpm = get_pulse_as_number()
-	if(bpm >= PULSE_MAX_BPM)
-		return method ? ">[PULSE_MAX_BPM]" : "extremely weak and fast, patient's artery feels like a thread"
-
-	return "[method ? bpm : bpm + rand(-10, 10)]"
-// output for machines ^	 ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ output for people
-
-/mob/living/carbon/human/proc/pulse()
-	var/obj/item/organ/internal/heart/H = get_organ(BP_HEART, /obj/item/organ/internal/heart)
-	return H ? H.pulse : PULSE_NONE
-
 /mob/living/carbon/human/can_devour(atom/movable/victim, var/silent = FALSE)
 
 	if(!should_have_organ(BP_STOMACH))
@@ -949,7 +907,7 @@
 	. = ..()
 	var/obj/item/organ/internal/heart/H = get_organ(BP_HEART, /obj/item/organ/internal/heart)
 	if(H && !H.open)
-		. *= (!BP_IS_PROSTHETIC(H)) ? pulse()/PULSE_NORM : 1.5
+		. *= (!BP_IS_PROSTHETIC(H)) ? get_pulse()/PULSE_NORM : 1.5
 
 /mob/living/carbon/human/need_breathe()
 	if(mNobreath in mutations)

--- a/code/modules/mob/living/carbon/human/human_verbs.dm
+++ b/code/modules/mob/living/carbon/human/human_verbs.dm
@@ -184,7 +184,7 @@
 			SPAN_NOTICE("\The [usr] begins counting [G.his] pulse."), \
 			SPAN_NOTICE("You begin counting your pulse."))
 
-	if(pulse())
+	if(get_pulse())
 		to_chat(usr, "<span class='notice'>[self ? "You have a" : "[src] has a"] pulse! Counting...</span>")
 	else
 		to_chat(usr, "<span class='danger'>[src] has no pulse!</span>")//it is REALLY UNLIKELY that a dead person would check his own pulse
@@ -192,7 +192,7 @@
 
 	to_chat(usr, "You must[self ? "" : " both"] remain still until counting is finished.")
 	if(do_mob(usr, src, 60))
-		var/message = "<span class='notice'>[self ? "Your" : "[src]'s"] pulse is [src.get_pulse(GETPULSE_HAND)].</span>"
+		var/message = "<span class='notice'>[self ? "Your" : "[src]'s"] pulse is [src.get_pulse_as_string(GETPULSE_HAND)].</span>"
 		to_chat(usr, message)
 	else
 		to_chat(usr, "<span class='warning'>You failed to check the pulse. Try again.</span>")

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -860,7 +860,7 @@
 		else if(is_asystole())
 			holder.icon_state = "flatline"
 		else
-			holder.icon_state = "[pulse()]"
+			holder.icon_state = "[get_pulse()]"
 		hud_list[HEALTH_HUD] = holder
 
 	if (BITTEST(hud_updateflag, LIFE_HUD) && hud_list[LIFE_HUD])

--- a/code/modules/mob/living/living_pulse.dm
+++ b/code/modules/mob/living/living_pulse.dm
@@ -1,0 +1,42 @@
+/mob/living/proc/get_pulse()
+	if(stat == DEAD || isSynthetic())
+		return PULSE_NONE
+	if(!should_have_organ(BP_HEART))
+		return PULSE_NORM
+	var/obj/item/organ/internal/heart/heart = get_organ(BP_HEART, /obj/item/organ/internal/heart)
+	if(heart)
+		return heart.pulse
+	return PULSE_NONE
+
+//generates realistic-ish pulse output based on preset levels as text
+/mob/living/proc/get_pulse_as_string(var/method)	//method 0 is for hands, 1 is for machines, more accurate
+	if(should_have_organ(BP_HEART))
+		var/obj/item/organ/internal/heart/heart_organ = get_organ(BP_HEART, /obj/item/organ/internal/heart)
+		if(!heart_organ)
+			// No heart, no pulse
+			return "0"
+		if(heart_organ.open && !method)
+			// Heart is a open type (?) and cannot be checked unless it's a machine
+			return "muddled and unclear; you can't seem to find a vein"
+	var/bpm = get_pulse_as_number()
+	if(bpm >= PULSE_MAX_BPM)
+		return method ? ">[PULSE_MAX_BPM]" : "extremely weak and fast, patient's artery feels like a thread"
+	return "[method ? bpm : bpm + rand(-10, 10)]"
+// output for machines ^	 ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ output for people
+
+// Similar to get_pulse, but returns only integer numbers instead of text.
+/mob/living/proc/get_pulse_as_number()
+	switch(get_pulse())
+		if(PULSE_NONE)
+			return 0
+		if(PULSE_SLOW)
+			return rand(40, 60)
+		if(PULSE_NORM)
+			return rand(60, 90)
+		if(PULSE_FAST)
+			return rand(90, 120)
+		if(PULSE_2FAST)
+			return rand(120, 160)
+		if(PULSE_THREADY)
+			return PULSE_MAX_BPM
+	return 0

--- a/code/modules/organs/external/diagnostics.dm
+++ b/code/modules/organs/external/diagnostics.dm
@@ -171,7 +171,7 @@
 		if(gutsound)
 			sounds += gutsound
 	if(!sounds.len)
-		if(owner.pulse())
+		if(owner.get_pulse())
 			sounds += "faint pulse"
 	return sounds
 

--- a/nebula.dme
+++ b/nebula.dme
@@ -2347,6 +2347,7 @@
 #include "code\modules\mob\living\living_maneuvers.dm"
 #include "code\modules\mob\living\living_organs.dm"
 #include "code\modules\mob\living\living_powers.dm"
+#include "code\modules\mob\living\living_pulse.dm"
 #include "code\modules\mob\living\living_status.dm"
 #include "code\modules\mob\living\login.dm"
 #include "code\modules\mob\living\logout.dm"


### PR DESCRIPTION
## Description of changes
- Renamed get_pulse() to get_pulse_as_string().
- Renamed pulse() to get_pulse().
- Moved pulse procs down to /mob/living.
- May also fix issues with mobs having pulses after death by explicitly checking stat.

## Why and what will this PR improve
Makes it easier to generalize code.

## Authorship
Myself.

## Changelog
Nothing player-facing.