### PR TITLE
Fixes mapped shield gen being inoperable.

### DIFF
--- a/code/game/machinery/_machines_base/stock_parts/power/terminal.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/terminal.dm
@@ -85,6 +85,7 @@
 		return
 	if(istype(new_loc) && (terminal.loc == get_step(new_loc, terminal_dir)))
 		return     // This location is fine
+	// TODO: disconnect and drop the terminal as an item instead of deleting it.
 	machine.visible_message(SPAN_WARNING("The terminal is ripped out of \the [machine]!"))
 	qdel(terminal) // will handle everything via the destroyed event
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -131,11 +131,10 @@
 			. |= DAM_LASER
 
 /obj/attackby(obj/item/O, mob/user)
-	if(obj_flags & OBJ_FLAG_ANCHORABLE)
-		if(IS_WRENCH(O))
-			wrench_floor_bolts(user)
-			update_icon()
-			return
+	if((obj_flags & OBJ_FLAG_ANCHORABLE) && IS_WRENCH(O))
+		wrench_floor_bolts(user)
+		update_icon()
+		return TRUE
 	return ..()
 
 /obj/proc/wrench_floor_bolts(mob/user, delay=20)

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -4298,7 +4298,7 @@
 /turf/simulated/floor/tiled/usedup,
 /area/ship/scrap/maintenance/power)
 "in" = (
-/obj/machinery/shield_generator,
+/obj/machinery/shield_generator/mapped,
 /obj/structure/cable{
 	icon_state = "0-2";
 	pixel_y = 1

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -2958,7 +2958,7 @@
 /turf/simulated/floor/airless,
 /area/constructionsite)
 "kr" = (
-/obj/machinery/shield_generator{
+/obj/machinery/shield_generator/mapped{
 	desc = "A heavy-duty shield generator and capacitor, capable of generating energy shields at large distances. This one seems to be in a state of disrepair.";
 	name = "disused shield generator"
 	},

--- a/maps/away/liberia/liberia.dmm
+++ b/maps/away/liberia/liberia.dmm
@@ -371,7 +371,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/merchantstorage)
 "aR" = (
-/obj/machinery/shield_generator,
+/obj/machinery/shield_generator/mapped,
 /obj/structure/cable,
 /obj/structure/cable/blue{
 	icon_state = "1-2"

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -3678,7 +3678,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/trade/maintenance/power)
 "iU" = (
-/obj/machinery/shield_generator,
+/obj/machinery/shield_generator/mapped,
 /obj/structure/cable{
 	icon_state = "0-2";
 	pixel_y = 1
@@ -6828,7 +6828,7 @@
 /turf/simulated/floor/tiled,
 /area/ship/trade/shuttle/outgoing/general)
 "Lm" = (
-/obj/machinery/shield_generator,
+/obj/machinery/shield_generator/mapped,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},


### PR DESCRIPTION
Fixes https://github.com/ScavStation/ScavStation/issues/975

Would be good to make terminals a bit less unintuitive in the UX sense down the track, particularly considering shield generators and such are expected to be portable to an extent.