### PR TITLE
Replacing blinded with is_blind(), HAS_STATUS and SET_STATUS_MAX.

### DIFF
--- a/code/_onclick/hud/ai.dm
+++ b/code/_onclick/hud/ai.dm
@@ -2,6 +2,7 @@
 	hud_type = /datum/hud/ai
 
 /datum/hud/ai/FinalizeInstantiation()
+	adding = list()
 	var/list/ai_hud_data = decls_repository.get_decls_of_subtype(/decl/ai_hud)
 	for(var/elem_type in ai_hud_data)
 		var/decl/ai_hud/ai_hud = ai_hud_data[elem_type]

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -83,7 +83,7 @@
 					H.flash_eyes()
 					E.damage += rand(1, 5)
 
-		if(!O.blinded)
+		if(!O.is_blind())
 			do_flash(O, flash_time)
 
 /obj/machinery/flasher/proc/do_flash(var/mob/living/victim, var/flash_time)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -137,7 +137,7 @@
 
 	if(!BP_IS_PROSTHETIC(vision))
 
-		if(vision.owner.stat == DEAD || H.blinded)	//mob is dead or fully blind
+		if(vision.owner.stat == DEAD || H.is_blind())	//mob is dead or fully blind
 			to_chat(user, "<span class='warning'>\The [H]'s pupils do not react to the light!</span>")
 			return
 		if(MUTATION_XRAY in H.mutations)

--- a/code/modules/admin/view_variables/helpers.dm
+++ b/code/modules/admin/view_variables/helpers.dm
@@ -66,6 +66,7 @@
 		<option value='?_src_=vars;removeaura=\ref[src]'>Remove Aura</option>
 		<option value='?_src_=vars;addstressor=\ref[src]'>Add Stressor</option>
 		<option value='?_src_=vars;removestressor=\ref[src]'>Remove Stressor</option>
+		<option value='?_src_=vars;setstatuscond=\ref[src]'>Set Status Condition</option>
 		"}
 
 /mob/living/carbon/human/get_view_variables_options()

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -613,7 +613,7 @@
 			return
 		var/duration = clamp(input("Enter a duration ([STRESSOR_DURATION_INDEFINITE] for permanent).", "Add Stressor") as num|null, STRESSOR_DURATION_INDEFINITE, INFINITY)
 		if(duration && L.add_stressor(stressor, duration))
-			log_and_message_admins("added [stressor] to \the [src] for duration [duration].")
+			log_and_message_admins("added [stressor] to \the [L] for duration [duration].")
 
 	else if(href_list["removestressor"])
 		if(!check_rights(R_DEBUG))
@@ -626,7 +626,28 @@
 			return
 		var/datum/stressor/stressor = input("Select a stressor to remove.", "Remove Stressor") as null|anything in L.stressors
 		if(L.remove_stressor(stressor))
-			log_and_message_admins("removed [stressor] from \the [src].")
+			log_and_message_admins("removed [stressor] from \the [L].")
+
+	else if(href_list["setstatuscond"])
+		if(!check_rights(R_DEBUG))
+			return
+		var/mob/living/L = locate(href_list["removestressor"])
+		if(!istype(L))
+			return
+		var/list/all_status_conditions = decls_repository.get_decls_of_subtype(/decl/status_condition)
+		var/list/select_from_conditions = list()
+		for(var/status_cond in all_status_conditions)
+			select_from_conditions += all_status_conditions[status_cond]
+		var/decl/status_condition/selected_condition = input("Select a status condition to set.", "Set Status Condition") as null|anything in select_from_conditions
+		if(!selected_condition || QDELETED(L) || !check_rights(R_DEBUG))
+			return
+		var/amt = input("Enter an amount to set the condition to.", "Set Status Condition") as num|null
+		if(isnull(amt) || QDELETED(L) || !check_rights(R_DEBUG))
+			return
+		if(amt < 0)
+			amt += GET_STATUS(L, selected_condition.type)
+		L.set_status(selected_condition.type, amt)
+		log_and_message_admins("set [selected_condition.name] to [amt] on \the [L].")
 
 	else if(href_list["setmaterial"])
 		if(!check_rights(R_DEBUG))	return

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -631,7 +631,7 @@
 	else if(href_list["setstatuscond"])
 		if(!check_rights(R_DEBUG))
 			return
-		var/mob/living/L = locate(href_list["removestressor"])
+		var/mob/living/L = locate(href_list["setstatuscond"])
 		if(!istype(L))
 			return
 		var/list/all_status_conditions = decls_repository.get_decls_of_subtype(/decl/status_condition)

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -473,7 +473,7 @@
 				if(flash_time <= 0)
 					return
 
-			if(!O.blinded)
+			if(!O.is_blind())
 				O.flash_eyes(FLASH_PROTECTION_MODERATE - protection)
 				SET_STATUS_MAX(O, STAT_BLURRY, flash_time)
 				SET_STATUS_MAX(O, STAT_CONFUSE, (flash_time + 2))
@@ -519,7 +519,7 @@
 				if(flash_time <= 0)
 					return
 
-			if(!O.blinded)
+			if(!O.is_blind())
 				O.flash_eyes(FLASH_PROTECTION_MAJOR - protection)
 				SET_STATUS_MAX(O, STAT_BLURRY, flash_time)
 				SET_STATUS_MAX(O, STAT_CONFUSE, (flash_time + 2))

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -186,11 +186,9 @@
 	if(istype(affecting_mob) && G.special_target_functional)
 		switch(G.target_zone)
 			if(BP_MOUTH)
-				if(GET_STATUS(affecting_mob, STAT_SILENCE) < 2)
-					affecting_mob.set_status(STAT_SILENCE, 2)
+				SET_STATUS_MAX(affecting_mob, STAT_SILENCE, 2)
 			if(BP_EYES)
-				if(GET_STATUS(affecting_mob, STAT_BLIND) < 2)
-					affecting_mob.set_status(STAT_BLIND, 2)
+				SET_STATUS_MAX(affecting_mob, STAT_BLIND, 2)
 
 // Handles when they change targeted areas and something is supposed to happen.
 /decl/grab/normal/special_target_change(var/obj/item/grab/G, old_zone, new_zone)

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -31,7 +31,7 @@
 
 	//non-verbal languages are garbled if you can't see the speaker. Yes, this includes if they are inside a closet.
 	if (language && (language.flags & LANG_FLAG_NONVERBAL))
-		if (!speaker || (src.sdisabilities & BLINDED || src.blinded) || !(speaker in view(src)))
+		if (!speaker || is_blind() || !(speaker in view(src)))
 			message = stars(message)
 
 	var/understands_language = say_understands(speaker, language)
@@ -104,7 +104,7 @@
 
 	//non-verbal languages are garbled if you can't see the speaker. Yes, this includes if they are inside a closet.
 	if (language && (language.flags & LANG_FLAG_NONVERBAL))
-		if (!speaker || (src.sdisabilities & BLINDED || src.blinded) || !(speaker in view(src)))
+		if (!speaker || is_blind() || !(speaker in view(src)))
 			message = stars(message)
 
 	if(!(language && (language.flags & LANG_FLAG_INNATE))) // skip understanding checks for LANG_FLAG_INNATE languages

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -23,18 +23,18 @@
 	if(status_flags & GODMODE)	return 0
 
 	if(stat == DEAD)
-		SET_STATUS_MAX(src, STAT_BLIND, 2)
+		SET_STATUS_MAX(src, STAT_BLIND, 1)
 		set_status(STAT_SILENCE, 0)
 	else
 		updatehealth()
 		if(health <= 0)
 			death()
-			SET_STATUS_MAX(src, STAT_BLIND, 2)
+			SET_STATUS_MAX(src, STAT_BLIND, 1)
 			set_status(STAT_SILENCE, 0)
 			return 1
 
 		if(HAS_STATUS(src, STAT_PARA))
-			SET_STATUS_MAX(src, STAT_BLIND, 2)
+			SET_STATUS_MAX(src, STAT_BLIND, 1)
 			set_stat(UNCONSCIOUS)
 			if(getHalLoss() > 0)
 				adjustHalLoss(-3)
@@ -44,7 +44,7 @@
 			if (mind)
 				if(mind.active && client != null)
 					ADJ_STATUS(src, STAT_ASLEEP, -1)
-			SET_STATUS_MAX(src, STAT_BLIND, 2)
+			SET_STATUS_MAX(src, STAT_BLIND, 1)
 			set_stat(UNCONSCIOUS)
 		else if(resting)
 			if(getHalLoss() > 0)
@@ -57,8 +57,8 @@
 
 		// Eyes and blindness.
 		if(!check_has_eyes())
-			set_status(STAT_BLIND, 1)
-			set_status(STAT_BLURRY, 1)
+			SET_STATUS_MAX(src, STAT_BLIND, 1)
+			SET_STATUS_MAX(src, STAT_BLURRY, 1)
 		else if(GET_STATUS(src, STAT_BLIND))
 			ADJ_STATUS(src, STAT_BLIND, -1)
 

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -22,20 +22,19 @@
 
 	if(status_flags & GODMODE)	return 0
 
-	var/is_blind = FALSE
 	if(stat == DEAD)
-		is_blind = TRUE
+		SET_STATUS_MAX(src, STAT_BLIND, 2)
 		set_status(STAT_SILENCE, 0)
 	else
 		updatehealth()
 		if(health <= 0)
 			death()
-			is_blind = TRUE
+			SET_STATUS_MAX(src, STAT_BLIND, 2)
 			set_status(STAT_SILENCE, 0)
 			return 1
 
 		if(HAS_STATUS(src, STAT_PARA))
-			is_blind = TRUE
+			SET_STATUS_MAX(src, STAT_BLIND, 2)
 			set_stat(UNCONSCIOUS)
 			if(getHalLoss() > 0)
 				adjustHalLoss(-3)
@@ -45,7 +44,7 @@
 			if (mind)
 				if(mind.active && client != null)
 					ADJ_STATUS(src, STAT_ASLEEP, -1)
-			is_blind = TRUE
+			SET_STATUS_MAX(src, STAT_BLIND, 2)
 			set_stat(UNCONSCIOUS)
 		else if(resting)
 			if(getHalLoss() > 0)
@@ -59,16 +58,11 @@
 		// Eyes and blindness.
 		if(!check_has_eyes())
 			set_status(STAT_BLIND, 1)
-			is_blind = TRUE
 			set_status(STAT_BLURRY, 1)
 		else if(GET_STATUS(src, STAT_BLIND))
 			ADJ_STATUS(src, STAT_BLIND, -1)
-			is_blind = TRUE
 
 		update_icon()
-
-	if(is_blind)
-		SET_STATUS_MAX(src, STAT_BLIND, 2)
 
 	return 1
 

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -23,18 +23,18 @@
 	if(status_flags & GODMODE)	return 0
 
 	if(stat == DEAD)
-		SET_STATUS_MAX(src, STAT_BLIND, 1)
+		SET_STATUS_MAX(src, STAT_BLIND, 2)
 		set_status(STAT_SILENCE, 0)
 	else
 		updatehealth()
 		if(health <= 0)
 			death()
-			SET_STATUS_MAX(src, STAT_BLIND, 1)
+			SET_STATUS_MAX(src, STAT_BLIND, 2)
 			set_status(STAT_SILENCE, 0)
 			return 1
 
 		if(HAS_STATUS(src, STAT_PARA))
-			SET_STATUS_MAX(src, STAT_BLIND, 1)
+			SET_STATUS_MAX(src, STAT_BLIND, 2)
 			set_stat(UNCONSCIOUS)
 			if(getHalLoss() > 0)
 				adjustHalLoss(-3)
@@ -44,7 +44,7 @@
 			if (mind)
 				if(mind.active && client != null)
 					ADJ_STATUS(src, STAT_ASLEEP, -1)
-			SET_STATUS_MAX(src, STAT_BLIND, 1)
+			SET_STATUS_MAX(src, STAT_BLIND, 2)
 			set_stat(UNCONSCIOUS)
 		else if(resting)
 			if(getHalLoss() > 0)
@@ -57,7 +57,7 @@
 
 		// Eyes and blindness.
 		if(!check_has_eyes())
-			SET_STATUS_MAX(src, STAT_BLIND, 1)
+			SET_STATUS_MAX(src, STAT_BLIND, 2)
 			SET_STATUS_MAX(src, STAT_BLURRY, 1)
 		else if(GET_STATUS(src, STAT_BLIND))
 			ADJ_STATUS(src, STAT_BLIND, -1)

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -41,9 +41,6 @@
 
 		if(HAS_STATUS(src, STAT_ASLEEP))
 			adjustHalLoss(-3)
-			if (mind)
-				if(mind.active && client != null)
-					ADJ_STATUS(src, STAT_ASLEEP, -1)
 			SET_STATUS_MAX(src, STAT_BLIND, 2)
 			set_stat(UNCONSCIOUS)
 		else if(resting)
@@ -59,8 +56,6 @@
 		if(!check_has_eyes())
 			SET_STATUS_MAX(src, STAT_BLIND, 2)
 			SET_STATUS_MAX(src, STAT_BLURRY, 1)
-		else if(GET_STATUS(src, STAT_BLIND))
-			ADJ_STATUS(src, STAT_BLIND, -1)
 
 		update_icon()
 

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -1,16 +1,10 @@
 // Alien larva are quite simple.
 /mob/living/carbon/alien/Life()
-
 	set invisibility = 0
 	set background = 1
-
 	if (HAS_TRANSFORMATION_MOVEMENT_HANDLER(src))	return
 	if(!loc)			return
-
 	..()
-
-	blinded = null
-
 	//Status updates, death etc.
 	update_icon()
 
@@ -28,19 +22,20 @@
 
 	if(status_flags & GODMODE)	return 0
 
+	var/is_blind = FALSE
 	if(stat == DEAD)
-		blinded = 1
+		is_blind = TRUE
 		set_status(STAT_SILENCE, 0)
 	else
 		updatehealth()
 		if(health <= 0)
 			death()
-			blinded = 1
+			is_blind = TRUE
 			set_status(STAT_SILENCE, 0)
 			return 1
 
 		if(HAS_STATUS(src, STAT_PARA))
-			blinded = 1
+			is_blind = TRUE
 			set_stat(UNCONSCIOUS)
 			if(getHalLoss() > 0)
 				adjustHalLoss(-3)
@@ -50,7 +45,7 @@
 			if (mind)
 				if(mind.active && client != null)
 					ADJ_STATUS(src, STAT_ASLEEP, -1)
-			blinded = 1
+			is_blind = TRUE
 			set_stat(UNCONSCIOUS)
 		else if(resting)
 			if(getHalLoss() > 0)
@@ -64,13 +59,16 @@
 		// Eyes and blindness.
 		if(!check_has_eyes())
 			set_status(STAT_BLIND, 1)
-			blinded = 1
+			is_blind = TRUE
 			set_status(STAT_BLURRY, 1)
 		else if(GET_STATUS(src, STAT_BLIND))
 			ADJ_STATUS(src, STAT_BLIND, -1)
-			blinded = 1
+			is_blind = TRUE
 
 		update_icon()
+
+	if(is_blind)
+		SET_STATUS_MAX(src, STAT_BLIND, 2)
 
 	return 1
 
@@ -97,7 +95,7 @@
 			healths.icon_state = "health7"
 
 	if(stat != DEAD)
-		if(blinded)
+		if(is_blind())
 			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
 		else
 			clear_fullscreen("blind")

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -75,14 +75,13 @@
 /mob/living/carbon/brain/handle_regular_status_updates()	//TODO: comment out the unused bits >_>
 	updatehealth()
 
-	var/is_blind = FALSE
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
-		is_blind = TRUE
+		SET_STATUS_MAX(src, STAT_BLIND, 1)
 		set_status(STAT_SILENCE, 0)
 	else				//ALIVE. LIGHTS ARE ON
 		if( !container && (health < config.health_threshold_dead || (config.revival_brain_life >= 0 && (world.time - timeofhostdeath) > config.revival_brain_life)) )
 			death()
-			is_blind = TRUE
+			SET_STATUS_MAX(src, STAT_BLIND, 1)
 			set_status(STAT_SILENCE, 0)
 			return 1
 
@@ -96,10 +95,9 @@
 				if(31 to INFINITY)
 					emp_damage = 30//Let's not overdo it
 				if(21 to 30)//High level of EMP damage, unable to see, hear, or speak
-					set_status(STAT_BLIND, 1)
-					is_blind = TRUE
+					SET_STATUS_MAX(src, STAT_BLIND, 1)
 					SET_STATUS_MAX(src, STAT_DEAF, 1)
-					set_status(STAT_SILENCE, 1)
+					SET_STATUS_MAX(src, STAT_SILENCE, 1)
 					if(!alert)//Sounds an alarm, but only once per 'level'
 						emote("alarm")
 						to_chat(src, "<span class='warning'>Major electrical distruption detected: System rebooting.</span>")
@@ -137,9 +135,6 @@
 					alert = 0
 					to_chat(src, "<span class='warning'>All systems restored.</span>")
 					emp_damage -= 1
-
-	if(is_blind)
-		SET_STATUS_MAX(src, STAT_BLIND, 2)
 
 	return 1
 

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -75,13 +75,14 @@
 /mob/living/carbon/brain/handle_regular_status_updates()	//TODO: comment out the unused bits >_>
 	updatehealth()
 
+	var/is_blind = FALSE
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
-		blinded = 1
+		is_blind = TRUE
 		set_status(STAT_SILENCE, 0)
 	else				//ALIVE. LIGHTS ARE ON
 		if( !container && (health < config.health_threshold_dead || (config.revival_brain_life >= 0 && (world.time - timeofhostdeath) > config.revival_brain_life)) )
 			death()
-			blinded = 1
+			is_blind = TRUE
 			set_status(STAT_SILENCE, 0)
 			return 1
 
@@ -96,7 +97,7 @@
 					emp_damage = 30//Let's not overdo it
 				if(21 to 30)//High level of EMP damage, unable to see, hear, or speak
 					set_status(STAT_BLIND, 1)
-					blinded = 1
+					is_blind = TRUE
 					SET_STATUS_MAX(src, STAT_DEAF, 1)
 					set_status(STAT_SILENCE, 1)
 					if(!alert)//Sounds an alarm, but only once per 'level'
@@ -107,7 +108,6 @@
 						emp_damage -= 1
 				if(20)
 					alert = 0
-					blinded = 0
 					set_status(STAT_BLIND,   0)
 					set_status(STAT_DEAF,    0)
 					set_status(STAT_SILENCE, 0)
@@ -138,6 +138,9 @@
 					to_chat(src, "<span class='warning'>All systems restored.</span>")
 					emp_damage -= 1
 
+	if(is_blind)
+		SET_STATUS_MAX(src, STAT_BLIND, 2)
+
 	return 1
 
 /mob/living/carbon/brain/handle_regular_hud_updates()
@@ -163,7 +166,7 @@
 			healths.icon_state = "health7"
 
 	if(stat != DEAD)
-		if(blinded)
+		if(is_blind())
 			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
 		else
 			clear_fullscreen("blind")

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -76,12 +76,12 @@
 	updatehealth()
 
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
-		SET_STATUS_MAX(src, STAT_BLIND, 1)
+		SET_STATUS_MAX(src, STAT_BLIND, 2)
 		set_status(STAT_SILENCE, 0)
 	else				//ALIVE. LIGHTS ARE ON
 		if( !container && (health < config.health_threshold_dead || (config.revival_brain_life >= 0 && (world.time - timeofhostdeath) > config.revival_brain_life)) )
 			death()
-			SET_STATUS_MAX(src, STAT_BLIND, 1)
+			SET_STATUS_MAX(src, STAT_BLIND, 2)
 			set_status(STAT_SILENCE, 0)
 			return 1
 
@@ -95,9 +95,9 @@
 				if(31 to INFINITY)
 					emp_damage = 30//Let's not overdo it
 				if(21 to 30)//High level of EMP damage, unable to see, hear, or speak
-					SET_STATUS_MAX(src, STAT_BLIND, 1)
-					SET_STATUS_MAX(src, STAT_DEAF, 1)
-					SET_STATUS_MAX(src, STAT_SILENCE, 1)
+					SET_STATUS_MAX(src, STAT_BLIND, 2)
+					SET_STATUS_MAX(src, STAT_DEAF, 2)
+					SET_STATUS_MAX(src, STAT_SILENCE, 2)
 					if(!alert)//Sounds an alarm, but only once per 'level'
 						emote("alarm")
 						to_chat(src, "<span class='warning'>Major electrical distruption detected: System rebooting.</span>")
@@ -111,8 +111,8 @@
 					set_status(STAT_SILENCE, 0)
 					emp_damage -= 1
 				if(11 to 19)//Moderate level of EMP damage, resulting in nearsightedness and ear damage
-					set_status(STAT_BLURRY, 1)
-					set_status(STAT_TINNITUS, 1)
+					set_status(STAT_BLURRY, 2)
+					set_status(STAT_TINNITUS, 2)
 					if(!alert)
 						emote("alert")
 						to_chat(src, "<span class='warning'>Primary systems are now online.</span>")

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -213,8 +213,8 @@
 			to_chat(src, "<span class='warning'>Your eyes are really starting to hurt. This can't be good for you!</span>")
 		if (E.damage >= E.min_bruised_damage)
 			to_chat(src, "<span class='danger'>You go blind!</span>")
-			set_status(STAT_BLIND, 5)
-			set_status(STAT_BLURRY, 5)
+			SET_STATUS_MAX(src, STAT_BLIND, 5)
+			SET_STATUS_MAX(src, STAT_BLURRY, 5)
 			disabilities |= NEARSIGHTED
 			spawn(100)
 				disabilities &= ~NEARSIGHTED

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -388,9 +388,8 @@
 	if(status_flags & GODMODE)	return 0
 
 	//SSD check, if a logged player is awake put them back to sleep!
-	var/is_blind = FALSE
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
-		is_blind = TRUE
+		SET_STATUS_MAX(src, STAT_BLIND, 2)
 		set_status(STAT_SILENCE, 0)
 	else				//ALIVE. LIGHTS ARE ON
 		updatehealth()	//TODO
@@ -405,7 +404,7 @@
 			SET_STATUS_MAX(src, STAT_PARA, 10)
 
 		if(HAS_STATUS(src, STAT_PARA) ||HAS_STATUS(src, STAT_ASLEEP))
-			is_blind = TRUE
+			SET_STATUS_MAX(src, STAT_BLIND, 2)
 			set_stat(UNCONSCIOUS)
 			animate_tail_reset()
 			adjustHalLoss(-3)
@@ -463,9 +462,6 @@
 			ADJ_STATUS(src, STAT_DROWSY, min(stasis_value, 3))
 			if(!stat && prob(1))
 				to_chat(src, "<span class='notice'>You feel slow and sluggish...</span>")
-
-	if(is_blind)
-		SET_STATUS_MAX(src, STAT_BLIND, 2)
 
 	return 1
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -159,11 +159,9 @@
 		set_status(STAT_BLIND, 1)
 		blinded =    1
 		set_status(STAT_BLURRY, 1)
-	else
-		//blindness
-		if(!(sdisabilities & BLINDED))
-			if(equipment_tint_total >= TINT_BLIND)	// Covered eyes, heal faster
-				ADJ_STATUS(src, STAT_BLURRY, -1)
+	// Non-genetic blindness; covered eyes will heal faster.
+	else if(!(sdisabilities & BLINDED) && equipment_tint_total >= TINT_BLIND)
+		ADJ_STATUS(src, STAT_BLURRY, -1)
 
 /mob/living/carbon/human/handle_disabilities()
 	..()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -155,8 +155,8 @@
 		set_status(STAT_BLIND, 0)
 		set_status(STAT_BLURRY, 0)
 	else if(!vision || (vision && !vision.is_usable()))   // Vision organs cut out or broken? Permablind.
-		set_status(STAT_BLIND, 1)
-		set_status(STAT_BLURRY, 1)
+		SET_STATUS_MAX(src, STAT_BLIND, 1)
+		SET_STATUS_MAX(src, STAT_BLURRY, 1)
 	// Non-genetic blindness; covered eyes will heal faster.
 	else if(!(sdisabilities & BLINDED) && equipment_tint_total >= TINT_BLIND)
 		ADJ_STATUS(src, STAT_BLURRY, -1)
@@ -389,7 +389,7 @@
 
 	//SSD check, if a logged player is awake put them back to sleep!
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
-		SET_STATUS_MAX(src, STAT_BLIND, 2)
+		SET_STATUS_MAX(src, STAT_BLIND, 1)
 		set_status(STAT_SILENCE, 0)
 	else				//ALIVE. LIGHTS ARE ON
 		updatehealth()	//TODO
@@ -404,7 +404,7 @@
 			SET_STATUS_MAX(src, STAT_PARA, 10)
 
 		if(HAS_STATUS(src, STAT_PARA) ||HAS_STATUS(src, STAT_ASLEEP))
-			SET_STATUS_MAX(src, STAT_BLIND, 2)
+			SET_STATUS_MAX(src, STAT_BLIND, 1)
 			set_stat(UNCONSCIOUS)
 			animate_tail_reset()
 			adjustHalLoss(-3)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -153,11 +153,9 @@
 
 	if(!root_bodytype.vision_organ) // Presumably if a species has no vision organs, they see via some other means.
 		set_status(STAT_BLIND, 0)
-		blinded =    0
 		set_status(STAT_BLURRY, 0)
 	else if(!vision || (vision && !vision.is_usable()))   // Vision organs cut out or broken? Permablind.
 		set_status(STAT_BLIND, 1)
-		blinded =    1
 		set_status(STAT_BLURRY, 1)
 	// Non-genetic blindness; covered eyes will heal faster.
 	else if(!(sdisabilities & BLINDED) && equipment_tint_total >= TINT_BLIND)
@@ -390,8 +388,9 @@
 	if(status_flags & GODMODE)	return 0
 
 	//SSD check, if a logged player is awake put them back to sleep!
+	var/is_blind = FALSE
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
-		blinded = 1
+		is_blind = TRUE
 		set_status(STAT_SILENCE, 0)
 	else				//ALIVE. LIGHTS ARE ON
 		updatehealth()	//TODO
@@ -406,7 +405,7 @@
 			SET_STATUS_MAX(src, STAT_PARA, 10)
 
 		if(HAS_STATUS(src, STAT_PARA) ||HAS_STATUS(src, STAT_ASLEEP))
-			blinded = 1
+			is_blind = TRUE
 			set_stat(UNCONSCIOUS)
 			animate_tail_reset()
 			adjustHalLoss(-3)
@@ -464,6 +463,9 @@
 			ADJ_STATUS(src, STAT_DROWSY, min(stasis_value, 3))
 			if(!stat && prob(1))
 				to_chat(src, "<span class='notice'>You feel slow and sluggish...</span>")
+
+	if(is_blind)
+		SET_STATUS_MAX(src, STAT_BLIND, 2)
 
 	return 1
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -155,7 +155,7 @@
 		set_status(STAT_BLIND, 0)
 		set_status(STAT_BLURRY, 0)
 	else if(!vision || (vision && !vision.is_usable()))   // Vision organs cut out or broken? Permablind.
-		SET_STATUS_MAX(src, STAT_BLIND, 1)
+		SET_STATUS_MAX(src, STAT_BLIND, 2)
 		SET_STATUS_MAX(src, STAT_BLURRY, 1)
 	// Non-genetic blindness; covered eyes will heal faster.
 	else if(!(sdisabilities & BLINDED) && equipment_tint_total >= TINT_BLIND)
@@ -389,7 +389,7 @@
 
 	//SSD check, if a logged player is awake put them back to sleep!
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
-		SET_STATUS_MAX(src, STAT_BLIND, 1)
+		SET_STATUS_MAX(src, STAT_BLIND, 2)
 		set_status(STAT_SILENCE, 0)
 	else				//ALIVE. LIGHTS ARE ON
 		updatehealth()	//TODO
@@ -404,7 +404,7 @@
 			SET_STATUS_MAX(src, STAT_PARA, 10)
 
 		if(HAS_STATUS(src, STAT_PARA) ||HAS_STATUS(src, STAT_ASLEEP))
-			SET_STATUS_MAX(src, STAT_BLIND, 1)
+			SET_STATUS_MAX(src, STAT_BLIND, 2)
 			set_stat(UNCONSCIOUS)
 			animate_tail_reset()
 			adjustHalLoss(-3)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -29,7 +29,6 @@
 		//Body temperature adjusts itself (self-regulation)
 		stabilize_body_temperature()
 
-	blinded = 0 // Placing this here just show how out of place it is.
 	// human/handle_regular_status_updates() needs a cleanup, as blindness should be handled in handle_disabilities()
 	handle_regular_status_updates() // Status & health update, are we dead or alive etc.
 	handle_stasis()

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -270,11 +270,11 @@
 
 /mob/living/proc/handle_impaired_vision()
 	if((sdisabilities & BLINDED) || stat) //blindness from disability or unconsciousness doesn't get better on its own
-		SET_STATUS_MAX(src, STAT_BLIND, 1)
+		SET_STATUS_MAX(src, STAT_BLIND, 2)
 
 /mob/living/proc/handle_impaired_hearing()
 	if((sdisabilities & DEAFENED) || stat) //disabled-deaf, doesn't get better on its own
-		SET_STATUS_MAX(src, STAT_TINNITUS, 1)
+		SET_STATUS_MAX(src, STAT_TINNITUS, 2)
 
 //this handles hud updates. Calls update_vision() and handle_hud_icons()
 /mob/living/proc/handle_regular_hud_updates()

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -270,7 +270,7 @@
 
 /mob/living/proc/handle_impaired_vision()
 	if((sdisabilities & BLINDED) || stat) //blindness from disability or unconsciousness doesn't get better on its own
-		SET_STATUS_MAX(src, STAT_BLIND, 2)
+		SET_STATUS_MAX(src, STAT_BLIND, 1)
 
 /mob/living/proc/handle_impaired_hearing()
 	if((sdisabilities & DEAFENED) || stat) //disabled-deaf, doesn't get better on its own

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -410,8 +410,7 @@ default behaviour is:
 	sdisabilities = 0
 	disabilities = 0
 
-	// fix blindness and deafness
-	blinded =     0
+	// fix all status conditions including blind/deaf
 	clear_status_effects()
 
 	heal_overall_damage(getBruteLoss(), getFireLoss())

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -35,7 +35,6 @@
 
 	process_queued_alarms()
 	handle_regular_hud_updates()
-	handle_status_effects()
 
 	switch(src.sensor_mode)
 		if (SEC_HUD)
@@ -44,6 +43,7 @@
 			process_med_hud(src,0,src.eyeobj,get_computer_network())
 
 	process_os()
+	handle_status_effects()
 
 	if(controlling_drone && stat != CONSCIOUS)
 		controlling_drone.release_ai_control("<b>WARNING: Primary control loop failure.</b> Session terminated.")

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -82,13 +82,7 @@
 	if (src.stat != DEAD) //Alive.
 		if (incapacitated(INCAPACITATION_DISRUPTED) || !has_power)
 			src.set_stat(UNCONSCIOUS)
-			if (HAS_STATUS(src, STAT_STUN))
-				ADJ_STATUS(src, STAT_STUN, -1)
-			if(HAS_STATUS(src, STAT_WEAK))
-				ADJ_STATUS(src, STAT_WEAK, -1)
-			if (HAS_STATUS(src, STAT_PARA) > 0)
-				ADJ_STATUS(src, STAT_PARA, -1)
-				SET_STATUS_MAX(src, STAT_BLIND, 2)
+			SET_STATUS_MAX(src, STAT_BLIND, 2)
 		else	//Not stunned.
 			src.set_stat(CONSCIOUS)
 
@@ -96,9 +90,6 @@
 		cameranet.update_visibility(src, FALSE)
 		SET_STATUS_MAX(src, STAT_BLIND, 2)
 		src.set_stat(DEAD)
-
-	if(HAS_STATUS(src, STAT_BLIND))
-		ADJ_STATUS(src, STAT_BLIND, -1)
 
 	src.set_density(!src.lying)
 	if(src.sdisabilities & BLINDED)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -98,7 +98,6 @@
 
 	if(HAS_STATUS(src, STAT_BLIND))
 		ADJ_STATUS(src, STAT_BLIND, -1)
-		SET_STATUS_MAX(src, STAT_BLIND, 1)
 
 	src.set_density(!src.lying)
 	if(src.sdisabilities & BLINDED)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -88,13 +88,13 @@
 				ADJ_STATUS(src, STAT_WEAK, -1)
 			if (HAS_STATUS(src, STAT_PARA) > 0)
 				ADJ_STATUS(src, STAT_PARA, -1)
-				SET_STATUS_MAX(src, STAT_BLIND, 1)
+				SET_STATUS_MAX(src, STAT_BLIND, 2)
 		else	//Not stunned.
 			src.set_stat(CONSCIOUS)
 
 	else //Dead.
 		cameranet.update_visibility(src, FALSE)
-		SET_STATUS_MAX(src, STAT_BLIND, 1)
+		SET_STATUS_MAX(src, STAT_BLIND, 2)
 		src.set_stat(DEAD)
 
 	if(HAS_STATUS(src, STAT_BLIND))
@@ -102,7 +102,7 @@
 
 	src.set_density(!src.lying)
 	if(src.sdisabilities & BLINDED)
-		SET_STATUS_MAX(src, STAT_BLIND, 1)
+		SET_STATUS_MAX(src, STAT_BLIND, 2)
 
 	if(src.sdisabilities & DEAFENED)
 		src.set_status(STAT_DEAF, 1)
@@ -118,7 +118,7 @@
 			silicon_radio.on = 1
 
 	if(!isnull(components["camera"]) && !is_component_functioning("camera"))
-		SET_STATUS_MAX(src, STAT_BLIND, 1)
+		SET_STATUS_MAX(src, STAT_BLIND, 2)
 		cameranet.update_visibility(src, FALSE)
 
 	return 1

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -78,7 +78,6 @@
 	if(health < config.health_threshold_dead && src.stat != 2) //die only once
 		death()
 
-	var/is_blind = FALSE
 	if (src.stat != DEAD) //Alive.
 		if (incapacitated(INCAPACITATION_DISRUPTED) || !has_power)
 			src.set_stat(UNCONSCIOUS)
@@ -88,22 +87,23 @@
 				ADJ_STATUS(src, STAT_WEAK, -1)
 			if (HAS_STATUS(src, STAT_PARA) > 0)
 				ADJ_STATUS(src, STAT_PARA, -1)
-				is_blind = TRUE
+				SET_STATUS_MAX(src, STAT_BLIND, 1)
 		else	//Not stunned.
 			src.set_stat(CONSCIOUS)
 
 	else //Dead.
 		cameranet.update_visibility(src, FALSE)
-		is_blind = TRUE
+		SET_STATUS_MAX(src, STAT_BLIND, 1)
 		src.set_stat(DEAD)
 
 	if(HAS_STATUS(src, STAT_BLIND))
 		ADJ_STATUS(src, STAT_BLIND, -1)
-		is_blind = TRUE
+		SET_STATUS_MAX(src, STAT_BLIND, 1)
 
 	src.set_density(!src.lying)
 	if(src.sdisabilities & BLINDED)
-		is_blind = TRUE
+		SET_STATUS_MAX(src, STAT_BLIND, 1)
+
 	if(src.sdisabilities & DEAFENED)
 		src.set_status(STAT_DEAF, 1)
 
@@ -118,11 +118,8 @@
 			silicon_radio.on = 1
 
 	if(!isnull(components["camera"]) && !is_component_functioning("camera"))
-		is_blind = TRUE
+		SET_STATUS_MAX(src, STAT_BLIND, 1)
 		cameranet.update_visibility(src, FALSE)
-
-	if(is_blind)
-		SET_STATUS_MAX(src, STAT_BLIND, 2)
 
 	return 1
 

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -11,7 +11,6 @@
 	//Status updates, death etc.
 	clamp_values()
 	handle_regular_status_updates()
-	handle_status_effects()
 	handle_actions()
 
 	if(client)
@@ -23,6 +22,8 @@
 		process_locks()
 		process_queued_alarms()
 		process_os()
+
+	handle_status_effects()
 	UpdateLyingBuckledAndVerbStatus()
 
 /mob/living/silicon/robot/proc/clamp_values()

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -109,9 +109,7 @@
 /mob/living/simple_animal/corgi/attackby(var/obj/item/O, var/mob/user)  //Marker -Agouri
 	if(istype(O, /obj/item/newspaper))
 		if(!stat)
-			for(var/mob/M in viewers(user, null))
-				if ((M.client && !( M.blinded )))
-					M.show_message("<span class='notice'>[user] baps [name] on the nose with the rolled up [O]</span>")
+			visible_message(SPAN_NOTICE("\The [user] baps \the [src] on the nose with the rolled-up [O.name]!"))
 			spawn(0)
 				for(var/i in list(1,2,4,8,4,2,1,2))
 					set_dir(i)

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -48,11 +48,8 @@
 	OnDeathInLife()
 
 /mob/living/simple_animal/shade/proc/OnDeathInLife()
-	if(stat == 2)
+	if(stat == DEAD)
 		new /obj/item/ectoplasm (src.loc)
-		for(var/mob/M in viewers(src, null))
-			if((M.client && !( M.blinded )))
-				M.show_message("<span class='warning'>[src] lets out a contented sigh as their form unwinds.</span>")
-				ghostize()
+		visible_message(SPAN_WARNING("\The [src] lets out a contented sigh as their form unwinds."))
+		ghostize()
 		qdel(src)
-		return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -251,7 +251,7 @@
 	return restrained() ? FULLY_BUCKLED : PARTIALLY_BUCKLED
 
 /mob/proc/is_blind()
-	return ((sdisabilities & BLINDED) || blinded || incapacitated(INCAPACITATION_KNOCKOUT))
+	return (blinded || (sdisabilities & BLINDED) || incapacitated(INCAPACITATION_KNOCKOUT))
 
 /mob/proc/is_deaf()
 	return ((sdisabilities & DEAFENED) || incapacitated(INCAPACITATION_KNOCKOUT))
@@ -393,8 +393,8 @@
 	if(!usr || !usr.client)
 		return
 
-	if((is_blind(src) || usr.stat) && !isobserver(src))
-		to_chat(src, "<span class='notice'>Something is there but you can't see it.</span>")
+	if(is_blind() && !isobserver(src))
+		to_chat(src, SPAN_WARNING("Something is there but you can't see it."))
 		return TRUE
 
 	face_atom(A)
@@ -1114,7 +1114,7 @@
 	if(!QDELETED(src))
 		if(severity == 1)
 			physically_destroyed()
-		else if(!blinded)
+		else if(!is_blind())
 			flash_eyes()
 
 /mob/proc/get_telecomms_race_info()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -251,10 +251,10 @@
 	return restrained() ? FULLY_BUCKLED : PARTIALLY_BUCKLED
 
 /mob/proc/is_blind()
-	return (blinded || (sdisabilities & BLINDED) || incapacitated(INCAPACITATION_KNOCKOUT))
+	return ((sdisabilities & BLINDED) || incapacitated(INCAPACITATION_KNOCKOUT) || HAS_STATUS(src, STAT_BLIND))
 
 /mob/proc/is_deaf()
-	return ((sdisabilities & DEAFENED) || incapacitated(INCAPACITATION_KNOCKOUT))
+	return ((sdisabilities & DEAFENED) || incapacitated(INCAPACITATION_KNOCKOUT) || HAS_STATUS(src, STAT_DEAF))
 
 /mob/proc/is_physically_disabled()
 	return incapacitated(INCAPACITATION_DISABLED)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -129,7 +129,6 @@
 	var/voice_name = "unidentifiable voice"
 
 	var/faction = MOB_FACTION_NEUTRAL //Used for checking whether hostile simple animals will attack you, possibly more stuff later
-	var/blinded = null
 
 	//The last mob/living/carbon to push/drag/grab this mob (mostly used by slimes friend recognition)
 	var/weakref/last_handled_by_mob

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -400,13 +400,6 @@ var/global/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HURT)
 			else
 				hud_used.action_intent.icon_state = I_HELP
 
-/proc/is_blind(A)
-	if(istype(A, /mob/living/carbon))
-		var/mob/living/carbon/C = A
-		if(C.sdisabilities & BLINDED|| C.blinded)
-			return 1
-	return 0
-
 /mob/proc/welding_eyecheck()
 	return
 
@@ -471,7 +464,7 @@ var/global/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HURT)
 		communicate(/decl/communication_channel/dsay, C || O, message, /decl/dsay_communication/direct)
 
 /mob/proc/switch_to_camera(var/obj/machinery/camera/C)
-	if (!C.can_use() || stat || (get_dist(C, src) > 1 || machine != src || blinded))
+	if (!C.can_use() || stat || (get_dist(C, src) > 1 || machine != src || is_blind()))
 		return 0
 	check_eye(src)
 	return 1

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -7,7 +7,6 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "ghost"
 	appearance_flags = KEEP_TOGETHER | LONG_GLIDE
-	blinded = 0
 	anchored = TRUE	//  don't get pushed around
 	universal_speak = TRUE
 	mob_sort_value = 9

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -79,9 +79,9 @@
 	if(!owner)
 		return
 	if(is_bruised())
-		owner.set_status(STAT_BLURRY, 20)
+		SET_STATUS_MAX(owner, STAT_BLURRY, 20)
 	if(is_broken())
-		owner.set_status(STAT_BLIND, 20)
+		SET_STATUS_MAX(owner, STAT_BLIND, 20)
 
 /obj/item/organ/internal/eyes/proc/get_total_protection(var/flash_protection = FLASH_PROTECTION_NONE)
 	return (flash_protection + get_innate_flash_protection())

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -104,7 +104,7 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 		look(user)
 
 /obj/machinery/computer/ship/check_eye(var/mob/user)
-	if (!get_dist(user, src) > 1 || user.blinded || !linked )
+	if (!get_dist(user, src) > 1 || user.is_blind() || !linked )
 		unlook(user)
 		return -1
 	else

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -63,7 +63,7 @@
 		for(var/mob/living/mob in global.living_mob_list_)
 			var/turf/T = get_turf(mob)
 			var/area/A1 = T.loc
-			if(T && (T != TO) && (TO.z == T.z) && !mob.blinded)
+			if(T && (T != TO) && (TO.z == T.z) && !mob.is_blind())
 				var/visible = FALSE
 				if(A1 && (A1.area_flags & AREA_FLAG_EXTERNAL))
 					visible = TRUE

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -534,7 +534,7 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 			H.set_see_invisible(max(min(H.see_invisible, H.equipment_see_invis), vision[2]))
 
 	if(H.equipment_tint_total >= TINT_BLIND)
-		SET_STATUS_MAX(H, STAT_BLIND, 1)
+		SET_STATUS_MAX(H, STAT_BLIND, 2)
 
 	if(!H.client)//no client, no screen to update
 		return 1

--- a/mods/mobs/borers/mob/borer/borer.dm
+++ b/mods/mobs/borers/mob/borer/borer.dm
@@ -85,7 +85,6 @@
 
 	sdisabilities = 0
 	if(host)
-		blinded = host.blinded
 		set_status(STAT_BLIND, GET_STATUS(host, STAT_BLIND))
 		set_status(STAT_BLURRY, GET_STATUS(host, STAT_BLURRY))
 		if(host.sdisabilities & BLINDED)
@@ -93,7 +92,6 @@
 		if(host.sdisabilities & DEAFENED)
 			sdisabilities |= DEAFENED
 	else
-		blinded = FALSE
 		set_status(STAT_BLIND, 0)
 		set_status(STAT_BLURRY, 0)
 

--- a/mods/mobs/borers/mob/borer/borer.dm
+++ b/mods/mobs/borers/mob/borer/borer.dm
@@ -93,7 +93,7 @@
 		if(host.sdisabilities & DEAFENED)
 			sdisabilities |= DEAFENED
 	else
-		blinded =    FALSE
+		blinded = FALSE
 		set_status(STAT_BLIND, 0)
 		set_status(STAT_BLURRY, 0)
 

--- a/mods/species/serpentid/mobs/bodyparts_serpentid.dm
+++ b/mods/species/serpentid/mobs/bodyparts_serpentid.dm
@@ -122,7 +122,7 @@
 			lowblood_tally = 10
 			if(prob(10))
 				to_chat(owner, "<span class='warning'>Your body is barely functioning and is starting to shut down.</span>")
-				SET_STATUS_MAX(owner, STAT_PARA, 1)
+				SET_STATUS_MAX(owner, STAT_PARA, 2)
 				var/obj/item/organ/internal/I = pick(owner.internal_organs)
 				I.take_internal_damage(5)
 	..()


### PR DESCRIPTION
## Description of changes
- Replaces `blinded` with `is_blind()` or the `STAT_BLIND` condition in mob code.
- Replaces a bunch of status setting with SET_STATUS_MAX and a minimum value of 2 to avoid flickering/half tick conditions. This will need revisiting down the track when status conditions are made more immediate.
- Adds a VV dropdown option for setting status conditions on mobs.

## Why and what will this PR improve
Consistent blindness, nicer code.
Tested with:
- [X] Humans
- [x] Robots
- [x] Simple animals
- [X] Observers
- [x] AI eyes
- [x] Aliens
- [x] Brains

## Authorship
Myself.

## Changelog
Nothing player-facing.