### PR TITLE
Adjust wood types on Shaded Hills

### DIFF
--- a/code/__defines/colors.dm
+++ b/code/__defines/colors.dm
@@ -148,7 +148,7 @@ var/global/list/telecomms_colours = list(
 #define WOOD_COLOR_RICH        "#792f27"
 #define WOOD_COLOR_PALE        "#d2bc9d"
 #define WOOD_COLOR_PALE2       "#e6d2ba"
-#define WOOD_COLOR_BLACK       "#332521"
+#define WOOD_COLOR_BLACK       "#39342c"
 #define WOOD_COLOR_CHOCOLATE   "#543c30"
 #define WOOD_COLOR_YELLOW      "#e3994e"
 

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -443,11 +443,32 @@
 /obj/structure/fire_source/fireplace/grab_attack(obj/item/grab/G)
 	return FALSE
 
+#define MATERIAL_FIREPLACE(material_name) \
+/obj/structure/fire_source/fireplace/##material_name { \
+	color = TYPE_INITIAL(/decl/material/solid/stone/##material_name, color); \
+	material = /decl/material/solid/stone/##material_name; \
+}
+
 /obj/structure/fire_source/fireplace/basalt
 	material = /decl/material/solid/stone/basalt
 
+/obj/structure/fire_source/fireplace/marble
+	material = /decl/material/solid/stone/marble
+
+/obj/structure/fire_source/fireplace/granite
+	material = /decl/material/solid/stone/granite
+
+/obj/structure/fire_source/fireplace/pottery
+	material = /decl/material/solid/stone/pottery
+
 /obj/structure/fire_source/firepit/basalt
 	material = /decl/material/solid/stone/basalt
+
+/obj/structure/fire_source/firepit/marble
+	material = /decl/material/solid/stone/marble
+
+/obj/structure/fire_source/firepit/granite
+	material = /decl/material/solid/stone/granite
 
 #undef FUEL_CONSUMPTION_CONSTANT
 #undef FIRE_LIT

--- a/code/game/turfs/floors/subtypes/floor_path.dm
+++ b/code/game/turfs/floors/subtypes/floor_path.dm
@@ -38,17 +38,23 @@
 //	initial_flooring = /decl/flooring/path/herringbone
 
 // Material subtypes.
-/turf/floor/natural/path/basalt
-	color = COLOR_DARK_GRAY
-	base_color = COLOR_DARK_GRAY
-	material = /decl/material/solid/stone/basalt
-
-/turf/floor/natural/path/herringbone/basalt
-	color = COLOR_DARK_GRAY
-	base_color = COLOR_DARK_GRAY
-	material = /decl/material/solid/stone/basalt
-
-/turf/floor/natural/path/running_bond/basalt
-	color = COLOR_DARK_GRAY
-	base_color = COLOR_DARK_GRAY
-	material = /decl/material/solid/stone/basalt
+#define PATH_MATERIAL_SUBTYPES(material_name) \
+/turf/floor/natural/path/##material_name { \
+	color = TYPE_INITIAL(/decl/material/solid/stone/##material_name, color); \
+	base_color = TYPE_INITIAL(/decl/material/solid/stone/##material_name, color); \
+	material = /decl/material/solid/stone/##material_name; \
+} \
+/turf/floor/natural/path/herringbone/##material_name { \
+	color = TYPE_INITIAL(/decl/material/solid/stone/##material_name, color); \
+	base_color = TYPE_INITIAL(/decl/material/solid/stone/##material_name, color); \
+	material = /decl/material/solid/stone/##material_name; \
+} \
+/turf/floor/natural/path/running_bond/##material_name { \
+	color = TYPE_INITIAL(/decl/material/solid/stone/##material_name, color); \
+	base_color = TYPE_INITIAL(/decl/material/solid/stone/##material_name, color); \
+	material = /decl/material/solid/stone/##material_name; \
+}
+PATH_MATERIAL_SUBTYPES(basalt)
+PATH_MATERIAL_SUBTYPES(granite)
+PATH_MATERIAL_SUBTYPES(marble)
+#undef PATH_MATERIAL_SUBTYPES

--- a/code/game/turfs/walls/wall_brick.dm
+++ b/code/game/turfs/walls/wall_brick.dm
@@ -21,9 +21,15 @@
 		desc = "A brick wall made of [material.solid_name]."
 
 // Subtypes.
-/turf/wall/brick/sandstone
-	color = COLOR_GOLD
+#define MATERIAL_BRICK_WALL(material_name) \
+/turf/wall/brick/##material_name { \
+	color = TYPE_INITIAL(/decl/material/solid/stone/##material_name, color); \
+	material = /decl/material/solid/stone/##material_name; \
+}
 
-/turf/wall/brick/basalt
-	material = /decl/material/solid/stone/basalt
-	color = COLOR_DARK_GRAY
+MATERIAL_BRICK_WALL(sandstone)
+MATERIAL_BRICK_WALL(basalt)
+MATERIAL_BRICK_WALL(granite)
+MATERIAL_BRICK_WALL(marble)
+MATERIAL_BRICK_WALL(pottery)
+#undef MATERIAL_BRICK_WALL

--- a/code/modules/random_map/noise/forage.dm
+++ b/code/modules/random_map/noise/forage.dm
@@ -83,8 +83,10 @@
 		)
 	)
 	var/list/trees = list(
-		/obj/structure/flora/tree/hardwood/ebony = 9,
-		/obj/structure/flora/tree/dead/ebony = 1
+		/obj/structure/flora/tree/hardwood/walnut = 9,
+		/obj/structure/flora/tree/dead/walnut = 1,
+		/obj/structure/flora/tree/hardwood/ebony = 1,
+		/obj/structure/flora/tree/dead/ebony = 1,
 	)
 	var/list/cave_trees = list(
 		/obj/structure/flora/tree/softwood/towercap

--- a/maps/shaded_hills/levels/random_map.dm
+++ b/maps/shaded_hills/levels/random_map.dm
@@ -47,8 +47,8 @@
 /datum/random_map/noise/forage/shaded_hills/swamp
 	tree_weight = 4
 	trees = list(
-		/obj/structure/flora/tree/hardwood/ebony = 1,
-		/obj/structure/flora/tree/dead/ebony = 2,
+		/obj/structure/flora/tree/hardwood/walnut = 1,
+		/obj/structure/flora/tree/dead/walnut = 2,
 		/obj/structure/flora/bush = 4,
 		/obj/structure/flora/bush/leafybush = 5,
 		/obj/structure/flora/bush/grassybush = 5,
@@ -78,9 +78,11 @@
 /datum/random_map/noise/forage/shaded_hills/woods
 	tree_weight = 7
 	trees = list(
+		/obj/structure/flora/tree/hardwood/walnut = 8,
 		/obj/structure/flora/tree/hardwood/yew = 8,
 		/obj/structure/flora/tree/hardwood/mahogany = 8,
 		/obj/structure/flora/bush/pointybush = 5,
+		/obj/structure/flora/tree/dead/walnut = 1,
 		/obj/structure/flora/tree/dead/yew = 1,
 		/obj/structure/flora/tree/dead/mahogany = 1,
 		/obj/structure/flora/bush/genericbush = 1,


### PR DESCRIPTION
## Description of changes
Adds extra stone and wood presets for furniture, walls, and floors.
Makes ebony wood slightly lighter.
Replaces non-furniture uses of ebony on Shaded Hills with walnut, and makes walnut the dominant tree instead of ebony.

## Why and what will this PR improve
Shaded Hills is less oppressively dark, more presets for use in mapping.