### PR TITLE
Corrects an issue with holidays clearing station name.

### DIFF
--- a/code/modules/holidays/_holiday.dm
+++ b/code/modules/holidays/_holiday.dm
@@ -29,6 +29,5 @@ var/global/datum/holiday/current_holiday
 		return
 	global.current_holiday = holiday_data
 	if(refresh_station_name)
-		global.using_map.station_name = null
-		station_name()
+		global.using_map.station_name = initial(global.using_map.station_name)
 		world.update_status()


### PR DESCRIPTION
- `station_name()` is called by `update_status()` anyway.
- Nulling the name was causing any preset station name to be lost.