### PR TITLE
Fix the taste of grown foods.

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -99,7 +99,7 @@
 			if(LAZYACCESS(reagent_amounts,2) && potency > 0)
 				rtotal += round(potency/reagent_amounts[2])
 			if(rid == /decl/material/liquid/nutriment)
-				LAZYSET(data, seed.product_name, max(1,rtotal))
+				LAZYSET(data, "taste", list(seed.product_name = max(1,rtotal)))
 			add_to_reagents(rid,max(1,rtotal),data)
 
 /obj/item/chems/food/grown/proc/update_desc()


### PR DESCRIPTION
## Description of changes
While investigating some reagent transfer issues for #4278, I noticed that nutriment from a non-dried tea leaf had no taste. I then saw the code for grown food reagent initialisation while breakpointing it to investigate rounding errors, and noticed that taste had been changed to use a separate list everywhere but there. Seems like a simple enough fix.

## Why and what will this PR improve
Tea leaves no longer give the message `You taste  .`, and will instead say `You taste tea leaf.`... which is at least a little better?