### PR TITLE
Adds KEEP_APART and RESET_ALPHA to status markers.

### DIFF
--- a/code/modules/status_conditions/_status_markers.dm
+++ b/code/modules/status_conditions/_status_markers.dm
@@ -43,7 +43,7 @@
 
 	mob_image = new /image
 	mob_image.loc = owner
-	mob_image.appearance_flags |= (RESET_COLOR|RESET_TRANSFORM|KEEP_TOGETHER)
+	mob_image.appearance_flags |= (RESET_ALPHA|RESET_COLOR|RESET_TRANSFORM|KEEP_APART)
 	mob_image.plane = DEFAULT_PLANE
 	mob_image.layer = POINTER_LAYER
 
@@ -53,7 +53,7 @@
 
 	mob_image_personal = new /image
 	mob_image_personal.loc = owner
-	mob_image_personal.appearance_flags |= (RESET_COLOR|RESET_TRANSFORM|KEEP_TOGETHER)
+	mob_image_personal.appearance_flags |= (RESET_ALPHA|RESET_COLOR|RESET_TRANSFORM|KEEP_APART)
 	mob_image_personal.plane = DEFAULT_PLANE
 	mob_image_personal.layer = POINTER_LAYER
 


### PR DESCRIPTION
## Description of changes
Adds KEEP_APART and RESET_ALPHA to status markers.

## Why and what will this PR improve
![TWERKING_DESTROYED1](https://github.com/NebulaSS13/Nebula/assets/2468979/857b3681-0b26-4233-9efd-4ee2b36bc890)

## Authorship
Myself.