### PR TITLE
Fix various issues with butchery

### DIFF
--- a/code/modules/butchery/butchery_data.dm
+++ b/code/modules/butchery/butchery_data.dm
@@ -23,6 +23,8 @@
 	var/gut_amount        = 1
 
 	var/butchery_rotation = 270
+	/// A two-element lazylist of the form list(x, y), used to translate the mob's appearance on a butcher hook. Applied after rotation.
+	var/butchery_offset
 	var/must_use_hook     = TRUE
 	var/needs_surface     = FALSE
 

--- a/code/modules/butchery/butchery_data_fish.dm
+++ b/code/modules/butchery/butchery_data_fish.dm
@@ -12,15 +12,18 @@
 	meat_flags    = INGREDIENT_FLAG_MEAT | INGREDIENT_FLAG_FISH
 
 /decl/butchery_data/animal/fish/small
-	bone_amount   = 1
-	skin_amount   = 2
+	bone_amount     = 1
+	skin_amount     = 2
+	butchery_offset = list(-14, 4)
 
 /decl/butchery_data/animal/fish/medium
-	meat_amount   = 2
+	meat_amount     = 2
+	butchery_offset = list(-7, -2)
 
 /decl/butchery_data/animal/fish/carp
 	meat_type     = /obj/item/chems/food/butchery/meat/fish/carp
 	stomach_type  = /obj/item/chems/food/butchery/stomach
+	butchery_offset = list(-10, -2)
 
 /decl/butchery_data/animal/fish/space_carp
 	meat_type     = /obj/item/chems/food/butchery/meat/fish/poison
@@ -29,24 +32,27 @@
 	stomach_type  = /obj/item/chems/food/butchery/stomach
 
 /decl/butchery_data/animal/fish/space_carp/pike
-	meat_amount   = 10
-	bone_amount   = 20
-	skin_amount   = 20
-	must_use_hook = TRUE
-	gut_type      = /obj/item/chems/food/butchery/offal
+	meat_amount     = 10
+	bone_amount     = 20
+	skin_amount     = 20
+	must_use_hook   = TRUE
+	gut_type        = /obj/item/chems/food/butchery/offal
+	butchery_offset = list(-16, 0)
 
 /decl/butchery_data/animal/fish/shark
-	meat_type     = /obj/item/chems/food/butchery/meat/fish/shark
-	meat_amount   = 5
-	bone_amount   = 15
-	skin_amount   = 15
-	bone_material = /decl/material/solid/organic/bone/cartilage
-	skin_material = /decl/material/solid/organic/skin/shark
-	must_use_hook = TRUE
-	stomach_type  = /obj/item/chems/food/butchery/stomach
-	gut_type      = /obj/item/chems/food/butchery/offal
+	meat_type       = /obj/item/chems/food/butchery/meat/fish/shark
+	meat_amount     = 5
+	bone_amount     = 15
+	skin_amount     = 15
+	bone_material   = /decl/material/solid/organic/bone/cartilage
+	skin_material   = /decl/material/solid/organic/skin/shark
+	must_use_hook   = TRUE
+	stomach_type    = /obj/item/chems/food/butchery/stomach
+	gut_type        = /obj/item/chems/food/butchery/offal
+	butchery_offset = list(-6, 0)
 
 /decl/butchery_data/animal/fish/shark/large
-	meat_amount   = 10
-	bone_amount   = 30
-	skin_amount   = 30
+	meat_amount     = 10
+	bone_amount     = 30
+	skin_amount     = 30
+	butchery_offset = list(-16, 0)

--- a/code/modules/butchery/butchery_data_livestock.dm
+++ b/code/modules/butchery/butchery_data_livestock.dm
@@ -44,13 +44,14 @@
 	skin_amount   = 10
 
 /decl/butchery_data/animal/small/fowl
-	meat_name     = "fowl"
-	meat_type     = /obj/item/chems/food/butchery/meat/chicken
-	meat_material = /decl/material/solid/organic/meat/chicken
-	meat_amount   = 2
-	bone_amount   = 2
-	skin_amount   = 2
-	skin_material = /decl/material/solid/organic/skin/feathers
+	meat_name       = "fowl"
+	meat_type       = /obj/item/chems/food/butchery/meat/chicken
+	meat_material   = /decl/material/solid/organic/meat/chicken
+	meat_amount     = 2
+	bone_amount     = 2
+	skin_amount     = 2
+	skin_material   = /decl/material/solid/organic/skin/feathers
+	butchery_offset = list(-10, 0)
 
 /decl/butchery_data/animal/small/fowl/chicken
 	meat_name     = "chicken"

--- a/code/modules/butchery/butchery_data_livestock.dm
+++ b/code/modules/butchery/butchery_data_livestock.dm
@@ -17,20 +17,22 @@
 		LAZYADD(., food)
 
 /decl/butchery_data/animal/ruminant/goat
-	meat_name     = "chevon"
-	meat_type     = /obj/item/chems/food/butchery/meat/goat
-	meat_amount   = 4
-	bone_amount   = 8
-	skin_material = /decl/material/solid/organic/skin/goat
-	skin_amount   = 8
+	meat_name       = "chevon"
+	meat_type       = /obj/item/chems/food/butchery/meat/goat
+	meat_amount     = 4
+	bone_amount     = 8
+	skin_material   = /decl/material/solid/organic/skin/goat
+	skin_amount     = 8
+	butchery_offset = list(-6, 0)
 
 /decl/butchery_data/animal/ruminant/deer
-	meat_name     = "venison"
-	meat_type     = /obj/item/chems/food/butchery/meat
-	meat_amount   = 5
-	bone_amount   = 9
-	skin_material = /decl/material/solid/organic/skin/deer
-	skin_amount   = 9
+	meat_name       = "venison"
+	meat_type       = /obj/item/chems/food/butchery/meat
+	meat_amount     = 5
+	bone_amount     = 9
+	skin_material   = /decl/material/solid/organic/skin/deer
+	skin_amount     = 9
+	butchery_offset = list(-8, 0)
 
 /decl/butchery_data/animal/ruminant/deer/buck
 	// todo: drop antlers

--- a/code/modules/butchery/butchery_hook.dm
+++ b/code/modules/butchery/butchery_hook.dm
@@ -117,6 +117,7 @@
 	var/decl/butchery_data/butchery_data = GET_DECL(occupant.butchery_data)
 	if(butchery_data)
 		M.Turn(butchery_data.butchery_rotation)
+		M.Translate(arglist(butchery_data.butchery_offset))
 	I.transform = M
 
 	add_overlay(I)

--- a/code/modules/butchery/butchery_products.dm
+++ b/code/modules/butchery/butchery_products.dm
@@ -116,14 +116,13 @@
 
 /obj/item/chems/food/butchery/offal/handle_utensil_cutting(obj/item/tool, mob/user)
 	. = ..()
-	if(dry && length(.))
-		for(var/obj/item/chems/food/butchery/offal/guts in .)
-			if(!guts.dry)
-				guts.dry = TRUE
-				guts.SetName("dried [guts.name]")
-			else if(!guts._cleaned)
-				guts._cleaned = TRUE
-				guts.SetName("cleaned [guts.name]")
+	for(var/obj/item/chems/food/butchery/offal/guts in .)
+		if(dry && !guts.dry)
+			guts.dry = TRUE
+			guts.SetName("dried [guts.name]")
+		else if(_cleaned && !guts._cleaned)
+			guts._cleaned = TRUE
+			guts.SetName("cleaned [guts.name]")
 
 /obj/item/chems/food/butchery/offal/fluid_act(var/datum/reagents/fluids)
 	. = ..()

--- a/code/modules/butchery/butchery_products.dm
+++ b/code/modules/butchery/butchery_products.dm
@@ -29,7 +29,7 @@
 		ingredient_flags = butchery_decl.meat_flags
 	. = ..()
 	if(istype(donor))
-		meat_name = set_meat_name(donor.get_butchery_product_name())
+		meat_name = donor.get_butchery_product_name()
 	if(meat_name)
 		set_meat_name(meat_name)
 

--- a/code/modules/butchery/butchery_products.dm
+++ b/code/modules/butchery/butchery_products.dm
@@ -148,6 +148,8 @@
 	icon                = 'icons/obj/items/butchery/offal_small.dmi'
 	nutriment_amt       = 5
 	w_class             = ITEM_SIZE_SMALL
+	slice_path          = null
+	slice_num           = null
 
 /obj/item/chems/food/butchery/haunch
 	name                = "haunch"

--- a/code/modules/butchery/butchery_products_meat_fish.dm
+++ b/code/modules/butchery/butchery_products_meat_fish.dm
@@ -29,6 +29,9 @@
 		for(var/atom/food in .)
 			food.remove_from_reagents(/decl/material/liquid/carpotoxin, REAGENT_VOLUME(reagents, /decl/material/liquid/carpotoxin))
 
+/obj/item/chems/food/butchery/meat/fish/create_slice()
+	return new slice_path(loc, material?.type, meat_name) // pass fish name to sashimi
+
 /obj/item/chems/food/butchery/meat/fish/grilled
 	desc                           = "A lightly grilled fish fillet."
 	icon_state                     = "grilledfish"

--- a/code/modules/mob/living/simple_animal/aquatic/_aquatic_hostile.dm
+++ b/code/modules/mob/living/simple_animal/aquatic/_aquatic_hostile.dm
@@ -1,4 +1,5 @@
 /mob/living/simple_animal/hostile/aquatic
+	abstract_type = /mob/living/simple_animal/hostile/aquatic
 	icon = 'icons/mob/simple_animal/fish_content.dmi'
 	turns_per_move = 5
 	natural_weapon = /obj/item/natural_weapon/bite

--- a/code/modules/mob/living/simple_animal/aquatic/_aquatic_retaliate.dm
+++ b/code/modules/mob/living/simple_animal/aquatic/_aquatic_retaliate.dm
@@ -1,4 +1,5 @@
 /mob/living/simple_animal/hostile/retaliate/aquatic
+	abstract_type = /mob/living/simple_animal/hostile/retaliate/aquatic
 	icon = 'icons/mob/simple_animal/fish_content.dmi'
 	turns_per_move = 5
 	natural_weapon = /obj/item/natural_weapon/bite

--- a/code/modules/reagents/reagent_containers/food/sushi.dm
+++ b/code/modules/reagents/reagent_containers/food/sushi.dm
@@ -16,15 +16,13 @@
 		if(istype(topping, /obj/item/chems/food/sashimi))
 			var/obj/item/chems/food/sashimi/sashimi = topping
 			fish_type = sashimi.fish_type
-		else if(istype(topping, /obj/item/chems/food/butchery/meat))
+		else if(istype(topping, /obj/item/chems/food/butchery))
 			var/obj/item/chems/food/butchery/meat = topping
 			fish_type = meat.meat_name
 		else if(istype(topping, /obj/item/chems/food/friedegg))
 			fish_type = "egg"
 		else if(istype(topping, /obj/item/chems/food/tofu))
 			fish_type = "tofu"
-		else if(istype(topping, /obj/item/chems/food/butchery/cutlet))
-			fish_type = "meat"
 
 		if(topping.reagents)
 			topping.reagents.trans_to(src, topping.reagents.total_volume)
@@ -63,7 +61,7 @@
 	var/fish_type = "fish"
 	var/slices = 1
 
-/obj/item/chems/food/sashimi/Initialize(mapload, var/_fish_type)
+/obj/item/chems/food/sashimi/Initialize(mapload, material_key, var/_fish_type)
 	. = ..(mapload)
 	if(_fish_type) fish_type = _fish_type
 	name = "[fish_type] sashimi"


### PR DESCRIPTION
## Description of changes
- Fixes `meat_name` getting nulled after name set on init, so butchery products weren't properly passing it down to their children
- Adds an offset variable to butchery data for use on butchery hooks
- Fixes being able to infinitely chop small offal into more offal
- Fixes cleaned/dry vars not being properly propagated to offal
- Fixes sashimi having a decl path in its name
- Sets butchering pixel offsets for a bunch of butcherable mobs

## Why and what will this PR improve
Fixes a bunch of butchery issues I found in testing.