### PR TITLE
Fix Big Pharma strong painkiller bottles

### DIFF
--- a/code/modules/reagents/storage/pill_bottle_subtypes.dm
+++ b/code/modules/reagents/storage/pill_bottle_subtypes.dm
@@ -63,7 +63,7 @@
 	return list(/obj/item/chems/pill/painkillers = 14)
 
 /obj/item/storage/pill_bottle/strong_painkillers
-	name = "pill bottle (strong painkillers)"
+	labeled_name = "strong painkillers"
 	desc = "Contains pills used to relieve pain. Do not mix with alcohol consumption."
 	wrapper_color = COLOR_PURPLE_GRAY
 


### PR DESCRIPTION
## Description of changes
Makes strong painkiller bottles use `labeled_name`.

## Why and what will this PR improve
Prevents this from happening:
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/358336c7-d57f-43fd-b1d2-c22d690950fd)