### PR TITLE
Fix material archaeological find spawn

### DIFF
--- a/code/modules/xenoarcheaology/finds/find_types/material.dm
+++ b/code/modules/xenoarcheaology/finds/find_types/material.dm
@@ -5,7 +5,7 @@
 	var/list/possible_materials = list(/decl/material/solid/metal/steel, /decl/material/solid/metal/plasteel, /decl/material/solid/metal/titanium, /decl/material/solid/glass)
 
 /decl/archaeological_find/material/spawn_item(atom/loc)
-	return SSmaterials.create_object(pick(possible_materials), loc, rand(5,45))
+	return SSmaterials.create_object(pick(possible_materials), loc, rand(5,45))?[1]
 
 /decl/archaeological_find/material/exotic
 	item_type = "rare material lump"
@@ -14,7 +14,7 @@
 //Machinery parts
 /decl/archaeological_find/parts
 	item_type = "machinery part"
-	modification_flags = XENOFIND_APPLY_PREFIX 
+	modification_flags = XENOFIND_APPLY_PREFIX
 	responsive_reagent = /decl/material/solid/potassium
 	possible_types = list()
 


### PR DESCRIPTION
## Description of changes
Return and modify only the first material item in the created objects list.

## Why and what will this PR improve
Stops a runtime and makes the modifications actually apply to created material stacks. Should probably be made to handle lists via a recursive call or something, but that would require changing the return values of all of the procs that call it, which is a bit of a headache.