### PR TITLE
Heads now provide base dexterity to mouth grippers.

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -303,6 +303,7 @@
 
 #define DEXTERITY_NONE            0
 #define DEXTERITY_SIMPLE_MACHINES BITFLAG(0)
+// TODO: let HOLD equip items to hand just not other slots
 #define DEXTERITY_HOLD_ITEM       BITFLAG(1)
 #define DEXTERITY_EQUIP_ITEM      BITFLAG(2)
 #define DEXTERITY_KEYBOARDS       BITFLAG(3)

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -29,6 +29,10 @@
 		if(eyes)
 			return eyes.get_special_overlay()
 
+// Let people with mouth slots pick things up.
+/obj/item/organ/external/head/get_manual_dexterity()
+	. = ..() | DEXTERITY_BASE
+
 /obj/item/organ/external/head/proc/get_eyes()
 	var/obj/item/organ/internal/eyes/eyes = owner.get_organ((owner.get_bodytype().vision_organ || BP_EYES), /obj/item/organ/internal/eyes)
 	if(eyes)


### PR DESCRIPTION
Baxxid on Scav can't hold items due to the organ not having a dexterity value.