### PR TITLE
Rough pass on removing isSynthetic [DNM]

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -129,7 +129,7 @@
 		mymob.bodytemp.screen_loc = ui_temp
 		hud_elements |= mymob.bodytemp
 
-	if(target.isSynthetic())
+	if(GET_INTERNAL_ORGAN(target, BP_CELL))
 		target.cells = new /obj/screen()
 		target.cells.icon = 'icons/mob/screen1_robot.dmi'
 		target.cells.icon_state = "charge-empty"

--- a/code/datums/repositories/crew/binary.dm
+++ b/code/datums/repositories/crew/binary.dm
@@ -1,17 +1,16 @@
 /* Binary */
 /crew_sensor_modifier/binary/process_crew_data(var/mob/living/carbon/human/H, var/obj/item/clothing/under/C, var/turf/pos, var/list/crew_data)
 	crew_data["alert"] = FALSE
-	if(!H.isSynthetic() && H.should_have_organ(BP_HEART))
+	var/obj/item/organ/internal/cell/cell = H.should_have_organ(BP_CELL) && GET_INTERNAL_ORGAN(H, BP_CELL)
+	if(istype(cell))
+		crew_data["alert"] = cell.percent() < 10
+	else if(H.should_have_organ(BP_HEART))
 		var/obj/item/organ/internal/heart/O = H.get_organ(BP_HEART, /obj/item/organ/internal/heart)
 		if (!O || !BP_IS_PROSTHETIC(O)) // Don't make medical freak out over prosthetic hearts
 			var/pulse = H.get_pulse()
 			if(pulse == PULSE_NONE || pulse == PULSE_THREADY)
 				crew_data["alert"] = TRUE
 		if(H.get_blood_oxygenation() < BLOOD_VOLUME_SAFE)
-			crew_data["alert"] = TRUE
-	if(H.isSynthetic())
-		var/obj/item/organ/internal/cell/cell = H.get_organ(BP_CELL, /obj/item/organ/internal/cell)
-		if(!cell || cell.percent() < 10)
 			crew_data["alert"] = TRUE
 	return ..()
 

--- a/code/datums/repositories/crew/vital.dm
+++ b/code/datums/repositories/crew/vital.dm
@@ -3,7 +3,19 @@
 	crew_data["true_pulse"] = -1
 	crew_data["pulse"] = "N/A"
 	crew_data["pulse_span"] = "neutral"
-	if(!H.isSynthetic() && H.should_have_organ(BP_HEART))
+
+	if(H.should_have_organ(BP_CELL))
+		var/obj/item/organ/internal/cell/cell = H.get_organ(BP_CELL, /obj/item/organ/internal/cell)
+		if(cell)
+			crew_data["charge"] = cell.percent()
+			if(cell.percent() <= 10)
+				crew_data["charge_span"] = "bad"
+			else
+				crew_data["charge_span"] = "good"
+		else
+			crew_data["charge"] = "No cell"
+			crew_data["charge_span"] = "bad"
+	else if(H.should_have_organ(BP_HEART))
 		var/obj/item/organ/internal/heart/O = H.get_organ(BP_HEART, /obj/item/organ/internal/heart)
 		if (!O || !BP_IS_PROSTHETIC(O)) // Don't make medical freak out over prosthetic hearts
 			crew_data["true_pulse"] = H.get_pulse()
@@ -23,23 +35,12 @@
 					crew_data["pulse_span"] = "bad"
 	crew_data["charge"] = "N/A"
 	crew_data["charge_span"] = "N/A"
-	if(H.isSynthetic())
-		var/obj/item/organ/internal/cell/cell = H.get_organ(BP_CELL, /obj/item/organ/internal/cell)
-		if(cell)
-			crew_data["charge"] = cell.percent()
-			if(cell.percent() <= 10)
-				crew_data["charge_span"] = "bad"
-			else
-				crew_data["charge_span"] = "good"
-		else
-			crew_data["charge"] = "No cell"
-			crew_data["charge_span"] = "bad"
 
 	crew_data["pressure"] = "N/A"
 	crew_data["true_oxygenation"] = -1
 	crew_data["oxygenation"] = ""
 	crew_data["oxygenation_span"] = ""
-	if(!H.isSynthetic() && H.should_have_organ(BP_HEART))
+	if(!H.should_have_organ(BP_CELL) && H.should_have_organ(BP_HEART))
 		crew_data["pressure"] = H.get_blood_pressure()
 		crew_data["true_oxygenation"] = H.get_blood_oxygenation()
 		switch (crew_data["true_oxygenation"])

--- a/code/datums/traits/radiation_hardened.dm
+++ b/code/datums/traits/radiation_hardened.dm
@@ -1,0 +1,3 @@
+/decl/trait/radiation_hardened
+	name = "Radiation Hardened"
+	description = "While this creature can become radioactive, it will not suffer ill effects from being so."

--- a/code/datums/traits/traits.dm
+++ b/code/datums/traits/traits.dm
@@ -16,30 +16,30 @@
 /mob/living/proc/GetTraits()
 	SHOULD_NOT_SLEEP(TRUE)
 	RETURN_TYPE(/list)
-	var/decl/species/our_species = get_species()
-	return traits || our_species?.traits
+	var/decl/bodytype/our_bodytype = get_bodytype()
+	return traits || our_bodytype?.traits
 
 /mob/living/proc/SetTrait(trait_type, trait_level)
 	SHOULD_NOT_SLEEP(TRUE)
-	var/decl/species/our_species = get_species()
+	var/decl/bodytype/our_bodytype = get_bodytype()
 	var/decl/trait/T = GET_DECL(trait_type)
 	if(!T.validate_level(trait_level))
 		return FALSE
 
-	if(our_species && !traits) // If species traits haven't been setup before, check if we need to do so now
-		var/species_level = our_species.traits[trait_type]
+	if(our_bodytype && !traits) // If species traits haven't been setup before, check if we need to do so now
+		var/species_level = our_bodytype.traits[trait_type]
 		if(species_level == trait_level) // Matched the default species trait level, ignore
 			return TRUE
-		traits = our_species.traits.Copy() // The setup is to simply copy the species list of traits
+		traits = our_bodytype.traits.Copy() // The setup is to simply copy the species list of traits
 
 	LAZYSET(traits, trait_type, trait_level)
 	return TRUE
 
 /mob/living/proc/RemoveTrait(trait_type, canonize = TRUE)
-	var/decl/species/our_species = get_species()
+	var/decl/bodytype/our_bodytype = get_bodytype()
 	// If traits haven't been set up, but we're trying to remove a trait that exists on the species then set up traits
-	if(!traits && LAZYISIN(our_species?.traits, trait_type))
-		traits = our_species.traits.Copy()
+	if(!traits && LAZYISIN(our_bodytype?.traits, trait_type))
+		traits = our_bodytype.traits.Copy()
 	if(LAZYLEN(traits))
 		LAZYREMOVE(traits, trait_type)
 	// Check if we can just default back to species traits.
@@ -49,26 +49,26 @@
 /// Removes a trait unless it exists on the species.
 /// If it does exist on the species, we reset it to the species' trait level.
 /mob/living/proc/RemoveExtrinsicTrait(trait_type)
-	var/decl/species/our_species = get_species()
-	if(!LAZYACCESS(our_species?.traits, trait_type))
+	var/decl/bodytype/our_bodytype = get_bodytype()
+	if(!LAZYACCESS(our_bodytype?.traits, trait_type))
 		RemoveTrait(trait_type)
-	else if(our_species?.traits[trait_type] != GetTraitLevel(trait_type))
-		SetTrait(trait_type, our_species?.traits[trait_type])
+	else if(our_bodytype?.traits[trait_type] != GetTraitLevel(trait_type))
+		SetTrait(trait_type, our_bodytype?.traits[trait_type])
 
 /// Sets the traits list to null if it's identical to the species list.
 /// Returns TRUE if the list was reset and FALSE otherwise.
 /mob/living/proc/CanonizeTraits()
 	if(!traits) // Already in canonical form.
 		return FALSE
-	var/decl/species/our_species = get_species()
-	if(!our_species) // Doesn't apply without a species.
+	var/decl/bodytype/our_bodytype = get_bodytype()
+	if(!our_bodytype) // Doesn't apply without a species.
 		return FALSE
-	var/list/missing_traits = traits ^ our_species?.traits
-	var/list/matched_traits = traits & our_species?.traits
+	var/list/missing_traits = traits ^ our_bodytype?.traits
+	var/list/matched_traits = traits & our_bodytype?.traits
 	if(LAZYLEN(missing_traits))
 		return FALSE
-	for(var/trait in matched_traits) // inside this loop we know our_species exists and has traits
-		if(traits[trait] != our_species.traits[trait])
+	for(var/trait in matched_traits) // inside this loop we know our_bodytype exists and has traits
+		if(traits[trait] != our_bodytype.traits[trait])
 			return FALSE
 	traits = null
 	return TRUE

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -459,7 +459,7 @@
 			M.dna = new /datum/dna()
 			M.dna.real_name = M.real_name
 		M.check_dna()
-		blood_color = M.species.get_blood_color(M)
+		blood_color = M.get_blood_color()
 	return TRUE
 
 /**

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -89,7 +89,7 @@
 		remove_blood_simple(cost * damage)
 		if(locate(/obj/effect/rune) in T)
 			return
-		var/obj/effect/rune/R = new rune(T, get_rune_color(), get_blood_name())
+		var/obj/effect/rune/R = new rune(T, get_blood_color(), get_blood_name())
 		var/area/A = get_area(R)
 		log_and_message_admins("created \an [R.cultname] rune at \the [A.proper_name].")
 		R.add_fingerprint(src)
@@ -116,9 +116,7 @@
 	return "oil"
 
 /mob/living/carbon/human/get_blood_name()
-	if(species)
-		return species.get_blood_name(src)
-	return "blood"
+	return get_bodytype()?.get_blood_name(src) || "blood"
 
 /mob/living/simple_animal/construct/get_blood_name()
 	return "ichor"
@@ -129,11 +127,11 @@
 /mob/living/carbon/human/mob_needs_tome()
 	return 1
 
-/mob/proc/get_rune_color()
+/mob/proc/get_blood_color()
 	return "#c80000"
 
-/mob/living/carbon/human/get_rune_color()
-	return species.get_blood_color(src)
+/mob/living/carbon/human/get_blood_color()
+	return get_bodytype()?.get_blood_color(src) || COLOR_BLOOD_HUMAN
 
 var/global/list/Tier1Runes = list(
 	/mob/proc/convert_rune,

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -161,7 +161,7 @@
 		return
 
 	use_power_oneoff(1000)
-	visible_message("<span class='danger'>You hear a loud [occupant.isSynthetic() ? "metallic" : "squelchy"] grinding sound.</span>")
+	visible_message("<span class='danger'>You hear a loud [occupant.get_gib_descriptor()] grinding sound.</span>")
 	src.operating = 1
 	update_icon()
 

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -195,8 +195,8 @@
 		return (R.cell)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(H.isSynthetic())
-			return 1
+		if(H.should_have_organ(BP_CELL))
+			return TRUE
 		var/obj/item/rig/rig = H.get_rig()
 		if(rig)
 			return rig.cell

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -90,12 +90,9 @@
 
 	if(M.stat != DEAD && M.handle_flashed(src, rand(str_min,str_max)))
 		admin_attack_log(user, M, "flashed their victim using \a [src].", "Was flashed by \a [src].", "used \a [src] to flash")
-		if(!M.isSynthetic())
-			user.visible_message(SPAN_DANGER("[user] blinds [M] with \the [src]!"))
-		else
-			user.visible_message(SPAN_DANGER("[user] overloads [M]'s sensors with \the [src]!"))
+		user.visible_message(SPAN_DANGER("\The [user] blinds \the [M] with \the [src]!"))
 	else
-		user.visible_message(SPAN_WARNING("[user] fails to blind [M] with \the [src]!"))
+		user.visible_message(SPAN_WARNING("\The [user] fails to blind \the [M] with \the [src]!"))
 	return TRUE
 
 /obj/item/flash/attack_self(mob/user, flag = 0, emp = 0)

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -50,7 +50,7 @@
 	if(!scan_subject)
 		return
 
-	if (scan_subject.isSynthetic())
+	if(!ishuman(scan_subject) || scan_subject.get_bodytype().is_robotic)
 		to_chat(user, "<span class='warning'>\The [scanner] is designed for organic humanoid patients only.</span>")
 		return
 

--- a/code/game/objects/items/devices/scanners/xenobio.dm
+++ b/code/game/objects/items/devices/scanners/xenobio.dm
@@ -51,7 +51,8 @@
 		var/decl/material/mat = GET_DECL(species.exhale_type)
 		. += "Exhales:\t[mat.gas_name]"
 	. += "Known toxins:\t[english_list(species.poison_types)]"
-	. += "Temperature comfort zone:\t[species.cold_discomfort_level] K to [species.heat_discomfort_level] K"
+	var/decl/bodytype/my_bodytype = get_bodytype() || species.default_bodytype
+	. += "Temperature comfort zone:\t[my_bodytype.cold_discomfort_level] K to [my_bodytype.heat_discomfort_level] K"
 	. += "Pressure comfort zone:\t[species.warning_low_pressure] kPa to [species.warning_high_pressure] kPa"
 	. = jointext(., "<br>")
 

--- a/code/game/objects/items/weapons/implants/implants/imprinting.dm
+++ b/code/game/objects/items/weapons/implants/implants/imprinting.dm
@@ -103,11 +103,11 @@
 	. = ..()
 
 /obj/item/implant/imprinting/can_implant(mob/M, mob/user, target_zone)
-	var/mob/living/carbon/human/H = M	
+	var/mob/living/carbon/human/H = M
 	if(istype(H))
 		var/obj/item/organ/internal/B = GET_INTERNAL_ORGAN(H, BP_BRAIN)
-		if(!B || H.isSynthetic())
-			to_chat(user, "<span class='warning'>\The [M] cannot be imprinted.</span>")
+		if(!B || BP_IS_PROSTHETIC(B) || BP_IS_CRYSTAL(B))
+			to_chat(user, "<span class='warning'>\The [M] does not have an organic brain, and cannot be imprinted.</span>")
 			return FALSE
 		if(!(B.parent_organ == check_zone(target_zone, H)))
 			to_chat(user, "<span class='warning'>\The [src] must be implanted in [GET_EXTERNAL_ORGAN(H, B.parent_organ)].</span>")

--- a/code/game/objects/structures/fitness.dm
+++ b/code/game/objects/structures/fitness.dm
@@ -15,7 +15,7 @@
 		return ..()
 
 	var/mob/living/carbon/human/H = user
-	var/synth = H.isSynthetic()
+	var/synth = H.get_bodytype().is_robotic
 	if(!synth && H.nutrition < 20)
 		to_chat(H, SPAN_WARNING("You [synth ? "need more energy" : "are too tired"] to use the punching bag. Go [synth ? "recharge" : "eat something"]."))
 		return TRUE
@@ -52,7 +52,7 @@
 	if(!ishuman(user))
 		return ..()
 	var/mob/living/carbon/human/H = user
-	var/synth = H.isSynthetic()
+	var/synth = H.get_bodytype().is_robotic
 	if(H.loc != src.loc)
 		to_chat(H, SPAN_WARNING("You must be on the weight machine to use it."))
 		return TRUE

--- a/code/game/objects/structures/fountain.dm
+++ b/code/game/objects/structures/fountain.dm
@@ -31,7 +31,7 @@
 		return ..()
 
 	var/datum/appearance_descriptor/age/age = my_species && LAZYACCESS(my_species.appearance_descriptors, "age")
-	if(H.isSynthetic() || !my_species || !age)
+	if(H.get_bodytype()?.is_robotic || !my_species || !age)
 		to_chat(H, SPAN_WARNING("A feeling of foreboding stills your hand. The fountain is not for your kind."))
 		return
 

--- a/code/modules/butchery/butchery.dm
+++ b/code/modules/butchery/butchery.dm
@@ -16,9 +16,12 @@
 /mob/living/carbon/human
 	butchery_rotation = 180
 
+/mob/living/proc/get_meat_type()
+	return get_bodytype()?.meat_type || meat_type
+
 // Harvest an animal's delicious byproducts
 /mob/living/proc/harvest_meat()
-	var/effective_meat_type = isSynthetic() ? /obj/item/stack/material/rods : meat_type
+	var/effective_meat_type = get_meat_type()
 	if(!effective_meat_type || !meat_amount)
 		return
 	blood_splatter(get_turf(src), src, large = TRUE)

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -110,10 +110,9 @@
 		pref.species = global.using_map.default_species
 
 	var/decl/species/mob_species = get_species_by_key(pref.species)
-	if(!pref.blood_type || !(pref.blood_type in mob_species.blood_types))
-		pref.blood_type = pickweight(mob_species.blood_types)
-
 	var/decl/bodytype/mob_bodytype = mob_species.get_bodytype_by_name(pref.bodytype) || mob_species.default_bodytype
+	if(!pref.blood_type || !(pref.blood_type in mob_bodytype?.blood_types))
+		pref.blood_type = pickweight(mob_bodytype.blood_types)
 	var/low_skin_tone = mob_bodytype ? (35 - mob_bodytype.max_skin_tone()) : -185
 	sanitize_integer(pref.skin_tone, low_skin_tone, 34, initial(pref.skin_tone))
 
@@ -243,10 +242,10 @@
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 
 	else if(href_list["blood_type"])
-		var/new_b_type = input(user, "Choose your character's blood type:", CHARACTER_PREFERENCE_INPUT_TITLE) as null|anything in mob_species.blood_types
+		var/new_b_type = input(user, "Choose your character's blood type:", CHARACTER_PREFERENCE_INPUT_TITLE) as null|anything in mob_bodytype.blood_types
 		if(new_b_type && CanUseTopic(user))
 			mob_species = get_species_by_key(pref.species)
-			if(new_b_type in mob_species.blood_types)
+			if(new_b_type in mob_bodytype.blood_types)
 				pref.blood_type = new_b_type
 				return TOPIC_REFRESH
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -87,7 +87,7 @@ var/global/list/time_prefs_fixed = list()
 	real_name = get_random_name()
 
 	var/decl/species/species = get_species_by_key(global.using_map.default_species)
-	blood_type = pickweight(species.blood_types)
+	blood_type = pickweight(species.default_bodytype.blood_types)
 
 	if(client)
 		if(IsGuestKey(client.key))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -454,7 +454,7 @@ var/global/list/time_prefs_fixed = list()
 	character.flavor_texts["legs"] = flavor_texts["legs"]
 	character.flavor_texts["feet"] = flavor_texts["feet"]
 
-	if(!character.isSynthetic())
+	if(!character.get_bodytype().is_robotic)
 		character.set_nutrition(rand(140,360))
 		character.set_hydration(rand(140,360))
 

--- a/code/modules/clothing/head/fated_key.dm
+++ b/code/modules/clothing/head/fated_key.dm
@@ -10,7 +10,8 @@
 	. = ..()
 	if(istype(user) && canremove && loc == user && slot == slot_head_str)
 		canremove = FALSE
-		to_chat(user, SPAN_DANGER("<font size=3>\The [src] shatters your mind as it sears through [user.isSynthetic() ? "metal and circuitry" : "flesh and bone"], embedding itself into your skull!</font>"))
+		var/obj/item/organ/external/head/head = GET_EXTERNAL_ORGAN(user, BP_HEAD)
+		to_chat(user, SPAN_DANGER("<font size=3>\The [src] shatters your mind as it sears through [BP_IS_PROSTHETIC(head) ? "metal and circuitry" : "flesh and bone"], embedding itself into your skull!</font>"))
 		SET_STATUS_MAX(user, STAT_PARA, 5)
 		addtimer(CALLBACK(src, .proc/activate_role), 5 SECONDS)
 	else

--- a/code/modules/clothing/masks/chewable.dm
+++ b/code/modules/clothing/masks/chewable.dm
@@ -44,7 +44,7 @@
 			var/mob/living/carbon/human/C = loc
 			if (src == C.get_equipped_item(slot_wear_mask_str) && C.check_has_mouth())
 				reagents.trans_to_mob(C, REM, CHEM_INGEST, 0.2)
-			add_trace_DNA(C)
+			add_trace_DNA(C, BP_HEAD)
 		else
 			STOP_PROCESSING(SSobj, src)
 

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -60,7 +60,7 @@
 			smoke_loc = C.loc
 			if ((src == C.get_equipped_item(slot_wear_mask_str) || manual) && C.check_has_mouth()) // if it's in the human/monkey mouth, transfer reagents to the mob
 				reagents.trans_to_mob(C, smoke_amount * amount, CHEM_INHALE, 0.2)
-				add_trace_DNA(C)
+				add_trace_DNA(C, BP_HEAD)
 		else // else just remove some of the reagents
 			reagents.remove_any(smoke_amount * amount)
 
@@ -375,7 +375,7 @@
 			SPAN_NOTICE("\The [user] takes a [puff_str] on [G.his] [name]."), \
 			SPAN_NOTICE("You take a [puff_str] on your [name]."))
 		smoke(12, TRUE)
-		add_trace_DNA(H)
+		add_trace_DNA(H, BP_HEAD)
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		return 1
 

--- a/code/modules/detectivework/evidence/trace_dna.dm
+++ b/code/modules/detectivework/evidence/trace_dna.dm
@@ -5,7 +5,7 @@
 /datum/forensics/trace_dna/add_from_atom(mob/living/carbon/human/M)
 	if(!istype(M))
 		return
-	if(M.isSynthetic())
+	if(M.get_bodytype()?.is_robotic)
 		return
 	var/unique_enzymes = M.get_unique_enzymes()
 	if(unique_enzymes)

--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -55,14 +55,14 @@
 		var/datum/forensics/F = forensics.evidence[T]
 		other_forensics.add_data(T, F.data)
 
-/obj/item/proc/add_trace_DNA(mob/living/carbon/M)
-	if(!istype(M))
+/obj/item/proc/add_trace_DNA(mob/living/carbon/M, organ_used)
+	if(!istype(M) || !istype(M.dna))
 		return
-	if(M.isSynthetic())
+	var/obj/item/organ/external/organ = organ_used && GET_EXTERNAL_ORGAN(M, organ_used)
+	if(istype(organ) && (BP_IS_PROSTHETIC(ORGAN) || !organ.dna))
 		return
-	if(istype(M.dna))
-		var/datum/extension/forensic_evidence/forensics = get_or_create_extension(src, /datum/extension/forensic_evidence)
-		forensics.add_from_atom(/datum/forensics/trace_dna, M)
+	var/datum/extension/forensic_evidence/forensics = get_or_create_extension(src, /datum/extension/forensic_evidence)
+	forensics.add_from_atom(/datum/forensics/trace_dna, M)
 
 // On examination get hints of evidence
 /obj/item/examine(mob/user, distance)

--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -59,7 +59,7 @@
 	if(!istype(M) || !istype(M.dna))
 		return
 	var/obj/item/organ/external/organ = organ_used && GET_EXTERNAL_ORGAN(M, organ_used)
-	if(istype(organ) && (BP_IS_PROSTHETIC(ORGAN) || !organ.dna))
+	if(istype(organ) && (BP_IS_PROSTHETIC(organ) || !organ.dna))
 		return
 	var/datum/extension/forensic_evidence/forensics = get_or_create_extension(src, /datum/extension/forensic_evidence)
 	forensics.add_from_atom(/datum/forensics/trace_dna, M)

--- a/code/modules/emotes/definitions/audible.dm
+++ b/code/modules/emotes/definitions/audible.dm
@@ -102,7 +102,7 @@
 	if(!.)
 		return .
 	var/obj/item/organ/internal/lungs/lung = user.get_organ(BP_LUNGS)
-	. = lung?.active_breathing && !user.isSynthetic()
+	. = istype(lung) && lung.active_breathing && !BP_IS_PROSTHETIC(lung)
 
 /decl/emote/audible/cough/do_emote(var/mob/living/carbon/user, var/extra_params)
 	if(!istype(user))

--- a/code/modules/emotes/definitions/exertion.dm
+++ b/code/modules/emotes/definitions/exertion.dm
@@ -5,7 +5,7 @@
 	emote_message_3p = "USER is sweating heavily."
 
 /decl/emote/exertion/biological/check_user(mob/living/user)
-	if(istype(user) && !user.isSynthetic())
+	if(istype(user) && !user.get_bodytype()?.is_robotic)
 		return ..()
 	return FALSE
 
@@ -30,7 +30,7 @@
 	emote_message_3p = "USER's actuators whine with strain."
 
 /decl/emote/exertion/synthetic/check_user(mob/living/user)
-	if(istype(user) && user.isSynthetic())
+	if(istype(user) && user.get_bodytype()?.is_robotic)
 		return ..()
 	return FALSE
 

--- a/code/modules/emotes/definitions/human.dm
+++ b/code/modules/emotes/definitions/human.dm
@@ -5,7 +5,7 @@
 	key = "deathgasp"
 
 /decl/emote/human/deathgasp/get_emote_message_3p(var/mob/living/carbon/human/user)
-	return "USER [user.species.get_death_message()]"
+	return "USER [user.get_bodytype()?.get_death_message() || "seizes up and falls limp, their eyes dead and lifeless..."]"
 
 /decl/emote/human/swish
 	key = "swish"

--- a/code/modules/emotes/definitions/synthetics.dm
+++ b/code/modules/emotes/definitions/synthetics.dm
@@ -4,7 +4,7 @@
 	emote_sound = 'sound/machines/twobeep.ogg'
 
 /decl/emote/audible/synth/check_user(var/mob/living/user)
-	if(istype(user) && user.isSynthetic())
+	if(istype(user) && user.get_bodytype()?.is_robotic)
 		return ..()
 	return FALSE
 

--- a/code/modules/emotes/definitions/visible.dm
+++ b/code/modules/emotes/definitions/visible.dm
@@ -358,7 +358,7 @@
 	key = "vomit"
 
 /decl/emote/visible/vomit/check_user(var/mob/living/carbon/human/user)
-	. = ..() && user.check_has_mouth() && !user.isSynthetic()
+	. = ..() && user.check_has_mouth() && user.should_have_organ(BP_STOMACH)
 
 /decl/emote/visible/vomit/do_emote(var/atom/user, var/extra_params)
 	var/mob/living/carbon/human/H = user

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -18,7 +18,8 @@
 
 /datum/event/ionstorm/announce()
 	for(var/mob/living/carbon/S in SSmobs.mob_list)
-		if (!S.isSynthetic())
+		var/obj/item/organ/internal/brain/brain = S.should_have_organ(BP_BRAIN) && GET_INTERNAL_ORGAN(S, BP_BRAIN)
+		if(brain && !BP_IS_PROSTHETIC(brain))
 			continue
 		if(!(S.z in affecting_z))
 			continue

--- a/code/modules/maps/template_types/random_exoplanet/planetoid_data.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planetoid_data.dm
@@ -486,9 +486,9 @@
 	if(habitability_class == HABITABILITY_OKAY || habitability_class == HABITABILITY_IDEAL)
 		var/decl/species/S  = global.get_species_by_key(global.using_map.default_species)
 		if(habitability_class == HABITABILITY_IDEAL)
-			. = clamp(., S.cold_discomfort_level + rand(1,5), S.heat_discomfort_level - rand(1,5)) //Clamp between comfortable levels since we're ideal
+			. = clamp(., S.default_bodytype.cold_discomfort_level + rand(1,5), S.default_bodytype.heat_discomfort_level - rand(1,5)) //Clamp between comfortable levels since we're ideal
 		else
-			. = clamp(., S.cold_level_1 + 1, S.heat_level_1 - 1) //clamp between values species starts taking damages at
+			. = clamp(., S.default_bodytype.cold_level_1 + 1, S.default_bodytype.heat_level_1 - 1) //clamp between values species starts taking damages at
 
 ///Generates a valid surface pressure for the planet's atmosphere matching it's habitability class
 /datum/planetoid_data/random/proc/generate_surface_pressure()
@@ -546,8 +546,8 @@
 
 		//Make sure temperature can't damage people on casual planets (Only when not forcing an atmosphere)
 		var/decl/species/S = global.get_species_by_key(global.using_map.default_species)
-		var/lower_temp            = max(S.cold_level_1, atmosphere_gen_temperature_min)
-		var/higher_temp           = min(S.heat_level_1, atmosphere_gen_temperature_max)
+		var/lower_temp            = max(S.default_bodytype.cold_level_1, atmosphere_gen_temperature_min)
+		var/higher_temp           = min(S.default_bodytype.heat_level_1, atmosphere_gen_temperature_max)
 		var/breathed_gas          = S.breath_type
 		var/breathed_min_pressure = S.breath_pressure
 
@@ -582,7 +582,7 @@
 				if(((current_merged_flags & XGM_GAS_OXIDIZER) && (mat.gas_flags & XGM_GAS_FUEL)) || \
 					((current_merged_flags & XGM_GAS_FUEL) && (mat.gas_flags & XGM_GAS_OXIDIZER)))
 					continue
-				
+
 				// If we have an ignition point we're basically XGM_GAS_FUEL, kind of. TODO: Combine those somehow?
 				// These don't actually burn but it's still weird to see vaporized skin gas in an oxygen-rich atmosphere,
 				// so skip them.

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -279,6 +279,9 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	var/sound_manipulate          //Default sound something like a material stack made of this material does when picked up
 	var/sound_dropped             //Default sound something like a material stack made of this material does when hitting the ground or placed down
 
+	/// If ingested, does this material need the ingester to have an active metabolism to apply its effects?
+	var/is_metabolized = FALSE
+
 // Placeholders for light tiles and rglass.
 /decl/material/proc/reinforce(var/mob/user, var/obj/item/stack/material/used_stack, var/obj/item/stack/material/target_stack, var/use_sheets = 1)
 	if(!used_stack.can_use(use_sheets))

--- a/code/modules/materials/definitions/solids/materials_solid_metal.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_metal.dm
@@ -401,11 +401,9 @@
 	construction_difficulty = MAT_VALUE_NORMAL_DIY
 	reflectiveness = MAT_VALUE_MATTE
 	taste_description = "metal"
+	is_metabolized = TRUE
 
 /decl/material/solid/metal/iron/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
-
 	M.add_chemical_effect(CE_BLOODRESTORE, 8 * removed)
 
 /decl/material/solid/metal/tin

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -173,7 +173,7 @@
 
 	if(armor < 0.5 && target.headcheck(BP_HEAD) && prob(damage))
 		target.apply_effect(20, PARALYZE)
-		target.visible_message(SPAN_DANGER("\The [target] [target.species.get_knockout_message(target)]"))
+		target.visible_message(SPAN_DANGER("\The [target] [target.get_bodytype()?.get_knockout_message(target) || "collapses, having been knocked unconscious."]"))
 
 	playsound(attacker.loc, "swing_hit", 25, 1, -1)
 

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -26,8 +26,10 @@
 /mob/living/carbon/brain/UpdateLyingBuckledAndVerbStatus()
 	return
 
-/mob/living/carbon/brain/isSynthetic()
-	return istype(container, /obj/item/mmi/digital) || istype(loc, /obj/item/organ/internal/posibrain)
+/mob/living/carbon/brain/get_bodytype()
+	if(istype(container, /obj/item/mmi/digital) || istype(loc, /obj/item/organ/internal/posibrain))
+		return GET_DECL(/decl/bodytype/prosthetic)
+	return GET_DECL(/decl/bodytype/human) // This needs some serious work.
 
 /mob/living/carbon/brain/binarycheck()
 	return isSynthetic()

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -32,7 +32,7 @@
 	return GET_DECL(/decl/bodytype/human) // This needs some serious work.
 
 /mob/living/carbon/brain/binarycheck()
-	return isSynthetic()
+	return istype(container, /obj/item/mmi/digital) || istype(loc, /obj/item/organ/internal/posibrain)
 
 /mob/living/carbon/brain/check_has_mouth()
 	return 0

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -7,7 +7,8 @@ Specifically made to do radiation burns.
 /mob/living/carbon/apply_radiation(damage)
 	..()
 	if(!isSynthetic() && !ignore_rads)
-		damage = 0.25 * damage * (species ? species.get_radiation_mod(src) : 1)
+		var/decl/bodytype/my_bodytype = get_bodytype()
+		damage = 0.25 * damage * (my_bodytype ? my_bodytype.get_radiation_mod(src) : 1)
 		adjustFireLoss(damage)
 		updatehealth()
 	return TRUE

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -6,7 +6,7 @@ Specifically made to do radiation burns.
 
 /mob/living/carbon/apply_radiation(damage)
 	..()
-	if(!isSynthetic() && !ignore_rads)
+	if(!HasTrait(/decl/trait/radiation_hardened) && !ignore_rads)
 		var/decl/bodytype/my_bodytype = get_bodytype()
 		damage = 0.25 * damage * (my_bodytype ? my_bodytype.get_radiation_mod(src) : 1)
 		adjustFireLoss(damage)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -17,7 +17,7 @@
 	var/last_loc = loc
 	..(species.gibbed_anim, do_gibs = FALSE)
 	if(last_loc)
-		gibs(last_loc, dna, _fleshcolor = (get_bodytype()?.get_flesh_colour(src) || "#ffc896"), _bloodcolor = species.get_blood_color(src))
+		gibs(last_loc, dna, _fleshcolor = (get_bodytype()?.get_flesh_colour(src) || "#ffc896"), _bloodcolor = get_blood_color())
 
 /mob/living/carbon/human/dust()
 	if(species)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -17,7 +17,7 @@
 	var/last_loc = loc
 	..(species.gibbed_anim, do_gibs = FALSE)
 	if(last_loc)
-		gibs(last_loc, dna, _fleshcolor = species.get_flesh_colour(src), _bloodcolor = species.get_blood_color(src))
+		gibs(last_loc, dna, _fleshcolor = (get_bodytype()?.get_flesh_colour(src) || "#ffc896"), _bloodcolor = species.get_blood_color(src))
 
 /mob/living/carbon/human/dust()
 	if(species)
@@ -44,7 +44,7 @@
 		SSticker.mode.check_win()
 
 	if(config.show_human_death_message)
-		deathmessage = species.get_death_message(src) || "seizes up and falls limp..."
+		deathmessage = get_bodytype()?.get_death_message(src) || "seizes up and falls limp..."
 	else
 		deathmessage = "no message"
 	. = ..(gibbed, deathmessage, show_dead_message)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -1,12 +1,8 @@
 /mob/living/carbon/human/show_examined_short_description(mob/user, distance, infix, suffix, hideflags, decl/pronouns/pronouns)
+	var/decl/bodytype/my_bodytype = get_bodytype()
 	var/msg = list("<span class='info'>*---------*\n[user == src ? "You are" : "This is"] <EM>[name]</EM>")
 	if(!(hideflags & HIDEJUMPSUIT) || !(hideflags & HIDEFACE))
-		var/species_name = "\improper "
-		if(isSynthetic() && species.cyborg_noun)
-			species_name += "[species.cyborg_noun] [species.get_root_species_name(src)]"
-		else
-			species_name += "[species.name]"
-		msg += ", <b><font color='[species.get_flesh_colour(src)]'>\a [species_name]!</font></b>[(user.can_use_codex() && SScodex.get_codex_entry(get_codex_value(user))) ?  SPAN_NOTICE(" \[<a href='?src=\ref[SScodex];show_examined_info=\ref[src];show_to=\ref[user]'>?</a>\]") : ""]"
+		msg += ", <b><font color='[species.get_flesh_colour(src)]'>\a [my_bodytype.get_examined_name(src)]!</font></b>[(user.can_use_codex() && SScodex.get_codex_entry(get_codex_value(user))) ?  SPAN_NOTICE(" \[<a href='?src=\ref[SScodex];show_examined_info=\ref[src];show_to=\ref[user]'>?</a>\]") : ""]"
 	var/extra_species_text = species.get_additional_examine_text(src)
 	if(extra_species_text)
 		msg += "<br>[extra_species_text]"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -2,7 +2,7 @@
 	var/decl/bodytype/my_bodytype = get_bodytype()
 	var/msg = list("<span class='info'>*---------*\n[user == src ? "You are" : "This is"] <EM>[name]</EM>")
 	if(!(hideflags & HIDEJUMPSUIT) || !(hideflags & HIDEFACE))
-		msg += ", <b><font color='[species.get_flesh_colour(src)]'>\a [my_bodytype.get_examined_name(src)]!</font></b>[(user.can_use_codex() && SScodex.get_codex_entry(get_codex_value(user))) ?  SPAN_NOTICE(" \[<a href='?src=\ref[SScodex];show_examined_info=\ref[src];show_to=\ref[user]'>?</a>\]") : ""]"
+		msg += ", <b><font color='[my_bodytype.get_flesh_colour(src)]'>\a [my_bodytype.get_examined_name(src)]!</font></b>[(user.can_use_codex() && SScodex.get_codex_entry(get_codex_value(user))) ?  SPAN_NOTICE(" \[<a href='?src=\ref[SScodex];show_examined_info=\ref[src];show_to=\ref[user]'>?</a>\]") : ""]"
 	var/extra_species_text = species.get_additional_examine_text(src)
 	if(extra_species_text)
 		msg += "<br>[extra_species_text]"
@@ -75,7 +75,8 @@
 	if(on_fire)
 		msg += "<span class='warning'>[use_He] [use_is] on fire!.</span>\n"
 
-	var/ssd_msg = species.get_ssd(src)
+	var/decl/bodytype/my_bodytype = get_bodytype()
+	var/ssd_msg = my_bodytype?.get_ssd(src) || "fast asleep"
 	if(ssd_msg && (!should_have_organ(BP_BRAIN) || has_brain()) && stat != DEAD)
 		if(!key)
 			msg += "<span class='deadsay'>[use_He] [use_is] [ssd_msg]. It doesn't look like [use_he] [use_is] waking up anytime soon.</span>\n"
@@ -125,7 +126,7 @@
 					hidden_bleeders[hidden] = list()
 				hidden_bleeders[hidden] += E.name
 		else
-			if(!isSynthetic() && BP_IS_PROSTHETIC(E) && (E.parent && !BP_IS_PROSTHETIC(E.parent)))
+			if(!get_bodytype()?.is_robotic && BP_IS_PROSTHETIC(E) && (E.parent && !BP_IS_PROSTHETIC(E.parent)))
 				wound_flavor_text[E.name] = "[use_He] [use_has] a [E.name].\n"
 			var/wounddesc = E.get_wounds_desc()
 			if(wounddesc != "nothing")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -374,7 +374,7 @@
 
 	set waitfor = 0
 
-	if(!check_has_mouth() || isSynthetic() || !timevomit || !level || stat == DEAD || lastpuke)
+	if(!check_has_mouth() || should_have_organ(BP_STOMACH) || !timevomit || !level || stat == DEAD || lastpuke)
 		return
 
 	if(deliberate)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -523,7 +523,7 @@
 		if(!facialhairstyle?.accessory_is_available(src, species, new_bodytype))
 			change_facial_hair(new_bodytype.default_f_style, FALSE)
 		// TODO: check markings.
-
+		update_emotes()
 		update_eyes()
 		return TRUE
 	return FALSE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1042,7 +1042,7 @@
 					B.icon_state = pick("dir_splatter_1","dir_splatter_2")
 					var/scale = min(1, round(P.damage / 50, 0.2))
 					B.set_scale(scale)
-				new /obj/effect/temp_visual/bloodsplatter(loc, hit_dir, species.get_blood_color(src))
+				new /obj/effect/temp_visual/bloodsplatter(loc, hit_dir, get_blood_color())
 
 /mob/living/carbon/human/get_dexterity(var/silent = FALSE)
 
@@ -1180,8 +1180,9 @@
 	if(!eye_colour)
 		eye_colour = root_bodytype.base_eye_color
 	root_bodytype.set_default_hair(src, override_existing = TRUE, defer_update_hair = TRUE)
-	if(!blood_type && length(species?.blood_types))
-		blood_type = pickweight(species.blood_types)
+
+	if(!blood_type && length(root_bodytype?.blood_types))
+		blood_type = pickweight(root_bodytype.blood_types)
 
 	if(new_dna)
 		set_real_name(new_dna.real_name)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -147,7 +147,7 @@
 	return FALSE
 
 /mob/living/carbon/human/getToxLoss()
-	if((species.species_flags & SPECIES_FLAG_NO_POISON) || isSynthetic())
+	if((species.species_flags & SPECIES_FLAG_NO_POISON) || get_bodytype()?.is_robotic)
 		return 0
 	var/amount = 0
 	for(var/obj/item/organ/internal/I in get_internal_organs())
@@ -155,13 +155,13 @@
 	return amount
 
 /mob/living/carbon/human/setToxLoss(var/amount)
-	if(!(species.species_flags & SPECIES_FLAG_NO_POISON) && !isSynthetic())
+	if(!(species.species_flags & SPECIES_FLAG_NO_POISON) && !get_bodytype()?.is_robotic)
 		adjustToxLoss(getToxLoss()-amount)
 
 // TODO: better internal organ damage procs.
 /mob/living/carbon/human/adjustToxLoss(var/amount)
 
-	if((species.species_flags & SPECIES_FLAG_NO_POISON) || isSynthetic())
+	if((species.species_flags & SPECIES_FLAG_NO_POISON) || get_bodytype()?.is_robotic)
 		return
 
 	var/heal = amount < 0

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -197,7 +197,7 @@ meteor_act
 				if(prob(effective_force))
 					apply_effect(20, PARALYZE, blocked)
 					if(lying)
-						visible_message("<span class='danger'>[src] [species.knockout_message]</span>")
+						visible_message("<span class='danger'>[src] [get_bodytype()?.knockout_message || "collapses, having been knocked unconscious."]</span>")
 			else
 				//Easier to score a stun but lasts less time
 				if(prob(effective_force + 5))

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -286,7 +286,7 @@
 	return !cloaking_sources // If cloaking_sources wasn't initially null but is now, we've uncloaked
 
 /mob/living/carbon/human/set_sdisability(sdisability)
-	if(isSynthetic())
+	if(get_bodytype()?.is_robotic)
 		return // Can't cure disabilites, so don't give them.
 	..()
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -150,6 +150,6 @@
 				var/mob/M = buckled
 				M.unbuckle_mob()
 			var/decl/bodytype/B = get_bodytype()
-			playsound(loc, isSynthetic() ? pick(B.synthetic_bodyfall_sounds) : pick(B.bodyfall_sounds), 50, TRUE, -1)
+			playsound(loc, pick(B.bodyfall_sounds), 50, TRUE, -1)
 		else if(!lying && !old_buckled_lying)
 			handle_stance() // Force an immediate stance update.

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -55,8 +55,9 @@
 	if(facing_dir)
 		tally += 3 // Locking direction will slow you down.
 
-	if (bodytemperature < species.cold_discomfort_level)
-		tally += (species.cold_discomfort_level - bodytemperature) / 10 * 1.75
+	var/decl/bodytype/my_bodytype = get_bodytype()
+	if (my_bodytype && bodytemperature < my_bodytype.cold_discomfort_level)
+		tally += (my_bodytype.cold_discomfort_level - bodytemperature) / 10 * 1.75
 
 	tally += max(2 * stance_damage, 0) //damaged/missing feet or legs is slow
 

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -250,7 +250,7 @@
 	return FALSE
 
 /mob/living/carbon/human/is_asystole()
-	if(isSynthetic())
+	if(should_have_organ(BP_CELL))
 		var/obj/item/organ/internal/cell/C = get_organ(BP_CELL, /obj/item/organ/internal/cell)
 		if(!C || !C.is_usable() || !C.percent())
 			return TRUE

--- a/code/modules/mob/living/carbon/human/human_status.dm
+++ b/code/modules/mob/living/carbon/human/human_status.dm
@@ -9,6 +9,6 @@
 	. = ..()
 
 /mob/living/carbon/human/handle_status_effects()
-	if((ssd_check() && species.get_ssd(src)) || player_triggered_sleeping)
+	if((ssd_check() && get_bodytype()?.get_ssd(src)) || player_triggered_sleeping)
 		SET_STATUS_MAX(src, STAT_ASLEEP, 2)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -219,7 +219,8 @@
 	if(relative_density > 0.02) //don't bother if we are in vacuum or near-vacuum
 		var/loc_temp = environment.temperature
 
-		if(adjusted_pressure < species.warning_high_pressure && adjusted_pressure > species.warning_low_pressure && abs(loc_temp - bodytemperature) < 20 && bodytemperature < get_temperature_threshold(HEAT_LEVEL_1) && bodytemperature > get_temperature_threshold(COLD_LEVEL_1) && species.body_temperature)
+		var/decl/bodytype/my_bodytype = get_bodytype()
+		if(adjusted_pressure < species.warning_high_pressure && adjusted_pressure > species.warning_low_pressure && abs(loc_temp - bodytemperature) < 20 && bodytemperature < get_temperature_threshold(HEAT_LEVEL_1) && bodytemperature > get_temperature_threshold(COLD_LEVEL_1) && !isnull(my_bodytype?.body_temperature))
 			pressure_alert = 0
 			return // Temperatures are within normal ranges, fuck all this processing. ~Ccomp
 
@@ -611,7 +612,8 @@
 				var/heat_1 = get_temperature_threshold(HEAT_LEVEL_1)
 				var/cold_1 = get_temperature_threshold(COLD_LEVEL_1)
 				//TODO: precalculate all of this stuff when the species datum is created
-				var/base_temperature = species.body_temperature
+				var/decl/bodytype/my_bodytype = get_bodytype()
+				var/base_temperature = my_bodytype?.body_temperature
 				if(base_temperature == null) //some species don't have a set metabolic temperature
 					base_temperature = (heat_1 + cold_1)/2
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -410,7 +410,7 @@
 			animate_tail_reset()
 			adjustHalLoss(-3)
 
-			if(prob(2) && is_asystole() && isSynthetic())
+			if(prob(2) && is_asystole() && should_have_organ(BP_CELL))
 				visible_message("<b>[src]</b> [pick("emits low pitched whirr","beeps urgently")].")
 		//CONSCIOUS
 		else
@@ -579,7 +579,7 @@
 				if(150 to 250)					hydration_icon.icon_state = "hydration3"
 				else							hydration_icon.icon_state = "hydration4"
 
-		if(isSynthetic())
+		if(should_have_organ(BP_CELL))
 			var/obj/item/organ/internal/cell/C = get_organ(BP_CELL, /obj/item/organ/internal/cell)
 			if(C)
 				var/chargeNum = clamp(CEILING(C.percent()/25), 0, 4)	//0-100 maps to 0-4, but give it a paranoid clamp just in case.

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -265,7 +265,7 @@ var/global/list/damage_icon_parts = list()
 		if(O.damage_state == "00")
 			continue
 		var/icon/DI
-		var/use_colour = (BP_IS_PROSTHETIC(O) ? SYNTH_BLOOD_COLOR : O.species.get_blood_color(src))
+		var/use_colour = (BP_IS_PROSTHETIC(O) ? SYNTH_BLOOD_COLOR : O.bodytype.get_blood_color(src))
 		var/cache_index = "[O.damage_state]/[O.bodytype.type]/[O.icon_state]/[use_colour]/[species.name]"
 		if(damage_icon_parts[cache_index] == null)
 			DI = new /icon(O.bodytype.get_damage_overlays(src), O.damage_state) // the damage icon for whole human

--- a/code/modules/mob/living/carbon/taste.dm
+++ b/code/modules/mob/living/carbon/taste.dm
@@ -23,7 +23,8 @@ calculate text size per text.
 		return
 
 	var/minimum_percent
-	if(taster.isSynthetic())
+	var/obj/item/organ/external/head/head = GET_EXTERNAL_ORGAN(taster, BP_HEAD)
+	if(head && BP_IS_PROSTHETIC(head))
 		minimum_percent = TASTE_DULL
 	else
 		var/decl/species/my_species = istype(taster) && taster?.get_species()

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -149,8 +149,7 @@
 	SHOULD_CALL_PARENT(TRUE)
 	chem_effects = null
 
-	// TODO: handle isSynthetic() properly via Psi's metabolism modifiers for contact reagents like acid.
-	if((status_flags & GODMODE) || isSynthetic())
+	if(status_flags & GODMODE)
 		return FALSE
 
 	// Metabolize any reagents currently in our body and keep a reference for chem dose checking.

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -101,10 +101,11 @@
 	if(prob(25))
 		damage = 2
 
+	var/radiation_hardened = HasTrait(/decl/trait/radiation_hardened)
 	if (radiation > 50)
 		damage = 2
 		radiation -= 2 * RADIATION_SPEED_COEFFICIENT
-		if(!isSynthetic())
+		if(!radiation_hardened)
 			if(prob(5) && prob(100 * RADIATION_SPEED_COEFFICIENT))
 				radiation -= 5 * RADIATION_SPEED_COEFFICIENT
 				to_chat(src, "<span class='warning'>You feel weak.</span>")
@@ -117,7 +118,7 @@
 	if (radiation > 75)
 		damage = 3
 		radiation -= 3 * RADIATION_SPEED_COEFFICIENT
-		if(!isSynthetic())
+		if(!radiation_hardened)
 			if(prob(5))
 				take_overall_damage(0, 5 * RADIATION_SPEED_COEFFICIENT, used_weapon = "Radiation Burns")
 			if(prob(1))
@@ -134,7 +135,7 @@
 		immunity = max(0, immunity - damage * 15 * RADIATION_SPEED_COEFFICIENT)
 		updatehealth()
 		var/list/limbs = get_external_organs()
-		if(!isSynthetic() && LAZYLEN(limbs))
+		if(!radiation_hardened && LAZYLEN(limbs))
 			var/obj/item/organ/external/O = pick(limbs)
 			if(istype(O))
 				O.add_autopsy_data("Radiation Poisoning", damage)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -89,7 +89,7 @@
 	var/decl/bodytype/my_bodytype = get_bodytype()
 	if(my_species && my_bodytype && (my_bodytype.appearance_flags & RADIATION_GLOWS))
 		if(radiation)
-			set_light(max(1,min(10,radiation/10)), max(1,min(20,radiation/20)), my_species.get_flesh_colour(src))
+			set_light(max(1,min(10,radiation/10)), max(1,min(20,radiation/20)), my_bodytype.get_flesh_colour(src))
 		else
 			set_light(0)
 

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -128,7 +128,7 @@
 		damage = 8
 		radiation -= 4 * RADIATION_SPEED_COEFFICIENT
 
-	damage = FLOOR(damage * (my_species ? my_species.get_radiation_mod(src) : 1))
+	damage = FLOOR(damage * (my_bodytype ? my_bodytype.get_radiation_mod(src) : 1))
 	if(damage)
 		adjustToxLoss(damage * RADIATION_SPEED_COEFFICIENT)
 		immunity = max(0, immunity - damage * 15 * RADIATION_SPEED_COEFFICIENT)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -166,7 +166,7 @@
 				R.affect_overdose(src)
 
 	// Update chem dosage.
-	// TODO: refactor chem dosage above isSynthetic() and GODMODE checks.
+	// TODO: refactor chem dosage above GODMODE checks.
 	if(length(chem_doses))
 		for(var/T in chem_doses)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -926,7 +926,7 @@ default behaviour is:
 			blood_splatter(loc, src, large = TRUE)
 		if(prob(25))
 			adjustBruteLoss(1)
-			visible_message(SPAN_DANGER("\The [src]'s [isSynthetic() ? "state worsens": "wounds open more"] from being dragged!"))
+			visible_message(SPAN_DANGER("\The [src]'s [get_bodytype()?.drag_state_damage_descriptor || "wounds open more"] from being dragged!"))
 
 /mob/living/CanUseTopicPhysical(mob/user)
 	. = CanUseTopic(user, global.physical_no_access_topic_state)
@@ -1131,8 +1131,11 @@ default behaviour is:
 	M.death()
 	log_and_message_admins("\The [user] admin-killed [key_name].")
 
+/mob/living/silicon/get_speech_bubble_state_modifier()
+	return "synth"
+
 /mob/living/get_speech_bubble_state_modifier()
-	return isSynthetic() ? "synth" : ..()
+	return get_bodytype()?.speech_bubble_state || ..()
 
 /mob/living/proc/is_on_special_ability_cooldown()
 	return world.time < next_special_ability
@@ -1143,28 +1146,15 @@ default behaviour is:
 /mob/living/proc/get_seconds_until_next_special_ability_string()
 	return ticks2readable(next_special_ability - world.time)
 
+/mob/living/proc/isSynthetic()
+	return FALSE
+
 //Get species or synthetic temp if the mob is a FBP/robot. Used when a synthetic mob is exposed to a temp check.
 //Essentially, used when a synthetic mob should act diffferently than a normal type mob.
 /mob/living/get_temperature_threshold(var/threshold)
-	if(isSynthetic())
-		switch(threshold)
-			if(COLD_LEVEL_1)
-				return SYNTH_COLD_LEVEL_1
-			if(COLD_LEVEL_2)
-				return SYNTH_COLD_LEVEL_2
-			if(COLD_LEVEL_3)
-				return SYNTH_COLD_LEVEL_3
-			if(HEAT_LEVEL_1)
-				return SYNTH_HEAT_LEVEL_1
-			if(HEAT_LEVEL_2)
-				return SYNTH_HEAT_LEVEL_2
-			if(HEAT_LEVEL_3)
-				return SYNTH_HEAT_LEVEL_3
-			else
-				CRASH("synthetic get_temperature_threshold() called with invalid threshold value.")
-	var/decl/species/my_species = get_species()
-	if(my_species)
-		return my_species.get_species_temperature_threshold(threshold)
+	var/decl/bodytype/my_bodytype = get_bodytype()
+	if(my_bodytype)
+		return my_bodytype.get_bodytype_temperature_threshold(threshold)
 	return ..()
 
 /mob/living/proc/handle_some_updates()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -406,7 +406,7 @@ default behaviour is:
 
 	// shut down ongoing problems
 	radiation = 0
-	bodytemperature = get_species()?.body_temperature || initial(bodytemperature)
+	bodytemperature = get_bodytype()?.body_temperature || initial(bodytemperature)
 	sdisabilities = 0
 	disabilities = 0
 
@@ -1146,9 +1146,6 @@ default behaviour is:
 /mob/living/proc/get_seconds_until_next_special_ability_string()
 	return ticks2readable(next_special_ability - world.time)
 
-/mob/living/proc/isSynthetic()
-	return FALSE
-
 //Get species or synthetic temp if the mob is a FBP/robot. Used when a synthetic mob is exposed to a temp check.
 //Essentially, used when a synthetic mob should act diffferently than a normal type mob.
 /mob/living/get_temperature_threshold(var/threshold)
@@ -1204,7 +1201,7 @@ default behaviour is:
 		var/list/overlays_to_add
 		if(check_state_in_icon(overlay_state, surgery_icon))
 			var/image/flesh = image(icon = surgery_icon, icon_state = overlay_state, layer = -HO_SURGERY_LAYER)
-			flesh.color = E.species.get_flesh_colour(src)
+			flesh.color = E.bodytype.get_flesh_colour(src)
 			LAZYADD(overlays_to_add, flesh)
 		overlay_state = "[base_state]-blood"
 		if(check_state_in_icon(overlay_state, surgery_icon))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1206,7 +1206,7 @@ default behaviour is:
 		overlay_state = "[base_state]-blood"
 		if(check_state_in_icon(overlay_state, surgery_icon))
 			var/image/blood = image(icon = surgery_icon, icon_state = overlay_state, layer = -HO_SURGERY_LAYER)
-			blood.color = E.species.get_blood_color(src)
+			blood.color = E.bodytype.get_blood_color(src)
 			LAZYADD(overlays_to_add, blood)
 		overlay_state = "[base_state]-bones"
 		if(check_state_in_icon(overlay_state, surgery_icon))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1296,3 +1296,6 @@ default behaviour is:
 //Useful when player is being seen by other mobs
 /mob/living/proc/get_id_name(if_no_id = "Unknown")
 	return GetIdCard(exceptions = list(/obj/item/holder))?.registered_name || if_no_id
+
+/mob/living/proc/get_gib_descriptor()
+	return get_bodytype()?.gib_descriptor || "squelchy"

--- a/code/modules/mob/living/living_bodytemp.dm
+++ b/code/modules/mob/living/living_bodytemp.dm
@@ -1,15 +1,13 @@
 /mob/living/proc/has_metabolic_thermoregulation()
-	if(get_bodytype()?.is_robotic)
-		return FALSE
-	var/decl/species/my_species = get_species()
-	if(my_species?.body_temperature == null)
+	var/decl/bodytype/my_bodytype = get_bodytype()
+	if(my_bodytype && my_bodytype.body_temperature == null)
 		return FALSE
 	return TRUE
 
 /mob/living/proc/get_bodytemperature_difference()
-	var/decl/species/my_species = get_species()
-	if(my_species)
-		return (my_species.body_temperature - bodytemperature)
+	var/decl/bodytype/my_bodytype = get_bodytype()
+	if(my_bodytype)
+		return (my_bodytype.body_temperature - bodytemperature)
 	return 0
 
 /mob/living/proc/stabilize_body_temperature()
@@ -19,9 +17,9 @@
 		return
 
 	// We may produce heat naturally.
-	var/decl/species/my_species = get_species()
-	if(my_species?.passive_temp_gain)
-		bodytemperature += my_species.passive_temp_gain
+	var/decl/bodytype/my_bodytype = get_bodytype()
+	if(my_bodytype?.passive_temp_gain)
+		bodytemperature += my_bodytype.passive_temp_gain
 
 	var/body_temperature_difference = get_bodytemperature_difference()
 	if (abs(body_temperature_difference) < 0.5)

--- a/code/modules/mob/living/living_bodytemp.dm
+++ b/code/modules/mob/living/living_bodytemp.dm
@@ -1,5 +1,5 @@
 /mob/living/proc/has_metabolic_thermoregulation()
-	if(isSynthetic())
+	if(get_bodytype()?.is_robotic)
 		return FALSE
 	var/decl/species/my_species = get_species()
 	if(my_species?.body_temperature == null)

--- a/code/modules/mob/living/living_pulse.dm
+++ b/code/modules/mob/living/living_pulse.dm
@@ -1,8 +1,8 @@
 /mob/living/proc/get_pulse()
-	if(stat == DEAD || isSynthetic())
+	if(stat == DEAD)
 		return PULSE_NONE
 	if(!should_have_organ(BP_HEART))
-		return PULSE_NORM
+		return get_bodytype().default_pulse_value || PULSE_NORM
 	var/obj/item/organ/internal/heart/heart = get_organ(BP_HEART, /obj/item/organ/internal/heart)
 	if(heart)
 		return heart.pulse

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -2,14 +2,6 @@
 	var/datum/ai_laws/laws
 	var/list/additional_law_channels = list("State" = "")
 
-/mob/living/silicon/Initialize()
-	. = ..()
-	if(!laws)
-		laws = global.using_map.default_law_type
-	if(ispath(laws))
-		laws = new laws()
-	laws_sanity_check()
-
 /mob/living/silicon/proc/laws_sanity_check()
 	if (!src.laws)
 		laws = new global.using_map.default_law_type

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -50,6 +50,8 @@
 	global.silicon_mob_list += src
 	. = ..()
 
+	SetTrait(/decl/trait/radiation_hardened, TRAIT_LEVEL_EXISTS)
+
 	if(silicon_radio)
 		silicon_radio = new silicon_radio(src)
 	if(silicon_camera)
@@ -64,6 +66,13 @@
 	default_language = /decl/language/human/common
 	init_id()
 	init_subsystems()
+
+	if(!laws)
+		laws = global.using_map.default_law_type
+	if(ispath(laws))
+		laws = new laws()
+	laws_sanity_check()
+
 
 /mob/living/silicon/Destroy()
 	global.silicon_mob_list -= src

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -463,3 +463,6 @@
 		return // Unconscious, dead or once possessed but now client-less silicons are not considered to have id access.
 	if(istype(idcard))
 		LAZYDISTINCTADD(., idcard)
+
+/mob/living/silicon/get_gib_descriptor()
+	return "metallic"

--- a/code/modules/mob/living/simple_animal/hostile/bad_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bad_drone.dm
@@ -28,7 +28,7 @@
 			return FALSE
 		if(ishuman(A))
 			var/mob/living/carbon/human/H = A
-			if(H.isSynthetic())
+			if(H.get_bodytype()?.is_robotic)
 				return FALSE
 			var/obj/item/head = H.get_equipped_item(slot_head_str)
 			if(istype(head, /obj/item/holder/drone))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -645,7 +645,7 @@ var/global/list/simplemob_icon_bitflag_cache = list()
 	return !(QDELETED(src) || incapacitated() || (is_aquatic && !submerged()))
 
 /mob/living/simple_animal/experiences_hunger_and_thirst()
-	// return !supernatural && !isSynthetic()
+	// return !supernatural
 	return FALSE // They need a reliable way to recover nutrition/hydration before this is made general.
 
 /mob/living/simple_animal/get_nutrition()

--- a/code/modules/mob/living/stasis.dm
+++ b/code/modules/mob/living/stasis.dm
@@ -18,7 +18,8 @@
 
 /mob/living/proc/get_cryogenic_factor(var/bodytemperature)
 
-	if(isSynthetic())
+	var/decl/bodytype/my_bodytype = get_bodytype()
+	if(my_bodytype && isnull(my_bodytype.body_temperature))
 		return 0
 
 	var/cold_1 = get_temperature_threshold(COLD_LEVEL_1)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -14,7 +14,7 @@
 	return TRUE
 
 /mob/living/proc/isSynthetic()
-	return 0
+	return FALSE
 
 /mob/living/carbon/human/isSynthetic()
 	if(isnull(full_prosthetic))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -13,23 +13,6 @@
 		return FALSE //M is too small to wield this
 	return TRUE
 
-/mob/living/proc/isSynthetic()
-	return FALSE
-
-/mob/living/carbon/human/isSynthetic()
-	if(isnull(full_prosthetic))
-		robolimb_count = 0
-		var/list/limbs = get_external_organs()
-		for(var/obj/item/organ/external/E in limbs)
-			if(BP_IS_PROSTHETIC(E))
-				robolimb_count++
-		full_prosthetic = robolimb_count > 0 && (robolimb_count == LAZYLEN(limbs)) //If no organs, no way to tell
-		update_emotes()
-	return full_prosthetic
-
-/mob/living/silicon/isSynthetic()
-	return 1
-
 /mob/proc/isMonkey()
 	return 0
 

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -45,7 +45,7 @@
 
 	var/list/all_backpacks = decls_repository.get_decls_of_subtype(/decl/backpack_outfit)
 	backpack = all_backpacks[pick(all_backpacks)]
-	blood_type = pickweight(current_species.blood_types)
+	blood_type = pickweight(current_bodytype.blood_types)
 	if(H)
 		copy_to(H)
 

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -221,7 +221,7 @@
 	if(my_species)
 		data["has_oxy"]     = my_species.blood_oxy
 		data["blood_color"] = my_species.get_blood_color(src)
-	else if(isSynthetic())
+	else if(get_bodytype()?.is_robotic)
 		data["has_oxy"]     = FALSE
 		data["blood_color"] = SYNTH_BLOOD_COLOR
 	else

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -49,7 +49,7 @@
 		"donor"       = weakref(src),
 		"species"     = get_species_name(),
 		"blood_DNA"   = get_unique_enzymes(),
-		"blood_color" = species.get_blood_color(src),
+		"blood_color" = get_blood_color(),
 		"blood_type"  = get_blood_type(),
 		"trace_chem"  = null
 	))
@@ -220,10 +220,10 @@
 	var/decl/species/my_species = get_species()
 	if(my_species)
 		data["has_oxy"]     = my_species.blood_oxy
-		data["blood_color"] = my_species.get_blood_color(src)
-	else if(get_bodytype()?.is_robotic)
-		data["has_oxy"]     = FALSE
-		data["blood_color"] = SYNTH_BLOOD_COLOR
+	var/decl/bodytype/my_bodytype = get_bodytype()
+	if(my_bodytype)
+		data["has_oxy"]     = my_bodytype.is_robotic
+		data["blood_color"] = get_blood_color()
 	else
 		data["has_oxy"]     = TRUE
 		data["blood_color"] = COLOR_BLOOD_HUMAN

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1028,7 +1028,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(istype(., /obj/effect/decal/cleanable/blood/gibs))
 		var/obj/effect/decal/cleanable/blood/gibs/G = .
 		G.fleshcolor = bodytype.get_flesh_colour(owner)
-		G.basecolor =  species.get_blood_color(owner)
+		G.basecolor =  bodytype.get_blood_color(owner)
 		G.update_icon()
 
 //Handles dismemberment

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1025,9 +1025,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 			else
 				. = new /obj/effect/decal/cleanable/blood/gibs(dropturf)
 
-	if(species && istype(., /obj/effect/decal/cleanable/blood/gibs))
+	if(istype(., /obj/effect/decal/cleanable/blood/gibs))
 		var/obj/effect/decal/cleanable/blood/gibs/G = .
-		G.fleshcolor = species.get_flesh_colour(owner)
+		G.fleshcolor = bodytype.get_flesh_colour(owner)
 		G.basecolor =  species.get_blood_color(owner)
 		G.update_icon()
 

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -359,7 +359,7 @@
 
 /mob/living/carbon/proc/cough(var/deliberate = FALSE)
 	var/obj/item/organ/internal/lungs/lung = get_organ(BP_LUNGS)
-	if(!lung || !lung.active_breathing || isSynthetic() || stat == DEAD || (deliberate && lastcough + 3 SECONDS > world.time))
+	if(!lung || !lung.active_breathing || BP_IS_PROSTHETIC(lung) || stat == DEAD || (deliberate && lastcough + 3 SECONDS > world.time))
 		return
 
 	if(lung.breath_fail_ratio > 0.9 && world.time > lung.last_successful_breath + 2 MINUTES)

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -271,16 +271,16 @@
 
 /obj/item/organ/internal/lungs/proc/handle_temperature_effects(datum/gas_mixture/breath)
 	// Hot air hurts :(
-	var/cold_1 = species.get_species_temperature_threshold(COLD_LEVEL_1)
-	var/heat_1 = species.get_species_temperature_threshold(HEAT_LEVEL_1)
+	var/cold_1 = bodytype.get_bodytype_temperature_threshold(COLD_LEVEL_1)
+	var/heat_1 = bodytype.get_bodytype_temperature_threshold(HEAT_LEVEL_1)
 	if((breath.temperature < cold_1 || breath.temperature > heat_1) && !(MUTATION_COLD_RESISTANCE in owner.mutations))
 		var/damage = 0
 		if(breath.temperature <= cold_1)
 			if(prob(20))
 				to_chat(owner, "<span class='danger'>You feel your face freezing and icicles forming in your lungs!</span>")
-			if(breath.temperature < species.get_species_temperature_threshold(COLD_LEVEL_3))
+			if(breath.temperature < bodytype.get_bodytype_temperature_threshold(COLD_LEVEL_3))
 				damage = COLD_GAS_DAMAGE_LEVEL_3
-			else if(breath.temperature < species.get_species_temperature_threshold(COLD_LEVEL_2))
+			else if(breath.temperature < bodytype.get_bodytype_temperature_threshold(COLD_LEVEL_2))
 				damage = COLD_GAS_DAMAGE_LEVEL_2
 			else
 				damage = COLD_GAS_DAMAGE_LEVEL_1
@@ -294,9 +294,9 @@
 			if(prob(20))
 				to_chat(owner, "<span class='danger'>You feel your face burning and a searing heat in your lungs!</span>")
 
-			if(breath.temperature < species.get_species_temperature_threshold(HEAT_LEVEL_2))
+			if(breath.temperature < bodytype.get_bodytype_temperature_threshold(HEAT_LEVEL_2))
 				damage = HEAT_GAS_DAMAGE_LEVEL_1
-			else if(breath.temperature < species.get_species_temperature_threshold(HEAT_LEVEL_3))
+			else if(breath.temperature < bodytype.get_bodytype_temperature_threshold(HEAT_LEVEL_3))
 				damage = HEAT_GAS_DAMAGE_LEVEL_2
 			else
 				damage = HEAT_GAS_DAMAGE_LEVEL_3
@@ -322,10 +322,10 @@
 //		log_debug("Breath: [breath.temperature], [src]: [bodytemperature], Adjusting: [temp_adj]")
 		owner.bodytemperature += temp_adj
 
-	else if(breath.temperature >= species.heat_discomfort_level)
-		species.get_environment_discomfort(owner,"heat")
-	else if(breath.temperature <= species.cold_discomfort_level)
-		species.get_environment_discomfort(owner,"cold")
+	else if(breath.temperature >= bodytype.heat_discomfort_level)
+		bodytype.get_environment_discomfort(owner,"heat")
+	else if(breath.temperature <= bodytype.cold_discomfort_level)
+		bodytype.get_environment_discomfort(owner,"cold")
 
 /obj/item/organ/internal/lungs/listen()
 	if(owner.failed_last_breath || !active_breathing)

--- a/code/modules/organs/internal/posibrain.dm
+++ b/code/modules/organs/internal/posibrain.dm
@@ -211,7 +211,7 @@
 	var/cost = get_power_drain()
 	if(world.time - owner.l_move_time < 15)
 		cost *= 2
-	if(!checked_use(cost) && owner.isSynthetic())
+	if(!checked_use(cost) && owner.should_have_organ(BP_CELL))
 		if(!owner.lying && !owner.buckled)
 			to_chat(owner, "<span class='warning'>You don't have enough energy to function!</span>")
 		SET_STATUS_MAX(owner, STAT_PARA, 3)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -275,7 +275,7 @@
 				germ_level += 10
 
 	if(germ_level >= INFECTION_LEVEL_ONE)
-		var/fever_temperature = (owner.get_temperature_threshold(HEAT_LEVEL_1) - owner.species.body_temperature - 5)* min(germ_level/INFECTION_LEVEL_TWO, 1) + owner.species.body_temperature
+		var/fever_temperature = (owner.get_temperature_threshold(HEAT_LEVEL_1) - bodytype.body_temperature - 5)* min(germ_level/INFECTION_LEVEL_TWO, 1) + bodytype.body_temperature
 		owner.bodytemperature += clamp(0, (fever_temperature - T20C)/BODYTEMP_COLD_DIVISOR + 1, fever_temperature - owner.bodytemperature)
 
 	if (germ_level >= INFECTION_LEVEL_TWO)

--- a/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
+++ b/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
@@ -17,7 +17,24 @@
 		/decl/trait/metabolically_inert = TRAIT_LEVEL_EXISTS,
 		/decl/trait/radiation_hardened  = TRAIT_LEVEL_EXISTS
 	)
+	speech_bubble_state = "synth"
 	default_pulse_value = PULSE_NONE
+	drag_state_damage_descriptor = "state worsens"
+
+	body_temperature = null
+	passive_temp_gain = 5  // stabilize at ~80 C in a 20 C environment.
+	heat_discomfort_level = 373.15
+	heat_discomfort_strings = list(
+		"You are dangerously close to overheating!"
+	)
+
+	cold_level_1 = SYNTH_COLD_LEVEL_1
+	cold_level_2 = SYNTH_COLD_LEVEL_2
+	cold_level_3 = SYNTH_COLD_LEVEL_3
+	heat_level_1 = SYNTH_HEAT_LEVEL_1
+	heat_level_2 = SYNTH_HEAT_LEVEL_2
+	heat_level_3 = SYNTH_HEAT_LEVEL_3
+
 	/// Determines which bodyparts can use this limb.
 	var/list/applies_to_part
 

--- a/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
+++ b/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
@@ -35,6 +35,17 @@
 	heat_level_2 = SYNTH_HEAT_LEVEL_2
 	heat_level_3 = SYNTH_HEAT_LEVEL_3
 
+	flesh_color =           COLOR_GUNMETAL
+
+	bodyfall_sounds = list(
+		'sound/foley/metal1.ogg'
+	)
+
+	knockout_message = "encounters a hardware fault and suddenly reboots!"
+	death_message = "gives one shrill beep before falling lifeless."
+	show_ssd = "flashing a 'system offline' glyph on their monitor"
+	flesh_color = SYNTH_FLESH_COLOUR
+
 	/// Determines which bodyparts can use this limb.
 	var/list/applies_to_part
 

--- a/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
+++ b/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
@@ -9,6 +9,7 @@
 	material = /decl/material/solid/metal/steel
 	eye_flash_mod = 1
 	eye_darksight_range = 2
+	radiation_mod = 0.5
 	/// Determines which bodyparts can use this limb.
 	var/list/applies_to_part
 

--- a/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
+++ b/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
@@ -13,6 +13,7 @@
 	eye_darksight_range = 2
 	radiation_mod = 0.5
 	meat_type = /obj/item/stack/material/rods
+	traits = list(/decl/trait/metabolically_inert = TRAIT_LEVEL_EXISTS)
 	/// Determines which bodyparts can use this limb.
 	var/list/applies_to_part
 

--- a/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
+++ b/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
@@ -13,7 +13,10 @@
 	eye_darksight_range = 2
 	radiation_mod = 0.5
 	meat_type = /obj/item/stack/material/rods
-	traits = list(/decl/trait/metabolically_inert = TRAIT_LEVEL_EXISTS)
+	traits = list(
+		/decl/trait/metabolically_inert = TRAIT_LEVEL_EXISTS,
+		/decl/trait/radiation_hardened  = TRAIT_LEVEL_EXISTS
+	)
 	/// Determines which bodyparts can use this limb.
 	var/list/applies_to_part
 

--- a/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
+++ b/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
@@ -12,6 +12,7 @@
 	eye_flash_mod = 1
 	eye_darksight_range = 2
 	radiation_mod = 0.5
+	meat_type = /obj/item/stack/material/rods
 	/// Determines which bodyparts can use this limb.
 	var/list/applies_to_part
 

--- a/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
+++ b/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
@@ -17,6 +17,7 @@
 		/decl/trait/metabolically_inert = TRAIT_LEVEL_EXISTS,
 		/decl/trait/radiation_hardened  = TRAIT_LEVEL_EXISTS
 	)
+	default_pulse_value = PULSE_NONE
 	/// Determines which bodyparts can use this limb.
 	var/list/applies_to_part
 

--- a/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
+++ b/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
@@ -1,5 +1,7 @@
 /decl/bodytype/prosthetic
 	abstract_type = /decl/bodytype/prosthetic
+	examined_name = "synthetic"
+	gib_descriptor = "metallic"
 	icon_base = 'icons/mob/human_races/cyberlimbs/robotic.dmi'
 	desc = "A generic unbranded robotic prosthesis."
 	limb_tech = "{'engineering':1,'materials':1,'magnets':1}"

--- a/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
+++ b/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
@@ -17,6 +17,7 @@
 		/decl/trait/metabolically_inert = TRAIT_LEVEL_EXISTS,
 		/decl/trait/radiation_hardened  = TRAIT_LEVEL_EXISTS
 	)
+	blood_types = list(/decl/blood_type/coolant)
 	speech_bubble_state = "synth"
 	default_pulse_value = PULSE_NONE
 	drag_state_damage_descriptor = "state worsens"

--- a/code/modules/overmap/ftl_shunt/core.dm
+++ b/code/modules/overmap/ftl_shunt/core.dm
@@ -322,7 +322,7 @@
 		if(isnull(H) || QDELETED(H))
 			continue
 
-		if(H.isSynthetic())
+		if(H.get_bodytype()?.is_robotic)
 			continue //We don't affect synthetics.
 
 		switch(shunt_sev)

--- a/code/modules/reagents/Chemistry-Metabolism.dm
+++ b/code/modules/reagents/Chemistry-Metabolism.dm
@@ -23,7 +23,11 @@
 /datum/reagents/metabolism/proc/metabolize(var/list/dosage_tracker)
 	if(!parent || total_volume < MINIMUM_CHEMICAL_VOLUME || !length(reagent_volumes))
 		return
+	var/update_reagents = FALSE
 	for(var/rtype in reagent_volumes)
 		var/decl/material/current = GET_DECL(rtype)
-		current.on_mob_life(parent, metabolism_class, src, dosage_tracker)
-	update_total()
+		if(!current.is_metabolized || !parent.HasTrait(/decl/trait/metabolically_inert))
+			current.on_mob_life(parent, metabolism_class, src, dosage_tracker)
+			update_reagents = TRUE
+	if(update_reagents)
+		update_total()

--- a/code/modules/reagents/chems/chems_blood.dm
+++ b/code/modules/reagents/chems/chems_blood.dm
@@ -26,6 +26,7 @@
 	)
 	heating_point = 318
 	heating_message = "coagulates and clumps together."
+	is_metabolized = TRUE
 
 /decl/material/liquid/blood/initialize_data(var/newdata)
 	. = ..() || list()
@@ -63,8 +64,6 @@
 			B.blood_DNA["UNKNOWN DNA STRUCTURE"] = "X*"
 
 /decl/material/liquid/blood/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
 	if(LAZYACCESS(M.chem_doses, type) > 5)
 		M.adjustToxLoss(removed)
 	if(LAZYACCESS(M.chem_doses, type) > 15)

--- a/code/modules/reagents/chems/chems_blood.dm
+++ b/code/modules/reagents/chems/chems_blood.dm
@@ -69,12 +69,6 @@
 	if(LAZYACCESS(M.chem_doses, type) > 15)
 		M.adjustToxLoss(removed)
 
-/decl/material/liquid/blood/affect_touch(var/mob/living/M, var/removed, var/datum/reagents/holder)
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(H.isSynthetic())
-			return
-
 /decl/material/liquid/blood/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(ishuman(M))
 		var/volume = REAGENT_VOLUME(holder, type)

--- a/code/modules/reagents/chems/chems_compounds.dm
+++ b/code/modules/reagents/chems/chems_compounds.dm
@@ -93,6 +93,7 @@
 		/decl/material/liquid/capsaicin/condensed = 0.5,
 		/decl/material/liquid/water = 0.5
 	)
+	is_metabolized = TRUE
 
 	var/agony_dose = 5
 	var/agony_amount = 2
@@ -104,10 +105,6 @@
 
 /decl/material/liquid/capsaicin/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	holder.remove_reagent(/decl/material/liquid/frostoil, 5)
-
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
-
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(!H.can_feel_pain())
@@ -140,6 +137,7 @@
 	heating_products = null
 	heating_point = null
 	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
+	is_metabolized = TRUE
 
 /decl/material/liquid/capsaicin/condensed/affect_touch(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	var/eyes_covered = 0
@@ -193,10 +191,6 @@
 
 /decl/material/liquid/capsaicin/condensed/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	holder.remove_reagent(/decl/material/liquid/frostoil, 5)
-
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
-
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(!H.can_feel_pain())

--- a/code/modules/reagents/chems/chems_compounds.dm
+++ b/code/modules/reagents/chems/chems_compounds.dm
@@ -213,6 +213,7 @@
 	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
 	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_mutagenics"
+	is_metabolized = TRUE
 
 /decl/material/liquid/mutagenics/affect_touch(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(prob(33))
@@ -223,9 +224,6 @@
 		affect_blood(M, removed, holder)
 
 /decl/material/liquid/mutagenics/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
-
-	if(M.isSynthetic())
-		return
 
 	var/mob/living/carbon/human/H = M
 	if(istype(H) && (H.get_bodytype()?.body_flags & BODY_FLAG_NO_DNA))

--- a/code/modules/reagents/chems/chems_drinks.dm
+++ b/code/modules/reagents/chems/chems_drinks.dm
@@ -5,6 +5,7 @@
 	value = 0.4
 	abstract_type = /decl/material/liquid/drink
 	exoplanet_rarity_gas = MAT_RARITY_NOWHERE // Please, no more berry juice atmosphere planets.
+	is_metabolized = TRUE
 
 	var/nutrition = 0 // Per unit
 	var/hydration = 6 // Per unit
@@ -17,9 +18,6 @@
 	M.adjustToxLoss(removed) // Probably not a good idea; not very deadly though
 
 /decl/material/liquid/drink/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
-
 	if(nutrition)
 		M.adjust_nutrition(nutrition * removed)
 	if(hydration)
@@ -40,8 +38,7 @@
 
 /decl/material/liquid/drink/juice/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
-	if(!M.HasTrait(/decl/trait/metabolically_inert))
-		M.immunity = min(M.immunity + 0.25, M.immunity_norm*1.5)
+	M.immunity = min(M.immunity + 0.25, M.immunity_norm*1.5)
 
 /decl/material/liquid/drink/juice/banana
 	name = "banana juice"
@@ -114,10 +111,6 @@
 
 /decl/material/liquid/drink/juice/lime/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
-
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
-
 	M.adjustToxLoss(-0.5 * removed)
 
 /decl/material/liquid/drink/juice/orange
@@ -133,10 +126,6 @@
 
 /decl/material/liquid/drink/juice/orange/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
-
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
-
 	M.adjustOxyLoss(-2 * removed)
 
 /decl/material/liquid/poisonberryjuice
@@ -196,10 +185,6 @@
 
 /decl/material/liquid/drink/juice/tomato/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
-
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
-
 	M.heal_organ_damage(0, 0.5 * removed)
 
 /decl/material/liquid/drink/juice/watermelon
@@ -270,12 +255,7 @@
 
 /decl/material/liquid/drink/milk/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
-
 	holder.remove_reagent(/decl/material/liquid/capsaicin, 10 * removed)
-
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
-
 	M.heal_organ_damage(0.5 * removed, 0)
 
 /decl/material/liquid/drink/milk/cream
@@ -338,10 +318,6 @@
 	..()
 	if(adj_temp > 0)
 		holder.remove_reagent(/decl/material/liquid/frostoil, 10 * removed)
-
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
-
 	var/volume = REAGENT_VOLUME(holder, type)
 	if(volume > 15)
 		M.add_chemical_effect(CE_PULSE, 1)
@@ -511,10 +487,6 @@
 
 /decl/material/liquid/drink/mutagencola/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
-
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
-
 	M.add_chemical_effect(CE_SPEEDBOOST, 1)
 	SET_STATUS_MAX(M, STAT_JITTER, 20)
 	SET_STATUS_MAX(M, STAT_DIZZY,  20)
@@ -641,10 +613,6 @@
 
 /decl/material/liquid/drink/hell_ramen/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
-
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
-
 	M.bodytemperature += 10 * TEMPERATURE_DAMAGE_COEFFICIENT
 
 /decl/material/liquid/drink/tea
@@ -660,10 +628,6 @@
 
 /decl/material/liquid/drink/tea/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
-
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
-
 	M.adjustToxLoss(-0.5 * removed)
 
 /decl/material/liquid/drink/tea/black
@@ -835,10 +799,6 @@
 
 /decl/material/liquid/drink/beastenergy/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
-
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
-
 	ADJ_STATUS(M, STAT_DROWSY, -7)
 	ADJ_STATUS(M, STAT_JITTER, 2)
 	M.add_chemical_effect(CE_PULSE, 1)

--- a/code/modules/reagents/chems/chems_ethanol.dm
+++ b/code/modules/reagents/chems/chems_ethanol.dm
@@ -24,6 +24,10 @@
 	)
 	bypass_cooling_products_for_root_type = /decl/material/liquid/ethanol
 	affect_blood_on_ingest = FALSE // prevents automatic toxins/inebriation as though injected
+	is_metabolized = TRUE
+	glass_name = "ethanol"
+	glass_desc = "A well-known alcohol with a variety of applications."
+	value = 1.2
 
 	var/nutriment_factor = 0
 	var/hydration_factor = 0
@@ -33,10 +37,6 @@
 	var/targ_temp = 310
 	var/halluci = 0
 
-	glass_name = "ethanol"
-	glass_desc = "A well-known alcohol with a variety of applications."
-	value = 1.2
-
 /decl/material/liquid/ethanol/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
 	M.adjustToxLoss(removed * 2 * alcohol_toxicity)
@@ -44,13 +44,8 @@
 
 /decl/material/liquid/ethanol/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
-
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
-
 	M.adjust_nutrition(nutriment_factor * removed)
 	M.adjust_hydration(hydration_factor * removed)
-
 	M.add_chemical_effect(CE_ALCOHOL, 1)
 	var/strength_mod = (M.GetTraitLevel(/decl/trait/malus/ethanol) * 2.5) || 1
 
@@ -134,8 +129,6 @@
 
 /decl/material/liquid/ethanol/beer/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
 	ADJ_STATUS(M, STAT_JITTER, -3)
 
 /decl/material/liquid/ethanol/bluecuracao
@@ -196,10 +189,6 @@
 
 /decl/material/liquid/ethanol/coffee/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
-
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
-
 	ADJ_STATUS(M, STAT_DIZZY, -5)
 	ADJ_STATUS(M, STAT_DROWSY, -3)
 	ADJ_STATUS(M, STAT_ASLEEP, -2)
@@ -278,10 +267,6 @@
 
 /decl/material/liquid/ethanol/thirteenloko/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
-
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
-
 	ADJ_STATUS(M, STAT_DROWSY, -7)
 	if(M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
@@ -447,10 +432,6 @@
 
 /decl/material/liquid/ethanol/pwine/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()
-
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
-
 	var/dose = LAZYACCESS(M.chem_doses, type)
 	if(dose > 30)
 		M.adjustToxLoss(2 * removed)

--- a/code/modules/reagents/chems/chems_nutriment.dm
+++ b/code/modules/reagents/chems/chems_nutriment.dm
@@ -46,10 +46,6 @@
 
 /decl/material/liquid/nutriment/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	adjust_nutrition(M, removed)
-
-	if(M.HasTrait(/decl/trait/metabolically_inert))
-		return
-
 	M.heal_organ_damage(0.5 * removed, 0) //what
 	M.add_chemical_effect(CE_BLOODRESTORE, 4 * removed)
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -182,7 +182,7 @@
 			self_feed_message(user)
 			reagents.trans_to_mob(user, issmall(user) ? CEILING(amount_per_transfer_from_this/2) : amount_per_transfer_from_this, CHEM_INGEST)
 			feed_sound(user)
-			add_trace_DNA(user)
+			add_trace_DNA(user, BP_HEAD)
 			return 1
 
 
@@ -203,7 +203,7 @@
 
 			reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_INGEST)
 			feed_sound(user)
-			add_trace_DNA(target)
+			add_trace_DNA(target, BP_HEAD)
 			return 1
 
 	return 0

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -276,7 +276,7 @@
 
 // Human mobs
 /mob/living/carbon/human/can_pass_shield(var/obj/machinery/shield_generator/gen)
-	if(isSynthetic())
+	if(get_bodytype()?.is_robotic)
 		return !gen.check_flag(MODEFLAG_ANORGANIC)
 	return !gen.check_flag(MODEFLAG_HUMANOIDS)
 

--- a/code/modules/species/outsider/random.dm
+++ b/code/modules/species/outsider/random.dm
@@ -33,7 +33,7 @@
 	. = ..()
 
 /decl/bodytype/alium/get_blood_color(mob/living/carbon/human/H)
-	if(istype(H) && H.isSynthetic())
+	if(istype(H) && H.get_bodytype() != src)
 		return ..()
 	return blood_color
 

--- a/code/modules/species/outsider/random.dm
+++ b/code/modules/species/outsider/random.dm
@@ -6,8 +6,11 @@
 	limb_blend =        ICON_MULTIPLY
 	appearance_flags =  HAS_SKIN_COLOR
 	body_flags =        BODY_FLAG_NO_DNA | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
+	var/blood_color
 
 /decl/bodytype/alium/Initialize()
+	//Coloring
+	blood_color = RANDOM_RGB
 	if(prob(10))
 		movement_slowdown += pick(-1,1)
 	if(prob(5))
@@ -28,6 +31,11 @@
 	body_temperature += temp_comfort_shift
 	flesh_color = RANDOM_RGB
 	. = ..()
+
+/decl/bodytype/alium/get_blood_color(mob/living/carbon/human/H)
+	if(istype(H) && H.isSynthetic())
+		return ..()
+	return blood_color
 
 /decl/species/alium
 	name = SPECIES_ALIEN
@@ -52,12 +60,8 @@
 		/decl/emote/exertion/biological/breath,
 		/decl/emote/exertion/biological/pant
 	)
-	var/blood_color
 
 /decl/species/alium/Initialize()
-
-	//Coloring
-	blood_color = RANDOM_RGB
 
 	//Combat stats
 	MULT_BY_RANDOM_COEF(total_health, 0.8, 1.2)
@@ -98,11 +102,6 @@
 		species_flags |= SPECIES_FLAG_NO_TANGLE
 
 	. = ..()
-
-/decl/species/alium/get_blood_color(mob/living/carbon/human/H)
-	if(istype(H) && H.isSynthetic())
-		return ..()
-	return blood_color
 
 /obj/structure/aliumizer
 	name = "alien monolith"

--- a/code/modules/species/outsider/random.dm
+++ b/code/modules/species/outsider/random.dm
@@ -20,15 +20,13 @@
 	cold_level_1 += temp_comfort_shift
 	cold_level_2 += temp_comfort_shift
 	cold_level_3 += temp_comfort_shift
-
 	heat_level_1 += temp_comfort_shift
 	heat_level_2 += temp_comfort_shift
 	heat_level_3 += temp_comfort_shift
-
 	heat_discomfort_level += temp_comfort_shift
 	cold_discomfort_level += temp_comfort_shift
-
 	body_temperature += temp_comfort_shift
+	flesh_color = RANDOM_RGB
 	. = ..()
 
 /decl/species/alium
@@ -60,7 +58,6 @@
 
 	//Coloring
 	blood_color = RANDOM_RGB
-	flesh_color = RANDOM_RGB
 
 	//Combat stats
 	MULT_BY_RANDOM_COEF(total_health, 0.8, 1.2)

--- a/code/modules/species/outsider/random.dm
+++ b/code/modules/species/outsider/random.dm
@@ -14,6 +14,7 @@
 		body_flags |= BODY_FLAG_NO_PAIN
 	base_color  = RANDOM_RGB
 	MULT_BY_RANDOM_COEF(eye_flash_mod, 0.5, 1.5)
+	MULT_BY_RANDOM_COEF(radiation_mod, 0, 2)
 	eye_darksight_range = rand(1,8)
 	. = ..()
 
@@ -54,7 +55,6 @@
 	MULT_BY_RANDOM_COEF(burn_mod, 0.8, 1.2)
 	MULT_BY_RANDOM_COEF(oxy_mod, 0.5, 1.5)
 	MULT_BY_RANDOM_COEF(toxins_mod, 0, 2)
-	MULT_BY_RANDOM_COEF(radiation_mod, 0, 2)
 
 	if(brute_mod < 1 && prob(40))
 		species_flags |= SPECIES_FLAG_NO_MINOR_CUT

--- a/code/modules/species/outsider/random.dm
+++ b/code/modules/species/outsider/random.dm
@@ -16,6 +16,19 @@
 	MULT_BY_RANDOM_COEF(eye_flash_mod, 0.5, 1.5)
 	MULT_BY_RANDOM_COEF(radiation_mod, 0, 2)
 	eye_darksight_range = rand(1,8)
+	var/temp_comfort_shift = rand(-50,50)
+	cold_level_1 += temp_comfort_shift
+	cold_level_2 += temp_comfort_shift
+	cold_level_3 += temp_comfort_shift
+
+	heat_level_1 += temp_comfort_shift
+	heat_level_2 += temp_comfort_shift
+	heat_level_3 += temp_comfort_shift
+
+	heat_discomfort_level += temp_comfort_shift
+	cold_discomfort_level += temp_comfort_shift
+
+	body_temperature += temp_comfort_shift
 	. = ..()
 
 /decl/species/alium
@@ -73,20 +86,6 @@
 			stomach_capacity += ITEM_SIZE_HUGE
 
 	//Environment
-	var/temp_comfort_shift = rand(-50,50)
-	cold_level_1 += temp_comfort_shift
-	cold_level_2 += temp_comfort_shift
-	cold_level_3 += temp_comfort_shift
-
-	heat_level_1 += temp_comfort_shift
-	heat_level_2 += temp_comfort_shift
-	heat_level_3 += temp_comfort_shift
-
-	heat_discomfort_level += temp_comfort_shift
-	cold_discomfort_level += temp_comfort_shift
-
-	body_temperature += temp_comfort_shift
-
 	var/pressure_comfort_shift = rand(-50,50)
 	hazard_high_pressure += pressure_comfort_shift
 	warning_high_pressure += pressure_comfort_shift
@@ -107,44 +106,6 @@
 	if(istype(H) && H.isSynthetic())
 		return ..()
 	return blood_color
-
-/decl/species/alium/proc/adapt_to_atmosphere(var/datum/gas_mixture/atmosphere)
-	var/temp_comfort_shift = atmosphere.temperature - body_temperature
-
-	cold_level_1 += temp_comfort_shift
-	cold_level_2 += temp_comfort_shift
-	cold_level_3 += temp_comfort_shift
-
-	heat_level_1 += temp_comfort_shift
-	heat_level_2 += temp_comfort_shift
-	heat_level_3 += temp_comfort_shift
-
-	heat_discomfort_level += temp_comfort_shift
-	cold_discomfort_level += temp_comfort_shift
-
-	body_temperature += temp_comfort_shift
-
-	var/normal_pressure = atmosphere.return_pressure()
-	hazard_high_pressure = 5 * normal_pressure
-	warning_high_pressure = 0.7 * hazard_high_pressure
-
-	hazard_low_pressure = 0.2 * normal_pressure
-	warning_low_pressure = 2.5 * hazard_low_pressure
-
-	breath_type = pick(atmosphere.gas)
-	breath_pressure = 0.8*(atmosphere.gas[breath_type]/atmosphere.total_moles)*normal_pressure
-
-	var/list/newgases = decls_repository.get_decl_paths_of_subtype(/decl/material/gas)
-	newgases = newgases.Copy()
-	newgases ^= atmosphere.gas
-	for(var/gas in newgases)
-		var/decl/material/mat = GET_DECL(gas)
-		if(mat.gas_flags & (XGM_GAS_OXIDIZER|XGM_GAS_FUEL))
-			newgases -= gas
-	if(newgases.len)
-		poison_types = list(pick_n_take(newgases))
-	if(newgases.len)
-		exhale_type = pick_n_take(newgases)
 
 /obj/structure/aliumizer
 	name = "alien monolith"

--- a/code/modules/species/outsider/shadow.dm
+++ b/code/modules/species/outsider/shadow.dm
@@ -5,6 +5,8 @@
 	icon_deformed =    'icons/mob/human_races/species/shadow/body.dmi'
 	body_flags =       BODY_FLAG_NO_DNA | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 	eye_darksight_range = 8
+	flesh_color = "#aaaaaa"
+	death_message = "dissolves into ash..."
 
 /decl/blood_type/shadowstuff
 	name = "shadowstuff"
@@ -30,15 +32,13 @@
 	blood_types = list(
 		/decl/blood_type/shadowstuff
 	)
-	flesh_color = "#aaaaaa"
 
 	remains_type = /obj/effect/decal/cleanable/ash
-	death_message = "dissolves into ash..."
 
 	species_flags = SPECIES_FLAG_NO_SLIP | SPECIES_FLAG_NO_POISON | SPECIES_FLAG_NO_EMBED
 
 /decl/species/starlight/shadow/handle_environment_special(var/mob/living/carbon/human/H)
-	if(H.is_in_stasis() || H.stat == DEAD || H.isSynthetic())
+	if(H.is_in_stasis() || H.stat == DEAD || H.get_bodytype()?.is_robotic)
 		return
 	var/light_amount = 0
 	if(isturf(H.loc))

--- a/code/modules/species/outsider/shadow.dm
+++ b/code/modules/species/outsider/shadow.dm
@@ -7,6 +7,9 @@
 	eye_darksight_range = 8
 	flesh_color = "#aaaaaa"
 	death_message = "dissolves into ash..."
+	blood_types = list(
+		/decl/blood_type/shadowstuff
+	)
 
 /decl/blood_type/shadowstuff
 	name = "shadowstuff"
@@ -19,22 +22,13 @@
 	name = "Shadow"
 	name_plural = "shadows"
 	description = "A being of pure darkness, hates the light and all that comes with it."
-
 	meat_type = null
 	bone_material = null
 	skin_material = null
-
 	available_bodytypes = list(/decl/bodytype/starlight/shadow)
-
 	unarmed_attacks = list(/decl/natural_attack/claws/strong, /decl/natural_attack/bite/sharp)
 	siemens_coefficient = 0
-
-	blood_types = list(
-		/decl/blood_type/shadowstuff
-	)
-
 	remains_type = /obj/effect/decal/cleanable/ash
-
 	species_flags = SPECIES_FLAG_NO_SLIP | SPECIES_FLAG_NO_POISON | SPECIES_FLAG_NO_EMBED
 
 /decl/species/starlight/shadow/handle_environment_special(var/mob/living/carbon/human/H)

--- a/code/modules/species/outsider/starlight.dm
+++ b/code/modules/species/outsider/starlight.dm
@@ -63,6 +63,9 @@
 		"Surprisingly, you start burning!",
 		"You're... burning!?!"
 	)
+	blood_types = list(
+		/decl/blood_type/starstuff
+	)
 
 /decl/blood_type/starstuff
 	name = "starstuff"
@@ -78,10 +81,6 @@
 	name_plural = "Starborn"
 	description = "Beings of fire and light, split off from a sun deity of unbelievable power."
 	available_bodytypes = list(/decl/bodytype/starlight/starborn)
-
-	blood_types = list(
-		/decl/blood_type/starstuff
-	)
 	unarmed_attacks = list(/decl/natural_attack/punch/starborn)
 	warning_low_pressure = 50
 	hazard_low_pressure = 0
@@ -92,7 +91,7 @@
 	species_flags = SPECIES_FLAG_NO_MINOR_CUT | SPECIES_FLAG_NO_SLIP | SPECIES_FLAG_NO_POISON | SPECIES_FLAG_NO_EMBED | SPECIES_FLAG_NO_TANGLE
 	base_auras = list(
 		/obj/aura/starborn
-		)
+	)
 
 /decl/species/starlight/starborn/handle_death(var/mob/living/carbon/human/H)
 	..()

--- a/code/modules/species/outsider/starlight.dm
+++ b/code/modules/species/outsider/starlight.dm
@@ -115,6 +115,7 @@
 	eye_icon =         'icons/mob/human_races/species/blueforged/eyes.dmi'
 	body_flags =       BODY_FLAG_NO_DNA | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 	override_organ_types = list(BP_EYES = /obj/item/organ/internal/eyes/blueforged)
+	radiation_mod = 0
 
 /decl/blood_type/spacestuff
 	name = "spacestuff"
@@ -140,7 +141,6 @@
 	brute_mod = 0
 	oxy_mod = 0
 	toxins_mod = 0
-	radiation_mod = 0
 	species_flags = SPECIES_FLAG_NO_MINOR_CUT | SPECIES_FLAG_NO_SLIP | SPECIES_FLAG_NO_POISON | SPECIES_FLAG_NO_EMBED | SPECIES_FLAG_NO_TANGLE
 
 /decl/species/starlight/blueforged/handle_death(var/mob/living/carbon/human/H)

--- a/code/modules/species/outsider/starlight.dm
+++ b/code/modules/species/outsider/starlight.dm
@@ -44,6 +44,29 @@
 	husk_icon =        'icons/mob/human_races/species/starborn/husk.dmi'
 	body_flags =       BODY_FLAG_NO_DNA | BODY_FLAG_NO_PAIN | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 
+	body_temperature = T0C + 500 //We are being of fire and light.
+
+	cold_level_1 = 260
+	cold_level_2 = 250
+	cold_level_3 = 235
+
+	heat_level_1 = 20000
+	heat_level_2 = 30000
+	heat_level_3 = 40000
+
+	cold_discomfort_level = 300
+	cold_discomfort_strings = list(
+		"You feel your fire dying out...",
+		"Your fire begins to shrink away from the cold.",
+		"You feel slow and sluggish from the cold."
+	)
+
+	heat_discomfort_level = 10000
+	heat_discomfort_strings = list(
+		"Surprisingly, you start burning!",
+		"You're... burning!?!"
+	)
+
 /decl/blood_type/starstuff
 	name = "starstuff"
 	antigen_category = "starstuff"
@@ -53,7 +76,6 @@
 
 /decl/species/starlight/handle_death(var/mob/living/carbon/human/H)
 	addtimer(CALLBACK(H,/mob/proc/dust),0)
-
 /decl/species/starlight/starborn
 	name = "Starborn"
 	name_plural = "Starborn"
@@ -64,37 +86,15 @@
 		/decl/blood_type/starstuff
 	)
 	flesh_color = "#ffff00"
-
 	unarmed_attacks = list(/decl/natural_attack/punch/starborn)
-
-	cold_discomfort_level = 300
-	cold_discomfort_strings = list("You feel your fire dying out...",
-								"Your fire begins to shrink away from the cold.",
-								"You feel slow and sluggish from the cold."
-								)
-	cold_level_1 = 260
-	cold_level_2 = 250
-	cold_level_3 = 235
-
-	heat_discomfort_level = 10000
-	heat_discomfort_strings = list("Surprisingly, you start burning!",
-									"You're... burning!?!")
-	heat_level_1 = 20000
-	heat_level_2 = 30000
-	heat_level_3 = 40000
-
 	warning_low_pressure = 50
 	hazard_low_pressure = 0
 	siemens_coefficient = 0
 	hunger_factor = 0
 	death_message = "dissolves into pure flames!"
 	breath_type = null
-
-
 	total_health = 250
-	body_temperature = T0C + 500 //We are being of fire and light.
 	species_flags = SPECIES_FLAG_NO_MINOR_CUT | SPECIES_FLAG_NO_SLIP | SPECIES_FLAG_NO_POISON | SPECIES_FLAG_NO_EMBED | SPECIES_FLAG_NO_TANGLE
-
 	base_auras = list(
 		/obj/aura/starborn
 		)

--- a/code/modules/species/outsider/starlight.dm
+++ b/code/modules/species/outsider/starlight.dm
@@ -43,24 +43,21 @@
 	icon_deformed =    'icons/mob/human_races/species/starborn/body.dmi'
 	husk_icon =        'icons/mob/human_races/species/starborn/husk.dmi'
 	body_flags =       BODY_FLAG_NO_DNA | BODY_FLAG_NO_PAIN | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
-
+	flesh_color = "#ffff00"
+	death_message = "dissolves into pure flames!"
 	body_temperature = T0C + 500 //We are being of fire and light.
-
 	cold_level_1 = 260
 	cold_level_2 = 250
 	cold_level_3 = 235
-
 	heat_level_1 = 20000
 	heat_level_2 = 30000
 	heat_level_3 = 40000
-
 	cold_discomfort_level = 300
 	cold_discomfort_strings = list(
 		"You feel your fire dying out...",
 		"Your fire begins to shrink away from the cold.",
 		"You feel slow and sluggish from the cold."
 	)
-
 	heat_discomfort_level = 10000
 	heat_discomfort_strings = list(
 		"Surprisingly, you start burning!",
@@ -85,13 +82,11 @@
 	blood_types = list(
 		/decl/blood_type/starstuff
 	)
-	flesh_color = "#ffff00"
 	unarmed_attacks = list(/decl/natural_attack/punch/starborn)
 	warning_low_pressure = 50
 	hazard_low_pressure = 0
 	siemens_coefficient = 0
 	hunger_factor = 0
-	death_message = "dissolves into pure flames!"
 	breath_type = null
 	total_health = 250
 	species_flags = SPECIES_FLAG_NO_MINOR_CUT | SPECIES_FLAG_NO_SLIP | SPECIES_FLAG_NO_POISON | SPECIES_FLAG_NO_EMBED | SPECIES_FLAG_NO_TANGLE
@@ -116,6 +111,7 @@
 	body_flags =       BODY_FLAG_NO_DNA | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 	override_organ_types = list(BP_EYES = /obj/item/organ/internal/eyes/blueforged)
 	radiation_mod = 0
+	flesh_color = "#2222ff"
 
 /decl/blood_type/spacestuff
 	name = "spacestuff"
@@ -129,14 +125,10 @@
 	name_plural = "Blueforged"
 	description = "Living chunks of spacetime, carved out of the original dimension and given life by a being of unbelievable power."
 	available_bodytypes = list(/decl/bodytype/starlight/blueforged)
-
-	flesh_color = "#2222ff"
-
 	warning_low_pressure = 50
 	hazard_low_pressure = 0
 	hunger_factor = 0
 	breath_type = null
-
 	burn_mod = 10
 	brute_mod = 0
 	oxy_mod = 0

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -220,8 +220,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	var/list/exertion_emotes_biological
 	var/list/exertion_emotes_synthetic
 
-	var/list/traits = list() // An associative list of /decl/traits and trait level - See individual traits for valid levels
-
 	// Preview icon gen/tracking vars.
 	var/icon/preview_icon
 	var/preview_icon_width = 64
@@ -361,12 +359,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 
 /decl/species/validate()
 	. = ..()
-
-	for(var/trait_type in traits)
-		var/trait_level = traits[trait_type]
-		var/decl/trait/T = GET_DECL(trait_type)
-		if(!T.validate_level(trait_level))
-			. += "invalid levels for species trait [trait_type]"
 
 	if(!length(blood_types))
 		. += "missing at least one blood type"

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -32,7 +32,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 		/decl/blood_type/ominus
 	)
 
-	var/flesh_color = "#ffc896"             // Pink.
 	var/blood_oxy = 1
 
 	var/static/list/hair_styles
@@ -41,7 +40,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	var/organs_icon		//species specific internal organs icons
 
 	var/strength = STR_MEDIUM
-	var/show_ssd = "fast asleep"
 	var/short_sighted                         // Permanent weldervision.
 	var/light_sensitive                       // Ditto, but requires sunglasses to fix
 	var/blood_volume = SPECIES_BLOOD_DEFAULT  // Initial blood volume.
@@ -92,8 +90,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	var/snow_slowdown_mod = 0
 
 	var/death_sound
-	var/death_message = "seizes up and falls limp, their eyes dead and lifeless..."
-	var/knockout_message = "collapses, having been knocked unconscious."
 	var/halloss_message = "slumps over, too weak to continue fighting..."
 	var/halloss_message_self = "The pain is too severe for you to keep going..."
 
@@ -406,7 +402,7 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	return
 
 /decl/species/proc/handle_sleeping(var/mob/living/carbon/human/H)
-	if(prob(2) && !H.failed_last_breath && !H.isSynthetic())
+	if(prob(2) && !H.failed_last_breath && !H.get_bodytype()?.is_robotic)
 		if(!HAS_STATUS(H, STAT_PARA))
 			H.emote("snore")
 		else

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -655,7 +655,7 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 		return
 	var/chance = max((100 - H.stamina), exertion_effect_chance * H.encumbrance())
 	if (chance && prob(H.skill_fail_chance(SKILL_HAULING, chance)))
-		var/synthetic = H.isSynthetic()
+		var/synthetic = H.get_bodytype()?.is_robotic
 		if (synthetic)
 			if (exertion_charge_scale)
 				var/obj/item/organ/internal/cell/cell = H.get_organ(BP_CELL, /obj/item/organ/internal/cell)

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -13,7 +13,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	var/codex_description
 	var/roleplay_summary
 	var/ooc_codex_information
-	var/cyborg_noun = "Cyborg"
 	var/hidden_from_codex = TRUE
 	var/secret_codex_info
 

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -21,17 +21,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	var/decl/bodytype/default_bodytype
 	var/base_prosthetics_model = /decl/bodytype/prosthetic/basic_human
 
-	var/list/blood_types = list(
-		/decl/blood_type/aplus,
-		/decl/blood_type/aminus,
-		/decl/blood_type/bplus,
-		/decl/blood_type/bminus,
-		/decl/blood_type/abplus,
-		/decl/blood_type/abminus,
-		/decl/blood_type/oplus,
-		/decl/blood_type/ominus
-	)
-
 	var/blood_oxy = 1
 
 	var/static/list/hair_styles
@@ -266,12 +255,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 
 	. = ..()
 
-	// Populate blood type table.
-	for(var/blood_type in blood_types)
-		var/decl/blood_type/blood_decl = GET_DECL(blood_type)
-		blood_types -= blood_type
-		blood_types[blood_decl.name] = blood_decl.random_weighting
-
 	for(var/bodytype in available_bodytypes)
 		available_bodytypes -= bodytype
 		available_bodytypes += GET_DECL(bodytype)
@@ -334,9 +317,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 
 /decl/species/validate()
 	. = ..()
-
-	if(!length(blood_types))
-		. += "missing at least one blood type"
 	if(default_bodytype && !(default_bodytype in available_bodytypes))
 		. += "default bodytype is not in available bodytypes list"
 	if(!length(available_bodytypes))
@@ -346,7 +326,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 		. += "age descriptor was unset"
 	else if(!ispath(age_descriptor, /datum/appearance_descriptor/age))
 		. += "age descriptor was not a /datum/appearance_descriptor/age subtype"
-
 	if(taste_sensitivity < 0)
 		. += "taste_sensitivity ([taste_sensitivity]) was negative"
 
@@ -524,19 +503,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 
 /decl/species/proc/handle_additional_hair_loss(var/mob/living/carbon/human/H, var/defer_body_update = TRUE)
 	return FALSE
-
-/decl/species/proc/get_blood_decl(var/mob/living/carbon/human/H)
-	if(istype(H) && H.isSynthetic())
-		return GET_DECL(/decl/blood_type/coolant)
-	return get_blood_type_by_name(blood_types[1])
-
-/decl/species/proc/get_blood_name(var/mob/living/carbon/human/H)
-	var/decl/blood_type/blood = get_blood_decl(H)
-	return istype(blood) ? blood.splatter_name : "blood"
-
-/decl/species/proc/get_blood_color(var/mob/living/carbon/human/H)
-	var/decl/blood_type/blood = get_blood_decl(H)
-	return istype(blood) ? blood.splatter_colour : COLOR_BLOOD_HUMAN
 
 // Impliments different trails for species depending on if they're wearing shoes.
 /decl/species/proc/get_move_trail(var/mob/living/carbon/human/H)

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -69,7 +69,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	var/brute_mod =      1                    // Physical damage multiplier.
 	var/burn_mod =       1                    // Burn damage multiplier.
 	var/toxins_mod =     1                    // Toxloss modifier
-	var/radiation_mod =  1                    // Radiation modifier
 
 	var/oxy_mod =        1                    // Oxyloss modifier
 	var/metabolism_mod = 1                    // Reagent metabolism modifier

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -109,31 +109,10 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	var/blood_reagent = /decl/material/liquid/blood
 
 	var/max_pressure_diff = 60                                  // Maximum pressure difference that is safe for lungs
-	var/cold_level_1 = 243                                      // Cold damage level 1 below this point. -30 Celsium degrees
-	var/cold_level_2 = 200                                      // Cold damage level 2 below this point.
-	var/cold_level_3 = 120                                      // Cold damage level 3 below this point.
-	var/heat_level_1 = 360                                      // Heat damage level 1 above this point.
-	var/heat_level_2 = 400                                      // Heat damage level 2 above this point.
-	var/heat_level_3 = 1000                                     // Heat damage level 3 above this point.
-	var/passive_temp_gain = 0		                            // Species will gain this much temperature every second
 	var/hazard_high_pressure = HAZARD_HIGH_PRESSURE             // Dangerously high pressure.
 	var/warning_high_pressure = WARNING_HIGH_PRESSURE           // High pressure warning.
 	var/warning_low_pressure = WARNING_LOW_PRESSURE             // Low pressure warning.
 	var/hazard_low_pressure = HAZARD_LOW_PRESSURE               // Dangerously low pressure.
-	var/body_temperature = 310.15	                            // Species will try to stabilize at this temperature.
-	                                                            // (also affects temperature processing)
-	var/heat_discomfort_level = 315                             // Aesthetic messages about feeling warm.
-	var/cold_discomfort_level = 285                             // Aesthetic messages about feeling chilly.
-	var/list/heat_discomfort_strings = list(
-		"You feel sweat drip down your neck.",
-		"You feel uncomfortably warm.",
-		"Your skin prickles in the heat."
-		)
-	var/list/cold_discomfort_strings = list(
-		"You feel chilly.",
-		"You shiver suddenly.",
-		"Your chilly flesh stands out in goosebumps."
-		)
 
 	var/water_soothe_amount
 
@@ -371,31 +350,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 		. += "age descriptor was unset"
 	else if(!ispath(age_descriptor, /datum/appearance_descriptor/age))
 		. += "age descriptor was not a /datum/appearance_descriptor/age subtype"
-
-	if(cold_level_3)
-		if(cold_level_2)
-			if(cold_level_3 > cold_level_2)
-				. += "cold_level_3 ([cold_level_3]) was not lower than cold_level_2 ([cold_level_2])"
-			if(cold_level_1)
-				if(cold_level_3 > cold_level_1)
-					. += "cold_level_3 ([cold_level_3]) was not lower than cold_level_1 ([cold_level_1])"
-	if(cold_level_2 && cold_level_1)
-		if(cold_level_2 > cold_level_1)
-			. += "cold_level_2 ([cold_level_2]) was not lower than cold_level_1 ([cold_level_1])"
-
-	if(heat_level_3 != INFINITY)
-		if(heat_level_2 != INFINITY)
-			if(heat_level_3 < heat_level_2)
-				. += "heat_level_3 ([heat_level_3]) was not higher than heat_level_2 ([heat_level_2])"
-			if(heat_level_1 != INFINITY)
-				if(heat_level_3 < heat_level_1)
-					. += "heat_level_3 ([heat_level_3]) was not higher than heat_level_1 ([heat_level_1])"
-	if((heat_level_2 != INFINITY) && (heat_level_1 != INFINITY))
-		if(heat_level_2 < heat_level_1)
-			. += "heat_level_2 ([heat_level_2]) was not higher than heat_level_1 ([heat_level_1])"
-
-	if(min(heat_level_1, heat_level_2, heat_level_3) <= max(cold_level_1, cold_level_2, cold_level_3))
-		. += "heat and cold damage level thresholds overlap"
 
 	if(taste_sensitivity < 0)
 		. += "taste_sensitivity ([taste_sensitivity]) was negative"
@@ -786,6 +740,12 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	//Make sure only supported descriptors are left
 	H.appearance_descriptors = new_descriptors
 
+/decl/species/proc/customize_preview_mannequin(mob/living/carbon/human/dummy/mannequin/mannequin)
+	if(mannequin.species.preview_outfit)
+		var/decl/hierarchy/outfit/outfit = outfit_by_type(preview_outfit)
+		outfit.equip_outfit(mannequin, equip_adjustments = (OUTFIT_ADJUSTMENT_SKIP_SURVIVAL_GEAR|OUTFIT_ADJUSTMENT_SKIP_BACKPACK))
+	mannequin.update_transform()
+
 /decl/species/proc/get_preview_icon()
 	if(!preview_icon)
 
@@ -817,20 +777,3 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	H.mob_swap_flags = swap_flags
 	H.mob_push_flags = push_flags
 	H.pass_flags = pass_flags
-
-/decl/species/proc/get_species_temperature_threshold(var/threshold)
-	switch(threshold)
-		if(COLD_LEVEL_1)
-			return cold_level_1
-		if(COLD_LEVEL_2)
-			return cold_level_2
-		if(COLD_LEVEL_3)
-			return cold_level_3
-		if(HEAT_LEVEL_1)
-			return heat_level_1
-		if(HEAT_LEVEL_2)
-			return heat_level_2
-		if(HEAT_LEVEL_3)
-			return heat_level_3
-		else
-			CRASH("get_species_temperature_threshold() called with invalid threshold value.")

--- a/code/modules/species/species_bodytype.dm
+++ b/code/modules/species/species_bodytype.dm
@@ -113,10 +113,6 @@ var/global/list/bodytypes_by_category = list()
 		'sound/foley/meat2.ogg'
 	)
 
-	var/list/synthetic_bodyfall_sounds = list(
-		'sound/foley/metal1.ogg'
-	)
-
 	// Used for initializing prefs/preview
 	var/base_color =      COLOR_BLACK
 	var/base_eye_color =  COLOR_BLACK
@@ -216,6 +212,13 @@ var/global/list/bodytypes_by_category = list()
 	var/speech_bubble_state
 	/// Overrides the default 'worsens' message for being dragged with wounds.
 	var/drag_state_damage_descriptor
+
+	// Various strings/values moved over here from /decl/species.
+	var/death_message = "seizes up and falls limp, their eyes dead and lifeless..."
+	var/knockout_message = "collapses, having been knocked unconscious."
+	var/show_ssd = "fast asleep"
+	var/flesh_color = "#ffc896" // Pink.
+
 
 /decl/bodytype/Initialize()
 	. = ..()
@@ -510,3 +513,15 @@ var/global/list/bodytypes_by_category = list()
 		if("heat")
 			if(covered)
 				to_chat(H, "<span class='danger'>[pick(heat_discomfort_strings)]</span>")
+
+/decl/bodytype/proc/get_knockout_message(var/mob/living/carbon/human/H)
+	return knockout_message
+
+/decl/bodytype/proc/get_death_message(var/mob/living/carbon/human/H)
+	return death_message
+
+/decl/bodytype/proc/get_ssd(var/mob/living/carbon/human/H)
+	return show_ssd
+
+/decl/bodytype/proc/get_flesh_colour(var/mob/living/carbon/human/H)
+	return flesh_color

--- a/code/modules/species/species_bodytype.dm
+++ b/code/modules/species/species_bodytype.dm
@@ -22,6 +22,9 @@ var/global/list/bodytypes_by_category = list()
 	var/associated_gender
 	var/appearance_flags = 0 // Appearance/display related features.
 
+	/// Damage mods
+	var/radiation_mod = 1 // Not as biologically fragile as meatboys.
+
 	/// What tech levels should limbs of this type use/need?
 	var/limb_tech = "{'biotech':2}"
 	var/icon_cache_uid
@@ -390,3 +393,6 @@ var/global/list/bodytypes_by_category = list()
 		var/decl/hierarchy/outfit/outfit = outfit_by_type(preview_outfit)
 		outfit.equip_outfit(mannequin, equip_adjustments = (OUTFIT_ADJUSTMENT_SKIP_SURVIVAL_GEAR|OUTFIT_ADJUSTMENT_SKIP_BACKPACK))
 	mannequin.update_transform()
+
+/decl/bodytype/proc/get_radiation_mod(var/mob/living/carbon/human/H)
+	return radiation_mod

--- a/code/modules/species/species_bodytype.dm
+++ b/code/modules/species/species_bodytype.dm
@@ -24,6 +24,8 @@ var/global/list/bodytypes_by_category = list()
 	var/appearance_flags = 0 // Appearance/display related features.
 	var/gib_descriptor = "squelchy"
 
+	var/list/traits = list() // An associative list of /decl/traits and trait level - See individual traits for valid levels
+
 	/// Damage mods
 	var/radiation_mod = 1 // Not as biologically fragile as meatboys.
 
@@ -222,6 +224,12 @@ var/global/list/bodytypes_by_category = list()
 
 /decl/bodytype/validate()
 	. = ..()
+
+	for(var/trait_type in traits)
+		var/trait_level = traits[trait_type]
+		var/decl/trait/T = GET_DECL(trait_type)
+		if(!T.validate_level(trait_level))
+			. += "invalid levels for species trait [trait_type]"
 
 	if(eye_base_low_light_vision > 1)
 		. += "base low light vision is greater than 1 (over 100%)"

--- a/code/modules/species/species_bodytype.dm
+++ b/code/modules/species/species_bodytype.dm
@@ -177,6 +177,9 @@ var/global/list/bodytypes_by_category = list()
 	/// Stun from blindness modifier.
 	var/eye_flash_mod = 1
 
+	/// Type used for butchery products.
+	var/meat_type = /obj/item/chems/food/meat
+
 /decl/bodytype/Initialize()
 	. = ..()
 	icon_deformed ||= icon_base

--- a/code/modules/species/species_bodytype.dm
+++ b/code/modules/species/species_bodytype.dm
@@ -182,6 +182,9 @@ var/global/list/bodytypes_by_category = list()
 	/// Type used for butchery products.
 	var/meat_type = /obj/item/chems/food/meat
 
+	/// Value supplied when this mob's pulse is checked, in the absence of a heart.
+	var/default_pulse_value = PULSE_NORM
+
 /decl/bodytype/Initialize()
 	. = ..()
 	icon_deformed ||= icon_base

--- a/code/modules/species/species_bodytype.dm
+++ b/code/modules/species/species_bodytype.dm
@@ -2,6 +2,7 @@ var/global/list/bodytypes_by_category = list()
 
 /decl/bodytype
 	var/name = "default"
+	var/examined_name // If set, will override species name in examine ("that's Dave, a foo bar").
 	/// Seen when examining a prosthetic limb, if non-null.
 	var/desc
 	var/icon_base
@@ -21,6 +22,7 @@ var/global/list/bodytypes_by_category = list()
 	var/ignited_icon =    'icons/mob/OnFire.dmi'
 	var/associated_gender
 	var/appearance_flags = 0 // Appearance/display related features.
+	var/gib_descriptor = "squelchy"
 
 	/// Damage mods
 	var/radiation_mod = 1 // Not as biologically fragile as meatboys.
@@ -396,3 +398,11 @@ var/global/list/bodytypes_by_category = list()
 
 /decl/bodytype/proc/get_radiation_mod(var/mob/living/carbon/human/H)
 	return radiation_mod
+
+/decl/bodytype/proc/get_examined_name(var/mob/living/showing)
+	var/decl/species/species = showing.get_species()
+	if(examined_name)
+		if(species)
+			return "\improper [examined_name] [species.get_root_species_name(showing)]"
+		return "\improper [examined_name]"
+	return "\improper [species?.name || "Unknown"]"

--- a/code/modules/species/species_bodytype.dm
+++ b/code/modules/species/species_bodytype.dm
@@ -219,10 +219,27 @@ var/global/list/bodytypes_by_category = list()
 	var/show_ssd = "fast asleep"
 	var/flesh_color = "#ffc896" // Pink.
 
+	/// A list of blood decl types available to this bodytype.
+	var/list/blood_types = list(
+		/decl/blood_type/aplus,
+		/decl/blood_type/aminus,
+		/decl/blood_type/bplus,
+		/decl/blood_type/bminus,
+		/decl/blood_type/abplus,
+		/decl/blood_type/abminus,
+		/decl/blood_type/oplus,
+		/decl/blood_type/ominus
+	)
 
 /decl/bodytype/Initialize()
 	. = ..()
 	icon_deformed ||= icon_base
+
+	// Populate blood type table.
+	for(var/blood_type in blood_types)
+		var/decl/blood_type/blood_decl = GET_DECL(blood_type)
+		blood_types -= blood_type
+		blood_types[blood_decl.name] = blood_decl.random_weighting
 
 	LAZYDISTINCTADD(global.bodytypes_by_category[bodytype_category], src)
 	//If the bodytype has eyes, they are the default vision organ
@@ -263,6 +280,9 @@ var/global/list/bodytypes_by_category = list()
 /decl/bodytype/validate()
 	. = ..()
 
+	if(!length(blood_types))
+		. += "missing at least one blood type"
+
 	if(cold_level_3)
 		if(cold_level_2)
 			if(cold_level_3 > cold_level_2)
@@ -273,7 +293,6 @@ var/global/list/bodytypes_by_category = list()
 	if(cold_level_2 && cold_level_1)
 		if(cold_level_2 > cold_level_1)
 			. += "cold_level_2 ([cold_level_2]) was not lower than cold_level_1 ([cold_level_1])"
-
 	if(heat_level_3 != INFINITY)
 		if(heat_level_2 != INFINITY)
 			if(heat_level_3 < heat_level_2)
@@ -525,3 +544,14 @@ var/global/list/bodytypes_by_category = list()
 
 /decl/bodytype/proc/get_flesh_colour(var/mob/living/carbon/human/H)
 	return flesh_color
+
+/decl/bodytype/proc/get_blood_decl(var/mob/living/carbon/human/H)
+	return get_blood_type_by_name(blood_types[1])
+
+/decl/bodytype/proc/get_blood_name(var/mob/living/carbon/human/H)
+	var/decl/blood_type/blood = get_blood_decl(H)
+	return istype(blood) ? blood.splatter_name : "blood"
+
+/decl/bodytype/proc/get_blood_color(var/mob/living/carbon/human/H)
+	var/decl/blood_type/blood = get_blood_decl(H)
+	return istype(blood) ? blood.splatter_colour : COLOR_BLOOD_HUMAN

--- a/code/modules/species/species_crystalline_bodytypes.dm
+++ b/code/modules/species/species_crystalline_bodytypes.dm
@@ -21,6 +21,7 @@
 	heat_level_1 = SYNTH_HEAT_LEVEL_1
 	heat_level_2 = SYNTH_HEAT_LEVEL_2
 	heat_level_3 = SYNTH_HEAT_LEVEL_3
+	blood_types = list(/decl/blood_type/coolant)
 	var/is_brittle
 
 /decl/bodytype/crystalline/apply_bodytype_organ_modifications(obj/item/organ/org)

--- a/code/modules/species/species_crystalline_bodytypes.dm
+++ b/code/modules/species/species_crystalline_bodytypes.dm
@@ -14,6 +14,13 @@
 		/decl/trait/metabolically_inert = TRAIT_LEVEL_EXISTS,
 		/decl/trait/radiation_hardened  = TRAIT_LEVEL_EXISTS
 	)
+	drag_state_damage_descriptor = "state worsens"
+	cold_level_1 = SYNTH_COLD_LEVEL_1
+	cold_level_2 = SYNTH_COLD_LEVEL_2
+	cold_level_3 = SYNTH_COLD_LEVEL_3
+	heat_level_1 = SYNTH_HEAT_LEVEL_1
+	heat_level_2 = SYNTH_HEAT_LEVEL_2
+	heat_level_3 = SYNTH_HEAT_LEVEL_3
 	var/is_brittle
 
 /decl/bodytype/crystalline/apply_bodytype_organ_modifications(obj/item/organ/org)

--- a/code/modules/species/species_crystalline_bodytypes.dm
+++ b/code/modules/species/species_crystalline_bodytypes.dm
@@ -10,7 +10,10 @@
 	material = /decl/material/solid/gemstone/crystal
 	body_flags = BODY_FLAG_CRYSTAL_REFORM | BODY_FLAG_NO_DNA | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 	gib_descriptor = "brittle, splintery"
-	traits = list(/decl/trait/metabolically_inert = TRAIT_LEVEL_EXISTS)
+	traits = list(
+		/decl/trait/metabolically_inert = TRAIT_LEVEL_EXISTS,
+		/decl/trait/radiation_hardened  = TRAIT_LEVEL_EXISTS
+	)
 	var/is_brittle
 
 /decl/bodytype/crystalline/apply_bodytype_organ_modifications(obj/item/organ/org)

--- a/code/modules/species/species_crystalline_bodytypes.dm
+++ b/code/modules/species/species_crystalline_bodytypes.dm
@@ -10,6 +10,7 @@
 	material = /decl/material/solid/gemstone/crystal
 	body_flags = BODY_FLAG_CRYSTAL_REFORM | BODY_FLAG_NO_DNA | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 	gib_descriptor = "brittle, splintery"
+	traits = list(/decl/trait/metabolically_inert = TRAIT_LEVEL_EXISTS)
 	var/is_brittle
 
 /decl/bodytype/crystalline/apply_bodytype_organ_modifications(obj/item/organ/org)

--- a/code/modules/species/species_crystalline_bodytypes.dm
+++ b/code/modules/species/species_crystalline_bodytypes.dm
@@ -9,6 +9,7 @@
 	is_robotic = FALSE
 	material = /decl/material/solid/gemstone/crystal
 	body_flags = BODY_FLAG_CRYSTAL_REFORM | BODY_FLAG_NO_DNA | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
+	gib_descriptor = "brittle, splintery"
 	var/is_brittle
 
 /decl/bodytype/crystalline/apply_bodytype_organ_modifications(obj/item/organ/org)

--- a/code/modules/species/species_getters.dm
+++ b/code/modules/species/species_getters.dm
@@ -22,28 +22,6 @@
 /decl/species/proc/get_flesh_colour(var/mob/living/carbon/human/H)
 	return ((H && H.isSynthetic()) ? SYNTH_FLESH_COLOUR : flesh_color)
 
-/decl/species/proc/get_environment_discomfort(var/mob/living/carbon/human/H, var/msg_type)
-
-	if(!prob(5))
-		return
-
-	var/covered = 0 // Basic coverage can help.
-	var/held_items = H.get_held_items()
-	for(var/obj/item/clothing/clothes in H)
-		if(clothes in held_items)
-			continue
-		if((clothes.body_parts_covered & SLOT_UPPER_BODY) && (clothes.body_parts_covered & SLOT_LOWER_BODY))
-			covered = 1
-			break
-
-	switch(msg_type)
-		if("cold")
-			if(!covered)
-				to_chat(H, "<span class='danger'>[pick(cold_discomfort_strings)]</span>")
-		if("heat")
-			if(covered)
-				to_chat(H, "<span class='danger'>[pick(heat_discomfort_strings)]</span>")
-
 /decl/species/proc/get_vision_flags(var/mob/living/carbon/human/H)
 	return vision_flags
 

--- a/code/modules/species/species_getters.dm
+++ b/code/modules/species/species_getters.dm
@@ -10,18 +10,6 @@
 /decl/species/proc/get_station_variant()
 	return name
 
-/decl/species/proc/get_knockout_message(var/mob/living/carbon/human/H)
-	return ((H && H.isSynthetic()) ? "encounters a hardware fault and suddenly reboots!" : knockout_message)
-
-/decl/species/proc/get_death_message(var/mob/living/carbon/human/H)
-	return ((H && H.isSynthetic()) ? "gives one shrill beep before falling lifeless." : death_message)
-
-/decl/species/proc/get_ssd(var/mob/living/carbon/human/H)
-	return ((H && H.isSynthetic()) ? "flashing a 'system offline' glyph on their monitor" : show_ssd)
-
-/decl/species/proc/get_flesh_colour(var/mob/living/carbon/human/H)
-	return ((H && H.isSynthetic()) ? SYNTH_FLESH_COLOUR : flesh_color)
-
 /decl/species/proc/get_vision_flags(var/mob/living/carbon/human/H)
 	return vision_flags
 

--- a/code/modules/species/species_getters.dm
+++ b/code/modules/species/species_getters.dm
@@ -62,9 +62,6 @@
 /decl/species/proc/get_burn_mod(var/mob/living/carbon/human/H)
 	. = burn_mod
 
-/decl/species/proc/get_radiation_mod(var/mob/living/carbon/human/H)
-	. = (H && H.isSynthetic() ? 0.5 : radiation_mod)
-
 /decl/species/proc/get_root_species_name(var/mob/living/carbon/human/H)
 	return name
 

--- a/code/modules/species/station/golem.dm
+++ b/code/modules/species/station/golem.dm
@@ -30,14 +30,6 @@
 
 	flesh_color = "#137e8f"
 
-	cold_level_1 = SYNTH_COLD_LEVEL_1
-	cold_level_2 = SYNTH_COLD_LEVEL_2
-	cold_level_3 = SYNTH_COLD_LEVEL_3
-
-	heat_level_1 = SYNTH_HEAT_LEVEL_1
-	heat_level_2 = SYNTH_HEAT_LEVEL_2
-	heat_level_3 = SYNTH_HEAT_LEVEL_3
-
 	death_message = "becomes completely motionless..."
 	available_pronouns = list(/decl/pronouns/neuter)
 

--- a/code/modules/species/station/golem.dm
+++ b/code/modules/species/station/golem.dm
@@ -47,8 +47,6 @@
 		TAG_FACTION =   /decl/cultural_info/faction/other
 	)
 
-	traits = list(/decl/trait/metabolically_inert = TRAIT_LEVEL_EXISTS)
-
 /decl/species/golem/handle_post_spawn(var/mob/living/carbon/human/H)
 	if(H.mind)
 		H.mind.reset()

--- a/code/modules/species/station/golem.dm
+++ b/code/modules/species/station/golem.dm
@@ -4,6 +4,8 @@
 	icon_base =         'icons/mob/human_races/species/golem/body.dmi'
 	husk_icon =         'icons/mob/human_races/species/golem/husk.dmi'
 	body_flags =        BODY_FLAG_NO_DNA | BODY_FLAG_NO_PAIN | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
+	flesh_color =       "#137e8f"
+	death_message =     "becomes completely motionless..."
 	has_organ = list(
 		BP_BRAIN = /obj/item/organ/internal/brain/golem
 	)
@@ -28,9 +30,6 @@
 
 	blood_types = list(/decl/blood_type/coolant)
 
-	flesh_color = "#137e8f"
-
-	death_message = "becomes completely motionless..."
 	available_pronouns = list(/decl/pronouns/neuter)
 
 	force_cultural_info = list(

--- a/code/modules/species/station/golem.dm
+++ b/code/modules/species/station/golem.dm
@@ -28,7 +28,6 @@
 	breath_type = null
 	poison_types = null
 
-	blood_types = list(/decl/blood_type/coolant)
 
 	available_pronouns = list(/decl/pronouns/neuter)
 

--- a/code/modules/species/station/human.dm
+++ b/code/modules/species/station/human.dm
@@ -31,11 +31,6 @@
 /decl/species/human/get_root_species_name(var/mob/living/carbon/human/H)
 	return SPECIES_HUMAN
 
-/decl/species/human/get_ssd(var/mob/living/carbon/human/H)
-	if(H.stat == CONSCIOUS)
-		return "staring blankly, not reacting to your presence"
-	return ..()
-
 /decl/species/human/equip_default_fallback_uniform(var/mob/living/carbon/human/H)
 	if(istype(H))
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey, slot_w_uniform_str)

--- a/code/modules/species/station/human_bodytypes.dm
+++ b/code/modules/species/station/human_bodytypes.dm
@@ -11,6 +11,11 @@
 	uniform_state_modifier = "f"
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE_NORMAL | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR
 
+/decl/bodytype/human/get_ssd(var/mob/living/carbon/human/H)
+	if(H.stat == CONSCIOUS)
+		return "staring blankly, not reacting to your presence"
+	return ..()
+
 /decl/bodytype/human/masculine
 	name =                "masculine"
 	icon_base =           'icons/mob/human_races/species/human/body_male.dmi'

--- a/code/modules/species/station/monkey.dm
+++ b/code/modules/species/station/monkey.dm
@@ -9,11 +9,9 @@
 	available_bodytypes = list(/decl/bodytype/monkey)
 	holder_icon = 'icons/mob/human_races/species/monkey/holder.dmi'
 
-	show_ssd = null
 
 	gibbed_anim = "gibbed-m"
 	dusted_anim = "dust-m"
-	death_message = "lets out a faint chimper as it collapses and stops moving..."
 
 	unarmed_attacks = list(/decl/natural_attack/bite, /decl/natural_attack/claws, /decl/natural_attack/punch)
 	inherent_verbs = list(/mob/living/proc/ventcrawl)

--- a/code/modules/species/station/monkey_bodytypes.dm
+++ b/code/modules/species/station/monkey_bodytypes.dm
@@ -10,6 +10,8 @@
 		BP_TAIL = /obj/item/organ/external/tail/monkey
 	)
 	mob_size = MOB_SIZE_SMALL
+	show_ssd = null
+	death_message = "lets out a faint chimper as it collapses and stops moving..."
 
 /decl/bodytype/monkey/Initialize()
 	equip_adjust = list(

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -237,7 +237,6 @@
 		return affected
 
 /decl/surgery_step/generic/amputate/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool, target_zone)
-	var/target_zone = user.get_target_zone()
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	if(BP_IS_PROSTHETIC(affected))
 		return SURGERY_SKILLS_ROBOTIC

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -236,7 +236,7 @@
 	if(affected && (affected.limb_flags & ORGAN_FLAG_CAN_AMPUTATE) && !affected.how_open())
 		return affected
 
-/decl/surgery_step/generic/amputate/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool)
+/decl/surgery_step/generic/amputate/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool, target_zone)
 	var/target_zone = user.get_target_zone()
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	if(BP_IS_PROSTHETIC(affected))

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -13,18 +13,19 @@
 	delicate = 1
 	abstract_type = /decl/surgery_step/limb
 
-/decl/surgery_step/limb/get_skill_reqs(mob/living/user, mob/living/target, obj/item/organ/external/tool)
+/decl/surgery_step/limb/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool, target_zone)
 	// Not supplied a limb.
-	if(!istype(tool))
+	var/obj/item/organ/external/limb = tool
+	if(!istype(limb))
 		return ..()
 	// No parent (how did we get here?)
-	var/tool_is_prosthetic = BP_IS_PROSTHETIC(tool)
-	if(!tool.parent_organ)
+	var/tool_is_prosthetic = BP_IS_PROSTHETIC(limb)
+	if(!limb.parent_organ)
 		if(tool_is_prosthetic)
 			return SURGERY_SKILLS_ROBOTIC
 		return ..()
 	// Parent is invalid.
-	var/obj/item/organ/external/parent = target && GET_EXTERNAL_ORGAN(target, tool.parent_organ)
+	var/obj/item/organ/external/parent = target && GET_EXTERNAL_ORGAN(target, limb.parent_organ)
 	if(!istype(parent))
 		return ..()
 	// If either is meat and the other is not, return mixed skills.

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -168,7 +168,7 @@
 			return show_radial_menu(user, tool, removable_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
 	return FALSE
 
-/decl/surgery_step/internal/remove_organ/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool)
+/decl/surgery_step/internal/remove_organ/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool, target_zone)
 	var/target_zone = user.get_target_zone()
 	var/obj/item/organ/internal/O = LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
@@ -225,7 +225,7 @@
 	max_duration = 80
 	var/robotic_surgery = FALSE
 
-/decl/surgery_step/internal/replace_organ/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool)
+/decl/surgery_step/internal/replace_organ/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool, target_zone)
 	var/obj/item/organ/internal/O = tool
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, user.get_target_zone())
 	if(BP_IS_PROSTHETIC(O) || istype(O, /obj/item/organ/internal/augment))
@@ -308,7 +308,7 @@
 	max_duration = 120
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_ROBOTIC | SURGERY_NEEDS_ENCASEMENT
 
-/decl/surgery_step/internal/attach_organ/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool)
+/decl/surgery_step/internal/attach_organ/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool, target_zone)
 	var/target_zone = user.get_target_zone()
 	var/obj/item/organ/internal/O = LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -169,7 +169,6 @@
 	return FALSE
 
 /decl/surgery_step/internal/remove_organ/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool, target_zone)
-	var/target_zone = user.get_target_zone()
 	var/obj/item/organ/internal/O = LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	if(BP_IS_PROSTHETIC(O))
@@ -309,7 +308,6 @@
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_ROBOTIC | SURGERY_NEEDS_ENCASEMENT
 
 /decl/surgery_step/internal/attach_organ/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool, target_zone)
-	var/target_zone = user.get_target_zone()
 	var/obj/item/organ/internal/O = LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	if(BP_IS_PROSTHETIC(O))

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -115,7 +115,7 @@
 /decl/surgery_step/hardsuit/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	return TRUE
 
-/decl/surgery_step/hardsuit/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool)
+/decl/surgery_step/hardsuit/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool, target_zone)
 	return list(SKILL_EVA = SKILL_BASIC)
 
 /decl/surgery_step/hardsuit/can_use(mob/living/user, mob/living/target, target_zone, obj/item/tool)
@@ -179,7 +179,7 @@
 	if(affected && !affected.is_disinfected() && check_chemicals(tool))
 		return affected
 
-/decl/surgery_step/sterilize/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool)
+/decl/surgery_step/sterilize/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool, target_zone)
 	return list(SKILL_MEDICAL = SKILL_BASIC)
 
 /decl/surgery_step/sterilize/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -12,7 +12,7 @@
 	abstract_type = /decl/surgery_step/robotics
 	end_step_sound = 'sound/items/Screwdriver.ogg'
 
-/decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool)
+/decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool, target_zone)
 	return SURGERY_SKILLS_ROBOTIC
 
 /decl/surgery_step/robotics/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
@@ -351,11 +351,11 @@
 	max_duration = 90
 	surgery_candidate_flags = 0
 
-/decl/surgery_step/robotics/fix_organ_robotic/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool)
-	if(target.isSynthetic())
+/decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool, target_zone)
+	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, check_zone(target_zone, target))
+	if(E && BP_IS_PROSTHETIC(E))
 		return SURGERY_SKILLS_ROBOTIC
-	else
-		return SURGERY_SKILLS_ROBOTIC_ON_MEAT
+	return SURGERY_SKILLS_ROBOTIC_ON_MEAT
 
 /decl/surgery_step/robotics/fix_organ_robotic/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
@@ -509,13 +509,13 @@
 
 /decl/surgery_step/robotics/install_mmi/pre_surgery_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/mmi/M = tool
-	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
+	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, check_zone(target_zone, target))
 	if(affected && istype(M))
 		if(!M.brainmob || !M.brainmob.client || !M.brainmob.ckey || M.brainmob.stat >= DEAD)
 			to_chat(user, SPAN_WARNING("That brain is not usable."))
 		else if(BP_IS_CRYSTAL(affected))
 			to_chat(user, SPAN_WARNING("The crystalline interior of \the [affected] is incompatible with \the [M]."))
-		else if(!target.isSynthetic())
+		else if(!BP_IS_PROSTHETIC(affected))
 			to_chat(user, SPAN_WARNING("You cannot install a computer brain into a meat body."))
 		else if(!target.should_have_organ(BP_BRAIN))
 			var/decl/species/species = target.get_species()
@@ -586,7 +586,7 @@
 	can_infect = 0
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_FLESH | SURGERY_NEEDS_ENCASEMENT
 
-/decl/surgery_step/remove_mmi/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool)
+/decl/surgery_step/remove_mmi/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool, target_zone)
 	return SURGERY_SKILLS_ROBOTIC
 
 /decl/surgery_step/remove_mmi/assess_bodypart(mob/living/user, mob/living/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -353,7 +353,7 @@
 
 /decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool, target_zone)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, check_zone(target_zone, target))
-	if(E && BP_IS_PROSTHETIC(E))
+	if(affected && BP_IS_PROSTHETIC(affected))
 		return SURGERY_SKILLS_ROBOTIC
 	return SURGERY_SKILLS_ROBOTIC_ON_MEAT
 

--- a/code/modules/xenoarcheaology/artifacts/effects/heal.dm
+++ b/code/modules/xenoarcheaology/artifacts/effects/heal.dm
@@ -30,7 +30,7 @@
 		C.adjustBrainLoss(-force)
 		if(strong)
 			C.apply_radiation(-25 * weakness)
-			C.bodytemperature = C.species?.body_temperature || initial(C.bodytemperature)
+			C.bodytemperature = C.get_bodytype()?.body_temperature || initial(C.bodytemperature)
 			C.adjust_nutrition(50 * weakness)
 			if(ishuman(C))
 				var/mob/living/carbon/human/H = C

--- a/code/modules/xenoarcheaology/artifacts/effects/sleepy.dm
+++ b/code/modules/xenoarcheaology/artifacts/effects/sleepy.dm
@@ -34,7 +34,8 @@
 /datum/artifact_effect/sleepy/proc/sleepify(mob/living/carbon/human/H, speed, limit, message_prob)
 	var/weakness = GetAnomalySusceptibility(H)
 	if(prob(weakness * 100))
-		if(H.isSynthetic())
+		var/obj/item/organ/internal/brain/brain = H.should_have_organ(BP_BRAIN) && GET_INTERNAL_ORGAN(H, BP_BRAIN)
+		if(istype(brain) && BP_IS_PROSTHETIC(brain))
 			if(prob(message_prob))
 				to_chat(H, SPAN_WARNING("SYSTEM ALERT: CPU cycles slowing down."))
 			return

--- a/code/modules/xenoarcheaology/artifacts/triggers/touch.dm
+++ b/code/modules/xenoarcheaology/artifacts/triggers/touch.dm
@@ -32,10 +32,7 @@
 		return TRUE
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		if(H.isSynthetic())
-			return TRUE
 		var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(H, bodypart)
 		if(E && BP_IS_PROSTHETIC(E))
 			return TRUE
 		return FALSE
-		

--- a/code/unit_tests/mob_tests.dm
+++ b/code/unit_tests/mob_tests.dm
@@ -108,8 +108,8 @@ var/global/default_mobloc = null
 			loss = M.getHalLoss()
 
 	if(!loss && ishuman(M))
-		var/mob/living/carbon/human/H = M            // Synthetics have robot limbs which don't report damage to getXXXLoss()
-		if(H.isSynthetic())                          // So we have to hard code this check or create a different one for them.
+		var/mob/living/carbon/human/H = M // Synthetics have robot limbs which don't report damage to getXXXLoss()
+		if(H.get_bodytype()?.is_robotic)  // So we have to hard code this check or create a different one for them.
 			return H.species.total_health - H.health
 	return loss
 

--- a/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
+++ b/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
@@ -48,7 +48,7 @@
 	SHOULD_CALL_PARENT(FALSE)
 	visible_message("\The [user] touches \the [src].")
 
-	if(!iscarbon(user))
+	if(!ishuman(user))
 		to_chat(user, SPAN_NOTICE("\The [src] is still."))
 		return TRUE
 
@@ -57,8 +57,8 @@
 		to_chat(user, SPAN_NOTICE("\The [src] is still."))
 		return TRUE
 
-	var/mob/living/carbon/C = user
-	if(C.isSynthetic())
+	var/obj/item/organ/external/hand = GET_EXTERNAL_ORGAN(user, user.get_active_held_item_slot())
+	if(istype(hand) && BP_IS_PROSTHETIC(hand))
 		to_chat(user, SPAN_NOTICE("\The [src] is still."))
 		return TRUE
 
@@ -72,7 +72,8 @@
 	to_chat(user, SPAN_DANGER("An overwhelming stream of information invades your mind!"))
 	to_chat(user, SPAN_DANGER("<font size=2>[uppertext(E.engraving_generator.generate_violent_vision_text())]</font>"))
 	SET_STATUS_MAX(user, STAT_PARA, 2)
-	C.set_hallucination(20, 100)
+	var/mob/living/user_living = user
+	user_living.set_hallucination(20, 100)
 	return TRUE
 
 /turf/simulated/floor/fixed/alium/ruin

--- a/mods/content/psionics/_psionics.dm
+++ b/mods/content/psionics/_psionics.dm
@@ -29,3 +29,7 @@
 	character = ..()
 	if(istype(character) && character.psi && !is_preview_copy)
 		character.psi.update()
+
+/decl/trait/psionically_inert
+	name = "Psionically Inert"
+	description = "This creature is unable to manifest psionics."

--- a/mods/content/psionics/system/psionics/events/mini_spasm.dm
+++ b/mods/content/psionics/system/psionics/events/mini_spasm.dm
@@ -30,6 +30,8 @@
 		var/obj/item/radio/source = victims[victim]
 		do_spasm(victim, source)
 
+/mob/proc/isSynthetic()
+
 /datum/event/minispasm/proc/do_spasm(var/mob/living/victim, var/obj/item/radio/source)
 	set waitfor = 0
 

--- a/mods/content/psionics/system/psionics/events/mini_spasm.dm
+++ b/mods/content/psionics/system/psionics/events/mini_spasm.dm
@@ -30,12 +30,10 @@
 		var/obj/item/radio/source = victims[victim]
 		do_spasm(victim, source)
 
-/mob/proc/isSynthetic()
-
 /datum/event/minispasm/proc/do_spasm(var/mob/living/victim, var/obj/item/radio/source)
 	set waitfor = 0
 
-	if(iscarbon(victim) && !victim.isSynthetic())
+	if(iscarbon(victim) && !victim.HasTrait(/decl/trait/psionically_inert))
 		var/list/disabilities = list(NEARSIGHTED, EPILEPSY, TOURETTES, NERVOUS)
 		for(var/disability in disabilities)
 			if(victim.disabilities & disability)

--- a/mods/content/xenobiology/slime/slime_surgery.dm
+++ b/mods/content/xenobiology/slime/slime_surgery.dm
@@ -22,7 +22,7 @@
 /decl/surgery_step/slime/assess_surgery_candidate(mob/living/user, mob/living/slime/target, target_zone, obj/item/tool)
 	return isslime(target) && target.stat == DEAD
 
-/decl/surgery_step/slime/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool)
+/decl/surgery_step/slime/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool, target_zone)
 	return list(SKILL_SCIENCE = SKILL_ADEPT)
 
 //////////////////////////////////////////////////////////////////

--- a/mods/species/ascent/datum/languages.dm
+++ b/mods/species/ascent/datum/languages.dm
@@ -72,12 +72,10 @@
 #undef MANTID_SCRAMBLE_CACHE_LEN
 
 /decl/language/mantid/nonvocal/can_speak_special(var/mob/living/speaker)
-	if(istype(speaker) && speaker.isSynthetic())
+	if(issilicon(speaker))
 		return TRUE
-	else if(ishuman(speaker))
-		var/mob/living/carbon/human/H = speaker
-		return (H.species.name == SPECIES_MANTID_ALATE || H.species.name == SPECIES_MANTID_GYNE)
-	return FALSE
+	var/species_name = speaker.get_species_name()
+	return species_name == SPECIES_MANTID_ALATE || species_name == SPECIES_MANTID_GYNE
 
 /decl/language/mantid/worldnet
 	key = "\["

--- a/mods/species/ascent/datum/languages.dm
+++ b/mods/species/ascent/datum/languages.dm
@@ -20,12 +20,14 @@
 	var/mob/living/S = speaker
 	if(!istype(S))
 		return FALSE
-	if(S.isSynthetic())
+	if(issilicon(speaker))
 		return TRUE
-	if(ishuman(speaker))
-		var/mob/living/carbon/human/H = speaker
-		if(H.species.name in correct_mouthbits)
-			return TRUE
+	var/obj/item/organ/external/head/head = GET_EXTERNAL_ORGAN(speaker, BP_HEAD)
+	if(istype(head) && BP_IS_PROSTHETIC(head))
+		return TRUE
+	var/my_species_name = speaker.get_species_name()
+	if(my_species_name && (my_species_name in correct_mouthbits))
+		return TRUE
 	return FALSE
 
 /decl/language/mantid/muddle(var/message)

--- a/mods/species/ascent/datum/species.dm
+++ b/mods/species/ascent/datum/species.dm
@@ -27,7 +27,6 @@
 
 	name =                   SPECIES_MANTID_ALATE
 	name_plural =            "Kharmaan Alates"
-	show_ssd =               "quiescent"
 
 	base_prosthetics_model = null
 	available_bodytypes = list(/decl/bodytype/crystalline/mantid/alate)
@@ -37,7 +36,6 @@
 	amid reports of highly advanced, astonishingly violent mantid-cephlapodean sentients with particle cannons."
 	organs_icon =       'mods/species/ascent/icons/species/body/organs.dmi'
 
-	flesh_color =             "#009999"
 	move_trail =              /obj/effect/decal/cleanable/blood/tracks/snake
 
 	blood_types = list(/decl/blood_type/hemolymph/mantid)

--- a/mods/species/ascent/datum/species.dm
+++ b/mods/species/ascent/datum/species.dm
@@ -55,7 +55,6 @@
 	siemens_coefficient =   0.2 // Crystalline body.
 	oxy_mod =               0.8 // Don't need as much breathable gas as humans.
 	toxins_mod =            0.8 // Not as biologically fragile as meatboys.
-	radiation_mod =         0.5 // Not as biologically fragile as meatboys.
 
 	age_descriptor = /datum/appearance_descriptor/age/kharmaani
 	rarity_value =            3

--- a/mods/species/ascent/datum/species.dm
+++ b/mods/species/ascent/datum/species.dm
@@ -35,11 +35,7 @@
 	new frontiers and new planets to exploit. They were largely not expecting to have entire expeditions lost \
 	amid reports of highly advanced, astonishingly violent mantid-cephlapodean sentients with particle cannons."
 	organs_icon =       'mods/species/ascent/icons/species/body/organs.dmi'
-
 	move_trail =              /obj/effect/decal/cleanable/blood/tracks/snake
-
-	blood_types = list(/decl/blood_type/hemolymph/mantid)
-
 	speech_chance = 100
 	speech_sounds = list(
 		'mods/species/ascent/sounds/ascent1.ogg',

--- a/mods/species/ascent/datum/species.dm
+++ b/mods/species/ascent/datum/species.dm
@@ -60,7 +60,6 @@
 	rarity_value =            3
 	gluttonous =              2
 	siemens_coefficient =     0
-	body_temperature =        null
 
 	breath_type =             /decl/material/gas/methyl_bromide
 	exhale_type =             /decl/material/gas/methane
@@ -71,16 +70,7 @@
 	species_flags =           SPECIES_FLAG_NO_SLIP | SPECIES_FLAG_NO_MINOR_CUT
 	spawn_flags =             SPECIES_IS_RESTRICTED
 
-	heat_discomfort_strings = list(
-		"You feel brittle and overheated.",
-		"Your overheated carapace flexes uneasily.",
-		"Overheated ichor trickles from your eyes."
-		)
-	cold_discomfort_strings = list(
-		"Frost forms along your carapace.",
-		"You hear a faint crackle of ice as you shift your freezing body.",
-		"Your movements become sluggish under the weight of the chilly conditions."
-		)
+
 	unarmed_attacks = list(
 		/decl/natural_attack/claws/strong/gloves,
 		/decl/natural_attack/bite/sharp

--- a/mods/species/ascent/datum/species_bodytypes.dm
+++ b/mods/species/ascent/datum/species_bodytypes.dm
@@ -30,6 +30,17 @@
 		BP_SYSTEM_CONTROLLER = /obj/item/organ/internal/controller
 	)
 	limb_mapping = list(BP_CHEST = list(BP_CHEST, BP_M_HAND))
+	body_temperature =        null
+	heat_discomfort_strings = list(
+		"You feel brittle and overheated.",
+		"Your overheated carapace flexes uneasily.",
+		"Overheated ichor trickles from your eyes."
+	)
+	cold_discomfort_strings = list(
+		"Frost forms along your carapace.",
+		"You hear a faint crackle of ice as you shift your freezing body.",
+		"Your movements become sluggish under the weight of the chilly conditions."
+	)
 
 /decl/bodytype/crystalline/mantid/alate
 	name =              "alate"

--- a/mods/species/ascent/datum/species_bodytypes.dm
+++ b/mods/species/ascent/datum/species_bodytypes.dm
@@ -41,6 +41,8 @@
 		"You hear a faint crackle of ice as you shift your freezing body.",
 		"Your movements become sluggish under the weight of the chilly conditions."
 	)
+	show_ssd =    "quiescent"
+	flesh_color = "#009999"
 
 /decl/bodytype/crystalline/mantid/alate
 	name =              "alate"

--- a/mods/species/ascent/datum/species_bodytypes.dm
+++ b/mods/species/ascent/datum/species_bodytypes.dm
@@ -43,6 +43,7 @@
 	)
 	show_ssd =    "quiescent"
 	flesh_color = "#009999"
+	blood_types = list(/decl/blood_type/hemolymph/mantid)
 
 /decl/bodytype/crystalline/mantid/alate
 	name =              "alate"

--- a/mods/species/ascent/datum/species_bodytypes.dm
+++ b/mods/species/ascent/datum/species_bodytypes.dm
@@ -1,7 +1,7 @@
 /decl/bodytype/crystalline/mantid
 	abstract_type = /decl/bodytype/crystalline/mantid
 	eye_flash_mod =     2 // Highly photosensitive.
-
+	radiation_mod = 0.5
 	appearance_flags =  0
 	is_brittle = FALSE
 	has_limbs = list(

--- a/mods/species/bayliens/adherent/datum/species.dm
+++ b/mods/species/bayliens/adherent/datum/species.dm
@@ -53,7 +53,6 @@
 	species_flags = SPECIES_FLAG_NO_POISON | SPECIES_FLAG_NO_MINOR_CUT
 	spawn_flags =   SPECIES_CAN_JOIN
 
-	flesh_color = "#90edeb"
 	hud_type = /datum/hud_data/adherent
 
 	available_cultural_info = list(

--- a/mods/species/bayliens/adherent/datum/species.dm
+++ b/mods/species/bayliens/adherent/datum/species.dm
@@ -24,8 +24,6 @@
 	bone_material = null
 	skin_material = null
 
-	blood_types = list(/decl/blood_type/coolant)
-
 	available_pronouns = list(/decl/pronouns)
 	available_bodytypes = list(
 		/decl/bodytype/crystalline/adherent,

--- a/mods/species/bayliens/adherent/datum/species.dm
+++ b/mods/species/bayliens/adherent/datum/species.dm
@@ -37,7 +37,6 @@
 		/decl/bodytype/crystalline/adherent/quartz,
 		/decl/bodytype/crystalline/adherent/jet
 	)
-	cyborg_noun =             null
 
 	siemens_coefficient =     0
 	rarity_value =            6

--- a/mods/species/bayliens/adherent/datum/species.dm
+++ b/mods/species/bayliens/adherent/datum/species.dm
@@ -50,14 +50,6 @@
 	speech_sounds = list('mods/species/bayliens/adherent/sound/chime.ogg')
 	speech_chance = 25
 
-	cold_level_1 = SYNTH_COLD_LEVEL_1
-	cold_level_2 = SYNTH_COLD_LEVEL_2
-	cold_level_3 = SYNTH_COLD_LEVEL_3
-
-	heat_level_1 = SYNTH_HEAT_LEVEL_1
-	heat_level_2 = SYNTH_HEAT_LEVEL_2
-	heat_level_3 = SYNTH_HEAT_LEVEL_3
-
 	species_flags = SPECIES_FLAG_NO_POISON | SPECIES_FLAG_NO_MINOR_CUT
 	spawn_flags =   SPECIES_CAN_JOIN
 

--- a/mods/species/bayliens/adherent/datum/species_bodytypes.dm
+++ b/mods/species/bayliens/adherent/datum/species_bodytypes.dm
@@ -15,6 +15,7 @@
 	is_robotic =                FALSE
 	mob_size =                  MOB_SIZE_LARGE
 	arterial_bleed_multiplier = 0
+	flesh_color =               "#90edeb"
 	apply_encased =             list(
 		BP_CHEST = "ceramic hull",
 		BP_GROIN = "ceramic hull",

--- a/mods/species/bayliens/skrell/datum/species.dm
+++ b/mods/species/bayliens/skrell/datum/species.dm
@@ -39,7 +39,6 @@
 	hazard_high_pressure = HAZARD_HIGH_PRESSURE / 0.84615
 	water_soothe_amount = 5
 
-	body_temperature = null // cold-blooded, implemented the same way nabbers do it
 
 	spawn_flags = SPECIES_CAN_JOIN
 
@@ -56,17 +55,6 @@
 		/decl/blood_type/skrell/noplus,
 		/decl/blood_type/skrell/nominus
 	)
-
-	cold_level_1 = 280 //Default 260 - Lower is better
-	cold_level_2 = 220 //Default 200
-	cold_level_3 = 130 //Default 120
-
-	heat_level_1 = 420 //Default 360 - Higher is better
-	heat_level_2 = 480 //Default 400
-	heat_level_3 = 1100 //Default 1000
-
-	cold_discomfort_level = 292 //Higher than perhaps it should be, to avoid big speed reduction at normal room temp
-	heat_discomfort_level = 368
 
 	appearance_descriptors = list(
 		/datum/appearance_descriptor/height = 1,

--- a/mods/species/bayliens/skrell/datum/species.dm
+++ b/mods/species/bayliens/skrell/datum/species.dm
@@ -38,11 +38,7 @@
 	warning_high_pressure = WARNING_HIGH_PRESSURE / 0.8125
 	hazard_high_pressure = HAZARD_HIGH_PRESSURE / 0.84615
 	water_soothe_amount = 5
-
-
 	spawn_flags = SPECIES_CAN_JOIN
-
-	flesh_color = "#8cd7a3"
 	organs_icon = 'mods/species/bayliens/skrell/icons/body/organs.dmi'
 
 	blood_types = list(

--- a/mods/species/bayliens/skrell/datum/species.dm
+++ b/mods/species/bayliens/skrell/datum/species.dm
@@ -41,17 +41,6 @@
 	spawn_flags = SPECIES_CAN_JOIN
 	organs_icon = 'mods/species/bayliens/skrell/icons/body/organs.dmi'
 
-	blood_types = list(
-		/decl/blood_type/skrell/yplus,
-		/decl/blood_type/skrell/yminus,
-		/decl/blood_type/skrell/zplus,
-		/decl/blood_type/skrell/zminus,
-		/decl/blood_type/skrell/yzplus,
-		/decl/blood_type/skrell/yzminus,
-		/decl/blood_type/skrell/noplus,
-		/decl/blood_type/skrell/nominus
-	)
-
 	appearance_descriptors = list(
 		/datum/appearance_descriptor/height = 1,
 		/datum/appearance_descriptor/build = 0.8,

--- a/mods/species/bayliens/skrell/datum/species_bodytype.dm
+++ b/mods/species/bayliens/skrell/datum/species_bodytype.dm
@@ -9,7 +9,7 @@
 	eye_flash_mod = 1.2
 	eye_icon = 'mods/species/bayliens/skrell/icons/body/eyes.dmi'
 	apply_eye_colour = FALSE
-
+	flesh_color = "#8cd7a3"
 	body_temperature = null // cold-blooded, implemented the same way nabbers do it
 
 	cold_level_1 = 280 //Default 260 - Lower is better

--- a/mods/species/bayliens/skrell/datum/species_bodytype.dm
+++ b/mods/species/bayliens/skrell/datum/species_bodytype.dm
@@ -10,6 +10,19 @@
 	eye_icon = 'mods/species/bayliens/skrell/icons/body/eyes.dmi'
 	apply_eye_colour = FALSE
 
+	body_temperature = null // cold-blooded, implemented the same way nabbers do it
+
+	cold_level_1 = 280 //Default 260 - Lower is better
+	cold_level_2 = 220 //Default 200
+	cold_level_3 = 130 //Default 120
+
+	heat_level_1 = 420 //Default 360 - Higher is better
+	heat_level_2 = 480 //Default 400
+	heat_level_3 = 1100 //Default 1000
+
+	cold_discomfort_level = 292 //Higher than perhaps it should be, to avoid big speed reduction at normal room temp
+	heat_discomfort_level = 368
+
 	associated_gender =    PLURAL
 	appearance_flags =     HAS_HAIR_COLOR | HAS_UNDERWEAR | HAS_SKIN_COLOR
 	base_color =         "#006666"

--- a/mods/species/bayliens/skrell/datum/species_bodytype.dm
+++ b/mods/species/bayliens/skrell/datum/species_bodytype.dm
@@ -12,6 +12,17 @@
 	flesh_color = "#8cd7a3"
 	body_temperature = null // cold-blooded, implemented the same way nabbers do it
 
+	blood_types = list(
+		/decl/blood_type/skrell/yplus,
+		/decl/blood_type/skrell/yminus,
+		/decl/blood_type/skrell/zplus,
+		/decl/blood_type/skrell/zminus,
+		/decl/blood_type/skrell/yzplus,
+		/decl/blood_type/skrell/yzminus,
+		/decl/blood_type/skrell/noplus,
+		/decl/blood_type/skrell/nominus
+	)
+
 	cold_level_1 = 280 //Default 260 - Lower is better
 	cold_level_2 = 220 //Default 200
 	cold_level_3 = 130 //Default 120

--- a/mods/species/bayliens/tajaran/datum/species.dm
+++ b/mods/species/bayliens/tajaran/datum/species.dm
@@ -54,23 +54,6 @@
 
 	move_trail = /obj/effect/decal/cleanable/blood/tracks/paw
 
-	cold_level_1 = 200
-	cold_level_2 = 140
-	cold_level_3 = 80
-
-	heat_level_1 = 330
-	heat_level_2 = 380
-	heat_level_3 = 800
-
-	heat_discomfort_level = 294
-	cold_discomfort_level = 230
-
-	heat_discomfort_strings = list(
-		"Your fur prickles in the heat.",
-		"You feel uncomfortably warm.",
-		"Your overheated skin itches."
-	)
-
 	available_cultural_info = list(
 		TAG_CULTURE = list(
 			/decl/cultural_info/culture/tajaran,

--- a/mods/species/bayliens/tajaran/datum/species.dm
+++ b/mods/species/bayliens/tajaran/datum/species.dm
@@ -37,11 +37,7 @@
 		/decl/blood_type/feline/oplus,
 		/decl/blood_type/feline/ominus
 	)
-
-	flesh_color = "#ae7d32"
-
 	organs_icon = 'mods/species/bayliens/tajaran/icons/organs.dmi'
-
 	hunger_factor = DEFAULT_HUNGER_FACTOR * 1.2
 	gluttonous = GLUT_TINY
 

--- a/mods/species/bayliens/tajaran/datum/species.dm
+++ b/mods/species/bayliens/tajaran/datum/species.dm
@@ -27,16 +27,6 @@
 
 	spawn_flags = SPECIES_CAN_JOIN
 
-	blood_types = list(
-		/decl/blood_type/feline/mplus,
-		/decl/blood_type/feline/mminus,
-		/decl/blood_type/feline/rplus,
-		/decl/blood_type/feline/rminus,
-		/decl/blood_type/feline/mrplus,
-		/decl/blood_type/feline/mrminus,
-		/decl/blood_type/feline/oplus,
-		/decl/blood_type/feline/ominus
-	)
 	organs_icon = 'mods/species/bayliens/tajaran/icons/organs.dmi'
 	hunger_factor = DEFAULT_HUNGER_FACTOR * 1.2
 	gluttonous = GLUT_TINY

--- a/mods/species/bayliens/tajaran/datum/species_bodytypes.dm
+++ b/mods/species/bayliens/tajaran/datum/species_bodytypes.dm
@@ -16,6 +16,23 @@
 	base_eye_color = "#00aa00"
 	default_h_style = /decl/sprite_accessory/hair/taj/lynx
 
+	heat_discomfort_level = 294
+	cold_discomfort_level = 230
+
+	heat_discomfort_strings = list(
+		"Your fur prickles in the heat.",
+		"You feel uncomfortably warm.",
+		"Your overheated skin itches."
+	)
+
+	cold_level_1 = 200
+	cold_level_2 = 140
+	cold_level_3 = 80
+
+	heat_level_1 = 330
+	heat_level_2 = 380
+	heat_level_3 = 800
+
 	eye_darksight_range = 7
 	eye_flash_mod = 2
 	eye_blend = ICON_MULTIPLY

--- a/mods/species/bayliens/tajaran/datum/species_bodytypes.dm
+++ b/mods/species/bayliens/tajaran/datum/species_bodytypes.dm
@@ -17,6 +17,16 @@
 	default_h_style = /decl/sprite_accessory/hair/taj/lynx
 	flesh_color = "#ae7d32"
 
+	blood_types = list(
+		/decl/blood_type/feline/mplus,
+		/decl/blood_type/feline/mminus,
+		/decl/blood_type/feline/rplus,
+		/decl/blood_type/feline/rminus,
+		/decl/blood_type/feline/mrplus,
+		/decl/blood_type/feline/mrminus,
+		/decl/blood_type/feline/oplus,
+		/decl/blood_type/feline/ominus
+	)
 	heat_discomfort_level = 294
 	cold_discomfort_level = 230
 

--- a/mods/species/bayliens/tajaran/datum/species_bodytypes.dm
+++ b/mods/species/bayliens/tajaran/datum/species_bodytypes.dm
@@ -15,6 +15,7 @@
 	base_color = "#ae7d32"
 	base_eye_color = "#00aa00"
 	default_h_style = /decl/sprite_accessory/hair/taj/lynx
+	flesh_color = "#ae7d32"
 
 	heat_discomfort_level = 294
 	cold_discomfort_level = 230

--- a/mods/species/bayliens/tritonian/datum/species.dm
+++ b/mods/species/bayliens/tritonian/datum/species.dm
@@ -11,7 +11,6 @@
 	oxy_mod    = 0.5
 	toxins_mod = 1.5
 
-	body_temperature =    302
 	water_soothe_amount = 5
 
 	unarmed_attacks = list(

--- a/mods/species/bayliens/tritonian/datum/species_bodytypes.dm
+++ b/mods/species/bayliens/tritonian/datum/species_bodytypes.dm
@@ -2,6 +2,7 @@
 	icon_base = 'mods/species/bayliens/tritonian/icons/body_female.dmi'
 	movement_slowdown = 0.5
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE_TRITON | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR
+	body_temperature =    302
 	override_organ_types = list(
 		BP_LUNGS = /obj/item/organ/internal/lungs/gills
 	)

--- a/mods/species/bayliens/unathi/datum/species.dm
+++ b/mods/species/bayliens/unathi/datum/species.dm
@@ -46,17 +46,6 @@
 	organs_icon = 'mods/species/bayliens/unathi/icons/organs.dmi'
 
 	preview_outfit = /decl/hierarchy/outfit/job/generic/doctor
-
-	blood_types = list(
-		/decl/blood_type/reptile/splus,
-		/decl/blood_type/reptile/sminus,
-		/decl/blood_type/reptile/xplus,
-		/decl/blood_type/reptile/xminus,
-		/decl/blood_type/reptile/sxplus,
-		/decl/blood_type/reptile/sxminus,
-		/decl/blood_type/reptile/oplus,
-		/decl/blood_type/reptile/ominus,
-	)
 	move_trail = /obj/effect/decal/cleanable/blood/tracks/claw
 
 	breathing_sound = 'mods/species/bayliens/unathi/sound/lizard_breathing.ogg'

--- a/mods/species/bayliens/unathi/datum/species.dm
+++ b/mods/species/bayliens/unathi/datum/species.dm
@@ -39,18 +39,8 @@
 
 	age_descriptor = /datum/appearance_descriptor/age/lizard
 
-	body_temperature = null // cold-blooded, implemented the same way nabbers do it
-
 	description = "A heavily reptillian species. They prefer warmer temperatures than most species and \
 	their native tongue is a heavy hissing laungage."
-
-	cold_level_1 = 280 //Default 260 - Lower is better
-	cold_level_2 = 220 //Default 200
-	cold_level_3 = 130 //Default 120
-
-	heat_level_1 = 420 //Default 360 - Higher is better
-	heat_level_2 = 480 //Default 400
-	heat_level_3 = 1100 //Default 1000
 
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_ROBOTIC_INTERNAL_ORGANS
 
@@ -70,20 +60,6 @@
 		/decl/blood_type/reptile/ominus,
 	)
 	move_trail = /obj/effect/decal/cleanable/blood/tracks/claw
-
-	heat_discomfort_level = 320
-	heat_discomfort_strings = list(
-		"You feel soothingly warm.",
-		"You feel the heat sink into your bones.",
-		"You feel warm enough to take a nap."
-		)
-
-	cold_discomfort_level = 292
-	cold_discomfort_strings = list(
-		"You feel chilly.",
-		"You feel sluggish and cold.",
-		"Your scales bristle against the cold."
-		)
 
 	breathing_sound = 'mods/species/bayliens/unathi/sound/lizard_breathing.ogg'
 

--- a/mods/species/bayliens/unathi/datum/species.dm
+++ b/mods/species/bayliens/unathi/datum/species.dm
@@ -43,8 +43,6 @@
 	their native tongue is a heavy hissing laungage."
 
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_ROBOTIC_INTERNAL_ORGANS
-
-	flesh_color = "#34af10"
 	organs_icon = 'mods/species/bayliens/unathi/icons/organs.dmi'
 
 	preview_outfit = /decl/hierarchy/outfit/job/generic/doctor

--- a/mods/species/bayliens/unathi/datum/species_bodytypes.dm
+++ b/mods/species/bayliens/unathi/datum/species_bodytypes.dm
@@ -17,7 +17,7 @@
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
 	eye_darksight_range = 3
 	eye_flash_mod = 1.2
-
+	flesh_color = "#34af10"
 	body_temperature = null // cold-blooded, implemented the same way nabbers do it
 
 	heat_discomfort_level = 320

--- a/mods/species/bayliens/unathi/datum/species_bodytypes.dm
+++ b/mods/species/bayliens/unathi/datum/species_bodytypes.dm
@@ -18,6 +18,30 @@
 	eye_darksight_range = 3
 	eye_flash_mod = 1.2
 
+	body_temperature = null // cold-blooded, implemented the same way nabbers do it
+
+	heat_discomfort_level = 320
+	heat_discomfort_strings = list(
+		"You feel soothingly warm.",
+		"You feel the heat sink into your bones.",
+		"You feel warm enough to take a nap."
+	)
+
+	cold_discomfort_level = 292
+	cold_discomfort_strings = list(
+		"You feel chilly.",
+		"You feel sluggish and cold.",
+		"Your scales bristle against the cold."
+	)
+
+	cold_level_1 = 280 //Default 260 - Lower is better
+	cold_level_2 = 220 //Default 200
+	cold_level_3 = 130 //Default 120
+
+	heat_level_1 = 420 //Default 360 - Higher is better
+	heat_level_2 = 480 //Default 400
+	heat_level_3 = 1100 //Default 1000
+
 	override_organ_types = list(
 		BP_EYES = /obj/item/organ/internal/eyes/lizard,
 		BP_BRAIN = /obj/item/organ/internal/brain/lizard

--- a/mods/species/bayliens/unathi/datum/species_bodytypes.dm
+++ b/mods/species/bayliens/unathi/datum/species_bodytypes.dm
@@ -19,7 +19,16 @@
 	eye_flash_mod = 1.2
 	flesh_color = "#34af10"
 	body_temperature = null // cold-blooded, implemented the same way nabbers do it
-
+	blood_types = list(
+		/decl/blood_type/reptile/splus,
+		/decl/blood_type/reptile/sminus,
+		/decl/blood_type/reptile/xplus,
+		/decl/blood_type/reptile/xminus,
+		/decl/blood_type/reptile/sxplus,
+		/decl/blood_type/reptile/sxminus,
+		/decl/blood_type/reptile/oplus,
+		/decl/blood_type/reptile/ominus,
+	)
 	heat_discomfort_level = 320
 	heat_discomfort_strings = list(
 		"You feel soothingly warm.",

--- a/mods/species/neoavians/datum/species.dm
+++ b/mods/species/neoavians/datum/species.dm
@@ -46,11 +46,6 @@
 	swap_flags = MONKEY|SIMPLE_ANIMAL
 	push_flags = MONKEY|SIMPLE_ANIMAL
 
-	heat_discomfort_strings = list(
-		"Your feathers prickle in the heat.",
-		"You feel uncomfortably warm.",
-		)
-
 	unarmed_attacks = list(
 		/decl/natural_attack/bite/sharp,
 		/decl/natural_attack/claws,

--- a/mods/species/neoavians/datum/species_bodytypes.dm
+++ b/mods/species/neoavians/datum/species_bodytypes.dm
@@ -23,6 +23,11 @@
 	default_h_style = /decl/sprite_accessory/hair/avian
 	base_markings = list(/decl/sprite_accessory/marking/avian = "#454545")
 
+	heat_discomfort_strings = list(
+		"Your feathers prickle in the heat.",
+		"You feel uncomfortably warm.",
+		)
+
 	var/tail =              "tail_avian"
 	var/tail_icon =         'mods/species/neoavians/icons/tail.dmi'
 	var/tail_blend =        ICON_MULTIPLY

--- a/mods/species/serpentid/datum/species.dm
+++ b/mods/species/serpentid/datum/species.dm
@@ -15,11 +15,7 @@
 	name = SPECIES_SERPENTID
 	name_plural = "Serpentids"
 	spawn_flags = SPECIES_IS_RESTRICTED
-
 	preview_outfit = null
-
-	blood_types = list(/decl/blood_type/hemolymph)
-
 	hidden_from_codex = TRUE
 	silent_steps = TRUE
 	age_descriptor = /datum/appearance_descriptor/age/serpentid

--- a/mods/species/serpentid/datum/species.dm
+++ b/mods/species/serpentid/datum/species.dm
@@ -29,7 +29,6 @@
 	speech_chance = 2
 	warning_low_pressure = 50
 	hazard_low_pressure = -1
-	flesh_color = "#525252"
 	blood_oxy = 0
 
 	available_bodytypes = list(

--- a/mods/species/serpentid/datum/species.dm
+++ b/mods/species/serpentid/datum/species.dm
@@ -29,7 +29,6 @@
 	speech_chance = 2
 	warning_low_pressure = 50
 	hazard_low_pressure = -1
-	body_temperature = null
 	flesh_color = "#525252"
 	blood_oxy = 0
 
@@ -55,9 +54,7 @@
 	strength = STR_HIGH
 	breath_pressure = 25
 	blood_volume = 840
-	heat_level_1 = 410 //Default 360 - Higher is better
-	heat_level_2 = 440 //Default 400
-	heat_level_3 = 800 //Default 1000
+
 	species_flags = SPECIES_FLAG_NO_SLIP | SPECIES_FLAG_NO_BLOCK | SPECIES_FLAG_NO_MINOR_CUT | SPECIES_FLAG_NEED_DIRECT_ABSORB
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED
 	bump_flag = HEAVY

--- a/mods/species/serpentid/datum/species_bodytypes.dm
+++ b/mods/species/serpentid/datum/species_bodytypes.dm
@@ -22,6 +22,12 @@
 		BP_SYSTEM_CONTROLLER = /obj/item/organ/internal/controller
 	)
 
+	heat_level_1 = 410 //Default 360 - Higher is better
+	heat_level_2 = 440 //Default 400
+	heat_level_3 = 800 //Default 1000
+
+	body_temperature = null
+
 	eye_darksight_range = 8
 	eye_innate_flash_protection = FLASH_PROTECTION_VULNERABLE
 	eye_contaminant_guard = 1

--- a/mods/species/serpentid/datum/species_bodytypes.dm
+++ b/mods/species/serpentid/datum/species_bodytypes.dm
@@ -32,6 +32,7 @@
 	eye_innate_flash_protection = FLASH_PROTECTION_VULNERABLE
 	eye_contaminant_guard = 1
 	eye_icon = 'mods/species/serpentid/icons/eyes.dmi'
+	blood_types = list(/decl/blood_type/hemolymph)
 
 	has_limbs = list(
 		BP_CHEST =        list("path" = /obj/item/organ/external/chest/insectoid/serpentid),

--- a/mods/species/serpentid/datum/species_bodytypes.dm
+++ b/mods/species/serpentid/datum/species_bodytypes.dm
@@ -49,6 +49,8 @@
 		BP_R_FOOT =       list("path" = /obj/item/organ/external/foot/right/insectoid/serpentid)
 		)
 
+	flesh_color = "#525252"
+
 	limb_mapping = list(
 		BP_L_HAND = list(BP_L_HAND, BP_L_HAND_UPPER),
 		BP_R_HAND = list(BP_R_HAND, BP_R_HAND_UPPER)

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -25,7 +25,6 @@
 	strength =              STR_HIGH
 	warning_low_pressure =  50
 	hazard_low_pressure =  -1
-	flesh_color =           COLOR_GUNMETAL
 
 	blood_volume = 0
 

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -26,22 +26,11 @@
 	warning_low_pressure =  50
 	hazard_low_pressure =  -1
 	flesh_color =           COLOR_GUNMETAL
-	cold_level_1 =          SYNTH_COLD_LEVEL_1
-	cold_level_2 =          SYNTH_COLD_LEVEL_2
-	cold_level_3 =          SYNTH_COLD_LEVEL_3
-	heat_level_1 =          SYNTH_HEAT_LEVEL_1
-	heat_level_2 =          SYNTH_HEAT_LEVEL_2
-	heat_level_3 =          SYNTH_HEAT_LEVEL_3
-	body_temperature =      null
-	passive_temp_gain =     5  // stabilize at ~80 C in a 20 C environment.
-	heat_discomfort_level = 373.15
+
 	blood_volume = 0
 
 	preview_outfit = null
 
-	heat_discomfort_strings = list(
-		"You are dangerously close to overheating!"
-	)
 	unarmed_attacks = list(
 		/decl/natural_attack/stomp,
 		/decl/natural_attack/kick,

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -15,8 +15,6 @@
 	description =           "Simple AI-driven robots are used for many menial or repetitive tasks in human space."
 	base_prosthetics_model = null
 
-	blood_types = list(/decl/blood_type/coolant)
-
 	available_bodytypes = list(/decl/bodytype/prosthetic/utility_frame)
 	age_descriptor =        /datum/appearance_descriptor/age/utility_frame
 	hidden_from_codex =     FALSE

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -13,7 +13,6 @@
 	name =                  SPECIES_FRAME
 	name_plural =           "Utility Frames"
 	description =           "Simple AI-driven robots are used for many menial or repetitive tasks in human space."
-	cyborg_noun = null
 	base_prosthetics_model = null
 
 	blood_types = list(/decl/blood_type/coolant)

--- a/mods/species/utility_frames/species_bodytypes.dm
+++ b/mods/species/utility_frames/species_bodytypes.dm
@@ -1,5 +1,6 @@
 /decl/bodytype/prosthetic/utility_frame
 	name =              "utility frame"
+	examined_name =     null
 	desc =              "This limb is extremely cheap and simplistic, with a raw steel frame and plastic casing."
 	icon_base =         'mods/species/utility_frames/icons/body.dmi'
 	eye_icon = 'mods/species/utility_frames/icons/eyes.dmi'

--- a/mods/species/vox/datum/species.dm
+++ b/mods/species/vox/datum/species.dm
@@ -62,10 +62,6 @@
 	warning_low_pressure = 50
 	hazard_low_pressure = 0
 
-	cold_level_1 = 80
-	cold_level_2 = 50
-	cold_level_3 = -1
-
 	age_descriptor = /datum/appearance_descriptor/age/vox
 
 	preview_outfit = /decl/hierarchy/outfit/vox_raider

--- a/mods/species/vox/datum/species.dm
+++ b/mods/species/vox/datum/species.dm
@@ -61,22 +61,14 @@
 
 	warning_low_pressure = 50
 	hazard_low_pressure = 0
-
 	age_descriptor = /datum/appearance_descriptor/age/vox
-
 	preview_outfit = /decl/hierarchy/outfit/vox_raider
-
 	gluttonous = GLUT_TINY|GLUT_ITEM_NORMAL
 	stomach_capacity = 12
-
 	breath_type = /decl/material/gas/nitrogen
 	poison_types = list(/decl/material/gas/oxygen = TRUE)
 	siemens_coefficient = 0.2
-
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED
-
-	blood_types = list(/decl/blood_type/vox)
-
 	maneuvers = list(/decl/maneuver/leap/grab)
 	standing_jump_range = 5
 

--- a/mods/species/vox/datum/species.dm
+++ b/mods/species/vox/datum/species.dm
@@ -76,7 +76,6 @@
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED
 
 	blood_types = list(/decl/blood_type/vox)
-	flesh_color = "#808d11"
 
 	maneuvers = list(/decl/maneuver/leap/grab)
 	standing_jump_range = 5

--- a/mods/species/vox/datum/species_bodytypes.dm
+++ b/mods/species/vox/datum/species_bodytypes.dm
@@ -18,6 +18,7 @@
 	cold_level_2 = 50
 	cold_level_3 = -1
 	default_h_style = /decl/sprite_accessory/hair/vox/short
+	flesh_color = "#808d11"
 
 	vital_organs = list(
 		BP_STACK,

--- a/mods/species/vox/datum/species_bodytypes.dm
+++ b/mods/species/vox/datum/species_bodytypes.dm
@@ -14,6 +14,9 @@
 	base_eye_color =    "#d60093"
 	base_color =        "#526d29"
 	body_flags =        BODY_FLAG_NO_DNA
+	cold_level_1 = 80
+	cold_level_2 = 50
+	cold_level_3 = -1
 	default_h_style = /decl/sprite_accessory/hair/vox/short
 
 	vital_organs = list(

--- a/mods/species/vox/datum/species_bodytypes.dm
+++ b/mods/species/vox/datum/species_bodytypes.dm
@@ -19,6 +19,7 @@
 	cold_level_3 = -1
 	default_h_style = /decl/sprite_accessory/hair/vox/short
 	flesh_color = "#808d11"
+	blood_types = list(/decl/blood_type/vox)
 
 	vital_organs = list(
 		BP_STACK,

--- a/nebula.dme
+++ b/nebula.dme
@@ -532,6 +532,7 @@
 #include "code\datums\trading\traders\unique.dm"
 #include "code\datums\trading\traders\weaponry.dm"
 #include "code\datums\traits\metabolically_inert.dm"
+#include "code\datums\traits\radiation_hardened.dm"
 #include "code\datums\traits\trait_levels.dm"
 #include "code\datums\traits\traits.dm"
 #include "code\datums\traits\maluses\allergies.dm"


### PR DESCRIPTION
## Description of changes
Kills isSynthetic(). Opening this for input/review, it is in no state for a merge currently.

## Why and what will this PR improve
isSynthetic() is a holdover from the previous attempt at FBP and is pretty much redundant in view of the new bodytype system. Getting rid of it will make various systems more flexible and available to nonhuman synthetics and partial cyborgs.

## Authorship
Myself and @out-of-phaze.

## Changelog
Hopefully nothing player-facing.