### PR TITLE
Fix issues discovered by OpenDream

### DIFF
--- a/code/game/objects/items/weapons/towels.dm
+++ b/code/game/objects/items/weapons/towels.dm
@@ -55,7 +55,7 @@
 		if(!touching_reagents?.total_volume)
 			to_chat(user, SPAN_WARNING("[user == M ? "You are" : "\The [M] [G.is]"] already dry."))
 		else
-			user.visible_message(SPAN_NOTICE("\The [user] uses \the [src] to towel [user == M ? G.self : "\the M"] dry."))
+			user.visible_message(SPAN_NOTICE("\The [user] uses \the [src] to towel [user == M ? G.self : "\the [M]"] dry."))
 			touching_reagents.trans_to(src, min(touching_reagents.total_volume, reagent_space))
 			playsound(user, 'sound/weapons/towelwipe.ogg', 25, 1)
 	return TRUE

--- a/code/game/objects/structures/_structure_materials.dm
+++ b/code/game/objects/structures/_structure_materials.dm
@@ -22,15 +22,14 @@
 	else
 		set_opacity(initial(opacity))
 	hitsound = material?.hitsound || initial(hitsound)
-	var/current_max_health = get_max_health()
-	if(current_max_health != -1)
-		current_max_health = initial(current_max_health) + material?.integrity * get_material_health_modifier()
+	if(max_health != -1)
+		max_health = initial(max_health) + material?.integrity * get_material_health_modifier()
 		if(reinf_material)
 			var/bonus_health = reinf_material.integrity * get_material_health_modifier()
-			current_max_health += bonus_health
+			max_health += bonus_health
 			if(!keep_health)
 				current_health += bonus_health
-		current_health = keep_health ? min(current_health, current_max_health) : current_max_health
+		current_health = keep_health ? min(current_health, max_health) : max_health
 	update_icon()
 
 /obj/structure/proc/update_material_name(var/override_name)

--- a/code/modules/brain_interface/interface_radio.dm
+++ b/code/modules/brain_interface/interface_radio.dm
@@ -2,7 +2,7 @@
 	name = "radio-enabled neural interface"
 	desc = "A complex life support shell that interfaces between a brain and an electronic device. This one comes with a built-in radio."
 	origin_tech = @'{"biotech":4}'
-	var/VAR_PRIVATE/weakref/_radio
+	VAR_PRIVATE/weakref/_radio
 
 /obj/item/organ/internal/brain_interface/radio_enabled/empty
 	holding_brain = null

--- a/code/modules/organs/ailments/ailment_codex.dm
+++ b/code/modules/organs/ailments/ailment_codex.dm
@@ -43,8 +43,8 @@
 			continue
 		ailment_table += "<tr><td>[ailment.name]</td><td>"
 		var/list/ailment_cures = list()
-		if(ailment.treated_by_item_type)
-			var/obj/item/thing = ailment.treated_by_item_type
+		var/list/treated_by_types = islist(ailment.treated_by_item_type) ? ailment.treated_by_item_type : list(ailment.treated_by_item_type)
+		for(var/obj/item/thing as anything in treated_by_types) // if you put a non-item in here you deserve to have your face eaten by runtime errors
 			ailment_cures += "[ailment.treated_by_item_cost] x [initial(thing.name)]"
 		if(ailment.treated_by_reagent_type)
 			var/decl/material/mat = GET_DECL(ailment.treated_by_reagent_type)

--- a/mods/content/xenobiology/slime/slime_AI.dm
+++ b/mods/content/xenobiology/slime/slime_AI.dm
@@ -142,7 +142,7 @@
 
 		if(!current_target)
 			if(prob(1))
-				for(var/mob/living/slime/frenemy in range(1, src))
+				for(var/mob/living/slime/frenemy in range(1, body))
 					if(frenemy != body && body.Adjacent(frenemy))
 						body.a_intent_change((frenemy.slime_type == slime.slime_type) ? I_HELP : I_HURT)
 						body.UnarmedAttack(frenemy)


### PR DESCRIPTION
## Description of changes
- Fixes a missing interpolation in towel code.
- Fixes issues with structure max_health setting.
- Fixes an invalid weakref variable definition in radio-enabled MMI code.

I might add an OpenDream compile step to CI like various other servers have, since it's basically a more advanced linter now.

## Why and what will this PR improve
The game should compile on OpenDream again.