### PR TITLE
Food can now skip plate creation.

### DIFF
--- a/code/game/machinery/kitchen/cooking_machines/_cooker_output.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker_output.dm
@@ -8,7 +8,7 @@
 	filling_color = COLOR_BROWN
 	abstract_type = /obj/item/food/variable
 
-/obj/item/food/variable/Initialize()
+/obj/item/food/variable/Initialize(mapload, material_key, skip_plate = FALSE)
 	. = ..()
 	update_icon()
 

--- a/code/game/machinery/kitchen/icecream.dm
+++ b/code/game/machinery/kitchen/icecream.dm
@@ -204,7 +204,7 @@
 	var/ice_creamed
 	var/cone_type
 
-/obj/item/food/icecream/Initialize()
+/obj/item/food/icecream/Initialize(mapload, material_key, skip_plate = FALSE)
 	. = ..()
 	update_icon()
 

--- a/code/modules/butchery/butchery_data.dm
+++ b/code/modules/butchery/butchery_data.dm
@@ -36,6 +36,9 @@
 		blood_splatter(product_loc, donor, large = TRUE)
 	if(ispath(product_type, /obj/item/stack))
 		LAZYADD(., new product_type(product_loc, product_amount, product_material, donor))
+	else if(ispath(product_type, /obj/item/food))
+		for(var/i = 1 to product_amount)
+			LAZYADD(., new product_type(product_loc, product_material, TRUE, donor))
 	else
 		for(var/i = 1 to product_amount)
 			LAZYADD(., new product_type(product_loc, product_material, donor))

--- a/code/modules/butchery/butchery_products.dm
+++ b/code/modules/butchery/butchery_products.dm
@@ -16,7 +16,7 @@
 	var/fat_material    = /decl/material/solid/organic/meat/gut
 	var/meat_name       = "meat"
 
-/obj/item/food/butchery/Initialize(ml, material_key, mob/living/donor)
+/obj/item/food/butchery/Initialize(mapload, material_key, skip_plate = FALSE, mob/living/donor)
 	var/decl/butchery_data/butchery_decl = GET_DECL(donor?.butchery_data)
 	if(butchery_decl)
 		if(butchery_decl.meat_material)
@@ -159,7 +159,7 @@
 	w_class             = ITEM_SIZE_HUGE
 	var/bone_material   = /decl/material/solid/organic/bone
 
-/obj/item/food/butchery/haunch/Initialize(ml, material_key, mob/living/donor)
+/obj/item/food/butchery/haunch/Initialize(mapload, material_key, skip_plate = FALSE, mob/living/donor)
 	var/decl/butchery_data/butchery_decl = GET_DECL(donor?.butchery_data)
 	if(butchery_decl)
 		bone_material = butchery_decl.bone_material
@@ -187,7 +187,7 @@
 	icon                = 'icons/obj/items/butchery/side.dmi'
 	w_class             = ITEM_SIZE_GARGANTUAN
 
-/obj/item/food/butchery/haunch/side/Initialize(ml, material_key, mob/living/donor)
+/obj/item/food/butchery/haunch/side/Initialize(mapload, material_key, skip_plate = FALSE, mob/living/donor)
 	. = ..()
 	if(donor && !isnull(slice_num))
 		slice_num = max(1, round(slice_num/2))

--- a/code/modules/butchery/butchery_products_chopped.dm
+++ b/code/modules/butchery/butchery_products_chopped.dm
@@ -6,7 +6,7 @@
 	nutriment_amt = 1
 	w_class       = ITEM_SIZE_TINY
 
-/obj/item/food/butchery/chopped/Initialize()
+/obj/item/food/butchery/chopped/Initialize(mapload, material_key, skip_plate = FALSE)
 	. = ..()
 	slice_path = null
 	slice_num = null

--- a/code/modules/butchery/butchery_products_meat.dm
+++ b/code/modules/butchery/butchery_products_meat.dm
@@ -25,7 +25,7 @@
 	)
 	return meat_icons
 
-/obj/item/food/butchery/meat/Initialize(ml, material_key, mob/living/donor)
+/obj/item/food/butchery/meat/Initialize(mapload, material_key, skip_plate = FALSE, mob/living/donor)
 	icon = pick(get_meat_icons())
 	return ..()
 

--- a/code/modules/butchery/butchery_products_meat_fish.dm
+++ b/code/modules/butchery/butchery_products_meat_fish.dm
@@ -30,7 +30,7 @@
 			food.remove_from_reagents(/decl/material/liquid/carpotoxin, REAGENT_VOLUME(reagents, /decl/material/liquid/carpotoxin))
 
 /obj/item/food/butchery/meat/fish/create_slice()
-	return new slice_path(loc, material?.type, meat_name) // pass fish name to sashimi
+	return new slice_path(loc, material?.type, TRUE, meat_name) // pass fish name to sashimi
 
 /obj/item/food/butchery/meat/fish/grilled
 	desc                           = "A lightly grilled fish fillet."

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -166,7 +166,7 @@
 				SPAN_NOTICE("You slice \the [src]!")
 			)
 		for(var/i = 1 to slice_amount)
-			new /obj/item/food/processed_grown/chopped(loc, material?.type, plant)
+			new /obj/item/food/processed_grown/chopped(loc, null, TRUE, plant)
 		qdel(src)
 		return TRUE
 	return ..()

--- a/code/modules/clothing/masks/cig_crafting.dm
+++ b/code/modules/clothing/masks/cig_crafting.dm
@@ -45,7 +45,7 @@
 	seed = "tobacco"
 	w_class = ITEM_SIZE_TINY
 
-/obj/item/food/grown/dried_tobacco/Initialize()
+/obj/item/food/grown/dried_tobacco/Initialize(mapload, material_key, skip_plate = FALSE)
 	. = ..()
 	dry = TRUE
 	SetName("dried [name]")

--- a/code/modules/food/assembled.dm
+++ b/code/modules/food/assembled.dm
@@ -65,7 +65,27 @@
 
 	// TODO: move reagents/matter into produced food object.
 	if(ispath(create_type) && user.canUnEquip(src))
-		var/obj/item/food/result = new create_type()
+		var/obj/item/food/result
+		if(ispath(create_type, /obj/item/food))
+
+			// Create the food with no plate, and move over any existing plate.
+			result = new create_type(null, null, TRUE) // Skip plate creation.
+
+			if(istype(W, /obj/item/food))
+				var/obj/item/food/other_food = W
+				result.plate = other_food.plate
+				other_food.plate = null
+
+			if(!result.plate && plate)
+				result.plate = plate
+				plate = null
+
+			if(istype(result.plate) && result.plate.loc != result)
+				result.plate.forceMove(result)
+
+		else
+			result = new create_type
+
 		//If the snack was in your hands, the result will be too
 		if (src in user.get_held_item_slots())
 			user.drop_from_inventory(src)

--- a/code/modules/food/cooking/_recipe.dm
+++ b/code/modules/food/cooking/_recipe.dm
@@ -198,6 +198,8 @@ var/global/list/_cooking_recipe_cache = list()
 
 // Create the actual result atom. Handled by a proc to allow for recipes to override it.
 /decl/recipe/proc/create_result_atom(atom/container, list/used_ingredients)
+	if(ispath(result, /obj/item/food))
+		return new result(container, null, TRUE) // Supply argument to skip plate creation.
 	return new result(container)
 
 /// Return a data list to pass to a reagent creation proc. Allows for overriding/mutation based on ingredients.

--- a/code/modules/food/utensils/_utensil.dm
+++ b/code/modules/food/utensils/_utensil.dm
@@ -62,19 +62,6 @@
 		if(check_state_in_icon(loaded_state, icon))
 			add_overlay(overlay_image(icon, loaded_state, loaded_food.reagents?.get_color() || loaded_food.filling_color || get_color(), RESET_COLOR))
 
-/obj/item/food
-	/// A type used when cloning this food item for utensils.
-	var/utensil_type
-	/// A set of utensil flags determining which utensil interactions are valid with this food.
-	var/utensil_flags = UTENSIL_FLAG_SCOOP | UTENSIL_FLAG_COLLECT
-
-/obj/item/food/Initialize()
-	. = ..()
-	if(isnull(utensil_type))
-		utensil_type = type
-	if(slice_path && slice_num)
-		utensil_flags |= UTENSIL_FLAG_SLICE
-
 // TODO: generalize this for edible non-food items somehow?
 /obj/item/food/proc/seperate_chunk(obj/item/utensil/utensil, mob/user)
 	if(!istype(utensil))
@@ -84,7 +71,7 @@
 
 		// Create a dummy copy of the target food item.
 		// This ensures we keep all food behavior, strings, sounds, etc.
-		utensil.loaded_food = new utensil_type(utensil)
+		utensil.loaded_food = new utensil_food_type(utensil, material?.type, TRUE)
 		QDEL_NULL(utensil.loaded_food.trash)
 		QDEL_NULL(utensil.loaded_food.plate)
 		utensil.loaded_food.color = color
@@ -160,7 +147,7 @@
 	return . || TRUE
 
 /obj/item/food/proc/create_slice()
-	return new slice_path(loc, material?.type)
+	return new slice_path(loc, material?.type, TRUE)
 
 /obj/item/food/proc/do_utensil_interaction(obj/item/tool, mob/user)
 

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -23,7 +23,7 @@
 		else if(!seeds_extracted && seed.min_seed_extracted)
 			to_chat(user, SPAN_NOTICE("With a knife, you could extract at least [seed.min_seed_extracted] seed\s."))
 
-/obj/item/food/grown/Initialize(mapload, material_key, _seed)
+/obj/item/food/grown/Initialize(mapload, material_key, skip_plate = FALSE, _seed)
 
 	if(isnull(seed) && _seed)
 		seed = _seed
@@ -65,7 +65,7 @@
 	if(!dried_type)
 		dried_type = type
 
-	. = ..(mapload) //Init reagents
+	. = ..(mapload, material_key, skip_plate) //Init reagents
 
 /obj/item/food/grown/initialize_reagents(populate)
 	if(reagents)
@@ -287,7 +287,7 @@ var/global/list/_wood_materials = list(
 	. = dry ? "dried [seed.grown_tag]" : seed.grown_tag
 
 /obj/item/food/grown/create_slice()
-	return new slice_path(loc, material?.type, seed)
+	return new slice_path(loc, material?.type, TRUE, seed)
 
 /obj/item/food/grown/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone)
 	. = ..()

--- a/code/modules/hydroponics/processed_grown.dm
+++ b/code/modules/hydroponics/processed_grown.dm
@@ -18,7 +18,7 @@
 	/// Used in recipes to distinguish between general types.
 	var/processed_grown_tag
 
-/obj/item/food/processed_grown/Initialize(mapload, material_key, _seed)
+/obj/item/food/processed_grown/Initialize(mapload, material_key, skip_plate = FALSE, _seed)
 
 	if(isnull(seed) && _seed)
 		seed = _seed
@@ -43,7 +43,7 @@
 	. = dry ? "dried [seed.grown_tag] [processed_grown_tag]" : "[seed.grown_tag] [processed_grown_tag]"
 
 /obj/item/food/processed_grown/create_slice()
-	return new slice_path(loc, material?.type, seed)
+	return new slice_path(loc, material?.type, TRUE, seed)
 
 /obj/item/food/processed_grown/proc/update_strings()
 	return

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -624,7 +624,11 @@
 				. += new product_type(get_turf(user), using_yield)
 		else
 			for(var/i = 1 to total_yield)
-				var/obj/item/product = new product_type(get_turf(user), null, src)
+				var/obj/item/product
+				if(ispath(product_type, /obj/item/food))
+					product = new product_type(get_turf(user), null, TRUE, src)
+				else
+					product = new product_type(get_turf(user), null, src)
 				. += product
 
 				if(get_trait(TRAIT_PRODUCT_COLOUR) && istype(product, /obj/item/food))

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -41,17 +41,28 @@
 	var/filling_color = "#ffffff" //Used by sandwiches.
 	var/trash
 	var/obj/item/plate/plate
+	/// A type used when cloning this food item for utensils.
+	var/utensil_food_type
+	/// A set of utensil flags determining which utensil interactions are valid with this food.
+	var/utensil_flags = UTENSIL_FLAG_SCOOP | UTENSIL_FLAG_COLLECT
 
-/obj/item/food/Initialize()
+/obj/item/food/Initialize(ml, material_key, skip_plate = FALSE)
 	. = ..()
 	if(cooked_food == FOOD_RAW)
 		name = "raw [name]"
-	if(ispath(plate))
-		plate = new plate(src)
 
-/obj/item/food/Initialize(ml, material_key)
-	. = ..()
+	if(skip_plate)
+		plate = null
+	else if(ispath(plate))
+		plate = new plate(src)
+	else if(!istype(plate))
+		plate = null
+
 	initialize_reagents()
+	if(isnull(utensil_food_type))
+		utensil_food_type = type
+	if(slice_path && slice_num)
+		utensil_flags |= UTENSIL_FLAG_SLICE
 
 /obj/item/food/initialize_reagents(populate = TRUE)
 	if(!reagents)

--- a/code/modules/reagents/reagent_containers/food/canned.dm
+++ b/code/modules/reagents/reagent_containers/food/canned.dm
@@ -13,7 +13,7 @@
 	var/sealed = TRUE
 	var/open_complexity = OPEN_HARD
 
-/obj/item/food/can/Initialize()
+/obj/item/food/can/Initialize(mapload, material_key, skip_plate = FALSE)
 	. = ..()
 	if(!sealed)
 		unseal()

--- a/code/modules/reagents/reagent_containers/food/jerky.dm
+++ b/code/modules/reagents/reagent_containers/food/jerky.dm
@@ -8,7 +8,7 @@
 	nutriment_amt = 5
 	var/meat_name = "meat"
 
-/obj/item/food/jerky/Initialize()
+/obj/item/food/jerky/Initialize(mapload, material_key, skip_plate = FALSE)
 	. = ..()
 	if(meat_name)
 		set_meat_name(meat_name)

--- a/code/modules/reagents/reagent_containers/food/sliceable.dm
+++ b/code/modules/reagents/reagent_containers/food/sliceable.dm
@@ -28,7 +28,7 @@
  *  whole item, transferring the reagents and deleting the whole item, which may
  *  have performance implications.
  */
-/obj/item/food/slice/Initialize()
+/obj/item/food/slice/Initialize(mapload, material_key, skip_plate = FALSE)
 	. = ..()
 	if(filled)
 		var/obj/item/food/whole = new whole_path()

--- a/code/modules/reagents/reagent_containers/food/sushi.dm
+++ b/code/modules/reagents/reagent_containers/food/sushi.dm
@@ -6,8 +6,8 @@
 	bitesize = 1
 	var/fish_type = "fish"
 
-/obj/item/food/sushi/Initialize(mapload, var/obj/item/food/rice, var/obj/item/food/topping)
-	. = ..(mapload)
+/obj/item/food/sushi/Initialize(mapload, material_key, skip_plate = FALSE, obj/item/food/rice, obj/item/food/topping)
+	. = ..(mapload, material_key, skip_plate)
 
 	if(istype(topping))
 		for(var/taste_thing in topping.nutriment_desc)
@@ -61,9 +61,10 @@
 	var/fish_type = "fish"
 	var/slices = 1
 
-/obj/item/food/sashimi/Initialize(mapload, material_key, var/_fish_type)
-	. = ..(mapload)
-	if(_fish_type) fish_type = _fish_type
+/obj/item/food/sashimi/Initialize(mapload, material_key, skip_plate = FALSE, _fish_type)
+	. = ..(mapload, material_key, skip_plate)
+	if(_fish_type)
+		fish_type = _fish_type
 	name = "[fish_type] sashimi"
 	update_icon()
 
@@ -104,7 +105,7 @@
 		else
 			if(!user.try_unequip(I))
 				return
-			new /obj/item/food/sushi(get_turf(src), I, src)
+			new /obj/item/food/sushi(get_turf(src), null, TRUE, I, src)
 		return
 	. = ..()
 
@@ -116,36 +117,39 @@
 			if(sashimi.slices > 1)
 				to_chat(user, "<span class='warning'>Putting more than one slice of fish on your sushi is just greedy.</span>")
 			else
-				new /obj/item/food/sushi(get_turf(src), src, I)
+				new /obj/item/food/sushi(get_turf(src), null, TRUE, src, I)
 			return
-		if(istype(I, /obj/item/food/friedegg) || \
-		 istype(I, /obj/item/food/tofu) || \
-		 istype(I, /obj/item/food/butchery/cutlet) || \
-		 istype(I, /obj/item/food/butchery/cutlet/raw) || \
-		 istype(I, /obj/item/food/spider) || \
-		 istype(I, /obj/item/food/butchery/meat/chicken))
-			new /obj/item/food/sushi(get_turf(src), src, I)
+		var/static/list/sushi_types = list(
+			/obj/item/food/friedegg,
+			/obj/item/food/tofu,
+			/obj/item/food/butchery/cutlet,
+			/obj/item/food/butchery/cutlet/raw,
+			/obj/item/food/spider,
+			/obj/item/food/butchery/meat/chicken
+		)
+		if(is_type_in_list(I, sushi_types))
+			new /obj/item/food/sushi(get_turf(src), null, TRUE, src, I)
 			return
 	. = ..()
 // Used for turning other food into sushi.
 /obj/item/food/friedegg/attackby(var/obj/item/I, var/mob/user)
 	if((locate(/obj/structure/table) in loc) && istype(I, /obj/item/food/boiledrice))
-		new /obj/item/food/sushi(get_turf(src), I, src)
+		new /obj/item/food/sushi(get_turf(src), null, TRUE, I, src)
 		return
 	. = ..()
 /obj/item/food/tofu/attackby(var/obj/item/I, var/mob/user)
 	if((locate(/obj/structure/table) in loc) && istype(I, /obj/item/food/boiledrice))
-		new /obj/item/food/sushi(get_turf(src), I, src)
+		new /obj/item/food/sushi(get_turf(src), null, TRUE, I, src)
 		return
 	. = ..()
 /obj/item/food/butchery/cutlet/raw/attackby(var/obj/item/I, var/mob/user)
 	if((locate(/obj/structure/table) in loc) && istype(I, /obj/item/food/boiledrice))
-		new /obj/item/food/sushi(get_turf(src), I, src)
+		new /obj/item/food/sushi(get_turf(src), null, TRUE, I, src)
 		return
 	. = ..()
 /obj/item/food/butchery/cutlet/attackby(var/obj/item/I, var/mob/user)
 	if((locate(/obj/structure/table) in loc) && istype(I, /obj/item/food/boiledrice))
-		new /obj/item/food/sushi(get_turf(src), I, src)
+		new /obj/item/food/sushi(get_turf(src), null, TRUE, I, src)
 		return
 	. = ..()
 // End non-fish sushi.


### PR DESCRIPTION
## Description of changes
- Adds a parameter to food init to skip creating a plate.
- Updating parameters in other food spawning to use the parameter.
- Adding code to food combination to take a plate if one is available.

## Why and what will this PR improve
Broader fix for potato fries getting a plate ex nihilo.

## Authorship
Myself.

## Changelog
Nothing player-facing hopefully.