### PR TITLE
Cleaning up some old emote code.

### DIFF
--- a/code/modules/emotes/definitions/_mob.dm
+++ b/code/modules/emotes/definitions/_mob.dm
@@ -44,9 +44,6 @@
 		/decl/emote/audible/gnarl
 		)
 
-/mob/living/carbon/brain/can_emote()
-	return (istype(container, /obj/item/mmi) && ..())
-
 /mob/living/carbon/brain
 	default_emotes = list(
 		/decl/emote/audible/alarm,

--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -1,8 +1,17 @@
 /mob/proc/can_emote(var/emote_type)
+	. = check_mob_can_emote(emote_type)
+	if(!.)
+		to_chat(src, SPAN_WARNING("You cannot currently [emote_type == AUDIBLE_MESSAGE ? "audibly" : "visually"] emote!"))
+
+/mob/proc/check_mob_can_emote(var/emote_type)
+	SHOULD_CALL_PARENT(TRUE)
 	return (stat == CONSCIOUS)
 
-/mob/living/can_emote(var/emote_type)
-	return (..() && !(HAS_STATUS(src, STAT_SILENCE) && emote_type == AUDIBLE_MESSAGE))
+/mob/living/check_mob_can_emote(var/emote_type)
+	return ..() && !(HAS_STATUS(src, STAT_SILENCE) && emote_type == AUDIBLE_MESSAGE)
+
+/mob/living/carbon/brain/check_mob_can_emote(var/emote_type)
+	return ..() && istype(loc, /obj/item/mmi)
 
 /mob/proc/emote(var/act, var/m_type, var/message)
 	set waitfor = FALSE
@@ -20,7 +29,6 @@
 			return
 
 		if(!can_emote(m_type))
-			to_chat(src, "<span class='warning'>You cannot currently [m_type == AUDIBLE_MESSAGE ? "audibly" : "visually"] emote!</span>")
 			return
 
 		if(act == "me")
@@ -119,8 +127,7 @@
 
 /mob/proc/custom_emote(var/m_type = VISIBLE_MESSAGE, var/message = null)
 
-	if((usr && stat) || (!use_me && usr == src))
-		to_chat(src, "You are unable to emote.")
+	if(!can_emote(m_type))
 		return
 
 	var/input

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -5,7 +5,6 @@
 	var/timeofhostdeath = 0
 	var/emp_damage = 0//Handles a type of MMI damage
 	var/alert = null
-	use_me = 0 //Can't use the me verb, it's a freaking immobile brain
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "brain1"
 	mob_sort_value = 7
@@ -25,8 +24,7 @@
 	return (issilicon(speaker) && istype(container, /obj/item/mmi)) || ishuman(speaker) || ..()
 
 /mob/living/carbon/brain/UpdateLyingBuckledAndVerbStatus()
-	if(istype(loc, /obj/item/mmi))
-		use_me = 1
+	return
 
 /mob/living/carbon/brain/isSynthetic()
 	return istype(loc, /obj/item/mmi/digital) || istype(loc, /obj/item/organ/internal/posibrain)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -72,7 +72,6 @@
 	/// Cursor icon used when holding shift over things.
 	var/examine_cursor_icon = 'icons/effects/mouse_pointers/examine_pointer.dmi'
 
-	var/use_me = 1 //Allows all mobs to use the me verb by default, will have to manually specify they cannot
 	var/damageoverlaytemp = 0
 	var/obj/machinery/machine = null
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -34,8 +34,8 @@ var/global/list/special_channel_keys = list(
 	SStyping.set_indicator_state(client, FALSE)
 	if(!filter_block_message(usr, message))
 		message = sanitize(message)
-		if(use_me)
-			usr.emote("me",usr.emote_type,message)
+		if(can_emote(VISIBLE_MESSAGE))
+			usr.emote("me", usr.emote_type, message)
 		else
 			usr.emote(message)
 


### PR DESCRIPTION
## Description of changes
Removes `use_me`, merges a few things into `can_emote()` including the failure message.

## Why and what will this PR improve
Nicer, more consistent code.

## Authorship
Myself.

## Changelog
Nothing player-facing.