### PR TITLE
Prevent space from freezing things via gas conduction

### DIFF
--- a/code/game/atoms_temperature.dm
+++ b/code/game/atoms_temperature.dm
@@ -32,18 +32,19 @@
 	// Get our location temperature if possible.
 	// Nullspace is room temperature, clearly.
 	var/adjust_temp = T20C
+	var/thermal_mass_coefficient = get_thermal_mass_coefficient()
 	if(isturf(loc))
 		var/turf/T = loc
 		var/datum/gas_mixture/environment = T.return_air()
-		if(environment)
-			adjust_temp = environment.temperature
+		adjust_temp = environment.temperature
+		//scale the thermal mass coefficient so that 1atm = 1x, 0atm = 0x, 10atm = 10x
+		thermal_mass_coefficient *= (environment.return_pressure() / ONE_ATMOSPHERE)
 	else if(loc)
 		adjust_temp = loc.temperature
 
 	// Determine if our temperature needs to change.
 	var/old_temp = temperature
 	var/diff_temp = adjust_temp - temperature
-	var/thermal_mass_coefficient = get_thermal_mass_coefficient()
 	if(abs(diff_temp) >= (thermal_mass_coefficient * ATOM_TEMPERATURE_EQUILIBRIUM_THRESHOLD))
 		var/altered_temp = max(temperature + (thermal_mass_coefficient * diff_temp), 0)
 		ADJUST_ATOM_TEMPERATURE(src, (diff_temp > 0) ? min(adjust_temp, altered_temp) : max(adjust_temp, altered_temp))


### PR DESCRIPTION
## Description of changes
Heat transfer rate from local air to atoms now scales with air pressure.

## Why and what will this PR improve
Fixes #4163.

Currently, vacuum freezes things because it's at 2.7K even though there's no gas to transfer heat to. Now, at 0kPa no heat transfer will occur, and at 10kPa it'll equalize ten times as quickly (though maybe it'd be better to cap it at a max of 1x?)

In the future we can add radiation separately, but I would much rather have the issue of hot things not cooling down (since everything that does that presently has it hardcoded separately) than *everything* becoming ice-cold no matter what. This is gamebreaking, a lack of radiative cooling is relatively small.

## Authorship
Me.