### PR TITLE
Fix miscellaneous issues with fluids

### DIFF
--- a/code/controllers/subsystems/fluids.dm
+++ b/code/controllers/subsystems/fluids.dm
@@ -180,7 +180,7 @@ SUBSYSTEM_DEF(fluids)
 		if(current_depth <= FLUID_PUDDLE)
 			continue
 
-		if(lowest_neighbor)
+		if(lowest_neighbor && lowest_neighbor_flow)
 			current_fluid_holder.transfer_fluids_to(lowest_neighbor, lowest_neighbor_flow)
 			pending_flows[current_fluid_holder] = TRUE
 			if(lowest_neighbor_flow >= FLUID_PUSH_THRESHOLD)

--- a/code/game/turfs/floors/natural/_natural.dm
+++ b/code/game/turfs/floors/natural/_natural.dm
@@ -110,7 +110,7 @@
 /turf/floor/natural/on_reagent_change()
 	. = ..()
 	if(!QDELETED(src) && reagent_type && height < 0 && !QDELETED(reagents) && reagents.total_volume < abs(height))
-		add_to_reagents(abs(height) - reagents.total_volume)
+		add_to_reagents(reagent_type, abs(height) - reagents.total_volume)
 
 /turf/floor/natural/dismantle_turf(devastated, explode, no_product)
 	return !!switch_to_base_turf()

--- a/code/modules/fluids/_fluid.dm
+++ b/code/modules/fluids/_fluid.dm
@@ -62,6 +62,14 @@
 			set_overlays("ocean")
 	else
 		cut_overlays()
+// Define FLUID_AMOUNT_DEBUG before this to get a handy overlay of fluid amounts.
+#ifdef FLUID_AMOUNT_DEBUG
+	var/image/I = new()
+	I.maptext = STYLE_SMALLFONTS_OUTLINE("<center>[num2text(reagent_volume)]</center>", 6, COLOR_WHITE, COLOR_BLACK)
+	I.maptext_y = 8
+	I.appearance_flags |= KEEP_APART
+	add_overlay(I)
+#endif
 	compile_overlays()
 
 	if((last_update_depth > FLUID_PUDDLE) != (reagent_volume > FLUID_PUDDLE))

--- a/code/modules/hydroponics/trays/tray_soil.dm
+++ b/code/modules/hydroponics/trays/tray_soil.dm
@@ -60,7 +60,7 @@
 	var/turf/T = get_turf(src)
 	if(istype(T) && !closed_system)
 		var/space_left = reagents ? (reagents.maximum_volume - reagents.total_volume) : 0
-		if(space_left > 0 && reagents.total_volume < 10)
+		if(waterlevel < 100 && space_left > 0 && reagents.total_volume < 10)
 			for(var/step_dir in global.alldirs)
 				var/turf/neighbor = get_step_resolving_mimic(src, step_dir)
 				if(neighbor != loc && neighbor?.reagents?.total_volume && Adjacent(neighbor))


### PR DESCRIPTION
- SSfluids won't call `transfer_fluids_to` with an amount of 0, avoiding some miniscule overhead.
- Natural turfs now refill reagents properly.
- Adds debug code for displaying fluid amounts via maptext, enabled by a define.
- Soil plots will no longer suck up water if at max waterlevel.