### PR TITLE
Make wildgrass a subtype of grass

### DIFF
--- a/code/game/turfs/exterior/exterior_grass.dm
+++ b/code/game/turfs/exterior/exterior_grass.dm
@@ -8,8 +8,9 @@
 	base_color = "#5e7a3b"
 	icon_has_corners = TRUE
 
-/turf/exterior/wildgrass
+/turf/exterior/grass/wild
 	name = "wild grass"
+	possible_states = 0
 	icon = 'icons/turf/exterior/wildgrass.dmi'
 	icon_edge_layer = EXT_EDGE_GRASS_WILD
 	footstep_type = /decl/footsteps/grass
@@ -17,7 +18,7 @@
 	base_color = "#5e7a3b"
 	icon_has_corners = TRUE
 
-/turf/exterior/wildgrass/get_movable_alpha_mask_state(atom/movable/mover)
+/turf/exterior/grass/wild/get_movable_alpha_mask_state(atom/movable/mover)
 	. = ..() || "mask_grass"
 
 /obj/item/stack/material/bundle/grass
@@ -31,17 +32,17 @@
 	dried_type = null
 	material = /decl/material/solid/organic/plantmatter/grass/dry
 
-/turf/exterior/wildgrass/attackby(obj/item/W, mob/user)
+/turf/exterior/grass/wild/attackby(obj/item/W, mob/user)
 	if(IS_KNIFE(W))
 		if(W.do_tool_interaction(TOOL_KNIFE, user, src, 3 SECONDS, start_message = "harvesting", success_message = "harvesting"))
-			if(QDELETED(src) || !istype(src, /turf/exterior/wildgrass))
+			if(QDELETED(src) || !istype(src, /turf/exterior/grass/wild))
 				return TRUE
 			new /obj/item/stack/material/bundle/grass(src, rand(2,5))
 			ChangeTurf(/turf/exterior/grass)
 		return TRUE
 	return ..()
 
-/turf/exterior/wildgrass/Initialize(mapload, no_update_icon)
+/turf/exterior/grass/wild/Initialize(mapload, no_update_icon)
 	. = ..()
 	//It's possible we're created on a level that's not a planet!
 	var/datum/planetoid_data/P = SSmapping.planetoid_data_by_z[z]
@@ -60,12 +61,12 @@
 	if(!LAZYLEN(resources.resources))
 		remove_extension(src, /datum/extension/buried_resources)
 
-/turf/exterior/wildgrass/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+/turf/exterior/grass/wild/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if((temperature > T0C + 200 && prob(5)) || temperature > T0C + 1000)
 		handle_melting()
 	return ..()
 
-/turf/exterior/wildgrass/handle_melting(list/meltable_materials)
+/turf/exterior/grass/wild/handle_melting(list/meltable_materials)
 	. = ..()
 	if(icon_state != "scorched")
 		SetName("scorched ground")

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/grass.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/grass.dm
@@ -19,7 +19,7 @@
 ///Surface of a grass exoplanet
 /datum/level_data/planetoid/exoplanet/grass
 	base_area           = /area/exoplanet/grass
-	base_turf           = /turf/exterior/wildgrass
+	base_turf           = /turf/exterior/grass/wild
 	exterior_atmosphere = null
 	exterior_atmos_temp = null
 	level_generators    = list(
@@ -133,7 +133,7 @@
 ///Map generator for the grass exoplanet surface
 /datum/random_map/noise/exoplanet/grass
 	descriptor       = "grass exoplanet"
-	land_type        = /turf/exterior/wildgrass
+	land_type        = /turf/exterior/grass/wild
 	water_type       = /turf/exterior/mud/water
 	coast_type       = /turf/exterior/mud
 	water_level_min  = 3
@@ -147,7 +147,7 @@
 
 ///Area for the grass exoplanet surface
 /area/exoplanet/grass
-	base_turf = /turf/exterior/wildgrass
+	base_turf = /turf/exterior/grass/wild
 	ambience  = list(
 		'sound/effects/wind/wind_2_1.ogg',
 		'sound/effects/wind/wind_2_2.ogg',

--- a/code/modules/random_map/noise/forage.dm
+++ b/code/modules/random_map/noise/forage.dm
@@ -108,7 +108,7 @@
 				var/rock_type = pick(forage["rocks"])
 				new rock_type(T)
 				return
-		else if(istype(T, /turf/exterior/wildgrass))
+		else if(istype(T, /turf/exterior/grass))
 			if(prob(parse_value * 0.35))
 				var/tree_type = pick(trees)
 				new tree_type(T)

--- a/maps/random_ruins/exoplanet_ruins/oasis/oasis.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oasis/oasis.dmm
@@ -12,11 +12,11 @@
 /area/template_noop)
 "e" = (
 /obj/structure/flora/grass/green,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/template_noop)
 "f" = (
 /obj/structure/flora/grass/both,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/template_noop)
 "g" = (
 /turf/exterior/sand/water,
@@ -27,22 +27,22 @@
 /area/template_noop)
 "i" = (
 /obj/structure/flora/bush,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/template_noop)
 "j" = (
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/template_noop)
 "k" = (
 /obj/structure/flora/bush/palebush,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/template_noop)
 "l" = (
 /obj/structure/flora/grass/brown,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/template_noop)
 "m" = (
 /obj/structure/flora/bush,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/template_noop)
 
 (1,1,1) = {"

--- a/maps/random_ruins/exoplanet_ruins/oasis/oasis2.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oasis/oasis2.dmm
@@ -4,36 +4,36 @@
 /area/template_noop)
 "b" = (
 /obj/structure/flora/bush/genericbush,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/template_noop)
 "c" = (
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/template_noop)
 "d" = (
 /obj/structure/flora/bush/brflowers,
 /obj/structure/flora/bush/ywflowers,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/template_noop)
 "e" = (
 /obj/structure/flora/bush/ppflowers,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/template_noop)
 "f" = (
 /obj/structure/flora/bush/fullgrass,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/template_noop)
 "g" = (
 /obj/structure/flora/bush/leafybush,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/template_noop)
 "h" = (
 /obj/structure/flora/bush/ppflowers,
 /obj/structure/flora/bush/fernybush,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/template_noop)
 "i" = (
 /obj/structure/flora/grass/both,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/template_noop)
 "j" = (
 /turf/exterior/sand/water,
@@ -41,7 +41,7 @@
 "k" = (
 /obj/structure/flora/grass/both,
 /obj/structure/flora/bush/ywflowers,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/template_noop)
 "l" = (
 /obj/structure/flora/bush/reedbush,
@@ -50,12 +50,12 @@
 "m" = (
 /obj/structure/flora/grass/both,
 /obj/structure/flora/bush/fullgrass,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/template_noop)
 "n" = (
 /obj/structure/flora/bush/ywflowers,
 /obj/structure/flora/bush/ppflowers,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/template_noop)
 
 (1,1,1) = {"

--- a/mods/content/government/away_sites/icarus/icarus-1.dmm
+++ b/mods/content/government/away_sites/icarus/icarus-1.dmm
@@ -6,7 +6,7 @@
 /turf/unsimulated/mask,
 /area/mine/unexplored)
 "ac" = (
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/icarus/open)
 "ae" = (
 /turf/wall/natural,
@@ -34,7 +34,7 @@
 /area/icarus/vessel)
 "al" = (
 /obj/structure/flora/bush/palebush,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/icarus/open)
 "am" = (
 /obj/structure/bed/chair/comfy/black,
@@ -58,7 +58,7 @@
 /area/icarus/open)
 "ar" = (
 /obj/structure/flora/tree/dead,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/icarus/open)
 "as" = (
 /turf/wall/r_wall,
@@ -83,7 +83,7 @@
 /area/icarus/vessel)
 "ax" = (
 /obj/item/stack/material/ore/slag,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/icarus/open)
 "ay" = (
 /obj/item/shreddedp,
@@ -1362,7 +1362,7 @@
 /area/icarus/open)
 "eF" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/icarus/open)
 "eG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2616,24 +2616,24 @@
 /area/icarus/open)
 "io" = (
 /obj/effect/decal/cleanable/ash,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/icarus/open)
 "ip" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/icarus/open)
 "jb" = (
 /obj/effect/shuttle_landmark/nav_icarus/nav1,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/icarus/open)
 "kb" = (
 /obj/effect/shuttle_landmark/nav_icarus/nav2,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/icarus/open)
 "lb" = (
 /obj/effect/shuttle_landmark/nav_icarus/nav3,
-/turf/exterior/wildgrass,
+/turf/exterior/grass/wild,
 /area/icarus/open)
 "mb" = (
 /obj/structure/hygiene/sink{

--- a/tools/map_migrations/3824_wildgrass.txt
+++ b/tools/map_migrations/3824_wildgrass.txt
@@ -1,0 +1,1 @@
+/turf/exterior/wildgrass/@SUBTYPES : /turf/exterior/grass/wild/@SUBTYPES{@OLD}


### PR DESCRIPTION
## Description of changes
Makes wildgrass a subtype of grass.

## Why and what will this PR improve
Makes the forage map work for both grass and wild grass, plus general tidiness.