### PR TITLE
Allows spawn_atom to spawn invisible atoms.

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1144,7 +1144,7 @@ var/global/floorIsLava = 0
 	for(var/path in subtypesof(/atom))
 		var/atom/path_cast = path
 		if(TYPE_IS_SPAWNABLE(path_cast) && findtext(lowertext("[path]"), object))
-			matches += path
+			matches += "[path]" // We need to use a string because input() checks invisibility on types for Reasons:tm:.
 
 	if(matches.len==0)
 		return
@@ -1157,6 +1157,7 @@ var/global/floorIsLava = 0
 		if(!chosen)
 			return
 
+	chosen = text2path(chosen)
 	if(ispath(chosen,/turf))
 		var/turf/T = get_turf(usr.loc)
 		T.ChangeTurf(chosen)

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -37,7 +37,7 @@ exactly 1 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
 exactly 18 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 10 ">> uses" '>>(?!>)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
-exactly 23 "text2path uses" 'text2path'
+exactly 24 "text2path uses" 'text2path'
 exactly 4 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 0 "goto uses" 'goto '
 exactly 6 "atom/New uses" '^/(obj|atom|area|mob|turf).*/New\('


### PR DESCRIPTION
So it turns out `input()` with a list of types checks the `see_invisible` of the mob against initial `invisibility` on the type.

![image](https://github.com/NebulaSS13/Nebula/assets/2468979/e99bb44d-ed31-4c73-b6a7-7211898df478)
