### PR TITLE
Prevented random map generators from universally replacing the area with world.area.

### DIFF
--- a/code/modules/maps/template_types/random_exoplanet/planet_themes/mountains.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_themes/mountains.dm
@@ -16,6 +16,7 @@
 	cell_threshold = 6
 	target_turf_type = null
 	floor_type = null
+	change_area = TRUE
 
 /datum/random_map/automata/cave_system/mountains/New(var/tx, var/ty, var/tz, var/tlx, var/tly, var/do_not_apply, var/do_not_announce, var/used_area)
 	var/datum/level_data/LD = SSmapping.levels_by_z[tz]

--- a/code/modules/random_map/random_map.dm
+++ b/code/modules/random_map/random_map.dm
@@ -25,6 +25,7 @@ var/global/list/map_count = list()
 	var/floor_type = /turf/simulated/floor
 	var/target_turf_type
 
+	var/change_area = FALSE
 	var/area/use_area // If set, turfs will be put in this area. If set to type, new instance will be spawned for the map
 
 	// Storage for the final iteration of the map.
@@ -45,11 +46,15 @@ var/global/list/map_count = list()
 	if(tlx) limit_x = tlx
 	if(tly) limit_y = tly
 
-	if(used_area)
+	if(!change_area)
+		use_area = null
+	else if(!use_area && used_area)
 		if(ispath(used_area))
 			use_area = new(used_area)
 		else
 			use_area = used_area
+	else if(ispath(use_area))
+		use_area = new(use_area)
 
 	if(do_not_apply)
 		auto_apply = null


### PR DESCRIPTION
I'm not clear if this is a fix that will introduce regressions to other random maps, but as far as I can tell they have no business setting area.