### PR TITLE
Fix ships being stuck at max speed

### DIFF
--- a/code/__defines/overmap.dm
+++ b/code/__defines/overmap.dm
@@ -18,13 +18,14 @@
 #define KM_OVERMAP_RATE		100
 #define SHIP_MOVE_RESOLUTION 0.001
 #define MOVING(speed, min_speed) (abs(speed) >= min_speed)
-#define SANITIZE_SPEED(speed) (SIGN(speed) * clamp(abs(speed), 0, max_speed))
+// You can approach, but never reach, max_speed.
+#define SANITIZE_SPEED(speed) (SIGN(speed) * clamp(NONUNIT_FLOOR(abs(speed), SHIP_MOVE_RESOLUTION), 0, max_speed - SHIP_MOVE_RESOLUTION))
 #define CHANGE_SPEED_BY(speed_var, v_diff, min_speed) \
 	v_diff = SANITIZE_SPEED(v_diff);\
 	if(!MOVING(speed_var + v_diff, min_speed)) \
 		{speed_var = 0};\
 	else \
-		{speed_var = round(SANITIZE_SPEED((speed_var + v_diff) / (1 + speed_var * v_diff / (max_speed ** 2))), SHIP_MOVE_RESOLUTION)}
+		{speed_var = SANITIZE_SPEED((speed_var + v_diff) / (1 + speed_var * v_diff / (max_speed ** 2)))}
 // Uses Lorentzian dynamics to avoid going too fast.
 #define SENSOR_COEFFICENT 1000
 


### PR DESCRIPTION
## Description of changes
Removes rounding from `CHANGE_SPEED_BY` that sometimes allowed ships to reach their max speed, which is forbidden.
`SANITIZE_SPEED` now clamps between 0 and `max_speed - SHIP_MOVE_RESOLUTION` so that there's no way to ever reach max speed now anyway.

## Why and what will this PR improve
Ships that somehow attained exactly their max speed, due to rounding, would never be able to decelerate below it. This fixes that.