### PR TITLE
Replace sprite accessory required_gender with bodytypes_allowed/bodytypes_denied

### DIFF
--- a/code/modules/sprite_accessories/_accessory.dm
+++ b/code/modules/sprite_accessories/_accessory.dm
@@ -25,8 +25,10 @@
 	var/icon
 	/// the icon_state of the accessory
 	var/icon_state
-	/// Restricted to specific genders. null matches any
-	var/required_gender
+	/// Restricted to specific bodytypes. null matches any
+	var/list/decl/bodytype/bodytypes_allowed
+	/// Restricted from specific bodytypes. null matches none
+	var/list/decl/bodytype/bodytypes_denied
 	/// Restrict some styles to specific root species names
 	var/list/species_allowed = list(SPECIES_HUMAN)
 	/// Restrict some styles to specific species names, irrespective of root species name
@@ -65,8 +67,6 @@
 	var/list/disallows_accessories
 
 /decl/sprite_accessory/proc/accessory_is_available(var/mob/owner, var/decl/species/species, var/decl/bodytype/bodytype)
-	if(!isnull(required_gender) && bodytype.associated_gender != required_gender)
-		return FALSE
 	if(species)
 		var/species_is_permitted = TRUE
 		if(species_allowed)
@@ -76,6 +76,10 @@
 		if(!species_is_permitted)
 			return FALSE
 	if(bodytype)
+		if(LAZYLEN(bodytypes_allowed) && !(bodytype.type in bodytypes_allowed))
+			return FALSE
+		if(LAZYISIN(bodytypes_denied, bodytype.type))
+			return FALSE
 		if(!isnull(bodytype_categories_allowed) && !(bodytype.bodytype_category in bodytype_categories_allowed))
 			return FALSE
 		if(!isnull(bodytype_categories_denied) && (bodytype.bodytype_category in bodytype_categories_denied))

--- a/code/modules/sprite_accessories/_accessory_facial.dm
+++ b/code/modules/sprite_accessories/_accessory_facial.dm
@@ -19,7 +19,8 @@
 /decl/sprite_accessory/facial_hair/shaved
 	name = "Shaved"
 	icon_state = "bald"
-	required_gender = null
+	bodytypes_allowed = null
+	bodytypes_denied = null
 	species_allowed = null
 	subspecies_allowed = null
 	bodytype_categories_allowed = null

--- a/code/modules/sprite_accessories/_accessory_hair.dm
+++ b/code/modules/sprite_accessories/_accessory_hair.dm
@@ -22,7 +22,8 @@
 	name = "Bald"
 	icon_state = "bald"
 	flags = VERY_SHORT | HAIR_BALD
-	required_gender = null
+	bodytypes_allowed = null
+	bodytypes_denied = null
 	species_allowed = null
 	subspecies_allowed = null
 	bodytype_categories_allowed = null


### PR DESCRIPTION
## Description of changes
Removes `required_gender` from sprite accessories and replaces it with `bodytypes_allowed` and `bodytypes_denied`.

## Why and what will this PR improve
`required_gender` didn't even use character gender, it used character bodytype 'associated gender'. This is basically the same functionality but more granular. Also, nothing used `required_gender` and I wanted bodytype (not subspecies) restrictions downstream. Could theoretically also be used for FBP-only (or non-FBP-only) hairs and markings.