### PR TITLE
Repathing spellbooks to be /obj/item/book/spell.

### DIFF
--- a/code/datums/extensions/storage/subtypes_misc.dm
+++ b/code/datums/extensions/storage/subtypes_misc.dm
@@ -1,3 +1,7 @@
+/datum/storage/book
+	max_w_class = ITEM_SIZE_SMALL
+	storage_slots = 1
+
 /datum/storage/bible
 	max_w_class = ITEM_SIZE_SMALL
 	max_storage_space = 4

--- a/code/datums/outfits/wizardry.dm
+++ b/code/datums/outfits/wizardry.dm
@@ -5,7 +5,7 @@
 	r_pocket = /obj/item/teleportation_scroll
 	hands = list(
 		/obj/item/staff,
-		/obj/item/spellbook
+		/obj/item/book/spell
 	)
 	back = /obj/item/backpack
 	backpack_contents = list(/obj/item/box = 1)

--- a/code/modules/spells/artifacts/spellbound_servants.dm
+++ b/code/modules/spells/artifacts/spellbound_servants.dm
@@ -52,7 +52,7 @@
 					/obj/item/clothing/jumpsuit/lightpurple = slot_w_uniform_str,
 					/obj/item/clothing/shoes/sandal = slot_shoes_str,
 					/obj/item/staff = BP_R_HAND,
-					/obj/item/spellbook/apprentice = BP_L_HAND,
+					/obj/item/book/spell/apprentice = BP_L_HAND,
 					/obj/item/clothing/suit/wizrobe = slot_wear_suit_str)
 	spells = list(/spell/noclothes)
 

--- a/code/modules/spells/general/mark_recall.dm
+++ b/code/modules/spells/general/mark_recall.dm
@@ -80,7 +80,7 @@
 	return TRUE
 
 /obj/effect/cleanable/wizard_mark/attackby(var/obj/item/I, var/mob/user)
-	if(istype(I, /obj/item/spellbook))
+	if(istype(I, /obj/item/book/spell))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		visible_message("\The [src] fades away!")
 		qdel(src)

--- a/code/modules/spells/spellbook/cleric.dm
+++ b/code/modules/spells/spellbook/cleric.dm
@@ -1,5 +1,5 @@
 //Cleric is all about healing. Mobility and offense comes at a higher price but not impossible.
-/obj/item/spellbook/cleric
+/obj/item/book/spell/cleric
 	spellbook_type = /datum/spellbook/cleric
 
 /datum/spellbook/cleric

--- a/code/modules/spells/spellbook/druid.dm
+++ b/code/modules/spells/spellbook/druid.dm
@@ -1,6 +1,6 @@
 //all about the summons, nature, and a bit o' healin.
 
-/obj/item/spellbook/druid
+/obj/item/book/spell/druid
 	spellbook_type = /datum/spellbook/druid
 
 /datum/spellbook/druid

--- a/code/modules/spells/spellbook/spatial.dm
+++ b/code/modules/spells/spellbook/spatial.dm
@@ -1,6 +1,6 @@
 //all about moving around and mobility and being an annoying shit.
 
-/obj/item/spellbook/spatial
+/obj/item/book/spell/spatial
 	spellbook_type = /datum/spellbook/spatial
 
 /datum/spellbook/spatial

--- a/code/modules/spells/spellbook/standard.dm
+++ b/code/modules/spells/spellbook/standard.dm
@@ -1,6 +1,6 @@
 //the spellbook we know and love. Well, the one we know, at least.
 
-/obj/item/spellbook/standard
+/obj/item/book/spell/standard
 	spellbook_type = /datum/spellbook/standard
 
 /datum/spellbook/standard

--- a/code/modules/spells/spellbook/student.dm
+++ b/code/modules/spells/spellbook/student.dm
@@ -1,6 +1,6 @@
 //wizard's training wheels. Basically. Same shit as in the general one.
 
-/obj/item/spellbook/student
+/obj/item/book/spell/student
 	spellbook_type = /datum/spellbook/student
 
 /datum/spellbook/student
@@ -24,5 +24,5 @@
 /datum/spellbook/student/apprentice
 	book_flags = CAN_MAKE_CONTRACTS|INVESTABLE|NOREVERT|NO_LOCKING
 
-/obj/item/spellbook/apprentice
+/obj/item/book/spell/apprentice
 	spellbook_type = /datum/spellbook/student/apprentice

--- a/mods/gamemodes/cult/ritual.dm
+++ b/mods/gamemodes/cult/ritual.dm
@@ -1,13 +1,15 @@
 /obj/item/book/tome
-	name = "arcane tome"
-	icon = 'icons/obj/items/tome.dmi'
-	icon_state = "tome"
-	throw_speed = 1
-	throw_range = 5
-	w_class = ITEM_SIZE_SMALL
-	unique = 1
-	carved = 2 // Don't carve it
-	can_dissolve_text = FALSE // Or dissolve it
+	name              = "arcane tome"
+	icon              = 'icons/obj/items/tome.dmi'
+	icon_state        = "tome"
+	throw_speed       = 1
+	throw_range       = 5
+	w_class           = ITEM_SIZE_SMALL
+	unique            = TRUE
+	can_dissolve_text = FALSE
+
+/obj/item/book/tome/try_carve(mob/user, obj/item/tool)
+	return
 
 /obj/item/book/tome/attack_self(var/mob/user)
 	if(!iscultist(user))


### PR DESCRIPTION
## Description of changes
- Books now use a storage datum for their carved-out storage.
- Spellbooks are books.
 
## Why and what will this PR improve
Spellbooks can go in shelves, book storage is generalized.

## Authorship
Myself.

## Changelog
:cl:
tweak: Spellbooks can go into bookshelves.
/:cl: