### PR TITLE
Make initial contents for most storage objects lazy-initialize

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -12,6 +12,7 @@
 	slot_flags = SLOT_LOWER_BODY
 	attack_verb = list("whipped", "lashed", "disciplined")
 	material = /decl/material/solid/organic/leather/synth
+	lazyload_contents = FALSE // because we sometimes overlay our contents
 	var/overlay_flags
 
 /obj/item/storage/belt/get_associated_equipment_slots()

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -762,7 +762,7 @@
 	var/list/cnt = WillContain()
 	if((islist(cnt) || ispath(cnt)) && length(cnt))
 		var/atom/movable/AM = ispath(cnt)? cnt : cnt[1]
-		SetName("[initial(AM.name)] pack")
+		SetName("[atom_info_repository.get_name_for(AM)] pack")
 
 /obj/item/storage/box/parts_pack/manipulator
 	icon_state = "mainpulator"

--- a/code/game/objects/items/weapons/storage/fancy/_fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy/_fancy.dm
@@ -4,6 +4,7 @@
 
 /obj/item/storage/box/fancy
 	abstract_type = /obj/item/storage/box/fancy
+	lazyload_contents = FALSE
 	/// A string modifier used to generate overlays for contents.
 	var/use_single_icon_overlay_state
 	/// The root type of the key item that this "fancy" container is meant to store.

--- a/code/game/objects/items/weapons/storage/trays.dm
+++ b/code/game/objects/items/weapons/storage/trays.dm
@@ -18,6 +18,7 @@
 	use_sound = null
 	material = /decl/material/solid/organic/cardboard
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME
+	lazyload_contents = FALSE
 	var/cooldown = 0	//Cooldown for banging the tray with a rolling pin. based on world.time. very silly
 	var/no_drop = FALSE
 

--- a/code/modules/reagents/storage/pill_foil.dm
+++ b/code/modules/reagents/storage/pill_foil.dm
@@ -5,6 +5,7 @@
 	icon_state = "pill_pack"
 	pop_sound = 'sound/effects/pop.ogg'
 	color = COLOR_GRAY80
+	lazyload_contents = FALSE
 	var/pill_type
 	var/pill_count = 4
 	var/pill_positions


### PR DESCRIPTION
## Description of changes
Do not merge, needs additional testing and maintainer consensus on if this is something we even want to do. Could also make it a config or compile option if desired.

Most storage objects will now wait until their first interaction to create their contents. Storage objects that display their contents do not do this.

Notably, this will cause issues for a few things like `in world`s, which is why I want maintainer consensus about what, if anything, to do about that sort of thing.

## Why and what will this PR improve
Cuts off a decent amount of init time by waiting to create objects that functionally don't exist until interacted with already.

## Changelog
:cl:
experiment: Most storage contents will not initialize their contents until first interacted with, which makes startup faster but could cause bugs. Report any issues on the issue tracker!
/:cl: