### PR TITLE
Fix various matter-related issues

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -81,6 +81,7 @@ The latter will result in a linter warning and will not work correctly.
 #define ITEM_FLAG_CAN_HIDE_IN_SHOES       BITFLAG(12) // Items that can be hidden in shoes that permit it
 #define ITEM_FLAG_PADDED                  BITFLAG(13) // When set on gloves, will act like pulling punches in unarmed combat.
 #define ITEM_FLAG_CAN_TAPE                BITFLAG(14) //Whether the item can be be taped onto something using tape
+#define ITEM_FLAG_IS_WEAPON               BITFLAG(15) // Item is considered a weapon. Currently only used for force-based worth calculation.
 
 // Flags for pass_flags (/atom/var/pass_flags)
 #define PASS_FLAG_TABLE                   BITFLAG(0)

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -57,7 +57,6 @@
 				src.health -= W.force * 0.75
 			if(BRUTE)
 				src.health -= W.force * 0.5
-			else
 		if (src.health <= 0)
 			src.explode()
 		..()
@@ -91,7 +90,7 @@
 /obj/machinery/deployable/barrier/physically_destroyed(skip_qdel)
 	SSmaterials.create_object(/decl/material/solid/metal/steel, get_turf(src), 1, /obj/item/stack/material/rods)
 	. = ..()
-	
+
 /obj/machinery/deployable/barrier/proc/explode()
 	visible_message("<span class='danger'>[src] blows apart!</span>")
 	spark_at(src, cardinal_only = TRUE)

--- a/code/game/objects/items/weapons/candle/candle.dm
+++ b/code/game/objects/items/weapons/candle/candle.dm
@@ -51,6 +51,8 @@
 /obj/item/flame/candle/proc/light(mob/user)
 	if(!lit)
 		lit = TRUE
+		damtype = BURN
+		update_force()
 		visible_message(SPAN_NOTICE("\The [user] lights \the [src]."), SPAN_NOTICE("You light \the [src]."))
 		set_light(candle_range, candle_power)
 		START_PROCESSING(SSobj, src)

--- a/code/game/objects/items/weapons/candle/candle.dm
+++ b/code/game/objects/items/weapons/candle/candle.dm
@@ -48,12 +48,12 @@
 		var/obj/item/flame/candle/other_candle = A
 		other_candle.light()
 
-/obj/item/flame/candle/proc/light(mob/user)
+/obj/item/flame/candle/light(mob/user, no_message)
 	if(!lit)
-		lit = TRUE
-		damtype = BURN
+		..()
 		update_force()
-		user.visible_message(SPAN_NOTICE("\The [user] lights \the [src]."), SPAN_NOTICE("You light \the [src]."))
+		if(!no_message)
+			user.visible_message(SPAN_NOTICE("\The [user] lights \the [src]."), SPAN_NOTICE("You light \the [src]."))
 		set_light(candle_range, candle_power)
 		START_PROCESSING(SSobj, src)
 
@@ -73,7 +73,7 @@
 
 /obj/item/flame/candle/attack_self(mob/user)
 	if(lit)
-		lit = FALSE
+		extinguish(user)
 		update_icon()
 		set_light(0)
 		remove_extension(src, /datum/extension/scent)
@@ -89,6 +89,6 @@
 	max_storage_space = 7
 	slot_flags = SLOT_LOWER_BODY
 	material = /decl/material/solid/cardboard
-	
+
 /obj/item/storage/candle_box/WillContain()
 	return list(/obj/item/flame/candle = 7)

--- a/code/game/objects/items/weapons/candle/candle.dm
+++ b/code/game/objects/items/weapons/candle/candle.dm
@@ -53,7 +53,7 @@
 		lit = TRUE
 		damtype = BURN
 		update_force()
-		visible_message(SPAN_NOTICE("\The [user] lights \the [src]."), SPAN_NOTICE("You light \the [src]."))
+		user.visible_message(SPAN_NOTICE("\The [user] lights \the [src]."), SPAN_NOTICE("You light \the [src]."))
 		set_light(candle_range, candle_power)
 		START_PROCESSING(SSobj, src)
 

--- a/code/game/objects/items/weapons/candle/candle.dm
+++ b/code/game/objects/items/weapons/candle/candle.dm
@@ -50,8 +50,8 @@
 
 /obj/item/flame/candle/proc/light(mob/user)
 	if(!lit)
-		lit = 1
-		visible_message("<span class='notice'>\The [user] lights the [name].</span>")
+		lit = TRUE
+		visible_message(SPAN_NOTICE("\The [user] lights \the [src]."), SPAN_NOTICE("You light \the [src]."))
 		set_light(candle_range, candle_power)
 		START_PROCESSING(SSobj, src)
 
@@ -71,7 +71,7 @@
 
 /obj/item/flame/candle/attack_self(mob/user)
 	if(lit)
-		lit = 0
+		lit = FALSE
 		update_icon()
 		set_light(0)
 		remove_extension(src, /datum/extension/scent)

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -78,7 +78,7 @@
 		to_chat(user,SPAN_NOTICE("There's no cartridge connected."))
 
 /obj/item/clothing/mask/smokable/ecig/proc/Deactivate()
-	lit = 0
+	lit = FALSE
 	STOP_PROCESSING(SSobj, src)
 	update_icon()
 

--- a/code/game/objects/items/weapons/flame.dm
+++ b/code/game/objects/items/weapons/flame.dm
@@ -13,6 +13,7 @@
 /obj/item/flame/proc/extinguish(var/mob/user, var/no_message)
 	lit = FALSE
 	damtype = BRUTE
+	update_force()
 	STOP_PROCESSING(SSobj, src)
 
 /obj/item/flame/fluid_act(var/datum/reagents/fluids)
@@ -44,6 +45,7 @@
 	slot_flags = SLOT_EARS
 	attack_verb = list("burnt", "singed")
 	randpixel = 10
+	max_force = 1
 
 /obj/item/flame/match/Process()
 	if(isliving(loc))
@@ -71,7 +73,7 @@
 	. = ..()
 	name = "burnt match"
 	desc = "A match. This one has seen better days."
-	burnt = 1
+	burnt = TRUE
 	update_icon()
 
 /obj/item/flame/match/on_update_icon()

--- a/code/game/objects/items/weapons/flame.dm
+++ b/code/game/objects/items/weapons/flame.dm
@@ -40,6 +40,7 @@
 	icon_state = ICON_STATE_WORLD
 	var/burnt = 0
 	var/smoketime = 5
+	obj_flags = OBJ_FLAG_HOLLOW // so that it's not super overpriced compared to lighters
 	w_class = ITEM_SIZE_TINY
 	origin_tech = "{'materials':1}"
 	slot_flags = SLOT_EARS

--- a/code/game/objects/items/weapons/flame.dm
+++ b/code/game/objects/items/weapons/flame.dm
@@ -2,7 +2,7 @@
 /obj/item/flame
 	var/lit_heat = 1000
 	var/waterproof = FALSE
-	var/lit = 0
+	var/lit = FALSE
 	material = /decl/material/solid/wood
 
 /obj/item/flame/afterattack(var/obj/O, var/mob/user, proximity)
@@ -11,7 +11,7 @@
 		O.HandleObjectHeating(src, user, 700)
 
 /obj/item/flame/proc/extinguish(var/mob/user, var/no_message)
-	lit = 0
+	lit = FALSE
 	damtype = BRUTE
 	STOP_PROCESSING(SSobj, src)
 

--- a/code/game/objects/items/weapons/flame.dm
+++ b/code/game/objects/items/weapons/flame.dm
@@ -24,6 +24,14 @@
 			location.hotspot_expose(700, 5) // Potentially set fire to fuel etc.
 		extinguish(no_message = TRUE)
 
+/obj/item/flame/proc/light(mob/user, no_message)
+	if(lit)
+		return
+	lit = TRUE
+	damtype = BURN
+	update_force()
+	update_icon()
+
 /obj/item/flame/get_heat()
 	. = max(..(), lit ? lit_heat : 0)
 
@@ -48,6 +56,14 @@
 	randpixel = 10
 	max_force = 1
 
+/obj/item/flame/match/light(mob/user, no_message)
+	if(burnt)
+		return
+	if(lit)
+		return
+	. = ..()
+	START_PROCESSING(SSobj, src)
+
 /obj/item/flame/match/Process()
 	if(isliving(loc))
 		var/mob/living/M = loc
@@ -70,12 +86,13 @@
 		extinguish()
 	return ..()
 
-/obj/item/flame/match/extinguish(var/mob/user, var/no_message)
+/obj/item/flame/match/extinguish(var/mob/user, var/no_message, var/burn = TRUE)
 	. = ..()
-	name = "burnt match"
-	desc = "A match. This one has seen better days."
-	burnt = TRUE
-	update_icon()
+	if(burn)
+		name = "burnt match"
+		desc = "A match. This one has seen better days."
+		burnt = TRUE
+		update_icon()
 
 /obj/item/flame/match/on_update_icon()
 	. = ..()

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -32,9 +32,9 @@
 
 /obj/item/flame/lighter/proc/light(mob/user)
 	if(submerged())
-		to_chat(user, "<span class='warning'>You cannot light \the [src] underwater.</span>")
+		to_chat(user, SPAN_WARNING("You cannot light \the [src] underwater."))
 		return
-	lit = 1
+	lit = TRUE
 	update_icon()
 	light_effects(user)
 	set_light(2, l_color = COLOR_PALE_ORANGE)

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -6,8 +6,7 @@
 	item_state = "lighter"
 	w_class = ITEM_SIZE_TINY
 	throwforce = 4
-	obj_flags = OBJ_FLAG_CONDUCTIBLE
-	obj_flags = OBJ_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_CONDUCTIBLE | OBJ_FLAG_HOLLOW
 	slot_flags = SLOT_LOWER_BODY
 	attack_verb = list("burnt", "singed")
 	lit_heat = 1500

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -6,12 +6,12 @@
 	item_state = "lighter"
 	w_class = ITEM_SIZE_TINY
 	throwforce = 4
-	obj_flags = OBJ_FLAG_CONDUCTIBLE | OBJ_FLAG_HOLLOW
+	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_LOWER_BODY
 	attack_verb = list("burnt", "singed")
 	lit_heat = 1500
 	material = /decl/material/solid/plastic
-	matter = list(/decl/material/solid/metal/steel = MATTER_AMOUNT_TRACE)
+	matter = list(/decl/material/solid/metal/steel = MATTER_AMOUNT_REINFORCEMENT)
 	var/tmp/max_fuel = 5
 
 /obj/item/flame/lighter/Initialize()

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -29,11 +29,13 @@
 /obj/item/flame/lighter/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/fuel, max_fuel)
 
-/obj/item/flame/lighter/proc/light(mob/user)
+/obj/item/flame/lighter/light(mob/user)
 	if(submerged())
 		to_chat(user, SPAN_WARNING("You cannot light \the [src] underwater."))
 		return
-	lit = TRUE
+	if(lit)
+		return
+	..()
 	update_icon()
 	light_effects(user)
 	set_light(2, l_color = COLOR_PALE_ORANGE)

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -11,7 +11,7 @@
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	sharp = TRUE
 	edge = TRUE
-	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES | ITEM_FLAG_IS_WEAPON
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME
 	pickup_sound = 'sound/foley/knife1.ogg'
 	drop_sound = 'sound/foley/knifedrop3.ogg'

--- a/code/game/objects/items/weapons/material/misc.dm
+++ b/code/game/objects/items/weapons/material/misc.dm
@@ -7,6 +7,7 @@
 	icon_state = "harpoon"
 	item_state = "harpoon"
 	max_force = 20
+	item_flags = ITEM_FLAG_IS_WEAPON
 	material_force_multiplier = 0.3 // 18 with hardness 60 (steel)
 	thrown_material_force_multiplier = 0.6
 	attack_verb = list("jabbed","stabbed","ripped")
@@ -50,6 +51,7 @@
 	icon = 'icons/obj/items/tool/hatchet.dmi'
 	icon_state = "hatchet"
 	max_force = 15
+	item_flags = ITEM_FLAG_IS_WEAPON
 	material_force_multiplier = 0.2 // 12 with hardness 60 (steel)
 	thrown_material_force_multiplier = 0.25 // 15 with weight 60 (steel)
 	w_class = ITEM_SIZE_SMALL

--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/items/weapon/swords/claymore.dmi'
 	slot_flags = SLOT_LOWER_BODY
 	w_class = ITEM_SIZE_LARGE
+	item_flags = ITEM_FLAG_IS_WEAPON
 	material_force_multiplier = 0.5 // 30 when wielded with hardnes 60 (steel)
 	armor_penetration = 10
 	thrown_material_force_multiplier = 0.16 // 10 when thrown with weight 60 (steel)
@@ -16,7 +17,7 @@
 	melee_accuracy_bonus = 10
 	material = /decl/material/solid/metal/steel
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME
-	pickup_sound = 'sound/foley/knife1.ogg' 
+	pickup_sound = 'sound/foley/knife1.ogg'
 	drop_sound = 'sound/foley/knifedrop3.ogg'
 
 	var/draw_handle = TRUE
@@ -34,7 +35,7 @@
 		attack_verb = list("attacked", "smashed", "jabbed", "smacked", "prodded", "bonked")
 		hitsound = "chop"
 	. = ..()
-	
+
 /obj/item/sword/on_update_icon()
 	. = ..()
 	if(material_alteration & MAT_FLAG_ALTERATION_COLOR)

--- a/code/game/objects/items/weapons/material/thrown.dm
+++ b/code/game/objects/items/weapons/material/thrown.dm
@@ -12,6 +12,10 @@
 	edge =  1
 	material = /decl/material/solid/metal/steel
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME
+	item_flags = ITEM_FLAG_IS_WEAPON
+
+/obj/item/star/get_max_weapon_value()
+	return throwforce
 
 /obj/item/star/throw_impact(atom/hit_atom)
 	..()

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -18,6 +18,7 @@
  */
 /obj/item/twohanded
 	w_class = ITEM_SIZE_HUGE
+	item_flags = ITEM_FLAG_IS_WEAPON
 	slot_flags = SLOT_BACK
 	icon_state = ICON_STATE_WORLD
 	pickup_sound = 'sound/foley/scrape1.ogg'

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -6,6 +6,7 @@
 
 	icon_state = ICON_STATE_WORLD
 	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_NO_BLOOD
+	item_flags = ITEM_FLAG_IS_WEAPON
 	w_class = ITEM_SIZE_SMALL
 	hitsound = 'sound/weapons/genhit.ogg'
 
@@ -43,6 +44,9 @@
 	attack_verb =                   list("hit")
 	var/list/active_attack_verb	=   list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	var/list/inactive_attack_verb = list("hit")
+
+/obj/item/energy_blade/get_max_weapon_value()
+	return active_force
 
 /obj/item/energy_blade/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
 	. = ..()

--- a/code/game/objects/items/weapons/melee/energy_axe.dm
+++ b/code/game/objects/items/weapons/melee/energy_axe.dm
@@ -12,6 +12,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_NO_BLOOD
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	item_flags = ITEM_FLAG_IS_WEAPON
 	origin_tech = "{'magnets':3,'combat':4}"
 	active_attack_verb =   list("attacked", "chopped", "cleaved", "torn", "cut")
 	inactive_attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -7,6 +7,7 @@
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_LOWER_BODY
 	force = 10
+	item_flags = ITEM_FLAG_IS_WEAPON
 	throwforce = 7
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = "{'combat':4}"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -438,8 +438,8 @@
 
 /obj/item/storage/box/matches/attackby(obj/item/flame/match/W, mob/user)
 	if(istype(W) && !W.lit && !W.burnt)
-		W.lit = 1
-		W.damtype = "burn"
+		W.lit = TRUE
+		W.damtype = BURN
 		W.update_icon()
 		START_PROCESSING(SSobj, W)
 		playsound(src.loc, 'sound/items/match.ogg', 60, 1, -4)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -438,11 +438,7 @@
 
 /obj/item/storage/box/matches/attackby(obj/item/flame/match/W, mob/user)
 	if(istype(W) && !W.lit && !W.burnt)
-		W.lit = TRUE
-		W.damtype = BURN
-		W.update_force()
-		W.update_icon()
-		START_PROCESSING(SSobj, W)
+		W.light()
 		playsound(src.loc, 'sound/items/match.ogg', 60, 1, -4)
 		user.visible_message(SPAN_NOTICE("[user] strikes [W] on \the [src]."), SPAN_NOTICE("You strike [W] on \the [src]."))
 	W.update_icon()

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -440,10 +440,11 @@
 	if(istype(W) && !W.lit && !W.burnt)
 		W.lit = TRUE
 		W.damtype = BURN
+		W.update_force()
 		W.update_icon()
 		START_PROCESSING(SSobj, W)
 		playsound(src.loc, 'sound/items/match.ogg', 60, 1, -4)
-		user.visible_message("<span class='notice'>[user] strikes the match on the matchbox.</span>")
+		user.visible_message(SPAN_NOTICE("[user] strikes [W] on \the [src]."), SPAN_NOTICE("You strike [W] on \the [src]."))
 	W.update_icon()
 	return
 

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -19,6 +19,7 @@
 		/decl/material/solid/metal/copper = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/silicon      = MATTER_AMOUNT_REINFORCEMENT,
 	)
+	item_flags = ITEM_FLAG_IS_WEAPON
 	var/stunforce = 0
 	var/agonyforce = 30
 	var/status = 0		//whether the thing is on or not

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -14,6 +14,7 @@
 	icon_state = ICON_STATE_WORLD
 	slot_flags = SLOT_LOWER_BODY
 	force = 10
+	item_flags = ITEM_FLAG_IS_WEAPON
 	material = /decl/material/solid/wood
 
 /obj/item/classic_baton/attack(mob/M, mob/living/user)
@@ -37,6 +38,7 @@
 	slot_flags = SLOT_LOWER_BODY
 	w_class = ITEM_SIZE_SMALL
 	force = 3
+	item_flags = ITEM_FLAG_IS_WEAPON
 	material = /decl/material/solid/metal/aluminium
 	var/on = 0
 

--- a/code/game/objects/items/weapons/tools/crowbar.dm
+++ b/code/game/objects/items/weapons/tools/crowbar.dm
@@ -14,6 +14,7 @@
 	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked")
 	material_alteration = MAT_FLAG_ALTERATION_COLOR
 	drop_sound = 'sound/foley/bardrop1.ogg'
+	item_flags = ITEM_FLAG_IS_WEAPON
 	var/static/valid_colours = list(COLOR_RED_GRAY, COLOR_MAROON, COLOR_DARK_BROWN, COLOR_GRAY20)
 	var/handle_color
 	var/shape_variations = 1

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -6,6 +6,7 @@
 	item_state = "nullrod"
 	slot_flags = SLOT_LOWER_BODY
 	force = 10
+	item_flags = ITEM_FLAG_IS_WEAPON
 	throw_speed = 1
 	throw_range = 4
 	throwforce = 7

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -35,7 +35,7 @@
 	return ..()
 
 /obj/proc/get_matter_amount_modifier()
-	. = CEILING(w_class * BASE_OBJECT_MATTER_MULTPLIER)
+	. = w_class * BASE_OBJECT_MATTER_MULTPLIER
 
 /obj/assume_air(datum/gas_mixture/giver)
 	return loc?.assume_air(giver)

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -195,6 +195,8 @@
 			var/obj/item/flame/match/match = thing
 			if(!match.burnt && !match.lit)
 				match.lit = TRUE
+				match.damtype = BURN
+				match.update_force()
 				match.update_icon()
 				return TRUE
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -526,7 +526,7 @@ var/global/list/hygiene_props = list()
 		return
 
 	if(can_use(1))
-		visible_message(SPAN_NOTICE("\The [usr] tears a sheet from \the [src]."), SPAN_NOTICE("You tear a sheet from \the [src]."))
+		usr.visible_message(SPAN_NOTICE("\The [usr] tears a sheet from \the [src]."), SPAN_NOTICE("You tear a sheet from \the [src]."))
 		var/obj/item/paper/crumpled/bog/C =  new(loc)
 		usr.put_in_hands(C)
 

--- a/code/modules/clothing/masks/chewable.dm
+++ b/code/modules/clothing/masks/chewable.dm
@@ -4,6 +4,8 @@
 	icon = 'icons/clothing/mask/chewables/lollipop.dmi'
 	body_parts_covered = 0
 	bodytype_equip_flags = null
+	origin_tech = null
+	matter = null // no plastic/fiberglass
 
 	var/type_butt = null
 	var/chem_volume = 0
@@ -62,6 +64,7 @@
 	chem_volume = 50
 	chewtime = 300
 	brand = "tobacco"
+	material = /decl/material/solid/plantmatter
 
 /obj/item/trash/cigbutt/spitwad
 	name = "spit wad"
@@ -120,6 +123,7 @@
 	slot_flags = SLOT_EARS | SLOT_FACE
 	chem_volume = 50
 	chewtime = 300
+	material = /decl/material/liquid/nutriment/sugar
 	var/initial_payload_amount = 3
 
 /obj/item/clothing/mask/chewable/candy/populate_reagents()

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -6,7 +6,7 @@
 	bodytype_equip_flags = null
 	z_flags = ZMM_MANGLE_PLANES
 
-	var/lit = 0
+	var/lit = FALSE
 	var/waterproof = FALSE
 	var/type_butt = null
 	var/chem_volume = 0
@@ -131,7 +131,7 @@
 		if(submerged())
 			to_chat(usr, SPAN_WARNING("You cannot light \the [src] underwater."))
 			return
-		lit = 1
+		lit = TRUE
 		damtype = BURN
 		if(REAGENT_VOLUME(reagents, /decl/material/liquid/fuel)) // the fuel explodes
 			var/datum/effect/effect/system/reagents_explosion/e = new()
@@ -149,7 +149,7 @@
 		START_PROCESSING(SSobj, src)
 
 /obj/item/clothing/mask/smokable/proc/extinguish(var/mob/user, var/no_message)
-	lit = 0
+	lit = FALSE
 	damtype = BRUTE
 	STOP_PROCESSING(SSobj, src)
 	set_light(0)
@@ -518,7 +518,7 @@
 		if(submerged())
 			to_chat(usr, SPAN_WARNING("You cannot light \the [src] underwater."))
 			return
-		lit = 1
+		lit = TRUE
 		damtype = BURN
 		var/turf/T = get_turf(src)
 		T.visible_message(flavor_text)
@@ -542,7 +542,7 @@
 /obj/item/clothing/mask/smokable/pipe/attack_self(var/mob/user)
 	if(lit == 1)
 		user.visible_message(SPAN_NOTICE("[user] puts out [src]."), SPAN_NOTICE("You put out [src]."))
-		lit = 0
+		lit = FALSE
 		update_icon()
 		STOP_PROCESSING(SSobj, src)
 		remove_extension(src, /datum/extension/scent)

--- a/code/modules/economy/worth_items.dm
+++ b/code/modules/economy/worth_items.dm
@@ -16,7 +16,9 @@
 		var/largest_tech_val = 0
 		var/list/tech = cached_json_decode(origin_tech)
 		for(var/t in tech)
-			var/next_tech_val = (tech[t]**2) * 5
+			if(tech[t] <= 1)
+				continue
+			var/next_tech_val = ((tech[t] - 1)**2) * 5
 			if(next_tech_val > largest_tech_val)
 				largest_tech_val = next_tech_val
 		. += largest_tech_val

--- a/code/modules/economy/worth_items.dm
+++ b/code/modules/economy/worth_items.dm
@@ -19,9 +19,9 @@
 			var/next_tech_val = (tech[t]**2) * 5
 			if(next_tech_val > largest_tech_val)
 				largest_tech_val = next_tech_val
-			. += largest_tech_val
+		. += largest_tech_val
 
-	if(force)
+	if(item_flags & ITEM_FLAG_IS_WEAPON && force)
 		var/weapon_value = ((get_max_weapon_value() * 15) * (1 + max(sharp, edge)))
 		if(attack_cooldown <= FAST_WEAPON_COOLDOWN)
 			weapon_value *= 1.5

--- a/code/modules/economy/worth_items.dm
+++ b/code/modules/economy/worth_items.dm
@@ -23,7 +23,7 @@
 				largest_tech_val = next_tech_val
 		. += largest_tech_val
 
-	if(item_flags & ITEM_FLAG_IS_WEAPON && force)
+	if((item_flags & ITEM_FLAG_IS_WEAPON) && force)
 		var/weapon_value = ((get_max_weapon_value() * 15) * (1 + max(sharp, edge)))
 		if(attack_cooldown <= FAST_WEAPON_COOLDOWN)
 			weapon_value *= 1.5

--- a/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
@@ -57,7 +57,7 @@
 	var/obj/item/rsf/M = locate() in equipment
 	M.stored_matter = 30
 	var/obj/item/flame/lighter/zippo/L = locate() in equipment
-	L.lit = 1
+	L.lit = TRUE
 
 /obj/item/robot_module/clerical/butler/finalize_emag()
 	. = ..()

--- a/code/modules/modular_computers/networking/network_cable.dm
+++ b/code/modules/modular_computers/networking/network_cable.dm
@@ -66,7 +66,7 @@
 			if(G)
 				LAZYADD(graphs[G], cable.network_node)
 			cable.update_icon()
-	
+
 	for(var/datum/graph/G in graphs)
 		G.Connect(network_node, graphs[G])
 	update_icon()
@@ -99,7 +99,7 @@
 		network_node.Connect(new_neighbours[1]) // Pick a random new neighbour to connect to and get a new graph.
 		for(var/datum/node/neighbour in new_neighbours.Copy(2))
 			neighbour.Connect(network_node)		// Connect the other neighbours to the network node with its (new) graph.
-	
+
 	return TRUE
 
 /obj/structure/network_cable/Move()
@@ -127,12 +127,12 @@
 	if(T.is_open())
 		var/turf/A = GetBelow(src)
 		var/obj/structure/network_cable/cable = locate() in A
-		if(cable) 
+		if(cable)
 			add_overlay("cable-down")
 	var/turf/U = GetAbove(src)
 	if(U?.is_open())
 		var/obj/structure/network_cable/cable = locate() in U
-		if(cable) 
+		if(cable)
 			add_overlay("cable-up")
 
 /obj/structure/network_cable/terminal
@@ -165,6 +165,7 @@
 	matter = list(
 		/decl/material/solid/plastic = MATTER_AMOUNT_REINFORCEMENT
 	)
+	matter_multiplier = 0.15
 	item_state = "coil"
 
 /obj/item/stack/net_cable_coil/single

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -509,13 +509,12 @@ By design, d1 is the smallest direction and d2 is the highest
 	max_health = ITEM_HEALTH_NO_DAMAGE
 	is_spawnable_type = FALSE
 
-/obj/item/stack/cable_coil/Initialize(mapload, c_length = MAXCOIL, var/param_color = null)
+/obj/item/stack/cable_coil/Initialize(mapload, c_length, var/param_color = null)
 	. = ..(mapload, c_length)
 	set_extension(src, /datum/extension/tool/variable, list(
 		TOOL_CABLECOIL = TOOL_QUALITY_DEFAULT,
 		TOOL_SUTURES =   TOOL_QUALITY_MEDIOCRE
 	))
-	src.amount = c_length
 	if (param_color) // It should be red by default, so only recolor it if parameter was specified.
 		color = param_color
 	update_icon()

--- a/code/modules/power/fission/core.dm
+++ b/code/modules/power/fission/core.dm
@@ -216,7 +216,7 @@
 		if(!user.try_unequip(W, src))
 			return
 		fuel_rods[W] = FALSE // Rod is not exposed to begin with.
-		visible_message(SPAN_NOTICE("\The [user] inserts \a [W] into \the [src]."), SPAN_NOTICE("You insert \a [W] into \the [src]."))
+		user.visible_message(SPAN_NOTICE("\The [user] inserts \a [W] into \the [src]."), SPAN_NOTICE("You insert \a [W] into \the [src]."))
 		return
 	. = ..()
 


### PR DESCRIPTION
## Description of changes
- Fixes single cable coils spawning with the wrong amount.
- Fixes network and electrical cables costing too much when fabricating.
- Fixes lit matches/lighters dealing brute damage instead of burn
- Fixes matches dealing 5 damage
- Fixes chewing tobacco and chewing gum being made of plastic and fiberglass
- Fix visible messages with bad deaf/self messages
- Removes rounding from matter amount modifier
- Update lighter/match object flags to fix overwriting/matter values
- Makes force-based item value calculation only apply to items with the new IS_WEAPON item flag.

## Why and what will this PR improve
Fixes the value and matter of a lot of objects being way too high. Stuff is going to be cheaper and have less matter in it across the board.