### PR TITLE
Fix smelter being unable to melt graphite

### DIFF
--- a/code/__defines/research.dm
+++ b/code/__defines/research.dm
@@ -20,7 +20,7 @@
 #define BASE_OBJECT_MATTER_MULTPLIER    0.25
 
 #define GENERIC_SMELTING_HEAT_POINT 1000 CELSIUS
-#define HIGH_SMELTING_HEAT_POINT    1500 CELSIUS
+#define HIGH_SMELTING_HEAT_POINT    4000 CELSIUS // must be at least 4074K (3800 C) to melt graphite
 #define TECH_MATERIAL      "materials"
 #define TECH_ENGINEERING   "engineering"
 #define TECH_EXOTIC_MATTER "exoticmatter"

--- a/code/modules/mining/machinery/material_smelter.dm
+++ b/code/modules/mining/machinery/material_smelter.dm
@@ -24,30 +24,11 @@
 	create_reagents(INFINITY)
 	queue_temperature_atoms(src)
 
-// Outgas anything that is in gas form. Check what you put into the smeltery, nerds.
+// Update displayed materials
 /obj/machinery/material_processing/smeltery/on_reagent_change()
 
 	if(!(. = ..()) || !reagents)
 		return
-
-	var/datum/gas_mixture/environment = loc?.return_air()
-	if(!environment)
-		return
-
-	var/adjusted_air = FALSE
-	for(var/mtype in reagents?.reagent_volumes)
-		var/decl/material/mat = GET_DECL(mtype)
-		if(!isnull(mat.boiling_point) && temperature >= mat.boiling_point)
-			adjusted_air = TRUE
-			var/removing = REAGENT_VOLUME(reagents, mtype)
-			remove_from_reagents(mtype, removing, defer_update = TRUE)
-			if(environment)
-				environment.adjust_gas_temp(mtype, (removing * 0.2), temperature, FALSE) // Arbitrary conversion constant, TODO consistent one
-
-	if(adjusted_air)
-		if(environment)
-			environment.update_values()
-		reagents.update_total()
 
 	for(var/mtype in reagents.reagent_volumes)
 		show_materials |= mtype


### PR DESCRIPTION
## Description of changes
Increases the high smelting temperature to 4000C (4273.15K), enough to melt graphite (melting point of 4074K).

## Why and what will this PR improve
Fixes #4161. I understand that before it was set way too high, but like, it does need to be hot enough to melt graphite...

## Authorship
Me.