### PR TITLE
Fixes clamp() args order (at old `between` helper calls)

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -203,7 +203,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 			line+=locate(px,py,M.z)
 	return line
 
-#define LOCATE_COORDS(X, Y, Z) locate(clamp(1, X, world.maxx), clamp(1, Y, world.maxy), Z)
+#define LOCATE_COORDS(X, Y, Z) locate(clamp(X, 1, world.maxx), clamp(Y, 1, world.maxy), Z)
 /proc/getcircle(turf/center, var/radius) //Uses a fast Bresenham rasterization algorithm to return the turfs in a thin circle.
 	if(!radius) return list(center)
 
@@ -230,7 +230,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 #undef LOCATE_COORDS
 
-#define LOCATE_COORDS_SAFE(X, Y, Z) locate(clamp(TRANSITIONEDGE + 1, X, world.maxx - TRANSITIONEDGE), clamp(TRANSITIONEDGE + 1, Y, world.maxy - TRANSITIONEDGE), Z)
+#define LOCATE_COORDS_SAFE(X, Y, Z) locate(clamp(X, TRANSITIONEDGE + 1, world.maxx - TRANSITIONEDGE), clamp(Y, TRANSITIONEDGE + 1, world.maxy - TRANSITIONEDGE), Z)
 /proc/getcirclesafe(turf/center, var/radius) //Uses a fast Bresenham rasterization algorithm to return the turfs in a thin circle.
 	if(!radius) return list(center)
 

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -161,7 +161,7 @@
 		input_info = null
 		refreshing_input = TRUE
 		input_flow_setting = input("What would you like to set the rate limit to?", "Set Volume", input_flow_setting) as num|null
-		input_flow_setting = clamp(0, input_flow_setting, ATMOS_DEFAULT_VOLUME_PUMP+500)
+		input_flow_setting = clamp(input_flow_setting, 0, ATMOS_DEFAULT_VOLUME_PUMP+500)
 		signal.data = list ("tag" = input_tag, "set_volume_rate" = input_flow_setting)
 		. = 1
 
@@ -188,7 +188,7 @@
 		output_info = null
 		refreshing_output = TRUE
 		pressure_setting = input("How much pressure would you like to output?", "Set Pressure", pressure_setting) as num|null
-		pressure_setting = clamp(0, pressure_setting, MAX_PUMP_PRESSURE)
+		pressure_setting = clamp(pressure_setting, 0, MAX_PUMP_PRESSURE)
 		signal.data = list ("tag" = output_tag, "set_internal_pressure" = "[pressure_setting]", "status" = 1)
 		. = 1
 
@@ -196,7 +196,7 @@
 		output_info = null
 		refreshing_output = TRUE
 		pressure_setting = input("How much pressure would you like to maintain inside the core?", "Set Core Pressure", pressure_setting) as num|null
-		pressure_setting = clamp(0, pressure_setting, MAX_PUMP_PRESSURE)
+		pressure_setting = clamp(pressure_setting, 0, MAX_PUMP_PRESSURE)
 		signal.data = list ("tag" = output_tag, "set_external_pressure" = pressure_setting, "checks" = 1, "status" = 1)
 		. = 1
 

--- a/code/game/machinery/doors/_door.dm
+++ b/code/game/machinery/doors/_door.dm
@@ -285,7 +285,7 @@
 			playsound(src, 'sound/items/Welder.ogg', 100, 1)
 			if(do_after(user, 5 * repairing.amount, src) && welder && welder.isOn())
 				to_chat(user, "<span class='notice'>You finish repairing the damage to \the [src].</span>")
-				health = clamp(health, health + repairing.amount*DOOR_REPAIR_AMOUNT, maxhealth)
+				health = clamp(health + repairing.amount*DOOR_REPAIR_AMOUNT, health, maxhealth)
 				update_icon()
 				qdel(repairing)
 				repairing = null

--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -181,7 +181,7 @@
 	var/pressure = 0
 	var/datum/gas_mixture/environment = location.return_air()
 	if(environment) pressure = environment.return_pressure()
-	smoke_duration = clamp(5, smoke_duration*pressure/(ONE_ATMOSPHERE/3), smoke_duration)
+	smoke_duration = clamp(smoke_duration*pressure/(ONE_ATMOSPHERE/3), 5, smoke_duration)
 
 	var/const/arcLength = 2.3559 //distance between each smoke cloud
 

--- a/code/game/objects/structures/_structure_construction.dm
+++ b/code/game/objects/structures/_structure_construction.dm
@@ -110,7 +110,7 @@
 		to_chat(user, SPAN_NOTICE("You fit [used] [stack.singular_name]\s to damaged areas of \the [src]."))
 		stack.use(used)
 		last_damage_message = null
-		health = clamp(health, health + used*DOOR_REPAIR_AMOUNT, maxhealth)
+		health = clamp(health + used*DOOR_REPAIR_AMOUNT, health, maxhealth)
 
 /obj/structure/attackby(obj/item/O, mob/user)
 

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -134,11 +134,11 @@
 		if(BRUTE)
 			//bullets
 			if(Proj.original == src || prob(20))
-				Proj.damage *= clamp(0, Proj.damage/60, 0.5)
+				Proj.damage *= clamp(Proj.damage/60, 0, 0.5)
 				if(prob(max((damage-10)/25, 0))*100)
 					passthrough = 1
 			else
-				Proj.damage *= clamp(0, Proj.damage/60, 1)
+				Proj.damage *= clamp(Proj.damage/60, 0, 1)
 				passthrough = 1
 		if(BURN)
 			//beams and other projectiles are either blocked completely by grilles or stop half the damage.
@@ -148,7 +148,7 @@
 
 	if(passthrough)
 		. = PROJECTILE_CONTINUE
-		damage = clamp(0, (damage - Proj.damage)*(Proj.damage_type == BRUTE? 0.4 : 1), 10) //if the bullet passes through then the grille avoids most of the damage
+		damage = clamp((damage - Proj.damage)*(Proj.damage_type == BRUTE? 0.4 : 1), 0, 10) //if the bullet passes through then the grille avoids most of the damage
 
 	take_damage(damage*0.2)
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -331,7 +331,7 @@ var/global/list/hygiene_props = list()
 	if(!on || !istype(M))
 		return
 	var/water_temperature = temperature_settings[watertemp]
-	var/temp_adj = clamp(BODYTEMP_COOLING_MAX, water_temperature - M.bodytemperature, BODYTEMP_HEATING_MAX)
+	var/temp_adj = clamp(water_temperature - M.bodytemperature, BODYTEMP_COOLING_MAX, BODYTEMP_HEATING_MAX)
 	M.bodytemperature += temp_adj
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M

--- a/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
+++ b/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
@@ -68,7 +68,7 @@
 
 	if (phase == "processing")//processing CO2 in tank
 		if (inner_tank.gas[/decl/material/gas/carbon_dioxide])
-			var/co2_intake = clamp(0, inner_tank.gas[/decl/material/gas/carbon_dioxide], power_setting*wait/10)
+			var/co2_intake = clamp(inner_tank.gas[/decl/material/gas/carbon_dioxide], 0, power_setting*wait/10)
 			last_flow_rate = co2_intake
 			inner_tank.adjust_gas(/decl/material/gas/carbon_dioxide, -co2_intake, 1)
 			var/datum/gas_mixture/new_oxygen = new
@@ -144,5 +144,5 @@
 		update_icon()
 		return 1
 	if(href_list["setPower"]) //setting power to 0 is redundant anyways
-		power_setting = clamp(1, text2num(href_list["setPower"]), 5)
+		power_setting = clamp(text2num(href_list["setPower"]), 1, 5)
 		return 1

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -157,7 +157,7 @@
 			target_pressure = max_pressure_setting
 		if ("set")
 			var/new_pressure = input(usr,"Enter new output pressure (0-[max_pressure_setting]kPa)","Pressure Control",src.target_pressure) as num
-			src.target_pressure = clamp(0, new_pressure, max_pressure_setting)
+			src.target_pressure = clamp(new_pressure, 0, max_pressure_setting)
 
 	switch(href_list["set_flow_rate"])
 		if ("min")
@@ -166,7 +166,7 @@
 			set_flow_rate = air1.volume
 		if ("set")
 			var/new_flow_rate = input(usr,"Enter new flow rate limit (0-[air1.volume]kPa)","Flow Rate Control",src.set_flow_rate) as num
-			src.set_flow_rate = clamp(0, new_flow_rate, air1.volume)
+			src.set_flow_rate = clamp(new_flow_rate, 0, air1.volume)
 
 	usr.set_machine(src)	//Is this even needed with NanoUI?
 	src.update_icon()

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -157,7 +157,7 @@ Thus, the two variables affect pump operation are set in New():
 			. = 1
 		if ("set")
 			var/new_pressure = input(usr,"Enter new output pressure (0-[max_pressure_setting]kPa)","Pressure control",src.target_pressure) as num
-			src.target_pressure = clamp(0, new_pressure, max_pressure_setting)
+			src.target_pressure = clamp(new_pressure, 0, max_pressure_setting)
 			. = 1
 
 	if(.)

--- a/code/modules/atmospherics/components/unary/cold_sink.dm
+++ b/code/modules/atmospherics/components/unary/cold_sink.dm
@@ -81,7 +81,7 @@
 		else
 			set_temperature = max(set_temperature + amount, 0)
 	if(href_list["setPower"]) //setting power to 0 is redundant anyways
-		var/new_setting = clamp(0, text2num(href_list["setPower"]), 100)
+		var/new_setting = clamp(text2num(href_list["setPower"]), 0, 100)
 		set_power_level(new_setting)
 
 	add_fingerprint(usr)

--- a/code/modules/atmospherics/components/unary/heat_source.dm
+++ b/code/modules/atmospherics/components/unary/heat_source.dm
@@ -99,7 +99,7 @@
 		else
 			set_temperature = max(set_temperature + amount, 0)
 	if(href_list["setPower"]) //setting power to 0 is redundant anyways
-		var/new_setting = clamp(0, text2num(href_list["setPower"]), 100)
+		var/new_setting = clamp(text2num(href_list["setPower"]), 0, 100)
 		set_power_level(new_setting)
 
 	add_fingerprint(usr)

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -36,7 +36,7 @@
 /datum/breach/proc/update_descriptor()
 
 	//Sanity...
-	class = clamp(1, round(class), 5)
+	class = clamp(round(class), 1, 5)
 	//Apply the correct descriptor.
 	if(damtype == BURN)
 		descriptor = breach_burn_descriptors[class]

--- a/code/modules/materials/definitions/liquids/materials_liquid_water.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_water.dm
@@ -76,7 +76,7 @@
 
 	var/volume = REAGENT_VOLUME(holder, type)
 	if (environment && environment.temperature > min_temperature) // Abstracted as steam or something
-		var/removed_heat = clamp(0, volume * WATER_LATENT_HEAT, -environment.get_thermal_energy_change(min_temperature))
+		var/removed_heat = clamp(volume * WATER_LATENT_HEAT, 0, -environment.get_thermal_energy_change(min_temperature))
 		environment.add_thermal_energy(-removed_heat)
 		if (prob(5) && environment && environment.temperature > T100C)
 			T.visible_message("<span class='warning'>The water sizzles as it lands on \the [T]!</span>")

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -235,7 +235,7 @@
 				temp_adj = (1-thermal_protection) * ((loc_temp - bodytemperature) / BODYTEMP_HEAT_DIVISOR)
 
 		//Use heat transfer as proportional to the gas density. However, we only care about the relative density vs standard 101 kPa/20 C air. Therefore we can use mole ratios
-		bodytemperature += clamp(BODYTEMP_COOLING_MAX, temp_adj*relative_density, BODYTEMP_HEATING_MAX)
+		bodytemperature += clamp(temp_adj*relative_density, BODYTEMP_COOLING_MAX, BODYTEMP_HEATING_MAX)
 
 	// +/- 50 degrees from 310.15K is the 'safe' zone, where no damage is dealt.
 	if(bodytemperature >= get_temperature_threshold(HEAT_LEVEL_1))

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -106,9 +106,9 @@
 
 /obj/item/organ/internal/proc/take_internal_damage(amount, var/silent=0)
 	if(BP_IS_PROSTHETIC(src))
-		damage = clamp(0, src.damage + (amount * 0.8), max_damage)
+		damage = clamp(src.damage + (amount * 0.8), 0, max_damage)
 	else
-		damage = clamp(0, src.damage + amount, max_damage)
+		damage = clamp(src.damage + amount, 0, max_damage)
 
 		//only show this if the organ is not robotic
 		if(owner && can_feel_pain() && parent_organ && (amount > 5 || prob(10)))

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -283,7 +283,7 @@
 
 	if(germ_level >= INFECTION_LEVEL_ONE)
 		var/fever_temperature = (owner.get_temperature_threshold(HEAT_LEVEL_1) - owner.species.body_temperature - 5)* min(germ_level/INFECTION_LEVEL_TWO, 1) + owner.species.body_temperature
-		owner.bodytemperature += clamp(0, (fever_temperature - T20C)/BODYTEMP_COLD_DIVISOR + 1, fever_temperature - owner.bodytemperature)
+		owner.bodytemperature += clamp((fever_temperature - T20C)/BODYTEMP_COLD_DIVISOR + 1, 0, fever_temperature - owner.bodytemperature)
 
 	if (germ_level >= INFECTION_LEVEL_TWO)
 		var/obj/item/organ/external/parent = GET_EXTERNAL_ORGAN(owner, parent_organ)
@@ -367,7 +367,7 @@
 
 /obj/item/organ/proc/heal_damage(amount)
 	if(can_recover())
-		damage = clamp(0, damage - round(amount, 0.1), max_damage)
+		damage = clamp(damage - round(amount, 0.1), 0, max_damage)
 
 /obj/item/organ/attack(var/mob/target, var/mob/user)
 	if(BP_IS_PROSTHETIC(src) || !istype(target) || !istype(user) || (user != target && user.a_intent == I_HELP))

--- a/code/modules/paperwork/papershredder.dm
+++ b/code/modules/paperwork/papershredder.dm
@@ -176,7 +176,7 @@
 /obj/machinery/papershredder/on_update_icon()
 	cut_overlays()
 	var/ratio = ((cached_total_matter * 5) / max_total_matter)
-	icon_state = "papershredder[clamp(0, CEILING(ratio), 5)]"
+	icon_state = "papershredder[clamp(CEILING(ratio), 0, 5)]"
 	if(!is_unpowered())
 		add_overlay("papershredder_power")
 		if(is_broken() || is_bin_full())

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -47,7 +47,7 @@
 	icon_update = 0
 
 	var/cellcount = 0
-	var/charge_level = clamp(0, round(Percentage() / 12), 7)
+	var/charge_level = clamp(round(Percentage() / 12), 0, 7)
 
 
 	overlays += "charge[charge_level]"
@@ -67,7 +67,7 @@
 		newmaxcharge += C.maxcharge
 
 	capacity = newmaxcharge
-	charge = clamp(0, charge, newmaxcharge)
+	charge = clamp(charge, 0, newmaxcharge)
 
 
 // Sets input/output depending on our "mode" var.
@@ -182,7 +182,7 @@
 			celldiff = (least.maxcharge / 100) * percentdiff
 		else
 			celldiff = (most.maxcharge / 100) * percentdiff
-		celldiff = clamp(0, celldiff, max_transfer_rate * CELLRATE)
+		celldiff = clamp(celldiff, 0, max_transfer_rate * CELLRATE)
 		// Ensure we don't transfer more energy than the most charged cell has, and that the least charged cell can input.
 		celldiff = min(min(celldiff, most.charge), least.maxcharge - least.charge)
 		least.give(most.use(celldiff))
@@ -260,7 +260,7 @@
 		update_io(0)
 		return 1
 	else if( href_list["enable"] )
-		update_io(clamp(1, text2num(href_list["enable"]), 3))
+		update_io(clamp(text2num(href_list["enable"]), 1, 3))
 		return 1
 	else if( href_list["equaliseon"] )
 		equalise = 1

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -259,7 +259,7 @@
 
 	if (operating_temperature > cooling_temperature)
 		var/temp_loss = (operating_temperature - cooling_temperature)/TEMPERATURE_DIVISOR
-		temp_loss = clamp(2, round(temp_loss, 1), TEMPERATURE_CHANGE_MAX)
+		temp_loss = clamp(round(temp_loss, 1), 2, TEMPERATURE_CHANGE_MAX)
 		operating_temperature = max(operating_temperature - temp_loss, cooling_temperature)
 		src.updateDialog()
 

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -48,7 +48,7 @@ field_generator power level display
 	// Scale % power to % num_power_levels and truncate value
 	var/level = round(num_power_levels * power / field_generator_max_power)
 	// Clamp between 0 and num_power_levels for out of range power values
-	level = clamp(0, level, num_power_levels)
+	level = clamp(level, 0, num_power_levels)
 	if(level)
 		overlays += "+p[level]"
 

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -115,7 +115,7 @@
 
 /obj/machinery/power/smes/proc/input_power(var/percentage)
 	var/to_input = target_load * (percentage/100)
-	to_input = clamp(0, to_input, target_load)
+	to_input = clamp(to_input, 0, target_load)
 	input_available = 0
 	if(percentage == 100)
 		inputting = 2
@@ -196,7 +196,7 @@
 		return
 
 	var/total_restore = output_used * (percent_load / 100) // First calculate amount of power used from our output
-	total_restore = clamp(0, total_restore, output_used) // Now clamp the value between 0 and actual output, just for clarity.
+	total_restore = clamp(total_restore, 0, output_used) // Now clamp the value between 0 and actual output, just for clarity.
 	total_restore = output_used - total_restore			   // And, at last, subtract used power from outputted power, to get amount of power we will give back to the SMES.
 
 	// now recharge this amount

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -137,7 +137,7 @@
 		capacity *= 1.2
 		input_level_max *= 2
 		output_level_max *= 2
-	charge = clamp(0, charge, capacity)
+	charge = clamp(charge, 0, capacity)
 
 // Proc: total_system_failure()
 // Parameters: 2 (intensity - how strong the failure is, user - person which caused the failure)
@@ -376,14 +376,14 @@
 // Parameters: 1 (new_input - New input value in Watts)
 // Description: Sets input setting on this SMES. Trims it if limits are exceeded.
 /obj/machinery/power/smes/buildable/proc/set_input(var/new_input = 0)
-	input_level = clamp(0, new_input, input_level_max)
+	input_level = clamp(new_input, 0, input_level_max)
 	update_icon()
 
 // Proc: set_output()
 // Parameters: 1 (new_output - New output value in Watts)
 // Description: Sets output setting on this SMES. Trims it if limits are exceeded.
 /obj/machinery/power/smes/buildable/proc/set_output(var/new_output = 0)
-	output_level = clamp(0, new_output, output_level_max)
+	output_level = clamp(new_output, 0, output_level_max)
 	update_icon()
 
 /obj/machinery/power/smes/buildable/emp_act(var/severity)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -177,8 +177,8 @@
 	//randomize clickpoint a bit based on dispersion
 	if(dispersion)
 		var/radius = round((dispersion*0.443)*world.icon_size*0.8) //0.443 = sqrt(pi)/4 = 2a, where a is the side length of a square that shares the same area as a circle with diameter = dispersion
-		p_x = clamp(0, p_x + gaussian(0, radius) * 0.25, world.icon_size)
-		p_y = clamp(0, p_y + gaussian(0, radius) * 0.25, world.icon_size)
+		p_x = clamp(p_x + gaussian(0, radius) * 0.25, 0, world.icon_size)
+		p_y = clamp(p_y + gaussian(0, radius) * 0.25, 0, world.icon_size)
 
 //Used to change the direction of the projectile in flight.
 /obj/item/projectile/proc/redirect(var/new_x, var/new_y, var/atom/starting_loc, var/atom/movable/new_firer=null, var/is_ricochet = FALSE)

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -308,7 +308,7 @@
 
 // Small visual effect, makes the shield tiles brighten up by becoming more opaque for a moment, and spreads to nearby shields.
 /obj/effect/shield/proc/impact_effect(var/i, var/list/affected_shields = list())
-	i = clamp(1, i, 10)
+	i = clamp(i, 1, 10)
 	alpha = 255
 	animate(src, alpha = initial(alpha), time = 1 SECOND)
 	affected_shields |= src

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -88,12 +88,12 @@
 	for(var/obj/item/stock_parts/smes_coil/S in component_parts)
 		full_shield_strength += (S.ChargeCapacity / CELLRATE) * 5
 	max_energy = full_shield_strength * 20
-	current_energy = clamp(0, current_energy, max_energy)
+	current_energy = clamp(current_energy, 0, max_energy)
 
 	mitigation_max = MAX_MITIGATION_BASE + MAX_MITIGATION_RESEARCH * total_component_rating_of_type(/obj/item/stock_parts/capacitor)
-	mitigation_em = clamp(0, mitigation_em, mitigation_max)
-	mitigation_physical = clamp(0, mitigation_physical, mitigation_max)
-	mitigation_heat = clamp(0, mitigation_heat, mitigation_max)
+	mitigation_em = clamp(mitigation_em, 0, mitigation_max)
+	mitigation_physical = clamp(mitigation_physical, 0, mitigation_max)
+	mitigation_heat = clamp(mitigation_heat, 0, mitigation_max)
 	..()
 
 
@@ -172,9 +172,9 @@
 			running = SHIELD_RUNNING
 			regenerate_field()
 
-	mitigation_em = clamp(0, mitigation_em - MITIGATION_LOSS_PASSIVE, mitigation_max)
-	mitigation_heat = clamp(0, mitigation_heat - MITIGATION_LOSS_PASSIVE, mitigation_max)
-	mitigation_physical = clamp(0, mitigation_physical - MITIGATION_LOSS_PASSIVE, mitigation_max)
+	mitigation_em = clamp(mitigation_em - MITIGATION_LOSS_PASSIVE, 0, mitigation_max)
+	mitigation_heat = clamp(mitigation_heat - MITIGATION_LOSS_PASSIVE, 0, mitigation_max)
+	mitigation_physical = clamp(mitigation_physical - MITIGATION_LOSS_PASSIVE, 0, mitigation_max)
 
 	if(running == SHIELD_RUNNING)
 		upkeep_power_usage = round((field_segments.len - damaged_segments.len) * ENERGY_UPKEEP_PER_TILE * upkeep_multiplier)
@@ -193,7 +193,7 @@
 		// Now try to recharge our internal energy.
 		var/energy_to_demand
 		if(input_cap)
-			energy_to_demand = clamp(0, max_energy - current_energy, input_cap - energy_buffer)
+			energy_to_demand = clamp(max_energy - current_energy, 0, input_cap - energy_buffer)
 		else
 			energy_to_demand = max(0, max_energy - current_energy)
 		energy_buffer = energy_to_demand - use_power_oneoff(energy_to_demand)
@@ -345,7 +345,7 @@
 		var/new_range = input(user, "Enter new field range (1-[world.maxx]). Leave blank to cancel.", "Field Radius Control", field_radius) as num
 		if(!new_range)
 			return TOPIC_HANDLED
-		target_radius = clamp(1, new_range, world.maxx)
+		target_radius = clamp(new_range, 1, world.maxx)
 		return TOPIC_REFRESH
 
 	if(href_list["set_input_cap"])
@@ -397,9 +397,9 @@
 				mitigation_heat += MITIGATION_HIT_LOSS + MITIGATION_HIT_GAIN
 				energy_to_use *= 1 - (mitigation_heat / 100)
 
-		mitigation_em = clamp(0, mitigation_em, mitigation_max)
-		mitigation_heat = clamp(0, mitigation_heat, mitigation_max)
-		mitigation_physical = clamp(0, mitigation_physical, mitigation_max)
+		mitigation_em = clamp(mitigation_em, 0, mitigation_max)
+		mitigation_heat = clamp(mitigation_heat, 0, mitigation_max)
+		mitigation_physical = clamp(mitigation_physical, 0, mitigation_max)
 
 	current_energy -= energy_to_use
 

--- a/code/modules/shieldgen/shieldwallgen.dm
+++ b/code/modules/shieldgen/shieldwallgen.dm
@@ -24,7 +24,7 @@
 	data["draw"] = round(power_draw)
 	data["power"] = round(storedpower)
 	data["maxpower"] = round(max_stored_power)
-	data["current_draw"] = ((clamp(500, max_stored_power - storedpower, power_draw)) + power ? active_power_usage : 0)
+	data["current_draw"] = ((clamp(max_stored_power - storedpower, 500, power_draw)) + power ? active_power_usage : 0)
 	data["online"] = active == 2 ? 1 : 0
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
@@ -108,7 +108,7 @@
 	if(C)	PN = C.powernet		// find the powernet of the connected cable
 
 	if(PN)
-		var/shieldload = clamp(500, max_stored_power - storedpower, power_draw)	//what we try to draw
+		var/shieldload = clamp(max_stored_power - storedpower, 500, power_draw)	//what we try to draw
 		shieldload = PN.draw_power(shieldload) //what we actually get
 		storedpower += shieldload
 

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -485,7 +485,7 @@ var/global/list/supermatter_delam_accent_sounds = list(
 	else
 		damage_archived = damage
 
-		damage = max(0, damage + clamp(-damage_rate_limit, (removed.temperature - critical_temperature) / 150, damage_inc_limit))
+		damage = max(0, damage + clamp((removed.temperature - critical_temperature) / 150, -damage_rate_limit, damage_inc_limit))
 
 		//Ok, 100% oxygen atmosphere = best reaction
 		//Maxes out at 100% oxygen pressure
@@ -518,7 +518,7 @@ var/global/list/supermatter_delam_accent_sounds = list(
 			visible_message("[src]: Releasing additional [round((heat_capacity_new - heat_capacity)*removed.temperature)] W with exhaust gasses.")
 
 		removed.add_thermal_energy(thermal_power)
-		removed.temperature = clamp(0, removed.temperature, 10000)
+		removed.temperature = clamp(removed.temperature, 0, 10000)
 
 		env.merge(removed)
 

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -260,7 +260,7 @@
 /datum/gas_mixture/proc/remove_ratio(ratio, out_group_multiplier = 1)
 	if(ratio <= 0)
 		return null
-	out_group_multiplier = clamp(1, out_group_multiplier, group_multiplier)
+	out_group_multiplier = clamp(out_group_multiplier, 1, group_multiplier)
 
 	ratio = min(ratio, 1)
 


### PR DESCRIPTION
## Description of changes
PR #2704 had removed the redundant clamp helper functions. But all calls of `between(lo, mid, hi)` had been replaced by `clamp(lo, mid, hi)`, while the documentation names its arguments as `clamp(Number, Low, High)`. Thus, this PR changes order of arguments for all places where `between` had been called once.
Old `Clamp` has the same order of arguments as modern `clamp`, and all usages of `dd_range(lo,hi,mid)` had been already reordered previously.
Technically changing args order still doesn't preserve erroneous behaviour of old helper functions (when lo>hi, those may have returned `lo`) and probably should change nothing in the current behaviour.

## Why and what will this PR improve
Improves readability of code. 

## Changelog
:cl:
refactor: `clamp` args order changed to comprehensible where `between` was used once
/:cl: