### PR TITLE
Converting human icon code to exist on the inventory slots instead.

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -345,3 +345,36 @@ var/global/list/dexterity_levels = list(
 #define MOB_ICON_HAS_GIB_STATE       BITFLAG(4)
 #define MOB_ICON_HAS_PARALYZED_STATE BITFLAG(5)
 #define NEUTER_ANIMATE "animate singular neutral"
+
+// Equipment Overlays Indices //
+#define HO_MUTATIONS_LAYER  1
+#define HO_SKIN_LAYER       2
+#define HO_DAMAGE_LAYER     3
+#define HO_SURGERY_LAYER    4 //bs12 specific.
+#define HO_UNDERWEAR_LAYER  5
+#define HO_UNIFORM_LAYER    6
+#define HO_ID_LAYER         7
+#define HO_SHOES_LAYER      8
+#define HO_GLOVES_LAYER     9
+#define HO_BELT_LAYER       10
+#define HO_SUIT_LAYER       11
+#define HO_GLASSES_LAYER    12
+#define HO_BELT_LAYER_ALT   13
+#define HO_SUIT_STORE_LAYER 14
+#define HO_BACK_LAYER       15
+#define HO_TAIL_LAYER       16 //bs12 specific. this hack is probably gonna come back to haunt me
+#define HO_HAIR_LAYER       17 //TODO: make part of head layer?
+#define HO_GOGGLES_LAYER    18
+#define HO_EARS_LAYER       19
+#define HO_FACEMASK_LAYER   20
+#define HO_HEAD_LAYER       21
+#define HO_COLLAR_LAYER     22
+#define HO_HANDCUFF_LAYER   23
+#define HO_INHAND_LAYER     24
+#define HO_FIRE_LAYER       25 //If you're on fire
+#define TOTAL_OVER_LAYERS   25
+//////////////////////////////////
+
+// Underlay defines; vestigal implementation currently.
+#define HU_TAIL_LAYER 1
+#define TOTAL_UNDER_LAYERS 1

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -365,14 +365,15 @@ var/global/list/dexterity_levels = list(
 #define HO_TAIL_LAYER       16 //bs12 specific. this hack is probably gonna come back to haunt me
 #define HO_HAIR_LAYER       17 //TODO: make part of head layer?
 #define HO_GOGGLES_LAYER    18
-#define HO_EARS_LAYER       19
-#define HO_FACEMASK_LAYER   20
-#define HO_HEAD_LAYER       21
-#define HO_COLLAR_LAYER     22
-#define HO_HANDCUFF_LAYER   23
-#define HO_INHAND_LAYER     24
-#define HO_FIRE_LAYER       25 //If you're on fire
-#define TOTAL_OVER_LAYERS   25
+#define HO_L_EAR_LAYER      19
+#define HO_R_EAR_LAYER      20
+#define HO_FACEMASK_LAYER   21
+#define HO_HEAD_LAYER       22
+#define HO_COLLAR_LAYER     23
+#define HO_HANDCUFF_LAYER   24
+#define HO_INHAND_LAYER     25
+#define HO_FIRE_LAYER       26 //If you're on fire
+#define TOTAL_OVER_LAYERS   26
 //////////////////////////////////
 
 // Underlay defines; vestigal implementation currently.

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -108,7 +108,7 @@
 	if(W == A) // Handle attack_self
 		W.attack_self(src)
 		trigger_aiming(TARGET_CAN_CLICK)
-		update_inv_hands(0)
+		usr.update_inhand_overlays(FALSE)
 		return 1
 
 	//Atoms on your person

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -341,7 +341,7 @@
 		else
 			usr.select_held_item_slot(name)
 	else if(usr.attack_ui(slot_id))
-		usr.update_inv_hands(0)
+		usr.update_inhand_overlays(FALSE)
 
 	return TRUE
 

--- a/code/datums/inventory_slots/_inventory_slot.dm
+++ b/code/datums/inventory_slots/_inventory_slot.dm
@@ -19,6 +19,9 @@
 	var/requires_slot_flags
 	var/requires_organ_tag
 
+	var/mob_overlay_layer
+	var/alt_mob_overlay_layer
+
 /datum/inventory_slot/Destroy(force)
 	_holding = null
 	return ..()
@@ -39,7 +42,7 @@
 	prop.equipped(user, slot_id)
 
 	// Redraw overlays if needed.
-	update_overlay(user, prop, redraw_mob)
+	update_mob_equipment_overlay(user, prop, redraw_mob)
 	return TRUE
 
 /datum/inventory_slot/proc/unequipped(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
@@ -49,11 +52,21 @@
 		var/obj/item/thing = user.get_equipped_item(slot)
 		if(thing)
 			user.drop_from_inventory(thing)
-	update_overlay(user, prop, redraw_mob)
+	update_mob_equipment_overlay(user, prop, redraw_mob)
 	return TRUE
 
-/datum/inventory_slot/proc/update_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
-	return
+/datum/inventory_slot/proc/update_mob_equipment_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
+	if(!mob_overlay_layer || !slot_id)
+		return
+	if(alt_mob_overlay_layer)
+		if(_holding)
+			user.set_mob_overlay((_holding.use_alt_layer ? alt_mob_overlay_layer : mob_overlay_layer), _holding.get_mob_overlay(user, slot_id), FALSE)
+			user.set_mob_overlay((_holding.use_alt_layer ? mob_overlay_layer : alt_mob_overlay_layer), null, redraw_mob)
+		else
+			user.set_mob_overlay(mob_overlay_layer, null, FALSE)
+			user.set_mob_overlay(alt_mob_overlay_layer, null, redraw_mob)
+	else
+		user.set_mob_overlay(mob_overlay_layer, _holding?.get_mob_overlay(user, slot_id), redraw_mob)
 
 /datum/inventory_slot/proc/set_slot(var/obj/item/prop)
 	_holding = prop

--- a/code/datums/inventory_slots/_inventory_slot.dm
+++ b/code/datums/inventory_slots/_inventory_slot.dm
@@ -60,13 +60,13 @@
 		return
 	if(alt_mob_overlay_layer)
 		if(_holding)
-			user.set_mob_overlay((_holding.use_alt_layer ? alt_mob_overlay_layer : mob_overlay_layer), _holding.get_mob_overlay(user, slot_id), FALSE)
-			user.set_mob_overlay((_holding.use_alt_layer ? mob_overlay_layer : alt_mob_overlay_layer), null, redraw_mob)
+			user.set_current_mob_overlay((_holding.use_alt_layer ? alt_mob_overlay_layer : mob_overlay_layer), _holding.get_mob_overlay(user, slot_id), FALSE)
+			user.set_current_mob_overlay((_holding.use_alt_layer ? mob_overlay_layer : alt_mob_overlay_layer), null, redraw_mob)
 		else
-			user.set_mob_overlay(mob_overlay_layer, null, FALSE)
-			user.set_mob_overlay(alt_mob_overlay_layer, null, redraw_mob)
+			user.set_current_mob_overlay(mob_overlay_layer, null, FALSE)
+			user.set_current_mob_overlay(alt_mob_overlay_layer, null, redraw_mob)
 	else
-		user.set_mob_overlay(mob_overlay_layer, _holding?.get_mob_overlay(user, slot_id), redraw_mob)
+		user.set_current_mob_overlay(mob_overlay_layer, _holding?.get_mob_overlay(user, slot_id), redraw_mob)
 
 /datum/inventory_slot/proc/set_slot(var/obj/item/prop)
 	_holding = prop

--- a/code/datums/inventory_slots/inventory_gripper.dm
+++ b/code/datums/inventory_slots/inventory_gripper.dm
@@ -10,9 +10,8 @@
 /datum/inventory_slot/gripper/GetCloneArgs()
 	return list(slot_id, ui_loc, overlay_slot, ui_label)
 
-/datum/inventory_slot/gripper/update_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
-	. = ..()
-	user.update_inv_hands(redraw_mob)
+/datum/inventory_slot/gripper/update_mob_equipment_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
+	user.update_inhand_overlays(redraw_mob)
 
 /datum/inventory_slot/gripper/equipped(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE, var/delete_old_item = TRUE)
 	. = ..()

--- a/code/datums/inventory_slots/slots/slot_back.dm
+++ b/code/datums/inventory_slots/slots/slot_back.dm
@@ -5,9 +5,7 @@
 	slot_state = "back"
 	requires_organ_tag = BP_CHEST
 	requires_slot_flags = SLOT_BACK
-
-/datum/inventory_slot/back/update_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
-	user.update_inv_back(redraw_mob)
+	mob_overlay_layer = HO_BACK_LAYER
 
 /datum/inventory_slot/back/get_examined_string(mob/owner, mob/user, distance, hideflags, decl/pronouns/pronouns)
 	if(_holding)

--- a/code/datums/inventory_slots/slots/slot_belt.dm
+++ b/code/datums/inventory_slots/slots/slot_belt.dm
@@ -5,9 +5,8 @@
 	ui_loc = ui_belt
 	requires_organ_tag = BP_CHEST
 	requires_slot_flags = SLOT_LOWER_BODY
-
-/datum/inventory_slot/belt/update_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
-	user.update_inv_belt(redraw_mob)
+	mob_overlay_layer = HO_BELT_LAYER
+	alt_mob_overlay_layer = HO_BELT_LAYER_ALT
 
 /datum/inventory_slot/belt/can_equip_to_slot(var/mob/user, var/obj/item/prop, var/disable_warning, var/ignore_equipped)
 	. = ..()

--- a/code/datums/inventory_slots/slots/slot_cuffs.dm
+++ b/code/datums/inventory_slots/slots/slot_cuffs.dm
@@ -7,9 +7,7 @@
 		BP_L_HAND,
 		BP_R_HAND
 	)
-
-/datum/inventory_slot/handcuffs/update_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
-	user.update_inv_handcuffed(redraw_mob)
+	mob_overlay_layer = HO_HANDCUFF_LAYER
 
 /datum/inventory_slot/handcuffs/equipped(mob/living/user, obj/item/prop, var/silent = FALSE)
 	. = ..()

--- a/code/datums/inventory_slots/slots/slot_ears.dm
+++ b/code/datums/inventory_slots/slots/slot_ears.dm
@@ -9,8 +9,32 @@
 	requires_organ_tag = BP_HEAD
 	requires_slot_flags = SLOT_EARS
 
-/datum/inventory_slot/ear/update_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
-	user.update_inv_ears(redraw_mob)
+/datum/inventory_slot/ear/update_mob_equipment_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
+
+	for(var/slot in global.airtight_slots)
+		var/obj/item/gear = get_equipped_item(slot)
+		if(gear && (gear.flags_inv & (BLOCK_ALL_HAIR)))
+			user.set_mob_overlay(HO_EARS_LAYER, null, redraw_mob)
+			return
+
+	var/seen_an_ear = FALSE
+	var/image/both
+	for(var/slot in global.ear_slots)
+		var/obj/item/ear = get_equipped_item(slot)
+		if(ear)
+			// We don't draw over the top of an ear slot unless we're the first ear
+			// slot in the list, // to avoid doubling up or overwriting other ear slots.
+			if(slot != slot_id && !seen_an_ear)
+				return
+			seen_an_ear = TRUE
+			if(!both)
+				both = image("icon" = 'icons/effects/effects.dmi', "icon_state" = "nothing")
+			both.overlays += ear.get_mob_overlay(user, slot)
+
+	if(both)
+		user.set_mob_overlay(HO_EARS_LAYER, both, redraw_mob)
+	else
+		user.set_mob_overlay(HO_EARS_LAYER, null, redraw_mob)
 
 /datum/inventory_slot/ear/get_examined_string(mob/owner, mob/user, distance, hideflags, decl/pronouns/pronouns)
 	if(_holding && !(hideflags & HIDEEARS))

--- a/code/datums/inventory_slots/slots/slot_ears.dm
+++ b/code/datums/inventory_slots/slots/slot_ears.dm
@@ -8,33 +8,15 @@
 	can_be_hidden = TRUE
 	requires_organ_tag = BP_HEAD
 	requires_slot_flags = SLOT_EARS
+	mob_overlay_layer = HO_L_EAR_LAYER
 
 /datum/inventory_slot/ear/update_mob_equipment_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
-
 	for(var/slot in global.airtight_slots)
 		var/obj/item/gear = get_equipped_item(slot)
 		if(gear?.flags_inv & BLOCK_ALL_HAIR)
-			user.set_current_mob_overlay(HO_EARS_LAYER, null, redraw_mob)
+			user.set_current_mob_overlay(mob_overlay_layer, null, redraw_mob)
 			return
-
-	var/seen_an_ear = FALSE
-	var/image/both
-	for(var/slot in global.ear_slots)
-		var/obj/item/ear = get_equipped_item(slot)
-		if(ear)
-			// We don't draw over the top of an ear slot unless we're the first ear
-			// slot in the list, // to avoid doubling up or overwriting other ear slots.
-			if(slot != slot_id && !seen_an_ear)
-				return
-			seen_an_ear = TRUE
-			if(!both)
-				both = image("icon" = 'icons/effects/effects.dmi', "icon_state" = "nothing")
-			both.overlays += ear.get_mob_overlay(user, slot)
-
-	if(both)
-		user.set_current_mob_overlay(HO_EARS_LAYER, both, redraw_mob)
-	else
-		user.set_current_mob_overlay(HO_EARS_LAYER, null, redraw_mob)
+	..()
 
 /datum/inventory_slot/ear/get_examined_string(mob/owner, mob/user, distance, hideflags, decl/pronouns/pronouns)
 	if(_holding && !(hideflags & HIDEEARS))
@@ -59,3 +41,4 @@
 	slot_name = "Right Ear"
 	slot_id = slot_r_ear_str
 	ui_loc = ui_r_ear
+	mob_overlay_layer = HO_R_EAR_LAYER

--- a/code/datums/inventory_slots/slots/slot_ears.dm
+++ b/code/datums/inventory_slots/slots/slot_ears.dm
@@ -13,7 +13,7 @@
 
 	for(var/slot in global.airtight_slots)
 		var/obj/item/gear = get_equipped_item(slot)
-		if(gear && (gear.flags_inv & (BLOCK_ALL_HAIR)))
+		if(gear?.flags_inv & BLOCK_ALL_HAIR)
 			user.set_mob_overlay(HO_EARS_LAYER, null, redraw_mob)
 			return
 

--- a/code/datums/inventory_slots/slots/slot_ears.dm
+++ b/code/datums/inventory_slots/slots/slot_ears.dm
@@ -14,7 +14,7 @@
 	for(var/slot in global.airtight_slots)
 		var/obj/item/gear = get_equipped_item(slot)
 		if(gear?.flags_inv & BLOCK_ALL_HAIR)
-			user.set_mob_overlay(HO_EARS_LAYER, null, redraw_mob)
+			user.set_current_mob_overlay(HO_EARS_LAYER, null, redraw_mob)
 			return
 
 	var/seen_an_ear = FALSE
@@ -32,9 +32,9 @@
 			both.overlays += ear.get_mob_overlay(user, slot)
 
 	if(both)
-		user.set_mob_overlay(HO_EARS_LAYER, both, redraw_mob)
+		user.set_current_mob_overlay(HO_EARS_LAYER, both, redraw_mob)
 	else
-		user.set_mob_overlay(HO_EARS_LAYER, null, redraw_mob)
+		user.set_current_mob_overlay(HO_EARS_LAYER, null, redraw_mob)
 
 /datum/inventory_slot/ear/get_examined_string(mob/owner, mob/user, distance, hideflags, decl/pronouns/pronouns)
 	if(_holding && !(hideflags & HIDEEARS))

--- a/code/datums/inventory_slots/slots/slot_glasses.dm
+++ b/code/datums/inventory_slots/slots/slot_glasses.dm
@@ -8,9 +8,8 @@
 	can_be_hidden = TRUE
 	requires_organ_tag = BP_HEAD
 	requires_slot_flags = SLOT_EYES
-
-/datum/inventory_slot/glasses/update_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
-	user.update_inv_glasses(redraw_mob)
+	mob_overlay_layer = HO_GLASSES_LAYER
+	alt_mob_overlay_layer = HO_GOGGLES_LAYER
 
 /datum/inventory_slot/glasses/get_examined_string(mob/owner, mob/user, distance, hideflags, decl/pronouns/pronouns)
 	if(_holding && !(hideflags & HIDEEYES))

--- a/code/datums/inventory_slots/slots/slot_gloves.dm
+++ b/code/datums/inventory_slots/slots/slot_gloves.dm
@@ -12,8 +12,22 @@
 	covering_flags = SLOT_HANDS
 	requires_slot_flags = SLOT_HANDS
 
-/datum/inventory_slot/gloves/update_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
-	user.update_inv_gloves(redraw_mob)
+/datum/inventory_slot/gloves/update_mob_equipment_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
+	var/obj/item/suit = user.get_equipped_item(slot_wear_suit_str)
+	if(_holding && !(suit && suit.flags_inv & HIDEGLOVES))
+		user.set_mob_overlay(HO_GLOVES_LAYER, _holding.get_mob_overlay(user, slot_gloves_str), redraw_mob)
+		return
+	var/mob_blood_overlay = user.get_bodytype().get_blood_overlays(src)
+	if(mob_blood_overlay)
+		var/blood_color
+		for(var/obj/item/organ/external/grabber in user.get_hands_organs())
+			if(grabber.coating)
+				blood_color = grabber.coating.get_color()
+				break
+		if(blood_color)
+			user.set_mob_overlay(HO_GLOVES_LAYER, overlay_image(mob_blood_overlay, "bloodyhands", blood_color, RESET_COLOR), redraw_mob)
+			return
+	user.set_mob_overlay(HO_GLOVES_LAYER, null, redraw_mob)
 
 /datum/inventory_slot/gloves/get_examined_string(mob/owner, mob/user, distance, hideflags, decl/pronouns/pronouns)
 	if(_holding && !(hideflags & HIDEGLOVES))

--- a/code/datums/inventory_slots/slots/slot_gloves.dm
+++ b/code/datums/inventory_slots/slots/slot_gloves.dm
@@ -15,7 +15,7 @@
 /datum/inventory_slot/gloves/update_mob_equipment_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
 	var/obj/item/suit = user.get_equipped_item(slot_wear_suit_str)
 	if(_holding && !(suit && suit.flags_inv & HIDEGLOVES))
-		user.set_mob_overlay(HO_GLOVES_LAYER, _holding.get_mob_overlay(user, slot_gloves_str), redraw_mob)
+		user.set_current_mob_overlay(HO_GLOVES_LAYER, _holding.get_mob_overlay(user, slot_gloves_str), redraw_mob)
 		return
 	var/mob_blood_overlay = user.get_bodytype().get_blood_overlays(src)
 	if(mob_blood_overlay)
@@ -25,9 +25,9 @@
 				blood_color = grabber.coating.get_color()
 				break
 		if(blood_color)
-			user.set_mob_overlay(HO_GLOVES_LAYER, overlay_image(mob_blood_overlay, "bloodyhands", blood_color, RESET_COLOR), redraw_mob)
+			user.set_current_mob_overlay(HO_GLOVES_LAYER, overlay_image(mob_blood_overlay, "bloodyhands", blood_color, RESET_COLOR), redraw_mob)
 			return
-	user.set_mob_overlay(HO_GLOVES_LAYER, null, redraw_mob)
+	user.set_current_mob_overlay(HO_GLOVES_LAYER, null, redraw_mob)
 
 /datum/inventory_slot/gloves/get_examined_string(mob/owner, mob/user, distance, hideflags, decl/pronouns/pronouns)
 	if(_holding && !(hideflags & HIDEGLOVES))

--- a/code/datums/inventory_slots/slots/slot_head.dm
+++ b/code/datums/inventory_slots/slots/slot_head.dm
@@ -7,15 +7,15 @@
 	requires_organ_tag = BP_HEAD
 	covering_flags = SLOT_HEAD
 	requires_slot_flags = SLOT_HEAD
+	mob_overlay_layer = HO_HEAD_LAYER
 
-/datum/inventory_slot/head/update_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
-	if(prop.flags_inv & (HIDEMASK|BLOCK_ALL_HAIR))
-		if(ishuman(user))
-			var/mob/living/carbon/human/H = user
-			H.update_hair(0)	//rebuild hair
-		user.update_inv_ears(0)
-		user.update_inv_wear_mask(0)
-	user.update_inv_head(redraw_mob)
+/datum/inventory_slot/head/update_mob_equipment_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
+	if(prop?.flags_inv & (HIDEMASK|BLOCK_ALL_HAIR))
+		user.update_hair(FALSE)
+		user.update_equipment_overlay(slot_l_ear_str, FALSE)
+		user.update_equipment_overlay(slot_r_ear_str, FALSE)
+		user.update_equipment_overlay(slot_wear_mask_str, FALSE)
+	..()
 
 /datum/inventory_slot/head/unequipped(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
 	. = ..()

--- a/code/datums/inventory_slots/slots/slot_id.dm
+++ b/code/datums/inventory_slots/slots/slot_id.dm
@@ -9,7 +9,7 @@
 /datum/inventory_slot/id/update_mob_equipment_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
 	var/obj/item/clothing/under/under = user.get_equipped_item(slot_w_uniform_str)
 	if(istype(under) && !under.displays_id && !under.rolled_down)
-		user.set_mob_overlay(HO_ID_LAYER, null, redraw_mob)
+		user.set_current_mob_overlay(HO_ID_LAYER, null, redraw_mob)
 	else
 		..()
 	BITSET(user.hud_updateflag, ID_HUD)

--- a/code/datums/inventory_slots/slots/slot_id.dm
+++ b/code/datums/inventory_slots/slots/slot_id.dm
@@ -10,8 +10,8 @@
 	var/obj/item/clothing/under/under = user.get_equipped_item(slot_w_uniform_str)
 	if(istype(under) && !under.displays_id && !under.rolled_down)
 		user.set_mob_overlay(HO_ID_LAYER, null, redraw_mob)
-		return
-	..()
+	else
+		..()
 	BITSET(user.hud_updateflag, ID_HUD)
 	BITSET(user.hud_updateflag, WANTED_HUD)
 

--- a/code/datums/inventory_slots/slots/slot_id.dm
+++ b/code/datums/inventory_slots/slots/slot_id.dm
@@ -4,9 +4,16 @@
 	ui_loc = ui_id
 	slot_id = slot_wear_id_str
 	requires_slot_flags = SLOT_ID
+	mob_overlay_layer = HO_ID_LAYER
 
-/datum/inventory_slot/id/update_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
-	user.update_inv_wear_id(redraw_mob)
+/datum/inventory_slot/id/update_mob_equipment_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
+	var/obj/item/clothing/under/under = user.get_equipped_item(slot_w_uniform_str)
+	if(istype(under) && !under.displays_id && !under.rolled_down)
+		user.set_mob_overlay(HO_ID_LAYER, null, redraw_mob)
+		return
+	..()
+	BITSET(user.hud_updateflag, ID_HUD)
+	BITSET(user.hud_updateflag, WANTED_HUD)
 
 /datum/inventory_slot/id/can_equip_to_slot(var/mob/user, var/obj/item/prop, var/disable_warning, var/ignore_equipped)
 	. = ..()

--- a/code/datums/inventory_slots/slots/slot_mask.dm
+++ b/code/datums/inventory_slots/slots/slot_mask.dm
@@ -17,15 +17,22 @@
 		user.update_equipment_overlay(slot_r_ear_str, FALSE)
 	..()
 
+/mob/proc/check_for_airtight_internals(var/update_internals = TRUE)
+	for(var/slot in global.airtight_slots)
+		var/obj/item/gear = get_equipped_item(slot)
+		if(gear?.item_flags & ITEM_FLAG_AIRTIGHT)
+			return TRUE
+	if(update_internals)
+		set_internals(null)
+	return FALSE
+
 /datum/inventory_slot/mask/equipped(mob/living/user, obj/item/prop, redraw_mob, delete_old_item)
 	. = ..()
-	if(!_holding || !(_holding.item_flags & ITEM_FLAG_AIRTIGHT))
-		user.set_internals(null)
+	user.check_for_airtight_internals()
 
 /datum/inventory_slot/mask/unequipped(mob/living/user, obj/item/prop, redraw_mob)
 	. = ..()
-	if(!_holding || !(_holding.item_flags & ITEM_FLAG_AIRTIGHT))
-		user.set_internals(null)
+	user.check_for_airtight_internals()
 
 /datum/inventory_slot/mask/get_examined_string(mob/owner, mob/user, distance, hideflags, decl/pronouns/pronouns)
 	if(_holding && !(hideflags & HIDEMASK))

--- a/code/datums/inventory_slots/slots/slot_mask.dm
+++ b/code/datums/inventory_slots/slots/slot_mask.dm
@@ -8,12 +8,24 @@
 	requires_organ_tag = BP_HEAD
 	requires_slot_flags = SLOT_FACE
 	can_be_hidden = TRUE
+	mob_overlay_layer = HO_FACEMASK_LAYER
 
-/datum/inventory_slot/mask/update_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
-	if(prop.flags_inv & BLOCK_ALL_HAIR)
+/datum/inventory_slot/mask/update_mob_equipment_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
+	if(prop?.flags_inv & BLOCK_ALL_HAIR)
 		user.update_hair(0)
-		user.update_inv_ears(0)
-	user.update_inv_wear_mask(redraw_mob)
+		user.update_equipment_overlay(slot_l_ear_str, FALSE)
+		user.update_equipment_overlay(slot_r_ear_str, FALSE)
+	..()
+
+/datum/inventory_slot/mask/equipped(mob/living/user, obj/item/prop, redraw_mob, delete_old_item)
+	. = ..()
+	if(!_holding || !(_holding.item_flags & ITEM_FLAG_AIRTIGHT))
+		user.set_internals(null)
+
+/datum/inventory_slot/mask/unequipped(mob/living/user, obj/item/prop, redraw_mob)
+	. = ..()
+	if(!_holding || !(_holding.item_flags & ITEM_FLAG_AIRTIGHT))
+		user.set_internals(null)
 
 /datum/inventory_slot/mask/get_examined_string(mob/owner, mob/user, distance, hideflags, decl/pronouns/pronouns)
 	if(_holding && !(hideflags & HIDEMASK))

--- a/code/datums/inventory_slots/slots/slot_pockets.dm
+++ b/code/datums/inventory_slots/slots/slot_pockets.dm
@@ -8,8 +8,8 @@
 	requires_organ_tag = BP_CHEST
 	requires_slot_flags = SLOT_POCKET
 
-/datum/inventory_slot/pocket/update_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
-	user.update_inv_pockets(redraw_mob)
+/datum/inventory_slot/pocket/update_mob_equipment_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
+	return
 
 /datum/inventory_slot/pocket/prop_can_fit_in_slot(var/obj/item/prop)
 	return ..() || prop.w_class <= ITEM_SIZE_SMALL

--- a/code/datums/inventory_slots/slots/slot_shoes.dm
+++ b/code/datums/inventory_slots/slots/slot_shoes.dm
@@ -10,8 +10,25 @@
 	)
 	requires_slot_flags = SLOT_FEET
 
-/datum/inventory_slot/shoes/update_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
-	user.update_inv_shoes(redraw_mob)
+/datum/inventory_slot/shoes/update_mob_equipment_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
+	var/obj/item/suit =    user.get_equipped_item(slot_wear_suit_str)
+	var/obj/item/uniform = user.get_equipped_item(slot_w_uniform_str)
+	if(_holding && !((suit && suit.flags_inv & HIDESHOES) || (uniform && uniform.flags_inv & HIDESHOES)))
+		user.set_mob_overlay(HO_SHOES_LAYER, _holding.get_mob_overlay(user, slot_shoes_str), redraw_mob)
+		return
+	var/mob_blood_overlay = user.get_bodytype().get_blood_overlays(src)
+	if(mob_blood_overlay)
+		var/blood_color
+		for(var/foot_tag in list(BP_L_FOOT, BP_R_FOOT))
+			var/obj/item/organ/external/stomper = GET_EXTERNAL_ORGAN(user, foot_tag)
+			if(stomper && stomper.coating)
+				blood_color = stomper.coating.get_color()
+				break
+		if(blood_color)
+			var/image/bloodsies = overlay_image(mob_blood_overlay, "shoeblood", blood_color, RESET_COLOR)
+			user.set_mob_overlay(HO_SHOES_LAYER, bloodsies, redraw_mob)
+			return
+	user.set_mob_overlay(HO_SHOES_LAYER, null, redraw_mob)
 
 /datum/inventory_slot/shoes/get_examined_string(mob/owner, mob/user, distance, hideflags, decl/pronouns/pronouns)
 	if(_holding && !(hideflags & HIDESHOES))

--- a/code/datums/inventory_slots/slots/slot_shoes.dm
+++ b/code/datums/inventory_slots/slots/slot_shoes.dm
@@ -14,7 +14,7 @@
 	var/obj/item/suit =    user.get_equipped_item(slot_wear_suit_str)
 	var/obj/item/uniform = user.get_equipped_item(slot_w_uniform_str)
 	if(_holding && !((suit && suit.flags_inv & HIDESHOES) || (uniform && uniform.flags_inv & HIDESHOES)))
-		user.set_mob_overlay(HO_SHOES_LAYER, _holding.get_mob_overlay(user, slot_shoes_str), redraw_mob)
+		user.set_current_mob_overlay(HO_SHOES_LAYER, _holding.get_mob_overlay(user, slot_shoes_str), redraw_mob)
 		return
 	var/mob_blood_overlay = user.get_bodytype().get_blood_overlays(src)
 	if(mob_blood_overlay)
@@ -26,9 +26,9 @@
 				break
 		if(blood_color)
 			var/image/bloodsies = overlay_image(mob_blood_overlay, "shoeblood", blood_color, RESET_COLOR)
-			user.set_mob_overlay(HO_SHOES_LAYER, bloodsies, redraw_mob)
+			user.set_current_mob_overlay(HO_SHOES_LAYER, bloodsies, redraw_mob)
 			return
-	user.set_mob_overlay(HO_SHOES_LAYER, null, redraw_mob)
+	user.set_current_mob_overlay(HO_SHOES_LAYER, null, redraw_mob)
 
 /datum/inventory_slot/shoes/get_examined_string(mob/owner, mob/user, distance, hideflags, decl/pronouns/pronouns)
 	if(_holding && !(hideflags & HIDESHOES))

--- a/code/datums/inventory_slots/slots/slot_suit.dm
+++ b/code/datums/inventory_slots/slots/slot_suit.dm
@@ -7,12 +7,19 @@
 	drop_slots_on_unequip = list(slot_s_store_str)
 	requires_organ_tag = BP_CHEST
 	requires_slot_flags = SLOT_OVER_BODY
+	mob_overlay_layer = HO_SUIT_LAYER
 
-/datum/inventory_slot/suit/update_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
-	if(prop.flags_inv & HIDESHOES)
-		user.update_inv_shoes(0)
-	if(prop.flags_inv & HIDEGLOVES)
-		user.update_inv_gloves(0)
-	if(prop.flags_inv & HIDEJUMPSUIT)
-		user.update_inv_w_uniform(0)
-	user.update_inv_wear_suit(redraw_mob)
+/datum/inventory_slot/suit/update_mob_equipment_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
+	if(prop)
+		if(prop.flags_inv & HIDESHOES)
+			user.update_equipment_overlay(slot_shoes_str, FALSE)
+		if(prop.flags_inv & HIDEGLOVES)
+			user.update_equipment_overlay(slot_gloves_str, FALSE)
+		if(prop.flags_inv & HIDEJUMPSUIT)
+			user.update_equipment_overlay(slot_w_uniform_str, FALSE)
+	user.update_tail_showing(FALSE)
+	..()
+	// Adds a collar overlay above the helmet layer if the suit has one
+	// Suit needs an identically named sprite in icons/mob/collar.dmi
+	var/obj/item/clothing/suit/suit = _holding
+	user.set_mob_overlay(HO_COLLAR_LAYER, (istype(suit) ? suit.get_collar() : null), redraw_mob)

--- a/code/datums/inventory_slots/slots/slot_suit.dm
+++ b/code/datums/inventory_slots/slots/slot_suit.dm
@@ -22,4 +22,4 @@
 	// Adds a collar overlay above the helmet layer if the suit has one
 	// Suit needs an identically named sprite in icons/mob/collar.dmi
 	var/obj/item/clothing/suit/suit = _holding
-	user.set_mob_overlay(HO_COLLAR_LAYER, (istype(suit) ? suit.get_collar() : null), redraw_mob)
+	user.set_current_mob_overlay(HO_COLLAR_LAYER, (istype(suit) ? suit.get_collar() : null), redraw_mob)

--- a/code/datums/inventory_slots/slots/slot_suit_storage.dm
+++ b/code/datums/inventory_slots/slots/slot_suit_storage.dm
@@ -4,9 +4,7 @@
 	ui_loc = ui_sstore1
 	slot_id = slot_s_store_str
 	requires_organ_tag = BP_CHEST
-
-/datum/inventory_slot/suit_storage/update_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
-	user.update_inv_s_store(redraw_mob)
+	mob_overlay_layer = HO_SUIT_STORE_LAYER
 
 /datum/inventory_slot/suit_storage/can_equip_to_slot(var/mob/user, var/obj/item/prop, var/disable_warning, var/ignore_equipped)
 	. = ..()

--- a/code/datums/inventory_slots/slots/slot_uniform.dm
+++ b/code/datums/inventory_slots/slots/slot_uniform.dm
@@ -14,10 +14,14 @@
 	requires_organ_tag = BP_CHEST
 	requires_slot_flags = SLOT_UPPER_BODY
 
-/datum/inventory_slot/uniform/update_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
-	if(prop.flags_inv & HIDESHOES)
-		user.update_inv_shoes(0)
-	user.update_inv_w_uniform(redraw_mob)
+/datum/inventory_slot/uniform/update_mob_equipment_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
+	if(prop?.flags_inv & HIDESHOES)
+		user.update_equipment_overlay(slot_shoes_str, FALSE)
+	var/obj/item/suit = user.get_equipped_item(slot_wear_suit_str)
+	if(_holding && (!suit || !(suit.flags_inv & HIDEJUMPSUIT)))
+		user.set_mob_overlay(HO_UNIFORM_LAYER, _holding.get_mob_overlay(user, slot_w_uniform_str), redraw_mob)
+	else
+		user.set_mob_overlay(HO_UNIFORM_LAYER, null, redraw_mob)
 
 /datum/inventory_slot/uniform/get_examined_string(mob/owner, mob/user, distance, hideflags, decl/pronouns/pronouns)
 	if(_holding && !(hideflags & HIDEJUMPSUIT))

--- a/code/datums/inventory_slots/slots/slot_uniform.dm
+++ b/code/datums/inventory_slots/slots/slot_uniform.dm
@@ -19,9 +19,9 @@
 		user.update_equipment_overlay(slot_shoes_str, FALSE)
 	var/obj/item/suit = user.get_equipped_item(slot_wear_suit_str)
 	if(_holding && (!suit || !(suit.flags_inv & HIDEJUMPSUIT)))
-		user.set_mob_overlay(HO_UNIFORM_LAYER, _holding.get_mob_overlay(user, slot_w_uniform_str), redraw_mob)
+		user.set_current_mob_overlay(HO_UNIFORM_LAYER, _holding.get_mob_overlay(user, slot_w_uniform_str), redraw_mob)
 	else
-		user.set_mob_overlay(HO_UNIFORM_LAYER, null, redraw_mob)
+		user.set_current_mob_overlay(HO_UNIFORM_LAYER, null, redraw_mob)
 
 /datum/inventory_slot/uniform/get_examined_string(mob/owner, mob/user, distance, hideflags, decl/pronouns/pronouns)
 	if(_holding && !(hideflags & HIDEJUMPSUIT))

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -111,7 +111,7 @@ var/global/list/image/splatter_cache=list()
 		var/obj/structure/bed/chair/wheelchair/W = perp.buckled
 		W.bloodiness = 4
 
-	perp.update_inv_shoes(1)
+	perp.update_equipment_overlay(slot_shoes_str)
 	amount--
 
 /obj/effect/decal/cleanable/blood/proc/dry()

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -196,11 +196,8 @@ steam.start() -- spawns the effect
 /obj/effect/effect/smoke/proc/affect(var/mob/living/carbon/M)
 	if (!istype(M))
 		return 0
-	if(M.internal != null)
-		for(var/slot in global.airtight_slots)
-			var/obj/item/gear = M.get_equipped_item(slot)
-			if(gear && (gear.item_flags & ITEM_FLAG_AIRTIGHT))
-				return FALSE
+	if(M.internal != null && M.check_for_airtight_internals(FALSE))
+		return FALSE
 	return TRUE
 
 /////////////////////////////////////////////

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -183,7 +183,7 @@
 /obj/item/proc/update_held_icon()
 	if(ismob(src.loc))
 		var/mob/M = src.loc
-		M.update_inv_hands()
+		M.update_inhand_overlays()
 
 /obj/item/proc/is_held_twohanded(mob/living/M)
 	if(!M)
@@ -806,9 +806,25 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	update_icon()
 	update_clothing_icon()
 
+// Used to call appropriate slot updates in update_clothing_icon()
+/obj/item/proc/get_associated_equipment_slots()
+	return
+
 // Updates the icons of the mob wearing the clothing item, if any.
 /obj/item/proc/update_clothing_icon()
-	return
+	var/equip_slots = get_associated_equipment_slots()
+	if(!equip_slots)
+		return FALSE
+	var/mob/wearer = loc
+	if(!istype(wearer))
+		return FALSE
+	if(islist(equip_slots))
+		for(var/slot in equip_slots)
+			wearer.update_equipment_overlay(slot, FALSE)
+		wearer.update_icon()
+	else
+		wearer.update_equipment_overlay(equip_slots)
+	return TRUE
 
 /obj/item/proc/reconsider_client_screen_presence(var/client/client, var/slot)
 	if(!ismob(loc) || !client) // Storage handles screen loc updating/setting itself so should be fine

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -808,22 +808,21 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 // Used to call appropriate slot updates in update_clothing_icon()
 /obj/item/proc/get_associated_equipment_slots()
-	return
+	SHOULD_CALL_PARENT(TRUE)
+	if(item_flags & ITEM_FLAG_IS_BELT)
+		LAZYADD(., slot_belt_str)
 
 // Updates the icons of the mob wearing the clothing item, if any.
 /obj/item/proc/update_clothing_icon()
-	var/equip_slots = get_associated_equipment_slots()
-	if(!equip_slots)
-		return FALSE
 	var/mob/wearer = loc
 	if(!istype(wearer))
 		return FALSE
-	if(islist(equip_slots))
-		for(var/slot in equip_slots)
-			wearer.update_equipment_overlay(slot, FALSE)
-		wearer.update_icon()
-	else
-		wearer.update_equipment_overlay(equip_slots)
+	var/equip_slots = get_associated_equipment_slots()
+	if(!islist(equip_slots))
+		return FALSE
+	for(var/slot in equip_slots)
+		wearer.update_equipment_overlay(slot, FALSE)
+	wearer.update_icon()
 	return TRUE
 
 /obj/item/proc/reconsider_client_screen_presence(var/client/client, var/slot)

--- a/code/game/objects/items/devices/paint_sprayer.dm
+++ b/code/game/objects/items/devices/paint_sprayer.dm
@@ -82,9 +82,9 @@
 	. = ..()
 	add_overlay(overlay_image(icon, "[icon_state]_color", paint_color))
 	add_overlay(color_picker ? "[icon_state]_red" : "[icon_state]_blue")
-	if(ismob(loc))
+	if(isliving(loc))
 		var/mob/M = loc
-		M.update_inv_hands()
+		M.update_inhand_overlays()
 
 /obj/item/paint_sprayer/adjust_mob_overlay(var/mob/living/user_mob, var/bodytype,  var/image/overlay, var/slot, var/bodypart)
 	if(overlay && check_state_in_icon("[overlay.icon_state]_color", overlay.icon))

--- a/code/game/objects/items/weapons/cane.dm
+++ b/code/game/objects/items/weapons/cane.dm
@@ -34,7 +34,7 @@
 		user.put_in_hands(src)
 		concealed_blade = null
 		update_icon()
-		user.update_inv_hands()
+		user.update_inhand_overlays()
 	else
 		..()
 
@@ -43,7 +43,7 @@
 		user.visible_message("<span class='warning'>[user] has sheathed \a [W] into [src]!</span>", "You sheathe \the [W] into [src].")
 		src.concealed_blade = W
 		update_icon()
-		user.update_inv_hands()
+		user.update_inhand_overlays()
 	else
 		..()
 

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -126,8 +126,8 @@
 		add_overlay("[icon_state]-loaded")
 	if(ismob(loc))
 		var/mob/living/M = loc
-		M.update_inv_wear_mask(0)
-		M.update_inv_hands()
+		M.update_equipment_overlay(slot_wear_mask_str, redraw_mob = FALSE)
+		M.update_inhand_overlays()
 
 /obj/item/clothing/mask/smokable/ecig/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/chems/ecig_cartridge))

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -207,7 +207,7 @@
 
 	if(istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user
-		H.update_inv_hands()
+		H.update_inhand_overlays()
 
 	add_fingerprint(user)
 	return

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -10,9 +10,12 @@
 	item_flags = ITEM_FLAG_IS_BELT
 	max_w_class = ITEM_SIZE_NORMAL
 	slot_flags = SLOT_LOWER_BODY
-	var/overlay_flags
 	attack_verb = list("whipped", "lashed", "disciplined")
 	material = /decl/material/solid/leather/synth
+	var/overlay_flags
+
+/obj/item/storage/belt/get_associated_equipment_slots()
+	return slot_belt_str
 
 /obj/item/storage/belt/verb/toggle_layer()
 	set name = "Switch Belt Layer"
@@ -34,11 +37,6 @@
 		if(LAZYLEN(cur_overlays))
 			add_overlay(cur_overlays)
 	update_clothing_icon()
-
-/obj/item/storage/belt/update_clothing_icon()
-	if(ismob(src.loc))
-		var/mob/M = src.loc
-		M.update_inv_belt()
 
 /obj/item/storage/belt/get_mob_overlay(mob/user_mob, slot, bodypart)
 	var/image/ret = ..()

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -15,7 +15,8 @@
 	var/overlay_flags
 
 /obj/item/storage/belt/get_associated_equipment_slots()
-	return slot_belt_str
+	. = ..()
+	LAZYDISTINCTADD(., slot_belt_str)
 
 /obj/item/storage/belt/verb/toggle_layer()
 	set name = "Switch Belt Layer"

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -58,7 +58,7 @@
 
 	if (ismob(usr))
 		var/mob/M = usr
-		M.update_inv_back()
+		M.update_equipment_overlay(slot_back_str)
 		M.update_action_buttons()
 
 	to_chat(usr, "You toggle the thrusters [on? "on":"off"].")

--- a/code/game/objects/items/weapons/tools/wirecutter.dm
+++ b/code/game/objects/items/weapons/tools/wirecutter.dm
@@ -48,7 +48,7 @@
 		qdel(cuffs)
 		if(C.buckled && C.buckled.buckle_require_restraints)
 			C.buckled.unbuckle_mob()
-		C.update_inv_handcuffed()
+		C.update_equipment_overlay(slot_handcuffed_str)
 		return
 	else
 		..()

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -132,7 +132,7 @@
 		bloodDNA = list()
 	bloodcolor = source.coating.get_color()
 	source.remove_coating(1)
-	update_inv_shoes(1)
+	update_equipment_overlay(slot_shoes_str)
 
 	if(species.get_move_trail(src))
 		T.AddTracks(species.get_move_trail(src),bloodDNA, dir, 0, bloodcolor) // Coming

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -155,7 +155,6 @@
 			id.assignment = "Captain"
 			id.SetName("[id.registered_name]'s ID Card ([id.assignment])")
 			H.equip_to_slot_or_del(id, slot_wear_id_str)
-			H.update_inv_wear_id()
 	else
 		alert("Invalid mob")
 	SSstatistics.add_field_details("admin_verb","GFA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -185,7 +185,7 @@
 	//so our overlays update.
 	if (ismob(src.loc))
 		var/mob/M = src.loc
-		M.update_inv_back()
+		M.update_equipment_overlay(slot_back_str)
 
 //********************
 //**Chameleon Gloves**
@@ -305,7 +305,8 @@
 		disguise(clothing_choices[picked], usr)
 		if (ismob(src.loc))
 			var/mob/M = src.loc
-			M.update_inv_ears()
+			M.update_equipment_overlay(slot_l_ear_str, FALSE)
+			M.update_equipment_overlay(slot_r_ear_str)
 
 //***********************
 //**Chameleon Accessory**
@@ -417,4 +418,4 @@
 	//so our overlays update.
 	if (ismob(src.loc))
 		var/mob/M = src.loc
-		M.update_inv_hands()
+		M.update_inhand_overlays()

--- a/code/modules/clothing/ears/_ears.dm
+++ b/code/modules/clothing/ears/_ears.dm
@@ -9,7 +9,5 @@
 	throwforce = 2
 	slot_flags = SLOT_EARS
 
-/obj/item/clothing/ears/update_clothing_icon()
-	if (ismob(src.loc))
-		var/mob/M = src.loc
-		M.update_inv_ears()
+/obj/item/clothing/ears/get_associated_equipment_slots()
+	return global.ear_slots

--- a/code/modules/clothing/ears/_ears.dm
+++ b/code/modules/clothing/ears/_ears.dm
@@ -10,4 +10,5 @@
 	slot_flags = SLOT_EARS
 
 /obj/item/clothing/ears/get_associated_equipment_slots()
-	return global.ear_slots
+	. = ..()
+	LAZYDISTINCTADD(., global.ear_slots)

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -102,9 +102,9 @@
 	tint = TINT_NONE
 
 /obj/item/clothing/glasses/update_clothing_icon()
-	if(ismob(src.loc))
-		var/mob/M = src.loc
-		M.update_inv_glasses()
+	. = ..()
+	if(.)
+		var/mob/M = loc
 		M.update_action_buttons()
 
 /obj/item/clothing/glasses/proc/toggle()

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -15,7 +15,8 @@
 	var/obj/item/clothing/ring/covering_ring
 
 /obj/item/clothing/gloves/get_associated_equipment_slots()
-	return slot_gloves_str
+	. = ..()
+	LAZYDISTINCTADD(., slot_gloves_str)
 
 /obj/item/clothing/gloves/proc/Touch(var/atom/A, var/proximity)
 	return

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -14,10 +14,8 @@
 	bodytype_equip_flags = BODY_FLAG_HUMANOID
 	var/obj/item/clothing/ring/covering_ring
 
-/obj/item/clothing/gloves/update_clothing_icon()
-	if(ismob(loc))
-		var/mob/M = loc
-		M.update_inv_gloves()
+/obj/item/clothing/gloves/get_associated_equipment_slots()
+	return slot_gloves_str
 
 /obj/item/clothing/gloves/proc/Touch(var/atom/A, var/proximity)
 	return

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -92,7 +92,5 @@
 		overlay.overlays += light_overlay
 	. = ..()
 
-/obj/item/clothing/head/update_clothing_icon()
-	if (ismob(src.loc))
-		var/mob/M = src.loc
-		M.update_inv_head()
+/obj/item/clothing/head/get_associated_equipment_slots()
+	return slot_head_str

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -93,4 +93,5 @@
 	. = ..()
 
 /obj/item/clothing/head/get_associated_equipment_slots()
-	return slot_head_str
+	. = ..()
+	LAZYDISTINCTADD(., slot_head_str)

--- a/code/modules/clothing/masks/_mask.dm
+++ b/code/modules/clothing/masks/_mask.dm
@@ -30,8 +30,8 @@
 		verbs += .verb/adjust_mask
 
 /obj/item/clothing/mask/get_associated_equipment_slots()
-	return slot_wear_mask_str
-
+	. = ..()
+	LAZYDISTINCTADD(., slot_wear_mask_str)
 
 /obj/item/clothing/mask/adjust_mob_overlay(var/mob/living/user_mob, var/bodytype,  var/image/overlay, var/slot, var/bodypart)
 	if(overlay && hanging && slot == slot_wear_mask_str && check_state_in_icon("[overlay.icon_state]-down", overlay.icon))

--- a/code/modules/clothing/masks/_mask.dm
+++ b/code/modules/clothing/masks/_mask.dm
@@ -29,16 +29,15 @@
 		action_button_name = "Adjust Mask"
 		verbs += .verb/adjust_mask
 
-/obj/item/clothing/mask/update_clothing_icon()
-	if (ismob(src.loc))
-		var/mob/M = src.loc
-		M.update_inv_wear_mask()
+/obj/item/clothing/mask/get_associated_equipment_slots()
+	return slot_wear_mask_str
+
 
 /obj/item/clothing/mask/adjust_mob_overlay(var/mob/living/user_mob, var/bodytype,  var/image/overlay, var/slot, var/bodypart)
 	if(overlay && hanging && slot == slot_wear_mask_str && check_state_in_icon("[overlay.icon_state]-down", overlay.icon))
 		overlay.icon_state = "[overlay.icon_state]-down"
 	. = ..()
- 
+
 /obj/item/clothing/mask/proc/filter_air(datum/gas_mixture/air)
 	return
 

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -104,8 +104,8 @@
 
 	if(ismob(loc))
 		var/mob/living/M = loc
-		M.update_inv_wear_mask(0)
-		M.update_inv_hands()
+		M.update_equipment_overlay(slot_wear_mask_str, FALSE)
+		M.update_inhand_overlays()
 
 /obj/item/clothing/mask/smokable/adjust_mob_overlay(var/mob/living/user_mob, var/bodytype,  var/image/overlay, var/slot, var/bodypart)
 	if(overlay && lit && check_state_in_icon("[overlay.icon_state]-on", overlay.icon))
@@ -467,8 +467,8 @@
 
 /obj/item/clothing/mask/smokable/cigarette/cigar/attackby(var/obj/item/W, var/mob/user)
 	..()
-	user.update_inv_wear_mask(0)
-	user.update_inv_hands()
+	user.update_equipment_overlay(slot_wear_mask_str, FALSE)
+	user.update_inhand_overlays()
 
 //Bizarre
 /obj/item/clothing/mask/smokable/cigarette/rolled/sausage
@@ -523,8 +523,8 @@
 		START_PROCESSING(SSobj, src)
 		if(ismob(loc))
 			var/mob/living/M = loc
-			M.update_inv_wear_mask(0)
-			M.update_inv_hands()
+			M.update_equipment_overlay(slot_wear_mask_str, FALSE)
+			M.update_inhand_overlays()
 		set_scent_by_reagents(src)
 		update_icon()
 
@@ -585,8 +585,8 @@
 	else if(istype(W, /obj/item/assembly/igniter))
 		light(SPAN_NOTICE("[user] fiddles with [W], and manages to light their [name] with the power of science."))
 
-	user.update_inv_wear_mask(0)
-	user.update_inv_hands()
+	user.update_equipment_overlay(slot_wear_mask_str, FALSE)
+	user.update_inhand_overlays()
 
 /obj/item/clothing/mask/smokable/pipe/cobpipe
 	name = "corn cob pipe"

--- a/code/modules/clothing/pants/_pants.dm
+++ b/code/modules/clothing/pants/_pants.dm
@@ -29,5 +29,6 @@
 	)
 
 /obj/item/clothing/pants/get_associated_equipment_slots()
+	. = ..()
 	var/static/list/pants_slots = list(slot_w_uniform_str, slot_wear_id_str)
-	return pants_slots
+	LAZYDISTINCTADD(., pants_slots)

--- a/code/modules/clothing/pants/_pants.dm
+++ b/code/modules/clothing/pants/_pants.dm
@@ -28,8 +28,6 @@
 		ACCESSORY_SLOT_OVER
 	)
 
-/obj/item/clothing/pants/update_clothing_icon()
-	if(ismob(src.loc))
-		var/mob/M = src.loc
-		M.update_inv_w_uniform(0)
-		M.update_inv_wear_id()
+/obj/item/clothing/pants/get_associated_equipment_slots()
+	var/static/list/pants_slots = list(slot_w_uniform_str, slot_wear_id_str)
+	return pants_slots

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -157,10 +157,8 @@
 			attached_cuffs = null
 	return
 
-/obj/item/clothing/shoes/update_clothing_icon()
-	if (ismob(src.loc))
-		var/mob/M = src.loc
-		M.update_inv_shoes()
+/obj/item/clothing/shoes/get_associated_equipment_slots()
+	return slot_shoes_str
 
 /obj/item/clothing/shoes/set_material(var/new_material)
 	..()

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -158,7 +158,8 @@
 	return
 
 /obj/item/clothing/shoes/get_associated_equipment_slots()
-	return slot_shoes_str
+	. = ..()
+	LAZYDISTINCTADD(., slot_shoes_str)
 
 /obj/item/clothing/shoes/set_material(var/new_material)
 	..()

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -311,16 +311,16 @@
 					switch(msg_type)
 						if("boots")
 							to_chat(wearer, SPAN_HARDSUIT("\The [piece] [!seal_target ? "seal around your feet" : "relax their grip on your legs"]."))
-							wearer.update_inv_shoes()
+							wearer.update_equipment_overlay(slot_shoes_str)
 						if("gloves")
 							to_chat(wearer, SPAN_HARDSUIT("\The [piece] [!seal_target ? "tighten around your fingers and wrists" : "become loose around your fingers"]."))
-							wearer.update_inv_gloves()
+							wearer.update_equipment_overlay(slot_gloves_str)
 						if("chest")
 							to_chat(wearer, SPAN_HARDSUIT("\The [piece] [!seal_target ? "cinches tight again your chest" : "releases your chest"]."))
-							wearer.update_inv_wear_suit()
+							wearer.update_equipment_overlay(slot_wear_suit_str)
 						if("helmet")
 							to_chat(wearer, SPAN_HARDSUIT("\The [piece] hisses [!seal_target ? "closed" : "open"]."))
-							wearer.update_inv_head()
+							wearer.update_equipment_overlay(slot_head_str)
 							if(helmet)
 								helmet.update_light(wearer)
 					//sealed pieces become airtight, protecting against diseases
@@ -575,14 +575,17 @@
 				chest.add_overlay(image("icon" = equipment_overlay_icon, "icon_state" = "[module.suit_overlay]", "dir" = SOUTH))
 
 	if(wearer)
-		wearer.update_inv_shoes()
-		wearer.update_inv_gloves()
-		wearer.update_inv_head()
-		wearer.update_inv_wear_mask()
-		wearer.update_inv_wear_suit()
-		wearer.update_inv_w_uniform()
-		wearer.update_inv_back()
-	return
+		var/static/list/update_rig_slots = list(
+			slot_shoes_str,
+			slot_gloves_str,
+			slot_head_str,
+			slot_wear_mask_str,
+			slot_wear_suit_str,
+			slot_w_uniform_str,
+			slot_back_str
+		)
+		for(var/slot in update_rig_slots)
+			wearer.update_equipment_overlay(slot)
 
 /obj/item/rig/adjust_mob_overlay(var/mob/living/user_mob, var/bodytype,  var/image/overlay, var/slot, var/bodypart)
 	if(overlay && slot == slot_back_str && !offline && equipment_overlay_icon && LAZYLEN(installed_modules))

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -508,13 +508,7 @@
 		data["valveOpen"] = (wearer.internal == air_supply)
 
 		if(!wearer.internal || wearer.internal == air_supply)	// if they have no active internals or if tank is current internal
-			var/found_mask = 0
-			for(var/slot in global.airtight_slots)
-				var/obj/item/gear = wearer.get_equipped_item(slot)
-				if(gear && (gear.item_flags & ITEM_FLAG_AIRTIGHT))
-					found_mask = 1
-					break
-			data["maskConnected"] = found_mask
+			data["maskConnected"] = wearer.check_for_airtight_internals(FALSE)
 
 	data["tankPressure"] = round(air_supply && air_supply.air_contents && air_supply.air_contents.return_pressure() ? air_supply.air_contents.return_pressure() : 0)
 	data["releasePressure"] = round(air_supply && air_supply.distribute_pressure ? air_supply.distribute_pressure : 0)

--- a/code/modules/clothing/suits/_suit.dm
+++ b/code/modules/clothing/suits/_suit.dm
@@ -12,10 +12,8 @@
 	var/protects_against_weather = FALSE
 	var/fire_resist = T0C+100
 
-/obj/item/clothing/suit/update_clothing_icon()
-	if (ismob(src.loc))
-		var/mob/M = src.loc
-		M.update_inv_wear_suit()
+/obj/item/clothing/suit/get_associated_equipment_slots()
+	return slot_wear_suit_str
 
 /obj/item/clothing/suit/preserve_in_cryopod(var/obj/machinery/cryopod/pod)
 	return TRUE

--- a/code/modules/clothing/suits/_suit.dm
+++ b/code/modules/clothing/suits/_suit.dm
@@ -13,7 +13,8 @@
 	var/fire_resist = T0C+100
 
 /obj/item/clothing/suit/get_associated_equipment_slots()
-	return slot_wear_suit_str
+	. = ..()
+	LAZYDISTINCTADD(., slot_wear_suit_str)
 
 /obj/item/clothing/suit/preserve_in_cryopod(var/obj/machinery/cryopod/pod)
 	return TRUE

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -84,8 +84,9 @@
 		update_clothing_icon()
 
 /obj/item/clothing/under/get_associated_equipment_slots()
+	. = ..()
 	var/static/list/under_slots = list(slot_w_uniform_str, slot_wear_id_str)
-	return under_slots
+	LAZYDISTINCTADD(., under_slots)
 
 /obj/item/clothing/under/examine(mob/user)
 	. = ..()

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -83,11 +83,9 @@
 		to_chat(usr, SPAN_NOTICE("You roll [rolled_sleeves ? "up" : "down"] the sleeves of \the [src]."))
 		update_clothing_icon()
 
-/obj/item/clothing/under/update_clothing_icon()
-	if(ismob(src.loc))
-		var/mob/M = src.loc
-		M.update_inv_w_uniform(0)
-		M.update_inv_wear_id()
+/obj/item/clothing/under/get_associated_equipment_slots()
+	var/static/list/under_slots = list(slot_w_uniform_str, slot_wear_id_str)
+	return under_slots
 
 /obj/item/clothing/under/examine(mob/user)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -489,7 +489,7 @@
 	for(var/obj/item/organ/external/grabber in get_hands_organs())
 		bloodied |= grabber.add_blood(M, amount, blood_data)
 	if(bloodied)
-		update_inv_gloves()	//handles bloody hands overlays and updating
+		update_equipment_overlay(slot_gloves_str)	//handles bloody hands overlays and updating
 		verbs += /mob/living/carbon/human/proc/bloody_doodle
 	return 1 //we applied blood to the item
 
@@ -506,8 +506,8 @@
 		//TODO check that organ is not covered
 		if(clean_feet || (organ.organ_tag in list(BP_L_HAND,BP_R_HAND)))
 			organ.clean()
-	update_inv_gloves(1)
-	update_inv_shoes(1)
+	update_equipment_overlay(slot_gloves_str, FALSE)
+	update_equipment_overlay(slot_shoes_str)
 	return TRUE
 
 /mob/living/carbon/human/get_visible_implants(var/class = 0)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -242,15 +242,15 @@ meteor_act
 				var/obj/item/mask = get_equipped_item(slot_wear_mask_str)
 				if(mask)
 					mask.add_blood(src)
-					update_inv_wear_mask(0)
+					update_equipment_overlay(slot_wear_mask_str, FALSE)
 				var/obj/item/head = get_equipped_item(slot_head_str)
 				if(head)
 					head.add_blood(src)
-					update_inv_head(0)
+					update_equipment_overlay(slot_head_str, FALSE)
 				var/obj/item/glasses = get_equipped_item(slot_glasses_str)
 				if(glasses && prob(33))
 					glasses.add_blood(src)
-					update_inv_glasses(0)
+					update_equipment_overlay(slot_glasses_str, FALSE)
 			if(BP_CHEST)
 				bloody_body(src)
 
@@ -382,17 +382,18 @@ meteor_act
 		gloves.add_blood(source, amount)
 	else
 		add_blood(source, amount)
-	update_inv_gloves()		//updates on-mob overlays for bloody hands and/or bloody gloves
+	//updates on-mob overlays for bloody hands and/or bloody gloves
+	update_equipment_overlay(slot_gloves_str)
 
 /mob/living/carbon/human/proc/bloody_body(var/mob/living/source)
 	var/obj/item/gear = get_equipped_item(slot_wear_suit_str)
 	if(gear)
 		gear.add_blood(source)
-		update_inv_wear_suit(0)
+		update_equipment_overlay(slot_wear_suit_str, redraw_mob = FALSE)
 	gear = get_equipped_item(slot_w_uniform_str)
 	if(gear)
 		gear.add_blood(source)
-		update_inv_w_uniform(0)
+		update_equipment_overlay(slot_w_uniform_str, redraw_mob = FALSE)
 
 /mob/living/carbon/human/proc/handle_suit_punctures(var/damtype, var/damage, var/def_zone)
 

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -280,7 +280,7 @@
 
 	//#TODO: wish we could invalidate the human icons to trigger a single update when the organ state changes multiple times in a row
 	if(update_icon)
-		update_inv_hands(FALSE)
+		update_inhand_overlays(FALSE)
 		update_body(FALSE)
 		update_bandages(FALSE)
 		UpdateDamageIcon(FALSE)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -581,6 +581,7 @@ var/global/list/damage_icon_parts = list()
 		set_current_mob_overlay(HO_FIRE_LAYER, null, update_icons)
 
 /mob/living/carbon/human/update_surgery(var/update_icons=1)
+	SHOULD_CALL_PARENT(FALSE)
 	var/image/total = null
 	for(var/obj/item/organ/external/E in get_external_organs())
 		if(BP_IS_PROSTHETIC(E))

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -580,39 +580,6 @@ var/global/list/damage_icon_parts = list()
 	else
 		set_current_mob_overlay(HO_FIRE_LAYER, null, update_icons)
 
-/mob/living/carbon/human/update_surgery(var/update_icons=1)
-	SHOULD_CALL_PARENT(FALSE)
-	var/image/total = null
-	for(var/obj/item/organ/external/E in get_external_organs())
-		if(BP_IS_PROSTHETIC(E))
-			continue
-		var/how_open = round(E.how_open())
-		if(how_open <= 0)
-			continue
-		var/surgery_icon = E.species.get_surgery_overlay_icon(src)
-		if(!surgery_icon)
-			continue
-		if(!total)
-			total = new
-			total.appearance_flags = RESET_COLOR
-		var/base_state = "[E.icon_state][how_open]"
-		var/overlay_state = "[base_state]-flesh"
-		var/list/overlays_to_add
-		if(check_state_in_icon(overlay_state, surgery_icon))
-			var/image/flesh = image(icon = surgery_icon, icon_state = overlay_state, layer = -HO_SURGERY_LAYER)
-			flesh.color = E.species.get_flesh_colour(src)
-			LAZYADD(overlays_to_add, flesh)
-		overlay_state = "[base_state]-blood"
-		if(check_state_in_icon(overlay_state, surgery_icon))
-			var/image/blood = image(icon = surgery_icon, icon_state = overlay_state, layer = -HO_SURGERY_LAYER)
-			blood.color = E.species.get_blood_color(src)
-			LAZYADD(overlays_to_add, blood)
-		overlay_state = "[base_state]-bones"
-		if(check_state_in_icon(overlay_state, surgery_icon))
-			LAZYADD(overlays_to_add, image(icon = surgery_icon, icon_state = overlay_state, layer = -HO_SURGERY_LAYER))
-		total.overlays |= overlays_to_add
-	set_current_mob_overlay(HO_SURGERY_LAYER, total, update_icons)
-
 //Ported from hud login stuff
 //
 /mob/living/carbon/hud_reset(full_reset = FALSE)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -59,27 +59,8 @@ There are several things that need to be remembered:
 
 >	Whenever we do something that should cause an overlay to update (which doesn't use standard procs
 	( i.e. you do something like l_hand = /obj/item/something new(src) )
-	You will need to call the relevant update_inv_* proc:
-		update_inv_head()
-		update_inv_wear_suit()
-		update_inv_gloves()
-		update_inv_shoes()
-		update_inv_w_uniform()
-		update_inv_glasse()
-		update_inv_hands()
-		update_inv_belt()
-		update_inv_wear_id()
-		update_inv_ears()
-		update_inv_s_store()
-		update_inv_pockets()
-		update_inv_back()
-		update_inv_handcuffed()
-		update_inv_wear_mask()
-
-	All of these are named after the variable they update from. They are defined at the mob/ level like
-	update_clothing was, so you won't cause undefined proc runtimes with usr.update_inv_wear_id() if the usr is a
-	slime etc. Instead, it'll just return without doing any work. So no harm in calling it for slimes and such.
-
+	You will need to call the update_equipment_overlay() proc with the approriate slot flag ie.
+		update_equipment_overlay(slot_wear_suit_str)
 
 >	There are also these special cases:
 		update_mutations()	//handles updating your appearance for certain mutations.  e.g TK head-glows
@@ -93,12 +74,12 @@ There are several things that need to be remembered:
 	If you wish to update several overlays at once, you can set the argument to 0 to disable the update and call
 	it manually:
 		e.g.
-		update_inv_head(0)
-		update_inv_hands()		//<---calls update_icon()
+		update_equipment_overlay(slot_head_str, FALSE)
+		update_inhand_overlays()		//<---calls update_icon()
 
 	or equivillantly:
-		update_inv_head(0)
-		update_inv_hands(0)
+		update_equipment_overlay(slot_head_str, FALSE)
+		update_inhand_overlays(FALSE)
 		update_icon()
 
 >	If you need to update all overlays you can use refresh_visible_overlays(). it works exactly like update_clothing used to.
@@ -117,45 +98,17 @@ If you have any questions/constructive-comments/bugs-to-report/or have a massivl
 Please contact me on #coderbus IRC. ~Carn x
 */
 
-//Human Overlays Indexes/////////
-#define HO_MUTATIONS_LAYER  1
-#define HO_SKIN_LAYER       2
-#define HO_DAMAGE_LAYER     3
-#define HO_SURGERY_LAYER    4 //bs12 specific.
-#define HO_UNDERWEAR_LAYER  5
-#define HO_UNIFORM_LAYER    6
-#define HO_ID_LAYER         7
-#define HO_SHOES_LAYER      8
-#define HO_GLOVES_LAYER     9
-#define HO_BELT_LAYER       10
-#define HO_SUIT_LAYER       11
-#define HO_GLASSES_LAYER    12
-#define HO_BELT_LAYER_ALT   13
-#define HO_SUIT_STORE_LAYER 14
-#define HO_BACK_LAYER       15
-#define HO_TAIL_LAYER       16 //bs12 specific. this hack is probably gonna come back to haunt me
-#define HO_HAIR_LAYER       17 //TODO: make part of head layer?
-#define HO_GOGGLES_LAYER    18
-#define HO_EARS_LAYER       19
-#define HO_FACEMASK_LAYER   20
-#define HO_HEAD_LAYER       21
-#define HO_COLLAR_LAYER     22
-#define HO_HANDCUFF_LAYER   23
-#define HO_INHAND_LAYER     24
-#define HO_FIRE_LAYER       25 //If you're on fire
-#define TOTAL_OVER_LAYERS   25
-//////////////////////////////////
-
-// Underlay defines; vestigal implementation currently.
-#define HU_TAIL_LAYER 1
-#define TOTAL_UNDER_LAYERS 1
-
 /mob/living/carbon/human
 	var/list/overlays_standing[TOTAL_OVER_LAYERS]
 	var/list/underlays_standing[TOTAL_UNDER_LAYERS]
 	var/previous_damage_appearance // store what the body last looked like, so we only have to update it if something changed
 
-/mob/living/carbon/human/proc/refresh_visible_overlays()
+/mob/living/proc/refresh_visible_overlays()
+	SHOULD_CALL_PARENT(TRUE)
+	for(var/slot in get_inventory_slots())
+		update_equipment_overlay(slot, FALSE)
+
+/mob/living/carbon/human/refresh_visible_overlays()
 
 	if(HasMovementHandler(/datum/movement_handler/mob/transformation) || QDELETED(src))
 		return
@@ -165,21 +118,10 @@ Please contact me on #coderbus IRC. ~Carn x
 	update_skin(FALSE)
 	update_underwear(FALSE)
 	update_hair(FALSE)
-	update_inv_w_uniform(FALSE)
-	update_inv_wear_id(FALSE)
-	update_inv_gloves(FALSE)
-	update_inv_glasses(FALSE)
-	update_inv_ears(FALSE)
-	update_inv_shoes(FALSE)
-	update_inv_s_store(FALSE)
-	update_inv_wear_mask(FALSE)
-	update_inv_head(FALSE)
-	update_inv_belt(FALSE)
-	update_inv_back(FALSE)
-	update_inv_wear_suit(FALSE)
-	update_inv_hands(FALSE)
-	update_inv_handcuffed(FALSE)
-	update_inv_pockets(FALSE)
+
+	..()
+
+	update_inhand_overlays(FALSE)
 	update_fire(FALSE)
 	update_surgery(FALSE)
 	update_bandages(FALSE)
@@ -510,214 +452,10 @@ var/global/list/damage_icon_parts = list()
 
 /* --------------------------------------- */
 //vvvvvv UPDATE_INV PROCS vvvvvv
+/mob/living/proc/update_tail_showing(var/update_icons=1)
+	return
 
-/mob/living/carbon/human/update_inv_w_uniform(var/update_icons=1)
-	var/obj/item/suit = get_equipped_item(slot_wear_suit_str)
-	var/obj/item/uniform = get_equipped_item(slot_w_uniform_str)
-	if(uniform && (!suit || !(suit.flags_inv & HIDEJUMPSUIT)))
-		overlays_standing[HO_UNIFORM_LAYER]	= uniform.get_mob_overlay(src,slot_w_uniform_str)
-	else
-		overlays_standing[HO_UNIFORM_LAYER]	= null
-	if(update_icons)
-		queue_icon_update()
-
-/mob/living/carbon/human/update_inv_wear_id(var/update_icons=1)
-	overlays_standing[HO_ID_LAYER] = null
-	var/obj/item/id = get_equipped_item(slot_wear_id_str)
-	if(id)
-		var/obj/item/clothing/under/U = get_equipped_item(slot_w_uniform_str)
-		if(istype(U) && !U.displays_id && !U.rolled_down)
-			return
-		overlays_standing[HO_ID_LAYER] = id.get_mob_overlay(src, slot_wear_id_str)
-	BITSET(hud_updateflag, ID_HUD)
-	BITSET(hud_updateflag, WANTED_HUD)
-
-	if(update_icons)
-		queue_icon_update()
-
-/mob/living/carbon/human/update_inv_gloves(var/update_icons=1)
-	var/obj/item/suit = get_equipped_item(slot_wear_suit_str)
-	var/obj/item/gloves = get_equipped_item(slot_gloves_str)
-	if(gloves && !(suit && suit.flags_inv & HIDEGLOVES))
-		overlays_standing[HO_GLOVES_LAYER]	= gloves.get_mob_overlay(src,slot_gloves_str)
-	else
-		var/list/blood_color
-		for(var/obj/item/organ/external/grabber in get_hands_organs())
-			if(grabber.coating)
-				blood_color = grabber.coating.get_color()
-
-		overlays_standing[HO_GLOVES_LAYER]	= null
-		if(blood_color)
-			var/mob_blood_overlay = get_bodytype().get_blood_overlays(src)
-			if(mob_blood_overlay)
-				var/image/bloodsies	= overlay_image(mob_blood_overlay, "bloodyhands", blood_color, RESET_COLOR)
-				overlays_standing[HO_GLOVES_LAYER]	= bloodsies
-
-	if(update_icons)
-		queue_icon_update()
-
-/mob/living/carbon/human/update_inv_glasses(var/update_icons=1)
-	var/obj/item/glasses = get_equipped_item(slot_glasses_str)
-	if(glasses)
-		overlays_standing[glasses.use_alt_layer ? HO_GOGGLES_LAYER : HO_GLASSES_LAYER] = glasses.get_mob_overlay(src,slot_glasses_str)
-		overlays_standing[glasses.use_alt_layer ? HO_GLASSES_LAYER : HO_GOGGLES_LAYER] = null
-	else
-		overlays_standing[HO_GLASSES_LAYER]	= null
-		overlays_standing[HO_GOGGLES_LAYER]	= null
-	if(update_icons)
-		queue_icon_update()
-
-/mob/living/carbon/human/update_inv_ears(var/update_icons=1)
-
-	overlays_standing[HO_EARS_LAYER] = null
-	for(var/slot in global.airtight_slots)
-		var/obj/item/gear = get_equipped_item(slot)
-		if(gear && (gear.flags_inv & (BLOCK_ALL_HAIR)))
-			if(update_icons)
-				queue_icon_update()
-			return
-
-	var/image/both
-	for(var/slot in global.ear_slots)
-		var/obj/item/ear = get_equipped_item(slot)
-		if(ear)
-			if(!both)
-				both = image("icon" = 'icons/effects/effects.dmi', "icon_state" = "nothing")
-			both.overlays += ear.get_mob_overlay(src, slot)
-
-	if(both)
-		overlays_standing[HO_EARS_LAYER] = both
-	else
-		overlays_standing[HO_EARS_LAYER]	= null
-	if(update_icons)
-		queue_icon_update()
-
-/mob/living/carbon/human/update_inv_shoes(var/update_icons=1)
-	var/obj/item/shoes =   get_equipped_item(slot_shoes_str)
-	var/obj/item/suit =    get_equipped_item(slot_wear_suit_str)
-	var/obj/item/uniform = get_equipped_item(slot_w_uniform_str)
-	if(shoes && !((suit && suit.flags_inv & HIDESHOES) || (uniform && uniform.flags_inv & HIDESHOES)))
-		overlays_standing[HO_SHOES_LAYER] = shoes.get_mob_overlay(src,slot_shoes_str)
-	else
-		var/list/blood_color
-		for(var/foot_tag in list(BP_L_FOOT, BP_R_FOOT))
-			var/obj/item/organ/external/stomper = GET_EXTERNAL_ORGAN(src, foot_tag)
-			if(stomper && stomper.coating)
-				blood_color = stomper.coating.get_color()
-
-		overlays_standing[HO_SHOES_LAYER] = null
-		if(blood_color)
-			var/mob_blood_overlay = get_bodytype().get_blood_overlays(src)
-			if(mob_blood_overlay)
-				var/image/bloodsies = overlay_image(mob_blood_overlay, "shoeblood", blood_color, RESET_COLOR)
-				overlays_standing[HO_SHOES_LAYER] = bloodsies
-		else
-	if(update_icons)
-		queue_icon_update()
-
-/mob/living/carbon/human/update_inv_s_store(var/update_icons=1)
-	var/obj/item/stored = get_equipped_item(slot_s_store_str)
-	if(stored)
-		overlays_standing[HO_SUIT_STORE_LAYER] = stored.get_mob_overlay(src, slot_belt_str)
-	else
-		overlays_standing[HO_SUIT_STORE_LAYER] = null
-	if(update_icons)
-		queue_icon_update()
-
-/mob/living/carbon/human/update_inv_head(var/update_icons=1)
-	var/obj/item/head = get_equipped_item(slot_head_str)
-	if(head)
-		overlays_standing[HO_HEAD_LAYER] = head.get_mob_overlay(src,slot_head_str)
-	else
-		overlays_standing[HO_HEAD_LAYER]	= null
-	if(update_icons)
-		queue_icon_update()
-
-/mob/living/carbon/human/update_inv_belt(var/update_icons=1)
-	var/obj/item/belt = get_equipped_item(slot_belt_str)
-	if(belt)
-		overlays_standing[belt.use_alt_layer ? HO_BELT_LAYER_ALT : HO_BELT_LAYER] = belt.get_mob_overlay(src,slot_belt_str)
-		overlays_standing[belt.use_alt_layer ? HO_BELT_LAYER : HO_BELT_LAYER_ALT] = null
-	else
-		overlays_standing[HO_BELT_LAYER] = null
-		overlays_standing[HO_BELT_LAYER_ALT] = null
-	if(update_icons)
-		queue_icon_update()
-
-/mob/living/carbon/human/update_inv_wear_suit(var/update_icons=1)
-	var/obj/item/suit = get_equipped_item(slot_wear_suit_str)
-	if(suit)
-		overlays_standing[HO_SUIT_LAYER] = suit.get_mob_overlay(src,slot_wear_suit_str)
-		update_tail_showing(0)
-	else
-		overlays_standing[HO_SUIT_LAYER] = null
-		update_tail_showing(0)
-		update_inv_w_uniform(0)
-		update_inv_shoes(0)
-		update_inv_gloves(0)
-
-	update_collar(0)
-
-	if(update_icons)
-		queue_icon_update()
-
-/mob/living/carbon/human/update_inv_pockets(var/update_icons=1)
-	if(update_icons)
-		queue_icon_update()
-
-/mob/living/carbon/human/update_inv_wear_mask(var/update_icons=1)
-	var/obj/item/mask = get_equipped_item(slot_wear_mask_str)
-	var/obj/item/head = get_equipped_item(slot_head_str)
-	update_hair(0)	//rebuild hair
-	update_inv_ears(0)
-
-	if(!(mask && (mask.item_flags & ITEM_FLAG_AIRTIGHT)))
-		set_internals(null)
-
-	if(mask && !(head && head.flags_inv & HIDEMASK))
-		overlays_standing[HO_FACEMASK_LAYER] = mask.get_mob_overlay(src,slot_wear_mask_str)
-	else
-		overlays_standing[HO_FACEMASK_LAYER] = null
-	if(update_icons)
-		queue_icon_update()
-
-/mob/living/carbon/human/update_inv_back(var/update_icons=1)
-	var/obj/item/back = get_equipped_item(slot_back_str)
-	if(back)
-		overlays_standing[HO_BACK_LAYER] = back.get_mob_overlay(src,slot_back_str)
-	else
-		overlays_standing[HO_BACK_LAYER] = null
-	if(update_icons)
-		queue_icon_update()
-
-/mob/living/carbon/human/update_inv_handcuffed(var/update_icons=1)
-	var/obj/item/cuffs = get_equipped_item(slot_handcuffed_str)
-	if(cuffs)
-		overlays_standing[HO_HANDCUFF_LAYER] = cuffs.get_mob_overlay(src,slot_handcuffed_str)
-	else
-		overlays_standing[HO_HANDCUFF_LAYER] = null
-	if(update_icons)
-		queue_icon_update()
-
-/mob/living/carbon/human/update_inv_hands(var/update_icons=1)
-	overlays_standing[HO_INHAND_LAYER] = null
-	for(var/hand_slot in get_held_item_slots())
-		var/datum/inventory_slot/inv_slot = get_inventory_slot_datum(hand_slot)
-		var/obj/item/held = inv_slot?.get_equipped_item()
-		if(istype(held))
-			// This should be moved out of icon code
-			if(get_equipped_item(slot_handcuffed_str))
-				drop_from_inventory(held)
-				continue
-			var/image/standing = held.get_mob_overlay(src, inv_slot.overlay_slot, hand_slot)
-			if(standing)
-				standing.appearance_flags |= RESET_ALPHA
-				LAZYADD(overlays_standing[HO_INHAND_LAYER], standing)
-
-	if(update_icons)
-		queue_icon_update()
-
-/mob/living/carbon/human/proc/update_tail_showing(var/update_icons=1)
+/mob/living/carbon/human/update_tail_showing(var/update_icons=1)
 	overlays_standing[HO_TAIL_LAYER] =  null
 	underlays_standing[HU_TAIL_LAYER] = null
 	var/obj/item/organ/external/tail/tail_organ = get_organ(BP_TAIL, /obj/item/organ/external/tail)
@@ -758,13 +496,12 @@ var/global/list/damage_icon_parts = list()
 
 	return tail_icon
 
-/mob/living/carbon/human/set_dir()
+/mob/living/set_dir()
 	. = ..()
 	if(.)
 		var/obj/item/organ/external/tail/tail_organ = get_organ(BP_TAIL, /obj/item/organ/external/tail)
-		if(tail_organ && tail_organ.get_tail())
+		if(tail_organ?.get_tail())
 			update_tail_showing()
-
 
 /mob/living/carbon/human/proc/set_tail_state(var/t_state)
 	var/image/tail_overlay = overlays_standing[HO_TAIL_LAYER] || underlays_standing[HU_TAIL_LAYER]
@@ -837,18 +574,6 @@ var/global/list/damage_icon_parts = list()
 	if(!tail_organ)
 		return
 	set_tail_state("[tail_organ.get_tail()]_static")
-
-//Adds a collar overlay above the helmet layer if the suit has one
-//	Suit needs an identically named sprite in icons/mob/collar.dmi
-/mob/living/carbon/human/proc/update_collar(var/update_icons=1)
-	var/obj/item/clothing/suit/S = get_equipped_item(slot_wear_suit_str)
-	if(istype(S))
-		overlays_standing[HO_COLLAR_LAYER]	= S.get_collar()
-	else
-		overlays_standing[HO_COLLAR_LAYER]	= null
-
-	if(update_icons)
-		queue_icon_update()
 
 /mob/living/carbon/human/update_fire(var/update_icons=1)
 	overlays_standing[HO_FIRE_LAYER] = null

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -89,7 +89,7 @@
 			QDEL_NULL(cuffs)
 			if(buckled && buckled.buckle_require_restraints)
 				buckled.unbuckle_mob()
-			update_inv_handcuffed()
+			update_equipment_overlay(slot_handcuffed_str)
 			return
 	visible_message(
 		SPAN_WARNING("\The [src] manages to remove \the [cuffs]!"),

--- a/code/modules/mob/living/internals.dm
+++ b/code/modules/mob/living/internals.dm
@@ -19,14 +19,7 @@
 		return
 
 	// Check for airtight mask/helmet.
-	var/found_mask = FALSE
-	for(var/slot in global.airtight_slots)
-		var/obj/item/gear = get_equipped_item(slot)
-		if(gear && (gear.item_flags & ITEM_FLAG_AIRTIGHT))
-			found_mask = TRUE
-			break
-
-	if(!found_mask)
+	if(!check_for_airtight_internals(FALSE))
 		to_chat(user, SPAN_WARNING("\The [src] does not have a suitable mask or helmet."))
 		return
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1188,6 +1188,33 @@ default behaviour is:
 
 /mob/living/proc/update_surgery(update_icons)
 	SHOULD_CALL_PARENT(TRUE)
-	if(update_icons)
-		queue_icon_update()
-
+	var/image/total = null
+	for(var/obj/item/organ/external/E in get_external_organs())
+		if(BP_IS_PROSTHETIC(E))
+			continue
+		var/how_open = round(E.how_open())
+		if(how_open <= 0)
+			continue
+		var/surgery_icon = E.species.get_surgery_overlay_icon(src)
+		if(!surgery_icon)
+			continue
+		if(!total)
+			total = new
+			total.appearance_flags = RESET_COLOR
+		var/base_state = "[E.icon_state][how_open]"
+		var/overlay_state = "[base_state]-flesh"
+		var/list/overlays_to_add
+		if(check_state_in_icon(overlay_state, surgery_icon))
+			var/image/flesh = image(icon = surgery_icon, icon_state = overlay_state, layer = -HO_SURGERY_LAYER)
+			flesh.color = E.species.get_flesh_colour(src)
+			LAZYADD(overlays_to_add, flesh)
+		overlay_state = "[base_state]-blood"
+		if(check_state_in_icon(overlay_state, surgery_icon))
+			var/image/blood = image(icon = surgery_icon, icon_state = overlay_state, layer = -HO_SURGERY_LAYER)
+			blood.color = E.species.get_blood_color(src)
+			LAZYADD(overlays_to_add, blood)
+		overlay_state = "[base_state]-bones"
+		if(check_state_in_icon(overlay_state, surgery_icon))
+			LAZYADD(overlays_to_add, image(icon = surgery_icon, icon_state = overlay_state, layer = -HO_SURGERY_LAYER))
+		total.overlays |= overlays_to_add
+	set_current_mob_overlay(HO_SURGERY_LAYER, total, update_icons)

--- a/code/modules/mob/living/living_breath.dm
+++ b/code/modules/mob/living/living_breath.dm
@@ -104,14 +104,7 @@
 			if(!(old_internals in contents))
 				set_internals(null)
 			else
-				var/found_mask = FALSE
-				for(var/slot in global.airtight_slots)
-					var/obj/item/gear = get_equipped_item(slot)
-					if(gear && (gear.item_flags & ITEM_FLAG_AIRTIGHT))
-						found_mask = TRUE
-						break
-				if(!found_mask)
-					set_internals(null)
+				check_for_airtight_internals()
 	var/obj/item/tank/new_internals = get_internals()
 	if(internals && old_internals != new_internals)
 		internals.icon_state = "internal[!!new_internals]"

--- a/code/modules/mob/update_icons.dm
+++ b/code/modules/mob/update_icons.dm
@@ -1,52 +1,37 @@
-//Most of these are defined at this level to reduce on checks elsewhere in the code.
-//Having them here also makes for a nice reference list of the various overlay-updating procs available
+/mob/proc/update_equipment_overlay(var/slot, var/redraw_mob = TRUE)
+	var/datum/inventory_slot/inv_slot = slot && get_inventory_slot_datum(slot)
+	if(inv_slot)
+		inv_slot.update_mob_equipment_overlay(src, null, redraw_mob)
 
-/mob/proc/update_inv_handcuffed()
-	return
+/mob/proc/update_inhand_overlays(var/redraw_mob = TRUE)
+	var/list/hand_overlays = null
+	for(var/hand_slot in get_held_item_slots())
+		var/datum/inventory_slot/inv_slot = get_inventory_slot_datum(hand_slot)
+		var/obj/item/held = inv_slot?.get_equipped_item()
+		if(istype(held))
+			// This should be moved out of icon code
+			if(get_equipped_item(slot_handcuffed_str))
+				drop_from_inventory(held)
+				continue
+			var/image/standing = held.get_mob_overlay(src, inv_slot.overlay_slot, hand_slot)
+			if(standing)
+				standing.appearance_flags |= RESET_ALPHA
+				LAZYADD(hand_overlays, standing)
+	if(LAZYLEN(hand_overlays))
+		set_mob_overlay(HO_INHAND_LAYER, hand_overlays, redraw_mob)
+	else
+		set_mob_overlay(HO_INHAND_LAYER, null, redraw_mob)
 
-/mob/proc/update_inv_back()
-	return
+/mob/proc/set_mob_overlay(var/overlay_layer, var/image/overlay, var/redraw_mob = TRUE)
+	SHOULD_CALL_PARENT(TRUE)
+	if(redraw_mob)
+		queue_icon_update()
 
-/mob/proc/update_inv_hands()
-	return
-
-/mob/proc/update_inv_wear_mask()
-	return
-
-/mob/proc/update_inv_wear_suit()
-	return
-
-/mob/proc/update_inv_w_uniform()
-	return
-
-/mob/proc/update_inv_belt()
-	return
-
-/mob/proc/update_inv_head()
-	return
-
-/mob/proc/update_inv_gloves()
-	return
+/mob/living/carbon/human/set_mob_overlay(var/overlay_layer, var/image/overlay, var/redraw_mob = TRUE)
+	overlays_standing[overlay_layer] = overlay
+	..()
 
 /mob/proc/update_mutations()
-	return
-
-/mob/proc/update_inv_wear_id()
-	return
-
-/mob/proc/update_inv_shoes()
-	return
-
-/mob/proc/update_inv_glasses()
-	return
-
-/mob/proc/update_inv_s_store()
-	return
-
-/mob/proc/update_inv_pockets()
-	return
-
-/mob/proc/update_inv_ears()
 	return
 
 /mob/proc/update_targeted()

--- a/code/modules/mob/update_icons.dm
+++ b/code/modules/mob/update_icons.dm
@@ -16,15 +16,10 @@
 	for(var/hand_slot in get_held_item_slots())
 		var/datum/inventory_slot/inv_slot = get_inventory_slot_datum(hand_slot)
 		var/obj/item/held = inv_slot?.get_equipped_item()
-		if(istype(held))
-			// This should be moved out of icon code
-			if(get_equipped_item(slot_handcuffed_str))
-				drop_from_inventory(held)
-				continue
-			var/image/standing = held.get_mob_overlay(src, inv_slot.overlay_slot, hand_slot)
-			if(standing)
-				standing.appearance_flags |= RESET_ALPHA
-				LAZYADD(hand_overlays, standing)
+		var/image/standing = held?.get_mob_overlay(src, inv_slot.overlay_slot, hand_slot)
+		if(standing)
+			standing.appearance_flags |= (RESET_ALPHA|RESET_COLOR)
+			LAZYADD(hand_overlays, standing)
 	set_current_mob_overlay(HO_INHAND_LAYER, hand_overlays, redraw_mob)
 
 /mob/proc/get_current_mob_overlay(var/overlay_layer)

--- a/code/modules/mob/update_icons.dm
+++ b/code/modules/mob/update_icons.dm
@@ -25,26 +25,26 @@
 			if(standing)
 				standing.appearance_flags |= RESET_ALPHA
 				LAZYADD(hand_overlays, standing)
-	set_mob_overlay(HO_INHAND_LAYER, hand_overlays, redraw_mob)
+	set_current_mob_overlay(HO_INHAND_LAYER, hand_overlays, redraw_mob)
 
-/mob/proc/get_mob_overlay(var/overlay_layer)
+/mob/proc/get_current_mob_overlay(var/overlay_layer)
 	return
 
-/mob/proc/get_all_mob_overlays()
+/mob/proc/get_all_current_mob_overlays()
 	return
 
-/mob/proc/set_mob_overlay(var/overlay_layer, var/image/overlay, var/redraw_mob = TRUE)
+/mob/proc/set_current_mob_overlay(var/overlay_layer, var/image/overlay, var/redraw_mob = TRUE)
 	SHOULD_CALL_PARENT(TRUE)
 	if(redraw_mob)
 		queue_icon_update()
 
-/mob/proc/get_mob_underlay(var/underlay_layer)
+/mob/proc/get_current_mob_underlay(var/underlay_layer)
 	return
 
-/mob/proc/get_all_mob_underlays()
+/mob/proc/get_all_current_mob_underlays()
 	return
 
-/mob/proc/set_mob_underlay(var/underlay_layer, var/image/underlay, var/redraw_mob = TRUE)
+/mob/proc/set_current_mob_underlay(var/underlay_layer, var/image/underlay, var/redraw_mob = TRUE)
 	SHOULD_CALL_PARENT(TRUE)
 	if(redraw_mob)
 		queue_icon_update()

--- a/code/modules/mob/update_icons.dm
+++ b/code/modules/mob/update_icons.dm
@@ -1,3 +1,11 @@
+/mob/living/proc/refresh_visible_overlays()
+	SHOULD_CALL_PARENT(TRUE)
+	if(HasMovementHandler(/datum/movement_handler/mob/transformation) || QDELETED(src))
+		return FALSE
+	for(var/slot in get_inventory_slots())
+		update_equipment_overlay(slot, FALSE)
+	return TRUE
+
 /mob/proc/update_equipment_overlay(var/slot, var/redraw_mob = TRUE)
 	var/datum/inventory_slot/inv_slot = slot && get_inventory_slot_datum(slot)
 	if(inv_slot)
@@ -17,19 +25,29 @@
 			if(standing)
 				standing.appearance_flags |= RESET_ALPHA
 				LAZYADD(hand_overlays, standing)
-	if(LAZYLEN(hand_overlays))
-		set_mob_overlay(HO_INHAND_LAYER, hand_overlays, redraw_mob)
-	else
-		set_mob_overlay(HO_INHAND_LAYER, null, redraw_mob)
+	set_mob_overlay(HO_INHAND_LAYER, hand_overlays, redraw_mob)
+
+/mob/proc/get_mob_overlay(var/overlay_layer)
+	return
+
+/mob/proc/get_all_mob_overlays()
+	return
 
 /mob/proc/set_mob_overlay(var/overlay_layer, var/image/overlay, var/redraw_mob = TRUE)
 	SHOULD_CALL_PARENT(TRUE)
 	if(redraw_mob)
 		queue_icon_update()
 
-/mob/living/carbon/human/set_mob_overlay(var/overlay_layer, var/image/overlay, var/redraw_mob = TRUE)
-	overlays_standing[overlay_layer] = overlay
-	..()
+/mob/proc/get_mob_underlay(var/underlay_layer)
+	return
+
+/mob/proc/get_all_mob_underlays()
+	return
+
+/mob/proc/set_mob_underlay(var/underlay_layer, var/image/underlay, var/redraw_mob = TRUE)
+	SHOULD_CALL_PARENT(TRUE)
+	if(redraw_mob)
+		queue_icon_update()
 
 /mob/proc/update_mutations()
 	return

--- a/code/modules/modular_computers/computers/subtypes/dev_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_pda.dm
@@ -26,7 +26,7 @@
 	add_overlay(image(icon, "blank_screen"))
 	var/mob/living/carbon/human/H = loc
 	if(istype(H) && H.get_equipped_item(slot_wear_id_str) == src)
-		H.update_inv_wear_id()
+		H.update_equipment_overlay(slot_wear_id_str)
 
 // PDA box
 /obj/item/storage/box/PDAs

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -161,7 +161,7 @@
 		if(has_safety && M.skill_check(SKILL_WEAPONS,SKILL_BASIC))
 			add_overlay(image('icons/obj/guns/gui.dmi',"safety[safety()]"))
 		if(src in M.get_held_items())
-			M.update_inv_hands()
+			M.update_inhand_overlays()
 	if(safety_icon)
 		add_overlay(get_safety_indicator())
 

--- a/code/modules/projectiles/guns/energy/capacitor.dm
+++ b/code/modules/projectiles/guns/energy/capacitor.dm
@@ -221,7 +221,7 @@ var/global/list/laser_wavelengths
 
 	if(ismob(loc))
 		var/mob/M = loc
-		M.update_inv_hands()
+		M.update_inhand_overlays()
 
 /obj/item/gun/energy/capacitor/adjust_mob_overlay(var/mob/living/user_mob, var/bodytype,  var/image/overlay, var/slot, var/bodypart)
 	if(overlay && (slot == BP_L_HAND || slot == BP_R_HAND || slot == slot_back_str))


### PR DESCRIPTION
## Description of changes
- Inventory slot `update_overlay` now becomes `update_mob_equipment_overlay`.
- `update_mob_equipment_overlay` can handle a null prop being passed in.
- `update_mob_equipment_overlay` is called by `refresh_visible_overlays` at `/mob/living` level.
- The various `update_inv_foo` procs have been rolled into their respective inventory slots which are now updated with `update_equipment_overlay`.
- `set/get_current_mob_over/underlay` added for the human `over/underlays_standing` updating.
- `overlays_standing` is now `mob_overlays`, `underlays_standing` is now `mob_underlays`. Direct use of these lists has been replaced with getters/setters pending a better layering solution.

Tested on local but I expect I will have missed `src` or not set slots in some places.

## Why and what will this PR improve
Centralizes inventory updates in a way that allows for many mobs to benefit from the logic, not just humans.
Allows me to do some cheating with inventory slots when replacing the hattable extension in the future.

## Authorship
Myself.

## Changelog
Nothing player-facing.