### PR TITLE
Add coffee and tea

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -20,12 +20,15 @@
 	var/list/traits = list()       // Initialized in New()
 	var/list/mutants               // Possible predefined mutant varieties, if any.
 	var/list/chems                 // Chemicals that plant produces in products/injects into victim.
+	var/list/dried_chems           // Chemicals that a dried plant product will have.
+	var/list/roasted_chems         // Chemicals that a roasted/grilled plant product will have.
 	var/list/consume_gasses        // The plant will absorb these gasses during its life.
 	var/list/exude_gasses          // The plant will exude these gasses during its life.
 	var/kitchen_tag                // Used by the reagent grinder.
 	var/trash_type                 // Garbage item produced when eaten.
 	var/splat_type = /obj/effect/decal/cleanable/fruit_smudge // Graffiti decal.
 	var/product_type = /obj/item/chems/food/grown
+	var/product_material
 	var/force_layer
 	var/req_CO2_moles    = 1.0// Moles of CO2 required for photosynthesis.
 	var/hydrotray_only

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -1342,3 +1342,50 @@
 	set_trait(TRAIT_IDEAL_HEAT, 298)
 	set_trait(TRAIT_IDEAL_LIGHT, 6)
 	set_trait(TRAIT_WATER_CONSUMPTION, 6)
+
+/datum/seed/tea
+	name = "tea"
+	seed_name = "tea leaf"
+	display_name = "tea plant"
+	chems = list(/decl/material/liquid/nutriment = list(1))
+	dried_chems = list(/decl/material/liquid/nutriment/tea = list(10,10))
+
+/datum/seed/tea/New()
+	..()
+	set_trait(TRAIT_HARVEST_REPEAT,TRUE)
+	set_trait(TRAIT_MATURATION,6)
+	set_trait(TRAIT_PRODUCTION,6)
+	set_trait(TRAIT_YIELD,5)
+	set_trait(TRAIT_PRODUCT_ICON,"tobacco")
+	set_trait(TRAIT_PRODUCT_COLOUR,"#749733")
+	set_trait(TRAIT_PLANT_COLOUR,"#749733")
+	set_trait(TRAIT_PLANT_ICON,"vine2")
+	set_trait(TRAIT_IDEAL_HEAT, 299)
+	set_trait(TRAIT_IDEAL_LIGHT, 6)
+	set_trait(TRAIT_WATER_CONSUMPTION, 6)
+	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)
+
+/datum/seed/coffee
+	name = "coffee"
+	seed_name = "coffee cherries"
+	display_name = "coffee plant"
+	chems = list(/decl/material/liquid/nutriment = list(1))
+	roasted_chems = list(/decl/material/liquid/nutriment/coffee = list(10,10))
+	backyard_grilling_product = /obj/item/chems/food/grown/grilled
+	backyard_grilling_announcement = "roasts and darkens."
+	product_material = /decl/material/solid/organic/plantmatter/pith
+
+/datum/seed/coffee/New()
+	..()
+	set_trait(TRAIT_HARVEST_REPEAT,TRUE)
+	set_trait(TRAIT_MATURATION,6)
+	set_trait(TRAIT_PRODUCTION,6)
+	set_trait(TRAIT_YIELD,5)
+	set_trait(TRAIT_PRODUCT_ICON,"grapes")
+	set_trait(TRAIT_PRODUCT_COLOUR,"#a80000")
+	set_trait(TRAIT_PLANT_COLOUR,"#749733")
+	set_trait(TRAIT_PLANT_ICON,"vine2")
+	set_trait(TRAIT_IDEAL_HEAT, 299)
+	set_trait(TRAIT_IDEAL_LIGHT, 6)
+	set_trait(TRAIT_WATER_CONSUMPTION, 6)
+	set_trait(TRAIT_NUTRIENT_CONSUMPTION, 0.15)

--- a/code/modules/materials/definitions/solids/materials_solid_organic.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_organic.dm
@@ -247,6 +247,14 @@
 	sound_manipulate = 'sound/foley/paperpickup2.ogg'
 	sound_dropped = 'sound/foley/paperpickup1.ogg'
 
+/// Used for plant products that aren't quite wood, but are still tougher than normal plant matter.
+/decl/material/solid/organic/plantmatter/pith
+	name = "plant pith"
+	uid = "solid_plantpith"
+	melting_point = null
+	hardness = MAT_VALUE_FLEXIBLE
+	value = 0.4
+
 /decl/material/solid/organic/plantmatter/grass
 	name = "grass"
 	uid = "solid_grass"

--- a/code/modules/random_map/noise/forage.dm
+++ b/code/modules/random_map/noise/forage.dm
@@ -59,7 +59,9 @@
 			"lavender",
 			"garlic",
 			"peppercorn",
-			"bamboo"
+			"bamboo",
+			"coffee",
+			"tea"
 		),
 	)
 	var/list/trees = list(

--- a/code/modules/reagents/reagent_containers/food_cooking.dm
+++ b/code/modules/reagents/reagent_containers/food_cooking.dm
@@ -7,6 +7,8 @@
 	var/backyard_grilling_announcement = "smokes and chars!"
 	/// The span class used for the message above. Burned food defaults to SPAN_DANGER.
 	var/backyard_grilling_span         = "notice"
+	/// The number of times this object and its ancestors have been grilled. Used for grown foods' roasted chems.
+	var/backyard_grilling_count        = 0
 
 /obj/item/chems/food/get_dried_product()
 	drop_plate(get_turf(loc))
@@ -33,20 +35,26 @@
 /obj/item/chems/food/dry_out(var/obj/rack, var/drying_power = 1, var/fire_exposed = FALSE, var/silent = FALSE)
 	return fire_exposed ? grill(rack) : ..()
 
+/obj/item/chems/food/proc/get_grilled_product()
+	return new backyard_grilling_product(loc)
+
 /obj/item/chems/food/proc/grill(var/atom/heat_source)
 	if(!backyard_grilling_product || backyard_grilling_rawness <= 0)
 		return null
 	backyard_grilling_rawness--
 	if(backyard_grilling_rawness <= 0)
-		var/obj/item/food = new backyard_grilling_product
-		food.dropInto(loc)
+		var/obj/item/product = get_grilled_product()
+		product.dropInto(loc)
+		var/obj/item/chems/food/food = product
+		if(istype(food))
+			food.backyard_grilling_count = src.backyard_grilling_count + 1
 		if(backyard_grilling_announcement)
-			if(istype(food, /obj/item/chems/food/badrecipe))
-				food.visible_message(SPAN_DANGER("\The [src] [backyard_grilling_announcement]"))
+			if(istype(product, /obj/item/chems/food/badrecipe))
+				product.visible_message(SPAN_DANGER("\The [src] [backyard_grilling_announcement]"))
 			else
-				food.visible_message("<span class='[backyard_grilling_span]'>\The [src] [backyard_grilling_announcement]</span>")
+				product.visible_message("<span class='[backyard_grilling_span]'>\The [src] [backyard_grilling_announcement]</span>")
 		qdel(src)
-		return food
+		return product
 
 /obj/item/chems/food/proc/get_backyard_grilling_text(var/obj/rack)
 	var/moistness = backyard_grilling_rawness / initial(backyard_grilling_rawness)

--- a/code/unit_tests/chemistry_tests.dm
+++ b/code/unit_tests/chemistry_tests.dm
@@ -185,7 +185,9 @@
 	// Types to be skipped for reasons other than abstraction/spawnability.
 	var/static/list/excepted_types = list(
 		// Not technically abstract, but should not be spawned outside of /datum/seed/harvest().
-		/obj/item/chems/food/grown
+		/obj/item/chems/food/grown,
+		/obj/item/chems/food/grown/dry,
+		/obj/item/chems/food/grown/grilled
 	)
 
 /datum/unit_test/chemistry_premade_bottles_shall_not_melt/start_test()


### PR DESCRIPTION
## Description of changes
Adds coffee and tea. Opening for CI and diff, needs #3764 though.
Adds the ability for plant products to have different reagents when dried and roasted.
Adds the ability for plant products to specify a material. This is mostly useful for making coffee cherries not melt when heated.

## Why and what will this PR improve
Adds coffee cherries (must be roasted) and tea leaves (must be dried) as renewable ways to get coffee grounds and tea.

## Authorship
Me

## Changelog
:cl:
add: Added coffee and tea. Coffee must be roasted and tea must be dried before you can extract coffee grounds or tea from the plant.
/:cl: