### PR TITLE
Does a pass over mech gear, adds origin tech and recipes.

### DIFF
--- a/code/modules/augment/active/armblades.dm
+++ b/code/modules/augment/active/armblades.dm
@@ -21,12 +21,12 @@
 	action_button_name = "Deploy blade"
 	icon_state = "armblade"
 	allowed_organs = list(BP_AUGMENT_R_ARM, BP_AUGMENT_L_ARM)
-	holding_type = /obj/item/armblade
+	holding = /obj/item/armblade
 	//Limited to robolimbs
 	augment_flags = AUGMENTATION_MECHANIC
 	material = /decl/material/solid/metal/steel
 	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
-	
+
 /obj/item/armblade/claws
 	icon_state = "wolverine"
 	name = "combat claws"
@@ -42,7 +42,7 @@
 	action_button_name = "Deploy claws"
 	icon_state = "wolverine"
 	allowed_organs = list(BP_AUGMENT_R_HAND, BP_AUGMENT_L_HAND)
-	holding_type = /obj/item/armblade/claws
+	holding = /obj/item/armblade/claws
 	//Limited to robolimbs
 	augment_flags = AUGMENTATION_MECHANIC
 	material = /decl/material/solid/metal/steel

--- a/code/modules/augment/active/circuit.dm
+++ b/code/modules/augment/active/circuit.dm
@@ -3,7 +3,7 @@
 	action_button_name = "Activate Circuit"
 	icon_state = "circuit"
 	allowed_organs = list(BP_AUGMENT_R_ARM, BP_AUGMENT_L_ARM)
-	holding_type = null //We must get the holding item externally
+	holding = null //We must get the holding item externally
 	//Limited to robolimbs
 	augment_flags = AUGMENTATION_MECHANIC
 	desc = "A DIY modular assembly. Circuitry not included"

--- a/code/modules/augment/simple.dm
+++ b/code/modules/augment/simple.dm
@@ -1,13 +1,12 @@
 //Simple toggleabse module. Just put holding in hands or get it back
 /obj/item/organ/internal/augment/active/simple
 	origin_tech = null
-	var/obj/item/holding = null
-	var/holding_type = null
+	var/obj/item/holding
 
 /obj/item/organ/internal/augment/active/simple/Initialize()
 	. = ..()
-	if(holding_type)
-		holding = new holding_type(src)
+	if(ispath(holding))
+		holding = new holding(src)
 		holding.canremove = 0
 		if(!origin_tech)
 			origin_tech = holding.get_origin_tech()
@@ -18,7 +17,6 @@
 		if(holding.loc == src)
 			QDEL_NULL(holding)
 	return ..()
-
 
 /obj/item/organ/internal/augment/active/simple/proc/holding_dropped()
 

--- a/code/modules/fabrication/designs/industrial/designs_exosuit_components.dm
+++ b/code/modules/fabrication/designs/industrial/designs_exosuit_components.dm
@@ -78,8 +78,26 @@
 	category = "Exosuit Equipment"
 	path = /obj/item/mech_equipment/clamp
 
+/datum/fabricator_recipe/industrial/exosuit_gear/flash
+	path = /obj/item/mech_equipment/flash
+
 /datum/fabricator_recipe/industrial/exosuit_gear/gravity_catapult
 	path = /obj/item/mech_equipment/catapult
+
+/datum/fabricator_recipe/industrial/exosuit_gear/ionjets
+	path = /obj/item/mech_equipment/ionjets
+
+/datum/fabricator_recipe/industrial/exosuit_gear/camera
+	path = /obj/item/mech_equipment/camera
+
+/datum/fabricator_recipe/industrial/exosuit_gear/shields
+	path = /obj/item/mech_equipment/shields
+
+/datum/fabricator_recipe/industrial/exosuit_gear/ballistic_shield
+	path = /obj/item/mech_equipment/ballistic_shield
+
+/datum/fabricator_recipe/industrial/exosuit_gear/atmos_shields
+	path = /obj/item/mech_equipment/atmos_shields
 
 /datum/fabricator_recipe/industrial/exosuit_gear/drill
 	path = /obj/item/mech_equipment/drill
@@ -93,13 +111,15 @@
 	if(!ispath(path, /obj/item/mech_equipment/mounted_system))
 		return
 	var/obj/item/mech_equipment/mounted_system/system = path
-
-	var/mounted_type = initial(system.holding_type)
+	var/mounted_type = initial(system.holding)
 	if(!mounted_type)
 		return
 	var/list/mounted_cost = atom_info_repository.get_matter_for(mounted_type)
 	for(var/mat in mounted_cost)
 		resources[mat] += mounted_cost[mat] * FABRICATOR_EXTRA_COST_FACTOR
+
+/datum/fabricator_recipe/industrial/exosuit_gear/mounted/machete
+	path = /obj/item/mech_equipment/mounted_system/melee/machete
 
 /datum/fabricator_recipe/industrial/exosuit_gear/mounted/plasma
 	path = /obj/item/mech_equipment/mounted_system/taser/plasma
@@ -109,6 +129,9 @@
 
 /datum/fabricator_recipe/industrial/exosuit_gear/mounted/laser
 	path = /obj/item/mech_equipment/mounted_system/taser/laser
+
+/datum/fabricator_recipe/industrial/exosuit_gear/mounted/autoplasma
+	path = /obj/item/mech_equipment/mounted_system/taser/autoplasma
 
 /datum/fabricator_recipe/industrial/exosuit_gear/mounted/smg
 	path = /obj/item/mech_equipment/mounted_system/projectile
@@ -127,9 +150,6 @@
 
 /datum/fabricator_recipe/industrial/exosuit_gear/mounted/extinguisher
 	path = /obj/item/mech_equipment/mounted_system/extinguisher
-
-/datum/fabricator_recipe/industrial/exosuit_gear/mounted/mechshields
-	path = /obj/item/mech_equipment/shields
 
 /datum/fabricator_recipe/industrial/exosuit_ammo
 	category = "Exosuit Ammunition"

--- a/code/modules/mechs/equipment/_equipment.dm
+++ b/code/modules/mechs/equipment/_equipment.dm
@@ -94,7 +94,7 @@
 		return FALSE
 
 /obj/item/mech_equipment/mounted_system
-	var/holding_type
+	abstract_type = /obj/item/mech_equipment/mounted_system
 	var/obj/item/holding
 
 /obj/item/mech_equipment/mounted_system/attack_self(var/mob/user)
@@ -111,16 +111,16 @@
 
 /obj/item/mech_equipment/mounted_system/Initialize()
 	. = ..()
-	if(holding_type)
-		holding = new holding_type(src)
+	if(ispath(holding))
+		holding = new holding(src)
 		events_repository.register(/decl/observ/destroyed, holding, src, .proc/forget_holding)
-	if(holding)
-		if(!icon_state)
-			icon = holding.icon
-			icon_state = holding.icon_state
-		SetName(holding.name)
-		desc = "[holding.desc] This one is suitable for installation on an exosuit."
-
+	if(!istype(holding))
+		return
+	if(!icon_state)
+		icon = holding.icon
+		icon_state = holding.icon_state
+	SetName(holding.name)
+	desc = "[holding.desc] This one is suitable for installation on an exosuit."
 
 /obj/item/mech_equipment/mounted_system/Destroy()
 	events_repository.unregister(/decl/observ/destroyed, holding, src, .proc/forget_holding)

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -2,7 +2,8 @@
 	name = "mounted electrolaser carbine"
 	desc = "A dual fire mode electrolaser system connected to the exosuit's targetting system."
 	icon_state = "mech_taser"
-	holding_type = /obj/item/gun/energy/taser/mounted/mech
+	origin_tech = "{'combat':1,'magnets':1,'engineering':1}"
+	holding = /obj/item/gun/energy/taser/mounted/mech
 	restricted_hardpoints = list(HARDPOINT_LEFT_HAND, HARDPOINT_RIGHT_HAND)
 	restricted_software = list(MECH_SOFTWARE_WEAPONS)
 
@@ -10,13 +11,15 @@
 	name = "mounted ion rifle"
 	desc = "An exosuit-mounted ion rifle. Handle with care."
 	icon_state = "mech_ionrifle"
-	holding_type = /obj/item/gun/energy/ionrifle/mounted/mech
+	holding = /obj/item/gun/energy/ionrifle/mounted/mech
+	origin_tech = "{'combat':2,'powerstorage':2,'magnets':4,'engineering':2}"
 
 /obj/item/mech_equipment/mounted_system/taser/laser
 	name = "\improper CH-PS \"Immolator\" laser"
 	desc = "An exosuit-mounted laser rifle. Handle with care."
 	icon_state = "mech_lasercarbine"
-	holding_type = /obj/item/gun/energy/laser/mounted/mech
+	holding = /obj/item/gun/energy/laser/mounted/mech
+	origin_tech = "{'combat':3,'magnets':2,'engineering':2}"
 
 /obj/item/gun/energy/taser/mounted/mech
 	use_external_power = TRUE
@@ -54,6 +57,7 @@
 	restricted_hardpoints = list(HARDPOINT_BACK)
 	restricted_software = list(MECH_SOFTWARE_WEAPONS)
 	material = /decl/material/solid/metal/steel
+	origin_tech = "{'magnets':3,'powerstorage':4,'materials':2,'engineering':2}"
 	matter = list(
 		/decl/material/solid/metal/silver = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/metal/gold = MATTER_AMOUNT_TRACE
@@ -224,6 +228,8 @@
 
 //Melee! As a general rule I would recommend using regular objects and putting logic in them.
 /obj/item/mech_equipment/mounted_system/melee
+	abstract_type = /obj/item/mech_equipment/mounted_system/melee
+	origin_tech = "{'combat':1,'materials':1,'engineering':1}"
 	restricted_hardpoints = list(HARDPOINT_LEFT_HAND, HARDPOINT_RIGHT_HAND)
 	restricted_software = list(MECH_SOFTWARE_UTILITY)
 
@@ -258,7 +264,7 @@
 	. = ..()
 	if (user.a_intent != I_HURT)
 		return
-	var/obj/item/mech_equipment/mounted_system/melee/mechete/MC = loc
+	var/obj/item/mech_equipment/mounted_system/melee/machete/MC = loc
 	if (istype(MC))
 		//SPIN BLADE ATTACK GO!
 		var/mob/living/exosuit/E = MC.owner
@@ -272,9 +278,9 @@
 				E.spin(0.65 SECONDS, 0.125 SECONDS)
 				playsound(E, 'sound/mecha/mechturn.ogg', 40, 1)
 
-/obj/item/mech_equipment/mounted_system/melee/mechete
+/obj/item/mech_equipment/mounted_system/melee/machete
 	icon_state = "mech_blade"
-	holding_type = /obj/item/hatchet/machete/mech
+	holding = /obj/item/hatchet/machete/mech
 
 
 //Ballistic shield
@@ -282,14 +288,15 @@
 	name = "exosuit ballistic shield"
 	desc = "This formidable line of defense, sees widespread use in planetary peacekeeping operations and military formations alike."
 	icon_state = "mech_shield" //Rendering is handled by aura due to layering issues: TODO, figure out a better way to do this
+	restricted_hardpoints = list(HARDPOINT_LEFT_HAND, HARDPOINT_RIGHT_HAND)
+	restricted_software = list(MECH_SOFTWARE_UTILITY)
+	origin_tech = "{'materials':2,'engineering':2}"
 	var/obj/aura/mech_ballistic/aura = null
 	var/last_push = 0
 	var/chance = 60 //For attacks from the front, diminishing returns
 	var/last_max_block = 0 //Blocking during a perfect block window resets this, else there is an anti spam
 	var/max_block = 60 // Should block most things
 	var/blocking = FALSE
-	restricted_hardpoints = list(HARDPOINT_LEFT_HAND, HARDPOINT_RIGHT_HAND)
-	restricted_software = list(MECH_SOFTWARE_UTILITY)
 
 /obj/item/mech_equipment/ballistic_shield/installed(mob/living/exosuit/_owner)
 	. = ..()

--- a/code/modules/mechs/equipment/combat_projectile.dm
+++ b/code/modules/mechs/equipment/combat_projectile.dm
@@ -28,7 +28,7 @@
 /obj/item/mech_equipment/mounted_system/projectile
 	name = "mounted submachine gun"
 	icon_state = "mech_ballistic"
-	holding_type = /obj/item/gun/projectile/automatic/smg/mech
+	holding = /obj/item/gun/projectile/automatic/smg/mech
 	restricted_hardpoints = list(HARDPOINT_LEFT_HAND, HARDPOINT_RIGHT_HAND)
 	restricted_software = list(MECH_SOFTWARE_WEAPONS)
 	origin_tech = "{'programming':4,'combat':6,'engineering':5}"
@@ -49,7 +49,7 @@
 /obj/item/mech_equipment/mounted_system/projectile/assault_rifle
 	name = "mounted assault rifle"
 	icon_state = "mech_ballistic2"
-	holding_type = /obj/item/gun/projectile/automatic/assault_rifle/mech
+	holding = /obj/item/gun/projectile/automatic/assault_rifle/mech
 	restricted_hardpoints = list(HARDPOINT_LEFT_HAND, HARDPOINT_RIGHT_HAND)
 	restricted_software = list(MECH_SOFTWARE_WEAPONS)
 	origin_tech = "{'programming':4,'combat':8,'engineering':6}"
@@ -69,9 +69,10 @@
 /obj/item/mech_equipment/mounted_system/projectile/machine
 	name = "mounted machine gun"
 	icon_state = "mech_machine_gun"
-	holding_type = /obj/item/gun/projectile/automatic/machine/mech
+	holding = /obj/item/gun/projectile/automatic/machine/mech
 	restricted_hardpoints = list(HARDPOINT_LEFT_HAND, HARDPOINT_RIGHT_HAND)
 	restricted_software = list(MECH_SOFTWARE_WEAPONS)
+	origin_tech = "{'programming':4,'combat':8,'engineering':6}"
 
 /obj/item/gun/projectile/automatic/machine/mech
 	magazine_type = /obj/item/ammo_magazine/mech/rifle/drum

--- a/code/modules/mechs/equipment/engineering.dm
+++ b/code/modules/mechs/equipment/engineering.dm
@@ -1,6 +1,7 @@
 /obj/item/mech_equipment/mounted_system/rcd
 	icon_state = "mech_rcd"
-	holding_type = /obj/item/rcd/mounted
+	holding = /obj/item/rcd/mounted
+	origin_tech = "{'engineering':4,'materials':3,'powerstorage':1}"
 	restricted_hardpoints = list(HARDPOINT_LEFT_HAND, HARDPOINT_RIGHT_HAND)
 	restricted_software = list(MECH_SOFTWARE_ENGINEERING)
 	material = /decl/material/solid/metal/steel
@@ -38,21 +39,24 @@
 
 /obj/item/mech_equipment/mounted_system/extinguisher
 	icon_state = "mech_exting"
-	holding_type = /obj/item/chems/spray/extinguisher/mech
+	holding = /obj/item/chems/spray/extinguisher/mech
 	restricted_hardpoints = list(HARDPOINT_LEFT_HAND, HARDPOINT_RIGHT_HAND)
 	restricted_software = list(MECH_SOFTWARE_ENGINEERING)
+	origin_tech = "{'engineering':1,'materials':1}"
 
 /obj/item/mech_equipment/atmos_shields
 	icon_state = "mech_atmoshield_off"
 	name = "exosuit airshield"
-	desc = "A 'Zephyros' portable Atmospheric Isolation and Retention Screen. It keeps air where it should be... Most of the time. Press ctrl-click to switch modes"
+	desc = "A 'Zephyros' portable Atmospheric Isolation and Retention Screen. It keeps air where it should be... most of the time. Press ctrl-click to switch modes."
 	restricted_hardpoints = list(HARDPOINT_BACK)
 	restricted_software = list(MECH_SOFTWARE_ENGINEERING)
-	var/list/segments
 	equipment_delay = 0.25 SECONDS
+	origin_tech = "{'engineering':2,'powerstorage':2,'materials':3}"
+	var/list/segments
 	var/current_mode = 0  //0 barrier, 1 bubble
 	var/shield_range = 2
 
+// TODO: convert to alt interaction.
 /obj/item/mech_equipment/atmos_shields/CtrlClick(mob/user)
 	if (owner && ((user in owner.pilots) || user == owner))
 		if (active)

--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -544,14 +544,14 @@
 	name = "mounted plasma cutter"
 	desc = "An industrial plasma cutter mounted onto the chassis of the mech. "
 	icon_state = "mech_plasma"
-	holding_type = /obj/item/gun/energy/plasmacutter/mounted/mech
+	holding = /obj/item/gun/energy/plasmacutter/mounted/mech
 	restricted_hardpoints = list(HARDPOINT_LEFT_HAND, HARDPOINT_RIGHT_HAND, HARDPOINT_LEFT_SHOULDER, HARDPOINT_RIGHT_SHOULDER)
 	restricted_software = list(MECH_SOFTWARE_UTILITY)
 	origin_tech = "{'materials':4,'engineering':6,'exoticmatter':4,'combat':3}"
 
 /obj/item/mech_equipment/mounted_system/taser/autoplasma
 	icon_state = "mech_energy"
-	holding_type = /obj/item/gun/energy/plasmacutter/mounted/mech/auto
+	holding = /obj/item/gun/energy/plasmacutter/mounted/mech/auto
 	restricted_hardpoints = list(HARDPOINT_LEFT_HAND, HARDPOINT_RIGHT_HAND)
 	restricted_software = list(MECH_SOFTWARE_UTILITY)
 	origin_tech = "{'materials':5,'engineering':6,'exoticmatter':4,'combat':4}"

--- a/code/modules/mechs/premade/powerloader.dm
+++ b/code/modules/mechs/premade/powerloader.dm
@@ -105,7 +105,7 @@
 
 /mob/living/exosuit/premade/powerloader/mechete/spawn_mech_equipment()
 	install_system(new /obj/item/mech_equipment/ballistic_shield(src), HARDPOINT_LEFT_HAND)
-	install_system(new /obj/item/mech_equipment/mounted_system/melee/mechete(src), HARDPOINT_RIGHT_HAND)
+	install_system(new /obj/item/mech_equipment/mounted_system/melee/machete(src), HARDPOINT_RIGHT_HAND)
 
 /mob/living/exosuit/premade/powerloader/flames_red
 	name = "APLU \"Firestarter\""

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -23,6 +23,12 @@
 /obj/item/gun/energy/ionrifle/emp_act(severity)
 	..(max(severity, 2)) //so it doesn't EMP itself, I guess
 
+/obj/item/gun/energy/ionrifle/mounted
+	name = "mounted ion gun"
+	self_recharge = TRUE
+	use_external_power = TRUE
+	has_safety = FALSE
+
 /obj/item/gun/energy/decloner
 	name = "biological demolecularisor"
 	desc = "A gun that discharges high amounts of controlled radiation to slowly break a target into component elements."


### PR DESCRIPTION
## Description of changes
- Simplifies `holding` and `holding_type` down to one var.
- Adds missing origin tech to several mech items.
- Tweaks other origin tech to line up better with gear tech.
- Adds fab recipes for all mech gear.

## Why and what will this PR improve
Addresses #3519.

## Authorship
Myself.

## Changelog
:cl:
tweak: Some mech equipment origin tech has changed. Please report any missing or odd values.
add: Added several mech equipment recipes to the exosuit fabricator.
/:cl:
