### PR TITLE
Fix "Disposal pipe dispenser outputs both construction and finished objects" #3697

### DIFF
--- a/code/modules/fabrication/designs/pipe/pipe_datum_base.dm
+++ b/code/modules/fabrication/designs/pipe/pipe_datum_base.dm
@@ -47,7 +47,7 @@
 		. += new_item
 
 /datum/fabricator_recipe/pipe/disposal_dispenser/build(var/turf/location, var/datum/fabricator_build_order/order)
-	. = ..()
+	. = list()
 	for(var/i = 1, i <= order.multiplier, i++)
 		var/obj/structure/disposalconstruct/new_item = new path(location)
 		new_item.SetName(name)


### PR DESCRIPTION
## Description of changes
Makes the disposal pipe fabrication order build() override not call parent, to avoid it calling the base pipe dispenser build() code. I considered making them not inherit from each other but I didn't want to duplicate the resource cost code.

## Why and what will this PR improve
Fixes #3697.