### PR TITLE
Replace a number of hooks with observation decls, remove deprecated hooks

### DIFF
--- a/code/_helpers/auxtools.dm
+++ b/code/_helpers/auxtools.dm
@@ -9,13 +9,21 @@ var/global/auxtools_debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
 /proc/enable_debugging(mode, port)
 	CRASH("auxtools not loaded")
 
-/hook/startup/proc/auxtools_init()
+/world/New()
+	auxtools_init()
+	return ..()
+
+/world/proc/auxtools_init()
 	if (global.auxtools_debug_server)
 		call_ext(global.auxtools_debug_server, "auxtools_init")()
 		enable_debugging()
 	return TRUE
 
-/hook/shutdown/proc/auxtools_shutdown()
+/world/Del()
+	auxtools_shutdown()
+	return ..()
+
+/world/proc/auxtools_shutdown()
 	if (global.auxtools_debug_server)
 		call_ext(global.auxtools_debug_server, "auxtools_shutdown")()
 	return TRUE

--- a/code/controllers/hooks-defs.dm
+++ b/code/controllers/hooks-defs.dm
@@ -76,16 +76,3 @@
  */
 /hook/change_account_status
 
-/**
- * Employee reassignment hook.
- * Called in card.dm when someone's card is reassigned at the HoP's desk.
- * Parameters: var/obj/item/card/id
- */
-/hook/reassign_employee
-
-/**
- * Employee terminated hook.
- * Called in card.dm when someone's card is terminated at the HoP's desk.
- * Parameters: var/obj/item/card/id
- */
-/hook/terminate_employee

--- a/code/controllers/hooks-defs.dm
+++ b/code/controllers/hooks-defs.dm
@@ -55,9 +55,3 @@
  */
 /hook/debrain
 
-/**
- * Borged hook.
- * Called in robot_parts.dm when someone gets turned into a cyborg.
- * Parameters: var/mob/living/silicon/robot
- */
-/hook/borgify

--- a/code/controllers/hooks-defs.dm
+++ b/code/controllers/hooks-defs.dm
@@ -33,10 +33,3 @@
  * Called in world.dm prior to the parent call in world/Reboot.
  */
 /hook/reboot
-
-/**
- * Death hook.
- * Called in death.dm when someone dies.
- * Parameters: var/mob/living/human, var/gibbed
- */
-/hook/death

--- a/code/controllers/hooks-defs.dm
+++ b/code/controllers/hooks-defs.dm
@@ -47,11 +47,3 @@
  * Parameters: var/mob/living/human
  */
 /hook/clone
-
-/**
- * Debrained hook.
- * Called in brain_item.dm when someone gets debrained.
- * Parameters: var/obj/item/organ/internal/brain
- */
-/hook/debrain
-

--- a/code/controllers/hooks-defs.dm
+++ b/code/controllers/hooks-defs.dm
@@ -40,10 +40,3 @@
  * Parameters: var/mob/living/human, var/gibbed
  */
 /hook/death
-
-/**
- * Cloning hook.
- * Called in cloning.dm when someone is brought back by the wonders of modern science.
- * Parameters: var/mob/living/human
- */
-/hook/clone

--- a/code/controllers/hooks-defs.dm
+++ b/code/controllers/hooks-defs.dm
@@ -61,18 +61,3 @@
  * Parameters: var/mob/living/silicon/robot
  */
 /hook/borgify
-
-/**
- * Payroll revoked hook.
- * Called in Accounts_DB.dm when someone's payroll is stolen at the Accounts terminal.
- * Parameters: var/datum/money_account
- */
-/hook/revoke_payroll
-
-/**
- * Account suspension hook.
- * Called in Accounts_DB.dm when someone's account is suspended or unsuspended at the Accounts terminal.
- * Parameters: var/datum/money_account
- */
-/hook/change_account_status
-

--- a/code/controllers/hooks-defs.dm
+++ b/code/controllers/hooks-defs.dm
@@ -89,10 +89,3 @@
  * Parameters: var/obj/item/card/id
  */
 /hook/terminate_employee
-
-/**
- * Crate sold hook.
- * Called in supplyshuttle.dm when a crate is sold on the shuttle.
- * Parameters: var/obj/structure/closet/crate/sold, var/area/shuttle
- */
-/hook/sell_crate

--- a/code/controllers/hooks-defs.dm
+++ b/code/controllers/hooks-defs.dm
@@ -103,10 +103,3 @@
  * Parameters: var/datum/job/job, var/mob/living/character
  */
 /hook/player_latejoin
-
-/**
- * Submap join hook.
- * Called in submap_join.dm when a player joins a submap.
- * Parameters: var/datum/submap/submap, var/datum/job/job, var/mob/living/character
- */
-/hook/submap_join

--- a/code/controllers/hooks-defs.dm
+++ b/code/controllers/hooks-defs.dm
@@ -96,10 +96,3 @@
  * Parameters: var/obj/structure/closet/crate/sold, var/area/shuttle
  */
 /hook/sell_crate
-
-/**
- * Player latejoin hook.
- * Called in new_player.dm when a player joins the round after it has started.
- * Parameters: var/datum/job/job, var/mob/living/character
- */
-/hook/player_latejoin

--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -84,9 +84,9 @@ SUBSYSTEM_DEF(supply)
 		for(var/atom/movable/AM in subarea)
 			if(AM.anchored)
 				continue
-			if(istype(AM, /obj/structure/closet/crate/))
+			if(istype(AM, /obj/structure/closet/crate))
 				var/obj/structure/closet/crate/CR = AM
-				callHook("sell_crate", list(CR, subarea))
+				RAISE_EVENT(/decl/observ/crate_sold, subarea, CR)
 				add_points_from_source(CR.get_single_monetary_worth() * crate_return_rebate * 0.1, "crate")
 				var/find_slip = 1
 

--- a/code/datums/observation/crate_sold.dm
+++ b/code/datums/observation/crate_sold.dm
@@ -1,0 +1,11 @@
+//	Observer Pattern Implementation: Crate Sold
+//		Registration type: /area
+//
+//		Raised when: A crate is sold on the shuttle.
+//
+//		Arguments that the called proc should expect:
+//			/area/shuttle: The shuttle the crate was sold on.
+//			/obj/structure/closet/crate/sold: The crate that was sold.
+
+/decl/observ/crate_sold
+	name = "Crate Sold"

--- a/code/datums/observation/cyborg_created.dm
+++ b/code/datums/observation/cyborg_created.dm
@@ -1,0 +1,10 @@
+/**
+ * Observer Pattern Implementation: Cyborg Created
+ *
+ * Raised when: A cyborg is created.
+ *
+ * Arguments that the called proc should expect:
+ *     /mob/living/silicon/robot: The cyborg that was created.
+ */
+/decl/observ/cyborg_created
+	name = "Cyborg Created"

--- a/code/datums/observation/debrain.dm
+++ b/code/datums/observation/debrain.dm
@@ -1,0 +1,13 @@
+/**
+ * Observer Pattern Implementation: Debrained
+ *
+ * Raised when: A brainmob is created by the removal of a brain.
+ *
+ * Arguments that the called proc should expect:
+ *     /mob/living/brainmob: The brainmob that was created.
+ *     /obj/item/organ/internal/brain: The brain that was removed.
+ *     /mob/living/owner: The mob the brain was formerly installed in.
+ */
+/decl/observ/debrain
+	name = "Debrained"
+	expected_type = /mob/living

--- a/code/datums/observation/employee_id.dm
+++ b/code/datums/observation/employee_id.dm
@@ -1,0 +1,22 @@
+/**
+ * Observer Pattern Implementation: Employee ID Reassigned
+ *
+ * Raised when: A card's assignment is changed in the ID card modification program.
+ *
+ * Arguments that the called proc should expect:
+ *     /obj/item/card/id: The card that was reassigned.
+ */
+/decl/observ/employee_id_reassigned
+	name = "Employee ID Reassigned"
+
+//	Observer Pattern Implementation: Employee ID Terminated
+//		Registration type: /obj/item/card/id
+//
+//		Raised when: A card is terminated in the ID card modification program.
+//
+//		Arguments that the called proc should expect:
+//			/area/shuttle: The shuttle the crate was sold on.
+//			/obj/structure/closet/crate/sold: The crate that was sold.
+
+/decl/observ/employee_id_terminated
+	name = "Employee ID Terminated"

--- a/code/datums/observation/money_accounts.dm
+++ b/code/datums/observation/money_accounts.dm
@@ -1,0 +1,22 @@
+
+/**
+ * Observer Pattern Implementation: Payroll Revoked
+ *
+ * Raised when: Someone's payroll is stolen at the Accounts terminal.
+ *
+ * Arguments that the called proc should expect:
+ *     /datum/money_account: The account whose payroll was revoked.
+ */
+/decl/observ/revoke_payroll
+	name = "Payroll Revoked"
+
+/**
+ * Observer Pattern Implementation: Account Status Changed
+ *
+ * Raised when: Someone's account is suspended or unsuspended at the Accounts terminal.
+ *
+ * Arguments that the called proc should expect:
+ *     /datum/money_account: The account whose status was changed.
+ */
+/decl/observ/change_account_status
+	name = "Account Status Changed"

--- a/code/datums/observation/player_latejoin.dm
+++ b/code/datums/observation/player_latejoin.dm
@@ -1,0 +1,11 @@
+//	Observer Pattern Implementation: Player Latejoin
+//		Registration type: /mob/living
+//
+//		Raised when: A player joins the round after it has started.
+//
+//		Arguments that the called proc should expect:
+//			/mob/living/character: The mob that joined the round.
+//			/datum/job/job: The job the mob joined as.
+
+/decl/observ/player_latejoin
+	name = "Player Latejoin"

--- a/code/datums/observation/submap_join.dm
+++ b/code/datums/observation/submap_join.dm
@@ -1,0 +1,13 @@
+//	Observer Pattern Implementation: Submap Join
+//		Registration type: /datum/submap
+//
+//		Raised when: A mob joins on a submap
+//
+//		Arguments that the called proc should expect:
+//			/datum/submap/submap: The submap the mob joined.
+//			/mob/joiner: The mob that joined the submap.
+//			/datum/job/job: The job the mob joined as.
+
+/decl/observ/submap_join
+	name = "Submap Joined"
+	expected_type = /datum/submap

--- a/code/game/objects/items/robot/robot_frame.dm
+++ b/code/game/objects/items/robot/robot_frame.dm
@@ -128,7 +128,7 @@
 			cell_component.installed = 1
 
 		SSstatistics.add_field("cyborg_birth",1)
-		callHook("borgify", list(O))
+		RAISE_EVENT(/decl/observ/cyborg_created, O)
 		O.Namepick()
 		qdel(src)
 

--- a/code/modules/economy/cael/Accounts_DB.dm
+++ b/code/modules/economy/cael/Accounts_DB.dm
@@ -99,7 +99,7 @@
 			if("toggle_suspension")
 				if(detailed_account_view)
 					detailed_account_view.suspended = !detailed_account_view.suspended
-					callHook("change_account_status", list(detailed_account_view))
+					RAISE_EVENT(/decl/observ/change_account_status, detailed_account_view)
 
 			if("finalise_create_account")
 				var/account_name = href_list["holder_name"]
@@ -149,7 +149,7 @@
 				var/funds = detailed_account_view.money
 				detailed_account_view.transfer(station_account, funds, "Revocation of payroll")
 
-				callHook("revoke_payroll", list(detailed_account_view))
+				RAISE_EVENT(/decl/observ/revoke_payroll, detailed_account_view)
 
 			if("print")
 

--- a/code/modules/mob/living/human/death.dm
+++ b/code/modules/mob/living/human/death.dm
@@ -29,7 +29,6 @@
 	BITSET(hud_updateflag, LIFE_HUD)
 
 	//Handle species-specific deaths.
-	callHook("death", list(src, gibbed))
 	handle_hud_list()
 	if(!gibbed)
 		animate_tail_stop()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -241,7 +241,7 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 		else if(spawnpoint.spawn_announcement)
 			AnnounceCyborg(character, job, spawnpoint.spawn_announcement)
 
-	callHook("player_latejoin", list(job, character))
+	RAISE_EVENT(/decl/observ/player_latejoin, character, job)
 	log_and_message_admins("has joined the round as [character.mind.assigned_role].", character)
 
 	qdel(src)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -135,7 +135,7 @@
 
 	O.dropInto(loc)
 	O.job = ASSIGNMENT_ROBOT
-	callHook("borgify", list(O))
+	RAISE_EVENT(/decl/observ/cyborg_created, O)
 	O.Namepick()
 
 	qdel(src) // Queues us for a hard delete

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -198,7 +198,7 @@
 			if(computer)
 				id_card.assignment = "Terminated"
 				remove_nt_access(id_card)
-				callHook("terminate_employee", list(id_card))
+				RAISE_EVENT(/decl/observ/employee_id_terminated, id_card)
 		if("edit")
 			if(!(get_file_perms(module.get_access(user), user) & OS_WRITE_ACCESS))
 				to_chat(usr, SPAN_WARNING("Access denied."))
@@ -296,7 +296,7 @@
 					id_card.assignment = t1
 					id_card.position = t1
 
-				callHook("reassign_employee", list(id_card))
+				RAISE_EVENT(/decl/observ/employee_id_reassigned, id_card)
 		if("access")
 			if(href_list["allowed"] && id_card)
 				var/access_type = href_list["access_target"]

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -279,7 +279,7 @@
 			brainmob.languages = M.languages?.Copy()
 			brainmob.default_language = M.default_language
 			to_chat(brainmob, SPAN_NOTICE("You feel slightly disoriented. That's normal when you're just \a [initial(src.name)]."))
-			callHook("debrain", list(brainmob))
+			RAISE_EVENT(/decl/observ/debrain, brainmob, src, M)
 		return TRUE
 	return FALSE
 

--- a/code/modules/submaps/submap_join.dm
+++ b/code/modules/submaps/submap_join.dm
@@ -111,7 +111,7 @@
 		SSticker.mode.handle_offsite_latejoin(character)
 		global.universe.OnPlayerLatejoin(character)
 		log_and_message_admins("has joined the round as offsite role [character.mind.assigned_role].", character)
-		callHook("submap_join", list(job, character))
+		RAISE_EVENT(/decl/observ/submap_join, src, character, job)
 		if(character.cannot_stand()) equip_wheelchair(character)
 		job.post_equip_job_title(character, job.title)
 		qdel(joining)

--- a/mods/content/matchmaking/matchmaker.dm
+++ b/mods/content/matchmaking/matchmaker.dm
@@ -4,10 +4,14 @@ var/global/datum/matchmaker/matchmaker = new()
 	matchmaker.do_matchmaking()
 	return TRUE
 
-/hook/player_latejoin/proc/matchmaking(var/datum/job/job, var/mob/living/character)
+/datum/matchmaker/matchmaker/New()
+	. = ..()
+	events_repository.register_global(/decl/observ/player_latejoin, src, PROC_REF(matchmake_latejoiner))
+
+/datum/matchmaker/proc/matchmake_latejoiner(mob/living/character, datum/job/job)
 	if(character.mind && character.client?.prefs.relations.len)
 		for(var/T in character.client.prefs.relations)
-			var/TT = matchmaker.relation_types[T]
+			var/TT = relation_types[T]
 			var/datum/relation/R = new TT
 			R.holder = character.mind
 			R.info = character.client.prefs.relations_info[T]
@@ -16,7 +20,7 @@ var/global/datum/matchmaker/matchmaker = new()
 		return TRUE
 	if(!job.create_record)
 		return TRUE
-	matchmaker.do_matchmaking()
+	do_matchmaking()
 	return TRUE
 
 /datum/mind

--- a/nebula.dme
+++ b/nebula.dme
@@ -565,6 +565,7 @@
 #include "code\datums\observation\shuttle_moved.dm"
 #include "code\datums\observation\sight_set.dm"
 #include "code\datums\observation\stat_set.dm"
+#include "code\datums\observation\submap_join.dm"
 #include "code\datums\observation\unequipped.dm"
 #include "code\datums\observation\updated_icon.dm"
 #include "code\datums\observation\zone_selected.dm"

--- a/nebula.dme
+++ b/nebula.dme
@@ -546,6 +546,7 @@
 #include "code\datums\observation\destroyed.dm"
 #include "code\datums\observation\dir_set.dm"
 #include "code\datums\observation\dismembered.dm"
+#include "code\datums\observation\employee_id.dm"
 #include "code\datums\observation\entered.dm"
 #include "code\datums\observation\equipped.dm"
 #include "code\datums\observation\examine.dm"

--- a/nebula.dme
+++ b/nebula.dme
@@ -556,6 +556,7 @@
 #include "code\datums\observation\life.dm"
 #include "code\datums\observation\logged_in.dm"
 #include "code\datums\observation\logged_out.dm"
+#include "code\datums\observation\money_accounts.dm"
 #include "code\datums\observation\moved.dm"
 #include "code\datums\observation\name_set.dm"
 #include "code\datums\observation\observation.dm"

--- a/nebula.dme
+++ b/nebula.dme
@@ -558,6 +558,7 @@
 #include "code\datums\observation\name_set.dm"
 #include "code\datums\observation\observation.dm"
 #include "code\datums\observation\opacity_set.dm"
+#include "code\datums\observation\player_latejoin.dm"
 #include "code\datums\observation\see_in_dark_set.dm"
 #include "code\datums\observation\see_invisible_set.dm"
 #include "code\datums\observation\set_invisibility.dm"

--- a/nebula.dme
+++ b/nebula.dme
@@ -540,6 +540,7 @@
 #include "code\datums\music_tracks\wake.dm"
 #include "code\datums\observation\_defines.dm"
 #include "code\datums\observation\area_power_change.dm"
+#include "code\datums\observation\crate_sold.dm"
 #include "code\datums\observation\death.dm"
 #include "code\datums\observation\density_set.dm"
 #include "code\datums\observation\destroyed.dm"

--- a/nebula.dme
+++ b/nebula.dme
@@ -543,6 +543,7 @@
 #include "code\datums\observation\crate_sold.dm"
 #include "code\datums\observation\cyborg_created.dm"
 #include "code\datums\observation\death.dm"
+#include "code\datums\observation\debrain.dm"
 #include "code\datums\observation\density_set.dm"
 #include "code\datums\observation\destroyed.dm"
 #include "code\datums\observation\dir_set.dm"

--- a/nebula.dme
+++ b/nebula.dme
@@ -541,6 +541,7 @@
 #include "code\datums\observation\_defines.dm"
 #include "code\datums\observation\area_power_change.dm"
 #include "code\datums\observation\crate_sold.dm"
+#include "code\datums\observation\cyborg_created.dm"
 #include "code\datums\observation\death.dm"
 #include "code\datums\observation\density_set.dm"
 #include "code\datums\observation\destroyed.dm"

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -24,7 +24,7 @@ exactly() { # exactly N name search [mode] [filter]
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 # Additional exception August 2020: \b is a regex symbol as well as a BYOND macro.
 exactly 1 "escapes" '\\\\(red|blue|green|black|b|i[^mc])'
-exactly 5 "Del()s" '\WDel\('
+exactly 6 "Del()s" '\WDel\('
 exactly 2 "/atom text paths" '"/atom'
 exactly 2 "/area text paths" '"/area'
 exactly 2 "/datum text paths" '"/datum'


### PR DESCRIPTION
## Description of changes
Replaces `/hook/submap_join`, `/hook/player_latejoin`, `/hook/sell_crate`, `/hook/terminate_employee`, `/hook/reassign_employee`, `/hook/change_account_status`, `/hook/revoke_payroll`, `/hook/borgify`, and `/hook/debrain` with corresponding observation decls.
Removes `/hook/death` because it handled on-species death effects which are now handled elsewhere.
Removes `/hook/clone` because we don't have cloning.
Makes auxtools debugging not use hooks.

## Why and what will this PR improve
Hooks are an old and gross system and I want to deprecate them in favour of observation events. hooks-def.dm was one of the oldest files in our codebase before this.