### PR TITLE
Make yellow/green text readable in lightmode

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -217,7 +217,8 @@ var/global/list/admin_verbs_debug = list(
 	/client/proc/spawn_ore_pile,
 	/datum/admins/proc/force_initialize_weather,
 	/datum/admins/proc/force_weather_state,
-	/datum/admins/proc/force_kill_weather
+	/datum/admins/proc/force_kill_weather,
+	/client/proc/force_reload_theme_css,
 	)
 
 var/global/list/admin_verbs_paranoid_debug = list(
@@ -918,3 +919,13 @@ var/global/list/admin_verbs_mod = list(
 
 		if("Cancel")
 			return
+
+/client/proc/force_reload_theme_css()
+	set category = "Debug"
+	set name     = "Reload UI Theme CSS"
+	set desc     = "Forces the client to reload its UI theme css file."
+	if(!check_rights(R_DEBUG))
+		return
+	var/datum/D = src
+	ReloadModeThemeCss(D.get_client())
+

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -926,6 +926,4 @@ var/global/list/admin_verbs_mod = list(
 	set desc     = "Forces the client to reload its UI theme css file."
 	if(!check_rights(R_DEBUG))
 		return
-	var/datum/D = src
-	ReloadModeThemeCss(D.get_client())
-
+	ReloadThemeCss(src)

--- a/code/modules/client/darkmode.css
+++ b/code/modules/client/darkmode.css
@@ -1,3 +1,8 @@
+/**
+ * The CSS for the UI theme supports only the older subset of CSS supported by the 'style' attribute of the byond client's browser windows.
+ * Colors hex values should be in lower case for compatibility reasons.
+ */
+
 body					{font-family: Verdana, sans-serif;}
 
 h1, h2, h3, h4, h5, h6	{color: #a4bad6;font-family: Georgia, Verdana, sans-serif;}

--- a/code/modules/client/darkmode.dm
+++ b/code/modules/client/darkmode.dm
@@ -3,6 +3,26 @@
 var/global/lightmode_style = url_encode(file2text('code/modules/client/lightmode.css'))
 var/global/darkmode_style = url_encode(file2text('code/modules/client/darkmode.css'))
 
+/**
+	Force the light and dark theme css files to be reloaded. Mainly usefule for devs.
+ */
+/proc/ReloadModeThemeCss(client/C, quiet = FALSE)
+	//Reload the files.
+	//#NOTE: I'm not sure why we're caching those as globals on the server? Would make more sense to load them directly from client local file into the winset()
+	global.lightmode_style = url_encode(file2text('code/modules/client/lightmode.css'))
+	global.darkmode_style  = url_encode(file2text('code/modules/client/darkmode.css'))
+
+	//Tell our client to set their output window style.
+	var/pref_mode = C.get_preference_value(/datum/client_preference/chat_color_mode)
+	var/style_string
+	if(pref_mode == PREF_LIGHTMODE)
+		style_string = global.lightmode_style
+	else
+		style_string = global.darkmode_style
+	winset(C, "output", "style = [style_string]")
+	if(!quiet)
+		to_chat(C, "Reloaded client CSS stylesheet for current theme.")
+
 /*
 This lets you switch chat themes by using winset and CSS loading.
 Things to note:

--- a/code/modules/client/darkmode.dm
+++ b/code/modules/client/darkmode.dm
@@ -6,7 +6,7 @@ var/global/darkmode_style = url_encode(file2text('code/modules/client/darkmode.c
 /**
 	Force the light and dark theme css files to be reloaded. Mainly usefule for devs.
  */
-/proc/ReloadModeThemeCss(client/C, quiet = FALSE)
+/proc/ReloadThemeCss(client/C, quiet = FALSE)
 	//Reload the files.
 	//#NOTE: I'm not sure why we're caching those as globals on the server? Would make more sense to load them directly from client local file into the winset()
 	global.lightmode_style = url_encode(file2text('code/modules/client/lightmode.css'))

--- a/code/modules/client/lightmode.css
+++ b/code/modules/client/lightmode.css
@@ -85,7 +85,7 @@ h1.alert, h2.alert		{color: #000000;}
 .info					{color: #0000cc;}
 .notice					{color: #000099;}
 .subtle					{color: #000099; font-size: 75%; font-style: italic;}
-.alium					{color: #00ff00;}
+.alium					{color: #439C16;}
 .cult					{color: #800080; font-weight: bold; font-style: italic;}
 .cultannounce			{color: #800080; font-style: italic; font-size: 175%;}
 .mfauna					{color: #884422; font-weight: bold; font-size: 125%;}
@@ -95,15 +95,15 @@ h1.alert, h2.alert		{color: #000000;}
 /* General purpose colour classes */
 .font_red               {color: #ff0000;}
 .font_orange            {color: #ff7f00;}
-.font_yellow            {color: #ffff00;}
-.font_green             {color: #00ff00;}
+.font_yellow            {color: #b9aa1d;}
+.font_green             {color: #439C16;}
 .font_blue              {color: #0000ff;}
 .font_violet            {color: #4B0082;}
 .font_purple            {color: #8f00ff;}
 .font_grey              {color: #454545;}
 .font_maroon            {color: #800000;}
-.font_pink              {color: #ff8787;}
-.font_palepink          {color: #ffc4c4;}
+.font_pink              {color: #b86262;}
+.font_palepink          {color: #b68c8c;}
 
 /* Languages */
 
@@ -127,7 +127,7 @@ h1.alert, h2.alert		{color: #000000;}
 
 .interface				{color: #330033;}
 
-.good					{color: #00ff00; font-weight: bold;}
+.good					{color: #439C16; font-weight: bold;}
 .bad					{color: #ee0000; font-weight: bold;}
 
 BIG IMG.icon 			{width: 32px; height: 32px;}

--- a/code/modules/client/lightmode.css
+++ b/code/modules/client/lightmode.css
@@ -85,7 +85,7 @@ h1.alert, h2.alert		{color: #000000;}
 .info					{color: #0000cc;}
 .notice					{color: #000099;}
 .subtle					{color: #000099; font-size: 75%; font-style: italic;}
-.alium					{color: #439C16;}
+.alium					{color: #439c16;}
 .cult					{color: #800080; font-weight: bold; font-style: italic;}
 .cultannounce			{color: #800080; font-style: italic; font-size: 175%;}
 .mfauna					{color: #884422; font-weight: bold; font-size: 125%;}
@@ -96,7 +96,7 @@ h1.alert, h2.alert		{color: #000000;}
 .font_red               {color: #ff0000;}
 .font_orange            {color: #ff7f00;}
 .font_yellow            {color: #b9aa1d;}
-.font_green             {color: #439C16;}
+.font_green             {color: #439c16;}
 .font_blue              {color: #0000ff;}
 .font_violet            {color: #4B0082;}
 .font_purple            {color: #8f00ff;}
@@ -127,7 +127,7 @@ h1.alert, h2.alert		{color: #000000;}
 
 .interface				{color: #330033;}
 
-.good					{color: #439C16; font-weight: bold;}
+.good					{color: #439c16; font-weight: bold;}
 .bad					{color: #ee0000; font-weight: bold;}
 
 BIG IMG.icon 			{width: 32px; height: 32px;}

--- a/code/modules/client/lightmode.css
+++ b/code/modules/client/lightmode.css
@@ -1,3 +1,8 @@
+/**
+ * The CSS for the UI theme supports only the older subset of CSS supported by the 'style' attribute of the byond client's browser windows.
+ * Colors hex values should be in lower case for compatibility reasons.
+ */
+
 body					{font-family: Verdana, sans-serif;}
 
 h1, h2, h3, h4, h5, h6	{color: #0000ff;font-family: Georgia, Verdana, sans-serif;}


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Light text color would be hard to read on the light theme. So made them darker.
Also added a verb to reload only the CSS for the theme at runtime.

## Changelog
:cl:
code: Added verb to reload light/dark mode CSS file. 
config: Made yellow and green text more readable for users of the light mode theme.
/:cl:
