### PR TITLE
Added the ability for materials to transition into other materials based on atom temperature.

### DIFF
--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -949,3 +949,9 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	// delay for 1ds to allow the rest of the call stack to resolve
 	if(!QDELETED(src) && !QDELETED(user) && user.get_equipped_slot_for_item(src) == slot)
 		try_burn_wearer(user, slot, 1)
+
+/obj/item/ProcessAtomTemperature()
+	if(material && material.bakes_into_material && !isnull(material.bakes_into_at_temperature) && temperature >= material.bakes_into_at_temperature)
+		set_material(material.bakes_into_material)
+	. = ..()
+

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -422,3 +422,12 @@
 	if(amount == 1)
 		return indefinite_article ? "[indefinite_article] [singular_name]" : ADD_ARTICLE(singular_name)
 	return "[amount] [plural_name]"
+
+/obj/item/stack/ProcessAtomTemperature()
+	. = ..()
+	if(QDELETED(src))
+		return
+	matter_per_piece = list()
+	for(var/mat in matter)
+		matter_per_piece[mat] = round(matter[mat] / amount)
+	update_icon()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -341,3 +341,25 @@
 
 /obj/can_be_injected_by(var/atom/injector)
 	return ATOM_IS_OPEN_CONTAINER(src)
+
+/obj/ProcessAtomTemperature()
+	. = ..()
+	if(QDELETED(src))
+		return
+	// Bake any matter into the cooked form.
+	if(LAZYLEN(matter))
+		var/new_matter
+		var/remove_matter
+		for(var/matter_type in matter)
+			var/decl/material/mat = GET_DECL(matter_type)
+			if(mat.bakes_into_material && !isnull(mat.bakes_into_at_temperature) && temperature >= mat.bakes_into_at_temperature)
+				LAZYINITLIST(new_matter)
+				new_matter[mat.bakes_into_material] += matter[matter_type]
+				LAZYDISTINCTADD(remove_matter, remove_matter)
+		if(LAZYLEN(new_matter))
+			for(var/mat in new_matter)
+				matter[mat] = new_matter[mat]
+		if(LAZYLEN(remove_matter))
+			for(var/mat in remove_matter)
+				matter -= mat
+		UNSETEMPTY(matter)

--- a/code/game/objects/structures/__structure.dm
+++ b/code/game/objects/structures/__structure.dm
@@ -130,6 +130,18 @@
 	if(dmg)
 		take_damage(dmg)
 
+/obj/structure/ProcessAtomTemperature()
+	var/update_mats = FALSE
+	if(material && material.bakes_into_material && !isnull(material.bakes_into_at_temperature) && temperature >= material.bakes_into_at_temperature)
+		material = GET_DECL(material.bakes_into_material)
+		update_mats = TRUE
+	if(reinf_material && reinf_material.bakes_into_material && !isnull(reinf_material.bakes_into_at_temperature) && temperature >= reinf_material.bakes_into_at_temperature)
+		reinf_material = GET_DECL(reinf_material.bakes_into_material)
+		update_mats = TRUE
+	if(update_mats)
+		update_materials()
+	. = ..()
+
 /obj/structure/Destroy()
 	var/turf/T = get_turf(src)
 	. = ..()

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -29,7 +29,7 @@
 	var/const/light_color_low =  "#ff0000"
 
 	var/list/affected_exterior_turfs
-	var/list/exterior_temperature = 30 // Celcius, but it is added directly to a Kelvin value so don't do any conversion.
+	var/list/exterior_temperature = 30 // Celsius, but it is added directly to a Kelvin value so don't do any conversion.
 
 	var/output_temperature = T0C+50  // The amount that the fire will try to heat up the air.
 	var/fuel = 0                     // How much fuel is left?

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -281,6 +281,10 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 
 	var/holographic // Set to true if this material is fake/visual only.
 
+	/// Does high temperature baking change this material into something else?
+	var/bakes_into_material
+	var/bakes_into_at_temperature
+
 // Placeholders for light tiles and rglass.
 /decl/material/proc/reinforce(var/mob/user, var/obj/item/stack/material/used_stack, var/obj/item/stack/material/target_stack, var/use_sheets = 1)
 	if(!used_stack.can_use(use_sheets))
@@ -370,6 +374,13 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 #define FALSEWALL_STATE "fwall_open"
 /decl/material/validate()
 	. = ..()
+
+	if(!isnull(bakes_into_at_temperature))
+		if(!isnull(melting_point) && melting_point <= bakes_into_at_temperature)
+			. += "baking point is set but melting point is lower or equal to it"
+		if(!isnull(boiling_point) && boiling_point <= bakes_into_at_temperature)
+			. += "baking point is set but boiling point is lower or equal to it"
+
 	if(accelerant_value > FUEL_VALUE_NONE && isnull(ignition_point))
 		. += "accelerant value larger than zero but null ignition point"
 	if(!isnull(ignition_point) && accelerant_value <= FUEL_VALUE_NONE)

--- a/code/modules/materials/definitions/solids/_mat_solid.dm
+++ b/code/modules/materials/definitions/solids/_mat_solid.dm
@@ -10,6 +10,7 @@
 	icon_reinf = 'icons/turf/walls/reinforced_stone.dmi'
 	default_solid_form = /obj/item/stack/material/brick
 	abstract_type = /decl/material/solid
+	bakes_into_material = null
 
 /decl/material/solid/Initialize()
 	if(!liquid_name)

--- a/code/modules/materials/definitions/solids/materials_solid_mineral.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_mineral.dm
@@ -219,7 +219,7 @@
 	uid = "solid_sand"
 	color = "#e2dbb5"
 	heating_products = list(/decl/material/solid/glass = 1)
-	heating_point = GENERIC_SMELTING_HEAT_POINT
+	heating_point = 2000 CELSIUS
 	heating_sound = null
 	heating_message = null
 	ore_compresses_to = /decl/material/solid/stone/sandstone
@@ -236,18 +236,17 @@
 
 /decl/material/solid/clay
 	name = "clay"
+	codex_name = "raw clay"
 	uid = "solid_clay"
-	color = COLOR_OFF_WHITE
+	color = "#807f7a"
 	ore_name = "clay"
-	ore_icon_overlay = "lump"
-	heating_products = list(/decl/material/solid/stone/ceramic = 1)
-	heating_point = GENERIC_SMELTING_HEAT_POINT
-	heating_sound = null
-	heating_message = null
 	ore_compresses_to = null
-	ore_icon_overlay = "dust"
+	ore_icon_overlay = "lump"
 	value = 0.8
 	default_solid_form = /obj/item/stack/material/lump
+	bakes_into_material = /decl/material/solid/stone/pottery
+	melting_point = null // Clay is already almost a liquid...
+	bakes_into_at_temperature = 1100 CELSIUS // roughly the temperature expected from a kiln
 
 /decl/material/solid/hematite
 	name = "hematite"

--- a/code/modules/materials/definitions/solids/materials_solid_organic.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_organic.dm
@@ -3,6 +3,10 @@
 	ignition_point = T0C+500 // Based on loose ignition temperature of plastic
 	accelerant_value = 0.1
 	burn_product = /decl/material/gas/carbon_monoxide
+/* TODO: burn products for solids
+	bakes_into_at_temperature = T0C+500
+	bakes_into_material = /decl/material/solid/carbon
+*/
 
 /decl/material/solid/organic/plastic
 	name = "plastic"

--- a/code/modules/materials/definitions/solids/materials_solid_stone.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_stone.dm
@@ -51,14 +51,22 @@
 		/decl/material/solid/slag    = 0.10,
 	)
 
+/decl/material/solid/stone/pottery
+	name = "fired clay"
+	uid = "solid_pottery"
+	lore_text = "A hard but brittle substance produced by firing clay in a kiln."
+	color = "#cd8f75"
+	melting_point = 1750 // Arbitrary, hotter than the kiln currently reaches.
+
 /decl/material/solid/stone/ceramic
 	name = "ceramic"
 	uid = "solid_ceramic"
-	lore_text = "A hard substance produced by firing clay in a kiln."
+	lore_text = "A very hard, heat-resistant substance produced by firing glazed clay in a kiln."
 	color = COLOR_OFF_WHITE
+	melting_point = 6000 // Arbitrary, very heat-resistant.
+
 	dissolves_in = MAT_SOLVENT_IMMUNE
 	dissolves_into = null
-
 /decl/material/solid/stone/marble
 	name = "marble"
 	uid = "solid_marble"

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -142,6 +142,11 @@
 	alpha = 100 + max(1, amount/25)*(material.opacity * 255)
 	update_state_from_amount()
 
+/obj/item/stack/material/ProcessAtomTemperature()
+	. = ..()
+	if(!QDELETED(src))
+		update_strings()
+
 /obj/item/stack/material/proc/update_state_from_amount()
 	if(max_icon_state && amount == max_amount)
 		icon_state = max_icon_state


### PR DESCRIPTION
## Description of changes
- `ProcessAtomTemperature()` can losslessly/non-destructively replace material and matter type (sand to glass, clay to pottery).
- Added a pottery type for simple baked clay instead of using ceramic.

## Why and what will this PR improve
Notes towards a more full featured pottery system involving a kiln.

## Authorship
Myself.

## Changelog
Functionally nothing player-facing unless someone has a habit of setting lumps of clay on fire.