### PR TITLE
Fax machines now autopopulate with admin URIs.

### DIFF
--- a/maps/away/liberia/liberia.dmm
+++ b/maps/away/liberia/liberia.dmm
@@ -5017,7 +5017,7 @@
 /area/liberia/bridge)
 "jD" = (
 /obj/structure/table/glass,
-/obj/machinery/faxmachine{
+/obj/machinery/faxmachine/mapped{
 	req_access = list("ACCESS_MERCHANT");
 	},
 /obj/effect/floor_decal/corner/blue/mono,

--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -3433,7 +3433,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/exodus/security/warden)
 "ahv" = (
-/obj/machinery/faxmachine,
+/obj/machinery/faxmachine/mapped,
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/exodus/security/warden)
@@ -3599,7 +3599,7 @@
 /obj/machinery/keycard_auth{
 	dir = 8
 	},
-/obj/machinery/faxmachine,
+/obj/machinery/faxmachine/mapped,
 /turf/simulated/floor/tiled/dark,
 /area/exodus/crew_quarters/heads/hos)
 "ahP" = (
@@ -7058,7 +7058,7 @@
 /turf/simulated/floor/plating,
 /area/exodus/maintenance/auxsolarstarboard)
 "aoK" = (
-/obj/machinery/faxmachine{
+/obj/machinery/faxmachine/mapped{
 	anchored = 0
 	},
 /obj/structure/table/reinforced,
@@ -25315,7 +25315,7 @@
 /area/exodus/library)
 "bbF" = (
 /obj/structure/table,
-/obj/machinery/faxmachine,
+/obj/machinery/faxmachine/mapped,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -28480,7 +28480,7 @@
 /area/exodus/bridge/meeting_room)
 "biv" = (
 /obj/structure/table/woodentable,
-/obj/machinery/faxmachine,
+/obj/machinery/faxmachine/mapped,
 /turf/simulated/floor/wood/walnut,
 /area/exodus/bridge/meeting_room)
 "biw" = (
@@ -31533,7 +31533,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/exodus/research/chargebay)
 "boF" = (
-/obj/machinery/faxmachine,
+/obj/machinery/faxmachine/mapped,
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -38377,7 +38377,7 @@
 /area/ship/exodus_pod_research)
 "bCs" = (
 /obj/structure/table,
-/obj/machinery/faxmachine,
+/obj/machinery/faxmachine/mapped,
 /obj/effect/floor_decal/corner/purple/diagonal{
 	dir = 4
 	},
@@ -39496,7 +39496,7 @@
 /turf/simulated/floor/tiled/white,
 /area/exodus/medical/medbay3)
 "bEA" = (
-/obj/machinery/faxmachine,
+/obj/machinery/faxmachine/mapped,
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/crew_quarters/heads/hop)
@@ -43643,7 +43643,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/machinery/faxmachine,
+/obj/machinery/faxmachine/mapped,
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled/white,
 /area/exodus/crew_quarters/heads/cmo)
@@ -44133,7 +44133,7 @@
 /area/exodus/hallway/primary/aft)
 "bNG" = (
 /obj/structure/table,
-/obj/machinery/faxmachine,
+/obj/machinery/faxmachine/mapped,
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/quartermaster/qm)
 "bNH" = (
@@ -50979,7 +50979,7 @@
 /area/exodus/crew_quarters/heads/chief)
 "cbC" = (
 /obj/structure/table/reinforced,
-/obj/machinery/faxmachine,
+/obj/machinery/faxmachine/mapped,
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/crew_quarters/heads/chief)
 "cbD" = (

--- a/maps/ministation/ministation.dmm
+++ b/maps/ministation/ministation.dmm
@@ -99,7 +99,7 @@
 /area/ministation/medical)
 "ao" = (
 /obj/structure/table/reinforced,
-/obj/machinery/faxmachine,
+/obj/machinery/faxmachine/mapped,
 /turf/simulated/floor/tiled,
 /area/ministation/bridge)
 "ap" = (
@@ -1644,7 +1644,7 @@
 /area/ministation/atmospherics)
 "eB" = (
 /obj/structure/table,
-/obj/machinery/faxmachine,
+/obj/machinery/faxmachine/mapped,
 /turf/simulated/floor/tiled,
 /area/ministation/court)
 "eC" = (
@@ -9183,7 +9183,7 @@
 /area/ministation/hop)
 "xL" = (
 /obj/structure/table,
-/obj/machinery/faxmachine,
+/obj/machinery/faxmachine/mapped,
 /turf/simulated/floor/tiled,
 /area/ministation/hop)
 "xM" = (

--- a/mods/content/corporate/away_sites/lar_maria/lar_maria-2.dmm
+++ b/mods/content/corporate/away_sites/lar_maria/lar_maria-2.dmm
@@ -1235,7 +1235,7 @@
 /area/lar_maria/library)
 "dM" = (
 /obj/structure/table,
-/obj/machinery/faxmachine,
+/obj/machinery/faxmachine/mapped,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/alarm{
 	dir = 8;


### PR DESCRIPTION
## Description of changes
- Mapped fax machines autopopulate a disk of quick dial locations with the admin URIs.
- Admin URIs don't require an outgoing network connection to send.

## Why and what will this PR improve
Admin faxes work again.

## Authorship
Myself with advice from @PsyCommando, cheers.

## Changelog
:cl:
tweak: Fax machines now show you admin URIs by default.
/:cl:
