### PR TITLE
Updating yaml.safe_load() as indicated by CL fail.

### DIFF
--- a/tools/changelog/generate_cl.py
+++ b/tools/changelog/generate_cl.py
@@ -74,8 +74,9 @@ else:
 
 write_cl['delete-after'] = True
 
+yaml = yaml.YAML(typ='safe', pure=True)
 with open(Path.cwd().joinpath("tools/changelog/tags.yml")) as file:
-    tags = yaml.safe_load(file)
+    tags = yaml.load(file)
 
 write_cl['changes'] = []
 
@@ -87,7 +88,6 @@ for k, v in cl_list:
 
 if write_cl['changes']:
     with io.StringIO() as cl_contents:
-        yaml = yaml.YAML()
         yaml.indent(sequence=4, offset=2)
         yaml.dump(write_cl, cl_contents)
         cl_contents.seek(0)


### PR DESCRIPTION
## Description of changes
Changes a call in accordance with a warning seen during a failed changelog run.
````
"safe_load()" has been removed, use
  yaml = YAML(typ='safe', pure=True)
  yaml.load(...)
````
## Why and what will this PR improve
busted

## Authorship
<!-- Describe original authors of changes to credit them. -->

## Changelog
:cl:
tweak: This is a test to make sure the changelog generator works now.
/:cl:
