### PR TITLE
Tweaks from Shaded Hills playtesting, June 11, 2024

### DIFF
--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -94,7 +94,7 @@
 
 //A "preset" for counting_english_list that displays the list "inline" (comma separated)
 /proc/inline_counting_english_list(list/input, output_icons = TRUE, determiners = DET_NONE, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "", line_prefix = "", first_item_prefix = "", last_item_suffix = "")
-	return counting_english_list(input, output_icons, determiners, nothing_text, and_text, comma_text, final_comma_text)
+	return counting_english_list(input, output_icons, determiners, nothing_text, line_prefix, first_item_prefix, last_item_suffix, and_text, comma_text, final_comma_text)
 
 //Checks for specific types in a list
 /proc/is_type_in_list(datum/thing, list/type_list)

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -118,6 +118,7 @@
 	desc = "A simple sack for carrying goods."
 	icon = 'icons/obj/items/storage/sack.dmi'
 	icon_state = ICON_STATE_WORLD
+	w_class = ITEM_SIZE_SMALL
 	slot_flags = SLOT_LOWER_BODY | SLOT_BACK
 	storage = /datum/storage/bag/sack
 	material = /decl/material/solid/organic/leather

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -40,6 +40,10 @@
 		return PAIN
 	return BRUTE
 
+/decl/natural_attack/proc/get_damage_flags()
+	. |= (sharp && DAM_SHARP)
+	. |= (edge && DAM_EDGE)
+
 /decl/natural_attack/proc/padded_by_user_gear(var/mob/living/carbon/human/user)
 	if(istype(user) && length(usable_with_limbs))
 		for(var/limb_slot in usable_with_limbs)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -26,11 +26,11 @@
 		if(BURN)
 			if(MUTATION_COLD_RESISTANCE in mutations)
 				return
-			take_damage(damage, BURN)
+			take_damage(damage, BURN, damage_flags, used_weapon, armor_pen)
 		if(ELECTROCUTE)
 			electrocute_act(damage, used_weapon, 1, def_zone)
 		else
-			take_damage(damage, damagetype)
+			take_damage(damage, damagetype, damage_flags, used_weapon, armor_pen)
 	return TRUE
 
 /mob/living/apply_radiation(var/damage = 0)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -20,7 +20,9 @@
 
 /mob/living/show_other_examine_strings(mob/user, distance, infix, suffix, hideflags, decl/pronouns/pronouns)
 	if(admin_paralyzed)
-		to_chat(user, SPAN_OCCULT("OOC: They have been paralyzed by staff. Please avoid interacting with them unless cleared to do so by staff."))
+		to_chat(user, SPAN_OCCULT("OOC: [pronouns.He] [pronouns.has] been paralyzed by staff. Please avoid interacting with [pronouns.him] unless cleared to do so by staff."))
+	if(!length(get_external_organs()) && length(embedded)) // fallback for simple embedding used by limbless mobs
+		to_chat(user, SPAN_WARNING("[pronouns.He] [pronouns.has] [inline_counting_english_list(embedded, determiners = DET_INDEFINITE)] embedded in [pronouns.him]."))
 
 //mob verbs are faster than object verbs. See above.
 /mob/living/pointed(atom/A as mob|obj|turf in view())

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -333,15 +333,17 @@ var/global/list/simplemob_icon_bitflag_cache = list()
 	if(!.)
 		var/dealt_damage = harm_intent_damage
 		var/harm_verb = response_harm
+		var/damageflags
+		var/damagetype
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			var/decl/natural_attack/attack = H.get_unarmed_attack(src)
 			if(istype(attack))
 				dealt_damage = attack.damage <= dealt_damage ? dealt_damage : attack.damage
 				harm_verb = pick(attack.attack_verb)
-				if(attack.sharp || attack.edge)
-					adjustBleedTicks(dealt_damage)
-		take_damage(dealt_damage)
+				damageflags = attack.get_damage_flags()
+				damagetype = attack.get_damage_type()
+		take_damage(dealt_damage, damagetype, damageflags, user)
 		user.visible_message(SPAN_DANGER("\The [user] [harm_verb] \the [src]!"))
 		user.do_attack_animation(src)
 		return TRUE
@@ -380,11 +382,14 @@ var/global/list/simplemob_icon_bitflag_cache = list()
 	if(supernatural && istype(O,/obj/item/nullrod))
 		damage *= 2
 		purge = 3
-	take_damage(damage)
-	if(O.edge || O.sharp)
-		adjustBleedTicks(damage)
+	take_damage(damage, O.atom_damage_type, O.damage_flags())
 
 	return 1
+
+/mob/living/simple_animal/take_damage(damage, damagetype, def_zone, damage_flags, obj/item/used_weapon, armor_pen, silent, do_update_health)
+	. = ..()
+	if((damagetype == BRUTE) && damage_flags & (DAM_EDGE | DAM_SHARP | DAM_BULLET)) // damage flags that should cause bleeding
+		adjustBleedTicks(damage)
 
 /mob/living/simple_animal/get_movement_delay(var/travel_dir)
 	var/tally = ..() //Incase I need to add stuff other than "speed" later

--- a/code/modules/tools/components/recipes.dm
+++ b/code/modules/tools/components/recipes.dm
@@ -13,7 +13,8 @@
 	difficulty                  = MAT_VALUE_NORMAL_DIY
 	craft_stack_types = list(
 		/obj/item/stack/material/plank,
-		/obj/item/stack/material/rods
+		/obj/item/stack/material/rods,
+		/obj/item/stack/material/bone
 	)
 
 /decl/stack_recipe/tool/handle/long


### PR DESCRIPTION
## Description of changes
Lists embedded objects for simplemobs using the fallback organ-less system. Fixes `inline_counting_english_list()`.
Makes simple_animal bleeding more consistent. Also adjusts some parameters in calls to `take_damage()`, sorry Loaf!
Makes sacks small when empty, so that the bag resizing mechanics actually have an impact. It's presumably intended because there was an empty state that existed but wasn't ever shown.
Allows tool handles to be made from bone.

## Why and what will this PR improve
You can now see when arrows are embedded in a simplemob.
Animals bleed when shot with an arrow, and from a variety of sources of damage.
Sacks are smaller (giving them an advantage over other containers like baskets) and now use all their icon states.
Tool handles can be made from bone.