### PR TITLE
qdel() now warns if a datum is still processing after Destroy()

### DIFF
--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -312,6 +312,9 @@ SUBSYSTEM_DEF(garbage)
 		if(isnull(D))
 			return
 
+		if(D.is_processing)
+			get_stack_trace("[D] ([D.type]) was qdeleted while still processing on [D.is_processing]!")
+
 		switch(hint)
 			if (QDEL_HINT_QUEUE)		//qdel should queue the object for deletion.
 				GC_CHECK_AM_NULLSPACE(D, "QDEL_HINT_QUEUE")

--- a/code/datums/extensions/milkable/milkable.dm
+++ b/code/datums/extensions/milkable/milkable.dm
@@ -23,6 +23,7 @@
 	START_PROCESSING(SSprocessing, src)
 
 /datum/extension/milkable/Destroy()
+	STOP_PROCESSING(SSprocessing, src)
 	QDEL_NULL(udder)
 	return ..()
 

--- a/code/datums/extensions/shearable/shearable.dm
+++ b/code/datums/extensions/shearable/shearable.dm
@@ -20,6 +20,10 @@
 		fleece_material = GET_DECL(fleece_material)
 	START_PROCESSING(SSprocessing, src)
 
+/datum/extension/shearable/Destroy()
+	STOP_PROCESSING(SSprocessing, src)
+	return ..()
+
 /datum/extension/shearable/Process()
 	if(has_fleece)
 		return PROCESS_KILL


### PR DESCRIPTION
qdel() now prints a stack trace (non-aborting runtime error that marks a CI run as failed) if a datum is still processing after Destroy() resolves. I can't put it in `/datum/Destroy()` because of the geothermal extension doing `STOP_PROCESSING()` after the parent call for some reason, and this is more robust against downstreams doing things like that, so...

This won't catch all cases (for example, temperature processing doesn't use is_processing) but it should catch a bunch.

Requires #4507 as a dependency, but it should be noted that before I rebased it, it also caught those as well.