### PR TITLE
Fix solars not working in space

### DIFF
--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -585,6 +585,8 @@ INITIALIZE_IMMEDIATE(/obj/abstract/level_data_spawner)
 // Level Data Implementations
 ////////////////////////////////////////////
 /datum/level_data/space
+	daycycle_id = "space_solars"
+	daycycle_type = /datum/daycycle/solars
 
 /datum/level_data/debug
 	name = "Debug Level"


### PR DESCRIPTION
## Description of changes
Gives space levels a dummy daycycle by default.

## Why and what will this PR improve
Fixes #4162.

## Authorship
Loaf created the dummy daycycle, I'm just setting it up.