### PR TITLE
Removing outdated verbiage from paramount coercion and borer antags.

### DIFF
--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -48,13 +48,13 @@
 
 /decl/special_role/proc/add_antagonist_mind(var/datum/mind/player, var/ignore_role, var/nonstandard_role_type, var/nonstandard_role_msg)
 	if(!istype(player))
-		return 0
+		return FALSE
 	if(!player.current)
-		return 0
+		return FALSE
 	if(player in current_antagonists)
-		return 0
+		return FALSE
 	if(!can_become_antag(player, ignore_role))
-		return 0
+		return FALSE
 	current_antagonists |= player
 
 	if(faction_verb)
@@ -80,7 +80,7 @@
 		if(nonstandard_role_msg)
 			to_chat(player.current, "<span class='notice'>[nonstandard_role_msg]</span>")
 		update_icons_added(player)
-	return 1
+	return TRUE
 
 /decl/special_role/proc/remove_antagonist(var/datum/mind/player, var/show_message, var/implanted)
 	if(!istype(player))

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -1,7 +1,7 @@
 /decl/special_role/proc/can_become_antag(var/datum/mind/player, var/ignore_role)
 
 	if(player.current)
-		if(isliving(player.current) && player.current.stat)
+		if(isliving(player.current) && player.current.stat == DEAD)
 			return FALSE
 		if(jobban_isbanned(player.current, name))
 			return FALSE

--- a/code/game/antagonist/station/thrall.dm
+++ b/code/game/antagonist/station/thrall.dm
@@ -17,7 +17,7 @@
 
 /decl/special_role/beguiled/add_antagonist(var/datum/mind/player, var/ignore_role, var/do_not_equip, var/move_to_spawn, var/do_not_announce, var/preserve_appearance, var/mob/new_controller)
 	if(!new_controller)
-		return 0
+		return FALSE
 	. = ..()
 	if(.)
 		minion_controllers["\ref[player]"] = new_controller

--- a/code/game/antagonist/station/thrall.dm
+++ b/code/game/antagonist/station/thrall.dm
@@ -1,28 +1,29 @@
-/decl/special_role/thrall
-	name = "Thrall"
-	name_plural = "Thralls"
+/decl/special_role/beguiled
+	name = "Beguiled"
+	name_plural = "Beguiled"
 	welcome_text = "Your mind is no longer solely your own..."
 	flags = ANTAG_IMPLANT_IMMUNE
 
-	var/list/thrall_controllers = list()
+	var/list/minion_controllers = list()
 
-/decl/special_role/thrall/create_objectives(var/datum/mind/player)
-	var/mob/living/controller = thrall_controllers["\ref[player]"]
+/decl/special_role/beguiled/create_objectives(var/datum/mind/player)
+	var/mob/living/controller = minion_controllers["\ref[player]"]
 	if(!controller)
 		return // Someone is playing with buttons they shouldn't be.
 	var/datum/objective/obey = new
 	obey.owner = player
-	obey.explanation_text = "Obey your master, [controller.real_name], in all things."
+	obey.explanation_text = "You are under [controller.real_name]'s glamour, and must follow their commands."
 	player.objectives |= obey
 
-/decl/special_role/thrall/add_antagonist(var/datum/mind/player, var/ignore_role, var/do_not_equip, var/move_to_spawn, var/do_not_announce, var/preserve_appearance, var/mob/new_controller)
+/decl/special_role/beguiled/add_antagonist(var/datum/mind/player, var/ignore_role, var/do_not_equip, var/move_to_spawn, var/do_not_announce, var/preserve_appearance, var/mob/new_controller)
 	if(!new_controller)
 		return 0
 	. = ..()
-	if(.) thrall_controllers["\ref[player]"] = new_controller
+	if(.)
+		minion_controllers["\ref[player]"] = new_controller
 
-/decl/special_role/thrall/greet(var/datum/mind/player)
+/decl/special_role/beguiled/greet(var/datum/mind/player)
 	. = ..()
-	var/mob/living/controller = thrall_controllers["\ref[player]"]
+	var/mob/living/controller = minion_controllers["\ref[player]"]
 	if(controller)
-		to_chat(player, "<span class='danger'>Your will has been subjugated by that of [controller.real_name]. Obey them in all things.</span>")
+		to_chat(player, "<span class='danger'>You have been ensnared by [controller.real_name]'s glamour. Follow their commands.</span>")

--- a/mods/content/psionics/items/cerebro_enhancers.dm
+++ b/mods/content/psionics/items/cerebro_enhancers.dm
@@ -81,7 +81,7 @@
 		canremove = TRUE
 		return
 
-	to_chat(H, SPAN_WARNING("You feel a strange tugging sensation as \the [src] begins removing the slave-minds from your brain..."))
+	to_chat(H, SPAN_WARNING("You feel a strange tugging sensation as \the [src] begins removing the subpersonas from your brain..."))
 	playsound(H, 'sound/weapons/circsawhit.ogg', 50, 1, -1)
 	operating = TRUE
 
@@ -90,7 +90,7 @@
 	if(H.psi)
 		H.psi.reset()
 
-	to_chat(H, SPAN_NOTICE("\The [src] chimes quietly as it finishes removing the slave-minds from your brain."))
+	to_chat(H, SPAN_NOTICE("\The [src] chimes quietly as it finishes removing the subpersonas from your brain."))
 
 	canremove = TRUE
 	operating = FALSE

--- a/mods/content/psionics/system/psionics/faculties/coercion.dm
+++ b/mods/content/psionics/system/psionics/faculties/coercion.dm
@@ -139,38 +139,57 @@
 				target.visible_message(SPAN_DANGER("\The [target] drops what they were holding as their [E ? E.name : "hand"] spasms!"))
 		return TRUE
 
-/decl/psionic_power/coercion/mindslave
-	name =          "Mindslave"
+/decl/psionic_power/coercion/beguile
+	name =          "Beguile"
 	cost =          28
 	cooldown =      200
 	use_grab =      TRUE
 	min_rank =      PSI_RANK_PARAMOUNT
-	use_description = "Grab a victim, target the eyes, then use the grab on them while on disarm intent, in order to convert them into a loyal mind-slave. The process takes some time, and failure is punished harshly."
+	use_description = "Grab a victim, target the eyes, then use the grab on them while on disarm intent, in order to beguile them into serving your cause."
 
-/decl/psionic_power/coercion/mindslave/invoke(var/mob/living/user, var/mob/living/target)
+/decl/psionic_power/coercion/beguile/invoke(var/mob/living/user, var/mob/living/target)
 	if(!istype(target) || user.get_target_zone() != BP_EYES)
 		return FALSE
 	. = ..()
 	if(.)
 		if(target.stat == DEAD || (target.status_flags & FAKEDEATH))
-			to_chat(user, "<span class='warning'>\The [target] is dead!</span>")
+			to_chat(user, SPAN_WARNING("\The [target] is dead!"))
 			return TRUE
 		if(!target.mind || !target.key)
-			to_chat(user, "<span class='warning'>\The [target] is mindless!</span>")
+			to_chat(user, SPAN_WARNING("\The [target] is mindless!"))
 			return TRUE
-		var/decl/special_role/thrall/thralls = GET_DECL(/decl/special_role/thrall)
-		if(thralls.is_antagonist(target.mind))
-			to_chat(user, "<span class='warning'>\The [target] is already in thrall to someone!</span>")
+		var/decl/special_role/beguiled/beguiled = GET_DECL(/decl/special_role/beguiled)
+		if(beguiled.is_antagonist(target.mind))
+			to_chat(user, SPAN_WARNING("\The [target] is already under a glamour!"))
 			return TRUE
-		user.visible_message("<span class='danger'><i>\The [user] seizes the head of \the [target] in both hands...</i></span>")
-		to_chat(user, "<span class='warning'>You plunge your mentality into that of \the [target]...</span>")
-		to_chat(target, "<span class='danger'>Your mind is invaded by the presence of \the [user]! They are trying to make you a slave!</span>")
-		if(!do_after(user, target.stat == CONSCIOUS ? 80 : 40, target, 0, 1))
-			user.psi.backblast(rand(10,25))
+
+		user.visible_message("<b>\The [user] seizes the head of \the [target] in both hands...</b>")
+		to_chat(user,   SPAN_NOTICE("You insinuate your mentality into that of \the [target]..."))
+		to_chat(target, SPAN_DANGER("Your mind is being beguiled by the presence of \the [user]! They are trying to pull you under their glamour!"))
+
+		var/accepted_glamour = alert(target, "Will you become \the [user]'s beguiled servant? Refusal will have harsh consequences.", "Beguilement", "No", "Yes")
+
+		// Redo all our validity checks post-blocking call.
+		if(QDELETED(user) || QDELETED(target) || !user.Adjacent(target) || user.incapacitated())
 			return TRUE
-		to_chat(user, "<span class='danger'>You sear through \the [target]'s neurons, reshaping as you see fit and leaving them subservient to your will!</span>")
-		to_chat(target, "<span class='danger'>Your defenses have eroded away and \the [user] has made you their mindslave.</span>")
-		thralls.add_antagonist(target.mind, new_controller = user)
+		if(target.stat == DEAD || (target.status_flags & FAKEDEATH))
+			return TRUE
+		if(!target.mind || !target.key)
+			return TRUE
+		if(!target.mind || beguiled.is_antagonist(target.mind))
+			return TRUE
+
+		if(accepted_glamour == "Yes")
+			to_chat(user,   SPAN_DANGER("You layer a glamour across the \the [target]'s senses, beguiling them to unwittingly follow your commands."))
+			to_chat(target, SPAN_DANGER("You have been ensnared by \the [user]'s glamour!"))
+			beguiled.add_antagonist(target.mind, new_controller = user)
+		else
+			to_chat(user,   SPAN_WARNING("\The [target] resists your glamour, writhing in your grip. You hurriedly release them before too much damage is done, but the psyche is left tattered. They should have no memory of this encounter, at least."))
+			to_chat(target, SPAN_DANGER("You resist \the [user], struggling free of their influence at the cost of your own mind!"))
+			to_chat(target, SPAN_DANGER("You fall into darkness, losing all memory of the encounter..."))
+			target.adjustBrainLoss(rand(25,40))
+			SET_STATUS_MAX(target, STAT_PARA, 10 SECONDS)
+
 		return TRUE
 
 /decl/psionic_power/coercion/assay

--- a/mods/content/psionics/system/psionics/mob/mob_assay.dm
+++ b/mods/content/psionics/system/psionics/mob/mob_assay.dm
@@ -29,11 +29,11 @@
 				use_rating = "<font color = '#FF0000'><b>[effective_rating]-Alpha-Plus</b></font>"
 				rating_descriptor = "This indicates a completely deviant psi complexus, either beyond or outside anything currently recorded. Approach with care."
 			// This space intentionally left blank (for Omega-Minus psi vampires. todo)
-			var/decl/special_role/thrall/thralls = GET_DECL(/decl/special_role/thrall)
-			if(viewer != usr && thralls.is_antagonist(mind) && ishuman(viewer))
+			var/decl/special_role/beguiled/beguiled = GET_DECL(/decl/special_role/beguiled)
+			if(viewer != usr && beguiled.is_antagonist(mind) && ishuman(viewer))
 				var/mob/living/H = viewer
 				if(H.psi && H.psi.get_rank(PSI_REDACTION) >= PSI_RANK_GRANDMASTER)
-					dat += "<font color='#FF0000'><b>Their mind has been cored like an apple, and enslaved by another operant psychic.</b></font>" // <A href='?src=\ref[H.psi];clear_thralldom=\ref[psi]'>>Attempt to remove</a>"
+					dat += "<font color='#FF0000'><b>Their mind has been subverted by another operant psychic; their actions are not their own.</b></font>"
 
 		if(!use_rating)
 			switch(effective_rating)
@@ -90,7 +90,7 @@
 		machine.last_assay = dat
 		return
 
-	var/interface_type = machine ? /datum/browser/written_digital : /datum/browser 
+	var/interface_type = machine ? /datum/browser/written_digital : /datum/browser
 	var/datum/browser/popup = new interface_type(viewer, "psi_assay_\ref[src]", "Psi-Assay")
 	popup.set_content(jointext(dat,null))
 	popup.open()

--- a/mods/mobs/borers/datum/antagonist.dm
+++ b/mods/mobs/borers/datum/antagonist.dm
@@ -8,9 +8,9 @@
 	antag_indicator = "hudborer"
 	antaghud_indicator = "hudborer"
 
-	faction_name = "Borer Thrall"
+	faction_name = "Borer Host"
 	faction_descriptor = "Unity"
-	faction_welcome = "You are now a thrall to a cortical borer. Please listen to what they have to say; they're in your head."
+	faction_welcome = "You are now host to a cortical borer. Please listen to what they have to say; they're in your head."
 	faction = "borer"
 	faction_indicator = "hudalien"
 

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -35,7 +35,7 @@ exactly 1 "world<< uses" 'world<<|world[[:space:]]<<'
 exactly 92 "'in world' uses" 'in world'
 exactly 1 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
 exactly 18 "<< uses" '(?<!<)<<(?!<)' -P
-exactly 10 ">> uses" '>>(?!>)' -P
+exactly 9 ">> uses" '>>(?!>)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 23 "text2path uses" 'text2path'
 exactly 4 "update_icon() override" '/update_icon\((.*)\)'  -P


### PR DESCRIPTION
## Description of changes
- Replaces 'slave' and 'thrall' with 'beguiled' or 'host'.
- Rewrites the coercion messages to be more appropriate to the new concept.
- Adds a confirmation prompt and punishment for refusal to paramount coercion.

## Why and what will this PR improve

Had a lengthy discussion about this with some folks on Polaris who were uncomfortable with it conceptually and in terms of the language used, as well as the issues with conversion modes in terms of agency/consent/not really being fun if you didn't agree to them. 

Additionally from a purely pragmatic perspective if you convert someone who doesn't want to be converted they'll take the first opportunity to leave, if they don't ghost immediately.

The language in question is not something I think needs justification, it hasn't been appropriate to casually use 'slave' for years. Thrall is a bit less problematic in some senses but is close enough that I just trimmed it out as well.

## Authorship
<!-- Describe original authors of changes to credit them. -->

## Changelog
:cl:
tweak: Paramount Coercion is now 'Beguile', and does not have a channel or a risk of backblast. It also prompts the target to join willingly, knocking them unconscious and dealing brain damage so you can escape if they refuse.
/:cl:
