### PR TITLE
Fix crafting failure warning when putting tool handles in storage

### DIFF
--- a/code/modules/crafting/slapcrafting/crafting_recipes/tool_crafting/_tool_crafting.dm
+++ b/code/modules/crafting/slapcrafting/crafting_recipes/tool_crafting/_tool_crafting.dm
@@ -52,6 +52,9 @@ var/global/list/_tool_crafting_components = list(
 
 /decl/crafting_stage/tool/tool_start/is_appropriate_tool(obj/item/thing, obj/item/target)
 
+	if(!..())
+		return FALSE
+
 	if(thing.material?.hardness < MAT_VALUE_SOFT)
 		to_chat(usr, SPAN_WARNING("\The [thing] is too soft to be used as part of an effective tool."))
 		return FALSE
@@ -74,7 +77,7 @@ var/global/list/_tool_crafting_components = list(
 		to_chat(usr, SPAN_WARNING("\The [target] and \the [thing] cannot be combined into a functional tool."))
 		return FALSE
 
-	return ..()
+	return TRUE
 
 /decl/crafting_stage/tool_binding
 	descriptor = "tool binding"


### PR DESCRIPTION
## Description of changes
Moves the istype check to the start to avoid invalid warnings for things that could never succeed crafting anyway.

## Why and what will this PR improve
Fixes an issue reported by torimaesua, thank you for reporting it!
![image](https://github.com/user-attachments/assets/7cc646a8-9bd2-45dd-a9f4-eceeaec96314)