### PR TITLE
Give wood chests and cabinets temporary open/close sounds

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -6,6 +6,8 @@
 /obj/structure/closet/cabinet/wooden
 	desc = "A stout cabinet."
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME | MAT_FLAG_ALTERATION_DESC
+	open_sound = 'sound/effects/doorcreaky.ogg'
+	close_sound = 'sound/effects/doorcreaky.ogg'
 	material = /decl/material/solid/organic/wood
 	closet_appearance = /decl/closet_appearance/cabinet/nocolor
 

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -314,6 +314,8 @@
 	name = "chest"
 	desc = "A compact, hinged chest."
 	icon = 'icons/obj/closets/bases/chest.dmi'
+	open_sound = 'sound/effects/storage/briefcase.ogg'
+	close_sound = 'sound/effects/storage/briefcase.ogg'
 	closet_appearance = /decl/closet_appearance/crate/chest
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME | MAT_FLAG_ALTERATION_DESC
 	material = /decl/material/solid/organic/wood


### PR DESCRIPTION
## Description of changes
Gives wooden chests the briefcase open sound for open/close (like you're unclasping a fastener; this is what the few wooden chests I've opened in real life have sounded like at least).
Gives wooden cabinets/wardrobes/armoires the door open/close sound, because you're basically just swinging open a door. It might need to be shortened at some point given there's no delay when opening it like the actual doors have.

## Why and what will this PR improve
Fixes these having metal locker noises.