### PR TITLE
Fixes flooded turf overlay.

### DIFF
--- a/code/game/objects/effects/fluids.dm
+++ b/code/game/objects/effects/fluids.dm
@@ -126,14 +126,19 @@
 	fluid_initial = 10
 
 // Permaflood overlay.
-var/global/obj/abstract/flood/flood_object = new
-/obj/abstract/flood
-	layer = DEEP_FLUID_LAYER
-	color = COLOR_LIQUID_WATER
+var/global/obj/effect/flood/flood_object = new
+/obj/effect/flood
+	name          = ""
 	icon = 'icons/effects/liquids.dmi'
 	icon_state = "ocean"
+	layer = DEEP_FLUID_LAYER
+	color = COLOR_LIQUID_WATER
 	alpha = 140
 	invisibility = 0
+	simulated     = FALSE
+	density       = FALSE
+	anchored      = TRUE
+	unacidable    = TRUE
 
 /obj/effect/fluid/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	. = ..()

--- a/code/unit_tests/del_the_world.dm
+++ b/code/unit_tests/del_the_world.dm
@@ -26,7 +26,7 @@
 		// Fluid system related; causes issues with atoms spawned on the turf.
 		/obj/abstract/fluid_mapped,
 		/obj/effect/fluid,
-		/obj/abstract/flood,
+		/obj/effect/flood,
 		// Not valid when spawned manually.
 		/obj/effect/overmap,
 		/obj/effect/shuttle_landmark,


### PR DESCRIPTION
Converts /obj/abstract/flood back to /obj/effect/flood as abstract objs set alpha to 255 in Initialize() as doing it in the def is needed for them to show up on the map (whew).