### PR TITLE
Fix daycycle pending rewrite

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -509,7 +509,7 @@
 	planet_template.load_new_z(gen_data = PD)
 	if(!daycycle)
 		PD.day_duration = null
-		SSdaycyle.remove_linked_levels(PD.topmost_level_id)
+		SSdaycycle.remove_linked_levels(PD.topmost_level_id)
 
 /client/proc/display_del_log()
 	set category = "Debug"

--- a/code/modules/maps/template_types/random_exoplanet/planetoid_data.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planetoid_data.dm
@@ -244,11 +244,11 @@
 ///Registers to neccessary processors and begin running all processing needed by the planet
 /datum/planetoid_data/proc/begin_processing()
 	if(day_duration)
-		SSdaycyle.add_linked_levels(get_linked_level_ids(), starts_at_night, day_duration)
+		SSdaycycle.add_linked_levels(get_linked_level_ids(), starts_at_night, day_duration)
 
 ///Stop running any processing needed by the planet, and unregister from processors.
 /datum/planetoid_data/proc/end_processing()
-	SSdaycyle.remove_linked_levels(topmost_level_id)
+	SSdaycycle.remove_linked_levels(topmost_level_id)
 
 //#TODO: Move this into some SS for planet processing stuff or something?
 /datum/planetoid_data/Process(wait, tick)


### PR DESCRIPTION
## Description of changes
The math for daycycle was a bit off, so it would take like, a hundred times longer than it was supposed to—it took an entire day length just for one column. It also processed far too slowly for something that already had a rate-limit built in; this brings it to parity with the SSobjs-based daycycle on stable.

Ideally this would be replaced by a level-wide ambient light-based dimming, but I'm too lazy to write that.

## Why and what will this PR improve
- Makes `SSdaycycle` run at the intended speed rather than a hundred or so times slower.
- Fixes `SSdaycycle` being called `SSdaycyle` in the code.