### PR TITLE
Remove or implement unused variables and procs

### DIFF
--- a/code/datums/extensions/scent/_scent.dm
+++ b/code/datums/extensions/scent/_scent.dm
@@ -128,7 +128,7 @@ To add a scent extension to an atom using a reagent's info, where R. is the reag
 // Returns the smelliest reagent of a reagent holder.
 /proc/get_smelliest_reagent(var/datum/reagents/holder)
 	var/decl/material/smelliest
-	var/decl/material/scent_intensity
+	var/scent_intensity
 	if(!holder || !holder.total_volume)
 		return
 	for(var/reagent_type in holder.reagent_volumes)

--- a/code/datums/extensions/state_machine.dm
+++ b/code/datums/extensions/state_machine.dm
@@ -6,16 +6,15 @@ var/global/list/state_machines = list()
 		var/list/machines = global.state_machines["\ref[holder]"]
 		return islist(machines) && machines[base_type]
 
-/proc/add_state_machine(var/datum/holder, var/base_type, var/fsm_type)
-	if(istype(holder) && base_type)
+/proc/add_state_machine(var/datum/holder, var/datum/state_machine/fsm_type)
+	if(istype(holder) && fsm_type)
 		var/holder_ref = "\ref[holder]"
 		var/list/machines = global.state_machines[holder_ref]
 		if(!islist(machines))
 			machines = list()
 			global.state_machines[holder_ref] = machines
+		var/base_type = fsm_type::base_type
 		if(!machines[base_type])
-			if(!fsm_type)
-				fsm_type = base_type
 			var/datum/state_machine/machine = new fsm_type(holder)
 			machines[base_type] = machine
 			holder.has_state_machine = TRUE

--- a/code/datums/extensions/state_machine.dm
+++ b/code/datums/extensions/state_machine.dm
@@ -43,8 +43,8 @@ var/global/list/state_machines = list()
 
 /datum/state_machine/New(var/datum/_holder)
 	..()
-	if(!istype(_holder))
-		PRINT_STACK_TRACE("Non-datum holder supplied to [type] New().")
+	if(!istype(_holder, expected_type))
+		PRINT_STACK_TRACE("Non-[expected_type] holder supplied to [type] New().")
 	else
 		holder_ref = weakref(_holder)
 	set_state(current_state)

--- a/code/datums/extensions/storage/_storage.dm
+++ b/code/datums/extensions/storage/_storage.dm
@@ -42,8 +42,8 @@ var/global/list/_test_storage_items = list()
 	global._test_storage_items += src
 #endif
 
-	if(!istype(_holder))
-		PRINT_STACK_TRACE("Storage datum initialized with non-atom holder '[_holder || "NULL"].")
+	if(!istype(_holder, expected_type))
+		PRINT_STACK_TRACE("Storage datum initialized with non-[expected_type] holder '[_holder || "NULL"].")
 		qdel(src)
 		return
 

--- a/code/datums/hostility/hostility.dm
+++ b/code/datums/hostility/hostility.dm
@@ -59,5 +59,5 @@
 		var/mob/living/L = target
 		if(iscuffed(L))
 			return FALSE
-		return L.assess_perp(holder, access_security, check_weapons, check_no_record, check_wanted) < threat_level_threshold
+		return L.assess_perp(holder, access_check, check_weapons, check_no_record, check_wanted) < threat_level_threshold
 	return FALSE

--- a/code/datums/inventory_slots/inventory_gripper.dm
+++ b/code/datums/inventory_slots/inventory_gripper.dm
@@ -1,6 +1,5 @@
 /datum/inventory_slot/gripper
 	var/hand_sort_priority = 1
-	var/can_use_held_item = TRUE
 	var/dexterity = DEXTERITY_FULL
 	var/covering_slot_flags
 	/// If set, use this icon_state for the hand slot overlay; otherwise, use slot_id.

--- a/code/datums/inventory_slots/inventory_gripper_subtypes.dm
+++ b/code/datums/inventory_slots/inventory_gripper_subtypes.dm
@@ -2,7 +2,6 @@
 	slot_name = "Mouth"
 	slot_id = BP_MOUTH
 	requires_organ_tag = BP_HEAD
-	can_use_held_item = FALSE
 	overlay_slot = BP_MOUTH
 	ui_label = "M"
 	hand_sort_priority = 3

--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -283,7 +283,7 @@
 			if(!def_value)//If it's a custom objective, it will be an empty string.
 				def_value = "custom"
 
-		var/new_obj_type = input("Select objective type:", "Objective type", def_value) as null|anything in list("assassinate", "debrain", "protect", "prevent", "harm", "brig", "hijack", "escape", "survive", "steal", "download", "mercenary", "capture", "custom")
+		var/new_obj_type = input("Select objective type:", "Objective type", def_value) as null|anything in list("assassinate", "debrain", "protect", "prevent", "harm", "brig", "hijack", "escape", "survive", "steal", "download", "mercenary", "custom")
 		if (!new_obj_type) return
 
 		var/datum/objective/new_objective = null
@@ -341,7 +341,7 @@
 				new_objective = new /datum/objective/steal
 				new_objective.owner = src
 
-			if("download","capture")
+			if("download")
 				var/def_num
 				if(objective&&objective.type==text2path("/datum/objective/[new_obj_type]"))
 					def_num = objective.target_amount
@@ -354,9 +354,6 @@
 					if("download")
 						new_objective = new /datum/objective/download
 						new_objective.explanation_text = "Download [target_number] research levels."
-					if("capture")
-						new_objective = new /datum/objective/capture
-						new_objective.explanation_text = "Accumulate [target_number] capture points."
 				new_objective.owner = src
 				new_objective.target_amount = target_number
 
@@ -366,6 +363,8 @@
 				new_objective = new /datum/objective
 				new_objective.owner = src
 				new_objective.explanation_text = expl
+			else
+				PRINT_STACK_TRACE("ERROR: Unrecognized objective type [new_obj_type]")
 
 		if (!new_objective) return
 

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -209,16 +209,17 @@
 			W.update_icon()
 	H.update_icon()
 	H.set_id_info(W)
-	equip_pda(H, assignment, equip_adjustments)
+	equip_pda(H, id_pda_assignment || assignment, equip_adjustments)
 	if(H.equip_to_slot_or_store_or_drop(W, id_slot))
 		return W
 
-/decl/outfit/proc/equip_pda(var/mob/living/human/H, var/assignment, var/equip_adjustments)
+/decl/outfit/proc/equip_pda(var/mob/living/human/H, var/label_assignment, var/equip_adjustments)
 	if(!pda_slot || !pda_type)
 		return
 	if(OUTFIT_ADJUSTMENT_SKIP_ID_PDA & equip_adjustments)
 		return
 	var/obj/item/modular_computer/pda/pda = new pda_type(H)
+	pda.set_owner_rank_job(H.real_name, label_assignment)
 	if(H.equip_to_slot_or_store_or_drop(pda, pda_slot))
 		return pda
 

--- a/code/datums/state_machine/paper_fortune_fsm.dm
+++ b/code/datums/state_machine/paper_fortune_fsm.dm
@@ -71,4 +71,5 @@
 
 /datum/state_machine/paper_fortune
 	current_state = /decl/state/paper_fortune/closed
-
+	expected_type = /obj/item/paper_fortune_teller
+	base_type = /datum/state_machine/paper_fortune

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -22,13 +22,6 @@ var/global/list/nuke_disks = list()
 	var/nuke_off_station = 0 //Used for tracking if the syndies actually haul the nuke to the station
 	var/syndies_didnt_escape = 0 //Used for tracking if the syndies got the shuttle off of the z-level
 
-//checks if L has a nuke disk on their person
-/decl/game_mode/nuclear/proc/check_mob(mob/living/L)
-	for(var/obj/item/disk/nuclear/N in nuke_disks)
-		if(N.storage_depth(L) >= 0)
-			return TRUE
-	return FALSE
-
 /decl/game_mode/nuclear/declare_completion()
 	var/decl/special_role/merc = GET_DECL(/decl/special_role/mercenary)
 	if(get_config_value(/decl/config/enum/objectives_disabled) == CONFIG_OBJECTIVE_NONE || (merc && !merc.global_objectives.len))

--- a/code/game/gamemodes/objectives/objective_capture.dm
+++ b/code/game/gamemodes/objectives/objective_capture.dm
@@ -1,4 +1,0 @@
-/datum/objective/capture/proc/gen_amount_goal()
-	target_amount = rand(5,10)
-	explanation_text = "Accumulate [target_amount] capture points."
-	return target_amount

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -43,6 +43,10 @@ var/global/list/machine_path_to_circuit_type
 	for(var/component_path in uncreated_component_parts)
 		var/number = uncreated_component_parts[component_path] || 1
 		LAZYREMOVE(uncreated_component_parts, component_path)
+		// Stacks are created differently to avoid qdel churn.
+		if(ispath(component_path, /obj/item/stack))
+			install_component(new component_path(src, number), refresh_parts = FALSE)
+			continue
 		for(var/i in 1 to number)
 			install_component(component_path, refresh_parts = FALSE)
 

--- a/code/game/machinery/turrets/turret_fsm.dm
+++ b/code/game/machinery/turrets/turret_fsm.dm
@@ -1,6 +1,7 @@
 /datum/state_machine/turret
 	current_state = /decl/state/turret/idle
 	expected_type = /obj/machinery/turret
+	base_type = /datum/state_machine/turret
 
 /decl/state/turret
 	var/ray_color = "#ffffffff" // Turrets have a visual indicator of their current state.

--- a/code/game/objects/items/stacks/medical/_medical.dm
+++ b/code/game/objects/items/stacks/medical/_medical.dm
@@ -59,7 +59,7 @@
 		return TRUE
 
 	// If they have organs, we try to treat a specific organ being targeted.
-	if(length(target.get_organs()))
+	if(target.has_organs())
 
 		var/obj/item/organ/external/affecting = GET_EXTERNAL_ORGAN(target, user.get_target_zone())
 		if(!affecting)

--- a/code/modules/modular_computers/computers/subtypes/dev_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_pda.dm
@@ -1,5 +1,6 @@
 /obj/item/modular_computer/pda
 	name = "\improper PDA"
+	base_name = "\improper PDA"
 	desc = "A very compact computer, designed to keep its user always connected."
 	icon = 'icons/obj/modular_computers/pda/pda.dmi'
 	screen_icon = 'icons/obj/modular_computers/pda/screens.dmi'
@@ -21,12 +22,27 @@
 	computer_type = /datum/extension/assembly/modular_computer/pda
 	color = COLOR_GRAY80
 	dark_screen_state = "blank_screen"
+	var/owner_name = null
+	var/label_assignment = null
 
 /obj/item/modular_computer/pda/on_update_icon()
 	. = ..()
 	var/mob/living/human/H = loc
 	if(istype(H) && H.get_equipped_item(slot_wear_id_str) == src)
 		H.update_equipment_overlay(slot_wear_id_str)
+
+/obj/item/modular_computer/pda/update_name()
+	if(owner_name || label_assignment)
+		var/used_name = owner_name || "Unknown"
+		var/used_assignment = label_assignment || "Unknown"
+		SetName("[base_name] - [used_name] ([used_assignment])")
+	else
+		SetName(base_name)
+
+/obj/item/modular_computer/pda/proc/set_owner_rank_job(_owner_name, _label_assignment)
+	owner_name = _owner_name
+	label_assignment = _label_assignment
+	update_name()
 
 // PDA box
 /obj/item/box/PDAs

--- a/code/modules/modular_computers/file_system/programs/generic/supply.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/supply.dm
@@ -368,7 +368,7 @@
 		return "No Connection"
 
 	if(shuttle.has_arrive_time())
-		return "In transit ([shuttle.eta_seconds()] s)"
+		return "In transit ([shuttle.eta_readable()])"
 
 	if (shuttle.can_launch())
 		return "Docked"

--- a/code/modules/modular_computers/networking/device_types/broadcaster.dm
+++ b/code/modules/modular_computers/networking/device_types/broadcaster.dm
@@ -2,11 +2,13 @@
 	expected_type = /obj/machinery
 	receiver_type = RECEIVER_BROADCASTER
 	var/allow_wifi = TRUE
+	var/tmp/cached_rating = null
 
 /datum/extension/network_device/broadcaster/proc/get_broadcast_strength()
 	var/obj/machinery/M = holder
 	if(!istype(M) || !M.operable())
 		return 0
-		
-	var/rating = clamp(M.total_component_rating_of_type(/obj/item/stock_parts/micro_laser), 1, 3)
-	return NETWORK_BASE_BROADCAST_STRENGTH * rating
+
+	if(isnull(cached_rating))
+		cached_rating = NETWORK_BASE_BROADCAST_STRENGTH * clamp(M.total_component_rating_of_type(/obj/item/stock_parts/micro_laser), 1, 3)
+	return cached_rating

--- a/code/modules/modular_computers/networking/machinery/relay.dm
+++ b/code/modules/modular_computers/networking/machinery/relay.dm
@@ -10,6 +10,11 @@
 	base_type = /obj/machinery/network/relay
 	produces_heat = FALSE // for convenience
 
+/obj/machinery/network/relay/RefreshParts()
+	. = ..()
+	var/datum/extension/network_device/broadcaster/relay/R = get_extension(src, /datum/extension/network_device)
+	R.cached_rating = null // regenerate cached value
+
 /obj/machinery/network/relay/ui_data(mob/user, ui_key)
 	var/data = ..()
 	var/datum/extension/network_device/broadcaster/relay/R = get_extension(src, /datum/extension/network_device)

--- a/code/modules/modular_computers/networking/machinery/router.dm
+++ b/code/modules/modular_computers/networking/machinery/router.dm
@@ -14,6 +14,11 @@
 		initial_network_id = "network[random_id(type, 100, 999)]"
 	. = ..()
 
+/obj/machinery/network/router/RefreshParts()
+	. = ..()
+	var/datum/extension/network_device/broadcaster/router/R = get_extension(src, /datum/extension/network_device)
+	R.cached_rating = null // regenerate cached value
+
 /obj/machinery/network/router/ui_data(mob/user, ui_key)
 	var/data = ..()
 	var/datum/extension/network_device/broadcaster/router/R = get_extension(src, /datum/extension/network_device)
@@ -31,7 +36,7 @@
 		if(R)
 			R.allow_wifi = !R.allow_wifi
 			return TOPIC_REFRESH
-	
+
 	. = ..()
 
 /obj/machinery/network/router/update_network_status()

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -247,7 +247,6 @@
 	desc = "Put in water to get space cleaner. Do not eat. Really."
 	icon_state = "pod21"
 	autolabel = FALSE
-	var/smell_clean_time = 10 MINUTES
 
 // Don't overwrite the custom name.
 /obj/item/chems/pill/detergent/update_container_name()

--- a/code/modules/recycling/destination_tagger.dm
+++ b/code/modules/recycling/destination_tagger.dm
@@ -33,6 +33,7 @@
 	dat += "</div>"
 
 	dat += "<h4>Tag History:</h4>"
+	dat += "<a href='byond://?src=\ref[src];clear_previous_tags=1'>Clear History</a>"
 	dat += "<table style='width:100%; padding:4px;'><tr>"
 	var/cnt = 1
 	for(var/prevdest in last_used_tags)
@@ -69,6 +70,10 @@
 			. = TOPIC_REFRESH
 		else
 			. = TOPIC_HANDLED
+	else if(href_list["clear_previous_tags"])
+		clear_previous_tags()
+		to_chat(user, SPAN_NOTICE("You clear \the [src]'s tag history."))
+		. = TOPIC_REFRESH
 
 	if(. == TOPIC_REFRESH)
 		interact(user)

--- a/code/modules/shuttles/shuttle_supply.dm
+++ b/code/modules/shuttles/shuttle_supply.dm
@@ -64,15 +64,6 @@
 /datum/shuttle/autodock/ferry/supply/proc/at_station()
 	return (!location)
 
-//returns 1 if the shuttle is idle and we can still mess with the cargo shopping list
-/datum/shuttle/autodock/ferry/supply/proc/idle()
-	return (moving_status == SHUTTLE_IDLE)
-
-//returns the ETA in minutes
-/datum/shuttle/autodock/ferry/supply/proc/eta_minutes()
-	var/ticksleft = arrive_time - world.time
-	return max(0, round(ticksleft/600,1))
-
-/datum/shuttle/autodock/ferry/supply/proc/eta_seconds()
-	var/ticksleft = arrive_time - world.time
-	return max(0, round(ticksleft/10,1))
+//returns the ETA as a natural language timestamp
+/datum/shuttle/autodock/ferry/supply/proc/eta_readable()
+	return ticks2readable(max(0, arrive_time - world.time))

--- a/code/modules/tools/components/head.dm
+++ b/code/modules/tools/components/head.dm
@@ -5,7 +5,6 @@ var/global/list/_tool_properties_cache = list()
 	name = "tool head"
 	icon                     = 'icons/obj/items/tool/components/tool_head.dmi'
 	abstract_type            = /obj/item/tool_component/head
-	var/requires_handle_type = /obj/item/tool_component/handle/short
 
 	var/tool_type
 	var/list/tool_qualities

--- a/code/modules/weather/weather_fsm.dm
+++ b/code/modules/weather/weather_fsm.dm
@@ -1,5 +1,6 @@
 /datum/state_machine/weather
 	expected_type = /obj/abstract/weather_system
+	base_type = /datum/state_machine/weather
 
 /datum/state_machine/weather/choose_transition(list/valid_transitions)
 	var/list/transitions = list()

--- a/mods/gamemodes/cult/talisman.dm
+++ b/mods/gamemodes/cult/talisman.dm
@@ -1,6 +1,5 @@
 /obj/item/paper/talisman
 	info = "<center><img src='talisman.png'></center><br/><br/>"
-	var/imbue = null
 
 /obj/item/paper/talisman/update_contents_overlays()
 	var/talisman_state = "[icon_state]-talisman"

--- a/nebula.dme
+++ b/nebula.dme
@@ -781,7 +781,6 @@
 #include "code\game\gamemodes\objectives\_objective.dm"
 #include "code\game\gamemodes\objectives\objective_assassinate.dm"
 #include "code\game\gamemodes\objectives\objective_brig.dm"
-#include "code\game\gamemodes\objectives\objective_capture.dm"
 #include "code\game\gamemodes\objectives\objective_debrain.dm"
 #include "code\game\gamemodes\objectives\objective_demote.dm"
 #include "code\game\gamemodes\objectives\objective_download.dm"


### PR DESCRIPTION
## Description of changes
Removes a bunch of unused variables and procs, implements/uses some other ones.

In terms of new features:
- Re-adds the name/job labels to PDAs. At some point I might make this use the labels extension, right now I can't be assed.
- Some optimizations I forgot to nab before

Also includes a few optimizations I forgot to pull in :(

## Why and what will this PR improve
code quality, restoring a feature that got clobbered in the move from device->modcomp PDAs, some missing optimizations oops

## Authorship
Me

## Changelog
:cl:
add: Readds name and job labels to PDAs obtained via job equipment
/:cl: