### PR TITLE
Improve natural floor descriptions

### DIFF
--- a/code/__defines/lists.dm
+++ b/code/__defines/lists.dm
@@ -71,3 +71,12 @@
 			__BIN_LIST.Insert(__BIN_MID, INPUT);\
 		};\
 	} while(FALSE)
+
+#if DM_VERSION < 515 // legacy, remove once we make 515 mandatory
+/proc/LIST_CLEAR_NULLS(L)
+	var/start_len = L.len
+	L -= new /list(L.len)
+	return start_len - L.len
+#else
+#define LIST_CLEAR_NULLS(L) L.RemoveAll(null)
+#endif

--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -778,3 +778,8 @@ var/global/list/plural_words_unchanged = list(
 	for(var/i = 1 to num)
 		. += str
 	. = JOINTEXT(.)
+
+/proc/jointext_no_nulls(list/L, Glue, Start = 1, End = 0)
+	var/list/temp = L.Copy()
+	LIST_CLEAR_NULLS(temp)
+	return jointext(temp, Glue, Start, End)

--- a/code/game/turfs/floors/natural/_natural.dm
+++ b/code/game/turfs/floors/natural/_natural.dm
@@ -1,6 +1,7 @@
 /turf/floor/natural
 
 	name = "ground"
+	gender = PLURAL
 	icon = 'icons/turf/flooring/barren.dmi'
 	desc = "Bare, barren sand."
 	icon_state = "0"

--- a/code/game/turfs/floors/natural/natural_rock.dm
+++ b/code/game/turfs/floors/natural/natural_rock.dm
@@ -1,5 +1,5 @@
 /turf/floor/natural/rock
-	name = "rock floor"
+	name = "rock"
 	desc = "A patch of rough, rocky ground."
 	icon = 'icons/turf/flooring/rock.dmi'
 	icon_edge_layer = EXT_EDGE_VOLCANIC

--- a/code/game/turfs/floors/natural/natural_seafloor.dm
+++ b/code/game/turfs/floors/natural/natural_seafloor.dm
@@ -1,5 +1,6 @@
 /turf/floor/natural/seafloor
 	name = "sea floor"
+	gender = NEUTER
 	desc = "A thick layer of silt and debris from above."
 	icon = 'icons/turf/flooring/seafloor.dmi'
 	icon_edge_layer = EXT_EDGE_SEAFLOOR

--- a/code/game/turfs/floors/subtypes/floor_path.dm
+++ b/code/game/turfs/floors/subtypes/floor_path.dm
@@ -1,21 +1,40 @@
 // These need conversion to flooring decls but I am leaving it till after this PR.
 /turf/floor/natural/path
 	name = "path"
+	gender = NEUTER
+	desc = "A cobbled path made of loose stones."
 	color = COLOR_GRAY
 	base_color = COLOR_GRAY
 	icon = 'icons/turf/flooring/legacy/cobblestone.dmi'
 	icon_state = "0"
 	material = /decl/material/solid/stone/sandstone
 //	initial_flooring = /decl/flooring/path/cobblestone
+	// If null, this is just skipped.
+	var/paving_adjective = "cobbled"
+	var/paver_adjective = "loose"
+	// This one should never be null.
+	var/paver_noun = "stones"
+
+/turf/floor/natural/path/update_from_material()
+	SetName("[material.adjective_name] [initial(name)]")
+	ASSERT(material?.adjective_name)
+	ASSERT(paver_noun)
+	desc = "[jointext_no_nulls(list("A", paving_adjective, "path made of", paver_adjective, material?.adjective_name, paver_noun), " ")]."
 
 /turf/floor/natural/path/running_bond
 	icon = 'icons/turf/flooring/legacy/running_bond.dmi'
 	icon_edge_layer = -1
+	paving_adjective = null
+	paver_adjective = "staggered"
+	paver_noun = "bricks"
 //	initial_flooring = /decl/flooring/path/running_bond
 
 /turf/floor/natural/path/herringbone
 	icon = 'icons/turf/flooring/legacy/herringbone.dmi'
 	icon_edge_layer = -1
+	paving_adjective = "herringbone"
+	paver_adjective = null
+	paver_noun = "bricks"
 //	initial_flooring = /decl/flooring/path/herringbone
 
 // Material subtypes.


### PR DESCRIPTION
## Description of changes
Change the gender of most natural floors to PLURAL, resulting in `some ground`, `some clay`, `some dirt`, etc. instead of `a ground`, `a clay`, `a dirt` when examining turfs.
Changes rock floor to just be named "rock" so that it says "That's some rock." instead of "That's a rock floor" or "That's some rock floor." To me, floor implied intentional construction, which isn't always accurate.
Adds descriptions to paths, based on material and pattern.

## Why and what will this PR improve
Improves examine text for paths and other natural turfs.