### PR TITLE
Fix omni filter runtime

### DIFF
--- a/code/datums/repositories/decls.dm
+++ b/code/datums/repositories/decls.dm
@@ -37,7 +37,11 @@ var/global/repository/decls/decls_repository = new
 			fetched_decl_ids[decl_uid] = decl
 
 /repository/decls/proc/get_decl_by_id(var/decl_id)
+	RETURN_TYPE(/decl)
 	. = get_decl(fetched_decl_ids[decl_id])
+
+/repository/decls/proc/get_decl_path_by_id(decl_id)
+	. = fetched_decl_ids[decl_id]
 
 /repository/decls/proc/get_decl(var/decl/decl_type)
 	ASSERT(ispath(decl_type, /decl))

--- a/code/modules/atmospherics/components/omni_devices/omni_base.dm
+++ b/code/modules/atmospherics/components/omni_devices/omni_base.dm
@@ -53,7 +53,7 @@
 				if(new_port.mode == ATM_FILTER && tag_filter_gas_north)
 					if(!istext(tag_filter_gas_north))
 						CRASH("The tag_filter_gas_north var of [src] ([x],[y],[z]) was not set to a material uid string! Got : '[tag_filter_gas_north]'.")
-					new_port.filtering = decls_repository.get_decl_by_id(tag_filter_gas_north)
+					new_port.filtering = decls_repository.get_decl_path_by_id(tag_filter_gas_north)
 				if(tag_north >= 3 && tag_north < 8)
 					new_port.filtering = handle_legacy_gas_filtering(tag_north)
 					new_port.mode = ATM_FILTER
@@ -62,7 +62,7 @@
 				if(new_port.mode == ATM_FILTER && tag_filter_gas_south)
 					if(!istext(tag_filter_gas_south))
 						CRASH("The tag_filter_gas_south var of [src] ([x],[y],[z]) was not set to a material uid string! Got : '[tag_filter_gas_south]'.")
-					new_port.filtering = decls_repository.get_decl_by_id(tag_filter_gas_south)
+					new_port.filtering = decls_repository.get_decl_path_by_id(tag_filter_gas_south)
 				if(tag_south >= 3 && tag_south < 8)
 					new_port.filtering = handle_legacy_gas_filtering(tag_south)
 					new_port.mode = ATM_FILTER
@@ -71,7 +71,7 @@
 				if(new_port.mode == ATM_FILTER && tag_filter_gas_east)
 					if(!istext(tag_filter_gas_east))
 						CRASH("The tag_filter_gas_east var of [src] ([x],[y],[z]) was not set to a material uid string! Got : '[tag_filter_gas_east]'.")
-					new_port.filtering = decls_repository.get_decl_by_id(tag_filter_gas_east)
+					new_port.filtering = decls_repository.get_decl_path_by_id(tag_filter_gas_east)
 				if(tag_east >= 3 && tag_east < 8)
 					new_port.filtering = handle_legacy_gas_filtering(tag_east)
 					new_port.mode = ATM_FILTER
@@ -80,7 +80,7 @@
 				if(new_port.mode == ATM_FILTER && tag_filter_gas_west)
 					if(!istext(tag_filter_gas_west))
 						CRASH("The tag_filter_gas_west var of [src] ([x],[y],[z]) was not set to a material uid string! Got : '[tag_filter_gas_west]'.")
-					new_port.filtering = decls_repository.get_decl_by_id(tag_filter_gas_west)
+					new_port.filtering = decls_repository.get_decl_path_by_id(tag_filter_gas_west)
 				if(tag_west >= 3 && tag_west < 8)
 					new_port.filtering = handle_legacy_gas_filtering(tag_west)
 					new_port.mode = ATM_FILTER


### PR DESCRIPTION
## Description of changes
`/datum/omni_port/var/filtering` is always a path rather than an instance.

## Why and what will this PR improve
Fixes omni filters causing runtimes from `filtering` sometimes being an instance and sometimes being a type.