### PR TITLE
Fix mispath in plate map migration

### DIFF
--- a/tools/map_migrations/3681_plates.txt
+++ b/tools/map_migrations/3681_plates.txt
@@ -1,3 +1,3 @@
 # REPATH /trash/plate to /plate
 /obj/item/trash/plate/@SUBTYPES : /obj/item/plate/@SUBTYPES{@OLD}
-/obj/item/trash/tray/@SUBTYPES : /obj/item/tray/@SUBTYPES{@OLD}
+/obj/item/trash/tray/@SUBTYPES : /obj/item/plate/tray/@SUBTYPES{@OLD}


### PR DESCRIPTION
## Description of changes
The path `/obj/item/tray` in the plate PR migration file did not exist (it looks like it became /obj/item/storage/tray a long time ago), so I changed it to `/obj/item/plate/tray` instead.

## Why and what will this PR improve
Fixes an error in the map migration file for #3681.