### PR TITLE
Fixes dispenser refilling

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -102,7 +102,7 @@
 		return ..()
 
 /obj/item/chems/proc/standard_dispenser_refill(var/mob/user, var/obj/structure/reagent_dispensers/target) // This goes into afterattack
-	if(!istype(target))
+	if(!istype(target) || target.atom_flags & ATOM_FLAG_OPEN_CONTAINER)
 		return 0
 
 	if(!target.reagents || !target.reagents.total_volume)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -102,7 +102,7 @@
 		return ..()
 
 /obj/item/chems/proc/standard_dispenser_refill(var/mob/user, var/obj/structure/reagent_dispensers/target) // This goes into afterattack
-	if(!istype(target) || target.atom_flags & ATOM_FLAG_OPEN_CONTAINER)
+	if(!istype(target) || (target.atom_flags & ATOM_FLAG_OPEN_CONTAINER))
 		return 0
 
 	if(!target.reagents || !target.reagents.total_volume)


### PR DESCRIPTION
## Description of changes
Fixes refilling chemical dispensers (water tanks, sulphuric acid dispensers etc.) by returning FALSE to the dispenser refill proc if the refilling cap is open.
## Changelog
:cl:
bugfix: Fixed water tanks being unable to be refilled
/:cl:
