### PR TITLE
Fix browser popup titles covering popup contents on overflow

### DIFF
--- a/html/browser/common.css
+++ b/html/browser/common.css
@@ -135,10 +135,8 @@ h4
 
 .uiWrapper
 {
-
 	width: 100%;
 	height: 100%;
-	padding-top:32px;
 }
 
 .uiTitle
@@ -153,19 +151,11 @@ h4
 
 .uiTitleWrapper
  {
- 	position:fixed;
- 	top:0px;
- 	left:0px;
- 	right:0px;
- 	z-index: 10
+ 	z-index: 10;
  }
 
  .uiTitleButtons
  {
- 	position:fixed;
- 	top:0px;
- 	right:0px;
- 	height:32px;
  	z-index:11;
  }
 


### PR DESCRIPTION
## Description of changes
Supersedes #3687.
Removes hacky absolute positioning in the browser window popup CSS. This means elements will actually be in the document flow.

## Why and what will this PR improve
Elements being in the document flow means that they shouldn't cover each other up. Fixes https://github.com/ScavStation/ScavStation/issues/867.

## Authorship
Me for the fix, Loaf for bringing it to my attention.