### PR TITLE
Fixes ID card object not being initialized due to mind.initial_account being set before the account is initialized

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -491,6 +491,8 @@ SUBSYSTEM_DEF(jobs)
 		job.apply_fingerprints(H)
 		spawn_in_storage = equip_custom_loadout(H, job)
 		job.setup_account(H)
+		var/decl/hierarchy/outfit/outfit = job.get_outfit(H, H.mind ? H.mind.role_alt_title : "", H.char_branch, H.char_rank)
+		outfit.equip_id(H, H.mind ? H.mind.role_alt_title : "", H.char_branch, H.char_rank)
 	else
 		to_chat(H, "Your job is [rank] and the game just can't handle it! Please report this bug to an administrator.")
 

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -77,14 +77,6 @@ var/global/list/outfits_decls_by_type_
 /decl/hierarchy/outfit/proc/equip(mob/living/carbon/human/H, var/rank, var/assignment, var/equip_adjustments)
 	equip_base(H, equip_adjustments)
 
-	rank = id_pda_assignment || rank
-	assignment = id_pda_assignment || assignment || rank
-	var/obj/item/card/id/W = equip_id(H, rank, assignment, equip_adjustments)
-	if(W)
-		rank = W.rank
-		assignment = W.assignment
-	equip_pda(H, rank, assignment, equip_adjustments)
-
 	for(var/path in backpack_contents)
 		var/number = backpack_contents[path]
 		for(var/i=0,i<number,i++)
@@ -92,9 +84,7 @@ var/global/list/outfits_decls_by_type_
 
 	if(!(OUTFIT_ADJUSTMENT_SKIP_POST_EQUIP & equip_adjustments))
 		post_equip(H)
-	H.update_icon()
-	if(W) // We set ID info last to ensure the ID photo is as correct as possible.
-		H.set_id_info(W)
+
 	return 1
 
 /decl/hierarchy/outfit/proc/equip_base(mob/living/carbon/human/H, var/equip_adjustments)
@@ -191,9 +181,12 @@ var/global/list/outfits_decls_by_type_
 		W.rank = rank
 	if(assignment)
 		W.assignment = assignment
+	H.update_icon()
 	H.set_id_info(W)
+	equip_pda(H, rank, assignment, equip_adjustments)
 	if(H.equip_to_slot_or_store_or_drop(W, id_slot))
 		return W
+
 
 /decl/hierarchy/outfit/proc/equip_pda(var/mob/living/carbon/human/H, var/rank, var/assignment, var/equip_adjustments)
 	if(!pda_slot || !pda_type)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Modified the order of functions called in equip_rank in code/controllers/subsystems/jobs.dm, and moved some code that got called in /decl/hierarchy/outfit/proc/equip in /code/datums/outfits/outfit.dm to equip_id later in that file in order to avoid conflicts from the order change.

Although it does function properly as far as I've been able to tell, there's no way this PR is at the moment considered a "clean" fix; please let me know what needs to be changed in order to be accepted.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This PR will allow functions that attempt to use the ID object to function properly (i.e. using ATMs via your ID card instead of your account number, obtaining cash from folding@home, etc).

## Authorship
<!-- Describe original authors of changes to credit them. -->

## Changelog
:cl:
bugfix: Fixed ID object initialization
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->