### PR TITLE
Prevents nutriment and soap from melting at room temperature.

### DIFF
--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -12,7 +12,7 @@
 	throwforce = 0
 	throw_speed = 4
 	throw_range = 20
-	material = /decl/material/liquid/cleaner
+	material = /decl/material/liquid/cleaner/soap
 	max_health = 5
 	var/key_data
 
@@ -105,13 +105,15 @@
 
 /obj/item/soap/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/key))
-		if(!key_data)
+		if(key_data)
+			to_chat(user, SPAN_WARNING("\The [src] already has a key imprint."))
+		else
 			to_chat(user, SPAN_NOTICE("You imprint \the [I] into \the [src]."))
 			var/obj/item/key/K = I
 			key_data = K.key_data
 			update_icon()
-		return
-	..()
+		return TRUE
+	return ..()
 
 /obj/item/soap/on_update_icon()
 	. = ..()

--- a/code/modules/locks/key.dm
+++ b/code/modules/locks/key.dm
@@ -4,21 +4,20 @@
 	icon = 'icons/obj/items/key.dmi'
 	icon_state = "keys"
 	w_class = ITEM_SIZE_TINY
-	material = DEFAULT_FURNITURE_MATERIAL
+	material = /decl/material/solid/metal/brass
+	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME | MAT_FLAG_ALTERATION_DESC
 	var/key_data = ""
 
-/obj/item/key/Initialize(mapload,var/data)
-	. = ..(mapload)
-	if(data)
-		key_data = data
+/obj/item/key/Initialize(var/mapload, var/material_key, var/new_key_data)
+	. = ..(mapload, material_key)
+	if(new_key_data)
+		key_data = new_key_data
 
 /obj/item/key/proc/get_data(var/mob/user)
 	return key_data
 
 /obj/item/key/soap
-	name = "soap key"
-	desc = "a fragile key made using a bar of soap."
-	material = /decl/material/liquid/cleaner
+	material = /decl/material/liquid/cleaner/soap
 	var/uses = 0
 
 /obj/item/key/soap/get_data(var/mob/user)

--- a/code/modules/locks/lock_construct.dm
+++ b/code/modules/locks/lock_construct.dm
@@ -14,7 +14,7 @@
 	lock_data = generateRandomString(round(material.integrity/50))
 
 /obj/item/lock_construct/attackby(var/obj/item/I, var/mob/user)
-	if(istype(I,/obj/item/key))
+	if(istype(I, /obj/item/key))
 		var/obj/item/key/K = I
 		if(!K.key_data)
 			to_chat(user, SPAN_NOTICE("You fashion \the [I] to unlock \the [src]."))

--- a/code/modules/reagents/chems/chems_cleaner.dm
+++ b/code/modules/reagents/chems/chems_cleaner.dm
@@ -9,3 +9,14 @@
 	turf_touch_threshold = 0.1
 	uid = "chem_cleaner"
 	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
+
+/decl/material/liquid/cleaner/soap
+	name = "soap"
+	lore_text = "A soft solid compound used to clean things. Usually derived from oil or fat."
+	taste_description = "waxy blandness"
+	color = COLOR_BEIGE
+	uid = "chem_soap"
+	melting_point    = 323
+	ignition_point   = 353
+	boiling_point    = 373
+	accelerant_value = 0.3

--- a/code/modules/reagents/chems/chems_nutriment.dm
+++ b/code/modules/reagents/chems/chems_nutriment.dm
@@ -10,6 +10,12 @@
 	uid = "chem_nutriment"
 	exoplanet_rarity_gas = MAT_RARITY_NOWHERE // Please, no more animal protein or glowsap or corn oil atmosphere.
 
+	// Technically a room-temperature solid, but saves
+	// repathing it to /solid all over the codebase.
+	melting_point  = 323
+	ignition_point = 353
+	boiling_point  = 373
+
 	var/nutriment_factor = 10 // Per unit
 	var/hydration_factor = 0 // Per unit
 	var/injectable = 0
@@ -102,6 +108,8 @@
 	taste_description = "egg"
 	color = "#ffffaa"
 	uid = "chem_nutriment_egg"
+	melting_point = 273
+	boiling_point = 373
 
 //vegetamarian alternative that is safe for vegans to ingest//rewired it from its intended nutriment/protein/egg/softtofu because it would not actually work, going with plan B, more recipes.
 
@@ -120,6 +128,8 @@
 	color = "#ffff00"
 	fruit_descriptor = "rich"
 	uid = "chem_nutriment_honey"
+	melting_point = 273
+	boiling_point = 373
 
 /decl/material/liquid/nutriment/flour
 	name = "flour"
@@ -145,6 +155,8 @@
 	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
 	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_batter"
+	melting_point = 273
+	boiling_point = 373
 
 /decl/material/liquid/nutriment/batter/touch_turf(var/turf/T, var/amount, var/datum/reagents/holder)
 	..()
@@ -257,6 +269,8 @@
 	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
 	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_soysauce"
+	melting_point = 273
+	boiling_point = 373
 
 /decl/material/liquid/nutriment/ketchup
 	name = "ketchup"
@@ -267,6 +281,8 @@
 	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
 	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_ketchup"
+	melting_point = 273
+	boiling_point = 373
 
 /decl/material/liquid/nutriment/banana_cream
 	name = "banana cream"
@@ -276,6 +292,8 @@
 	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
 	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_bananacream"
+	melting_point = 273
+	boiling_point = 373
 
 /decl/material/liquid/nutriment/barbecue
 	name = "barbecue sauce"
@@ -286,6 +304,8 @@
 	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
 	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_bbqsauce"
+	melting_point = 273
+	boiling_point = 373
 
 /decl/material/liquid/nutriment/garlicsauce
 	name = "garlic sauce"
@@ -296,6 +316,8 @@
 	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
 	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	uid = "chem_nutriment_garlicsauce"
+	melting_point = 273
+	boiling_point = 373
 
 /decl/material/liquid/nutriment/rice
 	name = "rice"
@@ -326,6 +348,8 @@
 	color = "#801e28"
 	fruit_descriptor = "sweet"
 	uid = "chem_nutriment_cherryjelly"
+	melting_point = 273
+	boiling_point = 373
 
 /decl/material/liquid/nutriment/cornoil
 	name = "corn oil"
@@ -336,6 +360,8 @@
 	color = "#302000"
 	slipperiness = 8
 	uid = "chem_nutriment_cornoil"
+	melting_point = 273
+	boiling_point = 373
 
 /decl/material/liquid/nutriment/sprinkles
 	name = "sprinkles"
@@ -369,6 +395,8 @@
 	color = "#e8dfd0"
 	taste_mult = 3
 	uid = "chem_nutriment_vinegar"
+	melting_point = 273
+	boiling_point = 373
 
 /decl/material/liquid/nutriment/mayo
 	name = "mayonnaise"

--- a/code/modules/reagents/chems/chems_nutriment.dm
+++ b/code/modules/reagents/chems/chems_nutriment.dm
@@ -12,13 +12,14 @@
 
 	// Technically a room-temperature solid, but saves
 	// repathing it to /solid all over the codebase.
-	melting_point  = 323
-	ignition_point = 353
-	boiling_point  = 373
+	melting_point    = 323
+	ignition_point   = 353
+	boiling_point    = 373
+	accelerant_value =   0.65
 
 	var/nutriment_factor = 10 // Per unit
 	var/hydration_factor = 0 // Per unit
-	var/injectable = 0
+	var/injectable       = FALSE
 
 /decl/material/liquid/nutriment/mix_data(var/datum/reagents/reagents, var/list/newdata, var/newamount)
 

--- a/code/modules/reagents/reactions/reaction_other.dm
+++ b/code/modules/reagents/reactions/reaction_other.dm
@@ -13,7 +13,7 @@
 /decl/chemical_reaction/soap_key/on_reaction(var/datum/reagents/holder)
 	var/obj/item/soap/S = holder.get_reaction_loc(chemical_reaction_flags)
 	if(istype(S) && S.key_data)
-		var/obj/item/key/soap/key = new(get_turf(S), S.key_data)
+		var/obj/item/key/soap/key = new(get_turf(S), null, S.key_data)
 		key.uses = strength
 	..()
 

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -6,19 +6,20 @@
 	on = 0
 	powered = 1
 	locked = 0
-
 	load_item_visible = 1
 	load_offset_x = 0
 	buckle_pixel_shift = list("x" = 0, "y" = 0, "z" = 7)
-
-	var/car_limit = 3		//how many cars an engine can pull before performance degrades
 	charge_use = 1 KILOWATTS
 	active_engines = 1
+	var/car_limit = 3		//how many cars an engine can pull before performance degrades
 	var/obj/item/key/cargo_train/key
 
 /obj/item/key/cargo_train
-	name = "key"
-	desc = "A keyring with a small steel key, and a yellow fob reading \"Choo Choo!\"."
+	desc = "A small key on a yellow fob reading \"Choo Choo!\"."
+	material = /decl/material/solid/metal/steel
+	matter = list(
+		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT
+	)
 	icon = 'icons/obj/vehicles.dmi'
 	icon_state = "train_keys"
 	w_class = ITEM_SIZE_TINY


### PR DESCRIPTION
## Description of changes
- Sets nutriment to have low but solid-at-room-temp temperature thresholds.
- Adds a soap material that does the same for soap bars.
- Tweaks some key material logic.

## Why and what will this PR improve
Currently if we add temperature modelling to matter/material, all food objects and bars of soap instantly melt. 

## Authorship
Myself.

## Changelog
Nothing player-facing.