### PR TITLE
Starting cash choices are now handled the same way as surivival box options.

### DIFF
--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -106,10 +106,9 @@
 	. = outfit_by_type(.)
 
 /datum/job/proc/create_cash_on_hand(var/mob/living/carbon/human/H, var/datum/money_account/M)
-	if(!istype(M) || !ispath(H.client?.prefs?.starting_cash_choice, /decl/starting_cash_choice))
+	if(!istype(M) || !H.client?.prefs?.starting_cash_choice)
 		return 0
-	var/decl/starting_cash_choice/cash = GET_DECL(H.client.prefs.starting_cash_choice)
-	for(var/obj/item/thing in cash.get_cash_objects(H, M))
+	for(var/obj/item/thing in H.client.prefs.starting_cash_choice.get_cash_objects(H, M))
 		. += thing.get_base_value()
 		H.equip_to_storage_or_put_in_hands(thing)
 

--- a/code/modules/client/preference_setup/general/04_equipment.dm
+++ b/code/modules/client/preference_setup/general/04_equipment.dm
@@ -4,7 +4,7 @@
 	var/decl/backpack_outfit/backpack
 	var/list/backpack_metadata
 	var/decl/survival_box_option/survival_box_choice
-	var/starting_cash_choice
+	var/decl/starting_cash_choice/starting_cash_choice
 	var/give_passport = TRUE
 
 /datum/category_item/player_setup_item/physical/equipment
@@ -26,8 +26,8 @@
 	pref.all_underwear =          R.read("all_underwear")
 	pref.all_underwear_metadata = R.read("all_underwear_metadata")
 	pref.backpack_metadata =      R.read("backpack_metadata")
-	pref.starting_cash_choice =   R.read("starting_cash_choice")
-	pref.survival_box_choice =    decls_repository.get_decl_by_id(R.read("survival_box"), validate_decl_type = FALSE)
+	pref.starting_cash_choice =   decls_repository.get_decl_by_id_or_var(R.read("starting_cash_choice"), /decl/starting_cash_choice)
+	pref.survival_box_choice =    decls_repository.get_decl_by_id_or_var(R.read("survival_box"), /decl/survival_box_option)
 
 	pref.give_passport = R.read("passport")
 	if(isnull(pref.give_passport))
@@ -36,23 +36,14 @@
 	var/load_backbag = R.read("backpack")
 	pref.backpack = backpacks_by_name[load_backbag] || get_default_outfit_backpack()
 
-	var/list/all_cash_choices = decls_repository.get_decls_of_type(/decl/starting_cash_choice)
-	for(var/ctype in all_cash_choices)
-		var/decl/starting_cash_choice/cash_choice = all_cash_choices[ctype]
-		if(lowertext(cash_choice.name) == pref.starting_cash_choice)
-			pref.starting_cash_choice = ctype
-			break
-
 /datum/category_item/player_setup_item/physical/equipment/save_character(datum/pref_record_writer/W)
 	W.write("all_underwear",          pref.all_underwear)
 	W.write("all_underwear_metadata", pref.all_underwear_metadata)
 	W.write("backpack",               pref.backpack.name)
 	W.write("backpack_metadata",      pref.backpack_metadata)
 	W.write("survival_box",           pref.survival_box_choice?.uid)
+	W.write("starting_cash_choice",   pref.starting_cash_choice?.uid)
 	W.write("passport",               pref.give_passport)
-
-	var/decl/starting_cash_choice/cash_choice = GET_DECL(pref.starting_cash_choice)
-	W.write("starting_cash_choice", lowertext(cash_choice.name))
 
 /datum/category_item/player_setup_item/physical/equipment/sanitize_character()
 	if(!istype(pref.all_underwear))
@@ -103,8 +94,11 @@
 				var/list/metadata = tweak_metadata["[tweak]"]
 				tweak_metadata["[tweak]"] = tweak.validate_metadata(metadata)
 
-	if(!ispath(pref.starting_cash_choice, /decl/starting_cash_choice))
-		pref.starting_cash_choice = global.using_map.default_starting_cash_choice
+	if(length(global.using_map.starting_cash_choices))
+		if(!pref.starting_cash_choice || !(pref.starting_cash_choice.type in global.using_map.starting_cash_choices))
+			pref.starting_cash_choice = global.using_map.starting_cash_choices[global.using_map.starting_cash_choices[1]]
+	else
+		pref.starting_cash_choice = null
 
 	// if you have at least one box available, 'none' must be its own bespoke option
 	if(length(global.using_map.survival_box_choices))
@@ -138,8 +132,8 @@
 	if(global.using_map.passport_type)
 		. += "<b>Passport:</b> <a href='?src=\ref[src];toggle_passport=1'><b>[pref.give_passport ? "Yes" : "No"]</b></a><br>"
 
-	var/decl/starting_cash_choice/cash_choice = GET_DECL(pref.starting_cash_choice)
-	. += "<br><b>Personal finances:</b><br><a href='?src=\ref[src];change_cash_choice=1'>[capitalize(cash_choice.name)]</a><br>"
+	if(length(global.using_map.starting_cash_choices))
+		. += "<br><b>Personal finances:</b><br><a href='?src=\ref[src];change_cash_choice=1'>[pref.starting_cash_choice]</a><br>"
 	return jointext(.,null)
 
 /datum/category_item/player_setup_item/physical/equipment/proc/get_underwear_metadata(var/underwear_category, var/datum/gear_tweak/gt)
@@ -224,6 +218,12 @@
 			set_backpack_metadata(bo, bt, new_metadata)
 			return TOPIC_REFRESH_UPDATE_PREVIEW
 	else if(href_list["change_cash_choice"])
-		pref.starting_cash_choice = next_in_list(pref.starting_cash_choice, decls_repository.get_decl_paths_of_subtype(/decl/starting_cash_choice))
-		return TOPIC_REFRESH_UPDATE_PREVIEW
+		var/list/display_choices = list()
+		for(var/key in global.using_map.starting_cash_choices)
+			display_choices += global.using_map.starting_cash_choices[key]
+		var/chosen_cash = input(user, "Select a personal finance alternative.", "Personal Finances", pref.starting_cash_choice) as null|anything in display_choices
+		if(!chosen_cash)
+			return TOPIC_NOACTION
+		pref.starting_cash_choice = chosen_cash
+		return TOPIC_REFRESH
 	return ..()

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -158,6 +158,9 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	/// A list of survival box types selectable for this map. If null, defaults to all defined decls. At runtime, this is an associative list of decl type -> decl.
 	var/list/decl/survival_box_option/survival_box_choices
 
+	// A list of cash spawn options, similar to above.
+	var/list/decl/starting_cash_choice/starting_cash_choices
+
 /datum/map/proc/get_lobby_track(var/exclude)
 	var/lobby_track_type
 	if(LAZYLEN(lobby_tracks) == 1)
@@ -183,6 +186,11 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 		survival_box_choices = decls_repository.get_decls_of_subtype(/decl/survival_box_option)
 	else if(length(survival_box_choices))
 		survival_box_choices = decls_repository.get_decls(survival_box_choices)
+
+	if(isnull(starting_cash_choices))
+		starting_cash_choices = decls_repository.get_decls_of_subtype(/decl/starting_cash_choice)
+	else if(length(starting_cash_choices))
+		starting_cash_choices = decls_repository.get_decls(starting_cash_choices)
 
 	if(secrets_directory)
 		secrets_directory = trim(lowertext(secrets_directory))

--- a/maps/~mapsystem/maps_currency.dm
+++ b/maps/~mapsystem/maps_currency.dm
@@ -1,8 +1,9 @@
 /datum/map
 	var/default_currency = /decl/currency/credits
-	var/default_starting_cash_choice = /decl/starting_cash_choice/credstick/half
 
 /decl/starting_cash_choice
+	decl_flags = DECL_FLAG_MANDATORY_UID
+	uid = "starting_cash_account"
 	var/name = "all in bank account"
 	var/transfer_mult = 1
 
@@ -11,6 +12,7 @@
 
 /decl/starting_cash_choice/credstick
 	name = "all on charge stick"
+	uid = "starting_cash_stick"
 
 /decl/starting_cash_choice/credstick/get_cash_objects(var/mob/living/carbon/human/owner, var/datum/money_account/owner_account)
 	var/obj/item/charge_stick/credstick = new
@@ -23,31 +25,35 @@
 /decl/starting_cash_choice/credstick/half
 	name = "split between bank account and charge stick"
 	transfer_mult = 0.5
+	uid = "starting_cash_account_stick_split"
 
 /decl/starting_cash_choice/cash
 	name = "all in cash"
+	uid = "starting_cash_cash"
 
 /decl/starting_cash_choice/cash/get_cash_objects(var/mob/living/carbon/human/owner, var/datum/money_account/owner_account)
 	var/obj/item/cash/cash = new
 	cash.set_currency(owner_account.currency)
 	cash.adjust_worth(FLOOR(owner_account.money * transfer_mult))
 	owner_account.money -= cash.absolute_worth
-	return list(cash)	
+	return list(cash)
 
 /decl/starting_cash_choice/cash/half
 	name = "split between bank account and cash"
 	transfer_mult = 0.5
+	uid = "starting_cash_cash_account_split"
 
 /decl/starting_cash_choice/split
 	name = "split between cash and charge stick"
 	transfer_mult = 0.5
+	uid = "starting_cash_cash_stick_split"
 
 /decl/starting_cash_choice/split/get_cash_objects(var/mob/living/carbon/human/owner, var/datum/money_account/owner_account)
 	. = list()
 	var/obj/item/cash/cash = new
 	cash.set_currency(owner_account.currency)
 	cash.adjust_worth(FLOOR(owner_account.money * transfer_mult))
-	. += cash	
+	. += cash
 	var/obj/item/charge_stick/credstick = new
 	credstick.creator = owner.real_name
 	credstick.currency = owner_account.currency
@@ -59,3 +65,4 @@
 /decl/starting_cash_choice/split/even
 	name = "split between bank account, cash and charge stick"
 	transfer_mult = 0.33
+	uid = "starting_cash_cash_account_stick_split"


### PR DESCRIPTION
## Description of changes
Allows maps to override cash options.

## Why and what will this PR improve
Flexibility in making forks.

## Authorship
Myself, cribbing the pattern Penny used for survival boxes.

## Changelog
Nothing player-facing.