### PR TITLE
Fix some issues with items spawned from loadout

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -487,8 +487,8 @@ SUBSYSTEM_DEF(jobs)
 		H.skillset.obtain_from_client(job, H.client)
 
 		//Equip job items.
-		job.setup_account(H)
 		job.equip_job(H, H.mind?.role_alt_title, H.char_branch, H.char_rank)
+		job.setup_account(H)
 		job.apply_fingerprints(H)
 		spawn_in_storage = equip_custom_loadout(H, job)
 	else

--- a/code/datums/inventory_slots/_inventory_slot.dm
+++ b/code/datums/inventory_slots/_inventory_slot.dm
@@ -18,7 +18,7 @@
 	var/skip_on_strip_display = FALSE
 	var/requires_slot_flags
 	var/requires_organ_tag
-	var/quick_equip_priority = 0 // Higher priority means it will be checked first.
+	var/quick_equip_priority = 0 // Higher priority means it will be checked first. If null, will not be considered for quick equip.
 
 	var/mob_overlay_layer
 	var/alt_mob_overlay_layer

--- a/code/datums/inventory_slots/inventory_gripper.dm
+++ b/code/datums/inventory_slots/inventory_gripper.dm
@@ -5,7 +5,7 @@
 	var/covering_slot_flags
 	/// If set, use this icon_state for the hand slot overlay; otherwise, use slot_id.
 	var/hand_overlay
-	quick_equip_priority = -1 // you quick-equip stuff by holding it in a gripper, so this ought to be dead last
+	quick_equip_priority = null // you quick-equip stuff by holding it in a gripper, so this ought to be skipped
 
 	// For reference, grippers do not use ui_loc, they have it set dynamically during /datum/hud/proc/rebuild_hands()
 

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -890,6 +890,8 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 /obj/item/proc/reconsider_client_screen_presence(var/client/client, var/slot)
 	if(!client)
 		return
+	if(client.mob?.get_equipped_item(slot) != src)
+		return
 	if(client.mob?.item_should_have_screen_presence(src, slot))
 		client.screen |= src
 	else

--- a/code/modules/mob/living/inventory.dm
+++ b/code/modules/mob/living/inventory.dm
@@ -15,6 +15,8 @@
 		for(var/slot in get_inventory_slots())
 			all_slots += get_inventory_slot_datum(slot)
 		for(var/datum/inventory_slot/inv_slot as anything in sortTim(all_slots, /proc/cmp_inventory_slot_desc))
+			if(isnull(inv_slot.quick_equip_priority)) // Never quick-equip into some slots.
+				continue
 			_inventory_slot_priority += inv_slot.slot_id
 	return _inventory_slot_priority
 


### PR DESCRIPTION
## Description of changes
- Reorders setup_account to come after job outfit equipping.
- Makes quick equip skip hands, so the 'equip in best slot' code will not equip anything to hands directly. This also means that the "placed in hands" message for loadout/job items will show properly.
- Makes `reconsider_client_screen_presence` actually check the item is the slot being considered, and if it isn't, we return early.

## Why and what will this PR improve
- Fixes job outfits clearing cash, creditsticks, etc.
- Fixes equipping an item from one hand to another hand, and fixes loadout items placed in your hands using the generic "placed in your inventory" message.
- Fixes job items relocated by loadout items not being visible until dropped.