### PR TITLE
Allows faults to be treated with duct tape.

### DIFF
--- a/code/modules/organs/ailments/_ailment.dm
+++ b/code/modules/organs/ailments/_ailment.dm
@@ -69,7 +69,13 @@
 	return
 
 /datum/ailment/proc/treated_by_item(var/obj/item/treatment)
-	return treated_by_item_type && istype(treatment, treated_by_item_type)
+	if(islist(treated_by_item_type))
+		for(var/treatment_type in treated_by_item_type)
+			if(istype(treatment, treatment_type))
+				return TRUE
+	else if(ispath(treated_by_item_type))
+		return istype(treatment, treated_by_item_type)
+	return FALSE
 
 /datum/ailment/proc/replace_tokens(var/message, var/obj/item/treatment, var/mob/user, var/mob/target)
 	. = message

--- a/code/modules/organs/ailments/faults/_fault.dm
+++ b/code/modules/organs/ailments/faults/_fault.dm
@@ -1,7 +1,10 @@
 /datum/ailment/fault
 	affects_robotics = TRUE
 	category = /datum/ailment/fault
-	treated_by_item_type = /obj/item/stack/nanopaste
+	treated_by_item_type = list(
+		/obj/item/stack/nanopaste,
+		/obj/item/stack/tape_roll/duct_tape
+	)
 	treated_by_item_cost = 3
 	third_person_treatment_message = "$USER$ patches $TARGET$'s faulty $ORGAN$ with $ITEM$."
 	self_treatment_message = "$USER$ patches $USER_HIS$ faulty $ORGAN$ with $ITEM$."


### PR DESCRIPTION
## Description of changes
- Allows ailments to have multiple treatment types.
- Allows duct tape to treat prosthetic faults.
 
## Why and what will this PR improve
Faults needing nanopaste means if Science has no players, faults can't be treated. This fixes that.

## Authorship
Myself.

## Changelog
:cl:
tweak: Duct tape can be used to repair prosthetic faults.
/:cl:
