### PR TITLE
Modpack config handling

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -838,7 +838,9 @@ var/global/list/gamemode_cache = list()
 					config.show_typing_indicator_for_whispers = TRUE
 
 				else
-					log_misc("Unknown setting in configuration: '[name]'")
+					//crappy hook to get modpacks to load any extra config
+					if(!load_mod_config(name, value))
+						log_misc("Unknown setting in configuration: '[name]'")
 
 		else if(type == "game_options")
 			if(!value)
@@ -945,7 +947,9 @@ var/global/list/gamemode_cache = list()
 					config.disable_daycycle = TRUE
 
 				else
-					log_misc("Unknown setting in configuration: '[name]'")
+					//crappy hook to get modpacks to load any extra config
+					if(!load_mod_config(name, value))
+						log_misc("Unknown setting in game_options configuration: '[name]'")
 
 	fps = round(fps)
 	if(fps <= 0)
@@ -989,7 +993,9 @@ var/global/list/gamemode_cache = list()
 			if ("password")
 				sqlpass = value
 			else
-				log_misc("Unknown setting in configuration: '[name]'")
+				//crappy hook to get modpacks to load any extra config
+				if(!load_mod_dbconfig(name, value))
+					log_misc("Unknown setting in DB configuration: '[name]'")
 
 /datum/configuration/proc/pick_mode(mode_name)
 	// I wish I didn't have to instance the game modes in order to look up
@@ -1011,3 +1017,19 @@ var/global/list/gamemode_cache = list()
 	var/event_info = safe_file2text(filename, FALSE)
 	if(event_info)
 		custom_event_msg = event_info
+
+///Hook stub for loading modpack specific configs. Just override in modpack.
+/datum/configuration/proc/load_mod_config(var/name, var/value)
+	//Force it to run parents overrides, so other modpacks don't just completely break config loading for one another
+	SHOULD_CALL_PARENT(TRUE)
+	return
+
+///Hook stub for loading modpack specific game_options. Just override in modpack.
+/datum/configuration/proc/load_mod_game_options(var/name, var/value)
+	SHOULD_CALL_PARENT(TRUE)
+	return
+
+///Hook stub for loading modpack specific dbconfig. Just override in modpack.
+/datum/configuration/proc/load_mod_dbconfig(var/name, var/value)
+	SHOULD_CALL_PARENT(TRUE)
+	return


### PR DESCRIPTION
## Description of changes
Ported this from a PR I was working on downstream to get configs that's persistence specific.
Added 3 hook procs stubs in /datum/configuration which get called in the huge switches for loading config options from file. Those can be overridden in modpacks to handle any extra config options specific to a modpack.

## Why and what will this PR improve
Adding modpack specific config options normally means you have to modify the core files to get them parsed. But this way you can just define all your new config options in your modpack along with the code parsing them.
