### PR TITLE
ID card and access tweaks.

### DIFF
--- a/code/datums/extensions/access_provider.dm
+++ b/code/datums/extensions/access_provider.dm
@@ -13,6 +13,6 @@
 /datum/extension/access_provider/proc/unregister_id(atom/movable/to_unregister)
 	LAZYREMOVE(registered_ids, to_unregister)
 
-/datum/extension/access_provider/proc/GetIdCards()
+/datum/extension/access_provider/proc/get_id_cards()
 	for(var/atom/movable/registered_id in registered_ids)
-		LAZYDISTINCTADD(., registered_id.GetIdCards())
+		LAZYDISTINCTADD(., registered_id.get_id_cards())

--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -490,7 +490,7 @@
 // have to call this periodically for the duration to work properly
 /datum/mind/proc/is_brigged(duration)
 	var/area/A = get_area(current)
-	if(!isturf(current.loc) || !istype(A) || !(A.area_flags & AREA_FLAG_PRISON) || current.GetIdCard())
+	if(!isturf(current.loc) || !istype(A) || !(A.area_flags & AREA_FLAG_PRISON) || current.get_id_card())
 		brigged_since = -1
 		return 0
 

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -181,7 +181,7 @@ var/global/list/outfits_decls_by_type_
 		W.assignment = assignment
 	if(job)
 		W.position = job.title
-		LAZYDISTINCTADD(W.access, job.get_access())
+		LAZYDISTINCTADD(W.access, job.get_job_access())
 		if(!W.detail_color)
 			W.detail_color = job.selection_color
 			W.update_icon()

--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -205,7 +205,7 @@
 /obj/item/uplink_service/fake_crew_announcement/enable(var/mob/user = usr)
 
 	var/datum/computer_file/report/crew_record/random_record
-	var/obj/item/card/id/I = user.GetIdCard()
+	var/obj/item/card/id/I = user.get_id_card()
 	var/datum/computer_network/net = get_local_network_at(get_turf(user))
 	if(net && length(net.get_crew_records()))
 		random_record = pick(net.get_crew_records())

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -5,30 +5,30 @@
 		return TRUE
 	if(!istype(M))
 		return FALSE
-	return check_access_list(M.GetAccess())
+	return check_access_list(M.get_access())
 
-/atom/movable/proc/GetAccess(var/union = FALSE)
+/atom/movable/proc/get_access(var/union = TRUE)
 	. = list()
 	if(union)
-		for(var/atom/movable/id in GetIdCards())
-			. |= id.GetAccess()
+		for(var/atom/movable/id in get_id_cards())
+			. |= id.get_access()
 		return .
-	var/atom/movable/id = GetIdCard()
+	var/atom/movable/id = get_id_card()
 	if(id)
-		. = id.GetAccess()
+		. = id.get_access()
 
-/atom/movable/proc/GetIdCard()
+/atom/movable/proc/get_id_card()
 	RETURN_TYPE(/obj/item/card/id)
-	var/list/cards = GetIdCards()
+	var/list/cards = get_id_cards()
 	return LAZYACCESS(cards, LAZYLEN(cards))
 
-/atom/movable/proc/GetIdCards()
+/atom/movable/proc/get_id_cards()
 	var/datum/extension/access_provider/our_provider = get_extension(src, /datum/extension/access_provider)
 	if(our_provider)
-		LAZYDISTINCTADD(., our_provider.GetIdCards())
+		LAZYDISTINCTADD(., our_provider.get_id_cards())
 
 /atom/movable/proc/check_access(atom/movable/A)
-	return check_access_list(A ? A.GetAccess() : list())
+	return check_access_list(A ? A.get_access() : list())
 
 /atom/movable/proc/check_access_list(list/L)
 	var/list/R = get_req_access()
@@ -214,7 +214,7 @@ var/global/list/priv_region_access
 /mob/observer/ghost
 	var/static/obj/item/card/id/all_access/ghost_all_access
 
-/mob/observer/ghost/GetIdCards()
+/mob/observer/ghost/get_id_cards()
 	. = ..()
 	if (!is_admin(src))
 		return .
@@ -223,17 +223,17 @@ var/global/list/priv_region_access
 		ghost_all_access = new()
 	LAZYDISTINCTADD(., ghost_all_access)
 
-/mob/living/bot/GetIdCards()
+/mob/living/bot/get_id_cards()
 	. = ..()
 	if(istype(botcard))
 		LAZYDISTINCTADD(., botcard)
 
 // Gets the ID card of a mob, but will not check types in the exceptions list
-/mob/living/carbon/human/GetIdCard(exceptions = null)
+/mob/living/carbon/human/get_id_card(exceptions = null)
 	RETURN_TYPE(/obj/item/card/id)
-	return LAZYACCESS(GetIdCards(exceptions), 1)
+	return LAZYACCESS(get_id_cards(exceptions), 1)
 
-/mob/living/carbon/human/GetIdCards(exceptions = null)
+/mob/living/carbon/human/get_id_cards(exceptions = null)
 	. = ..()
 	var/list/candidates = get_held_items()
 	var/id = get_equipped_item(slot_wear_id_str)
@@ -242,14 +242,11 @@ var/global/list/priv_region_access
 	for(var/atom/movable/candidate in candidates)
 		if(!candidate || is_type_in_list(candidate, exceptions))
 			continue
-		var/list/obj/item/card/id/id_cards = candidate.GetIdCards()
+		var/list/obj/item/card/id/id_cards = candidate.get_id_cards()
 		if(LAZYLEN(id_cards))
 			LAZYDISTINCTADD(., id_cards)
 
-/mob/living/carbon/human/GetAccess(var/union = TRUE)
-	. = ..(union)
-
-/mob/living/silicon/GetIdCards()
+/mob/living/silicon/get_id_cards()
 	. = ..()
 	if(stat || (ckey && !client))
 		return // Unconscious, dead or once possessed but now client-less silicons are not considered to have id access.
@@ -257,7 +254,7 @@ var/global/list/priv_region_access
 		LAZYDISTINCTADD(., idcard)
 
 /proc/FindNameFromID(var/mob/M, var/missing_id_name = "Unknown")
-	var/obj/item/card/id/C = M.GetIdCard()
+	var/obj/item/card/id/C = M.get_id_card()
 	if(C)
 		return C.registered_name
 	return missing_id_name
@@ -266,7 +263,7 @@ var/global/list/priv_region_access
 	return SSjobs.titles_to_datums + list("Prisoner")
 
 /obj/proc/GetJobName() //Used in secHUD icon generation
-	var/obj/item/card/id/I = GetIdCard()
+	var/obj/item/card/id/I = get_id_card()
 
 	if(I)
 		var/job_icons = get_all_job_icons()

--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -165,7 +165,7 @@
 		return FALSE
 	. = outfit.equip_outfit(H, alt_title || title, equip_adjustments = (OUTFIT_ADJUSTMENT_SKIP_POST_EQUIP|OUTFIT_ADJUSTMENT_SKIP_ID_PDA|additional_skips), job = src, rank = grade)
 
-/datum/job/proc/get_access()
+/datum/job/proc/get_job_access()
 	if(minimal_access.len && (!config || config.jobs_have_minimal_access))
 		return minimal_access?.Copy()
 	return access?.Copy()

--- a/code/game/machinery/_machines_base/stock_parts/access_lock.dm
+++ b/code/game/machinery/_machines_base/stock_parts/access_lock.dm
@@ -57,7 +57,7 @@
 /obj/item/stock_parts/access_lock/attackby(obj/item/W, mob/user)
 	var/obj/machinery/machine = loc
 	if(!emagged && istype(machine))
-		var/obj/item/card/id/I = W.GetIdCard()
+		var/obj/item/card/id/I = W.get_id_card()
 		if(I && check_access(I))
 			locked = !locked
 			visible_message(SPAN_NOTICE("\The [src] beeps and flashes green twice: it is now [locked ? "" : "un"]locked."))
@@ -106,7 +106,7 @@
 			if(!req_access)
 				locked = FALSE
 			else
-				var/obj/item/card/id/I = user.GetIdCard()				
+				var/obj/item/card/id/I = user.get_id_card()
 				if(!istype(I, /obj/item/card/id))
 					to_chat(user, SPAN_WARNING("[\src] flashes a yellow LED near the ID scanner. Did you remember to scan your ID or PDA?"))
 					return TOPIC_HANDLED

--- a/code/game/machinery/_machines_base/stock_parts/card_reader.dm
+++ b/code/game/machinery/_machines_base/stock_parts/card_reader.dm
@@ -59,11 +59,5 @@
 		on_insert_target.InvokeAsync(C, user)
 	return TRUE
 
-/obj/item/stock_parts/item_holder/card_reader/proc/get_id_card()
-	return istype(inserted_card, /obj/item/card/id) ? inserted_card : null
-
 /obj/item/stock_parts/item_holder/card_reader/proc/get_data_card()
 	return istype(inserted_card, /obj/item/card/data) ? inserted_card : null
-
-/obj/item/stock_parts/item_holder/card_reader/proc/get_emag_card()
-	return istype(inserted_card, /obj/item/card/emag) ? inserted_card : null

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -615,7 +615,7 @@
 		if(rcon_setting == RCON_YES || (alarm_area.atmosalm && rcon_setting == RCON_AUTO))
 			. = STATUS_INTERACTIVE // Have rcon access
 
-		if(has_access(rcon_remote_override_access, user.GetAccess()))
+		if(has_access(rcon_remote_override_access, user.get_access()))
 			. = STATUS_INTERACTIVE // They have the access to set rcon anyway
 		else if(href_list && href_list["rcon"])
 			. = STATUS_UPDATE // They don't have rcon access but are trying to set it: that's a no

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -200,7 +200,7 @@
 
 /mob/living/proc/tracking_status()
 	// Easy checks first.
-	var/obj/item/card/id/id = GetIdCard()
+	var/obj/item/card/id/id = get_id_card()
 	if(id && id.prevent_tracking())
 		return TRACKING_TERMINATE
 	if(InvalidPlayerTurf(get_turf(src)))

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -115,7 +115,7 @@ var/global/list/empty_playable_ai_cores = list()
 		update_icon()
 	else
 		if(!authorized)
-			if(access_ai_upload in P.GetAccess())
+			if(access_ai_upload in P.get_access())
 				to_chat(user, SPAN_NOTICE("You swipe [P] at [src] and authorize it to connect into the systems of [global.using_map.full_name]."))
 				authorized = 1
 

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -12,7 +12,7 @@
 	var/expired = FALSE
 	var/reason = "NOT SPECIFIED"
 
-/obj/item/card/id/guest/GetAccess()
+/obj/item/card/id/guest/get_access(var/union = TRUE)
 	return temp_access
 
 /obj/item/card/id/guest/examine(mob/user)

--- a/code/game/machinery/computer/shuttle.dm
+++ b/code/game/machinery/computer/shuttle.dm
@@ -22,7 +22,7 @@
 
 	if (istype(W, /obj/item/card/id)||istype(W, /obj/item/modular_computer))
 		if (istype(W, /obj/item/modular_computer))
-			W = W.GetIdCard()
+			W = W.get_id_card()
 		if (!W:access) //no access
 			to_chat(user, "The access level of [W:registered_name]\'s card is not high enough.")
 			return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -705,7 +705,7 @@ About the new airlock wires panel:
 
 /obj/machinery/door/airlock/attackby(var/obj/item/C, var/mob/user)
 	// Brace is considered installed on the airlock, so interacting with it is protected from electrification.
-	if(brace && (istype(C.GetIdCard(), /obj/item/card/id/) || istype(C, /obj/item/crowbar/brace_jack)))
+	if(brace && (istype(C.get_id_card(), /obj/item/card/id/) || istype(C, /obj/item/crowbar/brace_jack)))
 		return brace.attackby(C, user)
 
 	if(!brace && istype(C, /obj/item/airlock_brace))

--- a/code/game/machinery/doors/braces.dm
+++ b/code/game/machinery/doors/braces.dm
@@ -70,12 +70,12 @@
 
 /obj/item/airlock_brace/attackby(obj/item/W, mob/user)
 	..()
-	if (istype(W.GetIdCard(), /obj/item/card/id))
+	if (istype(W.get_id_card(), /obj/item/card/id))
 		if(!airlock)
 			attack_self(user)
 			return
 		else
-			var/obj/item/card/id/C = W.GetIdCard()
+			var/obj/item/card/id/C = W.get_id_card()
 			if(check_access(C))
 				to_chat(user, "You swipe \the [C] through \the [src].")
 				if(do_after(user, 10, airlock))

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -53,7 +53,7 @@ var/global/list/navbeacons = list()
 
 		update_icon()
 
-	else if(I.GetIdCard())
+	else if(I.get_id_card())
 		if(open)
 			if (src.allowed(user))
 				src.locked = !src.locked

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -888,7 +888,7 @@ var/global/list/allCasters = list() //Global list that will contain reference to
 				src.scribble = s
 				src.attack_self(user)
 				return TRUE
-			return 
+			return
 	return ..()
 
 ////////////////////////////////////helper procs
@@ -897,7 +897,7 @@ var/global/list/allCasters = list() //Global list that will contain reference to
 /obj/machinery/newscaster/proc/scan_user(mob/living/user)
 	if(istype(user,/mob/living/carbon/human))                       //User is a human
 		var/mob/living/carbon/human/human_user = user
-		var/obj/item/card/id/id = human_user.GetIdCard()
+		var/obj/item/card/id/id = human_user.get_id_card()
 		if(istype(id))                                      //Newscaster scans you
 			src.scanned_user = GetNameAndAssignmentFromId(id)
 		else

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -215,7 +215,7 @@ var/global/req_console_information = list()
 			SSnano.update_uis(src)
 		if(screen == RCS_ANNOUNCE)
 			var/obj/item/card/id/ID = O
-			if (access_RC_announce in ID.GetAccess())
+			if (access_RC_announce in ID.get_access())
 				announceAuth = 1
 				announcement.announcer = ID.assignment ? "[ID.assignment] [ID.registered_name]" : ID.registered_name
 			else

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -707,7 +707,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 		. = SPAN_WARNING("[html_icon(src)] [gender==PLURAL?"some":"a"] <font color='[coating.get_color()]'>stained</font> [name]")
 	else
 		. = "[html_icon(src)] \a [src]"
-	var/ID = GetIdCard()
+	var/ID = get_id_card()
 	if(ID)
 		. += "  <a href='?src=\ref[ID];look_at_id=1'>\[Look at ID\]</a>"
 

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -13,8 +13,8 @@
 	req_access = list(list(access_heads, access_security))
 	material = /decl/material/solid/plastic
 	matter = list(
-		/decl/material/solid/metal/copper    = MATTER_AMOUNT_REINFORCEMENT, 
-		/decl/material/solid/silicon         = MATTER_AMOUNT_REINFORCEMENT, 
+		/decl/material/solid/metal/copper    = MATTER_AMOUNT_REINFORCEMENT,
+		/decl/material/solid/silicon         = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/glass           = MATTER_AMOUNT_TRACE,
 	)
@@ -56,7 +56,7 @@
 		active = null
 		update_icon()
 		return TOPIC_REFRESH
-	
+
 	if(href_list["select"])
 		var/list/active_warrants = list()
 		for(var/datum/computer_file/report/warrant/W in global.all_warrants)
@@ -84,13 +84,13 @@
 
 /obj/item/holowarrant/attackby(obj/item/W, mob/user)
 	if(active)
-		var/obj/item/card/id/I = W.GetIdCard()
-		if(I && check_access_list(I.GetAccess()))
+		var/obj/item/card/id/I = W.get_id_card()
+		if(I && check_access_list(I.get_access()))
 			var/choice = alert(user, "Would you like to authorize this warrant?","Warrant authorization","Yes","No")
 			var/datum/report_field/signature/auth = active.field_from_name("Authorized by")
 			if(choice == "Yes")
 				auth.ask_value(user)
-			user.visible_message(SPAN_NOTICE("You swipe \the [I] through the [src]."), 
+			user.visible_message(SPAN_NOTICE("You swipe \the [I] through the [src]."),
 								 SPAN_NOTICE("[user] swipes \the [I] through the [src]."))
 			broadcast_security_hud_message("[active.get_broadcast_summary()] has been authorized by [auth.get_value()].", src)
 		else

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -21,7 +21,7 @@
 /obj/item/encryptionkey/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/card/id))
 		var/obj/item/card/id/id = W
-		var/list/access = id.GetAccess()
+		var/list/access = id.get_access()
 		if(!length(access))
 			to_chat(user, SPAN_WARNING("\The [W] has no access keys to copy."))
 			return TRUE

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -299,14 +299,14 @@ var/global/const/NO_EMAG_ACT = -50
 	src.add_fingerprint(user)
 	return
 
-/obj/item/card/id/GetAccess()
+/obj/item/card/id/get_access(var/union = TRUE)
 	return access.Copy()
 
-/obj/item/card/id/GetIdCard()
+/obj/item/card/id/get_id_card()
 	RETURN_TYPE(/obj/item/card/id)
 	return src
 
-/obj/item/card/id/GetIdCards()
+/obj/item/card/id/get_id_cards()
 	return list(src)
 
 /obj/item/card/id/verb/read()

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -87,7 +87,7 @@
 			tiny_state = "id-"+front_id.icon_state
 		add_overlay(overlay_image(icon, tiny_state, flags = RESET_COLOR))
 
-/obj/item/storage/wallet/GetIdCards()
+/obj/item/storage/wallet/get_id_cards()
 	. = ..()
 	if(istype(front_id))
 		LAZYDISTINCTADD(., front_id)
@@ -148,10 +148,10 @@
 
 /decl/interaction_handler/remove_id/wallet/is_possible(atom/target, mob/user, obj/item/prop)
 	. = ..() && ishuman(user)
-	
+
 /decl/interaction_handler/remove_id/wallet/invoked(atom/target, mob/user, obj/item/prop)
 	var/obj/item/storage/wallet/W = target
-	var/obj/item/card/id/id = W.GetIdCard()
+	var/obj/item/card/id/id = W.get_id_card()
 	if (istype(id))
 		W.remove_from_storage(id)
 		user.put_in_hands(id)

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -37,9 +37,9 @@
 	if(cult)
 		return ..()
 
-	var/obj/item/card/id/card = I.GetIdCard()
+	var/obj/item/card/id/card = I.get_id_card()
 	if(istype(card))
-		if(access_bar in card.GetAccess())
+		if(access_bar in card.get_access())
 			var/sign_type = input(user, "What would you like to change the barsign to?") as null|anything in get_valid_states(0)
 			if(!sign_type)
 				return

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -458,7 +458,7 @@ var/global/list/closets = list()
 	add_fingerprint(user)
 
 	if(!id_card)
-		id_card = user.GetIdCard()
+		id_card = user.get_id_card()
 
 	if(!user.check_dexterity(DEXTERITY_COMPLEX_TOOLS))
 		return FALSE
@@ -473,7 +473,7 @@ var/global/list/closets = list()
 		return FALSE
 
 /obj/structure/closet/proc/CanToggleLock(var/mob/user, var/obj/item/card/id/id_card)
-	return allowed(user) || (istype(id_card) && check_access_list(id_card.GetAccess()))
+	return allowed(user) || (istype(id_card) && check_access_list(id_card.get_access()))
 
 /obj/structure/closet/CtrlAltClick(var/mob/user)
 	verb_toggleopen()

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -32,7 +32,7 @@
 /obj/structure/closet/secure_closet/personal/togglelock(var/mob/user, var/obj/item/card/id/id_card)
 	if (..())
 		if(locked)
-			id_card = istype(id_card) ? id_card : user.GetIdCard()
+			id_card = istype(id_card) ? id_card : user.get_id_card()
 			if (id_card)
 				set_owner(id_card.registered_name)
 		else

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -91,7 +91,7 @@
 
 /obj/structure/displaycase/attackby(obj/item/W, mob/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	var/obj/item/card/id/id = W.GetIdCard()
+	var/obj/item/card/id/id = W.get_id_card()
 	if(istype(id))
 		if(allowed(usr))
 			locked = !locked

--- a/code/game/objects/structures/under_wardrobe.dm
+++ b/code/game/objects/structures/under_wardrobe.dm
@@ -15,7 +15,7 @@
 		qdel(underwear)
 		user.visible_message("<span class='notice'>\The [user] inserts \their [underwear.name] into \the [src].</span>", "<span class='notice'>You insert your [underwear.name] into \the [src].</span>")
 
-		var/id = user.GetIdCard()
+		var/id = user.get_id_card()
 		var/message
 		if(id)
 			message = "ID card detected. Your underwear quota for this shift has been increased, if applicable."
@@ -45,7 +45,7 @@
 	return TRUE
 
 /obj/structure/undies_wardrobe/interact(var/mob/living/carbon/human/H)
-	var/id = H.GetIdCard()
+	var/id = H.get_id_card()
 
 	var/dat = list()
 	dat += "<b>Underwear</b><br><hr>"
@@ -91,7 +91,7 @@
 		if(!CanInteract(H, state))
 			return
 
-		var/id = H.GetIdCard()
+		var/id = H.get_id_card()
 		if(!id)
 			audible_message("No ID card detected. Unable to acquire your underwear quota for this shift.", WARDROBE_BLIND_MESSAGE(H))
 			return

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -143,7 +143,7 @@
 		return
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
-		var/obj/item/card/id/id = H.GetIdCard()
+		var/obj/item/card/id/id = H.get_id_card()
 		if(id)
 			id.icon_state = "gold"
 			id.access = get_all_accesses()

--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -11,7 +11,7 @@
 		return chest.attackby(W,user)
 
 	// Lock or unlock the access panel.
-	if(W.GetIdCard())
+	if(W.get_id_card())
 		if(subverted)
 			locked = 0
 			to_chat(user, "<span class='danger'>It looks like the locking system has been shorted out.</span>")

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -102,7 +102,7 @@
 /obj/item/clothing/accessory/badge/holo/attackby(var/obj/item/O, var/mob/user)
 	if(istype(O, /obj/item/card/id) || istype(O, /obj/item/modular_computer))
 
-		var/obj/item/card/id/id_card = O.GetIdCard()
+		var/obj/item/card/id/id_card = O.get_id_card()
 
 		if(!id_card)
 			return

--- a/code/modules/economy/cael/ATM.dm
+++ b/code/modules/economy/cael/ATM.dm
@@ -443,7 +443,7 @@
 
 /obj/machinery/atm/proc/scan_user(mob/living/carbon/human/human_user)
 	if(!authenticated_account)
-		var/obj/item/card/id/I = human_user.GetIdCard()
+		var/obj/item/card/id/I = human_user.get_id_card()
 		if(istype(I))
 			return I
 

--- a/code/modules/economy/cael/Accounts_DB.dm
+++ b/code/modules/economy/cael/Accounts_DB.dm
@@ -48,7 +48,7 @@
 	data["src"] = "\ref[src]"
 	data["id_inserted"] = !!held_card
 	data["id_card"] = held_card ? text("[held_card.registered_name], [held_card.assignment]") : "-----"
-	data["access_level"] = has_access(needed_access, held_card && held_card.GetAccess())
+	data["access_level"] = has_access(needed_access, held_card && held_card.get_access())
 	data["machine_id"] = machine_id
 	data["creating_new_account"] = creating_new_account
 	data["detailed_account_view"] = !!detailed_account_view

--- a/code/modules/economy/cael/EFTPOS.dm
+++ b/code/modules/economy/cael/EFTPOS.dm
@@ -35,10 +35,10 @@
 	txt += "2. Lock the new transaction. If you want to modify or cancel the transaction, you simply have to reset your EFTPOS device.<br>"
 	txt += "3. Give the EFTPOS device to your customer, he/she must finish the transaction by swiping their ID card or a charge card with enough funds.<br>"
 	txt += "4. If everything is done correctly, the money will be transferred. To unlock the device you will have to reset the EFTPOS device.<br>"
-	
+
 	var/obj/item/paper/R = new(src.loc, null, txt, "Steps to success: Correct EFTPOS Usage")
 	R.apply_custom_stamp(
-		overlay_image('icons/obj/bureaucracy.dmi', icon_state = "paper_stamp-boss", flags = RESET_COLOR), 
+		overlay_image('icons/obj/bureaucracy.dmi', icon_state = "paper_stamp-boss", flags = RESET_COLOR),
 		"by \the [src]")
 
 	//by default, connect to the station account
@@ -46,14 +46,14 @@
 	linked_account = station_account
 
 /obj/item/eftpos/proc/print_reference()
-	var/obj/item/paper/R = new(src.loc, null, 
-		"<b>[eftpos_name] reference</b><br><br>Access code: [access_code]<br><br><b>Do not lose or misplace this code.</b><br>", 
+	var/obj/item/paper/R = new(src.loc, null,
+		"<b>[eftpos_name] reference</b><br><br>Access code: [access_code]<br><br><b>Do not lose or misplace this code.</b><br>",
 		"Reference: [eftpos_name]")
 	R.apply_custom_stamp(
-		overlay_image('icons/obj/bureaucracy.dmi', icon_state = "paper_stamp-boss", flags = RESET_COLOR), 
+		overlay_image('icons/obj/bureaucracy.dmi', icon_state = "paper_stamp-boss", flags = RESET_COLOR),
 		"by the [src]")
-	
-	
+
+
 	var/obj/item/parcel/D = new(R.loc, null, R, "EFTPOS access code")
 	D.attach_label(usr, null, "EFTPOS access code")
 
@@ -87,7 +87,7 @@
 
 /obj/item/eftpos/attackby(obj/item/O, user)
 
-	var/obj/item/card/id/I = O.GetIdCard()
+	var/obj/item/card/id/I = O.get_id_card()
 
 	if(I)
 		if(linked_account)

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -344,4 +344,4 @@
 		return 1
 
 /obj/machinery/computer/HolodeckControl/proc/cantogglelock(var/mob/user)
-	return has_access(lock_access, user.GetAccess())
+	return has_access(lock_access, user.get_access())

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -74,10 +74,10 @@
 /obj/item/electronic_assembly/proc/check_interactivity(mob/user)
 	return (!user.incapacitated() && CanUseTopic(user))
 
-/obj/item/electronic_assembly/GetAccess()
+/obj/item/electronic_assembly/get_access(var/union = TRUE)
 	. = list()
 	for(var/obj/item/integrated_circuit/output/O in assembly_components)
-		var/o_access = O.GetAccess()
+		var/o_access = O.get_access()
 		. |= o_access
 
 /obj/item/electronic_assembly/Bump(atom/AM)

--- a/code/modules/integrated_electronics/subtypes/access.dm
+++ b/code/modules/integrated_electronics/subtypes/access.dm
@@ -19,8 +19,8 @@
 	spawn_flags = 0
 
 /obj/item/integrated_circuit/input/card_reader/attackby_react(obj/item/I, mob/user, intent)
-	var/obj/item/card/id/card = I.GetIdCard()
-	var/list/access = I.GetAccess()
+	var/obj/item/card/id/card = I.get_id_card()
+	var/list/access = I.get_access()
 	var/json_access = json_encode(access)
 	var/passkey = add_data_signature(json_access)
 
@@ -65,12 +65,12 @@
 	// check if the signature is valid
 	if(!check_data_signature(signature, result))
 		return FALSE
-	
+
 	if(length(result) > 1)
 		result = cached_json_decode(result)
 	else
 		result = list(result)
 	access = result
 
-/obj/item/integrated_circuit/output/access_displayer/GetAccess()
+/obj/item/integrated_circuit/output/access_displayer/get_access(var/union = TRUE)
 	return access

--- a/code/modules/mechs/mech.dm
+++ b/code/modules/mechs/mech.dm
@@ -208,7 +208,7 @@
 /mob/living/exosuit/return_air()
 	return (body && body.pilot_coverage >= 100 && hatch_closed && body.cockpit) ? body.cockpit : loc.return_air()
 
-/mob/living/exosuit/GetIdCards()
+/mob/living/exosuit/get_id_cards()
 	. = ..()
 	if(istype(access_card))
 		LAZYDISTINCTADD(., access_card)

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -294,7 +294,7 @@
 	access_card.access = saved_access?.Copy()
 	if(sync_access)
 		for(var/mob/pilot in pilots)
-			access_card.access |= pilot.GetAccess()
+			access_card.access |= pilot.get_access()
 			to_chat(pilot, SPAN_NOTICE("Security access permissions synchronized."))
 
 /mob/living/exosuit/proc/eject(var/mob/user, var/silent)

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -85,7 +85,7 @@
 	explode()
 
 /mob/living/bot/attackby(var/obj/item/O, var/mob/user)
-	if(O.GetIdCard())
+	if(O.get_id_card())
 		if(access_scanner.allowed(user) && !open)
 			locked = !locked
 			to_chat(user, "<span class='notice'>Controls are now [locked ? "locked." : "unlocked."]</span>")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -158,7 +158,7 @@
 		var/perpname = "wot"
 		var/criminal = "None"
 
-		var/obj/item/card/id/check_id = GetIdCard()
+		var/obj/item/card/id/check_id = get_id_card()
 		if(istype(check_id))
 			perpname = check_id.registered_name
 		else
@@ -178,7 +178,7 @@
 		var/perpname = "wot"
 		var/medical = "None"
 
-		var/obj/item/card/id/check_id = GetIdCard()
+		var/obj/item/card/id/check_id = get_id_card()
 		if(istype(check_id))
 			perpname = check_id.registered_name
 		else

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -144,17 +144,17 @@
 
 // Get rank from ID, ID inside PDA, PDA, ID in wallet, etc.
 /mob/living/carbon/human/proc/get_authentification_rank(var/if_no_id = "No id", var/if_no_job = "No job")
-	return GetIdCard()?.position || if_no_job
+	return get_id_card()?.position || if_no_job
 
 //gets assignment from ID or ID inside PDA or PDA itself
 //Useful when player do something with computers
 /mob/living/carbon/human/proc/get_assignment(var/if_no_id = "No id", var/if_no_job = "No job")
-	return GetIdCard()?.assignment || if_no_job
+	return get_id_card()?.assignment || if_no_job
 
 //gets name from ID or ID inside PDA or PDA itself
 //Useful when player do something with computers
 /mob/living/carbon/human/proc/get_authentification_name(var/if_no_id = "Unknown")
-	var/obj/item/card/id/id = GetIdCard()
+	var/obj/item/card/id/id = get_id_card()
 	if(istype(id))
 		return id.registered_name
 	else
@@ -187,7 +187,7 @@
 //Useful when player is being seen by other mobs
 /mob/living/carbon/human/proc/get_id_name(var/if_no_id = "Unknown")
 	. = if_no_id
-	var/obj/item/card/id/I = GetIdCard(exceptions = list(/obj/item/holder))
+	var/obj/item/card/id/I = get_id_card(exceptions = list(/obj/item/holder))
 	if(istype(I))
 		return I.registered_name
 
@@ -219,7 +219,7 @@
 			var/perpname = "wot"
 			var/obj/item/id = get_equipped_item(slot_wear_id_str)
 			if(id)
-				var/obj/item/card/id/I = id.GetIdCard()
+				var/obj/item/card/id/I = id.get_id_card()
 				if(I)
 					perpname = I.registered_name
 				else
@@ -255,7 +255,7 @@
 			var/perpname = "wot"
 			var/read = 0
 
-			var/obj/item/card/id/id = GetIdCard()
+			var/obj/item/card/id/id = get_id_card()
 			if(istype(id))
 				perpname = id.registered_name
 			else
@@ -280,7 +280,7 @@
 			var/perpname = "wot"
 			var/modified = 0
 
-			var/obj/item/card/id/id = GetIdCard()
+			var/obj/item/card/id/id = get_id_card()
 			if(istype(id))
 				perpname = id.registered_name
 			else
@@ -313,7 +313,7 @@
 			var/perpname = "wot"
 			var/read = 0
 
-			var/obj/item/card/id/id = GetIdCard()
+			var/obj/item/card/id/id = get_id_card()
 			if(istype(id))
 				perpname = id.registered_name
 			else

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -960,7 +960,7 @@
 
 		var/obj/item/id = get_equipped_item(slot_wear_id_str)
 		if(id)
-			var/obj/item/card/id/I = id.GetIdCard()
+			var/obj/item/card/id/I = id.get_id_card()
 			if(I)
 				var/datum/job/J = SSjobs.get_by_title(I.GetJobName())
 				if(J)
@@ -974,7 +974,7 @@
 		var/perpname = name
 		var/obj/item/id = get_equipped_item(slot_wear_id_str)
 		if(id)
-			var/obj/item/card/id/I = id.GetIdCard()
+			var/obj/item/card/id/I = id.get_id_card()
 			if(I)
 				perpname = I.registered_name
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -252,9 +252,9 @@ var/global/list/possible_say_verbs = list(
 
 //Overriding this will stop a number of headaches down the track.
 /mob/living/silicon/pai/attackby(obj/item/W, mob/user)
-	var/obj/item/card/id/card = W.GetIdCard()
+	var/obj/item/card/id/card = W.get_id_card()
 	if(card && user.a_intent == I_HELP)
-		var/list/new_access = card.GetAccess()
+		var/list/new_access = card.get_access()
 		idcard.access = new_access
 		visible_message("<span class='notice'>[user] slides [W] across [src].</span>")
 		to_chat(src, SPAN_NOTICE("Your access has been updated!"))

--- a/code/modules/mob/living/simple_animal/crow/crow.dm
+++ b/code/modules/mob/living/simple_animal/crow/crow.dm
@@ -41,7 +41,7 @@
 	messenger_bag = new(src)
 	update_icon()
 
-/mob/living/simple_animal/crow/GetIdCards()
+/mob/living/simple_animal/crow/get_id_cards()
 	. = ..()
 	if (istype(access_card))
 		LAZYDISTINCTADD(., access_card)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -512,7 +512,7 @@ var/global/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HURT)
 		return SAFE_PERP
 
 	//Agent cards lower threatlevel.
-	var/obj/item/card/id/id = GetIdCard()
+	var/obj/item/card/id/id = get_id_card()
 	if(id && istype(id, /obj/item/card/id/syndicate))
 		threatcount -= 2
 	// A proper	CentCom id is hard currency.

--- a/code/modules/mob_holder/_holder.dm
+++ b/code/modules/mob_holder/_holder.dm
@@ -99,10 +99,10 @@
 		return loc.loc
 	return ..()
 
-/obj/item/holder/GetIdCards()
+/obj/item/holder/get_id_cards()
 	. = ..()
 	for(var/mob/M in contents)
-		LAZYDISTINCTADD(., M.GetIdCards())
+		LAZYDISTINCTADD(., M.get_id_cards())
 
 /obj/item/holder/attack_self()
 	for(var/mob/M in contents)

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -128,7 +128,7 @@
 		if(user)
 			ui_interact(user)
 
-/obj/item/modular_computer/GetIdCards()
+/obj/item/modular_computer/get_id_cards()
 	. = ..()
 	var/datum/extension/assembly/assembly = get_extension(src, /datum/extension/assembly)
 	var/obj/item/stock_parts/computer/card_slot/card_slot = assembly.get_component(PART_CARD)

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -112,15 +112,15 @@
 	if(nanomodule_path)
 		NM = new nanomodule_path(src, new /datum/topic_manager/program(src), src)
 		if(user)
-			NM.using_access = computer.get_access() // Nano modules nab access from users in their get_access() proc so don't bother adding it
-													// to the using list as well.
+			NM.using_access = computer.get_os_access() // Nano modules nab access from users in their get_access() proc so don't bother adding it
+													   // to the using list as well.
 	if(requires_network && network_destination)
 		generate_network_log("Connection opened to [network_destination].")
 	return 1
 
 /datum/computer_file/program/proc/update_access()
 	if(NM)
-		NM.using_access = computer.get_access()
+		NM.using_access = computer.get_os_access()
 
 // Use this proc to kill the program. Designed to be implemented by each program if it requires on-quit logic, such as the NTNRC client.
 /datum/computer_file/program/proc/on_shutdown(var/forced = 0)

--- a/code/modules/modular_computers/file_system/programs/command/accounts.dm
+++ b/code/modules/modular_computers/file_system/programs/command/accounts.dm
@@ -154,14 +154,14 @@
 				module.selected_parent_group = null // Just in case.
 				return TOPIC_REFRESH
 			var/list/group_dict = net_acl.get_group_dict()
-			
+
 			if(href_list["create_account"])
 				var/list/account_creation_access
 
 				// Passing null access to create_account will ignore access checks on account servers, so only assign this
 				// if the user doesn't have parent group account creation authorization.
 				if(!net_acl.check_account_creation_auth(computer.get_account()))
-					account_creation_access = NM.get_access(user)
+					account_creation_access = NM.get_user_access(user)
 				var/new_login = input(user, "Input new account login. Login will be sanitized.", "Account Creation") as text|null
 
 				var/login_check = alert(user, "Account login will be [sanitize_for_account(new_login)]. Is this acceptable?","Account Creation", "Yes", "No")
@@ -184,8 +184,8 @@
 				var/list/account_recovery_access
 
 				if(!net_acl.check_account_creation_auth(computer.get_account()))
-					account_recovery_access = NM.get_access(user)
-				
+					account_recovery_access = NM.get_user_access(user)
+
 				var/list/backups = network.get_account_backups(account_recovery_access)
 				if(!length(backups))
 					to_chat(user, SPAN_WARNING("No account backups found on account servers!"))
@@ -194,11 +194,11 @@
 				var/selected_login = input(user, "Select the account backup you would like to recover:", "Account Backups") as anything in backups
 				if(!CanInteract(user, state) || !selected_login)
 					return TOPIC_HANDLED
-				
+
 				if(network.find_account_by_login(selected_login))
 					to_chat(user, SPAN_WARNING("An account with that login already exists on the network! Cannot recover backup."))
 					return TOPIC_HANDLED
-				
+
 				var/datum/computer_file/data/account/backup = backups[selected_login]
 				backup.backup = FALSE
 				backup.filename = replacetext(backup.filename, backup.copy_string, null) // Remove the backup signifier on the file.
@@ -216,7 +216,7 @@
 					return TOPIC_REFRESH
 				// This is a parent group, or group submanagement is disabled - no matter what, direct access to the ACL is required.
 				if(is_parent_group || !net_acl.allow_submanagement)
-					if(!net_acl.has_access(module.get_access(user)))
+					if(!net_acl.has_access(module.get_user_access(user)))
 						to_chat(user, SPAN_WARNING("Access denied."))
 						return TOPIC_HANDLED
 					if(group_name in module.selected_account.groups)
@@ -228,7 +228,7 @@
 					// is a member of the parent group.
 					var/datum/computer_file/data/account/A = computer.get_account()
 					var/is_parent_member = (module.selected_parent_group in A.groups)
-					if(is_parent_member || net_acl.has_access(module.get_access(user)))
+					if(is_parent_member || net_acl.has_access(module.get_user_access(user)))
 						if(group_name in module.selected_account.groups)
 							module.selected_account.groups -= group_name
 						else
@@ -244,17 +244,17 @@
 							module.selected_account.parent_groups |= module.selected_parent_group
 							return TOPIC_REFRESH
 					module.selected_account.parent_groups -= module.selected_parent_group
-				
+
 			if(href_list["select_parent_group"])
 				if(module.selected_parent_group)
 					return TOPIC_REFRESH
 				var/parent_group = href_list["select_parent_group"]
 				if(parent_group in group_dict)
 					// In order to see child group membership, you need submanagement access or direct ACL access.
-					if(!net_acl.has_access(module.get_access(user)))
+					if(!net_acl.has_access(module.get_user_access(user)))
 						if(net_acl.allow_submanagement)
 							var/list/child_access = list("[parent_group].[network.network_id]")
-							if(!has_access(child_access, module.get_access(user)))
+							if(!has_access(child_access, module.get_user_access(user)))
 								to_chat(user, SPAN_WARNING("Access denied."))
 								return TOPIC_HANDLED
 						else

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -26,7 +26,7 @@
 	data["assignments"] = show_assignments
 	data["have_id_slot"] = !!card_slot
 	data["have_printer"] = program.computer.has_component(PART_PRINTER)
-	data["authenticated"] = program.get_file_perms(get_access(user), user) & OS_WRITE_ACCESS
+	data["authenticated"] = program.get_file_perms(get_user_access(user), user) & OS_WRITE_ACCESS
 	if(!data["have_id_slot"] || !data["have_printer"])
 		mod_mode = 0 //We can't modify IDs when there is no card reader
 	if(card_slot)
@@ -127,14 +127,14 @@
 		to_chat(usr, SPAN_WARNING("No log exists for this job: [rank]"))
 		return
 
-	return jobdatum.get_access()
+	return jobdatum.get_job_access()
 
 /datum/computer_file/program/card_mod/Topic(href, href_list)
 	if(..())
 		return 1
 
 	var/mob/user = usr
-	var/obj/item/card/id/user_id_card = user.GetIdCard()
+	var/obj/item/card/id/user_id_card = user.get_id_card()
 	var/obj/item/card/id/id_card = computer.get_inserted_id()
 
 	var/datum/nano_module/program/card_mod/module = NM
@@ -150,7 +150,7 @@
 			else
 				module.show_assignments = 1
 		if("print")
-			if(!(get_file_perms(module.get_access(user), user) & OS_WRITE_ACCESS))
+			if(!(get_file_perms(module.get_user_access(user), user) & OS_WRITE_ACCESS))
 				to_chat(usr, SPAN_WARNING("Access denied."))
 				return
 			if(computer.has_component(PART_PRINTER)) //This option should never be called if there is no printer
@@ -192,7 +192,7 @@
 			else
 				card_slot.insert_id(user.get_active_hand(), user)
 		if("terminate")
-			if(!(get_file_perms(module.get_access(user), user) & OS_WRITE_ACCESS))
+			if(!(get_file_perms(module.get_user_access(user), user) & OS_WRITE_ACCESS))
 				to_chat(usr, SPAN_WARNING("Access denied."))
 				return
 			if(computer)
@@ -200,7 +200,7 @@
 				remove_nt_access(id_card)
 				callHook("terminate_employee", list(id_card))
 		if("edit")
-			if(!(get_file_perms(module.get_access(user), user) & OS_WRITE_ACCESS))
+			if(!(get_file_perms(module.get_user_access(user), user) & OS_WRITE_ACCESS))
 				to_chat(usr, SPAN_WARNING("Access denied."))
 				return
 			if(computer)
@@ -274,7 +274,7 @@
 						remove_nt_access(id_card)
 						apply_access(id_card, access)
 		if("assign")
-			if(!(get_file_perms(module.get_access(user), user) & OS_WRITE_ACCESS))
+			if(!(get_file_perms(module.get_user_access(user), user) & OS_WRITE_ACCESS))
 				to_chat(usr, SPAN_WARNING("Access denied."))
 				return
 			if(computer && id_card)
@@ -302,7 +302,7 @@
 				var/access_type = href_list["access_target"]
 				var/access_allowed = text2num(href_list["allowed"])
 				if(access_type in get_access_ids(ACCESS_TYPE_STATION|ACCESS_TYPE_CENTCOM))
-					for(var/access in module.get_access(user))
+					for(var/access in module.get_user_access(user))
 						var/region_type = get_access_region_by_id(access_type)
 						if(access in global.using_map.access_modify_region[region_type])
 							id_card.access -= access_type

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -109,7 +109,7 @@
 
 /datum/nano_module/program/comm/proc/is_authenticated(var/mob/user)
 	if(program)
-		return program.get_file_perms(get_access(user), user) & OS_READ_ACCESS
+		return program.get_file_perms(get_user_access(user), user) & OS_READ_ACCESS
 	return 1
 
 /datum/nano_module/program/comm/proc/get_shunt()
@@ -155,7 +155,7 @@
 			. = 1
 			if(is_authenticated(user) && !issilicon(usr) && ntn_comm)
 				if(user)
-					var/obj/item/card/id/id_card = user.GetIdCard()
+					var/obj/item/card/id/id_card = user.get_id_card()
 					crew_announcement.announcer = GetNameAndAssignmentFromId(id_card)
 				else
 					crew_announcement.announcer = "Unknown"

--- a/code/modules/modular_computers/file_system/programs/engineering/network_monitoring.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/network_monitoring.dm
@@ -57,7 +57,7 @@
 			mainframes.Add(list(rdata))
 		data["mainframes"] = mainframes
 
-		if(length(network.get_mainframes_by_role(MF_ROLE_LOG_SERVER, user.GetAccess())))
+		if(length(network.get_mainframes_by_role(MF_ROLE_LOG_SERVER, user.get_access())))
 			var/list/logs[0]
 			for(var/datum/extension/network_device/mainframe/M in network.get_mainframes_by_role(MF_ROLE_LOG_SERVER, user))
 				var/list/logdata[0]

--- a/code/modules/modular_computers/file_system/programs/engineering/power_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/power_monitor.dm
@@ -103,7 +103,7 @@
 
 /datum/nano_module/program/power_monitor/proc/is_sysadmin(var/mob/user)
 	if(program)
-		has_access(list(access_network), get_access(user))
+		has_access(list(access_network), get_user_access(user))
 	return FALSE
 
 // Allows us to process UI clicks, which are relayed in form of hrefs.

--- a/code/modules/modular_computers/file_system/programs/generic/deck_management.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/deck_management.dm
@@ -104,7 +104,7 @@
 					L["name"] = report.display_name()
 					L["index"] = i
 					L["exists"] = locate(report) in selected_mission.other_reports
-					L["access_edit"] = report.get_file_perms(get_access(user), user) & OS_WRITE_ACCESS
+					L["access_edit"] = report.get_file_perms(get_user_access(user), user) & OS_WRITE_ACCESS
 					other_reports += list(L)
 				data["other_reports"] = other_reports
 
@@ -114,7 +114,7 @@
 			if(!istype(selected_report))
 				prog_state = DECK_MISSION_DETAILS
 				return
-			data["report_data"] = selected_report.generate_nano_data(get_access(user), user)
+			data["report_data"] = selected_report.generate_nano_data(get_user_access(user), user)
 			data["shuttle_name"] = selected_shuttle.name
 			data["mission_data"] = generate_mission_data(selected_mission)
 			data["view_only"] = can_view_only
@@ -297,14 +297,14 @@
 			return 1
 		var/field_ID = text2num(href_list["ID"])
 		var/datum/report_field/field = selected_report.field_from_ID(field_ID)
-		if(!field || !(field.get_perms(get_access(user), user) & OS_WRITE_ACCESS))
+		if(!field || !(field.get_perms(get_user_access(user), user) & OS_WRITE_ACCESS))
 			return 1
 		field.ask_value(user) //Handles the remaining IO.
 		return 1
 	if(href_list["submit"])
 		if(!ensure_valid_mission() || !selected_report)
 			return 1
-		if(!(selected_report.get_file_perms(get_access(user), user) & OS_WRITE_ACCESS))
+		if(!(selected_report.get_file_perms(get_user_access(user), user) & OS_WRITE_ACCESS))
 			return 1
 		var/datum/shuttle_log/my_log = SSshuttle.shuttle_logs[selected_shuttle]
 		if(my_log.submit_report(selected_mission, selected_report, user))
@@ -355,7 +355,7 @@
 		var/datum/report_field/people/manifest = selected_mission.flight_plan.manifest
 		if(!manifest.get_value())
 			return 1
-		manifest.send_email(user, get_access(user))
+		manifest.send_email(user, get_user_access(user))
 		return 1
 
 #undef DECK_HOME

--- a/code/modules/modular_computers/file_system/programs/generic/file_manager.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/file_manager.dm
@@ -61,7 +61,7 @@
 		return
 
 	var/mob/user = usr
-	var/list/accesses = computer.get_access(user)
+	var/list/accesses = computer.get_os_access(user)
 
 	error = null
 	if(file_error)
@@ -570,7 +570,7 @@
 	if(!.)
 		return
 	var/list/data = computer.initial_data()
-	var/list/accesses = computer.get_access(user)
+	var/list/accesses = computer.get_os_access(user)
 
 	if(current_index > disks.len) // Safety check.
 		current_index = null

--- a/code/modules/modular_computers/file_system/programs/generic/folding.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/folding.dm
@@ -45,7 +45,7 @@
 	if(href_list["collect"] && started_on > 0 && program_status != PROGRAM_STATUS_CRASHED)
 		if(started_on + current_interval > world.timeofday)
 			return TOPIC_HANDLED // not ready to collect.
-		var/obj/item/card/id/I = usr.GetIdCard()
+		var/obj/item/card/id/I = usr.get_id_card()
 		if(!I)
 			to_chat(usr, SPAN_WARNING("Unable to locate ID card for transaction."))
 			return TOPIC_HANDLED

--- a/code/modules/modular_computers/file_system/programs/generic/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntdownloader.dm
@@ -149,7 +149,7 @@
 			var/list/category_list[0]
 			for(var/datum/computer_file/program/P in net.get_software_list(category))
 				// Only those programs our user can run will show in the list
-				if(!P.can_run(get_access(user), user, FALSE) && P.requires_access_to_download)
+				if(!P.can_run(get_user_access(user), user, FALSE) && P.requires_access_to_download)
 					continue
 				if(!P.is_supported_by_hardware(program.computer.get_hardware_flag(), user, FALSE))
 					continue

--- a/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
@@ -87,7 +87,7 @@
 				channel = null
 			return 1
 		var/mob/living/user = usr
-		if(has_access(list(access_network), usr.GetAccess()))
+		if(has_access(list(access_network), usr.get_access()))
 			if(channel)
 				var/response = alert(user, "Really engage admin-mode? You will be disconnected from your current channel!", "NTNRC Admin mode", "Yes", "No")
 				if(response == "Yes")

--- a/code/modules/modular_computers/file_system/programs/generic/records.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/records.dm
@@ -51,7 +51,7 @@
 
 
 /datum/nano_module/program/records/proc/get_record_access(var/mob/user)
-	var/list/user_access = get_access(user)
+	var/list/user_access = get_user_access(user)
 
 	var/obj/PC = nano_host()
 	var/datum/extension/interactive/os/os = get_extension(PC, /datum/extension/interactive/os)
@@ -68,7 +68,7 @@
 	var/datum/report_field/F = R.field_from_ID(field_ID)
 	if(!F)
 		return
-	if(!(F.get_perms(get_access(user),user) & OS_WRITE_ACCESS))
+	if(!(F.get_perms(get_user_access(user),user) & OS_WRITE_ACCESS))
 		to_chat(user, "<span class='notice'>\The [nano_host()] flashes an \"Access Denied\" warning.</span>")
 		return
 	F.ask_value(user)
@@ -86,7 +86,7 @@
 		var/ID = text2num(href_list["set_active"])
 		for(var/datum/computer_file/report/crew_record/R in get_records())
 			if(R.uid == ID)
-				if(R.get_file_perms(get_access(usr), usr) & OS_READ_ACCESS)
+				if(R.get_file_perms(get_user_access(usr), usr) & OS_READ_ACCESS)
 					active_record = R
 				else
 					to_chat(usr, SPAN_WARNING("Access Denied"))
@@ -97,7 +97,7 @@
 		if(!network)
 			to_chat(usr, SPAN_WARNING("Network error."))
 			return
-		var/list/accesses = get_access(usr)
+		var/list/accesses = get_user_access(usr)
 		if(!network.get_mainframes_by_role(MF_ROLE_CREW_RECORDS, accesses))
 			to_chat(usr, SPAN_WARNING("You may not have access to generate new crew records, or there may not be a crew record mainframe active on the network."))
 			return
@@ -124,12 +124,12 @@
 		if(!search)
 			return
 		for(var/datum/computer_file/report/crew_record/R in get_records())
-			if(!(R.get_file_perms(get_access(usr), usr) & OS_READ_ACCESS))
+			if(!(R.get_file_perms(get_user_access(usr), usr) & OS_READ_ACCESS))
 				continue
 			var/datum/report_field/field = R.field_from_name(field_name)
 			if(!field.searchable)
 				continue
-			if(!(field.get_perms(get_access(usr), usr) & OS_READ_ACCESS))
+			if(!(field.get_perms(get_user_access(usr), usr) & OS_READ_ACCESS))
 				continue
 			if(findtext(lowertext(field.get_value()), lowertext(search)))
 				active_record = R

--- a/code/modules/modular_computers/file_system/programs/generic/reports.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/reports.dm
@@ -24,14 +24,14 @@
 	switch(prog_state)
 		if(REPORTS_VIEW)
 			if(selected_report)
-				data["report_data"] = selected_report.generate_nano_data(get_access(user), user)
+				data["report_data"] = selected_report.generate_nano_data(get_user_access(user), user)
 			data["view_only"] = can_view_only
 			data["printer"] = program.computer.has_component(PART_PRINTER)
 		if(REPORTS_DOWNLOAD)
 			var/list/L = list()
 			var/datum/computer_network/net = program.computer.get_network()
 			if(net)
-				for(var/datum/computer_file/report/report in net.fetch_reports(get_access(user)))
+				for(var/datum/computer_file/report/report in net.fetch_reports(get_user_access(user)))
 					var/M = list()
 					M["name"] = report.display_name()
 					M["uid"] = report.uid
@@ -86,12 +86,12 @@
 		var/datum/computer_file/report/chosen_report = choices[choice]
 		var/editing = alert(user, "Would you like to view or edit the report", "Loading Report", "View", "Edit")
 		if(editing == "View")
-			if(!(chosen_report.get_file_perms(get_access(user), user) & OS_READ_ACCESS))
+			if(!(chosen_report.get_file_perms(get_user_access(user), user) & OS_READ_ACCESS))
 				to_chat(user, "<span class='warning'>You lack access to view this report.</span>")
 				return
 			can_view_only = 1
 		else
-			if(!(chosen_report.get_file_perms(get_access(user), user) & OS_WRITE_ACCESS))
+			if(!(chosen_report.get_file_perms(get_user_access(user), user) & OS_WRITE_ACCESS))
 				to_chat(user, "<span class='warning'>You lack access to edit this report.</span>")
 				return
 			can_view_only = 0
@@ -118,15 +118,15 @@
 			return 1
 		var/save_as = text2num(href_list["save_as"])
 		var/req_access = save_as ? OS_READ_ACCESS : OS_WRITE_ACCESS
-		if(!(selected_report.get_file_perms(get_access(user), user) & req_access))
+		if(!(selected_report.get_file_perms(get_user_access(user), user) & req_access))
 			return 1
 		save_report(user, save_as)
 	if(href_list["submit"])
 		if(!selected_report)
 			return 1
-		if(!(selected_report.get_file_perms(get_access(user), user) & OS_WRITE_ACCESS))
+		if(!(selected_report.get_file_perms(get_user_access(user), user) & OS_WRITE_ACCESS))
 			return 1
-		if(selected_report.submit(user, get_access(user)))
+		if(selected_report.submit(user, get_user_access(user)))
 			to_chat(user, "The [src] has been submitted.")
 			if(alert(user, "Would you like to save a copy?","Save Report", "Yes.", "No.") == "Yes.")
 				save_report(user)
@@ -141,24 +141,24 @@
 			return 1
 		var/field_ID = text2num(href_list["ID"])
 		var/datum/report_field/field = selected_report.field_from_ID(field_ID)
-		if(!field || !(field.get_perms(get_access(usr), usr) & OS_WRITE_ACCESS))
+		if(!field || !(field.get_perms(get_user_access(usr), usr) & OS_WRITE_ACCESS))
 			return 1
 		field.ask_value(user) //Handles the remaining IO.
 		return 1
 	if(href_list["print"])
-		if(!selected_report || !(selected_report.get_file_perms(get_access(user), user) & OS_READ_ACCESS))
+		if(!selected_report || !(selected_report.get_file_perms(get_user_access(user), user) & OS_READ_ACCESS))
 			return 1
 		var/with_fields = text2num(href_list["print_mode"])
-		var/text = selected_report.generate_pencode(get_access(user), user, with_fields)
+		var/text = selected_report.generate_pencode(get_user_access(user), user, with_fields)
 		if(!program.computer.print_paper(text, selected_report.display_name()))
 			to_chat(user, "Hardware error: Printer was unable to print the file. It may be out of paper.")
 		return 1
 	if(href_list["export"])
-		if(!selected_report || !(selected_report.get_file_perms(get_access(user), user) & OS_READ_ACCESS))
+		if(!selected_report || !(selected_report.get_file_perms(get_user_access(user), user) & OS_READ_ACCESS))
 			return 1
 		var/datum/computer_file/data/text/file = new
 		selected_report.rename_file()
-		file.stored_data = selected_report.generate_pencode(get_access(user), user, no_html = 1) //TXT files can't have html; they use pencode only.
+		file.stored_data = selected_report.generate_pencode(get_user_access(user), user, no_html = 1) //TXT files can't have html; they use pencode only.
 		file.filename = selected_report.filename
 		if(program.computer.store_file(file, "reports", create_directories = TRUE))
 			to_chat(user, "The report has been exported as '[file.filename].[file.filetype]'.")
@@ -172,7 +172,7 @@
 	if(href_list["get_report"])
 		var/uid = text2num(href_list["report"])
 		var/datum/computer_network/net = program.computer.get_network()
-		for(var/datum/computer_file/report/report in net.fetch_reports(get_access(user), user))
+		for(var/datum/computer_file/report/report in net.fetch_reports(get_user_access(user), user))
 			if(report.uid == uid)
 				selected_report = report.Clone()
 				can_view_only = 0

--- a/code/modules/modular_computers/file_system/programs/generic/wordprocessor.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/wordprocessor.dm
@@ -45,7 +45,7 @@
 	error = "I/O error: Unable to open file '[openingfile]'."
 
 /datum/computer_file/program/wordprocessor/proc/save_file(mob/user)
-	var/datum/computer_file/result = computer.save_file(open_file, file_directory, loaded_data, /datum/computer_file/data/text, null, computer.get_access(user), user)
+	var/datum/computer_file/result = computer.save_file(open_file, file_directory, loaded_data, /datum/computer_file/data/text, null, computer.get_os_access(user), user)
 	. = FALSE
 	if(istype(result))
 		to_chat(user, SPAN_NOTICE("Successfully saved file '[open_file]'."))
@@ -117,7 +117,7 @@
 			saving.stored_data = loaded_data
 			view_file_browser(usr, "saveas_file", /datum/computer_file/data/text, OS_WRITE_ACCESS, browser_desc, saving)
 			return TOPIC_HANDLED
-		
+
 		save_file(usr)
 		return TOPIC_REFRESH
 
@@ -125,8 +125,8 @@
 		var/oldtext = html_decode(loaded_data)
 		oldtext = replacetext(oldtext, "\[br\]", "\n")
 		if(open_file)
-			var/datum/computer_file/data/F = get_file(open_file, file_directory, computer.get_access(usr), usr)
-			if(istype(F) && !(F.get_file_perms(computer.get_access(usr), usr) & OS_WRITE_ACCESS))
+			var/datum/computer_file/data/F = get_file(open_file, file_directory, computer.get_os_access(usr), usr)
+			if(istype(F) && !(F.get_file_perms(computer.get_os_access(usr), usr) & OS_WRITE_ACCESS))
 				error = "I/O error: You do not have permission to edit this file."
 				return TOPIC_REFRESH
 		var/newtext = sanitize(replacetext(input(usr, "Editing file '[open_file]'. You may use most tags used in paper formatting:", "Text Editor", oldtext) as message|null, "\n", "\[br\]"), MAX_TEXTFILE_LENGTH)

--- a/code/modules/modular_computers/file_system/programs/research/email_administration.dm
+++ b/code/modules/modular_computers/file_system/programs/research/email_administration.dm
@@ -57,7 +57,7 @@
 		data["messagecount"] = all_messages.len
 	else
 		var/list/all_accounts = list()
-		for(var/datum/computer_file/data/account/account in network.get_accounts(get_access(user)))
+		for(var/datum/computer_file/data/account/account in network.get_accounts(get_user_access(user)))
 			if(!account.can_login)
 				continue
 			all_accounts.Add(list(list(
@@ -125,5 +125,5 @@
 		return TOPIC_REFRESH
 
 	if(href_list["viewaccount"])
-		current_account = network.find_account_by_login(href_list["viewaccount"], get_access(user))
+		current_account = network.find_account_by_login(href_list["viewaccount"], get_user_access(user))
 		return TOPIC_REFRESH

--- a/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
+++ b/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
@@ -37,7 +37,7 @@ var/global/list/all_warrants
 /datum/nano_module/program/digitalwarrant/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = global.default_topic_state)
 	var/list/data = host.initial_data()
 
-	var/list/accesses = get_access(user)
+	var/list/accesses = get_user_access(user)
 
 	if(active)
 		data["details"] = active.generate_nano_data(accesses, user)
@@ -56,7 +56,7 @@ var/global/list/all_warrants
 /datum/nano_module/program/digitalwarrant/Topic(href, href_list)
 	if(..())
 		return 1
-	var/list/accesses = get_access(usr)
+	var/list/accesses = get_user_access(usr)
 	var/list/avail_warrants = get_warrants(accesses, usr)
 
 	if(href_list["editwarrant"])
@@ -94,7 +94,7 @@ var/global/list/all_warrants
 		if(!active)
 			return
 		broadcast_security_hud_message("[active.get_broadcast_summary()] has been [(active in global.all_warrants) ? "edited" : "uploaded"].", nano_host())
-		
+
 		var/success = save_warrant(active, accesses, usr)
 		if(success != OS_FILE_SUCCESS)
 			to_chat(usr, SPAN_WARNING("Could not save warrant. You may lack access to the file servers."))

--- a/code/modules/modular_computers/file_system/programs/security/turret_control.dm
+++ b/code/modules/modular_computers/file_system/programs/security/turret_control.dm
@@ -20,7 +20,7 @@
 	var/list/area_turrets = list() // Dictionary of area name -> turret
 	var/datum/computer_network/network = get_network()
 	if(network)
-		var/list/turrets = network.get_devices_by_type(/obj/machinery/turret/network, get_access(user))
+		var/list/turrets = network.get_devices_by_type(/obj/machinery/turret/network, get_user_access(user))
 		for(var/obj/machinery/turret/network/net_turret in turrets)
 			var/area/A = get_area(net_turret)
 			var/area_name = A.name
@@ -54,7 +54,7 @@
 		return TOPIC_REFRESH
 	if(href_list["turret"])
 		var/datum/extension/network_device/turret_device = network.get_device_by_tag(href_list["turret"])
-		if(!turret_device || !turret_device.has_access(module.get_access(user)))
+		if(!turret_device || !turret_device.has_access(module.get_user_access(user)))
 			return TOPIC_REFRESH
 		var/obj/machinery/turret/network/net_turret = turret_device.holder
 		if(href_list["settings"])

--- a/code/modules/modular_computers/file_system/reports/people.dm
+++ b/code/modules/modular_computers/file_system/reports/people.dm
@@ -13,7 +13,7 @@
 		if(access)
 			user_access = access.Copy()
 		else
-			var/obj/item/card/id/I = user.GetIdCard()
+			var/obj/item/card/id/I = user.get_id_card()
 			if(I)
 				user_access += I.access
 		report_file = new

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -31,7 +31,7 @@
 			. += "Registered Assignment: [stars(stored_card.assignment, read_string_stability)]\n"
 			. += "Registered Position: [stars(stored_card.position, read_string_stability)]\n"
 			. += "Access Addresses Enabled: \n"
-			var/list/access_list = stored_card.GetAccess()
+			var/list/access_list = stored_card.get_access()
 			if(!access_list) // "NONE" for empty list
 				. += "NONE"
 			else

--- a/code/modules/modular_computers/networking/accounts/_network_accounts.dm
+++ b/code/modules/modular_computers/networking/accounts/_network_accounts.dm
@@ -25,7 +25,7 @@
 				continue
 			if(E.backup)
 				result[E.login] = E
-	
+
 	return result
 
 /datum/computer_network/proc/add_account(datum/computer_file/data/account/acc, accesses)
@@ -75,7 +75,7 @@
 		mind.initial_account_login["password"] = password
 		mind.account_network = network_id
 	StoreMemory("Your [network_id] login is [login] and the password is [password].", /decl/memory_options/system)
-	var/obj/item/card/id/I = GetIdCard()
+	var/obj/item/card/id/I = get_id_card()
 	if(I)
 		I.associated_network_account = list("login" = login, "password" = password)
 
@@ -83,7 +83,7 @@
 	if(mind)
 		mind.initial_account_login["login"] = login
 	StoreMemory("Your network account login has been changed to [login].", /decl/memory_options/system)
-	var/obj/item/card/id/I = GetIdCard()
+	var/obj/item/card/id/I = get_id_card()
 	if(I && I.associated_network_account)
 		I.associated_network_account["login"] = login
 

--- a/code/modules/modular_computers/networking/accounts/id_card.dm
+++ b/code/modules/modular_computers/networking/accounts/id_card.dm
@@ -8,7 +8,7 @@
 	set_extension(src, /datum/extension/network_device/id_card)
 	return ..()
 
-/obj/item/card/id/network/GetAccess(var/ignore_account)
+/obj/item/card/id/network/get_access(var/ignore_account)
 	. = ..()
 	var/datum/computer_file/data/account/access_account = resolve_account()
 	var/datum/extension/network_device/D = get_extension(src, /datum/extension/network_device)
@@ -86,7 +86,7 @@
 
 		current_account = null
 		return TOPIC_REFRESH
-	
+
 	if(href_list["login_account"])
 		if(login_account())
 			to_chat(usr, SPAN_NOTICE("Account successfully logged in."))

--- a/code/modules/modular_computers/networking/machinery/telecomms.dm
+++ b/code/modules/modular_computers/networking/machinery/telecomms.dm
@@ -231,7 +231,7 @@ var/global/list/telecomms_hubs = list()
 	var/list/data = list()
 	var/datum/extension/network_device/device = get_extension(src, /datum/extension/network_device)
 	data["network_id"] = device.network_tag
-	data["authenticated"] = (access_keycard_auth in user.GetAccess())
+	data["authenticated"] = (access_keycard_auth in user.get_access())
 	var/list/data_channels = list()
 	for(var/datum/radio_channel/channel_datum in channels)
 		var/list/channel_data = list()
@@ -288,7 +288,7 @@ var/global/list/telecomms_hubs = list()
 
 					var/lower_freq
 					var/upper_freq
-					if(access_keycard_auth in user.GetAccess())
+					if(access_keycard_auth in user.get_access())
 						lower_freq = RADIO_LOW_FREQ
 						upper_freq = RADIO_HIGH_FREQ
 					else
@@ -297,7 +297,7 @@ var/global/list/telecomms_hubs = list()
 
 					var/new_freq = input(user, "Enter a new frequency beween [lower_freq] and [upper_freq].", "Channel Configuration", channel_datum.frequency) as num
 
-					if(access_keycard_auth in user.GetAccess())
+					if(access_keycard_auth in user.get_access())
 						lower_freq = RADIO_LOW_FREQ
 						upper_freq = RADIO_HIGH_FREQ
 					else
@@ -354,7 +354,7 @@ var/global/list/telecomms_hubs = list()
 							if("Clear")
 								channel_datum.secured = null
 							if("Sync to personal access")
-								var/list/new_access = user.GetAccess()
+								var/list/new_access = user.get_access()
 								channel_datum.secured = (new_access && new_access.Copy())
 						. = TOPIC_REFRESH
 

--- a/code/modules/modular_computers/os/_os.dm
+++ b/code/modules/modular_computers/os/_os.dm
@@ -59,7 +59,7 @@
 	if(D)
 		return D.get_network()
 
-/datum/extension/interactive/os/proc/get_access(var/mob/user)
+/datum/extension/interactive/os/proc/get_os_access(var/mob/user)
 	. = list()
 	var/datum/computer_file/data/account/access_account = get_account()
 	if(access_account)
@@ -72,9 +72,9 @@
 			for(var/group in access_account.parent_groups) // Membership in a child group grants access to anything with an access requirement set to the parent group.
 				. += "[group].[location]"
 	if(user)
-		var/obj/item/card/id/I = user.GetIdCard()
+		var/obj/item/card/id/I = user.get_id_card()
 		if(I)
-			. += I.GetAccess(access_account?.login) // Ignore any access that's already on the user account.
+			. += I.get_access(access_account?.login) // Ignore any access that's already on the user account.
 
 // Returns the current account, if possible. User var is passed only for updating program access from ID, if no account is found.
 /datum/extension/interactive/os/proc/get_account(var/mob/user)
@@ -129,7 +129,7 @@
 		P.update_access(user)
 
 /datum/extension/interactive/os/proc/login_prompt(var/mob/user)
-	var/obj/item/card/id/I = user.GetIdCard()
+	var/obj/item/card/id/I = user.get_id_card()
 	var/default_login = I?.associated_network_account["login"]
 	var/default_password = I?.associated_network_account["password"]
 
@@ -213,7 +213,7 @@
 	if(P in running_programs)
 		P.program_state = PROGRAM_STATE_ACTIVE
 		active_program = P
-	else if(P.can_run(get_access(user), user, TRUE))
+	else if(P.can_run(get_os_access(user), user, TRUE))
 		active_program = P
 		P.on_startup(user, src)
 	else

--- a/code/modules/modular_computers/terminal/terminal.dm
+++ b/code/modules/modular_computers/terminal/terminal.dm
@@ -151,15 +151,15 @@
 /datum/terminal/proc/get_account_computer()
 	return computer
 
-/datum/terminal/proc/get_access(mob/user)
+/datum/terminal/proc/get_terminal_user_access(mob/user)
 	var/datum/extension/interactive/os/account_computer = get_account_computer()
-	return(account_computer.get_access(user))
+	return(account_computer.get_os_access(user))
 
 // Returns list(/datum/file_storage, directory) on success. Returns error code on failure.
 /datum/terminal/proc/parse_directory(directory_path, create_directories = FALSE)
 	var/datum/file_storage/target_disk = current_disk
 	var/datum/computer_file/directory/root_dir = current_directory
-	
+
 	if(!length(directory_path))
 		return list(target_disk, root_dir)
 
@@ -168,8 +168,8 @@
 
 	// Otherwise, we append the working directory path to the passed path.
 	var/list/directories = splittext(directory_path, "/")
-	
-	// When splitting the text, there could be blank strings at either end, so remove them. If there's any in the body of the path, there was a 
+
+	// When splitting the text, there could be blank strings at either end, so remove them. If there's any in the body of the path, there was a
 	// missed input, so leave them.
 	if(!length(directories[1]))
 		directories.Cut(1, 2)
@@ -194,7 +194,7 @@
 			if(!target_disk) // Invalid disk entered.
 				return OS_DIR_NOT_FOUND
 			directories.Cut(1, 2)
-			
+
 		break // Any further use of ../ is handled by the hard drive.
 
 	// If we were only pathing to the parent of a directory or to a disk, we can return early.
@@ -208,7 +208,7 @@
 	var/datum/computer_file/directory/target_directory = target_disk.parse_directory(final_path, create_directories)
 	if(!istype(target_directory))
 		return OS_DIR_NOT_FOUND
-	
+
 	return list(target_disk, target_directory)
 
 // Returns list(/datum/file_storage, /datum/computer_file/directory, /datum/computer_file) on success. Returns error code on failure.
@@ -221,7 +221,7 @@
 	var/list/dirs_and_file = splittext(file_path, "/")
 	if(!length(dirs_and_file))
 		return OS_DIR_NOT_FOUND
-	
+
 	// Join together everything but the filename into a path.
 	var/list/file_loc = parse_directory(jointext(dirs_and_file, "/", 1, dirs_and_file.len))
 	if(!islist(file_loc)) // Errored!
@@ -231,7 +231,7 @@
 	var/datum/computer_file/directory/target_dir = file_loc[2]
 	if(!istype(target_disk))
 		return OS_DIR_NOT_FOUND
-	
+
 	var/filename = dirs_and_file[dirs_and_file.len]
 	var/datum/computer_file/target_file = target_disk.get_file(filename, target_dir)
 	if(!istype(target_file))
@@ -265,5 +265,5 @@
 			return "I/O error, Harddrive may be non-functional"
 		if(OS_NETWORK_ERROR)
 			return "Unable to connect to the network"
-	
+
 	return "An unspecified error occured."

--- a/code/modules/modular_computers/terminal/terminal_commands.dm
+++ b/code/modules/modular_computers/terminal/terminal_commands.dm
@@ -63,7 +63,7 @@ var/global/list/terminal_commands
 		return
 	if(!user.skill_check(core_skill, skill_needed))
 		return skill_fail_message()
-	if(!check_access(terminal.get_access(user)))
+	if(!check_access(terminal.get_terminal_user_access(user)))
 		return "[name]: ACCESS DENIED"
 	if(needs_network && !terminal.computer.get_network_status())
 		return "NETWORK ERROR: Check connection and try again."
@@ -329,7 +329,7 @@ Subtypes
 
 	var/datum/file_storage/disk = file_loc[1]
 	var/datum/computer_file/file = file_loc[3]
-	var/deleted = disk.delete_file(file, terminal.get_access(user), user)
+	var/deleted = disk.delete_file(file, terminal.get_terminal_user_access(user), user)
 	if(deleted == OS_FILE_SUCCESS)
 		return "rm: Removed file '[file.filename]'."
 	if(deleted == OS_FILE_NO_WRITE)
@@ -363,7 +363,7 @@ Subtypes
 		return "mv: [get_terminal_error(target_path, file_loc)]."
 
 	// Check file permisisons.
-	var/error = check_file_transfer(destination[2], F, copying, terminal.get_access(user), user)
+	var/error = check_file_transfer(destination[2], F, copying, terminal.get_terminal_user_access(user), user)
 	if(error)
 		return "mv: [error]."
 
@@ -397,7 +397,7 @@ Subtypes
 	var/datum/computer_file/copy = file.Clone(TRUE)
 	if(!istype(copy))
 		return
-	var/success = disk.store_file(copy, file_loc[2], FALSE, terminal.get_access(user), user)
+	var/success = disk.store_file(copy, file_loc[2], FALSE, terminal.get_terminal_user_access(user), user)
 	if(success == OS_FILE_SUCCESS)
 		return "cp: Successfully copied file [file.filename]."
 
@@ -422,7 +422,7 @@ Subtypes
 	var/new_name = sanitize_for_file(rename_args[2])
 
 	if(length(new_name))
-		if(F.unrenamable || !(F.get_file_perms(terminal.get_access(user), user) & OS_WRITE_ACCESS))
+		if(F.unrenamable || !(F.get_file_perms(terminal.get_terminal_user_access(user), user) & OS_WRITE_ACCESS))
 			return "rename: You lack permission to rename [F.filename]."
 		F.filename = new_name
 		return "rename: File renamed to '[new_name]'."
@@ -555,7 +555,7 @@ Subtypes
 	else
 		return "permmod: Invalid flag syntax. Use man command to learn more about permmod flag syntax."
 
-	var/success = F.change_perms(mode, perm, access_key, terminal.get_access(user))
+	var/success = F.change_perms(mode, perm, access_key, terminal.get_terminal_user_access(user))
 	if(success)
 		return "permmod: Successfully changed permissions for [F.filename]."
 	else
@@ -610,7 +610,7 @@ Subtypes
 	else if(length(com_args) == 2)
 		called_args = com_args[2]
 
-	return D.on_command(com_args[1], called_args, terminal.get_access(user))
+	return D.on_command(com_args[1], called_args, terminal.get_terminal_user_access(user))
 
 // Lists the commands available on the target device.
 /datum/terminal_command/listcom

--- a/code/modules/nano/modules/nano_module.dm
+++ b/code/modules/nano/modules/nano_module.dm
@@ -25,12 +25,12 @@
 	return -1
 
 //returns a list.
-/datum/nano_module/proc/get_access(mob/user)
+/datum/nano_module/proc/get_user_access(mob/user)
 	. = using_access.Copy()
 	if(user) // Insist on scanning ID again to make things a little less clunky.
-		var/obj/item/card/id/I = user.GetIdCard()
+		var/obj/item/card/id/I = user.get_id_card()
 		if(I)
-			. |= I.GetAccess()
+			. |= I.get_access()
 
 /datum/nano_module/proc/check_access(var/mob/user, var/access)
 	if(!access)
@@ -39,7 +39,7 @@
 		access = list(access) //listify a single access code.
 	if(has_access(access, using_access))
 		return 1 //This is faster, and often enough.
-	return has_access(access, get_access(user)) //Also checks the mob's ID.
+	return has_access(access, get_user_access(user)) //Also checks the mob's ID.
 
 /datum/nano_module/Topic(href, href_list)
 	if(topic_manager && topic_manager.Topic(href, href_list))

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -447,10 +447,10 @@ var/global/list/adminfaxes     = list()	//cache for faxes that have been sent to
 	if(target_admin_fax)
 		var/list/fax_req_access = target_admin_fax["access"]
 		if(!emagged)
-			if(!has_access(req_access, ID?.GetAccess()))
+			if(!has_access(req_access, ID?.get_access()))
 				to_chat(user, SPAN_WARNING("You do not have the right credentials to use the send function on this device!"))
 				return FALSE
-			if(!has_access(fax_req_access, ID?.GetAccess()))
+			if(!has_access(fax_req_access, ID?.get_access()))
 				to_chat(user, SPAN_WARNING("You do not have the right credentials to send a fax to this recipient!"))
 				return FALSE
 		else if(prob(1))
@@ -496,10 +496,10 @@ var/global/list/adminfaxes     = list()	//cache for faxes that have been sent to
 
 	//Authenticate as needed
 	if(!emagged)
-		if(!has_access(req_access, ID?.GetAccess()))
+		if(!has_access(req_access, ID?.get_access()))
 			to_chat(user, SPAN_WARNING("You do not have the right credentials to use the send function on this device!"))
 			return FALSE
-		if(!has_access(target.req_access, ID?.GetAccess()))
+		if(!has_access(target.req_access, ID?.get_access()))
 			to_chat(user, SPAN_WARNING("You do not have the right credentials to send a fax to this recipient!"))
 			return FALSE
 	else if(prob(1))

--- a/code/modules/research/design_console.dm
+++ b/code/modules/research/design_console.dm
@@ -89,7 +89,7 @@
 		data["tech_levels"] = show_tech_levels
 
 		var/list/found_databases = list()
-		for(var/obj/machinery/design_database/db in network?.get_devices_by_type(/obj/machinery/design_database, user.GetAccess()))
+		for(var/obj/machinery/design_database/db in network?.get_devices_by_type(/obj/machinery/design_database, user.get_access()))
 			var/list/database = list("name" = db.name, "ref" = "\ref[db]")
 			if(db.stat & (BROKEN|NOPOWER))
 				database["status"] = "Offline"
@@ -100,7 +100,7 @@
 		data["connected_databases"] = found_databases
 
 		var/list/found_analyzers = list()
-		for(var/obj/machinery/destructive_analyzer/az in network?.get_devices_by_type(/obj/machinery/destructive_analyzer, user.GetAccess()))
+		for(var/obj/machinery/destructive_analyzer/az in network?.get_devices_by_type(/obj/machinery/destructive_analyzer, user.get_access()))
 			var/list/analyzer = list("name" = az.name, "ref" = "\ref[az]")
 			if(az.stat & (BROKEN|NOPOWER))
 				analyzer["status"] = "Offline"

--- a/code/modules/shuttles/shuttle_emergency.dm
+++ b/code/modules/shuttles/shuttle_emergency.dm
@@ -138,7 +138,7 @@
 	var/auth_name
 	var/dna_hash
 
-	var/obj/item/card/id/ID = ident.GetIdCard()
+	var/obj/item/card/id/ID = ident.get_id_card()
 
 	if(!ID)
 		return

--- a/maps/tradeship/jobs/civilian.dm
+++ b/maps/tradeship/jobs/civilian.dm
@@ -15,7 +15,7 @@
 	minimal_access = list()
 	event_categories = list(ASSIGNMENT_GARDENER, ASSIGNMENT_JANITOR)
 
-/datum/job/tradeship_deckhand/get_access()
+/datum/job/tradeship_deckhand/get_job_access()
 	if(config.assistant_maint)
 		return list(access_maint_tunnels)
 	else

--- a/maps/tradeship/jobs/command.dm
+++ b/maps/tradeship/jobs/command.dm
@@ -35,7 +35,7 @@
 		H.verbs |= /mob/proc/tradehouse_rename_ship
 		H.verbs |= /mob/proc/tradehouse_rename_company
 
-/datum/job/tradeship_captain/get_access()
+/datum/job/tradeship_captain/get_job_access()
 	return get_all_station_access()
 
 /mob/proc/tradehouse_rename_ship()

--- a/mods/content/psionics/machines/psimonitor.dm
+++ b/mods/content/psionics/machines/psimonitor.dm
@@ -36,7 +36,7 @@
 
 		if(href_list["login"])
 
-			var/obj/item/card/id/ID = usr.GetIdCard()
+			var/obj/item/card/id/ID = usr.get_id_card()
 			if(!ID || !allowed(usr))
 				to_chat(usr, "<span class='warning'>Access denied.</span>")
 			else

--- a/mods/species/ascent/items/id_control.dm
+++ b/mods/species/ascent/items/id_control.dm
@@ -6,7 +6,7 @@
 	desc = "A slender, complex chip of alien circuitry."
 	access = list(access_ascent)
 
-/obj/item/card/id/ascent/GetAccess()
+/obj/item/card/id/ascent/get_access(var/union = TRUE)
 	var/mob/living/carbon/human/H = loc
 	if(istype(H) && !(H.species.name in ALL_ASCENT_SPECIES))
 		. = list()
@@ -61,12 +61,12 @@
 		id_card = new id_card(src)
 	. = ..()
 
-/obj/item/organ/internal/controller/GetIdCards()
+/obj/item/organ/internal/controller/get_id_cards()
 	. = ..()
 	//Not using is_broken() because it should be able to function when CUT_AWAY is set
 	if(damage < min_broken_damage)
 		LAZYDISTINCTADD(., id_card)
 
-/obj/item/organ/internal/controller/GetAccess()
+/obj/item/organ/internal/controller/get_access(var/union = TRUE)
 	if(damage < min_broken_damage)
-		return id_card?.GetAccess()
+		return id_card?.get_access()


### PR DESCRIPTION
## Description of changes
- Disambiguates a bunch of ID card and access procs and normalizes their casing.
- Defaults the `union` argument of `get_access()` to `TRUE`.

## Why and what will this PR improve
More searchable procs.
~Fixes #3461.~~ nope :(

## Authorship
Myself.

## Changelog
Nothing player-facing.