### PR TITLE
Fix additional 515 compatibility issues with proccalls

### DIFF
--- a/code/__defines/qdel.dm
+++ b/code/__defines/qdel.dm
@@ -29,7 +29,7 @@
 #define QDEL_NULL_SCREEN(item) if(client) { client.screen -= item; }; QDEL_NULL(item)
 #define QDEL_NULL_LIST(x) if(x) { for(var/y in x) { qdel(y) }}; if(x) {x.Cut(); x = null } // Second x check to handle items that LAZYREMOVE on qdel.
 #define QDEL_LIST(L) if(L) { for(var/I in L) qdel(I); L.Cut(); }
-#define QDEL_LIST_IN(L, time) addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(______qdel_list_wrapper), L), time, TIMER_STOPPABLE)
+#define QDEL_LIST_IN(L, time) addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(______qdel_list_wrapper), L), time, TIMER_STOPPABLE)
 #define QDEL_LIST_ASSOC(L) if(L) { for(var/I in L) { qdel(L[I]); qdel(I); } L.Cut(); }
 #define QDEL_LIST_ASSOC_VAL(L) if(L) { for(var/I in L) qdel(L[I]); L.Cut(); }
 

--- a/code/_helpers/animations.dm
+++ b/code/_helpers/animations.dm
@@ -5,7 +5,7 @@
 
 /proc/fade_out(image/I, list/show_to)
 	animate(I, alpha = 0, time = 0.5 SECONDS, easing = EASE_IN)
-	addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(remove_images_from_clients), I, show_to), 0.5 SECONDS)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(remove_images_from_clients), I, show_to), 0.5 SECONDS)
 
 /proc/animate_speech_bubble(image/I, list/show_to, duration)
 	if(!I)
@@ -17,7 +17,7 @@
 	for(var/client/C in show_to)
 		C.images += I
 	animate(I, transform = 0, alpha = 255, time = 0.2 SECONDS, easing = EASE_IN)
-	addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(fade_out), I, show_to), (duration - 0.5 SECONDS))
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(fade_out), I, show_to), (duration - 0.5 SECONDS))
 
 /proc/animate_receive_damage(atom/A)
 	var/pixel_x_diff = rand(-2,2)
@@ -53,7 +53,7 @@
 /proc/flick_overlay(image/I, list/show_to, duration)
 	for(var/client/C in show_to)
 		C.images += I
-	addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(remove_images_from_clients), I, show_to), duration)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(remove_images_from_clients), I, show_to), duration)
 
 /atom/movable/proc/do_attack_effect(atom/A, effect) //Simple effects for telegraphing or marking attack locations
 	if (effect)

--- a/code/_onclick/hud/ai_hud.dm
+++ b/code/_onclick/hud/ai_hud.dm
@@ -11,70 +11,70 @@
 	screen_loc = ui_ai_core
 	name = "AI Core"
 	icon_state = "ai_core"
-	proc_path = /mob/living/silicon/ai/proc/core
+	proc_path = TYPE_PROC_REF(/mob/living/silicon/ai, core)
 
 /decl/ai_hud/ai_announcement
 	screen_loc = ui_ai_announcement
 	name = "AI Announcement"
 	icon_state = "announcement"
-	proc_path = /mob/living/silicon/ai/proc/ai_announcement
+	proc_path = TYPE_PROC_REF(/mob/living/silicon/ai, ai_announcement)
 
 /decl/ai_hud/ai_cam_track
 	screen_loc = ui_ai_cam_track
 	name = "Track With Camera"
 	icon_state = "track"
-	proc_path = /mob/living/silicon/ai/proc/ai_camera_track
+	proc_path = TYPE_PROC_REF(/mob/living/silicon/ai, ai_camera_track)
 	input_procs = list(/mob/living/silicon/ai/proc/trackable_mobs = (AI_BUTTON_PROC_BELONGS_TO_CALLER|AI_BUTTON_INPUT_REQUIRES_SELECTION))
 
 /decl/ai_hud/ai_cam_light
 	screen_loc = ui_ai_cam_light
 	name = "Toggle Camera Lights"
 	icon_state = "camera_light"
-	proc_path = /mob/living/silicon/ai/proc/toggle_camera_light
+	proc_path = TYPE_PROC_REF(/mob/living/silicon/ai, toggle_camera_light)
 
 /decl/ai_hud/ai_cam_change_channel
 	screen_loc = ui_ai_cam_change_channel
 	name = "Jump to Camera Channel"
 	icon_state = "camera"
-	proc_path = /mob/living/silicon/ai/proc/ai_channel_change
+	proc_path = TYPE_PROC_REF(/mob/living/silicon/ai, ai_channel_change)
 	input_procs = list(/mob/living/silicon/ai/proc/get_camera_channel_list = (AI_BUTTON_PROC_BELONGS_TO_CALLER|AI_BUTTON_INPUT_REQUIRES_SELECTION))
 
 /decl/ai_hud/ai_sensor
 	screen_loc = ui_ai_sensor
 	name = "Set Sensor Mode"
 	icon_state = "ai_sensor"
-	proc_path = /mob/living/silicon/ai/proc/sensor_mode
+	proc_path = TYPE_PROC_REF(/mob/living/silicon/ai, sensor_mode)
 
 /decl/ai_hud/ai_manifest
 	screen_loc = ui_ai_crew_manifest
 	name = "Show Crew Manifest"
 	icon_state = "manifest"
-	proc_path = /mob/living/silicon/ai/proc/run_program
+	proc_path = TYPE_PROC_REF(/mob/living/silicon/ai, run_program)
 	input_args = list("crewmanifest")
 
 /decl/ai_hud/ai_take_image
 	screen_loc = ui_ai_take_image
 	name = "Toggle Camera Mode"
 	icon_state = "take_picture"
-	proc_path = /mob/living/silicon/ai/proc/ai_take_image
+	proc_path = TYPE_PROC_REF(/mob/living/silicon/ai, ai_take_image)
 
 /decl/ai_hud/ai_view_images
 	screen_loc = ui_ai_view_images
 	name = "View Images"
 	icon_state = "view_images"
-	proc_path = /mob/living/silicon/ai/proc/ai_view_images
+	proc_path = TYPE_PROC_REF(/mob/living/silicon/ai, ai_view_images)
 
 /decl/ai_hud/ai_laws
 	screen_loc = ui_ai_state_laws
 	name = "State Laws"
 	icon_state = "state_laws"
-	proc_path = /mob/living/silicon/ai/proc/ai_checklaws
+	proc_path = TYPE_PROC_REF(/mob/living/silicon/ai, ai_checklaws)
 
 /decl/ai_hud/ai_call_shuttle
 	screen_loc = ui_ai_call_shuttle
 	name = "Call Shuttle"
 	icon_state = "call_shuttle"
-	proc_path = /mob/living/silicon/ai/proc/ai_call_shuttle
+	proc_path = TYPE_PROC_REF(/mob/living/silicon/ai, ai_call_shuttle)
 
 /decl/ai_hud/ai_up
 	screen_loc = ui_ai_up
@@ -92,53 +92,53 @@
 	screen_loc = ui_ai_color
 	name = "Change Floor Color"
 	icon_state = "ai_floor"
-	proc_path = /mob/living/silicon/ai/proc/change_floor
+	proc_path = TYPE_PROC_REF(/mob/living/silicon/ai, change_floor)
 
 /decl/ai_hud/ai_hologram
 	screen_loc = ui_ai_holo_change
 	name = "Change Hologram"
 	icon_state = "ai_holo_change"
-	proc_path = /mob/living/silicon/ai/proc/ai_hologram_change
+	proc_path = TYPE_PROC_REF(/mob/living/silicon/ai, ai_hologram_change)
 
 /decl/ai_hud/ai_crew_monitor
 	screen_loc = ui_ai_crew_mon
 	name = "Crew Monitor"
 	icon_state = "crew_monitor"
-	proc_path = /mob/living/silicon/ai/proc/run_program
+	proc_path = TYPE_PROC_REF(/mob/living/silicon/ai, run_program)
 	input_args = list("sensormonitor")
 
 /decl/ai_hud/ai_power_override
 	screen_loc = ui_ai_power_override
 	name = "Toggle Power Override"
 	icon_state = "ai_p_override"
-	proc_path = /mob/living/silicon/ai/proc/ai_power_override
+	proc_path = TYPE_PROC_REF(/mob/living/silicon/ai, ai_power_override)
 
 /decl/ai_hud/ai_shutdown
 	screen_loc = ui_ai_shutdown
 	name = "Shutdown"
 	icon_state = "ai_shutdown"
-	proc_path = /mob/living/silicon/ai/proc/ai_shutdown
+	proc_path = TYPE_PROC_REF(/mob/living/silicon/ai, ai_shutdown)
 
 /decl/ai_hud/ai_move_hologram
 	screen_loc = ui_ai_holo_mov
 	name = "Toggle Hologram Movement"
 	icon_state = "ai_holo_mov"
-	proc_path = /mob/living/silicon/ai/proc/toggle_hologram_movement
+	proc_path = TYPE_PROC_REF(/mob/living/silicon/ai, toggle_hologram_movement)
 
 /decl/ai_hud/ai_core_icon
 	screen_loc = ui_ai_core_icon
 	name = "Pick Icon"
 	icon_state = "ai_core_pick"
-	proc_path = /mob/living/silicon/ai/proc/pick_icon
+	proc_path = TYPE_PROC_REF(/mob/living/silicon/ai, pick_icon)
 
 /decl/ai_hud/ai_status
 	screen_loc = ui_ai_status
 	name = "Pick Status"
 	icon_state = "ai_status"
-	proc_path = /mob/living/silicon/ai/proc/ai_statuschange
+	proc_path = TYPE_PROC_REF(/mob/living/silicon/ai, ai_statuschange)
 
 /decl/ai_hud/ai_inbuilt_comp
 	screen_loc = ui_ai_crew_rec
 	name = "Inbuilt Computer"
 	icon_state = "ai_crew_rec"
-	proc_path = /mob/living/silicon/proc/access_computer
+	proc_path = TYPE_PROC_REF(/mob/living/silicon, access_computer)

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -291,7 +291,7 @@ SUBSYSTEM_DEF(jobs)
 				if(age < job.minimum_character_age) // Nope.
 					continue
 				switch(age - job.ideal_character_age)
-					if(0 to -10)
+					if(-INFINITY to -10)
 						if(age < (job.minimum_character_age+10))
 							weightedCandidates[V] = 3 // Still a bit young.
 						else
@@ -611,7 +611,7 @@ SUBSYSTEM_DEF(jobs)
 		T.maptext = "<span style=\"[style]\">[copytext_char(text, 1, i)] </span>"
 		sleep(1)
 
-	addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(fade_location_blurb), src, T), duration)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(fade_location_blurb), src, T), duration)
 
 /proc/fade_location_blurb(client/C, obj/T)
 	animate(T, alpha = 0, time = 5)

--- a/code/controllers/subsystems/processing/mobs.dm
+++ b/code/controllers/subsystems/processing/mobs.dm
@@ -5,7 +5,7 @@ PROCESSING_SUBSYSTEM_DEF(mobs)
 	runlevels = RUNLEVEL_GAME|RUNLEVEL_POSTGAME
 	wait = 2 SECONDS
 
-	process_proc = /mob/proc/Life
+	process_proc = TYPE_PROC_REF(/mob, Life)
 
 	var/list/mob_list
 

--- a/code/controllers/subsystems/processing/processing.dm
+++ b/code/controllers/subsystems/processing/processing.dm
@@ -8,7 +8,7 @@ SUBSYSTEM_DEF(processing)
 
 	var/list/processing = list()
 	var/list/current_run = list()
-	var/process_proc = /datum/proc/Process
+	var/process_proc = TYPE_PROC_REF(/datum, Process)
 
 	var/debug_last_thing
 	var/debug_original_process_proc // initial() does not work with procs
@@ -43,7 +43,7 @@ SUBSYSTEM_DEF(processing)
 		debug_original_process_proc = null
 	else
 		debug_original_process_proc	= process_proc
-		process_proc = /datum/proc/DebugSubsystemProcess
+		process_proc = TYPE_PROC_REF(/datum, DebugSubsystemProcess)
 
 	to_chat(usr, "[name] - Debug mode [debug_original_process_proc ? "en" : "dis"]abled")
 

--- a/code/controllers/subsystems/processing/temperature.dm
+++ b/code/controllers/subsystems/processing/temperature.dm
@@ -2,4 +2,4 @@ PROCESSING_SUBSYSTEM_DEF(temperature)
 	name = "Temperature"
 	priority = SS_PRIORITY_TEMPERATURE
 	wait = 5 SECONDS
-	process_proc = /atom/proc/ProcessAtomTemperature
+	process_proc = TYPE_PROC_REF(/atom, ProcessAtomTemperature)

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -76,7 +76,7 @@ var/global/list/singularity_beacons = list()
 
 /obj/machinery/syndicate_beacon/proc/selfdestruct()
 	selfdestructing = 1
-	INVOKE_ASYNC(GLOBAL_PROC, PROC_REF(explosion), src.loc, 1, rand(1, 3), rand(3, 8), 10)
+	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(explosion), src.loc, 1, rand(1, 3), rand(3, 8), 10)
 
 ////////////////////////////////////////
 //Singularity beacon

--- a/code/modules/mob/floating_message.dm
+++ b/code/modules/mob/floating_message.dm
@@ -78,8 +78,8 @@ var/global/list/floating_chat_colors = list()
 
 	LAZYADD(holder.stored_chat_text, I)
 
-	addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(remove_floating_text), holder, I), duration)
-	addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(remove_images_from_clients), I, show_to), duration + CHAT_MESSAGE_EOL_FADE)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(remove_floating_text), holder, I), duration)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(remove_images_from_clients), I, show_to), duration + CHAT_MESSAGE_EOL_FADE)
 
 	return I
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -300,7 +300,7 @@
 				if(O) //It's possible that it could be deleted in the meantime.
 					O.hear_talk(src, stars(message), verb, speaking)
 
-	INVOKE_ASYNC(GLOBAL_PROC, PROC_REF(animate_speech_bubble), speech_bubble, speech_bubble_recipients | eavesdroppers, 30)
+	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(animate_speech_bubble), speech_bubble, speech_bubble_recipients | eavesdroppers, 30)
 	INVOKE_ASYNC(src, TYPE_PROC_REF(/atom/movable, animate_chat), message, speaking, italics, speech_bubble_recipients)
 	if(length(eavesdroppers))
 		INVOKE_ASYNC(src, TYPE_PROC_REF(/atom/movable, animate_chat), stars(message), speaking, italics, eavesdroppers)


### PR DESCRIPTION
## Description of changes
A number of global proc calls didn't use `GLOBAL_PROC_REF`. This fixes that.
Also makes processing subsystems use `PROC_REF`.
Once again, making a note here to ***NOT USE `PROC_REF` FOR ADDING PROCS TO VERB LISTS.***

## Why and what will this PR improve
A number of things were busted when running dev on 515. Thanks to BlueBip for reporting them.