### PR TITLE
Fluid system tweaks.

### DIFF
--- a/code/__defines/fluids.dm
+++ b/code/__defines/fluids.dm
@@ -1,5 +1,5 @@
 #define FLUID_QDEL_POINT 1           // Depth a fluid begins self-deleting
-#define FLUID_MINIMUM_TRANSFER 10    // Minimum amount that a flowing fluid will transfer from one turf to another.
+#define FLUID_MINIMUM_TRANSFER 5     // Minimum amount that a flowing fluid will transfer from one turf to another.
 #define FLUID_PUDDLE 25              // Minimum total depth that a fluid needs before it will start spreading.
 #define FLUID_SHALLOW 200            // Depth shallow icon is used
 #define FLUID_OVER_MOB_HEAD 300      // Depth icon layers over mobs.

--- a/code/controllers/subsystems/fluids.dm
+++ b/code/controllers/subsystems/fluids.dm
@@ -127,6 +127,9 @@ SUBSYSTEM_DEF(fluids)
 			qdel(current_fluid)
 			continue
 
+		// Wash our turf.
+		current_turf.fluid_act(reagent_holder)
+
 		if(isspaceturf(current_turf) || istype(current_turf, /turf/exterior))
 			removing = round(current_depth * 0.5)
 			if(removing > 0)

--- a/code/controllers/subsystems/fluids.dm
+++ b/code/controllers/subsystems/fluids.dm
@@ -115,12 +115,12 @@ SUBSYSTEM_DEF(fluids)
 		current_depth = reagent_holder?.total_volume || 0
 
 		// How is this happening
-		if(current_depth == -1.#IND || current_depth == 1.#IND)
+		if(QDELETED(reagent_holder) || current_depth == -1.#IND || current_depth == 1.#IND)
 			qdel(current_fluid)
 			continue
 
 		// Evaporation: todo, move liquid into current_turf.zone air contents if applicable.
-		if(current_depth <= FLUID_MINIMUM_TRANSFER && prob(15))
+		if(current_depth <= FLUID_PUDDLE && prob(60))
 			current_turf.remove_fluids(min(current_depth, 1), defer_update = TRUE)
 			current_depth = current_turf.get_fluid_depth()
 		if(current_depth <= FLUID_QDEL_POINT)

--- a/code/game/atoms_fluids.dm
+++ b/code/game/atoms_fluids.dm
@@ -2,8 +2,8 @@
 	return
 
 /atom/proc/fluid_act(var/datum/reagents/fluids)
-	fluids.touch(src)
-	if(reagents && fluids.total_volume >= FLUID_SHALLOW && ATOM_IS_OPEN_CONTAINER(src))
+	SHOULD_CALL_PARENT(TRUE)
+	if(reagents && fluids?.total_volume >= FLUID_SHALLOW && ATOM_IS_OPEN_CONTAINER(src))
 		reagents.trans_to_holder(fluids, reagents.total_volume)
 		fluids.trans_to_holder(reagents, min(fluids.total_volume, reagents.maximum_volume))
 

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -444,7 +444,7 @@ Class Procs:
 // This is really pretty crap and should be overridden for specific machines.
 /obj/machinery/fluid_act(var/datum/reagents/fluids)
 	..()
-	if(!(stat & (NOPOWER|BROKEN)) && !waterproof && (fluids.total_volume > FLUID_DEEP))
+	if(!QDELETED(src) && !(stat & (NOPOWER|BROKEN)) && !waterproof && (fluids?.total_volume > FLUID_DEEP))
 		explosion_act(3)
 
 /obj/machinery/Move()

--- a/code/game/objects/effects/chem/water.dm
+++ b/code/game/objects/effects/chem/water.dm
@@ -54,7 +54,7 @@
 
 /obj/effect/effect/water/Bump(atom/A)
 	if(reagents)
-		reagents.touch(A)
+		A.fluid_act(reagents)
 	return ..()
 
 //Used by spraybottles.

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -49,5 +49,8 @@
 		set_extension(src, scent_type, cleanable_scent, scent_intensity, scent_descriptor, scent_range)
 
 /obj/effect/decal/cleanable/fluid_act(var/datum/reagents/fluid)
-	reagents?.trans_to(fluid, reagents.total_volume)
-	qdel(src)
+	SHOULD_CALL_PARENT(FALSE)
+	if(fluid?.total_volume && !QDELETED(src))
+		if(reagents?.total_volume)
+			reagents.trans_to(fluid, reagents.total_volume)
+		qdel(src)

--- a/code/game/objects/effects/fluids.dm
+++ b/code/game/objects/effects/fluids.dm
@@ -10,6 +10,7 @@
 	alpha = 0
 	color = COLOR_LIQUID_WATER
 
+	var/last_slipperiness = 0
 	var/last_flow_strength = 0
 	var/last_flow_dir = 0
 	var/update_lighting = FALSE
@@ -34,6 +35,12 @@
 
 /obj/effect/fluid/on_reagent_change()
 	. = ..()
+
+	if(reagents?.total_volume)
+		var/decl/material/primary_reagent = reagents.get_primary_reagent_decl()
+		if(primary_reagent)
+			last_slipperiness = primary_reagent.slipperiness
+
 	ADD_ACTIVE_FLUID(src)
 	for(var/checkdir in global.cardinal)
 		var/obj/effect/fluid/F = locate() in get_step(loc, checkdir)
@@ -51,8 +58,8 @@
 	REMOVE_ACTIVE_FLUID(src)
 	SSfluids.pending_flows -= src
 	. = ..()
-	if(istype(T) && reagents?.total_volume > 0)
-		T.wet_floor()
+	if(istype(T) && last_slipperiness > 0)
+		T.wet_floor(last_slipperiness)
 
 /obj/effect/fluid/on_update_icon()
 

--- a/code/game/objects/effects/fluids.dm
+++ b/code/game/objects/effects/fluids.dm
@@ -104,7 +104,7 @@
 			set_light(0)
 
 // Map helper.
-/obj/effect/fluid_mapped
+/obj/abstract/fluid_mapped
 	name = "mapped flooded area"
 	alpha = 125
 	icon_state = "shallow_still"
@@ -113,14 +113,14 @@
 	var/fluid_type = /decl/material/liquid/water
 	var/fluid_initial = FLUID_MAX_DEPTH
 
-/obj/effect/fluid_mapped/Initialize()
+/obj/abstract/fluid_mapped/Initialize()
 	..()
 	var/turf/T = get_turf(src)
 	if(istype(T))
 		T.add_fluid(fluid_type, fluid_initial)
 	return INITIALIZE_HINT_QDEL
 
-/obj/effect/fluid_mapped/fuel
+/obj/abstract/fluid_mapped/fuel
 	name = "spilled fuel"
 	fluid_type = /decl/material/liquid/fuel
 	fluid_initial = 10

--- a/code/game/objects/items/weapons/flame.dm
+++ b/code/game/objects/items/weapons/flame.dm
@@ -17,7 +17,10 @@
 
 /obj/item/flame/fluid_act(var/datum/reagents/fluids)
 	..()
-	if(!waterproof && lit)
+	if(!QDELETED(src) && fluids?.total_volume && !waterproof && lit)
+		var/turf/location = get_turf(src)
+		if(location)
+			location.hotspot_expose(700, 5) // Potentially set fire to fuel etc.
 		extinguish(no_message = TRUE)
 
 /obj/item/flame/get_heat()

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -168,7 +168,10 @@
 
 /obj/item/weldingtool/fluid_act(var/datum/reagents/fluids)
 	..()
-	if(welding && !waterproof)
+	if(!QDELETED(src) && fluids?.total_volume && welding && !waterproof)
+		var/turf/location = get_turf(src)
+		if(location)
+			location.hotspot_expose(WELDING_TOOL_HOTSPOT_TEMP_ACTIVE, 50, 1)
 		turn_off()
 
 /obj/item/weldingtool/Process()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -308,3 +308,8 @@
 /decl/interaction_handler/rotate/invoked(atom/target, mob/user, obj/item/prop)
 	var/obj/O = target
 	O.rotate(user)
+
+/obj/fluid_act(var/datum/reagents/fluids)
+	..()
+	if(!QDELETED(src) && fluids?.total_volume)
+		fluids.touch_obj(src)

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -100,7 +100,7 @@
 
 /obj/structure/fire_source/fluid_act(datum/reagents/fluids)
 	. = ..()
-	if(fluids.total_volume > 0)
+	if(!QDELETED(src) && fluids?.total_volume)
 		take_reagents(fluids)
 
 /obj/structure/fire_source/explosion_act()

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -88,9 +88,11 @@
 	return flooring?.height || 0
 
 /turf/fluid_act(var/datum/reagents/fluids)
-	fluids.touch(src)
-	for(var/atom/movable/AM as anything in get_contained_external_atoms())
-		AM.fluid_act(fluids)
+	..()
+	if(!QDELETED(src) && fluids?.total_volume)
+		fluids.touch_turf(src)
+		for(var/atom/movable/AM as anything in get_contained_external_atoms())
+			AM.fluid_act(fluids)
 
 /turf/proc/remove_fluids(var/amount, var/defer_update)
 	var/obj/effect/fluid/F = locate() in src

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -116,7 +116,10 @@
 
 /obj/item/clothing/mask/smokable/fluid_act(var/datum/reagents/fluids)
 	..()
-	if(!waterproof && lit)
+	if(!QDELETED(src) && fluids?.total_volume && !waterproof && lit)
+		var/turf/location = get_turf(src)
+		if(location)
+			location.hotspot_expose(700, 5)
 		extinguish(no_message = TRUE)
 
 /obj/item/clothing/mask/smokable/proc/light(var/flavor_text = "[usr] lights the [name].")

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -578,7 +578,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 			for(var/obj/effect/overlay/wallrot/E in W)
 				W.visible_message(SPAN_NOTICE("\The [E] is completely dissolved by the solution!"))
 				qdel(E)
-		if(slipperiness != 0)
+		if(slipperiness != 0 && !T.check_fluid_depth()) // Don't make floors slippery if they have an active fluid on top of them please.
 			if(slipperiness < 0)
 				W.unwet_floor(TRUE)
 			else

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -366,11 +366,12 @@
 	. = ..() && (species.get_manual_dexterity() >= dex_level)
 
 /mob/living/carbon/fluid_act(var/datum/reagents/fluids)
+	..()
+	if(QDELETED(src) || !fluids?.total_volume || !touching)
+		return
 	var/saturation =  min(fluids.total_volume, round(mob_size * 1.5 * reagent_permeability()) - touching.total_volume)
 	if(saturation > 0)
 		fluids.trans_to_holder(touching, saturation)
-	if(fluids.total_volume)
-		..()
 
 /mob/living/carbon/get_species()
 	return species

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1127,8 +1127,9 @@
 	return breath
 
 /mob/living/carbon/human/fluid_act(var/datum/reagents/fluids)
-	species.fluid_act(src, fluids)
 	..()
+	if(!QDELETED(src) && fluids?.total_volume)
+		species.fluid_act(src, fluids)
 
 /mob/living/carbon/human/proc/set_cultural_value(var/token, var/decl/cultural_info/_culture, var/defer_language_update)
 	if(ispath(_culture, /decl/cultural_info))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -788,19 +788,23 @@ default behaviour is:
 	return TRUE // Presumably chemical smoke can't be breathed while you're underwater.
 
 /mob/living/fluid_act(var/datum/reagents/fluids)
-	for(var/thing in get_equipped_items(TRUE))
-		if(isnull(thing)) continue
-		var/atom/movable/A = thing
-		if(A.simulated)
-			A.fluid_act(fluids)
-	if(fluids.total_volume)
-		var/datum/reagents/touching_reagents = get_contact_reagents()
-		if(touching_reagents)
-			var/saturation =  min(fluids.total_volume, round(mob_size * 1.5 * reagent_permeability()) - touching_reagents.total_volume)
-			if(saturation > 0)
-				fluids.trans_to_holder(touching_reagents, saturation)
-	if(fluids.total_volume)
-		. = ..()
+	..()
+	if(QDELETED(src) || !fluids?.total_volume)
+		return
+	fluids.touch_mob(src)
+	if(QDELETED(src) || !fluids.total_volume)
+		return
+	for(var/atom/movable/A as anything in get_equipped_items(TRUE))
+		if(!A.simulated)
+			continue
+		A.fluid_act(fluids)
+		if(QDELETED(src) || !fluids.total_volume)
+			return
+	var/datum/reagents/touching_reagents = get_contact_reagents()
+	if(touching_reagents)
+		var/saturation =  min(fluids.total_volume, round(mob_size * 1.5 * reagent_permeability()) - touching_reagents.total_volume)
+		if(saturation > 0)
+			fluids.trans_to_holder(touching_reagents, saturation)
 
 /mob/living/proc/nervous_system_failure()
 	return FALSE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -57,13 +57,13 @@
 	QDEL_NULL_SCREEN(zone_sel)
 
 /mob/Initialize()
-	. = ..()
 	if(ispath(skillset))
 		skillset = new skillset(src)
 	if(!move_intent)
 		move_intent = move_intents[1]
 	if(ispath(move_intent))
 		move_intent = GET_DECL(move_intent)
+	. = ..()
 	refresh_ai_handler()
 	START_PROCESSING(SSmobs, src)
 

--- a/code/modules/species/species_helpers.dm
+++ b/code/modules/species/species_helpers.dm
@@ -11,6 +11,7 @@ var/global/list/stored_shock_by_ref = list()
 		to_chat(H, "<span class='notice'>You are now [H.pulling_punches ? "pulling your punches" : "not pulling your punches"].</span>")
 
 /decl/species/proc/fluid_act(var/mob/living/carbon/human/H, var/datum/reagents/fluids)
+	SHOULD_CALL_PARENT(TRUE)
 	var/water = REAGENT_VOLUME(fluids, /decl/material/liquid/water)
 	if(water >= 40 && H.getHalLoss())
 		H.adjustHalLoss(-(water_soothe_amount))

--- a/code/modules/xenoarcheaology/artifacts/artifact.dm
+++ b/code/modules/xenoarcheaology/artifacts/artifact.dm
@@ -133,4 +133,6 @@
 	return out
 
 /obj/structure/artifact/fluid_act(datum/reagents/fluids)
-	check_triggers(/datum/artifact_trigger/proc/on_fluid_act, fluids)
+	..()
+	if(!QDELETED(src) && fluids?.total_volume)
+		check_triggers(/datum/artifact_trigger/proc/on_fluid_act, fluids)

--- a/code/unit_tests/del_the_world.dm
+++ b/code/unit_tests/del_the_world.dm
@@ -23,6 +23,10 @@
 		/mob/living/deity,
 		// Needs a level above.
 		/obj/structure/stairs,
+		// Fluid system related; causes issues with atoms spawned on the turf.
+		/obj/abstract/fluid_mapped,
+		/obj/effect/fluid,
+		/obj/abstract/flood,
 		// Not valid when spawned manually.
 		/obj/effect/overmap,
 		/obj/effect/shuttle_landmark,

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -4066,7 +4066,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /turf/simulated/floor/tiled/usedup,
 /area/ship/scrap/maintenance/engineering)
 "hI" = (
@@ -4254,7 +4254,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
 	},
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/usedup,
 /area/ship/scrap/maintenance/engineering)
@@ -4263,7 +4263,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
 	},
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /obj/structure/sign/warning/nosmoking_1{
 	pixel_y = -32
 	},

--- a/maps/away/mining/mining-signal.dmm
+++ b/maps/away/mining/mining-signal.dmm
@@ -1083,18 +1083,18 @@
 /turf/simulated/floor/tiled/airless,
 /area/outpost/abandoned)
 "dJ" = (
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /obj/structure/table/steel,
 /obj/random/bomb_supply,
 /turf/simulated/floor/tiled/airless,
 /area/outpost/abandoned)
 "dK" = (
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/airless,
 /area/outpost/abandoned)
 "dL" = (
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /obj/structure/bed/chair,
 /obj/machinery/light/small/emergency{
 	dir = 1;
@@ -1177,7 +1177,7 @@
 /turf/simulated/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "dZ" = (
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /obj/structure/sign/directions/medical{
 	dir = 8
 	},
@@ -1185,8 +1185,8 @@
 /area/outpost/abandoned)
 "ea" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/fluid_mapped/fuel,
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /turf/simulated/floor/tiled/airless,
 /area/outpost/abandoned)
 "eb" = (
@@ -1198,11 +1198,11 @@
 /area/outpost/abandoned)
 "ec" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /turf/simulated/floor/tiled/airless,
 /area/outpost/abandoned)
 "ed" = (
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/airless,
 /area/outpost/abandoned)
@@ -1286,7 +1286,7 @@
 /turf/simulated/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "et" = (
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /obj/structure/table,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -1298,14 +1298,14 @@
 /turf/simulated/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "eu" = (
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/bot/medbot,
 /turf/simulated/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "ev" = (
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /turf/simulated/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "ex" = (
@@ -1314,7 +1314,7 @@
 /turf/simulated/floor/tiled/airless,
 /area/outpost/abandoned)
 "ey" = (
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
@@ -1472,7 +1472,7 @@
 "eW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
 	},
@@ -2268,7 +2268,7 @@
 /area/outpost/abandoned)
 "hp" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /turf/simulated/floor/plating,
 /area/outpost/abandoned)
 "hq" = (
@@ -2369,13 +2369,13 @@
 "hD" = (
 /obj/random/junk,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /turf/simulated/floor/plating,
 /area/outpost/abandoned)
 "hE" = (
 /obj/structure/table/reinforced,
 /obj/random/material,
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /turf/simulated/floor/plating,
 /area/outpost/abandoned)
 "hF" = (
@@ -2384,7 +2384,7 @@
 /turf/simulated/floor/plating,
 /area/outpost/abandoned)
 "hG" = (
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /obj/structure/closet/crate/radiation,
 /obj/random/voidsuit,
 /obj/random/voidhelmet,
@@ -2392,7 +2392,7 @@
 /area/outpost/abandoned)
 "hH" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /turf/simulated/floor/plating,
 /area/outpost/abandoned)
 "hL" = (

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -3438,7 +3438,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/fluid_mapped/fuel,
+/obj/abstract/fluid_mapped/fuel,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/engineering)
 "in" = (

--- a/mods/content/xenobiology/slime/life.dm
+++ b/mods/content/xenobiology/slime/life.dm
@@ -14,12 +14,12 @@
 
 /mob/living/slime/fluid_act(datum/reagents/fluids)
 	. = ..()
-	if(stat == DEAD)
-		var/obj/effect/fluid/F = locate() in loc
-		if(F && F.reagents?.total_volume >= FLUID_SHALLOW)
-			F.reagents.add_reagent(/decl/material/liquid/slimejelly, (is_adult ? rand(30, 40) : rand(10, 30)))
-			visible_message(SPAN_DANGER("\The [src] melts away...")) // Slimes are water soluble.
-			qdel(src)
+	if(!QDELETED(src) && fluids?.total_volume >= FLUID_SHALLOW && stat == DEAD)
+		var/turf/T = get_turf(src)
+		if(T)
+			T.add_fluid(/decl/material/liquid/slimejelly, (is_adult ? rand(30, 40) : rand(10, 30)))
+		visible_message(SPAN_DANGER("\The [src] melts away...")) // Slimes are water soluble.
+		qdel(src)
 
 /mob/living/slime/proc/handle_local_conditions()
 	var/datum/gas_mixture/environment = loc?.return_air()


### PR DESCRIPTION
## Description of changes
- Adjusted minimum transfer and evaporation thresholds to make fluids feel a bit snappier.
- Replaced some get_fluid_depth() calls with direct `total_volume` references to save proc overhead.
- Readded a `touch_turf()` for fluids to clean the turfs they go over.
- Added a `last_slipperiness` value to fluid objects so the wet floor proc can be applied more obviously and for longer.

- Fixes #3226 
- Fixes #3227
- Partially restores fluid-turf interactions. Will see if it's performant or not.

## Why and what will this PR improve
Better fluid behavior.

## Authorship
Myself.

## Changelog
:cl:
tweak: Fluids should behave more responsively and interact better with their turfs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->