### PR TITLE
Ground descriptions

### DIFF
--- a/code/game/turfs/floors/natural/natural_grass.dm
+++ b/code/game/turfs/floors/natural/natural_grass.dm
@@ -1,6 +1,6 @@
 /turf/floor/natural/grass
 	name = "grass"
-	desc = "You see a patch of grass. The grass is wild and seems to like it here."
+	desc = "A patch of grass, growing steadily from the sun's nourishment."
 	possible_states = 1
 	icon = 'icons/turf/flooring/grass.dmi'
 	footstep_type = /decl/footsteps/grass

--- a/code/game/turfs/floors/natural/natural_grass.dm
+++ b/code/game/turfs/floors/natural/natural_grass.dm
@@ -1,6 +1,6 @@
 /turf/floor/natural/grass
 	name = "grass"
-	desc = "A patch of grass, growing steadily from the sun's nourishment."
+	desc = "A patch of grass, growing steadily and healthily."
 	possible_states = 1
 	icon = 'icons/turf/flooring/grass.dmi'
 	footstep_type = /decl/footsteps/grass
@@ -75,7 +75,7 @@
 	. = ..()
 	if(icon_state != "scorched")
 		SetName("scorched ground")
-		desc = "What was once lush grass has been reduced to burnt, ashy wastes."
+		desc = "What was once lush grass has been reduced to burnt ashes."
 		icon_state = "scorched"
 		icon_edge_layer = -1
 		footstep_type = /decl/footsteps/asteroid

--- a/code/game/turfs/floors/natural/natural_grass.dm
+++ b/code/game/turfs/floors/natural/natural_grass.dm
@@ -1,5 +1,6 @@
 /turf/floor/natural/grass
 	name = "grass"
+	desc = "You see a patch of grass. The grass is wild and seems to like it here."
 	possible_states = 1
 	icon = 'icons/turf/flooring/grass.dmi'
 	footstep_type = /decl/footsteps/grass
@@ -14,6 +15,7 @@
 
 /turf/floor/natural/grass/wild
 	name = "wild grass"
+	desc = "Tall, lush grass that reaches past your ankles."
 	possible_states = null
 	icon = 'icons/turf/flooring/wildgrass.dmi'
 	icon_edge_layer = EXT_EDGE_GRASS_WILD
@@ -73,6 +75,7 @@
 	. = ..()
 	if(icon_state != "scorched")
 		SetName("scorched ground")
+		desc = "What was once lush grass has been reduced to burnt, ashy wastes."
 		icon_state = "scorched"
 		icon_edge_layer = -1
 		footstep_type = /decl/footsteps/asteroid

--- a/code/game/turfs/floors/natural/natural_ice.dm
+++ b/code/game/turfs/floors/natural/natural_ice.dm
@@ -1,5 +1,6 @@
 /turf/floor/natural/ice
 	name = "ice"
+	desc = "A sheet of smooth, slick ice. Be careful not to fall.."
 	icon = 'icons/turf/flooring/ice.dmi'
 	footstep_type = /decl/footsteps/plating
 	base_color = COLOR_LIQUID_WATER

--- a/code/game/turfs/floors/natural/natural_ice.dm
+++ b/code/game/turfs/floors/natural/natural_ice.dm
@@ -1,6 +1,6 @@
 /turf/floor/natural/ice
 	name = "ice"
-	desc = "A sheet of smooth, slick ice. Be careful not to fall.."
+	desc = "A sheet of smooth, slick ice. Be careful not to slip..."
 	icon = 'icons/turf/flooring/ice.dmi'
 	footstep_type = /decl/footsteps/plating
 	base_color = COLOR_LIQUID_WATER

--- a/code/game/turfs/floors/natural/natural_lava.dm
+++ b/code/game/turfs/floors/natural/natural_lava.dm
@@ -1,6 +1,6 @@
 /turf/floor/natural/lava
 	name = "lava"
-	desc = "Incredibly hot molten rock, you can feel the heat radiating even from a distance.."
+	desc = "Incredibly hot molten rock, you can feel the heat radiating even from a distance."
 	icon = 'icons/turf/flooring/lava.dmi'
 	movement_delay = 4
 	dirt_color = COLOR_GRAY20

--- a/code/game/turfs/floors/natural/natural_lava.dm
+++ b/code/game/turfs/floors/natural/natural_lava.dm
@@ -1,5 +1,6 @@
 /turf/floor/natural/lava
 	name = "lava"
+	desc = "Incredibly hot molten rock, you can feel the heat radiating even from a distance.."
 	icon = 'icons/turf/flooring/lava.dmi'
 	movement_delay = 4
 	dirt_color = COLOR_GRAY20

--- a/code/game/turfs/floors/natural/natural_lava.dm
+++ b/code/game/turfs/floors/natural/natural_lava.dm
@@ -1,6 +1,6 @@
 /turf/floor/natural/lava
 	name = "lava"
-	desc = "Incredibly hot molten rock, you can feel the heat radiating even from a distance."
+	desc = "Incredibly hot molten rock. You can feel the heat radiating even from a distance."
 	icon = 'icons/turf/flooring/lava.dmi'
 	movement_delay = 4
 	dirt_color = COLOR_GRAY20

--- a/code/game/turfs/floors/natural/natural_rock.dm
+++ b/code/game/turfs/floors/natural/natural_rock.dm
@@ -1,6 +1,6 @@
 /turf/floor/natural/rock
 	name = "rock floor"
-	desc = "A surface of rough, rocky ground."
+	desc = "A patch of rough, rocky ground."
 	icon = 'icons/turf/flooring/rock.dmi'
 	icon_edge_layer = EXT_EDGE_VOLCANIC
 	is_fundament_turf = TRUE

--- a/code/game/turfs/floors/natural/natural_rock.dm
+++ b/code/game/turfs/floors/natural/natural_rock.dm
@@ -1,5 +1,6 @@
 /turf/floor/natural/rock
 	name = "rock floor"
+	desc = "A surface of rough, rocky ground."
 	icon = 'icons/turf/flooring/rock.dmi'
 	icon_edge_layer = EXT_EDGE_VOLCANIC
 	is_fundament_turf = TRUE


### PR DESCRIPTION
## Description of changes
Adds descriptions to the natural ground tiles that lacked them

## Why and what will this PR improve
The descriptions previously inherited from the base ground, which wasn't accurate for most of them.

## Authorship
Myself, Penny suggested the grass desc.

## Changelog
:cl:
add: Descriptions for natural ground turfs.
/:cl:
