### PR TITLE
Fix ambiguous 'in' order warnings from OpenDream

### DIFF
--- a/code/___opendream_linting.dm
+++ b/code/___opendream_linting.dm
@@ -31,4 +31,5 @@
 #pragma UnsafeClientAccess disabled
 #pragma SuspiciousSwitchCase error
 #pragma AssignmentInConditional error
+#pragma AmbiguousInOrder error
 #endif

--- a/code/game/verbs/ignore.dm
+++ b/code/game/verbs/ignore.dm
@@ -7,7 +7,7 @@
 		return
 	key_to_ignore = ckey(sanitize(key_to_ignore))
 	if(prefs && prefs.ignored_players)
-		if(key_to_ignore in prefs.ignored_players && key_to_ignore != ckey)
+		if((key_to_ignore in prefs.ignored_players) && key_to_ignore != ckey)
 			to_chat(usr, "<span class='warning'>[key_to_ignore] is already being ignored.</span>")
 			return
 		prefs.ignored_players |= key_to_ignore

--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -106,7 +106,7 @@
 
 			owner.visible_message(SPAN_NOTICE("\The [owner] begins loading \the [O]."))
 			if(do_after(owner, 20, O, 0, 1))
-				if(O in carrying || O.buckled_mob || O.anchored || (locate(/mob/living) in O)) //Repeat checks
+				if((O in carrying) || O.buckled_mob || O.anchored || (locate(/mob/living) in O)) //Repeat checks
 					return
 				if(length(carrying) >= carrying_capacity)
 					to_chat(user, SPAN_WARNING("\The [src] is fully loaded!"))

--- a/code/modules/overmap/events/event.dm
+++ b/code/modules/overmap/events/event.dm
@@ -146,7 +146,7 @@
 
 /decl/overmap_event_handler/proc/is_event_in_turf(var/datum/event/E, var/turf/T)
 	for(var/obj/effect/overmap/event/hazard in hazard_by_turf[T])
-		if(E in hazard.events && E.severity == hazard.difficulty)
+		if((E in hazard.events) && E.severity == hazard.difficulty)
 			return TRUE
 
 /decl/overmap_event_handler/proc/is_event_included(var/list/hazards, var/obj/effect/overmap/event/E, var/equal_or_better)//this proc is only used so it can break out of 2 loops cleanly

--- a/code/modules/xenoarcheaology/finds/find_types/statuette.dm
+++ b/code/modules/xenoarcheaology/finds/find_types/statuette.dm
@@ -40,7 +40,7 @@
 	//see if we've identified anyone nearby
 	if(world.time - last_bloodcall > bloodcall_interval && nearby_mobs.len)
 		var/mob/living/human/M = pop(nearby_mobs)
-		if(M in view(7,src) && M.current_health > 20)
+		if((M in viewers(7,src)) && M.current_health > 20)
 			if(prob(50))
 				bloodcall(M)
 				nearby_mobs.Add(M)


### PR DESCRIPTION
## Description of changes
Adds parentheses to disambiguate 'in' clauses with ambiguous precedence, caught by OpenDream.
Also elevates the warning to an error.

## Why and what will this PR improve
Fixes things broken due to 'in' precedence being weird