### PR TITLE
Fixing and making available custom name/desc for loadout.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -278,6 +278,8 @@ var/global/list/gamemode_cache = list()
 	var/exoplanet_max_day_duration = 40 MINUTES
 	///If true, exoplanets won't have daycycles
 	var/disable_daycycle = FALSE
+	/// Whether or not loadout options will get free name and desc entry by default.
+	var/allow_loadout_customization = FALSE
 
 /datum/configuration/VV_hidden()
 	. = ..() | protected_vars
@@ -836,6 +838,9 @@ var/global/list/gamemode_cache = list()
 
 				if("show_typing_indicator_for_whispers")
 					config.show_typing_indicator_for_whispers = TRUE
+
+				if("allow_loadout_customization")
+					config.allow_loadout_customization = TRUE
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/datums/underwear/underwear.dm
+++ b/code/datums/underwear/underwear.dm
@@ -66,5 +66,5 @@
 	UW.icon_state = icon_state
 
 	for(var/datum/gear_tweak/gt in tweaks)
-		gt.tweak_item(user, UW, metadata && metadata["[gt]"] ? metadata["[gt]"] : gt.get_default())
+		gt.tweak_item(user, UW, ((metadata && metadata["[gt]"]) ? metadata["[gt]"] : gt.get_default()))
 	return UW

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -847,3 +847,11 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	else if(current_size > STAGE_ONE)
 		step_towards(src,S)
 	else ..()
+
+// Supplied during loadout gear tweaking.
+/obj/item/proc/set_custom_name(var/new_name)
+	SetName(new_name)
+
+// Supplied during loadout gear tweaking.
+/obj/item/proc/set_custom_desc(var/new_desc)
+	desc = new_desc

--- a/code/modules/client/preference_setup/loadout/lists/accessories.dm
+++ b/code/modules/client/preference_setup/loadout/lists/accessories.dm
@@ -28,7 +28,7 @@
 /decl/loadout_option/accessory/tie_color
 	name = "colored tie"
 	path = /obj/item/clothing/accessory
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/accessory/tie_color/get_gear_tweak_options()
 	. = ..()
@@ -45,7 +45,7 @@
 /decl/loadout_option/accessory/necklace
 	name = "necklace, colour select"
 	path = /obj/item/clothing/accessory/necklace
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/accessory/bowtie
 	name = "bowtie, horrible"
@@ -54,10 +54,10 @@
 /decl/loadout_option/accessory/bowtie/color
 	name = "bowtie, colour select"
 	path = /obj/item/clothing/accessory/bowtie/color
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/accessory/bracelet
 	name = "bracelet, color select"
 	path = /obj/item/clothing/accessory/bracelet
 	cost = 1
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION

--- a/code/modules/client/preference_setup/loadout/lists/augmentations.dm
+++ b/code/modules/client/preference_setup/loadout/lists/augmentations.dm
@@ -4,7 +4,7 @@
 /decl/loadout_option/augmentation
 	category = /decl/loadout_category/augmentation
 	abstract_type = /decl/loadout_option/augmentation
-	flags = GEAR_NO_EQUIP | GEAR_NO_FINGERPRINTS
+	loadout_flags = GEAR_NO_EQUIP | GEAR_NO_FINGERPRINTS
 	custom_setup_proc = /obj/item/proc/AttemptAugmentation
 	custom_setup_proc_arguments = list(BP_CHEST)
 

--- a/code/modules/client/preference_setup/loadout/lists/clothing.dm
+++ b/code/modules/client/preference_setup/loadout/lists/clothing.dm
@@ -10,12 +10,12 @@
 	name = "flannel (colorable)"
 	path = /obj/item/clothing/accessory/toggleable/flannel
 	slot = slot_tie_str
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/clothing/scarf
 	name = "scarf"
 	path = /obj/item/clothing/accessory/scarf
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/clothing/hawaii
 	name = "hawaii shirt"
@@ -33,7 +33,7 @@
 /decl/loadout_option/clothing/vest
 	name = "suit vest, colour select"
 	path = /obj/item/clothing/accessory/toggleable
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/clothing/suspenders
 	name = "suspenders"
@@ -42,22 +42,22 @@
 /decl/loadout_option/clothing/suspenders/colorable
 	name = "suspenders, colour select"
 	path = /obj/item/clothing/accessory/suspenders/colorable
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/clothing/wcoat
 	name = "waistcoat, colour select"
 	path = /obj/item/clothing/accessory/wcoat
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/clothing/zhongshan
 	name = "zhongshan jacket, colour select"
 	path = /obj/item/clothing/accessory/toggleable/zhongshan
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/clothing/dashiki
 	name = "dashiki selection"
 	path = /obj/item/clothing/accessory/dashiki
-	flags = GEAR_HAS_TYPE_SELECTION
+	loadout_flags = GEAR_HAS_TYPE_SELECTION
 
 /decl/loadout_option/clothing/thawb
 	name = "thawb"
@@ -66,19 +66,19 @@
 /decl/loadout_option/clothing/sherwani
 	name = "sherwani, colour select"
 	path = /obj/item/clothing/accessory/sherwani
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/clothing/qipao
 	name = "qipao blouse, colour select"
 	path = /obj/item/clothing/accessory/qipao
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/clothing/sweater
 	name = "turtleneck sweater, colour select"
 	path = /obj/item/clothing/accessory/sweater
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/clothing/tangzhuang
 	name = "tangzhuang jacket, colour select"
 	path = /obj/item/clothing/accessory/tangzhuang
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION

--- a/code/modules/client/preference_setup/loadout/lists/eyegear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/eyegear.dm
@@ -40,4 +40,4 @@
 /decl/loadout_option/eyes/blindfold
 	name = "blindfold"
 	path = /obj/item/clothing/glasses/blindfold
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION

--- a/code/modules/client/preference_setup/loadout/lists/footwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/footwear.dm
@@ -9,7 +9,7 @@
 /decl/loadout_option/shoes/athletic
 	name = "athletic shoes, colour select"
 	path = /obj/item/clothing/shoes/athletic
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/shoes/boots
 	name = "boot selection"
@@ -53,12 +53,12 @@
 /decl/loadout_option/shoes/flats
 	name = "flats, colour select"
 	path = /obj/item/clothing/shoes/flats
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/shoes/high
 	name = "high tops selection"
 	path = /obj/item/clothing/shoes/color/hightops
-	flags = GEAR_HAS_TYPE_SELECTION
+	loadout_flags = GEAR_HAS_TYPE_SELECTION
 
 /decl/loadout_option/shoes/sandal
 	name = "wooden sandals"
@@ -67,4 +67,4 @@
 /decl/loadout_option/shoes/heels
 	name = "high heels, colour select"
 	path = /obj/item/clothing/shoes/heels
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION

--- a/code/modules/client/preference_setup/loadout/lists/gloves.dm
+++ b/code/modules/client/preference_setup/loadout/lists/gloves.dm
@@ -9,13 +9,13 @@
 
 /decl/loadout_option/gloves/colored
 	name = "gloves, colored"
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 	path = /obj/item/clothing/gloves/color
 
 /decl/loadout_option/gloves/evening
 	name = "gloves, evening, colour select"
 	path = /obj/item/clothing/gloves/color/evening
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/ring
 	name = "ring"

--- a/code/modules/client/preference_setup/loadout/lists/headwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/headwear.dm
@@ -9,7 +9,7 @@
 /decl/loadout_option/head/beret
 	name = "beret, colour select"
 	path = /obj/item/clothing/head/beret/plaincolor
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 	description = "A simple, solid color beret. This one has no emblems or insignia on it."
 
 /decl/loadout_option/head/bandana
@@ -24,17 +24,17 @@
 /decl/loadout_option/head/beanie
 	name = "beanie, color select"
 	path = /obj/item/clothing/head/beanie
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/head/bow
 	name = "hair bow, colour select"
 	path = /obj/item/clothing/head/hairflower/bow
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/head/flat_cap
 	name = "flat cap, colour select"
 	path = /obj/item/clothing/head/flatcap
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/head/cap
 	name = "cap selection"
@@ -118,22 +118,22 @@
 /decl/loadout_option/head/hijab
 	name = "hijab, colour select"
 	path = /obj/item/clothing/head/hijab
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/head/kippa
 	name = "kippa, colour select"
 	path = /obj/item/clothing/head/kippa
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/head/turban
 	name = "turban, colour select"
 	path = /obj/item/clothing/head/turban
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/head/taqiyah
 	name = "taqiyah, colour select"
 	path = /obj/item/clothing/head/taqiyah
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/head/rastacap
 	name = "rastacap"

--- a/code/modules/client/preference_setup/loadout/lists/misc.dm
+++ b/code/modules/client/preference_setup/loadout/lists/misc.dm
@@ -51,12 +51,12 @@
 /decl/loadout_option/coffeecup
 	name = "coffee cup"
 	path = /obj/item/chems/drinks/glass2/coffeecup
-	flags = GEAR_HAS_TYPE_SELECTION
+	loadout_flags = GEAR_HAS_TYPE_SELECTION
 
 /decl/loadout_option/towel
 	name = "towel"
 	path = /obj/item/towel
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/mirror
 	name = "handheld mirror"
@@ -65,12 +65,12 @@
 /decl/loadout_option/lipstick
 	name = "lipstick selection"
 	path = /obj/item/lipstick
-	flags = GEAR_HAS_TYPE_SELECTION
+	loadout_flags = GEAR_HAS_TYPE_SELECTION
 
 /decl/loadout_option/comb
 	name = "plastic comb"
 	path = /obj/item/haircomb
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/mask
 	name = "sterile mask"
@@ -152,7 +152,7 @@
 /decl/loadout_option/wallet
 	name = "wallet, colour select"
 	path = /obj/item/storage/wallet
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/wallet_poly
 	name = "wallet, polychromic"
@@ -164,4 +164,4 @@
 	name = "multi-tool"
 	path = /obj/item/knife/folding/swiss
 	cost = 4
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION

--- a/code/modules/client/preference_setup/loadout/lists/suits.dm
+++ b/code/modules/client/preference_setup/loadout/lists/suits.dm
@@ -10,7 +10,7 @@
 	name = "poncho selection"
 	path = /obj/item/clothing/suit/poncho/colored
 	cost = 1
-	flags = GEAR_HAS_TYPE_SELECTION
+	loadout_flags = GEAR_HAS_TYPE_SELECTION
 
 /decl/loadout_option/suit/suit_jacket
 	name = "standard suit jackets"
@@ -28,17 +28,17 @@
 /decl/loadout_option/suit/custom_suit_jacket
 	name = "suit jacket, colour select"
 	path = /obj/item/clothing/suit/storage/toggle/suit
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/suit/hoodie
 	name = "hoodie, colour select"
 	path = /obj/item/clothing/suit/storage/toggle/hoodie
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/suit/coat
 	name = "coat, colour select"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/coat
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/suit/leather
 	name = "jacket selection"
@@ -60,7 +60,7 @@
 /decl/loadout_option/suit/track
 	name = "track jacket selection"
 	path = /obj/item/clothing/suit/storage/toggle/track
-	flags = GEAR_HAS_TYPE_SELECTION
+	loadout_flags = GEAR_HAS_TYPE_SELECTION
 
 /decl/loadout_option/suit/blueapron
 	name = "apron, blue"
@@ -89,11 +89,11 @@
 /decl/loadout_option/suit/letterman_custom
 	name = "letterman jacket, colour select"
 	path = /obj/item/clothing/suit/letterman
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 	cost = 1
 
 /decl/loadout_option/suit/cloak
 	name = "plain cloak"
 	path = /obj/item/clothing/accessory/cloak
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 	cost = 3

--- a/code/modules/client/preference_setup/loadout/lists/uniforms.dm
+++ b/code/modules/client/preference_setup/loadout/lists/uniforms.dm
@@ -9,12 +9,12 @@
 /decl/loadout_option/uniform/jumpsuit
 	name = "jumpsuit, colour select"
 	path = /obj/item/clothing/under/color
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/uniform/shortjumpskirt
 	name = "short jumpskirt, colour select"
 	path = /obj/item/clothing/under/shortjumpskirt
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/uniform/blackjumpshorts
 	name = "black jumpsuit shorts"
@@ -76,62 +76,62 @@
 /decl/loadout_option/uniform/cheongsam
 	name = "cheongsam, colour select"
 	path = /obj/item/clothing/under/cheongsam
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/uniform/abaya
 	name = "abaya, colour select"
 	path = /obj/item/clothing/under/abaya
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/uniform/skirt
 	name = "skirt selection"
 	path = /obj/item/clothing/under/skirt
-	flags = GEAR_HAS_TYPE_SELECTION
+	loadout_flags = GEAR_HAS_TYPE_SELECTION
 
 /decl/loadout_option/uniform/skirt_c
 	name = "short skirt, colour select"
 	path = /obj/item/clothing/under/skirt_c
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/uniform/skirt_c/dress
 	name = "simple dress, colour select"
 	path = /obj/item/clothing/under/skirt_c/dress
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/uniform/casual_pants
 	name = "casual pants selection"
 	path = /obj/item/clothing/pants/casual
-	flags = GEAR_HAS_TYPE_SELECTION
+	loadout_flags = GEAR_HAS_TYPE_SELECTION
 
 /decl/loadout_option/uniform/formal_pants
 	name = "formal pants selection"
 	path = /obj/item/clothing/pants/formal
-	flags = GEAR_HAS_TYPE_SELECTION
+	loadout_flags = GEAR_HAS_TYPE_SELECTION
 
 /decl/loadout_option/uniform/formal_pants/baggycustom
 	name = "baggy suit pants, colour select"
 	path = /obj/item/clothing/pants/baggy
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/uniform/shorts
 	name = "shorts selection"
 	path = /obj/item/clothing/pants/shorts
-	flags = GEAR_HAS_TYPE_SELECTION
+	loadout_flags = GEAR_HAS_TYPE_SELECTION
 
 /decl/loadout_option/uniform/shorts/custom
 	name = "athletic shorts, colour select"
 	path = /obj/item/clothing/pants/shorts/athletic
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/uniform/turtleneck
 	name = "sweater, colour select"
 	path = /obj/item/clothing/under/psych/turtleneck/sweater
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/uniform/kimono
 	name = "kimono, colour select"
 	path = /obj/item/clothing/under/kimono
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/uniform/frontier
 	name = "frontier clothes"

--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -67,7 +67,7 @@
 /decl/loadout_option/utility/umbrella
 	name = "umbrella"
 	path = /obj/item/umbrella
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/utility/knives/get_gear_tweak_options()
 	. = ..()

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -24,6 +24,14 @@
 	if(!possible_transfer_amounts)
 		src.verbs -= /obj/item/chems/verb/set_amount_per_transfer_from_this
 
+/obj/item/chems/set_custom_name(var/new_name)
+	base_name = new_name
+	update_container_name()
+
+/obj/item/chems/set_custom_desc(var/new_desc)
+	base_desc = new_desc
+	update_container_desc()
+
 /obj/item/chems/proc/cannot_interact(mob/user)
 	if(!CanPhysicallyInteract(user))
 		to_chat(usr, SPAN_WARNING("You're in no condition to do that!"))

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -462,3 +462,6 @@ RADIATION_LOWER_LIMIT 0.15
 
 ## Uncomment this to show a typing indicator for people writing whispers.
 #SHOW_TYPING_INDICATOR_FOR_WHISPERS
+
+## Uncomment this to allow loadout name/desc customization by default.
+#ALLOW_LOADOUT_CUSTOMIZATION

--- a/mods/content/corporate/datum/loadout.dm
+++ b/mods/content/corporate/datum/loadout.dm
@@ -20,7 +20,7 @@
 /decl/loadout_option/suit/labcoat_corp
 	name = "labcoat, corporate colors"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/science
-	flags = GEAR_HAS_TYPE_SELECTION
+	loadout_flags = GEAR_HAS_TYPE_SELECTION
 
 /decl/loadout_option/uniform/corporate
 	name = "corporate uniform selection"
@@ -50,22 +50,22 @@
 /decl/loadout_option/uniform/corp_exec
 	name = "corporate colours, senior researcher"
 	path = /obj/item/clothing/under/executive
-	flags = GEAR_HAS_TYPE_SELECTION
+	loadout_flags = GEAR_HAS_TYPE_SELECTION
 
 /decl/loadout_option/uniform/corp_overalls
 	name = "corporate colours, coveralls"
 	path = /obj/item/clothing/under/work
-	flags = GEAR_HAS_TYPE_SELECTION
+	loadout_flags = GEAR_HAS_TYPE_SELECTION
 
 /decl/loadout_option/uniform/corp_flight
 	name = "corporate colours, flight suit"
 	path = /obj/item/clothing/under/pilot
-	flags = GEAR_HAS_TYPE_SELECTION
+	loadout_flags = GEAR_HAS_TYPE_SELECTION
 
 /decl/loadout_option/uniform/corp_exec_jacket
 	name = "corporate colours, liason suit"
 	path = /obj/item/clothing/under/suit_jacket/corp
-	flags = GEAR_HAS_TYPE_SELECTION
+	loadout_flags = GEAR_HAS_TYPE_SELECTION
 
 /decl/loadout_option/suit/nanotrasen_poncho
 	name = "poncho, NanoTrasen"

--- a/mods/species/bayliens/skrell/gear/gear_ears.dm
+++ b/mods/species/bayliens/skrell/gear/gear_ears.dm
@@ -45,4 +45,4 @@
 	category = /decl/loadout_category/ears
 	whitelisted = list(SPECIES_SKRELL)
 	path = /obj/item/clothing/ears/skrell
-	flags = GEAR_HAS_COLOR_SELECTION | GEAR_HAS_SUBTYPE_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION | GEAR_HAS_SUBTYPE_SELECTION

--- a/mods/species/neoavians/datum/loadout.dm
+++ b/mods/species/neoavians/datum/loadout.dm
@@ -28,5 +28,5 @@
 /decl/loadout_option/avian/shoes
 	name  = "footwraps"
 	path  = /obj/item/clothing/shoes/avian/footwraps
-	flags = GEAR_HAS_COLOR_SELECTION
+	loadout_flags = GEAR_HAS_COLOR_SELECTION
 	slot  = slot_shoes_str


### PR DESCRIPTION
## Description of changes
- Adds a config option to enable custom name/desc on all loadout.
- Fixes issues with custom name/desc on loadout.
- Renames loadout `flags` var to `loadout_flags` for searchability.

## Why and what will this PR improve
It's a nice RP feature on Polaris and it was previously broken.

![image](https://github.com/NebulaSS13/Nebula/assets/2468979/b05b97b4-3e90-49ee-b051-444703bb64c6)

## Authorship
Myself.

## Changelog
:cl:
server: There is now a configuration option to enable custom loadout names and descs by default.
/:cl:
