### PR TITLE
Allow soup to be bulk-produced

### DIFF
--- a/code/modules/food/cooking/_recipe.dm
+++ b/code/modules/food/cooking/_recipe.dm
@@ -63,6 +63,9 @@ var/global/list/_cooking_recipe_cache = list()
 	/// A minimum about of the above reagent required.
 	var/cooking_medium_amount
 
+	/// Whether this recipe is eligible for bulk cooking in a cooking vessel. Not currently checked by microwaves.
+	var/can_bulk_cook = FALSE
+
 	var/const/REAGENT_REPLACE = 0 //Reagents in the ingredients are discarded (only the reagents present in the result at compiletime are used)
 	var/const/REAGENT_MAX     = 1 //The result will contain the maximum of each reagent present between the two pools. Compiletime result, and sum of ingredients
 	var/const/REAGENT_MIN     = 2 //As above, but the minimum, ignoring zero values.

--- a/code/modules/food/cooking/cooking_vessels/_cooking_vessel.dm
+++ b/code/modules/food/cooking/cooking_vessels/_cooking_vessel.dm
@@ -106,8 +106,14 @@
 		started_cooking = world.time
 	else if((world.time - started_cooking) >= recipe.cooking_time)
 		recipe.produce_result(src)
-		started_cooking = null
-		last_recipe = null
+		recipe = select_recipe(cooking_category, src, temperature)
+		if(recipe && recipe == last_recipe && recipe.can_bulk_cook)
+			// Bulk cooking has benefits like reduced cook time
+			// we don't just do it instantly because there's messages each time
+			started_cooking = world.time + (recipe.cooking_time / 2)
+		else
+			started_cooking = null
+			last_recipe = null
 		return
 	last_recipe = recipe
 	update_icon()

--- a/code/modules/food/cooking/recipes/recipe_soup.dm
+++ b/code/modules/food/cooking/recipes/recipe_soup.dm
@@ -2,6 +2,7 @@
 	abstract_type = /decl/recipe/soup
 	reagent_mix = REAGENT_REPLACE
 	container_categories = list(RECIPE_CATEGORY_POT)
+	can_bulk_cook = TRUE
 	var/precursor_type
 
 /decl/recipe/soup/get_result_data(atom/container, list/used_ingredients)


### PR DESCRIPTION
## Description of changes
Allows soup to be bulk-produced when cooking. Rather than instantly repeating the recipe as with the microwave, this makes the next iteration of the recipe start half-completed, to avoid message spam from doing it instantly while still providing a benefit to cooking in larger batches.

## Why and what will this PR improve
Makes it easier to make large batches of soup.

## Authorship
me

## Changelog
:cl:
add: allows soup to be bulk-produced in pots; repeating a recipe immediately after the completing it cuts the recipe timer by half.
/:cl: