### PR TITLE
Small Pyrelight fixes, September 28 2024

### DIFF
--- a/code/game/objects/structures/bookcase.dm
+++ b/code/game/objects/structures/bookcase.dm
@@ -197,4 +197,8 @@ var/global/list/station_bookcases = list()
 	tool_interaction_flags = TOOL_INTERACTION_DECONSTRUCT
 	obj_flags = 0
 
+/obj/structure/bookcase/ebony
+	material = /decl/material/solid/organic/wood/ebony
+	color =    /decl/material/solid/organic/wood/ebony::color
+
 #undef GET_BOOK_POS

--- a/code/modules/butchery/butchery_data_animal.dm
+++ b/code/modules/butchery/butchery_data_animal.dm
@@ -83,6 +83,7 @@
 	skin_material     = /decl/material/solid/organic/skin/fur/white
 	gut_type          = /obj/item/food/butchery/offal/small
 	must_use_hook     = FALSE
+	butchery_offset   = list(-6, 0)
 
 /decl/butchery_data/animal/rabbit/brown
 	skin_material     = /decl/material/solid/organic/skin/fur/brown

--- a/code/modules/mob/examine.dm
+++ b/code/modules/mob/examine.dm
@@ -53,8 +53,8 @@
 
 	// Show our equipment, held items, desc, etc.
 	var/decl/pronouns/pronouns = get_visible_pronouns(hideflags)
-	to_chat(user, "<quote>")
+	// to_chat(user, "<blockquote>") // these don't work in BYOND's native output panel. If we switch to browser output instead, you can readd this
 	show_examined_short_description(user, distance, infix, suffix, hideflags, pronouns)
 	show_examined_worn_held_items(user, distance, infix, suffix, hideflags, pronouns)
 	show_other_examine_strings(user, distance, infix, suffix, hideflags, pronouns)
-	to_chat(user, "</quote>")
+	// to_chat(user, "</blockquote>") // see above

--- a/maps/shaded_hills/shaded_hills-dungeon.dmm
+++ b/maps/shaded_hills/shaded_hills-dungeon.dmm
@@ -429,7 +429,7 @@
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/caves/dungeon/poi)
 "Ef" = (
-/obj/structure/reagent_dispensers/barrel,
+/obj/structure/reagent_dispensers/barrel/ebony,
 /turf/floor/natural/path/basalt,
 /area/shaded_hills/caves/dungeon/poi)
 "Eq" = (
@@ -525,7 +525,7 @@
 /turf/floor/natural/path/running_bond/basalt,
 /area/shaded_hills/caves/dungeon/poi)
 "Ky" = (
-/obj/structure/bookcase,
+/obj/structure/bookcase/ebony,
 /turf/floor/natural/path/running_bond/basalt,
 /area/shaded_hills/caves/dungeon/poi)
 "Kz" = (

--- a/maps/shaded_hills/shaded_hills-grassland.dmm
+++ b/maps/shaded_hills/shaded_hills-grassland.dmm
@@ -14,9 +14,6 @@
 /obj/abstract/landmark/start/shaded_hills/miner,
 /turf/floor/natural/grass,
 /area/shaded_hills/outside)
-"dB" = (
-/turf/wall/log/walnut,
-/area/shaded_hills/caves/unexplored)
 "ee" = (
 /turf/floor/natural/path/running_bond/basalt,
 /area/shaded_hills/outside/poi)
@@ -69,10 +66,10 @@
 /turf/floor/natural/path/running_bond/basalt,
 /area/shaded_hills/outside)
 "kr" = (
-/obj/structure/closet/crate/chest,
 /obj/item/tool/pickaxe/iron,
 /obj/item/tool/axe,
 /obj/abstract/exterior_marker/inside,
+/obj/structure/closet/crate/chest/ebony,
 /turf/floor/woven,
 /area/shaded_hills/outside)
 "kz" = (
@@ -180,7 +177,6 @@
 /area/shaded_hills/caves/unexplored/south)
 "Ed" = (
 /obj/item/stack/material/brick/mapped/graphite/ten,
-/obj/structure/closet/crate/chest,
 /obj/item/stack/material/ore/coal,
 /obj/abstract/exterior_marker/inside,
 /obj/item/flame/torch,
@@ -188,6 +184,7 @@
 /obj/item/flame/torch,
 /obj/item/flame/torch,
 /obj/item/bag/sack,
+/obj/structure/closet/crate/chest/ebony,
 /turf/floor/woven,
 /area/shaded_hills/outside)
 "EE" = (
@@ -12252,7 +12249,7 @@ tp
 tp
 tp
 tp
-dB
+tp
 tp
 tp
 tp

--- a/maps/shaded_hills/shaded_hills-inn.dmm
+++ b/maps/shaded_hills/shaded_hills-inn.dmm
@@ -17,7 +17,7 @@
 /turf/floor/wood/walnut,
 /area/shaded_hills/farmhouse)
 "bz" = (
-/obj/structure/closet/crate/chest,
+/obj/structure/closet/crate/chest/ebony,
 /turf/floor/natural/path/basalt,
 /area/shaded_hills/general_store)
 "bW" = (
@@ -106,7 +106,7 @@
 /obj/structure/railing/mapped/wooden/walnut{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/compost_bin,
+/obj/structure/reagent_dispensers/compost_bin/walnut,
 /turf/floor/natural/dirt,
 /area/shaded_hills/outside/shrine)
 "fh" = (
@@ -582,7 +582,6 @@
 /turf/floor/natural/path/herringbone/basalt,
 /area/shaded_hills/shrine)
 "wh" = (
-/obj/structure/closet/crate/chest,
 /obj/item/cash/imperial/regalis,
 /obj/item/cash/imperial/regalis,
 /obj/item/cash/imperial/regalis,
@@ -598,6 +597,7 @@
 /obj/item/cash/imperial/crown,
 /obj/item/cash/imperial/crown,
 /obj/item/cash/imperial/crown,
+/obj/structure/closet/crate/chest/ebony,
 /turf/floor/natural/path/basalt,
 /area/shaded_hills/general_store)
 "wA" = (
@@ -1134,7 +1134,7 @@
 /turf/unsimulated/mask,
 /area/shaded_hills/outside/downlands/poi)
 "Oa" = (
-/obj/structure/closet/crate/chest,
+/obj/structure/closet/crate/chest/ebony,
 /turf/floor/natural/path/basalt,
 /area/shaded_hills/slaughterhouse)
 "Ot" = (
@@ -1167,11 +1167,11 @@
 /turf/floor/wood/walnut,
 /area/shaded_hills/shrine)
 "PQ" = (
-/obj/structure/closet/crate/chest,
 /obj/item/food/butchery/meat,
 /obj/item/food/butchery/meat,
 /obj/item/food/butchery/meat,
 /obj/item/food/butchery/meat/chicken,
+/obj/structure/closet/crate/chest/ebony,
 /turf/floor/natural/path/basalt,
 /area/shaded_hills/slaughterhouse)
 "PS" = (

--- a/mods/content/fantasy/_fantasy.dme
+++ b/mods/content/fantasy/_fantasy.dme
@@ -25,6 +25,7 @@
 #include "datum\kobaloi\markings.dm"
 #include "datum\kobaloi\organs.dm"
 #include "datum\kobaloi\species.dm"
+#include "items\material_overrides.dm"
 #include "items\clothing\_loadout.dm"
 #include "items\clothing\_recipes.dm"
 #include "items\clothing\armor.dm"

--- a/mods/content/fantasy/items/material_overrides.dm
+++ b/mods/content/fantasy/items/material_overrides.dm
@@ -1,0 +1,7 @@
+/obj/structure/gravemarker
+	material = /decl/material/solid/organic/wood/walnut
+	color =    /decl/material/solid/organic/wood/walnut::color
+
+/obj/item/gravemarker
+	material = /decl/material/solid/organic/wood/walnut
+	color =    /decl/material/solid/organic/wood/walnut::color


### PR DESCRIPTION
Rabbits have a butchery offset so that they're centered on the hook.
All props made of generic 'wood' on Shaded Hills are now made of walnut or ebony.
Fixed erroneous extra linebreak before mob examine messages. (sadly, blockquote doesn't work in a native BYOND output control and you can't fake it with CSS either)