### PR TITLE
Holomap fixes

### DIFF
--- a/code/controllers/subsystems/holomap.dm
+++ b/code/controllers/subsystems/holomap.dm
@@ -39,16 +39,11 @@ SUBSYSTEM_DEF(minimap)
 			single.Blend(A.holomap_color, ICON_MULTIPLY)
 		combinedareas.Blend(single, ICON_OVERLAY)
 
-	var/icon/map_base = icon(data.holomap_base)
-
-	// Generate the full sized map by blending the base and areas onto the backdrop
-	var/icon/big_map = icon(HOLOMAP_ICON, "stationmap")
-	big_map.Blend(map_base, ICON_OVERLAY)
-	big_map.Blend(combinedareas, ICON_OVERLAY)
-
 	// Generate the "small" map
 	var/icon/small_map = icon(HOLOMAP_ICON, "blank")
+
 	//Make it green.
+	var/icon/map_base = icon(data.holomap_base)
 	small_map.Blend(map_base, ICON_OVERLAY)
 	small_map.Blend(COLOR_HOLOMAP_HOLOFIER, ICON_MULTIPLY)
 	small_map.Blend(combinedareas, ICON_OVERLAY)

--- a/code/controllers/subsystems/holomap.dm
+++ b/code/controllers/subsystems/holomap.dm
@@ -5,8 +5,6 @@
 /datum/holomapdata
 	var/icon/holomap_base
 	var/list/icon/holomap_areas = list()
-	var/icon/holomap_combined
-	var/icon/holomap_areas_combined
 	var/icon/holomap_small
 
 SUBSYSTEM_DEF(minimap)
@@ -41,15 +39,12 @@ SUBSYSTEM_DEF(minimap)
 			single.Blend(A.holomap_color, ICON_MULTIPLY)
 		combinedareas.Blend(single, ICON_OVERLAY)
 
-	data.holomap_areas_combined = combinedareas
-
 	var/icon/map_base = icon(data.holomap_base)
 
 	// Generate the full sized map by blending the base and areas onto the backdrop
 	var/icon/big_map = icon(HOLOMAP_ICON, "stationmap")
 	big_map.Blend(map_base, ICON_OVERLAY)
 	big_map.Blend(combinedareas, ICON_OVERLAY)
-	data.holomap_combined = big_map
 
 	// Generate the "small" map
 	var/icon/small_map = icon(HOLOMAP_ICON, "blank")

--- a/code/modules/holomap/holomap.dm
+++ b/code/modules/holomap/holomap.dm
@@ -321,8 +321,10 @@
 	if(length(global.using_map.overmap_ids))
 		var/obj/effect/overmap/visitable/O = global.overmap_sectors["[z]"]
 
-		var/current_z_offset_x = (HOLOMAP_ICON_SIZE / 2) - WORLD_CENTER_X
-		var/current_z_offset_y = (HOLOMAP_ICON_SIZE / 2) - WORLD_CENTER_Y
+		if(isAI)
+			T = get_turf(user.client.eye)
+		cursor.pixel_x = (T.x - 6 + (HOLOMAP_ICON_SIZE / 2) - WORLD_CENTER_X) * PIXEL_MULTIPLIER
+		cursor.pixel_y = (T.y - 6 + (HOLOMAP_ICON_SIZE / 2) - WORLD_CENTER_Y) * PIXEL_MULTIPLIER
 
 		//For the given z level fetch the related map sector and build the list
 		if(istype(O))
@@ -371,11 +373,6 @@
 
 			//Reset to starting zlevel
 			set_level(current_z_index)
-		if(isAI)
-			T = get_turf(user.client.eye)
-		cursor.pixel_x = (T.x - 6 + current_z_offset_x) * PIXEL_MULTIPLIER
-		cursor.pixel_y = (T.y - 6 + current_z_offset_y) * PIXEL_MULTIPLIER
-
 
 /datum/station_holomap/proc/set_level(level)
 	if(level > z_levels.len)

--- a/code/modules/holomap/holomap.dm
+++ b/code/modules/holomap/holomap.dm
@@ -278,10 +278,12 @@
 	QDEL_NULL(station_map)
 	QDEL_NULL(cursor)
 	QDEL_NULL_LIST(legend)
-	QDEL_NULL_LIST(levels)
 	QDEL_NULL_LIST(lbuttons)
-	QDEL_NULL_LIST(maptexts)
-	QDEL_NULL_LIST(z_levels)
+	QDEL_LIST_ASSOC_VAL(maptexts)
+	QDEL_LIST_ASSOC_VAL(levels)
+	LAZYCLEARLIST(maptexts)
+	LAZYCLEARLIST(levels)
+	LAZYCLEARLIST(z_levels)
 	. = ..()
 
 /datum/station_holomap/proc/initialize_holomap(turf/T, isAI = null, mob/user = null, reinit = FALSE)
@@ -291,7 +293,7 @@
 		cursor.layer = HUD_ABOVE_ITEM_LAYER
 
 	if(!LAZYLEN(legend) || reinit)
-		QDEL_NULL_LIST(legend)
+		QDEL_LIST_ASSOC_VAL(legend)
 		legend = list(
 			new /obj/screen/legend(null, HOLOMAP_AREACOLOR_COMMAND, "■ Command"),
 			new /obj/screen/legend(null, HOLOMAP_AREACOLOR_SECURITY, "■ Security"),
@@ -306,10 +308,11 @@
 			new /obj/screen/legend/cursor(null, HOLOMAP_AREACOLOR_BASE, "You are here")
 		)
 	if(reinit)
-		QDEL_NULL_LIST(maptexts)
-		QDEL_NULL_LIST(levels)
-		QDEL_NULL_LIST(z_levels)
 		QDEL_NULL_LIST(lbuttons)
+		QDEL_LIST_ASSOC_VAL(maptexts)
+		LAZYCLEARLIST(maptexts)
+		LAZYCLEARLIST(levels)
+		LAZYCLEARLIST(z_levels)
 
 	station_map = image(icon(HOLOMAP_ICON, "stationmap"))
 	station_map.layer = UNDER_HUD_LAYER
@@ -386,8 +389,8 @@
 	if(z == z_levels[displayed_level])
 		station_map.overlays += cursor
 
-	station_map.overlays += levels["[z_levels[displayed_level]]"]
-	station_map.vis_contents += maptexts["[z_levels[displayed_level]]"]
+	station_map.overlays += LAZYACCESS(levels, "[z_levels[displayed_level]]")
+	station_map.vis_contents += LAZYACCESS(maptexts, "[z_levels[displayed_level]]")
 
 	//Fix legend position
 	var/pixel_y = HOLOMAP_LEGEND_Y

--- a/code/modules/holomap/holomap.dm
+++ b/code/modules/holomap/holomap.dm
@@ -286,8 +286,6 @@
 
 /datum/station_holomap/proc/initialize_holomap(turf/T, isAI = null, mob/user = null, reinit = FALSE)
 	z = T.z
-	if(!station_map || reinit)
-		station_map = image(SSminimap.holomaps[z].holomap_combined)
 	if(!cursor || reinit)
 		cursor = image('icons/misc/holomap_markers.dmi', "you")
 		cursor.layer = HUD_ABOVE_ITEM_LAYER


### PR DESCRIPTION
- Holomaps don't runtime error on qdel or reinit.
- Holomap cursors work first go instead of only after a level change.
Thanks @out-of-phaze for identifying the cursor issue and a fix.