### PR TITLE
Fix bodyscan printout not having contents

### DIFF
--- a/code/game/machinery/bodyscanner_console.dm
+++ b/code/game/machinery/bodyscanner_console.dm
@@ -107,7 +107,7 @@
 			to_chat(user, "[html_icon(src)]<span class='warning'>Error: No scan stored.</span>")
 			return TOPIC_REFRESH
 		var/list/scan = data["scan"]
-		new /obj/item/paper/bodyscan(loc, "Printout error.", "Body scan report - [stored_scan_subject]", scan.Copy())
+		new /obj/item/paper/bodyscan(loc, null, "Printout error.", "Body scan report - [stored_scan_subject]", scan.Copy())
 		return TOPIC_REFRESH
 
 	if(href_list["push"])


### PR DESCRIPTION
## Description of changes
Adds a null `material_key` argument to the bodyscan printout's `new()` args to avoid an off-by-one error.

## Why and what will this PR improve
Bodyscan printouts will now have their correct title and contents.