### PR TITLE
Adjust material hardness to make iron pickaxes able to mine stone

### DIFF
--- a/code/modules/materials/definitions/solids/materials_solid_metal.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_metal.dm
@@ -194,7 +194,7 @@
 	boiling_point = 2774
 	weight = MAT_VALUE_NORMAL
 	wall_support_value = MAT_VALUE_VERY_HEAVY // Ideal construction material.
-	hardness = MAT_VALUE_HARD
+	hardness = MAT_VALUE_HARD + 5
 	integrity = 150
 	brute_armor = 5
 	icon_base = 'icons/turf/walls/solid.dmi'
@@ -225,6 +225,7 @@
 	melting_point = 1784
 	boiling_point = null
 	wall_support_value = MAT_VALUE_HEAVY
+	hardness = MAT_VALUE_HARD + 5
 	integrity = 175
 	burn_armor = 10
 	color = "#a5a5a5"
@@ -356,6 +357,7 @@
 	color = "#deddff"
 	weight = MAT_VALUE_VERY_HEAVY
 	wall_support_value = MAT_VALUE_VERY_HEAVY
+	hardness = MAT_VALUE_VERY_HARD
 	stack_origin_tech = @'{"materials":2}'
 	ore_compresses_to = /decl/material/solid/metal/osmium
 	ore_result_amount = 5
@@ -377,6 +379,7 @@
 	boiling_point = 3134
 	color = "#5c5454"
 	hitsound = 'sound/weapons/smash.ogg'
+	hardness = MAT_VALUE_HARD
 	construction_difficulty = MAT_VALUE_NORMAL_DIY
 	reflectiveness = MAT_VALUE_MATTE
 	taste_description = "metal"

--- a/code/modules/materials/definitions/solids/materials_solid_stone.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_stone.dm
@@ -27,6 +27,7 @@
 	lore_text = "A clastic sedimentary rock. The cost of boosting it to orbit is almost universally much higher than the actual value of the material."
 	value = 1.5
 	melting_point = T0C + 600
+	hardness = MAT_VALUE_RIGID + 5
 
 /decl/material/solid/stone/flint
 	name      = "flint"
@@ -42,7 +43,7 @@
 	color                  = "#615f5f"
 	exoplanet_rarity_plant = MAT_RARITY_MUNDANE
 	exoplanet_rarity_gas   = MAT_RARITY_MUNDANE
-	hardness               = MAT_VALUE_HARD + 5
+	hardness               = MAT_VALUE_HARD
 	melting_point          = T0C + 1260
 	brute_armor            = 15
 	explosion_resistance   = 15
@@ -69,6 +70,7 @@
 
 	dissolves_in = MAT_SOLVENT_IMMUNE
 	dissolves_into = null
+
 /decl/material/solid/stone/marble
 	name = "marble"
 	uid = "solid_marble"


### PR DESCRIPTION
## Description of changes
Makes iron, platinum, steel, and stainless steel harder, and makes most stones slightly softer than hard metals (iron, steel, etc.).

Future TODO: adjust hardness of mineral/ore materials to make upgrading to steel (or using explosives) important.

## Why and what will this PR improve
You'll be able to mine basalt and granite with iron pickaxes, which is good since steel won't be easily available on Shaded Hills.