### PR TITLE
Condensing some bodytemp handling on /mob/living.

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -55,15 +55,10 @@
 	//No need to update all of these procs if the guy is dead.
 	if(stat != DEAD && !is_in_stasis())
 		last_pain = null // Clear the last cached pain value so further getHalloss() calls won't use an old value.
-
 		//Organs and blood
 		handle_organs()
-		stabilize_body_temperature() //Body temperature adjusts itself (self-regulation)
-
 		handle_shock()
-
 		handle_pain()
-
 		handle_stamina()
 
 	if(!handle_some_updates())
@@ -362,42 +357,18 @@
 
 	return
 
-/mob/living/carbon/human/proc/stabilize_body_temperature()
-	// We produce heat naturally.
-	if (species.passive_temp_gain)
-		bodytemperature += species.passive_temp_gain
+/mob/living/carbon/human/get_bodytemperature_difference()
+	if (on_fire)
+		return 0 //too busy for pesky metabolic regulation
+	return ..()
 
+/mob/living/carbon/human/stabilize_body_temperature()
 	// Robolimbs cause overheating too.
 	if(robolimb_count)
 		bodytemperature += round(robolimb_count/2)
+	return ..()
 
-	if (species.body_temperature == null || isSynthetic())
-		return //this species doesn't have metabolic thermoregulation
-
-	var/body_temperature_difference = species.body_temperature - bodytemperature
-
-	if (abs(body_temperature_difference) < 0.5)
-		return //fuck this precision
-
-	if (on_fire)
-		return //too busy for pesky metabolic regulation
-
-	var/cold_1 = get_temperature_threshold(COLD_LEVEL_1)
-	var/heat_1 = get_temperature_threshold(HEAT_LEVEL_1)
-	if(bodytemperature < cold_1) //260.15 is 310.15 - 50, the temperature where you start to feel effects.
-		var/nut_remove = 10 * DEFAULT_HUNGER_FACTOR
-		if(nutrition >= nut_remove) //If we are very, very cold we'll use up quite a bit of nutriment to heat us up.
-			adjust_nutrition(-nut_remove)
-			bodytemperature += max((body_temperature_difference / BODYTEMP_AUTORECOVERY_DIVISOR), BODYTEMP_AUTORECOVERY_MINIMUM)
-	else if(cold_1 <= bodytemperature && bodytemperature <= heat_1)
-		bodytemperature += body_temperature_difference / BODYTEMP_AUTORECOVERY_DIVISOR
-	else if(bodytemperature > heat_1) //360.15 is 310.15 + 50, the temperature where you start to feel effects.
-		var/hyd_remove = 10 * DEFAULT_THIRST_FACTOR
-		if(hydration >= hyd_remove)
-			adjust_hydration(-hyd_remove)
-			bodytemperature += min((body_temperature_difference / BODYTEMP_AUTORECOVERY_DIVISOR), -BODYTEMP_AUTORECOVERY_MINIMUM)
-
-	//This proc returns a number made up of the flags for body parts which you are protected on. (such as HEAD, SLOT_UPPER_BODY, SLOT_LOWER_BODY, etc. See setup.dm for the full list)
+//This proc returns a number made up of the flags for body parts which you are protected on. (such as HEAD, SLOT_UPPER_BODY, SLOT_LOWER_BODY, etc. See setup.dm for the full list)
 /mob/living/carbon/human/proc/get_heat_protection_flags(temperature) //Temperature is the temperature you're being exposed to.
 	. = 0
 	//Handle normal clothing

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -24,6 +24,8 @@
 	if(stat != DEAD && !is_in_stasis())
 		handle_nutrition_and_hydration()
 		handle_immunity()
+		//Body temperature adjusts itself (self-regulation)
+		stabilize_body_temperature()
 
 	blinded = 0 // Placing this here just show how out of place it is.
 	// human/handle_regular_status_updates() needs a cleanup, as blindness should be handled in handle_disabilities()

--- a/code/modules/mob/living/living_bodytemp.dm
+++ b/code/modules/mob/living/living_bodytemp.dm
@@ -1,0 +1,43 @@
+/mob/living/proc/has_metabolic_thermoregulation()
+	if(isSynthetic())
+		return FALSE
+	var/decl/species/my_species = get_species()
+	if(my_species?.body_temperature == null)
+		return FALSE
+	return TRUE
+
+/mob/living/proc/get_bodytemperature_difference()
+	var/decl/species/my_species = get_species()
+	if(my_species)
+		return (my_species.body_temperature - bodytemperature)
+	return 0
+
+/mob/living/proc/stabilize_body_temperature()
+
+	// This species doesn't have metabolic thermoregulation and can't adjust towards a baseline.
+	if(!has_metabolic_thermoregulation())
+		return
+
+	// We may produce heat naturally.
+	var/decl/species/my_species = get_species()
+	if(my_species?.passive_temp_gain)
+		bodytemperature += my_species.passive_temp_gain
+
+	var/body_temperature_difference = get_bodytemperature_difference()
+	if (abs(body_temperature_difference) < 0.5)
+		return //fuck this precision
+
+	var/cold_1 = get_temperature_threshold(COLD_LEVEL_1)
+	var/heat_1 = get_temperature_threshold(HEAT_LEVEL_1)
+	if(bodytemperature < cold_1) //260.15 is 310.15 - 50, the temperature where you start to feel effects.
+		var/nut_remove = 10 * DEFAULT_HUNGER_FACTOR
+		if(get_nutrition() >= nut_remove) //If we are very, very cold we'll use up quite a bit of nutriment to heat us up.
+			adjust_nutrition(-nut_remove)
+			bodytemperature += max((body_temperature_difference / BODYTEMP_AUTORECOVERY_DIVISOR), BODYTEMP_AUTORECOVERY_MINIMUM)
+	else if(cold_1 <= bodytemperature && bodytemperature <= heat_1)
+		bodytemperature += body_temperature_difference / BODYTEMP_AUTORECOVERY_DIVISOR
+	else if(bodytemperature > heat_1) //360.15 is 310.15 + 50, the temperature where you start to feel effects.
+		var/hyd_remove = 10 * DEFAULT_THIRST_FACTOR
+		if(get_hydration() >= hyd_remove)
+			adjust_hydration(-hyd_remove)
+			bodytemperature += min((body_temperature_difference / BODYTEMP_AUTORECOVERY_DIVISOR), -BODYTEMP_AUTORECOVERY_MINIMUM)

--- a/nebula.dme
+++ b/nebula.dme
@@ -2342,6 +2342,7 @@
 #include "code\modules\mob\living\life.dm"
 #include "code\modules\mob\living\living.dm"
 #include "code\modules\mob\living\living_attackhand.dm"
+#include "code\modules\mob\living\living_bodytemp.dm"
 #include "code\modules\mob\living\living_defense.dm"
 #include "code\modules\mob\living\living_defines.dm"
 #include "code\modules\mob\living\living_grabs.dm"


### PR DESCRIPTION
## Description of changes
Per title, moving human-level bodytemp equalizing down to /mob/living.

## Why and what will this PR improve
Usual argument, makes it easier to kill carbon and generalize/share environment handling logic.

## Authorship
Myself.

## Changelog
Nothing player-facing.