### PR TITLE
Various flooding and fluids optimizations and fixes.

### DIFF
--- a/code/__defines/fluids.dm
+++ b/code/__defines/fluids.dm
@@ -11,21 +11,40 @@
 	var/_fluid_turf_is_active = FALSE
 
 // Expects /turf for TURF.
-#define ADD_ACTIVE_FLUID_SOURCE(TURF)    if(!QDELETED(TURF) && !TURF.changing_turf && !TURF._fluid_source_is_active) { TURF._fluid_source_is_active = TRUE;  SSfluids.water_sources += TURF; }
-#define REMOVE_ACTIVE_FLUID_SOURCE(TURF) if(!QDELETED(TURF) && TURF._fluid_source_is_active)                         { TURF._fluid_source_is_active = FALSE; SSfluids.water_sources -= TURF; }
-#define ADD_ACTIVE_FLUID(TURF)           if(!QDELETED(TURF) && !TURF._fluid_turf_is_active)                          { TURF._fluid_turf_is_active   = TRUE;  SSfluids.active_fluids += TURF; }
-#define REMOVE_ACTIVE_FLUID(TURF)        if(!QDELETED(TURF) && TURF._fluid_turf_is_active)                           { TURF._fluid_turf_is_active   = FALSE; SSfluids.active_fluids -= TURF; }
+#define ADD_ACTIVE_FLUID_SOURCE(TURF)                                         \
+if(!QDELETED(TURF) && !TURF.changing_turf && !TURF._fluid_source_is_active) { \
+	TURF._fluid_source_is_active = TRUE;                                      \
+	SSfluids.water_sources += TURF;                                           \
+}
 
-#define UPDATE_FLUID_BLOCKED_DIRS(TURF)                     \
-	if(isnull(TURF.fluid_blocked_dirs)) {                   \
-		TURF.fluid_blocked_dirs = 0;                        \
-		for(var/obj/structure/window/W in TURF) {           \
-			if(W.density) TURF.fluid_blocked_dirs |= W.dir; \
-		}                                                   \
-		for(var/obj/machinery/door/window/D in TURF) {      \
-			if(D.density) TURF.fluid_blocked_dirs |= D.dir; \
-		}                                                   \
-	}
+#define REMOVE_ACTIVE_FLUID_SOURCE(TURF)                                      \
+if(!QDELETED(TURF) && TURF._fluid_source_is_active) {                         \
+	TURF._fluid_source_is_active = FALSE;                                     \
+	SSfluids.water_sources -= TURF;                                           \
+}
+
+#define ADD_ACTIVE_FLUID(TURF)                                                \
+if(!QDELETED(TURF) && !TURF._fluid_turf_is_active) {                          \
+	TURF._fluid_turf_is_active = TRUE;                                        \
+	SSfluids.active_fluids += TURF;                                           \
+}
+
+#define REMOVE_ACTIVE_FLUID(TURF)                                             \
+if(!QDELETED(TURF) && TURF._fluid_turf_is_active) {                           \
+	TURF._fluid_turf_is_active = FALSE;                                       \
+	SSfluids.active_fluids -= TURF;                                           \
+}
+
+#define UPDATE_FLUID_BLOCKED_DIRS(TURF)                                       \
+if(isnull(TURF.fluid_blocked_dirs)) {                                         \
+	TURF.fluid_blocked_dirs = 0;                                              \
+	for(var/obj/structure/window/W in TURF) {                                 \
+		if(W.density) TURF.fluid_blocked_dirs |= W.dir;                       \
+	}                                                                         \
+	for(var/obj/machinery/door/window/D in TURF) {                            \
+		if(D.density) TURF.fluid_blocked_dirs |= D.dir;                       \
+	}                                                                         \
+}
 
 #define FLUID_MAX_ALPHA 200
 #define FLUID_MIN_ALPHA 96

--- a/code/__defines/fluids.dm
+++ b/code/__defines/fluids.dm
@@ -6,12 +6,16 @@
 #define FLUID_DEEP 800               // Depth deep icon is used
 #define FLUID_MAX_DEPTH FLUID_DEEP*4 // Arbitrary max value for flooding.
 #define FLUID_PUSH_THRESHOLD 20      // Amount of flow needed to push items.
+/turf
+	var/_fluid_source_is_active = FALSE
+	var/_fluid_turf_is_active = FALSE
 
 // Expects /turf for TURF.
-#define ADD_ACTIVE_FLUID_SOURCE(TURF)    if(!TURF.changing_turf) { SSfluids.water_sources[TURF] = TRUE; }
-#define REMOVE_ACTIVE_FLUID_SOURCE(TURF) SSfluids.water_sources -= TURF
-#define ADD_ACTIVE_FLUID(TURF)           if(!QDELETED(TURF)) { SSfluids.active_fluids[TURF] = TRUE; }
-#define REMOVE_ACTIVE_FLUID(TURF)        SSfluids.active_fluids -= TURF
+#define ADD_ACTIVE_FLUID_SOURCE(TURF)    if(!QDELETED(TURF) && !TURF.changing_turf && !TURF._fluid_source_is_active) { TURF._fluid_source_is_active = TRUE;  SSfluids.water_sources += TURF; }
+#define REMOVE_ACTIVE_FLUID_SOURCE(TURF) if(!QDELETED(TURF) && TURF._fluid_source_is_active)                         { TURF._fluid_source_is_active = FALSE; SSfluids.water_sources -= TURF; }
+#define ADD_ACTIVE_FLUID(TURF)           if(!QDELETED(TURF) && !TURF._fluid_turf_is_active)                          { TURF._fluid_turf_is_active   = TRUE;  SSfluids.active_fluids += TURF; }
+#define REMOVE_ACTIVE_FLUID(TURF)        if(!QDELETED(TURF) && TURF._fluid_turf_is_active)                           { TURF._fluid_turf_is_active   = FALSE; SSfluids.active_fluids -= TURF; }
+
 #define UPDATE_FLUID_BLOCKED_DIRS(TURF)                     \
 	if(isnull(TURF.fluid_blocked_dirs)) {                   \
 		TURF.fluid_blocked_dirs = 0;                        \

--- a/code/controllers/subsystems/fluids.dm
+++ b/code/controllers/subsystems/fluids.dm
@@ -34,24 +34,6 @@ SUBSYSTEM_DEF(fluids)
 
 /datum/controller/subsystem/fluids/fire(resumed = 0)
 
-	// Predeclaring a bunch of vars for performance purposes.
-	var/turf/other_fluid_holder        = null
-	var/turf/current_fluid_holder      = null
-	var/datum/reagents/reagent_holder  = null
-	var/turf/neighbor                  = null
-	var/turf/lowest_neighbor           = null
-
-	var/removing =                       0
-	var/spread_dir =                     0
-	var/coming_from =                    0
-	var/flow_amount =                    0
-	var/current_depth =                  0
-	var/current_turf_depth =             0
-	var/neighbor_depth =                 0
-	var/lowest_neighbor_flow =           0
-	var/flooded_a_neighbor =             FALSE
-	var/lowest_neighbor_depth =          INFINITY
-
 	if(!resumed)
 		active_fluids_copied_yet = FALSE
 		holders_copied_yet =       FALSE
@@ -63,7 +45,15 @@ SUBSYSTEM_DEF(fluids)
 		fluid_sources_copied_yet = TRUE
 		processing_sources = water_sources.Copy()
 
-	var/i = 0
+	// Predeclaring a bunch of vars for performance purposes.
+	var/flooded_a_neighbor            = FALSE
+	var/spread_dir                    = 0
+	var/i                             = 0
+	var/turf/current_fluid_holder     = null
+	var/datum/reagents/reagent_holder = null
+	var/turf/neighbor                 = null
+	var/turf/lowest_neighbor          = null
+
 	while(i < processing_sources.len)
 		i++
 		current_fluid_holder = processing_sources[i]
@@ -94,6 +84,16 @@ SUBSYSTEM_DEF(fluids)
 	if(!active_fluids_copied_yet)
 		active_fluids_copied_yet = TRUE
 		processing_fluids = active_fluids.Copy()
+
+	var/removing                = 0
+	var/coming_from             = 0
+	var/flow_amount             = 0
+	var/current_depth           = 0
+	var/current_turf_depth      = 0
+	var/neighbor_depth          = 0
+	var/lowest_neighbor_flow    = 0
+	var/lowest_neighbor_depth   = INFINITY
+	var/turf/other_fluid_holder = null
 
 	i = 0
 	while(i < processing_fluids.len)

--- a/code/controllers/subsystems/fluids.dm
+++ b/code/controllers/subsystems/fluids.dm
@@ -150,8 +150,6 @@ SUBSYSTEM_DEF(fluids)
 						current_fluid_holder.transfer_fluids_to(other_fluid_holder, min(FLOOR(current_depth*0.5), FLUID_MAX_DEPTH - other_fluid_holder.reagents?.total_volume), defer_update = TRUE)
 						current_depth = current_fluid_holder.get_fluid_depth()
 
-		// Short-circuit spread behavior here and just wake up our neighbors, as they will likely want to flow into our turf.
-
 		// Flow into the lowest level neighbor.
 		lowest_neighbor_depth = INFINITY
 		lowest_neighbor_flow =  0
@@ -169,7 +167,8 @@ SUBSYSTEM_DEF(fluids)
 			other_fluid_holder = neighbor
 			neighbor_depth = (other_fluid_holder?.reagents?.total_volume || 0) + neighbor.get_physical_height()
 			flow_amount = round((current_turf_depth - neighbor_depth)*0.5)
-
+			// TODO: multiply flow amount or minimum transfer amount by some
+			// viscosity calculation to allow for piles of jelly vs piles of water.
 			if(flow_amount <= FLUID_MINIMUM_TRANSFER)
 				continue
 			ADD_ACTIVE_FLUID(neighbor)

--- a/code/controllers/subsystems/fluids.dm
+++ b/code/controllers/subsystems/fluids.dm
@@ -64,10 +64,10 @@ SUBSYSTEM_DEF(fluids)
 		fluid_sources_copied_yet = TRUE
 		processing_sources = water_sources.Copy()
 
-	while(processing_sources.len)
-
-		current_fluid_holder = processing_sources[processing_sources.len]
-		processing_sources.len--
+	var/i = 0
+	while(i < processing_sources.len)
+		i++
+		current_fluid_holder = processing_sources[i]
 
 		flooded_a_neighbor = FALSE
 		UPDATE_FLUID_BLOCKED_DIRS(current_fluid_holder)
@@ -88,16 +88,18 @@ SUBSYSTEM_DEF(fluids)
 			REMOVE_ACTIVE_FLUID_SOURCE(current_fluid_holder)
 
 		if (MC_TICK_CHECK)
+			processing_sources.Cut(1, i+1)
 			return
+	processing_sources.Cut()
 
 	if(!active_fluids_copied_yet)
 		active_fluids_copied_yet = TRUE
 		processing_fluids = active_fluids.Copy()
 
-	while(processing_fluids.len)
-
-		current_fluid_holder = processing_fluids[processing_fluids.len]
-		processing_fluids.len--
+	i = 0
+	while(i < processing_fluids.len)
+		i++
+		current_fluid_holder = processing_fluids[i]
 
 		REMOVE_ACTIVE_FLUID(current_fluid_holder) // This will be refreshed if our level changes at all in this iteration of the subsystem.
 
@@ -191,29 +193,35 @@ SUBSYSTEM_DEF(fluids)
 			current_fluid_holder.last_flow_dir = 0
 
 		if (MC_TICK_CHECK)
-			break
+			processing_fluids.Cut(1, i+1)
+			return
+	processing_fluids.Cut()
 
 	if(!holders_copied_yet)
 		holders_copied_yet = TRUE
 		processing_holders = holders_to_update.Copy()
 
-	while(processing_holders.len)
-		reagent_holder = processing_holders[processing_holders.len]
-		processing_holders.len--
+	i = 0
+	while(i < processing_holders.len)
+		i++
+		reagent_holder = processing_holders[i]
 		if(!QDELETED(reagent_holder))
 			reagent_holder.handle_update()
 		else
 			holders_to_update -= reagent_holder
 		if(MC_TICK_CHECK)
+			processing_holders.Cut(1, i+1)
 			return
+	processing_holders.Cut()
 
 	if(!flows_copied_yet)
 		flows_copied_yet = TRUE
 		processing_flows = pending_flows.Copy()
 
-	while(processing_flows.len)
-		current_fluid_holder = processing_flows[processing_flows.len]
-		processing_flows.len--
+	i = 0
+	while(i < processing_flows.len)
+		i++
+		current_fluid_holder = processing_flows[i]
 		if(!istype(current_fluid_holder) || QDELETED(current_fluid_holder))
 			continue
 		reagent_holder = current_fluid_holder.reagents
@@ -226,7 +234,9 @@ SUBSYSTEM_DEF(fluids)
 		if(pushed_something && prob(1))
 			playsound(current_fluid_holder, 'sound/effects/slosh.ogg', 25, 1)
 		if(MC_TICK_CHECK)
+			processing_flows.Cut(1, i+1)
 			return
+	processing_flows.Cut()
 
 /datum/controller/subsystem/fluids/StartLoadingMap()
 	suspend()

--- a/code/game/objects/effects/fluids.dm
+++ b/code/game/objects/effects/fluids.dm
@@ -52,24 +52,38 @@
 	else
 		set_overlays("ocean")
 
-// Map helper.
-/obj/abstract/fluid_mapped
-	name = "mapped flooded area"
-	alpha = 125
+// Map helpers.
+/obj/abstract/landmark/mapped_flood
+	name = "mapped fluid area"
+	alpha = FLUID_MAX_ALPHA
+	icon_state = "ocean"
+	color = COLOR_LIQUID_WATER
+	var/fluid_type = /decl/material/liquid/water
+
+/obj/abstract/landmark/mapped_flood/Initialize()
+	..()
+	var/turf/my_turf = get_turf(src)
+	if(my_turf)
+		my_turf.set_flooded(fluid_type)
+	return INITIALIZE_HINT_QDEL
+
+/obj/abstract/landmark/mapped_fluid
+	name = "mapped fluid area"
+	alpha = FLUID_MIN_ALPHA
 	icon_state = "shallow_still"
 	color = COLOR_LIQUID_WATER
 
 	var/fluid_type = /decl/material/liquid/water
 	var/fluid_initial = FLUID_MAX_DEPTH
 
-/obj/abstract/fluid_mapped/Initialize()
+/obj/abstract/landmark/mapped_fluid/Initialize()
 	..()
-	var/turf/T = get_turf(src)
-	if(istype(T))
-		T.add_fluid(fluid_type, fluid_initial)
+	var/turf/my_turf = get_turf(src)
+	if(my_turf)
+		my_turf.add_fluid(fluid_type, fluid_initial)
 	return INITIALIZE_HINT_QDEL
 
-/obj/abstract/fluid_mapped/fuel
+/obj/abstract/landmark/mapped_fluid/fuel
 	name = "spilled fuel"
 	fluid_type = /decl/material/liquid/fuel
 	fluid_initial = 10

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -12,6 +12,7 @@
 	var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
 	if(L)
 		qdel(L)
+
 // Called after turf replaces old one
 /turf/proc/post_change()
 	levelupdate()

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -100,7 +100,7 @@
 			qdel(old_fire)
 
 	if(old_flooded != W.flooded)
-		set_flooded(old_flooded && !W.density)
+		set_flooded(old_flooded)
 
 	// Raise appropriate events.
 	W.post_change()

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -13,6 +13,29 @@
 	if(reagents)
 		reagents.remove_any(amount)
 
+/turf/proc/displace_all_reagents()
+	UPDATE_FLUID_BLOCKED_DIRS(src)
+	var/list/spread_into_neighbors
+	var/turf/neighbor
+	var/coming_from
+	for(var/spread_dir in global.cardinal)
+		if(fluid_blocked_dirs & spread_dir)
+			continue
+		neighbor = get_step(src, spread_dir)
+		if(!neighbor)
+			continue
+		UPDATE_FLUID_BLOCKED_DIRS(neighbor)
+		coming_from = global.reverse_dir[spread_dir]
+		if((neighbor.fluid_blocked_dirs & coming_from) || !neighbor.CanFluidPass(coming_from) || neighbor.is_flooded(absolute = TRUE) || !neighbor.CanFluidPass(global.reverse_dir[spread_dir]))
+			continue
+		LAZYDISTINCTADD(spread_into_neighbors, neighbor)
+	if(length(spread_into_neighbors))
+		var/spreading = round(reagents.total_volume / length(spread_into_neighbors))
+		if(spreading > 0)
+			for(var/turf/spread_into_turf as anything in spread_into_neighbors)
+				reagents.trans_to_turf(spread_into_turf, spreading)
+	reagents?.clear_reagents()
+
 /turf/proc/set_flooded(new_flooded, force = FALSE, skip_vis_contents_update = FALSE, mapload = FALSE)
 
 	// Don't do unnecessary work.
@@ -72,6 +95,8 @@
 				T.fluid_update(TRUE)
 	if(flooded)
 		ADD_ACTIVE_FLUID_SOURCE(src)
+	else
+		ADD_ACTIVE_FLUID(src)
 
 /turf/proc/add_fluid(var/fluid_type, var/fluid_amount, var/defer_update)
 	if(!reagents)
@@ -136,7 +161,7 @@
 
 	..()
 
-	if(reagents?.total_volume)
+	if(reagents?.total_volume > FLUID_QDEL_POINT)
 		ADD_ACTIVE_FLUID(src)
 		var/decl/material/primary_reagent = reagents.get_primary_reagent_decl()
 		if(primary_reagent)
@@ -151,8 +176,7 @@
 		SSfluids.pending_flows -= src
 		if(last_slipperiness > 0)
 			wet_floor(last_slipperiness)
-
-	for(var/checkdir in global.cardinal)
-		var/turf/neighbor = get_step(src, checkdir)
-		if(neighbor)
-			ADD_ACTIVE_FLUID(neighbor)
+		for(var/checkdir in global.cardinal)
+			var/turf/neighbor = get_step(src, checkdir)
+			if(neighbor?.reagents?.total_volume)
+				ADD_ACTIVE_FLUID(neighbor)

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -178,5 +178,5 @@
 			wet_floor(last_slipperiness)
 		for(var/checkdir in global.cardinal)
 			var/turf/neighbor = get_step(src, checkdir)
-			if(neighbor?.reagents?.total_volume)
+			if(neighbor?.reagents?.total_volume > FLUID_QDEL_POINT)
 				ADD_ACTIVE_FLUID(neighbor)

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -95,7 +95,7 @@
 				T.fluid_update(TRUE)
 	if(flooded)
 		ADD_ACTIVE_FLUID_SOURCE(src)
-	else
+	else if(reagents?.total_volume > FLUID_QDEL_POINT)
 		ADD_ACTIVE_FLUID(src)
 
 /turf/proc/add_fluid(var/fluid_type, var/fluid_amount, var/defer_update)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -176,6 +176,9 @@ var/global/obj/temp_reagents_holder = new
 
 /* Holder-to-chemical */
 /datum/reagents/proc/handle_update(var/safety)
+	if(QDELETED(src))
+		return
+	SSfluids.holders_to_update -= src
 	update_total()
 	if(!safety)
 		HANDLE_REACTIONS(src)

--- a/code/modules/reagents/chems/chems_blood.dm
+++ b/code/modules/reagents/chems/chems_blood.dm
@@ -51,7 +51,7 @@
 	if(!istype(T) || REAGENT_VOLUME(holder, type) < 3)
 		return
 	var/weakref/W = LAZYACCESS(data, "donor")
-	blood_splatter(T, W.resolve() || holder.my_atom, 1)
+	blood_splatter(T, W?.resolve() || holder.my_atom, 1)
 
 /decl/material/liquid/blood/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(M.HasTrait(/decl/trait/metabolically_inert))

--- a/code/unit_tests/del_the_world.dm
+++ b/code/unit_tests/del_the_world.dm
@@ -34,7 +34,7 @@
 		// Needs a level above.
 		/obj/structure/stairs,
 		// Fluid system related; causes issues with atoms spawned on the turf.
-		/obj/abstract/fluid_mapped,
+		/obj/abstract/landmark/mapped_fluid,
 		/obj/effect/flood,
 		// Not valid when spawned manually.
 		/obj/effect/overmap,

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -3978,7 +3978,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /turf/simulated/floor/tiled/usedup,
 /area/ship/scrap/maintenance/engineering)
 "hI" = (
@@ -4166,7 +4166,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
 	},
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/usedup,
 /area/ship/scrap/maintenance/engineering)
@@ -4175,7 +4175,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
 	},
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /obj/structure/sign/warning/nosmoking_1{
 	pixel_y = -32
 	},

--- a/maps/away/mining/mining-signal.dmm
+++ b/maps/away/mining/mining-signal.dmm
@@ -1079,18 +1079,18 @@
 /turf/simulated/floor/tiled/airless,
 /area/outpost/abandoned)
 "dJ" = (
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /obj/structure/table/steel,
 /obj/random/bomb_supply,
 /turf/simulated/floor/tiled/airless,
 /area/outpost/abandoned)
 "dK" = (
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/airless,
 /area/outpost/abandoned)
 "dL" = (
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /obj/structure/bed/chair,
 /obj/machinery/light/small/emergency{
 	dir = 1;
@@ -1173,7 +1173,7 @@
 /turf/simulated/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "dZ" = (
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /obj/structure/sign/directions/medical{
 	dir = 8
 	},
@@ -1181,8 +1181,8 @@
 /area/outpost/abandoned)
 "ea" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/abstract/fluid_mapped/fuel,
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /turf/simulated/floor/tiled/airless,
 /area/outpost/abandoned)
 "eb" = (
@@ -1194,11 +1194,11 @@
 /area/outpost/abandoned)
 "ec" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /turf/simulated/floor/tiled/airless,
 /area/outpost/abandoned)
 "ed" = (
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/airless,
 /area/outpost/abandoned)
@@ -1282,7 +1282,7 @@
 /turf/simulated/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "et" = (
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /obj/structure/table,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -1294,14 +1294,14 @@
 /turf/simulated/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "eu" = (
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/bot/medbot,
 /turf/simulated/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "ev" = (
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /turf/simulated/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "ex" = (
@@ -1310,7 +1310,7 @@
 /turf/simulated/floor/tiled/airless,
 /area/outpost/abandoned)
 "ey" = (
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
@@ -1468,7 +1468,7 @@
 "eW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
 	},
@@ -2260,7 +2260,7 @@
 /area/outpost/abandoned)
 "hp" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /turf/simulated/floor/plating,
 /area/outpost/abandoned)
 "hq" = (
@@ -2361,13 +2361,13 @@
 "hD" = (
 /obj/random/junk,
 /obj/effect/decal/cleanable/dirt,
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /turf/simulated/floor/plating,
 /area/outpost/abandoned)
 "hE" = (
 /obj/structure/table/reinforced,
 /obj/random/material,
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /turf/simulated/floor/plating,
 /area/outpost/abandoned)
 "hF" = (
@@ -2376,7 +2376,7 @@
 /turf/simulated/floor/plating,
 /area/outpost/abandoned)
 "hG" = (
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /obj/structure/closet/crate/radiation,
 /obj/random/voidsuit,
 /obj/random/voidhelmet,
@@ -2384,7 +2384,7 @@
 /area/outpost/abandoned)
 "hH" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /turf/simulated/floor/plating,
 /area/outpost/abandoned)
 "hL" = (

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -3391,7 +3391,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/abstract/fluid_mapped/fuel,
+/obj/abstract/landmark/mapped_fluid/fuel,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/engineering)
 "in" = (


### PR DESCRIPTION
## Description of changes
- ChangeTurf now universally preserves flooded status. A helper landmark has been added to let people spawn flooded turfs ad hoc.
- Fluid updates and sleeping have been refined/optimized.
- Fluid and flood activation/sleeping have been optimized.
- Turfs now have a displace_all_reagents() proc that tries to move all reagent contents into neighbors. This is used when a turf discovers it fails CanFluidPass() during SSfluids processing.

## Why and what will this PR improve
Performance of the fluid system and flooding init.

## Authorship
Myself and @out-of-phaze.

## Changelog
Nothing player-facing.