### PR TITLE
Make food not an open container

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -965,3 +965,12 @@
 /atom/proc/is_outside()
 	var/turf/turf = get_turf(src)
 	return istype(turf) ? turf.is_outside() : OUTSIDE_UNCERTAIN
+
+/atom/proc/can_be_poured_into(atom/source)
+	return (reagents?.maximum_volume > 0) && ATOM_IS_OPEN_CONTAINER(src)
+
+/// This is whether it's physically possible to pour from this atom to the target atom, based on context like user intent and src being open, etc.
+/// This should not check things like whether there is actually anything in src to pour.
+/// It should also not check anything controlled by the target atom, because can_be_poured_into() already exists.
+/atom/proc/can_be_poured_from(mob/user, atom/target)
+	return (reagents?.maximum_volume > 0) && ATOM_IS_OPEN_CONTAINER(src)

--- a/code/game/atoms_fluids.dm
+++ b/code/game/atoms_fluids.dm
@@ -3,8 +3,7 @@
 
 /atom/proc/fluid_act(var/datum/reagents/fluids)
 	SHOULD_CALL_PARENT(TRUE)
-	// TODO: fix food open container behavior jesus christ
-	if(reagents && reagents != fluids && fluids?.total_volume >= FLUID_SHALLOW && ATOM_IS_OPEN_CONTAINER(src) && !istype(src, /obj/item/food))
+	if(reagents && reagents != fluids && fluids?.total_volume >= FLUID_SHALLOW && ATOM_IS_OPEN_CONTAINER(src))
 		reagents.trans_to_holder(fluids, reagents.total_volume)
 		fluids.trans_to_holder(reagents, min(fluids.total_volume, reagents.maximum_volume))
 

--- a/code/game/objects/items/_item_reagents.dm
+++ b/code/game/objects/items/_item_reagents.dm
@@ -1,34 +1,34 @@
 /obj/item/proc/standard_dispenser_refill(var/mob/user, var/obj/structure/reagent_dispensers/target) // This goes into afterattack
 	if(!istype(target) || (target.atom_flags & ATOM_FLAG_OPEN_CONTAINER))
-		return 0
+		return FALSE
 
 	if(!target.reagents || !target.reagents.total_volume)
 		to_chat(user, SPAN_NOTICE("[target] is empty."))
-		return 1
+		return TRUE
 
 	if(reagents && !REAGENTS_FREE_SPACE(reagents))
 		to_chat(user, SPAN_NOTICE("[src] is full."))
-		return 1
+		return TRUE
 
 	var/trans = target.reagents.trans_to_obj(src, target.amount_dispensed)
 	to_chat(user, SPAN_NOTICE("You fill [src] with [trans] units of the contents of [target]."))
-	return 1
+	return TRUE
 
 /obj/item/proc/standard_splash_mob(var/mob/user, var/mob/target) // This goes into afterattack
 	if(!istype(target))
-		return
+		return FALSE
 
 	if(user.a_intent == I_HELP)
 		to_chat(user, SPAN_NOTICE("You can't splash people on help intent."))
-		return 1
+		return TRUE
 
 	if(!reagents || !reagents.total_volume)
 		to_chat(user, SPAN_NOTICE("[src] is empty."))
-		return 1
+		return TRUE
 
 	if(target.reagents && !REAGENTS_FREE_SPACE(target.reagents))
 		to_chat(user, SPAN_NOTICE("[target] is full."))
-		return 1
+		return TRUE
 
 	var/contained = REAGENT_LIST(src)
 
@@ -38,30 +38,32 @@
 		SPAN_DANGER("You splash \the [target] with the contents of \the [src]."))
 
 	reagents.splash(target, reagents.total_volume)
-	return 1
-
+	return TRUE
 
 /obj/item/proc/standard_pour_into(mob/user, atom/target, amount = 5) // This goes into afterattack and yes, it's atom-level
 	if(!target.reagents)
-		return 0
+		return FALSE
 
-	// Ensure we don't splash beakers and similar containers.
-	if(!ATOM_IS_OPEN_CONTAINER(target) && istype(target, /obj/item/chems))
-		to_chat(user, SPAN_NOTICE("\The [target] is closed."))
-		return 1
-	// Otherwise don't care about splashing.
-	else if(!ATOM_IS_OPEN_CONTAINER(target))
-		return 0
+	if(!target.can_be_poured_into(src))
+		// Ensure we don't splash beakers and similar containers.
+		if(istype(target, /obj/item/chems))
+			to_chat(user, SPAN_NOTICE("\The [target] is closed."))
+			return TRUE
+		// Otherwise don't care about splashing.
+		return FALSE
+
+	if(!can_be_poured_from(user, target))
+		return TRUE // don't splash if we can't pour
 
 	if(!reagents || !reagents.total_volume)
 		to_chat(user, SPAN_NOTICE("[src] is empty."))
-		return 1
+		return TRUE
 
 	if(!REAGENTS_FREE_SPACE(target.reagents))
 		to_chat(user, SPAN_NOTICE("[target] is full."))
-		return 1
+		return TRUE
 
 	var/trans = reagents.trans_to(target, amount)
 	playsound(src, 'sound/effects/pour.ogg', 25, 1)
 	to_chat(user, SPAN_NOTICE("You transfer [trans] unit\s of the solution to \the [target].  \The [src] now contains [src.reagents.total_volume] units."))
-	return 1
+	return TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -280,9 +280,7 @@
 		return TRUE
 
 	if(reagents?.total_volume >= FLUID_PUDDLE)
-		// Must be open, but food items should not be filled from sources like this. They're open in order to add condiments, not to be poured into/out of.
-		// TODO: Rewrite open-container-ness or food to make this unnecessary!
-		if(ATOM_IS_OPEN_CONTAINER(W) && !istype(W, /obj/item/food) && W.reagents)
+		if(ATOM_IS_OPEN_CONTAINER(W) && W.reagents)
 			var/taking = min(reagents.total_volume, REAGENTS_FREE_SPACE(W.reagents))
 			if(taking > 0)
 				to_chat(user, SPAN_NOTICE("You fill \the [W] with [reagents.get_primary_reagent_name()] from \the [src]."))

--- a/code/modules/food/cooking/cooking_vessels/_cooking_vessel.dm
+++ b/code/modules/food/cooking/cooking_vessels/_cooking_vessel.dm
@@ -21,7 +21,7 @@
 		return ..()
 
 	// Fill or take from the vessel.
-	if(W.reagents && ATOM_IS_OPEN_CONTAINER(W) && !istype(W, /obj/item/food))
+	if(W.reagents && ATOM_IS_OPEN_CONTAINER(W))
 		if(W.reagents.total_volume)
 			if(istype(W, /obj/item/chems))
 				var/obj/item/chems/vessel = W

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -449,16 +449,16 @@ var/global/obj/temp_reagents_holder = new
 	if(ismob(target))
 		touch_mob(target)
 		if(QDELETED(target))
-			return TRUE
+			return 0
 		return splash_mob(target, amount, copy, defer_update = defer_update)
 	if(isturf(target))
 		return trans_to_turf(target, amount, multiplier, copy, defer_update = defer_update)
 	if(isobj(target))
 		touch_obj(target)
-		if(!QDELETED(target) && ATOM_IS_OPEN_CONTAINER(target))
+		if(!QDELETED(target) && target.can_be_poured_into(my_atom))
 			return trans_to_obj(target, amount, multiplier, copy, defer_update = defer_update)
-		return TRUE
-	return FALSE
+		return 0
+	return 0
 
 //Splashing reagents is messier than trans_to, the target's loc gets some of the reagents as well.
 /datum/reagents/proc/splash(var/atom/target, var/amount = 1, var/multiplier = 1, var/copy = 0, var/min_spill=0, var/max_spill=60, var/defer_update = FALSE)

--- a/code/modules/reagents/reagent_containers/condiment.dm
+++ b/code/modules/reagents/reagent_containers/condiment.dm
@@ -58,20 +58,7 @@
 		return
 	if(standard_pour_into(user, target))
 		return
-
-	if(istype(target, /obj/item/food)) // These are not opencontainers but we can transfer to them
-		if(!reagents || !reagents.total_volume)
-			to_chat(user, SPAN_NOTICE("There is no condiment left in \the [src]."))
-			return
-
-		if(!REAGENTS_FREE_SPACE(target.reagents))
-			to_chat(user, SPAN_NOTICE("You can't add more condiment to \the [target]."))
-			return
-
-		var/trans = reagents.trans_to_obj(target, amount_per_transfer_from_this)
-		to_chat(user, SPAN_NOTICE("You add [trans] units of the condiment to \the [target]."))
-	else
-		..()
+	..()
 
 /obj/item/chems/condiment/proc/update_center_of_mass()
 	center_of_mass = is_special_bottle ? initial(is_special_bottle.center_of_mass) : initial(center_of_mass)

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -14,7 +14,6 @@
 	icon = 'icons/obj/food.dmi'
 	icon_state = null
 	randpixel = 6
-	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	obj_flags = OBJ_FLAG_HOLLOW
 	item_flags = null
 	material = /decl/material/liquid/nutriment
@@ -68,8 +67,9 @@
 /obj/item/food/can_be_injected_by(var/atom/injector)
 	return TRUE
 
-/obj/item/food/standard_pour_into(mob/user, atom/target)
-	return FALSE
+// Does not rely on ATOM_IS_OPEN_CONTAINER because we want to be able to pour in but not out.
+/obj/item/food/can_be_poured_into(atom/source)
+	return (reagents?.maximum_volume > 0)
 
 /obj/item/food/attack_self(mob/user)
 	if(is_edible(user) && handle_eaten_by_mob(user, user) != EATEN_INVALID)

--- a/code/modules/reagents/reagent_containers/food/canned.dm
+++ b/code/modules/reagents/reagent_containers/food/canned.dm
@@ -60,6 +60,9 @@
 /obj/item/food/can/apply_filling_overlay()
 	return //Bypass searching through the whole icon file for a filling icon
 
+/obj/item/food/can/can_be_poured_into(atom/source)
+	return (reagents?.maximum_volume > 0) && ATOM_IS_OPEN_CONTAINER(src)
+
 //Just a short line of Canned Consumables, great for treasure in faraway abandoned outposts
 
 /obj/item/food/can/beef
@@ -127,10 +130,10 @@
 /obj/item/food/can/caviar/true
 	name = "canned caviar"
 	icon_state = "carpeggs"
-	desc = "Caviar, or space carp eggs. Exceeds the recomended amount of heavy metals in your diet! But very posh."
+	desc = "Caviar, or space carp eggs. Exceeds the recommended amount of heavy metals in your diet! But very posh."
 	trash = /obj/item/trash/carpegg
 	filling_color = "#330066"
-	nutriment_desc = list("fish" = 1, "salt" = 1, "numbing sensation" = 1)
+	nutriment_desc = list("fish" = 1, "salt" = 1, "a numbing sensation" = 1)
 	nutriment_amt = 6
 
 /obj/item/food/can/caviar/true/populate_reagents()

--- a/code/modules/reagents/reagent_containers/food/meat/cubes.dm
+++ b/code/modules/reagents/reagent_containers/food/meat/cubes.dm
@@ -3,7 +3,6 @@
 /obj/item/food/monkeycube
 	name = "monkey cube"
 	desc = "Just add water!"
-	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	icon_state = "monkeycube"
 	bitesize = 12
 	filling_color = "#adac7f"
@@ -38,9 +37,11 @@
 	icon_state = "monkeycube"
 	desc = "Just add water!"
 	to_chat(user, SPAN_NOTICE("You unwrap \the [src]."))
-	atom_flags |= ATOM_FLAG_OPEN_CONTAINER
 	user.put_in_hands(new wrapper_type(get_turf(user)))
 	wrapper_type = null
+
+/obj/item/food/monkeycube/can_be_poured_into(atom/source)
+	return ..() && !wrapper_type
 
 /obj/item/food/monkeycube/handle_eaten_by_mob(mob/user, mob/target)
 	. = ..()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -86,10 +86,7 @@
 
 	// We do this here to avoid putting the vessel straight into storage.
 	// This is usually handled by afterattack on /chems.
-	// The item must be an open container, but food items should not be filled from sources like this.
-	// They're open in order to add condiments, not to be poured into/out of.
-	// TODO: Rewrite open-container-ness or food to make this unnecessary!
-	if(storage && ATOM_IS_OPEN_CONTAINER(W) && !istype(W, /obj/item/food) && user.a_intent == I_HELP)
+	if(storage && ATOM_IS_OPEN_CONTAINER(W) && user.a_intent == I_HELP)
 		if(W.standard_dispenser_refill(user, src))
 			return TRUE
 		if(W.standard_pour_into(user, src))

--- a/code/modules/vehicles/engine.dm
+++ b/code/modules/vehicles/engine.dm
@@ -90,13 +90,9 @@
 	temp_reagents_holder.atom_flags |= ATOM_FLAG_OPEN_CONTAINER
 
 /obj/item/engine/thermal/attackby(var/obj/item/I, var/mob/user)
-	if(istype(I,/obj/item/chems) && ATOM_IS_OPEN_CONTAINER(I))
-		if(istype(I,/obj/item/food) || istype(I,/obj/item/chems/pill))
-			return 0
-		var/obj/item/chems/C = I
-		C.standard_pour_into(user,src)
-		return 1
-	..()
+	if(I.standard_pour_into(user, src))
+		return TRUE
+	return ..()
 
 /obj/item/engine/thermal/use_power()
 	if(fuel_points >= cost_per_move)


### PR DESCRIPTION
## Description of changes
Makes food objects no longer open containers, preventing a bunch of unwanted reagent interactions with fluids, pouring, etc. Also removes a lot of typechecks that disabled (or tried to disable) those interactions since they aren't necessary anymore.

Relies on #4274.

Tested:
- [x] Pouring condiments/spices/etc. into food
- [x] Unable to pour out of food
- [x] Unable to eat closed canned food
- [x] Able to eat closed canned food
- [x] Unable to pour out of open canned food 
- [x] Unable to pour into closed canned food
- [x] Able to pour into open canned food

## Why and what will this PR improve
Prevents a bunch of unwanted interactions between food reagent contents and fluid/pouring/etc.