### PR TITLE
Fix non-directional terminal icon loc check

### DIFF
--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -36,7 +36,7 @@
 			to_chat(user, SPAN_WARNING("You must remove the floor plating in front of \the [machine] first!"))
 			return
 
-		 // If this is a terminal that's somehow been left behind, let it be removed freely. 
+		 // If this is a terminal that's somehow been left behind, let it be removed freely.
 		if(machine && !machine.components_are_accessible(/obj/item/stock_parts/power/terminal))
 			to_chat(user, SPAN_WARNING("You must open the panel on \the [machine] first!"))
 			return
@@ -88,9 +88,9 @@
 	. = ..()
 	if(master)
 		var/obj/machinery/machine = master_machine()
-		
+
 		// Wall frames and SMES have directional terminals.
-		if(!master.terminal_dir && !ispath(machine.frame_type, /obj/item/frame) && master.loc == loc)
+		if(!master.terminal_dir && !ispath(machine.frame_type, /obj/item/frame) && machine.loc == loc)
 			icon_state = "term-omni"
 		else
 			icon_state = "term"


### PR DESCRIPTION
## Description of changes
Replaces `master.loc` with `machine.loc` in the omni-terminal icon-state check.

## Why and what will this PR improve
Fixes the omni-terminal icon (non-directional terminal) from never being used.