### PR TITLE
Upstreams fixes from Lighthouse and Shiptesting modpack branch

### DIFF
--- a/code/datums/inventory_slots/slots/slot_belt.dm
+++ b/code/datums/inventory_slots/slots/slot_belt.dm
@@ -12,13 +12,16 @@
 /datum/inventory_slot/belt/can_equip_to_slot(var/mob/user, var/obj/item/prop, var/disable_warning)
 	. = ..()
 	if(.)
-		// If they have a uniform slot, they need a uniform to wear a belt.
+		// Things with this flag can be worn on the belt slot without a uniform.
+		if(prop.item_flags & ITEM_FLAG_IS_BELT)
+			return TRUE
+		// Otherwise, if they have a uniform slot, they need a uniform to wear a belt.
 		var/datum/inventory_slot/check_slot = user.get_inventory_slot_datum(slot_w_uniform_str)
-		if(check_slot && !check_slot.get_equipped_item())
-			if(!disable_warning)
-				to_chat(user, SPAN_WARNING("You need to be wearing something on your body before you can wear \the [prop]."))
-			return FALSE
-		return (prop.item_flags & ITEM_FLAG_IS_BELT)
+		if(check_slot?.get_equipped_item())
+			return TRUE
+		if(!disable_warning)
+			to_chat(user, SPAN_WARNING("You need to be wearing something on your body before you can wear \the [prop]."))
+		return FALSE
 
 /datum/inventory_slot/belt/get_examined_string(mob/owner, mob/user, distance, hideflags, decl/pronouns/pronouns)
 	if(_holding)

--- a/code/game/machinery/_machines_base/stock_parts/radio/transmitter.dm
+++ b/code/game/machinery/_machines_base/stock_parts/radio/transmitter.dm
@@ -4,6 +4,9 @@
 	icon_state = "transmitter"
 	var/range = 60  // Limits transmit range
 	var/latency = 2 // Delay between event and transmission; doesn't apply to transmit on tick
+	#ifdef UNIT_TEST
+	latency = 0 // this can slow down testing and cause random inconsistent failures
+	#endif
 	var/buffer
 
 /obj/item/stock_parts/radio/transmitter/proc/queue_transmit(list/data)
@@ -11,7 +14,10 @@
 		return
 	if(!buffer)
 		buffer = data
-		addtimer(CALLBACK(src, .proc/transmit), latency)
+		if(latency)
+			addtimer(CALLBACK(src, .proc/transmit), latency)
+		else
+			transmit()
 	else
 		buffer |= data
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -86,13 +86,12 @@
 	if(!c_tag)
 		var/area/A = get_area(src)
 		if(isturf(loc) && A)
-			for(var/obj/machinery/camera/C in A)
-				if(C == src) continue
-				if(C.number)
-					number = max(number, C.number+1)
-			c_tag = "[A.proper_name][number == 1 ? "" : " #[number]"]"
-		if(!c_tag)	// Add a default c_tag in case the camera has been placed in an invalid location or inside another object.
-			c_tag = "Security Camera - [random_id(/obj/machinery/camera, 100,999)]"
+			var/suffix = uniqueness_repository.Generate(/datum/uniqueness_generator/id_sequential, "c_tag [A.proper_name]", 1) // unlike sequential_id, starts at 1 instead of 100
+			if(suffix == 1)
+				suffix = null
+			c_tag = "[A.proper_name][suffix ? " [suffix]" : null]"
+		// Add a default c_tag in case the camera has been placed in an invalid location or inside another object.
+		c_tag ||= "Security Camera - [random_id(/obj/machinery/camera, 100,999)]"
 
 		invalidateCameraCache()
 	set_extension(src, /datum/extension/network_device/camera, null, null, null, TRUE, preset_channels, c_tag, cameranet_enabled, requires_connection)

--- a/code/game/objects/items/weapons/circuitboards/computer/holodeckcontrol.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/holodeckcontrol.dm
@@ -7,6 +7,9 @@
 	var/list/supported_programs
 	var/list/restricted_programs
 
+/obj/item/stock_parts/circuitboard/holodeckcontrol/get_buildable_types()
+	return typesof(/obj/machinery/computer/HolodeckControl)
+
 /obj/item/stock_parts/circuitboard/holodeckcontrol/construct(var/obj/machinery/computer/HolodeckControl/HC)
 	if (..(HC))
 		HC.supported_programs	= supported_programs.Copy()

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -47,7 +47,7 @@
 	var/created_size = 0
 	for(var/i = 1 to 200) //sanity loop limit
 		var/obj/item/cash_type = pick(3; /obj/item/cash/c1000, 4; /obj/item/cash/c500, 5; /obj/item/cash/c200)
-		var/bundle_size = initial(cash_type.w_class) / 2
+		var/bundle_size = initial(cash_type.w_class)
 		if(created_size + bundle_size <= storage_capacity)
 			created_size += bundle_size
 			. += cash_type

--- a/code/game/objects/structures/tables.dm
+++ b/code/game/objects/structures/tables.dm
@@ -667,23 +667,23 @@
 
 /obj/structure/table/holotable
 	icon_state = "holo_preview"
+	holographic = TRUE
 	color = COLOR_OFF_WHITE
 	material = /decl/material/solid/metal/aluminium/holographic
 	reinf_material = /decl/material/solid/metal/aluminium/holographic
 
 /obj/structure/table/holo_plastictable
 	icon_state = "holo_preview"
+	holographic = TRUE
 	color = COLOR_OFF_WHITE
 	material = /decl/material/solid/plastic/holographic
 	reinf_material = /decl/material/solid/plastic/holographic
 
 /obj/structure/table/holo_woodentable
+	holographic = TRUE
 	icon_state = "holo_preview"
-
-/obj/structure/table/holo_woodentable/Initialize()
 	material = /decl/material/solid/wood/holographic
 	reinf_material = /decl/material/solid/wood/holographic
-	. = ..()
 
 //wood wood wood
 /obj/structure/table/woodentable

--- a/code/modules/atmospherics/he_pipes.dm
+++ b/code/modules/atmospherics/he_pipes.dm
@@ -28,8 +28,8 @@
 	add_filter("glow",1, list(type="drop_shadow", x = 0, y = 0, offset = 0, size = 4))
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/set_dir(new_dir)
-	..()
-	initialize_directions_he = initialize_directions	// all directions are HE
+	. = ..()
+	initialize_directions_he = get_initialize_directions()	// all directions are HE
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/atmos_init()
 	atmos_initalized = TRUE

--- a/code/modules/economy/worth_cash.dm
+++ b/code/modules/economy/worth_cash.dm
@@ -152,6 +152,7 @@
 
 /obj/item/cash/c200
 	absolute_worth = 200
+	w_class = ITEM_SIZE_SMALL // so that the money freezer doesn't overflow bc this is a pile instead of single bill
 
 /obj/item/cash/c500
 	absolute_worth = 500

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -206,9 +206,15 @@
 		visible_message("[src] fades away as it shatters!")
 	qdel(src)
 
-/obj/structure/bed/chair/holochair/attackby(obj/item/W, mob/user)
-	if(IS_WRENCH(W))
-		to_chat(user, ("<span class='notice'>It's a holochair, you can't dismantle it!</span>"))
+/obj/structure/bed/holobed
+	tool_interaction_flags = 0
+	holographic = TRUE
+	material = /decl/material/solid/metal/aluminium/holographic
+
+/obj/structure/bed/chair/holochair
+	tool_interaction_flags = 0
+	holographic = TRUE
+	material = /decl/material/solid/metal/aluminium/holographic
 
 /obj/item/holo
 	damtype = PAIN

--- a/code/modules/materials/definitions/solids/materials_solid_ice.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_ice.dm
@@ -124,13 +124,13 @@
 
 //Little helper macro, since hydrates are all basically the same
 // DISPLAY_NAME is needed because of compounds with white spaces in their names
-#define DECLARE_HYDRATE_DNAME_PATH(PATH, NAME, DISPLAY_NAME)                \
-/decl/material/solid/ice/hydrate/##NAME/uid = "solid_hydrate_##NAME";       \
-/decl/material/solid/ice/hydrate/##NAME/Initialize(){                       \
-	name = "[##DISPLAY_NAME] hydrate";                                      \
-	heating_products = list(PATH = 0.2, /decl/material/liquid/water = 0.8); \
-	. = ..();                                                               \
-}                                                                           \
+#define DECLARE_HYDRATE_DNAME_PATH(PATH, NAME, DISPLAY_NAME)               \
+/decl/material/solid/ice/hydrate/##NAME/uid = "solid_hydrate_" + #NAME;    \
+/decl/material/solid/ice/hydrate/##NAME/name = #DISPLAY_NAME + " hydrate"; \
+/decl/material/solid/ice/hydrate/##NAME/heating_products = list(           \
+	PATH = 0.2,                                                            \
+	/decl/material/liquid/water = 0.8                                      \
+);                                                                         \
 /decl/material/solid/ice/hydrate/##NAME
 
 #define DECLARE_HYDRATE_DNAME(NAME, DISPLAY_NAME) DECLARE_HYDRATE_DNAME_PATH(/decl/material/gas/##NAME, NAME, DISPLAY_NAME)

--- a/code/modules/multiz/turf_mimic_edge.dm
+++ b/code/modules/multiz/turf_mimic_edge.dm
@@ -69,7 +69,7 @@
 	return
 
 /turf/simulated/mimic_edge/get_vis_contents_to_add()
-	. = shared_mimic_edge_get_add_vis_contents(src, get_mimic_turf(), ..())
+	. = shared_mimic_edge_get_add_vis_contents(src, get_mimic_turf(), list())
 
 /turf/simulated/mimic_edge/proc/get_mimic_turf()
 	return mimic_x && mimic_y && mimic_z && locate(mimic_x, mimic_y, mimic_z)
@@ -135,7 +135,7 @@
 	return
 
 /turf/unsimulated/mimic_edge/get_vis_contents_to_add()
-	. = shared_mimic_edge_get_add_vis_contents(src, get_mimic_turf(), ..())
+	. = shared_mimic_edge_get_add_vis_contents(src, get_mimic_turf(), list())
 
 /turf/unsimulated/mimic_edge/proc/get_mimic_turf()
 	return mimic_x && mimic_y && mimic_z && locate(mimic_x, mimic_y, mimic_z)
@@ -201,7 +201,7 @@
 	return
 
 /turf/exterior/mimic_edge/get_vis_contents_to_add()
-	. = shared_mimic_edge_get_add_vis_contents(src, get_mimic_turf(), ..())
+	. = shared_mimic_edge_get_add_vis_contents(src, get_mimic_turf(), list())
 
 /turf/exterior/mimic_edge/proc/get_mimic_turf()
 	return mimic_x && mimic_y && mimic_z && locate(mimic_x, mimic_y, mimic_z)

--- a/code/modules/recycling/disposalholder.dm
+++ b/code/modules/recycling/disposalholder.dm
@@ -9,7 +9,7 @@
 	var/datum/gas_mixture/gas = null	// gas used to flush, will appear at exit point
 	var/active = 0	// true if the holder is moving, otherwise inactive
 	dir = 0
-	var/count = 2048	//*** can travel 2048 steps before going inactive (in case of loops)
+	var/count = 4096 //*** can travel 4096 steps before going inactive (in case of loops)
 	var/destinationTag = "" // changes if contains a delivery container
 	var/tomail = 0 //changes if contains wrapped package
 	var/hasmob = 0 //If it contains a mob

--- a/code/unit_tests/equipment_tests.dm
+++ b/code/unit_tests/equipment_tests.dm
@@ -116,7 +116,7 @@
 		"[slot_gloves_str]"    = /obj/item/clothing/gloves/rainbow,
 		"[slot_l_ear_str]"     = /obj/item/clothing/head/hairflower,
 		"[slot_r_ear_str]"     = /obj/item/clothing/head/hairflower,
-		"[slot_belt_str]"      = /obj/item/storage/belt/utility,
+		"[slot_belt_str]"      = /obj/item/storage/ore, // note: this should be an item without ITEM_FLAG_IS_BELT
 		"[slot_wear_suit_str]" = /obj/item/clothing/suit/chickensuit
 	)
 

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -419,7 +419,7 @@
 			pass = FALSE
 
 	if(pass)
-		pass("Have cameras have the c_tag set.")
+		pass("All cameras have the c_tag set.")
 	else
 		fail("One or more cameras do not have the c_tag set.")
 

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -719,6 +719,9 @@
 	var/datum/unit_test/networked_disposals_shall_deliver_tagged_packages/test
 	speed = 100
 
+/obj/structure/disposalholder/unit_test/merge()
+	return FALSE
+
 /obj/structure/disposalholder/unit_test/Destroy()
 	test.package_delivered(src)
 	. = ..()

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -78,10 +78,14 @@
 			continue
 		if(!isPlayerLevel(A.z))
 			continue
-		var/obj/machinery/alarm/alarm = locate() in A // Only test areas with functional alarms
-		if(!alarm)
-			continue
-		if(alarm.stat & (NOPOWER | BROKEN))
+		// Only test areas with functional alarms
+		var/obj/machinery/alarm/found_alarm
+		for (var/obj/machinery/alarm/alarm in A)
+			if(alarm.inoperable()) // must have at least one functional alarm
+				continue
+			found_alarm = alarm
+
+		if(!found_alarm)
 			continue
 
 		//Make a list of devices that are being controlled by their air alarms
@@ -97,17 +101,37 @@
 		for(var/tag in vents_in_area) // The point of this test is that while the names list is registered at init, the info is transmitted by radio.
 			if(!A.air_vent_info[tag])
 				var/obj/machinery/atmospherics/unary/vent_pump/V = vents_in_area[tag]
-				var/logtext = "Vent [A.air_vent_names[tag]] ([V.x], [V.y], [V.z]) with id_tag [tag] did not update the air alarm in area [A]."
-				if(!V.operable())
+				var/logtext = "Vent [A.air_vent_names[tag]] ([V.x], [V.y], [V.z]) with id_tag [tag] did not update [log_info_line(found_alarm)] in area [A]."
+				if(V.inoperable())
 					logtext = "[logtext] The vent was not functional."
+				var/alarm_dist = get_dist(found_alarm, V)
+				if(alarm_dist > 60)
+					logtext += " The vent may be out of transmission range (max 60, was [alarm_dist])."
+				var/V_freq
+				for(var/obj/item/stock_parts/radio/radio_component in V.component_parts)
+					V_freq ||= radio_component.frequency
+				if(isnull(V_freq))
+					logtext += " The vent had no frequency set."
+				else if(V_freq != found_alarm.frequency)
+					logtext += " Frequencies did not match (alarm: [found_alarm.frequency], vent: [V_freq])."
 				log_bad(logtext)
 				failed = TRUE
 		for(var/tag in scrubbers_in_area)
 			if(!A.air_scrub_info[tag])
 				var/obj/machinery/atmospherics/unary/vent_scrubber/V = scrubbers_in_area[tag]
-				var/logtext = "Scrubber [A.air_scrub_names[tag]] ([V.x], [V.y], [V.z]) with id_tag [tag] did not update the air alarm in area [A]."
-				if(!V.operable())
+				var/logtext = "Scrubber [A.air_scrub_names[tag]] ([V.x], [V.y], [V.z]) with id_tag [tag] did not update [log_info_line(found_alarm)] in area [A]."
+				if(V.inoperable())
 					logtext = "[logtext] The scrubber was not functional."
+				var/alarm_dist = get_dist(found_alarm, V)
+				if(alarm_dist > 60)
+					logtext += " The scrubber may be out of transmission range (max 60, was [alarm_dist])."
+				var/V_freq
+				for(var/obj/item/stock_parts/radio/radio_component in V.component_parts)
+					V_freq ||= radio_component.frequency
+				if(isnull(V_freq))
+					logtext += " The scrubber had no frequency set."
+				else if(V_freq != found_alarm.frequency)
+					logtext += " Frequencies did not match (alarm: [found_alarm.frequency], scrubber: [V_freq])."
 				log_bad(logtext)
 				failed = TRUE
 

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -686,6 +686,8 @@
 			continue
 		if(is_type_in_list(sort, exempt_junctions))
 			continue
+		if(sort.sort_type in global.using_map.disconnected_disposals_tags)
+			continue
 		var/obj/machinery/disposal/bin = get_bin_from_junction(sort)
 		if(!bin)
 			log_bad("Junction with tag [sort.sort_type] at ([sort.x], [sort.y], [sort.z]) could not find disposal.")

--- a/maps/~mapsystem/maps_unit_testing.dm
+++ b/maps/~mapsystem/maps_unit_testing.dm
@@ -37,3 +37,6 @@
 	)
 
 	var/list/area_purity_test_exempt_areas = list()
+
+	/// A list of disposals tags (sort_type var) that aren't expected to have outputs.
+	var/list/disconnected_disposals_tags = list()

--- a/mods/content/xenobiology/slime/_slime.dm
+++ b/mods/content/xenobiology/slime/_slime.dm
@@ -213,9 +213,9 @@
 			adjust_friendship(user, rand(2,3))
 		return TRUE
 
-	if(feeding_on)
-		var/prey = feeding_on
-		if(feeding_on == user)
+	var/prey = feeding_on?.resolve()
+	if(prey)
+		if(prey == user)
 			if(prob(60))
 				visible_message(SPAN_DANGER("\The [user] fails to escape \the [src]!"))
 			else
@@ -223,12 +223,12 @@
 				set_feeding_on()
 		else
 			if(prob(30))
-				visible_message(SPAN_DANGER("\The [user] attempts to wrestle \the [src] off \the [feeding_on]!"))
+				visible_message(SPAN_DANGER("\The [user] attempts to wrestle \the [src] off \the [prey]!"))
 			else
-				visible_message(SPAN_DANGER("\The [user] manages to wrestle \the [src] off \the [feeding_on]!"))
+				visible_message(SPAN_DANGER("\The [user] manages to wrestle \the [src] off \the [prey]!"))
 				set_feeding_on()
 
-		if(prey != feeding_on)
+		if(prey != feeding_on?.resolve())
 			playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 			SET_STATUS_MAX(src, STAT_CONFUSE, 2)
 			step_away(src, user)
@@ -335,6 +335,7 @@
 
 /mob/living/slime/xenobio_scan_results()
 	var/decl/slime_colour/slime_data = GET_DECL(slime_type)
+	. = list()
 	. += "Slime scan result for \the [src]:"
 	. += "[slime_data.name] [is_adult ? "adult" : "baby"] slime"
 	. += "Nutrition:\t[nutrition]/[get_max_nutrition()]"
@@ -360,7 +361,7 @@
 
 		var/list/mutationTexts = list("[slime_data.name] ([100 - mutation_chance]%)")
 		for(var/i in mutationChances)
-			mutationTexts += "[i] ([mutationChances[i]]%)"
+			mutationTexts += "[GET_DECL(i)] ([mutationChances[i]]%)"
 
 		. += "Possible colours on splitting:\t[english_list(mutationTexts)]"
 


### PR DESCRIPTION
## Description of changes
- Fixes the auto-generation of hydrate UIDs, which just outright did not work (that's why the hydrate UIDs are manually set).
- Fixes/expands the disposals connection unit test
  - Adds exceptions to disposals connection map unit tests, since we don't have down-facing disposals outlets.
  - Stops unit test disposalholders from merging if they stall, so it's clearer that they've stalled.
  - Doubles the step limit for disposalholders, since some maps I was testing were too large (!!!) for the current one.
- Prevents the vault cash freezer closet from overfilling by correcting the w_class calculation.
- Adds more diagnostics to the air alarm connection unit test, to prevent more Desperado-esque frustration.
- Disables transmitter latency for unit testing, which should prevent the Desperado issue from ever happening again even with a boatload of timers.
- Makes camera tag autogeneration use sequential_id instead of a bespoke system.
- Allows holodeck control circuitboards to create subtypes of holodeck control computers, useful for maps with multiple holodecks.
- Makes heat exchange pipes' set_dir override return parent. Also makes it use the general initialize_directions helper directly.
- Fixes the slime scanner and slime grappling messages.
- Fixes edge mimic turfs doubling their air/gas overlay.
- Fixes not being able to wear PDAs (and other items) on your belt slot.

## Why and what will this PR improve
Fixes a bunch of issues I caught/solved downstream.