### PR TITLE
Holopad ID uniqueness pass.

### DIFF
--- a/code/unit_tests/unique_tests.dm
+++ b/code/unit_tests/unique_tests.dm
@@ -209,7 +209,7 @@
 	return TRUE
 
 /datum/unit_test/aspects_shall_have_unique_names
-	name = "ASPECTS: All Aspects Shall Have Unique Names"
+	name = "UNIQUENESS: All Aspects Shall Have Unique Names"
 
 /datum/unit_test/aspects_shall_have_unique_names/start_test()
 	var/list/aspects_by_name = list()
@@ -229,7 +229,7 @@
 	return 1
 
 /datum/unit_test/submaps_shall_have_a_unique_descriptor
-	name = "SUBMAPS: Archetypes shall have a valid, unique descriptor."
+	name = "UNIQUENESS: Archetypes shall have a valid, unique descriptor."
 
 /datum/unit_test/submaps_shall_have_a_unique_descriptor/start_test()
 	var/list/submaps_by_name = list()
@@ -271,3 +271,29 @@
 	for(var/entry in entries)
 		pretty_print += log_info_line(entry)
 	priv_print(ut, type, key, jointext(pretty_print, "\n"))
+
+/datum/unit_test/holopad_id_uniqueness
+	name = "UNIQUENESS: Holopads Shall Have Unique Valid IDs"
+
+/datum/unit_test/holopad_id_uniqueness/start_test()
+
+	var/list/failures = list()
+
+	var/list/seen_holopad_ids = list()
+	for(var/obj/machinery/hologram/holopad/holopad in global.holopads)
+		var/area/area = get_area(holopad)
+		var/holopad_loc = "x[holopad.x],y[holopad.y],z[holopad.z] - [area?.proper_name || "Unknown"]"
+		if(istext(holopad.holopad_id))
+			LAZYDISTINCTADD(seen_holopad_ids[holopad.holopad_id], holopad_loc)
+		else
+			failures += "[holopad_loc] - null or non-text holopad_id ([isnull(holopad.holopad_id) ? "NULL" : holopad.holopad_id])"
+
+	for(var/holopad_id in seen_holopad_ids)
+		if(length(seen_holopad_ids[holopad_id]) > 1)
+			failures += "overlapping holopad_id ([holopad_id]) - [jointext(seen_holopad_ids[holopad_id], ", ")]"
+
+	if(length(failures))
+		fail("Some holopads had overlapping or invalid ID values:\n[jointext(failures,"\n")]")
+	else
+		pass("All holopads had unique valid ID values.")
+	return 1

--- a/maps/away/bearcat/bearcat_areas.dm
+++ b/maps/away/bearcat/bearcat_areas.dm
@@ -151,7 +151,7 @@
 	req_access = list(access_bearcat)
 
 /area/ship/scrap/command/bridge
-	name = "Bridge"
+	name = "Hauler Bridge"
 	icon_state = "bridge"
 	req_access = list(access_bearcat)
 

--- a/maps/away/errant_pisces/errant_pisces_areas.dm
+++ b/maps/away/errant_pisces/errant_pisces_areas.dm
@@ -86,7 +86,7 @@
 	icon_state = "fishing_wing"
 
 /area/errant_pisces/bridge
-	name = "Bridge"
+	name = "Trawler Bridge"
 	icon_state = "bridge"
 
 /area/errant_pisces/prod_storage

--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -1953,7 +1953,9 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/security/main)
 "aen" = (
-/obj/machinery/hologram/holopad,
+/obj/machinery/hologram/holopad{
+	holopad_id = "Security South"
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/security/main)
 "aeo" = (
@@ -29616,7 +29618,9 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/quartermaster/office)
 "bkC" = (
-/obj/machinery/hologram/holopad,
+/obj/machinery/hologram/holopad{
+	holopad_id = "Supply Foyer"
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/quartermaster/office)
 "bkD" = (
@@ -37305,7 +37309,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exodus/medical/medbay)
 "bAp" = (
-/obj/machinery/hologram/holopad,
+/obj/machinery/hologram/holopad{
+	holopad_id = "Medbay Storage"
+	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
@@ -45792,7 +45798,9 @@
 /turf/simulated/floor/tiled/white,
 /area/exodus/medical/sleeper)
 "bQZ" = (
-/obj/machinery/hologram/holopad,
+/obj/machinery/hologram/holopad{
+	holopad_id = "Emergency Recovery"
+	},
 /turf/simulated/floor/tiled/white,
 /area/exodus/medical/sleeper)
 "bRa" = (
@@ -48289,7 +48297,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/hologram/holopad,
+/obj/machinery/hologram/holopad{
+	holopad_id = "Emergency Scanning"
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/medical/sleeper)
 "bWe" = (
@@ -61098,7 +61108,9 @@
 /turf/simulated/floor/tiled/white,
 /area/exodus/medical/virology)
 "cCW" = (
-/obj/machinery/hologram/holopad,
+/obj/machinery/hologram/holopad{
+	holopad_id = "Virology Cafeteria"
+	},
 /turf/simulated/floor/tiled/white,
 /area/exodus/medical/virology)
 "cCX" = (
@@ -63466,6 +63478,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/exodus_pod_research)
+"elq" = (
+/obj/machinery/hologram/holopad{
+	holopad_id = "Security North"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/exodus/security/main)
 "esY" = (
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/titanium,
@@ -64906,6 +64924,12 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/port)
+"woj" = (
+/obj/machinery/hologram/holopad{
+	holopad_id = "Library Rec Area"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/exodus/library)
 "wqh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/lime{
@@ -65021,6 +65045,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/exodus/research)
+"xTe" = (
+/obj/machinery/hologram/holopad{
+	holopad_id = "Sorting Office"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/exodus/quartermaster/office)
 "xVx" = (
 /obj/structure/bed/chair/shuttle/black{
 	dir = 8
@@ -88588,7 +88618,7 @@ bfm
 bez
 bga
 bga
-bkC
+xTe
 bga
 bga
 bga
@@ -94956,7 +94986,7 @@ acO
 adm
 adm
 adP
-aen
+elq
 aev
 aeX
 afp
@@ -108105,7 +108135,7 @@ aJD
 aJJ
 aJW
 aMg
-qlX
+woj
 hLX
 aRK
 hLX

--- a/maps/exodus/exodus-admin.dmm
+++ b/maps/exodus/exodus-admin.dmm
@@ -782,7 +782,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/escape_shuttle)
 "aHt" = (
-/obj/machinery/hologram/holopad,
+/obj/machinery/hologram/holopad{
+	holopad_id = "Emergency Shuttle Bridge"
+	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
@@ -1169,7 +1171,9 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/shuttle/escape_shuttle)
 "aLd" = (
-/obj/machinery/hologram/holopad,
+/obj/machinery/hologram/holopad{
+	holopad_id = "Emergency Shuttle Brig"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/shuttle/escape_shuttle)
 "aLe" = (
@@ -1977,7 +1981,9 @@
 	},
 /area/centcom/holding)
 "aPJ" = (
-/obj/machinery/hologram/holopad,
+/obj/machinery/hologram/holopad{
+	holopad_id = "Holding Facility Bar"
+	},
 /turf/unsimulated/floor{
 	icon_state = "lino"
 	},
@@ -2091,7 +2097,9 @@
 	},
 /area/centcom/holding)
 "bkb" = (
-/obj/machinery/hologram/holopad,
+/obj/machinery/hologram/holopad{
+	holopad_id = "Holding Facility Foyer"
+	},
 /turf/unsimulated/floor{
 	icon_state = "steel"
 	},
@@ -2378,7 +2386,9 @@
 	},
 /area/tdome)
 "fpV" = (
-/obj/machinery/hologram/holopad,
+/obj/machinery/hologram/holopad{
+	holopad_id = "Emergency Shuttle Medbay"
+	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/escape_shuttle)
 "fsh" = (


### PR DESCRIPTION
## Description of changes
- Changes holopads to use an instance variable instead of area proper_name.
- Adds a uniqueness test for holopad IDs.

## Why and what will this PR improve
Prevents overlapping area names from making holopads inaccessible.
In theory allows for multiple holopads in the same area.

## Authorship
Myself.

## Changelog
Nothing player-facing.