### PR TITLE
Fluid reagents are now turf reagents.

### DIFF
--- a/code/__defines/fluids.dm
+++ b/code/__defines/fluids.dm
@@ -7,30 +7,24 @@
 #define FLUID_MAX_DEPTH FLUID_DEEP*4 // Arbitrary max value for flooding.
 #define FLUID_PUSH_THRESHOLD 20      // Amount of flow needed to push items.
 
-// Expects /turf for T.
-#define ADD_ACTIVE_FLUID_SOURCE(T)    if(!T.changing_turf) { SSfluids.water_sources[T] = TRUE; }
-#define REMOVE_ACTIVE_FLUID_SOURCE(T) SSfluids.water_sources -= T
-
-// Expects /obj/effect/fluid for F.
-#define ADD_ACTIVE_FLUID(F)           if(!QDELETED(F)) { SSfluids.active_fluids[F] = TRUE; }
-#define REMOVE_ACTIVE_FLUID(F)        SSfluids.active_fluids -= F
-
-// Expects turf for T,
-#define UPDATE_FLUID_BLOCKED_DIRS(T) \
-	if(isnull(T.fluid_blocked_dirs)) {\
-		T.fluid_blocked_dirs = 0; \
-		for(var/obj/structure/window/W in T) { \
-			if(W.density) T.fluid_blocked_dirs |= W.dir; \
-		} \
-		for(var/obj/machinery/door/window/D in T) {\
-			if(D.density) T.fluid_blocked_dirs |= D.dir; \
-		} \
+// Expects /turf for TURF.
+#define ADD_ACTIVE_FLUID_SOURCE(TURF)    if(!TURF.changing_turf) { SSfluids.water_sources[TURF] = TRUE; }
+#define REMOVE_ACTIVE_FLUID_SOURCE(TURF) SSfluids.water_sources -= TURF
+#define ADD_ACTIVE_FLUID(TURF)           if(!QDELETED(TURF)) { SSfluids.active_fluids[TURF] = TRUE; }
+#define REMOVE_ACTIVE_FLUID(TURF)        SSfluids.active_fluids -= TURF
+#define UPDATE_FLUID_BLOCKED_DIRS(TURF)                     \
+	if(isnull(TURF.fluid_blocked_dirs)) {                   \
+		TURF.fluid_blocked_dirs = 0;                        \
+		for(var/obj/structure/window/W in TURF) {           \
+			if(W.density) TURF.fluid_blocked_dirs |= W.dir; \
+		}                                                   \
+		for(var/obj/machinery/door/window/D in TURF) {      \
+			if(D.density) TURF.fluid_blocked_dirs |= D.dir; \
+		}                                                   \
 	}
 
 // We share overlays for all fluid turfs to sync icon animation.
-#define APPLY_FLUID_OVERLAY(img_state) \
-	if(!SSfluids.fluid_images[img_state]) SSfluids.fluid_images[img_state] = image('icons/effects/liquids.dmi',img_state); \
-	add_overlay(SSfluids.fluid_images[img_state]);
+#define APPLY_FLUID_OVERLAY(img_state) if(!SSfluids.fluid_images[img_state]) SSfluids.fluid_images[img_state] = image('icons/effects/liquids.dmi',img_state); add_overlay(SSfluids.fluid_images[img_state]);
 
 #define FLUID_MAX_ALPHA 200
 #define FLUID_MIN_ALPHA 96

--- a/code/__defines/fluids.dm
+++ b/code/__defines/fluids.dm
@@ -23,9 +23,6 @@
 		}                                                   \
 	}
 
-// We share overlays for all fluid turfs to sync icon animation.
-#define APPLY_FLUID_OVERLAY(img_state) if(!SSfluids.fluid_images[img_state]) SSfluids.fluid_images[img_state] = image('icons/effects/liquids.dmi',img_state); add_overlay(SSfluids.fluid_images[img_state]);
-
 #define FLUID_MAX_ALPHA 200
 #define FLUID_MIN_ALPHA 96
 #define TANK_WATER_MULTIPLIER 5

--- a/code/controllers/subsystems/fluids.dm
+++ b/code/controllers/subsystems/fluids.dm
@@ -21,7 +21,6 @@ SUBSYSTEM_DEF(fluids)
 	var/tmp/active_fluids_copied_yet = FALSE
 	var/tmp/list/processing_fluids
 
-	var/tmp/list/fluid_images =        list()
 	var/tmp/list/checked_targets =     list()
 	var/tmp/list/gurgles =             list(
 		'sound/effects/gurgle1.ogg',

--- a/code/game/atoms_fluids.dm
+++ b/code/game/atoms_fluids.dm
@@ -7,9 +7,6 @@
 		reagents.trans_to_holder(fluids, reagents.total_volume)
 		fluids.trans_to_holder(reagents, min(fluids.total_volume, reagents.maximum_volume))
 
-/atom/proc/return_fluid()
-	return null
-
 /atom/proc/check_fluid_depth(var/min)
 	return 0
 

--- a/code/game/machinery/cracker.dm
+++ b/code/game/machinery/cracker.dm
@@ -42,19 +42,17 @@
 
 	// Produce materials.
 	var/turf/T = get_turf(src)
-	if(istype(T))
-		var/obj/effect/fluid/F = T.return_fluid()
-		if(istype(F))
+	if(istype(T) && T.reagents?.total_volume)
 
-			// Drink more water!
-			var/consuming = min(F.reagents.total_volume, fluid_consumption_per_tick)
-			F.reagents.remove_any(consuming)
-			T.show_bubbles()
+		// Drink more water!
+		var/consuming = min(T.reagents.total_volume, fluid_consumption_per_tick)
+		T.reagents.remove_any(consuming)
+		T.show_bubbles()
 
-			// Gas production.
-			var/datum/gas_mixture/produced = new
-			var/gen_amt = min(1, (gas_generated_per_tick * (consuming/fluid_consumption_per_tick)))
-			produced.adjust_gas(/decl/material/gas/oxygen,  gen_amt)
-			produced.adjust_gas(/decl/material/gas/hydrogen, gen_amt * 2)
-			produced.temperature = T20C //todo water temperature
-			air_contents.merge(produced)
+		// Gas production.
+		var/datum/gas_mixture/produced = new
+		var/gen_amt = min(1, (gas_generated_per_tick * (consuming/fluid_consumption_per_tick)))
+		produced.adjust_gas(/decl/material/gas/oxygen,  gen_amt)
+		produced.adjust_gas(/decl/material/gas/hydrogen, gen_amt * 2)
+		produced.temperature = T20C //todo water temperature
+		air_contents.merge(produced)

--- a/code/game/objects/effects/fluids.dm
+++ b/code/game/objects/effects/fluids.dm
@@ -1,90 +1,44 @@
-/obj/effect/fluid_overlay
-	name = ""
-	icon = 'icons/effects/liquids.dmi'
-	icon_state = "puddle"
-	anchored = TRUE
-	simulated = 0
-	opacity = FALSE
-	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
-	layer = FLY_LAYER
-	alpha = 0
-	color = COLOR_LIQUID_WATER
-	var/update_lighting = FALSE
+/atom/movable/fluid_overlay
+	name                = ""
+	icon                = 'icons/effects/liquids.dmi'
+	icon_state          = "puddle"
+	anchored            = TRUE
+	simulated           = FALSE
+	opacity             = FALSE
+	mouse_opacity       = MOUSE_OPACITY_UNCLICKABLE
+	layer               = FLY_LAYER
+	alpha               = 0
+	color               = COLOR_LIQUID_WATER
+	is_spawnable_type   = FALSE
 
-/obj/effect/fluid_overlay/Initialize()
-	atom_flags |= ATOM_FLAG_OPEN_CONTAINER
-	icon_state = ""
-	. = ..()
-	var/turf/simulated/T = get_turf(src)
-	if(!isturf(T) || !T.CanFluidPass())
-		return INITIALIZE_HINT_QDEL
-	if(istype(T))
-		T.unwet_floor(FALSE)
-
-/obj/effect/fluid_overlay/airlock_crush()
-	qdel(src)
-
-/obj/effect/fluid_overlay/Move()
-	PRINT_STACK_TRACE("A fluid overlay had Move() called!")
-	return FALSE
-
-/obj/effect/fluid_overlay/Destroy()
-	var/turf/old_loc = get_turf(src)
-	for(var/checkdir in global.cardinal)
-		var/turf/neighbor = get_step(old_loc, checkdir)
-		if(neighbor)
-			ADD_ACTIVE_FLUID(neighbor)
-	REMOVE_ACTIVE_FLUID(loc)
-	SSfluids.pending_flows -= src
-	. = ..()
-	if(istype(old_loc) && old_loc.last_slipperiness > 0)
-		old_loc.wet_floor(old_loc.last_slipperiness)
-
-/obj/effect/fluid_overlay/on_update_icon()
-
-	cut_overlays()
+/atom/movable/fluid_overlay/on_update_icon()
 	var/datum/reagents/loc_reagents = loc?.reagents
-	if(!loc_reagents)
-		return
-
-	if(loc_reagents.total_volume > FLUID_OVER_MOB_HEAD)
+	var/reagent_volume = loc_reagents?.total_volume
+	if(reagent_volume > FLUID_OVER_MOB_HEAD)
 		layer = DEEP_FLUID_LAYER
 	else
 		layer = SHALLOW_FLUID_LAYER
-
-	color = loc_reagents.get_color()
-
-	if(!loc_reagents.total_volume)
-		return
-
-	var/decl/material/main_reagent = loc_reagents.get_primary_reagent_decl()
+	var/new_color = loc_reagents?.get_color()
+	if(color != new_color)
+		color = new_color
+	var/decl/material/main_reagent = loc_reagents?.get_primary_reagent_decl()
 	if(main_reagent) // TODO: weighted alpha from all reagents, not just primary
-		alpha = clamp(CEILING(255*(loc_reagents.total_volume/FLUID_DEEP)) * main_reagent.opacity, main_reagent.min_fluid_opacity, main_reagent.max_fluid_opacity)
-
-	if(loc_reagents.total_volume <= FLUID_PUDDLE)
-		APPLY_FLUID_OVERLAY("puddle")
-	else if(loc_reagents.total_volume <= FLUID_SHALLOW)
-		APPLY_FLUID_OVERLAY("shallow_still")
-	else if(loc_reagents.total_volume < FLUID_DEEP)
-		APPLY_FLUID_OVERLAY("mid_still")
-	else if(loc_reagents.total_volume < (FLUID_DEEP*2))
-		APPLY_FLUID_OVERLAY("deep_still")
+		alpha = clamp(CEILING(255*(reagent_volume/FLUID_DEEP)) * main_reagent.opacity, main_reagent.min_fluid_opacity, main_reagent.max_fluid_opacity)
 	else
-		APPLY_FLUID_OVERLAY("ocean")
-	compile_overlays()
-
-	if(update_lighting)
-		update_lighting = FALSE
-		var/glowing
-		for(var/rtype in loc_reagents.reagent_volumes)
-			var/decl/material/reagent = GET_DECL(rtype)
-			if(REAGENT_VOLUME(reagents, rtype) >= 3 && reagent.radioactivity)
-				glowing = TRUE
-				break
-		if(glowing)
-			set_light(1, 0.2, COLOR_GREEN)
-		else
-			set_light(0)
+		alpha = FLUID_MIN_ALPHA
+	var/new_icon_state
+	if(reagent_volume <= FLUID_PUDDLE)
+		new_icon_state = "puddle"
+	else if(reagent_volume <= FLUID_SHALLOW)
+		new_icon_state = "shallow_still"
+	else if(reagent_volume < FLUID_DEEP)
+		new_icon_state = "mid_still"
+	else if(reagent_volume < (FLUID_DEEP*2))
+		new_icon_state = "deep_still"
+	else
+		new_icon_state = "ocean"
+	if(new_icon_state != icon_state)
+		icon_state = new_icon_state
 
 // Map helper.
 /obj/abstract/fluid_mapped

--- a/code/game/objects/effects/fluids.dm
+++ b/code/game/objects/effects/fluids.dm
@@ -1,7 +1,7 @@
 /atom/movable/fluid_overlay
 	name                = ""
 	icon                = 'icons/effects/liquids.dmi'
-	icon_state          = "puddle"
+	icon_state          = ""
 	anchored            = TRUE
 	simulated           = FALSE
 	opacity             = FALSE
@@ -12,33 +12,45 @@
 	is_spawnable_type   = FALSE
 
 /atom/movable/fluid_overlay/on_update_icon()
+
 	var/datum/reagents/loc_reagents = loc?.reagents
 	var/reagent_volume = loc_reagents?.total_volume
+
+	// Update layer.
+	var/new_layer
 	if(reagent_volume > FLUID_OVER_MOB_HEAD)
-		layer = DEEP_FLUID_LAYER
+		new_layer = DEEP_FLUID_LAYER
 	else
-		layer = SHALLOW_FLUID_LAYER
+		new_layer = SHALLOW_FLUID_LAYER
+	if(layer != new_layer)
+		layer = new_layer
+
+	// Update colour.
 	var/new_color = loc_reagents?.get_color()
 	if(color != new_color)
 		color = new_color
+
+	// Update alpha.
 	var/decl/material/main_reagent = loc_reagents?.get_primary_reagent_decl()
+	var/new_alpha
 	if(main_reagent) // TODO: weighted alpha from all reagents, not just primary
-		alpha = clamp(CEILING(255*(reagent_volume/FLUID_DEEP)) * main_reagent.opacity, main_reagent.min_fluid_opacity, main_reagent.max_fluid_opacity)
+		new_alpha = clamp(CEILING(255*(reagent_volume/FLUID_DEEP)) * main_reagent.opacity, main_reagent.min_fluid_opacity, main_reagent.max_fluid_opacity)
 	else
-		alpha = FLUID_MIN_ALPHA
-	var/new_icon_state
+		new_alpha = FLUID_MIN_ALPHA
+	if(new_alpha != alpha)
+		alpha = new_alpha
+
+	// Update icon state. We use overlays so flick() can work on the base fluid overlay.
 	if(reagent_volume <= FLUID_PUDDLE)
-		new_icon_state = "puddle"
+		set_overlays("puddle")
 	else if(reagent_volume <= FLUID_SHALLOW)
-		new_icon_state = "shallow_still"
+		set_overlays("shallow_still")
 	else if(reagent_volume < FLUID_DEEP)
-		new_icon_state = "mid_still"
+		set_overlays("mid_still")
 	else if(reagent_volume < (FLUID_DEEP*2))
-		new_icon_state = "deep_still"
+		set_overlays("deep_still")
 	else
-		new_icon_state = "ocean"
-	if(new_icon_state != icon_state)
-		icon_state = new_icon_state
+		set_overlays("ocean")
 
 // Map helper.
 /obj/abstract/fluid_mapped

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -35,18 +35,17 @@
 	var/moppable
 	if(isturf(A))
 		var/turf/T = A
-		var/obj/effect/fluid/F = locate() in T
-		if(F && F.reagents.total_volume > 0)
-			if(F.reagents.total_volume > FLUID_SHALLOW)
+		if(T?.reagents?.total_volume > 0)
+			if(T.reagents.total_volume > FLUID_SHALLOW)
 				to_chat(user, SPAN_WARNING("There is too much water here to be mopped up."))
 			else
 				user.visible_message(SPAN_NOTICE("\The [user] begins to mop up \the [T]."))
-				if(do_after(user, 40, T) && F && !QDELETED(F))
-					if(F.reagents.total_volume > FLUID_SHALLOW)
+				if(do_after(user, 40, T) && !QDELETED(T))
+					if(T.reagents?.total_volume > FLUID_SHALLOW)
 						to_chat(user, SPAN_WARNING("There is too much water here to be mopped up."))
 					else
-						qdel(F)
 						to_chat(user, SPAN_NOTICE("You have finished mopping!"))
+						T.reagents?.clear_reagents()
 			return
 		moppable = TRUE
 

--- a/code/game/objects/items/weapons/paint.dm
+++ b/code/game/objects/items/weapons/paint.dm
@@ -26,7 +26,7 @@ var/global/list/cached_icons = list()
 
 /obj/item/chems/glass/paint/on_update_icon()
 	. = ..()
-	if(reagents.total_volume)
+	if(reagents?.total_volume)
 		add_overlay(overlay_image('icons/obj/reagentfillings.dmi', "paintbucket", reagents.get_color()))
 
 /obj/item/chems/glass/paint/red

--- a/code/game/objects/structures/fishtanks.dm
+++ b/code/game/objects/structures/fishtanks.dm
@@ -94,11 +94,9 @@ var/global/list/fishtank_cache = list()
 
 /obj/structure/glass_tank/dump_contents()
 	. = ..()
-	if(reagents && reagents.total_volume)
-		var/turf/T = get_turf(src)
-		var/obj/effect/fluid/F = locate() in T
-		if(!F) F = new(T)
-		reagents.trans_to_holder(F.reagents, reagents.total_volume)
+	var/turf/T = get_turf(src)
+	if(reagents?.total_volume && T)
+		reagents.trans_to_turf(T, T.reagents, reagents.total_volume)
 
 var/global/list/global/aquarium_states_and_layers = list(
 	"b" = FLY_LAYER - 0.02,

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -75,11 +75,9 @@ var/global/list/hygiene_props = list()
 				visible_message("\The [src] gurgles and overflows!")
 				next_gurgle = world.time + 80
 				playsound(T, pick(SSfluids.gurgles), 50, 1)
-			var/obj/effect/fluid/F = locate() in T
-			var/adding = min(flood_amt-F?.reagents.total_volume, rand(30,50)*clogged)
+			var/adding = min(flood_amt-T?.reagents?.total_volume, rand(30,50)*clogged)
 			if(adding > 0)
-				if(!F) F = new(T)
-				F.reagents.add_reagent(/decl/material/liquid/water, adding)
+				T.add_fluid(/decl/material/liquid/water, adding)
 
 /obj/structure/hygiene/proc/drain()
 	if(!can_drain) return

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -14,7 +14,10 @@
 	var/timer_id
 
 // This is not great.
-/turf/simulated/proc/wet_floor(var/wet_val = 1, var/overwrite = FALSE)
+/turf/proc/wet_floor(var/wet_val = 1, var/overwrite = FALSE)
+	return
+
+/turf/simulated/wet_floor(var/wet_val = 1, var/overwrite = FALSE)
 
 	if(is_flooded(absolute = TRUE))
 		return

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -14,9 +14,6 @@
 	var/timer_id
 
 // This is not great.
-/turf/proc/wet_floor(var/wet_val = 1, var/overwrite = FALSE)
-	return
-
 /turf/simulated/wet_floor(var/wet_val = 1, var/overwrite = FALSE)
 
 	if(is_flooded(absolute = TRUE))
@@ -33,12 +30,12 @@
 		wet_overlay = image('icons/effects/water.dmi',src,"wet_floor")
 		overlays += wet_overlay
 
-	timer_id = addtimer(CALLBACK(src, TYPE_PROC_REF(/turf/simulated, unwet_floor)), 8 SECONDS, (TIMER_STOPPABLE|TIMER_UNIQUE|TIMER_NO_HASH_WAIT|TIMER_OVERRIDE))
+	timer_id = addtimer(CALLBACK(src, TYPE_PROC_REF(/turf, unwet_floor)), 8 SECONDS, (TIMER_STOPPABLE|TIMER_UNIQUE|TIMER_NO_HASH_WAIT|TIMER_OVERRIDE))
 
-/turf/simulated/proc/unwet_floor(var/check_very_wet = TRUE)
+/turf/simulated/unwet_floor(var/check_very_wet = TRUE)
 	if(check_very_wet && wet >= 2)
 		wet--
-		timer_id = addtimer(CALLBACK(src, TYPE_PROC_REF(/turf/simulated, unwet_floor)), 8 SECONDS, (TIMER_STOPPABLE|TIMER_UNIQUE|TIMER_NO_HASH_WAIT|TIMER_OVERRIDE))
+		timer_id = addtimer(CALLBACK(src, TYPE_PROC_REF(/turf, unwet_floor)), 8 SECONDS, (TIMER_STOPPABLE|TIMER_UNIQUE|TIMER_NO_HASH_WAIT|TIMER_OVERRIDE))
 		return
 	wet = 0
 	if(wet_overlay)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -77,6 +77,7 @@
 	var/last_slipperiness = 0
 	var/last_flow_strength = 0
 	var/last_flow_dir = 0
+	var/atom/movable/fluid_overlay/fluid_overlay
 
 /turf/Initialize(mapload, ...)
 	. = null && ..()	// This weird construct is to shut up the 'parent proc not called' warning without disabling the lint for child types. We explicitly return an init hint so this won't change behavior.
@@ -162,6 +163,8 @@
 	if(weather)
 		remove_vis_contents(src, weather.vis_contents_additions)
 		weather = null
+
+	QDEL_NULL(fluid_overlay)
 
 	..()
 
@@ -639,3 +642,8 @@
 		to_chat(AM, SPAN_WARNING("Something blocks the path."))
 	return TRUE
 
+/turf/proc/wet_floor(var/wet_val = 1, var/overwrite = FALSE)
+	return
+
+/turf/proc/unwet_floor(var/check_very_wet = TRUE)
+	return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -73,6 +73,10 @@
 	/// Used by exterior turfs to determine the warming effect of campfires and such.
 	var/list/affecting_heat_sources
 
+	// Fluid flow tracking vars
+	var/last_slipperiness = 0
+	var/last_flow_strength = 0
+	var/last_flow_dir = 0
 
 /turf/Initialize(mapload, ...)
 	. = null && ..()	// This weird construct is to shut up the 'parent proc not called' warning without disabling the lint for child types. We explicitly return an init hint so this won't change behavior.
@@ -214,14 +218,12 @@
 				to_chat(user, SPAN_WARNING("There is nothing to be dug out of \the [src]."))
 			return TRUE
 
-	if(ATOM_IS_OPEN_CONTAINER(W) && W.reagents)
-		var/obj/effect/fluid/F = locate() in src
-		if(F && F.reagents?.total_volume >= FLUID_PUDDLE)
-			var/taking = min(F.reagents?.total_volume, REAGENTS_FREE_SPACE(W.reagents))
-			if(taking > 0)
-				to_chat(user, SPAN_NOTICE("You fill \the [W] with [F.reagents.get_primary_reagent_name()] from \the [src]."))
-				F.reagents.trans_to(W, taking)
-				return TRUE
+	if(ATOM_IS_OPEN_CONTAINER(W) && W.reagents && reagents?.total_volume >= FLUID_PUDDLE)
+		var/taking = min(reagents.total_volume, REAGENTS_FREE_SPACE(W.reagents))
+		if(taking > 0)
+			to_chat(user, SPAN_NOTICE("You fill \the [W] with [reagents.get_primary_reagent_name()] from \the [src]."))
+			reagents.trans_to(W, taking)
+			return TRUE
 
 	if(istype(W, /obj/item/storage))
 		var/obj/item/storage/S = W
@@ -636,3 +638,4 @@
 	else
 		to_chat(AM, SPAN_WARNING("Something blocks the path."))
 	return TRUE
+

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -10,12 +10,8 @@
 	return fluid_can_pass
 
 /turf/proc/remove_fluid(var/amount = 0)
-	var/obj/effect/fluid/F = locate() in src
-	if(F)
-		F.reagents.remove_any(amount)
-
-/turf/return_fluid()
-	return (locate(/obj/effect/fluid) in contents)
+	if(reagents)
+		reagents.remove_any(amount)
 
 /turf/proc/set_flooded(new_flooded, force = FALSE, skip_vis_contents_update = FALSE, mapload = FALSE)
 
@@ -32,7 +28,8 @@
 	// Set our flood state.
 	flooded = new_flooded
 	if(flooded)
-		for(var/obj/effect/fluid/fluid in src)
+		QDEL_NULL(reagents)
+		for(var/obj/effect/fluid_overlay/fluid in src)
 			qdel(fluid)
 		ADD_ACTIVE_FLUID_SOURCE(src)
 		if(!skip_vis_contents_update)
@@ -50,27 +47,21 @@
 	. = (get_fluid_depth() >= min)
 
 /turf/proc/get_fluid_name()
-	var/obj/effect/fluid/F = return_fluid()
-	if(istype(F) && F.reagents?.primary_reagent)
-		return F.reagents.get_primary_reagent_name()
-	return "liquid"
+	return reagents?.get_primary_reagent_name() || "liquid"
 
 /turf/get_fluid_depth()
 	if(is_flooded(absolute=1))
 		return FLUID_MAX_DEPTH
-	var/obj/effect/fluid/F = return_fluid()
-	if(istype(F))
-		return F.reagents.total_volume
 	var/obj/structure/glass_tank/aquarium = locate() in contents
-	if(aquarium && aquarium.reagents && aquarium.reagents.total_volume)
-		return aquarium.reagents.total_volume * TANK_WATER_MULTIPLIER
-	return 0
+	if(aquarium)
+		return aquarium.reagents?.total_volume * TANK_WATER_MULTIPLIER
+	return reagents?.total_volume || 0
 
 /turf/proc/show_bubbles()
 	set waitfor = FALSE
 	if(flooded)
 		return
-	var/obj/effect/fluid/F = locate() in src
+	var/obj/effect/fluid_overlay/F = locate() in src
 	if(istype(F))
 		flick("bubbles",F)
 
@@ -86,11 +77,9 @@
 		ADD_ACTIVE_FLUID_SOURCE(src)
 
 /turf/proc/add_fluid(var/fluid_type, var/fluid_amount, var/defer_update)
-	var/obj/effect/fluid/F = locate() in src
-	if(!F)
-		F = new(src)
-	if(!QDELETED(F))
-		F.reagents.add_reagent(fluid_type, min(fluid_amount, FLUID_MAX_DEPTH - F.reagents.total_volume), defer_update = defer_update)
+	if(!reagents)
+		create_reagents(FLUID_MAX_DEPTH)
+	reagents.add_reagent(fluid_type, min(fluid_amount, FLUID_MAX_DEPTH - reagents.total_volume), defer_update = defer_update)
 
 /turf/proc/get_physical_height()
 	return 0
@@ -106,24 +95,66 @@
 			AM.fluid_act(fluids)
 
 /turf/proc/remove_fluids(var/amount, var/defer_update)
-	var/obj/effect/fluid/F = locate() in src
-	if(QDELETED(F) || !F.reagents?.total_volume)
+	if(!reagents?.total_volume)
 		return
-	F.reagents.remove_any(amount, defer_update = defer_update)
-	if(defer_update && !QDELETED(F.reagents))
-		SSfluids.holders_to_update[F.reagents] = TRUE
+	reagents.remove_any(amount, defer_update = defer_update)
+	if(defer_update && !QDELETED(reagents))
+		SSfluids.holders_to_update[reagents] = TRUE
 
 /turf/proc/transfer_fluids_to(var/turf/target, var/amount, var/defer_update)
-	var/obj/effect/fluid/F = locate() in src
-	if(!F || !F.reagents?.total_volume)
+	if(!reagents?.total_volume)
 		return
-	var/obj/effect/fluid/other = locate() in target
-	if(!other)
-		other = new(target)
-	if(!QDELETED(other) && other.reagents)
-		F.reagents.trans_to_holder(other.reagents, min(F.reagents.total_volume, min(FLUID_MAX_DEPTH - other.reagents.total_volume, amount)), defer_update = defer_update)
-		if(defer_update)
-			if(!QDELETED(F.reagents))
-				SSfluids.holders_to_update[F.reagents] = TRUE
-			if(!QDELETED(other.reagents))
-				SSfluids.holders_to_update[other.reagents] = TRUE
+	if(!target.reagents)
+		target.create_reagents(FLUID_MAX_DEPTH)
+	reagents.trans_to_holder(target.reagents, min(reagents.total_volume, min(FLUID_MAX_DEPTH - target.reagents.total_volume, amount)), defer_update = defer_update)
+	if(defer_update)
+		if(!QDELETED(reagents))
+			SSfluids.holders_to_update[reagents] = TRUE
+		if(!QDELETED(target.reagents))
+			SSfluids.holders_to_update[target.reagents] = TRUE
+
+/turf/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	. = ..()
+	if(exposed_temperature >= FLAMMABLE_GAS_MINIMUM_BURN_TEMPERATURE)
+		vaporize_fuel(air)
+
+/turf/proc/vaporize_fuel(datum/gas_mixture/air)
+	if(!length(reagents?.reagent_volumes) || !istype(air))
+		return
+	var/update_air = FALSE
+	for(var/rtype in reagents.reagent_volumes)
+		var/decl/material/mat = GET_DECL(rtype)
+		if(mat.gas_flags & XGM_GAS_FUEL)
+			var/moles = round(reagents.reagent_volumes[rtype] / REAGENT_UNITS_PER_GAS_MOLE)
+			if(moles > 0)
+				air.adjust_gas(rtype, moles, FALSE)
+				reagents.remove_reagent(round(moles * REAGENT_UNITS_PER_GAS_MOLE))
+				update_air = TRUE
+	if(update_air)
+		air.update_values()
+		return TRUE
+	return FALSE
+
+/turf/on_reagent_change()
+	..()
+
+	// Update fluid status and wake neighbors.
+	ADD_ACTIVE_FLUID(src)
+	for(var/checkdir in global.cardinal)
+		var/turf/neighbor = get_step(src, checkdir)
+		if(neighbor)
+			ADD_ACTIVE_FLUID(neighbor)
+
+	// Update slipperiness.
+	if(reagents?.total_volume)
+		var/decl/material/primary_reagent = reagents.get_primary_reagent_decl()
+		if(primary_reagent)
+			last_slipperiness = primary_reagent.slipperiness
+		// Update fluid overlay.
+		var/obj/effect/fluid_overlay/fluid_overlay = (locate() in src) || new /obj/effect/fluid_overlay(src)
+		fluid_overlay.update_lighting = TRUE
+		fluid_overlay.update_icon()
+	else
+		// Clear fluid overlays.
+		for(var/obj/effect/fluid_overlay/fluid_overlay in src)
+			qdel(fluid_overlay)

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -58,11 +58,9 @@
 
 /turf/proc/show_bubbles()
 	set waitfor = FALSE
-	if(flooded)
-		return
-	var/atom/movable/fluid_overlay/fluid = locate() in src
-	if(istype(fluid))
-		flick("bubbles", fluid)
+	// TODO: make flooding show bubbles.
+	if(!flooded && fluid_overlay)
+		flick("bubbles", fluid_overlay)
 
 /turf/fluid_update(var/ignore_neighbors)
 	fluid_blocked_dirs = null

--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -30,9 +30,7 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 	if(!air_contents || exposed_temperature < FLAMMABLE_GAS_MINIMUM_BURN_TEMPERATURE)
 		return 0
 
-	var/obj/effect/fluid/F = locate() in src
-	if(F)
-		F.vaporize_fuel(air_contents)
+	vaporize_fuel(air_contents)
 
 	var/igniting = 0
 	if(air_contents.check_combustibility())
@@ -127,7 +125,7 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 	// prioritize nearby fuel overlays first
 	for(var/direction in global.cardinal)
 		var/turf/enemy_tile = get_step(my_tile, direction)
-		if(istype(enemy_tile) && (locate(/obj/effect/fluid) in enemy_tile))
+		if(istype(enemy_tile) && enemy_tile.reagents)
 			enemy_tile.hotspot_expose(air_contents.temperature, air_contents.volume)
 
 	//spread
@@ -141,7 +139,7 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 
 				//if(!enemy_tile.zone.fire_tiles.len) TODO - optimize
 				var/datum/gas_mixture/acs = enemy_tile.return_air()
-				if(!acs || !acs.check_combustibility(enemy_tile.return_fluid()))
+				if(!acs || !acs.check_combustibility())
 					continue
 
 				//If extinguisher mist passed over the turf it's trying to spread to, don't spread and

--- a/code/modules/ZAS/Zone.dm
+++ b/code/modules/ZAS/Zone.dm
@@ -191,9 +191,7 @@ Class Procs:
 				if(condense_amt < 1)
 					break
 				air.adjust_gas(g, -condense_amt)
-				var/obj/effect/fluid/F = locate() in flooding
-				if(!F) F = new(flooding)
-				F.reagents.add_reagent(g, condense_amt * REAGENT_UNITS_PER_GAS_MOLE)
+				flooding.add_fluid(g, condense_amt * REAGENT_UNITS_PER_GAS_MOLE)
 		CHECK_TICK
 	condensing = FALSE
 

--- a/code/modules/integrated_electronics/passive/power.dm
+++ b/code/modules/integrated_electronics/passive/power.dm
@@ -121,7 +121,7 @@
 
 /obj/item/integrated_circuit/passive/power/chemical_cell/on_reagent_change(changetype)
 	..()
-	set_pin_data(IC_OUTPUT, 1, reagents.total_volume)
+	set_pin_data(IC_OUTPUT, 1, reagents?.total_volume || 0)
 	push_data()
 
 /obj/item/integrated_circuit/passive/power/chemical_cell/make_energy()

--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -19,7 +19,7 @@
 		push_vol()
 
 /obj/item/integrated_circuit/reagent/proc/push_vol()
-	set_pin_data(IC_OUTPUT, 1, reagents.total_volume)
+	set_pin_data(IC_OUTPUT, 1, reagents?.total_volume || 0)
 	push_data()
 
 /obj/item/integrated_circuit/reagent/smoke
@@ -49,7 +49,7 @@
 	var/smoke_radius = 5
 	var/notified = FALSE
 
-/obj/item/integrated_circuit/reagent/smoke/on_reagent_change()
+/obj/item/integrated_circuit/reagent/on_reagent_change()
 	..()
 	push_vol()
 
@@ -108,10 +108,6 @@
 	var/direction_mode = IC_REAGENTS_INJECT
 	var/transfer_amount = 10
 	var/busy = FALSE
-
-/obj/item/integrated_circuit/reagent/injector/on_reagent_change(changetype)
-	..()
-	push_vol()
 
 /obj/item/integrated_circuit/reagent/injector/on_data_written()
 	var/new_amount = get_pin_data(IC_INPUT, 2)
@@ -323,10 +319,6 @@
 /obj/item/integrated_circuit/reagent/storage/do_work()
 	set_pin_data(IC_OUTPUT, 2, weakref(src))
 	push_data()
-
-/obj/item/integrated_circuit/reagent/storage/on_reagent_change(changetype)
-	..()
-	push_vol()
 
 /obj/item/integrated_circuit/reagent/storage/big
 	name = "big reagent storage"
@@ -599,10 +591,6 @@
 		if(3)
 			set_pin_data(IC_OUTPUT, 4, weakref(src))
 			push_data()
-
-/obj/item/integrated_circuit/reagent/temp/on_reagent_change()
-	..()
-	push_vol()
 
 /obj/item/integrated_circuit/reagent/temp/power_fail()
 	active = 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -797,22 +797,21 @@ default behaviour is:
 
 /mob/living/handle_drowning()
 	var/turf/T = get_turf(src)
-	if(!can_drown() || !loc.is_flooded(lying))
+	if(!T || !can_drown() || !T.is_flooded(lying))
 		return FALSE
 	if(!lying && T.above && T.above.is_open() && !T.above.is_flooded() && can_overcome_gravity())
 		return FALSE
 	if(prob(5))
 		var/datum/reagents/metabolism/inhaled = get_inhaled_reagents()
 		var/datum/reagents/metabolism/ingested = get_ingested_reagents()
-		var/obj/effect/fluid/F = locate() in loc
-		to_chat(src, SPAN_DANGER("You choke and splutter as you inhale [(F?.reagents && F.reagents.get_primary_reagent_name()) || "liquid"]!"))
+		to_chat(src, SPAN_DANGER("You choke and splutter as you inhale [T.reagents?.get_primary_reagent_name() || "liquid"]!"))
 		var/inhale_amount = 0
 		if(inhaled)
 			inhale_amount = rand(2,5)
-			F?.reagents?.trans_to_holder(inhaled, min(F.reagents.total_volume, inhale_amount))
+			T.reagents?.trans_to_holder(inhaled, min(T.reagents.total_volume, inhale_amount))
 		if(ingested)
 			var/ingest_amount = 5 - inhale_amount
-			F?.reagents?.trans_to_holder(ingested, min(F.reagents.total_volume, ingest_amount))
+			reagents?.trans_to_holder(ingested, min(T.reagents.total_volume, ingest_amount))
 
 	T.show_bubbles()
 	return TRUE // Presumably chemical smoke can't be breathed while you're underwater.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -796,15 +796,15 @@ default behaviour is:
 	return (!L || L.can_drown())
 
 /mob/living/handle_drowning()
-	var/turf/T = get_turf(src)
-	if(!T || !can_drown() || !T.is_flooded(lying))
+	if(!can_drown() || !loc?.is_flooded(lying))
 		return FALSE
+	var/turf/T = get_turf(src)
 	if(!lying && T.above && T.above.is_open() && !T.above.is_flooded() && can_overcome_gravity())
 		return FALSE
 	if(prob(5))
 		var/datum/reagents/metabolism/inhaled = get_inhaled_reagents()
 		var/datum/reagents/metabolism/ingested = get_ingested_reagents()
-		to_chat(src, SPAN_DANGER("You choke and splutter as you inhale [T.reagents?.get_primary_reagent_name() || "liquid"]!"))
+		to_chat(src, SPAN_DANGER("You choke and splutter as you inhale [T.get_fluid_name()]!"))
 		var/inhale_amount = 0
 		if(inhaled)
 			inhale_amount = rand(2,5)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -24,7 +24,8 @@ var/global/obj/temp_reagents_holder = new
 	if(my_atom)
 		if(my_atom.reagents == src)
 			my_atom.reagents = null
-			my_atom.on_reagent_change()
+			if(total_volume > 0) // we can assume 0 reagents and null reagents are broadly identical for the purposes of atom logic
+				my_atom.on_reagent_change()
 		my_atom = null
 
 /datum/reagents/GetCloneArgs()

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -24,6 +24,7 @@ var/global/obj/temp_reagents_holder = new
 	if(my_atom)
 		if(my_atom.reagents == src)
 			my_atom.reagents = null
+			my_atom.on_reagent_change()
 		my_atom = null
 
 /datum/reagents/GetCloneArgs()

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -580,9 +580,9 @@ var/global/obj/temp_reagents_holder = new
 	R.touch_turf(target)
 	if(R?.total_volume <= FLUID_QDEL_POINT || QDELETED(target))
 		return
-	var/obj/effect/fluid/F = locate() in target
-	if(!F) F = new(target)
-	trans_to_holder(F.reagents, amount, multiplier, copy, defer_update = defer_update)
+	if(!target.reagents)
+		target.create_reagents(FLUID_MAX_DEPTH)
+	trans_to_holder(target.reagents, amount, multiplier, copy, defer_update = defer_update)
 
 /datum/reagents/proc/trans_to_obj(var/obj/target, var/amount = 1, var/multiplier = 1, var/copy = 0, var/defer_update = FALSE) // Objects may or may not; if they do, it's probably a beaker or something and we need to transfer properly; otherwise, just touch.
 	if(!target || !target.simulated)

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -26,15 +26,15 @@
 
 /obj/item/chems/ivbag/on_reagent_change()
 	..()
-	if(reagents.total_volume > volume/2)
+	if(reagents?.total_volume > volume/2)
 		w_class = ITEM_SIZE_SMALL
 	else
 		w_class = ITEM_SIZE_TINY
 
 /obj/item/chems/ivbag/on_update_icon()
 	. = ..()
-	var/percent = round(reagents.total_volume / volume * 100)
-	if(reagents.total_volume)
+	var/percent = round(reagents?.total_volume / volume * 100)
+	if(percent)
 		add_overlay(overlay_image(icon, "[round(percent,25)]", reagents.get_color()))
 	add_overlay(attached? "dongle" : "top")
 

--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -107,16 +107,15 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 	. = custom_desc || ..()
 
 /obj/item/chems/drinks/glass2/on_reagent_change()
-	temperature_coefficient = 4 / max(1, reagents.total_volume)
+	temperature_coefficient = 4 / max(1, reagents?.total_volume)
 	..()
 
 /obj/item/chems/drinks/glass2/proc/can_add_extra(obj/item/glass_extra/GE)
 	if(!("[overlay_base_icon]_[GE.glass_addition]left" in icon_states(icon)))
-		return 0
+		return FALSE
 	if(!("[overlay_base_icon]_[GE.glass_addition]right" in icon_states(icon)))
-		return 0
-
-	return 1
+		return FALSE
+	return TRUE
 
 /obj/item/chems/drinks/glass2/examine(mob/user, distance)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/drinks.dm
+++ b/code/modules/reagents/reagent_containers/drinks.dm
@@ -86,9 +86,8 @@
 
 /obj/item/chems/drinks/on_update_icon()
 	. = ..()
-	if(LAZYLEN(reagents.reagent_volumes))
-		if(filling_states)
-			add_overlay(overlay_image(icon, "[base_icon][get_filling_state()]", reagents.get_color()))
+	if(LAZYLEN(reagents?.reagent_volumes) && filling_states)
+		add_overlay(overlay_image(icon, "[base_icon][get_filling_state()]", reagents.get_color()))
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -62,7 +62,7 @@
 			return
 		else
 			trans = reagents.splash(target, amount_per_transfer_from_this, max_spill=0) //sprinkling reagents on generic non-mobs. Droppers are very precise
-			to_chat(user, SPAN_NOTICE("You transfer [trans] units of the solution."))
+			to_chat(user, SPAN_NOTICE("You transfer [trans] unit\s of the solution."))
 
 	else // Taking from something
 
@@ -76,7 +76,7 @@
 
 		var/trans = target.reagents.trans_to_obj(src, amount_per_transfer_from_this)
 
-		to_chat(user, SPAN_NOTICE("You fill the dropper with [trans] units of the solution."))
+		to_chat(user, SPAN_NOTICE("You fill the dropper with [trans] unit\s of the solution."))
 
 /obj/item/chems/dropper/update_container_name()
 	return
@@ -86,7 +86,7 @@
 
 /obj/item/chems/dropper/on_update_icon()
 	. = ..()
-	if(reagents.total_volume)
+	if(reagents?.total_volume)
 		icon_state = "dropper1"
 	else
 		icon_state = "dropper0"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -25,7 +25,7 @@
 /obj/item/chems/pill/on_update_icon()
 	. = ..()
 	if(icon_state in colorizable_icon_states)
-		color = reagents.get_color()
+		color = reagents?.get_color()
 		alpha = 255 // above probably reset our alpha
 	else
 		color = null

--- a/code/modules/species/outsider/starlight.dm
+++ b/code/modules/species/outsider/starlight.dm
@@ -103,9 +103,7 @@
 /decl/species/starlight/starborn/handle_death(var/mob/living/carbon/human/H)
 	..()
 	var/turf/T = get_turf(H)
-	var/obj/effect/fluid/F = locate() in T
-	if(!F) F = new(T)
-	F.reagents.add_reagent(/decl/material/liquid/fuel, 20)
+	T.add_fluid(/decl/material/liquid/fuel, 20)
 	T.hotspot_expose(FLAMMABLE_GAS_MINIMUM_BURN_TEMPERATURE)
 
 /decl/bodytype/starlight/blueforged

--- a/code/unit_tests/chemistry_tests.dm
+++ b/code/unit_tests/chemistry_tests.dm
@@ -219,9 +219,8 @@
 
 	// Cleanup pt. 2
 	chem_refs.Cut()
-	var/obj/effect/fluid/fluid = locate() in spawn_spot
-	if(fluid)
-		qdel(fluid)
+	if(spawn_spot.reagents?.total_volume)
+		spawn_spot.reagents.clear_reagents()
 		failures += "- spawn turf had fluids post-test"
 
 	// Report status.

--- a/code/unit_tests/del_the_world.dm
+++ b/code/unit_tests/del_the_world.dm
@@ -35,7 +35,7 @@
 		/obj/structure/stairs,
 		// Fluid system related; causes issues with atoms spawned on the turf.
 		/obj/abstract/fluid_mapped,
-		/obj/effect/fluid,
+		/obj/effect/fluid_overlay,
 		/obj/effect/flood,
 		// Not valid when spawned manually.
 		/obj/effect/overmap,

--- a/code/unit_tests/del_the_world.dm
+++ b/code/unit_tests/del_the_world.dm
@@ -35,7 +35,6 @@
 		/obj/structure/stairs,
 		// Fluid system related; causes issues with atoms spawned on the turf.
 		/obj/abstract/fluid_mapped,
-		/obj/effect/fluid_overlay,
 		/obj/effect/flood,
 		// Not valid when spawned manually.
 		/obj/effect/overmap,

--- a/mods/content/xenobiology/slime/life.dm
+++ b/mods/content/xenobiology/slime/life.dm
@@ -65,12 +65,10 @@
 
 /mob/living/slime/fluid_act(datum/reagents/fluids)
 	. = ..()
-	if(stat == DEAD)
-		var/obj/effect/fluid/F = locate() in loc
-		if(F && F.reagents?.total_volume >= FLUID_SHALLOW)
-			F.reagents.add_reagent(/decl/material/liquid/slimejelly, (is_adult ? rand(30, 40) : rand(10, 30)))
-			visible_message(SPAN_DANGER("\The [src] melts away...")) // Slimes are water soluble.
-			qdel(src)
+	if(stat == DEAD && loc?.reagents?.total_volume >= FLUID_SHALLOW)
+		loc.reagents.add_reagent(/decl/material/liquid/slimejelly, (is_adult ? rand(30, 40) : rand(10, 30)))
+		visible_message(SPAN_DANGER("\The [src] melts away...")) // Slimes are water soluble.
+		qdel(src)
 
 /mob/living/slime/handle_living_non_stasis_processes()
 	. = ..()

--- a/mods/content/xenobiology/slime/life.dm
+++ b/mods/content/xenobiology/slime/life.dm
@@ -65,8 +65,8 @@
 
 /mob/living/slime/fluid_act(datum/reagents/fluids)
 	. = ..()
-	if(stat == DEAD && loc?.reagents?.total_volume >= FLUID_SHALLOW)
-		loc.reagents.add_reagent(/decl/material/liquid/slimejelly, (is_adult ? rand(30, 40) : rand(10, 30)))
+	if(stat == DEAD && fluids?.total_volume && REAGENT_VOLUME(fluids, /decl/material/liquid/water) >= FLUID_SHALLOW)
+		fluids.add_reagent(/decl/material/liquid/slimejelly, (is_adult ? rand(30, 40) : rand(10, 30)))
 		visible_message(SPAN_DANGER("\The [src] melts away...")) // Slimes are water soluble.
 		qdel(src)
 


### PR DESCRIPTION
## Description of changes
- Moves reagent holding from the fluid overlay onto the turf.
- Moves various processing and updating from the fluid overlay onto the turf.
- `on_reagent_change()` is now called by `/datum/reagents/Destroy()`.
- Several icon updates and on_reagent_change calls have been updated to check for null reagents due to the atom info repo now causing calls to on_reagent_change().
- Fluid glowing has been removed - it never worked anyway.

## Why and what will this PR improve
Simplifies fluid logic/handling and makes future atom-level reagent consumption like fires easier.

## Authorship
Myself.

## Changelog
Nothing player-facing.