### PR TITLE
Merged /turf/exterior/open and /turf/simulated/open.

### DIFF
--- a/code/game/turfs/exterior/_exterior.dm
+++ b/code/game/turfs/exterior/_exterior.dm
@@ -4,7 +4,7 @@
 	footstep_type = /decl/footsteps/asteroid
 	icon_state = "0"
 	layer = PLATING_LAYER
-	open_turf_type = /turf/exterior/open
+	open_turf_type = /turf/open
 	turf_flags = TURF_FLAG_BACKGROUND | TURF_IS_HOLOMAP_PATH
 	zone_membership_candidate = TRUE
 	var/base_color

--- a/code/game/turfs/exterior/exterior_sky.dm
+++ b/code/game/turfs/exterior/exterior_sky.dm
@@ -1,33 +1,33 @@
-/turf/exterior/open/sky
+/turf/open/sky
 	name = "sky"
 	desc = "Hope you don't have a fear of heights..."
 	icon = 'icons/turf/exterior/sky_static.dmi'
 	icon_state = "0"
 	z_flags = 0
 
-/turf/exterior/open/sky/north
+/turf/open/sky/north
 	dir = NORTH
 
-/turf/exterior/open/sky/south
+/turf/open/sky/south
 	dir = SOUTH
 
-/turf/exterior/open/sky/west
+/turf/open/sky/west
 	dir = WEST
 
-/turf/exterior/open/sky/east
+/turf/open/sky/east
 	dir = EAST
 
-/turf/exterior/open/sky/moving
+/turf/open/sky/moving
 	icon = 'icons/turf/exterior/sky_slow.dmi'
 
-/turf/exterior/open/sky/moving/north
+/turf/open/sky/moving/north
 	dir = NORTH
 
-/turf/exterior/open/sky/moving/south
+/turf/open/sky/moving/south
 	dir = SOUTH
 
-/turf/exterior/open/sky/moving/west
+/turf/open/sky/moving/west
 	dir = WEST
 
-/turf/exterior/open/sky/moving/east
+/turf/open/sky/moving/east
 	dir = EAST

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -4,7 +4,7 @@
 		/decl/material/gas/oxygen = MOLES_O2STANDARD,
 		/decl/material/gas/nitrogen = MOLES_N2STANDARD
 	)
-	open_turf_type = /turf/simulated/open
+	open_turf_type = /turf/open
 	zone_membership_candidate = TRUE
 	abstract_type = /turf/simulated
 

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -46,7 +46,7 @@
 		var/turf/below = GetBelow(src)
 		if(istype(below) && !isspaceturf(below))
 			var/area/A = get_area(src)
-			N = A?.open_turf || open_turf_type || /turf/simulated/open
+			N = A?.open_turf || open_turf_type || /turf/open
 
 	if (!(atom_flags & ATOM_FLAG_INITIALIZED))
 		return new N(src)

--- a/code/modules/mining/drilling/drill_act.dm
+++ b/code/modules/mining/drilling/drill_act.dm
@@ -19,15 +19,3 @@
 
 /turf/space/drill_act()
 	SHOULD_CALL_PARENT(FALSE)
-
-/turf/simulated/open/drill_act()
-	SHOULD_CALL_PARENT(FALSE)
-	var/turf/T = GetBelow(src)
-	if(istype(T))
-		T.drill_act()
-
-/turf/exterior/open/drill_act()
-	SHOULD_CALL_PARENT(FALSE)
-	var/turf/T = GetBelow(src)
-	if(istype(T))
-		T.drill_act()

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -22,7 +22,7 @@
 	if(loc != old_loc)
 		return
 
-	var/turf/simulated/open/O = GetAbove(src)
+	var/turf/open/O = GetAbove(src)
 	var/atom/climb_target
 	if(istype(O))
 		for(var/turf/T in RANGE_TURFS(O, 1))
@@ -171,7 +171,7 @@
 	return TRUE
 
 /obj/item/pipe/can_fall(var/anchor_bypass = FALSE, var/turf/location_override = loc)
-	var/turf/simulated/open/below = loc
+	var/turf/open/below = loc
 	below = below.below
 
 	. = ..()

--- a/code/modules/multiz/stairs.dm
+++ b/code/modules/multiz/stairs.dm
@@ -14,7 +14,7 @@
 			warning("Stair created without level above: ([loc.x], [loc.y], [loc.z])")
 			return INITIALIZE_HINT_QDEL
 		if(!above.is_open())
-			above.ChangeTurf(/turf/simulated/open)
+			above.ChangeTurf(/turf/space) // This will be resolved to the appropriate open space type by ChangeTurf().
 	. = ..()
 
 /obj/structure/stairs/CheckExit(atom/movable/mover, turf/target)

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -1,41 +1,3 @@
-// Shared attackby behaviors that /turf/exterior/open also uses.
-/proc/shared_open_turf_attackhand(var/turf/target, var/mob/user)
-	for(var/atom/movable/M in target.below)
-		if(M.movable_flags & MOVABLE_FLAG_Z_INTERACT)
-			return M.attack_hand_with_interaction_checks(user)
-
-/proc/shared_open_turf_attackby(var/turf/target, obj/item/thing, mob/user)
-
-	if(istype(thing, /obj/item/stack/material/rods))
-		var/ladder = (locate(/obj/structure/ladder) in target)
-		if(ladder)
-			to_chat(user, SPAN_WARNING("\The [ladder] is in the way."))
-			return TRUE
-		var/obj/structure/lattice/lattice = locate(/obj/structure/lattice, target)
-		if(lattice)
-			return lattice.attackby(thing, user)
-		var/obj/item/stack/material/rods/rods = thing
-		if (rods.use(1))
-			to_chat(user, SPAN_NOTICE("You lay down the support lattice."))
-			playsound(target, 'sound/weapons/Genhit.ogg', 50, 1)
-			new /obj/structure/lattice(locate(target.x, target.y, target.z), rods.material.type)
-		return TRUE
-
-	if (istype(thing, /obj/item/stack/tile))
-		var/obj/item/stack/tile/tile = thing
-		tile.try_build_turf(user, target)
-		return TRUE
-
-	//To lay cable.
-	if(IS_COIL(thing) && target.try_build_cable(thing, user))
-		return TRUE
-
-	for(var/atom/movable/M in target.below)
-		if(M.movable_flags & MOVABLE_FLAG_Z_INTERACT)
-			return M.attackby(thing, user)
-
-	return FALSE
-
 /// `direction` is the direction the atom is trying to leave by.
 /turf/proc/CanZPass(atom/A, direction, check_neighbor_canzpass = TRUE)
 
@@ -59,9 +21,9 @@
 	return Enter(A, A)
 
 ////////////////////////////////
-// Open SIMULATED
+// Open space
 ////////////////////////////////
-/turf/simulated/open
+/turf/open
 	name = "open space"
 	icon = 'icons/turf/space.dmi'
 	icon_state = ""
@@ -70,29 +32,26 @@
 	z_flags = ZM_MIMIC_DEFAULTS | ZM_MIMIC_OVERWRITE | ZM_MIMIC_NO_AO | ZM_ALLOW_ATMOS
 	turf_flags = TURF_FLAG_BACKGROUND
 
-/turf/simulated/open/flooded
+/turf/open/flooded
 	name = "open water"
 	flooded = /decl/material/liquid/water
 
-/turf/simulated/open/update_dirt()
-	return 0
-
-/turf/simulated/open/Entered(var/atom/movable/mover, var/atom/oldloc)
+/turf/open/Entered(var/atom/movable/mover, var/atom/oldloc)
 	..()
 	mover.fall(oldloc)
 
 // Called when thrown object lands on this turf.
-/turf/simulated/open/hitby(var/atom/movable/AM)
+/turf/open/hitby(var/atom/movable/AM)
 	..()
 	if(!QDELETED(AM))
 		AM.fall()
 
 // override to make sure nothing is hidden
-/turf/simulated/open/levelupdate()
+/turf/open/levelupdate()
 	for(var/obj/O in src)
 		O.hide(0)
 
-/turf/simulated/open/examine(mob/user, distance, infix, suffix)
+/turf/open/examine(mob/user, distance, infix, suffix)
 	. = ..()
 	if(distance <= 2)
 		var/depth = 1
@@ -100,64 +59,56 @@
 			depth += 1
 		to_chat(user, "It is about [depth] level\s deep.")
 
-/turf/simulated/open/is_open()
+/turf/open/is_open()
 	return TRUE
 
-/turf/simulated/open/attackby(obj/item/C, mob/user)
-	return shared_open_turf_attackby(src, C, user)
+/turf/open/attackby(obj/item/C, mob/user)
+	if(istype(C, /obj/item/stack/material/rods))
+		var/ladder = (locate(/obj/structure/ladder) in src)
+		if(ladder)
+			to_chat(user, SPAN_WARNING("\The [ladder] is in the way."))
+			return TRUE
+		var/obj/structure/lattice/lattice = locate(/obj/structure/lattice, src)
+		if(lattice)
+			return lattice.attackby(C, user)
+		var/obj/item/stack/material/rods/rods = C
+		if (rods.use(1))
+			to_chat(user, SPAN_NOTICE("You lay down the support lattice."))
+			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
+			new /obj/structure/lattice(src, rods.material.type)
+		return TRUE
 
-/turf/simulated/open/attack_hand(mob/user)
+	if (istype(C, /obj/item/stack/tile))
+		var/obj/item/stack/tile/tile = C
+		tile.try_build_turf(user, src)
+		return TRUE
+
+	//To lay cable.
+	if(IS_COIL(C) && try_build_cable(C, user))
+		return TRUE
+
+	for(var/atom/movable/M in below)
+		if(M.movable_flags & MOVABLE_FLAG_Z_INTERACT)
+			return M.attackby(C, user)
+
+	return FALSE
+
+/turf/open/attack_hand(mob/user)
 	SHOULD_CALL_PARENT(FALSE)
-	return shared_open_turf_attackhand(src, user)
+	for(var/atom/movable/M in below)
+		if(M.movable_flags & MOVABLE_FLAG_Z_INTERACT)
+			return M.attack_hand_with_interaction_checks(user)
+	return FALSE
 
 //Most things use is_plating to test if there is a cover tile on top (like regular floors)
-/turf/simulated/open/is_plating()
+/turf/open/is_plating()
 	return TRUE
 
-/turf/simulated/open/cannot_build_cable()
+/turf/open/cannot_build_cable()
 	return 0
 
-////////////////////////////////
-// Open EXTERIOR
-////////////////////////////////
-/turf/exterior/open
-	name = "open space"
-	icon = 'icons/turf/space.dmi'
-	icon_state = ""
-	density = FALSE
-	pathweight = 100000
-	z_flags = ZM_MIMIC_DEFAULTS | ZM_MIMIC_OVERWRITE | ZM_MIMIC_NO_AO | ZM_ALLOW_ATMOS
-
-/turf/exterior/open/flooded
-	name = "open water"
-	flooded = /decl/material/liquid/water
-
-/turf/exterior/open/Entered(var/atom/movable/mover, var/atom/oldloc)
-	..()
-	mover.fall(oldloc)
-
-/turf/exterior/open/hitby(var/atom/movable/AM)
-	..()
-	if(!QDELETED(AM))
-		AM.fall()
-
-/turf/exterior/open/examine(mob/user, distance, infix, suffix)
-	. = ..()
-	if(distance <= 2)
-		var/depth = 1
-		for(var/turf/T = GetBelow(src); (istype(T) && T.is_open()); T = GetBelow(T))
-			depth += 1
-		to_chat(user, "It is about [depth] level\s deep.")
-
-/turf/exterior/open/is_open()
-	return TRUE
-
-/turf/exterior/open/attackby(obj/item/C, mob/user)
-	return shared_open_turf_attackby(src, C, user)
-
-/turf/exterior/open/attack_hand(mob/user)
+/turf/open/drill_act()
 	SHOULD_CALL_PARENT(FALSE)
-	return shared_open_turf_attackhand(src, user)
-
-/turf/exterior/open/cannot_build_cable()
-	return 0
+	var/turf/T = GetBelow(src)
+	if(istype(T))
+		T.drill_act()

--- a/code/modules/turbolift/turbolift_areas.dm
+++ b/code/modules/turbolift/turbolift_areas.dm
@@ -1,7 +1,7 @@
 // Used for creating the exchange areas.
 /area/turbolift
 	name = "Turbolift"
-	base_turf = /turf/simulated/open
+	base_turf = /turf/open
 	requires_power = 0
 	sound_env = SMALL_ENCLOSED
 	holomap_color = HOLOMAP_AREACOLOR_LIFTS

--- a/code/modules/turbolift/turbolift_map.dm
+++ b/code/modules/turbolift/turbolift_map.dm
@@ -157,7 +157,7 @@ INITIALIZE_IMMEDIATE(/obj/abstract/turbolift_spawner)
 					return
 
 				// Update path appropriately if needed.
-				var/swap_to = /turf/simulated/open
+				var/swap_to = /turf/space // this will be resolved to the appropriate open turf type by ChangeTurf().
 				if(cz == uz)                                                                       // Elevator.
 					if(wall_type && (tx == ux || ty == uy || tx == ex || ty == ey) && !(tx >= door_x1 && tx <= door_x2 && ty >= door_y1 && ty <= door_y2))
 						swap_to = wall_type

--- a/code/unit_tests/icon_tests.dm
+++ b/code/unit_tests/icon_tests.dm
@@ -8,8 +8,7 @@
 		/turf/unsimulated/mimic_edge,
 		/turf/exterior/mimic_edge,
 		/turf/simulated/mimic_edge,
-		/turf/exterior/open,
-		/turf/simulated/open
+		/turf/open
 	)
 
 /datum/unit_test/icon_test/turfs_shall_have_icon_states/start_test()

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -922,7 +922,7 @@
 
 			var/is_bad_door = FALSE
 			for(var/turf/T in D.locs)
-				if((istype(T, /turf/simulated/open) || isspaceturf(T)) && !(T.type in turf_exceptions))
+				if(T.is_open() && !(T.type in turf_exceptions))
 					is_bad_door = TRUE
 					log_bad("Invalid door turf: [log_info_line(T)]")
 			if(is_bad_door)

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -2608,7 +2608,7 @@
 	pixel_x = 24;
 	req_access = newlist()
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ship/scrap/crew/hallway/starboard)
 "fg" = (
 /obj/structure/lattice,
@@ -2753,7 +2753,7 @@
 /turf/simulated/floor/tiled/usedup,
 /area/ship/scrap/crew/hallway/port)
 "ft" = (
-/turf/simulated/open,
+/turf/open,
 /area/ship/scrap/cargo)
 "fu" = (
 /obj/structure/cable{
@@ -2929,7 +2929,7 @@
 /area/ship/scrap/crew/hallway/port)
 "fM" = (
 /obj/effect/shuttle_landmark/lift/top,
-/turf/simulated/open,
+/turf/open,
 /area/ship/scrap/cargo)
 "fN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,

--- a/maps/away/bearcat/bearcat_areas.dm
+++ b/maps/away/bearcat/bearcat_areas.dm
@@ -168,4 +168,4 @@
 /area/ship/scrap/shuttle/lift
   name = "Cargo Lift"
   icon_state = "shuttle3"
-  base_turf = /turf/simulated/open
+  base_turf = /turf/open

--- a/maps/away/unishi/unishi-2.dmm
+++ b/maps/away/unishi/unishi-2.dmm
@@ -593,7 +593,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "32-1"
 	},
-/turf/simulated/open,
+/turf/open,
 /area/unishi/common)
 "bO" = (
 /obj/machinery/floodlight,

--- a/maps/away/unishi/unishi-3.dmm
+++ b/maps/away/unishi/unishi-3.dmm
@@ -357,7 +357,7 @@
 	dir = 8;
 	icon_state = "railing0"
 	},
-/turf/simulated/open,
+/turf/open,
 /area/unishi/living)
 "bp" = (
 /turf/simulated/floor/tiled,
@@ -430,7 +430,7 @@
 /obj/structure/cable{
 	icon_state = "32-1"
 	},
-/turf/simulated/open,
+/turf/open,
 /area/unishi/living)
 "bB" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -2009,7 +2009,7 @@
 /area/unishi/living)
 "XA" = (
 /obj/structure/railing/mapped,
-/turf/simulated/open,
+/turf/open,
 /area/unishi/living)
 
 (1,1,1) = {"

--- a/maps/example/example-2.dmm
+++ b/maps/example/example-2.dmm
@@ -39,7 +39,7 @@
 /area/example/second)
 "es" = (
 /obj/machinery/light,
-/turf/simulated/open,
+/turf/open,
 /area/example/second)
 "fJ" = (
 /obj/machinery/light/small{
@@ -181,7 +181,7 @@
 /area/example/second)
 "nB" = (
 /obj/effect/shuttle_landmark/upper_level,
-/turf/simulated/open,
+/turf/open,
 /area/space)
 "nC" = (
 /obj/effect/floor_decal/corner/mauve/mono,
@@ -209,7 +209,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/example/second)
 "oS" = (
-/turf/simulated/open,
+/turf/open,
 /area/space)
 "pc" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -359,13 +359,13 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/example/second)
 "wP" = (
-/turf/simulated/open,
+/turf/open,
 /area/example/second)
 "xk" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/open,
+/turf/open,
 /area/example/second)
 "xs" = (
 /turf/space,
@@ -509,7 +509,7 @@
 /area/example/second)
 "GG" = (
 /obj/structure/railing/mapped,
-/turf/simulated/open,
+/turf/open,
 /area/example/second)
 "GP" = (
 /obj/machinery/light{
@@ -585,7 +585,7 @@
 /area/example/second)
 "NY" = (
 /obj/structure/ladder,
-/turf/simulated/open,
+/turf/open,
 /area/example/second)
 "Pc" = (
 /obj/effect/floor_decal/corner/orange{
@@ -655,7 +655,7 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/example/second)
 "VL" = (
-/turf/simulated/open,
+/turf/open,
 /area/turbolift/example/second)
 "Xm" = (
 /obj/structure/iv_drip,
@@ -669,7 +669,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/open,
+/turf/open,
 /area/example/second)
 "XE" = (
 /turf/simulated/wall/r_wall/prepainted,

--- a/maps/example/example-3.dmm
+++ b/maps/example/example-3.dmm
@@ -11,7 +11,7 @@
 /turf/simulated/floor,
 /area/example/third)
 "cj" = (
-/turf/simulated/open,
+/turf/open,
 /area/turbolift/example/third)
 "cw" = (
 /obj/machinery/atmospherics/portables_connector,
@@ -61,7 +61,7 @@
 /area/example/third)
 "jb" = (
 /obj/machinery/light,
-/turf/simulated/open,
+/turf/open,
 /area/example/third)
 "lK" = (
 /turf/simulated/floor/glass,
@@ -71,7 +71,7 @@
 /turf/simulated/floor,
 /area/example/third)
 "nG" = (
-/turf/simulated/open,
+/turf/open,
 /area/space)
 "nN" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -132,7 +132,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/open,
 /area/example/third)
 "wD" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -209,7 +209,7 @@
 /turf/simulated/floor,
 /area/example/third)
 "Ke" = (
-/turf/simulated/open,
+/turf/open,
 /area/example/third)
 "KS" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -275,7 +275,7 @@
 /area/example/third)
 "TM" = (
 /obj/structure/catwalk,
-/turf/simulated/open,
+/turf/open,
 /area/example/third)
 "TO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -286,7 +286,7 @@
 /area/example/third)
 "UC" = (
 /obj/structure/ladder,
-/turf/simulated/open,
+/turf/open,
 /area/example/third)
 "UM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{

--- a/maps/example/example_areas.dm
+++ b/maps/example/example_areas.dm
@@ -35,7 +35,7 @@
 	arrival_sound = null
 	lift_announce_str = null
 
-	base_turf = /turf/simulated/open
+	base_turf = /turf/open
 
 /area/turbolift/example/first
 	name = "Testing Site First Floor Lift"

--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -13770,7 +13770,7 @@
 	},
 /obj/structure/lattice,
 /turf/simulated/floor/plating,
-/turf/simulated/open,
+/turf/open,
 /area/exodus/engineering/sublevel_access)
 "aDl" = (
 /obj/machinery/atmospherics/pipe/zpipe/down/red{
@@ -13778,7 +13778,7 @@
 	},
 /obj/structure/lattice,
 /turf/simulated/floor/plating,
-/turf/simulated/open,
+/turf/open,
 /area/exodus/engineering/sublevel_access)
 "aDm" = (
 /obj/structure/reagent_dispensers/beerkeg,
@@ -14480,7 +14480,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/turf/simulated/open,
+/turf/open,
 /area/exodus/engineering/sublevel_access)
 "aEI" = (
 /obj/structure/shuttle/engine/propulsion/burst{

--- a/maps/ministation/ministation-1.dmm
+++ b/maps/ministation/ministation-1.dmm
@@ -266,7 +266,7 @@
 /obj/machinery/atmospherics/pipe/zpipe/down/supply,
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,
 /obj/structure/disposalpipe/down,
-/turf/simulated/open,
+/turf/open,
 /area/ministation/maint/l2centraln)
 "bH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -407,7 +407,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/w2)
 "cN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -502,7 +502,7 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/w2)
 "dN" = (
 /obj/structure/cable{
@@ -821,7 +821,7 @@
 /turf/simulated/floor/plating,
 /area/ministation/maint/l2centrals)
 "gz" = (
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/e2)
 "gB" = (
 /obj/structure/cable{
@@ -1776,7 +1776,7 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/w2)
 "md" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -2636,7 +2636,7 @@
 	dir = 4;
 	icon_state = "warningcorner"
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/w2)
 "qO" = (
 /obj/machinery/cryopod{
@@ -2827,7 +2827,7 @@
 	dir = 1;
 	icon_state = "warningcorner"
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/w2)
 "rA" = (
 /obj/structure/table/woodentable,
@@ -3357,7 +3357,7 @@
 /obj/abstract/landmark{
 	name = "bluespace_a"
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/e2)
 "tx" = (
 /obj/machinery/door/firedoor{
@@ -4151,7 +4151,7 @@
 "wr" = (
 /obj/structure/lattice,
 /obj/structure/ladder,
-/turf/simulated/open,
+/turf/open,
 /area/ministation/maint/l2centrals)
 "ws" = (
 /turf/simulated/floor/tiled,
@@ -4670,7 +4670,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/maint/nebypass)
 "yl" = (
 /obj/structure/displaycase,
@@ -6625,7 +6625,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/w2)
 "MU" = (
 /obj/structure/filing_cabinet/chestdrawer,
@@ -6747,7 +6747,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hall/w2)
 "NC" = (
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/w2)
 "ND" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7316,7 +7316,7 @@
 /obj/structure/cable{
 	icon_state = "32-1"
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/maint/hydromaint)
 "RQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7416,7 +7416,7 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/w2)
 "SA" = (
 /obj/machinery/network/relay{
@@ -7841,7 +7841,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/maint/sebypass)
 "Wi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{

--- a/maps/ministation/ministation-2.dmm
+++ b/maps/ministation/ministation-2.dmm
@@ -637,7 +637,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	icon_state = "warningcorner"
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/n3)
 "ch" = (
 /obj/structure/cable{
@@ -1741,7 +1741,7 @@
 "hY" = (
 /obj/structure/lattice,
 /obj/structure/ladder,
-/turf/simulated/open,
+/turf/open,
 /area/ministation/maint/l3nw)
 "if" = (
 /obj/machinery/door/window/eastright,
@@ -3001,7 +3001,7 @@
 "pb" = (
 /obj/structure/lattice,
 /obj/structure/ladder,
-/turf/simulated/open,
+/turf/open,
 /area/ministation/maint/l3sw)
 "pf" = (
 /obj/effect/floor_decal/corner/blue{
@@ -3355,7 +3355,7 @@
 /obj/abstract/landmark{
 	name = "bluespace_a"
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/n3)
 "tx" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -3365,7 +3365,7 @@
 "ty" = (
 /obj/structure/lattice,
 /obj/structure/ladder,
-/turf/simulated/open,
+/turf/open,
 /area/ministation/maint/l3se)
 "tA" = (
 /obj/effect/floor_decal/corner/yellow/full,
@@ -3435,7 +3435,7 @@
 /area/ministation/court)
 "ug" = (
 /obj/structure/catwalk,
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/n3)
 "uh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3662,7 +3662,7 @@
 "xc" = (
 /obj/structure/lattice,
 /obj/structure/ladder,
-/turf/simulated/open,
+/turf/open,
 /area/ministation/maint/l3ne)
 "xg" = (
 /obj/machinery/light{
@@ -4546,7 +4546,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/n3)
 "Dp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4842,7 +4842,7 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s3)
 "GD" = (
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/n3)
 "GF" = (
 /obj/structure/disposalpipe/segment,
@@ -5132,7 +5132,7 @@
 /obj/structure/disposalpipe/down{
 	dir = 4
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/maint/l3central)
 "Kg" = (
 /obj/structure/cable{
@@ -5646,7 +5646,7 @@
 /obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/railing/mapped,
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/n3)
 "OG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5745,7 +5745,7 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/n3)
 "Pg" = (
 /obj/structure/cable{
@@ -6418,7 +6418,7 @@
 	dir = 8;
 	icon_state = "warning"
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/n3)
 "TR" = (
 /obj/structure/window/basic{
@@ -6580,7 +6580,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/maint/l3se)
 "Vi" = (
 /obj/machinery/light_switch{
@@ -6904,7 +6904,7 @@
 /obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/railing/mapped,
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/n3)
 "XE" = (
 /obj/structure/catwalk,
@@ -6912,7 +6912,7 @@
 	dir = 8;
 	icon_state = "warningcorner"
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/hall/n3)
 "XI" = (
 /obj/effect/floor_decal/carpet/green/corners,

--- a/maps/ministation/ministation-3.dmm
+++ b/maps/ministation/ministation-3.dmm
@@ -229,7 +229,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/maint/l4overpass)
 "Aj" = (
 /obj/structure/cable,
@@ -264,7 +264,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/maint/l4overpass)
 "CJ" = (
 /obj/structure/cable{
@@ -411,7 +411,7 @@
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
 	dir = 4
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ministation/maint/l4central)
 "VO" = (
 /obj/structure/cable{

--- a/maps/ministation/ministation_areas.dm
+++ b/maps/ministation/ministation_areas.dm
@@ -333,8 +333,8 @@
 
 /area/turbolift/l2
 	name = "Station Level 2"
-	base_turf = /turf/simulated/open
+	base_turf = /turf/open
 
 /area/turbolift/l3
 	name = "Station Level 3"
-	base_turf = /turf/simulated/open
+	base_turf = /turf/open

--- a/maps/planets/test_planet/neutralia-4.dmm
+++ b/maps/planets/test_planet/neutralia-4.dmm
@@ -3,19 +3,19 @@
 /turf/unsimulated/dark_filler,
 /area/exoplanet/neutralia/sky)
 "b" = (
-/turf/exterior/open,
+/turf/open,
 /area/exoplanet/neutralia/sky)
 "c" = (
 /obj/abstract/level_data_spawner/neutralia/sky,
-/turf/exterior/open,
+/turf/open,
 /area/exoplanet/neutralia/sky)
 "d" = (
 /obj/abstract/map_data/neutralia,
-/turf/exterior/open,
+/turf/open,
 /area/exoplanet/neutralia/sky)
 "e" = (
 /obj/effect/overmap/visitable/sector/planetoid/neutralia,
-/turf/exterior/open,
+/turf/open,
 /area/exoplanet/neutralia/sky)
 
 (1,1,1) = {"

--- a/maps/planets/test_planet/test_planet.dm
+++ b/maps/planets/test_planet/test_planet.dm
@@ -121,7 +121,7 @@
 	name             = "neutralia sky"
 	level_id         = NEUTRALIA_SKY_LEVEL_ID
 	base_area        = /area/exoplanet/neutralia/sky
-	base_turf        = /turf/exterior/open
+	base_turf        = /turf/open
 	border_filler    = /turf/unsimulated/dark_filler
 
 /datum/level_data/planetoid/neutralia/surface

--- a/maps/random_ruins/space_ruins/multi_zas_test.dmm
+++ b/maps/random_ruins/space_ruins/multi_zas_test.dmm
@@ -10,7 +10,7 @@
 /turf/simulated/floor,
 /area/template_noop)
 "d" = (
-/turf/simulated/open,
+/turf/open,
 /area/template_noop)
 "e" = (
 /turf/unsimulated/floor/shuttle_ceiling,

--- a/maps/tradeship/tradeship-1.dmm
+++ b/maps/tradeship/tradeship-1.dmm
@@ -634,7 +634,7 @@
 "br" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/down,
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/maintenance/lower)
 "bt" = (
 /obj/effect/floor_decal/corner/beige{
@@ -1239,7 +1239,7 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo/lower)
 "dj" = (
 /obj/effect/floor_decal/corner/beige{
@@ -1345,7 +1345,7 @@
 /area/ship/trade/cargo/lower)
 "dv" = (
 /obj/machinery/light,
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo/lower)
 "dw" = (
 /obj/effect/floor_decal/corner/beige{
@@ -2165,7 +2165,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
 "lZ" = (
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo/lower)
 "mb" = (
 /obj/effect/floor_decal/corner/beige{

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -1942,7 +1942,7 @@
 	icon_state = "32-1"
 	},
 /obj/structure/disposalpipe/down,
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/crew/hallway/starboard)
 "eL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -2061,7 +2061,7 @@
 /area/ship/trade/cargo)
 "eV" = (
 /obj/structure/catwalk,
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo)
 "fa" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -2208,7 +2208,7 @@
 "fp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk,
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo)
 "fr" = (
 /obj/structure/closet/crate,
@@ -2218,7 +2218,7 @@
 /obj/random/bomb_supply,
 /obj/item/storage/box/syringes,
 /obj/structure/catwalk,
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo)
 "fs" = (
 /obj/structure/catwalk,
@@ -2229,7 +2229,7 @@
 	pixel_x = 24;
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo)
 "fu" = (
 /obj/structure/cable{
@@ -2328,20 +2328,20 @@
 "fI" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo)
 "fJ" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/railing/mapped,
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo)
 "fK" = (
 /obj/structure/catwalk,
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo)
 "fN" = (
 /obj/effect/paint/brown,
@@ -2438,7 +2438,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "fZ" = (
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo)
 "ga" = (
 /obj/structure/catwalk,
@@ -2449,7 +2449,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo)
 "gc" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
@@ -2603,7 +2603,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo)
 "gt" = (
 /obj/structure/emergency_dispenser/west,
@@ -2691,7 +2691,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo)
 "gI" = (
 /obj/random/maintenance,
@@ -2717,7 +2717,7 @@
 	dir = 8;
 	icon_state = "warning"
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo)
 "gN" = (
 /obj/effect/floor_decal/techfloor/orange{
@@ -2755,7 +2755,7 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo)
 "gW" = (
 /obj/structure/catwalk,
@@ -2771,7 +2771,7 @@
 	pixel_y = -20;
 	dir = 1
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo)
 "hb" = (
 /obj/machinery/power/terminal{
@@ -4691,7 +4691,7 @@
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
 	dir = 1
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo)
 "nW" = (
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -5178,7 +5178,7 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo)
 "sG" = (
 /obj/effect/floor_decal/corner/beige{
@@ -6772,7 +6772,7 @@
 /obj/structure/handrail{
 	dir = 4
 	},
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo)
 "KO" = (
 /obj/structure/cable{
@@ -7923,7 +7923,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/catwalk,
 /obj/structure/railing/mapped,
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/cargo)
 "Yc" = (
 /obj/structure/cable{

--- a/maps/tradeship/tradeship-3.dmm
+++ b/maps/tradeship/tradeship-3.dmm
@@ -461,7 +461,7 @@
 	icon_state = "32-2"
 	},
 /obj/structure/lattice,
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/maintenance/solars)
 "bg" = (
 /obj/structure/cable{
@@ -995,7 +995,7 @@
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/solars)
 "GP" = (
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/maintenance/solars)
 "HN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -1273,7 +1273,7 @@
 	dir = 8
 	},
 /obj/structure/lattice,
-/turf/simulated/open,
+/turf/open,
 /area/ship/trade/command/bridge_upper)
 "ZU" = (
 /obj/machinery/network/telecomms_hub{

--- a/maps/tradeship/tradeship_areas.dm
+++ b/maps/tradeship/tradeship_areas.dm
@@ -318,12 +318,12 @@
 
 /area/turbolift/tradeship_cargo
 	name = "Lower Cargo Bay"
-	base_turf = /turf/simulated/open
+	base_turf = /turf/open
 
 /area/turbolift/tradeship_upper
 	name = "Upper Cargo Bay"
-	base_turf = /turf/simulated/open
+	base_turf = /turf/open
 
 /area/turbolift/tradeship_roof
 	name = "Solar Array Access"
-	base_turf = /turf/simulated/open
+	base_turf = /turf/open

--- a/mods/content/corporate/away_sites/lar_maria/lar_maria-2.dmm
+++ b/mods/content/corporate/away_sites/lar_maria/lar_maria-2.dmm
@@ -2100,7 +2100,7 @@
 /turf/simulated/floor/plating,
 /area/lar_maria/hallway)
 "gD" = (
-/turf/simulated/open,
+/turf/open,
 /area/lar_maria/hallway)
 "gE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -2265,7 +2265,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/open,
 /area/lar_maria/hallway)
 "hf" = (
 /obj/structure/window/basic{
@@ -2286,7 +2286,7 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/open,
+/turf/open,
 /area/lar_maria/hallway)
 "hi" = (
 /obj/machinery/power/apc{
@@ -3077,7 +3077,7 @@
 /obj/structure/cable{
 	icon_state = "32-1"
 	},
-/turf/simulated/open,
+/turf/open,
 /area/lar_maria/solar_control)
 "nb" = (
 /obj/structure/tank_rack/oxygen,

--- a/mods/content/government/away_sites/icarus/icarus-2.dmm
+++ b/mods/content/government/away_sites/icarus/icarus-2.dmm
@@ -6,7 +6,7 @@
 /turf/unsimulated/mask,
 /area/mine/unexplored)
 "ac" = (
-/turf/simulated/open,
+/turf/open,
 /area/icarus/open)
 "ad" = (
 /turf/exterior/wall,
@@ -861,7 +861,7 @@
 /area/icarus/vessel)
 "cR" = (
 /obj/structure/lattice,
-/turf/simulated/open,
+/turf/open,
 /area/icarus/open)
 "cS" = (
 /obj/structure/rack,
@@ -1263,7 +1263,7 @@
 /area/icarus/open)
 "dZ" = (
 /obj/effect/icarus/irradiate,
-/turf/simulated/open,
+/turf/open,
 /area/icarus/open)
 "ea" = (
 /obj/structure/cable{

--- a/mods/species/bayliens/adherent/datum/species.dm
+++ b/mods/species/bayliens/adherent/datum/species.dm
@@ -96,7 +96,7 @@
 				float_is_usable = TRUE
 				break
 	if(float_is_usable)
-		if(istype(landing, /turf/simulated/open))
+		if(landing.is_open())
 			H.visible_message("\The [H] descends from \the [landing].", "You descend regally.")
 		else
 			H.visible_message("\The [H] floats gracefully down from \the [landing].", "You land gently on \the [landing].")

--- a/tools/map_migrations/3634_openspace_merge.txt
+++ b/tools/map_migrations/3634_openspace_merge.txt
@@ -1,0 +1,2 @@
+/turf/simulated/open/@SUBTYPES : /turf/open/@SUBTYPES{@OLD} 
+/turf/exterior/open/@SUBTYPES : /turf/open/@SUBTYPES{@OLD} 


### PR DESCRIPTION
## Description of changes
- Merges simulated and exterior open turfs into `/turf/open`.
- Replaces some ChangeTurf uses of open turf types with `/turf/space` as ChangeTurf will handle this appropriately in multiz contexts.
- Replaces a couple of typechecks with `is_open()`.

## Why and what will this PR improve
Less redundant code, more flexible code.

## Authorship
Myself.

## Changelog
Nothing player-facing.