### PR TITLE
Backports pheromones from Scav.

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -188,7 +188,6 @@
 #define BP_VOICE             "vocal synthesiser"
 #define BP_STACK             "stack"
 #define BP_OPTICS            "optics"
-#define BP_SYSTEM_CONTROLLER "system controller"
 
 //Augmetations
 #define BP_AUGMENT_R_ARM        "right arm augment"

--- a/code/datums/extensions/scent/_scent.dm
+++ b/code/datums/extensions/scent/_scent.dm
@@ -63,7 +63,7 @@ Scent intensity
 		return PROCESS_KILL
 	emit_scent()
 
-/datum/extension/scent/proc/check_smeller(var/mob/living/carbon/human/smeller)
+/datum/extension/scent/proc/check_smeller(var/mob/living/smeller)
 	if(!istype(smeller) || smeller.stat != CONSCIOUS || smeller.failed_last_breath)
 		return FALSE
 	if(smeller.get_equipped_item(slot_wear_mask_str))
@@ -82,7 +82,7 @@ Scent intensity
 			continue
 		show_smell(M)
 
-/datum/extension/scent/proc/show_smell(var/mob/living/carbon/human/smeller)
+/datum/extension/scent/proc/show_smell(var/mob/living/smeller)
 	if(LAZYACCESS(smeller.smell_cooldown, scent) < world.time)
 		intensity.PrintMessage(smeller, descriptor, scent)
 		LAZYSET(smeller.smell_cooldown, scent, world.time + intensity.cooldown)

--- a/code/modules/emotes/definitions/_mob.dm
+++ b/code/modules/emotes/definitions/_mob.dm
@@ -5,9 +5,7 @@
 	. = ..()
 	var/decl/species/my_species = get_species()
 	if(LAZYLEN(my_species?.default_emotes))
-		LAZYINITLIST(.)
-		. |= my_species.default_emotes
+		LAZYDISTINCTADD(., my_species.default_emotes)
 	var/decl/bodytype/my_bodytype = get_bodytype()
 	if(LAZYLEN(my_bodytype?.default_emotes))
-		LAZYINITLIST(.)
-		. |= my_bodytype.default_emotes
+		LAZYDISTINCTADD(., my_bodytype.default_emotes)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -39,7 +39,6 @@
 	worn_underwear = null
 	QDEL_NULL(attack_selector)
 	QDEL_NULL(vessel)
-	LAZYCLEARLIST(smell_cooldown)
 	. = ..()
 
 /mob/living/carbon/human/get_ingested_reagents()

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -59,7 +59,6 @@
 	/// vars for fountain of youth examine lines
 	var/became_older
 	var/became_younger
-	var/list/smell_cooldown
 	/// var for caching last pain calc to avoid looping through organs over and over and over again
 	var/last_pain
 	var/vital_organ_missing_time

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -1,16 +1,6 @@
 /****************
  true human verbs
 ****************/
-/mob/living/carbon/human/verb/sniff_verb()
-	set name = "Sniff"
-	set desc = "Smell the local area."
-	set category = "IC"
-	set src = usr
-	if(!incapacitated())
-		if(species.sniff_message_3p && species.sniff_message_1p)
-			visible_message(SPAN_NOTICE("\The [src] [species.sniff_message_3p]."), SPAN_NOTICE(species.sniff_message_1p))
-		LAZYCLEARLIST(smell_cooldown)
-
 /mob/living/carbon/human/proc/tie_hair()
 	set name = "Tie Hair"
 	set desc = "Style your hair."

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -687,6 +687,7 @@ default behaviour is:
 	QDEL_NULL(aiming)
 	QDEL_NULL_LIST(_hallucinations)
 	QDEL_NULL_LIST(aimed_at_by)
+	LAZYCLEARLIST(smell_cooldown)
 	if(stressors) // Do not QDEL_NULL, keys are managed instances.
 		stressors = null
 	if(auras)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -75,3 +75,5 @@
 
 	/// Whether this mob's ability to stand has been affected
 	var/stance_damage = 0
+
+	var/list/smell_cooldown

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -107,3 +107,20 @@
  */
 /mob/living/proc/can_devour(atom/movable/victim)
 	return FALSE
+
+/mob/living/verb/sniff_verb()
+	set name = "Sniff"
+	set desc = "Smell the local area."
+	set category = "IC"
+	set src = usr
+
+	var/decl/species/my_species = get_species()
+	if(incapacitated())
+		to_chat(src, SPAN_WARNING("You can't sniff right now."))
+		return
+
+	if(my_species && my_species.sniff_message_3p && my_species.sniff_message_1p)
+		visible_message(SPAN_NOTICE("\The [src] [my_species.sniff_message_3p]."), SPAN_NOTICE(my_species.sniff_message_1p))
+	else
+		visible_message(SPAN_NOTICE("\The [src] sniffs the air."), SPAN_NOTICE("You sniff the air."))
+	LAZYCLEARLIST(smell_cooldown)

--- a/maps/exodus/exodus.dm
+++ b/maps/exodus/exodus.dm
@@ -15,6 +15,7 @@
 	#include "../../mods/mobs/borers/_borers.dme"
 
 	#include "../../mods/species/ascent/_ascent.dme"
+	#include "../../mods/content/pheromones/_pheromones.dme"
 	#include "../../mods/species/serpentid/_serpentid.dme"
 	#include "../../mods/species/utility_frames/_utility_frames.dme"
 	#include "../../mods/species/bayliens/_bayliens.dme"

--- a/maps/ministation/ministation.dm
+++ b/maps/ministation/ministation.dm
@@ -22,6 +22,7 @@ Twice...
 	#include "../../mods/content/matchmaking/_matchmaking.dme"
 	#include "../../mods/species/ascent/_ascent.dme"
 	#include "../../mods/species/neoavians/_neoavians.dme"
+	#include "../../mods/content/pheromones/_pheromones.dme"
 	#include "../../mods/species/serpentid/_serpentid.dme"
 	#include "../../mods/species/bayliens/_bayliens.dme"
 	#include "../../mods/content/mundane.dm"

--- a/maps/modpack_testing/modpack_testing.dm
+++ b/maps/modpack_testing/modpack_testing.dm
@@ -18,10 +18,12 @@
 	#include "../../mods/content/psionics/_psionics.dme"
 	#include "../../mods/content/shackles/_shackles.dme"
 	#include "../../mods/content/xenobiology/_xenobiology.dme"
+	#include "../../mods/content/pheromones/_pheromones.dme"
 
 	#include "../../mods/mobs/dionaea/_dionaea.dme"
 	#include "../../mods/mobs/borers/_borers.dme"
 
+	#include "../../mods/species/serpentid/_serpentid.dme"
 	#include "../../mods/species/ascent/_ascent.dme"
 	#include "../../mods/species/neoavians/_neoavians.dme"
 	#include "../../mods/species/utility_frames/_utility_frames.dme"

--- a/maps/tradeship/tradeship.dm
+++ b/maps/tradeship/tradeship.dm
@@ -17,6 +17,7 @@
 	#include "../../mods/content/scaling_descriptors.dm"
 	#include "../../mods/content/xenobiology/_xenobiology.dme"
 	#include "../../mods/content/matchmaking/_matchmaking.dme"
+	#include "../../mods/content/pheromones/_pheromones.dme"
 
 	#include "../../mods/mobs/dionaea/_dionaea.dme"
 	#include "../../mods/mobs/borers/_borers.dme"

--- a/mods/content/pheromones/_pheromones.dm
+++ b/mods/content/pheromones/_pheromones.dm
@@ -1,0 +1,6 @@
+#define BP_PHEROMONE_GLAND "pheromone gland"
+
+var/global/list/pheromone_markers = list()
+
+/decl/modpack/pheromones
+	name = "Pheromones Content"

--- a/mods/content/pheromones/_pheromones.dme
+++ b/mods/content/pheromones/_pheromones.dme
@@ -1,0 +1,8 @@
+#ifndef MODPACK_PHEROMONES
+#define MODPACK_PHEROMONES
+#include "_pheromones.dm"
+#include "pheromone_effect.dm"
+#include "pheromone_emotes.dm"
+#include "pheromone_implant.dm"
+#include "pheromone_mob.dm"
+#endif

--- a/mods/content/pheromones/pheromone_effect.dm
+++ b/mods/content/pheromones/pheromone_effect.dm
@@ -1,0 +1,65 @@
+/datum/extension/scent/custom/pheromone/check_smeller(var/mob/living/smeller)
+	. = (..() && istype(smeller) && smeller.can_read_pheromones())
+
+/obj/effect/decal/cleanable/pheromone
+	name = "pheromone trace"
+	invisibility = INVISIBILITY_MAXIMUM
+	alpha = 0
+	scent_type = /datum/extension/scent/custom/pheromone
+	var/image/marker
+
+/obj/effect/decal/cleanable/pheromone/proc/fade()
+	alpha = max(alpha-5, 0)
+	if(alpha <= 0)
+		qdel(src)
+	else
+		addtimer(CALLBACK(src, /obj/effect/decal/cleanable/pheromone/proc/fade), 300 SECONDS)
+		update_scent_marker()
+
+/obj/effect/decal/cleanable/pheromone/Initialize(ml, _age)
+	. = ..()
+	addtimer(CALLBACK(src, /obj/effect/decal/cleanable/pheromone/proc/fade), 300 SECONDS)
+	marker = image(loc = src, icon = 'icons/effects/blood.dmi', icon_state = pick(list("mfloor1", "mfloor2", "mfloor3", "mfloor4", "mfloor5", "mfloor6", "mfloor7")))
+	marker.alpha = 90
+	marker.plane = ABOVE_LIGHTING_PLANE
+	marker.layer = ABOVE_LIGHTING_LAYER
+
+/obj/effect/decal/cleanable/pheromone/Destroy()
+	. = ..()
+	global.pheromone_markers -= marker
+	for(var/client/C)
+		C.images -= marker
+
+/obj/effect/decal/cleanable/pheromone/proc/update_scent_marker()
+	if(!marker)
+		return
+	for(var/client/C)
+		var/mob/living/carbon/human/H = C.mob
+		if(istype(H) && H.can_read_pheromones())
+			C.images -= marker
+	var/datum/extension/scent/custom/pheromone/smell = get_extension(src, /datum/extension/scent)
+	if(!istype(smell))
+		return
+	marker.alpha = alpha
+	if(color)
+		marker.color = color
+		marker.filters = filter(type="drop_shadow", color = color + "F0", size = 2, offset = 1, x = 0, y = 0)
+	global.pheromone_markers |= marker
+	for(var/client/C)
+		var/mob/living/carbon/human/H = C.mob
+		if(istype(H) && H.can_read_pheromones())
+			C.images |= marker
+
+/obj/effect/decal/cleanable/pheromone/set_cleanable_scent()
+	. = ..()
+	update_scent_marker()
+	var/datum/extension/scent/custom/pheromone/smell = get_extension(src, /datum/extension/scent)
+	if(istype(smell))
+		for(var/mob/living/smeller in all_hearers(smell.holder, smell.range))
+			var/turf/T = get_turf(smeller.loc)
+			if(!T || !T.return_air())
+				continue
+			if(!smell.check_smeller(smeller))
+				continue
+			if(smell.scent in smeller.smell_cooldown)
+				to_chat(smeller, SPAN_NOTICE("The scent of [smell.scent] intensifies."))

--- a/mods/content/pheromones/pheromone_emotes.dm
+++ b/mods/content/pheromones/pheromone_emotes.dm
@@ -1,0 +1,92 @@
+/decl/emote/pheromone
+	abstract_type = /decl/emote/pheromone
+	var/smell_message
+	var/self_smell_descriptor
+	var/scent_color
+
+/decl/emote/pheromone/mob_can_use(mob/living/user, assume_available = FALSE)
+	return istype(user) && user.can_read_pheromones() && ..()
+
+/decl/emote/pheromone/fear
+	key = "scentfear"
+	smell_message = "<span class='danger'>FEAR</span>"
+	self_smell_descriptor = "distressing"
+	scent_color = COLOR_RED
+
+/decl/emote/pheromone/calm
+	key = "scentcalm"
+	smell_message = "<span class='notice'><b>calm</b></span>"
+	self_smell_descriptor = "soothing"
+	scent_color = COLOR_BLUE
+
+/decl/emote/pheromone/storm
+	key = "scentstorm"
+	smell_message = "<span class='danger'><b>an oncoming storm</b></span>"
+	self_smell_descriptor = "distressing"
+	scent_color = COLOR_ORANGE
+
+/decl/emote/pheromone/flood
+	key = "scentflood"
+	smell_message = "<span class='danger'><b>flooding tunnels</b></span>"
+	self_smell_descriptor = "frantic"
+	scent_color = COLOR_YELLOW
+
+/decl/emote/pheromone/newsisters
+	key = "scentsisters"
+	smell_message = "<span class='danger'><b>new sisters</b></span>"
+	self_smell_descriptor = "cheerful"
+	scent_color = COLOR_GREEN_GRAY
+
+/decl/emote/pheromone/foodgood
+	key = "scentgoodfood"
+	smell_message = "<span class='danger'><b>lots of good food</b></span>"
+	self_smell_descriptor = "enticing"
+	scent_color = COLOR_GREEN
+
+/decl/emote/pheromone/foodbad
+	key = "scentbadfood"
+	smell_message = "<span class='danger'><b>spoiled food</b></span>"
+	self_smell_descriptor = "disgusting"
+	scent_color = COLOR_PURPLE
+
+/decl/emote/pheromone/happy
+	key = "scenthappy"
+	smell_message = "<span class='danger'><b>happiness</b></span>"
+	self_smell_descriptor = "positive"
+	scent_color = COLOR_BABY_BLUE
+
+/decl/emote/pheromone/sad
+	key = "scentsad"
+	smell_message = "<span class='danger'><b>sadness</b></span>"
+	self_smell_descriptor = "ennervating"
+	scent_color = COLOR_INDIGO
+
+/decl/emote/pheromone/do_emote(var/atom/user, var/extra_params)
+	if(!ismob(user))
+		return
+	var/mob/M = user
+	if(M.incapacitated())
+		return
+	var/turf/T = get_turf(M)
+	if(!T)
+		return
+	to_chat(user, SPAN_NOTICE("You emit the [self_smell_descriptor ? "[self_smell_descriptor] " : ""]scent of [smell_message]."))
+	for(var/mob/living/carbon/human/H in viewers(world.view, user))
+		if(H != user && H.stat == CONSCIOUS && H.can_read_pheromones())
+			to_chat(H, SPAN_NOTICE("\The [user] emits the [self_smell_descriptor ? "[self_smell_descriptor] " : ""]scent of [smell_message]."))
+
+	var/obj/effect/decal/cleanable/pheromone/pheromone = (locate() in T) || new(T)
+	pheromone.color = scent_color || get_random_colour()
+	pheromone.alpha = min(pheromone.alpha+30, 120)
+	pheromone.cleanable_scent = smell_message
+	pheromone.desc = "It smells of [smell_message]."
+	pheromone.set_cleanable_scent()
+
+/decl/emote/pheromone/custom
+	key = "scentcustom"
+
+/decl/emote/pheromone/custom/do_emote(var/atom/user, var/extra_params)
+	var/new_smell = sanitize(extra_params || input("Please enter a short pheromone message.", "Pheromone") as text|null, max_length = MAX_LNAME_LEN)
+	if(new_smell)
+		smell_message = new_smell
+		. = ..()

--- a/mods/content/pheromones/pheromone_implant.dm
+++ b/mods/content/pheromones/pheromone_implant.dm
@@ -1,0 +1,8 @@
+/obj/item/implant/pheromone
+	name = "pheromone implant"
+	desc = "A civilian grade implant for communicating with Indrel via pheromones."
+	origin_tech = "{'materials':1,'biotech':1}"
+
+/obj/item/implanter/pheromone
+	name = "implanter (P)"
+	imp = /obj/item/implant/pheromone

--- a/mods/content/pheromones/pheromone_mob.dm
+++ b/mods/content/pheromones/pheromone_mob.dm
@@ -1,0 +1,44 @@
+
+/mob/living/Login()
+	. = ..()
+	update_pheromone_markers()
+
+/mob/living/proc/update_pheromone_markers()
+	if(client)
+		if(can_read_pheromones())
+			client.images |= global.pheromone_markers
+		else
+			client.images -= global.pheromone_markers
+
+/mob/living/proc/can_read_pheromones()
+	var/obj/item/organ/internal/pheromone_gland/gland = GET_INTERNAL_ORGAN(src, BP_PHEROMONE_GLAND)
+	if(istype(gland) && !gland.is_broken())
+		return TRUE
+	var/obj/item/implant/pheromone/imp = locate() in get_organ(BP_HEAD)
+	if(imp && imp.implanted && !imp.malfunction)
+		return TRUE
+	return FALSE
+
+/obj/item/organ/internal/pheromone_gland
+	name = "pheromone gland"
+	desc = "A miscellenaous lump of flesh full of chemicals."
+	icon_state = "stomach"
+	organ_tag = BP_PHEROMONE_GLAND
+	parent_organ = BP_CHEST
+
+/mob/living/get_default_emotes()
+	. = ..()
+	if(can_read_pheromones())
+		var/static/list/pheromone_emotes = list(
+			/decl/emote/pheromone/fear,
+			/decl/emote/pheromone/calm,
+			/decl/emote/pheromone/storm,
+			/decl/emote/pheromone/flood,
+			/decl/emote/pheromone/newsisters,
+			/decl/emote/pheromone/foodgood,
+			/decl/emote/pheromone/foodbad,
+			/decl/emote/pheromone/happy,
+			/decl/emote/pheromone/sad,
+			/decl/emote/pheromone/custom
+		)
+		LAZYDISTINCTADD(., pheromone_emotes)

--- a/mods/species/ascent/ascent.dm
+++ b/mods/species/ascent/ascent.dm
@@ -8,6 +8,7 @@
 #define BODY_FLAG_ALATE BITFLAG(4)
 #define BODY_FLAG_GYNE  BITFLAG(5)
 
+#define BP_SYSTEM_CONTROLLER "system controller"
 
 #define MANTIDIFY(_thing, _name, _desc) \
 ##_thing/ascent/name = _name; \

--- a/mods/species/serpentid/datum/species_bodytypes.dm
+++ b/mods/species/serpentid/datum/species_bodytypes.dm
@@ -13,13 +13,13 @@
 	base_eye_color =  "#3f0505"
 	mob_size = MOB_SIZE_LARGE
 	has_organ = list(
-		BP_BRAIN =             /obj/item/organ/internal/brain/insectoid/serpentid,
-		BP_EYES =              /obj/item/organ/internal/eyes/insectoid/serpentid,
-		BP_TRACH =             /obj/item/organ/internal/lungs/insectoid/serpentid,
-		BP_HEART =             /obj/item/organ/internal/heart/open,
-		BP_LIVER =             /obj/item/organ/internal/liver/insectoid/serpentid,
-		BP_STOMACH =           /obj/item/organ/internal/stomach/insectoid,
-		BP_SYSTEM_CONTROLLER = /obj/item/organ/internal/controller
+		BP_BRAIN           = /obj/item/organ/internal/brain/insectoid/serpentid,
+		BP_EYES            = /obj/item/organ/internal/eyes/insectoid/serpentid,
+		BP_TRACH           = /obj/item/organ/internal/lungs/insectoid/serpentid,
+		BP_HEART           = /obj/item/organ/internal/heart/open,
+		BP_LIVER           = /obj/item/organ/internal/liver/insectoid/serpentid,
+		BP_STOMACH         = /obj/item/organ/internal/stomach/insectoid,
+		BP_PHEROMONE_GLAND = /obj/item/organ/internal/pheromone_gland
 	)
 
 	eye_darksight_range = 8
@@ -28,20 +28,20 @@
 	eye_icon = 'mods/species/serpentid/icons/eyes.dmi'
 
 	has_limbs = list(
-		BP_CHEST =        list("path" = /obj/item/organ/external/chest/insectoid/serpentid),
-		BP_GROIN =        list("path" = /obj/item/organ/external/groin/insectoid/serpentid),
-		BP_HEAD =         list("path" = /obj/item/organ/external/head/insectoid/serpentid),
-		BP_L_ARM =        list("path" = /obj/item/organ/external/arm/insectoid),
-		BP_L_HAND =       list("path" = /obj/item/organ/external/hand/insectoid),
+		BP_CHEST        = list("path" = /obj/item/organ/external/chest/insectoid/serpentid),
+		BP_GROIN        = list("path" = /obj/item/organ/external/groin/insectoid/serpentid),
+		BP_HEAD         = list("path" = /obj/item/organ/external/head/insectoid/serpentid),
+		BP_L_ARM        = list("path" = /obj/item/organ/external/arm/insectoid),
+		BP_L_HAND       = list("path" = /obj/item/organ/external/hand/insectoid),
 		BP_L_HAND_UPPER = list("path" = /obj/item/organ/external/hand/insectoid/upper),
-		BP_R_ARM =        list("path" = /obj/item/organ/external/arm/right/insectoid),
-		BP_R_HAND =       list("path" = /obj/item/organ/external/hand/right/insectoid),
+		BP_R_ARM        = list("path" = /obj/item/organ/external/arm/right/insectoid),
+		BP_R_HAND       = list("path" = /obj/item/organ/external/hand/right/insectoid),
 		BP_R_HAND_UPPER = list("path" = /obj/item/organ/external/hand/right/insectoid/upper),
-		BP_R_LEG =        list("path" = /obj/item/organ/external/leg/right/insectoid/serpentid),
-		BP_L_LEG =        list("path" = /obj/item/organ/external/leg/insectoid/serpentid),
-		BP_L_FOOT =       list("path" = /obj/item/organ/external/foot/insectoid/serpentid),
-		BP_R_FOOT =       list("path" = /obj/item/organ/external/foot/right/insectoid/serpentid)
-		)
+		BP_R_LEG        = list("path" = /obj/item/organ/external/leg/right/insectoid/serpentid),
+		BP_L_LEG        = list("path" = /obj/item/organ/external/leg/insectoid/serpentid),
+		BP_L_FOOT       = list("path" = /obj/item/organ/external/foot/insectoid/serpentid),
+		BP_R_FOOT       = list("path" = /obj/item/organ/external/foot/right/insectoid/serpentid)
+	)
 
 	limb_mapping = list(
 		BP_L_HAND = list(BP_L_HAND, BP_L_HAND_UPPER),


### PR DESCRIPTION
## Description of changes
- Adds a modpack for leaving pheremone traces around the place via a set of emotes. They have a visual effect and a zone smell for mobs that can read pheromones.
- Removes the access controller from the base serpentid.

## Why and what will this PR improve
Nice little feature that makes serpentid more unique on Neb.

## Authorship
Myself.

## Changelog
:cl:
tweak: Serpentid can now leave pheremone traces with a set of emotes.
/:cl:
