### PR TITLE
Port fixes from Lighthouse, 02/23/2024

### DIFF
--- a/code/controllers/subsystems/atoms.dm
+++ b/code/controllers/subsystems/atoms.dm
@@ -66,6 +66,7 @@ SUBSYSTEM_DEF(atoms)
 		for(var/I in late_loaders)
 			var/atom/A = I
 			A.LateInitialize(arglist(late_loaders[A]))
+			CHECK_TICK
 		report_progress("Late initialized [late_loaders.len] atom\s")
 		late_loaders.Cut()
 

--- a/code/controllers/subsystems/initialization/fabrication.dm
+++ b/code/controllers/subsystems/initialization/fabrication.dm
@@ -33,6 +33,7 @@ SUBSYSTEM_DEF(fabrication)
 				LAZYADD(locked_recipes[fab_type], recipe)
 			else
 				LAZYADD(initial_recipes[fab_type], recipe)
+		CHECK_TICK
 
 	// Slapcrafting trees.
 	var/list/all_crafting_handlers = decls_repository.get_decls_of_subtype(/decl/crafting_stage)

--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -46,6 +46,7 @@ SUBSYSTEM_DEF(supply)
 			for(var/decl/hierarchy/supply_pack/spc in sp.get_descendents())
 				spc.setup()
 				master_supply_list += spc
+				CHECK_TICK
 
 // Just add points over time.
 /datum/controller/subsystem/supply/fire()

--- a/code/datums/repositories/atom_info.dm
+++ b/code/datums/repositories/atom_info.dm
@@ -26,7 +26,7 @@ var/global/repository/atom_info/atom_info_repository = new()
 	var/atom/instance
 	if(!matter_cache[key])
 		instance = get_instance_of(path, material, amount)
-		matter_cache[key] = instance.get_contained_matter()
+		matter_cache[key] = instance.get_contained_matter() || list()
 	if(!combined_worth_cache[key])
 		instance = instance || get_instance_of(path, material, amount)
 		combined_worth_cache[key] = instance.get_combined_monetary_worth()

--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -248,6 +248,7 @@ var/global/template_file_name = "all_templates.json"
 	for(var/type in subtypesof(/datum/asset) - /datum/asset/simple)
 		var/datum/asset/A = new type()
 		A.register()
+		CHECK_TICK
 
 	for(var/client/C in global.clients) // This is also called in client/New, but as we haven't initialized the cache until now, and it's possible the client is already connected, we risk doing it twice.
 		// Doing this to a client too soon after they've connected can cause issues, also the proc we call sleeps.

--- a/code/modules/mob/living/living_organs.dm
+++ b/code/modules/mob/living/living_organs.dm
@@ -20,6 +20,11 @@
 /mob/living/proc/has_internal_organs()
 	return LAZYLEN(get_internal_organs()) > 0
 
+/mob/living/get_contained_matter()
+	. = ..()
+	for(var/obj/item/organ in get_organs())
+		. = MERGE_ASSOCS_WITH_NUM_VALUES(., organ.get_contained_matter())
+
 //Can be called when we want to add an organ in a detached state or an attached state.
 /mob/living/proc/add_organ(var/obj/item/organ/O, var/obj/item/organ/external/affected = null, var/in_place = FALSE, var/update_icon = TRUE, var/detached = FALSE)
 	. = O.do_install(src, affected, in_place, update_icon, detached)


### PR DESCRIPTION
## Description of changes
Adds CHECK_TICK to some subsystem init procs that were missing it.
Fixes mobs not having matter from their organs.
Fixes cache misses in the atom info repository for atoms with null matter.

## Why and what will this PR improve
Init procs should CHECK_TICK on live servers. Mobs should have matter from their internal and external organs. Atoms with null matter should have that cached properly.