### PR TITLE
Grabs a bunch of small tweaks from Crux.

### DIFF
--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -227,7 +227,7 @@
 	if(random_record)
 		COPY_VALUE(faction)
 		COPY_VALUE(religion)
-		COPY_VALUE(homeSystem)
+		COPY_VALUE(residence)
 		COPY_VALUE(fingerprint)
 		COPY_VALUE(dna)
 		COPY_VALUE(bloodtype)

--- a/code/game/objects/structures/tables.dm
+++ b/code/game/objects/structures/tables.dm
@@ -279,7 +279,10 @@
 /obj/structure/table/update_material_desc(override_desc)
 	desc = initial(desc)
 	if(reinf_material)
-		desc = "[desc] This one has a frame made from [material.solid_name] and \a [top_surface_noun] made from [reinf_material.solid_name]."
+		if(reinf_material == material)
+			desc = "[desc] This one has a frame and \a [top_surface_noun] made from [material.solid_name]."
+		else
+			desc = "[desc] This one has a frame made from [material.solid_name] and \a [top_surface_noun] made from [reinf_material.solid_name]."
 	else if(material)
 		desc = "[desc] This one has a frame made from [material.solid_name]."
 	if(felted)

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -39,7 +39,7 @@
 /turf/proc/set_flooded(new_flooded, force = FALSE, skip_vis_contents_update = FALSE, mapload = FALSE)
 
 	// Don't do unnecessary work.
-	if(!force && new_flooded == flooded)
+	if(!simulated || (!force && new_flooded == flooded))
 		return
 
 	// Remove our old overlay if necessary.

--- a/code/game/turfs/unsimulated/floor.dm
+++ b/code/game/turfs/unsimulated/floor.dm
@@ -18,6 +18,10 @@
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "rockvault"
 
+/turf/unsimulated/mask/flooded
+	flooded = /decl/material/liquid/water
+	color = COLOR_LIQUID_WATER
+
 /turf/unsimulated/floor/rescue_base
 	icon_state = "asteroidfloor"
 

--- a/code/game/turfs/walls/wall_natural.dm
+++ b/code/game/turfs/walls/wall_natural.dm
@@ -11,6 +11,10 @@
 	var/static/list/exterior_wall_shine_cache = list()
 	var/being_mined = FALSE
 
+/turf/wall/natural/flooded
+	flooded = /decl/material/liquid/water
+	color = COLOR_LIQUID_WATER
+
 /turf/wall/natural/get_paint_examine_message()
 	return SPAN_NOTICE("It has been <font color = '[paint_color]'>noticeably discoloured</font> by the elements.")
 

--- a/code/modules/culture_descriptor/location/_location.dm
+++ b/code/modules/culture_descriptor/location/_location.dm
@@ -1,6 +1,6 @@
 /decl/cultural_info/location
 	abstract_type = /decl/cultural_info/location
-	desc_type = "Home System"
+	desc_type = "Residence"
 	category = TAG_HOMEWORLD
 	var/distance_heading = "Distance from Sol"
 	var/distance = 0

--- a/code/modules/emotes/emote_define.dm
+++ b/code/modules/emotes/emote_define.dm
@@ -34,6 +34,7 @@ var/global/list/_emotes_by_key
 	return global._emotes_by_key[key]
 
 /decl/emote
+	abstract_type = /decl/emote
 	/// Command to use emote ie. '*[key]'
 	var/key
 	/// First person message ('You do a flip!')

--- a/code/modules/materials/material_sheets_mapping.dm
+++ b/code/modules/materials/material_sheets_mapping.dm
@@ -79,7 +79,7 @@ STACK_SUBTYPES(yew,            "yew",                           solid/organic/wo
 STACK_SUBTYPES(cardboard,      "cardboard",                     solid/organic/cardboard,     cardstock,        null)
 STACK_SUBTYPES(leather,        "leather",                       solid/organic/leather,       skin,             null)
 STACK_SUBTYPES(synthleather,   "synthleather",                  solid/organic/leather/synth, skin,             null)
-STACK_SUBTYPES(bone,           "bone",                          solid/organic/bone,          bone,            null)
+STACK_SUBTYPES(bone,           "bone",                          solid/organic/bone,          bone,             null)
 STACK_SUBTYPES(glass,          "glass",                         solid/glass,                 pane,             null)
 STACK_SUBTYPES(borosilicate,   "borosilicate glass",            solid/glass/borosilicate,    pane,             null)
 STACK_SUBTYPES(aliumium,       "aliumium",                      solid/metal/aliumium,        cubes,            null)

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -110,9 +110,9 @@ var/global/arrest_security_status =  "Arrest"
 	set_employment_record(employment_record)
 
 	// Misc cultural info.
-	set_homeSystem(H ? html_decode(H.get_cultural_value(TAG_HOMEWORLD)) : "Unset")
-	set_faction(H ?    html_decode(H.get_cultural_value(TAG_FACTION)) :   "Unset")
-	set_religion(H ?   html_decode(H.get_cultural_value(TAG_RELIGION)) :  "Unset")
+	set_residence(H ? html_decode(H.get_cultural_value(TAG_HOMEWORLD)) : "Unset")
+	set_faction(H ?   html_decode(H.get_cultural_value(TAG_FACTION)) :   "Unset")
+	set_religion(H ?  html_decode(H.get_cultural_value(TAG_RELIGION)) :  "Unset")
 
 	if(H)
 		var/skills = list()
@@ -255,8 +255,8 @@ FIELD_SHORT("Fingerprint", fingerprint, access_security, access_security, TRUE, 
 
 // EMPLOYMENT RECORDS
 FIELD_LONG("Employment Record", employment_record, access_bridge, access_bridge, TRUE)
-FIELD_SHORT("Home System", homeSystem, access_bridge, access_change_ids, FALSE, TRUE)
-FIELD_SHORT("Faction", faction, access_bridge, access_bridge, FALSE, TRUE)
+FIELD_SHORT("Residence", residence, access_bridge, access_change_ids, FALSE, TRUE)
+FIELD_SHORT("Association", faction, access_bridge, access_bridge, FALSE, TRUE)
 FIELD_LONG("Qualifications", skillset, access_bridge, access_bridge, TRUE)
 
 // ANTAG RECORDS

--- a/code/modules/modular_computers/networking/machinery/wall_relay.dm
+++ b/code/modules/modular_computers/networking/machinery/wall_relay.dm
@@ -12,3 +12,19 @@
 /obj/machinery/network/relay/wall_mounted/Initialize()
 	. = ..()
 	queue_icon_update()
+
+/obj/machinery/network/relay/wall_mounted/south
+	dir = NORTH
+	pixel_y = -21
+
+/obj/machinery/network/relay/wall_mounted/north
+	dir = SOUTH
+	pixel_y = 21
+
+/obj/machinery/network/relay/wall_mounted/west
+	dir = EAST
+	pixel_x = -21
+
+/obj/machinery/network/relay/wall_mounted/east
+	dir = WEST
+	pixel_x = 21

--- a/code/modules/turbolift/turbolift_areas.dm
+++ b/code/modules/turbolift/turbolift_areas.dm
@@ -1,8 +1,8 @@
 // Used for creating the exchange areas.
 /area/turbolift
-	name = "Turbolift"
+	name = "\improper Turbolift"
 	base_turf = /turf/open
-	requires_power = 0
+	requires_power = FALSE
 	sound_env = SMALL_ENCLOSED
 	holomap_color = HOLOMAP_AREACOLOR_LIFTS
 

--- a/mods/content/pheromones/pheromone_emotes.dm
+++ b/mods/content/pheromones/pheromone_emotes.dm
@@ -13,6 +13,12 @@
 	self_smell_descriptor = "distressing"
 	scent_color = COLOR_RED
 
+/decl/emote/pheromone/pain
+	key = "scentpain"
+	smell_message = "<span class='danger'>PAIN</span>"
+	self_smell_descriptor = "distressing"
+	scent_color = COLOR_RED
+
 /decl/emote/pheromone/calm
 	key = "scentcalm"
 	smell_message = "<span class='notice'><b>calm</b></span>"


### PR DESCRIPTION
- Neatens table material desc.
- Adds a simulated check to set_flooded().
- Adds flood subtypes for `/turf/unsimulated/mask` and `/turf/wall/natural`.
- Renamed `home system` to `residence` and faction to `association`.
- Adds a pain pheremone emote.
- Adds mappable directional subtypes for wall-mounted relays.