### PR TITLE
Fix medical ailment codex entries

### DIFF
--- a/code/modules/organs/ailments/ailment_codex.dm
+++ b/code/modules/organs/ailments/ailment_codex.dm
@@ -16,6 +16,26 @@
 	name_column = "Fault"
 	treatment_column = "Recommended repair"
 
+/proc/get_chem_effect_display_name(effect)
+	switch(effect)
+		if(CE_PAINKILLER)
+			return "painkillers"
+		if(CE_ANTIBIOTIC)
+			return "antibiotics"
+		if(CE_ALCOHOL)
+			return "alcohol"
+		if(CE_ALCOHOL_TOXIC)
+			return "alcohol overdose"
+		if(CE_ANTITOX)
+			return "antitoxins"
+		if(CE_TOXIN)
+			return "toxins"
+		if(CE_SEDATE)
+			return "sedative drugs"
+		if(CE_ENERGETIC)
+			return "stimulant drugs"
+	return null
+
 /datum/codex_entry/ailments/New()
 	var/list/ailment_table = list("<table border = 1px>")
 	ailment_table += "<tr><td><b>[name_column]</b></td><td><b>[treatment_column]</b></td></tr>"
@@ -31,6 +51,8 @@
 		if(ailment.treated_by_reagent_type)
 			var/decl/material/mat = GET_DECL(ailment.treated_by_reagent_type)
 			ailment_cures += "[ailment.treated_by_reagent_dosage]u [mat.name]"
+		if(ailment.treated_by_chem_effect)
+			ailment_cures += get_chem_effect_display_name(ailment.treated_by_chem_effect)
 		if(!length(ailment_cures))
 			ailment_cures += "Unknown."
 		ailment_table += "[jointext(ailment_cures,"<br>")]</td></tr>"


### PR DESCRIPTION
## Description of changes
Adds handling for `ailment.treated_by_chem_effect` in the autogenerated ailment codex entries.

## Why and what will this PR improve
Before: 
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/e37fc55e-63e2-45d3-bc46-732419fce5f8)
After:
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/9697ea59-ac80-4846-8630-6b545331e337)