### PR TITLE
Fix issues with wells and fountains

### DIFF
--- a/code/game/objects/structures/fountain.dm
+++ b/code/game/objects/structures/fountain.dm
@@ -92,10 +92,10 @@
 	material               = /decl/material/solid/stone/marble
 	used                   = TRUE
 	material_alteration    = MAT_FLAG_ALTERATION_ALL
+	atom_flags             = ATOM_FLAG_OPEN_CONTAINER | ATOM_FLAG_CLIMBABLE
 
 /obj/structure/fountain/mundane/Initialize(ml, _mat, _reinf_mat)
 	. = ..()
-	atom_flags |= ATOM_FLAG_OPEN_CONTAINER | ATOM_FLAG_CLIMBABLE
 	initialize_reagents(ml)
 
 /obj/structure/fountain/mundane/initialize_reagents(populate = TRUE)

--- a/code/game/objects/structures/well.dm
+++ b/code/game/objects/structures/well.dm
@@ -47,15 +47,15 @@
 		W.fluid_act(reagents)
 		return TRUE
 
-/obj/structure/reagent_dispensers/well/mapped
-	auto_refill = /decl/material/liquid/water
-
-/obj/structure/reagent_dispensers/well/mapped/Process()
+/obj/structure/reagent_dispensers/well/Process()
 	if(!reagents || (reagents.total_volume >= reagents.maximum_volume) || !auto_refill)
 		return PROCESS_KILL
 	reagents.add_reagent(auto_refill, rand(5, 10))
 	if(reagents.total_volume >= reagents.maximum_volume)
 		return PROCESS_KILL
+
+/obj/structure/reagent_dispensers/well/mapped
+	auto_refill = /decl/material/liquid/water
 
 /obj/structure/reagent_dispensers/well/wall_fountain
 	name            = "wall fountain"

--- a/code/game/objects/structures/well.dm
+++ b/code/game/objects/structures/well.dm
@@ -6,7 +6,7 @@
 	opacity                   = FALSE
 	anchored                  = TRUE
 	density                   = TRUE
-	atom_flags                = ATOM_FLAG_CLIMBABLE
+	atom_flags                = ATOM_FLAG_CLIMBABLE | ATOM_FLAG_OPEN_CONTAINER
 	matter                    = null
 	material                  = /decl/material/solid/stone/granite
 	color                     = /decl/material/solid/stone/granite::color


### PR DESCRIPTION
## Description of changes
Wells and wall fountains are now open containers.
`auto_refill` processing on wells was moved to the base type from the `/mapped` subtype.
Autofill wells and wall fountains now drain contaminants.
`remove_any_reagent()` and `reagents.remove_any()` can now skip a reagent. This uses a new 'infinite sink' subtype of reagent holder that never actually gets anything added to it, meaning any reagent transferred to it is effectively deleted. yayyy

## Why and what will this PR improve
You can drink out of and wash your hands in wells/wall fountains.
Wall fountains now properly refill with water.

## Authorship
me