### PR TITLE
Make refreshing VV not clear the search filter

### DIFF
--- a/code/js/view_variables.js
+++ b/code/js/view_variables.js
@@ -17,6 +17,11 @@ function updateSearch() {
 	}
 }
 
+function refreshPage(datumref) {
+	window.location.href = 'byond://?_src_=vars;datumrefresh=' + encodeURIComponent(datumref) + ';filter=' + encodeURIComponent(document.getElementById('filter').value);
+	return true;
+}
+
 function selectTextField() {
 	var filter_text = document.getElementById('filter');
 	filter_text.focus();

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -693,6 +693,6 @@
 	if(href_list["datumrefresh"])
 		var/datum/datum_to_refresh = locate(href_list["datumrefresh"])
 		if(istype(datum_to_refresh, /datum) || istype(datum_to_refresh, /client))
-			debug_variables(datum_to_refresh)
+			debug_variables_inner(datum_to_refresh, filter = href_list["filter"])
 
 	return

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -8,6 +8,9 @@ var/global/list/view_variables_no_assoc = list("verbs", "contents","screen","ima
 	set category = "Debug"
 	set name = "View Variables"
 
+	debug_variables_inner(D)
+
+/client/proc/debug_variables_inner(datum/D, filter = "" as null|text)
 	if(!check_rights(R_VAREDIT | R_DEBUG))
 		return
 
@@ -49,7 +52,7 @@ var/global/list/view_variables_no_assoc = list("verbs", "contents","screen","ima
 					</td>
 					<td width='50%'>
 						<div align='center'>
-							<a href='byond://?_src_=vars;datumrefresh=\ref[D]'>Refresh</a>
+							<a href='javascript:void(0)' onClick='refreshPage(\"\ref[D]\")'>Refresh</a>
 							[A ? "<A HREF='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[A.x];Y=[A.y];Z=[A.z]'>Jump To</a>":""]
 							<form>
 								<select name='file'
@@ -86,7 +89,7 @@ var/global/list/view_variables_no_assoc = list("verbs", "contents","screen","ima
 					<input type='text'
 					       id='filter'
 					       name='filter_text'
-					       value=''
+					       value='[filter]'
 					       style='width:100%;' />
 				</td>
 			</tr></table>


### PR DESCRIPTION
## Description of changes
The search filter for VV is now preserved when you refresh the page.

## Why and what will this PR improve
This makes testing things a lot easier, because you don't have to re-type your search after refreshing.

## Authorship
Me,

## Changelog
:cl:
admin: Refreshing the View Variables window no longer clears its search filter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->