### PR TITLE
Made fullscreen overlays use the fullscreen layer by default.

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -75,6 +75,7 @@
 	icon_state = "default"
 	screen_loc = ui_center_fullscreen
 	plane = FULLSCREEN_PLANE
+	layer = FULLSCREEN_LAYER
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
 	var/severity = 0
 	var/allstate = 0 //shows if it should show up for dead people too
@@ -134,14 +135,12 @@
 	icon = 'icons/effects/static.dmi'
 	icon_state = "1 light"
 	screen_loc = ui_entire_screen
-	layer = FULLSCREEN_LAYER
 	alpha = 127
 
 /obj/screen/fullscreen/fadeout
 	icon = 'icons/mob/screen1.dmi'
 	icon_state = "black"
 	screen_loc = ui_entire_screen
-	layer = FULLSCREEN_LAYER
 	alpha = 0
 	allstate = 1
 
@@ -154,7 +153,6 @@
 	icon_state = "scanlines"
 	screen_loc = ui_entire_screen
 	alpha = 50
-	layer = FULLSCREEN_LAYER
 
 /obj/screen/fullscreen/fishbed
 	icon_state = "fishbed"
@@ -169,4 +167,3 @@
 	icon_state = "base"
 	screen_loc = ui_entire_screen
 	alpha = 100
-	layer = FULLSCREEN_LAYER

--- a/code/_onclick/hud/global_hud.dm
+++ b/code/_onclick/hud/global_hud.dm
@@ -26,10 +26,8 @@ var/global/datum/global_hud/hud
 	screen.layer = FULLSCREEN_LAYER
 	screen.mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
 	screen.alpha = 125
-
 	screen.blend_mode = BLEND_MULTIPLY
 	screen.color = color
-
 	return screen
 
 /datum/global_hud/New()

--- a/code/controllers/evacuation/evacuation_pods.dm
+++ b/code/controllers/evacuation/evacuation_pods.dm
@@ -137,7 +137,6 @@
 	screen_loc = ui_entire_screen
 	color = "#ff9900"
 	blend_mode = BLEND_SUBTRACT
-	layer = FULLSCREEN_LAYER
 
 #undef EVAC_OPT_ABANDON_SHIP
 #undef EVAC_OPT_JUMP

--- a/code/game/gamemodes/endgame/ftl_jump/ftl_jump.dm
+++ b/code/game/gamemodes/endgame/ftl_jump/ftl_jump.dm
@@ -144,4 +144,3 @@
 	color = "#ff9900"
 	alpha = 100
 	blend_mode = BLEND_SUBTRACT
-	layer = FULLSCREEN_LAYER


### PR DESCRIPTION
## Description of changes
Deletes some layer setting from fullscreen objects in favour of setting it on the shared type.

## Why and what will this PR improve
Cleaner code.

## Authorship
Myself + Spookerton I think from the Bay emissives work.

## Changelog
Nothing player-facing.