### PR TITLE
Simplifies gravity checking for mobs.

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -447,23 +447,10 @@ var/global/list/mob/living/forced_ambiance_list = new
 
 /atom/proc/has_gravity()
 	var/area/A = get_area(src)
-	if(A && A.has_gravity())
-		return 1
-	return 0
-
-/mob/has_gravity()
-	if(!lastarea)
-		lastarea = get_area(src)
-	if(!lastarea || !lastarea.has_gravity())
-		return 0
-
-	return 1
+	return A?.has_gravity()
 
 /turf/has_gravity()
-	var/area/A = loc
-	if(A && A.has_gravity())
-		return 1
-	return 0
+	return loc.has_gravity()
 
 /area/proc/get_dimensions()
 	var/list/res = list("x"=1,"y"=1)


### PR DESCRIPTION
Pointing this to dev in case of unexpected impacts, but as far as I can tell the previous logic was in place due to new player spawning causing gravity changes, which was later fixed in copy_to(). This appears to fix the constant slipping issue resulting from lateral Z-transitions not setting lastarea.