### PR TITLE
Make vendors include products in matter

### DIFF
--- a/code/datums/repositories/atom_info.dm
+++ b/code/datums/repositories/atom_info.dm
@@ -43,6 +43,7 @@ var/global/repository/atom_info/atom_info_repository = new()
 		qdel(instance)
 
 /repository/atom_info/proc/get_matter_for(var/path, var/material, var/amount)
+	RETURN_TYPE(/list)
 	var/key = create_key_for(path, material, amount)
 	update_cached_info_for(path, material, amount, key)
 	. = matter_cache[key]

--- a/code/datums/vending/stored_item.dm
+++ b/code/datums/vending/stored_item.dm
@@ -81,3 +81,15 @@
 	storing_object = new_storing_obj
 	for(var/atom/movable/thing in instances)
 		thing.forceMove(new_storing_obj)
+
+/datum/stored_items/proc/get_combined_matter(include_instances = TRUE)
+	var/virtual_amount = amount - length(instances)
+	if(virtual_amount)
+		. = atom_info_repository.get_matter_for(item_path)?.Copy()
+		for(var/key in .)
+			.[key] *= virtual_amount
+	else
+		. = list()
+	if(include_instances)
+		for(var/atom/instance in instances)
+			. = MERGE_ASSOCS_WITH_NUM_VALUES(., instance.get_contained_matter())

--- a/code/game/machinery/vending_deconstruction.dm
+++ b/code/game/machinery/vending_deconstruction.dm
@@ -38,6 +38,16 @@
 			return TRUE
 	. = ..()
 
+/obj/structure/vending_refill/get_contained_matter()
+	. = ..()
+	for(var/datum/stored_items/vending_products/record in product_records)
+		. = MERGE_ASSOCS_WITH_NUM_VALUES(., record.get_combined_matter(include_instances = FALSE))
+
+/obj/machinery/vending/get_contained_matter()
+	. = ..()
+	for(var/datum/stored_items/vending_products/record in product_records)
+		. = MERGE_ASSOCS_WITH_NUM_VALUES(., record.get_combined_matter(include_instances = FALSE))
+
 /obj/machinery/vending/dismantle()
 	var/obj/structure/vending_refill/dump = new(loc)
 	dump.SetName("[dump.name] ([name])")


### PR DESCRIPTION
## Description of changes
Vendors now include their stored products in matter, including properly handling virtual and real contents.

## Why and what will this PR improve
You can recycle vending machine and vending refill object contents using decompiler grenades now, which means the products aren't wasted.