### PR TITLE
Removed default hair hiding from head items, added to hoods.

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -42,9 +42,8 @@
 /obj/item/clothing/head/culthood
 	name = "cult hood"
 	desc = "A hood worn by the followers of Nar-Sie."
-
 	icon = 'icons/clothing/head/cult.dmi'
-	flags_inv = HIDEFACE
+	flags_inv = HIDEFACE | BLOCK_HEAD_HAIR
 	body_parts_covered = SLOT_HEAD
 	armor = list(
 		ARMOR_MELEE = ARMOR_MELEE_RESISTANT,

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -4,7 +4,6 @@
 	icon                = 'icons/clothing/head/softcap.dmi'
 	blood_overlay_type  = "helmetblood"
 	w_class             = ITEM_SIZE_SMALL
-	flags_inv           = BLOCK_HEAD_HAIR
 	slot_flags          = SLOT_HEAD
 	body_parts_covered  = SLOT_HEAD
 


### PR DESCRIPTION
Fixes https://github.com/ScavStation/ScavStation/issues/780.

I had a look at `/obj/item/clothing/head` subtypes and almost all that I saw are already overriding the flag setting. It does not make sense to me for the default behavior to be completely hiding hair.