### PR TITLE
Tweak dexterity messages to fix table dexterity warning spam

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -25,8 +25,7 @@
 /obj/item/stack/medical/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
 	// TODO: dex check
-	if(!ishuman(user) && !issilicon(user))
-		to_chat(user, SPAN_WARNING("You don't have the dexterity to do this!"))
+	if(!user.can_wield_item(src))
 		return TRUE
 
 	if(!ishuman(target))

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -130,8 +130,8 @@
 
 /obj/attackby(obj/item/used_item, mob/user)
 	// We need to call parent even if we lack dexterity, so that storage can work.
-	if(used_item.user_can_wield(user))
-		if((obj_flags & OBJ_FLAG_ANCHORABLE) && (IS_WRENCH(used_item) || IS_HAMMER(used_item)))
+	if((obj_flags & OBJ_FLAG_ANCHORABLE) && (IS_WRENCH(used_item) || IS_HAMMER(used_item)))
+		if(used_item.user_can_wield(user))
 			wrench_floor_bolts(user, null, used_item)
 			update_icon()
 			return TRUE

--- a/code/game/objects/structures/_structure_construction.dm
+++ b/code/game/objects/structures/_structure_construction.dm
@@ -114,7 +114,7 @@
 		current_health = clamp(current_health + used*DOOR_REPAIR_AMOUNT, current_health, current_max_health)
 
 /obj/structure/attackby(obj/item/used_item, mob/user)
-	if(used_item.user_can_wield(user))
+	if(used_item.user_can_wield(user, silent = TRUE))
 		if(used_item.force && user.a_intent == I_HURT)
 			attack_animation(user)
 			visible_message(SPAN_DANGER("\The [src] has been [pick(used_item.attack_verb)] with \the [used_item] by \the [user]!"))


### PR DESCRIPTION
## Description of changes
- Adds a missing dexterity check to medical stack code.
- Moves a wielding check in structure code around so that it doesn't trigger prematurely.
- Makes a wielding check in attackby code silent to avoid it sending a message when you place an item on a table as a drake.

## Why and what will this PR improve
Fixes dexterity warning spam when placing items on tables with insufficient dexterity to wield that item as a tool.