### PR TITLE
Allow sashimi to be chopped into chopped fish

### DIFF
--- a/code/modules/butchery/butchery_data_fish.dm
+++ b/code/modules/butchery/butchery_data_fish.dm
@@ -9,7 +9,7 @@
 	skin_amount   = 3
 	must_use_hook = FALSE
 	gut_type      = /obj/item/food/butchery/offal/small
-	meat_flags    = INGREDIENT_FLAG_MEAT | INGREDIENT_FLAG_FISH
+	meat_flags    = INGREDIENT_FLAG_FISH
 
 /decl/butchery_data/animal/fish/small
 	bone_amount     = 1

--- a/code/modules/butchery/butchery_products_meat_fish.dm
+++ b/code/modules/butchery/butchery_products_meat_fish.dm
@@ -15,7 +15,7 @@
 	slice_path                     = /obj/item/food/sashimi
 	slice_num                      = 3
 	meat_name                      = "fish"
-	ingredient_flags               = INGREDIENT_FLAG_MEAT | INGREDIENT_FLAG_FISH
+	ingredient_flags               = INGREDIENT_FLAG_FISH
 
 /obj/item/food/butchery/meat/fish/get_meat_icons()
 	var/static/list/meat_icons = list(

--- a/code/modules/reagents/reagent_containers/food/sushi.dm
+++ b/code/modules/reagents/reagent_containers/food/sushi.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/sushi.dmi'
 	icon_state = "sushi_rice"
 	bitesize = 1
+	ingredient_flags = INGREDIENT_FLAG_FISH
 	var/fish_type = "fish"
 
 /obj/item/food/sushi/Initialize(mapload, material_key, skip_plate = FALSE, obj/item/food/rice, obj/item/food/topping)
@@ -58,6 +59,9 @@
 	icon_state = "sashimi"
 	gender = PLURAL
 	bitesize = 1
+	slice_num = 1
+	slice_path = /obj/item/food/butchery/chopped
+	ingredient_flags = INGREDIENT_FLAG_FISH
 	var/fish_type = "fish"
 	var/slices = 1
 
@@ -108,6 +112,17 @@
 			new /obj/item/food/sushi(get_turf(src), null, TRUE, I, src)
 		return
 	. = ..()
+
+/obj/item/food/sashimi/handle_utensil_cutting(obj/item/tool, mob/user)
+	slice_num = slices // to avoid wasting it
+	. = ..()
+	if(length(.))
+		for(var/obj/item/food/food in .)
+			food.cooked_food = cooked_food
+			food.ingredient_flags = ingredient_flags
+		if(fish_type)
+			for(var/obj/item/food/butchery/meat in .)
+				meat.set_meat_name(fish_type)
 
  // Used for turning rice into sushi.
 /obj/item/food/boiledrice/attackby(var/obj/item/I, var/mob/user)


### PR DESCRIPTION
## Description of changes
Sashimi can be chopped into chopped fish for use in soup.
Fish no longer has both the meat and fish flags, for future distinction like pescetarian foods.

## Why and what will this PR improve
You can make fish soup now.

## Authorship
me

## Changelog
:cl:
add: You can now chop sashimi (sliced fish) into chopped fish for use in soups and stews.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->