### PR TITLE
Change produce bin to use seed product name as a key

### DIFF
--- a/code/datums/extensions/storage/_storage_ui.dm
+++ b/code/datums/extensions/storage/_storage_ui.dm
@@ -285,10 +285,16 @@
 		user.client.screen -= storage_end
 		user.client.screen += boxes
 
+/// Returns a key (not necessarily a string) to group objects by.
+/datum/storage_ui/default/produce_bin/proc/get_key_for_object(obj/item/food/grown/produce)
+	if(!istype(produce) || !produce.seed)
+		return produce // should never happen, but it's a fallback nonetheless
+	return produce.seed.product_name || produce.seed.name
+
 /datum/storage_ui/default/produce_bin/proc/get_seed_counts()
 	var/list/counts = list()
 	for(var/obj/item/food/grown/produce in _storage.get_contents())
-		counts[produce.seed.name]++
+		counts[get_key_for_object(produce)]++
 	return counts
 
 //This proc determins the size of the inventory to be displayed. Please touch it only if you know what you're doing.
@@ -308,13 +314,14 @@
 	var/list/counts = get_seed_counts()
 	var/list/displayed = list()
 	for(var/obj/item/food/grown/produce in _storage.get_contents())
-		if(displayed[produce.seed.name])
+		var/produce_key = get_key_for_object(produce)
+		if(displayed[produce_key])
 			continue
-		displayed[produce.seed.name] = TRUE
+		displayed[produce_key] = TRUE
 		produce.screen_loc = "LEFT+[cx]:[SCREEN_LOC_MOD_DIVIDED],BOTTOM+[cy]:[SCREEN_LOC_MOD_DIVIDED]"
 		produce.maptext_x = 2
 		produce.maptext_y = 2
-		produce.maptext = STYLE_SMALLFONTS_OUTLINE(counts[produce.seed.name], 6, COLOR_WHITE, COLOR_BLACK)
+		produce.maptext = STYLE_SMALLFONTS_OUTLINE(counts[produce_key], 6, COLOR_WHITE, COLOR_BLACK)
 		produce.hud_layerise()
 		cx++
 		if (cx > (SCREEN_LOC_MOD_FIRST + cols))


### PR DESCRIPTION
## Description of changes
Makes produce bins use seeds' product_name as a grouping key so that produce from diverged lines don't show separately. An apple is an apple, a coffee cherry is a coffee cherry, etc.

## Why and what will this PR improve
Fixes produce from diverged lines showing separately (which will be important if we ever add any kind of selective breeding/artificial selection mechanics to Pyrelight).