### PR TITLE
Added paint stripper.

### DIFF
--- a/code/_onclick/hud/screen/screen_lighting.dm
+++ b/code/_onclick/hud/screen/screen_lighting.dm
@@ -6,6 +6,6 @@
 	blend_mode       = BLEND_MULTIPLY
 	alpha            = 255
 
-/obj/screen/lighting_plane_master/proc/set_alpha(var/newalpha)
-	if(alpha != newalpha)
-		animate(src, alpha = newalpha, time = SSmobs.wait)
+/obj/screen/lighting_plane_master/set_alpha(var/new_alpha)
+	if(alpha != new_alpha)
+		animate(src, alpha = new_alpha, time = SSmobs.wait)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -743,9 +743,27 @@
 /atom/proc/get_color()
 	return color
 
-/// Set the color of this atom to `new_color`.
-/atom/proc/set_color(new_color)
-	color = new_color
+/* Set the atom colour. This is a stub effectively due to the broad use of direct setting. */
+// TODO: implement this everywhere that it should be used instead of direct setting.
+/atom/proc/set_color(var/new_color)
+	if(isnull(new_color))
+		return reset_color()
+	if(color != new_color)
+		color = new_color
+		return TRUE
+	return FALSE
+
+/atom/proc/reset_color()
+	if(!isnull(color))
+		color = null
+		return TRUE
+	return FALSE
+
+/atom/proc/set_alpha(var/new_alpha)
+	if(alpha != new_alpha)
+		alpha = new_alpha
+		return TRUE
+	return FALSE
 
 /// Get any power cell associated with this atom.
 /atom/proc/get_cell()

--- a/code/modules/reagents/chems/chems_pigments.dm
+++ b/code/modules/reagents/chems/chems_pigments.dm
@@ -63,6 +63,35 @@
 	color = "#aaaaaa"
 	uid = "chem_pigment_white"
 
+/decl/material/liquid/paint_stripper
+	name = "paint stripper"
+	uid = "liquid_paint_remover"
+	lore_text = "A highly toxic compound used as an effective paint stripper."
+	taste_description = "bleach and acid"
+	color = "#a0a0a0"
+	metabolism = REM * 0.2
+	value = 0.1
+	solvent_power = MAT_SOLVENT_MODERATE
+	toxicity = 10
+
+/decl/material/liquid/paint_stripper/proc/remove_paint(var/atom/painting, var/datum/reagents/holder)
+	if(istype(painting) && istype(holder))
+		var/keep_alpha = painting.alpha
+		painting.reset_color()
+		painting.set_alpha(keep_alpha)
+
+/decl/material/liquid/paint_stripper/touch_turf(var/turf/T, var/amount, var/datum/reagents/holder)
+	if(istype(T) && !isspaceturf(T))
+		remove_paint(T, holder)
+
+/decl/material/liquid/paint_stripper/touch_obj(var/obj/O, var/amount, var/datum/reagents/holder)
+	if(istype(O))
+		remove_paint(O, holder)
+
+/decl/material/liquid/paint_stripper/touch_mob(var/mob/living/M, var/amount, var/datum/reagents/holder)
+	if(istype(M))
+		remove_paint(M, holder)
+
 /decl/material/liquid/paint
 	name = "paint"
 	lore_text = "This paint will stick to almost any object."
@@ -76,8 +105,8 @@
 /decl/material/liquid/paint/proc/apply_paint(var/atom/painting, var/datum/reagents/holder)
 	if(istype(painting) && istype(holder))
 		var/keep_alpha = painting.alpha
-		painting.color = holder.get_color()
-		painting.alpha = keep_alpha
+		painting.set_color(holder.get_color())
+		painting.set_alpha(keep_alpha)
 
 /decl/material/liquid/paint/touch_turf(var/turf/T, var/amount, var/datum/reagents/holder)
 	if(istype(T) && !isspaceturf(T))

--- a/code/modules/reagents/reactions/reaction_other.dm
+++ b/code/modules/reagents/reactions/reaction_other.dm
@@ -75,3 +75,12 @@
 	required_reagents = list(/decl/material/liquid/plasticide = 1, /decl/material/liquid/water = 3)
 	result_amount = 5
 	mix_message = "The solution thickens and takes on a glossy sheen."
+
+//
+/decl/chemical_reaction/paint_stripper
+	name = "Paint Stripper"
+	//TODO: some way to mix chlorine and methane to make proper paint stripper.
+	required_reagents = list(/decl/material/liquid/acetone = 2, /decl/material/liquid/acid = 2)
+	result = /decl/material/liquid/paint_stripper
+	result_amount = 4
+	mix_message = "The mixture thins and clears."


### PR DESCRIPTION
## Description of changes
This is a very anemic feature PR. Adds paint stripper, which works like paint but backwards.

## Why and what will this PR improve
At the moment there's no way to properly reset the colour changes resulting from splashing a mob with paint. You can use white paint, but it's not perfect. This adds the bare bones of a paint stripper chem to do it properly.

## Authorship
Myself.

## Changelog
:cl:
add: Added paint stripper.
/:cl:
