### PR TITLE
Allow hnolls to wear gloves

### DIFF
--- a/mods/content/fantasy/_fantasy.dme
+++ b/mods/content/fantasy/_fantasy.dme
@@ -24,5 +24,6 @@
 #include "items/clothing/gown.dm"
 #include "items/clothing/jerkin.dm"
 #include "items/clothing/loincloth.dm"
+#include "items/clothing/overrides.dm"
 #include "items/clothing/trousers.dm"
 #endif

--- a/mods/content/fantasy/items/clothing/overrides.dm
+++ b/mods/content/fantasy/items/clothing/overrides.dm
@@ -1,0 +1,4 @@
+/obj/item/clothing/gloves/setup_equip_flags()
+	. = ..()
+	if(!isnull(bodytype_equip_flags) && !(bodytype_equip_flags & BODY_FLAG_EXCLUDE))
+		bodytype_equip_flags |= BODY_FLAG_HNOLL


### PR DESCRIPTION
## Description of changes
Allows hnolls to wear gloves, using the same code as neoavians.

## Why and what will this PR improve
Hnolls can now wear gloves. According to Loaf their claws are more like dog claws so there shouldn't be any conceptual issues with them tearing gloves.