### PR TITLE
Allowing maps to override the presented/available skills.

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -81,10 +81,7 @@ SUBSYSTEM_DEF(jobs)
 					if((ASSIGNMENT_ROBOT in J.event_categories) || (ASSIGNMENT_COMPUTER in J.event_categories))
 						J.total_positions = 0
 
-	// Init skills.
-	if(!global.skills.len)
-		GET_DECL(/decl/hierarchy/skill)
-	if(!global.skills.len)
+	if(!length(global.using_map.get_available_skills()))
 		log_error("<span class='warning'>Error setting up job skill requirements, no skill datums found!</span>")
 
 	// Update title and path tracking, submap list, etc.

--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -43,7 +43,7 @@ SUBSYSTEM_DEF(supply)
 	var/decl/hierarchy/supply_pack/root = GET_DECL(/decl/hierarchy/supply_pack)
 	for(var/decl/hierarchy/supply_pack/sp in root.children)
 		if(sp.is_category())
-			for(var/decl/hierarchy/supply_pack/spc in sp.get_descendents())
+			for(var/decl/hierarchy/supply_pack/spc in sp.get_descendants())
 				spc.setup()
 				master_supply_list += spc
 				CHECK_TICK

--- a/code/datums/hierarchy.dm
+++ b/code/datums/hierarchy.dm
@@ -19,13 +19,13 @@
 /decl/hierarchy/proc/is_category()
 	return length(children)
 
-/decl/hierarchy/proc/get_descendents()
+/decl/hierarchy/proc/get_descendants()
 	if(!children)
 		return
 	. = children.Copy()
 	for(var/decl/hierarchy/child in children)
 		if(child.children)
-			. |= child.get_descendents()
+			. |= child.get_descendants()
 
 /decl/hierarchy/dd_SortValue()
 	return name

--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -234,7 +234,7 @@
 	var/datum/job/job = SSjobs.get_by_title(new_record.get_job())
 	if(job)
 		var/skills = list()
-		for(var/decl/hierarchy/skill/S in global.skills)
+		for(var/decl/hierarchy/skill/S in global.using_map.get_available_skills())
 			var/level = job.min_skill[S.type]
 			if(prob(10))
 				level = min(rand(1,3), job.max_skill[S.type])

--- a/code/game/objects/items/books/skill/_skill_custom.dm
+++ b/code/game/objects/items/books/skill/_skill_custom.dm
@@ -132,7 +132,7 @@
 
 	//Choosing the skill
 	var/list/skill_choices = list()
-	for(var/decl/hierarchy/skill/S in global.skills)
+	for(var/decl/hierarchy/skill/S in global.using_map.get_available_skills())
 		if(user.skill_check(S.type, SKILL_BASIC))
 			LAZYADD(skill_choices, S)
 	var/decl/hierarchy/skill/skill_choice = input(user, "What subject does your textbook teach?", "Textbook skill selection") as null|anything in skill_choices

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -80,8 +80,6 @@ var/global/list/time_prefs_fixed = list()
 	QDEL_LIST_ASSOC_VAL(char_render_holders)
 
 /datum/preferences/proc/setup()
-	if(!length(global.skills))
-		GET_DECL(/decl/hierarchy/skill)
 	player_setup = new(src)
 	gender = pick(MALE, FEMALE)
 	real_name = get_random_name()

--- a/code/modules/codex/categories/category_skills.dm
+++ b/code/modules/codex/categories/category_skills.dm
@@ -3,7 +3,7 @@
 	desc = "Certifiable skills."
 
 /decl/codex_category/skills/Populate()
-	for(var/decl/hierarchy/skill/skill in global.skills)
+	for(var/decl/hierarchy/skill/skill in global.using_map.get_available_skills())
 		var/list/skill_info = list()
 		if(skill.prerequisites)
 			var/list/reqs = list()

--- a/code/modules/mob/living/silicon/robot/modules/module_illegal.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_illegal.dm
@@ -17,7 +17,7 @@
 	var/id
 
 /obj/item/robot_module/syndicate/Initialize()
-	for(var/decl/hierarchy/skill/skill in global.skills)
+	for(var/decl/hierarchy/skill/skill in global.using_map.get_available_skills())
 		skills[skill.type] = SKILL_EXPERT
 	. = ..()
 

--- a/code/modules/mob/skills/skill.dm
+++ b/code/modules/mob/skills/skill.dm
@@ -1,5 +1,3 @@
-var/global/list/skills = list()
-
 /decl/hierarchy/skill
 
 	name = "None"                         // Name of the skill. This is what the player sees.
@@ -31,13 +29,6 @@ var/global/list/skills = list()
 
 /decl/hierarchy/skill/proc/update_special_effects(mob/mob, level)
 	return
-
-/decl/hierarchy/skill/Initialize()
-	. = ..()
-	GET_DECL(/decl/hierarchy/skill) // Make sure the full skill decl list is populated.
-	if(INSTANCE_IS_ABSTRACT(src))
-		for(var/decl/hierarchy/skill/C in children)
-			global.skills |= C.get_descendents()
 
 /decl/hierarchy/skill/dd_SortValue()
 	return sort_priority

--- a/code/modules/mob/skills/skill_ui.dm
+++ b/code/modules/mob/skills/skill_ui.dm
@@ -52,21 +52,34 @@
 	.["hide_unskilled"] = hide_unskilled
 
 	var/list/skill_data = list()
+	var/list/available_skills = global.using_map.get_available_skills()
 	var/decl/hierarchy/skill/skill = GET_DECL(/decl/hierarchy/skill)
+
 	for(var/decl/hierarchy/skill/V in skill.children)
+
 		var/list/skill_cat = list()
-		skill_cat["name"] = V.name
 		var/list/skills_in_cat = list()
+
 		for(var/decl/hierarchy/skill/S in V.children)
+
+			if(!(S in available_skills))
+				continue
+
 			var/offset = S.prerequisites ? S.prerequisites[S.parent.type] - 1 : 0
 			if(hide_unskilled && (get_value(S.type) + offset == SKILL_MIN))
 				continue
+
 			skills_in_cat += list(get_nano_row(S))
 			for(var/decl/hierarchy/skill/perk in S.children)
+				if(!(perk in available_skills))
+					continue
 				skills_in_cat += list(get_nano_row(perk))
+
 		if(length(skills_in_cat))
+			skill_cat["name"] = V.name
 			skill_cat["skills"] = skills_in_cat
 			skill_data += list(skill_cat)
+
 	.["skills_by_cat"] = skill_data
 
 /datum/skillset/proc/get_nano_row(var/decl/hierarchy/skill/S)
@@ -142,7 +155,7 @@ The generic antag version.
 			return 1
 		var/level = text2num(href_list["add_skill"])
 		var/list/choices = list()
-		for(var/decl/hierarchy/skill/S in global.skills)
+		for(var/decl/hierarchy/skill/S in global.using_map.get_available_skills())
 			if(can_select(S.type, level))
 				choices[S.name] = S.type
 		var/choice = input(usr, "Which skill would you like to add?", "Add Skill") as null|anything in choices

--- a/code/modules/mob/skills/skill_verbs.dm
+++ b/code/modules/mob/skills/skill_verbs.dm
@@ -68,7 +68,7 @@ Robots and antags can instruct.
 /datum/skill_verb/instruct/should_see_verb()
 	if(!..())
 		return
-	for(var/decl/hierarchy/skill/S in global.skills)
+	for(var/decl/hierarchy/skill/S in global.using_map.get_available_skills())
 		if(skillset.owner.skill_check(S.type, SKILL_EXPERT))
 			return 1
 
@@ -94,7 +94,7 @@ Robots and antags can instruct.
 	if(!get_options)
 		. = TRUE
 	else
-		for(var/decl/hierarchy/skill/S in global.skills)
+		for(var/decl/hierarchy/skill/S in global.using_map.get_available_skills())
 			if(!target.skill_check(S.type, SKILL_BASIC) && skill_check(S.type, SKILL_EXPERT))
 				LAZYSET(., S.name, S)
 

--- a/code/modules/mob/skills/skillset.dm
+++ b/code/modules/mob/skills/skillset.dm
@@ -61,7 +61,7 @@ var/global/list/all_skill_verbs
 /datum/skillset/proc/update_special_effects()
 	if(!owner)
 		return
-	for(var/decl/hierarchy/skill/skill in global.skills)
+	for(var/decl/hierarchy/skill/skill in global.using_map.get_available_skills())
 		skill.update_special_effects(owner, get_value(skill.type))
 
 /datum/skillset/proc/obtain_from_client(datum/job/job, client/given_client, override = 0)
@@ -75,7 +75,7 @@ var/global/list/all_skill_verbs
 	var/allocation = given_client.prefs.skills_allocated[job] || list()
 	skill_list = list()
 
-	for(var/decl/hierarchy/skill/S in global.skills)
+	for(var/decl/hierarchy/skill/S in global.using_map.get_available_skills())
 		var/min = job ? given_client.prefs.get_min_skill(job, S) : SKILL_MIN
 		skill_list[S.type] = min + (allocation[S] || 0)
 	on_levels_change()

--- a/code/modules/modular_computers/file_system/programs/generic/supply.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/supply.dm
@@ -320,7 +320,7 @@
 			continue // No children
 		category_names.Add(sp.name)
 		var/list/category[0]
-		for(var/decl/hierarchy/supply_pack/spc in sp.get_descendents())
+		for(var/decl/hierarchy/supply_pack/spc in sp.get_descendants())
 			if((spc.hidden || spc.contraband || !spc.sec_available()) && !emagged)
 				continue
 			category.Add(list(list(

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -116,7 +116,7 @@ var/global/arrest_security_status =  "Arrest"
 
 	if(H)
 		var/skills = list()
-		for(var/decl/hierarchy/skill/S in global.skills)
+		for(var/decl/hierarchy/skill/S in global.using_map.get_available_skills())
 			var/level = H.get_skill_value(S.type)
 			if(level > SKILL_NONE)
 				skills += "[S.name], [S.levels[level]]"

--- a/maps/~mapsystem/map_skills.dm
+++ b/maps/~mapsystem/map_skills.dm
@@ -1,0 +1,23 @@
+/datum/map
+	var/list/_available_skills
+
+// Broken into a proc to allow maps to override the general skillset.
+/datum/map/proc/get_available_skill_types()
+	. = list()
+	for(var/skill_type in decls_repository.get_decls_of_type(/decl/hierarchy/skill))
+		. += skill_type
+
+/datum/map/proc/build_available_skills()
+	_available_skills = list()
+	for(var/skill_type in get_available_skill_types())
+		var/decl/hierarchy/skill/skill = GET_DECL(skill_type)
+		if(INSTANCE_IS_ABSTRACT(skill))
+			for(var/decl/hierarchy/skill/child in skill.children)
+				_available_skills |= child.get_descendants()
+		else
+			_available_skills |= skill
+
+/datum/map/proc/get_available_skills()
+	if(!_available_skills)
+		build_available_skills()
+	return _available_skills

--- a/nebula.dme
+++ b/nebula.dme
@@ -3803,6 +3803,7 @@
 #include "maps\tradeship\tradeship_define.dm"
 #include "maps\~mapsystem\map_preferences.dm"
 #include "maps\~mapsystem\map_ranks.dm"
+#include "maps\~mapsystem\map_skills.dm"
 #include "maps\~mapsystem\maps.dm"
 #include "maps\~mapsystem\maps_announcements.dm"
 #include "maps\~mapsystem\maps_antagonism.dm"


### PR DESCRIPTION
## Description of changes
- Replaces `global.skills` with a list on `global.using_map`.
- Adds checking to the various skill hierarchy iteration blocks to skip unavailable skills.

## Why and what will this PR improve
Allows overriding skills on maps like Shaded Hills.

## Authorship
Myself.