### PR TITLE
Add Shaded Hills-specific map skills

### DIFF
--- a/code/modules/codex/categories/category_skills.dm
+++ b/code/modules/codex/categories/category_skills.dm
@@ -3,7 +3,10 @@
 	desc = "Certifiable skills."
 
 /decl/codex_category/skills/Populate()
-	for(var/decl/hierarchy/skill/skill in global.using_map.get_available_skills())
+	var/list/available_skill_types = global.using_map.get_available_skill_types()
+	for(var/decl/hierarchy/skill/skill in decls_repository.get_decls_of_subtype_unassociated(/decl/hierarchy/skill))
+		if(INSTANCE_IS_ABSTRACT(skill))
+			continue
 		var/list/skill_info = list()
 		if(skill.prerequisites)
 			var/list/reqs = list()
@@ -18,5 +21,7 @@
 			_lore_text = skill.desc,
 			_mechanics_text = jointext(skill_info, "<br>"),
 		)
+		if(!(skill.type in available_skill_types))
+			entry.unsearchable = TRUE
 		items |= entry.name
 	. = ..()

--- a/code/modules/crafting/pottery/pottery_moulds.dm
+++ b/code/modules/crafting/pottery/pottery_moulds.dm
@@ -135,7 +135,10 @@
 		if(!squash_item())
 			physically_destroyed(src)
 	else
-		take_damage(rand(10, 20))
+		// At skill 1/5, damage it 3x more. At skill 2/5, damage it 1.5x more.
+		// At skill 3/5 deal base damage, at 4/5 deal 75% damage, and at max skill deal 60% damage.
+		var/damage_modifier = clamp(1 + (user.get_skill_value(work_skill) - SKILL_ADEPT) / (SKILL_MAX - SKILL_BASIC), 0.1, 3)
+		take_damage(rand(5, 10) / damage_modifier)
 
 /obj/item/chems/mould/proc/try_take_impression(mob/user, obj/item/thing)
 

--- a/maps/shaded_hills/shaded_hills_skills.dm
+++ b/maps/shaded_hills/shaded_hills_skills.dm
@@ -64,3 +64,74 @@
 		"Master"      = "Placeholder."
 	)
 
+/decl/hierarchy/skill/crafting/sculpting
+	name = "Sculpting"
+	uid =  "skill_crafting_sculpting"
+	desc = "This skill describes your skill shaping wax, clay, and other soft materials."
+	levels = list(
+		"Unskilled"   = "Placeholder.",
+		"Basic"       = "Placeholder.",
+		"Trained"     = "Placeholder.",
+		"Experienced" = "Placeholder.",
+		"Master"      = "Placeholder."
+	)
+
+// SCULPTING OVERRIDES
+/decl/material/solid/clay
+	crafting_skill = /decl/hierarchy/skill/crafting/sculpting
+
+/decl/material/solid/soil
+	crafting_skill = /decl/hierarchy/skill/crafting/sculpting
+
+/decl/material/solid/organic/wax
+	crafting_skill = /decl/hierarchy/skill/crafting/sculpting
+
+// TEXTILES OVERRIDES
+/obj/structure/textiles
+	work_skill = /decl/hierarchy/skill/crafting/textiles
+
+/decl/material/solid/organic/cloth
+	crafting_skill = /decl/hierarchy/skill/crafting/textiles
+
+/decl/material/solid/organic/skin
+	crafting_skill = /decl/hierarchy/skill/crafting/textiles
+
+/decl/material/solid/organic/leather
+	crafting_skill = /decl/hierarchy/skill/crafting/textiles
+
+/decl/material/solid/organic/plantmatter
+	crafting_skill = /decl/hierarchy/skill/crafting/textiles
+
+// STONEMASONRY OVERRIDES
+/decl/material/solid/stone
+	crafting_skill = /decl/hierarchy/skill/crafting/stonemasonry
+
+// METALWORK OVERRIDES
+/decl/material/solid/metal
+	crafting_skill = /decl/hierarchy/skill/crafting/metalwork
+
+// CARPENTRY OVERRIDES
+/decl/material/solid/organic/wood
+	crafting_skill = /decl/hierarchy/skill/crafting/carpentry
+
+/decl/material/solid/organic/plantmatter/pith // not quite wood but it's basically still wood carving
+	crafting_skill = /decl/hierarchy/skill/crafting/carpentry
+
+// MISC OVERRIDES
+/decl/stack_recipe
+	recipe_skill = null // set based on material
+
+// Removal of space skills
+/datum/map/shaded_hills/get_available_skill_types()
+	. = ..()
+	. -= list(
+		SKILL_EVA,
+		SKILL_MECH,
+		SKILL_PILOT,
+		SKILL_COMPUTER,
+		SKILL_FORENSICS,
+		SKILL_ELECTRICAL,
+		SKILL_ATMOS,
+		SKILL_ENGINES,
+		SKILL_DEVICES
+	)

--- a/maps/shaded_hills/shaded_hills_skills.dm
+++ b/maps/shaded_hills/shaded_hills_skills.dm
@@ -67,13 +67,13 @@
 /decl/hierarchy/skill/crafting/sculpting
 	name = "Sculpting"
 	uid =  "skill_crafting_sculpting"
-	desc = "This skill describes your skill shaping wax, clay, and other soft materials."
+	desc = "Your ability to craft objects out of soft materials like wax or clay."
 	levels = list(
-		"Unskilled"   = "Placeholder.",
-		"Basic"       = "Placeholder.",
-		"Trained"     = "Placeholder.",
-		"Experienced" = "Placeholder.",
-		"Master"      = "Placeholder."
+		"Unskilled"   = "You can mould soft materials into rough shapes, but your work is sloppy and anything more complicated than a pinch-pot is beyond your ken.",
+		"Basic"       = "Your understanding of sculpting has improved to allow you to create more even and symmetrical designs. You likely have experience using a pottery wheel, turntable, or similar device.",
+		"Trained"     = "Your creations have become at once more uniform and more aesthetically pleasing, with a consistent level of quality to them.",
+		"Experienced" = "You have extensive experience with sculpting, able to work with a wide array of materials to form just about anything you set your mind to, as long as you put in the effort.",
+		"Master"      = "You have reached the pinnacle of your craft, able to sculpt clay, wax, and similar materials to your every whim, so much so that a mound of clay may as well be an extension of your will itself."
 	)
 
 // SCULPTING OVERRIDES

--- a/maps/shaded_hills/shaded_hills_skills.dm
+++ b/maps/shaded_hills/shaded_hills_skills.dm
@@ -7,13 +7,13 @@
 /decl/hierarchy/skill/crafting/carpentry
 	name = "Carpentry"
 	uid =  "skill_crafting_carpentry"
-	desc = "This skill describes your skill with woodworking."
+	desc = "Your ability to construct and repair objects and structures made out of wood, and use woodworking tools."
 	levels = list(
-		"Unskilled"   = "Placeholder.",
-		"Basic"       = "Placeholder.",
-		"Trained"     = "Placeholder.",
-		"Experienced" = "Placeholder.",
-		"Master"      = "Placeholder."
+		"Unskilled"   = "You can use an axe to split wood and cut it into planks, but your splits and cuts are often wasteful and uneven. You can nail pieces of wood together.",
+		"Basic"       = "You've whittled a few things out of wood before, and maybe even done a small construction project or two. You're more effective at using tools like hatchets, knives, and hammers for woodworking.",
+		"Trained"     = "You've received some degree of formal instruction or apprenticeship in woodworking, or have a lot of hands-on practice with woodcraft. Your cuts are cleaner, your whittling is quicker, and your joinery is sturdier.",
+		"Experienced" = "You have a plethora of professional carpentry experience, either as a trade or from running a farmstead or business. You could likely train an apprentice of your own in carpentry.",
+		"Master"      = "Few can match your experience with woodcraft. You fit tight joinery, carve intricate items, and prepare raw material with precision and speed. Trees dream of being worked by your hands."
 	)
 
 /decl/hierarchy/skill/crafting/stonemasonry

--- a/maps/shaded_hills/shaded_hills_skills.dm
+++ b/maps/shaded_hills/shaded_hills_skills.dm
@@ -55,13 +55,13 @@
 /decl/hierarchy/skill/crafting/textiles
 	name = "Textiles"
 	uid =  "skill_crafting_textiles"
-	desc = "This skill describes your skill with cloth, thread and leather."
+	desc = "Your ability to create and mend objects made of cloth, thread, leather, and other fabrics."
 	levels = list(
-		"Unskilled"   = "Placeholder.",
-		"Basic"       = "Placeholder.",
-		"Trained"     = "Placeholder.",
-		"Experienced" = "Placeholder.",
-		"Master"      = "Placeholder."
+		"Unskilled"   = "You can use a sewing needle, but it takes substantial care to not prick yourself with it. With plenty of time, you can weave grass into a basic basket or a mat. Your patch repair jobs are rough and ramshackle and anything you make from scratch is often fragile and misshapen.",
+		"Basic"       = "You've got some experience with a loom or spinning wheel, and you can sew without poking yourself. More advanced stitching, knitting, or weaving techniques are still beyond you, but your handiwork is rapidly improving.",
+		"Trained"     = "You have plenty of experience with weaving, sewing, or spinning, and may even be an apprentice in the trade. You've started to grasp some more advanced techniques and greatly improved your proficiency at the basics.",
+		"Experienced" = "You've reached a near-mastery of basic sewing, weaving, and leatherworking skills, but still have room to improve. You know enough to train someone in the basics of working with textiles, but mastery is not yet within your reach.",
+		"Master"      = "You've never seen a piece of clothing you couldn't mend. You've mastered not just the basics but more advanced techniques as well, making your skill with texiles nearly unmatched. Your knowledge would be suitable to train an apprentice enough to work independently."
 	)
 
 /decl/hierarchy/skill/crafting/sculpting

--- a/maps/shaded_hills/shaded_hills_skills.dm
+++ b/maps/shaded_hills/shaded_hills_skills.dm
@@ -31,13 +31,13 @@
 /decl/hierarchy/skill/crafting/metalwork
 	name = "Metalwork"
 	uid =  "skill_crafting_metalwork"
-	desc = "This skill describes your skill with shaping, forging and casting metal."
+	desc = "Your ability to shape, forge, and cast metal into various decorative or useful objects."
 	levels = list(
-		"Unskilled"   = "Placeholder.",
-		"Basic"       = "Placeholder.",
-		"Trained"     = "Placeholder.",
-		"Experienced" = "Placeholder.",
-		"Master"      = "Placeholder."
+		"Unskilled"   = "You know that a smith uses an anvil and hammer, that metal has to be hot to be worked, and that metal becomes a liquid when heated enough. You've likely never done anything like that yourself, though, and if you have it wasn't very good.",
+		"Basic"       = "You've got some experience working with metals. You know how to keep a workpiece steady enough on the anvil to strike it with a hammer, but you're not sure how to do anything more complex with an anvil. You can pour hot metal into a warmed mould without much splattering.",
+		"Trained"     = "You know the basics of smithing as a trade, like drawing, punching, and bending, and you can crack a cast item out of a mould without breaking it or the mould as often. You know what fuels burn hot enough to melt certain metals, and what metals go into certain alloys.",
+		"Experienced" = "You are either a professional smith or farrier, or someone who works extensively with metal as part of another trade. You have the knowledge necessary to supervise and instruct an untrained apprentice to avoid basic mistakes. You may know about more complex or niche alloys, or have experience working expensive or rare metals.",
+		"Master"      = "To you, metal may as well be putty in your hands and under your hammer. You're able to get many casts from one mould, make and fill moulds of detailed objects, and forge intricate projects all on your own. With enough time, you could train someone enough to become a professional smith of their own."
 	)
 
 /decl/hierarchy/skill/crafting/artifice
@@ -109,6 +109,9 @@
 // METALWORK OVERRIDES
 /decl/material/solid/metal
 	crafting_skill = /decl/hierarchy/skill/crafting/metalwork
+
+/obj/item/chems/mould
+	work_skill = /decl/hierarchy/skill/crafting/metalwork
 
 // CARPENTRY OVERRIDES
 /decl/material/solid/organic/wood

--- a/maps/shaded_hills/shaded_hills_skills.dm
+++ b/maps/shaded_hills/shaded_hills_skills.dm
@@ -43,13 +43,13 @@
 /decl/hierarchy/skill/crafting/artifice
 	name = "Artifice"
 	uid =  "skill_crafting_artifice"
-	desc = "This skill describes your skill with complex devices and mechanisms."
+	desc = "Your ability to create, install, and comprehend complex devices and mechanisms, as well as your ability to create finely-detailed objects."
 	levels = list(
-		"Unskilled"   = "Placeholder.",
-		"Basic"       = "Placeholder.",
-		"Trained"     = "Placeholder.",
-		"Experienced" = "Placeholder.",
-		"Master"      = "Placeholder."
+		"Unskilled"   = "You know that gears turn together when intermeshed and that axles are used to connect spinning things, but you've never done more work on a machine than hitting it if it's broken. You struggle with the precision needed to work on finely-detailed objects.",
+		"Basic"       = "You know some basic mechanical principles, like the construction of a basic pulley, or how to put a wheel on an axle. You could fix a broken or stuck well winch, but you'd struggle to deal with a malfunctioning windmill or granary. You have a steadier hand than most, able to place small gems on jewelry and connect small mechanisms.",
+		"Trained"     = "You know how to operate and repair machinery, that axles and gears need to be oiled to work smoothly, and how to figure out what's broken when something goes wrong. You might routinely deal with machines enough to have training with them, or just lots of hands-on experience. You can steady your hands greatly when working with delicate objects.",
+		"Experienced" = "You work with machinery and delicate crafts either as part of your trade or in your daily life. You could construct a delicate music box or wind-up toy, and can easily connect mechanical components together.",
+		"Master"      = "You are a machine maestro, conducting a symphony of steadily-whirring mechanical parts. Every one of your creations has the utmost care put into its design and manufacture. Your hand never slips nor wavers when you work."
 	)
 
 /decl/hierarchy/skill/crafting/textiles

--- a/maps/shaded_hills/shaded_hills_skills.dm
+++ b/maps/shaded_hills/shaded_hills_skills.dm
@@ -90,6 +90,12 @@
 /obj/structure/textiles
 	work_skill = /decl/hierarchy/skill/crafting/textiles
 
+/obj/item/stack/material/skin
+	work_skill = /decl/hierarchy/skill/crafting/textiles
+
+/obj/item/chems/food/butchery/offal
+	work_skill = /decl/hierarchy/skill/crafting/textiles
+
 /decl/material/solid/organic/cloth
 	crafting_skill = /decl/hierarchy/skill/crafting/textiles
 

--- a/maps/shaded_hills/shaded_hills_skills.dm
+++ b/maps/shaded_hills/shaded_hills_skills.dm
@@ -19,13 +19,13 @@
 /decl/hierarchy/skill/crafting/stonemasonry
 	name = "Stonemasonry"
 	uid =  "skill_crafting_mason"
-	desc = "This skill describes your skill with stonecarving."
+	desc = "Your ability to chisel, cut, carve, construct with, and knap stone and stone-like materials."
 	levels = list(
-		"Unskilled"   = "Placeholder.",
-		"Basic"       = "Placeholder.",
-		"Trained"     = "Placeholder.",
-		"Experienced" = "Placeholder.",
-		"Master"      = "Placeholder."
+		"Unskilled"   = "You know that a hammer and chisel are used to split and shape stone, and that bricks are joined using mortar or cement, but you're not entirely sure how to do either of those things. If you tried to chisel a sculpture from a block of stone, you'd risk shattering it entirely, or just having the chisel glance off. You know some primitive tools are made by hitting rocks together to break pieces off, but if you tried you'd probably just make noise and little else.",
+		"Basic"       = "You've done some stoneknapping before and have begun developing an understanding of how stone cracks and splits when struck. You can replicate rough forms out of stone, and while your bricks may not be perfect by any means, they're flat enough to be used in a wall.",
+		"Trained"     = "You can do basic sculpting and carving with a hammer and chisel. You work well with bricks, loose stones, concrete, and rock slabs, whether you're knapping a tool out of flint or carving a form into a block of marble. You may not be able to work professionally at this stage, but you could cut it as an apprentice mason.",
+		"Experienced" = "You work with stone in your daily life, either on your homestead or as part of your profession. Your work improves in quality and speed, with fewer mistakes that result in scrapped workpieces, even if with some blows you still take off a little more than you planned.",
+		"Master"      = "Your work is delicate yet firm, always applying the exact amount of force for the desired effect, no more and no less. Mistakes in your work are unheard of, at least while you work without interference. You could be the head of a masons' guild, or at least train someone to work as a mason or stonecarver."
 	)
 
 /decl/hierarchy/skill/crafting/metalwork

--- a/maps/~mapsystem/map_skills.dm
+++ b/maps/~mapsystem/map_skills.dm
@@ -12,10 +12,8 @@
 	for(var/skill_type in get_available_skill_types())
 		var/decl/hierarchy/skill/skill = GET_DECL(skill_type)
 		if(INSTANCE_IS_ABSTRACT(skill))
-			for(var/decl/hierarchy/skill/child in skill.children)
-				_available_skills |= child.get_descendants()
-		else
-			_available_skills |= skill
+			continue
+		_available_skills |= skill
 
 /datum/map/proc/get_available_skills()
 	if(!_available_skills)


### PR DESCRIPTION
## Description of changes
Fixes some issues with removing skills per-map caused by `build_available_skills` automatically including all subcategories in skill categories.
Removes some modern- and space-setting-specific skills from Shaded Hills.
Adds a sculpting skill to Shaded Hills, used for soft recipes and potentially for making actual sculptures, wax statues, etc. in the future.
Overrides crafting skills for various materials.

Requires #3866. Contains commented code that can be uncommented after #3849.

TO-DO:
- [x] Rebase onto #3866
- [x] Add better skill descriptions

## Why and what will this PR improve
Removes unused/unfitting skills from Shaded Hills and replaces them with skilled trades.