### PR TITLE
Fix copy_lighting checking the wrong icon state

### DIFF
--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -87,9 +87,9 @@
 	MA.blend_mode = BLEND_MULTIPLY
 
 	if (use_shadower_mult)
-		if (icon_state == LIGHTING_BASE_ICON_STATE)
+		if (MA.icon_state == LIGHTING_BASE_ICON_STATE)
 			// We're using a color matrix, so just darken the colors across the board.
-			var/list/c_list = color
+			var/list/c_list = MA.color
 			c_list[CL_MATRIX_RR] *= SHADOWER_DARKENING_FACTOR
 			c_list[CL_MATRIX_RG] *= SHADOWER_DARKENING_FACTOR
 			c_list[CL_MATRIX_RB] *= SHADOWER_DARKENING_FACTOR
@@ -106,8 +106,8 @@
 		else
 			// Not a color matrix, so we can just use the color var ourselves.
 			MA.color = SHADOWER_DARKENING_COLOR
-	set_invisibility(INVISIBILITY_NONE)
 	appearance = MA
+	set_invisibility(INVISIBILITY_NONE)
 
 	if (our_overlays || priority_overlays)
 		compile_overlays()


### PR DESCRIPTION
## Description of changes
I forgot to change `icon_state` to `MA.icon_state` (or `LO.icon_state`), causing shadower corruption. Again. This rectifies that and also fixes an issue where `set_invisibility(INVISIBILITY_NONE)` was getting clobbered by the appearance set.

## Why and what will this PR improve
Fixes shadower corruption (again) and makes shadowers not go invisible if you have darkness disabled.