### PR TITLE
Fix upstream components of Pyrelight wyrdling bugs

### DIFF
--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -427,7 +427,7 @@
 			to_chat(usr, "Mob doesn't exist anymore")
 			return
 
-		if(victim.remove_language(rem_language.name))
+		if(victim.remove_language(rem_language.type))
 			to_chat(usr, "Removed [rem_language] from [victim].")
 		else
 			to_chat(usr, "Mob doesn't know that language.")

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -287,10 +287,15 @@
 		return TOPIC_HANDLED
 	return ..()
 
-/proc/transfer_languages(var/mob/source, var/mob/target, var/except_flags)
-	for(var/decl/language/L in source.languages)
-		if(L.flags & except_flags)
+/mob/proc/copy_languages_to(mob/target, except_flags)
+	for(var/decl/language/new_lang in languages)
+		if(new_lang.flags & except_flags)
 			continue
-		target.add_language(L.name)
+		target.add_language(new_lang.type)
+
+/mob/living/copy_languages_to(mob/living/target, except_flags)
+	..()
+	if(isliving(target))
+		target.default_language = default_language
 
 #undef SCRAMBLE_CACHE_LEN

--- a/code/modules/mob/living/silicon/robot/modules/_module.dm
+++ b/code/modules/mob/living/silicon/robot/modules/_module.dm
@@ -179,7 +179,7 @@
 	// Then add back all the original languages, and the relevant synthezising ability
 	for(var/original_language in original_languages)
 		var/decl/language/language_datum = original_language
-		R.add_language(language_datum.name, original_languages[original_language])
+		R.add_language(language_datum.type, original_languages[original_language])
 	original_languages.Cut()
 
 /obj/item/robot_module/proc/add_camera_channels(var/mob/living/silicon/robot/R)

--- a/code/modules/modular_computers/file_system/manifest.dm
+++ b/code/modules/modular_computers/file_system/manifest.dm
@@ -35,7 +35,7 @@
 		if(OOC)
 			var/active = 0
 			for(var/mob/M in global.player_list)
-				var/mob_real_name = M.real_name
+				var/mob_real_name = M.mind?.name || M.real_name
 				if(sanitize(mob_real_name) == CR.get_name() && M.client && M.client.inactivity <= 10 MINUTES)
 					active = 1
 					break

--- a/code/modules/spells/targeted/shapeshift.dm
+++ b/code/modules/spells/targeted/shapeshift.dm
@@ -38,9 +38,8 @@
 			if(varName in trans.vars)
 				trans.vars[varName] = newVars[varName]
 		//Give them our languages
-		for(var/l in M.languages)
-			var/decl/language/L = l
-			trans.add_language(L.name)
+		for(var/decl/language/lang as anything in M.languages)
+			trans.add_language(lang.type)
 
 		trans.SetName("[trans.name] ([M])")
 		if(ishuman(M) && drop_items)

--- a/mods/content/xenobiology/slime/items.dm
+++ b/mods/content/xenobiology/slime/items.dm
@@ -107,7 +107,7 @@
 	I.implant_in_mob(G, BP_HEAD)
 	if (user.languages.len)
 		var/decl/language/lang = user.languages[1]
-		G.add_language(lang.name)
+		G.add_language(lang.type)
 		G.set_default_language(lang)
 		I.languages[lang.name] = 1
 


### PR DESCRIPTION
## Description of changes
Makes OOC/lobby manifest activity checking more robust by using the mind's name, if set, rather than `real_name`. This might cause some weirdness with bodyswap, but it's OOC info anyway. Shrug.
Fixes some invalid arguments to add_language and remove_language; it takes a typepath, not a string.
Pretties up the unused transfer_languages proc for use downstream.

## Why and what will this PR improve
Fixes https://github.com/PyrelightSS13/Pyrelight/issues/70 and lays the groundwork for fixing https://github.com/PyrelightSS13/Pyrelight/issues/69.

## Authorship
Me.