### PR TITLE
Fixes penlights not working to inspect pupils

### DIFF
--- a/code/game/objects/items/flashlights/_flashlight.dm
+++ b/code/game/objects/items/flashlights/_flashlight.dm
@@ -97,7 +97,7 @@
 
 /obj/item/flashlight/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
-	if(on && user.get_target_zone() == BP_EYES && target.should_have_organ(BP_HEAD))
+	if(on && user.get_target_zone() == BP_EYES && target.should_have_limb(BP_HEAD))
 
 		add_fingerprint(user)
 		if(user.has_genetic_condition(GENE_COND_CLUMSY) && prob(50))	//too dumb to use flashlight properly

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -58,7 +58,7 @@
 			to_chat(user, SPAN_WARNING("\The [target] isn't wearing a spacesuit for you to reseal."))
 		return TRUE
 
-	if(!target?.should_have_organ(BP_HEAD))
+	if(!target?.should_have_limb(BP_HEAD))
 		return ..()
 
 	if(user.get_target_zone() == BP_EYES)


### PR DESCRIPTION
## Description of changes
Penlights (and duct tape) used `should_have_organ()` (internal organs) rather than `should_have_limb()` (external organs). This fixes that.

## Why and what will this PR improve
Fixes #4173.