### PR TITLE
Bows are now used by clicking and holding.

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -135,7 +135,7 @@
 		deltimer(autofiring_timer)
 		autofiring_timer = null
 
-/obj/item/gun/proc/handle_autofire(var/autoturn)
+/obj/item/gun/proc/handle_autofire(autoturn)
 	set waitfor = FALSE
 	. = TRUE
 	if(QDELETED(autofiring_at) || QDELETED(autofiring_by))
@@ -145,9 +145,12 @@
 	if(!.)
 		clear_autofire()
 	else if(can_autofire())
-		if(autoturn)
-			autofiring_by.set_dir(get_dir(src, autofiring_at))
-		Fire(autofiring_at, autofiring_by, null, (get_dist(autofiring_at, autofiring_by) <= 1), FALSE, FALSE)
+		try_autofire(autoturn)
+
+/obj/item/gun/proc/try_autofire(autoturn)
+	if(autoturn)
+		autofiring_by.set_dir(get_dir(src, autofiring_at))
+	Fire(autofiring_at, autofiring_by, null, (get_dist(autofiring_at, autofiring_by) <= 1), FALSE, FALSE)
 
 /obj/item/gun/update_twohanding()
 	if(one_hand_penalty)

--- a/code/modules/projectiles/guns/launcher/bows/bow_drawing.dm
+++ b/code/modules/projectiles/guns/launcher/bows/bow_drawing.dm
@@ -1,15 +1,17 @@
 /obj/item/gun/launcher/bow/proc/get_loaded_arrow(mob/user)
 	return _loaded
 
-/obj/item/gun/launcher/bow/proc/get_draw_time()
-	return draw_time
+/obj/item/gun/launcher/bow/proc/get_draw_time(mob/firer)
+	. = draw_time
+	if(firer)
+		. = max(1, round(draw_time * firer.skill_delay_mult(work_skill)))
 
 /obj/item/gun/launcher/bow/proc/check_can_draw(mob/user)
 	return istype(user) && !QDELETED(user) && !QDELETED(src) && istype(string) && !QDELETED(string) && (!require_loaded_to_draw || get_loaded_arrow(user))
 
 /obj/item/gun/launcher/bow/proc/start_drawing(var/mob/user)
 
-	if(tension != 0)
+	if(tension != 0 || autofire_enabled)
 		return
 
 	if(!get_loaded_arrow(user) && require_loaded_to_draw)

--- a/code/modules/projectiles/guns/launcher/bows/bow_interaction.dm
+++ b/code/modules/projectiles/guns/launcher/bows/bow_interaction.dm
@@ -4,18 +4,23 @@
 		relax_tension(user)
 		return TRUE
 
-	if(!get_loaded_arrow(user) && user.skill_check(SKILL_WEAPONS, SKILL_ADEPT))
-		for(var/obj/item/stack/material/bow_ammo/ammo in user.get_inactive_held_items())
-			attackby(ammo, user)
-			if(get_loaded_arrow(user))
-				start_drawing(user)
-				return TRUE
+	if(!get_loaded_arrow(user) && !autofire_enabled && user.skill_check(SKILL_WEAPONS, SKILL_ADEPT) && load_available_ammo(user))
+		return TRUE
 
-	if(get_loaded_arrow(user))
+	if(!autofire_enabled && get_loaded_arrow(user))
 		start_drawing(user)
 		return TRUE
 
 	return ..()
+
+/obj/item/gun/launcher/bow/proc/load_available_ammo(mob/living/user)
+	for(var/obj/item/stack/material/bow_ammo/ammo in user.get_inactive_held_items())
+		attackby(ammo, user)
+		if(get_loaded_arrow(user))
+			if(!autofire_enabled)
+				start_drawing(user)
+			return TRUE
+	return FALSE
 
 /obj/item/gun/launcher/bow/attack_hand(mob/user)
 	if(user.is_holding_offhand(src))
@@ -59,10 +64,12 @@
 	update_icon()
 
 /obj/item/gun/launcher/bow/proc/relax_tension(mob/user)
-	if(user)
-		show_string_relax_message(user)
 	tension = 0
 	update_icon()
+	if(autofire_enabled)
+		clear_autofire()
+	else if(user)
+		show_string_relax_message(user)
 
 /obj/item/gun/launcher/bow/proc/try_string(mob/user, obj/item/bowstring/new_string)
 	if(string)

--- a/code/modules/projectiles/guns/launcher/bows/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/bows/crossbow.dm
@@ -10,6 +10,7 @@
 	bow_ammo_type = /obj/item/stack/material/bow_ammo/bolt
 	draw_time = 2 SECONDS
 	release_speed = 18
+	autofire_enabled = FALSE
 
 /obj/item/gun/launcher/bow/crossbow/show_load_message(mob/user)
 	if(user)


### PR DESCRIPTION
## Description of changes
- Bows are drawn by clicking and holding.
- Crossbows are still manually drawn.

## Why and what will this PR improve
You can move while drawing a bow, and it feels a lot more natural.

## Authorship
Myself.

## Changelog
:cl:
tweak: Bows are now drawn by clicking and holding.
/:cl:
