### PR TITLE
Hide underwear selection for species without it

### DIFF
--- a/code/modules/client/preference_setup/general/04_equipment.dm
+++ b/code/modules/client/preference_setup/general/04_equipment.dm
@@ -113,16 +113,18 @@
 /datum/category_item/player_setup_item/physical/equipment/content()
 	. = list()
 	. += "<b>Equipment:</b><br>"
-	for(var/datum/category_group/underwear/UWC in global.underwear.categories)
-		var/item_name = (pref.all_underwear && pref.all_underwear[UWC.name]) ? pref.all_underwear[UWC.name] : "None"
-		. += "[UWC.name]: <a href='?src=\ref[src];change_underwear=[UWC.name]'><b>[item_name]</b></a>"
+	var/decl/species/mob_species = get_species_by_key(pref.species)
+	if(mob_species?.appearance_flags & HAS_UNDERWEAR)
+		for(var/datum/category_group/underwear/UWC in global.underwear.categories)
+			var/item_name = (pref.all_underwear && pref.all_underwear[UWC.name]) ? pref.all_underwear[UWC.name] : "None"
+			. += "[UWC.name]: <a href='?src=\ref[src];change_underwear=[UWC.name]'><b>[item_name]</b></a>"
 
-		var/datum/category_item/underwear/UWI = UWC.items_by_name[item_name]
-		if(UWI)
-			for(var/datum/gear_tweak/gt in UWI.tweaks)
-				. += " <a href='?src=\ref[src];underwear=[UWC.name];tweak=\ref[gt]'>[gt.get_contents(get_underwear_metadata(UWC.name, gt))]</a>"
+			var/datum/category_item/underwear/UWI = UWC.items_by_name[item_name]
+			if(UWI)
+				for(var/datum/gear_tweak/gt in UWI.tweaks)
+					. += " <a href='?src=\ref[src];underwear=[UWC.name];tweak=\ref[gt]'>[gt.get_contents(get_underwear_metadata(UWC.name, gt))]</a>"
 
-		. += "<br>"
+			. += "<br>"
 	. += "<b>Backpack type:</b> <a href='?src=\ref[src];change_backpack=1'><b>[pref.backpack.name]</b></a>"
 	for(var/datum/backpack_tweak/bt in pref.backpack.tweaks)
 		. += " <a href='?src=\ref[src];backpack=[pref.backpack.name];tweak=\ref[bt]'>[bt.get_ui_content(get_backpack_metadata(pref.backpack, bt))]</a>"


### PR DESCRIPTION
## Description of changes
Hides underwear selection if the currently selected species can't wear it.

## Why and what will this PR improve
It felt odd to have a selection there that did nothing, when other things forbidden by missing appearance flags (i.e. hair, eye, and skin color) are hidden.