### PR TITLE
Fix icon colours in view-variables menu

### DIFF
--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -23,6 +23,8 @@ var/global/list/view_variables_no_assoc = list("verbs", "contents","screen","ima
 		A = D
 		if(A.icon && A.icon_state)
 			sprite = icon(A.icon, A.icon_state)
+			if(A.color)
+				sprite.Blend(A.color, ICON_MULTIPLY)
 			send_rsc(usr, sprite, "view_vars_sprite.png")
 
 	send_rsc(usr,'code/js/view_variables.js', "view_variables.js")


### PR DESCRIPTION
## Description of changes
The icon sent to the VV menu is uncoloured by default. This blends the colour in manually. The blend call is probably minimal in terms of overhead compared to browse_rsc, and it's only for an admin feature anyway, so I figure the icon operation overhead is negligible.

## Why and what will this PR improve
The VV menu will now have a coloured preview icon for the datum you're viewing, if it's an atom. Previously, it was monochrome only.
It could be made more accurate if you used getFlatIcon, but that would be too much for just a small preview icon; this handles things like grass, meat, and most clothes just fine.