### PR TITLE
Sort stack recipes into further categories

### DIFF
--- a/code/modules/crafting/stack_recipes/recipe_structures.dm
+++ b/code/modules/crafting/stack_recipes/recipe_structures.dm
@@ -6,3 +6,4 @@
 	apply_material_name = FALSE
 	required_material   = /decl/material/solid/metal/chromium
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
+	category            = "furniture"

--- a/code/modules/crafting/stack_recipes/recipes_bricks.dm
+++ b/code/modules/crafting/stack_recipes/recipes_bricks.dm
@@ -9,12 +9,14 @@
 		/obj/item/stack/material/log,
 		/obj/item/stack/material/lump
 	)
+	category                    = "structures"
 
 /decl/stack_recipe/bricks/firepit
 	on_floor                    = TRUE
 	one_per_turf                = TRUE
 	apply_material_name         = FALSE
 	result_type                 = /obj/structure/fire_source/firepit
+	category                    = "fire sources"
 
 /decl/stack_recipe/bricks/firepit/kiln
 	result_type                 = /obj/structure/fire_source/kiln
@@ -24,6 +26,7 @@
 	one_per_turf               = TRUE
 	on_floor                   = TRUE
 	difficulty                 = MAT_VALUE_HARD_DIY
+	category                   = "furniture"
 
 /decl/stack_recipe/bricks/furniture/planting_bed
 	result_type                = /obj/machinery/portable_atmospherics/hydroponics/soil

--- a/code/modules/crafting/stack_recipes/recipes_cardstock.dm
+++ b/code/modules/crafting/stack_recipes/recipes_cardstock.dm
@@ -5,6 +5,7 @@
 
 /decl/stack_recipe/cardstock/box
 	result_type       = /obj/item/storage/box
+	category          = "cardstock boxes"
 
 /decl/stack_recipe/cardstock/box/large
 	result_type       = /obj/item/storage/box/large

--- a/code/modules/crafting/stack_recipes/recipes_coins.dm
+++ b/code/modules/crafting/stack_recipes/recipes_coins.dm
@@ -11,11 +11,13 @@
 /decl/stack_recipe/coin/Initialize()
 	. = ..()
 	var/decl/currency/currency_decl = GET_DECL(currency)
-	if(currency_decl && name)
-		for(var/datum/denomination/currency_denomination in currency_decl.denominations)
-			if(currency_denomination.name == name)
-				denomination = currency_denomination
-				return
+	if(currency_decl)
+		required_material = currency_decl.material
+		if(name)
+			for(var/datum/denomination/currency_denomination in currency_decl.denominations)
+				if(currency_denomination.name == name)
+					denomination = currency_denomination
+					return
 
 /decl/stack_recipe/coin/validate()
 	. = ..()

--- a/code/modules/crafting/stack_recipes/recipes_grass.dm
+++ b/code/modules/crafting/stack_recipes/recipes_grass.dm
@@ -1,6 +1,7 @@
 /decl/stack_recipe/woven
 	abstract_type       = /decl/stack_recipe/woven
 	craft_stack_types   = /obj/item/stack/material/bundle
+	category            = "woven items"
 
 /decl/stack_recipe/woven/basket
 	result_type = /obj/item/storage/basket

--- a/code/modules/crafting/stack_recipes/recipes_hardness.dm
+++ b/code/modules/crafting/stack_recipes/recipes_hardness.dm
@@ -4,35 +4,42 @@
 
 /decl/stack_recipe/hardness/improvised_armour
 	result_type       = /obj/item/clothing/suit/armor/crafted
+	category          = "improvised armor"
 
-/decl/stack_recipe/hardness/armguards
+/decl/stack_recipe/hardness/improvised_armour/armguards
 	result_type       = /obj/item/clothing/accessory/armguards/craftable
 
-/decl/stack_recipe/hardness/legguards
+/decl/stack_recipe/hardness/improvised_armour/legguards
 	result_type       = /obj/item/clothing/accessory/legguards/craftable
 
-/decl/stack_recipe/hardness/gauntlets
+/decl/stack_recipe/hardness/improvised_armour/gauntlets
 	result_type       = /obj/item/clothing/gloves/thick/craftable
 
-/decl/stack_recipe/hardness/fork
+/decl/stack_recipe/hardness/utensils
+	abstract_type     = /decl/stack_recipe/hardness/utensils
+	category          = "utensils"
+
+/decl/stack_recipe/hardness/utensils/fork
 	result_type       = /obj/item/utensil/fork
 
-/decl/stack_recipe/hardness/chopsticks
+/decl/stack_recipe/hardness/utensils/chopsticks
 	result_type       = /obj/item/utensil/chopsticks
 
-/decl/stack_recipe/hardness/knife
+/decl/stack_recipe/hardness/utensils/knife
 	result_type       = /obj/item/utensil/knife
 	difficulty        = MAT_VALUE_HARD_DIY
 
+/decl/stack_recipe/hardness/utensils/spoon
+	result_type       = /obj/item/utensil/spoon
+
 /decl/stack_recipe/hardness/bell
 	result_type       = /obj/item/bell
-
-/decl/stack_recipe/hardness/spoon
-	result_type       = /obj/item/utensil/spoon
+	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE // similar to boxes and bats, not thematically appropriate to low tech
 
 /decl/stack_recipe/hardness/blade
 	result_type       = /obj/item/butterflyblade
 	difficulty        = MAT_VALUE_NORMAL_DIY
+	category          = "weapons"
 
 /decl/stack_recipe/hardness/urn
 	result_type       = /obj/item/urn
@@ -46,6 +53,7 @@
 	result_type       = /obj/item/twohanded/baseballbat
 	difficulty        = MAT_VALUE_HARD_DIY
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE // similar to boxes, not thematically appropriate to low tech
+	category          = "weapons"
 
 /decl/stack_recipe/hardness/ashtray
 	result_type       = /obj/item/ashtray

--- a/code/modules/crafting/stack_recipes/recipes_hardness_integrity.dm
+++ b/code/modules/crafting/stack_recipes/recipes_hardness_integrity.dm
@@ -7,6 +7,7 @@
 	one_per_turf       = TRUE
 	on_floor           = TRUE
 	difficulty         = MAT_VALUE_HARD_DIY
+	category           = "furniture"
 
 /decl/stack_recipe/hardness/integrity/furniture/door
 	result_type        = /obj/structure/door

--- a/code/modules/crafting/stack_recipes/recipes_items.dm
+++ b/code/modules/crafting/stack_recipes/recipes_items.dm
@@ -4,6 +4,7 @@
 	difficulty        = MAT_VALUE_VERY_HARD_DIY
 	required_material = /decl/material/solid/metal/aluminium
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
+	category          = "weapons"
 
 /decl/stack_recipe/candle
 	result_type       = /obj/item/flame/candle

--- a/code/modules/crafting/stack_recipes/recipes_panels.dm
+++ b/code/modules/crafting/stack_recipes/recipes_panels.dm
@@ -37,6 +37,7 @@
 	one_per_turf      = TRUE
 	on_floor          = TRUE
 	difficulty        = MAT_VALUE_HARD_DIY
+	category          = "furniture"
 
 /decl/stack_recipe/panels/furniture/crate
 	result_type       = /obj/structure/closet/crate/plastic

--- a/code/modules/crafting/stack_recipes/recipes_planks.dm
+++ b/code/modules/crafting/stack_recipes/recipes_planks.dm
@@ -8,9 +8,11 @@
 /decl/stack_recipe/planks/crossbowframe
 	result_type            = /obj/item/crossbowframe
 	difficulty             = MAT_VALUE_VERY_HARD_DIY
+	category               = "weapons"
 
 /decl/stack_recipe/planks/beehive_assembly
 	result_type            = /obj/item/beehive_assembly
+	category               = "furniture"
 
 /decl/stack_recipe/planks/beehive_frame
 	result_type            = /obj/item/honey_frame
@@ -19,6 +21,7 @@
 	result_type            = /obj/item/zipgunframe
 	difficulty             = MAT_VALUE_VERY_HARD_DIY
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
+	category               = "weapons"
 
 /decl/stack_recipe/planks/coilgun
 	result_type            = /obj/item/coilgun_assembly
@@ -88,6 +91,7 @@
 	one_per_turf           = TRUE
 	on_floor               = TRUE
 	difficulty             = MAT_VALUE_HARD_DIY
+	category               = "furniture"
 
 /decl/stack_recipe/planks/furniture/coffin
 	result_type            = /obj/structure/closet/coffin/wooden

--- a/code/modules/crafting/stack_recipes/recipes_reinforced.dm
+++ b/code/modules/crafting/stack_recipes/recipes_reinforced.dm
@@ -9,11 +9,14 @@
 	result_type       = /obj/structure/aicore
 	on_floor          = FALSE
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
+	category          = "furniture"
 
 /decl/stack_recipe/reinforced/crate
 	result_type       = /obj/structure/closet/crate
+	category          = "furniture"
 
 /decl/stack_recipe/reinforced/grip
 	result_type       = /obj/item/butterflyhandle
 	difficulty        = MAT_VALUE_NORMAL_DIY
 	one_per_turf      = FALSE
+	category          = "weapons"

--- a/code/modules/crafting/stack_recipes/recipes_steel.dm
+++ b/code/modules/crafting/stack_recipes/recipes_steel.dm
@@ -2,6 +2,7 @@
 	abstract_type     = /decl/stack_recipe/steel
 	required_material = /decl/material/solid/metal/steel
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
+	category          = "structures"
 
 /decl/stack_recipe/steel/apc
 	result_type       = /obj/item/frame/apc
@@ -37,12 +38,14 @@
 /decl/stack_recipe/steel/cannon
 	result_type       = /obj/item/cannonframe
 	difficulty        = MAT_VALUE_VERY_HARD_DIY
+	category          = "weapons"
 
 /decl/stack_recipe/steel/furniture
 	abstract_type     = /decl/stack_recipe/steel/furniture
 	one_per_turf      = TRUE
 	on_floor          = TRUE
 	difficulty        = MAT_VALUE_HARD_DIY
+	category          = "furniture"
 
 /decl/stack_recipe/steel/furniture/computerframe
 	result_type       = /obj/machinery/constructable_frame/computerframe

--- a/code/modules/crafting/stack_recipes/recipes_struts.dm
+++ b/code/modules/crafting/stack_recipes/recipes_struts.dm
@@ -8,6 +8,7 @@
 	on_floor                    = TRUE
 	difficulty                  = MAT_VALUE_HARD_DIY
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
+	category                    = "structures"
 
 /decl/stack_recipe/strut/railing
 	result_type = /obj/structure/railing
@@ -27,19 +28,23 @@
 
 /decl/stack_recipe/strut/table_frame
 	result_type                 = /obj/structure/table/frame
+	category                    = "furniture"
 
 /decl/stack_recipe/strut/rack
 	result_type                 = /obj/structure/rack
+	category                    = "furniture"
 
 /decl/stack_recipe/strut/butcher_hook
 	result_type                 = /obj/structure/meat_hook
 	one_per_turf                = TRUE
 	difficulty                  = MAT_VALUE_NORMAL_DIY
+	category                    = "furniture"
 
 /decl/stack_recipe/strut/bed
 	result_type                 = /obj/structure/bed
 	required_integrity          = 50
 	required_min_hardness           = MAT_VALUE_FLEXIBLE + 10
+	category                    = "furniture"
 
 /decl/stack_recipe/strut/machine
 	result_type                 = /obj/machinery/constructable_frame/machine_frame

--- a/code/modules/crafting/stack_recipes/recipes_textiles.dm
+++ b/code/modules/crafting/stack_recipes/recipes_textiles.dm
@@ -7,12 +7,16 @@
 
 /decl/stack_recipe/textiles/cloak
 	result_type   = /obj/item/clothing/accessory/cloak/hide
+	category      = "clothing"
 
 /decl/stack_recipe/textiles/banner
 	result_type   = /obj/item/banner
+	category      = "furniture"
 
 /decl/stack_recipe/textiles/shoes
 	result_type   = /obj/item/clothing/shoes/craftable
+	category      = "clothing"
 
 /decl/stack_recipe/textiles/boots
 	result_type   = /obj/item/clothing/shoes/craftable/boots
+	category      = "clothing"

--- a/code/modules/crafting/stack_recipes/recipes_turfs.dm
+++ b/code/modules/crafting/stack_recipes/recipes_turfs.dm
@@ -35,7 +35,9 @@
 /decl/stack_recipe/turfs/wall
 	abstract_type         = /decl/stack_recipe/turfs/wall
 	expected_product_type = /turf/wall
+	category              = "walls"
 
 /decl/stack_recipe/turfs/path
 	abstract_type         = /decl/stack_recipe/turfs/path
 	expected_product_type = /turf/exterior
+	category              = "floors"

--- a/code/modules/tools/components/recipes.dm
+++ b/code/modules/tools/components/recipes.dm
@@ -1,6 +1,7 @@
 /decl/stack_recipe/tool
 	category = "tool parts"
 	abstract_type               = /decl/stack_recipe/tool
+	category = "tool parts"
 	forbidden_craft_stack_types = null
 	craft_stack_types           = list(
 		/obj/item/stack/material/ore,


### PR DESCRIPTION
## Description of changes
- Adds a `category` entry to many recipes.
- Accidentally included: Antique coins now require material.

## Why and what will this PR improve
Less clutter in the recipes menu, easier navigation.
No antique wooden versions of coins with the exact same value as the real deal.