### PR TITLE
Fix waterskins not being open containers

### DIFF
--- a/code/game/objects/items/waterskin.dm
+++ b/code/game/objects/items/waterskin.dm
@@ -4,8 +4,20 @@
 	icon = 'icons/obj/items/waterskin.dmi'
 	icon_state = ICON_STATE_WORLD
 	material = /decl/material/solid/organic/leather/gut
+	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	volume = 120
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME
+
+/obj/item/chems/waterskin/attack_self()
+	. = ..()
+	if(!.)
+		if(ATOM_IS_OPEN_CONTAINER(src))
+			to_chat(usr, SPAN_NOTICE("You cork \the [src]."))
+			atom_flags ^= ATOM_FLAG_OPEN_CONTAINER
+		else
+			to_chat(usr, SPAN_NOTICE("You remove the cork from \the [src]."))
+			atom_flags |= ATOM_FLAG_OPEN_CONTAINER
+		update_icon() // TODO: filled/empty and corked/uncorked sprites
 
 /obj/item/chems/waterskin/crafted
 	desc = "A long and rather unwieldly water-carrying vessel."


### PR DESCRIPTION
## Description of changes
Fixes waterskins not being an open container.
Allows you to toggle waterskins being open/closed.

## Why and what will this PR improve
You can now drink from waterskins, and avoid them spilling.

## Authorship
Me

## Changelog
:cl:
add: Waterskins can now be corked and uncorked
/:cl: