### PR TITLE
Adjust temperature equalization

### DIFF
--- a/code/game/atoms_temperature.dm
+++ b/code/game/atoms_temperature.dm
@@ -43,8 +43,9 @@
 	// Determine if our temperature needs to change.
 	var/old_temp = temperature
 	var/diff_temp = adjust_temp - temperature
-	if(abs(diff_temp) >= ATOM_TEMPERATURE_EQUILIBRIUM_THRESHOLD)
-		var/altered_temp = max(temperature + (get_thermal_mass_coefficient() * diff_temp), 0)
+	var/thermal_mass_coefficient = get_thermal_mass_coefficient()
+	if(abs(diff_temp) >= (thermal_mass_coefficient * ATOM_TEMPERATURE_EQUILIBRIUM_THRESHOLD))
+		var/altered_temp = max(temperature + (thermal_mass_coefficient * diff_temp), 0)
 		ADJUST_ATOM_TEMPERATURE(src, (diff_temp > 0) ? min(adjust_temp, altered_temp) : max(adjust_temp, altered_temp))
 	else
 		temperature = adjust_temp


### PR DESCRIPTION
## Description of changes
Adjust the equilibrium threshold to scale with thermal mass coefficient, allowing things with a low thermal mass coefficient to heat themselves without worrying about the environment.

## Why and what will this PR improve
I was having issues with cooking machinery downstairs getting reset to room temperature because they didn't heat up more than 5C per tick. This should make things reach equilibrium with room air temperature faster with higher coefficients and slower with lower coefficients.