### PR TITLE
Adding mouth gripper to passive animals.

### DIFF
--- a/code/modules/mob/living/human/human_grabs.dm
+++ b/code/modules/mob/living/human/human_grabs.dm
@@ -1,9 +1,3 @@
-/mob/living/human/add_grab(var/obj/item/grab/grab, var/defer_hand = FALSE)
-	if(defer_hand)
-		. = put_in_hands(grab)
-	else
-		. = put_in_active_hand(grab)
-
 /mob/living/human/can_be_grabbed(var/mob/grabber, var/target_zone, var/defer_hand = FALSE)
 	. = ..()
 	if(.)

--- a/code/modules/mob/living/inventory.dm
+++ b/code/modules/mob/living/inventory.dm
@@ -34,6 +34,7 @@
 			LAZYDISTINCTADD(., slot)
 
 /mob/living/add_held_item_slot(var/datum/inventory_slot/held_slot)
+	has_had_gripper = TRUE
 	var/datum/inventory_slot/existing_slot = get_inventory_slot_datum(held_slot.slot_id)
 	if(existing_slot && existing_slot != held_slot)
 		var/held = existing_slot.get_equipped_item()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -92,3 +92,6 @@
 
 	/// Var used to track current step for footsteps sounds.
 	var/tmp/step_count
+
+	/// Has this mob -ever- had a gripper? Used to skip hand checks in some cases.
+	var/has_had_gripper = FALSE

--- a/code/modules/mob/living/living_grabs.dm
+++ b/code/modules/mob/living/living_grabs.dm
@@ -61,6 +61,14 @@
 	return grab
 
 /mob/living/add_grab(var/obj/item/grab/grab, var/defer_hand = FALSE)
+
+	if(has_had_gripper)
+		if(defer_hand)
+			. = put_in_hands(grab)
+		else
+			. = put_in_active_hand(grab)
+		return
+
 	for(var/obj/item/grab/other_grab in contents)
 		if(other_grab != grab)
 			return FALSE

--- a/code/modules/mob/living/simple_animal/_simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/_simple_animal.dm
@@ -359,10 +359,6 @@ var/global/list/simplemob_icon_bitflag_cache = list()
 
 	..(message, null, verb)
 
-/mob/living/simple_animal/put_in_hands(var/obj/item/W) // No hands.
-	W.forceMove(get_turf(src))
-	return 1
-
 /mob/living/simple_animal/is_burnable()
 	return heat_damage_per_tick
 

--- a/code/modules/mob/living/simple_animal/passive/_passive.dm
+++ b/code/modules/mob/living/simple_animal/passive/_passive.dm
@@ -7,3 +7,6 @@
 	maxbodytemp          = 323
 	base_movement_delay  = -1
 
+/mob/living/simple_animal/passive/Initialize()
+	. = ..()
+	add_held_item_slot(new /datum/inventory_slot/gripper/mouth/simple)


### PR DESCRIPTION
- Adds mouth gripper to passive animal type. Mice can't pick stuff up so no big balance implications there.
- Removes simple_animal put_in_hands() override that is covered by lower level behavior.
- Merged human add_grab() down to /mob/living behind a new bool set the first time a hand slot is added.
- Fixes https://github.com/PyrelightSS13/Pyrelight/issues/73
- Fixes unreported issues with simple animal grabs in general.