### PR TITLE
Add default names to grown/processed grown items

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -1,6 +1,6 @@
 //Grown foods.
 /obj/item/chems/food/grown
-	name = "fruit"
+	name = "produce"
 	icon = 'icons/obj/hydroponics/hydroponics_products.dmi'
 	icon_state = "blank"
 	randpixel = 5

--- a/code/modules/hydroponics/processed_grown.dm
+++ b/code/modules/hydroponics/processed_grown.dm
@@ -62,6 +62,7 @@
 
 // Fruit slices. TODO: seed color so orange slices don't get black seeds.
 /obj/item/chems/food/processed_grown/slice
+	name                = "fruit slice"
 	icon                = 'icons/obj/grown/fruit_slice.dmi'
 	processed_grown_tag = "slice"
 	slice_path          = /obj/item/chems/food/processed_grown/chopped
@@ -77,6 +78,7 @@
 
 // Chopped fruit or veg
 /obj/item/chems/food/processed_grown/chopped
+	name                = "chopped produce"
 	icon                = 'icons/obj/grown/chopped.dmi'
 	processed_grown_tag = "chopped"
 
@@ -86,6 +88,7 @@
 
 // Matchstick veg
 /obj/item/chems/food/processed_grown/sticks
+	name                = "vegetable sticks"
 	icon                = 'icons/obj/grown/sticks.dmi'
 	gender              = PLURAL
 	draw_rind           = FALSE
@@ -99,6 +102,7 @@
 
 // Crushed nuts/bulbs/flowers
 /obj/item/chems/food/processed_grown/crushed
+	name                = "crushed produce"
 	icon                = 'icons/obj/grown/crushed.dmi'
 	gender              = PLURAL
 	processed_grown_tag = "crushed"


### PR DESCRIPTION
## Description of changes
Adds some default names to grown and processed grown items, which makes recipe instructions clearer.

## Why and what will this PR improve
Before:
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/1c62afc6-0aa4-4412-917d-304f92e5b047)

After:
![image](https://github.com/NebulaSS13/Nebula/assets/110272328/d5bc9547-7370-432a-a301-0fc95a9fb6b8)