### PR TITLE
Fix folding@home crashing too quickly

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/folding.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/folding.dm
@@ -52,17 +52,17 @@
 		started_on = 0
 		current_interval = 0
 
-/datum/computer_file/program/folding/process_tick()
+/datum/computer_file/program/folding/process_tick() //Every 50-100 seconds, gives you a 1/3 chance of the program crashing
 	. = ..()
 	if(!started_on)
 		return
 
-	if(world.timeofday > next_event)
+	if(world.timeofday < next_event) //Checks if it's time for the next crash chance
 		return
 	var/mob/living/holder = computer.holder.get_recursive_loc_of_type(/mob/living/carbon/human)
 	if(!crashed)
 		if(holder)
-			switch(rand(1,3))
+			switch(rand(1,3)) //Gives 1/3 chance of crashing
 				if(1)
 					to_chat(holder, SPAN_WARNING("The [computer] starts to get very warm."))
 				if(2)
@@ -76,7 +76,7 @@
 			crashed = TRUE
 			crashed_at = world.timeofday
 
-	next_event = (rand(MINIMUM_FOLDING_EVENT_INTERVAL, MAXIMUM_FOLDING_EVENT_INTERVAL) SECONDS) + world.timeofday
+	next_event = (rand(MINIMUM_FOLDING_EVENT_INTERVAL, MAXIMUM_FOLDING_EVENT_INTERVAL) SECONDS) + world.timeofday //Sets the next crash chance 50-100 seconds from now
 
 /datum/computer_file/program/folding/on_shutdown()
 	started_on = 0


### PR DESCRIPTION
Fixed improper comparison operator resulting in folding@home crashing almost immediately every time; added comments. Fixes https://github.com/NebulaSS13/Nebula/issues/3290

<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The next crash chance will not occur until it's time for the next crash chance, it was incorrectly firing constantly due to checking if it was *before* the next crash chance.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Will make folding@home usable for players.

## Authorship
<!-- Describe original authors of changes to credit them. -->

Thank you to https://github.com/out-of-phaze for pointing out the specific reason why this was actually happening.

## Changelog
:cl:
bugfix: fixed folding@home
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->