### PR TITLE
Network/disk storage fixes and additions

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/network.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/network.dm
@@ -8,7 +8,7 @@
 		/obj/item/stock_parts/power/apc/buildable = 1,
 		/obj/item/stock_parts/console_screen = 1,
 		/obj/item/stock_parts/keyboard = 1,
-		/obj/item/stock_parts/computer/hard_drive/cluster/fullhouse
+		/obj/item/stock_parts/computer/hard_drive/cluster/empty = 1
 	)
 
 /obj/item/stock_parts/circuitboard/acl

--- a/code/game/objects/items/weapons/tech_disks.dm
+++ b/code/game/objects/items/weapons/tech_disks.dm
@@ -3,7 +3,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 /obj/item/disk
 	name                   = "data disk"
-	desc                   = "A standard 3.5 inches floppy disk for storing computer files... What's even an inch?"
+	desc                   = "A standard 3.5 inch floppy disk for storing computer files... What's even an inch?"
 	icon                   = 'icons/obj/items/device/diskette.dmi'
 	icon_state             = ICON_STATE_WORLD
 	w_class                = ITEM_SIZE_TINY

--- a/code/game/objects/items/weapons/tech_disks.dm
+++ b/code/game/objects/items/weapons/tech_disks.dm
@@ -31,6 +31,7 @@
 	if(existing && existing != F)
 		delete_file(F.filename)
 
+	F.holder = weakref(src)
 	LAZYSET(stored_files, F.filename, F)
 	free_blocks = clamp(round(free_blocks - F.block_size), 0, block_capacity)
 	return TRUE
@@ -53,6 +54,15 @@
 	// do not qdel; should be GC'd once it has no references anyway
 	F.holder = null
 	LAZYREMOVE(stored_files, name)
+	return TRUE
+
+/**Renames a file's handle on the disk. Does not rename the file itself. */
+/obj/item/disk/proc/rename_file(var/oldname, var/newname, var/force = FALSE)
+	var/datum/computer_file/data/F = LAZYACCESS(stored_files, oldname)
+	if(!F || (F.unrenamable && !force))
+		return FALSE
+	stored_files -= oldname
+	stored_files[newname] = F
 	return TRUE
 
 /**Like a full disk format. Erase all files, even if write protected! */

--- a/code/modules/modular_computers/computers/subtypes/preset_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_console.dm
@@ -1,6 +1,9 @@
 /obj/machinery/computer/modular/preset
 	var/list/default_software
 	var/datum/computer_file/program/autorun_program
+	/// Mounts the mainframe with the corresponding key as its ID to the root directory named after the value.
+	/// Ex. list("RECORDS_MAINFRAME" = "records")
+	var/automount_disks
 	base_type = /obj/machinery/computer/modular
 
 /obj/machinery/computer/modular/preset/full
@@ -35,6 +38,12 @@
 			autorun.filename = "autorun"
 			autorun.stored_data = initial(autorun_program.filename)
 			HDD.store_file(autorun)
+		if(LAZYLEN(automount_disks))
+			var/datum/computer_file/data/automount = new()
+			automount.filename = "automount"
+			for(var/disk in automount_disks)
+				automount.stored_data += "[automount_disks[disk]]|[disk];"
+			HDD.store_file(automount)
 
 /obj/machinery/computer/modular/preset/engineering
 	default_software = list(

--- a/code/modules/modular_computers/file_system/computer_file.dm
+++ b/code/modules/modular_computers/file_system/computer_file.dm
@@ -9,6 +9,7 @@ var/global/file_uid = 0
 	var/filetype = "XXX" 									// File full names are [filename].[filetype] so like NewFile.XXX in this case
 	var/size = 1											// File size in GQ. Integers only!
 	var/weakref/holder										// Holder that contains this file. Refers to a obj/item/stock_parts/computer/hard_drive.
+	var/uncopyable = FALSE									// Whether the file may be cloned or copied by a user.
 	var/unsendable = 0										// Whether the file may be sent to someone via file transfer or other means.
 	var/undeletable = 0										// Whether the file may be deleted. Setting to 1 prevents deletion/renaming/etc.
 	var/unrenamable = 0										// Whether the file may be renamed. Setting to 1 prevents renaming.
@@ -28,10 +29,17 @@ var/global/file_uid = 0
 	if(islist(md))
 		metadata = md.Copy()
 
-/datum/computer_file/Destroy()
+/datum/computer_file/proc/remove_from_holder()
+	// This just *begs* for making filesystems an extension
 	var/obj/item/stock_parts/computer/hard_drive/hard_drive = holder?.resolve()
-	if(hard_drive)
+	if(istype(hard_drive))
 		hard_drive.remove_file(src, forced = TRUE)
+	var/obj/item/disk/data_disk = hard_drive
+	if(istype(data_disk))
+		data_disk.delete_file(filename, force = TRUE)
+
+/datum/computer_file/Destroy()
+	remove_from_holder()
 	. = ..()
 
 /datum/computer_file/PopulateClone(datum/computer_file/clone)

--- a/code/modules/modular_computers/file_system/programs/generic/file_manager.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/file_manager.dm
@@ -761,7 +761,7 @@
 		ui_header = null
 
 /datum/computer_file/program/filemanager/on_file_storage_removal(datum/file_storage/removed)
-	var/list/current_disk_list = current_index != null ? disks[current_index] : null
+	var/list/current_disk_list = LAZYACCESS(disks, current_index)
 	for(var/list/disk_list in disks)
 		var/datum/file_storage/disk = disk_list[1]
 		if(disk == removed)

--- a/code/modules/modular_computers/file_system/programs/generic/file_manager.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/file_manager.dm
@@ -333,7 +333,7 @@
 		if(F.get_file_perms(accesses, user) & OS_WRITE_ACCESS)
 			var/newname = sanitize_for_file(input(user, "Enter new file name:", "File rename", F.filename))
 			if(F && length(newname))
-				F.filename = newname
+				current_disk.rename_file(F, newname, user)
 			return TOPIC_REFRESH
 		else
 			to_chat(user, SPAN_WARNING("You do not have permission to rename that file."))
@@ -391,7 +391,9 @@
 			to_chat(user, SPAN_WARNING("I/O ERROR: Unable to transfer file."))
 			return
 
-		var/copying = alert(usr, "Would you like to copy the file or transfer it? Transfering files requires write access.", "Copying file", "Copy", "Transfer")
+		var/copying = "Transfer"
+		if(!F.uncopyable)
+			copying = alert(usr, "Would you like to copy the file or transfer it? Transfering files requires write access.", "Copying file", "Copy", "Transfer")
 		var/list/choices = list()
 		var/list/curr_fs_list = disks[current_index]
 		for(var/list/fs_list in disks)

--- a/code/modules/modular_computers/file_system/programs/generic/file_manager.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/file_manager.dm
@@ -96,6 +96,7 @@
 		var/list/available_mainframes = network.get_file_server_tags(MF_ROLE_FILESERVER, accesses)
 		if(!length(available_mainframes))
 			to_chat(user, SPAN_WARNING("NETWORK ERROR: No available mainframes on the network."))
+			return TOPIC_HANDLED
 		var/fileserver_tag = input(user, "Choose a mainframe you would like to mount as a disk:", "Mainframe Mount") as null|anything in available_mainframes
 		if(!fileserver_tag)
 			return TOPIC_HANDLED

--- a/code/modules/modular_computers/networking/device_types/mainframe.dm
+++ b/code/modules/modular_computers/networking/device_types/mainframe.dm
@@ -104,20 +104,6 @@ var/global/list/all_mainframe_roles = list(
 		return 0
 	return HDD.used_capacity
 
-// Disk that spawns with everything old system had
-/obj/item/stock_parts/computer/hard_drive/cluster/fullhouse/Initialize()
-	. = ..()
-
-	for(var/F in subtypesof(/datum/computer_file/report))
-		var/datum/computer_file/report/type = F
-		if(TYPE_IS_ABSTRACT(type))
-			continue
-		if(initial(type.available_on_network))
-			store_file(new type, "reports", TRUE)
-
-	for(var/F in subtypesof(/datum/computer_file/program))
-		var/datum/computer_file/program/type = F
-		if(TYPE_IS_ABSTRACT(type))
-			continue
-		if(initial(type.available_on_network))
-			store_file(new type, OS_PROGRAMS_DIR, TRUE)
+// starts with no files, useful for things like mainframes
+/obj/item/stock_parts/computer/hard_drive/cluster/empty/install_default_programs()
+	return

--- a/code/modules/modular_computers/networking/machinery/mainframe.dm
+++ b/code/modules/modular_computers/networking/machinery/mainframe.dm
@@ -68,3 +68,20 @@
 
 /obj/machinery/network/mainframe/software
 	initial_roles = list(MF_ROLE_SOFTWARE)
+
+/obj/machinery/network/mainframe/software/Initialize()
+	. = ..()
+	var/obj/item/stock_parts/computer/hard_drive/drive = get_component_of_type(PART_HDD)
+	for(var/F in subtypesof(/datum/computer_file/report))
+		var/datum/computer_file/report/type = F
+		if(TYPE_IS_ABSTRACT(type))
+			continue
+		if(initial(type.available_on_network))
+			drive.store_file(new type, "reports", TRUE)
+
+	for(var/F in subtypesof(/datum/computer_file/program))
+		var/datum/computer_file/program/type = F
+		if(TYPE_IS_ABSTRACT(type))
+			continue
+		if(initial(type.available_on_network))
+			drive.store_file(new type, OS_PROGRAMS_DIR, TRUE)

--- a/code/modules/modular_computers/os/files.dm
+++ b/code/modules/modular_computers/os/files.dm
@@ -258,6 +258,10 @@
 
 /datum/file_storage/proc/delete_file(datum/computer_file/F, list/accesses, mob/user)
 
+/datum/file_storage/proc/rename_file(datum/computer_file/F, newname, mob/user)
+	F.filename = newname
+	return OS_FILE_SUCCESS
+
 /datum/file_storage/proc/create_file(filename, directory, data, file_type = /datum/computer_file/data, list/metadata, list/accesses, mob/user)
 	if(check_errors())
 		return OS_HARDDRIVE_ERROR
@@ -283,7 +287,7 @@
 	var/datum/computer_file/F = get_file(filename, directory)
 	if(!istype(F))
 		return F
-	if(!(F.get_file_perms(accesses, user) & OS_READ_ACCESS))
+	if(!(F.get_file_perms(accesses, user) & OS_READ_ACCESS) || F.uncopyable)
 		return OS_FILE_NO_READ
 
 	var/datum/computer_file/cloned_file = F.Clone(TRUE)
@@ -599,6 +603,13 @@
 		return OS_FILE_NOT_FOUND
 	var/obj/item/disk/disk = get_disk()
 	if(disk.delete_file(file.filename))
+		return OS_FILE_SUCCESS
+
+/datum/file_storage/disk/datadisk/rename_file(datum/computer_file/file, newname, mob/user)
+	if(check_errors())
+		return OS_HARDDRIVE_ERROR
+	var/obj/item/disk/disk = get_disk()
+	if(disk.rename_file(file.filename, newname))
 		return OS_FILE_SUCCESS
 
 /datum/file_storage/disk/datadisk/get_transfer_speed()

--- a/code/modules/modular_computers/terminal/terminal_commands.dm
+++ b/code/modules/modular_computers/terminal/terminal_commands.dm
@@ -418,14 +418,17 @@ Subtypes
 	if(!islist(file_loc))
 		return "rename: [get_terminal_error(file_path, file_loc)]."
 
+	var/datum/file_storage/disk = file_loc[1]
 	var/datum/computer_file/F = file_loc[3]
 	var/new_name = sanitize_for_file(rename_args[2])
 
 	if(length(new_name))
 		if(F.unrenamable || !(F.get_file_perms(terminal.get_access(user), user) & OS_WRITE_ACCESS))
 			return "rename: You lack permission to rename [F.filename]."
-		F.filename = new_name
-		return "rename: File renamed to '[new_name]'."
+		if(disk.rename_file(F, new_name, user))
+			return "rename: File renamed to '[new_name]'."
+		else
+			return "rename: Unable to rename file."
 	else
 		return "rename: Invalid file name."
 


### PR DESCRIPTION
## Description of changes
- Fixes a duplicate programs folder appearing on mainframes.
- Changes how mainframes get their files.
- Fixes qdeleted files on data disks not being removed.
- Fixes a typo in the data disk description.
- Makes renaming files use helpers so that data disks handle them properly.
- Adds mainframe automounts to preset consoles.
- Allows files to be marked `uncopyable` to disable cloning and force transferring instead of copying.
- Fixes a runtime when unmounting a storage disk with no disk currently open.

## Why and what will this PR improve
Various fixes, and some additional features that cover gaps and aren't big enough to be worth a dev PR, IMO. I can retarget if needed though.

## Authorship
Me