### PR TITLE
Fix lossy reagent transfer

### DIFF
--- a/code/__defines/maths.dm
+++ b/code/__defines/maths.dm
@@ -6,6 +6,9 @@
 #define NONUNIT_FLOOR(x, y)    (round( (x) / (y)) * (y))
 #define NONUNIT_CEILING(x, y) (-round(-(x) / (y)) * (y))
 
+// Special two-step rounding for reagents, to avoid floating point errors.
+#define CHEMS_QUANTIZE(x) NONUNIT_FLOOR(round(x, MINIMUM_CHEMICAL_VOLUME * 0.1), MINIMUM_CHEMICAL_VOLUME)
+
 #define MULT_BY_RANDOM_COEF(VAR,LO,HI) VAR =  round((VAR * rand(LO * 100, HI * 100))/100, 0.1)
 
 #define ROUND(x) (((x) >= 0) ? round((x)) : -round(-(x)))

--- a/code/modules/reagents/reactions/_reaction.dm
+++ b/code/modules/reagents/reactions/_reaction.dm
@@ -57,7 +57,7 @@
 
 	var/reaction_volume = holder.maximum_volume
 	for(var/reactant in required_reagents)
-		var/A = NONUNIT_FLOOR(REAGENT_VOLUME(holder, reactant) / required_reagents[reactant] / limit, MINIMUM_CHEMICAL_VOLUME)  // How much of this reagent we are allowed to use
+		var/A = CHEMS_QUANTIZE(REAGENT_VOLUME(holder, reactant) / required_reagents[reactant] / limit)  // How much of this reagent we are allowed to use
 		if(reaction_volume > A)
 			reaction_volume = A
 


### PR DESCRIPTION
## Description of changes
Redoes reagent transfer rounding to fix floating-point errors without allowing for reagent duplication. We now use a two-step rounding process, where first we round to the nearest multiple of 1/10 `MINIMUM_CHEMICAL_VOLUME`, and then do the current step of flooring to the highest multiple of `MINIMUM_CHEMICAL_VOLUME` lower than the amount. This helps in cases where floating point errors cause something like 17.52 to be represented as 17.519999.

Also adds a compensation mechanism for when the apportionment of reagents in `trans_to_holder()` doesn't add up to `amount` precisely due to rounding—if `. < amount`, we transfer the difference from the primary reagent. This means you'll always transfer exactly the amount you intend.

## Why and what will this PR improve
17.519999 will now round to 17.52 instead of 17.52. 17.5190 will still properly round down to 17.51.

Transferring 40u of two reagents (35u of tea and 5u of water) 5u at a time will properly transfer 5u rather than 4.98u.