### PR TITLE
Add fluff to Shaded Hills

### DIFF
--- a/maps/shaded_hills/areas/_areas.dm
+++ b/maps/shaded_hills/areas/_areas.dm
@@ -7,6 +7,14 @@
 	name = "Grasslands"
 	color = COLOR_GREEN
 	is_outside = OUTSIDE_YES
+	ambience = list(
+		'sound/effects/wind/wind_2_1.ogg',
+		'sound/effects/wind/wind_2_2.ogg',
+		'sound/effects/wind/wind_3_1.ogg',
+		'sound/effects/wind/wind_4_1.ogg',
+		'sound/effects/wind/wind_4_2.ogg',
+		'sound/effects/wind/wind_5_1.ogg'
+	)
 	description = "Birds and insects call from the grasses, and a cool wind gusts from across the river."
 	area_blurb_category = /area/shaded_hills/outside
 
@@ -24,6 +32,7 @@
 	color = COLOR_GRAY40
 	is_outside = OUTSIDE_NO
 	description = "The deep dark brings distant, whispering echoes to your ears."
+	ambience = list('sound/ambience/ambimine.ogg', 'sound/ambience/song_game.ogg')
 	area_blurb_category = /area/shaded_hills/caves
 
 /area/shaded_hills/caves/entrance
@@ -33,9 +42,19 @@
 /area/shaded_hills/caves/unexplored
 	name = "Trackless Deeps"
 	color = COLOR_GRAY20
+	ambience = list(
+		'sound/ambience/ominous1.ogg',
+		'sound/ambience/ominous2.ogg',
+		'sound/ambience/ominous3.ogg',
+	)
 
 /area/shaded_hills/caves/river
 	name = "Silent River"
 	color = COLOR_GRAY20
 	description = "The silent, black water catches whatever sparse light survives in the depths, glittering like a river of stars."
 	area_blurb_category = /area/shaded_hills/caves/river
+	ambience = list(
+		'sound/ambience/ominous1.ogg',
+		'sound/ambience/ominous2.ogg',
+		'sound/ambience/ominous3.ogg',
+	)

--- a/maps/shaded_hills/shaded_hills-1.dmm
+++ b/maps/shaded_hills/shaded_hills-1.dmm
@@ -54,9 +54,6 @@
 "sS" = (
 /turf/exterior/mud/water,
 /area/shaded_hills/caves/unexplored)
-"tp" = (
-/turf/exterior/grass,
-/area/space)
 "ul" = (
 /obj/abstract/landmark/roofed,
 /turf/floor/wood/ebony,
@@ -14783,7 +14780,7 @@ lE
 lE
 lE
 lE
-tp
+lC
 lC
 lC
 lC
@@ -14935,7 +14932,7 @@ lE
 lE
 lE
 lE
-tp
+lC
 lC
 lC
 lC

--- a/maps/shaded_hills/shaded_hills.dm
+++ b/maps/shaded_hills/shaded_hills.dm
@@ -10,6 +10,7 @@
 	#include "levels/_levels.dm"
 	#include "outfits/_outfits.dm"
 
+	#include "shaded_hills_currency.dm"
 	#include "shaded_hills_skills.dm"
 	#include "shaded_hills_turfs.dm"
 

--- a/maps/shaded_hills/shaded_hills_currency.dm
+++ b/maps/shaded_hills/shaded_hills_currency.dm
@@ -1,0 +1,10 @@
+/datum/map/shaded_hills
+	default_starting_cash_choice = /decl/starting_cash_choice/cash
+	starting_cash_choices = list(/decl/starting_cash_choice/none, /decl/starting_cash_choice/cash)
+	default_currency = /decl/currency/imperial
+	salary_modifier = 0.05 // turn the 300-400 base into 15-20 base
+
+/// Functionally identical to its parent type, but with a different name since it's not defined until later.
+/decl/starting_cash_choice/none
+	name = "none"
+	uid = "starting_cash_none"

--- a/maps/shaded_hills/shaded_hills_define.dm
+++ b/maps/shaded_hills/shaded_hills_define.dm
@@ -2,13 +2,13 @@
 	name          = "shaded_hills"
 	full_name     = "Shaded Hills"
 	path          = "shaded_hills"
-	station_name  = "Shaded Hills"
-	station_short = "Shaded Hills"
-	dock_name     = "Shaded Heights"
-	boss_name     = "The Elder Council"
+	station_name  = "shaded hills"
+	station_short = "shaded hills"
+	dock_name     = "shaded heights"
+	boss_name     = "the Elder Council"
 	boss_short    = "Elders"
-	company_name  = "Whispers from the Deep"
-	company_short = "The Deep"
+	company_name  = "whispers from the Deep"
+	company_short = "the Deep"
 	system_name   = "Outward Lands"
 
 	default_species = SPECIES_KOBALOI
@@ -21,3 +21,9 @@
 		/decl/loadout_category/fantasy/clothing,
 		/decl/loadout_category/fantasy/utility
 	)
+
+	survival_box_choices = list()
+
+/datum/map/shaded_hills/get_map_info()
+	return "You're in the <b>[station_name]</b> of the [system_name], nestled between the mountains and the river. On all sides, you are surrounded by untamed wilds. \
+	Far from the control of [boss_name], you are free to carve forward a path to survival for yourself and your comrades however you wish. Strike the earth!"

--- a/mods/species/fantasy/_fantasy.dme
+++ b/mods/species/fantasy/_fantasy.dme
@@ -2,6 +2,7 @@
 #define MODPACK_FANTASY_SPECIES
 #include "_fantasy.dm"
 #include "datum/cultures.dm"
+#include "datum/currencies.dm"
 #include "datum/factions.dm"
 #include "datum/locations.dm"
 #include "datum/overrides.dm"

--- a/mods/species/fantasy/datum/currencies.dm
+++ b/mods/species/fantasy/datum/currencies.dm
@@ -1,0 +1,35 @@
+/decl/currency/imperial
+	name = "\improper Imperial crowns"
+	name_prefix = "¢"
+
+/decl/currency/imperial/build_denominations()
+	denominations = list(
+		new /datum/denomination/coin/crown/regalis(src, 125, null, COLOR_GOLD),
+		new /datum/denomination/coin/crown/quin(src,    5, null,  COLOR_SILVER),
+		new /datum/denomination/coin/crown(src,         1, null,  COLOR_BRONZE)
+	)
+	..()
+
+/datum/denomination/coin/crown
+	name = "\improper Imperial crown"
+	faces = list("obverse", "reverse")
+
+/datum/denomination/coin/crown/New(decl/currency/_currency, value, value_name, colour)
+	. = ..()
+	name = initial(name) // Awful, evil, terrible.
+
+/datum/denomination/coin/crown/quin
+	name = "\improper Imperial quincrown"
+
+/datum/denomination/coin/crown/regalis
+	name = "\improper Imperial crown regalis"
+
+/decl/stack_recipe/coin/imperial
+	currency = /decl/currency/imperial
+	name = "\improper Imperial crown"
+
+/decl/stack_recipe/coin/imperial/quin
+	name = "\improper Imperial quincrown"
+
+/decl/stack_recipe/coin/imperial/huge
+	name = "\improper Imperial crown regalis"


### PR DESCRIPTION
## Description of changes
Adds some map flavortext to Shaded Hills.
Adjusts ambience for Shaded Hills areas.
Adds map-specific currency, crowns, which come in the denomination of crown, quincrown, and crown regalis.

## Why and what will this PR improve
Some extra fluff for the Shaded Hills setting.