### PR TITLE
Porting simplemob melee windup from Polaris.

### DIFF
--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -159,3 +159,25 @@
 		return
 	playsound(T, "sparks", 50, 1)
 	anim(src,'icons/mob/mob.dmi',,"phaseout",,dir)
+
+// Similar to attack animations, but in reverse and is longer to act as a telegraph.
+/atom/movable/proc/do_windup_animation(atom/A, windup_time, no_reset)
+
+	var/pixel_x_diff = 0
+	var/pixel_y_diff = 0
+
+	var/direction = get_dir(src, A)
+	if(direction & NORTH)
+		pixel_y_diff = -8
+	else if(direction & SOUTH)
+		pixel_y_diff = 8
+	if(direction & EAST)
+		pixel_x_diff = -8
+	else if(direction & WEST)
+		pixel_x_diff = 8
+
+	if(no_reset)
+		animate(src, pixel_x = pixel_x + pixel_x_diff, pixel_y = pixel_y + pixel_y_diff, time = windup_time)
+	else
+		animate(src, pixel_x = pixel_x + pixel_x_diff, pixel_y = pixel_y + pixel_y_diff, time = windup_time-2)
+		animate(pixel_x = default_pixel_x, pixel_y = default_pixel_y, time = 2)

--- a/code/modules/mob/living/simple_animal/hostile/bad_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bad_drone.dm
@@ -14,6 +14,7 @@
 	speed = 4
 	mob_size = MOB_SIZE_TINY
 	gene_damage = -1
+	attack_delay = DEFAULT_QUICK_COOLDOWN
 	var/corpse = /obj/effect/decal/cleanable/blood/gibs/robot
 
 /mob/living/simple_animal/hostile/rogue_drone/Initialize()

--- a/code/modules/mob/living/simple_animal/hostile/faithful_hound.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithful_hound.dm
@@ -41,9 +41,7 @@
 			var/mob/living/M = m
 			var/dist = get_dist(M, src)
 			if(dist < 2) //Attack! Attack!
-				var/attacking_with = get_natural_weapon()
-				if(attacking_with)
-					M.attackby(attacking_with, src)
+				UnarmedAttack(M, TRUE)
 				return .
 			else if(dist == 2)
 				new_aggress = 3

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -12,14 +12,13 @@
 	var/attack_same = 0
 	var/ranged = 0
 	var/rapid = 0
-	var/sa_accuracy = 85 //base chance to hit out of 100
 	var/projectiletype
 	var/projectilesound
 	var/casingtype
 	var/fire_desc = "fires" //"X fire_desc at Y!"
 	var/ranged_range = 6 //tiles of range for ranged attackers to attack
 	var/move_to_delay = 4 //delay for the automated movement.
-	var/attack_delay = DEFAULT_ATTACK_COOLDOWN
+
 	var/list/friends = list()
 	var/break_stuff_probability = 10
 	var/destroy_surroundings = 1
@@ -94,7 +93,10 @@
 /mob/living/simple_animal/hostile/proc/Found(var/atom/A)
 	return
 
-/mob/living/simple_animal/hostile/proc/MoveToTarget(var/move_only = FALSE)
+/mob/living/simple_animal/proc/MoveToTarget(var/move_only = FALSE)
+	return
+
+/mob/living/simple_animal/hostile/MoveToTarget(var/move_only = FALSE)
 	if(!can_act())
 		return
 	if(HAS_STATUS(src, STAT_CONFUSE))
@@ -149,19 +151,11 @@
 
 		return target_mob
 
-	face_atom(target_mob)
-	setClickCooldown(attack_delay)
 	if(!Adjacent(target_mob))
 		return
 	if(isliving(target_mob))
-		if(!prob(get_accuracy()))
-			visible_message("<span class='notice'>\The [src] misses its attack on \the [target_mob]!</span>")
-			return
-		var/mob/living/L = target_mob
-		var/attacking_with = get_natural_weapon()
-		if(attacking_with)
-			L.attackby(attacking_with, src)
-		return L
+		UnarmedAttack(target_mob)
+		return target_mob
 
 /mob/living/simple_animal/hostile/proc/LoseTarget()
 	stance = HOSTILE_STANCE_IDLE
@@ -174,9 +168,6 @@
 
 /mob/living/simple_animal/hostile/proc/ListTargets(var/dist = 7)
 	return hearers(src, dist)-src
-
-/mob/living/simple_animal/hostile/proc/get_accuracy()
-	return clamp(sa_accuracy - melee_accuracy_mods(), 0, 100)
 
 /mob/living/simple_animal/hostile/death(gibbed, deathmessage, show_dead_message)
 	..(gibbed, deathmessage, show_dead_message)
@@ -283,18 +274,13 @@
 
 		var/obj/effect/shield/S = locate(/obj/effect/shield) in targ
 		if(S && S.gen && S.gen.check_flag(MODEFLAG_NONHUMANS))
-			var/attacking_with = get_natural_weapon()
-			if(attacking_with)
-				S.attackby(attacking_with, src)
+			UnarmedAttack(S)
 			return
 
 		for(var/type in valid_obstacles_by_priority)
 			var/obj/obstacle = locate(type) in targ
 			if(obstacle)
-				face_atom(obstacle)
-				var/attacking_with = get_natural_weapon()
-				if(attacking_with)
-					obstacle.attackby(attacking_with, src)
+				UnarmedAttack(obstacle)
 				return
 
 		if(can_pry)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
@@ -95,7 +95,7 @@
 	desc = "A small pack animal. Although omnivorous, it will hunt meat on occasion."
 	faction = "diyaab"
 	icon = 'icons/mob/simple_animal/diyaab.dmi'
-	move_to_delay = 1
+	move_to_delay = 3
 	mob_default_max_health = 25
 	speed = 1
 	natural_weapon = /obj/item/natural_weapon/claws/weak
@@ -111,7 +111,7 @@
 	desc = "A piglike creature with a bright iridiscent mane that sparkles as though lit by an inner light. Don't be fooled by its beauty though."
 	faction = "shantak"
 	icon = 'icons/mob/simple_animal/shantak.dmi'
-	move_to_delay = 1
+	move_to_delay = 3
 	mob_default_max_health = 75
 	speed = 1
 	natural_weapon = /obj/item/natural_weapon/claws

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/jelly.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/jelly.dm
@@ -3,15 +3,15 @@
 	desc = "It looks like a floating jellyfish. How does it do that?"
 	faction = "zeq"
 	icon = 'icons/mob/simple_animal/jelly.dmi'
-	move_to_delay = 1
+	move_to_delay = 2
 	mob_default_max_health = 75
 	speed = 1
-	natural_weapon = /obj/item/natural_weapon/tentecles
+	natural_weapon = /obj/item/natural_weapon/tentacles
 	speak_chance = 1
 	emote_see = list("wobbles slightly","oozes something out of tentacles' ends")
 	var/gets_random_color = TRUE
 
-/obj/item/natural_weapon/tentecles
+/obj/item/natural_weapon/tentacles
 	name = "tentacles"
 	attack_verb = list("stung","slapped")
 	force = 10

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
@@ -319,9 +319,7 @@
 				return
 
 			//Time for the hurt to begin!
-			var/attacking_with = get_natural_weapon()
-			if(attacking_with)
-				L.attackby(attacking_with, src)
+			UnarmedAttack(L)
 			return
 
 		//Otherwise, fly towards the mob!

--- a/code/modules/mob/living/simple_animal/hostile/viscerator.dm
+++ b/code/modules/mob/living/simple_animal/hostile/viscerator.dm
@@ -9,7 +9,7 @@
 	min_gas = null
 	max_gas = null
 	minbodytemp = 0
-
+	attack_delay = DEFAULT_QUICK_COOLDOWN
 	bleed_colour = SYNTH_BLOOD_COLOR
 
 	meat_type =     null

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -91,6 +91,9 @@
 	var/scannable_result // Codex page generated when this mob is scanned.
 	var/base_animal_type // set automatically in Initialize(), used for language checking.
 
+	var/attack_delay = DEFAULT_ATTACK_COOLDOWN // How long in ds that a creature winds up before attacking.
+	var/sa_accuracy = 85 //base chance to hit out of 100
+
 /mob/living/simple_animal/Initialize()
 	. = ..()
 
@@ -626,7 +629,6 @@ var/global/list/simplemob_icon_bitflag_cache = list()
 /mob/living/simple_animal/get_hydration()
 	return get_max_hydration()
 
-
 /// Adapts our temperature and atmos thresholds to our current z-level.
 /mob/living/simple_animal/proc/adapt_to_current_level()
 	var/turf/T = get_turf(src)
@@ -665,3 +667,6 @@ var/global/list/simplemob_icon_bitflag_cache = list()
 	name = "animal"
 	bodytype_flag = 0
 	bodytype_category = "animal body"
+
+/mob/living/simple_animal/proc/get_melee_accuracy()
+	return clamp(sa_accuracy - melee_accuracy_mods(), 0, 100)


### PR DESCRIPTION
## Description of changes
- Replaces several direct uses of natural weapon with `UnarmedAttack()`.
- Inverts the attack cooldown on simplemobs to allow a chance to dodge away from them in melee.

## Why and what will this PR improve
It makes PVE a bit less clunky and allows some skill based play.

## Authorship
Concept is from Polaris, I think Neerti.

## Changelog
:cl:
tweak: Simple mobs will now show a windup before hitting you in melee, allowing you to dodge.
/:cl:
