### PR TITLE
Fix textile crafting issues

### DIFF
--- a/code/__defines/materials.dm
+++ b/code/__defines/materials.dm
@@ -29,10 +29,12 @@
 #define MAT_VALUE_VERY_HEAVY         80		// uranium tier
 
 //Construction difficulty
-#define MAT_VALUE_EASY_DIY          0
-#define MAT_VALUE_NORMAL_DIY        1
-#define MAT_VALUE_HARD_DIY          2
-#define MAT_VALUE_VERY_HARD_DIY     3
+#define MAT_VALUE_TRIVIAL_DIY       0 // Does not have any difficulty component at all
+#define MAT_VALUE_EASY_DIY          1 // SKILL_NONE (Unskilled)
+#define MAT_VALUE_NORMAL_DIY        2 // SKILL_BASIC (Basic)
+#define MAT_VALUE_HARD_DIY          3 // SKILL_ADEPT (Trained)
+#define MAT_VALUE_VERY_HARD_DIY     4 // SKILL_EXPERT (Experienced)
+#define MAT_VALUE_EXTREME_DIY       5 // SKILL_PROF (Master)
 
 //Arbitrary hardness thresholds
 #define MAT_VALUE_MALLEABLE          0

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -41,6 +41,9 @@
 /obj/item/clothing/get_equipment_tint()
 	return tint
 
+/obj/item/clothing/get_matter_amount_modifier()
+	return ..() * 5 // clothes are complicated and have a high surface area. todo: a better way to do this?
+
 /obj/item/clothing/Initialize()
 
 	. = ..()

--- a/code/modules/crafting/stack_recipes/recipes_textiles.dm
+++ b/code/modules/crafting/stack_recipes/recipes_textiles.dm
@@ -1,24 +1,27 @@
 /decl/stack_recipe/textiles
-	craft_stack_types     = list(
+	craft_stack_types          = list(
 		/obj/item/stack/material/bolt,
 		/obj/item/stack/material/skin
 	)
-	difficulty            = null // Autoset from material difficulty
-	abstract_type         = /decl/stack_recipe/textiles
+	difficulty                 = null // Autoset from material difficulty
+	crafting_extra_cost_factor = 1.5 // measure twice, cut once; material is lost. todo: produce scraps?
+	abstract_type              = /decl/stack_recipe/textiles
 
 /decl/stack_recipe/textiles/cloak
 	result_type           = /obj/item/clothing/suit/cloak/hide
 	category              = "clothing"
 
 /decl/stack_recipe/textiles/banner
-	result_type             = /obj/item/banner
-	category                = "furniture"
-	difficulty              = MAT_VALUE_NORMAL_DIY // Slightly easier than making actual clothing.
+	result_type                = /obj/item/banner
+	category                   = "furniture"
+	crafting_extra_cost_factor = 1.1 // less material is lost because it's relatively simple
+	difficulty                 = MAT_VALUE_NORMAL_DIY // Slightly easier than making actual clothing.
 
 /decl/stack_recipe/textiles/sack
-	result_type             = /obj/item/bag/sack
-	category                = "storage"
-	difficulty              = MAT_VALUE_NORMAL_DIY // Slightly easier than making actual clothing.
+	result_type                = /obj/item/bag/sack
+	category                   = "storage"
+	crafting_extra_cost_factor = 1.1 // less material is lost because it's relatively simple
+	difficulty                 = MAT_VALUE_NORMAL_DIY // Slightly easier than making actual clothing.
 
 /decl/stack_recipe/textiles/bandolier
 	result_type           = /obj/item/clothing/webbing/bandolier/crafted
@@ -26,6 +29,7 @@
 
 /decl/stack_recipe/textiles/headband
 	result_type           = /obj/item/clothing/head/headband
+	crafting_extra_cost_factor = 1.2 // less material is lost because it's relatively simple
 	category              = "clothing"
 
 
@@ -52,8 +56,9 @@
 	result_type           = /obj/item/clothing/gloves/thick
 
 /decl/stack_recipe/textiles/leather/sling
-	result_type             = /obj/item/gun/launcher/bow/sling
-	difficulty              = MAT_VALUE_NORMAL_DIY // Slightly easier than making clothing.
+	result_type                = /obj/item/gun/launcher/bow/sling
+	crafting_extra_cost_factor = 1.1 // less material is lost because it's relatively simple
+	difficulty                 = MAT_VALUE_NORMAL_DIY // Slightly easier than making clothing.
 
 /decl/stack_recipe/textiles/leather/waterskin
 	result_type           = /obj/item/chems/waterskin/crafted
@@ -67,7 +72,8 @@
 
 /decl/stack_recipe/textiles/cloth/bandana
 	result_type             = /obj/item/clothing/mask/bandana/colourable
-	difficulty              = MAT_VALUE_EASY_DIY // It's basically tying a rag around your head.
+	crafting_extra_cost_factor = 1 // basically just a rag
+	difficulty              = MAT_VALUE_EASY_DIY // see above comment
 
 /decl/stack_recipe/textiles/cloth/gloves
 	result_type           = /obj/item/clothing/gloves
@@ -79,30 +85,35 @@
 	result_type           = /obj/item/clothing/suit/poncho/colored
 
 /decl/stack_recipe/textiles/cloth/bedding
-	result_type           = /obj/item/bedsheet
-	category              = "bedding"
+	result_type                = /obj/item/bedsheet
+	crafting_extra_cost_factor = 1.1 // less material is lost because it's relatively simple
+	category                   = "bedding"
 
 /decl/stack_recipe/textiles/cloth/bandages
-	result_type             = /obj/item/stack/medical/bandage/crafted
-	difficulty              = MAT_VALUE_EASY_DIY
-	category                = "medical"
+	result_type                = /obj/item/stack/medical/bandage/crafted
+	difficulty                 = MAT_VALUE_EASY_DIY
+	crafting_extra_cost_factor = 1.1 // it's not that much more complicated than making a rag, but you probably want to at least tidy up the edges
+	category                   = "medical"
 
 /decl/stack_recipe/textiles/fur
 	abstract_type         = /decl/stack_recipe/textiles/fur
 	craft_stack_types     = /obj/item/stack/material/skin/pelt
 
 /decl/stack_recipe/textiles/fur/bedding
-	difficulty              = MAT_VALUE_EASY_DIY
-	result_type             = /obj/item/bedsheet/furs
-	category                = "bedding"
+	difficulty                 = MAT_VALUE_EASY_DIY
+	crafting_extra_cost_factor = 1.1 // you're basically just trimming the edges and cleaning the pelt
+	result_type                = /obj/item/bedsheet/furs
+	category                   = "bedding"
 
 /decl/stack_recipe/textiles/surgical_sutures
-	result_type           = /obj/item/ancient_surgery/sutures
-	craft_stack_types     = list(/obj/item/stack/material/thread)
-	difficulty            = MAT_VALUE_HARD_DIY
-	category              = "medical"
+	result_type                 = /obj/item/ancient_surgery/sutures
+	craft_stack_types           = list(/obj/item/stack/material/thread)
+	difficulty                  = MAT_VALUE_HARD_DIY
+	crafting_extra_cost_factor  = 1 // no overall material loss, you're just prepping the thread
+	category                    = "medical"
 	available_to_map_tech_level = MAP_TECH_LEVEL_MEDIEVAL
 
 /decl/stack_recipe/textiles/rag
 	result_type = /obj/item/chems/glass/rag
+	crafting_extra_cost_factor = 1 // whatever you produce is going to be a rag, there's no wastage
 	difficulty = MAT_VALUE_TRIVIAL_DIY

--- a/code/modules/crafting/stack_recipes/recipes_textiles.dm
+++ b/code/modules/crafting/stack_recipes/recipes_textiles.dm
@@ -3,6 +3,7 @@
 		/obj/item/stack/material/bolt,
 		/obj/item/stack/material/skin
 	)
+	difficulty            = null // Autoset from material difficulty
 	abstract_type         = /decl/stack_recipe/textiles
 
 /decl/stack_recipe/textiles/cloak
@@ -10,12 +11,14 @@
 	category              = "clothing"
 
 /decl/stack_recipe/textiles/banner
-	result_type           = /obj/item/banner
-	category              = "furniture"
+	result_type             = /obj/item/banner
+	category                = "furniture"
+	difficulty              = MAT_VALUE_NORMAL_DIY // Slightly easier than making actual clothing.
 
 /decl/stack_recipe/textiles/sack
-	result_type           = /obj/item/bag/sack
-	category              = "storage"
+	result_type             = /obj/item/bag/sack
+	category                = "storage"
+	difficulty              = MAT_VALUE_NORMAL_DIY // Slightly easier than making actual clothing.
 
 /decl/stack_recipe/textiles/bandolier
 	result_type           = /obj/item/clothing/webbing/bandolier/crafted
@@ -32,8 +35,9 @@
 	category              = "clothing"
 
 /decl/stack_recipe/textiles/leather/bedroll
-	result_type           = /obj/item/bedroll
-	category              = "bedding"
+	result_type = /obj/item/bedroll
+	difficulty  = MAT_VALUE_NORMAL_DIY // Slightly easier than making clothing.
+	category    = "bedding"
 
 /decl/stack_recipe/textiles/leather/shoes
 	result_type           = /obj/item/clothing/shoes/craftable
@@ -48,7 +52,8 @@
 	result_type           = /obj/item/clothing/gloves/thick
 
 /decl/stack_recipe/textiles/leather/sling
-	result_type           = /obj/item/gun/launcher/bow/sling
+	result_type             = /obj/item/gun/launcher/bow/sling
+	difficulty              = MAT_VALUE_NORMAL_DIY // Slightly easier than making clothing.
 
 /decl/stack_recipe/textiles/leather/waterskin
 	result_type           = /obj/item/chems/waterskin/crafted
@@ -61,7 +66,8 @@
 	category              = "clothing"
 
 /decl/stack_recipe/textiles/cloth/bandana
-	result_type           = /obj/item/clothing/mask/bandana/colourable
+	result_type             = /obj/item/clothing/mask/bandana/colourable
+	difficulty              = MAT_VALUE_EASY_DIY // It's basically tying a rag around your head.
 
 /decl/stack_recipe/textiles/cloth/gloves
 	result_type           = /obj/item/clothing/gloves
@@ -77,16 +83,18 @@
 	category              = "bedding"
 
 /decl/stack_recipe/textiles/cloth/bandages
-	result_type           = /obj/item/stack/medical/bandage/crafted
-	category              = "medical"
+	result_type             = /obj/item/stack/medical/bandage/crafted
+	difficulty              = MAT_VALUE_EASY_DIY
+	category                = "medical"
 
 /decl/stack_recipe/textiles/fur
 	abstract_type         = /decl/stack_recipe/textiles/fur
 	craft_stack_types     = /obj/item/stack/material/skin/pelt
 
 /decl/stack_recipe/textiles/fur/bedding
-	result_type           = /obj/item/bedsheet/furs
-	category              = "bedding"
+	difficulty              = MAT_VALUE_EASY_DIY
+	result_type             = /obj/item/bedsheet/furs
+	category                = "bedding"
 
 /decl/stack_recipe/textiles/surgical_sutures
 	result_type           = /obj/item/ancient_surgery/sutures
@@ -97,3 +105,4 @@
 
 /decl/stack_recipe/textiles/rag
 	result_type = /obj/item/chems/glass/rag
+	difficulty = MAT_VALUE_TRIVIAL_DIY

--- a/code/modules/materials/definitions/solids/materials_solid_organic.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_organic.dm
@@ -165,7 +165,7 @@
 	ignition_point = T0C+300
 	conductive = 1
 	hidden_from_codex = TRUE
-	construction_difficulty = MAT_VALUE_NORMAL_DIY
+	construction_difficulty = MAT_VALUE_EASY_DIY
 	integrity = 70
 	hardness = MAT_VALUE_SOFT
 	weight = MAT_VALUE_NORMAL
@@ -219,7 +219,7 @@
 	ignition_point = T0C+300
 	conductive = 0
 	hidden_from_codex = TRUE
-	construction_difficulty = MAT_VALUE_NORMAL_DIY
+	construction_difficulty = MAT_VALUE_HARD_DIY
 	integrity = 50
 	hardness = MAT_VALUE_FLEXIBLE
 	weight = MAT_VALUE_EXTREMELY_LIGHT

--- a/code/modules/materials/material_stack_cloth.dm
+++ b/code/modules/materials/material_stack_cloth.dm
@@ -37,7 +37,8 @@
 	crafting_stack_type = /obj/item/stack/material/thread
 	craft_verb = "weave"
 	craft_verbing = "weaving"
-	matter_multiplier = 0.1
+	w_class = ITEM_SIZE_TINY
+	matter_multiplier = 0.4
 	icon_state = "thread"
 	plural_icon_state = "thread-mult"
 	max_icon_state = "thread-max"

--- a/code/modules/materials/material_stack_cloth.dm
+++ b/code/modules/materials/material_stack_cloth.dm
@@ -3,6 +3,7 @@
 	icon_state = "sheet-cloth"
 	singular_name = "bolt"
 	plural_name = "bolts"
+	w_class = ITEM_SIZE_NORMAL
 	stack_merge_type = /obj/item/stack/material/bolt
 	crafting_stack_type = /obj/item/stack/material/bolt
 	craft_verb = "tailor"


### PR DESCRIPTION
## Description of changes
- Increases skill requirements for crafting across the board; MAT_VALUE_EASY_DIY and MAT_VALUE_NORMAL_DIY were identical, as in both had no skill requirement.
- Clothing now takes 5x the matter to make.
- Cloth bolts now have slightly less matter and a lower w_class.
- Spools of thread now have a lower w_class, higher matter multiplier, and the same overall matter.
- Textile crafting recipes now mostly autoset difficulty from material.
- Adjusts crafting skill requirements for certain textile crafting recipes.
- Adjusts extra cost factor for textile recipes.

## Why and what will this PR improve
Makes clothes and other textiles cost more than just one cloth bolt to make.
Makes skills actually relevant for textile crafting.

## Authorship
Me