### PR TITLE
Prevents unsimulated turfs from accumulating CO2 or losing oxygen.

### DIFF
--- a/code/modules/ZAS/Turf.dm
+++ b/code/modules/ZAS/Turf.dm
@@ -226,6 +226,10 @@
 /turf/return_air()
 	RETURN_TYPE(/datum/gas_mixture)
 
+	// TODO: immutable gas mixtures for stuff like this, to avoid creating new datums every time.
+	if(!simulated)
+		return make_air()
+
 	// ZAS participation
 	if(zone && !zone.invalid)
 		SSair.mark_zone_update(zone)
@@ -256,7 +260,7 @@
 	return FALSE
 
 /turf/proc/make_air()
-	air = new/datum/gas_mixture
+	air = new /datum/gas_mixture
 	air.temperature = temperature
 	if(initial_gas)
 		air.gas = initial_gas.Copy()


### PR DESCRIPTION
## Description of changes
Unsimulated turfs will now always return a fresh gas datum to return_air().

## Why and what will this PR improve
Currently standing on an unsimulated turf as a human causes CO2 to accumulate and oxygen to drop. This isn't desirable for unsimulated spaces like Centcomm.

## Authorship
Myself.

## Changelog
Nothing player-facing.