### PR TITLE
Fix grown food drying/grilling products vanishing

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -338,7 +338,7 @@ var/global/list/_wood_materials = list(
 
 /obj/item/chems/food/grown/get_dried_product()
 	if(ispath(dried_type, /obj/item/chems/food/grown))
-		return new dried_type(loc, seed.type)
+		return new dried_type(loc, null, seed.type)
 	return ..()
 
 /obj/item/chems/food/grown/grilled
@@ -347,7 +347,7 @@ var/global/list/_wood_materials = list(
 
 /obj/item/chems/food/grown/get_grilled_product()
 	if(ispath(backyard_grilling_product, /obj/item/chems/food/grown))
-		return new backyard_grilling_product(loc, seed.type)
+		return new backyard_grilling_product(loc, null, seed.type)
 	return ..()
 
 // Predefined types for placing on the map.


### PR DESCRIPTION
## Description of changes
Fixes a missing material_key argument causing dried/grilled growns to be created with no seed.

## Why and what will this PR improve
Dried/grilled growns will actually be properly created.