### PR TITLE
Shaded Hills Beggar Knight changes

### DIFF
--- a/maps/shaded_hills/jobs/visitors.dm
+++ b/maps/shaded_hills/jobs/visitors.dm
@@ -42,12 +42,16 @@
 	name                    = "Itinerant Scholar"
 
 /datum/job/shaded_hills/visitor/beggar_knight
-	title                   = "Beggar Knight"
+	title                   = "Beggar Knight, Shortsword and Shield"
 	supervisors             = "your vows"
 	description             = "You are a wandering swordmaster sworn to a vow of poverty, with nothing to your name but the armour on your back and the blade at your hip. Beggar knights are tolerated due to their martial prowess, and are usually paid with food or new equipment as they are avowed against carrying coin."
 	spawn_positions         = 2
 	total_positions         = 2
+	economic_power = 0 //vowed against carrying money
 	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/beggar_knight
+	alt_titles              = list(
+		"Beggar Knight, Longsword" = /decl/hierarchy/outfit/job/shaded_hills/beggar_knight/longsword,
+	)
 	min_skill               = list(
 		SKILL_WEAPONS       = SKILL_ADEPT,
 		SKILL_ATHLETICS     = SKILL_ADEPT,

--- a/maps/shaded_hills/outfits/visitors.dm
+++ b/maps/shaded_hills/outfits/visitors.dm
@@ -2,9 +2,20 @@
 	name    = "Shaded Hills - Traveller"
 
 /decl/hierarchy/outfit/job/shaded_hills/beggar_knight
-	name = "Shaded Hills - Beggar Knight"
+	name = "Shaded Hills - Beggar Knight, Shortsword and Shield"
 	suit = /obj/item/clothing/suit/armor/forged/banded
 	belt = /obj/item/bladed/shortsword
+	hands = list(/obj/item/shield/buckler)
+	backpack_contents = list(
+		/obj/item/stack/medical/bruise_pack/bandage/five = 1,
+		/obj/item/stack/medical/ointment/poultice/five   = 1,
+		/obj/item/chems/waterskin/crafted/wine           = 1
+	)
+
+/decl/hierarchy/outfit/job/shaded_hills/beggar_knight/longsword
+	name = "Shaded Hills - Beggar Knight, Longsword"
+	suit = /obj/item/clothing/suit/armor/forged/banded
+	belt = /obj/item/bladed/longsword
 	backpack_contents = list(
 		/obj/item/stack/medical/bruise_pack/bandage/five = 1,
 		/obj/item/stack/medical/ointment/poultice/five   = 1,

--- a/maps/shaded_hills/outfits/visitors.dm
+++ b/maps/shaded_hills/outfits/visitors.dm
@@ -16,6 +16,7 @@
 	name = "Shaded Hills - Beggar Knight, Longsword"
 	suit = /obj/item/clothing/suit/armor/forged/banded
 	belt = /obj/item/bladed/longsword
+	hands = list()
 	backpack_contents = list(
 		/obj/item/stack/medical/bruise_pack/bandage/five = 1,
 		/obj/item/stack/medical/ointment/poultice/five   = 1,


### PR DESCRIPTION
## Description of changes
Adds different alt titles for beggar knight, allowing them to either spawn with a shortsword and shield, or with a longsword. Also makes it so beggar knights do not spawn with money even if you select to have money in character setup.

## Why and what will this PR improve
Being able to pick different kinds of weapon to carry is neat, and keeping knights from breaking their vow before even spawning is good.

## Authorship
Myself

## Changelog
:cl:
add: Alt titles to allow Beggar Knights on Shaded Hills to spawn either with a shortsword and shield or a longsword.
tweak: Made it so Beggar Knights on Shaded Hills do not spawn with money.
/:cl: