### PR TITLE
Tweak lanterns, sconces, refueling and reagent interactions

### DIFF
--- a/code/game/objects/items/_item_reagents.dm
+++ b/code/game/objects/items/_item_reagents.dm
@@ -1,0 +1,67 @@
+/obj/item/proc/standard_dispenser_refill(var/mob/user, var/obj/structure/reagent_dispensers/target) // This goes into afterattack
+	if(!istype(target) || (target.atom_flags & ATOM_FLAG_OPEN_CONTAINER))
+		return 0
+
+	if(!target.reagents || !target.reagents.total_volume)
+		to_chat(user, SPAN_NOTICE("[target] is empty."))
+		return 1
+
+	if(reagents && !REAGENTS_FREE_SPACE(reagents))
+		to_chat(user, SPAN_NOTICE("[src] is full."))
+		return 1
+
+	var/trans = target.reagents.trans_to_obj(src, target.amount_dispensed)
+	to_chat(user, SPAN_NOTICE("You fill [src] with [trans] units of the contents of [target]."))
+	return 1
+
+/obj/item/proc/standard_splash_mob(var/mob/user, var/mob/target) // This goes into afterattack
+	if(!istype(target))
+		return
+
+	if(user.a_intent == I_HELP)
+		to_chat(user, SPAN_NOTICE("You can't splash people on help intent."))
+		return 1
+
+	if(!reagents || !reagents.total_volume)
+		to_chat(user, SPAN_NOTICE("[src] is empty."))
+		return 1
+
+	if(target.reagents && !REAGENTS_FREE_SPACE(target.reagents))
+		to_chat(user, SPAN_NOTICE("[target] is full."))
+		return 1
+
+	var/contained = REAGENT_LIST(src)
+
+	admin_attack_log(user, target, "Used \the [name] containing [contained] to splash the victim.", "Was splashed by \the [name] containing [contained].", "used \the [name] containing [contained] to splash")
+	user.visible_message( \
+		SPAN_DANGER("\The [target] has been splashed with the contents of \the [src] by \the [user]!"), \
+		SPAN_DANGER("You splash \the [target] with the contents of \the [src]."))
+
+	reagents.splash(target, reagents.total_volume)
+	return 1
+
+
+/obj/item/proc/standard_pour_into(mob/user, atom/target, amount = 5) // This goes into afterattack and yes, it's atom-level
+	if(!target.reagents)
+		return 0
+
+	// Ensure we don't splash beakers and similar containers.
+	if(!ATOM_IS_OPEN_CONTAINER(target) && istype(target, /obj/item/chems))
+		to_chat(user, SPAN_NOTICE("\The [target] is closed."))
+		return 1
+	// Otherwise don't care about splashing.
+	else if(!ATOM_IS_OPEN_CONTAINER(target))
+		return 0
+
+	if(!reagents || !reagents.total_volume)
+		to_chat(user, SPAN_NOTICE("[src] is empty."))
+		return 1
+
+	if(!REAGENTS_FREE_SPACE(target.reagents))
+		to_chat(user, SPAN_NOTICE("[target] is full."))
+		return 1
+
+	var/trans = reagents.trans_to(target, amount)
+	playsound(src, 'sound/effects/pour.ogg', 25, 1)
+	to_chat(user, SPAN_NOTICE("You transfer [trans] unit\s of the solution to \the [target].  \The [src] now contains [src.reagents.total_volume] units."))
+	return 1

--- a/code/game/objects/items/flame/flame_fuelled.dm
+++ b/code/game/objects/items/flame/flame_fuelled.dm
@@ -68,3 +68,9 @@
 		visible_message(SPAN_WARNING("\The [src]'s flame flickers."))
 		set_light(0)
 		addtimer(CALLBACK(src, TYPE_PROC_REF(.atom, set_light), 2), 4)
+
+/obj/item/flame/fuelled/afterattack(obj/target, mob/user, proximity)
+	if(proximity && !lit && standard_dispenser_refill(user, target)) // To be able to refill lanterns and lighters from reagent dispensers.
+		playsound(src.loc, 'sound/effects/refill.ogg', 50, TRUE, -6)
+		return TRUE
+	return ..()

--- a/code/game/objects/items/flame/flame_fuelled_lantern.dm
+++ b/code/game/objects/items/flame/flame_fuelled_lantern.dm
@@ -1,10 +1,11 @@
 /obj/item/flame/fuelled/lantern
 	name                = "oil lantern"
-	desc                = "An unwieldly oil lantern."
+	desc                = "An unwieldy oil lantern."
 	icon                = 'icons/obj/items/flame/lantern.dmi'
 	force               = 10
 	attack_verb         = list ("bludgeoned", "bashed", "whack")
 	w_class             = ITEM_SIZE_NORMAL
+	atom_flags          = ATOM_FLAG_OPEN_CONTAINER
 	obj_flags           = OBJ_FLAG_CONDUCTIBLE
 	slot_flags          = SLOT_LOWER_BODY
 	lit_light_power     = 0.9

--- a/code/game/objects/items/flame/flame_fuelled_lighter_zippo.dm
+++ b/code/game/objects/items/flame/flame_fuelled_lighter_zippo.dm
@@ -26,14 +26,6 @@
 	user.visible_message(SPAN_ROSE("You hear a quiet click, as [user] shuts off \the [src] without even looking at what they're doing."))
 	playsound(src.loc, 'sound/items/zippo_close.ogg', 100, 1, -4)
 
-/obj/item/flame/fuelled/lighter/zippo/afterattack(obj/O, mob/user, proximity)
-	if(proximity && istype(O, /obj/structure/reagent_dispensers/fueltank) && !lit)
-		O.reagents.trans_to_obj(src, max_fuel)
-		to_chat(user, SPAN_NOTICE("You refuel [src] from \the [O]."))
-		playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
-		return TRUE
-	return ..()
-
 /obj/item/flame/fuelled/lighter/zippo/black
 	color = COLOR_DARK_GRAY
 	name = "black zippo"

--- a/code/game/objects/structures/barrel.dm
+++ b/code/game/objects/structures/barrel.dm
@@ -51,3 +51,7 @@
 /obj/structure/reagent_dispensers/barrel/ebony/wine/populate_reagents()
 	. = ..()
 	add_to_reagents(/decl/material/liquid/ethanol/wine, reagents.maximum_volume)
+
+/obj/structure/reagent_dispensers/barrel/ebony/oil/populate_reagents()
+	. = ..()
+	add_to_reagents(/decl/material/liquid/nutriment/plant_oil, reagents.maximum_volume)

--- a/code/game/objects/structures/wall_sconce.dm
+++ b/code/game/objects/structures/wall_sconce.dm
@@ -86,14 +86,13 @@
 		dismantle_structure(user)
 		return TRUE
 
+	if(W.isflamesource() && light_source && !light_source.lit)
+		light_source.attackby(W, user)
+		update_icon()
+		return TRUE
+
 	if(istype(W, /obj/item/flame))
 		var/obj/item/flame/flame = W
-
-		if(flame.lit && light_source && light_source.can_manually_light)
-			light_source.attackby(flame, user)
-			update_icon()
-			return TRUE
-
 		if(flame.sconce_can_hold)
 
 			if(light_source)
@@ -106,9 +105,11 @@
 				update_icon()
 			return TRUE
 
-	if(W.isflamesource() && light_source && !light_source.lit)
-		light_source.attackby(W, user)
-		return TRUE
+	// Refilling
+	if(light_source && istype(W, /obj/item/chems))
+		var/obj/item/chems/chem_source = W
+		if(chem_source.standard_pour_into(user, light_source))
+			return TRUE
 
 	return ..()
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -107,72 +107,8 @@
 	else
 		return ..()
 
-/obj/item/chems/proc/standard_dispenser_refill(var/mob/user, var/obj/structure/reagent_dispensers/target) // This goes into afterattack
-	if(!istype(target) || (target.atom_flags & ATOM_FLAG_OPEN_CONTAINER))
-		return 0
-
-	if(!target.reagents || !target.reagents.total_volume)
-		to_chat(user, SPAN_NOTICE("[target] is empty."))
-		return 1
-
-	if(reagents && !REAGENTS_FREE_SPACE(reagents))
-		to_chat(user, SPAN_NOTICE("[src] is full."))
-		return 1
-
-	var/trans = target.reagents.trans_to_obj(src, target.amount_dispensed)
-	to_chat(user, SPAN_NOTICE("You fill [src] with [trans] units of the contents of [target]."))
-	return 1
-
-/obj/item/chems/proc/standard_splash_mob(var/mob/user, var/mob/target) // This goes into afterattack
-	if(!istype(target))
-		return
-
-	if(user.a_intent == I_HELP)
-		to_chat(user, SPAN_NOTICE("You can't splash people on help intent."))
-		return 1
-
-	if(!reagents || !reagents.total_volume)
-		to_chat(user, SPAN_NOTICE("[src] is empty."))
-		return 1
-
-	if(target.reagents && !REAGENTS_FREE_SPACE(target.reagents))
-		to_chat(user, SPAN_NOTICE("[target] is full."))
-		return 1
-
-	var/contained = REAGENT_LIST(src)
-
-	admin_attack_log(user, target, "Used \the [name] containing [contained] to splash the victim.", "Was splashed by \the [name] containing [contained].", "used \the [name] containing [contained] to splash")
-	user.visible_message( \
-		SPAN_DANGER("\The [target] has been splashed with the contents of \the [src] by \the [user]!"), \
-		SPAN_DANGER("You splash \the [target] with the contents of \the [src]."))
-
-	reagents.splash(target, reagents.total_volume)
-	return 1
-
-/obj/item/chems/proc/standard_pour_into(var/mob/user, var/atom/target) // This goes into afterattack and yes, it's atom-level
-	if(!target.reagents)
-		return 0
-
-	// Ensure we don't splash beakers and similar containers.
-	if(!ATOM_IS_OPEN_CONTAINER(target) && istype(target, /obj/item/chems))
-		to_chat(user, SPAN_NOTICE("\The [target] is closed."))
-		return 1
-	// Otherwise don't care about splashing.
-	else if(!ATOM_IS_OPEN_CONTAINER(target))
-		return 0
-
-	if(!reagents || !reagents.total_volume)
-		to_chat(user, SPAN_NOTICE("[src] is empty."))
-		return 1
-
-	if(!REAGENTS_FREE_SPACE(target.reagents))
-		to_chat(user, SPAN_NOTICE("[target] is full."))
-		return 1
-
-	var/trans = reagents.trans_to(target, amount_per_transfer_from_this)
-	playsound(src, 'sound/effects/pour.ogg', 25, 1)
-	to_chat(user, SPAN_NOTICE("You transfer [trans] unit\s of the solution to \the [target].  \The [src] now contains [src.reagents.total_volume] units."))
-	return 1
+/obj/item/chems/standard_pour_into(mob/user, atom/target, amount = 5)
+	return ..(user, target, amount_per_transfer_from_this)
 
 /obj/item/chems/do_surgery(mob/living/carbon/M, mob/living/user)
 	if(user.get_target_zone() != BP_MOUTH) //in case it is ever used as a surgery tool

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -74,11 +74,13 @@
 
 	// We do this here to avoid putting the vessel straight into storage.
 	// This is usually handled by afterattack on /chems.
-	if(storage && istype(W, /obj/item/chems) && !istype(W, /obj/item/chems/food) && user.a_intent == I_HELP)
-		var/obj/item/chems/vessel = W
-		if(vessel.standard_dispenser_refill(user, src))
+	// The item must be an open container, but food items should not be filled from sources like this.
+	// They're open in order to add condiments, not to be poured into/out of.
+	// TODO: Rewrite open-container-ness or food to make this unnecessary!
+	if(storage && ATOM_IS_OPEN_CONTAINER(W) && !istype(W, /obj/item/chems/food) && user.a_intent == I_HELP)
+		if(W.standard_dispenser_refill(user, src))
 			return TRUE
-		if(vessel.standard_pour_into(user, src))
+		if(W.standard_pour_into(user, src))
 			return TRUE
 
 	if(wrenchable && IS_WRENCH(W))

--- a/maps/shaded_hills/shaded_hills-inn.dmm
+++ b/maps/shaded_hills/shaded_hills-inn.dmm
@@ -386,6 +386,10 @@
 /obj/abstract/landmark/start/shaded_hills/innkeeper,
 /turf/floor/wood/ebony,
 /area/shaded_hills/inn)
+"yu" = (
+/obj/structure/reagent_dispensers/barrel/ebony,
+/turf/floor/wood/ebony,
+/area/shaded_hills/general_store)
 "yz" = (
 /turf/wall/brick/basalt,
 /area/shaded_hills/general_store)
@@ -440,6 +444,10 @@
 "BL" = (
 /obj/structure/bed/simple/ebony/cloth,
 /obj/item/bedsheet/yellowed,
+/turf/floor/wood/ebony,
+/area/shaded_hills/general_store)
+"Dn" = (
+/obj/structure/reagent_dispensers/barrel/ebony/oil,
 /turf/floor/wood/ebony,
 /area/shaded_hills/general_store)
 "Ee" = (
@@ -8907,8 +8915,8 @@ TR
 Ic
 EV
 Wg
-uJ
-uJ
+Dn
+yu
 Wg
 eG
 Wg

--- a/nebula.dme
+++ b/nebula.dme
@@ -1077,6 +1077,7 @@
 #include "code\game\objects\items\_item_interactions.dm"
 #include "code\game\objects\items\_item_materials.dm"
 #include "code\game\objects\items\_item_melting.dm"
+#include "code\game\objects\items\_item_reagents.dm"
 #include "code\game\objects\items\apc_frame.dm"
 #include "code\game\objects\items\blackout.dm"
 #include "code\game\objects\items\blueprints.dm"


### PR DESCRIPTION
## Description of changes
Move certain standard reagent interactions down to `/item`-level.
Adds `ATOM_FLAG_OPEN_CONTAINER` to oil lanterns.
Fixes a typo in the oil lantern description.
Oil lanterns in wall sconces can be refueled without having to take them down first.
Generalizes zippo refueling interactions to `/obj/item/flame/fuelled`.
Adds an ebony barrel full of plant oil to the general store in Shaded Hills.

## Why and what will this PR improve
Oil lanterns can be refilled with oil. Fixes #4010.
Fuelled flame item refueling code should be more consistent.
Refueling lanterns in wall sconces should be easier and quicker now.
Allows for deeper interactions with reagent dispensers and removes over-reliance on the `/obj/item/chems` subtype.

## Authorship
Me.