### PR TITLE
Fix protein shake name

### DIFF
--- a/code/modules/reagents/reagent_containers/drinkingglass/shaker.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/shaker.dm
@@ -25,6 +25,18 @@
 /obj/item/chems/drinks/glass2/fitnessflask/proteinshake
 	name = "protein shake"
 
+// This exists to let the name auto-set properly.
+/decl/cocktail/proteinshake
+	name = "protein shake"
+	description = "A revolting slurry of protein and water, fortified with iron."
+	hidden_from_codex = TRUE
+	ratios = list(
+		/decl/material/liquid/nutriment = 2,
+		/decl/material/liquid/nutriment/protein = 1,
+		/decl/material/liquid/water = 3,
+		/decl/material/solid/metal/iron
+	)
+
 /obj/item/chems/drinks/glass2/fitnessflask/proteinshake/populate_reagents()
 	reagents.add_reagent(/decl/material/liquid/nutriment,         30)
 	reagents.add_reagent(/decl/material/solid/metal/iron,         10)


### PR DESCRIPTION
## Description of changes
Adds a hidden 'protein shake' cocktail so that protein shakes are named properly, rather than just using the primary reagent (water).

## Why and what will this PR improve
The protein shake in the FitnessMAX vendor was just named `shaker of water`, which was confusing people, especially since it's relatively expensive: 110cr for it compared to 49cr for a bottle of water half the size. This makes it clear what's actually in it.

## Authorship
me