### PR TITLE
Fix being unable to open storage on accessories

### DIFF
--- a/code/datums/extensions/storage/subtypes_tray.dm
+++ b/code/datums/extensions/storage/subtypes_tray.dm
@@ -4,7 +4,7 @@
 	allow_quick_gather = 1
 	use_sound = null
 
-/datum/storage/remove_from_storage(mob/user, obj/item/W, atom/new_location, skip_update)
+/datum/storage/tray/remove_from_storage(mob/user, obj/item/W, atom/new_location, skip_update)
 	. = ..()
 	W.vis_flags = initial(W.vis_flags)
 	W.appearance_flags = initial(W.appearance_flags)

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -10,7 +10,7 @@
 	var/material_health_multiplier = 0.2
 	var/hitsound
 	/// This is used to determine on which slots an item can fit.
-	var/slot_flags = SLOT_NONE      
+	var/slot_flags = SLOT_NONE
 	/// If it's an item we don't want to log attack_logs with, set this to TRUE
 	var/no_attack_log = 0
 	var/obj/item/master = null
@@ -424,13 +424,18 @@
 	. = ..()
 	squash_item()
 
+/// Whether this item can be picked up.
+/// Primarily exists to be overridden to prevent, e.g. accessories from being removed by clicking on them while worn.
+/obj/item/proc/can_be_picked_up(mob/user)
+	return !anchored
+
 /obj/item/attack_hand(mob/user)
 
 	. = ..()
 	if(.)
 		return
 
-	if(anchored)
+	if(!can_be_picked_up(user))
 		return ..()
 
 	if(!user.check_dexterity(DEXTERITY_EQUIP_ITEM, silent = TRUE))

--- a/code/modules/clothing/_clothing_accessories.dm
+++ b/code/modules/clothing/_clothing_accessories.dm
@@ -137,9 +137,23 @@
 			accessory.emp_act(severity)
 	..()
 
-/obj/item/clothing/attack_hand(var/mob/user)
+// Make 'strict' a bit less strict, for accessories.
+// If we're checking strictly and our parent is an accessory,
+// This will need to be handled differently if we ever allow non-clothing accessories!
+/obj/item/clothing/can_interact_with_storage(user, strict = FALSE)
+	if((. = ..(user, FALSE)) || !strict) // Ignore the parent strictness check.
+		return .
 	if(istype(loc, /obj/item/clothing))
-		return TRUE //we aren't an object on the ground so don't call parent
+		var/obj/item/clothing/parent = loc
+		return (src in parent.accessories) && loc.can_interact_with_storage(user, strict)
+	return user == loc // Same as in parent, since we pass strict = FALSE to it.
+
+/obj/item/clothing/can_be_picked_up(mob/user)
+	. = ..()
+	var/obj/item/clothing/parent = loc
+	return . && (!istype(parent) || !(src in parent.accessories))
+
+/obj/item/clothing/attack_hand(var/mob/user)
 	//only forward to the attached accessory if the clothing is equipped (not in a storage)
 	if(!length(accessories) || loc != user)
 		return ..()


### PR DESCRIPTION
## Description of changes
Clothing `attack_hand` propagates to accessories properly. `can_interact_with_storage()` now checks for accessory membership (so you can't interact with storage pouches inside storage pouches) on clothes, so that it can actually open. Picking up items checks `can_be_picked_up()` so that we can prevent accessories from being plucked off of clothes on accident.

## Why and what will this PR improve
Fixes #3946.