### PR TITLE
Log and plank buffs.

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -363,14 +363,17 @@
 			stacks |= item
 	for (var/obj/item/stack/item in user?.loc)
 		stacks |= item
+	for (var/obj/item/stack/item in loc)
+		stacks |= item
 	for (var/obj/item/stack/item in stacks)
 		if(item == src || !(can_merge_stacks(item) || item.can_merge_stacks(src)))
 			continue
-		var/transfer = src.transfer_to(item)
+		var/transfer = transfer_to(item)
 		if(user && transfer)
-			to_chat(user, "<span class='notice'>You add a new [item.singular_name] to the stack. It now contains [item.amount] [item.singular_name]\s.</span>")
+			to_chat(user, SPAN_NOTICE("You add a new [item.singular_name] to the stack. It now contains [item.amount] [item.singular_name]\s."))
 		if(!amount)
 			break
+	return !QDELETED(src)
 
 /obj/item/stack/get_storage_cost()	//Scales storage cost to stack size
 	. = ..()

--- a/code/game/objects/structures/flora/_flora.dm
+++ b/code/game/objects/structures/flora/_flora.dm
@@ -29,7 +29,7 @@
 
 /obj/structure/flora/attackby(obj/item/O, mob/user)
 	if(user.a_intent != I_HURT && can_cut_down(O, user))
-		play_cut_sound()
+		play_cut_sound(user)
 		cut_down(O, user)
 		return TRUE
 	. = ..()
@@ -39,7 +39,7 @@
 	return (I.force >= 5) && I.sharp //Anything sharp and relatively strong can cut us instantly
 
 /**What to do when the can_cut_down check returns true. Normally simply calls dismantle. */
-/obj/structure/flora/proc/play_cut_sound()
+/obj/structure/flora/proc/play_cut_sound(mob/user)
 	set waitfor = FALSE
 	if(snd_cut)
 		playsound(src, snd_cut, 40, TRUE)

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -314,10 +314,11 @@
 	if(plank_type && (IS_HATCHET(W) || IS_SAW(W)))
 		var/tool_type = W.get_tool_quality(TOOL_HATCHET) >= W.get_tool_quality(TOOL_SAW) ? TOOL_HATCHET : TOOL_SAW
 		if(W.do_tool_interaction(tool_type, user, src, 1 SECOND, set_cooldown = TRUE) && !QDELETED(src))
-			var/obj/item/stack/planks = new plank_type(loc, 1, material?.type, reinf_material?.type)
-			planks.add_to_stacks(user, TRUE)
+			var/obj/item/stack/planks = new plank_type(get_turf(src), rand(2,4), material?.type, reinf_material?.type) // todo: change plank amount based on carpentry skillcheck
 			playsound(loc, 'sound/foley/wooden_drop.ogg', 40, TRUE)
 			use(1)
+			if(planks.add_to_stacks(user, TRUE))
+				user.put_in_hands(planks)
 		return TRUE
 	return ..()
 


### PR DESCRIPTION
## Description of changes
- Trees give more logs.
- Logs give more planks.
- Tree cut animation lasts longer.

## Why and what will this PR improve
QOL changes for survival/crafting stuff.

## Authorship
Myself.

## Changelog
:cl:
tweak: Trees and logs give more logs/planks.
/:cl:
