### PR TITLE
Adjust job items being replaced by loadout

### DIFF
--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -86,6 +86,9 @@
 	var/tmp/use_single_icon
 	var/center_of_mass = @'{"x":16,"y":16}' //can be null for no exact placement behaviour
 
+	/// Used when this item is replaced by a loadout item. If TRUE, loadout places src in wearer's storage. If FALSE, src is deleted.
+	var/replaced_in_loadout = TRUE
+
 	var/paint_color
 	var/paint_verb = "painted"
 
@@ -972,6 +975,10 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 /obj/item/proc/handle_loadout_equip_replacement(obj/item/old_item)
 	return
+
+/// Used to handle equipped icons overwritten by custom loadout. If TRUE, loadout places src in wearer's storage. If FALSE, src is deleted by loadout.
+/obj/item/proc/loadout_should_keep(obj/item/new_item, mob/wearer)
+	return type != new_item.type && !replaced_in_loadout
 
 /obj/item/equipped(mob/user, slot)
 	. = ..()

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -436,7 +436,7 @@ var/global/list/gear_datums = list()
 		if(!old_item)
 			return
 		item.handle_loadout_equip_replacement(old_item)
-		if(old_item.type != item.type)
+		if(old_item.loadout_should_keep(item, wearer))
 			place_in_storage_or_drop(wearer, old_item)
 		else
 			qdel(old_item)

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -4,6 +4,7 @@
 	origin_tech = @'{"materials":1,"engineering":1}'
 	material = /decl/material/solid/organic/cloth
 	paint_verb = "dyed"
+	replaced_in_loadout = TRUE
 
 	var/wizard_garb = 0
 	var/flash_protection = FLASH_PROTECTION_NONE	  // Sets the item's level of flash protection.

--- a/code/modules/clothing/gloves/latex.dm
+++ b/code/modules/clothing/gloves/latex.dm
@@ -7,6 +7,7 @@
 	icon_state = ICON_STATE_WORLD
 	anomaly_shielding = 0.1
 	material = /decl/material/solid/organic/plastic //todo: latex
+	replaced_in_loadout = FALSE
 
 /obj/item/clothing/gloves/latex/nitrile
 	name = "nitrile gloves"

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -12,6 +12,7 @@
 	icon_state = ICON_STATE_WORLD
 	material = /decl/material/solid/organic/plastic //TODO: rubber
 	matter = list(/decl/material/solid/organic/cloth = MATTER_AMOUNT_REINFORCEMENT)
+	replaced_in_loadout = FALSE
 
 /obj/item/clothing/gloves/insulated/cheap                             //Cheap Chinese Crap
 	desc = "These gloves are cheap copies of the coveted gloves, no way this can end badly."

--- a/code/modules/clothing/gloves/thick.dm
+++ b/code/modules/clothing/gloves/thick.dm
@@ -20,6 +20,7 @@
 		ARMOR_BOMB = ARMOR_BOMB_RESISTANT,
 		ARMOR_BIO = ARMOR_BIO_MINOR)
 	material = /decl/material/solid/organic/leather
+	replaced_in_loadout = FALSE
 
 /obj/item/clothing/gloves/thick/swat
 	desc = "These tactical gloves are somewhat fire and impact-resistant."

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -22,6 +22,7 @@
 	material = /decl/material/solid/organic/plastic
 	matter = list(/decl/material/solid/metal/steel = MATTER_AMOUNT_REINFORCEMENT)
 	origin_tech = @'{"materials":1,"engineering":1,"combat":1}'
+	replaced_in_loadout = FALSE
 
 /obj/item/clothing/head/hardhat/orange
 	icon = 'icons/clothing/head/hardhat/orange.dmi'

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -24,6 +24,7 @@
 	matter = list(/decl/material/solid/metal/plasteel = MATTER_AMOUNT_TRACE)
 	origin_tech = @'{"materials":1,"engineering":1,"combat":1}'
 	protects_against_weather = TRUE
+	replaced_in_loadout = FALSE
 
 /obj/item/clothing/head/helmet/tactical
 	name = "tactical helmet"

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -31,6 +31,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	flash_protection = FLASH_PROTECTION_MAJOR
 	tint = TINT_HEAVY
+	replaced_in_loadout = FALSE
 	var/up = 0
 	var/base_state
 

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -26,6 +26,7 @@
 	brightness_on = 4
 	light_wedge = LIGHT_WIDE
 	on = 0
+	replaced_in_loadout = FALSE
 
 	var/obj/machinery/camera/camera
 	var/tinted = null	//Set to non-null for toggleable tint helmets
@@ -143,6 +144,7 @@
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT
 	)
 	protects_against_weather = TRUE
+	replaced_in_loadout = FALSE
 
 /obj/item/clothing/suit/space/Initialize()
 	. = ..()

--- a/code/modules/clothing/suits/armor/_armor.dm
+++ b/code/modules/clothing/suits/armor/_armor.dm
@@ -10,3 +10,4 @@
 	siemens_coefficient = 0.6
 	blood_overlay_type = "armor"
 	origin_tech = @'{"materials":1,"engineering":1,"combat":1}'
+	replaced_in_loadout = FALSE

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -17,6 +17,7 @@
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/metal/silver = MATTER_AMOUNT_REINFORCEMENT
 	)
+	replaced_in_loadout = FALSE
 
 /obj/item/clothing/suit/bio_suit
 	name = "bio suit"
@@ -39,6 +40,7 @@
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/metal/silver = MATTER_AMOUNT_REINFORCEMENT
 	)
+	replaced_in_loadout = FALSE
 
 /obj/item/clothing/suit/bio_suit/Initialize()
 	. = ..()

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/suit/storage
+	replaced_in_loadout = FALSE
 	var/obj/item/storage/internal/pockets/pockets
 	var/slots = 2
 


### PR DESCRIPTION
## Description of changes
A lot of junk job items were being kept in loadout even though they really could've been deleted—after all, typically when you take something in loadout, that means you're not using the thing it replaces. Now, types can enable/disable whether they're kept, and I've set it on a few important types for things like safety gear, armor, and anything with storage.

## Why and what will this PR improve
Fixes useless/worthless job items cluttering up your storage if you take loadout items.