### PR TITLE
Fix lighting artifacts on mimic edge boundaries

### DIFF
--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -83,6 +83,8 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	// Issue being that the only way I could think of doing it was very messy, slow and honestly overengineered.
 	// So we'll have this hardcode instead.
 	var/turf/T
+	// This is to resolve the proper diagonal direction relative to the corner position for mimiced turfs.
+	var/Tc
 
 
 	// Diagonal one is easy.
@@ -99,24 +101,26 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 
 	// Now the horizontal one.
 	T = get_step_resolving_mimic(t1, horizontal)
+	Tc = t1.x + (horizontal == EAST  ? 1 : -1)
 	if (T) // Ditto.
 		if (!T.corners)
 			T.corners = new(4)
 
 		t3 = T
-		t3i = REVERSE_LIGHTING_CORNER_DIAGONAL[((T.x > x) ? EAST : WEST) | ((T.y > y) ? NORTH : SOUTH)] // Get the dir based on coordinates.
+		t3i = REVERSE_LIGHTING_CORNER_DIAGONAL[((Tc > x) ? EAST : WEST) | ((t1.y > y) ? NORTH : SOUTH)] // Get the dir based on coordinates.
 		T.corners[t3i] = src
 		if (T.ambient_light)
 			has_ambience = TRUE
 
 	// And finally the vertical one.
 	T = get_step_resolving_mimic(t1, vertical)
+	Tc = t1.y + (vertical   == NORTH ? 1 : -1)
 	if (T)
 		if (!T.corners)
 			T.corners = new(4)
 
 		t4 = T
-		t4i = REVERSE_LIGHTING_CORNER_DIAGONAL[((T.x > x) ? EAST : WEST) | ((T.y > y) ? NORTH : SOUTH)] // Get the dir based on coordinates.
+		t4i = REVERSE_LIGHTING_CORNER_DIAGONAL[((t1.x > x) ? EAST : WEST) | ((Tc > y) ? NORTH : SOUTH)] // Get the dir based on coordinates.
 		T.corners[t4i] = src
 		if (T.ambient_light)
 			has_ambience = TRUE


### PR DESCRIPTION
## Description of changes
Fixes lighting artifacts with mimic edge boundaries by fixing the coordinates used for corner-dir-getting. There's probably a more optimized way to do this without adding an extra variable, but all my attempts kept breaking, so I'll let someone else handle that or take a stab at it myself later.

## Why and what will this PR improve
Fixes lighting artifacts from edge mimic violating the assumption that a turf to the west of a corner will always have an X coordinate lower than the corner's, that a turf to the east will have an X coordinate greater, etc., and the same for north/south and the Y coordinate.

## Authorship
Me. No one else in Coderbus helped at all and I solved it on my own, wtf.