### PR TITLE
Fixes issues with object embedding.

### DIFF
--- a/code/_helpers/atom_movables.dm
+++ b/code/_helpers/atom_movables.dm
@@ -40,11 +40,6 @@
 /atom/movable/proc/do_simple_ranged_interaction(var/mob/user)
 	return FALSE
 
-/atom/movable/hitby(var/atom/movable/AM)
-	..()
-	if(density && prob(50))
-		do_simple_ranged_interaction()
-
 /atom/movable/can_be_injected_by(var/atom/injector)
 	if(!Adjacent(get_turf(injector)))
 		return FALSE

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -274,6 +274,7 @@
 		hit_atom.hitby(src, TT)
 
 /atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, datum/callback/callback) //If this returns FALSE then callback will not be called.
+
 	. = TRUE
 	if (!target || speed <= 0 || QDELETED(src) || (target.z != src.z))
 		return FALSE

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -776,9 +776,14 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 		. += "  <a href='?src=\ref[ID];look_at_id=1'>\[Look at ID\]</a>"
 
 /obj/item/proc/on_active_hand()
-
-/obj/item/proc/has_embedded()
 	return
+
+/obj/item/proc/has_embedded(mob/living/victim)
+	if(istype(victim))
+		LAZYDISTINCTADD(victim.embedded, src)
+		victim.verbs |= /mob/proc/yank_out_object
+		return TRUE
+	return FALSE
 
 /obj/item/proc/get_pressure_weakness(pressure,zone)
 	. = 1
@@ -954,3 +959,6 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	// delay for 1ds to allow the rest of the call stack to resolve
 	if(!QDELETED(src) && !QDELETED(user) && user.get_equipped_slot_for_item(src) == slot)
 		try_burn_wearer(user, slot, 1)
+
+/obj/item/can_embed()
+	return !anchored && !is_robot_module(src)

--- a/code/game/objects/items/weapons/material/misc.dm
+++ b/code/game/objects/items/weapons/material/misc.dm
@@ -22,6 +22,7 @@
 	icon_state = "harpoon_bomb"
 
 /obj/item/harpoon/bomb/has_embedded()
+	..()
 	if(spent)
 		return
 	audible_message(SPAN_WARNING("\The [src] emits a long, harsh tone!"))

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -23,7 +23,6 @@
 	var/holographic = 0 //if the obj is a holographic object spawned by the holodeck
 	var/tmp/directional_offset ///JSON list of directions to x,y offsets to be applied to the object depending on its direction EX: @'{"NORTH":{"x":12,"y":5}, "EAST":{"x":10,"y":50}}'
 
-
 /obj/Initialize(mapload)
 	. = ..()
 	temperature_coefficient = isnull(temperature_coefficient) ? clamp(MAX_TEMPERATURE_COEFFICIENT - w_class, MIN_TEMPERATURE_COEFFICIENT, MAX_TEMPERATURE_COEFFICIENT) : temperature_coefficient
@@ -158,7 +157,7 @@
 	return ..() && w_class <= round(amt/20)
 
 /obj/proc/can_embed()
-	return is_sharp(src)
+	return FALSE
 
 /obj/examine(mob/user, distance, infix, suffix)
 	. = ..()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -383,8 +383,6 @@
 		if(isliving(AM))
 			var/mob/living/M = AM
 			M.turf_collision(src, TT.speed)
-			if(LAZYLEN(M.pinned))
-				return
 		addtimer(CALLBACK(src, TYPE_PROC_REF(/turf, bounce_off), AM, TT.init_dir), 2)
 	else if(isobj(AM))
 		var/obj/structure/ladder/L = locate() in contents
@@ -392,6 +390,12 @@
 			L.hitby(AM)
 
 /turf/proc/bounce_off(var/atom/movable/AM, var/direction)
+	if(AM.anchored)
+		return
+	if(ismob(AM))
+		var/mob/living/M = AM
+		if(LAZYLEN(M.pinned))
+			return
 	step(AM, turn(direction, 180))
 
 /turf/proc/can_engrave()

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -1,25 +1,6 @@
 
 /mob/living/carbon/standard_weapon_hit_effects(obj/item/I, mob/living/user, var/effective_force, var/hit_zone)
-	if(!effective_force)
-		return 0
-
-	//Apply weapon damage
-	var/damage_flags = I.damage_flags()
-	var/datum/wound/created_wound = apply_damage(effective_force, I.damtype, hit_zone, damage_flags, used_weapon=I, armor_pen=I.armor_penetration)
-
-	//Melee weapon embedded object code.
-	if(istype(created_wound) && I && I.can_embed() && I.damtype == BRUTE && !I.anchored && !is_robot_module(I))
-		var/weapon_sharp = (damage_flags & DAM_SHARP)
-		var/damage = effective_force //just the effective damage used for sorting out embedding, no further damage is applied here
-		damage *= 1 - get_blocked_ratio(hit_zone, I.damtype, I.damage_flags(), I.armor_penetration, I.force)
-
-		//blunt objects should really not be embedding in things unless a huge amount of force is involved
-		var/embed_chance = weapon_sharp? damage/I.w_class : damage/(I.w_class*3)
-		var/embed_threshold = weapon_sharp? 5*I.w_class : 15*I.w_class
-
-		//Sharp objects will always embed if they do enough damage.
-		if((weapon_sharp && damage > (10*I.w_class)) || (damage > embed_threshold && prob(embed_chance)))
-			embed_in_mob(I, hit_zone, damage, I.damtype, supplied_wound = created_wound)
-			I.has_embedded()
-
-	return 1
+	if(effective_force)
+		try_embed_in_mob(I, hit_zone, effective_force, direction = get_dir(user, src))
+		return TRUE
+	return FALSE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1475,3 +1475,5 @@ default behaviour is:
 		return TRUE
 	return FALSE
 
+/mob/living/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, datum/callback/callback) //If this returns FALSE then callback will not be called.
+	return !length(pinned) && ..()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -183,11 +183,9 @@
 			return FALSE
 
 	visible_message(SPAN_DANGER("\The [src] is hit [affecting ? "in \the [affecting.name] " : ""]by \the [O]!"))
-	var/datum/wound/created_wound = apply_damage(throw_damage, dtype, zone, O.damage_flags(), O, O.armor_penetration)
 	if(TT?.thrower?.client)
 		admin_attack_log(TT.thrower, src, "Threw \an [O] at the victim.", "Had \an [O] thrown at them.", "threw \an [O] at")
-	if(O.can_embed() && (throw_damage > 5*O.w_class)) //Handles embedding for non-humans and simple_animals.
-		embed_in_mob(O, zone, throw_damage, dtype, created_wound, affecting)
+	try_embed_in_mob(O, zone, throw_damage, dtype, null, affecting, direction = TT.init_dir)
 	return TRUE
 
 /mob/living/momentum_power(var/atom/movable/AM, var/datum/thrownthing/TT)
@@ -198,53 +196,56 @@
 	if(has_gravity() || check_space_footing())
 		. *= 0.5
 
-/mob/living/momentum_do(var/power, var/datum/thrownthing/TT, var/atom/movable/AM)
-	if(power >= 0.75)		//snowflake to enable being pinned to walls
-		var/direction = TT.init_dir
-		throw_at(get_edge_target_turf(src, direction), min((TT.maxrange - TT.dist_travelled) * power, 10), throw_speed * min(power, 1.5), callback = CALLBACK(src, TYPE_PROC_REF(/mob/living, pin_to_wall), AM, direction))
-		visible_message(SPAN_DANGER("\The [src] staggers under the impact!"),SPAN_DANGER("You stagger under the impact!"))
-		return
+/mob/living/proc/try_embed_in_mob(obj/O, def_zone, embed_damage = 0, dtype = BRUTE, datum/wound/supplied_wound, obj/item/organ/external/affecting, direction)
 
-	. = ..()
-
-/mob/living/proc/pin_to_wall(var/obj/O, var/direction)
-	if(!istype(O) || O.loc != src || !O.can_embed())//Projectile is suitable for pinning.
-		return
-
-	var/turf/T = near_wall(direction,2)
-
-	if(T)
-		forceMove(T)
-		visible_message(SPAN_DANGER("[src] is pinned to the wall by [O]!"),SPAN_DANGER("You are pinned to the wall by [O]!"))
-		src.anchored = TRUE
-		LAZYADD(pinned, O)
-		if(!LAZYISIN(embedded,O))
-			embed_in_mob(O)
-
-/mob/living/proc/embed_in_mob(obj/O, def_zone, embed_damage = 0, dtype = BRUTE, datum/wound/supplied_wound, obj/item/organ/external/affecting)
-
-	if(!istype(O))
+	if(!istype(O) || !O.can_embed())
 		return FALSE
 
-	if(affecting && supplied_wound && dtype == BRUTE && isitem(O) && !is_robot_module(O))
+	if(!affecting)
+		affecting = get_organ(def_zone)
+
+	if(!supplied_wound)
+		supplied_wound = apply_damage(embed_damage, dtype, def_zone, O.damage_flags(), O, O.armor_penetration)
+
+	if(affecting && supplied_wound?.is_open() && dtype == BRUTE) // Can't embed in a small bruise.
 		var/obj/item/I = O
-		var/sharp = I.can_embed()
+		var/sharp = is_sharp(I)
 		embed_damage *= (1 - get_blocked_ratio(def_zone, BRUTE, O.damage_flags(), O.armor_penetration, I.force))
 
 		//blunt objects should really not be embedding in things unless a huge amount of force is involved
 		var/embed_chance = embed_damage / (sharp ? I.w_class : (I.w_class*3))
-		var/embed_threshold = (sharp ? 5 : 15) * I.w_class
+		var/embed_threshold = (sharp ? 5 : 10) * I.w_class
+		var/sharp_embed_chance = embed_damage/(10*I.w_class)*100
 
 		//Sharp objects will always embed if they do enough damage.
 		//Thrown sharp objects have some momentum already and have a small chance to embed even if the damage is below the threshold
-		if((sharp && prob(embed_damage/(10*I.w_class)*100)) || (embed_damage > embed_threshold && prob(embed_chance)))
+		if((sharp && prob(sharp_embed_chance)) || (embed_damage > embed_threshold && prob(embed_chance)))
 			affecting.embed_in_organ(I, supplied_wound = supplied_wound)
-			I.has_embedded()
-			return TRUE
+			I.has_embedded(src)
+			. = TRUE
 
-	O.forceMove(src)
-	LAZYDISTINCTADD(embedded, O)
-	verbs += /mob/proc/yank_out_object
+	// Simple embed for mobs with no limbs.
+	if(!. && !length(get_external_organs()))
+		O.forceMove(src)
+		if(isitem(O))
+			var/obj/item/I = O
+			I.has_embedded(src)
+		. = TRUE
+
+	// Allow a tick for throwing/striking to resolve.
+	if(. && direction)
+		addtimer(CALLBACK(src, PROC_REF(check_embed_pinning), O, direction), 1)
+
+/mob/living/proc/check_embed_pinning(obj/O, direction)
+	if(QDELETED(src) || QDELETED(O) || !isturf(loc) || !(O in embedded) || !direction)
+		return FALSE
+	var/turf/wall = get_step_resolving_mimic(loc, direction)
+	if(!istype(wall) || !wall.density)
+		return FALSE
+	LAZYDISTINCTADD(pinned, O)
+	visible_message("\The [src] is pinned to \the [wall] by \the [O]!")
+	// TODO: cancel all throwing and momentum after this point
+	return TRUE
 
 //This is called when the mob is thrown into a dense turf
 /mob/living/proc/turf_collision(var/turf/T, var/speed)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -198,14 +198,17 @@
 
 /mob/living/proc/try_embed_in_mob(obj/O, def_zone, embed_damage = 0, dtype = BRUTE, datum/wound/supplied_wound, obj/item/organ/external/affecting, direction)
 
-	if(!istype(O) || !O.can_embed())
+	if(!istype(O))
+		return FALSE
+
+	if(!supplied_wound)
+		supplied_wound = apply_damage(embed_damage, dtype, def_zone, O.damage_flags(), O, O.armor_penetration)
+
+	if(!O.can_embed())
 		return FALSE
 
 	if(!affecting)
 		affecting = get_organ(def_zone)
-
-	if(!supplied_wound)
-		supplied_wound = apply_damage(embed_damage, dtype, def_zone, O.damage_flags(), O, O.armor_penetration)
 
 	if(affecting && supplied_wound?.is_open() && dtype == BRUTE) // Can't embed in a small bruise.
 		var/obj/item/I = O

--- a/code/modules/mob/living/simple_animal/natural_weapons.dm
+++ b/code/modules/mob/living/simple_animal/natural_weapons.dm
@@ -14,6 +14,7 @@
 
 /obj/item/natural_weapon/can_embed()
 	return FALSE
+
 /obj/item/natural_weapon/bite
 	name = "teeth"
 	attack_verb = list("bitten")

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1459,7 +1459,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 				incision = other
 	else
 		for(var/datum/wound/cut/W in wounds)
-			if(W.bandaged || W.current_stage > W.max_bleeding_stage) // Shit's unusable
+			if(!W.is_open()) // Shit's unusable
 				continue
 			if(strict && !W.is_surgical()) //We don't need dirty ones
 				continue

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -31,7 +31,7 @@
 		owner.bodytemperature += burn
 		burn = 0
 		if(prob(25))
-			owner.visible_message("<span class='warning'>\The [owner]'s crystalline [name] shines with absorbed energy!</span>")
+			owner.visible_message(SPAN_WARNING("\The [owner]'s crystalline [name] shines with absorbed energy!"))
 
 	if(used_weapon)
 		add_autopsy_data(used_weapon, brute + burn)

--- a/code/modules/organs/external/wounds/wound.dm
+++ b/code/modules/organs/external/wounds/wound.dm
@@ -169,6 +169,9 @@
 	// return amount of healing still leftover, can be used for other wounds
 	return amount
 
+/datum/wound/proc/is_open()
+	return current_stage <= max_bleeding_stage && !bandaged
+
 // opens the wound again
 /datum/wound/proc/open_wound(damage)
 	src.damage += damage
@@ -203,7 +206,7 @@
 			return FALSE
 	if(bandaged || clamped)
 		return FALSE
-	return ((bleed_timer > 0 || wound_damage() > bleed_threshold) && current_stage <= max_bleeding_stage)
+	return ((bleed_timer > 0 || wound_damage() > bleed_threshold) && is_open())
 
 /datum/wound/proc/is_surgical()
 	return 0

--- a/code/modules/organs/external/wounds/wound.dm
+++ b/code/modules/organs/external/wounds/wound.dm
@@ -201,12 +201,11 @@
 	return 1
 
 /datum/wound/proc/bleeding()
-	for(var/obj/item/thing in embedded_objects)
-		if(thing.w_class > ITEM_SIZE_SMALL)
-			return FALSE
-	if(bandaged || clamped)
-		return FALSE
-	return ((bleed_timer > 0 || wound_damage() > bleed_threshold) && is_open())
+	. = !clamped && is_open() && (bleed_timer > 0 || wound_damage() > bleed_threshold)
+	if(. && length(embedded_objects))
+		for(var/obj/item/thing in embedded_objects)
+			if(thing.w_class > ITEM_SIZE_SMALL)
+				return FALSE
 
 /datum/wound/proc/is_surgical()
 	return 0


### PR DESCRIPTION
- Embedding is now unified under `try_embed_in_mob()`.
- Embedding will proactively try to find an appropriate limb and create a wound if unsupplied.
- Failed embedding will not teleport the item inside the mob with no way to remove it.
- Pinning should work again.
- Slightly lowered the damage threshold for embedding.