### PR TITLE
Fix closet appearance unit test error logging

### DIFF
--- a/code/unit_tests/closets.dm
+++ b/code/unit_tests/closets.dm
@@ -55,21 +55,21 @@
 		)
 		var/fail_msg = "Insane closet appearances found: "
 		if(LAZYLEN(bad_decl))
-			fail_msg += "\nDecl did not add itself to appropriate global list:\n[jointext("\t[bad_icon]", "\n")]."
+			fail_msg += "\nDecl did not add itself to appropriate global list:\n[jointext(bad_icon, "\n\t")]."
 		if(LAZYLEN(bad_icon))
-			fail_msg += "\nNull final icon values:\n[jointext("\t[bad_icon]", "\n")]."
+			fail_msg += "\nNull final icon values:\n\t[jointext(bad_icon, "\n\t")]."
 		if(LAZYLEN(bad_colour))
-			fail_msg += "\nNull color values:\n[jointext("\t[bad_colour]", "\n")]."
+			fail_msg += "\nNull color values:\n\t[jointext(bad_colour, "\n\t")]."
 		if(LAZYLEN(bad_base_icon))
-			fail_msg += "\nNull base icon value:\n[jointext("\t[bad_base_icon]", "\n")]."
+			fail_msg += "\nNull base icon value:\n\t[jointext(bad_base_icon, "\n\t")]."
 		if(LAZYLEN(bad_base_state))
-			fail_msg += "\nMissing state from base icon:\n[jointext("\t[bad_base_state]", "\n")]."
+			fail_msg += "\nMissing state from base icon:\n\t[jointext(bad_base_state, "\n\t")]."
 		if(LAZYLEN(bad_decal_icon))
-			fail_msg += "\nDecal icon not set but decal lists populated:\n[jointext("\t[bad_decal_icon]", "\n")]."
+			fail_msg += "\nDecal icon not set but decal lists populated:\n\t[jointext(bad_decal_icon, "\n\t")]."
 		if(LAZYLEN(bad_decal_colour))
-			fail_msg += "\nNull color in final decal entry:\n[jointext("\t[bad_decal_colour]", "\n")]."
+			fail_msg += "\nNull color in final decal entry:\n\t[jointext(bad_decal_colour, "\n\t")]."
 		if(LAZYLEN(bad_decal_state))
-			fail_msg += "\nNon-existent decal icon state:\n[jointext("\t[bad_decal_state]", "\n")]."
+			fail_msg += "\nNon-existent decal icon state:\n\t[jointext(bad_decal_state, "\n\t")]."
 
 		fail(fail_msg)
 	else


### PR DESCRIPTION
## Description of changes
`jointext("[list]", "\n")` is different than `jointext(list, "\n")`. The former will just embed a text representation of the list type, i.e. `/list`. The latter will jointext the list, which is the desired behavior. I made the closet appearance unit test use the latter.

## Why and what will this PR improve
Fixes the closet appearance unit test just reporting `/list` instead of the list contents.