### PR TITLE
Refactored EMP grenade inheritance (fix #3458)

### DIFF
--- a/code/game/objects/items/weapons/grenades/emgrenade.dm
+++ b/code/game/objects/items/weapons/grenades/emgrenade.dm
@@ -2,10 +2,12 @@
 	name = "classic EMP grenade"
 	icon = 'icons/obj/items/grenades/emp.dmi'
 	origin_tech = "{'materials':2,'magnets':3}"
+	var/emp_light_range = 10
+	var/emp_heavy_range = 4
 
 /obj/item/grenade/empgrenade/detonate()
 	..()
-	if(empulse(src, 4, 10))
+	if(empulse(src, emp_heavy_range, emp_light_range))
 		qdel(src)
 	return
 
@@ -14,8 +16,5 @@
 	desc = "A weaker variant of the classic EMP grenade."
 	icon = 'icons/obj/items/grenades/emp_old.dmi'
 	origin_tech = "{'materials':2,'magnets':3}"
-
-/obj/item/grenade/empgrenade/low_yield/detonate()
-	..()
-	if(empulse(src, 4, 1))
-		qdel(src)
+	emp_heavy_range = 1
+	emp_light_range = 4


### PR DESCRIPTION
## Description of changes
Removed repeating code with wrong super `..()` calls; also edited `4/1` range to be `1/4` (because `em_pulse` would set `4/1` to `4/4` anyway)

## Why and what will this PR improve
Now the low-yield EMP grenades would be actually low-yield.

## Authorship
Myself.

## Changelog
:cl:
bugfix: fixed low-yield EMP grenades to be lower yield than classic
/:cl: