### PR TITLE
Fixes exoplanets not having any atmosphere

### DIFF
--- a/code/modules/maps/template_types/random_exoplanet/random_planet_level_data.dm
+++ b/code/modules/maps/template_types/random_exoplanet/random_planet_level_data.dm
@@ -82,11 +82,12 @@
 	//Rename the surface area if we have one yet
 	adapt_location_name(parent_planetoid.name)
 
-///If we're getting atmos from our parent planet, decide if we're going to apply it, or ignore it
+///If we're getting atmos from our parent planet, apply it.
 /datum/level_data/planetoid/proc/apply_planet_atmosphere(var/datum/planetoid_data/P)
-	if(istype(exterior_atmosphere))
-		return //level atmos takes priority over planet atmos
-	exterior_atmosphere = P.atmosphere.Clone() //Make sure we get one instance per level
+	if(istype(P) && istype(P.atmosphere))
+		exterior_atmosphere = P.atmosphere.Clone()
+		exterior_atmosphere.update_values()
+		exterior_atmosphere.check_tile_graphic()
 
 ///Apply our parent planet's ambient lighting settings if we want to.
 /datum/level_data/planetoid/proc/apply_planet_ambient_lighting(var/datum/planetoid_data/P)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Exoplanets currently always have vacuum instead of the atmosphere they're supposed to get.
This is because `/datum/level_data/proc/setup_exterior_atmosphere()` gets called first, and sets `exterior_atmosphere` to an empty gas mixture datum, and later on `/datum/level_data/planetoid/proc/apply_planet_atmosphere(var/datum/planetoid_data/P)` gets called, but doesn't do anything because `exterior_atmosphere` is already set, and thus the correct atmosphere held inside of `P.atmosphere` won't be applied.

I was told to just have `exterior_atmosphere` get overwritten regardless if it's set, since it seems that it was changed so it always gets set, so that's what this PR does.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Exoplanets will have atmospheres once again.

## Authorship
<!-- Describe original authors of changes to credit them. -->
Me
