### PR TITLE
Improve airlock speed and contamination safety

### DIFF
--- a/code/game/machinery/embedded_controller/airlock_program.dm
+++ b/code/game/machinery/embedded_controller/airlock_program.dm
@@ -9,7 +9,7 @@
 #define TARGET_INOPEN		-1
 #define TARGET_OUTOPEN		-2
 
-#define SENSOR_TOLERANCE 1
+#define SENSOR_TOLERANCE 0.5
 
 /datum/computer/file/embedded_program/airlock
 	var/tag_exterior_door
@@ -234,7 +234,7 @@
 						signalPump(tag_airpump, 1, 0, target_pressure)	//send a signal to start depressurizing
 					else
 						signalPump(tag_pump_out_internal, 1, 0, target_pressure) // if going inside, pump external air out of the airlock
-						signalPump(tag_pump_out_external, 1, 1, 1000) // make sure the air is actually going outside
+						signalPump(tag_pump_out_external, 1, 1, MAX_PUMP_PRESSURE) // make sure the air is actually going outside
 
 				else if(chamber_pressure <= target_pressure)
 					state = STATE_PRESSURIZE

--- a/code/modules/ZAS/Turf.dm
+++ b/code/modules/ZAS/Turf.dm
@@ -234,11 +234,10 @@
 		return gas
 
 	// Base behavior
-	. = air
-	if(!.)
-		. = make_air()
-		if(zone)
-			c_copy_air()
+	. = air || make_air()
+	if(zone)
+		c_copy_air()
+		zone = null
 
 /turf/remove_air(amount as num)
 	var/datum/gas_mixture/GM = return_air()

--- a/code/modules/ZAS/Zone.dm
+++ b/code/modules/ZAS/Zone.dm
@@ -84,6 +84,7 @@ Class Procs:
 	ASSERT(T.zone == src)
 	soft_assert(T in contents, "Lists are weird broseph")
 #endif
+	T.c_copy_air() // to avoid losing contents
 	contents.Remove(T)
 	fire_tiles.Remove(T)
 	T.zone = null

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -222,10 +222,7 @@
 			power_draw = pump_gas(src, air_contents, environment, transfer_moles, power_rating)
 		else //external -> internal
 			var/datum/pipe_network/network = network_in_dir(dir)
-			transfer_moles = calculate_transfer_moles(environment, air_contents, pressure_delta, network?.volume)
-
-			//limit flow rate from turfs
-			transfer_moles = min(transfer_moles, environment.total_moles*air_contents.volume/environment.volume)	//group_multiplier gets divided out here
+			transfer_moles = calculate_transfer_moles(environment, air_contents, pressure_delta, network?.volume) / environment.group_multiplier // limit it to just one turf's worth of gas per tick
 			power_draw = pump_gas(src, environment, air_contents, transfer_moles, power_rating)
 
 	else


### PR DESCRIPTION
## Description of changes
Fixes a bug causing airlocks to multiply their contaminants dramatically due to ZAS using stale airmix.
Reworks vent pump slowdown to properly scale to one turf's worth of input, instead of slowing down exponentially as it approaches zero.
Changes the airlock program sensor tolerance to 0.5, the lowest number that didn't also result in cycling taking ages. This should reduce how much contaminated air leaks out of cycle-to-external-air airlocks.
Changes the target external pressure for the external drain vent from 1000 to MAX_PUMP_PRESSURE, for more reliable results on volcanic planets with very high pressures. Unfortunately, some planets can still generate with pressures even higher than that.

## Why and what will this PR improve
Fixes an issue in ZAS.
Makes airlocks not take a fucking century to cycle.
Fixes downstream issues with airlock contamination in atmospheric environments.
Fixes cycle-to-external-air vents turning themselves off on volcanic planets.

## Authorship
Me.