### PR TITLE
Forces equipment slot test to use human species regardless of map default.

### DIFF
--- a/code/unit_tests/equipment_tests.dm
+++ b/code/unit_tests/equipment_tests.dm
@@ -146,7 +146,7 @@
 		failure_list += "[item] was equipped to [equipped_location] despite failing isEquipped (should not be equipped)."
 
 /datum/unit_test/equipment_slot_test/start_test()
-	var/mob/living/carbon/human/subject = new(get_safe_turf())
+	var/mob/living/carbon/human/subject = new(get_safe_turf(), SPECIES_HUMAN) // force human so default map species doesn't mess with anything
 	created_atoms |= subject
 	var/list/failures = list()
 


### PR DESCRIPTION
Unit tests expect a standardized set of slots that default species can change. This forces it to use human.