### PR TITLE
Fix power monitor and power sensor name handling

### DIFF
--- a/code/modules/modular_computers/file_system/programs/engineering/power_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/power_monitor.dm
@@ -65,7 +65,7 @@
 	// Build list of data from sensor readings.
 	for(var/obj/machinery/power/sensor/S in grid_sensors)
 		sensors.Add(list(list(
-		"name" = S.id_tag,
+		"name" = html_encode(S.id_tag),
 		"alarm" = S.check_grid_warning()
 		)))
 		if(S.id_tag == active_sensor)
@@ -167,5 +167,5 @@
 
 
 	else if( href_list["setsensor"] )
-		active_sensor = href_list["setsensor"]
+		active_sensor = html_decode(href_list["setsensor"])
 		. = 1

--- a/code/modules/power/sensors/powernet_sensor.dm
+++ b/code/modules/power/sensors/powernet_sensor.dm
@@ -36,7 +36,10 @@
 		var/area/A = get_area(src)
 		if(!A)
 			return // in nullspace
-		id_tag = "[A.proper_name] #[sequential_id(A.name + "power/sensor")]"
+		var/suffix = uniqueness_repository.Generate(/datum/uniqueness_generator/id_sequential, "[A.proper_name]power/sensor", 1) // unlike sequential_id, starts at 1 instead of 100
+		if(suffix == 1)
+			suffix = null
+		id_tag = "[A.proper_name][suffix ? " #[suffix]" : null]"
 	name = "[id_tag] - powernet sensor"
 
 // Proc: check_grid_warning()


### PR DESCRIPTION
## Description of changes
Makes power monitors not break on power sensors with non-alphanumeric characters in their names.
Makes power sensor autonaming start at #1 instead of #100.

Changes taken from Lighthouse.

## Why and what will this PR improve
Power monitors can actually view sensors regardless of non-alphanumeric characters being in their name.
Power sensor autonaming now only adds labels to #2 and onwards, so an area with only one auto-named sensor will just use the area name.