### PR TITLE
Nutrition and hydration adjustments.

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -319,24 +319,6 @@
 /mob/living/carbon/get_max_hydration()
 	return 400
 
-/mob/living/carbon/proc/set_nutrition(var/amt)
-	nutrition = clamp(amt, 0, get_max_nutrition())
-
-/mob/living/carbon/get_nutrition(var/amt)
-	return nutrition
-
-/mob/living/carbon/adjust_nutrition(var/amt)
-	set_nutrition(nutrition + amt)
-
-/mob/living/carbon/get_hydration(var/amt)
-	return hydration
-
-/mob/living/carbon/proc/set_hydration(var/amt)
-	hydration = clamp(amt, 0, get_max_hydration())
-
-/mob/living/carbon/adjust_hydration(var/amt)
-	set_hydration(hydration + amt)
-
 /mob/living/carbon/fluid_act(var/datum/reagents/fluids)
 	var/saturation =  min(fluids.total_volume, round(mob_size * 1.5 * reagent_permeability()) - touching.total_volume)
 	if(saturation > 0)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -16,9 +16,6 @@
 	var/lastpuke = 0
 	var/lastcough = 0
 
-	var/nutrition = 400
-	var/hydration = 400
-
 	var/obj/item/tank/internal = null//Human/Monkey
 	var/decl/species/species   // Contains environment tolerances and language information, set during New().
 	var/decl/bodytype/bodytype // Contains icon generation info, set during set_species().

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1290,3 +1290,30 @@
 		if(safety > FLASH_PROTECTION_NONE)
 			flash_strength = (flash_strength / 2)
 	. = ..()
+
+/mob/living/carbon/human/handle_nutrition_and_hydration()
+	..()
+	apply_nutrition_and_hydration_stressors()
+
+/mob/living/carbon/human/proc/apply_nutrition_and_hydration_stressors()
+	SHOULD_CALL_PARENT(TRUE)
+	var/nut =    get_nutrition()
+	var/maxnut = get_max_nutrition()
+	if(nut < (maxnut * 0.3))
+		add_stressor(/datum/stressor/hungry_very, STRESSOR_DURATION_INDEFINITE)
+	else
+		remove_stressor(/datum/stressor/hungry_very)
+		if(nut < (maxnut * 0.5))
+			add_stressor(/datum/stressor/hungry, STRESSOR_DURATION_INDEFINITE)
+		else
+			remove_stressor(/datum/stressor/hungry)
+	var/hyd =    get_hydration()
+	var/maxhyd = get_max_hydration()
+	if(hyd < (maxhyd * 0.3))
+		add_stressor(/datum/stressor/thirsty_very, STRESSOR_DURATION_INDEFINITE)
+	else
+		remove_stressor(/datum/stressor/thirsty_very)
+		if(hyd < (maxhyd * 0.5))
+			add_stressor(/datum/stressor/thirsty, STRESSOR_DURATION_INDEFINITE)
+		else
+			remove_stressor(/datum/stressor/thirsty)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1293,10 +1293,11 @@
 
 /mob/living/carbon/human/handle_nutrition_and_hydration()
 	..()
-	apply_nutrition_and_hydration_stressors()
 
-/mob/living/carbon/human/proc/apply_nutrition_and_hydration_stressors()
-	SHOULD_CALL_PARENT(TRUE)
+	// Apply stressors.
+	if(!client)
+		return
+
 	var/nut =    get_nutrition()
 	var/maxnut = get_max_nutrition()
 	if(nut < (maxnut * 0.3))

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -526,13 +526,6 @@
 
 	return 1
 
-/mob/living/carbon/human/handle_nutrition_and_hydration()
-	if(nutrition > 0)
-		adjust_nutrition(-species.hunger_factor)
-	if(hydration > 0)
-		adjust_hydration(-species.thirst_factor)
-	..()
-
 /mob/living/carbon/human/handle_regular_hud_updates()
 	if(hud_updateflag) // update our mob's hud overlays, AKA what others see flaoting above our head
 		handle_hud_list()

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -51,13 +51,33 @@
 
 	return 1
 
-/mob/living/proc/handle_nutrition_and_hydration()
+/mob/living/proc/experiences_hunger_and_thirst()
+	return TRUE
+
+/mob/living/proc/get_hunger_factor()
 	var/decl/species/my_species = get_species()
 	if(my_species)
-		if(nutrition > 0 && my_species.hunger_factor)
-			adjust_nutrition(-(my_species.hunger_factor))
-		if(hydration > 0 && my_species.thirst_factor)
-			adjust_hydration(-(my_species.thirst_factor))
+		return my_species.hunger_factor
+	return 0
+
+/mob/living/proc/get_thirst_factor()
+	var/decl/species/my_species = get_species()
+	if(my_species)
+		return my_species.hunger_factor
+	return 0
+
+/mob/living/proc/handle_nutrition_and_hydration()
+	SHOULD_CALL_PARENT(TRUE)
+	if(!experiences_hunger_and_thirst())
+		return
+	if(get_nutrition() > 0)
+		var/hunger_factor = get_hunger_factor()
+		if(hunger_factor)
+			adjust_nutrition(-(hunger_factor))
+	if(get_hydration() > 0)
+		var/thirst_factor = get_thirst_factor()
+		if(thirst_factor)
+			adjust_hydration(-(thirst_factor))
 
 /mob/living/proc/handle_breathing()
 	return

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -52,27 +52,12 @@
 	return 1
 
 /mob/living/proc/handle_nutrition_and_hydration()
-	SHOULD_CALL_PARENT(TRUE)
-	var/nut =    get_nutrition()
-	var/maxnut = get_max_nutrition()
-	if(nut < (maxnut * 0.3))
-		add_stressor(/datum/stressor/hungry_very, STRESSOR_DURATION_INDEFINITE)
-	else
-		remove_stressor(/datum/stressor/hungry_very)
-		if(nut < (maxnut * 0.5))
-			add_stressor(/datum/stressor/hungry, STRESSOR_DURATION_INDEFINITE)
-		else
-			remove_stressor(/datum/stressor/hungry)
-	var/hyd =    get_hydration()
-	var/maxhyd = get_max_hydration()
-	if(hyd < (maxhyd * 0.3))
-		add_stressor(/datum/stressor/thirsty_very, STRESSOR_DURATION_INDEFINITE)
-	else
-		remove_stressor(/datum/stressor/thirsty_very)
-		if(hyd < (maxhyd * 0.5))
-			add_stressor(/datum/stressor/thirsty, STRESSOR_DURATION_INDEFINITE)
-		else
-			remove_stressor(/datum/stressor/thirsty)
+	var/decl/species/my_species = get_species()
+	if(my_species)
+		if(nutrition > 0 && my_species.hunger_factor)
+			adjust_nutrition(-(my_species.hunger_factor))
+		if(hydration > 0 && my_species.thirst_factor)
+			adjust_hydration(-(my_species.thirst_factor))
 
 /mob/living/proc/handle_breathing()
 	return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -838,20 +838,26 @@ default behaviour is:
 /mob/living/proc/get_max_nutrition()
 	return 500
 
-/mob/living/proc/get_nutrition()
-	return get_max_nutrition()
+/mob/living/proc/set_nutrition(var/amt)
+	nutrition = clamp(amt, 0, get_max_nutrition())
+
+/mob/living/proc/get_nutrition(var/amt)
+	return nutrition
 
 /mob/living/proc/adjust_nutrition(var/amt)
-	return
+	set_nutrition(nutrition + amt)
 
 /mob/living/proc/get_max_hydration()
 	return 500
 
-/mob/living/proc/get_hydration()
-	return get_max_hydration()
+/mob/living/proc/get_hydration(var/amt)
+	return hydration
+
+/mob/living/proc/set_hydration(var/amt)
+	hydration = clamp(amt, 0, get_max_hydration())
 
 /mob/living/proc/adjust_hydration(var/amt)
-	return
+	set_hydration(hydration + amt)
 
 /mob/living/proc/has_chemical_effect(var/chem, var/threshold_over, var/threshold_under)
 	var/val = GET_CHEMICAL_EFFECT(src, chem)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -57,6 +57,9 @@
 	var/list/stasis_sources
 	var/stasis_value
 
+	var/nutrition = 400
+	var/hydration = 400
+
 	var/original_fingerprint_seed
 	var/fingerprint
 	var/original_genetic_seed

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -75,8 +75,8 @@
 	QDEL_NULL_LIST(stock_parts)
 	return ..()
 
-/mob/living/silicon/handle_nutrition_and_hydration()
-	return // Doesn't really apply to robots. Maybe unify this with cells in the future.
+/mob/living/silicon/experiences_hunger_and_thirst()
+	return FALSE // Doesn't really apply to robots. Maybe unify this with cells in the future.
 
 /mob/living/silicon/get_nutrition()
 	return get_max_nutrition()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -76,7 +76,13 @@
 	return ..()
 
 /mob/living/silicon/handle_nutrition_and_hydration()
-	return
+	return // Doesn't really apply to robots. Maybe unify this with cells in the future.
+
+/mob/living/silicon/get_nutrition()
+	return get_max_nutrition()
+
+/mob/living/silicon/get_hydration()
+	return get_max_hydration()
 
 /mob/living/silicon/fully_replace_character_name(new_name)
 	..()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -75,6 +75,9 @@
 	QDEL_NULL_LIST(stock_parts)
 	return ..()
 
+/mob/living/silicon/handle_nutrition_and_hydration()
+	return
+
 /mob/living/silicon/fully_replace_character_name(new_name)
 	..()
 	create_or_update_account(new_name)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -645,3 +645,9 @@ var/global/list/simplemob_icon_bitflag_cache = list()
 
 /mob/living/simple_animal/handle_nutrition_and_hydration()
 	return // They need a reliable way to recover nutrition/hydration before this is made general.
+
+/mob/living/simple_animal/get_nutrition()
+	return get_max_nutrition()
+
+/mob/living/simple_animal/get_hydration()
+	return get_max_hydration()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -642,3 +642,6 @@ var/global/list/simplemob_icon_bitflag_cache = list()
 
 /mob/living/simple_animal/proc/can_act()
 	return !(QDELETED(src) || incapacitated() || (is_aquatic && !submerged()))
+
+/mob/living/simple_animal/handle_nutrition_and_hydration()
+	return // They need a reliable way to recover nutrition/hydration before this is made general.

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -643,8 +643,9 @@ var/global/list/simplemob_icon_bitflag_cache = list()
 /mob/living/simple_animal/proc/can_act()
 	return !(QDELETED(src) || incapacitated() || (is_aquatic && !submerged()))
 
-/mob/living/simple_animal/handle_nutrition_and_hydration()
-	return // They need a reliable way to recover nutrition/hydration before this is made general.
+/mob/living/simple_animal/experiences_hunger_and_thirst()
+	// return !supernatural && !isSynthetic()
+	return FALSE // They need a reliable way to recover nutrition/hydration before this is made general.
 
 /mob/living/simple_animal/get_nutrition()
 	return get_max_nutrition()

--- a/mods/content/xenobiology/slime/_slime.dm
+++ b/mods/content/xenobiology/slime/_slime.dm
@@ -22,13 +22,13 @@
 	bone_amount = 0
 	ai = /datum/ai/slime
 	hud_type = /datum/hud/slime
+	nutrition = 800
 
 	var/is_adult = FALSE
 	var/mutation_chance = 30 // Chance of mutating, should be between 25 and 35
 	var/powerlevel = 0 // 0-10 controls how much electricity they are generating
 	var/amount_grown = 0 // controls how long the slime has been overfed, if 10, grows or reproduces
 	var/weakref/feeding_on
-	var/nutrition = 800
 	var/toxloss = 0
 	var/hurt_temperature = T0C-50 // slime keeps taking damage when its bodytemperature is below this
 	var/die_temperature = 50 // slime dies instantly when its bodytemperature is below this
@@ -292,6 +292,12 @@
 /mob/living/slime/check_has_mouth()
 	return 0
 
+/mob/living/slime/set_nutrition(amt)
+	..()
+
+/mob/living/slime/get_hydration()
+	return get_nutrition()
+
 /mob/living/slime/proc/gain_nutrition(var/amount)
 	adjust_nutrition(amount)
 	if(prob(amount * 2)) // Gain around one level per 50 nutrition
@@ -299,12 +305,6 @@
 		if(powerlevel > 10)
 			powerlevel = 10
 			adjustToxLoss(-10)
-
-/mob/living/slime/get_nutrition()
-	return nutrition
-
-/mob/living/slime/adjust_nutrition(var/amt)
-	nutrition = clamp(nutrition + amt, 0, get_max_nutrition())
 
 /mob/living/slime/proc/get_hunger_state()
 	. = 0

--- a/mods/content/xenobiology/slime/life.dm
+++ b/mods/content/xenobiology/slime/life.dm
@@ -80,9 +80,13 @@
 	if(length(contents) != last_contents_length)
 		queue_icon_update()
 
-/mob/living/slime/handle_nutrition_and_hydration()
+/mob/living/slime/get_hunger_factor()
+	return (0.1 + 0.05 * is_adult)
 
-	adjust_nutrition(-(0.1 + 0.05 * is_adult))
+/mob/living/slime/get_thirst_factor()
+	return 0
+
+/mob/living/slime/handle_nutrition_and_hydration()
 
 	// Digest whatever we've got floating around in our goop.
 	if(length(contents))


### PR DESCRIPTION
## Description of changes
- Adds procs and vars for handling nutrition and hydration at /mob/living.
- Opts out of this for simple mobs and silicons for the time being.

## Why and what will this PR improve
Allows for unifying a bunch of shared logic.

## Authorship
Myself.

## Changelog
Nothing player-facing.