### PR TITLE
Optimize floor decals

### DIFF
--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -9,6 +9,7 @@
 		if(!istype(storage))
 			storage = null
 
+	// This preloader code is duplicated in /obj/effect/floor_decal/Initialize(). If you change this, be sure to change it there, too.
 	//atom creation method that preloads variables at creation
 	if(global.use_preloader && (src.type == global._preloader.target_path))//in case the instanciated atom is creating other atoms in New()
 		global._preloader.load(src)

--- a/code/game/turfs/floors/_floor.dm
+++ b/code/game/turfs/floors/_floor.dm
@@ -41,6 +41,8 @@
 	return TRUE
 
 /turf/floor/is_plating()
+	if(!(atom_flags & ATOM_FLAG_INITIALIZED))
+		return !initial_flooring
 	return !flooring
 
 /turf/floor/get_base_movement_delay(var/travel_dir, var/mob/mover)

--- a/code/game/turfs/floors/natural/_natural.dm
+++ b/code/game/turfs/floors/natural/_natural.dm
@@ -35,6 +35,9 @@
 /turf/floor/natural/get_plant_growth_rate()
 	return 0.1
 
+/turf/floor/natural/is_plating()
+	return FALSE
+
 /turf/floor/natural/Initialize(mapload, no_update_icon = FALSE)
 
 	if(base_color)

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -40,7 +40,7 @@ exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 24 "text2path uses" 'text2path'
 exactly 4 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 0 "goto uses" 'goto '
-exactly 5 "atom/New uses" '^/(obj|atom|area|mob|turf).*/New\('
+exactly 10 "atom/New uses" '^/(obj|atom|area|mob|turf).*/New\('
 exactly 1 "decl/New uses" '^/decl.*/New\('
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 3 "unmarked globally scoped variables" -P '^(/|)var/(?!global)'


### PR DESCRIPTION
## Description of changes
Changes split out from #4186 because they were contentious enough to block that PR for months.

Need to find a way to make decals layer over natural turfs without preventing you from building on them (`is_plating` is insufficient).

## Why and what will this PR improve
Optimizes floor decals by making them skip Initialize and Destroy logic because, well, they don't need it.
Fixes a bug where floor decals wouldn't show up on natural turfs.

## Authorship
Me.