### PR TITLE
Psionics tweaks.

### DIFF
--- a/mods/content/psionics/system/psionics/complexus/complexus_helpers.dm
+++ b/mods/content/psionics/system/psionics/complexus/complexus_helpers.dm
@@ -41,7 +41,7 @@
 /datum/psi_complexus/proc/can_use(var/incapacitation_flags)
 	return (owner.stat == CONSCIOUS && (!incapacitation_flags || !owner.incapacitated(incapacitation_flags)) && !suppressed && !stun && world.time >= next_power_use)
 
-/datum/psi_complexus/proc/spend_power(var/value = 0, var/check_incapacitated)
+/datum/psi_complexus/proc/spend_power(var/value = 0, var/check_incapacitated, var/backblast_on_failure = TRUE)
 	. = FALSE
 	if(isnull(check_incapacitated))
 		check_incapacitated = (INCAPACITATION_STUNNED|INCAPACITATION_KNOCKOUT)
@@ -52,7 +52,8 @@
 			ui.update_icon()
 			. = TRUE
 		else
-			backblast(abs(stamina - value))
+			if(backblast_on_failure)
+				backblast(abs(stamina - value))
 			stamina = 0
 			. = FALSE
 		ui.update_icon()

--- a/mods/content/psionics/system/psionics/complexus/complexus_process.dm
+++ b/mods/content/psionics/system/psionics/complexus/complexus_process.dm
@@ -188,6 +188,10 @@
 					if(BP_IS_PROSTHETIC(I) || BP_IS_CRYSTAL(I))
 						continue
 
+					// Autoredaction doesn't heal brain damage directly.
+					if(I.organ_tag == BP_BRAIN)
+						continue
+
 					if(I.damage > 0 && spend_power(heal_rate))
 						I.damage = max(I.damage - heal_rate, 0)
 						if(prob(25))

--- a/mods/content/psionics/system/psionics/complexus/complexus_process.dm
+++ b/mods/content/psionics/system/psionics/complexus/complexus_process.dm
@@ -196,12 +196,6 @@
 				if(BP_IS_PROSTHETIC(E))
 					continue
 
-				if(heal_internal && (E.status & ORGAN_BROKEN) && E.damage < (E.min_broken_damage * config.organ_health_multiplier)) // So we don't mend and autobreak.
-					if(spend_power(heal_rate))
-						if(E.mend_fracture())
-							to_chat(H, SPAN_NOTICE("Your autoredactive faculty coaxes together the shattered bones in your [E.name]."))
-							return
-
 				if(heal_bleeding)
 
 					if((E.status & ORGAN_ARTERY_CUT) && spend_power(heal_rate))
@@ -215,7 +209,6 @@
 						return TRUE
 
 					for(var/datum/wound/W in E.wounds)
-
 						if(W.bleeding() && spend_power(heal_rate))
 							to_chat(H, SPAN_NOTICE("Your autoredactive faculty knits together severed veins, stemming the bleeding from \a [W.desc] on your [E.name]."))
 							W.bleed_timer = 0

--- a/mods/content/psionics/system/psionics/complexus/complexus_process.dm
+++ b/mods/content/psionics/system/psionics/complexus/complexus_process.dm
@@ -106,7 +106,7 @@
 			else if(owner.stat == UNCONSCIOUS)
 				stamina = min(max_stamina, stamina + rand(3,5))
 
-		if(!owner.nervous_system_failure() && owner.stat == CONSCIOUS && stamina && !suppressed && get_rank(PSI_REDACTION) >= PSI_RANK_OPERANT)
+		if(!owner.nervous_system_failure() && owner.stat != DEAD && stamina && !suppressed && get_rank(PSI_REDACTION) >= PSI_RANK_OPERANT)
 			attempt_regeneration()
 
 	var/next_aura_size = max(0.1,((stamina/max_stamina)*min(3,rating))/5)
@@ -158,6 +158,10 @@
 		heal_rate = 1
 	else
 		return
+
+	if(owner.stat != CONSCIOUS)
+		mend_prob = round(mend_prob * 0.65)
+		heal_rate = round(heal_rate * 0.65)
 
 	if(!heal_rate || stamina < heal_rate)
 		return // Don't backblast from trying to heal ourselves thanks.

--- a/mods/content/psionics/system/psionics/equipment/psipower.dm
+++ b/mods/content/psionics/system/psionics/equipment/psipower.dm
@@ -13,7 +13,6 @@
 	abstract_type = /obj/item/psychic_power
 
 	var/maintain_cost = 3
-	var/backblast_on_failed_maintain = FALSE
 	var/mob/living/owner
 
 /obj/item/psychic_power/Initialize()

--- a/mods/content/psionics/system/psionics/equipment/psipower.dm
+++ b/mods/content/psionics/system/psionics/equipment/psipower.dm
@@ -13,6 +13,7 @@
 	abstract_type = /obj/item/psychic_power
 
 	var/maintain_cost = 3
+	var/backblast_on_failed_maintain = FALSE
 	var/mob/living/owner
 
 /obj/item/psychic_power/Initialize()
@@ -54,6 +55,6 @@
 
 /obj/item/psychic_power/Process()
 	if(istype(owner))
-		owner.psi.spend_power(maintain_cost)
+		owner.psi.spend_power(maintain_cost, backblast_on_failure = FALSE)
 	if((!owner || owner.do_psionics_check(maintain_cost, owner) || loc != owner || !(src in owner.get_held_items())) && !QDELETED(src))
 		qdel(src)

--- a/mods/content/psionics/system/psionics/faculties/redaction.dm
+++ b/mods/content/psionics/system/psionics/faculties/redaction.dm
@@ -93,6 +93,10 @@
 				E.status &= ~ORGAN_BROKEN
 				E.stage = 0
 				return TRUE
+			if(E.is_dislocated() && !E.is_parent_dislocated())
+				to_chat(user, SPAN_NOTICE("You carefully guide the dislocated joint back into place and soothe the inflamed muscles."))
+				E.undislocate(skip_pain = TRUE)
+				return TRUE
 
 		for(var/datum/wound/W in E.wounds)
 			if(W.bleeding())

--- a/mods/content/psionics/system/psionics/faculties/redaction.dm
+++ b/mods/content/psionics/system/psionics/faculties/redaction.dm
@@ -111,7 +111,7 @@
 
 		if(redaction_rank >= PSI_RANK_GRANDMASTER)
 			for(var/obj/item/organ/internal/I in E.internal_organs)
-				if(!BP_IS_PROSTHETIC(I) && !BP_IS_CRYSTAL(I) && I.damage > 0)
+				if(!BP_IS_PROSTHETIC(I) && !BP_IS_CRYSTAL(I) && I.damage > 0 && I.organ_tag != BP_BRAIN)
 					to_chat(user, SPAN_NOTICE("You encourage the damaged tissue of \the [I] to repair itself."))
 					var/heal_rate = redaction_rank
 					I.damage = max(0, I.damage - rand(heal_rate,heal_rate*2))


### PR DESCRIPTION
## Description of changes
Addresses the issues mentioned in #2399.
- Maintained psionics do not give you brain damage if you run out of juice.
- Redaction cannot repair the brain.
- Autoredaction cannot repair broken bones.
- Redaction repairs dislocation.
- Autoredaction does not halt when unconscious, but loses 30% effectiveness.

## Why and what will this PR improve
These are long-outstanding tweaks to update psionics to gel a little better with the current health system.

## Authorship
Myself.

## Changelog
:cl:
tweak: Redaction no longer heals the brain, or automatically heals breaks, but can now heal dislocation when used actively.
tweak: Maintained psionic powers like Tinker and Psychokinetic Slash do not zap your brain when they end.
/:cl:
