### PR TITLE
Fix colored cloth objects being 'made of [color]'

### DIFF
--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -307,16 +307,13 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	. = ..()
 	if(!name)
 		CRASH("Unnamed material /decl tried to initialize.")
-	if(!use_name)
-		use_name = name
-	if(!liquid_name)
-		liquid_name = name
-	if(!solid_name)
-		solid_name = name
-	if(!gas_name)
-		gas_name = name
-	if(!adjective_name)
-		adjective_name = name
+	// Default use_name to name if unset.
+	use_name       ||= name
+	// Default everything else to use_name, so that if it's overridden, we use that instead of base name.
+	liquid_name    ||= use_name
+	solid_name     ||= use_name
+	gas_name       ||= use_name
+	adjective_name ||= use_name
 	if(!shard_icon)
 		shard_icon = shard_type
 	if(!burn_armor)

--- a/code/modules/materials/definitions/solids/materials_solid_ice.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_ice.dm
@@ -19,16 +19,11 @@
 	uid = "solid_ice"
 
 /decl/material/solid/ice/Initialize()
-	if(!liquid_name)
-		liquid_name = "liquid [name]" // avoiding the 'molten ice' issue
-	if(!gas_name)
-		gas_name = name
-	if(!solid_name)
-		solid_name = "[name] ice"
-	if(!use_name)
-		use_name = solid_name
-	if(!ore_name)
-		ore_name = solid_name
+	liquid_name ||= "liquid [name]" // avoiding the 'molten ice' issue
+	gas_name    ||= name
+	solid_name  ||= "[name] ice"
+	use_name    ||= solid_name
+	ore_name    ||= solid_name
 	. = ..()
 
 /decl/material/solid/ice/aspium

--- a/code/modules/materials/definitions/solids/materials_solid_organic.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_organic.dm
@@ -154,60 +154,70 @@
 	name = "yellow"
 	uid = "solid_cotton_yellow"
 	use_name = "yellow cloth"
+	adjective_name = "yellow"
 	color = "#ffbf00"
 
 /decl/material/solid/cloth/teal
 	name = "teal"
 	uid = "solid_cotton_teal"
 	use_name = "teal cloth"
+	adjective_name = "teal"
 	color = "#00e1ff"
 
 /decl/material/solid/cloth/black
 	name = "black"
 	uid = "solid_cotton_black"
 	use_name = "black cloth"
+	adjective_name = "black"
 	color = "#505050"
 
 /decl/material/solid/cloth/green
 	name = "green"
 	uid = "solid_cotton_green"
 	use_name = "green cloth"
+	adjective_name = "green"
 	color = "#b7f27d"
 
 /decl/material/solid/cloth/purple
 	name = "purple"
 	uid = "solid_cotton_purple"
 	use_name = "purple cloth"
+	adjective_name = "purple"
 	color = "#9933ff"
 
 /decl/material/solid/cloth/blue
 	name = "blue"
 	uid = "solid_cotton_blue"
 	use_name = "blue cloth"
+	adjective_name = "blue"
 	color = "#46698c"
 
 /decl/material/solid/cloth/beige
 	name = "beige"
 	uid = "solid_cotton_beige"
 	use_name = "beige cloth"
+	adjective_name = "beige"
 	color = "#ceb689"
 
 /decl/material/solid/cloth/lime
 	name = "lime"
 	uid = "solid_cotton_lime"
 	use_name = "lime cloth"
+	adjective_name = "lime"
 	color = "#62e36c"
 
 /decl/material/solid/cloth/red
 	name = "red"
 	uid = "solid_cotton_red"
 	use_name = "red cloth"
+	adjective_name = "red"
 	color = "#9d2300"
 
 /decl/material/solid/carpet
 	name = "red"
 	uid = "solid_carpet"
 	use_name = "red upholstery"
+	adjective_name = "red"
 	color = "#9d2300"
 	flags = MAT_FLAG_PADDING
 	ignition_point = T0C+232


### PR DESCRIPTION
## Description of changes
Makes `use_name` the default value for liquid/adjective/solid/etc. names if set.
Cleans up the default names code for base materials and ices.
Gives `adjective_name` values to colored cloth.

## Why and what will this PR improve
Fixes things made of colored cloth being "made of black" or "made of yellow" while making black padded chairs still named "black padded chair" instead of "black cloth padded chair".
Also, the code looks nicer.