### PR TITLE
Replace a bunch of single- and double-letter variable names with more descriptive terms

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -169,6 +169,7 @@
 #define SPAN_PINK(X)     SPAN_CLASS("font_pink",     X)
 #define SPAN_PALEPINK(X) SPAN_CLASS("font_palepink", X)
 #define SPAN_SINISTER(X) SPAN_CLASS("sinister", X)
+#define SPAN_MODERATE(X) SPAN_CLASS("moderate", X)
 // placeholders
 #define SPAN_GOOD(X)     SPAN_GREEN(X)
 #define SPAN_NEUTRAL(X)  SPAN_BLUE(X)

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -39,8 +39,7 @@
 // Receive a mouse drop.
 // Returns false if the atom is valid for dropping further up the chain, true if the drop has been handled.
 /atom/proc/receive_mouse_drop(atom/dropping, mob/user, params)
-	var/mob/living/H = user
-	if(istype(H) && !H.anchored && can_climb(H) && dropping == user)
+	if(isliving(user) && !user.anchored && can_climb(user) && dropping == user)
 		do_climb(dropping)
 		return TRUE
 	return FALSE

--- a/code/datums/hostility/hostility.dm
+++ b/code/datums/hostility/hostility.dm
@@ -12,13 +12,13 @@
 		return FALSE
 
 	if(isliving(target))
-		var/mob/living/L = target
-		if(L.stat)
+		var/mob/living/target_mob = target
+		if(target_mob.stat)
 			return FALSE
 
 		if(isliving(holder))
-			var/mob/living/H = holder
-			if(L.faction == H.faction)
+			var/mob/holder_mob = holder
+			if(target_mob.faction == holder_mob.faction)
 				return FALSE
 
 	return can_special_target(holder, target)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -961,24 +961,24 @@ var/global/BSACooldown = 0
 /proc/is_special_character(var/character) // returns 1 for special characters and 2 for heroes of gamemode
 	if(!SSticker.mode)
 		return 0
-	var/datum/mind/M
+	var/datum/mind/mind
 	if (ismob(character))
-		var/mob/C = character
-		M = C.mind
+		var/mob/character_mob = character
+		mind = character_mob.mind
 	else if(istype(character, /datum/mind))
-		M = character
+		mind = character
 
-	if(M)
+	if(mind)
 		if(SSticker.mode.antag_templates && SSticker.mode.antag_templates.len)
 			for(var/decl/special_role/antag in SSticker.mode.antag_templates)
-				if(antag.is_antagonist(M))
+				if(antag.is_antagonist(mind))
 					return 2
-		if(M.assigned_special_role)
+		if(mind.assigned_special_role)
 			return 1
 
 	if(isrobot(character))
-		var/mob/living/silicon/robot/R = character
-		if(R.emagged)
+		var/mob/living/silicon/robot/robot = character
+		if(robot.emagged)
 			return 1
 
 	return 0

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -10,255 +10,255 @@
 	else if(href_list["rename"])
 		if(!check_rights(R_VAREDIT))	return
 
-		var/mob/M = locate(href_list["rename"])
-		if(!istype(M))
+		var/mob/victim = locate(href_list["rename"])
+		if(!istype(victim))
 			to_chat(usr, "This can only be used on instances of type /mob")
 			return
 
-		var/new_name = sanitize(input(usr,"What would you like to name this mob?","Input a name",M.real_name) as text|null, MAX_NAME_LEN)
-		if(!new_name || !M)	return
+		var/new_name = sanitize(input(usr,"What would you like to name this mob?","Input a name",victim.real_name) as text|null, MAX_NAME_LEN)
+		if(!new_name || !victim)	return
 
-		message_admins("Admin [key_name_admin(usr)] renamed [key_name_admin(M)] to [new_name].")
-		M.fully_replace_character_name(new_name)
+		message_admins("Admin [key_name_admin(usr)] renamed [key_name_admin(victim)] to [new_name].")
+		victim.fully_replace_character_name(new_name)
 		href_list["datumrefresh"] = href_list["rename"]
 
 	else if(href_list["dressup"])
 		if(!check_rights(R_VAREDIT))	return
 
-		var/mob/living/human/H = locate(href_list["dressup"])
-		if(!istype(H))
+		var/mob/living/human/victim = locate(href_list["dressup"])
+		if(!istype(victim))
 			to_chat(usr, "This can only be used on instances of type /mob/living/human")
 			return
 		var/decl/hierarchy/outfit/outfit = input("Select outfit.", "Select equipment.") as null|anything in outfits()
 		if(!outfit)
 			return
 
-		dressup_human(H, outfit, TRUE)
+		dressup_human(victim, outfit, TRUE)
 
 	else if(href_list["varnameedit"] && href_list["datumedit"])
 		if(!check_rights(R_VAREDIT))	return
 
-		var/D = locate(href_list["datumedit"])
-		if(!istype(D,/datum) && !istype(D,/client))
+		var/datum_to_edit = locate(href_list["datumedit"])
+		if(!istype(datum_to_edit, /datum) && !istype(datum_to_edit, /client))
 			to_chat(usr, "This can only be used on instances of types /client or /datum")
 			return
 
-		modify_variables(D, href_list["varnameedit"], 1)
+		modify_variables(datum_to_edit, href_list["varnameedit"], 1)
 
 	else if(href_list["varnamechange"] && href_list["datumchange"])
 		if(!check_rights(R_VAREDIT))	return
 
-		var/D = locate(href_list["datumchange"])
-		if(!istype(D,/datum) && !istype(D,/client))
+		var/datum_to_edit = locate(href_list["datumchange"])
+		if(!istype(datum_to_edit,/datum) && !istype(datum_to_edit,/client))
 			to_chat(usr, "This can only be used on instances of types /client or /datum")
 			return
 
-		modify_variables(D, href_list["varnamechange"], 0)
+		modify_variables(datum_to_edit, href_list["varnamechange"], 0)
 
 	else if(href_list["varnamemass"] && href_list["datummass"])
 		if(!check_rights(R_VAREDIT))	return
 
-		var/atom/A = locate(href_list["datummass"])
-		if(!istype(A))
+		var/atom/atom_to_edit = locate(href_list["datummass"])
+		if(!isatom(atom_to_edit))
 			to_chat(usr, "This can only be used on instances of type /atom")
 			return
 
-		cmd_mass_modify_object_variables(A, href_list["varnamemass"])
+		cmd_mass_modify_object_variables(atom_to_edit, href_list["varnamemass"])
 
 	else if(href_list["datumwatch"] && href_list["varnamewatch"])
-		var/datum/D = locate(href_list["datumwatch"])
-		if(D)
-			if(!watched_variables[D])
-				watched_variables[D] = list()
-			watched_variables[D] |= href_list["varnamewatch"]
+		var/datum/datum_to_edit = locate(href_list["datumwatch"])
+		if(datum_to_edit)
+			if(!watched_variables[datum_to_edit])
+				watched_variables[datum_to_edit] = list()
+			watched_variables[datum_to_edit] |= href_list["varnamewatch"]
 			watched_variables()
 
 			if(!watched_variables_window.is_processing)
 				START_PROCESSING(SSprocessing, watched_variables_window)
 
 	else if(href_list["datumunwatch"] && href_list["varnameunwatch"])
-		var/datum/D = locate(href_list["datumunwatch"])
-		if(D && watched_variables[D])
-			watched_variables[D] -= href_list["varnameunwatch"]
-			var/list/datums_watched_vars = watched_variables[D]
+		var/datum/datum_to_edit = locate(href_list["datumunwatch"])
+		if(datum_to_edit && watched_variables[datum_to_edit])
+			watched_variables[datum_to_edit] -= href_list["varnameunwatch"]
+			var/list/datums_watched_vars = watched_variables[datum_to_edit]
 			if(!datums_watched_vars.len)
-				watched_variables -= D
+				watched_variables -= datum_to_edit
 		if(!watched_variables.len && watched_variables_window.is_processing)
 			STOP_PROCESSING(SSprocessing, watched_variables_window)
 
 	else if(href_list["mob_player_panel"])
 		if(!check_rights(0))	return
 
-		var/mob/M = locate(href_list["mob_player_panel"])
-		if(!istype(M))
+		var/mob/victim = locate(href_list["mob_player_panel"])
+		if(!istype(victim))
 			to_chat(usr, "This can only be used on instances of type /mob")
 			return
 
-		src.holder.show_player_panel(M)
+		src.holder.show_player_panel(victim)
 		href_list["datumrefresh"] = href_list["mob_player_panel"]
 
 	else if(href_list["give_spell"])
 		if(!check_rights(R_ADMIN|R_FUN))	return
 
-		var/mob/M = locate(href_list["give_spell"])
-		if(!istype(M))
+		var/mob/victim = locate(href_list["give_spell"])
+		if(!istype(victim))
 			to_chat(usr, "This can only be used on instances of type /mob")
 			return
 
-		src.give_spell(M)
+		src.give_spell(victim)
 		href_list["datumrefresh"] = href_list["give_spell"]
 
 	else if(href_list["godmode"])
 		if(!check_rights(R_REJUVENATE))	return
 
-		var/mob/M = locate(href_list["godmode"])
-		if(!istype(M))
+		var/mob/victim = locate(href_list["godmode"])
+		if(!istype(victim))
 			to_chat(usr, "This can only be used on instances of type /mob")
 			return
 
-		src.cmd_admin_godmode(M)
+		src.cmd_admin_godmode(victim)
 		href_list["datumrefresh"] = href_list["godmode"]
 
 	else if(href_list["gib"])
 		if(!check_rights(0))	return
 
-		var/mob/M = locate(href_list["gib"])
-		if(!istype(M))
+		var/mob/victim = locate(href_list["gib"])
+		if(!istype(victim))
 			to_chat(usr, "This can only be used on instances of type /mob")
 			return
 
-		src.cmd_admin_gib(M)
+		src.cmd_admin_gib(victim)
 
 	else if(href_list["drop_everything"])
 		if(!check_rights(R_DEBUG|R_ADMIN))	return
 
-		var/mob/M = locate(href_list["drop_everything"])
-		if(!istype(M))
+		var/mob/victim = locate(href_list["drop_everything"])
+		if(!istype(victim))
 			to_chat(usr, "This can only be used on instances of type /mob")
 			return
 
 		if(usr.client)
-			usr.client.cmd_admin_drop_everything(M)
+			usr.client.cmd_admin_drop_everything(victim)
 
 	else if(href_list["direct_control"])
 		if(!check_rights(0))	return
 
-		var/mob/M = locate(href_list["direct_control"])
-		if(!istype(M))
+		var/mob/victim = locate(href_list["direct_control"])
+		if(!istype(victim))
 			to_chat(usr, "This can only be used on instances of type /mob")
 			return
 
 		if(usr.client)
-			usr.client.cmd_assume_direct_control(M)
+			usr.client.cmd_assume_direct_control(victim)
 
 	else if(href_list["delthis"])
 		if(!check_rights(R_DEBUG|R_SERVER))	return
 
-		var/obj/O = locate(href_list["delthis"])
-		if(!isobj(O))
+		var/obj/object = locate(href_list["delthis"])
+		if(!isobj(object))
 			to_chat(usr, "This can only be used on instances of type /obj")
 			return
-		cmd_admin_delete(O)
+		cmd_admin_delete(object)
 
 	else if(href_list["delall"])
 		if(!check_rights(R_DEBUG|R_SERVER))	return
 
-		var/obj/O = locate(href_list["delall"])
-		if(!isobj(O))
+		var/obj/object = locate(href_list["delall"])
+		if(!isobj(object))
 			to_chat(usr, "This can only be used on instances of type /obj")
 			return
 
-		var/action_type = alert("Strict type ([O.type]) or type and all subtypes?",,"Strict type","Type and subtypes","Cancel")
+		var/action_type = alert("Strict type ([object.type]) or type and all subtypes?",,"Strict type","Type and subtypes","Cancel")
 		if(action_type == "Cancel" || !action_type)
 			return
 
-		if(alert("Are you really sure you want to delete all objects of type [O.type]?",,"Yes","No") != "Yes")
+		if(alert("Are you really sure you want to delete all objects of type [object.type]?",,"Yes","No") != "Yes")
 			return
 
 		if(alert("Second confirmation required. Delete?",,"Yes","No") != "Yes")
 			return
 
-		var/O_type = O.type
+		var/type_to_delete = object.type
 		switch(action_type)
 			if("Strict type")
-				var/i = 0
-				for(var/obj/Obj in world)
-					if(Obj.type == O_type)
-						i++
-						qdel(Obj)
-				if(!i)
+				var/count = 0
+				for(var/obj/deleted_object in world)
+					if(deleted_object.type == type_to_delete)
+						count++
+						qdel(deleted_object)
+				if(!count)
 					to_chat(usr, "No objects of this type exist")
 					return
-				log_admin("[key_name(usr)] deleted all objects of type [O_type] ([i] objects deleted)")
-				message_admins("<span class='notice'>[key_name(usr)] deleted all objects of type [O_type] ([i] objects deleted)</span>")
+				log_admin("[key_name(usr)] deleted all objects of type [type_to_delete] ([count] objects deleted)")
+				message_admins("<span class='notice'>[key_name(usr)] deleted all objects of type [type_to_delete] ([count] objects deleted)</span>")
 			if("Type and subtypes")
-				var/i = 0
-				for(var/obj/Obj in world)
-					if(istype(Obj,O_type))
-						i++
-						qdel(Obj)
-				if(!i)
+				var/count = 0
+				for(var/obj/deleted_object in world)
+					if(istype(deleted_object, type_to_delete))
+						count++
+						qdel(deleted_object)
+				if(!count)
 					to_chat(usr, "No objects of this type exist")
 					return
-				log_admin("[key_name(usr)] deleted all objects of type or subtype of [O_type] ([i] objects deleted)")
-				message_admins("<span class='notice'>[key_name(usr)] deleted all objects of type or subtype of [O_type] ([i] objects deleted)</span>")
+				log_admin("[key_name(usr)] deleted all objects of type or subtype of [type_to_delete] ([count] objects deleted)")
+				message_admins("<span class='notice'>[key_name(usr)] deleted all objects of type or subtype of [type_to_delete] ([count] objects deleted)</span>")
 
 	else if(href_list["explode"])
 		if(!check_rights(R_DEBUG|R_FUN))	return
 
-		var/atom/A = locate(href_list["explode"])
-		if(!isobj(A) && !ismob(A) && !isturf(A))
+		var/atom/atom_to_explode = locate(href_list["explode"])
+		if(!isobj(atom_to_explode) && !ismob(atom_to_explode) && !isturf(atom_to_explode))
 			to_chat(usr, "This can only be done to instances of type /obj, /mob and /turf")
 			return
 
-		src.cmd_admin_explosion(A)
+		src.cmd_admin_explosion(atom_to_explode)
 		href_list["datumrefresh"] = href_list["explode"]
 
 	else if(href_list["emp"])
 		if(!check_rights(R_DEBUG|R_FUN))	return
 
-		var/atom/A = locate(href_list["emp"])
-		if(!isobj(A) && !ismob(A) && !isturf(A))
+		var/atom/atom_to_emp = locate(href_list["emp"])
+		if(!isobj(atom_to_emp) && !ismob(atom_to_emp) && !isturf(atom_to_emp))
 			to_chat(usr, "This can only be done to instances of type /obj, /mob and /turf")
 			return
 
-		src.cmd_admin_emp(A)
+		src.cmd_admin_emp(atom_to_emp)
 		href_list["datumrefresh"] = href_list["emp"]
 
 	else if(href_list["mark_object"])
 		if(!check_rights(0))	return
 
-		var/datum/D = locate(href_list["mark_object"])
-		if(!istype(D))
+		var/datum/datum_to_mark = locate(href_list["mark_object"])
+		if(!istype(datum_to_mark))
 			to_chat(usr, "This can only be done to instances of type /datum")
 			return
 
-		src.holder.marked_datum_weak = weakref(D)
+		src.holder.marked_datum_weak = weakref(datum_to_mark)
 		href_list["datumrefresh"] = href_list["mark_object"]
 
 	else if(href_list["rotatedatum"])
 		if(!check_rights(0))	return
 
-		var/atom/A = locate(href_list["rotatedatum"])
-		if(!istype(A))
+		var/atom/atom_to_rotate = locate(href_list["rotatedatum"])
+		if(!isatom(atom_to_rotate))
 			to_chat(usr, "This can only be done to instances of type /atom")
 			return
 
 		switch(href_list["rotatedir"])
-			if("right")	A.set_dir(turn(A.dir, -45))
-			if("left")	A.set_dir(turn(A.dir, 45))
+			if("right")	atom_to_rotate.set_dir(turn(atom_to_rotate.dir, -45))
+			if("left")	atom_to_rotate.set_dir(turn(atom_to_rotate.dir, 45))
 		href_list["datumrefresh"] = href_list["rotatedatum"]
 
 	else if(href_list["makemonkey"])
 		if(!check_rights(R_SPAWN))	return
 
-		var/mob/living/human/H = locate(href_list["makemonkey"])
-		if(!istype(H))
+		var/mob/living/human/victim = locate(href_list["makemonkey"])
+		if(!istype(victim))
 			to_chat(usr, "This can only be done to instances of type /mob/living/human")
 			return
 
 		if(alert("Confirm mob type change?",,"Transform","Cancel") != "Transform")	return
-		if(!H)
+		if(!victim)
 			to_chat(usr, "Mob doesn't exist anymore")
 			return
 		holder.Topic(href, list("monkeyone"=href_list["makemonkey"]))
@@ -266,13 +266,13 @@
 	else if(href_list["makerobot"])
 		if(!check_rights(R_SPAWN))	return
 
-		var/mob/living/human/H = locate(href_list["makerobot"])
-		if(!istype(H))
+		var/mob/living/human/victim = locate(href_list["makerobot"])
+		if(!istype(victim))
 			to_chat(usr, "This can only be done to instances of type /mob/living/human")
 			return
 
 		if(alert("Confirm mob type change?",,"Transform","Cancel") != "Transform")	return
-		if(!H)
+		if(!victim)
 			to_chat(usr, "Mob doesn't exist anymore")
 			return
 		holder.Topic(href, list("makerobot"=href_list["makerobot"]))
@@ -280,114 +280,114 @@
 	else if(href_list["makeai"])
 		if(!check_rights(R_SPAWN))	return
 
-		var/mob/living/human/H = locate(href_list["makeai"])
-		if(!istype(H))
+		var/mob/living/human/victim = locate(href_list["makeai"])
+		if(!istype(victim))
 			to_chat(usr, "This can only be done to instances of type /mob/living/human")
 			return
 
 		if(alert("Confirm mob type change?",,"Transform","Cancel") != "Transform")	return
-		if(!H)
+		if(!victim)
 			to_chat(usr, "Mob doesn't exist anymore")
 			return
 		holder.Topic(href, list("makeai"=href_list["makeai"]))
 
 	else if(href_list["addailment"])
 
-		var/mob/living/human/H = locate(href_list["addailment"])
-		if(!istype(H))
+		var/mob/living/human/victim = locate(href_list["addailment"])
+		if(!istype(victim))
 			to_chat(usr, "This can only be done to instances of type /mob/living/human")
 			return
-		var/obj/item/organ/O = input("Select a limb to add the ailment to.", "Add Ailment") as null|anything in H.get_organs()
-		if(QDELETED(H) || QDELETED(O) || O.owner != H)
+		var/obj/item/organ/limb = input("Select a limb to add the ailment to.", "Add Ailment") as null|anything in victim.get_organs()
+		if(QDELETED(victim) || QDELETED(limb) || limb.owner != victim)
 			return
 		var/list/possible_ailments = list()
 		for(var/atype in subtypesof(/datum/ailment))
 			var/datum/ailment/ailment = get_ailment_reference(atype)
-			if(ailment && ailment.category != ailment.type && ailment.can_apply_to(O))
+			if(ailment && ailment.category != ailment.type && ailment.can_apply_to(limb))
 				possible_ailments |= ailment
 
 		var/datum/ailment/ailment = input("Select an ailment type to add.", "Add Ailment") as null|anything in possible_ailments
 		if(!istype(ailment))
 			return
-		if(!QDELETED(H) && !QDELETED(O) && O.owner == H && O.add_ailment(ailment))
-			to_chat(usr, SPAN_NOTICE("Added [ailment] to \the [H]."))
+		if(!QDELETED(victim) && !QDELETED(limb) && limb.owner == victim && limb.add_ailment(ailment))
+			to_chat(usr, SPAN_NOTICE("Added [ailment] to \the [victim]."))
 		else
-			to_chat(usr, SPAN_WARNING("Failed to add [ailment] to \the [H]."))
+			to_chat(usr, SPAN_WARNING("Failed to add [ailment] to \the [victim]."))
 		return
 
 	else if(href_list["remailment"])
 
-		var/mob/living/human/H = locate(href_list["remailment"])
-		if(!istype(H))
+		var/mob/living/human/victim = locate(href_list["remailment"])
+		if(!istype(victim))
 			to_chat(usr, "This can only be done to instances of type /mob/living/human")
 			return
 		var/list/all_ailments = list()
-		for(var/obj/item/organ/O in H.get_organs())
-			for(var/datum/ailment/ailment in O.ailments)
-				all_ailments["[ailment.name] - [O.name]"] = ailment
+		for(var/obj/item/organ/limb in victim.get_organs())
+			for(var/datum/ailment/ailment in limb.ailments)
+				all_ailments["[ailment.name] - [limb.name]"] = ailment
 
 		var/datum/ailment/ailment = input("Which ailment do you wish to remove?", "Removing Ailment") as null|anything in all_ailments
 		if(!ailment)
 			return
 		ailment = all_ailments[ailment]
-		if(istype(ailment) && ailment.organ && ailment.organ.owner == H && ailment.organ.remove_ailment(ailment))
-			to_chat(usr, SPAN_NOTICE("Removed [ailment] from \the [H]."))
+		if(istype(ailment) && ailment.organ && ailment.organ.owner == victim && ailment.organ.remove_ailment(ailment))
+			to_chat(usr, SPAN_NOTICE("Removed [ailment] from \the [victim]."))
 		else
-			to_chat(usr, SPAN_WARNING("Failed to remove [ailment] from \the [H]."))
+			to_chat(usr, SPAN_WARNING("Failed to remove [ailment] from \the [victim]."))
 		return
 
 	else if(href_list["setspecies"])
 		if(!check_rights(R_SPAWN))	return
 
-		var/mob/living/human/H = locate(href_list["setspecies"])
-		if(!istype(H))
+		var/mob/living/human/victim = locate(href_list["setspecies"])
+		if(!istype(victim))
 			to_chat(usr, SPAN_WARNING("This can only be done to instances of type /mob/living/human"))
 			return
 
 		var/new_species = input("Please choose a new species.","Species",null) as null|anything in get_all_species()
 
-		if(!H)
+		if(!victim)
 			to_chat(usr, SPAN_WARNING("Mob doesn't exist anymore"))
 			return
 
 		if(!new_species)
 			return
 
-		if(H.change_species(new_species))
-			to_chat(usr, SPAN_NOTICE("Set species of [H] to [H.species]."))
+		if(victim.change_species(new_species))
+			to_chat(usr, SPAN_NOTICE("Set species of [victim] to [victim.species]."))
 		else
 			to_chat(usr, SPAN_WARNING("Failed! Something went wrong."))
 
 	else if(href_list["setbodytype"])
 		if(!check_rights(R_SPAWN))	return
 
-		var/mob/living/human/H = locate(href_list["setbodytype"])
-		if(!istype(H))
+		var/mob/living/human/victim = locate(href_list["setbodytype"])
+		if(!istype(victim))
 			to_chat(usr, SPAN_WARNING("This can only be done to instances of type /mob/living/human"))
 			return
 
-		var/new_bodytype = input("Please choose a new bodytype.","Bodytype",null) as null|anything in H.species.available_bodytypes
+		var/new_bodytype = input("Please choose a new bodytype.","Bodytype",null) as null|anything in victim.species.available_bodytypes
 
 		if(!new_bodytype)
 			return
 
-		if(!H)
+		if(!victim)
 			to_chat(usr, SPAN_WARNING("Mob doesn't exist anymore"))
 			return
 
-		if(!(new_bodytype in H.species.available_bodytypes))
+		if(!(new_bodytype in victim.species.available_bodytypes))
 			to_chat(usr, SPAN_WARNING("Bodytype is no longer available to the mob species."))
 
-		if(H.set_bodytype(new_bodytype))
-			to_chat(usr, SPAN_NOTICE("Set bodytype of [H] to [H.get_bodytype()]."))
+		if(victim.set_bodytype(new_bodytype))
+			to_chat(usr, SPAN_NOTICE("Set bodytype of [victim] to [victim.get_bodytype()]."))
 		else
 			to_chat(usr, SPAN_WARNING("Failed! Something went wrong."))
 
 	else if(href_list["addlanguage"])
 		if(!check_rights(R_SPAWN))	return
 
-		var/mob/H = locate(href_list["addlanguage"])
-		if(!istype(H))
+		var/mob/victim = locate(href_list["addlanguage"])
+		if(!istype(victim))
 			to_chat(usr, "This can only be done to instances of type /mob")
 			return
 
@@ -397,238 +397,237 @@
 		if(!new_language)
 			return
 
-		if(!H)
+		if(!victim)
 			to_chat(usr, "Mob doesn't exist anymore")
 			return
 
-		if(H.add_language(new_language))
-			to_chat(usr, "Added [new_language] to [H].")
+		if(victim.add_language(new_language))
+			to_chat(usr, "Added [new_language] to [victim].")
 		else
 			to_chat(usr, "Mob already knows that language.")
 
 	else if(href_list["remlanguage"])
 		if(!check_rights(R_SPAWN))	return
 
-		var/mob/H = locate(href_list["remlanguage"])
-		if(!istype(H))
+		var/mob/victim = locate(href_list["remlanguage"])
+		if(!istype(victim))
 			to_chat(usr, "This can only be done to instances of type /mob")
 			return
 
-		if(!H.languages.len)
+		if(!victim.languages.len)
 			to_chat(usr, "This mob knows no languages.")
 			return
 
-		var/decl/language/rem_language = input("Please choose a language to remove.","Language",null) as null|anything in H.languages
+		var/decl/language/rem_language = input("Please choose a language to remove.","Language",null) as null|anything in victim.languages
 
 		if(!rem_language)
 			return
 
-		if(!H)
+		if(!victim)
 			to_chat(usr, "Mob doesn't exist anymore")
 			return
 
-		if(H.remove_language(rem_language.name))
-			to_chat(usr, "Removed [rem_language] from [H].")
+		if(victim.remove_language(rem_language.name))
+			to_chat(usr, "Removed [rem_language] from [victim].")
 		else
 			to_chat(usr, "Mob doesn't know that language.")
 
 	else if(href_list["addverb"])
 		if(!check_rights(R_DEBUG))      return
 
-		var/mob/living/H = locate(href_list["addverb"])
+		var/mob/living/victim = locate(href_list["addverb"])
 
-		if(!istype(H))
+		if(!istype(victim))
 			to_chat(usr, "This can only be done to instances of type /mob/living")
 			return
 		var/list/possibleverbs = list()
 		possibleverbs += "Cancel" 								// One for the top...
 		possibleverbs += typesof(/mob/proc, /mob/verb, /mob/living/proc, /mob/living/verb)
-		switch(H.type)
-			if(/mob/living/human)
-				possibleverbs += typesof(/mob/living/human/verb, /mob/living/human/proc)
-			if(/mob/living/silicon/robot)
-				possibleverbs += typesof(/mob/living/silicon/proc, /mob/living/silicon/robot/proc, /mob/living/silicon/robot/verb)
-			if(/mob/living/silicon/ai)
-				possibleverbs += typesof(/mob/living/silicon/proc, /mob/living/silicon/ai/proc, /mob/living/silicon/ai/verb)
-		possibleverbs -= H.verbs
+		if(ishuman(victim))
+			possibleverbs += typesof(/mob/living/human/verb, /mob/living/human/proc)
+		else if(isrobot(victim))
+			possibleverbs += typesof(/mob/living/silicon/proc, /mob/living/silicon/robot/proc, /mob/living/silicon/robot/verb)
+		else if(isAI(victim))
+			possibleverbs += typesof(/mob/living/silicon/proc, /mob/living/silicon/ai/proc, /mob/living/silicon/ai/verb)
+		possibleverbs -= victim.verbs
 		possibleverbs += "Cancel" 								// ...And one for the bottom
 
 		var/verb = input("Select a verb!", "Verbs",null) as null|anything in possibleverbs
-		if(!H)
+		if(!victim)
 			to_chat(usr, "Mob doesn't exist anymore")
 			return
 		if(!verb || verb == "Cancel")
 			return
 		else
-			H.verbs += verb
+			victim.verbs += verb
 
 	else if(href_list["remverb"])
 		if(!check_rights(R_DEBUG))      return
 
-		var/mob/H = locate(href_list["remverb"])
+		var/mob/victim = locate(href_list["remverb"])
 
-		if(!istype(H))
+		if(!istype(victim))
 			to_chat(usr, "This can only be done to instances of type /mob")
 			return
-		var/verb = input("Please choose a verb to remove.","Verbs",null) as null|anything in H.verbs
-		if(!H)
+		var/verb = input("Please choose a verb to remove.","Verbs",null) as null|anything in victim.verbs
+		if(!victim)
 			to_chat(usr, "Mob doesn't exist anymore")
 			return
 		if(!verb)
 			return
 		else
-			H.verbs -= verb
+			victim.verbs -= verb
 
 	else if(href_list["addorgan"])
 		if(!check_rights(R_SPAWN))	return
 
-		var/mob/living/M = locate(href_list["addorgan"])
-		if(!istype(M))
+		var/mob/living/victim = locate(href_list["addorgan"])
+		if(!istype(victim))
 			to_chat(usr, "This can only be done to instances of type /mob/living")
 			return
 
-		if(!length(M.get_external_organs())) // quick and dirty check for organs; should always be >0 for humanlike mobs.
+		if(!length(victim.get_external_organs())) // quick and dirty check for organs; should always be >0 for humanlike mobs.
 			to_chat(usr, "This can only be done to mobs that implement organs!")
 			return
 
 		var/obj/item/organ/new_organ = input("Please choose an organ to add.","Organ",null) as null|anything in subtypesof(/obj/item/organ)
 		if(!new_organ) return
 
-		if(!M)
+		if(!victim)
 			to_chat(usr, "Mob doesn't exist anymore")
 			return
 
-		if(locate(new_organ) in M.get_internal_organs())
+		if(locate(new_organ) in victim.get_internal_organs())
 			to_chat(usr, "Mob already has that organ.")
 			return
 
-		var/obj/item/organ/target_organ = M.get_organ(initial(new_organ.parent_organ))
+		var/obj/item/organ/target_organ = victim.get_organ(initial(new_organ.parent_organ))
 		if(!target_organ)
 			to_chat(usr, "Mob doesn't have \a [target_organ] to install that in.")
 			return
-		var/obj/item/organ/organ_instance = new new_organ(M)
-		M.add_organ(organ_instance, target_organ)
+		var/obj/item/organ/organ_instance = new new_organ(victim)
+		victim.add_organ(organ_instance, target_organ)
 
 
 	else if(href_list["remorgan"])
 		if(!check_rights(R_SPAWN))	return
 
-		var/mob/living/M = locate(href_list["remorgan"])
-		if(!istype(M))
+		var/mob/living/victim = locate(href_list["remorgan"])
+		if(!istype(victim))
 			to_chat(usr, "This can only be done to instances of type /mob/living")
 			return
 
-		if(!length(M.get_external_organs())) // quick and dirty check for organs; should always be >0 for humanlike mobs.
+		if(!length(victim.get_external_organs())) // quick and dirty check for organs; should always be >0 for humanlike mobs.
 			to_chat(usr, "This can only be done to mobs that implement organs!")
 			return
 
-		var/obj/item/organ/rem_organ = input("Please choose an organ to remove.","Organ",null) as null|anything in M.get_internal_organs()
+		var/obj/item/organ/rem_organ = input("Please choose an organ to remove.","Organ",null) as null|anything in victim.get_internal_organs()
 
-		if(!M)
+		if(!victim)
 			to_chat(usr, "Mob doesn't exist anymore")
 			return
 
-		if(!(locate(rem_organ) in M.get_internal_organs()))
+		if(!(locate(rem_organ) in victim.get_internal_organs()))
 			to_chat(usr, "Mob does not have that organ.")
 			return
 
-		to_chat(usr, "Removed [rem_organ] from [M].")
-		M.remove_organ(rem_organ)
+		to_chat(usr, "Removed [rem_organ] from [victim].")
+		victim.remove_organ(rem_organ)
 		if(!QDELETED(rem_organ))
 			qdel(rem_organ)
 
 	else if(href_list["fix_nano"])
 		if(!check_rights(R_DEBUG)) return
 
-		var/mob/H = locate(href_list["fix_nano"])
+		var/mob/victim = locate(href_list["fix_nano"])
 
-		if(!istype(H) || !H.client)
+		if(!istype(victim) || !victim.client)
 			to_chat(usr, "This can only be done on mobs with clients")
 			return
 
-		SSnano.close_uis(H)
-		H.client.cache.Cut()
+		SSnano.close_uis(victim)
+		victim.client.cache.Cut()
 		var/datum/asset/assets = get_asset_datum(/datum/asset/nanoui)
-		assets.send(H)
+		assets.send(victim)
 
 		to_chat(usr, "Resource files sent")
-		to_chat(H, "Your NanoUI Resource files have been refreshed")
+		to_chat(victim, "Your NanoUI Resource files have been refreshed")
 
-		log_admin("[key_name(usr)] resent the NanoUI resource files to [key_name(H)] ")
+		log_admin("[key_name(usr)] resent the NanoUI resource files to [key_name(victim)] ")
 
 	else if(href_list["updateicon"])
 		if(!check_rights(0))
 			return
-		var/mob/M = locate(href_list["updateicon"])
-		if(!ismob(M))
+		var/mob/victim = locate(href_list["updateicon"])
+		if(!ismob(victim))
 			to_chat(usr, "This can only be done to instances of type /mob")
 			return
-		M.update_icon()
+		victim.update_icon()
 
 	else if(href_list["refreshoverlays"])
 		if(!check_rights(0))
 			return
-		var/mob/living/human/H = locate(href_list["refreshoverlays"])
-		if(!istype(H))
+		var/mob/living/human/victim = locate(href_list["refreshoverlays"])
+		if(!istype(victim))
 			to_chat(usr, "This can only be done to instances of type /mob/living/human")
 			return
-		H.try_refresh_visible_overlays()
+		victim.try_refresh_visible_overlays()
 
 	else if(href_list["adjustDamage"] && href_list["mobToDamage"])
 		if(!check_rights(R_DEBUG|R_ADMIN|R_FUN))	return
 
-		var/mob/living/L = locate(href_list["mobToDamage"])
-		if(!istype(L)) return
+		var/mob/living/victim = locate(href_list["mobToDamage"])
+		if(!istype(victim)) return
 
 		var/Text = href_list["adjustDamage"]
 
 		var/amount =  input("Deal how much damage to mob? (Negative values here heal)","Adjust [Text]loss",0) as num
 
-		if(!L)
+		if(!victim)
 			to_chat(usr, "Mob doesn't exist anymore")
 			return
 
 		if(istext(Text))
-			L.take_damage(amount, Text)
+			victim.take_damage(amount, Text)
 		else
-			to_chat(usr, "You caused an error. DEBUG: Text:[Text] Mob:[L]")
+			to_chat(usr, "You caused an error. DEBUG: Text:[Text] Mob:[victim]")
 			return
 
 		if(amount != 0)
-			log_admin("[key_name(usr)] dealt [amount] amount of [Text] damage to [L]")
-			message_admins("<span class='notice'>[key_name(usr)] dealt [amount] amount of [Text] damage to [L]</span>")
+			log_admin("[key_name(usr)] dealt [amount] amount of [Text] damage to [victim]")
+			message_admins("<span class='notice'>[key_name(usr)] dealt [amount] amount of [Text] damage to [victim]</span>")
 			href_list["datumrefresh"] = href_list["mobToDamage"]
 
 	else if(href_list["call_proc"])
-		var/datum/D = locate(href_list["call_proc"])
-		if(istype(D) || istype(D, /client)) // can call on clients too, not just datums
-			callproc_targetpicked(1, D)
+		var/datum/callee = locate(href_list["call_proc"])
+		if(istype(callee) || istype(callee, /client)) // can call on clients too, not just datums
+			callproc_targetpicked(1, callee)
 	else if(href_list["addaura"])
 		if(!check_rights(R_DEBUG|R_ADMIN|R_FUN))	return
-		var/mob/living/L = locate(href_list["addaura"])
-		if(!istype(L))
+		var/mob/living/victim = locate(href_list["addaura"])
+		if(!istype(victim))
 			return
 		var/choice = input("Please choose an aura to add", "Auras", null) as null|anything in typesof(/obj/aura)
-		if(!choice || !L)
+		if(!choice || !victim)
 			return
-		var/obj/o = new choice(L)
-		log_and_message_admins("added \the [o] to \the [L]")
+		var/obj/new_aura = new choice(victim)
+		log_and_message_admins("added \the [new_aura] to \the [victim]")
 	else if(href_list["removeaura"])
 		if(!check_rights(R_DEBUG|R_ADMIN|R_FUN))	return
-		var/mob/living/L = locate(href_list["removeaura"])
-		if(!istype(L))
+		var/mob/living/victim = locate(href_list["removeaura"])
+		if(!istype(victim))
 			return
-		var/choice = input("Please choose an aura to remove", "Auras", null) as null|anything in L.auras
-		if(!choice || !L)
+		var/choice = input("Please choose an aura to remove", "Auras", null) as null|anything in victim.auras
+		if(!choice || !victim)
 			return
-		log_and_message_admins("removed \the [choice] to \the [L]")
+		log_and_message_admins("removed \the [choice] to \the [victim]")
 		qdel(choice)
 
 	else if(href_list["addstressor"])
 		if(!check_rights(R_DEBUG))
 			return
-		var/mob/living/L = locate(href_list["addstressor"])
-		if(!istype(L))
+		var/mob/living/victim = locate(href_list["addstressor"])
+		if(!istype(victim))
 			return
 		var/static/list/_all_stressors
 		if(!_all_stressors)
@@ -637,63 +636,63 @@
 		if(!stressor)
 			return
 		var/duration = clamp(input("Enter a duration ([STRESSOR_DURATION_INDEFINITE] for permanent).", "Add Stressor") as num|null, STRESSOR_DURATION_INDEFINITE, INFINITY)
-		if(duration && L.add_stressor(stressor, duration))
-			log_and_message_admins("added [stressor] to \the [L] for duration [duration].")
+		if(duration && victim.add_stressor(stressor, duration))
+			log_and_message_admins("added [stressor] to \the [victim] for duration [duration].")
 
 	else if(href_list["removestressor"])
 		if(!check_rights(R_DEBUG))
 			return
-		var/mob/living/L = locate(href_list["removestressor"])
-		if(!istype(L))
+		var/mob/living/victim = locate(href_list["removestressor"])
+		if(!istype(victim))
 			return
-		if(!length(L.stressors))
+		if(!length(victim.stressors))
 			to_chat(usr, "Nothing to remove.")
 			return
-		var/datum/stressor/stressor = input("Select a stressor to remove.", "Remove Stressor") as null|anything in L.stressors
-		if(L.remove_stressor(stressor))
-			log_and_message_admins("removed [stressor] from \the [L].")
+		var/datum/stressor/stressor = input("Select a stressor to remove.", "Remove Stressor") as null|anything in victim.stressors
+		if(victim.remove_stressor(stressor))
+			log_and_message_admins("removed [stressor] from \the [victim].")
 
 	else if(href_list["setstatuscond"])
 		if(!check_rights(R_DEBUG))
 			return
-		var/mob/living/L = locate(href_list["setstatuscond"])
-		if(!istype(L))
+		var/mob/living/victim = locate(href_list["setstatuscond"])
+		if(!istype(victim))
 			return
 		var/list/all_status_conditions = decls_repository.get_decls_of_subtype(/decl/status_condition)
 		var/list/select_from_conditions = list()
 		for(var/status_cond in all_status_conditions)
 			select_from_conditions += all_status_conditions[status_cond]
 		var/decl/status_condition/selected_condition = input("Select a status condition to set.", "Set Status Condition") as null|anything in select_from_conditions
-		if(!selected_condition || QDELETED(L) || !check_rights(R_DEBUG))
+		if(!selected_condition || QDELETED(victim) || !check_rights(R_DEBUG))
 			return
 		var/amt = input("Enter an amount to set the condition to.", "Set Status Condition") as num|null
-		if(isnull(amt) || QDELETED(L) || !check_rights(R_DEBUG))
+		if(isnull(amt) || QDELETED(victim) || !check_rights(R_DEBUG))
 			return
 		if(amt < 0)
-			amt += GET_STATUS(L, selected_condition.type)
-		L.set_status(selected_condition.type, amt)
-		log_and_message_admins("set [selected_condition.name] to [amt] on \the [L].")
+			amt += GET_STATUS(victim, selected_condition.type)
+		victim.set_status(selected_condition.type, amt)
+		log_and_message_admins("set [selected_condition.name] to [amt] on \the [victim].")
 
 	else if(href_list["setmaterial"])
 		if(!check_rights(R_DEBUG))	return
 
-		var/obj/item/I = locate(href_list["setmaterial"])
-		if(!istype(I))
+		var/obj/item/item = locate(href_list["setmaterial"])
+		if(!istype(item))
 			to_chat(usr, "This can only be done to instances of type /obj/item")
 			return
 
 		var/decl/material/new_material = input("Please choose a new material.","Materials",null) as null|anything in decls_repository.get_decls_of_subtype_unassociated(/decl/material)
 		if(!istype(new_material))
 			return
-		if(QDELETED(I))
+		if(QDELETED(item))
 			to_chat(usr, "Item doesn't exist anymore")
 			return
-		I.set_material(new_material.type)
-		to_chat(usr, "Set material of [I] to [I.get_material()].")
+		item.set_material(new_material.type)
+		to_chat(usr, "Set material of [item] to [item.get_material()].")
 
 	if(href_list["datumrefresh"])
-		var/datum/DAT = locate(href_list["datumrefresh"])
-		if(istype(DAT, /datum) || istype(DAT, /client))
-			debug_variables(DAT)
+		var/datum/datum_to_refresh = locate(href_list["datumrefresh"])
+		if(istype(datum_to_refresh, /datum) || istype(datum_to_refresh, /client))
+			debug_variables(datum_to_refresh)
 
 	return

--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -62,7 +62,7 @@
 		return 0
 
 	if(!holder.cell.check_charge(use_power_cost * CELLRATE))
-		to_chat(holder.wearer,"<span class='warning'>Not enough stored power.</span>")
+		to_chat(holder.wearer,SPAN_WARNING("Not enough stored power."))
 		return 0
 
 	if(!target)
@@ -123,7 +123,7 @@
 		return 0
 
 	if(accepted_item.charges >= 5)
-		to_chat(user, "<span class='danger'>Another grenade of that type will not fit into the module.</span>")
+		to_chat(user, SPAN_DANGER("Another grenade of that type will not fit into the module."))
 		return 0
 
 	to_chat(user, SPAN_BLUE("<b>You slot \the [input_device] into the suit module.</b>"))
@@ -139,10 +139,10 @@
 	if(!target)
 		return 0
 
-	var/mob/living/human/H = holder.wearer
+	var/mob/living/human/wearer = holder.wearer
 
 	if(!charge_selected)
-		to_chat(H, "<span class='danger'>You have not selected a grenade type.</span>")
+		to_chat(wearer, SPAN_DANGER("You have not selected a grenade type."))
 		return 0
 
 	var/datum/rig_charge/charge = charges[charge_selected]
@@ -151,14 +151,14 @@
 		return 0
 
 	if(charge.charges <= 0)
-		to_chat(H, "<span class='danger'>Insufficient grenades!</span>")
+		to_chat(wearer, SPAN_DANGER("Insufficient grenades!"))
 		return 0
 
 	charge.charges--
-	var/obj/item/grenade/new_grenade = new charge.product_type(get_turf(H))
-	H.visible_message("<span class='danger'>[H] launches \a [new_grenade]!</span>")
+	var/obj/item/grenade/new_grenade = new charge.product_type(get_turf(wearer))
+	wearer.visible_message(SPAN_DANGER("[wearer] launches \a [new_grenade]!"), SPAN_DANGER("You launch \a [new_grenade]!"))
 	log_and_message_admins("fired a grenade ([new_grenade.name]) from a rigsuit grenade launcher.")
-	new_grenade.activate(H)
+	new_grenade.activate(wearer)
 	new_grenade.throw_at(target,fire_force,fire_distance)
 
 /obj/item/rig_module/grenade_launcher/cleaner
@@ -402,21 +402,21 @@
 	if(!..())
 		return FALSE
 
-	var/mob/living/H = holder.wearer
+	var/mob/living/wearer = holder.wearer
 
 	if(target)
 		var/obj/item/firing = new fabrication_type()
 		firing.dropInto(loc)
-		H.visible_message(SPAN_DANGER("\The [H] launches \a [firing]!"))
+		wearer.visible_message(SPAN_DANGER("\The [wearer] launches \a [firing]!"), SPAN_DANGER("You launch \a [firing]!"))
 		firing.throw_at(target,fire_force,fire_distance)
 	else
-		if(!H.get_empty_hand_slot())
-			to_chat(H, SPAN_WARNING("Your hands are full."))
+		if(!wearer.get_empty_hand_slot())
+			to_chat(wearer, SPAN_WARNING("Your hands are full."))
 		else
 			var/obj/item/new_weapon = new fabrication_type()
-			new_weapon.forceMove(H)
-			to_chat(H, SPAN_BLUE("<b>You quickly fabricate \a [new_weapon].</b>"))
-			H.put_in_hands(new_weapon)
+			new_weapon.forceMove(wearer)
+			to_chat(wearer, SPAN_BLUE("<b>You quickly fabricate \a [new_weapon].</b>"))
+			wearer.put_in_hands(new_weapon)
 
 	return TRUE
 

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -23,11 +23,11 @@ var/global/arrest_security_status =  "Arrest"
 	. = ..()
 	global.all_crew_records.Remove(src)
 
-/datum/computer_file/report/crew_record/proc/load_from_mob(var/mob/living/human/H)
+/datum/computer_file/report/crew_record/proc/load_from_mob(var/mob/living/human/crewmember)
 
-	if(istype(H))
-		photo_front = getFlatIcon(H, SOUTH, always_use_defdir = 1)
-		photo_side = getFlatIcon(H, WEST, always_use_defdir = 1)
+	if(istype(crewmember))
+		photo_front = getFlatIcon(crewmember, SOUTH, always_use_defdir = 1)
+		photo_side = getFlatIcon(crewmember, WEST, always_use_defdir = 1)
 	else
 		var/mob/living/human/dummy = new()
 		photo_front = getFlatIcon(dummy, SOUTH, always_use_defdir = 1)
@@ -35,73 +35,73 @@ var/global/arrest_security_status =  "Arrest"
 		qdel(dummy)
 
 	// Load records from the client.
-	var/list/records = H?.client?.prefs?.records || list()
+	var/list/records = crewmember?.client?.prefs?.records || list()
 
 	// Add honorifics, etc.
 	var/formal_name = "Unset"
-	if(H)
-		formal_name = H.real_name
-		if(H.client && H.client.prefs)
-			for(var/culturetag in H.client.prefs.cultural_info)
-				var/decl/cultural_info/culture = GET_DECL(H.client.prefs.cultural_info[culturetag])
-				if(H.char_rank && H.char_rank.name_short)
+	if(crewmember)
+		formal_name = crewmember.real_name
+		if(crewmember.client && crewmember.client.prefs)
+			for(var/culturetag in crewmember.client.prefs.cultural_info)
+				var/decl/cultural_info/culture = GET_DECL(crewmember.client.prefs.cultural_info[culturetag])
+				if(crewmember.char_rank && crewmember.char_rank.name_short)
 					formal_name = "[formal_name][culture.get_formal_name_suffix()]"
 				else
 					formal_name = "[culture.get_formal_name_prefix()][formal_name][culture.get_formal_name_suffix()]"
 
 	// Generic record
-	set_name(H ? H.real_name : "Unset")
+	set_name(crewmember ? crewmember.real_name : "Unset")
 	set_formal_name(formal_name)
-	set_job(H ? GetAssignment(H) : "Unset")
+	set_job(crewmember ? GetAssignment(crewmember) : "Unset")
 	var/gender_term = "Unset"
-	if(H)
-		var/decl/pronouns/G = H.get_pronouns(ignore_coverings = TRUE)
-		if(G && G.bureaucratic_term )
-			gender_term = G.bureaucratic_term
+	if(crewmember)
+		var/decl/pronouns/gender = crewmember.get_pronouns(ignore_coverings = TRUE)
+		if(gender?.bureaucratic_term)
+			gender_term = gender.bureaucratic_term
 	set_gender(gender_term)
-	set_age(H?.get_age() || 30)
+	set_age(crewmember?.get_age() || 30)
 	set_status(global.default_physical_status)
-	set_species_name(H ? H.get_species_name() : global.using_map.default_species)
-	set_branch(H ? (H.char_branch && H.char_branch.name) : "None")
-	set_rank(H ? (H.char_rank && H.char_rank.name) : "None")
+	set_species_name(crewmember ? crewmember.get_species_name() : global.using_map.default_species)
+	set_branch(crewmember ? (crewmember.char_branch && crewmember.char_branch.name) : "None")
+	set_rank(crewmember ? (crewmember.char_rank && crewmember.char_rank.name) : "None")
 
 	var/public_record = records[PREF_PUB_RECORD]
-	set_public_record((public_record && !jobban_isbanned(H, "Records")) ? html_decode(public_record) : "No record supplied")
+	set_public_record((public_record && !jobban_isbanned(crewmember, "Records")) ? html_decode(public_record) : "No record supplied")
 
 	// Medical record
-	set_bloodtype(H?.get_blood_type() || "Unset")
+	set_bloodtype(crewmember?.get_blood_type() || "Unset")
 	var/medical_record = records[PREF_MED_RECORD]
-	set_medical_record((medical_record && !jobban_isbanned(H, "Records")) ? html_decode(medical_record) : "No record supplied")
+	set_medical_record((medical_record && !jobban_isbanned(crewmember, "Records")) ? html_decode(medical_record) : "No record supplied")
 
-	if(H)
-		var/decl/bodytype/root_bodytype = H.get_bodytype()
+	if(crewmember)
+		var/decl/bodytype/root_bodytype = crewmember.get_bodytype()
 		var/organ_data = list("\[*\]")
-		for(var/obj/item/organ/external/E in H.get_external_organs())
-			if(E.bodytype != root_bodytype)
-				organ_data += "[E.bodytype] [E.name] [BP_IS_PROSTHETIC(E) ? "prosthetic" : "graft"]"
-		for(var/obj/item/organ/internal/I in H.get_internal_organs())
-			if(I.bodytype != root_bodytype)
-				organ_data += "[I.bodytype] [I.name] [BP_IS_PROSTHETIC(I) ? "prosthetic" : "graft"]"
+		for(var/obj/item/organ/external/child in crewmember.get_external_organs())
+			if(child.bodytype != root_bodytype)
+				organ_data += "[child.bodytype] [child.name] [BP_IS_PROSTHETIC(child) ? "prosthetic" : "graft"]"
+		for(var/obj/item/organ/internal/internal_organ in crewmember.get_internal_organs())
+			if(internal_organ.bodytype != root_bodytype)
+				organ_data += "[internal_organ.bodytype] [internal_organ.name] [BP_IS_PROSTHETIC(internal_organ) ? "prosthetic" : "graft"]"
 		set_implants(jointext(organ_data, "\[*\]"))
 
 	// Security record
 	set_criminalStatus(global.default_security_status)
-	set_dna(H?.get_unique_enzymes() || "")
-	set_fingerprint(H?.get_full_print(ignore_blockers = TRUE) || "")
+	set_dna(crewmember?.get_unique_enzymes() || "")
+	set_fingerprint(crewmember?.get_full_print(ignore_blockers = TRUE) || "")
 
 	var/security_record = records[PREF_SEC_RECORD]
-	set_security_record((security_record && !jobban_isbanned(H, "Records")) ? html_decode(security_record) : "No record supplied")
+	set_security_record((security_record && !jobban_isbanned(crewmember, "Records")) ? html_decode(security_record) : "No record supplied")
 
 	// Employment record
 	var/employment_record = "No record supplied"
-	if(H)
+	if(crewmember)
 		var/gen_record = records[PREF_GEN_RECORD]
-		if(gen_record && !jobban_isbanned(H, "Records"))
+		if(gen_record && !jobban_isbanned(crewmember, "Records"))
 			employment_record = html_decode(gen_record)
-		if(H.client && H.client.prefs)
+		if(crewmember.client && crewmember.client.prefs)
 			var/list/qualifications
-			for(var/culturetag in H.client.prefs.cultural_info)
-				var/decl/cultural_info/culture = GET_DECL(H.client.prefs.cultural_info[culturetag])
+			for(var/culturetag in crewmember.client.prefs.cultural_info)
+				var/decl/cultural_info/culture = GET_DECL(crewmember.client.prefs.cultural_info[culturetag])
 				var/extra_note = culture.get_qualifications()
 				if(extra_note)
 					LAZYADD(qualifications, extra_note)
@@ -110,46 +110,46 @@ var/global/arrest_security_status =  "Arrest"
 	set_employment_record(employment_record)
 
 	// Misc cultural info.
-	set_residence(H ? html_decode(H.get_cultural_value(TAG_HOMEWORLD)) : "Unset")
-	set_faction(H ?   html_decode(H.get_cultural_value(TAG_FACTION)) :   "Unset")
-	set_religion(H ?  html_decode(H.get_cultural_value(TAG_RELIGION)) :  "Unset")
+	set_residence(crewmember ? html_decode(crewmember.get_cultural_value(TAG_HOMEWORLD)) : "Unset")
+	set_faction(crewmember ?   html_decode(crewmember.get_cultural_value(TAG_FACTION)) :   "Unset")
+	set_religion(crewmember ?  html_decode(crewmember.get_cultural_value(TAG_RELIGION)) :  "Unset")
 
-	if(H)
+	if(crewmember)
 		var/skills = list()
-		for(var/decl/hierarchy/skill/S in global.using_map.get_available_skills())
-			var/level = H.get_skill_value(S.type)
+		for(var/decl/hierarchy/skill/skill in global.using_map.get_available_skills())
+			var/level = crewmember.get_skill_value(skill.type)
 			if(level > SKILL_NONE)
-				skills += "[S.name], [S.levels[level]]"
+				skills += "[skill.name], [skill.levels[level]]"
 
 		set_skillset(jointext(skills,"\n"))
 
 	// Antag record
-	if(H?.client?.prefs)
-		var/exploit_record =  H.client.prefs.exploit_record
-		set_antag_record((exploit_record && !jobban_isbanned(H, "Records")) ? html_decode(exploit_record) : "")
+	if(crewmember?.client?.prefs)
+		var/exploit_record =  crewmember.client.prefs.exploit_record
+		set_antag_record((exploit_record && !jobban_isbanned(crewmember, "Records")) ? html_decode(exploit_record) : "")
 
 // Cut down version for silicons
-/datum/computer_file/report/crew_record/synth/load_from_mob(var/mob/living/silicon/S)
-	if(istype(S))
-		photo_front = getFlatIcon(S, SOUTH, always_use_defdir = 1)
-		photo_side = getFlatIcon(S, WEST, always_use_defdir = 1)
+/datum/computer_file/report/crew_record/synth/load_from_mob(var/mob/living/silicon/silicon_crewmember)
+	if(istype(silicon_crewmember))
+		photo_front = getFlatIcon(silicon_crewmember, SOUTH, always_use_defdir = 1)
+		photo_side = getFlatIcon(silicon_crewmember, WEST, always_use_defdir = 1)
 
 	// Generic record
-	set_name(S ? S.real_name : "Unset")
-	set_formal_name(S ? S.real_name : "Unset")
+	set_name(silicon_crewmember ? silicon_crewmember.real_name : "Unset")
+	set_formal_name(silicon_crewmember ? silicon_crewmember.real_name : "Unset")
 	set_gender("Unset")
 	set_status(global.default_physical_status)
 	var/silicon_type = "Synthetic Lifeform"
-	var/robojob = GetAssignment(S)
-	if(isrobot(S))
-		var/mob/living/silicon/robot/R = S
-		silicon_type = R.braintype
-		if(R.module)
-			robojob = "[R.module.display_name] [silicon_type]"
-	if(isAI(S))
+	var/robojob = GetAssignment(silicon_crewmember)
+	if(isrobot(silicon_crewmember))
+		var/mob/living/silicon/robot/robot = silicon_crewmember
+		silicon_type = robot.braintype
+		if(robot.module)
+			robojob = "[robot.module.display_name] [silicon_type]"
+	if(isAI(silicon_crewmember))
 		silicon_type = "AI"
 		robojob = "Artificial Intelligence"
-	set_job(S ? robojob : "Unset")
+	set_job(silicon_crewmember ? robojob : "Unset")
 	set_species_name(silicon_type)
 
 	set_implants("Robotic body")
@@ -159,57 +159,57 @@ var/global/arrest_security_status =  "Arrest"
 
 // Global methods
 // Used by character creation to create a record for new arrivals.
-/proc/CreateModularRecord(var/mob/living/H, record_type = /datum/computer_file/report/crew_record)
-	var/datum/computer_file/report/crew_record/CR = new record_type()
-	global.all_crew_records.Add(CR)
-	CR.load_from_mob(H)
-	var/datum/computer_network/network = get_local_network_at(get_turf(H))
+/proc/CreateModularRecord(var/mob/living/crewmember, record_type = /datum/computer_file/report/crew_record)
+	var/datum/computer_file/report/crew_record/crew_record = new record_type()
+	global.all_crew_records.Add(crew_record)
+	crew_record.load_from_mob(crewmember)
+	var/datum/computer_network/network = get_local_network_at(get_turf(crewmember))
 	if(network)
-		network.store_file(CR, OS_RECORDS_DIR, TRUE, mainframe_role = MF_ROLE_CREW_RECORDS)
-	return CR
+		network.store_file(crew_record, OS_RECORDS_DIR, TRUE, mainframe_role = MF_ROLE_CREW_RECORDS)
+	return crew_record
 
 // Gets crew records filtered by set of positions
 /proc/department_crew_manifest(var/list/filter_positions, var/blacklist = FALSE)
 	var/list/matches = list()
-	for(var/datum/computer_file/report/crew_record/CR in global.all_crew_records)
-		var/rank = CR.get_job()
+	for(var/datum/computer_file/report/crew_record/crew_record in global.all_crew_records)
+		var/rank = crew_record.get_job()
 		if(blacklist)
 			if(!(rank in filter_positions))
-				matches.Add(CR)
+				matches.Add(crew_record)
 		else
 			if(rank in filter_positions)
-				matches.Add(CR)
+				matches.Add(crew_record)
 	return matches
 
 // Simple record to HTML (for paper purposes) conversion.
 // Not visually that nice, but it gets the work done, feel free to tweak it visually
-/proc/record_to_html(var/datum/computer_file/report/crew_record/CR, var/access)
+/proc/record_to_html(var/datum/computer_file/report/crew_record/crew_record, var/access)
 	var/dat = "<tt><H2>RECORD DATABASE DATA DUMP</H2><i>Generated on: [stationdate2text()] [stationtime2text()]</i><br>******************************<br>"
 	dat += "<table>"
-	for(var/datum/report_field/F in CR.fields)
-		if(F.get_perms(access) & OS_READ_ACCESS)
-			dat += "<tr><td><b>[F.display_name()]</b>"
-			if(F.needs_big_box)
+	for(var/datum/report_field/field in crew_record.fields)
+		if(field.get_perms(access) & OS_READ_ACCESS)
+			dat += "<tr><td><b>[field.display_name()]</b>"
+			if(field.needs_big_box)
 				dat += "<tr>"
-			dat += "<td>[F.get_value()]"
+			dat += "<td>[field.get_value()]"
 	dat += "</tt>"
 	return dat
 
 //Should only be used for OOC stuff, for player-facing stuff you must go through the network.
 /proc/get_crewmember_record(var/name)
-	for(var/datum/computer_file/report/crew_record/CR in global.all_crew_records)
-		if(CR.get_name() == name)
-			return CR
+	for(var/datum/computer_file/report/crew_record/crew_record in global.all_crew_records)
+		if(crew_record.get_name() == name)
+			return crew_record
 	return null
 
-/proc/GetAssignment(var/mob/living/human/H)
-	if(!H)
+/proc/GetAssignment(var/mob/living/crewmember)
+	if(!crewmember)
 		return "Unassigned"
-	if(!H.mind)
-		return H.job
-	if(H.mind.role_alt_title)
-		return H.mind.role_alt_title
-	return H.mind.assigned_role
+	if(!crewmember.mind)
+		return crewmember.job
+	if(crewmember.mind.role_alt_title)
+		return crewmember.mind.role_alt_title
+	return crewmember.mind.assigned_role
 
 #define GETTER_SETTER(PATH, KEY) /datum/computer_file/report/crew_record/proc/get_##KEY(){var/datum/report_field/F = locate(/datum/report_field/##PATH/##KEY) in fields; if(F) return F.get_value()} \
 /datum/computer_file/report/crew_record/proc/set_##KEY(given_value){var/datum/report_field/F = locate(/datum/report_field/##PATH/##KEY) in fields; if(F) F.set_value(given_value)}
@@ -279,16 +279,16 @@ FIELD_LONG("Exploitable Information", antag_record, access_hacked, access_hacked
 	. |= "Unset"
 	var/list/all_genders = decls_repository.get_decls_of_type(/decl/pronouns)
 	for(var/thing in all_genders)
-		var/decl/pronouns/G = all_genders[thing]
-		if(G.bureaucratic_term )
-			. |= G.bureaucratic_term
+		var/decl/pronouns/gender = all_genders[thing]
+		if(gender.bureaucratic_term )
+			. |= gender.bureaucratic_term
 
 /datum/report_field/options/crew_record/branch/proc/record_branches()
 	. = list()
 	. |= "Unset"
-	for(var/B in mil_branches.branches)
-		var/datum/mil_branch/BR = mil_branches.branches[B]
-		. |= BR.name
+	for(var/branch in mil_branches.branches)
+		var/datum/mil_branch/branch_datum = mil_branches.branches[branch]
+		. |= branch_datum.name
 
 #undef GETTER_SETTER
 #undef SETUP_FIELD

--- a/code/modules/sealant_gun/sealant.dm
+++ b/code/modules/sealant_gun/sealant.dm
@@ -38,7 +38,7 @@
 	break_apart(user)
 	return TRUE
 
-/obj/item/sealant/attackby(obj/item/W, mob/user)
+/obj/item/sealant/attackby(obj/item/used_item, mob/user)
 	break_apart(user)
 	return TRUE
 
@@ -54,9 +54,9 @@
 		user.setClickCooldown(1 SECOND)
 	qdel(src)
 
-/obj/item/sealant/Bump(atom/A, forced)
+/obj/item/sealant/Bump(atom/bumped, forced)
 	. = ..()
-	splat(A)
+	splat(bumped)
 
 /obj/item/sealant/throw_impact(atom/hit_atom)
 	. = ..()
@@ -66,18 +66,18 @@
 	if(splatted)
 		return
 	splatted = TRUE
-	var/turf/T = get_turf(target) || get_turf(src)
-	if(T)
-		new /obj/effect/sealant(T)
+	var/turf/target_turf = get_turf(target) || get_turf(src)
+	if(target_turf)
+		new /obj/effect/sealant(target_turf)
 		if(isliving(target))
-			var/mob/living/H = target
+			var/mob/living/living_target = target
 			for(var/slot in shuffle(splat_try_equip_slots))
-				if(!H.get_equipped_item(slot))
-					H.equip_to_slot_if_possible(src, slot)
-					if(H.get_equipped_item(slot) == src)
+				if(!living_target.get_equipped_item(slot))
+					living_target.equip_to_slot_if_possible(src, slot)
+					if(living_target.get_equipped_item(slot) == src)
 						return
-		if(!T.density && !(locate(foam_type) in T))
-			new foam_type(T)
+		if(!target_turf.density && !(locate(foam_type) in target_turf))
+			new foam_type(target_turf)
 
 	if(!QDELETED(src))
 		qdel(src)

--- a/code/modules/species/species_bodytype.dm
+++ b/code/modules/species/species_bodytype.dm
@@ -614,11 +614,11 @@ var/global/list/bodytypes_by_category = list()
 /decl/bodytype/proc/get_limb_from_zone(limb)
 	. = length(LAZYACCESS(limb_mapping, limb)) ? pick(limb_mapping[limb]) : limb
 
-/decl/bodytype/proc/check_vital_organ_missing(mob/living/H)
+/decl/bodytype/proc/check_vital_organ_missing(mob/living/patient)
 	if(length(vital_organs))
 		for(var/organ_tag in vital_organs)
-			var/obj/item/organ/O = H.get_organ(organ_tag, /obj/item/organ)
-			if(!O || (O.status & ORGAN_DEAD))
+			var/obj/item/organ/vital_organ = patient.get_organ(organ_tag, /obj/item/organ)
+			if(!vital_organ || (vital_organ.status & ORGAN_DEAD))
 				return TRUE
 	return FALSE
 

--- a/mods/content/psionics/machines/psimeter.dm
+++ b/mods/content/psionics/machines/psimeter.dm
@@ -31,9 +31,9 @@
 	else
 		dat += "<h2>TELESTO Mark I Psi-Meter</h2><hr><table border = 1 width = 100%><tr><td colspan = 2><b>Candidates</b></td></tr>"
 		var/found
-		for(var/mob/living/H in range(1, src))
+		for(var/mob/living/subject in range(1, src))
 			found = TRUE
-			dat += "<tr><td>[H.name]</td><td><a href='byond://?src=\ref[src];assay=\ref[H]'>Conduct Assay</a>"
+			dat += "<tr><td>[subject.name]</td><td><a href='byond://?src=\ref[src];assay=\ref[subject]'>Conduct Assay</a>"
 		if(!found)
 			dat += "<tr><td colspan = 2>No candidates found.</td></tr>"
 		dat += "<table>"

--- a/mods/gamemodes/deity/spells/open_gateway.dm
+++ b/mods/gamemodes/deity/spells/open_gateway.dm
@@ -13,14 +13,14 @@
 	cast_sound = 'sound/effects/meteorimpact.ogg'
 
 /spell/open_gateway/choose_targets()
-	var/mob/living/H = holder
-	var/turf/T = get_turf(H)
-	holder.visible_message(SPAN_NOTICE("A gateway opens up underneath \the [H]!"))
-	var/g
+	var/mob/living/spellcaster = holder
+	var/turf/source_turf = get_turf(spellcaster)
+	holder.visible_message(SPAN_NOTICE("A gateway opens up underneath \the [spellcaster]!"))
+	var/deity
 	var/decl/special_role/godcultist/godcult = GET_DECL(/decl/special_role/godcultist)
-	if(H.mind && (H.mind in godcult.current_antagonists))
-		g = godcult.get_deity(H.mind)
-	return list(new /obj/structure/deity/gateway(T,g))
+	if(spellcaster.mind && (spellcaster.mind in godcult.current_antagonists))
+		deity = godcult.get_deity(spellcaster.mind)
+	return list(new /obj/structure/deity/gateway(source_turf, deity))
 
 /spell/open_gateway/cast(var/list/targets, var/mob/holder, var/channel_count)
 	if(prob((channel_count / 5) * 100))

--- a/mods/mobs/borers/mob/borer/borer.dm
+++ b/mods/mobs/borers/mob/borer/borer.dm
@@ -235,9 +235,7 @@
 
 	host.reset_view(null)
 	host.machine = null
-
-	var/mob/living/H = host
-	H.status_flags &= ~PASSEMOTES
+	host.status_flags &= ~PASSEMOTES
 	host = null
 	return
 

--- a/mods/species/ascent/items/id_control.dm
+++ b/mods/species/ascent/items/id_control.dm
@@ -51,10 +51,10 @@
 	if(owner)
 		var/datum/extension/access_provider/owner_access = get_extension(owner, /datum/extension/access_provider)
 		owner_access?.unregister_id(src)
-	var/mob/living/H = owner
+	var/mob/living/old_owner = owner
 	. = ..()
-	if(H && !(locate(type) in H.get_internal_organs()))
-		H.remove_language(/decl/language/mantid/worldnet)
+	if(old_owner && !(locate(type) in old_owner.get_internal_organs()))
+		old_owner.remove_language(/decl/language/mantid/worldnet)
 
 /obj/item/organ/internal/controller/Initialize()
 	if(ispath(id_card))

--- a/mods/species/ascent/mobs/bodyparts_insectoid.dm
+++ b/mods/species/ascent/mobs/bodyparts_insectoid.dm
@@ -12,19 +12,19 @@
 
 /obj/item/organ/internal/egg_sac/insectoid/attack_self(var/mob/user)
 	. = ..()
-	var/mob/living/H = user
+	var/mob/living/living_user = user
 	if(.)
-		if(H.incapacitated())
-			to_chat(H, SPAN_WARNING("You can't produce eggs in your current state."))
+		if(living_user.incapacitated())
+			to_chat(living_user, SPAN_WARNING("You can't produce eggs in your current state."))
 			return
-		if(H.nutrition < egg_metabolic_cost)
-			to_chat(H, SPAN_WARNING("You are too ravenously hungry to produce more eggs."))
+		if(living_user.nutrition < egg_metabolic_cost)
+			to_chat(living_user, SPAN_WARNING("You are too ravenously hungry to produce more eggs."))
 			return
-		if(do_after(H, 5 SECONDS, H, FALSE))
-			H.adjust_nutrition(-1 * egg_metabolic_cost)
-			H.visible_message(SPAN_NOTICE("\icon[H] [H] carelessly deposits an egg on \the [get_turf(src)]."))
-			var/obj/structure/insectoid_egg/egg = new(get_turf(H)) // splorp
-			egg.lineage = H.get_gyne_lineage()
+		if(do_after(living_user, 5 SECONDS, living_user, FALSE))
+			living_user.adjust_nutrition(-1 * egg_metabolic_cost)
+			living_user.visible_message(SPAN_NOTICE("\icon[living_user] [living_user] carelessly deposits an egg on \the [get_turf(src)]."))
+			var/obj/structure/insectoid_egg/egg = new(get_turf(living_user)) // splorp
+			egg.lineage = living_user.get_gyne_lineage()
 
 /obj/item/organ/external/foot/insectoid/mantid
 	name = "left tail tip"


### PR DESCRIPTION
## Description of changes
Replaces a bunch of single- and double-letter variable names with more descriptive terms. All of the ones I changed were found by searching for `mob/living/H` and `mob/H` (except for one `mob/C`), and non-mob changes were done if I noticed the file was particularly egregious.

## Why and what will this PR improve
Code quality! Not player-facing, but part of my project to modernize the codebase and bring it up to proper code standards.