### PR TITLE
Fix extensions causing GC failures

### DIFF
--- a/code/datums/extensions/extensions.dm
+++ b/code/datums/extensions/extensions.dm
@@ -20,6 +20,8 @@
 
 //Variadic - Additional positional arguments can be given. Named arguments might not work so well
 /proc/set_extension(var/datum/source, var/datum/extension/extension_type)
+	if(QDELETED(source))
+		CRASH("Invalid extension source datum: source was qdeleted, was [log_info_line(source)]")
 	var/datum/extension/extension_base_type = initial(extension_type.base_type)
 	if(!ispath(extension_base_type, /datum/extension))
 		CRASH("Invalid base type: Expected /datum/extension, was [log_info_line(extension_base_type)]")

--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -24,6 +24,8 @@
 	if(isAI(M)) return
 	if(!M || !M.key)
 		return
+	if(QDELETED(src))
+		return
 	if(istype(tool) && (tool.item_flags & ITEM_FLAG_NO_PRINT))
 		return
 


### PR DESCRIPTION
## Description of changes
Sometimes, the `forensic_evidence` extension would be added after the `source` datum was `qdel`'d. These cases now cause a runtime, and `add_fingerprint` checks if `source` is `QDELETED`.

## Why and what will this PR improve
Fixes destroyed structures causing GC fails.