### PR TITLE
Multi-item recipes fix #3382

### DIFF
--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -95,7 +95,7 @@
 					needed_items -= itype
 			else
 				needed_items -= itype
-			break
+			// break
 		if(!length(container_contents))
 			break
 	return !length(needed_items)
@@ -128,10 +128,15 @@
 	//Find items we need
 	if (LAZYLEN(items))
 		for (var/i in items)
-			var/obj/item/I = locate(i) in container_contents
-			if (I && I.reagents)
-				I.reagents.trans_to_holder(buffer,I.reagents.total_volume)
-				qdel(I)
+			var/cnt = 1
+			if (isnum(items[i]))
+				cnt = items[i]
+			for (cnt, cnt > 0, cnt--)
+				var/obj/item/I = locate(i) in container_contents
+				if (I && I.reagents)
+					container_contents -= I
+					I.reagents.trans_to_holder(buffer,I.reagents.total_volume)
+					qdel(I)
 
 	//Find fruits
 	if (LAZYLEN(fruit))

--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -93,8 +93,10 @@
 				--needed_items[itype]
 				if(needed_items[itype] <= 0)
 					needed_items -= itype
+					break
 			else
 				needed_items -= itype
+				break
 			// break
 		if(!length(container_contents))
 			break


### PR DESCRIPTION
## Description of changes
Since `/decl/recipe` uses a sometimes-numerical value to the component items (i.e., a few microwave food cooking recipes), the existing code was modified:
- the recipe deciding algorithm at `check_items` needs to iterate over all items (and not to break after finding a first example of required item);
- the procedure actually finalizing cooking process (`make_food`) should similarly consume and move all of the used-up items.

## Why and what will this PR improve
This way, the recipes should work the way they are written down (in code and in codex)

## Authorship
Myself.

## Changelog
:cl:
bugfix: fixed multi-item (food) recipe
/:cl:

## Postscriptum
Looking around, I guess that general `/decl/recipe/proc/make` may also need similar edits, but I am unsure.