### PR TITLE
Fix runtime in create_area_image

### DIFF
--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -894,7 +894,7 @@ The _flatIcons list is a cache for generated icon files.
 			var/turf/T = locate(target_x + x_offset, target_y + y_offset, target_z)
 			if(checker && !checker?.can_capture_turf(T))
 				continue
-			else
+			else if(T)
 				render_turfs.Add(T)
 
 	// - Collecting list of atoms to render -


### PR DESCRIPTION
Fixes a runtime in `create_area_image`, preventing nulls from being added to `render_turfs`. When we iterate over it later, the `as anything` (a speed optimization, supposedly) causes a nullcheck to be skipped, leading to a runtime.