### PR TITLE
Fix elevators resetting turfs to external air

### DIFF
--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -120,7 +120,7 @@
 		if(ignore_background && (source.turf_flags & TURF_FLAG_BACKGROUND))
 			continue
 		var/old_turf = source.prev_type || base_turf || get_base_turf_by_area(source)
-		source.ChangeTurf(old_turf)
+		source.ChangeTurf(old_turf, keep_air_below = TRUE)
 
 //Transports a turf from a source turf to a target turf, moving all of the turf's contents and making the target a copy of the source.
 //If ignore_background is set to true, turfs with TURF_FLAG_BACKGROUND set will only translate anchored contents.


### PR DESCRIPTION
## Description of changes
Adds `keep_air_below = TRUE` to `ChangeTurf()` in `translate_turfs()` to fix area contents transfer from resetting air.

## Why and what will this PR improve
Fixes elevators resetting turfs to external air. Fixes https://github.com/ScavStation/ScavStation/issues/888.