### PR TITLE
Removes bodytype DNA flag checking from organ code.

### DIFF
--- a/code/game/gamemodes/endgame/ftl_jump/ftl_jump.dm
+++ b/code/game/gamemodes/endgame/ftl_jump/ftl_jump.dm
@@ -121,7 +121,7 @@
 /obj/effect/bluegoast/proc/blueswitch()
 	var/mob/living/human/H
 	if(ishuman(daddy))
-		H = new(get_turf(src), daddy.species.name, daddy.get_mob_snapshot(force = TRUE), daddy.get_bodytype())
+		H = new(get_turf(src), daddy.species.name, daddy.get_mob_snapshot(), daddy.get_bodytype())
 		for(var/obj/item/entry in daddy.get_equipped_items(TRUE))
 			daddy.remove_from_mob(entry) //steals instead of copies so we don't end up with duplicates
 			H.equip_to_appropriate_slot(entry)

--- a/code/modules/fabrication/fabricator_bioprinter.dm
+++ b/code/modules/fabrication/fabricator_bioprinter.dm
@@ -44,7 +44,7 @@
 				var/weakref/R = sample["donor"]
 				var/mob/living/human/H = R.resolve()
 				if(H && istype(H) && H.species)
-					loaded_dna = H.get_mob_snapshot()
+					loaded_dna = H.get_mob_snapshot(check_dna = TRUE)
 					if(loaded_dna)
 						to_chat(user, SPAN_INFO("You inject the blood sample into \the [src]."))
 						S.remove_any_reagents(BIOPRINTER_BLOOD_SAMPLE_SIZE)

--- a/code/modules/mob/living/living_genetics.dm
+++ b/code/modules/mob/living/living_genetics.dm
@@ -16,7 +16,7 @@
 	return _genetic_conditions
 
 /mob/living/can_have_genetic_conditions()
-	return !(get_bodytype()?.body_flags & BODY_FLAG_NO_DNA)
+	return has_genetic_information()
 
 /mob/living/has_genetic_condition(condition_type)
 	if(!LAZYLEN(_genetic_conditions))

--- a/code/modules/mob/mob_snapshot.dm
+++ b/code/modules/mob/mob_snapshot.dm
@@ -15,7 +15,7 @@
 	var/list/sprite_accessories
 	var/list/genetic_conditions
 
-/datum/mob_snapshot/New(mob/living/donor, force)
+/datum/mob_snapshot/New(mob/living/donor, genetic_info_only = FALSE)
 
 	real_name      = donor?.real_name        || "unknown"
 	eye_color      = donor?.get_eye_colour() || COLOR_BLACK
@@ -29,7 +29,7 @@
 	for(var/obj/item/organ/external/limb in donor?.get_external_organs())
 		// Discard anything not relating to our core/original bodytype and species.
 		// Does this need to be reviewed for Outreach serde?
-		if(limb.bodytype == root_bodytype && limb.species == root_species && (force || !BP_IS_PROSTHETIC(limb)))
+		if(limb.bodytype == root_bodytype && limb.species == root_species && (!genetic_info_only || !BP_IS_PROSTHETIC(limb)))
 			var/list/limb_sprite_acc = limb.get_sprite_accessories(copy = TRUE)
 			if(length(limb_sprite_acc))
 				LAZYSET(sprite_accessories, limb.organ_tag, limb_sprite_acc)
@@ -85,5 +85,5 @@
 	target.update_eyes()
 	return TRUE
 
-/mob/proc/get_mob_snapshot(force = FALSE)
-	return (force || has_genetic_information()) ? new /datum/mob_snapshot(src, force) : null
+/mob/proc/get_mob_snapshot(check_dna = FALSE)
+	return (!check_dna || has_genetic_information()) ? new /datum/mob_snapshot(src, genetic_info_only = check_dna) : null

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -93,11 +93,10 @@
 		// this can be fine if appearance data with species is passed
 		log_debug("obj/item/organ/setup(): [src] had null bodytype, with an owner with null bodytype!")
 	bodytype = new_bodytype // used in later setup procs
-	if((bodytype?.body_flags & BODY_FLAG_NO_DNA) || !supplied_appearance)
-		// set_bodytype will unset invalid appearance data anyway, so set_dna(null) is unnecessary
-		set_species(owner?.get_species() || global.using_map.default_species)
-	else
+	if(supplied_appearance)
 		copy_from_mob_snapshot(supplied_appearance)
+	else
+		set_species(owner?.get_species() || global.using_map.default_species)
 
 //Called on initialization to add the neccessary reagents
 
@@ -116,9 +115,6 @@
 		add_to_reagents(reagent_to_add, reagents.maximum_volume)
 
 /obj/item/organ/proc/copy_from_mob_snapshot(var/datum/mob_snapshot/supplied_appearance)
-	if(istype(bodytype) && (bodytype.body_flags & BODY_FLAG_NO_DNA))
-		QDEL_NULL(organ_appearance)
-		return
 	if(supplied_appearance != organ_appearance) // Hacky. Is this ever used? Do any organs ever have DNA set before setup_as_organic?
 		QDEL_NULL(organ_appearance)
 		organ_appearance = supplied_appearance.Clone()
@@ -152,8 +148,6 @@
 	if(reagents)
 		reagents.clear_reagents()
 		populate_reagents()
-	if(bodytype.body_flags & BODY_FLAG_NO_DNA)
-		QDEL_NULL(organ_appearance)
 	reset_status()
 	return TRUE
 

--- a/code/modules/reagents/chems/chems_compounds.dm
+++ b/code/modules/reagents/chems/chems_compounds.dm
@@ -246,20 +246,14 @@
 
 /decl/material/liquid/mutagenics/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	. = ..()
-	if(M.isSynthetic())
+	if(!M.has_genetic_information())
 		return
-	var/mob/living/human/H = M
-	if(istype(H) && (H.get_bodytype()?.body_flags & BODY_FLAG_NO_DNA))
-		return
-
 	if(prob(removed * 0.1)) // Approx. one mutation per 10 injected/20 ingested/30 touching units
 		H.set_unique_enzymes(num2text(random_id(/mob, 1000000, 9999999)))
 		if(prob(98))
 			M.add_genetic_condition(pick(decls_repository.get_decls_of_type(/decl/genetic_condition/disability)))
 		else
 			M.add_genetic_condition(pick(decls_repository.get_decls_of_type(/decl/genetic_condition/superpower)))
-
-
 	M.apply_damage(10 * removed, IRRADIATE, armor_pen = 100)
 
 /decl/material/liquid/lactate

--- a/code/modules/reagents/chems/chems_compounds.dm
+++ b/code/modules/reagents/chems/chems_compounds.dm
@@ -249,7 +249,7 @@
 	if(!M.has_genetic_information())
 		return
 	if(prob(removed * 0.1)) // Approx. one mutation per 10 injected/20 ingested/30 touching units
-		H.set_unique_enzymes(num2text(random_id(/mob, 1000000, 9999999)))
+		M.set_unique_enzymes(num2text(random_id(/mob, 1000000, 9999999)))
 		if(prob(98))
 			M.add_genetic_condition(pick(decls_repository.get_decls_of_type(/decl/genetic_condition/disability)))
 		else

--- a/code/modules/species/species_bodytype.dm
+++ b/code/modules/species/species_bodytype.dm
@@ -595,7 +595,7 @@ var/global/list/bodytypes_by_category = list()
 				qdel(O)
 
 	//Create missing limbs
-	var/datum/mob_snapshot/supplied_data = H.get_mob_snapshot(force = TRUE)
+	var/datum/mob_snapshot/supplied_data = H.get_mob_snapshot()
 	supplied_data.root_bodytype = src // This may not have been set on the target mob torso yet.
 
 	for(var/limb_type in has_limbs)
@@ -722,7 +722,7 @@ var/global/list/bodytypes_by_category = list()
 			qdel(innard)
 
 	// Install any necessary new organs.
-	var/datum/mob_snapshot/supplied_data = limb.owner.get_mob_snapshot(force = TRUE)
+	var/datum/mob_snapshot/supplied_data = limb.owner.get_mob_snapshot()
 	supplied_data.root_bodytype = src
 	for(var/organ_tag in replacing_organs)
 		var/organ_type = replacing_organs[organ_tag]

--- a/mods/content/xenobiology/slime/feeding.dm
+++ b/mods/content/xenobiology/slime/feeding.dm
@@ -21,12 +21,15 @@
 		if(!silent)
 			to_chat(src, SPAN_WARNING("\The [M] is protected from your feeding."))
 		return FEED_RESULT_INVALID
-	if(ishuman(M))
-		var/mob/living/human/H = M
-		if((H.species.species_flags & SPECIES_FLAG_NO_POISON) || (H.get_bodytype()?.body_flags & BODY_FLAG_NO_DNA))
-			if(!silent)
-				to_chat(src, SPAN_WARNING("You cannot feed on \the [M]."))
-			return FEED_RESULT_INVALID
+	if(!M.has_genetic_information())
+		if(!silent)
+			to_chat(src, SPAN_WARNING("You cannot feed on \the [M]."))
+		return FEED_RESULT_INVALID
+	var/decl/species/prey_species = M.get_species()
+	if(istype(prey_species) && (prey_species.species_flags & SPECIES_FLAG_NO_POISON))
+		if(!silent)
+			to_chat(src, SPAN_WARNING("You cannot feed on \the [M]."))
+		return FEED_RESULT_INVALID
 	if(M.stat == DEAD)
 		if(!silent)
 			to_chat(src, SPAN_WARNING("\The [src] is dead."))


### PR DESCRIPTION
- BODY_FLAG_NO_DNA is no longer checked when organs are being setup from a mob snapshot.
- Mob snapshots now only care about genetics when being requested by the organ printer, where genetics are the purpose.
- Fixes vox and utility frames not getting species set on bodyparts.
- Fixes vox and utility frame markings and hair.