### PR TITLE
Fixes planet colors for skybox image generation

### DIFF
--- a/code/modules/maps/template_types/random_exoplanet/planet_types/barren.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/barren.dm
@@ -6,8 +6,6 @@
 	name          = "barren exoplanet"
 	desc          = "A planet that couldn't hold its atmosphere from either low gravity, or the lack of a strong magnetosphere, or even from intense solar winds."
 	color         = "#6c6c6c"
-	surface_color = "#807d7a"
-	water_color   = null
 
 ////////////////////////////////////////////////////////////////////////////
 // Level Data
@@ -48,6 +46,8 @@
 	atmosphere_gen_temperature_min = -240 CELSIUS //-240c is about the surface temp of pluto for ref
 	atmosphere_gen_temperature_max = 450 CELSIUS //450c is the temperature at the surface of mercury for ref
 	initial_weather_state          = null // No weather.
+	surface_color = "#807d7a"
+	water_color   = null
 	possible_rock_colors           = list(
 		COLOR_BEIGE,
 		COLOR_GRAY80,

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/chlorine.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/chlorine.dm
@@ -6,8 +6,6 @@
 	name          = "chlorine exoplanet"
 	desc          = "An exoplanet with a chlorine based ecosystem. Large quantities of liquid chlorine are present."
 	color         = "#c9df9f"
-	surface_color = "#a3b879"
-	water_color   = COLOR_BOTTLE_GREEN
 
 /obj/effect/overmap/visitable/sector/planetoid/exoplanet/chlorine/get_atmosphere_color()
 	return "#e5f2bd"
@@ -72,6 +70,8 @@
 	surface_light_gen_level_max    = 0.85
 	flora                          = /datum/planet_flora/random/chlorine
 	fauna                          = /datum/fauna_generator/chlorine
+	surface_color 				   = "#a3b879"
+	water_color  				   = COLOR_BOTTLE_GREEN
 	possible_rock_colors           = list(
 		COLOR_GRAY80,
 		COLOR_PALE_GREEN_GRAY,

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/desert.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/desert.dm
@@ -6,8 +6,6 @@
 	name          = "desert exoplanet"
 	desc          = "An arid exoplanet with sparse biological resources but rich mineral deposits underground."
 	color         = "#a08444"
-	surface_color = "#d6cca4"
-	water_color   = null
 
 ////////////////////////////////////////////////////////////////////////////
 // Level Data
@@ -80,6 +78,8 @@
 	surface_light_gen_level_max    = 0.95
 	flora                          = /datum/planet_flora/random/desert
 	fauna                          = /datum/fauna_generator/desert
+	surface_color 				   = "#d6cca4"
+	water_color   				   = null
 	possible_rock_colors           = list(
 		COLOR_BEIGE,
 		COLOR_PALE_YELLOW,

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/meat.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/meat.dm
@@ -6,8 +6,6 @@
 	name          = "organic exoplanet"
 	desc          = "An exoplanet made entirely of organic matter."
 	color         = "#ac4653"
-	surface_color = "#e2768d"
-	water_color   = "#c7c27c"
 
 ////////////////////////////////////////////////////////////////////////////
 // Level Data
@@ -76,6 +74,8 @@
 	flora                          = /datum/planet_flora/random/meat
 	fauna                          = /datum/fauna_generator/meat
 	strata                         = /decl/strata/sedimentary
+	surface_color = "#e2768d"
+	water_color   = "#c7c27c"
 	possible_rock_colors           = list(
 		COLOR_OFF_WHITE,
 		"#f3ebd4",

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/shrouded.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/shrouded.dm
@@ -6,8 +6,6 @@
 	name          = "shrouded exoplanet"
 	desc          = "An exoplanet shrouded in a perpetual storm of bizzare, light absorbing particles."
 	color         = "#783ca4"
-	surface_color = "#3e3960"
-	water_color   = "#2b2840"
 
 /obj/effect/overmap/visitable/sector/planetoid/exoplanet/shrouded/get_atmosphere_color()
 	return COLOR_BLACK
@@ -71,6 +69,8 @@
 	surface_light_gen_level_max    = 0.25
 	flora                          = /datum/planet_flora/random/shrouded
 	fauna                          = /datum/fauna_generator/shrouded
+	surface_color = "#3e3960"
+	water_color   = "#2b2840"
 	possible_rock_colors           = list(
 		COLOR_INDIGO,
 		COLOR_DARK_BLUE_GRAY,

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/snow.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/snow.dm
@@ -6,8 +6,6 @@
 	name          = "snow exoplanet"
 	desc          = "Cold planet with limited plant life."
 	color         = "#dcdcdc"
-	surface_color = "#e8faff"
-	water_color   = "#b5dfeb"
 
 ////////////////////////////////////////////////////////////////////////////
 // Level Data
@@ -62,6 +60,8 @@
 	initial_weather_state          = /decl/state/weather/snow
 	flora                          = /datum/planet_flora/random/snow
 	fauna                          = /datum/fauna_generator/snow
+	surface_color = "#e8faff"
+	water_color   = "#b5dfeb"
 	possible_rock_colors           = list(
 		COLOR_DARK_BLUE_GRAY,
 		COLOR_GUNMETAL,

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/volcanic.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/volcanic.dm
@@ -6,8 +6,6 @@
 	name          = "volcanic exoplanet"
 	desc          = "A tectonically unstable planet, extremely rich in minerals."
 	color         = "#9c2020"
-	surface_color = "#261e19"
-	water_color   = "#c74d00"
 
 /obj/effect/overmap/visitable/sector/planetoid/exoplanet/volcanic/get_atmosphere_color()
 	return COLOR_GRAY20
@@ -78,6 +76,8 @@
 	initial_weather_state          = /decl/state/weather/ash
 	flora                          = /datum/planet_flora/random/volcanic
 	fauna                          = /datum/fauna_generator/volcanic
+	surface_color = "#261e19"
+	water_color   = "#c74d00"
 	possible_rock_colors           = list(
 		COLOR_DARK_GRAY
 	)


### PR DESCRIPTION


<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Overmap object gets these variables set by template data so they were always overwritten by default values. Moves them in the right place now.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Meat planets now look meat colored from space again

## Authorship
<!-- Describe original authors of changes to credit them. -->
Me

## Changelog
:cl:
bugfix: Fixed planets having wrong colors when seen on skybox
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->