### PR TITLE
Fix terminal_setup adding terminals to unanchored machines 

### DIFF
--- a/code/game/machinery/_machines_base/stock_parts/power/terminal.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/terminal.dm
@@ -180,7 +180,7 @@
 	expected_part_type = /obj/item/stock_parts/power/terminal
 
 /decl/stock_part_preset/terminal_setup/apply(obj/machinery/machine, var/obj/item/stock_parts/power/terminal/part)
-	if(isturf(machine.loc))
+	if(isturf(machine.loc) && machine.anchored)
 		part.make_terminal(machine)
 
 //Offset terminals towards the owner's facing direction


### PR DESCRIPTION
## Description of changes
The terminal_setup stock part preset no longer applies if the machine is unanchored.

## Why and what will this PR improve
This makes it so you can safely drag unanchored shield generators from a storage room to wherever they need to be deployed, without leaving a ghost terminal behind or causing runtimes.