### PR TITLE
Fixes to weather system.

### DIFF
--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -80,10 +80,6 @@ SUBSYSTEM_DEF(mapping)
 	if (new_maxy > world.maxy)
 		world.maxy = new_maxy
 
-	// Generate turbolifts.
-	for(var/obj/abstract/turbolift_spawner/turbolift as anything in turbolifts_to_initialize)
-		turbolift.build_turbolift()
-
 	// Populate overmap.
 	if(length(global.using_map.overmap_ids))
 		for(var/overmap_id in global.using_map.overmap_ids)
@@ -106,6 +102,10 @@ SUBSYSTEM_DEF(mapping)
 			level = new /datum/level_data/space(z)
 			PRINT_STACK_TRACE("Missing z-level data object for z[num2text(z)]!")
 		level.setup_level_data()
+
+	// Generate turbolifts.
+	for(var/obj/abstract/turbolift_spawner/turbolift as anything in turbolifts_to_initialize)
+		turbolift.build_turbolift()
 
 	. = ..()
 

--- a/code/controllers/subsystems/weather.dm
+++ b/code/controllers/subsystems/weather.dm
@@ -47,7 +47,7 @@ SUBSYSTEM_DEF(weather)
 /datum/controller/subsystem/weather/proc/register_weather_system(var/obj/abstract/weather_system/WS)
 	if(weather_by_z[WS.z])
 		CRASH("Trying to register another weather system on the same z-level([WS.z]) as an existing one!")
-	LAZYDISTINCTADD(weather_systems, WS)
+	weather_systems |= WS
 
 	//Mark all affected z-levels
 	var/list/affected = SSmapping.get_connected_levels(WS.z)
@@ -62,10 +62,4 @@ SUBSYSTEM_DEF(weather)
 	for(var/Z = 1 to length(weather_by_z))
 		if(weather_by_z[Z] == WS)
 			weather_by_z[Z] = null
-	LAZYREMOVE(weather_systems, WS)
-
-///Returns the weather obj for a given z-level if it exists
-/datum/controller/subsystem/weather/proc/get_weather_for_level(var/z_level)
-	if(z_level > length(weather_by_z))
-		return null
-	return weather_by_z[z_level]
+	weather_systems -= WS

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -401,7 +401,7 @@
 /turf/proc/update_weather(var/obj/abstract/weather_system/new_weather, var/force_update_below = FALSE)
 
 	if(isnull(new_weather))
-		new_weather = SSweather.get_weather_for_level(z)
+		new_weather = SSweather.weather_by_z[z]
 
 	// We have a weather system and we are exposed to it; update our vis contents.
 	if(istype(new_weather) && is_outside())

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -144,7 +144,7 @@
 	// If we're standing in the rain, use the turf weather.
 	. = istype(actual_loc) && actual_loc.weather
 	if(!.) // If we're under or inside shelter, use the z-level rain (for ambience)
-		. = SSweather.get_weather_for_level(my_turf.z)
+		. = SSweather.weather_by_z[my_turf.z]
 
 /mob/living/proc/handle_environment(var/datum/gas_mixture/environment)
 

--- a/code/modules/weather/weather_debug.dm
+++ b/code/modules/weather/weather_debug.dm
@@ -11,7 +11,7 @@
 		to_chat(usr, SPAN_WARNING("You need to have a turf to use this verb."))
 		return
 
-	var/obj/abstract/weather_system/weather = T.weather || SSweather.get_weather_for_level(T.z)
+	var/obj/abstract/weather_system/weather = T.weather || SSweather.weather_by_z[T.z]
 	if(!weather)
 		to_chat(usr, SPAN_WARNING("This z-level does not have weather."))
 		return
@@ -28,15 +28,17 @@
 		return
 
 	var/turf/T = get_turf(usr)
+	while(T && HasAbove(T.z))
+		T = GetAbove(T)
 	if(!istype(T))
 		to_chat(usr, SPAN_WARNING("You need to have a turf to use this verb."))
 		return
 
-	var/obj/abstract/weather_system/weather = T.weather || SSweather.get_weather_for_level(T.z)
+	var/obj/abstract/weather_system/weather = T.weather || SSweather.weather_by_z[T.z]
 	if(weather)
 		to_chat(usr, SPAN_WARNING("This z-level already has weather."))
 		return
-	new /obj/abstract/weather_system(null, T.z)
+	SSweather.setup_weather_system(SSmapping.levels_by_z[T.z])
 	to_chat(usr, SPAN_NOTICE("Weather created for z[T.z]."))
 
 /datum/admins/proc/force_weather_state()
@@ -52,13 +54,13 @@
 		to_chat(usr, SPAN_WARNING("You need to have a turf to use this verb."))
 		return
 
-	var/obj/abstract/weather_system/weather = T.weather || SSweather.get_weather_for_level(T.z)
+	var/obj/abstract/weather_system/weather = T.weather || SSweather.weather_by_z[T.z]
 	if(!weather)
 		to_chat(usr, SPAN_WARNING("This z-level has no weather. Use <b>Initialize Weather For Level</b> if you want to create it."))
 		return
 
 	var/use_state = input(usr, "Which state do you wish to use?", "Target State") as null|anything in decls_repository.get_decl_paths_of_subtype(/decl/state/weather)
-	if(!use_state || weather != (T.weather || SSweather.get_weather_for_level(T.z)))
+	if(!use_state || weather != (T.weather || SSweather.weather_by_z[T.z]))
 		return
 	weather.weather_system.set_state(use_state)
 	var/decl/state/weather/weather_state = GET_DECL(use_state)

--- a/code/modules/weather/weather_init.dm
+++ b/code/modules/weather/weather_init.dm
@@ -26,12 +26,13 @@ INITIALIZE_IMMEDIATE(/obj/abstract/weather_system)
 // Start the weather effects from the highest point; they will propagate downwards during update.
 /obj/abstract/weather_system/proc/init_weather()
 	// Track all z-levels.
-	var/highest_z = affecting_zs[1]
-	for(var/tz in affecting_zs)
-		if(tz > highest_z)
-			highest_z = tz
-
-	// Update turf weather.
-	for(var/turf/T as anything in block(locate(1, 1, highest_z), locate(world.maxx, world.maxy, highest_z)))
-		T.update_weather(src)
-		CHECK_TICK
+	for(var/highest_z in affecting_zs)
+		var/turfcount = 0
+		if(HasAbove(highest_z))
+			continue
+		// Update turf weather.
+		for(var/turf/T as anything in block(locate(1, 1, highest_z), locate(world.maxx, world.maxy, highest_z)))
+			T.update_weather(src)
+			turfcount++
+			CHECK_TICK
+		log_debug("Initialized weather for [turfcount] turf\s from z[highest_z].")


### PR DESCRIPTION
- De-lazied `weather_systems` as the subsystem expects to copy it and was causing a runtime.
- Replaced a helper with direct list access to `weather_by_z` as the list is reindexed by SSmapping and should always be long enough.
- Fixed debug weather creation verb.
- Fixed edge case where lateral z-levels were messing with `init_weather()`.