### PR TITLE
Areas can provide interior ambient lighting.

### DIFF
--- a/code/controllers/subsystems/ambience.dm
+++ b/code/controllers/subsystems/ambience.dm
@@ -16,18 +16,25 @@ SUBSYSTEM_DEF(ambience)
 		var/turf/target = curr[curr.len]
 		curr.len--
 		if(!QDELETED(target))
-			target.update_ambient_light_from_z()
+			target.update_ambient_light_from_z_or_area()
 		if (no_mc_tick)
 			CHECK_TICK
 		else if (MC_TICK_CHECK)
 			return
 
-/turf/proc/update_ambient_light_from_z()
+/turf/proc/update_ambient_light_from_z_or_area()
 
 	// If we're not outside, we don't show ambient light.
+	clear_ambient_light() // TODO: fix the delta issues resulting in burn-in so this can be run only when needed
+
+	var/override_light_power
+	var/override_light_color
 	if(!is_outside())
-		clear_ambient_light()
-		return FALSE
+		var/area/A = get_area(src)
+		if(!A || !A.interior_ambient_light_level)
+			return FALSE
+		override_light_power = A.interior_ambient_light_level
+		override_light_color = A.interior_ambient_light_color || COLOR_WHITE
 
 	// If we're dynamically lit, we want ambient light regardless of neighbors.
 	var/lit = TURF_IS_DYNAMICALLY_LIT_UNSAFE(src)
@@ -40,11 +47,16 @@ SUBSYSTEM_DEF(ambience)
 				break
 
 	if(lit)
+
+		// If we're using area lighting, we're indoors, so shouldn't use level data ambience.
+		if(override_light_power)
+			set_ambient_light(override_light_color || COLOR_WHITE, override_light_power)
+			return TRUE
+
 		// Grab what we need to set ambient light from our level handler.
 		var/datum/level_data/level_data = SSmapping.levels_by_z[z]
 		if(level_data?.ambient_light_level)
 			set_ambient_light(level_data.ambient_light_color, level_data.ambient_light_level)
 			return TRUE
 
-	clear_ambient_light()
 	return FALSE

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -13,6 +13,11 @@ var/global/list/areas = list()
 	luminosity =    0
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
 
+	// If set, will apply ambient light of this power to turfs under a ceiling.
+	var/interior_ambient_light_level
+	// If set, will apply ambient light of this colour to turfs under a ceiling.
+	var/interior_ambient_light_color
+
 	var/proper_name /// Automatically set by SetName and Initialize; cached result of strip_improper(name).
 	var/holomap_color	// Color of this area on the holomap. Must be a hex color (as string) or null.
 
@@ -111,6 +116,9 @@ var/global/list/areas = list()
 	var/area/old_area = get_area(T)
 	if(old_area == A)
 		return
+
+	var/old_area_ambience = old_area?.interior_ambient_light_level
+
 	A.contents.Add(T)
 	if(old_area)
 		old_area.Exited(T, A)
@@ -130,9 +138,13 @@ var/global/list/areas = list()
 			adjacent_turf.update_registrations_on_adjacent_area_change()
 
 	T.last_outside_check = OUTSIDE_UNCERTAIN
-	if(T.is_outside == OUTSIDE_AREA && T.is_outside() != old_outside)
+	var/outside_changed = T.is_outside() != old_outside
+	if(T.is_outside == OUTSIDE_AREA && outside_changed)
 		T.update_weather()
 		T.update_external_atmos_participation()
+
+	if(A.interior_ambient_light_level != old_area_ambience || outside_changed)
+		SSambience.queued |= T
 
 /turf/proc/update_registrations_on_adjacent_area_change()
 	for(var/obj/machinery/door/firedoor/door in src)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -140,6 +140,8 @@
 	if (!changing_turf)
 		PRINT_STACK_TRACE("Improper turf qdel. Do not qdel turfs directly.")
 
+	SSambience.queued -= src
+
 	changing_turf = FALSE
 
 	if (contents.len > !!lighting_overlay)
@@ -509,7 +511,7 @@
 	is_outside = new_outside
 	if(!skip_weather_update)
 		update_weather()
-	SSambience.queued += src
+	SSambience.queued |= src
 
 	last_outside_check = OUTSIDE_UNCERTAIN
 	update_external_atmos_participation()

--- a/code/modules/multiz/turf_mimic_edge.dm
+++ b/code/modules/multiz/turf_mimic_edge.dm
@@ -95,7 +95,7 @@
 	return
 /turf/simulated/mimic_edge/update_ambient_light(no_corner_update)
 	return
-/turf/simulated/mimic_edge/update_ambient_light_from_z()
+/turf/simulated/mimic_edge/update_ambient_light_from_z_or_area()
 	return
 /turf/simulated/mimic_edge/lighting_build_overlay(now)
 	return
@@ -171,7 +171,7 @@
 	return
 /turf/unsimulated/mimic_edge/update_ambient_light(no_corner_update)
 	return
-/turf/unsimulated/mimic_edge/update_ambient_light_from_z()
+/turf/unsimulated/mimic_edge/update_ambient_light_from_z_or_area()
 	return
 /turf/unsimulated/mimic_edge/lighting_build_overlay(now)
 	return
@@ -247,7 +247,7 @@
 	return
 /turf/exterior/mimic_edge/update_ambient_light(no_corner_update)
 	return
-/turf/exterior/mimic_edge/update_ambient_light_from_z()
+/turf/exterior/mimic_edge/update_ambient_light_from_z_or_area()
 	return
 /turf/exterior/mimic_edge/lighting_build_overlay(now)
 	return


### PR DESCRIPTION
## Description of changes
Adds area vars for luminosity and colour that are used when an interior turf updates ambience.

## Why and what will this PR improve
Allows for setting diffuse ambience as a way to moderate the pitch black shadows that result from multiz overhangs in ambient-lit areas. Example (ignore the runway difference):
![image](https://github.com/NebulaSS13/Nebula/assets/2468979/69a101f3-d35a-42fc-b275-17516a99da52)

## Authorship
Myself.

## Changelog
Nothing player-facing.