### PR TITLE
Fix fire dousing issues

### DIFF
--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -336,7 +336,7 @@
 			if(reagent.accelerant_value <= FUEL_VALUE_SUPPRESSANT && !isnull(reagent.boiling_point) && reagent.boiling_point < get_current_burn_temperature())
 				do_steam = TRUE
 
-			var/volume = round(REAGENT_VOLUME(reagents, rtype) / REAGENT_UNITS_PER_GAS_MOLE)
+			var/volume = NONUNIT_CEILING(REAGENT_VOLUME(reagents, rtype) / REAGENT_UNITS_PER_GAS_MOLE, 0.1)
 			var/list/waste_products = burn_material(reagent, volume)
 			if(!isnull(waste_products))
 				for(var/product in waste_products)

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -237,8 +237,8 @@
 			last_fuel_burn_temperature = max(last_fuel_burn_temperature, mat.burn_temperature)
 			last_fuel_ignite_temperature = min(last_fuel_ignite_temperature, mat.ignition_point)
 		else if(mat.accelerant_value <= FUEL_VALUE_SUPPRESSANT)
-			// This means that 200u, a full wooden bucket of water, will suppress a fire with 20 fuel.
-			fuel -= amount * (mat.accelerant_value / FUEL_VALUE_SUPPRESSANT)
+			// This means that 100u (under two soup bowls full of water), will suppress a fire with 20 fuel.
+			fuel -= amount * (mat.accelerant_value / FUEL_VALUE_SUPPRESSANT) * 2
 		fuel = max(fuel, 0)
 		loc.take_waste_burn_products(., last_fuel_burn_temperature)
 


### PR DESCRIPTION
## Description of changes
changes a floor to a nonunit ceiling so that <10u of water doesn't get rounded to 0mol of water. instead 1u rounds to 0.1, 2u to 0.2, etc. nonunit floor is probably also safe but i didn't wanna risk 1u randomly failing, so.

also makes dousing fires twice as effective because honestly it was kind of underwhelming

## Why and what will this PR improve
fixes https://github.com/PyrelightSS13/Pyrelight/issues/74

## Authorship
me