### PR TITLE
Move test exceptions to leveldata/map datum

### DIFF
--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -144,6 +144,8 @@
 	///This is set to prevent spamming the log when a turf has tried to grab our strata before we've been initialized
 	var/tmp/_has_warned_uninitialized_strata = FALSE
 
+	VAR_PROTECTED/UT_turf_exceptions_by_door_type // An associate list of door types/list of allowed turfs
+
 /datum/level_data/New(var/_z_level, var/defer_level_setup = FALSE)
 	. = ..()
 	level_z = _z_level

--- a/code/modules/multiz/map_data.dm
+++ b/code/modules/multiz/map_data.dm
@@ -6,17 +6,6 @@
 	var/height = 1     ///< The number of Z-Levels in the map.
 	var/turf/edge_type ///< What the map edge should be formed with. (null = world.turf)
 
-	VAR_PROTECTED/UT_turf_exceptions_by_door_type // An associate list of door types/list of allowed turfs
-
-#ifdef UNIT_TEST
-// Do not use this in production; for unit tests ONLY.
-/obj/abstract/map_data/proc/get_UT_turf_exceptions_by_door_type()
-	return UT_turf_exceptions_by_door_type
-#else
-/obj/abstract/map_data/proc/get_UT_turf_exceptions_by_door_type()
-	CRASH("map_data.get_UT_turf_exceptions_by_door_type() called in production code!")
-#endif
-
 // If the height is more than 1, we mark all contained levels as connected.
 // This is in New because it is an auxiliary effect specifically needed pre-init.
 /obj/abstract/map_data/New(turf/loc, _height)

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -823,7 +823,7 @@
 /datum/unit_test/doors_shall_be_on_appropriate_turfs
 	name = "MAP: Doors shall be on appropriate turfs"
 
-/obj/abstract/map_data/proc/get_door_turf_exceptions(var/obj/machinery/door/D)
+/datum/level_data/proc/get_door_turf_exceptions(var/obj/machinery/door/D)
 	return LAZYACCESS(UT_turf_exceptions_by_door_type, D.type)
 
 /datum/unit_test/doors_shall_be_on_appropriate_turfs/start_test()
@@ -835,8 +835,8 @@
 			bad_doors++
 			log_bad("Invalid door turf: [log_info_line(D.loc)]")
 		else
-			var/obj/abstract/map_data/MD = get_map_data(D.loc.z)
-			var/list/turf_exceptions = MD?.get_door_turf_exceptions(D)
+			var/datum/level_data/level_data = SSmapping.levels_by_z[D.loc.z]
+			var/list/turf_exceptions = level_data?.get_door_turf_exceptions(D)
 
 			var/is_bad_door = FALSE
 			for(var/turf/T in D.locs)

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -595,6 +595,8 @@
 /datum/unit_test/station_wires_shall_be_connected/start_test()
 	var/failures = 0
 
+	exceptions = global.using_map.disconnected_wires_test_exempt_turfs
+
 	var/exceptions_by_turf = list()
 	for(var/exception in exceptions)
 		var/turf/T = locate(exception[1], exception[2], exception[3])

--- a/maps/tradeship/tradeship_unit_testing.dm
+++ b/maps/tradeship/tradeship_unit_testing.dm
@@ -1,7 +1,5 @@
-/datum/unit_test/station_wires_shall_be_connected
-	exceptions = list(list(48, 54, 3, EAST))
-
 /datum/map/tradeship
+	disconnected_wires_test_exempt_turfs = list(list(48, 54, 3, EAST))
 	// Unit test exemptions
 	apc_test_exempt_areas = list(
 		/area/turbolift =                               NO_SCRUBBER|NO_VENT|NO_APC,

--- a/maps/~mapsystem/maps_unit_testing.dm
+++ b/maps/~mapsystem/maps_unit_testing.dm
@@ -37,3 +37,6 @@
 	)
 
 	var/list/area_purity_test_exempt_areas = list()
+
+	/// A list of lists, of the format ((x, y, z, dir),).
+	var/list/disconnected_wires_test_exempt_turfs = list()


### PR DESCRIPTION
## Description of changes
- Moves door test exceptions from mapdata to leveldata.
- Moves wire connection test exceptions from a var on the unit test to the map datum.
## Why and what will this PR improve
- Mapdata doesn't apply to the Z-level it's actually on, meaning the topmost level in a z-stack will never have its exceptions applied.
- Having a per-map override of a var on the unit test feels kind of icky and unsafe. This would make a TG-style runtime map loading system more feasible (though I'm not necessarily arguing we should add that).