### PR TITLE
Automatic grab upgrade now only applies when grabbing on harm intent.

### DIFF
--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -72,7 +72,7 @@
 		else
 			visible_message(SPAN_NOTICE("\The [assailant] has grabbed [G.self]!"))
 
-	if(affecting_mob && affecting_mob.a_intent != I_HELP)
+	if(affecting_mob && assailant?.a_intent == I_HURT)
 		upgrade(TRUE)
 
 /obj/item/grab/examine(mob/user)


### PR DESCRIPTION
## Description of changes
Swaps logic on automatic grab upgrade to check assailant's intent is on harm instead of subject's intent is not on help.

## Why and what will this PR improve
Prevents automatically trying to go to an aggressive grab on any mob you grab.
Fixes #3222.

## Authorship
Myself.

## Changelog
:cl:
tweak: Ctrl-click grabbing on harm intent will automatically try to upgrade to an aggressive grab. 
/:cl:
