### PR TITLE
Expanding the existing whitelist config to support several levels of severity.

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -131,7 +131,7 @@
 #define PROJECTILE_CONTINUE   -1 //if the projectile should continue flying after calling bullet_act()
 #define PROJECTILE_FORCE_MISS -2 //if the projectile should treat the attack as a miss (suppresses attack and admin logs) - only applies to mobs.
 
-// Objective cofig enum values.
+// Objective config enum values.
 #define CONFIG_OBJECTIVE_NONE 2
 #define CONFIG_OBJECTIVE_VERB 1
 #define CONFIG_OBJECTIVE_ALL  0

--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -131,10 +131,19 @@
 #define PROJECTILE_CONTINUE   -1 //if the projectile should continue flying after calling bullet_act()
 #define PROJECTILE_FORCE_MISS -2 //if the projectile should treat the attack as a miss (suppresses attack and admin logs) - only applies to mobs.
 
-//objectives
+// Objective cofig enum values.
 #define CONFIG_OBJECTIVE_NONE 2
 #define CONFIG_OBJECTIVE_VERB 1
 #define CONFIG_OBJECTIVE_ALL  0
+
+// Server whitelist config enums.
+#define CONFIG_SERVER_NO_WHITELIST      1
+#define CONFIG_SERVER_JOBS_WHITELIST    2
+#define CONFIG_SERVER_JOIN_WHITELIST    3
+#define CONFIG_SERVER_CONNECT_WHITELIST 4
+
+// Location for server whitelist file to load from.
+#define CONFIG_SERVER_WHITELIST_FILE "config/server_whitelist.txt"
 
 // How many times an AI tries to connect to APC before switching to low power mode.
 #define AI_POWER_RESTORE_MAX_ATTEMPTS 3

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -330,6 +330,8 @@ SUBSYSTEM_DEF(jobs)
 	//Get the players who are ready
 	for(var/mob/new_player/player in global.player_list)
 		if(player.ready && player.mind && !player.mind.assigned_role)
+			if(get_config_value(/decl/config/enum/server_whitelist) == CONFIG_SERVER_JOIN_WHITELIST && !check_server_whitelist(player))
+				continue
 			unassigned_roundstart += player
 	if(unassigned_roundstart.len == 0)	return 0
 	//Shuffle players and jobs

--- a/code/datums/config/config_types/config_server.dm
+++ b/code/datums/config/config_types/config_server.dm
@@ -43,7 +43,6 @@
 		/decl/config/toggle/on/allow_ai,
 		/decl/config/toggle/on/allow_drone_spawn,
 		/decl/config/toggle/hub_visibility,
-		/decl/config/toggle/usewhitelist,
 		/decl/config/toggle/load_jobs_from_txt,
 		/decl/config/toggle/disable_player_mice,
 		/decl/config/toggle/uneducated_mice,
@@ -61,7 +60,8 @@
 		/decl/config/toggle/guests_allowed,
 		/decl/config/toggle/on/jobs_have_minimal_access,
 		/decl/config/toggle/on/admin_legacy_system,
-		/decl/config/toggle/on/ban_legacy_system
+		/decl/config/toggle/on/ban_legacy_system,
+		/decl/config/enum/server_whitelist
 	)
 
 /decl/config/num/kick_inactive
@@ -293,13 +293,6 @@
 	. = ..()
 	world.update_hub_visibility()
 
-/decl/config/toggle/usewhitelist
-	uid = "usewhitelist"
-	desc = list(
-		"Set to jobban everyone who's key is not listed in data/whitelist.txt from Captain, HoS, HoP, CE, RD, CMO, Warden, Security, Detective, and AI positions.",
-		"Uncomment to 1 to jobban, leave commented out to allow these positions for everyone (but see GUEST_JOBBAN above and regular jobbans)."
-	)
-
 /decl/config/toggle/load_jobs_from_txt
 	uid = "load_jobs_from_txt"
 	desc = "Toggle for having jobs load up from the .txt"
@@ -369,3 +362,14 @@
 /decl/config/toggle/on/jobs_have_minimal_access
 	uid = "jobs_have_minimal_access"
 	desc = "Add a # here if you wish to use the setup where jobs have more access. This is intended for servers with low populations - where there are not enough players to fill all roles, so players need to do more than just one job. Also for servers where they don't want people to hide in their own departments."
+
+/decl/config/enum/server_whitelist
+	uid = "server_whitelist"
+	desc = "Determines how the server should handle whitelisting for ckeys. Whitelisted ckeys are found in '" + CONFIG_SERVER_WHITELIST_FILE + "'. Set to 'none' for no whitelisting, 'jobs' to whitelist sensitive jobs, 'join' to whitelist joining the round (observing and OOC are still available, or 'connect' to whitelist access to the server."
+	default_value = CONFIG_SERVER_NO_WHITELIST
+	enum_map = list(
+		"none"    = CONFIG_SERVER_NO_WHITELIST,
+		"jobs"    = CONFIG_SERVER_JOBS_WHITELIST,
+		"join"    = CONFIG_SERVER_JOIN_WHITELIST,
+		"connect" = CONFIG_SERVER_CONNECT_WHITELIST
+	)

--- a/code/game/jobs/server_whitelist.dm
+++ b/code/game/jobs/server_whitelist.dm
@@ -12,6 +12,24 @@ var/global/list/server_whitelist
 		global.server_whitelist = file2list(CONFIG_SERVER_WHITELIST_FILE) || list()
 	return (ckey in global.server_whitelist)
 
+/proc/save_server_whitelist()
+	// Ensure we have the server whitelist loaded regardless of config or prior call.
+	if(!global.server_whitelist)
+		global.server_whitelist = file2list(CONFIG_SERVER_WHITELIST_FILE) || list()
+
+	// Clear blank rows.
+	while(null in global.server_whitelist)
+		global.server_whitelist -= null
+	while("" in global.server_whitelist)
+		global.server_whitelist -= ""
+
+	// Remove old list rather than append.
+	if(fexists(CONFIG_SERVER_WHITELIST_FILE))
+		fdel(CONFIG_SERVER_WHITELIST_FILE)
+	// Write our list out.
+	var/write_file = file(CONFIG_SERVER_WHITELIST_FILE)
+	to_file(write_file, jointext(global.server_whitelist, "\n"))
+
 var/global/list/alien_whitelist = list()
 /hook/startup/proc/loadAlienWhitelist()
 	if(get_config_value(/decl/config/toggle/use_alien_whitelist))

--- a/code/game/jobs/server_whitelist.dm
+++ b/code/game/jobs/server_whitelist.dm
@@ -1,21 +1,16 @@
-#define WHITELISTFILE "data/whitelist.txt"
+var/global/list/server_whitelist
 
-var/global/list/whitelist = list()
-
-/hook/startup/proc/loadWhitelist()
-	if(get_config_value(/decl/config/toggle/usewhitelist))
-		load_whitelist()
-	return 1
-
-/proc/load_whitelist()
-	whitelist = file2list(WHITELISTFILE)
-	if(!length(whitelist))
-		whitelist = null
-
-/proc/check_whitelist(mob/M /*, var/rank*/)
-	if(!whitelist)
-		return 0
-	return ("[M.ckey]" in whitelist)
+/proc/check_server_whitelist(ckey)
+	if(get_config_value(/decl/config/enum/server_whitelist) == CONFIG_SERVER_NO_WHITELIST)
+		return TRUE
+	if(ismob(ckey))
+		var/mob/checking = ckey
+		ckey = checking.ckey
+	if(!istext(ckey))
+		return FALSE
+	if(!global.server_whitelist)
+		global.server_whitelist = file2list(CONFIG_SERVER_WHITELIST_FILE) || list()
+	return (ckey in global.server_whitelist)
 
 var/global/list/alien_whitelist = list()
 /hook/startup/proc/loadAlienWhitelist()
@@ -106,5 +101,3 @@ var/global/list/alien_whitelist = list()
 			if(findtext(s,"[ckey] - All"))
 				return TRUE
 	return FALSE
-
-#undef WHITELISTFILE

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -1,5 +1,6 @@
 //Blocks an attempt to connect before even creating our client datum thing.
 /world/IsBanned(key, address, computer_id, type)
+
 	var/static/key_cache = list()
 	if(type == "world")
 		return ..()
@@ -10,6 +11,11 @@
 
 	var/ckeytext = ckey(key)
 
+	if(get_config_value(/decl/config/enum/server_whitelist) == CONFIG_SERVER_CONNECT_WHITELIST && !check_server_whitelist(ckeytext))
+		log_access("Failed Login: [key] - Not server whitelisted")
+		message_admins("<span class='notice'>Failed Login: [key] - Not server whitelisted</span>")
+		return list("reason"="whitelist", "desc"="\nReason: This server requires players to be whitelisted to join.")
+
 	if(admin_datums[ckeytext])
 		key_cache[key] = 0
 		return ..()
@@ -19,7 +25,7 @@
 		log_access("Failed Login: [key] - Guests not allowed")
 		message_admins("<span class='notice'>Failed Login: [key] - Guests not allowed</span>")
 		key_cache[key] = 0
-		return list("reason"="guest", "desc"="\nReason: Guests not allowed. Please sign in with a byond account.")
+		return list("reason"="guest", "desc"="\nReason: Guests not allowed. Please sign in with a BYOND account.")
 
 	var/client/C = global.ckey_directory[ckeytext]
 	//If this isn't here, then topic call spam will result in all clients getting kicked with a connecting too fast error.

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1497,3 +1497,34 @@ var/global/BSACooldown = 0
 
 	LAZYADD(global.adminfaxes, P)
 	faxreply = null
+
+/datum/admins/proc/addserverwhitelist(ckey as text)
+	set category = "Admin"
+	set name = "Add Ckey To Server Whitelist"
+	set desc = "Permanently adds the specified ckey to the server whitelist."
+
+	ckey = ckey(ckey)
+
+	if(!ckey)
+		to_chat(usr, SPAN_WARNING("Please specify a ckey to insert."))
+	else if(check_server_whitelist(ckey)) // This will also preload the server whitelist.
+		to_chat(usr, SPAN_WARNING("That ckey is already server whitelisted."))
+	else
+		global.server_whitelist |= ckey
+		save_server_whitelist()
+		log_and_message_admins("has added [ckey] to the server whitelist.", usr)
+
+/datum/admins/proc/removeserverwhitelist(ckey as text)
+	set category = "Admin"
+	set name = "Remove Ckey From Server Whitelist"
+	set desc = "Permanently removes the specified ckey from the server whitelist."
+
+	ckey = ckey(ckey)
+	if(!ckey)
+		to_chat(usr, SPAN_WARNING("Please specify a ckey to remove."))
+	else if(!check_server_whitelist(ckey)) // This will also preload the server whitelist.
+		to_chat(usr, SPAN_WARNING("That ckey is not server whitelisted."))
+	else
+		global.server_whitelist -= ckey
+		save_server_whitelist()
+		log_and_message_admins("has removed [ckey] from the server whitelist.", usr)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -154,6 +154,8 @@ var/global/list/admin_verbs_server = list(
 	/datum/admins/proc/toggle_aliens,
 	/client/proc/toggle_random_events,
 	/client/proc/nanomapgen_DumpImage,
+	/datum/admins/proc/addserverwhitelist,
+	/datum/admins/proc/removeserverwhitelist,
 	/datum/admins/proc/panicbunker,
 	/datum/admins/proc/addbunkerbypass,
 	/datum/admins/proc/revokebunkerbypass

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -21,7 +21,7 @@ var/global/jobban_keylist[0]		//to store the keys & ranks
 		if (SSjobs.guest_jobbans(rank))
 			if(get_config_value(/decl/config/toggle/on/guest_jobban) && IsGuestKey(M.key))
 				return "Guest Job-ban"
-			if(get_config_value(/decl/config/toggle/usewhitelist) && !check_whitelist(M))
+			if(get_config_value(/decl/config/enum/server_whitelist) == CONFIG_SERVER_JOBS_WHITELIST && !check_server_whitelist(M))
 				return "Whitelisted Job"
 		return ckey_is_jobbanned(M.ckey, rank)
 	return 0

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -15,7 +15,9 @@
 // Check for bans, proper atom types, etc.
 /decl/ghosttrap/proc/assess_candidate(var/mob/observer/ghost/candidate, var/mob/target, var/feedback = TRUE)
 	. = TRUE
-	if(!candidate.MayRespawn(feedback, minutes_since_death))
+	if(get_config_value(/decl/config/enum/server_whitelist) == CONFIG_SERVER_JOIN_WHITELIST && !check_server_whitelist(candidate))
+		. = FALSE
+	else if(!candidate.MayRespawn(feedback, minutes_since_death))
 		. = FALSE
 	else if(islist(ban_checks))
 		for(var/bantype in ban_checks)

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -107,20 +107,24 @@
 /proc/try_drone_spawn(var/mob/user, var/obj/machinery/drone_fabricator/fabricator)
 
 	if(GAME_STATE < RUNLEVEL_GAME)
-		to_chat(user, "<span class='danger'>The game hasn't started yet!</span>")
+		to_chat(user, SPAN_WARNING("The game hasn't started yet!"))
+		return
+
+	if(get_config_value(/decl/config/enum/server_whitelist) == CONFIG_SERVER_JOIN_WHITELIST && !check_server_whitelist(user))
+		to_chat(user, SPAN_WARNING("Non-whitelisted players cannot join rounds except as observers."))
 		return
 
 	if(!get_config_value(/decl/config/toggle/on/allow_drone_spawn))
-		to_chat(user, "<span class='danger'>That verb is not currently permitted.</span>")
+		to_chat(user, SPAN_WARNING("That verb is not currently permitted."))
 		return
 
 	if(jobban_isbanned(user,ASSIGNMENT_ROBOT))
-		to_chat(user, "<span class='danger'>You are banned from playing synthetics and cannot spawn as a drone.</span>")
+		to_chat(user, SPAN_WARNING("You are banned from playing synthetics and cannot spawn as a drone."))
 		return
 
 	if(get_config_value(/decl/config/num/use_age_restriction_for_jobs) && isnum(user.client.player_age))
 		if(user.client.player_age <= 3)
-			to_chat(user, "<span class='danger'> Your account is not old enough to play as a maintenance drone.</span>")
+			to_chat(user, SPAN_WARNING("Your account is not old enough to play as a maintenance drone."))
 			return
 
 	if(!user.MayRespawn(1, DRONE_SPAWN_DELAY))
@@ -135,7 +139,7 @@
 			all_fabricators[DF.fabricator_tag] = DF
 
 		if(!all_fabricators.len)
-			to_chat(user, "<span class='danger'>There are no available drone spawn points, sorry.</span>")
+			to_chat(user, SPAN_WARNING("There are no available drone spawn points, sorry."))
 			return
 
 		var/choice = input(user,"Which fabricator do you wish to use?") as null|anything in all_fabricators

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -183,11 +183,15 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 		return 0
 
 	if(GAME_STATE != RUNLEVEL_GAME)
-		to_chat(usr, "<span class='warning'>The round is either not ready, or has already finished...</span>")
+		to_chat(usr, SPAN_WARNING("The round is either not ready, or has already finished."))
+		return 0
+
+	if(get_config_value(/decl/config/enum/server_whitelist) == CONFIG_SERVER_JOIN_WHITELIST && !check_server_whitelist(usr))
+		alert("Non-whitelisted players are not permitted to join rounds except as observers.")
 		return 0
 
 	if(!get_config_value(/decl/config/toggle/on/enter_allowed))
-		to_chat(usr, "<span class='notice'>There is an administrative lock on entering the game!</span>")
+		to_chat(usr, SPAN_WARNING("There is an administrative lock on entering the game!"))
 		return 0
 
 	if(!job || !job.is_available(client))

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -372,14 +372,18 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(ishuman(following))
 		to_chat(src, medical_scan_results(following, 1, SKILL_MAX))
 
-	else to_chat(src, "<span class='notice'>Not a scannable target.</span>")
+	else to_chat(src, SPAN_WARNING("\The [following] is not a scannable target."))
 
 /mob/observer/ghost/verb/become_mouse()
 	set name = "Become mouse"
 	set category = "Ghost"
 
+	if(get_config_value(/decl/config/enum/server_whitelist) == CONFIG_SERVER_JOIN_WHITELIST && !check_server_whitelist(src))
+		to_chat(src, SPAN_WARNING("Non-whitelisted players cannot join rounds except as observers."))
+		return
+
 	if(get_config_value(/decl/config/toggle/disable_player_mice))
-		to_chat(src, "<span class='warning'>Spawning as a mouse is currently disabled.</span>")
+		to_chat(src, SPAN_WARNING("Spawning as a mouse is currently disabled."))
 		return
 
 	if(!MayRespawn(1, ANIMAL_SPAWN_DELAY))
@@ -387,12 +391,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	var/turf/T = get_turf(src)
 	if(!T || isAdminLevel(T.z))
-		to_chat(src, "<span class='warning'>You may not spawn as a mouse on this Z-level.</span>")
+		to_chat(src, SPAN_WARNING("You may not spawn as a mouse on this Z-level."))
 		return
 
 	var/response = alert(src, "Are you -sure- you want to become a mouse?","Are you sure you want to squeek?","Squeek!","Nope!")
-	if(response != "Squeek!") return  //Hit the wrong key...again.
-
+	if(response != "Squeek!")
+		return
 
 	//find a viable mouse candidate
 	var/mob/living/simple_animal/passive/mouse/host
@@ -405,14 +409,16 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		vent_found = pick(found_vents)
 		host = new /mob/living/simple_animal/passive/mouse(vent_found.loc)
 	else
-		to_chat(src, "<span class='warning'>Unable to find any unwelded vents to spawn mice at.</span>")
+		to_chat(src, SPAN_WARNING("Unable to find any unwelded vents to spawn mice at."))
+
 	if(host)
 		if(get_config_value(/decl/config/toggle/uneducated_mice))
 			host.universal_understand = FALSE
 		announce_ghost_joinleave(src, 0, "They are now a mouse.")
 		host.ckey = src.ckey
 		host.status_flags |= NO_ANTAG
-		to_chat(host, "<span class='info'>You are now a mouse. Try to avoid interaction with players, and do not give hints away that you are more than a simple rodent.</span>")
+		to_chat(host, SPAN_INFO("You are now a mouse. Try to avoid interaction with players, and do not give hints away that you are more than a simple rodent."))
+
 /mob/observer/ghost/verb/view_manfiest()
 	set name = "Show Crew Manifest"
 	set category = "Ghost"

--- a/config/example/configuration.txt
+++ b/config/example/configuration.txt
@@ -68,8 +68,8 @@
 # Configuration options relating to event timers and probabilities.
 ##
 
-## Hash out to disable random events during the round. Uncomment to enable.
-#ALLOW_RANDOM_EVENTS
+## Hash out to disable random events during the round.
+#ALLOW_RANDOM_EVENTS 1
 
 ## The lower delay between events in minutes.
 ## Affect mundane, moderate, and major events respectively.
@@ -99,8 +99,8 @@ OBJECTIVES_DISABLED all
 ## Remove the # to allow people to leave public comments on each other's characters via the comments system. Uncomment to enable.
 #ALLOW_CHARACTER_COMMENTS
 
-## Allow multiple input keys to be pressed for diagonal movement. Uncomment to enable.
-#ALLOW_DIAGONAL_MOVEMENT
+## Allow multiple input keys to be pressed for diagonal movement.
+#ALLOW_DIAGONAL_MOVEMENT 1
 
 ## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied.
 #ANIMAL_DELAY 0
@@ -162,9 +162,6 @@ OBJECTIVES_DISABLED all
 ## Minimum stamina recovered per tick when resting.
 #MINIMUM_STAMINA_RECOVERY 1
 
-## Remove the # to let ninjas spawn. Uncomment to enable.
-#NINJAS_ALLOWED
-
 ## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied.
 #ROBOT_DELAY 0
 
@@ -194,6 +191,9 @@ OBJECTIVES_DISABLED all
 ## Determines if players can print copy/pasted integrated circuits.
 #ALLOW_IC_PRINTING 1
 
+## If true, when bodytype is changed in character creation, selected pronouns are also changed.
+#CISNORMATIVITY 1
+
 ## Determines if ghosts are permitted to write in blood during cult rounds.
 #CULT_GHOSTWRITER 1
 
@@ -220,6 +220,9 @@ OBJECTIVES_DISABLED all
 
 ## Defines how Law Zero is phrased. Primarily used in the Malfunction gamemode.
 #LAW_ZERO ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'ALL LAWS OVERRIDDEN#*?&110010
+
+## If true, most lightswitches start on by default. Otherwise, they start off. Uncomment to enable.
+#LIGHTS_START_ON
 
 ## After this amount alive, walking mushrooms spawned from botany will not reproduce.
 #MAXIMUM_MUSHROOMS 15
@@ -319,9 +322,6 @@ ROUNDSTART_LEVEL_GENERATION
 ## log OOC channel Uncomment to enable.
 #LOG_OOC
 
-## Log PDA messages. Uncomment to enable.
-#LOG_PDA
-
 ## Log world.log and runtime errors to a file. Uncomment to enable.
 #LOG_RUNTIME
 
@@ -354,13 +354,13 @@ ROUNDSTART_LEVEL_GENERATION
 #FEATURE_OBJECT_SPELL_SYSTEM
 
 ## Allowed modes.
-#MODES ["crossfire","cult","extended","god","heist","mercenary","ninja","revolution","siege","spyvspy","traitor","uprising","wizard"]
+#MODES ["crossfire","cult","extended","heist","mercenary","ninja","revolution","spyvspy","traitor","wizard"]
 
 ## Mode names.
-#MODE_NAMES {"calamity":"Calamity","cult":"Cult","extended":"Extended","god":"Deity","heist":"Heist","meteor":"Meteor","crossfire":"Mercenary & heist","siege":"Mercenary & revolution","spyvspy":"Spy v. spy","uprising":"Cult & revolution","ninja":"Ninja","mercenary":"Mercenary","revolution":"Revolution","traitor":"Traitor","wizard":"Wizard"}
+#MODE_NAMES {"calamity":"Calamity","extended":"Extended","mercenary":"Mercenary","wizard":"Wizard","cult":"Cult","heist":"Heist","ninja":"Ninja","revolution":"Revolution","traitor":"Traitor","spyvspy":"Spy v. spy","crossfire":"Crossfire"}
 
 ## Relative probability of each mode.
-#PROBABILITIES {"calamity":0,"cult":1,"extended":1,"god":0,"heist":0,"meteor":0,"crossfire":0,"siege":0,"spyvspy":0,"uprising":0,"ninja":0,"mercenary":1,"revolution":0,"traitor":0,"wizard":1}
+#PROBABILITIES {"calamity":0,"extended":1,"mercenary":1,"wizard":1,"cult":1,"heist":0,"ninja":0,"revolution":0,"traitor":0,"spyvspy":0,"crossfire":0}
 
 ## If security is prohibited from being most antagonists. Uncomment to enable.
 #PROTECT_ROLES_FROM_ANTAGONIST
@@ -369,7 +369,7 @@ ROUNDSTART_LEVEL_GENERATION
 #TRAITOR_SCALING
 
 ## A list of modes that should be votable.
-#VOTABLE_MODES ["crossfire","cult","extended","god","heist","mercenary","meteor","ninja","revolution","secret","siege","spyvspy","traitor","uprising","wizard"]
+#VOTABLE_MODES ["crossfire","cult","extended","heist","mercenary","ninja","revolution","secret","spyvspy","traitor","wizard"]
 
 ##
 # PROTECTED
@@ -377,13 +377,13 @@ ROUNDSTART_LEVEL_GENERATION
 ##
 
 ## Password used for authorizing external tools that can apply bans.
-#BAN_COMMS_PASSWORD
+#BAN_COMMS_PASSWORD 
 
 ## Password used for authorizing ircbot and other external tools.
-#COMMS_PASSWORD
+#COMMS_PASSWORD 
 
 ## Export address where external tools that monitor logins are located.
-#LOGIN_EXPORT_ADDR
+#LOGIN_EXPORT_ADDR 
 
 ##
 # RESOURCES
@@ -413,7 +413,7 @@ ROUNDSTART_LEVEL_GENERATION
 #ABANDON_ALLOWED 1
 
 ## IRC channel to send adminhelps to. Leave blank to disable adminhelps-to-irc.
-#ADMIN_IRC
+#ADMIN_IRC 
 
 ## Add a # infront of this if you want to use the SQL based admin system, the legacy system uses admins.txt. You need to set up your database to use the SQL based system.
 #ADMIN_LEGACY_SYSTEM 1
@@ -431,7 +431,7 @@ ROUNDSTART_LEVEL_GENERATION
 #AOOC_ALLOWED 1
 
 ## Ban appeals URL - usually for a forum or wherever people should go to contact your admins.
-#BANAPPEALS
+#BANAPPEALS 
 
 ## Add a # infront of this if you want to use the SQL based banning system. The legacy systems use the files in the data folder. You need to set up your database to use the SQL based system.
 #BAN_LEGACY_SYSTEM 1
@@ -442,7 +442,7 @@ ROUNDSTART_LEVEL_GENERATION
 ## Sets the minimum number of cultists needed for ghosts to write in blood.
 #CULT_GHOSTWRITER_REQ_CULTISTS 10
 
-## Determines if the server should hide itself from the hub when no admins are online.. Uncomment to enable.
+## Determines if the server should hide itself from the hub when no admins are online. Uncomment to enable.
 #DELIST_WHEN_NO_ADMINS
 
 ## Uncomment to enable.
@@ -452,7 +452,7 @@ ROUNDSTART_LEVEL_GENERATION
 #DISABLE_WEBHOOK_EMBEDS
 
 ## Discord server permanent invite address.
-#DISCORDURL
+#DISCORDURL 
 
 ## Comment to disable the dead OOC channel by default.
 #DOOC_ALLOWED 1
@@ -473,20 +473,20 @@ ROUNDSTART_LEVEL_GENERATION
 #FORBID_SINGULO_POSSESSION
 
 ## Discussion forum address.
-#FORUMURL
+#FORUMURL 
 
 ## Defines world FPS. Defaults to 20.
 ## Can also accept ticklag values (0.9, 0.5, etc) which will automatically be converted to FPS.
 #FPS 20
 
 ## GitHub address.
-#GITHUBURL
+#GITHUBURL 
 
 ## Determines whether or not people without a registered ckey (i.e. guest-*) can connect to your server. Uncomment to enable.
 #GUESTS_ALLOWED
 
 ## Set a hosted by name for UNIX platforms.
-#HOSTEDBY
+#HOSTEDBY 
 
 ## Hub visibility: If you want to be visible on the hub, uncomment the below line and be sure that Dream Daemon is set to visible. This can be changed in-round as well with toggle-hub-visibility if Dream Daemon is set correctly. Uncomment to enable.
 #HUB_VISIBILITY
@@ -495,7 +495,7 @@ ROUNDSTART_LEVEL_GENERATION
 #IRC_BOT_HOST localhost
 
 ## GitHub new issue address.
-#ISSUEREPORTURL
+#ISSUEREPORTURL 
 
 ## Add a # here if you wish to use the setup where jobs have more access. This is intended for servers with low populations - where there are not enough players to fill all roles, so players need to do more than just one job. Also for servers where they don't want people to hide in their own departments.
 #JOBS_HAVE_MINIMAL_ACCESS 1
@@ -515,8 +515,11 @@ ROUNDSTART_LEVEL_GENERATION
 ## IRC channel to send information to. Leave blank to disable.
 #MAIN_IRC #main
 
-## Remove the # to define a different cap for aspect points in chargen.
-#MAX_CHARACTER_ASPECTS 5
+## Remove the # to define a different maximum for alternate language selection in chargen.
+#MAX_ALTERNATE_LANGUAGES 3
+
+## Remove the # to define a different cap for trait points in chargen.
+#MAX_CHARACTER_TRAITS 5
 
 ## This many drones can be active at the same time.
 #MAX_MAINT_DRONES 5
@@ -551,14 +554,17 @@ ROUNDSTART_LEVEL_GENERATION
 #RESPAWN_DELAY 30
 
 ## Set a server location for world reboot. Don't include the byond://, just give the address and port.
-#SERVER
+#SERVER 
 
 ## Set a server URL for the IRC bot to use; like SERVER, don't include the byond://
 ## Unlike SERVER, this one shouldn't break auto-reconnect.
-#SERVERURL
+#SERVERURL 
 
 ## Server name: This appears at the top of the screen in-game.
 #SERVER_NAME Nebula 13
+
+## Determines how the server should handle whitelisting for ckeys. Whitelisted ckeys are found in 'config/whitelist.txt'. Set to 'none' for no whitelisting, 'jobs' to whitelist sensitive jobs, 'join' to whitelist joining the round (observing and OOC are still available, or 'connect' to whitelist access to the server. Valid values: none, jobs, join, and connect.
+#SERVER_WHITELIST none
 
 ## Determinese if a typing indicator shows overhead for people currently writing whispers. Uncomment to enable.
 #SHOW_TYPING_INDICATOR_FOR_WHISPERS
@@ -570,15 +576,10 @@ ROUNDSTART_LEVEL_GENERATION
 #UNEDUCATED_MICE
 
 ## Determines if non-admins are restricted from using humanoid alien races. Uncomment to enable.
-#USEALIENWHITELIST
+USEALIENWHITELIST
 
 ## Determines if the alien whitelist should use SQL instead of the legacy system. (requires the above uncommented as well). Uncomment to enable.
 #USEALIENWHITELIST_SQL
-
-## Set to jobban everyone who's key is not listed in data/whitelist.txt from Captain, HoS, HoP, CE, RD, CMO, Warden, Security, Detective, and AI positions.
-## Uncomment to 1 to jobban, leave commented out to allow these positions for everyone (but see GUEST_JOBBAN above and regular jobbans).
-##  Uncomment to enable.
-#USEWHITELIST
 
 ## Determines if data is sent to the IRC bot. Generally requires MAIN_IRC and associated setup. Uncomment to enable.
 #USE_IRC_BOT
@@ -590,7 +591,7 @@ ROUNDSTART_LEVEL_GENERATION
 #WAIT_FOR_SIGUSR1_REBOOT
 
 ## Wiki address.
-#WIKIURL
+#WIKIURL 
 
 ##
 # VOTING

--- a/config/example/gamemodes/ninja.txt
+++ b/config/example/gamemodes/ninja.txt
@@ -1,0 +1,7 @@
+##
+# NINJA
+# Configuration options relating to the Ninja gamemode and antagonist.
+##
+
+## Remove the # to let ninjas spawn in random antag events. Uncomment to enable.
+#RANDOM_NINJAS_ALLOWED

--- a/config/example/server_whitelist.txt
+++ b/config/example/server_whitelist.txt
@@ -1,0 +1,1 @@
+# Enter ckeys line by line with no whitespace or other formatting for them to be loaded into the server whitelist at runtime.

--- a/nebula.dme
+++ b/nebula.dme
@@ -805,7 +805,7 @@
 #include "code\game\jobs\_access_defs.dm"
 #include "code\game\jobs\access.dm"
 #include "code\game\jobs\access_datum.dm"
-#include "code\game\jobs\whitelist.dm"
+#include "code\game\jobs\server_whitelist.dm"
 #include "code\game\jobs\job\_job.dm"
 #include "code\game\machinery\ai_slipper.dm"
 #include "code\game\machinery\air_sensor.dm"


### PR DESCRIPTION
- `USEWHITELIST` is gone.
- `SERVER_WHITELIST` does the same job with four options:
    - `none`: no server whitelist checking.
    - `jobs`: unwhitelisted keys cannot join as jobs that are considered 'sensitive' (barred from guest joins).
    - `join`: unwhitelisted keys cannot join rounds except as observers.
    - `connect`: unwhitelisted keys can't connect to the server (similar to guestbans).
    
I haven't been able to test the IsBanned() change due to it apparently not being called on local joins, so will test that on Pyrelight this weekend.