### PR TITLE
Soup taste fixes.

### DIFF
--- a/code/game/machinery/kitchen/icecream.dm
+++ b/code/game/machinery/kitchen/icecream.dm
@@ -198,12 +198,14 @@
 	layer = ABOVE_OBJ_LAYER
 	bitesize = 3
 	volume = 20
+	nutriment_amt = 5
+	nutriment_type = /decl/material/liquid/nutriment
+	nutriment_desc = "crunchy waffle cone"
 	var/ice_creamed
 	var/cone_type
 
 /obj/item/chems/food/icecream/Initialize()
 	. = ..()
-	add_to_reagents(/decl/material/liquid/nutriment, 5)
 	update_icon()
 
 /obj/item/chems/food/icecream/on_update_icon()

--- a/code/modules/food/cooking/_recipe.dm
+++ b/code/modules/food/cooking/_recipe.dm
@@ -186,7 +186,14 @@ var/global/list/_cooking_recipe_cache = list()
 		return produced
 
 	if(ispath(result, /decl/material))
-		container.reagents?.add_reagent(result, result_quantity, get_result_data(container, used_ingredients))
+		var/created_volume = result_quantity
+		for(var/obj/item/ingredient in (used_ingredients["items"]|used_ingredients["fruits"]))
+			if(!ingredient.reagents?.total_volume)
+				continue
+			for(var/reagent_type in ingredient.reagents.reagent_volumes)
+				created_volume += ingredient.reagents.reagent_volumes[reagent_type]
+
+		container.reagents?.add_reagent(result, created_volume, get_result_data(container, used_ingredients))
 		return null
 
 // Create the actual result atom. Handled by a proc to allow for recipes to override it.

--- a/code/modules/food/cooking/cooking_vessels/_cooking_vessel.dm
+++ b/code/modules/food/cooking/cooking_vessels/_cooking_vessel.dm
@@ -43,8 +43,8 @@
 		for(var/reagent_type in reagents.reagent_volumes)
 			var/decl/material/reagent = GET_DECL(reagent_type)
 			var/reagent_name = reagent.get_reagent_name(reagents)
-			if(!isnull(reagent.boiling_point) && temperature >= reagent.boiling_point)
-				. += "[reagents.reagent_volumes[reagent_type]]u of simmering [reagent_name]"
+			if(!isnull(reagent.boiling_point) && temperature >= reagent.boiling_point && reagent.soup_hot_desc)
+				. += "[reagents.reagent_volumes[reagent_type]]u of [reagent.soup_hot_desc] [reagent_name]"
 			else
 				. += "[reagents.reagent_volumes[reagent_type]]u of [reagent_name]"
 

--- a/code/modules/food/cooking/recipes/recipe_soup.dm
+++ b/code/modules/food/cooking/recipes/recipe_soup.dm
@@ -14,11 +14,17 @@
 
 	if(length(used_items))
 
-		for(var/obj/item/chems/food/food in used_items)
-			if(food.nutriment_type && food.nutriment_desc)
+		for(var/obj/item/chems/ingredient in used_items)
+			var/obj/item/chems/food/food = ingredient
+			if(istype(food))
 				for(var/taste in food.nutriment_desc)
-					taste_strings[taste] += food.nutriment_desc[taste]
-			soup_flags |= food.ingredient_flags
+					taste_strings[taste] = max(taste_strings[taste], food.nutriment_desc[taste])
+				soup_flags |= food.ingredient_flags
+
+			for(var/reagent_type in ingredient.reagents?.reagent_volumes)
+				var/decl/material/reagent = GET_DECL(reagent_type)
+				if(reagent.taste_description)
+					taste_strings[reagent.taste_description] = max(taste_strings[reagent.taste_description], reagent.taste_mult)
 
 		if(locate(/obj/item/chems/food/grown) in used_items)
 			for(var/obj/item/chems/food/grown/veg in used_items)
@@ -85,6 +91,7 @@
 	. = list()
 	.["soup_ingredients"] = list("marrow" = 1)
 	.["soup_flags"] = INGREDIENT_FLAG_MEAT
+	.["taste"] = list("rich marrow" = 5)
 
 /decl/recipe/soup/simple
 	abstract_type = /decl/recipe/soup/simple

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -73,6 +73,9 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	var/antag_text
 	var/default_solid_form = /obj/item/stack/material/sheet
 
+	var/soup_name
+	var/soup_hot_desc = "simmering"
+
 	var/affect_blood_on_ingest = TRUE
 	var/affect_blood_on_inhale = TRUE
 
@@ -351,6 +354,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	solid_name     ||= use_name
 	gas_name       ||= use_name
 	adjective_name ||= use_name
+	soup_name      ||= liquid_name
 
 	// Null/clear a bunch of physical vars as this material is fake.
 	if(holographic)
@@ -1004,7 +1008,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 			var/data_name = rdata["mask_name"]
 			if(data_name)
 				return data_name
-	return liquid_name
+	return soup_name
 
 /decl/material/proc/get_reagent_color(datum/reagents/holder)
 	if(istype(holder) && holder.reagent_data)

--- a/code/modules/materials/definitions/solids/materials_solid_mineral.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_mineral.dm
@@ -160,6 +160,8 @@
 	dissolves_into = list(
 		/decl/material/solid/sodium = 1
 	)
+	soup_name = "salt"
+	soup_hot_desc = null
 
 /decl/material/solid/potash
 	name = "potash"

--- a/code/modules/reagents/chems/chems_drinks.dm
+++ b/code/modules/reagents/chems/chems_drinks.dm
@@ -154,14 +154,14 @@
 
 /decl/material/liquid/drink/juice/potato
 	name = "potato juice"
-	lore_text = "Juice of the potato. Bleh."
-	taste_description = "sadness and potatoes"
+	lore_text = "Juice of the potato."
+	taste_description = "starch"
 	nutrition = 2
 	color = "#302000"
 	uid = "chem_drink_potato"
 
 	glass_name = "potato juice"
-	glass_desc = "Juice from a potato. Bleh."
+	glass_desc = "Juice from a potato. Possibly the most boring drink in existence, other than water."
 
 /decl/material/liquid/drink/juice/garlic
 	name = "garlic juice"

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -34,7 +34,9 @@
 	var/dry = FALSE
 	var/nutriment_amt = 0
 	var/nutriment_type = /decl/material/liquid/nutriment // Used to determine which base nutriment type is spawned for this item.
-	var/list/nutriment_desc = list("food" = 1)    // List of flavours and flavour strengths. The flavour strength text is determined by the ratio of flavour strengths in the snack.
+	// List of flavours and flavour strengths.
+	// The flavour strength text is determined by the ratio of flavour strengths in the snack.
+	var/list/nutriment_desc
 	var/list/eat_sound = 'sound/items/eatfood.ogg'
 	var/filling_color = "#ffffff" //Used by sandwiches.
 	var/trash


### PR DESCRIPTION
- Salt in a soup pot is now called `salt` instead of `simmering molten sodium chloride`.
- Broth/soup/stew keeps track of ingredient taste strings from reagents as well as item taste.
- Broth/soup/stew adds volume based on the reagent contents of the ingredients.
- Ice cream cones don't taste generic.
- Potatoes don't taste of sadness.