### PR TITLE
ID card retrieval rework.

### DIFF
--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -77,10 +77,12 @@
 
 //Checks for specific types in a list
 /proc/is_type_in_list(var/atom/A, var/list/L)
+	if(!length(L) || !istype(A))
+		return FALSE
 	for(var/type in L)
 		if(istype(A, type))
-			return 1
-	return 0
+			return TRUE
+	return FALSE
 
 //Checks for specific paths in a list
 /proc/is_path_in_list(var/path, var/list/L)

--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -76,20 +76,22 @@
 	return counting_english_list(input, output_icons, determiners, nothing_text, and_text, comma_text, final_comma_text)
 
 //Checks for specific types in a list
-/proc/is_type_in_list(var/atom/A, var/list/L)
-	if(!length(L) || !istype(A))
+/proc/is_type_in_list(datum/thing, list/type_list)
+	if(!length(type_list) || !istype(thing))
 		return FALSE
-	for(var/type in L)
-		if(istype(A, type))
+	for(var/check_type in type_list)
+		if(istype(thing, check_type))
 			return TRUE
 	return FALSE
 
 //Checks for specific paths in a list
-/proc/is_path_in_list(var/path, var/list/L)
-	for(var/type in L)
-		if(ispath(path, type))
-			return 1
-	return 0
+/proc/is_path_in_list(var/check_path, list/type_list)
+	if(!length(type_list) || !ispath(check_path))
+		return FALSE
+	for(var/check_type in type_list)
+		if(ispath(check_path, check_type))
+			return TRUE
+	return FALSE
 
 //returns a new list with only atoms that are in typecache L
 /proc/typecache_filter_list(list/atoms, list/typecache)

--- a/code/datums/extensions/access_provider.dm
+++ b/code/datums/extensions/access_provider.dm
@@ -13,6 +13,6 @@
 /datum/extension/access_provider/proc/unregister_id(atom/movable/to_unregister)
 	LAZYREMOVE(registered_ids, to_unregister)
 
-/datum/extension/access_provider/proc/GetIdCards()
+/datum/extension/access_provider/proc/GetIdCards(list/exceptions)
 	for(var/atom/movable/registered_id in registered_ids)
-		LAZYDISTINCTADD(., registered_id.GetIdCards())
+		LAZYDISTINCTADD(., registered_id.GetIdCards(exceptions))

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -302,12 +302,11 @@ var/global/const/NO_EMAG_ACT = -50
 /obj/item/card/id/GetAccess()
 	return access.Copy()
 
-/obj/item/card/id/GetIdCard()
-	RETURN_TYPE(/obj/item/card/id)
-	return src
 
-/obj/item/card/id/GetIdCards()
-	return list(src)
+/obj/item/card/id/GetIdCards(list/exceptions)
+	. = ..()
+	if(!is_type_in_list(src, exceptions))
+		LAZYDISTINCTADD(., src)
 
 /obj/item/card/id/verb/read()
 	set name = "Read ID Card"

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -87,9 +87,9 @@
 			tiny_state = "id-"+front_id.icon_state
 		add_overlay(overlay_image(icon, tiny_state, flags = RESET_COLOR))
 
-/obj/item/storage/wallet/GetIdCards()
+/obj/item/storage/wallet/GetIdCards(list/exceptions)
 	. = ..()
-	if(istype(front_id))
+	if(istype(front_id) && !is_type_in_list(front_id, exceptions))
 		LAZYDISTINCTADD(., front_id)
 
 /obj/item/storage/wallet/GetChargeStick()
@@ -148,7 +148,7 @@
 
 /decl/interaction_handler/remove_id/wallet/is_possible(atom/target, mob/user, obj/item/prop)
 	. = ..() && ishuman(user)
-	
+
 /decl/interaction_handler/remove_id/wallet/invoked(atom/target, mob/user, obj/item/prop)
 	var/obj/item/storage/wallet/W = target
 	var/obj/item/card/id/id = W.GetIdCard()

--- a/code/modules/mechs/mech.dm
+++ b/code/modules/mechs/mech.dm
@@ -208,9 +208,9 @@
 /mob/living/exosuit/return_air()
 	return (body && body.pilot_coverage >= 100 && hatch_closed && body.cockpit) ? body.cockpit : loc.return_air()
 
-/mob/living/exosuit/GetIdCards()
+/mob/living/exosuit/GetIdCards(list/exceptions)
 	. = ..()
-	if(istype(access_card))
+	if(istype(access_card) && !is_type_in_list(access_card, exceptions))
 		LAZYDISTINCTADD(., access_card)
 
 /mob/living/exosuit/set_dir()

--- a/code/modules/mob/living/simple_animal/crow/crow.dm
+++ b/code/modules/mob/living/simple_animal/crow/crow.dm
@@ -41,9 +41,9 @@
 	messenger_bag = new(src)
 	update_icon()
 
-/mob/living/simple_animal/crow/GetIdCards()
+/mob/living/simple_animal/crow/GetIdCards(list/exceptions)
 	. = ..()
-	if (istype(access_card))
+	if (istype(access_card) && !is_type_in_list(access_card, exceptions))
 		LAZYDISTINCTADD(., access_card)
 
 /mob/living/simple_animal/crow/show_stripping_window(var/mob/user)

--- a/code/modules/mob_holder/_holder.dm
+++ b/code/modules/mob_holder/_holder.dm
@@ -99,10 +99,12 @@
 		return loc.loc
 	return ..()
 
-/obj/item/holder/GetIdCards()
+/obj/item/holder/GetIdCards(list/exceptions)
 	. = ..()
 	for(var/mob/M in contents)
-		LAZYDISTINCTADD(., M.GetIdCards())
+		var/list/cards = M.GetIdCards(exceptions)
+		if(length(cards))
+			LAZYDISTINCTADD(., cards)
 
 /obj/item/holder/attack_self()
 	for(var/mob/M in contents)

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -128,11 +128,11 @@
 		if(user)
 			ui_interact(user)
 
-/obj/item/modular_computer/GetIdCards()
+/obj/item/modular_computer/GetIdCards(list/exceptions)
 	. = ..()
 	var/datum/extension/assembly/assembly = get_extension(src, /datum/extension/assembly)
 	var/obj/item/stock_parts/computer/card_slot/card_slot = assembly.get_component(PART_CARD)
-	if(card_slot && card_slot.can_broadcast && istype(card_slot.stored_card) && card_slot.check_functionality())
+	if(card_slot && card_slot.can_broadcast && istype(card_slot.stored_card) && card_slot.check_functionality() && !is_type_in_list(card_slot.stored_card, exceptions))
 		LAZYDISTINCTADD(., card_slot.stored_card)
 
 /obj/item/modular_computer/GetChargeStick()

--- a/mods/species/ascent/items/id_control.dm
+++ b/mods/species/ascent/items/id_control.dm
@@ -44,8 +44,8 @@
 		return
 	var/datum/extension/access_provider/owner_access = get_or_create_extension(owner, /datum/extension/access_provider)
 	owner_access?.register_id(src)
-	owner?.set_id_info(id_card)
-	owner?.add_language(/decl/language/mantid/worldnet)
+	owner.set_id_info(id_card)
+	owner.add_language(/decl/language/mantid/worldnet)
 
 /obj/item/organ/internal/controller/do_uninstall(in_place, detach, ignore_children)
 	if(owner)
@@ -61,10 +61,10 @@
 		id_card = new id_card(src)
 	. = ..()
 
-/obj/item/organ/internal/controller/GetIdCards()
+/obj/item/organ/internal/controller/GetIdCards(list/exceptions)
 	. = ..()
 	//Not using is_broken() because it should be able to function when CUT_AWAY is set
-	if(damage < min_broken_damage)
+	if(id_card && damage < min_broken_damage && !is_type_in_list(id_card, exceptions))
 		LAZYDISTINCTADD(., id_card)
 
 /obj/item/organ/internal/controller/GetAccess()


### PR DESCRIPTION
## Description of changes
- Collapses ID card retrieval procs a bit.
- Ensures that `exceptions` is actually passed through the chain and consistently checked.
- Semi-sorts mob ID cards so GetIDCard() will prefer to return held cards, then equipped cards, then any remaining cards (ID implants).

## Why and what will this PR improve
Fixes #3461.

## Authorship
Myself.

## Changelog
Nothing player-facing.