### PR TITLE
Add Helping Hands

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -211,8 +211,8 @@
 			inv_box = sublist[2]
 			inv_box.screen_loc = "CENTER:[world.icon_size/2],BOTTOM:[hand_y_offset]"
 		hand_y_offset += world.icon_size
-		if(mymob.client)
-			mymob.client.screen |= inv_box
+	if(mymob.client)
+		mymob.client.screen |= hand_hud_objects
 
 	// Make sure all held items are on the screen and set to the correct screen loc.
 	var/datum/inventory_slot/inv_slot

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -152,7 +152,7 @@
 		gripper_datums += mymob.get_inventory_slot_datum(hand_tag)
 	gripper_datums = sortTim(gripper_datums, /proc/cmp_gripper_asc)
 
-	for(var/datum/inventory_slot/inv_slot in gripper_datums)
+	for(var/datum/inventory_slot/gripper/inv_slot in gripper_datums)
 
 		// Re-order the held slot list so it aligns with the display order.
 		var/hand_tag = inv_slot.slot_id
@@ -176,7 +176,7 @@
 		inv_box.icon_state = "hand_base"
 
 		inv_box.cut_overlays()
-		inv_box.add_overlay("hand_[hand_tag]", TRUE)
+		inv_box.add_overlay("hand_[inv_slot.hand_overlay || hand_tag]", TRUE)
 		if(inv_slot.ui_label)
 			inv_box.add_overlay("hand_[inv_slot.ui_label]", TRUE)
 		inv_box.update_icon()

--- a/code/datums/inventory_slots/inventory_gripper.dm
+++ b/code/datums/inventory_slots/inventory_gripper.dm
@@ -3,6 +3,8 @@
 	var/can_use_held_item = TRUE
 	var/dexterity = DEXTERITY_FULL
 	var/covering_slot_flags
+	/// If set, use this icon_state for the hand slot overlay; otherwise, use slot_id.
+	var/hand_overlay
 	quick_equip_priority = -1 // you quick-equip stuff by holding it in a gripper, so this ought to be dead last
 
 	// For reference, grippers do not use ui_loc, they have it set dynamically during /datum/hud/proc/rebuild_hands()

--- a/code/modules/augment/helping_hands.dm
+++ b/code/modules/augment/helping_hands.dm
@@ -1,0 +1,49 @@
+/obj/item/helpinghands
+	name = "back-mounted arms"
+	desc = "A pair of arms with an included harness worn on the back, controlled by a noninvasive spinal prosthesis."
+	icon = 'icons/mecha/mech_parts_held.dmi'
+	icon_state = "light_arms"
+	material = /decl/material/solid/metal/steel
+	slot_flags = SLOT_BACK
+	var/list/slot_types = list(
+		/datum/inventory_slot/gripper/left_hand/no_organ/helping,
+		/datum/inventory_slot/gripper/right_hand/no_organ/helping
+	)
+
+/obj/item/helpinghands/proc/add_hands(mob/user)
+	for (var/gripper_type in slot_types)
+		user.add_held_item_slot(new gripper_type)
+
+/obj/item/helpinghands/proc/remove_hands(mob/user)
+	for (var/datum/inventory_slot/gripper_type as anything in slot_types)
+		user.remove_held_item_slot(initial(gripper_type.slot_id))
+
+/obj/item/helpinghands/equipped(mob/user, slot)
+	. = ..()
+	if(!user)
+		return
+	switch(slot)
+		if(slot_back_str)
+			add_hands(user)
+		else
+			remove_hands(user)
+
+/obj/item/helpinghands/dropped(mob/user)
+	. = ..()
+	if(user)
+		remove_hands(user)
+
+/datum/inventory_slot/gripper/left_hand/no_organ
+	requires_organ_tag = null
+/datum/inventory_slot/gripper/right_hand/no_organ
+	requires_organ_tag = null
+
+/datum/inventory_slot/gripper/left_hand/no_organ/helping
+	slot_id = "helping_hand_l"
+	hand_overlay = BP_L_HAND
+	hand_sort_priority = 4
+
+/datum/inventory_slot/gripper/right_hand/no_organ/helping
+	slot_id = "helping_hand_r"
+	hand_overlay = BP_R_HAND
+	hand_sort_priority = 5

--- a/code/modules/mob/living/inventory.dm
+++ b/code/modules/mob/living/inventory.dm
@@ -168,7 +168,7 @@
 		if(held)
 			drop_from_inventory(held)
 		qdel(inv_slot)
-	LAZYREMOVE(_inventory_slots, slot)
+	LAZYREMOVE(_inventory_slots, inv_slot.slot_id)
 
 /mob/living/proc/get_jetpack()
 	var/obj/item/tank/jetpack/thrust = get_equipped_item(slot_back_str)

--- a/code/modules/mob/living/inventory.dm
+++ b/code/modules/mob/living/inventory.dm
@@ -46,10 +46,10 @@
 /mob/living/remove_held_item_slot(var/slot)
 	var/datum/inventory_slot/inv_slot = istype(slot, /datum/inventory_slot) ? slot : get_inventory_slot_datum(slot)
 	if(inv_slot)
-		LAZYREMOVE(_held_item_slots, slot)
+		LAZYREMOVE(_held_item_slots, inv_slot.slot_id)
 		remove_inventory_slot(inv_slot)
 		var/held_slots = get_held_item_slots()
-		if(get_active_held_item_slot() == slot && length(held_slots))
+		if(!get_active_held_item_slot() && length(held_slots))
 			select_held_item_slot(held_slots[1])
 		queue_hand_rebuild()
 

--- a/code/modules/mob/living/inventory.dm
+++ b/code/modules/mob/living/inventory.dm
@@ -39,7 +39,7 @@
 		qdel(existing_slot)
 	LAZYDISTINCTADD(_held_item_slots, held_slot.slot_id)
 	add_inventory_slot(held_slot)
-	if(!get_active_hand())
+	if(!get_active_held_item_slot())
 		select_held_item_slot(held_slot.slot_id)
 	queue_hand_rebuild()
 

--- a/nebula.dme
+++ b/nebula.dme
@@ -1656,6 +1656,7 @@
 #include "code\modules\atmospherics\components\unary\vent_scrubber.dm"
 #include "code\modules\augment\active.dm"
 #include "code\modules\augment\augment.dm"
+#include "code\modules\augment\helping_hands.dm"
 #include "code\modules\augment\simple.dm"
 #include "code\modules\augment\active\armblades.dm"
 #include "code\modules\augment\active\circuit.dm"


### PR DESCRIPTION
## Description of changes
Rebased version of #3187.

Adds Helping Hands from Caves of Qud, currently just called "back-mounted arms". The description and name are completely just placeholders. Mostly opening this for review and so that others can see how cool it is.

<details>
<summary> Screenshots </summary>

![image](https://github.com/NebulaSS13/Nebula/assets/110272328/b8a3c4f5-8b1f-458c-9355-d296c07a40dd)
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/40bdefb3-692b-4abe-9e3e-d39a981e7275)
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/598dca96-83d3-45a6-a404-5eb46d8fb7a4)
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/9f8d3d6c-0c2f-4d80-bc11-69a8339e0368)
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/1fe235e1-6b6f-4270-a3f9-4cc03e71b296)
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/692a57c5-938e-4555-bfa5-138445e8d1c6)
</details>

### TODO:
- [ ] Add worn sprite
- [ ] ~~Maybe replace placeholder mech sprite with something original?~~

#### Optional:
- [ ] Figure out how to make held items display on the mob?
- [ ] Make it obtainable somehow?

## Why and what will this PR improve
Mostly a proof-of-concept for organless hand slots, and adding hand slots with items.

## Changelog
:cl:
add: Adds back-mounted arms, which provide an extra two hand slots but take up a back slot.
/:cl: