### PR TITLE
Updates space turfs in radius of simulated/exterior turfs during init.

### DIFF
--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -43,6 +43,11 @@
 
 	. = ..(mapload)	// second param is our own, don't pass to children
 
+	if(!mapload)
+		// Force neighboring space to update corners.
+		for(var/turf/space/space in RANGE_TURFS(src, 1))
+			SSambience.queued |= space
+
 	if (no_update_icon)
 		return
 

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -175,3 +175,7 @@
 	holy = istype(A) && (A.area_flags & AREA_FLAG_HOLY)
 	levelupdate()
 	. = ..()
+	if(!ml)
+		// Force neighboring space to update corners.
+		for(var/turf/space/space in RANGE_TURFS(src, 1))
+			SSambience.queued |= space


### PR DESCRIPTION
## Description of changes
Simulated and exterior turfs iterate neighboring space turfs and queue them in SSambience. Init times seem fine on tradeship (19s which is the normal init time on my hardware) but I haven't benchmarked exodus or the other maps.

## Why and what will this PR improve
- Fixes #2746

## Authorship
Myself.

## Changelog
Nothing player-facing.