### PR TITLE
Small optimizations to proximity_trigger and get_mobs_and_objs_in_view_fast

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -172,7 +172,6 @@
 	return L
 
 // Returns a list of mobs and/or objects in range of R from source. Used in radio and say code.
-
 /proc/get_mobs_or_objects_in_view(var/R, var/atom/source, var/include_mobs = 1, var/include_objects = 1)
 
 	var/turf/T = get_turf(source)
@@ -195,28 +194,24 @@
 				hear += I
 	return hear
 
-/proc/get_mobs_and_objs_in_view_fast(var/turf/T, var/range, var/list/mobs, var/list/objs, var/check_ghosts = null)
-	var/list/hear = list()
-	DVIEW(hear, range, T, INVISIBILITY_MAXIMUM)
+// Alternative to get_mobs_or_objects_in_view which only considers mobs and "listening" objects.
+/proc/get_listeners_in_range(turf/center, range, list/mobs, list/objs, check_ghosts=FALSE)
 	var/list/hearturfs = list()
-
-	for(var/atom/movable/AM in hear)
-		if(ismob(AM))
-			mobs += AM
-			hearturfs += get_turf(AM)
-		else if(isobj(AM))
-			objs += AM
-			hearturfs += get_turf(AM)
+	FOR_DVIEW(var/turf/T, range, center, INVISIBILITY_MAXIMUM)
+		hearturfs[T] = TRUE
+		for(var/mob/M in T)
+			mobs += M
+	END_FOR_DVIEW
 
 	for(var/mob/M in global.player_list)
 		if(check_ghosts && M.stat == DEAD && M.get_preference_value(check_ghosts) != PREF_NEARBY)
 			mobs |= M
-		else if(get_turf(M) in hearturfs)
+		else if(hearturfs[get_turf(M)])
 			mobs |= M
 
 	for(var/obj/O in global.listening_objects)
-		if(get_turf(O) in hearturfs)
-			objs |= O
+		if(hearturfs[get_turf(O)])
+			objs += O
 
 
 

--- a/code/datums/proximity_trigger/proximity_trigger.dm
+++ b/code/datums/proximity_trigger/proximity_trigger.dm
@@ -151,7 +151,7 @@ var/global/const/PROXIMITY_EXCLUDE_HOLDER_TURF = 1 // When acquiring turfs to mo
 
 /datum/proximity_trigger/proc/update_opaque_atom(var/atom/opaque_atom)
 	var/turf/atom_loc = get_turf(opaque_atom)
-	if(QDELETED(opaque_atom) || !opaque_atom.opacity || !atom_loc || !(atom_loc in turfs_in_range))
+	if(QDELETED(opaque_atom) || !opaque_atom.opacity || !atom_loc || !turfs_in_range[atom_loc])
 		events_repository.unregister(/decl/observ/opacity_set, opaque_atom, src, TYPE_PROC_REF(/datum/proximity_trigger, update_opaque_atom))
 		events_repository.unregister(/decl/observ/destroyed, opaque_atom, src, TYPE_PROC_REF(/datum/proximity_trigger, update_opaque_atom))
 		events_repository.unregister(/decl/observ/moved, opaque_atom, src, TYPE_PROC_REF(/datum/proximity_trigger, update_opaque_atom))
@@ -163,15 +163,17 @@ var/global/const/PROXIMITY_EXCLUDE_HOLDER_TURF = 1 // When acquiring turfs to mo
 	if(!center)
 		return
 
-	FOR_DVIEW(var/T, range_, center, 0)
-		if (T in turfs_in_range)	// This is awful, but I don't want to refactor this to be assoc.
-			. += T
+	FOR_DVIEW(var/turf/t, range_, center, 0)
+		if (turfs_in_range[t])
+			. += t
 	END_FOR_DVIEW
 
 /datum/proximity_trigger/proc/acquire_relevant_turfs()
 	. = turf_selection.get_turfs(holder, range_, l_angle_, r_angle_)
 	if(proximity_flags & PROXIMITY_EXCLUDE_HOLDER_TURF)
 		. -= get_turf(holder)
+	for(var/T in .)
+		.[T] = TRUE
 
 /obj/item/proxy_debug
 	abstract_type = /obj/item/proxy_debug

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -584,7 +584,7 @@
 	var/turf/T = get_turf(src)
 	var/list/mobs = list()
 	var/list/objs = list()
-	get_mobs_and_objs_in_view_fast(T,range, mobs, objs, check_ghosts)
+	get_listeners_in_range(T,range, mobs, objs, check_ghosts)
 
 	for(var/o in objs)
 		var/obj/O = o
@@ -612,7 +612,7 @@
 	var/turf/T = get_turf(src)
 	var/list/mobs = list()
 	var/list/objs = list()
-	get_mobs_and_objs_in_view_fast(T, hearing_distance, mobs, objs, check_ghosts)
+	get_listeners_in_range(T, hearing_distance, mobs, objs, check_ghosts)
 
 	for(var/m in mobs)
 		var/mob/M = m
@@ -991,4 +991,3 @@
 
 /atom/proc/is_watertight()
 	return ATOM_IS_OPEN_CONTAINER(src)
-

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -63,8 +63,9 @@ var/global/list/holopads = list()
 /obj/machinery/hologram/holopad/Initialize()
 	. = ..()
 
-	// Null ID means we want to use our area name.
 	global.holopads += src
+	global.listening_objects += src
+	// Null ID means we want to use our area name.
 	if(isnull(holopad_id))
 		var/area/A = get_area(src)
 		holopad_id = A?.proper_name || "Unknown"
@@ -76,6 +77,10 @@ var/global/list/holopads = list()
 
 	// Update our desc.
 	desc = "It's a floor-mounted device for projecting holographic images. Its ID is '[holopad_id]'"
+
+/obj/machinery/hologram/holopad/Destroy()
+	global.listening_objects -= src
+	return ..()
 
 /obj/machinery/hologram/holopad/interface_interact(var/mob/living/human/user) //Carn: Hologram requests.
 	if(!CanInteract(user, DefaultTopicState()))

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -10,13 +10,14 @@
 	var/list/victims = list()
 	var/list/objs = list()
 	var/turf/T = get_turf(src)
-	get_mobs_and_objs_in_view_fast(T, 7, victims, objs)
+	get_listeners_in_range(T, 7, victims, objs)
 	for(var/mob/living/M in victims)
 		bang(T, M)
 
-	for(var/obj/effect/blob/B in objs) //Blob damage here
+	FOR_DVIEW(var/obj/effect/blob/B, 7, T, INVISIBILITY_MAXIMUM) //Blob damage here
 		var/damage = round(30/(get_dist(B,T)+1))
 		B.take_damage(damage, BURN)
+	END_FOR_DVIEW
 
 	new /obj/effect/sparks(loc)
 	new /obj/effect/effect/smoke/illumination(loc, 5, 30, 1, "#ffffff")

--- a/code/modules/fabrication/fabricator_food.dm
+++ b/code/modules/fabrication/fabricator_food.dm
@@ -7,6 +7,14 @@
 	base_icon_state = "replicator"
 	base_storage_capacity_mult = 5
 
+/obj/machinery/fabricator/replicator/Initialize()
+	. = ..()
+	global.listening_objects += src
+
+/obj/machinery/fabricator/replicator/Destroy()
+	global.listening_objects -= src
+	return ..()
+
 /obj/machinery/fabricator/replicator/hear_talk(var/mob/M, var/text, var/verb, var/decl/language/speaking)
 	if(speaking && !speaking.machine_understands)
 		return ..()

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -243,7 +243,7 @@
 			italics = 1
 			sound_vol *= 0.5 //muffle the sound a bit, so it's like we're actually talking through contact
 
-		get_mobs_and_objs_in_view_fast(T, message_range, listening, listening_obj, /datum/client_preference/ghost_ears)
+		get_listeners_in_range(T, message_range, listening, listening_obj, /datum/client_preference/ghost_ears)
 
 	var/speech_bubble_state = check_speech_punctuation_state(message)
 	var/speech_state_modifier = get_speech_bubble_state_modifier()
@@ -273,7 +273,7 @@
 		var/eavesdroping_range = 5
 		var/list/eavesdroping = list()
 		var/list/eavesdroping_obj = list()
-		get_mobs_and_objs_in_view_fast(T, eavesdroping_range, eavesdroping, eavesdroping_obj)
+		get_listeners_in_range(T, eavesdroping_range, eavesdroping, eavesdroping_obj)
 		eavesdroping -= listening
 		eavesdroping_obj -= listening_obj
 		for(var/mob/M in eavesdroping)

--- a/code/modules/mob/living/simple_animal/hostile/faithful_hound.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithful_hound.dm
@@ -29,7 +29,7 @@
 	var/aggressiveness = 0 //The closer somebody is to us, the more aggressive we are
 	var/list/mobs = list()
 	var/list/objs = list()
-	get_mobs_and_objs_in_view_fast(get_turf(body), 5, mobs, objs, 0)
+	get_listeners_in_range(get_turf(body), 5, mobs, objs, 0)
 	for(var/mob/living/mailman in mobs)
 		if((mailman == body) || is_friend(mailman) || mailman.faction == body.faction)
 			continue

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -118,7 +118,7 @@
 	var/turf/T = get_turf(src)
 	var/list/mobs = list()
 	var/list/objs = list()
-	get_mobs_and_objs_in_view_fast(T, range, mobs, objs, check_ghosts)
+	get_listeners_in_range(T, range, mobs, objs, check_ghosts)
 
 	for(var/o in objs)
 		var/obj/O = o
@@ -158,7 +158,7 @@
 	var/turf/T = get_turf(src)
 	var/list/mobs = list()
 	var/list/objs = list()
-	get_mobs_and_objs_in_view_fast(T, hearing_distance, mobs, objs, check_ghosts)
+	get_listeners_in_range(T, hearing_distance, mobs, objs, check_ghosts)
 
 	for(var/m in mobs)
 		var/mob/M = m
@@ -1392,4 +1392,3 @@
 
 /mob/proc/can_twohand_item(obj/item/item)
 	return FALSE
-


### PR DESCRIPTION
## Description of changes

`proximity_trigger`:
- Makes turfs_in_range into a turf->TRUE assoc list to speed up lookups.
- Puts a /turf filter in the FOR_DVIEW so we don't check if random atoms are in turfs_in_range.

`get_mobs_and_objs_in_view_fast`:
- Renamed to get_listeners_in_range to better represent what it does.
- No longer returns objs that aren't in global.listening_objects; this is where most of the benefit is.
- Use assoc lists for the turf check; this is minor but does help.
- Adds holopad + replicator to listening_objects so that they still work after the above.

## Why and what will this PR improve

Situations where there's a lot of opaque turf changes will be significantly faster within proximity_trigger.

Situations where there's a lot of visible_messages will be somewhat faster, especially if there's a lot of non-listening objects nearby. Airflow shmack messages in particular benefit from this.

Basically: large explosions are a bit faster now. :)

Tested with a 10/20/30/40 explosion on tradeship bridge. Profile before changes:

```
                                                   Profile results (total time)
Proc Name                                                                           Self CPU    Total CPU    Real Time     Overtime        Calls
-------------------------------------------------------------------------------    ---------    ---------    ---------    ---------    ---------
/datum/proximity_trigger/proc/get_seen_turfs                                           0.703        0.703        0.738        0.251          204
...
/proc/get_mobs_and_objs_in_view_fast                                                   0.448        0.449       -1.084        0.174         1452
/atom/proc/visible_message                                                             0.299        0.832       -0.682        0.145         1421
...
```

After changes:
```
                                                   Profile results (total time)
Proc Name                                                                           Self CPU    Total CPU    Real Time     Overtime        Calls
-------------------------------------------------------------------------------    ---------    ---------    ---------    ---------    ---------
...
/proc/get_listeners_in_range                                                           0.254        0.254        0.268        0.103         1459
...
/datum/proximity_trigger/proc/get_seen_turfs                                           0.070        0.070        0.074        0.002          193
...
/atom/proc/visible_message                                                             0.018        0.275        0.289        0.009         1453
...
```

## Authorship
Just me.