### PR TITLE
Simplifying how accessory slot flags and slot strings are handled.

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -66,6 +66,7 @@
 #define slot_socks_str       "slot_socks"
 
 // Bodypart coverage bitflags.
+#define SLOT_NONE        0
 #define SLOT_UPPER_BODY  BITFLAG(0)
 #define SLOT_LOWER_BODY  BITFLAG(1)
 #define SLOT_OVER_BODY   BITFLAG(2)
@@ -83,10 +84,9 @@
 #define SLOT_HEAD        BITFLAG(14)
 #define SLOT_ID          BITFLAG(15)
 #define SLOT_BACK        BITFLAG(16)
-#define SLOT_TIE         BITFLAG(17)
-#define SLOT_HOLSTER     BITFLAG(18)
-#define SLOT_POCKET      BITFLAG(19)
-#define SLOT_TAIL        BITFLAG(20)
+#define SLOT_HOLSTER     BITFLAG(17)
+#define SLOT_POCKET      BITFLAG(18)
+#define SLOT_TAIL        BITFLAG(19)
 #define SLOT_LEGS        (SLOT_LEG_LEFT|SLOT_LEG_RIGHT)
 #define SLOT_FEET        (SLOT_FOOT_LEFT|SLOT_FOOT_RIGHT)
 #define SLOT_ARMS        (SLOT_ARM_LEFT|SLOT_ARM_RIGHT)

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -33,20 +33,19 @@ var/global/list/string_part_flags = list(
 
 // Strings which corraspond to slot flags, useful for outputting what slot something is.
 var/global/list/string_slot_flags = list(
-	"back" =     SLOT_BACK,
-	"face" =     SLOT_FACE,
-	"waist" =    SLOT_LOWER_BODY,
-	"tail" =     SLOT_TAIL,
-	"ID slot" =  SLOT_ID,
-	"ears" =     SLOT_EARS,
-	"eyes" =     SLOT_EYES,
-	"hands" =    SLOT_HANDS,
-	"head" =     SLOT_HEAD,
-	"feet" =     SLOT_FEET,
-	"exo slot" = SLOT_OVER_BODY,
-	"body" =     SLOT_UPPER_BODY,
-	"uniform" =  SLOT_TIE,
-	"holster" =  SLOT_HOLSTER
+	"back"      = SLOT_BACK,
+	"face"      = SLOT_FACE,
+	"waist"     = SLOT_LOWER_BODY,
+	"tail"      = SLOT_TAIL,
+	"ID slot"   = SLOT_ID,
+	"ears"      = SLOT_EARS,
+	"eyes"      = SLOT_EYES,
+	"hands"     = SLOT_HANDS,
+	"head"      = SLOT_HEAD,
+	"feet"      = SLOT_FEET,
+	"exo slot"  = SLOT_OVER_BODY,
+	"body"      = SLOT_UPPER_BODY,
+	"holster"   = SLOT_HOLSTER
 )
 
 //////////////////////////

--- a/code/game/objects/item_mob_overlay.dm
+++ b/code/game/objects/item_mob_overlay.dm
@@ -73,8 +73,9 @@ var/global/list/icon_state_cache = list()
 	var/useicon   = get_icon_for_bodytype(bodytype)
 	var/use_state = "[bodytype]-[slot][state_modifier]"
 
+	var/is_not_held_slot = !(slot in global.all_hand_slots)
 	if(bodytype != BODYTYPE_HUMANOID && !check_state_in_icon(use_state, useicon) && use_fallback_if_icon_missing)
-		var/fallback = get_fallback_slot(slot)
+		var/fallback = is_not_held_slot && get_fallback_slot(slot)
 		if(fallback && fallback != slot && check_state_in_icon("[bodytype]-[fallback][state_modifier]", useicon))
 			slot = fallback
 		else
@@ -86,7 +87,7 @@ var/global/list/icon_state_cache = list()
 		use_state = "[bodytype]-[global.bodypart_to_slot_lookup_table[slot]][state_modifier]"
 
 	if(!check_state_in_icon(use_state, useicon))
-		var/fallback = use_fallback_if_icon_missing && get_fallback_slot(slot)
+		var/fallback = use_fallback_if_icon_missing && is_not_held_slot && get_fallback_slot(slot)
 		if(!fallback)
 			return new /image
 		slot = fallback

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -9,8 +9,10 @@
 	var/randpixel = 6
 	var/material_health_multiplier = 0.2
 	var/hitsound
-	var/slot_flags = 0		//This is used to determine on which slots an item can fit.
-	var/no_attack_log = 0			//If it's an item we don't want to log attack_logs with, set this to 1
+	/// This is used to determine on which slots an item can fit.
+	var/slot_flags = SLOT_NONE      
+	/// If it's an item we don't want to log attack_logs with, set this to TRUE
+	var/no_attack_log = 0
 	var/obj/item/master = null
 	var/origin_tech                    //Used by R&D to determine what research bonuses it grants.
 	var/list/attack_verb = list("hit") //Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"

--- a/code/game/objects/items/dog_tags.dm
+++ b/code/game/objects/items/dog_tags.dm
@@ -3,7 +3,7 @@
 	desc = "Plain identification tags made from a durable metal. They are stamped with a variety of informational details."
 	gender = PLURAL
 	icon = 'icons/clothing/accessories/jewelry/dogtags.dmi'
-	slot_flags = SLOT_FACE | SLOT_TIE
+	slot_flags = SLOT_FACE
 	badge_string = null
 	material = /decl/material/solid/metal/stainlesssteel
 	var/owner_rank

--- a/code/modules/client/preference_setup/loadout/lists/accessories.dm
+++ b/code/modules/client/preference_setup/loadout/lists/accessories.dm
@@ -4,7 +4,6 @@
 /decl/loadout_option/accessory
 	category = /decl/loadout_category/accessories
 	abstract_type = /decl/loadout_option/accessory
-	slot = slot_tie_str
 
 /decl/loadout_option/accessory/tie
 	name = "tie selection"

--- a/code/modules/client/preference_setup/loadout/lists/clothing.dm
+++ b/code/modules/client/preference_setup/loadout/lists/clothing.dm
@@ -4,12 +4,10 @@
 /decl/loadout_option/clothing
 	category = /decl/loadout_category/clothing
 	abstract_type = /decl/loadout_option/clothing
-	slot = slot_tie_str
 
 /decl/loadout_option/clothing/flannel
 	name = "flannel (colorable)"
 	path = /obj/item/clothing/shirt/flannel
-	slot = slot_tie_str
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
 
 /decl/loadout_option/clothing/scarf

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -333,7 +333,7 @@ var/global/list/gear_datums = list()
 	var/description                       // Description of this gear. If left blank will default to the description of the pathed item.
 	var/path                              // Path of item.
 	var/cost = 1                          // Number of points used. Items in general cost 1 point, storage/armor/gloves/special use costs 2 points.
-	var/slot                              // Slot to equip to.
+	var/slot = slot_tie_str               // Slot to equip to.
 	var/list/allowed_roles                // Roles that can spawn with this item.
 	var/list/allowed_branches             // Service branches that can spawn with it.
 	var/list/allowed_skills               // Skills required to spawn with this item.

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -386,10 +386,3 @@
 	. = ..()
 	LAZYADD(., /decl/interaction_handler/clothing_set_sensors)
 
-// This stub is so the linter stops yelling about sleeping during Initialize()
-// due to corpse props equipping themselves, which calls equip_to_slot, which
-// calls attackby(), which sometimes sleeps due to input(). Yeah.
-// Remove this if a better fix presents itself.
-/obj/item/clothing/proc/try_attach_accessory(var/obj/item/accessory, var/mob/user)
-	set waitfor = FALSE
-	attackby(accessory, user)

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -25,12 +25,18 @@
 	var/markings_state_modifier	// simple colored overlay that would be applied to the icon
 	var/markings_color	// for things like colored parts of labcoats or shoes
 	var/should_display_id = TRUE
+	var/fallback_slot
 
 /obj/item/clothing/Initialize()
 
 	. = ..()
 
-	accessory_hide_on_states = get_initial_accessory_hide_on_states()
+	if(accessory_slot)
+		if(isnull(accessory_removable))
+			accessory_removable = TRUE
+		if(isnull(fallback_slot))
+			fallback_slot = slot_tie_str
+		accessory_hide_on_states = get_initial_accessory_hide_on_states()
 
 	if(starting_accessories)
 		for(var/T in starting_accessories)
@@ -46,6 +52,9 @@
 	if(is_accessory())
 		on_removed()
 	return ..()
+
+/obj/item/clothing/get_fallback_slot(slot)
+	return fallback_slot
 
 /obj/item/clothing/get_stored_inventory()
 	. = ..()

--- a/code/modules/clothing/_clothing_accessories.dm
+++ b/code/modules/clothing/_clothing_accessories.dm
@@ -10,15 +10,19 @@
 /obj/item/clothing/proc/get_initial_accessory_hide_on_states()
 	return null
 
-/obj/item/clothing/proc/can_attach_accessory(obj/item/clothing/accessory)
-	if(valid_accessory_slots && istype(accessory) && !isnull(accessory.accessory_slot) && (accessory.accessory_slot in valid_accessory_slots))
-		. = 1
-	else
-		return 0
+/obj/item/clothing/proc/can_attach_accessory(obj/item/clothing/accessory, mob/user)
+	if(!length(valid_accessory_slots))
+		to_chat(user, SPAN_WARNING("You cannot attach accessories of any kind to \the [src]."))
+		return FALSE
+	if(!istype(accessory) || isnull(accessory.accessory_slot) || !(accessory.accessory_slot in valid_accessory_slots))
+		to_chat(user, SPAN_WARNING("You cannot attach accessories of this kind to \the [src]."))
+		return FALSE
 	if(LAZYLEN(accessories) && restricted_accessory_slots && (accessory.accessory_slot in restricted_accessory_slots))
 		for(var/obj/item/clothing/other_accessory in accessories)
 			if (other_accessory.accessory_slot == accessory.accessory_slot)
-				return 0
+				to_chat(user, SPAN_WARNING("You cannot attach more accessories of this kind to \the [src]."))
+				return FALSE
+	return TRUE
 
 // Override for action buttons.
 /obj/item/clothing/attack_self(mob/user)
@@ -43,20 +47,16 @@
 	return ..()
 
 /obj/item/clothing/attackby(var/obj/item/I, var/mob/user)
+
 	if(istype(I, /obj/item/clothing))
 
 		var/obj/item/clothing/accessory = I
 		if(!isnull(accessory.accessory_slot))
-
-			if(!valid_accessory_slots || !valid_accessory_slots.len)
-				to_chat(usr, SPAN_WARNING("You cannot attach accessories of any kind to \the [src]."))
-				return TRUE
-
-			if(can_attach_accessory(accessory))
+			if(can_attach_accessory(accessory, user))
 				if(user.try_unequip(accessory))
 					attach_accessory(user, accessory)
 			else
-				to_chat(user, SPAN_WARNING("You cannot attach more accessories of this type to [src]."))
+				to_chat(user, SPAN_WARNING("You cannot attach \the [I] to \the [src]."))
 			return TRUE
 
 	if(length(accessories))

--- a/code/modules/clothing/_clothing_accessories.dm
+++ b/code/modules/clothing/_clothing_accessories.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing
 	var/accessory_slot
-	var/accessory_removable = FALSE
+	var/accessory_removable
 	/// if it should appear on examine without detailed view
 	var/accessory_high_visibility
 	/// used when an accessory is meant to slow the wearer down when attached to clothing

--- a/code/modules/clothing/badges/_badge.dm
+++ b/code/modules/clothing/badges/_badge.dm
@@ -9,15 +9,11 @@
 	desc = "A leather-backed badge, with gold trimmings."
 	icon = 'icons/clothing/accessories/badges/detectivebadge.dmi'
 	w_class = ITEM_SIZE_SMALL
-	slot_flags = SLOT_LOWER_BODY | SLOT_TIE
+	slot_flags = SLOT_LOWER_BODY
 	accessory_slot = ACCESSORY_SLOT_INSIGNIA
-	accessory_removable = TRUE
 	var/badge_string = "Detective"
 	var/stored_name
 
-/obj/item/clothing/badge/get_fallback_slot(var/slot)
-	if(slot != BP_L_HAND && slot != BP_R_HAND)
-		return slot_tie_str
 
 /obj/item/clothing/badge/get_initial_accessory_hide_on_states()
 	var/static/list/initial_accessory_hide_on_states = list(

--- a/code/modules/clothing/badges/holobadge.dm
+++ b/code/modules/clothing/badges/holobadge.dm
@@ -13,7 +13,7 @@
 
 /obj/item/clothing/badge/holo/cord
 	icon = 'icons/clothing/accessories/badges/holobadge_cord.dmi'
-	slot_flags = SLOT_FACE | SLOT_TIE
+	slot_flags = SLOT_FACE
 
 /obj/item/clothing/badge/holo/set_name(var/new_name)
 	..()

--- a/code/modules/clothing/belts/suspenders.dm
+++ b/code/modules/clothing/belts/suspenders.dm
@@ -2,14 +2,10 @@
 	name = "suspenders"
 	desc = "They suspend the illusion of the mime's play."
 	icon = 'icons/clothing/belt/suspenders_red.dmi'
-	slot_flags = SLOT_TIE | SLOT_LOWER_BODY
+	slot_flags = SLOT_LOWER_BODY
 	w_class = ITEM_SIZE_SMALL
 	accessory_slot = ACCESSORY_SLOT_DECOR
-	accessory_removable = TRUE
-
-/obj/item/clothing/suspenders/get_fallback_slot(slot)
-	if(slot != BP_L_HAND && slot != BP_R_HAND)
-		return slot_belt_str
+	fallback_slot = slot_belt_str
 
 /obj/item/clothing/suspenders/colorable
 	icon = 'icons/clothing/belt/suspenders.dmi'

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -12,11 +12,8 @@
 	attack_verb = list("challenged")
 	blood_overlay_type = "bloodyhands"
 	bodytype_equip_flags = BODY_FLAG_HUMANOID
+	fallback_slot = slot_gloves_str
 	var/obj/item/clothing/ring/covering_ring
-
-/obj/item/clothing/gloves/get_fallback_slot(slot)
-	if(slot != BP_L_HAND && slot != BP_R_HAND)
-		return slot_gloves_str
 
 /obj/item/clothing/gloves/get_associated_equipment_slots()
 	. = ..()

--- a/code/modules/clothing/medals/medals.dm
+++ b/code/modules/clothing/medals/medals.dm
@@ -4,12 +4,7 @@
 	icon = 'icons/clothing/accessories/medals/medal_bronze.dmi'
 	w_class = ITEM_SIZE_SMALL
 	accessory_slot = ACCESSORY_SLOT_MEDAL
-	slot_flags = SLOT_UPPER_BODY | SLOT_TIE
-	accessory_removable = TRUE
-
-/obj/item/clothing/medal/get_fallback_slot(var/slot)
-	if(slot != BP_L_HAND && slot != BP_R_HAND)
-		return slot_tie_str
+	slot_flags = SLOT_UPPER_BODY
 
 /obj/item/clothing/medal/bronze
 	name = "bronze medal"

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -1,9 +1,4 @@
 /obj/item/clothing/neck
 	abstract_type = /obj/item/clothing/neck
-	slot_flags = SLOT_TIE
 	w_class = ITEM_SIZE_SMALL
 	accessory_slot = ACCESSORY_SLOT_NECK
-
-/obj/item/clothing/neck/get_fallback_slot(var/slot)
-	if(slot != BP_L_HAND && slot != BP_R_HAND)
-		return slot_tie_str

--- a/code/modules/clothing/pants/_pants.dm
+++ b/code/modules/clothing/pants/_pants.dm
@@ -8,6 +8,7 @@
 	slot_flags = SLOT_UPPER_BODY // SLOT_LOWER_BODY when pants slot exists
 	w_class = ITEM_SIZE_NORMAL
 	force = 0
+	fallback_slot = slot_w_uniform_str
 	valid_accessory_slots = list(
 		ACCESSORY_SLOT_SENSORS,
 		ACCESSORY_SLOT_UTILITY,
@@ -34,8 +35,3 @@
 	. = ..()
 	var/static/list/pants_slots = list(slot_w_uniform_str, slot_wear_id_str)
 	LAZYDISTINCTADD(., pants_slots)
-
-
-/obj/item/clothing/pants/get_fallback_slot(var/slot)
-	if(slot != BP_L_HAND && slot != BP_R_HAND)
-		return slot_w_uniform_str

--- a/code/modules/clothing/pants/misc.dm
+++ b/code/modules/clothing/pants/misc.dm
@@ -2,19 +2,13 @@
 	name = "fire overpants"
 	desc = "some overpants made of fire-resistant synthetic fibers. To be worn over the uniform."
 	icon = 'icons/clothing/under/pants/overpants.dmi'
-
 	gas_transfer_coefficient = 0.90
 	permeability_coefficient = 0.50
-
 	armor = list(ARMOR_LASER = ARMOR_LASER_MINOR, ARMOR_ENERGY = ARMOR_ENERGY_MINOR, ARMOR_BOMB = ARMOR_BOMB_MINOR)
 	body_parts_covered = SLOT_LOWER_BODY | SLOT_LEGS | SLOT_TAIL
 	accessory_slowdown = 0.5
-
 	heat_protection = SLOT_LOWER_BODY | SLOT_LEGS | SLOT_TAIL
 	cold_protection = SLOT_LOWER_BODY | SLOT_LEGS | SLOT_TAIL
-
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	max_pressure_protection = FIRESUIT_MAX_PRESSURE
-
 	accessory_slot = ACCESSORY_SLOT_DECOR
-	accessory_removable = TRUE

--- a/code/modules/clothing/sensors/_sensor.dm
+++ b/code/modules/clothing/sensors/_sensor.dm
@@ -1,8 +1,6 @@
 /obj/item/clothing/sensor
 	name = "sensor"
 	abstract_type = /obj/item/clothing/sensor
-	slot_flags = SLOT_TIE
-	icon_state = ICON_STATE_WORLD
 	accessory_slot = ACCESSORY_SLOT_SENSORS
 
 /obj/item/clothing/sensor/get_mob_overlay(mob/user_mob, slot, bodypart, use_fallback_if_icon_missing = TRUE, skip_adjustment = FALSE)

--- a/code/modules/clothing/shirts/_shirts.dm
+++ b/code/modules/clothing/shirts/_shirts.dm
@@ -2,17 +2,14 @@
 	abstract_type = /obj/item/clothing/shirt
 	body_parts_covered = SLOT_UPPER_BODY|SLOT_ARMS
 	permeability_coefficient = 0.90
-	slot_flags = SLOT_UPPER_BODY | SLOT_TIE
+	slot_flags = SLOT_UPPER_BODY
 	w_class = ITEM_SIZE_SMALL
 	accessory_slot = ACCESSORY_SLOT_DECOR
-	accessory_removable = TRUE
 	force = 0
+	fallback_slot = slot_w_uniform_str
 
 /obj/item/clothing/shirt/get_associated_equipment_slots()
 	. = ..()
 	var/static/list/shirt_slots = list(slot_w_uniform_str, slot_wear_id_str)
 	LAZYDISTINCTADD(., shirt_slots)
 
-/obj/item/clothing/shirt/get_fallback_slot(var/slot)
-	if(slot != BP_L_HAND && slot != BP_R_HAND)
-		return slot_w_uniform_str

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -14,6 +14,7 @@
 	blood_overlay_type = "shoeblood"
 	material = /decl/material/solid/organic/leather
 	origin_tech = @'{"materials":1,"engineering":1}'
+	fallback_slot = slot_shoes_str
 
 	var/can_fit_under_magboots = TRUE
 	var/can_add_cuffs = TRUE
@@ -29,10 +30,6 @@
 	var/footstep_range_mod  = 1
 	/// A modifier applied to move delay when walking on snow.
 	var/snow_slowdown_mod   = 0
-
-/obj/item/clothing/shoes/get_fallback_slot(slot)
-	if(slot != BP_L_HAND && slot != BP_R_HAND)
-		return slot_shoes_str
 
 /obj/item/clothing/shoes/Destroy()
 	. = ..()

--- a/code/modules/clothing/suits/_suit.dm
+++ b/code/modules/clothing/suits/_suit.dm
@@ -9,19 +9,12 @@
 	siemens_coefficient = 0.9
 	w_class = ITEM_SIZE_NORMAL
 	valid_accessory_slots = list(ACCESSORY_SLOT_ARMBAND, ACCESSORY_SLOT_OVER)
+	fallback_slot = slot_wear_suit_str
 	var/protects_against_weather = FALSE
 	var/fire_resist = T0C+100
 
-/obj/item/clothing/suit/get_fallback_slot(var/slot)
-	if(slot != BP_L_HAND && slot != BP_R_HAND)
-		return slot_wear_suit_str
-
 /obj/item/clothing/suit/gives_weather_protection()
 	return protects_against_weather
-
-/obj/item/clothing/suit/get_fallback_slot(var/slot)
-	if(slot != BP_L_HAND && slot != BP_R_HAND)
-		return slot_wear_suit_str
 
 /obj/item/clothing/suit/get_associated_equipment_slots()
 	. = ..()

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -27,7 +27,7 @@
 // than relying on overlay order. This also overlays over inhands but it looks ok.
 /obj/item/clothing/suit/cloak/adjust_mob_overlay(mob/living/user_mob, bodytype, image/overlay, slot, bodypart, use_fallback_if_icon_missing = TRUE)
 
-	if(slot == slot_wear_suit_str || slot == slot_tie_str || slot == slot_w_uniform_str)
+	if(slot == slot_wear_suit_str || slot == slot_w_uniform_str)
 
 		var/image/underlay
 		var/image/cloverlay

--- a/code/modules/clothing/suits/dashiki.dm
+++ b/code/modules/clothing/suits/dashiki.dm
@@ -2,9 +2,8 @@
 	name = "black dashiki"
 	desc = "An ornately embroidered pullover garmant sporting a v-shaped collar. This one is green and black."
 	icon = 'icons/clothing/suit/dashiki/dashiki.dmi'
-	slot_flags = SLOT_TIE | SLOT_OVER_BODY
+	slot_flags = SLOT_OVER_BODY
 	accessory_slot = ACCESSORY_SLOT_DECOR
-	accessory_removable = TRUE
 
 /obj/item/clothing/suit/dashiki/red
 	name = "red dashiki"

--- a/code/modules/clothing/suits/jackets/_jacket.dm
+++ b/code/modules/clothing/suits/jackets/_jacket.dm
@@ -3,12 +3,11 @@
 	desc                = "A snappy dress jacket."
 	icon                = 'icons/clothing/suit/jackets/jacket.dmi'
 	blood_overlay_type  = "coat"
-	body_parts_covered  = SLOT_UPPER_BODY|SLOT_ARMS
-	cold_protection     = SLOT_UPPER_BODY|SLOT_ARMS
-	slot_flags          = SLOT_OVER_BODY | SLOT_TIE
+	body_parts_covered  = SLOT_UPPER_BODY | SLOT_ARMS
+	cold_protection     = SLOT_UPPER_BODY | SLOT_ARMS
+	slot_flags          = SLOT_OVER_BODY
 	w_class             = ITEM_SIZE_NORMAL
 	accessory_slot      = ACCESSORY_SLOT_DECOR
-	accessory_removable = TRUE
 	valid_accessory_slots = list(
 		ACCESSORY_SLOT_INSIGNIA,
 		ACCESSORY_SLOT_ARMBAND,

--- a/code/modules/clothing/suits/poncho.dm
+++ b/code/modules/clothing/suits/poncho.dm
@@ -3,9 +3,8 @@
 	desc = "A simple, comfortable poncho."
 	icon = 'icons/clothing/suit/poncho/classic.dmi'
 	bodytype_equip_flags = null
-	slot_flags = SLOT_TIE | SLOT_OVER_BODY
+	slot_flags = SLOT_OVER_BODY
 	accessory_slot = ACCESSORY_SLOT_DECOR
-	accessory_removable = TRUE
 
 /obj/item/clothing/suit/poncho/colored
 	icon = 'icons/clothing/suit/poncho/colourable.dmi'

--- a/code/modules/clothing/suits/robes.dm
+++ b/code/modules/clothing/suits/robes.dm
@@ -4,9 +4,8 @@
 	icon = 'icons/clothing/suit/rough_robe.dmi'
 	body_parts_covered = SLOT_UPPER_BODY|SLOT_LOWER_BODY|SLOT_LEGS
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME | MAT_FLAG_ALTERATION_DESC
-	slot_flags = SLOT_OVER_BODY | SLOT_TIE
+	slot_flags = SLOT_OVER_BODY
 	accessory_slot = ACCESSORY_SLOT_DECOR
-	accessory_removable = TRUE
 
 /obj/item/clothing/suit/robe/thawb
 	name = "thawb"

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -1,13 +1,7 @@
 /obj/item/clothing/accessory
 	abstract_type = /obj/item/clothing/accessory
-	slot_flags = SLOT_TIE
 	w_class = ITEM_SIZE_SMALL
 	accessory_slot = ACCESSORY_SLOT_DECOR
-	accessory_removable = TRUE
-
-/obj/item/clothing/accessory/get_fallback_slot(var/slot)
-	if(slot != BP_L_HAND && slot != BP_R_HAND)
-		return slot_tie_str
 
 //default attack_hand behaviour
 /obj/item/clothing/accessory/attack_hand(mob/user)
@@ -29,7 +23,7 @@
 	name = "necklace"
 	desc = "A simple necklace."
 	icon = 'icons/clothing/accessories/jewelry/necklace.dmi'
-	slot_flags = SLOT_FACE | SLOT_TIE
+	slot_flags = SLOT_FACE
 
 //Misc
 /obj/item/clothing/accessory/kneepads

--- a/code/modules/clothing/under/accessories/armband.dm
+++ b/code/modules/clothing/under/accessories/armband.dm
@@ -3,14 +3,10 @@
 	desc = "A fancy red armband!"
 	icon = 'icons/clothing/accessories/armbands/armband_security.dmi'
 	bodytype_equip_flags = null
-	slot_flags = SLOT_UPPER_BODY | SLOT_TIE
+	slot_flags = SLOT_UPPER_BODY
 	w_class = ITEM_SIZE_SMALL
 	accessory_slot = ACCESSORY_SLOT_ARMBAND
-	accessory_removable = TRUE
-
-/obj/item/clothing/armband/get_fallback_slot(var/slot)
-	if(slot != BP_L_HAND && slot != BP_R_HAND)
-		return slot_w_uniform_str
+	fallback_slot = slot_w_uniform_str
 
 /obj/item/clothing/armband/get_initial_accessory_hide_on_states()
 	var/static/list/initial_accessory_hide_on_states = list(

--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -99,9 +99,8 @@
 	)
 	origin_tech = @'{"materials":1,"engineering":1,"combat":1}'
 	accessory_slot = ACCESSORY_SLOT_ARMOR_A
-	slot_flags = SLOT_TIE | SLOT_HANDS
+	slot_flags = SLOT_HANDS
 	accessory_slot = ACCESSORY_SLOT_DECOR
-	accessory_removable = TRUE
 
 /obj/item/clothing/gloves/armguards/craftable
 	material_armor_multiplier = 1
@@ -130,9 +129,8 @@
 	)
 	origin_tech = @'{"materials":1,"engineering":1,"combat":1}'
 	accessory_slot = ACCESSORY_SLOT_ARMOR_L
-	slot_flags = SLOT_TIE | SLOT_FEET
+	slot_flags = SLOT_FEET
 	accessory_slot = ACCESSORY_SLOT_DECOR
-	accessory_removable = TRUE
 
 /obj/item/clothing/shoes/legguards/craftable
 	material_armor_multiplier = 1

--- a/code/modules/clothing/under/accessories/lockets.dm
+++ b/code/modules/clothing/under/accessories/lockets.dm
@@ -3,7 +3,7 @@
 	desc = "A silver locket that seems to have space for a photo within."
 	slot_flags = 0
 	w_class = ITEM_SIZE_SMALL
-	slot_flags = SLOT_FACE | SLOT_TIE
+	slot_flags = SLOT_FACE
 	icon = 'icons/clothing/accessories/jewelry/locket.dmi'
 	var/open
 	var/obj/item/held

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -3,10 +3,8 @@
 	desc = "Sturdy mess of synthcotton belts and buckles, ready to share your burden."
 	icon = 'icons/clothing/accessories/storage/webbing.dmi'
 	w_class = ITEM_SIZE_NORMAL
-	slot_flags = SLOT_TIE
 	accessory_slot = ACCESSORY_SLOT_UTILITY
 	accessory_high_visibility = TRUE
-	accessory_removable = TRUE
 	storage = /datum/storage/pockets
 
 /obj/item/clothing/webbing/webbing_large

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -47,7 +47,10 @@
 		return TRUE
 
 	if(slot == slot_tie_str)
-		var/obj/item/clothing/uniform = get_equipped_item(slot_w_uniform_str)
+		var/try_equip_slot = W.get_fallback_slot()
+		if(!try_equip_slot || try_equip_slot == slot_tie_str)
+			try_equip_slot = slot_w_uniform_str
+		var/obj/item/clothing/uniform = get_equipped_item(try_equip_slot)
 		if(istype(uniform))
 			uniform.try_attach_accessory(W, src)
 		return TRUE

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -47,12 +47,24 @@
 		return TRUE
 
 	if(slot == slot_tie_str)
-		var/try_equip_slot = W.get_fallback_slot()
-		if(!try_equip_slot || try_equip_slot == slot_tie_str)
-			try_equip_slot = slot_w_uniform_str
-		var/obj/item/clothing/uniform = get_equipped_item(try_equip_slot)
-		if(istype(uniform))
-			uniform.try_attach_accessory(W, src)
+
+		var/list/check_slots = get_inventory_slots()
+		if(islist(check_slots))
+
+			check_slots = check_slots.Copy()
+			check_slots -= global.all_hand_slots
+
+			var/try_equip_slot = W.get_fallback_slot()
+			if(try_equip_slot)
+				check_slots -= try_equip_slot
+				check_slots.Insert(1, try_equip_slot)
+		
+			for(var/slot_string in check_slots)
+				var/obj/item/clothing/clothes = get_equipped_item(slot_string)
+				if(istype(clothes) && clothes.can_attach_accessory(W, src))
+					clothes.attach_accessory(src, W)
+					break
+
 		return TRUE
 
 	unequip(W)

--- a/code/modules/mob/living/inventory.dm
+++ b/code/modules/mob/living/inventory.dm
@@ -18,6 +18,7 @@
 			if(isnull(inv_slot.quick_equip_priority)) // Never quick-equip into some slots.
 				continue
 			_inventory_slot_priority += inv_slot.slot_id
+		_inventory_slot_priority |= slot_tie_str // fallback for non-clothing accessories
 	return _inventory_slot_priority
 
 /mob/living/get_inventory_slot_datum(var/slot)

--- a/code/modules/mob/stripping.dm
+++ b/code/modules/mob/stripping.dm
@@ -106,7 +106,7 @@
 			admin_attack_log(user, src, "Attempted to strip \a [target_slot]", "Target of a failed strip of \a [target_slot].", "attempted to strip \a [target_slot] from")
 	else if(user.try_unequip(held))
 		var/obj/item/clothing/C = get_equipped_item(slot_to_strip_text)
-		if(istype(C) && C.can_attach_accessory(held))
+		if(istype(C) && C.can_attach_accessory(held, user))
 			C.attach_accessory(user, held)
 		else if(!equip_to_slot_if_possible(held, slot_to_strip_text, del_on_fail=0, disable_warning=1, redraw_mob=1))
 			user.put_in_active_hand(held)

--- a/code/modules/species/species_hud.dm
+++ b/code/modules/species/species_hud.dm
@@ -49,8 +49,7 @@
 	equip_slots |= slot_handcuffed_str
 	if(slot_back_str in equip_slots)
 		equip_slots |= slot_in_backpack_str
-	if(slot_w_uniform_str in equip_slots)
-		equip_slots |= slot_tie_str
+	equip_slots |= slot_tie_str
 
 /datum/hud_data/monkey
 	inventory_slots = list(

--- a/mods/content/corporate/items/badges.dm
+++ b/mods/content/corporate/items/badges.dm
@@ -24,4 +24,4 @@
 
 /obj/item/clothing/badge/holo/NT/cord
 	icon = 'mods/content/corporate/icons/clothing/accessories/holobadge_cord.dmi'
-	slot_flags = SLOT_FACE | SLOT_TIE
+	slot_flags = SLOT_FACE

--- a/mods/species/neoavians/datum/species_bodytypes.dm
+++ b/mods/species/neoavians/datum/species_bodytypes.dm
@@ -72,7 +72,6 @@
 		slot_glasses_str   = list("[NORTH]" = list( 0, -6), "[EAST]" = list( 1, -6), "[SOUTH]" = list( 0, -6),  "[WEST]" = list(-1, -6)),
 		slot_back_str      = list("[NORTH]" = list( 0, -6), "[EAST]" = list( 3, -6), "[SOUTH]" = list( 0, -6),  "[WEST]" = list(-3, -6)),
 		slot_w_uniform_str = list("[NORTH]" = list( 0, -6), "[EAST]" = list(-1, -6), "[SOUTH]" = list( 0, -6),  "[WEST]" = list( 1, -6)),
-		slot_tie_str       = list("[NORTH]" = list( 0, -5), "[EAST]" = list( 0, -5), "[SOUTH]" = list( 0, -5),  "[WEST]" = list( 0, -5)),
 		slot_wear_id_str   = list("[NORTH]" = list( 0, -6), "[EAST]" = list(-1, -6), "[SOUTH]" = list( 0, -6),  "[WEST]" = list( 1, -6)),
 		slot_wear_suit_str = list("[NORTH]" = list( 0, -6), "[EAST]" = list(-1, -6), "[SOUTH]" = list( 0, -6),  "[WEST]" = list( 1, -6)),
 		slot_belt_str      = list("[NORTH]" = list( 0, -6), "[EAST]" = list(-1, -6), "[SOUTH]" = list( 0, -6),  "[WEST]" = list( 1, -6))


### PR DESCRIPTION
## Description of changes
- Removes `SLOT_TIE` as it turns out it hasn't actually been used for a long time.
- `get_fallback_slot()` has been simplified to return a var on clothing and the hands checking has been moved into the base proc.
- Clothing will automatically set removable accessory status and accessory fallback slot if the relevant vars are null during Initialize.
- Equipping an accessory will try to equip it to the fallback slot rather than always trying to equip it to uniform.
- Loadout options will default to `slot_tie_str`.

## Why and what will this PR improve
Cleans the code up significantly.

## Authorship
Myself.

## Changelog
Nothing player-facing.