### PR TITLE
Adds template flag for limiting spawn to habitable planets.

### DIFF
--- a/code/__defines/ruin_tags.dm
+++ b/code/__defines/ruin_tags.dm
@@ -1,8 +1,9 @@
 //Flags for exoplanet ruin picking
 
-#define RUIN_HABITAT 	1		//long term habitat
-#define RUIN_HUMAN 		2		//human-made structure
-#define RUIN_ALIEN 		4		//artificial structure of an unknown origin
-#define RUIN_WRECK 		8		//crashed vessel
-#define RUIN_NATURAL	16		//naturally occuring structure
-#define RUIN_WATER 		32		//ruin depending on planet having water accessible
+#define RUIN_HABITAT   BITFLAG(0) //long term habitat
+#define RUIN_HUMAN     BITFLAG(1) //human-made structure
+#define RUIN_ALIEN     BITFLAG(2) //artificial structure of an unknown origin
+#define RUIN_WRECK     BITFLAG(3) //crashed vessel
+#define RUIN_NATURAL   BITFLAG(4) //naturally occuring structure
+#define RUIN_WATER     BITFLAG(5) //ruin depending on planet having water accessible
+#define RUIN_HABITABLE BITFLAG(6) //ruin depending on planet being habitable

--- a/code/modules/maps/template_types/random_exoplanet/random_planet.dm
+++ b/code/modules/maps/template_types/random_exoplanet/random_planet.dm
@@ -155,6 +155,10 @@
 	if(!gen_data)
 		gen_data = create_planetoid_instance()
 
+	// Update our blacklist for habitability
+	if(gen_data.habitability_class >= HABITABILITY_BAD)
+		ruin_tags_blacklist |= RUIN_HABITABLE
+
 	//Generate some of the background stuff for our new planet
 	before_planet_gen(gen_data)
 


### PR DESCRIPTION
## Description of changes
- Adds a new flag, RUIN_HABITABLE.
- Adds a habitability check to random planet gen that blacklists this tag for uninhabitable planets.
- ~~Adds the flag to the crashed pod submap.~~

## Why and what will this PR improve
Pod can't survive on half the uninhabitable planets due to the softsuit melting. Flag allows downstream to change that.

## Authorship
Myself.

## Changelog
Nothing player-facing.