### PR TITLE
Adds atmos connection extension

### DIFF
--- a/code/game/machinery/atmoalter/_atmos_connection.dm
+++ b/code/game/machinery/atmoalter/_atmos_connection.dm
@@ -1,0 +1,92 @@
+// Extension for allowing an atom to be connected to an atmospherics connector port.
+/datum/extension/atmospherics_connection
+	expected_type = /atom/movable
+	base_type = /datum/extension/atmospherics_connection
+
+	var/toggle_anchor // Whether to toggle anchor holder on connect/disconnect
+	var/obj/machinery/atmospherics/portables_connector/connected_port
+
+	var/datum/gas_mixture/merged_mixture
+
+/datum/extension/atmospherics_connection/New(datum/holder, _toggle_anchor, _merged_mixture)
+	. = ..()
+	toggle_anchor = _toggle_anchor
+	merged_mixture = _merged_mixture
+
+/datum/extension/atmospherics_connection/Destroy()
+	merged_mixture = null
+	disconnect()
+	. = ..()
+
+/datum/extension/atmospherics_connection/proc/connect(obj/machinery/atmospherics/portables_connector/new_port)
+	//Make sure not already connected to something else
+	if(connected_port || !new_port || new_port.connected_device)
+		return FALSE
+
+	var/atom/movable/movable_holder = holder
+
+	//Make sure are close enough for a valid connection
+	if(new_port.loc != movable_holder.loc)
+		return FALSE
+
+	//Perform the connection
+	connected_port = new_port
+	connected_port.connected_device = holder
+	connected_port.on = 1 //Activate port updates
+
+	if(toggle_anchor)
+		movable_holder.anchored = TRUE //Prevent movement
+
+	//Actually enforce the air sharing
+	var/datum/pipe_network/network = connected_port.return_network(holder)
+
+	if(network && !network.gases.Find(merged_mixture))
+		network.gases += merged_mixture
+		network.update = 1
+
+	return TRUE
+
+/datum/extension/atmospherics_connection/proc/disconnect()
+	if(!connected_port)
+		return FALSE
+
+	var/datum/pipe_network/network = connected_port.return_network(holder)
+	if(network)
+		network.gases -= merged_mixture
+
+	var/atom/movable/movable_holder = holder
+
+	if(toggle_anchor)
+		movable_holder.anchored = FALSE
+
+	connected_port.connected_device = null
+	connected_port = null
+
+	return TRUE
+
+/datum/extension/atmospherics_connection/proc/update_connected_network()
+	if(!connected_port)
+		return
+
+	var/datum/pipe_network/network = connected_port.return_network(holder)
+	if(network)
+		network.update = 1
+
+/datum/extension/atmospherics_connection/proc/update_merged_mixture(datum/gas_mixture/new_mixture)
+	if(merged_mixture == new_mixture)
+		return TRUE
+
+	if(!connected_port)
+		return FALSE
+
+	var/datum/pipe_network/network = connected_port.return_network(holder)
+
+	if(!network)
+		return FALSE
+
+	network.gases.Remove(merged_mixture)
+	if(!network.gases.Find(new_mixture))
+		network.gases += new_mixture
+
+	network.update = 1
+	return TRUE

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -117,7 +117,7 @@
 	update_flag = 0
 	if(holding)
 		update_flag |= 1
-	if(connected_port)
+	if(get_port())
 		update_flag |= 2
 
 	var/tank_pressure = return_pressure()
@@ -298,7 +298,7 @@ update_flag
 	var/data[0]
 	data["name"] = name
 	data["canLabel"] = can_label ? 1 : 0
-	data["portConnected"] = connected_port ? 1 : 0
+	data["portConnected"] = get_port() ? 1 : 0
 	data["tankPressure"] = round(air_contents.return_pressure() ? air_contents.return_pressure() : 0)
 	data["releasePressure"] = round(release_pressure ? release_pressure : 0)
 	data["minReleasePressure"] = round(0.1 ATM)

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -5,7 +5,6 @@
 	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CLIMBABLE
 
 	var/datum/gas_mixture/air_contents = new
-	var/obj/machinery/atmospherics/portables_connector/connected_port
 	var/obj/item/tank/holding
 	var/volume = 0
 	var/destroyed = 0
@@ -22,6 +21,10 @@
 	..()
 	air_contents.volume = volume
 	air_contents.temperature = T20C
+
+
+	set_extension(src, /datum/extension/atmospherics_connection, TRUE, air_contents)
+
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/portable_atmospherics/Destroy()
@@ -32,12 +35,13 @@
 /obj/machinery/portable_atmospherics/LateInitialize()
 	var/obj/machinery/atmospherics/portables_connector/port = locate() in loc
 	if(port)
-		connect(port)
-		update_icon()
+		var/datum/extension/atmospherics_connection/connection = get_extension(src, /datum/extension/atmospherics_connection)
+		if(connection)
+			connection.connect(port)
+			update_icon()
 
 /obj/machinery/portable_atmospherics/Process()
-	if(!connected_port) //only react when pipe_network will ont it do it for you
-		//Allow for reactions
+	if(get_port()) // Only react when pipe_network will not do it for you
 		air_contents.react()
 	else
 		update_icon()
@@ -53,52 +57,24 @@
 /obj/machinery/portable_atmospherics/on_update_icon()
 	return null
 
+/obj/machinery/portable_atmospherics/proc/get_port()
+	var/datum/extension/atmospherics_connection/connection = get_extension(src, /datum/extension/atmospherics_connection)
+
+	return connection?.connected_port
+
 /obj/machinery/portable_atmospherics/proc/connect(obj/machinery/atmospherics/portables_connector/new_port)
-	//Make sure not already connected to something else
-	if(connected_port || !new_port || new_port.connected_device)
-		return 0
+	var/datum/extension/atmospherics_connection/connection = get_extension(src, /datum/extension/atmospherics_connection)
 
-	//Make sure are close enough for a valid connection
-	if(new_port.loc != loc)
-		return 0
-
-	//Perform the connection
-	connected_port = new_port
-	connected_port.connected_device = src
-	connected_port.on = 1 //Activate port updates
-
-	anchored = TRUE //Prevent movement
-
-	//Actually enforce the air sharing
-	var/datum/pipe_network/network = connected_port.return_network(src)
-	if(network && !network.gases.Find(air_contents))
-		network.gases += air_contents
-		network.update = 1
-
-	return 1
+	return connection?.connect(new_port)
 
 /obj/machinery/portable_atmospherics/proc/disconnect()
-	if(!connected_port)
-		return 0
+	var/datum/extension/atmospherics_connection/connection = get_extension(src, /datum/extension/atmospherics_connection)
 
-	var/datum/pipe_network/network = connected_port.return_network(src)
-	if(network)
-		network.gases -= air_contents
-
-	anchored = FALSE
-
-	connected_port.connected_device = null
-	connected_port = null
-
-	return 1
+	return connection?.disconnect()
 
 /obj/machinery/portable_atmospherics/proc/update_connected_network()
-	if(!connected_port)
-		return
-
-	var/datum/pipe_network/network = connected_port.return_network(src)
-	if (network)
-		network.update = 1
+	var/datum/extension/atmospherics_connection/connection = get_extension(src, /datum/extension/atmospherics_connection)
+	connection?.update_connected_network()
 
 /obj/machinery/portable_atmospherics/attackby(var/obj/item/W, var/mob/user)
 	if ((istype(W, /obj/item/tank) && !( src.destroyed )))
@@ -111,8 +87,7 @@
 		return
 
 	else if(IS_WRENCH(W) && !panel_open)
-		if(connected_port)
-			disconnect()
+		if(disconnect())
 			to_chat(user, "<span class='notice'>You disconnect \the [src] from the port.</span>")
 			update_icon()
 			return

--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -40,7 +40,7 @@
 	if(holding)
 		overlays += "siphon-open"
 
-	if(connected_port)
+	if(get_port())
 		overlays += "siphon-connector"
 
 /obj/machinery/portable_atmospherics/powered/pump/emp_act(severity)
@@ -112,7 +112,7 @@
 /obj/machinery/portable_atmospherics/powered/pump/ui_interact(mob/user, ui_key = "rcon", datum/nanoui/ui=null, force_open=1)
 	var/list/data[0]
 	var/obj/item/cell/cell = get_cell()
-	data["portConnected"] = connected_port ? 1 : 0
+	data["portConnected"] = get_port() ? 1 : 0
 	data["tankPressure"] = round(air_contents.return_pressure() > 0 ? air_contents.return_pressure() : 0)
 	data["targetpressure"] = round(target_pressure)
 	data["pump_dir"] = direction_out

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -49,7 +49,7 @@
 	if(holding)
 		overlays += "scrubber-open"
 
-	if(connected_port)
+	if(get_port())
 		overlays += "scrubber-connector"
 
 /obj/machinery/portable_atmospherics/powered/scrubber/Process()
@@ -95,7 +95,7 @@
 /obj/machinery/portable_atmospherics/powered/scrubber/ui_interact(mob/user, ui_key = "rcon", datum/nanoui/ui=null, force_open=1)
 	var/list/data[0]
 	var/obj/item/cell/cell = get_cell()
-	data["portConnected"] = connected_port ? 1 : 0
+	data["portConnected"] = get_port() ? 1 : 0
 	data["tankPressure"] = round(air_contents.return_pressure() > 0 ? air_contents.return_pressure() : 0)
 	data["rate"] = round(volume_rate)
 	data["minrate"] = round(minrate)

--- a/code/modules/atmospherics/components/portables_connector.dm
+++ b/code/modules/atmospherics/components/portables_connector.dm
@@ -2,13 +2,13 @@
 	icon = 'icons/atmos/connector.dmi'
 	icon_state = "map_connector"
 
-	name = "Connector Port"
+	name = "connector port"
 	desc = "For connecting portable devices related to atmospherics control."
 
 	dir = SOUTH
 	initialize_directions = SOUTH
 
-	var/obj/machinery/portable_atmospherics/connected_device
+	var/atom/movable/connected_device
 	var/on = 0
 	use_power = POWER_USE_OFF
 	interact_offline = TRUE
@@ -43,7 +43,8 @@
 
 /obj/machinery/atmospherics/portables_connector/Destroy()
 	if(connected_device)
-		connected_device.disconnect()
+		var/datum/extension/atmospherics_connection/connection = get_extension(connected_device, /datum/extension/atmospherics_connection)
+		connection?.disconnect()
 	. = ..()
 
 /obj/machinery/atmospherics/portables_connector/return_network(obj/machinery/atmospherics/reference)
@@ -54,7 +55,9 @@
 
 /obj/machinery/atmospherics/portables_connector/return_network_air(datum/pipe_network/reference)
 	if(connected_device)
-		return list(connected_device.air_contents)
+		var/datum/extension/atmospherics_connection/connection = get_extension(connected_device, /datum/extension/atmospherics_connection)
+		if(connection)
+			return list(connection.merged_mixture)
 
 /obj/machinery/atmospherics/portables_connector/deconstruction_pressure_check()
 	var/datum/gas_mixture/int_air = return_air()

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -581,7 +581,7 @@
 		var/turf/T = loc
 		var/datum/gas_mixture/environment
 
-		if(closed_system && (connected_port || holding))
+		if(closed_system && (get_port() || holding))
 			environment = air_contents
 
 		if(!environment)

--- a/code/modules/hydroponics/trays/tray_process.dm
+++ b/code/modules/hydroponics/trays/tray_process.dm
@@ -76,7 +76,7 @@
 	var/turf/T = loc
 	var/datum/gas_mixture/environment
 	// If we're closed, take from our internal sources.
-	if(closed_system && (connected_port || holding))
+	if(closed_system && (get_port() || holding))
 		environment = air_contents
 	// If atmos input is not there, grab from turf.
 	if(!environment && istype(T)) environment = T.return_air()
@@ -89,7 +89,7 @@
 		plant_health -= seed.handle_environment(T,environment)
 
 	// If we're attached to a pipenet, then we should let the pipenet know we might have modified some gasses
-	if (closed_system && connected_port)
+	if (closed_system && get_port())
 		update_connected_network()
 
 	// Toxin levels beyond the plant's tolerance cause damage, but

--- a/nebula.dme
+++ b/nebula.dme
@@ -814,6 +814,7 @@
 #include "code\game\machinery\_machines_base\stock_parts\radio\receiver.dm"
 #include "code\game\machinery\_machines_base\stock_parts\radio\stock_parts_radio.dm"
 #include "code\game\machinery\_machines_base\stock_parts\radio\transmitter.dm"
+#include "code\game\machinery\atmoalter\_atmos_connection.dm"
 #include "code\game\machinery\atmoalter\area_atmos_computer.dm"
 #include "code\game\machinery\atmoalter\canister.dm"
 #include "code\game\machinery\atmoalter\meter.dm"


### PR DESCRIPTION
## Description of changes
Moves most of the portable atmospherics connection behavior into an extension. The atmospherics connection extension takes in a gas mixture that a portables connector will add to its network when connected, and remove when disconnected.

## Why and what will this PR improve
Makes it easier to add machinery that can connect to atmospherics pipes without descending from the atmospherics type. An alternative way to do this is adding an extension which spawns an invincible unary machine. I think this solution is less prone to break, but both are likely feasible.
## Authorship
Myself
## Changelog
Nothing player facing