### PR TITLE
Allow spoons to be used to dig with

### DIFF
--- a/code/modules/food/utensils/utensil_spoon.dm
+++ b/code/modules/food/utensils/utensil_spoon.dm
@@ -6,5 +6,14 @@
 	material_force_multiplier = 0.1 //2 when wielded with weight 20 (steel)
 	utensil_flags              = UTENSIL_FLAG_SCOOP
 
+/obj/item/utensil/spoon/Initialize()
+	. = ..()
+	if(!has_extension(src, /datum/extension/tool) && w_class > ITEM_SIZE_TINY)
+		set_extension(src, /datum/extension/tool, list(
+			// yes, this is entirely so you can dig normally with a comically large spoon
+			// a tiny spoon cannot be used to dig, a small spoon has a very slow multiplier, a huge spoon is basically a shovel
+			TOOL_SHOVEL = Interpolate(TOOL_QUALITY_WORST / 10, TOOL_QUALITY_MEDIOCRE, (w_class - ITEM_SIZE_SMALL) / (ITEM_SIZE_HUGE - ITEM_SIZE_SMALL))
+		))
+
 /obj/item/utensil/spoon/plastic
 	material = /decl/material/solid/organic/plastic


### PR DESCRIPTION
## Description of changes
Spoons now function as basic shovels based on size.

## Why and what will this PR improve
I made a guy dig a grave with a spoon as punishment and wanted that to be possible without adminbus. 

## Authorship
me

## Changelog
:cl:
tweak: spoons can now be used as a very poor shovel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->