### PR TITLE
Fix prosthetic organ 'fault' ailments

### DIFF
--- a/code/modules/organs/ailments/_ailment.dm
+++ b/code/modules/organs/ailments/_ailment.dm
@@ -39,7 +39,7 @@
 /datum/ailment/proc/can_apply_to(var/obj/item/organ/_organ)
 	if(specific_organ_subtype && !istype(_organ, specific_organ_subtype))
 		return FALSE
-	if(affects_robotics != !!(BP_IS_PROSTHETIC(organ)))
+	if(affects_robotics != !!(BP_IS_PROSTHETIC(_organ)))
 		return FALSE
 	if(length(applies_to_organ) && !(_organ?.organ_tag in applies_to_organ))
 		return FALSE

--- a/code/modules/organs/ailments/_ailment.dm
+++ b/code/modules/organs/ailments/_ailment.dm
@@ -96,7 +96,7 @@
 
 	if(istype(treatment, /obj/item/stack))
 		var/obj/item/stack/stack = treatment
-		stack.use(1)
+		stack.use(treated_by_item_cost)
 	qdel(src)
 
 /datum/ailment/proc/treated_by_medication(var/reagent_type, var/dosage)

--- a/code/modules/organs/ailments/faults/_fault.dm
+++ b/code/modules/organs/ailments/faults/_fault.dm
@@ -4,5 +4,5 @@
 	treated_by_item_type = /obj/item/stack/nanopaste
 	treated_by_item_cost = 3
 	third_person_treatment_message = "$USER$ patches $TARGET$'s faulty $ORGAN$ with $ITEM$."
-	self_treatment_message = "$USER$ patches $USER_HIS$'s faulty $ORGAN$ with $ITEM$."
+	self_treatment_message = "$USER$ patches $USER_HIS$ faulty $ORGAN$ with $ITEM$."
 	initial_ailment_message = "Damage to your $ORGAN$ has caused a fault..."


### PR DESCRIPTION
## Description of changes
- Fixes the self-treatment message for faults.
- Makes it so that prosthetic limbs can't get organic ailments, and *can* get prosthetic faults.
- Makes it so that `treated_by_item_cost` actually affects how many uses of a stack are consumed by treating an ailment.

## Why and what will this PR improve
Fixes #3294.