### PR TITLE
Adds missing check in find_file_by_name

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntdownloader.dm
@@ -43,6 +43,8 @@
 	if(!check_file_download(filename))
 		return 0
 	var/datum/computer_file/program/PRG = net.find_file_by_name(filename, OS_PROGRAMS_DIR, MF_ROLE_SOFTWARE)
+	if(!istype(PRG))
+		return 0
 	var/datum/file_storage/disk/destination = computer.mounted_storage["local"]
 	if(!destination)
 		return 0

--- a/code/modules/modular_computers/networking/network_files.dm
+++ b/code/modules/modular_computers/networking/network_files.dm
@@ -1,8 +1,10 @@
 /datum/computer_network/proc/find_file_by_name(filename, directory, mainframe_role = MF_ROLE_FILESERVER, list/accesses)
 	for(var/datum/extension/network_device/mainframe/M in get_mainframes_by_role(mainframe_role, accesses))
 		var/datum/computer_file/F = M.get_file(filename, directory)
-		if(F)
+		if(istype(F))
 			return F
+
+	return OS_FILE_NOT_FOUND
 
 /datum/computer_network/proc/get_all_files_of_type(file_type, mainframe_role = MF_ROLE_FILESERVER, uniques_only = FALSE, list/accesses)
 	. = list()


### PR DESCRIPTION

## Description of changes
Fixes missing ``istype`` in ``find_file_by_name``. This would cause the proc to return an error code too early in the case that a network had multiple file servers of a role, but only one had a certain file.
## Authorship
Myself