### PR TITLE
Make species not hidden from the codex by default

### DIFF
--- a/code/modules/species/outsider/random.dm
+++ b/code/modules/species/outsider/random.dm
@@ -32,6 +32,7 @@
 	name_plural = "Humanoids"
 	description = "Some alien humanoid species, unknown to humanity. How exciting."
 	rarity_value = 5
+	hidden_from_codex = TRUE
 
 	spawn_flags = SPECIES_IS_RESTRICTED
 

--- a/code/modules/species/outsider/starlight.dm
+++ b/code/modules/species/outsider/starlight.dm
@@ -6,6 +6,7 @@
 	force_cultural_info = list(
 		TAG_CULTURE = /decl/cultural_info/culture/other
 	)
+	hidden_from_codex = TRUE
 
 /decl/bodytype/starlight
 	abstract_type = /decl/bodytype/starlight

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -14,7 +14,7 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	var/roleplay_summary
 	var/ooc_codex_information
 	var/cyborg_noun = "Cyborg"
-	var/hidden_from_codex = TRUE
+	var/hidden_from_codex = FALSE
 	var/secret_codex_info
 
 	var/holder_icon

--- a/code/modules/species/species_shapeshifter.dm
+++ b/code/modules/species/species_shapeshifter.dm
@@ -11,6 +11,7 @@ var/global/list/wrapped_species_by_ref = list()
 		/mob/living/human/proc/shapeshifter_select_gender,
 		/mob/living/human/proc/shapeshifter_select_colour
 	)
+	hidden_from_codex = TRUE
 	var/list/valid_transform_species = list()
 	var/monochromatic
 	var/default_form

--- a/code/modules/species/station/golem.dm
+++ b/code/modules/species/station/golem.dm
@@ -12,6 +12,7 @@
 /decl/species/golem
 	name = SPECIES_GOLEM
 	name_plural = "Golems"
+	hidden_from_codex = TRUE
 
 	available_bodytypes = list(/decl/bodytype/crystalline/golem)
 

--- a/mods/species/ascent/datum/species.dm
+++ b/mods/species/ascent/datum/species.dm
@@ -28,6 +28,7 @@
 	name =                   SPECIES_MANTID_ALATE
 	name_plural =            "Kharmaan Alates"
 	show_ssd =               "quiescent"
+	hidden_from_codex =      TRUE
 
 	base_external_prosthetics_model = null
 	available_bodytypes = list(/decl/bodytype/crystalline/mantid/alate)

--- a/mods/species/drakes/species.dm
+++ b/mods/species/drakes/species.dm
@@ -5,6 +5,7 @@
 	They commonly dig shallow dens in dirt, snow or foliage, sometimes using them for concealment prior to an ambush. \
 	Biological cousins to the elusive kururak, they have heavy, low-slung bodies and powerful jaws suited to hunting land prey rather than fishing. \
 	Colonization and subsequent expansion have displaced many populations from their tundral territories into colder areas; as a result, their diet of Sivian prey animals has pivoted to a diet of giant spider meat."
+	hidden_from_codex = FALSE
 	available_bodytypes = list(
 		/decl/bodytype/quadruped/grafadreka,
 		/decl/bodytype/quadruped/grafadreka/hatchling


### PR DESCRIPTION
## Description of changes
Species are not hidden from the codex by default. Where applicable, `hidden_from_codex = TRUE` was explicitly added to species that inherited it beforehand.
Drakes are also explicitly not hidden, juuuust in case.

## Why and what will this PR improve
Fixes https://github.com/PyrelightSS13/Pyrelight/issues/77

## Authorship
Me