### PR TITLE
Prevents food items from equalizing with turf reagents on fluid_act().

### DIFF
--- a/code/game/atoms_fluids.dm
+++ b/code/game/atoms_fluids.dm
@@ -3,7 +3,8 @@
 
 /atom/proc/fluid_act(var/datum/reagents/fluids)
 	SHOULD_CALL_PARENT(TRUE)
-	if(reagents && fluids?.total_volume >= FLUID_SHALLOW && ATOM_IS_OPEN_CONTAINER(src))
+	// TODO: fix food open container behavior jesus christ
+	if(reagents && reagents != fluids && fluids?.total_volume >= FLUID_SHALLOW && ATOM_IS_OPEN_CONTAINER(src) && !istype(src, /obj/item/chems/food))
 		reagents.trans_to_holder(fluids, reagents.total_volume)
 		fluids.trans_to_holder(reagents, min(fluids.total_volume, reagents.maximum_volume))
 


### PR DESCRIPTION
Absolutely hate doing istype(src) but until we fix food it's the easiest way to sort this out. :(