### PR TITLE
Adding istype guard to sprite accessory metadata load.

### DIFF
--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -51,7 +51,6 @@
 							deserialized_metadata[meta.type] = loaded_metadata[metadata_uid]
 				pref.sprite_accessories[accessory_category.type][loaded_accessory.type] = deserialized_metadata
 
-
 	// Grandfather in pre-existing hair and markings.
 	var/decl/style_decl
 	var/decl/sprite_accessory_category/accessory_cat
@@ -149,9 +148,12 @@
 				var/acc_data = pref.sprite_accessories[acc_cat][acc]
 				for(var/metadata_type in acc_data)
 					var/decl/sprite_accessory_metadata/metadata = GET_DECL(metadata_type)
-					var/value = acc_data[metadata_type]
-					if(!metadata.validate_data(value))
-						acc_data[metadata_type] = metadata.default_value
+					if(istype(metadata))
+						var/value = acc_data[metadata_type]
+						if(!metadata.validate_data(value))
+							acc_data[metadata_type] = metadata.default_value
+					else
+						acc_data -= metadata_type
 
 	for(var/accessory_category in mob_species.available_accessory_categories)
 


### PR DESCRIPTION
This is only an issue due to Pyrelight having a volatile branch that included a save structure that changed by the time the PR was actually merged. Still, better safe than sorry.