### PR TITLE
Examining a mob shows non-high-vis accessories worn in ensemble.

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -20,6 +20,13 @@
 #define ACCESSORY_SLOT_OVER     "Over"
 #define ACCESSORY_SLOT_SENSORS  "Suit Sensors"
 
+// Accessory will be shown as part of the name of the item when examined.
+#define ACCESSORY_VISIBILITY_ENSEMBLE   0
+// Accessory will be shown as 'with a [foo] attached'.
+#define ACCESSORY_VISIBILITY_ATTACHMENT 1
+// Accessory will only be shown on 'view accessories'.
+#define ACCESSORY_VISIBILITY_HIDDEN     2
+
 // Bitmasks for the flags_inv variable. These determine when a piece of clothing hides another, i.e. a helmet hiding glasses.
 // WARNING: The following flags apply only to the external suit!
 #define HIDEGLOVES         BITFLAG(0)

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -853,14 +853,20 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 /obj/item/proc/pwr_drain()
 	return 0 // Process Kill
 
-/obj/item/proc/get_examine_line()
+/obj/item/proc/get_examine_name()
+	. = name
 	if(coating)
-		. = SPAN_WARNING("[html_icon(src)] [gender==PLURAL?"some":"a"] <font color='[coating.get_color()]'>stained</font> [name]")
+		. = SPAN_WARNING("<font color='[coating.get_color()]'>stained</font> [.]")
+	if(gender == PLURAL)
+		. = "some [.]"
 	else
-		. = "[html_icon(src)] \a [src]"
+		. = "\a [.]"
+
+/obj/item/proc/get_examine_line()
+	. = "[html_icon(src)] [get_examine_name()]"
 	var/ID = GetIdCard()
 	if(ID)
-		. += "  <a href='?src=\ref[ID];look_at_id=1'>\[Look at ID\]</a>"
+		. += " <a href='?src=\ref[ID];look_at_id=1'>\[Look at ID\]</a>"
 
 /obj/item/proc/on_active_hand()
 

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -239,11 +239,20 @@
 		reconsider_single_icon()
 		update_clothing_icon()
 
+/obj/item/clothing/get_examine_name()
+	var/list/ensemble = list(name)
+	for(var/obj/item/clothing/accessory in accessories)
+		if(accessory.accessory_visibility == ACCESSORY_VISIBILITY_ENSEMBLE)
+			LAZYADD(ensemble, accessory.get_examine_name())
+	if(length(ensemble) <= 1)
+		return ..()
+	return english_list(ensemble, summarize = TRUE)
+
 /obj/item/clothing/get_examine_line()
 	. = ..()
 	var/list/ties
 	for(var/obj/item/clothing/accessory in accessories)
-		if(accessory.accessory_high_visibility)
+		if(accessory.accessory_visibility == ACCESSORY_VISIBILITY_ATTACHMENT)
 			LAZYADD(ties, "\a [accessory.get_examine_line()]")
 	if(LAZYLEN(ties))
 		.+= " with [english_list(ties)] attached"

--- a/code/modules/clothing/_clothing_accessories.dm
+++ b/code/modules/clothing/_clothing_accessories.dm
@@ -1,10 +1,13 @@
 /obj/item/clothing
+	/// If not-null, this clothing can be equipped as an accessory.
 	var/accessory_slot
+	/// Can this accessory be removed? Defaults to TRUE.
 	var/accessory_removable
-	/// if it should appear on examine without detailed view
-	var/accessory_high_visibility
-	/// used when an accessory is meant to slow the wearer down when attached to clothing
+	/// How should this accessory behave on mob examine?
+	var/accessory_visibility = ACCESSORY_VISIBILITY_ENSEMBLE
+	/// Used when an accessory is meant to slow the wearer down when attached to clothing
 	var/accessory_slowdown
+	/// What clothing states should hide this accessory?
 	var/list/accessory_hide_on_states
 
 /obj/item/clothing/proc/get_initial_accessory_hide_on_states()

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -341,8 +341,8 @@
 	var/obj/item/clothing/copy = ..()
 	if (!copy)
 		return
-	accessory_slot            = copy.accessory_slot
-	accessory_high_visibility = copy.accessory_high_visibility
+	accessory_slot       = copy.accessory_slot
+	accessory_visibility = copy.accessory_visibility
 	return copy
 
 //*****************

--- a/code/modules/clothing/neck/stethoscope.dm
+++ b/code/modules/clothing/neck/stethoscope.dm
@@ -2,7 +2,7 @@
 	name = "stethoscope"
 	desc = "An outdated medical apparatus for listening to the sounds of the human body. It also makes you look like you know what you're doing."
 	icon = 'icons/clothing/accessories/stethoscope.dmi'
-	accessory_high_visibility = TRUE
+	accessory_visibility = ACCESSORY_VISIBILITY_ATTACHMENT
 
 /obj/item/clothing/neck/stethoscope/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	if(ishuman(target) && isliving(user) && user.a_intent == I_HELP)

--- a/code/modules/clothing/sensors/buddytag.dm
+++ b/code/modules/clothing/sensors/buddytag.dm
@@ -2,7 +2,7 @@
 	name = "buddy tag"
 	desc = "A tiny device, paired up with a counterpart set to same code. When devices are taken apart too far, they start beeping."
 	icon = 'icons/clothing/accessories/buddytag.dmi'
-	accessory_high_visibility = TRUE
+	accessory_visibility = ACCESSORY_VISIBILITY_ATTACHMENT
 	var/next_search = 0
 	var/on = 0
 	var/id = 1

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -9,7 +9,7 @@
 	body_parts_covered = SLOT_UPPER_BODY|SLOT_LOWER_BODY|SLOT_ARMS|SLOT_LEGS
 	siemens_coefficient = 0.9
 	accessory_slot = ACCESSORY_SLOT_OVER
-	accessory_high_visibility = TRUE
+	accessory_visibility = ACCESSORY_VISIBILITY_ATTACHMENT
 
 /obj/item/clothing/suit/cloak/on_update_icon()
 	. = ..()

--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -141,6 +141,7 @@
 	name = "master armor"
 	icon = 'icons/clothing/accessories/tags/tag_small.dmi'
 	icon_state = ICON_STATE_WORLD
+	accessory_visibility = ACCESSORY_VISIBILITY_HIDDEN
 
 //Decorative attachments
 /obj/item/clothing/accessory/armor/tag

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/clothing/accessories/storage/webbing.dmi'
 	w_class = ITEM_SIZE_NORMAL
 	accessory_slot = ACCESSORY_SLOT_UTILITY
-	accessory_high_visibility = TRUE
+	accessory_visibility = ACCESSORY_VISIBILITY_ATTACHMENT
 	storage = /datum/storage/pockets
 
 /obj/item/clothing/webbing/webbing_large


### PR DESCRIPTION
## Description of changes
Ensemble clothing shows as 'a formal suit, a long yellow tie and a tan jacket' instead of 'a formal suit' with the others only shown in 'see accessories'.

## Why and what will this PR improve
Nicer examine.

## Authorship
Myself.

## Changelog
:cl:
tweak: Non-high vis accessories on clothes will show as part of the examine string.
/:cl: