### PR TITLE
Fixes to syringe/dart gun behavior.

### DIFF
--- a/code/modules/projectiles/ammunition/chemdart.dm
+++ b/code/modules/projectiles/ammunition/chemdart.dm
@@ -9,12 +9,16 @@
 	material = /decl/material/solid/glass
 	var/reagent_amount = 15
 
-/obj/item/projectile/bullet/chemdart/initialize_reagents(populate)
+/obj/item/projectile/bullet/chemdart/Initialize()
+	. = ..()
+	initialize_reagents()
+
+/obj/item/projectile/bullet/chemdart/initialize_reagents(populate = TRUE)
 	create_reagents(reagent_amount)
 	. = ..()
 
 /obj/item/projectile/bullet/chemdart/on_hit(var/atom/target, var/blocked = 0, var/def_zone = null)
-	if(blocked < 100 && isliving(target))
+	if(reagents?.total_volume && blocked < 100 && isliving(target))
 		var/mob/living/L = target
 		if(L.can_inject(null, def_zone) == CAN_INJECT)
 			reagents.trans_to_mob(L, reagent_amount, CHEM_INJECT)

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -47,10 +47,10 @@
 	. = ..()
 
 /obj/item/gun/projectile/dartgun/consume_next_projectile()
-	. = ..()
-	var/obj/item/projectile/bullet/chemdart/dart = .
+	var/obj/item/projectile/bullet/chemdart/dart = ..()
 	if(istype(dart))
 		fill_dart(dart)
+	return dart
 
 /obj/item/gun/projectile/dartgun/examine(mob/user)
 	. = ..()

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -300,6 +300,9 @@ var/global/obj/temp_reagents_holder = new
 /* Holder-to-holder and similar procs */
 /datum/reagents/proc/remove_any(var/amount = 1, var/defer_update = FALSE) // Removes up to [amount] of reagents from [src]. Returns actual amount removed.
 
+	if(amount <= 0)
+		return 0
+
 	if(amount >= total_volume)
 		. = total_volume
 		clear_reagents()


### PR DESCRIPTION
- Dartgun projectiles initialize reagents correctly.
- remove_any() now returns early if amount is zero, avoiding clamping against total_volume and clearing reagents entirely.