### PR TITLE
Adding skill checks and damage to shields.

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -37,12 +37,16 @@
 /obj/item/shield/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
 	if(user.incapacitated())
 		return 0
-
 	//block as long as they are not directly behind us
 	var/bad_arc = user.dir && global.reverse_dir[user.dir] //arc of directions from which we cannot block
 	if(check_shield_arc(user, bad_arc, damage_source, attacker))
-		if(prob(get_block_chance(user, damage, damage_source, attacker)))
+		var/block_chance = get_block_chance(user, damage, damage_source, attacker)
+		if(attacker)
+			block_chance = max(0, block_chance - 10 * attacker.get_skill_difference(SKILL_COMBAT, user))
+		if(prob(block_chance))
 			user.visible_message("<span class='danger'>\The [user] blocks [attack_text] with \the [src]!</span>")
+			if(max_health != ITEM_HEALTH_NO_DAMAGE)
+				take_damage(damage)
 			return 1
 	return 0
 
@@ -126,6 +130,7 @@
 	material = /decl/material/solid/metal/steel
 	matter = list(/decl/material/solid/organic/wood = MATTER_AMOUNT_REINFORCEMENT)
 	attack_verb = list("shoved", "bashed")
+	max_health = 250
 
 /obj/item/shield/buckler/handle_shield(mob/user)
 	. = ..()

--- a/code/modules/mob/living/human/human_attackhand.dm
+++ b/code/modules/mob/living/human/human_attackhand.dm
@@ -231,7 +231,7 @@
 	// Should this all be in Touch()?
 		var/mob/living/human/H = user
 		if(istype(H))
-			if(H != src && check_shields(0, null, H, H.get_target_zone(), H.name))
+			if(H != src && check_shields(0, null, H, H.get_target_zone(), H))
 				H.do_attack_animation(src)
 				return TRUE
 

--- a/code/modules/mob/living/human/human_defense.dm
+++ b/code/modules/mob/living/human/human_defense.dm
@@ -14,7 +14,7 @@ meteor_act
 		return PROJECTILE_FORCE_MISS //if they don't have the organ in question then the projectile just passes by.
 
 	//Shields
-	var/shield_check = check_shields(P.damage, P, null, def_zone, "the [P.name]")
+	var/shield_check = check_shields(P.damage, P, null, def_zone, P)
 	if(shield_check)
 		if(shield_check < 0)
 			return shield_check
@@ -119,7 +119,7 @@ meteor_act
 		visible_message("<span class='danger'>\The [user] misses [src] with \the [I]!</span>")
 		return null
 
-	if(check_shields(I.force, I, user, target_zone, "the [I.name]"))
+	if(check_shields(I.force, I, user, target_zone, I))
 		return null
 
 	var/obj/item/organ/external/affecting = GET_EXTERNAL_ORGAN(src, hit_zone)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -175,7 +175,7 @@
 	zone = get_zone_with_miss_chance(zone, src, miss_chance, ranged_attack=1)
 
 	if(zone && TT?.thrower && TT.thrower != src)
-		var/shield_check = check_shields(throw_damage, O, TT.thrower, zone, "[O]")
+		var/shield_check = check_shields(throw_damage, O, TT.thrower, zone, O)
 		if(shield_check == PROJECTILE_FORCE_MISS)
 			zone = null
 		else if(shield_check)
@@ -436,6 +436,8 @@
 	var/obj/item/suit = get_equipped_item(slot_wear_suit_str)
 	if(suit)
 		LAZYDISTINCTADD(checking_slots, suit)
+	if(isatom(attack_text))
+		attack_text = "\the [attack_text]"
 	for(var/obj/item/shield in checking_slots)
 		if(shield.handle_shield(src, damage, damage_source, attacker, def_zone, attack_text))
 			return TRUE

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -280,7 +280,7 @@
 
 		var/hit_area = affecting.name
 
-		if((user != target) && H.check_shields(7, src, user, "\the [src]"))
+		if((user != target) && H.check_shields(7, src, user, target_zone, src))
 			return
 
 		if (target != user && H.get_blocked_ratio(target_zone, BRUTE, damage_flags=DAM_SHARP) > 0.1 && prob(50))

--- a/mods/content/psionics/system/psionics/mob/mob.dm
+++ b/mods/content/psionics/system/psionics/mob/mob.dm
@@ -33,7 +33,7 @@
 	var/obj/item/projectile/P = damage_source
 	var/datum/ability_handler/psionics/psi = get_ability_handler(/datum/ability_handler/psionics)
 	if(istype(P) && !P.disrupts_psionics() && psi && P.starting && prob(psi.get_armour(SSmaterials.get_armor_key(P.atom_damage_type, P.damage_flags())) * 0.5) && psi.spend_power(round(damage/10)))
-		visible_message("<span class='danger'>\The [src] deflects [attack_text]!</span>")
+		visible_message(SPAN_DANGER("\The [src] deflects [isatom(attack_text) ? "\the [attack_text]" : attack_text]!"))
 		P.redirect(P.starting.x + rand(-2,2), P.starting.y + rand(-2,2), get_turf(src), src)
 		return PROJECTILE_FORCE_MISS
 	. = ..()


### PR DESCRIPTION
## Description of changes
- Close combat skill is factored into shield blocking just like it is for parrying.
- Bucklers degrade when blocking damage.

## Why and what will this PR improve
- Melee combat is less awful against default skillsets.
- Bucklers are less impossible to bypass.

## Authorship
Myself.

## Changelog
:cl:
tweak: Blocking with a shield now uses close combat skill, and bucklers will not survive forever.
/:cl: