### PR TITLE
Tweaks radial label positioning.

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -362,3 +362,7 @@
 
 /// Call by name proc reference, checks if the proc is an existing global proc
 #define GLOBAL_PROC_REF(X) (/proc/##X)
+
+#define RADIAL_LABELS_NONE     0
+#define RADIAL_LABELS_OFFSET   1
+#define RADIAL_LABELS_CENTERED 2

--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -173,7 +173,7 @@ var/global/list/radial_menus = list()
 /datum/radial_menu/proc/get_next_id()
 	return "c_[choices.len]"
 
-/datum/radial_menu/proc/set_choices(list/new_choices, use_tooltips, use_labels)
+/datum/radial_menu/proc/set_choices(list/new_choices, use_tooltips, use_labels = RADIAL_LABELS_NONE)
 	if(choices.len)
 		Reset()
 	for(var/E in new_choices)
@@ -186,8 +186,7 @@ var/global/list/radial_menus = list()
 				choices_icons[id] = I
 	setup_menu(use_tooltips)
 
-
-/datum/radial_menu/proc/extract_image(image/E, var/use_labels)
+/datum/radial_menu/proc/extract_image(image/E, var/use_labels = RADIAL_LABELS_NONE)
 	var/mutable_appearance/MA = new /mutable_appearance(E)
 	if(MA)
 		MA.layer = HUD_ABOVE_HUD_LAYER
@@ -196,9 +195,15 @@ var/global/list/radial_menus = list()
 			MA.maptext_width = 64
 			MA.maptext_height = 64
 			MA.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-			MA.maptext_x = -round(MA.maptext_width/2) + 16
-			MA.maptext_y = -round(MA.maptext_height/2) + 16
-			MA.maptext = STYLE_SMALLFONTS_OUTLINE("<center>[E.name]</center>", 7, COLOR_WHITE, COLOR_BLACK)
+			switch(use_labels)
+				if(RADIAL_LABELS_OFFSET)
+					MA.maptext_x = -16
+					MA.maptext_y = -8
+					MA.maptext = STYLE_SMALLFONTS_OUTLINE("<center>[E.name]</center>", 7, COLOR_WHITE, COLOR_BLACK)
+				if(RADIAL_LABELS_CENTERED)
+					MA.maptext_x = -16
+					MA.maptext_y = -16
+					MA.maptext = "<span style='font-family: \"Small Fonts\"; color: #fff; -dm-text-outline: 1 #000; font-size: 7px; text-align:center; vertical-align:middle'>[E.name]</span>"
 
 	return MA
 
@@ -253,7 +258,7 @@ var/global/list/radial_menus = list()
 	Choices should be a list where list keys are movables or text used for element names and return value
 	and list values are movables/icons/images used for element icons
 */
-/proc/show_radial_menu(mob/user, atom/anchor, list/choices, uniqueid, radius, datum/callback/custom_check, require_near = FALSE, tooltips = FALSE, no_repeat_close = FALSE, list/check_locs, use_labels = FALSE)
+/proc/show_radial_menu(mob/user, atom/anchor, list/choices, uniqueid, radius, datum/callback/custom_check, require_near = FALSE, tooltips = FALSE, no_repeat_close = FALSE, list/check_locs, use_labels = RADIAL_LABELS_NONE)
 	if(!user || !anchor || !length(choices))
 		return
 	if(!uniqueid)

--- a/code/game/objects/items/blades/folding.dm
+++ b/code/game/objects/items/blades/folding.dm
@@ -147,7 +147,7 @@
 
 /decl/interaction_handler/folding_knife/invoked(atom/target, mob/user)
 	var/obj/item/bladed/folding/folding_knife = target
-	var/chosen_option = show_radial_menu(user, user, get_radial_choices(folding_knife), radius = 42, use_labels = TRUE)
+	var/chosen_option = show_radial_menu(user, user, get_radial_choices(folding_knife), radius = 42, use_labels = RADIAL_LABELS_OFFSET)
 	if(!chosen_option)
 		return
 	if(chosen_option == "Toggle")

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -124,7 +124,7 @@
 
 	if(!locked || destroyed)
 		var/obj/item/selected_item
-		selected_item = show_radial_menu(user, src, make_item_radial_menu_choices(src), radius = 42, require_near = TRUE, use_labels = TRUE)
+		selected_item = show_radial_menu(user, src, make_item_radial_menu_choices(src), radius = 42, require_near = TRUE, use_labels = RADIAL_LABELS_OFFSET)
 		if(QDELETED(selected_item) || !contents.Find(selected_item) || !Adjacent(user) || user.incapacitated())
 			return
 

--- a/code/modules/interactions/interactions_atom.dm
+++ b/code/modules/interactions/interactions_atom.dm
@@ -18,7 +18,7 @@
 	if(length(possibilities) == 1)
 		choice = possibilities[1]
 	else
-		choice = show_radial_menu(user, src, possibilities, use_labels = TRUE)
+		choice = show_radial_menu(user, src, possibilities, use_labels = RADIAL_LABELS_CENTERED)
 		if(!istype(choice) || QDELETED(user) || !(choice.type in get_alt_interactions(user)) || !choice.is_possible(src, user, prop))
 			return TRUE
 

--- a/code/modules/mob/living/human/human_attackhand.dm
+++ b/code/modules/mob/living/human/human_attackhand.dm
@@ -408,7 +408,7 @@
 			var/image/radial_button = new
 			radial_button.name = capitalize(u_attack.name)
 			LAZYSET(choices, u_attack, radial_button)
-	var/decl/natural_attack/new_attack = show_radial_menu(src, (attack_selector || src), choices, radius = 42, use_labels = TRUE)
+	var/decl/natural_attack/new_attack = show_radial_menu(src, (attack_selector || src), choices, radius = 42, use_labels = RADIAL_LABELS_OFFSET)
 	if(QDELETED(src) || !istype(new_attack) || !(new_attack.type in get_natural_attacks()))
 		return
 	default_attack = new_attack

--- a/code/modules/mob/living/living_maneuvers.dm
+++ b/code/modules/mob/living/living_maneuvers.dm
@@ -53,7 +53,7 @@
 		I.name = capitalize(maneuver_decl.name)
 		maneuvers[maneuver_decl.name] = I
 
-	var/next_maneuver = show_radial_menu(src, src, maneuvers, require_near = TRUE, radius = 42, tooltips = TRUE, check_locs = list(src), use_labels = TRUE)
+	var/next_maneuver = show_radial_menu(src, src, maneuvers, require_near = TRUE, radius = 42, tooltips = TRUE, check_locs = list(src), use_labels = RADIAL_LABELS_OFFSET)
 	if(next_maneuver)
 		var/decl/maneuver/maneuver = maneuvers_by_name[next_maneuver]
 		if(!maneuver.can_be_used_by(src, null))

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -326,7 +326,7 @@
 	if(stage == 2 && (used_item.sharp || IS_HEMOSTAT(used_item) || IS_WIRECUTTER(used_item)))
 		var/list/radial_buttons = make_item_radial_menu_choices(get_contents_recursive())
 		if(LAZYLEN(radial_buttons))
-			var/obj/item/removing = show_radial_menu(user, src, radial_buttons, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(src))
+			var/obj/item/removing = show_radial_menu(user, src, radial_buttons, radius = 42, require_near = TRUE, use_labels = RADIAL_LABELS_OFFSET, check_locs = list(src))
 			if(removing)
 				if(istype(removing, /obj/item/organ))
 					var/obj/item/organ/removed_organ = removing
@@ -351,7 +351,7 @@
 		return
 
 	//Display radial menu
-	var/obj/item/organ/external/removing = show_radial_menu(user, src, radial_buttons, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(src))
+	var/obj/item/organ/external/removing = show_radial_menu(user, src, radial_buttons, radius = 42, require_near = TRUE, use_labels = RADIAL_LABELS_OFFSET, check_locs = list(src))
 	if(!istype(removing))
 		return TRUE
 

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -118,7 +118,7 @@
 		HAND_LABELER_MODE_REM_NAME    = btn_rem_one,
 		HAND_LABELER_MODE_REMALL_NAME = btn_rem_all,
 	)
-	return show_radial_menu(user, user, choices, use_labels = TRUE)
+	return show_radial_menu(user, user, choices, use_labels = RADIAL_LABELS_OFFSET)
 
 /obj/item/hand_labeler/attack_self(mob/user)
 	var/choice = show_action_radial_menu(user)

--- a/code/modules/surgery/_surgery.dm
+++ b/code/modules/surgery/_surgery.dm
@@ -271,7 +271,7 @@ var/global/list/surgery_tool_exception_cache = list()
 		if(!user.client) // In case of future autodocs.
 			S = possible_surgeries[1]
 		else
-			S = show_radial_menu(user, M, possible_surgeries, radius = 42, use_labels = TRUE, require_near = TRUE, check_locs = list(src))
+			S = show_radial_menu(user, M, possible_surgeries, radius = 42, use_labels = RADIAL_LABELS_OFFSET, require_near = TRUE, check_locs = list(src))
 		if(S && !user.skill_check_multiple(S.get_skill_reqs(user, M, src, zone)))
 			S = pick(possible_surgeries)
 

--- a/code/modules/surgery/necrotic.dm
+++ b/code/modules/surgery/necrotic.dm
@@ -53,7 +53,7 @@
 	else
 		if(length(dead_organs) == 1)
 			return dead_organs[1]
-		return show_radial_menu(user, tool, dead_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
+		return show_radial_menu(user, tool, dead_organs, radius = 42, require_near = TRUE, use_labels = RADIAL_LABELS_OFFSET, check_locs = list(tool))
 	return FALSE
 
 /decl/surgery_step/necrotic/tissue/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
@@ -149,7 +149,7 @@
 	else
 		if(length(dead_organs) == 1)
 			return dead_organs[1]
-		return show_radial_menu(user, tool, dead_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
+		return show_radial_menu(user, tool, dead_organs, radius = 42, require_near = TRUE, use_labels = RADIAL_LABELS_OFFSET, check_locs = list(tool))
 	return FALSE
 
 /decl/surgery_step/necrotic/regeneration/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -111,7 +111,7 @@
 	else
 		if(length(attached_organs) == 1)
 			return attached_organs[1]
-		return show_radial_menu(user, tool, attached_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
+		return show_radial_menu(user, tool, attached_organs, radius = 42, require_near = TRUE, use_labels = RADIAL_LABELS_OFFSET, check_locs = list(tool))
 	return FALSE
 
 /decl/surgery_step/internal/detach_organ/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
@@ -165,7 +165,7 @@
 		else
 			if(length(removable_organs) == 1)
 				return removable_organs[1]
-			return show_radial_menu(user, tool, removable_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
+			return show_radial_menu(user, tool, removable_organs, radius = 42, require_near = TRUE, use_labels = RADIAL_LABELS_OFFSET, check_locs = list(tool))
 	return FALSE
 
 /decl/surgery_step/internal/remove_organ/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool)
@@ -342,7 +342,7 @@
 	if(!LAZYLEN(attachable_organs))
 		return FALSE
 
-	var/obj/item/organ/organ_to_replace = show_radial_menu(user, tool, attachable_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
+	var/obj/item/organ/organ_to_replace = show_radial_menu(user, tool, attachable_organs, radius = 42, require_near = TRUE, use_labels = RADIAL_LABELS_OFFSET, check_locs = list(tool))
 	if(!organ_to_replace)
 		return FALSE
 

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -421,7 +421,7 @@
 	if(!LAZYLEN(attached_organs))
 		to_chat(user, SPAN_WARNING("There are no appropriate internal components to decouple."))
 		return FALSE
-	return show_radial_menu(user, tool, attached_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
+	return show_radial_menu(user, tool, attached_organs, radius = 42, require_near = TRUE, use_labels = RADIAL_LABELS_OFFSET, check_locs = list(tool))
 
 /decl/surgery_step/robotics/detach_organ_robotic/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	user.visible_message("[user] starts to decouple [target]'s [LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone)] with \the [tool].", \
@@ -463,7 +463,7 @@
 			var/image/radial_button = image(icon = I.icon, icon_state = I.icon_state)
 			radial_button.name = "Reattach \the [I.name]"
 			LAZYSET(removable_organs, I.organ_tag, radial_button)
-	var/organ_to_replace = show_radial_menu(user, tool, removable_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
+	var/organ_to_replace = show_radial_menu(user, tool, removable_organs, radius = 42, require_near = TRUE, use_labels = RADIAL_LABELS_OFFSET, check_locs = list(tool))
 	if(!organ_to_replace)
 		return FALSE
 	var/obj/item/organ/internal/augment/A = organ_to_replace


### PR DESCRIPTION
## Description of changes
- Moves the default label position up eight pixels to associate the labels closer with their button.
- Adds a `use_labels` value that centers the value on the button.

![image](https://github.com/user-attachments/assets/a58c3ad0-6c80-4774-af4e-91a9aebaae55)
![image](https://github.com/user-attachments/assets/ea5efb00-a934-400c-bf1e-8725308c07ed)

## Why and what will this PR improve
Improves UI readability for radials. Stops me repeatedly clicking on cancel because the label is closer to cancel than its own button.

## Authorship
Myself.

## Changelog
Nothing really player relevant.