### PR TITLE
Reworking how surgery handles sounds

### DIFF
--- a/code/modules/surgery/_surgery.dm
+++ b/code/modules/surgery/_surgery.dm
@@ -17,22 +17,44 @@ var/global/list/surgery_tool_exception_cache = list()
 /* SURGERY STEPS */
 /decl/surgery_step
 	abstract_type = /decl/surgery_step
+	/// An identifying name string.
 	var/name
+	/// An informative description string.
 	var/description
-	var/list/allowed_tools               // type path referencing tools that can be used for this step, and how well are they suited for it
-	var/list/allowed_species             // type paths referencing races that this step applies to.
-	var/list/disallowed_species          // type paths referencing races that this step applies to.
-	var/min_duration = 0                 // duration of the step
-	var/max_duration = 0                 // duration of the step
-	var/can_infect = 0                   // evil infection stuff that will make everyone hate me
-	var/blood_level = 0                  // How much blood this step can get on surgeon. 1 - hands, 2 - full body.
-	var/shock_level = 0	                 // what shock level will this step put patient on
-	var/delicate = 0                     // if this step NEEDS stable optable or can be done on any valid surface with no penalty
-	var/surgery_candidate_flags = 0      // Various bitflags for requirements of the surgery.
-	var/strict_access_requirement = TRUE // Whether or not this surgery will be fuzzy on size requirements.
-	var/hidden_from_codex                // Is this surgery a secret?
+	/// type path referencing tools that can be used for this step, and how well are they suited for it
+	var/list/allowed_tools
+	/// type paths referencing races that this step applies to.
+	var/list/allowed_species
+	/// type paths referencing races that this step applies to.
+	var/list/disallowed_species
+	/// duration of the step
+	var/min_duration = 0
+	/// duration of the step
+	var/max_duration = 0
+	/// evil infection stuff that will make everyone hate me
+	var/can_infect = 0
+	/// How much blood this step can get on surgeon. 1 - hands, 2 - full body.
+	var/blood_level = 0
+	/// what shock level will this step put patient on
+	var/shock_level = 0
+	/// if this step NEEDS stable optable or can be done on any valid surface with no penalty
+	var/delicate = 0
+	/// Various bitflags for requirements of the surgery.
+	var/surgery_candidate_flags = 0
+	/// Whether or not this surgery will be fuzzy on size requirements.
+	var/strict_access_requirement = TRUE
+	/// Is this surgery a secret?
+	var/hidden_from_codex
+	/// Any additional information to add to the codex entry for this step.
 	var/list/additional_codex_lines
+	/// What mob type does this surgery apply to.
 	var/expected_mob_type = /mob/living/carbon/human
+	/// Sound (or list of sounds) to play on end step.
+	var/end_step_sound = "rustle"
+	/// Sound (or list of sounds) to play on fail step.
+	var/fail_step_sound
+	/// Sound (or list of sounds) to play on begin step.
+	var/begin_step_sound = "rustle"
 
 /decl/surgery_step/proc/is_self_surgery_permitted(var/mob/target, var/bodypart)
 	return TRUE
@@ -134,6 +156,9 @@ var/global/list/surgery_tool_exception_cache = list()
 
 // does stuff to begin the step, usually just printing messages. Moved germs transfering and bloodying here too
 /decl/surgery_step/proc/begin_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
+	SHOULD_CALL_PARENT(TRUE)
+	if(begin_step_sound)
+		playsound(target, pick(begin_step_sound), 15, 1)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	if (can_infect && affected)
 		spread_germs_to_organ(affected, user)
@@ -149,10 +174,15 @@ var/global/list/surgery_tool_exception_cache = list()
 
 // does stuff to end the step, which is normally print a message + do whatever this step changes
 /decl/surgery_step/proc/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
-	return
+	SHOULD_CALL_PARENT(TRUE)
+	if(end_step_sound)
+		playsound(target, pick(end_step_sound), 15, 1)
 
 // stuff that happens when the step fails
 /decl/surgery_step/proc/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
+	SHOULD_CALL_PARENT(TRUE)
+	if(fail_step_sound)
+		playsound(target, pick(fail_step_sound), 15, 1)
 	return null
 
 /decl/surgery_step/proc/success_chance(mob/living/user, mob/living/target, obj/item/tool, target_zone)

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -19,6 +19,7 @@
 /decl/surgery_step/bone/glue
 	name = "Begin bone repair"
 	description = "This procedure is used to begin setting a bone in place by treating the damage with bone gel."
+	end_step_sound = 'sound/effects/ointment.ogg'
 	allowed_tools = list(
 		TOOL_BONE_GEL = 100,
 		TOOL_SCREWDRIVER = 75
@@ -46,12 +47,13 @@
 	if(affected.stage == 0)
 		affected.stage = 1
 	affected.status &= ~ORGAN_BRITTLE
+	..()
 
 /decl/surgery_step/bone/glue/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>" , \
 	"<span class='warning'>Your hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>")
-
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	bone setting surgery step
@@ -69,6 +71,7 @@
 	delicate = 1
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NEEDS_ENCASEMENT
 	required_stage = 1
+	end_step_sound = "fracture"
 
 /decl/surgery_step/bone/set_bone/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
@@ -93,6 +96,7 @@
 			user.visible_message("<span class='notice'>\The [user] sets [bone] in place with \the [tool].</span>", \
 				"<span class='notice'>You set [bone] in place with \the [tool].</span>")
 		affected.stage = 2
+		..() // The pseudo-fail condition below plays a fracture sound anyway.
 	else
 		user.visible_message("<span class='notice'>\The [user] sets [bone]</span> <span class='warning'>in the WRONG place with \the [tool].</span>", \
 			"<span class='notice'>You set [bone]</span> <span class='warning'>in the WRONG place with \the [tool].</span>")
@@ -104,6 +108,7 @@
 		"<span class='warning'>Your hand slips, damaging the [affected.encased ? affected.encased : "bones"] in \the [target]'s [affected.name] with \the [tool]!</span>")
 	affected.fracture()
 	affected.take_external_damage(5, used_weapon = tool)
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	post setting bone-gelling surgery step
@@ -111,6 +116,7 @@
 /decl/surgery_step/bone/finish
 	name = "Finish bone repair"
 	description = "This procedure seals a damaged bone with bone gel after setting the bone in place."
+	end_step_sound = 'sound/effects/ointment.ogg'
 	allowed_tools = list(
 		TOOL_BONE_GEL = 100,
 		TOOL_SCREWDRIVER = 75
@@ -137,8 +143,10 @@
 	affected.status &= ~ORGAN_BROKEN
 	affected.stage = 0
 	affected.update_wounds()
+	..()
 
 /decl/surgery_step/bone/finish/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>" , \
 	"<span class='warning'>Your hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>")
+	..()

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -39,6 +39,7 @@
 	user.visible_message("<span class='notice'>[user] has cut [target]'s [affected.encased] open with \the [tool].</span>",		\
 	"<span class='notice'>You have cut [target]'s [affected.encased] open with \the [tool].</span>")
 	affected.fracture()
+	..()
 
 /decl/surgery_step/open_encased/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
@@ -46,3 +47,4 @@
 	"<span class='warning'>Your hand slips, cracking [target]'s [affected.encased] with \the [tool]!</span>" )
 	affected.take_external_damage(15, 0, (DAM_SHARP|DAM_EDGE), used_weapon = tool)
 	affected.fracture()
+	..()

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -28,11 +28,13 @@
 	user.visible_message("<span class='notice'>[user] repairs \the [target]'s face with \the [tool].</span>",	\
 	"<span class='notice'>You repair \the [target]'s face with \the [tool].</span>")
 	var/obj/item/organ/external/h = GET_EXTERNAL_ORGAN(target, target_zone)
-	if(h) 
+	if(h)
 		h.status &= ~ORGAN_DISFIGURED
+	..()
 
 /decl/surgery_step/fix_face/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, tearing skin on [target]'s face with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, tearing skin on [target]'s face with \the [tool]!</span>")
 	affected.take_external_damage(10, 0, (DAM_SHARP|DAM_EDGE), used_weapon = tool)
+	..()

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -23,6 +23,7 @@
 /decl/surgery_step/generic/cut_open
 	name = "Make incision"
 	description = "This procedure cuts a small wound that allows access to deeper tissue."
+	end_step_sound = 'sound/items/Wirecutter.ogg'
 	allowed_tools = list(TOOL_SCALPEL = 100)
 	min_duration = 90
 	max_duration = 110
@@ -50,15 +51,18 @@
 	user.visible_message("<span class='notice'>[user] has made [access_string] on [target]'s [affected.name] with \the [tool].</span>", \
 	"<span class='notice'>You have made [access_string] on [target]'s [affected.name] with \the [tool].</span>",)
 	affected.createwound(CUT, CEILING(affected.min_broken_damage/2), TRUE)
-	playsound(target.loc, 'sound/weapons/bladeslice.ogg', 15, 1)
 	if(tool.damtype == BURN)
 		affected.clamp_organ()
+		playsound(target, 'sound/items/Welder.ogg', 15, 1)
+	else
+		..()
 
 /decl/surgery_step/generic/cut_open/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, [fail_string] \the [target]'s [affected.name] in the wrong place with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, [fail_string] \the [target]'s [affected.name] in the wrong place with \the [tool]!</span>")
 	affected.take_external_damage(10, 0, (DAM_SHARP|DAM_EDGE), used_weapon = tool)
+	..()
 
 /decl/surgery_step/generic/cut_open/success_chance(mob/living/user, mob/living/target, obj/item/tool)
 	. = ..()
@@ -73,6 +77,7 @@
 /decl/surgery_step/generic/clamp_bleeders
 	name = "Clamp bleeders"
 	description = "This procedure clamps off veins within an incision, preventing it from bleeding excessively."
+	end_step_sound = 'sound/items/Wirecutter.ogg'
 	allowed_tools = list(
 		TOOL_HEMOSTAT = 100,
 		TOOL_CABLECOIL = 75
@@ -100,13 +105,14 @@
 	"<span class='notice'>You clamp bleeders in [target]'s [affected.name] with \the [tool].</span>")
 	affected.clamp_organ()
 	spread_germs_to_organ(affected, user)
-	playsound(target.loc, 'sound/items/Welder.ogg', 15, 1)
+	..()
 
 /decl/surgery_step/generic/clamp_bleeders/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, tearing blood vessals and causing massive bleeding in [target]'s [affected.name] with \the [tool]!</span>",	\
 	"<span class='warning'>Your hand slips, tearing blood vessels and causing massive bleeding in [target]'s [affected.name] with \the [tool]!</span>",)
 	affected.take_external_damage(10, 0, (DAM_SHARP|DAM_EDGE), used_weapon = tool)
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	 retractor surgery step
@@ -145,12 +151,14 @@
 	user.visible_message("<span class='notice'>[user] keeps the incision open on [target]'s [affected.name] with \the [tool].</span>",	\
 	"<span class='notice'>You keep the incision open on [target]'s [affected.name] with \the [tool].</span>")
 	affected.open_incision()
+	..()
 
 /decl/surgery_step/generic/retract_skin/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, tearing the edges of the incision on [target]'s [affected.name] with \the [tool]!</span>",	\
 	"<span class='warning'>Your hand slips, tearing the edges of the incision on [target]'s [affected.name] with \the [tool]!</span>")
 	affected.take_external_damage(12, 0, (DAM_SHARP|DAM_EDGE), used_weapon = tool)
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	 skin cauterization surgery step
@@ -158,6 +166,7 @@
 /decl/surgery_step/generic/cauterize
 	name = "Cauterize incision"
 	description = "This procedure cauterizes and closes an incision."
+	end_step_sound = 'sound/items/Welder.ogg'
 	allowed_tools = list(
 		TOOL_CAUTERY = 100,
 		TOOL_WELDER = 25
@@ -198,12 +207,14 @@
 		affected.update_wounds()
 	if(affected.clamped())
 		affected.remove_clamps()
+	..()
 
 /decl/surgery_step/generic/cauterize/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, damaging [target]'s [affected.name] with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, damaging [target]'s [affected.name] with \the [tool]!</span>")
 	affected.take_external_damage(0, 3, used_weapon = tool)
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	 limb amputation surgery step
@@ -211,6 +222,7 @@
 /decl/surgery_step/generic/amputate
 	name = "Amputate limb"
 	description = "This procedure removes a limb, or the stump of a limb, from the body entirely."
+	end_step_sound = 'sound/weapons/bladeslice.ogg'
 	allowed_tools = list(
 		TOOL_SAW = 100,
 		TOOL_HATCHET = 75
@@ -265,6 +277,7 @@
 			SPAN_DANGER("\The [user] hacks off \the [target]'s [affected.name] at the [affected.amputation_point] with \the [tool]!"), \
 			SPAN_DANGER("You hack off \the [target]'s [affected.name] with \the [tool]!"))
 	affected.dismember(clean_cut, DISMEMBER_METHOD_EDGE)
+	..()
 
 /decl/surgery_step/generic/amputate/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
@@ -279,3 +292,4 @@
 			SPAN_WARNING("You slip, mangling \the [target]'s [affected.name] with \the [tool]."))
 		affected.take_external_damage(30, 0, (DAM_SHARP|DAM_EDGE), used_weapon = tool)
 	affected.fracture()
+	..()

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -12,12 +12,14 @@
 	delicate = 1
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NEEDS_ENCASEMENT
 	abstract_type = /decl/surgery_step/cavity
+	end_step_sound = 'sound/effects/squelch1.ogg'
 
 /decl/surgery_step/cavity/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, scraping around inside [target]'s [affected.name] with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, scraping around inside [target]'s [affected.name] with \the [tool]!</span>")
 	affected.take_external_damage(20, 0, (DAM_SHARP|DAM_EDGE), used_weapon = tool)
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	 create implant space surgery step
@@ -46,6 +48,7 @@
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='notice'>[user] makes some space inside [target]'s [affected.cavity_name] cavity with \the [tool].</span>", \
 	"<span class='notice'>You make some space inside [target]'s [affected.cavity_name] cavity with \the [tool].</span>" )
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	 implant cavity sealing surgery step
@@ -77,6 +80,7 @@
 	user.visible_message("<span class='notice'>[user] mends [target]'s [affected.cavity_name] cavity walls with \the [tool].</span>", \
 	"<span class='notice'>You mend [target]'s [affected.cavity_name] cavity walls with \the [tool].</span>" )
 	affected.cavity = FALSE
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	 implanting surgery step
@@ -88,6 +92,7 @@
 	min_duration = 80
 	max_duration = 100
 	hidden_from_codex = TRUE
+	begin_step_sound = 'sound/effects/squelch1.ogg'
 
 /decl/surgery_step/cavity/place_item/can_use(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	if(isrobot(user))
@@ -123,7 +128,6 @@
 	user.visible_message("[user] starts putting \the [tool] inside [target]'s [affected.cavity_name] cavity.", \
 	"You start putting \the [tool] inside [target]'s [affected.cavity_name] cavity." )
 	target.custom_pain("The pain in your chest is living hell!",1,affecting = affected)
-	playsound(target.loc, 'sound/effects/squelch1.ogg', 25, 1)
 	..()
 
 /decl/surgery_step/cavity/place_item/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
@@ -137,6 +141,7 @@
 		affected.owner.custom_pain("You feel something rip in your [affected.name]!", 1,affecting = affected)
 	LAZYDISTINCTADD(affected.implants, tool)
 	affected.cavity = 0
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	 implant removal surgery step
@@ -150,6 +155,7 @@
 	)
 	min_duration = 80
 	max_duration = 100
+	end_step_sound = 'sound/effects/squelch1.ogg'
 
 /decl/surgery_step/cavity/implant_removal/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
@@ -202,13 +208,16 @@
 			"<span class='notice'>You take \the [obj] out of incision on \the [target]'s [affected.name] with \the [tool].</span>" )
 			target.remove_implant(obj, TRUE, affected)
 			BITSET(target.hud_updateflag, IMPLOYAL_HUD)
-			playsound(target.loc, 'sound/effects/squelch1.ogg', 15, 1)
+			..()
 		else
 			user.visible_message("<span class='notice'>[user] removes \the [tool] from [target]'s [affected.name].</span>", \
 			"<span class='notice'>There's something inside [target]'s [affected.name], but you just missed it this time.</span>" )
+			playsound(target.loc, "rustle", 15, 1)
 	else
 		user.visible_message("<span class='notice'>[user] could not find anything inside [target]'s [affected.name], and pulls \the [tool] out.</span>", \
 		"<span class='notice'>You could not find anything inside [target]'s [affected.name].</span>" )
+		playsound(target.loc, "rustle", 15, 1)
+
 
 /decl/surgery_step/cavity/implant_removal/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	..()

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -81,6 +81,7 @@
 	var/obj/item/organ/external/E = tool
 	user.visible_message("[user] starts attaching [E.name] to [target]'s [E.amputation_point].", \
 	"You start attaching [E.name] to [target]'s [E.amputation_point].")
+	..()
 
 /decl/surgery_step/limb/attach/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	if(!user.try_unequip(tool))
@@ -95,12 +96,14 @@
 
 	if(BP_IS_PROSTHETIC(E) && prob(user.skill_fail_chance(SKILL_DEVICES, 50, SKILL_ADEPT)))
 		E.add_random_ailment()
+	..()
 
 /decl/surgery_step/limb/attach/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = tool
 	user.visible_message("<span class='warning'> [user]'s hand slips, damaging [target]'s [E.amputation_point]!</span>", \
 	"<span class='warning'> Your hand slips, damaging [target]'s [E.amputation_point]!</span>")
 	target.apply_damage(10, BRUTE, null, damage_flags=DAM_SHARP)
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	 limb connecting surgery step
@@ -134,6 +137,7 @@
 	var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("[user] starts connecting tendons and muscles in [target]'s [E.amputation_point] with [tool].", \
 	"You start connecting tendons and muscle in [target]'s [E.amputation_point].")
+	..()
 
 /decl/surgery_step/limb/connect/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(target, target_zone)
@@ -143,9 +147,11 @@
 
 	//This time we call add_organ but we want it to install in a non detached state
 	target.add_organ(E, P, FALSE, TRUE, FALSE)
+	..()
 
 /decl/surgery_step/limb/connect/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'> [user]'s hand slips, damaging [target]'s [E.amputation_point]!</span>", \
 	"<span class='warning'> Your hand slips, damaging [target]'s [E.amputation_point]!</span>")
 	target.apply_damage(10, BRUTE, null, damage_flags=DAM_SHARP)
+	..()

--- a/code/modules/surgery/necrotic.dm
+++ b/code/modules/surgery/necrotic.dm
@@ -16,6 +16,7 @@
 	allowed_tools = list(TOOL_SCALPEL = 90)
 	min_duration = 150
 	max_duration = 170
+	end_step_sound = 'sound/weapons/bladeslice.ogg'
 
 /decl/surgery_step/necrotic/tissue/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	. = ..()
@@ -70,7 +71,6 @@
 	user.visible_message(
 		SPAN_NOTICE("\The [user] has excised the necrotic tissue from \the [target]'s [target_organ] with \the [tool]."), \
 		SPAN_NOTICE("You have excised the necrotic tissue from \the [target]'s [target_organ] with \the [tool]."))
-	playsound(target.loc, 'sound/weapons/bladeslice.ogg', 15, 1)
 
 	var/obj/item/organ/O = target.get_organ(LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone))
 	if(O)
@@ -78,6 +78,7 @@
 		if(istype(O,/obj/item/organ/external))
 			var/obj/item/organ/external/E = O
 			E.disinfect()
+	..()
 
 /decl/surgery_step/necrotic/tissue/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
@@ -86,6 +87,7 @@
 			SPAN_DANGER("\The [user]'s hand slips, slicing into a healthy portion of \the [target]'s [affected.name] with \the [tool]!"),
 			SPAN_DANGER("Your hand slips, slicing into a healthy portion of [target]'s [affected.name] with \the [tool]!"))
 		affected.take_external_damage(10, 0, (DAM_SHARP|DAM_EDGE), used_weapon = tool)
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	 Dead organ regeneration treatment
@@ -183,6 +185,7 @@
 		to_chat(user,SPAN_WARNING("You transferred too little for the organ to regenerate!"))
 	qdel(temp_reagents)
 	qdel(temp_holder)
+	..()
 
 /decl/surgery_step/necrotic/regeneration/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	if(!istype(tool) || !tool.reagents)
@@ -194,3 +197,4 @@
 		user.visible_message(
 			SPAN_DANGER("\The [user]'s hand slips, spilling \the [tool]'s contents over the [target]'s [affected.name]!"),
 			SPAN_DANGER("Your hand slips, spilling \the [tool]'s contents over the [target]'s [affected.name]!"))
+	..()

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -9,6 +9,7 @@
 	delicate = 1
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NEEDS_ENCASEMENT
 	abstract_type = /decl/surgery_step/internal
+	end_step_sound = 'sound/effects/squelch1.ogg'
 
 //////////////////////////////////////////////////////////////////
 //	Organ mending surgery step
@@ -69,6 +70,7 @@
 				I.surgical_fix(user)
 	user.visible_message("\The [user] finishes treating damage within \the [target]'s [affected.name] with [tool_name].", \
 	"You finish treating damage within \the [target]'s [affected.name] with [tool_name]." )
+	..()
 
 /decl/surgery_step/internal/fix_organ/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
@@ -84,6 +86,7 @@
 	for(var/obj/item/organ/internal/I in affected.internal_organs)
 		if(I && I.damage > 0 && !BP_IS_PROSTHETIC(I) && (I.surface_accessible || affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED)))
 			I.take_internal_damage(dam_amt)
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	 Organ detachment surgery step
@@ -125,6 +128,7 @@
 	if(I && istype(I) && istype(affected))
 		//First only detach the organ, without fully removing it
 		target.remove_organ(I, FALSE, TRUE)
+	..()
 
 /decl/surgery_step/internal/detach_organ/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
@@ -132,6 +136,7 @@
 		user.visible_message("<span class='warning'>[user]'s hand slips, slicing an artery inside [target]'s [affected.name] with \the [tool]!</span>", \
 		"<span class='warning'>Your hand slips, slicing an artery inside [target]'s [affected.name] with \the [tool]!</span>")
 		affected.take_external_damage(rand(30,50), 0, (DAM_SHARP|DAM_EDGE), used_weapon = tool)
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	 Organ removal surgery step
@@ -198,12 +203,14 @@
 		var/obj/item/organ/internal/mmi_holder/brain = O
 		brain.transfer_and_delete()
 		log_warning("Organ removal surgery on '[target]' returned a mmi_holder '[O]' instead of a mmi!!")
+	..()
 
 /decl/surgery_step/internal/remove_organ/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, damaging [target]'s [affected.name] with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, damaging [target]'s [affected.name] with \the [tool]!</span>")
 	affected.take_external_damage(20, used_weapon = tool)
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	 Organ inserting surgery step
@@ -273,12 +280,10 @@
 	if(istype(O) && user.try_unequip(O, target))
 		//Place the organ but don't attach it yet
 		target.add_organ(O, affected, detached = TRUE)
-
-		if(!BP_IS_PROSTHETIC(affected))
-			playsound(target.loc, 'sound/effects/squelch1.ogg', 15, 1)
-		else
+		if(BP_IS_PROSTHETIC(affected))
 			playsound(target.loc, 'sound/items/Ratchet.ogg', 50, 1)
-
+		else
+			..()
 		if(BP_IS_PROSTHETIC(O) && prob(user.skill_fail_chance(SKILL_DEVICES, 50, SKILL_ADEPT)))
 			O.add_random_ailment()
 
@@ -288,6 +293,7 @@
 	var/obj/item/organ/internal/I = tool
 	if(istype(I))
 		I.take_internal_damage(rand(3,5))
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	 Organ attachment surgery step
@@ -372,9 +378,11 @@
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	if(istype(I) && I.parent_organ == target_zone && affected && (I in affected.implants))
 		target.add_organ(I, affected, detached = FALSE)
+	..()
 
 /decl/surgery_step/internal/attach_organ/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, damaging the flesh in [target]'s [affected.name] with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, damaging the flesh in [target]'s [affected.name] with \the [tool]!</span>")
 	affected.take_external_damage(20, used_weapon = tool)
+	..()

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -39,12 +39,14 @@
 		"<span class='notice'>You have reattached the [affected.tendon_name] in [target]'s [affected.name] with \the [tool].</span>")
 	affected.status &= ~ORGAN_TENDON_CUT
 	affected.update_damages()
+	..()
 
 /decl/surgery_step/fix_tendon/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>" , \
 	"<span class='warning'>Your hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>")
 	affected.take_external_damage(5, used_weapon = tool)
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	 IB fix surgery step
@@ -83,12 +85,14 @@
 		"<span class='notice'>You have patched the [affected.artery_name] in [target]'s [affected.name] with \the [tool].</span>")
 	affected.status &= ~ORGAN_ARTERY_CUT
 	affected.update_damages()
+	..()
 
 /decl/surgery_step/fix_vein/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>" , \
 	"<span class='warning'>Your hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>")
 	affected.take_external_damage(5, used_weapon = tool)
+	..()
 
 
 //////////////////////////////////////////////////////////////////
@@ -137,10 +141,12 @@
 		rig.reset()
 	user.visible_message("<span class='notice'>[user] has cut through the support systems of [target]'s [rig] with \the [tool].</span>", \
 		"<span class='notice'>You have cut through the support systems of [target]'s [rig] with \the [tool].</span>")
+	..()
 
 /decl/surgery_step/hardsuit/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	user.visible_message("<span class='danger'>[user]'s [tool] can't quite seem to get through the metal...</span>", \
 	"<span class='danger'>Your [tool] can't quite seem to get through the metal. It's weakening, though - try again.</span>")
+	..()
 
 
 //////////////////////////////////////////////////////////////////
@@ -185,17 +191,11 @@
 
 /decl/surgery_step/sterilize/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-
-	if (!istype(tool, /obj/item/chems))
-		return
-
 	var/obj/item/chems/container = tool
-
 	var/amount = container.amount_per_transfer_from_this
 	var/temp_holder = new/obj()
 	var/datum/reagents/temp_reagents = new(amount, temp_holder)
 	container.reagents.trans_to_holder(temp_reagents, amount)
-
 	var/trans = temp_reagents.trans_to_mob(target, temp_reagents.total_volume, CHEM_INJECT) //technically it's contact, but the reagents are being applied to internal tissue
 	if (trans > 0)
 		user.visible_message("<span class='notice'>[user] rubs [target]'s [affected.name] down with \the [tool]'s contents</span>.", \
@@ -203,20 +203,16 @@
 	affected.disinfect()
 	qdel(temp_reagents)
 	qdel(temp_holder)
+	..()
 
 /decl/surgery_step/sterilize/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-
-	if (!istype(tool, /obj/item/chems))
-		return
-
 	var/obj/item/chems/container = tool
-
 	container.reagents.trans_to_mob(target, container.amount_per_transfer_from_this, CHEM_INJECT)
-
 	user.visible_message("<span class='warning'>[user]'s hand slips, spilling \the [tool]'s contents over the [target]'s [affected.name]!</span>" , \
 	"<span class='warning'>Your hand slips, spilling \the [tool]'s contents over the [target]'s [affected.name]!</span>")
 	affected.disinfect()
+	..()
 
 /decl/surgery_step/sterilize/proc/check_chemicals(var/obj/item/chems/container)
 

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -10,6 +10,7 @@
 	can_infect = 0
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_FLESH
 	abstract_type = /decl/surgery_step/robotics
+	end_step_sound = 'sound/items/Screwdriver.ogg'
 
 /decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool)
 	return SURGERY_SKILLS_ROBOTIC
@@ -56,11 +57,13 @@
 	user.visible_message("<span class='notice'>[user] has opened the maintenance hatch on [target]'s [affected.name] with \the [tool].</span>", \
 	"<span class='notice'>You have opened the maintenance hatch on [target]'s [affected.name] with \the [tool].</span>",)
 	affected.hatch_state = HATCH_UNSCREWED
+	..()
 
 /decl/surgery_step/robotics/unscrew_hatch/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'>\The [user]'s [tool.name] slips, failing to unscrew \the [target]'s [affected.name].</span>", \
 	"<span class='warning'>Your [tool.name] slips, failing to unscrew [target]'s [affected.name].</span>")
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	 screw robotic limb hatch surgery step
@@ -88,11 +91,13 @@
 	user.visible_message("<span class='notice'>[user] has screwed down the maintenance hatch on [target]'s [affected.name] with \the [tool].</span>", \
 	"<span class='notice'>You have screwed down the maintenance hatch on [target]'s [affected.name] with \the [tool].</span>",)
 	affected.hatch_state = HATCH_CLOSED
+	..()
 
 /decl/surgery_step/robotics/screw_hatch/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'>[user]'s [tool.name] slips, failing to screw down [target]'s [affected.name].</span>", \
 	"<span class='warning'>Your [tool] slips, failing to screw down [target]'s [affected.name].</span>")
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	open robotic limb surgery step
@@ -123,11 +128,13 @@
 	user.visible_message("<span class='notice'>[user] opens the maintenance hatch on [target]'s [affected.name] with \the [tool].</span>", \
 	 "<span class='notice'>You open the maintenance hatch on [target]'s [affected.name] with \the [tool].</span>")
 	affected.hatch_state = HATCH_OPENED
+	..()
 
 /decl/surgery_step/robotics/open_hatch/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'>[user]'s [tool.name] slips, failing to open the hatch on [target]'s [affected.name].</span>",
 	"<span class='warning'>Your [tool] slips, failing to open the hatch on [target]'s [affected.name].</span>")
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	close robotic limb surgery step
@@ -160,11 +167,13 @@
 	"<span class='notice'>You close the hatch on [target]'s [affected.name] with \the [tool].</span>")
 	affected.hatch_state = HATCH_UNSCREWED
 	affected.germ_level = 0
+	..()
 
 /decl/surgery_step/robotics/close_hatch/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'>[user]'s [tool.name] slips, failing to close the hatch on [target]'s [affected.name].</span>",
 	"<span class='warning'>Your [tool.name] slips, failing to close the hatch on [target]'s [affected.name].</span>")
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	robotic limb brute damage repair surgery step
@@ -219,12 +228,14 @@
 	"<span class='notice'>You finish patching damage to [target]'s [affected.name] with \the [tool].</span>")
 	affected.heal_damage(rand(30,50),0,1,1)
 	affected.status &= ~ORGAN_DISFIGURED
+	..()
 
 /decl/surgery_step/robotics/repair_brute/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'>[user]'s [tool.name] slips, damaging the internal structure of [target]'s [affected.name].</span>",
 	"<span class='warning'>Your [tool.name] slips, damaging the internal structure of [target]'s [affected.name].</span>")
 	target.apply_damage(rand(5,10), BURN, affected)
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	robotic limb brittleness repair surgery step
@@ -257,12 +268,14 @@
 	user.visible_message("<span class='notice'>[user] finishes repairing the brittle interior of \the [target]'s [affected.name].</span>", \
 	"<span class='notice'>You finish repairing the brittle interior of \the [target]'s [affected.name].</span>")
 	affected.status &= ~ORGAN_BRITTLE
+	..()
 
 /decl/surgery_step/robotics/repair_brittle/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'>[user] causes some of \the [target]'s [affected.name] to crumble!</span>",
 	"<span class='warning'>You cause some of \the [target]'s [affected.name] to crumble!</span>")
 	target.apply_damage(rand(5,10), BRUTE, affected)
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	robotic limb burn damage repair surgery step
@@ -314,12 +327,14 @@
 	"<span class='notice'>You finishes splicing new cable into [target]'s [affected.name].</span>")
 	affected.heal_damage(0,rand(30,50),1,1)
 	affected.status &= ~ORGAN_DISFIGURED
+	..()
 
 /decl/surgery_step/robotics/repair_burn/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='warning'>[user] causes a short circuit in [target]'s [affected.name]!</span>",
 	"<span class='warning'>You cause a short circuit in [target]'s [affected.name]!</span>")
 	target.apply_damage(rand(5,10), BURN, affected)
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	 artificial organ repair surgery step
@@ -369,6 +384,7 @@
 				user.visible_message("<span class='notice'>[user] repairs [target]'s [I.name] with [tool].</span>", \
 				"<span class='notice'>You repair [target]'s [I.name] with [tool].</span>" )
 				I.damage = 0
+	..()
 
 /decl/surgery_step/robotics/fix_organ_robotic/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
@@ -380,6 +396,7 @@
 		var/obj/item/organ/internal/I = internal
 		if(I)
 			I.take_internal_damage(rand(3,5))
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	robotic organ detachment surgery step
@@ -418,10 +435,12 @@
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	if(I && istype(I) && istype(affected))
 		target.remove_organ(I, detach = TRUE)
+	..()
 
 /decl/surgery_step/robotics/detach_organ_robotic/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	user.visible_message("<span class='warning'>[user]'s hand slips, unseating \the [tool].</span>", \
 	"<span class='warning'>Your hand slips, unseating \the [tool].</span>")
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	robotic organ transplant finalization surgery step
@@ -468,10 +487,12 @@
 		if (I.organ_tag == current_organ)
 			target.add_organ(I, affected, detached = FALSE)
 			break
+	..()
 
 /decl/surgery_step/robotics/attach_organ_robotic/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	user.visible_message("<span class='warning'>[user]'s hand slips, unseating \the [tool].</span>", \
 	"<span class='warning'>Your hand slips, unseating \the [tool].</span>")
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	mmi installation surgery step
@@ -533,10 +554,12 @@
 
 	if(M.brainmob && M.brainmob.mind)
 		M.brainmob.mind.transfer_to(target)
+	..()
 
 /decl/surgery_step/robotics/install_mmi/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	user.visible_message("<span class='warning'>[user]'s hand slips.</span>", \
 	"<span class='warning'>Your hand slips.</span>")
+	..()
 
 /decl/surgery_step/internal/remove_organ/robotic
 	name = "Remove robotic component"
@@ -592,6 +615,7 @@
 			user.visible_message( \
 			SPAN_NOTICE("\The [user] could not find anything inside [target]'s [affected.name]."), \
 			SPAN_NOTICE("You could not find anything inside [target]'s [affected.name]."))
+	..()
 
 /decl/surgery_step/remove_mmi/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
@@ -599,3 +623,4 @@
 	SPAN_WARNING("\The [user]'s hand slips, damaging \the [target]'s [affected.name] with \the [tool]!"), \
 	SPAN_WARNING("Your hand slips, damaging \the [target]'s [affected.name] with \the [tool]!"))
 	affected.take_external_damage(3, 0, used_weapon = tool)
+	..()

--- a/code/modules/surgery/suture_wounds.dm
+++ b/code/modules/surgery/suture_wounds.dm
@@ -44,9 +44,11 @@
 					W.clamped = 1
 			break
 	affected.update_damages()
+	..()
 
 /decl/surgery_step/suture_wounds/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message(SPAN_DANGER("[user]'s hand slips, tearing [target]'s [affected.name] with \the [tool]!"), \
 		SPAN_DANGER("Your hand slips, tearing [target]'s [affected.name] with \the [tool]!"))
 	target.apply_damage(3, BRUTE, affected)
+	..()

--- a/mods/content/xenobiology/slime/slime_surgery.dm
+++ b/mods/content/xenobiology/slime/slime_surgery.dm
@@ -41,15 +41,18 @@
 /decl/surgery_step/slime/cut_flesh/begin_step(mob/user, mob/living/slime/target, target_zone, obj/item/tool)
 	user.visible_message("[user] starts cutting through [target]'s flesh with \the [tool].", \
 	"You start cutting through [target]'s flesh with \the [tool].")
+	..()
 
 /decl/surgery_step/slime/cut_flesh/end_step(mob/living/user, mob/living/slime/target, target_zone, obj/item/tool)
 	user.visible_message("<span class='notice'>[user] cuts through [target]'s flesh with \the [tool].</span>",	\
 	"<span class='notice'>You cut through [target]'s flesh with \the [tool], revealing its silky innards.</span>")
 	target.core_removal_stage = 1
+	..()
 
 /decl/surgery_step/slime/cut_flesh/fail_step(mob/living/user, mob/living/slime/target, target_zone, obj/item/tool)
 	user.visible_message("<span class='warning'>[user]'s hand slips, tearing [target]'s flesh with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, tearing [target]'s flesh with \the [tool]!</span>")
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	slime innards cutting surgery step
@@ -67,15 +70,18 @@
 /decl/surgery_step/slime/cut_innards/begin_step(mob/user, mob/living/slime/target, target_zone, obj/item/tool)
 	user.visible_message("[user] starts cutting [target]'s silky innards apart with \the [tool].", \
 	"You start cutting [target]'s silky innards apart with \the [tool].")
+	..()
 
 /decl/surgery_step/slime/cut_innards/end_step(mob/living/user, mob/living/slime/target, target_zone, obj/item/tool)
 	user.visible_message("<span class='notice'>[user] cuts [target]'s innards apart with \the [tool], exposing the cores.</span>",	\
 	"<span class='notice'>You cut [target]'s innards apart with \the [tool], exposing the cores.</span>")
 	target.core_removal_stage = 2
+	..()
 
 /decl/surgery_step/slime/cut_innards/fail_step(mob/living/user, mob/living/slime/target, target_zone, obj/item/tool)
 	user.visible_message("<span class='warning'>[user]'s hand slips, tearing [target]'s innards with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, tearing [target]'s innards with \the [tool]!</span>")
+	..()
 
 //////////////////////////////////////////////////////////////////
 //	slime core removal surgery step
@@ -97,6 +103,7 @@
 	user.visible_message(
 		SPAN_NOTICE("\The [user] starts cutting out one of \the [target]'s cores with \the [tool]."), \
 		SPAN_NOTICE("You start cutting out one of \the [target]'s cores with \the [tool]."))
+	..()
 
 /decl/surgery_step/slime/saw_core/end_step(mob/living/user, mob/living/slime/target, target_zone, obj/item/tool)
 	if(target.cores <= 0)
@@ -108,8 +115,10 @@
 		SPAN_NOTICE("\The [user] cuts \the [core] out of \the [target] with \the [tool]."),	\
 		SPAN_NOTICE("You cut \the [core] out of \the [target] with \the [tool]. It looks like there are [target.cores] core\s left."))
 	target.update_icon()
+	..()
 
 /decl/surgery_step/slime/saw_core/fail_step(mob/living/user, mob/living/slime/target, target_zone, obj/item/tool)
 	user.visible_message(
 		SPAN_DANGER("\The [user]'s hand slips, failing to extract the slime core."), \
 		SPAN_DANGER("Your hand slips, causing you to miss the core!"))
+	..()


### PR DESCRIPTION
## Description of changes
- Adds vars to surgery steps to play sounds on begin, end and fail.
- Adds parent calls and linting to ensure these sounds play.
- Tweaks some existing surgery sounds and adds more.
- Addresses #3374 to some extent.

## Why and what will this PR improve
Hoping to make surgery sounds feel a little more consistent and easier to set/change.

## Authorship
Myself.

## Changelog
:cl:
tweak: Surgery now has more/different sounds.
/:cl:
