### PR TITLE
Adding recipes and ores for producing sulfuric acid.

### DIFF
--- a/code/modules/reagents/reactions/reaction_compounds.dm
+++ b/code/modules/reagents/reactions/reaction_compounds.dm
@@ -120,3 +120,29 @@
 	result = /decl/material/liquid/contaminant_cleaner
 	required_reagents = list(/decl/material/solid/sodium = 1, /decl/material/liquid/surfactant = 1)
 	result_amount = 2
+
+/decl/chemical_reaction/compound/lube
+	name = "Lubricant"
+	result = /decl/material/liquid/lube
+	required_reagents = list(/decl/material/liquid/water = 1, /decl/material/solid/silicon = 1, /decl/material/liquid/acetone = 1)
+	result_amount = 3
+	mix_message = "The solution becomes thick and slimy."
+
+/decl/chemical_reaction/compound/pacid
+	name = "Polytrinic acid"
+	result = /decl/material/liquid/acid/polyacid
+	required_reagents = list(/decl/material/liquid/acid = 1, /decl/material/liquid/acid/hydrochloric = 1, /decl/material/solid/potassium = 1)
+	result_amount = 3
+
+/decl/chemical_reaction/compound/sulfuric_acid
+	name = "Oil of Vitriol"
+	result = /decl/material/liquid/acid
+	required_reagents = list(/decl/material/solid/pyrite = 2, /decl/material/solid/sodiumchloride = 2)
+	mix_message = "The solution turns a bright red and gives off harsh fumes."
+	minimum_temperature = 500 CELSIUS
+	result_amount = 2
+
+/decl/chemical_reaction/compound/sulfuric_acid/pure
+	name = "Sulfuric Acid"
+	required_reagents = list(/decl/material/solid/sulfur = 1, /decl/material/solid/sodium = 2)
+	result_amount = 3

--- a/code/modules/reagents/reactions/reaction_drugs.dm
+++ b/code/modules/reagents/reactions/reaction_drugs.dm
@@ -48,19 +48,6 @@
 	minimum_temperature = 50 CELSIUS
 	maximum_temperature = (50 CELSIUS) + 100
 
-/decl/chemical_reaction/drug/lube
-	name = "Lubricant"
-	result = /decl/material/liquid/lube
-	required_reagents = list(/decl/material/liquid/water = 1, /decl/material/solid/silicon = 1, /decl/material/liquid/acetone = 1)
-	result_amount = 3
-	mix_message = "The solution becomes thick and slimy."
-
-/decl/chemical_reaction/drug/pacid
-	name = "Polytrinic acid"
-	result = /decl/material/liquid/acid/polyacid
-	required_reagents = list(/decl/material/liquid/acid = 1, /decl/material/liquid/acid/hydrochloric = 1, /decl/material/solid/potassium = 1)
-	result_amount = 3
-
 /decl/chemical_reaction/drug/antirads
 	name = "Anti-Radiation Medication"
 	result = /decl/material/liquid/antirads

--- a/maps/shaded_hills/levels/strata.dm
+++ b/maps/shaded_hills/levels/strata.dm
@@ -7,7 +7,9 @@
 		/decl/material/solid/quartz,
 		/decl/material/solid/graphite,
 		/decl/material/solid/tetrahedrite,
-		/decl/material/solid/hematite
+		/decl/material/solid/hematite,
+		/decl/material/solid/pyrite,
+		/decl/material/solid/sodiumchloride
 	)
 	ores_rich = list(
 		/decl/material/solid/gemstone/diamond,


### PR DESCRIPTION
Opening on behalf of Crimes because of Github shenanigans.

## Description of changes
Adds two reactions for creating sulfuric acid, one using raw ores and one from pure reagents.
Puts pyrite and rock salt in the strata list for Shaded Hills.

## Why and what will this PR improve
Being able to produce sulfuric acid with these reactions expands the possibilities for low-tech chemistry, by allowing it to be used as a raw material for reactions and as a solvent for metals. Pyrite and rock salt are added to Shaded Hills to provide the necessary ores to start the process.

## Authorship
@Dhul-Qarnayn 

## Changelog
:cl:
tweak: Salt and fools' gold can be mined on Shaded Hills.
add: Sulfuric acid can be produced from sodium and sulfur.
/:cl: