### PR TITLE
Allow ailments to be hidden from the codex, add ailment getter/haver helpers.

### DIFF
--- a/code/modules/organs/ailments/_ailment.dm
+++ b/code/modules/organs/ailments/_ailment.dm
@@ -28,6 +28,8 @@
 	var/manual_diagnosis_string  /* ex: "$USER_HIS$ $ORGAN$ has something wrong with it" */ // Shown when grab-diagnosed by a doctor. Leave null to be undiagnosable.
 	var/scanner_diagnosis_string /* ex: "Significant swelling" */                           // Shown on the handheld and body scanners. Leave null to be undiagnosable.
 
+	var/hidden_from_codex = FALSE
+
 /datum/ailment/New(var/obj/item/organ/_organ)
 	..()
 	if(_organ)

--- a/code/modules/organs/ailments/ailment_codex.dm
+++ b/code/modules/organs/ailments/ailment_codex.dm
@@ -21,7 +21,7 @@
 	ailment_table += "<tr><td><b>[name_column]</b></td><td><b>[treatment_column]</b></td></tr>"
 	for(var/atype in subtypesof(/datum/ailment))
 		var/datum/ailment/ailment = get_ailment_reference(atype)
-		if(!ailment.name || show_robotics_recipes != ailment.affects_robotics)
+		if(!ailment.name || show_robotics_recipes != ailment.affects_robotics || ailment.hidden_from_codex)
 			continue
 		ailment_table += "<tr><td>[ailment.name]</td><td>"
 		var/list/ailment_cures = list()

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -516,6 +516,15 @@ var/global/list/ailment_reference_cache = list()
 		else if(ailment.scanner_diagnosis_string && scanner)
 			LAZYADD(., ailment.replace_tokens(message = ailment.scanner_diagnosis_string, user = user))
 
+/obj/item/organ/proc/get_ailment_of_type(ailment_type)
+	for(var/datum/ailment/ext_ailment in ailments)
+		if(ailment_type == ext_ailment.type)
+			return ext_ailment
+	return null
+
+/obj/item/organ/proc/has_ailment_of_type(ailment_type)
+	return !!get_ailment_of_type(ailment_type)
+
 //Handles only the installation of the organ, without triggering any callbacks.
 //if we're an internal organ, having a null "target" is legal if we have an "affected"
 //CASES:


### PR DESCRIPTION
## Description of changes
- Adds `hidden_from_codex` var to ailments (mostly useful for removing redundant entries, for example downstream I wanted to create a subtype of headache that could affect a certain synthetic species but was otherwise the exact same).
- Adds `get_ailment_of_type()` and `has_ailment_of_type()` helpers to organs.

## Why and what will this PR improve
General utility stuff for working with ailments.