### PR TITLE
Excluding unsimulated and space turfs from vessel mass calc.

### DIFF
--- a/code/game/turfs/unsimulated.dm
+++ b/code/game/turfs/unsimulated.dm
@@ -1,6 +1,7 @@
 /turf/unsimulated
 	name = "command"
 	initial_gas = list(/decl/material/gas/oxygen = MOLES_O2STANDARD, /decl/material/gas/nitrogen = MOLES_N2STANDARD)
+	simulated = FALSE
 
 /turf/unsimulated/get_lumcount(var/minlum = 0, var/maxlum = 1)
 	return 0.8

--- a/code/modules/overmap/ships/ship_physics.dm
+++ b/code/modules/overmap/ships/ship_physics.dm
@@ -37,8 +37,14 @@
 /obj/effect/overmap/visitable/ship/proc/recalculate_vessel_mass()
 	var/list/zones = list()
 	for(var/area/A in get_areas())
+
+		// Do not include space please
+		if(istype(A, world.area))
+			continue
+
 		for(var/turf/T in A)
-			if(T.is_open())
+
+			if(!T.simulated || T.is_open())
 				continue
 
 			. += DEFAULT_TURF_MASS


### PR DESCRIPTION
## Description of changes
Adds `simulated = FALSE` to unsimulated turfs and excludes unsim turfs and the world area from vessel mass calc.

## Why and what will this PR improve
Mass calc is currently adding 500 mass units per unsimulated filler turf on the edge of the map.

## Authorship
@out-of-phaze found the issue and fix, I just committed it.

## Changelog
:cl:
bugfix: Vessel acceleration should be much more responsive now.
/:cl: