### PR TITLE
Fix ghosts not being able to read fire alarms

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -963,7 +963,7 @@ FIRE ALARM
 	var/d2
 
 	var/decl/security_state/security_state = GET_DECL(global.using_map.security_state)
-	if (istype(user, /mob/living/carbon/human) || istype(user, /mob/living/silicon))
+	if (istype(user, /mob/living/carbon/human) || istype(user, /mob/living/silicon) || istype(user, /mob/observer))
 		A = A.loc
 
 		if (A.fire)


### PR DESCRIPTION
## Description of changes
Fixes a typecheck that stopped ghosts from reading fire alarms.

## Why and what will this PR improve
Ghosts can now read fire alarms without them being starred out, which means it's easier for adminghosts to mess with them.