### PR TITLE
Machinery damage

### DIFF
--- a/code/game/machinery/_machines_base/machinery_damage.dm
+++ b/code/game/machinery/_machines_base/machinery_damage.dm
@@ -30,8 +30,11 @@
 
 	// And lastly hit the circuitboard
 	victim = get_component_of_type(/obj/item/stock_parts/circuitboard)
-	if(victim)
-		victim.take_damage(amount, damtype)
+	if(victim?.can_take_damage() && victim.is_functional())
+		amount -= victim.take_damage(amount, damtype)
+
+	if(amount)
+		dismantle()
 
 /obj/machinery/proc/get_damageable_component(var/damage_type)
 	var/list/victims = shuffle(component_parts)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
If all components are busted and there's still damage to apply, machine will dismantle.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Machines die when they're killed.
It's more of an oversight in the original damage implementation I did, as things are right now the machines are indestructible aside from explosions and deconstruction.

## Authorship
<!-- Describe original authors of changes to credit them. -->
Me

## Changelog
:cl:
tweak: Machinery now will get actually destroyed with damage if all components are busted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->