### PR TITLE
Network camera fixes

### DIFF
--- a/code/game/machinery/camera/_camera_device.dm
+++ b/code/game/machinery/camera/_camera_device.dm
@@ -12,7 +12,7 @@
 	var/xray_enabled = FALSE
 	has_commands = TRUE
 
-/datum/extension/network_device/camera/New(datum/holder, n_id, n_key, c_type, autojoin, list/preset_channels, camera_name, camnet_enabled = TRUE, req_connection = TRUE)
+/datum/extension/network_device/camera/New(datum/holder, n_id, n_key, r_type, autojoin, list/preset_channels, camera_name, camnet_enabled = TRUE, req_connection = TRUE)
 	if(length(preset_channels))
 		channels = preset_channels.Copy()
 	. = ..()
@@ -22,6 +22,7 @@
 	display_name = camera_name
 
 /datum/extension/network_device/camera/post_construction()
+	. = ..()
 	if(cameranet_enabled)
 		cameranet.add_source(holder)
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -192,7 +192,7 @@
 	if (istype(AM, /obj))
 		var/obj/O = AM
 		if (O.throwforce >= src.toughness)
-			visible_message("<span class='warning'><B>[src] was hit by [O].</B></span>")
+			visible_message(SPAN_WARNING("[src] was hit by [O]!"))
 		take_damage(O.throwforce)
 
 /obj/machinery/camera/physical_attack_hand(mob/living/carbon/human/user)
@@ -200,7 +200,7 @@
 		return
 	if(user.species.can_shred(user))
 		user.do_attack_animation(src)
-		visible_message("<span class='warning'>\The [user] slashes at [src]!</span>")
+		visible_message(SPAN_WARNING("\The [user] slashes at [src]!"))
 		playsound(src.loc, 'sound/weapons/slash.ogg', 100, 1)
 		add_hiddenprint(user)
 		take_damage(25)

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -1,32 +1,31 @@
 /obj/machinery/camera/network/engineering
 	preset_channels = list(CAMERA_CAMERA_CHANNEL_ENGINEERING)
-	initial_access = list(access_engine)
+	req_access = list(access_engine)
 
 /obj/machinery/camera/network/ert
 	preset_channels = list(CAMERA_CHANNEL_ERT)
 	cameranet_enabled = FALSE
-	initial_access = list(access_engine)
+	req_access = list(access_engine)
 
 /obj/machinery/camera/network/medbay
 	preset_channels = list(CAMERA_CHANNEL_MEDICAL)
-	initial_access = list(access_medical)
-
+	req_access = list(access_medical)
 /obj/machinery/camera/network/mercenary
 	preset_channels = list(CAMERA_CHANNEL_MERCENARY)
 	cameranet_enabled = FALSE
-	initial_access = list(access_mercenary)
+	req_access = list(access_mercenary)
 
 /obj/machinery/camera/network/mining
 	preset_channels = list(CAMERA_CHANNEL_MINE)
-	initial_access = list(access_mining)
+	req_access = list(access_mining)
 
 /obj/machinery/camera/network/research
 	preset_channels = list(CAMERA_CHANNEL_RESEARCH)
-	initial_access = list(access_research)
+	req_access = list(access_research)
 
 /obj/machinery/camera/network/security
 	preset_channels = list(CAMERA_CHANNEL_SECURITY)
-	initial_access = list(access_security)
+	req_access = list(access_security)
 
 /obj/machinery/camera/network/television
 	preset_channels = list(CAMERA_CHANNEL_TELEVISION)

--- a/maps/exodus/exodus_cameras.dm
+++ b/maps/exodus/exodus_cameras.dm
@@ -8,37 +8,37 @@ var/global/const/CAMERA_CHANNEL_ENGINEERING_OUTPOST = "Engineering Outpost"
 // Networks
 /obj/machinery/camera/network/command
 	preset_channels = list(CAMERA_CHANNEL_COMMAND)
-	initial_access = list(access_heads)
+	req_access = list(access_heads)
 
 /obj/machinery/camera/network/crescent
 	preset_channels = list(CAMERA_CHANNEL_CRESCENT)
 
 /obj/machinery/camera/network/engine
 	preset_channels = list(CAMERA_CHANNEL_ENGINE)
-	initial_access = list(access_engine)
+	req_access = list(access_engine)
 
 /obj/machinery/camera/network/engineering_outpost
 	preset_channels = list(CAMERA_CHANNEL_ENGINEERING_OUTPOST)
-	initial_access = list(access_engine)
+	req_access = list(access_engine)
 
 // Motion
 /obj/machinery/camera/motion/engineering_outpost
 	preset_channels = list(CAMERA_CHANNEL_ENGINEERING_OUTPOST)
-	initial_access = list(access_engine)
+	req_access = list(access_engine)
 
 // All Upgrades
 /obj/machinery/camera/all/command
 	preset_channels = list(CAMERA_CHANNEL_COMMAND)
-	initial_access = list(access_heads)
+	req_access = list(access_heads)
 
 // Compile stubs.
 /obj/machinery/camera/motion/command
 	preset_channels = list(CAMERA_CHANNEL_COMMAND)
-	initial_access = list(access_heads)
+	req_access = list(access_heads)
 
 /obj/machinery/camera/network/maintenance
 	preset_channels = list(CAMERA_CAMERA_CHANNEL_ENGINEERING)
-	initial_access = list(access_engine)
+	req_access = list(access_engine)
 
 /obj/machinery/camera/xray/security
 	preset_channels = list(CAMERA_CHANNEL_SECURITY)


### PR DESCRIPTION
## Description of changes
Fixes #3356, caused by a missing parent call in ``post_construction`` that was preventing cameras from autoconnecting to networks.
Changes preset camera accesses from ``initial_access`` to ``req_access``

## Why and what will this PR improve
Cameras will now work on round start again. Camera access will be properly restricted, and not default to broken network access.

As mentioned on Discord, there's deeper issues with machinery access that still need to be fixed. It's likely cameras will require more modification in the future to prevent easy tampering.

## Authorship
Myself, thanks to Loaf et. al for the report.
## Changelog
:cl:
fix: Fixed cameras not auto connecting to networks on round start
/:cl: