### PR TITLE
Fix inventory slot equip issues

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -423,7 +423,7 @@ var/global/list/gear_datums = list()
 		return
 
 	var/obj/item/old_item = wearer.get_equipped_item(slot)
-	if(wearer.equip_to_slot_if_possible(item, slot, del_on_fail = TRUE, force = TRUE, delete_old_item = FALSE))
+	if(wearer.equip_to_slot_if_possible(item, slot, del_on_fail = TRUE, force = TRUE, delete_old_item = FALSE, ignore_equipped = TRUE))
 		. = item
 		if(!old_item)
 			return

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -15,10 +15,10 @@
 //set disable_warning to disable the 'you are unable to equip that' warning.
 //unset redraw_mob to prevent the mob from being redrawn at the end.
 //set force to replace items in the slot and ignore blocking overwear
-/mob/proc/equip_to_slot_if_possible(obj/item/W, slot, del_on_fail = 0, disable_warning = 0, redraw_mob = 1, force = FALSE, delete_old_item = TRUE)
+/mob/proc/equip_to_slot_if_possible(obj/item/W, slot, del_on_fail = 0, disable_warning = 0, redraw_mob = 1, force = FALSE, delete_old_item = TRUE, ignore_equipped = FALSE)
 	if(!istype(W) || !slot)
 		return FALSE
-	. = (canUnEquip(W) && can_equip_anything_to_slot(slot) && has_organ_for_slot(slot) && W.mob_can_equip(src, slot, disable_warning, force, ignore_equipped = TRUE))
+	. = (canUnEquip(W) && can_equip_anything_to_slot(slot) && has_organ_for_slot(slot) && W.mob_can_equip(src, slot, disable_warning, force, ignore_equipped = ignore_equipped))
 	if(.)
 		equip_to_slot(W, slot, redraw_mob, delete_old_item = delete_old_item) //This proc should not ever fail.
 	else if(del_on_fail)


### PR DESCRIPTION
## Description of changes
- Moves the `ignore_equipped` flag up to `equip_to_slot_if_possible` so you can't hit E and delete your backpack with an oxygen tank because, for some reason, I set it to always be true.
- Reworks in-place equip/unequip, using slight changes to `/unequipped()` to facilitate this (it now only clears the slot if `prop` is actually in the slot to begin with).

## Why and what will this PR improve
You can't accidentally nuke your backpack by trying to equip a back slot item.
You no longer spawn without an ID/PDA if you take a uniform in the loadout.

## Authorship
Me.