### PR TITLE
Exterior turf and shuttle fixes

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -132,6 +132,7 @@ var/global/list/areas = list()
 	T.last_outside_check = OUTSIDE_UNCERTAIN
 	if(T.is_outside == OUTSIDE_AREA && T.is_outside() != old_outside)
 		T.update_weather()
+		T.update_external_atmos_participation()
 
 /turf/proc/update_registrations_on_adjacent_area_change()
 	for(var/obj/machinery/door/firedoor/door in src)

--- a/code/game/base_turf.dm
+++ b/code/game/base_turf.dm
@@ -13,12 +13,9 @@
 			return A.open_turf
 
 		// Find the first non-open turf below and use its open_turf_type.
-		var/turf/below = T
-		while ((below = GetBelow(below)))
-			if(!below.is_open() || !HasBelow(below.z))
-				if(below.open_turf_type)
-					return below.open_turf_type
-				break
+		var/z_stack_type = get_open_turf_type(T)
+		if(z_stack_type)
+			return z_stack_type
 
 		// Otherwise, default to the open turf type set on the turf being removed.
 		if(T.open_turf_type)
@@ -26,6 +23,17 @@
 	if(istype(A) && A.base_turf)
 		return A.base_turf
 	return get_base_turf(T.z)
+
+// Returns the open turf of a Z-stack by finding the nearest non-open turf below.
+/proc/get_open_turf_type(var/turf/T)
+	if(!HasBelow(T.z))
+		return
+	var/turf/below = T
+	while ((below = GetBelow(below)))
+		if(!below.is_open() || !HasBelow(below.z))
+			if(below.open_turf_type)
+				return below.open_turf_type
+			return
 
 /client/proc/set_base_turf()
 	set category = "Debug"

--- a/code/game/base_turf.dm
+++ b/code/game/base_turf.dm
@@ -11,6 +11,16 @@
 	if(HasBelow(T.z))
 		if(istype(A) && A.open_turf)
 			return A.open_turf
+
+		// Find the first non-open turf below and use its open_turf_type.
+		var/turf/below = T
+		while ((below = GetBelow(below)))
+			if(!below.is_open() || !HasBelow(below.z))
+				if(below.open_turf_type)
+					return below.open_turf_type
+				break
+
+		// Otherwise, default to the open turf type set on the turf being removed.
 		if(T.open_turf_type)
 			return T.open_turf_type
 	if(istype(A) && A.base_turf)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -148,7 +148,7 @@ var/global/list/wall_fullblend_objects = list(
 			plant.update_icon()
 			plant.reset_offsets(0)
 
-/turf/simulated/wall/ChangeTurf(var/turf/N, var/tell_universe = TRUE, var/force_lighting_update = FALSE, var/keep_air = FALSE)
+/turf/simulated/wall/ChangeTurf(var/turf/N, var/tell_universe = TRUE, var/force_lighting_update = FALSE, var/keep_air = FALSE, var/keep_air_below = FALSE, var/update_open_turfs_above = TRUE)
 	clear_plants()
 	. = ..()
 

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -11,6 +11,8 @@
 	z_eventually_space = TRUE
 	turf_flags = TURF_FLAG_BACKGROUND
 
+	open_turf_type = /turf/space
+
 	/// If we're an edge.
 	var/edge = 0
 	/// Force this one to pretend it's an overedge turf.
@@ -80,6 +82,7 @@
 		var/turf/T = src
 		while ((T = GetAbove(T)))
 			T.z_eventually_space = FALSE
+
 	return ..()
 
 /turf/space/LateInitialize()

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -86,7 +86,7 @@
 	if(SSmapping.base_floor_area)
 		var/area/new_area = locate(SSmapping.base_floor_area) || new SSmapping.base_floor_area
 		ChangeArea(src, new_area)
-	ChangeTurf(SSmapping.base_floor_type)
+	ChangeTurf(SSmapping.base_floor_type, keep_air_below = TRUE)
 
 // override for space turfs, since they should never hide anything
 /turf/space/levelupdate()
@@ -241,8 +241,8 @@
 					A.loc.Entered(A)
 	return
 
-/turf/space/ChangeTurf(var/turf/N, var/tell_universe = TRUE, var/force_lighting_update = FALSE, var/keep_air = FALSE)
-	return ..(N, tell_universe, TRUE, keep_air)
+/turf/space/ChangeTurf(var/turf/N, var/tell_universe = TRUE, var/force_lighting_update = FALSE, var/keep_air = FALSE, var/keep_air_below = FALSE, var/update_open_turfs_above = TRUE)
+	return ..(N, tell_universe, TRUE, keep_air, keep_air_below, update_open_turfs_above)
 
 /turf/space/is_open()
 	return TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -36,7 +36,7 @@
 	var/fluid_blocked_dirs = 0
 	var/flooded // Whether or not this turf is absolutely flooded ie. a water source.
 	var/footstep_type
-	var/open_turf_type // Which turf to use when this turf is destroyed or replaced in a multiz context. Overridden by area.
+	var/open_turf_type // Which open turf type to use by default above this turf in a multiz context. Overridden by area.
 
 	var/tmp/changing_turf
 	var/tmp/prev_type // Previous type of the turf, prior to turf translation.
@@ -424,6 +424,29 @@
 		if(below)
 			below.update_weather(new_weather)
 
+// Updates turf participation in ZAS according to outside status. Must be called whenever the outside status of a turf may change.
+/turf/proc/update_external_atmos_participation(overwrite_air = TRUE)
+	if(is_outside())
+		if(zone && external_atmosphere_participation)
+			if(can_safely_remove_from_zone())
+				#ifdef MULTIZAS
+				var/dirs = global.cardinalz
+				#else
+				var/dirs = global.cardinal
+				#endif
+				zone.remove(src)
+				// Update neighbors to create edges between zones and exterior
+				for(var/dir in dirs)
+					var/turf/neighbor = get_step(src, dir)
+					SSair.mark_for_update(neighbor)
+			else
+				zone.rebuild()
+	else if(zone_membership_candidate)
+		// Set the turf's air to the external atmosphere to add to its new zone.
+		if(overwrite_air)
+			air = get_external_air(FALSE)
+		SSair.mark_for_update(src)
+
 /turf/proc/is_outside()
 
 	// Can't rain inside or through solid walls.
@@ -445,7 +468,7 @@
 
 	// If we are in a multiz volume and not already inside, we return
 	// the outside value of the highest unenclosed turf in the stack.
-	if((. != OUTSIDE_NO) && HasAbove(z))
+	if(HasAbove(z))
 		. =  OUTSIDE_YES // assume for the moment we're unroofed until we learn otherwise.
 		var/turf/top_of_stack = src
 		while(HasAbove(top_of_stack.z))
@@ -467,14 +490,7 @@
 	SSambience.queued += src
 
 	last_outside_check = OUTSIDE_UNCERTAIN
-	if(is_outside())
-		if(zone && external_atmosphere_participation)
-			if(can_safely_remove_from_zone())
-				zone.remove(src)
-			else
-				zone.rebuild()
-	else if(zone_membership_candidate)
-		SSair.mark_for_update(src)
+	update_external_atmos_participation()
 
 	if(!HasBelow(z))
 		return TRUE

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -160,7 +160,6 @@
 	if(update_open_turfs_above)
 		update_open_above(old_open_turf_type)
 
-
 /turf/proc/transport_properties_from(turf/other)
 	if(other.zone)
 		if(!air)

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -22,6 +22,21 @@
 	SHOULD_CALL_PARENT(FALSE)
 	. = TRUE
 
+// Updates open turfs above this one to use its open_turf_type
+/turf/proc/update_open_above(var/restrict_type, var/respect_area = TRUE)
+	if(!HasAbove(src.z))
+		return
+	var/turf/above = src
+	while ((above = GetAbove(above)))
+		if(!above.is_open())
+			break
+		if(!restrict_type || istype(above, restrict_type))
+			if(respect_area)
+				var/area/A = get_area(above)
+				above.ChangeTurf(A?.open_turf || open_turf_type, update_open_turfs_above = FALSE)
+			else
+				above.ChangeTurf(open_turf_type, update_open_turfs_above = FALSE)
+
 /turf/proc/ChangeTurf(var/turf/N, var/tell_universe = TRUE, var/force_lighting_update = FALSE, var/keep_air = FALSE, var/keep_air_below = FALSE, var/update_open_turfs_above = TRUE)
 	if (!N)
 		return
@@ -51,6 +66,7 @@
 	var/old_flooded =          flooded
 	var/old_outside =          is_outside
 	var/old_is_open =          is_open()
+	var/old_open_turf_type =   open_turf_type
 	var/old_affecting_heat_sources = affecting_heat_sources
 
 	var/old_ambience =         ambient_light
@@ -182,7 +198,7 @@
 	stripe_color = other.stripe_color
 
 	material = other.material
-	reinf_material = other.material
+	reinf_material = other.reinf_material
 	girder_material = other.girder_material
 
 	floor_type = other.floor_type

--- a/code/modules/ZAS/Turf.dm
+++ b/code/modules/ZAS/Turf.dm
@@ -223,15 +223,7 @@
 
 	// Exterior turf global atmosphere
 	if((!air && isnull(initial_gas)) || (external_atmosphere_participation && is_outside()))
-		var/datum/level_data/level = SSmapping.levels_by_z[z]
-		var/datum/gas_mixture/gas = level.get_exterior_atmosphere()
-		var/initial_temperature = weather ? weather.adjust_temperature(gas.temperature) : gas.temperature
-		if(length(affecting_heat_sources))
-			for(var/obj/structure/fire_source/heat_source as anything in affecting_heat_sources)
-				gas.temperature = gas.temperature + heat_source.exterior_temperature / max(1, get_dist(src, get_turf(heat_source)))
-				if(abs(gas.temperature - initial_temperature) >= 100)
-					break
-		return gas
+		return get_external_air()
 
 	// Base behavior
 	. = air
@@ -261,6 +253,21 @@
 		air.gas = initial_gas.Copy()
 	air.update_values()
 	return air
+
+// Returns the external air if this turf is outside, modified by weather and heat sources. Outside checks do not occur in this proc!
+/turf/proc/get_external_air(include_heat_sources = TRUE)
+	var/datum/level_data/level = SSmapping.levels_by_z[z]
+	var/datum/gas_mixture/gas = level.get_exterior_atmosphere()
+	if(!include_heat_sources)
+		return gas
+
+	var/initial_temperature = weather ? weather.adjust_temperature(gas.temperature) : gas.temperature
+	if(length(affecting_heat_sources))
+		for(var/obj/structure/fire_source/heat_source as anything in affecting_heat_sources)
+			gas.temperature = gas.temperature + heat_source.exterior_temperature / max(1, get_dist(src, get_turf(heat_source)))
+			if(abs(gas.temperature - initial_temperature) >= 100)
+				break
+	return gas
 
 /turf/proc/c_copy_air()
 	if(!air)

--- a/code/modules/ZAS/Zone.dm
+++ b/code/modules/ZAS/Zone.dm
@@ -114,8 +114,7 @@ Class Procs:
 	for(var/connection_edge/E in edges)
 		if(E.contains_zone(into))
 			continue //don't need to rebuild this edge
-		for(var/turf/T in E.connecting_turfs)
-			SSair.mark_for_update(T)
+		E.update_post_merge()
 
 /zone/proc/c_invalidate()
 	invalid = 1

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -313,7 +313,7 @@
 			if(force || (istype(TA, get_base_turf_by_area(TA)) || (istype(TA) && TA.is_open())))
 				if(get_area(TA) in shuttle_area)
 					continue
-				TA.ChangeTurf(ceiling_type, TRUE, TRUE, TRUE, FALSE)
+				TA.ChangeTurf(ceiling_type, TRUE, TRUE, TRUE, TRUE)
 
 //returns 1 if the shuttle has a valid arrive time
 /datum/shuttle/proc/has_arrive_time()

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -16,6 +16,7 @@
 	var/multiz = 0	//how many multiz levels, starts at 0
 
 	var/ceiling_type = /turf/unsimulated/floor/shuttle_ceiling
+	var/force_ceiling_on_init = TRUE // Whether or not to force ceilings turfs to be created above on initialization.
 
 	var/sound_takeoff = 'sound/effects/shuttle_takeoff.ogg'
 	var/sound_landing = 'sound/effects/shuttle_landing.ogg'
@@ -79,6 +80,8 @@
 		if(SSsupply.shuttle)
 			CRASH("A supply shuttle is already defined.")
 		SSsupply.shuttle = src
+
+	create_ceiling(force_ceiling_on_init)
 
 /datum/shuttle/proc/remove_shuttle_area(area/area_to_remove)
 	events_repository.unregister(/decl/observ/destroyed, area_to_remove, src, .proc/remove_shuttle_area)
@@ -252,14 +255,7 @@
 	current_location = destination
 
 	// if there's a zlevel above our destination, paint in a ceiling on it so we retain our air
-	if(HasAbove(current_location.z))
-		for(var/area/A in shuttle_area)
-			for(var/turf/TD in A.contents)
-				var/turf/TA = GetAbove(TD)
-				if(istype(TA, get_base_turf_by_area(TA)) || (istype(TA) && TA.is_open()))
-					if(get_area(TA) in shuttle_area)
-						continue
-					TA.ChangeTurf(ceiling_type, TRUE, TRUE, TRUE)
+	create_ceiling()
 
 	handle_pipes_and_power_on_move(new_turfs)
 
@@ -304,6 +300,20 @@
 		pipe.atmos_init() // this will clear pipenet/pipeline
 	for(var/obj/machinery/atmospherics/pipe as anything in pipes)
 		pipe.build_network()
+
+/datum/shuttle/proc/create_ceiling(force)
+	if(!HasAbove(current_location.z))
+		return
+	for(var/area/A in shuttle_area)
+		for(var/turf/TD in A.contents)
+			// Background turfs don't get a ceiling.
+			if(TD.turf_flags & TURF_FLAG_BACKGROUND)
+				continue
+			var/turf/TA = GetAbove(TD)
+			if(force || (istype(TA, get_base_turf_by_area(TA)) || (istype(TA) && TA.is_open())))
+				if(get_area(TA) in shuttle_area)
+					continue
+				TA.ChangeTurf(ceiling_type, TRUE, TRUE, TRUE, FALSE)
 
 //returns 1 if the shuttle has a valid arrive time
 /datum/shuttle/proc/has_arrive_time()


### PR DESCRIPTION
## Description of changes
Adjustments and fixes to ZAS and exterior/open turf logic. Also fixes some issues with shuttles while I'm in the area.

**ZAS**
* Unsimulated connection edges now keep track of the connecting turfs in the simulated zone in their ``inner_turfs`` list
* ``inner_turfs`` are now marked for update on zone merges. This fixes an issue where unsimulated connection edges were not retained post zone merge

**Exterior turf logic**
* ``update_external_atmos_participation`` should now be called whenever the external status of a turf may change. Currently, this is when ``set_outside`` is called directly, when the area of the turf changes, or if a turf above changes
* In most situations, turfs' ``air`` variable will be updated with the exterior mix when changing from exterior to ZAS participating
* Fixes issue where turfs on planets were automatically becoming pressurized when a non-external area was set

**Open turf logic**
* The ``open_turf_type`` variable on the bottom most turf in a Z-stack will now determine the type of open turf created when a turf above it is destroyed in most situations. The ``open_turf`` variable on the area will still take precedence if present.
* When the turf at the bottom of a Z-stack is changed, it will attempt to update all open turfs of its previous ``open_turf_type`` to its new ``open_turf_type``

**Shuttle fixes**
* Shuttles now have a ``force_ceiling_on_init`` variable which will overwrite any ceiling directly above it on Initialization. This is necessary because space turfs automatically create plating above the shuttle when they see non-dense spaces below them in ``LateInitialize``, which then must be overwritten
* Shuttles no longer create ceilings over background turfs (e.g. the catwalk tiles on the Bee)
* Fixes shuttle walls magically becoming reinforced when moving

## Why and what will this PR improve
Makes exterior and ZAS-participating turfs behave as expected. Holes in ceilings into space now act properly, and buildings on planets should not become magically pressurized.

The shuttle ceiling issue is mostly a pet peeve, since currently the Bee leaves behind an ugly plating outline above it when it takes off. I set ``force_ceiling_on_init`` to be ``TRUE`` by default, so any shuttles which are mapped to have ceilings immediately above them need to be adjusted. This isn't a perfect solution. Ideally I would simply have space turfs not turn into plating if they are above a shuttle, but I can't think of a clean way to do this currently due to init order

The open turf changes are mostly to make creation and removal of space turfs more consistent. Space turfs are set to have themselves as their ``open_turf_type``, so as long as there is space at the bottom, there will be space through the entire Z-stack. On the other hand, plating will always have ``/turf/simulated/open`` above it, rather than space, unless it has been mapped otherwise. In the short future, we should be able to unify ``/turf/exterior/open`` and ``/turf/simulated/open``, so this change shouldn't have much of an effect on multi-Z planets.  In the event that a turf cannot find an open turf type from the bottom of its Z-stack or its area, it will still fall back on its own ``open_turf_type``. Overall, I believe this is a better solution than having every turf deciding its own open turf type, as this can lead to inconsistencies in the Z-stack. Happy to discuss this change further though if more flexibility is needed or I'm missing an edge case.

Targeting staging for this, since these are mostly fixes

## Authorship
Myself. Thanks to Loaf for helpful discussions