### PR TITLE
Ports vox slowdown/pressure immunity toggle from Polaris.

### DIFF
--- a/code/game/objects/items/devices/scanners/xenobio.dm
+++ b/code/game/objects/items/devices/scanners/xenobio.dm
@@ -53,7 +53,7 @@
 	var/decl/bodytype/root_bodytype = get_bodytype()
 	if(root_bodytype)
 		. += "Temperature comfort zone:\t[root_bodytype.cold_discomfort_level] K to [root_bodytype.heat_discomfort_level] K"
-	. += "Pressure comfort zone:\t[species.warning_low_pressure] kPa to [species.warning_high_pressure] kPa"
+	. += "Pressure comfort zone:\t[species.get_warning_low_pressure(src)] kPa to [species.get_warning_high_pressure(src)] kPa"
 	. = jointext(., "<br>")
 
 /mob/living/simple_animal/xenobio_scan_results()

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -104,7 +104,7 @@
 	playsound(src.loc, 'sound/effects/glass_step.ogg', 50, 1) // not sure how to handle metal shards with sounds
 
 	var/decl/species/walker_species = M.get_species()
-	if(walker_species && (walker_species.siemens_coefficient<0.5 || (walker_species.species_flags & (SPECIES_FLAG_NO_EMBED|SPECIES_FLAG_NO_MINOR_CUT)))) //Thick skin.
+	if(walker_species && (walker_species.get_shock_vulnerability(M) < 0.5 || (walker_species.species_flags & (SPECIES_FLAG_NO_EMBED|SPECIES_FLAG_NO_MINOR_CUT)))) //Thick skin.
 		return
 
 	var/obj/item/shoes = M.get_equipped_item(slot_shoes_str)

--- a/code/modules/maps/template_types/random_exoplanet/planetoid_data.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planetoid_data.dm
@@ -498,10 +498,10 @@
 	if(habitability_class == HABITABILITY_OKAY || habitability_class == HABITABILITY_IDEAL)
 		var/decl/species/S           = global.get_species_by_key(global.using_map.default_species)
 		var/breathed_min_pressure    = S.breath_pressure
-		var/safe_max_pressure        = S.hazard_high_pressure
-		var/safe_min_pressure        = S.hazard_low_pressure
-		var/comfortable_max_pressure = S.warning_high_pressure
-		var/comfortable_min_pressure = S.warning_low_pressure
+		var/safe_max_pressure        = S.get_hazard_high_pressure()
+		var/safe_min_pressure        = S.get_hazard_low_pressure()
+		var/comfortable_max_pressure = S.get_warning_high_pressure()
+		var/comfortable_min_pressure = S.get_warning_low_pressure()
 
 		//On ideal planets, clamp against the comfortability limit pressures, since it shouldn't hit any extremes
 		if(habitability_class == HABITABILITY_IDEAL)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -90,7 +90,7 @@ meteor_act
 	if (!def_zone)
 		return 1.0
 
-	var/siemens_coefficient = max(species.siemens_coefficient,0)
+	var/siemens_coefficient = max(species.get_shock_vulnerability(src), 0)
 	for(var/slot in global.standard_clothing_slots)
 		var/obj/item/clothing/C = get_equipped_item(slot)
 		if(istype(C) && (C.body_parts_covered & def_zone.body_part)) // Is that body part being targeted covered?
@@ -379,7 +379,7 @@ meteor_act
 
 	if(status_flags & GODMODE)	return 0	//godmode
 
-	if(species.siemens_coefficient == -1)
+	if(species.get_shock_vulnerability(src) == -1)
 		if(stored_shock_by_ref["\ref[src]"])
 			stored_shock_by_ref["\ref[src]"] += shock_damage
 		else

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -6,7 +6,7 @@
 
 	var/obj/item/organ/external/H = GET_EXTERNAL_ORGAN(src, BP_GROIN) // gets bodytype slowdown, which can be reset by set_bodytype
 	if(H)
-		tally += H.slowdown
+		tally += H.bodytype.get_movement_slowdown(src)
 
 	tally += species.handle_movement_delay_special(src)
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -189,7 +189,7 @@
 	if(relative_density > 0.02) //don't bother if we are in vacuum or near-vacuum
 		var/loc_temp = environment.temperature
 
-		if(adjusted_pressure < species.warning_high_pressure && adjusted_pressure > species.warning_low_pressure && abs(loc_temp - bodytemperature) < 20 && bodytemperature < get_mob_temperature_threshold(HEAT_LEVEL_1) && bodytemperature > get_mob_temperature_threshold(COLD_LEVEL_1) && species.body_temperature)
+		if(adjusted_pressure < species.get_warning_high_pressure(src) && adjusted_pressure > species.get_warning_low_pressure(src) && abs(loc_temp - bodytemperature) < 20 && bodytemperature < get_mob_temperature_threshold(HEAT_LEVEL_1) && bodytemperature > get_mob_temperature_threshold(COLD_LEVEL_1) && species.body_temperature)
 			SET_HUD_ALERT(src, /decl/hud_element/condition/pressure, 0)
 			return // Temperatures are within normal ranges, fuck all this processing. ~Ccomp
 
@@ -242,15 +242,16 @@
 	// Made it possible to actually have something that can protect against high pressure... Done by Errorage. Polymorph now has an axe sticking from his head for his previous hardcoded nonsense!
 	if(status_flags & GODMODE)	return 1	//godmode
 
-	if(adjusted_pressure >= species.hazard_high_pressure)
-		var/pressure_damage = min( ( (adjusted_pressure / species.hazard_high_pressure) -1 )*PRESSURE_DAMAGE_COEFFICIENT , MAX_HIGH_PRESSURE_DAMAGE)
+	var/high_pressure = species.get_hazard_high_pressure(src)
+	if(adjusted_pressure >= high_pressure)
+		var/pressure_damage = min( ( (adjusted_pressure / high_pressure) -1 )*PRESSURE_DAMAGE_COEFFICIENT , MAX_HIGH_PRESSURE_DAMAGE)
 		take_overall_damage(brute=pressure_damage, used_weapon = "High Pressure")
 		SET_HUD_ALERT(src, /decl/hud_element/condition/pressure, 2)
-	else if(adjusted_pressure >= species.warning_high_pressure)
+	else if(adjusted_pressure >= species.get_warning_high_pressure(src))
 		SET_HUD_ALERT(src, /decl/hud_element/condition/pressure, 1)
-	else if(adjusted_pressure >= species.warning_low_pressure)
+	else if(adjusted_pressure >= species.get_warning_low_pressure(src))
 		SET_HUD_ALERT(src, /decl/hud_element/condition/pressure, 0)
-	else if(adjusted_pressure >= species.hazard_low_pressure)
+	else if(adjusted_pressure >= species.get_hazard_low_pressure(src))
 		SET_HUD_ALERT(src, /decl/hud_element/condition/pressure, -1)
 	else
 		var/list/obj/item/organ/external/parts = get_damageable_organs()

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -11,7 +11,7 @@
 	scale_max_damage_to_species_health = TRUE
 	abstract_type = /obj/item/organ/external
 
-	var/slowdown = 0
+	var/_slowdown = 0
 	var/tmp/_icon_cache_key
 	// Strings
 	var/broken_description             // fracture string if any.
@@ -142,7 +142,6 @@
 	. = ..(new_bodytype, override_material)
 	if(bodytype != old_bodytype && apply_to_internal_organs)
 		bodytype.rebuild_internal_organs(src, override_material)
-	slowdown = bodytype.movement_slowdown
 	if(.)
 		update_icon(TRUE)
 

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -216,7 +216,7 @@
 		PN.trigger_warning(5)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(H.species.siemens_coefficient <= 0)
+		if(H.species.get_shock_vulnerability(H) <= 0)
 			return
 		var/obj/item/clothing/gloves/G = H.get_equipped_item(slot_gloves_str)
 		if(istype(G) && G.siemens_coefficient == 0)

--- a/code/modules/species/outsider/shadow.dm
+++ b/code/modules/species/outsider/shadow.dm
@@ -25,7 +25,7 @@
 	available_bodytypes = list(/decl/bodytype/starlight/shadow)
 
 	unarmed_attacks = list(/decl/natural_attack/claws/strong, /decl/natural_attack/bite/sharp)
-	siemens_coefficient = 0
+	shock_vulnerability = 0
 
 	blood_types = list(
 		/decl/blood_type/shadowstuff

--- a/code/modules/species/outsider/starlight.dm
+++ b/code/modules/species/outsider/starlight.dm
@@ -86,7 +86,7 @@
 
 	warning_low_pressure = 50
 	hazard_low_pressure = 0
-	siemens_coefficient = 0
+	shock_vulnerability = 0
 	hunger_factor = 0
 	death_message = "dissolves into pure flames!"
 	breath_type = null

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -142,7 +142,7 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 
 	// Body/form vars.
 	var/list/inherent_verbs 	  // Species-specific verbs.
-	var/siemens_coefficient = 1   // The lower, the thicker the skin and better the insulation.
+	var/shock_vulnerability = 1   // The lower, the thicker the skin and better the insulation.
 	var/species_flags = 0         // Various specific features.
 	var/spawn_flags = 0           // Flags that specify who can spawn as this species
 	// Move intents. Earlier in list == default for that type of movement.

--- a/code/modules/species/species_bodytype.dm
+++ b/code/modules/species/species_bodytype.dm
@@ -590,3 +590,6 @@ var/global/list/limbs_with_nails = list(
 			"descriptor" = nail_noun
 		)
 	return null
+
+/decl/bodytype/proc/get_movement_slowdown(var/mob/living/carbon/human/H)
+	return movement_slowdown

--- a/code/modules/species/species_helpers.dm
+++ b/code/modules/species/species_helpers.dm
@@ -45,3 +45,18 @@ var/global/list/stored_shock_by_ref = list()
 /decl/species/proc/equip_default_fallback_uniform(var/mob/living/carbon/human/H)
 	if(istype(H))
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/harness, slot_w_uniform_str)
+
+/decl/species/proc/get_hazard_high_pressure(var/mob/living/carbon/human/H)
+	return hazard_high_pressure
+
+/decl/species/proc/get_warning_high_pressure(var/mob/living/carbon/human/H)
+	return warning_high_pressure
+
+/decl/species/proc/get_warning_low_pressure(var/mob/living/carbon/human/H)
+	return warning_low_pressure
+
+/decl/species/proc/get_hazard_low_pressure(var/mob/living/carbon/human/H)
+	return hazard_low_pressure
+
+/decl/species/proc/get_shock_vulnerability(var/mob/living/carbon/human/H)
+	return shock_vulnerability

--- a/code/modules/species/station/golem.dm
+++ b/code/modules/species/station/golem.dm
@@ -17,7 +17,7 @@
 	unarmed_attacks = list(/decl/natural_attack/stomp, /decl/natural_attack/kick, /decl/natural_attack/punch)
 	species_flags = SPECIES_FLAG_NO_POISON
 	spawn_flags = SPECIES_IS_RESTRICTED
-	siemens_coefficient = 0
+	shock_vulnerability = 0
 
 	meat_type = null
 	bone_material = null

--- a/mods/species/ascent/datum/species.dm
+++ b/mods/species/ascent/datum/species.dm
@@ -52,7 +52,7 @@
 		'mods/species/ascent/sounds/ascent6.ogg'
 	)
 
-	siemens_coefficient =   0.2 // Crystalline body.
+	shock_vulnerability =   0.2 // Crystalline body.
 	oxy_mod =               0.8 // Don't need as much breathable gas as humans.
 	toxins_mod =            0.8 // Not as biologically fragile as meatboys.
 	radiation_mod =         0.5 // Not as biologically fragile as meatboys.
@@ -60,7 +60,6 @@
 	age_descriptor = /datum/appearance_descriptor/age/kharmaani
 	rarity_value =            3
 	gluttonous =              2
-	siemens_coefficient =     0
 	body_temperature =        null
 
 	breath_type =             /decl/material/gas/methyl_bromide

--- a/mods/species/bayliens/adherent/datum/species.dm
+++ b/mods/species/bayliens/adherent/datum/species.dm
@@ -39,7 +39,7 @@
 	)
 	cyborg_noun =             null
 
-	siemens_coefficient =     0
+	shock_vulnerability =     0
 	rarity_value =            6
 
 	age_descriptor = /datum/appearance_descriptor/age/adherent

--- a/mods/species/bayliens/skrell/datum/species.dm
+++ b/mods/species/bayliens/skrell/datum/species.dm
@@ -32,7 +32,7 @@
 	burn_mod = 0.9
 	oxy_mod = 1.3
 	toxins_mod = 0.8
-	siemens_coefficient = 1.3
+	shock_vulnerability = 1.3
 	warning_low_pressure = WARNING_LOW_PRESSURE * 1.4
 	hazard_low_pressure = HAZARD_LOW_PRESSURE * 2
 	warning_high_pressure = WARNING_HIGH_PRESSURE / 0.8125

--- a/mods/species/vox/datum/species_bodytypes.dm
+++ b/mods/species/vox/datum/species_bodytypes.dm
@@ -14,7 +14,6 @@
 	base_color        = "#526d29"
 	body_flags        = BODY_FLAG_NO_DNA
 
-
 	cold_level_1 = 80
 	cold_level_2 = 50
 	cold_level_3 = -1
@@ -63,6 +62,11 @@
 			slot_undershirt_str = list("[NORTH]" = list(0, -1), "[EAST]" = list(0, -1), "[SOUTH]" = list( 0, -1),  "[WEST]" = list( 0, -1)),
 			slot_back_str       = list("[NORTH]" = list(0,  0), "[EAST]" = list(3,  0), "[SOUTH]" = list( 0,  0),  "[WEST]" = list(-3,  0))
 		)
+	return ..()
+
+/decl/bodytype/vox/get_movement_slowdown(var/mob/living/carbon/human/H)
+	if(H && global.vox_current_pressure_toggle["\ref[H]"])
+		return 1.5
 	return ..()
 
 /decl/bodytype/vox/servitor


### PR DESCRIPTION
## Description of changes
- Species pressure bounds, shock vulnerability, and movement speed are now handled with getters.
- Vox now need to toggle between pressure immunity and movement speed.

## Why and what will this PR improve
Makes vox a bit more balanced, allows species and bodytypes to more easily dynamically adjust some values.

## Authorship
Myself.

## Changelog
:cl:
tweak: Vox must now pick between pressure resistance and speed using the Toggle Pressure Seal verb.
/:cl: