### PR TITLE
Disable belt uniform check for species without it

### DIFF
--- a/code/datums/inventory_slots/slots/slot_belt.dm
+++ b/code/datums/inventory_slots/slots/slot_belt.dm
@@ -18,7 +18,7 @@
 			return TRUE
 		// Otherwise, if they have a uniform slot, they need a uniform to wear a belt.
 		var/datum/inventory_slot/check_slot = user.get_inventory_slot_datum(slot_w_uniform_str)
-		if(check_slot?.get_equipped_item())
+		if(!check_slot || check_slot.get_equipped_item())
 			return TRUE
 		if(!disable_warning)
 			to_chat(user, SPAN_WARNING("You need to be wearing something on your body before you can wear \the [prop]."))


### PR DESCRIPTION
## Description of changes
If a uniform slot doesn't exist, can_equip_to_slot now returns true for the belt slot.

## Why and what will this PR improve
Species without a uniform slot can now equip belt slot items even without `ITEM_FLAG_IS_BELT` without a uniform on.
I'm not actually sure if this is a good thing or not. Maybe it should check a variable on bodytype/species/something instead of just unilaterally returning true?