### PR TITLE
Fixing bodyscanner display connection logic

### DIFF
--- a/code/game/machinery/bodyscanner_console.dm
+++ b/code/game/machinery/bodyscanner_console.dm
@@ -9,7 +9,6 @@
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
-	var/list/display_tags = list()
 	var/list/connected_displays = list()
 	var/list/data = list()
 
@@ -36,7 +35,7 @@
 
 /obj/machinery/body_scanconsole/proc/FindDisplays()
 	for(var/obj/machinery/body_scan_display/D in SSmachines.machinery)
-		if(D.tag in display_tags)
+		if(D.id_tag == connected.id_tag)
 			connected_displays += D
 			events_repository.register(/decl/observ/destroyed, D, src, .proc/remove_display)
 	return !!connected_displays.len

--- a/code/game/machinery/bodyscanner_display.dm
+++ b/code/game/machinery/bodyscanner_display.dm
@@ -19,18 +19,25 @@
 /obj/machinery/body_scan_display/proc/add_new_scan(var/list/scan)
 	bodyscans += list(scan.Copy())
 	updateUsrDialog()
+	queue_icon_update()
 
 /obj/machinery/body_scan_display/on_update_icon()
 	. = ..()
 	cut_overlays()
 	if(!(stat & (BROKEN|NOPOWER)))
-		add_overlay("operating")
+		if (selected != 0)
+			add_overlay("operating")
+		else if (bodyscans.len > 0)
+			add_overlay("menu")
+		else
+			add_overlay("standby")
 
 /obj/machinery/body_scan_display/OnTopic(mob/user, href_list)
 	if(href_list["view"])
 		var/selection = text2num(href_list["view"])
 		if(is_valid_index(selection, bodyscans))
 			selected = selection
+			queue_icon_update()
 			return TOPIC_REFRESH
 		return TOPIC_HANDLED
 	if(href_list["delete"])
@@ -39,6 +46,7 @@
 			return TOPIC_HANDLED
 		if(selected == selection)
 			selected = 0
+			queue_icon_update()
 		else if(selected > selection)
 			selected--
 		bodyscans -= list(bodyscans[selection])


### PR DESCRIPTION
## Description of changes
For some reason bodyscanner used `tag` for connecting to displays instead of `id_tag` used on a map downstream. Fixed that and added calls for icon updates to redraw the display overlays.

## Why and what will this PR improve
Now the bodyscanner console would be able to connect to bodyscanner display, which in turn will light up according to its current state.

## Authorship
Myself.

## Changelog
:cl:
bugfix: fixed bodyscanner display connection
/:cl: