### PR TITLE
Cleaning up ID and PDA equipping.

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -291,7 +291,7 @@ Helpers
 			if(player.mind.assigned_role == "Captain")
 				captainless=0
 			if(!player_is_antag(player.mind, only_offstation_roles = 1))
-				SSjobs.equip_rank(player, player.mind.assigned_role, 0)
+				SSjobs.equip_job_title(player, player.mind.assigned_role, 0)
 				SScustomitems.equip_custom_items(player)
 	if(captainless)
 		for(var/mob/M in global.player_list)

--- a/code/datums/outfits/jobs/job.dm
+++ b/code/datums/outfits/jobs/job.dm
@@ -12,12 +12,3 @@
 	pda_type = /obj/item/modular_computer/pda
 
 	flags = OUTFIT_HAS_BACKPACK
-
-/decl/hierarchy/outfit/job/equip_id(var/mob/living/carbon/human/H, var/rank, var/assignment, var/equip_adjustments, var/datum/job/job)
-	var/obj/item/card/id/C = ..()
-	if(!C)
-		return
-	if(H.mind)
-		if(H.mind.initial_account)
-			C.associated_account_number = H.mind.initial_account.account_number
-	return C

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -74,9 +74,9 @@ var/global/list/outfits_decls_by_type_
 		J.toggle()
 		J.toggle_valve()
 
-/decl/hierarchy/outfit/proc/equip(mob/living/carbon/human/H, var/rank, var/assignment, var/equip_adjustments)
+/decl/hierarchy/outfit/proc/equip_outfit(mob/living/carbon/human/H, assignment, equip_adjustments, datum/job/job, datum/mil_rank/rank)
 	equip_base(H, equip_adjustments)
-
+	equip_id(H, assignment, equip_adjustments, job, rank)
 	for(var/path in backpack_contents)
 		var/number = backpack_contents[path]
 		for(var/i=0,i<number,i++)
@@ -169,7 +169,7 @@ var/global/list/outfits_decls_by_type_
 	if(H.client?.prefs?.give_passport)
 		global.using_map.create_passport(H)
 
-/decl/hierarchy/outfit/proc/equip_id(var/mob/living/carbon/human/H, var/rank, var/assignment, var/equip_adjustments, var/datum/job/job)
+/decl/hierarchy/outfit/proc/equip_id(mob/living/carbon/human/H, assignment, equip_adjustments, datum/job/job, datum/mil_rank/rank)
 	if(!id_slot || !id_type)
 		return
 	if(OUTFIT_ADJUSTMENT_SKIP_ID_PDA & equip_adjustments)
@@ -177,22 +177,23 @@ var/global/list/outfits_decls_by_type_
 	var/obj/item/card/id/W = new id_type(H)
 	if(id_desc)
 		W.desc = id_desc
-	if(rank)
-		W.rank = rank
 	if(assignment)
 		W.assignment = assignment
 	if(job)
+		W.rank = job.title
 		LAZYDISTINCTADD(W.access, job.get_access())
 		if(!W.detail_color)
 			W.detail_color = job.selection_color
 			W.update_icon()
 	H.update_icon()
 	H.set_id_info(W)
-	equip_pda(H, rank, assignment, equip_adjustments)
+	if(H.mind?.initial_account)
+		W.associated_account_number = H.mind.initial_account.account_number
+	equip_pda(H, assignment, equip_adjustments)
 	if(H.equip_to_slot_or_store_or_drop(W, id_slot))
 		return W
 
-/decl/hierarchy/outfit/proc/equip_pda(var/mob/living/carbon/human/H, var/rank, var/assignment, var/equip_adjustments)
+/decl/hierarchy/outfit/proc/equip_pda(var/mob/living/carbon/human/H, var/assignment, var/equip_adjustments)
 	if(!pda_slot || !pda_type)
 		return
 	if(OUTFIT_ADJUSTMENT_SKIP_ID_PDA & equip_adjustments)

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -180,7 +180,7 @@ var/global/list/outfits_decls_by_type_
 	if(assignment)
 		W.assignment = assignment
 	if(job)
-		W.rank = job.title
+		W.position = job.title
 		LAZYDISTINCTADD(W.access, job.get_access())
 		if(!W.detail_color)
 			W.detail_color = job.selection_color

--- a/code/game/antagonist/antagonist_equip.dm
+++ b/code/game/antagonist/antagonist_equip.dm
@@ -19,7 +19,7 @@
 
 	if(default_outfit)
 		var/decl/hierarchy/outfit/outfit = GET_DECL(default_outfit)
-		outfit.equip(player)
+		outfit.equip_outfit(player)
 
 	if(default_access)
 		var/obj/item/card/id/id = player.get_equipped_item(slot_wear_id_str)

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -18,6 +18,7 @@
 		. = id.GetAccess()
 
 /atom/movable/proc/GetIdCard()
+	RETURN_TYPE(/obj/item/card/id)
 	var/list/cards = GetIdCards()
 	return LAZYACCESS(cards, LAZYLEN(cards))
 
@@ -229,6 +230,7 @@ var/global/list/priv_region_access
 
 // Gets the ID card of a mob, but will not check types in the exceptions list
 /mob/living/carbon/human/GetIdCard(exceptions = null)
+	RETURN_TYPE(/obj/item/card/id)
 	return LAZYACCESS(GetIdCards(exceptions), 1)
 
 /mob/living/carbon/human/GetIdCards(exceptions = null)
@@ -270,13 +272,13 @@ var/global/list/priv_region_access
 		var/job_icons = get_all_job_icons()
 		if(I.assignment	in job_icons) //Check if the job has a hud icon
 			return I.assignment
-		if(I.rank in job_icons)
-			return I.rank
+		if(I.position in job_icons)
+			return I.position
 
 		var/centcom = get_all_centcom_jobs()
 		if(I.assignment	in centcom)
 			return "Centcom"
-		if(I.rank in centcom)
+		if(I.position in centcom)
 			return "Centcom"
 	else
 		return

--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -85,7 +85,7 @@
 /datum/job/dd_SortValue()
 	return title
 
-/datum/job/proc/equip(var/mob/living/carbon/human/H, var/alt_title, var/datum/mil_branch/branch, var/datum/mil_rank/grade)
+/datum/job/proc/equip_job(var/mob/living/carbon/human/H, var/alt_title, var/datum/mil_branch/branch, var/datum/mil_rank/grade)
 	if (required_language)
 		H.add_language(required_language)
 		H.set_default_language(required_language)
@@ -93,7 +93,7 @@
 	H.set_default_language(/decl/language/human/common)
 	var/decl/hierarchy/outfit/outfit = get_outfit(H, alt_title, branch, grade)
 	if(outfit)
-		return outfit.equip(H, title, alt_title)
+		return outfit.equip_outfit(H, alt_title || title, job = src, rank = grade)
 
 /datum/job/proc/get_outfit(var/mob/living/carbon/human/H, var/alt_title, var/datum/mil_branch/branch, var/datum/mil_rank/grade)
 	if(alt_title && alt_titles)
@@ -163,7 +163,7 @@
 	var/decl/hierarchy/outfit/outfit = get_outfit(H, alt_title, branch, grade)
 	if(!outfit)
 		return FALSE
-	. = outfit.equip(H, title, alt_title, OUTFIT_ADJUSTMENT_SKIP_POST_EQUIP|OUTFIT_ADJUSTMENT_SKIP_ID_PDA|additional_skips)
+	. = outfit.equip_outfit(H, alt_title || title, equip_adjustments = (OUTFIT_ADJUSTMENT_SKIP_POST_EQUIP|OUTFIT_ADJUSTMENT_SKIP_ID_PDA|additional_skips), job = src, rank = grade)
 
 /datum/job/proc/get_access()
 	if(minimal_access.len && (!config || config.jobs_have_minimal_access))
@@ -445,7 +445,7 @@
 				break
 	return spawnpos
 
-/datum/job/proc/post_equip_rank(var/mob/person, var/alt_title)
+/datum/job/proc/post_equip_job_title(var/mob/person, var/alt_title, var/rank)
 	if(is_semi_antagonist && person.mind)
 		var/decl/special_role/provocateur/provocateurs = GET_DECL(/decl/special_role/provocateur)
 		provocateurs.add_antagonist(person.mind)

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -91,7 +91,7 @@
 
 	if(giver)
 		data["giver"] = !!giver
-		data["giver_name"] = giver.rank || giver.assignment
+		data["giver_name"] = giver.position || giver.assignment
 		data["giv_name"] = giv_name
 
 		var/list/giver_access = list()

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -170,8 +170,8 @@ var/global/const/NO_EMAG_ACT = -50
 	var/icon/side
 
 	//alt titles are handled a bit weirdly in order to unobtrusively integrate into existing ID system
-	var/assignment = null	//can be alt title or the actual job
-	var/rank = null			//actual job
+	var/assignment //can be alt title or the actual job
+	var/position   // actual job
 
 	var/datum/mil_branch/military_branch = null //Vars for tracking branches and ranks on multi-crewtype maps
 	var/datum/mil_rank/military_rank = null
@@ -303,6 +303,7 @@ var/global/const/NO_EMAG_ACT = -50
 	return access.Copy()
 
 /obj/item/card/id/GetIdCard()
+	RETURN_TYPE(/obj/item/card/id)
 	return src
 
 /obj/item/card/id/GetIdCards()

--- a/code/modules/admin/quantum_mechanic.dm
+++ b/code/modules/admin/quantum_mechanic.dm
@@ -23,7 +23,7 @@
 	Q.ckey = ckey
 
 	var/decl/hierarchy/outfit/outfit = outfit_by_type(/decl/hierarchy/outfit/quantum)
-	outfit.equip(Q)
+	outfit.equip_outfit(Q)
 
 	//Sort out ID
 	var/obj/item/card/id/quantum/id = new (Q)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -300,7 +300,7 @@
 		return
 	if(undress)
 		H.delete_inventory(TRUE)
-	outfit.equip(H)
+	outfit.equip_outfit(H)
 	log_and_message_admins("changed the equipment of [key_name(H)] to [outfit.name].")
 
 /client/proc/startSinglo()

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -492,7 +492,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		antag_data.add_antagonist(new_character.mind)
 		antag_data.place_mob(new_character)
 	else
-		SSjobs.equip_rank(new_character, new_character.mind.assigned_role, 1)
+		SSjobs.equip_job_title(new_character, new_character.mind.assigned_role, 1)
 
 	//Announces the character on all the systems, based on the record.
 	if(!issilicon(new_character))//If they are not a cyborg/AI.

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -36,7 +36,7 @@
 /obj/abstract/landmark/corpse/Initialize()
 	..()
 	if(!species) species = global.using_map.default_species
-	var/species_choice = islist(species) ? pickweight(species) : species 
+	var/species_choice = islist(species) ? pickweight(species) : species
 	new /mob/living/carbon/human/corpse(loc, species_choice, src)
 	return INITIALIZE_HINT_QDEL
 
@@ -91,14 +91,14 @@
 		M.SetName(name)
 	M.real_name = M.name
 
-/obj/abstract/landmark/corpse/proc/equip_outfit(var/mob/living/carbon/human/M)
+/obj/abstract/landmark/corpse/proc/equip_corpse_outfit(var/mob/living/carbon/human/M)
 	var/adjustments = 0
 	adjustments = (spawn_flags & CORPSE_SPAWNER_CUT_SURVIVAL)  ? (adjustments|OUTFIT_ADJUSTMENT_SKIP_SURVIVAL_GEAR) : adjustments
 	adjustments = (spawn_flags & CORPSE_SPAWNER_CUT_ID_PDA)    ? (adjustments|OUTFIT_ADJUSTMENT_SKIP_ID_PDA)        : adjustments
 	adjustments = (spawn_flags & CORPSE_SPAWNER_PLAIN_HEADSET) ? (adjustments|OUTFIT_ADJUSTMENT_PLAIN_HEADSET)      : adjustments
 
 	var/decl/hierarchy/outfit/corpse_outfit = outfit_by_type(pickweight(corpse_outfits))
-	corpse_outfit.equip(M, equip_adjustments = adjustments)
+	corpse_outfit.equip_outfit(M, equip_adjustments = adjustments)
 
 /obj/abstract/landmark/corpse/pirate
 	name = "Pirate"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -144,20 +144,12 @@
 
 // Get rank from ID, ID inside PDA, PDA, ID in wallet, etc.
 /mob/living/carbon/human/proc/get_authentification_rank(var/if_no_id = "No id", var/if_no_job = "No job")
-	var/obj/item/card/id/id = GetIdCard()
-	if(istype(id))
-		return id.rank ? id.rank : if_no_job
-	else
-		return if_no_id
+	return GetIdCard()?.position || if_no_job
 
 //gets assignment from ID or ID inside PDA or PDA itself
 //Useful when player do something with computers
 /mob/living/carbon/human/proc/get_assignment(var/if_no_id = "No id", var/if_no_job = "No job")
-	var/obj/item/card/id/id = GetIdCard()
-	if(istype(id))
-		return id.assignment ? id.assignment : if_no_job
-	else
-		return if_no_id
+	return GetIdCard()?.assignment || if_no_job
 
 //gets name from ID or ID inside PDA or PDA itself
 //Useful when player do something with computers

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -36,7 +36,7 @@
 		corpse_heart.pulse = PULSE_NONE//actually stops heart to make worried explorers not care too much
 	if(corpse)
 		corpse.randomize_appearance(src, new_species)
-		corpse.equip_outfit(src)
+		corpse.equip_corpse_outfit(src)
 	update_icon()
 
 /mob/living/carbon/human/dummy/mannequin/add_to_living_mob_list()

--- a/code/modules/mob/living/carbon/human/npcs.dm
+++ b/code/modules/mob/living/carbon/human/npcs.dm
@@ -36,7 +36,7 @@
 	var/number = "[pick(possible_changeling_IDs)]-[rand(1,30)]"
 	fully_replace_character_name("Subject [number]")
 	var/decl/hierarchy/outfit/outfit = outfit_by_type(/decl/hierarchy/outfit/blank_subject)
-	outfit.equip(src)
+	outfit.equip_outfit(src)
 	var/obj/item/clothing/head/helmet/facecover/F = locate() in src
 	if(F)
 		F.SetName("[F.name] ([number])")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -221,7 +221,7 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 	if(!character)
 		return 0
 
-	character = SSjobs.equip_rank(character, job.title, 1)					//equips the human
+	character = SSjobs.equip_job_title(character, job.title, 1)					//equips the human
 	SScustomitems.equip_custom_items(character)
 
 	if(job.do_spawn_special(character, src, TRUE)) //This replaces the AI spawn logic with a proc stub. Refer to silicon.dm for the spawn logic.

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -259,7 +259,7 @@
 					if(!isnull(selected_CR) && CanUseTopic(user))
 						id_card.registered_name = selected_CR.get_name()
 						id_card.assignment = selected_CR.get_job()
-						id_card.rank = selected_CR.get_rank()
+						id_card.position = selected_CR.get_rank()
 						id_card.dna_hash = selected_CR.get_dna()
 						id_card.fingerprint_hash = selected_CR.get_fingerprint()
 						id_card.card_gender = selected_CR.get_gender()
@@ -294,7 +294,7 @@
 					remove_nt_access(id_card)
 					apply_access(id_card, access)
 					id_card.assignment = t1
-					id_card.rank = t1
+					id_card.position = t1
 
 				callHook("reassign_employee", list(id_card))
 		if("access")

--- a/code/modules/modular_computers/file_system/programs/generic/supply.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/supply.dm
@@ -398,7 +398,7 @@
 	t += "<h3>[global.using_map.station_name] Supply Requisition Reciept</h3><hr>"
 	t += "INDEX: #[O.ordernum]<br>"
 	t += "REQUESTED BY: [O.orderedby]<br>"
-	t += "RANK: [O.orderedrank]<br>"
+	t += "ASSIGNMENT: [O.orderedrank]<br>"
 	t += "REASON: [O.reason]<br>"
 	t += "SUPPLY CRATE TYPE: [O.object.name]<br>"
 	t += "ACCESS RESTRICTION: [get_access_desc(O.object.access)]<br>"

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -29,7 +29,7 @@
 				read_string_stability = 80
 			. += "Registered Name: [stars(stored_card.registered_name, read_string_stability)]\n"
 			. += "Registered Assignment: [stars(stored_card.assignment, read_string_stability)]\n"
-			. += "Registered Rank: [stars(stored_card.rank, read_string_stability)]\n"
+			. += "Registered Position: [stars(stored_card.position, read_string_stability)]\n"
 			. += "Access Addresses Enabled: \n"
 			var/list/access_list = stored_card.GetAccess()
 			if(!access_list) // "NONE" for empty list

--- a/code/modules/species/species_helpers.dm
+++ b/code/modules/species/species_helpers.dm
@@ -69,7 +69,7 @@ var/global/list/stored_shock_by_ref = list()
 
 	if(preview_outfit)
 		var/decl/hierarchy/outfit/outfit = outfit_by_type(preview_outfit)
-		outfit.equip(mannequin, equip_adjustments = (OUTFIT_ADJUSTMENT_SKIP_SURVIVAL_GEAR|OUTFIT_ADJUSTMENT_SKIP_BACKPACK))
+		outfit.equip_outfit(mannequin, equip_adjustments = (OUTFIT_ADJUSTMENT_SKIP_SURVIVAL_GEAR|OUTFIT_ADJUSTMENT_SKIP_BACKPACK))
 
 	mannequin.force_update_limbs()
 	mannequin.update_mutations(0)

--- a/code/modules/submaps/submap_join.dm
+++ b/code/modules/submaps/submap_join.dm
@@ -54,7 +54,7 @@
 	if(!check_general_join_blockers(joining, job))
 		return
 
-	log_debug("Player: [joining] is now offsite rank: [job.title] ([name]), JCP:[job.current_positions], JPL:[job.total_positions]")
+	log_debug("Player: [joining] is now offsite job: [job.title] ([name]), JCP:[job.current_positions], JPL:[job.total_positions]")
 	joining.faction = name
 	job.current_positions++
 

--- a/code/modules/submaps/submap_join.dm
+++ b/code/modules/submaps/submap_join.dm
@@ -74,7 +74,7 @@
 
 			// We need to make sure to use the abstract instance here; it's not the same as the one we were passed.
 			character.skillset.obtain_from_client(SSjobs.get_by_path(job.type), character.client)
-			job.equip(character, "")
+			job.equip_job(character)
 			job.apply_fingerprints(character)
 			var/list/spawn_in_storage = SSjobs.equip_custom_loadout(character, job)
 			if(spawn_in_storage)
@@ -113,7 +113,7 @@
 		log_and_message_admins("has joined the round as offsite role [character.mind.assigned_role].", character)
 		callHook("submap_join", list(job, character))
 		if(character.cannot_stand()) equip_wheelchair(character)
-		job.post_equip_rank(character, job.title)
+		job.post_equip_job_title(character, job.title)
 		qdel(joining)
 
 	return character

--- a/maps/antag_spawn/heist/heist_outfit.dm
+++ b/maps/antag_spawn/heist/heist_outfit.dm
@@ -69,7 +69,7 @@
 	randomize_clothing()
 	. = ..()
 
-/decl/hierarchy/outfit/raider/equip(mob/living/carbon/human/H, rank, assignment, equip_adjustments)
+/decl/hierarchy/outfit/raider/equip_outfit(mob/living/carbon/human/H, assignment, equip_adjustments, datum/job/job, datum/mil_rank/rank)
 	randomize_clothing()
 	. = ..()
 	if(. && H)

--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -116,7 +116,7 @@
 	corpse.real_name = "Captain"
 	corpse.name = "Captain"
 	var/decl/hierarchy/outfit/outfit = outfit_by_type(/decl/hierarchy/outfit/deadcap)
-	outfit.equip(corpse)
+	outfit.equip_outfit(corpse)
 	corpse.adjustOxyLoss(corpse.maxHealth)
 	corpse.setBrainLoss(corpse.maxHealth)
 	var/obj/structure/bed/chair/C = locate() in T

--- a/maps/away/liberia/liberia_jobs.dm
+++ b/maps/away/liberia/liberia_jobs.dm
@@ -25,7 +25,7 @@
 		SKILL_PILOT	   = SKILL_BASIC
 	)
 
-/datum/job/submap/merchant/equip(var/mob/living/carbon/human/H)
+/datum/job/submap/merchant/equip_job(var/mob/living/carbon/human/H, var/alt_title, var/datum/mil_branch/branch, var/datum/mil_rank/grade)
 	to_chat(H, "Your connections helped you learn about the words that will help you identify a locals... Particularly interested buyers:")
 	to_chat(H, "<b>Code phases</b>: <span class='danger'>[syndicate_code_phrase]</span>")
 	to_chat(H, "<b>Responses to phrases</b>: <span class='danger'>[syndicate_code_response]</span>")

--- a/maps/exodus/jobs/captain.dm
+++ b/maps/exodus/jobs/captain.dm
@@ -33,7 +33,7 @@
 		/datum/computer_file/program/reports
 	)
 
-/datum/job/captain/equip(var/mob/living/carbon/human/H)
+/datum/job/captain/equip_job(var/mob/living/carbon/human/H)
 	. = ..()
 	if(.)
 		H.implant_loyalty(src)

--- a/maps/exodus/jobs/civilian.dm
+++ b/maps/exodus/jobs/civilian.dm
@@ -304,7 +304,7 @@
 	skill_points = 20
 	software_on_spawn = list(/datum/computer_file/program/reports)
 
-/datum/job/lawyer/equip(var/mob/living/carbon/human/H)
+/datum/job/lawyer/equip_job(var/mob/living/carbon/human/H)
 	. = ..()
 	if(.)
 		H.implant_loyalty(H)

--- a/maps/exodus/jobs/medical.dm
+++ b/maps/exodus/jobs/medical.dm
@@ -200,7 +200,7 @@
 	)
 	give_psionic_implant_on_join = FALSE
 
-/datum/job/counselor/equip(var/mob/living/carbon/human/H)
+/datum/job/counselor/equip_job(var/mob/living/carbon/human/H)
 	if(H.mind.role_alt_title == "Counselor")
 		psi_faculties = list("[PSI_REDACTION]" = PSI_RANK_OPERANT)
 	if(H.mind.role_alt_title == "Mentalist")

--- a/maps/exodus/jobs/security.dm
+++ b/maps/exodus/jobs/security.dm
@@ -85,7 +85,7 @@
 	)
 	event_categories = list(ASSIGNMENT_SECURITY)
 
-/datum/job/hos/equip(var/mob/living/carbon/human/H)
+/datum/job/hos/equip_job(var/mob/living/carbon/human/H)
 	. = ..()
 	if(.)
 		H.implant_loyalty(H)

--- a/maps/exodus/jobs/synthetics.dm
+++ b/maps/exodus/jobs/synthetics.dm
@@ -19,9 +19,8 @@
 	skip_loadout_preview = TRUE
 	department_types = list(/decl/department/miscellaneous)
 
-/datum/job/computer/equip(var/mob/living/carbon/human/H)
-	if(!H)	return 0
-	return 1
+/datum/job/computer/equip_job(var/mob/living/carbon/human/H)
+	return !!H
 
 /datum/job/computer/is_position_available()
 	return (empty_playable_ai_cores.len != 0)
@@ -71,7 +70,7 @@
 	if(H)
 		return H.Robotize(SSrobots.get_mob_type_by_title(alt_title || title))
 
-/datum/job/robot/equip(var/mob/living/carbon/human/H)
+/datum/job/robot/equip_job(var/mob/living/carbon/human/H)
 	return !!H
 
 /datum/job/robot/New()

--- a/maps/ministation/jobs/command.dm
+++ b/maps/ministation/jobs/command.dm
@@ -28,9 +28,9 @@
 	must_fill = 1
 	not_random_selectable = 1
 
-/datum/job/ministation/captain/equip(var/mob/living/carbon/human/H)
+/datum/job/ministation/captain/equip_job(var/mob/living/carbon/human/H)
 	. = ..()
-	if(H) 
+	if(H)
 		H.verbs |= /mob/proc/freetradeunion_rename_company
 
 /datum/job/ministation/captain/get_access()

--- a/maps/ministation/jobs/synthetics.dm
+++ b/maps/ministation/jobs/synthetics.dm
@@ -22,7 +22,7 @@
 	if(H)
 		return H.Robotize(SSrobots.get_mob_type_by_title(alt_title || title))
 
-/datum/job/ministation/robot/equip(var/mob/living/carbon/human/H)
+/datum/job/ministation/robot/equip_job(var/mob/living/carbon/human/H)
 	return !!H
 
 /datum/job/ministation/robot/New()
@@ -51,7 +51,7 @@
 	skip_loadout_preview = TRUE
 	department_types = list(/decl/department/miscellaneous)
 
-/datum/job/ministation/computer/equip(var/mob/living/carbon/human/H)
+/datum/job/ministation/computer/equip_job(var/mob/living/carbon/human/H)
 	return !!H
 
 /datum/job/ministation/computer/is_position_available()

--- a/maps/tradeship/jobs/command.dm
+++ b/maps/tradeship/jobs/command.dm
@@ -29,7 +29,7 @@
 	not_random_selectable = 1
 	forced_spawnpoint = /decl/spawnpoint/cryo/captain
 
-/datum/job/tradeship_captain/equip(var/mob/living/carbon/human/H)
+/datum/job/tradeship_captain/equip_job(var/mob/living/carbon/human/H, var/alt_title, var/datum/mil_branch/branch, var/datum/mil_rank/grade)
 	. = ..()
 	if(H)
 		H.verbs |= /mob/proc/tradehouse_rename_ship

--- a/maps/tradeship/jobs/synthetics.dm
+++ b/maps/tradeship/jobs/synthetics.dm
@@ -22,7 +22,7 @@
 	if(H)
 		return H.Robotize(SSrobots.get_mob_type_by_title(alt_title || title))
 
-/datum/job/tradeship_robot/equip(var/mob/living/carbon/human/H)
+/datum/job/tradeship_robot/equip_job(var/mob/living/carbon/human/H, var/alt_title, var/datum/mil_branch/branch, var/datum/mil_rank/grade)
 	return !!H
 
 /datum/job/tradeship_robot/New()

--- a/mods/content/corporate/clothing/outfits.dm
+++ b/mods/content/corporate/clothing/outfits.dm
@@ -46,7 +46,7 @@
 /decl/hierarchy/outfit/death_command
 	name = "Spec Ops - Death commando"
 
-/decl/hierarchy/outfit/death_command/equip(mob/living/carbon/human/H, rank, assignment, equip_adjustments)
+/decl/hierarchy/outfit/death_command/equip_outfit(mob/living/carbon/human/H, assignment, equip_adjustments, datum/job/job, datum/mil_rank/rank)
 	var/decl/special_role/deathsquad = GET_DECL(/decl/special_role/deathsquad)
 	deathsquad.equip(H)
 	return 1
@@ -54,7 +54,7 @@
 /decl/hierarchy/outfit/syndicate_command
 	name = "Spec Ops - Syndicate commando"
 
-/decl/hierarchy/outfit/syndicate_command/equip(mob/living/carbon/human/H, rank, assignment, equip_adjustments)
+/decl/hierarchy/outfit/syndicate_command/equip_outfit(mob/living/carbon/human/H, assignment, equip_adjustments, datum/job/job, datum/mil_rank/rank)
 	var/decl/special_role/commandos = GET_DECL(/decl/special_role/deathsquad/mercenary)
 	commandos.equip(H)
 	return 1

--- a/mods/content/psionics/datum/jobs.dm
+++ b/mods/content/psionics/datum/jobs.dm
@@ -6,7 +6,7 @@
 /datum/job/submap
 	give_psionic_implant_on_join = FALSE
 
-/datum/job/equip(var/mob/living/carbon/human/H, var/alt_title, var/datum/mil_branch/branch, var/datum/mil_rank/grade)
+/datum/job/equip_job(var/mob/living/carbon/human/H, var/alt_title, var/datum/mil_branch/branch, var/datum/mil_rank/grade)
 	. = ..()
 	if(psi_latency_chance && prob(psi_latency_chance))
 		H.set_psi_rank(pick(PSI_COERCION, PSI_REDACTION, PSI_ENERGISTICS, PSI_PSYCHOKINESIS), 1, defer_update = TRUE)

--- a/mods/mobs/borers/datum/symbiote.dm
+++ b/mods/mobs/borers/datum/symbiote.dm
@@ -29,7 +29,7 @@ var/global/list/symbiote_starting_points = list()
 /decl/hierarchy/outfit/job/symbiote_host
 	name = "Job - Symbiote Host"
 
-/datum/job/symbiote/post_equip_rank(var/mob/person, var/alt_title)
+/datum/job/symbiote/post_equip_job_title(var/mob/person, var/alt_title)
 
 	var/mob/living/simple_animal/borer/symbiote = person
 	symbiote.SetName(symbiote.truename)
@@ -118,7 +118,7 @@ var/global/list/symbiote_starting_points = list()
 			return
 
 /datum/job/symbiote/is_position_available()
-	. = ..() && length(find_valid_hosts(TRUE)) 
+	. = ..() && length(find_valid_hosts(TRUE))
 
 /obj/abstract/landmark/symbiote_start
 	name = "Symbiote Start"

--- a/mods/species/vox/datum/antagonism.dm
+++ b/mods/species/vox/datum/antagonism.dm
@@ -17,7 +17,7 @@
 	hands =      list(/obj/item/gun/launcher/alien/spikethrower)
 	id_type =    /obj/item/card/id/syndicate
 
-/decl/hierarchy/outfit/vox_raider/equip(mob/living/carbon/human/H, rank, assignment, equip_adjustments)
+/decl/hierarchy/outfit/vox_raider/equip_outfit(mob/living/carbon/human/H, assignment, equip_adjustments, datum/job/job, datum/mil_rank/rank)
 	uniform = pick(/obj/item/clothing/under/vox/vox_robes, /obj/item/clothing/under/vox/vox_casual)
 	glasses = pick(/obj/item/clothing/glasses/thermal, /obj/item/clothing/glasses/thermal/plain/eyepatch, /obj/item/clothing/glasses/thermal/plain/monocle)
 	holster = pick(/obj/item/clothing/accessory/storage/holster/armpit, /obj/item/clothing/accessory/storage/holster/waist, /obj/item/clothing/accessory/storage/holster/hip)
@@ -39,13 +39,13 @@
 	if(!istype(user) || !user.mind || !user.mind.assigned_special_role != raiders || user.species.name == SPECIES_VOX || !is_alien_whitelisted(user, SPECIES_VOX))
 		return ..()
 
-	var/choice = input("Do you wish to become a Vox of the Shoal? This is not reversible.") as null|anything in list("No","Yes")
+	var/choice = input("Do you wish to become a vox of the Shoal? This is not reversible.") as null|anything in list("No","Yes")
 	if(choice != "Yes")
 		return ..()
 
 	var/decl/hierarchy/outfit/outfit = GET_DECL(/decl/hierarchy/outfit/vox_raider)
 	var/mob/living/carbon/human/vox/vox = new(get_turf(src), SPECIES_VOX)
-	outfit.equip(vox)
+	outfit.equip_outfit(vox)
 	if(user.mind)
 		user.mind.transfer_to(vox)
 	qdel(user)


### PR DESCRIPTION
## Description of changes
Fixes https://github.com/ScavStation/ScavStation/issues/799. More specifically:
- `equip_rank` -> `equip_job_title` to disambiguate from military rank datums, which are also passed around these procs.
- `equip()` to `equip_outfit()` and `equip_job()` for searchability.
- `equip_id` override merged into base proc.
- `equip_id` calls unified on the outfit datum in the `equip_outfit` chain.
- `equip_outfit` arguments somewhat simplified/cleaned up.
- `setup_account()` moved prior to outfit dressing.

## Why and what will this PR improve
Fixes issues with equip ordering and ID not having assignment or account info set sometimes.

## Authorship
Myself.

## Changelog
Nothing player-facing.