### PR TITLE
Allow grown produce to have differing w_classes

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -38,6 +38,7 @@
 	filling_color = seed.get_trait(TRAIT_PRODUCT_COLOUR) || seed.get_trait(TRAIT_FLESH_COLOUR)
 	slice_path    = seed.slice_product
 	slice_num     = seed.slice_amount
+	w_class       = seed.product_w_class
 
 	if(!seed.chems && !(dry && seed.dried_chems) && !(backyard_grilling_count > 0 && seed.roasted_chems))
 		return INITIALIZE_HINT_QDEL // No reagent contents, no froot

--- a/code/modules/hydroponics/plant_types/seeds_misc.dm
+++ b/code/modules/hydroponics/plant_types/seeds_misc.dm
@@ -1086,6 +1086,7 @@
 	name = "watermelon"
 	product_name = "watermelon"
 	display_name = "watermelon vine"
+	product_w_class = ITEM_SIZE_LARGE
 	chems = list(/decl/material/liquid/nutriment = list(1,6), /decl/material/liquid/drink/juice/watermelon = list(10,6))
 	slice_product = /obj/item/food/processed_grown/slice/large
 
@@ -1110,6 +1111,7 @@
 	name = "pumpkin"
 	product_name = "pumpkin"
 	display_name = "pumpkin vine"
+	product_w_class = ITEM_SIZE_LARGE
 	chems = list(/decl/material/liquid/nutriment = list(1,6))
 	grown_tag = "pumpkin"
 	slice_product = /obj/item/clothing/head/pumpkinhead
@@ -1328,6 +1330,7 @@
 	chems = list(/decl/material/solid/tobacco = list(1,10))
 	slice_product = /obj/item/food/processed_grown/chopped
 	slice_amount = 3
+	product_w_class = ITEM_SIZE_TINY // so that it can fit in bags of tobacco
 
 /datum/seed/tobacco/New()
 	..()

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -31,6 +31,7 @@
 	var/base_seed_value = 5 // Used when generating price.
 	var/scannable_result
 	var/grown_is_seed = FALSE
+	var/product_w_class = ITEM_SIZE_SMALL
 
 	// Dissection values.
 	var/min_seed_extracted = 1


### PR DESCRIPTION
## Description of changes
Seeds have a `produce_w_class` variable that `/obj/item/food/grown` uses to set its own `w_class`.
This makes growns `ITEM_SIZE_SMALL` by default, with pumpkins and watermelons being `ITEM_SIZE_LARGE`.

## Why and what will this PR improve
Pumpkins and watermelons are large, other produce is small.

## Authorship
Me

## Changelog
:cl:
tweak: Pumpkins and watermelons are now large objects, while other produce is small.
/:cl: