### PR TITLE
Backporting fax webhook from Scav.

### DIFF
--- a/code/__defines/webhooks.dm
+++ b/code/__defines/webhooks.dm
@@ -7,3 +7,4 @@
 #define WEBHOOK_CUSTOM_EVENT      "webhook_custom_event"
 #define WEBHOOK_ELEVATOR_FALL     "webhook_elevator_fall"
 #define WEBHOOK_AHELP_SENT        "webhook_ahelp_sent"
+#define WEBHOOK_FAX_SENT          "webhook_fax_sent"

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -683,6 +683,10 @@ var/global/list/adminfaxes     = list()	//cache for faxes that have been sent to
 	msg += "(<A HREF='?_src_=holder;take_ic=\ref[sender]'>TAKE</a>) (<a href='?_src_=holder;FaxReply=\ref[sender];originfax=\ref[source_fax];replyorigin=[reply_type]'>REPLY</a>)</b>: "
 	msg += "Receiving '[rcvdcopy.name]' via secure connection ... <a href='?_src_=holder;AdminFaxView=\ref[rcvdcopy]'>view message</a></span>"
 
+	if (istype(doc, /obj/item/paper))
+		var/obj/item/paper/paper = doc
+		SSwebhooks.send(WEBHOOK_FAX_SENT, list("title" = "Incoming fax transmission from [sender] in [faxname] for [dest_display_name].", "body" = "[paper.info]"))
+
 	for(var/client/C in global.admins)
 		if(check_rights((R_ADMIN|R_MOD),0,C))
 			to_chat(C, msg)

--- a/code/modules/webhooks/webhook_fax.dm
+++ b/code/modules/webhooks/webhook_fax.dm
@@ -1,0 +1,11 @@
+/decl/webhook/fax_sent
+	id = WEBHOOK_FAX_SENT
+
+// Data expects a "body" field containing a message.
+/decl/webhook/fax_sent/get_message(var/list/data)
+	. = ..()
+	.["embeds"] = list(list(
+		"title" = (data && data["title"]) || "undefined",
+		"description" = (data && data["body"]) || "undefined",
+		"color" = COLOR_WEBHOOK_DEFAULT
+	))

--- a/nebula.dme
+++ b/nebula.dme
@@ -3574,6 +3574,7 @@
 #include "code\modules\webhooks\webhook_ahelp2discord.dm"
 #include "code\modules\webhooks\webhook_custom_event.dm"
 #include "code\modules\webhooks\webhook_elevator_fall.dm"
+#include "code\modules\webhooks\webhook_fax.dm"
 #include "code\modules\webhooks\webhook_roundend.dm"
 #include "code\modules\webhooks\webhook_roundprep.dm"
 #include "code\modules\webhooks\webhook_roundstart.dm"


### PR DESCRIPTION
## Description of changes
Adds a webhook for faxes.

## Why and what will this PR improve
Allows staff to set up Discord hooks for admin faxes.

## Authorship
@Qumefox wrote this webhook for Scav, I'm just ganking it.

## Changelog
:cl:
add: There is now a webhook for faxes.
/:cl:
