### PR TITLE
Replace rounding macros with 515 procs

### DIFF
--- a/code/__defines/maths.dm
+++ b/code/__defines/maths.dm
@@ -11,7 +11,6 @@
 #define MULT_BY_RANDOM_COEF(VAR,LO,HI) VAR =  round((VAR * rand(LO * 100, HI * 100))/100, 0.1)
 
 #define ROUND(x) (((x) >= 0) ? round((x)) : -round(-(x)))
-#define FLOOR(x) (round(x))
 #define EULER 2.7182818285
 
 #define MODULUS_FLOAT(X, Y) ( (X) - (Y) * round((X) / (Y)) )

--- a/code/__defines/maths.dm
+++ b/code/__defines/maths.dm
@@ -2,15 +2,14 @@
 #define RAND_F(LOW, HIGH) (rand() * (HIGH - LOW) + LOW)
 
 // Float-aware floor and ceiling since round() will round upwards when given a second arg.
-#define NONUNIT_FLOOR(x, y)    (round( (x) / (y)) * (y))
-#define NONUNIT_CEILING(x, y) (-round(-(x) / (y)) * (y))
+#define NONUNIT_FLOOR(x, y)    (floor((x) / (y)) * (y))
+#define NONUNIT_CEILING(x, y) (ceil((x) / (y)) * (y))
 
 // Special two-step rounding for reagents, to avoid floating point errors.
 #define CHEMS_QUANTIZE(x) NONUNIT_FLOOR(round(x, MINIMUM_CHEMICAL_VOLUME * 0.1), MINIMUM_CHEMICAL_VOLUME)
 
 #define MULT_BY_RANDOM_COEF(VAR,LO,HI) VAR =  round((VAR * rand(LO * 100, HI * 100))/100, 0.1)
 
-#define ROUND(x) (((x) >= 0) ? round((x)) : -round(-(x)))
 #define EULER 2.7182818285
 
 #define MODULUS_FLOAT(X, Y) ( (X) - (Y) * round((X) / (Y)) )

--- a/code/__defines/maths.dm
+++ b/code/__defines/maths.dm
@@ -1,6 +1,5 @@
 // Macro functions.
 #define RAND_F(LOW, HIGH) (rand() * (HIGH - LOW) + LOW)
-#define CEILING(x) (-round(-(x)))
 
 // Float-aware floor and ceiling since round() will round upwards when given a second arg.
 #define NONUNIT_FLOOR(x, y)    (round( (x) / (y)) * (y))
@@ -22,4 +21,4 @@
 #define SIMPLIFY_DEGREES(degrees) (MODULUS_FLOAT((degrees), 360))
 
 #define IS_POWER_OF_TWO(VAL) ((VAL & (VAL-1)) == 0)
-#define ROUND_UP_TO_POWER_OF_TWO(VAL) (2 ** CEILING(log(2,VAL)))
+#define ROUND_UP_TO_POWER_OF_TWO(VAL) (2 ** ceil(log(2,VAL)))

--- a/code/__defines/turfs.dm
+++ b/code/__defines/turfs.dm
@@ -20,9 +20,9 @@
 
 //Here are a few macros to help with people always forgetting to round the coordinates somewhere, and forgetting that not everything automatically rounds decimals.
 ///Helper macro for the x coordinate of the turf at the center of the world. Handles rounding.
-#define WORLD_CENTER_X CEILING((1 + world.maxx) / 2)
+#define WORLD_CENTER_X ceil((1 + world.maxx) / 2)
 ///Helper macro for the y coordinate of the turf at the center of the world. Handles rounding.
-#define WORLD_CENTER_Y CEILING((1 + world.maxy) / 2)
+#define WORLD_CENTER_Y ceil((1 + world.maxy) / 2)
 ///Helper macro for getting the center turf on a given z-level. Handles rounding.
 #define WORLD_CENTER_TURF(Z) locate(WORLD_CENTER_X, WORLD_CENTER_Y, Z)
 ///Helper macro to check if a position is within the world's bounds.

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -108,7 +108,7 @@
 	return dist
 
 /proc/get_dist_bounds(var/target, var/source) // Alternative to get_dist for multi-turf objects
-	return CEILING(bounds_dist(target, source)/world.icon_size) + 1
+	return ceil(bounds_dist(target, source)/world.icon_size) + 1
 
 /proc/circlerangeturfs(center=usr,radius=3)
 	var/turf/centerturf = get_turf(center)

--- a/code/_helpers/maths.dm
+++ b/code/_helpers/maths.dm
@@ -91,7 +91,7 @@
 /proc/polar2turf(x, y, z, angle, distance)
 	var/x_offset = POLAR_TO_BYOND_X(distance, angle)
 	var/y_offset = POLAR_TO_BYOND_Y(distance, angle)
-	return locate(CEILING(x + x_offset), CEILING(y + y_offset), z)
+	return locate(ceil(x + x_offset), ceil(y + y_offset), z)
 
 /proc/get_turf_from_angle(x, y, z, angle, ideal_distance)
 	do

--- a/code/_helpers/maths.dm
+++ b/code/_helpers/maths.dm
@@ -1,7 +1,7 @@
 // min is inclusive, max is exclusive
 /proc/Wrap(val, min, max)
 	var/d = max - min
-	var/t = FLOOR((val - min) / d)
+	var/t = floor((val - min) / d)
 	return val - (t * d)
 
 // Trigonometric functions.
@@ -37,7 +37,7 @@
 	return (val >= min) && (val <= max)
 
 /proc/IsInteger(x)
-	return FLOOR(x) == x
+	return floor(x) == x
 
 /proc/IsMultiple(x, y)
 	return x % y == 0

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -241,7 +241,7 @@
 		return val
 	if(istext(val))
 		var/list/vals = splittext(val, "x")
-		return FLOOR(max(text2num(vals[1]), text2num(vals[2]))/2)
+		return floor(max(text2num(vals[1]), text2num(vals[2]))/2)
 	return 0
 
 // If all of these flags are present, it should come out at exactly 1. Yes, this

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -66,7 +66,7 @@
 			screen.transform = null
 			if(screen.screen_loc != ui_entire_screen && largest_bound > 7)
 				var/matrix/M = matrix()
-				M.Scale(CEILING(client.last_view_x_dim/7), CEILING(client.last_view_y_dim/7))
+				M.Scale(ceil(client.last_view_x_dim/7), ceil(client.last_view_y_dim/7))
 				screen.transform = M
 			client.screen |= screen
 

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -63,7 +63,7 @@
 		var/stamina = mymob.get_stamina()
 		if(stamina < 100)
 			stamina_bar.set_invisibility(INVISIBILITY_NONE)
-			stamina_bar.icon_state = "prog_bar_[FLOOR(stamina/5)*5][(stamina >= 5) && (stamina <= 25) ? "_fail" : null]"
+			stamina_bar.icon_state = "prog_bar_[floor(stamina/5)*5][(stamina >= 5) && (stamina <= 25) ? "_fail" : null]"
 
 /datum/hud/proc/hide_inventory()
 	inventory_shown = FALSE

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -106,7 +106,7 @@ var/global/obj/screen/robot_inventory
 		if(!R.robot_modules_background)
 			return
 
-		var/display_rows = -round(-(R.module.equipment.len) / 8)
+		var/display_rows = ceil(R.module.equipment.len / 8)
 		R.robot_modules_background.screen_loc = "CENTER-4:16,BOTTOM+1:7 to CENTER+3:16,BOTTOM+[display_rows]:7"
 		R.client.screen += R.robot_modules_background
 

--- a/code/_onclick/hud/skybox.dm
+++ b/code/_onclick/hud/skybox.dm
@@ -13,7 +13,7 @@ var/global/const/SKYBOX_DIMENSION = 736 // Largest measurement for icon sides, u
 
 /obj/skybox/Initialize()
 	if(!max_view_dim)
-		max_view_dim = CEILING(SKYBOX_DIMENSION / world.icon_size)
+		max_view_dim = ceil(SKYBOX_DIMENSION / world.icon_size)
 	. = ..()
 
 /client

--- a/code/controllers/subsystems/fluids.dm
+++ b/code/controllers/subsystems/fluids.dm
@@ -147,7 +147,7 @@ SUBSYSTEM_DEF(fluids)
 				UPDATE_FLUID_BLOCKED_DIRS(other_fluid_holder)
 				if(!(other_fluid_holder.fluid_blocked_dirs & UP) && other_fluid_holder.CanFluidPass(UP))
 					if(!QDELETED(other_fluid_holder) && other_fluid_holder.reagents?.total_volume < FLUID_MAX_DEPTH)
-						current_fluid_holder.transfer_fluids_to(other_fluid_holder, min(FLOOR(current_depth*0.5), FLUID_MAX_DEPTH - other_fluid_holder.reagents?.total_volume))
+						current_fluid_holder.transfer_fluids_to(other_fluid_holder, min(floor(current_depth*0.5), FLUID_MAX_DEPTH - other_fluid_holder.reagents?.total_volume))
 						current_depth = current_fluid_holder.get_fluid_depth()
 
 		// Flow into the lowest level neighbor.

--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -1,7 +1,7 @@
 /// Controls how many buckets should be kept, each representing a tick. (1 minutes worth)
 #define BUCKET_LEN (world.fps*1*60)
 /// Helper for getting the correct bucket for a given timer
-#define BUCKET_POS(timer) (((CEILING((timer.timeToRun - timer.timer_subsystem.head_offset) / world.tick_lag)+1) % BUCKET_LEN)||BUCKET_LEN)
+#define BUCKET_POS(timer) (((ceil((timer.timeToRun - timer.timer_subsystem.head_offset) / world.tick_lag)+1) % BUCKET_LEN)||BUCKET_LEN)
 /// Gets the maximum time at which timers will be invoked from buckets, used for deferring to secondary queue
 #define TIMER_MAX(timer_ss) (timer_ss.head_offset + TICKS2DS(BUCKET_LEN + timer_ss.practical_offset - 1))
 /// Max float with integer precision

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -120,11 +120,11 @@ var/global/list/beam_icon_cache = list() // shut up chinsky I do not have a cach
 		//Position the effect so the beam is one continous line
 		var/a
 		if(abs(Pixel_x)>32)
-			a = Pixel_x > 0 ? round(Pixel_x/32) : CEILING(Pixel_x/32)
+			a = Pixel_x > 0 ? round(Pixel_x/32) : ceil(Pixel_x/32)
 			X.x += a
 			Pixel_x %= 32
 		if(abs(Pixel_y)>32)
-			a = Pixel_y > 0 ? round(Pixel_y/32) : CEILING(Pixel_y/32)
+			a = Pixel_y > 0 ? round(Pixel_y/32) : ceil(Pixel_y/32)
 			X.y += a
 			Pixel_y %= 32
 

--- a/code/datums/extensions/lockable.dm
+++ b/code/datums/extensions/lockable.dm
@@ -132,8 +132,8 @@
 	Returns null if there are no problems. Or a text string describing the problem otherwise.
  */
 /datum/extension/lockable/proc/keycode_issues_text(code)
-	if(length(code) < FLOOR(max_code_length * 0.5) || length(code) > max_code_length)
-		return "Keycode must be between [FLOOR(max_code_length * 0.5)] and [max_code_length] numbers long."
+	if(length(code) < floor(max_code_length * 0.5) || length(code) > max_code_length)
+		return "Keycode must be between [floor(max_code_length * 0.5)] and [max_code_length] numbers long."
 	return null //Return null, since we have no issues
 
 /**

--- a/code/datums/position_point_vector.dm
+++ b/code/datums/position_point_vector.dm
@@ -112,11 +112,11 @@
 	AM.pixel_y = return_py()
 
 /datum/point/proc/return_turf()
-	var/turf/T = locate(CEILING(x / world.icon_size), CEILING(y / world.icon_size), z)
+	var/turf/T = locate(ceil(x / world.icon_size), ceil(y / world.icon_size), z)
 	return T?.resolve_to_actual_turf()
 
 /datum/point/proc/return_coordinates()		//[turf_x, turf_y, z]
-	return list(CEILING(x / world.icon_size), CEILING(y / world.icon_size), z)
+	return list(ceil(x / world.icon_size), ceil(y / world.icon_size), z)
 
 /datum/point/proc/return_position()
 	return new /datum/position(src)

--- a/code/datums/repositories/crew/vital.dm
+++ b/code/datums/repositories/crew/vital.dm
@@ -74,7 +74,7 @@
 		crew_data["charge_span"] = "good"
 
 	if(crew_data["true_oxygenation"] != -1)
-		crew_data["pressure"] = "[FLOOR(120+rand(-5,5))]/[FLOOR(80+rand(-5,5))]"
+		crew_data["pressure"] = "[floor(120+rand(-5,5))]/[floor(80+rand(-5,5))]"
 		crew_data["true_oxygenation"] = 100
 		crew_data["oxygenation"] = "normal"
 		crew_data["oxygenation_span"] = "good"
@@ -91,7 +91,7 @@
 		crew_data["charge_span"] = "bad"
 
 	if(crew_data["true_oxygenation"] != -1)
-		crew_data["pressure"] = "[FLOOR((120+rand(-5,5))*0.25)]/[FLOOR((80+rand(-5,5))*0.25)]"
+		crew_data["pressure"] = "[floor((120+rand(-5,5))*0.25)]/[floor((80+rand(-5,5))*0.25)]"
 		crew_data["true_oxygenation"] = 25
 		crew_data["oxygenation"] = "extremely low"
 		crew_data["oxygenation_span"] = "bad"

--- a/code/datums/traits/prosthetics/prosthetic_limbs.dm
+++ b/code/datums/traits/prosthetics/prosthetic_limbs.dm
@@ -24,7 +24,7 @@
 	. = ..()
 	// Macro can generate float costs, round to closest point value.
 	if(trait_cost)
-		trait_cost = CEILING(trait_cost)
+		trait_cost = ceil(trait_cost)
 	if(bodypart_name)
 		if(model)
 			var/decl/bodytype/prosthetic/model_manufacturer = GET_DECL(model)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -380,7 +380,7 @@
 	if(length(reagents?.reagent_volumes))
 		LAZYINITLIST(.)
 		for(var/R in reagents.reagent_volumes)
-			.[R] += FLOOR(REAGENT_VOLUME(reagents, R) / REAGENT_UNITS_PER_MATERIAL_UNIT)
+			.[R] += floor(REAGENT_VOLUME(reagents, R) / REAGENT_UNITS_PER_MATERIAL_UNIT)
 	for(var/atom/contained_obj as anything in get_contained_external_atoms()) // machines handle component parts separately
 		. = MERGE_ASSOCS_WITH_NUM_VALUES(., contained_obj.get_contained_matter())
 

--- a/code/game/machinery/dehumidifier.dm
+++ b/code/game/machinery/dehumidifier.dm
@@ -76,7 +76,7 @@
 			use_power_oneoff(drainage * 1000)
 			return
 
-		T.remove_fluid(CEILING(fluid_here * drainage))
+		T.remove_fluid(ceil(fluid_here * drainage))
 		T.show_bubbles()
 		use_power_oneoff(drainage * 5000)
 

--- a/code/game/machinery/doors/_door.dm
+++ b/code/game/machinery/doors/_door.dm
@@ -272,7 +272,7 @@
 
 		//figure out how much metal we need
 		var/amount_needed = (current_max_health - current_health) / DOOR_REPAIR_AMOUNT
-		amount_needed = CEILING(amount_needed)
+		amount_needed = ceil(amount_needed)
 
 		var/obj/item/stack/stack = I
 		var/transfer

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -159,7 +159,7 @@
 				to_chat(user, "<span class='notice'>[src]'s motors resist your effort.</span>")
 			return
 	if(istype(C, /obj/item/stack/material) && C.get_material_type() == /decl/material/solid/metal/plasteel)
-		var/amt = CEILING((get_max_health() - current_health)/150)
+		var/amt = ceil((get_max_health() - current_health)/150)
 		if(!amt)
 			to_chat(user, "<span class='notice'>\The [src] is already fully functional.</span>")
 			return

--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -163,7 +163,7 @@
 		cooking_obj = null
 	else
 		var/failed
-		var/overcook_period = max(FLOOR(cook_time/5),1)
+		var/overcook_period = max(floor(cook_time/5),1)
 		cooking_obj = result
 		while(1)
 			sleep(overcook_period)

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -187,7 +187,7 @@
 
 	slab_nutrition /= gib_products.len
 
-	var/drop_products = FLOOR(gib_products.len * 0.35)
+	var/drop_products = floor(gib_products.len * 0.35)
 	for(var/atom/movable/thing in gib_products)
 		if(drop_products)
 			drop_products--

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -456,5 +456,5 @@
 	las_rating = total_component_rating_of_type(/obj/item/stock_parts/micro_laser)
 
 	change_power_consumption(initial(active_power_usage) - (cap_rating * 25), POWER_USE_ACTIVE)
-	max_n_of_items = initial(max_n_of_items) + FLOOR(bin_rating)
+	max_n_of_items = initial(max_n_of_items) + floor(bin_rating)
 	cooking_power = initial(cooking_power) + (las_rating / 3)

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -214,7 +214,7 @@
 		return
 
 	if (reagents.total_volume && prob(50)) // 50% chance a liquid recipe gets messy
-		dirty += CEILING(reagents.total_volume / 10)
+		dirty += ceil(reagents.total_volume / 10)
 
 	var/decl/recipe/recipe = select_recipe(RECIPE_CATEGORY_MICROWAVE, src, cooking_temperature)
 	if (!recipe)

--- a/code/game/machinery/vending/_vending.dm
+++ b/code/game/machinery/vending/_vending.dm
@@ -269,7 +269,7 @@
 		data["mode"] = 1
 		data["product"] = currently_vending.item_name
 		data["price"] = cur.format_value(currently_vending.price)
-		data["price_num"] = FLOOR(currently_vending.price / cur.absolute_value)
+		data["price_num"] = floor(currently_vending.price / cur.absolute_value)
 		data["message"] = status_message
 		data["message_err"] = status_error
 	else
@@ -286,7 +286,7 @@
 				"key" =    key,
 				"name" =   I.item_name,
 				"price" =  cur.format_value(I.price),
-				"price_num" = FLOOR(I.price / cur.absolute_value),
+				"price_num" = floor(I.price / cur.absolute_value),
 				"color" =  I.display_color,
 				"amount" = I.get_amount())))
 

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -69,7 +69,7 @@
 /obj/machinery/washing_machine/proc/wash()
 	if(operable())
 		var/list/washing_atoms = get_contained_external_atoms()
-		var/amount_per_atom = FLOOR(reagents.total_volume / length(washing_atoms))
+		var/amount_per_atom = floor(reagents.total_volume / length(washing_atoms))
 
 		if(amount_per_atom > 0)
 			var/decl/material/smelliest = get_smelliest_reagent(reagents)

--- a/code/game/objects/items/_item_damage.dm
+++ b/code/game/objects/items/_item_damage.dm
@@ -53,7 +53,7 @@
 	return (mult * (4 - severity)) + (severity != 1? rand(-(mult / severity), (mult / severity)) : 0 )
 
 /obj/item/proc/explosion_severity_damage_multiplier()
-	return CEILING(get_max_health() / 3)
+	return ceil(get_max_health() / 3)
 
 /obj/item/is_burnable()
 	return simulated

--- a/code/game/objects/items/devices/suit_sensor_jammer.dm
+++ b/code/game/objects/items/devices/suit_sensor_jammer.dm
@@ -113,7 +113,7 @@
 		"methods" = methods,
 		"current_method" = "\ref[jammer_method]",
 		"current_cost" = jammer_method.energy_cost,
-		"total_cost" = "[CEILING(JAMMER_POWER_CONSUMPTION(10))]"
+		"total_cost" = "[ceil(JAMMER_POWER_CONSUMPTION(10))]"
 	)
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -412,7 +412,7 @@
 /obj/item/stack/get_storage_cost()	//Scales storage cost to stack size
 	. = ..()
 	if (amount < max_amount)
-		. = CEILING(. * amount / max_amount)
+		. = ceil(. * amount / max_amount)
 
 /obj/item/stack/get_mass() // Scales mass to stack size
 	. = ..()

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -21,7 +21,7 @@
 			to_chat(user, "<span class='notice'>You slot \the [src] into \the [I] and charge its internal uplink.</span>")
 
 /obj/item/stack/telecrystal/attack_self(var/mob/user)
-	if(use(CEILING(DEFAULT_TELECRYSTAL_AMOUNT/20)))
+	if(use(ceil(DEFAULT_TELECRYSTAL_AMOUNT/20)))
 		user.visible_message("<span class='warning'>\The [user] crushes a crystal!</span>", "<span class='warning'>You crush \a [src]!</span>", "You hear the sound of a crystal breaking just before a sudden crack of electricity.")
 		var/turf/T = get_random_turf_in_range(user, 7, 3)
 		if(T)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -49,7 +49,7 @@
 			else
 				add_overlay("[icon_state]-powered")
 	if(bcell)
-		var/ratio = CEILING(bcell.percent()/25) * 25
+		var/ratio = ceil(bcell.percent()/25) * 25
 		add_overlay("[icon_state]-charge[ratio]")
 	else
 		add_overlay("[icon_state]-nocell")

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -86,4 +86,4 @@
 	. = res
 
 /obj/item/dice/d100/convert_result(var/res)
-	. = FLOOR(res/10)
+	. = floor(res/10)

--- a/code/game/objects/items/weapons/grenades/decompiler.dm
+++ b/code/game/objects/items/weapons/grenades/decompiler.dm
@@ -56,7 +56,7 @@
 	if(dump_cubes)
 		visible_message(SPAN_DANGER("\The [src] collapses!"))
 		for(var/mat in decompiled_matter)
-			var/sheet_amount = FLOOR(decompiled_matter[mat]/SHEET_MATERIAL_AMOUNT)
+			var/sheet_amount = floor(decompiled_matter[mat]/SHEET_MATERIAL_AMOUNT)
 			if(sheet_amount > 0)
 				while(sheet_amount > 100)
 					var/obj/item/stack/material/cubes/cubes = new (dump_cubes, 100, mat)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -55,7 +55,7 @@
 	. = ..()
 	if(. || length(contents) || !ispath(foldable) || !istype(material))
 		return TRUE
-	var/sheet_amount = FLOOR(LAZYACCESS(matter, material.type) / SHEET_MATERIAL_AMOUNT)
+	var/sheet_amount = floor(LAZYACCESS(matter, material.type) / SHEET_MATERIAL_AMOUNT)
 	if(sheet_amount <= 0 || !user.try_unequip(src))
 		return TRUE
 	to_chat(user, SPAN_NOTICE("You fold \the [src] flat."))

--- a/code/game/objects/items/weapons/storage/fancy/vials.dm
+++ b/code/game/objects/items/weapons/storage/fancy/vials.dm
@@ -16,7 +16,7 @@
 /obj/item/box/fancy/vials/on_update_icon()
 	. = ..()
 	var/key_count = count_by_type(contents, key_type)
-	icon_state = "[initial(icon_state)][FLOOR(key_count/2)]"
+	icon_state = "[initial(icon_state)][floor(key_count/2)]"
 
 /*
  * Not actually a "fancy" storage...
@@ -38,7 +38,7 @@
 /obj/item/lockbox/vials/on_update_icon()
 	. = ..()
 	var/total_contents = count_by_type(contents, /obj/item/chems/glass/beaker/vial)
-	icon_state = "vialbox[FLOOR(total_contents/2)]"
+	icon_state = "vialbox[floor(total_contents/2)]"
 	if (!broken)
 		add_overlay("led[locked]")
 		if(locked)

--- a/code/game/objects/structures/_structure_construction.dm
+++ b/code/game/objects/structures/_structure_construction.dm
@@ -105,7 +105,7 @@
 /obj/structure/proc/handle_repair(mob/user, obj/item/tool)
 	var/current_max_health = get_max_health()
 	var/obj/item/stack/stack = tool
-	var/amount_needed = CEILING((current_max_health - current_health)/DOOR_REPAIR_AMOUNT)
+	var/amount_needed = ceil((current_max_health - current_health)/DOOR_REPAIR_AMOUNT)
 	var/used = min(amount_needed,stack.amount)
 	if(used)
 		to_chat(user, SPAN_NOTICE("You fit [stack.get_string_for_amount(used)] to damaged areas of \the [src]."))

--- a/code/game/objects/structures/_structure_materials.dm
+++ b/code/game/objects/structures/_structure_materials.dm
@@ -70,7 +70,7 @@
 				placing = (matter[mat] / SHEET_MATERIAL_AMOUNT) * 0.75
 				if(parts_type)
 					placing *= atom_info_repository.get_matter_multiplier_for(parts_type, mat, placing)
-				placing = FLOOR(placing)
+				placing = floor(placing)
 			else
 				placing = parts_amount
 			if(placing > 0)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -66,7 +66,7 @@
 		effective_cover *= 2
 	if(!anchored)
 		effective_cover *= 0.5
-	effective_cover = clamp(FLOOR(effective_cover), 0, 100)
+	effective_cover = clamp(floor(effective_cover), 0, 100)
 	if(Proj.original != src && !prob(effective_cover))
 		return PROJECTILE_CONTINUE
 	var/damage = Proj.get_structure_damage()
@@ -75,7 +75,7 @@
 	if(!istype(Proj, /obj/item/projectile/beam))
 		damage *= 0.4
 	if(reinf_material)
-		damage = FLOOR(damage * 0.75)
+		damage = floor(damage * 0.75)
 	..()
 	if(damage)
 		take_damage(damage, Proj.atom_damage_type)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -87,7 +87,7 @@ var/global/list/hygiene_props = list()
 	if(fluid_here <= 0)
 		return
 
-	T.remove_fluid(CEILING(fluid_here*drainage))
+	T.remove_fluid(ceil(fluid_here*drainage))
 	T.show_bubbles()
 	if(world.time > last_gurgle + 80)
 		last_gurgle = world.time

--- a/code/game/turfs/floors/natural/_natural.dm
+++ b/code/game/turfs/floors/natural/_natural.dm
@@ -99,7 +99,7 @@
 		// At best, you get about 5 pieces of clay or dirt from digging the
 		// associated turfs. So we'll make it cost 5 to put some back.
 		// TODO: maybe make this use the diggable loot list.
-		var/stack_depth = CEILING((abs(get_physical_height()) / TRENCH_DEPTH_PER_ACTION) * 5)
+		var/stack_depth = ceil((abs(get_physical_height()) / TRENCH_DEPTH_PER_ACTION) * 5)
 		var/using_lumps = max(1, min(stack.amount, min(stack_depth, 5)))
 		if(stack.use(using_lumps))
 			set_physical_height(min(0, get_physical_height() + ((using_lumps / 5) * TRENCH_DEPTH_PER_ACTION)))

--- a/code/game/turfs/turf_enter.dm
+++ b/code/game/turfs/turf_enter.dm
@@ -73,7 +73,7 @@
 				M.reset_layer()
 			else
 				// arbitrary timing value that feels good in practice. it sucks and is inconsistent:(
-				addtimer(CALLBACK(M, TYPE_PROC_REF(/atom, reset_layer)), max(0, CEILING(M.next_move - world.time)) + 1 SECOND)
+				addtimer(CALLBACK(M, TYPE_PROC_REF(/atom, reset_layer)), max(0, ceil(M.next_move - world.time)) + 1 SECOND)
 
 	if(simulated)
 		A.OnSimulatedTurfEntered(src, old_loc)

--- a/code/modules/character_info/comment_mood.dm
+++ b/code/modules/character_info/comment_mood.dm
@@ -5,7 +5,7 @@ var/global/_comment_mood_legend
 	if(!global._comment_mood_legend)
 		var/legend_width = 500
 		var/legend_per_row = 5
-		var/legend_cell_width = FLOOR(legend_width/legend_per_row)
+		var/legend_cell_width = floor(legend_width/legend_per_row)
 		global._comment_mood_legend = list("<table align = 'center' width = '[legend_width]px' style='padding: 3px'><tr><td colspan = [legend_per_row]><center><b>Legend</b></center></td></tr>")
 		var/list/all_moods = decls_repository.get_decls_of_type(/decl/comment_mood)
 		var/counter = 0

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -501,8 +501,8 @@ var/global/const/MAX_VIEW = 41
 		return // Some kind of malformed winget(), do not proceed.
 
 	// Rescale as needed.
-	var/res_x =    get_config_value(/decl/config/num/clients/lock_client_view_x) || CEILING(text2num(view_components[1]) / divisor)
-	var/res_y =    get_config_value(/decl/config/num/clients/lock_client_view_y) || CEILING(text2num(view_components[2]) / divisor)
+	var/res_x =    get_config_value(/decl/config/num/clients/lock_client_view_x) || ceil(text2num(view_components[1]) / divisor)
+	var/res_y =    get_config_value(/decl/config/num/clients/lock_client_view_y) || ceil(text2num(view_components[2]) / divisor)
 	var/max_view = get_config_value(/decl/config/num/clients/max_client_view_x)  || MAX_VIEW
 
 	last_view_x_dim = clamp(res_x, MIN_VIEW, max_view)

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -89,7 +89,7 @@
 	return TRUE
 
 // Sort of a placeholder for proper tailoring.
-#define RAG_COUNT(X) CEILING((LAZYACCESS(X.matter, /decl/material/solid/organic/cloth) * 0.65) / SHEET_MATERIAL_AMOUNT)
+#define RAG_COUNT(X) ceil((LAZYACCESS(X.matter, /decl/material/solid/organic/cloth) * 0.65) / SHEET_MATERIAL_AMOUNT)
 
 /obj/item/clothing/attackby(obj/item/I, mob/user)
 	var/rags = RAG_COUNT(src)

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -244,7 +244,7 @@
 				return
 
 			var/obj/item/stack/tape_roll/duct_tape/D = W
-			var/amount_needed = CEILING(target_breach.class * 2)
+			var/amount_needed = ceil(target_breach.class * 2)
 			if(!D.can_use(amount_needed))
 				to_chat(user, SPAN_WARNING("There's not enough [D.plural_name] in your [src] to seal \the [target_breach.descriptor] on \the [src]! You need at least [amount_needed] [D.plural_name]."))
 				return

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -498,7 +498,7 @@
 
 	data["charge"] =       cell ? round(cell.charge,1) : 0
 	data["maxcharge"] =    cell ? cell.maxcharge : 0
-	data["chargestatus"] = cell ? FLOOR(cell.percent()/2) : 0
+	data["chargestatus"] = cell ? floor(cell.percent()/2) : 0
 
 	data["emagged"] =       subverted
 	data["coverlock"] =     locked

--- a/code/modules/codex/categories/category_recipes.dm
+++ b/code/modules/codex/categories/category_recipes.dm
@@ -95,13 +95,13 @@
 			ingredients += "[recipe.fruit[thing]] [thing]\s"
 		mechanics_text += "<ul><li>[jointext(ingredients, "</li><li>")]</li></ul>"
 		var/atom/recipe_product = recipe.result
-		mechanics_text += "<br>This recipe takes [CEILING(recipe.cooking_time/10)] second\s to cook and creates \a [initial(recipe_product.name)]."
+		mechanics_text += "<br>This recipe takes [ceil(recipe.cooking_time/10)] second\s to cook and creates \a [initial(recipe_product.name)]."
 		var/lore_text = recipe.lore_text
 		if(!lore_text)
 			lore_text = initial(recipe_product.desc)
 
 		var/recipe_name = recipe.display_name || sanitize(initial(recipe_product.name))
-		guide_html += "<h3>[capitalize(recipe_name)]</h3>Cook [english_list(ingredients)] for [CEILING(recipe.cooking_time/10)] second\s."
+		guide_html += "<h3>[capitalize(recipe_name)]</h3>Cook [english_list(ingredients)] for [ceil(recipe.cooking_time/10)] second\s."
 
 		entries_to_register += new /datum/codex_entry(           \
 		 _display_name =       "[recipe_name] (cooking recipe)", \

--- a/code/modules/crafting/pottery/pottery_moulds.dm
+++ b/code/modules/crafting/pottery/pottery_moulds.dm
@@ -45,7 +45,7 @@
 	var/list/matter_for_product = atom_info_repository.get_matter_for(product_type, /decl/material/placeholder, 1)
 	for(var/mat in matter_for_product)
 		required_volume += matter_for_product[mat]
-	required_volume = CEILING(required_volume * REAGENT_UNITS_PER_MATERIAL_UNIT)
+	required_volume = ceil(required_volume * REAGENT_UNITS_PER_MATERIAL_UNIT)
 	if(required_volume > 0)
 		if(reagents)
 			reagents.maximum_volume = required_volume

--- a/code/modules/crafting/stack_recipes/_recipe.dm
+++ b/code/modules/crafting/stack_recipes/_recipe.dm
@@ -154,13 +154,13 @@
 				. += "[stack_type] is in both forbidden and craftable stack types"
 
 /decl/stack_recipe/proc/get_required_stack_amount(obj/item/stack/stack)
-	return max(1, CEILING(req_amount / max(1, (SHEET_MATERIAL_AMOUNT * stack?.matter_multiplier))))
+	return max(1, ceil(req_amount / max(1, (SHEET_MATERIAL_AMOUNT * stack?.matter_multiplier))))
 
 /decl/stack_recipe/proc/get_list_display(mob/user, obj/item/stack/stack, datum/stack_recipe_list/sublist)
 
-	var/sheets_per_product = req_amount / CEILING(FLOOR(SHEET_MATERIAL_AMOUNT * stack.matter_multiplier))
-	var/products_per_sheet = CEILING(FLOOR(SHEET_MATERIAL_AMOUNT * stack.matter_multiplier)) / req_amount
-	var/clamp_sheets = max(1, CEILING(sheets_per_product))
+	var/sheets_per_product = req_amount / ceil(FLOOR(SHEET_MATERIAL_AMOUNT * stack.matter_multiplier))
+	var/products_per_sheet = ceil(FLOOR(SHEET_MATERIAL_AMOUNT * stack.matter_multiplier)) / req_amount
+	var/clamp_sheets = max(1, ceil(sheets_per_product))
 	var/max_multiplier = FLOOR(stack.get_amount() / clamp_sheets)
 
 	// Stacks can have a max bound that will cause us to waste material on crafting an impossible amount.
@@ -314,7 +314,7 @@
 		materials = atom_info_repository.get_matter_for((test_result_type || result_type), (ispath(required_material) ? required_material : null))
 		for(var/mat in materials)
 			req_amount += round(materials[mat])
-		req_amount = CEILING(req_amount*crafting_extra_cost_factor)
+		req_amount = ceil(req_amount*crafting_extra_cost_factor)
 		if(!ispath(result_type, /obj/item/stack))
 			// Due to matter calc, without this clamping, one sheet can make 32x grenade casings. Not ideal.
 			req_amount = max(req_amount, SHEET_MATERIAL_AMOUNT)

--- a/code/modules/crafting/stack_recipes/_recipe.dm
+++ b/code/modules/crafting/stack_recipes/_recipe.dm
@@ -158,10 +158,10 @@
 
 /decl/stack_recipe/proc/get_list_display(mob/user, obj/item/stack/stack, datum/stack_recipe_list/sublist)
 
-	var/sheets_per_product = req_amount / ceil(FLOOR(SHEET_MATERIAL_AMOUNT * stack.matter_multiplier))
-	var/products_per_sheet = ceil(FLOOR(SHEET_MATERIAL_AMOUNT * stack.matter_multiplier)) / req_amount
+	var/sheets_per_product = req_amount / ceil(floor(SHEET_MATERIAL_AMOUNT * stack.matter_multiplier))
+	var/products_per_sheet = ceil(floor(SHEET_MATERIAL_AMOUNT * stack.matter_multiplier)) / req_amount
 	var/clamp_sheets = max(1, ceil(sheets_per_product))
-	var/max_multiplier = FLOOR(stack.get_amount() / clamp_sheets)
+	var/max_multiplier = floor(stack.get_amount() / clamp_sheets)
 
 	// Stacks can have a max bound that will cause us to waste material on crafting an impossible amount.
 	if(ispath(result_type, /obj/item/stack))
@@ -177,7 +177,7 @@
 	. = list("<tr>")
 
 	. += "<td width = '150px'>"
-	. += get_display_name(max(1, FLOOR(products_per_sheet)), apply_article = FALSE)
+	. += get_display_name(max(1, floor(products_per_sheet)), apply_article = FALSE)
 	. += "</td>"
 
 	. += "<td width = '75px'>"
@@ -206,7 +206,7 @@
 	else if(allow_multiple_craft && !one_per_turf && clamp_sheets <= max_multiplier)
 		var/new_row = 5
 		for(var/i = clamp_sheets to max_multiplier step clamp_sheets)
-			var/producing = FLOOR(i * products_per_sheet)
+			var/producing = floor(i * products_per_sheet)
 			. += "<a href='byond://?src=\ref[stack];make=\ref[src];producing=[producing];expending=[i];returning=\ref[sublist]'>[producing]x</a>"
 			if(new_row == 0)
 				new_row = 5
@@ -214,7 +214,7 @@
 			else
 				new_row--
 	else
-		. += "<a href='byond://?src=\ref[stack];make=\ref[src];producing=[FLOOR(clamp_sheets * products_per_sheet)];expending=[clamp_sheets];returning=\ref[sublist]'>1x</a>"
+		. += "<a href='byond://?src=\ref[stack];make=\ref[src];producing=[floor(clamp_sheets * products_per_sheet)];expending=[clamp_sheets];returning=\ref[sublist]'>1x</a>"
 
 	. += "</td>"
 	. += "</tr>"

--- a/code/modules/crafting/textiles/loom.dm
+++ b/code/modules/crafting/textiles/loom.dm
@@ -106,7 +106,7 @@
 
 		weaving_progress += loaded_thread.matter_per_piece[weaving_type]
 		var/obj/item/stack/material/product_ref = product_type
-		var/matter_per_product = CEILING(initial(product_ref.matter_multiplier) * SHEET_MATERIAL_AMOUNT)
+		var/matter_per_product = ceil(initial(product_ref.matter_multiplier) * SHEET_MATERIAL_AMOUNT)
 		if(weaving_progress > matter_per_product)
 			var/produced = round(weaving_progress / matter_per_product)
 			processed += produced

--- a/code/modules/economy/worth_cash.dm
+++ b/code/modules/economy/worth_cash.dm
@@ -55,7 +55,7 @@
 
 /obj/item/cash/proc/get_worth()
 	var/decl/currency/cur = GET_DECL(currency)
-	. = FLOOR(absolute_worth / cur.absolute_value)
+	. = floor(absolute_worth / cur.absolute_value)
 
 /obj/item/cash/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/cash))
@@ -138,12 +138,12 @@
 		return TRUE
 
 	var/amount = input(usr, "How many [cur.name] do you want to take? (0 to [get_worth() - 1])", "Take Money", 20) as num
-	amount = round(clamp(amount, 0, FLOOR(get_worth() - 1)))
+	amount = round(clamp(amount, 0, floor(get_worth() - 1)))
 
 	if(!amount || QDELETED(src) || get_worth() <= 1 || user.incapacitated() || loc != user)
 		return TRUE
 
-	amount = FLOOR(amount * cur.absolute_value)
+	amount = floor(amount * cur.absolute_value)
 	adjust_worth(-(amount))
 	var/obj/item/cash/cash = new(get_turf(src))
 	cash.set_currency(currency)
@@ -238,7 +238,7 @@
 		else
 			to_chat(user, SPAN_NOTICE("<b>Id:</b> [id]."))
 			var/decl/currency/cur = GET_DECL(currency)
-			to_chat(user, SPAN_NOTICE("<b>[capitalize(cur.name)]</b> remaining: [FLOOR(loaded_worth / cur.absolute_value)]."))
+			to_chat(user, SPAN_NOTICE("<b>[capitalize(cur.name)]</b> remaining: [floor(loaded_worth / cur.absolute_value)]."))
 
 /obj/item/charge_stick/get_base_value()
 	. = holographic ? 0 : loaded_worth

--- a/code/modules/economy/worth_currency.dm
+++ b/code/modules/economy/worth_currency.dm
@@ -100,7 +100,7 @@
 		. += "missing coin crafting recipes: [english_list(validating_denominations)]"
 
 /decl/currency/proc/format_value(var/amt)
-	. = "[name_prefix][FLOOR(amt / absolute_value)][name_suffix]"
+	. = "[name_prefix][floor(amt / absolute_value)][name_suffix]"
 
 /decl/currency/proc/build_denominations()
 	denominations = sortTim(denominations, /proc/cmp_currency_denomination_des)

--- a/code/modules/economy/worth_items.dm
+++ b/code/modules/economy/worth_items.dm
@@ -43,7 +43,7 @@
 		var/shock_protection  = ((1-siemens_coefficient) * 20) * total_coverage
 		var/gas_leak_value = ((1-gas_transfer_coefficient) * 20) * total_coverage
 		var/permeability_value = ((1-permeability_coefficient) * 20) * total_coverage
-		var/pressure_protection = FLOOR(abs(max_pressure_protection - min_pressure_protection)/ONE_ATMOSPHERE)
+		var/pressure_protection = floor(abs(max_pressure_protection - min_pressure_protection)/ONE_ATMOSPHERE)
 
 		additional_value += shock_protection + gas_leak_value + permeability_value + pressure_protection
 

--- a/code/modules/economy/worth_obj.dm
+++ b/code/modules/economy/worth_obj.dm
@@ -24,7 +24,7 @@
 		. = 0
 		for(var/mat in matter)
 			. += matter[mat]
-		. = FLOOR(. * REAGENT_UNITS_PER_MATERIAL_UNIT)
+		. = floor(. * REAGENT_UNITS_PER_MATERIAL_UNIT)
 	else
 		. = clamp(w_class, ITEM_SIZE_MIN, ITEM_SIZE_MAX)
 	. = max(1, round(.))

--- a/code/modules/fabrication/designs/general/designs_general.dm
+++ b/code/modules/fabrication/designs/general/designs_general.dm
@@ -112,8 +112,8 @@
 
 /datum/fabricator_recipe/fiberglass/get_resources()
 	resources = list(
-		/decl/material/solid/glass =   CEILING((SHEET_MATERIAL_AMOUNT * FABRICATOR_EXTRA_COST_FACTOR)/2),
-		/decl/material/solid/organic/plastic = CEILING((SHEET_MATERIAL_AMOUNT * FABRICATOR_EXTRA_COST_FACTOR)/2)
+		/decl/material/solid/glass =   ceil((SHEET_MATERIAL_AMOUNT * FABRICATOR_EXTRA_COST_FACTOR)/2),
+		/decl/material/solid/organic/plastic = ceil((SHEET_MATERIAL_AMOUNT * FABRICATOR_EXTRA_COST_FACTOR)/2)
 	)
 
 /datum/fabricator_recipe/struts
@@ -122,7 +122,7 @@
 
 /datum/fabricator_recipe/struts/get_resources()
 	resources = list(
-		/decl/material/solid/metal/steel =   CEILING((SHEET_MATERIAL_AMOUNT * FABRICATOR_EXTRA_COST_FACTOR)),
+		/decl/material/solid/metal/steel =   ceil((SHEET_MATERIAL_AMOUNT * FABRICATOR_EXTRA_COST_FACTOR)),
 	)
 
 /datum/fabricator_recipe/struts/plastic
@@ -131,7 +131,7 @@
 
 /datum/fabricator_recipe/struts/plastic/get_resources()
 	resources = list(
-		/decl/material/solid/organic/plastic =   CEILING((SHEET_MATERIAL_AMOUNT * FABRICATOR_EXTRA_COST_FACTOR)),
+		/decl/material/solid/organic/plastic =   ceil((SHEET_MATERIAL_AMOUNT * FABRICATOR_EXTRA_COST_FACTOR)),
 	)
 
 /datum/fabricator_recipe/struts/aluminium
@@ -141,7 +141,7 @@
 
 /datum/fabricator_recipe/struts/aluminium/get_resources()
 	resources = list(
-		/decl/material/solid/metal/aluminium =   CEILING((SHEET_MATERIAL_AMOUNT * FABRICATOR_EXTRA_COST_FACTOR)),
+		/decl/material/solid/metal/aluminium =   ceil((SHEET_MATERIAL_AMOUNT * FABRICATOR_EXTRA_COST_FACTOR)),
 	)
 
 /datum/fabricator_recipe/struts/titanium
@@ -151,7 +151,7 @@
 
 /datum/fabricator_recipe/struts/titanium/get_resources()
 	resources = list(
-		/decl/material/solid/metal/titanium =   CEILING((SHEET_MATERIAL_AMOUNT * FABRICATOR_EXTRA_COST_FACTOR)),
+		/decl/material/solid/metal/titanium =   ceil((SHEET_MATERIAL_AMOUNT * FABRICATOR_EXTRA_COST_FACTOR)),
 	)
 
 /datum/fabricator_recipe/umbrella

--- a/code/modules/fabrication/fabricator_intake.dm
+++ b/code/modules/fabrication/fabricator_intake.dm
@@ -9,7 +9,7 @@
 	for(var/R in thing.reagents.reagent_volumes)
 		if(!base_storage_capacity[R])
 			continue
-		var/taking_reagent = min(REAGENT_VOLUME(thing.reagents, R), FLOOR((storage_capacity[R] - stored_material[R]) * REAGENT_UNITS_PER_MATERIAL_UNIT))
+		var/taking_reagent = min(REAGENT_VOLUME(thing.reagents, R), floor((storage_capacity[R] - stored_material[R]) * REAGENT_UNITS_PER_MATERIAL_UNIT))
 		if(taking_reagent <= 0)
 			continue
 		var/reagent_matter = round(taking_reagent / REAGENT_UNITS_PER_MATERIAL_UNIT)

--- a/code/modules/fabrication/fabricator_intake.dm
+++ b/code/modules/fabrication/fabricator_intake.dm
@@ -34,7 +34,7 @@
 	. = SUBSTANCE_TAKEN_NONE
 
 	var/obj/item/stack/stack_ref = istype(thing, /obj/item/stack) && thing
-	var/stack_matter_div = stack_ref ? max(1, CEILING(SHEET_MATERIAL_AMOUNT * stack_ref.matter_multiplier)) : 1
+	var/stack_matter_div = stack_ref ? max(1, ceil(SHEET_MATERIAL_AMOUNT * stack_ref.matter_multiplier)) : 1
 	var/stacks_used = 0
 
 	var/mat_colour = thing.color
@@ -53,7 +53,7 @@
 
 		stored_material[material_def.type] += taking_material
 		if(stack_ref)
-			stacks_used = max(stacks_used, CEILING(taking_material/stack_matter_div))
+			stacks_used = max(stacks_used, ceil(taking_material/stack_matter_div))
 
 		if(storage_capacity[material_def.type] == stored_material[material_def.type])
 			. = SUBSTANCE_TAKEN_FULL

--- a/code/modules/fabrication/fabricator_topic.dm
+++ b/code/modules/fabrication/fabricator_topic.dm
@@ -70,7 +70,7 @@
 	if(mat?.phase_at_temperature() != MAT_PHASE_SOLID)
 		stored_material[mat_path] = 0
 	else
-		var/sheet_count = FLOOR(stored_material[mat_path]/SHEET_MATERIAL_AMOUNT)
+		var/sheet_count = floor(stored_material[mat_path]/SHEET_MATERIAL_AMOUNT)
 		if(sheet_count >= 1)
 			stored_material[mat_path] -= sheet_count * SHEET_MATERIAL_AMOUNT
 			SSmaterials.create_object(mat_path, get_turf(src), sheet_count)

--- a/code/modules/fabrication/fabricator_ui.dm
+++ b/code/modules/fabrication/fabricator_ui.dm
@@ -123,7 +123,7 @@
 	var/list/multiplier
 	if(R.max_amount >= PRINT_MULTIPLIER_DIVISOR && max_sheets >= PRINT_MULTIPLIER_DIVISOR)
 		multiplier = list()
-		for(var/i = 1 to FLOOR(min(R.max_amount, max_sheets)/PRINT_MULTIPLIER_DIVISOR))
+		for(var/i = 1 to floor(min(R.max_amount, max_sheets)/PRINT_MULTIPLIER_DIVISOR))
 			var/mult = i * PRINT_MULTIPLIER_DIVISOR
 			multiplier += list(list("label" = "x[mult]", "multiplier" = mult))
 	return multiplier

--- a/code/modules/fabrication/recycler.dm
+++ b/code/modules/fabrication/recycler.dm
@@ -88,7 +88,7 @@
 				// Dump the material out as a stack.
 				var/obj/item/stack/material/cubestack = created_stack_type
 				var/max_stack = initial(cubestack.max_amount)
-				var/stack_amount = FLOOR(munched_matter[mat] / SHEET_MATERIAL_AMOUNT)
+				var/stack_amount = floor(munched_matter[mat] / SHEET_MATERIAL_AMOUNT)
 
 				// Keep track of any trace matter for the next run.
 				munched_matter[mat] -= stack_amount * SHEET_MATERIAL_AMOUNT

--- a/code/modules/fluids/_fluid.dm
+++ b/code/modules/fluids/_fluid.dm
@@ -43,7 +43,7 @@
 		var/decl/material/main_reagent = loc_reagents?.get_primary_reagent_decl()
 		var/new_alpha
 		if(main_reagent) // TODO: weighted alpha from all reagents, not just primary
-			new_alpha = clamp(CEILING(255*(reagent_volume/FLUID_DEEP)) * main_reagent.opacity, main_reagent.min_fluid_opacity, main_reagent.max_fluid_opacity)
+			new_alpha = clamp(ceil(255*(reagent_volume/FLUID_DEEP)) * main_reagent.opacity, main_reagent.min_fluid_opacity, main_reagent.max_fluid_opacity)
 		else
 			new_alpha = FLUID_MIN_ALPHA
 		if(new_alpha != alpha)

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -367,7 +367,7 @@ var/global/list/card_decks = list()
 		overlays += I
 		return
 
-	var/offset = FLOOR(20/cards.len)
+	var/offset = floor(20/cards.len)
 
 	var/matrix/M = matrix()
 	if(direction)

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -196,7 +196,7 @@
 
 		if(length(assembly_components) > components_per_page)
 			HTML += "<br>\["
-			for(var/i = 1 to CEILING(length(assembly_components)/components_per_page))
+			for(var/i = 1 to ceil(length(assembly_components)/components_per_page))
 				if((i-1) == interact_page)
 					HTML += " [i]"
 				else
@@ -384,7 +384,7 @@
 	add_allowed_scanner(user.ckey)
 
 	// Make sure we're not on an invalid page
-	interact_page = clamp(interact_page, 0, CEILING(length(assembly_components)/components_per_page)-1)
+	interact_page = clamp(interact_page, 0, ceil(length(assembly_components)/components_per_page)-1)
 
 	return TRUE
 

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -69,7 +69,7 @@
 		var/obj/item/stack/material/M = O
 		var/amt = M.amount
 		if(amt * SHEET_MATERIAL_AMOUNT + materials[M.material.type] > metal_max)
-			amt = -round(-(metal_max - materials[M.material.type]) / SHEET_MATERIAL_AMOUNT) //round up
+			amt = ceil((metal_max - materials[M.material.type]) / SHEET_MATERIAL_AMOUNT)
 		if(M.use(amt))
 			materials[M.material.type] = min(metal_max, materials[M.material.type] + amt * SHEET_MATERIAL_AMOUNT)
 			to_chat(user, "<span class='warning'>You insert [M.material.solid_name] into \the [src].</span>")

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -148,7 +148,6 @@
 #define POLAR_TO_CART_X(R,T) ((R) * cos(T))
 #define POLAR_TO_CART_Y(R,T) ((R) * sin(T))
 #define DETERMINANT(A_X,A_Y,B_X,B_Y) ((A_X)*(B_Y) - (A_Y)*(B_X))
-#define MINMAX(NUM) ((NUM) < 0 ? -round(-(NUM)) : round(NUM))
 #define ARBITRARY_NUMBER 10
 
 /datum/light_source/proc/regenerate_angle(ndir)
@@ -190,16 +189,15 @@
 
 	// Convert our angle + range into a vector.
 	limit_a_x = POLAR_TO_CART_X(light_range + ARBITRARY_NUMBER, limit_a_t)
-	limit_a_x = MINMAX(limit_a_x)
+	limit_a_x = trunc(limit_a_x)
 	limit_a_y = POLAR_TO_CART_Y(light_range + ARBITRARY_NUMBER, limit_a_t)
-	limit_a_y = MINMAX(limit_a_y)
+	limit_a_y = trunc(limit_a_y)
 	limit_b_x = POLAR_TO_CART_X(light_range + ARBITRARY_NUMBER, limit_b_t)
-	limit_b_x = MINMAX(limit_b_x)
+	limit_b_x = trunc(limit_b_x)
 	limit_b_y = POLAR_TO_CART_Y(light_range + ARBITRARY_NUMBER, limit_b_t)
-	limit_b_y = MINMAX(limit_b_y)
+	limit_b_y = trunc(limit_b_y)
 
 #undef ARBITRARY_NUMBER
-#undef MINMAX
 #undef POLAR_TO_CART_Y
 #undef POLAR_TO_CART_X
 

--- a/code/modules/maps/_map_template.dm
+++ b/code/modules/maps/_map_template.dm
@@ -152,8 +152,8 @@
 /// * If centered is TRUE, the template's center will be aligned to the world's center. Otherwise, the template will load at pos 1,1.
 /datum/map_template/proc/load_new_z(no_changeturf = TRUE, centered = TRUE)
 	//When we're set to centered we're aligning the center of the template to the center of the map
-	var/x = max(CEILING((WORLD_CENTER_X - width/2)), 1)
-	var/y = max(CEILING((WORLD_CENTER_Y - height/2)), 1)
+	var/x = max(ceil((WORLD_CENTER_X - width/2)), 1)
+	var/y = max(ceil((WORLD_CENTER_Y - height/2)), 1)
 	if(!centered)
 		x = 1
 		y = 1
@@ -193,7 +193,7 @@
 
 /datum/map_template/proc/load(turf/T, centered=FALSE)
 	if(centered)
-		T = locate(CEILING(T.x - width/2), CEILING(T.y - height/2), T.z)
+		T = locate(ceil(T.x - width/2), ceil(T.y - height/2), T.z)
 	if(!T)
 		CRASH("Can't load '[src]' (size: [width]x[height]) onto a null turf! Current world size ([WORLD_SIZE_TO_STRING]).")
 	if(!IS_WITHIN_WORLD((T.x + width - 1), (T.y + height - 1))) // the first row/column begins with T, so subtract 1

--- a/code/modules/maps/template_types/random_exoplanet/random_planet.dm
+++ b/code/modules/maps/template_types/random_exoplanet/random_planet.dm
@@ -246,7 +246,7 @@
 	var/list/places
 	var/attempts       = 10 * amount_shuttle_landing_points
 	var/points_left    = amount_shuttle_landing_points
-	var/landing_radius = CEILING(max_shuttle_radius / 2)
+	var/landing_radius = ceil(max_shuttle_radius / 2)
 	var/border_padding = landing_radius + 3
 
 	while(points_left)

--- a/code/modules/materials/_material_stack.dm
+++ b/code/modules/materials/_material_stack.dm
@@ -175,12 +175,12 @@
 		if(convert_type)
 
 			var/product_per_sheet         = matter_multiplier / initial(convert_type.matter_multiplier)
-			var/minimum_per_one_product   = CEILING(1 / product_per_sheet)
+			var/minimum_per_one_product   = ceil(1 / product_per_sheet)
 
 			if(get_amount() < minimum_per_one_product)
 				to_chat(user, SPAN_WARNING("You will need [minimum_per_one_product] [minimum_per_one_product == 1 ? singular_name : plural_name] to produce [product_per_sheet] [product_per_sheet == 1 ? initial(convert_type.singular_name) : initial(convert_type.plural_name)]."))
 			else if(W.do_tool_interaction(convert_tool, user, src, 1 SECOND, set_cooldown = TRUE) && !QDELETED(src) && get_amount() >= minimum_per_one_product)
-				var/obj/item/stack/product = new convert_type(get_turf(src), CEILING(product_per_sheet), material?.type, reinf_material?.type)
+				var/obj/item/stack/product = new convert_type(get_turf(src), ceil(product_per_sheet), material?.type, reinf_material?.type)
 				use(minimum_per_one_product)
 				if(product.add_to_stacks(user, TRUE))
 					user.put_in_hands(product)

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -595,7 +595,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 // General wall debris product placement.
 // Not particularly necessary aside from snowflakey cult girders.
 /decl/material/proc/place_dismantled_product(var/turf/target, var/is_devastated, var/amount = 2, var/drop_type)
-	amount = is_devastated ? FLOOR(amount * 0.5) : amount
+	amount = is_devastated ? floor(amount * 0.5) : amount
 	if(amount > 0)
 		return create_object(target, amount, object_type = drop_type)
 
@@ -676,7 +676,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 // This doesn't apply to skin contact - this is for, e.g. extinguishers and sprays. The difference is that reagent is not directly on the mob's skin - it might just be on their clothing.
 /decl/material/proc/touch_mob(var/mob/living/M, var/amount, var/datum/reagents/holder)
 	if(accelerant_value != FUEL_VALUE_NONE && amount && istype(M))
-		M.fire_stacks += FLOOR((amount * accelerant_value)/FLAMMABLE_LIQUID_DIVISOR)
+		M.fire_stacks += floor((amount * accelerant_value)/FLAMMABLE_LIQUID_DIVISOR)
 #undef FLAMMABLE_LIQUID_DIVISOR
 
 /decl/material/proc/touch_turf(var/turf/T, var/amount, var/datum/reagents/holder) // Cleaner cleaning, lube lubbing, etc, all go here

--- a/code/modules/mining/machinery/material_compressor.dm
+++ b/code/modules/mining/machinery/material_compressor.dm
@@ -46,7 +46,7 @@
 			var/decl/material/source = GET_DECL(mat)
 			var/decl/material/product = source.ore_compresses_to ? GET_DECL(source.ore_compresses_to) : source
 			product.create_object(output_turf, sheets)
-			stored[mat] -= CEILING(sheets * SHEET_MATERIAL_AMOUNT * 2)
+			stored[mat] -= ceil(sheets * SHEET_MATERIAL_AMOUNT * 2)
 			if(stored[mat] <= 0)
 				stored -= mat
 			produced += sheets

--- a/code/modules/mining/machinery/material_compressor.dm
+++ b/code/modules/mining/machinery/material_compressor.dm
@@ -17,7 +17,7 @@
 			if(!O.simulated || O.anchored)
 				continue
 			for(var/mat in O.reagents?.reagent_volumes)
-				stored[mat] = stored[mat] + FLOOR((O.reagents.reagent_volumes[mat] / REAGENT_UNITS_PER_MATERIAL_UNIT) * 0.75) // liquid reagents, lossy
+				stored[mat] = stored[mat] + floor((O.reagents.reagent_volumes[mat] / REAGENT_UNITS_PER_MATERIAL_UNIT) * 0.75) // liquid reagents, lossy
 			for(var/mat in O.matter)
 				stored[mat] = stored[mat] + O.matter[mat]
 			qdel(O)
@@ -40,7 +40,7 @@
 	if(output_turf)
 		var/produced = 0
 		for(var/mat in stored)
-			var/sheets = min(FLOOR((stored[mat] / SHEET_MATERIAL_AMOUNT) / 2), (MAX_COMPRESS_ORE_PER_TICK - produced))
+			var/sheets = min(floor((stored[mat] / SHEET_MATERIAL_AMOUNT) / 2), (MAX_COMPRESS_ORE_PER_TICK - produced))
 			if(sheets <= 0)
 				continue
 			var/decl/material/source = GET_DECL(mat)

--- a/code/modules/mining/machinery/material_extractor.dm
+++ b/code/modules/mining/machinery/material_extractor.dm
@@ -88,7 +88,7 @@
 			if(eating.reagents?.total_volume)
 				eating.reagents.trans_to_obj(src, eating.reagents.total_volume)
 			for(var/mtype in eating.matter)
-				add_to_reagents(mtype, FLOOR(eating.matter[mtype] * REAGENT_UNITS_PER_MATERIAL_UNIT))
+				add_to_reagents(mtype, floor(eating.matter[mtype] * REAGENT_UNITS_PER_MATERIAL_UNIT))
 			qdel(eating)
 			if(eaten >= MAX_INTAKE_ORE_PER_TICK)
 				break
@@ -143,7 +143,7 @@
 		if(MAT_PHASE_SOLID)
 			if(!can_process_material_name(mtype))
 				var/removing = REAGENT_VOLUME(reagents, mtype) || 0
-				var/sheets = FLOOR((removing / REAGENT_UNITS_PER_MATERIAL_UNIT) / SHEET_MATERIAL_AMOUNT)
+				var/sheets = floor((removing / REAGENT_UNITS_PER_MATERIAL_UNIT) / SHEET_MATERIAL_AMOUNT)
 				if(sheets > 0) // If we can't process any sheets at all, leave it for manual processing.
 					adjusted_reagents = TRUE
 					SSmaterials.create_object(mtype, output_turf, sheets)

--- a/code/modules/mining/machinery/material_smelter.dm
+++ b/code/modules/mining/machinery/material_smelter.dm
@@ -70,9 +70,9 @@
 				continue
 			eaten++
 			if(eating.reagents?.total_volume)
-				eating.reagents.trans_to_obj(src, FLOOR(eating.reagents.total_volume * 0.75)) // liquid reagents, lossy
+				eating.reagents.trans_to_obj(src, floor(eating.reagents.total_volume * 0.75)) // liquid reagents, lossy
 			for(var/mtype in eating.matter)
-				add_to_reagents(mtype, FLOOR(eating.matter[mtype] * REAGENT_UNITS_PER_MATERIAL_UNIT))
+				add_to_reagents(mtype, floor(eating.matter[mtype] * REAGENT_UNITS_PER_MATERIAL_UNIT))
 			qdel(eating)
 			if(eaten >= MAX_INTAKE_ORE_PER_TICK)
 				break
@@ -83,7 +83,7 @@
 						continue
 					visible_message(SPAN_DANGER("\The [src] rips \the [H]'s [eating.name] clean off!"))
 					for(var/mtype in eating.matter)
-						add_to_reagents(mtype, FLOOR(eating.matter[mtype] * REAGENT_UNITS_PER_MATERIAL_UNIT))
+						add_to_reagents(mtype, floor(eating.matter[mtype] * REAGENT_UNITS_PER_MATERIAL_UNIT))
 					eating.dismember(silent = TRUE)
 					qdel(eating)
 					break
@@ -91,7 +91,7 @@
 	if(output_turf)
 		for(var/mtype in casting)
 			var/ramt = REAGENT_VOLUME(reagents, mtype) || 0
-			var/samt = FLOOR((ramt / REAGENT_UNITS_PER_MATERIAL_UNIT) / SHEET_MATERIAL_AMOUNT)
+			var/samt = floor((ramt / REAGENT_UNITS_PER_MATERIAL_UNIT) / SHEET_MATERIAL_AMOUNT)
 			if(samt > 0)
 				SSmaterials.create_object(mtype, output_turf, samt)
 				remove_from_reagents(mtype, ramt)
@@ -130,7 +130,7 @@
 		var/ramt = REAGENT_VOLUME(reagents, mtype) || 0
 		if(ramt <= 0 && !show_all_materials && !(mtype in always_show_materials))
 			continue
-		var/samt = FLOOR((ramt / REAGENT_UNITS_PER_MATERIAL_UNIT) / SHEET_MATERIAL_AMOUNT)
+		var/samt = floor((ramt / REAGENT_UNITS_PER_MATERIAL_UNIT) / SHEET_MATERIAL_AMOUNT)
 		var/obj/item/stack/material/sheet = mat.default_solid_form
 		materials += list(list("label" = "[mat.liquid_name]<br>[ramt]u ([samt] [samt == 1 ? initial(sheet.singular_name) : initial(sheet.plural_name)])", "casting" = (mtype in casting), "key" = "\ref[mat]"))
 		data["materials"] = materials

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -297,7 +297,7 @@
 	return current_grab.force_danger
 
 /obj/item/grab/proc/grab_slowdown()
-	. = CEILING(affecting?.get_object_size() * current_grab.grab_slowdown)
+	. = ceil(affecting?.get_object_size() * current_grab.grab_slowdown)
 	. /= (affecting?.movable_flags & MOVABLE_FLAG_WHEELED) ? 2 : 1
 	. = max(.,1)
 

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -68,7 +68,7 @@
 	var/possible_syllables = allow_repeated_syllables ? syllables : syllables.Copy()
 	for(var/i = 0;i<name_count;i++)
 		var/new_name = ""
-		for(var/x = rand(FLOOR(syllable_count/syllable_divisor),syllable_count);x>0;x--)
+		for(var/x = rand(floor(syllable_count/syllable_divisor),syllable_count);x>0;x--)
 			if(!length(possible_syllables))
 				break
 			new_name += allow_repeated_syllables ? pick(possible_syllables) : pick_n_take(possible_syllables)

--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -107,7 +107,7 @@
 	if(emp_damage <= 0)
 		return
 	emp_damage -= 1
-	var/msg_threshold = clamp(CEILING(emp_damage / (max_emp_damage / length(emp_reboot_strings))), 1, length(emp_reboot_strings))
+	var/msg_threshold = clamp(ceil(emp_damage / (max_emp_damage / length(emp_reboot_strings))), 1, length(emp_reboot_strings))
 	if(last_emp_message != msg_threshold)
 		last_emp_message = msg_threshold
 		to_chat(src, emp_reboot_strings[msg_threshold])

--- a/code/modules/mob/living/human/descriptors/_descriptors.dm
+++ b/code/modules/mob/living/human/descriptors/_descriptors.dm
@@ -59,7 +59,7 @@
 	..(null)
 
 /datum/appearance_descriptor/proc/set_default_value()
-	default_value = CEILING(LAZYLEN(standalone_value_descriptors) * 0.5)
+	default_value = ceil(LAZYLEN(standalone_value_descriptors) * 0.5)
 
 /datum/appearance_descriptor/proc/get_mob_scale_adjustments(decl/bodytype/bodytype, offset_value)
 	return
@@ -134,12 +134,12 @@
 
 /datum/appearance_descriptor/proc/get_comparative_value_string_smaller(value, decl/pronouns/my_gender, decl/pronouns/other_gender)
 	var/maxval = LAZYLEN(comparative_value_descriptors_smaller)
-	value = clamp(CEILING(value * maxval), 1, maxval)
+	value = clamp(ceil(value * maxval), 1, maxval)
 	return comparative_value_descriptors_smaller[value]
 
 /datum/appearance_descriptor/proc/get_comparative_value_string_larger(value, decl/pronouns/my_gender, decl/pronouns/other_gender)
 	var/maxval = LAZYLEN(comparative_value_descriptors_larger)
-	value = clamp(CEILING(value * maxval), 1, maxval)
+	value = clamp(ceil(value * maxval), 1, maxval)
 	return comparative_value_descriptors_larger[value]
 
 /datum/appearance_descriptor/proc/has_custom_value()

--- a/code/modules/mob/living/human/human.dm
+++ b/code/modules/mob/living/human/human.dm
@@ -852,9 +852,9 @@
 //Get fluffy numbers
 /mob/living/human/proc/get_blood_pressure()
 	if(status_flags & FAKEDEATH)
-		return "[FLOOR(120+rand(-5,5))*0.25]/[FLOOR(80+rand(-5,5)*0.25)]"
+		return "[floor(120+rand(-5,5))*0.25]/[floor(80+rand(-5,5)*0.25)]"
 	var/blood_result = get_blood_circulation()
-	return "[FLOOR((120+rand(-5,5))*(blood_result/100))]/[FLOOR((80+rand(-5,5))*(blood_result/100))]"
+	return "[floor((120+rand(-5,5))*(blood_result/100))]/[floor((80+rand(-5,5))*(blood_result/100))]"
 
 //Point at which you dun breathe no more. Separate from asystole crit, which is heart-related.
 /mob/living/human/nervous_system_failure()

--- a/code/modules/mob/living/human/human_blood.dm
+++ b/code/modules/mob/living/human/human_blood.dm
@@ -66,7 +66,7 @@
 	if(amt <= 0 || !istype(sprayloc))
 		return
 	var/spraydir = pick(global.alldirs)
-	amt = CEILING(amt/BLOOD_SPRAY_DISTANCE)
+	amt = ceil(amt/BLOOD_SPRAY_DISTANCE)
 	var/bled = 0
 	spawn(0)
 		for(var/i = 1 to BLOOD_SPRAY_DISTANCE)

--- a/code/modules/mob/living/human/life.dm
+++ b/code/modules/mob/living/human/life.dm
@@ -526,7 +526,7 @@
 		if(isSynthetic())
 			var/obj/item/organ/internal/cell/C = get_organ(BP_CELL, /obj/item/organ/internal/cell)
 			if(C)
-				var/chargeNum = clamp(CEILING(C.percent()/25), 0, 4)	//0-100 maps to 0-4, but give it a paranoid clamp just in case.
+				var/chargeNum = clamp(ceil(C.percent()/25), 0, 4)	//0-100 maps to 0-4, but give it a paranoid clamp just in case.
 				cells.icon_state = "charge[chargeNum]"
 			else
 				cells.icon_state = "charge-empty"

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -633,7 +633,7 @@
 	// Calculate the expected and actual number of functioning legs we have.
 	var/has_sufficient_working_legs = TRUE
 	var/list/root_limb_tags  = root_bodytype.organ_tags_by_category[ORGAN_CATEGORY_STANCE_ROOT]
-	var/minimum_working_legs = CEILING(length(root_limb_tags) * 0.5)
+	var/minimum_working_legs = ceil(length(root_limb_tags) * 0.5)
 	if(minimum_working_legs > 0)
 		var/leg_count = 0
 		has_sufficient_working_legs = FALSE

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -194,7 +194,7 @@
 		radiation -= 4 * RADIATION_SPEED_COEFFICIENT
 
 	var/decl/species/my_species = get_species()
-	damage = FLOOR(damage * (my_species ? my_species.get_radiation_mod(src) : 1))
+	damage = floor(damage * (my_species ? my_species.get_radiation_mod(src) : 1))
 	if(damage)
 		immunity = max(0, immunity - damage * 15 * RADIATION_SPEED_COEFFICIENT)
 		take_damage(damage * RADIATION_SPEED_COEFFICIENT, TOX)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1116,7 +1116,7 @@ default behaviour is:
 				A.alert_on_fall(src)
 
 /mob/living/proc/apply_fall_damage(var/turf/landing)
-	take_damage(rand(max(1, CEILING(mob_size * 0.33)), max(1, CEILING(mob_size * 0.66))) * get_fall_height())
+	take_damage(rand(max(1, ceil(mob_size * 0.33)), max(1, ceil(mob_size * 0.66))) * get_fall_height())
 
 /mob/living/proc/get_toxin_resistance()
 	var/decl/species/species = get_species()

--- a/code/modules/mob/living/living_maneuvers.dm
+++ b/code/modules/mob/living/living_maneuvers.dm
@@ -7,7 +7,7 @@
 		return
 	if(!can_fall(location_override = lastloc) && prepared_maneuver && prepared_maneuver.can_be_used_by(src, silent = TRUE))
 		var/turf/check = get_turf(lastloc)
-		for(var/i = 1 to CEILING((get_jump_distance() * get_acrobatics_multiplier()) * prepared_maneuver.reflexive_modifier))
+		for(var/i = 1 to ceil((get_jump_distance() * get_acrobatics_multiplier()) * prepared_maneuver.reflexive_modifier))
 			var/turf/next_check = get_step(check, dir)
 			if(!next_check || next_check.density)
 				break

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -147,7 +147,7 @@
 
 	if (src.cells)
 		if (src.cell)
-			var/chargeNum = clamp(CEILING(cell.percent()/25), 0, 4)	//0-100 maps to 0-4, but give it a paranoid clamp just in case.
+			var/chargeNum = clamp(ceil(cell.percent()/25), 0, 4)	//0-100 maps to 0-4, but give it a paranoid clamp just in case.
 			src.cells.icon_state = "charge[chargeNum]"
 		else
 			src.cells.icon_state = "charge-empty"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -679,7 +679,7 @@
 
 //Robots take half damage from basic attacks.
 /mob/living/silicon/robot/attack_generic(var/mob/user, var/damage, var/attack_message)
-	return ..(user,FLOOR(damage/2),attack_message)
+	return ..(user,floor(damage/2),attack_message)
 
 /mob/living/silicon/robot/get_req_access()
 	return req_access

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1027,7 +1027,7 @@
 	if(braindamage)
 		var/brainloss_threshold = get_config_value(/decl/config/num/dex_malus_brainloss_threshold)
 		if(braindamage > brainloss_threshold) ///brainloss shouldn't instantly cripple you, so the effects only start once past the threshold and escalate from there.
-			dex_malus = clamp(CEILING((braindamage-brainloss_threshold)/10), 0, length(global.dexterity_levels))
+			dex_malus = clamp(ceil((braindamage-brainloss_threshold)/10), 0, length(global.dexterity_levels))
 			if(dex_malus > 0)
 				dex_malus = global.dexterity_levels[dex_malus]
 

--- a/code/modules/mob/mob_eating.dm
+++ b/code/modules/mob/mob_eating.dm
@@ -6,7 +6,7 @@
 /mob/proc/get_eaten_transfer_amount(var/default)
 	. = default
 	if(issmall(src))
-		. = CEILING(.*0.5)
+		. = ceil(.*0.5)
 
 /mob/proc/can_eat_food_currently(obj/eating, mob/user)
 	return TRUE

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -261,7 +261,7 @@ var/global/list/global/organ_rel_size = list(
 		return
 	M.shakecamera = current_time + max(TICKS_PER_RECOIL_ANIM, duration)
 	strength = abs(strength)*PIXELS_PER_STRENGTH_VAL
-	var/steps = min(1, FLOOR(duration/TICKS_PER_RECOIL_ANIM))-1
+	var/steps = min(1, floor(duration/TICKS_PER_RECOIL_ANIM))-1
 	animate(M.client, pixel_x = rand(-(strength), strength), pixel_y = rand(-(strength), strength), time = TICKS_PER_RECOIL_ANIM, easing = JUMP_EASING|EASE_IN)
 	if(steps)
 		for(var/i = 1 to steps)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -263,7 +263,7 @@
 		if (!BP_IS_PROSTHETIC(organ))
 			organ.rejuvenate(1)
 			organ.max_damage *= 3
-			organ.min_broken_damage = FLOOR(organ.max_damage * 0.75)
+			organ.min_broken_damage = floor(organ.max_damage * 0.75)
 	verbs += /mob/living/proc/breath_death
 	verbs += /mob/living/proc/consume
 	playsound(get_turf(src), 'sound/hallucinations/wail.ogg', 20, 1)

--- a/code/modules/modular_computers/terminal/terminal_commands.dm
+++ b/code/modules/modular_computers/terminal/terminal_commands.dm
@@ -79,7 +79,7 @@ var/global/list/terminal_commands
 // Prints data out, split by page number.
 /datum/terminal_command/proc/print_as_page(list/data, value_name, selected_page, pg_length)
 	. = list()
-	var/max_pages = CEILING(length(data)/pg_length)
+	var/max_pages = ceil(length(data)/pg_length)
 	var/pg = clamp(selected_page, 1, max_pages)
 
 	var/start_index = (pg - 1)*pg_length + 1

--- a/code/modules/multiz/ladder.dm
+++ b/code/modules/multiz/ladder.dm
@@ -228,7 +228,7 @@
 
 	var/can_carry = can_pull_size
 	if(loc?.has_gravity())
-		can_carry = FLOOR(can_carry * 0.75)
+		can_carry = floor(can_carry * 0.75)
 	for(var/obj/item/grab/G in get_active_grabs())
 		can_carry -= G.affecting.get_object_size()
 		if(can_carry < 0)

--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -243,8 +243,8 @@
 
 	//Get the origin of the lower left corner where the level's edge begins at on the world.
 	//#FIXME: This is problematic when dealing with an even width/height
-	var/x_origin = origin_is_world_center? max(FLOOR((world.maxx - level_max_width)  / 2), 1) : 1
-	var/y_origin = origin_is_world_center? max(FLOOR((world.maxy - level_max_height) / 2), 1) : 1
+	var/x_origin = origin_is_world_center? max(floor((world.maxx - level_max_width)  / 2), 1) : 1
+	var/y_origin = origin_is_world_center? max(floor((world.maxy - level_max_height) / 2), 1) : 1
 
 	//The first x/y that's past the edge and within the accessible level
 	level_inner_min_x = x_origin + TRANSITIONEDGE

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1487,8 +1487,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 				. = SURGERY_ENCASED
 		else
 			var/total_health_coefficient = scale_max_damage_to_species_health ? (species.total_health / DEFAULT_SPECIES_HEALTH) : 1
-			var/smol_threshold = max(1, FLOOR(min_broken_damage * 0.4 * total_health_coefficient))
-			var/beeg_threshold = max(1, FLOOR(min_broken_damage * 0.6 * total_health_coefficient))
+			var/smol_threshold = max(1, floor(min_broken_damage * 0.4 * total_health_coefficient))
+			var/beeg_threshold = max(1, floor(min_broken_damage * 0.6 * total_health_coefficient))
 			if(!incision.autoheal_cutoff == 0) //not clean incision
 				smol_threshold *= 1.5
 				beeg_threshold = max(beeg_threshold, min(beeg_threshold * 1.5, incision.damage_list[1])) //wounds can't achieve bigger

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -659,7 +659,7 @@ This function completely restores a damaged organ to perfect condition.
 		var/internal_damage
 		if(prob(damage) && sever_artery())
 			internal_damage = TRUE
-		if(prob(CEILING(damage/4)) && sever_tendon())
+		if(prob(ceil(damage/4)) && sever_tendon())
 			internal_damage = TRUE
 		if(internal_damage)
 			owner.custom_pain("You feel something rip in your [name]!", 50, affecting = src)

--- a/code/modules/organs/external/_external_icons.dm
+++ b/code/modules/organs/external/_external_icons.dm
@@ -342,7 +342,7 @@ var/global/list/robot_hud_colours = list("#ffffff","#cccccc","#aaaaaa","#888888"
 		dam_state = min_dam_state
 	// Apply colour and return product.
 	var/list/hud_colours = !BP_IS_PROSTHETIC(src) ? flesh_hud_colours : robot_hud_colours
-	hud_damage_image.color = hud_colours[max(1,min(CEILING(dam_state*hud_colours.len),hud_colours.len))]
+	hud_damage_image.color = hud_colours[max(1,min(ceil(dam_state*hud_colours.len),hud_colours.len))]
 	return hud_damage_image
 
 /obj/item/organ/external/proc/bandage_level()

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -106,8 +106,8 @@
 
 /obj/item/organ/internal/set_max_damage(var/ndamage)
 	. = ..()
-	min_broken_damage = FLOOR(0.75 * max_damage)
-	min_bruised_damage = FLOOR(0.25 * max_damage)
+	min_broken_damage = floor(0.75 * max_damage)
+	min_bruised_damage = floor(0.25 * max_damage)
 	if(damage_threshold_count > 0)
 		damage_threshold_value = round(max_damage / damage_threshold_count)
 
@@ -208,7 +208,7 @@
 	if(damage > min_broken_damage)
 		var/scarring = damage/max_damage
 		scarring = 1 - 0.3 * scarring ** 2 // Between ~15 and 30 percent loss
-		var/new_max_dam = FLOOR(scarring * max_damage)
+		var/new_max_dam = floor(scarring * max_damage)
 		if(new_max_dam < max_damage)
 			to_chat(user, SPAN_WARNING("Not every part of [src] could be saved; some dead tissue had to be removed, making it more susceptible to damage in the future."))
 			set_max_damage(new_max_dam)

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -225,7 +225,7 @@
 	var/blood_volume = owner.get_blood_oxygenation()
 	if(blood_volume < BLOOD_VOLUME_SURVIVE)
 		to_chat(user, SPAN_DANGER("Parts of \the [src] didn't survive the procedure due to lack of air supply!"))
-		set_max_damage(FLOOR(max_damage - 0.25*damage))
+		set_max_damage(floor(max_damage - 0.25*damage))
 	heal_damage(damage)
 
 /obj/item/organ/internal/brain/die()

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -178,7 +178,7 @@
 			//AB occurs every heartbeat, this only throttles the visible effect
 			next_blood_squirt = world.time + 80
 			var/turf/sprayloc = get_turf(owner)
-			blood_max -= owner.drip(CEILING(blood_max/3), sprayloc)
+			blood_max -= owner.drip(ceil(blood_max/3), sprayloc)
 			if(blood_max > 0)
 				blood_max -= owner.blood_squirt(blood_max, sprayloc)
 				if(blood_max > 0)

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -147,7 +147,7 @@
 							blood_max += W.damage / 40
 
 			if(temp.status & ORGAN_ARTERY_CUT)
-				var/bleed_amount = FLOOR((owner.vessel.total_volume / (temp.applied_pressure || !open_wound ? 400 : 250))*temp.arterial_bleed_severity)
+				var/bleed_amount = floor((owner.vessel.total_volume / (temp.applied_pressure || !open_wound ? 400 : 250))*temp.arterial_bleed_severity)
 				if(bleed_amount)
 					if(open_wound)
 						blood_max += bleed_amount

--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -43,7 +43,7 @@
 	return !isnull(get_devour_time(food))
 
 /obj/item/organ/internal/stomach/proc/is_full(var/atom/movable/food)
-	var/total = FLOOR(ingested.total_volume / 10)
+	var/total = floor(ingested.total_volume / 10)
 	for(var/a in contents + food)
 		if(ismob(a))
 			var/mob/M = a

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -160,7 +160,7 @@
 
 // resets scarring, but ah well
 /obj/item/organ/proc/set_max_damage(var/ndamage)
-	absolute_max_damage = FLOOR(ndamage)
+	absolute_max_damage = floor(ndamage)
 	max_damage = absolute_max_damage
 
 /obj/item/organ/proc/set_species(specie_name)
@@ -183,11 +183,11 @@
 	min_broken_damage = initial(min_broken_damage)
 
 	if(absolute_max_damage)
-		set_max_damage(max(1, FLOOR(absolute_max_damage * total_health_coefficient)))
-		min_broken_damage = max(1, FLOOR(absolute_max_damage * 0.5))
+		set_max_damage(max(1, floor(absolute_max_damage * total_health_coefficient)))
+		min_broken_damage = max(1, floor(absolute_max_damage * 0.5))
 	else
-		min_broken_damage = max(1, FLOOR(min_broken_damage * total_health_coefficient))
-		set_max_damage(max(1, FLOOR(min_broken_damage * 2)))
+		min_broken_damage = max(1, floor(min_broken_damage * total_health_coefficient))
+		set_max_damage(max(1, floor(min_broken_damage * 2)))
 
 	reset_status()
 

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -3,7 +3,7 @@
 		var/matrix/M
 		if(client && max(client.last_view_x_dim, client.last_view_y_dim) > 7)
 			M = matrix()
-			M.Scale(CEILING(client.last_view_x_dim/7), CEILING(client.last_view_y_dim/7))
+			M.Scale(ceil(client.last_view_x_dim/7), ceil(client.last_view_y_dim/7))
 		pain.transform = M
 		animate(pain, alpha = target, time = 15, easing = ELASTIC_EASING)
 		animate(pain, alpha = 0, time = 20)
@@ -24,9 +24,9 @@
 	// Excessive halloss is horrible, just give them enough to make it visible.
 	if(!nohalloss && power)
 		if(affecting)
-			affecting.add_pain(CEILING(power/2))
+			affecting.add_pain(ceil(power/2))
 		else
-			take_damage(CEILING(power/2), PAIN)
+			take_damage(ceil(power/2), PAIN)
 	flash_pain(min(round(2*power)+55, 255))
 
 	// Anti message spam checks

--- a/code/modules/overmap/overmap_object.dm
+++ b/code/modules/overmap/overmap_object.dm
@@ -182,7 +182,7 @@
 		// Add speed to this dimension of our position.
 		position[i] += clamp((speed[i] * OVERMAP_SPEED_CONSTANT) * (wait / (1 SECOND)), -1, 1)
 		if(position[i] < 0)
-			deltas[i] = CEILING(position[i])
+			deltas[i] = ceil(position[i])
 		else if(position[i] > 0)
 			deltas[i] = FLOOR(position[i])
 		moved = TRUE

--- a/code/modules/overmap/overmap_object.dm
+++ b/code/modules/overmap/overmap_object.dm
@@ -184,7 +184,7 @@
 		if(position[i] < 0)
 			deltas[i] = ceil(position[i])
 		else if(position[i] > 0)
-			deltas[i] = FLOOR(position[i])
+			deltas[i] = floor(position[i])
 		moved = TRUE
 		// Delta over 0 means we've moved a turf, so we adjust our position accordingly.
 		if(deltas[i] != 0)

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -155,7 +155,7 @@ var/global/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 	for(var/i = 1 to 2)
 		if(MOVING(speed[i], min_speed))
 			. = min(., ((speed[i] > 0 ? 1 : -1) - position[i]) / speed[i])
-	. = max(CEILING(.),0)
+	. = max(ceil(.),0)
 
 /obj/effect/overmap/visitable/ship/proc/halt()
 	adjust_speed(-speed[1], -speed[2])

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -186,7 +186,7 @@
 
 		if(available_units > max_accepted_units)
 			//Take only what's needed
-			var/needed_sheets  = CEILING(max_accepted_units / SHEET_MATERIAL_AMOUNT)
+			var/needed_sheets  = ceil(max_accepted_units / SHEET_MATERIAL_AMOUNT)
 			var/leftover_units = max_accepted_units % SHEET_MATERIAL_AMOUNT
 			ST.use(needed_sheets)
 			//Drop the extra as shards
@@ -199,10 +199,10 @@
 
 		else if(available_units > LABEL_MATERIAL_COST)
 			//Take all that's available
-			ST.use(CEILING(available_units/SHEET_MATERIAL_AMOUNT))
+			ST.use(ceil(available_units/SHEET_MATERIAL_AMOUNT))
 			added_labels = round(available_units / LABEL_MATERIAL_COST)
 			add_paper_labels(added_labels)
-			to_chat(user, SPAN_NOTICE("You use [CEILING(available_units/SHEET_MATERIAL_AMOUNT)] [ST.plural_name] to refill \the [src] with [added_labels] label(s)."))
+			to_chat(user, SPAN_NOTICE("You use [ceil(available_units/SHEET_MATERIAL_AMOUNT)] [ST.plural_name] to refill \the [src] with [added_labels] label(s)."))
 		else
 			//Abort because not enough materials for even a single label
 			to_chat(user, SPAN_WARNING("There's not enough [ST.plural_name] in \the [ST] to refil \the [src]!"))

--- a/code/modules/paperwork/papershredder.dm
+++ b/code/modules/paperwork/papershredder.dm
@@ -177,7 +177,7 @@
 /obj/machinery/papershredder/on_update_icon()
 	cut_overlays()
 	var/ratio = ((cached_total_matter * 5) / max_total_matter)
-	icon_state = "papershredder[clamp(CEILING(ratio), 0, 5)]"
+	icon_state = "papershredder[clamp(ceil(ratio), 0, 5)]"
 	if(!is_unpowered())
 		add_overlay("papershredder_power")
 		if(is_broken() || is_bin_full())

--- a/code/modules/paperwork/pen/crayon_edibility.dm
+++ b/code/modules/paperwork/pen/crayon_edibility.dm
@@ -8,7 +8,7 @@
 	if(!eater_ingested)
 		return
 	if(pigment_type)
-		var/partial_amount = CEILING(amount * 0.4)
+		var/partial_amount = ceil(amount * 0.4)
 		eater_ingested.add_reagent(pigment_type, partial_amount)
 		eater_ingested.add_reagent(/decl/material/solid/organic/wax, amount - partial_amount)
 	else

--- a/code/modules/persistence/persistence_datum.dm
+++ b/code/modules/persistence/persistence_datum.dm
@@ -20,7 +20,7 @@
 	if(name)
 		filename = "data/persistent/[ckey(global.using_map.name)]-[ckey(name)].json"
 	if(!isnull(entries_decay_at) && !isnull(entries_expire_at))
-		entries_decay_at = FLOOR(entries_expire_at * entries_decay_at)
+		entries_decay_at = floor(entries_expire_at * entries_decay_at)
 
 /decl/persistence_handler/proc/GetValidTurf(var/turf/T, var/list/tokens)
 	if(T && isStationLevel(T.z) && CheckTurfContents(T, tokens))

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -875,8 +875,8 @@ By design, d1 is the smallest direction and d2 is the highest
 
 /obj/item/stack/cable_coil/fabricator/get_amount()
 	var/obj/item/cell/cell = get_cell()
-	. = (cell ? FLOOR(cell.charge / cost_per_cable) : 0)
+	. = (cell ? floor(cell.charge / cost_per_cable) : 0)
 
 /obj/item/stack/cable_coil/fabricator/get_max_amount()
 	var/obj/item/cell/cell = get_cell()
-	. = (cell ? FLOOR(cell.maxcharge / cost_per_cable) : 0)
+	. = (cell ? floor(cell.maxcharge / cost_per_cable) : 0)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -544,7 +544,7 @@ By design, d1 is the smallest direction and d2 is the highest
 		if(BP_IS_BRITTLE(S))
 			to_chat(user, SPAN_WARNING("\The [H]'s [S.name] is hard and brittle - \the [src] cannot repair it."))
 			return TRUE
-		var/use_amt = min(src.amount, CEILING(S.burn_dam/3), 5)
+		var/use_amt = min(src.amount, ceil(S.burn_dam/3), 5)
 		if(can_use(use_amt))
 			if(S.robo_repair(3*use_amt, BURN, "some damaged wiring", src, user))
 				use(use_amt)

--- a/code/modules/power/fuel_assembly/fuel_assembly.dm
+++ b/code/modules/power/fuel_assembly/fuel_assembly.dm
@@ -74,7 +74,7 @@
 		return PROCESS_KILL
 
 	if(istype(loc, /turf))
-		SSradiation.radiate(src, max(1,CEILING(radioactivity/15)))
+		SSradiation.radiate(src, max(1,ceil(radioactivity/15)))
 
 /obj/item/fuel_assembly/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/modules/power/fuel_assembly/fuel_compressor.dm
+++ b/code/modules/power/fuel_assembly/fuel_compressor.dm
@@ -57,7 +57,7 @@
 
 	var/decl/material/mat = GET_DECL(mat_type)
 	if(mat && stored_material[mat_type] >= SHEET_MATERIAL_AMOUNT)
-		var/sheet_count = FLOOR(stored_material[mat_type]/SHEET_MATERIAL_AMOUNT)
+		var/sheet_count = floor(stored_material[mat_type]/SHEET_MATERIAL_AMOUNT)
 		stored_material[mat_type] -= sheet_count * SHEET_MATERIAL_AMOUNT
 		SSmaterials.create_object(mat_type, get_turf(src), sheet_count)
 		if(isnull(stored_material[mat_type]))

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -154,8 +154,8 @@
 			alpha = 230
 		else
 			var/temp_mod = ((plasma_temperature-5000)/20000)
-			use_range = light_min_range + CEILING((light_max_range-light_min_range)*temp_mod)
-			use_power = light_min_power + CEILING((light_max_power-light_min_power)*temp_mod)
+			use_range = light_min_range + ceil((light_max_range-light_min_range)*temp_mod)
+			use_power = light_min_power + ceil((light_max_power-light_min_power)*temp_mod)
 			switch (plasma_temperature)
 				if (1000 to 6000)
 					light_color = COLOR_ORANGE
@@ -233,7 +233,7 @@
 	set waitfor = FALSE
 	visible_message("<span class='danger'>\The [src] shudders like a dying animal before flaring to eye-searing brightness and rupturing!</span>")
 	set_light(15, 15, "#ccccff")
-	empulse(get_turf(src), CEILING(plasma_temperature/1000), CEILING(plasma_temperature/300))
+	empulse(get_turf(src), ceil(plasma_temperature/1000), ceil(plasma_temperature/300))
 	sleep(5)
 	RadiateAll()
 	explosion(get_turf(owned_core),-1,-1,8,10) // Blow out all the windows.
@@ -307,7 +307,7 @@
 
 /obj/effect/fusion_em_field/proc/Radiate()
 	if(isturf(loc))
-		var/empsev = max(1, min(3, CEILING(size/2)))
+		var/empsev = max(1, min(3, ceil(size/2)))
 		for(var/atom/movable/AM in range(max(1,FLOOR(size/2)), loc))
 
 			if(AM == src || AM == owned_core || !AM.simulated)

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -308,7 +308,7 @@
 /obj/effect/fusion_em_field/proc/Radiate()
 	if(isturf(loc))
 		var/empsev = max(1, min(3, ceil(size/2)))
-		for(var/atom/movable/AM in range(max(1,FLOOR(size/2)), loc))
+		for(var/atom/movable/AM in range(max(1,floor(size/2)), loc))
 
 			if(AM == src || AM == owned_core || !AM.simulated)
 				continue
@@ -366,7 +366,7 @@
 		//determine a random amount to actually react this cycle, and remove it from the standard pool
 		//this is a hack, and quite nonrealistic :(
 		for(var/reactant in react_pool)
-			react_pool[reactant] = rand(FLOOR(react_pool[reactant]/2),react_pool[reactant])
+			react_pool[reactant] = rand(floor(react_pool[reactant]/2),react_pool[reactant])
 			reactants[reactant] -= react_pool[reactant]
 			if(!react_pool[reactant])
 				react_pool -= reactant

--- a/code/modules/power/fusion/kinetic_harvester.dm
+++ b/code/modules/power/fusion/kinetic_harvester.dm
@@ -45,7 +45,7 @@
 	var/datum/extension/local_network_member/lanm = get_extension(src, /datum/extension/local_network_member)
 	var/datum/local_network/lan = lanm.get_local_network()
 
-	if(lan)	
+	if(lan)
 		var/list/fusion_cores = lan.get_devices(/obj/machinery/fusion_core)
 		if(fusion_cores && fusion_cores.len)
 			harvest_from = fusion_cores[1]
@@ -66,7 +66,7 @@
 	data["materials"] = list()
 	for(var/mat in stored)
 		var/decl/material/material = GET_DECL(mat)
-		var/sheets = FLOOR(stored[mat]/(SHEET_MATERIAL_AMOUNT * 1.5))
+		var/sheets = floor(stored[mat]/(SHEET_MATERIAL_AMOUNT * 1.5))
 		data["materials"] += list(list("name" = material.solid_name, "amount" = sheets, "harvest" = harvesting[mat], "mat_ref" = "\ref[material]"))
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
@@ -112,7 +112,7 @@
 		var/decl/material/material = locate(href_list["remove_mat"])
 		if(istype(material))
 			var/sheet_cost = (SHEET_MATERIAL_AMOUNT * 1.5)
-			var/sheets = FLOOR(stored[material.type]/sheet_cost)
+			var/sheets = floor(stored[material.type]/sheet_cost)
 			if(sheets > 0)
 				material.create_object(loc, sheets)
 				stored[material.type] -= (sheets * sheet_cost)

--- a/code/modules/projectiles/guns/energy/capacitor.dm
+++ b/code/modules/projectiles/guns/energy/capacitor.dm
@@ -251,8 +251,8 @@ var/global/list/laser_wavelengths
 		var/obj/item/projectile/P = new projectile_type(src)
 		P.color = selected_wavelength.color
 		P.set_light(l_color = selected_wavelength.light_color)
-		P.damage = FLOOR(sqrt(total_charge) * selected_wavelength.damage_multiplier)
-		P.armor_penetration = FLOOR(sqrt(total_charge) * selected_wavelength.armour_multiplier)
+		P.damage = floor(sqrt(total_charge) * selected_wavelength.damage_multiplier)
+		P.armor_penetration = floor(sqrt(total_charge) * selected_wavelength.armour_multiplier)
 		. = P
 
 // Subtypes.

--- a/code/modules/projectiles/guns/launcher/money_cannon.dm
+++ b/code/modules/projectiles/guns/launcher/money_cannon.dm
@@ -19,7 +19,7 @@
 	emagged = 1
 
 /obj/item/gun/launcher/money/proc/vomit_cash(var/mob/living/vomit_onto, var/projectile_vomit)
-	var/bundle_worth = FLOOR(receptacle_value / 10)
+	var/bundle_worth = floor(receptacle_value / 10)
 	var/turf/T = get_turf(vomit_onto)
 	for(var/i = 1 to 10)
 		var/nv = bundle_worth

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -583,7 +583,7 @@
 	time_offset = 0
 	var/required_moves = 0
 	if(speed > 0)
-		required_moves = FLOOR(elapsed_time_deciseconds / speed)
+		required_moves = floor(elapsed_time_deciseconds / speed)
 		if(required_moves > SSprojectiles.global_max_tick_moves)
 			var/overrun = required_moves - SSprojectiles.global_max_tick_moves
 			required_moves = SSprojectiles.global_max_tick_moves

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -61,8 +61,8 @@
 				P.light_color = color
 				P.firer = firer
 				P.shot_from = shot_from
-				P.damage = FLOOR(damage/split_count)
-				P.armor_penetration = FLOOR(armor_penetration/split_count)
+				P.damage = floor(damage/split_count)
+				P.armor_penetration = floor(armor_penetration/split_count)
 				P.launch(pick_n_take(targets), def_zone)
 	. = ..()
 

--- a/code/modules/random_map/drop/droppod.dm
+++ b/code/modules/random_map/drop/droppod.dm
@@ -41,8 +41,8 @@
 /datum/random_map/droppod/generate_map()
 
 	// No point calculating these 200 times.
-	var/x_midpoint = CEILING(limit_x / 2)
-	var/y_midpoint = CEILING(limit_y / 2)
+	var/x_midpoint = ceil(limit_x / 2)
+	var/y_midpoint = ceil(limit_y / 2)
 
 	// Draw walls/floors/doors.
 	for(var/x = 1, x <= limit_x, x++)
@@ -80,7 +80,7 @@
 
 /datum/random_map/droppod/apply_to_map()
 	if(placement_explosion_dev || placement_explosion_heavy || placement_explosion_light || placement_explosion_flash)
-		var/turf/T = locate((origin_x + CEILING(limit_x / 2)-1), (origin_y + CEILING(limit_y / 2)-1), origin_z)
+		var/turf/T = locate((origin_x + ceil(limit_x / 2)-1), (origin_y + ceil(limit_y / 2)-1), origin_z)
 		if(istype(T))
 			explosion(T, placement_explosion_dev, placement_explosion_heavy, placement_explosion_light, placement_explosion_flash)
 			sleep(15) // Let the explosion finish proccing before we ChangeTurf(), otherwise it might destroy our spawned objects.
@@ -97,8 +97,8 @@
 
 // Pods are circular. Get the direction this object is facing from the center of the pod.
 /datum/random_map/droppod/get_spawn_dir(var/x, var/y)
-	var/x_midpoint = CEILING(limit_x / 2)
-	var/y_midpoint = CEILING(limit_y / 2)
+	var/x_midpoint = ceil(limit_x / 2)
+	var/y_midpoint = ceil(limit_y / 2)
 	if(x == x_midpoint && y == y_midpoint)
 		return null
 	var/turf/target = locate(origin_x+x-1, origin_y+y-1, origin_z)

--- a/code/modules/reagents/Chemistry-Grinder.dm
+++ b/code/modules/reagents/Chemistry-Grinder.dm
@@ -208,7 +208,7 @@
 			if(!material)
 				break
 
-			var/amount_to_take = max(0,min(stack.amount, FLOOR(remaining_volume / REAGENT_UNITS_PER_MATERIAL_SHEET)))
+			var/amount_to_take = max(0,min(stack.amount, floor(remaining_volume / REAGENT_UNITS_PER_MATERIAL_SHEET)))
 			if(amount_to_take)
 				stack.use(amount_to_take)
 				if(QDELETED(stack))

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -471,7 +471,7 @@ var/global/obj/temp_reagents_holder = new
 		return
 
 	if(isturf(target.loc) && min_spill && max_spill)
-		var/spill = FLOOR(amount*(rand(min_spill, max_spill)/100))
+		var/spill = floor(amount*(rand(min_spill, max_spill)/100))
 		if(spill)
 			amount -= spill
 			trans_to_turf(target.loc, spill, multiplier, copy, defer_update)

--- a/code/modules/reagents/heat_sources/_heat_source.dm
+++ b/code/modules/reagents/heat_sources/_heat_source.dm
@@ -150,10 +150,10 @@
 
 	dat += "</td></tr>"
 
-	dat += "<tr><td>Current temperature:</td><td>[FLOOR(temperature - T0C)]C</td></tr>"
+	dat += "<tr><td>Current temperature:</td><td>[floor(temperature - T0C)]C</td></tr>"
 
 	dat += "<tr><td>Loaded container:</td>"
-	dat += "<td>[container ? "[container.name] ([FLOOR(container.temperature - T0C)]C) <a href='byond://?src=\ref[src];remove_container=1'>Remove</a>" : "None."]</td></tr>"
+	dat += "<td>[container ? "[container.name] ([floor(container.temperature - T0C)]C) <a href='byond://?src=\ref[src];remove_container=1'>Remove</a>" : "None."]</td></tr>"
 
 	dat += "<tr><td>Switched:</td><td><a href='byond://?src=\ref[src];toggle_power=1'>[use_power == POWER_USE_ACTIVE ? "On" : "Off"]</a></td></tr>"
 	dat += "</table>"

--- a/code/modules/reagents/reactions/reaction_synthesis.dm
+++ b/code/modules/reagents/reactions/reaction_synthesis.dm
@@ -53,7 +53,7 @@
 		var/list/removing_reagents = list()
 		for(var/rtype in holder.reagent_volumes)
 			if(rtype != /decl/material/liquid/crystal_agent)
-				var/solidifying = FLOOR(REAGENT_VOLUME(holder, rtype) / REAGENT_UNITS_PER_MATERIAL_SHEET)
+				var/solidifying = floor(REAGENT_VOLUME(holder, rtype) / REAGENT_UNITS_PER_MATERIAL_SHEET)
 				if(solidifying)
 					SSmaterials.create_object(rtype, location, solidifying, /obj/item/stack/material/cubes)
 					removing_reagents[rtype] = solidifying * REAGENT_UNITS_PER_MATERIAL_SHEET
@@ -88,7 +88,7 @@
 		for(var/rtype in holder.reagent_volumes)
 			var/decl/material/mat = GET_DECL(rtype)
 			if(mat.default_solid_form == /obj/item/stack/material/aerogel)
-				var/solidifying = FLOOR(REAGENT_VOLUME(holder, rtype) / REAGENT_UNITS_PER_MATERIAL_SHEET)
+				var/solidifying = floor(REAGENT_VOLUME(holder, rtype) / REAGENT_UNITS_PER_MATERIAL_SHEET)
 				if(solidifying)
 					SSmaterials.create_object(rtype, location, solidifying)
 					removing_reagents[rtype] = solidifying * REAGENT_UNITS_PER_MATERIAL_SHEET
@@ -120,7 +120,7 @@
 	var/turf/T = get_turf(holder.get_reaction_loc(chemical_reaction_flags))
 	if(!istype(T))
 		return
-	var/create_stacks = FLOOR(created_volume)
+	var/create_stacks = floor(created_volume)
 	if(create_stacks <= 0)
 		return
 	new /obj/item/stack/medical/resin/crafted(T, create_stacks)
@@ -141,7 +141,7 @@
 	var/turf/T = get_turf(holder.get_reaction_loc(chemical_reaction_flags))
 	if(!istype(T))
 		return
-	var/create_soap = FLOOR(created_volume)
+	var/create_soap = floor(created_volume)
 	if(create_soap <= 0)
 		return
 	for(var/i = 1 to create_soap)

--- a/code/modules/reagents/reactions/reaction_synthesis.dm
+++ b/code/modules/reagents/reactions/reaction_synthesis.dm
@@ -14,8 +14,8 @@
 
 /decl/chemical_reaction/synthesis/fiberglass/Initialize()
 	required_reagents = list(
-		/decl/material/solid/glass =   CEILING(REAGENT_UNITS_PER_MATERIAL_SHEET/2),
-		/decl/material/solid/organic/plastic = CEILING(REAGENT_UNITS_PER_MATERIAL_SHEET/2)
+		/decl/material/solid/glass =   ceil(REAGENT_UNITS_PER_MATERIAL_SHEET/2),
+		/decl/material/solid/organic/plastic = ceil(REAGENT_UNITS_PER_MATERIAL_SHEET/2)
 	)
 	. = ..()
 
@@ -23,7 +23,7 @@
 	..()
 	var/location = get_turf(holder.get_reaction_loc(chemical_reaction_flags))
 	if(location)
-		created_volume = CEILING(created_volume)
+		created_volume = ceil(created_volume)
 		if(created_volume > 0)
 			var/decl/material/mat = GET_DECL(/decl/material/solid/fiberglass)
 			mat.create_object(location, created_volume)

--- a/code/modules/reagents/reagent_containers/food/sandwich.dm
+++ b/code/modules/reagents/reagent_containers/food/sandwich.dm
@@ -72,7 +72,7 @@
 
 	SetName(lowertext("[fullname] sandwich"))
 	if(length(name) > 80) SetName("[pick(list("absurd","colossal","enormous","ridiculous"))] sandwich")
-	w_class = CEILING(clamp((ingredients.len/2),2,4))
+	w_class = ceil(clamp((ingredients.len/2),2,4))
 
 /obj/item/food/csandwich/Destroy()
 	for(var/obj/item/O in ingredients)

--- a/code/modules/research/design_database_analyzer.dm
+++ b/code/modules/research/design_database_analyzer.dm
@@ -60,7 +60,7 @@
 
 	var/list/dump_matter
 	for(var/mat in cached_materials)
-		var/amt = FLOOR(cached_materials[mat]/SHEET_MATERIAL_AMOUNT)
+		var/amt = floor(cached_materials[mat]/SHEET_MATERIAL_AMOUNT)
 		if(amt > 0)
 			LAZYSET(dump_matter, mat, amt)
 	if(length(dump_matter))

--- a/code/modules/sealant_gun/sealant_injector.dm
+++ b/code/modules/sealant_gun/sealant_injector.dm
@@ -63,7 +63,7 @@
 		to_chat(user, SPAN_WARNING("There is no tank loaded."))
 		return TRUE
 
-	var/fill_space = FLOOR(loaded_tank.max_foam_charges - loaded_tank.foam_charges) / 5
+	var/fill_space = floor(loaded_tank.max_foam_charges - loaded_tank.foam_charges) / 5
 	if(fill_space <= 0)
 		to_chat(user, SPAN_WARNING("\The [loaded_tank] is full."))
 		return TRUE

--- a/code/modules/sealant_gun/sealant_tank.dm
+++ b/code/modules/sealant_gun/sealant_tank.dm
@@ -9,7 +9,7 @@
 
 /obj/item/sealant_tank/on_update_icon()
 	. = ..()
-	add_overlay("fill_[FLOOR((foam_charges/max_foam_charges) * 5)]")
+	add_overlay("fill_[floor((foam_charges/max_foam_charges) * 5)]")
 
 /obj/item/sealant_tank/examine(mob/user, distance)
 	. = ..()

--- a/code/modules/spells/targeted/shapeshift.dm
+++ b/code/modules/spells/targeted/shapeshift.dm
@@ -75,7 +75,7 @@
 	if(share_damage)
 		var/transformer_max_health = transformer.get_max_health()
 		var/damage = transformer.set_max_health(transformer_max_health-round(transformer_max_health*(transformer.get_health_ratio())))
-		for(var/i in 1 to CEILING(damage/10))
+		for(var/i in 1 to ceil(damage/10))
 			transformer.take_damage(10)
 	if(target.mind)
 		target.mind.transfer_to(transformer)

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -50,7 +50,7 @@
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	user.visible_message("<span class='notice'>[user] has made [access_string] on [target]'s [affected.name] with \the [tool].</span>", \
 	"<span class='notice'>You have made [access_string] on [target]'s [affected.name] with \the [tool].</span>",)
-	affected.createwound(CUT, CEILING(affected.min_broken_damage/2), TRUE)
+	affected.createwound(CUT, ceil(affected.min_broken_damage/2), TRUE)
 	if(tool.atom_damage_type == BURN)
 		affected.clamp_organ()
 		playsound(target, 'sound/items/Welder.ogg', 15, 1)

--- a/code/modules/synthesized_instruments/song_editor.dm
+++ b/code/modules/synthesized_instruments/song_editor.dm
@@ -13,11 +13,11 @@
 
 
 /datum/nano_module/song_editor/proc/pages()
-	return CEILING(src.song.lines.len / global.musical_config.song_editor_lines_per_page)
+	return ceil(src.song.lines.len / global.musical_config.song_editor_lines_per_page)
 
 
 /datum/nano_module/song_editor/proc/current_page()
-	return src.song.current_line > 0 ? CEILING(src.song.current_line / global.musical_config.song_editor_lines_per_page) : src.page
+	return src.song.current_line > 0 ? ceil(src.song.current_line / global.musical_config.song_editor_lines_per_page) : src.page
 
 
 /datum/nano_module/song_editor/proc/page_bounds(page_num)

--- a/code/modules/tools/archetypes/tool_extension.dm
+++ b/code/modules/tools/archetypes/tool_extension.dm
@@ -64,7 +64,7 @@
 	return LAZYACCESS(tool_use_sounds, archetype) || get_tool_property(archetype, TOOL_PROP_SOUND) || tool_archetype.tool_sound
 
 /datum/extension/tool/proc/get_expected_tool_use_delay(archetype, delay, mob/user, check_skill = SKILL_CONSTRUCTION)
-	. = CEILING(delay * get_tool_speed(archetype))
+	. = ceil(delay * get_tool_speed(archetype))
 	if(user && check_skill)
 		. *= user.skill_delay_mult(check_skill, 0.3)
 	. = max(round(.), 5)

--- a/code/modules/turbolift/turbolift_map.dm
+++ b/code/modules/turbolift/turbolift_map.dm
@@ -76,7 +76,7 @@ INITIALIZE_IMMEDIATE(/obj/abstract/turbolift_spawner)
 
 		if(NORTH)
 
-			int_panel_x = ux + FLOOR(lift_size_x/2)
+			int_panel_x = ux + floor(lift_size_x/2)
 			int_panel_y = uy + 1
 			ext_panel_x = ux
 			ext_panel_y = ey + 2
@@ -93,7 +93,7 @@ INITIALIZE_IMMEDIATE(/obj/abstract/turbolift_spawner)
 
 		if(SOUTH)
 
-			int_panel_x = ux + FLOOR(lift_size_x/2)
+			int_panel_x = ux + floor(lift_size_x/2)
 			int_panel_y = ey - 1
 			ext_panel_x = ex
 			ext_panel_y = uy - 2
@@ -111,7 +111,7 @@ INITIALIZE_IMMEDIATE(/obj/abstract/turbolift_spawner)
 		if(EAST)
 
 			int_panel_x = ux+1
-			int_panel_y = uy + FLOOR(lift_size_y/2)
+			int_panel_y = uy + floor(lift_size_y/2)
 			ext_panel_x = ex+2
 			ext_panel_y = ey
 
@@ -128,7 +128,7 @@ INITIALIZE_IMMEDIATE(/obj/abstract/turbolift_spawner)
 		if(WEST)
 
 			int_panel_x = ex-1
-			int_panel_y = uy + FLOOR(lift_size_y/2)
+			int_panel_y = uy + floor(lift_size_y/2)
 			ext_panel_x = ux-2
 			ext_panel_y = uy
 

--- a/code/unit_tests/materials.dm
+++ b/code/unit_tests/materials.dm
@@ -67,9 +67,9 @@
 								if(length(product_obj.matter))
 									failed = "unsupplied material types"
 							else if(material && (product_obj.matter[material.type]) > recipe.req_amount)
-								failed = "excessive base material ([recipe.req_amount]/[CEILING(product_obj.matter[material.type])])"
+								failed = "excessive base material ([recipe.req_amount]/[ceil(product_obj.matter[material.type])])"
 							else if(reinforced && (product_obj.matter[reinforced.type]) > recipe.req_amount)
-								failed = "excessive reinf material ([recipe.req_amount]/[CEILING(product_obj.matter[reinforced.type])])"
+								failed = "excessive reinf material ([recipe.req_amount]/[ceil(product_obj.matter[reinforced.type])])"
 							else
 								for(var/mat in product_obj.matter)
 									if(mat != material?.type && mat != reinforced?.type)

--- a/maps/~mapsystem/maps_currency.dm
+++ b/maps/~mapsystem/maps_currency.dm
@@ -18,7 +18,7 @@
 	var/obj/item/charge_stick/credstick = new
 	credstick.creator = owner.real_name
 	credstick.currency = owner_account.currency
-	credstick.loaded_worth = min(credstick.max_worth, FLOOR(owner_account.money * transfer_mult))
+	credstick.loaded_worth = min(credstick.max_worth, floor(owner_account.money * transfer_mult))
 	owner_account.money -= credstick.loaded_worth
 	return list(credstick)
 
@@ -34,7 +34,7 @@
 /decl/starting_cash_choice/cash/get_cash_objects(var/mob/living/human/owner, var/datum/money_account/owner_account)
 	var/obj/item/cash/cash = new
 	cash.set_currency(owner_account.currency)
-	cash.adjust_worth(FLOOR(owner_account.money * transfer_mult))
+	cash.adjust_worth(floor(owner_account.money * transfer_mult))
 	owner_account.money -= cash.absolute_worth
 	return list(cash)
 
@@ -52,12 +52,12 @@
 	. = list()
 	var/obj/item/cash/cash = new
 	cash.set_currency(owner_account.currency)
-	cash.adjust_worth(FLOOR(owner_account.money * transfer_mult))
+	cash.adjust_worth(floor(owner_account.money * transfer_mult))
 	. += cash
 	var/obj/item/charge_stick/credstick = new
 	credstick.creator = owner.real_name
 	credstick.currency = owner_account.currency
-	credstick.loaded_worth = min(credstick.max_worth, FLOOR(owner_account.money * transfer_mult))
+	credstick.loaded_worth = min(credstick.max_worth, floor(owner_account.money * transfer_mult))
 	. += credstick
 	owner_account.money -= cash.absolute_worth
 	owner_account.money -= credstick.loaded_worth

--- a/mods/content/psionics/items/implant.dm
+++ b/mods/content/psionics/items/implant.dm
@@ -73,7 +73,7 @@
 
 		// If we're disrupting psionic attempts at the moment, we might overload.
 		if(disrupts_psionics())
-			var/overload_amount = FLOOR(stress/10)
+			var/overload_amount = floor(stress/10)
 			if(overload_amount > 0)
 				overload += overload_amount
 				if(overload >= max_overload)

--- a/mods/content/psionics/system/psionics/complexus/complexus_helpers.dm
+++ b/mods/content/psionics/system/psionics/complexus/complexus_helpers.dm
@@ -42,7 +42,7 @@
 	if(isnull(check_incapacitated))
 		check_incapacitated = (INCAPACITATION_STUNNED|INCAPACITATION_KNOCKOUT)
 	if(can_use(check_incapacitated))
-		value = max(1, CEILING(value * cost_modifier))
+		value = max(1, ceil(value * cost_modifier))
 		if(value <= stamina)
 			stamina -= value
 			ui.update_icon()

--- a/mods/content/psionics/system/psionics/complexus/complexus_process.dm
+++ b/mods/content/psionics/system/psionics/complexus/complexus_process.dm
@@ -21,7 +21,7 @@
 
 	UNSETEMPTY(latencies)
 	var/rank_count = max(1, LAZYLEN(ranks))
-	if(force || last_rating != CEILING(combined_rank/rank_count))
+	if(force || last_rating != ceil(combined_rank/rank_count))
 		if(highest_rank <= 1)
 			if(highest_rank == 0)
 				qdel(src)
@@ -29,7 +29,7 @@
 		else
 			rebuild_power_cache = TRUE
 			sound_to(owner, 'sound/effects/psi/power_unlock.ogg')
-			rating = CEILING(combined_rank/rank_count)
+			rating = ceil(combined_rank/rank_count)
 			cost_modifier = 1
 			if(rating > 1)
 				cost_modifier -= min(1, max(0.1, (rating-1) / 10))
@@ -74,7 +74,7 @@
 
 	var/update_hud
 	if(armor_cost)
-		var/value = max(1, CEILING(armor_cost * cost_modifier))
+		var/value = max(1, ceil(armor_cost * cost_modifier))
 		if(value <= stamina)
 			stamina -= value
 		else

--- a/mods/content/xenobiology/slime/feeding.dm
+++ b/mods/content/xenobiology/slime/feeding.dm
@@ -100,7 +100,7 @@
 			ate_victim = TRUE
 		if(drained)
 			gain_nutrition(drained)
-			var/heal_amt = FLOOR(drained*0.5)
+			var/heal_amt = floor(drained*0.5)
 			if(heal_amt > 0)
 				heal_damage(OXY, heal_amt, do_update_health = FALSE)
 				heal_damage(BRUTE, heal_amt, do_update_health = FALSE)

--- a/mods/mobs/dionaea/mob/nymph_attacks.dm
+++ b/mods/mobs/dionaea/mob/nymph_attacks.dm
@@ -83,7 +83,7 @@
 		return TRUE
 
 	if(tray.waterlevel < 100)
-		var/nutrition_cost = FLOOR((100-tray.nutrilevel)/10) * 5
+		var/nutrition_cost = floor((100-tray.nutrilevel)/10) * 5
 		if(nutrition >= nutrition_cost)
 			visible_message(SPAN_NOTICE("<b>\The [src]</b> secretes a trickle of clear liquid, refilling [tray]."),SPAN_NOTICE("You secrete some water into \the [tray]."))
 			tray.waterlevel = 100

--- a/mods/mobs/dionaea/mob/nymph_life.dm
+++ b/mods/mobs/dionaea/mob/nymph_life.dm
@@ -22,7 +22,7 @@
 			set_light((5 * mult), mult, "#55ff55")
 			last_glow = mult
 
-	set_nutrition(clamp(nutrition + FLOOR(radiation/100) + light_amount, 0, 500))
+	set_nutrition(clamp(nutrition + floor(radiation/100) + light_amount, 0, 500))
 
 	if(radiation >= 50 || light_amount > 2) //if there's enough light, heal
 		var/update_health = FALSE

--- a/mods/species/ascent/items/guns.dm
+++ b/mods/species/ascent/items/guns.dm
@@ -46,7 +46,7 @@
 	var/datum/firemode/current_mode = firemodes[sel_mode]
 	set_overlays(list(
 		"[get_world_inventory_state()]-[istype(current_mode) ? current_mode.name : "lethal"]",
-		"[get_world_inventory_state()]-charge-[istype(power_supply) ? FLOOR(power_supply.percent()/20) : 0]"
+		"[get_world_inventory_state()]-charge-[istype(power_supply) ? floor(power_supply.percent()/20) : 0]"
 	))
 
 /obj/item/gun/magnetic/railgun/flechette/ascent
@@ -62,7 +62,7 @@
 
 /obj/item/gun/magnetic/railgun/flechette/ascent/show_ammo(var/mob/user)
 	var/obj/item/cell/cell = get_cell()
-	to_chat(user, "<span class='notice'>There are [cell ? FLOOR(cell.charge/charge_per_shot) : 0] shot\s remaining.</span>")
+	to_chat(user, "<span class='notice'>There are [cell ? floor(cell.charge/charge_per_shot) : 0] shot\s remaining.</span>")
 
 /obj/item/gun/magnetic/railgun/flechette/ascent/check_ammo()
 	var/obj/item/cell/cell = get_cell()

--- a/mods/species/vox/organs_vox.dm
+++ b/mods/species/vox/organs_vox.dm
@@ -109,7 +109,7 @@
 
 				// Process it.
 				if(can_digest_matter[mat])
-					owner.adjust_nutrition(max(1, FLOOR(digested/100)))
+					owner.adjust_nutrition(max(1, floor(digested/100)))
 					updated_stacks = TRUE
 				else if(can_process_matter[mat])
 					LAZYDISTINCTADD(check_materials, mat)
@@ -121,7 +121,7 @@
 			if(M && stored_matter[mat] >= SHEET_MATERIAL_AMOUNT)
 
 				// Remove as many sheets as possible from the gizzard.
-				var/sheets = FLOOR(stored_matter[mat]/SHEET_MATERIAL_AMOUNT)
+				var/sheets = floor(stored_matter[mat]/SHEET_MATERIAL_AMOUNT)
 				stored_matter[mat] -= SHEET_MATERIAL_AMOUNT * sheets
 				if(stored_matter[mat] <= 0)
 					stored_matter -= mat


### PR DESCRIPTION
## Description of changes
Since we require 515 now, I replaced `FLOOR()` with `floor()`, `CEILING()` with `ceil()`, and the unused `ROUND()` (identical to `MINMAX()` in lighting code) with `trunc()`.

## Why and what will this PR improve
Better code quality, fewer ugly redundant macros.