### PR TITLE
Fix issues with ointment, ailments, and medical stacks

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -58,6 +58,14 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	if(!ismob(user))
 		return TRUE
 
+	if(!QDELETED(used_item) && user.a_intent == I_HELP)
+		var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(src, user.get_target_zone())
+		if(length(E?.ailments))
+			for(var/datum/ailment/ailment in E.ailments)
+				if(ailment.treated_by_item(used_item))
+					ailment.was_treated_by_item(used_item, user, src)
+					return TRUE
+
 	if(user.a_intent != I_HURT)
 		if(can_operate(src, user) != OPERATE_DENY && used_item.do_surgery(src,user)) //Surgery
 			return TRUE
@@ -79,26 +87,12 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	if(used_item.get_attack_force(user) && istype(ai) && current_health < oldhealth)
 		ai.retaliate(user)
 
-/mob/living/human/attackby(obj/item/I, mob/user)
-
-	. = ..()
-	if(.)
-		if(user.a_intent != I_HELP)
-			return
-		var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(src, user.get_target_zone())
-		if(!E)
-			return
-		for(var/datum/ailment/ailment in E.ailments)
-			if(ailment.treated_by_item(I))
-				ailment.was_treated_by_item(I, user, src)
-				return
-
-	else if(user == src && user.get_target_zone() == BP_MOUTH && can_devour(I, silent = TRUE))
+	if(!. && user == src && user.get_target_zone() == BP_MOUTH && can_devour(used_item, silent = TRUE))
 		var/obj/item/blocked = src.check_mouth_coverage()
 		if(blocked)
 			to_chat(user, SPAN_WARNING("\The [blocked] is in the way!"))
 		else
-			devour(I)
+			devour(used_item)
 		return TRUE
 
 

--- a/code/game/objects/items/stacks/medical/medical_ointment.dm
+++ b/code/game/objects/items/stacks/medical/medical_ointment.dm
@@ -27,10 +27,9 @@
 		to_chat(user, SPAN_WARNING("You must stand still to salve wounds."))
 		return 0
 	show_limb_salve_message(user, target, affecting)
-	use(1)
 	affecting.salve()
 	affecting.disinfect()
-	return 1
+	return 1 // consume 1 stack
 
 /obj/item/stack/medical/ointment/proc/show_limb_salve_message(mob/living/user, mob/living/target, obj/item/organ/external/affecting)
 	user.visible_message(

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -105,7 +105,7 @@
 /**
  *  Return FALSE if victim can't be devoured, DEVOUR_FAST if they can be devoured quickly, DEVOUR_SLOW for slow devour
  */
-/mob/living/proc/can_devour(atom/movable/victim)
+/mob/living/proc/can_devour(atom/movable/victim, silent = FALSE)
 	return FALSE
 
 /mob/living/verb/sniff_verb()

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -522,12 +522,12 @@ var/global/list/ailment_reference_cache = list()
 	if(ispath(ailment, /datum/ailment))
 		for(var/datum/ailment/ext_ailment in ailments)
 			if(ailment == ext_ailment.type)
-				LAZYREMOVE(ailments, ext_ailment)
+				qdel(ext_ailment)
 				return TRUE
 	else if(istype(ailment))
 		for(var/datum/ailment/ext_ailment in ailments)
 			if(ailment == ext_ailment)
-				LAZYREMOVE(ailments, ext_ailment)
+				qdel(ext_ailment)
 				return TRUE
 	return FALSE
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -343,6 +343,7 @@
 		PRINT_STACK_TRACE("rejuvenate() called on organ of type [type] with no owner.")
 	damage = 0
 	reset_status()
+	QDEL_NULL_LIST(ailments)
 	if(!ignore_organ_traits)
 		for(var/trait_type in owner.get_traits())
 			var/decl/trait/trait = GET_DECL(trait_type)


### PR DESCRIPTION
## Description of changes
Makes treating ailments take priority over other interactions, to avoid conflicts with organ treatment.
Replaces `LAZYREMOVE` with `qdel` in `remove_ailment()`.
Removes ailments on organ rejuvenation.
Removes a redundant `use(1)` in ointment code.

## Why and what will this PR improve
Fixes being unable to treat rashes and sprains using ointment and gauze.
Fixes ointment being twice as expensive, using (up to) two stacks per interaction.
Fixes removing ailments via VV not ending ailment effects.
Fixes rejuvenation not removing ailments.