### PR TITLE
Hide certain codex entries based on map tech level

### DIFF
--- a/code/controllers/subsystems/initialization/codex.dm
+++ b/code/controllers/subsystems/initialization/codex.dm
@@ -112,6 +112,8 @@ SUBSYSTEM_DEF(codex)
 			results = list()
 			for(var/entry_title in entries_by_string)
 				var/datum/codex_entry/entry = entries_by_string[entry_title]
+				if(entry.unsearchable) // This entry can only be opened directly from links, and does not show up in search results.
+					continue
 				if(findtext(entry.name, searching) || findtext(entry.lore_text, searching) || findtext(entry.mechanics_text, searching) || findtext(entry.antag_text, searching))
 					results |= entry
 		search_cache[searching] = sortTim(results, /proc/cmp_name_asc)

--- a/code/modules/codex/categories/_category.dm
+++ b/code/modules/codex/categories/_category.dm
@@ -26,8 +26,10 @@
 				PRINT_STACK_TRACE("Invalid item supplied to codex category Populate(): [item]")
 				continue
 			var/starter = uppertext(copytext(strip_improper(item_entry.name), 1, 2))
-			LAZYADD(links[starter], "<l>[item_entry.name]</l>")
 			LAZYDISTINCTADD(item_entry.categories, src)
+			if(item_entry.unsearchable) // Unsearchable entries don't show up in category listings either.
+				continue
+			LAZYADD(links[starter], "<l>[item_entry.name]</l>")
 
 		var/list/link_cells = list()
 		for(var/letter in global.alphabet_capital)

--- a/code/modules/codex/categories/category_uncategorized.dm
+++ b/code/modules/codex/categories/category_uncategorized.dm
@@ -1,6 +1,6 @@
 /decl/codex_category/uncategorized
 	name = "Uncategorized"
-	desc = "A collection uncategorized entries."
+	desc = "A collection of uncategorized entries."
 	defer_population = TRUE
 
 /decl/codex_category/uncategorized/Populate()

--- a/code/modules/codex/codex_client.dm
+++ b/code/modules/codex/codex_client.dm
@@ -87,6 +87,9 @@
 		if(!antag_check && entry.antag_text && !entry.mechanics_text && !entry.lore_text)
 			continue
 
+		if(entry.unsearchable) // We act as if this entry doesn't exist unless directly opened by an item.
+			continue
+
 		var/first_letter = uppertext(copytext(thing, 1, 2))
 		if(first_letter != last_first_letter)
 			last_first_letter = first_letter

--- a/code/modules/codex/entries/_codex_entry.dm
+++ b/code/modules/codex/entries/_codex_entry.dm
@@ -25,11 +25,18 @@
 	var/include_subtypes = FALSE
 	/// HTML returned when the entry is used to populate a guide manual.
 	var/guide_html
+	/// The map tech level this entry will appear for.
+	var/available_to_map_tech_level = MAP_TECH_LEVEL_ANY
+	/// If TRUE, the entry will be excluded from search results, category listings, or the index.
+	/// It will only be accessible from items and entries that directly link to it.
+	var/unsearchable = FALSE
 
 /datum/codex_entry/temporary
 	store_codex_entry = FALSE
 
 /datum/codex_entry/New(var/_display_name, var/list/_associated_paths, var/list/_associated_strings, var/_lore_text, var/_mechanics_text, var/_antag_text)
+	if(global.using_map.map_tech_level < available_to_map_tech_level)
+		unsearchable = TRUE
 
 	if(_display_name)       name =               _display_name
 	if(_associated_paths)   associated_paths =   _associated_paths

--- a/code/modules/codex/entries/atmospherics.dm
+++ b/code/modules/codex/entries/atmospherics.dm
@@ -7,18 +7,21 @@
 	<br>To terminate a pipeline, use a cap to prevent the gas escaping into the environment."
 	include_subtypes = TRUE
 	disambiguator = "atmospherics"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //T-shaped valves
 /datum/codex_entry/atmos_tvalve
 	associated_paths = list(/obj/machinery/atmospherics/tvalve)
 	mechanics_text = "Click this to toggle the mode.  The direction with the green light is where the gas will flow."
 	disambiguator = "atmospherics"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Normal valves
 /datum/codex_entry/atmos_valve
 	associated_paths = list(/obj/machinery/atmospherics/valve)
 	mechanics_text = "Click this to turn the valve.  If red, the pipes on each end are seperated.  Otherwise, they are connected."
 	disambiguator = "atmospherics"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //TEG ports
 /datum/codex_entry/atmos_circulator
@@ -26,24 +29,28 @@
 	mechanics_text = "This generates electricity, depending on the difference in temperature between each side of the machine.  The meter in \
 	the center of the machine gives an indicator of how much elecrtricity is being generated."
 	disambiguator = "atmospherics"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Passive gates
 /datum/codex_entry/atmos_gate
 	associated_paths = list(/obj/machinery/atmospherics/binary/passive_gate)
 	mechanics_text = "This is a one-way regulator, allowing gas to flow only at a specific pressure and flow rate.  If the light is green, it is flowing."
 	disambiguator = "atmospherics"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Normal pumps (high power one inherits from this)
 /datum/codex_entry/atmos_pump
 	associated_paths = list(/obj/machinery/atmospherics/binary/pump)
 	mechanics_text = "This moves gas from one pipe to another.  A higher target pressure demands more energy.  The side with the red end is the output."
 	disambiguator = "atmospherics"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Vents
 /datum/codex_entry/atmos_vent_pump
 	associated_paths = list(/obj/machinery/atmospherics/unary/vent_pump)
 	mechanics_text = "This pumps the contents of the attached pipe out into the atmosphere, if needed.  It can be controlled from an Air Alarm."
 	disambiguator = "atmospherics"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Freezers
 /datum/codex_entry/atmos_freezer
@@ -52,6 +59,7 @@
 	It can be upgraded by replacing the capacitors, manipulators, and matter bins.  It can be deconstructed by screwing the maintenance panel open with a \
 	screwdriver, and then using a crowbar."
 	disambiguator = "atmospherics"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Heaters
 /datum/codex_entry/atmos_heater
@@ -60,6 +68,7 @@
 	It can be upgraded by replacing the capacitors, manipulators, and matter bins.  It can be deconstructed by screwing the maintenance panel open with a \
 	screwdriver, and then using a crowbar."
 	disambiguator = "atmospherics"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Gas injectors
 /datum/codex_entry/atmos_injector
@@ -67,6 +76,7 @@
 	mechanics_text = "Outputs the pipe's gas into the atmosphere, similar to an airvent.  It can be controlled by a nearby atmospherics computer. \
 	A green light on it means it is on."
 	disambiguator = "atmospherics"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Scrubbers
 /datum/codex_entry/atmos_vent_scrubber
@@ -74,6 +84,7 @@
 	mechanics_text = "This filters the atmosphere of harmful gas.  Filtered gas goes to the pipes connected to it, typically a scrubber pipe. \
 	It can be controlled from an Air Alarm.  It can be configured to drain all air rapidly with a 'panic syphon' from an air alarm."
 	disambiguator = "atmospherics"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Omni filters
 /datum/codex_entry/atmos_omni_filter
@@ -81,12 +92,14 @@
 	mechanics_text = "Filters gas from a custom input direction, with up to two filtered outputs and a 'everything else' \
 	output.  The filtered output's arrows glow orange."
 	disambiguator = "atmospherics"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Omni mixers
 /datum/codex_entry/atmos_omni_mixer
 	associated_paths = list(/obj/machinery/atmospherics/omni/mixer)
 	mechanics_text = "Combines gas from custom input and output directions.  The percentage of combined gas can be defined."
 	disambiguator = "atmospherics"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Canisters
 /datum/codex_entry/atmos_canister
@@ -97,6 +110,7 @@
 	*DO NOT* remove the tank until the valve is closed.  A gas analyzer can be used to check the contents of the canister."
 	antag_text = "Canisters can be damaged, spilling their contents into the air, or you can just leave the release valve open."
 	disambiguator = "atmospherics"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Portable pumps
 /datum/codex_entry/atmos_power_pump
@@ -105,6 +119,7 @@
 	connecting it to a connector port.  The pump can pump the air in (sucking) or out (blowing), at a specific target pressure.  The powercell inside can be \
 	replaced by using a screwdriver, and then adding a new cell.  A tank of gas can also be attached to the air pump."
 	disambiguator = "machine"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Portable scrubbers
 /datum/codex_entry/atmos_power_scrubber
@@ -113,24 +128,28 @@
 	connecting it to a connector port.  The pump can pump the air in (sucking) or out (blowing), at a specific target pressure.  The powercell inside can be \
 	replaced by using a screwdriver, and then adding a new cell.  A tank of gas can also be attached to the scrubber. "
 	disambiguator = "machine"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Meters
 /datum/codex_entry/atmos_meter
 	associated_paths = list(/obj/machinery/meter)
 	mechanics_text = "Measures the volume and temperature of the pipe under the meter."
 	disambiguator = "atmospherics"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Pipe dispensers
 /datum/codex_entry/atmos_pipe_dispenser
 	associated_paths = list(/obj/machinery/fabricator/pipe)
 	mechanics_text = "This can be moved by using a wrench.  You will need to wrench it again when you want to use it.  You can put \
 	excess (atmospheric) pipes into the dispenser, as well.  The dispenser requires electricity to function."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/transfer_valve
 	associated_paths = list(/obj/item/transfer_valve)
 	mechanics_text = "This machine is used to merge the contents of two different gas tanks. Plug the tanks into the transfer, then open the valve to mix them together. You can also attach various assembly devices to trigger this process."
 	antag_text = "With a tank of hot hydrogen and cold oxygen, this benign little atmospheric device becomes an incredibly deadly bomb. You don't want to be anywhere near it when it goes off."
 	disambiguator = "component"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/gas_tank
 	associated_paths = list(/obj/item/tank)
@@ -146,6 +165,7 @@
 	Wired and assembled tanks may be disarmed with a set of wirecutters. Any exploding or rupturing tank will generate shrapnel, assuming their relief valves have been welded beforehand. Even if not, they can be incited to expel hot gas on ignition if pushed above 173?C. \
 	Relatively easy to make, the single tank bomb requries no tank transfer valve, and is still a fairly formidable weapon that can be manufactured from any tank."
 	disambiguator = "atmospherics"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/gas_analyzer
 	associated_paths = list(/obj/item/scanner/gas)
@@ -153,3 +173,4 @@
 	additional output data; Moles and volume shows the moles per gas in the mixture and the total moles and volume; Gas \
 	traits and data describes the traits per gas, how it interacts with the world, and some of its property constants."
 	disambiguator = "equipment"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE

--- a/code/modules/codex/entries/engineering.dm
+++ b/code/modules/codex/entries/engineering.dm
@@ -13,6 +13,7 @@
 	antag_text = "Exposing the supermatter to oxygen or vaccum will cause it to start rapidly heating up.  Sabotaging the supermatter and making it explode will \
 	cause a period of lag as the explosion is processed by the server, as well as irradiating the entire station and causing hallucinations to happen.  \
 	Wearing radiation equipment will protect you from most of the delamination effects sans explosion."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/apc
 	associated_paths = list(/obj/machinery/power/apc)
@@ -23,10 +24,12 @@
 	with an ID with Engineering access or by one of the station's robots or the artificial intelligence."
 	antag_text = "This can be emagged to unlock it.  It will cause the APC to have a blue error screen. \
 	Wires can be pulsed remotely with a signaler attached to it.  A powersink will also drain any APCs connected to the same wire the powersink is on."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/inflatable_item
 	associated_paths = list(/obj/item/inflatable, /obj/structure/inflatable, /obj/structure/inflatable/door)
 	mechanics_text = "Inflate by using it in your hand.  The inflatable barrier will inflate on your tile.  To deflate it, use the 'deflate' verb. Hitting this with any object will probably puncture and break it forever.<br>Walls are static, but doors may be clicked to open or close them. They only stop air while closed."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/welding_pack
 	associated_paths = list(/obj/item/chems/weldpack, /obj/item/chems/weldpack/empty)
@@ -34,17 +37,20 @@
 	lore_text = "The Shenzhen Chain of 2133 was an industrial accident of noteworthy infamy that occurred at Earth's L3 Lagrange Point. An apprentice welder, working for the Shenzhen Space Fabrication Group, failed to properly seal her fuel port, triggering a chain reaction that spread from laborer to laborer, instantly vaporizing a crew of fourteen. Don't let this happen to you!"
 	antag_text = "In theory, you could hold an open flame to this pack and produce some pretty catastrophic results. The trick is getting out of the blast radius."
 	disambiguator = "equipment"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/gripper
 	associated_paths = list(/obj/item/gripper)
 	mechanics_text = "Click an item to pick it up with your gripper. Use it as you would normally use anything in your hand. The Drop Item verb will allow you to release the item."
 	disambiguator = "equipment"
 	include_subtypes = TRUE
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/diffuser_item
 	associated_paths = list(/obj/item/shield_diffuser)
 	mechanics_text = "This device disrupts shields on directly adjacent tiles (in a + shaped pattern), in a similar way the floor mounted variant does. It is, however, portable and run by an internal battery. Can be recharged with a regular recharger."
 	disambiguator = "equipment"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/solars
 	associated_paths = list(/obj/item/solar_assembly, /obj/machinery/power/solar, /obj/machinery/power/tracker, /obj/machinery/power/solar_control)
@@ -61,6 +67,7 @@
 	4.) Add glass to every solar panel assembly, including the one with the tracker electronics.<BR> \
 	5.) Make a computer frame out of steel and install a circuit board (solar control console).<BR> \
 	If at any point you need to move a solar panel, use a crowbar to remove the glass, a wrench to unsecure the assembly, and a wirecutter to remove the cables."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/cable
 	associated_paths = list(/obj/structure/cable, /obj/item/stack/cable_coil)
@@ -75,3 +82,4 @@
 	<li>To lay a cable between decks (z-levels), use a cable on an open space from the deck above, dropping it down to the level below.</li></ul>"
 	antag_text = "Sometimes a carefully cut cable in the right place can cause power issues over a wide area once APCs start to run out. Just make sure to hide it after."
 	include_subtypes = TRUE
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE

--- a/code/modules/codex/entries/guides.dm
+++ b/code/modules/codex/entries/guides.dm
@@ -23,6 +23,7 @@
 
 /datum/codex_entry/guide/robotics
 	name = "Guide to Robotics"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 	lore_text = {"
 		<h1>Cyborgs for Dummies</h1>
 
@@ -149,6 +150,7 @@
 
 /datum/codex_entry/guide/detective
 	name = "Guide to Forensics"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 	lore_text = {"
 		<h1>Detective Work</h1>
 		Between your bouts of self-narration and drinking whiskey on the rocks, you might get a case or two to solve.<br>
@@ -174,6 +176,7 @@
 
 /datum/codex_entry/guide/nuclear_sabotage
 	name = "Guide to Nuclear Sabotage"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 	lore_text = {"
 		<h1>Nuclear Explosives 101</h1>
 		Hello and thank you for choosing the Syndicate for your nuclear information needs. Today's crash course will deal with the operation of a Nuclear Fission Device.<br><br>
@@ -208,6 +211,7 @@
 
 /datum/codex_entry/guide/particle_accelerator
 	name = "Guide to Particle Accelerators"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 	lore_text = {"
 		<h1>Experienced User's Guide</h1>
 		<h2>Setting up the accelerator</h2>
@@ -229,6 +233,7 @@
 
 /datum/codex_entry/guide/singularity
 	name = "Guide to Singularity Engines"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 	lore_text = {"
 		<h1>Singularity Safety in Special Circumstances</h1>
 		<h2>Power outage</h2>
@@ -258,6 +263,7 @@
 
 /datum/codex_entry/guide/mech_construction
 	name = "Guide to Exosuit Construction"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 	lore_text = {"
 		<center>
 		<br>
@@ -315,6 +321,7 @@
 
 /datum/codex_entry/guide/atmospherics
 	name = "Guide to Atmospherics"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 	lore_text = {"
 		<h1><a name="Contents">Contents</a></h1>
 		<ol>
@@ -391,6 +398,7 @@
 
 /datum/codex_entry/guide/eva
 	name = "Guide to EVA"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 	lore_text = {"
 		<h1><a name="Foreword">EVA Gear and You: Not Spending All Day Inside</a></h1>
 		<I>Or: How not to suffocate because there's a hole in your shoes</I><BR>
@@ -447,6 +455,7 @@
 
 /datum/codex_entry/guide/xenoarchaeology
 	name = "Guide to Xenoarchaeology"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 	lore_text = {"
 		<h1><a name="Contents">Contents</a></h1>
 		<ol>
@@ -538,6 +547,7 @@
 
 /datum/codex_entry/guide/mass_spectrometry
 	name = "Guide to Mass Spectrometry"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 	lore_text = {"
 		<h1><a name="Contents">Contents</a></h1>
 		<ol>
@@ -586,18 +596,22 @@
 
 /datum/codex_entry/guide/engineering
 	name = "Guide to Engineering"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/guide/construction
 	name = "Guide to Construction"
 
 /datum/codex_entry/guide/supermatter
 	name = "Guide to Supermatter Engines"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/guide/fusion
 	name = "Guide to Fusion Reactors"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/guide/hacking
 	name = "Guide to Hacking"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 	associated_strings = list("hacking")
 	mechanics_text = "Airlocks, vending machines, and various other machinery can be hacked by opening them up and fiddling with the wires. \
 	While it might sound like a unlawful deed (and it usually is) this process is also performed by engineers, usually to fix said criminal deeds. \

--- a/code/modules/codex/entries/guns.dm
+++ b/code/modules/codex/entries/guns.dm
@@ -116,6 +116,7 @@
 		place. Additionally, most energy weapons can go straight through windows and hit whatever is on the other side, and are \
 		hitscan, making them accurate and useful against distant targets. \
 		<br><br>"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/ballistic_weapons
 	name = "ballistic weapons"
@@ -127,6 +128,7 @@
 		weapons, difficulties in maintaining them, and the sheer stopping and wounding power of solid slugs or \
 		composite shot. Using a ballistic weapon on a spacebound habitat is usually considered a serious undertaking, \
 		as a missed shot or careless use of automatic fire could rip open the hull or injure bystanders with ease."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE // TODO: MAP_TECH_LEVEL_CONTEMPORARY for things that exist in real life?
 
 /datum/codex_entry/magnetic_weapons
 	name = "magnetic weapons"
@@ -136,3 +138,4 @@
 	lore_text = "<p>Magnetic weapons, while uncommon, are seen throughout human space, firing physical projectiles using powerful magnets. \
 		Magnetic weapons tend to be very power inefficient. The most recognizable form is the railgun, though crafty engineers have been known to \
 		produce their own makeshift coilguns.</p>"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE

--- a/code/modules/codex/entries/jukebox.dm
+++ b/code/modules/codex/entries/jukebox.dm
@@ -3,7 +3,9 @@
 	mechanics_text = "Click the jukebox and then select a track on the interface. You can choose to play or stop the track, or set the volume. Use a wrench to attach or detach the jukebox to the floor. The room it is installed in must have power for it to operate!"
 	lore_text = "The Leitmotif is Auraliving's most popular brand of retro jukebox, putting a modern spin on the ancient curved plasmascreen design. The Enterprise Edition allows an indefinite number of users to sync music from their devices simultaneously... of course the Expeditionary Corps made sure to lock down the selection before they installed this one."
 	antag_text = "Slide a cryptographic sequencer into the jukebox to overload its speakers. Instead of music, it'll produce a hellish blast of noise and explode!"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/jukebox/old
 	associated_paths = list(/obj/machinery/media/jukebox/old)
 	lore_text = "No one these days knows what civilization is responsible for this machine's design - various alien species have been credited on more than one occasion."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE

--- a/code/modules/codex/entries/machinery.dm
+++ b/code/modules/codex/entries/machinery.dm
@@ -3,6 +3,7 @@
 	mechanics_text = "An airtight mechanical door. Most airlocks require an ID to open (wearing it on your ID slot is enough), and many have special access requirements to be on your ID. You can open an airlock by clicking on one, or simply walking into it, and clicking on an open airlock will close it. If the lights on the door flash red, you don't have the required access to open the airlock, and if they're consistently red, the door is bolted. Airlocks also require power to operate. In a situation without power, a crowbar can be used to force it open. <BR><BR>Airlocks can also be <span codexlink='hacking'>hacked</span>.<BR>Airlock hacking information:<BR>* Door bolts will lock the door, preventing it from being opened by any means until the bolts are raised again. Pulsing the correct wire will toggle the bolts, but cutting it will only drop them.<BR>* IDscan light indicates the door can scan ID cards. If the wire for this is pulsed it will cause the door to flash red, and cutting it will cause doors with restricted access to be unable to scan ID, essentially locking it.<BR>* The AI control light shows whether or not AI and robots can control the door. Pulsing is only temporary, while cutting is more permanent.<BR>* The test light shows whether the door has power or not. When turned off, the door can be opened with a crowbar.<BR>* If the door sparks, it is electrified. Pulsing the corresponding wire causes this to happen for 30 seconds, and cutting it electrifies the door until mended.<BR>* The check wiring light will turn on if the safety is turned off. This causes the airlock to close even when someone is standing on it, crushing them.<BR>* If the Check Timing Mechanism light is on then the door will close much faster than normal. Dangerous in conjuction with the Check Wiring light.<BR><BR><B>Deconstruction</B><BR>To pull apart an airlock, you must open the maintenance panel, disable the power via hacking (or any other means), weld the door shut, and crowbar the electroncs out, cut the wires with a wirecutter, unsecure the whole assembly with a wrench, and then cut it into metal sheets with a welding tool."
 	antag_text = "Electrifying a door makes for a good trap, hurting and stunning whoever touches it. The same goes for a combination of disabling the safety and timing mechanisms. Bolting a door can also help ensure privacy, or slow down those in search of you. It's also a good idea to disable AI interaction when needed."
 	disambiguator = "machine"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/computer
 	associated_paths = list(/obj/machinery/computer, /obj/machinery/constructable_frame/computerframe)
@@ -25,6 +26,7 @@
 	5.) Use a welder to cut the frame into sheets."
 	disambiguator = "machine"
 	include_subtypes = TRUE
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/computer/modular
 	associated_paths = list(/obj/machinery/computer/modular)
@@ -38,32 +40,38 @@
 	* PDA usually come with a pen, which can be remove with the right click menu(or Remove-Pen verb). The pen can be inserted again by using it on the PDA."
 	antag_text = "You can use an emag on the computer to reveal a secret list of downloadable software."
 	disambiguator = "machine"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/conveyor_construct
 	associated_paths = list(/obj/machinery/conveyor, /obj/item/conveyor_construct)
 	mechanics_text = "This device must be connected to a switch assembly before placement by clicking the switch on the conveyor belt assembly. When active it will move objects on top of it to the adjacent space based on its direction and if it is runnnig in forward or reverse mode. Can be removed with a crowbar."
 	disambiguator = "machine"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/conveyor_switch
 	associated_paths = list(/obj/machinery/conveyor_switch, /obj/machinery/conveyor_switch/oneway, /obj/item/conveyor_switch_construct, /obj/item/conveyor_switch_construct/oneway)
 	mechanics_text = "This device can connect to a number of conveyor belts and control their movement. A two-way switch will allow you to make the conveyors run in forward and reverse mode, the one-way switch will only allow one direction. Can be removed with a crowbar."
 	disambiguator = "machine"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/cryopod
 	associated_paths = list(/obj/machinery/cryopod)
 	mechanics_text = "To enter a cryopod, or put someone in a cryopod, click+drag. When someone is in a cryopod, and they use the <i>ghost</i> verb, their character will despawn, be removed from the game round along with all their belongings, and freeing their job slot for someone else to take. This also occurs if a character is inside a cryopod for 15 minutes. Any particularly important belongings that the game can't do without will be stored. The item can then be retrieved from the nearby oversight console."
 	disambiguator = "machine"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/diffuser_machine
 	associated_paths = list(/obj/machinery/shield_diffuser)
 	mechanics_text = "This device disrupts shields on directly adjacent tiles (in a + shaped pattern). They are commonly installed around exterior airlocks to prevent shields from blocking EVA access."
 	disambiguator = "machine"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/disposal
 	associated_paths = list(/obj/machinery/disposal/buildable)
 	mechanics_text = "A high-tech garbage bin. Inserting an item causes the disposal unit (after a delay) to pneumatically launch the item through a series of pipes leading to either a garbage processing room, or space, depending on the ship/station. Larger objects can be inserted via click+drag. <BR> You can remove a disposal unit by turning it off, using a screwdriver, then a welding tool, and removing the floor tile underneath it."
 	antag_text = "People can be inserted into the disposal unit. If they're capable of moving however, it's easy for them to get out. Be careful though, putting things in disposal units doesn't always mean they're gone forever. <BR>If you turn it off, it can be used to hide in. Just be careful no one turns it back on while you're still in there!"
 	disambiguator = "machine"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/emitter
 	associated_paths = list(/obj/machinery/emitter)
@@ -71,12 +79,14 @@
 	lore_text = "Lasers like this one have been in use for ages, in applications such as mining, cutting, and in the startup sequence of many advanced space station and starshipn engines."
 	antag_text = "This baby is capable of slicing through walls, sealed lockers, and people."
 	disambiguator = "machine"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/fusion_fuel_injector
 	associated_paths = list(/obj/machinery/fusion_fuel_injector, /obj/machinery/computer/fusion/fuel_control)
 	lore_text = "A simple magnetic accelerator used to inject small pellets of fuel into a fusion field."
 	mechanics_text = "Accepts a fuel rod produced by the fuel compressor and regularly fires fuel pellets into the fusion field. Rods can be swapped by hand when the injector is not firing. Power outages will require the injector to be turned on again. If there is no electromagnetic field active to catch the injected fuel, the results can be very unhealthy for anyone standing in the firing path. <BR>Controlled via the fuel injection control computer."
 	disambiguator = "machine"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/fusion_core
 	associated_paths = list(/obj/machinery/fusion_core, /obj/machinery/computer/fusion/core_control)
@@ -84,34 +94,40 @@
 	mechanics_text = "Generates the field used to contain reaction material from fuel injectors, and dumps power into the power network under it based on plasma heat. Needs 500W or more in the network to start the field. Field will become unstable if it intersects with windows or other objects, and from some reactions, and will eventually rupture violently if not stabilized by a gyrotron. Turning the field off without letting it cool below 1000K will cause a violent explosion and EMP depending on the contents of the field. <BR>Controlled via the R-UST Mk. 8 core control. Make careful note of the instability."
 	antag_text = "Be careful when blowing this thing up. The blast is fairly large and can happen instantly depending how you do it."
 	disambiguator = "machine"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/fuel_compressor
 	associated_paths = list(/obj/machinery/fuel_compressor)
 	lore_text = "A highly secret design that can compress many varieties of solid and liquid matter into fuel rods for nuclear power production."
 	mechanics_text = "Uses sheets of material or units of reagents to produce fuel rods. Material/units are inserted by hand. Can also have some objects click-dragged onto it for more exotic fuel."
 	disambiguator = "machine"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/gyrotron
 	associated_paths = list(/obj/machinery/emitter/gyrotron, /obj/machinery/computer/fusion/gyrotron)
 	lore_text = "A high-power industrial laser used to excite plasma for fusion reactions. Also used to excite careless engineers, usually fatally."
 	mechanics_text = "Fires in pulses and will heat up a plasma toroid that is below 1000K. Mostly used to lower field instability after heating it to ignition point. Very power hungry, uses 20k per point of power. <BR>Controlled via the gyrotron control console."
 	disambiguator = "machine"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/pacman
 	associated_paths = list(/obj/machinery/port_gen/pacman)
 	mechanics_text = "Lends itself to being portable thanks to the small size and ease of use. Some versions use radioactive fuel and as such produces radiation, while others may produce dangerous byproducts as gasses. Ideally one should wear protective gear while interacting with an active generator. While active it also produces heat and will eventually overheat and explode. While the power output can be increased, doing this causes it to heat up faster. Must be secured using a wrench before use."
 	antag_text = "Can be used as a makeshift delayed explosive when power output is set to unsafe levels, though it may take some time to go off."
 	disambiguator = "machine"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/replicator
 	associated_paths = list(/obj/machinery/fabricator/replicator)
 	mechanics_text = "The food replicator is operated through voice commands. To inquire available dishes on the menu, say 'menu'. To dispense a dish, say the name of the dish listed in its menu. Dishes can only be produced as long as the replicator has biomass. To check on the biomass level of the replicator, say 'status'. Various food items or plants may be inserted to refill biomass."
 	disambiguator = "machine"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/smes
 	associated_paths = list(/obj/machinery/power/smes)
 	mechanics_text = "It's a big battery. An important part of the power network that ensures that you still have power when your generators eventually explode. Maximum input and output settings are available. <BR>The lights on the front show the status of the SMES: The column on the left shows stored power, a blinking red light at top right shows that it's on but receiving no power, blinking yellow shows that the SMES is charging, and the little light on the middle right shows whether it's outputting power or not. <BR>A floor terminal puts power into the SMES, and power is output to a wire underneath."
 	disambiguator = "machine"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/vending
 	associated_paths = list(/obj/machinery/vending)
@@ -120,15 +136,18 @@
 	antag_text = "Accessing the secret inventory of a vending machine can sometimes be very useful, especially for department-focused machines."
 	disambiguator = "machine"
 	include_subtypes = TRUE
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/internet_uplink
 	associated_paths = list(/obj/machinery/internet_uplink, /obj/machinery/computer/internet_uplink)
 	lore_text = "A complex internet uplink, capable of communicating near instantaneously with other uplinks through wormhole technology. It can also communicate with PLEXUS repeaters within a local range using hyperintense radio waves."
 	mechanics_text = "Allows for PLEXUS receivers in a set range on the overmap to function, permitting internetwork functions in the sector. The PLEXUS uplink can restrict access to certain networks. The uplink requires massive amounts of power and atmospheric cooling, scaling with the desired range. <BR>Maximum range can be inreased by installing SMES coils. <BR>Can be controlled via the PLEXUS uplink computer."
 	disambiguator = "machine"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/internet_repeater
 	associated_paths = list(/obj/machinery/internet_repeater)
 	lore_text = "A signal repeater, capable of transmitting and decoding hyperintense radio waves to and from PLEXUS uplinks."
 	mechanics_text = "Allows for network devices in its sector to connect to and communicate with distant networks over PLEXUS.<BR>Networks requires a modem to utilize PLEXUS connections."
 	disambiguator = "machine"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE

--- a/code/modules/codex/entries/medical.dm
+++ b/code/modules/codex/entries/medical.dm
@@ -7,16 +7,19 @@
 	Right-click the scanner and click 'Eject Occupant' to remove them.  You can enter the scanner yourself in a similar way, using the 'Enter Body Scanner' \
 	verb."
 	disambiguator = "machinery"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/optable
 	associated_paths = list(/obj/machinery/optable)
 	mechanics_text = "Click your target with Grab intent, then click on the table with an empty hand, to place them on it.<br>Click on table after that to enable knockout function."
 	disambiguator = "machinery"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/operating
 	associated_paths = list(/obj/machinery/computer/operating)
 	mechanics_text = "This console gives information on the status of the patient on the adjacent operating table, notably their consciousness."
 	disambiguator = "machinery"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/sleeper
 	associated_paths = list(/obj/machinery/sleeper)
@@ -32,6 +35,7 @@
 	Right-click the cell and click 'Eject Occupant' to remove them.  You can enter the cell yourself by right clicking and selecting 'Enter Sleeper'. \
 	Note that you cannot control the sleeper while inside of it."
 	disambiguator = "machinery"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/cryobag
 	associated_paths = list(/obj/item/bodybag/cryobag, /obj/structure/closet/body_bag/cryobag)
@@ -45,6 +49,7 @@
 	<br>\
 	You can use a health analyzer to scan the occupant's vitals without opening the bag by clicking the occupied bag with the analyzer."
 	include_subtypes = TRUE
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/autopump
 	associated_paths = list(/obj/item/auto_cpr/)
@@ -53,3 +58,4 @@
 	There are several things to keep in mind when using it. First off, you need Basic Medicine AND Anatomy skills to align it properly, otherwise it'll hurt patient. \
 	It will only provide some circulation, you need to fix blood volume and oxygen supply issues for it to be useful. \
 	It performs worse than manual CPR by a skilled user and will NOT restart the heart. It's advantage is automatic nature.<br>"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE

--- a/code/modules/codex/entries/misc.dm
+++ b/code/modules/codex/entries/misc.dm
@@ -3,14 +3,17 @@
 	mechanics_text = "You may wear this instead of your backpack to cool yourself down. It is commonly used by full-body prosthetic users, \
 	as it allows them to go into low pressure environments for more than few seconds without overhating. It runs off energy provided by internal power cell. \
 	Remember to turn it on by clicking it when it's your in your hand before you put it on."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/barsign
 	associated_paths = list(/obj/structure/sign/double/barsign)
 	mechanics_text = "If your ID has bar access, you may swipe it on this sign to alter its display."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/sneakies
 	associated_paths = list(/obj/item/clothing/shoes/dress/sneakies)
 	lore_text =  "Originally designed to confuse Terran troops on the swamp moon of Nabier XI, where they were proven somewhat effective. Not bad on a space vessel, either."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/moneygun
 	associated_paths = list(/obj/item/gun/launcher/money)
@@ -18,3 +21,4 @@
 	lore_text = "These devices were invented several centuries ago and are a distinctly human cultural infection. They have produced knockoffs as timeless and as insipid as the potato gun and the paddle ball, showing up in all corners of the galaxy. The Money Cannon variation is noteworthy for its sturdiness and build quality, but is, at the end of the day, just another knockoff of the ancient originals."
 	antag_text = "Sliding a cryptographic sequencer into the receptacle will short the motors and override their speed. If you set the cannon to dispense 100 units or more, this might make a handy weapon."
 	include_subtypes = TRUE
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE

--- a/code/modules/codex/entries/mobs.dm
+++ b/code/modules/codex/entries/mobs.dm
@@ -9,8 +9,10 @@
 	antag_text = "A cryptographic sequencer, available via a traitor uplink, can be used to subvert the drone to your cause."
 	disambiguator = "synthetic"
 	include_subtypes = TRUE
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/uncertified_module
 	associated_paths = list(/obj/item/borg/upgrade/uncertified)
 	mechanics_text = "This special chip will forcibly change a robot's module to a new one. In most cases, this is the only way for the robot to obtain these modules. Once you've unlocked the robot's maintenance hatch with an ID card and opened it with a crowbar, click the bot to install this chip."
 	lore_text = "No TSC, industrial concern, or military organization worth their salt would dare install uncertified hardware on their robotic platforms. Nevertheless, in backwater sectors of the universe, there is a thriving grey market for third-party modular configurations such as this one."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE

--- a/code/modules/codex/entries/stacks.dm
+++ b/code/modules/codex/entries/stacks.dm
@@ -1,6 +1,7 @@
 /datum/codex_entry/telecrystal
 	associated_paths = list(/obj/item/stack/telecrystal)
 	antag_text = "Telecrystals can be activated by utilizing them on devices with an actively running uplink. They will not activate on unactivated uplinks."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/rods
 	associated_paths = list(/obj/item/stack/material/rods)
@@ -15,16 +16,19 @@
 	associated_paths = list(/obj/item/stack/material/cyborg/glass)
 	mechanics_text = "Use in your hand to build a window.  Can be upgraded to reinforced glass by adding metal rods, which are made from metal sheets.<br>\
 	As a synthetic, you can acquire more sheets of glass by recharging."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/glass_reinf_borg
 	associated_paths = list(/obj/item/stack/material/cyborg/glass/reinforced)
 	mechanics_text = "Use in your hand to build a window. Reinforced glass is much stronger against damage.<br>\
 	As a synthetic, you can gain more reinforced glass by recharging."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/steel_borg
 	associated_paths = list(/obj/item/stack/material/cyborg/steel)
 	mechanics_text = "Use in your hand to bring up the recipe menu.  If you have enough sheets, click on something on the list to build it.<br>\
 	You can replenish your supply of metal as a synthetic by recharging."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/material_sheet
 	associated_paths = list(/obj/item/stack/material)

--- a/code/modules/codex/entries/tools.dm
+++ b/code/modules/codex/entries/tools.dm
@@ -38,43 +38,51 @@
 	associated_paths = list(/obj/item/cable_painter)
 	mechanics_text = "Use this device to select a preferred cable color. Apply it to a bundle of cables on your person, or use it on installed cabling on the floor to paint it in your chosen color."
 	lore_text = "A device often used by spacefaring engineers to color-code their electrical systems. An experienced technician can identify traditional installations by color alone."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/paint_sprayer
 	associated_paths = list(/obj/item/paint_sprayer)
 	mechanics_text = "Use the paint sprayer to set decal, color and direction used for painting or to switch into the color picking mode. Ctrl+Click for quickly switching modes and Alt+Click for quickly selecting a preset color."
 	lore_text = "This ubiquitous maintenance-grade paint sprayer isn't as fancy or convenient as modern consumer models, but with an internal synthesizer it never runs out of pigment!"
 	antag_text = "This thing would be perfect for vandalism. Could you write your name in the halls?"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/geiger_counter
 	associated_paths = list(/obj/item/geiger)
 	mechanics_text = "By using this item, you may toggle its scanning mode on and off. Examine it while it's on to check for ambient radiation."
 	lore_text = "For centuries geiger counters have been saving the lives of unsuspecting laborers and technicians. You can never be too careful around radiation."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/light_replacer
 	associated_paths = list(/obj/item/lightreplacer)
 	mechanics_text = "Examine or use this item to see how many lights are remaining. You can feed it lightbulbs or sheets of glass to refill it."
 	lore_text = "Can you believe they used to have to screw lightbulbs in by hand?"
 	antag_text = "Using a cryptographic sequencer on this device will cause it to overload each light it replaces; when turned on, the new lights will explode!"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/multitool
 	name = TOOL_CODEX_MULTITOOL
 	mechanics_text = "Multitools are incredibly versatile and can be used on a wide variety of machines. The most common use for this is to trip a device's wires without having to cut them. Simply click on an object with exposed wiring to use it. There might be other uses, as well..."
 	lore_text = "The common, every day multitool is descended from certain electrical tools from Earth's early space age. Though none too cheap, they are incredibly handy, and can be found in any self-respecting technician's toolbox."
 	antag_text = "This handy little tool can get you through doors, turn off power, and anything else you might need."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/t_scanner
 	associated_paths = list(/obj/item/t_scanner)
 	mechanics_text = "Use this to toggle its scanning capabilities on and off. While on, it will expose the layout of cabling and pipework in a 7x7 area around you."
 	lore_text = "The T-ray scanner is a modern spectroscopy solution and labor-saving device. Why work yourself to the bone removing floor panels when you can simply look through them with submillimeter radiation?"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/rcd
 	associated_paths = list(/obj/item/rcd)
 	mechanics_text = "On use, this device will toggle between various types of structures (or their removal). You can examine it to see its current mode. It must be loaded with compressed matter cartridges, which can be obtained from an autolathe. Click an adjacent tile to use the device."
 	lore_text = "Advents in material printing and synthesis technology have produced everyday miracles, such as the RCD, which in certain industries has single-handedly put entire construction crews out of a job."
 	antag_text = "RCDs can be incredibly dangerous in the wrong hands. Use them to swiftly block off corridors, or instantly breach the ship wherever you want."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/toolbox
 	associated_paths = list(/obj/item/toolbox)
 	mechanics_text = "The toolbox is a general-purpose storage item with lots of space. With an item in your hand, click on it to store it inside."
 	lore_text = "No one remembers which company designed this particular toolbox. It's been mass-produced, retired, brought out of retirement, and counterfeited for decades."
 	antag_text = "Carrying one of these and being bald tends to instill a certain primal fear in most people."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE

--- a/code/modules/codex/entries/weapons.dm
+++ b/code/modules/codex/entries/weapons.dm
@@ -3,12 +3,14 @@
 	mechanics_text = "The baton needs to be turned on to apply the stunning effect. Use it in your hand to toggle it on or off. If your intent is \
 	set to 'harm', you will inflict damage when using it, regardless if it is on or not. Each stun reduces the baton's charge, which can be replenished by \
 	putting it inside a weapon recharger."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/energy_sword
 	associated_paths = list(/obj/item/energy_blade/sword)
 	antag_text = "The energy sword is a very strong melee weapon, capable of severing limbs easily, if they are targeted. It can also has a chance \
 	to block projectiles and melee attacks while it is on and being held. The sword can be toggled on or off by using it in your hand. While it is off, \
 	it can be concealed in your pocket or bag."
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/cultblade
 	associated_paths = list(/obj/item/sword/cultblade)

--- a/code/modules/codex/entries/weapons.dm
+++ b/code/modules/codex/entries/weapons.dm
@@ -14,7 +14,7 @@
 
 /datum/codex_entry/cultblade
 	associated_paths = list(/obj/item/sword/cultblade)
-	antag_text = "This sword is a powerful weapon, capable of severing limbs easily, if they are targeted. Nonbelivers are unable to use this weapon."
+	antag_text = "This sword is a powerful weapon, capable of severing limbs easily, if they are targeted. Nonbelievers are unable to use this weapon."
 
 /datum/codex_entry/spear
 	associated_paths = list(/obj/item/twohanded/spear)

--- a/code/modules/materials/definitions/solids/materials_solid_ice.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_ice.dm
@@ -34,6 +34,7 @@
 	liquid_name = "water"
 	solid_name = "snow"
 	gas_name = "steam"
+	codex_name = null
 	uid = "solid_snow"
 	hardness = MAT_VALUE_MALLEABLE
 	dug_drop_type = /obj/item/stack/material/ore/handful
@@ -161,7 +162,7 @@
 // DISPLAY_NAME is needed because of compounds with white spaces in their names
 #define DECLARE_HYDRATE_DNAME_PATH(PATH, NAME, DISPLAY_NAME)               \
 /decl/material/solid/ice/hydrate/##NAME/uid = "solid_hydrate_" + #NAME;    \
-/decl/material/solid/ice/hydrate/##NAME/name = #DISPLAY_NAME + " hydrate"; \
+/decl/material/solid/ice/hydrate/##NAME/name = DISPLAY_NAME + " hydrate"; \
 /decl/material/solid/ice/hydrate/##NAME/heating_products = list(           \
 	PATH = 0.1,                                                            \
 	/decl/material/liquid/water = 0.9                                      \

--- a/code/modules/organs/ailments/ailment_codex.dm
+++ b/code/modules/organs/ailments/ailment_codex.dm
@@ -13,6 +13,7 @@
 	show_robotics_recipes = TRUE
 	name_column = "Fault"
 	treatment_column = "Recommended repair"
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /proc/get_chem_effect_display_name(effect)
 	switch(effect)


### PR DESCRIPTION
## Description of changes
Codex entries can have a tech level set, and now remove themselves from search results and listings if the map doesn't have at least that tech level.

## Why and what will this PR improve
Hacking, electrical engineering, the supermatter engine, etc. will not appear on Shaded Hills.