### PR TITLE
Fix various issues with atom heating

### DIFF
--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -76,37 +76,33 @@
 	var/datum/extension/atmospherics_connection/connection = get_extension(src, /datum/extension/atmospherics_connection)
 	connection?.update_connected_network()
 
-/obj/machinery/portable_atmospherics/attackby(var/obj/item/W, var/mob/user)
-	if ((istype(W, /obj/item/tank) && !( src.destroyed )))
-		if (src.holding)
-			return
-		if(!user.try_unequip(W, src))
-			return
-		src.holding = W
+/obj/machinery/portable_atmospherics/attackby(var/obj/item/used_item, var/mob/user)
+	if ((istype(used_item, /obj/item/tank) && !destroyed))
+		if (holding)
+			return TRUE
+		if(!user.try_unequip(used_item, src))
+			return TRUE
+		holding = used_item
 		update_icon()
-		return
+		return TRUE
 
-	else if(IS_WRENCH(W) && !panel_open)
+	else if(IS_WRENCH(used_item) && !panel_open)
 		if(disconnect())
-			to_chat(user, "<span class='notice'>You disconnect \the [src] from the port.</span>")
+			to_chat(user, SPAN_NOTICE("You disconnect \the [src] from the port."))
 			update_icon()
-			return
-		else
-			var/obj/machinery/atmospherics/portables_connector/possible_port = locate(/obj/machinery/atmospherics/portables_connector/) in loc
-			if(possible_port)
-				if(connect(possible_port))
-					to_chat(user, "<span class='notice'>You connect \the [src] to the port.</span>")
-					update_icon()
-					return
-				else
-					to_chat(user, "<span class='notice'>\The [src] failed to connect to the port.</span>")
-					return
-			else
-				to_chat(user, "<span class='notice'>Nothing happens.</span>")
-				return ..()
+			return TRUE
+		var/obj/machinery/atmospherics/portables_connector/possible_port = locate(/obj/machinery/atmospherics/portables_connector) in loc
+		if(possible_port)
+			if(connect(possible_port))
+				to_chat(user, SPAN_NOTICE("You connect \the [src] to the port."))
+				update_icon()
+				return TRUE
+			to_chat(user, SPAN_NOTICE("\The [src] failed to connect to the port."))
+			return TRUE
+		return ..()
 
-	else if (istype(W, /obj/item/scanner/gas))
-		return
+	else if (istype(used_item, /obj/item/scanner/gas))
+		return FALSE // allow the scanner's afterattack to run
 
 	return ..()
 

--- a/code/game/objects/items/weapons/electric_welder.dm
+++ b/code/game/objects/items/weapons/electric_welder.dm
@@ -27,9 +27,8 @@
 		to_chat(user, (distance == 0 ? "It has [get_fuel()] [welding_resource] remaining. " : "") + "[cell] is attached.")
 
 /obj/item/weldingtool/electric/afterattack(var/obj/O, var/mob/user, var/proximity)
-	if(proximity && istype(O, /obj/structure/reagent_dispensers/fueltank))
-		if(!welding)
-			to_chat(user, SPAN_WARNING("\The [src] runs on an internal charge and does not need to be refuelled."))
+	if(proximity && istype(O, /obj/structure/reagent_dispensers/fueltank) && !welding)
+		to_chat(user, SPAN_WARNING("\The [src] runs on an internal charge and does not need to be refuelled."))
 		return
 	. = ..()
 

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -95,7 +95,7 @@
 			else
 				cig.light("<span class='notice'>[user] holds the [name] out for [M], and lights the [cig.name].</span>")
 			return
-	..()
+	return ..()
 
 /obj/item/flame/lighter/Process()
 	if(!submerged() && reagents.has_reagent(/decl/material/liquid/fuel))
@@ -190,6 +190,8 @@
 		O.reagents.trans_to_obj(src, max_fuel)
 		to_chat(user, "<span class='notice'>You refuel [src] from \the [O]</span>")
 		playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
+		return TRUE
+	return ..()
 
 /obj/item/flame/lighter/zippo/black
 	color = COLOR_DARK_GRAY

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -389,13 +389,12 @@
 	return ..()
 
 /obj/item/clothing/mask/smokable/cigarette/afterattack(obj/item/chems/glass/glass, var/mob/user, proximity)
-	..()
 	if(!proximity)
 		return
-	if(istype(glass)) //you can dip cigarettes into beakers
+	if(!lit && istype(glass)) //you can dip unlit cigarettes into beakers. todo: extinguishing lit cigarettes in beakers? disambiguation via intent?
 		if(!ATOM_IS_OPEN_CONTAINER(glass))
 			to_chat(user, SPAN_NOTICE("You need to take the lid off first."))
-			return
+			return TRUE
 		var/transfered = glass.reagents.trans_to_obj(src, chem_volume)
 		if(transfered)	//if reagents were transfered, show the message
 			to_chat(user, SPAN_NOTICE("You dip \the [src] into \the [glass]."))
@@ -404,6 +403,8 @@
 				to_chat(user, SPAN_NOTICE("[glass] is empty."))
 			else
 				to_chat(user, SPAN_NOTICE("[src] is full."))
+		return TRUE
+	return ..()
 
 /obj/item/clothing/mask/smokable/cigarette/attack_self(var/mob/user)
 	if(lit == 1)


### PR DESCRIPTION
## Description of changes
Fixes incorrect return values in portable atmos code, and does some cleanup to the area while I was at it.
Fixes zippo afterattack not calling parent.
Fixes electric welder not calling parent when attacking a welder fuel tank while lit.
Makes cigarette afterattack call parent if not dipping it in a beaker.

## Why and what will this PR improve
You can now heat stuff with zippo lighters and lit cigarettes and pipes. You can probably welderbomb with an electric welder now, if you so desired. You no longer heat canisters and other portable atmos objects when putting tanks into them.

## Authorship
Me.