### PR TITLE
Rewrite cmp_name_or_type_asc to avoid iterating vars

### DIFF
--- a/code/_helpers/cmp.dm
+++ b/code/_helpers/cmp.dm
@@ -17,7 +17,7 @@
 	return a.sort_order - b.sort_order
 
 /proc/cmp_name_or_type_asc(atom/a, atom/b)
-	return sorttext(istype(b) || ("name" in b.vars) ? b.name : b.type, istype(a) || ("name" in a.vars) ? a.name : a.type)
+	return sorttext("[b]", "[a]")
 
 /proc/cmp_name_asc(atom/a, atom/b)
 	return sorttext(b.name, a.name)

--- a/code/controllers/subsystems/initialization/materials.dm
+++ b/code/controllers/subsystems/initialization/materials.dm
@@ -58,7 +58,7 @@ SUBSYSTEM_DEF(materials)
 	build_material_lists()       // Build core material lists.
 	build_fusion_reaction_list() // Build fusion reaction tree.
 	materials = sortTim(SSmaterials.materials, /proc/cmp_name_asc)
-	materials_by_name = sortTim(SSmaterials.materials_by_name, /proc/cmp_name_or_type_asc, TRUE)
+	materials_by_name = sortTim(SSmaterials.materials_by_name, /proc/cmp_text_asc, FALSE) // sort by key, so DON'T use associative = TRUE
 
 	var/alpha_inc = 256 / DAMAGE_OVERLAY_COUNT
 	for(var/i = 1; i <= DAMAGE_OVERLAY_COUNT; i++)


### PR DESCRIPTION
## Description of changes
I'm just relying on stringification here, since if name doesn't exist or is unset, it'll be the type.

## Why and what will this PR improve
Shaves 0.3 seconds off of SSmaterials init, plus iterating vars is icky and bad practice anyway.