### PR TITLE
Heart and lungs should now not report functioning well to the vitals monitor when dead or cut out.

### DIFF
--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -189,6 +189,10 @@
 	return is_usable() && (pulse > PULSE_NONE || BP_IS_PROSTHETIC(src) || (owner.status_flags & FAKEDEATH))
 
 /obj/item/organ/internal/heart/listen()
+
+	if(!owner || (status & (ORGAN_DEAD|ORGAN_CUT_AWAY)))
+		return "no pulse"
+
 	if(BP_IS_PROSTHETIC(src) && is_working())
 		if(is_bruised())
 			return "sputtering pump"

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -328,7 +328,8 @@
 		species.get_environment_discomfort(owner,"cold")
 
 /obj/item/organ/internal/lungs/listen()
-	if(owner.failed_last_breath || !active_breathing)
+
+	if((status & (ORGAN_DEAD|ORGAN_CUT_AWAY)) || !owner || owner.failed_last_breath || !active_breathing)
 		return "no respiration"
 
 	if(BP_IS_PROSTHETIC(src))


### PR DESCRIPTION
Fixes https://github.com/ScavStation/ScavStation/issues/891