### PR TITLE
Rig Jetpacks Start With Gas

### DIFF
--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -112,5 +112,6 @@
 /obj/item/tank/jetpack/rig
 	name = "integrated manuvering module thrusterpack"
 	desc = "The 'manuvering' part of a manuvering jet module for a hardsuit. You could... probably use this standalone?"
+	starting_pressure = list(/decl/material/gas/oxygen = 6 ATM)
 	var/obj/item/rig/holder
 


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Changes the internal jetpack of the RIG manuvering jets module to start with the same amount of gas as all of the other jetpacks instead of starting empty.
I decided to put oxygen inside since both the internal jetpack sprite and the manuvering module sprite are blue, just like the oxygen jetpacks.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Hardsuits with pre-installed parts are generally expected to be functional as-is and it will be consistent with standalone jetpacks coming pre-filled with gas.

## Authorship
<!-- Describe original authors of changes to credit them. -->
Me