### PR TITLE
Fix 2.5ph ZMimic shadower corruption

### DIFF
--- a/code/__defines/zmimic.dm
+++ b/code/__defines/zmimic.dm
@@ -46,7 +46,9 @@ var/global/list/mimic_defines = list(
 	"ZM_ALLOW_ATMOS",
 	"ZM_MIMIC_NO_AO",
 	"ZM_NO_OCCLUDE",
-	"ZM_MIMIC_BASETURF"
+	"ZM_OVERRIDE",
+	"ZM_NO_SHADOW",
+	"ZM_TERMINATOR"
 )
 
 // Movable flags.

--- a/code/controllers/subsystems/zcopy.dm
+++ b/code/controllers/subsystems/zcopy.dm
@@ -382,6 +382,7 @@ SUBSYSTEM_DEF(zcopy)
 			// Special case: these are merged into the shadower to reduce memory usage.
 			if (object.type == /atom/movable/lighting_overlay)
 				T.shadower.copy_lighting(object, !(T.below.z_flags & ZM_NO_SHADOW))
+				shadower_set = TRUE
 				continue
 
 			// If an atom already has an overlay, we probably don't need to discover it again.


### PR DESCRIPTION
## Description of changes
Adds a missing `shadower_set = TRUE`.
Also adds the new ZM flag defines to the openturf analyzer list.

## Why and what will this PR improve
Not setting `shadower_set` to TRUE when the shadower received a color caused all ZM shadowers to have invalid/incorrect colors.

## Authorship
Me.