### PR TITLE
Allow recipes to set their skill and difficulty from material

### DIFF
--- a/code/datums/repositories/decls.dm
+++ b/code/datums/repositories/decls.dm
@@ -24,7 +24,9 @@ var/global/repository/decls/decls_repository = new
 	var/list/fetched_decls =                 list()
 	var/list/fetched_decl_ids =              list()
 	var/list/fetched_decl_types =            list()
+	var/list/fetched_decl_instances =        list()
 	var/list/fetched_decl_subtypes =         list()
+	var/list/fetched_decl_subinstances =     list()
 	var/list/fetched_decl_paths_by_type =    list()
 	var/list/fetched_decl_paths_by_subtype = list()
 
@@ -113,6 +115,18 @@ var/global/repository/decls/decls_repository = new
 		var/decl = get_decl(decl_type)
 		if(decl)
 			. += decl
+
+/repository/decls/proc/get_decls_of_type_unassociated(var/decl_prototype)
+	. = fetched_decl_instances[decl_prototype]
+	if(!.)
+		. = get_decls_unassociated(typesof(decl_prototype))
+		fetched_decl_instances[decl_prototype] = .
+
+/repository/decls/proc/get_decls_of_subtype_unassociated(var/decl_prototype)
+	. = fetched_decl_subinstances[decl_prototype]
+	if(!.)
+		. = get_decls_unassociated(subtypesof(decl_prototype))
+		fetched_decl_subinstances[decl_prototype] = .
 
 /repository/decls/proc/get_decls_of_type(var/decl_prototype)
 	. = fetched_decl_types[decl_prototype]

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -165,15 +165,18 @@
 		return
 	if(!recipe.can_make(user))
 		return
-	if (recipe.time)
+	var/used_skill = recipe.get_skill(mat, reinf_mat)
+	var/used_difficulty = recipe.get_skill_difficulty(mat, reinf_mat)
+	var/used_time = recipe.get_adjusted_time(mat, reinf_mat)
+	if (used_time)
 		to_chat(user, SPAN_NOTICE("You set about [recipe.get_craft_verbing(src)] [recipe.get_display_name(producing, mat, reinf_mat)]..."))
-		if (!user.do_skilled(recipe.time, recipe.recipe_skill))
+		if (!user.do_skilled(used_time, used_skill))
 			return
 
 	if(!use(expending))
 		return
 
-	if(user.skill_fail_prob(recipe.recipe_skill, 90, recipe.difficulty))
+	if(user.skill_fail_prob(used_skill, 90, used_difficulty))
 		to_chat(user, SPAN_WARNING("You waste some [name] and fail to [recipe.get_craft_verb(src)] [recipe.get_display_name(producing, mat, reinf_mat)]!"))
 		return
 

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -167,13 +167,13 @@
 		return
 	if (recipe.time)
 		to_chat(user, SPAN_NOTICE("You set about [recipe.get_craft_verbing(src)] [recipe.get_display_name(producing, mat, reinf_mat)]..."))
-		if (!user.do_skilled(recipe.time, SKILL_CONSTRUCTION))
+		if (!user.do_skilled(recipe.time, recipe.recipe_skill))
 			return
 
 	if(!use(expending))
 		return
 
-	if(user.skill_fail_prob(SKILL_CONSTRUCTION, 90, recipe.difficulty))
+	if(user.skill_fail_prob(recipe.recipe_skill, 90, recipe.difficulty))
 		to_chat(user, SPAN_WARNING("You waste some [name] and fail to [recipe.get_craft_verb(src)] [recipe.get_display_name(producing, mat, reinf_mat)]!"))
 		return
 

--- a/code/modules/crafting/stack_recipes/_recipe.dm
+++ b/code/modules/crafting/stack_recipes/_recipe.dm
@@ -226,8 +226,15 @@
 	// Early checks to avoid letting recipes make themselves.
 	if(ispath(result_type, /obj/item/stack))
 		var/obj/item/stack/result_ref = result_type
-		if(stack_type == initial(result_ref.crafting_stack_type))
+		if(stack_type == result_ref::crafting_stack_type)
 			return FALSE
+
+	if(required_reinforce_material == MATERIAL_FORBIDDEN && reinf_mat)
+		return FALSE
+	else if(ispath(required_reinforce_material) && !istype(reinf_mat, required_reinforce_material))
+		return FALSE
+	else if(required_reinforce_material == MATERIAL_REQUIRED && !reinf_mat)
+		return FALSE
 
 	// Check if they're using the appropriate materials.
 	if(ispath(required_material) && !istype(mat, required_material))
@@ -235,13 +242,6 @@
 	else if(required_material == MATERIAL_FORBIDDEN && mat)
 		return FALSE
 	else if(required_material == MATERIAL_REQUIRED && !mat)
-		return FALSE
-
-	if(ispath(required_reinforce_material) && !istype(reinf_mat, required_reinforce_material))
-		return FALSE
-	else if(required_reinforce_material == MATERIAL_FORBIDDEN && reinf_mat)
-		return FALSE
-	else if(required_reinforce_material == MATERIAL_REQUIRED && !reinf_mat)
 		return FALSE
 
 	// Check if the material has the appropriate properties.

--- a/code/modules/crafting/stack_recipes/_recipe_getter.dm
+++ b/code/modules/crafting/stack_recipes/_recipe_getter.dm
@@ -17,34 +17,37 @@
  * Recipe retrieval proc.
  */
 var/global/list/cached_recipes = list()
-/proc/get_stack_recipes(decl/material/mat, decl/material/reinf_mat, stack_type, tool_type)
+/proc/get_stack_recipes(decl/material/mat, decl/material/reinf_mat, stack_type, tool_type, flat = FALSE)
 
 	// No recipes for holograms or fluids.
 	if(istype(mat) && (mat.holographic || mat.phase_at_temperature() != MAT_PHASE_SOLID))
 		return list()
 
+	#ifndef UNIT_TEST // key creation is SLOW and in unit testing almost every call to this will be a cache fail
 	// Check if we've cached this before.
 	var/key = jointext(list((mat?.name || "base"), (reinf_mat?.name || "base"), (stack_type || "base"), (tool_type || "base")), "-")
 	. = global.cached_recipes[key]
+	#endif
 	if(!.)
 
 		. = list()
 
 		// Collect our recipes, grouping as appropriate.
 		var/list/grouped_recipes = list()
-		var/list/all_recipes = decls_repository.get_decls_of_subtype(/decl/stack_recipe)
-		for(var/recipe_type in all_recipes)
-			var/decl/stack_recipe/recipe = all_recipes[recipe_type]
+		var/list/all_recipes = decls_repository.get_decls_of_subtype_unassociated(/decl/stack_recipe)
+		for(var/decl/stack_recipe/recipe in all_recipes)
 			if(global.using_map.map_tech_level < recipe.available_to_map_tech_level)
 				continue
 			if(recipe.can_be_made_from(stack_type, tool_type, mat, reinf_mat))
-				if(recipe.category)
-					LAZYDISTINCTADD(grouped_recipes[recipe.category], recipe)
+				if(recipe.category && !flat)
+					LAZYADD(grouped_recipes[recipe.category], recipe)
 				else
-					. |= recipe
+					. += recipe
 
 		// Turn groups into recipe lists.
 		if(length(grouped_recipes))
 			for(var/group_name in grouped_recipes)
 				. += new /datum/stack_recipe_list(group_name, grouped_recipes[group_name])
+		#ifndef UNIT_TEST // associative list insertion is SLOW and in unit testing almost every call to this will be a cache fail
 		global.cached_recipes[key] = .
+		#endif

--- a/code/modules/crafting/stack_recipes/recipes_hardness.dm
+++ b/code/modules/crafting/stack_recipes/recipes_hardness.dm
@@ -36,6 +36,19 @@
 
 /decl/stack_recipe/hardness/urn
 	result_type       = /obj/item/urn
+	craft_stack_types           = list(
+		/obj/item/stack/material/sheet,
+		/obj/item/stack/material/ingot,
+		/obj/item/stack/material/bar,
+		/obj/item/stack/material/puck
+	)
+	forbidden_craft_stack_types = list(
+		/obj/item/stack/material/ore,
+		/obj/item/stack/material/log,
+		/obj/item/stack/material/lump,
+		/obj/item/stack/material/slab,
+		/obj/item/stack/material/plank
+	)
 
 /decl/stack_recipe/hardness/drill_head
 	result_type       = /obj/item/drill_head

--- a/code/modules/crafting/stack_recipes/recipes_opacity.dm
+++ b/code/modules/crafting/stack_recipes/recipes_opacity.dm
@@ -1,8 +1,9 @@
 /decl/stack_recipe/opacity
-	abstract_type        = /decl/stack_recipe/opacity
-	required_max_opacity = 0.5
-	on_floor             = TRUE
-	difficulty           = MAT_VALUE_HARD_DIY
+	abstract_type               = /decl/stack_recipe/opacity
+	required_max_opacity        = 0.5
+	on_floor                    = TRUE
+	difficulty                  = MAT_VALUE_HARD_DIY
+	required_reinforce_material = MATERIAL_ALLOWED
 
 /decl/stack_recipe/opacity/fullwindow
 	name                 = "full-tile window"

--- a/code/modules/crafting/stack_recipes/recipes_stacks.dm
+++ b/code/modules/crafting/stack_recipes/recipes_stacks.dm
@@ -9,20 +9,20 @@
 	result_type         = /obj/item/stack/tile/wood
 	required_material   = /decl/material/solid/organic/wood
 
-/decl/stack_recipe/tile/mahogany
+/decl/stack_recipe/tile/wood/mahogany
 	result_type         = /obj/item/stack/tile/mahogany
 	required_material   = /decl/material/solid/organic/wood/mahogany
 
-/decl/stack_recipe/tile/maple
+/decl/stack_recipe/tile/wood/maple
 	result_type         = /obj/item/stack/tile/maple
 	required_material   = /decl/material/solid/organic/wood/maple
 
-/decl/stack_recipe/tile/ebony
+/decl/stack_recipe/tile/wood/ebony
 	difficulty          = MAT_VALUE_VERY_HARD_DIY
 	result_type         = /obj/item/stack/tile/ebony
 	required_material   = /decl/material/solid/organic/wood/ebony
 
-/decl/stack_recipe/tile/walnut
+/decl/stack_recipe/tile/wood/walnut
 	result_type         = /obj/item/stack/tile/walnut
 	required_material   = /decl/material/solid/organic/wood/walnut
 
@@ -68,6 +68,7 @@
 /decl/stack_recipe/tile/panels
 	abstract_type = /decl/stack_recipe/tile/panels
 	craft_stack_types = /obj/item/stack/material/panel
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /decl/stack_recipe/tile/panels/floor
 	result_type       = /obj/item/stack/tile/floor_white

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -169,6 +169,8 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	var/hitsound = 'sound/weapons/genhit.ogg'
 	// Wallrot crumble message.
 	var/rotting_touch_message = "crumbles under your touch"
+	/// When a stack recipe doesn't specify a skill to use, use this skill.
+	var/crafting_skill = SKILL_CONSTRUCTION
 	// Modifies skill checks when constructing with this material.
 	var/construction_difficulty = MAT_VALUE_EASY_DIY
 	// Determines what is used to remove or dismantle this material.
@@ -293,7 +295,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 		to_chat(user, SPAN_WARNING("You need need at least one [used_stack.singular_name] to reinforce [target_stack]."))
 		return
 
-	var/decl/material/reinf_mat = used_stack.material
+	var/decl/material/reinf_mat = used_stack.get_material()
 	if(reinf_mat.integrity <= integrity || reinf_mat.is_brittle())
 		to_chat(user, SPAN_WARNING("The [reinf_mat.solid_name] is too structurally weak to reinforce the [name]."))
 		return
@@ -382,6 +384,18 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 #define FALSEWALL_STATE "fwall_open"
 /decl/material/validate()
 	. = ..()
+
+	if(!crafting_skill)
+		. += "no construction skill set"
+	else if(!isnull(construction_difficulty))
+		var/decl/hierarchy/skill/used_skill = GET_DECL(crafting_skill)
+		if(!istype(used_skill))
+			. += "invalid skill decl [used_skill]"
+		else if(length(used_skill.levels) < construction_difficulty)
+			. += "required skill [used_skill] is missing skill level [json_encode(construction_difficulty)]"
+
+	if(isnull(construction_difficulty))
+		. += "no construction difficulty set"
 
 	if(!isnull(bakes_into_at_temperature))
 		if(!isnull(melting_point) && melting_point <= bakes_into_at_temperature)

--- a/code/unit_tests/materials.dm
+++ b/code/unit_tests/materials.dm
@@ -42,13 +42,7 @@
 					var/decl/material/reinforced = GET_DECL(reinforced_type)
 
 					// Get a linear list of all recipes available to this combination.
-					var/list/recipes = get_stack_recipes(material, reinforced, stack_type, tool_type)
-					while(locate(/datum/stack_recipe_list) in recipes)
-						for(var/datum/stack_recipe_list/recipe_stack in recipes)
-							recipes -= recipe_stack
-							if(length(recipe_stack.recipes))
-								recipes |= recipe_stack.recipes
-
+					var/list/recipes = get_stack_recipes(material, reinforced, stack_type, tool_type, flat = TRUE)
 					if(!length(recipes))
 						continue
 


### PR DESCRIPTION
## Description of changes
Recipes with a null difficulty now calculate it from material properties.
Materials' construction difficulty var is now actually used.
Materials now have a construction skill var.
Recipe time is now calculated dynamically based on material if time is unset, rather than set once in init.
Does some (slight, experimental) optimizations to the inconsistent recipe materials test.

## Why and what will this PR improve
Makes it less fiddly to override recipe skills on other maps, and lets materials inform what skill they should use. This is a step towards breaking up the construction skill monolith.