### PR TITLE
Make trees give shade and protect from weather

### DIFF
--- a/code/controllers/subsystems/ambience.dm
+++ b/code/controllers/subsystems/ambience.dm
@@ -29,7 +29,9 @@ SUBSYSTEM_DEF(ambience)
 
 	var/override_light_power
 	var/override_light_color
-	if(!is_outside())
+	// If we're indoors because of our area, OR we're outdoors and not exposed to the weather, get interior ambience.
+	var/outsideness = is_outside()
+	if((!outsideness && is_outside == OUTSIDE_AREA) || (outsideness && get_weather_exposure() != WEATHER_EXPOSED))
 		var/area/A = get_area(src)
 		if(!A || !A.interior_ambient_light_level)
 			return FALSE

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -981,9 +981,6 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	else
 		client.screen -= src
 
-/obj/item/proc/gives_weather_protection()
-	return FALSE
-
 /obj/item/proc/get_assembly_detail_color()
 	return
 

--- a/code/game/objects/structures/flora/tree.dm
+++ b/code/game/objects/structures/flora/tree.dm
@@ -38,6 +38,20 @@
 		. = ..()
 	someone_is_cutting = FALSE
 
+/obj/structure/flora/tree/Initialize(ml, _mat, _reinf_mat)
+	. = ..()
+	if(!ml && protects_against_weather)
+		for(var/turf/T in RANGE_TURFS(src, 1))
+			T.update_ambient_light_from_z_or_area()
+
+// I hate doing things that aren't cleanup in Destroy(), but this should still update even when admin-deleted.
+/obj/structure/flora/tree/Destroy()
+	var/list/turfs_to_update = RANGE_TURFS(src, 1)
+	. = ..()
+	if(protects_against_weather)
+		for(var/turf/T in turfs_to_update)
+			T.update_ambient_light_from_z_or_area()
+
 /obj/structure/flora/tree/take_damage(damage)
 	. = ..()
 	if(!QDELETED(src) && damage >= 5)
@@ -83,6 +97,7 @@
 	icon         = 'icons/obj/flora/pinetrees.dmi'
 	icon_state   = "pine_1"
 	stump_type   = /obj/structure/flora/stump/tree/pine
+	opacity      = TRUE
 
 /obj/structure/flora/tree/pine/init_appearance()
 	icon_state = "pine_[rand(1, 3)]"
@@ -158,6 +173,7 @@
 	icon_state = "mahogany_1"
 	material   = /decl/material/solid/organic/wood/mahogany
 	stump_type = /obj/structure/flora/stump/tree/mahogany
+	opacity    = TRUE
 
 /obj/structure/flora/tree/hardwood/maple
 	name       = "maple tree"
@@ -170,6 +186,7 @@
 	icon_state = "yew_1"
 	material   = /decl/material/solid/organic/wood/yew
 	stump_type = /obj/structure/flora/stump/tree/yew
+	opacity    = TRUE
 
 /obj/structure/flora/tree/hardwood/walnut
 	name       = "walnut tree"

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -12,6 +12,9 @@
 	var/brightness_on
 	var/on = 0
 
+/obj/item/clothing/head/gives_weather_protection()
+	return protects_against_weather
+
 /obj/item/clothing/head/attack_self(mob/user)
 	if(brightness_on)
 		if(!isturf(user.loc))

--- a/code/modules/clothing/suits/_suit.dm
+++ b/code/modules/clothing/suits/_suit.dm
@@ -12,6 +12,9 @@
 	var/protects_against_weather = FALSE
 	var/fire_resist = T0C+100
 
+/obj/item/clothing/suit/gives_weather_protection()
+	return protects_against_weather
+
 /obj/item/clothing/suit/get_associated_equipment_slots()
 	. = ..()
 	LAZYDISTINCTADD(., slot_wear_suit_str)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1232,58 +1232,6 @@
 /mob/proc/set_glide_size(var/delay)
 	glide_size = ADJUSTED_GLIDE_SIZE(delay)
 
-/mob/proc/get_weather_protection()
-	for(var/obj/item/brolly in get_held_items())
-		if(brolly.gives_weather_protection())
-			LAZYADD(., brolly)
-	if(!LAZYLEN(.))
-		for(var/turf/T as anything in RANGE_TURFS(loc, 1))
-			for(var/obj/structure/flora/tree/tree in T)
-				if(tree.protects_against_weather)
-					LAZYADD(., tree)
-
-/mob/living/carbon/human/get_weather_protection()
-	. = ..()
-	if(!LAZYLEN(.))
-		var/obj/item/clothing/head/check_head = get_equipped_item(slot_head_str)
-		if(!istype(check_head) || !check_head.protects_against_weather)
-			return
-		var/obj/item/clothing/suit/check_body = get_equipped_item(slot_wear_suit_str)
-		if(!istype(check_body) || !check_body.protects_against_weather)
-			return
-		LAZYADD(., check_head)
-		LAZYADD(., check_body)
-
-/mob/proc/get_weather_exposure()
-
-	// We're inside something else.
-	if(!isturf(loc))
-		return WEATHER_IGNORE
-
-	var/turf/T = loc
-	// We're under a roof or otherwise shouldn't be being rained on.
-	if(!T.is_outside())
-
-		// For non-multiz we'll give everyone some nice ambience.
-		if(!HasAbove(T.z))
-			return WEATHER_ROOFED
-
-		// For multi-z, check the actual weather on the turf above.
-		// TODO: maybe make this a property of the z-level marker.
-		var/turf/above = GetAbove(T)
-		if(above.weather)
-			return WEATHER_ROOFED
-
-		// Being more than one level down should exempt us from ambience.
-		return WEATHER_IGNORE
-
-	// Nothing's protecting us from the rain here
-	var/list/weather_protection = get_weather_protection()
-	if(LAZYLEN(weather_protection))
-		return WEATHER_PROTECTED
-
-	return WEATHER_EXPOSED
-
 /mob/proc/IsMultiZAdjacent(var/atom/neighbor)
 
 	var/turf/T = get_turf(src)

--- a/code/modules/weather/weather_helpers.dm
+++ b/code/modules/weather/weather_helpers.dm
@@ -1,0 +1,67 @@
+/atom/proc/get_weather_protection()
+	return
+
+/atom/proc/gives_weather_protection()
+	return FALSE
+
+/mob/get_weather_protection()
+	var/list/loc_protection = isturf(loc) && loc.get_weather_protection()
+	if(loc_protection)
+		LAZYADD(., loc_protection)
+	for(var/obj/item/brolly in get_held_items())
+		if(brolly.gives_weather_protection())
+			LAZYADD(., brolly)
+	var/obj/item/clothing/head/check_head = get_equipped_item(slot_head_str)
+	if(istype(check_head) && check_head.protects_against_weather)
+		LAZYADD(., check_head)
+	var/obj/item/clothing/suit/check_body = get_equipped_item(slot_wear_suit_str)
+	if(istype(check_body) && check_body.protects_against_weather)
+		LAZYADD(., check_body)
+
+/turf/get_weather_protection()
+	for(var/obj/structure/flora/tree/tree in range(1, src))
+		if(tree.protects_against_weather)
+			LAZYADD(., tree)
+
+/atom/proc/get_weather_exposure()
+	CRASH("Something called get_weather_exposure on a non-turf, non-object, non-mob, non-area type!")
+
+/area/get_weather_exposure()
+	CRASH("Something called get_weather_exposure on an area!")
+
+/turf/get_weather_exposure()
+	if(is_outside())
+		// A roof isn't protecting us from the weather, do we have anything else blocking it?
+		var/list/weather_protection = get_weather_protection()
+		if(LAZYLEN(weather_protection))
+			return WEATHER_PROTECTED
+		return WEATHER_EXPOSED
+	// We're under a roof or otherwise shouldn't be being rained on.
+	// For non-multiz we'll give everyone some nice ambience.
+	if(!HasAbove(z))
+		return WEATHER_ROOFED
+
+	// For multi-z, check the actual weather on the turf above.
+	// TODO: maybe make this a property of the z-level marker.
+	var/turf/above = GetAbove(src)
+	if(above.weather)
+		return WEATHER_ROOFED
+
+	// Being more than one level down should exempt us from ambience.
+	return WEATHER_IGNORE
+
+/atom/movable/get_weather_exposure()
+	// We're inside something else.
+	if(!isturf(loc))
+		return WEATHER_IGNORE
+
+	. = loc.get_weather_exposure()
+	if(. != WEATHER_EXPOSED)
+		return .
+
+	// Our loc isn't protecting us from the weather, is anything about us protecting us?
+	var/list/weather_protection = get_weather_protection()
+	if(LAZYLEN(weather_protection))
+		return WEATHER_PROTECTED
+
+	return WEATHER_EXPOSED

--- a/maps/shaded_hills/areas/_areas.dm
+++ b/maps/shaded_hills/areas/_areas.dm
@@ -35,6 +35,8 @@
 	)
 	description = "Birds and insects call from the grasses, and a cool wind gusts from across the river."
 	area_blurb_category = /area/shaded_hills/outside
+	interior_ambient_light_level = 0.2
+	interior_ambient_light_color = "#f3e6ca"
 
 /area/shaded_hills/outside/river
 	name = "River"

--- a/nebula.dme
+++ b/nebula.dme
@@ -3649,6 +3649,7 @@
 #include "code\modules\weather\weather_fsm.dm"
 #include "code\modules\weather\weather_fsm_state_transitions.dm"
 #include "code\modules\weather\weather_fsm_states.dm"
+#include "code\modules\weather\weather_helpers.dm"
 #include "code\modules\weather\weather_init.dm"
 #include "code\modules\weather\weather_mob_tracking.dm"
 #include "code\modules\weather\weather_wind.dm"


### PR DESCRIPTION
## Description of changes
- Moves some mob-related weather code checks onto atoms.
- Trees now give weather protection in a more generalized way than before.
- Trees that provide weather protection also block ambient light in a 3x3 centered on them.

## Why and what will this PR improve
Makes weather protection code more flexible.
Makes dense forests less absurdly bright.