### PR TITLE
Makes food no longer hollow

### DIFF
--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -14,7 +14,6 @@
 	icon = 'icons/obj/food.dmi'
 	icon_state = null
 	randpixel = 6
-	obj_flags = OBJ_FLAG_HOLLOW
 	item_flags = null
 	material = /decl/material/liquid/nutriment
 	center_of_mass = @'{"x":16,"y":16}'


### PR DESCRIPTION
## Description of changes
Food inherited `obj_flags = OBJ_FLAG_HOLLOW` from `/obj/item/chems` and I only noticed it after making food not a chems subtype. This explains why they had fuckall results when doing things like turning cotton (`/obj/item/chems/food/grown`) or offal (`/obj/item/chems/food/butchery/offal`) into thread.

## Why and what will this PR improve
Food, including offal and plants, will have a meaningful amount of matter in it, which should fix things like twisting benches and spinning wheels producing almost no thread.