### PR TITLE
Skintone defaults to the middle of the range.

### DIFF
--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -1,10 +1,9 @@
 /datum/preferences
 	var/species
-	var/blood_type                           //blood type
-
+	var/blood_type
 	var/eye_colour = COLOR_BLACK
 	var/skin_colour = COLOR_BLACK
-	var/skin_tone = 0                    //Skin tone
+	var/skin_tone = -75
 	var/list/sprite_accessories = list()
 	var/list/appearance_descriptors = list()
 	var/equip_preview_mob = EQUIP_PREVIEW_ALL
@@ -24,6 +23,10 @@
 	pref.blood_type =             R.read("b_type")
 	pref.appearance_descriptors = R.read("appearance_descriptors")
 	pref.bgstate =                R.read("bgstate")
+
+	// Null skintone loaded from file -> initial skintone value.
+	if(isnull(pref.skin_tone))
+		pref.skin_tone = initial(pref.skin_tone)
 
 	// Load all of our saved accessories.
 	pref.sprite_accessories = list()


### PR DESCRIPTION
Previous logic had `pref.skin_tone` as null unless explicitly set via the prefs Topic(), which meant an adjustment to the default skin tone that Polaris wanted to do was completely ignored.

Also included the Polaris adjustment because setting the default skintone to the middle of the range makes decent sense.

Ty @Cerebulon for pointing the bug out.