### PR TITLE
Unloaded items with cells should still create their extension.

### DIFF
--- a/code/datums/extensions/cell/cell.dm
+++ b/code/datums/extensions/cell/cell.dm
@@ -17,15 +17,18 @@
 			PRINT_STACK_TRACE("Non-cell type supplied to [type] as expected cell type.")
 		expected_cell_type = _expected_cell_type
 	if(ispath(_create_cell_type))
-		if(!ispath(_expected_cell_type, expected_cell_type))
-			PRINT_STACK_TRACE("Non-expected type supplied to [type] as premade cell type.")
-		loaded_cell_ref = weakref(new _create_cell_type(holder, _override_cell_capacity))
+		create_cell(_create_cell_type, _override_cell_capacity)
 
 /datum/extension/loaded_cell/Destroy()
 	var/obj/item/cell/existing_cell = loaded_cell_ref?.resolve()
 	if(istype(existing_cell) && !QDELETED(existing_cell) && existing_cell.loc == holder)
 		qdel(existing_cell)
 	return ..()
+
+/datum/extension/loaded_cell/proc/create_cell(_create_cell_type, _override_cell_capacity)
+	if(!ispath(_create_cell_type, expected_cell_type))
+		PRINT_STACK_TRACE("Non-expected type supplied to [type] as premade cell type.")
+	loaded_cell_ref = weakref(new _create_cell_type(holder, _override_cell_capacity))
 
 /datum/extension/loaded_cell/proc/get_cell()
 	var/obj/item/cell/cell = loaded_cell_ref?.resolve()

--- a/code/datums/extensions/cell/cell.dm
+++ b/code/datums/extensions/cell/cell.dm
@@ -27,7 +27,7 @@
 
 /datum/extension/loaded_cell/proc/create_cell(_create_cell_type, _override_cell_capacity)
 	if(!ispath(_create_cell_type, expected_cell_type))
-		PRINT_STACK_TRACE("Non-expected type supplied to [type] as premade cell type.")
+		PRINT_STACK_TRACE("Non-expected type '[_create_cell_type]' supplied to [type] as premade cell type (expected '[expected_cell_type]').")
 	loaded_cell_ref = weakref(new _create_cell_type(holder, _override_cell_capacity))
 
 /datum/extension/loaded_cell/proc/get_cell()

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -948,8 +948,8 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 /obj/item/proc/setup_power_supply(loaded_cell_type, accepted_cell_type, power_supply_extension_type, charge_value)
 	SHOULD_CALL_PARENT(FALSE)
-	if(loaded_cell_type && accepted_cell_type)
-		set_extension(src, (power_supply_extension_type || /datum/extension/loaded_cell), accepted_cell_type, loaded_cell_type, charge_value)
+	if(loaded_cell_type || accepted_cell_type)
+		set_extension(src, (power_supply_extension_type || /datum/extension/loaded_cell), (accepted_cell_type || loaded_cell_type), loaded_cell_type, charge_value)
 
 /obj/item/proc/handle_loadout_equip_replacement(obj/item/old_item)
 	return

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -37,7 +37,7 @@
 	return ..(ml, material_key, loaded_cell_type = /obj/item/cell/device/high)
 
 /obj/item/baton/infinite/Initialize(var/ml, var/material_key, var/loaded_cell_type)
-	. = ..(ml, material_key, loaded_cell_type = /obj/item/cell/infinite)
+	. = ..(ml, material_key, loaded_cell_type = /obj/item/cell/device/infinite)
 	set_status(1, null)
 
 /obj/item/baton/proc/update_status()


### PR DESCRIPTION
Fixes https://github.com/ScavStation/ScavStation/issues/1025.