### PR TITLE
Reworking how contact reagents are handled.

### DIFF
--- a/code/game/objects/items/weapons/towels.dm
+++ b/code/game/objects/items/weapons/towels.dm
@@ -14,16 +14,18 @@
 /obj/item/towel/Initialize()
 	. = ..()
 	initialize_reagents()
-	START_PROCESSING(SSobj, src)
 
 /obj/item/towel/Destroy()
-	STOP_PROCESSING(SSobj, src)
+	if(is_processing)
+		STOP_PROCESSING(SSobj, src)
 	return ..()
 
 // Slowly dry out.
 /obj/item/towel/Process()
 	if(reagents?.total_volume)
 		reagents.remove_any(max(1, round(reagents.total_volume * 0.05)))
+	if(!reagents?.total_volume)
+		return PROCESS_KILL
 
 /obj/item/towel/initialize_reagents()
 	create_reagents(50)
@@ -33,8 +35,12 @@
 	. = ..()
 	if(reagents?.total_volume)
 		SetName("damp [initial(name)]")
+		if(!is_processing)
+			START_PROCESSING(SSobj, src)
 	else
 		SetName(initial(name))
+		if(is_processing)
+			STOP_PROCESSING(SSobj, src)
 
 /obj/item/towel/attack(mob/living/M, mob/living/user, var/target_zone, animate = TRUE)
 	if(user.a_intent == I_HURT)

--- a/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
@@ -226,6 +226,7 @@
 /decl/material/liquid/hair_remover/affect_touch(var/mob/M, var/removed, var/datum/reagents/holder)
 	M.lose_hair()
 	holder.remove_reagent(type, REAGENT_VOLUME(holder, type))
+	return TRUE
 
 /decl/material/liquid/zombie
 	name = "liquid corruption"
@@ -244,6 +245,7 @@
 
 /decl/material/liquid/zombie/affect_touch(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	affect_blood(M, removed * 0.5, holder)
+	return TRUE
 
 /decl/material/liquid/zombie/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -5,7 +5,7 @@
 	if(!reagents)
 		reagents = bloodstr
 	if(!touching)
-		touching = new/datum/reagents/metabolism(1000, src, CHEM_TOUCH)
+		touching = new/datum/reagents/metabolism(mob_size * 100, src, CHEM_TOUCH)
 
 	if (!default_language && species_language)
 		default_language = species_language
@@ -303,8 +303,9 @@
 
 /mob/living/carbon/fluid_act(var/datum/reagents/fluids)
 	..()
-	if(QDELETED(src) || !fluids?.total_volume || !touching)
+	if(QDELETED(src) || !fluids?.total_volume || !touching || fluids.total_volume <= touching.total_volume)
 		return
+	// TODO: review saturation logic so we can end up with more than like 15 water in our contact reagents.
 	var/saturation =  min(fluids.total_volume, round(mob_size * 1.5 * reagent_permeability()) - touching.total_volume)
 	if(saturation > 0)
 		fluids.trans_to_holder(touching, saturation)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -71,10 +71,22 @@
 					else
 						to_chat(user, "<span class='deadsay'>[use_He] [use_has] a pulse!</span>")
 
+	var/datum/reagents/touching_reagents = get_contact_reagents()
+	if(touching_reagents?.total_volume)
+		var/saturation = touching_reagents.total_volume / touching_reagents.maximum_volume
+		if(saturation > 0.9)
+			msg += "[use_He] [use_is] completely saturated.\n"
+		else if(saturation > 0.6)
+			msg += "[use_He] [use_is] looking like a drowned cat.\n"
+		else if(saturation > 0.3)
+			msg += "[use_He] [use_is] looking notably soggy.\n"
+		else 
+			msg += "[use_He] [use_is] looking a bit damp.\n"
+
 	if(fire_stacks > 0)
-		msg += "[use_He] is covered in flammable liquid!\n"
+		msg += "[use_He] [use_is] looking highly flammable!\n"
 	else if(fire_stacks < 0)
-		msg += "[use_He] [use_is] soaking wet.\n"
+		msg += "[use_He] [use_is] looking rather damp.\n"
 
 	if(on_fire)
 		msg += "<span class='warning'>[use_He] [use_is] on fire!.</span>\n"

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -233,6 +233,16 @@
 
 	SHOULD_CALL_PARENT(TRUE)
 
+	// TODO: process dripping outside of Life() so corpses don't become sponges.
+	// TODO: factor temperature and vapor into this so warmer locations dry you off.
+	// TODO: apply a dripping overlay a la fire to show someone is saturated.
+	if(loc)
+		var/datum/reagents/touching_reagents = get_contact_reagents()
+		if(touching_reagents?.total_volume)
+			var/drip_amount = max(1, round(touching_reagents.total_volume * 0.1))
+			if(drip_amount)
+				touching_reagents.trans_to(loc, drip_amount)
+
 	// Handle physical effects of weather.
 	var/decl/state/weather/weather_state
 	var/obj/abstract/weather_system/weather = get_affecting_weather()

--- a/code/modules/reagents/chems/chems_blood.dm
+++ b/code/modules/reagents/chems/chems_blood.dm
@@ -61,12 +61,6 @@
 	if(LAZYACCESS(M.chem_doses, type) > 15)
 		M.adjustToxLoss(removed)
 
-/decl/material/liquid/blood/affect_touch(var/mob/living/M, var/removed, var/datum/reagents/holder)
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(H.isSynthetic())
-			return
-
 /decl/material/liquid/blood/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(ishuman(M))
 		var/volume = REAGENT_VOLUME(holder, type)

--- a/code/modules/reagents/chems/chems_compounds.dm
+++ b/code/modules/reagents/chems/chems_compounds.dm
@@ -191,6 +191,8 @@
 			M.custom_emote(2, "[pick("coughs!","coughs hysterically!","splutters!")]")
 			SET_STATUS_MAX(M, STAT_STUN, 3)
 
+	return TRUE
+
 /decl/material/liquid/capsaicin/condensed/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	holder.remove_reagent(/decl/material/liquid/frostoil, 5)
 
@@ -223,6 +225,7 @@
 /decl/material/liquid/mutagenics/affect_touch(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(prob(33))
 		affect_blood(M, removed, holder)
+	return TRUE
 
 /decl/material/liquid/mutagenics/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(prob(67))

--- a/code/modules/reagents/chems/chems_medicines.dm
+++ b/code/modules/reagents/chems/chems_medicines.dm
@@ -102,6 +102,7 @@
 
 /decl/material/liquid/adminordrazine/affect_touch(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	affect_blood(M, removed, holder)
+	return TRUE
 
 /decl/material/liquid/adminordrazine/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	M.rejuvenate()

--- a/mods/content/xenobiology/slime/slime_reagents.dm
+++ b/mods/content/xenobiology/slime/slime_reagents.dm
@@ -15,7 +15,7 @@
 	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 
 /decl/material/liquid/water/affect_touch(var/mob/living/M, var/removed, var/datum/reagents/holder)
-	..()
+	. = ..()
 	if(isslime(M))
 		M.adjustToxLoss(10 * removed)
 		var/mob/living/slime/S = M


### PR DESCRIPTION
## Description of changes
- Contact reagents will no longer process out of the metabolism holder by default.
- Contact reagents will drip onto your loc over time.
- Examine will show a message based on your current contact reagent saturation.
- Towels can be used to remove contact reagents.

## Why and what will this PR improve
Working towards slightly less wonky contact reagent handling in general.

## Authorship
Myself.

## Changelog
:cl:
tweak: You can now dry yourself or others off with a towel.
tweak: You will now drip contact reagents onto your turf if you get splashed or dunked.
/:cl: