### PR TITLE
Various material stack and recipe tweaks.

### DIFF
--- a/code/__defines/mapping.dm
+++ b/code/__defines/mapping.dm
@@ -40,3 +40,7 @@ if(other_init) { \
 #define MAP_TEMPLATE_CATEGORY_SPACE           "space_template"
 #define MAP_TEMPLATE_CATEGORY_AWAYSITE        "awaysite_template"
 #define MAP_TEMPLATE_CATEGORY_LANDMARK_LOADED "landmark_template"
+
+/// Used to filter out some crafting recipes.
+#define MAP_TECH_LEVEL_ANY     0
+#define MAP_TECH_LEVEL_SPACE 100

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -154,8 +154,8 @@
 
 
 /obj/item/stack/proc/produce_recipe(decl/stack_recipe/recipe, var/quantity, mob/user, var/paint_color)
-	var/required = quantity*recipe.req_amount
-	var/produced = quantity*recipe.res_amount
+	var/required = quantity * recipe.get_required_stack_amount(src)
+	var/produced = quantity * recipe.res_amount
 	if(!isnull(recipe.max_res_amount))
 		produced = min(produced, recipe.max_res_amount)
 	var/decl/material/mat       = get_material()

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -24,7 +24,7 @@
 	var/max_icon_state
 	var/amount = 1
 	var/matter_multiplier = 1
-	var/max_amount //also see stack recipes initialisation, param "max_res_amount" must be equal to this max_amount
+	var/max_amount
 	var/stack_merge_type  //determines whether different stack types can merge
 	var/build_type //used when directly applied to a turf
 	var/uses_charge
@@ -153,33 +153,32 @@
 	popup.open()
 
 
-/obj/item/stack/proc/produce_recipe(decl/stack_recipe/recipe, var/quantity, mob/user, var/paint_color)
-	var/required = quantity * recipe.get_required_stack_amount(src)
-	var/produced = quantity * recipe.res_amount
-	if(!isnull(recipe.max_res_amount))
-		produced = min(produced, recipe.max_res_amount)
+/obj/item/stack/proc/produce_recipe(decl/stack_recipe/recipe, var/producing, var/expending, mob/user, paint_color)
+
+	if(producing <= 0 || expending <= 0 || expending > get_amount())
+		return
+
 	var/decl/material/mat       = get_material()
 	var/decl/material/reinf_mat = get_reinforced_material()
-
-	if (!can_use(required))
-		to_chat(user, SPAN_WARNING("You haven't got enough [plural_name] to [recipe.get_craft_verb(src)] [recipe.get_display_name(produced, mat, reinf_mat)]!"))
+	if (!can_use(expending))
+		to_chat(user, SPAN_WARNING("You haven't got enough [plural_name] to [recipe.get_craft_verb(src)] [recipe.get_display_name(producing, mat, reinf_mat)]!"))
 		return
 	if(!recipe.can_make(user))
 		return
 	if (recipe.time)
-		to_chat(user, SPAN_NOTICE("You set about [recipe.get_craft_verbing(src)] [recipe.get_display_name(produced, mat, reinf_mat)]..."))
+		to_chat(user, SPAN_NOTICE("You set about [recipe.get_craft_verbing(src)] [recipe.get_display_name(producing, mat, reinf_mat)]..."))
 		if (!user.do_skilled(recipe.time, SKILL_CONSTRUCTION))
 			return
 
-	if(!use(required))
+	if(!use(expending))
 		return
 
 	if(user.skill_fail_prob(SKILL_CONSTRUCTION, 90, recipe.difficulty))
-		to_chat(user, SPAN_WARNING("You waste some [name] and fail to [recipe.get_craft_verb(src)] [recipe.get_display_name(produced, mat, reinf_mat)]!"))
+		to_chat(user, SPAN_WARNING("You waste some [name] and fail to [recipe.get_craft_verb(src)] [recipe.get_display_name(producing, mat, reinf_mat)]!"))
 		return
 
-	to_chat(user, SPAN_NOTICE("You [recipe.get_craft_verb(src)] [recipe.get_display_name(produced, mat, reinf_mat)]!"))
-	var/list/atom/results = recipe.spawn_result(user, user.loc, produced, mat, reinf_mat, paint_color)
+	to_chat(user, SPAN_NOTICE("You [recipe.get_craft_verb(src)] [recipe.get_display_name(producing, mat, reinf_mat)]!"))
+	var/list/atom/results = recipe.spawn_result(user, user.loc, producing, mat, reinf_mat, paint_color)
 	var/atom/movable/O = LAZYACCESS(results, 1)
 	if(istype(O) && !QDELETED(O)) // In case of stack merger.
 		O.add_fingerprint(user)
@@ -229,11 +228,10 @@
 				return TOPIC_NOACTION
 
 		// Validate the target amount and create the product.
-		var/multiplier = clamp(text2num(href_list["multiplier"]), 0, min(round(get_amount() / recipe.req_amount)))
-		if(!isnull(recipe.max_res_amount))
-			multiplier = min(multiplier, round(recipe.max_res_amount / recipe.res_amount))
-		if(multiplier > 0)
-			produce_recipe(recipe, multiplier, user, paint_color)
+		var/producing = text2num(href_list["producing"])
+		var/expending = text2num(href_list["expending"])
+		if(producing > 0 && expending > 0)
+			produce_recipe(recipe, producing, expending, user, paint_color)
 			return TOPIC_REFRESH
 
 	return TOPIC_NOACTION

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -15,7 +15,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	max_amount = 100
 	icon = 'icons/obj/tiles.dmi'
-	matter_multiplier = 0.15
+	matter_multiplier = 0.2
 	force = 1
 	throwforce = 1
 	throw_speed = 5

--- a/code/modules/crafting/stack_recipes/_recipe.dm
+++ b/code/modules/crafting/stack_recipes/_recipe.dm
@@ -25,10 +25,6 @@
 	var/result_type
 	/// Amount of matter units needed for this recipe. If null, generates from result matter.
 	var/req_amount
-	/// Amount of stuff that is produced in one batch (e.g. 4 for floor tiles).
-	var/res_amount                       = 1
-	// Caps the amount that can be produced in one craft action. Set to null for no cap.
-	var/max_res_amount
 	/// Time it takes for this recipe to be crafted (not including skill and tool modifiers). If null, generates from product w_class and difficulty.
 	var/time
 	/// If set, only one of this object can be made per turf.
@@ -43,7 +39,10 @@
 	var/set_dir_on_spawn                 = TRUE
 	/// Used to validate some checks like matter (since /turf has no matter).
 	var/expected_product_type            = /obj
-	/// Used for providing a display name.
+	/// Used to prevent multiple being crafted at once.
+	var/allow_multiple_craft = TRUE
+	/// Category var used to discriminate recipes per-map. Unrelated to origin_tech.
+	var/available_to_map_tech_level = MAP_TECH_LEVEL_ANY
 
 	/// What stack types can be used to make this recipe?
 	var/list/craft_stack_types           = list(
@@ -96,17 +95,6 @@
 			time = max(0.5 SECONDS, round(BASE_CRAFTING_TIME + CRAFT_TIME_SIZE(initial(result.w_class)) + CRAFT_TIME_DIFFICULTY(difficulty), 5))
 		if(isnull(gender))
 			gender = initial(result.gender)
-
-	// Clamp stack max amount to this regardless of anything else
-	// so we don't lose material on crafting an impossible stack.
-	if(ispath(result_type, /obj/item/stack))
-		var/obj/item/stack/result_stack = result_type
-		var/stack_max = initial(result_stack.max_amount)
-		if(isnull(max_res_amount) || max_res_amount > stack_max)
-			max_res_amount = stack_max
-
-	if(isnull(max_res_amount) && one_per_turf)
-		max_res_amount = 1
 
 	if(isnull(name_plural))
 		name_plural = "[name]s"
@@ -165,16 +153,27 @@
 
 /decl/stack_recipe/proc/get_list_display(mob/user, obj/item/stack/stack)
 
+	var/sheets_per_product = req_amount / CEILING(FLOOR(SHEET_MATERIAL_AMOUNT * stack.matter_multiplier))
+	var/products_per_sheet = CEILING(FLOOR(SHEET_MATERIAL_AMOUNT * stack.matter_multiplier)) / req_amount
+	var/clamp_sheets = max(1, CEILING(sheets_per_product))
+	var/max_multiplier = FLOOR(stack.get_amount() / clamp_sheets)
+
+	// Stacks can have a max bound that will cause us to waste material on crafting an impossible amount.
+	if(ispath(result_type, /obj/item/stack))
+		var/obj/item/stack/product_stack = result_type
+		max_multiplier = min(max_multiplier, initial(product_stack.max_amount) * sheets_per_product)
+	else
+		// TODO: work out what types should let you craft multiple.
+		max_multiplier = min(max_multiplier, 1)
+
 	. = list("<tr>")
 
 	. += "<td width = '150px'>"
-	. += get_display_name(res_amount, apply_article = FALSE)
+	. += get_display_name(max(1, FLOOR(products_per_sheet)), apply_article = FALSE)
 	. += "</td>"
 
-
-	var/stack_req_amount = get_required_stack_amount(stack)
 	. += "<td width = '75px'>"
-	. += "[stack_req_amount] [stack_req_amount == 1 ? stack.singular_name : stack.plural_name]"
+	. += "[clamp_sheets] [clamp_sheets == 1 ? stack.singular_name : stack.plural_name]"
 	. += "</td>"
 
 	. += "<td width = '75px'>"
@@ -192,22 +191,20 @@
 	. += "</td>"
 
 	. += "<td width = '200px'>"
-	var/max_multiplier = round(stack.get_amount() / stack_req_amount)
-	if(max_multiplier)
-		var/min_multiplier = max(1, stack_req_amount)
-		if(max_res_amount > 0)
-			max_multiplier = min(max_multiplier, round(max_res_amount / res_amount))
-		var/static/list/multipliers = list(1, 5, 10, 25, 50)
-		if(!(min_multiplier in multipliers))
-			. += "<a href='?src=\ref[stack];make=\ref[src];multiplier=[min_multiplier]'>[min_multiplier*res_amount]x</a>"
-		for(var/n in multipliers)
-			if(n <= min_multiplier)
-				continue
-			if(max_multiplier < n)
-				break
-			. += "<a href='?src=\ref[stack];make=\ref[src];multiplier=[n]'>[n*res_amount]x</a>"
-		if(!(max_multiplier in multipliers))
-			. += "<a href='?src=\ref[stack];make=\ref[src];multiplier=[max_multiplier]'>[max_multiplier*res_amount]x</a>"
+	if(max_multiplier <= 0 || clamp_sheets > stack.get_amount())
+		. += "Insufficient materials."
+	else if(allow_multiple_craft && !one_per_turf && clamp_sheets <= max_multiplier)
+		var/new_row = 5
+		for(var/i = clamp_sheets to max_multiplier step clamp_sheets)
+			var/producing = i * FLOOR(products_per_sheet)
+			. += "<a href='?src=\ref[stack];make=\ref[src];producing=[producing];expending=[i]'>[producing]x</a>"
+			if(new_row == 0)
+				new_row = 5
+				. += "<br>"
+			else
+				new_row--
+	else
+		. += "<a href='?src=\ref[stack];make=\ref[src];producing=[FLOOR(clamp_sheets * products_per_sheet)];expending=[clamp_sheets]'>1x</a>"
 
 	. += "</td>"
 	. += "</tr>"
@@ -296,10 +293,13 @@
 	if(result_type && isnull(req_amount))
 		req_amount = 0
 		var/list/materials
-		materials = atom_info_repository.get_matter_for(result_type, (ispath(required_material) ? required_material : null), res_amount)
+		materials = atom_info_repository.get_matter_for(result_type, (ispath(required_material) ? required_material : null))
 		for(var/mat in materials)
-			req_amount += round(materials[mat]/res_amount)
+			req_amount += round(materials[mat])
 		req_amount = CEILING(req_amount*crafting_extra_cost_factor)
+		if(!ispath(result_type, /obj/item/stack))
+			// Due to matter calc, without this clamping, one sheet can make 32x grenade casings. Not ideal.
+			req_amount = max(req_amount, SHEET_MATERIAL_AMOUNT)
 
 /decl/stack_recipe/proc/get_display_name(amount, decl/material/mat, decl/material/reinf_mat, apply_article = TRUE)
 	var/material_strings

--- a/code/modules/crafting/stack_recipes/_recipe_getter.dm
+++ b/code/modules/crafting/stack_recipes/_recipe_getter.dm
@@ -35,6 +35,8 @@ var/global/list/cached_recipes = list()
 		var/list/all_recipes = decls_repository.get_decls_of_subtype(/decl/stack_recipe)
 		for(var/recipe_type in all_recipes)
 			var/decl/stack_recipe/recipe = all_recipes[recipe_type]
+			if(global.using_map.map_tech_level < recipe.available_to_map_tech_level)
+				continue
 			if(recipe.can_be_made_from(stack_type, tool_type, mat, reinf_mat))
 				if(recipe.category)
 					LAZYDISTINCTADD(grouped_recipes[recipe.category], recipe)

--- a/code/modules/crafting/stack_recipes/recipe_structures.dm
+++ b/code/modules/crafting/stack_recipes/recipe_structures.dm
@@ -5,3 +5,4 @@
 	difficulty          = MAT_VALUE_VERY_HARD_DIY
 	apply_material_name = FALSE
 	required_material   = /decl/material/solid/metal/chromium
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE

--- a/code/modules/crafting/stack_recipes/recipes_bricks.dm
+++ b/code/modules/crafting/stack_recipes/recipes_bricks.dm
@@ -27,7 +27,7 @@
 
 /decl/stack_recipe/bricks/furniture/planting_bed
 	result_type                = /obj/machinery/portable_atmospherics/hydroponics/soil
-	req_amount                 = 3 // Arbitrary value since machines don't handle matter properly yet.
+	req_amount                 = 3 * SHEET_MATERIAL_AMOUNT // Arbitrary value since machines don't handle matter properly yet.
 
 /decl/stack_recipe/bricks/furniture/planting_bed/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat, paint_color)
 	return list(new result_type(location))

--- a/code/modules/crafting/stack_recipes/recipes_cardstock.dm
+++ b/code/modules/crafting/stack_recipes/recipes_cardstock.dm
@@ -1,6 +1,7 @@
 /decl/stack_recipe/cardstock
 	abstract_type     = /decl/stack_recipe/cardstock
 	craft_stack_types = /obj/item/stack/material/cardstock
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE // not exactly high tech, but donuts etc are not medieval
 
 /decl/stack_recipe/cardstock/box
 	result_type       = /obj/item/storage/box

--- a/code/modules/crafting/stack_recipes/recipes_clay.dm
+++ b/code/modules/crafting/stack_recipes/recipes_clay.dm
@@ -1,5 +1,4 @@
 /decl/stack_recipe/clay
-	res_amount                  = 1
 	time                        = 1 SECOND
 	abstract_type               = /decl/stack_recipe/clay
 	required_material           = /decl/material/solid/clay
@@ -23,8 +22,6 @@
 
 /decl/stack_recipe/clay/brick
 	name_plural                 = "bricks"
-	res_amount                  = 2
-	max_res_amount              = 20
 	result_type                 = /obj/item/stack/material/brick/clay
 
 /decl/stack_recipe/clay/brick/spawn_result(user, location, amount)

--- a/code/modules/crafting/stack_recipes/recipes_hardness.dm
+++ b/code/modules/crafting/stack_recipes/recipes_hardness.dm
@@ -40,10 +40,12 @@
 /decl/stack_recipe/hardness/drill_head
 	result_type       = /obj/item/drill_head
 	difficulty        = MAT_VALUE_EASY_DIY
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /decl/stack_recipe/hardness/baseball_bat
 	result_type       = /obj/item/twohanded/baseballbat
 	difficulty        = MAT_VALUE_HARD_DIY
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE // similar to boxes, not thematically appropriate to low tech
 
 /decl/stack_recipe/hardness/ashtray
 	result_type       = /obj/item/ashtray
@@ -56,6 +58,7 @@
 
 /decl/stack_recipe/hardness/clipboard
 	result_type       = /obj/item/clipboard
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /decl/stack_recipe/hardness/cross
 	result_type       = /obj/item/cross

--- a/code/modules/crafting/stack_recipes/recipes_hardness_integrity.dm
+++ b/code/modules/crafting/stack_recipes/recipes_hardness_integrity.dm
@@ -10,7 +10,7 @@
 
 /decl/stack_recipe/hardness/integrity/furniture/door
 	result_type        = /obj/structure/door
-	req_amount         = 5 // Arbitrary value since doors return weird matter values.
+	req_amount         = 5 * SHEET_MATERIAL_AMOUNT // Arbitrary value since doors return weird matter values.
 
 /decl/stack_recipe/hardness/integrity/furniture/barricade
 	result_type        = /obj/structure/barricade

--- a/code/modules/crafting/stack_recipes/recipes_hardness_integrity.dm
+++ b/code/modules/crafting/stack_recipes/recipes_hardness_integrity.dm
@@ -47,6 +47,7 @@
 
 /decl/stack_recipe/hardness/integrity/furniture/tank_dispenser
 	result_type        = /obj/structure/tank_rack
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /decl/stack_recipe/hardness/integrity/furniture/coffin
 	result_type        = /obj/structure/closet/coffin
@@ -57,6 +58,7 @@
 
 /decl/stack_recipe/hardness/integrity/furniture/chair/office
 	result_type        = /obj/structure/bed/chair/office/comfy/unpadded
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /decl/stack_recipe/hardness/integrity/furniture/chair/comfy
 	result_type        = /obj/structure/bed/chair/comfy/unpadded
@@ -78,6 +80,4 @@
 
 /decl/stack_recipe/hardness/integrity/rod
 	result_type        = /obj/item/stack/material/rods
-	res_amount         = 2
-	max_res_amount     = 60
 	difficulty         = MAT_VALUE_NORMAL_DIY

--- a/code/modules/crafting/stack_recipes/recipes_items.dm
+++ b/code/modules/crafting/stack_recipes/recipes_items.dm
@@ -3,6 +3,7 @@
 	result_type       = /obj/item/grenade/chem_grenade
 	difficulty        = MAT_VALUE_VERY_HARD_DIY
 	required_material = /decl/material/solid/metal/aluminium
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /decl/stack_recipe/candle
 	result_type       = /obj/item/flame/candle
@@ -12,8 +13,6 @@
 /decl/stack_recipe/paper_sheets
 	name              = "sheet of paper"
 	result_type       = /obj/item/paper
-	res_amount        = 4
-	max_res_amount    = 30
 	required_material = /decl/material/solid/organic/paper
 
 /decl/stack_recipe/paper_sheets/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat, paint_color)

--- a/code/modules/crafting/stack_recipes/recipes_opacity.dm
+++ b/code/modules/crafting/stack_recipes/recipes_opacity.dm
@@ -27,7 +27,7 @@
 	name                 = "border window"
 	result_type          = /obj/structure/window
 	one_per_turf         = FALSE
-	max_res_amount       = 1 // one per direction
+	allow_multiple_craft = FALSE
 
 /decl/stack_recipe/opacity/borderwindow/can_make(mob/user)
 	. = ..()

--- a/code/modules/crafting/stack_recipes/recipes_panels.dm
+++ b/code/modules/crafting/stack_recipes/recipes_panels.dm
@@ -1,6 +1,7 @@
 /decl/stack_recipe/panels
 	abstract_type     = /decl/stack_recipe/panels
 	craft_stack_types = /obj/item/stack/material/panel
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /decl/stack_recipe/panels/bag
 	result_type       = /obj/item/storage/bag/flimsy

--- a/code/modules/crafting/stack_recipes/recipes_planks.dm
+++ b/code/modules/crafting/stack_recipes/recipes_planks.dm
@@ -18,10 +18,12 @@
 /decl/stack_recipe/planks/zipgunframe
 	result_type            = /obj/item/zipgunframe
 	difficulty             = MAT_VALUE_VERY_HARD_DIY
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /decl/stack_recipe/planks/coilgun
 	result_type            = /obj/item/coilgun_assembly
 	difficulty             = MAT_VALUE_VERY_HARD_DIY
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /decl/stack_recipe/planks/stick
 	result_type            = /obj/item/stick

--- a/code/modules/crafting/stack_recipes/recipes_reinforced.dm
+++ b/code/modules/crafting/stack_recipes/recipes_reinforced.dm
@@ -3,10 +3,12 @@
 	craft_stack_types = /obj/item/stack/material/sheet/reinforced
 	one_per_turf      = TRUE
 	difficulty        = MAT_VALUE_HARD_DIY
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /decl/stack_recipe/reinforced/ai_core
 	result_type       = /obj/structure/aicore
 	on_floor          = FALSE
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /decl/stack_recipe/reinforced/crate
 	result_type       = /obj/structure/closet/crate

--- a/code/modules/crafting/stack_recipes/recipes_stacks.dm
+++ b/code/modules/crafting/stack_recipes/recipes_stacks.dm
@@ -1,9 +1,6 @@
 // Tiles
 /decl/stack_recipe/tile
 	abstract_type       = /decl/stack_recipe/tile
-	req_amount          = 1 * SHEET_MATERIAL_AMOUNT
-	res_amount          = 4
-	max_res_amount      = 20
 	difficulty          = MAT_VALUE_NORMAL_DIY
 	apply_material_name = FALSE
 	category            = "tiling"
@@ -33,6 +30,7 @@
 /decl/stack_recipe/tile/steel
 	abstract_type     = /decl/stack_recipe/tile/steel
 	required_material = /decl/material/solid/metal/steel
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /decl/stack_recipe/tile/steel/floor
 	result_type       = /obj/item/stack/tile/floor

--- a/code/modules/crafting/stack_recipes/recipes_stacks.dm
+++ b/code/modules/crafting/stack_recipes/recipes_stacks.dm
@@ -1,7 +1,7 @@
 // Tiles
 /decl/stack_recipe/tile
 	abstract_type       = /decl/stack_recipe/tile
-	req_amount          = 1
+	req_amount          = 1 * SHEET_MATERIAL_AMOUNT
 	res_amount          = 4
 	max_res_amount      = 20
 	difficulty          = MAT_VALUE_NORMAL_DIY

--- a/code/modules/crafting/stack_recipes/recipes_steel.dm
+++ b/code/modules/crafting/stack_recipes/recipes_steel.dm
@@ -1,6 +1,7 @@
 /decl/stack_recipe/steel
 	abstract_type     = /decl/stack_recipe/steel
 	required_material = /decl/material/solid/metal/steel
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /decl/stack_recipe/steel/apc
 	result_type       = /obj/item/frame/apc
@@ -97,7 +98,7 @@
 
 /decl/stack_recipe/steel/furniture/canister
 	result_type       = /obj/machinery/portable_atmospherics/canister
-	req_amount        = 20 * SHEET_MATERIAL_AMOUNT // Arbitrary value since machines don't handle matter properly yet.
+	req_amount        = 5 * SHEET_MATERIAL_AMOUNT // Arbitrary value since machines don't handle matter properly yet.
 
 /decl/stack_recipe/steel/furniture/tank
 	result_type       = /obj/item/pipe/tank

--- a/code/modules/crafting/stack_recipes/recipes_steel.dm
+++ b/code/modules/crafting/stack_recipes/recipes_steel.dm
@@ -45,7 +45,7 @@
 
 /decl/stack_recipe/steel/furniture/computerframe
 	result_type       = /obj/machinery/constructable_frame/computerframe
-	req_amount        = 5 // Arbitrary value since machines don't handle matter properly yet.
+	req_amount        = 5 * SHEET_MATERIAL_AMOUNT // Arbitrary value since machines don't handle matter properly yet.
 
 /decl/stack_recipe/steel/furniture/computerframe/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat, paint_color)
 	return ..(user, location, amount, null, null)
@@ -97,7 +97,7 @@
 
 /decl/stack_recipe/steel/furniture/canister
 	result_type       = /obj/machinery/portable_atmospherics/canister
-	req_amount        = 20 // Arbitrary value since machines don't handle matter properly yet.
+	req_amount        = 20 * SHEET_MATERIAL_AMOUNT // Arbitrary value since machines don't handle matter properly yet.
 
 /decl/stack_recipe/steel/furniture/tank
 	result_type       = /obj/item/pipe/tank

--- a/code/modules/crafting/stack_recipes/recipes_struts.dm
+++ b/code/modules/crafting/stack_recipes/recipes_struts.dm
@@ -7,6 +7,7 @@
 	one_per_turf                = TRUE
 	on_floor                    = TRUE
 	difficulty                  = MAT_VALUE_HARD_DIY
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /decl/stack_recipe/strut/railing
 	result_type = /obj/structure/railing

--- a/code/modules/crafting/stack_recipes/recipes_struts.dm
+++ b/code/modules/crafting/stack_recipes/recipes_struts.dm
@@ -19,7 +19,7 @@
 /decl/stack_recipe/strut/girder
 	result_type                 = /obj/structure/girder
 	required_wall_support_value = 10
-	req_amount                  = 5 // Arbitrary value since girders return weird matter values.
+	req_amount                  = 5 * SHEET_MATERIAL_AMOUNT // Arbitrary value since girders return weird matter values.
 
 /decl/stack_recipe/strut/wall_frame
 	result_type                 = /obj/structure/wall_frame
@@ -42,7 +42,7 @@
 
 /decl/stack_recipe/strut/machine
 	result_type                 = /obj/machinery/constructable_frame/machine_frame
-	req_amount                  = 5 // Arbitrary value since machines don't handle matter properly yet.
+	req_amount                  = 5 * SHEET_MATERIAL_AMOUNT // Arbitrary value since machines don't handle matter properly yet.
 	required_material           = /decl/material/solid/metal/steel
 
 /decl/stack_recipe/strut/machine/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat, paint_color)

--- a/code/modules/crafting/stack_recipes/recipes_turfs.dm
+++ b/code/modules/crafting/stack_recipes/recipes_turfs.dm
@@ -2,7 +2,7 @@
 	abstract_type         = /decl/stack_recipe/turfs
 	expected_product_type = /turf
 	time                  = 5 SECONDS // Arbitrary value since turfs don't behave like objs in terms of w_class/time
-	req_amount            = 5         // Arbitrary value since turfs have no matter return weird matter values.
+	req_amount            = 5 * SHEET_MATERIAL_AMOUNT // Arbitrary value since turfs have no matter return weird matter values.
 	max_res_amount        = 1
 	res_amount            = 1
 

--- a/code/modules/crafting/stack_recipes/recipes_turfs.dm
+++ b/code/modules/crafting/stack_recipes/recipes_turfs.dm
@@ -3,8 +3,7 @@
 	expected_product_type = /turf
 	time                  = 5 SECONDS // Arbitrary value since turfs don't behave like objs in terms of w_class/time
 	req_amount            = 5 * SHEET_MATERIAL_AMOUNT // Arbitrary value since turfs have no matter return weird matter values.
-	max_res_amount        = 1
-	res_amount            = 1
+	one_per_turf          = TRUE
 
 /decl/stack_recipe/turfs/can_make(mob/user)
 	. = ..()

--- a/code/modules/materials/definitions/solids/materials_solid_mineral.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_mineral.dm
@@ -223,6 +223,8 @@
 	ore_type_value = ORE_SURFACE
 	ore_data_value = 1
 	value = 0.8
+	hardness = MAT_VALUE_SOFT
+	integrity = 10
 	dirtiness = 15
 	dissolves_into = list(
 		/decl/material/solid/silicon = 1
@@ -241,6 +243,9 @@
 	ore_type_value = ORE_SURFACE
 	ore_data_value = 1
 	value = 0.8
+	hardness = MAT_VALUE_SOFT
+	integrity = 10
+	dirtiness = 10
 	default_solid_form = /obj/item/stack/material/lump/large
 	bakes_into_material = /decl/material/solid/stone/pottery
 	melting_point = null // Clay is already almost a liquid...
@@ -256,8 +261,9 @@
 	value = 0
 	default_solid_form = /obj/item/stack/material/lump/large
 	melting_point = null
-	hardness = 0
-	integrity = 0
+	hardness = MAT_VALUE_SOFT
+	integrity = 10
+	dirtiness = 30
 	can_backfill_turf_type = list(
 		/turf/exterior/mud,
 		/turf/exterior/dirt

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -17,7 +17,6 @@
 	plural_name = "sheets"
 	abstract_type = /obj/item/stack/material
 	is_spawnable_type = FALSE // Mapped subtypes set this so they can be spawned from the verb.
-	var/list/can_be_converted_into
 	var/can_be_pulverized = FALSE
 	var/can_be_reinforced = FALSE
 	var/decl/material/reinf_material
@@ -120,6 +119,9 @@
 		update_strings()
 		update_icon()
 
+/obj/item/stack/material/proc/get_stack_conversion_dictionary()
+	return
+
 /obj/item/stack/material/attackby(var/obj/item/W, var/mob/user)
 
 	if(can_be_reinforced && istype(W, /obj/item/stack/material))
@@ -129,7 +131,7 @@
 			material.reinforce(user, W, src)
 		return TRUE
 
-	// TODO: convert to can_be_converted_into entry.
+	// TODO: convert to converts_into entry.
 	if(can_be_pulverized && IS_HAMMER(W) && material?.hardness >= MAT_VALUE_RIGID && user.a_intent == I_HURT)
 
 		if(W.material?.hardness < material.hardness)
@@ -137,7 +139,6 @@
 			return TRUE
 
 		var/converting = clamp(get_amount(), 0, 5)
-		world << "[converting] [get_amount()]"
 		if(converting && W.do_tool_interaction(TOOL_HAMMER, user, src, 1 SECOND, "pulverizing", "pulverizing", set_cooldown = TRUE) && !QDELETED(src) && get_amount() >= converting)
 			// TODO: make a gravel type?
 			// TODO: pass actual stone material to gravel?
@@ -155,6 +156,7 @@
 			reinf_material.create_object(get_turf(user), 1)
 			return TRUE
 
+	var/list/can_be_converted_into = get_stack_conversion_dictionary()
 	if(length(can_be_converted_into) && user.a_intent != I_HURT)
 
 		var/convert_tool
@@ -408,11 +410,14 @@
 	crafting_stack_type = /obj/item/stack/material/log
 	craft_verb = "whittle"
 	craft_verbing = "whittling"
-	can_be_converted_into = list(
+	matter_multiplier = 3
+
+/obj/item/stack/material/log/get_stack_conversion_dictionary()
+	var/static/list/converts_into = list(
 		TOOL_HATCHET = /obj/item/stack/material/plank,
 		TOOL_SAW = /obj/item/stack/material/plank
 	)
-	matter_multiplier = 3
+	return converts_into
 
 /obj/item/stack/material/segment
 	name = "segments"
@@ -462,8 +467,13 @@
 	craft_verb = "sculpt"
 	craft_verbing = "sculpting"
 	can_be_pulverized = TRUE
-	can_be_converted_into = list(TOOL_HAMMER = /obj/item/stack/material/brick)
 	matter_multiplier = 1.5
+
+/obj/item/stack/material/lump/get_stack_conversion_dictionary()
+	var/static/list/converts_into = list(
+		TOOL_HAMMER = /obj/item/stack/material/brick
+	)
+	return converts_into
 
 /obj/item/stack/material/lump/large
 	base_state        = "lump_large"

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -409,6 +409,7 @@
 		TOOL_HATCHET = /obj/item/stack/material/plank,
 		TOOL_SAW = /obj/item/stack/material/plank
 	)
+	matter_multiplier = 3
 
 /obj/item/stack/material/segment
 	name = "segments"
@@ -459,6 +460,7 @@
 	craft_verbing = "sculpting"
 	can_be_pulverized = TRUE
 	can_be_converted_into = list(TOOL_HAMMER = /obj/item/stack/material/brick)
+	matter_multiplier = 1.5
 
 /obj/item/stack/material/lump/large
 	base_state        = "lump_large"
@@ -466,6 +468,7 @@
 	plural_icon_state = "lump_large-mult"
 	max_icon_state    = "lump_large-max"
 	stack_merge_type  = /obj/item/stack/material/lump/large
+	matter_multiplier = 3
 
 /obj/item/stack/material/lump/large/clay
 	material = /decl/material/solid/clay

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -129,17 +129,22 @@
 			material.reinforce(user, W, src)
 		return TRUE
 
-	if(can_be_pulverized && IS_HAMMER(W) && material?.hardness >= MAT_VALUE_RIGID)
+	// TODO: convert to can_be_converted_into entry.
+	if(can_be_pulverized && IS_HAMMER(W) && material?.hardness >= MAT_VALUE_RIGID && user.a_intent == I_HURT)
+
 		if(W.material?.hardness < material.hardness)
 			to_chat(user, SPAN_WARNING("\The [W] is not hard enough to pulverize [material.solid_name]."))
 			return TRUE
+
 		var/converting = clamp(get_amount(), 0, 5)
-		if(converting)
+		world << "[converting] [get_amount()]"
+		if(converting && W.do_tool_interaction(TOOL_HAMMER, user, src, 1 SECOND, "pulverizing", "pulverizing", set_cooldown = TRUE) && !QDELETED(src) && get_amount() >= converting)
 			// TODO: make a gravel type?
 			// TODO: pass actual stone material to gravel?
 			new /obj/item/stack/material/ore/handful/sand(get_turf(user), converting)
 			user.visible_message("\The [user] pulverizes [converting == 1 ? "a [singular_name]" : "some [plural_name]"] with \the [W].")
 			use(converting)
+
 		return TRUE
 
 	if(reinf_material?.default_solid_form && IS_WELDER(W))
@@ -151,6 +156,7 @@
 			return TRUE
 
 	if(length(can_be_converted_into) && user.a_intent != I_HURT)
+
 		var/convert_tool
 		var/obj/item/stack/convert_type
 		for(var/tool_type in can_be_converted_into)
@@ -161,20 +167,17 @@
 
 		if(convert_type)
 
-			var/matter_per_single_sheet = SHEET_MATERIAL_AMOUNT * matter_multiplier
-			var/product_per_sheet = matter_per_single_sheet / (SHEET_MATERIAL_AMOUNT * initial(convert_type.matter_multiplier))
-			var/minimum_per_one_product = CEILING(1 / product_per_sheet)
+			var/product_per_sheet         = matter_multiplier / initial(convert_type.matter_multiplier)
+			var/minimum_per_one_product   = CEILING(1 / product_per_sheet)
 
 			if(get_amount() < minimum_per_one_product)
 				to_chat(user, SPAN_WARNING("You will need [minimum_per_one_product] [minimum_per_one_product == 1 ? singular_name : plural_name] to produce [product_per_sheet] [product_per_sheet == 1 ? initial(convert_type.singular_name) : initial(convert_type.plural_name)]."))
 			else if(W.do_tool_interaction(convert_tool, user, src, 1 SECOND, set_cooldown = TRUE) && !QDELETED(src) && get_amount() >= minimum_per_one_product)
-				var/obj/item/stack/product = new convert_type(get_turf(src), product_per_sheet, material?.type, reinf_material?.type)
+				var/obj/item/stack/product = new convert_type(get_turf(src), CEILING(product_per_sheet), material?.type, reinf_material?.type)
 				use(minimum_per_one_product)
 				if(product.add_to_stacks(user, TRUE))
 					user.put_in_hands(product)
-
 			return TRUE
-
 
 	return ..()
 

--- a/code/modules/materials/materials_ore.dm
+++ b/code/modules/materials/materials_ore.dm
@@ -23,6 +23,7 @@
 	craft_verbing              = "knapping"
 	can_be_pulverized          = TRUE
 	can_be_converted_into      = list(TOOL_HAMMER = /obj/item/stack/material/brick)
+	matter_multiplier          = 1.5
 
 	///Associative list of cache key to the generate icons for the ore piles. We pre-generate a pile of all possible ore icon states, and make them available
 	var/static/list/cached_ore_icon_states

--- a/code/modules/materials/materials_ore.dm
+++ b/code/modules/materials/materials_ore.dm
@@ -22,13 +22,18 @@
 	craft_verb                 = "knap"
 	craft_verbing              = "knapping"
 	can_be_pulverized          = TRUE
-	can_be_converted_into      = list(TOOL_HAMMER = /obj/item/stack/material/brick)
 	matter_multiplier          = 1.5
 
 	///Associative list of cache key to the generate icons for the ore piles. We pre-generate a pile of all possible ore icon states, and make them available
 	var/static/list/cached_ore_icon_states
 	///A list of all the existing ore icon states in the ore file
 	var/static/list/ore_icon_states = icon_states('icons/obj/materials/ore.dmi')
+
+/obj/item/stack/material/ore/get_stack_conversion_dictionary()
+	var/static/list/converts_into = list(
+		TOOL_HAMMER = /obj/item/stack/material/brick
+	)
+	return converts_into
 
 ///Returns a cached ore pile icon state
 /obj/item/stack/material/ore/proc/get_cached_ore_pile_overlay(var/state_name, var/stack_icon_index)
@@ -164,8 +169,10 @@
 	plural_name           = "handfuls"
 	stack_merge_type      = /obj/item/stack/material/ore/handful
 	matter_multiplier     = 1
-	can_be_converted_into = null
 	can_be_pulverized     = FALSE
+
+/obj/item/stack/material/ore/handful/get_stack_conversion_dictionary()
+	return
 
 /obj/item/stack/material/ore/handful/sand
 	material      = /decl/material/solid/sand

--- a/code/modules/materials/materials_ore.dm
+++ b/code/modules/materials/materials_ore.dm
@@ -160,9 +160,12 @@
 	material = /decl/material/solid/organic/meat
 
 /obj/item/stack/material/ore/handful
-	singular_name = "handful"
-	plural_name   = "handfuls"
-	stack_merge_type           = /obj/item/stack/material/ore/handful
+	singular_name         = "handful"
+	plural_name           = "handfuls"
+	stack_merge_type      = /obj/item/stack/material/ore/handful
+	matter_multiplier     = 1
+	can_be_converted_into = null
+	can_be_pulverized     = FALSE
 
 /obj/item/stack/material/ore/handful/sand
 	material      = /decl/material/solid/sand

--- a/code/modules/materials/materials_ore.dm
+++ b/code/modules/materials/materials_ore.dm
@@ -22,6 +22,7 @@
 	craft_verb                 = "knap"
 	craft_verbing              = "knapping"
 	can_be_pulverized          = TRUE
+	can_be_converted_into      = list(TOOL_HAMMER = /obj/item/stack/material/brick)
 
 	///Associative list of cache key to the generate icons for the ore piles. We pre-generate a pile of all possible ore icon states, and make them available
 	var/static/list/cached_ore_icon_states
@@ -96,7 +97,6 @@
 /obj/item/stack/material/ore/attackby(var/obj/item/W, var/mob/user)
 	if(istype(W, /obj/item/stack/material) && !is_same(W))
 		return FALSE //Don't reinforce
-
 	if(reinf_material && reinf_material.default_solid_form && IS_WELDER(W))
 		return FALSE //Don't melt stuff with welder
 	return ..()

--- a/code/unit_tests/materials.dm
+++ b/code/unit_tests/materials.dm
@@ -68,10 +68,10 @@
 							if(!material && !reinforced)
 								if(length(product_obj.matter))
 									failed = "unsupplied material types"
-							else if(material && (product_obj.matter[material.type]/SHEET_MATERIAL_AMOUNT) > recipe.req_amount)
-								failed = "excessive base material ([recipe.req_amount]/[CEILING(product_obj.matter[material.type]/SHEET_MATERIAL_AMOUNT)])"
-							else if(reinforced && (product_obj.matter[reinforced.type]/SHEET_MATERIAL_AMOUNT) > recipe.req_amount)
-								failed = "excessive reinf material ([recipe.req_amount]/[CEILING(product_obj.matter[reinforced.type]/SHEET_MATERIAL_AMOUNT)])"
+							else if(material && (product_obj.matter[material.type]) > recipe.req_amount)
+								failed = "excessive base material ([recipe.req_amount]/[CEILING(product_obj.matter[material.type])])"
+							else if(reinforced && (product_obj.matter[reinforced.type]) > recipe.req_amount)
+								failed = "excessive reinf material ([recipe.req_amount]/[CEILING(product_obj.matter[reinforced.type])])"
 							else
 								for(var/mat in product_obj.matter)
 									if(mat != material?.type && mat != reinforced?.type)

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -53,6 +53,7 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	 */
 	var/list/map_admin_faxes
 
+	var/map_tech_level = MAP_TECH_LEVEL_SPACE
 
 	var/shuttle_docked_message
 	var/shuttle_leaving_dock

--- a/mods/content/psionics/system/psionics/null/material.dm
+++ b/mods/content/psionics/system/psionics/null/material.dm
@@ -25,6 +25,7 @@
 
 /obj/item/shard/nullglass
 	material = MAT_NULLGLASS
+
 /decl/stack_recipe/tile/nullglass
-	name = "nullglass floor tile"
 	result_type = /obj/item/stack/tile/floor_nullglass
+	required_material = MAT_NULLGLASS


### PR DESCRIPTION
## Description of changes
- Stacks can be pulverized or converted into other forms via a generalized list returned to a proc on the stack instance.
- Stacks will now handle matter multiplier on self and stack products appropriately.
- Stacks will automatically calculate maximum result amount.
- Stack recipes can be hidden via a map var.
- Tiles now use material and matter mult instead of hardcoding result amount.
- Ore, logs and lump stacks have more matter in them.

## Why and what will this PR improve
Generally more dynamic crafting system. Allows for freely using stack types with different matter multipliers without causing discrepancies in cost.

## Authorship
Myself.

## Changelog
:cl:
tweak: More ore per ore!
/:cl: