### PR TITLE
Damage propagation for stock_parts and SMES overload (fixes #3457)

### DIFF
--- a/code/game/machinery/air_sensor.dm
+++ b/code/game/machinery/air_sensor.dm
@@ -11,7 +11,7 @@
 	public_variables = list(
 		/decl/public_access/public_variable/gas,
 		/decl/public_access/public_variable/pressure,
-		/decl/public_access/public_variable/temperature		
+		/decl/public_access/public_variable/temperature
 	)
 	stock_part_presets = list(/decl/stock_part_preset/radio/basic_transmitter/air_sensor = 1)
 	use_power = POWER_USE_IDLE
@@ -47,7 +47,7 @@
 		return
 	. = list()
 	for(var/gas in air_sample.gas)
-		var/decl/material/mat = GET_DECL(gas)			
+		var/decl/material/mat = GET_DECL(gas)
 		var/gaspercent = round(air_sample.gas[gas]*100/total_moles,0.01)
 		var/gas_list = list("symbol" = mat.gas_symbol_html, "percent" = gaspercent)
 		. += list(gas_list)

--- a/code/game/objects/item_damage.dm
+++ b/code/game/objects/item_damage.dm
@@ -18,6 +18,7 @@
 		return 0 //must return a number
 
 	//Apply damage
+	damage = min(health, damage)
 	health = clamp(health - damage, 0, max_health)
 	check_health(damage, damage_type, damage_flags)
 	return damage

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -210,8 +210,8 @@
 				SET_STATUS_MAX(h_user, STAT_PARA, 6)
 			spawn(0)
 				empulse(src.loc, 8, 16)
-			charge = 0
 			apcs_overload(1, 10, 20)
+			charge = 0
 			energy_fail(10)
 			src.ping("Caution. Output regulators malfunction. Uncontrolled discharge detected.")
 
@@ -225,8 +225,8 @@
 			SET_STATUS_MAX(h_user, STAT_PARA, 8)
 			spawn(0)
 				empulse(src.loc, 32, 64)
-			charge = 0
 			apcs_overload(5, 25, 100)
+			charge = 0
 			energy_fail(30)
 			src.ping("Caution. Output regulators malfunction. Significant uncontrolled discharge detected.")
 
@@ -258,22 +258,33 @@
 		total_system_failure(failure_probability, user)
 		return TRUE
 
-// Proc: apcs_overload()
-// Parameters: 3 (failure_chance - chance to actually break the APC, overload_chance - Chance of breaking lights, reboot_chance - Chance of temporarily disabling the APC)
-// Description: Damages output powernet by power surge. Destroys few APCs and lights, depending on parameters.
+/**
+ * Processes the APCs overloaded by malfunctioning SMES.
+ *
+ * Damages output powernet by power surge. Destroys or damages few APCs and lights, depending on parameters and current SMES charge.
+ *
+ * - `failure_chance`: chance to actually damage the individual APC (in %). Damage scales from SMES charge, can easily destroy some.
+ * - `overload_chance`: chance of breaking the lightbulbs on individual APC network (in %).
+ * - `reboot_chance`: chance of temporarily (30..60 sec) disabling the individual APC (in %).
+ */
 /obj/machinery/power/smes/buildable/proc/apcs_overload(var/failure_chance, var/overload_chance, var/reboot_chance)
 	if (!src.powernet)
 		return
-
+	var/list/obj/machinery/power/apc/apcs = list()
 	for(var/obj/machinery/power/terminal/T in powernet.nodes)
 		var/obj/machinery/power/apc/A = T.master_machine()
 		if(istype(A))
 			if (prob(overload_chance))
 				A.overload_lighting()
 			if (prob(failure_chance))
-				A.set_broken(TRUE)
+				apcs |= A
 			if(prob(reboot_chance))
 				A.energy_fail(rand(30,60))
+
+	if (apcs.len)
+		var/overload_damage = charge/100/apcs.len
+		for (var/obj/machinery/power/apc/A in apcs)
+			A.take_damage(overload_damage, ELECTROCUTE)
 
 // Proc: update_icon()
 // Parameters: None


### PR DESCRIPTION
## Description of changes
Changed APCs failure from plain `set_broken(TRUE)` to getting dealt electrocute damage in SMES failure procedures.

To allow that to break more than a singular `stock_part`, damage returned from `take_damage` should be changed from being reduced only by armor (unapplicable to stock parts) to keeping track of the health the item had before damage; thus, sufficient amount of damage to machinery will dismantle it in one hit.

## Why and what will this PR improve
Will make APCs repairable after SMES failures.

## Authorship
Myself

## Changelog
:cl:
tweak: changed the SMES overloading APC failure damage
bugfix: fixed APCs being stuck irrepairable on overloading
bugfix: fixed clamping any machinery damage to one part per hit
/:cl:
