### PR TITLE
Increased towercap hardness to allow it to be used in crafting.

### DIFF
--- a/code/modules/materials/definitions/solids/materials_solid_wood.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_wood.dm
@@ -45,7 +45,7 @@
 	name = "towercap"
 	uid = "solid_wood_fungal"
 	color = "#e6d8dd"
-	hardness = MAT_VALUE_FLEXIBLE + 1
+	hardness = MAT_VALUE_FLEXIBLE + 10
 
 /decl/material/solid/organic/wood/holographic
 	name = "holographic wood"


### PR DESCRIPTION
Bumps fungal wood up to the minimum hardness for most furniture and item crafting.