### PR TITLE
Fix Shaded Hills map issues

### DIFF
--- a/code/game/turfs/turf_ao.dm
+++ b/code/game/turfs/turf_ao.dm
@@ -99,7 +99,7 @@
 	CUT_AO(src, ao_overlays)
 	if (z_flags & ZM_MIMIC_BELOW)
 		REGEN_AO(shadower, ao_overlays_mimic, ao_neighbors_mimic)
-	if (AO_TURF_CHECK(src) && !(z_flags & ZM_MIMIC_NO_AO))
+	if (AO_SELF_CHECK(src) && !(z_flags & ZM_MIMIC_NO_AO))
 		REGEN_AO(src, ao_overlays, ao_neighbors)
 
 	update_above()

--- a/code/game/turfs/walls/wall_icon.dm
+++ b/code/game/turfs/walls/wall_icon.dm
@@ -177,7 +177,7 @@
 				var/turf/other_neighbor = get_step_resolving_mimic(src, global.reverse_dir[stepdir])
 				if(istype(other_neighbor))
 					var/light_amt   = 255 * other_neighbor.get_lumcount()
-					if(light_amt > 0)
+					if(other_neighbor.lighting_overlay && light_amt > 0) // get_lumcount defaults to 0.5 if lighting_overlay is null
 						if(!new_light_dir || light_str < light_amt / 255)
 							new_light_dir = stepdir
 							light_str = light_amt / 255

--- a/maps/shaded_hills/shaded_hills-inn.dmm
+++ b/maps/shaded_hills/shaded_hills-inn.dmm
@@ -1133,6 +1133,12 @@
 	},
 /turf/floor/wood/walnut,
 /area/shaded_hills/general_store/porch)
+"Rh" = (
+/obj/structure/bed/simple/ebony/cloth,
+/obj/item/bedsheet/yellowed,
+/obj/abstract/landmark/start/shaded_hills/innkeeper,
+/turf/floor/wood/walnut,
+/area/shaded_hills/inn)
 "Rl" = (
 /turf/floor/natural/mud,
 /area/shaded_hills/outside/downlands)
@@ -9048,7 +9054,7 @@ HI
 TR
 cx
 Ee
-th
+Rh
 Jo
 BB
 Ee

--- a/maps/shaded_hills/shaded_hills-inn.dmm
+++ b/maps/shaded_hills/shaded_hills-inn.dmm
@@ -175,7 +175,9 @@
 /turf/floor/natural/grass,
 /area/shaded_hills/outside/shrine)
 "gB" = (
-/obj/structure/wall_sconce/lantern,
+/obj/structure/wall_sconce/lantern{
+	start_lit = 1
+	},
 /turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "gL" = (
@@ -187,6 +189,13 @@
 /obj/item/chems/condiment/flour,
 /obj/item/chems/condiment/large/salt,
 /turf/floor/natural/path/herringbone/basalt,
+/area/shaded_hills/inn)
+"hb" = (
+/obj/structure/wall_sconce/lantern{
+	dir = 4;
+	start_lit = 1
+	},
+/turf/floor/wood/walnut,
 /area/shaded_hills/inn)
 "hc" = (
 /obj/structure/bed/chair/bench/ebony{
@@ -262,7 +271,9 @@
 /turf/wall/brick/basalt,
 /area/shaded_hills/outside/shrine)
 "iX" = (
-/turf/wall/log/walnut/shutter,
+/turf/wall/log/walnut/shutter{
+	shutter_state = 1
+	},
 /area/shaded_hills/inn)
 "iZ" = (
 /obj/structure/fire_source/fireplace/basalt,
@@ -465,6 +476,12 @@
 /mob/living/simple_animal/fowl/chicken,
 /turf/floor/natural/grass,
 /area/shaded_hills/outside/downlands)
+"rS" = (
+/obj/structure/wall_sconce/lantern{
+	start_lit = 1
+	},
+/turf/floor/wood/walnut,
+/area/shaded_hills/shrine)
 "sJ" = (
 /obj/structure/closet/cabinet/wooden/ebony,
 /turf/floor/wood/walnut,
@@ -508,7 +525,8 @@
 "uA" = (
 /obj/structure/wall_sconce/lantern{
 	dir = 1;
-	pixel_y = 10
+	pixel_y = 10;
+	start_lit = 1
 	},
 /turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
@@ -932,7 +950,9 @@
 /turf/floor/wood/walnut,
 /area/shaded_hills/storehouse)
 "IQ" = (
-/turf/wall/log/walnut/shutter,
+/turf/wall/log/walnut/shutter{
+	shutter_state = 1
+	},
 /area/shaded_hills/farmhouse)
 "IS" = (
 /turf/floor/natural/mud/water/deep,
@@ -996,7 +1016,9 @@
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/shrine)
 "Kh" = (
-/turf/wall/log/walnut/shutter,
+/turf/wall/log/walnut/shutter{
+	shutter_state = 1
+	},
 /area/shaded_hills/shrine)
 "KG" = (
 /obj/structure/railing/mapped/wooden/walnut{
@@ -1009,6 +1031,13 @@
 /obj/abstract/exterior_marker/inside,
 /turf/floor/natural/dirt,
 /area/shaded_hills/outside/downlands)
+"Ly" = (
+/obj/structure/wall_sconce/lantern{
+	dir = 4;
+	start_lit = 1
+	},
+/turf/floor/natural/path/herringbone/basalt,
+/area/shaded_hills/inn)
 "LK" = (
 /obj/structure/railing/mapped/wooden/walnut{
 	dir = 4
@@ -1087,7 +1116,8 @@
 "Pe" = (
 /obj/structure/wall_sconce/lantern{
 	dir = 1;
-	pixel_y = 10
+	pixel_y = 10;
+	start_lit = 1
 	},
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/inn)
@@ -1122,6 +1152,10 @@
 /obj/structure/bed/chair/wood/ebony{
 	dir = 1
 	},
+/obj/structure/wall_sconce/lantern{
+	dir = 8;
+	start_lit = 1
+	},
 /turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "QQ" = (
@@ -1151,7 +1185,9 @@
 /turf/floor/natural/grass,
 /area/shaded_hills/outside/downlands)
 "RG" = (
-/turf/wall/brick/basalt/shutter,
+/turf/wall/brick/basalt/shutter{
+	shutter_state = 1
+	},
 /area/shaded_hills/shrine)
 "RO" = (
 /obj/structure/wall_sconce/lantern{
@@ -1361,6 +1397,14 @@
 /obj/structure/fire_source/stove,
 /obj/item/stack/material/log/mapped/walnut/twenty,
 /turf/floor/natural/path/herringbone/basalt,
+/area/shaded_hills/shrine)
+"XJ" = (
+/obj/structure/wall_sconce/lantern{
+	dir = 1;
+	pixel_y = 10;
+	start_lit = 1
+	},
+/turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "XM" = (
 /turf/floor/carpet/red,
@@ -9663,7 +9707,7 @@ TR
 cx
 Ee
 sJ
-Im
+hb
 ZY
 yn
 ZY
@@ -11191,7 +11235,7 @@ WV
 fK
 qG
 pi
-FH
+Ly
 Wl
 BG
 ZY
@@ -18757,10 +18801,10 @@ kv
 kv
 Kh
 CR
-CR
+rS
 QB
 CR
-CR
+rS
 QB
 CR
 XM
@@ -18914,7 +18958,7 @@ QB
 Jt
 qe
 QB
-uP
+XJ
 XM
 Gj
 XM

--- a/maps/shaded_hills/shaded_hills-swamp.dmm
+++ b/maps/shaded_hills/shaded_hills-swamp.dmm
@@ -1,6 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aM" = (
-/turf/wall/log/walnut/shutter,
+/turf/wall/log/walnut/shutter{
+	shutter_state = 1
+	},
 /area/shaded_hills/witch_hut)
 "bg" = (
 /turf/floor/wood/walnut,
@@ -68,7 +70,8 @@
 "vz" = (
 /obj/structure/table/woodentable/ebony,
 /obj/structure/wall_sconce/lantern{
-	dir = 8
+	dir = 8;
+	start_lit = 1
 	},
 /turf/floor/wood/walnut,
 /area/shaded_hills/witch_hut)
@@ -169,7 +172,8 @@
 "Vl" = (
 /obj/structure/table/woodentable/ebony,
 /obj/structure/wall_sconce/lantern{
-	dir = 4
+	dir = 4;
+	start_lit = 1
 	},
 /obj/item/chems/glass/mortar,
 /obj/item/rock/basalt,

--- a/maps/shaded_hills/shaded_hills-woods.dmm
+++ b/maps/shaded_hills/shaded_hills-woods.dmm
@@ -161,11 +161,15 @@
 /turf/floor/natural/grass,
 /area/shaded_hills/outside/river/lake)
 "MR" = (
-/obj/structure/wall_sconce/lantern,
+/obj/structure/wall_sconce/lantern{
+	start_lit = 1
+	},
 /turf/floor/wood/walnut,
 /area/shaded_hills/forester_hut)
 "MU" = (
-/turf/wall/log/walnut/shutter,
+/turf/wall/log/walnut/shutter{
+	shutter_state = 1
+	},
 /area/shaded_hills/forester_hut)
 "Oi" = (
 /obj/structure/closet/crate/chest/ebony,


### PR DESCRIPTION
## Description of changes
Rooms on Shaded Hills that people can spawn in will now start with lanterns lit and shutters open. This is because, wow, it really sucks to spawn in a pitch-black room, and honestly as long as it's not *every* lantern, refilling them is pretty manageable.
Fixes an issue with AO where wall shutters that began open at roundstart were getting AO overlays.
Fixes the innkeeper lacking a spawnpoint and inn workers spawning in the innkeeper's room.
Fixes an issue with wall shutters that started open at roundstart, where due to lacking a lighting overlay, their adjacent turfs' lumcount were all assumed to be 0.5.

## Why and what will this PR improve
> wow, it really sucks to spawn in a pitch-black room, and honestly as long as it's not *every* lantern, refilling them is pretty manageable

also the innkeeper gets a spawnpoint again

## Authorship
me

## Changelog
:cl:
tweak: inhabited rooms on Shaded Hills now start with open shutters and lit lanterns
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->