### PR TITLE
Readd name and description to revolver speed loader

### DIFF
--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -1,4 +1,6 @@
 /obj/item/ammo_magazine/speedloader
+	name = "speed loader"
+	desc = "A speed loader for revolvers."
 	icon = 'icons/obj/ammo/speedloader.dmi'
 	icon_state = ICON_STATE_WORLD
 	caliber = CALIBER_PISTOL_MAGNUM


### PR DESCRIPTION
## Description of changes
The name and description of revolver speed loaders were accidentally removed. This readds them.

## Why and what will this PR improve
Revolver speed loaders are no longer named `magazine`.