### PR TITLE
Loadout now uses the decl system and UID.

### DIFF
--- a/code/__defines/bodytype.dm
+++ b/code/__defines/bodytype.dm
@@ -8,9 +8,9 @@
 
 // Bodytype appearance flags
 #define HAS_SKIN_TONE_NORMAL  BITFLAG(0)  // Skin tone selectable in chargen for baseline humans (0-220)
-#define HAS_SKIN_COLOR        BITFLAG(1)  // Skin colour selectable in chargen. (RGB)
+#define HAS_SKIN_COLOR        BITFLAG(1)  // Skin color selectable in chargen. (RGB)
 #define HAS_UNDERWEAR         BITFLAG(3)  // Underwear is drawn onto the mob icon.
-#define HAS_EYE_COLOR         BITFLAG(4)  // Eye colour selectable in chargen. (RGB)
+#define HAS_EYE_COLOR         BITFLAG(4)  // Eye color selectable in chargen. (RGB)
 #define RADIATION_GLOWS       BITFLAG(6)  // Radiation causes this character to glow.
 #define HAS_SKIN_TONE_GRAV    BITFLAG(7)  // Skin tone selectable in chargen for grav-adapted humans (0-100)
 #define HAS_SKIN_TONE_SPCR    BITFLAG(8)  // Skin tone selectable in chargen for spacer humans (0-165)

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -418,7 +418,7 @@ SUBSYSTEM_DEF(jobs)
 	var/list/loadout_taken_slots = list()
 	if(H.client.prefs.Gear() && job.loadout_allowed)
 		for(var/thing in H.client.prefs.Gear())
-			var/decl/loadout_option/G = global.gear_datums[thing]
+			var/decl/loadout_option/G = decls_repository.get_decl_by_id_or_var(thing, /decl/loadout_option)
 			if(G)
 				var/permitted = FALSE
 				if(G.allowed_branches)
@@ -448,7 +448,7 @@ SUBSYSTEM_DEF(jobs)
 					to_chat(H, SPAN_WARNING("Your current species, job, branch, skills or whitelist status does not permit you to spawn with [thing]!"))
 					continue
 
-				if(!G.slot || G.slot == slot_tie_str || (G.slot in loadout_taken_slots) || !G.spawn_on_mob(H, H.client.prefs.Gear()[G.name]))
+				if(!G.slot || G.slot == slot_tie_str || (G.slot in loadout_taken_slots) || !G.spawn_on_mob(H, H.client.prefs.Gear()[G.uid]))
 					spawn_in_storage.Add(G)
 				else
 					loadout_taken_slots.Add(G.slot)
@@ -542,7 +542,7 @@ SUBSYSTEM_DEF(jobs)
 
 	if(spawn_in_storage)
 		for(var/decl/loadout_option/G in spawn_in_storage)
-			G.spawn_in_storage_or_drop(H, H.client.prefs.Gear()[G.name])
+			G.spawn_in_storage_or_drop(H, H.client.prefs.Gear()[G.uid])
 
 	to_chat(H, "<font size = 3><B>You are [job.total_positions == 1 ? "the" : "a"] [alt_title || job_title].</B></font>")
 

--- a/code/game/objects/items/passport.dm
+++ b/code/game/objects/items/passport.dm
@@ -23,8 +23,8 @@
 	var/pob = culture ? culture.name : "Unset"
 
 	var/fingerprint = H.get_full_print(ignore_blockers = TRUE) || "N/A"
-	var/decl/pronouns/G = H.get_pronouns(ignore_coverings = TRUE)
-	info = "\icon[src] [src]:\nName: [H.real_name]\nSpecies: [H.get_species_name()]\nGender: [capitalize(G.name)]\nAge: [H.get_age()]\nPlace of Birth: [pob]\nFingerprint: [fingerprint]"
+	var/decl/pronouns/pronouns = H.get_pronouns(ignore_coverings = TRUE)
+	info = "\icon[src] [src]:\nName: [H.real_name]\nSpecies: [H.get_species_name()]\nGender: [capitalize(pronouns.name)]\nAge: [H.get_age()]\nPlace of Birth: [pob]\nFingerprint: [fingerprint]"
 
 /obj/item/passport/attack_self(mob/user)
 	user.visible_message(

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -83,11 +83,11 @@
 			. += "<a href='?src=\ref[src];bodytype=\ref[B]'>[capitalize(B.pref_name)]</a>"
 
 	. += "<br><b>Pronouns:</b> "
-	for(var/decl/pronouns/G in S.available_pronouns)
-		if(G.name == pref.gender)
-			. += "<span class='linkOn'>[G.pronoun_string]</span>"
+	for(var/decl/pronouns/pronouns in S.available_pronouns)
+		if(pronouns.name == pref.gender)
+			. += "<span class='linkOn'>[pronouns.pronoun_string]</span>"
 		else
-			. += "<a href='?src=\ref[src];gender=\ref[G]'>[G.pronoun_string]</a>"
+			. += "<a href='?src=\ref[src];gender=\ref[pronouns]'>[pronouns.pronoun_string]</a>"
 
 	. += "<br><b>Spawnpoint</b>:"
 	var/decl/spawnpoint/spawnpoint = GET_DECL(pref.spawnpoint)

--- a/code/modules/client/preference_setup/loadout/lists/accessories.dm
+++ b/code/modules/client/preference_setup/loadout/lists/accessories.dm
@@ -9,6 +9,7 @@
 /decl/loadout_option/accessory/tie
 	name = "tie selection"
 	path = /obj/item/clothing/accessory
+	uid = "gear_accessory_tie"
 
 /decl/loadout_option/accessory/tie/get_gear_tweak_options()
 	. = ..()
@@ -29,6 +30,7 @@
 	name = "colored tie"
 	path = /obj/item/clothing/accessory
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_accessory_tie_color"
 
 /decl/loadout_option/accessory/tie_color/get_gear_tweak_options()
 	. = ..()
@@ -41,23 +43,28 @@
 /decl/loadout_option/accessory/locket
 	name = "locket"
 	path = /obj/item/clothing/accessory/locket
+	uid = "gear_accessory_locket"
 
 /decl/loadout_option/accessory/necklace
-	name = "necklace, colour select"
+	name = "necklace, color select"
 	path = /obj/item/clothing/accessory/necklace
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_accessory_necklace"
 
 /decl/loadout_option/accessory/bowtie
 	name = "bowtie, horrible"
 	path = /obj/item/clothing/accessory/bowtie/ugly
+	uid = "gear_accessory_bowtie"
 
 /decl/loadout_option/accessory/bowtie/color
-	name = "bowtie, colour select"
+	name = "bowtie, color select"
 	path = /obj/item/clothing/accessory/bowtie/color
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_accessory_bowtie_color"
 
 /decl/loadout_option/accessory/bracelet
 	name = "bracelet, color select"
 	path = /obj/item/clothing/accessory/bracelet
 	cost = 1
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_accessory_bracelet"

--- a/code/modules/client/preference_setup/loadout/lists/clothing.dm
+++ b/code/modules/client/preference_setup/loadout/lists/clothing.dm
@@ -11,15 +11,18 @@
 	path = /obj/item/clothing/accessory/toggleable/flannel
 	slot = slot_tie_str
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_clothing_flannel"
 
 /decl/loadout_option/clothing/scarf
 	name = "scarf"
 	path = /obj/item/clothing/accessory/scarf
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_clothing_scarf"
 
 /decl/loadout_option/clothing/hawaii
 	name = "hawaii shirt"
 	path = /obj/item/clothing/accessory/toggleable/hawaii
+	uid = "gear_clothing_hawaii"
 
 /decl/loadout_option/clothing/hawaii/get_gear_tweak_options()
 	. = ..()
@@ -31,54 +34,65 @@
 	)
 
 /decl/loadout_option/clothing/vest
-	name = "suit vest, colour select"
+	name = "suit vest, color select"
 	path = /obj/item/clothing/accessory/toggleable
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_clothing_suit_vest"
 
 /decl/loadout_option/clothing/suspenders
 	name = "suspenders"
 	path = /obj/item/clothing/accessory/suspenders
+	uid = "gear_clothing_suspenders"
 
 /decl/loadout_option/clothing/suspenders/colorable
-	name = "suspenders, colour select"
+	name = "suspenders, color select"
 	path = /obj/item/clothing/accessory/suspenders/colorable
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_clothing_suspenders_colour"
 
 /decl/loadout_option/clothing/wcoat
-	name = "waistcoat, colour select"
+	name = "waistcoat, color select"
 	path = /obj/item/clothing/accessory/wcoat
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_clothing_waistcoat"
 
 /decl/loadout_option/clothing/zhongshan
-	name = "zhongshan jacket, colour select"
+	name = "zhongshan jacket, color select"
 	path = /obj/item/clothing/accessory/toggleable/zhongshan
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_clothing_zhongshan"
 
 /decl/loadout_option/clothing/dashiki
 	name = "dashiki selection"
 	path = /obj/item/clothing/accessory/dashiki
 	loadout_flags = GEAR_HAS_TYPE_SELECTION
+	uid = "gear_clothing_dashiki"
 
 /decl/loadout_option/clothing/thawb
 	name = "thawb"
 	path = /obj/item/clothing/accessory/thawb
+	uid = "gear_clothing_thawb"
 
 /decl/loadout_option/clothing/sherwani
-	name = "sherwani, colour select"
+	name = "sherwani, color select"
 	path = /obj/item/clothing/accessory/sherwani
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_clothing_sherwani"
 
 /decl/loadout_option/clothing/qipao
-	name = "qipao blouse, colour select"
+	name = "qipao blouse, color select"
 	path = /obj/item/clothing/accessory/qipao
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_clothing_qipao"
 
 /decl/loadout_option/clothing/sweater
-	name = "turtleneck sweater, colour select"
+	name = "turtleneck sweater, color select"
 	path = /obj/item/clothing/accessory/sweater
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_clothing_sweater"
 
 /decl/loadout_option/clothing/tangzhuang
-	name = "tangzhuang jacket, colour select"
+	name = "tangzhuang jacket, color select"
 	path = /obj/item/clothing/accessory/tangzhuang
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_clothing_tangzuhang"

--- a/code/modules/client/preference_setup/loadout/lists/earwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/earwear.dm
@@ -10,6 +10,7 @@
 /decl/loadout_option/ears/earrings
 	name = "earrings"
 	path = /obj/item/clothing/ears
+	uid = "gear_ears_earrings"
 
 /decl/loadout_option/ears/earrings/get_gear_tweak_options()
 	. = ..()

--- a/code/modules/client/preference_setup/loadout/lists/eyegear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/eyegear.dm
@@ -9,10 +9,12 @@
 /decl/loadout_option/eyes/eyepatch
 	name = "eyepatch"
 	path = /obj/item/clothing/glasses/eyepatch
+	uid = "gear_eyes_eyepatch"
 
 /decl/loadout_option/eyes/glasses
 	name = "glasses selection"
 	path = /obj/item/clothing/glasses
+	uid = "gear_eyes_glasses"
 
 /decl/loadout_option/eyes/glasses/get_gear_tweak_options()
 	. = ..()
@@ -28,6 +30,7 @@
 	name = "sunglasses selection"
 	path = /obj/item/clothing/glasses/sunglasses
 	cost = 3
+	uid = "gear_eyes_shades"
 
 /decl/loadout_option/eyes/shades/get_gear_tweak_options()
 	. = ..()
@@ -41,3 +44,4 @@
 	name = "blindfold"
 	path = /obj/item/clothing/glasses/blindfold
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_eyes_blindfold"

--- a/code/modules/client/preference_setup/loadout/lists/footwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/footwear.dm
@@ -7,14 +7,16 @@
 	abstract_type = /decl/loadout_option/shoes
 
 /decl/loadout_option/shoes/athletic
-	name = "athletic shoes, colour select"
+	name = "athletic shoes, color select"
 	path = /obj/item/clothing/shoes/athletic
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_shoes_athletic"
 
 /decl/loadout_option/shoes/boots
 	name = "boot selection"
 	path = /obj/item/clothing/shoes
 	cost = 2
+	uid = "gear_shoes_boots"
 
 /decl/loadout_option/shoes/boots/get_gear_tweak_options()
 	. = ..()
@@ -30,6 +32,7 @@
 /decl/loadout_option/shoes/color
 	name = "shoe selection"
 	path = /obj/item/clothing/shoes
+	uid = "gear_shoes_color"
 
 /decl/loadout_option/shoes/color/get_gear_tweak_options()
 	. = ..()
@@ -51,20 +54,24 @@
 	)
 
 /decl/loadout_option/shoes/flats
-	name = "flats, colour select"
+	name = "flats, color select"
 	path = /obj/item/clothing/shoes/flats
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_shoes_flats"
 
 /decl/loadout_option/shoes/high
 	name = "high tops selection"
 	path = /obj/item/clothing/shoes/color/hightops
 	loadout_flags = GEAR_HAS_TYPE_SELECTION
+	uid = "gear_shoes_high_tops"
 
 /decl/loadout_option/shoes/sandal
 	name = "wooden sandals"
 	path = /obj/item/clothing/shoes/sandal
+	uid = "gear_shoes_sandals"
 
 /decl/loadout_option/shoes/heels
-	name = "high heels, colour select"
+	name = "high heels, color select"
 	path = /obj/item/clothing/shoes/heels
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_shoes_heels"

--- a/code/modules/client/preference_setup/loadout/lists/gloves.dm
+++ b/code/modules/client/preference_setup/loadout/lists/gloves.dm
@@ -11,16 +11,19 @@
 	name = "gloves, colored"
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
 	path = /obj/item/clothing/gloves/color
+	uid = "gear_gloves_color"
 
 /decl/loadout_option/gloves/evening
-	name = "gloves, evening, colour select"
+	name = "gloves, evening, color select"
 	path = /obj/item/clothing/gloves/color/evening
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_gloves_evening"
 
 /decl/loadout_option/ring
 	name = "ring"
 	path = /obj/item/clothing/ring
 	cost = 2
+	uid = "gear_gloves_ring"
 
 /decl/loadout_option/ring/get_gear_tweak_options()
 	. = ..()

--- a/code/modules/client/preference_setup/loadout/lists/headwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/headwear.dm
@@ -7,14 +7,16 @@
 	abstract_type = /decl/loadout_option/head
 
 /decl/loadout_option/head/beret
-	name = "beret, colour select"
+	name = "beret, color select"
 	path = /obj/item/clothing/head/beret/plaincolor
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
 	description = "A simple, solid color beret. This one has no emblems or insignia on it."
+	uid = "gear_head_beret"
 
 /decl/loadout_option/head/bandana
 	name = "bandana selection"
 	path = /obj/item/clothing
+	uid = "gear_head_bandana"
 
 /decl/loadout_option/head/bandana/get_gear_tweak_options()
 	. = ..()
@@ -25,20 +27,24 @@
 	name = "beanie, color select"
 	path = /obj/item/clothing/head/beanie
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_head_beanie"
 
 /decl/loadout_option/head/bow
-	name = "hair bow, colour select"
+	name = "hair bow, color select"
 	path = /obj/item/clothing/head/hairflower/bow
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_head_bow"
 
 /decl/loadout_option/head/flat_cap
-	name = "flat cap, colour select"
+	name = "flat cap, color select"
 	path = /obj/item/clothing/head/flatcap
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_head_flat_cap"
 
 /decl/loadout_option/head/cap
 	name = "cap selection"
 	path = /obj/item/clothing/head
+	uid = "gear_head_cap"
 
 /decl/loadout_option/head/cap/get_gear_tweak_options()
 	. = ..()
@@ -59,6 +65,7 @@
 /decl/loadout_option/head/hairflower
 	name = "hair flower pin"
 	path = /obj/item/clothing/head/hairflower
+	uid = "gear_head_hairflower"
 
 /decl/loadout_option/head/hairflower/get_gear_tweak_options()
 	. = ..()
@@ -74,6 +81,7 @@
 	name = "hardhat selection"
 	path = /obj/item/clothing/head/hardhat
 	cost = 2
+	uid = "gear_head_hardhat"
 
 /decl/loadout_option/head/hardhat/get_gear_tweak_options()
 	. = ..()
@@ -88,6 +96,7 @@
 /decl/loadout_option/head/formalhat
 	name = "formal hat selection"
 	path = /obj/item/clothing/head
+	uid = "gear_head_formal"
 
 /decl/loadout_option/head/formalhat/get_gear_tweak_options()
 	. = ..()
@@ -106,6 +115,7 @@
 /decl/loadout_option/head/informalhat
 	name = "informal hat selection"
 	path = /obj/item/clothing/head
+	uid = "gear_head_informal"
 
 /decl/loadout_option/head/informalhat/get_gear_tweak_options()
 	. = ..()
@@ -116,37 +126,45 @@
 	)
 
 /decl/loadout_option/head/hijab
-	name = "hijab, colour select"
+	name = "hijab, color select"
 	path = /obj/item/clothing/head/hijab
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_head_hijab"
 
 /decl/loadout_option/head/kippa
-	name = "kippa, colour select"
+	name = "kippa, color select"
 	path = /obj/item/clothing/head/kippa
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_head_kippa"
 
 /decl/loadout_option/head/turban
-	name = "turban, colour select"
+	name = "turban, color select"
 	path = /obj/item/clothing/head/turban
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_head_turban"
 
 /decl/loadout_option/head/taqiyah
-	name = "taqiyah, colour select"
+	name = "taqiyah, color select"
 	path = /obj/item/clothing/head/taqiyah
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_head_taqiyah"
 
 /decl/loadout_option/head/rastacap
 	name = "rastacap"
 	path = /obj/item/clothing/head/rastacap
+	uid = "gear_head_rastacap"
 
 /decl/loadout_option/head/tankccap
 	name = "padded cap"
 	path = /obj/item/clothing/head/tank
+	uid = "gear_head_tankcap"
 
 /decl/loadout_option/head/headphones
 	name = "headphones"
 	path = /obj/item/clothing/head/headphones
+	uid = "gear_head_headphones"
 
 /decl/loadout_option/head/balaclava
 	name = "balaclava"
 	path = /obj/item/clothing/mask/balaclava
+	uid = "gear_head_balaclava"

--- a/code/modules/client/preference_setup/loadout/lists/misc.dm
+++ b/code/modules/client/preference_setup/loadout/lists/misc.dm
@@ -1,38 +1,47 @@
 /decl/loadout_option/cane
 	name = "cane"
 	path = /obj/item/cane
+	uid = "gear_misc_cane"
 
 /decl/loadout_option/dice
 	name = "dice pack"
 	path = /obj/item/storage/pill_bottle/dice
+	uid = "gear_misc_dice"
 
 /decl/loadout_option/dice/nerd
 	name = "dice pack (gaming)"
 	path = /obj/item/storage/pill_bottle/dice_nerd
+	uid = "gear_misc_dice_gamer"
 
 /decl/loadout_option/cards
 	name = "deck of cards"
 	path = /obj/item/deck/cards
+	uid = "gear_misc_cards"
 
 /decl/loadout_option/tarot
 	name = "deck of tarot cards"
 	path = /obj/item/deck/tarot
+	uid = "gear_misc_cards_tarot"
 
 /decl/loadout_option/holder
 	name = "card holder"
 	path = /obj/item/deck/holder
+	uid = "gear_misc_card_holder"
 
 /decl/loadout_option/cardemon_pack
 	name = "Cardemon booster pack"
 	path = /obj/item/pack/cardemon
+	uid = "gear_misc_cardemon"
 
 /decl/loadout_option/spaceball_pack
 	name = "Spaceball booster pack"
 	path = /obj/item/pack/spaceball
+	uid = "gear_misc_spaceball"
 
 /decl/loadout_option/flask
 	name = "flask"
 	path = /obj/item/chems/drinks/flask/barflask
+	uid = "gear_misc_flask"
 
 /decl/loadout_option/flask/get_gear_tweak_options()
 	. = ..()
@@ -42,6 +51,7 @@
 /decl/loadout_option/vacflask
 	name = "vacuum-flask"
 	path = /obj/item/chems/drinks/flask/vacuumflask
+	uid = "gear_misc_vacflask"
 
 /decl/loadout_option/vacflask/get_gear_tweak_options()
 	. = ..()
@@ -52,30 +62,36 @@
 	name = "coffee cup"
 	path = /obj/item/chems/drinks/glass2/coffeecup
 	loadout_flags = GEAR_HAS_TYPE_SELECTION
+	uid = "gear_misc_coffeecup"
 
 /decl/loadout_option/towel
 	name = "towel"
 	path = /obj/item/towel
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_misc_towel"
 
 /decl/loadout_option/mirror
 	name = "handheld mirror"
 	path = /obj/item/mirror
+	uid = "gear_misc_mirror"
 
 /decl/loadout_option/lipstick
 	name = "lipstick selection"
 	path = /obj/item/cosmetics/lipstick
 	loadout_flags = GEAR_HAS_SUBTYPE_SELECTION
+	uid = "gear_misc_lipstick"
 
 /decl/loadout_option/eyeshadow
 	name = "eyeshadow selection"
 	path = /obj/item/cosmetics/eyeshadow
 	loadout_flags = GEAR_HAS_SUBTYPE_SELECTION
+	uid = "gear_misc_eyeshadow"
 
 /decl/loadout_option/grooming
 	name = "grooming tool selection"
 	path = /obj/item/grooming
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_misc_grooming"
 
 /decl/loadout_option/grooming/get_gear_tweak_options()
 	. = ..()
@@ -91,22 +107,27 @@
 	name = "sterile mask"
 	path = /obj/item/clothing/mask/surgical
 	cost = 2
+	uid = "gear_misc_mask"
 
 /decl/loadout_option/smokingpipe
 	name = "pipe, smoking"
 	path = /obj/item/clothing/mask/smokable/pipe
+	uid = "gear_misc_pipe"
 
 /decl/loadout_option/cornpipe
 	name = "pipe, corn"
 	path = /obj/item/clothing/mask/smokable/pipe/cobpipe
+	uid = "gear_misc_cornpipe"
 
 /decl/loadout_option/matchbook
 	name = "matchbook"
 	path = /obj/item/storage/box/matches
+	uid = "gear_misc_matches"
 
 /decl/loadout_option/lighter
 	name = "cheap lighter"
 	path = /obj/item/flame/lighter
+	uid = "gear_misc_lighter"
 
 /decl/loadout_option/lighter/get_gear_tweak_options()
 	. = ..()
@@ -123,20 +144,24 @@
 /decl/loadout_option/ashtray
 	name = "ashtray, plastic"
 	path = /obj/item/ashtray/plastic
+	uid = "gear_misc_ashtray"
 
 /decl/loadout_option/ecig
 	name = "electronic cigarette"
 	path = /obj/item/clothing/mask/smokable/ecig/util
+	uid = "gear_misc_ecig"
 
 /decl/loadout_option/ecig/deluxe
 	name = "electronic cigarette, deluxe"
 	path = /obj/item/clothing/mask/smokable/ecig/deluxe
 	cost = 2
+	uid = "gear_misc_ecig_deluxe"
 
 /decl/loadout_option/bible
 	name = "holy book"
 	path = /obj/item/storage/bible
 	cost = 2
+	uid = "gear_misc_bible"
 
 /decl/loadout_option/bible/get_gear_tweak_options()
 	. = ..()
@@ -154,6 +179,7 @@
 	name = "cross"
 	path = /obj/item/cross
 	cost = 2
+	uid = "gear_misc_cross"
 
 /decl/loadout_option/cross/get_gear_tweak_options()
 	. = ..()
@@ -165,14 +191,16 @@
 	)
 
 /decl/loadout_option/wallet
-	name = "wallet, colour select"
+	name = "wallet, color select"
 	path = /obj/item/storage/wallet
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_misc_wallet"
 
 /decl/loadout_option/wallet_poly
 	name = "wallet, polychromic"
 	path = /obj/item/storage/wallet/poly
 	cost = 2
+	uid = "gear_misc_wallet_poly"
 
 
 /decl/loadout_option/swiss
@@ -180,3 +208,4 @@
 	path = /obj/item/knife/folding/swiss
 	cost = 4
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_misc_multitool"

--- a/code/modules/client/preference_setup/loadout/lists/suits.dm
+++ b/code/modules/client/preference_setup/loadout/lists/suits.dm
@@ -11,10 +11,12 @@
 	path = /obj/item/clothing/suit/poncho/colored
 	cost = 1
 	loadout_flags = GEAR_HAS_TYPE_SELECTION
+	uid = "gear_suit_poncho"
 
 /decl/loadout_option/suit/suit_jacket
 	name = "standard suit jackets"
 	path = /obj/item/clothing/suit/storage/toggle/suit
+	uid = "gear_suit_jackets"
 
 /decl/loadout_option/suit/suit_jacket/get_gear_tweak_options()
 	. = ..()
@@ -26,23 +28,27 @@
 	)
 
 /decl/loadout_option/suit/custom_suit_jacket
-	name = "suit jacket, colour select"
+	name = "suit jacket, color select"
 	path = /obj/item/clothing/suit/storage/toggle/suit
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_suit_jackets_color"
 
 /decl/loadout_option/suit/hoodie
-	name = "hoodie, colour select"
+	name = "hoodie, color select"
 	path = /obj/item/clothing/suit/storage/toggle/hoodie
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_suit_hoodie"
 
 /decl/loadout_option/suit/coat
-	name = "coat, colour select"
+	name = "coat, color select"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/coat
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_suit_coat"
 
 /decl/loadout_option/suit/leather
 	name = "jacket selection"
 	path = /obj/item/clothing/suit
+	uid = "gear_suit_leather_jacket"
 
 /decl/loadout_option/suit/leather/get_gear_tweak_options()
 	. = ..()
@@ -56,26 +62,31 @@
 /decl/loadout_option/suit/wintercoat
 	name = "winter coat"
 	path = /obj/item/clothing/suit/storage/toggle/wintercoat
+	uid = "gear_suit_winter_coat"
 
 /decl/loadout_option/suit/track
 	name = "track jacket selection"
 	path = /obj/item/clothing/suit/storage/toggle/track
 	loadout_flags = GEAR_HAS_TYPE_SELECTION
+	uid = "gear_suit_track_jacket"
 
 /decl/loadout_option/suit/blueapron
 	name = "apron, blue"
 	path = /obj/item/clothing/suit/apron
 	cost = 1
+	uid = "gear_suit_apron"
 
 /decl/loadout_option/suit/overalls
 	name = "apron, overalls"
 	path = /obj/item/clothing/suit/apron/overalls
 	cost = 1
+	uid = "gear_suit_overalls"
 
 /decl/loadout_option/suit/trenchcoat
 	name = "trenchcoat selection"
 	path = /obj/item/clothing/suit
 	cost = 3
+	uid = "gear_suit_trenchcoat"
 
 /decl/loadout_option/suit/trenchcoat/get_gear_tweak_options()
 	. = ..()
@@ -87,13 +98,15 @@
 	)
 
 /decl/loadout_option/suit/letterman_custom
-	name = "letterman jacket, colour select"
+	name = "letterman jacket, color select"
 	path = /obj/item/clothing/suit/letterman
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
 	cost = 1
+	uid = "gear_suit_letterman"
 
 /decl/loadout_option/suit/cloak
 	name = "plain cloak"
 	path = /obj/item/clothing/accessory/cloak
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
 	cost = 3
+	uid = "gear_suit_cloak"

--- a/code/modules/client/preference_setup/loadout/lists/uniforms.dm
+++ b/code/modules/client/preference_setup/loadout/lists/uniforms.dm
@@ -7,22 +7,26 @@
 	abstract_type = /decl/loadout_option/uniform
 
 /decl/loadout_option/uniform/jumpsuit
-	name = "jumpsuit, colour select"
+	name = "jumpsuit, color select"
 	path = /obj/item/clothing/under/color
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_under_jumpsuit"
 
 /decl/loadout_option/uniform/shortjumpskirt
-	name = "short jumpskirt, colour select"
+	name = "short jumpskirt, color select"
 	path = /obj/item/clothing/under/shortjumpskirt
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_under_jumpskirt"
 
 /decl/loadout_option/uniform/blackjumpshorts
 	name = "black jumpsuit shorts"
 	path = /obj/item/clothing/under/color/blackjumpshorts
+	uid = "gear_under_jumpshorts"
 
 /decl/loadout_option/uniform/suit
 	name = "clothes selection"
 	path = /obj/item/clothing/under
+	uid = "gear_under_clothes"
 
 /decl/loadout_option/uniform/suit/get_gear_tweak_options()
 	. = ..()
@@ -59,6 +63,7 @@
 /decl/loadout_option/uniform/dress
 	name = "dress selection"
 	path = /obj/item/clothing/under
+	uid = "gear_under_dress"
 
 /decl/loadout_option/uniform/dress/get_gear_tweak_options()
 	. = ..()
@@ -74,65 +79,78 @@
 	)
 
 /decl/loadout_option/uniform/cheongsam
-	name = "cheongsam, colour select"
+	name = "cheongsam, color select"
 	path = /obj/item/clothing/under/cheongsam
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_under_cheongsam"
 
 /decl/loadout_option/uniform/abaya
-	name = "abaya, colour select"
+	name = "abaya, color select"
 	path = /obj/item/clothing/under/abaya
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_under_abaya"
 
 /decl/loadout_option/uniform/skirt
 	name = "skirt selection"
 	path = /obj/item/clothing/under/skirt
 	loadout_flags = GEAR_HAS_TYPE_SELECTION
+	uid = "gear_under_skirt"
 
 /decl/loadout_option/uniform/skirt_c
-	name = "short skirt, colour select"
+	name = "short skirt, color select"
 	path = /obj/item/clothing/under/skirt_c
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_under_skirt_c"
 
 /decl/loadout_option/uniform/skirt_c/dress
-	name = "simple dress, colour select"
+	name = "simple dress, color select"
 	path = /obj/item/clothing/under/skirt_c/dress
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_under_simple_dress"
 
 /decl/loadout_option/uniform/casual_pants
 	name = "casual pants selection"
 	path = /obj/item/clothing/pants/casual
 	loadout_flags = GEAR_HAS_TYPE_SELECTION
+	uid = "gear_under_pants"
 
 /decl/loadout_option/uniform/formal_pants
 	name = "formal pants selection"
 	path = /obj/item/clothing/pants/formal
 	loadout_flags = GEAR_HAS_TYPE_SELECTION
+	uid = "gear_under_pants_formal"
 
 /decl/loadout_option/uniform/formal_pants/baggycustom
-	name = "baggy suit pants, colour select"
+	name = "baggy suit pants, color select"
 	path = /obj/item/clothing/pants/baggy
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_under_pants_baggy"
 
 /decl/loadout_option/uniform/shorts
 	name = "shorts selection"
 	path = /obj/item/clothing/pants/shorts
 	loadout_flags = GEAR_HAS_TYPE_SELECTION
+	uid = "gear_under_shorts"
 
 /decl/loadout_option/uniform/shorts/custom
-	name = "athletic shorts, colour select"
+	name = "athletic shorts, color select"
 	path = /obj/item/clothing/pants/shorts/athletic
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_under_shorts_athletic"
 
 /decl/loadout_option/uniform/turtleneck
-	name = "sweater, colour select"
+	name = "sweater, color select"
 	path = /obj/item/clothing/under/psych/turtleneck/sweater
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_under_sweater"
 
 /decl/loadout_option/uniform/kimono
-	name = "kimono, colour select"
+	name = "kimono, color select"
 	path = /obj/item/clothing/under/kimono
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_under_kimono"
 
 /decl/loadout_option/uniform/frontier
 	name = "frontier clothes"
 	path = /obj/item/clothing/under/frontier
+	uid = "gear_under_frontier"

--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -9,18 +9,22 @@
 /decl/loadout_option/utility/briefcase
 	name = "briefcase"
 	path = /obj/item/storage/briefcase
+	uid = "gear_utility_briefcase"
 
 /decl/loadout_option/utility/clipboard
 	name = "clipboard"
 	path = /obj/item/clipboard
+	uid = "gear_utility_clipboard"
 
 /decl/loadout_option/utility/folder
 	name = "folders"
 	path = /obj/item/folder
+	uid = "gear_utility_folders"
 
 /decl/loadout_option/utility/taperecorder
 	name = "tape recorder"
 	path = /obj/item/taperecorder
+	uid = "gear_utility_taperecorder"
 
 /decl/loadout_option/utility/folder/get_gear_tweak_options()
 	. = ..()
@@ -36,38 +40,46 @@
 /decl/loadout_option/utility/paicard
 	name = "personal AI device"
 	path = /obj/item/paicard
+	uid = "gear_utility_pai"
 
 /decl/loadout_option/utility/camera
 	name = "camera"
 	path = /obj/item/camera
+	uid = "gear_utility_camera"
 
 /decl/loadout_option/utility/photo_album
 	name = "photo album"
 	path = /obj/item/storage/photo_album
+	uid = "gear_utility_album"
 
 /decl/loadout_option/utility/film_roll
 	name = "film roll"
 	path = /obj/item/camera_film
+	uid = "gear_utility_film"
 
 /decl/loadout_option/utility/pen
 	name = "multicolored pen"
 	path = /obj/item/pen/multi
 	cost = 2
+	uid = "gear_utility_pen"
 
 /decl/loadout_option/utility/fancy
 	name = "fancy pen"
 	path = /obj/item/pen/fancy
 	cost = 2
-
-/decl/loadout_option/utility/knives
-	name = "utility knife selection"
-	description = "A selection of knives."
-	path = /obj/item/knife
+	uid = "gear_utility_pen_fancy"
 
 /decl/loadout_option/utility/umbrella
 	name = "umbrella"
 	path = /obj/item/umbrella
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
+	uid = "gear_utility_umbrella"
+
+/decl/loadout_option/utility/knives
+	name = "utility knife selection"
+	description = "A selection of knives."
+	path = /obj/item/knife
+	uid = "gear_utility_knives"
 
 /decl/loadout_option/utility/knives/get_gear_tweak_options()
 	. = ..()

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -1,5 +1,3 @@
-var/global/list/gear_datums = list()
-
 /datum/preferences
 	var/list/gear_list //Custom/fluff item loadouts.
 	var/gear_slot = 1  //The current gear save slot
@@ -50,9 +48,6 @@ var/global/list/gear_datums = list()
 	if(!category)
 		return FALSE
 
-	if(!name || !(name in global.gear_datums))
-		return FALSE
-
 	if(whitelisted)
 		if(!user)
 			return FALSE
@@ -91,12 +86,17 @@ var/global/list/gear_datums = list()
 		pref.total_loadout_selections = list()
 		var/list/gears = pref.gear_list[index]
 		if(istype(gears))
-			for(var/gear_name in gears)
+			for(var/gear_id in gears)
 				var/mob/user = preference_mob()
-				var/decl/loadout_option/LO = global.gear_datums[gear_name]
-				if(!LO || !(GET_DECL(LO.category) in global.using_map.loadout_categories) || !LO.can_be_taken_by(user, pref) || !LO.can_afford(user, pref))
-					gears -= gear_name
-				else
+				var/decl/loadout_option/LO = decls_repository.get_decl_by_id_or_var(gear_id, /decl/loadout_option)
+
+				// Swap names for UIDs to grandfather in old saves.
+				if(LO.uid != gear_id)
+					gears[LO.uid] = gears[gear_id]
+					gears -= gear_id
+					gear_id = LO.uid
+
+				if(LO && (GET_DECL(LO.category) in global.using_map.loadout_categories) && LO.can_be_taken_by(user, pref) && LO.can_afford(user, pref))
 					pref.total_loadout_cost += LO.cost
 					pref.total_loadout_selections[LO.category] = (pref.total_loadout_selections[LO.category] + 1)
 		else
@@ -109,7 +109,7 @@ var/global/list/gear_datums = list()
 
 	var/list/gears = pref.gear_list[pref.gear_slot]
 	for(var/i = 1; i <= gears.len; i++)
-		var/decl/loadout_option/G = global.gear_datums[gears[i]]
+		var/decl/loadout_option/G = decls_repository.get_decl_by_id_or_var(gears[i], /decl/loadout_option)
 		if(G)
 			pref.total_loadout_cost += G.cost
 			pref.total_loadout_selections[G.category] = (pref.total_loadout_selections[G.category] + 1)
@@ -172,17 +172,17 @@ var/global/list/gear_datums = list()
 			dd_insertObjectList(jobs, J)
 
 	var/mob/user = preference_mob()
-	for(var/gear_name in current_category_decl.gear)
+	for(var/gear_id in current_category_decl.gear)
 
-		var/decl/loadout_option/G = current_category_decl.gear[gear_name]
+		var/decl/loadout_option/G = current_category_decl.gear[gear_id]
 		if(!G.can_be_taken_by(user, pref))
 			continue
 
-		var/ticked = (G.name in pref.gear_list[pref.gear_slot])
+		var/ticked = (G.uid in pref.gear_list[pref.gear_slot])
 		var/list/entry = list()
 		entry += "<tr style='vertical-align:top;'><td width=25%><a style='white-space:normal;' [ticked ? "class='linkOn' " : ""]href='?src=\ref[src];toggle_gear=\ref[G]'>[G.name]</a></td>"
 		entry += "<td width = 10% style='vertical-align:top'>[G.cost]</td>"
-		entry += "<td><font size=2>[G.get_description(get_gear_metadata(G,1))]</font>"
+		entry += "<td><font size=2>[G.get_description(get_gear_metadata(G, TRUE))]</font>"
 
 		var/allowed = 1
 		if(allowed && G.allowed_roles)
@@ -257,11 +257,11 @@ var/global/list/gear_datums = list()
 
 /datum/category_item/player_setup_item/loadout/proc/get_gear_metadata(var/decl/loadout_option/G, var/readonly)
 	var/list/gear = pref.gear_list[pref.gear_slot]
-	. = gear[G.name]
+	. = gear[G.uid]
 	if(!.)
 		. = list()
 		if(!readonly)
-			gear[G.name] = .
+			gear[G.uid] = .
 
 /datum/category_item/player_setup_item/loadout/proc/get_tweak_metadata(var/decl/loadout_option/G, var/datum/gear_tweak/tweak)
 	var/list/metadata = get_gear_metadata(G)
@@ -277,18 +277,18 @@ var/global/list/gear_datums = list()
 /datum/category_item/player_setup_item/loadout/OnTopic(href, href_list, user)
 	if(href_list["toggle_gear"])
 		var/decl/loadout_option/TG = locate(href_list["toggle_gear"])
-		if(!istype(TG) || global.gear_datums[TG.name] != TG)
+		if(!istype(TG))
 			return TOPIC_REFRESH
-		if(TG.name in pref.gear_list[pref.gear_slot])
-			pref.gear_list[pref.gear_slot] -= TG.name
+		if(TG.uid in pref.gear_list[pref.gear_slot])
+			pref.gear_list[pref.gear_slot] -= TG.uid
 		else if(TG.can_afford(preference_mob(), pref))
-			pref.gear_list[pref.gear_slot] += TG.name
+			pref.gear_list[pref.gear_slot] += TG.uid
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 
 	if(href_list["gear"] && href_list["tweak"])
 		var/decl/loadout_option/gear = locate(href_list["gear"])
 		var/datum/gear_tweak/tweak = locate(href_list["tweak"])
-		if(!tweak || !istype(gear) || !(tweak in gear.gear_tweaks) || global.gear_datums[gear.name] != gear)
+		if(!tweak || !istype(gear) || !(tweak in gear.gear_tweaks))
 			return TOPIC_NOACTION
 		var/metadata = tweak.get_metadata(user, get_tweak_metadata(gear, tweak))
 		if(!metadata || !CanUseTopic(user))
@@ -329,6 +329,9 @@ var/global/list/gear_datums = list()
 	var/list/gear = list()
 
 /decl/loadout_option
+	abstract_type = /decl/loadout_option
+	decl_flags = DECL_FLAG_MANDATORY_UID
+
 	var/name                              // Name/index. Must be unique.
 	var/description                       // Description of this gear. If left blank will default to the description of the pathed item.
 	var/path                              // Path of item.
@@ -346,8 +349,6 @@ var/global/list/gear_datums = list()
 	var/list/faction_restricted // List of types of cultural datums that will allow this loadout option.
 	var/whitelisted             // Species name to check the whitelist for.
 
-	abstract_type = /decl/loadout_option
-
 /decl/loadout_option/Initialize()
 
 	if(get_config_value(/decl/config/toggle/allow_loadout_customization))
@@ -355,11 +356,10 @@ var/global/list/gear_datums = list()
 
 	. = ..()
 
-	if(name && (!global.using_map.loadout_blacklist || !(type in global.using_map.loadout_blacklist)))
-		global.gear_datums[name] = src
+	if(!global.using_map.loadout_blacklist || !(type in global.using_map.loadout_blacklist))
 		var/decl/loadout_category/LC = GET_DECL(category)
-		ADD_SORTED(LC.gear, name, /proc/cmp_text_asc)
-		LC.gear[name] = src
+		ADD_SORTED(LC.gear, uid, /proc/cmp_text_asc)
+		LC.gear[uid] = src
 
 	if(FLAGS_EQUALS(loadout_flags, GEAR_HAS_TYPE_SELECTION|GEAR_HAS_SUBTYPE_SELECTION))
 		CRASH("May not have both type and subtype selection tweaks")

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -567,18 +567,18 @@
 	..()
 
 	if (istype(W, /obj/item/chems/food))
-		var/obj/item/chems/food/grown/G = W
-		if (!G.dry)
-			to_chat(user, SPAN_NOTICE("[G] must be dried before you stuff it into [src]."))
+		var/obj/item/chems/food/grown/grown = W
+		if (!grown.dry)
+			to_chat(user, SPAN_NOTICE("\The [grown] must be dried before you stuff it into \the [src]."))
 			return
 		if (smoketime)
-			to_chat(user, SPAN_NOTICE("[src] is already packed."))
+			to_chat(user, SPAN_NOTICE("\The [src] is already packed."))
 			return
 		smoketime = 1000
-		if(G.reagents)
-			G.reagents.trans_to_obj(src, G.reagents.total_volume)
-		SetName("[G.name]-packed [initial(name)]")
-		qdel(G)
+		if(grown.reagents)
+			grown.reagents.trans_to_obj(src, grown.reagents.total_volume)
+		SetName("[grown.name]-packed [initial(name)]")
+		qdel(grown)
 
 	else if(istype(W, /obj/item/flame/lighter))
 		var/obj/item/flame/lighter/L = W

--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -484,13 +484,13 @@
 		return
 
 	for(var/rtype in source.reagents.reagent_volumes)
-		var/decl/material/G = GET_DECL(rtype)
+		var/decl/material/mat = GET_DECL(rtype)
 		if(!direction_mode)
-			if(G.name in demand)
-				source.reagents.trans_type_to(target, G.type, transfer_amount)
+			if(mat.name in demand)
+				source.reagents.trans_type_to(target, rtype, transfer_amount)
 		else
-			if(!(G.name in demand))
-				source.reagents.trans_type_to(target, G.type, transfer_amount)
+			if(!(mat.name in demand))
+				source.reagents.trans_type_to(target, rtype, transfer_amount)
 	activate_pin(2)
 	push_data()
 

--- a/code/modules/mob/living/deity/deity.dm
+++ b/code/modules/mob/living/deity/deity.dm
@@ -102,14 +102,14 @@
 	var/list/forms = subtypesof(/datum/god_form)
 
 	for(var/form in forms)
-		var/datum/god_form/G = form
-		var/god_name = initial(G.name)
-		var/icon/god_icon = icon('icons/mob/mob.dmi', initial(G.pylon_icon_state))
+		var/datum/god_form/god = form
+		var/god_name = initial(god.name)
+		var/icon/god_icon = icon('icons/mob/mob.dmi', initial(god.pylon_icon_state))
 		send_rsc(src,god_icon, "[god_name].png")
 		dat += {"<tr>
-					<td><a href="?src=\ref[src];form=\ref[G]">[god_name]</a></td>
+					<td><a href="?src=\ref[src];form=\ref[god]">[god_name]</a></td>
 					<td><img src="[god_name].png"></td>
-					<td>[initial(G.info)]</td>
+					<td>[initial(god.info)]</td>
 				</tr>"}
 	dat += "</table>"
 	show_browser(src, JOINTEXT(dat), "window=godform;can_close=0")

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -80,7 +80,7 @@
 		// Equip custom gear loadout, replacing any job items
 		var/list/loadout_taken_slots = list()
 		for(var/thing in Gear())
-			var/decl/loadout_option/G = global.gear_datums[thing]
+			var/decl/loadout_option/G = decls_repository.get_decl_by_id_or_var(thing, /decl/loadout_option)
 			if(G)
 				var/permitted = FALSE
 				if(G.allowed_roles && G.allowed_roles.len)
@@ -97,7 +97,7 @@
 				if(!permitted)
 					continue
 
-				if(G.slot && G.slot != slot_tie_str && !(G.slot in loadout_taken_slots) && G.spawn_on_mob(mannequin, gear_list[gear_slot][G.name]))
+				if(G.slot && G.slot != slot_tie_str && !(G.slot in loadout_taken_slots) && G.spawn_on_mob(mannequin, gear_list[gear_slot][G.uid]))
 					loadout_taken_slots.Add(G.slot)
 					update_icon = TRUE
 

--- a/code/modules/nano/modules/human_appearance.dm
+++ b/code/modules/nano/modules/human_appearance.dm
@@ -96,8 +96,8 @@
 	data["change_gender"] = can_change(APPEARANCE_GENDER)
 	if(data["change_gender"])
 		var/genders[0]
-		for(var/decl/pronouns/G as anything in owner.species.available_pronouns)
-			genders[++genders.len] =  list("gender_name" = G.pronoun_string, "gender_key" = G.name)
+		for(var/decl/pronouns/pronouns as anything in owner.species.available_pronouns)
+			genders[++genders.len] =  list("gender_name" = pronouns.pronoun_string, "gender_key" = pronouns.name)
 		data["genders"] = genders
 
 	data["bodytype"] = capitalize(owner.get_bodytype().name)

--- a/code/modules/submaps/submap_join.dm
+++ b/code/modules/submaps/submap_join.dm
@@ -79,7 +79,7 @@
 			var/list/spawn_in_storage = SSjobs.equip_custom_loadout(character, job)
 			if(spawn_in_storage)
 				for(var/decl/loadout_option/G in spawn_in_storage)
-					G.spawn_in_storage_or_drop(user_human, user_human.client.prefs.Gear()[G.name])
+					G.spawn_in_storage_or_drop(user_human, user_human.client.prefs.Gear()[G.uid])
 			SScustomitems.equip_custom_items(user_human)
 
 		character.job = job.title

--- a/code/modules/xenoarcheaology/artifacts/triggers/gas.dm
+++ b/code/modules/xenoarcheaology/artifacts/triggers/gas.dm
@@ -6,8 +6,8 @@
 /datum/artifact_trigger/gas/New()
 	if(!gas_needed)
 		gas_needed = list(pick(decls_repository.get_decl_paths_of_subtype(/decl/material/gas)) = rand(1,10))
-	var/decl/material/gas/G = GET_DECL(gas_needed[1])
-	name = "concentration of [G.name]"
+	var/decl/material/gas/gas = GET_DECL(gas_needed[1])
+	name = "concentration of [gas.name]"
 
 /datum/artifact_trigger/gas/copy()
 	var/datum/artifact_trigger/gas/C = ..()

--- a/code/unit_tests/loadout_tests.dm
+++ b/code/unit_tests/loadout_tests.dm
@@ -4,8 +4,7 @@
 /datum/unit_test/loadout_test_shall_have_valid_icon_states/start_test()
 
 	var/list/failed = list()
-	for(var/gear_name in global.gear_datums)
-		var/decl/loadout_option/G = global.gear_datums[gear_name]
+	for(var/decl/loadout_option/G in decls_repository.get_decls_unassociated(/decl/loadout_option))
 		var/list/path_tweaks = list()
 		for(var/datum/gear_tweak/path/p in G.gear_tweaks)
 			path_tweaks += p
@@ -39,8 +38,7 @@
 
 /datum/unit_test/loadout_test_gear_path_tweaks_shall_be_of_gear_path/start_test()
 	var/list/failed = list()
-	for(var/gear_name in global.gear_datums)
-		var/decl/loadout_option/G = global.gear_datums[gear_name]
+	for(var/decl/loadout_option/G in decls_repository.get_decls_unassociated(/decl/loadout_option))
 		for(var/datum/gear_tweak/path/p in G.gear_tweaks)
 			for(var/path_name in p.valid_paths)
 				var/path_type = p.valid_paths[path_name]
@@ -58,8 +56,7 @@
 
 /datum/unit_test/loadout_test_gear_path_tweaks_shall_have_unique_keys/start_test()
 	var/path_entries_by_gear_path_and_name = list()
-	for(var/gear_name in global.gear_datums)
-		var/decl/loadout_option/G = global.gear_datums[gear_name]
+	for(var/decl/loadout_option/G in decls_repository.get_decls_unassociated(/decl/loadout_option))
 		for(var/datum/gear_tweak/path/p in G.gear_tweaks)
 			for(var/path_name in p.valid_paths)
 				group_by(path_entries_by_gear_path_and_name, "[G] - [p] - [path_name]", path_name)
@@ -82,8 +79,7 @@
 /datum/unit_test/loadout_custom_setup_tweaks_shall_have_valid_procs/start_test()
 
 	var/list/failures = list()
-	for(var/gear_name in global.gear_datums)
-		var/decl/loadout_option/G = global.gear_datums[gear_name]
+	for(var/decl/loadout_option/G in decls_repository.get_decls_unassociated(/decl/loadout_option))
 		var/datum/instance
 		var/mob/user
 		for(var/datum/gear_tweak/custom_setup/cs in G.gear_tweaks)
@@ -125,6 +121,7 @@
 	path = /obj/unit_test/loadout
 	custom_setup_proc = /obj/unit_test/loadout/proc/loadout_proc
 	custom_setup_proc_arguments = list(5)
+	uid = "gear_debug"
 
 /obj/unit_test/loadout
 	var/loadout_mob

--- a/maps/exodus/exodus_loadout.dm
+++ b/maps/exodus/exodus_loadout.dm
@@ -3,6 +3,7 @@
 	path = /obj/item/clothing/accessory/chaplaininsignia
 	cost = 1
 	allowed_roles = list(/datum/job/chaplain)
+	uid = "gear_accessory_insignia"
 
 /decl/loadout_option/accessory/chaplaininsignia/Initialize()
 	. = ..()

--- a/maps/tradeship/tradeship_loadouts.dm
+++ b/maps/tradeship/tradeship_loadouts.dm
@@ -2,6 +2,7 @@
 	name = "guns"
 	cost = 4
 	path = /obj/item/gun/projectile
+	uid = "gear_utility_guns"
 
 /decl/loadout_option/utility/guns/Initialize()
 	. = ..()

--- a/mods/content/corporate/datum/loadout.dm
+++ b/mods/content/corporate/datum/loadout.dm
@@ -3,6 +3,7 @@
 	description = "A medal or ribbon awarded to corporate personnel for significant accomplishments."
 	path = /obj/item/clothing/accessory/medal
 	cost = 8
+	uid = "gear_accessory_corpaward"
 
 /decl/loadout_option/accessory/ntaward/get_gear_tweak_options()
 	. = ..()
@@ -16,15 +17,18 @@
 /decl/loadout_option/accessory/armband_nt
 	name = "corporate armband"
 	path = /obj/item/clothing/accessory/armband/whitegreen
+	uid = "gear_accessory_corparmband"
 
 /decl/loadout_option/suit/labcoat_corp
 	name = "labcoat, corporate colors"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/science
 	loadout_flags = GEAR_HAS_TYPE_SELECTION
+	uid = "gear_suit_corplabcoat"
 
 /decl/loadout_option/uniform/corporate
 	name = "corporate uniform selection"
 	path = /obj/item/clothing/under
+	uid = "gear_under_corpuniform"
 
 /decl/loadout_option/uniform/corporate/get_gear_tweak_options()
 	. = ..()
@@ -51,29 +55,35 @@
 	name = "corporate colours, senior researcher"
 	path = /obj/item/clothing/under/executive
 	loadout_flags = GEAR_HAS_TYPE_SELECTION
+	uid = "gear_under_corpexec"
 
 /decl/loadout_option/uniform/corp_overalls
 	name = "corporate colours, coveralls"
 	path = /obj/item/clothing/under/work
 	loadout_flags = GEAR_HAS_TYPE_SELECTION
+	uid = "gear_under_corpcoveralls"
 
 /decl/loadout_option/uniform/corp_flight
 	name = "corporate colours, flight suit"
 	path = /obj/item/clothing/under/pilot
 	loadout_flags = GEAR_HAS_TYPE_SELECTION
+	uid = "gear_under_corpflight"
 
 /decl/loadout_option/uniform/corp_exec_jacket
 	name = "corporate colours, liason suit"
 	path = /obj/item/clothing/under/suit_jacket/corp
 	loadout_flags = GEAR_HAS_TYPE_SELECTION
+	uid = "gear_under_corpexecjacket"
 
 /decl/loadout_option/suit/nanotrasen_poncho
 	name = "poncho, NanoTrasen"
 	path = /obj/item/clothing/suit/poncho/roles/science/nanotrasen
+	uid = "gear_suit_corpponcho"
 
 /decl/loadout_option/suit/corp_jacket
 	name = "corporate jacket selection"
 	path = /obj/item/clothing/suit
+	uid = "gear_suit_corpjacket"
 
 /decl/loadout_option/suit/corp_jacket/get_gear_tweak_options()
 	. = ..()
@@ -86,14 +96,17 @@
 /decl/loadout_option/suit/science_poncho
 	name = "poncho, science"
 	path = /obj/item/clothing/suit/poncho/roles/science
+	uid = "gear_suit_corpponcho_science"
 
 /decl/loadout_option/suit/hoodie_nt
 	name = "hoodie, NanoTrasen"
 	path = /obj/item/clothing/suit/storage/toggle/hoodie/nt
+	uid = "gear_suit_corphoodie"
 
 /decl/loadout_option/suit/wintercoat_dais
 	name = "winter coat, DAIS"
 	path = /obj/item/clothing/suit/storage/toggle/wintercoat/dais
+	uid = "gear_suit_corpcoat_dais"
 
 /decl/loadout_option/suit/leather/get_gear_tweak_options()
 	. = ..()

--- a/mods/species/bayliens/skrell/gear/gear_ears.dm
+++ b/mods/species/bayliens/skrell/gear/gear_ears.dm
@@ -46,3 +46,4 @@
 	whitelisted = list(SPECIES_SKRELL)
 	path = /obj/item/clothing/ears/skrell
 	loadout_flags = GEAR_HAS_COLOR_SELECTION | GEAR_HAS_SUBTYPE_SELECTION
+	uid = "gear_accessory_skrell"

--- a/mods/species/bayliens/skrell/gear/gear_mask.dm
+++ b/mods/species/bayliens/skrell/gear/gear_mask.dm
@@ -2,6 +2,7 @@
 	name = "skrellian gill cover"
 	path = /obj/item/clothing/mask/gas/skrell
 	whitelisted = list(BODYTYPE_SKRELL)
+	uid = "gear_mask_skrell"
 
 /obj/item/clothing/mask/gas/skrell
 	name = "skrellian gill cover"

--- a/mods/species/neoavians/datum/loadout.dm
+++ b/mods/species/neoavians/datum/loadout.dm
@@ -10,6 +10,7 @@
 	name = "Neo-Avian uniform selection"
 	path = /obj/item/clothing/under/avian_smock
 	slot = slot_w_uniform_str
+	uid = "gear_under_avian"
 
 /decl/loadout_option/avian/uniform_selection/get_gear_tweak_options()
 	. = ..()
@@ -30,3 +31,4 @@
 	path  = /obj/item/clothing/shoes/avian/footwraps
 	loadout_flags = GEAR_HAS_COLOR_SELECTION
 	slot  = slot_shoes_str
+	uid = "gear_shoes_avian"


### PR DESCRIPTION
Pointing this at stable as it fixes an issue with loadout being broken if you try to load your character before someone has looked at loadout options.

- Fixes https://github.com/ScavStation/ScavStation/issues/1030
- Loadout uses UID instead of name.
- Loadout uses the decls repository instead of a global list.
- `colour select` find and replaced to `color select` for consistency and accuracy (since it is setting `color`).
- UID added to all loadout options.