### PR TITLE
Fix everyone starting off with $0

### DIFF
--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -145,7 +145,8 @@
 	. *= background_mod
 	// Apply other mods.
 	. *= global.using_map.salary_modifier
-	. *= 1 + 2 * H.get_skill_value(SKILL_FINANCE)/(SKILL_MAX - SKILL_MIN)
+	// Apply a 50% bonus per skill level above minimum.
+	. *= 1 + 2 * (H.get_skill_value(SKILL_FINANCE) - SKILL_MIN)/(SKILL_MAX - SKILL_MIN)
 	. = round(.)
 
 /datum/job/proc/setup_account(var/mob/living/human/H)

--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -136,8 +136,8 @@
 	var/background_mod =   0
 	var/background_count = 0
 	for(var/token in H.background_info)
-		var/decl/background_detail/background = GET_DECL(H.background_info[token])
-		if(istype(background) && !isnull(background.economic_power))
+		var/decl/background_detail/background = H.get_background_datum(token)
+		if(!isnull(background?.economic_power))
 			background_count++
 			background_mod += background.economic_power
 	if(background_count)


### PR DESCRIPTION
## Description of changes
`human.background_info` is an associative list of background category tokens to background detail instances. `prefs.background_info` is an associative list of background category tokens to background detail *types.* `GET_DECL()` should only be used in the latter case. I used `human.get_background_datum(token)` just for thoroughness.

Also reworks the finance skill bonus so that it doesn't apply at unskilled. This means everyone gets a slight reduction in starting pay across the board. Sorry!!

oh and I changed the variable names in the related procs because `M` for `/datum/money_account` instead of `/mob` was tripping me up.

## Why and what will this PR improve
Characters start with money again.

## Authorship
me