### PR TITLE
Smaller atoms now manually heat target atoms slower or faster based on size.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -490,6 +490,9 @@
 /atom/movable/proc/get_object_size()
 	return ITEM_SIZE_NORMAL
 
+/atom/movable/get_manual_heat_source_coefficient()
+	return ..() * (get_object_size() / ITEM_SIZE_NORMAL)
+
 // TODO: account for reagents and matter.
 /atom/movable/get_thermal_mass()
 	if(!simulated)

--- a/code/game/atoms_temperature.dm
+++ b/code/game/atoms_temperature.dm
@@ -21,9 +21,12 @@
 	if(user && heated_by)
 		visible_message(SPAN_NOTICE("\The [user] carefully heats \the [src] with \the [heated_by]."))
 	// Update our own heat.
-	var/altered_temp = max(temperature + (get_thermal_mass_coefficient() * diff_temp), 0)
+	var/altered_temp = max(temperature + (get_thermal_mass_coefficient() * diff_temp * (heated_by ? heated_by.get_manual_heat_source_coefficient() : 1)), 0)
 	ADJUST_ATOM_TEMPERATURE(src, min(adjust_temp, altered_temp))
 	return TRUE
+
+/atom/proc/get_manual_heat_source_coefficient()
+	return 1
 
 // TODO: move mob bodytemperature onto this proc.
 /atom/proc/ProcessAtomTemperature()


### PR DESCRIPTION
## Description of changes
Adds procs to modify the effective heat transfer when 'carefully heating' atoms with things like welding torches.

## Why and what will this PR improve
Addresses #4147.

## Authorship
Myself.

## Changelog
:cl:
tweak: Cigarettes and welding torches will now heat atom reagents slower.
/:cl: