### PR TITLE
Fixes from Shaded Hills playtesting, June 11, 2024

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -412,6 +412,11 @@
 	if (amount < max_amount)
 		. = CEILING(. * amount / max_amount)
 
+/obj/item/stack/get_mass() // Scales mass to stack size
+	. = ..()
+	if (amount < max_amount)
+		. *= amount / max_amount // Don't round, this can be non-integer
+
 /obj/item/stack/attack_hand(mob/user)
 	if(!user.is_holding_offhand(src) || !can_split())
 		return ..()

--- a/code/modules/crafting/slapcrafting/crafting_recipes/tool_crafting/_tool_crafting.dm
+++ b/code/modules/crafting/slapcrafting/crafting_recipes/tool_crafting/_tool_crafting.dm
@@ -91,7 +91,6 @@ var/global/list/_tool_crafting_components = list(
 	var/static/list/binding_materials = list(
 		/decl/material/solid/organic/plantmatter/grass/dry,
 		/decl/material/solid/organic/leather,
-		/decl/material/solid/organic/meat/gut,
 		/decl/material/solid/organic/cloth
 	)
 

--- a/code/modules/hydroponics/plant_types/seeds_misc.dm
+++ b/code/modules/hydroponics/plant_types/seeds_misc.dm
@@ -1470,7 +1470,7 @@
 	set_trait(TRAIT_MATURATION,6)
 	set_trait(TRAIT_PRODUCTION,6)
 	set_trait(TRAIT_YIELD,5)
-	set_trait(TRAIT_PRODUCT_ICON,"grapes")
+	set_trait(TRAIT_PRODUCT_ICON,"treefruit")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#a80000")
 	set_trait(TRAIT_PLANT_COLOUR,"#749733")
 	set_trait(TRAIT_PLANT_ICON,"vine2")

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -244,6 +244,7 @@
 	if(!istype(wall) || !wall.density)
 		return FALSE
 	LAZYDISTINCTADD(pinned, O)
+	walk_to(src, 0) // cancel any automated movement
 	visible_message("\The [src] is pinned to \the [wall] by \the [O]!")
 	// TODO: cancel all throwing and momentum after this point
 	return TRUE

--- a/code/modules/mob/living/simple_animal/passive/_passive.dm
+++ b/code/modules/mob/living/simple_animal/passive/_passive.dm
@@ -8,7 +8,8 @@
 	var/mob/living/simple_animal/critter = body
 	var/atom/flee_target_atom = flee_target?.resolve()
 	if(istype(flee_target_atom) && (flee_target_atom.loc in view(body)))
-		walk_away(body, flee_target_atom, 7, 2)
+		if(body.MayMove())
+			walk_away(body, flee_target_atom, 7, 2)
 		critter.stop_automated_movement = TRUE
 	else
 		flee_target = null

--- a/code/modules/projectiles/guns/launcher/bows/bow_drawing.dm
+++ b/code/modules/projectiles/guns/launcher/bows/bow_drawing.dm
@@ -5,7 +5,7 @@
 	return draw_time
 
 /obj/item/gun/launcher/bow/proc/check_can_draw(mob/user)
-	return istype(user) && !QDELETED(user) && !QDELETED(src) && (!require_loaded_to_draw || get_loaded_arrow(user))
+	return istype(user) && !QDELETED(user) && !QDELETED(src) && istype(string) && !QDELETED(string) && (!require_loaded_to_draw || get_loaded_arrow(user))
 
 /obj/item/gun/launcher/bow/proc/start_drawing(var/mob/user)
 

--- a/code/modules/projectiles/guns/launcher/bows/bow_firing.dm
+++ b/code/modules/projectiles/guns/launcher/bows/bow_firing.dm
@@ -2,6 +2,10 @@
 	return istype(ammo, bow_ammo_type)
 
 /obj/item/gun/launcher/bow/proc/load_arrow(mob/user, obj/item/ammo)
+	if(!istype(string))
+		if(user)
+			to_chat(user, SPAN_WARNING("\The [src] has no bowstring!"))
+		return FALSE
 	if(istype(ammo, /obj/item/stack))
 		var/obj/item/stack/stack = ammo
 		ammo = stack.split(1)


### PR DESCRIPTION
## Description of changes
~~Adjusts the icon state used for plant harvest overlays.~~ Adjusts the harvest overlay used by coffee to not float in midair.
Fleeing now checks if the mob can move (including pinning), and being pinned cancels automated BYOND movement like fleeing.
Adjusts stack `get_mass()` to scale with `amount / max_amount`.
Removes non-dried gut from tool binding materials; it can't be made into thread/cloth/bundles/etc. anyway.
Drawing and firing a bow now checks for a bowstring.

## Why and what will this PR improve
~~Fixes plant harvest overlays.~~ Coffee harvest overlays won't float off the plant. Requires #4102 to be visible.
Prevents pinned animals from fleeing/makes pinning stop fleeing properly.
Fixes arrows sending rabbits flying offscreen.
Removes an invalid binding material.
Fixes being able to draw and fire a bow without a bowstring.