### PR TITLE
Fix duplicate railing damage code

### DIFF
--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -76,25 +76,6 @@
 		return !density
 	return TRUE
 
-/obj/structure/railing/examine(mob/user)
-	. = ..()
-	if(health < maxhealth)
-		switch(health / maxhealth)
-			if(0.0 to 0.5)
-				to_chat(user, "<span class='warning'>It looks severely damaged!</span>")
-			if(0.25 to 0.5)
-				to_chat(user, "<span class='warning'>It looks damaged!</span>")
-			if(0.5 to 1.0)
-				to_chat(user, "<span class='notice'>It has a few scrapes and dents.</span>")
-
-/obj/structure/railing/take_damage(amount)
-	health -= amount
-	if(health <= 0)
-		visible_message("<span class='danger'>\The [src] [material.destruction_desc]!</span>")
-		playsound(loc, 'sound/effects/grillehit.ogg', 50, 1)
-		material.place_shards(get_turf(usr))
-		qdel(src)
-
 /obj/structure/railing/proc/NeighborsCheck(var/UpdateNeighbors = 1)
 	neighbor_status = 0
 	var/Rturn = turn(src.dir, -90)


### PR DESCRIPTION
## Description of changes
Removes duplicate railing examine and damage code.

## Why and what will this PR improve
The message no longer shows up twice, and damage should be taken in a way consistent with other structures, e.g. calling `physically_destroyed()` on destruction.