### PR TITLE
Chewable and smokable items now have no bodytype flag requirements.

### DIFF
--- a/code/modules/clothing/masks/chewable.dm
+++ b/code/modules/clothing/masks/chewable.dm
@@ -3,6 +3,7 @@
 	desc = "You're not sure what this is. You should probably ahelp it."
 	icon = 'icons/clothing/mask/chewables/lollipop.dmi'
 	body_parts_covered = 0
+	bodytype_equip_flags = null
 
 	var/type_butt = null
 	var/chem_volume = 0

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -3,7 +3,9 @@
 	desc = "You're not sure what this is. You should probably ahelp it."
 	icon = 'icons/clothing/mask/smokables/cigarette.dmi'
 	body_parts_covered = 0
+	bodytype_equip_flags = null
 	z_flags = ZMM_MANGLE_PLANES
+
 	var/lit = 0
 	var/waterproof = FALSE
 	var/type_butt = null


### PR DESCRIPTION
See title. No reason to restrict these, they are meant to be consumables.