### PR TITLE
Moves setup_level_bounds() arg to level data datum.

### DIFF
--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -144,6 +144,9 @@
 	///This is set to prevent spamming the log when a turf has tried to grab our strata before we've been initialized
 	var/tmp/_has_warned_uninitialized_strata = FALSE
 
+	///Determines if edge turfs should be centered on the map dimensions.
+	var/origin_is_world_center = TRUE
+
 /datum/level_data/New(var/_z_level, var/defer_level_setup = FALSE)
 	. = ..()
 	level_z = _z_level
@@ -209,11 +212,10 @@
 	_level_setup_completed = TRUE
 
 ///Calculate the bounds of the level, the border area, and the inner accessible area.
-/// * origin_is_world_center : An arg to clarify how level bounds work, and allow some control.
 ///   Basically, by default levels are assumed to be loaded relative to the world center, so if they're smaller than the world
 ///   they get their origin offset so they're in the middle of the world. By default templates are always loaded at origin 1,1.
 ///   so that's useful to know and have control over!
-/datum/level_data/proc/setup_level_bounds(var/origin_is_world_center = TRUE)
+/datum/level_data/proc/setup_level_bounds()
 	//Get the width/height we got for the level and the edges
 	level_max_width  = level_max_width  ? level_max_width  : world.maxx
 	level_max_height = level_max_height ? level_max_height : world.maxy


### PR DESCRIPTION
See title. Required to allow compiled maps with borders to not get completely mangled.