### PR TITLE
Added a mild toxin to replace bromide in food.

### DIFF
--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -421,7 +421,7 @@
 	SSnano.update_uis(src)
 	var/obj/item/chems/food/badrecipe/ffuu = new(src)
 	ffuu.add_to_reagents(/decl/material/solid/carbon, amount)
-	ffuu.add_to_reagents(/decl/material/liquid/bromide, amount/10)
+	ffuu.add_to_reagents(/decl/material/liquid/acrylamide, amount/10)
 	return ffuu
 
 /obj/machinery/microwave/OnTopic(href, href_list)

--- a/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
@@ -257,6 +257,15 @@
 		else if (prob(10))
 			to_chat(H, "<span class='warning'>You feel terribly ill!</span>")
 
+/decl/material/liquid/acrylamide
+	name = "acrylamide"
+	uid = "liquid_acrylamide"
+	lore_text = "A colourless substance formed when food is burned. Rumoured to cause cancer, but mostly just nasty to eat."
+	taste_description = "bitter char"
+	color = "#a39894"
+	toxicity = 2
+	taste_mult = 2
+
 /decl/material/liquid/bromide
 	name = "bromide"
 	codex_name = "elemental bromide"

--- a/code/modules/reagents/reagent_containers/food/meat/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/meat/meat.dm
@@ -191,7 +191,7 @@
 
 /obj/item/chems/food/organ
 	name = "organ"
-	desc = "It's good for you."
+	desc = "It's good for you, probably."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "appendix"
 	filling_color = "#e00d34"
@@ -201,7 +201,7 @@
 /obj/item/chems/food/organ/populate_reagents()
 	. = ..()
 	add_to_reagents(/decl/material/liquid/nutriment/protein, rand(3,5))
-	add_to_reagents(/decl/material/liquid/bromide,           rand(1,3)) //lolwat?
+	add_to_reagents(/decl/material/gas/ammonia,              rand(1,3)) // you probably should not be eating raw organ meat
 
 /obj/item/chems/food/meatkabob
 	name = "meat-kabob"

--- a/code/modules/reagents/reagent_containers/food/misc.dm
+++ b/code/modules/reagents/reagent_containers/food/misc.dm
@@ -8,8 +8,8 @@
 
 /obj/item/chems/food/badrecipe/populate_reagents()
 	. = ..()
-	add_to_reagents(/decl/material/liquid/nutriment/protein, 1)
-	add_to_reagents(/decl/material/solid/carbon,             3)
+	add_to_reagents(/decl/material/liquid/acrylamide, 1)
+	add_to_reagents(/decl/material/solid/carbon,      3)
 
 /obj/item/chems/food/stuffing
 	name = "stuffing"

--- a/code/modules/reagents/reagent_containers/food/soup.dm
+++ b/code/modules/reagents/reagent_containers/food/soup.dm
@@ -128,7 +128,7 @@
 		),
 		list(
 			/decl/material/solid/carbon =              10,
-			/decl/material/liquid/bromide =            10
+			/decl/material/liquid/acrylamide =         10
 		),
 		list(
 			/decl/material/liquid/nutriment =           5,


### PR DESCRIPTION
## Description of changes
- Adds acrylamide, a mild toxin, to replace the weird use of bromide in foods following the removal of generic `/decl/material/liquid/toxin` ages ago.
- Swaps meat/protein for acrylamide in burned recipes.
- Swaps bromide for ammonia in raw organs.

## Why and what will this PR improve
Generally makes more sense, patches over an unintended or undocumented change to cause burned recipes to have meat, which let them be farmed to make meatballs.

## Authorship
Myself.

## Changelog
:cl:
tweak: Burned recipes no longer contain meat, burned foods contain acrylamide, and organs now contain ammonia instead of bromide.
/:cl:
