### PR TITLE
Fix paint sprayers on walls and wall frames

### DIFF
--- a/code/game/objects/items/devices/paint_sprayer.dm
+++ b/code/game/objects/items/devices/paint_sprayer.dm
@@ -112,10 +112,6 @@
 			new_color = A.get_color()
 		change_color(new_color, user)
 
-	else if (A.atom_flags & ATOM_FLAG_CAN_BE_PAINTED)
-		A.set_color(paint_color)
-		. = TRUE
-
 	else if (istype(A, /turf/simulated/wall))
 		. = paint_wall(A, user)
 
@@ -129,8 +125,12 @@
 		to_chat(user, SPAN_WARNING("You can't paint an active exosuit. Dismantle it first."))
 		. = FALSE
 
+	else if (A.atom_flags & ATOM_FLAG_CAN_BE_PAINTED)
+		A.set_color(paint_color)
+		. = TRUE
+
 	else
-		to_chat(user, SPAN_WARNING("\The [src] can only be used on floors, windows, walls, exosuits or certain airlocks."))
+		to_chat(user, SPAN_WARNING("\The [src] can only be used on floors, windows, walls, exosuits, airlocks, and certain other objects."))
 		. = FALSE
 
 	if (.)

--- a/code/game/objects/items/devices/paint_sprayer.dm
+++ b/code/game/objects/items/devices/paint_sprayer.dm
@@ -115,6 +115,9 @@
 	else if (istype(A, /turf/simulated/wall))
 		. = paint_wall(A, user)
 
+	else if (istype(A, /obj/structure/wall_frame))
+		. = paint_wall_frame(A, user)
+
 	else if (istype(A, /turf/simulated/floor))
 		. = paint_floor(A, user, params)
 

--- a/code/game/objects/items/devices/paint_sprayer.dm
+++ b/code/game/objects/items/devices/paint_sprayer.dm
@@ -106,11 +106,13 @@
 		else if (istype(A, /turf/simulated/wall))
 			new_color = pick_color_from_wall(A, user)
 		else if (istype(A, /obj/structure/wall_frame))
-			var/obj/structure/wall_frame/WF = A
-			new_color = pick_color_from_wall_frame(WF, user)
+			new_color = pick_color_from_wall_frame(A, user)
 		else
 			new_color = A.get_color()
-		change_color(new_color, user)
+		if(!new_color)
+			to_chat(user, SPAN_NOTICE("You fail to scan a color from \the [A]."))
+		else
+			change_color(new_color, user)
 
 	else if (istype(A, /turf/simulated/wall))
 		. = paint_wall(A, user)

--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -6,7 +6,7 @@
 	desc = "A low wall section which serves as the base of windows, amongst other things."
 	icon = 'icons/obj/structures/wall_frame.dmi'
 	icon_state = "frame"
-	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CLIMBABLE | ATOM_FLAG_CAN_BE_PAINTED | ATOM_FLAG_ADJACENT_EXCEPTION
+	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CLIMBABLE | ATOM_FLAG_ADJACENT_EXCEPTION
 	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 	anchored = 1
 	density = 1

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -27,7 +27,6 @@ var/global/list/wall_fullblend_objects = list(
 	heat_capacity = 312500 //a little over 5 cm thick , 312500 for 1 m by 2.5 m by 0.25 m plasteel wall
 	explosion_resistance = 10
 	color = COLOR_STEEL
-	atom_flags = ATOM_FLAG_CAN_BE_PAINTED
 	turf_flags = TURF_IS_HOLOMAP_OBSTACLE
 
 	var/damage = 0


### PR DESCRIPTION
## Description of changes
Reorders the generic paintable flag handling to come after special-cased handling in the paint sprayer.
Removes the generic paintable flag from walls and frames.
Properly implements the handling for painting wall frames.

## Why and what will this PR improve
Wall frames and walls can be painted properly now.