### PR TITLE
Fix mapped windoors facing the wrong direction

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -17,6 +17,7 @@
 	pry_mod = 0.5
 	base_type = /obj/machinery/door/window
 	frame_type = /obj/structure/windoor_assembly
+	set_dir_on_update = FALSE // these can properly face all 4 directions! don't force us into just 2!
 	var/base_state = "left"
 
 /obj/machinery/door/window/get_auto_access()


### PR DESCRIPTION
## Description of changes
Windoors should not autoset their direction like this, all four cardinal directions are valid for them. :(

## Why and what will this PR improve
Windoors can face all four cardinal directions now.