### PR TITLE
Adding temperature_damage_threshold and removing use of material melting points.

### DIFF
--- a/code/_onclick/hud/screen/screen_exosuit.dm
+++ b/code/_onclick/hud/screen/screen_exosuit.dm
@@ -381,7 +381,7 @@
 	var/modifiers = params2list(params)
 	if(modifiers["shift"])
 		if(owner.material)
-			user.show_message(SPAN_NOTICE("Your suit's safe operating limit ceiling is [(celsius ? "[owner.material.melting_point - T0C] °C" : "[owner.material.melting_point] K" )]."), VISIBLE_MESSAGE)
+			user.show_message(SPAN_NOTICE("Your suit's safe operating limit ceiling is [(celsius ? "[owner.material.temperature_damage_threshold - T0C] °C" : "[owner.material.temperature_damage_threshold] K" )]."), VISIBLE_MESSAGE)
 		return TRUE
 	if(modifiers["ctrl"])
 		celsius = !celsius
@@ -390,7 +390,7 @@
 	if(owner.body && owner.body.diagnostics?.is_functional() && owner.loc)
 		user.show_message(SPAN_NOTICE("The life support panel blinks several times as it updates:"), VISIBLE_MESSAGE)
 		user.show_message(SPAN_NOTICE("Chassis heat probe reports temperature of [(celsius ? "[owner.bodytemperature - T0C] °C" : "[owner.bodytemperature] K" )]."), VISIBLE_MESSAGE)
-		if(owner.material.melting_point < owner.bodytemperature)
+		if(owner.material.temperature_damage_threshold < owner.bodytemperature)
 			user.show_message(SPAN_WARNING("Warning: Current chassis temperature exceeds operating parameters."), VISIBLE_MESSAGE)
 		var/air_contents = owner.loc.return_air()
 		if(!air_contents)
@@ -405,7 +405,7 @@
 	//Relative value of heat
 	var/mob/living/exosuit/owner = get_owning_exosuit()
 	if(istype(owner) && owner.body && owner.body.diagnostics?.is_functional() && gauge_needle)
-		var/value = clamp(owner.bodytemperature / (owner.material.melting_point * 1.55), 0, 1)
+		var/value = clamp(owner.bodytemperature / (owner.material.temperature_damage_threshold * 1.55), 0, 1)
 		var/matrix/rot_matrix = matrix()
 		rot_matrix.Turn(Interpolate(-90, 90, value))
 		rot_matrix.Translate(0, -2)

--- a/code/game/objects/item_melting.dm
+++ b/code/game/objects/item_melting.dm
@@ -14,7 +14,7 @@
 	var/list/meltable_materials
 	for(var/mat in matter)
 		var/decl/material/melt_material = GET_DECL(mat)
-		if(!isnull(melt_material.melting_point) && temperature >= melt_material.melting_point)
+		if(!isnull(melt_material.temperature_damage_threshold) && temperature >= melt_material.temperature_damage_threshold)
 			LAZYDISTINCTADD(meltable_materials, melt_material)
 	if(length(meltable_materials))
 		. = null // Don't return PROCESS_KILL here.

--- a/code/game/objects/item_melting.dm
+++ b/code/game/objects/item_melting.dm
@@ -14,7 +14,7 @@
 	var/list/meltable_materials
 	for(var/mat in matter)
 		var/decl/material/melt_material = GET_DECL(mat)
-		if(!isnull(melt_material.temperature_damage_threshold) && temperature >= melt_material.temperature_damage_threshold)
+		if(!isnull(melt_material.melting_point) && temperature >= melt_material.melting_point)
 			LAZYDISTINCTADD(meltable_materials, melt_material)
 	if(length(meltable_materials))
 		. = null // Don't return PROCESS_KILL here.

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -248,7 +248,7 @@
 
 /obj/structure/grille/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(!destroyed)
-		if(exposed_temperature > material.melting_point)
+		if(exposed_temperature > material.temperature_damage_threshold)
 			take_damage(1)
 	..()
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -449,10 +449,10 @@
 			add_overlay(I)
 
 /obj/structure/window/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	var/melting_point = material.melting_point
+	var/damage_point = material.temperature_damage_threshold
 	if(reinf_material)
-		melting_point += 0.25*reinf_material.melting_point
-	if(exposed_temperature > melting_point)
+		damage_point += 0.25*reinf_material.temperature_damage_threshold
+	if(exposed_temperature > damage_point)
 		hit(damage_per_fire_tick, 0)
 	..()
 

--- a/code/game/turfs/simulated/_wall.dm
+++ b/code/game/turfs/simulated/_wall.dm
@@ -208,8 +208,8 @@ var/global/list/wall_fullblend_objects = list(
 
 /turf/simulated/wall/adjacent_fire_act(turf/adj_turf, datum/gas_mixture/adj_air, adj_temp, adj_volume)
 	burn(adj_temp)
-	if(adj_temp > material.melting_point)
-		take_damage(log(RAND_F(0.9, 1.1) * (adj_temp - material.melting_point)))
+	if(adj_temp > material.temperature_damage_threshold)
+		take_damage(log(RAND_F(0.9, 1.1) * (adj_temp - material.temperature_damage_threshold)))
 	return ..()
 
 /turf/simulated/wall/proc/get_dismantle_stack_type()

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -348,6 +348,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 		solvent_melt_dose            = 0
 		solvent_max_damage           = 0
 		slipperiness                 = 0
+		bakes_into_at_temperature    = null
 		ignition_point               = null
 		melting_point                = null
 		boiling_point                = null
@@ -356,7 +357,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 		burn_product                 = null
 		vapor_products               = null
 	else if(isnull(temperature_damage_threshold))
-		for(var/value in list(ignition_point, melting_point, boiling_point))
+		for(var/value in list(ignition_point, melting_point, boiling_point, heating_point, bakes_into_at_temperature))
 			if(!isnull(value) && (isnull(temperature_damage_threshold) || temperature_damage_threshold > value))
 				temperature_damage_threshold = value
 

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -126,6 +126,8 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	var/melting_point = 1800
 	/// K, point that material will become a gas.
 	var/boiling_point = 3000
+	/// Set automatically if null based on ignition, boiling and melting point
+	var/temperature_damage_threshold
 	/// kJ/kg, enthalpy of vaporization
 	var/latent_heat = 7000
 	/// kg/mol
@@ -330,28 +332,33 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 
 	// Null/clear a bunch of physical vars as this material is fake.
 	if(holographic)
-		shard_type             = SHARD_NONE
-		conductive             = 0
-		hidden_from_codex      = TRUE
-		value                  = 0
-		exoplanet_rarity_plant = MAT_RARITY_NOWHERE
-		exoplanet_rarity_gas   = MAT_RARITY_NOWHERE
-		dissolves_into         = null
-		dissolves_in           = MAT_SOLVENT_IMMUNE
-		solvent_power          = MAT_SOLVENT_NONE
-		heating_products       = null
-		chilling_products      = null
-		heating_point          = null
-		chilling_point         = null
-		solvent_melt_dose      = 0
-		solvent_max_damage     = 0
-		slipperiness           = 0
-		ignition_point         = null
-		melting_point          = null
-		boiling_point          = null
-		accelerant_value       = FUEL_VALUE_NONE
-		burn_product           = null
-		vapor_products         = null
+		shard_type                   = SHARD_NONE
+		conductive                   = 0
+		hidden_from_codex            = TRUE
+		value                        = 0
+		exoplanet_rarity_plant       = MAT_RARITY_NOWHERE
+		exoplanet_rarity_gas         = MAT_RARITY_NOWHERE
+		dissolves_into               = null
+		dissolves_in                 = MAT_SOLVENT_IMMUNE
+		solvent_power                = MAT_SOLVENT_NONE
+		heating_products             = null
+		chilling_products            = null
+		heating_point                = null
+		chilling_point               = null
+		solvent_melt_dose            = 0
+		solvent_max_damage           = 0
+		slipperiness                 = 0
+		ignition_point               = null
+		melting_point                = null
+		boiling_point                = null
+		temperature_damage_threshold = INFINITY
+		accelerant_value             = FUEL_VALUE_NONE
+		burn_product                 = null
+		vapor_products               = null
+	else if(isnull(temperature_damage_threshold))
+		for(var/value in list(ignition_point, melting_point, boiling_point))
+			if(!isnull(value) && (isnull(temperature_damage_threshold) || temperature_damage_threshold > value))
+				temperature_damage_threshold = value
 
 	if(!shard_icon)
 		shard_icon = shard_type

--- a/code/modules/materials/definitions/solids/materials_solid_organic.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_organic.dm
@@ -3,6 +3,8 @@
 	ignition_point = T0C+500 // Based on loose ignition temperature of plastic
 	accelerant_value = 0.1
 	burn_product = /decl/material/gas/carbon_monoxide
+	melting_point = null
+
 /* TODO: burn products for solids
 	bakes_into_at_temperature = T0C+500
 	bakes_into_material = /decl/material/solid/carbon
@@ -74,7 +76,6 @@
 	brute_armor = 1
 	weight = MAT_VALUE_EXTREMELY_LIGHT - 5
 	ignition_point = T0C+232 //"the temperature at which book-paper catches fire, and burns." close enough
-	melting_point = T0C+232 //temperature at which cardboard walls would be destroyed
 	stack_origin_tech = @'{"materials":1}'
 	door_icon_base = "wood"
 	destruction_desc = "crumples"
@@ -109,7 +110,6 @@
 	wall_flags              = PAINT_PAINTABLE | PAINT_STRIPABLE | WALL_HAS_EDGES
 	brute_armor             = 0.5
 	ignition_point          = T0C + 232 //"the temperature at which book-paper catches fire, and burns." close enough
-	melting_point           = T0C + 232
 	conductive              = FALSE
 	value                   = 0.25
 	default_solid_form      = /obj/item/stack/material/bolt
@@ -127,7 +127,6 @@
 	stack_origin_tech = @'{"materials":2}'
 	door_icon_base = "wood"
 	ignition_point = T0C+232
-	melting_point = T0C+300
 	flags = MAT_FLAG_PADDING
 	brute_armor = 1
 	conductive = 0
@@ -214,7 +213,7 @@
 	color = "#9d2300"
 	flags = MAT_FLAG_PADDING
 	ignition_point = T0C+232
-	melting_point = T0C+300
+	melting_point = T0C+300 // assuming synthetic carpet (plastic)
 	conductive = 0
 	construction_difficulty = MAT_VALUE_NORMAL_DIY
 	reflectiveness = MAT_VALUE_DULL
@@ -234,7 +233,6 @@
 	color = COLOR_GREEN_GRAY
 	flags = MAT_FLAG_PADDING
 	ignition_point = T0C+300
-	melting_point = T0C+300
 	conductive = 1
 	hidden_from_codex = TRUE
 	construction_difficulty = MAT_VALUE_NORMAL_DIY
@@ -255,7 +253,6 @@
 	color = COLOR_DARK_RED
 	flags = MAT_FLAG_PADDING
 	ignition_point = T0C+300
-	melting_point = T0C+300
 	conductive = 1
 	hidden_from_codex = TRUE
 	construction_difficulty = MAT_VALUE_NORMAL_DIY
@@ -277,7 +274,6 @@
 	color = "#9e8c72"
 	flags = MAT_FLAG_PADDING
 	ignition_point = T0C+300
-	melting_point = T0C+300
 	conductive = 0
 	hidden_from_codex = TRUE
 	construction_difficulty = MAT_VALUE_NORMAL_DIY
@@ -403,7 +399,6 @@
 	uid = "solid_bone"
 	color = "#f0edc7"
 	ignition_point = T0C+1100
-	melting_point = T0C+1800
 	conductive = 0
 	hidden_from_codex = TRUE
 	construction_difficulty = MAT_VALUE_NORMAL_DIY
@@ -451,7 +446,6 @@
 	stack_origin_tech = @'{"materials":2}'
 	flags = MAT_FLAG_PADDING
 	ignition_point = T0C+300
-	melting_point = T0C+300
 	conductive = 0
 	hidden_from_codex = TRUE
 	construction_difficulty = MAT_VALUE_NORMAL_DIY
@@ -471,7 +465,7 @@
 	uid = "solid_synthleather"
 	color = "#1f1f20"
 	ignition_point = T0C+150
-	melting_point = T0C+100
+	melting_point = T0C+100 // Assuming synthetic leather.
 
 /decl/material/solid/organic/leather/lizard
 	name = "scaled hide"

--- a/code/modules/materials/definitions/solids/materials_solid_wood.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_wood.dm
@@ -20,7 +20,6 @@
 	hardness = MAT_VALUE_FLEXIBLE + 10
 	brute_armor = 1
 	weight = MAT_VALUE_NORMAL
-	melting_point = T0C+300 //okay, not melting in this case, but hot enough to destroy wood
 	ignition_point = T0C+288
 	stack_origin_tech = @'{"materials":1,"biotech":1}'
 	dooropen_noise = 'sound/effects/doorcreaky.ogg'

--- a/code/modules/mechs/mech_life.dm
+++ b/code/modules/mechs/mech_life.dm
@@ -76,11 +76,11 @@
 	if(abs(environment.temperature - bodytemperature) > 0 )
 		bodytemperature += ((environment.temperature - bodytemperature) / 6)
 
-	if(bodytemperature > material.melting_point * 1.45 ) //A bit higher because I like to assume there's a difference between a mech and a wall
+	if(bodytemperature > material.temperature_damage_threshold * 1.45 ) //A bit higher because I like to assume there's a difference between a mech and a wall
 		var/damage = 5
-		if(bodytemperature > material.melting_point * 1.75 )
+		if(bodytemperature > material.temperature_damage_threshold * 1.75 )
 			damage = 10
-		if(bodytemperature > material.melting_point * 2.15 )
+		if(bodytemperature > material.temperature_damage_threshold * 2.15 )
 			damage = 15
 		apply_damage(damage, BURN)
 	//A possibility is to hook up interface icons here. But this works pretty well in my experience


### PR DESCRIPTION
## Description of changes
- Meat, skin, wood, paper, several other materials, no longer melt.
- Added `temperature_damage_threshold` which takes the minimum non-null of `melting_point`, `ignition_point` and `boiling_point`.
- Grilles, exosuits, walls and windows now use `temperature_damage_threshold` instead of `melting_point`.

## Why and what will this PR improve
Cloth melting was dumb and used only for wall damage.

## Authorship
Myself.

## Changelog
Nothing player-facing.