### PR TITLE
Add support for compiled-in map template load landmarks

### DIFF
--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -53,6 +53,8 @@ SUBSYSTEM_DEF(mapping)
 	var/list/planetoid_data_by_id
 	///List of all z-levels in the world where the index corresponds to a z-level, and the key at that index is the planetoid_data datum for the associated planet
 	var/list/planetoid_data_by_z = list()
+	///A list of queued markers to initialize during SSmapping init.
+	var/list/obj/abstract/landmark/map_load_mark/queued_markers = list()
 
 /datum/controller/subsystem/mapping/PreInit()
 	reindex_lists()
@@ -114,6 +116,10 @@ SUBSYSTEM_DEF(mapping)
 		world.maxx = new_maxx
 	if (new_maxy > world.maxy)
 		world.maxy = new_maxy
+
+	for(var/obj/abstract/landmark/map_load_mark/mark in queued_markers)
+		mark.load_subtemplate()
+	queued_markers.Cut()
 
 	. = ..()
 

--- a/code/modules/maps/helper_landmarks.dm
+++ b/code/modules/maps/helper_landmarks.dm
@@ -1,15 +1,20 @@
 //Load a random map template from the list. Maploader handles it to avoid order of init madness
 /obj/abstract/landmark/map_load_mark
 	name = "map loader landmark"
+	var/centered = TRUE
 	var/list/map_template_names	//list of template names to pick from
 
-/obj/abstract/landmark/map_load_mark/Initialize(var/mapload)
-	. = ..()
-	if(!mapload)
-		return INITIALIZE_HINT_LATELOAD
-
-/obj/abstract/landmark/map_load_mark/LateInitialize()
-	load_subtemplate()
+/obj/abstract/landmark/map_load_mark/New(loc)
+	..()
+	if(Master.map_loading) // If we're created while a map is being loaded
+		return // Let after_load() handle us
+	if(!SSmapping.initialized) // If we're being created prior to SSmapping
+		SSmapping.queued_markers += src // Then run after SSmapping
+	else
+		// How did we get here?
+		// These should only be loaded from compiled maps or map templates.
+		PRINT_STACK_TRACE("map_load_mark created outside of maploading")
+		load_subtemplate()
 
 /obj/abstract/landmark/map_load_mark/proc/get_subtemplate()
 	. = LAZYLEN(map_template_names) && pick(map_template_names)
@@ -29,7 +34,7 @@
 		if(istext(template))
 			template = SSmapping.get_template(template)
 		if(istype(template))
-			template.load(spawn_loc, TRUE)
+			template.load(spawn_loc, centered = centered)
 
 //Throw things in the area around randomly
 /obj/abstract/landmark/carnage_mark

--- a/code/modules/multiz/map_data.dm
+++ b/code/modules/multiz/map_data.dm
@@ -19,8 +19,8 @@
 
 // If the height is more than 1, we mark all contained levels as connected.
 // This is in New because it is an auxiliary effect specifically needed pre-init.
-/obj/abstract/map_data/New(turf/loc, _height)
-	..()
+INITIALIZE_IMMEDIATE(/obj/abstract/map_data)
+/obj/abstract/map_data/Initialize(mapload, _height)
 	if(!istype(loc)) // Using loc.z is safer when using the maploader and New.
 		return
 	if(_height)
@@ -32,6 +32,7 @@
 
 	if (length(SSzcopy.zlev_maximums))
 		SSzcopy.calculate_zstack_limits()
+	return ..()
 
 /obj/abstract/map_data/Destroy(forced)
 	if(forced)


### PR DESCRIPTION
## Description of changes
/obj/abstract/map_data now uses INITIALIZE_IMMEDIATE, since there's no reason for it not to.
Map template load landmarks will work when compiled in.
Map template load landmarks can disable loading their templates centered on their loc (centering is on by default).

The map load landmark doesn't use INITIALIZE_IMMEDIATE because running it in Initialize will break things.

## Why and what will this PR improve
Adds support for compiled-in map template load landmarks.
Adds support for map template load landmarks that aren't centered.
Makes /obj/abstract/map_data use INITIALIZE_IMMEDIATE to free up a `/New` override so I don't have to change the number of those in CI.