### PR TITLE
Fixes quote marks getting scrambled in custom emotes.

### DIFF
--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -168,6 +168,7 @@
 	message = trim(html_encode(message))
 	message = filter_modify_message(message)
 	message = format_emote(src, message)
+	message = trim(html_decode(message))
 
 	if (message)
 		log_emote("[name]/[key] : [message]")


### PR DESCRIPTION
Fixes #4201. 
Not sure if this is a good fix, or why html_encode is being used in the first place, but this appears to fix it.