### PR TITLE
Fix various photocopying and paper bundle issues

### DIFF
--- a/code/datums/type_cloning.dm
+++ b/code/datums/type_cloning.dm
@@ -6,3 +6,5 @@
 /matrix/GetCloneArgs()
 	return list(src) //Matrices handle copies themselves
 
+/image/GetCloneArgs()
+	return list(src) //Same for images

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -302,8 +302,7 @@
 	icon       = P.icon
 	icon_state = P.icon_state
 
-	for(var/overlay in P.overlays)
-		add_overlay(overlay)
+	copy_overlays(P)
 
 	var/paper_count = 0
 	var/photo_count = 0

--- a/code/modules/paperwork/printer.dm
+++ b/code/modules/paperwork/printer.dm
@@ -281,7 +281,19 @@
 			stop_printing_queue()
 			return FALSE
 		print_picture(queued_element)
-	else
+	else if(istype(queued_element, /obj/item/paper_bundle))
+		var/obj/item/paper_bundle/bundle = queued_element
+		var/photo_count = 0
+		for(var/obj/item/photo/picture in bundle.pages)
+			photo_count++
+		if(!has_enough_to_print((TONER_USAGE_PAPER * (length(bundle.pages) - photo_count)) + (TONER_USAGE_PHOTO * photo_count)))
+			var/obj/machinery/M = loc
+			if(istype(M))
+				M.state("Warning: Not enough paper or toner!")
+			stop_printing_queue()
+			return FALSE
+		print_paper_bundle(bundle)
+	else if(istype(queued_element, /obj/item/paper))
 		if(!has_enough_to_print(TONER_USAGE_PAPER))
 			var/obj/machinery/M = loc
 			if(istype(M))
@@ -289,6 +301,8 @@
 			stop_printing_queue()
 			return FALSE
 		print_paper(queued_element)
+	else
+		PRINT_STACK_TRACE("A printer printed something that wasn't a paper, paper bundle, or photo: [queued_element] ([queued_element.type])")
 
 	//#TODO: machinery should allow a component to trigger and wait for an animation sequence. So that we can drop out the paper in sync.
 	queued_element.dropInto(get_turf(loc))
@@ -305,6 +319,12 @@
 
 	use_toner(TONER_USAGE_PHOTO, FALSE) //photos use a lot of ink!
 	use_paper(1)
+
+/obj/item/stock_parts/printer/proc/print_paper_bundle(var/obj/item/paper_bundle/bundle)
+	for(var/obj/item/paper/page in bundle.pages)
+		print_paper(page)
+	for(var/obj/item/photo/picture in bundle.pages)
+		print_picture(picture)
 
 /obj/item/stock_parts/printer/proc/print_paper(var/obj/item/paper/P)
 	//Apply a greyscale filter on all stamps overlays

--- a/code/modules/paperwork/printer.dm
+++ b/code/modules/paperwork/printer.dm
@@ -319,12 +319,14 @@
 
 	use_toner(TONER_USAGE_PHOTO, FALSE) //photos use a lot of ink!
 	use_paper(1)
+	P.update_icon()
 
 /obj/item/stock_parts/printer/proc/print_paper_bundle(var/obj/item/paper_bundle/bundle)
 	for(var/obj/item/paper/page in bundle.pages)
 		print_paper(page)
 	for(var/obj/item/photo/picture in bundle.pages)
 		print_picture(picture)
+	bundle.update_icon()
 
 /obj/item/stock_parts/printer/proc/print_paper(var/obj/item/paper/P)
 	//Apply a greyscale filter on all stamps overlays
@@ -341,6 +343,7 @@
 
 	use_toner(TONER_USAGE_PAPER, FALSE)
 	use_paper(1)
+	P.update_icon() // reapply stamp overlays
 
 /obj/item/stock_parts/printer/proc/use_toner(var/amount, var/update_parent = TRUE)
 	if(!toner?.use_toner(amount))


### PR DESCRIPTION
## Description of changes
Adds separate handling for paper bundles in printers, instead of just assuming anything that's not a photo is a single sheet of paper. Also logs if something unexpected is printed.
Makes image cloning use BYOND's native image cloning, via `GetCloneArgs()` returning `list(src)`: `new /image(existing_image)` will clone `existing_image`.
Makes paper bundles properly use `copy_overlays(atom)` instead of `copy_overlays(atom.overlays)`. `copy_overlays()` specifically expects an atom and will fail (runtime, even) if a non-atom is passed.

## Why and what will this PR improve
Fixes image cloning, used in photocopied papers.
Fixes paper bundles being blank, sort of: the prior fix on stable wasn't properly copied to staging/dev so I'm hoping this one will be. It's also cleaner.
Fixes printers runtiming when trying to print a paper bundle. Now, paper bundles are handled properly and will print-ify all the photos and papers in them.
Also makes printing paper bundles check for the right amount of toner.