### PR TITLE
Fix immediately leaving recharge stations

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -177,7 +177,7 @@
 	overlays = list(image(overlay_icon, overlay_state()))
 
 /obj/machinery/recharge_station/Bumped(var/mob/living/silicon/robot/R)
-	go_in(R)
+	addtimer(CALLBACK(src, .proc/go_in, R), 1)
 
 /obj/machinery/recharge_station/proc/go_in(var/mob/M)
 


### PR DESCRIPTION
## Description of changes
Adds a 1-tick timer when entering recharge stations via Bumped() so that the keypress can be unregistered and the mob won't immediately exit.
This is a side-effect of porting SSInput, I think, so Bay shouldn't have this issue.

## Why and what will this PR improve
Prevents mobs from immediately exiting recharge stations the same tick they enter them.