### PR TITLE
Rebalance mob sizes to allow small mobs to fit in bags

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -90,11 +90,11 @@
 #define COMPANY_ALIGNMENTS		list(COMPANY_LOYAL,COMPANY_SUPPORTATIVE,COMPANY_NEUTRAL,COMPANY_SKEPTICAL,COMPANY_OPPOSED)
 
 // Defines mob sizes, used by lockers and to determine what is considered a small sized mob, etc.
-#define MOB_SIZE_LARGE     40
-#define MOB_SIZE_MEDIUM    20
-#define MOB_SIZE_SMALL     10
-#define MOB_SIZE_TINY      5
-#define MOB_SIZE_MINISCULE 1
+#define MOB_SIZE_LARGE     ITEM_SIZE_STRUCTURE * 2
+#define MOB_SIZE_MEDIUM    ITEM_SIZE_STRUCTURE
+#define MOB_SIZE_SMALL     ITEM_SIZE_NORMAL
+#define MOB_SIZE_TINY      ITEM_SIZE_SMALL
+#define MOB_SIZE_MINISCULE ITEM_SIZE_TINY
 
 #define MOB_SIZE_MIN       MOB_SIZE_MINISCULE
 #define MOB_SIZE_MAX       MOB_SIZE_LARGE

--- a/code/modules/mob/living/simple_animal/passive/rabbit.dm
+++ b/code/modules/mob/living/simple_animal/passive/rabbit.dm
@@ -5,7 +5,7 @@
 	max_health = 20
 	natural_weapon = /obj/item/natural_weapon/bite/weak
 	speak_emote = list("chitters")
-	mob_size = MOB_SIZE_TINY
+	mob_size = MOB_SIZE_SMALL
 	butchery_data = /decl/butchery_data/animal/rabbit
 	holder_type = /obj/item/holder
 	ai = /datum/mob_controller/passive/rabbit


### PR DESCRIPTION
## Description of changes
Changes the mob size defines to be more in line with the ITEM_SIZE defines, since they're on the same scale now.
Rabbits are now MOB_SIZE_SMALL instead of MOB_SIZE_TINY.

## Why and what will this PR improve
Rabbits and chickens can now be put into sacks.