### PR TITLE
Properly center holomap overlays

### DIFF
--- a/code/__defines/holomap.dm
+++ b/code/__defines/holomap.dm
@@ -29,9 +29,9 @@
 #define HOLOMAP_AREACOLOR_LIFTS       null
 
 // Handy defines to lookup the pixel offsets for holomap
-// Currently set to 0, left here in case of need for per map offsets
-#define HOLOMAP_PIXEL_OFFSET_X (0)
-#define HOLOMAP_PIXEL_OFFSET_Y (0)
+// world.maxx/y should always be greater than or equal to level_max_width/level_max_height
+#define HOLOMAP_PIXEL_OFFSET_X(zlevel) (round((world.maxx - SSmapping.levels_by_z[zlevel]?.level_max_width)/2))
+#define HOLOMAP_PIXEL_OFFSET_Y(zlevel) (round((world.maxy - SSmapping.levels_by_z[zlevel]?.level_max_height)/2))
 
 #define HOLOMAP_LEGEND_X 96
 #define HOLOMAP_LEGEND_Y 156

--- a/code/controllers/subsystems/holomap.dm
+++ b/code/controllers/subsystems/holomap.dm
@@ -58,6 +58,8 @@ SUBSYSTEM_DEF(minimap)
 	small_map.Blend(COLOR_HOLOMAP_HOLOFIER, ICON_MULTIPLY)
 	small_map.Blend(combinedareas, ICON_OVERLAY)
 	small_map.Scale(WORLD_ICON_SIZE, WORLD_ICON_SIZE)
+	var/const/border_size = 6 // the width of the border (non-map) section of the icon
+	small_map.Shift(NORTHEAST, border_size)
 
 	// And rotate it in every direction of course!
 	var/icon/actual_small_map = icon(small_map)

--- a/code/controllers/subsystems/holomap.dm
+++ b/code/controllers/subsystems/holomap.dm
@@ -54,9 +54,9 @@ SUBSYSTEM_DEF(minimap)
 	// Generate the "small" map
 	var/icon/small_map = icon(HOLOMAP_ICON, "blank")
 	//Make it green.
-	small_map.Blend(map_base, ICON_OVERLAY)
+	small_map.Blend(map_base, ICON_OVERLAY, HOLOMAP_PIXEL_OFFSET_X(zlevel), HOLOMAP_PIXEL_OFFSET_Y(zlevel))
 	small_map.Blend(COLOR_HOLOMAP_HOLOFIER, ICON_MULTIPLY)
-	small_map.Blend(combinedareas, ICON_OVERLAY)
+	small_map.Blend(combinedareas, ICON_OVERLAY, HOLOMAP_PIXEL_OFFSET_X(zlevel), HOLOMAP_PIXEL_OFFSET_Y(zlevel))
 	small_map.Scale(WORLD_ICON_SIZE, WORLD_ICON_SIZE)
 	var/const/border_size = 6 // the width of the border (non-map) section of the icon
 	small_map.Shift(NORTHEAST, border_size)
@@ -74,8 +74,8 @@ SUBSYSTEM_DEF(minimap)
 // Generates the "base" holomap for one z-level, showing only the physical structure of walls and paths.
 /datum/controller/subsystem/minimap/proc/generateBaseHolomap(zlevel = 1)
 	// Save these values now to avoid a bazillion array lookups
-	var/offset_x = HOLOMAP_PIXEL_OFFSET_X
-	var/offset_y = HOLOMAP_PIXEL_OFFSET_Y
+	var/offset_x = HOLOMAP_PIXEL_OFFSET_X(zlevel)
+	var/offset_y = HOLOMAP_PIXEL_OFFSET_Y(zlevel)
 
 	// Sanity checks - Better to generate a helpful error message now than have DrawBox() runtime
 	var/icon/canvas = icon(HOLOMAP_ICON, "blank")
@@ -99,8 +99,8 @@ SUBSYSTEM_DEF(minimap)
 /datum/controller/subsystem/minimap/proc/generateHolomapAreaOverlays(zlevel)
 	var/list/icon/areas = list()
 
-	var/offset_x = HOLOMAP_PIXEL_OFFSET_X
-	var/offset_y = HOLOMAP_PIXEL_OFFSET_Y
+	var/offset_x = HOLOMAP_PIXEL_OFFSET_X(zlevel)
+	var/offset_y = HOLOMAP_PIXEL_OFFSET_Y(zlevel)
 
 	for(var/x = 1 to world.maxx)
 		for(var/y = 1 to world.maxy)

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -22,9 +22,9 @@ SUBSYSTEM_DEF(mapping)
 	 * Z-Level Handling Stuff
 	 */
 	/// Associative list of levels by strict z-level
-	var/list/levels_by_z =  list()
+	var/list/datum/level_data/levels_by_z =  list()
 	/// Associative list of levels by string ID
-	var/list/levels_by_id = list()
+	var/list/datum/level_data/levels_by_id = list()
 	/// List of z-levels containing the 'main map'
 	var/list/station_levels = list()
 	/// List of z-levels for admin functionality (Centcom, shuttle transit, etc)
@@ -67,19 +67,6 @@ SUBSYSTEM_DEF(mapping)
 	for(var/datum/map_template/MT as anything in get_all_template_instances())
 		register_map_template(MT)
 
-	// Resize the world to the max template size to fix a BYOND bug with world resizing breaking events.
-	// REMOVE WHEN THIS IS FIXED: https://www.byond.com/forum/post/2833191
-	var/new_maxx = world.maxx
-	var/new_maxy = world.maxy
-	for(var/map_template_name in map_templates)
-		var/datum/map_template/map_template = map_templates[map_template_name]
-		new_maxx = max(map_template.width, new_maxx)
-		new_maxy = max(map_template.height, new_maxy)
-	if (new_maxx > world.maxx)
-		world.maxx = new_maxx
-	if (new_maxy > world.maxy)
-		world.maxy = new_maxy
-
 	// Generate turbolifts.
 	for(var/obj/abstract/turbolift_spawner/turbolift as anything in turbolifts_to_initialize)
 		turbolift.build_turbolift()
@@ -92,20 +79,41 @@ SUBSYSTEM_DEF(mapping)
 	// This needs to be non-null even if the overmap isn't created for this map.
 	overmap_event_handler = GET_DECL(/decl/overmap_event_handler)
 
-	// Build away sites.
-	global.using_map.build_away_sites()
-	global.using_map.build_planets()
-
-	// Initialize z-level objects.
-#ifdef UNIT_TEST
-	config.roundstart_level_generation = FALSE
-#endif
+	var/old_maxz
 	for(var/z = 1 to world.maxz)
 		var/datum/level_data/level = levels_by_z[z]
 		if(!istype(level))
 			level = new /datum/level_data/space(z)
 			PRINT_STACK_TRACE("Missing z-level data object for z[num2text(z)]!")
 		level.setup_level_data()
+
+	// Build away sites.
+	global.using_map.build_away_sites()
+	global.using_map.build_planets()
+	for(var/z = old_maxz + 1 to world.maxz)
+		var/datum/level_data/level = levels_by_z[z]
+		if(!istype(level))
+			level = new /datum/level_data/space(z)
+			PRINT_STACK_TRACE("Missing z-level data object for z[num2text(z)]!")
+		level.setup_level_data()
+
+	// Initialize z-level objects.
+#ifdef UNIT_TEST
+	config.roundstart_level_generation = FALSE
+#endif
+
+	// Resize the world to the max template size to fix a BYOND bug with world resizing breaking events.
+	// REMOVE WHEN THIS IS FIXED: https://www.byond.com/forum/post/2833191
+	var/new_maxx = world.maxx
+	var/new_maxy = world.maxy
+	for(var/map_template_name in map_templates)
+		var/datum/map_template/map_template = map_templates[map_template_name]
+		new_maxx = max(map_template.width, new_maxx)
+		new_maxy = max(map_template.height, new_maxy)
+	if (new_maxx > world.maxx)
+		world.maxx = new_maxx
+	if (new_maxy > world.maxy)
+		world.maxy = new_maxy
 
 	. = ..()
 

--- a/code/modules/holomap/holomap.dm
+++ b/code/modules/holomap/holomap.dm
@@ -57,8 +57,6 @@
 	small_station_map = image(icon = SSminimap.holomaps[original_zLevel].holomap_small)
 	small_station_map.plane = ABOVE_LIGHTING_PLANE
 	small_station_map.layer = ABOVE_LIGHTING_LAYER
-	small_station_map.pixel_x = 10
-	small_station_map.pixel_y = 10
 
 	update_icon()
 
@@ -320,8 +318,8 @@
 	if(length(global.using_map.overmap_ids))
 		var/obj/effect/overmap/visitable/O = global.overmap_sectors["[z]"]
 
-		var/current_z_offset_x = (HOLOMAP_ICON_SIZE / 2) - WORLD_CENTER_X
-		var/current_z_offset_y = (HOLOMAP_ICON_SIZE / 2) - WORLD_CENTER_Y
+		cursor.pixel_x = (T.x - 6 + (HOLOMAP_ICON_SIZE / 2) - WORLD_CENTER_X) * PIXEL_MULTIPLIER + HOLOMAP_PIXEL_OFFSET_X(z)
+		cursor.pixel_y = (T.y - 6 + (HOLOMAP_ICON_SIZE / 2) - WORLD_CENTER_Y) * PIXEL_MULTIPLIER + HOLOMAP_PIXEL_OFFSET_Y(z)
 
 		//For the given z level fetch the related map sector and build the list
 		if(istype(O))
@@ -372,8 +370,6 @@
 			set_level(current_z_index)
 		if(isAI)
 			T = get_turf(user.client.eye)
-		cursor.pixel_x = (T.x - 6 + current_z_offset_x) * PIXEL_MULTIPLIER
-		cursor.pixel_y = (T.y - 6 + current_z_offset_y) * PIXEL_MULTIPLIER
 
 
 /datum/station_holomap/proc/set_level(level)

--- a/maps/tradeship/tradeship_areas.dm
+++ b/maps/tradeship/tradeship_areas.dm
@@ -152,7 +152,7 @@
 	name = "\improper Fabrication Bay"
 	icon_state = "yellow"
 	req_access = list(access_research)
-	holomap_color = HOLOMAP_AREACOLOR_ENGINEERING
+	holomap_color = HOLOMAP_AREACOLOR_SCIENCE
 
 /area/ship/trade/crew/medbay/chemistry
 	name = "\improper Chemistry Bay"


### PR DESCRIPTION
## Description of changes
- Uses level_data level_max_width and level_max_height to center holomap overlays on small z-levels
- Splits SSmapping level_data init into two parts so that compiled-in levels will have the correct size in their data
- Adjusts how the icon overlay is generated so that it isn't shifted off the icon with a non-`SOUTH` `dir`.
Requires #3271.
- Adjusts the color of the fabrication bay on Tradeship holomaps to match the rest of Research.

## Why and what will this PR improve
Holomaps are now centered properly both on the main display and on their machinery icon.