### PR TITLE
Converting several instances of simple mob AI into datums.

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -264,7 +264,7 @@
 			set_stat(UNCONSCIOUS)
 		else
 			set_stat(CONSCIOUS)
-		return 1
+		return TRUE
 
 /mob/living/proc/handle_disabilities()
 	handle_impaired_vision()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -849,7 +849,7 @@ default behaviour is:
 	return nutrition
 
 /mob/living/proc/adjust_nutrition(var/amt)
-	set_nutrition(nutrition + amt)
+	set_nutrition(get_nutrition() + amt)
 
 /mob/living/proc/get_max_hydration()
 	return 500
@@ -861,7 +861,7 @@ default behaviour is:
 	hydration = clamp(amt, 0, get_max_hydration())
 
 /mob/living/proc/adjust_hydration(var/amt)
-	set_hydration(hydration + amt)
+	set_hydration(get_hydration() + amt)
 
 /mob/living/proc/has_chemical_effect(var/chem, var/threshold_over, var/threshold_under)
 	var/val = GET_CHEMICAL_EFFECT(src, chem)

--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -18,6 +18,7 @@
 	natural_armor = list(
 		ARMOR_MELEE = ARMOR_MELEE_KNIVES
 		)
+	ai = /datum/ai/crab
 
 	meat_amount =   3
 	skin_material = /decl/material/solid/skin/insect
@@ -30,18 +31,18 @@
 		hat_offsets = list("[SOUTH]" = list(-1, -10))
 	. = ..()
 
-/mob/living/simple_animal/crab/Life()
+/datum/ai/crab
+	expected_type = /mob/living/simple_animal/crab
+
+/datum/ai/crab/do_process(time_elapsed)
 	. = ..()
-	if(!.)
-		return FALSE
-	//CRAB movement
-	if(!ckey && !stat)
-		if(isturf(src.loc) && !resting && !buckled)		//This is so it only moves if it's not inside a closet, gentics machine, etc.
-			turns_since_move++
-			if(turns_since_move >= turns_per_move)
-				Move(get_step(src,pick(4,8)))
-				turns_since_move = 0
-	update_icon()
+	var/mob/living/simple_animal/crab/crab = body
+	if(!isturf(crab.loc) || crab.resting || crab.buckled)
+		return
+	crab.turns_since_move++
+	if(crab.turns_since_move >= crab.turns_per_move)
+		crab.Move(get_step(crab,pick(4,8)))
+		crab.turns_since_move = 0
 
 //COFFEE! SQUEEEEEEEEE!
 /mob/living/simple_animal/crab/Coffee

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -20,7 +20,42 @@
 	skin_material = /decl/material/solid/skin/goat
 	skin_amount = 8
 
+	ai = /datum/ai/goat
+
 	var/datum/reagents/udder = null
+
+/datum/ai/goat
+	expected_type = /mob/living/simple_animal/hostile/retaliate/goat
+
+/datum/ai/goat/do_process(time_elapsed)
+	. = ..()
+	var/mob/living/simple_animal/hostile/retaliate/goat/goat = body
+
+	//chance to go crazy and start wacking stuff
+	if(!length(goat.enemies) && prob(1))
+		goat.Retaliate()
+
+	if(length(goat.enemies) && prob(10))
+		goat.enemies = list()
+		goat.LoseTarget()
+		goat.visible_message(SPAN_NOTICE("\The [goat] calms down."))
+
+	var/obj/effect/vine/SV = locate() in goat.loc
+	if(SV && prob(60))
+		goat.visible_message(SPAN_NOTICE("\The [goat] eats the plants."))
+		SV.die_off(1)
+		var/obj/machinery/portable_atmospherics/hydroponics/soil/invisible/SP = locate() in goat.loc
+		if(SP)
+			qdel(SP)
+		else if(prob(20))
+			goat.visible_message(SPAN_NOTICE("\The [goat] chews on the plants."))
+		return
+
+	if(!LAZYLEN(goat.grabbed_by))
+		var/obj/effect/vine/food = locate(/obj/effect/vine) in oview(5,goat.loc)
+		if(food)
+			var/step = get_step_to(goat, food, 0)
+			goat.Move(step)
 
 /mob/living/simple_animal/hostile/retaliate/goat/Initialize()
 	. = ..()
@@ -30,40 +65,10 @@
 	QDEL_NULL(udder)
 	. = ..()
 
-/mob/living/simple_animal/hostile/retaliate/goat/Life()
+/mob/living/simple_animal/hostile/retaliate/goat/handle_regular_status_updates()
 	. = ..()
-	if(.)
-		//chance to go crazy and start wacking stuff
-		if(!enemies.len && prob(1))
-			Retaliate()
-
-		if(enemies.len && prob(10))
-			enemies = list()
-			LoseTarget()
-			src.visible_message("<span class='notice'>\The [src] calms down.</span>")
-
-		if(stat == CONSCIOUS)
-			if(udder && prob(5))
-				udder.add_reagent(/decl/material/liquid/drink/milk, rand(5, 10))
-
-		if(locate(/obj/effect/vine) in loc)
-			var/obj/effect/vine/SV = locate() in loc
-			if(prob(60))
-				src.visible_message("<span class='notice'>\The [src] eats the plants.</span>")
-				SV.die_off(1)
-				if(locate(/obj/machinery/portable_atmospherics/hydroponics/soil/invisible) in loc)
-					var/obj/machinery/portable_atmospherics/hydroponics/soil/invisible/SP = locate() in loc
-					qdel(SP)
-			else if(prob(20))
-				src.visible_message("<span class='notice'>\The [src] chews on the plants.</span>")
-			return
-
-		if(!LAZYLEN(grabbed_by))
-			var/obj/effect/vine/food
-			food = locate(/obj/effect/vine) in oview(5,loc)
-			if(food)
-				var/step = get_step_to(src, food, 0)
-				Move(step)
+	if(. && stat == CONSCIOUS && udder && prob(5))
+		udder.add_reagent(/decl/material/liquid/drink/milk, rand(5, 10))
 
 /mob/living/simple_animal/hostile/retaliate/goat/Retaliate()
 	..()
@@ -134,11 +139,9 @@
 		return TRUE
 	. = ..()
 
-/mob/living/simple_animal/cow/Life()
+/mob/living/simple_animal/cow/handle_regular_status_updates()
 	. = ..()
-	if(!.)
-		return FALSE
-	if(udder && prob(5))
+	if(. && udder && prob(5))
 		udder.add_reagent(/decl/material/liquid/drink/milk, rand(5, 10))
 
 /mob/living/simple_animal/cow/default_disarm_interaction(mob/user)

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -41,12 +41,13 @@
 		goat.visible_message(SPAN_NOTICE("\The [goat] calms down."))
 
 	var/obj/effect/vine/SV = locate() in goat.loc
-	if(SV && prob(60))
-		goat.visible_message(SPAN_NOTICE("\The [goat] eats the plants."))
-		SV.die_off(1)
-		var/obj/machinery/portable_atmospherics/hydroponics/soil/invisible/SP = locate() in goat.loc
-		if(SP)
-			qdel(SP)
+	if(SV)
+		if(prob(60))
+			goat.visible_message(SPAN_NOTICE("\The [goat] eats the plants."))
+			SV.die_off(1)
+			var/obj/machinery/portable_atmospherics/hydroponics/soil/invisible/SP = locate() in goat.loc
+			if(SP)
+				qdel(SP)
 		else if(prob(20))
 			goat.visible_message(SPAN_NOTICE("\The [goat] chews on the plants."))
 		return

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -32,31 +32,32 @@
 	skin_amount =   1
 	skin_material = /decl/material/solid/skin/fur
 
+	ai = /datum/ai/mouse
+
 	var/body_color //brown, gray and white, leave blank for random
 	var/splatted = FALSE
 
 /mob/living/simple_animal/mouse/get_dexterity(var/silent = FALSE)
 	return DEXTERITY_NONE // Mice are troll bait, give them no power.
 
-/mob/living/simple_animal/mouse/Life()
-	. = ..()
-	if(!.)
-		return FALSE
-	if(prob(speak_chance))
-		for(var/mob/M in view())
-			sound_to(M, 'sound/effects/mousesqueek.ogg')
+/datum/ai/mouse
+	expected_type = /mob/living/simple_animal/mouse
 
-	if(!ckey && stat == CONSCIOUS && prob(0.5))
-		set_stat(UNCONSCIOUS)
-		wander = 0
-		speak_chance = 0
-		//snuffles
-	else if(stat == UNCONSCIOUS)
-		if(ckey || prob(1))
-			set_stat(CONSCIOUS)
-			wander = 1
+/datum/ai/mouse/do_process()
+	..()
+	var/mob/living/simple_animal/mouse/mouse = body
+	if(prob(mouse.speak_chance))
+		playsound(mouse.loc, 'sound/effects/mousesqueek.ogg', 50)
+	if(mouse.stat == CONSCIOUS && prob(0.5))
+		mouse.set_stat(UNCONSCIOUS)
+		mouse.wander = 0
+		mouse.speak_chance = 0
+	else if(mouse.stat == UNCONSCIOUS)
+		if(prob(1))
+			mouse.set_stat(CONSCIOUS)
+			mouse.wander = 1
 		else if(prob(5))
-			INVOKE_ASYNC(src, .proc/audible_emote, "snuffles.")
+			INVOKE_ASYNC(mouse, /mob/living/simple_animal/proc/audible_emote, "snuffles.")
 
 /mob/living/simple_animal/mouse/Initialize()
 	verbs += /mob/living/proc/ventcrawl

--- a/code/modules/mob/living/simple_animal/friendly/possum.dm
+++ b/code/modules/mob/living/simple_animal/friendly/possum.dm
@@ -28,8 +28,6 @@
 	ai = /datum/ai/opossum
 	var/is_angry = FALSE
 
-	var/is_angry = FALSE
-
 /datum/ai/opossum
 	expected_type = /mob/living/simple_animal/opossum
 /datum/ai/opossum/do_process(time_elapsed)

--- a/code/modules/mob/living/simple_animal/friendly/possum.dm
+++ b/code/modules/mob/living/simple_animal/friendly/possum.dm
@@ -25,25 +25,30 @@
 	can_pull_size = ITEM_SIZE_SMALL
 	can_pull_mobs = MOB_PULL_SMALLER
 	holder_type = /obj/item/holder
+	ai = /datum/ai/opossum
+	var/is_angry = FALSE
 
 	var/is_angry = FALSE
 
-/mob/living/simple_animal/opossum/Life()
+/datum/ai/opossum
+	expected_type = /mob/living/simple_animal/opossum
+/datum/ai/opossum/do_process(time_elapsed)
 	. = ..()
-	if(. && !ckey && stat != DEAD && prob(1))
-		resting = (stat == UNCONSCIOUS)
-		if(!resting)
-			wander = initial(wander)
-			speak_chance = initial(speak_chance)
-			set_stat(CONSCIOUS)
-			if(prob(10))
-				is_angry = TRUE
-		else
-			wander = FALSE
-			speak_chance = 0
-			set_stat(UNCONSCIOUS)
-			is_angry = FALSE
-		update_icon()
+	if(!prob(1))
+		return
+	var/mob/living/simple_animal/opossum/poss = body
+	poss.resting = (poss.stat == UNCONSCIOUS)
+	if(poss.resting)
+		poss.wander = FALSE
+		poss.speak_chance = 0
+		poss.set_stat(UNCONSCIOUS)
+		poss.is_angry = FALSE
+	else
+		poss.wander = initial(poss.wander)
+		poss.speak_chance = initial(poss.speak_chance)
+		poss.set_stat(CONSCIOUS)
+		if(prob(10))
+			poss.is_angry = TRUE
 
 /mob/living/simple_animal/opossum/adjustBruteLoss(damage)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
@@ -28,7 +28,7 @@
 /datum/ai/commanded/do_process(time_elapsed)
 	..()
 	var/mob/living/simple_animal/hostile/commanded/com = body
-	while(com.command_buffer.len > 0)
+	while(com.command_buffer.len > 1)
 		var/mob/speaker = com.command_buffer[1]
 		var/text = com.command_buffer[2]
 		var/filtered_name = lowertext(html_decode(com.name))

--- a/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
@@ -3,6 +3,7 @@
 	stance = COMMANDED_STOP
 	natural_weapon = /obj/item/natural_weapon
 	density = FALSE
+	ai = /datum/ai/commanded
 	var/list/command_buffer = list()
 	var/list/known_commands = list("stay", "stop", "attack", "follow")
 	var/mob/master = null //undisputed master. Their commands hold ultimate sway and ultimate power.
@@ -21,27 +22,25 @@
 		command_buffer.Add(lowertext(html_decode(message)))
 	return 0
 
-/mob/living/simple_animal/hostile/commanded/Life()
-	. = ..()
-	if(!.)
-		return FALSE
-	while(command_buffer.len > 0)
-		var/mob/speaker = command_buffer[1]
-		var/text = command_buffer[2]
-		var/filtered_name = lowertext(html_decode(name))
+/datum/ai/commanded
+	expected_type = /mob/living/simple_animal/hostile/commanded
+
+/datum/ai/commanded/do_process(time_elapsed)
+	..()
+	var/mob/living/simple_animal/hostile/commanded/com = body
+	while(com.command_buffer.len > 0)
+		var/mob/speaker = com.command_buffer[1]
+		var/text = com.command_buffer[2]
+		var/filtered_name = lowertext(html_decode(com.name))
 		if(dd_hasprefix(text,filtered_name) || dd_hasprefix(text,"everyone") || dd_hasprefix(text, "everybody")) //in case somebody wants to command 8 bears at once.
 			var/substring = copytext(text,length(filtered_name)+1) //get rid of the name.
-			listen(speaker,substring)
-		command_buffer.Remove(command_buffer[1],command_buffer[2])
-	. = ..()
-	if(.)
-		switch(stance)
-			if(COMMANDED_FOLLOW)
-				follow_target()
-			if(COMMANDED_STOP)
-				commanded_stop()
-
-
+			com.listen(speaker,substring)
+		com.command_buffer.Remove(com.command_buffer[1],com.command_buffer[2])
+	switch(com.stance)
+		if(COMMANDED_FOLLOW)
+			com.follow_target()
+		if(COMMANDED_STOP)
+			com.commanded_stop()
 
 /mob/living/simple_animal/hostile/commanded/FindTarget(var/new_stance = HOSTILE_STANCE_ATTACK)
 	if(!allowed_targets.len)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
@@ -1,6 +1,6 @@
 
 /mob/living/simple_animal/hostile/retaliate/beast
-	var/hunger = 0
+	ai = /datum/ai/beast
 	var/list/prey = list()
 
 /mob/living/simple_animal/hostile/retaliate/beast/ListTargets(var/dist = 7)
@@ -12,34 +12,36 @@
 				var/mob/M = W.resolve()
 				if(M)
 					. |= M
-		else if(hunger > 500) //time to look for some food
+		else if(get_nutrition() < get_max_nutrition() * 0.75) //time to look for some food
 			for(var/mob/living/L in view(src, dist))
 				if(!attack_same && L.faction != faction)
 					prey |= weakref(L)
 
-/mob/living/simple_animal/hostile/retaliate/beast/Life()
-	. = ..()
-	if(!.)
-		return FALSE
-	hunger++
-	if(hunger < 100) //stop hunting when satiated
-		prey.Cut()
-	else if(stat == CONSCIOUS)
-		for(var/mob/living/simple_animal/S in range(src,1))
-			if(S == src)
-				continue
-			if(S.stat != DEAD)
-				continue
-			visible_message(SPAN_DANGER("\The [src] consumes the body of \the [S]!"))
-			var/turf/T = get_turf(S)
-			var/obj/item/remains/xeno/X = new(T)
-			X.desc += "These look like they belong to \a [S.name]."
-			hunger = max(0, hunger - 5*S.maxHealth)
-			if(prob(5))
-				S.gib()
-			else
-				qdel(S)
-			return
+/datum/ai/beast
+	expected_type = /mob/living/simple_animal/hostile/retaliate/beast
+
+/datum/ai/beast/do_process(time_elapsed)
+	var/mob/living/simple_animal/hostile/retaliate/beast/beast = body
+	var/nut = beast.get_nutrition()
+	var/max_nut = beast.get_max_nutrition()
+	if(nut > max_nut * 0.75 || beast.incapacitated())
+		beast.prey.Cut()
+		return
+	for(var/mob/living/simple_animal/S in range(beast,1))
+		if(S == beast)
+			continue
+		if(S.stat != DEAD)
+			continue
+		beast.visible_message(SPAN_DANGER("\The [beast] consumes the body of \the [S]!"))
+		var/turf/T = get_turf(S)
+		var/obj/item/remains/xeno/X = new(T)
+		X.desc += "These look like they belong to \a [S.name]."
+		beast.adjust_nutrition(5 * S.maxHealth)
+		if(prob(5))
+			S.gib()
+		else
+			qdel(S)
+		break
 
 /mob/living/simple_animal/proc/name_species()
 	set name = "Name Alien Species"

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
@@ -1,12 +1,16 @@
 
 /mob/living/simple_animal/hostile/retaliate/beast
 	ai = /datum/ai/beast
-	var/list/prey = list()
+	nutrition = 300
+	var/list/prey
+
+/mob/living/simple_animal/hostile/retaliate/beast/get_max_nutrition()
+	return 300
 
 /mob/living/simple_animal/hostile/retaliate/beast/ListTargets(var/dist = 7)
 	. = ..()
 	if(!length(.))
-		if(length(prey))
+		if(LAZYLEN(prey))
 			. = list()
 			for(var/weakref/W in prey)
 				var/mob/M = W.resolve()
@@ -15,7 +19,7 @@
 		else if(get_nutrition() < get_max_nutrition() * 0.75) //time to look for some food
 			for(var/mob/living/L in view(src, dist))
 				if(!attack_same && L.faction != faction)
-					prey |= weakref(L)
+					LAZYDISTINCTADD(prey, weakref(L))
 
 /datum/ai/beast
 	expected_type = /mob/living/simple_animal/hostile/retaliate/beast
@@ -25,7 +29,7 @@
 	var/nut = beast.get_nutrition()
 	var/max_nut = beast.get_max_nutrition()
 	if(nut > max_nut * 0.75 || beast.incapacitated())
-		beast.prey.Cut()
+		LAZYCLEARLIST(beast.prey)
 		return
 	for(var/mob/living/simple_animal/S in range(beast,1))
 		if(S == beast)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/giant_crab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/giant_crab.dm
@@ -24,11 +24,26 @@
 		ARMOR_BULLET = ARMOR_BALLISTIC_PISTOL
 		)
 	ability_cooldown = 2 MINUTES
+	ai = /datum/ai/giant_crab
+
 	var/mob/living/carbon/human/victim //the human we're grabbing
 	var/grab_duration = 3 //duration of disable in life ticks to simulate a grab
 	var/grab_damage = 6 //brute damage before reductions, per crab's life tick
 	var/list/grab_desc = list("thrashes", "squeezes", "crushes")
 	var/continue_grab_prob = 35 //probability that a successful grab will be extended by one life tick
+
+/datum/ai/giant_crab
+	expected_type = /mob/living/simple_animal/hostile/retaliate/giant_crab
+
+/datum/ai/giant_crab/do_process(time_elapsed)
+	. = ..()
+	var/mob/living/simple_animal/hostile/retaliate/giant_crab/crab = body
+	if((crab.health > crab.maxHealth / 1.5) && length(crab.enemies) && prob(10))
+		if(crab.victim)
+			crab.release_grab()
+		crab.enemies = list()
+		crab.LoseTarget()
+		crab.visible_message(SPAN_NOTICE("\The [crab] lowers its pincer."))
 
 /obj/item/natural_weapon/pincers/giant
 	force = 15
@@ -46,18 +61,6 @@
 	. = ..()
 	if(. && ishuman(user))
 		reflect_unarmed_damage(user, BRUTE, "armoured carapace")
-
-/mob/living/simple_animal/hostile/retaliate/giant_crab/Life()
-	. = ..()
-	if(!.)
-		return
-
-	if((health > maxHealth / 1.5) && enemies.len && prob(10))
-		if(victim)
-			release_grab()
-		enemies = list()
-		LoseTarget()
-		visible_message("<span class='notice'>\The [src] lowers its pincer.</span>")
 
 /mob/living/simple_animal/hostile/retaliate/giant_crab/do_delayed_life_action()
 	..()


### PR DESCRIPTION
## Description of changes
See title and commit messages.
Also slipped in some moving of udder reagent generation from `Life()` to `handle_regular_status_updates()`.

To test:
- [x]  goat
- [x] cow
- [x]  giant crab
- [x]  exoplanet beast
- [x]  commanded mob
- [x]  crab
- [x]  poss
- [x]  mouse
- [x]  spooder

## Why and what will this PR improve
Ideally all mob AI should be handled by AI datums in the future. This is a step towards that.

## Authorship
Myself.

## Changelog
Nothing player-facing.