### PR TITLE
Mark beach turfs as background

### DIFF
--- a/code/game/turfs/unsimulated/beach.dm
+++ b/code/game/turfs/unsimulated/beach.dm
@@ -1,6 +1,7 @@
 /turf/unsimulated/beach
 	name = "Beach"
 	icon = 'icons/misc/beach.dmi'
+	turf_flags = TURF_FLAG_BACKGROUND
 
 /turf/unsimulated/beach/sand
 	name = "Sand"
@@ -14,7 +15,7 @@
 /turf/unsimulated/beach/water
 	name = "Water"
 	icon_state = "water"
-	turf_flags = TURF_IS_WET | TURF_IS_HOLOMAP_PATH
+	turf_flags = TURF_FLAG_BACKGROUND | TURF_IS_WET | TURF_IS_HOLOMAP_PATH
 
 /turf/unsimulated/beach/water/Initialize(var/ml)
 	. = ..()


### PR DESCRIPTION
## Description of changes
Adds the background turf flag to beach turfs.

## Why and what will this PR improve
After landing on Mobius Rift, you'll no longer take the sand turfs with you.