### PR TITLE
Disables temperature-based melting until it is refined.

### DIFF
--- a/code/game/objects/item_melting.dm
+++ b/code/game/objects/item_melting.dm
@@ -15,6 +15,7 @@
 		var/mob/holder = loc
 		try_burn_wearer(holder, holder.get_equipped_slot_for_item(src))
 
+/*
 	// Check if this is meltable at all.
 	var/list/meltable_materials
 	for(var/mat in matter)
@@ -24,6 +25,7 @@
 	if(length(meltable_materials))
 		. = null // Don't return PROCESS_KILL here.
 		handle_melting(meltable_materials)
+*/
 
 /obj/item/place_melted_product(list/meltable_materials)
 


### PR DESCRIPTION
Melting is really problematic at the moment and needs more time in the oven, disabling temperature-based melting for the time being.