### PR TITLE
Sync with Lighthouse, 06/03/2024

### DIFF
--- a/code/datums/config/config_types/config_game_world.dm
+++ b/code/datums/config/config_types/config_game_world.dm
@@ -20,7 +20,8 @@
 		/decl/config/toggle/on/cult_ghostwriter,
 		/decl/config/toggle/allow_holidays,
 		/decl/config/toggle/humans_need_surnames,
-		/decl/config/toggle/roundstart_level_generation
+		/decl/config/toggle/roundstart_level_generation,
+		/decl/config/toggle/lights_start_on
 	)
 
 /decl/config/num/exterior_ambient_light
@@ -125,3 +126,7 @@
 /decl/config/toggle/roundstart_level_generation
 	uid = "roundstart_level_generation"
 	desc = "Enable/Disable random level generation. Will behave strangely if turned off with a map that expects it on."
+
+/decl/config/toggle/lights_start_on
+	uid = "lights_start_on"
+	desc = "If true, most lightswitches start on by default. Otherwise, they start off."

--- a/code/datums/inventory_slots/slots/slot_shoes.dm
+++ b/code/datums/inventory_slots/slots/slot_shoes.dm
@@ -22,7 +22,7 @@
 		var/blood_color
 		for(var/foot_tag in list(BP_L_FOOT, BP_R_FOOT))
 			var/obj/item/organ/external/stomper = GET_EXTERNAL_ORGAN(user, foot_tag)
-			if(stomper && stomper.coating)
+			if(stomper && stomper.coating?.total_volume)
 				blood_color = stomper.coating.get_color()
 				break
 		if(blood_color)
@@ -38,7 +38,7 @@
 		return "[pronouns.He] [pronouns.is] wearing [_holding.get_examine_line()] on [pronouns.his] feet."
 	for(var/bp in list(BP_L_FOOT, BP_R_FOOT))
 		var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(owner, bp)
-		if(E && E.coating)
+		if(E && E.coating?.total_volume)
 			if(user == owner)
 				return "There's <font color='[E.coating.get_color()]'>something on your feet</font>!"
 			return "There's <font color='[E.coating.get_color()]'>something on [pronouns.his] feet</font>!"

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -162,6 +162,15 @@
 	for(var/g in decls_repository.get_decl_paths_of_subtype(/decl/material/gas))
 		if(!env_info.important_gasses[g])
 			trace_gas += g
+	// not everything in these lists is a subtype of /decl/material/gas, so:
+	for(var/dangerous_gas in env_info.dangerous_gasses)
+		if(env_info.important_gasses[dangerous_gas] || !env_info.dangerous_gasses[dangerous_gas])
+			continue
+		trace_gas |= dangerous_gas
+	for(var/filtered_gas in env_info.filter_gasses)
+		if(env_info.important_gasses[filtered_gas])
+			continue
+		trace_gas |= filtered_gas
 
 	queue_icon_update()
 

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -14,7 +14,7 @@
 	z_flags = ZMM_MANGLE_PLANES
 	layer = ABOVE_WINDOW_LAYER
 
-	var/on = 0
+	var/on = null // if null, takes from config option on init
 	var/area/connected_area = null
 	var/other_area = null
 
@@ -42,6 +42,8 @@
 
 /obj/machinery/light_switch/LateInitialize()
 	. = ..()
+	if(isnull(on))
+		on = get_config_value(/decl/config/toggle/lights_start_on)
 	connected_area?.set_lightswitch(on)
 	update_icon()
 

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -860,7 +860,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 /obj/item/proc/get_examine_name()
 	. = name
-	if(coating)
+	if(coating?.total_volume)
 		. = SPAN_WARNING("<font color='[coating.get_color()]'>stained</font> [.]")
 	if(gender == PLURAL)
 		. = "some [.]"

--- a/code/modules/chat_filter/_chat_filter.dm
+++ b/code/modules/chat_filter/_chat_filter.dm
@@ -7,7 +7,7 @@ var/global/list/chat_modifiers_in_use
 	var/list/all_filters = decls_repository.get_decls_of_type(/decl/chat_filter)
 	for(var/filtertype in all_filters)
 		var/decl/chat_filter/chat_filter = all_filters[filtertype]
-		if(!chat_filter.disabled && chat_filter.filter_category != chat_filter.type)
+		if(!chat_filter.disabled)
 			if(chat_filter.can_deny_message)
 				global.chat_blockers_in_use += chat_filter
 			if(chat_filter.can_modify_message)
@@ -31,10 +31,10 @@ var/global/list/chat_modifiers_in_use
 			. = chat_filter.replace(., match)
 
 /decl/chat_filter
+	abstract_type = /decl/chat_filter
 	var/name
 	var/disabled
 	var/summary
-	var/filter_category = /decl/chat_filter
 	var/can_modify_message = FALSE
 	var/can_deny_message = FALSE
 

--- a/code/modules/chat_filter/_chat_filter_regex.dm
+++ b/code/modules/chat_filter/_chat_filter_regex.dm
@@ -1,6 +1,7 @@
 /decl/chat_filter/regexp
-	filter_category = /decl/chat_filter/regexp
+	abstract_type = /decl/chat_filter/regexp
 	var/regex/filter_regex
 
 /decl/chat_filter/regexp/match(var/message)
-	. = filter_regex && findtext(message, filter_regex)
+	filter_regex.index = 0 // we use the global flag, so we need to reset this for every match or else repeat messages will break
+	. = filter_regex && filter_regex.Find(message)

--- a/code/modules/chat_filter/filter_markdown.dm
+++ b/code/modules/chat_filter/filter_markdown.dm
@@ -1,27 +1,27 @@
 /decl/chat_filter/regexp/markdown
-	filter_category = /decl/chat_filter/regexp/markdown
+	abstract_type = /decl/chat_filter/regexp/markdown
 	can_modify_message = TRUE
 	var/format_char
 	var/format_replace_proc
 
 /decl/chat_filter/regexp/markdown/Initialize()
 	. = ..()
-	filter_regex = regex("([format_char])(.+?)([format_char])", "g")
+	filter_regex = regex("([REGEX_QUOTE(format_char)])(.+?)([REGEX_QUOTE(format_char)])", "g")
 
 /decl/chat_filter/regexp/markdown/replace(var/message, var/match)
 	. = filter_regex.Replace(message, format_replace_proc)
 
 /proc/chatFilterRegexBold(full_match, prefix_char, message_body, suffix_char)
-	. = "<b>[message_body]</b>"
+	. = "<b>[trim(message_body)]</b>"
 
 /decl/chat_filter/regexp/markdown/bold
 	name = "Bold"
 	summary = "Applies <b>bold</b> to speech and emote text that is surrounded by *asterisks*."
-	format_char = "\\*"
+	format_char = "*"
 	format_replace_proc = /proc/chatFilterRegexBold
 
 /proc/chatFilterRegexItalic(full_match, prefix_char, message_body, suffix_char)
-	. = "<i>[message_body]</i>"
+	. = "<i>[trim(message_body)]</i>"
 
 /decl/chat_filter/regexp/markdown/italic
 	name = "Italics"

--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -117,8 +117,6 @@
 	if(!message || !emoter)
 		return
 
-	message = html_decode(message)
-
 	name_anchor = findtext(message, anchor_char)
 	if(name_anchor > 0) // User supplied emote with visible_emote token (default ^)
 		pretext = copytext(message, 1, name_anchor)
@@ -139,11 +137,7 @@
 		if(end_char != " ")
 			pretext += " "
 
-	// Grab the last character of the emote message.
-	end_char = copytext(subtext, length(subtext), length(subtext) + 1)
-	if(!(end_char in list(".", "?", "!", "\"", "-", "~"))) // gotta include ~ for all you fucking weebs
-		// No punctuation supplied. Tack a period on the end.
-		subtext += "."
+	handle_autopunctuation(subtext)
 
 	// Add a space to the subtext, unless it begins with an apostrophe or comma.
 	if(subtext != ".")
@@ -153,12 +147,9 @@
 		if(start_char != "," && start_char != "'")
 			subtext = " " + subtext
 
-	pretext = capitalize(html_encode(pretext))
-	nametext = html_encode(nametext)
-	subtext = html_encode(subtext)
 	// Store the player's name in a nice bold, naturalement
 	nametext = "<B>[emoter]</B>"
-	return pretext + nametext + subtext
+	return capitalize(pretext) + nametext + subtext
 
 /mob/proc/custom_emote(var/m_type = VISIBLE_MESSAGE, var/message = null)
 
@@ -171,15 +162,16 @@
 	else
 		input = message
 
-	if(input)
-		message = format_emote(src, message)
-	else
+	if(!input)
 		return
+
+	message = trim(html_encode(message))
+	message = filter_modify_message(message)
+	message = format_emote(src, message)
 
 	if (message)
 		log_emote("[name]/[key] : [message]")
 	//do not show NPC animal emotes to ghosts, it turns into hellscape
-	message = filter_modify_message(message)
 	var/check_ghosts = client ? /datum/client_preference/ghost_sight : null
 	if(m_type == VISIBLE_MESSAGE)
 		visible_message(message, check_ghosts = check_ghosts)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -204,7 +204,7 @@
 					criminal = R.get_criminalStatus()
 
 				msg += "<span class = 'deptradio'>Criminal status:</span> <a href='?src=\ref[src];criminal=1'>\[[criminal]\]</a>\n"
-				msg += "<span class = 'deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=`'>\[View\]</a>\n"
+				msg += "<span class = 'deptradio'>Security records:</span> <a href='?src=\ref[src];secrecord=1'>\[View\]</a>\n"
 
 	if(hasHUD(user, HUD_MEDICAL))
 		var/perpname = "wot"
@@ -223,7 +223,7 @@
 				medical = R.get_status()
 
 			msg += "<span class = 'deptradio'>Physical status:</span> <a href='?src=\ref[src];medical=1'>\[[medical]\]</a>\n"
-			msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=`'>\[View\]</a>\n"
+			msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=1'>\[View\]</a>\n"
 
 	// Show IC/OOC info if available.
 	if(comments_record_id)
@@ -270,7 +270,7 @@
 /mob/living/carbon/human/getHUDsource(hudtype)
 	var/obj/item/clothing/glasses/G = get_equipped_item(slot_glasses_str)
 	if(!istype(G))
-		return
+		return ..()
 	if(G.glasses_hud_type & hudtype)
 		return G
 	if(G.hud && (G.hud.glasses_hud_type & hudtype))

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -19,6 +19,7 @@
 		machine = null
 
 	CLEAR_HUD_ALERTS(src) // These will be set again in the various update procs below.
+	handle_hud_glasses() // Clear HUD overlay images. Done early so that organs, etc. can add them back.
 
 	//Handle temperature/pressure differences between body and environment
 	handle_environment(loc.return_air())
@@ -540,7 +541,6 @@
 
 /mob/living/proc/handle_hud_icons()
 	handle_hud_icons_health()
-	handle_hud_glasses()
 
 /mob/living/proc/handle_hud_icons_health()
 	return

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -100,18 +100,6 @@
 	returns[2] = null
 	return returns
 
-/mob/living/proc/format_say_message(var/message = null)
-	if(!message)
-		return
-
-	message = html_decode(message)
-
-	var/end_char = copytext_char(message, -1)
-	if(!(end_char in list(".", "?", "!", "-", "~")))
-		message += "."
-
-	return html_encode(message)
-
 /mob/living/proc/handle_mob_specific_speech(message, message_mode, verb = "says", decl/language/speaking)
 	SHOULD_CALL_PARENT(TRUE)
 	return FALSE
@@ -142,7 +130,8 @@
 		else
 			message = copytext_char(message, 3)
 
-	message = trim_left(message)
+	// trim pre-language-parsing so we can get language and radio keys
+	message = trim(message)
 
 	//parse the language code and consume it
 	if(!speaking)
@@ -177,10 +166,10 @@
 		else
 			verb = say_quote(message, speaking)
 
-	message = trim_left(message)
+	message = trim(html_encode(message)) // trim again post-language-parsing
 	message = handle_autohiss(message, speaking)
-	message = format_say_message(message)
 	message = filter_modify_message(message)
+	message = handle_autopunctuation(message)
 
 	if(speaking && !speaking.can_be_spoken_properly_by(src))
 		message = speaking.muddle(message)

--- a/code/modules/mob/observer/eye/freelook/life.dm
+++ b/code/modules/mob/observer/eye/freelook/life.dm
@@ -1,7 +1,7 @@
 /mob/observer/eye/freelook/Life()
-	. = ..()
+	..()
 	// If we lost our client, reset the list of visible chunks so they update properly on return
-	if(. && owner == src && !client)
+	if(owner == src && !client)
 		visibleChunks.Cut()
 	/*else if(owner && !owner.client)
 		visibleChunks.Cut()*/

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -109,8 +109,8 @@ Works together with spawning an observer, noted above.
 
 /mob/observer/ghost/Life()
 
-	. = ..()
-	if(!. || !loc || !client)
+	..()
+	if(!loc || !client)
 		return FALSE
 
 	handle_hud_glasses()

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -111,3 +111,12 @@ var/global/list/special_channel_keys = list(
 		var/obj/item/mask = get_equipped_item(slot_wear_mask_str)
 		if(istype(mask, /obj/item/clothing/mask/muzzle) || istype(mask, /obj/item/sealant))
 			. = mask
+
+/// Adds punctuation to an emote or speech message automatically.
+/mob/proc/handle_autopunctuation(message)
+	if(!message)
+		return
+	var/end_char = copytext_char(trim_right(strip_html_properly(message)), -1)
+	if(!(end_char in list(".", "?", "!", "-", "~")))
+		message += "."
+	return message

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -138,6 +138,7 @@
 	LAZYADD(., /decl/interaction_handler/remove_id/modular_computer)
 	LAZYADD(., /decl/interaction_handler/remove_pen/modular_computer)
 	LAZYADD(., /decl/interaction_handler/emergency_shutdown)
+	LAZYADD(., /decl/interaction_handler/remove_chargestick)
 
 //
 // Remove ID
@@ -149,7 +150,8 @@
 	. = ..()
 	if(.)
 		var/datum/extension/assembly/assembly = get_extension(target, /datum/extension/assembly)
-		. = !!(assembly?.get_component(PART_CARD))
+		var/obj/item/stock_parts/computer/card_slot/card_slot = assembly?.get_component(PART_CARD)
+		return !!card_slot?.stored_card
 
 /decl/interaction_handler/remove_id/modular_computer/invoked(atom/target, mob/user, obj/item/prop)
 	var/datum/extension/assembly/assembly = get_extension(target, /datum/extension/assembly)
@@ -187,3 +189,25 @@
 
 /decl/interaction_handler/emergency_shutdown/invoked(obj/item/modular_computer/target, mob/user, obj/item/prop)
 	target.emergency_shutdown()
+
+//
+// Remove Charge-stick
+//
+/decl/interaction_handler/remove_chargestick
+	name = "Remove Chargestick"
+	icon = 'icons/screen/radial.dmi'
+	icon_state = "radial_eject"
+	expected_target_type = /obj/item/modular_computer
+
+/decl/interaction_handler/remove_chargestick/is_possible(atom/target, mob/user, obj/item/prop)
+	. = ..()
+	if(!.)
+		return .
+	var/datum/extension/assembly/assembly = get_extension(target, /datum/extension/assembly)
+	var/obj/item/stock_parts/computer/charge_stick_slot/mstick_slot = assembly.get_component(PART_MSTICK)
+	return !!mstick_slot?.stored_stick
+
+/decl/interaction_handler/remove_chargestick/invoked(atom/target, mob/user, obj/item/prop)
+	var/datum/extension/assembly/assembly = get_extension(target, /datum/extension/assembly)
+	var/obj/item/stock_parts/computer/charge_stick_slot/mstick_slot = assembly.get_component(PART_MSTICK)
+	mstick_slot.eject_stick(user)

--- a/mods/content/dungeon_loot/loot_pile.dm
+++ b/mods/content/dungeon_loot/loot_pile.dm
@@ -62,7 +62,7 @@
 		return TRUE
 
 	//You already searched this one
-	if(!allow_multiple_looting && (user.ckey in searched_by))
+	if(!allow_multiple_looting && LAZYISIN(user.ckey, searched_by))
 		to_chat(L, SPAN_WARNING("You can't find anything else vaguely useful in \the [src]. Another set of eyes might, however."))
 		return TRUE
 
@@ -72,7 +72,7 @@
 		return TRUE
 
 	// You found something!
-	searched_by |= user.ckey
+	LAZYDISTINCTADD(searched_by, user.ckey)
 	var/obj/item/loot = null
 	var/span = "notice" // Blue
 


### PR DESCRIPTION
## Description of changes
Makes certain coating checks check total volume instead of just if the datum exists.
Makes loot piles use the lazylist macros for `searched_by`.
Reorders certain HUD calls.
Removes invalid parent call return value check in ghost Life().
Adds 'remove chargestick' modular computer alt interaction.
Makes the 'remove ID card' modular computer alt interaction only show up when there is an ID to remove.
Adds a config option to have lightswitches start on.
Implements a stopgap for air alarm trace gases, by adding gases from the filtered/dangerous gases list to the trace gases list. TODO: Cached list of materials by state at STP,.. OR just have the trace gas amount be `100 - every_other_gas`.
Makes regex chat filters reset their index after one use.
Makes markdown chat filters use REGEX_QUOTE for format_char.
Rewrites autopunctuation and format_emote/format_say_message. Trims trailing and leading whitespace from messages prior to autopunctuation. Autopunctuation now runs after chat modification filters, so the HTML can be trivially stripped when checking for punctuation.

## Why and what will this PR improve
Fix false-positives in stained item messages when the coating datum exists but is empty.
Fixes runtimes when searching loot piles.
Allows all methods of getting a HUD, not just HUD glasses, to work. (Anything that comes after the clear call, anyway.)
Fixes Ghost Medic HUDs not showing up.
Adds a way to remove chargesticks without using the right-click menu.
Prevents confusion by contextually hiding/showing the 'remove ID card' interaction.
Allows servers to configure whether their maps look empty and deserted at roundstart.
Temporarily fixes downstream issues with phoron (`/datum/material/solid/phoron`) not showing up in air alarm trace gases, without having to add an explicit reference to phoron.
Fixes regex chat filters having weird stateful behavior on repeated messages, causing them to not detect a message every other time it's repeated without a message in-between.
`format_char` for markdown filters no longer has to be manually escaped and can just be `"*"` or `"_"`.
Autopunctuation now gracefully handles HTML tags and trailing whitespace, avoiding issues like
> Annabelle Whitefur says, "This.  ."

and
> Cassandra Cressmann says, "**This.**."

## Authorship
Me, on Lighthouse.

## Changelog
:cl:
add: Adds an alt-click interaction to modular computers for removing chargesticks.
/:cl: