### PR TITLE
Add straw floor turf with placeholder icon

### DIFF
--- a/code/game/turfs/floors/subtypes/floor_misc.dm
+++ b/code/game/turfs/floors/subtypes/floor_misc.dm
@@ -48,3 +48,10 @@
 	icon_state = "woven"
 	color = COLOR_BEIGE
 	initial_flooring = /decl/flooring/woven
+
+/turf/floor/straw
+	name = "loose straw"
+	// TEMPORARY ICON, CHANGE LATER
+	icon = 'icons/turf/flooring/wildgrass.dmi'
+	icon_state = "0"
+	color = COLOR_WHEAT

--- a/maps/shaded_hills/shaded_hills-inn.dmm
+++ b/maps/shaded_hills/shaded_hills-inn.dmm
@@ -590,7 +590,7 @@
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/inn)
 "PA" = (
-/turf/floor/woven,
+/turf/floor/straw,
 /area/shaded_hills/stable)
 "PQ" = (
 /obj/structure/closet/crate/chest,
@@ -698,7 +698,7 @@
 /obj/structure/railing/mapped/ebony{
 	dir = 8
 	},
-/turf/floor/woven,
+/turf/floor/straw,
 /area/shaded_hills/stable)
 "Wl" = (
 /obj/structure/table/woodentable_reinforced/ebony,


### PR DESCRIPTION
## Description of changes
Adds a straw floor turf that uses the wildgrass icon, replacing the woven floors in the stable.

## Why and what will this PR improve
It's a marginally better placeholder than the woven tile and is actually its own type.