### PR TITLE
Flooded turfs can now have reagents other than water.

### DIFF
--- a/code/controllers/subsystems/fluids.dm
+++ b/code/controllers/subsystems/fluids.dm
@@ -3,6 +3,7 @@ SUBSYSTEM_DEF(fluids)
 	wait = 1 SECOND
 	priority = SS_PRIORITY_FLUIDS
 	flags = SS_NO_INIT
+	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT // So we can flush our queued activity during lobby setup on ocean maps.
 
 	var/tmp/list/water_sources =       list()
 	var/tmp/fluid_sources_copied_yet = FALSE
@@ -84,7 +85,7 @@ SUBSYSTEM_DEF(fluids)
 				continue
 			checked_targets[neighbor] = TRUE
 			flooded_a_neighbor = TRUE
-			neighbor.add_fluid(/decl/material/liquid/water, FLUID_MAX_DEPTH)
+			neighbor.add_fluid(current_turf.flooded, FLUID_MAX_DEPTH)
 
 		if(!flooded_a_neighbor)
 			REMOVE_ACTIVE_FLUID_SOURCE(current_turf)

--- a/code/game/objects/effects/fluids.dm
+++ b/code/game/objects/effects/fluids.dm
@@ -126,7 +126,19 @@
 	fluid_initial = 10
 
 // Permaflood overlay.
-var/global/obj/effect/flood/flood_object = new
+var/global/list/flood_type_overlay_cache = list()
+/proc/get_flood_overlay(fluid_type)
+	if(!ispath(fluid_type, /decl/material))
+		return null
+	if(!global.flood_type_overlay_cache[fluid_type])
+		var/decl/material/fluid_decl = GET_DECL(fluid_type)
+		var/obj/effect/flood/new_flood = new
+		new_flood.color = fluid_decl.color
+		new_flood.alpha = round(fluid_decl.min_fluid_opacity + ((fluid_decl.max_fluid_opacity - fluid_decl.min_fluid_opacity) * 0.5))
+		global.flood_type_overlay_cache[fluid_type] = new_flood
+		return new_flood
+	return global.flood_type_overlay_cache[fluid_type]
+
 /obj/effect/flood
 	name          = ""
 	icon          = 'icons/effects/liquids.dmi'

--- a/code/game/turfs/exterior/exterior_concrete.dm
+++ b/code/game/turfs/exterior/exterior_concrete.dm
@@ -21,7 +21,7 @@ var/global/exterior_broken_states = icon_states('icons/turf/exterior/broken.dmi'
 	return FALSE
 
 /turf/exterior/concrete/flooded
-	flooded = TRUE
+	flooded = /decl/material/liquid/water
 	color = COLOR_LIQUID_WATER
 
 /turf/exterior/concrete/Initialize(var/ml)

--- a/code/game/turfs/exterior/exterior_mud.dm
+++ b/code/game/turfs/exterior/exterior_mud.dm
@@ -9,7 +9,7 @@
 	return dug ? null : list(/obj/item/stack/material/ore/clay = list(3, 2))
 
 /turf/exterior/clay/flooded
-	flooded = TRUE
+	flooded = /decl/material/liquid/water
 
 /turf/exterior/mud
 	name = "mud"
@@ -19,7 +19,7 @@
 	footstep_type = /decl/footsteps/mud
 
 /turf/exterior/mud/flooded
-	flooded = TRUE
+	flooded = /decl/material/liquid/water
 
 /turf/exterior/dry
 	name = "dry mud"

--- a/code/game/turfs/exterior/exterior_ocean.dm
+++ b/code/game/turfs/exterior/exterior_ocean.dm
@@ -2,5 +2,5 @@
 	name = "open ocean"
 	icon = 'icons/turf/exterior/ocean_deep.dmi'
 	icon_state = "0"
-	flooded = TRUE
+	flooded = /decl/material/liquid/water
 	icon_edge_layer = EXT_EDGE_OCEAN

--- a/code/game/turfs/exterior/exterior_seafloor.dm
+++ b/code/game/turfs/exterior/exterior_seafloor.dm
@@ -9,7 +9,7 @@
 	return dug ? null : list(/obj/item/stack/material/ore/sand = list(3, 2))
 
 /turf/exterior/seafloor/flooded
-	flooded = TRUE
+	flooded = /decl/material/liquid/water
 	color = COLOR_LIQUID_WATER
 
 /turf/exterior/seafloor/Initialize()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -106,9 +106,8 @@
 	if (z_flags & ZM_MIMIC_BELOW)
 		setup_zmimic(mapload)
 
-	if(flooded && !density)
-		make_flooded(TRUE)
-
+	if(flooded)
+		set_flooded(flooded, TRUE, skip_vis_contents_update = TRUE, mapload = mapload)
 	refresh_vis_contents()
 
 	return INITIALIZE_HINT_NORMAL
@@ -540,7 +539,9 @@
 	if(weather)
 		LAZYADD(., weather)
 	if(flooded)
-		LAZYADD(., global.flood_object)
+		var/flood_object = get_flood_overlay(flooded)
+		if(flood_object)
+			LAZYADD(., flood_object)
 
 /**Whether we can place a cable here
  * If you cannot build a cable will return an error code explaining why you cannot.

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -99,11 +99,8 @@
 		else if(old_fire)
 			qdel(old_fire)
 
-	if(isnull(W.flooded) && old_flooded != W.flooded)
-		if(old_flooded && !W.density)
-			W.make_flooded()
-		else
-			W.make_unflooded()
+	if(old_flooded != W.flooded)
+		set_flooded(old_flooded && !W.density)
 
 	// Raise appropriate events.
 	W.post_change()

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -72,7 +72,7 @@
 
 /turf/simulated/open/flooded
 	name = "open water"
-	flooded = TRUE
+	flooded = /decl/material/liquid/water
 
 /turf/simulated/open/update_dirt()
 	return 0
@@ -130,7 +130,7 @@
 
 /turf/exterior/open/flooded
 	name = "open water"
-	flooded = TRUE
+	flooded = /decl/material/liquid/water
 
 /turf/exterior/open/Entered(var/atom/movable/mover, var/atom/oldloc)
 	..()

--- a/code/modules/multiz/turf_mimic_edge.dm
+++ b/code/modules/multiz/turf_mimic_edge.dm
@@ -357,6 +357,9 @@
 		return
 	shared_transition_edge_bumped(src, AM, mimic_z)
 
+/turf/unsimulated/mimic_edge/transition/flooded
+	flooded = /decl/material/liquid/water
+
 /turf/unsimulated/mimic_edge/transition/setup_mimic()
 	var/list/coord = shared_transition_edge_get_coordinates_turf_to_mimic(src, shared_transition_edge_get_valid_level_data(src))
 	set_mimic_turf(coord[1], coord[2], coord[3])


### PR DESCRIPTION
## Description of changes
- `flooded` is now a material type that will be used for fluis from this source.
- `make_flooded()` and `make_unflooded()` are now unified as `set_flooded()`.

## Why and what will this PR improve
Nicer flooding code, more mapping options (seawater for example).

## Authorship
Myself.

## Changelog
Nothing player-facing.