### PR TITLE
Make survival box choices per-map

### DIFF
--- a/code/datums/outfits/equipment/survival_box.dm
+++ b/code/datums/outfits/equipment/survival_box.dm
@@ -1,21 +1,25 @@
-var/global/list/survival_box_choices = list()
-
 /decl/survival_box_option
-	var/name = "survival kit"
-	var/box_type = /obj/item/storage/box/survival
+	decl_flags = DECL_FLAG_MANDATORY_UID
+	abstract_type = /decl/survival_box_option
+	var/name = "survival box option"
+	var/box_type
 
-/decl/survival_box_option/Initialize()
-	. = ..()
-	global.survival_box_choices[name] = src
+/decl/survival_box_option/survival
+	name = "survival kit"
+	box_type = /obj/item/storage/box/survival
+	uid = "survival_box_kit"
 
 /decl/survival_box_option/lunchbox
 	name = "lunchbox"
 	box_type = /obj/item/storage/lunchbox/filled
+	uid = "survival_box_lunchbox"
 
 /decl/survival_box_option/lunchbox/heart
 	name = "heart lunchbox"
 	box_type = /obj/item/storage/lunchbox/heart/filled
+	uid = "survival_box_lunchbox_heart"
 
 /decl/survival_box_option/lunchbox/cat
 	name = "cat lunchbox"
 	box_type = /obj/item/storage/lunchbox/cat/filled
+	uid = "survival_box_lunchbox_cat"

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -185,13 +185,11 @@ var/global/list/outfits_decls_by_type_
 				H.equip_to_slot_or_del(backpack, slot_back_str)
 
 	if(H.species && !(OUTFIT_ADJUSTMENT_SKIP_SURVIVAL_GEAR & equip_adjustments))
+		var/decl/survival_box_option/chosen_survival_box = H?.client?.prefs.survival_box_choice
 		if(outfit_flags & OUTFIT_EXTENDED_SURVIVAL)
 			H.species.equip_survival_gear(H, /obj/item/storage/box/engineer)
-		else if(H.client?.prefs?.survival_box_choice && global.survival_box_choices[H.client.prefs.survival_box_choice])
-			var/decl/survival_box_option/box = global.survival_box_choices[H.client.prefs.survival_box_choice]
-			H.species.equip_survival_gear(H, box.box_type)
-		else
-			H.species.equip_survival_gear(H)
+		else if(chosen_survival_box?.box_type)
+			H.species.equip_survival_gear(H, chosen_survival_box.box_type)
 
 	if(H.client?.prefs?.give_passport)
 		global.using_map.create_passport(H)

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -154,6 +154,9 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	/// A list of /decl/loadout_category types which will be available for characters made on this map. Uses all categories if null.
 	var/list/decl/loadout_category/loadout_categories
 
+	/// A list of survival box types selectable for this map. If null, defaults to all defined decls. At runtime, this is an associative list of decl type -> decl.
+	var/list/decl/survival_box_option/survival_box_choices
+
 /datum/map/proc/get_lobby_track(var/exclude)
 	var/lobby_track_type
 	if(LAZYLEN(lobby_tracks) == 1)
@@ -174,6 +177,11 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	for(var/loadout_category in loadout_categories)
 		loadout_categories -= loadout_category
 		loadout_categories += GET_DECL(loadout_category)
+
+	if(isnull(survival_box_choices)) // an empty list is a valid option here, a null one is not
+		survival_box_choices = decls_repository.get_decls_of_subtype(/decl/survival_box_option)
+	else if(length(survival_box_choices))
+		survival_box_choices = decls_repository.get_decls(survival_box_choices)
 
 	if(secrets_directory)
 		secrets_directory = trim(lowertext(secrets_directory))


### PR DESCRIPTION
## Description of changes
Makes survival box choices per-map. A null list will auto-populate while an empty list will have no survival box options at all.
Makes `/datum/preferences/var/survival_box_choice` a decl reference rather than a string. It's (de)serialized using the UID.

## Why and what will this PR improve
Maps where emergency kits don't make sense can avoid having any, or limit it to just certain ones.

## Authorship
Me.