### PR TITLE
Fix map template centering and WORLD_CENTER_TURF calculation

### DIFF
--- a/code/__defines/turfs.dm
+++ b/code/__defines/turfs.dm
@@ -23,9 +23,9 @@
 
 //Here are a few macros to help with people always forgetting to round the coordinates somewhere, and forgetting that not everything automatically rounds decimals.
 ///Helper macro for the x coordinate of the turf at the center of the world. Handles rounding.
-#define WORLD_CENTER_X round(world.maxx / 2)
+#define WORLD_CENTER_X CEILING((1 + world.maxx) / 2)
 ///Helper macro for the y coordinate of the turf at the center of the world. Handles rounding.
-#define WORLD_CENTER_Y round(world.maxy / 2)
+#define WORLD_CENTER_Y CEILING((1 + world.maxy) / 2)
 ///Helper macro for getting the center turf on a given z-level. Handles rounding.
 #define WORLD_CENTER_TURF(Z) locate(WORLD_CENTER_X, WORLD_CENTER_Y, Z)
 ///Helper macro to check if a position is within the world's bounds.

--- a/code/modules/maps/_map_template.dm
+++ b/code/modules/maps/_map_template.dm
@@ -151,8 +151,8 @@
 /// * If centered is TRUE, the template's center will be aligned to the world's center. Otherwise, the template will load at pos 1,1.
 /datum/map_template/proc/load_new_z(no_changeturf = TRUE, centered = TRUE)
 	//When we're set to centered we're aligning the center of the template to the center of the map
-	var/x = max(round((world.maxx - width)  / 2), 1)
-	var/y = max(round((world.maxy - height) / 2), 1)
+	var/x = max(CEILING((WORLD_CENTER_X - width/2)), 1)
+	var/y = max(CEILING((WORLD_CENTER_Y - height/2)), 1)
 	if(!centered)
 		x = 1
 		y = 1
@@ -192,10 +192,10 @@
 
 /datum/map_template/proc/load(turf/T, centered=FALSE)
 	if(centered)
-		T = locate(T.x - (round(width/2) - 1), T.y - (round(height/2) - 1), T.z)
+		T = locate(CEILING(T.x - width/2), CEILING(T.y - height/2), T.z)
 	if(!T)
 		CRASH("Can't load '[src]' (size: [width]x[height]) onto a null turf! Current world size ([WORLD_SIZE_TO_STRING]).")
-	if(!IS_WITHIN_WORLD((T.x + (width - 1)), (T.y + (height - 1))))
+	if(!IS_WITHIN_WORLD((T.x + width - 1), (T.y + height - 1))) // the first row/column begins with T, so subtract 1
 		CRASH("Couldn't fit the entire template '[src]' (size: [width]x[height]) between lower left corner ([T.x], [T.y])[centered?"(WORLD CENTER)":""] and upper right corner ([T.x + width], [T.y + height]) in current world size ([WORLD_SIZE_TO_STRING]).")
 
 	var/list/atoms_to_initialise = list()


### PR DESCRIPTION
## Description of changes
Fixes incorrect rounding/offsets in map template centering and WORLD_CENTER_TURF calculation.

## Why and what will this PR improve
Crashed data pod template on current staging:
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/f44911cf-404e-46a7-bdde-34f7de5f517d)
After these changes:
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/4a09f168-0569-43cc-b7cf-04c97e2e1cd4)