### PR TITLE
Make mortars use a storage datum

### DIFF
--- a/code/datums/extensions/storage/subtypes_misc.dm
+++ b/code/datums/extensions/storage/subtypes_misc.dm
@@ -113,6 +113,15 @@
 		return worms < COMPOST_MAX_WORMS
 	return W.is_compostable()
 
+/datum/storage/hopper/mortar
+	max_w_class = ITEM_SIZE_NORMAL * 2
+
+/datum/storage/hopper/mortar/can_be_inserted(obj/item/inserting_item, mob/user, stop_messages)
+	. = ..()
+	if(!.)
+		return
+	return inserting_item.reagents?.total_volume > 0
+
 /datum/storage/photo_album
 	storage_slots = DEFAULT_BOX_STORAGE //yes, that's storage_slots. Photos are w_class 1 so this has as many slots equal to the number of photos you could put in a box
 	can_hold = list(/obj/item/photo)

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -54,13 +54,13 @@
 	update_icon()
 
 /obj/item/soap/proc/wet()
-	add_to_reagents(/decl/material/liquid/cleaner, SOAP_CLEANER_ON_WET)
+	add_to_reagents(/decl/material/liquid/cleaner/soap, SOAP_CLEANER_ON_WET)
 
 /obj/item/soap/Crossed(atom/movable/AM)
 	if(!isliving(AM))
 		return
 	var/mob/living/M = AM
-	M.slip("the [src.name]", 3)
+	M.slip("\the [src]", 3)
 
 /obj/item/soap/afterattack(atom/target, mob/user, proximity)
 	if(!proximity) return

--- a/code/modules/reagents/chems/chems_cleaner.dm
+++ b/code/modules/reagents/chems/chems_cleaner.dm
@@ -33,6 +33,7 @@
 	taste_description = "waxy blandness"
 	color = COLOR_BEIGE
 	uid = "chem_soap"
+	hardness         = MAT_VALUE_FLEXIBLE + 10
 	melting_point    = 323
 	ignition_point   = 353
 	boiling_point    = 373

--- a/code/modules/reagents/reagent_containers/mortar.dm
+++ b/code/modules/reagents/reagent_containers/mortar.dm
@@ -6,36 +6,28 @@
 	volume = 40
 	material = /decl/material/solid/stone/basalt
 	material_alteration = MAT_FLAG_ALTERATION_ALL
+	storage = /datum/storage/hopper/mortar
+	var/grinding = FALSE
 
 // todo: generalize to use TOOL_PESTLE
-/obj/item/chems/glass/mortar/attack_self(mob/user)
-	var/list/contained_atoms = get_contained_external_atoms()
-	var/obj/item/crushing_item = LAZYACCESS(contained_atoms, 1)
-	if(crushing_item)
-		crushing_item.dropInto(loc || get_turf(user))
-		return TRUE
-	return ..()
-
 /obj/item/chems/glass/mortar/attackby(obj/item/using_item, mob/living/user)
 	if((. = ..()))
 		return
+	return try_grind(using_item, user)
+
+/obj/item/chems/glass/mortar/proc/try_grind(obj/item/using_item, mob/living/user)
 	if(!istype(using_item))
 		return FALSE
 	if(!CanPhysicallyInteract(user) || !user.check_dexterity(DEXTERITY_HOLD_ITEM))
 		return TRUE
-	var/list/contained_atoms = get_contained_external_atoms()
+	if(grinding)
+		to_chat(user, SPAN_WARNING("Something is already being crushed in \the [src]."))
+		return TRUE
+	var/list/contained_atoms = get_stored_inventory()
 	var/obj/item/crushing_item = LAZYACCESS(contained_atoms, 1)
 	var/decl/material/attacking_material = using_item.get_material()
 	var/decl/material/crushing_material = crushing_item?.get_material()
 	var/skill_factor = CLAMP01(1 + 0.3*(user.get_skill_value(SKILL_CHEMISTRY) - SKILL_EXPERT)/(SKILL_EXPERT - SKILL_MIN))
-	if(!crushing_item)
-		if(!using_item.reagents?.total_volume)
-			to_chat(user, SPAN_NOTICE("\The [using_item] is not suitable for grinding."))
-			return TRUE
-		if(!user.try_unequip(using_item, src))
-			return TRUE
-		to_chat(user, SPAN_NOTICE("You add \the [using_item] to \the [src] for grinding."))
-		return TRUE
 	if(using_item.force <= 0 || !attacking_material || !crushing_material)
 		return TRUE
 	if(attacking_material.hardness <= crushing_material.hardness)
@@ -53,11 +45,19 @@
 			to_chat(user, SPAN_WARNING("You are too tired to crush \the [crushing_item], take a break!"))
 			return TRUE
 		to_chat(user, SPAN_NOTICE("You start grinding \the [crushing_item] with \the [using_item]."))
+		grinding = TRUE
 		if(!do_after(user, stamina_to_consume SECONDS))
 			to_chat(user, SPAN_NOTICE("You stop grinding \the [crushing_item]."))
+			grinding = FALSE
 			return TRUE
+		grinding = FALSE
+		if(QDELETED(crushing_item))
+			return TRUE // already been ground!
 		user.adjust_stamina(-stamina_to_consume)
 		crushing_item.reagents.trans_to(src, crushing_item.reagents.total_volume, skill_factor)
 		to_chat(user, SPAN_NOTICE("You finish grinding \the [crushing_item] with \the [using_item]."))
 	QDEL_NULL(crushing_item)
+	// If there's more to crush, try looping
+	if(length(get_stored_inventory()) > 0)
+		try_grind(using_item, user)
 	return TRUE


### PR DESCRIPTION
## Description of changes
Makes mortars use a storage datum for managing stored contents. 
(also some changes to soap, which I used as a test item, and it turns out it was too hard to crush + produced spray cleaner instead of soap)

## Why and what will this PR improve
Better quality of life and better code.

## Authorship
Me

## Changelog
:cl:
tweak: Mortars (for grinding) are now capable of holding more than one item at a time.
/:cl: