### PR TITLE
Minor jetpack consistency refactor.

### DIFF
--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -20,6 +20,7 @@
 	. = ..()
 	ion_trail = new /datum/effect/effect/system/trail/ion()
 	ion_trail.set_up(src)
+	refresh_ion_trail()
 
 /obj/item/tank/jetpack/Destroy()
 	QDEL_NULL(ion_trail)
@@ -46,15 +47,24 @@
 		overlay.icon_state = "[overlay.icon_state]-on"
 	. = ..()
 
+/obj/item/tank/jetpack/equipped(mob/user, slot)
+	. = ..()
+	refresh_ion_trail()
+
+/obj/item/tank/jetpack/proc/refresh_ion_trail()
+	if(on && isliving(loc))
+		var/mob/living/wearer = loc
+		if(wearer.get_jetpack() == src)
+			ion_trail.start()
+			return
+	ion_trail.stop()
+
 /obj/item/tank/jetpack/verb/toggle()
 	set name = "Toggle Jetpack"
 	set category = "Object"
 
 	on = !on
-	if(on)
-		ion_trail.start()
-	else
-		ion_trail.stop()
+	refresh_ion_trail()
 	update_icon()
 
 	if (ismob(usr))
@@ -104,4 +114,4 @@
 	name = "integrated manuvering module thrusterpack"
 	desc = "The 'manuvering' part of a manuvering jet module for a hardsuit. You could... probably use this standalone?"
 	var/obj/item/rig/holder
-	
+

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -73,15 +73,6 @@
 	. = ..()
 	. += species.strength
 
-/mob/living/carbon/human/Process_Spacemove(var/allow_movement)
-	var/obj/item/tank/jetpack/thrust = get_jetpack()
-
-	if(thrust && thrust.on && (allow_movement || thrust.stabilization_on) && thrust.allow_thrust(0.01, src))
-		return 1
-
-	. = ..()
-
-
 /mob/living/carbon/human/space_do_move(var/allow_move, var/direction)
 	if(allow_move == 1)
 		var/obj/item/tank/jetpack/thrust = get_jetpack()
@@ -96,15 +87,6 @@
 			return 0
 
 	. = ..()
-
-/mob/living/carbon/human/proc/get_jetpack()
-	if(back)
-		if(istype(back,/obj/item/tank/jetpack))
-			return back
-		else if(istype(back,/obj/item/rig))
-			var/obj/item/rig/rig = back
-			for(var/obj/item/rig_module/maneuvering_jets/module in rig.installed_modules)
-				return module.jets
 
 /mob/living/carbon/human/slip_chance(var/prob_slip = 5)
 	if(!..())

--- a/code/modules/mob/living/inventory.dm
+++ b/code/modules/mob/living/inventory.dm
@@ -107,3 +107,13 @@
 				break
 		if(.)
 			update_inv_hands()
+
+/mob/living/proc/get_jetpack()
+	var/obj/item/tank/jetpack/thrust = get_equipped_item(slot_back_str)
+	if(istype(thrust))
+		return thrust
+	if(istype(thrust, /obj/item/rig))
+		var/obj/item/rig/rig = thrust
+		for(var/obj/item/rig_module/maneuvering_jets/module in rig.installed_modules)
+			return module.jets
+	return null

--- a/code/modules/mob/living/silicon/robot/modules/module_illegal.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_illegal.dm
@@ -27,8 +27,7 @@
 	equipment += id
 
 /obj/item/robot_module/syndicate/finalize_equipment(var/mob/living/silicon/robot/R)
-	var/obj/item/tank/jetpack/carbondioxide/jetpack = locate() in equipment
-	R.internals = jetpack
+	R.internals = locate(/obj/item/tank/jetpack/carbondioxide) in equipment
 	. = ..()
 
 /obj/item/robot_module/syndicate/Destroy()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -427,18 +427,10 @@
 // this function displays jetpack pressure in the stat panel
 /mob/living/silicon/robot/proc/show_jetpack_pressure()
 	// if you have a jetpack, show the internal tank pressure
-	var/obj/item/tank/jetpack/current_jetpack = installed_jetpack()
+	var/obj/item/tank/jetpack/current_jetpack = get_jetpack()
 	if (current_jetpack)
 		stat("Internal Atmosphere Info", current_jetpack.name)
 		stat("Tank Pressure", current_jetpack.air_contents.return_pressure())
-
-
-// this function returns the robots jetpack, if one is installed
-/mob/living/silicon/robot/proc/installed_jetpack()
-	if(module)
-		return (locate(/obj/item/tank/jetpack) in module.equipment)
-	return 0
-
 
 // this function displays the cyborgs current cell charge in the stat panel
 /mob/living/silicon/robot/proc/show_cell_power()

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -8,13 +8,8 @@
 		return 1
 	return 0
 
-/mob/living/silicon/robot/Process_Spacemove()
-	if(module)
-		for(var/obj/item/tank/jetpack/J in module.equipment)
-			if(J && J.allow_thrust(0.01))
-				return 1
-	. = ..()
-
+/mob/living/silicon/robot/get_jetpack()
+	return locate(/obj/item/tank/jetpack) in module?.equipment
 
 /mob/living/silicon/robot/Move()
 	. = ..()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -163,6 +163,12 @@
 			return backup
 		return -1
 
+/mob/living/Process_Spacemove(allow_movement)
+	var/obj/item/tank/jetpack/thrust = get_jetpack()
+	if(thrust?.on && (allow_movement || thrust.stabilization_on) && thrust.allow_thrust(0.01, src))
+		return TRUE
+	return ..()
+
 /mob/proc/space_do_move(var/allow_move, var/direction)
 	if(ismovable(allow_move))//push off things in space
 		handle_space_pushoff(allow_move, direction)


### PR DESCRIPTION
## Description of changes
- `get_jetpack()` generalized to `/mob/living`.
- Jetpack-assisted spacemove generalized to `/mob/living`.
- Jetpack will only show ion trail when function as a jetpack (ie. not when in suit storage).

## Why and what will this PR improve
Less confusing jetpack interactions, cleaner code.

## Authorship
Myself.

## Changelog
:cl:
tweak: Jetpacks will no longer show ion trails except when they are actually functioning as jetpacks.
/:cl:
