### PR TITLE
Fix editmode runtiming for non-datum values

### DIFF
--- a/code/modules/admin/buildmode/edit.dm
+++ b/code/modules/admin/buildmode/edit.dm
@@ -62,7 +62,8 @@
 		return
 	ClearValue()
 	value_to_set = new_value
-	events_repository.register(/decl/observ/destroyed, value_to_set, src, /datum/build_mode/edit/proc/ClearValue)
+	if(istype(value_to_set, /datum))
+		events_repository.register(/decl/observ/destroyed, value_to_set, src, /datum/build_mode/edit/proc/ClearValue)
 
 /datum/build_mode/edit/proc/ClearValue(var/feedback)
 	if(!istype(value_to_set, /datum))


### PR DESCRIPTION
## Description of changes
Adds a typecheck for the event registration in buildmode's varedit mode.

## Why and what will this PR improve
Fixes editmode runtiming for non-datum variable values.