### PR TITLE
Fixes/tweaks to interacting with fluids.

### DIFF
--- a/code/datums/extensions/storage/_storage.dm
+++ b/code/datums/extensions/storage/_storage.dm
@@ -201,6 +201,12 @@ var/global/list/_test_storage_items = list()
 		var/mob/M = W.loc
 		if(!M.try_unequip(W))
 			return
+
+	if(holder.reagents?.total_volume)
+		W.fluid_act(holder.reagents)
+		if(QDELETED(W))
+			return
+
 	W.forceMove(holder)
 	W.on_enter_storage(src)
 	if(user)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -132,6 +132,9 @@
 /// Handle reagents being modified
 /atom/proc/on_reagent_change()
 	SHOULD_CALL_PARENT(TRUE)
+	if(storage && reagents?.total_volume)
+		for(var/obj/item/thing in get_stored_inventory())
+			thing.fluid_act(reagents)
 
 /**
 	Handle an atom bumping this atom

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -59,8 +59,8 @@
 	. = ..()
 
 /obj/machinery/biogenerator/on_reagent_change()			//When the reagents change, change the icon as well.
-	..()
-	update_icon()
+	if((. = ..()))
+		update_icon()
 
 /obj/machinery/biogenerator/on_update_icon()
 	if(state == BG_NO_BEAKER)

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -342,8 +342,7 @@
 	SSnano.update_uis(src)
 
 /obj/machinery/microwave/on_reagent_change()
-	..()
-	if(!operating)
+	if((. = ..()) && !operating)
 		SSnano.update_uis(src)
 
 /obj/machinery/microwave/proc/dispose(var/mob/user, var/message = TRUE)

--- a/code/game/objects/effects/chem/water.dm
+++ b/code/game/objects/effects/chem/water.dm
@@ -10,8 +10,8 @@
 	QDEL_IN(src, 15 SECONDS) // In case whatever made it forgets to delete it
 
 /obj/effect/effect/water/on_reagent_change()
-	..()
-	set_color(reagents?.get_color())
+	if((. = ..()))
+		set_color(reagents?.get_color())
 
 /obj/effect/effect/water/proc/set_up(var/turf/target, var/step_count = 5, var/delay = 5)
 	if(!target)

--- a/code/game/objects/items/devices/scanners/mass_spectrometer.dm
+++ b/code/game/objects/items/devices/scanners/mass_spectrometer.dm
@@ -14,8 +14,8 @@
 	create_reagents(5)
 
 /obj/item/scanner/spectrometer/on_reagent_change()
-	..()
-	update_icon()
+	if((. = ..()))
+		update_icon()
 
 /obj/item/scanner/spectrometer/on_update_icon()
 	. = ..()

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -64,7 +64,8 @@
 		to_chat(user, "It's [reagents?.total_volume > 0? "filled with liquid sloshing around" : "empty"].")
 
 /obj/item/chems/water_balloon/on_reagent_change()
-	..()
+	if(!(. = ..()))
+		return
 	w_class = (reagents?.total_volume > 0)? ITEM_SIZE_SMALL : ITEM_SIZE_TINY
 	//#TODO: Maybe acids should handle eating their own containers themselves?
 	for(var/reagent in reagents?.reagent_volumes)

--- a/code/game/objects/items/weapons/towels.dm
+++ b/code/game/objects/items/weapons/towels.dm
@@ -32,7 +32,8 @@
 	. = ..()
 
 /obj/item/towel/on_reagent_change()
-	. = ..()
+	if(!(. = ..()))
+		return
 	if(reagents?.total_volume)
 		SetName("damp [initial(name)]")
 		if(!is_processing)

--- a/code/game/objects/structures/barrel.dm
+++ b/code/game/objects/structures/barrel.dm
@@ -19,6 +19,13 @@
 	..()
 	return INITIALIZE_HINT_LATELOAD
 
+/obj/structure/reagent_dispensers/barrel/attackby(obj/item/W, mob/user)
+	. = ..()
+	if(!. && user.a_intent == I_HELP && reagents?.total_volume > FLUID_PUDDLE)
+		user.visible_message(SPAN_NOTICE("\The [user] dips \the [W] into \the [reagents.get_primary_reagent_name()]."))
+		W.fluid_act(reagents)
+		return TRUE
+
 /obj/structure/reagent_dispensers/barrel/LateInitialize(mapload, ...)
 	..()
 	if(mapload)

--- a/code/game/objects/structures/barrel.dm
+++ b/code/game/objects/structures/barrel.dm
@@ -36,7 +36,8 @@
 				storage.handle_item_insertion(null, thing)
 
 /obj/structure/reagent_dispensers/barrel/on_reagent_change()
-	. = ..()
+	if(!(. = ..()))
+		return
 	var/primary_mat = reagents?.get_primary_reagent_name()
 	if(primary_mat)
 		SetName("[material.solid_name] [initial(name)] of [primary_mat]")

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -314,7 +314,8 @@
 	return (fuel > 0)
 
 /obj/structure/fire_source/on_reagent_change()
-	..()
+	if(!(. = ..()))
+		return
 	if(reagents?.total_volume)
 		var/do_steam = FALSE
 		var/list/waste = list()

--- a/code/game/objects/structures/well.dm
+++ b/code/game/objects/structures/well.dm
@@ -21,7 +21,8 @@
 		add_overlay(overlay_image(icon, "[icon_state]-fluid", reagents.get_color(), (RESET_COLOR | RESET_ALPHA)))
 
 /obj/structure/reagent_dispensers/well/on_reagent_change()
-	. = ..()
+	if(!(. = ..()))
+		return
 	update_icon()
 	if(!is_processing)
 		START_PROCESSING(SSobj, src)

--- a/code/game/objects/structures/well.dm
+++ b/code/game/objects/structures/well.dm
@@ -26,6 +26,13 @@
 	if(!is_processing)
 		START_PROCESSING(SSobj, src)
 
+/obj/structure/reagent_dispensers/well/attackby(obj/item/W, mob/user)
+	. = ..()
+	if(!. && user.a_intent == I_HELP && reagents?.total_volume > FLUID_PUDDLE)
+		user.visible_message(SPAN_NOTICE("\The [user] dips \the [W] into \the [reagents.get_primary_reagent_name()]."))
+		W.fluid_act(reagents)
+		return TRUE
+
 /obj/structure/reagent_dispensers/well/mapped/populate_reagents()
 	. = ..()
 	add_to_reagents(/decl/material/liquid/water, reagents.maximum_volume)

--- a/code/game/turfs/floors/floor_attackby.dm
+++ b/code/game/turfs/floors/floor_attackby.dm
@@ -93,6 +93,7 @@
 					new /obj/structure/catwalk(src, R.material.type)
 					return TRUE
 				return
+
 			var/obj/item/stack/S = C
 			var/decl/flooring/use_flooring
 			var/list/decls = decls_repository.get_decls_of_subtype(/decl/flooring)
@@ -103,21 +104,22 @@
 				if((ispath(S.type, F.build_type) || ispath(S.build_type, F.build_type)) && (isnull(F.build_material) || S.material?.type == F.build_material))
 					use_flooring = F
 					break
-			if(!use_flooring)
-				return
-			// Do we have enough?
-			if(use_flooring.build_cost && S.get_amount() < use_flooring.build_cost)
-				to_chat(user, "<span class='warning'>You require at least [use_flooring.build_cost] [S.name] to complete the [use_flooring.descriptor].</span>")
-				return TRUE
-			// Stay still and focus...
-			if(use_flooring.build_time && !do_after(user, use_flooring.build_time, src))
-				return TRUE
-			if(flooring || !S || !user || !use_flooring)
-				return TRUE
-			if(S.use(use_flooring.build_cost))
-				set_flooring(use_flooring)
-				playsound(src, 'sound/items/Deconstruct.ogg', 80, 1)
-			return TRUE
+
+			if(use_flooring)
+				// Do we have enough?
+				if(use_flooring.build_cost && S.get_amount() < use_flooring.build_cost)
+					to_chat(user, "<span class='warning'>You require at least [use_flooring.build_cost] [S.name] to complete the [use_flooring.descriptor].</span>")
+					return TRUE
+				// Stay still and focus...
+				if(use_flooring.build_time && !do_after(user, use_flooring.build_time, src))
+					return TRUE
+				if(flooring || !S || !user || !use_flooring)
+					return TRUE
+				if(S.use(use_flooring.build_cost))
+					set_flooring(use_flooring)
+					playsound(src, 'sound/items/Deconstruct.ogg', 80, 1)
+					return TRUE
+
 		// Repairs and Deconstruction.
 		else if(IS_CROWBAR(C))
 			if(is_floor_damaged())

--- a/code/game/turfs/floors/natural/_natural.dm
+++ b/code/game/turfs/floors/natural/_natural.dm
@@ -113,7 +113,10 @@
 	return ..()
 
 /turf/floor/natural/on_reagent_change()
-	. = ..()
+
+	if(!(. = ..()))
+		return
+
 	if(!QDELETED(src) && reagent_type && height < 0 && !QDELETED(reagents) && reagents.total_volume < abs(height))
 		add_to_reagents(reagent_type, abs(height) - reagents.total_volume)
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -265,15 +265,6 @@
 		if(W?.storage?.collection_mode && W.storage.gather_all(src, user))
 			return TRUE
 
-	// Must be open, but food items should not be filled from sources like this. They're open in order to add condiments, not to be poured into/out of.
-	// TODO: Rewrite open-container-ness or food to make this unnecessary!
-	if(ATOM_IS_OPEN_CONTAINER(W) && !istype(W, /obj/item/chems/food) && W.reagents && reagents?.total_volume >= FLUID_PUDDLE)
-		var/taking = min(reagents.total_volume, REAGENTS_FREE_SPACE(W.reagents))
-		if(taking > 0)
-			to_chat(user, SPAN_NOTICE("You fill \the [W] with [reagents.get_primary_reagent_name()] from \the [src]."))
-			reagents.trans_to(W, taking)
-			return TRUE
-
 	if(istype(W, /obj/item) && storage && storage.use_to_pickup && storage.collection_mode)
 		storage.gather_all(src, user)
 		return TRUE
@@ -288,6 +279,21 @@
 
 	if(IS_COIL(W) && try_build_cable(W, user))
 		return TRUE
+
+	if(reagents?.total_volume >= FLUID_PUDDLE)
+		// Must be open, but food items should not be filled from sources like this. They're open in order to add condiments, not to be poured into/out of.
+		// TODO: Rewrite open-container-ness or food to make this unnecessary!
+		if(ATOM_IS_OPEN_CONTAINER(W) && !istype(W, /obj/item/chems/food) && W.reagents)
+			var/taking = min(reagents.total_volume, REAGENTS_FREE_SPACE(W.reagents))
+			if(taking > 0)
+				to_chat(user, SPAN_NOTICE("You fill \the [W] with [reagents.get_primary_reagent_name()] from \the [src]."))
+				reagents.trans_to(W, taking)
+				return TRUE
+
+		if(user.a_intent == I_HELP)
+			user.visible_message(SPAN_NOTICE("\The [user] dips \the [W] into \the [reagents.get_primary_reagent_name()]."))
+			W.fluid_act(reagents)
+			return TRUE
 
 	return ..()
 

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -163,7 +163,8 @@
 
 /turf/on_reagent_change()
 
-	..()
+	if(!(. = ..()))
+		return
 
 	if(reagents?.total_volume > FLUID_QDEL_POINT)
 		ADD_ACTIVE_FLUID(src)

--- a/code/modules/crafting/metalwork/metalwork_items.dm
+++ b/code/modules/crafting/metalwork/metalwork_items.dm
@@ -55,8 +55,8 @@
 	return ..()
 
 /obj/item/chems/crucible/on_reagent_change()
-	. = ..()
-	queue_icon_update()
+	if((. = ..()))
+		queue_icon_update()
 
 /obj/item/chems/crucible/on_update_icon()
 	. = ..()

--- a/code/modules/crafting/pottery/pottery_items.dm
+++ b/code/modules/crafting/pottery/pottery_items.dm
@@ -65,8 +65,8 @@
 	volume = 60
 
 /obj/item/chems/glass/pottery/bowl/on_reagent_change()
-	. = ..()
-	update_icon()
+	if((. = ..()))
+		update_icon()
 
 /obj/item/chems/glass/pottery/bowl/on_update_icon()
 	. = ..()

--- a/code/modules/food/cooking/cooking_vessels/_cooking_vessel.dm
+++ b/code/modules/food/cooking/cooking_vessels/_cooking_vessel.dm
@@ -89,7 +89,8 @@
 	update_icon()
 
 /obj/item/chems/cooking_vessel/on_reagent_change()
-	. = ..()
+	if(!(. = ..()))
+		return
 	started_cooking = null
 	if(!is_processing)
 		START_PROCESSING(SSobj, src)

--- a/code/modules/integrated_electronics/passive/power.dm
+++ b/code/modules/integrated_electronics/passive/power.dm
@@ -120,7 +120,8 @@
 	..()
 
 /obj/item/integrated_circuit/passive/power/chemical_cell/on_reagent_change(changetype)
-	..()
+	if(!(. = ..()))
+		return
 	set_pin_data(IC_OUTPUT, 1, reagents?.total_volume || 0)
 	push_data()
 

--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -50,8 +50,8 @@
 	var/notified = FALSE
 
 /obj/item/integrated_circuit/reagent/on_reagent_change()
-	..()
-	push_vol()
+	if((. = ..()))
+		push_vol()
 
 /obj/item/integrated_circuit/reagent/smoke/do_work(ord)
 	switch(ord)

--- a/code/modules/mining/machinery/material_extractor.dm
+++ b/code/modules/mining/machinery/material_extractor.dm
@@ -94,9 +94,8 @@
 				break
 
 /obj/machinery/material_processing/extractor/on_reagent_change()
-	..()
 
-	if(!reagents)
+	if(!(. = ..()) || !reagents)
 		return
 
 	var/adjusted_reagents = FALSE

--- a/code/modules/mining/machinery/material_smelter.dm
+++ b/code/modules/mining/machinery/material_smelter.dm
@@ -26,9 +26,8 @@
 
 // Outgas anything that is in gas form. Check what you put into the smeltery, nerds.
 /obj/machinery/material_processing/smeltery/on_reagent_change()
-	..()
 
-	if(!reagents)
+	if(!(. = ..()) || !reagents)
 		return
 
 	var/datum/gas_mixture/environment = loc?.return_air()

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -79,7 +79,7 @@ var/global/obj/temp_reagents_holder = new
 		if(my_atom.reagents == src)
 			my_atom.reagents = null
 			if(total_volume > 0) // we can assume 0 reagents and null reagents are broadly identical for the purposes of atom logic
-				my_atom.on_reagent_change()
+				my_atom.try_on_reagent_change()
 		my_atom = null
 
 /datum/reagents/GetCloneArgs()
@@ -235,16 +235,14 @@ var/global/obj/temp_reagents_holder = new
 	update_total()
 	if(!safety)
 		HANDLE_REACTIONS(src)
-	if(my_atom)
-		my_atom.on_reagent_change()
+	my_atom?.try_on_reagent_change()
 
 ///Set and call updates on the target holder.
 /datum/reagents/proc/set_holder(var/obj/new_holder)
 	if(my_atom == new_holder)
 		return
 	my_atom = new_holder
-	if(my_atom)
-		my_atom.on_reagent_change()
+	my_atom?.try_on_reagent_change()
 	handle_update()
 
 /datum/reagents/proc/add_reagent(var/reagent_type, var/amount, var/data = null, var/safety = 0, var/defer_update = FALSE)
@@ -333,7 +331,7 @@ var/global/obj/temp_reagents_holder = new
 	LAZYCLEARLIST(reagent_volumes)
 	LAZYCLEARLIST(reagent_data)
 	total_volume = 0
-	my_atom?.on_reagent_change()
+	my_atom?.try_on_reagent_change()
 
 /datum/reagents/proc/get_overdose(var/decl/material/current)
 	if(current)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -79,10 +79,10 @@
 	desc = new_desc_list.Join("\n")
 
 /obj/item/chems/on_reagent_change()
-	..()
-	update_container_name()
-	update_container_desc()
-	update_icon()
+	if((. = ..()))
+		update_container_name()
+		update_container_desc()
+		update_icon()
 
 /obj/item/chems/verb/set_amount_per_transfer_from_this()
 	set name = "Set Transfer Amount"

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -25,7 +25,8 @@
 	. = ..()
 
 /obj/item/chems/ivbag/on_reagent_change()
-	..()
+	if(!(. = ..()))
+		return
 	if(reagents?.total_volume > volume/2)
 		w_class = ITEM_SIZE_SMALL
 	else

--- a/code/modules/reagents/reagent_containers/condiment.dm
+++ b/code/modules/reagents/reagent_containers/condiment.dm
@@ -42,11 +42,12 @@
 			if(length(tmp_label))
 				to_chat(user, SPAN_NOTICE("You set the label to \"[tmp_label]\"."))
 				label_text = tmp_label
-				name = addtext(name," ([label_text])")
 			else
 				to_chat(user, SPAN_NOTICE("You remove the label."))
 				label_text = null
-				on_reagent_change()
+			update_container_name()
+			update_container_desc()
+			update_icon()
 		return
 
 /obj/item/chems/condiment/afterattack(var/obj/target, var/mob/user, var/proximity)
@@ -77,8 +78,8 @@
 
 /obj/item/chems/condiment/on_reagent_change()
 	is_special_bottle = reagents?.total_volume && special_bottles[reagents?.primary_reagent]
-	..()
-	update_center_of_mass()
+	if((. = ..()))
+		update_center_of_mass()
 
 /obj/item/chems/condiment/update_container_name()
 	name = is_special_bottle ? initial(is_special_bottle.name) : initial(name)

--- a/code/modules/reagents/reagent_containers/food/meat/cubes.dm
+++ b/code/modules/reagents/reagent_containers/food/meat/cubes.dm
@@ -54,8 +54,7 @@
 		Expand(get_turf(target))
 
 /obj/item/chems/food/monkeycube/on_reagent_change()
-	..()
-	if(!QDELETED(src) && reagents?.has_reagent(/decl/material/liquid/water))
+	if((. = ..()) && !QDELETED(src) && reagents?.has_reagent(/decl/material/liquid/water))
 		Expand()
 
 /obj/item/chems/food/monkeycube/wrapped

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -39,8 +39,8 @@
 
 
 /obj/item/chems/syringe/on_reagent_change()
-	. = ..()
-	update_icon()
+	if((. = ..()))
+		update_icon()
 
 /obj/item/chems/syringe/on_picked_up(mob/user)
 	. = ..()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -34,7 +34,8 @@
 		atom_flags = old_atom_flags
 
 /obj/structure/reagent_dispensers/on_reagent_change()
-	..()
+	if(!(. = ..()))
+		return
 	if(reagents?.total_volume > 0)
 		tool_interaction_flags = 0
 	else

--- a/mods/content/xenobiology/slime/items.dm
+++ b/mods/content/xenobiology/slime/items.dm
@@ -50,8 +50,7 @@
 	add_to_reagents(/decl/material/liquid/slimejelly, 30)
 
 /obj/item/slime_extract/on_reagent_change()
-	..()
-	if(reagents?.total_volume)
+	if((. = ..()) && reagents?.total_volume)
 		var/decl/slime_colour/slime_data = GET_DECL(slime_type)
 		slime_data.handle_reaction(reagents)
 


### PR DESCRIPTION
## Description of changes
- Turfs, wells and barrels can have items dipped into them.
- Atoms with storage and reagents will expose the stored items to the reagents (barrel of water, for example).
- `on_reagent_change()` should no longer be able to recurse due to updating `src` reagents itself.

## Why and what will this PR improve
Mostly to support using various water sources for tanning skin.

## Authorship
Myself and Penny.

## Changelog
:cl:
tweak: You can now dip things like stacks of skin into barrels of water, wells or rivers.
/:cl:
