### PR TITLE
Fixes pipeline GC error on burst

### DIFF
--- a/code/modules/atmospherics/datum_pipeline.dm
+++ b/code/modules/atmospherics/datum_pipeline.dm
@@ -32,8 +32,9 @@
 
 	if(air?.volume || liquid?.total_volume)
 		temporarily_store_fluids()
-		QDEL_NULL(air)
-		QDEL_NULL(liquid)
+
+	QDEL_NULL(air)
+	QDEL_NULL(liquid)
 
 	for(var/obj/machinery/atmospherics/pipe/P in members)
 		P.parent = null
@@ -51,17 +52,20 @@
 		for(var/obj/machinery/atmospherics/pipe/member in members)
 			if(!member.check_pressure(pressure))
 				members.Remove(member)
+
+				// Safety check.
+				if(member.parent == src)
+					member.parent = null
 				break //Only delete 1 pipe per process
 
 /datum/pipeline/proc/temporarily_store_fluids()
 	//Update individual gas_mixtures by volume ratio
 
 	var/liquid_transfer_per_pipe = min(REAGENT_UNITS_PER_PIPE, (liquid && length(members)) ? (liquid.total_volume / length(members)) : 0)
-	if(!liquid_transfer_per_pipe && !liquid_transfer_per_pipe)
+	if(!air?.volume && !liquid_transfer_per_pipe)
 		return
 
 	for(var/obj/machinery/atmospherics/pipe/member in members)
-
 		if(air?.volume)
 			member.air_temporary = new
 			member.air_temporary.copy_from(air)
@@ -69,7 +73,7 @@
 			member.air_temporary.multiply(member.volume / air.volume)
 
 		if(liquid_transfer_per_pipe)
-			member.liquid_temporary = new(REAGENT_UNITS_PER_PIPE, src)
+			member.liquid_temporary = new(REAGENT_UNITS_PER_PIPE, member)
 			liquid.trans_to_holder(member.liquid_temporary, liquid_transfer_per_pipe)
 
 /datum/pipeline/proc/build_pipeline(obj/machinery/atmospherics/pipe/base)

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -244,6 +244,7 @@
 		//TODO: leak to turf, doing pfshhhhh
 		if(prob(5))
 			burst()
+		else return 1
 
 	else return 1
 


### PR DESCRIPTION
## Description of changes
Fixes a few potential causes of pipelines failing to GC. The only one confirmed to cause an issue occurred in the ``check_pressure`` proc, which incorrectly returned 0 even when the pipe did not burst, causing it to be removed from pipeline ``line_members`` list, leading to a hanging reference on pipeline deletion.

Other changes are for GC safety for liquid pipelines (currently unimplemented).

## Why and what will this PR improve
GC error fix
## Authorship
Myself
## Changelog
Nothing player facing