### PR TITLE
Moving eye icons and vars onto bodytype.

### DIFF
--- a/code/__defines/bodytype.dm
+++ b/code/__defines/bodytype.dm
@@ -24,3 +24,5 @@
 #define BODY_FLAG_NO_PAIN             BITFLAG(1) // Cannot suffer halloss/recieves deceptive health indicator.
 #define BODY_FLAG_NO_EAT              BITFLAG(2) // Cannot eat food/drink drinks even if a stomach organ is present.
 #define BODY_FLAG_CRYSTAL_REFORM      BITFLAG(3) // Can regenerate missing limbs from mineral baths.
+#define BODY_FLAG_NO_STASIS           BITFLAG(4) // Does not experience stasis effects (sleeper, cryo)
+#define BODY_FLAG_NO_DEFIB            BITFLAG(5) // Cannot be revived with a defibrilator.

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -260,7 +260,7 @@
 
 //Checks for various conditions to see if the mob is revivable
 /obj/item/shockpaddles/proc/can_defib(mob/living/carbon/human/H) //This is checked before doing the defib operation
-	if(H.has_body_flag(BODY_FLAG_NO_DNA))
+	if(H.has_body_flag(BODY_FLAG_NO_DEFIB))
 		return "buzzes, \"Unrecogized physiology. Operation aborted.\""
 
 	if(!check_contact(H))

--- a/code/modules/ZAS/Contaminants.dm
+++ b/code/modules/ZAS/Contaminants.dm
@@ -103,7 +103,7 @@ var/global/image/contamination_overlay = image('icons/effects/contamination.dmi'
 
 /mob/living/carbon/human/proc/burn_eyes()
 	var/obj/item/organ/internal/eyes/E = get_organ(BP_EYES, /obj/item/organ/internal/eyes)
-	if(E && !E.contaminant_guard)
+	if(E && !E.bodytype.eye_contaminant_guard)
 		if(prob(20)) to_chat(src, "<span class='danger'>Your eyes burn!</span>")
 		E.damage += 2.5
 		SET_STATUS_MAX(src, STAT_BLURRY, 50)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -349,6 +349,9 @@
 	RETURN_TYPE(/decl/species)
 	return species
 
+/mob/living/carbon/get_bodytype()
+	return bodytype
+
 /mob/living/carbon/get_species_name()
 	return species.name
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -349,9 +349,6 @@
 	RETURN_TYPE(/decl/species)
 	return species
 
-/mob/living/carbon/get_bodytype()
-	return bodytype
-
 /mob/living/carbon/get_species_name()
 	return species.name
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -369,7 +369,7 @@
 		var/obj/item/organ/internal/eyes/I = get_organ(root_bodytype.vision_organ, /obj/item/organ/internal/eyes)
 		if(istype(I))
 			return I.darksight_range
-	return get_species().darksight_range
+	return root_bodytype.darksight_range
 
 /mob/living/carbon/human/abiotic(var/full_body = TRUE)
 	if(full_body)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -368,8 +368,8 @@
 	if(root_bodytype.vision_organ)
 		var/obj/item/organ/internal/eyes/I = get_organ(root_bodytype.vision_organ, /obj/item/organ/internal/eyes)
 		if(istype(I))
-			return I.darksight_range
-	return root_bodytype.darksight_range
+			return I.bodytype.eye_darksight_range
+	return root_bodytype.eye_darksight_range
 
 /mob/living/carbon/human/abiotic(var/full_body = TRUE)
 	if(full_body)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -368,7 +368,7 @@
 	if(root_bodytype.vision_organ)
 		var/obj/item/organ/internal/eyes/I = get_organ(root_bodytype.vision_organ, /obj/item/organ/internal/eyes)
 		if(istype(I))
-			return I.bodytype.eye_darksight_range
+			return I.get_darksight_range()
 	return root_bodytype.eye_darksight_range
 
 /mob/living/carbon/human/abiotic(var/full_body = TRUE)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -551,5 +551,5 @@ meteor_act
 	if(root_bodytype.vision_organ)
 		var/obj/item/organ/internal/eyes/I = get_organ(root_bodytype.vision_organ, /obj/item/organ/internal/eyes)
 		if(I) // get_organ with a type passed already does a typecheck
-			return I.flash_mod
-	return species.flash_mod
+			return I.get_flash_mod()
+	return bodytype.eye_flash_mod

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -552,4 +552,4 @@ meteor_act
 		var/obj/item/organ/internal/eyes/I = get_organ(root_bodytype.vision_organ, /obj/item/organ/internal/eyes)
 		if(I) // get_organ with a type passed already does a typecheck
 			return I.get_flash_mod()
-	return bodytype.eye_flash_mod
+	return root_bodytype.eye_flash_mod

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -290,22 +290,22 @@
 		return
 
 	// No loc or species means we should just assume no adjustment.
-	var/decl/species/species = get_species()
+	var/decl/bodytype/my_bodytype = get_bodytype()
 	var/turf/my_turf = get_turf(src)
-	if(!isturf(my_turf) || !species)
+	if(!isturf(my_turf) || !my_bodytype)
 		lighting_master.set_alpha(255)
 		return
 
 	// TODO: handling for being inside atoms.
-	var/target_value = 255 * (1-species.base_low_light_vision)
+	var/target_value = 255 * (1-my_bodytype.eye_base_low_light_vision)
 	var/loc_lumcount = my_turf.get_lumcount()
-	if(loc_lumcount < species.low_light_vision_threshold)
-		target_value = round(target_value * (1-species.low_light_vision_effectiveness))
+	if(loc_lumcount < my_bodytype.eye_low_light_vision_threshold)
+		target_value = round(target_value * (1-my_bodytype.eye_low_light_vision_effectiveness))
 
 	if(lighting_master.alpha == target_value)
 		return
 
-	var/difference = round((target_value-lighting_master.alpha) * species.low_light_vision_adjustment_speed)
+	var/difference = round((target_value-lighting_master.alpha) * my_bodytype.eye_low_light_vision_adjustment_speed)
 	if(abs(difference) > 1)
 		target_value = lighting_master.alpha + difference
 	lighting_master.set_alpha(target_value)

--- a/code/modules/mob/living/stasis.dm
+++ b/code/modules/mob/living/stasis.dm
@@ -1,6 +1,6 @@
 /mob/living/proc/set_stasis(var/factor, var/source = "misc")
 	var/decl/bodytype/my_bodytype = get_bodytype()
-	if(my_bodytype?.body_flags & BODY_FLAG_NO_DNA)
+	if(my_bodytype?.body_flags & BODY_FLAG_NO_STASIS)
 		return
 	LAZYSET(stasis_sources, source, factor)
 
@@ -11,7 +11,7 @@
 	stasis_value = 0
 	if(stasis_sources)
 		var/decl/bodytype/my_bodytype = get_bodytype()
-		if(!(my_bodytype?.body_flags & BODY_FLAG_NO_DNA))
+		if(!(my_bodytype?.body_flags & BODY_FLAG_NO_STASIS))
 			for(var/source in stasis_sources)
 				stasis_value += stasis_sources[source]
 		stasis_sources = null

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -90,7 +90,7 @@
 		owner.set_status(STAT_BLIND, 20)
 
 /obj/item/organ/internal/eyes/proc/get_total_protection(var/flash_protection = FLASH_PROTECTION_NONE)
-	return (flash_protection + bodytype.eye_innate_flash_protection)
+	return (flash_protection + get_innate_flash_protection())
 
 /obj/item/organ/internal/eyes/proc/additional_flash_effects(var/intensity)
 	return -1

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -12,24 +12,30 @@
 	max_damage = 45
 	z_flags = ZMM_MANGLE_PLANES
 
-	var/contaminant_guard = 0
 	var/eye_colour = COLOR_BLACK
-	var/innate_flash_protection = FLASH_PROTECTION_NONE
-	var/eye_icon = 'icons/mob/human_races/species/default_eyes.dmi'
-	var/apply_eye_colour = TRUE
 	var/tmp/last_cached_eye_colour
 	var/tmp/last_eye_cache_key
-	var/flash_mod
-	var/darksight_range
-	var/eye_blend = ICON_ADD
+
+/obj/item/organ/internal/eyes/proc/get_innate_flash_protection()
+	return bodytype.eye_innate_flash_protection
+
+/obj/item/organ/internal/eyes/proc/get_flash_mod()
+	return bodytype.eye_flash_mod
+
+/obj/item/organ/internal/eyes/proc/get_darksight_range()
+	return bodytype.eye_darksight_range
 
 /obj/item/organ/internal/eyes/robot
 	name = "optical sensor"
 	bodytype = /decl/bodytype/prosthetic/basic_human
 	organ_properties = ORGAN_PROP_PROSTHETIC
 	icon = 'icons/obj/robot_component.dmi'
-	flash_mod = 1
-	darksight_range = 2
+
+/obj/item/organ/internal/eyes/robot/get_flash_mod()
+	return 1
+
+/obj/item/organ/internal/eyes/robot/get_darksight_range()
+	return 2
 
 /obj/item/organ/internal/eyes/robot/Initialize(mapload, material_key, datum/dna/given_dna, decl/bodytype/new_bodytype)
 	. = ..()
@@ -38,17 +44,17 @@
 
 /obj/item/organ/internal/eyes/proc/get_eye_cache_key()
 	last_cached_eye_colour = eye_colour
-	last_eye_cache_key = "[type]-[eye_icon]-[last_cached_eye_colour]-[bodytype.eye_offset]"
+	last_eye_cache_key = "[type]-[bodytype.eye_icon]-[last_cached_eye_colour]-[bodytype.eye_offset]"
 	return last_eye_cache_key
 
 /obj/item/organ/internal/eyes/proc/get_onhead_icon()
 	var/cache_key = get_eye_cache_key()
 	if(!human_icon_cache[cache_key])
-		var/icon/eyes_icon = icon(icon = eye_icon, icon_state = "")
+		var/icon/eyes_icon = icon(icon = bodytype.eye_icon, icon_state = "")
 		if(bodytype.eye_offset)
 			eyes_icon.Shift(NORTH, bodytype.eye_offset)
-		if(apply_eye_colour)
-			eyes_icon.Blend(last_cached_eye_colour, eye_blend)
+		if(bodytype.apply_eye_colour)
+			eyes_icon.Blend(last_cached_eye_colour, bodytype.eye_blend)
 		human_icon_cache[cache_key] = eyes_icon
 	return human_icon_cache[cache_key]
 
@@ -83,13 +89,8 @@
 	if(is_broken())
 		owner.set_status(STAT_BLIND, 20)
 
-/obj/item/organ/internal/eyes/set_species(species_name)
-	. = ..()
-	flash_mod 		= species.flash_mod
-	darksight_range = species.darksight_range
-
 /obj/item/organ/internal/eyes/proc/get_total_protection(var/flash_protection = FLASH_PROTECTION_NONE)
-	return (flash_protection + innate_flash_protection)
+	return (flash_protection + bodytype.eye_innate_flash_protection)
 
 /obj/item/organ/internal/eyes/proc/additional_flash_effects(var/intensity)
 	return -1

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -31,12 +31,6 @@
 	organ_properties = ORGAN_PROP_PROSTHETIC
 	icon = 'icons/obj/robot_component.dmi'
 
-/obj/item/organ/internal/eyes/robot/get_flash_mod()
-	return 1
-
-/obj/item/organ/internal/eyes/robot/get_darksight_range()
-	return 2
-
 /obj/item/organ/internal/eyes/robot/Initialize(mapload, material_key, datum/dna/given_dna, decl/bodytype/new_bodytype)
 	. = ..()
 	verbs |= /obj/item/organ/internal/eyes/proc/change_eye_color

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -117,15 +117,11 @@
 	if(BP_IS_PROSTHETIC(src))
 		name = "optical sensor"
 		icon = 'icons/obj/robot_component.dmi'
-		flash_mod = 1
-		darksight_range = 2
 		verbs |= /obj/item/organ/internal/eyes/proc/change_eye_color
 		verbs |= /obj/item/organ/internal/eyes/proc/toggle_eye_glow
 	else
 		name = initial(name)
 		icon = initial(icon)
-		flash_mod = initial(flash_mod)
-		darksight_range = initial(darksight_range)
 		verbs -= /obj/item/organ/internal/eyes/proc/change_eye_color
 		verbs -= /obj/item/organ/internal/eyes/proc/toggle_eye_glow
 	update_colour()

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -116,7 +116,7 @@
 		reagents.add_reagent(reagent_to_add, reagents.maximum_volume)
 
 /obj/item/organ/proc/set_dna(var/datum/dna/new_dna)
-	if(istype(bodytype) && bodytype.body_flags & BODY_FLAG_NO_DNA)
+	if(istype(bodytype) && (bodytype.body_flags & BODY_FLAG_NO_DNA))
 		QDEL_NULL(dna)
 		return
 	if(new_dna != dna) // Hacky. Is this ever used? Do any organs ever have DNA set before setup_as_organic?

--- a/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
+++ b/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
@@ -7,6 +7,8 @@
 	is_robotic = TRUE
 	body_flags = BODY_FLAG_NO_DNA | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS | BODY_FLAG_NO_PAIN | BODY_FLAG_NO_EAT
 	material = /decl/material/solid/metal/steel
+	eye_flash_mod = 1
+	eye_darksight_range = 2
 	/// Determines which bodyparts can use this limb.
 	var/list/applies_to_part
 

--- a/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
+++ b/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
@@ -5,7 +5,7 @@
 	limb_tech = "{'engineering':1,'materials':1,'magnets':1}"
 	modifier_string = "robotic"
 	is_robotic = TRUE
-	body_flags = BODY_FLAG_NO_DNA | BODY_FLAG_NO_PAIN | BODY_FLAG_NO_EAT
+	body_flags = BODY_FLAG_NO_DNA | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS | BODY_FLAG_NO_PAIN | BODY_FLAG_NO_EAT
 	material = /decl/material/solid/metal/steel
 	/// Determines which bodyparts can use this limb.
 	var/list/applies_to_part

--- a/code/modules/species/outsider/random.dm
+++ b/code/modules/species/outsider/random.dm
@@ -15,6 +15,11 @@
 	base_color  = RANDOM_RGB
 	. = ..()
 
+/decl/bodytype/alium/Initialize()
+	. = ..()
+	MULT_BY_RANDOM_COEF(eye_flash_mod, 0.5, 1.5)
+	eye_darksight_range = rand(1,8)
+
 /decl/species/alium
 	name = SPECIES_ALIEN
 	name_plural = "Humanoids"
@@ -53,7 +58,6 @@
 	MULT_BY_RANDOM_COEF(oxy_mod, 0.5, 1.5)
 	MULT_BY_RANDOM_COEF(toxins_mod, 0, 2)
 	MULT_BY_RANDOM_COEF(radiation_mod, 0, 2)
-	MULT_BY_RANDOM_COEF(flash_mod, 0.5, 1.5)
 
 	if(brute_mod < 1 && prob(40))
 		species_flags |= SPECIES_FLAG_NO_MINOR_CUT
@@ -93,7 +97,6 @@
 	hazard_low_pressure += pressure_comfort_shift
 
 	//Misc traits
-	darksight_range = rand(1,8)
 	if(prob(40))
 		available_pronouns = list(/decl/pronouns)
 	if(prob(10))

--- a/code/modules/species/outsider/random.dm
+++ b/code/modules/species/outsider/random.dm
@@ -5,7 +5,7 @@
 	bandages_icon =     'icons/mob/bandage.dmi'
 	limb_blend =        ICON_MULTIPLY
 	appearance_flags =  HAS_SKIN_COLOR
-	body_flags =        BODY_FLAG_NO_DNA
+	body_flags =        BODY_FLAG_NO_DNA | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 
 /decl/bodytype/alium/Initialize()
 	if(prob(10))

--- a/code/modules/species/outsider/random.dm
+++ b/code/modules/species/outsider/random.dm
@@ -13,12 +13,9 @@
 	if(prob(5))
 		body_flags |= BODY_FLAG_NO_PAIN
 	base_color  = RANDOM_RGB
-	. = ..()
-
-/decl/bodytype/alium/Initialize()
-	. = ..()
 	MULT_BY_RANDOM_COEF(eye_flash_mod, 0.5, 1.5)
 	eye_darksight_range = rand(1,8)
+	. = ..()
 
 /decl/species/alium
 	name = SPECIES_ALIEN

--- a/code/modules/species/outsider/shadow.dm
+++ b/code/modules/species/outsider/shadow.dm
@@ -4,6 +4,7 @@
 	icon_base =        'icons/mob/human_races/species/shadow/body.dmi'
 	icon_deformed =    'icons/mob/human_races/species/shadow/body.dmi'
 	body_flags =       BODY_FLAG_NO_DNA
+	eye_darksight_range = 8
 
 /decl/blood_type/shadowstuff
 	name = "shadowstuff"
@@ -24,7 +25,6 @@
 	available_bodytypes = list(/decl/bodytype/starlight/shadow)
 
 	unarmed_attacks = list(/decl/natural_attack/claws/strong, /decl/natural_attack/bite/sharp)
-	darksight_range = 8
 	siemens_coefficient = 0
 
 	blood_types = list(

--- a/code/modules/species/outsider/shadow.dm
+++ b/code/modules/species/outsider/shadow.dm
@@ -3,7 +3,7 @@
 	desc =             "A wound of darkness inflicted upon the world."
 	icon_base =        'icons/mob/human_races/species/shadow/body.dmi'
 	icon_deformed =    'icons/mob/human_races/species/shadow/body.dmi'
-	body_flags =       BODY_FLAG_NO_DNA
+	body_flags =       BODY_FLAG_NO_DNA | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 	eye_darksight_range = 8
 
 /decl/blood_type/shadowstuff

--- a/code/modules/species/outsider/starlight.dm
+++ b/code/modules/species/outsider/starlight.dm
@@ -112,6 +112,7 @@
 	desc =             "A mass of carved and shaped spacetime."
 	icon_base =        'icons/mob/human_races/species/blueforged/body.dmi'
 	icon_deformed =    'icons/mob/human_races/species/blueforged/body.dmi'
+	eye_icon =         'icons/mob/human_races/species/blueforged/eyes.dmi'
 	body_flags =       BODY_FLAG_NO_DNA
 	override_organ_types = list(BP_EYES = /obj/item/organ/internal/eyes/blueforged)
 
@@ -150,4 +151,3 @@
 	name = "bluespace prism"
 	desc = "You can see an endless blue plane when looking through it. Your eyes tingle if you stare too hard."
 	icon = 'icons/mob/human_races/species/blueforged/organs.dmi'
-	eye_icon = 'icons/mob/human_races/species/blueforged/eyes.dmi'

--- a/code/modules/species/outsider/starlight.dm
+++ b/code/modules/species/outsider/starlight.dm
@@ -42,7 +42,7 @@
 	icon_base =        'icons/mob/human_races/species/starborn/body.dmi'
 	icon_deformed =    'icons/mob/human_races/species/starborn/body.dmi'
 	husk_icon =        'icons/mob/human_races/species/starborn/husk.dmi'
-	body_flags =       BODY_FLAG_NO_DNA | BODY_FLAG_NO_PAIN
+	body_flags =       BODY_FLAG_NO_DNA | BODY_FLAG_NO_PAIN | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 
 /decl/blood_type/starstuff
 	name = "starstuff"
@@ -113,7 +113,7 @@
 	icon_base =        'icons/mob/human_races/species/blueforged/body.dmi'
 	icon_deformed =    'icons/mob/human_races/species/blueforged/body.dmi'
 	eye_icon =         'icons/mob/human_races/species/blueforged/eyes.dmi'
-	body_flags =       BODY_FLAG_NO_DNA
+	body_flags =       BODY_FLAG_NO_DNA | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 	override_organ_types = list(BP_EYES = /obj/item/organ/internal/eyes/blueforged)
 
 /decl/blood_type/spacestuff

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -36,16 +36,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	var/flesh_color = "#ffc896"             // Pink.
 	var/blood_oxy = 1
 
-	// Darksight handling
-	/// Fractional multiplier (0 to 1) for the base alpha of the darkness overlay. A value of 1 means darkness is completely invisible.
-	var/base_low_light_vision = 0
-	/// The lumcount (turf luminosity) threshold under which adaptive low light vision will begin processing.
-	var/low_light_vision_threshold = 0.3
-	/// Fractional multiplier for the overall effectiveness of low light vision for this species. Caps the final alpha value of the darkness plane.
-	var/low_light_vision_effectiveness = 0
-	/// The rate at which low light vision adjusts towards the final value, as a fractional multiplier of the difference between the current and target alphas. ie. set to 0.15 for a 15% shift towards the target value each tick.
-	var/low_light_vision_adjustment_speed = 0.15
-
 	var/static/list/hair_styles
 	var/static/list/facial_hair_styles
 
@@ -82,7 +72,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	var/radiation_mod =  1                    // Radiation modifier
 
 	var/oxy_mod =        1                    // Oxyloss modifier
-	var/flash_mod =      1                    // Stun from blindness modifier.
 	var/metabolism_mod = 1                    // Reagent metabolism modifier
 	var/stun_mod =       1                    // Stun period modifier.
 	var/paralysis_mod =  1                    // Paralysis period modifier.
@@ -159,7 +148,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	// Body/form vars.
 	var/list/inherent_verbs 	  // Species-specific verbs.
 	var/siemens_coefficient = 1   // The lower, the thicker the skin and better the insulation.
-	var/darksight_range = 2       // Native darksight distance.
 	var/species_flags = 0         // Various specific features.
 	var/spawn_flags = 0           // Flags that specify who can spawn as this species
 	// Move intents. Earlier in list == default for that type of movement.
@@ -307,10 +295,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 
 	. = ..()
 
-	if(config.grant_default_darksight)
-		darksight_range = max(darksight_range, config.default_darksight_range)
-		low_light_vision_effectiveness = max(low_light_vision_effectiveness, config.default_darksight_effectiveness)
-
 	// Populate blood type table.
 	for(var/blood_type in blood_types)
 		var/decl/blood_type/blood_decl = GET_DECL(blood_type)
@@ -385,26 +369,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 		var/decl/trait/T = GET_DECL(trait_type)
 		if(!T.validate_level(trait_level))
 			. += "invalid levels for species trait [trait_type]"
-
-	if(base_low_light_vision > 1)
-		. += "base low light vision is greater than 1 (over 100%)"
-	else if(base_low_light_vision < 0)
-		. += "base low light vision is less than 0 (below 0%)"
-
-	if(low_light_vision_threshold > 1)
-		. += "low light vision threshold is greater than 1 (over 100%)"
-	else if(low_light_vision_threshold < 0)
-		. += "low light vision threshold is less than 0 (below 0%)"
-
-	if(low_light_vision_effectiveness > 1)
-		. += "low light vision effectiveness is greater than 1 (over 100%)"
-	else if(low_light_vision_effectiveness < 0)
-		. += "low light vision effectiveness is less than 0 (below 0%)"
-
-	if(low_light_vision_adjustment_speed > 1)
-		. += "low light vision adjustment speed is greater than 1 (over 100%)"
-	else if(low_light_vision_adjustment_speed < 0)
-		. += "low light vision adjustment speed is less than 0 (below 0%)"
 
 	if(!length(blood_types))
 		. += "missing at least one blood type"

--- a/code/modules/species/species_bodytype.dm
+++ b/code/modules/species/species_bodytype.dm
@@ -162,7 +162,6 @@ var/global/list/bodytypes_by_category = list()
 	/// The rate at which low light vision adjusts towards the final value, as a fractional multiplier of the difference between the current and target alphas. ie. set to 0.15 for a 15% shift towards the target value each tick.
 	var/eye_low_light_vision_adjustment_speed = 0.15
 
-
 	// Other eye vars.
 	var/eye_contaminant_guard = 0
 	var/eye_innate_flash_protection = FLASH_PROTECTION_NONE

--- a/code/modules/species/species_bodytype.dm
+++ b/code/modules/species/species_bodytype.dm
@@ -152,9 +152,31 @@ var/global/list/bodytypes_by_category = list()
 
 	var/list/base_markings
 
+	// Darksight handling
+	/// Fractional multiplier (0 to 1) for the base alpha of the darkness overlay. A value of 1 means darkness is completely invisible.
+	var/eye_base_low_light_vision = 0
+	/// The lumcount (turf luminosity) threshold under which adaptive low light vision will begin processing.
+	var/eye_low_light_vision_threshold = 0.3
+	/// Fractional multiplier for the overall effectiveness of low light vision for this species. Caps the final alpha value of the darkness plane.
+	var/eye_low_light_vision_effectiveness = 0
+	/// The rate at which low light vision adjusts towards the final value, as a fractional multiplier of the difference between the current and target alphas. ie. set to 0.15 for a 15% shift towards the target value each tick.
+	var/eye_low_light_vision_adjustment_speed = 0.15
+
+
+	// Other eye vars.
+	var/eye_contaminant_guard = 0
+	var/eye_innate_flash_protection = FLASH_PROTECTION_NONE
+	var/eye_icon = 'icons/mob/human_races/species/default_eyes.dmi'
+	var/apply_eye_colour = TRUE
+	var/eye_darksight_range = 2
+	var/eye_blend = ICON_ADD
+	/// Stun from blindness modifier.
+	var/eye_flash_mod = 1
+
 /decl/bodytype/Initialize()
 	. = ..()
 	icon_deformed ||= icon_base
+
 	LAZYDISTINCTADD(global.bodytypes_by_category[bodytype_category], src)
 	//If the species has eyes, they are the default vision organ
 	if(!vision_organ && has_organ[BP_EYES])
@@ -162,6 +184,10 @@ var/global/list/bodytypes_by_category = list()
 	//If the species has lungs, they are the default breathing organ
 	if(!breathing_organ && has_organ[BP_LUNGS])
 		breathing_organ = BP_LUNGS
+
+	if(config.grant_default_darksight)
+		eye_darksight_range = max(eye_darksight_range, config.default_darksight_range)
+		eye_low_light_vision_effectiveness = max(eye_low_light_vision_effectiveness, config.default_darksight_effectiveness)
 
 	// Modify organ lists if necessary.
 	if(islist(override_organ_types))
@@ -189,6 +215,27 @@ var/global/list/bodytypes_by_category = list()
 
 /decl/bodytype/validate()
 	. = ..()
+
+	if(eye_base_low_light_vision > 1)
+		. += "base low light vision is greater than 1 (over 100%)"
+	else if(eye_base_low_light_vision < 0)
+		. += "base low light vision is less than 0 (below 0%)"
+
+	if(eye_low_light_vision_threshold > 1)
+		. += "low light vision threshold is greater than 1 (over 100%)"
+	else if(eye_low_light_vision_threshold < 0)
+		. += "low light vision threshold is less than 0 (below 0%)"
+
+	if(eye_low_light_vision_effectiveness > 1)
+		. += "low light vision effectiveness is greater than 1 (over 100%)"
+	else if(eye_low_light_vision_effectiveness < 0)
+		. += "low light vision effectiveness is less than 0 (below 0%)"
+
+	if(eye_low_light_vision_adjustment_speed > 1)
+		. += "low light vision adjustment speed is greater than 1 (over 100%)"
+	else if(eye_low_light_vision_adjustment_speed < 0)
+		. += "low light vision adjustment speed is less than 0 (below 0%)"
+
 	if(icon_base)
 		if(check_state_in_icon("torso", icon_base))
 			. += "deprecated \"torso\" state present in icon_base"

--- a/code/modules/species/species_crystalline_bodytypes.dm
+++ b/code/modules/species/species_crystalline_bodytypes.dm
@@ -8,7 +8,7 @@
 	limb_tech = "{'materials':4}"
 	is_robotic = FALSE
 	material = /decl/material/solid/gemstone/crystal
-	body_flags = BODY_FLAG_CRYSTAL_REFORM | BODY_FLAG_NO_DNA
+	body_flags = BODY_FLAG_CRYSTAL_REFORM | BODY_FLAG_NO_DNA | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 	var/is_brittle
 
 /decl/bodytype/crystalline/apply_bodytype_organ_modifications(obj/item/organ/org)

--- a/code/modules/species/station/golem.dm
+++ b/code/modules/species/station/golem.dm
@@ -3,7 +3,7 @@
 	bodytype_category = BODYTYPE_HUMANOID
 	icon_base =         'icons/mob/human_races/species/golem/body.dmi'
 	husk_icon =         'icons/mob/human_races/species/golem/husk.dmi'
-	body_flags =        BODY_FLAG_NO_DNA | BODY_FLAG_NO_PAIN
+	body_flags =        BODY_FLAG_NO_DNA | BODY_FLAG_NO_PAIN | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 	has_organ = list(
 		BP_BRAIN = /obj/item/organ/internal/brain/golem
 	)

--- a/mods/content/corporate/datum/robolimbs.dm
+++ b/mods/content/corporate/datum/robolimbs.dm
@@ -56,7 +56,7 @@
 	name = "Ward-Takahashi"
 	desc = "This limb features sleek black and white polymers."
 	icon_base = 'mods/content/corporate/icons/cyberlimbs/wardtakahashi/wardtakahashi_main.dmi'
-	body_flags = BODY_FLAG_NO_DNA | BODY_FLAG_NO_PAIN
+	body_flags = BODY_FLAG_NO_DNA | BODY_FLAG_NO_PAIN | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 	bodytype_category = BODYTYPE_HUMANOID
 	material = /decl/material/solid/metal/aluminium
 	matter = list(
@@ -83,7 +83,7 @@
 	desc = "This high quality limb is nearly indistinguishable from an organic one."
 	icon_base = 'mods/content/corporate/icons/cyberlimbs/veymed/veymed_female.dmi'
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE_NORMAL | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR
-	body_flags = BODY_FLAG_NO_DNA
+	body_flags = BODY_FLAG_NO_DNA | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 	bodytype_category = BODYTYPE_HUMANOID
 	// todo: add synthflesh material?
 	material = /decl/material/solid/metal/aluminium

--- a/mods/species/ascent/datum/species.dm
+++ b/mods/species/ascent/datum/species.dm
@@ -56,7 +56,6 @@
 	oxy_mod =               0.8 // Don't need as much breathable gas as humans.
 	toxins_mod =            0.8 // Not as biologically fragile as meatboys.
 	radiation_mod =         0.5 // Not as biologically fragile as meatboys.
-	flash_mod =               2 // Highly photosensitive.
 
 	age_descriptor = /datum/appearance_descriptor/age/kharmaani
 	rarity_value =            3

--- a/mods/species/ascent/datum/species_bodytypes.dm
+++ b/mods/species/ascent/datum/species_bodytypes.dm
@@ -1,5 +1,7 @@
 /decl/bodytype/crystalline/mantid
 	abstract_type = /decl/bodytype/crystalline/mantid
+	eye_flash_mod =     2 // Highly photosensitive.
+
 	appearance_flags =  0
 	is_brittle = FALSE
 	has_limbs = list(
@@ -50,6 +52,7 @@
 	antaghud_offset_x = 4
 	associated_gender = FEMALE
 	bodytype_flag =     BODY_FLAG_GYNE
+	eye_flash_mod =     2 // Highly photosensitive.
 	movement_slowdown = 2
 	override_limb_types = list(
 		BP_GROIN = /obj/item/organ/external/groin/insectoid/mantid/gyne

--- a/mods/species/bayliens/adherent/datum/species_bodytypes.dm
+++ b/mods/species/bayliens/adherent/datum/species_bodytypes.dm
@@ -45,6 +45,9 @@
 		BP_CELL =         /obj/item/organ/internal/cell/adherent,
 		BP_COOLING_FINS = /obj/item/organ/internal/powered/cooling_fins
 		)
+	eye_contaminant_guard = TRUE
+	eye_innate_flash_protection = FLASH_PROTECTION_MAJOR
+	eye_icon = 'mods/species/bayliens/adherent/icons/eyes.dmi'
 
 /decl/bodytype/crystalline/adherent/Initialize()
 	equip_adjust = list(

--- a/mods/species/bayliens/adherent/datum/species_bodytypes.dm
+++ b/mods/species/bayliens/adherent/datum/species_bodytypes.dm
@@ -9,7 +9,7 @@
 	antaghud_offset_y =         14
 	movement_slowdown =         -1
 	appearance_flags =          HAS_EYE_COLOR
-	body_flags =                BODY_FLAG_CRYSTAL_REFORM | BODY_FLAG_NO_DNA | BODY_FLAG_NO_PAIN | BODY_FLAG_NO_EAT
+	body_flags =                BODY_FLAG_CRYSTAL_REFORM | BODY_FLAG_NO_DNA | BODY_FLAG_NO_PAIN | BODY_FLAG_NO_EAT | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 	base_eye_color =            COLOR_LIME
 	modifier_string =           "crystalline"
 	is_robotic =                FALSE

--- a/mods/species/bayliens/adherent/organs/organs_internal.dm
+++ b/mods/species/bayliens/adherent/organs/organs_internal.dm
@@ -115,11 +115,8 @@
 /obj/item/organ/internal/eyes/adherent
 	name = "receptor prism"
 	icon = 'mods/species/bayliens/adherent/icons/organs.dmi'
-	eye_icon = 'mods/species/bayliens/adherent/icons/eyes.dmi'
 	icon_state = "eyes"
 	organ_properties = ORGAN_PROP_CRYSTAL
-	contaminant_guard = TRUE
-	innate_flash_protection = FLASH_PROTECTION_MAJOR
 
 /obj/item/organ/internal/eyes/adherent/Initialize()
 	. = ..()

--- a/mods/species/bayliens/skrell/datum/species.dm
+++ b/mods/species/bayliens/skrell/datum/species.dm
@@ -31,7 +31,6 @@
 
 	burn_mod = 0.9
 	oxy_mod = 1.3
-	flash_mod = 1.2
 	toxins_mod = 0.8
 	siemens_coefficient = 1.3
 	warning_low_pressure = WARNING_LOW_PRESSURE * 1.4
@@ -41,8 +40,6 @@
 	water_soothe_amount = 5
 
 	body_temperature = null // cold-blooded, implemented the same way nabbers do it
-
-	darksight_range = 4
 
 	spawn_flags = SPECIES_CAN_JOIN
 
@@ -156,5 +153,3 @@
 	name = "amphibian eyes"
 	desc = "Large black orbs, belonging to some sort of giant frog by looks of it."
 	icon = 'mods/species/bayliens/skrell/icons/body/organs.dmi'
-	eye_icon = 'mods/species/bayliens/skrell/icons/body/eyes.dmi'
-	apply_eye_colour = FALSE

--- a/mods/species/bayliens/skrell/datum/species_bodytype.dm
+++ b/mods/species/bayliens/skrell/datum/species_bodytype.dm
@@ -4,6 +4,12 @@
 	bandages_icon =        'icons/mob/bandage.dmi'
 	bandages_icon =        'icons/mob/bandage.dmi'
 	health_hud_intensity = 1.75
+	associated_gender = PLURAL
+	eye_darksight_range = 4
+	eye_flash_mod = 1.2
+	eye_icon = 'mods/species/bayliens/skrell/icons/body/eyes.dmi'
+	apply_eye_colour = FALSE
+
 	associated_gender =    PLURAL
 	appearance_flags =     HAS_HAIR_COLOR | HAS_UNDERWEAR | HAS_SKIN_COLOR
 	base_color =         "#006666"

--- a/mods/species/bayliens/tajaran/datum/species.dm
+++ b/mods/species/bayliens/tajaran/datum/species.dm
@@ -104,9 +104,5 @@
 
 	autohiss_exempt = list(LANGUAGE_TAJARA)
 
-/obj/item/organ/internal/eyes/taj
-	eye_blend = ICON_MULTIPLY
-	eye_icon = 'mods/species/bayliens/tajaran/icons/eyes.dmi'
-
 /decl/species/tajaran/handle_additional_hair_loss(var/mob/living/carbon/human/H, var/defer_body_update = TRUE)
 	. = H && H.change_skin_color(rgb(189, 171, 143))

--- a/mods/species/bayliens/tajaran/datum/species.dm
+++ b/mods/species/bayliens/tajaran/datum/species.dm
@@ -16,9 +16,6 @@
 	name_plural = "Tajaran"
 	base_prosthetics_model = null
 
-	low_light_vision_effectiveness = 0.15
-	low_light_vision_adjustment_speed = 0.3
-
 	description = "A small mammalian carnivore. If you are reading this, you are probably a Tajaran."
 	hidden_from_codex = FALSE
 
@@ -44,9 +41,6 @@
 	flesh_color = "#ae7d32"
 
 	organs_icon = 'mods/species/bayliens/tajaran/icons/organs.dmi'
-
-	darksight_range = 7
-	flash_mod = 2
 
 	hunger_factor = DEFAULT_HUNGER_FACTOR * 1.2
 	gluttonous = GLUT_TINY

--- a/mods/species/bayliens/tajaran/datum/species_bodytypes.dm
+++ b/mods/species/bayliens/tajaran/datum/species_bodytypes.dm
@@ -24,7 +24,7 @@
 	eye_low_light_vision_adjustment_speed = 0.3
 
 	override_limb_types = list(
-		BP_EYES = /obj/item/organ/internal/eyes/taj,
+		BP_EYES = /obj/item/organ/internal/eyes,
 		BP_TAIL = /obj/item/organ/external/tail/cat
 	)
 

--- a/mods/species/bayliens/tajaran/datum/species_bodytypes.dm
+++ b/mods/species/bayliens/tajaran/datum/species_bodytypes.dm
@@ -16,6 +16,13 @@
 	base_eye_color = "#00aa00"
 	default_h_style = /decl/sprite_accessory/hair/taj/lynx
 
+	eye_darksight_range = 7
+	eye_flash_mod = 2
+	eye_blend = ICON_MULTIPLY
+	eye_icon = 'mods/species/bayliens/tajaran/icons/eyes.dmi'
+	eye_low_light_vision_effectiveness = 0.15
+	eye_low_light_vision_adjustment_speed = 0.3
+
 	override_limb_types = list(
 		BP_EYES = /obj/item/organ/internal/eyes/taj,
 		BP_TAIL = /obj/item/organ/external/tail/cat

--- a/mods/species/bayliens/unathi/datum/species.dm
+++ b/mods/species/bayliens/unathi/datum/species.dm
@@ -29,12 +29,10 @@
 	)
 
 	primitive_form = "Stok"
-	darksight_range = 3
 	gluttonous = GLUT_TINY
 	strength = STR_HIGH
 	breath_pressure = 18
 	brute_mod = 0.8
-	flash_mod = 1.2
 	blood_volume = 800
 
 	hunger_factor = DEFAULT_HUNGER_FACTOR * 2

--- a/mods/species/bayliens/unathi/datum/species_bodytypes.dm
+++ b/mods/species/bayliens/unathi/datum/species_bodytypes.dm
@@ -15,6 +15,8 @@
 	base_color = "#066000"
 	base_hair_color = "#192e19"
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
+	eye_darksight_range = 3
+	eye_flash_mod = 1.2
 
 	override_organ_types = list(
 		BP_EYES = /obj/item/organ/internal/eyes/lizard,

--- a/mods/species/neoavians/datum/species.dm
+++ b/mods/species/neoavians/datum/species.dm
@@ -73,9 +73,6 @@
 /decl/species/neoavian/get_holder_color(var/mob/living/carbon/human/H)
 	return H.skin_colour
 
-/obj/item/organ/internal/eyes/avian
-	eye_icon = 'mods/species/neoavians/icons/eyes.dmi'
-
 /decl/hierarchy/outfit/job/generic/assistant/avian
 	name = "Job - Avian Assistant"
 	uniform = /obj/item/clothing/under/avian_smock/worker

--- a/mods/species/neoavians/datum/species_bodytypes.dm
+++ b/mods/species/neoavians/datum/species_bodytypes.dm
@@ -5,6 +5,7 @@
 	blood_overlays =    'mods/species/neoavians/icons/blood_avian.dmi'
 	limb_blend =        ICON_MULTIPLY
 	bodytype_flag =     BODY_FLAG_AVIAN
+	eye_icon = 'mods/species/neoavians/icons/eyes.dmi'
 	appearance_flags =  HAS_HAIR_COLOR | HAS_SKIN_COLOR | HAS_EYE_COLOR
 	base_color = "#252525"
 	base_eye_color = "#f5c842"

--- a/mods/species/neoavians/datum/species_bodytypes.dm
+++ b/mods/species/neoavians/datum/species_bodytypes.dm
@@ -17,7 +17,7 @@
 		BP_LIVER =    /obj/item/organ/internal/liver,
 		BP_KIDNEYS =  /obj/item/organ/internal/kidneys,
 		BP_BRAIN =    /obj/item/organ/internal/brain,
-		BP_EYES =     /obj/item/organ/internal/eyes/avian
+		BP_EYES =     /obj/item/organ/internal/eyes
 	)
 	override_limb_types = list(BP_TAIL = /obj/item/organ/external/tail/avian)
 	default_h_style = /decl/sprite_accessory/hair/avian

--- a/mods/species/serpentid/datum/species.dm
+++ b/mods/species/serpentid/datum/species.dm
@@ -38,7 +38,6 @@
 		/decl/bodytype/serpentid/green
 	)
 
-	darksight_range = 8
 	rarity_value = 4
 	hud_type = /datum/hud_data/serpentid
 	total_health = 200

--- a/mods/species/serpentid/datum/species_bodytypes.dm
+++ b/mods/species/serpentid/datum/species_bodytypes.dm
@@ -22,6 +22,11 @@
 		BP_SYSTEM_CONTROLLER = /obj/item/organ/internal/controller
 	)
 
+	eye_darksight_range = 8
+	eye_innate_flash_protection = FLASH_PROTECTION_VULNERABLE
+	eye_contaminant_guard = 1
+	eye_icon = 'mods/species/serpentid/icons/eyes.dmi'
+
 	has_limbs = list(
 		BP_CHEST =        list("path" = /obj/item/organ/external/chest/insectoid/serpentid),
 		BP_GROIN =        list("path" = /obj/item/organ/external/groin/insectoid/serpentid),

--- a/mods/species/serpentid/mobs/bodyparts_serpentid.dm
+++ b/mods/species/serpentid/mobs/bodyparts_serpentid.dm
@@ -1,10 +1,11 @@
 /obj/item/organ/internal/eyes/insectoid/serpentid
 	name = "compound eyes"
-	innate_flash_protection = FLASH_PROTECTION_VULNERABLE
-	contaminant_guard = 1
 	action_button_name = "Toggle Eye Shields"
-	eye_icon = 'mods/species/serpentid/icons/eyes.dmi'
 	var/eyes_shielded
+	var/override_flash_protection = FLASH_PROTECTION_VULNERABLE
+
+/obj/item/organ/internal/eyes/insectoid/serpentid/get_innate_flash_protection()
+	return override_flash_protection
 
 /obj/item/organ/internal/eyes/insectoid/serpentid/get_special_overlay()
 	var/icon/I = get_onhead_icon()
@@ -35,12 +36,12 @@
 		eyes_shielded = !eyes_shielded
 		if(eyes_shielded)
 			to_chat(owner, "<span class='notice'>Nearly opaque lenses slide down to shield your eyes.</span>")
-			innate_flash_protection = FLASH_PROTECTION_MAJOR
+			override_flash_protection = FLASH_PROTECTION_MAJOR
 			owner.overlay_fullscreen("eyeshield", /obj/screen/fullscreen/blind)
 			owner.update_icon()
 		else
 			to_chat(owner, "<span class='notice'>Your protective lenses retract out of the way.</span>")
-			innate_flash_protection = FLASH_PROTECTION_VULNERABLE
+			override_flash_protection = FLASH_PROTECTION_VULNERABLE
 			addtimer(CALLBACK(src, .proc/remove_shield), 1 SECONDS)
 			owner.update_icon()
 		refresh_action_button()

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -63,9 +63,6 @@
 		/decl/emote/exertion/synthetic/creak
 	)
 
-/obj/item/organ/internal/eyes/robot/utility_frame
-	eye_icon = 'mods/species/utility_frames/icons/eyes.dmi'
-
 /obj/item/organ/external/head/utility_frame
 	glowing_eyes = TRUE
 

--- a/mods/species/utility_frames/species_bodytypes.dm
+++ b/mods/species/utility_frames/species_bodytypes.dm
@@ -2,6 +2,7 @@
 	name =              "utility frame"
 	desc =              "This limb is extremely cheap and simplistic, with a raw steel frame and plastic casing."
 	icon_base =         'mods/species/utility_frames/icons/body.dmi'
+	eye_icon = 'mods/species/utility_frames/icons/eyes.dmi'
 	bodytype_category = BODYTYPE_HUMANOID
 	limb_blend =        ICON_MULTIPLY
 	appearance_flags =  HAS_SKIN_COLOR | HAS_EYE_COLOR

--- a/mods/species/utility_frames/species_bodytypes.dm
+++ b/mods/species/utility_frames/species_bodytypes.dm
@@ -7,7 +7,7 @@
 	limb_blend =        ICON_MULTIPLY
 	appearance_flags =  HAS_SKIN_COLOR | HAS_EYE_COLOR
 	modular_limb_tier = MODULAR_BODYPART_CYBERNETIC
-	body_flags =        BODY_FLAG_NO_PAIN | BODY_FLAG_NO_DNA
+	body_flags =        BODY_FLAG_NO_PAIN | BODY_FLAG_NO_DNA | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 	base_color = "#333355"
 	base_eye_color = "#00ccff"
 	material = /decl/material/solid/metal/steel

--- a/mods/species/utility_frames/species_bodytypes.dm
+++ b/mods/species/utility_frames/species_bodytypes.dm
@@ -18,8 +18,8 @@
 	override_limb_types = list(BP_HEAD = /obj/item/organ/external/head/utility_frame)
 	has_organ = list(
 		BP_POSIBRAIN = /obj/item/organ/internal/posibrain,
-		BP_EYES      = /obj/item/organ/internal/eyes/robot/utility_frame,
-		BP_CELL = /obj/item/organ/internal/cell
+		BP_EYES      = /obj/item/organ/internal/eyes,
+		BP_CELL      = /obj/item/organ/internal/cell
 	)
 	base_markings = list(
 		/decl/sprite_accessory/marking/frame/plating = "#8888cc",

--- a/mods/species/vox/datum/species_bodytypes.dm
+++ b/mods/species/vox/datum/species_bodytypes.dm
@@ -5,6 +5,7 @@
 	icon_deformed =     'mods/species/vox/icons/body/deformed_body.dmi'
 	husk_icon =         'mods/species/vox/icons/body/husk.dmi'
 	blood_overlays =    'mods/species/vox/icons/body/blood_overlays.dmi'
+	eye_icon =          'mods/species/vox/icons/body/soldier/eyes.dmi'
 	bodytype_flag =     BODY_FLAG_VOX
 	limb_blend =        ICON_MULTIPLY
 	appearance_flags =  HAS_EYE_COLOR | HAS_HAIR_COLOR | HAS_SKIN_COLOR

--- a/mods/species/vox/organs_vox.dm
+++ b/mods/species/vox/organs_vox.dm
@@ -20,7 +20,6 @@
 	color = "#0033cc"
 
 /obj/item/organ/internal/eyes/vox
-	eye_icon = 'mods/species/vox/icons/body/soldier/eyes.dmi'
 	color = "#0033cc"
 
 /obj/item/organ/internal/stomach/vox


### PR DESCRIPTION
## Description of changes
- Moves a bunch of eye vars onto bodytype.
- Splits BODY_FLAG_NO_DNA into a couple of other flags for defib and stasis purposes.
- Allows vox to be defibbed and put in stasis.

## Why and what will this PR improve
Removes need for weird unwieldly eye subtypes.

## Authorship
Myself.

## Changelog
Nothing user-facing.