### PR TITLE
Make ammo magazines lazy-initialize

### DIFF
--- a/code/modules/mechs/equipment/combat_projectile.dm
+++ b/code/modules/mechs/equipment/combat_projectile.dm
@@ -17,11 +17,11 @@
 
 /obj/item/gun/projectile/automatic/get_hardpoint_status_value()
 	if(!isnull(ammo_magazine))
-		return ammo_magazine.stored_ammo.len
+		return ammo_magazine.get_stored_ammo_count()
 
 /obj/item/gun/projectile/automatic/get_hardpoint_maptext()
 	if(!isnull(ammo_magazine))
-		return "[ammo_magazine.stored_ammo.len]/[ammo_magazine.max_ammo]"
+		return "[ammo_magazine.get_stored_ammo_count()]/[ammo_magazine.max_ammo]"
 	return 0
 
 //Weapons below this.

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -146,8 +146,24 @@
 	var/list/icon_keys = list()		//keys
 	var/list/ammo_states = list()	//values
 
+	/// Determines whether or not we wait until the first time our contents are gotten to initialize contents. May lead to icon bugs if not handled delicately.
+	var/lazyload_contents = TRUE
+	/// Whether or not our contents have been initialized or not, used in lazyloaded contents.
+	var/contents_initialized = FALSE
+
 /obj/item/ammo_magazine/box
 	w_class = ITEM_SIZE_NORMAL
+
+/obj/item/ammo_magazine/proc/create_initial_contents()
+	if(contents_initialized || !initial_ammo || !ammo_type)
+		return
+	for(var/i in 1 to initial_ammo)
+		stored_ammo += new ammo_type(src)
+
+/obj/item/ammo_magazine/proc/get_stored_ammo_count()
+	. = length(stored_ammo)
+	if(!contents_initialized)
+		. += initial_ammo
 
 /obj/item/ammo_magazine/Initialize()
 	. = ..()
@@ -157,9 +173,8 @@
 	if(isnull(initial_ammo))
 		initial_ammo = max_ammo
 
-	if(initial_ammo)
-		for(var/i in 1 to initial_ammo)
-			stored_ammo += new ammo_type(src)
+	if(!lazyload_contents)
+		create_initial_contents()
 	if(caliber)
 		LAZYINSERT(labels, caliber, 1)
 	if(LAZYLEN(labels))
@@ -172,7 +187,7 @@
 		if(C.caliber != caliber)
 			to_chat(user, "<span class='warning'>[C] does not fit into [src].</span>")
 			return
-		if(stored_ammo.len >= max_ammo)
+		if(get_stored_ammo_count() >= max_ammo)
 			to_chat(user, "<span class='warning'>[src] is full!</span>")
 			return
 		if(!user.try_unequip(C, src))
@@ -183,6 +198,7 @@
 	else ..()
 
 /obj/item/ammo_magazine/attack_self(mob/user)
+	create_initial_contents()
 	if(!stored_ammo.len)
 		to_chat(user, "<span class='notice'>[src] is already empty!</span>")
 		return
@@ -197,6 +213,7 @@
 /obj/item/ammo_magazine/attack_hand(mob/user)
 	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
+	create_initial_contents()
 	if(!stored_ammo.len)
 		to_chat(user, SPAN_NOTICE("\The [src] is already empty!"))
 		return TRUE
@@ -213,18 +230,20 @@
 /obj/item/ammo_magazine/on_update_icon()
 	. = ..()
 	if(multiple_sprites)
-		//find the lowest key greater than or equal to stored_ammo.len
+		//find the lowest key greater than or equal to our ammo count
 		var/new_state = null
+		var/self_ammo_count = get_stored_ammo_count()
 		for(var/idx in 1 to icon_keys.len)
-			var/ammo_count = icon_keys[idx]
-			if (ammo_count >= stored_ammo.len)
+			var/icon_ammo_count = icon_keys[idx]
+			if (icon_ammo_count >= self_ammo_count)
 				new_state = ammo_states[idx]
 				break
 		icon_state = (new_state)? new_state : initial(icon_state)
 
 /obj/item/ammo_magazine/examine(mob/user)
 	. = ..()
-	to_chat(user, "There [(stored_ammo.len == 1)? "is" : "are"] [stored_ammo.len] round\s left!")
+	var/self_ammo_count = get_stored_ammo_count()
+	to_chat(user, "There [(self_ammo_count == 1)? "is" : "are"] [self_ammo_count] round\s left!")
 
 //magazine icon state caching
 var/global/list/magazine_icondata_keys = list()

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -66,6 +66,7 @@
 /obj/item/ammo_magazine/shotholder/attack_hand(mob/user)
 	if(loc != user || user.a_intent != I_HURT || !length(stored_ammo) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
+	create_initial_contents()
 	var/obj/item/ammo_casing/C = stored_ammo[stored_ammo.len]
 	stored_ammo -= C
 	user.put_in_hands(C)

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -68,10 +68,16 @@
 		chambered = loaded[1] //load next casing.
 		if(handle_casings != HOLD_CASINGS)
 			loaded -= chambered
-	else if(ammo_magazine && ammo_magazine.stored_ammo.len)
-		chambered = ammo_magazine.stored_ammo[ammo_magazine.stored_ammo.len]
-		if(handle_casings != HOLD_CASINGS)
-			ammo_magazine.stored_ammo -= chambered
+	else if(ammo_magazine)
+		if(!ammo_magazine.contents_initialized && ammo_magazine.initial_ammo > 0)
+			chambered = new ammo_magazine.ammo_type(src)
+			if(handle_casings == HOLD_CASINGS)
+				ammo_magazine.stored_ammo += chambered
+			ammo_magazine.initial_ammo--
+		else if(ammo_magazine.stored_ammo.len)
+			chambered = ammo_magazine.stored_ammo[ammo_magazine.stored_ammo.len]
+			if(handle_casings != HOLD_CASINGS)
+				ammo_magazine.stored_ammo -= chambered
 
 	if (chambered)
 		return chambered.BB
@@ -232,7 +238,7 @@
 
 /obj/item/gun/projectile/afterattack(atom/A, mob/living/user)
 	..()
-	if(auto_eject && ammo_magazine && ammo_magazine.stored_ammo && !ammo_magazine.stored_ammo.len)
+	if(auto_eject && ammo_magazine && !ammo_magazine.get_stored_ammo_count())
 		ammo_magazine.dropInto(loc)
 		user.visible_message(
 			"[ammo_magazine] falls out and clatters on the floor!",
@@ -257,8 +263,8 @@
 	var/bullets = 0
 	if(loaded)
 		bullets += loaded.len
-	if(ammo_magazine && ammo_magazine.stored_ammo)
-		bullets += ammo_magazine.stored_ammo.len
+	if(ammo_magazine)
+		bullets += ammo_magazine.get_stored_ammo_count()
 	if(chambered)
 		bullets += 1
 	return bullets

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -72,7 +72,7 @@
 
 /obj/item/gun/projectile/automatic/assault_rifle/update_base_icon()
 	if(ammo_magazine)
-		if(ammo_magazine.stored_ammo.len)
+		if(ammo_magazine.get_stored_ammo_count())
 			icon_state = "[get_world_inventory_state()]-loaded"
 		else
 			icon_state = "[get_world_inventory_state()]-empty"

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -37,13 +37,13 @@
 /obj/item/gun/projectile/dartgun/on_update_icon()
 	..()
 	if(ammo_magazine)
-		icon_state = "[get_world_inventory_state()]-[clamp(length(ammo_magazine.stored_ammo.len), 0, 5)]"
+		icon_state = "[get_world_inventory_state()]-[clamp(length(ammo_magazine.get_stored_ammo_count()), 0, 5)]"
 	else
 		icon_state = get_world_inventory_state()
 
 /obj/item/gun/projectile/dartgun/adjust_mob_overlay(mob/living/user_mob, bodytype, image/overlay, slot, bodypart, use_fallback_if_icon_missing = TRUE, skip_offset = FALSE)
 	if(overlay && (slot in user_mob?.get_held_item_slots()) && ammo_magazine)
-		overlay.icon_state += "-[clamp(length(ammo_magazine.stored_ammo.len), 0, 5)]"
+		overlay.icon_state += "-[clamp(length(ammo_magazine.get_stored_ammo_count()), 0, 5)]"
 	. = ..()
 
 /obj/item/gun/projectile/dartgun/consume_next_projectile()
@@ -121,8 +121,9 @@
 			dat += " \[<A href='?src=\ref[src];eject=[i]'>Eject</A>\]<br>"
 
 	if(ammo_magazine)
-		if(ammo_magazine.stored_ammo && ammo_magazine.stored_ammo.len)
-			dat += "The dart cartridge has [ammo_magazine.stored_ammo.len] shots remaining."
+		var/stored_ammo_count = ammo_magazine?.get_stored_ammo_count()
+		if(stored_ammo_count)
+			dat += "The dart cartridge has [stored_ammo_count] shot\s remaining."
 		else
 			dat += "<font color='red'>The dart cartridge is empty!</font>"
 		dat += " \[<A href='?src=\ref[src];eject_cart=1'>Eject</A>\]<br>"


### PR DESCRIPTION
## Description of changes
Do not merge, needs additional testing and maintainer consensus on if this is something we even want to do. Could also make it a config or compile option if desired.

Most ammo magazines will now wait until their first interaction (with their contents, not necessarily by players) to create their contents. Chambering/consuming a round from an uninitialized magazine will lower the initial ammo count by one and create exactly one round, further delaying initialization where possible.

## Why and what will this PR improve
Cuts off a decent amount of init time by waiting to create objects that functionally don't exist until interacted with already.

## Changelog
:cl:
experiment: Ammo magazines will not initialize their contents until first interacted with, which makes startup faster but could cause bugs. Report any issues on the issue tracker!
/:cl: