### PR TITLE
Add animal husbandry to Shaded Hills

### DIFF
--- a/code/datums/ai/_ai.dm
+++ b/code/datums/ai/_ai.dm
@@ -256,6 +256,11 @@
 /datum/mob_controller/proc/check_memory(mob/speaker, message)
 	return FALSE
 
+/// General-purpose scooping reaction proc, used by /passive.
+/// Returns TRUE if the scoop should proceed, FALSE if it should be canceled.
+/datum/mob_controller/proc/scooped_by(mob/initiator)
+	return TRUE
+
 // Enemy tracking - used on /aggressive
 /datum/mob_controller/proc/get_enemies()
 	return _enemies

--- a/code/datums/ai/passive.dm
+++ b/code/datums/ai/passive.dm
@@ -54,3 +54,20 @@
 		if(istype(source))
 			flee_target = weakref(source)
 			update_targets()
+
+/datum/mob_controller/passive
+	var/decl/skill/scooping_skill // If overridden (on a subtype, on a map/downstream, etc) check this skill to see if scooping should succeed uncontested.
+	var/scooping_skill_req = SKILL_ADEPT
+
+/datum/mob_controller/passive/scooped_by(mob/living/initiator)
+	if(is_friend(initiator))
+		return TRUE
+	if(is_enemy(initiator) || (scooping_skill && initiator.skill_fail_prob(scooping_skill, 50, scooping_skill_req))) // scary, try to wriggle away
+		retaliate(initiator) // run! run like the wind!
+		if(!initiator.skill_fail_prob(SKILL_HAULING, 100, SKILL_EXPERT))
+			to_chat(initiator, SPAN_WARNING("\The [body] tries to wriggle out of your grasp, but you hold on tight!"))
+			return TRUE
+		to_chat(initiator, SPAN_WARNING("\The [body] wriggles out of your grasp!"))
+		initiator.drop_from_inventory(body)
+		return FALSE
+	return TRUE

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -296,7 +296,8 @@
 
 /mob/living/simple_animal/chick/handle_living_non_stasis_processes()
 	if((. = ..()))
-		amount_grown += rand(1,2)
+		if(prob(50)) // should take around 4 or 5 minutes to grow up, give or take
+			amount_grown += rand(1, 2)
 		if(amount_grown >= 100)
 			new /mob/living/simple_animal/fowl/chicken(src.loc)
 			qdel(src)
@@ -364,10 +365,10 @@ var/global/chicken_count = 0
 	if(istype(O, /obj/item/food)) //feedin' dem chickens
 		var/obj/item/food/G = O
 		if(findtext(G.get_grown_tag(), "wheat")) // includes chopped, crushed, dried etc.
-			if(!stat && eggsleft < 8)
+			if(!stat && eggsleft < 4)
 				user.visible_message(SPAN_NOTICE("[user] feeds \the [O] to \the [src]! It clucks happily."), SPAN_NOTICE("You feed \the [O] to \the [src]! It clucks happily."), SPAN_NOTICE("You hear clucking."))
 				qdel(O)
-				eggsleft += rand(1, 4)
+				eggsleft += rand(1, 2)
 			else
 				to_chat(user, SPAN_NOTICE("\The [src] doesn't seem hungry!"))
 		else
@@ -376,13 +377,13 @@ var/global/chicken_count = 0
 		..()
 
 /mob/living/simple_animal/fowl/chicken/handle_living_non_stasis_processes()
-	if((. = ..()) && prob(3) && eggsleft > 0)
+	if((. = ..()) && prob(1) && eggsleft > 0)
 		visible_message("[src] [pick("lays an egg.","squats down and croons.","begins making a huge racket.","begins clucking raucously.")]")
 		eggsleft--
 		var/obj/item/food/egg/E = new(get_turf(src))
 		E.pixel_x = rand(-6,6)
 		E.pixel_y = rand(-6,6)
-		if(chicken_count < MAX_CHICKENS && prob(10))
+		if(chicken_count < MAX_CHICKENS && prob(30))
 			E.amount_grown = 1
 			START_PROCESSING(SSobj, E)
 
@@ -465,7 +466,8 @@ var/global/chicken_count = 0
 
 /obj/item/food/egg/Process()
 	if(isturf(loc))
-		amount_grown += rand(1,2)
+		if(prob(50))
+			amount_grown++
 		if(amount_grown >= 100)
 			visible_message("[src] hatches with a quiet cracking sound.")
 			new /mob/living/simple_animal/chick(get_turf(src))

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -194,6 +194,24 @@
 	ai = /datum/mob_controller/chick
 	holder_type = /obj/item/holder
 	var/amount_grown = 0
+	var/decl/skill/examine_skill = SKILL_BOTANY // for maps that change the default skills, or for alien eggs that need science/medical/anatomy instead
+	var/examine_difficulty = SKILL_ADEPT
+
+/mob/living/simple_animal/chick/examine(mob/user, distance, infix, suffix)
+	. = ..()
+	if(!user.skill_check(examine_skill, examine_difficulty))
+		var/decl/skill/examine_skill_decl = GET_DECL(examine_skill)
+		to_chat(user, SPAN_SUBTLE("If you knew more about [lowertext(examine_skill_decl.name)], you could learn additional information about this."))
+		return
+	switch(amount_grown)
+		if(0 to 20)
+			to_chat(user, SPAN_NOTICE("It's still young."))
+		if(20 to 40)
+			to_chat(user, SPAN_NOTICE("It's starting to grow in its adult feathers."))
+		if(40 to 80)
+			to_chat(user, SPAN_NOTICE("It's grown in almost all its adult feathers."))
+		if(80 to 100)
+			to_chat(user, SPAN_NOTICE("It's almost fully grown."))
 
 /datum/mob_controller/chick
 	emote_speech = list("Cherp.","Cherp?","Chirrup.","Cheep!")

--- a/code/modules/mob_holder/holder_mobs.dm
+++ b/code/modules/mob_holder/holder_mobs.dm
@@ -23,17 +23,20 @@
 	H.w_class = get_object_size()
 	if(initiator == src)
 		if(!target.equip_to_slot_if_possible(H, slot_back_str, del_on_fail=0, disable_warning=1))
-			to_chat(initiator, "<span class='warning'>You can't climb onto [target]!</span>")
-			return
-		to_chat(target, "<span class='notice'>\The [src] clambers onto you!</span>")
-		to_chat(initiator, "<span class='notice'>You climb up onto \the [target]!</span>")
+			to_chat(initiator, SPAN_WARNING("You can't climb onto [target]!"))
+			return FALSE
+		to_chat(target, SPAN_NOTICE("\The [src] clambers onto you!"))
+		to_chat(initiator, SPAN_NOTICE("You climb up onto \the [target]!"))
 	else
 		if(!target.put_in_hands(H))
-			to_chat(initiator, "<span class='warning'>Your hands are full!</span>")
-			return
+			to_chat(initiator, SPAN_WARNING("Your hands are full!"))
+			return FALSE
 
-		to_chat(initiator, "<span class='notice'>You scoop up \the [src]!</span>")
-		to_chat(src, "<span class='notice'>\The [initiator] scoops you up!</span>")
+		if(!ai?.scooped_by(initiator))
+			return FALSE // The AI canceled the scooping.
+
+		to_chat(initiator, SPAN_NOTICE("You scoop up \the [src]!"))
+		to_chat(src, SPAN_NOTICE("\The [initiator] scoops you up!"))
 
 	forceMove(H)
 	reset_offsets(0)

--- a/maps/shaded_hills/jobs/inn.dm
+++ b/maps/shaded_hills/jobs/inn.dm
@@ -86,6 +86,7 @@
 	outfit_type             = /decl/outfit/job/shaded_hills/farmer
 	min_skill               = list(
 		SKILL_HAULING       = SKILL_ADEPT, // farming can be demanding work
+		SKILL_HUSBANDRY     = SKILL_ADEPT, // must be able to pick up and milk animals
 		SKILL_BOTANY        = SKILL_ADEPT, // must be skilled enough to have plants reliably survive when planted
 	)
 	skill_points            = 18

--- a/maps/shaded_hills/jobs/wilderness.dm
+++ b/maps/shaded_hills/jobs/wilderness.dm
@@ -56,6 +56,7 @@
 	outfit_type             = /decl/outfit/job/shaded_hills/forester
 	min_skill               = list(
 		SKILL_HAULING       = SKILL_ADEPT, // overall physical activity
+		SKILL_HUSBANDRY     = SKILL_BASIC, // handling and caring for animals
 		SKILL_BOTANY        = SKILL_BASIC, // growing and harvesting plants, trees, etc
 		SKILL_COOKING       = SKILL_BASIC, // butchery
 		SKILL_CARPENTRY     = SKILL_ADEPT, // tree felling

--- a/mods/content/fantasy/datum/skills.dm
+++ b/mods/content/fantasy/datum/skills.dm
@@ -224,7 +224,7 @@
 	levels = list(
 		"Unskilled"   = "You know next to nothing about animals. You can feed and clean up after them, but you know nothing about their biology, their behavior, or raising their young.",
 		"Basic"       = "You've cared for farm animals before. You can care for the basic needs of an animal, and know how to do things like milk a cow or shear a sheep.<br>- Cows will not flee when you try to milk them.",
-		"Trained"     = "You are proficient at animal handling, and can delicately handle even skittish animals without frightening them. <br>- Passive animals will not flee when you pick them up.", // TODO: Implement this benefit
+		"Trained"     = "You are proficient at animal handling, and can delicately handle even skittish animals without frightening them. <br>- Passive animals will not flee when you pick them up.",
 		"Experienced" = "You are an experienced animal caretaker with an encyclopedic knowledge of animals.",
 		"Master"      = "You're a specialized animal caretaker. You can care for even the most exotic, fragile, or dangerous animals."
 	)
@@ -233,6 +233,7 @@
 /mob/living/simple_animal/chick/examine_skill = SKILL_HUSBANDRY
 /mob/living/simple_animal/cow/milking_skill = SKILL_HUSBANDRY
 /mob/living/simple_animal/hostile/goat/milking_skill = SKILL_HUSBANDRY
+/datum/mob_controller/passive/scooping_skill = SKILL_HUSBANDRY
 
 /decl/skill/service/cooking
 	name = "Cooking"

--- a/mods/content/fantasy/datum/skills.dm
+++ b/mods/content/fantasy/datum/skills.dm
@@ -224,10 +224,15 @@
 	levels = list(
 		"Unskilled"   = "You know next to nothing about animals. You can feed and clean up after them, but you know nothing about their biology, their behavior, or raising their young.",
 		"Basic"       = "You've cared for farm animals before. You can care for the basic needs of an animal, and know how to do things like milk a cow or shear a sheep.<br>- Cows will not flee when you try to milk them.",
-		"Trained"     = "You are proficient at animal handling, and can delicately handle even skittish animals without frightening them. <br>- Passive animals will not flee when you pick them up.",
+		"Trained"     = "You are proficient at animal handling, and can delicately handle even skittish animals without frightening them. <br>- Passive animals will not flee when you pick them up.", // TODO: Implement this benefit
 		"Experienced" = "You are an experienced animal caretaker with an encyclopedic knowledge of animals.",
 		"Master"      = "You're a specialized animal caretaker. You can care for even the most exotic, fragile, or dangerous animals."
 	)
+
+/obj/item/food/egg/examine_skill = SKILL_HUSBANDRY
+/mob/living/simple_animal/chick/examine_skill = SKILL_HUSBANDRY
+/mob/living/simple_animal/cow/milking_skill = SKILL_HUSBANDRY
+/mob/living/simple_animal/hostile/goat/milking_skill = SKILL_HUSBANDRY
 
 /decl/skill/service/cooking
 	name = "Cooking"

--- a/mods/content/fantasy/datum/skills.dm
+++ b/mods/content/fantasy/datum/skills.dm
@@ -5,6 +5,8 @@
 #define SKILL_SCULPTING     /decl/skill/crafting/sculpting
 #define SKILL_ARTIFICE      /decl/skill/crafting/artifice
 
+#define SKILL_HUSBANDRY     /decl/skill/service/husbandry
+
 /decl/skill/Initialize()
 	. = ..()
 	// Rename the default skill levels.
@@ -214,6 +216,17 @@
 		"Trained"     = "You are proficient at botany, and can grow plants for food, medicine or textile use. Your plants will generally survive and prosper. <br>- You can safely plant and weed exotic plants.",
 		"Experienced" = "You are an experienced horticulturalist with an encyclopedic knowledge of plants and their properties.",
 		"Master"      = "You're a specialized gardener. You can care for even the most exotic, fragile, or dangerous plants."
+	)
+
+/decl/skill/service/husbandry
+	name = "Animal Husbandry"
+	desc = "Your ability to raise and care for animals."
+	levels = list(
+		"Unskilled"   = "You know next to nothing about animals. You can feed and clean up after them, but you know nothing about their biology, their behavior, or raising their young.",
+		"Basic"       = "You've cared for farm animals before. You can care for the basic needs of an animal, and know how to do things like milk a cow or shear a sheep.<br>- Cows will not flee when you try to milk them.",
+		"Trained"     = "You are proficient at animal handling, and can delicately handle even skittish animals without frightening them. <br>- Passive animals will not flee when you pick them up.",
+		"Experienced" = "You are an experienced animal caretaker with an encyclopedic knowledge of animals.",
+		"Master"      = "You're a specialized animal caretaker. You can care for even the most exotic, fragile, or dangerous animals."
 	)
 
 /decl/skill/service/cooking


### PR DESCRIPTION
## Description of changes
Adds an animal husbandry skill to Shaded Hills used in the following interactions, using the botany skill as a fallback on the main map unless otherwise specified:
- Examining baby chicks now gives you an estimate of their age.
- Examining a held egg while holding a light source now lets you determine if the egg is fertile, and how far along the egg's development is.
- Cows will now flee from someone who fails a skill check when attempting to milk them. If they fail repeatedly, the cow will get stressed and run away.
- Cows cannot be milked while attempting to flee, except if the milker has max level in the skill used for milking, in which case they will stop trying to move.
- Goats will now become hostile against someone (who is not a friend) who fails a skill check when attempting to milk them.
- Goats cannot be milked by someone they're hostile to, except if the milker has max level in the skill used for milking, in which case they will stop being enemies with the milker.
- Passive animals now have a skill-based chance to flee when picked up on Shaded Hills. They will always flee if an enemy attempts to pick them up, and will never flee if a friend picks them up.
- Chickens lay fewer eggs less often that are fertilized more often but grow slower as both eggs and chicks.

## Why and what will this PR improve
Gives farmers/foresters another advantage over randos when dealing with animals.

## Authorship
Me.

## Changelog
:cl:
add: Added an animal husbandry skill to Shaded Hills.
add: Added skill checks to milking animals, using the animal husbandry skill. On maps where that skill is unavailable, the botany skill is used instead.
add: Added candling eggs. If sufficiently skilled, you can examine a held egg while also holding a light source in order to determine if it has a chick inside it or not.
add: Examining a baby chick with at least basic botany (animal handling on Shaded Hills) skill will tell you how close the chick is to growing into a chicken.
add: Passive animals now have a skill-based chance to flee when picked up on Shaded Hills. They will always flee if an enemy attempts to pick them up, and will never flee if a friend picks them up.
balance: Chickens lay fewer eggs less often that are fertilized more often but grow slower as both eggs and chicks.
/:cl: