### PR TITLE
Update spacemandmm.toml to fix mapdiffbot issues

### DIFF
--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -51,3 +51,22 @@ macro_undefined_no_definition = "error"
 
 # Raised by Object Tree
 override_precedes_definition = "error"
+
+[map_renderer]
+hide_invisible = [
+	"/obj/effect/step_trigger",
+	"/obj/abstract",
+]
+
+[map_renderer.render_passes]
+overlays = false
+gravity-gen = false
+pretty = false
+icon-smoothing = false
+icon-smoothing-2016 = true
+smart-cables = false
+# TODO: add support for directional_offsets var to Jupyterkat's fork?
+offsets = false
+# maybe also add support for our random spawners?
+random = false
+spawners = false


### PR DESCRIPTION
## Description of changes
Excludes certain types from rendering in mapdiffbot, and excludes some render passes that don't apply to us.
Made with reference to https://github.com/ParadiseSS13/Paradise/blob/9f963ffd2226191923d7871ef6c1965676443c7e/SpacemanDMM.toml and 

## Why and what will this PR improve
The mapdiffbot should render things better, since some TG-only features were disabled.

## Authorship
Made with advice from AA07.