### PR TITLE
Fix runtime from mining natural walls

### DIFF
--- a/code/game/turfs/walls/wall_natural.dm
+++ b/code/game/turfs/walls/wall_natural.dm
@@ -75,7 +75,8 @@
 			being_mined = TRUE
 			if(W.do_tool_interaction(TOOL_PICK, user, src, 2 SECONDS, suffix_message = destroy_artifacts(W, INFINITY)))
 				dismantle_wall()
-			being_mined = FALSE
+			if(istype(src, /turf/wall/natural)) // dismantle_wall() can change our type
+				being_mined = FALSE
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
## Description of changes
ChangeTurf changes the type of src mid-proc, which causes a runtime since the var no longer exists. Thus, we add a typecheck.

## Why and what will this PR improve
Fixes a runtime when mining natural walls.