### PR TITLE
Enable corners on sand turfs

### DIFF
--- a/code/game/turfs/floors/natural/natural_sand.dm
+++ b/code/game/turfs/floors/natural/natural_sand.dm
@@ -5,6 +5,7 @@
 	footstep_type = /decl/footsteps/sand
 	icon = 'icons/turf/flooring/sand.dmi'
 	icon_edge_layer = EXT_EDGE_SAND
+	icon_has_corners = TRUE
 	possible_states = 4
 	turf_flags = TURF_FLAG_BACKGROUND | TURF_IS_HOLOMAP_PATH | TURF_FLAG_ABSORB_LIQUID
 	material = /decl/material/solid/sand


### PR DESCRIPTION
## Description of changes
Enables corners on sand turfs.

## Why and what will this PR improve
They were enabled for grass turfs, but not sand turfs. Now they're enabled on sand turfs as well.