### PR TITLE
Remove unnecessary uses of unsafe var access operator

### DIFF
--- a/code/_global_vars/lists/objects.dm
+++ b/code/_global_vars/lists/objects.dm
@@ -5,7 +5,6 @@ var/global/list/hud_icon_reference = list()
 var/global/list/listening_objects = list() // List of objects that need to be able to hear, used to avoid recursive searching through contents.
 var/global/list/global_map = list()
 
-var/global/host = null //only here until check @ code\modules\ghosttrap\trap.dm:112 is fixed
 var/global/datum/universal_state/universe = new
 
 /// Vowels.

--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -302,8 +302,8 @@
 
 				var/mob/def_target = null
 				var/objective_list[] = list(/datum/objective/assassinate, /datum/objective/protect, /datum/objective/debrain)
-				if (objective&&(objective.type in objective_list) && objective:target)
-					def_target = objective.target?.current
+				if (objective?.target && (objective.type in objective_list))
+					def_target = objective.target.current
 
 				var/new_target = input("Select target:", "Objective target", def_target) as null|anything in possible_targets
 				if (!new_target) return
@@ -313,12 +313,12 @@
 				if (!istype(M) || !M.mind || new_target == "Free objective")
 					new_objective = new objective_path
 					new_objective.owner = src
-					new_objective:target = null
+					new_objective.target = null
 					new_objective.explanation_text = "Free objective"
 				else
 					new_objective = new objective_path
 					new_objective.owner = src
-					new_objective:target = M.mind
+					new_objective.target = M.mind
 					new_objective.explanation_text = "[objective_type] [M.real_name], the [M.mind.get_special_role_name(M.mind.assigned_role)]."
 
 			if ("hijack")

--- a/code/game/machinery/computer/shuttle.dm
+++ b/code/game/machinery/computer/shuttle.dm
@@ -9,44 +9,46 @@
 	var/list/authorized = list(  )
 
 
-/obj/machinery/computer/shuttle/attackby(var/obj/item/card/W as obj, var/mob/user as mob)
+/obj/machinery/computer/shuttle/attackby(var/obj/item/card as obj, var/mob/user as mob)
 	if(stat & (BROKEN|NOPOWER))	return
 
 	var/datum/evacuation_controller/shuttle/evac_control = SSevac.evacuation_controller
 	if(!istype(evac_control))
-		to_chat(user, "<span class='danger'>This console should not in use on this map. Please report this to a developer.</span>")
+		to_chat(user, "<span class='danger'>This console should not be in use on this map. Please report this to a developer.</span>")
 		return
 
-	if ((!( istype(W, /obj/item/card) ) || evac_control.has_evacuated() || !( user )))
+	if(!istype(card, /obj/item/card)) // don't try to get an ID card if we're an emag
+		card = card.GetIdCard() // handles stored IDs in  modcomps and similar
+
+	if ((!istype(card, /obj/item/card) || evac_control.has_evacuated() || !user))
 		return
 
-	if (istype(W, /obj/item/card/id)||istype(W, /obj/item/modular_computer))
-		if (istype(W, /obj/item/modular_computer))
-			W = W.GetIdCard()
-		if (!W:access) //no access
-			to_chat(user, "The access level of [W:registered_name]\'s card is not high enough.")
+	if (istype(card, /obj/item/card/id))
+		var/obj/item/card/id/id_card = card
+		if (!id_card.access) //no access
+			to_chat(user, "The access level of [id_card.registered_name]\'s card is not high enough.")
 			return
 
-		var/list/cardaccess = W:access
+		var/list/cardaccess = id_card.access
 		if(!istype(cardaccess, /list) || !cardaccess.len) //no access
-			to_chat(user, "The access level of [W:registered_name]\'s card is not high enough.")
+			to_chat(user, "The access level of [id_card.registered_name]\'s card is not high enough.")
 			return
 
-		if(!(access_bridge in W:access)) //doesn't have this access
-			to_chat(user, "The access level of [W:registered_name]\'s card is not high enough.")
+		if(!(access_bridge in id_card.access)) //doesn't have this access
+			to_chat(user, "The access level of [id_card.registered_name]\'s card is not high enough.")
 			return 0
 
-		var/choice = alert(user, text("Would you like to (un)authorize a shortened launch time? [] authorization\s are still needed. Use abort to cancel all authorizations.", src.auth_need - src.authorized.len), "Shuttle Launch", "Authorize", "Repeal", "Abort")
-		if(evac_control.is_prepared() && user.get_active_held_item() != W)
+		var/choice = alert(user, "Would you like to (un)authorize a shortened launch time? [auth_need - authorized.len] authorization\s are still needed. Use abort to cancel all authorizations.", "Shuttle Launch", "Authorize", "Repeal", "Abort")
+		if(evac_control.is_prepared() && user.get_active_held_item() != card)
 			return 0
 		switch(choice)
 			if("Authorize")
-				src.authorized -= W:registered_name
-				src.authorized += W:registered_name
+				src.authorized -= id_card.registered_name
+				src.authorized += id_card.registered_name
 				if (src.auth_need - src.authorized.len > 0)
 					message_admins("[key_name_admin(user)] has authorized early shuttle launch")
 					log_game("[user.ckey] has authorized early shuttle launch")
-					to_world(text("<span class='notice'><b>Alert: [] authorizations needed until shuttle is launched early</b></span>", src.auth_need - src.authorized.len))
+					to_world("<span class='notice'><b>Alert: [auth_need - authorized.len] authorizations needed until shuttle is launched early</b></span>")
 				else
 					message_admins("[key_name_admin(user)] has launched the shuttle")
 					log_game("[user.ckey] has launched the shuttle early")
@@ -57,18 +59,18 @@
 					src.authorized = list(  )
 
 			if("Repeal")
-				src.authorized -= W:registered_name
-				to_world(text("<span class='notice'><b>Alert: [] authorizations needed until shuttle is launched early</b></span>", src.auth_need - src.authorized.len))
+				src.authorized -= id_card.registered_name
+				to_world("<span class='notice'><b>Alert: [auth_need - authorized.len] authorizations needed until shuttle is launched early</b></span>")
 
 			if("Abort")
 				to_world("<span class='notice'><b>All authorizations to shortening time for shuttle launch have been revoked!</b></span>")
 				src.authorized.len = 0
 				src.authorized = list(  )
 
-	else if (istype(W, /obj/item/card/emag) && !emagged)
+	else if (istype(card, /obj/item/card/emag) && !emagged)
 		var/choice = alert(user, "Would you like to launch the shuttle?","Shuttle control", "Launch", "Cancel")
 
-		if(!emagged && !evac_control.is_prepared() && user.get_active_held_item() == W)
+		if(!emagged && !evac_control.is_prepared() && user.get_active_held_item() == card)
 			switch(choice)
 				if("Launch")
 					to_world("<span class='notice'><b>Alert: Shuttle launch time shortened to 10 seconds!</b></span>")

--- a/code/game/machinery/doors/_door.dm
+++ b/code/game/machinery/doors/_door.dm
@@ -234,12 +234,13 @@
 /obj/machinery/door/hitby(var/atom/movable/AM, var/datum/thrownthing/TT)
 	. = ..()
 	if(.)
-		visible_message("<span class='danger'>[src.name] was hit by [AM].</span>")
+		visible_message(SPAN_DANGER("\The [src] was hit by \the [AM]."))
 		var/tforce = 0
 		if(ismob(AM))
 			tforce = 3 * TT.speed
-		else
-			tforce = AM:throwforce * (TT.speed/THROWFORCE_SPEED_DIVISOR)
+		else if(isobj(AM))
+			var/obj/hitter_obj = AM
+			tforce = hitter_obj.throwforce * (TT.speed/THROWFORCE_SPEED_DIVISOR)
 		playsound(src.loc, hitsound, 100, 1)
 		take_damage(tforce)
 

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -147,7 +147,8 @@
 /obj/machinery/door/blast/attackby(obj/item/C, mob/user)
 	add_fingerprint(user, 0, C)
 	if(!panel_open) //Do this here so the door won't change state while prying out the circuit
-		if(IS_CROWBAR(C) || (istype(C, /obj/item/twohanded/fireaxe) && C:wielded == 1))
+		var/obj/item/twohanded/zweihander = C
+		if(IS_CROWBAR(C) || (istype(C, /obj/item/twohanded/fireaxe) && zweihander.wielded))
 			if(((stat & NOPOWER) || (stat & BROKEN)) && !( operating ))
 				to_chat(user, "<span class='notice'>You begin prying at \the [src]...</span>")
 				if(do_after(user, 2 SECONDS, src))

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -6,7 +6,7 @@
 	layer = OBJ_LAYER
 	icon = 'icons/obj/items/weapon/landmine.dmi'
 	icon_state = "uglymine"
-	var/triggerproc = "explode" //name of the proc thats called when the mine is triggered
+	var/triggerproc = PROC_REF(explode) // the proc that's called when the mine is triggered
 	var/triggered = 0
 
 /obj/effect/mine/Initialize()
@@ -28,9 +28,11 @@
 
 /obj/effect/mine/proc/triggerrad(obj)
 	spark_at(src, cardinal_only = TRUE)
-	obj:radiation += 50
-	randmutb(obj)
-	domutcheck(obj,null)
+	if(ismob(obj))
+		var/mob/victim = obj
+		victim.radiation += 50
+		randmutb(victim)
+		domutcheck(victim, null)
 	spawn(0)
 		qdel(src)
 
@@ -64,7 +66,9 @@
 
 /obj/effect/mine/proc/triggerkick(obj)
 	spark_at(src, cardinal_only = TRUE)
-	qdel(obj:client)
+	if(ismob(obj))
+		var/mob/victim = obj
+		qdel(victim.client)
 	spawn(0)
 		qdel(src)
 
@@ -76,24 +80,24 @@
 /obj/effect/mine/dnascramble
 	name = "Radiation Mine"
 	icon_state = "uglymine"
-	triggerproc = "triggerrad"
+	triggerproc = PROC_REF(triggerrad)
 
 /obj/effect/mine/flame
 	name = "Incendiary Mine"
 	icon_state = "uglymine"
-	triggerproc = "triggerflame"
+	triggerproc = PROC_REF(triggerflame)
 
 /obj/effect/mine/kick
 	name = "Kick Mine"
 	icon_state = "uglymine"
-	triggerproc = "triggerkick"
+	triggerproc = PROC_REF(triggerkick)
 
 /obj/effect/mine/n2o
 	name = "N2O Mine"
 	icon_state = "uglymine"
-	triggerproc = "triggern2o"
+	triggerproc = PROC_REF(triggern2o)
 
 /obj/effect/mine/stun
 	name = "Stun Mine"
 	icon_state = "uglymine"
-	triggerproc = "triggerstun"
+	triggerproc = PROC_REF(triggerstun)

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -6,7 +6,7 @@
 	material = /decl/material/solid/metal/stainlesssteel
 	var/obj/item/tank/tank_one
 	var/obj/item/tank/tank_two
-	var/obj/item/attached_device
+	var/obj/item/assembly/attached_device
 	var/mob/attacher = null
 	var/valve_open = 0
 	var/toggle = 1
@@ -110,7 +110,7 @@
 	else if(attached_device)
 		if(href_list["rem_device"])
 			attached_device.dropInto(loc)
-			attached_device:holder = null
+			attached_device.holder = null
 			attached_device = null
 			update_icon()
 		if(href_list["device"])

--- a/code/game/world_topic_commands.dm
+++ b/code/game/world_topic_commands.dm
@@ -85,7 +85,7 @@ var/global/list/decl/topic_command/topic_commands = list()
 	s["enter"] =   get_config_value(/decl/config/toggle/on/enter_allowed)
 	s["vote"] =    get_config_value(/decl/config/toggle/vote_mode)
 	s["ai"] =      !!length(empty_playable_ai_cores)
-	s["host"] =    host || null
+	s["host"] =    get_config_value(/decl/config/text/hosted_by)
 
 	// This is dumb, but spacestation13.com's banners break if player count isn't the 8th field of the reply, so... this has to go here.
 	s["players"] = 0

--- a/code/modules/admin/dbban/functions.dm
+++ b/code/modules/admin/dbban/functions.dm
@@ -257,6 +257,9 @@
 
 	if(!check_rights(R_BAN))	return
 
+	if(!owner || !istype(owner, /client))
+		return
+
 	establish_db_connection()
 	if(!dbcon.IsConnected())
 		return
@@ -271,21 +274,18 @@
 		ban_number++;
 
 	if(ban_number == 0)
-		to_chat(usr, "<span class='warning'>Database update failed due to a ban id not being present in the database.</span>")
+		to_chat(owner, "<span class='warning'>Database update failed due to a ban id not being present in the database.</span>")
 		return
 
 	if(ban_number > 1)
-		to_chat(usr, "<span class='warning'>Database update failed due to multiple bans having the same ID. Contact the database admin.</span>")
+		to_chat(owner, "<span class='warning'>Database update failed due to multiple bans having the same ID. Contact the database admin.</span>")
 		return
 
-	if(!src.owner || !istype(src.owner, /client))
-		return
+	var/unban_ckey = owner.ckey
+	var/unban_computerid = owner.computer_id
+	var/unban_ip = owner.address
 
-	var/unban_ckey = src.owner:ckey
-	var/unban_computerid = src.owner:computer_id
-	var/unban_ip = src.owner:address
-
-	message_admins("[key_name_admin(usr)] has lifted [pckey]'s ban.",1)
+	message_admins("[key_name_admin(owner)] has lifted [pckey]'s ban.",1)
 
 	var/DBQuery/query_update = dbcon.NewQuery("UPDATE `erro_ban` SET `unbanned` = TRUE, `unbanned_datetime` = NOW(), `unbanned_ckey` = '[unban_ckey]', `unbanned_computerid` = '[unban_computerid]', `unbanned_ip` = '[unban_ip]' WHERE `id` = [id]")
 	query_update.Execute()

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -116,13 +116,13 @@
 		return
 
 	if(get_config_value(/decl/config/toggle/on/admin_jump))
-		var/list/keys = list()
-		for(var/mob/M in global.player_list)
+		var/list/client/keys = list()
+		for(var/mob/M in global.player_list) // excludes /mob/new_player
 			keys += M.client
-		var/selection = input("Please, select a player!", "Admin Jumping", null, null) as null|anything in sortKey(keys)
+		var/client/selection = input("Please, select a player!", "Admin Jumping", null, null) as null|anything in sortKey(keys)
 		if(!selection)
 			return
-		var/mob/M = selection:mob
+		var/mob/M = selection.mob
 
 		if(!M)
 			return


### PR DESCRIPTION
## Description of changes
Removes uses of the unsafe var access operator `:` outside of View Variables, SDQL, lighting, atmos, and Z-mimic.
Also removes an unset global variable, `global.host`, and replaces its one use with the hosted_by config text.

## Why and what will this PR improve
This operator shouldn't be used without a very, very good reason. I also cleaned up some code a little while I was in the area.