### PR TITLE
Adds config option to disable swapping pronouns with bodytype in chargen

### DIFF
--- a/code/datums/config/_config.dm
+++ b/code/datums/config/_config.dm
@@ -13,7 +13,7 @@
 
 	// Get our actual value (loading from text etc. may change data type)
 	var/decl/config/config_option = GET_DECL(config_decl)
-	if((config_option.config_flags & CONFIG_FLAG_NUM) && istext(new_value))
+	if((config_option.config_flags & (CONFIG_FLAG_NUM|CONFIG_FLAG_BOOL)) && istext(new_value))
 		new_value = text2num(new_value)
 	else if((config_option.config_flags & (CONFIG_FLAG_ENUM|CONFIG_FLAG_TEXT)) && isnum(new_value))
 		new_value = num2text(new_value)
@@ -79,6 +79,8 @@
 	else
 		if((config_flags & (CONFIG_FLAG_NUM|CONFIG_FLAG_ENUM)) && !isnum(default_value))
 			. += "has numeric or enum flag but not numeric default_value"
+		else if((config_flags & CONFIG_FLAG_BOOL) && default_value != TRUE && default_value != FALSE)
+			. += "has bool flag but not TRUE (1) or FALSE (0) default_value"
 		else if((config_flags & CONFIG_FLAG_TEXT) && !istext(default_value))
 			. += "has text flag but not text default_value"
 		else if((config_flags & CONFIG_FLAG_LIST) && !islist(default_value))

--- a/code/datums/config/config_types/config_game_world.dm
+++ b/code/datums/config/config_types/config_game_world.dm
@@ -21,7 +21,8 @@
 		/decl/config/toggle/allow_holidays,
 		/decl/config/toggle/humans_need_surnames,
 		/decl/config/toggle/roundstart_level_generation,
-		/decl/config/toggle/lights_start_on
+		/decl/config/toggle/lights_start_on,
+		/decl/config/toggle/on/cisnormativity
 	)
 
 /decl/config/num/exterior_ambient_light
@@ -130,3 +131,7 @@
 /decl/config/toggle/lights_start_on
 	uid = "lights_start_on"
 	desc = "If true, most lightswitches start on by default. Otherwise, they start off."
+
+/decl/config/toggle/on/cisnormativity
+	uid = "cisnormativity"
+	desc = "If true, when bodytype is changed in character creation, selected pronouns are also changed."

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -141,7 +141,7 @@
 		var/decl/bodytype/new_body = locate(href_list["bodytype"])
 		if(istype(new_body) && CanUseTopic(user) && (new_body in S.available_bodytypes))
 			pref.set_bodytype(new_body.name)
-			if(new_body.associated_gender) // Set to default for male/female to avoid confusing people
+			if(get_config_value(/decl/config/toggle/on/cisnormativity) && new_body.associated_gender) // Let servers stuck in the 2010s set bodytype default to avoid "confusing" people
 				pref.gender = new_body.associated_gender
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 

--- a/code/modules/species/species_bodytype_helpers.dm
+++ b/code/modules/species/species_bodytype_helpers.dm
@@ -34,7 +34,19 @@
 	if(!pref)
 		return
 	// Markings used to be cleared outside of here, but it was always done before every call, so it was moved in here.
-	pref.sprite_accessories = list()
+	// remove invalid accessories for our new bodytype. don't clear the list directly as we did before, to preserve in the case of no default
+	var/decl/species/mob_species = get_species_by_key(pref.species)
+	var/decl/bodytype/mob_bodytype = mob_species.get_bodytype_by_name(pref.bodytype) || mob_species.default_bodytype
+	for(var/acc_cat in pref.sprite_accessories)
+		if(!(acc_cat in mob_species.available_accessory_categories))
+			pref.sprite_accessories -= acc_cat
+			continue
+		var/decl/sprite_accessory_category/accessory_category = GET_DECL(acc_cat)
+		for(var/acc in pref.sprite_accessories[acc_cat])
+			var/decl/sprite_accessory/accessory = GET_DECL(acc)
+			if(!istype(accessory, accessory_category.base_accessory_type) || !accessory.accessory_is_available(get_mannequin(pref.client?.ckey), mob_species, mob_bodytype))
+				pref.sprite_accessories[acc_cat] -= acc
+	// apply the defaults
 	for(var/accessory_category in default_sprite_accessories)
 		pref.sprite_accessories[accessory_category] = list()
 		for(var/accessory in default_sprite_accessories[accessory_category])

--- a/code/modules/sprite_accessories/_accessory_category.dm
+++ b/code/modules/sprite_accessories/_accessory_category.dm
@@ -15,7 +15,7 @@
 	var/single_selection        = TRUE
 	/// Set to TRUE to apply these markings as defaults when bodytype is set.
 	var/always_apply_defaults   = FALSE
-	/// Whether the default accessories in this category are cleared when prefs are applied.
+	/// Whether the accessories in this category are cleared when prefs are applied.
 	var/clear_in_pref_apply     = FALSE
 
 /decl/sprite_accessory_category/validate()


### PR DESCRIPTION
## Description of changes
Adds a `CISNORMATIVITY` config option to disable setting bodytype in chargen changing the character's pronouns. Sorry if the comment's a bit too pass-agg, happy to change it if needed.

Also fixes hair being reset even if the bodytype has no default accessories when changing bodytype in prefs. Now, we do a more intelligent reset taken from sanitize_character code, to remove accessories that aren't valid on the new bodytype. Default accessories are applied as before.

## Why and what will this PR improve
Allows me to disable this feature on a per-server basis, because I really don't like it and don't view avoiding "confusion" as a good justification for it.

## Authorship
Me.

## Changelog
:cl:
config: added a config option to disable pronouns switching on bodytype selection in character setup
/:cl: