### PR TITLE
Generalizes the simple_animal melee telegraph.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -124,10 +124,10 @@
 			var/resolved = holding.resolve_attackby(A, src, params)
 			if(!resolved && A && holding)
 				holding.afterattack(A, src, 1, params) // 1 indicates adjacency
-			setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+			setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		else
 			if(ismob(A)) // No instant mob attacking
-				setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+				setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 			UnarmedAttack(A, TRUE)
 
 		trigger_aiming(TARGET_CAN_CLICK)
@@ -151,10 +151,10 @@
 				var/resolved = holding.resolve_attackby(A,src, params)
 				if(!resolved && A && holding)
 					holding.afterattack(A, src, 1, params) // 1: clicking something Adjacent
-				setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+				setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 			else
 				if(ismob(A)) // No instant mob attacking
-					setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+					setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 				UnarmedAttack(A, TRUE)
 
 			trigger_aiming(TARGET_CAN_CLICK)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -116,6 +116,11 @@
 	var/sdepth = A.storage_depth(src)
 	if((!isturf(A) && A == loc) || (sdepth != -1 && sdepth <= 1))
 		if(holding)
+
+			// AI driven mobs have a melee telegraph that needs to be handled here.
+			if(a_intent == I_HURT && istype(A) && (!do_attack_windup_checking(A) || holding != get_active_held_item()))
+				return TRUE
+
 			var/resolved = holding.resolve_attackby(A, src, params)
 			if(!resolved && A && holding)
 				holding.afterattack(A, src, 1, params) // 1 indicates adjacency
@@ -137,6 +142,11 @@
 	if(isturf(A) || isturf(A.loc) || (sdepth != -1 && sdepth <= 1))
 		if(A.Adjacent(src)) // see adjacent.dm
 			if(holding)
+
+				// AI driven mobs have a melee telegraph that needs to be handled here.
+				if(a_intent == I_HURT && istype(A) && (!do_attack_windup_checking(A) || holding != get_active_held_item()))
+					return TRUE
+
 				// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)
 				var/resolved = holding.resolve_attackby(A,src, params)
 				if(!resolved && A && holding)
@@ -210,6 +220,10 @@
 	// Pick up items.
 	if(check_dexterity(DEXTERITY_HOLD_ITEM, silent = TRUE))
 		return A.attack_hand(src)
+
+	// AI driven mobs have a melee telegraph that needs to be handled here.
+	if(a_intent == I_HURT && istype(A) && !do_attack_windup_checking(A))
+		return TRUE
 
 	return FALSE
 

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -76,7 +76,7 @@
 		var/resolved = holding.resolve_attackby(A, src, params)
 		if(!resolved && A && holding)
 			holding.afterattack(A, src, 1, params) // 1 indicates adjacency
-		setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+		setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		return
 
 	if(!isturf(loc))
@@ -88,7 +88,7 @@
 			var/resolved = holding.resolve_attackby(A, src, params)
 			if(!resolved && A && holding)
 				holding.afterattack(A, src, 1, params) // 1 indicates adjacency
-			setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+			setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		else
 			holding.afterattack(A, src, 0, params)
 		return

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -74,31 +74,15 @@
 	if(.)
 		return
 
-	setClickCooldown(attack_delay)
+	a_intent = I_HURT
 	var/attacking_with = get_natural_weapon()
 	if(a_intent == I_HELP || !attacking_with)
 		return A.attack_animal(src)
 
-	var/decl/pronouns/G = get_pronouns()
-	face_atom(A)
-	if(attack_delay)
-		stop_automove() // Cancel any baked-in movement.
-		do_windup_animation(A, attack_delay, no_reset = TRUE)
-		if(!do_after(src, attack_delay, A) || !Adjacent(A))
-			visible_message(SPAN_NOTICE("\The [src] misses [G.his] attack on \the [A]!"))
-			animate(src, pixel_x = default_pixel_x, pixel_y = default_pixel_y, time = 2) // reset wherever the attack animation got us to.
-			ai?.move_to_target(TRUE) // Restart hostile mob tracking.
-			return TRUE
-		ai?.move_to_target(TRUE) // Restart hostile mob tracking.
-
-	if(ismob(A)) // Clientless mobs are too dum to move away, so they can be missed.
-		var/mob/mob = A
-		if(!mob.ckey && !prob(get_melee_accuracy()))
-			visible_message(SPAN_NOTICE("\The [src] misses [G.his] attack on \the [A]!"))
-			return TRUE
-
 	. = A.attackby(attacking_with, src)
-	if(isliving(A))
+	if(!.)
+		reset_offsets(anim_time = 2)
+	else if(isliving(A))
 		apply_attack_effects(A)
 
 // Attack hand but for simple animals

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -1073,7 +1073,15 @@ modules/mob/living/human/life.dm if you die, you will be zoomed out.
 		try_burn_wearer(user, slot, 1)
 
 /obj/item/can_embed()
-	return !anchored && !is_robot_module(src)
+	. = !anchored && !is_robot_module(src)
+	if(. && isliving(loc))
+		var/mob/living/holder = loc
+		// Terrible check for if the mob is being driven by an AI or not.
+		// AI can't retrieve the weapon currently so this is unfair.
+		if(holder.get_attack_telegraph_delay() > 0)
+			return FALSE
+		// Skill check to avoid getting it stuck.
+		return holder.skill_fail_prob(SKILL_COMBAT, 100, no_more_fail = SKILL_EXPERT)
 
 /obj/item/clear_matter()
 	..()

--- a/code/modules/mob/living/human/human.dm
+++ b/code/modules/mob/living/human/human.dm
@@ -1213,3 +1213,6 @@
 		if(istype(limb.material, /decl/material/solid/organic/meat))
 			return TRUE
 	return FALSE
+
+/mob/living/human/get_attack_telegraph_delay()
+	return client ? 0 : DEFAULT_ATTACK_COOLDOWN

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1691,3 +1691,42 @@ default behaviour is:
 	if(target.is_open() && target.has_gravity() && !can_overcome_gravity())
 		return FALSE
 	return TRUE
+
+/mob/living/proc/get_attack_telegraph_delay()
+	return 0
+
+/mob/living/proc/get_base_telegraphed_melee_accuracy()
+	return 85
+
+/mob/living/proc/get_telegraphed_melee_accuracy()
+	return clamp(get_base_telegraphed_melee_accuracy() - melee_accuracy_mods(), 0, 100)
+
+// This will generally only be invoked by AI driven mobs. Player humans do not show the windup.
+/mob/living/do_attack_windup_checking(atom/target)
+
+	var/attack_delay = get_attack_telegraph_delay()
+	if(attack_delay <= 0)
+		return TRUE
+
+	var/decl/pronouns/G = get_pronouns()
+	setClickCooldown(attack_delay)
+	face_atom(target)
+
+	stop_automove() // Cancel any baked-in movement.
+	do_windup_animation(target, attack_delay, no_reset = TRUE)
+	if(!do_after(src, attack_delay, target) || !Adjacent(target))
+		visible_message(SPAN_NOTICE("\The [src] misses [G.his] attack on \the [target]!"))
+		reset_offsets(anim_time = 2)
+		ai?.move_to_target(TRUE) // Restart hostile mob tracking.
+		return FALSE
+
+	ai?.move_to_target(TRUE) // Restart hostile mob tracking.
+	if(ismob(target))
+		// Clientless mobs are too dum to move away, so they can be missed.
+		var/mob/mob = target
+		if(!mob.ckey && !prob(get_telegraphed_melee_accuracy()))
+			visible_message(SPAN_NOTICE("\The [src] misses [G.his] attack on \the [target]!"))
+			reset_offsets(anim_time = 2)
+			return FALSE
+
+	return TRUE

--- a/code/modules/mob/living/simple_animal/_simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/_simple_animal.dm
@@ -461,8 +461,8 @@ var/global/list/simplemob_icon_bitflag_cache = list()
 	bodytype_flag = 0
 	bodytype_category = "quadrupedal animal body"
 
-/mob/living/simple_animal/proc/get_melee_accuracy()
-	return clamp(sa_accuracy - melee_accuracy_mods(), 0, 100)
+/mob/living/simple_animal/get_base_telegraphed_melee_accuracy()
+	return sa_accuracy
 
 /mob/living/simple_animal/check_has_mouth()
 	return TRUE
@@ -544,3 +544,6 @@ var/global/list/simplemob_icon_bitflag_cache = list()
 
 /mob/living/simple_animal/can_eat_food_currently(obj/eating, mob/user, consumption_method)
 	return TRUE
+
+/mob/living/simple_animal/get_attack_telegraph_delay()
+	return attack_delay

--- a/code/modules/mob/living/simple_animal/natural_weapons.dm
+++ b/code/modules/mob/living/simple_animal/natural_weapons.dm
@@ -7,6 +7,7 @@
 	canremove = FALSE
 	obj_flags = OBJ_FLAG_CONDUCTIBLE //for intent of shocking checks, they're right inside the animal
 	is_spawnable_type = FALSE
+	needs_attack_dexterity = DEXTERITY_NONE
 	var/show_in_message   // whether should we show up in attack message, e.g. 'urist has been bit with teeth by carp' vs 'urist has been bit by carp'
 
 /obj/item/natural_weapon/attack_message_name()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1371,3 +1371,6 @@
 	var/datum/movement_handler/mob/delay/delay = locate() in movement_handlers
 	if(istype(delay))
 		delay.next_move = world.time
+
+/mob/proc/do_attack_windup_checking(atom/target)
+	return TRUE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1374,3 +1374,11 @@
 
 /mob/proc/do_attack_windup_checking(atom/target)
 	return TRUE
+
+/mob/living/human/debug_attack_windup
+	ai = /datum/mob_controller/aggressive
+	faction = "arsehole"
+
+/mob/living/human/debug_attack_windup/Initialize(mapload, species_name, datum/mob_snapshot/supplied_appearance)
+	. = ..()
+	put_in_active_hand(new /obj/item/stamp/denied(src))


### PR DESCRIPTION
- AI-driven living mobs in general will perform the simple_animal windup before hitting with their melee attack.
- Click delay on attack_hand and use_on_mob has been returned to default attack cooldown instead of quick. You can go Fist of the Northern Star on current code.
- Melee embedding now has a skill check against close combat to avoid losing your weapon.