### PR TITLE
Crossed()/Uncrossed() consistency pass.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -539,3 +539,6 @@
 /atom/movable/singularity_pull(S, current_size)
 	if(simulated && !anchored)
 		step_towards(src, S)
+
+/atom/movable/proc/crossed_mob(var/mob/living/victim)
+	return

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -126,41 +126,44 @@
 	new t(src.loc)
 	qdel(src)
 
-/obj/effect/gateway/active/Crossed(var/atom/A)
-	if(!istype(A, /mob/living))
+/obj/effect/gateway/active/Crossed(atom/movable/AM)
+	if(!isliving(AM))
 		return
 
-	var/mob/living/M = A
+	var/mob/living/M = AM
+	if(M.stat == DEAD)
+		return
 
-	if(M.stat != DEAD)
-		if(M.HasMovementHandler(/datum/movement_handler/mob/transformation))
-			return
+	if(M.HasMovementHandler(/datum/movement_handler/mob/transformation))
+		return
 
-		M.handle_pre_transformation()
+	M.handle_pre_transformation()
 
-		if(iscultist(M)) return
-		if(!ishuman(M) && !isrobot(M)) return
+	if(iscultist(M))
+		return
+	if(!ishuman(M) && !isrobot(M))
+		return
 
-		M.AddMovementHandler(/datum/movement_handler/mob/transformation)
-		M.icon = null
-		M.overlays.len = 0
-		M.set_invisibility(101)
+	M.AddMovementHandler(/datum/movement_handler/mob/transformation)
+	M.icon = null
+	M.overlays.len = 0
+	M.set_invisibility(101)
 
-		if(istype(M, /mob/living/silicon/robot))
-			var/mob/living/silicon/robot/Robot = M
-			if(Robot.mmi)
-				qdel(Robot.mmi)
-		else
-			for(var/obj/item/W in M)
-				M.drop_from_inventory(W)
-				if(istype(W, /obj/item/implant))
-					qdel(W)
+	if(isrobot(M))
+		var/mob/living/silicon/robot/Robot = M
+		if(Robot.mmi)
+			qdel(Robot.mmi)
+	else
+		for(var/obj/item/W in M)
+			M.drop_from_inventory(W)
+			if(istype(W, /obj/item/implant))
+				qdel(W)
 
-		var/mob/living/new_mob = new /mob/living/simple_animal/corgi(A.loc)
-		new_mob.a_intent = I_HURT
-		if(M.mind)
-			M.mind.transfer_to(new_mob)
-		else
-			new_mob.key = M.key
+	var/mob/living/new_mob = new /mob/living/simple_animal/corgi(AM.loc)
+	new_mob.a_intent = I_HURT
+	if(M.mind)
+		M.mind.transfer_to(new_mob)
+	else
+		new_mob.key = M.key
 
-		to_chat(new_mob, "<B>Your form morphs into that of a corgi.</B>")//Because we don't have cluwnes
+	to_chat(new_mob, "<B>Your form morphs into that of a corgi.</B>")//Because we don't have cluwnes

--- a/code/game/machinery/mech_recharger.dm
+++ b/code/game/machinery/mech_recharger.dm
@@ -18,14 +18,15 @@
 	var/repair_power_usage = 10 KILOWATTS		// Per 1 HP of health.
 	var/repair = 0
 
-/obj/machinery/mech_recharger/Crossed(var/mob/living/exosuit/M)
+/obj/machinery/mech_recharger/Crossed(atom/movable/AM)
 	. = ..()
-	if(istype(M) && charging != M)
-		start_charging(M)
+	if(istype(AM, /mob/living/exosuit) && charging != AM)
+		start_charging(AM)
 
-/obj/machinery/mech_recharger/Uncrossed(var/mob/living/exosuit/M)
+/obj/machinery/mech_recharger/Uncrossed(atom/movable/AM)
 	. = ..()
-	if(M == charging)
+	var/mob/living/exosuit/M = AM
+	if(istype(M) && M == charging)
 		stop_charging()
 
 /obj/machinery/mech_recharger/RefreshParts()

--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -51,7 +51,7 @@
 
 /obj/effect/effect/smoke/chem/Crossed(atom/movable/AM)
 	..()
-	if(!istype(AM, /obj/effect/effect/smoke/chem))
+	if(AM.simulated && !istype(AM, /obj/effect/effect/smoke/chem))
 		reagents.splash(AM, splash_amount, copy = 1)
 
 /obj/effect/effect/smoke/chem/proc/initial_splash()

--- a/code/game/objects/effects/chem/foam.dm
+++ b/code/game/objects/effects/chem/foam.dm
@@ -71,12 +71,11 @@
 		spawn(5)
 			qdel(src)
 
-/obj/effect/effect/foam/Crossed(var/atom/movable/AM)
-	if(metal)
+/obj/effect/effect/foam/Crossed(atom/movable/AM)
+	if(metal || !isliving(AM))
 		return
-	if(istype(AM, /mob/living))
-		var/mob/living/M = AM
-		M.slip("the foam", 6)
+	var/mob/living/M = AM
+	M.slip("the foam", 6)
 
 /datum/effect/effect/system/foam_spread
 	var/amount = 5				// the size of the foam spread.

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -88,30 +88,29 @@ var/global/list/image/splatter_cache=list()
 		SetName(initial(name))
 		desc = initial(desc)
 
-/obj/effect/decal/cleanable/blood/Crossed(mob/living/carbon/human/perp)
-	if (!istype(perp))
-		return
-	if(amount < 1)
+/obj/effect/decal/cleanable/blood/Crossed(atom/movable/AM)
+	if(!isliving(AM) || amount < 1)
 		return
 
-	var/obj/item/organ/external/l_foot = GET_EXTERNAL_ORGAN(perp, BP_L_FOOT)
-	var/obj/item/organ/external/r_foot = GET_EXTERNAL_ORGAN(perp, BP_R_FOOT)
+	var/mob/living/M = AM
+	var/obj/item/organ/external/l_foot = GET_EXTERNAL_ORGAN(M, BP_L_FOOT)
+	var/obj/item/organ/external/r_foot = GET_EXTERNAL_ORGAN(M, BP_R_FOOT)
 	var/hasfeet = l_foot && r_foot
 
 	var/transferred_data = blood_data ? blood_data[pick(blood_data)] : null
-	var/obj/item/clothing/shoes/shoes = perp.get_equipped_item(slot_shoes_str)
-	if(istype(shoes) && !perp.buckled)//Adding blood to shoes
+	var/obj/item/clothing/shoes/shoes = M.get_equipped_item(slot_shoes_str)
+	if(istype(shoes) && !M.buckled)//Adding blood to shoes
 		shoes.add_coating(chemical, amount, transferred_data)
 	else if (hasfeet)//Or feet
 		if(l_foot)
 			l_foot.add_coating(chemical, amount, transferred_data)
 		if(r_foot)
 			r_foot.add_coating(chemical, amount, transferred_data)
-	else if (perp.buckled && istype(perp.buckled, /obj/structure/bed/chair/wheelchair))
-		var/obj/structure/bed/chair/wheelchair/W = perp.buckled
+	else if (M.buckled && istype(M.buckled, /obj/structure/bed/chair/wheelchair))
+		var/obj/structure/bed/chair/wheelchair/W = M.buckled
 		W.bloodiness = 4
 
-	perp.update_inv_shoes(1)
+	M.update_inv_shoes(1)
 	amount--
 
 /obj/effect/decal/cleanable/blood/proc/dry()

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -188,10 +188,10 @@ steam.start() -- spawns the effect
 	if(!QDELETED(src))
 		qdel(src)
 
-/obj/effect/effect/smoke/Crossed(mob/living/carbon/M)
+/obj/effect/effect/smoke/Crossed(atom/movable/AM)
 	..()
-	if(istype(M))
-		affect(M)
+	if(iscarbon(AM))
+		affect(AM)
 
 /obj/effect/effect/smoke/proc/affect(var/mob/living/carbon/M)
 	if (!istype(M))

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -14,7 +14,8 @@
 	icon_state = "uglyminearmed"
 
 /obj/effect/mine/Crossed(atom/movable/AM)
-	Bumped(AM)
+	if(!isobserver(AM))
+		Bumped(AM)
 
 /obj/effect/mine/Bumped(mob/M)
 

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -195,8 +195,11 @@
 	if(health > 0)
 		disturbed()
 
-/obj/effect/spider/spiderling/Crossed(var/mob/living/L)
-	if(dormant && istype(L) && L.mob_size > MOB_SIZE_TINY)
+/obj/effect/spider/spiderling/Crossed(atom/movable/AM)
+	if(!dormant || !isliving(AM))
+		return
+	var/mob/living/M = AM
+	if(M.mob_size > MOB_SIZE_TINY)
 		disturbed()
 
 /obj/effect/spider/spiderling/disturbed()

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -9,15 +9,11 @@
 /obj/effect/step_trigger/proc/Trigger(var/atom/movable/A)
 	return 0
 
-/obj/effect/step_trigger/Crossed(H)
+/obj/effect/step_trigger/Crossed(atom/movable/AM)
 	..()
-	if(!H)
+	if(!AM || (isobserver(AM) && !(isghost(AM) && affect_ghosts)))
 		return
-	if(isobserver(H) && !(isghost(H) && affect_ghosts))
-		return
-	Trigger(H)
-
-
+	Trigger(AM)
 
 /* Tosses things in a certain direction */
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -183,17 +183,19 @@
 	playsound(src, 'sound/effects/snap.ogg', 50, 1)
 	qdel(src)
 
-/obj/item/toy/snappop/Crossed(H)
-	if((ishuman(H))) //i guess carp and shit shouldn't set them off
-		var/mob/living/carbon/M = H
-		if(!MOVING_DELIBERATELY(M))
-			to_chat(M, "<span class='warning'>You step on the snap pop!</span>")
-
-			spark_at(src, amount=2)
-			new /obj/effect/decal/cleanable/ash(src.loc)
-			src.visible_message("<span class='warning'>The [src.name] explodes!</span>","<span class='warning'>You hear a snap!</span>")
-			playsound(src, 'sound/effects/snap.ogg', 50, 1)
-			qdel(src)
+/obj/item/toy/snappop/Crossed(atom/movable/AM)
+	//i guess carp and shit shouldn't set them off
+	var/mob/living/carbon/M = AM
+	if(!istype(M) || MOVING_DELIBERATELY(M))
+		return
+	to_chat(M, SPAN_WARNING("You step on the snap pop!"))
+	spark_at(src, amount=2)
+	new /obj/effect/decal/cleanable/ash(src.loc)
+	visible_message(
+		SPAN_WARNING("The [src] explodes!"),
+		SPAN_WARNING("You hear a snap!"))
+	playsound(src, 'sound/effects/snap.ogg', 50, 1)
+	qdel(src)
 
 /*
  * Bosun's whistle

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -7,10 +7,12 @@
 /*
  * Banana Peals
  */
-/obj/item/bananapeel/Crossed(var/atom/movable/AM)
-	if (istype(AM, /mob/living))
-		var/mob/living/M = AM
-		M.slip("the [src.name]", 4)
+/obj/item/bananapeel/Crossed(atom/movable/AM)
+	if(!isliving(AM))
+		return
+	var/mob/living/M = AM
+	M.slip("the [src.name]", 4)
+
 /*
  * Bike Horns
  */
@@ -26,7 +28,7 @@
 	throw_range = 15
 	attack_verb = list("HONKED")
 	material = /decl/material/solid/metal/steel
-	matter = list( 
+	matter = list(
 		/decl/material/solid/plastic = MATTER_AMOUNT_SECONDARY
 	)
 	obj_flags = OBJ_FLAG_HOLLOW

--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -338,16 +338,17 @@ var/global/list/image/hazard_overlays //Cached hazard floor overlays for the bar
 			return FALSE
 	return ..()
 
-/obj/structure/tape_barricade/Crossed(O)
+/obj/structure/tape_barricade/Crossed(atom/movable/AM)
 	. = ..()
-	if(!is_lifted && ismob(O))
-		var/mob/M = O
-		add_fingerprint(M)
-		shake_animation(2)
-		if (!allowed(M))	//only select few learn art of not crumpling the tape
-			to_chat(M, SPAN_NOTICE("You are not supposed to go past \the [src]..."))
-			if(M.a_intent != I_HELP)
-				crumple()
+	if(is_lifted || !isliving(AM))
+		return
+	var/mob/living/M = AM
+	add_fingerprint(M)
+	shake_animation(2)
+	if (!allowed(M))	//only select few learn art of not crumpling the tape
+		to_chat(M, SPAN_NOTICE("You are not supposed to go past \the [src]..."))
+		if(M.a_intent != I_HELP)
+			crumple()
 
 /obj/structure/tape_barricade/proc/crumple()
 	if(!is_crumpled)

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -45,9 +45,11 @@
 /obj/item/soap/proc/wet()
 	reagents.add_reagent(/decl/material/liquid/cleaner, SOAP_CLEANER_ON_WET)
 
-/obj/item/soap/Crossed(var/mob/living/AM)
-	if(istype(AM))
-		AM.slip("the [src.name]", 3)
+/obj/item/soap/Crossed(atom/movable/AM)
+	if(!isliving(AM))
+		return
+	var/mob/living/M = AM
+	M.slip("the [src.name]", 3)
 
 /obj/item/soap/afterattack(atom/target, mob/user, proximity)
 	if(!proximity) return

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -90,20 +90,21 @@
 	deployed = 0
 
 /obj/item/beartrap/Crossed(atom/movable/AM)
-	if(deployed && isliving(AM))
-		var/mob/living/L = AM
-		if(!MOVING_DELIBERATELY(L))
-			L.visible_message(
-				"<span class='danger'>[L] steps on \the [src].</span>",
-				"<span class='danger'>You step on \the [src]!</span>",
-				"<b>You hear a loud metallic snap!</b>"
-				)
-			attack_mob(L)
-			if(!buckled_mob)
-				anchored = 0
-			deployed = 0
-			update_icon()
 	..()
+	if(!deployed || !isliving(AM))
+		return
+	var/mob/living/L = AM
+	if(MOVING_DELIBERATELY(L))
+		return
+	L.visible_message(
+		SPAN_DANGER("\The [L] steps on \the [src]."),
+		SPAN_DANGER("You step on \the [src]!"),
+		"<b>You hear a loud metallic snap!</b>")
+	attack_mob(L)
+	if(!buckled_mob)
+		anchored = 0
+	deployed = 0
+	update_icon()
 
 /obj/item/beartrap/on_update_icon()
 	. = ..()

--- a/code/game/objects/structures/__structure.dm
+++ b/code/game/objects/structures/__structure.dm
@@ -144,19 +144,21 @@
 			AM.reset_offsets()
 			AM.reset_plane_and_layer()
 
-/obj/structure/Crossed(O)
+/obj/structure/Crossed(atom/movable/AM)
 	. = ..()
-	if(ismob(O))
-		var/mob/M = O
-		M.reset_offsets()
-		M.reset_plane_and_layer()
+	if(!ismob(AM))
+		return
+	var/mob/M = AM
+	M.reset_offsets()
+	M.reset_plane_and_layer()
 
-/obj/structure/Uncrossed(O)
+/obj/structure/Uncrossed(atom/movable/AM)
 	. = ..()
-	if(ismob(O))
-		var/mob/M = O
-		M.reset_offsets()
-		M.reset_plane_and_layer()
+	if(!ismob(AM))
+		return
+	var/mob/M = AM
+	M.reset_offsets()
+	M.reset_plane_and_layer()
 
 /obj/structure/Move()
 	var/turf/T = get_turf(src)

--- a/code/game/objects/structures/quicksand.dm
+++ b/code/game/objects/structures/quicksand.dm
@@ -83,12 +83,13 @@
 	else
 		..()
 
-/obj/effect/quicksand/Crossed(var/atom/movable/AM)
-	if(isliving(AM))
-		var/mob/living/L = AM
-		if(L.throwing || L.can_overcome_gravity())
-			return
-		buckle_mob(L)
-		if(!exposed)
-			expose()
-		to_chat(L, SPAN_DANGER("You fall into \the [src]!"))
+/obj/effect/quicksand/Crossed(atom/movable/AM)
+	if(!isliving(AM))
+		return
+	var/mob/living/L = AM
+	if(L.throwing || L.can_overcome_gravity())
+		return
+	buckle_mob(L)
+	if(!exposed)
+		expose()
+	to_chat(L, SPAN_DANGER("You fall into \the [src]!"))

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -108,7 +108,6 @@
 	if(special_assembly)
 		special_assembly.Crossed(AM)
 
-
 /obj/item/assembly_holder/on_found(mob/finder as mob)
 	if(a_left)
 		a_left.on_found(finder)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -74,17 +74,16 @@
 	. = toggle_arming(user) || ..()
 
 /obj/item/assembly/mousetrap/Crossed(atom/movable/AM)
-	if(armed)
-		if(ishuman(AM))
-			var/mob/living/carbon/H = AM
-			if(!MOVING_DELIBERATELY(H))
-				triggered(H)
-				H.visible_message("<span class='warning'>[H] accidentally steps on [src].</span>", \
-								  "<span class='warning'>You accidentally step on [src]</span>")
-		if(ismouse(AM))
-			triggered(AM)
 	..()
-
+	if(!armed || !isliving(AM))
+		return
+	var/mob/living/M = AM
+	if(MOVING_DELIBERATELY(M))
+		return
+	M.visible_message(
+		SPAN_DANGER("\The [M] steps on \the [src]!"),
+		SPAN_DANGER("You step on \the [src]!"))
+	triggered(M)
 
 /obj/item/assembly/mousetrap/on_found(mob/finder)
 	if(armed)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -125,26 +125,24 @@
 		fruit_leaves.color = seed.get_trait(TRAIT_PLANT_COLOUR)
 		add_overlay(fruit_leaves)
 
-/obj/item/chems/food/grown/Crossed(var/mob/living/M)
-	set waitfor = FALSE
-	if(seed && seed.get_trait(TRAIT_JUICY) == 2)
-		if(istype(M))
+/obj/item/chems/food/grown/Crossed(atom/movable/AM)
+	if(!isliving(AM) || !seed || seed.get_trait(TRAIT_JUICY) != 2)
+		return
 
-			if(M.buckled)
-				return
+	var/mob/living/M = AM
+	if(M.buckled || MOVING_DELIBERATELY(M))
+		return
 
-			if(istype(M,/mob/living/carbon/human))
-				var/mob/living/carbon/human/H = M
-				var/obj/item/shoes = H.get_equipped_item(slot_shoes_str)
-				if(shoes && shoes.item_flags & ITEM_FLAG_NOSLIP)
-					return
+	var/obj/item/shoes = M.get_equipped_item(slot_shoes_str)
+	if(shoes && shoes.item_flags & ITEM_FLAG_NOSLIP)
+		return
 
-			to_chat(M, SPAN_DANGER("You slipped on \the [src]!"))
-			playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-			SET_STATUS_MAX(M, STAT_STUN, 8)
-			SET_STATUS_MAX(M, STAT_WEAK, 5)
-			seed.thrown_at(src,M)
-			QDEL_IN(src, 0)
+	to_chat(M, SPAN_DANGER("You slipped on \the [src]!"))
+	playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
+	SET_STATUS_MAX(M, STAT_STUN, 8)
+	SET_STATUS_MAX(M, STAT_WEAK, 5)
+	seed.thrown_at(src,M)
+	QDEL_IN(src, 0)
 
 /obj/item/chems/food/grown/throw_impact(atom/hit_atom)
 	..()

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -20,9 +20,10 @@
 	manual_unbuckle(user)
 	return TRUE
 
-/obj/effect/vine/Crossed(atom/movable/O)
-	if(isliving(O))
-		trodden_on(O)
+/obj/effect/vine/Crossed(atom/movable/AM)
+	if(!isliving(AM))
+		return
+	trodden_on(AM)
 
 /obj/effect/vine/proc/trodden_on(var/mob/living/victim)
 	wake_neighbors()

--- a/code/modules/mob/living/bot/mulebot.dm
+++ b/code/modules/mob/living/bot/mulebot.dm
@@ -205,20 +205,18 @@
 		SET_STATUS_MAX(M, STAT_WEAK, 5)
 	..()
 
-/mob/living/bot/mulebot/proc/runOver(var/mob/living/carbon/human/H)
-	if(istype(H)) // No safety checks - WILL run over lying humans. Stop ERPing in the maint!
-		visible_message("<span class='warning'>[src] drives over [H]!</span>")
-		playsound(loc, 'sound/effects/splat.ogg', 50, 1)
-
-		var/damage = rand(5, 7)
-		H.apply_damage(2 * damage, BRUTE, BP_HEAD)
-		H.apply_damage(2 * damage, BRUTE, BP_CHEST)
-		H.apply_damage(0.5 * damage, BRUTE, BP_L_LEG)
-		H.apply_damage(0.5 * damage, BRUTE, BP_R_LEG)
-		H.apply_damage(0.5 * damage, BRUTE, BP_L_ARM)
-		H.apply_damage(0.5 * damage, BRUTE, BP_R_ARM)
-
-		blood_splatter(src, H, 1)
+/mob/living/bot/mulebot/crossed_mob(var/mob/living/victim)
+	// No safety checks - WILL run over lying humans. Stop ERPing in the maint!
+	visible_message(SPAN_WARNING("\The [src] drives over \the [victim]!"))
+	playsound(loc, 'sound/effects/splat.ogg', 50, 1)
+	var/damage = rand(5, 7)
+	victim.apply_damage(2 * damage, BRUTE, BP_HEAD)
+	victim.apply_damage(2 * damage, BRUTE, BP_CHEST)
+	victim.apply_damage(0.5 * damage, BRUTE, BP_L_LEG)
+	victim.apply_damage(0.5 * damage, BRUTE, BP_R_LEG)
+	victim.apply_damage(0.5 * damage, BRUTE, BP_L_ARM)
+	victim.apply_damage(0.5 * damage, BRUTE, BP_R_ARM)
+	blood_splatter(src, victim, 1)
 
 /mob/living/bot/mulebot/relaymove(var/mob/user, var/direction)
 	if(load == user)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -141,16 +141,6 @@
 		var/obj/item/underwear/UW = entry
 		LAZYADD(., "<BR><a href='?src=\ref[src];item=\ref[UW]'>Remove \the [UW]</a>")
 
-// called when something steps onto a human
-// this handles mulebots and vehicles
-/mob/living/carbon/human/Crossed(var/atom/movable/AM)
-	if(istype(AM, /mob/living/bot/mulebot))
-		var/mob/living/bot/mulebot/MB = AM
-		MB.runOver(src)
-
-	if(istype(AM, /obj/vehicle))
-		var/obj/vehicle/V = AM
-		V.RunOver(src)
 
 // Get rank from ID, ID inside PDA, PDA, ID in wallet, etc.
 /mob/living/carbon/human/proc/get_authentification_rank(var/if_no_id = "No id", var/if_no_job = "No job")

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -298,3 +298,8 @@
 	fire_act(air, temperature)
 	FireBurn(0.4*vsc.fire_firelevel_multiplier, temperature, pressure)
 	. =  (health <= 0) ? ..() : FALSE
+
+// called when something steps onto a mob
+// this handles mulebots and vehicles
+/mob/living/Crossed(var/atom/movable/AM)
+	AM.crossed_mob(src)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -91,13 +91,12 @@
 	if(stat == DEAD && splatted)
 		icon_state = "world-splat"
 
-/mob/living/simple_animal/mouse/Crossed(AM)
-	if( ishuman(AM) )
-		if(!stat)
-			var/mob/M = AM
-			to_chat(M, "<span class='warning'>[html_icon(src)] Squeek!</span>")
-			sound_to(M, 'sound/effects/mousesqueek.ogg')
+/mob/living/simple_animal/mouse/Crossed(atom/movable/AM)
 	..()
+	if(!ishuman(AM) || stat)
+		return
+	to_chat(AM, SPAN_WARNING("[html_icon(src)] Squeek!"))
+	sound_to(AM, 'sound/effects/mousesqueek.ogg')
 
 /*
  * Mouse types

--- a/code/modules/mob/observer/observer.dm
+++ b/code/modules/mob/observer/observer.dm
@@ -41,6 +41,9 @@ var/global/const/GHOST_IMAGE_ALL = ~GHOST_IMAGE_NONE
 		SSghost_images.queue_global_image_update()
 	. = ..()
 
+/mob/observer/get_movement_delay(travel_dir)
+	return 1
+
 /mob/observer/check_airflow_movable()
 	return FALSE
 

--- a/code/modules/overmap/overmap_object.dm
+++ b/code/modules/overmap/overmap_object.dm
@@ -64,16 +64,20 @@ var/global/list/overmap_unknown_ids = list()
 	add_filter("glow", 1, list("drop_shadow", color = color + "F0", size = 2, offset = 1,x = 0, y = 0))
 	update_icon()
 
-/obj/effect/overmap/Crossed(var/obj/effect/overmap/visitable/other)
-	if(istype(other))
-		for(var/obj/effect/overmap/visitable/O in loc)
-			SSskybox.rebuild_skyboxes(O.map_z)
+/obj/effect/overmap/Crossed(atom/movable/AM)
+	var/obj/effect/overmap/visitable/other = AM
+	if(!istype(other))
+		return
+	for(var/obj/effect/overmap/visitable/O in loc)
+		SSskybox.rebuild_skyboxes(O.map_z)
 
-/obj/effect/overmap/Uncrossed(var/obj/effect/overmap/visitable/other)
-	if(istype(other))
-		SSskybox.rebuild_skyboxes(other.map_z)
-		for(var/obj/effect/overmap/visitable/O in loc)
-			SSskybox.rebuild_skyboxes(O.map_z)
+/obj/effect/overmap/Uncrossed(atom/movable/AM)
+	var/obj/effect/overmap/visitable/other = AM
+	if(!istype(other))
+		return
+	SSskybox.rebuild_skyboxes(other.map_z)
+	for(var/obj/effect/overmap/visitable/O in loc)
+		SSskybox.rebuild_skyboxes(O.map_z)
 
 /obj/effect/overmap/on_update_icon()
 	. = ..()

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -43,22 +43,21 @@
 
 	update_icon()
 
-/obj/item/ammo_casing/Crossed(atom/AM)
+/obj/item/ammo_casing/Crossed(atom/movable/AM)
 	..()
+	if(!isliving(AM))
+		return
 
-	if(isliving(AM))
-		var/mob/living/L = AM
+	var/mob/living/L = AM
+	if(L.buckled || MOVING_DELIBERATELY(L) || prob(90))
+		return
 
-		if(L.buckled)
-			return
-
-		if(!MOVING_DELIBERATELY(L) && prob(10))
-			playsound(src, pick(drop_sound), 50, 1)
-			var/turf/turf_current = get_turf(src)
-			var/turf/turf_destiinaton = get_step(turf_current, AM.dir)
-			if(turf_destiinaton.Adjacent(turf_current))
-				throw_at(turf_destiinaton, 2, 2, spin = FALSE)
-				animate(src, pixel_x = rand(-16, 16), pixel_y = rand(-16, 16), transform = turn(matrix(), rand(120, 300)), time = rand(3, 8))
+	playsound(src, pick(drop_sound), 50, 1)
+	var/turf/turf_current = get_turf(src)
+	var/turf/turf_destiinaton = get_step(turf_current, AM.dir)
+	if(turf_destiinaton.Adjacent(turf_current))
+		throw_at(turf_destiinaton, 2, 2, spin = FALSE)
+		animate(src, pixel_x = rand(-16, 16), pixel_y = rand(-16, 16), transform = turn(matrix(), rand(120, 300)), time = rand(3, 8))
 
 /obj/item/ammo_casing/proc/leave_residue()
 	var/obj/item/gun/G = get_recursive_loc_of_type(/obj/item/gun)

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -149,29 +149,27 @@
 	else
 		verbs += /obj/vehicle/train/cargo/engine/verb/stop_engine
 
-/obj/vehicle/train/cargo/RunOver(var/mob/living/carbon/human/H)
-	var/list/parts = list(BP_HEAD, BP_CHEST, BP_L_LEG, BP_R_LEG, BP_L_ARM, BP_R_ARM)
+/obj/vehicle/train/cargo/crossed_mob(var/mob/living/victim)
+	victim.apply_effects(5, 5)
+	for(var/i = 1 to rand(1,5))
+		var/obj/item/organ/external/E = pick(victim.get_external_organs())
+		if(E)
+			victim.apply_damage(rand(5,10), BRUTE, E.organ_tag)
 
-	H.apply_effects(5, 5)
-	for(var/i = 0, i < rand(1,5), i++)
-		var/def_zone = pick(parts)
-		H.apply_damage(rand(5,10), BRUTE, def_zone)
-
-/obj/vehicle/train/cargo/trolley/RunOver(var/mob/living/carbon/human/H)
+/obj/vehicle/train/cargo/trolley/crossed_mob(var/mob/living/victim)
 	..()
-	attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [H.name] ([H.ckey])</font>")
+	attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [victim.name] ([victim.ckey])</font>")
 
-/obj/vehicle/train/cargo/engine/RunOver(var/mob/living/carbon/human/H)
+/obj/vehicle/train/cargo/engine/crossed_mob(var/mob/living/victim)
 	..()
-
 	if(is_train_head() && istype(load, /mob/living/carbon/human))
 		var/mob/living/carbon/human/D = load
-		to_chat(D, "<span class='danger'>You ran over [H]!</span>")
-		visible_message("<span class='danger'>\The [src] ran over [H]!</span>")
-		attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [H.name] ([H.ckey]), driven by [D.name] ([D.ckey])</font>")
-		msg_admin_attack("[D.name] ([D.ckey]) ran over [H.name] ([H.ckey]). (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)")
+		to_chat(D, "<span class='danger'>You ran over \the [victim]!</span>")
+		visible_message("<span class='danger'>\The [src] ran over \the [victim]!</span>")
+		attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [victim.name] ([victim.ckey]), driven by [D.name] ([D.ckey])</font>")
+		msg_admin_attack("[D.name] ([D.ckey]) ran over [victim.name] ([victim.ckey]). (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)")
 	else
-		attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [H.name] ([H.ckey])</font>")
+		attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [victim.name] ([victim.ckey])</font>")
 
 
 //-------------------------------------------

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -242,9 +242,6 @@
 	cell = null
 	powercheck()
 
-/obj/vehicle/proc/RunOver(var/mob/living/carbon/human/H)
-	return		//write specifics for different vehicles
-
 //-------------------------------------------
 // Loading/unloading procs
 //

--- a/code/unit_tests/movement_tests.dm
+++ b/code/unit_tests/movement_tests.dm
@@ -50,15 +50,11 @@
 /obj/test/crossed_obj
 	var/list/crossers
 
-/obj/test/crossed_obj/Crossed(var/crosser)
-	if(!crossers)
-		crossers = list()
-	crossers += crosser
+/obj/test/crossed_obj/Crossed(var/atom/movable/AM)
+	LAZYADD(crossers, AM)
 
 /obj/test/entered_obj
 	var/list/enterers
 
 /obj/test/entered_obj/Entered(var/enterer)
-	if(!enterers)
-		enterers = list()
-	enterers += enterer
+	LAZYADD(enterers, enterer)

--- a/mods/species/ascent/effects/razorweb.dm
+++ b/mods/species/ascent/effects/razorweb.dm
@@ -117,9 +117,11 @@
 		add_fingerprint(user)
 	return M
 
-/obj/effect/razorweb/Crossed(var/mob/living/L)
-	. = ..()
-	entangle(L)
+/obj/effect/razorweb/Crossed(var/atom/movable/AM)
+	..()
+	if(!isliving(AM))
+		return
+	entangle(AM)
 
 /obj/effect/razorweb/proc/entangle(var/mob/living/L, var/silent)
 


### PR DESCRIPTION
## Description of changes
- Standardizes argument to `Crossed()`/`Uncrossed()`.
- Generally cleans up overrides.
- Fixes a few places where the crosser is insufficiently checked.
- Fixes #3378,
- Broke some vehicle and mulebot logic out into an /atom/movable proc (`crossed_mob()`).

## Why and what will this PR improve
Fixes a number of bugs, general code quality.

## Authorship
Myself.

## Changelog
Nothing player-facing.