### PR TITLE
Pitchblende now requires acid to process.

### DIFF
--- a/code/modules/materials/definitions/solids/materials_solid_mineral.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_mineral.dm
@@ -2,13 +2,6 @@
 	name = "pitchblende"
 	uid = "solid_pitchblende"
 	color = "#917d1a"
-	heating_products = list(
-		/decl/material/solid/metal/uranium = 0.8,
-		/decl/material/solid/slag = 0.2
-	)
-	heating_point = GENERIC_SMELTING_HEAT_POINT
-	heating_sound = null
-	heating_message = null
 	ore_result_amount = 5
 	ore_spread_chance = 10
 	ore_name = "pitchblende"
@@ -20,8 +13,9 @@
 	sparse_material_weight = 8
 	rich_material_weight = 10
 	dissolves_into = list(
-		/decl/material/solid/metal/uranium = 0.5,
-		/decl/material/solid/metal/radium = 0.5
+		/decl/material/solid/metal/uranium = 0.6,
+		/decl/material/solid/metal/radium  = 0.3,
+		/decl/material/solid/slag          = 0.1
 	)
 	ore_type_value = ORE_NUCLEAR
 	ore_data_value = 3


### PR DESCRIPTION
## Description of changes
- Removes heating products from pitchblende.
- Tweaks ratio of dissolve products from pitchblende.

## Why and what will this PR improve
Should make it much harder to accidentally dump iron and uranium into the smeltery and EMP the cargo bay.

## Authorship
Aura and Bhjin helped with the brainstorming.

## Changelog
:cl:
tweak: Pitchblende must now be dissolved in acid to extract uranium and radium.
/:cl:
