### PR TITLE
Adjust Shaded Hills sound environments to reduce echo

### DIFF
--- a/maps/shaded_hills/areas/_areas.dm
+++ b/maps/shaded_hills/areas/_areas.dm
@@ -32,7 +32,7 @@
 	name = "\improper Grasslands"
 	color = COLOR_GREEN
 	is_outside = OUTSIDE_YES
-	sound_env = FOREST
+	sound_env = PLAIN
 	ambience = list(
 		'sound/effects/wind/wind_2_1.ogg',
 		'sound/effects/wind/wind_2_2.ogg',

--- a/maps/shaded_hills/areas/woods.dm
+++ b/maps/shaded_hills/areas/woods.dm
@@ -14,6 +14,7 @@
 
 /area/shaded_hills/outside/woods
 	name = "Woodlands"
+	sound_env = FOREST
 
 /area/shaded_hills/outside/woods/poi
 	name = "Deep Woodlands"


### PR DESCRIPTION
## Description of changes
The default outdoor Shaded Hills sound environment is `PLAIN` (as in grassy plains) to avoid echoing from the `FOREST` preset that isn't applicable outside of, well, a forest.

## Why and what will this PR improve
Prevents forest-like echoing off trees in areas with no trees.