### PR TITLE
Fixes Heart Attacks

### DIFF
--- a/code/modules/mob/living/human/human_organs.dm
+++ b/code/modules/mob/living/human/human_organs.dm
@@ -222,3 +222,15 @@
 	//Move some blood over to the organ
 	if(!BP_IS_PROSTHETIC(O) && O.species && O.reagents?.total_volume < 5)
 		vessel.trans_to(O, 5 - O.reagents.total_volume, 1, 1)
+
+
+/mob/living/human/is_asystole()
+	if(isSynthetic())
+		var/obj/item/organ/internal/cell/C = get_organ(BP_CELL, /obj/item/organ/internal/cell)
+		if(!C || !C.is_usable() || !C.percent())
+			return TRUE
+	else if(should_have_organ(BP_HEART))
+		var/obj/item/organ/internal/heart/heart = get_organ(BP_HEART, /obj/item/organ/internal/heart)
+		if(!istype(heart) || !heart.is_working())
+			return TRUE
+	return FALSE


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Re-adds human override for `is_asystole()` that was removed seemingly by accident in #3882 , which currently causes heart attacks to be permanent and making defibs not do anything useful.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
People undergoing cardiac arrest can now potentially be saved again. `is_asystole()` is also used in a few other places and it will accurately give an answer instead of always returning FALSE.

## Authorship
<!-- Describe original authors of changes to credit them. -->
Technically me even if I just brought back the old code as-is, just with correct pathing.