### PR TITLE
Mousing over an inventory slot will now show you whether or not your current active item can be equipped.

### DIFF
--- a/code/_onclick/hud/gun_mode.dm
+++ b/code/_onclick/hud/gun_mode.dm
@@ -1,7 +1,6 @@
 /obj/screen/gun
 	name = "gun"
 	icon = 'icons/mob/screen1.dmi'
-	master = null
 	dir = SOUTH
 
 /obj/screen/gun/Click(location, control, params)

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -150,18 +150,16 @@
 				inv_box = existing_box
 				break
 		if(!inv_box)
-			inv_box = new /obj/screen/inventory()
+			inv_box = new /obj/screen/inventory(null, mymob)
 		inv_box.SetName(hand_tag)
 		inv_box.icon = ui_style
 		inv_box.icon_state = "hand_base"
 
 		inv_box.cut_overlays()
-		inv_box.add_overlay("hand_[hand_tag]")
+		inv_box.add_overlay("hand_[hand_tag]", TRUE)
 		if(inv_slot.ui_label)
-			inv_box.add_overlay("hand_[inv_slot.ui_label]")
-		if(mymob.get_active_held_item_slot() == hand_tag)
-			inv_box.add_overlay("hand_selected")
-		inv_box.compile_overlays()
+			inv_box.add_overlay("hand_[inv_slot.ui_label]", TRUE)
+		inv_box.update_icon()
 
 		inv_box.slot_id = hand_tag
 		inv_box.color = ui_color
@@ -236,7 +234,7 @@
 		if(gear_slot in held_slots)
 			continue
 
-		inv_box = new /obj/screen/inventory()
+		inv_box = new /obj/screen/inventory(null, mymob)
 		inv_box.icon =  ui_style
 		inv_box.color = ui_color
 		inv_box.alpha = ui_alpha
@@ -287,7 +285,7 @@
 	var/list/held_slots = mymob.get_held_item_slots()
 	if(length(held_slots) > 1)
 
-		using = new /obj/screen/inventory()
+		using = new /obj/screen/inventory(null, mymob)
 		using.SetName("hand")
 		using.icon = ui_style
 		using.icon_state = "hand1"
@@ -296,7 +294,7 @@
 		src.adding += using
 		LAZYADD(swaphand_hud_objects, using)
 
-		using = new /obj/screen/inventory()
+		using = new /obj/screen/inventory(null, mymob)
 		using.SetName("hand")
 		using.icon = ui_style
 		using.icon_state = "hand2"

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -13,7 +13,6 @@
 	layer = HUD_BASE_LAYER
 	appearance_flags = NO_CLIENT_COLOR
 	unacidable = 1
-	var/obj/master = null    //A reference to the object in the slot. Grabs or items, generally.
 	var/globalscreen = FALSE //Global screens are not qdeled when the holding mob is destroyed.
 
 /obj/screen/receive_mouse_drop(atom/dropping, mob/user)
@@ -21,10 +20,6 @@
 
 /obj/screen/check_mousedrop_interactivity(var/mob/user)
 	return user.client && (src in user.client.screen)
-
-/obj/screen/Destroy()
-	master = null
-	return ..()
 
 /obj/screen/text
 	icon = null
@@ -34,13 +29,84 @@
 	maptext_height = 480
 	maptext_width = 480
 
-
 /obj/screen/inventory
 	var/slot_id	//The indentifier for the slot. It has nothing to do with ID cards.
+	var/weakref/mouse_over_atom_ref
+	var/weakref/owner_ref
 
+/obj/screen/inventory/Initialize(var/ml, var/mob/_owner)
+	if(!istype(_owner))
+		PRINT_STACK_TRACE("Inventory screen object supplied a non-mob owner!")
+	owner_ref = weakref(_owner)
+	return ..()
+
+/obj/screen/inventory/MouseDrop()
+	. = ..()
+	mouse_over_atom_ref = null
+	update_icon()
+
+/obj/screen/inventory/Click()
+	. = ..()
+	mouse_over_atom_ref = null
+	update_icon()
+
+/obj/screen/inventory/MouseEntered(location, control, params)
+	. = ..()
+	if(!slot_id || !usr)
+		return
+	var/equipped_item = usr.get_active_hand()
+	if(equipped_item)
+		var/new_mouse_over_atom = weakref(equipped_item)
+		if(new_mouse_over_atom != mouse_over_atom_ref)
+			mouse_over_atom_ref = new_mouse_over_atom
+			update_icon()
+
+/obj/screen/inventory/MouseExited(location, control, params)
+	. = ..()
+	if(mouse_over_atom_ref)
+		mouse_over_atom_ref = null
+		update_icon()
+
+/obj/screen/inventory/on_update_icon()
+
+	cut_overlays()
+
+	// Validate our owner still exists.
+	var/mob/owner = owner_ref?.resolve()
+	if(!istype(owner) || QDELETED(owner) || !(src in owner.client?.screen))
+		return
+
+	// Mark our selected hand.
+	if(owner.get_active_held_item_slot() == slot_id)
+		add_overlay("hand_selected")
+
+	// Mark anything we're potentially trying to equip.
+	var/obj/item/mouse_over_atom = mouse_over_atom_ref?.resolve()
+	if(istype(mouse_over_atom) && !QDELETED(mouse_over_atom) && !usr.get_equipped_item(slot_id))
+		var/mutable_appearance/MA = new /mutable_appearance(mouse_over_atom)
+		MA.layer   = HUD_ABOVE_ITEM_LAYER
+		MA.plane   = HUD_PLANE
+		MA.alpha   = 80
+		MA.color   = mouse_over_atom.mob_can_equip(owner, slot_id, TRUE) ? COLOR_GREEN : COLOR_RED
+		MA.pixel_x = mouse_over_atom.default_pixel_x
+		MA.pixel_y = mouse_over_atom.default_pixel_y
+		MA.pixel_w = mouse_over_atom.default_pixel_w
+		MA.pixel_z = mouse_over_atom.default_pixel_z
+		add_overlay(MA)
+	else
+		mouse_over_atom_ref = null
+
+	// UI needs to be responsive so avoid the subsecond update delay.
+	compile_overlays()
 
 /obj/screen/close
 	name = "close"
+	// A reference to the storage item this atom is associated with.
+	var/obj/master
+
+/obj/screen/close/Destroy()
+	master = null
+	return ..()
 
 /obj/screen/close/Click()
 	if(master)
@@ -113,6 +179,12 @@
 
 /obj/screen/storage
 	name = "storage"
+	// A reference to the storage item this atom is associated with.
+	var/obj/master
+
+/obj/screen/storage/Destroy()
+	master = null
+	return ..()
 
 /obj/screen/storage/Click()
 	if(!usr.canClick())


### PR DESCRIPTION
## Description of changes
Adds logic to highlight an equipment slot with a red or green overlay of your active item depending on whether or not it can be equipped. Also tidies some other screen stuff in the area.

![image](https://github.com/NebulaSS13/Nebula/assets/2468979/9672312f-013f-4854-adb1-a04e106015d9)

## Why and what will this PR improve
Nicer UI feedback.

## Authorship
Stole the idea from Polaris, code is entirely mine.

## Changelog
:cl:
tweak: You will now be able to tell if you can equip an item by mousing over the equipment slot with the item in your active hand.
/:cl: