### PR TITLE
Fix miscellaneous issues discovered in fantasy map playtesting

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -728,6 +728,11 @@
 		return TRUE
 	return FALSE
 
+/turf/proc/get_trench_name()
+	if(check_fluid_depth(FLUID_SHALLOW))
+		return get_fluid_name()
+	return src
+
 /turf/receive_mouse_drop(atom/dropping, mob/user, params)
 	. = ..()
 	if(!. && simulated && dropping == user && isturf(user.loc) && user.Adjacent(src))
@@ -737,15 +742,15 @@
 		if(abs(our_height-their_height) > FLUID_SHALLOW)
 			. = TRUE
 			if(our_height < their_height)
-				user.visible_message(SPAN_NOTICE("\The [user] starts climbing down into \the [src]."))
+				user.visible_message(SPAN_NOTICE("\The [user] starts climbing down into \the [get_trench_name()]."))
 			else
-				user.visible_message(SPAN_NOTICE("\The [user] starts climbing out of \the [other_turf]."))
+				user.visible_message(SPAN_NOTICE("\The [user] starts climbing out of \the [other_turf.get_trench_name()]."))
 			if(!do_after(user, 2 SECONDS, src) || QDELETED(user) || user?.loc != other_turf || !user.Adjacent(src))
 				return
 			if(our_height < their_height)
-				user.visible_message(SPAN_NOTICE("\The [user] climbs down into \the [src]."))
+				user.visible_message(SPAN_NOTICE("\The [user] climbs down into \the [get_trench_name()]."))
 			else
-				user.visible_message(SPAN_NOTICE("\The [user] climbs out of \the [other_turf]."))
+				user.visible_message(SPAN_NOTICE("\The [user] climbs out of \the [other_turf.get_trench_name()]."))
 			LAZYDISTINCTADD(skip_height_fall_for, weakref(user))
 			user.dropInto(src)
 			LAZYREMOVE(skip_height_fall_for, weakref(user))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -263,7 +263,9 @@
 		if(W?.storage?.collection_mode && W.storage.gather_all(src, user))
 			return TRUE
 
-	if(ATOM_IS_OPEN_CONTAINER(W) && W.reagents && reagents?.total_volume >= FLUID_PUDDLE)
+	// Must be open, but food items should not be filled from sources like this. They're open in order to add condiments, not to be poured into/out of.
+	// TODO: Rewrite open-container-ness or food to make this unnecessary!
+	if(ATOM_IS_OPEN_CONTAINER(W) && !istype(W, /obj/item/chems/food) && W.reagents && reagents?.total_volume >= FLUID_PUDDLE)
 		var/taking = min(reagents.total_volume, REAGENTS_FREE_SPACE(W.reagents))
 		if(taking > 0)
 			to_chat(user, SPAN_NOTICE("You fill \the [W] with [reagents.get_primary_reagent_name()] from \the [src]."))

--- a/code/game/turfs/walls/wall_brick.dm
+++ b/code/game/turfs/walls/wall_brick.dm
@@ -12,6 +12,14 @@
 /turf/wall/brick/get_dismantle_sound()
 	return 'sound/foley/wooden_drop.ogg' // todo
 
+/turf/wall/brick/update_strings()
+	if(reinf_material)
+		SetName("reinforced [material.solid_name] brick wall")
+		desc = "A brick wall made of [material.solid_name] and reinforced with [reinf_material.solid_name]."
+	else
+		SetName("[material.solid_name] brick wall")
+		desc = "A brick wall made of [material.solid_name]."
+
 // Subtypes.
 /turf/wall/brick/sandstone
 	color = COLOR_GOLD

--- a/code/game/turfs/walls/wall_log.dm
+++ b/code/game/turfs/walls/wall_log.dm
@@ -12,6 +12,14 @@
 /turf/wall/log/get_dismantle_sound()
 	return 'sound/foley/wooden_drop.ogg'
 
+/turf/wall/log/update_strings()
+	if(reinf_material)
+		SetName("reinforced [material.solid_name] log wall")
+		desc = "A log wall made of [material.solid_name] and reinforced with [reinf_material.solid_name]."
+	else
+		SetName("[material.solid_name] log wall")
+		desc = "A log wall made of [material.solid_name]."
+
 // Subtypes.
 /turf/wall/log/ebony
 	icon_state = "wood"

--- a/code/modules/food/cooking/_recipe.dm
+++ b/code/modules/food/cooking/_recipe.dm
@@ -232,9 +232,9 @@ var/global/list/_cooking_recipe_cache = list()
 			var/check_grown_tag = food.get_grown_tag()
 			if(check_grown_tag && checklist[check_grown_tag] > 0)
 				//We found a thing we need
-				container_contents -= fruit
+				container_contents -= food
 				checklist[check_grown_tag]--
-				used_ingredients["fruits"] += fruit
+				used_ingredients["fruits"] += food
 
 	// And lastly deduct necessary quantities of reagents.
 	if(LAZYLEN(reagents))

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -54,6 +54,8 @@
 
 /obj/item/chems/proc/update_container_name()
 	var/newname = get_base_name()
+	if(material_alteration & MAT_FLAG_ALTERATION_NAME)
+		newname = "[material.solid_name] [newname]"
 	if(presentation_flags & PRESENTATION_FLAG_NAME)
 		var/decl/material/R = reagents?.get_primary_reagent_decl()
 		if(R)


### PR DESCRIPTION
## Description of changes
Brick and log walls have custom names and descriptions.
Climbing in/out of a trench will refer to any liquid present instead of the name of the turf.
Reagent presentation name takes into account material alteration flags.
Food is excluded from turf attackby fluid filling.
The internal ingredients list in cooking now adds the correct grown item instead of the grown_tag, preventing a runtime.

## Why and what will this PR improve
Brick/log walls are no longer described as a section of hull plated with stone/wood.
You'll now climb into water instead of into mud when lowering yourself into a watery pit.
Clay bowls will be "fired clay bowl of something" rather than a nondescript "bowl of something" when reagents are added to them.
You will no longer fill food from puddles.
You can cook with growns again, presently they runtime.