### PR TITLE
Add interaction to switch folding blade tool mode

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -197,7 +197,7 @@ var/global/list/radial_menus = list()
 			MA.maptext_height = 64
 			MA.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 			MA.maptext_x = -round(MA.maptext_width/2) + 16
-			MA.maptext_x = -round(MA.maptext_height/2) + 16
+			MA.maptext_y = -round(MA.maptext_height/2) + 16
 			MA.maptext = STYLE_SMALLFONTS_OUTLINE("<center>[E.name]</center>", 7, COLOR_WHITE, COLOR_BLACK)
 
 	return MA

--- a/code/game/objects/items/blades/folding.dm
+++ b/code/game/objects/items/blades/folding.dm
@@ -22,16 +22,26 @@
 	update_force()
 
 /obj/item/bladed/folding/attack_self(mob/user)
-	open = !open
+	if(user.a_intent != I_HELP)
+		set_open(!open, user)
+		return TRUE
+	var/decl/interaction_handler/folding_knife/interaction = GET_DECL(/decl/interaction_handler/folding_knife)
+	if(!interaction.is_possible(src, user))
+		return FALSE
+	interaction.invoked(src, user)
+	return TRUE
+
+/obj/item/bladed/folding/proc/set_open(new_state, mob/user)
+	open = new_state
 	update_force()
 	update_icon()
-	if(open)
-		user.visible_message(SPAN_NOTICE("\The [user] opens \the [src]."))
-		playsound(user, 'sound/weapons/flipblade.ogg', 15, 1)
-	else
-		user.visible_message(SPAN_NOTICE("\The [user] closes \the [src]."))
-	add_fingerprint(user)
-	return TRUE
+	if(user)
+		if(open)
+			user.visible_message(SPAN_NOTICE("\The [user] opens \the [src]."))
+			playsound(user, 'sound/weapons/flipblade.ogg', 15, 1)
+		else
+			user.visible_message(SPAN_NOTICE("\The [user] closes \the [src]."))
+		add_fingerprint(user)
 
 /obj/item/bladed/folding/update_base_icon_state()
 	. = ..()
@@ -74,3 +84,73 @@
 			else
 				return TOOL_QUALITY_MEDIOCRE
 	return open ? ..() : 0
+
+//Interactions
+/obj/item/bladed/folding/get_alt_interactions(mob/user)
+	. = ..()
+	LAZYADD(., /decl/interaction_handler/folding_knife)
+
+/decl/interaction_handler/folding_knife
+	name = "Adjust Folding Knife"
+	expected_target_type = /obj/item/bladed/folding
+	interaction_flags = INTERACTION_NEEDS_INVENTORY | INTERACTION_NEEDS_PHYSICAL_INTERACTION
+
+/decl/interaction_handler/folding_knife/is_possible(atom/target, mob/user)
+	. = ..()
+	if(.)
+		var/datum/extension/tool/tool_extension = get_extension(target, /datum/extension/tool)
+		return istype(tool_extension, /datum/extension/tool/variable) && user.check_dexterity(DEXTERITY_COMPLEX_TOOLS)
+
+/decl/interaction_handler/folding_knife/proc/get_radial_choices(atom/target)
+	// - toggle open/closed
+	// - each tool
+	. = list()
+	var/obj/item/bladed/folding/folding_knife = target
+	// should always be in the inventory so we can assume get_world_inventory_state is inventory if it exists
+	var/open_close_state = "[folding_knife.get_world_inventory_state()]"
+	if(folding_knife.open)
+		open_close_state += "-closed"
+	var/image/open_close_image = new /image
+	open_close_image.name = folding_knife.open ? "Close blade" : "Open blade"
+	open_close_image.underlays = list(
+		overlay_image(folding_knife.icon, "[open_close_state]-hilt", folding_knife.hilt_material.color, RESET_COLOR),
+		overlay_image(folding_knife.icon, open_close_state, folding_knife.material.color, RESET_COLOR)
+	)
+	.["Toggle"] = open_close_image
+/* 	if(!folding_knife.open) // Can only switch mode with the knife open, because we assume all tool interactions use the blade currently
+		return . */
+	var/datum/extension/tool/variable/tool = get_extension(target, /datum/extension/tool)
+	for(var/tool_mode in tool.tool_values)
+		if(tool_mode == tool.current_tool)
+			continue
+		var/decl/tool_archetype/tool_archetype = GET_DECL(tool_mode)
+		// This blank image fuckery is done so that we can actually have a usable return value from show_radial_menu AND have a maptext label.
+		var/image/I = new /image
+		I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+		var/tool_name = tool_archetype.name
+		if(tool_archetype.article)
+			tool_name = "\a [tool_name]"
+		var/image/underlay = new /image
+		underlay.appearance = folding_knife
+		// reset a bunch of appearance vars we don't need
+		underlay.pixel_x = 0
+		underlay.pixel_y = 0
+		underlay.layer = FLOAT_LAYER
+		underlay.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+		I.underlays = list(underlay) // don't fuck with the base object's name or color please
+		I.name = "Use as [tool_name]"
+		.[tool_mode] = I
+
+/decl/interaction_handler/folding_knife/invoked(atom/target, mob/user)
+	var/obj/item/bladed/folding/folding_knife = target
+	var/chosen_option = show_radial_menu(user, user, get_radial_choices(folding_knife), radius = 42, use_labels = TRUE)
+	if(!chosen_option)
+		return
+	if(chosen_option == "Toggle")
+		folding_knife.set_open(!folding_knife.open, user)
+		return
+	var/datum/extension/tool/variable/tool = get_extension(folding_knife, /datum/extension/tool)
+	if(ispath(chosen_option, /decl/tool_archetype))
+		tool.switch_tool(chosen_option, user)
+		return
+	CRASH("Invalid option '[json_encode(chosen_option)]' selected in [folding_knife]'s [type]")

--- a/code/modules/tools/archetypes/tool_archetype.dm
+++ b/code/modules/tools/archetypes/tool_archetype.dm
@@ -1,4 +1,5 @@
 /decl/tool_archetype
+	abstract_type = /decl/tool_archetype
 	/// Noun for the tool.
 	var/name         = "tool"
 	/// Boolean value for prefixing 'a' or 'an' to the tool name.

--- a/code/modules/tools/archetypes/tool_extension_variable.dm
+++ b/code/modules/tools/archetypes/tool_extension_variable.dm
@@ -34,7 +34,12 @@
 	return (current_tool == archetype) ? ..() : INFINITY
 
 /datum/extension/tool/variable/handle_physical_manipulation(var/mob/user)
-	current_tool = next_in_list(current_tool, tool_values)
+	return switch_tool(next_in_list(current_tool, tool_values), user)
+
+/datum/extension/tool/variable/proc/switch_tool(new_tool, mob/user)
+	if(!(new_tool in tool_values))
+		CRASH("Invalid tool mode [new_tool] passed to [holder]'s [type]!")
+	current_tool = new_tool
 	var/config_sound = LAZYACCESS(tool_config_sounds, current_tool)
 	if(islist(config_sound) && length(config_sound))
 		config_sound = pick(config_sound)
@@ -48,6 +53,7 @@
 	to_chat(user, get_adjustment_message(tool_name))
 	var/atom/A = holder
 	A.update_icon()
+	return TRUE
 
 /datum/extension/tool/variable/proc/get_adjustment_message(tool_name)
 	return SPAN_NOTICE("You adjust \the [holder] to function as [tool_name].")


### PR DESCRIPTION
## Description of changes
Adds an alt interaction to folding blades that lets you open/close the blade, as well as switch tool modes. Replaces current open/close behavior in `attack_self()` when on help intent; when not on help intent you just open/close the blade, to hopefully prevent this from getting in the way of combat.

The code is a little weird, so feel free to ask questions and I'll answer and add additional comments to the code if needed.

Future work, not in this PR (because I can't sprite): Replace the knife icons for tool modes with per-tool-archetype radial menu icons. Would probably be useful elsewhere as well.

## Why and what will this PR improve
Currently there's no way to switch the tool mode with a folding blade. This fixes that.
Also fixes an issue in `code/_onclick/hud/radial.dm` where `maptext_y` was not set. If this PR is closed that needs to be salvaged as its own PR.

## Authorship
Me.

## Changelog
:cl:
add: Added the ability to switch tool mode with folding blades.
/:cl: