### PR TITLE
Heat exchanging pipes: fixes heat radiation to space

### DIFF
--- a/code/modules/atmospherics/datum_pipeline.dm
+++ b/code/modules/atmospherics/datum_pipeline.dm
@@ -286,6 +286,6 @@
 	// Previously, the temperature would enter equilibrium at 26C or 294K.
 	// Only would happen if both sides (all 2 square meters of surface area) were exposed to sunlight.  We now assume it aligned edge on.
 	// It currently should stabilise at 129.6K or -143.6C
-	. -= surface * STEFAN_BOLTZMANN_CONSTANT * thermal_conductivity * (surface_temperature - COSMIC_RADIATION_TEMPERATURE) ** 4
+	. -= surface * STEFAN_BOLTZMANN_CONSTANT * thermal_conductivity * (surface_temperature  ** 4 - COSMIC_RADIATION_TEMPERATURE ** 4)
 
 #undef REAGENT_UNITS_PER_PIPE

--- a/code/modules/atmospherics/he_pipes.dm
+++ b/code/modules/atmospherics/he_pipes.dm
@@ -57,7 +57,9 @@
 	else
 		var/turf/turf = loc
 		var/datum/gas_mixture/pipe_air = return_air()
-		if(istype(turf) && turf.simulated)
+		if(istype(loc, /turf/space))
+			parent.radiate_heat_to_space(surface, 1)
+		else if(istype(turf) && turf.simulated)
 			var/turf/pipe_turf = loc
 			var/environment_temperature = 0
 			if(pipe_turf.blocks_air)
@@ -67,8 +69,6 @@
 				environment_temperature = environment.temperature
 			if(abs(environment_temperature-pipe_air.temperature) > minimum_temperature_difference)
 				parent.temperature_interact(pipe_turf, volume, thermal_conductivity)
-		else if(istype(loc, /turf/space))
-			parent.radiate_heat_to_space(surface, 1)
 
 		if(buckled_mob)
 			var/hc = pipe_air.heat_capacity()


### PR DESCRIPTION
## Description of changes
Heat exchanging pipes now check for being in space before checking whether the turf is simulated, thus allowing radiation cooling to proceed. Also radiation heat loss should use difference of fourth powers, not fourth power of difference.
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
Fixes ScavStation downstream issues with cooling supermatter. Also a bit more precise physics.

## Authorship
Myself

## Changelog
:cl:
tweak: radiation cooling 
bugfix: fixed radiator pipes not radiating in space issue
/:cl: