### PR TITLE
Delete plates spawned by cooked food

### DIFF
--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -228,5 +228,6 @@
 
 	for(var/obj/item/chems/food/food in results)
 		food.cooked_food = TRUE
+		QDEL_NULL(food.plate)
 
 	return results


### PR DESCRIPTION
## Description of changes
Deletes plates spawned by recipes. I was too lazy to do something like 'tally up the plates in the ingredients and delete any in the products that exceed it, and dump out any plates that didn't get used." This is simple and easy.

## Why and what will this PR improve
Cooking food won't spawn plates, and this doesn't have to add a new argument to skip plate creation.