### PR TITLE
Simplifies accessory rendering

### DIFF
--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -167,18 +167,33 @@
 				overlay.overlays += accessory.get_mob_overlay(user_mob, slot, bodypart)
 	return overlay
 
+/obj/item/clothing/set_dir(ndir)
+	// Avoid rendering the profile or back sides of the mob overlay we used when accessories are rendered.
+	if(length(accessories))
+		ndir = SOUTH
+	return ..()
+
 /obj/item/clothing/on_update_icon()
 	. = ..()
-	icon_state = JOINTEXT(list(get_world_inventory_state(), get_clothing_state_modifier()))
-	if(markings_state_modifier && markings_color)
-		add_overlay(mutable_appearance(icon, "[icon_state][markings_state_modifier]", markings_color))
-	var/list/new_overlays
-	for(var/obj/item/clothing/accessory in accessories)
-		var/image/I = accessory.get_attached_inventory_overlay(icon_state)
+
+	// Clothing does not generally align with each other's world icons, so we just use the mob overlay in this case.
+	var/set_appearance = FALSE
+	if(length(accessories))
+		var/image/I = get_mob_overlay(ismob(loc) ? loc : null, get_fallback_slot())
 		if(I)
-			LAZYADD(new_overlays, I)
-	if(LAZYLEN(new_overlays))
-		add_overlay(new_overlays)
+			I.plane = plane
+			I.layer = layer
+			I.alpha = alpha
+			I.color = color
+			I.name = name
+			appearance = I
+			set_dir(SOUTH)
+			set_appearance = TRUE
+	if(!set_appearance)
+		icon_state = JOINTEXT(list(get_world_inventory_state(), get_clothing_state_modifier()))
+		if(markings_state_modifier && markings_color)
+			add_overlay(mutable_appearance(icon, "[icon_state][markings_state_modifier]", markings_color))
+
 	update_clothing_icon()
 
 // Used by washing machines to temporarily make clothes smell
@@ -219,6 +234,7 @@
 		to_chat(user, SPAN_WARNING("\The [src] [gender == PLURAL ? "do" : "does"] not fit you."))
 
 /obj/item/clothing/equipped(var/mob/user)
+	update_icon()
 	if(needs_vision_update())
 		update_wearer_vision()
 	return ..()
@@ -348,7 +364,7 @@
 /obj/item/clothing/proc/get_hood()
 	return null
 
-/obj/item/clothing/proc/remove_hood()
+/obj/item/clothing/proc/remove_hood(skip_update = FALSE)
 	var/obj/item/check_hood = get_hood()
 	if(!istype(check_hood) || check_hood.loc == src)
 		return
@@ -356,11 +372,13 @@
 		var/mob/M = check_hood.loc
 		M.drop_from_inventory(check_hood)
 	check_hood.forceMove(src)
-	update_clothing_icon()
+	if(!skip_update)
+		update_clothing_icon()
 
 /obj/item/clothing/dropped()
 	. = ..()
-	remove_hood()
+	remove_hood(skip_update = TRUE)
+	update_icon()
 
 /obj/item/clothing/get_alt_interactions(var/mob/user)
 	. = ..()

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -6,6 +6,7 @@
 	paint_verb = "dyed"
 	replaced_in_loadout = TRUE
 	icon_state = ICON_STATE_WORLD
+	force = 0
 
 	var/wizard_garb = 0
 	var/flash_protection = FLASH_PROTECTION_NONE	  // Sets the item's level of flash protection.

--- a/code/modules/clothing/_clothing_accessories.dm
+++ b/code/modules/clothing/_clothing_accessories.dm
@@ -83,11 +83,13 @@
 	accessory.on_attached(src, user)
 	if(accessory.accessory_removable)
 		src.verbs |= /obj/item/clothing/proc/removetie_verb
+	update_icon()
 
 /obj/item/clothing/proc/remove_accessory(mob/user, obj/item/clothing/accessory)
 	if(!accessory || !(accessory in accessories) || !accessory.accessory_removable || !accessory.canremove)
 		return
 	accessory.on_removed(user)
+	update_icon()
 
 /obj/item/clothing/proc/removetie_verb()
 	set name = "Remove Accessory"
@@ -180,16 +182,6 @@
 		var/obj/item/clothing/uniform = loc
 		if(uniform.should_hide_accessory(accessory_hide_on_states))
 			return FALSE
-
-/obj/item/clothing/proc/get_attached_overlay_state()
-	return "attached"
-
-/obj/item/clothing/proc/get_attached_inventory_overlay(var/base_state)
-	var/find_state = "[base_state]-[get_attached_overlay_state()]"
-	if(find_state && check_state_in_icon(find_state, icon))
-		var/image/ret = image(icon, find_state)
-		ret.color = color
-		return ret
 
 /obj/item/clothing/OnDisguise(obj/item/copy, mob/user)
 	. = ..()

--- a/code/modules/clothing/ears/_ears.dm
+++ b/code/modules/clothing/ears/_ears.dm
@@ -8,6 +8,7 @@
 	w_class = ITEM_SIZE_TINY
 	throwforce = 2
 	slot_flags = SLOT_EARS
+	fallback_slot = slot_l_ear_str
 
 /obj/item/clothing/ears/get_associated_equipment_slots()
 	. = ..()

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -7,6 +7,7 @@
 	w_class = ITEM_SIZE_SMALL
 	body_parts_covered = SLOT_EYES
 	slot_flags = SLOT_EYES
+	fallback_slot = slot_glasses_str
 
 	var/vision_flags =     0
 	var/darkness_view =    0

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -6,6 +6,7 @@
 	w_class             = ITEM_SIZE_SMALL
 	slot_flags          = SLOT_HEAD
 	body_parts_covered  = SLOT_HEAD
+	fallback_slot       = slot_head_str
 
 	var/protects_against_weather = FALSE
 	var/light_applied

--- a/code/modules/clothing/masks/_mask.dm
+++ b/code/modules/clothing/masks/_mask.dm
@@ -8,6 +8,7 @@
 	material = /decl/material/solid/fiberglass
 	matter = list(/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT)
 	origin_tech = @'{"materials":1,"engineering":1}'
+	fallback_slot = slot_wear_mask_str
 
 	var/voicechange = 0
 	var/list/say_messages

--- a/code/modules/clothing/pants/_pants.dm
+++ b/code/modules/clothing/pants/_pants.dm
@@ -7,7 +7,6 @@
 	permeability_coefficient = 0.90
 	slot_flags = SLOT_UPPER_BODY // SLOT_LOWER_BODY when pants slot exists
 	w_class = ITEM_SIZE_NORMAL
-	force = 0
 	fallback_slot = slot_w_uniform_str
 	valid_accessory_slots = list(
 		ACCESSORY_SLOT_SENSORS,

--- a/code/modules/clothing/rings/_ring.dm
+++ b/code/modules/clothing/rings/_ring.dm
@@ -5,4 +5,5 @@
 	icon_state = ICON_STATE_WORLD
 	slot_flags = SLOT_HANDS
 	gender = NEUTER
+	fallback_slot = slot_gloves_str
 	var/can_fit_under_gloves = TRUE

--- a/code/modules/clothing/sensors/_sensor.dm
+++ b/code/modules/clothing/sensors/_sensor.dm
@@ -2,6 +2,7 @@
 	name = "sensor"
 	abstract_type = /obj/item/clothing/sensor
 	accessory_slot = ACCESSORY_SLOT_SENSORS
+	fallback_slot = slot_tie_str
 
 /obj/item/clothing/sensor/get_mob_overlay(mob/user_mob, slot, bodypart, use_fallback_if_icon_missing = TRUE, skip_adjustment = FALSE)
 	return new /image

--- a/code/modules/clothing/shirts/_shirts.dm
+++ b/code/modules/clothing/shirts/_shirts.dm
@@ -5,7 +5,6 @@
 	slot_flags = SLOT_UPPER_BODY
 	w_class = ITEM_SIZE_SMALL
 	accessory_slot = ACCESSORY_SLOT_DECOR
-	force = 0
 	fallback_slot = slot_w_uniform_str
 
 /obj/item/clothing/shirt/get_associated_equipment_slots()

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -136,7 +136,6 @@
 	name = "bunny slippers"
 	desc = "Fluffy!"
 	icon = 'icons/clothing/feet/bunny_slippers.dmi'
-	force = 0
 	bodytype_equip_flags = null
 	w_class = ITEM_SIZE_SMALL
 	can_add_hidden_item = FALSE

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -6,7 +6,7 @@
 	permeability_coefficient = 0.90
 	slot_flags = SLOT_UPPER_BODY
 	w_class = ITEM_SIZE_NORMAL
-	force = 0
+	fallback_slot = slot_w_uniform_str
 
 	valid_accessory_slots = list(
 		ACCESSORY_SLOT_SENSORS,
@@ -20,7 +20,7 @@
 		ACCESSORY_SLOT_MEDAL,
 		ACCESSORY_SLOT_INSIGNIA,
 		ACCESSORY_SLOT_OVER
-		)
+	)
 
 	restricted_accessory_slots = list(
 		ACCESSORY_SLOT_UTILITY,
@@ -29,9 +29,10 @@
 		ACCESSORY_SLOT_RANK,
 		ACCESSORY_SLOT_DEPT,
 		ACCESSORY_SLOT_OVER
-		)
+	)
 
 /obj/item/clothing/under/get_associated_equipment_slots()
 	. = ..()
 	var/static/list/under_slots = list(slot_w_uniform_str, slot_wear_id_str)
 	LAZYDISTINCTADD(., under_slots)
+

--- a/code/unit_tests/clothing.dm
+++ b/code/unit_tests/clothing.dm
@@ -63,6 +63,10 @@
 
 		clothes = new clothes
 
+		// Check if the clothing has a fallback icon slot.
+		if(!clothes.get_fallback_slot(slot_w_uniform_str))
+			clothing_fails += "null or false fallback slot"
+
 		// Check if the clothing has all expected states.
 		var/decl/species/default_species = get_species_by_key(SPECIES_HUMAN)
 		var/decl/bodytype/default_bodytype = default_species.default_bodytype


### PR DESCRIPTION
## Description of changes
- Instead of relying on bespoke states defined on all clothing, clothing worn as an accessory will just force the topmost item to use the south-facing mob appearance for its world icon.
- Added some fallback slots to clothing without one defined and added a check for this to the unit test.

## Why and what will this PR improve
Accessories are now properly visible when equipped and clothing should never fail to have a fallback icon.

## Authorship
Myself.

## Changelog
Nothing player-facing, really.