### PR TITLE
Make outfits not subtypes of hierarchy

### DIFF
--- a/code/datums/outfits/horror_killers.dm
+++ b/code/datums/outfits/horror_killers.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/tunnel_clown
+/decl/outfit/tunnel_clown
 	name = "Tunnel clown"
 	uniform = /obj/item/clothing/costume/clown
 	shoes = /obj/item/clothing/shoes/clown_shoes
@@ -15,7 +15,7 @@
 	id_type = /obj/item/card/id/centcom/station
 	id_pda_assignment = "Tunnel Clown!"
 
-/decl/hierarchy/outfit/masked_killer
+/decl/outfit/masked_killer
 	name = "Masked killer"
 	uniform = /obj/item/clothing/pants/mustard/overalls
 	shoes = /obj/item/clothing/shoes/color/white
@@ -29,14 +29,14 @@
 	r_pocket = /obj/item/scalpel
 	hands = list(/obj/item/twohanded/fireaxe)
 
-/decl/hierarchy/outfit/masked_killer/post_equip(var/mob/living/human/H)
+/decl/outfit/masked_killer/post_equip(var/mob/living/human/H)
 	..()
 	var/victim = get_mannequin(H.ckey)
 	if(victim)
 		for(var/obj/item/carried_item in H.get_equipped_items(TRUE))
 			carried_item.add_blood(victim) //Oh yes, there will be blood... just not blood from the killer because that's odd
 
-/decl/hierarchy/outfit/reaper
+/decl/outfit/reaper
 	name = "Reaper"
 	uniform =  /obj/item/clothing/pants/slacks/outfit
 	shoes =    /obj/item/clothing/shoes/color/black
@@ -50,7 +50,7 @@
 	pda_slot = slot_belt_str
 	pda_type = /obj/item/modular_computer/pda/heads
 
-/decl/hierarchy/outfit/reaper/post_equip(var/mob/living/human/H)
+/decl/outfit/reaper/post_equip(var/mob/living/human/H)
 	..()
 	var/obj/item/secure_storage/briefcase/sec_briefcase = new(H)
 	for(var/obj/item/briefcase_item in sec_briefcase)

--- a/code/datums/outfits/jobs/generic.dm
+++ b/code/datums/outfits/jobs/generic.dm
@@ -1,11 +1,11 @@
-/decl/hierarchy/outfit/job/generic
-	abstract_type = /decl/hierarchy/outfit/job/generic
+/decl/outfit/job/generic
+	abstract_type = /decl/outfit/job/generic
 	id_type = /obj/item/card/id/civilian
 
-/decl/hierarchy/outfit/job/generic/assistant
+/decl/outfit/job/generic/assistant
 	name = "Job - Assistant"
 
-/decl/hierarchy/outfit/job/generic/scientist
+/decl/outfit/job/generic/scientist
 	name = "Job - Default Scientist"
 	l_ear = /obj/item/radio/headset/headset_sci
 	suit = /obj/item/clothing/suit/toggle/labcoat/science
@@ -13,7 +13,7 @@
 	pda_type = /obj/item/modular_computer/pda/science
 	uniform = /obj/item/clothing/jumpsuit/white
 
-/decl/hierarchy/outfit/job/generic/engineer
+/decl/outfit/job/generic/engineer
 	name = "Job - Default Engineer"
 	head = /obj/item/clothing/head/hardhat
 	uniform = /obj/item/clothing/jumpsuit/engineer
@@ -25,11 +25,11 @@
 	pda_slot = slot_l_store_str
 	outfit_flags = OUTFIT_HAS_BACKPACK | OUTFIT_EXTENDED_SURVIVAL | OUTFIT_HAS_VITALS_SENSOR
 
-/decl/hierarchy/outfit/job/generic/engineer/Initialize()
+/decl/outfit/job/generic/engineer/Initialize()
 	. = ..()
 	BACKPACK_OVERRIDE_ENGINEERING
 
-/decl/hierarchy/outfit/job/generic/doctor
+/decl/outfit/job/generic/doctor
 	name = "Job - Default Doctor"
 	uniform = /obj/item/clothing/jumpsuit/medical
 	suit = /obj/item/clothing/suit/toggle/labcoat
@@ -40,11 +40,11 @@
 	pda_type = /obj/item/modular_computer/pda/medical
 	pda_slot = slot_l_store_str
 
-/decl/hierarchy/outfit/job/generic/doctor/Initialize()
+/decl/outfit/job/generic/doctor/Initialize()
 	. = ..()
 	BACKPACK_OVERRIDE_MEDICAL
 
-/decl/hierarchy/outfit/job/generic/chef
+/decl/outfit/job/generic/chef
 	name = "Job - Default Chef"
 	l_ear = /obj/item/radio/headset/headset_service
 	uniform = /obj/item/clothing/pants/slacks/outfit_chef

--- a/code/datums/outfits/jobs/job.dm
+++ b/code/datums/outfits/jobs/job.dm
@@ -1,6 +1,6 @@
-/decl/hierarchy/outfit/job
+/decl/outfit/job
 	name = "Standard Gear"
-	abstract_type = /decl/hierarchy/outfit/job
+	abstract_type = /decl/outfit/job
 
 	uniform = /obj/item/clothing/jumpsuit/grey
 	l_ear = /obj/item/radio/headset

--- a/code/datums/outfits/jobs/misc.dm
+++ b/code/datums/outfits/jobs/misc.dm
@@ -1,11 +1,11 @@
-/decl/hierarchy/outfit/job/silicon
+/decl/outfit/job/silicon
 	head = /obj/item/clothing/head/cardborg
-	abstract_type = /decl/hierarchy/outfit/job/silicon
+	abstract_type = /decl/outfit/job/silicon
 
-/decl/hierarchy/outfit/job/silicon/ai
+/decl/outfit/job/silicon/ai
 	name = "Job - AI"
 	suit = /obj/item/clothing/suit/straight_jacket
 
-/decl/hierarchy/outfit/job/silicon/cyborg
+/decl/outfit/job/silicon/cyborg
 	name = "Job - Cyborg"
 	suit = /obj/item/clothing/suit/cardborg

--- a/code/datums/outfits/misc.dm
+++ b/code/datums/outfits/misc.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/standard_space_gear
+/decl/outfit/standard_space_gear
 	name = "Standard space gear"
 	shoes = /obj/item/clothing/shoes/color/black
 	head = /obj/item/clothing/head/helmet/space
@@ -8,7 +8,7 @@
 	mask = /obj/item/clothing/mask/breath
 	outfit_flags = OUTFIT_HAS_JETPACK|OUTFIT_RESET_EQUIPMENT
 
-/decl/hierarchy/outfit/soviet_soldier
+/decl/outfit/soviet_soldier
 	name = "Soviet soldier"
 	uniform = /obj/item/clothing/costume/soviet
 	shoes = /obj/item/clothing/shoes/jackboots/swat/combat
@@ -17,7 +17,7 @@
 	back = /obj/item/backpack/satchel
 	belt = /obj/item/gun/projectile/revolver
 
-/decl/hierarchy/outfit/soviet_soldier/admiral
+/decl/outfit/soviet_soldier/admiral
 	name = "Soviet admiral"
 	head = /obj/item/clothing/head/hgpiratecap
 	l_ear = /obj/item/radio/headset/heads/captain
@@ -28,7 +28,7 @@
 	id_type = /obj/item/card/id/centcom/station
 	id_pda_assignment = "Admiral"
 
-/decl/hierarchy/outfit/clown
+/decl/outfit/clown
 	name = "Clown"
 	shoes = /obj/item/clothing/shoes/clown_shoes
 	mask = /obj/item/clothing/mask/gas/clown_hat
@@ -37,6 +37,6 @@
 	l_pocket = /obj/item/bikehorn
 	outfit_flags = OUTFIT_HAS_BACKPACK | OUTFIT_RESET_EQUIPMENT | OUTFIT_HAS_VITALS_SENSOR
 
-/decl/hierarchy/outfit/clown/Initialize()
+/decl/outfit/clown/Initialize()
 	. = ..()
 	backpack_overrides[/decl/backpack_outfit/backpack] = /obj/item/backpack/clown

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -1,29 +1,6 @@
-var/global/list/outfits_decls_
-var/global/list/outfits_decls_root_
-var/global/list/outfits_decls_by_type_
-
-/proc/outfit_by_type(var/outfit_type)
-	if(!outfits_decls_root_)
-		init_outfit_decls()
-	return outfits_decls_by_type_[outfit_type]
-
-/proc/outfits()
-	if(!outfits_decls_root_)
-		init_outfit_decls()
-	return outfits_decls_
-
-/proc/init_outfit_decls()
-	if(outfits_decls_root_)
-		return
-	outfits_decls_ = list()
-	outfits_decls_by_type_ = list()
-	outfits_decls_root_ = GET_DECL(/decl/hierarchy/outfit)
-
-/decl/hierarchy/outfit
-	name = "Naked"
-	abstract_type = /decl/hierarchy/outfit
-	expected_type = /decl/hierarchy/outfit
-
+/decl/outfit
+	abstract_type = /decl/outfit
+	var/name = "Naked"
 	var/uniform = null
 	var/suit = null
 	var/back = null
@@ -55,15 +32,12 @@ var/global/list/outfits_decls_by_type_
 	var/list/backpack_overrides
 	var/outfit_flags = OUTFIT_RESET_EQUIPMENT
 
-/decl/hierarchy/outfit/Initialize()
+/decl/outfit/Initialize()
 	. = ..()
 	backpack_overrides = backpack_overrides || list()
-	if(!INSTANCE_IS_ABSTRACT(src))
-		outfits_decls_by_type_[type] = src
-		dd_insertObjectList(outfits_decls_, src)
 
 // This proc is structured slightly strangely because I will be adding pants to it.
-/decl/hierarchy/outfit/validate()
+/decl/outfit/validate()
 	. = ..()
 	if(uniform && (outfit_flags & OUTFIT_HAS_VITALS_SENSOR))
 		if(!ispath(uniform, /obj/item/clothing))
@@ -79,11 +53,11 @@ var/global/list/outfits_decls_by_type_
 			. += "outfit is flagged for sensors, but uniform does not accept sensors"
 		qdel(sensor)
 
-/decl/hierarchy/outfit/proc/pre_equip(mob/living/human/H)
+/decl/outfit/proc/pre_equip(mob/living/human/H)
 	if(outfit_flags & OUTFIT_RESET_EQUIPMENT)
 		H.delete_inventory(TRUE)
 
-/decl/hierarchy/outfit/proc/post_equip(mob/living/human/H)
+/decl/outfit/proc/post_equip(mob/living/human/H)
 	if(outfit_flags & OUTFIT_HAS_JETPACK)
 		var/obj/item/tank/jetpack/J = locate(/obj/item/tank/jetpack) in H
 		if(!J)
@@ -91,7 +65,7 @@ var/global/list/outfits_decls_by_type_
 		J.toggle()
 		J.toggle_valve()
 
-/decl/hierarchy/outfit/proc/equip_outfit(mob/living/human/H, assignment, equip_adjustments, datum/job/job, datum/mil_rank/rank)
+/decl/outfit/proc/equip_outfit(mob/living/human/H, assignment, equip_adjustments, datum/job/job, datum/mil_rank/rank)
 	equip_base(H, equip_adjustments)
 	equip_id(H, assignment, equip_adjustments, job, rank)
 	for(var/path in backpack_contents)
@@ -114,7 +88,7 @@ var/global/list/outfits_decls_by_type_
 
 	return 1
 
-/decl/hierarchy/outfit/proc/equip_base(mob/living/human/H, var/equip_adjustments)
+/decl/outfit/proc/equip_base(mob/living/human/H, var/equip_adjustments)
 	set waitfor = FALSE
 	pre_equip(H)
 
@@ -195,7 +169,7 @@ var/global/list/outfits_decls_by_type_
 	if(H.client?.prefs?.give_passport)
 		global.using_map.create_passport(H)
 
-/decl/hierarchy/outfit/proc/equip_id(mob/living/human/H, assignment, equip_adjustments, datum/job/job, datum/mil_rank/rank)
+/decl/outfit/proc/equip_id(mob/living/human/H, assignment, equip_adjustments, datum/job/job, datum/mil_rank/rank)
 	if(!id_slot || !id_type)
 		return
 	if(OUTFIT_ADJUSTMENT_SKIP_ID_PDA & equip_adjustments)
@@ -217,7 +191,7 @@ var/global/list/outfits_decls_by_type_
 	if(H.equip_to_slot_or_store_or_drop(W, id_slot))
 		return W
 
-/decl/hierarchy/outfit/proc/equip_pda(var/mob/living/human/H, var/assignment, var/equip_adjustments)
+/decl/outfit/proc/equip_pda(var/mob/living/human/H, var/assignment, var/equip_adjustments)
 	if(!pda_slot || !pda_type)
 		return
 	if(OUTFIT_ADJUSTMENT_SKIP_ID_PDA & equip_adjustments)
@@ -226,5 +200,5 @@ var/global/list/outfits_decls_by_type_
 	if(H.equip_to_slot_or_store_or_drop(pda, pda_slot))
 		return pda
 
-/decl/hierarchy/outfit/dd_SortValue()
+/decl/outfit/dd_SortValue()
 	return name

--- a/code/datums/outfits/pirates.dm
+++ b/code/datums/outfits/pirates.dm
@@ -1,16 +1,16 @@
-/decl/hierarchy/outfit/pirate
-	abstract_type = /decl/hierarchy/outfit/pirate
+/decl/outfit/pirate
+	abstract_type = /decl/outfit/pirate
 	name = "Pirate"
 	uniform = /obj/item/clothing/costume/pirate
 	shoes = /obj/item/clothing/shoes/jackboots
 	glasses = /obj/item/clothing/glasses/eyepatch
 	hands = list(/obj/item/energy_blade/cutlass)
 
-/decl/hierarchy/outfit/pirate/norm
+/decl/outfit/pirate/norm
 	name = "Pirate - Normal"
 	head = /obj/item/clothing/mask/bandana/red
 
-/decl/hierarchy/outfit/pirate/space
+/decl/outfit/pirate/space
 	name = "Pirate - Space"
 	head = /obj/item/clothing/suit/armor/pirate
 	suit = /obj/item/clothing/suit/pirate

--- a/code/datums/outfits/spec_op.dm
+++ b/code/datums/outfits/spec_op.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/spec_op_officer
+/decl/outfit/spec_op_officer
 	name = "Spec Ops - Officer"
 	uniform = /obj/item/clothing/pants/casual/camo/outfit_combat
 	suit = /obj/item/clothing/suit/armor/officer
@@ -16,7 +16,7 @@
 	id_desc = "Special operations ID."
 	id_pda_assignment = "Special Operations Officer"
 
-/decl/hierarchy/outfit/spec_op_officer/space
+/decl/outfit/spec_op_officer/space
 	name = "Spec Ops - Officer in space"
 	suit = /obj/item/clothing/suit/space/void/swat
 	back = /obj/item/tank/jetpack/oxygen
@@ -24,7 +24,7 @@
 
 	outfit_flags = OUTFIT_HAS_JETPACK|OUTFIT_RESET_EQUIPMENT
 
-/decl/hierarchy/outfit/ert
+/decl/outfit/ert
 	name = "Spec Ops - Emergency response team"
 	uniform = /obj/item/clothing/pants/casual/camo/outfit_combat
 	shoes = /obj/item/clothing/shoes/jackboots/swat
@@ -38,7 +38,7 @@
 	id_slot = slot_wear_id_str
 	id_type = /obj/item/card/id/centcom/ERT
 
-/decl/hierarchy/outfit/mercenary
+/decl/outfit/mercenary
 	name = "Spec Ops - Mercenary"
 	uniform = /obj/item/clothing/pants/casual/camo/outfit
 	shoes = /obj/item/clothing/shoes/jackboots/swat/combat
@@ -56,7 +56,7 @@
 
 	outfit_flags = OUTFIT_HAS_BACKPACK|OUTFIT_RESET_EQUIPMENT
 
-/decl/hierarchy/outfit/mercenary/syndicate
+/decl/outfit/mercenary/syndicate
 	name = "Spec Ops - Syndicate"
 	suit = /obj/item/clothing/suit/armor/vest
 	mask = /obj/item/clothing/mask/gas
@@ -64,7 +64,7 @@
 	shoes = /obj/item/clothing/shoes/jackboots/swat
 	id_desc = "Syndicate Operative"
 
-/decl/hierarchy/outfit/mercenary/syndicate/commando
+/decl/outfit/mercenary/syndicate/commando
 	name = "Spec Ops - Syndicate Commando"
 	suit = /obj/item/clothing/suit/space/void/merc
 	mask = /obj/item/clothing/mask/gas/syndicate

--- a/code/datums/outfits/tournament.dm
+++ b/code/datums/outfits/tournament.dm
@@ -1,5 +1,5 @@
-/decl/hierarchy/outfit/tournament_gear
-	abstract_type = /decl/hierarchy/outfit/tournament_gear
+/decl/outfit/tournament_gear
+	abstract_type = /decl/outfit/tournament_gear
 	head = /obj/item/clothing/head/helmet/thunderdome
 	suit = /obj/item/clothing/suit/armor/vest
 	hands = list(
@@ -9,15 +9,15 @@
 	r_pocket = /obj/item/grenade/smokebomb
 	shoes = /obj/item/clothing/shoes/color/black
 
-/decl/hierarchy/outfit/tournament_gear/red
+/decl/outfit/tournament_gear/red
 	name = "Tournament - Red"
 	uniform = /obj/item/clothing/jumpsuit/red
 
-/decl/hierarchy/outfit/tournament_gear/green
+/decl/outfit/tournament_gear/green
 	name = "Tournament gear - Green"
 	uniform = /obj/item/clothing/jumpsuit/green
 
-/decl/hierarchy/outfit/tournament_gear/gangster
+/decl/outfit/tournament_gear/gangster
 	name = "Tournament gear - Gangster"
 	head = /obj/item/clothing/head/det
 	uniform = /obj/item/clothing/pants/slacks/outfit/detective
@@ -29,7 +29,7 @@
 	)
 	l_pocket = /obj/item/ammo_magazine/speedloader
 
-/decl/hierarchy/outfit/tournament_gear/chef
+/decl/outfit/tournament_gear/chef
 	name = "Tournament gear - Chef"
 	head = /obj/item/clothing/head/chefhat
 	uniform = /obj/item/clothing/pants/slacks/outfit_chef
@@ -41,7 +41,7 @@
 	l_pocket = /obj/item/knife/combat
 	r_pocket = /obj/item/knife/combat
 
-/decl/hierarchy/outfit/tournament_gear/janitor
+/decl/outfit/tournament_gear/janitor
 	name = "Tournament gear - Janitor"
 	uniform = /obj/item/clothing/jumpsuit/janitor
 	back = /obj/item/backpack
@@ -53,7 +53,7 @@
 	r_pocket = /obj/item/grenade/chem_grenade/cleaner
 	backpack_contents = list(/obj/item/stack/tile/floor = 6)
 
-/decl/hierarchy/outfit/tournament_gear/janitor/post_equip(var/mob/living/human/H)
+/decl/outfit/tournament_gear/janitor/post_equip(var/mob/living/human/H)
 	..()
 	var/obj/item/chems/glass/bucket/bucket = locate(/obj/item/chems/glass/bucket) in H
 	if(bucket)

--- a/code/datums/outfits/wizardry.dm
+++ b/code/datums/outfits/wizardry.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/wizard
+/decl/outfit/wizard
 	uniform = /obj/item/clothing/jumpsuit/lightpurple
 	shoes = /obj/item/clothing/shoes/sandal
 	l_ear = /obj/item/radio/headset
@@ -9,20 +9,20 @@
 	)
 	back = /obj/item/backpack
 	backpack_contents = list(/obj/item/box = 1)
-	abstract_type = /decl/hierarchy/outfit/wizard
+	abstract_type = /decl/outfit/wizard
 	outfit_flags = OUTFIT_HAS_BACKPACK|OUTFIT_RESET_EQUIPMENT
 
-/decl/hierarchy/outfit/wizard/blue
+/decl/outfit/wizard/blue
 	name = "Wizard - Blue"
 	head = /obj/item/clothing/head/wizard
 	suit = /obj/item/clothing/suit/wizrobe
 
-/decl/hierarchy/outfit/wizard/red
+/decl/outfit/wizard/red
 	name = "Wizard - Red"
 	head = /obj/item/clothing/head/wizard/red
 	suit = /obj/item/clothing/suit/wizrobe/red
 
-/decl/hierarchy/outfit/wizard/marisa
+/decl/outfit/wizard/marisa
 	name = "Wizard - Marisa"
 	head = /obj/item/clothing/head/wizard/marisa
 	suit = /obj/item/clothing/suit/wizrobe/marisa

--- a/code/game/antagonist/antagonist_equip.dm
+++ b/code/game/antagonist/antagonist_equip.dm
@@ -18,7 +18,7 @@
 		player.species.equip_survival_gear(player)
 
 	if(default_outfit)
-		var/decl/hierarchy/outfit/outfit = GET_DECL(default_outfit)
+		var/decl/outfit/outfit = GET_DECL(default_outfit)
 		outfit.equip_outfit(player)
 
 	if(default_access)

--- a/code/game/antagonist/outsider/actors.dm
+++ b/code/game/antagonist/outsider/actors.dm
@@ -10,11 +10,11 @@
 	initial_spawn_target = 1
 	show_objectives_on_creation = 0 //actors are not antagonists and do not need the antagonist greet text
 	required_language = /decl/language/human/common
-	default_outfit = /decl/hierarchy/outfit/actor
+	default_outfit = /decl/outfit/actor
 	default_access = list()
 	id_title = "Actor"
 
-/decl/hierarchy/outfit/actor
+/decl/outfit/actor
 	name =    "Special Role - Actor"
 	uniform = /obj/item/clothing/jumpsuit/chameleon
 	shoes =   /obj/item/clothing/shoes/chameleon

--- a/code/game/antagonist/outsider/ert.dm
+++ b/code/game/antagonist/outsider/ert.dm
@@ -20,7 +20,7 @@
 	initial_spawn_req = 5
 	initial_spawn_target = 7
 	show_objectives_on_creation = 0 //we are not antagonists, we do not need the antagonist shpiel/objectives
-	default_outfit = /decl/hierarchy/outfit/ert
+	default_outfit = /decl/outfit/ert
 
 	base_to_load = "ERT Base"
 

--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -18,7 +18,7 @@
 	faction = "mercenary"
 
 	base_to_load = "Mercenary Base"
-	default_outfit = /decl/hierarchy/outfit/mercenary
+	default_outfit = /decl/outfit/mercenary
 
 /decl/special_role/mercenary/create_global_objectives()
 	if(!..())

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -65,7 +65,7 @@
 	wizard.current.SetName(wizard.current.real_name)
 
 /decl/special_role/wizard/equip_role(var/mob/living/human/wizard_mob)
-	default_outfit = pick(decls_repository.get_decl_paths_of_subtype(/decl/hierarchy/outfit/wizard))
+	default_outfit = pick(decls_repository.get_decl_paths_of_subtype(/decl/outfit/wizard))
 	. = ..()
 
 /decl/special_role/wizard/print_player_summary()

--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -68,7 +68,7 @@
 	if(type == /datum/job && global.using_map.default_job_type == type)
 		title = "Debug Job"
 		hud_icon = "hudblank"
-		outfit_type = /decl/hierarchy/outfit/job/generic/scientist
+		outfit_type = /decl/outfit/job/generic/scientist
 		autoset_department = TRUE
 
 	if(!length(department_types) && autoset_department)
@@ -96,7 +96,7 @@
 	else
 		H.set_default_language(/decl/language/human/common)
 
-	var/decl/hierarchy/outfit/outfit = get_outfit(H, alt_title, branch, grade)
+	var/decl/outfit/outfit = get_outfit(H, alt_title, branch, grade)
 	if(outfit)
 		. = outfit.equip_outfit(H, alt_title || title, job = src, rank = grade)
 
@@ -120,8 +120,8 @@
 		. = allowed_branches[branch.type] || .
 	if(allowed_ranks && grade)
 		. = allowed_ranks[grade.type] || .
-	. = . || outfit_type
-	. = outfit_by_type(.)
+	. ||= outfit_type
+	return GET_DECL(.)
 
 /datum/job/proc/create_cash_on_hand(var/mob/living/human/H, var/datum/money_account/M)
 	if(!istype(M) || !H.client?.prefs?.starting_cash_choice)
@@ -181,7 +181,7 @@
 
 // overrideable separately so AIs/borgs can have cardborg hats without unneccessary new()/qdel()
 /datum/job/proc/equip_preview(mob/living/human/H, var/alt_title, var/datum/mil_branch/branch, var/datum/mil_rank/grade, var/additional_skips)
-	var/decl/hierarchy/outfit/outfit = get_outfit(H, alt_title, branch, grade)
+	var/decl/outfit/outfit = get_outfit(H, alt_title, branch, grade)
 	if(!outfit)
 		return FALSE
 	. = outfit.equip_outfit(H, alt_title || title, equip_adjustments = (OUTFIT_ADJUSTMENT_SKIP_POST_EQUIP|OUTFIT_ADJUSTMENT_SKIP_ID_PDA|additional_skips), job = src, rank = grade)

--- a/code/modules/admin/quantum_mechanic.dm
+++ b/code/modules/admin/quantum_mechanic.dm
@@ -27,7 +27,7 @@
 	Q.set_dir(mob.dir)
 	Q.ckey = ckey
 
-	var/decl/hierarchy/outfit/outfit = outfit_by_type(/decl/hierarchy/outfit/quantum)
+	var/decl/outfit/outfit = GET_DECL(/decl/outfit/quantum)
 	outfit.equip_outfit(Q)
 
 	//Sort out ID
@@ -45,7 +45,7 @@
 	Q.phase_in(get_turf(Q))
 	log_debug("Quantum Mechanic spawned at X: [Q.x], Y: [Q.y], Z: [Q.z]. User: [src]")
 
-/decl/hierarchy/outfit/quantum
+/decl/outfit/quantum
 	name = "Quantum Mechanic"
 	glasses =  /obj/item/clothing/glasses/sunglasses/quantum
 	uniform =  /obj/item/clothing/jumpsuit/quantum

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -286,7 +286,7 @@
 	if(!H)
 		return
 
-	var/decl/hierarchy/outfit/outfit = input("Select outfit.", "Select equipment.") as null|anything in outfits()
+	var/decl/outfit/outfit = input("Select outfit.", "Select equipment.") as null|anything in decls_repository.get_decls_of_subtype_unassociated(/decl/outfit)
 	if(!outfit)
 		return
 
@@ -297,7 +297,7 @@
 	SSstatistics.add_field_details("admin_verb","SEQ")
 	dressup_human(H, outfit, reset_equipment)
 
-/proc/dressup_human(var/mob/living/human/H, var/decl/hierarchy/outfit/outfit, var/undress = TRUE)
+/proc/dressup_human(var/mob/living/human/H, var/decl/outfit/outfit, var/undress = TRUE)
 	if(!H || !outfit)
 		return
 	if(undress)

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -29,7 +29,7 @@
 		if(!istype(victim))
 			to_chat(usr, "This can only be used on instances of type /mob/living/human")
 			return
-		var/decl/hierarchy/outfit/outfit = input("Select outfit.", "Select equipment.") as null|anything in outfits()
+		var/decl/outfit/outfit = input("Select outfit.", "Select equipment.") as null|anything in decls_repository.get_decls_of_subtype_unassociated(/decl/outfit)
 		if(!outfit)
 			return
 

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -23,7 +23,7 @@
 	name = "Unknown"
 	abstract_type = /obj/abstract/landmark/corpse
 	var/species                                       // List of species to pick from.
-	var/corpse_outfits = list(/decl/hierarchy/outfit) // List of outfits to pick from. Uses pickweight()
+	var/corpse_outfits = list(/decl/outfit) // List of outfits to pick from. Uses pickweight()
 	var/spawn_flags = (~0)
 	var/weakref/my_corpse
 
@@ -107,47 +107,47 @@
 	adjustments = (spawn_flags & CORPSE_SPAWNER_CUT_ID_PDA)    ? (adjustments|OUTFIT_ADJUSTMENT_SKIP_ID_PDA)        : adjustments
 	adjustments = (spawn_flags & CORPSE_SPAWNER_PLAIN_HEADSET) ? (adjustments|OUTFIT_ADJUSTMENT_PLAIN_HEADSET)      : adjustments
 
-	var/decl/hierarchy/outfit/corpse_outfit = outfit_by_type(pickweight(corpse_outfits))
+	var/decl/outfit/corpse_outfit = GET_DECL(pickweight(corpse_outfits))
 	corpse_outfit.equip_outfit(M, equip_adjustments = adjustments)
 
 /obj/abstract/landmark/corpse/pirate
 	name = "Pirate"
-	corpse_outfits = list(/decl/hierarchy/outfit/pirate/norm)
+	corpse_outfits = list(/decl/outfit/pirate/norm)
 	spawn_flags = CORPSE_SPAWNER_NO_RANDOMIZATION
 
 /obj/abstract/landmark/corpse/pirate/ranged
 	name = "Pirate Gunner"
-	corpse_outfits = list(/decl/hierarchy/outfit/pirate/space)
+	corpse_outfits = list(/decl/outfit/pirate/space)
 
 /obj/abstract/landmark/corpse/russian
 	name = "Russian"
-	corpse_outfits = list(/decl/hierarchy/outfit/soviet_soldier)
+	corpse_outfits = list(/decl/outfit/soviet_soldier)
 	spawn_flags = CORPSE_SPAWNER_NO_RANDOMIZATION
 
 /obj/abstract/landmark/corpse/russian/ranged
-	corpse_outfits = list(/decl/hierarchy/outfit/soviet_soldier)
+	corpse_outfits = list(/decl/outfit/soviet_soldier)
 
 /obj/abstract/landmark/corpse/syndicate
 	name = "Syndicate Operative"
-	corpse_outfits = list(/decl/hierarchy/outfit/mercenary/syndicate)
+	corpse_outfits = list(/decl/outfit/mercenary/syndicate)
 	spawn_flags = CORPSE_SPAWNER_NO_RANDOMIZATION
 
 /obj/abstract/landmark/corpse/syndicate/commando
 	name = "Syndicate Commando"
-	corpse_outfits = list(/decl/hierarchy/outfit/mercenary/syndicate/commando)
+	corpse_outfits = list(/decl/outfit/mercenary/syndicate/commando)
 
 /obj/abstract/landmark/corpse/chef
 	name = "Chef"
-	corpse_outfits = list(/decl/hierarchy/outfit/job/generic/chef)
+	corpse_outfits = list(/decl/outfit/job/generic/chef)
 
 /obj/abstract/landmark/corpse/doctor
 	name = "Doctor"
-	corpse_outfits = list(/decl/hierarchy/outfit/job/generic/doctor)
+	corpse_outfits = list(/decl/outfit/job/generic/doctor)
 
 /obj/abstract/landmark/corpse/engineer
 	name = "Engineer"
-	corpse_outfits = list(/decl/hierarchy/outfit/job/generic/engineer)
+	corpse_outfits = list(/decl/outfit/job/generic/engineer)
 
 /obj/abstract/landmark/corpse/scientist
 	name = "Scientist"
-	corpse_outfits = list(/decl/hierarchy/outfit/job/generic/scientist)
+	corpse_outfits = list(/decl/outfit/job/generic/scientist)

--- a/code/modules/mob/living/human/npcs.dm
+++ b/code/modules/mob/living/human/npcs.dm
@@ -20,7 +20,7 @@
 		if(prob(10))
 			equip_to_appropriate_slot(new /obj/item/clothing/head/collectable/petehat(src))
 
-/decl/hierarchy/outfit/blank_subject
+/decl/outfit/blank_subject
 	name = "Test Subject"
 	uniform = /obj/item/clothing/jumpsuit/white/blank
 	shoes = /obj/item/clothing/shoes/color/white
@@ -43,7 +43,7 @@
 /mob/living/human/blank/LateInitialize()
 	var/number = "[pick(global.greek_letters)]-[rand(1,30)]"
 	fully_replace_character_name("Subject [number]")
-	var/decl/hierarchy/outfit/outfit = outfit_by_type(/decl/hierarchy/outfit/blank_subject)
+	var/decl/outfit/outfit = GET_DECL(/decl/outfit/blank_subject)
 	outfit.equip_outfit(src)
 	var/obj/item/clothing/head/helmet/facecover/F = locate() in src
 	if(F)

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -222,7 +222,7 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	var/preview_icon_width = 64
 	var/preview_icon_height = 64
 	var/preview_icon_path
-	var/preview_outfit = /decl/hierarchy/outfit/job/generic/assistant
+	var/preview_outfit = /decl/outfit/job/generic/assistant
 
 	/// List of emote types that this species can use by default.
 	var/list/default_emotes

--- a/code/modules/species/species_bodytype.dm
+++ b/code/modules/species/species_bodytype.dm
@@ -682,7 +682,7 @@ var/global/list/bodytypes_by_category = list()
 
 /decl/species/proc/customize_preview_mannequin(mob/living/human/dummy/mannequin/mannequin)
 	if(preview_outfit)
-		var/decl/hierarchy/outfit/outfit = outfit_by_type(preview_outfit)
+		var/decl/outfit/outfit = GET_DECL(preview_outfit)
 		outfit.equip_outfit(mannequin, equip_adjustments = (OUTFIT_ADJUSTMENT_SKIP_SURVIVAL_GEAR|OUTFIT_ADJUSTMENT_SKIP_BACKPACK))
 		mannequin.update_icon()
 	mannequin.update_transform()

--- a/code/modules/submaps/submap_job.dm
+++ b/code/modules/submaps/submap_job.dm
@@ -6,7 +6,7 @@
 	announced = FALSE
 	create_record = FALSE
 	total_positions = 4
-	outfit_type = /decl/hierarchy/outfit/job/survivor
+	outfit_type = /decl/outfit/job/survivor
 	hud_icon = "hudblank"
 	available_by_default = FALSE
 	allowed_ranks = null
@@ -45,7 +45,7 @@
 	var/list/blacklisted_species = list()
 	var/list/whitelisted_species = list()
 
-/decl/hierarchy/outfit/job/survivor
+/decl/outfit/job/survivor
 	name = "Job - Survivor"
 
 /datum/job/submap/New(var/datum/submap/_owner, var/abstract_job = FALSE)

--- a/code/unit_tests/job_tests.dm
+++ b/code/unit_tests/job_tests.dm
@@ -24,7 +24,7 @@
 
 	for (var/occ in SSjobs.titles_to_datums)
 		var/datum/job/occupation = SSjobs.titles_to_datums[occ]
-		var/decl/hierarchy/outfit/job/outfit = outfit_by_type(occupation.outfit_type)
+		var/decl/outfit/job/outfit = GET_DECL(occupation.outfit_type)
 		if(!istype(outfit))
 			log_bad("[occupation.title] - [occupation.type]: Invalid outfit type [outfit ? outfit.type : "NULL"].")
 			failed_jobs++

--- a/code/unit_tests/unique_tests.dm
+++ b/code/unit_tests/unique_tests.dm
@@ -65,8 +65,7 @@
 /datum/unit_test/outfit_datums_shall_have_unique_names/start_test()
 	var/list/outfits_by_name = list()
 
-	for(var/a in outfits())
-		var/decl/hierarchy/outfit/outfit = a
+	for(var/decl/outfit/outfit in decls_repository.get_decls_of_subtype_unassociated(/decl/outfit))
 		group_by(outfits_by_name, outfit.name, outfit.type)
 
 	var/number_of_issues = number_of_issues(outfits_by_name, "Names")

--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -101,7 +101,7 @@
 
 /obj/abstract/landmark/corpse/deadcap
 	name = "Dead Captain"
-	corpse_outfits = list(/decl/hierarchy/outfit/deadcap)
+	corpse_outfits = list(/decl/outfit/deadcap)
 	delete_me = FALSE //  we handle this in LateInit
 
 /obj/abstract/landmark/corpse/deadcap/Initialize()
@@ -118,14 +118,14 @@
 		C.buckle_mob(corpse)
 	qdel(src)
 
-/decl/hierarchy/outfit/deadcap
+/decl/outfit/deadcap
 	name = "Derelict Captain"
 	uniform = /obj/item/clothing/pants/baggy/casual/classicjeans
 	suit = /obj/item/clothing/suit/jacket/winter
 	shoes = /obj/item/clothing/shoes/color/black
 	r_pocket = /obj/item/radio
 
-/decl/hierarchy/outfit/deadcap/post_equip(mob/living/human/H)
+/decl/outfit/deadcap/post_equip(mob/living/human/H)
 	..()
 	var/obj/item/clothing/uniform = H.get_equipped_item(slot_w_uniform_str)
 	if(uniform)

--- a/maps/away/bearcat/bearcat_jobs.dm
+++ b/maps/away/bearcat/bearcat_jobs.dm
@@ -1,7 +1,7 @@
 /datum/job/submap/bearcat_captain
 	title = "Independant Captain"
 	total_positions = 1
-	outfit_type = /decl/hierarchy/outfit/job/bearcat/captain
+	outfit_type = /decl/outfit/job/bearcat/captain
 	supervisors = "your bottom line"
 	info = "Your ship has suffered a catastrophic amount of damage, leaving it dark and crippled in the depths of \
 	unexplored space. The Captain is dead, leaving you, previously the First Mate in charge. Organize what's left of \
@@ -11,31 +11,31 @@
 	title = "Independant Crewman"
 	supervisors = "the Captain"
 	total_positions = 3
-	outfit_type = /decl/hierarchy/outfit/job/bearcat/crew
+	outfit_type = /decl/outfit/job/bearcat/crew
 	info = "Your ship has suffered a catastrophic amount of damage, leaving it dark and crippled in the depths of \
 	unexplored space. Work together with the Acting Captain and what's left of the crew, and maybe you'll be able \
 	to survive long enough to be rescued."
 
-/decl/hierarchy/outfit/job/bearcat
-	abstract_type = /decl/hierarchy/outfit/job/bearcat
+/decl/outfit/job/bearcat
+	abstract_type = /decl/outfit/job/bearcat
 	pda_type = /obj/item/modular_computer/pda
 	pda_slot = slot_l_store_str
 	r_pocket = /obj/item/radio
 	l_ear = null
 	r_ear = null
 
-/decl/hierarchy/outfit/job/bearcat/crew
+/decl/outfit/job/bearcat/crew
 	name = "Bearcat - Job - FTU Crew"
 	id_type = /obj/item/card/id/bearcat
 
-/decl/hierarchy/outfit/job/bearcat/captain
+/decl/outfit/job/bearcat/captain
 	name = "Bearcat - Job - FTU Captain"
 	uniform = /obj/item/clothing/pants/baggy/casual/classicjeans
 	shoes = /obj/item/clothing/shoes/color/black
 	pda_type = /obj/item/modular_computer/pda/heads/captain
 	id_type = /obj/item/card/id/bearcat_captain
 
-/decl/hierarchy/outfit/job/bearcat/captain/post_equip(var/mob/living/human/H)
+/decl/outfit/job/bearcat/captain/post_equip(var/mob/living/human/H)
 	..()
 	var/obj/item/clothing/uniform = H.get_equipped_item(slot_w_uniform_str)
 	if(uniform)

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -242,9 +242,9 @@
 
 /obj/abstract/landmark/corpse/carp_fisher
 	name = "carp fisher"
-	corpse_outfits = list(/decl/hierarchy/outfit/corpse/carp_fisher)
+	corpse_outfits = list(/decl/outfit/corpse/carp_fisher)
 
-/decl/hierarchy/outfit/corpse/carp_fisher
+/decl/outfit/corpse/carp_fisher
 	name = "Dead carp fisher"
 	uniform = /obj/item/clothing/jumpsuit/green
 	suit = /obj/item/clothing/suit/apron/overalls

--- a/maps/away/liberia/liberia_jobs.dm
+++ b/maps/away/liberia/liberia_jobs.dm
@@ -15,7 +15,7 @@
 	ideal_character_age = 20
 	minimal_player_age = 7
 
-	outfit_type = /decl/hierarchy/outfit/job/merchant
+	outfit_type = /decl/outfit/job/merchant
 
 	skill_points = 24
 	min_skill = list(
@@ -36,7 +36,7 @@
 /obj/abstract/submap_landmark/spawnpoint/liberia
 	name = "Merchant"
 
-/decl/hierarchy/outfit/job/merchant
+/decl/outfit/job/merchant
 	name = "Job - Merchant - Liberia"
 	shoes = /obj/item/clothing/shoes/color/black
 	l_ear = /obj/item/radio/headset

--- a/maps/away/slavers/slavers_base.dm
+++ b/maps/away/slavers/slavers_base.dm
@@ -54,11 +54,11 @@
 	name = "Slavers Base Navpoint #7"
 	landmark_tag = "nav_slavers_base_antag"
 
-/decl/hierarchy/outfit/corpse
+/decl/outfit/corpse
 	name = "Corpse Clothing"
-	abstract_type = /decl/hierarchy/outfit/corpse
+	abstract_type = /decl/outfit/corpse
 
-/decl/hierarchy/outfit/corpse/slavers_base
+/decl/outfit/corpse/slavers_base
 	name = "Basic slaver output"
 
 /obj/abstract/landmark/corpse/slavers_base
@@ -66,9 +66,9 @@
 
 /obj/abstract/landmark/corpse/slavers_base/slaver1
 	name = "Slaver"
-	corpse_outfits = list(/decl/hierarchy/outfit/corpse/slavers_base/slaver1)
+	corpse_outfits = list(/decl/outfit/corpse/slavers_base/slaver1)
 
-/decl/hierarchy/outfit/corpse/slavers_base/slaver1
+/decl/outfit/corpse/slavers_base/slaver1
 	name = "Dead Slaver 1"
 	uniform = /obj/item/clothing/jumpsuit/johnny
 	shoes = /obj/item/clothing/shoes/color/black
@@ -76,36 +76,36 @@
 
 /obj/abstract/landmark/corpse/slavers_base/slaver2
 	name = "Slaver"
-	corpse_outfits = list(/decl/hierarchy/outfit/corpse/slavers_base/slaver2)
+	corpse_outfits = list(/decl/outfit/corpse/slavers_base/slaver2)
 
-/decl/hierarchy/outfit/corpse/slavers_base/slaver2
+/decl/outfit/corpse/slavers_base/slaver2
 	name = "Dead Slaver 2"
 	uniform = /obj/item/clothing/jumpsuit/johnny
 	shoes = /obj/item/clothing/shoes/color/blue
 
 /obj/abstract/landmark/corpse/slavers_base/slaver3
 	name = "Slaver"
-	corpse_outfits = list(/decl/hierarchy/outfit/corpse/slavers_base/slaver3)
+	corpse_outfits = list(/decl/outfit/corpse/slavers_base/slaver3)
 
-/decl/hierarchy/outfit/corpse/slavers_base/slaver3
+/decl/outfit/corpse/slavers_base/slaver3
 	name = "Dead Slaver 3"
 	uniform = /obj/item/clothing/costume/pirate
 	shoes = /obj/item/clothing/shoes/color/brown
 
 /obj/abstract/landmark/corpse/slavers_base/slaver4
 	name = "Slaver"
-	corpse_outfits = list(/decl/hierarchy/outfit/corpse/slavers_base/slaver4)
+	corpse_outfits = list(/decl/outfit/corpse/slavers_base/slaver4)
 
-/decl/hierarchy/outfit/corpse/slavers_base/slaver4
+/decl/outfit/corpse/slavers_base/slaver4
 	name = "Dead Slaver 4"
 	uniform = /obj/item/clothing/costume/redcoat
 	shoes = /obj/item/clothing/shoes/color/brown
 
 /obj/abstract/landmark/corpse/slavers_base/slaver5
 	name = "Slaver"
-	corpse_outfits = list(/decl/hierarchy/outfit/corpse/slavers_base/slaver5)
+	corpse_outfits = list(/decl/outfit/corpse/slavers_base/slaver5)
 
-/decl/hierarchy/outfit/corpse/slavers_base/slaver5
+/decl/outfit/corpse/slavers_base/slaver5
 	name = "Dead Slaver 5"
 	uniform = /obj/item/clothing/jumpsuit/sterile
 	shoes = /obj/item/clothing/shoes/color/orange
@@ -113,18 +113,18 @@
 
 /obj/abstract/landmark/corpse/slavers_base/slaver6
 	name = "Slaver"
-	corpse_outfits = list(/decl/hierarchy/outfit/corpse/slavers_base/slaver6)
+	corpse_outfits = list(/decl/outfit/corpse/slavers_base/slaver6)
 
-/decl/hierarchy/outfit/corpse/slavers_base/slaver6
+/decl/outfit/corpse/slavers_base/slaver6
 	name = "Dead Slaver 6"
 	uniform = /obj/item/clothing/shirt/flannel/red/outfit
 	shoes = /obj/item/clothing/shoes/color/orange
 
 /obj/abstract/landmark/corpse/slavers_base/slave
 	name = "Slave"
-	corpse_outfits = list(/decl/hierarchy/outfit/corpse/slavers_base/slave)
+	corpse_outfits = list(/decl/outfit/corpse/slavers_base/slave)
 
-/decl/hierarchy/outfit/corpse/slavers_base/slave
+/decl/outfit/corpse/slavers_base/slave
 	name = "Dead Slave"
 	uniform = /obj/item/clothing/jumpsuit/orange
 	shoes = /obj/item/clothing/shoes/jackboots/tactical
@@ -164,9 +164,9 @@
 
 /obj/abstract/landmark/corpse/abolitionist
 	name = "abolitionist"
-	corpse_outfits = list(/decl/hierarchy/outfit/corpse/abolitionist)
+	corpse_outfits = list(/decl/outfit/corpse/abolitionist)
 
-/decl/hierarchy/outfit/corpse/abolitionist
+/decl/outfit/corpse/abolitionist
 	name = "Dead abolitionist"
 	uniform = /obj/item/clothing/jumpsuit/abolitionist
 	shoes = /obj/item/clothing/shoes/jackboots

--- a/maps/away/unishi/unishi_jobs.dm
+++ b/maps/away/unishi/unishi_jobs.dm
@@ -1,7 +1,7 @@
 /datum/job/submap/unishi_crew
 	title = "Unishi Crew"
 	total_positions = 1
-	outfit_type = /decl/hierarchy/outfit/job/unishi/crew
+	outfit_type = /decl/outfit/job/unishi/crew
 	supervisors = "your survival"
 	info = "You remember waking up to alarms blaring in your face. Before you could react, a gush of hot air blew \
 	you away, knocking you cold unconcious.  Before this happened you were a crew member \
@@ -13,25 +13,25 @@
 	title = "Unishi Researcher"
 	supervisors = "the crew"
 	total_positions = 2
-	outfit_type = /decl/hierarchy/outfit/job/unishi/researcher
+	outfit_type = /decl/outfit/job/unishi/researcher
 	info = "You remember waking up to alarms blaring in your face. Before you could react, a gush of hot air blew \
 	you away, knocking you cold unconcious. Before this happened, you were a researcher, aboard SRV Verne."
 	required_language = /decl/language/human/common
 
-/decl/hierarchy/outfit/job/unishi
-	abstract_type = /decl/hierarchy/outfit/job/unishi
+/decl/outfit/job/unishi
+	abstract_type = /decl/outfit/job/unishi
 	pda_type = /obj/item/modular_computer/pda
 	pda_slot = slot_l_store_str
 	l_ear = null
 	r_ear = null
 
-/decl/hierarchy/outfit/job/unishi/crew
+/decl/outfit/job/unishi/crew
 	name = "CTI Research Vessel - Job - Unishi Crewman"
 	r_pocket = /obj/item/radio
 	shoes = /obj/item/clothing/shoes/color/black
 	belt = /obj/item/belt/utility/full
 
-/decl/hierarchy/outfit/job/unishi/researcher
+/decl/outfit/job/unishi/researcher
 	name = "CTI Research Vessel - Job - Researcher"
 	uniform = /obj/item/clothing/jumpsuit/engineer
 	suit = /obj/item/clothing/suit/jacket/hoodie

--- a/maps/example/example_jobs.dm
+++ b/maps/example/example_jobs.dm
@@ -12,10 +12,10 @@
 	economic_power = 1
 	access = list()
 	minimal_access = list()
-	outfit_type = /decl/hierarchy/outfit/job/tourist
+	outfit_type = /decl/outfit/job/tourist
 	department_types = list(
 		/decl/department/example
 		)
 
-/decl/hierarchy/outfit/job/tourist
+/decl/outfit/job/tourist
 	name = "Job - Testing Site Tourist"

--- a/maps/exodus/jobs/captain.dm
+++ b/maps/exodus/jobs/captain.dm
@@ -12,7 +12,7 @@
 	minimal_player_age = 14
 	economic_power = 20
 	ideal_character_age = 70
-	outfit_type = /decl/hierarchy/outfit/job/captain
+	outfit_type = /decl/outfit/job/captain
 	guestbanned = 1
 	must_fill = 1
 	not_random_selectable = 1
@@ -132,7 +132,7 @@
 		access_keycard_auth,
 		access_gateway
 	)
-	outfit_type = /decl/hierarchy/outfit/job/hop
+	outfit_type = /decl/outfit/job/hop
 	min_skill = list(
 		SKILL_LITERACY    = SKILL_ADEPT,
 		SKILL_COMPUTER    = SKILL_BASIC,

--- a/maps/exodus/jobs/civilian.dm
+++ b/maps/exodus/jobs/civilian.dm
@@ -7,7 +7,7 @@
 	access = list()
 	minimal_access = list()
 	alt_titles = list("Technical Assistant","Medical Intern","Research Assistant","Visitor")
-	outfit_type = /decl/hierarchy/outfit/job/generic/assistant
+	outfit_type = /decl/outfit/job/generic/assistant
 	department_types = list(/decl/department/civilian)
 
 /datum/job/assistant/get_access()
@@ -32,7 +32,7 @@
 		access_chapel_office,
 		access_crematorium
 	)
-	outfit_type = /decl/hierarchy/outfit/job/chaplain
+	outfit_type = /decl/outfit/job/chaplain
 	is_holy = TRUE
 	min_skill = list(
 		SKILL_LITERACY = SKILL_ADEPT,
@@ -55,7 +55,7 @@
 	)
 	minimal_access = list(access_bar)
 	alt_titles = list("Barista")
-	outfit_type = /decl/hierarchy/outfit/job/service/bartender
+	outfit_type = /decl/outfit/job/service/bartender
 	min_skill = list(
 		SKILL_LITERACY  = SKILL_ADEPT,
 		SKILL_COOKING   = SKILL_BASIC,
@@ -76,7 +76,7 @@
 	)
 	minimal_access = list(access_kitchen)
 	alt_titles = list("Cook")
-	outfit_type = /decl/hierarchy/outfit/job/service/chef
+	outfit_type = /decl/outfit/job/service/chef
 	min_skill = list(
 		SKILL_LITERACY  = SKILL_ADEPT,
 		SKILL_COOKING   = SKILL_ADEPT,
@@ -97,7 +97,7 @@
 	)
 	minimal_access = list(access_hydroponics)
 	alt_titles = list("Hydroponicist")
-	outfit_type = /decl/hierarchy/outfit/job/service/gardener
+	outfit_type = /decl/outfit/job/service/gardener
 	min_skill = list(
 		SKILL_LITERACY  = SKILL_ADEPT,
 		SKILL_BOTANY    = SKILL_BASIC,
@@ -133,7 +133,7 @@
 	)
 	minimal_player_age = 3
 	ideal_character_age = 40
-	outfit_type = /decl/hierarchy/outfit/job/cargo/qm
+	outfit_type = /decl/outfit/job/cargo/qm
 	min_skill = list(
 		SKILL_LITERACY = SKILL_ADEPT,
 	    SKILL_FINANCE  = SKILL_BASIC,
@@ -172,7 +172,7 @@
 		access_cargo_bot,
 		access_mailsorting
 	)
-	outfit_type = /decl/hierarchy/outfit/job/cargo/cargo_tech
+	outfit_type = /decl/outfit/job/cargo/cargo_tech
 	min_skill = list(
 		SKILL_LITERACY = SKILL_ADEPT,
 		SKILL_FINANCE  = SKILL_BASIC,
@@ -212,7 +212,7 @@
 		"Drill Technician",
 		"Prospector"
 	)
-	outfit_type = /decl/hierarchy/outfit/job/cargo/mining
+	outfit_type = /decl/outfit/job/cargo/mining
 	min_skill = list(
 		SKILL_LITERACY = SKILL_ADEPT,
 		SKILL_HAULING  = SKILL_ADEPT,
@@ -248,7 +248,7 @@
 		"Custodian",
 		"Sanitation Technician"
 	)
-	outfit_type = /decl/hierarchy/outfit/job/service/janitor
+	outfit_type = /decl/outfit/job/service/janitor
 	min_skill = list(
 		SKILL_LITERACY = SKILL_ADEPT,
 		SKILL_HAULING  = SKILL_BASIC
@@ -268,7 +268,7 @@
 	)
 	minimal_access = list(access_library)
 	alt_titles = list("Journalist")
-	outfit_type = /decl/hierarchy/outfit/job/librarian
+	outfit_type = /decl/outfit/job/librarian
 	min_skill = list(
 		SKILL_LITERACY = SKILL_ADEPT,
 		SKILL_FINANCE  = SKILL_BASIC
@@ -295,7 +295,7 @@
 		access_bridge
 	)
 	minimal_player_age = 10
-	outfit_type = /decl/hierarchy/outfit/job/internal_affairs_agent
+	outfit_type = /decl/outfit/job/internal_affairs_agent
 	min_skill = list(
 		SKILL_LITERACY = SKILL_ADEPT,
 		SKILL_FINANCE  = SKILL_BASIC

--- a/maps/exodus/jobs/engineering.dm
+++ b/maps/exodus/jobs/engineering.dm
@@ -56,7 +56,7 @@
 		access_ai_upload
 	)
 	minimal_player_age = 14
-	outfit_type = /decl/hierarchy/outfit/job/engineering/chief_engineer
+	outfit_type = /decl/outfit/job/engineering/chief_engineer
 	min_skill = list(
 		SKILL_LITERACY     = SKILL_ADEPT,
 		SKILL_COMPUTER     = SKILL_ADEPT,
@@ -124,9 +124,9 @@
 		"Maintenance Technician",
 		"Engine Technician",
 		"Electrician",
-		"Atmospheric Technician" = /decl/hierarchy/outfit/job/engineering/atmos
+		"Atmospheric Technician" = /decl/outfit/job/engineering/atmos
 	)
-	outfit_type = /decl/hierarchy/outfit/job/engineering/engineer
+	outfit_type = /decl/outfit/job/engineering/engineer
 	min_skill = list(
 		SKILL_LITERACY     = SKILL_ADEPT,
 		SKILL_COMPUTER     = SKILL_BASIC,

--- a/maps/exodus/jobs/medical.dm
+++ b/maps/exodus/jobs/medical.dm
@@ -52,7 +52,7 @@
 	guestbanned = 1
 	must_fill = 1
 	not_random_selectable = 1
-	outfit_type = /decl/hierarchy/outfit/job/medical/cmo
+	outfit_type = /decl/outfit/job/medical/cmo
 	min_skill = list(
 		SKILL_LITERACY  = SKILL_ADEPT,
 		SKILL_MEDICAL   = SKILL_EXPERT,
@@ -103,12 +103,12 @@
 		access_external_airlocks
 	)
 	alt_titles = list(
-		"Surgeon" =             /decl/hierarchy/outfit/job/medical/doctor/surgeon,
-		"Emergency Physician" = /decl/hierarchy/outfit/job/medical/doctor/emergency_physician,
-		"Nurse" =               /decl/hierarchy/outfit/job/medical/doctor/nurse,
-		"Virologist" =          /decl/hierarchy/outfit/job/medical/doctor/virologist
+		"Surgeon" =             /decl/outfit/job/medical/doctor/surgeon,
+		"Emergency Physician" = /decl/outfit/job/medical/doctor/emergency_physician,
+		"Nurse" =               /decl/outfit/job/medical/doctor/nurse,
+		"Virologist" =          /decl/outfit/job/medical/doctor/virologist
 	)
-	outfit_type = /decl/hierarchy/outfit/job/medical/doctor
+	outfit_type = /decl/outfit/job/medical/doctor
 	min_skill = list(
 		SKILL_LITERACY = SKILL_ADEPT,
 		SKILL_EVA      = SKILL_BASIC,
@@ -149,7 +149,7 @@
 		access_medical_equip,
 		access_chemistry
 	)
-	outfit_type = /decl/hierarchy/outfit/job/medical/chemist
+	outfit_type = /decl/outfit/job/medical/chemist
 	min_skill = list(
 		SKILL_LITERACY  = SKILL_ADEPT,
 		SKILL_MEDICAL   = SKILL_ADEPT,
@@ -186,7 +186,7 @@
 		access_medical_equip,
 		access_psychiatrist
 	)
-	outfit_type = /decl/hierarchy/outfit/job/medical/psychiatrist
+	outfit_type = /decl/outfit/job/medical/psychiatrist
 	min_skill = list(
 		SKILL_LITERACY = SKILL_ADEPT,
 		SKILL_MEDICAL  = SKILL_BASIC

--- a/maps/exodus/jobs/science.dm
+++ b/maps/exodus/jobs/science.dm
@@ -57,7 +57,7 @@
 	guestbanned = 1
 	must_fill = 1
 	not_random_selectable = 1
-	outfit_type = /decl/hierarchy/outfit/job/science/rd
+	outfit_type = /decl/outfit/job/science/rd
 	min_skill = list(
 		SKILL_LITERACY = SKILL_ADEPT,
 		SKILL_COMPUTER = SKILL_BASIC,
@@ -107,7 +107,7 @@
 		"High Energy Researcher"
 	)
 	minimal_player_age = 7
-	outfit_type = /decl/hierarchy/outfit/job/science/scientist
+	outfit_type = /decl/outfit/job/science/scientist
 	min_skill = list(
 		SKILL_LITERACY = SKILL_ADEPT,
 		SKILL_COMPUTER = SKILL_BASIC,
@@ -148,7 +148,7 @@
 		"Biomechanical Engineer",
 		"Mechatronic Engineer")
 	minimal_player_age = 3
-	outfit_type = /decl/hierarchy/outfit/job/science/roboticist
+	outfit_type = /decl/outfit/job/science/roboticist
 	min_skill = list(
 		SKILL_LITERACY = SKILL_ADEPT,
 		SKILL_COMPUTER = SKILL_ADEPT,

--- a/maps/exodus/jobs/security.dm
+++ b/maps/exodus/jobs/security.dm
@@ -63,7 +63,7 @@
 	guestbanned = 1
 	must_fill = 1
 	not_random_selectable = 1
-	outfit_type = /decl/hierarchy/outfit/job/security/hos
+	outfit_type = /decl/outfit/job/security/hos
 	min_skill = list(
 		SKILL_LITERACY  = SKILL_ADEPT,
 		SKILL_EVA       = SKILL_BASIC,
@@ -118,7 +118,7 @@
 		access_external_airlocks
 	)
 	minimal_player_age = 7
-	outfit_type = /decl/hierarchy/outfit/job/security/warden
+	outfit_type = /decl/outfit/job/security/warden
 	guestbanned = 1
 	min_skill = list(
 		SKILL_LITERACY  = SKILL_ADEPT,
@@ -147,7 +147,7 @@
 	supervisors = "the head of security"
 	selection_color = "#601c1c"
 	alt_titles = list(
-		"Forensic Technician" = /decl/hierarchy/outfit/job/security/detective/forensic
+		"Forensic Technician" = /decl/outfit/job/security/detective/forensic
 	)
 	economic_power = 5
 	access = list(
@@ -165,7 +165,7 @@
 		access_maint_tunnels
 	)
 	minimal_player_age = 7
-	outfit_type = /decl/hierarchy/outfit/job/security/detective
+	outfit_type = /decl/outfit/job/security/detective
 	guestbanned = 1
 	min_skill = list(
 		SKILL_LITERACY  = SKILL_ADEPT,
@@ -213,7 +213,7 @@
 		access_external_airlocks
 	)
 	minimal_player_age = 7
-	outfit_type = /decl/hierarchy/outfit/job/security/officer
+	outfit_type = /decl/outfit/job/security/officer
 	guestbanned = 1
 	min_skill = list(
 		SKILL_LITERACY  = SKILL_BASIC,

--- a/maps/exodus/jobs/synthetics.dm
+++ b/maps/exodus/jobs/synthetics.dm
@@ -9,7 +9,7 @@
 	minimal_player_age = 14
 	account_allowed = 0
 	economic_power = 0
-	outfit_type = /decl/hierarchy/outfit/job/silicon/ai
+	outfit_type = /decl/outfit/job/silicon/ai
 	loadout_allowed = FALSE
 	hud_icon = "hudblank"
 	skill_points = 0
@@ -57,7 +57,7 @@
 	account_allowed = 0
 	economic_power = 0
 	loadout_allowed = FALSE
-	outfit_type = /decl/hierarchy/outfit/job/silicon/cyborg
+	outfit_type = /decl/outfit/job/silicon/cyborg
 	hud_icon = "hudblank"
 	skill_points = 0
 	no_skill_buffs = TRUE

--- a/maps/exodus/outfits/cargo.dm
+++ b/maps/exodus/outfits/cargo.dm
@@ -1,8 +1,8 @@
-/decl/hierarchy/outfit/job/cargo
+/decl/outfit/job/cargo
 	l_ear = /obj/item/radio/headset/headset_cargo
-	abstract_type = /decl/hierarchy/outfit/job/cargo
+	abstract_type = /decl/outfit/job/cargo
 
-/decl/hierarchy/outfit/job/cargo/qm
+/decl/outfit/job/cargo/qm
 	name = "Job - Cargo"
 	uniform = /obj/item/clothing/jumpsuit/cargo
 	shoes = /obj/item/clothing/shoes/color/brown
@@ -16,13 +16,13 @@
 	desc = "A card which represents service and planning."
 	extra_details = list("goldstripe")
 
-/decl/hierarchy/outfit/job/cargo/cargo_tech
+/decl/outfit/job/cargo/cargo_tech
 	name = "Job - Cargo technician"
 	uniform = /obj/item/clothing/jumpsuit/cargotech
 	id_type = /obj/item/card/id/cargo
 	pda_type = /obj/item/modular_computer/pda/cargo
 
-/decl/hierarchy/outfit/job/cargo/mining
+/decl/outfit/job/cargo/mining
 	name = "Job - Shaft miner"
 	uniform = /obj/item/clothing/jumpsuit/miner
 	id_type = /obj/item/card/id/cargo
@@ -30,6 +30,6 @@
 	backpack_contents = list(/obj/item/crowbar = 1, /obj/item/ore = 1)
 	outfit_flags = OUTFIT_HAS_BACKPACK | OUTFIT_EXTENDED_SURVIVAL | OUTFIT_HAS_VITALS_SENSOR
 
-/decl/hierarchy/outfit/job/cargo/mining/Initialize()
+/decl/outfit/job/cargo/mining/Initialize()
 	. = ..()
 	BACKPACK_OVERRIDE_ENGINEERING

--- a/maps/exodus/outfits/civilian.dm
+++ b/maps/exodus/outfits/civilian.dm
@@ -1,14 +1,14 @@
-/decl/hierarchy/outfit/job/service
+/decl/outfit/job/service
 	l_ear = /obj/item/radio/headset/headset_service
-	abstract_type = /decl/hierarchy/outfit/job/service
+	abstract_type = /decl/outfit/job/service
 
-/decl/hierarchy/outfit/job/service/bartender
+/decl/outfit/job/service/bartender
 	name = "Job - Bartender"
 	uniform = /obj/item/clothing/pants/formal/black/outfit
 	id_type = /obj/item/card/id/civilian
 	pda_type = /obj/item/modular_computer/pda
 
-/decl/hierarchy/outfit/job/service/chef
+/decl/outfit/job/service/chef
 	name = "Job - Chef"
 	uniform = /obj/item/clothing/pants/slacks/outfit_chef
 	suit = /obj/item/clothing/suit/chef
@@ -16,7 +16,7 @@
 	id_type = /obj/item/card/id/civilian
 	pda_type = /obj/item/modular_computer/pda
 
-/decl/hierarchy/outfit/job/service/gardener
+/decl/outfit/job/service/gardener
 	name = "Job - Gardener"
 	uniform = /obj/item/clothing/jumpsuit/hydroponics
 	suit = /obj/item/clothing/suit/apron
@@ -25,19 +25,19 @@
 	id_type = /obj/item/card/id/civilian
 	pda_type = /obj/item/modular_computer/pda
 
-/decl/hierarchy/outfit/job/service/gardener/Initialize()
+/decl/outfit/job/service/gardener/Initialize()
 	. = ..()
 	backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/backpack/hydroponics
 	backpack_overrides[/decl/backpack_outfit/satchel]       = /obj/item/backpack/satchel/hyd
 	backpack_overrides[/decl/backpack_outfit/messenger_bag] = /obj/item/backpack/messenger/hyd
 
-/decl/hierarchy/outfit/job/service/janitor
+/decl/outfit/job/service/janitor
 	name = "Job - Janitor"
 	uniform = /obj/item/clothing/jumpsuit/janitor
 	id_type = /obj/item/card/id/civilian
 	pda_type = /obj/item/modular_computer/pda
 
-/decl/hierarchy/outfit/job/librarian
+/decl/outfit/job/librarian
 	name = "Job - Librarian"
 	uniform = /obj/item/clothing/pants/slacks/red/outfit
 	id_type = /obj/item/card/id/civilian
@@ -47,7 +47,7 @@
 	name = "internal affair's headset"
 	desc = "The headset of your worst enemy."
 
-/decl/hierarchy/outfit/job/internal_affairs_agent
+/decl/outfit/job/internal_affairs_agent
 	name = "Job - Internal affairs agent"
 	l_ear = /obj/item/radio/headset/heads/ia
 	uniform = /obj/item/clothing/pants/slacks/black/outfit/internal_affairs
@@ -58,7 +58,7 @@
 	id_type = /obj/item/card/id/civilian/internal_affairs_agent
 	pda_type = /obj/item/modular_computer/pda/heads/paperpusher
 
-/decl/hierarchy/outfit/job/chaplain
+/decl/outfit/job/chaplain
 	name = "Job - Chaplain"
 	uniform = /obj/item/clothing/jumpsuit/chaplain
 	hands = list(/obj/item/bible)

--- a/maps/exodus/outfits/command.dm
+++ b/maps/exodus/outfits/command.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/job/captain
+/decl/outfit/job/captain
 	name = "Job - Captain"
 	head = /obj/item/clothing/head/caphat
 	glasses = /obj/item/clothing/glasses/sunglasses
@@ -9,13 +9,13 @@
 	pda_type = /obj/item/modular_computer/pda/heads/captain
 	backpack_contents = list(/obj/item/box/ids = 1)
 
-/decl/hierarchy/outfit/job/captain/Initialize()
+/decl/outfit/job/captain/Initialize()
 	. = ..()
 	backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/backpack/captain
 	backpack_overrides[/decl/backpack_outfit/satchel]       = /obj/item/backpack/satchel/cap
 	backpack_overrides[/decl/backpack_outfit/messenger_bag] = /obj/item/backpack/messenger/com
 
-/decl/hierarchy/outfit/job/captain/post_equip(var/mob/living/human/H)
+/decl/outfit/job/captain/post_equip(var/mob/living/human/H)
 	..()
 	if(H.get_age() > 49)
 		// Since we can have something other than the default uniform at this
@@ -28,7 +28,7 @@
 			else
 				qdel(medal)
 
-/decl/hierarchy/outfit/job/hop
+/decl/outfit/job/hop
 	name = "Job - Head of Personnel"
 	uniform = /obj/item/clothing/jumpsuit/head_of_personnel
 	l_ear = /obj/item/radio/headset/heads/hop

--- a/maps/exodus/outfits/engineering.dm
+++ b/maps/exodus/outfits/engineering.dm
@@ -1,16 +1,16 @@
-/decl/hierarchy/outfit/job/engineering
-	abstract_type = /decl/hierarchy/outfit/job/engineering
+/decl/outfit/job/engineering
+	abstract_type = /decl/outfit/job/engineering
 	belt = /obj/item/belt/utility/full
 	l_ear = /obj/item/radio/headset/headset_eng
 	shoes = /obj/item/clothing/shoes/workboots
 	pda_slot = slot_l_store_str
 	outfit_flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL | OUTFIT_HAS_VITALS_SENSOR
 
-/decl/hierarchy/outfit/job/engineering/Initialize()
+/decl/outfit/job/engineering/Initialize()
 	. = ..()
 	BACKPACK_OVERRIDE_ENGINEERING
 
-/decl/hierarchy/outfit/job/engineering/chief_engineer
+/decl/outfit/job/engineering/chief_engineer
 	name = "Job - Chief Engineer"
 	head = /obj/item/clothing/head/hardhat/white
 	uniform = /obj/item/clothing/jumpsuit/chief_engineer
@@ -19,7 +19,7 @@
 	id_type = /obj/item/card/id/engineering/head
 	pda_type = /obj/item/modular_computer/pda/heads/ce
 
-/decl/hierarchy/outfit/job/engineering/engineer
+/decl/outfit/job/engineering/engineer
 	name = "Job - Engineer"
 	head = /obj/item/clothing/head/hardhat
 	uniform = /obj/item/clothing/jumpsuit/engineer
@@ -27,7 +27,7 @@
 	id_type = /obj/item/card/id/engineering
 	pda_type = /obj/item/modular_computer/pda/engineering
 
-/decl/hierarchy/outfit/job/engineering/atmos
+/decl/outfit/job/engineering/atmos
 	name = "Job - Atmospheric technician"
 	uniform = /obj/item/clothing/jumpsuit/atmospheric_technician
 	belt = /obj/item/belt/utility/atmostech

--- a/maps/exodus/outfits/medical.dm
+++ b/maps/exodus/outfits/medical.dm
@@ -1,15 +1,15 @@
-/decl/hierarchy/outfit/job/medical
-	abstract_type = /decl/hierarchy/outfit/job/medical
+/decl/outfit/job/medical
+	abstract_type = /decl/outfit/job/medical
 	l_ear = /obj/item/radio/headset/headset_med
 	shoes = /obj/item/clothing/shoes/color/white
 	pda_type = /obj/item/modular_computer/pda/medical
 	pda_slot = slot_l_store_str
 
-/decl/hierarchy/outfit/job/medical/Initialize()
+/decl/outfit/job/medical/Initialize()
 	. = ..()
 	BACKPACK_OVERRIDE_MEDICAL
 
-/decl/hierarchy/outfit/job/medical/cmo
+/decl/outfit/job/medical/cmo
 	name = "Job - Chief Medical Officer"
 	l_ear = /obj/item/radio/headset/heads/cmo
 	uniform = /obj/item/clothing/jumpsuit/chief_medical_officer
@@ -20,7 +20,7 @@
 	id_type = /obj/item/card/id/medical/head
 	pda_type = /obj/item/modular_computer/pda/heads
 
-/decl/hierarchy/outfit/job/medical/doctor
+/decl/outfit/job/medical/doctor
 	name = "Job - Medical Doctor"
 	uniform = /obj/item/clothing/jumpsuit/medical
 	suit = /obj/item/clothing/suit/toggle/labcoat
@@ -28,42 +28,42 @@
 	r_pocket = /obj/item/flashlight/pen
 	id_type = /obj/item/card/id/medical
 
-/decl/hierarchy/outfit/job/medical/doctor/emergency_physician
+/decl/outfit/job/medical/doctor/emergency_physician
 	name = "Job - Emergency physician"
 	suit = /obj/item/clothing/suit/jacket/first_responder
 
-/decl/hierarchy/outfit/job/medical/doctor/surgeon
+/decl/outfit/job/medical/doctor/surgeon
 	name = "Job - Surgeon"
 	uniform = /obj/item/clothing/pants/scrubs/blue/outfit
 	head = /obj/item/clothing/head/surgery/blue
 
-/decl/hierarchy/outfit/job/medical/doctor/virologist
+/decl/outfit/job/medical/doctor/virologist
 	name = "Job - Virologist"
 	uniform = /obj/item/clothing/jumpsuit/virologist
 	suit = /obj/item/clothing/suit/toggle/labcoat/virologist
 	mask = /obj/item/clothing/mask/surgical
 
-/decl/hierarchy/outfit/job/medical/doctor/virologist/Initialize()
+/decl/outfit/job/medical/doctor/virologist/Initialize()
 	. = ..()
 	BACKPACK_OVERRIDE_VIROLOGY
 
-/decl/hierarchy/outfit/job/medical/doctor/nurse
+/decl/outfit/job/medical/doctor/nurse
 	name = "Job - Nurse"
 	suit = null
 	uniform = /obj/item/clothing/pants/scrubs/purple/outfit
 	head = null
-/decl/hierarchy/outfit/job/medical/chemist
+/decl/outfit/job/medical/chemist
 	name = "Job - Chemist"
 	uniform = /obj/item/clothing/jumpsuit/chemist
 	suit = /obj/item/clothing/suit/toggle/labcoat/chemist
 	id_type = /obj/item/card/id/medical
 	pda_type = /obj/item/modular_computer/pda/medical
 
-/decl/hierarchy/outfit/job/medical/chemist/Initialize()
+/decl/outfit/job/medical/chemist/Initialize()
 	. = ..()
 	BACKPACK_OVERRIDE_VIROLOGY
 
-/decl/hierarchy/outfit/job/medical/psychiatrist
+/decl/outfit/job/medical/psychiatrist
 	name = "Job - Psychiatrist"
 	uniform = /obj/item/clothing/jumpsuit/psych
 	suit = /obj/item/clothing/suit/toggle/labcoat

--- a/maps/exodus/outfits/science.dm
+++ b/maps/exodus/outfits/science.dm
@@ -1,11 +1,11 @@
-/decl/hierarchy/outfit/job/science
-	abstract_type = /decl/hierarchy/outfit/job/science
+/decl/outfit/job/science
+	abstract_type = /decl/outfit/job/science
 	l_ear = /obj/item/radio/headset/headset_sci
 	suit = /obj/item/clothing/suit/toggle/labcoat
 	shoes = /obj/item/clothing/shoes/color/white
 	pda_type = /obj/item/modular_computer/pda/science
 
-/decl/hierarchy/outfit/job/science/rd
+/decl/outfit/job/science/rd
 	name = "Job - Chief Science Officer"
 	l_ear = /obj/item/radio/headset/heads/rd
 	uniform = /obj/item/clothing/jumpsuit/research_director
@@ -14,13 +14,13 @@
 	id_type = /obj/item/card/id/science/head
 	pda_type = /obj/item/modular_computer/pda/heads
 
-/decl/hierarchy/outfit/job/science/scientist
+/decl/outfit/job/science/scientist
 	name = "Job - Scientist"
 	uniform = /obj/item/clothing/jumpsuit/white
 	id_type = /obj/item/card/id/science
 	suit = /obj/item/clothing/suit/toggle/labcoat/science
 
-/decl/hierarchy/outfit/job/science/roboticist
+/decl/outfit/job/science/roboticist
 	name = "Job - Roboticist"
 	uniform = /obj/item/clothing/jumpsuit/white
 	shoes = /obj/item/clothing/shoes/color/black
@@ -29,6 +29,6 @@
 	pda_slot = slot_r_store_str
 	pda_type = /obj/item/modular_computer/pda/science
 
-/decl/hierarchy/outfit/job/science/roboticist/Initialize()
+/decl/outfit/job/science/roboticist/Initialize()
 	. = ..()
 	backpack_overrides.Cut()

--- a/maps/exodus/outfits/security.dm
+++ b/maps/exodus/outfits/security.dm
@@ -1,16 +1,16 @@
-/decl/hierarchy/outfit/job/security
-	abstract_type = /decl/hierarchy/outfit/job/security
+/decl/outfit/job/security
+	abstract_type = /decl/outfit/job/security
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud
 	l_ear = /obj/item/radio/headset/headset_sec
 	gloves = /obj/item/clothing/gloves/thick
 	shoes = /obj/item/clothing/shoes/jackboots
 	backpack_contents = list(/obj/item/handcuffs = 1)
 
-/decl/hierarchy/outfit/job/security/Initialize()
+/decl/outfit/job/security/Initialize()
 	. = ..()
 	BACKPACK_OVERRIDE_SECURITY
 
-/decl/hierarchy/outfit/job/security/hos
+/decl/outfit/job/security/hos
 	name = "Job - Head of security"
 	l_ear = /obj/item/radio/headset/heads/hos
 	uniform = /obj/item/clothing/jumpsuit/head_of_security
@@ -18,14 +18,14 @@
 	pda_type = /obj/item/modular_computer/pda/heads
 	backpack_contents = list(/obj/item/handcuffs = 1)
 
-/decl/hierarchy/outfit/job/security/warden
+/decl/outfit/job/security/warden
 	name = "Job - Warden"
 	uniform = /obj/item/clothing/jumpsuit/warden
 	l_pocket = /obj/item/flash
 	id_type = /obj/item/card/id/security
 	pda_type = /obj/item/modular_computer/pda
 
-/decl/hierarchy/outfit/job/security/detective
+/decl/outfit/job/security/detective
 	name = "Job - Detective"
 	head = /obj/item/clothing/head/det
 	uniform = /obj/item/clothing/pants/slacks/outfit/detective
@@ -37,16 +37,16 @@
 	pda_type = /obj/item/modular_computer/pda
 	backpack_contents = list(/obj/item/box/evidence = 1)
 
-/decl/hierarchy/outfit/job/security/detective/Initialize()
+/decl/outfit/job/security/detective/Initialize()
 	. = ..()
 	backpack_overrides.Cut()
 
-/decl/hierarchy/outfit/job/security/detective/forensic
+/decl/outfit/job/security/detective/forensic
 	name = "Job - Forensic technician"
 	head = null
 	suit = /obj/item/clothing/suit/forensics/blue
 
-/decl/hierarchy/outfit/job/security/officer
+/decl/outfit/job/security/officer
 	name = "Job - Security Officer"
 	uniform = /obj/item/clothing/jumpsuit/security
 	l_pocket = /obj/item/flash

--- a/maps/ministation/jobs/civilian.dm
+++ b/maps/ministation/jobs/civilian.dm
@@ -8,7 +8,7 @@
 	minimal_access = list()
 	hud_icon = "hudassistant"
 	alt_titles = list("Technical Recruit","Medical Recruit","Research Recruit","Visitor")
-	outfit_type = /decl/hierarchy/outfit/job/ministation_assistant
+	outfit_type = /decl/outfit/job/ministation_assistant
 	department_types = list(/decl/department/civilian)
 	event_categories = list(ASSIGNMENT_GARDENER)
 
@@ -17,7 +17,7 @@
 		return list(access_maint_tunnels)
 	return list()
 
-/decl/hierarchy/outfit/job/ministation_assistant
+/decl/outfit/job/ministation_assistant
 	name = "Job - Ministation Assistant"
 
 /datum/job/ministation/bartender
@@ -26,7 +26,7 @@
 	supervisors = "the Lieutenant and the Captain"
 	total_positions = 2
 	spawn_positions = 1
-	outfit_type = /decl/hierarchy/outfit/job/ministation/bartender
+	outfit_type = /decl/outfit/job/ministation/bartender
 	department_types = list(/decl/department/service)
 	selection_color = "#3fbe4a"
 	economic_power = 5
@@ -57,7 +57,7 @@
 	supervisors = "the Lieutenant and the Captain"
 	total_positions = 3
 	spawn_positions = 1
-	outfit_type = /decl/hierarchy/outfit/job/ministation/cargo
+	outfit_type = /decl/outfit/job/ministation/cargo
 	department_types = list(/decl/department/service)
 	selection_color = "#8a7c00"
 	economic_power = 5
@@ -129,7 +129,7 @@
 		"Custodian",
 		"Sanitation Technician"
 	)
-	outfit_type = /decl/hierarchy/outfit/job/ministation/janitor
+	outfit_type = /decl/outfit/job/ministation/janitor
 	min_skill = list(
 		SKILL_HAULING  = SKILL_BASIC
 	)
@@ -149,7 +149,7 @@
 		"Curator",
 		"Archivist"
 	)
-	outfit_type = /decl/hierarchy/outfit/job/ministation/librarian
+	outfit_type = /decl/outfit/job/ministation/librarian
 	min_skill = list(
 		SKILL_LITERACY = SKILL_AVERAGE
 	)

--- a/maps/ministation/jobs/command.dm
+++ b/maps/ministation/jobs/command.dm
@@ -1,7 +1,7 @@
 /datum/job/ministation/captain
 	title = "Captain"
 	supervisors = "your profit margin, your conscience, and the watchful eye of the Tradehouse Rep"
-	outfit_type = /decl/hierarchy/outfit/job/ministation/captain
+	outfit_type = /decl/outfit/job/ministation/captain
 	min_skill = list(
 		SKILL_LITERACY = SKILL_ADEPT,
 		SKILL_WEAPONS  = SKILL_ADEPT,
@@ -55,7 +55,7 @@
 /datum/job/ministation/hop
 	title = "Lieutenant"
 	supervisors = "the Captain"
-	outfit_type = /decl/hierarchy/outfit/job/ministation/hop
+	outfit_type = /decl/outfit/job/ministation/hop
 	head_position = 1
 	department_types = list(
 		/decl/department/command,

--- a/maps/ministation/jobs/engineering.dm
+++ b/maps/ministation/jobs/engineering.dm
@@ -3,7 +3,7 @@
 	supervisors = "the Head Engineer"
 	total_positions = 2
 	spawn_positions = 2
-	outfit_type = /decl/hierarchy/outfit/job/ministation/engineer
+	outfit_type = /decl/outfit/job/ministation/engineer
 	department_types = list(/decl/department/engineering)
 	selection_color = "#5b4d20"
 	economic_power = 5
@@ -118,7 +118,7 @@
 	)
 	minimal_player_age = 14
 	supervisors = "the Captain"
-	outfit_type = /decl/hierarchy/outfit/job/ministation/chief_engineer
+	outfit_type = /decl/outfit/job/ministation/chief_engineer
 	min_skill = list(
 		SKILL_LITERACY     = SKILL_ADEPT,
 		SKILL_COMPUTER     = SKILL_ADEPT,

--- a/maps/ministation/jobs/medical.dm
+++ b/maps/ministation/jobs/medical.dm
@@ -37,7 +37,7 @@
 		access_virology,
 		access_cameras
 	)
-	outfit_type = /decl/hierarchy/outfit/job/ministation/doctor
+	outfit_type = /decl/outfit/job/ministation/doctor
 	minimal_player_age = 3
 	event_categories = list(ASSIGNMENT_MEDICAL)
 
@@ -49,7 +49,7 @@
 		/decl/department/command
 	)
 	supervisors = "the Captain and your own ethics"
-	outfit_type = /decl/hierarchy/outfit/job/ministation/doctor/head
+	outfit_type = /decl/outfit/job/ministation/doctor/head
 	alt_titles = list("Chief Medical Officer", "Head Surgeon")
 	total_positions = 1
 	spawn_positions = 1

--- a/maps/ministation/jobs/science.dm
+++ b/maps/ministation/jobs/science.dm
@@ -5,7 +5,7 @@
 	spawn_positions = 1
 	total_positions = 2
 	department_types = list(/decl/department/science)
-	outfit_type = /decl/hierarchy/outfit/job/ministation/scientist
+	outfit_type = /decl/outfit/job/ministation/scientist
 	hud_icon = "hudscientist"
 	min_skill = list(
 		SKILL_LITERACY = SKILL_ADEPT,
@@ -45,7 +45,7 @@
 	spawn_positions = 1
 	total_positions = 1
 	alt_titles = list("Head Researcher", "Chief Researcher")
-	outfit_type = /decl/hierarchy/outfit/job/ministation/scientist/head
+	outfit_type = /decl/outfit/job/ministation/scientist/head
 	min_skill = list(
 		SKILL_LITERACY = SKILL_ADEPT,
 		SKILL_COMPUTER = SKILL_BASIC,

--- a/maps/ministation/jobs/security.dm
+++ b/maps/ministation/jobs/security.dm
@@ -4,7 +4,7 @@
 	supervisors = "the Head of Security"
 	spawn_positions = 1
 	total_positions = 2
-	outfit_type = /decl/hierarchy/outfit/job/ministation/security
+	outfit_type = /decl/outfit/job/ministation/security
 	department_types = list(/decl/department/security)
 	selection_color = "#990000"
 	economic_power = 7
@@ -43,7 +43,7 @@
 	supervisors = "Justice... and the Trademaster"
 	spawn_positions = 1
 	total_positions = 1
-	outfit_type = /decl/hierarchy/outfit/job/ministation/detective
+	outfit_type = /decl/outfit/job/ministation/detective
 	department_types = list(/decl/department/security)
 	selection_color = "#630000"
 	economic_power = 7
@@ -81,7 +81,7 @@
 /datum/job/ministation/security/head
 	title = "Head of Security"
 	supervisors = "the Captain"
-	outfit_type = /decl/hierarchy/outfit/job/ministation/security/head
+	outfit_type = /decl/outfit/job/ministation/security/head
 	head_position = 1
 	department_types = list(
 		/decl/department/security,

--- a/maps/ministation/jobs/synthetics.dm
+++ b/maps/ministation/jobs/synthetics.dm
@@ -9,7 +9,7 @@
 	account_allowed = 0
 	economic_power = 0
 	loadout_allowed = FALSE
-	outfit_type = /decl/hierarchy/outfit/job/silicon/cyborg
+	outfit_type = /decl/outfit/job/silicon/cyborg
 	hud_icon = "hudblank"
 	skill_points = 0
 	no_skill_buffs = TRUE
@@ -41,7 +41,7 @@
 	minimal_player_age = 7
 	account_allowed = 0
 	economic_power = 0
-	outfit_type = /decl/hierarchy/outfit/job/silicon/ai
+	outfit_type = /decl/outfit/job/silicon/ai
 	loadout_allowed = FALSE
 	hud_icon = "hudblank"
 	skill_points = 0

--- a/maps/ministation/jobs/tradehouse.dm
+++ b/maps/ministation/jobs/tradehouse.dm
@@ -7,7 +7,7 @@
 	req_admin_notify = 1
 	guestbanned = 1
 	supervisors = "the Trademaster"
-	outfit_type = /decl/hierarchy/outfit/job/ministation/tradehouse
+	outfit_type = /decl/outfit/job/ministation/tradehouse
 	min_skill = list(
 		SKILL_WEAPONS  = SKILL_BASIC,
 		SKILL_FINANCE  = SKILL_EXPERT,

--- a/maps/ministation/outfits/_outfits.dm
+++ b/maps/ministation/outfits/_outfits.dm
@@ -1,6 +1,6 @@
 // OUTFITS
-/decl/hierarchy/outfit/job/ministation
-	abstract_type = /decl/hierarchy/outfit/job/ministation
+/decl/outfit/job/ministation
+	abstract_type = /decl/outfit/job/ministation
 	pda_type = /obj/item/modular_computer/pda
 	pda_slot = slot_l_store_str
 	l_ear = null

--- a/maps/ministation/outfits/civilian.dm
+++ b/maps/ministation/outfits/civilian.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/job/ministation/cargo
+/decl/outfit/job/ministation/cargo
 	l_ear = /obj/item/radio/headset/headset_cargo
 	name = "Ministation - Job - Cargo technician"
 	uniform = /obj/item/clothing/jumpsuit/cargotech
@@ -7,11 +7,11 @@
 	backpack_contents = list(/obj/item/crowbar = 1, /obj/item/ore = 1)
 	outfit_flags = OUTFIT_HAS_BACKPACK | OUTFIT_EXTENDED_SURVIVAL | OUTFIT_HAS_VITALS_SENSOR
 
-/decl/hierarchy/outfit/job/ministation/cargo/Initialize()
+/decl/outfit/job/ministation/cargo/Initialize()
 	. = ..()
 	BACKPACK_OVERRIDE_ENGINEERING
 
-/decl/hierarchy/outfit/job/ministation/bartender
+/decl/outfit/job/ministation/bartender
 	l_ear = /obj/item/radio/headset/headset_service
 	name = "Ministation - Job - Bartender"
 	uniform = /obj/item/clothing/pants/formal/black/outfit
@@ -19,14 +19,14 @@
 	pda_type = /obj/item/modular_computer/pda
 	head = /obj/item/clothing/head/chefhat
 
-/decl/hierarchy/outfit/job/ministation/janitor
+/decl/outfit/job/ministation/janitor
 	l_ear = /obj/item/radio/headset/headset_service
 	name = "Ministation - Job - Janitor"
 	uniform = /obj/item/clothing/jumpsuit/janitor
 	id_type = /obj/item/card/id/ministation/janitor
 	pda_type = /obj/item/modular_computer/pda
 
-/decl/hierarchy/outfit/job/ministation/librarian
+/decl/outfit/job/ministation/librarian
 	l_ear = /obj/item/radio/headset/headset_service
 	name = "Ministation - Job - Librarian"
 	uniform = /obj/item/clothing/pants/slacks/red/outfit

--- a/maps/ministation/outfits/command.dm
+++ b/maps/ministation/outfits/command.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/job/ministation/captain
+/decl/outfit/job/ministation/captain
 	name = "Ministation - Job - Captain"
 	head = /obj/item/clothing/head/caphat
 	glasses = /obj/item/clothing/glasses/sunglasses
@@ -8,13 +8,13 @@
 	id_type = /obj/item/card/id/gold
 	pda_type = /obj/item/modular_computer/pda/heads/captain
 
-/decl/hierarchy/outfit/job/ministation/captain/Initialize()
+/decl/outfit/job/ministation/captain/Initialize()
 	. = ..()
 	backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/backpack/captain
 	backpack_overrides[/decl/backpack_outfit/satchel]       = /obj/item/backpack/satchel/cap
 	backpack_overrides[/decl/backpack_outfit/messenger_bag] = /obj/item/backpack/messenger/com
 
-/decl/hierarchy/outfit/job/ministation/captain/post_equip(var/mob/living/human/H)
+/decl/outfit/job/ministation/captain/post_equip(var/mob/living/human/H)
 	..()
 	if(H.get_age() > 20)
 		// Since we can have something other than the default uniform at this
@@ -27,7 +27,7 @@
 			else
 				qdel(medal)
 
-/decl/hierarchy/outfit/job/ministation/hop
+/decl/outfit/job/ministation/hop
 	name = "Ministation - Job - Lieutenant"
 	uniform = /obj/item/clothing/jumpsuit/head_of_personnel
 	l_ear = /obj/item/radio/headset/heads/hop

--- a/maps/ministation/outfits/engineering.dm
+++ b/maps/ministation/outfits/engineering.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/job/ministation/engineer
+/decl/outfit/job/ministation/engineer
 	name = "Job - Station Engineer"
 	belt = /obj/item/belt/utility/full
 	l_ear = /obj/item/radio/headset/headset_eng
@@ -11,7 +11,7 @@
 	id_type = /obj/item/card/id/ministation/engineering
 	pda_type = /obj/item/modular_computer/pda/engineering
 
-/decl/hierarchy/outfit/job/ministation/engineer/Initialize()
+/decl/outfit/job/ministation/engineer/Initialize()
 	. = ..()
 	BACKPACK_OVERRIDE_ENGINEERING
 
@@ -20,7 +20,7 @@
 	desc = "A card issued to engineering staff."
 	detail_color = COLOR_SUN
 
-/decl/hierarchy/outfit/job/ministation/chief_engineer
+/decl/outfit/job/ministation/chief_engineer
 	name = "Job - Head Engineer"
 	uniform = /obj/item/clothing/jumpsuit/hazard
 	glasses = /obj/item/clothing/glasses/welding/superior

--- a/maps/ministation/outfits/medical.dm
+++ b/maps/ministation/outfits/medical.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/job/ministation/doctor/head
+/decl/outfit/job/ministation/doctor/head
 	name = "Ministation - Job - Head Doctor"
 	l_ear = /obj/item/radio/headset/heads/cmo
 	uniform = /obj/item/clothing/pants/slacks/black/outfit/detective
@@ -9,7 +9,7 @@
 	hands = list(/obj/item/firstaid/adv)
 	id_type = /obj/item/card/id/ministation/doctor
 
-/decl/hierarchy/outfit/job/ministation/doctor
+/decl/outfit/job/ministation/doctor
 	l_ear = /obj/item/radio/headset/headset_med
 	shoes = /obj/item/clothing/shoes/color/white
 	pda_type = /obj/item/modular_computer/pda/medical
@@ -20,11 +20,11 @@
 	r_pocket = /obj/item/flashlight/pen
 	id_type = /obj/item/card/id/ministation/doctor
 
-/decl/hierarchy/outfit/job/ministation/doctor/Initialize()
+/decl/outfit/job/ministation/doctor/Initialize()
 	. = ..()
 	BACKPACK_OVERRIDE_MEDICAL
 
-/decl/hierarchy/outfit/job/ministation/doctor/head/Initialize()
+/decl/outfit/job/ministation/doctor/head/Initialize()
 	. = ..()
 	BACKPACK_OVERRIDE_MEDICAL
 

--- a/maps/ministation/outfits/science.dm
+++ b/maps/ministation/outfits/science.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/job/ministation/scientist
+/decl/outfit/job/ministation/scientist
 	l_ear = /obj/item/radio/headset/headset_sci
 	shoes = /obj/item/clothing/shoes/color/white
 	pda_type = /obj/item/modular_computer/pda/science
@@ -11,7 +11,7 @@
 	desc = "A card issued to science staff."
 	detail_color = COLOR_PALE_PURPLE_GRAY
 
-/decl/hierarchy/outfit/job/ministation/scientist/head
+/decl/outfit/job/ministation/scientist/head
 	name = "Tradeship - Job - Head Researcher"
 	l_ear = /obj/item/radio/headset/heads/rd
 	shoes = /obj/item/clothing/shoes/dress

--- a/maps/ministation/outfits/security.dm
+++ b/maps/ministation/outfits/security.dm
@@ -2,7 +2,7 @@
 	color = COLOR_DARK_RED
 	decals = list("stripe" = COLOR_RED_LIGHT)
 
-/decl/hierarchy/outfit/job/ministation/security
+/decl/outfit/job/ministation/security
 	l_ear = /obj/item/radio/headset/headset_sec
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud
 	gloves = /obj/item/clothing/gloves/thick
@@ -15,7 +15,7 @@
 	id_type = /obj/item/card/id/ministation/security
 	pda_type = /obj/item/modular_computer/pda/security
 
-/decl/hierarchy/outfit/job/ministation/security/head
+/decl/outfit/job/ministation/security/head
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud
 	l_ear = /obj/item/radio/headset/heads/hos
 	gloves = /obj/item/clothing/gloves/thick
@@ -28,11 +28,11 @@
 	id_type = /obj/item/card/id/ministation/security
 	pda_type = /obj/item/modular_computer/pda/security
 
-/decl/hierarchy/outfit/job/ministation/security/Initialize()
+/decl/outfit/job/ministation/security/Initialize()
 	. = ..()
 	BACKPACK_OVERRIDE_SECURITY
 
-/decl/hierarchy/outfit/job/ministation/security/head/Initialize()
+/decl/outfit/job/ministation/security/head/Initialize()
 	. = ..()
 	BACKPACK_OVERRIDE_SECURITY
 
@@ -44,7 +44,7 @@
 	default_hardware |= /obj/item/stock_parts/computer/scanner/reagent
 	. = ..()
 
-/decl/hierarchy/outfit/job/ministation/detective
+/decl/outfit/job/ministation/detective
 	name = "Ministation - Job - Detective"
 	head = /obj/item/clothing/head/det
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud
@@ -59,7 +59,7 @@
 	backpack_contents = list(/obj/item/box/evidence = 1)
 	gloves = /obj/item/clothing/gloves/thick
 
-/decl/hierarchy/outfit/job/ministation/detective/Initialize()
+/decl/outfit/job/ministation/detective/Initialize()
 	. = ..()
 	backpack_overrides.Cut()
 

--- a/maps/ministation/outfits/tradehouse.dm
+++ b/maps/ministation/outfits/tradehouse.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/job/ministation/tradehouse
+/decl/outfit/job/ministation/tradehouse
 	name = "Ministation - Tradehouse Representative"
 	id_type = /obj/item/card/id/ministation/tradehouse_rep
 

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
@@ -20,9 +20,9 @@
 /datum/job/submap/pod
 	title = "Stranded Survivor"
 	info = "Your ship has been destroyed by a terrible disaster."
-	outfit_type = /decl/hierarchy/outfit/job/survivor
+	outfit_type = /decl/outfit/job/survivor
 
-/decl/hierarchy/outfit/job/survivor
+/decl/outfit/job/survivor
 	name = "Job - Survivor"
 	id_type = null
 	pda_type = null

--- a/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
+++ b/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
@@ -16,9 +16,9 @@
 
 /obj/abstract/landmark/corpse/zombiescience
 	name = "Dead Scientist"
-	corpse_outfits = list(/decl/hierarchy/outfit/zombie_science)
+	corpse_outfits = list(/decl/outfit/zombie_science)
 
-/decl/hierarchy/outfit/zombie_science
+/decl/outfit/zombie_science
 	name = "Job - Dead Scientist"
 	uniform = /obj/item/clothing/jumpsuit/white
 	suit = /obj/item/clothing/suit/bio_suit/anomaly

--- a/maps/random_ruins/exoplanet_ruins/marooned/marooned.dm
+++ b/maps/random_ruins/exoplanet_ruins/marooned/marooned.dm
@@ -21,10 +21,10 @@
 
 /obj/abstract/landmark/corpse/marooned_officer
 	name = "Horazy Warda"
-	corpse_outfits = list(/decl/hierarchy/outfit/marooned_officer)
+	corpse_outfits = list(/decl/outfit/marooned_officer)
 	spawn_flags = ~CORPSE_SPAWNER_RANDOM_NAME
 
-/decl/hierarchy/outfit/marooned_officer
+/decl/outfit/marooned_officer
 	name = "Dead Magnitka's fleet officer"
 	uniform = /obj/item/clothing/costume/magintka_uniform
 	suit = /obj/item/clothing/suit/jacket/winter

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
@@ -19,7 +19,7 @@
 	title = "Colonist"
 	info = "You are a Colonist, living on the rim of explored, let alone inhabited, space in a reconstructed shelter made from the very ship that took you here."
 	total_positions = 6
-	outfit_type = /decl/hierarchy/outfit/job/colonist
+	outfit_type = /decl/outfit/job/colonist
 	min_skill = list(
 		SKILL_LITERACY = SKILL_BASIC,
 		SKILL_CONSTRUCTION = SKILL_BASIC,
@@ -37,7 +37,7 @@
 		"Colony Miner"
 	)
 
-/decl/hierarchy/outfit/job/colonist
+/decl/outfit/job/colonist
 	name = "Job - Colonist"
 	id_type = null
 	pda_type = null

--- a/maps/shaded_hills/jobs/caves.dm
+++ b/maps/shaded_hills/jobs/caves.dm
@@ -5,7 +5,7 @@
 	title                   = "Cave Dweller"
 	spawn_positions         = -1
 	total_positions         = -1
-	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/cave_dweller
+	outfit_type             = /decl/outfit/job/shaded_hills/cave_dweller
 	max_skill               = list(
 		SKILL_MEDICAL       = SKILL_MAX,
 		SKILL_ANATOMY       = SKILL_MAX,

--- a/maps/shaded_hills/jobs/inn.dm
+++ b/maps/shaded_hills/jobs/inn.dm
@@ -13,7 +13,7 @@
 	description             = "You are the proprietor of the inn, directing your employees and ensuring guests are treated properly, whatever you think that may mean."
 	spawn_positions         = 1
 	total_positions         = 1
-	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/innkeeper
+	outfit_type             = /decl/outfit/job/shaded_hills/innkeeper
 	head_position           = TRUE
 	req_admin_notify        = TRUE
 	guestbanned             = TRUE
@@ -43,7 +43,7 @@
 	description             = "You work at the inn, though your exact duties are nebulous. You may be a cook in the kitchen, someone who keeps the lanterns lit and the furniture from falling apart, or something else entirely; either way, you have to earn your keep."
 	spawn_positions         = 3
 	total_positions         = 3
-	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/inn_worker
+	outfit_type             = /decl/outfit/job/shaded_hills/inn_worker
 	min_skill               = list(
 		SKILL_HAULING       = SKILL_BASIC, // must be fit enough to do basic tasks around the inn
 		SKILL_COOKING       = SKILL_BASIC, // and should be skilled enough to do basic cooking/farming work
@@ -64,7 +64,7 @@
 	description             = "You work the bar at the inn and ensure that patrons are fed, slaked, and merry. If you keep the hearth lit and prepare fresh food and drink, you will certainly earn your keep."
 	spawn_positions         = 2
 	total_positions         = 2
-	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/bartender
+	outfit_type             = /decl/outfit/job/shaded_hills/bartender
 	min_skill               = list(
 		SKILL_COOKING       = SKILL_EXPERT // skilled with food and drink
 	)
@@ -83,7 +83,7 @@
 	description             = "You grow crops both for your own subsistence and to sell to others like the innkeeper or general store. You are knowledgeable of local plants grown for sustenance, but your knowledge of niche herbs may be spottier."
 	spawn_positions         = 3
 	total_positions         = 3
-	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/farmer
+	outfit_type             = /decl/outfit/job/shaded_hills/farmer
 	min_skill               = list(
 		SKILL_HAULING       = SKILL_ADEPT, // farming can be demanding work
 		SKILL_BOTANY        = SKILL_ADEPT, // must be skilled enough to have plants reliably survive when planted

--- a/maps/shaded_hills/jobs/shrine.dm
+++ b/maps/shaded_hills/jobs/shrine.dm
@@ -17,7 +17,7 @@
 	description             = "You are the leader of the local religious order, living and working within the shrine. You are expected to see to both the spiritual and physical health of the populace, as well as travellers, if they can offer appropriate tithe."
 	spawn_positions         = 1
 	total_positions         = 1
-	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/shrine/keeper
+	outfit_type             = /decl/outfit/job/shaded_hills/shrine/keeper
 	min_skill               = list(
 		SKILL_STONEMASONRY  = SKILL_BASIC,
 		SKILL_CARPENTRY     = SKILL_BASIC,
@@ -44,7 +44,7 @@
 	description             = "You are an acolyte of the local religious order, living and working within the shrine. Under the direction of the shrine keeper, you are expected to tend to the shrine and the grounds, and to produce food or other goods for use or trade to support the clergy."
 	spawn_positions         = 2
 	total_positions         = 2
-	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/shrine
+	outfit_type             = /decl/outfit/job/shaded_hills/shrine
 	min_skill               = list(
 		SKILL_STONEMASONRY  = SKILL_BASIC,
 		SKILL_CARPENTRY     = SKILL_BASIC,

--- a/maps/shaded_hills/jobs/visitors.dm
+++ b/maps/shaded_hills/jobs/visitors.dm
@@ -13,7 +13,7 @@
 	description             = "You have travelled to this area from elsewhere. You may be a vagabond, a wastrel, a nomad, or just passing through on your way to somewhere else. How long you're staying and where you're headed is up to you entirely."
 	spawn_positions         = -1
 	total_positions         = -1
-	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/traveller
+	outfit_type             = /decl/outfit/job/shaded_hills/traveller
 	skill_points            = 20
 
 /obj/abstract/landmark/start/shaded_hills/traveller
@@ -27,7 +27,7 @@
 	description             = "You are a skilled professional who has travelled to this area from elsewhere. You may be a doctor, a scholar, a monk, or some other highly-educated individual with rare skills. Whatever your reason for coming here, you are likely one of the only individuals in the area to possess your unique skillset."
 	spawn_positions         = 2
 	total_positions         = 2
-	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/traveller/scholar
+	outfit_type             = /decl/outfit/job/shaded_hills/traveller/scholar
 	skill_points            = 26
 	min_skill               = list(
 		SKILL_LITERACY      = SKILL_ADEPT
@@ -47,7 +47,7 @@
 	description             = "You are a wandering swordmaster sworn to a vow of poverty, with nothing to your name but the armour on your back and the blade at your hip. Beggar knights are tolerated due to their martial prowess, and are usually paid with food or new equipment as they are avowed against carrying coin."
 	spawn_positions         = 2
 	total_positions         = 2
-	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/beggar_knight
+	outfit_type             = /decl/outfit/job/shaded_hills/beggar_knight
 	min_skill               = list(
 		SKILL_COMBAT        = SKILL_ADEPT,
 		SKILL_WEAPONS       = SKILL_ADEPT,
@@ -75,7 +75,7 @@
 	description             = "You are an ordained person of faith, travelling the lands on the business of your order, to preach, or simply to experience new people and cultures. You are battle-trained, but are also a healer."
 	spawn_positions         = 2
 	total_positions         = 2
-	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/traveller/cleric
+	outfit_type             = /decl/outfit/job/shaded_hills/traveller/cleric
 	min_skill               = list(
 		SKILL_COMBAT        = SKILL_ADEPT,
 		SKILL_WEAPONS       = SKILL_ADEPT,

--- a/maps/shaded_hills/jobs/wilderness.dm
+++ b/maps/shaded_hills/jobs/wilderness.dm
@@ -13,7 +13,7 @@
 	supervisors             = "the consequences of your actions"
 	spawn_positions         = 1
 	total_positions         = 1
-	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/miner
+	outfit_type             = /decl/outfit/job/shaded_hills/miner
 	min_skill               = list(
 		SKILL_HAULING       = SKILL_ADEPT, // general physical activity
 		SKILL_METALWORK     = SKILL_BASIC, // ore smelting, metallurgy
@@ -31,7 +31,7 @@
 	supervisors             = "nature"
 	spawn_positions         = 1
 	total_positions         = 1
-	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/herbalist
+	outfit_type             = /decl/outfit/job/shaded_hills/herbalist
 	min_skill               = list(
 		SKILL_BOTANY        = SKILL_ADEPT, // growing, processing, and identifying plants
 		SKILL_MEDICAL       = SKILL_BASIC, // identifying illnesses and applying medicines
@@ -53,7 +53,7 @@
 	supervisors             = "nature"
 	spawn_positions         = 1
 	total_positions         = 1
-	outfit_type             = /decl/hierarchy/outfit/job/shaded_hills/forester
+	outfit_type             = /decl/outfit/job/shaded_hills/forester
 	min_skill               = list(
 		SKILL_HAULING       = SKILL_ADEPT, // overall physical activity
 		SKILL_BOTANY        = SKILL_BASIC, // growing and harvesting plants, trees, etc

--- a/maps/shaded_hills/outfits/_outfits.dm
+++ b/maps/shaded_hills/outfits/_outfits.dm
@@ -1,6 +1,6 @@
-/decl/hierarchy/outfit/job/shaded_hills
+/decl/outfit/job/shaded_hills
 	name              = "Shaded Hills Outfit"
-	abstract_type     = /decl/hierarchy/outfit/job/shaded_hills
+	abstract_type     = /decl/outfit/job/shaded_hills
 	id_type           = null
 	pda_type          = null
 	l_ear             = null

--- a/maps/shaded_hills/outfits/caves.dm
+++ b/maps/shaded_hills/outfits/caves.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/job/shaded_hills/cave_dweller
+/decl/outfit/job/shaded_hills/cave_dweller
 	name    = "Shaded Hills - Cave Dweller"
 	uniform = /obj/item/clothing/pants/loincloth
 	shoes   = /obj/item/clothing/shoes/sandal

--- a/maps/shaded_hills/outfits/inn.dm
+++ b/maps/shaded_hills/outfits/inn.dm
@@ -1,12 +1,12 @@
-/decl/hierarchy/outfit/job/shaded_hills/innkeeper
+/decl/outfit/job/shaded_hills/innkeeper
 	name    = "Shaded Hills - Innkeeper"
 	suit    = /obj/item/clothing/suit/apron/colourable
 
-/decl/hierarchy/outfit/job/shaded_hills/inn_worker
+/decl/outfit/job/shaded_hills/inn_worker
 	name    = "Shaded Hills - Inn Worker"
 
-/decl/hierarchy/outfit/job/shaded_hills/bartender
+/decl/outfit/job/shaded_hills/bartender
 	name    = "Shaded Hills - Bartender"
 
-/decl/hierarchy/outfit/job/shaded_hills/farmer
+/decl/outfit/job/shaded_hills/farmer
 	name    = "Shaded Hills - Farmer"

--- a/maps/shaded_hills/outfits/shrine.dm
+++ b/maps/shaded_hills/outfits/shrine.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/job/shaded_hills/shrine
+/decl/outfit/job/shaded_hills/shrine
 	name    = "Shaded Hills - Shrine Attendant"
 	uniform = /obj/item/clothing/suit/robe
 	shoes   = /obj/item/clothing/shoes/sandal
@@ -8,7 +8,7 @@
 		/obj/item/stack/medical/splint/crafted/five       = 1
 	)
 
-/decl/hierarchy/outfit/job/shaded_hills/shrine/keeper
+/decl/outfit/job/shaded_hills/shrine/keeper
 	name    = "Shaded Hills - Shrine Keeper"
 	suit    = /obj/item/clothing/suit/mantle
 	mask    = /obj/item/clothing/neck/necklace/prayer_beads/basalt

--- a/maps/shaded_hills/outfits/visitors.dm
+++ b/maps/shaded_hills/outfits/visitors.dm
@@ -1,7 +1,7 @@
-/decl/hierarchy/outfit/job/shaded_hills/traveller
+/decl/outfit/job/shaded_hills/traveller
 	name    = "Shaded Hills - Traveller"
 
-/decl/hierarchy/outfit/job/shaded_hills/beggar_knight
+/decl/outfit/job/shaded_hills/beggar_knight
 	name = "Shaded Hills - Beggar Knight"
 	suit = /obj/item/clothing/suit/armor/forged/banded
 	belt = /obj/item/bladed/shortsword
@@ -11,10 +11,10 @@
 		/obj/item/chems/waterskin/crafted/wine           = 1
 	)
 
-/decl/hierarchy/outfit/job/shaded_hills/traveller/scholar
+/decl/outfit/job/shaded_hills/traveller/scholar
 	name    = "Shaded Hills - Itinerant Scholar"
 
-/decl/hierarchy/outfit/job/shaded_hills/traveller/cleric
+/decl/outfit/job/shaded_hills/traveller/cleric
 	name    = "Shaded Hills - Travelling Cleric"
 	backpack_contents = list(
 		/obj/item/stack/medical/bandage/crafted/ten = 1,

--- a/maps/shaded_hills/outfits/wilderness.dm
+++ b/maps/shaded_hills/outfits/wilderness.dm
@@ -1,12 +1,12 @@
-/decl/hierarchy/outfit/job/shaded_hills/forester
+/decl/outfit/job/shaded_hills/forester
 	name  = "Shaded Hills - Forester"
 	hands = list(
 		/obj/item/gun/launcher/bow,
 		/obj/item/stack/material/bow_ammo/arrow/fifteen
 	)
 
-/decl/hierarchy/outfit/job/shaded_hills/miner
+/decl/outfit/job/shaded_hills/miner
 	name  = "Shaded Hills - Miner"
 
-/decl/hierarchy/outfit/job/shaded_hills/herbalist
+/decl/outfit/job/shaded_hills/herbalist
 	name  = "Shaded Hills - Herbalist"

--- a/maps/tradeship/jobs/civilian.dm
+++ b/maps/tradeship/jobs/civilian.dm
@@ -3,9 +3,9 @@
 	total_positions = -1
 	spawn_positions = -1
 	supervisors = "literally everyone, you bottom feeder"
-	outfit_type = /decl/hierarchy/outfit/job/tradeship/hand
+	outfit_type = /decl/outfit/job/tradeship/hand
 	alt_titles = list(
-		"Cook" = /decl/hierarchy/outfit/job/tradeship/hand/cook,
+		"Cook" = /decl/outfit/job/tradeship/hand/cook,
 		"Cargo Hand",
 		"Passenger")
 	department_types = list(/decl/department/civilian)

--- a/maps/tradeship/jobs/command.dm
+++ b/maps/tradeship/jobs/command.dm
@@ -1,7 +1,7 @@
 /datum/job/tradeship_captain
 	title = "Captain"
 	supervisors = "your profit margin, your conscience, and the Trademaster"
-	outfit_type = /decl/hierarchy/outfit/job/tradeship/captain
+	outfit_type = /decl/outfit/job/tradeship/captain
 	min_skill = list(
 		SKILL_LITERACY = SKILL_ADEPT,
 		SKILL_WEAPONS  = SKILL_ADEPT,
@@ -76,7 +76,7 @@
 /datum/job/tradeship_first_mate
 	title = "First Mate"
 	supervisors = "the Captain"
-	outfit_type = /decl/hierarchy/outfit/job/tradeship/mate
+	outfit_type = /decl/outfit/job/tradeship/mate
 	head_position = 1
 	department_types = list(
 		/decl/department/command,

--- a/maps/tradeship/jobs/engineering.dm
+++ b/maps/tradeship/jobs/engineering.dm
@@ -1,7 +1,7 @@
 /datum/job/tradeship_engineer
 	title = "Junior Engineer"
 	supervisors = "the Head Engineer"
-	outfit_type = /decl/hierarchy/outfit/job/tradeship/hand/engine
+	outfit_type = /decl/outfit/job/tradeship/hand/engine
 	department_types = list(/decl/department/engineering)
 	total_positions = 8
 	spawn_positions = 7
@@ -105,7 +105,7 @@
 	)
 	minimal_player_age = 14
 	supervisors = "the Captain"
-	outfit_type = /decl/hierarchy/outfit/job/tradeship/chief_engineer
+	outfit_type = /decl/outfit/job/tradeship/chief_engineer
 	min_skill = list(
 		SKILL_LITERACY     = SKILL_ADEPT,
 		SKILL_COMPUTER     = SKILL_ADEPT,

--- a/maps/tradeship/jobs/medical.dm
+++ b/maps/tradeship/jobs/medical.dm
@@ -36,7 +36,7 @@
 		access_surgery,
 		access_virology
 	)
-	outfit_type = /decl/hierarchy/outfit/job/tradeship/doc/junior
+	outfit_type = /decl/outfit/job/tradeship/doc/junior
 	event_categories = list(ASSIGNMENT_MEDICAL)
 
 /datum/job/tradeship_doctor/head
@@ -47,7 +47,7 @@
 		/decl/department/command
 	)
 	supervisors = "the Captain and your own ethics"
-	outfit_type = /decl/hierarchy/outfit/job/tradeship/doc
+	outfit_type = /decl/outfit/job/tradeship/doc
 	alt_titles = list("Surgeon")
 	total_positions = 1
 	spawn_positions = 1

--- a/maps/tradeship/jobs/science.dm
+++ b/maps/tradeship/jobs/science.dm
@@ -3,8 +3,8 @@
 	supervisors = "the Head Researcher and the Captain"
 	total_positions = 2
 	spawn_positions = 1
-	alt_titles = list()	
-	outfit_type = /decl/hierarchy/outfit/job/tradeship/hand/researcher/junior
+	alt_titles = list()
+	outfit_type = /decl/outfit/job/tradeship/hand/researcher/junior
 	min_skill = list(
 		SKILL_LITERACY = SKILL_ADEPT,
 		SKILL_COMPUTER = SKILL_BASIC,
@@ -22,11 +22,11 @@
 	economic_power = 7
 	minimal_player_age = 7
 	access = list(
-		access_robotics, 
-		access_tox, 
-		access_tox_storage, 
-		access_research, 
-		access_xenobiology, 
+		access_robotics,
+		access_tox,
+		access_tox_storage,
+		access_research,
+		access_xenobiology,
 		access_xenoarch
 	)
 	minimal_access = list(
@@ -45,7 +45,7 @@
 	spawn_positions = 1
 	total_positions = 1
 	alt_titles = list()
-	outfit_type = /decl/hierarchy/outfit/job/tradeship/hand/researcher
+	outfit_type = /decl/outfit/job/tradeship/hand/researcher
 	min_skill = list(
 		SKILL_LITERACY = SKILL_ADEPT,
 		SKILL_COMPUTER = SKILL_BASIC,
@@ -74,46 +74,46 @@
 		access_bridge,
 		access_tox,
 		access_morgue,
-		access_tox_storage, 
-		access_teleporter, 
-		access_sec_doors, 
+		access_tox_storage,
+		access_teleporter,
+		access_sec_doors,
 		access_heads,
 		access_research,
-		access_robotics, 
-		access_xenobiology, 
-		access_ai_upload, 
+		access_robotics,
+		access_xenobiology,
+		access_ai_upload,
 		access_tech_storage,
-		access_RC_announce, 
-		access_keycard_auth, 
-		access_tcomsat, 
-		access_gateway, 
-		access_xenoarch, 
+		access_RC_announce,
+		access_keycard_auth,
+		access_tcomsat,
+		access_gateway,
+		access_xenoarch,
 		access_network
 	)
 	minimal_access = list(
-		access_rd, 
-		access_bridge, 
-		access_tox, 
+		access_rd,
+		access_bridge,
+		access_tox,
 		access_morgue,
 		access_tox_storage,
-		access_teleporter, 
+		access_teleporter,
 		access_sec_doors,
 		access_heads,
-		access_research, 
+		access_research,
 		access_robotics,
 		access_xenobiology,
-		access_ai_upload, 
+		access_ai_upload,
 		access_tech_storage,
-		access_RC_announce, 
+		access_RC_announce,
 		access_keycard_auth,
-		access_tcomsat, 
-		access_gateway, 
-		access_xenoarch, 
+		access_tcomsat,
+		access_gateway,
+		access_xenoarch,
 		access_network
 	)
 	minimal_player_age = 14
 	ideal_character_age = 50
-	guestbanned = 1	
+	guestbanned = 1
 	must_fill = 1
 	not_random_selectable = 1
 	event_categories = list(ASSIGNMENT_SCIENTIST)

--- a/maps/tradeship/jobs/synthetics.dm
+++ b/maps/tradeship/jobs/synthetics.dm
@@ -9,7 +9,7 @@
 	account_allowed = 0
 	economic_power = 0
 	loadout_allowed = FALSE
-	outfit_type = /decl/hierarchy/outfit/job/silicon/cyborg
+	outfit_type = /decl/outfit/job/silicon/cyborg
 	hud_icon = "hudblank"
 	skill_points = 0
 	no_skill_buffs = TRUE

--- a/maps/tradeship/outfits/_outfits.dm
+++ b/maps/tradeship/outfits/_outfits.dm
@@ -1,15 +1,15 @@
 // OUTFITS
-/decl/hierarchy/outfit/job/tradeship
-	abstract_type = /decl/hierarchy/outfit/job/tradeship
+/decl/outfit/job/tradeship
+	abstract_type = /decl/outfit/job/tradeship
 	pda_type = /obj/item/modular_computer/pda
 	pda_slot = slot_l_store_str
 	l_ear = null
 	r_ear = null
 
-/decl/hierarchy/outfit/job/tradeship/hand
+/decl/outfit/job/tradeship/hand
 	name = "Tradeship - Job - Deck Hand"
 
-/decl/hierarchy/outfit/job/tradeship/hand/pre_equip(mob/living/human/H)
+/decl/outfit/job/tradeship/hand/pre_equip(mob/living/human/H)
 	..()
 	uniform = pick(list(
 		/obj/item/clothing/pants/mustard/overalls,
@@ -19,6 +19,6 @@
 		/obj/item/clothing/jumpsuit/grey
 	))
 
-/decl/hierarchy/outfit/job/tradeship/hand/cook
+/decl/outfit/job/tradeship/hand/cook
 	name = "Tradeship - Job - Cook"
 	head = /obj/item/clothing/head/chefhat

--- a/maps/tradeship/outfits/command.dm
+++ b/maps/tradeship/outfits/command.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/job/tradeship/captain
+/decl/outfit/job/tradeship/captain
 	name = "Tradeship - Job - Tradehouse Captain"
 	uniform = /obj/item/clothing/pants/baggy/casual/classicjeans
 	shoes = /obj/item/clothing/shoes/color/black
@@ -7,7 +7,7 @@
 	id_type = /obj/item/card/id/gold
 	l_ear = /obj/item/radio/headset/heads/captain
 
-/decl/hierarchy/outfit/job/tradeship/captain/post_equip(var/mob/living/human/H)
+/decl/outfit/job/tradeship/captain/post_equip(var/mob/living/human/H)
 	..()
 	var/obj/item/clothing/uniform = H.get_equipped_item(slot_w_uniform_str)
 	if(uniform)
@@ -17,7 +17,7 @@
 		else
 			qdel(eyegore)
 
-/decl/hierarchy/outfit/job/tradeship/mate
+/decl/outfit/job/tradeship/mate
 	name = "Tradeship - Job - Tradehouse First Mate"
 	uniform = /obj/item/clothing/pants/slacks/black/outfit/checkered
 	shoes = /obj/item/clothing/shoes/dress

--- a/maps/tradeship/outfits/engineering.dm
+++ b/maps/tradeship/outfits/engineering.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/job/tradeship/hand/engine
+/decl/outfit/job/tradeship/hand/engine
 	name = "Tradeship - Job - Junior Engineer"
 	head = /obj/item/clothing/head/hardhat
 	id_type = /obj/item/card/id/tradeship/engineering
@@ -14,7 +14,7 @@
 	desc = "A card issued to engineering staff."
 	detail_color = COLOR_SUN
 
-/decl/hierarchy/outfit/job/tradeship/chief_engineer
+/decl/outfit/job/tradeship/chief_engineer
 	name = "Tradeship - Job - Head Engineer"
 	uniform = /obj/item/clothing/jumpsuit/chief_engineer
 	glasses = /obj/item/clothing/glasses/welding/superior

--- a/maps/tradeship/outfits/medical.dm
+++ b/maps/tradeship/outfits/medical.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/job/tradeship/doc
+/decl/outfit/job/tradeship/doc
 	name = "Tradeship - Job - Head Doctor"
 	uniform = /obj/item/clothing/pants/slacks/black/outfit/detective
 	shoes = /obj/item/clothing/shoes/dress
@@ -12,6 +12,6 @@
 	desc = "A card issued to medical staff."
 	detail_color = COLOR_PALE_BLUE_GRAY
 
-/decl/hierarchy/outfit/job/tradeship/doc/junior
+/decl/outfit/job/tradeship/doc/junior
 	name = "Tradeship - Job - Junior Doctor"
 	l_ear = /obj/item/radio/headset/headset_med

--- a/maps/tradeship/outfits/science.dm
+++ b/maps/tradeship/outfits/science.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/job/tradeship/hand/researcher
+/decl/outfit/job/tradeship/hand/researcher
 	name = "Tradeship - Job - Head Researcher"
 	shoes = /obj/item/clothing/shoes/dress
 	pda_type = /obj/item/modular_computer/pda/science
@@ -10,7 +10,7 @@
 	desc = "A card issued to science staff."
 	detail_color = COLOR_PALE_PURPLE_GRAY
 
-/decl/hierarchy/outfit/job/tradeship/hand/researcher/junior
+/decl/outfit/job/tradeship/hand/researcher/junior
 	name = "Tradeship - Job - Junior Researcher"
 	id_type = /obj/item/card/id/tradeship/science
 	l_ear = /obj/item/radio/headset/headset_sci

--- a/mods/content/corporate/away_sites/lar_maria/lar_maria.dm
+++ b/mods/content/corporate/away_sites/lar_maria/lar_maria.dm
@@ -64,23 +64,23 @@
 
 /obj/abstract/landmark/corpse/lar_maria/test_subject
 	name = "dead test subject"
-	corpse_outfits = list(/decl/hierarchy/outfit/corpse/test_subject)
+	corpse_outfits = list(/decl/outfit/corpse/test_subject)
 	spawn_flags = CORPSE_SPAWNER_NO_RANDOMIZATION//no name, no hairs etc.
 
-/decl/hierarchy/outfit/corpse/test_subject
+/decl/outfit/corpse/test_subject
 	name = "dead ZHP test subject"
 	uniform = /obj/item/clothing/jumpsuit/orange
 	shoes = /obj/item/clothing/shoes/color/orange
 
 /obj/abstract/landmark/corpse/lar_maria/zhp_guard
 	name = "dead guard"
-	corpse_outfits = list(/decl/hierarchy/outfit/corpse/zhp_guard)
+	corpse_outfits = list(/decl/outfit/corpse/zhp_guard)
 	skin_tones_per_species = list(SPECIES_HUMAN = list(-15))
 
 /obj/abstract/landmark/corpse/lar_maria/zhp_guard/dark
 	skin_tones_per_species = list(SPECIES_HUMAN = list(-115))
 
-/decl/hierarchy/outfit/corpse/zhp_guard
+/decl/outfit/corpse/zhp_guard
 	name = "Dead ZHP guard"
 	uniform = /obj/item/clothing/jumpsuit/virologist
 	suit = /obj/item/clothing/suit/armor/pcarrier/light
@@ -133,9 +133,9 @@
 
 /obj/abstract/landmark/corpse/lar_maria/virologist
 	name = "dead virologist"
-	corpse_outfits = list(/decl/hierarchy/outfit/corpse/zhp_virologist)
+	corpse_outfits = list(/decl/outfit/corpse/zhp_virologist)
 
-/decl/hierarchy/outfit/corpse/zhp_virologist
+/decl/outfit/corpse/zhp_virologist
 	name = "Dead male ZHP virologist"
 	uniform = /obj/item/clothing/jumpsuit/virologist
 	suit = /obj/item/clothing/suit/toggle/labcoat
@@ -152,12 +152,12 @@
 
 /obj/abstract/landmark/corpse/lar_maria/virologist_female
 	name = "dead virologist"
-	corpse_outfits = list(/decl/hierarchy/outfit/corpse/zhp_virologist_female)
+	corpse_outfits = list(/decl/outfit/corpse/zhp_virologist_female)
 	hair_styles_per_species = list(SPECIES_HUMAN = list(/decl/sprite_accessory/hair/flair))
 	hair_colors_per_species = list(SPECIES_HUMAN = list("#ae7b48"))
 	genders_per_species = list(SPECIES_HUMAN = list(FEMALE))
 
-/decl/hierarchy/outfit/corpse/zhp_virologist_female
+/decl/outfit/corpse/zhp_virologist_female
 	name = "Dead female ZHP virologist"
 	uniform = /obj/item/clothing/jumpsuit/virologist
 	suit = /obj/item/clothing/suit/toggle/labcoat

--- a/mods/content/corporate/clothing/outfits.dm
+++ b/mods/content/corporate/clothing/outfits.dm
@@ -1,5 +1,5 @@
-/decl/hierarchy/outfit/nanotrasen
-	abstract_type = /decl/hierarchy/outfit/nanotrasen
+/decl/outfit/nanotrasen
+	abstract_type = /decl/outfit/nanotrasen
 	uniform = /obj/item/clothing/costume/centcom
 	shoes = /obj/item/clothing/shoes/dress
 	gloves = /obj/item/clothing/gloves
@@ -10,19 +10,19 @@
 	pda_slot = slot_r_store_str
 	pda_type = /obj/item/modular_computer/pda/heads
 
-/decl/hierarchy/outfit/nanotrasen/representative
+/decl/outfit/nanotrasen/representative
 	name = "Corporate Representative"
 	belt = /obj/item/clipboard
 	id_pda_assignment = "Corporate Representative"
 
-/decl/hierarchy/outfit/nanotrasen/officer
+/decl/outfit/nanotrasen/officer
 	name = "Corporate Officer"
 	head = /obj/item/clothing/head/beret/corp/centcom/officer
 	l_ear = /obj/item/radio/headset/heads/captain
 	belt = /obj/item/gun/energy
 	id_pda_assignment = "Corporate Officer"
 
-/decl/hierarchy/outfit/nanotrasen/captain
+/decl/outfit/nanotrasen/captain
 	name = "Corporate Captain"
 	uniform = /obj/item/clothing/costume/centcom_captain
 	l_ear = /obj/item/radio/headset/heads/captain
@@ -30,7 +30,7 @@
 	belt = /obj/item/gun/energy
 	id_pda_assignment = "Corporate Captain"
 
-/decl/hierarchy/outfit/nanotrasen/commander
+/decl/outfit/nanotrasen/commander
 	name = "Corporate Commander"
 	head = /obj/item/clothing/head/centhat
 	mask = /obj/item/clothing/mask/smokable/cigarette/cigar/cohiba
@@ -43,18 +43,18 @@
 	l_pocket = /obj/item/flame/fuelled/lighter/zippo
 	id_pda_assignment = "Corporate Commander"
 
-/decl/hierarchy/outfit/death_command
+/decl/outfit/death_command
 	name = "Spec Ops - Death commando"
 
-/decl/hierarchy/outfit/death_command/equip_outfit(mob/living/human/H, assignment, equip_adjustments, datum/job/job, datum/mil_rank/rank)
+/decl/outfit/death_command/equip_outfit(mob/living/human/H, assignment, equip_adjustments, datum/job/job, datum/mil_rank/rank)
 	var/decl/special_role/deathsquad = GET_DECL(/decl/special_role/deathsquad)
 	deathsquad.equip_role(H)
 	return 1
 
-/decl/hierarchy/outfit/syndicate_command
+/decl/outfit/syndicate_command
 	name = "Spec Ops - Syndicate commando"
 
-/decl/hierarchy/outfit/syndicate_command/equip_outfit(mob/living/human/H, assignment, equip_adjustments, datum/job/job, datum/mil_rank/rank)
+/decl/outfit/syndicate_command/equip_outfit(mob/living/human/H, assignment, equip_adjustments, datum/job/job, datum/mil_rank/rank)
 	var/decl/special_role/commandos = GET_DECL(/decl/special_role/deathsquad/mercenary)
 	commandos.equip_role(H)
 	return 1

--- a/mods/content/corporate/datum/antagonists/commando.dm
+++ b/mods/content/corporate/datum/antagonists/commando.dm
@@ -8,12 +8,12 @@
 	hard_cap_round = 8
 	initial_spawn_req = 4
 	initial_spawn_target = 6
-	default_outfit = /decl/hierarchy/outfit/mercenary_commando
+	default_outfit = /decl/outfit/mercenary_commando
 	default_access = list(access_mercenary)
 	rig_type = /obj/item/rig/merc
 	id_title = "Commando"
 
-/decl/hierarchy/outfit/mercenary_commando
+/decl/outfit/mercenary_commando
 	name =    "Special Role - Mercenary Commando"
 	l_ear =   /obj/item/radio/headset/mercenary/commando
 	id_type = /obj/item/card/id/centcom/ERT

--- a/mods/content/corporate/datum/antagonists/deathsquad.dm
+++ b/mods/content/corporate/datum/antagonists/deathsquad.dm
@@ -18,7 +18,7 @@
 	initial_spawn_target = 6
 
 	faction = "deathsquad"
-	default_outfit = /decl/hierarchy/outfit/commando
+	default_outfit = /decl/outfit/commando
 	id_title = "Asset Protection"
 	var/deployed = 0
 
@@ -26,7 +26,7 @@
 	if(..())
 		deployed = 1
 
-/decl/hierarchy/outfit/commando
+/decl/outfit/commando
 	name =     "Special Role - Deathsquad Commando"
 	l_ear =    /obj/item/radio/headset/ert
 	uniform =  /obj/item/clothing/jumpsuit/green
@@ -40,7 +40,7 @@
 		/obj/item/energy_blade/sword
 	)
 
-/decl/hierarchy/outfit/commando/leader
+/decl/outfit/commando/leader
 	name =    "Special Role - Deathsquad Leader"
 	uniform =  /obj/item/clothing/costume/centcom_officer
 	l_pocket = /obj/item/pinpointer
@@ -48,7 +48,7 @@
 
 /decl/special_role/deathsquad/equip_role(var/mob/living/human/player)
 	if (player.mind == leader)
-		default_outfit = /decl/hierarchy/outfit/commando/leader
+		default_outfit = /decl/outfit/commando/leader
 	else
 		default_outfit = initial(default_outfit)
 	. = ..()

--- a/mods/content/corporate/effects/landmarks.dm
+++ b/mods/content/corporate/effects/landmarks.dm
@@ -1,7 +1,7 @@
 /obj/abstract/landmark/corpse/bridgeofficer
 	name = "Bridge Officer"
-	corpse_outfits = list(/decl/hierarchy/outfit/nanotrasen/officer)
+	corpse_outfits = list(/decl/outfit/nanotrasen/officer)
 
 /obj/abstract/landmark/corpse/commander
 	name = "Commander"
-	corpse_outfits = list(/decl/hierarchy/outfit/nanotrasen/commander)
+	corpse_outfits = list(/decl/outfit/nanotrasen/commander)

--- a/mods/content/fantasy/datum/hnoll/species.dm
+++ b/mods/content/fantasy/datum/hnoll/species.dm
@@ -21,7 +21,7 @@
 	devotion to community, and loyalty to the family over individual glory or strength of arms."
 	hidden_from_codex   = FALSE
 	available_bodytypes = list(/decl/bodytype/hnoll)
-	preview_outfit      = /decl/hierarchy/outfit/job/generic/fantasy
+	preview_outfit      = /decl/outfit/job/generic/fantasy
 	spawn_flags         = SPECIES_CAN_JOIN
 	flesh_color         = "#ae7d32"
 	hunger_factor       = DEFAULT_HUNGER_FACTOR * 1.2

--- a/mods/content/fantasy/datum/kobaloi/species.dm
+++ b/mods/content/fantasy/datum/kobaloi/species.dm
@@ -11,7 +11,7 @@
 	available_bodytypes = list(
 		/decl/bodytype/kobaloi
 	)
-	preview_outfit      = /decl/hierarchy/outfit/job/generic/fantasy
+	preview_outfit      = /decl/outfit/job/generic/fantasy
 	base_external_prosthetics_model = null
 
 	available_cultural_info = list(

--- a/mods/content/fantasy/datum/outfits.dm
+++ b/mods/content/fantasy/datum/outfits.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/job/generic/fantasy
+/decl/outfit/job/generic/fantasy
 	name          = "Fantasy Outfit"
 	id_type       = null
 	pda_type      = null

--- a/mods/content/fantasy/datum/species.dm
+++ b/mods/content/fantasy/datum/species.dm
@@ -8,7 +8,7 @@
 		/decl/bodytype/human,
 		/decl/bodytype/human/masculine
 	)
-	preview_outfit = /decl/hierarchy/outfit/job/generic/fantasy
+	preview_outfit = /decl/outfit/job/generic/fantasy
 	base_external_prosthetics_model = /decl/bodytype/prosthetic/wooden
 
 	available_cultural_info = list(

--- a/mods/content/psionics/datum/antagonists/foundation.dm
+++ b/mods/content/psionics/datum/antagonists/foundation.dm
@@ -22,7 +22,7 @@
 	initial_spawn_target = 2
 	min_player_age = 14
 	faction = "foundation"
-	default_outfit = /decl/hierarchy/outfit/foundation
+	default_outfit = /decl/outfit/foundation
 	id_title = "Foundation Agent"
 
 /decl/special_role/foundation/equip_role(var/mob/living/human/player)
@@ -35,7 +35,7 @@
 		var/datum/ability_handler/psionics/psi = player.get_ability_handler(/datum/ability_handler/psionics)
 		psi?.update(TRUE)
 
-/decl/hierarchy/outfit/foundation
+/decl/outfit/foundation
 	name = "Cuchulain Foundation Agent"
 	glasses =  /obj/item/clothing/glasses/sunglasses
 	uniform =  /obj/item/clothing/pants/slacks/black/outfit

--- a/mods/content/psionics/datum/antagonists/paramount.dm
+++ b/mods/content/psionics/datum/antagonists/paramount.dm
@@ -11,9 +11,9 @@
 	hard_cap_round = 3
 	min_player_age = 18
 	faction = "paramount"
-	default_outfit = /decl/hierarchy/outfit/paramount
+	default_outfit = /decl/outfit/paramount
 
-/decl/hierarchy/outfit/paramount
+/decl/outfit/paramount
 	name =    "Special Role - Paramount Grandmaster"
 	head =    /obj/item/clothing/head/helmet/space/psi_amp
 	uniform = /obj/item/clothing/jumpsuit/psysuit

--- a/mods/gamemodes/heist/outfit.dm
+++ b/mods/gamemodes/heist/outfit.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/raider
+/decl/outfit/raider
 	name =  "Special Role - Raider"
 	l_ear = /obj/item/radio/headset/raider
 	id_type = /obj/item/card/id/syndicate
@@ -62,11 +62,11 @@
 		/obj/item/clothing/webbing/holster/hip
 	)
 
-/decl/hierarchy/outfit/raider/Initialize()
+/decl/outfit/raider/Initialize()
 	randomize_clothing()
 	. = ..()
 
-/decl/hierarchy/outfit/raider/equip_outfit(mob/living/human/H, assignment, equip_adjustments, datum/job/job, datum/mil_rank/rank)
+/decl/outfit/raider/equip_outfit(mob/living/human/H, assignment, equip_adjustments, datum/job/job, datum/mil_rank/rank)
 	randomize_clothing()
 	. = ..()
 	if(. && H)
@@ -122,7 +122,7 @@
 			else
 				H.put_in_hands(holster)
 
-/decl/hierarchy/outfit/raider/proc/randomize_clothing()
+/decl/outfit/raider/proc/randomize_clothing()
 	shoes =   pick(raider_shoes)
 	uniform = pick(raider_uniforms)
 	glasses = pick(raider_glasses)

--- a/mods/gamemodes/heist/special_role.dm
+++ b/mods/gamemodes/heist/special_role.dm
@@ -14,7 +14,7 @@
 	default_access = list(access_raider)
 	faction = "pirate"
 	base_to_load = "Heist Base"
-	default_outfit = /decl/hierarchy/outfit/raider
+	default_outfit = /decl/outfit/raider
 	id_title = "Visitor"
 
 	var/list/outfits_per_species

--- a/mods/gamemodes/ninja/datums/special_role.dm
+++ b/mods/gamemodes/ninja/datums/special_role.dm
@@ -13,7 +13,7 @@
 	default_access = list(access_ninja)
 	faction = "ninja"
 	base_to_load = "Ninja Base"
-	default_outfit = /decl/hierarchy/outfit/ninja
+	default_outfit = /decl/outfit/ninja
 	id_title = "Infiltrator"
 	rig_type = /obj/item/rig/light/ninja
 	var/list/ninja_titles
@@ -95,7 +95,7 @@
 		H.SetName(H.real_name)
 	player.name = H.name
 
-/decl/hierarchy/outfit/ninja
+/decl/outfit/ninja
 	name =    "Special Role - Ninja"
 	l_ear =   /obj/item/radio/headset
 	uniform = /obj/item/clothing/jumpsuit/black

--- a/mods/mobs/borers/datum/symbiote.dm
+++ b/mods/mobs/borers/datum/symbiote.dm
@@ -21,12 +21,12 @@ var/global/list/symbiote_starting_points = list()
 	economic_power = 0
 	defer_roundstart_spawn = TRUE
 	hud_icon = "hudblank"
-	outfit_type = /decl/hierarchy/outfit/job/symbiote_host
+	outfit_type = /decl/outfit/job/symbiote_host
 	create_record = FALSE
 	var/check_whitelist // = "Symbiote"
 	var/static/mob/living/simple_animal/borer/preview_slug
 
-/decl/hierarchy/outfit/job/symbiote_host
+/decl/outfit/job/symbiote_host
 	name = "Job - Symbiote Host"
 
 /datum/job/symbiote/post_equip_job_title(var/mob/person, var/alt_title)

--- a/mods/species/ascent/items/clothing.dm
+++ b/mods/species/ascent/items/clothing.dm
@@ -1,4 +1,4 @@
-/decl/hierarchy/outfit/job/ascent
+/decl/outfit/job/ascent
 	name         = "Ascent - Gyne"
 	mask         = /obj/item/clothing/mask/gas/ascent
 	uniform      = /obj/item/clothing/jumpsuit/ascent
@@ -9,11 +9,11 @@
 	pda_slot     = 0
 	outfit_flags = 0
 
-/decl/hierarchy/outfit/job/ascent/attendant
+/decl/outfit/job/ascent/attendant
 	name = "Ascent - Attendant"
 	back = /obj/item/rig/mantid
 
-/decl/hierarchy/outfit/job/ascent/tech
+/decl/outfit/job/ascent/tech
 	name = "Ascent - Technician"
 	suit = /obj/item/clothing/suit/ascent
 

--- a/mods/species/bayliens/skrell/datum/species.dm
+++ b/mods/species/bayliens/skrell/datum/species.dm
@@ -32,7 +32,7 @@
 	)
 	hidden_from_codex = FALSE
 
-	preview_outfit = /decl/hierarchy/outfit/job/generic/scientist
+	preview_outfit = /decl/outfit/job/generic/scientist
 
 	burn_mod = 0.9
 	oxy_mod = 1.3

--- a/mods/species/bayliens/tajaran/datum/species.dm
+++ b/mods/species/bayliens/tajaran/datum/species.dm
@@ -20,7 +20,7 @@
 	hidden_from_codex = FALSE
 	available_bodytypes = list(/decl/bodytype/feline)
 
-	preview_outfit = /decl/hierarchy/outfit/job/generic/engineer
+	preview_outfit = /decl/outfit/job/generic/engineer
 
 	spawn_flags = SPECIES_CAN_JOIN
 

--- a/mods/species/bayliens/unathi/datum/species.dm
+++ b/mods/species/bayliens/unathi/datum/species.dm
@@ -60,7 +60,7 @@
 	flesh_color = "#34af10"
 	organs_icon = 'mods/species/bayliens/unathi/icons/organs.dmi'
 
-	preview_outfit = /decl/hierarchy/outfit/job/generic/doctor
+	preview_outfit = /decl/outfit/job/generic/doctor
 
 	blood_types = list(
 		/decl/blood_type/reptile/splus,

--- a/mods/species/neoavians/datum/species.dm
+++ b/mods/species/neoavians/datum/species.dm
@@ -29,7 +29,7 @@
 
 	butchery_data = /decl/butchery_data/humanoid/avian
 
-	preview_outfit = /decl/hierarchy/outfit/job/generic/assistant/avian
+	preview_outfit = /decl/outfit/job/generic/assistant/avian
 
 	available_bodytypes = list(
 		/decl/bodytype/avian,
@@ -72,7 +72,7 @@
 /decl/species/neoavian/get_holder_color(var/mob/living/human/H)
 	return H.get_skin_colour()
 
-/decl/hierarchy/outfit/job/generic/assistant/avian
+/decl/outfit/job/generic/assistant/avian
 	name = "Job - Avian Assistant"
 	uniform = /obj/item/clothing/dress/avian_smock/worker
 	shoes = /obj/item/clothing/shoes/avian/footwraps

--- a/mods/species/vox/datum/heist_compatibility.dm
+++ b/mods/species/vox/datum/heist_compatibility.dm
@@ -1,9 +1,9 @@
 #ifdef GAMEMODE_PACK_HEIST
 /decl/special_role/raider/Initialize()
 	. = ..()
-	LAZYSET(outfits_per_species, SPECIES_VOX, /decl/hierarchy/outfit/vox_raider)
+	LAZYSET(outfits_per_species, SPECIES_VOX, /decl/outfit/vox_raider)
 
-/decl/hierarchy/outfit/vox_raider
+/decl/outfit/vox_raider
 	name = "Job - Vox Raider"
 	l_ear =      /obj/item/radio/headset/raider
 	shoes =      /obj/item/clothing/shoes/magboots/vox
@@ -17,7 +17,7 @@
 	hands =      list(/obj/item/gun/launcher/alien/spikethrower)
 	id_type =    /obj/item/card/id/syndicate
 
-/decl/hierarchy/outfit/vox_raider/equip_outfit(mob/living/human/H, assignment, equip_adjustments, datum/job/job, datum/mil_rank/rank)
+/decl/outfit/vox_raider/equip_outfit(mob/living/human/H, assignment, equip_adjustments, datum/job/job, datum/mil_rank/rank)
 	uniform = pick(/obj/item/clothing/suit/robe/vox, /obj/item/clothing/pants/vox)
 	glasses = pick(/obj/item/clothing/glasses/thermal, /obj/item/clothing/glasses/thermal/plain/eyepatch, /obj/item/clothing/glasses/thermal/plain/monocle)
 	holster = pick(/obj/item/clothing/webbing/holster/armpit, /obj/item/clothing/webbing/holster/waist, /obj/item/clothing/webbing/holster/hip)
@@ -44,7 +44,7 @@
 	if(choice != "Yes")
 		return ..()
 
-	var/decl/hierarchy/outfit/outfit = GET_DECL(/decl/hierarchy/outfit/vox_raider)
+	var/decl/outfit/outfit = GET_DECL(/decl/outfit/vox_raider)
 	var/mob/living/human/vox/vox = new(get_turf(src), SPECIES_VOX)
 	outfit.equip_outfit(vox)
 	if(user.mind)

--- a/mods/species/vox/datum/species.dm
+++ b/mods/species/vox/datum/species.dm
@@ -66,7 +66,7 @@
 	speech_sounds = list('sound/voice/shriek1.ogg')
 	speech_chance = 20
 
-	preview_outfit = /decl/hierarchy/outfit/vox_raider
+	preview_outfit = /decl/outfit/vox_raider
 
 	gluttonous = GLUT_TINY|GLUT_ITEM_NORMAL
 	stomach_capacity = 12


### PR DESCRIPTION
## Description of changes
Makes outfits not subtypes of hierarchy since they didn't even use anything defined on hierarchy except for `name` and, at one point, `expected_type`.

## Why and what will this PR improve
There was no reason for outfits to be a subtype of hierarchy. I'm coming for skills next...