### PR TITLE
Exterior turfs and lighting blend across lateral z-transitions.

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -462,6 +462,10 @@ Turf and target are seperate in case you want to teleport some distance from a t
 			cant_pass = 1
 	return cant_pass
 
+/proc/get_step_resolving_mimic(var/atom/source, var/direction)
+	var/turf/turf = get_step(get_turf(source), direction)
+	return turf?.resolve_to_actual_turf()
+
 /proc/get_step_towards2(var/atom/ref , var/atom/trg)
 	var/base_dir = get_dir(ref, get_step_towards(ref,trg))
 	var/turf/temp = get_step_towards(ref,trg)

--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -50,11 +50,13 @@
 	if(mapload)
 		update_icon()
 	else
-		for (var/turf/T in RANGE_TURFS(src, 1))
-			if(TICK_CHECK) // not CHECK_TICK -- only queue if the server is overloaded
-				T.queue_icon_update()
-			else
-				T.update_icon()
+		for(var/direction in global.alldirs)
+			var/turf/target_turf = get_step_resolving_mimic(src, direction)
+			if(istype(target_turf))
+				if(TICK_CHECK) // not CHECK_TICK -- only queue if the server is overloaded
+					target_turf.queue_icon_update()
+				else
+					target_turf.update_icon()
 
 /turf/exterior/is_floor()
 	return !density && !is_open()
@@ -106,8 +108,8 @@
 
 	var/neighbors = 0
 	for(var/direction in global.cardinal)
-		var/turf/exterior/turf_to_check = get_step(src,direction)
-		if(!turf_to_check || turf_to_check.density)
+		var/turf/exterior/turf_to_check = get_step_resolving_mimic(src, direction)
+		if(!istype(turf_to_check) || turf_to_check.density)
 			continue
 		if(istype(turf_to_check, type))
 			neighbors |= direction
@@ -128,7 +130,7 @@
 
 	if(icon_has_corners)
 		for(var/direction in global.cornerdirs)
-			var/turf/exterior/turf_to_check = get_step(src,direction)
+			var/turf/exterior/turf_to_check = get_step_resolving_mimic(src, direction)
 			if(!isturf(turf_to_check) || turf_to_check.density || istype(turf_to_check, type))
 				continue
 

--- a/code/game/turfs/exterior/exterior_wall.dm
+++ b/code/game/turfs/exterior/exterior_wall.dm
@@ -94,7 +94,7 @@ var/global/list/natural_walls = list()
 	for(var/trydir in global.cardinal)
 		if(!prob(reinf_material.ore_spread_chance))
 			continue
-		var/turf/exterior/wall/target_turf = get_step(src, trydir)
+		var/turf/exterior/wall/target_turf = get_step_resolving_mimic(src, trydir)
 		if(!istype(target_turf) || !isnull(target_turf.reinf_material))
 			continue
 		target_turf.set_material(target_turf.material, reinf_material)
@@ -164,8 +164,10 @@ var/global/list/natural_walls = list()
 		if(M)
 			ore_overlay.transform = M
 	if(update_neighbors)
-		for(var/turf/exterior/T in RANGE_TURFS(src, 1))
-			T.update_icon()
+		for(var/direction in global.alldirs)
+			var/turf/exterior/target_turf = get_step_resolving_mimic(src, direction)
+			if(istype(target_turf))
+				target_turf.update_icon()
 	else
 		update_icon()
 
@@ -177,10 +179,9 @@ var/global/list/natural_walls = list()
 		return
 
 	var/list/wall_connections = list()
-	for(var/stepdir in global.alldirs)
-		var/turf/exterior/wall/T = get_step(src, stepdir)
-		if(istype(T))
-			wall_connections += get_dir(src, T)
+	for(var/direction in global.alldirs)
+		if(istype(get_step_resolving_mimic(src, direction), /turf/exterior/wall))
+			wall_connections += direction
 	wall_connections = dirs_to_corner_states(wall_connections)
 
 	var/material_icon_base = material.icon_base_natural || 'icons/turf/walls/natural.dmi'

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -541,3 +541,6 @@
 
 /turf/proc/is_defiled()
 	return (locate(/obj/effect/narsie_footstep) in src)
+
+/turf/proc/resolve_to_actual_turf()
+	return src

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -66,18 +66,18 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 
 	var/has_ambience = FALSE
 
-	t1 = new_turf
-	z = new_turf.z
+	t1 = new_turf.resolve_to_actual_turf()
+	z = t1.z
 	t1i = oi
 
-	if (new_turf.ambient_light)
+	if (t1.ambient_light)
 		has_ambience = TRUE
 
 	var/vertical   = diagonal & ~(diagonal - 1) // The horizontal directions (4 and 8) are bigger than the vertical ones (1 and 2), so we can reliably say the lsb is the horizontal direction.
 	var/horizontal = diagonal & ~vertical       // Now that we know the horizontal one we can get the vertical one.
 
-	x = new_turf.x + (horizontal == EAST  ? 0.5 : -0.5)
-	y = new_turf.y + (vertical   == NORTH ? 0.5 : -0.5)
+	x = t1.x + (horizontal == EAST  ? 0.5 : -0.5)
+	y = t1.y + (vertical   == NORTH ? 0.5 : -0.5)
 
 	// My initial plan was to make this loop through a list of all the dirs (horizontal, vertical, diagonal).
 	// Issue being that the only way I could think of doing it was very messy, slow and honestly overengineered.
@@ -86,7 +86,7 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 
 
 	// Diagonal one is easy.
-	T = get_step(new_turf, diagonal)
+	T = get_step_resolving_mimic(t1, diagonal)
 	if (T) // In case we're on the map's border.
 		if (!T.corners)
 			T.corners = new(4)
@@ -98,7 +98,7 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 			has_ambience = TRUE
 
 	// Now the horizontal one.
-	T = get_step(new_turf, horizontal)
+	T = get_step_resolving_mimic(t1, horizontal)
 	if (T) // Ditto.
 		if (!T.corners)
 			T.corners = new(4)
@@ -110,7 +110,7 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 			has_ambience = TRUE
 
 	// And finally the vertical one.
-	T = get_step(new_turf, vertical)
+	T = get_step_resolving_mimic(t1, vertical)
 	if (T)
 		if (!T.corners)
 			T.corners = new(4)

--- a/code/modules/multiz/basic.dm
+++ b/code/modules/multiz/basic.dm
@@ -6,12 +6,14 @@ var/global/list/z_levels = list() // Each Z-level is associated with the relevan
 
 // Thankfully, no bitwise magic is needed here.
 /proc/GetAbove(var/atom/atom)
+	RETURN_TYPE(/turf)
 	var/turf/turf = get_turf(atom)
 	if(!turf)
 		return null
 	return HasAbove(turf.z) ? get_step(turf, UP) : null
 
 /proc/GetBelow(var/atom/atom)
+	RETURN_TYPE(/turf)
 	var/turf/turf = get_turf(atom)
 	if(!turf)
 		return null
@@ -24,3 +26,11 @@ var/global/list/z_levels = list() // Each Z-level is associated with the relevan
 		. = GetBelow(ref)
 	else
 		. = get_step(ref, dir)
+
+/proc/get_zstep_resolving_mimic(ref, dir)
+	if(dir == UP)
+		. = GetAbove(ref)?.resolve_to_actual_turf()
+	else if (dir == DOWN)
+		. = GetBelow(ref)?.resolve_to_actual_turf()
+	else
+		. = get_step_resolving_mimic(ref, dir)

--- a/code/modules/multiz/turf_mimic_edge.dm
+++ b/code/modules/multiz/turf_mimic_edge.dm
@@ -68,6 +68,9 @@
 		if(drop_turf)
 			O.forceMove(drop_turf)
 
+/turf/simulated/mimic_edge/resolve_to_actual_turf()
+	return get_mimic_turf()
+
 //Properly install itself, and allow overriding how the target turf is picked
 /turf/simulated/mimic_edge/proc/setup_mimic()
 	return
@@ -140,6 +143,9 @@
 		var/turf/drop_turf = get_mimic_turf()
 		if(drop_turf)
 			O.forceMove(drop_turf)
+
+/turf/unsimulated/mimic_edge/resolve_to_actual_turf()
+	return get_mimic_turf()
 
 //Properly install itself, and allow overriding how the target turf is picked
 /turf/unsimulated/mimic_edge/proc/setup_mimic()


### PR DESCRIPTION
## Description of changes
- Adds new helper procs for getting a step while also resolving to an actual turf, in the case of mimicked turfs.
- Plugs these procs into corner creation and exterior turf icon updates.

Would very much like @Lohikar's input on this one as I am fairly sure this will break things I don't understand. There are a couple of [visual artefacts that may be related](https://github.com/NebulaSS13/Nebula/assets/2468979/b1ff2e66-0d7a-48ac-97ea-37f7e763fdc7).

## Why and what will this PR improve
[Before.](https://cdn.discordapp.com/attachments/697198052183769089/1158291884721062019/image.png?ex=651bb6e1&is=651a6561&hm=15578e3db248aabe1f12842b58f1e941a4225a89831f527ed3742250d395398e&)
[After.](https://cdn.discordapp.com/attachments/697198052183769089/1158309812753420328/image.png?ex=651bc793&is=651a7613&hm=a83a7a2888d2200ae1a2a967d6deba65d05b4f632aefbef9d6141d7ab3bfcf70&)

## Authorship
Myself.

## Changelog
:cl:
tweak: Exterior turfs and lighting blend across z-level transitions now.
/:cl:
