### PR TITLE
Fix right sofa preview icon

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest_sofa/sofa.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest_sofa/sofa.dm
@@ -107,7 +107,7 @@
 /obj/structure/bed/sofa/right
 	name = "sofa"
 	desc = "A wide and comfy sofa - no one assistant was ate by it due production! It's made of wood and covered with colored cloth."
-	icon_state = "sofa_r_previewo"
+	icon_state = "sofa_r_preview"
 	base_icon = "sofa_r"
 
 /obj/structure/bed/sofa/right/red


### PR DESCRIPTION
## Description of changes
Fixes a typo in the name of the right sofa subtype's mapping preview icon_state name.

## Why and what will this PR improve
They will no longer be invisible.