### PR TITLE
Fix many double variable definitions

### DIFF
--- a/code/datums/inventory_slots/slots/slot_cuffs.dm
+++ b/code/datums/inventory_slots/slots/slot_cuffs.dm
@@ -1,5 +1,5 @@
 /datum/inventory_slot/handcuffs
-	slot_id = "Handcuffs"
+	slot_name = "Handcuffs"
 	slot_id = slot_handcuffed_str
 	skip_on_inventory_display = TRUE // Handcuffs have their own logic on examine.
 	skip_on_strip_display = TRUE // Handcuffs are removed with their own button in the strip menu.

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -118,7 +118,6 @@
 	name = "\improper Hot Foods Display"
 	desc = "A heated storage unit for piping hot meals."
 	icon_state = "fridge_food"
-	icon_state = "fridge_food"
 	icon_contents = "food"
 
 /obj/machinery/smartfridge/foods/accept_check(var/obj/item/O)

--- a/code/game/objects/items/devices/radio/headsets_shared.dm
+++ b/code/game/objects/items/devices/radio/headsets_shared.dm
@@ -176,6 +176,10 @@
 	name = "\improper ERT radio encryption key"
 	can_decrypt = list(access_cent_specops)
 
+/obj/item/encryptionkey/ert/Initialize(ml, material_key)
+	. = ..()
+	can_decrypt |= get_all_station_access()
+
 /obj/item/radio/headset/ert
 	name = "emergency response team radio headset"
 	desc = "The headset of the boss's boss."
@@ -191,6 +195,12 @@
 	origin_tech = @'{"esoteric":2}'
 	encryption_keys = list(/obj/item/encryptionkey/mercenary)
 	analog_secured = list((access_mercenary) = TRUE)
+
+/obj/item/radio/headset/mercenary/commando
+	encryption_keys = list(
+		/obj/item/encryptionkey/mercenary,
+		/obj/item/encryptionkey/hacked
+	)
 
 /obj/item/encryptionkey/entertainment
 	name = "entertainment radio key"

--- a/code/game/objects/items/weapons/circuitboards/machinery/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/research.dm
@@ -229,8 +229,8 @@
 	build_path = /obj/machinery/merchant_pad
 	board_type = "machine"
 	origin_tech = @'{"programming":6,"wormholes":6,"esoteric":1}'
-	req_components = list(/obj/item/stack/cable_coil = 15)
 	req_components = list(
+		/obj/item/stack/cable_coil = 15,
 		/obj/item/stock_parts/subspace/amplifier = 1,
 		/obj/item/stock_parts/subspace/ansible = 1,
 		/obj/item/stock_parts/subspace/crystal = 1,

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -164,7 +164,6 @@
 	icon = 'icons/obj/items/cosmetics/eyeshadow.dmi'
 	icon_state = "eyeshadow_closed"
 	cosmetic_type = /decl/sprite_accessory/cosmetics/eyeshadow
-	abstract_type = /obj/item/cosmetics/eyeshadow
 	apply_to_zone = BP_EYES
 	base_icon_state = "eyeshadow"
 

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -6,8 +6,7 @@
 	item_state                    = "fire_extinguisher"
 	hitsound                      = 'sound/weapons/smash.ogg'
 	atom_flags                    = ATOM_FLAG_OPEN_CONTAINER
-	obj_flags                     = OBJ_FLAG_CONDUCTIBLE
-	obj_flags                     = OBJ_FLAG_HOLLOW
+	obj_flags                     = OBJ_FLAG_CONDUCTIBLE | OBJ_FLAG_HOLLOW
 	w_class                       = ITEM_SIZE_NORMAL
 	throw_speed                   = 2
 	throw_range                   = 10

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -6,10 +6,9 @@
 	icon_state = ICON_STATE_WORLD
 	throw_speed = 4
 	throw_range = 20
-	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	obj_flags = OBJ_FLAG_CONDUCTIBLE | OBJ_FLAG_HOLLOW
 	slot_flags = SLOT_LOWER_BODY
 	z_flags = ZMM_MANGLE_PLANES
-	obj_flags = OBJ_FLAG_HOLLOW
 	material = /decl/material/solid/metal/steel
 	var/active
 	var/det_time = 50

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -706,7 +706,6 @@
 	name = "assorted parts pack"
 	icon = 'icons/obj/items/storage/part_pack.dmi'
 	icon_state = "big"
-	icon_state = "part"
 	w_class = ITEM_SIZE_NORMAL
 
 /obj/item/box/parts/WillContain()

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -39,7 +39,6 @@ var/global/list/global/tank_gauge_cache = list()
 	throwforce = 10.0
 	throw_speed = 1
 	throw_range = 4
-	material = /decl/material/solid/metal/steel
 
 	var/datum/gas_mixture/air_contents = null
 	var/distribute_pressure = ONE_ATMOSPHERE

--- a/code/game/objects/structures/barrel.dm
+++ b/code/game/objects/structures/barrel.dm
@@ -13,7 +13,6 @@
 	amount_dispensed          = 10
 	possible_transfer_amounts = @"[10,25,50,100]"
 	volume                    = 7500
-	atom_flags                = ATOM_FLAG_CLIMBABLE
 	movable_flags             = MOVABLE_FLAG_WHEELED
 
 /obj/structure/reagent_dispensers/barrel/Initialize()

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -20,7 +20,6 @@
 	var/panic = 0 //is this scrubber panicked?
 
 	var/welded = 0
-	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SCRUBBER
 	build_icon_state = "scrubber"
 
 	uncreated_component_parts = list(

--- a/code/modules/butchery/butchery_products_chopped.dm
+++ b/code/modules/butchery/butchery_products_chopped.dm
@@ -1,6 +1,5 @@
 /obj/item/chems/food/butchery/chopped
 	name          = "chopped meat"
-	bitesize      = 2
 	desc          = "A handful of chopped meat."
 	icon          = 'icons/obj/items/butchery/chopped.dmi'
 	bitesize      = 2

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -82,7 +82,6 @@
 	cold_protection = SLOT_HANDS
 	heat_protection = SLOT_HANDS
 	min_cold_protection_temperature = GLOVES_MIN_COLD_PROTECTION_TEMPERATURE
-	heat_protection = SLOT_HANDS
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	max_pressure_protection = FIRESUIT_MAX_PRESSURE
 	material = /decl/material/solid/organic/cloth

--- a/code/modules/fishing/bait.dm
+++ b/code/modules/fishing/bait.dm
@@ -5,8 +5,6 @@
 	icon_state = ICON_STATE_WORLD
 	color = "#835673"
 	w_class = ITEM_SIZE_TINY
-	nutriment_type = null
-	nutriment_amt = 0
 	material = /decl/material/solid/organic/meat
 	nutriment_type = /decl/material/solid/organic/meat
 	nutriment_amt = 5

--- a/code/modules/integrated_electronics/subtypes/lists.dm
+++ b/code/modules/integrated_electronics/subtypes/lists.dm
@@ -185,7 +185,7 @@
 		if(e in output_list)
 			continue
 		output_list.Add(e)
-		
+
 	set_pin_data(IC_OUTPUT, 1, output_list)
 	push_data()
 	activate_pin(2)
@@ -332,7 +332,6 @@
 	outputs = list(
 		"joined text" = IC_PINTYPE_STRING
 		)
-	icon_state = "addition"
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	cooldown_per_use = 1
 

--- a/code/modules/materials/definitions/gasses/material_gas_mundane.dm
+++ b/code/modules/materials/definitions/gasses/material_gas_mundane.dm
@@ -236,7 +236,6 @@
 	boiling_point = -33 CELSIUS
 	gas_symbol_html = "NH<sub>3</sub>"
 	gas_symbol = "NH3"
-	metabolism = 0.05 // So that low dosages have a chance to build up in the body.
 	taste_description = "mordant"
 	taste_mult = 2
 	lore_text = "A caustic substance commonly used in fertilizer or household cleaners."

--- a/code/modules/materials/definitions/liquids/materials_liquid_soup.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_soup.dm
@@ -59,7 +59,6 @@
 	name              = "broth"
 	codex_name        = "simple broth"
 	uid               = "liquid_soup_broth"
-	mask_name_suffix  = "broth"
 	solid_name        = "stock"
 	color             = "#8a7452"
 	mask_name_suffix  = "broth"

--- a/code/modules/materials/definitions/solids/materials_solid_exotic.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_exotic.dm
@@ -2,7 +2,6 @@
 	name = "metallic hydrogen"
 	uid = "solid_metallic_hydrogen"
 	lore_text = "When hydrogen is exposed to extremely high pressures and temperatures, such as at the core of gas giants like Jupiter, it can take on metallic properties and - more importantly - acts as a room temperature superconductor. Achieving solid metallic hydrogen at room temperature, though, has proven to be rather tricky."
-	name = "metallic hydrogen"
 	color = "#e6c5de"
 	stack_origin_tech = @'{"materials":6,"powerstorage":6,"magnets":5}'
 	heating_products = list(

--- a/code/modules/materials/materials_ore.dm
+++ b/code/modules/materials/materials_ore.dm
@@ -14,7 +14,6 @@
 	material                   = /decl/material/solid/stone/granite //By default is just a rock
 	material_health_multiplier = 0.5
 	stack_merge_type           = /obj/item/stack/material/ore
-	randpixel                  = 8
 	material_alteration        = MAT_FLAG_ALTERATION_COLOR //Name is handled in override
 	randpixel                  = 6
 	is_spawnable_type          = TRUE

--- a/code/modules/mob/living/deity/items/tower/transmutation.dm
+++ b/code/modules/mob/living/deity/items/tower/transmutation.dm
@@ -63,7 +63,6 @@
 	base_cost = 50
 	category = DEITY_TREE_TRANSMUTATION
 	requirements = list(DEITY_TREE_TRANSMUTATION = 3)
-	category = DEITY_TREE_TRANSMUTATION
 
 /datum/deity_item/boon/single_charge/heal
 	name = "Minor Heal"
@@ -71,7 +70,6 @@
 	base_cost = 15
 	category = DEITY_TREE_TRANSMUTATION
 	requirements = list(DEITY_UNLOCK_HEAL = 1)
-	category = DEITY_TREE_TRANSMUTATION
 	boon_path = /spell/targeted/heal_target/tower
 
 /datum/deity_item/boon/single_charge/heal/major

--- a/code/modules/mob/living/simple_animal/crow/crow.dm
+++ b/code/modules/mob/living/simple_animal/crow/crow.dm
@@ -23,7 +23,6 @@
 
 	stop_automated_movement = TRUE
 	universal_speak = TRUE
-	pass_flags = PASS_FLAG_TABLE
 
 
 /mob/living/simple_animal/crow/get_overlay_state_modifier()

--- a/code/modules/mob/living/simple_animal/hostile/faithful_hound.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithful_hound.dm
@@ -5,7 +5,6 @@
 	blend_mode = BLEND_SUBTRACT
 	max_health = 100
 	natural_weapon = /obj/item/natural_weapon/bite/strong
-	faction = MOB_FACTION_NEUTRAL
 	density = FALSE
 	stop_automated_movement = 1
 	wander = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -6,7 +6,6 @@
 	turns_per_move = 5
 	response_help_1p = "You wave your hand through $TARGET$."
 	response_help_3p = "$USER$ waves $USER_THEIR$ hand through $TARGET$."
-	speed = -1
 	max_health = 80
 	gene_damage = -1
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -2,7 +2,6 @@
 	name = "clown"
 	desc = "A denizen of clown planet"
 	icon = 'icons/mob/simple_animal/clown.dmi'
-	speak_chance = 0
 	turns_per_move = 5
 	emote_speech = list("HONK", "Honk!", "Welcome to clown planet!")
 	emote_see    = list("honks")

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -18,7 +18,6 @@
 	max_gas = null
 	speed = -1
 	stop_automated_movement = 1
-	status_flags = 0
 	faction = "cult"
 	supernatural = 1
 	status_flags = CANPUSH

--- a/code/modules/mob_holder/_holder.dm
+++ b/code/modules/mob_holder/_holder.dm
@@ -5,7 +5,6 @@
 	icon = 'icons/obj/items/holder.dmi'
 	icon_state = ICON_STATE_WORLD
 	slot_flags = SLOT_HEAD | SLOT_HOLSTER
-	origin_tech = null
 	pixel_y = 8
 	origin_tech = @'{"biotech":1}'
 	use_single_icon = TRUE

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -72,7 +72,6 @@
 	name = "nano battery"
 	desc = "A tiny power cell, commonly seen in low-end portable microcomputers. It's rating is 30 Wh."
 	icon_state = "battery_nano"
-	origin_tech = @'{"powerstorage":1,"engineering":1}'
 	battery_rating = 30
 	material = /decl/material/solid/metal/steel
 	origin_tech = @'{"powerstorage":2,"engineering":1}'

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -4,11 +4,10 @@
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "pistolcasing"
 	randpixel = 10
-	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	obj_flags = OBJ_FLAG_CONDUCTIBLE | OBJ_FLAG_HOLLOW
 	slot_flags = SLOT_LOWER_BODY | SLOT_EARS
 	throwforce = 1
 	w_class = ITEM_SIZE_TINY
-	obj_flags = OBJ_FLAG_HOLLOW
 	material = /decl/material/solid/metal/brass
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME
 	drop_sound = list(

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -71,7 +71,6 @@
 /obj/item/gun/energy/lasercannon
 	name = "laser cannon"
 	desc = "With the laser cannon, the lasing medium is enclosed in a tube lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core. This incredible technology may help YOU achieve high excitation rates with small laser volumes!"
-	icon_state = "lasercannon"
 	icon = 'icons/obj/guns/laser_cannon.dmi'
 	icon_state = ICON_STATE_WORLD
 	origin_tech = @'{"combat":4,"materials":3,"powerstorage":3}'

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -11,7 +11,6 @@
 	max_shots = 21
 	w_class = ITEM_SIZE_NORMAL
 	one_hand_penalty=1 //a bit heavy
-	burst_delay = 1
 	burst_delay = 3
 	burst = 3
 	accuracy = -1

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -125,7 +125,6 @@
 	projectile_type = /obj/item/projectile/beam/plasmacutter
 	max_shots = 10
 	self_recharge = 1
-	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/metal/gold = MATTER_AMOUNT_TRACE,

--- a/code/modules/projectiles/guns/projectile/flaregun.dm
+++ b/code/modules/projectiles/guns/projectile/flaregun.dm
@@ -8,7 +8,6 @@
 	slot_flags = SLOT_LOWER_BODY | SLOT_HOLSTER
 	w_class = ITEM_SIZE_SMALL
 	obj_flags = 0
-	slot_flags = SLOT_LOWER_BODY | SLOT_HOLSTER
 	material = /decl/material/solid/organic/plastic
 	matter = list(/decl/material/solid/metal/steel = MATTER_AMOUNT_REINFORCEMENT)
 

--- a/code/modules/random_map/noise/ore.dm
+++ b/code/modules/random_map/noise/ore.dm
@@ -128,7 +128,7 @@
 	deep_val = 0.8
 	rare_val = 0.7
 	min_rare_ratio = 0.02
-	min_rare_ratio = 0.01
+	min_deep_ratio = 0.01
 
 /datum/random_map/noise/ore/ice
 	surface_metals = list(

--- a/code/modules/reagents/reagent_containers/food/baked_goods.dm
+++ b/code/modules/reagents/reagent_containers/food/baked_goods.dm
@@ -201,7 +201,6 @@
 	name = "poppy pretzel"
 	desc = "It's all twisted up!"
 	icon_state = "poppypretzel"
-	bitesize = 2
 	filling_color = "#916e36"
 	center_of_mass = @'{"x":16,"y":10}'
 	nutriment_desc = list("poppy seeds" = 2, "pretzel" = 3)

--- a/code/modules/spells/general/create_air.dm
+++ b/code/modules/spells/general/create_air.dm
@@ -11,7 +11,6 @@
 	time_between_channels = 200
 	hud_state = "wiz_air"
 	var/list/air_change = list(/decl/material/gas/oxygen = ONE_ATMOSPHERE)
-	number_of_channels = 0
 
 /spell/create_air/choose_targets()
 	var/air = holder.return_air()

--- a/code/modules/spells/general/portal_teleport.dm
+++ b/code/modules/spells/general/portal_teleport.dm
@@ -3,7 +3,6 @@
 	desc = "This spell creates a long lasting portal to an area of your selection."
 	feedback = "TP"
 	school = "conjuration"
-	charge_max = 600
 	spell_flags = NEEDSCLOTHES
 	invocation = "Scyar Peranda!"
 	invocation_type = SpI_SHOUT

--- a/code/modules/spells/general/radiant_aura.dm
+++ b/code/modules/spells/general/radiant_aura.dm
@@ -1,7 +1,6 @@
 /spell/radiant_aura
 	name = "Radiant aura"
 	desc = "Form a protective layer of light around you, making you immune to laser fire."
-	school = "transmutation"
 	feedback = "ra"
 	invocation_type = SpI_EMOTE
 	invocation = "conjures a sphere of fire around themselves."

--- a/code/modules/spells/targeted/genetic.dm
+++ b/code/modules/spells/targeted/genetic.dm
@@ -81,7 +81,6 @@ code\game\dna\genes\goon_powers.dm
 	spell_flags = NOFACTION
 	invocation_type = SpI_SHOUT
 	charge_max = 60 SECONDS
-	spell_flags = 0
 
 	amt_dizziness = 0
 	amt_eye_blurry = 5

--- a/code/modules/spells/targeted/projectile/fireball.dm
+++ b/code/modules/spells/targeted/projectile/fireball.dm
@@ -13,8 +13,6 @@
 
 	level_max = list(Sp_TOTAL = 5, Sp_SPEED = 0, Sp_POWER = 5)
 
-	spell_flags = 0
-
 	duration = 20
 	proj_step_delay = 1
 

--- a/code/modules/spells/targeted/projectile/passage.dm
+++ b/code/modules/spells/targeted/projectile/passage.dm
@@ -7,7 +7,6 @@
 
 	school = "conjuration"
 	charge_max = 250
-	spell_flags = 0
 	invocation = "A'YASAMA"
 	invocation_type = SpI_SHOUT
 	range = 15

--- a/code/modules/tools/components/recipes.dm
+++ b/code/modules/tools/components/recipes.dm
@@ -1,7 +1,6 @@
 /decl/stack_recipe/tool
 	category = "tool parts"
 	abstract_type               = /decl/stack_recipe/tool
-	category = "tool parts"
 	forbidden_craft_stack_types = null
 	craft_stack_types           = list(
 		/obj/item/stack/material/ore,

--- a/code/modules/tools/subtypes/xenoarchaeology_picks.dm
+++ b/code/modules/tools/subtypes/xenoarchaeology_picks.dm
@@ -106,7 +106,6 @@
 	name              = "excavation pick set"
 	icon              = 'icons/obj/items/storage/excavation.dmi'
 	icon_state        = "excavation"
-	item_state        = "utility"
 	desc              = "A rugged case containing a set of standardized picks used in archaeological digs."
 	item_state        = "syringe_kit"
 	slot_flags        = SLOT_LOWER_BODY

--- a/maps/tradeship/jobs/civilian.dm
+++ b/maps/tradeship/jobs/civilian.dm
@@ -1,6 +1,5 @@
 /datum/job/tradeship_deckhand
 	title = "Deck Hand"
-	event_categories = list("Janitor", "Gardener")
 	total_positions = -1
 	spawn_positions = -1
 	supervisors = "literally everyone, you bottom feeder"

--- a/maps/tradeship/jobs/engineering.dm
+++ b/maps/tradeship/jobs/engineering.dm
@@ -1,8 +1,6 @@
 /datum/job/tradeship_engineer
 	title = "Junior Engineer"
 	supervisors = "the Head Engineer"
-	total_positions = 2
-	spawn_positions = 2
 	outfit_type = /decl/hierarchy/outfit/job/tradeship/hand/engine
 	department_types = list(/decl/department/engineering)
 	total_positions = 8
@@ -11,25 +9,25 @@
 	economic_power = 5
 	minimal_player_age = 7
 	access = list(
-		access_eva, 
-		access_engine, 
-		access_engine_equip, 
-		access_tech_storage, 
-		access_maint_tunnels, 
-		access_external_airlocks, 
-		access_construction, 
-		access_atmospherics, 
+		access_eva,
+		access_engine,
+		access_engine_equip,
+		access_tech_storage,
+		access_maint_tunnels,
+		access_external_airlocks,
+		access_construction,
+		access_atmospherics,
 		access_emergency_storage
 	)
 	minimal_access = list(
-		access_eva, 
-		access_engine, 
-		access_engine_equip, 
-		access_tech_storage, 
-		access_maint_tunnels, 
-		access_external_airlocks, 
-		access_construction, 
-		access_atmospherics, 
+		access_eva,
+		access_engine,
+		access_engine_equip,
+		access_tech_storage,
+		access_maint_tunnels,
+		access_external_airlocks,
+		access_construction,
+		access_atmospherics,
 		access_emergency_storage
 	)
 	min_skill = list(
@@ -64,23 +62,23 @@
 	req_admin_notify = 1
 	economic_power = 10
 	ideal_character_age = 50
-	guestbanned = 1	
+	guestbanned = 1
 	must_fill = 1
 	not_random_selectable = 1
 	access = list(
-		access_engine, 
-		access_engine_equip, 
-		access_tech_storage, 
-		access_maint_tunnels, 
+		access_engine,
+		access_engine_equip,
+		access_tech_storage,
+		access_maint_tunnels,
 		access_heads,
 		access_teleporter,
 		access_external_airlocks,
-		access_atmospherics, 
+		access_atmospherics,
 		access_emergency_storage,
 		access_eva,
 		access_bridge,
 		access_construction, access_sec_doors,
-		access_ce, 
+		access_ce,
 		access_RC_announce,
 		access_keycard_auth,
 		access_tcomsat,
@@ -88,9 +86,9 @@
 	)
 	minimal_access = list(
 		access_engine,
-		access_engine_equip, 
-		access_tech_storage, 
-		access_maint_tunnels, 
+		access_engine_equip,
+		access_tech_storage,
+		access_maint_tunnels,
 		access_heads,
 		access_teleporter,
 		access_external_airlocks,

--- a/maps/tradeship/jobs/medical.dm
+++ b/maps/tradeship/jobs/medical.dm
@@ -3,8 +3,6 @@
 	department_types = list(/decl/department/medical)
 	head_position = 0
 	supervisors = "the Head Doctor and the Captain"
-	total_positions = 2
-	spawn_positions = 2
 	alt_titles = list()
 	skill_points = 24
 	min_skill = list(
@@ -54,7 +52,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	skill_points = 28
-	guestbanned = 1	
+	guestbanned = 1
 	must_fill = 1
 	not_random_selectable = 1
 	selection_color = "#026865"

--- a/maps/tradeship/outfits/command.dm
+++ b/maps/tradeship/outfits/command.dm
@@ -22,7 +22,6 @@
 	uniform = /obj/item/clothing/pants/slacks/black/outfit/checkered
 	shoes = /obj/item/clothing/shoes/dress
 	glasses = /obj/item/clothing/glasses/sunglasses/big
-	pda_type = /obj/item/modular_computer/pda/cargo
 	hands = list(/obj/item/clipboard)
 	id_type = /obj/item/card/id/silver
 	pda_type = /obj/item/modular_computer/pda/heads/hop

--- a/mods/content/corporate/datum/antagonists/commando.dm
+++ b/mods/content/corporate/datum/antagonists/commando.dm
@@ -15,13 +15,12 @@
 
 /decl/hierarchy/outfit/mercenary_commando
 	name =    "Special Role - Mercenary Commando"
-	l_ear =   /obj/item/radio/headset/mercenary
+	l_ear =   /obj/item/radio/headset/mercenary/commando
 	id_type = /obj/item/card/id/centcom/ERT
 	uniform = /obj/item/clothing/under/syndicate
 	shoes =   /obj/item/clothing/shoes/jackboots/swat
 	glasses = /obj/item/clothing/glasses/thermal
 	mask =    /obj/item/clothing/mask/gas/syndicate
-	l_ear =   /obj/item/radio/headset/hacked
 	backpack_contents = list(/obj/item/ammo_magazine/box/pistol = 1)
 	hands = list(
 		/obj/item/gun/energy/laser,

--- a/mods/content/corporate/datum/antagonists/deathsquad.dm
+++ b/mods/content/corporate/datum/antagonists/deathsquad.dm
@@ -11,7 +11,6 @@
 		access_cent_storage
 	)
 	antaghud_indicator = "huddeathsquad"
-	default_access = list(access_cent_specops)
 
 	hard_cap = 4
 	hard_cap_round = 8
@@ -31,7 +30,6 @@
 	name =     "Special Role - Deathsquad Commando"
 	l_ear =    /obj/item/radio/headset/ert
 	uniform =  /obj/item/clothing/jumpsuit/green
-	l_ear =    /obj/item/radio/headset/hacked
 	l_pocket = /obj/item/plastique
 	shoes =    /obj/item/clothing/shoes/jackboots/swat
 	glasses =  /obj/item/clothing/glasses/thermal

--- a/mods/species/ascent/items/rig.dm
+++ b/mods/species/ascent/items/rig.dm
@@ -48,11 +48,10 @@
 /obj/item/rig_module/mounted/energy_blade/mantid
 	name = "nanoblade projector"
 	desc = "A fusion-powered blade nanofabricator of Ascent design."
-	interface_name = "nanoblade projector"
+	interface_name = "nanoblade"
 	interface_desc = "A fusion-powered blade nanofabricator of Ascent design."
 	icon = 'mods/species/ascent/icons/ascent.dmi'
 	icon_state = "blade"
-	interface_name = "nanoblade"
 	usable = FALSE
 	gun = null
 

--- a/mods/species/bayliens/skrell/datum/species_bodytype.dm
+++ b/mods/species/bayliens/skrell/datum/species_bodytype.dm
@@ -2,7 +2,6 @@
 	name                 = "skrellian body"
 	icon_base            = 'mods/species/bayliens/skrell/icons/body/body.dmi'
 	bandages_icon        = 'icons/mob/bandage.dmi'
-	bandages_icon        = 'icons/mob/bandage.dmi'
 	health_hud_intensity = 1.75
 	associated_gender    = PLURAL
 	eye_darksight_range  = 4
@@ -10,7 +9,6 @@
 	eye_icon             = 'mods/species/bayliens/skrell/icons/body/eyes.dmi'
 	apply_eye_colour     = FALSE
 
-	associated_gender    = PLURAL
 	appearance_flags     = HAS_UNDERWEAR | HAS_SKIN_COLOR
 	base_color           = "#006666"
 

--- a/mods/species/vox/datum/antagonism.dm
+++ b/mods/species/vox/datum/antagonism.dm
@@ -13,7 +13,6 @@
 	glasses =    /obj/item/clothing/glasses/thermal
 	holster =    /obj/item/clothing/webbing/holster/armpit
 	suit_store = /obj/item/flashlight
-	l_ear =      /obj/item/radio/headset/raider
 	hands =      list(/obj/item/gun/launcher/alien/spikethrower)
 	id_type =    /obj/item/card/id/syndicate
 


### PR DESCRIPTION
## Description of changes
Fixes issues where a variable was set twice in one type definition block, which can lead to confusion as only the second value applies.
I tried doing it in CI but automating it would be incredibly difficult; only ripgrep is powerful enough to handle it, and the grep is really brittle. Here's the regex anyway, it has to be used in VSC because that automatically adds `--crlf` and does some annoying conversion of `\n` to `\r\n` in the regex.
`^(?!\/\/)\/?[\w\/]+\/\w+(?:\s*\/\/.*)?$(?:\n+^\s*[^\s\/].*$)*?\n+\t(\w+\b)\s*=\s*.+$\n+(?:^\s*?(?:[^\s\/]|\/\/).*$\n+)*?\t\1\b`

## Why and what will this PR improve
Fixes issues where the actual value of a variable was unclear, or where the intended value was clobbered by a later definition. A lot of these were cases where `obj_flags` was defined twice, so I kept both sets of flags and just combined them into one.