### PR TITLE
Shaded Hills tweaks for September 24 2024

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -428,20 +428,20 @@
 		if(isliving(AM))
 			var/mob/living/M = AM
 			M.turf_collision(src, TT.speed)
-		addtimer(CALLBACK(src, TYPE_PROC_REF(/turf, bounce_off), AM, TT.init_dir), 2)
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/turf, bounce_off), AM, TT), 2)
 	else if(isobj(AM))
 		var/obj/structure/ladder/L = locate() in contents
 		if(L)
 			L.hitby(AM)
 
-/turf/proc/bounce_off(var/atom/movable/AM, var/direction)
+/turf/proc/bounce_off(var/atom/movable/AM, var/datum/thrownthing/thrown)
 	if(AM.anchored)
 		return
 	if(ismob(AM))
 		var/mob/living/M = AM
 		if(LAZYLEN(M.pinned))
 			return
-	step(AM, turn(direction, 180))
+	AM.throw_at(get_step(src, turn(thrown.init_dir, 180)), 1, thrown.speed / 2)
 
 /turf/proc/can_engrave()
 	return FALSE

--- a/code/game/turfs/walls/wall_natural.dm
+++ b/code/game/turfs/walls/wall_natural.dm
@@ -93,8 +93,8 @@
 
 /turf/wall/natural/update_strings()
 	if(reinf_material)
-		SetName("[reinf_material.solid_name] deposit")
-		desc = "A natural cliff face composed of bare [material.solid_name] and a deposit of [reinf_material.solid_name]."
+		SetName("[reinf_material.ore_name] deposit")
+		desc = "A natural cliff face composed of bare [material.solid_name] and a deposit of [reinf_material.ore_name]."
 	else
 		SetName("natural [material.solid_name] wall")
 		desc = "A natural cliff face composed of bare [material.solid_name]."

--- a/code/modules/crafting/stack_recipes/_recipe.dm
+++ b/code/modules/crafting/stack_recipes/_recipe.dm
@@ -53,7 +53,8 @@
 		/obj/item/stack/material/ingot,
 		/obj/item/stack/material/plank,
 		/obj/item/stack/material/bar,
-		/obj/item/stack/material/puck
+		/obj/item/stack/material/puck,
+		/obj/item/stack/material/brick
 	)
 	/// What stack types cannot be used to make this recipe?
 	var/list/forbidden_craft_stack_types = list(

--- a/code/modules/materials/definitions/solids/materials_solid_mineral.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_mineral.dm
@@ -85,8 +85,8 @@
 	color = "#ccc9a3"
 	reflectiveness = MAT_VALUE_SHINY
 	value = 0.8
-	sparse_material_weight = 3
-	rich_material_weight = 1
+	sparse_material_weight = 9
+	rich_material_weight = 3
 	dissolves_into = list(
 		/decl/material/solid/sulfur = 0.75,
 		/decl/material/solid/metal/iron = 0.25
@@ -102,8 +102,8 @@
 	ore_icon_overlay = "lump"
 	color = "#e5becb"
 	value = 0.8
-	sparse_material_weight = 3
-	rich_material_weight = 1
+	sparse_material_weight = 9
+	rich_material_weight = 3
 	dissolves_into = list(
 		/decl/material/solid/lithium = 1
 	)
@@ -118,8 +118,8 @@
 	ore_icon_overlay = "lump"
 	color = "#e54e4e"
 	value = 0.8
-	sparse_material_weight = 3
-	rich_material_weight = 1
+	sparse_material_weight = 9
+	rich_material_weight = 3
 	dissolves_into = list(
 		/decl/material/liquid/mercury = 1
 	)
@@ -137,8 +137,8 @@
 	)
 	color = "#832828"
 	value = 0.8
-	sparse_material_weight = 3
-	rich_material_weight = 1
+	sparse_material_weight = 9
+	rich_material_weight = 3
 	lore_text = "A chemical element, the backbone of biological energy carriers."
 	taste_description = "vinegar"
 
@@ -153,8 +153,8 @@
 	ore_icon_overlay = "lump"
 	color = "#d1c0bc"
 	value = 0.8
-	sparse_material_weight = 3
-	rich_material_weight = 1
+	sparse_material_weight = 12
+	rich_material_weight = 4
 	taste_description = "salt"
 	overdose = REAGENTS_OVERDOSE
 	dissolves_into = list(

--- a/code/modules/mob/living/living_throw.dm
+++ b/code/modules/mob/living/living_throw.dm
@@ -25,19 +25,32 @@
 		drop_from_inventory(grab)
 
 	// Hand items to a nearby target, or place them on the turf.
-	if(place_item && !QDELETED(item) && !QDELETED(target))
+	// Don't unequip early, keep it in our hands so we can give it!
+	else if(place_item && !QDELETED(item) && !QDELETED(target))
 		// We've already been unequipped above.
 		if(isliving(target))
 			var/mob/living/mob = target
 			if(length(mob.get_held_item_slots()))
-				if(mob.in_throw_mode && mob.a_intent == I_HELP)
+				if(mob == src || (mob.in_throw_mode && mob.a_intent == I_HELP))
 					if(!try_unequip(item, play_dropsound = place_item))
 						return FALSE
-					mob.put_in_hands(item) // If this fails it will just end up on the floor, but that's fitting for things like dionaea.
-					visible_message(
-						SPAN_NOTICE("<b>\The [src]</b> hands \the [mob] \a [item]."),
-						SPAN_NOTICE("You give \the [mob] \a [item].")
-					)
+					if(target != src)
+						mob.put_in_hands(item) // If this fails it will just end up on the floor, but that's fitting for things like dionaea.
+						visible_message(
+							"<b>\The [src]</b> hands \the [mob] \a [item].",
+							SPAN_NOTICE("You give \the [mob] \a [item].")
+						)
+					else
+						var/same_hand = a_intent == I_HELP
+						var/decl/pronouns/user_pronouns = get_pronouns()
+						visible_message(
+							"<b>\The [src]</b> tosses \the [item] [same_hand ? "in the air and catches it." : "between [user_pronouns.his] hands"].",
+							SPAN_NOTICE("You toss \the [item] [same_hand ? "in the air and catch it" : "between your hands"].")
+						)
+						if(same_hand)
+							put_in_active_hand(item)
+						else
+							put_in_inactive_hand(item)
 				else
 					to_chat(src, SPAN_NOTICE("You offer \the [item] to \the [mob]."))
 					do_give(mob)
@@ -52,6 +65,8 @@
 				item.forceMove(get_turf(target))
 
 		return TRUE
+	else if(!try_unequip(item))
+		return FALSE
 
 	if(!istype(item) || QDELETED(item) || !try_unequip(item, get_turf(target), play_dropsound = place_item) || !isturf(item.loc))
 		return FALSE

--- a/maps/shaded_hills/shaded_hills-inn.dmm
+++ b/maps/shaded_hills/shaded_hills-inn.dmm
@@ -1108,10 +1108,10 @@
 /area/shaded_hills/outside/downlands)
 "My" = (
 /obj/structure/table/woodentable_reinforced/ebony,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
 /obj/item/cash/imperial/regalis,
 /obj/item/cash/imperial/quin,
 /obj/item/cash/imperial/quin,


### PR DESCRIPTION
## Description of changes
- Bouncing off a turf now uses throw instead of step, meaning you can bounce an item off a wall and catch it. Nifty!
- Ore deposits now use ore_name instead of solid_name.
- Giving an item to yourself now has flavortext for tossing the item in or between your hand(s).
- Paper in the inn has been replaced with scrolls.
- Bricks are in the base recipe list, so you can actually craft a stone mortar now...
- Non-hematite/coal ores are more common now.

## Why and what will this PR improve
other ores aren't entirely impossible to find compared to hematite/coal. you can craft furniture and mortars and such out of bricks. the inn has parchment rather than modern paper. a neat flavortext thing for throwing an item to yourself. you can catch an item that bounces off a turf. ore deposits use the ore name.

## Authorship
me