### PR TITLE
Fix keyring errors from storage datum update

### DIFF
--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -104,13 +104,13 @@
 		var/obj/item/key/new_key = new(get_turf(H), lock_keys[lock_key] || /decl/material/solid/metal/iron, lock_key)
 		H.put_in_hands_or_store_or_drop(new_key)
 	else if(length(lock_keys))
-		var/obj/item/storage/keyring/keyring
+		var/obj/item/keyring/keyring
 		for(var/lock_key in lock_keys)
 			if(!keyring)
 				keyring = new(get_turf(H))
 				H.put_in_hands_or_store_or_drop(keyring)
 			var/obj/item/key/new_key = new(get_turf(H), lock_keys[lock_key] || /decl/material/solid/metal/iron, lock_key)
-			keyring.handle_item_insertion(new_key)
+			keyring.storage?.handle_item_insertion(new_key)
 
 /datum/job/proc/get_outfit(var/mob/living/carbon/human/H, var/alt_title, var/datum/mil_branch/branch, var/datum/mil_rank/grade)
 	if(alt_title && alt_titles)

--- a/code/game/objects/structures/structure_lock.dm
+++ b/code/game/objects/structures/structure_lock.dm
@@ -10,7 +10,7 @@
 		else
 			to_chat(user, SPAN_WARNING("\The [I] does not fit in the lock!"))
 		return TRUE
-	if(istype(I, /obj/item/storage/keyring))
+	if(istype(I, /obj/item/keyring))
 		for(var/obj/item/key/key in I)
 			if(lock.toggle(key))
 				to_chat(user, SPAN_NOTICE("You [lock.status ? "lock" : "unlock"] \the [src] with \the [key]."))
@@ -42,7 +42,7 @@
 		return FALSE
 	if(!lock.isLocked())
 		return TRUE
-	if(user?.a_intent == I_HELP && (istype(held, /obj/item/key) || istype(held, /obj/item/storage/keyring)))
+	if(user?.a_intent == I_HELP && (istype(held, /obj/item/key) || istype(held, /obj/item/keyring)))
 		try_key_unlock(held, user)
 	if(!lock.isLocked())
 		return TRUE

--- a/code/modules/crafting/stack_recipes/recipes_hardness_integrity.dm
+++ b/code/modules/crafting/stack_recipes/recipes_hardness_integrity.dm
@@ -80,7 +80,7 @@
 	result_type        = /obj/item/key
 
 /decl/stack_recipe/hardness/integrity/keyring
-	result_type        = /obj/item/storage/keyring
+	result_type        = /obj/item/keyring
 
 /decl/stack_recipe/hardness/integrity/rod
 	result_type        = /obj/item/stack/material/rods

--- a/code/modules/locks/keyring.dm
+++ b/code/modules/locks/keyring.dm
@@ -1,21 +1,15 @@
-/obj/item/storage/keyring
+/obj/item/keyring
 	name = "keyring"
 	desc = "A simple loop for threading keys onto."
 	icon = 'icons/obj/items/keyring.dmi'
 	icon_state = ICON_STATE_WORLD
-	can_hold = list(
-		/obj/item/key,
-		/obj/item/screwdriver,
-		/obj/item/arrow
-	)
+	storage = /datum/storage/keyring
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_LOWER_BODY | SLOT_POCKET
 	material = /decl/material/solid/metal/brass
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME | MAT_FLAG_ALTERATION_DESC
-	max_w_class = ITEM_SIZE_TINY
-	max_storage_space = 8
 
-/obj/item/storage/keyring/examine(mob/user, distance)
+/obj/item/keyring/examine(mob/user, distance)
 	. = ..()
 
 	if(length(contents) && distance <= 1)
@@ -31,7 +25,7 @@
 			for(var/key_string in key_strings)
 				to_chat(user, key_string)
 
-/obj/item/storage/keyring/on_update_icon()
+/obj/item/keyring/on_update_icon()
 	. = ..()
 	icon_state = get_world_inventory_state()
 	var/key_count = 0
@@ -45,10 +39,11 @@
 		if(key_count >= 3)
 			break
 
-/obj/item/storage/keyring/remove_from_storage(obj/item/W, atom/new_location, var/NoUpdate = 0)
-	. = ..()
-	update_icon()
-
-/obj/item/storage/keyring/handle_item_insertion(var/obj/item/W, var/prevent_warning = 0, var/NoUpdate = 0)
-	. = ..()
-	update_icon()
+/datum/storage/keyring
+	can_hold = list(
+		/obj/item/key,
+		/obj/item/screwdriver,
+		/obj/item/arrow
+	)
+	max_w_class = ITEM_SIZE_TINY
+	max_storage_space = 8


### PR DESCRIPTION
## Description of changes
Repaths `/obj/item/storage/keyring` to `/obj/item/keyring`.
Removes unnecessary on-remove and on-insert overrides on keyrings, as the base definitions now call update_icon.
Makes keyrings use storage datums.

## Why and what will this PR improve
Fixes CI failure due to merge skew on dev.