### PR TITLE
Make diagonal movement on by default

### DIFF
--- a/code/datums/config/config_types/config_game_option.dm
+++ b/code/datums/config/config_types/config_game_option.dm
@@ -21,7 +21,7 @@
 		/decl/config/num/default_darksight_effectiveness,
 		/decl/config/toggle/grant_default_darksight,
 		/decl/config/num/expected_round_length,
-		/decl/config/toggle/allow_diagonal_movement,
+		/decl/config/toggle/on/allow_diagonal_movement,
 		/decl/config/toggle/expanded_alt_interactions,
 		/decl/config/toggle/ert_admin_call_only,
 		/decl/config/toggle/ghosts_can_possess_animals,
@@ -134,7 +134,7 @@
 	uid = "grant_default_darksight"
 	desc = "Whether or not all human mobs have very basic darksight by default."
 
-/decl/config/toggle/allow_diagonal_movement
+/decl/config/toggle/on/allow_diagonal_movement
 	uid = "allow_diagonal_movement"
 	desc = "Allow multiple input keys to be pressed for diagonal movement."
 

--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -15,7 +15,7 @@
 	if((movement_dir & EAST) && (movement_dir & WEST))
 		movement_dir &= ~(EAST|WEST)
 
-	if(!get_config_value(/decl/config/toggle/allow_diagonal_movement))
+	if(!get_config_value(/decl/config/toggle/on/allow_diagonal_movement))
 		if(movement_dir & user.last_move_dir_pressed)
 			movement_dir = user.last_move_dir_pressed
 		else

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -37,7 +37,7 @@
 		if(!(next_move_dir_sub & movement))
 			next_move_dir_add |= movement
 
-		if(movement && !get_config_value(/decl/config/toggle/allow_diagonal_movement))
+		if(movement && !get_config_value(/decl/config/toggle/on/allow_diagonal_movement))
 			last_move_dir_pressed = movement
 
 	// Client-level keybindings are ones anyone should be able to do at any time


### PR DESCRIPTION
## Description of changes
Makes it so that diagonal movement is on by default.

## Why and what will this PR improve
Diagonal movement is the default on other servers, and not having it on by default makes people think our codebase is stuck in the last decade. If opinionated people want to disable it, they can do that themselves, but it should be on by default so that new player onboarding works better.

## Changelog
:cl:
config: diagonal movement is on by default
/:cl: