### PR TITLE
Adjust exterior temperature for cold weather

### DIFF
--- a/code/modules/ZAS/Turf.dm
+++ b/code/modules/ZAS/Turf.dm
@@ -258,12 +258,15 @@
 	if(!include_heat_sources)
 		return gas
 
-	var/initial_temperature = weather ? weather.adjust_temperature(gas.temperature) : gas.temperature
+	if(weather)
+		gas.temperature = weather.adjust_temperature(gas.temperature)
+	var/initial_temperature = gas.temperature
 	if(length(affecting_heat_sources))
 		for(var/obj/structure/fire_source/heat_source as anything in affecting_heat_sources)
 			gas.temperature = gas.temperature + heat_source.exterior_temperature / max(1, get_dist(src, get_turf(heat_source)))
 			if(abs(gas.temperature - initial_temperature) >= 100)
 				break
+	gas.update_values()
 	return gas
 
 /turf/proc/c_copy_air()

--- a/code/modules/weather/weather_effects.dm
+++ b/code/modules/weather/weather_effects.dm
@@ -21,7 +21,10 @@
 	return 0
 
 /obj/abstract/weather_system/proc/adjust_temperature(initial_temperature)
-	return initial_temperature
+	. = initial_temperature
+	var/decl/state/weather/current_weather = weather_system?.current_state
+	if(istype(current_weather))
+		. = current_weather.adjust_temperature(initial_temperature)
 
 /obj/abstract/weather_system/proc/show_weather(var/mob/M)
 	var/mob_ref = weakref(M)

--- a/code/modules/weather/weather_fsm_state_transitions.dm
+++ b/code/modules/weather/weather_fsm_state_transitions.dm
@@ -10,6 +10,9 @@
 	target = /decl/state/weather/calm
 	likelihood_weighting = 50
 
+/decl/state_transition/weather/cold
+	target = /decl/state/weather/cold
+
 /decl/state_transition/weather/snow
 	target = /decl/state/weather/snow
 

--- a/code/modules/weather/weather_fsm_states.dm
+++ b/code/modules/weather/weather_fsm_states.dm
@@ -77,6 +77,9 @@
 			if(LAZYLEN(protected_by))
 				handle_protected_effects(M, weather, pick(protected_by))
 
+/decl/state/weather/proc/adjust_temperature(initial_temperature)
+	return initial_temperature
+
 /decl/state/weather/proc/show_to(var/mob/living/M, var/obj/abstract/weather_system/weather)
 	to_chat(M, descriptor)
 
@@ -85,9 +88,22 @@
 	icon_state = "blank"
 	descriptor = "The weather is calm."
 	transitions = list(
+		/decl/state_transition/weather/cold,
+		/decl/state_transition/weather/rain
+	)
+
+/decl/state/weather/cold
+	name = "Cold"
+	icon_state = "blank"
+	descriptor = "There is a chill on the breeze."
+	transitions = list(
+		/decl/state_transition/weather/calm,
 		/decl/state_transition/weather/snow,
 		/decl/state_transition/weather/rain
 	)
+
+/decl/state/weather/cold/adjust_temperature(initial_temperature)
+	return max(initial_temperature - 10, min(initial_temperature, T0C))
 
 /decl/state/weather/snow
 	name = "Light Snow"
@@ -106,6 +122,9 @@
 		"Flakes of snow drift gently past."
 	)
 
+/decl/state/weather/snow/adjust_temperature(initial_temperature)
+	return min(initial_temperature - 20, T0C)
+
 /decl/state/weather/snow/medium
 	name =  "Snow"
 	icon_state = "snowfall_med"
@@ -114,6 +133,9 @@
 		/decl/state_transition/weather/snow,
 		/decl/state_transition/weather/snow_heavy
 	)
+
+/decl/state/weather/snow/heavy/adjust_temperature(initial_temperature)
+	return min(initial_temperature - 25, T0C)
 
 /decl/state/weather/snow/heavy
 	name =  "Heavy Snow"
@@ -125,6 +147,9 @@
 		"Thick flurries of snow swirl around you."
 	)
 	cosmetic_span_class = "warning"
+
+/decl/state/weather/snow/heavy/adjust_temperature(initial_temperature)
+	return min(initial_temperature - 30, T0C)
 
 /decl/state/weather/rain
 	name =  "Light Rain"


### PR DESCRIPTION
## Description of changes
Adds a `/cold` weather state, which is like `/calm` but colder, and can precede snowstorms.
`/cold`, `/snow`, and the other snow subtypes will lower outdoor temperature on their level by varying amounts.
Fixes `weather.adjust_temperature` not actually working.

Future changes: maybe I'll make weather states define a max and min temperature adjustment (and max/min temperature) and have the weather state machine object pick one at random?

## Why and what will this PR improve
Fleshes out some stub code for weather states adjusting level temperature. Also fixes a bug with `adjust_temperature()` not actually affecting the temperature if there were no fire sources around.

## Authorship
Me.

## Changelog
:cl:
add: Certain weather conditions now affect exterior temperature. Cold and snowy conditions will reduce the outdoor temperature accordingly.
/:cl: