### PR TITLE
Generalizing the weather processing system for atoms.

### DIFF
--- a/code/controllers/subsystems/weather_atoms.dm
+++ b/code/controllers/subsystems/weather_atoms.dm
@@ -1,0 +1,55 @@
+SUBSYSTEM_DEF(weather_atoms)
+	name     = "Weather Atoms"
+	wait     = 2 SECONDS
+	priority = SS_PRIORITY_WEATHER
+	flags    = SS_NO_INIT
+	var/list/weather_atoms = list()
+	var/list/processing_atoms
+
+	// Predeclared vars for processing.
+	var/atom/atom
+	var/obj/abstract/weather_system/weather
+	var/decl/state/weather/weather_state
+
+/datum/controller/subsystem/weather_atoms/stat_entry()
+	..("A:[weather_atoms.len]")
+
+/datum/controller/subsystem/weather_atoms/fire(resumed = 0)
+	if(!resumed)
+		processing_atoms = weather_atoms.Copy()
+
+	atom          = null
+	weather       = null
+	weather_state = null
+
+	var/i = 0
+	while(i < processing_atoms.len)
+		i++
+		atom = processing_atoms[i]
+
+		// Atom is null or doesn't exist, remove it from processing.
+		if(QDELETED(atom))
+			weather_atoms -= atom
+			continue
+
+		// Not outside, or not on a turf with a Z- weather is not relevant.
+		if(!atom.z || !atom.is_outside())
+			continue
+
+		// If weather does not exist, we don't care.
+		weather = atom.get_affecting_weather()
+		weather_state = weather?.weather_system?.current_state
+		if(!istype(weather_state))
+			continue
+
+		// Process the atom and return early if needed.
+		if(atom.process_weather(weather, weather_state) == PROCESS_KILL)
+			weather_atoms -= atom
+		if (MC_TICK_CHECK)
+			processing_atoms.Cut(1, i+1)
+			return
+
+	processing_atoms.Cut()
+
+/atom/proc/process_weather(obj/abstract/weather_system/weather, decl/state/weather/weather_state)
+	return PROCESS_KILL

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -958,3 +958,10 @@
 
 /atom/proc/spark_act(obj/effect/sparks/sparks)
 	return
+
+/atom/proc/get_affecting_weather()
+	return
+
+/atom/proc/is_outside()
+	var/turf/turf = get_turf(src)
+	return istype(turf) ? turf.is_outside() : OUTSIDE_UNCERTAIN

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -570,3 +570,13 @@
 	var/datum/movement_handler/delay/delay = locate() in movement_handlers
 	if(istype(delay))
 		delay.next_move = world.time
+
+/atom/movable/get_affecting_weather()
+	var/turf/my_turf = get_turf(src)
+	if(!istype(my_turf))
+		return
+	var/turf/actual_loc = loc
+	// If we're standing in the rain, use the turf weather.
+	. = istype(actual_loc) && actual_loc.weather
+	if(!.) // If we're under or inside shelter, use the z-level rain (for ambience)
+		. = SSweather.weather_by_z[my_turf.z]

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -59,13 +59,15 @@
 // Returns true if overriden and needs deletion. If the argument is false, we will merge into any existing blood.
 /obj/effect/decal/cleanable/blood/proc/merge_with_blood()
 	if(!isturf(loc) || blood_size == BLOOD_SIZE_NO_MERGE)
-		return
+		return FALSE
 	for(var/obj/effect/decal/cleanable/blood/B in loc)
 		if(B != src && B.blood_size != BLOOD_SIZE_NO_MERGE)
 			if(B.blood_DNA)
 				blood_size = BLOOD_SIZE_NO_MERGE
 				B.blood_DNA |= blood_DNA.Copy()
+			B.alpha = initial(B.alpha) // reset rain-based fading due to more drips
 			return TRUE
+	return FALSE
 
 /obj/effect/decal/cleanable/blood/proc/start_drying()
 	drytime = world.time + DRYING_TIME * (amount+1)

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -11,6 +11,7 @@
 	gender = PLURAL
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "ash"
+	weather_sensitive = FALSE
 
 /obj/effect/decal/cleanable/ash/attackby(obj/item/I, mob/user)
 	if(ATOM_IS_OPEN_CONTAINER(I))
@@ -46,6 +47,7 @@
 	layer = ABOVE_HUMAN_LAYER
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "cobweb1"
+	weather_sensitive = FALSE
 
 /obj/effect/decal/cleanable/molten_item
 	name = "gooey grey mass"
@@ -54,6 +56,7 @@
 	icon_state = "molten"
 	persistent = TRUE
 	generic_filth = TRUE
+	weather_sensitive = FALSE
 
 /obj/effect/decal/cleanable/cobweb2
 	name = "cobweb"
@@ -61,6 +64,7 @@
 	layer = ABOVE_HUMAN_LAYER
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "cobweb2"
+	weather_sensitive = FALSE
 
 //Vomit (sorry)
 /obj/effect/decal/cleanable/vomit

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -2,6 +2,7 @@
 	density = FALSE
 	anchored = TRUE
 
+	var/weather_sensitive = TRUE
 	var/persistent = FALSE
 	var/generic_filth = FALSE
 	var/age = 0
@@ -33,10 +34,23 @@
 		animate(src, alpha = 0, time = 5 SECONDS)
 		QDEL_IN(src, 5 SECONDS)
 
+	if(weather_sensitive)
+		SSweather_atoms.weather_atoms += src
+
 /obj/effect/decal/cleanable/Destroy()
+	if(weather_sensitive)
+		SSweather_atoms.weather_atoms -= src
 	if(persistent)
 		SSpersistence.forget_value(src, /decl/persistence_handler/filth)
 	. = ..()
+
+/obj/effect/decal/cleanable/process_weather(obj/abstract/weather_system/weather, decl/state/weather/weather_state)
+	if(!weather_sensitive)
+		return PROCESS_KILL
+	if(weather_state.is_liquid)
+		alpha -= 15
+		if(alpha <= 0)
+			clean(TRUE)
 
 /obj/effect/decal/cleanable/clean(clean_forensics = TRUE)
 	if(clean_forensics)

--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -2,6 +2,7 @@
 	name = "rune"
 	desc = "A rune drawn in crayon."
 	icon = 'icons/obj/rune.dmi'
+	weather_sensitive = FALSE
 
 /obj/effect/decal/cleanable/crayon/Initialize(mapload, main = "#ffffff", shade = "#000000", var/type = "rune")
 	name = type

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -537,7 +537,7 @@
 
 	SSair.mark_for_update(src)
 
-/turf/proc/is_outside()
+/turf/is_outside()
 
 	// Can't rain inside or through solid walls.
 	// TODO: dense structures like full windows should probably also block weather.
@@ -762,6 +762,9 @@
 /turf/proc/get_fishing_result(obj/item/chems/food/bait)
 	var/area/A = get_area(src)
 	return A.get_fishing_result(src, bait)
+
+/turf/get_affecting_weather()
+	return weather
 
 /turf/get_alt_interactions(mob/user)
 	. = ..()

--- a/code/modules/mob/living/human/human_defines.dm
+++ b/code/modules/mob/living/human/human_defines.dm
@@ -4,6 +4,7 @@
 	mob_bump_flag = HUMAN
 	mob_push_flags = ~HEAVY
 	mob_swap_flags = ~HEAVY
+	weather_sensitive = TRUE
 
 	/// If true, the next icon update will also regenerate the body.
 	var/regenerate_body_icon = FALSE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -12,6 +12,9 @@
 	else
 		add_to_living_mob_list()
 
+	if(weather_sensitive)
+		SSweather_atoms.weather_atoms += src
+
 /mob/living/get_ai_type()
 	var/decl/species/my_species = get_species()
 	if(ispath(my_species?.ai))
@@ -729,6 +732,8 @@ default behaviour is:
 	// done in this order so that icon updates aren't triggered once all our organs are obliterated
 	delete_inventory(TRUE)
 	delete_organs()
+	if(weather_sensitive)
+		SSweather_atoms.weather_atoms -= src
 	return ..()
 
 /mob/living/proc/melee_accuracy_mods()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -87,5 +87,8 @@
 	/// Organ instances that should report info to Stat().
 	var/list/stat_organs
 
+	/// Should this mob subscribe to the weather system for periodic weather effects?
+	var/weather_sensitive = FALSE
+
 	/// Var used to track current step for footsteps sounds.
 	var/tmp/step_count

--- a/code/modules/mob/living/simple_animal/_simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/_simple_animal.dm
@@ -470,10 +470,6 @@ var/global/list/simplemob_icon_bitflag_cache = list()
 /mob/living/simple_animal/can_buckle_mob(var/mob/living/dropping)
 	. = ..() && can_have_rider && (dropping.mob_size <= max_rider_size)
 
-// Simplemobs have to hang out in the rain so make them immune to weather effects (like hail).
-/mob/living/simple_animal/handle_weather_effects()
-	SHOULD_CALL_PARENT(FALSE)
-
 /mob/living/simple_animal/get_available_postures()
 	var/static/list/available_postures = list(
 		/decl/posture/standing,

--- a/code/modules/weather/weather_fsm_states.dm
+++ b/code/modules/weather/weather_fsm_states.dm
@@ -61,21 +61,16 @@
 	handle_protected_effects(M, weather)
 
 /decl/state/weather/proc/handle_exposure(var/mob/living/M, var/exposure, var/obj/abstract/weather_system/weather)
-
-	// Send strings if we're outside.
-	if(M.is_outside() && M.client)
-		if(!weather.show_weather(M))
-			weather.show_wind(M)
-
-	if(exposure != WEATHER_IGNORE && weather.set_cooldown(M))
-		if(exposure == WEATHER_EXPOSED)
-			handle_exposure_effects(M, weather)
-		else if(exposure == WEATHER_ROOFED)
-			handle_roofed_effects(M, weather)
-		else if(exposure == WEATHER_PROTECTED)
-			var/list/protected_by = M.get_weather_protection()
-			if(LAZYLEN(protected_by))
-				handle_protected_effects(M, weather, pick(protected_by))
+	if(exposure == WEATHER_IGNORE || !weather.set_cooldown(M))
+		return
+	if(exposure == WEATHER_EXPOSED)
+		handle_exposure_effects(M, weather)
+	else if(exposure == WEATHER_ROOFED)
+		handle_roofed_effects(M, weather)
+	else if(exposure == WEATHER_PROTECTED)
+		var/list/protected_by = M.get_weather_protection()
+		if(LAZYLEN(protected_by))
+			handle_protected_effects(M, weather, pick(protected_by))
 
 /decl/state/weather/proc/adjust_temperature(initial_temperature)
 	return initial_temperature

--- a/nebula.dme
+++ b/nebula.dme
@@ -294,6 +294,7 @@
 #include "code\controllers\subsystems\vis_contents.dm"
 #include "code\controllers\subsystems\vote.dm"
 #include "code\controllers\subsystems\weather.dm"
+#include "code\controllers\subsystems\weather_atoms.dm"
 #include "code\controllers\subsystems\xenoarch.dm"
 #include "code\controllers\subsystems\zcopy.dm"
 #include "code\controllers\subsystems\initialization\character_info.dm"


### PR DESCRIPTION
- `SSweather_atoms` handles processing atoms that care about weather (humans and cleanable decals currently).
- Most cleanable decals will slowly fade away while rained on. 
- Weather ambience for mobs is handled by `handle_environment()` while exposure effects are handled by `process_weather()`.
- `get_affecting_weather()` and `is_outside()` have been generalized to `/atom`.