### PR TITLE
Fix and tweak stamina costs and movement delays

### DIFF
--- a/code/datums/config/config_types/config_game_option.dm
+++ b/code/datums/config/config_types/config_game_option.dm
@@ -36,30 +36,31 @@
 
 /decl/config/num/movement_human
 	uid = "human_delay"
-	desc = "These modify the run/walk speed of all mobs before the mob-specific modifiers are applied."
+	desc = "A modifier applied to the run/walk delay of human-type mobs. A higher value will result in slower movement."
+	default_value = -1
 
 /decl/config/num/movement_robot
 	uid = "robot_delay"
-	desc = "These modify the run/walk speed of all mobs before the mob-specific modifiers are applied."
+	desc = "A modifier applied to the run/walk delay of robots (cyborgs and drones). A higher value will result in slower movement."
 
 /decl/config/num/movement_animal
 	uid = "animal_delay"
-	desc = "These modify the run/walk speed of all mobs before the mob-specific modifiers are applied."
+	desc = "A modifier applied to the run/walk delay of simple_animal type mobs (including combat drones and other simple hostile mobs). A higher value will result in slower movement."
 
 /decl/config/num/movement_run
 	uid = "run_delay"
 	default_value = 2
-	desc = "These modify the run/walk speed of all mobs before the mob-specific modifiers are applied."
+	desc = "A modifier applied to the run delay of all mobs, prior to the mob-specific modifiers being applied. A higher value will result in slower movement."
 
 /decl/config/num/movement_walk
 	uid = "walk_delay"
 	default_value = 4
-	desc = "These modify the run/walk speed of all mobs before the mob-specific modifiers are applied."
+	desc = "A modifier applied to the walk delay of all mobs, prior to the mob-specific modifiers being applied. A higher value will result in slower movement."
 
 /decl/config/num/movement_creep
 	uid = "creep_delay"
 	default_value = 6
-	desc = "These modify the run/walk speed of all mobs before the mob-specific modifiers are applied."
+	desc = "A modifier applied to the creep delay of all mobs, prior to the mob-specific modifiers being applied. A higher value will result in slower movement."
 
 /decl/config/num/movement_glide_size
 	uid = "glide_size_delay"

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -50,7 +50,7 @@
 	var/gas_transfer_coefficient = 1 // for leaking gas from turf to mask and vice-versa (for masks right now, but at some point, i'd like to include space helmets)
 	var/permeability_coefficient = 1 // for chemicals/diseases
 	var/siemens_coefficient = 1 // for electrical admittance/conductance (electrocution checks and shit)
-	var/slowdown_general = 0 // How much clothing is slowing you down. Negative values speeds you up. This is a genera##l slowdown, no matter equipment slot.
+	var/slowdown_general = 0 // How much clothing is slowing you down. Negative values speeds you up. This is a general slowdown, no matter equipment slot.
 	var/slowdown_per_slot // How much clothing is slowing you down. This is an associative list: item slot - slowdown
 	var/slowdown_accessory // How much an accessory will slow you down when attached to a worn article of clothing.
 	var/canremove = 1 //Mostly for Ninja code at this point but basically will not allow the item to be removed if set to 0. /N
@@ -110,7 +110,7 @@
 	var/base_name
 
 	/// Can this object leak into water sources?
-	var/watertight = FALSE 
+	var/watertight = FALSE
 
 /obj/item/get_color()
 	if(paint_color)

--- a/code/modules/mob/living/human/human_movement.dm
+++ b/code/modules/mob/living/human/human_movement.dm
@@ -53,8 +53,8 @@
 	if(aiming && aiming.aiming_at)
 		tally += 5 // Iron sights make you slower, it's a well-known fact.
 
-	if(facing_dir)
-		tally += 3 // Locking direction will slow you down.
+	if(facing_dir && ((travel_dir & facing_dir) != facing_dir))
+		tally += 3 // If we're not facing the direction we're going, we have to slow down.
 
 	var/decl/bodytype/root_bodytype = get_bodytype()
 	if (root_bodytype && bodytemperature < root_bodytype.cold_discomfort_level)

--- a/code/modules/mob/living/human/human_movement.dm
+++ b/code/modules/mob/living/human/human_movement.dm
@@ -30,15 +30,11 @@
 			var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(src, organ_name)
 			tally += E ? E.get_movement_delay(4) : 4
 	else
-		var/total_item_slowdown = -1
 		for(var/obj/item/I in get_equipped_items(include_carried = TRUE))
-			var/item_slowdown = 0
 			var/slot = get_equipped_slot_for_item(I)
-			item_slowdown += LAZYACCESS(I.slowdown_per_slot, slot)
-			item_slowdown += I.slowdown_general
-			item_slowdown += I.slowdown_accessory
-			total_item_slowdown += max(item_slowdown, 0)
-		tally += total_item_slowdown
+			tally += LAZYACCESS(I.slowdown_per_slot, slot)
+			tally += I.slowdown_general
+			tally += I.slowdown_accessory
 
 		for(var/organ_name in list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT))
 			var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(src, organ_name)

--- a/code/modules/mob/living/human/human_movement.dm
+++ b/code/modules/mob/living/human/human_movement.dm
@@ -19,10 +19,11 @@
 	tally += GET_CHEMICAL_EFFECT(src, CE_SLOWDOWN)
 
 	var/health_deficiency = (get_max_health() - current_health)
-	if(health_deficiency >= 40) tally += (health_deficiency / 25)
+	if(health_deficiency >= 40)
+		tally += (health_deficiency / 25)
 
-	if(can_feel_pain())
-		if(get_shock() >= 10) tally += (get_shock() / 10) //pain shouldn't slow you down if you can't even feel it
+	if(can_feel_pain() && get_shock() >= 10)
+		tally += (get_shock() / 10) //pain shouldn't slow you down if you can't even feel it
 
 	if(istype(buckled, /obj/structure/bed/chair/wheelchair))
 		for(var/organ_name in list(BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM))

--- a/code/modules/mob/living/human/human_movement.dm
+++ b/code/modules/mob/living/human/human_movement.dm
@@ -110,13 +110,6 @@
 
 		if(stat != DEAD)
 
-			var/stamina_cost = 0
-			for(var/obj/item/grab/grab as anything in get_active_grabs())
-				stamina_cost -= grab.grab_slowdown()
-			stamina_cost = round(stamina_cost)
-			if(stamina_cost < 0)
-				adjust_stamina(stamina_cost)
-
 			var/nut_removed = DEFAULT_HUNGER_FACTOR/10
 			var/hyd_removed = DEFAULT_THIRST_FACTOR/10
 			if (move_intent.flags & MOVE_INTENT_EXERTIVE)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -84,35 +84,29 @@
 //This proc should never be overridden elsewhere at /atom/movable to keep directions sane.
 /atom/movable/Move(newloc, direct)
 	if (direct & (direct - 1))
-		if (direct & 1)
-			if (direct & 4)
+		if (direct & NORTH)
+			if (direct & EAST)
 				if (step(src, NORTH))
 					step(src, EAST)
-				else
-					if (step(src, EAST))
-						step(src, NORTH)
-			else
-				if (direct & 8)
-					if (step(src, NORTH))
-						step(src, WEST)
-					else
-						if (step(src, WEST))
-							step(src, NORTH)
+				else if (step(src, EAST))
+					step(src, NORTH)
+			else if (direct & WEST)
+				if (step(src, NORTH))
+					step(src, WEST)
+				else if (step(src, WEST))
+					step(src, NORTH)
 		else
-			if (direct & 2)
-				if (direct & 4)
+			if (direct & SOUTH)
+				if (direct & EAST)
 					if (step(src, SOUTH))
 						step(src, EAST)
-					else
-						if (step(src, EAST))
-							step(src, SOUTH)
-				else
-					if (direct & 8)
-						if (step(src, SOUTH))
-							step(src, WEST)
-						else
-							if (step(src, WEST))
-								step(src, SOUTH)
+					else if (step(src, EAST))
+						step(src, SOUTH)
+				else if (direct & WEST)
+					if (step(src, SOUTH))
+						step(src, WEST)
+					else if (step(src, WEST))
+						step(src, SOUTH)
 	else
 		var/atom/A = src.loc
 

--- a/mods/species/serpentid/datum/species.dm
+++ b/mods/species/serpentid/datum/species.dm
@@ -114,15 +114,12 @@
 	else
 		return 0
 
-/decl/species/serpentid/handle_movement_delay_special(var/mob/living/human/H)
+/decl/species/serpentid/handle_movement_delay_special(var/mob/living/human/victim)
 	var/tally = 0
-
-	H.remove_cloaking_source(src)
-
-	var/obj/item/organ/internal/B = H.get_organ(BP_BRAIN)
-	if(istype(B,/obj/item/organ/internal/brain/insectoid/serpentid))
-		var/obj/item/organ/internal/brain/insectoid/serpentid/N = B
-		tally += N.lowblood_tally * 2
+	victim.remove_cloaking_source(src)
+	var/obj/item/organ/internal/brain/insectoid/serpentid/bugbrain = victim.get_organ(BP_BRAIN, /obj/item/organ/internal/brain/insectoid/serpentid)
+	if(bugbrain)
+		tally += bugbrain.lowblood_tally * 2
 	return tally
 
 // todo: make this on bodytype


### PR DESCRIPTION
## Description of changes
- Removes additive stamina cost from moving with grabs. The multiplicative cost still exists.
- Fixes config entry comments for movement delay options.
- Moves an implicit -1 to movement delay in item slowdown code into the default value for human movement slowdown.
- Improves the readability of diagonal movement code.
- Improves the readability of movement tally code.
- Setting a fixed facing direction now only slows you down if you're not moving in that direction.
- Negative movement slowdown on items now properly speeds you up as it did ~8 years ago on Baycode.

## Why and what will this PR improve
Makes moving with a grab slightly less punishing stamina-wise.
Makes the config have actual descriptive comments. (also, should those use game_options.txt instead??)
Makes movement code somewhat more readable.
Fixes an eight year old issue with negative movement slowdown not working.

## Authorship
me. Kapu for pointing out the weird hack bay did to 'fix' the negative slowdown thing.