### PR TITLE
on_reagent_change() consistency pass.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -116,7 +116,7 @@
 
 /// Handle reagents being modified
 /atom/proc/on_reagent_change()
-	return
+	SHOULD_CALL_PARENT(TRUE)
 
 /**
 	Handle an atom bumping this atom

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -59,6 +59,7 @@
 	. = ..()
 
 /obj/machinery/biogenerator/on_reagent_change()			//When the reagents change, change the icon as well.
+	..()
 	update_icon()
 
 /obj/machinery/biogenerator/on_update_icon()

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -350,7 +350,7 @@
 	SSnano.update_uis(src)
 
 /obj/machinery/microwave/on_reagent_change()
-	. = ..()
+	..()
 	if(!operating)
 		SSnano.update_uis(src)
 

--- a/code/game/objects/effects/fluids.dm
+++ b/code/game/objects/effects/fluids.dm
@@ -34,7 +34,7 @@
 	return FALSE
 
 /obj/effect/fluid/on_reagent_change()
-	. = ..()
+	..()
 
 	if(reagents?.total_volume)
 		var/decl/material/primary_reagent = reagents.get_primary_reagent_decl()

--- a/code/game/objects/items/devices/scanners/mass_spectrometer.dm
+++ b/code/game/objects/items/devices/scanners/mass_spectrometer.dm
@@ -17,6 +17,7 @@
 	create_reagents(5)
 
 /obj/item/scanner/spectrometer/on_reagent_change()
+	..()
 	update_icon()
 
 /obj/item/scanner/spectrometer/on_update_icon()

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -60,7 +60,7 @@
 		to_chat(user, "It's [reagents?.total_volume > 0? "filled with liquid sloshing around" : "empty"].")
 
 /obj/item/chems/water_balloon/on_reagent_change()
-	. = ..()
+	..()
 	w_class = (reagents?.total_volume > 0)? ITEM_SIZE_SMALL : ITEM_SIZE_TINY
 	//#TODO: Maybe acids should handle eating their own containers themselves?
 	for(var/reagent in reagents?.reagent_volumes)

--- a/code/modules/integrated_electronics/passive/power.dm
+++ b/code/modules/integrated_electronics/passive/power.dm
@@ -120,6 +120,7 @@
 	..()
 
 /obj/item/integrated_circuit/passive/power/chemical_cell/on_reagent_change(changetype)
+	..()
 	set_pin_data(IC_OUTPUT, 1, reagents.total_volume)
 	push_data()
 

--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -48,6 +48,7 @@
 	var/notified = FALSE
 
 /obj/item/integrated_circuit/reagent/smoke/on_reagent_change()
+	..()
 	push_vol()
 
 /obj/item/integrated_circuit/reagent/smoke/do_work(ord)
@@ -107,6 +108,7 @@
 	var/busy = FALSE
 
 /obj/item/integrated_circuit/reagent/injector/on_reagent_change(changetype)
+	..()
 	push_vol()
 
 /obj/item/integrated_circuit/reagent/injector/on_data_written()
@@ -322,6 +324,7 @@
 	push_data()
 
 /obj/item/integrated_circuit/reagent/storage/on_reagent_change(changetype)
+	..()
 	push_vol()
 
 /obj/item/integrated_circuit/reagent/storage/big
@@ -595,6 +598,7 @@
 			push_data()
 
 /obj/item/integrated_circuit/reagent/temp/on_reagent_change()
+	..()
 	push_vol()
 
 /obj/item/integrated_circuit/reagent/temp/power_fail()

--- a/code/modules/mining/machinery/material_extractor.dm
+++ b/code/modules/mining/machinery/material_extractor.dm
@@ -94,7 +94,7 @@
 				break
 
 /obj/machinery/material_processing/extractor/on_reagent_change()
-	. = ..()
+	..()
 
 	if(!reagents)
 		return

--- a/code/modules/mining/machinery/material_smelter.dm
+++ b/code/modules/mining/machinery/material_smelter.dm
@@ -26,7 +26,7 @@
 
 // Outgas anything that is in gas form. Check what you put into the smeltery, nerds.
 /obj/machinery/material_processing/smeltery/on_reagent_change()
-	. = ..()
+	..()
 
 	if(!reagents)
 		return
@@ -115,7 +115,7 @@
 			if(samt > 0)
 				SSmaterials.create_object(mtype, output_turf, samt)
 				reagents.remove_reagent(mtype, ramt)
-	
+
 /obj/machinery/material_processing/smeltery/Topic(var/user, var/list/href_list)
 	. = ..()
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -68,6 +68,7 @@
 	desc = new_desc_list.Join("\n")
 
 /obj/item/chems/on_reagent_change()
+	..()
 	update_container_name()
 	update_container_desc()
 	update_icon()

--- a/code/modules/reagents/reagent_containers/condiment.dm
+++ b/code/modules/reagents/reagent_containers/condiment.dm
@@ -15,20 +15,21 @@
 	center_of_mass = @"{'x':16,'y':6}"
 	randpixel = 6
 	volume = 50
+	var/obj/item/chems/condiment/is_special_bottle
 	var/static/list/special_bottles = list(
-		/decl/material/liquid/nutriment/ketchup = /obj/item/chems/condiment/ketchup,
+		/decl/material/liquid/nutriment/ketchup  = /obj/item/chems/condiment/ketchup,
 		/decl/material/liquid/nutriment/barbecue = /obj/item/chems/condiment/barbecue,
-		/decl/material/liquid/capsaicin = /obj/item/chems/condiment/capsaicin,
-		/decl/material/liquid/enzyme = /obj/item/chems/condiment/enzyme,
+		/decl/material/liquid/capsaicin          = /obj/item/chems/condiment/capsaicin,
+		/decl/material/liquid/enzyme             = /obj/item/chems/condiment/enzyme,
 		/decl/material/liquid/nutriment/soysauce = /obj/item/chems/condiment/small/soysauce,
-		/decl/material/liquid/frostoil = /obj/item/chems/condiment/frostoil,
-		/decl/material/solid/sodiumchloride = /obj/item/chems/condiment/small/saltshaker,
-		/decl/material/solid/blackpepper = /obj/item/chems/condiment/small/peppermill,
-		/decl/material/liquid/nutriment/cornoil = /obj/item/chems/condiment/cornoil,
-		/decl/material/liquid/nutriment/sugar = /obj/item/chems/condiment/sugar,
-		/decl/material/liquid/nutriment/mayo = /obj/item/chems/condiment/mayo,
-		/decl/material/liquid/nutriment/vinegar = /obj/item/chems/condiment/vinegar
-		)
+		/decl/material/liquid/frostoil           = /obj/item/chems/condiment/frostoil,
+		/decl/material/solid/sodiumchloride      = /obj/item/chems/condiment/small/saltshaker,
+		/decl/material/solid/blackpepper         = /obj/item/chems/condiment/small/peppermill,
+		/decl/material/liquid/nutriment/cornoil  = /obj/item/chems/condiment/cornoil,
+		/decl/material/liquid/nutriment/sugar    = /obj/item/chems/condiment/sugar,
+		/decl/material/liquid/nutriment/mayo     = /obj/item/chems/condiment/mayo,
+		/decl/material/liquid/nutriment/vinegar  = /obj/item/chems/condiment/vinegar
+	)
 
 /obj/item/chems/condiment/attackby(var/obj/item/W, var/mob/user)
 	if(IS_PEN(W))
@@ -84,24 +85,30 @@
 /obj/item/chems/condiment/self_feed_message(var/mob/user)
 	to_chat(user, SPAN_NOTICE("You swallow some of contents of \the [src]."))
 
+/obj/item/chems/condiment/proc/update_center_of_mass()
+	center_of_mass = is_special_bottle ? initial(is_special_bottle.center_of_mass) : initial(center_of_mass)
+
 /obj/item/chems/condiment/on_reagent_change()
-	var/reagent = reagents.primary_reagent
-	if(reagent in special_bottles)
-		var/obj/item/chems/condiment/special_bottle = special_bottles[reagent]
-		name = initial(special_bottle.name)
-		desc = initial(special_bottle.desc)
-		icon_state = initial(special_bottle.icon_state)
-		center_of_mass = initial(special_bottle.center_of_mass)
-	else
-		name = initial(name)
-		desc = initial(desc)
-		center_of_mass = initial(center_of_mass)
-		if(LAZYLEN(reagents.reagent_volumes))
-			icon_state = "mixedcondiments"
-		else
-			icon_state = "emptycondiment"
+	is_special_bottle = reagents?.total_volume && special_bottles[reagents?.primary_reagent]
+	..()
+	update_center_of_mass()
+
+/obj/item/chems/condiment/update_container_name()
+	name = is_special_bottle ? initial(is_special_bottle.name) : initial(name)
 	if(label_text)
 		name = addtext(name," ([label_text])")
+
+/obj/item/chems/condiment/update_container_desc()
+	desc = is_special_bottle ? initial(is_special_bottle.desc) : initial(desc)
+
+/obj/item/chems/condiment/on_update_icon()
+	..()
+	if(is_special_bottle)
+		icon_state = initial(is_special_bottle.icon_state)
+	else if(LAZYLEN(reagents?.reagent_volumes))
+		icon_state = "mixedcondiments"
+	else
+		icon_state = "emptycondiment"
 
 /obj/item/chems/condiment/enzyme
 	name = "universal enzyme"
@@ -180,7 +187,16 @@
 	amount_per_transfer_from_this = 1
 	volume = 20
 
-/obj/item/chems/condiment/small/on_reagent_change()
+/obj/item/chems/condiment/small/update_center_of_mass()
+	return
+
+/obj/item/chems/condiment/small/update_container_name()
+	return
+
+/obj/item/chems/condiment/small/update_container_desc()
+	return
+
+/obj/item/chems/condiment/small/on_update_icon()
 	return
 
 /obj/item/chems/condiment/small/saltshaker
@@ -218,9 +234,6 @@
 
 /obj/item/chems/condiment/small/mint/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/drink/syrup/mint, reagents.maximum_volume)
-
-/obj/item/chems/condiment/small/mint/on_reagent_change()
-	return
 
 /obj/item/chems/condiment/small/soysauce
 	name = "soy sauce"
@@ -412,7 +425,13 @@
 /obj/item/chems/condiment/flour/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/nutriment/flour, reagents.maximum_volume)
 
-/obj/item/chems/condiment/flour/on_reagent_change()
+/obj/item/chems/condiment/flour/update_container_name()
+	return
+
+/obj/item/chems/condiment/flour/update_container_desc()
+	return
+
+/obj/item/chems/condiment/flour/on_update_icon()
 	return
 
 /obj/item/chems/condiment/large
@@ -432,5 +451,11 @@
 /obj/item/chems/condiment/large/salt/populate_reagents()
 	reagents.add_reagent(/decl/material/solid/sodiumchloride, reagents.maximum_volume)
 
-/obj/item/chems/condiment/large/salt/on_reagent_change()
+/obj/item/chems/condiment/large/salt/update_container_name()
+	return
+
+/obj/item/chems/condiment/large/salt/update_container_desc()
+	return
+
+/obj/item/chems/condiment/large/salt/on_update_icon()
 	return

--- a/code/modules/reagents/reagent_containers/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/drinks/bottle.dm
@@ -31,7 +31,10 @@
 	rag = null
 	return ..()
 
-/obj/item/chems/drinks/bottle/on_reagent_change()
+/obj/item/chems/drinks/bottle/update_container_name()
+	return
+
+/obj/item/chems/drinks/bottle/update_container_desc()
 	return
 
 //when thrown on impact, bottles smash and spill their contents

--- a/code/modules/reagents/reagent_containers/drinks/cans.dm
+++ b/code/modules/reagents/reagent_containers/drinks/cans.dm
@@ -4,7 +4,10 @@
 	atom_flags = 0 //starts closed
 	material = /decl/material/solid/metal/aluminium
 
-/obj/item/chems/drinks/cans/on_reagent_change()
+/obj/item/chems/drinks/cans/update_container_name()
+	return
+
+/obj/item/chems/drinks/cans/update_container_desc()
 	return
 
 //DRINKS

--- a/code/modules/reagents/reagent_containers/drinks/jar.dm
+++ b/code/modules/reagents/reagent_containers/drinks/jar.dm
@@ -12,12 +12,20 @@
 	drop_sound = 'sound/foley/bottledrop1.ogg'
 	pickup_sound = 'sound/foley/bottlepickup1.ogg'
 
-/obj/item/chems/drinks/jar/on_reagent_change()
-	if(LAZYLEN(reagents.reagent_volumes))
-		icon_state ="jar_what"
+/obj/item/chems/drinks/jar/update_container_name()
+	if(LAZYLEN(reagents?.reagent_volumes))
 		SetName("jar of something")
+	else
+		SetName(initial(name))
+
+/obj/item/chems/drinks/jar/update_container_desc()
+	if(LAZYLEN(reagents?.reagent_volumes))
 		desc = "You can't really tell what this is."
 	else
-		icon_state = initial(icon_state)
-		SetName(initial(name))
 		desc = "A jar. You're not sure what it's supposed to hold."
+
+/obj/item/chems/drinks/jar/on_update_icon()
+	if(LAZYLEN(reagents?.reagent_volumes))
+		icon_state = "jar_what"
+	else
+		icon_state = initial(icon_state)

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -46,7 +46,7 @@
 					if(safe_thing && (safe_thing.body_parts_covered & SLOT_EYES))
 						trans = reagents.splash(safe_thing, amount_per_transfer_from_this, max_spill=30)
 						user.visible_message(
-							SPAN_DANGER("\The [user] tries to squirt something into [target]'s eyes, but fails!"), 
+							SPAN_DANGER("\The [user] tries to squirt something into [target]'s eyes, but fails!"),
 							SPAN_DANGER("You squirt [trans] unit\s at \the [target]'s eyes, but fail!")
 						)
 						return
@@ -78,9 +78,11 @@
 
 		to_chat(user, SPAN_NOTICE("You fill the dropper with [trans] units of the solution."))
 
+/obj/item/chems/dropper/update_container_name()
+	return
 
-/obj/item/chems/dropper/on_reagent_change()
-	update_icon()
+/obj/item/chems/dropper/update_container_desc()
+	return
 
 /obj/item/chems/dropper/on_update_icon()
 	. = ..()

--- a/code/modules/reagents/reagent_containers/food/meat/cubes.dm
+++ b/code/modules/reagents/reagent_containers/food/meat/cubes.dm
@@ -51,7 +51,8 @@
 	Expand()
 
 /obj/item/chems/food/monkeycube/on_reagent_change()
-	if(reagents.has_reagent(/decl/material/liquid/water))
+	..()
+	if(!QDELETED(src) && reagents?.has_reagent(/decl/material/liquid/water))
 		Expand()
 
 /obj/item/chems/food/monkeycube/wrapped

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -31,10 +31,6 @@
 	. = ..()
 	update_icon()
 
-/obj/item/chems/syringe/on_reagent_change()
-	. = ..()
-	update_icon()
-
 /obj/item/chems/syringe/on_picked_up(mob/user)
 	. = ..()
 	update_icon()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -22,7 +22,8 @@
 		verbs -= /obj/structure/reagent_dispensers/verb/set_amount_dispensed
 
 /obj/structure/reagent_dispensers/on_reagent_change()
-	if(reagents.total_volume > 0)
+	..()
+	if(reagents?.total_volume > 0)
 		tool_interaction_flags = 0
 	else
 		tool_interaction_flags = TOOL_INTERACTION_DECONSTRUCT

--- a/mods/content/xenobiology/slime/items.dm
+++ b/mods/content/xenobiology/slime/items.dm
@@ -50,7 +50,7 @@
 	reagents.add_reagent(/decl/material/liquid/slimejelly, 30)
 
 /obj/item/slime_extract/on_reagent_change()
-	. = ..()
+	..()
 	if(reagents?.total_volume)
 		var/decl/slime_colour/slime_data = GET_DECL(slime_type)
 		slime_data.handle_reaction(reagents)


### PR DESCRIPTION
## Description of changes
- `on_reagent_change()` always calls parent.
- `on_reagent_change()` does not return a value.
- Various `on_reagent_change()` overrides have been replaced by overriding the chem object procs that they were avoiding.

## Why and what will this PR improve
More consistent proc usage and allows for me to do fire fuel updates via this proc in another PR.

## Authorship
Myself.

## Changelog
Nothing player-facing.