### PR TITLE
Fix update_paths split and subpath issues

### DIFF
--- a/tools/mapmerge2/update_paths.py
+++ b/tools/mapmerge2/update_paths.py
@@ -31,7 +31,7 @@ default_map_directory = "../../_maps"
 replacement_re = re.compile(r'\s*(?P<path>[^{]*)\s*(\{(?P<props>.*)\})?')
 
 #urgent todo: replace with actual parser, this is slow as janitor in crit
-split_re = re.compile(r'((?:[A-Za-z0-9_\-$]+)\s*=\s*(?:"(?:.+?)"|[^";]*)|@OLD)')
+split_re = re.compile(r'((?:[A-Za-z0-9_\-$]+)\s*=\s*(?:"(?:.+?)"|list\([^;]*\)|[^";]*)|@OLD)')
 
 
 def props_to_string(props):
@@ -75,7 +75,7 @@ def update_path(dmm_data, replacement_string, verbose=False):
         old_path = old_path[:-len("/@SUBTYPES")]
         if verbose:
             print("Looking for subtypes of", old_path)
-        subtypes = r"(?:/\w+)*"
+        subtypes = r"(?P<subpath>(?:/\w+)*)"
 
     replacement_pattern = re.compile(rf"(?P<path>{re.escape(old_path)}{subtypes})\s*(:?{{(?P<props>.*)}})?$")
 


### PR DESCRIPTION
## Description of changes
Updates update_paths.py with newer regexes (regices?) from downstream.

## Why and what will this PR improve
Fixes an issue with update_paths breaking on certain lists.
Fixes an issue with update_paths not actually handling SUBTYPES substitution correctly.

## Authorship
Me.