### PR TITLE
Remove unnecessary zero-wait timers from handle_airflow

### DIFF
--- a/code/modules/ZAS/Airflow.dm
+++ b/code/modules/ZAS/Airflow.dm
@@ -19,9 +19,9 @@ Contains helper procs for airflow, called by /connection_group.
 				airflow_dest = pick(close_turfs) //Pick a random midpoint to fly towards.
 
 				if(repelled)
-					addtimer(CALLBACK(src, .proc/RepelAirflowDest, differential / 5), 0)
+					RepelAirflowDest(differential / 5)
 				else
-					addtimer(CALLBACK(src, .proc/GotoAirflowDest, differential / 10), 0)
+					GotoAirflowDest(differential / 10)
 
 /atom/movable/proc/handle_airflow_stun(var/differential)
 	return


### PR DESCRIPTION
## Description of changes
Removes unnecessary timers in handle_airflow().

## Why and what will this PR improve
Speeds up airflow handling massively by not clogging SStimer with a bunch of zero-tick timers.
Technically this could also have been done by porting SSDPC, but there was no need to postpone the calls to the end of the tick anyway.