### PR TITLE
Fix stew having a higher complexity than soup

### DIFF
--- a/code/modules/food/cooking/recipes/recipe_soup.dm
+++ b/code/modules/food/cooking/recipes/recipe_soup.dm
@@ -121,6 +121,7 @@
 	)
 	result_quantity = 10
 	result = /decl/material/liquid/nutriment/soup/stew
+	complexity = 0 // Have to reset it because it inherits from soup.
 
 /decl/recipe/soup/simple/stew/mixed
 	display_name = "mixed stew"


### PR DESCRIPTION
## Description of changes
Stew inherited the complexity of soup which made stew still take priority over soup, resulting in recipes not working right. Now, stew has its complexity bonus set back to zero. This means meat soup has a base complexity of 8 while meat stew has a base complexity of 4, meaning soup will take priority.

## Why and what will this PR improve
Stew will no longer take priority over soup, which fixes issues with 4 chopped meat and 40u broth resulting in 10 units of soup, 20 units of stew, and 10 units of broth rather than 40 units of soup.

## Authorship
me