### PR TITLE
Fixes Exosuits Being Tossed Around on Shuttles

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -434,6 +434,8 @@ var/global/list/mob/living/forced_ambiance_list = new
 
 /area/proc/throw_unbuckled_occupant(var/mob/M, var/maxrange, var/speed, var/direction)
 	if(isliving(M))
+		if(M.anchored) // So mechs don't get tossed around.
+			return
 		if(M.buckled)
 			to_chat(M, SPAN_WARNING("Sudden acceleration presses you into your chair!"))
 			shake_camera(M, 3, 1)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Exosuits (and any other mob that happens to be anchored) will no longer be thrown around on a shuttle when it moves.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Giant mechs will no longer appear to weigh almost nothing, or freak out people when it starts bouncing off the walls.

## Authorship
<!-- Describe original authors of changes to credit them. -->
Me