### PR TITLE
Fix farmbots infinite loop

### DIFF
--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -268,7 +268,7 @@
 	if(tray.dead && removes_dead || tray.harvest && collects_produce)
 		return FARMBOT_COLLECT
 
-	else if(refills_water && tray.waterlevel < 40 && !tray.reagents.has_reagent(/decl/material/liquid/water))
+	else if(refills_water && tray.waterlevel < 40 && !tray.reagents.has_reagent(/decl/material/liquid/water) && (tank?.reagents.total_volume > 0))
 		return FARMBOT_WATER
 
 	else if(uproots_weeds && tray.weedlevel > 3)


### PR DESCRIPTION
## Description of changes
Farm bot ai would cause an infinite loop and hog massive amounts of CPU by trying to constantly water the nearest plant while it was out of water.

## Changelog
:cl:
bugfix: Fixed farmbot lagging the server when running out of water while watering a plant.
/:cl: