### PR TITLE
Make digging pits and trenches check the athletics skill

### DIFF
--- a/code/game/turfs/turf_digging.dm
+++ b/code/game/turfs/turf_digging.dm
@@ -28,7 +28,7 @@
 	return can_be_dug(tool_hardness, using_tool) && !(locate(/obj/structure/pit) in src)
 
 /turf/proc/try_dig_pit(var/mob/user, var/obj/item/tool, using_tool = TOOL_SHOVEL)
-	if((!user && !tool) || tool.do_tool_interaction(using_tool, user, src, 5 SECONDS, set_cooldown = TRUE))
+	if((!user && !tool) || tool.do_tool_interaction(using_tool, user, src, 5 SECONDS, check_skill = SKILL_HAULING, set_cooldown = TRUE))
 		return dig_pit(tool?.material?.hardness, using_tool)
 	return null
 
@@ -55,7 +55,7 @@
 	return can_be_dug(tool_hardness, using_tool) && get_physical_height() > -(FLUID_DEEP)
 
 /turf/proc/try_dig_trench(mob/user, obj/item/tool, using_tool = TOOL_SHOVEL)
-	if((!user && !tool) || tool.do_tool_interaction(using_tool, user, src, 2.5 SECONDS, set_cooldown = TRUE))
+	if((!user && !tool) || tool.do_tool_interaction(using_tool, user, src, 2.5 SECONDS, check_skill = SKILL_HAULING, set_cooldown = TRUE))
 		return dig_trench(tool?.material?.hardness, using_tool)
 	return null
 


### PR DESCRIPTION
## Description of changes
Makes digging pits and trenches check the athletics skill instead of construction.

## Why and what will this PR improve
If you're a feeble 60 year old man, you will now take 14.5 seconds to dig a grave instead of 5. If you're a super athlete, you'll take 3.5 seconds. It's not much but it's pretty neat.

## Authorship
Me

## Changelog
:cl:
tweak: Digging pits and trenches now checks athletics instead of construction.
/:cl: