### PR TITLE
Update integration/unit tests to latest stable 515

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ on:
   workflow_dispatch:
 
 env:
-  BYOND_MAJOR: "514"
-  BYOND_MINOR: "1575"
-  SPACEMAN_DMM_VERSION: suite-1.7.2
+  BYOND_MAJOR: "515"
+  BYOND_MINOR: "1633"
+  SPACEMAN_DMM_VERSION: suite-1.8
 
 jobs:
   DreamChecker:

--- a/code/game/machinery/_machines_base/stock_parts/radio/transmitter.dm
+++ b/code/game/machinery/_machines_base/stock_parts/radio/transmitter.dm
@@ -14,10 +14,7 @@
 		return
 	if(!buffer)
 		buffer = data
-		if(latency)
-			addtimer(CALLBACK(src, PROC_REF(transmit)), latency)
-		else
-			transmit()
+		addtimer(CALLBACK(src, PROC_REF(transmit)), latency)
 	else
 		buffer |= data
 

--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -203,10 +203,11 @@
 	..()
 
 /datum/gear_tweak/custom_setup/tweak_item(mob/user, obj/item/gear, metadata)
-	var/arglist = list(user)
+	var/list/arglist = list(user)
 	if(length(additional_arguments))
 		arglist += additional_arguments
 	call(gear, custom_setup_proc)(arglist(arglist))
+	arglist.Cut()
 	return GEAR_TWEAK_SUCCESS
 
 /*


### PR DESCRIPTION
## Description of changes
Updates Github Actions testing to use BYOND 515, since 515.1633 is stable.
Also bumps SpacemanDMM to latest, suite-1.8.
Fixes a few CI issues caused by 515.

## Why and what will this PR improve
Ensures compatibility with the latest stable version of BYOND.