### PR TITLE
Reworks missing organs in scan to be type agnostic.

### DIFF
--- a/code/_helpers/medical_scans.dm
+++ b/code/_helpers/medical_scans.dm
@@ -84,9 +84,8 @@
 		scan["internal_organs"] += list(O)
 
 	scan["missing_organs"] = list()
-
 	for(var/organ_name in H.species.has_organ)
-		if(!locate(H.species.has_organ[organ_name]) in internal_organs)
+		if(!GET_INTERNAL_ORGAN(H, organ_name))
 			scan["missing_organs"] += organ_name
 	if(H.sdisabilities & BLINDED)
 		scan["blind"] = TRUE
@@ -332,7 +331,7 @@
 	else
 		dat += subdat
 	for(var/organ_name in scan["missing_organs"])
-		if(organ_name != "appendix")
+		if(organ_name != BP_APPENDIX)
 			dat += "<tr><td colspan='3'><span class='bad'>No [organ_name] detected.</span></td></tr>"
 		else
 			dat += "<tr><td colspan='3'>No [organ_name] detected</td></tr>"


### PR DESCRIPTION
## Description of changes
Makes the body scanner report a missing organ if nothing is present for the tag, not if the type doesn't match.

## Why and what will this PR improve
Fixes https://github.com/ScavStation/ScavStation/issues/741

## Authorship
@out-of-phaze for finding the issue, myself for the tweak.

## Changelog
Nothing player-facing.