### PR TITLE
Cleaning up/unifying a ton of conflicting/overlapping drag-equip code.

### DIFF
--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -457,8 +457,9 @@
 
 //the mob M is attempting to equip this item into the slot passed through as 'slot'. Return 1 if it can do this and 0 if it can't.
 //Set disable_warning to 1 if you wish it to not give you outputs.
-/obj/item/proc/mob_can_equip(mob/M, slot, disable_warning = FALSE, force = FALSE)
-	if(!slot || !M)
+/obj/item/proc/mob_can_equip(mob/user, slot, disable_warning = FALSE, force = FALSE)
+	SHOULD_CALL_PARENT(TRUE)
+	if(!slot || !user)
 		return FALSE
 
 	// Some slots don't have an associated handler as they are shorthand for various setup functions.
@@ -466,21 +467,21 @@
 		switch(slot)
 			// Putting stuff into backpacks.
 			if(slot_in_backpack_str)
-				var/obj/item/storage/backpack/backpack = M.get_equipped_item(slot_back_str)
-				return istype(backpack) && backpack.can_be_inserted(src, M, TRUE)
+				var/obj/item/storage/backpack/backpack = user.get_equipped_item(slot_back_str)
+				return istype(backpack) && backpack.can_be_inserted(src, user, TRUE)
 			// Equipping accessories.
 			if(slot_tie_str)
 				// Find something to equip the accessory to.
 				for(var/check_slot in list(slot_w_uniform_str, slot_wear_suit_str))
-					var/obj/item/clothing/check_gear = M.get_equipped_item(check_slot)
+					var/obj/item/clothing/check_gear = user.get_equipped_item(check_slot)
 					if(istype(check_gear) && check_gear.can_attach_accessory(src))
 						return TRUE
 				if(!disable_warning)
-					to_chat(M, SPAN_WARNING("You need to be wearing something you can attach \the [src] to."))
+					to_chat(user, SPAN_WARNING("You need to be wearing something you can attach \the [src] to."))
 				return FALSE
 
-	var/datum/inventory_slot/inv_slot = M.get_inventory_slot_datum(slot)
-	if(!inv_slot || !inv_slot.is_accessible(M, src, disable_warning) || !inv_slot.can_equip_to_slot(M, src, disable_warning))
+	var/datum/inventory_slot/inv_slot = user.get_inventory_slot_datum(slot)
+	if(!inv_slot || !inv_slot.is_accessible(user, src, disable_warning) || !inv_slot.can_equip_to_slot(user, src, disable_warning))
 		return FALSE
 	var/already_equipped = inv_slot.get_equipped_item()
 	if(already_equipped)
@@ -490,11 +491,11 @@
 		qdel(already_equipped)
 	return TRUE
 
-/obj/item/proc/mob_can_unequip(mob/M, slot, disable_warning = 0)
-	if(!slot || !M || !canremove)
+/obj/item/proc/mob_can_unequip(mob/user, slot, disable_warning = FALSE)
+	if(!slot || !user || !canremove)
 		return FALSE
-	var/datum/inventory_slot/inv_slot = M.get_inventory_slot_datum(slot)
-	return inv_slot?.is_accessible(M, src, disable_warning)
+	var/datum/inventory_slot/inv_slot = user.get_inventory_slot_datum(slot)
+	return inv_slot?.is_accessible(user, src, disable_warning)
 
 /obj/item/proc/can_be_dropped_by_client(mob/M)
 	return M.canUnEquip(src)

--- a/code/game/objects/items/devices/auto_cpr.dm
+++ b/code/game/objects/items/devices/auto_cpr.dm
@@ -17,10 +17,10 @@
 	var/last_pump
 	var/skilled_setup
 
-/obj/item/auto_cpr/mob_can_equip(mob/living/carbon/human/H, slot, disable_warning = 0, force = 0)
+/obj/item/auto_cpr/mob_can_equip(mob/user, slot, disable_warning = FALSE, force = FALSE)
 	. = ..()
 	if(. && slot == slot_wear_suit_str)
-		. = H.get_bodytype_category() == BODYTYPE_HUMANOID
+		. = user?.get_bodytype_category() == BODYTYPE_HUMANOID
 
 /obj/item/auto_cpr/attack(mob/living/carbon/human/M, mob/living/user, var/target_zone)
 	if(istype(M) && user.a_intent == I_HELP)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -73,16 +73,6 @@
 	toggle_paddles()
 	return TRUE
 
-// what is this proc doing?
-/obj/item/defibrillator/handle_mouse_drop(var/atom/over, var/mob/user)
-	if(ismob(loc))
-		var/mob/M = loc
-		if(M.try_unequip(src))
-			add_fingerprint(usr)
-			M.put_in_hands(src)
-			return TRUE
-	. = ..()
-
 /obj/item/defibrillator/attackby(obj/item/W, mob/user, params)
 	if(W == paddles)
 		reattach_paddles(user)

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -23,7 +23,8 @@
 	SHOULD_CALL_PARENT(FALSE)
 	return TRUE //make sure this is never picked up
 
-/obj/item/storage/internal/mob_can_equip()
+/obj/item/storage/internal/mob_can_equip(mob/user, slot, disable_warning = FALSE, force = FALSE)
+	SHOULD_CALL_PARENT(FALSE)
 	return FALSE //make sure this is never picked up
 
 //Helper procs to cleanly implement internal storages - storage items that provide inventory slots for other items.

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -33,20 +33,10 @@
 		QDEL_NULL(storage_ui)
 	. = ..()
 
-/obj/item/storage/check_mousedrop_adjacency(var/atom/over, var/mob/user)
-	. = (loc == user && istype(over, /obj/screen)) || ..()
-
 /obj/item/storage/handle_mouse_drop(var/atom/over, var/mob/user)
-	if(canremove && (ishuman(user) || isrobot(user) || isanimal(user)) && !user.incapacitated(INCAPACITATION_DISRUPTED))
-		if(over == user)
-			open(user)
-			return TRUE
-		if(istype(over, /obj/screen/inventory) && loc == user)
-			var/obj/screen/inventory/inv = over
-			add_fingerprint(usr)
-			if(user.try_unequip(src))
-				user.equip_to_slot_if_possible(src, inv.slot_id)
-				return TRUE
+	if(canremove && (ishuman(user) || isrobot(user) || isanimal(user)) && !user.incapacitated(INCAPACITATION_DISRUPTED) && over == user)
+		open(user)
+		return TRUE
 	. = ..()
 
 /obj/item/storage/proc/return_inv()

--- a/code/game/objects/items/weapons/weldbackpack.dm
+++ b/code/game/objects/items/weapons/weldbackpack.dm
@@ -141,18 +141,6 @@
 		return TRUE
 	return ..()
 
-/obj/item/chems/weldpack/check_mousedrop_adjacency(atom/over, mob/user)
-	return (loc == user && istype(over, /obj/screen)) || ..()
-
-/obj/item/chems/weldpack/handle_mouse_drop(atom/over, mob/user)
-	if(loc == user && !user.incapacitated())
-		if(istype(over, /obj/screen/inventory))
-			var/obj/screen/inventory/I = over
-			if(user.try_unequip(src))
-				user.equip_to_slot_if_possible(src, I.slot_id)
-				return TRUE
-	return ..()
-
 /obj/item/chems/weldpack/on_update_icon()
 	. = ..()
 	if(is_welder_attached())

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -133,13 +133,19 @@
 	if(markings_color && markings_icon)
 		update_icon()
 
-/obj/item/clothing/mob_can_equip(mob/living/M, slot, disable_warning = FALSE, force = FALSE)
+/obj/item/clothing/mob_can_equip(mob/user, slot, disable_warning = FALSE, force = FALSE)
 	. = ..()
-	if(. && !isnull(bodytype_equip_flags) && ishuman(M) && !(slot in list(slot_l_store_str, slot_r_store_str, slot_s_store_str)) && !(slot in M.get_held_item_slots()))
-		var/mob/living/carbon/human/H = M
-		. = (bodytype_equip_flags & BODY_FLAG_EXCLUDE) ? !(bodytype_equip_flags & H.bodytype.bodytype_flag) : (bodytype_equip_flags & H.bodytype.bodytype_flag)
-		if(!. && !disable_warning)
-			to_chat(H, SPAN_WARNING("\The [src] [gender == PLURAL ? "do" : "does"] not fit you."))
+	if(!. || slot == slot_s_store_str || (slot in global.pocket_slots))
+		return
+	var/decl/bodytype/root_bodytype = user?.get_bodytype()
+	if(!root_bodytype || isnull(bodytype_equip_flags) || (slot in user.get_held_item_slots()))
+		return
+	if(bodytype_equip_flags & BODY_FLAG_EXCLUDE)
+		. = !(bodytype_equip_flags & root_bodytype.bodytype_flag)
+	else
+		. = (bodytype_equip_flags & root_bodytype.bodytype_flag)
+	if(!. && !disable_warning)
+		to_chat(user, SPAN_WARNING("\The [src] [gender == PLURAL ? "do" : "does"] not fit you."))
 
 /obj/item/clothing/equipped(var/mob/user)
 	if(needs_vision_update())

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -46,18 +46,6 @@
 		. = A.attack_hand(user) || .
 	return TRUE
 
-/obj/item/clothing/check_mousedrop_adjacency(var/atom/over, var/mob/user)
-	. = (loc == user && istype(over, /obj/screen)) || ..()
-
-/obj/item/clothing/handle_mouse_drop(atom/over, mob/user)
-	if(ishuman(user) && loc == user && istype(over, /obj/screen/inventory))
-		var/obj/screen/inventory/inv = over
-		add_fingerprint(user)
-		if(user.try_unequip(src))
-			user.equip_to_slot_if_possible(src, inv.slot_id)
-		return TRUE
-	. = ..()
-
 /obj/item/clothing/proc/update_accessory_slowdown()
 	slowdown_accessory = 0
 	for(var/obj/item/clothing/accessory/A in accessories)

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -25,22 +25,21 @@
 /obj/item/clothing/gloves/get_fibers()
 	return "material from a pair of [name]."
 
-/obj/item/clothing/gloves/mob_can_equip(mob/M, slot, disable_warning = 0, force = 0)
+/obj/item/clothing/gloves/mob_can_equip(mob/user, slot, disable_warning = FALSE, force = FALSE)
 	var/obj/item/clothing/ring/check_ring
-	var/mob/living/carbon/human/H = M
-	var/obj/item/gloves = M.get_equipped_item(slot_gloves_str)
-	if(slot == slot_gloves_str && istype(H) && gloves)
+	var/obj/item/gloves = user?.get_equipped_item(slot_gloves_str)
+	if(slot == slot_gloves_str && gloves)
 		check_ring = gloves
-		if(!istype(check_ring) || !check_ring.can_fit_under_gloves || !H.try_unequip(check_ring, src))
-			to_chat(M, SPAN_WARNING("You are unable to wear \the [src] as \the [gloves] are in the way."))
+		if(!istype(check_ring) || !check_ring.can_fit_under_gloves || !user.try_unequip(check_ring, src))
+			to_chat(user, SPAN_WARNING("You are unable to wear \the [src] as \the [gloves] are in the way."))
 			return FALSE
 	. = ..()
 	if(check_ring)
 		if(.)
 			covering_ring = check_ring
-			to_chat(M, SPAN_NOTICE("You slip \the [src] on over \the [covering_ring]."))
+			to_chat(user, SPAN_NOTICE("You slip \the [src] on over \the [covering_ring]."))
 		else
-			M.equip_to_slot_if_possible(check_ring, slot_gloves_str, disable_warning = TRUE)
+			user.equip_to_slot_if_possible(check_ring, slot_gloves_str, disable_warning = TRUE)
 
 /obj/item/clothing/gloves/Destroy()
 	QDEL_NULL(covering_ring)

--- a/code/modules/clothing/head/headphones.dm
+++ b/code/modules/clothing/head/headphones.dm
@@ -50,12 +50,6 @@
 
 	update_icon()
 
-/obj/item/clothing/head/headphones/handle_mouse_drop(atom/over, mob/user)
-	if(istype(over, /obj/screen/inventory))
-		return ..()
-	interact(user)
-	return TRUE
-
 /obj/item/clothing/head/headphones/attack_self(mob/user)
 	..()
 	interact(user)
@@ -79,6 +73,14 @@
 		var/decl/music_track/track = GET_DECL(global.music_tracks[current_track])
 		sound_to(user, sound(null, channel = sound_channel))
 		sound_to(user, sound(track.song, repeat = 1, wait = 0, volume = music_volume, channel = sound_channel))
+
+/obj/item/clothing/head/headphones/attack_hand(mob/user)
+	// if it's equipped and we're not holding it, open
+	// the interface instead of removing it from the slot.
+	var/equip_slot = user.get_equipped_slot_for_item(src)
+	if(equip_slot && !(equip_slot in user.get_held_item_slots()))
+		return attack_self(user)
+	return ..()
 
 /obj/item/clothing/head/headphones/proc/stop_music(mob/user)
 	if(!user || !user.client)

--- a/code/modules/clothing/head/headphones.dm
+++ b/code/modules/clothing/head/headphones.dm
@@ -51,6 +51,8 @@
 	update_icon()
 
 /obj/item/clothing/head/headphones/handle_mouse_drop(atom/over, mob/user)
+	if(istype(over, /obj/screen/inventory))
+		return ..()
 	interact(user)
 	return TRUE
 

--- a/code/modules/clothing/masks/monitor.dm
+++ b/code/modules/clothing/masks/monitor.dm
@@ -71,7 +71,7 @@
 	canremove = 1
 	return ..()
 
-/obj/item/clothing/mask/monitor/mob_can_equip(var/mob/living/carbon/human/user, var/slot)
+/obj/item/clothing/mask/monitor/mob_can_equip(mob/user, slot, disable_warning = FALSE, force = FALSE)
 	. = ..()
 	if(. && (slot == slot_head_str || slot == slot_wear_mask_str))
 		var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(user, BP_HEAD)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -63,21 +63,20 @@
 			overlay.icon_state = new_state
 	. = ..()
 
-/obj/item/clothing/shoes/magboots/mob_can_equip(mob/M, slot, disable_warning = 0, force = 0)
+/obj/item/clothing/shoes/magboots/mob_can_equip(mob/user, slot, disable_warning = FALSE, force = FALSE)
 	var/obj/item/clothing/shoes/check_shoes
-	var/mob/living/carbon/human/H = M
-	if(slot == slot_shoes_str && istype(H))
-		check_shoes = H.get_equipped_item(slot_shoes_str)
-		if(istype(check_shoes) && (!check_shoes.can_fit_under_magboots || !H.try_unequip(check_shoes, src)))
-			to_chat(M, SPAN_WARNING("You are unable to wear \the [src] as \the [check_shoes] are in the way."))
+	if(slot == slot_shoes_str)
+		check_shoes = user?.get_equipped_item(slot_shoes_str)
+		if(istype(check_shoes) && (!check_shoes.can_fit_under_magboots || !user.try_unequip(check_shoes, src)))
+			to_chat(user, SPAN_WARNING("You are unable to wear \the [src] as \the [check_shoes] are in the way."))
 			return FALSE
 	. = ..()
 	if(check_shoes)
 		if(.)
 			covering_shoes = check_shoes
-			to_chat(M, SPAN_NOTICE("You slip \the [src] on over \the [covering_shoes]."))
+			to_chat(user, SPAN_NOTICE("You slip \the [src] on over \the [covering_shoes]."))
 		else
-			M.equip_to_slot_if_possible(check_shoes, slot_shoes_str, disable_warning = TRUE)
+			user.equip_to_slot_if_possible(check_shoes, slot_shoes_str, disable_warning = TRUE)
 	set_slowdown()
 
 /obj/item/clothing/shoes/magboots/Destroy()

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -16,7 +16,9 @@
 	return TRUE
 
 /obj/item/clothing/suit/storage/handle_mouse_drop(atom/over, mob/user)
-	. = pockets?.handle_storage_internal_mouse_drop(user, over) && ..()
+	if(istype(over, /obj/screen/inventory))
+		return ..()
+	return pockets?.handle_storage_internal_mouse_drop(user, over) && ..()
 
 /obj/item/clothing/suit/storage/attackby(obj/item/W, mob/user)
 	..()

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -32,8 +32,10 @@
 	return TRUE
 
 /obj/item/clothing/accessory/storage/handle_mouse_drop(atom/over, mob/user)
+	if(istype(over, /obj/screen/inventory))
+		return ..()
 	if(!istype(loc, /obj/item/clothing) && hold?.handle_storage_internal_mouse_drop(user, over))
-		. = ..(over)
+		return ..()
 	return TRUE
 
 /obj/item/clothing/accessory/storage/attackby(obj/item/W, mob/user)

--- a/code/modules/clothing/underwear/base.dm
+++ b/code/modules/clothing/underwear/base.dm
@@ -11,6 +11,7 @@
 	DelayedEquipUnderwear(user, target)
 
 /obj/item/underwear/handle_mouse_drop(atom/over, mob/user)
+	SHOULD_CALL_PARENT(FALSE)
 	DelayedEquipUnderwear(user, over)
 	return TRUE
 

--- a/code/modules/mechs/equipment/_equipment.dm
+++ b/code/modules/mechs/equipment/_equipment.dm
@@ -87,7 +87,7 @@
 /obj/item/mech_equipment/proc/MouseUpInteraction()
 	return 0
 
-/obj/item/mech_equipment/mob_can_unequip(mob/M, slot, disable_warning)
+/obj/item/mech_equipment/mob_can_unequip(mob/user, slot, disable_warning = FALSE)
 	. = ..()
 	if(. && owner)
 		//Installed equipment shall not be unequiped.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1128,7 +1128,7 @@
 	return
 
 /mob/proc/get_bodytype()
-	return
+	RETURN_TYPE(/decl/bodytype)
 
 /// Update the mouse pointer of the attached client in this mob.
 /mob/proc/update_mouse_pointer()

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -67,6 +67,11 @@
 /obj/item/modular_computer/attack_hand(var/mob/user)
 	if(anchored)
 		return attack_self(user)
+	// if it's equipped and we're not holding it, open
+	// the interface instead of removing it from the slot.
+	var/equip_slot = user.get_equipped_slot_for_item(src)
+	if(equip_slot && !(equip_slot in user.get_held_item_slots()))
+		return attack_self(user)
 	return ..()
 
 // On-click handling. Turns on the computer if it's off and opens the GUI.
@@ -108,9 +113,6 @@
 	if(card_slot && card_slot.stored_card)
 		to_chat(user, "\The [card_slot.stored_card] is inserted into it.")
 	assembly.examine(user)
-
-/obj/item/modular_computer/handle_mouse_drop(atom/over, mob/user)
-	. = (!istype(over, /obj/screen) && attack_self(user)) || ..()
 
 /obj/item/modular_computer/afterattack(atom/target, mob/user, proximity)
 	. = ..()

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -27,15 +27,6 @@
 	stored_pen = null
 	return ..()
 
-/obj/item/clipboard/handle_mouse_drop(atom/over, mob/user)
-	if(ishuman(user) && istype(over, /obj/screen/inventory))
-		var/obj/screen/inventory/inv = over
-		add_fingerprint(user)
-		if(user.try_unequip(src))
-			user.equip_to_slot_if_possible(src, inv.slot_id)
-			return TRUE
-	. = ..()
-
 /obj/item/clipboard/examine(mob/user, distance, infix, suffix)
 	. = ..()
 	if(stored_pen)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -186,17 +186,10 @@
 	material = /decl/material/solid/cardboard
 
 /obj/item/storage/photo_album/handle_mouse_drop(atom/over, mob/user)
-	if(istype(over, /obj/screen/inventory))
-		var/obj/screen/inventory/inv = over
-		playsound(loc, "rustle", 50, 1, -5)
-		if(user.get_equipped_item(slot_back_str) == src)
-			add_fingerprint(user)
-			if(user.try_unequip(src))
-				user.equip_to_slot_if_possible(src, inv.slot_id)
-		else if(over == user && in_range(src, user) || loc == user)
-			if(user.active_storage)
-				user.active_storage.close(user)
-			show_to(user)
+	if(over == user && in_range(src, user) || loc == user)
+		if(user.active_storage)
+			user.active_storage.close(user)
+		show_to(user)
 		return TRUE
 	. = ..()
 

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -48,7 +48,7 @@
 			START_PROCESSING(SSobj, src)
 		update_icon()
 		return TRUE
-	. = ..()
+	return ..()
 
 /obj/item/chems/ivbag/Process()
 	if(!ismob(loc))

--- a/mods/content/corporate/items/wristcomp.dm
+++ b/mods/content/corporate/items/wristcomp.dm
@@ -32,15 +32,7 @@
 		return attack_self(user)
 	return ..()
 
-/obj/item/modular_computer/pda/wrist/handle_mouse_drop(atom/over, mob/user)
-	if(ishuman(user) && loc == user && user.try_unequip(src))
-		user.put_in_hands(src)
-		add_fingerprint(usr)
-		return TRUE
-	. = ..()
-
 // wrist box //
-
 /obj/item/storage/box/wrist
 	name = "box of spare wrist computers"
 	desc = "A box of spare wrist microcomputers."

--- a/mods/species/ascent/items/rig.dm
+++ b/mods/species/ascent/items/rig.dm
@@ -228,13 +228,14 @@
 		/obj/item/rig_module/maneuvering_jets
 	)
 
-/obj/item/rig/mantid/mob_can_equip(var/mob/M, var/slot)
+/obj/item/rig/mantid/mob_can_equip(mob/user, slot, disable_warning = FALSE, force = FALSE)
 	. = ..()
-	if(. && slot == slot_back_str)
-		var/mob/living/carbon/human/H = M
-		if(!istype(H) || H.species.get_root_species_name(H) != mantid_caste)
-			to_chat(H, "<span class='danger'>Your species cannot wear \the [src].</span>")
-			. = 0
+	if(!. || slot != slot_back_str || !mantid_caste)
+		return
+	var/decl/species/my_species = user?.get_species()
+	if(my_species?.get_root_species_name(user) != mantid_caste)
+		to_chat(user, SPAN_WARNING("Your species cannot wear \the [src]."))
+		return FALSE
 
 /obj/item/clothing/head/helmet/space/rig/mantid
 	light_color = "#00ffff"

--- a/mods/species/bayliens/skrell/gear/gear_ears.dm
+++ b/mods/species/bayliens/skrell/gear/gear_ears.dm
@@ -2,10 +2,9 @@
 	name = "skrell tentacle wear"
 	desc = "Some stuff worn by skrell to adorn their head tentacles."
 
-/obj/item/clothing/ears/skrell/mob_can_equip(mob/living/M, slot, disable_warning = 0)
+/obj/item/clothing/ears/skrell/mob_can_equip(mob/user, slot, disable_warning = FALSE, force = FALSE)
 	. = ..()
-	var/mob/living/carbon/human/H = M
-	if(. && istype(H) && H.bodytype.name != BODYTYPE_SKRELL)
+	if(. && user?.get_bodytype()?.name != BODYTYPE_SKRELL)
 		return FALSE
 
 /obj/item/clothing/ears/skrell/band

--- a/mods/species/bayliens/skrell/gear/gear_head.dm
+++ b/mods/species/bayliens/skrell/gear/gear_head.dm
@@ -12,10 +12,9 @@
 		ARMOR_RAD = ARMOR_RAD_SHIELDED
 		)
 
-/obj/item/clothing/head/helmet/space/void/skrell/mob_can_equip(mob/living/M, slot, disable_warning = 0)
+/obj/item/clothing/head/helmet/space/void/skrell/mob_can_equip(mob/user, slot, disable_warning = FALSE, force = FALSE)
 	. = ..()
-	var/mob/living/carbon/human/H = M
-	if(. && istype(H) && H.bodytype.name != BODYTYPE_SKRELL)
+	if(. && user?.get_bodytype()?.name != BODYTYPE_SKRELL)
 		return FALSE
 
 /obj/item/clothing/head/helmet/space/void/skrell/black
@@ -26,8 +25,7 @@
 	desc = "A helmet built for use by a Skrell. This one appears to be fairly standard and reliable."
 	icon = 'mods/species/bayliens/skrell/icons/clothing/head/helmet_skrell.dmi'
 
-/obj/item/clothing/head/helmet/skrell/mob_can_equip(mob/living/M, slot, disable_warning = 0)
+/obj/item/clothing/head/helmet/skrell/mob_can_equip(mob/user, slot, disable_warning = FALSE, force = FALSE)
 	. = ..()
-	var/mob/living/carbon/human/H = M
-	if(. && istype(H) && H.bodytype.name != BODYTYPE_SKRELL)
+	if(. && user?.get_bodytype()?.name != BODYTYPE_SKRELL)
 		return FALSE

--- a/mods/species/bayliens/skrell/gear/gear_mask.dm
+++ b/mods/species/bayliens/skrell/gear/gear_mask.dm
@@ -10,8 +10,7 @@
 	flags_inv = 0
 	body_parts_covered = 0
 
-/obj/item/clothing/mask/gas/skrell/mob_can_equip(mob/living/M, slot, disable_warning = 0)
+/obj/item/clothing/mask/gas/skrell/mob_can_equip(mob/user, slot, disable_warning = FALSE, force = FALSE)
 	. = ..()
-	var/mob/living/carbon/human/H = M
-	if(. && istype(H) && H.bodytype.name != BODYTYPE_SKRELL)
+	if(. && user?.get_bodytype()?.name != BODYTYPE_SKRELL)
 		return FALSE


### PR DESCRIPTION
## Description of changes
Removes a bunch of handle_mouse_drop() overrides that duplicated functionality from /obj/item and were interfering with it.
Edited to add: did a cleanup pass on mob_can_equip() and mob_can_unequip() due to linter failures.

## Why and what will this PR improve
Nicer code, consistent drag equip of items.

## Authorship
Myself.

## Changelog
Nothing player-facing.