### PR TITLE
Adjusting some material softness so wax and such can be manipulated as lumps.

### DIFF
--- a/code/modules/crafting/stack_recipes/recipes_soft.dm
+++ b/code/modules/crafting/stack_recipes/recipes_soft.dm
@@ -4,7 +4,7 @@
 	craft_stack_types           = null
 	forbidden_craft_stack_types = null
 	required_min_hardness       = 0
-	required_max_hardness       = MAT_VALUE_MALLEABLE
+	required_max_hardness       = MAT_VALUE_SOFT
 	crafting_extra_cost_factor  = 1 // No wastage for just resculpting materials.
 
 /decl/stack_recipe/soft/teapot
@@ -47,6 +47,12 @@
 		if(user)
 			S.add_to_stacks(user, 1)
 	return S
+
+/decl/stack_recipe/soft/stack/bar
+	name                        = "bar"
+	name_plural                 = "bars"
+	result_type                 = /obj/item/stack/material/bar
+	result_type                 = /obj/item/stack/material/bar/wax
 
 /decl/stack_recipe/soft/stack/large_lump
 	name                        = "large lump"

--- a/code/modules/materials/definitions/solids/materials_solid_butchery.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_butchery.dm
@@ -63,7 +63,7 @@
 	hidden_from_codex = TRUE
 	construction_difficulty = MAT_VALUE_NORMAL_DIY
 	integrity = 50
-	hardness = MAT_VALUE_SOFT
+	hardness = MAT_VALUE_SOFT+5
 	weight = MAT_VALUE_EXTREMELY_LIGHT
 	explosion_resistance = 1
 	reflectiveness = MAT_VALUE_DULL

--- a/code/modules/materials/definitions/solids/materials_solid_metal.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_metal.dm
@@ -398,7 +398,7 @@
 	melting_point = 505
 	boiling_point = 2875
 	color = "#c5c5a8"
-	hardness = MAT_VALUE_SOFT + 10
+	hardness = MAT_VALUE_FLEXIBLE
 	construction_difficulty = MAT_VALUE_EASY_DIY
 	reflectiveness = MAT_VALUE_MATTE
 
@@ -409,7 +409,7 @@
 	melting_point = 600
 	boiling_point = 2022
 	color = "#3f3f4d"
-	hardness = MAT_VALUE_SOFT
+	hardness = MAT_VALUE_FLEXIBLE
 	construction_difficulty = MAT_VALUE_NORMAL_DIY
 	reflectiveness = MAT_VALUE_MATTE
 	taste_description = "metallic sugar"

--- a/code/modules/materials/definitions/solids/materials_solid_organic.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_organic.dm
@@ -76,7 +76,7 @@
 	wall_flags = PAINT_PAINTABLE|PAINT_STRIPABLE|WALL_HAS_EDGES
 	use_reinf_state = null
 	color = "#aaaaaa"
-	hardness = MAT_VALUE_SOFT
+	hardness = MAT_VALUE_SOFT+5
 	brute_armor = 1
 	weight = MAT_VALUE_EXTREMELY_LIGHT - 5
 	ignition_point = T0C+232 //"the temperature at which book-paper catches fire, and burns." close enough
@@ -108,7 +108,7 @@
 	use_reinf_state         = null
 	flags                   = MAT_FLAG_BRITTLE
 	reflectiveness          = MAT_VALUE_DULL
-	hardness                = MAT_VALUE_SOFT - 5
+	hardness                = MAT_VALUE_FLEXIBLE-5
 	wall_support_value      = MAT_VALUE_EXTREMELY_LIGHT - 9
 	weight                  = MAT_VALUE_EXTREMELY_LIGHT - 9
 	construction_difficulty = MAT_VALUE_EASY_DIY
@@ -139,7 +139,7 @@
 	hidden_from_codex = TRUE
 	construction_difficulty = MAT_VALUE_NORMAL_DIY
 	reflectiveness = MAT_VALUE_DULL
-	hardness = MAT_VALUE_SOFT
+	hardness = MAT_VALUE_SOFT+5
 	weight = MAT_VALUE_EXTREMELY_LIGHT
 	wall_support_value = MAT_VALUE_EXTREMELY_LIGHT
 	default_solid_form = /obj/item/stack/material/bolt


### PR DESCRIPTION
- Soft stack recipes now require MAT_VALUE_SOFT or less instead of MALLEABLE.
- Soft materials can be made into bars.
- Skin, lead, cardboard, paper and cloth are slightly harder to except them from soft crafting recipes.