### PR TITLE
Fix corpse random name generation

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -93,7 +93,7 @@
 
 	var/decl/cultural_info/culture = M.get_cultural_value(TAG_CULTURE)
 	if(culture && CORPSE_SPAWNER_RANDOM_NAME & spawn_flags)
-		M.SetName(M, culture.get_random_name(M.gender))
+		M.SetName(culture.get_random_name(M.gender))
 	else
 		M.SetName(name)
 	M.real_name = M.name


### PR DESCRIPTION
## Description of changes
Fixes an erroneous parameter to SetName in corpse generation.

## Why and what will this PR improve
Corpses won't always be named Unknown because the name gets set to null.