### PR TITLE
Fixes runtime in SScharacter_info load.

### DIFF
--- a/code/controllers/subsystems/initialization/character_info.dm
+++ b/code/controllers/subsystems/initialization/character_info.dm
@@ -4,6 +4,7 @@ SUBSYSTEM_DEF(character_info)
 	flags = SS_NEEDS_SHUTDOWN
 	init_order = SS_INIT_EARLY
 	wait = 1 SECOND
+	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT // We want to save changes made during pre-round lobby.
 	var/static/comments_source = "data/character_info/"
 	var/list/_comment_holders_by_id = list()
 	var/list/_ids_to_save = list()

--- a/code/modules/client/preferences_persist.dm
+++ b/code/modules/client/preferences_persist.dm
@@ -91,12 +91,8 @@
 		var/datum/pref_record_reader/R = load_pref_record(get_slot_key(slot))
 		if(!R)
 			R = new /datum/pref_record_reader/null_reader(PREF_SER_VERSION)
-		// Load/reload our character info record - mass preload is
-		// done if comments are enabled, but not done otherwise.
-		if(!SScharacter_info.get_record(record_id, TRUE))
-			SScharacter_info.load_record(record_id)
-		else
-			SScharacter_info.reload_record(record_id)
+		// Load/reload our character info record - mass preload is done if comments are enabled, but not done otherwise.
+		SScharacter_info.reload_record(record_id)
 		player_setup.load_character(R)
 
 	update_preview_icon()


### PR DESCRIPTION
## Description of changes
- Unnecessary get_record/load_record removed from pref comments load.
- SScharacter_info will flush save queue during round setup so pref changes aren't lost if you quit before the round starts.

## Why and what will this PR improve
Bugs!

## Authorship
Myself.

## Changelog
Nothing player-facing.