### PR TITLE
Reworking attack() -> use_on_mob()

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -9,7 +9,7 @@ item/resolve_attackby() calls the target atom's attackby() proc.
 
 Mobs:
 
-mob/living/attackby() after checking for surgery, calls the item's attack() proc.
+mob/living/attackby() after checking for surgery, calls the item's use_on_mob() proc.
 item/use_on_mob() generates attack logs, sets click cooldown and calls the mob's attacked_with_item() proc. If you override this, consider whether you need to set a click cooldown, play attack animations, and generate logs yourself.
 mob/attacked_with_item() should then do mob-type specific stuff (like determining hit/miss, handling shields, etc) and then possibly call the item's apply_hit_effect() proc to actually apply the effects of being hit.
 
@@ -24,7 +24,6 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	var/datum/extension/tool/tool = get_extension(src, /datum/extension/tool)
 	return (tool?.handle_physical_manipulation(user)) || FALSE
 
-//I would prefer to rename this to attack(), but that would involve touching hundreds of files.
 /obj/item/proc/resolve_attackby(atom/A, mob/user, var/click_params)
 	if(!(item_flags & ITEM_FLAG_NO_PRINT))
 		add_fingerprint(user)

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/items/weapon/swords/cult.dmi'
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME
 
-/obj/item/sword/cultblade/attack(mob/living/M, mob/living/user, var/target_zone)
+/obj/item/sword/cultblade/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
 	var/decl/special_role/godcult = GET_DECL(/decl/special_role/godcultist)
 	if(iscultist(user) || (user.mind in godcult.current_antagonists))
@@ -32,7 +32,7 @@
 	var/spooky = pick('sound/hallucinations/growl1.ogg', 'sound/hallucinations/growl2.ogg', 'sound/hallucinations/growl3.ogg', 'sound/hallucinations/wail.ogg')
 	playsound(loc, spooky, 50, 1)
 
-	return 1
+	return TRUE
 
 /obj/item/sword/cultblade/on_picked_up(mob/living/user)
 	if(!iscultist(user))

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -11,36 +11,42 @@
 	else
 		to_chat(user, "You see strange symbols on the paper. Are they supposed to mean something?")
 
-/obj/item/paper/talisman/attack(var/mob/living/M, var/mob/living/user)
-	return
+/obj/item/paper/talisman/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	return FALSE
 
 /obj/item/paper/talisman/stun/attack_self(var/mob/user)
 	if(iscultist(user))
 		to_chat(user, "This is a stun talisman.")
 	return ..()
 
-/obj/item/paper/talisman/stun/attack(var/mob/living/M, var/mob/living/user)
-	if(!iscultist(user))
-		return
-	user.say("Dream Sign: Evil Sealing Talisman!") //TODO: never change this shit
-	var/obj/item/nullrod/nrod = locate() in M
-	if(nrod)
-		user.visible_message(SPAN_DANGER("\The [user] invokes \the [src] at [M], but they are unaffected."), SPAN_DANGER("You invoke \the [src] at [M], but they are unaffected."))
-		return
-	else
-		user.visible_message(SPAN_DANGER("\The [user] invokes \the [src] at [M]."), SPAN_DANGER("You invoke \the [src] at [M]."))
+/obj/item/paper/talisman/stun/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
-	if(isliving(M))
-		if(issilicon(M))
-			SET_STATUS_MAX(M, STAT_WEAK, 15)
-			SET_STATUS_MAX(M, STAT_SILENCE, 15)
+	if(!iscultist(user))
+		return FALSE
+
+	user.say("Dream Sign: Evil Sealing Talisman!") //TODO: never change this shit
+	var/obj/item/nullrod/nrod = locate() in target
+	if(nrod)
+		user.visible_message(
+			SPAN_DANGER("\The [user] invokes \the [src] at [target], but they are unaffected."), 
+			SPAN_DANGER("You invoke \the [src] at [target], but they are unaffected.")
+		)
+		return TRUE
+
+	user.visible_message(SPAN_DANGER("\The [user] invokes \the [src] at [target]."), SPAN_DANGER("You invoke \the [src] at [target]."))
+	if(isliving(target))
+		if(issilicon(target))
+			SET_STATUS_MAX(target, STAT_WEAK, 15)
+			SET_STATUS_MAX(target, STAT_SILENCE, 15)
 		else
-			SET_STATUS_MAX(M, STAT_WEAK, 20)
-			SET_STATUS_MAX(M, STAT_STUN, 20)
-			SET_STATUS_MAX(M, STAT_SILENCE, 20)
-	admin_attack_log(user, M, "Used a stun talisman.", "Was victim of a stun talisman.", "used a stun talisman on")
+			SET_STATUS_MAX(target, STAT_WEAK, 20)
+			SET_STATUS_MAX(target, STAT_STUN, 20)
+			SET_STATUS_MAX(target, STAT_SILENCE, 20)
+	admin_attack_log(user, target, "Used a stun talisman.", "Was victim of a stun talisman.", "used a stun talisman on")
 	user.try_unequip(src)
 	qdel(src)
+	return TRUE
+
 
 /obj/item/paper/talisman/emp/attack_self(var/mob/user)
 	if(iscultist(user))

--- a/code/game/objects/items/_item_damage.dm
+++ b/code/game/objects/items/_item_damage.dm
@@ -82,11 +82,11 @@
 			if(istype(protection) && (protection.body_parts_covered & SLOT_EYES))
 				// you can't stab someone in the eyes wearing a mask!
 				to_chat(user, SPAN_WARNING("You're going to need to remove the eye covering first."))
-				return
+				return TRUE
 
 	if(!M.check_has_eyes())
 		to_chat(user, SPAN_WARNING("You cannot locate any eyes on [M]!"))
-		return
+		return TRUE
 
 	admin_attack_log(user, M, "Attacked using \a [src]", "Was attacked with \a [src]", "used \a [src] to attack")
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
@@ -125,4 +125,4 @@
 	else
 		M.take_organ_damage(7)
 	SET_STATUS_MAX(M, STAT_BLURRY, rand(3,4))
-	return
+	return TRUE

--- a/code/game/objects/items/books/_book.dm
+++ b/code/game/objects/items/books/_book.dm
@@ -136,14 +136,18 @@
 	else
 		..()
 
-/obj/item/book/attack(mob/living/carbon/M, mob/living/carbon/user)
+/obj/item/book/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	if(user.get_target_zone() == BP_EYES)
-		user.visible_message("<span class='notice'>You open up the book and show it to [M]. </span>", \
-			"<span class='notice'> [user] opens up a book and shows it to [M]. </span>")
+		user.visible_message(
+			SPAN_NOTICE("You open up the book and show it to \the [target]."),
+			SPAN_NOTICE("\The [user] opens up a book and shows it to \the [target].")
+		)
 		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN) //to prevent spam
-		var/processed_dat = M.handle_reading_literacy(user, "<i>Author: [author].</i><br><br>" + "[dat]")
+		var/processed_dat = target.handle_reading_literacy(user, "<i>Author: [author].</i><br><br>" + "[dat]")
 		if(processed_dat)
-			show_browser(M, processed_dat, "window=book;size=1000x550")
+			show_browser(target, processed_dat, "window=book;size=1000x550")
+		return TRUE
+	return ..()
 
 // Copied from paper for the most part. TODO: generalize.
 /obj/item/book/proc/formatpencode(var/mob/user, var/t, var/obj/item/pen/P)

--- a/code/game/objects/items/christmas.dm
+++ b/code/game/objects/items/christmas.dm
@@ -6,7 +6,7 @@
 	material = /decl/material/solid/organic/cardboard
 	var/cracked = 0
 
-/obj/item/toy/xmas_cracker/attack(mob/target, mob/user)
+/obj/item/toy/xmas_cracker/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	if(!cracked && ishuman(target) && (target.stat == CONSCIOUS) && !target.get_active_held_item() )
 		target.visible_message(
 			SPAN_NOTICE("\The [user] and \the [target] pop \an [src]! *pop*"),
@@ -33,7 +33,7 @@
 		other_half.icon_state = "cracker2"
 		target.put_in_active_hand(other_half)
 		playsound(user, 'sound/effects/snap.ogg', 50, 1)
-		return 1
+		return TRUE
 	return ..()
 
 /obj/item/clothing/head/festive

--- a/code/game/objects/items/devices/auto_cpr.dm
+++ b/code/game/objects/items/devices/auto_cpr.dm
@@ -22,23 +22,22 @@
 	if(. && slot == slot_wear_suit_str)
 		. = user?.get_bodytype_category() == BODYTYPE_HUMANOID
 
-/obj/item/auto_cpr/attack(mob/living/carbon/human/M, mob/living/user, var/target_zone)
-	if(istype(M) && user.a_intent == I_HELP)
-		var/obj/item/suit = M.get_equipped_item(slot_wear_suit_str)
+/obj/item/auto_cpr/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+
+	if(ishuman(target) && user.a_intent == I_HELP)
+		var/obj/item/suit = target.get_equipped_item(slot_wear_suit_str)
 		if(suit)
 			to_chat(user, SPAN_WARNING("Their [suit] is in the way, remove it first!"))
-			return 1
-		user.visible_message(SPAN_NOTICE("[user] starts fitting [src] onto the [M]'s chest."))
-
-		if(!do_mob(user, M, 2 SECONDS))
-			return
-
+			return TRUE
+		user.visible_message(SPAN_NOTICE("[user] starts fitting [src] onto \the [target]'s chest."))
+		if(!do_mob(user, target, 2 SECONDS))
+			return TRUE
 		if(user.try_unequip(src))
-			if(!M.equip_to_slot_if_possible(src, slot_wear_suit_str, del_on_fail=0, disable_warning=1, redraw_mob=1))
+			if(!target.equip_to_slot_if_possible(src, slot_wear_suit_str, del_on_fail=0, disable_warning=1, redraw_mob=1))
 				user.put_in_active_hand(src)
-			return 1
-	else
-		return ..()
+		return TRUE
+
+	return ..()
 
 /obj/item/auto_cpr/equipped(mob/user, slot)
 	..()

--- a/code/game/objects/items/devices/dociler.dm
+++ b/code/game/objects/items/devices/dociler.dm
@@ -23,35 +23,39 @@
 
 	to_chat(user, "You set \the [src] to [mode] docile mode.")
 
-/obj/item/dociler/attack(var/mob/living/L, var/mob/user)
-	if(!isanimal(L))
-		to_chat(user, "<span class='warning'>\The [src] cannot not work on \the [L].</span>")
-		return
+/obj/item/dociler/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+
+	if(!isanimal(target))
+		to_chat(user, SPAN_WARNING("\The [src] cannot not work on \the [target]."))
+		return TRUE
 
 	if(!loaded)
-		to_chat(user, "<span class='warning'>\The [src] isn't loaded!</span>")
-		return
+		to_chat(user, SPAN_WARNING("\The [src] isn't loaded!"))
+		return TRUE
 
-	user.visible_message("\The [user] thrusts \the [src] deep into \the [L]'s head, injecting something!")
-	to_chat(L, "<span class='notice'>You feel pain as \the [user] injects something into you. All of a sudden you feel as if [user] is the friendliest and nicest person you've ever know. You want to be friends with him and all his friends.</span>")
+	user.visible_message("\The [user] stabs \the [src] into \the [target], injecting something!")
+	var/decl/pronouns/G = user.get_pronouns()
+	to_chat(target, SPAN_NOTICE("You feel a stabbing pain as \the [user] injects something into you. All of a sudden you feel as if [user] is the friendliest and nicest person you've ever know. You want to be friends with [G.him] and all [G.his] friends."))
 	if(mode == "somewhat")
-		L.faction = user.faction
+		target.faction = user.faction
 	else
-		L.faction = null
-	if(istype(L,/mob/living/simple_animal/hostile))
-		var/mob/living/simple_animal/hostile/H = L
+		target.faction = null
+	if(istype(target, /mob/living/simple_animal/hostile))
+		var/mob/living/simple_animal/hostile/H = target
 		H.LoseTarget()
 		H.attack_same = 0
 		H.friends += weakref(user)
-	L.desc += "<br><span class='notice'>It looks especially docile.</span>"
-	var/name = input(user, "Would you like to rename \the [L]?", "Dociler", L.name) as text
+	target.desc += "<br><span class='notice'>It looks especially docile.</span>"
+	var/name = input(user, "Would you like to rename \the [target]?", "Dociler", target.name) as text
 	if(length(name))
-		L.real_name = name
-		L.SetName(name)
+		target.real_name = name
+		target.SetName(name)
 
-	loaded = 0
+	loaded = FALSE
 	icon_state = get_world_inventory_state()
-	spawn(1450)
-		loaded = 1
+	spawn(2.5 MINUTES)
+		loaded = TRUE
 		icon_state = "[icon_state]-charged"
 		src.visible_message("\The [src] beeps, refilling itself.")
+
+	return TRUE

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -80,22 +80,22 @@
 	return TRUE
 
 //attack_as_weapon
-/obj/item/flash/attack(mob/living/M, mob/living/user, var/target_zone)
+/obj/item/flash/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
-	if(!user || !M || !general_flash_check(user))
+	if(!user || !target || !general_flash_check(user))
 		return FALSE
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	do_flash_animation(user, M)
+	do_flash_animation(user, target)
 
-	if(M.stat != DEAD && M.handle_flashed(src, rand(str_min,str_max)))
-		admin_attack_log(user, M, "flashed their victim using \a [src].", "Was flashed by \a [src].", "used \a [src] to flash")
-		if(!M.isSynthetic())
-			user.visible_message(SPAN_DANGER("[user] blinds [M] with \the [src]!"))
+	if(target.stat != DEAD && target.handle_flashed(src, rand(str_min,str_max)))
+		admin_attack_log(user, target, "flashed their victim using \a [src].", "Was flashed by \a [src].", "used \a [src] to flash")
+		if(!target.isSynthetic())
+			user.visible_message(SPAN_DANGER("\The [user] blinds \the [target] with \the [src]!"))
 		else
-			user.visible_message(SPAN_DANGER("[user] overloads [M]'s sensors with \the [src]!"))
+			user.visible_message(SPAN_DANGER("\The [user] overloads \the [target]'s sensors with \the [src]!"))
 	else
-		user.visible_message(SPAN_WARNING("[user] fails to blind [M] with \the [src]!"))
+		user.visible_message(SPAN_WARNING("\The [user] fails to blind \the [target] with \the [src]!"))
 	return TRUE
 
 /obj/item/flash/attack_self(mob/user, flag = 0, emp = 0)

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -99,10 +99,13 @@
 	..()
 
 //hit other people with it
-/obj/item/holowarrant/attack(mob/living/carbon/M, mob/living/carbon/user)
-	user.visible_message("<span class='notice'>[user] holds up a warrant projector and shows the contents to [M].</span>", \
-			"<span class='notice'>You show the warrant to [M].</span>")
-	M.examinate(src)
+/obj/item/holowarrant/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] holds up a warrant projector and shows the contents to \the [target]."),
+		SPAN_NOTICE("You show the warrant to \the [target].")
+	)
+	target.examinate(src)
+	return TRUE
 
 /obj/item/holowarrant/on_update_icon()
 	. = ..()

--- a/code/game/objects/items/devices/inducer.dm
+++ b/code/game/objects/items/devices/inducer.dm
@@ -32,7 +32,7 @@
 	MyC.update_icon()
 	target.update_icon()
 
-/obj/item/inducer/afterattack(obj/O, mob/living/carbon/user, var/proximity)
+/obj/item/inducer/afterattack(obj/O, mob/living/user, var/proximity)
 	if (!proximity || user.a_intent == I_HURT || CannotUse(user) || !recharge(O, user))
 		return ..()
 
@@ -106,8 +106,8 @@
 	else
 		return 0
 
-/obj/item/inducer/attack(mob/M, mob/user)
-	return
+/obj/item/inducer/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	return FALSE
 
 /obj/item/inducer/on_update_icon()
 	. = ..()

--- a/code/game/objects/items/devices/scanners/breath.dm
+++ b/code/game/objects/items/devices/scanners/breath.dm
@@ -18,7 +18,7 @@
 	scan_data = breath_scan_action(A, user, src, mode)
 	playsound(src, 'sound/effects/fastbeep.ogg', 20)
 
-/proc/breath_scan_action(mob/living/carbon/target, mob/living/user, obj/scanner, var/verbose)
+/proc/breath_scan_action(mob/living/target, mob/living/user, obj/scanner, var/verbose)
 	if (!user.check_dexterity(DEXTERITY_COMPLEX_TOOLS) || !istype(target))
 		return
 
@@ -27,7 +27,7 @@
 	to_chat(user, .)
 	to_chat(user, "<hr>")
 
-/proc/breath_scan_results(var/mob/living/carbon/C, var/verbose, var/skill_level = SKILL_DEFAULT)
+/proc/breath_scan_results(var/mob/living/C, var/verbose, var/skill_level = SKILL_DEFAULT)
 	. = list()
 	var/header = list()
 	var/b

--- a/code/game/objects/items/flame/_flame.dm
+++ b/code/game/objects/items/flame/_flame.dm
@@ -97,17 +97,17 @@
 
 	return TRUE
 
-/obj/item/flame/attack(mob/living/M, mob/living/user)
+/obj/item/flame/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
-	if(!istype(M) || user.a_intent == I_HURT || !lit || user.get_target_zone() != BP_MOUTH)
+	if(!istype(target) || user.a_intent == I_HURT || !lit || user.get_target_zone() != BP_MOUTH)
 		return ..()
 
-	var/obj/item/clothing/mask/smokable/cigarette/cig = M.get_equipped_item(slot_wear_mask_str)
+	var/obj/item/clothing/mask/smokable/cigarette/cig = target.get_equipped_item(slot_wear_mask_str)
 	if(istype(cig))
-		if(M == user)
+		if(target == user)
 			cig.attackby(src, user)
 		else
-			cig.light(SPAN_NOTICE("\The [user] holds \the [src] out for \the [M], and lights \the [cig]."))
+			cig.light(SPAN_NOTICE("\The [user] holds \the [src] out for \the [target], and lights \the [cig]."))
 		return TRUE
 
 	return ..()

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -55,8 +55,8 @@
 				else
 					to_chat(user, "<span class='notice'>[src] is projecting at max capacity!</span>")
 
-/obj/item/holosign_creator/attack(mob/living/carbon/human/M, mob/user)
-	return
+/obj/item/holosign_creator/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	return FALSE
 
 /obj/item/holosign_creator/attack_self(mob/user)
 	if(signs.len)

--- a/code/game/objects/items/plushies.dm
+++ b/code/game/objects/items/plushies.dm
@@ -97,7 +97,7 @@
 		playsound(loc, phrase_sound, phrase_volume, phrase_vary)
 	return TRUE
 
-/obj/item/toy/plushie/attack(mob/M, mob/user)
+/obj/item/toy/plushie/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	. = ..()
 	if(. && phrase_sound)
 		playsound(src, phrase_sound, phrase_volume, phrase_vary)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -22,47 +22,42 @@
 	else
 		. = TRUE
 
-/obj/item/stack/medical/attack(var/mob/living/carbon/M, var/mob/user)
+/obj/item/stack/medical/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
-	if (!istype(M))
-		to_chat(user, SPAN_WARNING("\The [src] cannot be applied to [M]!"))
-		return 1
-
-	if ( ! (ishuman(user) || \
-			issilicon(user)) )
+	// TODO: dex check
+	if(!ishuman(user) && !issilicon(user))
 		to_chat(user, SPAN_WARNING("You don't have the dexterity to do this!"))
-		return 1
+		return TRUE
 
-	if (ishuman(M))
-		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/external/affecting = GET_EXTERNAL_ORGAN(H, user.get_target_zone())
-
-		if(!affecting)
-			to_chat(user, SPAN_WARNING("\The [M] is missing that body part!"))
-			return 1
-
-		if(!check_limb_state(user, affecting))
-			return 1
-
-		if(affecting.organ_tag == BP_HEAD)
-			var/obj/item/clothing/head/helmet/space/head = H.get_equipped_item(slot_head_str)
-			if(istype(head))
-				to_chat(user, SPAN_WARNING("You can't apply [src] through [head]!"))
-				return 1
-		else
-			var/obj/item/clothing/suit/space/suit = H.get_equipped_item(slot_wear_suit_str)
-			if(istype(suit))
-				to_chat(user, SPAN_WARNING("You can't apply [src] through [suit]!"))
-				return 1
-		H.update_health() // TODO: readd the actual healing logic that goes here, or check that it's applied in afterattack or something
-	else
-
-		M.heal_organ_damage((src.heal_brute/2), (src.heal_burn/2))
+	if(!ishuman(target))
+		target.heal_organ_damage((src.heal_brute/2), (src.heal_burn/2))
 		user.visible_message( \
-			SPAN_NOTICE("[M] has been applied with [src] by [user]."), \
-			SPAN_NOTICE("You apply \the [src] to [M].") \
+			SPAN_NOTICE("[target] has been applied with [src] by [user]."),
+			SPAN_NOTICE("You apply \the [src] to [target].")
 		)
 		use(1)
+		return TRUE
+
+	var/mob/living/carbon/human/H = target
+	var/obj/item/organ/external/affecting = GET_EXTERNAL_ORGAN(H, user.get_target_zone())
+	if(!affecting)
+		to_chat(user, SPAN_WARNING("\The [target] is missing that body part!"))
+		return TRUE
+	if(!check_limb_state(user, affecting))
+		return TRUE
+	if(affecting.organ_tag == BP_HEAD)
+		var/obj/item/clothing/head/helmet/space/head = H.get_equipped_item(slot_head_str)
+		if(istype(head))
+			to_chat(user, SPAN_WARNING("You can't apply [src] through [head]!"))
+			return TRUE
+		var/obj/item/clothing/suit/space/suit = H.get_equipped_item(slot_wear_suit_str)
+		if(istype(suit))
+			to_chat(user, SPAN_WARNING("You can't apply [src] through [suit]!"))
+			return TRUE
+		H.update_health() // TODO: readd the actual healing logic that goes here, or check that it's applied in afterattack or something
+		return TRUE
+
+	return ..()
 
 /obj/item/stack/medical/bruise_pack
 	name = "roll of gauze"
@@ -74,51 +69,60 @@
 	apply_sounds = list('sound/effects/rip1.ogg','sound/effects/rip2.ogg')
 	amount = 10
 
-/obj/item/stack/medical/bruise_pack/attack(var/mob/living/carbon/M, var/mob/user)
-	if(..())
-		return 1
+/obj/item/stack/medical/bruise_pack/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
-	if (ishuman(M))
-		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/external/affecting = GET_EXTERNAL_ORGAN(H, user.get_target_zone()) //nullchecked by ..()
+	. = ..()
+	if(. || !ishuman(target))
+		return
 
-		if(affecting.is_bandaged())
-			to_chat(user, SPAN_WARNING("The wounds on [M]'s [affecting.name] have already been bandaged."))
-			return 1
+	var/mob/living/carbon/human/H = target
+	var/obj/item/organ/external/affecting = GET_EXTERNAL_ORGAN(H, user.get_target_zone())
+	if(affecting.is_bandaged())
+		to_chat(user, SPAN_WARNING("The wounds on [target]'s [affecting.name] have already been bandaged."))
+		return TRUE
+
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts treating [target]'s [affecting.name]."),
+		SPAN_NOTICE("You start treating [target]'s [affecting.name].")
+	)
+
+	var/used = 0
+	for (var/datum/wound/W in affecting.wounds)
+		if(W.bandaged)
+			continue
+		if(used == amount)
+			break
+		if(!do_mob(user, target, W.damage/5))
+			to_chat(user, SPAN_NOTICE("You must stand still to bandage wounds."))
+			break
+
+		if (W.current_stage <= W.max_bleeding_stage)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] bandages \a [W.desc] on [target]'s [affecting.name]."),
+			    SPAN_NOTICE("You bandage \a [W.desc] on [target]'s [affecting.name].")
+			)
+		else if (W.damage_type == BRUISE)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] places a bruise patch over \a [W.desc] on [target]'s [affecting.name]."),
+			    SPAN_NOTICE("You place a bruise patch over \a [W.desc] on [target]'s [affecting.name].") 
+			)
 		else
-			user.visible_message(SPAN_NOTICE("\The [user] starts treating [M]'s [affecting.name]."), \
-					             SPAN_NOTICE("You start treating [M]'s [affecting.name]."))
-			var/used = 0
-			for (var/datum/wound/W in affecting.wounds)
-				if(W.bandaged)
-					continue
-				if(used == amount)
-					break
-				if(!do_mob(user, M, W.damage/5))
-					to_chat(user, SPAN_NOTICE("You must stand still to bandage wounds."))
-					break
-
-				if (W.current_stage <= W.max_bleeding_stage)
-					user.visible_message(SPAN_NOTICE("\The [user] bandages \a [W.desc] on [M]'s [affecting.name]."), \
-					                              SPAN_NOTICE("You bandage \a [W.desc] on [M]'s [affecting.name]."))
-					//H.add_side_effect("Itch")
-				else if (W.damage_type == BRUISE)
-					user.visible_message(SPAN_NOTICE("\The [user] places a bruise patch over \a [W.desc] on [M]'s [affecting.name]."), \
-					                              SPAN_NOTICE("You place a bruise patch over \a [W.desc] on [M]'s [affecting.name].") )
-				else
-					user.visible_message(SPAN_NOTICE("\The [user] places a bandaid over \a [W.desc] on [M]'s [affecting.name]."), \
-					                              SPAN_NOTICE("You place a bandaid over \a [W.desc] on [M]'s [affecting.name].") )
-				W.bandage()
-				playsound(src, pick(apply_sounds), 25)
-				used++
-			affecting.update_damages()
-			if(used == amount)
-				if(affecting.is_bandaged())
-					to_chat(user, SPAN_WARNING("\The [src] is used up."))
-				else
-					to_chat(user, SPAN_WARNING("\The [src] is used up, but there are more wounds to treat on \the [affecting.name]."))
-			use(used)
-			H.update_bandages(1)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] places a bandaid over \a [W.desc] on [target]'s [affecting.name]."),
+				SPAN_NOTICE("You place a bandaid over \a [W.desc] on [target]'s [affecting.name].") 
+			)
+		W.bandage()
+		playsound(src, pick(apply_sounds), 25)
+		used++
+	affecting.update_damages()
+	if(used == amount)
+		if(affecting.is_bandaged())
+			to_chat(user, SPAN_WARNING("\The [src] is used up."))
+		else
+			to_chat(user, SPAN_WARNING("\The [src] is used up, but there are more wounds to treat on \the [affecting.name]."))
+	use(used)
+	H.update_bandages(1)
+	return TRUE
 
 /obj/item/stack/medical/ointment
 	name = "ointment"
@@ -131,29 +135,34 @@
 	animal_heal = 4
 	apply_sounds = list('sound/effects/ointment.ogg')
 
-/obj/item/stack/medical/ointment/attack(var/mob/living/carbon/M, var/mob/user)
-	if(..())
-		return 1
+/obj/item/stack/medical/ointment/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	
+	. = ..()
+	if(. || !ishuman(target))
+		return
 
-	if (ishuman(M))
-		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/external/affecting = GET_EXTERNAL_ORGAN(H, user.get_target_zone()) //nullchecked by ..()
+	var/mob/living/carbon/human/H = target
+	var/obj/item/organ/external/affecting = GET_EXTERNAL_ORGAN(H, user.get_target_zone())
+	if(affecting.is_salved())
+		to_chat(user, SPAN_WARNING("The wounds on [target]'s [affecting.name] have already been salved."))
+		return TRUE
 
-		if(affecting.is_salved())
-			to_chat(user, SPAN_WARNING("The wounds on [M]'s [affecting.name] have already been salved."))
-			return 1
-		else
-			user.visible_message(SPAN_NOTICE("\The [user] starts salving wounds on [M]'s [affecting.name]."), \
-					             SPAN_NOTICE("You start salving the wounds on [M]'s [affecting.name].") )
-			playsound(src, pick(apply_sounds), 25)
-			if(!do_mob(user, M, 10))
-				to_chat(user, SPAN_NOTICE("You must stand still to salve wounds."))
-				return 1
-			user.visible_message(SPAN_NOTICE("[user] salved wounds on [M]'s [affecting.name]."), \
-			                         SPAN_NOTICE("You salved wounds on [M]'s [affecting.name].") )
-			use(1)
-			affecting.salve()
-			affecting.disinfect()
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts salving wounds on [target]'s [affecting.name]."),
+		SPAN_NOTICE("You start salving the wounds on [target]'s [affecting.name].")
+	)
+	playsound(src, pick(apply_sounds), 25)
+	if(!do_mob(user, target, 10))
+		to_chat(user, SPAN_NOTICE("You must stand still to salve wounds."))
+		return TRUE
+	user.visible_message(
+		SPAN_NOTICE("[user] salved wounds on [target]'s [affecting.name]."),
+	    SPAN_NOTICE("You salved wounds on [target]'s [affecting.name].") 
+	)
+	use(1)
+	affecting.salve()
+	affecting.disinfect()
+	return TRUE
 
 /obj/item/stack/medical/advanced/bruise_pack
 	name = "advanced trauma kit"
@@ -166,50 +175,60 @@
 	apply_sounds = list('sound/effects/rip1.ogg','sound/effects/rip2.ogg','sound/effects/tape.ogg')
 	amount = 10
 
-/obj/item/stack/medical/advanced/bruise_pack/attack(var/mob/living/carbon/M, var/mob/user)
-	if(..())
-		return 1
+/obj/item/stack/medical/advanced/bruise_pack/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	
+	. = ..()
+	if(. || !ishuman(target))
+		return
 
-	if (ishuman(M))
-		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/external/affecting = GET_EXTERNAL_ORGAN(H, user.get_target_zone()) //nullchecked by ..()
-		if(affecting.is_bandaged() && affecting.is_disinfected())
-			to_chat(user, SPAN_WARNING("The wounds on [M]'s [affecting.name] have already been treated."))
-			return 1
+	var/mob/living/carbon/human/H = target
+	var/obj/item/organ/external/affecting = GET_EXTERNAL_ORGAN(H, user.get_target_zone())
+	if(affecting.is_bandaged() && affecting.is_disinfected())
+		to_chat(user, SPAN_WARNING("The wounds on [target]'s [affecting.name] have already been treated."))
+		return TRUE
+
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts treating [target]'s [affecting.name]."),
+		SPAN_NOTICE("You start treating [target]'s [affecting.name].") 
+	)
+	var/used = 0
+	for (var/datum/wound/W in affecting.wounds)
+		if (W.bandaged && W.disinfected)
+			continue
+		if(used == amount)
+			break
+		if(!do_mob(user, target, W.damage/5))
+			to_chat(user, SPAN_NOTICE("You must stand still to bandage wounds."))
+			break
+		if (W.current_stage <= W.max_bleeding_stage)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] cleans \a [W.desc] on [target]'s [affecting.name] and seals the edges with bioglue."),
+			    SPAN_NOTICE("You clean and seal \a [W.desc] on [target]'s [affecting.name].") 
+			)
+		else if (W.damage_type == BRUISE)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] places a medical patch over \a [W.desc] on [target]'s [affecting.name]."),
+				SPAN_NOTICE("You place a medical patch over \a [W.desc] on [target]'s [affecting.name].") 
+			)
 		else
-			user.visible_message(SPAN_NOTICE("\The [user] starts treating [M]'s [affecting.name]."), \
-					             SPAN_NOTICE("You start treating [M]'s [affecting.name].") )
-			var/used = 0
-			for (var/datum/wound/W in affecting.wounds)
-				if (W.bandaged && W.disinfected)
-					continue
-				if(used == amount)
-					break
-				if(!do_mob(user, M, W.damage/5))
-					to_chat(user, SPAN_NOTICE("You must stand still to bandage wounds."))
-					break
-				if (W.current_stage <= W.max_bleeding_stage)
-					user.visible_message(SPAN_NOTICE("\The [user] cleans \a [W.desc] on [M]'s [affecting.name] and seals the edges with bioglue."), \
-					                     SPAN_NOTICE("You clean and seal \a [W.desc] on [M]'s [affecting.name].") )
-				else if (W.damage_type == BRUISE)
-					user.visible_message(SPAN_NOTICE("\The [user] places a medical patch over \a [W.desc] on [M]'s [affecting.name]."), \
-					                              SPAN_NOTICE("You place a medical patch over \a [W.desc] on [M]'s [affecting.name].") )
-				else
-					user.visible_message(SPAN_NOTICE("\The [user] smears some bioglue over \a [W.desc] on [M]'s [affecting.name]."), \
-					                              SPAN_NOTICE("You smear some bioglue over \a [W.desc] on [M]'s [affecting.name].") )
-				playsound(src, pick(apply_sounds), 25)
-				W.bandage()
-				W.disinfect()
-				W.heal_damage(heal_brute)
-				used++
-			affecting.update_damages()
-			if(used == amount)
-				if(affecting.is_bandaged())
-					to_chat(user, SPAN_WARNING("\The [src] is used up."))
-				else
-					to_chat(user, SPAN_WARNING("\The [src] is used up, but there are more wounds to treat on \the [affecting.name]."))
-			use(used)
-			H.update_bandages(1)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] smears some bioglue over \a [W.desc] on [target]'s [affecting.name]."),
+			    SPAN_NOTICE("You smear some bioglue over \a [W.desc] on [target]'s [affecting.name].") 
+			)
+		playsound(src, pick(apply_sounds), 25)
+		W.bandage()
+		W.disinfect()
+		W.heal_damage(heal_brute)
+		used++
+	affecting.update_damages()
+	if(used == amount)
+		if(affecting.is_bandaged())
+			to_chat(user, SPAN_WARNING("\The [src] is used up."))
+		else
+			to_chat(user, SPAN_WARNING("\The [src] is used up, but there are more wounds to treat on \the [affecting.name]."))
+	use(used)
+	H.update_bandages(1)
+	return TRUE
 
 /obj/item/stack/medical/advanced/ointment
 	name = "advanced burn kit"
@@ -222,30 +241,36 @@
 	apply_sounds = list('sound/effects/ointment.ogg')
 
 
-/obj/item/stack/medical/advanced/ointment/attack(var/mob/living/carbon/M, var/mob/user)
-	if(..())
-		return 1
+/obj/item/stack/medical/advanced/ointment/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
-	if (ishuman(M))
-		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/external/affecting = GET_EXTERNAL_ORGAN(H, user.get_target_zone()) //nullchecked by ..()
+	. = ..()
+	if(. || !ishuman(target))
+		return
 
-		if(affecting.is_salved())
-			to_chat(user, SPAN_WARNING("The wounds on [M]'s [affecting.name] have already been salved."))
-			return 1
-		else
-			user.visible_message(SPAN_NOTICE("\The [user] starts salving wounds on [M]'s [affecting.name]."), \
-					             SPAN_NOTICE("You start salving the wounds on [M]'s [affecting.name].") )
-			playsound(src, pick(apply_sounds), 25)
-			if(!do_mob(user, M, 10))
-				to_chat(user, SPAN_NOTICE("You must stand still to salve wounds."))
-				return 1
-			user.visible_message( 	SPAN_NOTICE("[user] covers wounds on [M]'s [affecting.name] with regenerative membrane."), \
-									SPAN_NOTICE("You cover wounds on [M]'s [affecting.name] with regenerative membrane.") )
-			affecting.heal_damage(0,heal_burn)
-			use(1)
-			affecting.salve()
-			affecting.disinfect()
+	var/mob/living/carbon/human/H = target
+	var/obj/item/organ/external/affecting = GET_EXTERNAL_ORGAN(H, user.get_target_zone())
+
+	if(affecting.is_salved())
+		to_chat(user, SPAN_WARNING("The wounds on [target]'s [affecting.name] have already been salved."))
+		return TRUE
+
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts salving wounds on [target]'s [affecting.name]."),
+		SPAN_NOTICE("You start salving the wounds on [target]'s [affecting.name].")
+	)
+	playsound(src, pick(apply_sounds), 25)
+	if(!do_mob(user, target, 10))
+		to_chat(user, SPAN_NOTICE("You must stand still to salve wounds."))
+		return TRUE
+	user.visible_message(
+		SPAN_NOTICE("[user] covers wounds on [target]'s [affecting.name] with regenerative membrane."),
+		SPAN_NOTICE("You cover wounds on [target]'s [affecting.name] with regenerative membrane.") 
+	)
+	affecting.heal_damage(0,heal_burn)
+	use(1)
+	affecting.salve()
+	affecting.disinfect()
+	return TRUE
 
 /obj/item/stack/medical/splint
 	name = "medical splints"
@@ -263,45 +288,74 @@
 		return FALSE
 	return TRUE
 
-/obj/item/stack/medical/splint/attack(var/mob/living/carbon/M, var/mob/user)
-	if(..())
-		return 1
+/obj/item/stack/medical/splint/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
-	if (ishuman(M))
-		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/external/affecting = GET_EXTERNAL_ORGAN(H, user.get_target_zone()) //nullchecked by ..()
-		var/limb = affecting.name
-		if(!(affecting.organ_tag in splintable_organs))
-			to_chat(user, SPAN_WARNING("You can't use \the [src] to apply a splint there!"))
-			return
-		if(affecting.splinted)
-			to_chat(user, SPAN_WARNING("\The [M]'s [limb] is already splinted!"))
-			return
-		if (M != user)
-			user.visible_message(SPAN_NOTICE("\The [user] starts to apply \the [src] to [M]'s [limb]."), SPAN_DANGER("You start to apply \the [src] to [M]'s [limb]."), SPAN_DANGER("You hear something being wrapped."))
-		else
-			var/obj/item/organ/external/using = GET_EXTERNAL_ORGAN(user, user.get_active_held_item_slot())
-			if(istype(using) && (affecting == using || (affecting in using.children) || affecting.organ_tag == using.parent_organ))
-				to_chat(user, SPAN_WARNING("You can't apply a splint to the arm you're using!"))
-				return
-			user.visible_message(SPAN_NOTICE("\The [user] starts to apply \the [src] to their [limb]."), SPAN_DANGER("You start to apply \the [src] to your [limb]."), SPAN_DANGER("You hear something being wrapped."))
-		if(user.do_skilled(5 SECONDS, SKILL_MEDICAL, M))
-			if((M == user && prob(75)) || prob(user.skill_fail_chance(SKILL_MEDICAL,50, SKILL_ADEPT)))
-				user.visible_message(SPAN_DANGER("\The [user] fumbles [src]."), SPAN_DANGER("You fumble [src]."), SPAN_DANGER("You hear something being wrapped."))
-				return
-			var/obj/item/stack/medical/splint/S = split(1, TRUE)
-			if(S)
-				if(affecting.apply_splint(S))
-					M.verbs += /mob/living/carbon/human/proc/remove_splints
-					S.forceMove(affecting)
-					if (M != user)
-						user.visible_message(SPAN_NOTICE("\The [user] finishes applying [src] to [M]'s [limb]."), SPAN_DANGER("You finish applying \the [src] to [M]'s [limb]."), SPAN_DANGER("You hear something being wrapped."))
-					else
-						user.visible_message(SPAN_NOTICE("\The [user] successfully applies [src] to their [limb]."), SPAN_DANGER("You successfully apply \the [src] to your [limb]."), SPAN_DANGER("You hear something being wrapped."))
-					return
-				S.dropInto(src.loc) //didn't get applied, so just drop it
-			user.visible_message(SPAN_DANGER("\The [user] fails to apply [src]."), SPAN_DANGER("You fail to apply [src]."), SPAN_DANGER("You hear something being wrapped."))
+	. = ..()
+	if(. || !ishuman(target))
 		return
+
+	var/mob/living/carbon/human/H = target
+	var/obj/item/organ/external/affecting = GET_EXTERNAL_ORGAN(H, user.get_target_zone())
+
+	if(!(affecting.organ_tag in splintable_organs))
+		to_chat(user, SPAN_WARNING("You can't use \the [src] to apply a splint there!"))
+		return TRUE
+
+	var/limb = affecting.name
+	if(affecting.splinted)
+		to_chat(user, SPAN_WARNING("\The [target]'s [limb] is already splinted!"))
+		return TRUE
+
+	if (target != user)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts to apply \the [src] to [target]'s [limb]."), 
+			SPAN_DANGER("You start to apply \the [src] to [target]'s [limb]."), 
+			SPAN_DANGER("You hear something being wrapped.")
+		)
+	else
+		var/obj/item/organ/external/using = GET_EXTERNAL_ORGAN(user, user.get_active_held_item_slot())
+		if(istype(using) && (affecting == using || (affecting in using.children) || affecting.organ_tag == using.parent_organ))
+			to_chat(user, SPAN_WARNING("You can't apply a splint to the arm you're using!"))
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts to apply \the [src] to their [limb]."), 
+			SPAN_DANGER("You start to apply \the [src] to your [limb]."), 
+			SPAN_DANGER("You hear something being wrapped.")
+		)
+
+	if(user.do_skilled(5 SECONDS, SKILL_MEDICAL, target))
+		if((target == user && prob(75)) || prob(user.skill_fail_chance(SKILL_MEDICAL,50, SKILL_ADEPT)))
+			user.visible_message(
+				SPAN_DANGER("\The [user] fumbles \the [src]."), 
+				SPAN_DANGER("You fumble \the [src]."), 
+				SPAN_DANGER("You hear something being wrapped.")
+			)
+			return TRUE
+		var/obj/item/stack/medical/splint/S = split(1, TRUE)
+		if(S)
+			if(affecting.apply_splint(S))
+				target.verbs += /mob/living/carbon/human/proc/remove_splints
+				S.forceMove(affecting)
+				if (target != user)
+					user.visible_message(
+						SPAN_NOTICE("\The [user] finishes applying \the [src] to \the [target]'s [limb]."), 
+						SPAN_DANGER("You finish applying \the [src] to \the [target]'s [limb]."), 
+						SPAN_DANGER("You hear something being wrapped.")
+					)
+				else
+					user.visible_message(
+						SPAN_NOTICE("\The [user] successfully applies \the [src] to their [limb]."), 
+						SPAN_DANGER("You successfully apply \the [src] to your [limb]."), 
+						SPAN_DANGER("You hear something being wrapped.")
+					)
+				return TRUE
+			S.dropInto(src.loc) //didn't get applied, so just drop it
+		user.visible_message(
+			SPAN_DANGER("\The [user] fails to apply \the [src]."), 
+			SPAN_DANGER("You fail to apply \the [src]."), 
+			SPAN_DANGER("You hear something being wrapped.")
+		)
+	return TRUE
 
 /obj/item/stack/medical/splint/ghetto
 	name = "makeshift splints"
@@ -337,23 +391,23 @@
 		return FALSE
 	return TRUE
 
-/obj/item/stack/medical/resin/attack(var/mob/living/carbon/M, var/mob/user)
+/obj/item/stack/medical/resin/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	. = ..()
-	if(!. && ishuman(M))
-		var/mob/living/carbon/human/H = M
+	if(!. && ishuman(target))
+		var/mob/living/carbon/human/H = target
 		var/obj/item/organ/external/affecting = GET_EXTERNAL_ORGAN(H, user.get_target_zone())
 		if((affecting.brute_dam + affecting.burn_dam) <= 0)
-			to_chat(user, SPAN_WARNING("\The [M]'s [affecting.name] is undamaged."))
+			to_chat(user, SPAN_WARNING("\The [target]'s [affecting.name] is undamaged."))
 			return 1
 		user.visible_message(
-			SPAN_NOTICE("\The [user] starts patching fractures on \the [M]'s [affecting.name]."), \
-			SPAN_NOTICE("You start patching fractures on \the [M]'s [affecting.name].") )
+			SPAN_NOTICE("\The [user] starts patching fractures on \the [target]'s [affecting.name]."), \
+			SPAN_NOTICE("You start patching fractures on \the [target]'s [affecting.name].") )
 		playsound(src, pick(apply_sounds), 25)
-		if(!do_mob(user, M, 10))
+		if(!do_mob(user, target, 10))
 			to_chat(user, SPAN_NOTICE("You must stand still to patch fractures."))
 			return 1
 		user.visible_message( \
-			SPAN_NOTICE("\The [user] patches the fractures on \the [M]'s [affecting.name] with resin."), \
-			SPAN_NOTICE("You patch fractures on \the [M]'s [affecting.name] with resin."))
+			SPAN_NOTICE("\The [user] patches the fractures on \the [target]'s [affecting.name] with resin."), \
+			SPAN_NOTICE("You patch fractures on \the [target]'s [affecting.name] with resin."))
 		affecting.heal_damage(heal_brute, heal_burn, robo_repair = TRUE)
 		use(1)

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -10,39 +10,46 @@
 	material = /decl/material/solid/metal/steel
 	matter = list(/decl/material/solid/glass = MATTER_AMOUNT_REINFORCEMENT)
 
-/obj/item/stack/nanopaste/attack(mob/living/M, mob/user)
-	if (!istype(M) || !istype(user))
-		return 0
-	if (isrobot(M))	//Repairing cyborgs
-		var/mob/living/silicon/robot/R = M
+/obj/item/stack/nanopaste/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+
+	if (isrobot(target))	//Repairing cyborgs
+		var/mob/living/silicon/robot/R = target
 		if (R.get_damage(BRUTE) || R.get_damage(BURN) )
 			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 			R.heal_damage(BRUTE, 15, do_update_health = FALSE)
 			R.heal_damage(BURN, 15)
 			use(1)
-			user.visible_message("<span class='notice'>\The [user] applied some [src] on [R]'s damaged areas.</span>",\
-				"<span class='notice'>You apply some [src] at [R]'s damaged areas.</span>")
+			user.visible_message(
+				SPAN_NOTICE("\The [user] applied some [src] on [R]'s damaged areas."),
+				SPAN_NOTICE("You apply some [src] at [R]'s damaged areas.")
+			)
 		else
-			to_chat(user, "<span class='notice'>All [R]'s systems are nominal.</span>")
-
-	if (ishuman(M))		//Repairing robolimbs
-		var/mob/living/carbon/human/H = M
+			to_chat(user, SPAN_NOTICE("All [R]'s systems are nominal."))
+		return TRUE
+	
+	if (ishuman(target))		//Repairing robolimbs
+		var/mob/living/carbon/human/H = target
 		var/obj/item/organ/external/S = GET_EXTERNAL_ORGAN(H, user.get_target_zone())
 
 		if(!S)
-			to_chat(user, "<span class='warning'>\The [M] is missing that body part.</span>")
-			return
+			to_chat(user, SPAN_WARNING("\The [target] is missing that body part."))
+			return TRUE
 
 		if(BP_IS_BRITTLE(S))
-			to_chat(user, "<span class='warning'>\The [M]'s [S.name] is hard and brittle - \the [src] cannot repair it.</span>")
-			return
+			to_chat(user, SPAN_WARNING("\The [target]'s [S.name] is hard and brittle - \the [src] cannot repair it."))
+			return TRUE
 
 		if(S && S.is_robotic() && S.hatch_state == HATCH_OPENED)
 			if(!S.get_damage())
-				to_chat(user, "<span class='notice'>Nothing to fix here.</span>")
+				to_chat(user, SPAN_NOTICE("Nothing to fix here."))
 			else if(can_use(1))
 				user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 				S.heal_damage(15, 15, robo_repair = 1)
 				use(1)
-				user.visible_message("<span class='notice'>\The [user] applies some nanite paste on [user != M ? "[M]'s [S.name]" : "[S]"] with [src].</span>",\
-				"<span class='notice'>You apply some nanite paste on [user == M ? "your" : "[M]'s"] [S.name].</span>")
+				user.visible_message(
+					SPAN_NOTICE("\The [user] applies some nanite paste on [user != target ? "[target]'s [S.name]" : "[S]"] with [src]."),
+					SPAN_NOTICE("You apply some nanite paste on [user == target ? "your" : "[target]'s"] [S.name].")
+				)
+			return TRUE
+
+	return ..()

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -172,5 +172,5 @@
 	desc = "a stick from some snack food item or a lollipop, not even useful as crafting material."
 	icon_state = "stick"
 
-/obj/item/trash/attack(mob/M, mob/living/user)
-	return
+/obj/item/trash/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	return FALSE

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -37,8 +37,8 @@
 		work_modes = h.children
 	work_mode = work_modes[1]
 
-/obj/item/rcd/attack()
-	return 0
+/obj/item/rcd/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	return FALSE
 
 /obj/item/rcd/proc/can_use(var/mob/user,var/turf/T)
 	return (user.Adjacent(T) && user.get_active_held_item() == src && !user.incapacitated())

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -45,25 +45,26 @@
 /obj/item/cosmetics/proc/show_open_message(mob/user)
 	return
 
-/obj/item/cosmetics/attack(atom/A, mob/user, target_zone)
-	if(!open || !ishuman(A))
+/obj/item/cosmetics/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+
+	if(!open)
 		return ..()
 
-	if(istype(A, /obj/item/organ/external/head))
-		var/obj/item/organ/external/head/head = A
+	if(istype(target, /obj/item/organ/external/head))
+		var/obj/item/organ/external/head/head = target
 		head.write_on(user, src)
 		return TRUE
 
 	var/obj/item/organ/external/limb = user.get_organ(apply_marking_to_limb, /obj/item/organ/external/head)
 	if(!limb)
 		return ..()
-
+	var/target_zone = user.get_target_zone()
 	if(user.a_intent == I_HELP && target_zone != apply_to_zone && istype(limb, /obj/item/organ/external/head))
 		var/obj/item/organ/external/head/head = limb
-		head.write_on(user, src.name)
+		head.write_on(user, name)
 		return TRUE
 
-	if(!isliving(A) || target_zone != apply_to_zone)
+	if(!istype(target) || target_zone != apply_to_zone)
 		return ..()
 
 	var/decl/sprite_accessory/cosmetics/lip_decl = GET_DECL(cosmetic_type)
@@ -71,35 +72,33 @@
 		to_chat(user, SPAN_WARNING("You can't wear this makeup!"))
 		return TRUE
 
-	var/mob/living/user_living = user
-	if(user_living == A)
-		if(user_living.get_organ_sprite_accessory(cosmetic_type, apply_marking_to_limb))	//if they already have lipstick on
+	if(user == target)
+		if(target.get_organ_sprite_accessory(cosmetic_type, apply_marking_to_limb))	//if they already have lipstick on
 			to_chat(user, SPAN_WARNING("You need to wipe off your old makeup first!"))
 			return TRUE
 		user.visible_message(
 			SPAN_NOTICE("\The [user] does their makeup with \the [src]."),
 			SPAN_NOTICE("You take a moment to apply \the [src]. Perfect!")
 		)
-		user_living.set_organ_sprite_accessory(cosmetic_type, SAC_COSMETICS, makeup_color, apply_marking_to_limb)
+		user.set_organ_sprite_accessory(cosmetic_type, SAC_COSMETICS, makeup_color, apply_marking_to_limb)
 		return TRUE
 
-	user_living = A
-	if(user_living.get_organ_sprite_accessory(cosmetic_type, apply_marking_to_limb))	//if they already have lipstick on
+	if(target.get_organ_sprite_accessory(cosmetic_type, apply_marking_to_limb))	//if they already have lipstick on
 		to_chat(user, SPAN_WARNING("You need to wipe off the old makeup first!"))
 		return TRUE
 
 	user.visible_message(
-		SPAN_NOTICE("\The [user] begins to do \the [user_living]'s makeup with \the [src]."),
-		SPAN_NOTICE("You begin to apply \the [src] to \the [user_living].")
+		SPAN_NOTICE("\The [user] begins to do \the [target]'s makeup with \the [src]."),
+		SPAN_NOTICE("You begin to apply \the [src] to \the [target].")
 	)
-	if(do_after(user, 2 SECONDS, user_living))
+	if(do_after(user, 2 SECONDS, target))
 		user.visible_message(
-			SPAN_NOTICE("\The [user] does \the [user_living]'s makeup with \the [src]."),
-			SPAN_NOTICE("You apply \the [src] to \the [user_living].")
+			SPAN_NOTICE("\The [user] does \the [target]'s makeup with \the [src]."),
+			SPAN_NOTICE("You apply \the [src] to \the [target].")
 		)
-		if(user_living.get_organ_sprite_accessory(cosmetic_type, SAC_COSMETICS, apply_marking_to_limb))
+		if(target.get_organ_sprite_accessory(cosmetic_type, SAC_COSMETICS, apply_marking_to_limb))
 			return TRUE
-		user_living.set_organ_sprite_accessory(cosmetic_type, SAC_COSMETICS, makeup_color, apply_marking_to_limb)
+		target.set_organ_sprite_accessory(cosmetic_type, SAC_COSMETICS, makeup_color, apply_marking_to_limb)
 	return TRUE
 
 //types

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -281,21 +281,17 @@
 /obj/item/shockpaddles/proc/checked_use(var/charge_amt)
 	return 0
 
-/obj/item/shockpaddles/attack(mob/living/M, mob/living/user, var/target_zone)
-	var/mob/living/carbon/human/H = M
-	if(!istype(H) || user.a_intent == I_HURT)
+/obj/item/shockpaddles/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(!ishuman(target) || user.a_intent == I_HURT)
 		return ..() //Do a regular attack. Harm intent shocking happens as a hit effect
-
+	var/mob/living/carbon/human/H = target
 	if(can_use(user, H))
 		busy = 1
 		update_icon()
-
 		do_revive(H, user)
-
 		busy = 0
 		update_icon()
-
-	return 1
+	return TRUE
 
 //Since harm-intent now skips the delay for deliberate placement, you have to be able to hit them in combat in order to shock people.
 /obj/item/shockpaddles/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone)

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -108,5 +108,5 @@
 		T--
 	explode(get_turf(target))
 
-/obj/item/plastique/attack(mob/M, mob/user, def_zone)
-	return
+/obj/item/plastique/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	return FALSE

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -38,32 +38,34 @@
 			return
 		to_chat(user, SPAN_WARNING("They look [display < 33 ? "badly ": ""]damaged."))
 
-/obj/item/handcuffs/attack(var/mob/living/carbon/C, var/mob/living/user)
+/obj/item/handcuffs/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
 	if(!user.check_dexterity(DEXTERITY_COMPLEX_TOOLS))
-		return
+		return ..()
 
 	if ((MUTATION_CLUMSY in user.mutations) && prob(50))
-		to_chat(user, "<span class='warning'>Uh ... how do those things work?!</span>")
+		to_chat(user, SPAN_WARNING("You can't figure out how to work \the [src]..."))
 		place_handcuffs(user, user)
-		return
+		return TRUE
 
-	// only carbons can be cuffed
-	if(istype(C))
-		if(!C.get_equipped_item(slot_handcuffed_str))
-			if (C == user)
+	// only humans can be cuffed for now
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		if(!H.get_equipped_item(slot_handcuffed_str))
+			if (H == user)
 				place_handcuffs(user, user)
-				return
+				return TRUE
 
 			//check for an aggressive grab (or robutts)
-			if(C.has_danger_grab(user))
-				place_handcuffs(C, user)
+			if(H.has_danger_grab(user))
+				place_handcuffs(H, user)
 			else
-				to_chat(user, "<span class='danger'>You need to have a firm grip on [C] before you can put \the [src] on!</span>")
+				to_chat(user, SPAN_WARNING("You need to have a firm grip on \the [H] before you can put \the [src] on!"))
 		else
-			to_chat(user, "<span class='warning'>\The [C] is already handcuffed!</span>")
-	else
-		..()
+			to_chat(user, SPAN_WARNING("\The [H] is already handcuffed!"))
+		return TRUE
+
+	return ..()
 
 /obj/item/handcuffs/proc/place_handcuffs(var/mob/living/carbon/target, var/mob/user)
 	playsound(src.loc, cuff_sound, 30, 1, -2)
@@ -73,15 +75,15 @@
 		return 0
 
 	if (!H.has_organ_for_slot(slot_handcuffed_str))
-		to_chat(user, "<span class='danger'>\The [H] needs at least two wrists before you can cuff them together!</span>")
+		to_chat(user, SPAN_WARNING("\The [H] needs at least two wrists before you can cuff them together!"))
 		return 0
 
 	var/obj/item/gloves = H.get_equipped_item(slot_gloves_str)
 	if((gloves && (gloves.item_flags & ITEM_FLAG_NOCUFFS)) && !elastic)
-		to_chat(user, "<span class='danger'>\The [src] won't fit around \the [gloves]!</span>")
+		to_chat(user, SPAN_WARNING("\The [src] won't fit around \the [gloves]!"))
 		return 0
 
-	user.visible_message("<span class='danger'>\The [user] is attempting to put [cuff_type] on \the [H]!</span>")
+	user.visible_message(SPAN_DANGER("\The [user] is attempting to put [cuff_type] on \the [H]!"))
 
 	if(!do_after(user,30, target))
 		return 0

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -61,28 +61,26 @@
 
 /obj/item/implanter/attackby(obj/item/I, mob/user)
 	if(!imp && istype(I, /obj/item/implant) && user.try_unequip(I,src))
-		to_chat(usr, "<span class='notice'>You slide \the [I] into \the [src].</span>")
+		to_chat(usr, SPAN_NOTICE("You slide \the [I] into \the [src]."))
 		imp = I
 		update_icon()
-	else
-		..()
+		return TRUE
+	return ..()
 
-/obj/item/implanter/attack(mob/M, mob/user)
-	if (!ishuman(M))
-		return
-	if (user && src.imp)
-		M.visible_message("<span class='warning'>[user] is attemping to implant [M].</span>")
+/obj/item/implanter/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
+	if(ishuman(target) && user && imp)
+		user.visible_message(SPAN_DANGER("\The [user] is attemping to implant \the [target]."))
 		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
-		user.do_attack_animation(M)
-
+		user.do_attack_animation(target)
 		var/target_zone = user.get_target_zone()
-		if(src.imp.can_implant(M, user, target_zone))
+		if(imp.can_implant(target, user, target_zone))
 			var/imp_name = imp.name
-
-			if(do_after(user, 50, M) && src.imp.implant_in_mob(M, target_zone))
-				M.visible_message("<span class='warning'>[M] has been implanted by [user].</span>")
-				admin_attack_log(user, M, "Implanted using \the [src] ([imp_name])", "Implanted with \the [src] ([imp_name])", "used an implanter, \the [src] ([imp_name]), on")
-
-				src.imp = null
+			if(do_after(user, 50, target) && imp.implant_in_mob(target, target_zone))
+				user.visible_message(SPAN_NOTICE("\The [target] has been implanted by \the [user]."))
+				admin_attack_log(user, target, "Implanted using \the [src] ([imp_name])", "Implanted with \the [src] ([imp_name])", "used an implanter, \the [src] ([imp_name]), on")
+				imp = null
 				update_icon()
+		return TRUE
+
+	return ..()

--- a/code/game/objects/items/weapons/implants/implants/compressed.dm
+++ b/code/game/objects/items/weapons/implants/implants/compressed.dm
@@ -50,13 +50,12 @@
 	else
 		icon_state = "cimplanter0"
 
-/obj/item/implanter/compressed/attack(mob/M, mob/user)
+/obj/item/implanter/compressed/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	var/obj/item/implant/compressed/c = imp
-	if (!c)	return
-	if (c.scanned == null)
-		to_chat(user, "Please compress an object with the implanter first.")
-		return
-	..()
+	if(!istype(c) || c.scanned == null)
+		to_chat(user, SPAN_WARNING("Please compress an object with the implanter first."))
+		return TRUE
+	return ..()
 
 /obj/item/implanter/compressed/afterattack(obj/item/A, mob/user, proximity)
 	if(!proximity)

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -16,10 +16,10 @@
 	material_force_multiplier = 0.7 // 10 when wielded with weight 15 (wood)
 	thrown_material_force_multiplier = 1 // as above
 
-/obj/item/kitchen/rollingpin/attack(mob/living/M, mob/living/user)
+/obj/item/kitchen/rollingpin/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	if ((MUTATION_CLUMSY in user.mutations) && prob(50) && user.try_unequip(src))
-		to_chat(user, "<span class='warning'>\The [src] slips out of your hand and hits your head.</span>")
+		to_chat(user, SPAN_DANGER("\The [src] slips out of your hand and hits your head."))
 		user.take_organ_damage(10)
 		SET_STATUS_MAX(user, STAT_PARA, 2)
-		return
+		return TRUE
 	return ..()

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -37,16 +37,12 @@
 			handle_color = pick(valid_handle_colors)
 		add_overlay(overlay_image(icon, "[get_world_inventory_state()]_handle", handle_color, flags=RESET_COLOR|RESET_ALPHA))
 
-/obj/item/knife/attack(mob/living/carbon/M, mob/living/carbon/user, target_zone)
-	if(!istype(M))
-		return ..()
+/obj/item/knife/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
-	if(user.a_intent != I_HELP)
-		if(user.get_target_zone() == BP_EYES)
-			if((MUTATION_CLUMSY in user.mutations) && prob(50))
-				M = user
-			return eyestab(M, user)
-
+	if(user.a_intent != I_HELP && user.get_target_zone() == BP_EYES)
+		if((MUTATION_CLUMSY in user.mutations) && prob(50))
+			target = user
+		return eyestab(target, user)
 	return ..()
 
 /obj/item/knife/can_take_wear_damage()

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -22,11 +22,11 @@
 	. = ..()
 	set_extension(src, /datum/extension/tool, list(TOOL_SCALPEL = TOOL_QUALITY_BAD))
 
-/obj/item/shard/attack(mob/living/M, mob/living/user, var/target_zone)
+/obj/item/shard/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	. = ..()
-	if(. && !has_handle)
+	if(. && !has_handle && ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(istype(H) && !H.get_equipped_item(slot_gloves_str) && !(H.species.species_flags & SPECIES_FLAG_NO_MINOR_CUT))
+		if(!H.get_equipped_item(slot_gloves_str) && !(H.species.species_flags & SPECIES_FLAG_NO_MINOR_CUT))
 			var/obj/item/organ/external/hand = GET_EXTERNAL_ORGAN(H, H.get_active_held_item_slot())
 			if(istype(hand) && !BP_IS_PROSTHETIC(hand))
 				to_chat(H, SPAN_DANGER("You slice your hand on \the [src]!"))

--- a/code/game/objects/items/weapons/material/stick.dm
+++ b/code/game/objects/items/weapons/material/stick.dm
@@ -43,12 +43,15 @@
 
 	return ..()
 
-/obj/item/stick/attack(mob/M, mob/user)
-	if(user != M && user.a_intent == I_HELP)
+/obj/item/stick/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(user != target && user.a_intent == I_HELP)
 		//Playful poking is its own thing
-		user.visible_message("<span class='notice'>[user] pokes [M] with [src].</span>", "<span class='notice'>You poke [M] with [src].</span>")
+		user.visible_message(
+			SPAN_NOTICE("\The [user] pokes \the [target] with \the [src]."),
+			SPAN_NOTICE("You poke \the [target] with \the [src].")
+		)
 		//Consider adding a check to see if target is dead
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		user.do_attack_animation(M)
-		return
+		user.do_attack_animation(target)
+		return TRUE
 	return ..()

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -87,7 +87,7 @@
 		user.update_personal_goal(/datum/goal/clean, 1)
 
 //attack_as_weapon
-/obj/item/soap/attack(mob/living/target, mob/living/user, var/target_zone)
+/obj/item/soap/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	if(ishuman(target) && user?.a_intent != I_HURT)
 		var/mob/living/carbon/human/victim = target
 		if(user.get_target_zone() == BP_MOUTH && victim.check_has_mouth())

--- a/code/game/objects/items/weapons/special_attacks/backstab.dm
+++ b/code/game/objects/items/weapons/special_attacks/backstab.dm
@@ -3,12 +3,12 @@ Holds the proc for backstabbing.
 
 usage:
 
-/obj/item/attack(mob/living/target, mob/user, var/target_zone)
+/obj/item/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	backstab(target, user, 60, BRUTE, DAM_SHARP, target_zone)
 	..()
 May also be used as:
 
-/obj/item/attack(mob/living/target, mob/user, var/target_zone)
+/obj/item/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	..()
 	if(backstab(target, user, 60, BRUTE, DAM_SHARP, target_zone))
 		[insert code here]

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -66,21 +66,25 @@
 	renamed = 1
 	icon_changed = 1
 
-/obj/item/storage/bible/attack(mob/living/carbon/human/M, mob/living/carbon/human/user)
-	if(user == M || !ishuman(user) || !ishuman(M))
-		return
+/obj/item/storage/bible/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+
+	if(user == target || !ishuman(user) || !ishuman(target))
+		return ..()
+
 	if(user.mind?.assigned_job?.is_holy)
-		user.visible_message(SPAN_NOTICE("\The [user] places \the [src] on \the [M]'s forehead, reciting a prayer..."))
-		if(do_after(user, 5 SECONDS) && user.Adjacent(M))
+		user.visible_message(SPAN_NOTICE("\The [user] places \the [src] on \the [target]'s forehead, reciting a prayer..."))
+		if(do_after(user, 5 SECONDS) && user.Adjacent(target))
 			var/decl/pronouns/G = user.get_pronouns()
-			user.visible_message( \
-				SPAN_NOTICE("\The [user] finishes reciting [G.his] prayer, removing \the [src] from \the [M]'s forehead."), \
-				SPAN_NOTICE("You finish reciting your prayer, removing \the [src] from \the [M]'s forehead."))
-			if(user.get_cultural_value(TAG_RELIGION) == M.get_cultural_value(TAG_RELIGION))
-				to_chat(M, SPAN_NOTICE("You feel calm and relaxed, at one with the universe."))
+			user.visible_message(
+				SPAN_NOTICE("\The [user] finishes reciting [G.his] prayer, removing \the [src] from \the [target]'s forehead."),
+				SPAN_NOTICE("You finish reciting your prayer, removing \the [src] from \the [target]'s forehead."))
+			if(user.get_cultural_value(TAG_RELIGION) == target.get_cultural_value(TAG_RELIGION))
+				to_chat(target, SPAN_NOTICE("You feel calm and relaxed, at one with the universe."))
 			else
-				to_chat(M, "Nothing happened.")
-		..()
+				to_chat(target, "Nothing happened.")
+		return TRUE
+
+	return ..()
 
 /obj/item/storage/bible/afterattack(atom/A, mob/user, proximity)
 	if(proximity && user?.mind?.assigned_job?.is_holy)

--- a/code/game/objects/items/weapons/storage/fancy/cigarettes.dm
+++ b/code/game/objects/items/weapons/storage/fancy/cigarettes.dm
@@ -33,11 +33,9 @@
 		reagents.trans_to_obj(C, (reagents.total_volume/contents.len))
 	..()
 
-/obj/item/storage/box/fancy/cigarettes/attack(mob/living/carbon/M, mob/living/carbon/user)
-	if(!ismob(M))
-		return
+/obj/item/storage/box/fancy/cigarettes/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
-	if(M == user && user.get_target_zone() == BP_MOUTH && contents.len > 0 && !user.get_equipped_item(slot_wear_mask_str))
+	if(target == user && user.get_target_zone() == BP_MOUTH && contents.len > 0 && !user.get_equipped_item(slot_wear_mask_str))
 		// Find ourselves a cig. Note that we could be full of lighters.
 		var/obj/item/clothing/mask/smokable/cigarette/cig = null
 		for(var/obj/item/clothing/mask/smokable/cigarette/C in contents)
@@ -45,24 +43,24 @@
 			break
 
 		if(cig == null)
-			to_chat(user, "<span class='notice'>Looks like the packet is out of cigarettes.</span>")
-			return
+			to_chat(user, SPAN_NOTICE("Looks like the packet is out of cigarettes."))
+			return TRUE
 
 		// Instead of running equip_to_slot_if_possible() we check here first,
 		// to avoid dousing cig with reagents if we're not going to equip it
 		if(!cig.mob_can_equip(user, slot_wear_mask_str))
-			return
+			return TRUE
 
 		// We call remove_from_storage first to manage the reagent transfer and
 		// UI updates.
 		remove_from_storage(cig, null)
 		user.equip_to_slot(cig, slot_wear_mask_str)
-
 		reagents.maximum_volume = 5 * contents.len
-		to_chat(user, "<span class='notice'>You take a cigarette out of the pack.</span>")
+		to_chat(user, SPAN_NOTICE("You take a cigarette out of the pack."))
 		update_icon()
-	else
-		..()
+		return TRUE
+
+	return ..()
 
 /obj/item/storage/box/fancy/cigarettes/dromedaryco
 	name = "pack of Dromedary Co. cigarettes"

--- a/code/game/objects/items/weapons/storage/trays.dm
+++ b/code/game/objects/items/weapons/storage/trays.dm
@@ -42,13 +42,13 @@
 	scatter_contents()
 	. = ..()
 
-/obj/item/storage/tray/attack(mob/living/carbon/M, mob/living/carbon/user)
+/obj/item/storage/tray/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	if((MUTATION_CLUMSY in user.mutations) && prob(50)) // There is a better way to do this but I'll be damned if I'm the one to fix it.
-		to_chat(user, SPAN_DANGER("You accidentally slam yourself with the [src]!"))
+		to_chat(user, SPAN_DANGER("You accidentally slam yourself with \the [src]!"))
 		SET_STATUS_MAX(user, STAT_WEAK, 1)
 		user.take_organ_damage(2)
 		if(prob(50))
-			playsound(M, hitsound, 50, 1)
+			playsound(target, hitsound, 50, 1)
 		. = TRUE
 	else
 		. = ..()
@@ -158,7 +158,8 @@ TRAY TYPES GO HERE
 /obj/item/storage/tray/metal
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 
-/obj/item/storage/tray/metal/attack(mob/living/carbon/M, mob/living/carbon/user) // So metal trays make the fun noise
+/obj/item/storage/tray/metal/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	// So metal trays make the fun noise
 	hitsound = pick('sound/items/trayhit1.ogg','sound/items/trayhit2.ogg')
 	. = ..()
 

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -94,12 +94,12 @@
 		status = s
 		update_icon()
 
-/obj/item/baton/attack(mob/M, mob/user)
+/obj/item/baton/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	if(status && (MUTATION_CLUMSY in user.mutations) && prob(50))
-		to_chat(user, "<span class='danger'>You accidentally hit yourself with the [src]!</span>")
+		to_chat(user, SPAN_DANGER("You accidentally hit yourself with the [src]!"))
 		SET_STATUS_MAX(user, STAT_WEAK, 30)
 		deductcharge(hitcost)
-		return
+		return TRUE
 	return ..()
 
 /obj/item/baton/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone)

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -17,16 +17,16 @@
 	item_flags = ITEM_FLAG_IS_WEAPON
 	material = /decl/material/solid/organic/wood
 
-/obj/item/classic_baton/attack(mob/M, mob/living/user)
+/obj/item/classic_baton/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	if ((MUTATION_CLUMSY in user.mutations) && prob(50))
-		to_chat(user, "<span class='warning'>You club yourself over the head.</span>")
+		to_chat(user, SPAN_WARNING("You club yourself over the head."))
 		SET_STATUS_MAX(user, STAT_WEAK, (3 * force))
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			H.apply_damage(2*force, BRUTE, BP_HEAD)
 		else
 			user.take_organ_damage(2*force)
-		return
+		return TRUE
 	return ..()
 
 //Telescopic baton
@@ -73,19 +73,14 @@
 	else
 		icon = 'icons/obj/items/weapon/telebaton.dmi'
 
-/obj/item/telebaton/attack(mob/target, mob/living/user)
-	if(on)
-		if ((MUTATION_CLUMSY in user.mutations) && prob(50))
-			to_chat(user, "<span class='warning'>You club yourself over the head.</span>")
-			SET_STATUS_MAX(user, STAT_WEAK, (3 * force))
-			if(ishuman(user))
-				var/mob/living/carbon/human/H = user
-				H.apply_damage(2*force, BRUTE, BP_HEAD)
-			else
-				user.take_organ_damage(2*force)
-			return
-		if(..())
-			//playsound(src.loc, "swing_hit", 50, 1, -1)
-			return
-	else
-		return ..()
+/obj/item/telebaton/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(on && (MUTATION_CLUMSY in user.mutations) && prob(50))
+		to_chat(user, SPAN_DANGER("You club yourself over the head."))
+		SET_STATUS_MAX(user, STAT_WEAK, (3 * force))
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			H.apply_damage(2*force, BRUTE, BP_HEAD)
+		else
+			user.take_organ_damage(2*force)
+		return TRUE
+	return ..()

--- a/code/game/objects/items/weapons/tools/screwdriver.dm
+++ b/code/game/objects/items/weapons/tools/screwdriver.dm
@@ -39,14 +39,12 @@
 		res.color = handle_color
 	return res
 
-/obj/item/screwdriver/attack(mob/living/carbon/M, mob/living/carbon/user)
-	if(!istype(M) || user.a_intent == I_HELP)
-		return ..()
-	if(user.get_target_zone() != BP_EYES && user.get_target_zone() != BP_HEAD)
+/obj/item/screwdriver/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(user.a_intent == I_HELP || user.get_target_zone() != BP_EYES && user.get_target_zone() != BP_HEAD)
 		return ..()
 	if((MUTATION_CLUMSY in user.mutations) && prob(50))
-		M = user
-	return eyestab(M,user)
+		target = user
+	return eyestab(target, user)
 
 /obj/item/screwdriver/gold
 	material = /decl/material/solid/metal/gold

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -342,27 +342,22 @@
 	else
 		return turn_on(user)
 
-/obj/item/weldingtool/attack(mob/living/M, mob/living/user, target_zone)
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/external/S = GET_EXTERNAL_ORGAN(H, target_zone)
-
+/obj/item/weldingtool/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		var/obj/item/organ/external/S = GET_EXTERNAL_ORGAN(H, user?.get_target_zone())
 		if(!S || !S.is_robotic() || user.a_intent != I_HELP)
 			return ..()
-
 		if(BP_IS_BRITTLE(S))
-			to_chat(user, SPAN_WARNING("\The [M]'s [S.name] is hard and brittle - \the [src]  cannot repair it."))
+			to_chat(user, SPAN_WARNING("\The [target]'s [S.name] is hard and brittle - \the [src]  cannot repair it."))
 			return TRUE
-
 		if(!welding)
-			to_chat(user, SPAN_WARNING("You'll need to turn [src] on to patch the damage on [M]'s [S.name]!"))
+			to_chat(user, SPAN_WARNING("You'll need to turn [src] on to patch the damage on [target]'s [S.name]!"))
 			return TRUE
-
 		if(S.robo_repair(15, BRUTE, "some dents", src, user))
 			weld(1, user)
 			return TRUE
-	else
-		return ..()
+	return ..()
 
 /obj/item/weldingtool/get_autopsy_descriptors()
 	if(isOn())

--- a/code/game/objects/items/weapons/tools/wirecutter.dm
+++ b/code/game/objects/items/weapons/tools/wirecutter.dm
@@ -38,17 +38,18 @@
 		ret.color = handle_color
 	return ret
 
-/obj/item/wirecutters/attack(mob/living/carbon/C, mob/user)
-	var/obj/item/handcuffs/cable/cuffs = C.get_equipped_item(slot_handcuffed_str)
-	if(istype(C) && user.a_intent == I_HELP && (istype(cuffs)))
-		usr.visible_message("\The [usr] cuts \the [C]'s restraints with \the [src]!",\
-		"You cut \the [C]'s restraints with \the [src]!",\
-		"You hear cable being cut.")
-		C.try_unequip(cuffs)
+/obj/item/wirecutters/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+
+	var/obj/item/handcuffs/cable/cuffs = target.get_equipped_item(slot_handcuffed_str)
+	if(user.a_intent == I_HELP && istype(cuffs) && target.try_unequip(cuffs))
+		user.visible_message(
+			"\The [usr] cuts \the [target]'s restraints with \the [src]!",
+			"You cut \the [target]'s restraints with \the [src]!",
+			"You hear cable being cut."
+		)
 		qdel(cuffs)
-		if(C.buckled && C.buckled.buckle_require_restraints)
-			C.buckled.unbuckle_mob()
-		C.update_equipment_overlay(slot_handcuffed_str)
-		return
-	else
-		..()
+		if(target.buckled?.buckle_require_restraints)
+			target.buckled.unbuckle_mob()
+		return TRUE
+
+	return ..()

--- a/code/game/objects/items/weapons/towels.dm
+++ b/code/game/objects/items/weapons/towels.dm
@@ -65,7 +65,7 @@
 		lay_out()
 		return TRUE
 	if(user.a_intent != I_HURT)
-		return use_on_mob(user, user, user.get_target_zone())
+		return use_on_mob(user, user)
 	return ..()
 
 /obj/item/towel/random/Initialize()

--- a/code/game/objects/items/weapons/towels.dm
+++ b/code/game/objects/items/weapons/towels.dm
@@ -42,20 +42,20 @@
 		if(is_processing)
 			STOP_PROCESSING(SSobj, src)
 
-/obj/item/towel/attack(mob/living/M, mob/living/user, var/target_zone, animate = TRUE)
+/obj/item/towel/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	if(user.a_intent == I_HURT)
 		return ..()
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	var/reagent_space = reagents.maximum_volume - reagents.total_volume
 	if(reagent_space <= 0)
-		to_chat(user, SPAN_WARNING("\The [src] is too saturated to dry [user == M ? "yourself" : "\the [M]"] off effectively."))
+		to_chat(user, SPAN_WARNING("\The [src] is too saturated to dry [user == target ? "yourself" : "\the [target]"] off effectively."))
 	else
-		var/decl/pronouns/G = M.get_pronouns()
-		var/datum/reagents/touching_reagents = M.get_contact_reagents()
+		var/decl/pronouns/G = target.get_pronouns()
+		var/datum/reagents/touching_reagents = target.get_contact_reagents()
 		if(!touching_reagents?.total_volume)
-			to_chat(user, SPAN_WARNING("[user == M ? "You are" : "\The [M] [G.is]"] already dry."))
+			to_chat(user, SPAN_WARNING("[user == target ? "You are" : "\The [target] [G.is]"] already dry."))
 		else
-			user.visible_message(SPAN_NOTICE("\The [user] uses \the [src] to towel [user == M ? G.self : "\the [M]"] dry."))
+			user.visible_message(SPAN_NOTICE("\The [user] uses \the [src] to towel [user == target ? G.self : "\the [target]"] dry."))
 			touching_reagents.trans_to(src, min(touching_reagents.total_volume, reagent_space))
 			playsound(user, 'sound/weapons/towelwipe.ogg', 25, 1)
 	return TRUE
@@ -65,7 +65,7 @@
 		lay_out()
 		return TRUE
 	if(user.a_intent != I_HURT)
-		return attack(user, user, user.get_target_zone())
+		return use_on_mob(user, user, user.get_target_zone())
 	return ..()
 
 /obj/item/towel/random/Initialize()

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -14,33 +14,33 @@
 	material = /decl/material/solid/glass
 	max_health = ITEM_HEALTH_NO_DAMAGE
 
-/obj/item/nullrod/attack(mob/M, mob/living/user) //Paste from old-code to decult with a null rod.
-	admin_attack_log(user, M, "Attacked using \a [src]", "Was attacked with \a [src]", "used \a [src] to attack")
+/obj/item/nullrod/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
+	admin_attack_log(user, target, "Attacked using \a [src]", "Was attacked with \a [src]", "used \a [src] to attack")
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	user.do_attack_animation(M)
-	//if(user != M)
-	if(M.mind && LAZYLEN(M.mind.learned_spells))
-		M.silence_spells(300) //30 seconds
-		to_chat(M, "<span class='danger'>You've been silenced!</span>")
-		return
+	user.do_attack_animation(target)
+
+	if(target.mind && LAZYLEN(target.mind.learned_spells))
+		target.silence_spells(300) //30 seconds
+		to_chat(target, SPAN_DANGER("You've been silenced!"))
+		return TRUE
 
 	if (!user.check_dexterity(DEXTERITY_WEAPONS))
-		return
+		return TRUE
 
 	if ((MUTATION_CLUMSY in user.mutations) && prob(50))
-		to_chat(user, "<span class='danger'>The rod slips out of your hand and hits your head.</span>")
+		to_chat(user, SPAN_DANGER("The rod slips out of your hand and hits your head."))
 		user.take_organ_damage(10)
 		SET_STATUS_MAX(user, STAT_PARA, 20)
-		return
+		return TRUE
 
-	if(iscultist(M))
-		M.visible_message("<span class='notice'>\The [user] waves \the [src] over \the [M]'s head.</span>")
+	if(iscultist(target))
+		target.visible_message(SPAN_NOTICE("\The [user] waves \the [src] over \the [target]'s head."))
 		var/decl/special_role/cultist/cult = GET_DECL(/decl/special_role/cultist)
-		cult.offer_uncult(M)
-		return
+		cult.offer_uncult(target)
+		return TRUE
 
-	..()
+	return ..()
 
 /obj/item/nullrod/afterattack(var/atom/A, var/mob/user, var/proximity)
 	if(!proximity)

--- a/code/game/objects/structures/wall_sconce.dm
+++ b/code/game/objects/structures/wall_sconce.dm
@@ -9,7 +9,7 @@
 	max_health          = 100
 	w_class             = ITEM_SIZE_LARGE
 
-/obj/item/wall_sconce/attack(mob/living/M, mob/living/user, var/target_zone)
+/obj/item/wall_sconce/use_on_mob(mob/living/target, mob/living/user, var/target_zone)
 	return FALSE
 
 /obj/item/wall_sconce/afterattack(var/atom/A, var/mob/user, var/proximity)

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -180,13 +180,12 @@
 		text = replacetext(text, "FLAME", "[W.name]")
 		light(text)
 
-/obj/item/clothing/mask/smokable/attack(var/mob/living/M, var/mob/living/user, def_zone)
-	if(istype(M) && M.on_fire)
-		user.do_attack_animation(M)
-		light(SPAN_NOTICE("\The [user] coldly lights the \the [src] with the burning body of \the [M]."))
-		return 1
-	else
-		return ..()
+/obj/item/clothing/mask/smokable/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(target.on_fire)
+		user.do_attack_animation(target)
+		light(SPAN_NOTICE("\The [user] coldly lights the \the [src] with the burning body of \the [target]."))
+		return TRUE
+	return ..()
 
 /obj/item/clothing/mask/smokable/cigarette
 	name = "cigarette"
@@ -368,26 +367,26 @@
 			return TRUE
 	return ..()
 
-/obj/item/clothing/mask/smokable/cigarette/attack(mob/living/carbon/human/H, mob/user, def_zone)
-	if(lit && H == user && istype(H))
-		var/obj/item/blocked = H.check_mouth_coverage()
+/obj/item/clothing/mask/smokable/cigarette/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(lit && target == user)
+		var/obj/item/blocked = target.check_mouth_coverage()
 		if(blocked)
-			to_chat(H, SPAN_WARNING("\The [blocked] is in the way!"))
-			return 1
+			to_chat(target, SPAN_WARNING("\The [blocked] is in the way!"))
+			return TRUE
 		var/decl/pronouns/G = user.get_pronouns()
 		var/puff_str = pick("drag","puff","pull")
 		user.visible_message(\
 			SPAN_NOTICE("\The [user] takes a [puff_str] on [G.his] [name]."), \
 			SPAN_NOTICE("You take a [puff_str] on your [name]."))
 		smoke(12, TRUE)
-		add_trace_DNA(H)
+		add_trace_DNA(target)
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		return 1
+		return TRUE
 
-	if(!lit && istype(H) && H.on_fire)
-		user.do_attack_animation(H)
-		light(H, user)
-		return 1
+	if(!lit && target.on_fire)
+		user.do_attack_animation(target)
+		light(target, user)
+		return TRUE
 
 	return ..()
 

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -47,11 +47,16 @@
 		else
 			user.visible_message("<span class='notice'>[user] displays their [src.name].\nIt reads: [badge_string].</span>","<span class='notice'>You display your [src.name]. It reads: [badge_string].</span>")
 
-/obj/item/clothing/accessory/badge/attack(mob/living/carbon/human/M, mob/living/user)
-	if(isliving(user))
-		user.visible_message("<span class='danger'>[user] invades [M]'s personal space, thrusting \the [src] into their face insistently.</span>","<span class='danger'>You invade [M]'s personal space, thrusting \the [src] into their face insistently.</span>")
+/obj/item/clothing/accessory/badge/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(isliving(user) && user.a_intent == I_HURT)
+		user.visible_message(
+			SPAN_DANGER("\The [user] invades \the [target]'s personal space, thrusting \the [src] into their face insistently."),
+			SPAN_DANGER("You invade \the [target]'s personal space, thrusting \the [src] into their face insistently.")
+		)
 		if(stored_name)
-			to_chat(M, "<span class='warning'>It reads: [stored_name], [badge_string].</span>")
+			to_chat(target, SPAN_NOTICE("It reads: [stored_name], [badge_string]."))
+		return TRUE
+	return ..()
 
 /obj/item/clothing/accessory/badge/PI
 	name = "private investigator's badge"

--- a/code/modules/clothing/under/accessories/stethoscope.dm
+++ b/code/modules/clothing/under/accessories/stethoscope.dm
@@ -4,11 +4,13 @@
 	icon = 'icons/clothing/accessories/stethoscope.dmi'
 	accessory_high_visibility = TRUE
 
-/obj/item/clothing/accessory/stethoscope/attack(mob/living/carbon/human/M, mob/living/user)
-	if(ishuman(M) && isliving(user) && user.a_intent == I_HELP)
-		var/obj/item/organ/organ = GET_EXTERNAL_ORGAN(M, user.get_target_zone())
+/obj/item/clothing/accessory/stethoscope/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(ishuman(target) && isliving(user) && user.a_intent == I_HELP)
+		var/obj/item/organ/organ = GET_EXTERNAL_ORGAN(target, user.get_target_zone())
 		if(organ)
-			user.visible_message("[user] places [src] against [M]'s [organ.name] and listens attentively.",
-								 "You place [src] against [M]'s [organ.name]. You hear [english_list(organ.listen())].")
+			user.visible_message(
+				"\The [user] places [src] against \the [target]'s [organ.name] and listens attentively.",
+				"You place \the [src] against \the [target]'s [organ.name]. You hear [english_list(organ.listen())]."
+			)
 			return TRUE
-	return ..(M,user)
+	return ..()

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -89,47 +89,49 @@
 			user.visible_message("\The [user] finishes wiping off the [A]!")
 			reagents.splash(A, FLUID_QDEL_POINT)
 
-/obj/item/chems/glass/rag/attack(atom/target, mob/user , flag)
-	if(isliving(target))
-		var/mob/living/M = target
-		if(on_fire)
+/obj/item/chems/glass/rag/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+
+	if(on_fire)
+		user.visible_message(
+			SPAN_DANGER("\The [user] hits \the [target] with \the [src]!"),
+			SPAN_DANGER("You hit \the [target] with \the [src]!")
+		)
+		user.do_attack_animation(target)
+		admin_attack_log(user, target, "used \the [src] (ignited) to attack", "was attacked using \the [src] (ignited)", "attacked with \the [src] (ignited)")
+		target.IgniteMob()
+		return TRUE
+
+	if(reagents.total_volume)
+		if(user.get_target_zone() != BP_MOUTH)
+			wipe_down(target, user)
+			return TRUE
+
+		if (!target.has_danger_grab(user))
+			to_chat(user, SPAN_WARNING("You need to have a firm grip on \the [target] before you can use \the [src] on them!"))
+			return TRUE
+
+		user.do_attack_animation(src)
+		user.visible_message(
+			SPAN_DANGER("\The [user] brings \the [src] up to \the [target]'s mouth!"),
+			SPAN_DANGER("You bring \the [src] up to \the [target]'s mouth!"),
+			SPAN_WARNING("You hear some struggling and muffled cries of surprise.")
+		)
+
+		var/grab_time = 6 SECONDS
+		if (user.skill_check(SKILL_COMBAT, SKILL_ADEPT))
+			grab_time = 3 SECONDS
+
+		if (do_after(user, grab_time, target))
 			user.visible_message(
-				SPAN_DANGER("\The [user] hits \the [target] with \the [src]!"),
-				SPAN_DANGER("You hit \the [target] with \the [src]!")
+				SPAN_DANGER("\The [user] smothers \the [target] with \the [src]!"),
+				SPAN_DANGER("You smother \the [target] with \the [src]!")
 			)
-			user.do_attack_animation(target)
-			admin_attack_log(user, M, "used \the [src] (ignited) to attack", "was attacked using \the [src] (ignited)", "attacked with \the [src] (ignited)")
-			M.IgniteMob()
-		else if(reagents.total_volume)
-			if(user.get_target_zone() == BP_MOUTH)
-				if (!M.has_danger_grab(user))
-					to_chat(user, SPAN_WARNING("You need to have a firm grip on \the [target] before you can use \the [src] on them!"))
-					return
-
-				user.do_attack_animation(src)
-				user.visible_message(
-					SPAN_DANGER("\The [user] brings \the [src] up to \the [target]'s mouth!"),
-					SPAN_DANGER("You bring \the [src] up to \the [target]'s mouth!"),
-					SPAN_WARNING("You hear some struggling and muffled cries of surprise.")
-				)
-
-				var/grab_time = 6 SECONDS
-				if (user.skill_check(SKILL_COMBAT, SKILL_ADEPT))
-					grab_time = 3 SECONDS
-
-				if (do_after(user, grab_time, target))
-					user.visible_message(
-						SPAN_DANGER("\The [user] smothers \the [target] with \the [src]!"),
-						SPAN_DANGER("You smother \the [target] with \the [src]!")
-					)
-					var/trans_amt = reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_INHALE)
-					var/contained_reagents = reagents.get_reagents()
-					admin_inject_log(user, M, src, contained_reagents, trans_amt)
-					update_name()
-			else
-				wipe_down(target, user)
-		return
-
+			var/trans_amt = reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_INHALE)
+			var/contained_reagents = reagents.get_reagents()
+			admin_inject_log(user, target, src, contained_reagents, trans_amt)
+			update_name()
+		return TRUE
+	
 	return ..()
 
 /obj/item/chems/glass/rag/afterattack(atom/A, mob/user, proximity)

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -131,7 +131,7 @@
 			admin_inject_log(user, target, src, contained_reagents, trans_amt)
 			update_name()
 		return TRUE
-	
+
 	return ..()
 
 /obj/item/chems/glass/rag/afterattack(atom/A, mob/user, proximity)
@@ -151,7 +151,7 @@
 	if(!on_fire && istype(A) && (src in user))
 		if(ATOM_IS_OPEN_CONTAINER(A) && !(A in user))
 			remove_contents(user, A)
-		else if(!ismob(A)) //mobs are handled in attack() - this prevents us from wiping down people while smothering them.
+		else if(!ismob(A)) //mobs are handled in use_on_mob() - this prevents us from wiping down people while smothering them.
 			wipe_down(A, user)
 		return
 

--- a/code/modules/detectivework/tools/sample_kits/fingerprinting.dm
+++ b/code/modules/detectivework/tools/sample_kits/fingerprinting.dm
@@ -72,10 +72,11 @@
 			return TRUE
 	to_chat(user, SPAN_WARNING("They don't have any hands."))
 
-/obj/item/forensics/sample/print/attack(var/mob/living/carbon/human/H, var/mob/user)
-	if(!istype(H))
+/obj/item/forensics/sample/print/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(!ishuman(target))
 		return ..()
 
+	var/mob/living/carbon/human/H = target
 	if(!can_take_print_from(H, user))
 		return 1
 

--- a/code/modules/detectivework/tools/sample_kits/swabs.dm
+++ b/code/modules/detectivework/tools/sample_kits/swabs.dm
@@ -16,10 +16,12 @@
 		/decl/material/solid/glass = MATTER_AMOUNT_REINFORCEMENT,
 	)
 
-/obj/item/forensics/sample_kit/swabs/attack(var/mob/living/carbon/human/H, var/mob/user)
-	if(!istype(H))
+/obj/item/forensics/sample_kit/swabs/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+
+	if(!ishuman(target))
 		return ..()
 
+	var/mob/living/carbon/human/H = target
 	var/time_to_take = H.a_intent == I_HELP ? 1 SECOND : 3 SECONDS
 	user.visible_message(SPAN_NOTICE("\The [user] starts swabbing a sample from \the [H]."))
 	if(!do_mob(user, H, time_to_take))

--- a/code/modules/emotes/definitions/audible.dm
+++ b/code/modules/emotes/definitions/audible.dm
@@ -103,7 +103,7 @@
 		var/obj/item/organ/internal/lungs/lung = user.get_organ(BP_LUNGS)
 		. = lung?.active_breathing && !user.isSynthetic()
 
-/decl/emote/audible/cough/do_emote(var/mob/living/carbon/user, var/extra_params)
+/decl/emote/audible/cough/do_emote(var/mob/living/user, var/extra_params)
 	if(!istype(user))
 		to_chat(user, SPAN_WARNING("You are unable to cough."))
 		return

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -161,7 +161,7 @@
 			overlay.overlays += overlay_image(overlay.icon, "[overlay.icon_state]-bait", bait.color, RESET_COLOR | RESET_ALPHA)
 	. = ..()
 
-/obj/item/fishing_rod/attack(mob/living/M, mob/living/user)
+/obj/item/fishing_rod/use_on_mob(mob/living/target, mob/living/user)
 	return user.a_intent != I_HURT ? FALSE : ..()
 
 /obj/item/fishing_rod/proc/can_fish_in(mob/user, atom/target)

--- a/code/modules/grooming/_grooming.dm
+++ b/code/modules/grooming/_grooming.dm
@@ -81,7 +81,7 @@
 		return TRUE
 	return ..()
 
-/obj/item/grooming/attack(mob/living/M, mob/living/user, var/target_zone, animate = TRUE)
-	if(try_groom(user, M))
+/obj/item/grooming/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(try_groom(user, target))
 		return TRUE
 	return ..()

--- a/code/modules/mechs/equipment/_equipment.dm
+++ b/code/modules/mechs/equipment/_equipment.dm
@@ -21,8 +21,8 @@
 	var/require_adjacent = TRUE
 	var/active = FALSE //For gear that has an active state (ie, floodlights)
 
-/obj/item/mech_equipment/attack() //Generally it's not desired to be able to attack with items
-	return 0
+/obj/item/mech_equipment/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	return FALSE
 
 /obj/item/mech_equipment/afterattack(var/atom/target, var/mob/living/user, var/inrange, var/params)
 	if(require_adjacent)

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -275,7 +275,7 @@
 			playsound(E, 'sound/mecha/mechmove03.ogg', 35, 1)
 			if (do_after(E, 1.2 SECONDS, get_turf(user)) && E && MC)
 				for (var/mob/living/M in orange(1, E))
-					attack(M, E, E.get_target_zone(), FALSE)
+					use_on_mob(M, E, animate = FALSE)
 				E.spin(0.65 SECONDS, 0.125 SECONDS)
 				playsound(E, 'sound/mecha/mechturn.ogg', 40, 1)
 

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -94,10 +94,10 @@
 		else
 			upgrade()
 
-/obj/item/grab/attack(mob/M, mob/living/user)
-	if(affecting == M)
+/obj/item/grab/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(affecting == target)
 		var/datum/extension/abilities/abilities = get_extension(user, /datum/extension/abilities)
-		if(abilities?.do_grabbed_invocation(M))
+		if(abilities?.do_grabbed_invocation(target))
 			return TRUE
 	. = ..()
 

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -189,6 +189,11 @@
 		handcuffs.place_handcuffs(C, src)
 	resetTarget() //we're done, failed or not. Don't want to get stuck if C is not
 
+/mob/living/bot/get_target_zone()
+	if(!client)
+		return BP_CHEST
+	return ..()
+
 /mob/living/bot/secbot/UnarmedAttack(var/mob/M, var/proximity)
 
 	. = ..()
@@ -208,7 +213,7 @@
 	else
 		a_intent = I_GRAB
 
-	stun_baton.attack(M, src, BP_CHEST) //robots and turrets aim for center of mass
+	stun_baton.use_on_mob(M, src) //robots and turrets aim for center of mass
 	flick(attack_state, src)
 	return TRUE
 

--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -1,3 +1,3 @@
 #define MOB_BREATH_DELAY 2
-/mob/living/carbon/should_breathe()
+/mob/living/should_breathe()
 	return ((life_tick % MOB_BREATH_DELAY) == 0 || failed_last_breath || is_asystole())

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -1,5 +1,5 @@
 
-/mob/living/carbon/standard_weapon_hit_effects(obj/item/I, mob/living/user, var/effective_force, var/hit_zone)
+/mob/living/standard_weapon_hit_effects(obj/item/I, mob/living/user, var/effective_force, var/hit_zone)
 	if(!effective_force)
 		return 0
 

--- a/code/modules/mob/living/carbon/carbon_eating.dm
+++ b/code/modules/mob/living/carbon/carbon_eating.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/can_eat_food_currently(obj/eating, mob/user, consumption_method)
+/mob/living/can_eat_food_currently(obj/eating, mob/user, consumption_method)
 	user = user || src
 	if(get_food_satiation(consumption_method) < get_max_nutrition())
 		return TRUE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -967,7 +967,10 @@
 		if(!defer_language_update)
 			update_languages()
 
-/mob/living/carbon/human/proc/get_cultural_value(var/token)
+/mob/living/proc/get_cultural_value(var/token)
+	return null
+
+/mob/living/carbon/human/get_cultural_value(var/token)
 	. = LAZYACCESS(cultural_info, token)
 	if(!istype(., /decl/cultural_info))
 		. = global.using_map.default_cultural_info[token]

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -19,7 +19,8 @@
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_TRACE
 	)
 
-/obj/item/robotanalyzer/attack(mob/living/M, mob/living/user)
+/obj/item/robotanalyzer/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+
 	if((MUTATION_CLUMSY in user.mutations) && prob(50))
 		user.visible_message(
 			SPAN_WARNING("\The [user] has analyzed the floor's vitals!"),
@@ -28,28 +29,28 @@
 		user.show_message(SPAN_NOTICE("\t Damage Specifics: [0]-[0]-[0]-[0]"))
 		user.show_message(SPAN_NOTICE("Key: Suffocation/Toxin/Burns/Brute"))
 		user.show_message(SPAN_NOTICE("Body Temperature: ???"))
-		return
+		return TRUE
 
 	var/scan_type
-	if(isrobot(M))
+	if(isrobot(target))
 		scan_type = "robot"
-	else if(ishuman(M))
+	else if(ishuman(target))
 		scan_type = "prosthetics"
 	else
 		to_chat(user, "<span class='warning'>You can't analyze non-robotic things!</span>")
-		return
+		return TRUE
 
-	user.visible_message("<span class='notice'>\The [user] has analyzed [M]'s components.</span>","<span class='notice'>You have analyzed [M]'s components.</span>")
+	user.visible_message("<span class='notice'>\The [user] has analyzed [target]'s components.</span>","<span class='notice'>You have analyzed [target]'s components.</span>")
 	switch(scan_type)
 		if("robot")
-			var/BU = M.get_damage(BURN) > 50 	? 	"<b>[M.get_damage(BURN)]</b>" 		: M.get_damage(BURN)
-			var/BR = M.get_damage(BRUTE) > 50 	? 	"<b>[M.get_damage(BRUTE)]</b>" 	: M.get_damage(BRUTE)
-			user.show_message("<span class='notice'>Analyzing Results for [M]:\n\t Overall Status: [M.stat > 1 ? "fully disabled" : "[M.current_health - M.get_damage(PAIN)]% functional"]</span>")
+			var/BU = target.get_damage(BURN)  > 50 ? "<b>[target.get_damage(BURN)]</b>"  : target.get_damage(BURN)
+			var/BR = target.get_damage(BRUTE) > 50 ? "<b>[target.get_damage(BRUTE)]</b>" : target.get_damage(BRUTE)
+			user.show_message("<span class='notice'>Analyzing Results for [target]:\n\t Overall Status: [target.stat > 1 ? "fully disabled" : "[target.current_health - target.get_damage(PAIN)]% functional"]</span>")
 			user.show_message("\t Key: <font color='#ffa500'>Electronics</font>/<font color='red'>Brute</font>", 1)
 			user.show_message("\t Damage Specifics: <font color='#ffa500'>[BU]</font> - <font color='red'>[BR]</font>")
-			if(M.stat == DEAD)
-				user.show_message("<span class='notice'>Time of Failure: [time2text(worldtime2stationtime(M.timeofdeath))]</span>")
-			var/mob/living/silicon/robot/H = M
+			if(target.stat == DEAD)
+				user.show_message("<span class='notice'>Time of Failure: [time2text(worldtime2stationtime(target.timeofdeath))]</span>")
+			var/mob/living/silicon/robot/H = target
 			var/list/damaged = H.get_damaged_components(1,1,1)
 			user.show_message("<span class='notice'>Localized Damage:</span>",1)
 			if(length(damaged)>0)
@@ -65,11 +66,11 @@
 				user.show_message("<span class='notice'>\t Components are OK.</span>",1)
 			if(H.emagged && prob(5))
 				user.show_message("<span class='warning'>\t ERROR: INTERNAL SYSTEMS COMPROMISED</span>",1)
-			user.show_message("<span class='notice'>Operating Temperature: [M.bodytemperature-T0C]&deg;C ([M.bodytemperature*1.8-459.67]&deg;F)</span>", 1)
+			user.show_message("<span class='notice'>Operating Temperature: [target.bodytemperature-T0C]&deg;C ([target.bodytemperature*1.8-459.67]&deg;F)</span>", 1)
 
 		if("prosthetics")
 
-			var/mob/living/carbon/human/H = M
+			var/mob/living/carbon/human/H = target
 			to_chat(user, SPAN_NOTICE("Analyzing Results for \the [H]:"))
 			to_chat(user, "Key: [SPAN_ORANGE("Electronics")]/[SPAN_RED("Brute")]")
 			var/obj/item/organ/internal/cell/C = H.get_organ(BP_CELL, /obj/item/organ/internal/cell)
@@ -98,4 +99,4 @@
 				to_chat(user, "No prosthetics located.")
 
 	src.add_fingerprint(user)
-	return
+	return TRUE

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -188,7 +188,7 @@
 		//Temporary put wrapped into user so target's attackby() checks pass.
 		wrapped.forceMove(user)
 
-		//The force of the wrapped obj gets set to zero during the attack() and afterattack().
+		//The force of the wrapped obj gets set to zero during the use_on_mob() and afterattack().
 		var/force_holder = wrapped.force
 		wrapped.force = 0.0
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -172,9 +172,9 @@
 	wrapped = null
 	//on_update_icon()
 
-/obj/item/gripper/attack(mob/living/carbon/M, mob/living/carbon/user)
+/obj/item/gripper/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	// Don't fall through and smack people with gripper, instead just no-op
-	return 0
+	return FALSE
 
 /obj/item/gripper/resolve_attackby(var/atom/target, var/mob/living/user, params)
 
@@ -287,8 +287,8 @@
 	plastic = null
 	return ..()
 
-/obj/item/matter_decompiler/attack(mob/living/carbon/M, mob/living/carbon/user)
-	return
+/obj/item/matter_decompiler/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	return FALSE
 
 /obj/item/matter_decompiler/afterattack(atom/target, mob/living/user, proximity, params)
 

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -174,8 +174,8 @@
 	item_state = "sheet-metal"
 	max_health = ITEM_HEALTH_NO_DAMAGE
 
-/obj/item/form_printer/attack(mob/living/carbon/M, mob/living/carbon/user)
-	return
+/obj/item/form_printer/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	return FALSE
 
 /obj/item/form_printer/afterattack(atom/target, mob/living/user, flag, params)
 

--- a/code/modules/mob/living/simple_animal/constructs/soulstone.dm
+++ b/code/modules/mob/living/simple_animal/constructs/soulstone.dm
@@ -57,21 +57,22 @@
 			user.visible_message("<span class='danger'>\The [user] shatters \the [src] with \the [I]!</span>")
 			shatter()
 
-/obj/item/soulstone/attack(var/mob/living/simple_animal/M, var/mob/user)
-	if(M == shade)
-		to_chat(user, "<span class='notice'>You recapture \the [M].</span>")
-		M.forceMove(src)
-		return
+/obj/item/soulstone/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(target == shade)
+		to_chat(user, SPAN_NOTICE("You recapture \the [target]."))
+		target.forceMove(src)
+		return TRUE
 	if(full == SOULSTONE_ESSENCE)
-		to_chat(user, "<span class='notice'>\The [src] is already full.</span>")
-		return
-	if(M.stat != DEAD && !M.is_asystole())
-		to_chat(user, "<span class='notice'>Kill or maim the victim first.</span>")
-		return
-	for(var/obj/item/W in M)
-		M.drop_from_inventory(W)
-	M.dust()
+		to_chat(user, SPAN_NOTICE("\The [src] is already full."))
+		return TRUE
+	if(target.stat != DEAD && !target.is_asystole())
+		to_chat(user, SPAN_NOTICE("Kill or maim the victim first."))
+		return TRUE
+	for(var/obj/item/thing in target)
+		target.drop_from_inventory(thing)
+	target.dust()
 	set_full(SOULSTONE_ESSENCE)
+	return TRUE
 
 /obj/item/soulstone/attack_self(var/mob/user)
 	if(full != SOULSTONE_ESSENCE) // No essence - no shade

--- a/code/modules/mob/living/simple_animal/hostile/slug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/slug.dm
@@ -60,13 +60,12 @@
 			var/datum/reagents/R = L.reagents
 			R.add_reagent(/decl/material/liquid/presyncopics, 0.5)
 
-/obj/item/holder/slug/attack(var/mob/target, var/mob/user)
+/obj/item/holder/slug/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	var/mob/living/simple_animal/hostile/slug/V = contents[1]
 	if(!V.stat && ishuman(target))
 		var/mob/living/carbon/human/H = target
-		if(!do_mob(user, H, 30))
-			return
-		V.attach(H)
-		qdel(src)
-		return
-	..()
+		if(do_mob(user, H, 30))
+			V.attach(H)
+			qdel(src)
+		return TRUE
+	return ..()

--- a/code/modules/mob_holder/_holder.dm
+++ b/code/modules/mob_holder/_holder.dm
@@ -120,14 +120,17 @@
 	for(var/mob/M in contents)
 		M.show_stripping_window(usr)
 
-/obj/item/holder/attack(mob/target, mob/user)
+/obj/item/holder/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+
 	// Devour on click on self with holder
 	if(target == user && isliving(user))
 		var/mob/living/M = user
 		for(var/mob/victim in src.contents)
 			M.devour(victim)
 		update_state()
-	..()
+		return TRUE
+
+	return ..()
 
 /obj/item/holder/proc/sync(var/mob/living/M)
 	SetName(M.name)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -380,7 +380,8 @@
 		if(owner)
 			owner.update_health()
 
-/obj/item/organ/attack(var/mob/target, var/mob/user)
+/obj/item/organ/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+
 	if(BP_IS_PROSTHETIC(src) || !istype(target) || !istype(user) || (user != target && user.a_intent == I_HELP))
 		return ..()
 

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -47,8 +47,8 @@
 	else
 		to_chat(user, SPAN_NOTICE("You're too far away to tell much more.."))
 
-/obj/item/hand_labeler/attack(mob/living/M, mob/living/user, target_zone, animate)
-	return //No attacking
+/obj/item/hand_labeler/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	return FALSE
 
 /obj/item/hand_labeler/afterattack(atom/movable/A, mob/user, proximity)
 	if(safety || !proximity || !istype(A) || A == loc)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -152,33 +152,32 @@
 	interact(user, readonly = TRUE)
 	return TRUE
 
-/obj/item/paper/attack(mob/living/carbon/M, mob/living/carbon/user)
+/obj/item/paper/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	var/target_zone = user.get_target_zone()
 	if(target_zone == BP_EYES)
 		user.visible_message(
-			SPAN_NOTICE("You show the paper to [M]."),
-			SPAN_NOTICE("[user] holds up a paper and shows it to [M].")
+			SPAN_NOTICE("You show the paper to [target]."),
+			SPAN_NOTICE("[user] holds up a paper and shows it to [target].")
 		)
-		M.examinate(src)
+		target.examinate(src)
 		return TRUE
 
 	target_zone = check_zone(target_zone)
-	if(M.get_organ_sprite_accessory_by_category(SAC_COSMETICS, target_zone))
-		var/mob/living/carbon/human/H = M
-		if(H == user)
+	if(target.get_organ_sprite_accessory_by_category(SAC_COSMETICS, target_zone))
+		if(target == user)
 			to_chat(user, SPAN_NOTICE("You wipe off the makeup with [src]."))
-			H.set_organ_sprite_accessory_by_category(null, SAC_COSMETICS, null, FALSE, FALSE, target_zone, FALSE)
+			target.set_organ_sprite_accessory_by_category(null, SAC_COSMETICS, null, FALSE, FALSE, target_zone, FALSE)
 			return TRUE
 		user.visible_message(
-			SPAN_NOTICE("\The [user] begins to wipe \the [H]'s makeup  off with \the [src]."),
-			SPAN_NOTICE("You begin to wipe off [H]'s makeup .")
+			SPAN_NOTICE("\The [user] begins to wipe \the [target]'s makeup  off with \the [src]."),
+			SPAN_NOTICE("You begin to wipe off [target]'s makeup .")
 		)
-		if(do_after(user, 10, H) && do_after(H, 10, check_holding = 0))	//user needs to keep their active hand, H does not.
+		if(do_after(user, 10, target) && do_after(target, 10, check_holding = 0))	//user needs to keep their active hand, H does not.
 			user.visible_message(
-				SPAN_NOTICE("\The [user] wipes \the [H]'s makeup  off with \the [src]."),
-				SPAN_NOTICE("You wipe off \the [H]'s makeup .")
+				SPAN_NOTICE("\The [user] wipes \the [target]'s makeup  off with \the [src]."),
+				SPAN_NOTICE("You wipe off \the [target]'s makeup .")
 			)
-		H.set_organ_sprite_accessory_by_category(null, SAC_COSMETICS, null, FALSE, FALSE, target_zone, FALSE)
+		target.set_organ_sprite_accessory_by_category(null, SAC_COSMETICS, null, FALSE, FALSE, target_zone, FALSE)
 		return TRUE
 
 	. = ..()

--- a/code/modules/paperwork/pen/pen.dm
+++ b/code/modules/paperwork/pen/pen.dm
@@ -34,17 +34,16 @@
 				TOOL_PROP_PEN_FONT   = pen_font)))
 	make_pen_description()
 
-/obj/item/pen/attack(atom/A, mob/user, target_zone)
+/obj/item/pen/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
-	if(isliving(A) && user.a_intent == I_HELP && target_zone == BP_HEAD)
-		var/mob/living/M = A
-		var/obj/item/organ/external/head/head = M.get_organ(BP_HEAD, /obj/item/organ/external/head)
+	if(user.a_intent == I_HELP && user.get_target_zone() == BP_HEAD)
+		var/obj/item/organ/external/head/head = target.get_organ(BP_HEAD, /obj/item/organ/external/head)
 		if(istype(head))
 			head.write_on(user, "[stroke_color_name] [medium_name]")
 			return TRUE
 
-	if(istype(A, /obj/item/organ/external/head))
-		var/obj/item/organ/external/head/head = A
+	if(istype(target, /obj/item/organ/external/head))
+		var/obj/item/organ/external/head/head = target
 		head.write_on(user, "[stroke_color_name] [medium_name]")
 		return TRUE
 

--- a/code/modules/paperwork/pen/reagent_pen.dm
+++ b/code/modules/paperwork/pen/reagent_pen.dm
@@ -12,27 +12,25 @@
 	create_reagents(30)
 	. = ..()
 
-/obj/item/pen/reagent/attack(mob/living/M, mob/living/user, var/target_zone)
+/obj/item/pen/reagent/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
-	if(!istype(M))
-		return
-
-	. = ..()
-
-	var/allow = M.can_inject(user, target_zone)
-	if(allow)
+	var/allow = target.can_inject(user, user.get_target_zone())
+	if(allow && user.a_intent == I_HELP)
 		if (allow == INJECTION_PORT)
-			if(M != user)
-				to_chat(user, SPAN_WARNING("You begin hunting for an injection port on \the [M]'s suit!"))
+			if(target != user)
+				to_chat(user, SPAN_WARNING("You begin hunting for an injection port on \the [target]'s suit!"))
 			else
 				to_chat(user, SPAN_NOTICE("You begin hunting for an injection port on your suit."))
-			if(!user.do_skilled(INJECTION_PORT_DELAY, SKILL_MEDICAL, M))
-				return
+			if(!user.do_skilled(INJECTION_PORT_DELAY, SKILL_MEDICAL, target))
+				return TRUE
 		if(reagents.total_volume)
-			if(M.reagents)
+			if(target.reagents)
 				var/contained_reagents = reagents.get_reagents()
-				var/trans = reagents.trans_to_mob(M, 30, CHEM_INJECT)
-				admin_inject_log(user, M, src, contained_reagents, trans)
+				var/trans = reagents.trans_to_mob(target, 30, CHEM_INJECT)
+				admin_inject_log(user, target, src, contained_reagents, trans)
+		return TRUE
+
+	. = ..()
 
 /*
  * Sleepy Pens

--- a/code/modules/paperwork/pen/retractable_pen.dm
+++ b/code/modules/paperwork/pen/retractable_pen.dm
@@ -28,10 +28,10 @@
 	if(pen_flag & PEN_FLAG_ACTIVE)
 		icon_state = "[icon_state]-on"
 
-/obj/item/pen/retractable/attack(atom/A, mob/user, target_zone)
+/obj/item/pen/retractable/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	if(!(pen_flag & PEN_FLAG_ACTIVE))
 		toggle()
-	..()
+	return ..()
 
 /obj/item/pen/retractable/attack_self(mob/user)
 	toggle()

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -229,8 +229,8 @@
 	else
 		icon_state = "[bis.base_icon_state]_off"
 
-/obj/item/camera/attack(mob/living/carbon/human/M, mob/user)
-	return
+/obj/item/camera/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	return FALSE
 
 /obj/item/camera/attack_self(mob/user)
 	if(film)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -535,24 +535,20 @@ By design, d1 is the smallest direction and d2 is the highest
 ///////////////////////////////////
 
 //you can use wires to heal robotics
-/obj/item/stack/cable_coil/attack(var/atom/A, var/mob/living/user, var/def_zone)
-	if(ishuman(A) && user.a_intent == I_HELP)
-		var/mob/living/carbon/human/H = A
+/obj/item/stack/cable_coil/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(ishuman(target) && user.a_intent == I_HELP)
+		var/mob/living/carbon/human/H = target
 		var/obj/item/organ/external/S = GET_EXTERNAL_ORGAN(H, user.get_target_zone())
-
-		if (!S) return
-		if(!BP_IS_PROSTHETIC(S) || user.a_intent != I_HELP)
+		if(!S || !BP_IS_PROSTHETIC(S) || user.a_intent != I_HELP)
 			return ..()
-
 		if(BP_IS_BRITTLE(S))
 			to_chat(user, SPAN_WARNING("\The [H]'s [S.name] is hard and brittle - \the [src] cannot repair it."))
-			return 1
-
+			return TRUE
 		var/use_amt = min(src.amount, CEILING(S.burn_dam/3), 5)
 		if(can_use(use_amt))
 			if(S.robo_repair(3*use_amt, BURN, "some damaged wiring", src, user))
-				src.use(use_amt)
-		return
+				use(use_amt)
+		return TRUE
 	return ..()
 
 /obj/item/stack/cable_coil/on_update_icon()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -230,18 +230,24 @@
 
 	Fire(A,user,params) //Otherwise, fire normally.
 
-/obj/item/gun/attack(atom/A, mob/living/user, def_zone)
-	if (A == user && user.get_target_zone() == BP_MOUTH && !mouthshoot)
+/obj/item/gun/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+
+	if (target == user && user.get_target_zone() == BP_MOUTH && !mouthshoot)
 		handle_suicide(user)
-	else if(user.a_intent != I_HURT && user.aiming && user.aiming.active) //if aim mode, don't pistol whip
-		if (user.aiming.aiming_at != A)
-			PreFire(A, user)
+		return TRUE
+	
+	if(user.a_intent != I_HURT && user.aiming && user.aiming.active) //if aim mode, don't pistol whip
+		if (user.aiming.aiming_at != target)
+			PreFire(target, user)
 		else
-			Fire(A, user, pointblank=1)
-	else if(user.a_intent == I_HURT) //point blank shooting
-		Fire(A, user, pointblank=1)
-	else
-		return ..() //Pistolwhippin'
+			Fire(target, user, pointblank=1)
+		return TRUE
+
+	if(user.a_intent == I_HURT) //point blank shooting
+		Fire(target, user, pointblank = TRUE)
+		return TRUE
+
+	return ..() //Pistolwhippin'
 
 /obj/item/gun/dropped(var/mob/living/user)
 	check_accidents(user)

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -60,30 +60,31 @@
 					reagent_volumes[T] = min(reagent_volumes[T] + 5, volume)
 	return 1
 
-/obj/item/chems/borghypo/attack(var/mob/living/M, var/mob/user, var/target_zone)
-	if(!istype(M))
-		return
+/obj/item/chems/borghypo/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
 	if(!reagent_volumes[reagent_ids[mode]])
-		to_chat(user, "<span class='warning'>The injector is empty.</span>")
-		return
+		to_chat(user, SPAN_WARNING("The injector is empty."))
+		return TRUE
 
-	var/allow = M.can_inject(user, target_zone)
+	var/allow = target.can_inject(user, user.get_target_zone())
 	if (allow)
 		if (allow == INJECTION_PORT)
-			user.visible_message(SPAN_WARNING("\The [user] begins hunting for an injection port on \the [M]'s suit!"))
-			if(!user.do_skilled(INJECTION_PORT_DELAY, SKILL_MEDICAL, M))
-				return
-		to_chat(user, "<span class='notice'>You inject [M] with the injector.</span>")
-		to_chat(M, "<span class='notice'>You feel a tiny prick!</span>")
+			user.visible_message(SPAN_WARNING("\The [user] begins hunting for an injection port on \the [target]'s suit!"))
+			if(!user.do_skilled(INJECTION_PORT_DELAY, SKILL_MEDICAL, target))
+				return TRUE
 
-		if(M.reagents)
+		to_chat(user,   SPAN_NOTICE("You inject \the [target] with the injector."))
+		to_chat(target, SPAN_NOTICE("You feel a tiny prick!"))
+
+		if(target.reagents)
 			var/t = min(amount_per_transfer_from_this, reagent_volumes[reagent_ids[mode]])
-			M.add_to_reagents(reagent_ids[mode], t)
+			target.add_to_reagents(reagent_ids[mode], t)
 			reagent_volumes[reagent_ids[mode]] -= t
-			admin_inject_log(user, M, src, reagent_ids[mode], t)
-			to_chat(user, "<span class='notice'>[t] units injected. [reagent_volumes[reagent_ids[mode]]] units remaining.</span>")
-	return
+			admin_inject_log(user, target, src, reagent_ids[mode], t)
+			to_chat(user, SPAN_NOTICE("[t] units injected. [reagent_volumes[reagent_ids[mode]]] units remaining."))
+		return TRUE
+
+	return ..()
 
 /obj/item/chems/borghypo/attack_self(mob/user) //Change the mode
 	var/t = ""
@@ -161,8 +162,8 @@
 		/decl/material/liquid/ethanol/coffee
 		)
 
-/obj/item/chems/borghypo/service/attack(var/mob/M, var/mob/user)
-	return
+/obj/item/chems/borghypo/service/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	return FALSE
 
 /obj/item/chems/borghypo/service/afterattack(var/obj/target, var/mob/user, var/proximity)
 	if(!proximity)

--- a/code/modules/reagents/reagent_containers/drinks.dm
+++ b/code/modules/reagents/reagent_containers/drinks.dm
@@ -28,8 +28,8 @@
 /obj/item/chems/drinks/attack_self(mob/user)
 	if(!ATOM_IS_OPEN_CONTAINER(src))
 		open(user)
-		return
-	attack(user, user)
+		return TRUE
+	return use_on_mob(user, user)
 
 /obj/item/chems/drinks/proc/open(mob/user)
 	if(!ATOM_IS_OPEN_CONTAINER(src))

--- a/code/modules/reagents/reagent_containers/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/drinks/bottle.dm
@@ -244,9 +244,10 @@
 	. = ..()
 	set_extension(src, /datum/extension/tool, list(TOOL_SCALPEL = TOOL_QUALITY_BAD))
 
-/obj/item/broken_bottle/attack(mob/living/carbon/M, mob/living/carbon/user)
-	playsound(loc, 'sound/weapons/bladeslice.ogg', 50, 1, -1)
-	return ..()
+/obj/item/broken_bottle/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	. = ..()
+	if(.)
+		playsound(loc, 'sound/weapons/bladeslice.ogg', 50, 1, -1)
 
 /obj/item/chems/drinks/bottle/gin
 	name = "Griffeater Gin"

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -58,10 +58,10 @@
 		plate = new plate(src)
 
 /obj/item/chems/food/attack_self(mob/user)
-	attack(user, user)
+	return use_on_mob(user, user)
 
 /obj/item/chems/food/dragged_onto(var/mob/user)
-	attack(user, user)
+	return use_on_mob(user, user)
 
 /obj/item/chems/food/examine(mob/user, distance)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/food/sandwich.dm
+++ b/code/modules/reagents/reagent_containers/food/sandwich.dm
@@ -84,19 +84,11 @@
 	var/obj/item/O = pick(contents)
 	to_chat(user, "<span class='warning'>You think you can see [O.name] in there.</span>")
 
-/obj/item/chems/food/csandwich/attack(mob/M, mob/user, def_zone)
-
-	var/obj/item/shard
-	for(var/obj/item/O in contents)
-		if(istype(O,/obj/item/shard))
-			shard = O
-			break
-
-	var/mob/living/H
-	if(isliving(M))
-		H = M
-
-	if(H && shard && M == user) //This needs a check for feeding the food to other people, but that could be abusable.
-		to_chat(H, "<span class='warning'>You lacerate your mouth on a [shard.name] in the sandwich!</span>")
-		H.take_damage(BRUTE, 5) //TODO: Target head if human.
-	..()
+/obj/item/chems/food/csandwich/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	var/obj/item/shard = locate() in get_contained_external_atoms() // grab early in case of qdele
+	. = ..()
+	if(. && target == user)
+		//This needs a check for feeding the food to other people, but that could be abusable.
+		if(shard) 
+			to_chat(target, SPAN_DANGER("You lacerate yourself on \a [shard] in \the [src]!"))
+			target.take_damage(BRUTE, 5) //TODO: Target head if human.

--- a/code/modules/reagents/reagent_containers/food/sliceable/pizza/pizza_box.dm
+++ b/code/modules/reagents/reagent_containers/food/sliceable/pizza/pizza_box.dm
@@ -40,7 +40,7 @@
 	. = ..()
 
 // Tossing a pizza around can have terrible effects...
-/obj/item/pizzabox/attack(mob/living/M, mob/living/user, var/target_zone)
+/obj/item/pizzabox/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	..()
 	return FALSE
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -64,9 +64,9 @@
 			atom_flags |= ATOM_FLAG_OPEN_CONTAINER
 		update_icon()
 
-/obj/item/chems/glass/attack(mob/M, mob/user, def_zone)
+/obj/item/chems/glass/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	if(force && !(item_flags & ITEM_FLAG_NO_BLUDGEON) && user.a_intent == I_HURT)
-		return	..()
+		return ..()
 	return FALSE
 
 /obj/item/chems/glass/afterattack(var/obj/target, var/mob/user, var/proximity)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -36,48 +36,47 @@
 	icon_state = get_world_inventory_state()
 	. = ..()
 
-/obj/item/chems/hypospray/attack(mob/living/M, mob/user)
-	if(!reagents.total_volume)
-		to_chat(user, SPAN_WARNING("[src] is empty."))
-		return
-	if (!istype(M))
-		return
+/obj/item/chems/hypospray/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
-	var/allow = M.can_inject(user, check_zone(user.get_target_zone(), M))
+	if(!reagents?.total_volume)
+		to_chat(user, SPAN_WARNING("\The [src] is empty."))
+		return TRUE
+
+	var/allow = target.can_inject(user, check_zone(user.get_target_zone(), target))
 	if(!allow)
-		return
+		return TRUE
 
 	if (allow == INJECTION_PORT)
-		if(M != user)
-			user.visible_message(SPAN_WARNING("\The [user] begins hunting for an injection port on \the [M]'s suit!"))
+		if(target != user)
+			user.visible_message(SPAN_WARNING("\The [user] begins hunting for an injection port on \the [target]'s suit!"))
 		else
 			to_chat(user, SPAN_NOTICE("You begin hunting for an injection port on your suit."))
-		if(!user.do_skilled(INJECTION_PORT_DELAY, SKILL_MEDICAL, M))
-			return
+		if(!user.do_skilled(INJECTION_PORT_DELAY, SKILL_MEDICAL, target))
+			return TRUE
 
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
-	user.do_attack_animation(M)
+	user.do_attack_animation(target)
 
-	if(user != M && !M.incapacitated() && time) // you're injecting someone else who is concious, so apply the device's intrisic delay
-		to_chat(user, SPAN_WARNING("\The [user] is trying to inject \the [M] with \the [name]."))
-		if(!user.do_skilled(time, SKILL_MEDICAL, M))
-			return
+	if(user != target && !target.incapacitated() && time) // you're injecting someone else who is concious, so apply the device's intrisic delay
+		to_chat(user, SPAN_WARNING("\The [user] is trying to inject \the [target] with \the [name]."))
+		if(!user.do_skilled(time, SKILL_MEDICAL, target))
+			return TRUE
 
 	if(single_use && reagents.total_volume <= 0) // currently only applies to autoinjectors
 		atom_flags &= ~ATOM_FLAG_OPEN_CONTAINER // Prevents autoinjectors to be refilled.
 
-	to_chat(user, SPAN_NOTICE("You inject [M] with [src]."))
-	to_chat(M, SPAN_NOTICE("You feel a tiny prick!"))
+	to_chat(user, SPAN_NOTICE("You inject [target] with [src]."))
+	to_chat(target, SPAN_NOTICE("You feel a tiny prick!"))
 	playsound(src, 'sound/effects/hypospray.ogg',25)
-	user.visible_message(SPAN_WARNING("[user] injects [M] with [src]."))
+	user.visible_message(SPAN_WARNING("[user] injects [target] with [src]."))
 
-	if(M.reagents)
+	if(target.reagents)
 		var/contained = REAGENT_LIST(src)
-		var/trans = reagents.trans_to_mob(M, amount_per_transfer_from_this, CHEM_INJECT)
-		admin_inject_log(user, M, src, contained, trans)
+		var/trans = reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_INJECT)
+		admin_inject_log(user, target, src, contained, trans)
 		to_chat(user, SPAN_NOTICE("[trans] unit\s injected. [reagents.total_volume] unit\s remaining in \the [src]."))
 
-	return
+	return TRUE
 
 ////////////////////////////////////////////////////////////////////////////////
 /// VIAL HYPOSPRAY
@@ -200,9 +199,10 @@
 	. = ..()
 	update_icon()
 
-/obj/item/chems/hypospray/autoinjector/attack(mob/M as mob, mob/user as mob)
+/obj/item/chems/hypospray/autoinjector/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	. = ..()
-	update_icon()
+	if(.)
+		update_icon()
 
 /obj/item/chems/hypospray/autoinjector/on_update_icon()
 	. = ..()

--- a/code/modules/reagents/reagent_containers/inhaler.dm
+++ b/code/modules/reagents/reagent_containers/inhaler.dm
@@ -40,13 +40,10 @@
 	if(reagents?.total_volume > 0)
 		add_overlay("[icon_state]_reagents")
 
-/obj/item/chems/inhaler/attack(var/mob/living/carbon/human/target, var/mob/user, var/proximity)
+/obj/item/chems/inhaler/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
-	if (!istype(target))
+	if (!ishuman(target))
 		return ..()
-
-	if(!proximity)
-		return TRUE
 
 	if(ATOM_IS_OPEN_CONTAINER(src))
 		to_chat(user, SPAN_NOTICE("You must secure the reagents inside \the [src] before using it!"))
@@ -57,36 +54,35 @@
 		return TRUE
 
 	// This properly handles mouth coverage/presence, but should probably be replaced later.
-	if(user == target)
-		if(!target.can_eat(src))
+	var/mob/living/carbon/human/H = target
+	if(user == H)
+		if(!H.can_eat(src))
 			return TRUE
-	else
-		if(!target.can_force_feed(user, src))
-			return TRUE
+	else if(!H.can_force_feed(user, src))
+		return TRUE
 
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
-	user.do_attack_animation(target)
+	user.do_attack_animation(H)
 
-	if(user == target)
+	if(user == H)
 		user.visible_message(SPAN_NOTICE("\The [user] inhales from \the [src]."), SPAN_NOTICE("You stick the \the [src] in your mouth and press the injection button."))
 	else
-		user.visible_message(SPAN_WARNING("\The [user] attempts to administer \the [src] to \the [target]..."), SPAN_NOTICE("You attempt to administer \the [src] to \the [target]..."))
-		if (!do_after(user, 1 SECONDS, target))
+		user.visible_message(SPAN_WARNING("\The [user] attempts to administer \the [src] to \the [H]..."), SPAN_NOTICE("You attempt to administer \the [src] to \the [H]..."))
+		if (!do_after(user, 1 SECONDS, H))
 			to_chat(user, SPAN_NOTICE("You and the target need to be standing still in order to inject \the [src]."))
 			return TRUE
 
-		user.visible_message(SPAN_NOTICE("\The [user] administers \the [src] to \the [target]."), SPAN_NOTICE("You stick \the [src] in \the [target]'s mouth and press the injection button."))
+		user.visible_message(SPAN_NOTICE("\The [user] administers \the [src] to \the [H]."), SPAN_NOTICE("You stick \the [src] in \the [H]'s mouth and press the injection button."))
 
 	var/contained = REAGENT_LIST(src)
-	var/trans = reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_INHALE)
+	var/trans = reagents.trans_to_mob(H, amount_per_transfer_from_this, CHEM_INHALE)
 	if(trans)
-		admin_inject_log(user, target, src, contained, trans)
+		admin_inject_log(user, H, src, contained, trans)
 		playsound(src.loc, 'sound/effects/hypospray.ogg', 50, 1)
 		to_chat(user, SPAN_NOTICE("[trans] units administered. [reagents.total_volume] units remaining in \the [src]."))
 		used = TRUE
 
 	update_icon()
-
 	return TRUE
 
 /obj/item/chems/inhaler/attack_self(mob/user)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -43,10 +43,10 @@
 		color = null
 
 /obj/item/chems/pill/attack_self(mob/user)
-	attack(user, user)
+	return use_on_mob(user, user)
 
 /obj/item/chems/pill/dragged_onto(var/mob/user)
-	attack(user, user)
+	return use_on_mob(user, user)
 
 /obj/item/chems/pill/afterattack(obj/target, mob/user, proximity)
 	if(proximity && ATOM_IS_OPEN_CONTAINER(target) && target.reagents)

--- a/code/modules/reagents/storage/pill_bottle.dm
+++ b/code/modules/reagents/storage/pill_bottle.dm
@@ -52,7 +52,7 @@
 	if(remove_from_storage(pill, user))
 		if(target_mouth)
 			user.visible_message(SPAN_NOTICE("\The [user] pops a pill from \the [src]."))
-			pill.attack(user, user)
+			pill.use_on_mob(user, user)
 		else
 			if(user.put_in_inactive_hand(pill))
 				to_chat(user, SPAN_NOTICE("You take \the [pill] out of \the [src]."))

--- a/code/modules/spells/hand/hand_item.dm
+++ b/code/modules/spells/hand/hand_item.dm
@@ -24,11 +24,12 @@ Basically: I can use it to target things where I click. I can then pass these ta
 /obj/item/magic_hand/get_storage_cost()
 	return ITEM_SIZE_NO_CONTAINER
 
-/obj/item/magic_hand/attack(var/mob/living/M, var/mob/living/user)
-	if(hand_spell && hand_spell.valid_target(M, user))
-		fire_spell(M, user)
-		return 0
-	return 1
+// These return values do not look correct...
+/obj/item/magic_hand/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(hand_spell && hand_spell.valid_target(target, user))
+		fire_spell(target, user)
+		return FALSE
+	return TRUE
 
 /obj/item/magic_hand/proc/fire_spell(var/atom/A, mob/living/user)
 	if(!hand_spell) //no spell? Die.

--- a/code/modules/xenoarcheaology/tools/ano_device_battery.dm
+++ b/code/modules/xenoarcheaology/tools/ano_device_battery.dm
@@ -191,14 +191,14 @@
 	STOP_PROCESSING(SSobj, src)
 	. = ..()
 
-/obj/item/anodevice/attack(mob/living/M, mob/living/user, def_zone)
-	if (!istype(M))
-		return
-
+/obj/item/anodevice/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if (!istype(target))
+		return ..()
 	if(activated && inserted_battery?.battery_effect?.operation_type == EFFECT_TOUCH)
-		inserted_battery.battery_effect.DoEffectTouch(M)
+		inserted_battery.battery_effect.DoEffectTouch(target)
 		inserted_battery.use_power(energy_consumed_on_touch)
-		user.visible_message("<span class='notice'>[user] taps [M] with [src], and it shudders on contact.</span>")
-		admin_attack_log(user, M, "Tapped their victim with \a [src] (EFFECT: [inserted_battery.battery_effect.name])", "Was tapped by \a [src] (EFFECT: [inserted_battery.battery_effect.name])", "used \a [src] (EFFECT: [inserted_battery.battery_effect.name]) to tap")
+		user.visible_message(SPAN_NOTICE("\The [user] taps [target] with \the [src], and it shudders on contact."))
+		admin_attack_log(user, target, "Tapped their victim with \a [src] (EFFECT: [inserted_battery.battery_effect.name])", "Was tapped by \a [src] (EFFECT: [inserted_battery.battery_effect.name])", "used \a [src] (EFFECT: [inserted_battery.battery_effect.name]) to tap")
 	else
-		user.visible_message("<span class='notice'>[user] taps [M] with [src], but nothing happens.</span>")
+		user.visible_message(SPAN_NOTICE("\The [user] taps \the [target] with \the [src], but nothing happens."))
+	return TRUE

--- a/mods/content/psionics/system/psionics/equipment/psipower.dm
+++ b/mods/content/psionics/system/psionics/equipment/psipower.dm
@@ -18,8 +18,8 @@
 	sound_to(owner, 'sound/effects/psi/power_fail.ogg')
 	. = ..()
 
-/obj/item/ability/psionic/attack(var/mob/living/M, var/mob/living/user, var/target_zone)
-	if(M.do_psionics_check(max(force, maintain_cost), user))
+/obj/item/ability/psionic/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(target.do_psionics_check(max(force, maintain_cost), user))
 		to_chat(user, SPAN_WARNING("\The [src] flickers violently out of phase!"))
 		return TRUE
 	. = ..()

--- a/mods/content/xenobiology/slime/items_potion.dm
+++ b/mods/content/xenobiology/slime/items_potion.dm
@@ -8,21 +8,22 @@
 	var/slime_type = /mob/living/simple_animal/slime
 	var/can_tame_adults = FALSE
 
-/obj/item/slime_potion/attack(mob/living/slime/M, mob/user)
-	if(isslime(M))
-		if(M.is_adult && can_tame_adults)
+/obj/item/slime_potion/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(isslime(target))
+		var/mob/living/slime/slime = target
+		if(slime.is_adult && can_tame_adults)
 			to_chat(user, SPAN_WARNING("Only baby slimes can be tamed!"))
 			return TRUE
-		if(M.stat)
-			to_chat(user, SPAN_WARNING("\The [M] is dead!"))
+		if(slime.stat)
+			to_chat(user, SPAN_WARNING("\The [slime] is dead!"))
 			return TRUE
-		if(M.client)
-			to_chat(user, SPAN_WARNING("\The [M] resists!"))
+		if(slime.client)
+			to_chat(user, SPAN_WARNING("\The [slime] resists!"))
 			return TRUE
-		var/mob/living/simple_animal/slime/pet = new slime_type(M.loc, M.slime_type)
+		var/mob/living/simple_animal/slime/pet = new slime_type(slime.loc, slime.slime_type)
 		to_chat(user, SPAN_NOTICE("You feed \the [pet] the potion, removing its powers and calming it."))
 		pet.prompt_rename(user)
-		qdel(M)
+		qdel(slime)
 		qdel(src)
 		return TRUE
 	. = ..()

--- a/mods/content/xenobiology/slime/items_steroid.dm
+++ b/mods/content/xenobiology/slime/items_steroid.dm
@@ -7,20 +7,22 @@
 	obj_flags = OBJ_FLAG_HOLLOW
 	var/grant_cores = 3
 
-/obj/item/slime_steroid/attack(mob/living/slime/M, mob/user)
-	if(!isslime(M))
+/obj/item/slime_steroid/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(!isslime(target))
 		return ..()
-	if(M.is_adult)
+
+	var/mob/living/slime/slime = target
+	if(slime.is_adult)
 		to_chat(user, SPAN_WARNING("Only baby slimes can use \the [src]!"))
 		return TRUE
-	if(M.stat == DEAD)
-		to_chat(user, SPAN_WARNING("\The [M] is dead!"))
+	if(slime.stat == DEAD)
+		to_chat(user, SPAN_WARNING("\The [slime] is dead!"))
 		return TRUE
-	if(M.cores >= grant_cores)
-		to_chat(user, SPAN_WARNING("\The [M] already has the maximum amount of cores!"))
+	if(slime.cores >= grant_cores)
+		to_chat(user, SPAN_WARNING("\The [slime] already has the maximum amount of cores!"))
 		return TRUE
 
-	to_chat(user, SPAN_NOTICE("You feed \the [src] to \the [M] and it suddenly grows two extra cores."))
-	M.cores = grant_cores
+	to_chat(user, SPAN_NOTICE("You feed \the [src] to \the [slime] and it suddenly grows two extra cores."))
+	slime.cores = grant_cores
 	qdel(src)
 	return TRUE


### PR DESCRIPTION
## Description of changes
- Renamed `attack()` to `use_on_mob()` and removed the zone parameter.
- Standardize parameters to `mob/living/target` and `mob/living/user`.
- Add return values and generally clean up the procs.

## Why and what will this PR improve
Standardized return value, standard parameters, less carbon types.

## Authorship
Myself.

## Changelog
Nothing player-facing.