### PR TITLE
Add flint and dead trees to forage noisemap

### DIFF
--- a/code/modules/random_map/noise/forage.dm
+++ b/code/modules/random_map/noise/forage.dm
@@ -46,12 +46,14 @@
 			"towercap"
 		),
 		"shallows" = list(
+			/obj/item/rock/flint,
 			"rice",
 			"mollusc",
 			"clam",
 			"sugarcane"
 		),
 		"cave_shallows" = list(
+			/obj/item/rock/flint,
 			"algae",
 			"mollusc",
 			"clam"
@@ -73,6 +75,12 @@
 			"coffee",
 			"tea"
 		),
+		"riverbed" = list(
+			/obj/item/rock/flint,
+			// no rice, generally rice wants at most 10cm water
+			"mollusc",
+			"clam"
+		)
 	)
 	var/list/trees = list(
 		/obj/structure/flora/tree/hardwood/ebony
@@ -115,6 +123,9 @@
 				return
 			place_prob = parse_value * 0.3
 			place_type = pick(forage["grass"])
+		else if(istype(T, /turf/exterior/mud/water/deep))
+			place_prob = parse_value * 0.3
+			place_type = pick(forage["riverbed"])
 		else if(istype(T, /turf/exterior/mud/water))
 			place_prob = parse_value * 0.3
 			place_type = pick(forage["shallows"])
@@ -134,9 +145,12 @@
 			place_type = pick(forage["cave_shallows"])
 
 	if(place_type && prob(place_prob))
-		new /obj/structure/flora/plant(T, null, null, place_type)
-		for(var/stepdir in global.alldirs)
-			if(prob(15))
-				var/turf/neighbor = get_step(T, stepdir)
-				if(istype(neighbor, T.type) && !(locate(/obj/structure/flora/plant) in neighbor))
-					new /obj/structure/flora/plant(neighbor, null, null, place_type)
+		if(istype(place_type, /datum/seed))
+			new /obj/structure/flora/plant(T, null, null, place_type)
+			for(var/stepdir in global.alldirs)
+				if(prob(15))
+					var/turf/neighbor = get_step(T, stepdir)
+					if(istype(neighbor, T.type) && !(locate(/obj/structure/flora/plant) in neighbor))
+						new /obj/structure/flora/plant(neighbor, null, null, place_type)
+		else if(ispath(place_type, /atom))
+			new place_type(T)

--- a/code/modules/random_map/noise/forage.dm
+++ b/code/modules/random_map/noise/forage.dm
@@ -83,7 +83,8 @@
 		)
 	)
 	var/list/trees = list(
-		/obj/structure/flora/tree/hardwood/ebony
+		/obj/structure/flora/tree/hardwood/ebony = 9,
+		/obj/structure/flora/tree/dead/ebony = 1
 	)
 	var/list/cave_trees = list(
 		/obj/structure/flora/tree/softwood/towercap
@@ -118,7 +119,7 @@
 				return
 		else if(istype(T, /turf/exterior/wildgrass))
 			if(prob(parse_value * 0.35))
-				var/tree_type = pick(trees)
+				var/tree_type = pickweight(trees)
 				new tree_type(T)
 				return
 			place_prob = parse_value * 0.3


### PR DESCRIPTION
## Description of changes
Adds flint and dead trees to the forage noisemap.
Also adds better support for spawning non-seeds in the forage noisemap.
Makes the tree list a weighted list.

## Why and what will this PR improve
Flint is now a lot easier to find without having to dig first, and moreover flint is commonly found on riverbeds in real life.
Adds some visual variety to trees in the forage noisemap.