### PR TITLE
Fix welding tool and fuel tank interactions

### DIFF
--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -395,6 +395,7 @@
 	icon              = 'icons/obj/items/tool/welders/welder_tanks.dmi'
 	icon_state        = "tank_normal"
 	w_class           = ITEM_SIZE_SMALL
+	atom_flags        = ATOM_FLAG_OPEN_CONTAINER
 	obj_flags         = OBJ_FLAG_HOLLOW
 	force             = 5
 	throwforce        = 5

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -264,10 +264,11 @@ var/global/obj/temp_reagents_holder = new
 
 /datum/reagents/proc/clear_reagents()
 	for(var/reagent in reagent_volumes)
-		clear_reagent(reagent, TRUE)
+		clear_reagent(reagent, defer_update = TRUE)
 	LAZYCLEARLIST(reagent_volumes)
 	LAZYCLEARLIST(reagent_data)
 	total_volume = 0
+	my_atom?.on_reagent_change()
 
 /datum/reagents/proc/get_overdose(var/decl/material/current)
 	if(current)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -21,6 +21,12 @@
 	if (!possible_transfer_amounts)
 		verbs -= /obj/structure/reagent_dispensers/verb/set_amount_dispensed
 
+/obj/structure/reagent_dispensers/on_reagent_change()
+	if(reagents.total_volume > 0)
+		tool_interaction_flags = 0
+	else
+		tool_interaction_flags = TOOL_INTERACTION_DECONSTRUCT
+
 /obj/structure/reagent_dispensers/initialize_reagents(populate = TRUE)
 	if(!reagents)
 		create_reagents(volume)


### PR DESCRIPTION
## Description of changes
Reagent dispensers can only be deconstructed if they are empty.
Welding tool internal tanks are now open containers.
`clear_reagents` now calls `on_reagent_change`.

## Why and what will this PR improve
You can now directly refill welding tools from fuel tanks again.
Welding tool internal tanks can now have reagents added or removed from them.
Things that use `on_reagent_change` will now update properly after being cleared.