### PR TITLE
ChemMaster pills do not discard their custom name.

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -17,8 +17,13 @@
 	var/autolabel = TRUE  		// if set, will add label with the name of the first initial reagent
 	var/static/list/colorizable_icon_states = list("pill1", "pill2", "pill3", "pill4", "pill5") // if using an icon state from here, color will be derived from reagents
 
+// Pill subtype that does not use a reagent name.
 /obj/item/chems/pill/dispensed
 	autolabel = FALSE
+/obj/item/chems/pill/dispensed/update_container_name()
+	return
+/obj/item/chems/pill/dispensed/update_container_desc()
+	return
 
 /obj/item/chems/pill/Initialize()
 	. = ..()


### PR DESCRIPTION
Fixes #4475 