### PR TITLE
Upstream dev branch features and tweaks from Lighthouse

### DIFF
--- a/code/_global_vars/lists/flavor.dm
+++ b/code/_global_vars/lists/flavor.dm
@@ -130,7 +130,8 @@ GLOBAL_GETTER(cable_colors, /list, SetupCableColors())
 		var/name = special_name_mappings[coil_type] || capitalize(copytext_after_last("[coil_type]", "/"))
 
 		var/obj/item/stack/cable_coil/C = coil_type
+		if(!initial(C.can_have_color))
+			continue
 		var/color = initial(C.color)
-
 		.[name] = color
 	. = sortTim(., /proc/cmp_text_asc)

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -275,10 +275,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 //Ensure the frequency is within bounds of what it should be sending/recieving at
 /proc/sanitize_frequency(var/f, var/low = PUBLIC_LOW_FREQ, var/high = PUBLIC_HIGH_FREQ)
-	f = round(f)
-	f = max(low, f)
-	f = min(high, f)
-	return f
+	return clamp(round(f), low, high)
 
 //Turns 1479 into 147.9
 /proc/format_frequency(var/f)

--- a/code/game/machinery/atmoalter/area_atmos_computer.dm
+++ b/code/game/machinery/atmoalter/area_atmos_computer.dm
@@ -1,5 +1,5 @@
 /obj/machinery/computer/area_atmos
-	name = "Area Air Control"
+	name = "area air control"
 	desc = "A computer used to control the stationary scrubbers and pumps in the area."
 	icon_keyboard = "atmos_key"
 	icon_screen = "area_atmos"
@@ -20,7 +20,7 @@
 /obj/machinery/computer/area_atmos/interface_interact(user)
 	interact(user)
 	return TRUE
-	
+
 /obj/machinery/computer/area_atmos/interact(mob/user)
 	var/dat = {"
 	<html>
@@ -173,3 +173,27 @@
 		status = "ERROR: No scrubber found!"
 
 	src.updateUsrDialog()
+
+/obj/machinery/computer/area_atmos/tag
+	name = "heavy scrubber control"
+	zone = "This computer is operating industrial scrubbers nearby."
+	var/last_scan
+
+/obj/machinery/computer/area_atmos/tag/scanscrubbers()
+	if(last_scan && ((world.time - last_scan) < 20 SECONDS))
+		return FALSE
+	else
+		last_scan = world.time
+
+	connectedscrubbers.Cut()
+
+	for(var/obj/machinery/portable_atmospherics/powered/scrubber/huge/scrubber in SSmachines.machinery)
+		if(scrubber.id_tag == id_tag)
+			connectedscrubbers += scrubber
+
+	updateUsrDialog()
+
+/obj/machinery/computer/area_atmos/tag/validscrubber(obj/machinery/portable_atmospherics/powered/scrubber/huge/scrubber)
+	if(scrubber.id_tag == id_tag)
+		return TRUE
+	return FALSE

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -17,6 +17,8 @@
 	var/list/matter_per_piece
 	var/singular_name
 	var/plural_name
+	/// If unset, picks a/an based off of if the first letter is a vowel or not.
+	var/indefinite_article
 	var/base_state
 	var/plural_icon_state
 	var/max_icon_state
@@ -42,7 +44,7 @@
 	if(!singular_name)
 		singular_name = "sheet"
 	if(!plural_name)
-		plural_name = "[singular_name]s"
+		plural_name = text_make_plural(singular_name)
 
 /obj/item/stack/Destroy()
 	if (src && usr && usr.machine == src)
@@ -414,3 +416,9 @@
 /**Whether a stack type has the capability to be merged. */
 /obj/item/stack/proc/can_merge_stacks(var/obj/item/stack/other)
 	return !(uses_charge && !force)
+
+/// Returns the string describing an amount of the stack, i.e. "an ingot" vs "a flag"
+/obj/item/stack/proc/get_string_for_amount(amount)
+	if(amount == 1)
+		return indefinite_article ? "[indefinite_article] [singular_name]" : ADD_ARTICLE(singular_name)
+	return "[amount] [plural_name]"

--- a/code/game/objects/items/weapons/circuitboards/computer/computer.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/computer.dm
@@ -97,6 +97,11 @@
 	build_path = /obj/machinery/computer/area_atmos
 	origin_tech = "{'programming':2}"
 
+/obj/item/stock_parts/circuitboard/tag_scrubber_control
+	name = "circuitboard (wireless scrubber control console)"
+	build_path = /obj/machinery/computer/area_atmos/tag
+	origin_tech = "{'programming':2}"
+
 /obj/item/stock_parts/circuitboard/account_database
 	name = "circuitboard (accounts uplink terminal)"
 	build_path = /obj/machinery/computer/account_database

--- a/code/game/objects/structures/_structure_construction.dm
+++ b/code/game/objects/structures/_structure_construction.dm
@@ -107,7 +107,7 @@
 	var/amount_needed = CEILING((maxhealth - health)/DOOR_REPAIR_AMOUNT)
 	var/used = min(amount_needed,stack.amount)
 	if(used)
-		to_chat(user, SPAN_NOTICE("You fit [used] [stack.singular_name]\s to damaged areas of \the [src]."))
+		to_chat(user, SPAN_NOTICE("You fit [stack.get_string_for_amount(used)] to damaged areas of \the [src]."))
 		stack.use(used)
 		last_damage_message = null
 		health = clamp(health, health + used*DOOR_REPAIR_AMOUNT, maxhealth)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -78,6 +78,9 @@ LINEN BINS
 /obj/item/bedsheet/brown
 	icon = 'icons/obj/bedsheets/bedsheet_brown.dmi'
 
+/obj/item/bedsheet/ian
+	icon = 'icons/obj/bedsheets/bedsheet_ian.dmi'
+
 //////////////////////////////////////////
 // Bedsheet bin
 //////////////////////////////////////////

--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -1426,6 +1426,20 @@ var/global/list/floor_decals = list()
 /obj/effect/floor_decal/rust/part_rusted1
 	icon_state = "part_rusted1"
 
+/obj/effect/floor_decal/rust/part_rusted2
+	icon_state = "part_rusted2"
+
+/obj/effect/floor_decal/rust/part_rusted3
+	icon_state = "part_rusted3"
+
+/obj/effect/floor_decal/rust/mono_rusted1
+	icon_state = "mono_rusted1"
+
+/obj/effect/floor_decal/rust/mono_rusted2
+	icon_state = "mono_rusted2"
+
+/obj/effect/floor_decal/rust/mono_rusted3
+	icon_state = "mono_rusted3"
 /obj/effect/floor_decal/rust/steel_decals_rusted1
 	icon_state = "steel_decals_rusted1"
 

--- a/code/modules/fabrication/designs/imprinter/designs_misc_circuits.dm
+++ b/code/modules/fabrication/designs/imprinter/designs_misc_circuits.dm
@@ -484,3 +484,6 @@
 
 /datum/fabricator_recipe/imprinter/circuit/geothermal_generator
 	path = /obj/item/stock_parts/circuitboard/geothermal
+
+/datum/fabricator_recipe/imprinter/circuit/tag_scrubber_control
+	path = /obj/item/stock_parts/circuitboard/tag_scrubber_control

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -218,14 +218,8 @@
 		if(!build_type || !ispath(build_type))
 			return TRUE
 
-		var/list/cost
-		if(ispath(build_type, /obj/item/electronic_assembly))
-			var/obj/item/electronic_assembly/E = SScircuit.cached_assemblies[build_type]
-			cost = E.matter
-		else if(ispath(build_type, /obj/item/integrated_circuit))
-			var/obj/item/integrated_circuit/IC = SScircuit.cached_components[build_type]
-			cost = IC.matter
-		else if(!(build_type in SScircuit.circuit_fabricator_recipe_list["Tools"]))
+		var/list/cost = atom_info_repository.get_matter_for(build_type)
+		if(!ispath(build_type, /obj/item/electronic_assembly) && !ispath(build_type, /obj/item/integrated_circuit) && !(build_type in SScircuit.circuit_fabricator_recipe_list["Tools"]))
 			return
 
 		if(!debug && !subtract_material_costs(cost, usr))

--- a/code/modules/maps/template_types/random_exoplanet/planet_themes/ruined_city.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_themes/ruined_city.dm
@@ -171,26 +171,27 @@
 	..()
 	for(var/x in 1 to limit_x - 1)
 		for(var/y in 1 to limit_y - 1)
-			var/value = map[get_map_cell(x,y)]
+			var/value = map[TRANSLATE_COORD(x,y)]
 			if(value != FLOOR_VALUE)
 				continue
 			var/list/neighbors = list()
 			for(var/offset in list(list(0,1), list(0,-1), list(1,0), list(-1,0)))
-				var/char = map[get_map_cell(x + offset[1], y + offset[2])]
+				var/tmp_cell = TRANSLATE_COORD(x + offset[1], y+offset[2])
+				var/char = LAZYACCESS(map, tmp_cell)
 				if(char == FLOOR_VALUE || char == DOOR_VALUE)
-					neighbors.Add(get_map_cell(x + offset[1], y + offset[2]))
+					neighbors.Add(tmp_cell)
 			if(length(neighbors) > 1)
 				continue
 
 			map[neighbors[1]] = DOOR_VALUE
 			if(artifacts_to_spawn)
-				map[get_map_cell(x,y)] = ARTIFACT_VALUE
+				map[TRANSLATE_COORD(x,y)] = ARTIFACT_VALUE
 				artifacts_to_spawn--
 	var/entrance_x = pick(rand(2,limit_x-1), 1, limit_x)
 	var/entrance_y = pick(1, limit_y)
 	if(entrance_x == 1 || entrance_x == limit_x)
 		entrance_y = rand(2,limit_y-1)
-	map[get_map_cell(entrance_x,entrance_y)] = DOOR_VALUE
+	map[TRANSLATE_COORD(entrance_x,entrance_y)] = DOOR_VALUE
 
 /datum/random_map/maze/lab/get_appropriate_path(var/value)
 	if(value == ARTIFACT_VALUE)

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/volcanic.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/volcanic.dm
@@ -119,23 +119,7 @@
 	flora_prob           = 3
 	grass_prob           = 0
 	large_flora_prob     = 0
-
-//Squashing most of 1 tile lava puddles
-/datum/random_map/noise/exoplanet/volcanic/cleanup()
-	for(var/x = 1, x <= limit_x, x++)
-		for(var/y = 1, y <= limit_y, y++)
-			var/current_cell = get_map_cell(x,y)
-			if(noise2value(map[current_cell]) < water_level)
-				continue
-			var/frendos
-			for(var/dx in list(-1,0,1))
-				for(var/dy in list(-1,0,1))
-					var/tmp_cell = get_map_cell(x+dx,y+dy)
-					if(tmp_cell && tmp_cell != current_cell && noise2value(map[tmp_cell]) >= water_level)
-						frendos = 1
-						break
-			if(!frendos)
-				map[current_cell] = 1
+	smooth_single_tiles  = TRUE
 
 ////////////////////////////////////////////////////////////////////////////
 // Areas

--- a/code/modules/maps/template_types/random_exoplanet/random_map.dm
+++ b/code/modules/maps/template_types/random_exoplanet/random_map.dm
@@ -1,4 +1,5 @@
 #define COAST_VALUE (cell_range + 1)
+#define TRANSLATE_COORD(X,Y) ((((Y) - 1) * limit_x) + (X))
 
 ///Place down flora/fauna spawners, grass, water, and apply selected land type.
 /datum/random_map/noise/exoplanet
@@ -137,7 +138,7 @@
 		return
 	for(var/x in 1 to limit_x - 1)
 		for(var/y in 1 to limit_y - 1)
-			var/mapcell = get_map_cell(x,y)
+			var/mapcell = TRANSLATE_COORD(x,y)
 			if(noise2value(map[mapcell]) < water_level)
 				var/neighbors = get_neighbors(x, y, TRUE)
 				for(var/cell in neighbors)
@@ -168,3 +169,5 @@
 	target_turf_type = /turf/exterior/rock/volcanic //Only let it apply to non-lava turfs
 	floor_type       = null
 	wall_type        = /turf/exterior/wall
+
+#undef TRANSLATE_COORD

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -147,6 +147,13 @@
 	else
 		icon_state = base_state
 
+/obj/item/stack/material/get_string_for_amount(amount)
+	. = "[reinf_material ? "reinforced " : null][material.use_name]"
+	if(amount == 1)
+		. += " [singular_name]"
+		return indefinite_article ? "[indefinite_article] [.]" : ADD_ARTICLE(.)
+	return "[amount] [.] [plural_name]"
+
 /obj/item/stack/material/ingot
 	name = "ingots"
 	singular_name = "ingot"

--- a/code/modules/mob/living/living_breath.dm
+++ b/code/modules/mob/living/living_breath.dm
@@ -57,8 +57,8 @@
 
 	// First handle being in a submerged environment.
 	var/datum/gas_mixture/breath
-	var/turf/my_turf = get_turf(src)
-	if(istype(my_turf) && my_turf.is_flooded(lying))
+	if(is_flooded(lying))
+		var/turf/my_turf = get_turf(src)
 
 		//Can we get air from the turf above us?
 		var/can_breathe_air_above = FALSE

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -33,6 +33,8 @@ By design, d1 is the smallest direction and d2 is the highest
 	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 	level = LEVEL_BELOW_PLATING
 
+	/// Whether this cable type can be (re)colored.
+	var/can_have_color = TRUE
 	var/d1
 	var/d2
 	var/datum/powernet/powernet
@@ -241,6 +243,8 @@ By design, d1 is the smallest direction and d2 is the highest
 	. = ..()
 
 /obj/structure/cable/proc/cableColor(var/colorC)
+	if(!can_have_color)
+		return
 	var/color_n = "#dd0000"
 	if(colorC)
 		color_n = colorC
@@ -495,6 +499,8 @@ By design, d1 is the smallest direction and d2 is the highest
 	attack_verb = list("whipped", "lashed", "disciplined", "flogged")
 	stack_merge_type = /obj/item/stack/cable_coil
 	matter_multiplier = 0.15
+	/// Whether or not this cable coil can even have a color in the first place.
+	var/can_have_color = TRUE
 
 /obj/item/stack/cable_coil/single
 	amount = 1
@@ -515,7 +521,7 @@ By design, d1 is the smallest direction and d2 is the highest
 		TOOL_CABLECOIL = TOOL_QUALITY_DEFAULT,
 		TOOL_SUTURES =   TOOL_QUALITY_MEDIOCRE
 	))
-	if (param_color) // It should be red by default, so only recolor it if parameter was specified.
+	if (can_have_color && param_color) // It should be red by default, so only recolor it if parameter was specified.
 		color = param_color
 	update_icon()
 	update_wclass()
@@ -547,7 +553,7 @@ By design, d1 is the smallest direction and d2 is the highest
 
 /obj/item/stack/cable_coil/on_update_icon()
 	. = ..()
-	if (!color)
+	if (!color && can_have_color)
 		var/list/possible_cable_colours = get_global_cable_colors()
 		color = possible_cable_colours[pick(possible_cable_colours)]
 	if(amount == 1)
@@ -564,7 +570,7 @@ By design, d1 is the smallest direction and d2 is the highest
 		SetName(initial(name))
 
 /obj/item/stack/cable_coil/proc/set_cable_color(var/selected_color, var/user)
-	if(!selected_color)
+	if(!selected_color || !can_have_color)
 		return
 
 	var/list/possible_cable_colours = get_global_cable_colors()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -259,7 +259,7 @@ By design, d1 is the smallest direction and d2 is the highest
 /obj/structure/cable/proc/mergeDiagonalsNetworks(var/direction)
 
 	//search for and merge diagonally matching cables from the first direction component (north/south)
-	var/turf/T  = get_step(src, direction&3)//go north/south
+	var/turf/T  = get_step_resolving_mimic(src, direction & (NORTH|SOUTH))
 
 	for(var/obj/structure/cable/C in T)
 
@@ -269,7 +269,7 @@ By design, d1 is the smallest direction and d2 is the highest
 		if(src == C)
 			continue
 
-		if(C.d1 == (direction^3) || C.d2 == (direction^3)) //we've got a diagonally matching cable
+		if(C.d1 == (direction ^ (NORTH|SOUTH)) || C.d2 == (direction ^ (NORTH|SOUTH))) //we've got a diagonally matching cable
 			if(!C.powernet) //if the matching cable somehow got no powernet, make him one (should not happen for cables)
 				var/datum/powernet/newPN = new()
 				newPN.add_cable(C)
@@ -280,7 +280,7 @@ By design, d1 is the smallest direction and d2 is the highest
 				C.powernet.add_cable(src) //else, we simply connect to the matching cable powernet
 
 	//the same from the second direction component (east/west)
-	T  = get_step(src, direction&12)//go east/west
+	T  = get_step_resolving_mimic(src, direction & (EAST|WEST))
 
 	for(var/obj/structure/cable/C in T)
 
@@ -289,7 +289,7 @@ By design, d1 is the smallest direction and d2 is the highest
 
 		if(src == C)
 			continue
-		if(C.d1 == (direction^12) || C.d2 == (direction^12)) //we've got a diagonally matching cable
+		if(C.d1 == (direction ^ (EAST|WEST)) || C.d2 == (direction ^ (EAST|WEST))) //we've got a diagonally matching cable
 			if(!C.powernet) //if the matching cable somehow got no powernet, make him one (should not happen for cables)
 				var/datum/powernet/newPN = new()
 				newPN.add_cable(C)
@@ -307,7 +307,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(!(d1 == direction || d2 == direction)) //if the cable is not pointed in this direction, do nothing
 		return
 
-	var/turf/TB  = get_zstep(src, direction)
+	var/turf/TB  = get_zstep_resolving_mimic(src, direction)
 
 	for(var/obj/structure/cable/C in TB)
 
@@ -384,14 +384,14 @@ By design, d1 is the smallest direction and d2 is the highest
 		if(cable_dir == 0)
 			continue
 		var/reverse = global.reverse_dir[cable_dir]
-		T = get_zstep(src, cable_dir)
+		T = get_zstep_resolving_mimic(src, cable_dir)
 		if(T)
 			for(var/obj/structure/cable/C in T)
 				if(C.d1 == reverse || C.d2 == reverse)
 					. += C
 		if(cable_dir & (cable_dir - 1)) // Diagonal, check for /\/\/\ style cables along cardinal directions
 			for(var/pair in list(NORTH|SOUTH, EAST|WEST))
-				T = get_step(src, cable_dir & pair)
+				T = get_step_resolving_mimic(src, cable_dir & pair)
 				if(T)
 					var/req_dir = cable_dir ^ pair
 					for(var/obj/structure/cable/C in T)
@@ -435,7 +435,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	var/list/P_list
 	if(!T1)	return
 	if(d1)
-		T1 = get_step(T1, d1)
+		T1 = get_zstep_resolving_mimic(T1, d1)
 		P_list = power_list(T1, src, turn(d1,180),0,cable_only = 1)	// what adjacently joins on to cut cable...
 
 	P_list += power_list(loc, src, d1, 0, cable_only = 1)//... and on turf

--- a/code/modules/random_map/_random_map_setup.dm
+++ b/code/modules/random_map/_random_map_setup.dm
@@ -30,3 +30,11 @@
 	if (tmp_cell < 1 || tmp_cell > LEN) {\
 		tmp_cell = null;\
 	}
+
+#define TRANSLATE_COORD_OTHER_MAP(X,Y,MAP) ((((Y) - 1) * MAP.limit_x) + (X))
+#define TRANSLATE_AND_VERIFY_COORD_OTHER_MAP(X,Y,MAP) TRANSLATE_AND_VERIFY_COORD_OTHER_MAP_MLEN(X, Y, MAP, MAP.map.len)
+#define TRANSLATE_AND_VERIFY_COORD_OTHER_MAP_MLEN(X,Y,MAP,LEN) \
+	tmp_cell = TRANSLATE_COORD_OTHER_MAP(X,Y,MAP);\
+	if (tmp_cell < 1 || tmp_cell > LEN) {\
+		tmp_cell = null;\
+	}

--- a/code/modules/random_map/building/building.dm
+++ b/code/modules/random_map/building/building.dm
@@ -6,7 +6,7 @@
 /datum/random_map/building/generate_map()
 	for(var/x = 1, x <= limit_x, x++)
 		for(var/y = 1, y <= limit_y, y++)
-			var/current_cell = get_map_cell(x,y)
+			var/current_cell = TRANSLATE_COORD(x,y)
 			if(!current_cell)
 				continue
 			if(x == 1 || y == 1 || x == limit_x || y == limit_y)
@@ -18,7 +18,7 @@
 	var/list/possible_doors
 	for(var/x = 1, x <= limit_x, x++)
 		for(var/y = 1, y <= limit_y, y++)
-			var/current_cell = get_map_cell(x,y)
+			var/current_cell = TRANSLATE_COORD(x,y)
 			if(!current_cell)
 				continue
 			if(!(x == 1 || y == 1 || x == limit_x || y == limit_y))
@@ -39,7 +39,10 @@
 
 
 			if(place_door)
-				possible_doors |= target_map.get_map_cell(tx+x,ty+y)
+				var/tmp_cell
+				TRANSLATE_AND_VERIFY_COORD_OTHER_MAP(tx+x, ty+y, target_map)
+				if(tmp_cell)
+					possible_doors |= tmp_cell
 
 	if(possible_doors.len)
 		// Place at least one door.

--- a/code/modules/random_map/drop/droppod.dm
+++ b/code/modules/random_map/drop/droppod.dm
@@ -47,7 +47,7 @@
 	// Draw walls/floors/doors.
 	for(var/x = 1, x <= limit_x, x++)
 		for(var/y = 1, y <= limit_y, y++)
-			var/current_cell = get_map_cell(x,y)
+			var/current_cell = TRANSLATE_COORD(x,y)
 			if(!current_cell)
 				continue
 
@@ -73,7 +73,7 @@
 					map[current_cell] = SD_FLOOR_TILE
 
 	// Draw the drop contents.
-	var/current_cell = get_map_cell(x_midpoint,y_midpoint)
+	var/current_cell = TRANSLATE_COORD(x_midpoint,y_midpoint)
 	if(current_cell)
 		map[current_cell] = SD_SUPPLY_TILE
 	return 1

--- a/code/modules/random_map/dungeon/room.dm
+++ b/code/modules/random_map/dungeon/room.dm
@@ -41,35 +41,45 @@ If its complexity is lower than our theme's then
 			for(var/j = 0, j < height, j++)
 				var/truex = xorigin + x + i - 1
 				var/truey = yorigin + y + j - 1
-				var/cell = map.get_map_cell(x+i,y+j)
+				var/tmp_cell
+				TRANSLATE_AND_VERIFY_COORD_OTHER_MAP(x+i, y+j, map)
+				var/cell = tmp_cell
 				room_theme.apply_room_theme(truex,truey,map.map[cell])
 				if(generate_doors && room_theme.door_type && !(map.map[cell] == WALL_CHAR || map.map[cell] == ARTIFACT_TURF_CHAR) && (i == 0 || i == width-1 || j == 0 || j == height-1))
 					var/isGood = 1
 					if(j == 0 || j == height-1) //check horizontally
-						var/curCell = map.map[map.get_map_cell(x+i-1,y+j)]
+						TRANSLATE_AND_VERIFY_COORD_OTHER_MAP(x+i-1,y+j, map)
+						var/curCell = map.map[tmp_cell]
 						if(curCell != WALL_CHAR && curCell != ARTIFACT_TURF_CHAR)
 							isGood = 0
-						curCell = map.map[map.get_map_cell(x+i+1,y+j)]
+						TRANSLATE_AND_VERIFY_COORD_OTHER_MAP(x+i+1,y+j, map)
+						curCell = map.map[tmp_cell]
 						if(curCell != WALL_CHAR && curCell != ARTIFACT_TURF_CHAR)
 							isGood = 0
-						curCell = map.map[map.get_map_cell(x+i,y+j-1)]
+						TRANSLATE_AND_VERIFY_COORD_OTHER_MAP(x+i,y+j-1, map)
+						curCell = map.map[tmp_cell]
 						if(curCell == WALL_CHAR || curCell == ARTIFACT_TURF_CHAR)
 							isGood = 0
-						curCell = map.map[map.get_map_cell(x+i,y+j+1)]
+						TRANSLATE_AND_VERIFY_COORD_OTHER_MAP(x+i,y+j+1, map)
+						curCell = map.map[tmp_cell]
 						if(curCell == WALL_CHAR || curCell == ARTIFACT_TURF_CHAR)
 							isGood = 0
-					if(i == 0 || i == width-1) //verticle
+					if(i == 0 || i == width-1) //vertical
 						isGood = 1 //if it failed above, it might not fail here.
-						var/curCell = map.map[map.get_map_cell(x+i,y+j-1)]
+						TRANSLATE_AND_VERIFY_COORD_OTHER_MAP(x+i,y+j-1, map)
+						var/curCell = map.map[tmp_cell]
 						if(curCell != WALL_CHAR && curCell != ARTIFACT_TURF_CHAR)
 							isGood = 0
-						curCell = map.map[map.get_map_cell(x+i,y+j+1)]
+						TRANSLATE_AND_VERIFY_COORD_OTHER_MAP(x+i,y+j+1, map)
+						curCell = map.map[tmp_cell]
 						if(curCell != WALL_CHAR && curCell != ARTIFACT_TURF_CHAR)
 							isGood = 0
-						curCell = map.map[map.get_map_cell(x+i-1,y+j)]
+						TRANSLATE_AND_VERIFY_COORD_OTHER_MAP(x+i-1,y+j, map)
+						curCell = map.map[tmp_cell]
 						if(curCell == WALL_CHAR || curCell == ARTIFACT_TURF_CHAR)
 							isGood = 0
-						curCell = map.map[map.get_map_cell(x+i+1,y+j)]
+						TRANSLATE_AND_VERIFY_COORD_OTHER_MAP(x+i+1,y+j, map)
+						curCell = map.map[tmp_cell]
 						if(curCell == WALL_CHAR || curCell == ARTIFACT_TURF_CHAR)
 							isGood = 0
 					if(isGood)

--- a/code/modules/random_map/mazes/maze.dm
+++ b/code/modules/random_map/mazes/maze.dm
@@ -31,19 +31,28 @@
 
 		// Preliminary marking-off...
 		closedlist[next.name] = next
-		map[get_map_cell(next.x,next.y)] = FLOOR_CHAR
+		map[TRANSLATE_COORD(next.x,next.y)] = FLOOR_CHAR
 
 		// Apply the values required and fill gap between this cell and origin point.
+		var/tmp_cell
 		if(next.ox && next.oy)
 			if(next.ox < next.x)
-				map[get_map_cell(next.x-1,next.y)] = FLOOR_CHAR
+				TRANSLATE_AND_VERIFY_COORD(next.x-1, next.y)
+				if(tmp_cell)
+					map[tmp_cell] = FLOOR_CHAR
 			else if(next.ox == next.x)
 				if(next.oy < next.y)
-					map[get_map_cell(next.x,next.y-1)] = FLOOR_CHAR
+					TRANSLATE_AND_VERIFY_COORD(next.x, next.y-1)
+					if(tmp_cell)
+						map[tmp_cell] = FLOOR_CHAR
 				else
-					map[get_map_cell(next.x,next.y+1)] = FLOOR_CHAR
+					TRANSLATE_AND_VERIFY_COORD(next.x, next.y+1)
+					if(tmp_cell)
+						map[tmp_cell] = FLOOR_CHAR
 			else
-				map[get_map_cell(next.x+1,next.y)] = FLOOR_CHAR
+				TRANSLATE_AND_VERIFY_COORD(next.x+1, next.y)
+				if(tmp_cell)
+					map[tmp_cell] = FLOOR_CHAR
 
 		// Grab valid neighbors for use in the open list!
 		add_to_openlist(next.x,next.y+2,next.x,next.y)
@@ -60,6 +69,6 @@
 	if(tx < 1 || ty < 1 || tx > limit_x || ty > limit_y || !isnull(checked_coord_cache["[tx]-[ty]"]))
 		return 0
 	checked_coord_cache["[tx]-[ty]"] = 1
-	map[get_map_cell(tx,ty)] = DOOR_CHAR
+	map[TRANSLATE_COORD(tx,ty)] = DOOR_CHAR
 	var/datum/maze_cell/new_cell = new(tx,ty,nx,ny)
 	openlist |= new_cell

--- a/code/modules/random_map/noise/magma.dm
+++ b/code/modules/random_map/noise/magma.dm
@@ -9,25 +9,26 @@
 /datum/random_map/noise/volcanism/cleanup()
 	for(var/x = 1, x <= limit_x, x++)
 		for(var/y = 1, y <= limit_y, y++)
-			var/current_cell = get_map_cell(x,y)
+			var/current_cell = TRANSLATE_COORD(x,y)
 			if(map[current_cell] < 178)
 				continue
 			var/count
-			var/tmp_cell = get_map_cell(x+1,y+1)
+			var/tmp_cell
+			TRANSLATE_AND_VERIFY_COORD(x+1, y+1)
 			if(tmp_cell && map[tmp_cell] >= 178) count++
-			tmp_cell = get_map_cell(x-1,y-1)
+			TRANSLATE_AND_VERIFY_COORD(x-1,y-1)
 			if(tmp_cell && map[tmp_cell] >= 178) count++
-			tmp_cell = get_map_cell(x+1,y-1)
+			TRANSLATE_AND_VERIFY_COORD(x+1,y-1)
 			if(tmp_cell && map[tmp_cell] >= 178) count++
-			tmp_cell = get_map_cell(x-1,y+1)
+			TRANSLATE_AND_VERIFY_COORD(x-1,y+1)
 			if(tmp_cell && map[tmp_cell] >= 178) count++
-			tmp_cell = get_map_cell(x-1,y)
+			TRANSLATE_AND_VERIFY_COORD(x-1,y)
 			if(tmp_cell && map[tmp_cell] >= 178) count++
-			tmp_cell = get_map_cell(x,y-1)
+			TRANSLATE_AND_VERIFY_COORD(x,y-1)
 			if(tmp_cell && map[tmp_cell] >= 178) count++
-			tmp_cell = get_map_cell(x+1,y)
+			TRANSLATE_AND_VERIFY_COORD(x+1,y)
 			if(tmp_cell && map[tmp_cell] >= 178) count++
-			tmp_cell = get_map_cell(x,y+1)
+			TRANSLATE_AND_VERIFY_COORD(x,y+1)
 			if(tmp_cell && map[tmp_cell] >= 178) count++
 			if(!count)
 				map[current_cell] = 177

--- a/code/modules/random_map/noise/ore.dm
+++ b/code/modules/random_map/noise/ore.dm
@@ -94,19 +94,19 @@
 
 			var/tmp_cell
 			TRANSLATE_AND_VERIFY_COORD(x, y)
+			if(tmp_cell)
+				var/spawning
+				if(tmp_cell < rare_val)
+					spawning = surface_metals
+				else if(tmp_cell < deep_val)
+					spawning = rare_metals
+				else
+					spawning = deep_metals
 
-			var/spawning
-			if(tmp_cell < rare_val)
-				spawning = surface_metals
-			else if(tmp_cell < deep_val)
-				spawning = rare_metals
-			else
-				spawning = deep_metals
-
-			for(var/val in spawning)
-				var/list/ranges = spawning[val]
-				resources[val] = rand(ranges[1], ranges[2])
-			set_extension(T, /datum/extension/buried_resources, resources)
+				for(var/val in spawning)
+					var/list/ranges = spawning[val]
+					resources[val] = rand(ranges[1], ranges[2])
+				set_extension(T, /datum/extension/buried_resources, resources)
 
 /datum/random_map/noise/ore/get_map_char(var/value)
 	if(value < rare_val)

--- a/code/modules/random_map/random_map.dm
+++ b/code/modules/random_map/random_map.dm
@@ -72,13 +72,6 @@ var/global/list/map_count = list()
 		else
 			admin_notice(SPAN_DANGER("[capitalize(name)] failed to generate ([round(0.1*(world.timeofday-start_time),0.1)] seconds): could not produce sane map."), R_DEBUG)
 
-/datum/random_map/proc/get_map_cell(var/x,var/y)
-	if(!map)
-		set_map_size()
-	. = ((y-1)*limit_x)+x
-	if((. < 1) || (. > map.len))
-		return null
-
 /datum/random_map/proc/get_map_char(var/value)
 	switch(value)
 		if(WALL_CHAR)
@@ -106,7 +99,7 @@ var/global/list/map_count = list()
 	var/dat = "<code>+------+<br>"
 	for(var/x = 1, x <= limit_x, x++)
 		for(var/y = 1, y <= limit_y, y++)
-			var/current_cell = get_map_cell(x,y)
+			var/current_cell = TRANSLATE_COORD(x,y)
 			if(current_cell)
 				dat += get_map_char(map[current_cell])
 		dat += "<br>"
@@ -119,7 +112,7 @@ var/global/list/map_count = list()
 /datum/random_map/proc/seed_map()
 	for(var/x = 1, x <= limit_x, x++)
 		for(var/y = 1, y <= limit_y, y++)
-			var/current_cell = get_map_cell(x,y)
+			var/current_cell = TRANSLATE_COORD(x,y)
 			if(prob(initial_wall_cell))
 				map[current_cell] = WALL_CHAR
 			else
@@ -128,7 +121,7 @@ var/global/list/map_count = list()
 /datum/random_map/proc/clear_map()
 	for(var/x = 1, x <= limit_x, x++)
 		for(var/y = 1, y <= limit_y, y++)
-			map[get_map_cell(x,y)] = 0
+			map[TRANSLATE_COORD(x,y)] = 0
 
 /datum/random_map/proc/generate()
 	seed_map()
@@ -165,7 +158,7 @@ var/global/list/map_count = list()
 			apply_to_turf(x,y)
 
 /datum/random_map/proc/apply_to_turf(var/x,var/y)
-	var/current_cell = get_map_cell(x,y)
+	var/current_cell = TRANSLATE_COORD(x,y)
 	if(!current_cell)
 		return 0
 	var/turf/T = locate((origin_x-1)+x,(origin_y-1)+y,origin_z)
@@ -201,14 +194,17 @@ var/global/list/map_count = list()
 	ty-- // doesn't push it off-kilter by one.
 	for(var/x = 1, x <= limit_x, x++)
 		for(var/y = 1, y <= limit_y, y++)
-			var/current_cell = get_map_cell(x,y)
+			var/current_cell = TRANSLATE_COORD(x,y)
 			if(!current_cell)
 				continue
 			if(tx+x > target_map.limit_x)
 				continue
 			if(ty+y > target_map.limit_y)
 				continue
-			target_map.map[target_map.get_map_cell(tx+x,ty+y)] = map[current_cell]
+			var/tmp_cell
+			TRANSLATE_AND_VERIFY_COORD_MLEN(tx+x, ty+y, target_map.map.len)
+			if(tmp_cell)
+				target_map.map[tmp_cell] = map[current_cell]
 	handle_post_overlay_on(target_map,tx,ty)
 
 


### PR DESCRIPTION
## Description of changes
Readds missing decals and other accidentally-cut content, adds a helper for grammatically-correct material amount strings, allows cable coil types to opt out of being recolored (for things like heavy-duty cable subtypes), optimizes random maps by about 70%, adds a console to control huge scrubbers based on ID tag (should maybe at some point make it use networks?), makes integrated circuit printers use the atom info repository for matter, and makes get_breath_from_environment check the mob's is_flooded instead of directly checking the turf. Also lets cablenets cross Z boundaries, using some of the recent mimic_edge turf work done by Loaf.

## Why and what will this PR improve
Various fixes and tweaks to either improve things directly or lay the groundwork for future expansion.