### PR TITLE
Restored call to handle_proximity_update() to turf/Entered

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -143,7 +143,7 @@
 	Handle an atom entering this atom's proximity
 
 	Called when an atom enters this atom's proximity. Both this and the other atom
-	need to have the PROXMOVE flag (as it helps reduce lag).
+	need to have the MOVABLE_FLAG_PROXMOVE flag (as it helps reduce lag).
 
 	- `AM`: The atom entering proximity
 	- Return: `TRUE` if proximity should continue to be handled, otherwise `FALSE`

--- a/code/game/turfs/turf_enter.dm
+++ b/code/game/turfs/turf_enter.dm
@@ -5,7 +5,7 @@
 	if(!istype(mover) || !(mover.movable_flags & MOVABLE_FLAG_PROXMOVE))
 		return
 	for(var/atom/movable/neighbor in range(1))
-		if(objects > ENTER_PROXIMITY_LOOP_SANITY) 
+		if(objects > ENTER_PROXIMITY_LOOP_SANITY)
 			break // Don't let ore piles kill the server as well as the client.
 		if(neighbor.movable_flags & MOVABLE_FLAG_PROXMOVE)
 			objects++
@@ -52,3 +52,6 @@
 	// Handle zmimic
 	if(!A.bound_overlay && !(A.z_flags & ZMM_IGNORE) && TURF_IS_MIMICKING(above))
 		above.update_mimic()
+
+	// Handle non-listener proximity triggers.
+	handle_proximity_update(A)


### PR DESCRIPTION
I guess this got clobbered during the turf stuff awhile ago and nobody noticed because proximity listeners don't rely on this flag. It's needed for stuff that implements HasProximity via MOVABLE_FLAG_PROXMOVE (like singularity containment shields).