### PR TITLE
Adding some chem handling boilerplate to lanterns and cooking vessels.

### DIFF
--- a/code/game/objects/items/flame/flame_fuelled.dm
+++ b/code/game/objects/items/flame/flame_fuelled.dm
@@ -18,6 +18,36 @@
 		fuel_type = global.using_map.default_liquid_fuel_type
 	initialize_reagents()
 
+// Boilerplate from /obj/item/chems/glass. TODO generalize to a lower level.
+/obj/item/flame/fuelled/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(force && !(item_flags & ITEM_FLAG_NO_BLUDGEON) && user.a_intent == I_HURT)
+		. = ..()
+		if(reagents?.total_volume && !QDELETED(target))
+			target.visible_message(SPAN_DANGER("Some of the contents of \the [src] splash onto \the [target]."))
+			reagents.splash(target, reagents.total_volume)
+		return TRUE
+	return FALSE
+
+/obj/item/flame/fuelled/afterattack(obj/target, mob/user, proximity)
+	if(!ATOM_IS_OPEN_CONTAINER(src) || !proximity) //Is the container open & are they next to whatever they're clicking?
+		return FALSE //If not, do nothing.
+	if(target?.storage)
+		return TRUE
+	if(!lit && standard_dispenser_refill(user, target)) //Are they clicking a water tank/some dispenser?
+		playsound(src.loc, 'sound/effects/refill.ogg', 50, TRUE, -6)
+		return TRUE
+	if(standard_pour_into(user, target)) //Pouring into another beaker?
+		return TRUE
+	if(handle_eaten_by_mob(user, target) != EATEN_INVALID)
+		return TRUE
+	if(reagents?.total_volume)
+		to_chat(user, SPAN_NOTICE("You splash a small amount of the contents of \the [src] onto \the [target]."))
+		reagents.splash(target, min(reagents.total_volume, 5))
+		return TRUE
+	. = ..()
+
+// End boilerplate.
+
 /obj/item/flame/fuelled/examine(mob/user, distance)
 	. = ..()
 	if(distance <= 1 && user)
@@ -68,9 +98,3 @@
 		visible_message(SPAN_WARNING("\The [src]'s flame flickers."))
 		set_light(0)
 		addtimer(CALLBACK(src, TYPE_PROC_REF(.atom, set_light), 2), 4)
-
-/obj/item/flame/fuelled/afterattack(obj/target, mob/user, proximity)
-	if(proximity && !lit && standard_dispenser_refill(user, target)) // To be able to refill lanterns and lighters from reagent dispensers.
-		playsound(src.loc, 'sound/effects/refill.ogg', 50, TRUE, -6)
-		return TRUE
-	return ..()

--- a/code/modules/food/cooking/cooking_vessels/_cooking_vessel.dm
+++ b/code/modules/food/cooking/cooking_vessels/_cooking_vessel.dm
@@ -32,6 +32,37 @@
 
 	return ..()
 
+// Boilerplate from /obj/item/chems/glass. TODO generalize to a lower level.
+/obj/item/chems/cooking_vessel/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
+	if(force && !(item_flags & ITEM_FLAG_NO_BLUDGEON) && user.a_intent == I_HURT)
+		return ..()
+	return FALSE
+
+/obj/item/chems/cooking_vessel/afterattack(var/obj/target, var/mob/user, var/proximity)
+	if(!ATOM_IS_OPEN_CONTAINER(src) || !proximity) //Is the container open & are they next to whatever they're clicking?
+		return FALSE //If not, do nothing.
+	if(target?.storage)
+		return TRUE
+	if(standard_dispenser_refill(user, target)) //Are they clicking a water tank/some dispenser?
+		return TRUE
+	if(standard_pour_into(user, target)) //Pouring into another beaker?
+		return TRUE
+	if(handle_eaten_by_mob(user, target) != EATEN_INVALID)
+		return TRUE
+	if(user.a_intent == I_HURT)
+		if(standard_splash_mob(user,target))
+			return TRUE
+		if(reagents && reagents.total_volume)
+			to_chat(user, SPAN_DANGER("You splash the contents of \the [src] onto \the [target]."))
+			reagents.splash(target, reagents.total_volume)
+			return TRUE
+	else if(reagents && reagents.total_volume)
+		to_chat(user, SPAN_NOTICE("You splash a small amount of the contents of \the [src] onto \the [target]."))
+		reagents.splash(target, min(reagents.total_volume, 5))
+		return TRUE
+	. = ..()
+// End boilerplate.
+
 /obj/item/chems/cooking_vessel/proc/get_cooking_contents_strings()
 
 	. = list()


### PR DESCRIPTION
- Lanterns splash the target with some fuel when used as a weapon.
- Lanterns can be used to splash a turf or transfer into a container.
- Cooking vessels have basic splash and pour handling.