### PR TITLE
Clean up topic commands to use UIDs instead of a global list

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -121,11 +121,13 @@ var/global/world_topic_last = world.timeofday
 	if(!length(params))
 		return
 	var/command_key = params[1]
-	if(!command_key || !global.topic_commands[command_key])
+	if(!command_key)
+		return "Unrecognised Command"
+	var/decl/topic_command/command = decls_repository.get_decl_by_id("topic_command_[command_key]")
+	if(!istype(command))
 		return "Unrecognised Command"
 
-	var/decl/topic_command/TC = global.topic_commands[command_key]
-	return TC.try_use(T, addr, master, key)
+	return command.try_use(T, addr, master, key)
 
 /world/Reboot(var/reason)
 

--- a/code/game/world_topic_commands.dm
+++ b/code/game/world_topic_commands.dm
@@ -1,24 +1,10 @@
-var/global/list/decl/topic_command/topic_commands = list()
-
 /decl/topic_command
+	abstract_type = /decl/topic_command
 	var/name
 	var/has_params = FALSE
-	var/base_type = /decl/topic_command
-
-/// Initialises the assoc list of topic commands by key.
-/hook/startup/proc/setup_api()
-	var/list/commands = decls_repository.get_decls_of_subtype(/decl/topic_command)
-	for (var/command in commands)
-		var/decl/topic_command/TC = commands[command]
-		if(TC.base_type == command)
-			continue
-		global.topic_commands[TC.name] = TC
-	return TRUE
 
 /// Returns TRUE if we can use this command, and FALSE otherwise
 /decl/topic_command/proc/can_use(var/T, var/addr, var/master, var/key)
-	if(base_type == type) // this is an abstract type
-		return FALSE
 	if (has_params)
 		if (copytext(T, 1, length(name) + 1) != name)
 			return FALSE
@@ -38,7 +24,7 @@ var/global/list/decl/topic_command/topic_commands = list()
 	return use(params)
 
 /decl/topic_command/secure
-	base_type = /decl/topic_command/secure
+	abstract_type = /decl/topic_command/secure
 
 /decl/topic_command/secure/try_use(var/T, var/addr, var/master, var/key)
 	if (!can_use(T, addr, master, key))
@@ -60,6 +46,7 @@ var/global/list/decl/topic_command/topic_commands = list()
 
 /decl/topic_command/ping
 	name = "ping"
+	uid = "topic_command_ping"
 
 /decl/topic_command/ping/use()
 	var/x = 1
@@ -69,12 +56,14 @@ var/global/list/decl/topic_command/topic_commands = list()
 
 /decl/topic_command/players
 	name = "players"
+	uid = "topic_command_players"
 
 /decl/topic_command/players/use()
 	return global.clients.len
 
 /decl/topic_command/status
 	name = "status"
+	uid = "topic_command_status"
 	has_params = TRUE
 
 /decl/topic_command/status/use(var/list/params)
@@ -119,6 +108,7 @@ var/global/list/decl/topic_command/topic_commands = list()
 
 /decl/topic_command/manifest
 	name = "manifest"
+	uid = "topic_command_manifest"
 
 /decl/topic_command/manifest/use()
 	var/list/positions = list()
@@ -138,6 +128,7 @@ var/global/list/decl/topic_command/topic_commands = list()
 
 /decl/topic_command/revision
 	name = "revision"
+	uid = "topic_command_revision"
 
 /decl/topic_command/revision/use()
 	var/list/L = list()
@@ -162,6 +153,7 @@ var/global/list/decl/topic_command/topic_commands = list()
 * * * * * * * */
 /decl/topic_command/ban
 	name = "placepermaban"
+	uid = "topic_command_placepermaban"
 	has_params = TRUE
 
 /decl/topic_command/ban/try_use(var/T, var/addr, var/master, var/key)
@@ -205,6 +197,7 @@ var/global/list/decl/topic_command/topic_commands = list()
 
 /decl/topic_command/secure/laws
 	name = "laws"
+	uid = "topic_command_laws"
 	has_params = TRUE
 
 /decl/topic_command/secure/laws/use(var/list/params)
@@ -251,6 +244,7 @@ var/global/list/decl/topic_command/topic_commands = list()
 
 /decl/topic_command/secure/info
 	name = "info"
+	uid = "topic_command_info"
 	has_params = TRUE
 
 /decl/topic_command/secure/info/use(var/list/params)
@@ -300,6 +294,7 @@ var/global/list/decl/topic_command/topic_commands = list()
 
 /decl/topic_command/secure/adminmsg
 	name = "adminmsg"
+	uid = "topic_command_adminmsg"
 	has_params = TRUE
 
 /decl/topic_command/secure/adminmsg/use(var/list/params)
@@ -335,6 +330,7 @@ var/global/list/decl/topic_command/topic_commands = list()
 
 /decl/topic_command/secure/notes
 	name = "notes"
+	uid = "topic_command_notes"
 	has_params = TRUE
 
 /decl/topic_command/secure/notes/use(var/list/params)
@@ -342,6 +338,7 @@ var/global/list/decl/topic_command/topic_commands = list()
 
 /decl/topic_command/secure/age
 	name = "age"
+	uid = "topic_command_age"
 	has_params = TRUE
 
 /decl/topic_command/secure/age/use(var/list/params)
@@ -356,6 +353,7 @@ var/global/list/decl/topic_command/topic_commands = list()
 
 /decl/topic_command/secure/prometheus_metrics
 	name = "prometheus_metrics"
+	uid = "topic_command_prometheus_metrics"
 
 /decl/topic_command/secure/prometheus_metrics/use()
 	if(!global.prometheus_metrics)


### PR DESCRIPTION
## Description of changes
Cleans up topic commands. They now use abstract_type and UIDs instead of a bespoke `base_type` var and a global list of names -> commands.

Might be a good idea to go back and remove the `name` var or have it auto-set UIDs (if we allow that?) or whatever.

## Why and what will this PR improve
Improves the code quality of topic commands, which hadn't been touched in like three years.