### PR TITLE
Add job descriptions to Shaded Hills and improve job displays

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -538,13 +538,15 @@ SUBSYSTEM_DEF(jobs)
 		for(var/decl/loadout_option/G in spawn_in_storage)
 			G.spawn_in_storage_or_drop(H, H.client.prefs.Gear()[G.name])
 
-	to_chat(H, "<font size = 3><B>You are [job.total_positions == 1 ? "the" : "a"] [alt_title || job_title].</B></font>")
+	var/article = job.total_positions == 1 ? "the" : "a"
+	to_chat(H, "<font size = 3><B>You are [article] [alt_title || job_title].</B></font>")
 
-	if(job.description)
-		to_chat(H, SPAN_BOLD("[job.description]"))
+	var/job_description = job.get_description_blurb()
+	if(job_description)
+		to_chat(H, SPAN_BOLD("[job_description]"))
 
 	if(job.supervisors)
-		to_chat(H, "<b>As the [alt_title || job_title] you answer directly to [job.supervisors]. Special circumstances may change this.</b>")
+		to_chat(H, "<b>As [article] [alt_title || job_title] you answer directly to [job.supervisors]. Special circumstances may change this.</b>")
 
 	if(H.has_headset_in_ears())
 		to_chat(H, "<b>To speak on your department's radio channel use [H.get_department_radio_prefix()]h. For the use of other channels, examine your headset.</b>")

--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -370,6 +370,17 @@
 	if(!SSjobs.job_icons[title])
 		var/mob/living/carbon/human/dummy/mannequin/mannequin = get_mannequin("#job_icon")
 		if(mannequin)
+			var/decl/species/mannequin_species = get_species_by_key(global.using_map.default_species)
+			if(!is_species_allowed(mannequin_species))
+				// Don't just default to the first species allowed, pick one at random.
+				for(var/other_species in shuffle(get_playable_species()))
+					var/decl/species/other_species_decl = get_species_by_key(other_species)
+					if(is_species_allowed(other_species_decl))
+						mannequin_species = other_species_decl
+						break
+			if(!is_species_allowed(mannequin_species))
+				PRINT_STACK_TRACE("No allowed species allowed for job [title] ([type]), falling back to default!")
+			mannequin.change_species(mannequin_species.name)
 			dress_mannequin(mannequin)
 			mannequin.set_dir(SOUTH)
 			var/icon/preview_icon = getFlatIcon(mannequin)

--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -11,7 +11,7 @@
 	var/guestbanned = FALSE                   // If set to 1 this job will be unavalible to guests
 	var/must_fill = FALSE                     // If set to 1 this job will be have priority over other job preferences. Do not recommend on jobs with more than one position.
 	var/not_random_selectable = FALSE         // If set to 1 this job will not be selected when a player asks for a random job.
-	var/description                           // If set, returns a static description. To add dynamic text, overwrite this proc, call parent aka . = ..() and then . += "extra text" on the line after that.
+	var/description                           // If set, returns a static description. To add dynamic text, override get_description_blurb, call parent aka . = ..() and then . += "extra text" on the line after that.
 	var/list/event_categories                 // A set of tags used to check jobs for suitability for things like random event selection.
 	var/skip_loadout_preview = FALSE          // Whether or not the job should render loadout items in char preview.
 	var/supervisors = null                    // Supervisors, who this person answers to directly

--- a/code/modules/client/preference_setup/background/01_species.dm
+++ b/code/modules/client/preference_setup/background/01_species.dm
@@ -16,7 +16,7 @@
 /datum/category_item/player_setup_item/background/species/proc/sanitize_species()
 
 	if(!pref.species || !get_species_by_key(pref.species))
-		pref.species = global.using_map.default_species
+		pref.set_species(global.using_map.default_species)
 	var/decl/species/mob_species = get_species_by_key(pref.species)
 	var/decl/bodytype/mob_bodytype = mob_species.get_bodytype_by_name(pref.bodytype) || mob_species.default_bodytype
 	var/decl/pronouns/pronouns = get_pronouns_by_gender(pref.gender)
@@ -89,14 +89,7 @@
 
 		var/choice = href_list["set_species"]
 		if(choice != pref.species)
-
-			pref.species = choice
-			pref.sanitize_preferences()
-			var/decl/species/mob_species = pref.get_species_decl()
-			mob_species.handle_post_species_pref_set(pref)
-			var/decl/bodytype/mob_bodytype = pref.get_bodytype_decl()
-			mob_bodytype.handle_post_bodytype_pref_set(pref)
-
+			pref.set_species(choice)
 			return TOPIC_REFRESH_UPDATE_PREVIEW
 
 	. = ..()

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -63,7 +63,7 @@
 	var/decl/bodytype/bodytype = S.get_bodytype_by_name(pref.bodytype)
 	if(!istype(bodytype) || !(bodytype in S.available_bodytypes))
 		bodytype = S.get_bodytype_by_pronouns(pronouns)
-		pref.bodytype = bodytype.name
+		pref.set_bodytype(bodytype.name)
 
 /datum/category_item/player_setup_item/physical/basic/content()
 
@@ -140,10 +140,9 @@
 	else if(href_list["bodytype"])
 		var/decl/bodytype/new_body = locate(href_list["bodytype"])
 		if(istype(new_body) && CanUseTopic(user) && (new_body in S.available_bodytypes))
-			pref.bodytype = new_body.name
+			pref.set_bodytype(new_body.name)
 			if(new_body.associated_gender) // Set to default for male/female to avoid confusing people
 				pref.gender = new_body.associated_gender
-		new_body.handle_post_bodytype_pref_set(pref)
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 
 	else if(href_list["spawnpoint"])

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -418,7 +418,8 @@
 			if(job.head_position)
 				dat += "You are in charge of this department."
 
-		dat += "You answer to <b>[job.supervisors]</b> normally."
+		if(job.supervisors)
+			dat += "You answer to <b>[job.supervisors]</b> normally."
 
 		if(job.allowed_branches)
 			dat += "You can be of following ranks:"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -507,3 +507,17 @@ var/global/list/time_prefs_fixed = list()
 		// Preferences datum - also holds some persistant data for the client (because we may as well keep these datums to a minimum).
 		SScharacter_setup.preferences_datums[client.ckey] = src
 		setup()
+
+/datum/preferences/proc/set_species(new_species)
+	species = new_species
+	sanitize_preferences()
+	var/decl/species/mob_species = get_species_decl()
+	mob_species.handle_post_species_pref_set(src)
+	var/decl/bodytype/mob_bodytype = get_bodytype_decl()
+	set_bodytype(mob_bodytype)
+
+/datum/preferences/proc/set_bodytype(new_bodytype)
+	bodytype = new_bodytype
+	sanitize_preferences()
+	var/decl/bodytype/mob_bodytype = get_bodytype_decl()
+	mob_bodytype.handle_post_bodytype_pref_set(src)

--- a/code/modules/mob/living/carbon/human/human_appearance.dm
+++ b/code/modules/mob/living/carbon/human/human_appearance.dm
@@ -20,7 +20,7 @@
 	if(!new_species)
 		return
 
-	if(species == new_species)
+	if(species?.name == new_species)
 		return
 
 	if(!(new_species in get_all_species()))
@@ -44,14 +44,12 @@
 	if (antag && antag.required_language)
 		add_language(antag.required_language)
 		set_default_language(antag.required_language)
-	reset_hair()
 	try_refresh_visible_overlays()
 	return 1
 
 /mob/living/carbon/human/set_gender(var/new_gender, var/update_body = FALSE)
 	. = ..()
 	if(. && update_body)
-		reset_hair()
 		update_body()
 		update_dna()
 

--- a/code/modules/sprite_accessories/accessory_markings.dm
+++ b/code/modules/sprite_accessories/accessory_markings.dm
@@ -1,15 +1,16 @@
 /decl/sprite_accessory_category/markings
-	name                = "Markings"
-	single_selection    = FALSE
-	base_accessory_type = /decl/sprite_accessory/marking
-	uid                 = "acc_cat_markings"
-	clear_in_pref_apply = TRUE
+	name                  = "Markings"
+	single_selection      = FALSE
+	base_accessory_type   = /decl/sprite_accessory/marking
+	uid                   = "acc_cat_markings"
+	always_apply_defaults = TRUE
+	clear_in_pref_apply   = TRUE
 
 /decl/sprite_accessory/marking
-	icon                = 'icons/mob/human_races/species/default_markings.dmi'
-	abstract_type       = /decl/sprite_accessory/marking
-	mask_to_bodypart    = TRUE
-	accessory_category  = SAC_MARKINGS
+	icon                  = 'icons/mob/human_races/species/default_markings.dmi'
+	abstract_type         = /decl/sprite_accessory/marking
+	mask_to_bodypart      = TRUE
+	accessory_category    = SAC_MARKINGS
 
 /decl/sprite_accessory/marking/refresh_mob(var/mob/living/subject)
 	if(istype(subject))

--- a/maps/shaded_hills/jobs/inn.dm
+++ b/maps/shaded_hills/jobs/inn.dm
@@ -9,6 +9,8 @@
 
 /datum/job/shaded_hills/inn/innkeeper
 	title                   = "Innkeeper"
+	supervisors             = "your business and self-interest"
+	description             = "You are the proprietor of the inn, directing your employees and ensuring guests are treated properly, whatever you think that may mean."
 	spawn_positions         = 1
 	total_positions         = 1
 	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/innkeeper
@@ -27,6 +29,8 @@
 
 /datum/job/shaded_hills/inn/inn_worker
 	title                   = "Inn Worker"
+	supervisors             = "the innkeeper"
+	description             = "You work at the inn, though your exact duties are nebulous. You may be a cook in the kitchen, someone who keeps the lanterns lit and the furniture from falling apart, or something else entirely; either way, you have to earn your keep."
 	spawn_positions         = 3
 	total_positions         = 3
 	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/inn_worker
@@ -36,6 +40,8 @@
 
 /datum/job/shaded_hills/inn/bartender
 	title                   = "Bartender"
+	supervisors             = "the innkeeper"
+	description             = "You work the bar at the inn and ensure that patrons are fed, slaked, and merry. If you keep the hearth lit and prepare fresh food and drink, you will certainly earn your keep."
 	spawn_positions         = 2
 	total_positions         = 2
 	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/bartender
@@ -45,6 +51,8 @@
 
 /datum/job/shaded_hills/inn/farmer
 	title                   = "Farmer"
+	supervisors             = "your self-interest"
+	description             = "You grow crops both for your own subsistence and to sell to others like the innkeeper or general store. You are knowledgeable of local plants grown for sustenance, but your knowledge of niche herbs may be spottier."
 	spawn_positions         = 3
 	total_positions         = 3
 	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/farmer

--- a/maps/shaded_hills/jobs/visitors.dm
+++ b/maps/shaded_hills/jobs/visitors.dm
@@ -9,6 +9,8 @@
 
 /datum/job/shaded_hills/visitor/traveller
 	title                   = "Traveller"
+	supervisors             = "your conscience"
+	description             = "You have travelled to this area from elsewhere. You may be a vagabond, a wastrel, a nomad, or just passing through on your way to somewhere else. How long you're staying and where you're headed is up to you entirely."
 	spawn_positions         = -1
 	total_positions         = -1
 	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/traveller

--- a/maps/shaded_hills/jobs/wilderness.dm
+++ b/maps/shaded_hills/jobs/wilderness.dm
@@ -9,6 +9,8 @@
 
 /datum/job/shaded_hills/local/miner
 	title                   = "Miner"
+	description             = "You mine ores from the mountain, and occasionally refine them, too. The only limit to your potential bounty is your own hard work and ingenuity... and the kobaloi in the caves."
+	supervisors             = "the consequences of your actions"
 	spawn_positions         = 1
 	total_positions         = 1
 	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/miner
@@ -18,6 +20,8 @@
 
 /datum/job/shaded_hills/local/herbalist
 	title                   = "Herbalist"
+	description             = "You collect and grow plants and herbs and process them into various useful substances, such as medicinal tinctures, ointments, and teas."
+	supervisors             = "nature"
 	spawn_positions         = 1
 	total_positions         = 1
 	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/herbalist
@@ -27,6 +31,8 @@
 
 /datum/job/shaded_hills/local/forester
 	title                   = "Forester"
+	description             = "You are at home in nature, whether you're fishing, hunting wild game, or chopping timber for firewood and construction."
+	supervisors             = "nature"
 	spawn_positions         = 1
 	total_positions         = 1
 	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/forester


### PR DESCRIPTION
## Description of changes
Add job descriptions and supervisors to Shaded Hills.
Fix articles in job message display.
Allow jobs that blacklist the default species to use a different species as their preview mannequin's species.
Fix kobaloi mannequins not getting their ears, and kobaloi not having ears by default.
Fixes a broken redundancy check in `change_species`.

## Why and what will this PR improve
Bunch of fixes and improvements.