### PR TITLE
Change non-furniture wood on Shaded Hills to walnut, tweak lanterns

### DIFF
--- a/code/game/objects/items/blades/_blade.dm
+++ b/code/game/objects/items/blades/_blade.dm
@@ -65,7 +65,7 @@
 		)
 		switch(w_class)
 			if(0 to ITEM_SIZE_SMALL)
-				initial_tool_qualities[TOOL_HATCHET] = TOOL_QUALITY_NONE
+				pass()
 			if(ITEM_SIZE_SMALL to ITEM_SIZE_NORMAL) // Since ITEM_SIZE_SMALL was already covered, this is just ITEM_SIZE_NORMAL.
 				initial_tool_qualities[TOOL_HATCHET] = TOOL_QUALITY_WORST
 			if(ITEM_SIZE_NORMAL to ITEM_SIZE_LARGE)

--- a/code/game/objects/items/flame/flame_fuelled_lantern.dm
+++ b/code/game/objects/items/flame/flame_fuelled_lantern.dm
@@ -10,7 +10,8 @@
 	slot_flags          = SLOT_LOWER_BODY
 	lit_light_power     = 0.7
 	lit_light_range     = 6
-	max_fuel            = 120
+	max_fuel            = 60
+	_fuel_spend_amt     = (1 / 60) // a full lantern should last an hour
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME | MAT_FLAG_ALTERATION_DESC
 	material            = /decl/material/solid/metal/copper
 	can_manually_light  = FALSE

--- a/code/game/objects/structures/compost.dm
+++ b/code/game/objects/structures/compost.dm
@@ -199,3 +199,11 @@ var/global/const/COMPOST_WORM_HUNGER_FACTOR = MINIMUM_CHEMICAL_VOLUME
 /obj/structure/reagent_dispensers/compost_bin/get_alt_interactions(var/mob/user)
 	. = ..()
 	LAZYREMOVE(., /decl/interaction_handler/toggle_open/reagent_dispenser)
+
+/obj/structure/reagent_dispensers/compost_bin/ebony
+	material = /decl/material/solid/organic/wood/ebony
+	color = /decl/material/solid/organic/wood/ebony::color
+
+/obj/structure/reagent_dispensers/compost_bin/walnut
+	material = /decl/material/solid/organic/wood/walnut
+	color = /decl/material/solid/organic/wood/walnut::color

--- a/code/game/objects/structures/doors/_door.dm
+++ b/code/game/objects/structures/doors/_door.dm
@@ -201,34 +201,31 @@
 
 /obj/structure/door/wood
 	material = /decl/material/solid/organic/wood
+	color = /decl/material/solid/organic/wood::color
 
 /obj/structure/door/mahogany
 	material = /decl/material/solid/organic/wood/mahogany
+	color = /decl/material/solid/organic/wood/mahogany::color
 
 /obj/structure/door/maple
 	material = /decl/material/solid/organic/wood/maple
+	color = /decl/material/solid/organic/wood/maple::color
 
 /obj/structure/door/ebony
 	material = /decl/material/solid/organic/wood/ebony
+	color = /decl/material/solid/organic/wood/ebony::color
 
 /obj/structure/door/walnut
 	material = /decl/material/solid/organic/wood/walnut
+	color = /decl/material/solid/organic/wood/walnut::color
 
 /obj/structure/door/wood/saloon
 	material = /decl/material/solid/organic/wood
 	opacity = FALSE
 
-/obj/structure/door/wood/ebony
-	material = /decl/material/solid/organic/wood/ebony
-	color = /decl/material/solid/organic/wood/ebony::color
-
 /obj/structure/door/wood/saloon/ebony
 	material = /decl/material/solid/organic/wood/ebony
 	color = /decl/material/solid/organic/wood/ebony::color
-
-/obj/structure/door/wood/walnut
-	material = /decl/material/solid/organic/wood/walnut
-	color = /decl/material/solid/organic/wood/walnut::color
 
 /obj/structure/door/wood/saloon/walnut
 	material = /decl/material/solid/organic/wood/walnut

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -27,11 +27,28 @@
 /obj/structure/railing/mapped/no_density
 	density = FALSE
 
-/obj/structure/railing/mapped/ebony
-	material = /decl/material/solid/organic/wood/ebony
+/obj/structure/railing/mapped/wooden
+	material = /decl/material/solid/organic/wood
 	parts_type = /obj/item/stack/material/plank
-	color = WOOD_COLOR_BLACK
+	color = WOOD_COLOR_GENERIC
 	paint_color = null
+
+// Subtypes.
+#define WOOD_RAILING_SUBTYPE(material_name) \
+/obj/structure/railing/mapped/wooden/##material_name { \
+	material = /decl/material/solid/organic/wood/##material_name; \
+	color = /decl/material/solid/organic/wood/##material_name::color; \
+}
+
+WOOD_RAILING_SUBTYPE(fungal)
+WOOD_RAILING_SUBTYPE(ebony)
+WOOD_RAILING_SUBTYPE(walnut)
+WOOD_RAILING_SUBTYPE(maple)
+WOOD_RAILING_SUBTYPE(mahogany)
+WOOD_RAILING_SUBTYPE(bamboo)
+WOOD_RAILING_SUBTYPE(yew)
+
+#undef WOOD_RAILING_SUBTYPE
 
 /obj/structure/railing/Process()
 	if(!material || !material.radioactivity)

--- a/code/game/objects/structures/wall_sconce.dm
+++ b/code/game/objects/structures/wall_sconce.dm
@@ -31,11 +31,14 @@
 	directional_offset  = @'{"NORTH":{"y":24}, "SOUTH":{"y":-1}, "EAST":{"x":10,"y":10}, "WEST":{"x":-10,"y":10}}'
 	/// Reference to the currently attached item.
 	var/obj/item/flame/light_source
+	/// Whether or not the light source, if present, is automatically lit on Initialize.
+	var/start_lit = FALSE
 
 /obj/structure/wall_sconce/Initialize(var/ml, var/_mat, var/_reinf_mat, var/supplied_dir)
 
 	if(ispath(light_source))
 		light_source = new light_source(src)
+	if(start_lit && istype(light_source))
 		light_source.light(null, no_message = TRUE)
 
 	. = ..()

--- a/maps/shaded_hills/shaded_hills-dungeon.dmm
+++ b/maps/shaded_hills/shaded_hills-dungeon.dmm
@@ -57,7 +57,7 @@
 /turf/floor/natural/rock/basalt,
 /area/shaded_hills/caves/dungeon/poi)
 "Xx" = (
-/turf/wall/log/ebony,
+/turf/wall/log/walnut,
 /area/shaded_hills/caves/dungeon)
 "YN" = (
 /turf/floor/natural/path/running_bond/basalt,

--- a/maps/shaded_hills/shaded_hills-grassland.dmm
+++ b/maps/shaded_hills/shaded_hills-grassland.dmm
@@ -15,7 +15,7 @@
 /turf/floor/natural/grass,
 /area/shaded_hills/outside)
 "dB" = (
-/turf/wall/log/ebony,
+/turf/wall/log/walnut,
 /area/shaded_hills/caves/unexplored)
 "ee" = (
 /turf/floor/natural/path/running_bond/basalt,
@@ -55,7 +55,7 @@
 /area/shaded_hills/outside/river)
 "iP" = (
 /obj/structure/fire_source/firepit/basalt,
-/obj/item/stack/material/log/mapped/ebony/ten,
+/obj/item/stack/material/log/mapped/walnut/ten,
 /turf/floor/natural/barren,
 /area/shaded_hills/outside)
 "jj" = (
@@ -111,9 +111,9 @@
 /turf/floor/natural/barren,
 /area/shaded_hills/caves/entrance)
 "nl" = (
-/obj/structure/door/wood/ebony,
+/obj/structure/door/walnut,
 /obj/abstract/exterior_marker/inside,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/outside)
 "oo" = (
 /obj/item/stack/material/ore/handful/sand,
@@ -147,7 +147,7 @@
 /area/shaded_hills/caves/unexplored)
 "ul" = (
 /obj/abstract/exterior_marker/inside,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/outside)
 "vX" = (
 /turf/floor/natural/path/running_bond/basalt,
@@ -162,7 +162,7 @@
 /turf/floor/natural/dirt,
 /area/shaded_hills/outside)
 "xC" = (
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/outside)
 "yA" = (
 /obj/abstract/landmark/latejoin/observer,
@@ -191,7 +191,7 @@
 /turf/floor/woven,
 /area/shaded_hills/outside)
 "EE" = (
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/outside/river)
 "EL" = (
 /obj/abstract/exterior_marker/inside,
@@ -209,13 +209,13 @@
 /area/shaded_hills/outside)
 "ES" = (
 /obj/abstract/exterior_marker/inside,
-/turf/wall/log/ebony,
+/turf/wall/log/walnut,
 /area/shaded_hills/outside)
 "EV" = (
 /turf/floor/natural/mud/water/deep,
 /area/shaded_hills/caves/river)
 "Fg" = (
-/obj/structure/door/wood/ebony,
+/obj/structure/door/walnut,
 /obj/abstract/exterior_marker/inside,
 /turf/floor/natural/path/basalt,
 /area/shaded_hills/outside)
@@ -262,7 +262,7 @@
 /turf/floor/natural/rock/basalt,
 /area/shaded_hills/outside)
 "JN" = (
-/turf/wall/log/ebony,
+/turf/wall/log/walnut,
 /area/shaded_hills/outside/river)
 "Kd" = (
 /turf/floor/natural/mud,
@@ -369,7 +369,7 @@
 /turf/floor/natural/rock/basalt,
 /area/shaded_hills/caves/unexplored/south)
 "ZV" = (
-/turf/wall/log/ebony,
+/turf/wall/log/walnut,
 /area/shaded_hills/outside)
 
 (1,1,1) = {"

--- a/maps/shaded_hills/shaded_hills-inn.dmm
+++ b/maps/shaded_hills/shaded_hills-inn.dmm
@@ -14,7 +14,7 @@
 /obj/structure/bed/chair/wood/ebony{
 	dir = 4
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "bz" = (
 /obj/structure/closet/crate/chest,
@@ -23,51 +23,51 @@
 "bW" = (
 /obj/structure/table/woodentable/ebony,
 /obj/item/chems/cooking_vessel/skillet,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "cl" = (
 /obj/structure/table/woodentable/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "cq" = (
 /obj/structure/table/woodentable/ebony,
 /obj/item/chems/glass/pottery/bowl,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn)
 "cx" = (
 /turf/wall/brick/basalt,
 /area/shaded_hills/outside/downlands)
 "cy" = (
 /obj/structure/reagent_dispensers/barrel/ebony/water,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "cT" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 1
 	},
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 4
 	},
 /turf/floor/natural/grass,
 /area/shaded_hills/outside/shrine)
 "dC" = (
-/obj/structure/door/wood/ebony{
+/obj/structure/door/walnut{
 	dir = 4
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn)
 "dH" = (
-/turf/wall/log/ebony/shutter,
+/turf/wall/log/walnut/shutter,
 /area/shaded_hills/general_store)
 "dK" = (
 /obj/structure/table/woodentable/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn/porch)
 "dN" = (
 /obj/structure/wall_sconce/lantern{
 	dir = 8
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn)
 "ev" = (
 /obj/structure/closet/crate/chest/ebony,
@@ -75,15 +75,15 @@
 /area/shaded_hills/shrine)
 "eD" = (
 /obj/structure/textiles/loom/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "eG" = (
-/obj/structure/door/wood/ebony,
-/turf/floor/wood/ebony,
+/obj/structure/door/walnut,
+/turf/floor/wood/walnut,
 /area/shaded_hills/general_store)
 "fg" = (
-/obj/structure/railing/mapped/ebony,
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut,
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 4
 	},
 /obj/structure/reagent_dispensers/compost_bin,
@@ -113,7 +113,7 @@
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/inn)
 "fR" = (
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/tannery)
 "fS" = (
 /obj/structure/table/woodentable/ebony,
@@ -134,10 +134,10 @@
 	dir = 4
 	},
 /obj/structure/table/woodentable/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "gp" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 1
 	},
 /turf/floor/natural/grass,
@@ -146,17 +146,17 @@
 /obj/structure/wall_sconce/lantern{
 	dir = 8
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "gA" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 8
 	},
 /turf/floor/natural/grass,
 /area/shaded_hills/outside/shrine)
 "gB" = (
 /obj/structure/wall_sconce/lantern,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "gL" = (
 /obj/structure/reagent_dispensers/barrel/ebony/oil,
@@ -172,23 +172,23 @@
 /obj/structure/bed/chair/bench/ebony{
 	dir = 1
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "hE" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 4
 	},
-/obj/structure/railing/mapped/ebony,
+/obj/structure/railing/mapped/wooden/walnut,
 /turf/floor/natural/grass,
 /area/shaded_hills/outside/downlands)
 "hJ" = (
 /obj/structure/bed/chair/bench/ebony{
 	dir = 4
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "hU" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 4
 	},
 /turf/floor/natural/grass,
@@ -198,7 +198,7 @@
 	dir = 1;
 	pixel_y = 10
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn/porch)
 "id" = (
 /obj/structure/table/woodentable/ebony,
@@ -214,16 +214,16 @@
 /obj/structure/bed/chair/wood/ebony{
 	dir = 4
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/general_store)
 "iC" = (
-/obj/structure/door/wood/ebony{
+/obj/structure/door/walnut{
 	dir = 4
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/general_store)
 "iH" = (
-/obj/structure/door/wood/ebony,
+/obj/structure/door/walnut,
 /obj/abstract/landmark/lock_preset/shaded_hills/inn_interior,
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/inn)
@@ -231,28 +231,28 @@
 /turf/wall/brick/basalt,
 /area/shaded_hills/outside/shrine)
 "iX" = (
-/turf/wall/log/ebony/shutter,
+/turf/wall/log/walnut/shutter,
 /area/shaded_hills/inn)
 "iZ" = (
 /obj/structure/fire_source/fireplace/basalt,
-/obj/item/stack/material/log/mapped/ebony/twenty,
+/obj/item/stack/material/log/mapped/walnut/twenty,
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/inn)
 "jf" = (
 /obj/structure/wall_sconce/lantern{
 	dir = 4
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/stable)
 "jk" = (
 /obj/structure/bed/chair/bench/pew/mahogany{
 	dir = 1
 	},
 /obj/abstract/landmark/start/shaded_hills/cleric,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "js" = (
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/stable)
 "jx" = (
 /obj/structure/reagent_dispensers/barrel/ebony,
@@ -270,7 +270,7 @@
 "jA" = (
 /obj/structure/bed/simple/ebony,
 /obj/item/bedsheet/furs,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/stable)
 "jI" = (
 /obj/structure/wall_sconce/lantern{
@@ -291,8 +291,8 @@
 /turf/floor/natural/dirt,
 /area/shaded_hills/outside/shrine)
 "kE" = (
-/obj/structure/door/wood/ebony,
-/turf/floor/wood/ebony,
+/obj/structure/door/walnut,
+/turf/floor/wood/walnut,
 /area/shaded_hills/stable)
 "lz" = (
 /obj/structure/table/woodentable_reinforced/ebony,
@@ -303,10 +303,10 @@
 /turf/unsimulated/dark_filler,
 /area/shaded_hills/outside/downlands)
 "lD" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 4
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn/porch)
 "lE" = (
 /obj/abstract/level_data_spawner/shaded_hills_downlands,
@@ -320,7 +320,7 @@
 	dir = 1
 	},
 /obj/abstract/landmark/start/shaded_hills/farmer,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "me" = (
 /obj/structure/reagent_dispensers/barrel/ebony,
@@ -336,13 +336,13 @@
 /turf/floor/natural/dirt,
 /area/shaded_hills/outside/downlands)
 "mG" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 4
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "nn" = (
-/turf/wall/log/ebony,
+/turf/wall/log/walnut,
 /area/shaded_hills/stable)
 "nN" = (
 /obj/structure/table/woodentable_reinforced/ebony,
@@ -350,7 +350,7 @@
 /turf/floor/natural/path/basalt,
 /area/shaded_hills/slaughterhouse)
 "ol" = (
-/obj/structure/railing/mapped/ebony,
+/obj/structure/railing/mapped/wooden/walnut,
 /turf/floor/natural/mud,
 /area/shaded_hills/outside/shrine)
 "or" = (
@@ -360,10 +360,10 @@
 /turf/floor/natural/path/basalt,
 /area/shaded_hills/stable)
 "oO" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 8
 	},
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 1
 	},
 /turf/floor/natural/grass,
@@ -372,7 +372,7 @@
 /obj/structure/bed/chair/bench/pew/mahogany{
 	dir = 1
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "pi" = (
 /obj/structure/table/woodentable/ebony,
@@ -383,13 +383,13 @@
 "qe" = (
 /obj/structure/bed/simple/ebony,
 /obj/abstract/landmark/start/shaded_hills/shrine_attendant,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "qf" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 8
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn/porch)
 "qG" = (
 /turf/wall/brick/basalt,
@@ -402,7 +402,7 @@
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/shrine)
 "qP" = (
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "qY" = (
 /turf/wall/brick/basalt,
@@ -411,7 +411,7 @@
 /obj/structure/table/woodentable/ebony,
 /obj/item/chems/glass/mortar,
 /obj/item/rock/basalt,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "rv" = (
 /obj/structure/table/woodentable/ebony,
@@ -423,33 +423,33 @@
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/inn)
 "ry" = (
-/obj/structure/railing/mapped/ebony,
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut,
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 4
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn/porch)
 "rO" = (
 /mob/living/simple_animal/fowl/chicken,
 /turf/floor/natural/grass,
 /area/shaded_hills/outside/downlands)
 "sJ" = (
-/obj/structure/door/wood/ebony,
+/obj/structure/door/walnut,
 /obj/abstract/landmark/lock_preset/shaded_hills/inn_interior,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn)
 "sM" = (
 /obj/structure/table/woodentable_reinforced/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/general_store)
 "th" = (
 /obj/structure/bed/simple/ebony/cloth,
 /obj/item/bedsheet/yellowed,
 /obj/abstract/landmark/start/shaded_hills/inn_worker,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn)
 "tq" = (
-/obj/structure/door/wood/ebony,
+/obj/structure/door/walnut,
 /turf/floor/natural/path/basalt,
 /area/shaded_hills/slaughterhouse)
 "tF" = (
@@ -462,27 +462,27 @@
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/inn)
 "tS" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 8
 	},
-/obj/structure/railing/mapped/ebony,
+/obj/structure/railing/mapped/wooden/walnut,
 /turf/floor/natural/grass,
 /area/shaded_hills/outside/downlands)
 "uu" = (
 /obj/structure/bed/simple/ebony,
 /obj/item/bedsheet/furs,
 /obj/abstract/landmark/start/shaded_hills/farmer,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "uA" = (
 /obj/structure/wall_sconce/lantern{
 	dir = 1;
 	pixel_y = 10
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "uJ" = (
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/general_store)
 "uK" = (
 /obj/structure/table/marble,
@@ -499,7 +499,7 @@
 	dir = 1;
 	pixel_y = 10
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "vA" = (
 /obj/structure/table/marble,
@@ -543,28 +543,28 @@
 /turf/wall/brick/basalt,
 /area/shaded_hills/slaughterhouse)
 "xU" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 4
 	},
 /turf/floor/natural/grass,
 /area/shaded_hills/outside/shrine)
 "xW" = (
-/obj/structure/reagent_dispensers/compost_bin,
+/obj/structure/reagent_dispensers/compost_bin/walnut,
 /turf/floor/natural/dirt,
 /area/shaded_hills/outside/downlands)
 "ya" = (
 /obj/structure/reagent_dispensers/barrel/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "yn" = (
 /obj/structure/bed/simple/ebony/cloth,
 /obj/item/bedsheet/yellowed,
 /obj/abstract/landmark/start/shaded_hills/innkeeper,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn)
 "yu" = (
 /obj/structure/reagent_dispensers/barrel/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/general_store)
 "yx" = (
 /obj/structure/table/marble,
@@ -578,11 +578,11 @@
 	dir = 1
 	},
 /obj/abstract/landmark/start/shaded_hills/farmer,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "yN" = (
 /obj/structure/closet/crate/chest/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "yY" = (
 /turf/floor/natural/grass,
@@ -598,10 +598,10 @@
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/inn)
 "zm" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 8
 	},
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 1
 	},
 /turf/floor/natural/grass,
@@ -615,10 +615,10 @@
 /area/shaded_hills/inn)
 "Aq" = (
 /obj/structure/textiles/loom/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "Aw" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 4
 	},
 /obj/structure/reagent_dispensers/barrel/ebony,
@@ -636,19 +636,19 @@
 /turf/floor/natural/mud/water,
 /area/shaded_hills/outside/downlands)
 "AE" = (
-/obj/structure/door/wood/ebony,
+/obj/structure/door/walnut,
 /turf/floor/natural/path/basalt,
 /area/shaded_hills/shrine)
 "AG" = (
 /obj/structure/table/woodentable/ebony,
 /obj/item/bag/sack,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "AX" = (
 /obj/structure/wall_sconce/lantern{
 	dir = 4
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "Br" = (
 /turf/floor/natural/path/basalt,
@@ -663,11 +663,11 @@
 /area/shaded_hills/outside/shrine)
 "BD" = (
 /obj/structure/reagent_dispensers/barrel/ebony/wine,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "BG" = (
 /obj/structure/bed/chair/bench/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn)
 "BI" = (
 /obj/abstract/map_data/shaded_hills,
@@ -676,32 +676,32 @@
 "BL" = (
 /obj/structure/bed/simple/ebony/cloth,
 /obj/item/bedsheet/yellowed,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/general_store)
 "CR" = (
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "Dn" = (
 /obj/structure/reagent_dispensers/barrel/ebony/oil,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/general_store)
 "Dt" = (
 /obj/structure/bed/simple/ebony/cloth,
 /obj/abstract/landmark/start/shaded_hills/shrine_keeper,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "Ee" = (
-/turf/wall/log/ebony,
+/turf/wall/log/walnut,
 /area/shaded_hills/inn)
 "Ep" = (
 /obj/structure/wall_sconce/lantern{
 	dir = 4
 	},
 /obj/structure/table/woodentable/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/general_store)
 "EJ" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 1
 	},
 /turf/floor/natural/grass,
@@ -729,7 +729,7 @@
 /area/shaded_hills/outside/downlands)
 "FE" = (
 /obj/structure/closet/cabinet/wooden/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "FH" = (
 /obj/structure/wall_sconce/lantern{
@@ -756,14 +756,14 @@
 /turf/floor/natural/path/basalt,
 /area/shaded_hills/outside/downlands)
 "Gs" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 8
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/general_store)
 "Gu" = (
 /obj/structure/fire_source/stove,
-/obj/item/stack/material/log/mapped/ebony/twenty,
+/obj/item/stack/material/log/mapped/walnut/twenty,
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/inn)
 "Gw" = (
@@ -776,7 +776,7 @@
 	dir = 1;
 	pixel_y = 10
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/general_store)
 "GW" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
@@ -793,11 +793,11 @@
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/inn)
 "HE" = (
-/turf/wall/log/ebony/shutter,
+/turf/wall/log/walnut/shutter,
 /area/shaded_hills/stable)
 "HF" = (
 /obj/structure/textiles/spinning_wheel/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "HI" = (
 /turf/floor/natural/grass,
@@ -806,29 +806,29 @@
 /turf/floor/natural/path/running_bond/basalt,
 /area/shaded_hills/outside/downlands)
 "Il" = (
-/obj/structure/door/wood/ebony{
+/obj/structure/door/walnut{
 	dir = 4
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "Im" = (
 /obj/structure/wall_sconce/lantern{
 	dir = 4
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn)
 "Iz" = (
 /obj/abstract/exterior_marker/inside,
 /turf/wall/brick/basalt,
 /area/shaded_hills/outside/downlands)
 "IL" = (
-/obj/structure/door/wood/ebony{
+/obj/structure/door/walnut{
 	dir = 4
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/tannery)
 "IQ" = (
-/turf/wall/log/ebony/shutter,
+/turf/wall/log/walnut/shutter,
 /area/shaded_hills/farmhouse)
 "IS" = (
 /turf/floor/natural/mud/water/deep,
@@ -844,26 +844,26 @@
 /area/shaded_hills/outside/shrine)
 "Jo" = (
 /obj/structure/wall_sconce/lantern,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn)
 "Jp" = (
 /obj/abstract/landmark/lock_preset/shaded_hills/inn_interior,
-/obj/structure/door/wood/ebony{
+/obj/structure/door/walnut{
 	dir = 4
 	},
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/inn)
 "Jt" = (
 /obj/structure/closet/cabinet/wooden/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "Jw" = (
 /obj/structure/bed/chair/wood/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn/porch)
 "Jz" = (
 /obj/structure/reagent_dispensers/barrel/ebony/water,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn)
 "JK" = (
 /obj/structure/table/woodentable_reinforced/mahogany,
@@ -877,8 +877,8 @@
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/shrine)
 "JU" = (
-/obj/structure/railing/mapped/ebony,
-/turf/floor/wood/ebony,
+/obj/structure/railing/mapped/wooden/walnut,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn/porch)
 "Ka" = (
 /mob/living/simple_animal/cow,
@@ -889,10 +889,10 @@
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/shrine)
 "Kh" = (
-/turf/wall/log/ebony/shutter,
+/turf/wall/log/walnut/shutter,
 /area/shaded_hills/shrine)
 "KG" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 8
 	},
 /turf/floor/natural/path/basalt,
@@ -903,16 +903,16 @@
 /turf/floor/natural/dirt,
 /area/shaded_hills/outside/downlands)
 "LK" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 4
 	},
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 1
 	},
 /turf/floor/natural/grass,
 /area/shaded_hills/outside/downlands)
 "LN" = (
-/turf/wall/log/ebony,
+/turf/wall/log/walnut,
 /area/shaded_hills/farmhouse)
 "Mb" = (
 /obj/abstract/landmark/start/shaded_hills/traveller/learned,
@@ -939,7 +939,7 @@
 "Ot" = (
 /obj/structure/table/woodentable/ebony,
 /obj/item/chems/cooking_vessel/pot,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "ON" = (
 /obj/structure/table/marble,
@@ -961,8 +961,8 @@
 /turf/floor/straw,
 /area/shaded_hills/stable)
 "PG" = (
-/obj/structure/door/wood/ebony,
-/turf/floor/wood/ebony,
+/obj/structure/door/walnut,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "PQ" = (
 /obj/structure/closet/crate/chest,
@@ -973,33 +973,33 @@
 /turf/floor/natural/path/basalt,
 /area/shaded_hills/slaughterhouse)
 "Qs" = (
-/obj/structure/door/wood/ebony,
+/obj/structure/door/walnut,
 /obj/abstract/landmark/lock_preset/shaded_hills/inn_exterior,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn)
 "QB" = (
-/turf/wall/log/ebony,
+/turf/wall/log/walnut,
 /area/shaded_hills/shrine)
 "QL" = (
 /obj/structure/bed/chair/wood/ebony{
 	dir = 1
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "QQ" = (
-/turf/wall/log/ebony,
+/turf/wall/log/walnut,
 /area/shaded_hills/tannery)
 "QS" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 4
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/general_store)
 "Rl" = (
 /turf/floor/natural/mud,
 /area/shaded_hills/outside/downlands)
 "RC" = (
-/obj/structure/railing/mapped/ebony,
+/obj/structure/railing/mapped/wooden/walnut,
 /turf/floor/natural/grass,
 /area/shaded_hills/outside/downlands)
 "RG" = (
@@ -1012,13 +1012,13 @@
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/inn)
 "Sf" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 8
 	},
 /turf/floor/natural/grass,
 /area/shaded_hills/outside/downlands)
 "Sj" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 4
 	},
 /obj/item/chems/glass/bucket/wood,
@@ -1026,14 +1026,14 @@
 /area/shaded_hills/outside/shrine)
 "Sy" = (
 /obj/structure/textiles/spinning_wheel/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "SF" = (
-/obj/structure/door/wood/ebony,
+/obj/structure/door/walnut,
 /turf/floor/natural/path/basalt,
 /area/shaded_hills/general_store)
 "SG" = (
-/obj/structure/door/wood/ebony,
+/obj/structure/door/walnut,
 /turf/floor/natural/path/basalt,
 /area/shaded_hills/stable)
 "SW" = (
@@ -1053,17 +1053,17 @@
 /obj/structure/bed/chair/wood/ebony{
 	dir = 8
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn)
 "Ti" = (
-/obj/structure/door/wood/ebony{
+/obj/structure/door/walnut{
 	dir = 4
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "Tr" = (
 /obj/structure/table/woodentable_reinforced/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn)
 "Ts" = (
 /obj/structure/wall_sconce/lantern,
@@ -1080,28 +1080,28 @@
 /obj/item/chems/food/grown/carrot,
 /obj/item/chems/food/grown/carrot,
 /obj/item/chems/food/grown/cabbage,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "TR" = (
 /turf/floor/natural/dirt,
 /area/shaded_hills/outside/downlands)
 "TZ" = (
-/obj/structure/door/wood/ebony,
+/obj/structure/door/walnut,
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/shrine)
 "UD" = (
 /obj/structure/table/woodentable/ebony,
 /obj/item/flame/candle,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "US" = (
 /obj/structure/bed/chair/wood/ebony{
 	dir = 4
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn)
 "UU" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 4
 	},
 /turf/floor/natural/path/basalt,
@@ -1111,19 +1111,19 @@
 /area/shaded_hills/shrine)
 "VE" = (
 /obj/structure/reagent_dispensers/barrel/ebony/beer,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "VM" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 4
 	},
 /turf/floor/natural/dirt,
 /area/shaded_hills/outside/shrine)
 "VU" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 8
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "VW" = (
 /obj/structure/table/marble,
@@ -1134,16 +1134,16 @@
 /turf/floor/natural/dirt,
 /area/shaded_hills/outside/downlands/poi)
 "Wg" = (
-/turf/wall/log/ebony,
+/turf/wall/log/walnut,
 /area/shaded_hills/general_store)
 "Wh" = (
 /obj/structure/table/woodentable/ebony,
 /obj/item/chems/glass/mortar,
 /obj/item/rock/basalt,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "Wk" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 8
 	},
 /turf/floor/straw,
@@ -1151,17 +1151,17 @@
 "Wl" = (
 /obj/structure/table/woodentable_reinforced/ebony,
 /obj/item/chems/glass/pottery/cup,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn)
 "Wm" = (
 /turf/unsimulated/mask,
 /area/shaded_hills/outside/downlands)
 "WD" = (
-/obj/structure/railing/mapped/ebony,
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut,
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 8
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn/porch)
 "WE" = (
 /obj/structure/reagent_dispensers/barrel/ebony,
@@ -1175,7 +1175,7 @@
 /obj/item/seeds/extracted/rice,
 /obj/item/seeds/extracted/potato,
 /obj/item/seeds/extracted/potato,
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 4
 	},
 /turf/floor/natural/mud,
@@ -1184,11 +1184,11 @@
 /obj/structure/wall_sconce/lantern{
 	dir = 8
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/general_store)
 "WO" = (
-/obj/structure/door/wood/ebony,
-/turf/floor/wood/ebony,
+/obj/structure/door/walnut,
+/turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "WV" = (
 /obj/structure/table/marble,
@@ -1199,7 +1199,7 @@
 "WY" = (
 /obj/structure/table/woodentable/ebony,
 /obj/structure/wall_sconce/lantern,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn)
 "Xr" = (
 /obj/structure/meat_hook,
@@ -1207,7 +1207,7 @@
 /area/shaded_hills/slaughterhouse)
 "XH" = (
 /obj/structure/fire_source/stove,
-/obj/item/stack/material/log/mapped/ebony/twenty,
+/obj/item/stack/material/log/mapped/walnut/twenty,
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/shrine)
 "XM" = (
@@ -1220,7 +1220,7 @@
 /turf/wall/brick/basalt,
 /area/shaded_hills/shrine)
 "Yg" = (
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn/porch)
 "Yp" = (
 /obj/structure/meat_hook,
@@ -1235,7 +1235,7 @@
 /obj/structure/wall_sconce/lantern{
 	dir = 4
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/general_store)
 "Zx" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
@@ -1247,7 +1247,7 @@
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/inn)
 "ZY" = (
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn)
 
 (1,1,1) = {"

--- a/maps/shaded_hills/shaded_hills-swamp.dmm
+++ b/maps/shaded_hills/shaded_hills-swamp.dmm
@@ -1,9 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aM" = (
-/turf/wall/log/ebony/shutter,
+/turf/wall/log/walnut/shutter,
 /area/shaded_hills/witch_hut)
 "bg" = (
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/witch_hut)
 "cE" = (
 /turf/floor/natural/mud/water,
@@ -12,7 +12,7 @@
 /obj/structure/bed/chair/wood/ebony{
 	dir = 8
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/witch_hut)
 "hT" = (
 /turf/floor/natural/mud/water/deep,
@@ -40,7 +40,7 @@
 /obj/structure/closet/crate/chest/ebony,
 /obj/item/rock/hematite,
 /obj/item/rock/flint,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/witch_hut)
 "oF" = (
 /turf/unsimulated/dark_filler,
@@ -50,7 +50,7 @@
 /area/shaded_hills/caves/swamp)
 "pl" = (
 /obj/structure/drying_rack,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/witch_hut)
 "rP" = (
 /obj/structure/reagent_dispensers/barrel/ebony/water,
@@ -70,7 +70,7 @@
 /obj/structure/wall_sconce/lantern{
 	dir = 8
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/witch_hut)
 "vZ" = (
 /turf/floor/natural/mud/water,
@@ -91,7 +91,7 @@
 /turf/floor/natural/mud,
 /area/shaded_hills/outside/river/swamp)
 "BF" = (
-/obj/structure/door/ebony,
+/obj/structure/door/walnut,
 /turf/floor/natural/path/basalt,
 /area/shaded_hills/witch_hut)
 "BY" = (
@@ -102,7 +102,7 @@
 /turf/unsimulated/dark_filler,
 /area/shaded_hills/caves/unexplored/swamp)
 "Ev" = (
-/turf/wall/log/ebony,
+/turf/wall/log/walnut,
 /area/shaded_hills/witch_hut)
 "EI" = (
 /turf/unsimulated/mask,
@@ -113,7 +113,7 @@
 /obj/item/chems/glass/pottery/cup,
 /obj/item/chems/glass/pottery/cup,
 /obj/item/chems/glass/bucket/wood,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/witch_hut)
 "Ic" = (
 /turf/floor/natural/clay,
@@ -132,11 +132,11 @@
 /obj/item/seeds/extracted/yarrow,
 /obj/item/seeds/extracted/yarrow,
 /obj/item/seeds/extracted/yarrow,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/witch_hut)
 "KA" = (
 /obj/abstract/landmark/start/shaded_hills/herbalist,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/witch_hut)
 "LF" = (
 /turf/wall/natural/basalt/shaded_hills,
@@ -149,8 +149,8 @@
 /turf/floor/natural/mud,
 /area/shaded_hills/outside/swamp)
 "SE" = (
-/obj/structure/door/ebony,
-/turf/floor/wood/ebony,
+/obj/structure/door/walnut,
+/turf/floor/wood/walnut,
 /area/shaded_hills/witch_hut)
 "Ty" = (
 /obj/abstract/landmark/start/shaded_hills/traveller,
@@ -164,7 +164,7 @@
 /area/shaded_hills/outside/swamp)
 "TR" = (
 /obj/structure/closet/crate/chest/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/witch_hut)
 "Vl" = (
 /obj/structure/table/woodentable/ebony,
@@ -173,7 +173,7 @@
 	},
 /obj/item/chems/glass/mortar,
 /obj/item/rock/basalt,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/witch_hut)
 "VA" = (
 /turf/wall/brick/basalt,
@@ -191,7 +191,7 @@
 /obj/structure/bed/simple/ebony,
 /obj/item/bedsheet/furs,
 /obj/abstract/landmark/start/shaded_hills/herbalist,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/witch_hut)
 
 (1,1,1) = {"

--- a/maps/shaded_hills/shaded_hills-woods.dmm
+++ b/maps/shaded_hills/shaded_hills-woods.dmm
@@ -10,10 +10,10 @@
 "cN" = (
 /obj/structure/table/woodentable/ebony,
 /obj/item/bladed/knife,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/forester_hut)
 "dp" = (
-/turf/wall/log/ebony,
+/turf/wall/log/walnut,
 /area/shaded_hills/outside/river/woods)
 "eJ" = (
 /obj/abstract/landmark/start/shaded_hills/forester,
@@ -42,7 +42,7 @@
 /turf/wall/natural/basalt/shaded_hills,
 /area/shaded_hills/caves/river/woods)
 "lb" = (
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/forester_hut)
 "lC" = (
 /turf/unsimulated/dark_filler,
@@ -54,7 +54,7 @@
 /turf/floor/natural/mud/water,
 /area/shaded_hills/outside/river/lake)
 "mo" = (
-/obj/structure/door/ebony,
+/obj/structure/door/walnut,
 /turf/floor/natural/path/basalt,
 /area/shaded_hills/forester_hut)
 "nl" = (
@@ -81,12 +81,12 @@
 "vw" = (
 /obj/structure/table/woodentable/ebony,
 /obj/item/stack/material/bundle/grass/dry,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/forester_hut)
 "wD" = (
 /obj/structure/table/woodentable/ebony,
 /obj/item/fishing_rod,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/forester_hut)
 "xn" = (
 /turf/unsimulated/mask,
@@ -104,8 +104,8 @@
 /turf/unsimulated/dark_filler,
 /area/shaded_hills/caves/unexplored/woods)
 "AN" = (
-/obj/structure/railing/mapped/ebony,
-/turf/floor/wood/ebony,
+/obj/structure/railing/mapped/wooden/walnut,
+/turf/floor/wood/walnut,
 /area/shaded_hills/outside/river/woods)
 "Co" = (
 /obj/abstract/landmark/start/shaded_hills/traveller/learned,
@@ -129,8 +129,8 @@
 /area/shaded_hills/caves/woods)
 "Fz" = (
 /obj/structure/fire_source/stove,
-/obj/item/stack/material/log/mapped/ebony/ten,
-/turf/floor/wood/ebony,
+/obj/item/stack/material/log/mapped/walnut/ten,
+/turf/floor/wood/walnut,
 /area/shaded_hills/forester_hut)
 "HA" = (
 /turf/floor/natural/grass,
@@ -142,17 +142,17 @@
 /obj/structure/bed/simple/ebony,
 /obj/item/bedsheet/furs,
 /obj/abstract/landmark/start/shaded_hills/forester,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/forester_hut)
 "JI" = (
-/obj/structure/railing/mapped/ebony{
+/obj/structure/railing/mapped/wooden/walnut{
 	dir = 1
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/outside/river/woods)
 "JJ" = (
 /obj/structure/meat_hook,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/forester_hut)
 "LJ" = (
 /turf/floor/natural/path/running_bond/basalt,
@@ -162,24 +162,24 @@
 /area/shaded_hills/outside/river/lake)
 "MR" = (
 /obj/structure/wall_sconce/lantern,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/forester_hut)
 "MU" = (
-/turf/wall/log/ebony/shutter,
+/turf/wall/log/walnut/shutter,
 /area/shaded_hills/forester_hut)
 "Oi" = (
 /obj/structure/closet/crate/chest/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/forester_hut)
 "PO" = (
 /turf/floor/natural/mud/water/deep,
 /area/shaded_hills/outside/river/woods)
 "SI" = (
-/turf/wall/log/ebony,
+/turf/wall/log/walnut,
 /area/shaded_hills/forester_hut)
 "TP" = (
 /obj/structure/table/woodentable/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/forester_hut)
 "VA" = (
 /obj/abstract/landmark/start/shaded_hills/traveller,

--- a/maps/shaded_hills/submaps/woods/hunter_camp/hunter_camp.dmm
+++ b/maps/shaded_hills/submaps/woods/hunter_camp/hunter_camp.dmm
@@ -34,7 +34,7 @@
 /area/shaded_hills/outside/point_of_interest/hunter_camp)
 "A" = (
 /obj/abstract/exterior_marker/inside,
-/turf/wall/log/ebony,
+/turf/wall/log/walnut,
 /area/shaded_hills/outside/point_of_interest/hunter_camp)
 "B" = (
 /obj/structure/flora/stump/tree/ebony,
@@ -77,7 +77,7 @@
 /area/shaded_hills/outside/point_of_interest/hunter_camp)
 "S" = (
 /obj/structure/fire_source/firepit/basalt,
-/obj/item/stack/material/log/mapped/ebony/fifteen,
+/obj/item/stack/material/log/mapped/walnut/fifteen,
 /turf/floor/natural/barren,
 /area/shaded_hills/outside/point_of_interest/hunter_camp)
 "U" = (

--- a/maps/shaded_hills/submaps/woods/old_cabin/old_cabin.dmm
+++ b/maps/shaded_hills/submaps/woods/old_cabin/old_cabin.dmm
@@ -1,8 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/structure/door/ebony,
+/obj/structure/door/walnut,
 /obj/abstract/exterior_marker/inside,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/outside/point_of_interest/old_cabin)
 "h" = (
 /turf/template_noop,
@@ -13,17 +13,17 @@
 "k" = (
 /obj/structure/closet/crate/chest/ebony,
 /obj/abstract/exterior_marker/inside,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/outside/point_of_interest/old_cabin)
 "o" = (
 /obj/structure/drying_rack/ebony,
 /obj/abstract/exterior_marker/inside,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/outside/point_of_interest/old_cabin)
 "u" = (
 /obj/structure/reagent_dispensers/barrel/ebony/beer,
 /obj/abstract/exterior_marker/inside,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/outside/point_of_interest/old_cabin)
 "x" = (
 /obj/structure/table/woodentable/ebony,
@@ -32,7 +32,7 @@
 /obj/item/rock/flint,
 /obj/item/rock/hematite,
 /obj/abstract/exterior_marker/inside,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/outside/point_of_interest/old_cabin)
 "z" = (
 /obj/effect/spider/spiderling/mundane,
@@ -41,19 +41,19 @@
 	dir = 1
 	},
 /obj/abstract/exterior_marker/inside,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/outside/point_of_interest/old_cabin)
 "B" = (
 /obj/effect/decal/cleanable/blood,
 /obj/abstract/exterior_marker/inside,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/outside/point_of_interest/old_cabin)
 "D" = (
 /obj/effect/spider/spiderling/mundane,
 /obj/structure/table/woodentable/ebony,
 /obj/item/chems/food/grown/carrot,
 /obj/abstract/exterior_marker/inside,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/outside/point_of_interest/old_cabin)
 "H" = (
 /obj/structure/table/woodentable/ebony,
@@ -62,25 +62,25 @@
 /obj/item/chems/food/grown/potato,
 /obj/item/chems/food/grown/carrot,
 /obj/abstract/exterior_marker/inside,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/outside/point_of_interest/old_cabin)
 "I" = (
 /obj/abstract/exterior_marker/inside,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/outside/point_of_interest/old_cabin)
 "L" = (
 /obj/effect/spider/spiderling/mundane,
 /obj/abstract/exterior_marker/inside,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/outside/point_of_interest/old_cabin)
 "M" = (
 /obj/abstract/exterior_marker/inside,
-/turf/wall/log/ebony,
+/turf/wall/log/walnut,
 /area/shaded_hills/outside/point_of_interest/old_cabin)
 "N" = (
 /obj/structure/coatrack,
 /obj/abstract/exterior_marker/inside,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/outside/point_of_interest/old_cabin)
 "S" = (
 /obj/structure/wall_sconce/torch{
@@ -95,7 +95,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/random/jewelry,
 /obj/abstract/exterior_marker/inside,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/shaded_hills/outside/point_of_interest/old_cabin)
 
 (1,1,1) = {"

--- a/maps/shaded_hills/submaps/woods/suspicious_cabin/suspicious_cabin.dmm
+++ b/maps/shaded_hills/submaps/woods/suspicious_cabin/suspicious_cabin.dmm
@@ -6,18 +6,18 @@
 /obj/structure/bed/chair/wood/ebony{
 	dir = 1
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/template_noop)
 "e" = (
 /obj/structure/bed/simple/ebony/cloth,
 /obj/item/bedsheet/furs,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/template_noop)
 "f" = (
 /turf/floor/natural/dirt,
 /area/template_noop)
 "g" = (
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/template_noop)
 "i" = (
 /obj/structure/reagent_dispensers/barrel/ebony/wine,
@@ -25,18 +25,18 @@
 /area/template_noop)
 "k" = (
 /obj/structure/coatrack,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/template_noop)
 "q" = (
 /obj/structure/table/woodentable/ebony,
 /obj/item/chems/glass/pottery/cup,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/template_noop)
 "r" = (
 /obj/structure/bed/chair/bench/ebony{
 	dir = 4
 	},
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/template_noop)
 "s" = (
 /turf/floor/natural/path/basalt,
@@ -47,17 +47,15 @@
 /turf/floor/natural/path/basalt,
 /area/template_noop)
 "v" = (
-/obj/structure/window/basic/full,
-/obj/structure/wall_frame/log/ebony,
-/turf/floor/natural/path/basalt,
+/turf/wall/log/walnut/shutter,
 /area/template_noop)
 "w" = (
 /obj/structure/bed/chair/wood/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/template_noop)
 "x" = (
-/obj/structure/door/ebony,
-/turf/floor/wood/ebony,
+/obj/structure/door/walnut,
+/turf/floor/wood/walnut,
 /area/template_noop)
 "y" = (
 /obj/structure/reagent_dispensers/barrel/ebony,
@@ -65,15 +63,15 @@
 /area/template_noop)
 "A" = (
 /obj/structure/closet/crate/chest/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/template_noop)
 "E" = (
 /obj/structure/table/woodentable/ebony,
 /obj/item/chems/glass/pottery/teapot,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/template_noop)
 "G" = (
-/obj/item/stack/material/log/mapped/ebony/twenty,
+/obj/item/stack/material/log/mapped/walnut/twenty,
 /turf/floor/natural/path/basalt,
 /area/template_noop)
 "J" = (
@@ -82,8 +80,11 @@
 /obj/item/chems/cooking_vessel/pot,
 /turf/floor/natural/path/basalt,
 /area/template_noop)
+"K" = (
+/turf/wall/brick/basalt/shutter,
+/area/template_noop)
 "M" = (
-/obj/structure/door/ebony,
+/obj/structure/door/walnut,
 /turf/floor/natural/path,
 /area/template_noop)
 "N" = (
@@ -97,7 +98,7 @@
 /area/template_noop)
 "P" = (
 /obj/structure/bed/chair/bench/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/template_noop)
 "Q" = (
 /obj/structure/reagent_dispensers/barrel/ebony/beer,
@@ -105,7 +106,7 @@
 /area/template_noop)
 "R" = (
 /obj/structure/table/woodentable/ebony,
-/turf/floor/wood/ebony,
+/turf/floor/wood/walnut,
 /area/template_noop)
 "S" = (
 /obj/structure/table/woodentable/ebony,
@@ -122,7 +123,7 @@
 /turf/wall/brick/basalt,
 /area/template_noop)
 "Y" = (
-/turf/wall/log/ebony,
+/turf/wall/log/walnut,
 /area/template_noop)
 
 (1,1,1) = {"
@@ -149,7 +150,7 @@ f
 X
 X
 X
-X
+K
 X
 X
 X

--- a/tools/map_migrations/4154_railing.txt
+++ b/tools/map_migrations/4154_railing.txt
@@ -1,0 +1,1 @@
+/obj/structure/railing/mapped/ebony : /obj/structure/railing/mapped/wooden/ebony{@OLD}

--- a/tools/map_migrations/4154_wood_doors.txt
+++ b/tools/map_migrations/4154_wood_doors.txt
@@ -1,0 +1,2 @@
+/obj/structure/door/wood/ebony : /obj/structure/door/ebony{@OLD}
+/obj/structure/door/wood/walnut : /obj/structure/door/walnut{@OLD}


### PR DESCRIPTION
## Description of changes
- Consolidates some wooden door types to reduce duplication.
- Fixes a blank tool entry when examining certain bladed tools.
- Adds wood type variants of railings, and ebony/walnut compost bins.
- Reduces the lantern max fuel amount to 60, but reduces fuel consumption to 1/3 of the current amount. This means that it'll last an hour from full to empty.
- Makes wall sconces start off unlit, so that the lights don't all go out at once 40 minutes in. It can be changed per sconce, for mapping flexibility.
- Replaces non-furniture uses of ebony on Shaded Hills with walnut. This was supposed to be done a while back but I kept forgetting to include the mapping commit.

## Why and what will this PR improve
Makes lanterns less of a pain to deal with.
Fixes compost bins being generic wood.
Adds more wood variants of objects and removes duplicate ones.
Makes the map less oppressively dark.

## Authorship
Me.

## Changelog
:cl:
tweak: Ebony walls, floors, doors, and railings on Shaded Hills have all been replaced with walnut variants.
tweak: Most wall sconces now start unlit.
balance: A full lantern now burns for an hour, but only holds 60 units of fuel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->