### PR TITLE
Fixes double encoding of matchmaking info input

### DIFF
--- a/mods/content/matchmaking/relations.dm
+++ b/mods/content/matchmaking/relations.dm
@@ -54,7 +54,7 @@
 		return TOPIC_REFRESH
 	if(href_list["relation_info"])
 		var/R = href_list["relation_info"]
-		var/info = sanitize(input("Character info", "What would you like the other party for this connection to know about your character?",pref.relations_info[R]) as message|null)
+		var/info = sanitize(input("Character info", "What would you like the other party for this connection to know about your character?",html_decode(pref.relations_info[R])) as message|null)
 		if(info)
 			pref.relations_info[R] = info
 		return TOPIC_REFRESH


### PR DESCRIPTION
## Description of changes
sanitize() html encodes the input but we never decode the default value, leading to repeated encoding.

## Why and what will this PR improve
Fixes double encoding of matchmaking info input.