### PR TITLE
Modernize unsim air comparisons and allow Test_ZAS_Connection for nonsim turfs

### DIFF
--- a/code/controllers/subsystems/air.dm
+++ b/code/controllers/subsystems/air.dm
@@ -411,7 +411,9 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 		return edge
 	else
 		for(var/connection_edge/unsimulated/edge in A.edges)
-			if(has_same_air(edge.B,B))
+			var/datum/gas_mixture/opponent_air = edge.B.return_air()
+			var/turf/our_turf = B
+			if(opponent_air.compare(our_turf.return_air()))
 				return edge
 		var/connection_edge/edge = new/connection_edge/unsimulated(A,B)
 		edges += edge

--- a/code/modules/ZAS/Diagnostic.dm
+++ b/code/modules/ZAS/Diagnostic.dm
@@ -13,7 +13,7 @@
 		for(var/g in mix.gas)
 			to_chat(mob, "ZONE GASES: [g]: [mix.gas[g]]\n")
 
-/client/proc/Test_ZAS_Connection(var/turf/simulated/T)
+/client/proc/Test_ZAS_Connection(var/turf/T)
 	set category = "Debug"
 	if(!istype(T))
 		return
@@ -40,7 +40,7 @@
 			to_chat(mob, "No air passage :x")
 		return
 
-	var/turf/simulated/other_turf = get_step(T, direction_list[direction])
+	var/turf/other_turf = get_step(T, direction_list[direction])
 	if(!istype(other_turf))
 		return
 


### PR DESCRIPTION
## Description of changes
Modernizes unsim air comparisons to actually compare the airmixes rather than just the initial gas vars.
Removes unnecessary typechecks in Test_ZAS_Connection so that nonsim turfs participating in zones can be checked.

## Why and what will this PR improve
Fix Test_ZAS_Connection for nonsim turfs participating in zones.
Improves unsim air comparisons to be more accurate.