### PR TITLE
Upstream various tweaks from Pyrelight anima branch

### DIFF
--- a/code/game/objects/effects/fake_fire.dm
+++ b/code/game/objects/effects/fake_fire.dm
@@ -33,17 +33,25 @@
 	if(lifetime)
 		QDEL_IN(src,lifetime)
 
+/obj/effect/fake_fire/proc/can_affect_atom(atom/target)
+	if(target == src)
+		return FALSE
+	return target.simulated
+
+/obj/effect/fake_fire/proc/can_affect_mob(mob/living/victim)
+	return can_affect_atom(victim)
+
 /obj/effect/fake_fire/Process()
 	if(!loc)
 		qdel(src)
 		return PROCESS_KILL
 	for(var/mob/living/victim in loc)
-		if(!victim.simulated)
+		if(!can_affect_mob(victim))
 			continue
 		victim.FireBurn(firelevel, last_temperature, pressure)
 	loc.fire_act(firelevel, last_temperature, pressure)
 	for(var/atom/burned in loc)
-		if(!burned.simulated || burned == src)
+		if(!can_affect_atom(burned))
 			continue
 		burned.fire_act(firelevel, last_temperature, pressure)
 
@@ -53,4 +61,17 @@
 
 /obj/effect/fake_fire/Destroy()
 	STOP_PROCESSING(SSobj,src)
-	. = ..()
+	return ..()
+
+// A subtype of fake_fire used for spells that shouldn't affect the caster.
+/obj/effect/fake_fire/variable/owned
+	var/mob/living/owner
+
+/obj/effect/fake_fire/variable/owned/can_affect_atom(atom/target)
+	if(target == owner)
+		return FALSE
+	return ..()
+
+/obj/effect/fake_fire/variable/owned/Destroy()
+	owner = null
+	return ..()

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -88,7 +88,7 @@
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	do_flash_animation(user, target)
 
-	if(target.stat != DEAD && target.handle_flashed(src, rand(str_min,str_max)))
+	if(target.stat != DEAD && target.handle_flashed(rand(str_min,str_max)))
 		admin_attack_log(user, target, "flashed their victim using \a [src].", "Was flashed by \a [src].", "used \a [src] to flash")
 		if(!target.isSynthetic())
 			user.visible_message(SPAN_DANGER("\The [user] blinds \the [target] with \the [src]!"))
@@ -105,7 +105,7 @@
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	do_flash_animation(user)
 	for(var/mob/living/M in oviewers(3, null))
-		M.handle_flashed(src, rand(str_min,str_max))
+		M.handle_flashed(rand(str_min,str_max))
 	return TRUE
 
 /obj/item/flash/emp_act(severity)
@@ -113,7 +113,7 @@
 		return FALSE
 	do_flash_animation()
 	for(var/mob/living/M in oviewers(3, null))
-		M.handle_flashed(src, rand(str_min,str_max))
+		M.handle_flashed(rand(str_min,str_max))
 
 /obj/item/flash/synthetic //not for regular use, weaker effects
 	name = "modified flash"

--- a/code/game/turfs/floors/natural/natural_mud.dm
+++ b/code/game/turfs/floors/natural/natural_mud.dm
@@ -36,7 +36,9 @@
 	return ..()
 
 /turf/floor/natural/mud/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	if(!reagents?.total_volume)
+	// scaling taken from /turf/floor/natural/grass/wild/fire_act
+	// smoothly scale between 1/5 chance to scorch at the boiling point of water and 100% chance to scorch at boiling point * 4
+	if(!reagents?.total_volume && temperature >= /decl/material/liquid/water::boiling_point && prob(20 + temperature * 80 / (/decl/material/liquid/water::boiling_point * 4)))
 		ChangeTurf(/turf/floor/natural/dry, keep_air = TRUE, keep_height = TRUE)
 		return
 	return ..()

--- a/code/modules/mob/living/human/human.dm
+++ b/code/modules/mob/living/human/human.dm
@@ -1024,7 +1024,7 @@
 /mob/living/human/proc/post_setup(species_name, datum/mob_snapshot/supplied_appearance)
 	try_refresh_visible_overlays() //Do this exactly once per setup
 
-/mob/living/human/handle_flashed(var/obj/item/flash/flash, var/flash_strength)
+/mob/living/human/handle_flashed(var/flash_strength)
 	var/safety = eyecheck()
 	if(safety < FLASH_PROTECTION_MODERATE)
 		flash_strength = round(get_flash_mod() * flash_strength)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1632,7 +1632,7 @@ default behaviour is:
 		return range * range - 0.333
 	return range
 
-/mob/living/handle_flashed(var/obj/item/flash/flash, var/flash_strength)
+/mob/living/handle_flashed(var/flash_strength)
 
 	var/safety = eyecheck()
 	if(safety >= FLASH_PROTECTION_MODERATE || flash_strength <= 0) // May be modified by human proc.

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -424,7 +424,7 @@
 	if(os)
 		os.Process()
 
-/mob/living/silicon/handle_flashed(var/obj/item/flash/flash, var/flash_strength)
+/mob/living/silicon/handle_flashed(var/flash_strength)
 	SET_STATUS_MAX(src, STAT_PARA, flash_strength)
 	SET_STATUS_MAX(src, STAT_WEAK, flash_strength)
 	return TRUE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1192,7 +1192,7 @@
 
 	return FALSE
 
-/mob/proc/handle_flashed(var/obj/item/flash/flash, var/flash_strength)
+/mob/proc/handle_flashed(var/flash_strength)
 	return FALSE
 
 /mob/proc/do_flash_animation()


### PR DESCRIPTION
## Description of changes
- `handle_flashed` no longer requires a flash as an argument; it wasn't actually used anyway and I felt weird just having things pass `null` as the first argument.
- Mud drying in `fire_act()` is now probabilistic based on temperature.
- Fake fire has been rewritten slightly, with `can_affect_atom()` and `can_affect_mob()` helpers. This could allow for more complex things in the future like faction-aligned fire, but for now...
- Adds an 'owned' subtype of fake fire, useful for fire spells that don't hurt the caster downstream.

## Why and what will this PR improve
Mostly just necessary changes for downstream magic system stuff.