### PR TITLE
Fix temperature sim causing infinite processing

### DIFF
--- a/code/__defines/MC.dm
+++ b/code/__defines/MC.dm
@@ -27,7 +27,7 @@ if (Datum.is_processing) {\
 		PRINT_STACK_TRACE("Failed to start processing. [log_info_line(Datum)] is already being processed by [Datum.is_processing] but queue attempt occured on [#Processor]."); \
 	}\
 } else {\
-	Datum.is_processing = #Processor;\
+	Datum.is_processing = Processor._internal_name;\
 	Processor.processing += Datum;\
 }
 
@@ -125,6 +125,9 @@ if(Datum.is_processing) {\
 	NEW_SS_GLOBAL(SS##X);\
 	PreInit();\
 }\
+/datum/controller/subsystem/##X{\
+	_internal_name = "SS" + #X;\
+}\
 /datum/controller/subsystem/##X
 
 #define PROCESSING_SUBSYSTEM_DEF(X) var/global/datum/controller/subsystem/processing/##X/SS##X;\
@@ -137,4 +140,5 @@ if(Datum.is_processing) {\
 		processing = SS##X.processing; \
 	}\
 }\
+/datum/controller/subsystem/processing/##X/_internal_name = "SS" + #X;\
 /datum/controller/subsystem/processing/##X

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -43,6 +43,8 @@
 
 	var/static/list/failure_strikes //How many times we suspect a subsystem type has crashed the MC, 3 strikes and you're out!
 
+	var/_internal_name //! A stringified version of the variable name for this subsystem. Used by the processing subsystem to make sure is_processing is unset properly.
+
 //Do not override
 ///datum/controller/subsystem/New()
 

--- a/code/controllers/subsystems/processing/processing.dm
+++ b/code/controllers/subsystems/processing/processing.dm
@@ -28,7 +28,7 @@ SUBSYSTEM_DEF(processing)
 		var/datum/thing = current_run[current_run.len]
 		current_run.len--
 		if(QDELETED(thing) || (call(thing, process_proc)(wait, times_fired, src) == PROCESS_KILL))
-			if(thing)
+			if(thing?.is_processing == _internal_name)
 				thing.is_processing = null
 			processing -= thing
 		if (MC_TICK_CHECK)


### PR DESCRIPTION
## Description of changes
Adds a variable to subsystems, `_internal_name`, for better bookkeeping with `is_processing`. Without this, the conversion from variable name to `is_processing` is one-way and so we can't tell what subsystem it last queued on. Tracking this helps prevent an issue where trying to dequeue something from SSobjs would instead dequeue it from SStemperature or vice versa. Now, a processing subsystem will only set a dequeued datum's `is_processing` to null if it's equal to their `_internal_name`.

## Why and what will this PR improve
Fixes lighters that run out of fuel spamming their extinguish message because their `is_processing` was set to null by temperature dequeueing.

## Authorship
Me.