### PR TITLE
Adding plant oil as a lantern fuel for the fantasy map.

### DIFF
--- a/code/game/objects/items/flame/flame_fuelled.dm
+++ b/code/game/objects/items/flame/flame_fuelled.dm
@@ -7,26 +7,37 @@
 
 	var/tmp/max_fuel      = 5
 	var/tmp/start_fuelled = FALSE
-	var/fuel_type         = /decl/material/liquid/fuel
+
+	/// TODO: make this calculate a fuel amount via accelerant value or some other check.
+	/// Reagent type to burn as fuel. If null, will use the map default.
+	var/fuel_type
 
 /obj/item/flame/fuelled/Initialize()
 	. = ..()
+	if(isnull(fuel_type))
+		fuel_type = global.using_map.default_liquid_fuel_type
 	initialize_reagents()
 
 /obj/item/flame/fuelled/examine(mob/user, distance)
 	. = ..()
-	if(distance <= 1 && reagents?.maximum_volume && user)
-		switch(reagents.total_volume / reagents.maximum_volume)
-			if(0 to 0.1)
-				to_chat(user, SPAN_WARNING("\The [src] is nearly empty."))
-			if(0.1 to 0.25)
-				to_chat(user, SPAN_NOTICE("\The [src] is one-quarter full."))
-			if(0.25 to 0.5)
-				to_chat(user, SPAN_NOTICE("\The [src] is half full."))
-			if(0.5 to 0.75)
-				to_chat(user, SPAN_NOTICE("\The [src] is three-quarters full."))
-			else
-				to_chat(user, SPAN_NOTICE("\The [src] is full."))
+	if(distance <= 1 && user)
+
+		var/decl/material/fuel_reagent = GET_DECL(fuel_type)
+		if(fuel_reagent)
+			to_chat(user, SPAN_NOTICE("\The [src] is designed to burn [fuel_reagent.liquid_name]."))
+
+		if(reagents?.maximum_volume)
+			switch(reagents.total_volume / reagents.maximum_volume)
+				if(0 to 0.1)
+					to_chat(user, SPAN_WARNING("\The [src] is nearly empty."))
+				if(0.1 to 0.25)
+					to_chat(user, SPAN_NOTICE("\The [src] is one-quarter full."))
+				if(0.25 to 0.5)
+					to_chat(user, SPAN_NOTICE("\The [src] is half full."))
+				if(0.5 to 0.75)
+					to_chat(user, SPAN_NOTICE("\The [src] is three-quarters full."))
+				else
+					to_chat(user, SPAN_NOTICE("\The [src] is full."))
 
 /obj/item/flame/fuelled/get_fuel()
 	return REAGENT_VOLUME(reagents, fuel_type)
@@ -48,7 +59,7 @@
 	. = ..()
 
 /obj/item/flame/fuelled/populate_reagents()
-	if(start_fuelled)
+	if(start_fuelled && fuel_type && max_fuel)
 		add_to_reagents(fuel_type, max_fuel)
 
 /obj/item/flame/fuelled/Process()

--- a/code/modules/hydroponics/plant_types/seeds_misc.dm
+++ b/code/modules/hydroponics/plant_types/seeds_misc.dm
@@ -4,6 +4,7 @@
 	display_name = "cotton"
 	product_material = /decl/material/solid/organic/plantmatter/pith/husk
 	chems = list(
+		/decl/material/liquid/nutriment/plant_oil = list(3,10),
 		/decl/material/solid/organic/cloth = list(10,1)
 	)
 	slice_product = null
@@ -684,6 +685,9 @@
 	name = "sunflowers"
 	product_name = "sunflower"
 	display_name = "sunflower patch"
+	chems = list(
+		/decl/material/liquid/nutriment/plant_oil = list(10,10)
+	)
 
 /datum/seed/flower/sunflower/New()
 	..()
@@ -754,7 +758,10 @@
 	name = "peanut"
 	product_name = "peanut"
 	display_name = "peanut vine"
-	chems = list(/decl/material/liquid/nutriment = list(1,10))
+	chems = list(
+		/decl/material/liquid/nutriment = list(1,10),
+		/decl/material/liquid/nutriment/plant_oil = list(1,10)
+	)
 	slice_product = /obj/item/chems/food/processed_grown/chopped
 	slice_amount = 3
 
@@ -934,7 +941,11 @@
 	name = "soybeans"
 	product_name = "soybeans"
 	display_name = "soybean patch"
-	chems = list(/decl/material/liquid/nutriment = list(1,20), /decl/material/liquid/drink/milk/soymilk = list(10,20))
+	chems = list(
+		/decl/material/liquid/nutriment = list(1,20),
+		/decl/material/liquid/nutriment/plant_oil = list(3,20),
+		/decl/material/liquid/drink/milk/soymilk = list(7,20)
+	)
 	grown_tag = "soybeans"
 	slice_product = /obj/item/chems/food/processed_grown/chopped
 	slice_amount = 3

--- a/code/modules/hydroponics/seed_packets.dm
+++ b/code/modules/hydroponics/seed_packets.dm
@@ -6,6 +6,7 @@
 	w_class = ITEM_SIZE_SMALL
 	abstract_type = /obj/item/seeds
 	max_health = 10 //Can't set a material, otherwise extracting seeds would generate free materials
+	material = /decl/material/solid/organic/plantmatter/pith
 
 	var/seed_mask_icon = 'icons/obj/seeds/seed_masks.dmi'
 	var/seed_base_name = "packet"
@@ -16,7 +17,16 @@
 	if(isnull(seed) && !isnull(_seed))
 		seed = _seed
 	update_seed()
+	initialize_reagents()
 	. = ..()
+
+/obj/item/seeds/initialize_reagents()
+	create_reagents(3)
+	. = ..()
+
+/obj/item/seeds/populate_reagents()
+	. = ..()
+	add_to_reagents(/decl/material/liquid/nutriment/plant_oil, 3)
 
 /obj/item/seeds/get_single_monetary_worth()
 	. = seed ? seed.get_monetary_value() : ..()

--- a/code/modules/reagents/chems/chems_nutriment.dm
+++ b/code/modules/reagents/chems/chems_nutriment.dm
@@ -57,6 +57,18 @@
 	color = "#ffffff"
 	uid = "chem_nutriment_plant"
 
+/decl/material/liquid/nutriment/plant_oil
+	name = "plant oil"
+	lore_text = "A thin yellow oil pressed from vegetables or nuts. Useful as fuel, or in cooking."
+	uid = "chem_nutriment_plant_oil"
+	melting_point = 273
+	boiling_point = 373
+	taste_description = "oily blandness"
+	burn_product = /decl/material/gas/carbon_monoxide
+	ignition_point = T0C+150
+	accelerant_value = FUEL_VALUE_ACCELERANT
+	gas_flags = XGM_GAS_FUEL
+
 /decl/material/liquid/nutriment/honey
 	name = "honey"
 	lore_text = "A golden yellow syrup, loaded with sugary sweetness."

--- a/maps/shaded_hills/shaded_hills_map.dm
+++ b/maps/shaded_hills/shaded_hills_map.dm
@@ -1,4 +1,5 @@
 /datum/map/shaded_hills
+	default_liquid_fuel_type = /decl/material/liquid/nutriment/plant_oil
 	default_species = SPECIES_KOBALOI
 	loadout_categories = list(
 		/decl/loadout_category/fantasy/clothing,

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -161,6 +161,9 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	// A list of cash spawn options, similar to above.
 	var/list/decl/starting_cash_choice/starting_cash_choices
 
+	/// A reagent used to prefill lanterns.
+	var/default_liquid_fuel_type = /decl/material/liquid/fuel
+
 /datum/map/proc/get_lobby_track(var/exclude)
 	var/lobby_track_type
 	if(LAZYLEN(lobby_tracks) == 1)


### PR DESCRIPTION
## Description of changes
- Adds a plant oil reagent usable as nutrition or fuel.
- Adds plant oil to cotton, sunflowers, soybeans and peanuts.
- Adds plant oil to seeds of all kinds.
- Adds `default_liquid_fuel_type` to `/datum/map`, defaulting to welding fuel, but set to plant oil for Shaded Hills.
- Tweaks lanterns to take the map default liquid fuel type.

## Why and what will this PR improve
Allows lanterns to be refuelled on Shaded Hills.
Also provides a potential reagent for frying/cooking or biodiesel in the future.

## Authorship
Myself.

## Changelog
Nothing player facing, really.