### PR TITLE
Move accessory attachment behavior down to /obj/item/clothing.

### DIFF
--- a/code/datums/extensions/multitool/items/clothing.dm
+++ b/code/datums/extensions/multitool/items/clothing.dm
@@ -1,8 +1,3 @@
-/obj/item/clothing/Initialize()
-	. = ..()
-	if(ACCESSORY_SLOT_SENSORS in valid_accessory_slots)
-		set_extension(src, /datum/extension/interactive/multitool/items/clothing)
-
 /datum/extension/interactive/multitool/items/clothing/interact(var/obj/item/multitool/M, var/mob/user)
 	if(extension_status(user) != STATUS_INTERACTIVE)
 		return

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -126,7 +126,7 @@ var/global/list/outfits_decls_by_type_
 
 		var/obj/item/equip_uniform = H.get_equipped_item(slot_w_uniform_str)
 		if(holster && equip_uniform)
-			var/obj/item/clothing/accessory/equip_holster = new holster
+			var/obj/item/clothing/equip_holster = new holster
 			equip_uniform.attackby(equip_holster, H)
 			if(equip_holster.loc != equip_uniform && !QDELETED(equip_holster))
 				qdel(equip_holster)

--- a/code/game/objects/items/dog_tags.dm
+++ b/code/game/objects/items/dog_tags.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/clothing/accessories/jewelry/dogtags.dmi'
 	slot_flags = SLOT_FACE | SLOT_TIE
 	badge_string = null
-	hide_on_uniform_rolldown = FALSE
+	accessory_hide_on_uniform_rolldown = FALSE
 	material = /decl/material/solid/metal/stainlesssteel
 	var/owner_rank
 	var/owner_name

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -338,12 +338,11 @@
 		update_clothing_icon()	//so our overlays update.
 
 /obj/item/clothing/accessory/chameleon/disguise(var/newtype, var/mob/user)
-	var/obj/item/clothing/accessory/copy = ..()
+	var/obj/item/clothing/copy = ..()
 	if (!copy)
 		return
-
-	slot = copy.slot
-	high_visibility = copy.high_visibility
+	accessory_slot            = copy.accessory_slot
+	accessory_high_visibility = copy.accessory_high_visibility
 	return copy
 
 //*****************

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -1,11 +1,22 @@
-/obj/item/clothing/proc/can_attach_accessory(obj/item/clothing/accessory/A)
-	if(valid_accessory_slots && istype(A) && (A.slot in valid_accessory_slots))
-		.=1
+/obj/item/clothing
+	var/accessory_slot
+	var/accessory_removable = FALSE
+	/// if it should appear on examine without detailed view
+	var/accessory_high_visibility
+	/// used when an accessory is meant to slow the wearer down when attached to clothing
+	var/accessory_slowdown
+	var/accessory_hide_on_uniform_rolldown = FALSE
+	var/accessory_hide_on_uniform_rollsleeves = FALSE
+
+
+/obj/item/clothing/proc/can_attach_accessory(obj/item/clothing/accessory)
+	if(valid_accessory_slots && istype(accessory) && !isnull(accessory.accessory_slot) && (accessory.accessory_slot in valid_accessory_slots))
+		. = 1
 	else
 		return 0
-	if(accessories.len && restricted_accessory_slots && (A.slot in restricted_accessory_slots))
-		for(var/obj/item/clothing/accessory/AC in accessories)
-			if (AC.slot == A.slot)
+	if(LAZYLEN(accessories) && restricted_accessory_slots && (accessory.accessory_slot in restricted_accessory_slots))
+		for(var/obj/item/clothing/other_accessory in accessories)
+			if (other_accessory.accessory_slot == accessory.accessory_slot)
 				return 0
 
 // Override for action buttons.
@@ -15,41 +26,33 @@
 	return ..()
 
 /obj/item/clothing/attackby(var/obj/item/I, var/mob/user)
-	if(istype(I, /obj/item/clothing/accessory))
+	if(istype(I, /obj/item/clothing))
 
-		if(!valid_accessory_slots || !valid_accessory_slots.len)
-			to_chat(usr, "<span class='warning'>You cannot attach accessories of any kind to \the [src].</span>")
-			return
+		var/obj/item/clothing/accessory = I
+		if(!isnull(accessory.accessory_slot))
 
-		var/obj/item/clothing/accessory/A = I
-		if(can_attach_accessory(A))
-			if(!user.try_unequip(A))
-				return
-			attach_accessory(user, A)
-			return
-		else
-			to_chat(user, "<span class='warning'>You cannot attach more accessories of this type to [src].</span>")
-		return
+			if(!valid_accessory_slots || !valid_accessory_slots.len)
+				to_chat(usr, SPAN_WARNING("You cannot attach accessories of any kind to \the [src]."))
+				return TRUE
+
+			if(can_attach_accessory(accessory))
+				if(user.try_unequip(accessory))
+					attach_accessory(user, accessory)
+			else
+				to_chat(user, SPAN_WARNING("You cannot attach more accessories of this type to [src]."))
+			return TRUE
 
 	if(length(accessories))
-		for(var/obj/item/clothing/accessory/A in accessories)
-			A.attackby(I, user)
+		for(var/obj/item/clothing/accessory in accessories)
+			accessory.attackby(I, user)
 		return
 
 	. = ..()
 
-/obj/item/clothing/attack_hand(var/mob/user)
-	//only forward to the attached accessory if the clothing is equipped (not in a storage)
-	if(!length(accessories) || loc != user)
-		return ..()
-	for(var/obj/item/clothing/accessory/A in accessories)
-		. = A.attack_hand(user) || .
-	return TRUE
-
 /obj/item/clothing/proc/update_accessory_slowdown()
 	slowdown_accessory = 0
-	for(var/obj/item/clothing/accessory/A in accessories)
-		slowdown_accessory += A.slowdown
+	for(var/obj/item/clothing/accessory in accessories)
+		slowdown_accessory += accessory.accessory_slowdown
 
 /**
  *  Attach accessory A to src
@@ -57,23 +60,23 @@
  *  user is the user doing the attaching. Can be null, such as when attaching
  *  items on spawn
  */
-/obj/item/clothing/proc/attach_accessory(mob/user, obj/item/clothing/accessory/A)
-	if(A in accessories)
+/obj/item/clothing/proc/attach_accessory(mob/user, obj/item/clothing/accessory)
+	if(accessory in accessories)
 		return
-	accessories += A
-	A.on_attached(src, user)
-	if(A.removable)
+	LAZYADD(accessories, accessory)
+	accessory.on_attached(src, user)
+	if(accessory.accessory_removable)
 		src.verbs |= /obj/item/clothing/proc/removetie_verb
 	update_accessory_slowdown()
 	update_icon()
 	update_clothing_icon()
 
-/obj/item/clothing/proc/remove_accessory(mob/user, obj/item/clothing/accessory/A)
-	if(!A || !(A in accessories) || !A.removable || !A.canremove)
+/obj/item/clothing/proc/remove_accessory(mob/user, obj/item/clothing/accessory)
+	if(!accessory || !(accessory in accessories) || !accessory.accessory_removable || !accessory.canremove)
 		return
 
-	A.on_removed(user)
-	accessories -= A
+	accessory.on_removed(user)
+	LAZYREMOVE(accessories, accessory)
 	update_accessory_slowdown()
 	update_icon()
 	update_clothing_icon()
@@ -95,8 +98,8 @@
 		return
 
 	var/list/removable_accessories = list()
-	for(var/obj/item/clothing/accessory/accessory in accessories)
-		if(accessory.canremove && accessory.removable)
+	for(var/obj/item/clothing/accessory in accessories)
+		if(accessory.canremove && accessory.accessory_removable)
 			removable_accessories += accessory
 
 	if(!length(removable_accessories))
@@ -104,19 +107,64 @@
 		verbs -= /obj/item/clothing/proc/removetie_verb
 		return
 
-	var/obj/item/clothing/accessory/A
+	var/obj/item/clothing/accessory
 	if(LAZYLEN(removable_accessories) > 1)
-		A = show_radial_menu(M, M, make_item_radial_menu_choices(removable_accessories), radius = 42, tooltips = TRUE)
+		accessory = show_radial_menu(M, M, make_item_radial_menu_choices(removable_accessories), radius = 42, tooltips = TRUE)
 	else
-		A = removable_accessories[1]
+		accessory = removable_accessories[1]
 
-	remove_accessory(usr, A)
+	remove_accessory(usr, accessory)
 
 	if(!LAZYLEN(accessories))
 		verbs -= /obj/item/clothing/proc/removetie_verb
 
 /obj/item/clothing/emp_act(severity)
 	if(length(accessories))
-		for(var/obj/item/clothing/accessory/A in accessories)
-			A.emp_act(severity)
+		for(var/obj/item/clothing/accessory in accessories)
+			accessory.emp_act(severity)
 	..()
+
+/obj/item/clothing/attack_hand(var/mob/user)
+	if(istype(loc, /obj/item/clothing))
+		return TRUE //we aren't an object on the ground so don't call parent
+	//only forward to the attached accessory if the clothing is equipped (not in a storage)
+	if(!length(accessories) || loc != user)
+		return ..()
+	for(var/obj/item/clothing/accessory in accessories)
+		. = accessory.attack_hand(user) || .
+	return TRUE
+
+/obj/item/clothing/proc/on_attached(var/obj/item/clothing/S, var/mob/user)
+	if(istype(S))
+		forceMove(S)
+		if(user)
+			to_chat(user, SPAN_NOTICE("You attach \the [src] to \the [S]."))
+			src.add_fingerprint(user)
+
+/obj/item/clothing/proc/on_removed(var/mob/user)
+	var/obj/item/clothing/suit = loc
+	if(istype(suit))
+		if(user)
+			usr.put_in_hands(src)
+			src.add_fingerprint(user)
+		else
+			dropInto(loc)
+
+/obj/item/clothing/proc/should_overlay()
+	. = istype(loc, /obj/item/clothing)
+	if(. && istype(loc, /obj/item/clothing/under))
+		var/obj/item/clothing/under/uniform = loc
+		if(uniform.rolled_down && accessory_hide_on_uniform_rolldown)
+			return FALSE
+		if(uniform.rolled_sleeves && accessory_hide_on_uniform_rollsleeves)
+			return FALSE
+
+/obj/item/clothing/proc/get_attached_overlay_state()
+	return "attached"
+
+/obj/item/clothing/proc/get_attached_inventory_overlay(var/base_state)
+	var/find_state = "[base_state]-[get_attached_overlay_state()]"
+	if(find_state && check_state_in_icon(find_state, icon))
+		var/image/ret = image(icon, find_state)
+		ret.color = color
+		return ret

--- a/code/modules/clothing/suits/alien.dm
+++ b/code/modules/clothing/suits/alien.dm
@@ -18,7 +18,7 @@
 	name = "shoulder cape"
 	desc = "A simple looking cape with a couple of runes woven into the fabric."
 	icon = 'icons/clothing/accessories/clothing/cape_grunt.dmi'
-	slot = ACCESSORY_SLOT_INSIGNIA // Adding again in case we want to change it in the future.
+	accessory_slot = ACCESSORY_SLOT_INSIGNIA // Adding again in case we want to change it in the future.
 
 /obj/item/clothing/accessory/shouldercape/officer
 	name = "officer's cape"

--- a/code/modules/clothing/suits/armor/bulletproof.dm
+++ b/code/modules/clothing/suits/armor/bulletproof.dm
@@ -58,7 +58,7 @@
 		ARMOR_BOMB = ARMOR_BOMB_PADDED
 		)
 	siemens_coefficient = 0.7
-	slowdown = 1
+	accessory_slowdown = 1
 	material = /decl/material/solid/metal/plasteel
 	matter = list(
 		/decl/material/solid/metal/titanium = MATTER_AMOUNT_REINFORCEMENT,

--- a/code/modules/clothing/suits/armor/laserproof.dm
+++ b/code/modules/clothing/suits/armor/laserproof.dm
@@ -61,4 +61,4 @@
 		ARMOR_BOMB = ARMOR_BOMB_PADDED
 		)
 	siemens_coefficient = 0
-	slowdown = 1
+	accessory_slowdown = 1

--- a/code/modules/clothing/suits/armor/riot.dm
+++ b/code/modules/clothing/suits/armor/riot.dm
@@ -38,7 +38,7 @@
 		ARMOR_BOMB = ARMOR_BOMB_PADDED
 		)
 	siemens_coefficient = 0.5
-	slowdown = 1
+	accessory_slowdown = 1
 	material = /decl/material/solid/metal/steel
 	matter = list(/decl/material/solid/organic/cloth = MATTER_AMOUNT_SECONDARY)
 	origin_tech = @'{"materials":1,"engineering":1,"combat":2}'

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -81,11 +81,3 @@
 	. = ..()
 	var/static/list/under_slots = list(slot_w_uniform_str, slot_wear_id_str)
 	LAZYDISTINCTADD(., under_slots)
-
-// This stub is so the linter stops yelling about sleeping during Initialize()
-// due to corpse props equipping themselves, which calls equip_to_slot, which
-// calls attackby(), which sometimes sleeps due to input(). Yeah.
-// Remove this if a better fix presents itself.
-/obj/item/clothing/under/proc/try_attach_accessory(var/obj/item/accessory, var/mob/user)
-	set waitfor = FALSE
-	attackby(accessory, user)

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -5,93 +5,27 @@
 	icon_state = ICON_STATE_WORLD
 	slot_flags = SLOT_TIE
 	w_class = ITEM_SIZE_SMALL
-
-	var/slot = ACCESSORY_SLOT_DECOR
-	var/high_visibility	//if it should appear on examine without detailed view
-	var/slowdown //used when an accessory is meant to slow the wearer down when attached to clothing
-	var/removable = TRUE
-	var/hide_on_uniform_rolldown = FALSE
-	var/hide_on_uniform_rollsleeves = FALSE
-
-/obj/item/clothing/accessory/Destroy()
-	on_removed()
-	return ..()
+	accessory_slot = ACCESSORY_SLOT_DECOR
+	accessory_removable = TRUE
 
 /obj/item/clothing/accessory/get_fallback_slot(var/slot)
 	if(slot != BP_L_HAND && slot != BP_R_HAND)
 		return slot_tie_str
-
-/obj/item/clothing/accessory/proc/on_attached(var/obj/item/clothing/S, var/mob/user)
-	if(istype(S))
-		forceMove(S)
-		if(user)
-			to_chat(user, SPAN_NOTICE("You attach \the [src] to \the [S]."))
-			src.add_fingerprint(user)
-
-/obj/item/clothing/accessory/proc/on_removed(var/mob/user)
-	var/obj/item/clothing/suit = loc
-	if(istype(suit))
-		if(user)
-			usr.put_in_hands(src)
-			src.add_fingerprint(user)
-		else
-			dropInto(loc)
-
-//default attackby behaviour
-/obj/item/clothing/accessory/attackby(obj/item/I, mob/user)
-	..()
-
-//default attack_hand behaviour
-/obj/item/clothing/accessory/attack_hand(mob/user)
-	if(istype(loc, /obj/item/clothing))
-		return TRUE //we aren't an object on the ground so don't call parent
-	return ..()
 
 /obj/item/clothing/accessory/get_pressure_weakness(pressure,zone)
 	if(body_parts_covered & zone)
 		return ..()
 	return 1
 
-/obj/item/clothing/accessory/proc/should_overlay()
-	. = istype(loc, /obj/item/clothing)
-	if(. && istype(loc, /obj/item/clothing/under))
-		var/obj/item/clothing/under/uniform = loc
-		if(uniform.rolled_down && hide_on_uniform_rolldown)
-			return FALSE
-		if(uniform.rolled_sleeves && hide_on_uniform_rollsleeves)
-			return FALSE
-
-/obj/item/clothing/accessory/adjust_mob_overlay(mob/living/user_mob, bodytype, image/overlay, slot, bodypart, use_fallback_if_icon_missing = TRUE, skip_offset = FALSE)
-	if(overlay && istype(loc, /obj/item/clothing/under))
-		var/new_state = overlay.icon_state
-		var/obj/item/clothing/under/uniform = loc
-		if(uniform.rolled_down)
-			new_state = "[new_state]-rolled"
-		else if(uniform.rolled_sleeves)
-			new_state = "[new_state]-sleeves"
-		if(check_state_in_icon(overlay.icon, new_state))
-			overlay.icon_state = new_state
-	. = ..()
-
-/obj/item/clothing/accessory/proc/get_attached_overlay_state()
-	return "attached"
-
-/obj/item/clothing/accessory/proc/get_attached_inventory_overlay(var/base_state)
-	var/find_state = "[base_state]-[get_attached_overlay_state()]"
-	if(find_state && check_state_in_icon(find_state, icon))
-		var/image/ret = image(icon, find_state)
-		ret.color = color
-		return ret
-
 /obj/item/clothing/accessory/OnDisguise(obj/item/copy, mob/user)
 	. = ..()
-	if(istype(copy, /obj/item/clothing/accessory))
-		var/obj/item/clothing/accessory/tie = copy
-		hide_on_uniform_rolldown =    tie.hide_on_uniform_rolldown
-		hide_on_uniform_rollsleeves = tie.hide_on_uniform_rollsleeves
+	if(istype(copy, /obj/item/clothing))
+		var/obj/item/clothing/accessory = copy
+		accessory_hide_on_uniform_rolldown =    accessory.accessory_hide_on_uniform_rolldown
+		accessory_hide_on_uniform_rollsleeves = accessory.accessory_hide_on_uniform_rollsleeves
 	else
-		hide_on_uniform_rolldown =    initial(hide_on_uniform_rolldown)
-		hide_on_uniform_rollsleeves = initial(hide_on_uniform_rollsleeves)
+		accessory_hide_on_uniform_rolldown =    initial(accessory_hide_on_uniform_rolldown)
+		accessory_hide_on_uniform_rollsleeves = initial(accessory_hide_on_uniform_rollsleeves)
 
 //Necklaces
 /obj/item/clothing/accessory/necklace

--- a/code/modules/clothing/under/accessories/armband.dm
+++ b/code/modules/clothing/under/accessories/armband.dm
@@ -2,10 +2,10 @@
 	name = "red armband"
 	desc = "A fancy red armband!"
 	icon = 'icons/clothing/accessories/armbands/armband_security.dmi'
-	slot = ACCESSORY_SLOT_ARMBAND
 	bodytype_equip_flags = null
-	hide_on_uniform_rolldown = TRUE
-	hide_on_uniform_rollsleeves = TRUE
+	accessory_slot = ACCESSORY_SLOT_ARMBAND
+	accessory_hide_on_uniform_rolldown = TRUE
+	accessory_hide_on_uniform_rollsleeves = TRUE
 
 /obj/item/clothing/accessory/armband/cargo
 	name = "cargo armband"

--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -6,15 +6,15 @@
 	icon_state = ICON_STATE_WORLD
 	color = COLOR_GRAY40
 	gender = PLURAL
-	slot = ACCESSORY_SLOT_ARMOR_S
 	slots = 2
+	accessory_slot = ACCESSORY_SLOT_ARMOR_S
 
 /obj/item/clothing/accessory/storage/pouches/large
 	name = "large storage pouches"
 	desc = "A collection of black pouches that can be attached to a plate carrier. Carries up to four items."
 	icon = 'icons/clothing/accessories/pouches/lpouches.dmi'
 	slots = 4
-	slowdown = 1
+	accessory_slowdown = 1
 
 /obj/item/clothing/accessory/storage/pouches/large/tan
 	color = COLOR_TAN
@@ -32,7 +32,7 @@
 		ARMOR_ENERGY = ARMOR_ENERGY_MINOR,
 		ARMOR_BOMB = ARMOR_BOMB_MINOR
 		)
-	slot = ACCESSORY_SLOT_ARMOR_C
+	accessory_slot = ACCESSORY_SLOT_ARMOR_C
 	material = /decl/material/solid/organic/plastic
 	matter = list(
 		/decl/material/solid/metal/steel = MATTER_AMOUNT_SECONDARY
@@ -69,7 +69,7 @@
 		ARMOR_ENERGY = ARMOR_ENERGY_RESISTANT,
 		ARMOR_BOMB = ARMOR_BOMB_PADDED
 		)
-	slowdown = 0.5
+	accessory_slowdown = 0.5
 	material = /decl/material/solid/metal/plasteel
 	matter = list(
 		/decl/material/solid/metal/titanium = MATTER_AMOUNT_REINFORCEMENT,
@@ -93,7 +93,7 @@
 		ARMOR_ENERGY = ARMOR_ENERGY_SMALL,
 		ARMOR_BOMB = ARMOR_BOMB_PADDED
 		)
-	slot = ACCESSORY_SLOT_ARMOR_A
+	accessory_slot = ACCESSORY_SLOT_ARMOR_A
 	material = /decl/material/solid/organic/plastic
 	matter = list(
 		/decl/material/solid/metal/steel = MATTER_AMOUNT_SECONDARY
@@ -121,7 +121,7 @@
 		ARMOR_ENERGY = ARMOR_ENERGY_SMALL,
 		ARMOR_BOMB = ARMOR_BOMB_PADDED
 		)
-	slot = ACCESSORY_SLOT_ARMOR_L
+	accessory_slot = ACCESSORY_SLOT_ARMOR_L
 	material = /decl/material/solid/organic/plastic
 	matter = list(
 		/decl/material/solid/metal/steel = MATTER_AMOUNT_SECONDARY
@@ -143,7 +143,7 @@
 	name = "\improper WARDEN tag"
 	desc = "A tag with the word WARDEN printed in silver lettering on it."
 	icon = 'icons/clothing/accessories/tags/tag_large.dmi'
-	slot = ACCESSORY_SLOT_ARMOR_M
+	accessory_slot = ACCESSORY_SLOT_ARMOR_M
 
 /obj/item/clothing/accessory/armor/tag/press
 	name = "\improper PRESS tag"
@@ -200,7 +200,7 @@
 	desc = "A fabric cover for armored helmets."
 	icon = 'icons/clothing/accessories/armor/helmcover.dmi'
 	icon_state = ICON_STATE_WORLD
-	slot = ACCESSORY_SLOT_HELM_C
+	accessory_slot = ACCESSORY_SLOT_HELM_C
 
 /obj/item/clothing/accessory/armor/helmcover/blue
 	color = COLOR_SKY_BLUE

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -9,9 +9,9 @@
 	desc = "A leather-backed badge, with gold trimmings."
 	icon = 'icons/clothing/accessories/badges/detectivebadge.dmi'
 	slot_flags = SLOT_LOWER_BODY | SLOT_TIE
-	slot = ACCESSORY_SLOT_INSIGNIA
-	high_visibility = 1
-	hide_on_uniform_rolldown = TRUE
+	accessory_slot = ACCESSORY_SLOT_INSIGNIA
+	accessory_high_visibility = TRUE
+	accessory_hide_on_uniform_rolldown = TRUE
 	var/badge_string = "Detective"
 	var/stored_name
 

--- a/code/modules/clothing/under/accessories/buddytag.dm
+++ b/code/modules/clothing/under/accessories/buddytag.dm
@@ -4,7 +4,7 @@
 	desc = "A tiny device, paired up with a counterpart set to same code. When devices are taken apart too far, they start beeping."
 	icon = 'icons/clothing/accessories/buddytag.dmi'
 	slot_flags = SLOT_TIE
-	high_visibility = 1
+	accessory_high_visibility = TRUE
 	var/next_search = 0
 	var/on = 0
 	var/id = 1

--- a/code/modules/clothing/under/accessories/chaplaininsignia.dm
+++ b/code/modules/clothing/under/accessories/chaplaininsignia.dm
@@ -2,8 +2,8 @@
 	name = "chaplain insignia (christianity)"
 	desc = "An insignia worn by chaplains. The cross represents Christianity."
 	icon = 'icons/clothing/accessories/religious/icon_christianity.dmi'
-	hide_on_uniform_rolldown = TRUE
-	slot = ACCESSORY_SLOT_INSIGNIA
+	accessory_hide_on_uniform_rolldown = TRUE
+	accessory_slot = ACCESSORY_SLOT_INSIGNIA
 
 /obj/item/clothing/accessory/chaplaininsignia/judaism
 	name = "chaplain insignia (judaism)"

--- a/code/modules/clothing/under/accessories/cloaks.dm
+++ b/code/modules/clothing/under/accessories/cloaks.dm
@@ -3,13 +3,13 @@
 	desc = "A simple, bland cloak."
 	icon = 'icons/clothing/suit/cloaks/_cloak.dmi'
 	w_class = ITEM_SIZE_NORMAL
-	slot = ACCESSORY_SLOT_OVER
 	slot_flags = SLOT_OVER_BODY
 	allowed = list(/obj/item/tank/emergency/oxygen)
-	high_visibility = TRUE
 	armor = list(ARMOR_MELEE = 0, ARMOR_BULLET = 0, ARMOR_LASER = 0,ARMOR_ENERGY = 0, ARMOR_BOMB = 0, ARMOR_BIO = 0, ARMOR_RAD = 0)
 	body_parts_covered = SLOT_UPPER_BODY|SLOT_LOWER_BODY|SLOT_ARMS|SLOT_LEGS
 	siemens_coefficient = 0.9
+	accessory_slot = ACCESSORY_SLOT_OVER
+	accessory_high_visibility = TRUE
 
 /obj/item/clothing/accessory/cloak/on_update_icon()
 	. = ..()

--- a/code/modules/clothing/under/accessories/clothing.dm
+++ b/code/modules/clothing/under/accessories/clothing.dm
@@ -110,7 +110,7 @@
 
 	armor = list(ARMOR_LASER = ARMOR_LASER_MINOR, ARMOR_ENERGY = ARMOR_ENERGY_MINOR, ARMOR_BOMB = ARMOR_BOMB_MINOR)
 	body_parts_covered = SLOT_LOWER_BODY | SLOT_LEGS | SLOT_TAIL
-	slowdown = 0.5
+	accessory_slowdown = 0.5
 
 	heat_protection = SLOT_LOWER_BODY | SLOT_LEGS | SLOT_TAIL
 	cold_protection = SLOT_LOWER_BODY | SLOT_LEGS | SLOT_TAIL
@@ -122,7 +122,7 @@
 	name = "venter assembly"
 	desc = "A series of complex tubes, meant to dissipate heat from the skin passively."
 	icon = 'icons/clothing/accessories/venter.dmi'
-	slot = "over"
+	accessory_slot = "over"
 
 /obj/item/clothing/accessory/space_adapted/bracer
 	name = "legbrace"

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -2,9 +2,9 @@
 	name = "shoulder holster"
 	desc = "A handgun holster."
 	icon = 'icons/clothing/accessories/holsters/holster.dmi'
-	slot = ACCESSORY_SLOT_HOLSTER
 	slots = 1
 	max_w_class = ITEM_SIZE_NORMAL
+	accessory_slot = ACCESSORY_SLOT_HOLSTER
 	var/list/can_holster = null
 	var/sound_in = 'sound/effects/holster/holsterin.ogg'
 	var/sound_out = 'sound/effects/holster/holsterout.ogg'

--- a/code/modules/clothing/under/accessories/medals.dm
+++ b/code/modules/clothing/under/accessories/medals.dm
@@ -4,7 +4,7 @@
 	name = ACCESSORY_SLOT_MEDAL
 	desc = "A simple medal."
 	icon = 'icons/clothing/accessories/medals/medal_bronze.dmi'
-	slot = ACCESSORY_SLOT_MEDAL
+	accessory_slot = ACCESSORY_SLOT_MEDAL
 
 /obj/item/clothing/accessory/medal/bronze
 	name = "bronze medal"

--- a/code/modules/clothing/under/accessories/stethoscope.dm
+++ b/code/modules/clothing/under/accessories/stethoscope.dm
@@ -2,7 +2,7 @@
 	name = "stethoscope"
 	desc = "An outdated medical apparatus for listening to the sounds of the human body. It also makes you look like you know what you're doing."
 	icon = 'icons/clothing/accessories/stethoscope.dmi'
-	high_visibility = 1
+	accessory_high_visibility = TRUE
 
 /obj/item/clothing/accessory/stethoscope/attack(mob/living/carbon/human/M, mob/living/user)
 	if(ishuman(M) && isliving(user) && user.a_intent == I_HELP)

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -2,10 +2,10 @@
 	name = "webbing"
 	desc = "Sturdy mess of synthcotton belts and buckles, ready to share your burden."
 	icon = 'icons/clothing/accessories/storage/webbing.dmi'
-	slot = ACCESSORY_SLOT_UTILITY
 	w_class = ITEM_SIZE_NORMAL
-	high_visibility = 1
-	hide_on_uniform_rolldown = TRUE
+	accessory_slot = ACCESSORY_SLOT_UTILITY
+	accessory_high_visibility = TRUE
+	accessory_hide_on_uniform_rolldown = TRUE
 	var/slots = 3
 	var/max_w_class = ITEM_SIZE_SMALL //pocket sized
 	var/obj/item/storage/internal/pockets/hold

--- a/code/modules/clothing/under/accessories/vitals_sensor.dm
+++ b/code/modules/clothing/under/accessories/vitals_sensor.dm
@@ -4,7 +4,7 @@
 	slot_flags = SLOT_TIE
 	icon = 'icons/clothing/accessories/vitals_sensor.dmi'
 	icon_state = ICON_STATE_WORLD
-	slot = ACCESSORY_SLOT_SENSORS
+	accessory_slot = ACCESSORY_SLOT_SENSORS
 	var/sensors_locked = FALSE
 	var/sensor_mode
 	var/static/list/sensor_modes = list(
@@ -54,9 +54,9 @@
 /obj/item/clothing/accessory/vitals_sensor/proc/update_removable()
 	var/obj/item/clothing/clothes = loc
 	if(istype(clothes) && (src in clothes.accessories))
-		removable = !sensors_locked
+		accessory_removable = !sensors_locked
 	else
-		removable = TRUE
+		accessory_removable = TRUE
 
 /obj/item/clothing/accessory/vitals_sensor/proc/set_sensor_mode(var/new_sensor_mode)
 	if(sensor_mode != new_sensor_mode)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -47,7 +47,7 @@
 		return TRUE
 
 	if(slot == slot_tie_str)
-		var/obj/item/clothing/under/uniform = get_equipped_item(slot_w_uniform_str)
+		var/obj/item/clothing/uniform = get_equipped_item(slot_w_uniform_str)
 		if(istype(uniform))
 			uniform.try_attach_accessory(W, src)
 		return TRUE

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -71,10 +71,10 @@ meteor_act
 		var/obj/item/clothing/gear = get_equipped_item(slot)
 		if(!istype(gear))
 			continue
-		if(gear.accessories.len)
-			for(var/obj/item/clothing/accessory/bling in gear.accessories)
-				if(bling.body_parts_covered & def_zone.body_part)
-					var/armor = get_extension(bling, /datum/extension/armor)
+		if(LAZYLEN(gear.accessories))
+			for(var/obj/item/clothing/accessory in gear.accessories)
+				if(accessory.body_parts_covered & def_zone.body_part)
+					var/armor = get_extension(accessory, /datum/extension/armor)
 					if(armor)
 						. += armor
 		if(gear.body_parts_covered & def_zone.body_part)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -291,10 +291,10 @@
 		if(istype(C))
 			if(C.max_heat_protection_temperature && C.max_heat_protection_temperature >= temperature)
 				. |= C.heat_protection
-			if(C.accessories.len)
-				for(var/obj/item/clothing/accessory/A in C.accessories)
-					if(A.max_heat_protection_temperature && A.max_heat_protection_temperature >= temperature)
-						. |= A.heat_protection
+			if(LAZYLEN(C.accessories))
+				for(var/obj/item/clothing/accessory in C.accessories)
+					if(accessory.max_heat_protection_temperature && accessory.max_heat_protection_temperature >= temperature)
+						. |= accessory.heat_protection
 
 //See proc/get_heat_protection_flags(temperature) for the description of this proc.
 /mob/living/carbon/human/proc/get_cold_protection_flags(temperature)
@@ -305,10 +305,10 @@
 		if(istype(C))
 			if(C.min_cold_protection_temperature && C.min_cold_protection_temperature <= temperature)
 				. |= C.cold_protection
-			if(C.accessories.len)
-				for(var/obj/item/clothing/accessory/A in C.accessories)
-					if(A.min_cold_protection_temperature && A.min_cold_protection_temperature <= temperature)
-						. |= A.cold_protection
+			if(LAZYLEN(C.accessories))
+				for(var/obj/item/clothing/accessory in C.accessories)
+					if(accessory.min_cold_protection_temperature && accessory.min_cold_protection_temperature <= temperature)
+						. |= accessory.cold_protection
 
 
 /mob/living/carbon/human/get_heat_protection(temperature) //Temperature is the temperature you're being exposed to.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -351,7 +351,7 @@
 			dat += "<B>[capitalize(get_descriptive_slot_name(slot))]:</b> <a href='?src=\ref[src];item=[slot]'>[thing_in_slot || "nothing"]</a>"
 			if(istype(thing_in_slot, /obj/item/clothing))
 				var/obj/item/clothing/C = thing_in_slot
-				if(C.accessories.len)
+				if(LAZYLEN(C.accessories))
 					dat += "<A href='?src=\ref[src];item=[slot_tie_str];holder=\ref[C]'>Remove accessory</A>"
 
 	// Do they get an option to set internals?

--- a/code/modules/mob/stripping.dm
+++ b/code/modules/mob/stripping.dm
@@ -52,28 +52,28 @@
 				toggle_internals(user)
 			return
 		if("tie")
-			if(!istype(holder) || !holder.accessories.len)
+			if(!istype(holder) || !LAZYLEN(holder.accessories))
 				return
 
-			var/obj/item/clothing/accessory/A
+			var/obj/item/clothing/accessory
 			if(LAZYLEN(holder.accessories) > 1)
-				A = show_radial_menu(user, user, make_item_radial_menu_choices(holder.accessories), radius = 42, tooltips = TRUE)
+				accessory = show_radial_menu(user, user, make_item_radial_menu_choices(holder.accessories), radius = 42, tooltips = TRUE)
 			else
-				A = holder.accessories[1]
+				accessory = holder.accessories[1]
 
-			if(!istype(A))
+			if(!istype(accessory))
 				return
 
-			visible_message("<span class='danger'>\The [user] is trying to remove \the [src]'s [A.name]!</span>")
+			visible_message("<span class='danger'>\The [user] is trying to remove \the [src]'s [accessory.name]!</span>")
 
 			if(!do_after(user, HUMAN_STRIP_DELAY, src, check_holding = FALSE, progress = FALSE))
 				return
 
-			if(!A || holder.loc != src || !(A in holder.accessories))
+			if(!accessory || holder.loc != src || !(accessory in holder.accessories))
 				return
 
-			admin_attack_log(user, src, "Stripped \an [A] from \the [holder].", "Was stripped of \an [A] from \the [holder].", "stripped \an [A] from \the [holder] of")
-			holder.remove_accessory(user,A)
+			admin_attack_log(user, src, "Stripped \an [accessory] from \the [holder].", "Was stripped of \an [accessory] from \the [holder].", "stripped \an [accessory] from \the [holder] of")
+			holder.remove_accessory(user, accessory)
 			return
 		else
 			var/obj/item/located_item = locate(slot_to_strip_text) in src


### PR DESCRIPTION
## Description of changes
- Lazylists `accessories` on `/obj/item/clothing`.
- Moves accessory attachment and handling procs and vars from `/obj/item/clothing/accessory` to `/obj/item/clothing`.

## Why and what will this PR improve
Working towards being able to freely mix and match clothing with other clothing without having to awkwardly work around typepaths (see: all the accessory shirts and jackets).

## Authorship
Myself.

## Changelog
Nothing player-facing.