### PR TITLE
Unacidable var replaced with material checks.

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -12,7 +12,6 @@
 	plane = HUD_PLANE
 	layer = HUD_BASE_LAYER
 	appearance_flags = NO_CLIENT_COLOR
-	unacidable = 1
 	var/globalscreen = FALSE //Global screens are not qdeled when the holding mob is destroyed.
 
 /obj/screen/receive_mouse_drop(atom/dropping, mob/user)

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -94,7 +94,6 @@
 	icon = 'icons/obj/cult.dmi'
 	icon_state = "hole"
 	density = TRUE
-	unacidable = 1
 	anchored = TRUE
 	var/spawnable = null
 

--- a/code/game/gamemodes/cult/narsie.dm
+++ b/code/game/gamemodes/cult/narsie.dm
@@ -16,7 +16,6 @@ var/global/list/narsie_list = list()
 	icon = 'icons/obj/narsie.dmi'
 	icon_state = "narsie"
 	anchored = TRUE
-	unacidable = TRUE
 	pixel_x = -236
 	pixel_y = -256
 	plane = ABOVE_LIGHTING_PLANE

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -4,7 +4,6 @@
 	anchored = TRUE
 	icon = 'icons/effects/uristrunes.dmi'
 	icon_state = "blank"
-	unacidable = 1
 	layer = RUNE_LAYER
 
 	var/blood
@@ -269,7 +268,7 @@
 	color = "#ff0000"
 	anchored = TRUE
 	density = TRUE
-	unacidable = 1
+
 	var/obj/effect/rune/wall/rune
 	var/health
 	var/max_health = 200

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -268,7 +268,6 @@
 	color = "#ff0000"
 	anchored = TRUE
 	density = TRUE
-
 	var/obj/effect/rune/wall/rune
 	var/health
 	var/max_health = 200

--- a/code/game/gamemodes/endgame/supermatter_cascade/portal.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/portal.dm
@@ -6,7 +6,6 @@
 	icon = 'icons/obj/rift.dmi'
 	icon_state = "rift"
 	anchored = TRUE
-	unacidable = TRUE
 	pixel_x = -236
 	pixel_y = -256
 	plane = ABOVE_LIGHTING_PLANE

--- a/code/game/gamemodes/events/black_hole.dm
+++ b/code/game/gamemodes/events/black_hole.dm
@@ -6,7 +6,6 @@
 	desc = "FUCK FUCK FUCK AAAHHH!"
 	icon_state = "bhole3"
 	opacity = TRUE
-	unacidable = 1
 	density = FALSE
 	anchored = TRUE
 

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -507,3 +507,6 @@ Class Procs:
 // Make sure that mapped subtypes get the right codex entry.
 /obj/machinery/get_codex_value()
 	return base_type || ..()
+
+/obj/machinery/solvent_can_melt(var/solvent_power = MAT_SOLVENT_STRONG)
+	return FALSE

--- a/code/game/machinery/embedded_controller/airlock_controllers_dummy.dm
+++ b/code/game/machinery/embedded_controller/airlock_controllers_dummy.dm
@@ -6,7 +6,6 @@
 	icon_state         = "airlock_control_off"
 	layer              = ABOVE_OBJ_LAYER
 	obj_flags          = OBJ_FLAG_MOVES_UNSUPPORTED
-	unacidable         = TRUE
 	base_type          = /obj/machinery/dummy_airlock_controller
 	construct_state    = /decl/machine_construction/wall_frame/panel_closed
 	frame_type         = /obj/item/frame/button/airlock_controller

--- a/code/game/machinery/embedded_controller/embedded_controller_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_controller_base.dm
@@ -50,7 +50,6 @@
 	icon_state              = "airlock_control_off"
 	power_channel           = ENVIRON
 	density                 = FALSE
-	unacidable              = TRUE
 	obj_flags               = OBJ_FLAG_MOVES_UNSUPPORTED
 	construct_state         = /decl/machine_construction/wall_frame/panel_closed
 	frame_type              = /obj/item/frame/button/airlock_controller

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -8,8 +8,8 @@ var/global/bomb_set
 	density = TRUE
 	use_power = POWER_USE_OFF
 	uncreated_component_parts = null
-	unacidable = 1
 	interact_offline = TRUE
+	wires = /datum/wires/nuclearbomb
 
 	var/deployable = 0
 	var/extended = 0
@@ -25,7 +25,6 @@ var/global/bomb_set
 	var/obj/item/disk/nuclear/auth = null
 	var/removal_stage = 0 // 0 is no removal, 1 is covers removed, 2 is covers open, 3 is sealant open, 4 is unwrenched, 5 is removed from bolts.
 	var/lastentered
-	wires = /datum/wires/nuclearbomb
 	var/decl/security_level/original_level
 
 /obj/machinery/nuclearbomb/Initialize()

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -10,7 +10,6 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	name = "effect"
 	icon = 'icons/effects/effects.dmi'
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
-	unacidable = 1//So effect are not targeted by alien acid.
 	pass_flags = PASS_FLAG_TABLE | PASS_FLAG_GRILLE
 
 /datum/effect/effect/system

--- a/code/game/objects/effects/fluids.dm
+++ b/code/game/objects/effects/fluids.dm
@@ -128,17 +128,16 @@
 // Permaflood overlay.
 var/global/obj/effect/flood/flood_object = new
 /obj/effect/flood
-	name          = ""
-	icon = 'icons/effects/liquids.dmi'
-	icon_state = "ocean"
-	layer = DEEP_FLUID_LAYER
-	color = COLOR_LIQUID_WATER
-	alpha = 140
+	name         = ""
+	icon         = 'icons/effects/liquids.dmi'
+	icon_state   = "ocean"
+	layer        = DEEP_FLUID_LAYER
+	color        = COLOR_LIQUID_WATER
+	alpha        = 140
 	invisibility = INVISIBILITY_NONE
-	simulated     = FALSE
-	density       = FALSE
-	anchored      = TRUE
-	unacidable    = TRUE
+	simulated    = FALSE
+	density      = FALSE
+	anchored     = TRUE
 
 /obj/effect/fluid/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	. = ..()

--- a/code/game/objects/effects/force_portal.dm
+++ b/code/game/objects/effects/force_portal.dm
@@ -5,7 +5,6 @@
 	icon_state = "portal"
 	blend_mode = BLEND_SUBTRACT
 	density = TRUE
-	unacidable = 1
 	anchored = TRUE
 	var/boom_time = 1
 

--- a/code/game/objects/effects/manifest.dm
+++ b/code/game/objects/effects/manifest.dm
@@ -2,7 +2,6 @@
 	name = "manifest"
 	icon = 'icons/mob/screen1.dmi'
 	icon_state = "x"
-	unacidable = 1//Just to be sure.
 
 /obj/effect/manifest/Initialize()
 	. = ..()

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -1,6 +1,5 @@
 /obj/effect/overlay
 	name = "overlay"
-	unacidable = 1
 
 /obj/effect/overlay/singularity_pull()
 	return

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -5,7 +5,6 @@
 	icon_state = "portal"
 	density = TRUE
 	anchored = TRUE
-	unacidable = TRUE // Can't destroy energy portals.
 	var/obj/item/target = null
 	var/dangerous = FALSE
 	var/failchance = 0

--- a/code/game/objects/effects/projectile/projectile_effects.dm
+++ b/code/game/objects/effects/projectile/projectile_effects.dm
@@ -5,7 +5,6 @@
 	plane = ABOVE_LIGHTING_PLANE
 	layer = BEAM_PROJECTILE_LAYER //Muzzle flashes would be above the lighting plane anyways.
 	anchored = TRUE
-	unacidable = TRUE
 	light_color = "#00ffff"
 	light_range = 2
 	light_power = 1

--- a/code/game/objects/effects/temporary_effect.dm
+++ b/code/game/objects/effects/temporary_effect.dm
@@ -1,7 +1,6 @@
 //A temporary effect that does not DO anything except look pretty.
 /obj/effect/temporary
 	anchored = TRUE
-	unacidable = 1
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
 	density = FALSE
 	layer = ABOVE_HUMAN_LAYER

--- a/code/game/objects/item_materials.dm
+++ b/code/game/objects/item_materials.dm
@@ -57,7 +57,8 @@
 		if(M.burn_product)
 			environment.adjust_gas(M.burn_product, M.fuel_value * (matter[mat] / SHEET_MATERIAL_AMOUNT))
 
-	new /obj/effect/decal/cleanable/molten_item(src)
+	var/obj/effect/decal/cleanable/molten_item/I = new(loc)
+	I.desc = "It looks like it was \a [src] some time ago."
 	qdel(src)
 
 /obj/item/proc/shatter(var/consumed)

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -5,7 +5,6 @@
 	w_class = ITEM_SIZE_SMALL
 	force = 2.0
 	det_time = null
-	unacidable = 1
 	var/stage = 0
 	var/path = 0
 	var/obj/item/assembly_holder/detonator = null

--- a/code/game/objects/items/weapons/paint.dm
+++ b/code/game/objects/items/weapons/paint.dm
@@ -14,7 +14,6 @@ var/global/list/cached_icons = list()
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = @"[10,20,30,60]"
 	volume = 60
-	unacidable = 0
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	var/pigment
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -325,5 +325,7 @@
 
 // TODO: maybe iterate the entire matter list or do some partial damage handling
 /obj/proc/solvent_can_melt(var/solvent_power = MAT_SOLVENT_STRONG)
+	if(!simulated)
+		return FALSE
 	var/decl/material/mat = get_material()
 	return !mat || mat.dissolves_in <= solvent_power

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -8,7 +8,6 @@
 	var/list/req_access
 	var/list/matter //Used to store information about the contents of the object.
 	var/w_class // Size of the object.
-	var/unacidable = 0 //universal "unacidabliness" var, here so you can use it in any obj.
 	var/throwforce = 1
 	var/sharp = 0		// whether this object cuts
 	var/edge = 0		// whether this object is more likely to dismember
@@ -323,3 +322,8 @@
 	..()
 	if(!QDELETED(src) && fluids?.total_volume)
 		fluids.touch_obj(src)
+
+// TODO: maybe iterate the entire matter list or do some partial damage handling
+/obj/proc/solvent_can_melt(var/solvent_power = MAT_SOLVENT_STRONG)
+	var/decl/material/mat = get_material()
+	return !mat || mat.dissolves_in <= solvent_power

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -5,11 +5,11 @@
 	desc = "A display case for prized possessions. It taunts you to kick it."
 	density = TRUE
 	anchored = TRUE
-	unacidable = TRUE //Dissolving the case would also delete the gun.
 	alpha = 150
 	maxhealth = 100
 	hitsound = 'sound/effects/Glasshit.ogg'
 	req_access = null
+	material = /decl/material/solid/glass
 
 	var/destroyed = FALSE
 	var/locked = TRUE

--- a/code/game/objects/structures/fountain.dm
+++ b/code/game/objects/structures/fountain.dm
@@ -7,7 +7,6 @@
 	icon_state = "fountain"
 	density    = TRUE
 	anchored   = TRUE
-	unacidable = TRUE
 	pixel_x    = -16
 	var/used   = FALSE
 	var/increase_age_prob = (100 / 6)

--- a/code/game/objects/structures/memorial.dm
+++ b/code/game/objects/structures/memorial.dm
@@ -7,7 +7,6 @@
 	pixel_y = -16
 	density = TRUE
 	anchored = TRUE
-	unacidable = TRUE
 	material = /decl/material/solid/stone/marble
 	material_alteration = MAT_FLAG_ALTERATION_DESC | MAT_FLAG_ALTERATION_NAME
 

--- a/code/game/objects/structures/showcase.dm
+++ b/code/game/objects/structures/showcase.dm
@@ -5,4 +5,3 @@
 	desc = "A stand with the empty body of a cyborg bolted to it."
 	density = TRUE
 	anchored = TRUE
-	unacidable = 1//temporary until I decide whether the borg can be removed. -veyveyr

--- a/code/modules/abstract/_abstract.dm
+++ b/code/modules/abstract/_abstract.dm
@@ -5,7 +5,6 @@
 	simulated     = FALSE
 	density       = FALSE
 	anchored      = TRUE
-	unacidable    = TRUE
 	abstract_type = /obj/abstract
 	invisibility  = INVISIBILITY_ABSTRACT
 

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -33,7 +33,6 @@
 
 	siemens_coefficient = 0.2
 	permeability_coefficient = 0.1
-	unacidable = 1
 	material = /decl/material/solid/metal/titanium
 	matter = list(
 		/decl/material/solid/fiberglass           = MATTER_AMOUNT_SECONDARY,
@@ -172,7 +171,6 @@
 		if(piece.siemens_coefficient > siemens_coefficient) //So that insulated gloves keep their insulation.
 			piece.siemens_coefficient = siemens_coefficient
 		piece.permeability_coefficient = permeability_coefficient
-		piece.unacidable = unacidable
 		if(islist(armor))
 			piece.armor = armor.Copy() // codex reads the armor list, not extensions. this list does not have any effect on in game mechanics
 			remove_extension(piece, /datum/extension/armor)

--- a/code/modules/clothing/spacesuits/void/wizard.dm
+++ b/code/modules/clothing/spacesuits/void/wizard.dm
@@ -3,7 +3,7 @@
 	name = "gem-encrusted voidsuit helmet"
 	desc = "A bizarre gem-encrusted helmet that radiates magical energies."
 	icon = 'icons/clothing/spacesuit/void/wizard/helmet.dmi'
-	unacidable = 1 //No longer shall our kind be foiled by lone chemists with spray bottles!
+	material = /decl/material/solid/gemstone/crystal
 	armor = list(
 		ARMOR_MELEE = ARMOR_MELEE_RESISTANT,
 		ARMOR_BULLET = ARMOR_BALLISTIC_PISTOL,
@@ -21,7 +21,7 @@
 	desc = "A bizarre gem-encrusted suit that radiates magical energies."
 	icon = 'icons/clothing/spacesuit/void/wizard/suit.dmi'
 	w_class = ITEM_SIZE_LARGE //normally voidsuits are bulky but this one is magic I suppose
-	unacidable = 1
+	material = /decl/material/solid/gemstone/crystal
 	armor = list(
 		ARMOR_MELEE = ARMOR_MELEE_RESISTANT,
 		ARMOR_BULLET = ARMOR_BALLISTIC_PISTOL,
@@ -53,7 +53,7 @@
 	gender = PLURAL
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.02
-	unacidable = 1
+	material = /decl/material/solid/gemstone/crystal
 	armor = list(
 		ARMOR_MELEE = ARMOR_MELEE_RESISTANT,
 		ARMOR_BULLET = ARMOR_BALLISTIC_PISTOL,

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -10,7 +10,6 @@
 	can_be_placed_into = null
 	item_flags = ITEM_FLAG_NO_BLUDGEON
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	unacidable = 0
 	material = /decl/material/solid/cloth
 
 	var/on_fire = 0

--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -6,9 +6,11 @@
 
 /obj/item/integrated_circuit/reagent
 	category_text = "Reagent"
-	unacidable = 1
 	cooldown_per_use = 10
 	var/volume = 0
+
+/obj/item/integrated_circuit/reagent/solvent_can_melt(var/solvent_power = MAT_SOLVENT_STRONG)
+	return FALSE
 
 /obj/item/integrated_circuit/reagent/Initialize()
 	. = ..()
@@ -512,10 +514,12 @@
 		"on transfer" = IC_PINTYPE_PULSE_OUT
 	)
 
-	unacidable = 1
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	complexity = 4
 	power_draw_per_use = 5
+
+/obj/item/integrated_circuit/input/funnel/solvent_can_melt(var/solvent_power = MAT_SOLVENT_STRONG)
+	return FALSE
 
 /obj/item/integrated_circuit/input/funnel/attackby_react(obj/item/I, mob/user, intent)
 	var/atom/movable/target = get_pin_data_as_type(IC_INPUT, 1, /atom/movable)

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -741,33 +741,8 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 				return
 		M.clean_blood()
 
-	if(solvent_power > MAT_SOLVENT_NONE && removed >= solvent_melt_dose && M.acid_act(min(removed * solvent_power * ((removed < solvent_melt_dose) ? 0.1 : 0.2), solvent_max_damage), solvent_melt_dose, solvent_power))
+	if(solvent_power > MAT_SOLVENT_NONE && removed >= solvent_melt_dose && M.solvent_act(min(removed * solvent_power * ((removed < solvent_melt_dose) ? 0.1 : 0.2), solvent_max_damage), solvent_melt_dose, solvent_power))
 		holder.remove_reagent(type, REAGENT_VOLUME(holder, type))
-
-/mob/living/proc/acid_act(var/severity, var/amount_per_item, var/solvent_power)
-
-	for(var/slot in global.standard_headgear_slots)
-		var/obj/item/thing = get_equipped_item(slot)
-		if(!istype(thing))
-			continue
-		if(!thing.solvent_can_melt(solvent_power) || !try_unequip(thing))
-			to_chat(src, SPAN_NOTICE("Your [thing] protects you from the solvent."))
-			return TRUE
-		to_chat(src, SPAN_DANGER("Your [thing] dissolves!"))
-		qdel(thing)
-		severity -= amount_per_item
-		if(severity <= 0)
-			return TRUE
-
-	// TODO move this to a contact var or something.
-	if(solvent_power >= MAT_SOLVENT_STRONG)
-		var/screamed
-		for(var/obj/item/organ/external/affecting in get_external_organs())
-			if(!screamed && affecting.can_feel_pain())
-				screamed = TRUE
-				emote("scream")
-			affecting.status |= ORGAN_DISFIGURED
-		take_organ_damage(0, severity, override_droplimb = DISMEMBER_METHOD_ACID)
 
 /decl/material/proc/affect_overdose(var/mob/living/M) // Overdose effect. Doesn't happen instantly.
 	M.add_chemical_effect(CE_TOXIN, 1)

--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -435,22 +435,24 @@
 	if (!..()) // /obj/item/mech_equipment/afterattack implements a usage guard
 		return
 
-	if (istype(target, /obj/item/drill_head))
-		attach_head(target, user)
+	if(!target.simulated)
 		return
 
 	if (!drill_head)
-		to_chat(user, SPAN_WARNING("\The [src] doesn't have a head!"))
+		if (istype(target, /obj/item/drill_head))
+			attach_head(target, user)
+		else
+			to_chat(user, SPAN_WARNING("\The [src] doesn't have a head!"))
 		return
 
 	if (ismob(target))
-		var/mob/tmob = target
-		to_chat(tmob, FONT_HUGE(SPAN_DANGER("You're about to get drilled - dodge!")))
+		to_chat(target, FONT_HUGE(SPAN_DANGER("You're about to get drilled - dodge!")))
 
 	else if (isobj(target))
 		var/obj/tobj = target
-		if (!tobj.solvent_can_melt()) // why the hell does this use an acid check
-			to_chat(user, SPAN_WARNING("\The [target] can't be drilled away."))
+		var/decl/material/mat = tobj.get_material()
+		if (mat && mat.hardness < drill_head.material?.hardness)
+			to_chat(user, SPAN_WARNING("\The [target] is too hard to be destroyed by [drill_head.material ? "a [drill_head.material.adjective_name]" : "this"] drill."))
 			return
 
 	else if (istype(target, /turf/unsimulated))

--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -445,15 +445,11 @@
 
 	if (ismob(target))
 		var/mob/tmob = target
-		if (tmob.unacidable)
-			to_chat(user, SPAN_WARNING("\The [target] can't be drilled away."))
-			return
-		else
-			to_chat(tmob, FONT_HUGE(SPAN_DANGER("You're about to get drilled - dodge!")))
+		to_chat(tmob, FONT_HUGE(SPAN_DANGER("You're about to get drilled - dodge!")))
 
 	else if (isobj(target))
 		var/obj/tobj = target
-		if (tobj.unacidable)
+		if (!tobj.solvent_can_melt()) // why the hell does this use an acid check
 			to_chat(user, SPAN_WARNING("\The [target] can't be drilled away."))
 			return
 

--- a/code/modules/mob/living/deity/phenomena/conjuration.dm
+++ b/code/modules/mob/living/deity/phenomena/conjuration.dm
@@ -71,7 +71,6 @@
 	desc = "a tear in space and time."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "rift"
-	unacidable = 1
 	anchored = TRUE
 	density = FALSE
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -303,3 +303,28 @@
 // this handles mulebots and vehicles
 /mob/living/Crossed(var/atom/movable/AM)
 	AM.crossed_mob(src)
+
+/mob/living/proc/solvent_act(var/severity, var/amount_per_item, var/solvent_power = MAT_SOLVENT_STRONG)
+
+	for(var/slot in global.standard_headgear_slots)
+		var/obj/item/thing = get_equipped_item(slot)
+		if(!istype(thing))
+			continue
+		if(!thing.solvent_can_melt(solvent_power) || !try_unequip(thing))
+			to_chat(src, SPAN_NOTICE("Your [thing] protects you from the solvent."))
+			return TRUE
+		to_chat(src, SPAN_DANGER("Your [thing] dissolves!"))
+		qdel(thing)
+		severity -= amount_per_item
+		if(severity <= 0)
+			return TRUE
+
+	// TODO move this to a contact var or something.
+	if(solvent_power >= MAT_SOLVENT_STRONG)
+		var/screamed
+		for(var/obj/item/organ/external/affecting in get_external_organs())
+			if(!screamed && affecting.can_feel_pain())
+				screamed = TRUE
+				emote("scream")
+			affecting.status |= ORGAN_DISFIGURED
+		take_organ_damage(0, severity, override_droplimb = DISMEMBER_METHOD_ACID)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -86,7 +86,6 @@
 
 	var/radio_interrupt_cooldown = 0    // TODO move this to /human
 
-	var/unacidable = 0
 	var/list/pinned                     // Lazylist of things pinning this creature to walls (see living_defense.dm)
 	var/list/embedded                   // Embedded items, since simple mobs don't have organs.
 	var/list/languages = list()         // TODO: lazylist this var. For speaking/listening.

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -7,7 +7,6 @@
 	icon_state = "Contain_F"
 	anchored = TRUE
 	density = FALSE
-	unacidable = 1
 	light_range = 4
 	movable_flags = MOVABLE_FLAG_PROXMOVE
 	var/obj/machinery/field_generator/FG1 = null

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -6,7 +6,6 @@ var/global/list/singularities = list()
 	icon_state = "singularity_s1"
 	anchored =   TRUE
 	density =    TRUE
-	unacidable = TRUE //Don't comment this out.
 	layer = SINGULARITY_LAYER
 	light_power = 1
 	light_range = 6

--- a/code/modules/projectiles/ammunition/chemdart.dm
+++ b/code/modules/projectiles/ammunition/chemdart.dm
@@ -4,11 +4,10 @@
 	damage = 5
 	sharp = 1
 	embed = 1 //the dart is shot fast enough to pierce space suits, so I guess splintering inside the target can be a thing. Should be rare due to low damage.
-	var/reagent_amount = 15
 	life_span = 15 //shorter range
-	unacidable = 1
-
 	muzzle_type = null
+	material = /decl/material/solid/glass
+	var/reagent_amount = 15
 
 /obj/item/projectile/bullet/chemdart/initialize_reagents(populate)
 	create_reagents(reagent_amount)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -6,11 +6,11 @@
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "bullet"
 	density = TRUE
-	unacidable = 1
 	anchored = TRUE //There's a reason this is here, Mport. God fucking damn it -Agouri. Find&Fix by Pete. The reason this is here is to stop the curving of emitter shots.
 	pass_flags = PASS_FLAG_TABLE
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
 	randpixel = 0
+	material = null
 	is_spawnable_type = FALSE
 
 	var/bumped = 0		//Prevents it from hitting more than one guy at once

--- a/code/modules/reagents/dispenser/cartridge.dm
+++ b/code/modules/reagents/dispenser/cartridge.dm
@@ -6,9 +6,9 @@
 	w_class = ITEM_SIZE_NORMAL
 	volume = CARTRIDGE_VOLUME_LARGE
 	amount_per_transfer_from_this = 50
+	material = /decl/material/solid/stone/ceramic
 	// Large, but inaccurate. Use a chem dispenser or beaker for accuracy.
 	possible_transfer_amounts = @"[50,100]"
-	unacidable = 1
 
 /obj/item/chems/chem_disp_cartridge/initialize_reagents(populate = TRUE)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/beaker.dm
+++ b/code/modules/reagents/reagent_containers/beaker.dm
@@ -85,7 +85,6 @@
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = @"[5,10,15,25,30,60,180]"
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	unacidable = 0
 	material = /decl/material/solid/metal/steel
 	material_force_multiplier = 0.2
 

--- a/code/modules/reagents/reagent_containers/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/drinks/bottle.dm
@@ -8,7 +8,7 @@
 	volume = 100
 	item_state = "broken_beer" //Generic held-item sprite until unique ones are made.
 	force = 5
-
+	material = /decl/material/solid/glass
 	drop_sound = 'sound/foley/bottledrop1.ogg'
 	pickup_sound = 'sound/foley/bottlepickup1.ogg'
 
@@ -20,9 +20,7 @@
 
 /obj/item/chems/drinks/bottle/Initialize()
 	. = ..()
-	if(isGlass)
-		unacidable = TRUE
-	else
+	if(material?.type != /decl/material/solid/glass)
 		verbs -= .verb/spin_bottle
 
 /obj/item/chems/drinks/bottle/Destroy()

--- a/code/modules/reagents/reagent_containers/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/drinks/bottle.dm
@@ -13,7 +13,6 @@
 	pickup_sound = 'sound/foley/bottlepickup1.ogg'
 
 	var/smash_duration = 5 //Directly relates to the 'weaken' duration. Lowered by armor (i.e. helmets)
-	var/isGlass = TRUE //Whether the 'bottle' is made of glass or not so that milk cartons dont shatter when someone gets hit by it
 	var/obj/item/chems/glass/rag/rag = null
 	var/rag_underlay = "rag"
 	var/stop_spin_bottle = FALSE //Gotta stop the rotation.
@@ -35,12 +34,12 @@
 //when thrown on impact, bottles smash and spill their contents
 /obj/item/chems/drinks/bottle/throw_impact(atom/hit_atom, var/datum/thrownthing/TT)
 	..()
-	if(isGlass && TT.thrower && TT.thrower.a_intent != I_HELP)
+	if(material?.is_brittle() && TT.thrower && TT.thrower.a_intent != I_HELP)
 		if(TT.speed > throw_speed || smash_check(TT.dist_travelled)) //not as reliable as smashing directly
 			smash(loc, hit_atom)
 
 /obj/item/chems/drinks/bottle/proc/smash_check(var/distance)
-	if(!isGlass)
+	if(!material?.is_brittle())
 		return 0
 	if(rag && rag.on_fire) // Molotovs should be somewhat reliable, they're a pain to make.
 		return TRUE
@@ -110,7 +109,7 @@
 		..()
 
 /obj/item/chems/drinks/bottle/proc/insert_rag(obj/item/chems/glass/rag/R, mob/user)
-	if(!isGlass || rag) return
+	if(!material?.type != /decl/material/solid/glass || rag) return
 
 	if(user.try_unequip(R))
 		to_chat(user, SPAN_NOTICE("You stuff [R] into [src]."))
@@ -502,7 +501,10 @@
 	icon_state = "orangejuice"
 	item_state = "carton"
 	center_of_mass = @"{'x':16,'y':7}"
-	isGlass = 0
+	material = /decl/material/solid/cardboard
+	matter = list(
+		/decl/material/solid/plastic = MATTER_AMOUNT_SECONDARY
+	)
 	drop_sound = 'sound/foley/drop1.ogg'
 	pickup_sound = 'sound/foley/paperpickup2.ogg'
 
@@ -515,7 +517,10 @@
 	icon_state = "cream"
 	item_state = "carton"
 	center_of_mass = @"{'x':16,'y':8}"
-	isGlass = 0
+	material = /decl/material/solid/cardboard
+	matter = list(
+		/decl/material/solid/plastic = MATTER_AMOUNT_SECONDARY
+	)
 	drop_sound = 'sound/foley/drop1.ogg'
 	pickup_sound = 'sound/foley/paperpickup2.ogg'
 
@@ -528,7 +533,10 @@
 	icon_state = "tomatojuice"
 	item_state = "carton"
 	center_of_mass = @"{'x':16,'y':8}"
-	isGlass = 0
+	material = /decl/material/solid/cardboard
+	matter = list(
+		/decl/material/solid/plastic = MATTER_AMOUNT_SECONDARY
+	)
 	drop_sound = 'sound/foley/drop1.ogg'
 	pickup_sound = 'sound/foley/paperpickup2.ogg'
 
@@ -541,7 +549,10 @@
 	icon_state = "limejuice"
 	item_state = "carton"
 	center_of_mass = @"{'x':16,'y':8}"
-	isGlass = 0
+	material = /decl/material/solid/cardboard
+	matter = list(
+		/decl/material/solid/plastic = MATTER_AMOUNT_SECONDARY
+	)
 	drop_sound = 'sound/foley/drop1.ogg'
 	pickup_sound = 'sound/foley/paperpickup2.ogg'
 

--- a/code/modules/reagents/reagent_containers/drinks/jar.dm
+++ b/code/modules/reagents/reagent_containers/drinks/jar.dm
@@ -8,7 +8,7 @@
 	icon_state = "jar"
 	item_state = "beaker"
 	center_of_mass = @"{'x':15,'y':8}"
-	unacidable = 1
+	material = /decl/material/solid/glass
 	drop_sound = 'sound/foley/bottledrop1.ogg'
 	pickup_sound = 'sound/foley/bottlepickup1.ogg'
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -13,7 +13,7 @@
 	w_class = ITEM_SIZE_SMALL
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	obj_flags = OBJ_FLAG_HOLLOW
-	unacidable = 1 //glass doesn't dissolve in acid
+	material = /decl/material/solid/glass
 
 	drop_sound = 'sound/foley/bottledrop1.ogg'
 	pickup_sound = 'sound/foley/bottlepickup1.ogg'
@@ -119,7 +119,6 @@
 	volume = 180
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	presentation_flags = PRESENTATION_FLAG_NAME
-	unacidable = 0
 	material = /decl/material/solid/plastic
 	material_force_multiplier = 0.2
 	slot_flags = SLOT_HEAD

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -10,7 +10,6 @@
 	icon_state = "hypo"
 	origin_tech = "{'materials':4,'biotech':5}"
 	amount_per_transfer_from_this = 5
-	unacidable = 1
 	volume = 30
 	possible_transfer_amounts = null
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER

--- a/code/modules/reagents/reagent_containers/inhaler.dm
+++ b/code/modules/reagents/reagent_containers/inhaler.dm
@@ -7,7 +7,6 @@
 	item_state = "autoinjector"
 	icon_state = "autoinhaler"
 	center_of_mass = @"{'x':16,'y':11}"
-	unacidable = TRUE
 	amount_per_transfer_from_this = 5
 	volume = 5
 	w_class = ITEM_SIZE_SMALL

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -12,7 +12,6 @@
 	throw_range                       = 10
 	throwforce                        = 3
 	attack_cooldown                   = DEFAULT_QUICK_COOLDOWN
-	unacidable                        = TRUE //plastic
 	material                          = /decl/material/solid/plastic
 	volume                            = 250
 	amount_per_transfer_from_this     = 10
@@ -22,7 +21,9 @@
 	var/tmp/particle_move_delay       = 10                          ///lower is faster
 	var/tmp/sound_spray               = 'sound/effects/spray2.ogg'  ///Sound played when spraying
 	var/safety                        = FALSE                       ///Whether the safety is on
-	
+
+/obj/item/chems/spray/solvent_can_melt(var/solvent_power = MAT_SOLVENT_STRONG)
+	return FALSE // maybe reconsider this
 
 /obj/item/chems/spray/Initialize()
 	. = ..()
@@ -70,7 +71,7 @@
 
 /obj/item/chems/spray/proc/create_chempuff(var/atom/movable/target, var/particle_amount)
 	set waitfor = FALSE
-	
+
 	var/obj/effect/effect/water/chempuff/D = new/obj/effect/effect/water/chempuff(get_turf(src))
 	D.create_reagents(amount_per_transfer_from_this)
 	if(QDELETED(src))

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -19,7 +19,6 @@
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
 	sharp = 1
-	unacidable = 1 //glass
 	item_flags = ITEM_FLAG_NO_BLUDGEON
 	var/mode = SYRINGE_DRAW
 	var/image/filling //holds a reference to the current filling overlay

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -1,12 +1,11 @@
 /obj/machinery/shield
-	name = "Emergency energy shield"
+	name = "emergency energy shield"
 	desc = "An energy shield used to contain hull breaches."
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "shield-old"
 	density = TRUE
 	opacity = FALSE
 	anchored = TRUE
-	unacidable = 1
 	var/const/max_health = 200
 	var/health = max_health //The shield can only take so much beating (prevents perma-prisons)
 	var/shield_generate_power = 7500	//how much power we use when regenerating

--- a/code/modules/shieldgen/shieldwallgen.dm
+++ b/code/modules/shieldgen/shieldwallgen.dm
@@ -258,13 +258,12 @@
 
 //////////////Containment Field START
 /obj/machinery/shieldwall
-	name = "Shield"
+	name = "shield"
 	desc = "An energy shield."
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "shieldwall"
 	anchored = TRUE
 	density = TRUE
-	unacidable = 1
 	light_range = 3
 	var/needs_power = 0
 	var/obj/machinery/shieldwallgen/gen_primary

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -6,8 +6,7 @@ var/global/list/shuttle_landmarks = list()
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "energynet"
 	anchored = TRUE
-	unacidable = 1
-	simulated = 0
+	simulated = FALSE
 	invisibility = INVISIBILITY_ABSTRACT
 
 	var/landmark_tag

--- a/code/modules/spells/aoe_turf/conjure/forcewall.dm
+++ b/code/modules/spells/aoe_turf/conjure/forcewall.dm
@@ -34,7 +34,6 @@
 	anchored = TRUE
 	opacity = FALSE
 	density = TRUE
-	unacidable = 1
 
 /obj/effect/forcefield/bullet_act(var/obj/item/projectile/Proj, var/def_zone)
 	var/turf/T = get_turf(src.loc)

--- a/code/modules/spells/general/mark_recall.dm
+++ b/code/modules/spells/general/mark_recall.dm
@@ -52,12 +52,9 @@
 	desc = "A strange rune said to be made by wizards. Or its just some shmuck playing with crayons again."
 	icon = 'icons/obj/rune.dmi'
 	icon_state = "wizard_mark"
-
 	anchored = TRUE
-	unacidable = 1
 	layer = TURF_LAYER
 	is_spawnable_type = FALSE // invalid without spell passed
-
 	var/spell/mark_recall/spell
 
 /obj/effect/cleanable/wizard_mark/Initialize(mapload,var/mrspell)

--- a/code/unit_tests/chemistry_tests.dm
+++ b/code/unit_tests/chemistry_tests.dm
@@ -174,3 +174,59 @@
 		pass("No reactions had conflicts.")
 
 	return 1
+
+/datum/unit_test/chemistry_premade_bottles_shall_not_melt
+	name = "CHEMISTRY: Reagent containers shall not be destroyed by their contents"
+	// List of master types that can be reasonably expected to spawn with chems inside them.
+	var/static/list/master_types = list(
+		/obj/item/chems,
+		/obj/structure/reagent_dispensers
+	)
+	// Types to be skipped for reasons other than abstraction/spawnability.
+	var/static/list/excepted_types = list()
+
+/datum/unit_test/chemistry_premade_bottles_shall_not_melt/start_test()
+
+	// Main test.
+	var/list/chem_refs = list()
+	var/turf/spawn_spot = get_safe_turf()
+	var/list/failures = list()
+	for(var/master_type in master_types)
+		for(var/chem_type in subtypesof(master_type))
+			if(chem_type in excepted_types)
+				continue
+			var/atom/chem = chem_type
+			if(TYPE_IS_ABSTRACT(chem))
+				continue
+			chem = new chem(spawn_spot)
+			if(QDELETED(chem))
+				failures += "- [type] qdeleted after Initialize()"
+				continue
+			chem_refs[chem.type] = weakref(chem)
+
+	// Let SSmaterials process chemical reactions and solvents.
+	sleep(SSmaterials.wait * 2)
+
+	// Followup status checking.
+	for(var/chem_type in chem_refs)
+		var/weakref/chem_ref = chem_refs[chem_type]
+		var/atom/chem_instance = istype(chem_ref) && chem_ref.resolve()
+		if(QDELETED(chem_instance) || !istype(chem_instance, chem_type) || chem_instance.loc != spawn_spot)
+			failures += "- [chem_type] qdeleted after reacting"
+		else
+			// Cleanup pt. 1
+			qdel(chem_instance)
+
+	// Cleanup pt. 2
+	chem_refs.Cut()
+	var/obj/effect/fluid/fluid = locate() in spawn_spot
+	if(fluid)
+		qdel(fluid)
+		failures += "- spawn turf had fluids post-test"
+
+	// Report status.
+	if(length(failures))
+		fail("At least one subtype was qdeleted:\n[jointext(failures, "\n")]")
+	else
+		pass("No subtypes melted.")
+	return 1

--- a/maps/away/mining/mining.dm
+++ b/maps/away/mining/mining.dm
@@ -208,7 +208,7 @@
 	icon_state = "totem"
 	density = TRUE
 	anchored = TRUE
-	unacidable = 1
+	material = /decl/material/solid/metal/aliumium
 	var/number
 
 /obj/structure/totem/Initialize()

--- a/mods/content/xenobiology/slime/items.dm
+++ b/mods/content/xenobiology/slime/items.dm
@@ -67,7 +67,6 @@
 	name = "rune"
 	icon = 'icons/obj/rune.dmi'
 	icon_state = "golem"
-	unacidable = 1
 	layer = RUNE_LAYER
 
 /obj/effect/golemrune/Initialize()


### PR DESCRIPTION
## Description of changes
- Removes `unacidable`.
- Sets materials on some things that didn't have it set already.
- Moves mob response to acid into a proc that can be overridden.
- Makes unacidable checks use the material of the object and solvent levels in a `solvent_can_melt()` helper.
- Overrides `solvent_can_melt()` to return false in a few specific spots that I wasn't sure about.

## Why and what will this PR improve
Tying systems together, removing ancient logic.

## Authorship
Myself.

## Changelog
:cl:
tweak: Acid resistance has been tweaked; report things melting or not melting unexpectedly on the bug tracker.
/:cl:
