### PR TITLE
Fix runtimes in psionics UI code

### DIFF
--- a/mods/content/psionics/system/psionics/interface/ui.dm
+++ b/mods/content/psionics/system/psionics/interface/ui.dm
@@ -1,6 +1,5 @@
 /obj/screen/psi
 	icon = 'mods/content/psionics/icons/psi.dmi'
-	var/mob/living/owner
 	var/hidden = TRUE
 
 /obj/screen/psi/Initialize(mapload, mob/_owner, ui_style, ui_color, ui_alpha)

--- a/mods/content/psionics/system/psionics/interface/ui_hub.dm
+++ b/mods/content/psionics/system/psionics/interface/ui_hub.dm
@@ -12,8 +12,8 @@
 	. = ..()
 	on_cooldown = image(icon, "cooldown")
 	components = list(
-		new /obj/screen/psi/armour(null, owner),
-		new /obj/screen/psi/toggle_psi_menu(null, owner, null, null, null, src)
+		new /obj/screen/psi/armour(null, _owner),
+		new /obj/screen/psi/toggle_psi_menu(null, _owner, null, null, null, src)
 	)
 	START_PROCESSING(SSprocessing, src)
 

--- a/mods/content/psionics/system/psionics/interface/ui_toggles.dm
+++ b/mods/content/psionics/system/psionics/interface/ui_toggles.dm
@@ -5,7 +5,8 @@
 
 /obj/screen/psi/armour/on_update_icon()
 	..()
-	if(invisibility == 0)
+	var/mob/living/owner = owner_ref.resolve()
+	if(istype(owner) && invisibility == 0)
 		icon_state = owner?.psi.use_psi_armour ? "psiarmour_on" : "psiarmour_off"
 
 /obj/screen/psi/armour/handle_click(mob/user, params)


### PR DESCRIPTION
## Description of changes
Removes the bespoke `owner` variable from `/obj/screen/psi`. Makes psi screen objects use `owner_ref.resolve()` or the `_owner` argument as necessary.

## Why and what will this PR improve
The psionics modpack screen objects used their own bespoke owner var that was partially deprecated but not fully removed when `owner_ref()` was added to dev. This caused some runtimes with psi stuff, most evident downstream on Replika models that start with psionics.