### PR TITLE
Fix wineskin not filling with wine

### DIFF
--- a/code/game/objects/items/waterskin.dm
+++ b/code/game/objects/items/waterskin.dm
@@ -17,4 +17,4 @@
 
 /obj/item/chems/waterskin/crafted/wine/populate_reagents()
 	. = ..()
-	add_to_reagents(/decl/material/liquid/ethanol/wine, reagents?.total_volume)
+	add_to_reagents(/decl/material/liquid/ethanol/wine, reagents?.maximum_volume)


### PR DESCRIPTION
## Description of changes
Changes `reagents?.total_volume` to be `reagents?.maximum_volume` instead.

## Why and what will this PR improve
The wineskin will now fill with wine. Fixes #4155.