### PR TITLE
Fixed missing storage removal check

### DIFF
--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -352,7 +352,8 @@
 	if(user.client && istype(inv) && inv.slot_id && (over in user.client.screen))
 		// Remove the item from our bag if necessary.
 		if(istype(loc?.storage))
-			loc.storage.remove_from_storage(user, src)
+			if(!loc.storage.remove_from_storage(user, src))
+				return ..()
 			dropInto(get_turf(loc))
 		// Otherwise remove it from our inventory if necessary.
 		else if(ismob(loc))
@@ -459,9 +460,8 @@
 				else
 					dropInto(get_turf(user))
 				return TRUE
-			if(loc?.storage)
+			if(loc?.storage?.remove_from_storage(user, src))
 				visible_message(SPAN_NOTICE("\The [user] fumbles \the [src] out of \the [loc]."))
-				loc.storage.remove_from_storage(user, src)
 				dropInto(get_turf(loc))
 				return TRUE
 		to_chat(user, SPAN_WARNING("You are not dexterous enough to pick up \the [src]."))


### PR DESCRIPTION
## Description of changes
In ``/obj/item/handle_mouse_drop`` and ``/obj/item/attack_hand``, the return value of remove_from_storage wouldn't be checked for success before assuming it worked. It doesn't seem to have caused any obvious problems so far, but it would probably make more sense to check it first.

Also, NOTE: I'm a bit unsure if returning to the base proc is the right thing to do on line 355? From what I can see it should be. But, I'm not 100% sure since a lot of things changed with inventories.


