### PR TITLE
Fixes from August 10, 2024 Pyrelight testing

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -84,10 +84,9 @@
 
 	a_intent = I_HURT
 	. = A.attackby(attacking_with, src)
+	// attack effects are handled in natural_weapon's apply_hit_effect() instead of here
 	if(!.)
 		reset_offsets(anim_time = 2)
-	else if(isliving(A))
-		apply_attack_effects(A)
 
 // Attack hand but for simple animals
 /atom/proc/attack_animal(mob/user)

--- a/code/datums/traits/maluses/amputations.dm
+++ b/code/datums/traits/maluses/amputations.dm
@@ -38,7 +38,7 @@
 /decl/trait/malus/amputation/applies_to_organ(var/organ)
 	return (organ in apply_to_limbs)
 
-/decl/trait/malus/amputation/is_available_to(datum/preferences/pref)
+/decl/trait/malus/amputation/is_available_to_select(datum/preferences/pref)
 	. = ..()
 	if(. && pref.bodytype)
 		var/decl/bodytype/mob_bodytype = pref.get_bodytype_decl()

--- a/code/datums/traits/prosthetics/prosthetic_organs.dm
+++ b/code/datums/traits/prosthetics/prosthetic_organs.dm
@@ -9,7 +9,7 @@
 	var/synthetic_bodytype_restricted = FALSE
 	var/apply_to_organ = BP_HEART
 
-/decl/trait/prosthetic_organ/is_available_to(datum/preferences/pref)
+/decl/trait/prosthetic_organ/is_available_to_select(datum/preferences/pref)
 	. = ..()
 	if(. && pref.species && pref.bodytype)
 

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -100,6 +100,9 @@ steam.start() -- spawns the effect
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
 	pass_flags = PASS_FLAG_TABLE
 	var/spark_sound = "sparks"
+	var/lit_light_range = 1
+	var/lit_light_power = 0.5
+	var/lit_light_color = COLOR_MUZZLE_FLASH
 
 /obj/effect/sparks/struck
 	spark_sound = "light_bic"
@@ -108,6 +111,7 @@ steam.start() -- spawns the effect
 	. = ..()
 	QDEL_IN(src, 5 SECONDS)
 	playsound(loc, spark_sound, 100, 1)
+	set_light(lit_light_range, lit_light_power, lit_light_color)
 	if(isturf(loc))
 		var/turf/T = loc
 		T.spark_act()

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -109,7 +109,9 @@ steam.start() -- spawns the effect
 
 /obj/effect/sparks/Initialize()
 	. = ..()
-	QDEL_IN(src, 5 SECONDS)
+	// this is 2 seconds so that it doesn't appear to freeze after its last move, which ends up making it look like timers are broken
+	// if you change the number of or delay between moves in spread(), this may need to be changed
+	QDEL_IN(src, 2 SECONDS)
 	playsound(loc, spark_sound, 100, 1)
 	set_light(lit_light_range, lit_light_power, lit_light_color)
 	if(isturf(loc))

--- a/code/game/objects/items/flame/flame_torch.dm
+++ b/code/game/objects/items/flame/flame_torch.dm
@@ -25,7 +25,13 @@
 	return available_scents
 
 /obj/item/flame/torch/light(mob/user, no_message)
-	. = !burnt && ..()
+	if(coating?.total_volume && coating.get_accelerant_value() < FUEL_VALUE_NONE)
+		to_chat(user, SPAN_WARNING("You cannot light \the [src] while it is wet!"))
+		return FALSE
+	if(burnt)
+		to_chat(user, SPAN_WARNING("\The [src] is burnt up."))
+		return FALSE
+	return ..()
 
 /obj/item/flame/torch/Initialize(var/ml, var/material_key, var/_head_material)
 	. = ..()

--- a/code/game/objects/items/flame/flame_torch.dm
+++ b/code/game/objects/items/flame/flame_torch.dm
@@ -47,7 +47,7 @@
 
 /obj/item/flame/torch/extinguish(var/mob/user, var/no_message)
 	. = ..()
-	if(. && !burnt)
+	if(. && _fuel <= 0 && !burnt)
 		burnt = TRUE
 		name = "burnt torch"
 		desc = "A torch. This one has seen better days."

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -257,7 +257,7 @@
 				var/list/metadata_strings = list()
 				for(var/metadata_type in accessory_decl.accessory_metadata_types)
 					var/decl/sprite_accessory_metadata/sam = GET_DECL(metadata_type)
-					metadata_strings += sam.get_metadata_options_string(src, accessory_cat_decl, accessory_decl, accessory_metadata[metadata_type])
+					metadata_strings += sam.get_metadata_options_string(src, accessory_cat_decl, accessory_decl, LAZYACCESS(accessory_metadata, metadata_type))
 				var/acc_decl_ref = "\ref[accessory_decl]"
 				. += "<tr>"
 				. += "<td width = '100px'><b>[accessory_cat_decl.name]</b></td>"

--- a/code/modules/client/preference_setup/general/03_traits.dm
+++ b/code/modules/client/preference_setup/general/03_traits.dm
@@ -7,7 +7,7 @@
 		removed_something = FALSE
 		for(var/trait_type in traits)
 			var/decl/trait/trait = GET_DECL(trait_type)
-			if(!istype(trait) || !trait.is_available_to(src) || (trait.parent && !(trait.parent.type in traits)))
+			if(!istype(trait) || !trait.is_available_to_select(src) || (trait.parent && !(trait.parent.type in traits)))
 				traits -= trait_type
 				removed_something = TRUE
 			else if(length(trait.incompatible_with))
@@ -95,7 +95,7 @@
 		if(trait_category.hide_from_chargen)
 			continue
 		for(var/decl/trait/trait as anything in trait_category.items)
-			if(trait.is_available_to(pref))
+			if(trait.is_available_to_select(pref))
 				available_categories[trait_category.name] = trait_category
 				break
 	if(!length(available_categories))
@@ -127,7 +127,7 @@
 			if(trait.type in pref.traits)
 				trait_spent += trait.trait_cost
 
-			if(trait_category_id == selected_category && !trait.parent && trait.is_available_at_chargen())
+			if(trait_category_id == selected_category && !trait.parent && trait.is_available_to_select(pref))
 				body += trait.get_trait_selection_data(src, pref.traits)
 
 		var/category_label = trait_category.name

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -386,9 +386,10 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 		vapor_products               = null
 		compost_value                = 0
 	else if(isnull(temperature_damage_threshold))
-		for(var/value in list(melting_point, boiling_point, heating_point))
-			if(!isnull(value) && (isnull(temperature_damage_threshold) || temperature_damage_threshold > value))
-				temperature_damage_threshold = value
+		var/new_temperature_damage_threshold = max(melting_point, boiling_point, heating_point)
+		// Don't let the threshold be lower than the ignition point.
+		if(!isnull(new_temperature_damage_threshold) && (isnull(ignition_point) || (new_temperature_damage_threshold > ignition_point)))
+			temperature_damage_threshold = new_temperature_damage_threshold
 
 	if(!shard_icon)
 		shard_icon = shard_type

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -386,7 +386,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 		vapor_products               = null
 		compost_value                = 0
 	else if(isnull(temperature_damage_threshold))
-		for(var/value in list(ignition_point, melting_point, boiling_point, heating_point, bakes_into_at_temperature))
+		for(var/value in list(melting_point, boiling_point, heating_point))
 			if(!isnull(value) && (isnull(temperature_damage_threshold) || temperature_damage_threshold > value))
 				temperature_damage_threshold = value
 
@@ -426,10 +426,29 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 		. += "no construction difficulty set"
 
 	if(!isnull(bakes_into_at_temperature))
-		if(!isnull(melting_point) && melting_point <= bakes_into_at_temperature)
-			. += "baking point is set but melting point is lower or equal to it"
-		if(!isnull(boiling_point) && boiling_point <= bakes_into_at_temperature)
-			. += "baking point is set but boiling point is lower or equal to it"
+		// all of these variables should be above our baking temperature, because we assume only solids not currently on fire can bake
+		// modify this if a material ever needs to bake while liquid or gaseous
+		var/list/temperatures = list("melting point" = melting_point, "boiling point" = boiling_point, "heating point" = heating_point, "ignition point" = ignition_point)
+		for(var/temperature in temperatures)
+			if(isnull(temperatures[temperature]))
+				continue
+			if(temperatures[temperature] <= bakes_into_at_temperature)
+				. += "baking point is set but [temperature] is lower or equal to it"
+
+	// this is a little overengineered for only two values...
+	// but requiring heating_point > boiling_point caused a bunch of issues
+	// at least it's easy to add more if we want to enforce order more
+	var/list/transition_temperatures_ascending = list("melting point" = melting_point, "boiling point" = boiling_point)
+	var/max_key // if not null, this is a key from the above list
+	for(var/temperature_key in transition_temperatures_ascending)
+		var/temperature = transition_temperatures_ascending[temperature_key]
+		if(isnull(temperature))
+			continue
+		if(!isnull(max_key) && temperature <= transition_temperatures_ascending[max_key])
+			var/expected_temp = transition_temperatures_ascending[max_key]
+			. += "transition temperature [temperature_key] ([temperature]K, [temperature - T0C]C) is colder than [max_key], expected >[expected_temp]K ([expected_temp - T0C]C)!"
+		else
+			max_key = temperature_key
 
 	if(accelerant_value > FUEL_VALUE_NONE && isnull(ignition_point))
 		. += "accelerant value larger than zero but null ignition point"

--- a/code/modules/materials/definitions/gasses/material_gas_mundane.dm
+++ b/code/modules/materials/definitions/gasses/material_gas_mundane.dm
@@ -21,6 +21,7 @@
 	gas_specific_heat = 80
 	molar_mass = 0.004
 	latent_heat = 21
+	melting_point = 0 // Helium does not ever freeze at standard pressure, but this temperature rises at higher pressures.
 	boiling_point = -269 CELSIUS
 	gas_symbol_html = "He"
 	gas_symbol = "He"
@@ -40,6 +41,7 @@
 	molar_mass = 0.044
 	latent_heat = 380
 	boiling_point = -78 CELSIUS
+	melting_point = null // at standard pressure it never becomes a liquid, it can only be a gas or solid
 	gas_symbol_html = "CO<sub>2</sub>"
 	gas_symbol = "CO2"
 	gas_metabolically_inert = TRUE
@@ -222,6 +224,7 @@
 	gas_specific_heat = 20
 	molar_mass = 0.02
 	latent_heat = 86
+	melting_point = -249 CELSIUS
 	boiling_point = -246 CELSIUS
 	gas_symbol_html = "Ne"
 	gas_symbol = "Ne"
@@ -307,6 +310,7 @@
 	gas_specific_heat = 100
 	molar_mass = 0.002
 	latent_heat = 454
+	melting_point = -259 CELSIUS
 	boiling_point = -252 CELSIUS
 	gas_flags = XGM_GAS_FUEL
 	burn_product = /decl/material/liquid/water
@@ -326,6 +330,8 @@
 	color = "#777777"
 	stack_origin_tech = @'{"materials":5}'
 	value = 0.45
+	melting_point = -252 CELSIUS
+	boiling_point = -248 CELSIUS
 	gas_symbol_html = "T"
 	gas_symbol = "T"
 	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
@@ -343,6 +349,8 @@
 	gas_symbol_html = "D"
 	gas_symbol = "D"
 	value = 0.5
+	melting_point = -254 CELSIUS
+	boiling_point = -250 CELSIUS
 	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
 	exoplanet_rarity_gas = MAT_RARITY_UNCOMMON
 

--- a/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
@@ -40,6 +40,7 @@
 	metabolism = REM * 0.25
 	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
 	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
+	compost_value = 0.1 // a pittance, but it's so that compost bins don't end up filled with uncompostable amatoxin
 
 /decl/material/liquid/carpotoxin
 	name = "carpotoxin"
@@ -58,6 +59,7 @@
 	metabolism = REM * 0.25
 	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
 	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
+	compost_value = 0.3 // a bit more than amatoxin or wax, but still not much
 
 /decl/material/liquid/venom
 	name = "spider venom"
@@ -76,6 +78,7 @@
 	metabolism = REM * 0.25
 	exoplanet_rarity_plant = MAT_RARITY_UNCOMMON
 	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
+	compost_value = 0.3 // a bit more than amatoxin or wax, but still not much
 
 /decl/material/liquid/venom/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(prob(REAGENT_VOLUME(holder, type)*2))

--- a/code/modules/mob/living/simple_animal/natural_weapons.dm
+++ b/code/modules/mob/living/simple_animal/natural_weapons.dm
@@ -16,6 +16,13 @@
 /obj/item/natural_weapon/can_embed()
 	return FALSE
 
+/obj/item/natural_weapon/apply_hit_effect(mob/living/target, mob/living/user, hit_zone)
+	if(!(. = ..()))
+		return
+	if(istype(user, /mob/living/simple_animal))
+		var/mob/living/simple_animal/animal = user
+		animal.apply_attack_effects(target)
+
 /obj/item/natural_weapon/bite
 	name = "teeth"
 	attack_verb = list("bitten")

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -357,6 +357,12 @@ var/global/obj/temp_reagents_holder = new
 		. += current.dirtiness
 	return . / length(reagent_volumes)
 
+/datum/reagents/proc/get_accelerant_value()
+	for(var/rtype in reagent_volumes)
+		var/decl/material/current = GET_DECL(rtype)
+		. += current.accelerant_value
+	return . / length(reagent_volumes)
+
 /* Holder-to-holder and similar procs */
 /datum/reagents/proc/remove_any(var/amount = 1, var/defer_update = FALSE) // Removes up to [amount] of reagents from [src]. Returns actual amount removed.
 

--- a/code/modules/reagents/chems/chems_drugs.dm
+++ b/code/modules/reagents/chems/chems_drugs.dm
@@ -140,6 +140,7 @@
 	euphoriant = 30
 	fruit_descriptor = "hallucinogenic"
 	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
+	compost_value = 0.1 // a pittance, but it's so that compost bins don't end up filled with uncompostable psychotropics
 	uid = "chem_psychotropics"
 
 /decl/material/liquid/psychotropics/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)

--- a/mods/content/fantasy/datum/overrides.dm
+++ b/mods/content/fantasy/datum/overrides.dm
@@ -52,3 +52,7 @@
 /obj/aura/sifsap_salve
 	name = "Drakespittle Salve"
 	descriptor = "glowing spittle"
+
+// Rename wooden prostheses
+/decl/bodytype/prosthetic/wooden
+	name = "carved wooden" // weird to call it 'crude' when it's cutting-edge for the setting

--- a/mods/content/fantasy/datum/species.dm
+++ b/mods/content/fantasy/datum/species.dm
@@ -9,7 +9,7 @@
 		/decl/bodytype/human/masculine
 	)
 	preview_outfit = /decl/hierarchy/outfit/job/generic/fantasy
-	base_external_prosthetics_model = null
+	base_external_prosthetics_model = /decl/bodytype/prosthetic/wooden
 
 	available_cultural_info = list(
 		TAG_HOMEWORLD = list(


### PR DESCRIPTION
## Description of changes
- Fixes a runtime with null sprite accessory metadata.
- Allows psychotropics, amatoxin (and carpotoxin, because why not) to be composted.
- Moves simple animal attack effect triggering to natural weapon hit effects.
- Torches now only become 'burnt' and fail to relight if they run out of fuel.
- Torches drenched in blood will now fail to light until they are cleaned.
- Fixes some issues with prosthetics traits to allow wooden prosthetics to be picked on Shaded Hills.
- Sparks are now light sources.
- Sparks only last for 2 seconds instead of 5.
- Modifies unit testing for material temperature transitions.
- Temperature damage threshold is no longer set by ignition point (pending atom fires) or baking temperature. We enforce that baking temperature and ignition point are less than the damage threshold in `/decl/material/validate()` now.
- Simplifies temperature damage threshold autosetting to just use `max()` with more than two arguments.
- Automatic temperature damage thresholds will only be set if they're greater than the ignition point/it has no ignition point.

The intent with the torch coating check is that being doused in water will immediately call `clean()`, which removes the water coating. I don't necessarily want to touch that in this PR, need to have a bit of a discussion on how to redo coatings/cleaning like that, maybe as its own PR

## Why and what will this PR improve
- Fixes a runtime.
- Compost bins no longer fill up with psychoactive compounds.
- Spiders no longer inject venom even on miss.
- Torches can be relit if manually quenched/extinguished with fuel left.
- Lays the basic groundwork for torches not being able to be relit until dried off after you fall into deep water.
- Wooden prostheses can be selected on Shaded Hills.
- Base prosthetic traits now show what model they use, based on selected species.
- Sparks now produce light.
- Sparks no longer appear to hang in midair or get 'stuck' for a few seconds.
- Improves material temperature transition unit testing and auto-setting.
- Clay and logs will no longer melt just because they have bake/ignition temperatures set.

## Authorship
Me.

## Changelog
:cl:
add: sparks now produce light
add: wooden prostheses can be selected on Shaded Hills
tweak: amatoxin and psychotropics can be composted in a composter
/:cl: