### PR TITLE
Fix techfloor decals hiding caution stripes

### DIFF
--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -1353,6 +1353,7 @@ var/global/list/floor_decals = list()
 /obj/effect/floor_decal/techfloor
 	name = "techfloor edges"
 	icon_state = "techfloor_edges"
+	layer = DECAL_LAYER - 0.005 // so other decals can show up over it
 
 /obj/effect/floor_decal/techfloor/corner
 	name = "techfloor corner"


### PR DESCRIPTION
## Description of changes
Makes techfloor decals slightly below other decals so they don't hide other decals, like caution stripes.

## Why and what will this PR improve
Techfloor edges won't hide caution stripes and other decals.