### PR TITLE
Fix double door dir detection

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -297,9 +297,9 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/on_update_icon(state=0, override=0)
 
 	if(set_dir_on_update)
-		if(connections & (NORTH|SOUTH))
+		if(connections & (NORTH|SOUTH) == (NORTH|SOUTH))
 			set_dir(EAST)
-		else
+		else if (connections & (EAST|WEST) == (EAST|WEST))
 			set_dir(SOUTH)
 
 	switch(state)

--- a/code/game/machinery/doors/double.dm
+++ b/code/game/machinery/doors/double.dm
@@ -19,7 +19,6 @@
 	appearance_flags = 0
 	opacity = TRUE
 	width = 2
-	set_dir_on_update = FALSE
 
 /obj/machinery/door/airlock/double/update_connections(var/propagate = 0)
 	var/dirs = 0


### PR DESCRIPTION
## Description of changes
Readds `set_dir_on_update` to double airlocks and makes `set_dir_on_update` a bit more picky to avoid cases where double airlocks being 2x2 causes them to face the wrong way.

## Why and what will this PR improve
Fixes several reported issues about doors facing the wrong way. Prevents double doors from facing invalid directions (NORTH and WEST).