### PR TITLE
Fix Shaded Hills issues for May 21, 2024

### DIFF
--- a/code/game/objects/items/_item_materials.dm
+++ b/code/game/objects/items/_item_materials.dm
@@ -56,6 +56,16 @@
 /obj/item/get_material()
 	. = material
 
+// TODO: Refactor more code to use this where necessary, and then make this use
+// some sort of generalized system for hitting with different parts of an item
+// e.g. pommel vs blade, rifle butt vs bayonet, knife hilt vs blade
+/// What material are we using when we hit things?
+/// Params:
+///   mob/user (the mob striking something with src)
+///   atom/target (the atom being struck with src)
+/obj/item/proc/get_striking_material(mob/user, atom/target)
+	return get_material()
+
 /obj/item/proc/update_force()
 	var/new_force
 	if(!max_force)

--- a/code/game/objects/items/blades/folding.dm
+++ b/code/game/objects/items/blades/folding.dm
@@ -49,5 +49,6 @@
 		attack_verb = closed_attack_verbs
 	..()
 
-/obj/item/knife/folding/get_mob_overlay(mob/user_mob, slot, bodypart, use_fallback_if_icon_missing = TRUE, skip_adjustment = FALSE)
+// Only show the inhand sprite when open.
+/obj/item/bladed/folding/get_mob_overlay(mob/user_mob, slot, bodypart, use_fallback_if_icon_missing = TRUE, skip_adjustment = FALSE)
 	. = open ? ..() : new /image

--- a/code/game/objects/items/blades/folding.dm
+++ b/code/game/objects/items/blades/folding.dm
@@ -52,3 +52,7 @@
 // Only show the inhand sprite when open.
 /obj/item/bladed/folding/get_mob_overlay(mob/user_mob, slot, bodypart, use_fallback_if_icon_missing = TRUE, skip_adjustment = FALSE)
 	. = open ? ..() : new /image
+
+// TODO: Select hilt, guard, etc. as striking material based on dynamic intents
+/obj/item/bladed/folding/get_striking_material(mob/user, atom/target)
+	. = open ? ..() : hilt_material

--- a/code/game/objects/items/rock.dm
+++ b/code/game/objects/items/rock.dm
@@ -23,7 +23,7 @@
 		var/turf/spark_turf = get_turf(src)
 		if(loc == user) // held in inventory
 			var/turf/front_spark_turf = get_step_resolving_mimic(spark_turf, user.dir)
-			if(istype(front_spark_turf) && !front_spark_turf.contains_dense_objects() && user.Adjacent(front_spark_turf))
+			if(istype(front_spark_turf) && !front_spark_turf.density && front_spark_turf.ClickCross(global.reverse_dir[user.dir]) && user.Adjacent(front_spark_turf))
 				spark_turf = front_spark_turf
 		if(spark_turf)
 			spark_at(spark_turf, amount = 2, spark_type = /datum/effect/effect/system/spark_spread/non_electrical)
@@ -41,6 +41,9 @@
 	material = /decl/material/solid/stone/flint
 
 /obj/item/rock/flint/striker
-	name = "striker"
-	desc = "A squared-off, rather worn-down piece of stone."
-	icon = 'icons/obj/items/striker.dmi'
+	name    = "striker"
+	desc    = "A squared-off, rather worn-down piece of stone."
+	icon    = 'icons/obj/items/striker.dmi'
+	sharp   = FALSE
+	edge    = FALSE
+	w_class = ITEM_SIZE_TINY

--- a/code/game/objects/items/rock.dm
+++ b/code/game/objects/items/rock.dm
@@ -23,7 +23,7 @@
 		var/turf/spark_turf = get_turf(src)
 		if(loc == user) // held in inventory
 			var/turf/front_spark_turf = get_step_resolving_mimic(spark_turf, user.dir)
-			if(istype(front_spark_turf) && user.Adjacent(front_spark_turf))
+			if(istype(front_spark_turf) && !front_spark_turf.contains_dense_objects() && user.Adjacent(front_spark_turf))
 				spark_turf = front_spark_turf
 		if(spark_turf)
 			spark_at(spark_turf, amount = 2, spark_type = /datum/effect/effect/system/spark_spread/non_electrical)

--- a/code/game/objects/items/rock.dm
+++ b/code/game/objects/items/rock.dm
@@ -19,7 +19,9 @@
 // TODO: craft a flint striker from a flint and a piece of metal
 /obj/item/rock/attackby(obj/item/W, mob/user)
 
-	if((W.material?.ferrous && material?.type == /decl/material/solid/stone/flint) || (material?.ferrous && W.material?.type == /decl/material/solid/stone/flint))
+	var/decl/material/weapon_material = W.get_striking_material()
+	var/decl/material/our_material = get_material()
+	if((weapon_material?.ferrous && our_material?.type == /decl/material/solid/stone/flint) || (our_material?.ferrous && weapon_material?.type == /decl/material/solid/stone/flint))
 		var/turf/spark_turf = get_turf(src)
 		if(loc == user) // held in inventory
 			var/turf/front_spark_turf = get_step_resolving_mimic(spark_turf, user.dir)

--- a/code/game/objects/items/weapons/material/folding.dm
+++ b/code/game/objects/items/weapons/material/folding.dm
@@ -1,5 +1,5 @@
-
 // folding/locking knives
+// TODO: Replace these with or merge these into /obj/item/bladed/folding
 /obj/item/knife/folding
 	name = "pocketknife"
 	desc = "A small folding knife."
@@ -58,11 +58,17 @@
 	icon = 'icons/obj/items/weapon/knives/folding/peasant.dmi'
 	valid_handle_colors = list(WOOD_COLOR_GENERIC, WOOD_COLOR_RICH, WOOD_COLOR_BLACK, WOOD_COLOR_CHOCOLATE, WOOD_COLOR_PALE)
 
+/obj/item/knife/folding/wood/get_striking_material(mob/user, atom/target)
+	. = open ? ..() : GET_DECL(/decl/material/solid/organic/wood) // todo: different handle colors -> different material
+
 /obj/item/knife/folding/tacticool
 	name = "folding knife"
 	desc = "A small folding knife with a polymer handle and a blackened steel blade. These are typically marketed for self defense purposes."
 	icon = 'icons/obj/items/weapon/knives/folding/tacticool.dmi'
 	valid_handle_colors = list("#0f0f2a", "#2a0f0f", "#0f2a0f", COLOR_GRAY20, COLOR_DARK_GUNMETAL)
+
+/obj/item/knife/folding/tacticool/get_striking_material(mob/user, atom/target)
+	. = open ? ..() : GET_DECL(/decl/material/solid/organic/plastic)
 
 /obj/item/knife/folding/combat //master obj
 	name = "switchblade"

--- a/code/game/objects/structures/doors/_door.dm
+++ b/code/game/objects/structures/doors/_door.dm
@@ -219,10 +219,19 @@
 
 /obj/structure/door/wood/ebony
 	material = /decl/material/solid/organic/wood/ebony
-	color = WOOD_COLOR_BLACK
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood/ebony, color)
 
 /obj/structure/door/wood/saloon/ebony
 	material = /decl/material/solid/organic/wood/ebony
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood/ebony, color)
+
+/obj/structure/door/wood/walnut
+	material = /decl/material/solid/organic/wood/walnut
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood/walnut, color)
+
+/obj/structure/door/wood/saloon/walnut
+	material = /decl/material/solid/organic/wood/walnut
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood/walnut, color)
 
 /obj/structure/door/glass
 	material = /decl/material/solid/glass

--- a/code/game/objects/structures/doors/_door.dm
+++ b/code/game/objects/structures/doors/_door.dm
@@ -219,19 +219,19 @@
 
 /obj/structure/door/wood/ebony
 	material = /decl/material/solid/organic/wood/ebony
-	color = TYPE_INITIAL(/decl/material/solid/organic/wood/ebony, color)
+	color = WOOD_COLOR_BLACK // TYPE_INITIAL(/decl/material/solid/organic/wood/ebony, color)
 
 /obj/structure/door/wood/saloon/ebony
 	material = /decl/material/solid/organic/wood/ebony
-	color = TYPE_INITIAL(/decl/material/solid/organic/wood/ebony, color)
+	color = WOOD_COLOR_BLACK // TYPE_INITIAL(/decl/material/solid/organic/wood/ebony, color)
 
 /obj/structure/door/wood/walnut
 	material = /decl/material/solid/organic/wood/walnut
-	color = TYPE_INITIAL(/decl/material/solid/organic/wood/walnut, color)
+	color = WOOD_COLOR_CHOCOLATE // TYPE_INITIAL(/decl/material/solid/organic/wood/walnut, color)
 
 /obj/structure/door/wood/saloon/walnut
 	material = /decl/material/solid/organic/wood/walnut
-	color = TYPE_INITIAL(/decl/material/solid/organic/wood/walnut, color)
+	color = WOOD_COLOR_CHOCOLATE // TYPE_INITIAL(/decl/material/solid/organic/wood/walnut, color)
 
 /obj/structure/door/glass
 	material = /decl/material/solid/glass

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -443,11 +443,13 @@
 /obj/structure/fire_source/fireplace/grab_attack(obj/item/grab/G)
 	return FALSE
 
+/* Uncomment when 515 is the minimum version.
 #define MATERIAL_FIREPLACE(material_name) \
 /obj/structure/fire_source/fireplace/##material_name { \
 	color = TYPE_INITIAL(/decl/material/solid/stone/##material_name, color); \
 	material = /decl/material/solid/stone/##material_name; \
 }
+*/
 
 /obj/structure/fire_source/fireplace/basalt
 	material = /decl/material/solid/stone/basalt

--- a/code/game/turfs/flooring/flooring_wood.dm
+++ b/code/game/turfs/flooring/flooring_wood.dm
@@ -8,28 +8,28 @@
 	build_type = /obj/item/stack/tile/wood
 	flags = TURF_CAN_BREAK | TURF_IS_FRAGILE | TURF_REMOVE_SCREWDRIVER
 	footstep_type = /decl/footsteps/wood
-	color = TYPE_INITIAL(/decl/material/solid/organic/wood, color)
+	color = WOOD_COLOR_GENERIC // TYPE_INITIAL(/decl/material/solid/organic/wood, color)
 
 /decl/flooring/wood/mahogany
-	color = TYPE_INITIAL(/decl/material/solid/organic/wood/mahogany, color)
+	color = WOOD_COLOR_RICH // TYPE_INITIAL(/decl/material/solid/organic/wood/mahogany, color)
 	build_type = /obj/item/stack/tile/mahogany
 
 /decl/flooring/wood/maple
-	color = TYPE_INITIAL(/decl/material/solid/organic/wood/maple, color)
+	color = WOOD_COLOR_PALE // TYPE_INITIAL(/decl/material/solid/organic/wood/maple, color)
 	build_type = /obj/item/stack/tile/maple
 
 /decl/flooring/wood/ebony
-	color = TYPE_INITIAL(/decl/material/solid/organic/wood/ebony, color)
+	color = WOOD_COLOR_BLACK // TYPE_INITIAL(/decl/material/solid/organic/wood/ebony, color)
 	build_type = /obj/item/stack/tile/ebony
 
 /decl/flooring/wood/walnut
-	color = TYPE_INITIAL(/decl/material/solid/organic/wood/walnut, color)
+	color = WOOD_COLOR_CHOCOLATE // TYPE_INITIAL(/decl/material/solid/organic/wood/walnut, color)
 	build_type = /obj/item/stack/tile/walnut
 
 /decl/flooring/wood/bamboo
-	color = TYPE_INITIAL(/decl/material/solid/organic/wood/bamboo, color)
+	color = WOOD_COLOR_PALE2 // TYPE_INITIAL(/decl/material/solid/organic/wood/bamboo, color)
 	build_type = /obj/item/stack/tile/bamboo
 
 /decl/flooring/wood/yew
-	color = TYPE_INITIAL(/decl/material/solid/organic/wood/yew, color)
+	color = WOOD_COLOR_YELLOW // TYPE_INITIAL(/decl/material/solid/organic/wood/yew, color)
 	build_type = /obj/item/stack/tile/yew

--- a/code/game/turfs/flooring/flooring_wood.dm
+++ b/code/game/turfs/flooring/flooring_wood.dm
@@ -8,28 +8,28 @@
 	build_type = /obj/item/stack/tile/wood
 	flags = TURF_CAN_BREAK | TURF_IS_FRAGILE | TURF_REMOVE_SCREWDRIVER
 	footstep_type = /decl/footsteps/wood
-	color = WOOD_COLOR_GENERIC
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood, color)
 
 /decl/flooring/wood/mahogany
-	color = WOOD_COLOR_RICH
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood/mahogany, color)
 	build_type = /obj/item/stack/tile/mahogany
 
 /decl/flooring/wood/maple
-	color = WOOD_COLOR_PALE
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood/maple, color)
 	build_type = /obj/item/stack/tile/maple
 
 /decl/flooring/wood/ebony
-	color = WOOD_COLOR_BLACK
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood/ebony, color)
 	build_type = /obj/item/stack/tile/ebony
 
 /decl/flooring/wood/walnut
-	color = WOOD_COLOR_CHOCOLATE
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood/walnut, color)
 	build_type = /obj/item/stack/tile/walnut
 
 /decl/flooring/wood/bamboo
-	color = WOOD_COLOR_PALE2
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood/bamboo, color)
 	build_type = /obj/item/stack/tile/bamboo
 
 /decl/flooring/wood/yew
-	color = WOOD_COLOR_YELLOW
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood/yew, color)
 	build_type = /obj/item/stack/tile/yew

--- a/code/game/turfs/floors/subtypes/floor_wood.dm
+++ b/code/game/turfs/floors/subtypes/floor_wood.dm
@@ -2,29 +2,29 @@
 	name = "wooden floor"
 	icon = 'icons/turf/flooring/wood.dmi'
 	icon_state = "wood"
-	color = TYPE_INITIAL(/decl/material/solid/organic/wood, color)
+	color = WOOD_COLOR_GENERIC // TYPE_INITIAL(/decl/material/solid/organic/wood, color)
 	initial_flooring = /decl/flooring/wood
 
 /turf/floor/wood/mahogany
-	color = TYPE_INITIAL(/decl/material/solid/organic/wood/mahogany, color)
+	color = WOOD_COLOR_RICH // TYPE_INITIAL(/decl/material/solid/organic/wood/mahogany, color)
 	initial_flooring = /decl/flooring/wood/mahogany
 
 /turf/floor/wood/maple
-	color = TYPE_INITIAL(/decl/material/solid/organic/wood/maple, color)
+	color = WOOD_COLOR_PALE // TYPE_INITIAL(/decl/material/solid/organic/wood/maple, color)
 	initial_flooring = /decl/flooring/wood/maple
 
 /turf/floor/wood/ebony
-	color = TYPE_INITIAL(/decl/material/solid/organic/wood/ebony, color)
+	color = WOOD_COLOR_BLACK // TYPE_INITIAL(/decl/material/solid/organic/wood/ebony, color)
 	initial_flooring = /decl/flooring/wood/ebony
 
 /turf/floor/wood/walnut
-	color = TYPE_INITIAL(/decl/material/solid/organic/wood/walnut, color)
+	color = WOOD_COLOR_CHOCOLATE // TYPE_INITIAL(/decl/material/solid/organic/wood/walnut, color)
 	initial_flooring = /decl/flooring/wood/walnut
 
 /turf/floor/wood/bamboo
-	color = TYPE_INITIAL(/decl/material/solid/organic/wood/bamboo, color)
+	color = WOOD_COLOR_PALE2 // TYPE_INITIAL(/decl/material/solid/organic/wood/bamboo, color)
 	initial_flooring = /decl/flooring/wood/bamboo
 
 /turf/floor/wood/yew
-	color = TYPE_INITIAL(/decl/material/solid/organic/wood/yew, color)
+	color = WOOD_COLOR_YELLOW // TYPE_INITIAL(/decl/material/solid/organic/wood/yew, color)
 	initial_flooring = /decl/flooring/wood/yew

--- a/code/game/turfs/floors/subtypes/floor_wood.dm
+++ b/code/game/turfs/floors/subtypes/floor_wood.dm
@@ -2,29 +2,29 @@
 	name = "wooden floor"
 	icon = 'icons/turf/flooring/wood.dmi'
 	icon_state = "wood"
-	color = WOOD_COLOR_GENERIC
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood, color)
 	initial_flooring = /decl/flooring/wood
 
 /turf/floor/wood/mahogany
-	color = WOOD_COLOR_RICH
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood/mahogany, color)
 	initial_flooring = /decl/flooring/wood/mahogany
 
 /turf/floor/wood/maple
-	color = WOOD_COLOR_PALE
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood/maple, color)
 	initial_flooring = /decl/flooring/wood/maple
 
 /turf/floor/wood/ebony
-	color = WOOD_COLOR_BLACK
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood/ebony, color)
 	initial_flooring = /decl/flooring/wood/ebony
 
 /turf/floor/wood/walnut
-	color = WOOD_COLOR_CHOCOLATE
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood/walnut, color)
 	initial_flooring = /decl/flooring/wood/walnut
 
 /turf/floor/wood/bamboo
-	color = WOOD_COLOR_PALE2
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood/bamboo, color)
 	initial_flooring = /decl/flooring/wood/bamboo
 
 /turf/floor/wood/yew
-	color = WOOD_COLOR_YELLOW
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood/yew, color)
 	initial_flooring = /decl/flooring/wood/yew

--- a/code/game/turfs/walls/wall_log.dm
+++ b/code/game/turfs/walls/wall_log.dm
@@ -1,6 +1,7 @@
 /turf/wall/log
 	icon_state = "log"
 	material = /decl/material/solid/organic/wood
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood, color)
 	girder_material = null
 
 /turf/wall/log/get_dismantle_stack_type()
@@ -21,7 +22,17 @@
 		desc = "A log wall made of [material.solid_name]."
 
 // Subtypes.
-/turf/wall/log/ebony
-	icon_state = "wood"
-	material = /decl/material/solid/organic/wood/ebony
-	color = WOOD_COLOR_BLACK
+#define LOG_WALL_SUBTYPE(material_name) \
+/turf/wall/log/##material_name { \
+	material = /decl/material/solid/organic/wood/##material_name; \
+	color = TYPE_INITIAL(/decl/material/solid/organic/wood/##material_name, color); \
+}
+
+LOG_WALL_SUBTYPE(fungal)
+LOG_WALL_SUBTYPE(ebony)
+LOG_WALL_SUBTYPE(walnut)
+LOG_WALL_SUBTYPE(maple)
+LOG_WALL_SUBTYPE(bamboo)
+LOG_WALL_SUBTYPE(yew)
+
+#undef LOG_WALL_SUBTYPE

--- a/code/game/turfs/walls/wall_log.dm
+++ b/code/game/turfs/walls/wall_log.dm
@@ -22,6 +22,7 @@
 		desc = "A log wall made of [material.solid_name]."
 
 // Subtypes.
+/* Uncomment when 515 is the minimum version.
 #define LOG_WALL_SUBTYPE(material_name) \
 /turf/wall/log/##material_name { \
 	material = /decl/material/solid/organic/wood/##material_name; \
@@ -32,7 +33,37 @@ LOG_WALL_SUBTYPE(fungal)
 LOG_WALL_SUBTYPE(ebony)
 LOG_WALL_SUBTYPE(walnut)
 LOG_WALL_SUBTYPE(maple)
+LOG_WALL_SUBTYPE(mahogany)
 LOG_WALL_SUBTYPE(bamboo)
 LOG_WALL_SUBTYPE(yew)
 
 #undef LOG_WALL_SUBTYPE
+*/
+
+/turf/wall/log/fungal
+	material = /decl/material/solid/organic/wood/fungal
+	color = "#e6d8dd"
+
+/turf/wall/log/ebony
+	material = /decl/material/solid/organic/wood/ebony
+	color = WOOD_COLOR_BLACK
+
+/turf/wall/log/walnut
+	material = /decl/material/solid/organic/wood/walnut
+	color = WOOD_COLOR_CHOCOLATE
+
+/turf/wall/log/maple
+	material = /decl/material/solid/organic/wood/maple
+	color = WOOD_COLOR_PALE
+
+/turf/wall/log/mahogany
+	material = /decl/material/solid/organic/wood/mahogany
+	color = WOOD_COLOR_RICH
+
+/turf/wall/log/bamboo
+	material = /decl/material/solid/organic/wood/bamboo
+	color = WOOD_COLOR_PALE2
+
+/turf/wall/log/yew
+	material = /decl/material/solid/organic/wood/yew
+	color = WOOD_COLOR_YELLOW

--- a/mods/content/fantasy/items/clothing/_loadout.dm
+++ b/mods/content/fantasy/items/clothing/_loadout.dm
@@ -141,9 +141,10 @@
 	)
 
 /decl/loadout_option/fantasy/utility/striker
-	name = "striker"
+	name = "flint striker"
 	path = /obj/item/rock/flint/striker
 	available_materials = null
+	loadout_flags = null
 
 /decl/loadout_option/fantasy/utility/knife
 	name = "knife, belt"


### PR DESCRIPTION
## Description of changes
Makes flint strikers not colorable in loadout, and changes the name from striker to flint striker.
Adds density and ClickCross checks to strikers, so you can't create sparks inside a dense turf or object.
Makes folding blades not display their icon when closed, as intended.
Adds a `get_striking_material()` to represent "which material we're hitting something with," to disambiguate between blade/hilt strikes. TODO: integrate this elsewhere, tie into dynamic intents.
Makes folding blades and folding knives with non-ferrous handles unable to be used to make sparks
Adds a commit that was supposed to be in #4021 (`Replaces non-furniture uses of ebony on Shaded Hills with walnut, and makes walnut the dominant tree instead of ebony.`)

## Why and what will this PR improve
Fixes some broken code and a few bugs/oversights, plus a commit I forgot to include in a prior PR.