### PR TITLE
Fix duplicate table removal and logging.

### DIFF
--- a/code/game/objects/structures/tables.dm
+++ b/code/game/objects/structures/tables.dm
@@ -91,6 +91,8 @@
 	. = ..()
 	if(istype(oldloc))
 		for(var/obj/structure/table/table in range(oldloc, 1))
+			if(QDELETED(table))
+				continue
 			table.update_connections(FALSE)
 			table.update_icon()
 

--- a/code/game/objects/structures/tables.dm
+++ b/code/game/objects/structures/tables.dm
@@ -46,9 +46,7 @@
 		if(reinf_material || additional_reinf_material || felted)
 			tool_interaction_flags &= ~TOOL_INTERACTION_DECONSTRUCT
 
-		for(var/obj/structure/table/T in loc)
-			if(T != src)
-				return INITIALIZE_HINT_QDEL
+		DELETE_IF_DUPLICATE_OF(/obj/structure/table)
 		. = INITIALIZE_HINT_LATELOAD
 
 // We do this because need to make sure adjacent tables init their material before we try and merge.
@@ -92,10 +90,9 @@
 	additional_reinf_material = null
 	. = ..()
 	if(istype(oldloc))
-		for(var/turf/turf as anything in RANGE_TURFS(oldloc, 1))
-			for(var/obj/structure/table/table in turf)
-				table.update_connections(FALSE)
-				table.update_icon()
+		for(var/obj/structure/table/table in range(oldloc, 1))
+			table.update_connections(FALSE)
+			table.update_icon()
 
 /obj/structure/table/can_dismantle(mob/user)
 	. = ..()


### PR DESCRIPTION
## Description of changes
Fixes a runtime in the code for removing duplicate tables, due to update_icon() being called on a deleted table.
Replaces the bespoke table duplicate removal code with what's already used for lattices and catwalks.

## Why and what will this PR improve
Fixes a runtime and improves code quality.