### PR TITLE
Fix recipe/material issues, adds missing brick presets

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -153,7 +153,9 @@
 
 /obj/item/stack/proc/produce_recipe(decl/stack_recipe/recipe, var/quantity, mob/user)
 	var/required = quantity*recipe.req_amount
-	var/produced = min(quantity*recipe.res_amount, recipe.max_res_amount)
+	var/produced = quantity*recipe.res_amount
+	if(!isnull(recipe.max_res_amount))
+		produced = min(produced, recipe.max_res_amount)
 	var/decl/material/mat       = get_material()
 	var/decl/material/reinf_mat = get_reinforced_material()
 

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -176,7 +176,8 @@
 		to_chat(user, SPAN_WARNING("You waste some [name] and fail to make [recipe.get_display_name(produced, mat, reinf_mat)]!"))
 		return
 	to_chat(user, SPAN_NOTICE("You complete [recipe.get_display_name(produced, mat, reinf_mat)]!"))
-	var/atom/movable/O = LAZYACCESS(recipe.spawn_result(user, user.loc, produced, mat, reinf_mat), 1)
+	var/list/atom/results = recipe.spawn_result(user, user.loc, produced, mat, reinf_mat)
+	var/atom/movable/O = LAZYACCESS(results, 1)
 	if(istype(O) && !QDELETED(O)) // In case of stack merger.
 		O.add_fingerprint(user)
 		user.put_in_hands(O)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -176,7 +176,7 @@
 		to_chat(user, SPAN_WARNING("You waste some [name] and fail to make [recipe.get_display_name(produced, mat, reinf_mat)]!"))
 		return
 	to_chat(user, SPAN_NOTICE("You complete [recipe.get_display_name(produced, mat, reinf_mat)]!"))
-	var/atom/movable/O = recipe.spawn_result(user, user.loc, produced, mat, reinf_mat)
+	var/atom/movable/O = LAZYACCESS(recipe.spawn_result(user, user.loc, produced, mat, reinf_mat), 1)
 	if(istype(O) && !QDELETED(O)) // In case of stack merger.
 		O.add_fingerprint(user)
 		user.put_in_hands(O)

--- a/code/game/objects/structures/flora/tree.dm
+++ b/code/game/objects/structures/flora/tree.dm
@@ -108,18 +108,28 @@
 
 /obj/structure/flora/tree/dead/ebony
 	icon_state = "dead_ebony_1"
+	material   = /decl/material/solid/organic/wood/ebony
+	stump_type = /obj/structure/flora/stump/tree/ebony
 
 /obj/structure/flora/tree/dead/mahogany
 	icon_state = "dead_mahogany_1"
+	material   = /decl/material/solid/organic/wood/mahogany
+	stump_type = /obj/structure/flora/stump/tree/mahogany
 
 /obj/structure/flora/tree/dead/walnut
 	icon_state = "dead_walnut_1"
+	material   = /decl/material/solid/organic/wood/walnut
+	stump_type = /obj/structure/flora/stump/tree/walnut
 
 /obj/structure/flora/tree/dead/maple
 	icon_state = "dead_maple_1"
+	material   = /decl/material/solid/organic/wood/maple
+	stump_type = /obj/structure/flora/stump/tree/maple
 
 /obj/structure/flora/tree/dead/yew
 	icon_state = "dead_yew_1"
+	material   = /decl/material/solid/organic/wood/yew
+	stump_type = /obj/structure/flora/stump/tree/yew
 
 /obj/structure/flora/tree/softwood
 	icon          = 'icons/obj/flora/softwood.dmi'

--- a/code/modules/crafting/stack_recipes/_recipe.dm
+++ b/code/modules/crafting/stack_recipes/_recipe.dm
@@ -318,31 +318,33 @@
 	return null
 
 /decl/stack_recipe/proc/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat)
-	var/atom/O
-
 	//TODO: standardize material argument passing in Initialize().
 	if(ispath(result_type, /obj/item/stack)) // Amount is set manually in some overrides as well.
-		O = new result_type(location, amount, MATERIAL_RECIPE_PARAMS)
+		. = list(new result_type(location, amount, MATERIAL_RECIPE_PARAMS))
 	else
-		O = new result_type(location, MATERIAL_RECIPE_PARAMS)
+		. = list()
+		for(var/i in 1 to amount)
+			. += new result_type(location, MATERIAL_RECIPE_PARAMS)
 
 	if(user && set_dir_on_spawn)
-		O.set_dir(user?.dir)
+		for(var/atom/O in .)
+			O.set_dir(user.dir)
 
 	// Temp block pending material/matter rework
-	if(mat && mat?.type != DEFAULT_FURNITURE_MATERIAL && istype(O, /obj))
-		var/obj/struct = O
-		if(LAZYACCESS(struct.matter, DEFAULT_FURNITURE_MATERIAL) > 0)
-			struct.matter[mat.type] = max(struct.matter[mat.type], struct.matter[DEFAULT_FURNITURE_MATERIAL])
-			struct.matter -= DEFAULT_FURNITURE_MATERIAL
+	if(mat && mat?.type != DEFAULT_FURNITURE_MATERIAL && ispath(result_type, /obj))
+		for(var/obj/struct in .)
+			if(LAZYACCESS(struct.matter, DEFAULT_FURNITURE_MATERIAL) > 0)
+				struct.matter[mat.type] = max(struct.matter[mat.type], struct.matter[DEFAULT_FURNITURE_MATERIAL])
+				struct.matter -= DEFAULT_FURNITURE_MATERIAL
 	// End temp block
 
-	if(user && istype(O, /obj/item/stack))
-		var/obj/item/stack/S = O
-		S.add_to_stacks(user, 1)
+	if(user && ispath(result_type, /obj/item/stack))
+		for(var/obj/item/stack/S in .)
+			S.add_to_stacks(user, 1)
 
-	if(!QDELETED(O))
-		return O
+	for(var/atom/res in .)
+		if(QDELETED(res))
+			. -= res
 
 /decl/stack_recipe/proc/can_make(mob/user)
 	if (one_per_turf && (locate(result_type) in user.loc))

--- a/code/modules/crafting/stack_recipes/_recipe.dm
+++ b/code/modules/crafting/stack_recipes/_recipe.dm
@@ -105,6 +105,9 @@
 		if(isnull(max_res_amount) || max_res_amount > stack_max)
 			max_res_amount = stack_max
 
+	if(isnull(max_res_amount) && one_per_turf)
+		max_res_amount = 1
+
 	if(isnull(name_plural))
 		name_plural = "[name]s"
 

--- a/code/modules/crafting/stack_recipes/recipes_bricks.dm
+++ b/code/modules/crafting/stack_recipes/recipes_bricks.dm
@@ -21,7 +21,7 @@
 	req_amount                 = 3 // Arbitrary value since machines don't handle matter properly yet.
 
 /decl/stack_recipe/bricks/furniture/planting_bed/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat)
-	return new result_type(location)
+	return list(new result_type(location))
 
 /decl/stack_recipe/bricks/fountain
 	result_type                = /obj/structure/fountain/mundane

--- a/code/modules/crafting/stack_recipes/recipes_coins.dm
+++ b/code/modules/crafting/stack_recipes/recipes_coins.dm
@@ -25,8 +25,8 @@
 		. += "invalid or null denomination: [denomination || "NULL"]"
 
 /decl/stack_recipe/coin/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat)
-	var/obj/item/coin/coin = ..()
-	if(istype(coin) && istype(denomination))
-		coin.denomination = denomination
-		coin.SetName(coin.denomination.name)
-	return coin
+	. = ..()
+	if(istype(denomination))
+		for(var/obj/item/coin/coin in .)
+			coin.denomination = denomination
+			coin.SetName(coin.denomination.name)

--- a/code/modules/crafting/stack_recipes/recipes_hardness.dm
+++ b/code/modules/crafting/stack_recipes/recipes_hardness.dm
@@ -2,58 +2,58 @@
 	abstract_type     = /decl/stack_recipe/hardness
 	required_hardness = MAT_VALUE_FLEXIBLE + 10
 
-/decl/stack_recipe/improvised_armour
+/decl/stack_recipe/hardness/improvised_armour
 	result_type       = /obj/item/clothing/suit/armor/crafted
 
-/decl/stack_recipe/armguards
+/decl/stack_recipe/hardness/armguards
 	result_type       = /obj/item/clothing/accessory/armguards/craftable
 
-/decl/stack_recipe/legguards
+/decl/stack_recipe/hardness/legguards
 	result_type       = /obj/item/clothing/accessory/legguards/craftable
 
-/decl/stack_recipe/gauntlets
+/decl/stack_recipe/hardness/gauntlets
 	result_type       = /obj/item/clothing/gloves/thick/craftable
 
-/decl/stack_recipe/fork
+/decl/stack_recipe/hardness/fork
 	result_type       = /obj/item/utensil/fork
 
-/decl/stack_recipe/chopsticks
+/decl/stack_recipe/hardness/chopsticks
 	result_type       = /obj/item/utensil/chopsticks
 
-/decl/stack_recipe/knife
+/decl/stack_recipe/hardness/knife
 	result_type       = /obj/item/utensil/knife
 	difficulty        = MAT_VALUE_HARD_DIY
 
-/decl/stack_recipe/bell
+/decl/stack_recipe/hardness/bell
 	result_type       = /obj/item/bell
 
-/decl/stack_recipe/spoon
+/decl/stack_recipe/hardness/spoon
 	result_type       = /obj/item/utensil/spoon
 
-/decl/stack_recipe/blade
+/decl/stack_recipe/hardness/blade
 	result_type       = /obj/item/butterflyblade
 	difficulty        = MAT_VALUE_NORMAL_DIY
 
-/decl/stack_recipe/urn
+/decl/stack_recipe/hardness/urn
 	result_type       = /obj/item/urn
 
-/decl/stack_recipe/drill_head
+/decl/stack_recipe/hardness/drill_head
 	result_type       = /obj/item/drill_head
 	difficulty        = MAT_VALUE_EASY_DIY
 
-/decl/stack_recipe/baseball_bat
+/decl/stack_recipe/hardness/baseball_bat
 	result_type       = /obj/item/twohanded/baseballbat
 	difficulty        = MAT_VALUE_HARD_DIY
 
-/decl/stack_recipe/ashtray
+/decl/stack_recipe/hardness/ashtray
 	result_type       = /obj/item/ashtray
 
 /decl/stack_recipe/ring
 	result_type       = /obj/item/clothing/ring/material
 
-/decl/stack_recipe/clipboard
+/decl/stack_recipe/hardness/clipboard
 	result_type       = /obj/item/clipboard
 
-/decl/stack_recipe/cross
+/decl/stack_recipe/hardness/cross
 	result_type       = /obj/item/cross
 	on_floor          = TRUE

--- a/code/modules/crafting/stack_recipes/recipes_items.dm
+++ b/code/modules/crafting/stack_recipes/recipes_items.dm
@@ -17,13 +17,19 @@
 	required_material = /decl/material/solid/organic/paper
 
 /decl/stack_recipe/paper_sheets/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat)
-	var/obj/item/paper/P = ..()
-	if(amount > 1)
-		var/obj/item/paper_bundle/B = new(location)
-		B.merge(P)
-		for(var/i = 1 to (amount - 1))
-			if(B.get_amount_papers() >= B.max_pages)
-				B = new(location)
-			B.merge(new /obj/item/paper(location))
-		return B
-	return P
+	. = ..()
+	if(amount <= 1)
+		return .
+	var/obj/item/paper_bundle/bundle = new (location)
+	var/list/bundles = list(bundle)
+	var/remaining = amount
+	for(var/obj/item/paper/paper in .)
+		remaining--
+		if(bundle.get_amount_papers() >= bundle.max_pages)
+			if(remaining == 0)
+				bundles += paper // not a bundle, this is an exception for single overflow pages
+				break
+			bundle = new(location)
+			bundles += bundle
+		bundle.merge(paper)
+	return bundles

--- a/code/modules/crafting/stack_recipes/recipes_logs.dm
+++ b/code/modules/crafting/stack_recipes/recipes_logs.dm
@@ -11,14 +11,13 @@
 
 // TODO: make this a firepit recipe using bricks or something instead.
 /decl/stack_recipe/logs/campfire/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat)
-	var/obj/structure/fire_source/product = ..(user, location, amount) // Discard the material since we're putting it into the fuel var.
-	if(product)
+	. = ..(user, location, amount, null, null) // Discard the materials since we're putting it into the fuel var.
+	for(var/obj/structure/fire_source/product in .)
 		product.matter = null
 		product.material = null
 		product.update_materials(TRUE)
 		if(mat?.accelerant_value > FUEL_VALUE_NONE)
 			product.fuel += round(mat.accelerant_value * (req_amount * (amount / res_amount) * SHEET_MATERIAL_AMOUNT))
-	return product
 
 /decl/stack_recipe/turfs/wall/logs
 	name                        = "log wall"

--- a/code/modules/crafting/stack_recipes/recipes_logs.dm
+++ b/code/modules/crafting/stack_recipes/recipes_logs.dm
@@ -19,3 +19,10 @@
 		if(mat?.accelerant_value > FUEL_VALUE_NONE)
 			product.fuel += round(mat.accelerant_value * (req_amount * (amount / res_amount) * SHEET_MATERIAL_AMOUNT))
 	return product
+
+/decl/stack_recipe/turfs/wall/logs
+	name                        = "log wall"
+	result_type                 = /turf/wall/log
+	craft_stack_types           = /obj/item/stack/material/log
+	forbidden_craft_stack_types = /obj/item/stack/material/ore
+	difficulty                  = MAT_VALUE_HARD_DIY

--- a/code/modules/crafting/stack_recipes/recipes_opacity.dm
+++ b/code/modules/crafting/stack_recipes/recipes_opacity.dm
@@ -6,6 +6,7 @@
 
 /decl/stack_recipe/opacity/fullwindow
 	name                 = "full-tile window"
+	one_per_turf         = TRUE
 	result_type          = /obj/structure/window
 
 /decl/stack_recipe/opacity/fullwindow/can_make(mob/user)
@@ -17,12 +18,13 @@
 				return FALSE
 
 /decl/stack_recipe/opacity/fullwindow/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat)
-	return new result_type(user?.loc, MATERIAL_RECIPE_PARAMS, SOUTHWEST, TRUE)
+	return list(new result_type(user?.loc, MATERIAL_RECIPE_PARAMS, SOUTHWEST, TRUE))
 
 /decl/stack_recipe/opacity/borderwindow
 	name                 = "border window"
 	result_type          = /obj/structure/window
-	one_per_turf         = 0
+	one_per_turf         = FALSE
+	max_res_amount       = 1 // one per direction
 
 /decl/stack_recipe/opacity/borderwindow/can_make(mob/user)
 	. = ..()
@@ -33,7 +35,7 @@
 				return FALSE
 
 /decl/stack_recipe/opacity/borderwindow/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat)
-	return new result_type(user?.loc, MATERIAL_RECIPE_PARAMS, user?.dir, TRUE)
+	return list(new result_type(user?.loc, MATERIAL_RECIPE_PARAMS, user?.dir, TRUE))
 
 /decl/stack_recipe/opacity/windoor
 	result_type          = /obj/structure/windoor_assembly
@@ -44,6 +46,3 @@
 		if(locate(/obj/machinery/door/window) in user.loc)
 			to_chat(user, "<span class='warning'>There is already a windoor here!</span>")
 			return FALSE
-
-/decl/stack_recipe/opacity/windoor/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat)
-	return new result_type(user?.loc, MATERIAL_RECIPE_PARAMS)

--- a/code/modules/crafting/stack_recipes/recipes_planks.dm
+++ b/code/modules/crafting/stack_recipes/recipes_planks.dm
@@ -34,10 +34,10 @@
 	set_dir_on_spawn       = FALSE
 
 /decl/stack_recipe/planks/noticeboard/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat)
-	var/obj/structure/noticeboard/board = ..()
-	if(istype(board) && user)
-		board.set_dir(global.reverse_dir[user.dir])
-	return board
+	. = ..()
+	if(user)
+		for(var/obj/structure/noticeboard/board in .)
+			board.set_dir(global.reverse_dir[user.dir])
 
 /decl/stack_recipe/planks/prosthetic
 	abstract_type          = /decl/stack_recipe/planks/prosthetic
@@ -47,12 +47,11 @@
 	var/prosthetic_model   = /decl/bodytype/prosthetic/wooden
 
 /decl/stack_recipe/planks/prosthetic/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat)
-	var/obj/item/organ/external/limb = ..()
-	if(limb)
+	. = ..()
+	for(var/obj/item/organ/external/limb in .)
 		limb.set_species(prosthetic_species)
 		limb.set_bodytype(prosthetic_model, override_material = (required_material != MATERIAL_FORBIDDEN ? mat?.type : null))
 		limb.status |= ORGAN_CUT_AWAY
-	return limb
 
 /decl/stack_recipe/planks/prosthetic/left_arm
 	result_type            = /obj/item/organ/external/arm

--- a/code/modules/crafting/stack_recipes/recipes_stacks.dm
+++ b/code/modules/crafting/stack_recipes/recipes_stacks.dm
@@ -8,14 +8,6 @@
 	apply_material_name = FALSE
 	category            = "tiling"
 
-/decl/stack_recipe/tile/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat)
-	var/obj/item/stack/S = ..()
-	if(istype(S))
-		S.amount = amount
-		if(user)
-			S.add_to_stacks(user, 1)
-	return S
-
 /decl/stack_recipe/tile/wood
 	result_type         = /obj/item/stack/tile/wood
 	required_material   = /decl/material/solid/organic/wood

--- a/code/modules/crafting/stack_recipes/recipes_steel.dm
+++ b/code/modules/crafting/stack_recipes/recipes_steel.dm
@@ -48,7 +48,7 @@
 	req_amount        = 5 // Arbitrary value since machines don't handle matter properly yet.
 
 /decl/stack_recipe/steel/furniture/computerframe/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat)
-	return new result_type(location)
+	return ..(user, location, amount, null, null)
 
 /decl/stack_recipe/steel/furniture/door_assembly
 	name              = "standard airlock assembly"

--- a/code/modules/crafting/stack_recipes/recipes_struts.dm
+++ b/code/modules/crafting/stack_recipes/recipes_struts.dm
@@ -46,4 +46,4 @@
 	required_material           = /decl/material/solid/metal/steel
 
 /decl/stack_recipe/strut/machine/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat)
-	return new result_type(location)
+	return ..(user, location, amount, null, null)

--- a/code/modules/materials/definitions/solids/materials_solid_stone.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_stone.dm
@@ -90,6 +90,7 @@
 	wall_support_value = MAT_VALUE_VERY_HEAVY
 	hardness = MAT_VALUE_HARD
 	reflectiveness = MAT_VALUE_SHINY
+	melting_point  = T0C + 1200
 	construction_difficulty = MAT_VALUE_HARD_DIY
 
 /decl/material/solid/stone/concrete
@@ -98,6 +99,7 @@
 	lore_text = "The most ubiquitous building material of old Earth, now in space. Consists of mineral aggregate bound with some sort of cementing solution."
 	color = COLOR_GRAY
 	value = 0.9
+	melting_point  = T0C + 1200
 	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
 	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	var/image/texture

--- a/code/modules/materials/material_sheets_mapping.dm
+++ b/code/modules/materials/material_sheets_mapping.dm
@@ -45,6 +45,8 @@ STACK_SUBTYPES(iron,           "iron",                          solid/metal/iron
 STACK_SUBTYPES(copper,         "copper",                        solid/metal/copper,          ingot,            null)
 STACK_SUBTYPES(sandstone,      "sandstone",                     solid/stone/sandstone,       brick,            null)
 STACK_SUBTYPES(marble,         "marble",                        solid/stone/marble,          brick,            null)
+STACK_SUBTYPES(basalt,         "basalt",                        solid/stone/basalt,          brick,            null)
+STACK_SUBTYPES(concrete,       "concrete",                      solid/stone/concrete,        brick,            null)
 STACK_SUBTYPES(graphite,       "graphite",                      solid/graphite,              brick,            null)
 STACK_SUBTYPES(diamond,        "diamond",                       solid/gemstone/diamond,      gemstone,         null)
 STACK_SUBTYPES(uranium,        "uranium",                       solid/metal/uranium,         puck,             null)

--- a/code/unit_tests/materials.dm
+++ b/code/unit_tests/materials.dm
@@ -56,7 +56,7 @@
 					for(var/decl/stack_recipe/recipe as anything in recipes)
 						if(ispath(recipe.result_type, /turf)) // Cannot exist without a loc and doesn't have matter, cannot assess here.
 							continue
-						var/atom/product = recipe.spawn_result(null, null, 1, material, reinforced)
+						var/atom/product = LAZYACCESS(recipe.spawn_result(null, null, 1, material, reinforced), 1)
 						var/failed
 						if(!product)
 							failed = "no product returned"


### PR DESCRIPTION
## Description of changes
Adds materials and stumps to dead trees.
Fixes hardness-based recipes not checking hardness.
Adds more stone brick types and adjusts melting point for basalt, granite, etc.
Readds the log wall recipe.
Fixes recipes not being able to create more than one result object.
Fixes blank amount in stack crafting message.
Fixes `one_per_turf` recipes still letting you bulk-create objects on the same turf.

## Why and what will this PR improve
Some issues I noted while playtesting Kobaloi with recent changes.

## Authorship
Me.