### PR TITLE
Fix supply/scrubber zpipes are not colored #3650

### DIFF
--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -39,7 +39,7 @@
 	qdel(src) // NOT qdel.
 
 /obj/machinery/atmospherics/pipe/zpipe/on_update_icon()
-	return
+	color = get_color()
 
 /////////////////////////
 // the elusive up pipe //


### PR DESCRIPTION
## Description of changes
Copies a `color = get_color()` from simple pipes, which multiz pipes are not a subtype of.

## Why and what will this PR improve
Fixes #3650.