### PR TITLE
Autoinjector band

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -41,7 +41,7 @@
 /obj/item/chems/on_update_icon()
 	. = ..()
 	if(detail_state)
-		add_overlay(overlay_image(icon, "[icon_state][detail_state]", detail_color || COLOR_WHITE, RESET_COLOR))
+		add_overlay(overlay_image(icon, "[initial(icon_state)][detail_state]", detail_color || COLOR_WHITE, RESET_COLOR))
 
 /obj/item/chems/proc/update_container_name()
 	var/newname = get_base_name()


### PR DESCRIPTION
## Description of changes
Changed the base `icon_state` to be used in `/obj/item/chems/on_update_icon()` for determining the name of the coloured detail overlay from the current value to initial value.

## Why and what will this PR improve
As reported in ScavStation/ScavStation#808, the autoinjector bands provide visual aid for the players.

Currently autoinjectors spawn with their default icon_state of `injector` briefly, and then update to `injector0` or `injector1` depending on whether they're empty. Thus, the non-priority overlay `injector_band` is automatically cut and replaced by a non-existent overlay `injector1_band`, which fails to display.

While technically just making detail overlay a priority one would work as well, it would mean that each autoinjector could accrue up to 2 extra nonfunctional overlays, which is probably more suboptimal than rechecking the previously cached overlay each time the state is modified.

## Authorship
Myself.

## Changelog
:cl:
bugfix: repaired autoinjector coloured band overlay
/:cl: