### PR TITLE
Items now take heat damage from fires, and organs can burn to nothing.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -474,6 +474,9 @@
 /atom/proc/handle_melting(list/meltable_materials)
 	SHOULD_CALL_PARENT(TRUE)
 
+/atom/proc/handle_destroyed_by_heat()
+	return handle_melting()
+
 /**
 	Handle this atom being exposed to lava. Calls qdel() by default
 

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -12,9 +12,20 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "ash"
 
+/obj/effect/decal/cleanable/ash/attackby(obj/item/I, mob/user)
+	if(ATOM_IS_OPEN_CONTAINER(I))
+		if(REAGENTS_FREE_SPACE(I.reagents) <= 0)
+			to_chat(user, SPAN_WARNING("\The [I] is full."))
+		else
+			I.add_to_reagents(/decl/material/solid/carbon/ashes, 20)
+			user.visible_message(SPAN_NOTICE("\The [user] carefully scoops \the [src] into \the [I]."))
+			qdel(src)
+		return TRUE
+	return ..()
+
 /obj/effect/decal/cleanable/ash/attack_hand(var/mob/user)
 	SHOULD_CALL_PARENT(FALSE)
-	to_chat(user, "<span class='notice'>[src] sifts through your fingers.</span>")
+	to_chat(user, SPAN_NOTICE("\The [src] sifts through your fingers."))
 	var/turf/F = get_turf(src)
 	if (istype(F))
 		F.add_dirt(4)

--- a/code/game/objects/items/_item_drying.dm
+++ b/code/game/objects/items/_item_drying.dm
@@ -73,5 +73,14 @@
 
 /obj/item/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()
+
+	// Take fire damage if appropriate.
+	if(get_max_health() != ITEM_HEALTH_NO_DAMAGE && length(matter))
+		for(var/mat in matter)
+			var/decl/material/material = GET_DECL(mat)
+			if(!isnull(material.temperature_damage_threshold) && exposed_temperature >= material.temperature_damage_threshold)
+				take_damage(rand(3,5), BURN)
+				break
+
 	if(exposed_temperature >= drying_threshold_temperature)
 		dry_out(drying_power = rand(2, 4), fire_exposed = TRUE, silent = TRUE)

--- a/code/game/objects/items/_item_materials.dm
+++ b/code/game/objects/items/_item_materials.dm
@@ -41,7 +41,7 @@
 			shatter(consumed)
 			return
 	else if(lastdamtype == BURN)
-		handle_melting()
+		handle_destroyed_by_heat()
 		return
 	physically_destroyed()
 

--- a/code/modules/materials/definitions/solids/materials_solid_elements.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_elements.dm
@@ -48,6 +48,17 @@
 			if(R != type)
 				ingested.remove_reagent(R, removed * effect)
 
+/decl/material/solid/carbon/ashes
+	name = "ashes"
+	uid = "solid_ashes"
+	lore_text = "The powdery remains of burned organic material."
+	color = "#5c5c5c"
+	dissolves_in = MAT_SOLVENT_MODERATE
+	// Todo: calcium
+	dissolves_into = list(
+		/decl/material/solid/carbon = 1
+	)
+
 /decl/material/solid/phosphorus
 	name = "phosphorus"
 	uid = "solid_phosphorus"

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -557,6 +557,11 @@ var/global/list/ailment_reference_cache = list()
 // The organ may be inside an external organ that's not inside a mob, or inside a mob
 //detached : If true, the organ will be installed in a detached state, otherwise it will be added in an attached state
 /obj/item/organ/proc/do_install(var/mob/living/human/target, var/obj/item/organ/external/affected, var/in_place = FALSE, var/update_icon = TRUE, var/detached = FALSE)
+
+	// While on an owner, do not take damage.
+	max_health = ITEM_HEALTH_NO_DAMAGE
+	current_health = ITEM_HEALTH_NO_DAMAGE
+
 	//Make sure to force the flag accordingly
 	set_detached(detached)
 	if(QDELETED(src))
@@ -584,6 +589,13 @@ var/global/list/ailment_reference_cache = list()
 //detach: If detach is true, we're going to set the organ to detached, and add it to the detached organs list, and remove it from processing lists.
 //        If its false, we just remove the organ from all lists
 /obj/item/organ/proc/do_uninstall(var/in_place = FALSE, var/detach = FALSE, var/ignore_children = FALSE, var/update_icon = TRUE)
+
+	max_health = max_damage
+	if(current_health == ITEM_HEALTH_NO_DAMAGE)
+		current_health = max_health
+	else
+		current_health = min(current_health, max_health)
+
 	action_button_name = null
 	screen_loc = null
 	rejecting = null
@@ -650,3 +662,11 @@ var/global/list/ailment_reference_cache = list()
 /// Returns a list with two entries, first being the stat panel title, the second being the value. See has_stat_value bool above.
 /obj/item/organ/proc/get_stat_info()
 	return null
+
+/obj/item/organ/handle_destroyed_by_heat()
+	if(owner)
+		return
+	if(isturf(loc))
+		new /obj/effect/decal/cleanable/ash(loc)
+	if(!QDELETED(src))
+		qdel(src)


### PR DESCRIPTION
- Items with matter will take damage if exposed to fire_act() temperatures beyond their temperature damage threshold.
- Organs will set and clear damage immunity on being added to or removed from a mob.
- Organs destroyed with heat will leave ashes behind.
- Ashes can be moved into containers by clicking them with the container (prep for soapmaking).