### PR TITLE
Fix missing punctuation in player-visible non-admin messages

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -44,7 +44,7 @@
 		if(is_component_functioning("camera"))
 			silicon_camera.captureimage(A, usr)
 		else
-			to_chat(src, "<span class='userdanger'>Your camera isn't functional.</span>")
+			to_chat(src, "<span class='danger'>Your camera isn't functional.</span>")
 		return
 
 	/*

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -96,11 +96,11 @@ var/global/obj/screen/robot_inventory
 			R.active_storage.close(R) //Closes the inventory ui.
 
 		if(!R.module)
-			to_chat(usr, "<span class='danger'>No module selected</span>")
+			to_chat(usr, SPAN_WARNING("No module selected."))
 			return
 
 		if(!R.module.equipment)
-			to_chat(usr, "<span class='danger'>Selected module has no modules to select</span>")
+			to_chat(usr, SPAN_WARNING("Selected module has no equipment available."))
 			return
 
 		if(!R.robot_modules_background)

--- a/code/game/gamemodes/godmode/form_items/starlight_structures.dm
+++ b/code/game/gamemodes/godmode/form_items/starlight_structures.dm
@@ -185,7 +185,7 @@
 		if(activate_charging())
 			to_chat(L, "<span class='notice'>You place your hands on \the [src], feeling your master's power course through you.</span>")
 		else
-			to_chat(L, "<span class='warning'>\The [src] is already activated</span>")
+			to_chat(L, SPAN_WARNING("\The [src] has already been activated."))
 	else
 		to_chat(L, "<span class='warning'>\The [src] does not recognize you as a herald of \the [linked_god]. You must wear a full set of herald's armor.</span>")
 	return TRUE

--- a/code/game/gamemodes/godmode/god_pylon.dm
+++ b/code/game/gamemodes/godmode/god_pylon.dm
@@ -72,4 +72,4 @@
 		for(var/minion in linked_god.minions)
 			var/datum/mind/mind = minion
 			if(mind.current && mind.current.eyeobj) //If it is currently having a vision of some sort
-				to_chat(mind.current,"[html_icon(src)] <span class='game say'><span class='name'>[M]</span> (<A href='?src=\ref[src];vision_jump=\ref[src];'>J</A>) [verb], <span class='message'<span class='body'>\"[text]\"</span></span>")
+				to_chat(mind.current,"[html_icon(src)] <span class='game say'><span class='name'>[M]</span> (<A href='byond://?src=\ref[src];vision_jump=\ref[src];'>J</A>) [verb], <span class='message'><span class='body'>\"[text]\"</span></span></span>")

--- a/code/game/machinery/_machines_base/stock_parts/card_reader.dm
+++ b/code/game/machinery/_machines_base/stock_parts/card_reader.dm
@@ -48,7 +48,7 @@
 /obj/item/stock_parts/item_holder/card_reader/attackby(obj/item/W, mob/user)
 	if(IS_SCREWDRIVER(W) && !istype(loc, /obj/machinery)) //Only if not in the machine, to prevent hijacking tool interactions with the machine
 		should_swipe = !should_swipe
-		to_chat(user, SPAN_NOTICE("You toggle \the [src] into [should_swipe? "swipe" : "insert"] card mode"))
+		to_chat(user, SPAN_NOTICE("You toggle \the [src] into [should_swipe? "swipe" : "insert"] card mode."))
 		return TRUE
 	. = ..()
 

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -43,20 +43,20 @@
 
 	camera_loc = sanitize(camera_loc)
 	if(!camera_loc)
-		to_chat(src, "<span class='warning'>Must supply a location name</span>")
+		to_chat(src, SPAN_WARNING("Must supply a location name."))
 		return
 
 	if(stored_locations.len >= max_locations)
-		to_chat(src, "<span class='warning'>Cannot store additional locations. Remove one first</span>")
+		to_chat(src, SPAN_WARNING("Cannot store additional locations, remove one first."))
 		return
 
 	if(camera_loc in stored_locations)
-		to_chat(src, "<span class='warning'>There is already a stored location by this name</span>")
+		to_chat(src, SPAN_WARNING("There is already a stored location by that name."))
 		return
 
 	var/L = src.eyeobj.getLoc()
 	if (InvalidPlayerTurf(get_turf(L)))
-		to_chat(src, "<span class='warning'>Unable to store this location</span>")
+		to_chat(src, SPAN_WARNING("Unable to store this location."))
 		return
 
 	stored_locations[camera_loc] = L
@@ -71,7 +71,7 @@
 	set desc = "Returns to the selected camera location"
 
 	if (!(loc in stored_locations))
-		to_chat(src, "<span class='warning'>Location [loc] not found</span>")
+		to_chat(src, SPAN_WARNING("Location [loc] not found."))
 		return
 
 	var/L = stored_locations[loc]
@@ -83,7 +83,7 @@
 	set desc = "Deletes the selected camera location"
 
 	if (!(loc in stored_locations))
-		to_chat(src, "<span class='warning'>Location [loc] not found</span>")
+		to_chat(src, SPAN_WARNING("Location [loc] not found."))
 		return
 
 	stored_locations.Remove(loc)
@@ -240,14 +240,14 @@
 /mob/living/silicon/robot/tracking_initiated()
 	tracking_entities++
 	if(tracking_entities == 1 && has_zeroth_law())
-		to_chat(src, "<span class='warning'>Internal camera is currently being accessed.</span>")
+		to_chat(src, SPAN_WARNING("Internal camera is currently being accessed."))
 
 /mob/living/proc/tracking_cancelled()
 
 /mob/living/silicon/robot/tracking_cancelled()
 	tracking_entities--
 	if(!tracking_entities && has_zeroth_law())
-		to_chat(src, "<span class='notice'>Internal camera is no longer being accessed.</span>")
+		to_chat(src, SPAN_NOTICE("Internal camera is no longer being accessed."))
 
 
 #undef TRACKING_POSSIBLE

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -60,7 +60,7 @@
 			return
 
 		anchored = !anchored
-		to_chat(user, "You [anchored ? "attach" : "detach"] the cell charger [anchored ? "to" : "from"] the ground")
+		to_chat(user, "You [anchored ? "attach" : "detach"] \the [src] [anchored ? "to" : "from"] the ground.")
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
 		return
 

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -56,7 +56,7 @@
 
 /obj/machinery/gibber/examine(mob/user)
 	. = ..()
-	to_chat(user, "The safety guard is [emagged ? "<span class='danger'>disabled</span>" : "enabled"].")
+	to_chat(user, "The safety guard is [emagged ? SPAN_DANGER("disabled") : "enabled"].")
 
 /obj/machinery/gibber/emag_act(var/remaining_charges, var/mob/user)
 	emagged = !emagged

--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -142,8 +142,8 @@ Using robohead because of restricting to roboticist */
 					..()
 					return
 				buildstep++
-				to_chat(user, "<span class='notice'>You wire the assembly</span>")
-				desc = "This TV camera assembly has wires sticking out"
+				to_chat(user, SPAN_NOTICE("You wire the assembly."))
+				desc = "This TV camera assembly has wires sticking out."
 				return
 		if(3)
 			if(IS_WIRECUTTER(W))

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -73,7 +73,7 @@
 	if(IS_SCREWDRIVER(W))
 		crafting = !crafting
 		if(!crafting)
-			to_chat(user, "<span class='notice'>You reassemble the RCD</span>")
+			to_chat(user, SPAN_NOTICE("You reassemble the RCD."))
 		else
 			to_chat(user, "<span class='notice'>The RCD can now be modified.</span>")
 		src.add_fingerprint(user)

--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -173,7 +173,7 @@ var/global/list/rpd_pipe_selection_skilled = list()
 
 /obj/item/rpd/proc/recycle(var/obj/item/W,var/mob/user)
 	if(!user.skill_check(SKILL_ATMOS,SKILL_BASIC))
-		user.visible_message("[user] struggles with \the [src], as they futilely jam \the [W] against it")
+		user.visible_message("<b>\The [user]</b> struggles with \the [src] as they futilely jam \the [W] against it.")
 		return
 	playsound(src.loc, 'sound/effects/pop.ogg', 50, 1)
 	qdel(W)

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -15,7 +15,7 @@
 	var/power_usage = 450 //value for simple ecig, enough for about 1 cartridge, in JOULES!
 	var/ecig_colors = list(null, COLOR_DARK_GRAY, COLOR_RED_GRAY, COLOR_BLUE_GRAY, COLOR_GREEN_GRAY, COLOR_PURPLE_GRAY)
 	var/idle = 0
-	var/idle_treshold = 30
+	var/idle_threshold = 30
 
 /obj/item/clothing/mask/smokable/ecig/Initialize()
 	setup_power_supply()
@@ -87,7 +87,7 @@
 		Deactivate()
 		return
 
-	if(idle >= idle_treshold) //idle too long -> automatic shut down
+	if(idle >= idle_threshold) //idle too long -> automatic shut down
 		idle = 0
 		visible_message(SPAN_NOTICE("\The [src] powers down automatically."), null, 2)
 		Deactivate()

--- a/code/game/objects/structures/__structure.dm
+++ b/code/game/objects/structures/__structure.dm
@@ -69,7 +69,7 @@
 			if(tool_interaction_flags & TOOL_INTERACTION_ANCHOR)
 				if(wired)
 					if(anchored)
-						to_chat(user, SPAN_SUBTLE("Can have its wiring removed with wirecutters"))
+						to_chat(user, SPAN_SUBTLE("Can have its wiring removed with wirecutters."))
 					else
 						to_chat(user, SPAN_SUBTLE("Can have its wiring removed with wirecutters, if anchored down with a wrench first."))
 				else
@@ -79,7 +79,7 @@
 						to_chat(user, SPAN_SUBTLE("Can have wiring installed with a cable coil, if anchored down with a wrench first."))
 			else
 				if(wired)
-					to_chat(user, SPAN_SUBTLE("Can have its wiring removed with wirecutters"))
+					to_chat(user, SPAN_SUBTLE("Can have its wiring removed with wirecutters."))
 				else
 					to_chat(user, SPAN_SUBTLE("Can have wiring installed with a cable coil."))
 

--- a/code/game/objects/structures/pit.dm
+++ b/code/game/objects/structures/pit.dm
@@ -26,9 +26,9 @@
 			to_chat(user, SPAN_WARNING("There's already a grave marker here."))
 		else
 			var/obj/item/stack/material/plank = W
-			visible_message(SPAN_WARNING("\The [user] starts making a grave marker on top of \the [src]"))
+			visible_message(SPAN_WARNING("\The [user] starts making a grave marker on top of \the [src]."))
 			if(do_after(user, 5 SECONDS) && plank.use(1))
-				visible_message(SPAN_NOTICE("\The [user] finishes the grave marker"))
+				visible_message(SPAN_NOTICE("\The [user] finishes the grave marker."))
 				new /obj/structure/gravemarker(src.loc)
 			else
 				to_chat(user, SPAN_NOTICE("You stop making a grave marker."))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -559,9 +559,9 @@
 				return
 			var/reason = sanitize(input("Please enter reason"))
 			if(!reason)
-				to_chat(M, "<span class='warning'>You have been kicked from the server</span>")
+				to_chat(M, SPAN_WARNING("You have been kicked from the server."))
 			else
-				to_chat(M, "<span class='warning'>You have been kicked from the server: [reason]</span>")
+				to_chat(M, SPAN_WARNING("You have been kicked from the server: [reason]"))
 			log_and_message_admins("booted [key_name_admin(M)].")
 			//M.client = null
 			qdel(M.client)

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -177,7 +177,7 @@
 
 	// Handled on Bot32's end, unsure about other bots
 //	if(length(msg) > 400) // TODO: if message length is over 400, divide it up into seperate messages, the message length restriction is based on IRC limitations.  Probably easier to do this on the bots ends.
-//		to_chat(src, "<span class='warning'>Your message was not sent because it was more then 400 characters find your message below for ease of copy/pasting</span>")
+//		to_chat(src, "<span class='warning'>Your message was not sent because it was more then 400 characters, find your message below for ease of copy/pasting.</span>")
 //		to_chat(src, "<span class='notice'>[msg]</span>")
 //		return
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -498,7 +498,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		else
 			M.add_ion_law(input)
 			for(var/mob/living/silicon/ai/O in SSmobs.mob_list)
-				to_chat(O, "<span class='warning'>" + input + "...LAWS UPDATED</span>")
+				to_chat(O, SPAN_WARNING("[input]... LAWS UPDATED."))
 				O.show_laws()
 
 	log_admin("Admin [key_name(usr)] has added a new AI law - [input]")

--- a/code/modules/augment/passive/nanoaura.dm
+++ b/code/modules/augment/passive/nanoaura.dm
@@ -40,7 +40,7 @@
 	for(var/obj/item/organ/external/E in owner.get_external_organs())
 		if(prob(25))
 			E.status |= ORGAN_BRITTLE //Some nanites are not responding and you're out of luck
-			to_chat(owner,SPAN_DANGER("Your [E.name] feels cold and rigid"))
+			to_chat(owner, SPAN_DANGER("Your [E.name] feels cold and rigid."))
 	QDEL_NULL(aura)
 
 /obj/item/organ/internal/augment/active/nanounit/activate()
@@ -73,7 +73,7 @@
 		playsound(user,'sound/effects/basscannon.ogg',35,1)
 		unit.charges -= 1
 		if(unit.charges <= 0)
-			to_chat(user, SPAN_DANGER("Warning: Critical damage treshold passed. Shut down unit to avoid further damage"))
+			to_chat(user, SPAN_DANGER("Warning: Critical damage threshold passed. Shut down unit to avoid further damage."))
 		return AURA_FALSE|AURA_CANCEL
 	else unit.catastrophic_failure()
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -66,11 +66,11 @@ var/global/list/localhost_addresses = list(
 		return
 
 	if(href_list["irc_msg"])
-		if(!holder && received_irc_pm < world.time - 6000) //Worse they can do is spam IRC for 10 minutes
-			to_chat(usr, "<span class='warning'>You are no longer able to use this, it's been more then 10 minutes since an admin on IRC has responded to you</span>")
+		if(!holder && received_irc_pm < world.time - 6000) //Worst they can do is spam IRC for 10 minutes
+			to_chat(usr, SPAN_WARNING("You are no longer able to use this, it's been more then 10 minutes since an admin on IRC has responded to you."))
 			return
 		if(mute_irc)
-			to_chat(usr, "<span class='warning'You cannot use this as your client has been muted from sending messages to the admins on IRC</span>")
+			to_chat(usr, SPAN_WARNING("You cannot use this as your client has been muted from sending messages to the admins on IRC."))
 			return
 		cmd_admin_irc_pm(href_list["irc_msg"])
 		return

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -91,7 +91,7 @@
 
 	if(difference > 0)
 		for(var/mob/pilot in owner.pilots)
-			to_chat(pilot, SPAN_DANGER("Warning: Deflector shield failure detect, shutting down"))
+			to_chat(pilot, SPAN_DANGER("Warning: Deflector shield failure detect, shutting down!"))
 		toggle()
 		playsound(owner.loc,'sound/mecha/internaldmgalarm.ogg',35,1)
 		return difference

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -85,7 +85,7 @@ default behaviour is:
 			for(var/mob/living/M in range(tmob, 1))
 				if(LAZYLEN(tmob.pinned) || (locate(/obj/item/grab, LAZYLEN(tmob.grabbed_by))))
 					if ( !(world.time % 5) )
-						to_chat(src, "<span class='warning'>[tmob] is restrained, you cannot push past</span>")
+						to_chat(src, SPAN_WARNING("[tmob] is restrained, you cannot push past."))
 					now_pushing = 0
 					return
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -657,7 +657,7 @@ var/global/list/custom_ai_icons_by_ckey_and_name = list()
 	set category = "Silicon Commands"
 
 	multitool_mode = !multitool_mode
-	to_chat(src, "<span class='notice'>Multitool mode: [multitool_mode ? "E" : "Dise"]ngaged</span>")
+	to_chat(src, SPAN_NOTICE("Multitool mode: [multitool_mode ? "E" : "Dise"]ngaged"))
 
 /mob/living/silicon/ai/on_update_icon()
 	..()

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -221,7 +221,7 @@
 	if(!(locate(O) in module.equipment) && O != src.module.emag)
 		return
 	if(activated(O))
-		to_chat(src, "<span class='notice'>Already activated</span>")
+		to_chat(src, SPAN_NOTICE("\The [O] is already active."))
 		return
 	if(!module_state_1)
 		module_state_1 = O
@@ -245,7 +245,7 @@
 		if(istype(module_state_3,/obj/item/borg/sight))
 			sight_mode |= module_state_3:sight_mode
 	else
-		to_chat(src, "<span class='notice'>You need to disable a module first!</span>")
+		to_chat(src, SPAN_NOTICE("You need to disable a module first!"))
 
 /mob/living/silicon/robot/put_in_hands(var/obj/item/W) // No hands.
 	W.forceMove(get_turf(src))

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -257,8 +257,7 @@
 	if(killswitch)
 		killswitch_time --
 		if(killswitch_time <= 0)
-			if(src.client)
-				to_chat(src, "<span class='danger'>Killswitch Activated</span>")
+			to_chat(src, SPAN_DANGER("Killswitch activated."))
 			killswitch = 0
 			spawn(5)
 				gib()
@@ -268,8 +267,7 @@
 		uneq_all()
 		weaponlock_time --
 		if(weaponlock_time <= 0)
-			if(src.client)
-				to_chat(src, "<span class='danger'>Weapon Lock Timed Out!</span>")
+			to_chat(src, SPAN_DANGER("Weapon lock timed out!"))
 			weapon_lock = 0
 			weaponlock_time = 120
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -403,7 +403,7 @@
 	if(!IS_CROWBAR(W) || user.a_intent == I_HURT)
 		return
 	if(!length(stock_parts))
-		to_chat(user, SPAN_WARNING("No parts left to remove"))
+		to_chat(user, SPAN_WARNING("There are no parts in \the [src] left to remove."))
 		return
 
 	var/obj/item/stock_parts/remove = input(user, "Which component do you want to pry out?", "Remove Component") as null|anything in stock_parts

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -139,7 +139,7 @@
 		if(prob(reflectchance))
 			adjustBruteLoss(P.damage * 0.5)
 			visible_message("<span class='danger'>The [P.name] gets reflected by [src]'s shell!</span>", \
-							"<span class='userdanger'>The [P.name] gets reflected by [src]'s shell!</span>")
+							"<span class='danger'>The [P.name] gets reflected by [src]'s shell!</span>")
 
 			// Find a turf near or on the original location to bounce to
 			if(P.starting)

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -209,7 +209,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return FALSE
 
 	if(QDELETED(mind?.current))
-		to_chat(src, SPAN_WARNING("You have no body"))
+		to_chat(src, SPAN_WARNING("You have no body."))
 		return FALSE
 
 	if(!(can_reenter_corpse & CORPSE_CAN_REENTER))

--- a/code/modules/modular_computers/file_system/programs/generic/records.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/records.dm
@@ -89,7 +89,7 @@
 				if(R.get_file_perms(get_access(usr), usr) & OS_READ_ACCESS)
 					active_record = R
 				else
-					to_chat(usr, SPAN_WARNING("Access Denied"))
+					to_chat(usr, SPAN_WARNING("Access denied."))
 				break
 		return 1
 	if(href_list["new_record"])

--- a/code/modules/modular_computers/networking/machinery/telecomms.dm
+++ b/code/modules/modular_computers/networking/machinery/telecomms.dm
@@ -358,7 +358,7 @@ var/global/list/telecomms_hubs = list()
 
 								var/list/all_groups = net_acl.get_all_groups()
 								if(!length(all_groups))
-									to_chat(user, SPAN_WARNING("No groups were found on the network access controller"))
+									to_chat(user, SPAN_WARNING("No groups were found on the network access controller."))
 									return TOPIC_HANDLED
 
 								choice = input(user, "Which group do you wish to add? Adding a parent group will allow all members of its children groups to access the channel.", "Channel Configuration") as null|anything in all_groups

--- a/code/modules/paperwork/silicon_photography.dm
+++ b/code/modules/paperwork/silicon_photography.dm
@@ -24,11 +24,11 @@
 /obj/item/camera/siliconcam/proc/injectmasteralbum(obj/item/photo/p) //stores image information to a list similar to that of the datacore
 	var/mob/living/silicon/robot/C = usr
 	if(C.connected_ai)
-		C.connected_ai.silicon_camera.injectaialbum(p.copy(1), " (synced from [C.name])")
-		to_chat(C.connected_ai, "<span class='unconscious'>Image uploaded by [C.name]</span>")
-		to_chat(usr, "<span class='unconscious'>Image synced to remote database, and can be printed from any photocopier.</span>")//feedback to the Cyborg player that the picture was taken
+		C.connected_ai.silicon_camera.injectaialbum(p.copy(1), " (synced from [C])")
+		to_chat(C.connected_ai, SPAN_NOTICE("Image uploaded by [C]."))
+		to_chat(usr, SPAN_NOTICE("Image synced to remote database, and can be printed from any photocopier."))//feedback to the Cyborg player that the picture was taken
 	else
-		to_chat(usr, "<span class='unconscious'>Image recorded, and can be printed from any photocopier.</span>")
+		to_chat(usr, SPAN_NOTICE("Image recorded, and can be printed from any photocopier."))
 	// Always save locally
 	injectaialbum(p)
 
@@ -39,7 +39,7 @@
 	var/list/nametemp = list()
 	var/find
 	if(cam.aipictures.len == 0)
-		to_chat(usr, "<span class='userdanger'>No images saved</span>")
+		to_chat(usr, SPAN_DANGER("No images saved."))
 		return
 	for(var/obj/item/photo/t in cam.aipictures)
 		nametemp += t.name
@@ -66,7 +66,7 @@
 		return
 
 	aipictures -= selection
-	to_chat(usr, "<span class='unconscious'>Local image deleted</span>")
+	to_chat(usr, SPAN_NOTICE("Local image deleted."))
 //Capture Proc for AI / Robot
 /mob/living/silicon/ai/can_capture_turf(turf/T)
 	var/mob/living/silicon/ai = src
@@ -86,7 +86,7 @@
 	to_chat(usr, "<B>Camera Mode activated</B>")
 /obj/item/camera/siliconcam/ai_camera/printpicture(mob/user, obj/item/photo/p)
 	injectaialbum(p)
-	to_chat(usr, "<span class='unconscious'>Image recorded</span>")
+	to_chat(usr, SPAN_NOTICE("Image recorded."))
 /obj/item/camera/siliconcam/robot_camera/printpicture(mob/user, obj/item/photo/p)
 	injectmasteralbum(p)
 

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -127,7 +127,7 @@ var/global/list/rad_collectors = list()
 				to_chat(user, "The controls are now [src.locked ? "locked." : "unlocked."]")
 			else
 				src.locked = 0 //just in case it somehow gets locked
-				to_chat(user, "<span class='warning'>The controls can only be locked when the [src] is active</span>")
+				to_chat(user, SPAN_WARNING("The controls can only be locked when \the [src] is active."))
 		else
 			to_chat(user, "<span class='warning'>Access denied!</span>")
 		return 1

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -548,7 +548,7 @@
 	admin_attacker_log(user, "is attempting to suicide with \a [src]")
 	M.visible_message("<span class='danger'>[user] sticks their gun in their mouth, ready to pull the trigger...</span>")
 	if(!do_after(user, 40, progress=0))
-		M.visible_message("<span class='notice'>[user] decided life was worth living</span>")
+		M.visible_message(SPAN_NOTICE("[user] decided life was worth living."))
 		mouthshoot = 0
 		return
 

--- a/code/modules/spells/hand/hand.dm
+++ b/code/modules/spells/hand/hand.dm
@@ -63,7 +63,7 @@
 /spell/hand/charges/cast_hand()
 	if(..())
 		casts--
-		to_chat(holder, "<span class='notice'>The [name] spell has [casts] out of [max_casts] charges left</span>")
+		to_chat(holder, SPAN_NOTICE("The [name] spell has [casts] out of [max_casts] charges left."))
 		cancel_hand()
 		return TRUE
 	return FALSE


### PR DESCRIPTION
## Description of changes
Fixes a broken `<span>` tag in deity pylon code.
Fixes a bunch of missing punctuation in player-visible messages that aren't triggered by admins. Also fixes a couple ones triggered by admins.
Fixes some nonexistent span classes (`userdanger` and `unconscious`)
Fixes a typo (`treshold` instead of `threshold`)

## Why and what will this PR improve
they were bugging me lol

## Authorship
me