### PR TITLE
Swaps world.turf from space to dark filler.

### DIFF
--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -59,7 +59,42 @@ SUBSYSTEM_DEF(mapping)
 /datum/controller/subsystem/mapping/PreInit()
 	reindex_lists()
 
+#ifdef UNIT_TEST
+/datum/controller/subsystem/mapping/proc/test_load_map_templates()
+	for(var/map_template_name in map_templates)
+		var/datum/map_template/map_template = get_template(map_template_name)
+		// Away sites are supposed to be tested separately in the Away Site environment
+		if(SSunit_tests.is_tested_separately(map_template))
+			report_progress("Skipping template '[map_template]' ([map_template.type]): Is tested separately.")
+			continue
+		if(map_template.is_runtime_generated())
+			report_progress("Skipping template '[map_template]' ([map_template.type]): Is generated at runtime.")
+			continue
+		load_template(map_template)
+		if(map_template.template_flags & TEMPLATE_FLAG_TEST_DUPLICATES)
+			load_template(map_template)
+	log_unit_test("Map templates loaded.")
+
+/datum/controller/subsystem/mapping/proc/load_template(datum/map_template/map_template)
+	// Suggestion: Do smart things here to squeeze as many templates as possible into the same Z-level
+	if(map_template.tallness == 1)
+		increment_world_z_size(/datum/level_data/unit_test)
+		var/turf/center = WORLD_CENTER_TURF(world.maxz)
+		if(!center)
+			CRASH("'[map_template]' (size: [map_template.width]x[map_template.height]) couldn't locate center turf at ([WORLD_CENTER_X][WORLD_CENTER_Y][world.maxz]) with world size ([WORLD_SIZE_TO_STRING])")
+		log_unit_test("Loading template '[map_template]' ([map_template.type]) at [log_info_line(center)]")
+		map_template.load(center, centered = TRUE)
+	else // Multi-Z templates are loaded using different means
+		log_unit_test("Loading template '[map_template]' ([map_template.type]) at Z-level [world.maxz+1] with a tallness of [map_template.tallness]")
+		map_template.load_new_z()
+#endif
+
 /datum/controller/subsystem/mapping/Initialize(timeofday)
+
+#ifdef UNIT_TEST
+	// Shouldn't we be forcing this to true?
+	set_config_value(/decl/config/toggle/roundstart_level_generation, FALSE)
+#endif
 
 	reindex_lists()
 
@@ -96,16 +131,6 @@ SUBSYSTEM_DEF(mapping)
 	// Build away sites.
 	global.using_map.build_away_sites()
 	global.using_map.build_planets()
-	for(var/z = old_maxz + 1 to world.maxz)
-		var/datum/level_data/level = levels_by_z[z]
-		if(!istype(level))
-			level = new /datum/level_data/space(z)
-			PRINT_STACK_TRACE("Missing z-level data object for z[num2text(z)]!")
-		level.setup_level_data()
-
-	// Generate turbolifts last, since away sites may have elevators to generate too.
-	for(var/obj/abstract/turbolift_spawner/turbolift as anything in turbolifts_to_initialize)
-		turbolift.build_turbolift()
 
 	// Resize the world to the max template size to fix a BYOND bug with world resizing breaking events.
 	// REMOVE WHEN THIS IS FIXED: https://www.byond.com/forum/post/2833191
@@ -120,10 +145,22 @@ SUBSYSTEM_DEF(mapping)
 	if (new_maxy > world.maxy)
 		world.maxy = new_maxy
 
-	// Initialize z-level objects.
 #ifdef UNIT_TEST
-	set_config_value(/decl/config/toggle/roundstart_level_generation, FALSE) //#FIXME: Shouldn't this be set before running level_data/setup_level_data()?
+	// Load all map templates if we're unit testing.
+	test_load_map_templates()
 #endif
+
+	// Check/associated/setup our level data objects.
+	for(var/z = old_maxz + 1 to world.maxz)
+		var/datum/level_data/level = levels_by_z[z]
+		if(!istype(level))
+			level = new /datum/level_data/space(z)
+			PRINT_STACK_TRACE("Missing z-level data object for z[num2text(z)]!")
+		level.setup_level_data()
+
+	// Generate turbolifts last, since away sites may have elevators to generate too.
+	for(var/obj/abstract/turbolift_spawner/turbolift as anything in turbolifts_to_initialize)
+		turbolift.build_turbolift()
 
 	. = ..()
 

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -54,6 +54,12 @@
 
 	return INITIALIZE_HINT_LATELOAD // oh no! we need to switch to being a different kind of turf!
 
+/turf/space/LateInitialize()
+	if(SSmapping.base_floor_area)
+		var/area/new_area = locate(SSmapping.base_floor_area) || new SSmapping.base_floor_area
+		ChangeArea(src, new_area)
+	ChangeTurf(SSmapping.base_floor_type, keep_air_below = TRUE)
+
 /turf/space/proc/toggle_transit(var/direction)
 	if(edge)
 		return
@@ -84,12 +90,6 @@
 			T.z_eventually_space = FALSE
 
 	return ..()
-
-/turf/space/LateInitialize()
-	if(SSmapping.base_floor_area)
-		var/area/new_area = locate(SSmapping.base_floor_area) || new SSmapping.base_floor_area
-		ChangeArea(src, new_area)
-	ChangeTurf(SSmapping.base_floor_type, keep_air_below = TRUE)
 
 /turf/space/attackby(obj/item/C, mob/user)
 

--- a/code/game/turfs/unsimulated.dm
+++ b/code/game/turfs/unsimulated.dm
@@ -7,6 +7,12 @@
 	abstract_type = /turf/unsimulated
 	simulated = FALSE
 
+// Shortcut a bunch of simulation stuff since this turf just needs to sit there.
+/turf/unsimulated/Initialize()
+	SHOULD_CALL_PARENT(FALSE)
+	atom_flags |= ATOM_FLAG_INITIALIZED
+	return INITIALIZE_HINT_NORMAL
+
 /turf/unsimulated/get_lumcount(var/minlum = 0, var/maxlum = 1)
 	return 0.8
 

--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -582,6 +582,7 @@ INITIALIZE_IMMEDIATE(/obj/abstract/level_data_spawner)
 
 /datum/level_data/unit_test
 	level_flags = (ZLEVEL_CONTACT|ZLEVEL_PLAYER|ZLEVEL_SEALED)
+	filler_turf = /turf/unsimulated/dark_filler
 
 /datum/level_data/overmap
 	name = "Sensor Display"

--- a/code/modules/random_map/noise/desert.dm
+++ b/code/modules/random_map/noise/desert.dm
@@ -4,7 +4,7 @@
 
 /datum/random_map/noise/desert/replace_space
 	descriptor = "desert (replacement)"
-	target_turf_type = /turf/space
+	target_turf_type = TRUE
 
 /datum/random_map/noise/desert/get_map_char(var/value)
 	return "<font color='#[value][value][value][value][value][value]'>[pick(list(",",".","'","`"))]</font>"

--- a/code/modules/random_map/noise/seafloor.dm
+++ b/code/modules/random_map/noise/seafloor.dm
@@ -4,8 +4,8 @@
 	target_turf_type = /turf/floor/natural/seafloor/flooded
 
 /datum/random_map/noise/seafloor/replace_space
-	descriptor = "seafloor (replace space)"
-	target_turf_type = /turf/space
+	descriptor = "seafloor (replace)"
+	target_turf_type = TRUE
 
 /datum/random_map/noise/seafloor/replace_space/get_appropriate_path(var/value)
 	return /turf/floor/natural/seafloor/flooded

--- a/code/modules/random_map/noise/tundra.dm
+++ b/code/modules/random_map/noise/tundra.dm
@@ -3,8 +3,8 @@
 	smoothing_iterations = 1
 
 /datum/random_map/noise/tundra/replace_space
-	descriptor = "tundra (replacement)"
-	target_turf_type = /turf/space
+	descriptor = "tundra (replace)"
+	target_turf_type = TRUE
 
 /datum/random_map/noise/tundra/get_map_char(var/value)
 	var/val = min(9,max(0,round((value/cell_range)*10)))

--- a/code/modules/random_map/random_map.dm
+++ b/code/modules/random_map/random_map.dm
@@ -23,6 +23,7 @@ var/global/list/map_count = list()
 	// Turf paths.
 	var/wall_type =  /turf/wall
 	var/floor_type = /turf/floor
+	// Turf type to act on when applying this map. Set to TRUE to use world.turf, or a path to use a specific turf subtype.
 	var/target_turf_type
 
 	var/change_area = FALSE
@@ -32,6 +33,9 @@ var/global/list/map_count = list()
 	var/list/map = list()           // Actual map.
 
 /datum/random_map/New(var/tx, var/ty, var/tz, var/tlx, var/tly, var/do_not_apply, var/do_not_announce, var/used_area)
+
+	if(target_turf_type == TRUE)
+		target_turf_type = world.turf
 
 	// Store this for debugging.
 	if(!map_count[descriptor])

--- a/code/unit_tests/~unit_test_subsystems.dm
+++ b/code/unit_tests/~unit_test_subsystems.dm
@@ -31,9 +31,6 @@ SUBSYSTEM_DEF(unit_tests)
 	#endif
 	log_unit_test("Initializing Unit Testing")
 
-	// Load Map Templates
-	load_map_templates()
-
 	//
 	//Start the Round.
 	//
@@ -50,34 +47,6 @@ SUBSYSTEM_DEF(unit_tests)
 		if(cat in skipped_template_categories)
 			return TRUE
 	return FALSE
-
-/datum/controller/subsystem/unit_tests/proc/load_map_templates()
-	for(var/map_template_name in SSmapping.map_templates)
-		var/datum/map_template/map_template = SSmapping.get_template(map_template_name)
-		// Away sites are supposed to be tested separately in the Away Site environment
-		if(is_tested_separately(map_template))
-			report_progress("Skipping template '[map_template]' ([map_template.type]): Is tested separately.")
-			continue
-		if(map_template.is_runtime_generated())
-			report_progress("Skipping template '[map_template]' ([map_template.type]): Is generated at runtime.")
-			continue
-		load_template(map_template)
-		if(map_template.template_flags & TEMPLATE_FLAG_TEST_DUPLICATES)
-			load_template(map_template)
-	log_unit_test("Map Templates Loaded")
-
-/datum/controller/subsystem/unit_tests/proc/load_template(datum/map_template/map_template)
-	// Suggestion: Do smart things here to squeeze as many templates as possible into the same Z-level
-	if(map_template.tallness == 1)
-		SSmapping.increment_world_z_size(/datum/level_data/unit_test)
-		var/turf/center = WORLD_CENTER_TURF(world.maxz)
-		if(!center)
-			CRASH("'[map_template]' (size: [map_template.width]x[map_template.height]) couldn't locate center turf at ([WORLD_CENTER_X][WORLD_CENTER_Y][world.maxz]) with world size ([WORLD_SIZE_TO_STRING])")
-		log_unit_test("Loading template '[map_template]' ([map_template.type]) at [log_info_line(center)]")
-		map_template.load(center, centered = TRUE)
-	else // Multi-Z templates are loaded using different means
-		log_unit_test("Loading template '[map_template]' ([map_template.type]) at Z-level [world.maxz+1] with a tallness of [map_template.tallness]")
-		map_template.load_new_z()
 
 /datum/controller/subsystem/unit_tests/proc/start_game()
 	if (GAME_STATE >= RUNLEVEL_POSTGAME)

--- a/code/world.dm
+++ b/code/world.dm
@@ -5,7 +5,7 @@
 
 /world
 	mob = /mob/new_player
-	turf = /turf/space
+	turf = /turf/unsimulated/dark_filler
 	area = /area/space
 	view = "15x15"
 	cache_lifespan = 7


### PR DESCRIPTION
## Description of changes
Changes `world.turf` to `/turf/unsimulated/dark_filler` instead of `/turf/space`.

## Why and what will this PR improve
Loaded z-levels aren't randomly surrounded by space.

## Authorship
Myself.

## Changelog
Nothing player-facing.