### PR TITLE
Fixing bad proc ref in timers.

### DIFF
--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -273,7 +273,7 @@ SUBSYSTEM_DEF(timer)
 		return
 
 	// Sort all timers by time to run
-	sortTim(alltimers, PROC_REF(cmp_timer))
+	sortTim(alltimers, /proc/cmp_timer)
 
 	// Get the earliest timer, and if the TTR is earlier than the current world.time,
 	// then set the head offset appropriately to be the earliest time tracked by the


### PR DESCRIPTION
Other timer cmp procs just use `/proc` and this one is generating a 'bad proc' runtime on dev testing.