### PR TITLE
Make wild plants have a lower chance of harvestable produce

### DIFF
--- a/code/game/objects/structures/flora/plant.dm
+++ b/code/game/objects/structures/flora/plant.dm
@@ -30,8 +30,8 @@
 	. = ..()
 	if(dead)
 		to_chat(user, SPAN_OCCULT("It is dead."))
-	else if(length(harvestable))
-		to_chat(user, SPAN_NOTICE("You can see [length(harvestable)] harvestable fruit\s."))
+	else if(harvestable)
+		to_chat(user, SPAN_NOTICE("You can see [harvestable] harvestable fruit\s."))
 
 /obj/structure/flora/plant/dismantle_structure(mob/user)
 	if(plant)

--- a/code/game/objects/structures/flora/plant.dm
+++ b/code/game/objects/structures/flora/plant.dm
@@ -55,7 +55,7 @@
 	desc = "A wild [name]."
 	growth_stage = rand(round(plant.growth_stages * 0.65), plant.growth_stages)
 	if(!dead)
-		if(prob(50) && growth_stage >= plant.growth_stages)
+		if(prob(25) && growth_stage >= plant.growth_stages)
 			harvestable = rand(1, 3)
 		if(plant.get_trait(TRAIT_BIOLUM))
 			var/potency = plant.get_trait(TRAIT_POTENCY)


### PR DESCRIPTION
## Description of changes
Lowers the chance of harvestable fruit from wild plants by about half.

fixes broken examine info on plants, `length(harvested)` is invalid because `harvested` is just a number

## Why and what will this PR improve
Incentivizes actually doing farming instead of just gathering a ton of wild plants.
also fixes a bug with the examine info thing

## Authorship
me

## Changelog
:cl:
balance: lowered the chance of wild plants bearing harvestable fruit by about half, to incentivize farming
/:cl: