### PR TITLE
Cleaning up new config system comments.

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -120,13 +120,18 @@ var/global/log_end= world.system_type == UNIX ? ascii2text(13) : ""
 //pretty print a direction bitflag, can be useful for debugging.
 /proc/dir_text(var/dir)
 	var/list/comps = list()
-	if(dir & NORTH) comps += "NORTH"
-	if(dir & SOUTH) comps += "SOUTH"
-	if(dir & EAST) comps += "EAST"
-	if(dir & WEST) comps += "WEST"
-	if(dir & UP) comps += "UP"
-	if(dir & DOWN) comps += "DOWN"
-
+	if(dir & NORTH)
+		comps += "NORTH"
+	if(dir & SOUTH)
+		comps += "SOUTH"
+	if(dir & EAST)
+		comps += "EAST"
+	if(dir & WEST)
+		comps += "WEST"
+	if(dir & UP)
+		comps += "UP"
+	if(dir & DOWN)
+		comps += "DOWN"
 	return english_list(comps, nothing_text="0", and_text="|", comma_text="|")
 
 //more or less a logging utility

--- a/code/datums/config/_config.dm
+++ b/code/datums/config/_config.dm
@@ -116,14 +116,15 @@
 	SHOULD_CALL_PARENT(TRUE)
 	return
 
-/decl/config/proc/get_config_file_text()
-	. = list()
+/decl/config/proc/get_comment_desc_text()
 	if(desc)
 		if(islist(desc))
 			for(var/config_line in desc)
-				. += "## [config_line]"
+				LAZYADD(., "## [config_line]")
 		else
-			. += "## [desc]"
+			LAZYADD(., "## [desc]")
+
+/decl/config/proc/get_comment_value_text()
 	if(config_flags & CONFIG_FLAG_HAS_VALUE)
 		if(compare_values(value, default_value))
 			. += "#[uppertext(uid)] [serialize_default_value()]"
@@ -133,6 +134,19 @@
 		. += uppertext(uid)
 	else
 		. += "#[uppertext(uid)]"
+
+/decl/config/proc/get_config_file_text()
+
+	. = list()
+
+	var/add_desc = get_comment_desc_text()
+	if(!isnull(add_desc))
+		. += add_desc
+
+	var/add_value = get_comment_value_text()
+	if(!isnull(add_value))
+		. += add_value
+
 	return jointext(., "\n")
 
 /decl/config/proc/serialize_value()

--- a/code/datums/config/config_enum.dm
+++ b/code/datums/config/config_enum.dm
@@ -2,31 +2,49 @@
 	abstract_type = /decl/config/enum
 	default_value = 0
 	config_flags = CONFIG_FLAG_ENUM | CONFIG_FLAG_HAS_VALUE
-
-/decl/config/enum/proc/get_enum_map()
-	return
+	var/list/enum_map
 
 /decl/config/enum/validate()
 	. = ..()
-	if(!length(get_enum_map()))
-		. += "enum config has zero-length return to get_enum_map()"
+	if(!length(enum_map))
+		. += "enum config has zero-length enum_map"
+
+/decl/config/enum/serialize_value()
+	var/enum_val
+	for(var/val in enum_map)
+		if(value == enum_map[val])
+			enum_val = val
+			break
+	if(isnull(enum_val))
+		enum_val = handle_value_deconversion(value)
+	return "[enum_val]"
+
+/decl/config/enum/serialize_default_value()
+	var/enum_val
+	for(var/val in enum_map)
+		if(default_value == enum_map[val])
+			enum_val = val
+			break
+	if(isnull(enum_val))
+		enum_val = handle_value_deconversion(default_value)
+	return "[enum_val]"
 
 /decl/config/enum/Initialize()
 	. = ..()
-	var/list/enum_map = get_enum_map()
-	if(length(enum_map))
-		if(desc)
+	if(islist(enum_map) && length(enum_map))
+		if(islist(desc))
+			desc += "[desc] Valid values: [english_list(enum_map)]."
+		else if(desc)
 			desc = "[desc] Valid values: [english_list(enum_map)]."
 		else
-			desc = english_list(enum_map)
+			desc = "Valid values: [english_list(enum_map)]."
 
 /decl/config/enum/set_value(var/new_value)
 	if(istext(new_value))
-		var/list/enum_map = get_enum_map()
 		new_value = trim(lowertext(new_value))
 		if(new_value in enum_map)
 			new_value = enum_map[new_value]
 		else
-			log_error("Invalid key '[new_value]' supplied to [type].")
+			log_error("Invalid key '[new_value]' supplied to [type]. [json_encode(enum_map)]")
 			new_value = default_value
 	return ..(new_value)

--- a/code/datums/config/config_types/config_admin.dm
+++ b/code/datums/config/config_types/config_admin.dm
@@ -29,7 +29,7 @@
 /decl/config/num/autostealth
 	uid = "autostealth"
 	default_value = 0
-	desc = "Uncomment to enable auto-stealthing staff who are AFK for more than specified minutes."
+	desc = "Sets a value in minutes after which to auto-hide staff who are AFK."
 
 /decl/config/toggle/on/guest_jobban
 	uid = "guest_jobban"
@@ -68,12 +68,12 @@
 
 /decl/config/toggle/allow_unsafe_narrates
 	uid = "allow_unsafe_narrates"
-	desc = "Uncomment this to allow admins to narrate using HTML tags."
+	desc = "Determines if admins are allowed to narrate using HTML tags."
 
 /decl/config/toggle/visible_examine
 	uid = "visible_examine"
-	desc = "Uncomment this to show a visible message when someone examines something ('Dave looks at you.')."
+	desc = "Determines if a visible message should be shown when someone examines something ('Dave looks at you.')."
 
 /decl/config/toggle/allow_loadout_customization
 	uid = "loadout_customization"
-	desc = "Uncomment this to allow all loadout items to have name and desc customized by default."
+	desc = "Determines if all loadout items are allowed to have name and desc customized by default."

--- a/code/datums/config/config_types/config_client.dm
+++ b/code/datums/config/config_types/config_client.dm
@@ -19,12 +19,12 @@
 /decl/config/num/clients/lock_client_view_x
 	uid = "lock_client_view_x"
 	default_value = 0
-	desc = "Uncomment and set to an integer to lock the automatic client view scaling on the X axis."
+	desc = "Set to an integer to lock the automatic client view scaling on the X axis."
 
 /decl/config/num/clients/lock_client_view_y
 	uid = "lock_client_view_y"
 	default_value = 0
-	desc = "Uncomment and set to an integer to lock the automatic client view scaling on the Y axis."
+	desc = "Set to an integer to lock the automatic client view scaling on the Y axis."
 
 /decl/config/num/clients/max_client_view_x
 	uid = "max_client_view_x"
@@ -57,4 +57,4 @@
 
 /decl/config/toggle/aggressive_changelog
 	uid = "aggressive_changelog"
-	desc = "Uncomment to have the changelog file automatically open when a user connects and hasn't seen the latest changelog."
+	desc = "Determines if the changelog file should automatically open when a user connects and hasn't seen the latest changelog."

--- a/code/datums/config/config_types/config_events.dm
+++ b/code/datums/config/config_types/config_events.dm
@@ -14,14 +14,11 @@
 	uid = "objectives_disabled"
 	default_value = CONFIG_OBJECTIVE_NONE
 	desc = "Determines if objectives are disabled."
-
-/decl/config/enum/objectives_disabled/get_enum_map()
-	var/static/list/obj_enum_map = list(
+	enum_map = list(
 		"none" = CONFIG_OBJECTIVE_NONE,
 		"verb" = CONFIG_OBJECTIVE_VERB,
 		"all"  = CONFIG_OBJECTIVE_ALL
 	)
-	return obj_enum_map
 
 // No custom time, no custom time, between 80 to 100 minutes respectively.
 /decl/config/lists/event_first_run

--- a/code/datums/config/config_types/config_game_option.dm
+++ b/code/datums/config/config_types/config_game_option.dm
@@ -102,13 +102,13 @@
 /decl/config/num/max_acts_per_interval
 	uid = "max_acts_per_interval"
 	default_value = 140
-	desc = "Uncomment this to modify the number of actions permitted per interval before being kicked for spam."
+	desc = "Defines the number of actions permitted per interval before a user is kicked for spam."
 
 /decl/config/num/act_interval
 	uid = "act_interval"
 	default_value = 0.1
 	rounding = 0.01
-	desc = "Uncomment this to modify the length of the spam kicking interval in seconds."
+	desc = "Determines the length of the spam kicking interval in seconds."
 
 /decl/config/num/dex_malus_brainloss_threshold
 	uid = "dex_malus_brainloss_threshold"
@@ -141,7 +141,7 @@
 
 /decl/config/toggle/expanded_alt_interactions
 	uid = "expanded_alt_interactions"
-	desc = "Uncomment this to enable expanded alt interactions with objects."
+	desc = "Determines if objects should provide expanded alt interactions when alt-clicked, such as use or grab."
 
 /decl/config/toggle/ert_admin_call_only
 	uid = "ert_admin_call_only"
@@ -149,7 +149,7 @@
 
 /decl/config/toggle/ghosts_can_possess_animals
 	uid = "ghosts_can_possess_animals"
-	desc = "Uncomment to allow ghosts to possess any animal."
+	desc = "Determines of ghosts are allowed to possess any animal."
 
 /decl/config/toggle/assistant_maint
 	uid = "assistant_maint"

--- a/code/datums/config/config_types/config_game_world.dm
+++ b/code/datums/config/config_types/config_game_world.dm
@@ -96,19 +96,19 @@
 
 /decl/config/toggle/on/welder_vision
 	uid = "welder_vision"
-	desc = "Uncomment to disable the restrictive weldervision overlay."
+	desc = "Toggles the restrictive weldervision overlay when wearing welding goggles or a welding helmet."
 
 /decl/config/toggle/on/allow_ic_printing
 	uid = "allow_ic_printing"
-	desc = "Uncomment this to prevent players from printing copy/pasted circuits."
+	desc = "Determines if players can print copy/pasted integrated circuits."
 
 /decl/config/toggle/on/cult_ghostwriter
 	uid = "cult_ghostwriter"
-	desc = "Uncomment to allow ghosts to write in blood during Cult rounds."
+	desc = "Determines if ghosts are permitted to write in blood during cult rounds."
 
 /decl/config/toggle/allow_holidays
 	uid = "allow_holidays"
-	desc = "Remove the # to allow special 'Easter-egg' events on special holidays such as seasonal holidays and stuff like 'Talk Like a Pirate Day' :3 YAARRR"
+	desc = "Determines if special 'Easter-egg' events are active on special holidays such as seasonal holidays and stuff like 'Talk Like a Pirate Day' :3 YAARRR"
 
 /decl/config/toggle/allow_holidays/update_post_value_set()
 	. = ..()

--- a/code/datums/config/config_types/config_health.dm
+++ b/code/datums/config/config_types/config_health.dm
@@ -17,17 +17,17 @@
 /decl/config/toggle/health_adjust_healing_from_stress
 	uid = "adjust_healing_from_stress"
 	config_flags = CONFIG_FLAG_BOOL
-	desc = "Uncomment to allow stressors to impact shock, healing and blood recovery."
+	desc = "Determines if allow stressors should impact shock, healing and blood recovery."
 
 /decl/config/toggle/health_show_human_death_message
 	uid = "show_human_death_message"
 	config_flags = CONFIG_FLAG_BOOL
-	desc = "Uncomment this line to enable humans showing a visible message upon death ('X seizes up then falls limp, eyes dead and lifeless')."
+	desc = "Determines if humans should show a visible message upon death ('X seizes up then falls limp, eyes dead and lifeless')."
 
 /decl/config/toggle/health_organs_decay
 	uid = "organs_decay"
 	config_flags = CONFIG_FLAG_BOOL
-	desc = "Uncomment to enable organ decay outside of a body or storage item."
+	desc = "Determines if organs should decay outside of a body or storage item."
 
 /decl/config/toggle/on/health_bones_can_break
 	uid = "bones_can_break"

--- a/code/datums/config/config_types/config_resources.dm
+++ b/code/datums/config/config_types/config_resources.dm
@@ -15,7 +15,7 @@
 /decl/config/text/custom_icon_icon_location
 	uid = "custom_icon_icon_location"
 	default_value = "config/custom_icons/icons"
-	desc = "Uncomment this and set it to a file path relative to the executing binary to prefix all custom icon locations with this location ie. '\[CUSTOM_ICON_ICON_LOCATION\]/\[custom icon path value\]'"
+	desc = "Set this to a file path relative to the executing binary to prefix all custom icon locations with this location ie. '\[CUSTOM_ICON_ICON_LOCATION\]/\[custom icon path value\]'"
 
 /decl/config/lists/resource_urls
 	uid = "resource_urls"

--- a/code/datums/config/config_types/config_server.dm
+++ b/code/datums/config/config_types/config_server.dm
@@ -234,7 +234,7 @@
 
 /decl/config/toggle/do_not_prevent_spam
 	uid = "do_not_prevent_spam"
-	desc = "Uncomment this to DISABLE action spam kicking. Not recommended; this helps protect from spam attacks."
+	desc = "Determines if action spam kicking should be DISABLED. Not recommended; this helps protect from spam attacks."
 
 /decl/config/toggle/no_throttle_localhost
 	uid = "no_throttle_localhost"
@@ -307,11 +307,11 @@
 
 /decl/config/toggle/use_alien_whitelist
 	uid = "usealienwhitelist"
-	desc = "Uncomment to restrict non-admins from using humanoid alien races."
+	desc = "Determines if non-admins are restricted from using humanoid alien races."
 
 /decl/config/toggle/use_alien_whitelist_sql
 	uid = "usealienwhitelist_sql"
-	desc = "Uncomment to use the alien whitelist system with SQL instead. (requires the above uncommented as well)."
+	desc = "Determines if the alien whitelist should use SQL instead of the legacy system. (requires the above uncommented as well)."
 
 /decl/config/toggle/forbid_singulo_possession
 	uid = "forbid_singulo_possession"
@@ -326,31 +326,31 @@
 
 /decl/config/toggle/disable_webhook_embeds
 	uid = "disable_webhook_embeds"
-	desc = "Uncomment to make Discord webhooks send in plaintext rather than as embeds."
+	desc = "Determines if Discord webhooks should be sent in plaintext rather than as embeds."
 
 /decl/config/toggle/delist_when_no_admins
 	uid = "delist_when_no_admins"
-	desc = "Uncomment this to remove the server from the hub."
+	desc = "Determines if the server should hide itself from the hub when no admins are online.."
 
 /decl/config/toggle/wait_for_sigusr1_reboot
 	uid = "wait_for_sigusr1_reboot"
-	desc = "Uncomment to make Dream Daemon refuse to reboot for any reason other than SIGUSR1."
+	desc = "Determines if Dream Daemon should refuse to reboot for any reason other than SIGUSR1."
 
 /decl/config/toggle/use_irc_bot
 	uid = "use_irc_bot"
-	desc = "Uncomment to enable sending data to the IRC bot."
+	desc = "Determines if data is sent to the IRC bot. Generally requires MAIN_IRC and associated setup."
 
 /decl/config/toggle/show_typing_indicator_for_whispers
 	uid = "show_typing_indicator_for_whispers"
-	desc = "Uncomment this to show a typing indicator for people writing whispers."
+	desc = "Determinese if a typing indicator shows overhead for people currently writing whispers."
 
 /decl/config/toggle/announce_shuttle_dock_to_irc
 	uid = "announce_shuttle_dock_to_irc"
-	desc = "Uncomment this line to announce shuttle dock announcements to the main IRC channel, if MAIN_IRC has also been setup."
+	desc = "Determines if announce shuttle dock announcements are sent to the main IRC channel, if MAIN_IRC has also been setup."
 
 /decl/config/toggle/guests_allowed
 	uid = "guests_allowed"
-	desc = "Uncomment this to stop people connecting to your server without a registered ckey. (i.e. guest-* are all blocked from connecting)."
+	desc = "Determines whether or not people without a registered ckey (i.e. guest-*) can connect to your server."
 
 /decl/config/toggle/on/ban_legacy_system
 	uid = "ban_legacy_system"

--- a/code/datums/config/config_types/config_voting.dm
+++ b/code/datums/config/config_types/config_voting.dm
@@ -76,4 +76,4 @@
 
 /decl/config/toggle/auto_map_vote
 	uid = "auto_map_vote"
-	desc = "Uncomment to enable an automatic map vote and switch at end of round. MAP_SWITCHING must also be enabled."
+	desc = "Determines if the automatic map vote and switch are called at end of round. MAP_SWITCHING must also be enabled."

--- a/config/example/configuration.txt
+++ b/config/example/configuration.txt
@@ -15,10 +15,10 @@
 ## Allows admin item spawning.
 #ALLOW_ADMIN_SPAWNING 1
 
-## Uncomment this to allow admins to narrate using HTML tags. Uncomment to enable.
+## Determines if admins are allowed to narrate using HTML tags. Uncomment to enable.
 #ALLOW_UNSAFE_NARRATES
 
-## Uncomment to enable auto-stealthing staff who are AFK for more than specified minutes.
+## Sets a value in minutes after which to auto-hide staff who are AFK.
 #AUTOSTEALTH 0
 
 ## Set to 0/1 to disable/enable automatic admin rights for users connecting from the host the server is running on.
@@ -82,15 +82,15 @@
 ## If the first delay has a custom start time. Defined in minutes.
 #EVENT_FIRST_RUN [null,null,{"lower":80,"upper":100}]
 
-## Determines if objectives are disabled.
-#OBJECTIVES_DISABLED 2
+## Determines if objectives are disabled. Valid values: none, verb, and all.
+OBJECTIVES_DISABLED all
 
 ##
 # GAME OPTIONS
 # Configuration options relating to gameplay, such as movement, health and stamina.
 ##
 
-## Uncomment this to modify the length of the spam kicking interval in seconds.
+## Determines the length of the spam kicking interval in seconds.
 #ACT_INTERVAL 0.1
 
 ## Remove the # to let aliens spawn. Uncomment to enable.
@@ -123,13 +123,13 @@
 ## Restricted ERT to be only called by admins. Uncomment to enable.
 #ERT_ADMIN_CALL_ONLY
 
-## Uncomment this to enable expanded alt interactions with objects. Uncomment to enable.
+## Determines if objects should provide expanded alt interactions when alt-clicked, such as use or grab. Uncomment to enable.
 #EXPANDED_ALT_INTERACTIONS
 
 ## Expected round length in hours.
 #EXPECTED_ROUND_LENGTH 3
 
-## Uncomment to allow ghosts to possess any animal. Uncomment to enable.
+## Determines of ghosts are allowed to possess any animal. Uncomment to enable.
 #GHOSTS_CAN_POSSESS_ANIMALS
 
 ## Remove the # to let ghosts spin chairs. Uncomment to enable.
@@ -150,7 +150,7 @@
 ## Maximum stamina recovered per tick when resting.
 #MAXIMUM_STAMINA_RECOVERY 3
 
-## Uncomment this to modify the number of actions permitted per interval before being kicked for spam.
+## Defines the number of actions permitted per interval before a user is kicked for spam.
 #MAX_ACTS_PER_INTERVAL 140
 
 ## How many loadout points are available. Use 0 to disable loadout, and any negative number to indicate infinite points.
@@ -174,6 +174,12 @@
 ## Determines the severity of athletics skill when applied to stamina cost.
 #SKILL_SPRINT_COST_RANGE 0.8
 
+## Enables or disables checking for specific tool types by some stack crafting recipes. Uncomment to enable.
+#STACK_CRAFTING_USES_TOOLS
+
+## Enables or disables checking for specific stack types by some stack crafting recipes.
+#STACK_CRAFTING_USES_TYPES 1
+
 ## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied.
 #WALK_DELAY 4
 
@@ -182,13 +188,13 @@
 # Configuration options relating to the game world and simulation.
 ##
 
-## Remove the # to allow special 'Easter-egg' events on special holidays such as seasonal holidays and stuff like 'Talk Like a Pirate Day' :3 YAARRR Uncomment to enable.
+## Determines if special 'Easter-egg' events are active on special holidays such as seasonal holidays and stuff like 'Talk Like a Pirate Day' :3 YAARRR Uncomment to enable.
 #ALLOW_HOLIDAYS
 
-## Uncomment this to prevent players from printing copy/pasted circuits.
+## Determines if players can print copy/pasted integrated circuits.
 #ALLOW_IC_PRINTING 1
 
-## Uncomment to allow ghosts to write in blood during Cult rounds.
+## Determines if ghosts are permitted to write in blood during cult rounds.
 #CULT_GHOSTWRITER 1
 
 ## The maximum duration of an exoplanet day, in minutes.
@@ -233,12 +239,12 @@
 #RADIATION_RESISTANCE_MULTIPLIER 1.25
 
 ## Enable/Disable random level generation. Will behave strangely if turned off with a map that expects it on. Uncomment to enable.
-#ROUNDSTART_LEVEL_GENERATION
+ROUNDSTART_LEVEL_GENERATION
 
 ## Unhash this to use iterative explosions, keep it hashed to use circle explosions. Uncomment to enable.
 #USE_ITERATIVE_EXPLOSIONS
 
-## Uncomment to disable the restrictive weldervision overlay.
+## Toggles the restrictive weldervision overlay when wearing welding goggles or a welding helmet.
 #WELDER_VISION 1
 
 ##
@@ -371,20 +377,20 @@
 ##
 
 ## Password used for authorizing external tools that can apply bans.
-#BAN_COMMS_PASSWORD 
+#BAN_COMMS_PASSWORD
 
 ## Password used for authorizing ircbot and other external tools.
-#COMMS_PASSWORD 
+#COMMS_PASSWORD
 
 ## Export address where external tools that monitor logins are located.
-#LOGIN_EXPORT_ADDR 
+#LOGIN_EXPORT_ADDR
 
 ##
 # RESOURCES
 # Configuration options relating to server resources.
 ##
 
-## Uncomment this and set it to a file path relative to the executing binary to prefix all custom icon locations with this location ie. '[CUSTOM_ICON_ICON_LOCATION]/[custom icon path value]'
+## Set this to a file path relative to the executing binary to prefix all custom icon locations with this location ie. '[CUSTOM_ICON_ICON_LOCATION]/[custom icon path value]'
 #CUSTOM_ICON_ICON_LOCATION config/custom_icons/icons
 
 ## Set this to a file path relative to the executing binary to prefix all custom item icon locations with this location ie. '[CUSTOM_ITEM_ICON_LOCATION]/[custom item icon path value]'
@@ -407,7 +413,7 @@
 #ABANDON_ALLOWED 1
 
 ## IRC channel to send adminhelps to. Leave blank to disable adminhelps-to-irc.
-#ADMIN_IRC 
+#ADMIN_IRC
 
 ## Add a # infront of this if you want to use the SQL based admin system, the legacy system uses admins.txt. You need to set up your database to use the SQL based system.
 #ADMIN_LEGACY_SYSTEM 1
@@ -418,14 +424,14 @@
 ## Allow ghosts to join as maintenance drones.
 #ALLOW_DRONE_SPAWN 1
 
-## Uncomment this line to announce shuttle dock announcements to the main IRC channel, if MAIN_IRC has also been setup. Uncomment to enable.
+## Determines if announce shuttle dock announcements are sent to the main IRC channel, if MAIN_IRC has also been setup. Uncomment to enable.
 #ANNOUNCE_SHUTTLE_DOCK_TO_IRC
 
 ## Comment to disable the AOOC channel by default.
 #AOOC_ALLOWED 1
 
 ## Ban appeals URL - usually for a forum or wherever people should go to contact your admins.
-#BANAPPEALS 
+#BANAPPEALS
 
 ## Add a # infront of this if you want to use the SQL based banning system. The legacy systems use the files in the data folder. You need to set up your database to use the SQL based system.
 #BAN_LEGACY_SYSTEM 1
@@ -436,22 +442,22 @@
 ## Sets the minimum number of cultists needed for ghosts to write in blood.
 #CULT_GHOSTWRITER_REQ_CULTISTS 10
 
-## Uncomment this to remove the server from the hub. Uncomment to enable.
+## Determines if the server should hide itself from the hub when no admins are online.. Uncomment to enable.
 #DELIST_WHEN_NO_ADMINS
 
 ## Uncomment to enable.
 #DISABLE_PLAYER_MICE
 
-## Uncomment to make Discord webhooks send in plaintext rather than as embeds. Uncomment to enable.
+## Determines if Discord webhooks should be sent in plaintext rather than as embeds. Uncomment to enable.
 #DISABLE_WEBHOOK_EMBEDS
 
 ## Discord server permanent invite address.
-#DISCORDURL 
+#DISCORDURL
 
 ## Comment to disable the dead OOC channel by default.
 #DOOC_ALLOWED 1
 
-## Uncomment this to DISABLE action spam kicking. Not recommended; this helps protect from spam attacks. Uncomment to enable.
+## Determines if action spam kicking should be DISABLED. Not recommended; this helps protect from spam attacks. Uncomment to enable.
 #DO_NOT_PREVENT_SPAM
 
 ## A drone will become available every X ticks since last drone spawn. Default is 2 minutes.
@@ -467,20 +473,20 @@
 #FORBID_SINGULO_POSSESSION
 
 ## Discussion forum address.
-#FORUMURL 
+#FORUMURL
 
 ## Defines world FPS. Defaults to 20.
 ## Can also accept ticklag values (0.9, 0.5, etc) which will automatically be converted to FPS.
 #FPS 20
 
 ## GitHub address.
-#GITHUBURL 
+#GITHUBURL
 
-## Uncomment this to stop people connecting to your server without a registered ckey. (i.e. guest-* are all blocked from connecting). Uncomment to enable.
+## Determines whether or not people without a registered ckey (i.e. guest-*) can connect to your server. Uncomment to enable.
 #GUESTS_ALLOWED
 
 ## Set a hosted by name for UNIX platforms.
-#HOSTEDBY 
+#HOSTEDBY
 
 ## Hub visibility: If you want to be visible on the hub, uncomment the below line and be sure that Dream Daemon is set to visible. This can be changed in-round as well with toggle-hub-visibility if Dream Daemon is set correctly. Uncomment to enable.
 #HUB_VISIBILITY
@@ -489,7 +495,7 @@
 #IRC_BOT_HOST localhost
 
 ## GitHub new issue address.
-#ISSUEREPORTURL 
+#ISSUEREPORTURL
 
 ## Add a # here if you wish to use the setup where jobs have more access. This is intended for servers with low populations - where there are not enough players to fill all roles, so players need to do more than just one job. Also for servers where they don't want people to hide in their own departments.
 #JOBS_HAVE_MINIMAL_ACCESS 1
@@ -545,16 +551,16 @@
 #RESPAWN_DELAY 30
 
 ## Set a server location for world reboot. Don't include the byond://, just give the address and port.
-#SERVER 
+#SERVER
 
 ## Set a server URL for the IRC bot to use; like SERVER, don't include the byond://
 ## Unlike SERVER, this one shouldn't break auto-reconnect.
-#SERVERURL 
+#SERVERURL
 
 ## Server name: This appears at the top of the screen in-game.
 #SERVER_NAME Nebula 13
 
-## Uncomment this to show a typing indicator for people writing whispers. Uncomment to enable.
+## Determinese if a typing indicator shows overhead for people currently writing whispers. Uncomment to enable.
 #SHOW_TYPING_INDICATOR_FOR_WHISPERS
 
 ## SSinitialization throttling.
@@ -563,10 +569,10 @@
 ## Set to 1 to prevent newly-spawned mice from understanding human speech. Uncomment to enable.
 #UNEDUCATED_MICE
 
-## Uncomment to restrict non-admins from using humanoid alien races. Uncomment to enable.
+## Determines if non-admins are restricted from using humanoid alien races. Uncomment to enable.
 #USEALIENWHITELIST
 
-## Uncomment to use the alien whitelist system with SQL instead. (requires the above uncommented as well). Uncomment to enable.
+## Determines if the alien whitelist should use SQL instead of the legacy system. (requires the above uncommented as well). Uncomment to enable.
 #USEALIENWHITELIST_SQL
 
 ## Set to jobban everyone who's key is not listed in data/whitelist.txt from Captain, HoS, HoP, CE, RD, CMO, Warden, Security, Detective, and AI positions.
@@ -574,17 +580,17 @@
 ##  Uncomment to enable.
 #USEWHITELIST
 
-## Uncomment to enable sending data to the IRC bot. Uncomment to enable.
+## Determines if data is sent to the IRC bot. Generally requires MAIN_IRC and associated setup. Uncomment to enable.
 #USE_IRC_BOT
 
 ## Remove the # in front of this config option to have loyalty implants spawn by default on your server. Uncomment to enable.
 #USE_LOYALTY_IMPLANTS
 
-## Uncomment to make Dream Daemon refuse to reboot for any reason other than SIGUSR1. Uncomment to enable.
+## Determines if Dream Daemon should refuse to reboot for any reason other than SIGUSR1. Uncomment to enable.
 #WAIT_FOR_SIGUSR1_REBOOT
 
 ## Wiki address.
-#WIKIURL 
+#WIKIURL
 
 ##
 # VOTING
@@ -602,7 +608,7 @@
 ## Allow players to initiate a restart vote. Uncomment to enable.
 #ALLOW_VOTE_RESTART
 
-## Uncomment to enable an automatic map vote and switch at end of round. MAP_SWITCHING must also be enabled. Uncomment to enable.
+## Determines if the automatic map vote and switch are called at end of round. MAP_SWITCHING must also be enabled. Uncomment to enable.
 #AUTO_MAP_VOTE
 
 ## Time left (seconds) before round start when automatic gamemote vote is called (default 160).


### PR DESCRIPTION
## Description of changes
- Updated some config descriptions to not start with 'uncomment this'.
- Made the objectives_disabled enum use a member list instead of a static list to avoid a weird ordering issue where the list was null during decl init.
- Separated some config decl comment generation out into procs for override. Didn't end up needing it but it's a harmless and potentially useful change.

## Why and what will this PR improve
Fixes enums.
Less misleading comments.

## Authorship
Myself.

## Changelog
Nothing player-facing.