### PR TITLE
Silicon radio fixes

### DIFF
--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -59,6 +59,8 @@ SUBSYSTEM_DEF(mapping)
 
 /datum/controller/subsystem/mapping/Initialize(timeofday)
 
+	reindex_lists()
+
 	// Load our banned map list, if we have one.
 	if(banned_dmm_location && fexists(banned_dmm_location))
 		banned_maps = cached_json_decode(safe_file2text(banned_dmm_location))

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -83,6 +83,7 @@
 // It then processes the message_mode to implement an additional behavior needed for the message, such
 // as retrieving radios or looking for an intercom nearby.
 /mob/living/proc/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
+	SHOULD_CALL_PARENT(TRUE)
 	if(!message_mode)
 		return
 	var/list/assess_items_as_radios = get_radios(message_mode)
@@ -117,6 +118,10 @@
 		message += "."
 
 	return html_encode(message)
+
+/mob/living/proc/handle_mob_specific_speech(message, message_mode, verb = "says", decl/language/speaking)
+	SHOULD_CALL_PARENT(TRUE)
+	return FALSE
 
 /mob/living/say(var/message, var/decl/language/speaking, var/verb = "says", var/alt_name = "", whispering)
 	set waitfor = FALSE
@@ -157,6 +162,9 @@
 				to_chat(src, SPAN_WARNING("You don't know a language and cannot speak."))
 				emote("custom", AUDIBLE_MESSAGE, "[pick("grunts", "babbles", "gibbers", "jabbers", "burbles")] aimlessly.")
 				return
+
+	if(handle_mob_specific_speech(message, message_mode, verb, speaking))
+		return
 
 	// This is broadcast to all mobs with the language,
 	// irrespective of distance or anything else.

--- a/code/modules/mob/living/silicon/pai/say.dm
+++ b/code/modules/mob/living/silicon/pai/say.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/pai/say(var/msg)
 	if(silence_time)
-		to_chat(src, SPAN_WARNING("Communication circuits remain uninitialized."))
-	else
-		..(msg)
+		to_chat(src, SPAN_WARNING("Communication circuits are disabled."))
+		return
+	return ..(msg)

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -1,34 +1,27 @@
-/mob/living/silicon/say(var/message, var/sanitize = 1)
-	return ..(sanitize ? sanitize(message) : message)
+/mob/living/silicon/get_radios(var/message_mode)
+	. = ..()
+	if(message_mode && silicon_radio)
+		LAZYDISTINCTADD(., silicon_radio)
 
-/mob/living/silicon/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
-	log_say("[key_name(src)] : [message]")
+/mob/living/silicon/robot/get_radios(var/message_mode)
+	. = ..()
+	if((silicon_radio in .) && !is_component_functioning("radio"))
+		to_chat(src, SPAN_WARNING("Your radio isn't functional at this time."))
+		LAZYREMOVE(., silicon_radio)
 
-/mob/living/silicon/robot/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
-	if(message_mode)
-		if(!is_component_functioning("radio"))
-			to_chat(src, SPAN_WARNING("Your radio isn't functional at this time."))
-		else
-			used_radios += silicon_radio
-		. = TRUE
+/mob/living/silicon/ai/handle_mob_specific_speech(message, message_mode, verb = "says", decl/language/speaking)
+	if(message_mode == MESSAGE_MODE_DEPARTMENT)
+		holopad_talk(message, verb, speaking)
+		return TRUE
 	return ..()
 
-/mob/living/silicon/ai/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
-	if(message_mode)
-		if(message_mode == MESSAGE_MODE_DEPARTMENT)
-			holopad_talk(message, verb, speaking)
-		else if (ai_radio.disabledAi || !has_power() || stat)
+/mob/living/silicon/ai/get_radios(var/message_mode)
+	. = ..()
+	if(ai_radio)
+		if(ai_radio.disabledAi || !has_power() || stat)
 			to_chat(src, SPAN_DANGER("System Error - Transceiver Disabled."))
 		else
-			used_radios += ai_radio
-		. = TRUE
-	..()
-
-/mob/living/silicon/pai/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
-	if(message_mode)
-		used_radios += silicon_radio
-		. = TRUE
-	..()
+			LAZYDISTINCTADD(., ai_radio)
 
 /mob/living/silicon/say_quote(var/text)
 	var/ending = copytext(text, length(text))

--- a/maps/ministation/jobs/synthetics.dm
+++ b/maps/ministation/jobs/synthetics.dm
@@ -13,7 +13,7 @@
 	hud_icon = "hudblank"
 	skill_points = 0
 	no_skill_buffs = TRUE
-	guestbanned = 1	
+	guestbanned = 1
 	not_random_selectable = 1
 	skip_loadout_preview = TRUE
 	department_types = list(/decl/department/miscellaneous)
@@ -51,7 +51,7 @@
 	skip_loadout_preview = TRUE
 	department_types = list(/decl/department/miscellaneous)
 
-/datum/job/ministation/computer/equip_job(var/mob/living/carbon/human/H)
+/datum/job/ministation/computer/equip(var/mob/living/carbon/human/H)
 	return !!H
 
 /datum/job/ministation/computer/is_position_available()

--- a/maps/ministation/jobs/synthetics.dm
+++ b/maps/ministation/jobs/synthetics.dm
@@ -29,3 +29,51 @@
 	..()
 	alt_titles = SSrobots.robot_alt_titles.Copy()
 	alt_titles -= title
+
+/datum/job/ministation/computer
+	title = "Computer"
+	event_categories = list(ASSIGNMENT_COMPUTER)
+	total_positions = 0
+	spawn_positions = 1
+	selection_color = "#3f823f"
+	supervisors = "your laws"
+	req_admin_notify = 1
+	minimal_player_age = 14
+	account_allowed = 0
+	economic_power = 0
+	outfit_type = /decl/hierarchy/outfit/job/silicon/ai
+	loadout_allowed = FALSE
+	hud_icon = "hudblank"
+	skill_points = 0
+	no_skill_buffs = TRUE
+	guestbanned = 1
+	not_random_selectable = 1
+	skip_loadout_preview = TRUE
+	department_types = list(/decl/department/miscellaneous)
+
+/datum/job/ministation/computer/equip_job(var/mob/living/carbon/human/H)
+	return !!H
+
+/datum/job/ministation/computer/is_position_available()
+	return (empty_playable_ai_cores.len != 0)
+
+/datum/job/ministation/computer/handle_variant_join(var/mob/living/carbon/human/H, var/alt_title)
+	return H
+
+/datum/job/ministation/computer/do_spawn_special(var/mob/living/character, var/mob/new_player/new_player_mob, var/latejoin)
+	character = character.AIize(move=0) // AIize the character, but don't move them yet
+
+	// is_available for AI checks that there is an empty core available in this list
+	var/obj/structure/aicore/deactivated/C = empty_playable_ai_cores[1]
+	empty_playable_ai_cores -= C
+
+	character.forceMove(C.loc)
+	var/mob/living/silicon/ai/A = character
+	A.on_mob_init()
+
+	if(latejoin)
+		new_player_mob.AnnounceCyborg(character, title, "has been downloaded to the empty core in \the [get_area_name(src)]")
+	SSticker.mode.handle_latejoin(character)
+
+	qdel(C)
+	return TRUE

--- a/maps/ministation/ministation_jobs.dm
+++ b/maps/ministation/ministation_jobs.dm
@@ -8,6 +8,7 @@
 		/datum/job/ministation/captain,
 		/datum/job/ministation/cargo,
 		/datum/job/ministation/robot,
+		/datum/job/ministation/computer,
 		/datum/job/ministation/detective,
 		/datum/job/ministation/doctor,
 		/datum/job/ministation/engineer,


### PR DESCRIPTION
## Description of changes
- Adds a Computer job to ministation for testing.
- Adds a `reindex_lists()` call to SSmapping so mobs on ministation don't runtime out the wazoo trying to access weather info.
- Removes and replaces outdated silicon saycode so they can actually use their radios.

## Why and what will this PR improve
Fixes https://github.com/ScavStation/ScavStation/issues/798

## Authorship
Myself.

## Changelog
Nothing player-facing.