### PR TITLE
Cherry-picks fixes from shuttle rotation PR

### DIFF
--- a/code/datums/proximity_trigger/proximity_trigger.dm
+++ b/code/datums/proximity_trigger/proximity_trigger.dm
@@ -139,6 +139,8 @@ var/global/const/PROXIMITY_EXCLUDE_HOLDER_TURF = 1 // When acquiring turfs to mo
 /datum/proximity_trigger/proc/on_turf_entered(var/turf/T, var/atom/enterer)
 	if(enterer == holder) // We have an explicit call for holder, in case it moved somewhere we're not listening to.
 		return
+	if(!enterer.simulated)
+		return
 	// For opaque movables, we need to recheck visibility on destruction, when their opacity is changed, or when they move out of range.
 	if(enterer.opacity)
 		events_repository.register(/decl/observ/opacity_set, enterer, src, TYPE_PROC_REF(/datum/proximity_trigger, update_opaque_atom))

--- a/code/game/machinery/_machines_base/machinery_public_vars_common.dm
+++ b/code/game/machinery/_machines_base/machinery_public_vars_common.dm
@@ -24,7 +24,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 /decl/public_access/public_method/toggle_input_toggle
 	name = "toggle input"
 	desc = "Toggles the input toggle variable."
-	call_proc = /obj/machinery/proc/toggle_input_toggle
+	call_proc = TYPE_PROC_REF(/obj/machinery, toggle_input_toggle)
 
 /obj/machinery/proc/toggle_input_toggle()
 	var/decl/public_access/public_variable/variable = GET_DECL(/decl/public_access/public_variable/input_toggle)
@@ -141,7 +141,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 /decl/public_access/public_method/toggle_power
 	name = "toggle power"
 	desc = "Turns the machine on or off."
-	call_proc = /obj/machinery/proc/toggle_power
+	call_proc = TYPE_PROC_REF(/obj/machinery, toggle_power)
 
 /obj/machinery/proc/toggle_power()
 	update_use_power(!use_power)
@@ -149,7 +149,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 /decl/public_access/public_method/refresh
 	name = "refresh machine"
 	desc = "Attempts to refresh the machine's status. Implementation may vary."
-	call_proc = /obj/machinery/proc/refresh
+	call_proc = TYPE_PROC_REF(/obj/machinery, refresh)
 
 /obj/machinery/proc/refresh()
 	queue_icon_update()

--- a/code/game/machinery/_machines_base/stock_parts/radio/transmitter.dm
+++ b/code/game/machinery/_machines_base/stock_parts/radio/transmitter.dm
@@ -14,9 +14,9 @@
 		return
 	if(!buffer)
 		buffer = data
-		addtimer(CALLBACK(src, PROC_REF(transmit)), latency)
+		addtimer(CALLBACK(src, PROC_REF(transmit)), latency, TIMER_UNIQUE)
 	else
-		buffer |= data
+		buffer = (data |= buffer) // this avoids list copies. basically, give entries already in data priority and add buffered data after
 
 /obj/item/stock_parts/radio/transmitter/proc/transmit()
 	if(!LAZYLEN(buffer))

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -360,7 +360,7 @@
 /decl/public_access/public_method/toggle_camera
 	name = "toggle camera"
 	desc = "Toggles camera on or off."
-	call_proc = /obj/machinery/camera/proc/toggle_status
+	call_proc = TYPE_PROC_REF(/obj/machinery/camera, toggle_status)
 
 /decl/public_access/public_variable/camera_state
 	expected_type = /obj/machinery/camera

--- a/code/game/machinery/doors/_door.dm
+++ b/code/game/machinery/doors/_door.dm
@@ -136,7 +136,7 @@
 	if(close_door_at && world.time >= close_door_at)
 		if(autoclose)
 			close_door_at = next_close_time()
-			INVOKE_ASYNC(src, TYPE_PROC_REF(/obj/machinery/door, close))
+			INVOKE_ASYNC(src, PROC_REF(close))
 		else
 			close_door_at = 0
 
@@ -429,7 +429,7 @@
 
 /obj/machinery/door/proc/open(forced = FALSE)
 	if(!can_open(forced))
-		return
+		return FALSE
 
 	operating = 1
 
@@ -457,7 +457,7 @@
 
 /obj/machinery/door/proc/close(forced = FALSE)
 	if(!can_close(forced))
-		return
+		return FALSE
 
 	operating = 1
 
@@ -478,6 +478,7 @@
 	//I shall not add a check every x ticks if a door has closed over some fire.
 	var/obj/fire/fire = locate() in loc
 	qdel(fire)
+	return TRUE
 
 /obj/machinery/door/proc/toggle(to_open = density)
 	if(to_open)
@@ -602,20 +603,20 @@
 /decl/public_access/public_method/open_door
 	name = "open door"
 	desc = "Opens the door if possible."
-	call_proc = /obj/machinery/door/proc/open
+	call_proc = TYPE_PROC_REF(/obj/machinery/door, open)
 
 /decl/public_access/public_method/toggle_door
 	name = "toggle door"
 	desc = "Toggles whether the door is open or not, if possible."
-	call_proc = /obj/machinery/door/proc/toggle
+	call_proc = TYPE_PROC_REF(/obj/machinery/door, toggle)
 
 /decl/public_access/public_method/toggle_door_to
 	name = "toggle door to"
 	desc = "Toggles the door, depending on the supplied argument, to open (if 1) or closed (if 0)."
-	call_proc = /obj/machinery/door/proc/toggle
+	call_proc = TYPE_PROC_REF(/obj/machinery/door, toggle)
 	forward_args = TRUE
 
 /decl/public_access/public_method/close_door
 	name = "close door"
 	desc = "Closes the door if possible."
-	call_proc = /obj/machinery/door/proc/close
+	call_proc = TYPE_PROC_REF(/obj/machinery/door, close)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -35,6 +35,10 @@ var/global/list/airlock_overlays = list()
 	var/shockedby = list()              //Some sort of admin logging var
 	var/welded = null
 	var/locked = FALSE
+	/// If TRUE, when operating goes from TRUE to FALSE (i.e. door finishes closing/opening), the door will lock itself.
+	var/locking = FALSE
+	/// If TRUE, when operating goes from TRUE to FALSE (i.e. door finishes closing/opening), the door will unlock itself.
+	var/unlocking = FALSE
 	var/lock_cut_state = BOLTS_FINE
 	var/lights = 1 // Lights show by default
 	var/aiDisabledIdScanner = 0
@@ -295,9 +299,9 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/on_update_icon(state=0, override=0)
 
 	if(set_dir_on_update)
-		if(connections & (NORTH|SOUTH) == (NORTH|SOUTH))
+		if((connections & (NORTH|SOUTH)) == (NORTH|SOUTH))
 			set_dir(EAST)
-		else if (connections & (EAST|WEST) == (EAST|WEST))
+		else if ((connections & (EAST|WEST)) == (EAST|WEST))
 			set_dir(SOUTH)
 
 	switch(state)
@@ -889,7 +893,7 @@ About the new airlock wires panel:
 
 /obj/machinery/door/airlock/open(var/forced=0)
 	if(!can_open(forced))
-		return 0
+		return FALSE
 	use_power_oneoff(360)	//360 W seems much more appropriate for an actuator moving an industrial door capable of crushing people
 
 	//if the door is unpowered then it doesn't make sense to hear the woosh of a pneumatic actuator
@@ -898,7 +902,15 @@ About the new airlock wires panel:
 	else
 		playsound(src.loc, pick(open_sound_unpowered), 100, 1)
 
-	return ..()
+	. = ..()
+	if(.)
+		// lock and unlock handle updating for us, we don't want duplicate updates
+		if(locking)
+			lock()
+		else if(unlocking)
+			unlock()
+		else
+			toggle_input_toggle() // this sends an update to anything listening for our status, like docking/airlock controllers
 
 /obj/machinery/door/airlock/can_open(var/forced=0)
 	if(QDELETED(src) || brace)
@@ -925,7 +937,7 @@ About the new airlock wires panel:
 
 /obj/machinery/door/airlock/close(var/forced=0)
 	if(!can_close(forced))
-		return 0
+		return FALSE
 
 	if(safe)
 		for(var/turf/turf in locs)
@@ -935,7 +947,7 @@ About the new airlock wires panel:
 						playsound(src.loc, close_failure_blocked, 30, 0, -3)
 						next_beep_at = world.time + SecondsToTicks(10)
 					close_door_at = world.time + 6
-					return
+					return FALSE
 
 	for(var/turf/turf in locs)
 		for(var/atom/movable/AM in turf)
@@ -949,35 +961,54 @@ About the new airlock wires panel:
 	else
 		playsound(src.loc, pick(close_sound_unpowered), 100, 1)
 
-	..()
+	. = ..()
+	if(.)
+		// lock and unlock handle updating for us, we don't want duplicate updates
+		if(locking)
+			lock()
+		else if(unlocking)
+			unlock()
+		else
+			toggle_input_toggle() // this sends an update to anything listening for our status, like docking/airlock controllers
 
 /obj/machinery/door/airlock/proc/lock(var/forced=0)
 	if(locked)
-		return 0
+		return FALSE
 
-	if (operating && !forced) return 0
+	if (operating && !forced)
+		unlocking = FALSE
+		locking = TRUE
+		return FALSE
 
-	if (lock_cut_state == BOLTS_CUT) return 0 //what bolts?
+	if (lock_cut_state == BOLTS_CUT) return FALSE //what bolts?
 
 	src.locked = TRUE
 	playsound(src, bolts_dropping, 30, 0, -6)
 	audible_message("You hear a click from the bottom of the door.", hearing_distance = 1)
 	update_icon()
-	return 1
+	toggle_input_toggle() // this sends an update to anything listening for our status, like docking/airlock controllers
+	return TRUE
 
 /obj/machinery/door/airlock/proc/unlock(var/forced=0)
 	if(!src.locked)
-		return
+		return FALSE
 
 	if (!forced)
+		if(!src.arePowerSystemsOn() || isWireCut(AIRLOCK_WIRE_DOOR_BOLTS))
+			return FALSE
+		if(operating)
+			locking = FALSE
+			unlocking = TRUE
+			return FALSE
 		if(operating || !src.arePowerSystemsOn() || isWireCut(AIRLOCK_WIRE_DOOR_BOLTS))
-			return
+			return FALSE
 
 	src.locked = FALSE
 	playsound(src, bolts_rising, 30, 0, -6)
 	audible_message("You hear a click from the bottom of the door.", hearing_distance = 1)
 	update_icon()
-	return 1
+	toggle_input_toggle() // this sends an update to anything listening for our status, like docking/airlock controllers
+	return TRUE
 
 /obj/machinery/door/airlock/proc/toggle_lock(var/forced = 0)
 	return locked ? unlock() : lock()

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -56,17 +56,17 @@
 /decl/public_access/public_method/airlock_lock
 	name = "engage bolts"
 	desc = "Bolts the airlock, if possible."
-	call_proc = /obj/machinery/door/airlock/proc/lock
+	call_proc = TYPE_PROC_REF(/obj/machinery/door/airlock, lock)
 
 /decl/public_access/public_method/airlock_unlock
 	name = "disengage bolts"
 	desc = "Unbolts the airlock, if possible."
-	call_proc = /obj/machinery/door/airlock/proc/unlock
+	call_proc = TYPE_PROC_REF(/obj/machinery/door/airlock, unlock)
 
 /decl/public_access/public_method/airlock_toggle_bolts
 	name = "toggle bolts"
 	desc = "Toggles whether the airlock is bolted or not, if possible."
-	call_proc = /obj/machinery/door/airlock/proc/toggle_lock
+	call_proc = TYPE_PROC_REF(/obj/machinery/door/airlock, toggle_lock)
 
 /decl/public_access/public_variable/airlock_door_state
 	expected_type = /obj/machinery/door/airlock

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -235,7 +235,7 @@
 /decl/public_access/public_method/close_door_delayed
 	name = "delayed close door"
 	desc = "Closes the door if possible, after a short delay."
-	call_proc = /obj/machinery/door/blast/proc/delayed_close
+	call_proc = TYPE_PROC_REF(/obj/machinery/door/blast, delayed_close)
 
 /decl/stock_part_preset/radio/receiver/blast_door
 	frequency = BLAST_DOORS_FREQ

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -145,7 +145,7 @@
 /decl/public_access/public_method/flasher_flash
 	name = "flash"
 	desc = "Performs a flash, if possible."
-	call_proc = /obj/machinery/flasher/proc/flash
+	call_proc = TYPE_PROC_REF(/obj/machinery/flasher, flash)
 
 /decl/stock_part_preset/radio/receiver/flasher
 	frequency = BUTTON_FREQ

--- a/code/game/machinery/holosign.dm
+++ b/code/game/machinery/holosign.dm
@@ -52,7 +52,7 @@
 /decl/public_access/public_method/holosign_toggle
 	name = "holosign toggle"
 	desc = "Toggle the holosign's active state."
-	call_proc = /obj/machinery/holosign/proc/toggle
+	call_proc = TYPE_PROC_REF(/obj/machinery/holosign, toggle)
 
 /decl/stock_part_preset/radio/receiver/holosign
 	frequency = BUTTON_FREQ

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -73,7 +73,7 @@
 /decl/public_access/public_method/igniter_toggle
 	name = "igniter toggle"
 	desc = "Toggle the igniter on or off."
-	call_proc = /obj/machinery/igniter/proc/ignite
+	call_proc = TYPE_PROC_REF(/obj/machinery/igniter, ignite)
 
 /decl/stock_part_preset/radio/receiver/igniter
 	frequency = BUTTON_FREQ
@@ -164,7 +164,7 @@
 /decl/public_access/public_method/sparker_spark
 	name = "spark"
 	desc = "Creates sparks to ignite nearby gases."
-	call_proc = /obj/machinery/sparker/proc/ignite
+	call_proc = TYPE_PROC_REF(/obj/machinery/sparker, ignite)
 
 /decl/stock_part_preset/radio/receiver/sparker
 	frequency = BUTTON_FREQ

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -55,12 +55,12 @@
 /decl/public_access/public_method/driver_drive
 	name = "launch"
 	desc = "Makes the mass driver launch immediately"
-	call_proc = /obj/machinery/mass_driver/proc/drive
+	call_proc = TYPE_PROC_REF(/obj/machinery/mass_driver, drive)
 
 /decl/public_access/public_method/driver_drive_delayed
 	name = "delayed launch"
 	desc = "Makes the mass driver launch after a short delay"
-	call_proc = /obj/machinery/mass_driver/proc/delayed_drive
+	call_proc = TYPE_PROC_REF(/obj/machinery/mass_driver, delayed_drive)
 
 /decl/stock_part_preset/radio/receiver/driver
 	frequency = BLAST_DOORS_FREQ

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -253,7 +253,7 @@
 /decl/public_access/public_method/toggle_unlocked
 	name = "toggle valve"
 	desc = "Open or close the valve."
-	call_proc = /obj/machinery/atmospherics/binary/passive_gate/proc/toggle_unlocked
+	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/binary/passive_gate, toggle_unlocked)
 
 /decl/stock_part_preset/radio/event_transmitter/passive_gate
 	frequency = PUMP_FREQ

--- a/code/modules/atmospherics/components/tvalve.dm
+++ b/code/modules/atmospherics/components/tvalve.dm
@@ -136,17 +136,17 @@
 /decl/public_access/public_method/tvalve_go_straight
 	name = "valve go straight"
 	desc = "Sets the valve to send output straight."
-	call_proc = /obj/machinery/atmospherics/tvalve/proc/go_straight
+	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/tvalve, go_straight)
 
 /decl/public_access/public_method/tvalve_go_side
 	name = "valve go side"
 	desc = "Redirects output to the side."
-	call_proc = /obj/machinery/atmospherics/tvalve/proc/go_to_side
+	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/tvalve, go_to_side)
 
 /decl/public_access/public_method/tvalve_toggle
 	name = "valve toggle"
 	desc = "Toggles the output direction."
-	call_proc = /obj/machinery/atmospherics/tvalve/proc/toggle
+	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/tvalve, toggle)
 
 /decl/stock_part_preset/radio/receiver/tvalve
 	frequency = FUEL_FREQ

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -155,7 +155,7 @@
 /decl/public_access/public_method/inject
 	name = "inject"
 	desc = "Injects gas into its environment."
-	call_proc = /obj/machinery/atmospherics/unary/outlet_injector/proc/inject
+	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/unary/outlet_injector, inject)
 
 /decl/stock_part_preset/radio/event_transmitter/outlet_injector
 	frequency = ATMOS_TANK_FREQ

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -439,12 +439,12 @@
 /decl/public_access/public_method/purge_pump
 	name = "activate purge mode"
 	desc = "Activates purge mode, overriding pressure checks and removing air."
-	call_proc = /obj/machinery/atmospherics/unary/vent_pump/proc/purge
+	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/unary/vent_pump, purge)
 
 /decl/public_access/public_method/toggle_pump_dir
 	name = "toggle pump direction"
 	desc = "Toggles the pump's direction, from release to siphon or vice versa."
-	call_proc = /obj/machinery/atmospherics/unary/vent_pump/proc/toggle_pump_dir
+	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/unary/vent_pump, toggle_pump_dir)
 
 /decl/stock_part_preset/radio/event_transmitter/vent_pump
 	frequency = PUMP_FREQ

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -317,13 +317,13 @@
 /decl/public_access/public_method/toggle_panic_siphon
 	name = "toggle panic siphon"
 	desc = "Toggles the panic siphon function."
-	call_proc = /obj/machinery/atmospherics/unary/vent_scrubber/proc/toggle_panic
+	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/unary/vent_scrubber, toggle_panic)
 
 /decl/public_access/public_method/set_scrub_gas
 	name = "set filter gases"
 	desc = "Given a list of gases, sets whether the gas is being scrubbed to the value of the gas in the list."
 	forward_args = TRUE
-	call_proc = /obj/machinery/atmospherics/unary/vent_scrubber/proc/set_scrub_gas
+	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/unary/vent_scrubber, set_scrub_gas)
 
 /decl/stock_part_preset/radio/event_transmitter/vent_scrubber
 	frequency = PUMP_FREQ

--- a/code/modules/atmospherics/components/valve.dm
+++ b/code/modules/atmospherics/components/valve.dm
@@ -136,17 +136,17 @@
 /decl/public_access/public_method/open_valve
 	name = "open valve"
 	desc = "Sets the valve to open."
-	call_proc = /obj/machinery/atmospherics/valve/proc/open
+	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/valve, open)
 
 /decl/public_access/public_method/close_valve
 	name = "open valve"
 	desc = "Sets the valve to open."
-	call_proc = /obj/machinery/atmospherics/valve/proc/close
+	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/valve, close)
 
 /decl/public_access/public_method/toggle_valve
 	name = "toggle valve"
 	desc = "Toggles whether the valve is open or closed."
-	call_proc = /obj/machinery/atmospherics/valve/proc/toggle
+	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/valve, toggle)
 
 /obj/machinery/atmospherics/valve/digital		// can be controlled by AI
 	name = "digital valve"

--- a/code/modules/mob/living/simple_animal/hostile/leech.dm
+++ b/code/modules/mob/living/simple_animal/hostile/leech.dm
@@ -67,9 +67,9 @@
 /obj/structure/leech_spawner/proc/burst(var/mob/living/carbon/victim)
 	if(!proxy_listener || !istype(victim) || !(victim in view(5, src)))
 		return
+	QDEL_NULL(proxy_listener) // delete prior to spawning the leeches to avoid infinite recursion
 	for(var/i in 1 to 12)
 		new leech_type(get_turf(src))
 	visible_message(SPAN_MFAUNA("A swarm of leeches burst out from \the [src]!"))
 	icon_state = "reeds_empty"
 	desc = "Some alien reeds."
-	QDEL_NULL(proxy_listener)

--- a/code/modules/modular_computers/networking/device_types/acl.dm
+++ b/code/modules/modular_computers/networking/device_types/acl.dm
@@ -1,6 +1,6 @@
 /datum/extension/network_device/acl
 	var/list/group_dict = list()	// Groups on the network, stored as strings.
-									// Parents groups with children have a list of child groups associated with the string key 
+									// Parents groups with children have a list of child groups associated with the string key
 
 	var/list/all_groups = list()	// All group strings, not sorted by parent or child group. Used for uniqueness checking.
 
@@ -39,7 +39,7 @@
 		return "Maximum group name length is 15 characters."
 	if(group_name in all_groups)
 		return "Group name must be unique"
-	
+
 	// Adding a child group.
 	if(parent_group)
 		if(!(parent_group in group_dict))
@@ -49,7 +49,7 @@
 		group_dict[parent_group] += group_name
 	else
 		group_dict += group_name
-	
+
 	all_groups += group_name
 	return "Added [parent_group ? "child group" : "parent group"] \"[group_name]\"" + "[parent_group ? " to \"[parent_group]\"." : "."]"
 
@@ -63,7 +63,7 @@
 			return "No child group with name \"[group_name]\" found in \"[parent_group]\""
 		group_dict[parent_group] -= group_name
 		if(!length(group_dict[parent_group])) // Cull the list until we add a new child group.
-			group_dict[parent_group] = null	
+			group_dict[parent_group] = null
 		all_groups -= group_name
 		return "Removed child group \"[group_name]\" from parent group \"[parent_group]\"."
 	if(group_name in group_dict)
@@ -110,17 +110,17 @@
 /decl/public_access/public_method/add_group
 	name = "Add group"
 	desc = "Adds a new group with the passed name. A parent group can be passed to add a child group."
-	call_proc = /datum/extension/network_device/acl/proc/add_group
+	call_proc = TYPE_PROC_REF(/datum/extension/network_device/acl, add_group)
 	forward_args = TRUE
 
 /decl/public_access/public_method/remove_group
 	name = "Remove group"
 	desc = "Removes a group with the passed name. A parent group can be passed to remove a child group of that parent."
-	call_proc = /datum/extension/network_device/acl/proc/remove_group
+	call_proc = TYPE_PROC_REF(/datum/extension/network_device/acl, remove_group)
 	forward_args = TRUE
 
 /decl/public_access/public_method/list_groups
 	name = "List groups"
 	desc = "Lists groups on the group access controller. A parent group can be passed list children of that parent group."
-	call_proc = /datum/extension/network_device/acl/proc/get_group_listing
+	call_proc = TYPE_PROC_REF(/datum/extension/network_device/acl, get_group_listing)
 	forward_args = TRUE

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -655,7 +655,7 @@ var/global/list/adminfaxes     = list()	//cache for faxes that have been sent to
 /decl/public_access/public_method/fax_receive_document
 	name = "Send Fax Message"
 	desc = "Sends the specified document over to the specified network tag."
-	call_proc = /obj/machinery/faxmachine/proc/receive_fax
+	call_proc = TYPE_PROC_REF(/obj/machinery/faxmachine, receive_fax)
 	forward_args = TRUE
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -233,7 +233,7 @@
 /decl/public_access/public_method/toggle_emitter
 	name = "toggle emitter"
 	desc = "Toggles whether or not the emitter is active. It must be unlocked to work."
-	call_proc = /obj/machinery/emitter/proc/activate
+	call_proc = TYPE_PROC_REF(/obj/machinery/emitter, activate)
 
 /decl/public_access/public_variable/emitter_active
 	expected_type = /obj/machinery/emitter


### PR DESCRIPTION
## Description of changes
Some cherry-picked fixes from the shuttle rotation pull request. Commit names are descriptive.

## Why and what will this PR improve
- Fixes airlocks not bolting properly when docking/undocking.
- Fixes radio airlock commands sometimes being lost.
- Fixes a potential infinite recursion caused by proximity triggers (relevant in megaleech spawner code)
- Fixes radio transmitters not overwriting stale data
- Queues unlock/lock commands received while an airlock is `operating` (opening/closing)

## Authorship
Me, in #3348.