### PR TITLE
Improve fireball enchantment and fire-related effects/interactions

### DIFF
--- a/code/game/objects/effects/fake_fire.dm
+++ b/code/game/objects/effects/fake_fire.dm
@@ -5,15 +5,30 @@
 	layer = FIRE_LAYER
 	var/lifetime = 10 SECONDS //0 for infinite
 	//See Fire.dm (the real one), but in a nutshell:
-	var/firelevel = 0 //Larger the number, worse burns.
-	var/last_temperature = 0 //People with heat protection above this temp will be immune.
-	var/pressure = 0 //Larger the number, worse burns.
+	var/firelevel = 1 //Larger the number, worse burns.
+	var/last_temperature = T100C //People with heat protection above this temp will be immune.
+	var/pressure = ONE_ATMOSPHERE //Larger the number, worse burns.
 
 /obj/effect/fake_fire/Initialize()
 	. = ..()
 	if(!loc)
 		return INITIALIZE_HINT_QDEL
-	set_light(3, 0.5, color)
+	var/new_light_range
+	var/new_light_power
+	if(firelevel > 6)
+		icon_state = "3"
+		new_light_range = 7
+		new_light_power = 3
+	else if(firelevel > 2.5)
+		icon_state = "2"
+		new_light_range = 5
+		new_light_power = 2
+	else
+		icon_state = "1"
+		new_light_range = 3
+		new_light_power = 1
+	color = fire_color()
+	set_light(new_light_range, new_light_power, color)
 	START_PROCESSING(SSobj,src)
 	if(lifetime)
 		QDEL_IN(src,lifetime)
@@ -22,11 +37,19 @@
 	if(!loc)
 		qdel(src)
 		return PROCESS_KILL
-	for(var/mob/living/L in loc)
-		L.FireBurn(firelevel,last_temperature,pressure)
-	loc.fire_act(firelevel,last_temperature,pressure)
-	for(var/atom/A in loc)
-		A.fire_act(firelevel,last_temperature,pressure)
+	for(var/mob/living/victim in loc)
+		if(!victim.simulated)
+			continue
+		victim.FireBurn(firelevel, last_temperature, pressure)
+	loc.fire_act(firelevel, last_temperature, pressure)
+	for(var/atom/burned in loc)
+		if(!burned.simulated || burned == src)
+			continue
+		burned.fire_act(firelevel, last_temperature, pressure)
+
+/obj/effect/fake_fire/proc/fire_color()
+	var/temperature = max(4000*sqrt(firelevel/vsc.fire_firelevel_multiplier), last_temperature)
+	return heat2color(temperature)
 
 /obj/effect/fake_fire/Destroy()
 	STOP_PROCESSING(SSobj,src)

--- a/code/game/turfs/floors/natural/natural_grass.dm
+++ b/code/game/turfs/floors/natural/natural_grass.dm
@@ -56,28 +56,22 @@
 	if(grass_color)
 		color = grass_color
 
-	//#TODO: Check if this is still relevant/wanted since we got map gen to handle this?
-	var/datum/extension/buried_resources/resources = get_or_create_extension(src, /datum/extension/buried_resources)
-	if(prob(70))
-		LAZYSET(resources.resources, /decl/material/solid/graphite, rand(3,5))
-	if(prob(5))
-		LAZYSET(resources.resources, /decl/material/solid/metal/uranium, rand(1,3))
-	if(prob(2))
-		LAZYSET(resources.resources, /decl/material/solid/gemstone/diamond,  1)
-	if(!LAZYLEN(resources.resources))
-		remove_extension(src, /datum/extension/buried_resources)
-
 /turf/floor/natural/grass/wild/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	if((temperature > T0C + 200 && prob(5)) || temperature > T0C + 1000)
+	// smoothly scale between 1/5 chance to scorch at ignition_point and 100% chance to scorch at ignition_point * 4
+	if(temperature >= material.ignition_point && prob(20 + temperature * 80 / (material.ignition_point * 4)))
 		handle_melting()
 	return ..()
 
 /turf/floor/natural/grass/wild/handle_melting(list/meltable_materials)
 	. = ..()
-	if(icon_state != "scorched")
-		SetName("scorched ground")
-		desc = "What was once lush grass has been reduced to burnt ashes."
-		icon_state = "scorched"
-		icon_edge_layer = -1
-		footstep_type = /decl/footsteps/asteroid
-		color = null
+	ChangeTurf(/turf/floor/natural/scorched)
+
+/turf/floor/natural/scorched
+	name = "scorched ground"
+	desc = "What was once lush grass has been reduced to burnt ashes."
+	icon = 'icons/turf/flooring/wildgrass.dmi'
+	icon_state = "scorched"
+	possible_states = null
+	footstep_type = /decl/footsteps/asteroid // closest we have to "stepping on carbonized grass"
+	material = /decl/material/solid/carbon
+	turf_flags = TURF_FLAG_BACKGROUND

--- a/code/modules/item_effects/item_effect_charges.dm
+++ b/code/modules/item_effects/item_effect_charges.dm
@@ -12,6 +12,52 @@
 /decl/item_effect/charges/examined(obj/item/item, mob/user)
 	to_chat(user, SPAN_NOTICE("\The [item] has [item.get_item_effect_parameter(src, ITEM_EFFECT_RANGED, "charges") || 0] charge\s of [effect_descriptor] left."))
 
+/obj/item/projectile/fireball
+	name = "fireball"
+	icon_state = "fireball"
+	fire_sound = 'sound/effects/bamf.ogg'
+	damage = 20
+	atom_damage_type = BURN
+	damage_flags = DAM_DISPERSED // burn all over
+	var/fire_lifetime = 2 SECONDS
+	var/fire_temperature = (288 CELSIUS) / 0.9 + 1 // hot enough to ignite wood! divided by 0.9 and plus one to ensure we can light firepits
+
+/obj/effect/fake_fire/variable
+	name = "fire"
+	anchored = TRUE
+	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
+	firelevel = 1
+	pressure = ONE_ATMOSPHERE
+
+/obj/effect/fake_fire/variable/Initialize(ml, new_temperature, new_lifetime)
+	lifetime = new_lifetime
+	last_temperature = new_temperature
+	return ..()
+
+// we deal our damage via fire_act, not via direct burn damage. our burn damage is specifically for mobs
+/obj/item/projectile/fireball/get_structure_damage()
+	return 0
+
+/obj/item/projectile/fireball/on_impact(var/atom/A)
+	. = ..()
+	var/obj/effect/fake_fire/fire = new /obj/effect/fake_fire/variable(get_turf(A), fire_temperature, fire_lifetime)
+	fire.Process() // process at least once!
+	qdel_self()
+
+/obj/item/projectile/fireball/after_move()
+	. = ..()
+	if(!loc)
+		return
+	for(var/mob/living/victim in loc)
+		if(!victim.simulated)
+			continue
+		victim.FireBurn(1, fire_temperature, ONE_ATMOSPHERE)
+	loc.fire_act(1, fire_temperature, ONE_ATMOSPHERE)
+	for(var/atom/burned in loc)
+		if(!burned.simulated || burned == src)
+			continue
+		burned.fire_act(1, fire_temperature, ONE_ATMOSPHERE)
+
 // Example effect; casts a fireball n times.
 /decl/item_effect/charges/fireball
 	effect_descriptor = "fireball"
@@ -20,5 +66,5 @@
 /decl/item_effect/charges/fireball/do_ranged_effect(mob/user, obj/item/item, atom/target, list/parameters)
 	. = ..()
 	if(.)
-		var/obj/item/projectile/spell_projectile/fireball/projectile = new(get_turf(user))
+		var/obj/item/projectile/fireball/projectile = new(get_turf(user))
 		projectile.launch_from_gun(target, user.get_target_zone(), user)

--- a/code/modules/item_effects/item_effect_debug.dm
+++ b/code/modules/item_effects/item_effect_debug.dm
@@ -62,3 +62,16 @@
 		ITEM_EFFECT_VISIBLE,
 		ITEM_EFFECT_WIELDED
 	))
+
+/obj/item/staff/fireball
+	name = "staff of fireball"
+	icon_state = "starstaff"
+	material = /decl/material/solid/organic/wood/ebony
+	matter = list(/decl/material/solid/metal/gold = MATTER_AMOUNT_TRACE)
+
+/obj/item/staff/fireball/Initialize(ml, material_key)
+	. = ..()
+	add_item_effect(/decl/item_effect/charges/fireball, list(
+		ITEM_EFFECT_VISIBLE,
+		ITEM_EFFECT_RANGED   = list("charges" = 5)
+	))

--- a/code/modules/mob/living/human/life.dm
+++ b/code/modules/mob/living/human/life.dm
@@ -268,8 +268,7 @@
 		bodytemperature += round(robolimb_count/2)
 	return ..()
 
-//This proc returns a number made up of the flags for body parts which you are protected on. (such as HEAD, SLOT_UPPER_BODY, SLOT_LOWER_BODY, etc. See setup.dm for the full list)
-/mob/living/human/proc/get_heat_protection_flags(temperature) //Temperature is the temperature you're being exposed to.
+/mob/living/human/get_heat_protection_flags(temperature)
 	. = 0
 	//Handle normal clothing
 	for(var/slot in global.standard_clothing_slots)
@@ -810,36 +809,6 @@
 				holder.icon_state = "hudsyndicate"
 			hud_list[SPECIALROLE_HUD] = holder
 	hud_updateflag = 0
-
-/mob/living/human/handle_fire()
-	if(..())
-		return
-
-	var/burn_temperature = fire_burn_temperature()
-	var/thermal_protection = get_heat_protection(burn_temperature)
-
-	if (thermal_protection < 1 && bodytemperature < burn_temperature)
-		bodytemperature += round(BODYTEMP_HEATING_MAX*(1-thermal_protection), 1)
-
-	var/species_heat_mod = 1
-
-	var/protected_limbs = get_heat_protection_flags(burn_temperature)
-
-
-	if(species)
-		if(burn_temperature < get_mob_temperature_threshold(HEAT_LEVEL_2))
-			species_heat_mod = 0.5
-		else if(burn_temperature < get_mob_temperature_threshold(HEAT_LEVEL_3))
-			species_heat_mod = 0.75
-
-	burn_temperature -= get_mob_temperature_threshold(HEAT_LEVEL_1)
-
-	if(burn_temperature < 1)
-		return
-
-	for(var/obj/item/organ/external/E in get_external_organs())
-		if(!(E.body_part & protected_limbs) && prob(20))
-			E.take_external_damage(burn = round(species_heat_mod * log(10, (burn_temperature + 10)), 0.1), used_weapon = "fire")
 
 /mob/living/human/rejuvenate()
 	reset_blood()

--- a/code/modules/mob/living/human/update_icons.dm
+++ b/code/modules/mob/living/human/update_icons.dm
@@ -531,13 +531,6 @@ Please contact me on #coderbus IRC. ~Carn x
 		return
 	set_tail_state("[tail_organ.get_tail()]_static")
 
-/mob/living/human/update_fire(var/update_icons=1)
-	if(on_fire)
-		var/image/standing = overlay_image(get_bodytype()?.get_ignited_icon(src) || 'icons/mob/OnFire.dmi', "Standing", RESET_COLOR)
-		set_current_mob_overlay(HO_FIRE_LAYER, standing, update_icons)
-	else
-		set_current_mob_overlay(HO_FIRE_LAYER, null, update_icons)
-
 /mob/living/human/hud_reset(full_reset = FALSE)
 	if((. = ..()) && internals && internal)
 		internals.icon_state = "internal1"

--- a/code/modules/mob/living/living_bodytemp.dm
+++ b/code/modules/mob/living/living_bodytemp.dm
@@ -41,3 +41,8 @@
 		if(get_hydration() >= hyd_remove)
 			adjust_hydration(-hyd_remove)
 			bodytemperature += min((body_temperature_difference / BODYTEMP_AUTORECOVERY_DIVISOR), -BODYTEMP_AUTORECOVERY_MINIMUM)
+
+/// This proc returns a number made up of the flags for body parts which you are protected on. (such as HEAD, SLOT_UPPER_BODY, SLOT_LOWER_BODY, etc.
+/// Temperature parameter is the temperature you're being exposed to.
+/mob/living/proc/get_heat_protection_flags(temperature)
+	return 0

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -301,8 +301,13 @@
 		set_light(0)
 		update_fire()
 
-/mob/living/proc/update_fire()
-	return
+/mob/living/proc/update_fire(var/update_icons=1)
+	if(on_fire)
+		var/decl/bodytype/mob_bodytype = get_bodytype()
+		var/image/standing = overlay_image(mob_bodytype?.get_ignited_icon(src) || 'icons/mob/OnFire.dmi', mob_bodytype?.get_ignited_icon_state(src) || "Generic_mob_burning", RESET_COLOR)
+		set_current_mob_overlay(HO_FIRE_LAYER, standing, update_icons)
+	else
+		set_current_mob_overlay(HO_FIRE_LAYER, null, update_icons)
 
 /mob/living/proc/adjust_fire_stacks(add_fire_stacks) //Adjusting the amount of fire_stacks we have on person
 	fire_stacks = clamp(fire_stacks + add_fire_stacks, FIRE_MIN_STACKS, FIRE_MAX_STACKS)
@@ -312,20 +317,47 @@
 		fire_stacks = min(0, ++fire_stacks) //If we've doused ourselves in water to avoid fire, dry off slowly
 
 	if(!on_fire)
-		return 1
+		return TRUE
 	else if(fire_stacks <= 0)
 		ExtinguishMob() //Fire's been put out.
-		return 1
+		return TRUE
 
 	fire_stacks = max(0, fire_stacks - 0.2) //I guess the fire runs out of fuel eventually
 
 	var/datum/gas_mixture/G = loc.return_air() // Check if we're standing in an oxygenless environment
 	if(G.get_by_flag(XGM_GAS_OXIDIZER) < 1)
 		ExtinguishMob() //If there's no oxygen in the tile we're on, put out the fire
-		return 1
+		return TRUE
 
 	var/turf/location = get_turf(src)
 	location.hotspot_expose(fire_burn_temperature(), 50, 1)
+
+	var/burn_temperature = fire_burn_temperature()
+	var/thermal_protection = get_heat_protection(burn_temperature)
+
+	if (thermal_protection < 1 && bodytemperature < burn_temperature)
+		bodytemperature += round(BODYTEMP_HEATING_MAX*(1-thermal_protection), 1)
+
+	var/species_heat_mod = 1
+
+	var/protected_limbs = get_heat_protection_flags(burn_temperature)
+
+	if(burn_temperature < get_mob_temperature_threshold(HEAT_LEVEL_2))
+		species_heat_mod = 0.5
+	else if(burn_temperature < get_mob_temperature_threshold(HEAT_LEVEL_3))
+		species_heat_mod = 0.75
+
+	burn_temperature -= get_mob_temperature_threshold(HEAT_LEVEL_1)
+
+	if(burn_temperature < 1)
+		return
+
+	if(has_external_organs())
+		for(var/obj/item/organ/external/E in get_external_organs())
+			if(!(E.body_part & protected_limbs) && prob(20))
+				E.take_external_damage(burn = round(species_heat_mod * log(10, (burn_temperature + 10)), 0.1), used_weapon = "fire")
+	else // fallback for simplemobs
+		take_damage(round(species_heat_mod * log(10, (burn_temperature + 10))), 0.1, BURN, DAM_DISPERSED)
 
 /mob/living/proc/increase_fire_stacks(exposed_temperature)
 	if(fire_stacks <= 4 || fire_burn_temperature() < exposed_temperature)

--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -27,6 +27,9 @@
 	bodytype_flag = 0
 	bodytype_category = "hexapodal animal body"
 
+/decl/bodytype/hexapod/get_ignited_icon_state(mob/living/victim)
+	return "Generic_mob_burning"
+
 /mob/living/simple_animal/crab/get_bodytype()
 	return GET_DECL(/decl/bodytype/hexapod/animal/crab)
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -293,6 +293,13 @@ var/global/list/simplemob_icon_bitflag_cache = list()
 	if(!atmos_suitable)
 		take_damage(unsuitable_atmos_damage)
 
+/mob/living/simple_animal/get_mob_temperature_threshold(threshold, bodypart)
+	if(threshold >= HEAT_LEVEL_1)
+		return maxbodytemp
+	if(threshold <= COLD_LEVEL_1)
+		return minbodytemp
+	return ..()
+
 /mob/living/simple_animal/proc/escape(mob/living/M, obj/O)
 	O.unbuckle_mob(M)
 	visible_message(SPAN_DANGER("\The [M] escapes from \the [O]!"))
@@ -448,15 +455,6 @@ var/global/list/simplemob_icon_bitflag_cache = list()
 /mob/living/simple_animal/put_in_hands(var/obj/item/W) // No hands.
 	W.forceMove(get_turf(src))
 	return 1
-
-/mob/living/simple_animal/handle_fire()
-	return
-/mob/living/simple_animal/update_fire()
-	return
-/mob/living/simple_animal/IgniteMob()
-	return
-/mob/living/simple_animal/ExtinguishMob()
-	return
 
 /mob/living/simple_animal/is_burnable()
 	return heat_damage_per_tick

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -156,7 +156,9 @@
 	def_zone = check_zone(target_zone)
 	firer = shooter
 	var/direct_target
-	if(get_turf(target) == get_turf(src))
+	var/turf/actual_target_turf = get_turf(target)
+	actual_target_turf = actual_target_turf?.resolve_to_actual_turf()
+	if(actual_target_turf == get_turf(src))
 		direct_target = target
 	preparePixelProjectile(target, shooter ? shooter : get_turf(src), params, forced_spread)
 	return fire(Angle_override, direct_target)
@@ -383,7 +385,7 @@
 			qdel(src)
 			return
 		var/turf/target = locate(clamp(starting + xo, 1, world.maxx), clamp(starting + yo, 1, world.maxy), starting.z)
-		setAngle(get_projectile_angle(src, target))
+		setAngle(get_projectile_angle(src, target.resolve_to_actual_turf()))
 	if(dispersion)
 		var/DeviationAngle = (dispersion * 15)
 		setAngle(Angle + rand(-DeviationAngle, DeviationAngle))
@@ -417,6 +419,7 @@
 /obj/item/projectile/proc/preparePixelProjectile(atom/target, atom/source, params, Angle_offset = 0)
 	var/turf/curloc = get_turf(source)
 	var/turf/targloc = get_turf(target)
+	targloc = targloc?.resolve_to_actual_turf()
 	forceMove(get_turf(source))
 	starting = get_turf(source)
 	original = target

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -495,7 +495,7 @@
 
 //Returns true if the target atom is on our current turf and above the right layer
 /obj/item/projectile/proc/can_hit_target(atom/target, var/list/passthrough)
-	return (target && ((target.layer >= TURF_LAYER + 0.3) || ismob(target)) && (loc == get_turf(target)) && (!(target in passthrough)))
+	return (target && ((target.layer >= STRUCTURE_LAYER) || ismob(target)) && (loc == get_turf(target)) && (!(target in passthrough)))
 
 /proc/calculate_projectile_Angle_and_pixel_offsets(mob/user, params)
 	var/list/mouse_control = params2list(params)

--- a/code/modules/species/species_bodytype_helpers.dm
+++ b/code/modules/species/species_bodytype_helpers.dm
@@ -1,5 +1,8 @@
-/decl/bodytype/proc/get_ignited_icon(var/mob/living/human/H)
+/decl/bodytype/proc/get_ignited_icon(var/mob/living/human/victim)
 	return ignited_icon
+
+/decl/bodytype/proc/get_ignited_icon_state(mob/living/victim)
+	return "Standing"
 
 /decl/bodytype/proc/get_icon_cache_uid(var/mob/H)
 	if(!icon_cache_uid)

--- a/code/modules/species/species_bodytype_quadruped.dm
+++ b/code/modules/species/species_bodytype_quadruped.dm
@@ -23,3 +23,6 @@
 	. = ..()
 	H.can_buckle         = ridable
 	H.buckle_pixel_shift = riding_offset
+
+/decl/bodytype/quadruped/get_ignited_icon_state(mob/living/victim)
+	return "Generic_mob_burning"


### PR DESCRIPTION
## Description of changes
- Makes fake fire effects use the same logic as real fire for color, light, etc.
- Makes scorched grass a separate turf type than normal grass, to fix issues with edges.
- Generalizes mob fire/burning logic to `mob/living`.
- Dramatically increases grass scorching chance because honestly, it was way too rare. Also, it's now based on material properties.
- Allows projectiles to hit objects on `STRUCTURE_LAYER` such as campfires.
- Improves projectile handling when mimic turfs are targeted.
- Completely redoes the fireball enchantment to use a custom projectile that spawns a fake_fire effect, since the previous one didn't work and even when I fixed it, all it did was cause an explosion.

## Why and what will this PR improve
Makes the fireball effect more fun to use, and you can even use it to light campfires!

Dev info and images here: https://cohost.org/in-phaze/post/6590850-shaded-hills-mini-up