### PR TITLE
Fix downward ambient lights propagation

### DIFF
--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -244,21 +244,26 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	var/turf/T
 	var/Ti
 
-	if (t1)
+	if (t1 && (t1.below || HasBelow(t1.z)) && (t1.z_flags & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(t1))
 		T = t1
 		Ti = t1i
-	else if (t2)
+	else if (t2 && (t2.below || HasBelow(t2.z)) && (t2.z_flags & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(t2))
 		T = t2
 		Ti = t2i
-	else if (t3)
+	else if (t3 && (t3.below || HasBelow(t3.z)) && (t3.z_flags & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(t3))
 		T = t3
 		Ti = t3i
-	else if (t4)
+	else if (t4 && (t4.below || HasBelow(t4.z)) && (t4.z_flags & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(t4))
 		T = t4
 		Ti = t4i
+	// No MZ candidates below, just update.
+	else if (needs_update || skip_update)
+		return
 	else
-		// This should be impossible to reach -- how do we exist without at least one master turf?
-		CRASH("Corner has no masters!")
+		// Always queue for this, not important enough to hit the synchronous path.
+		needs_update = TRUE
+		SSlighting.corner_queue += src
+		return
 
 	var/datum/lighting_corner/below = src
 

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -267,10 +267,8 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 
 	var/datum/lighting_corner/below = src
 
-	var/turf/lasT
-
 	// We init before Z-Mimic, cannot rely on above/below.
-	while ((lasT = T) && (T = GET_BELOW(T)) && (lasT.z_flags & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+	while ((T = GET_BELOW(T)) && ((below.t1?.z_flags | below.t2?.z_flags | below.t3?.z_flags | below.t4?.z_flags) & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
 		T.ambient_has_indirect = TRUE
 
 		if (!T.corners || !T.corners[Ti])


### PR DESCRIPTION
## Description of changes
With Lohikar's help, makes downward ambient lights propagation more robust to fix incorrect shadowing of the level below where ambiently-lit turfs shared a corner with a non-z-lighting-transparent turf.

## Why and what will this PR improve
Fixes some ugly shadowing artifacts from downward ambient light propagation.

## Authorship
Lohikar, me.