### PR TITLE
Fix return values for attack, Initialize, and Destroy procs

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -108,6 +108,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	var/mob/living/attackee = null
 
 //I would prefer to rename this attack_as_weapon(), but that would involve touching hundreds of files.
+// If this returns TRUE, the interaction has been handled and other interactions like afterattack should be skipped.
 /obj/item/proc/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
 	// TODO: revisit if this should be a silent failure/parent call instead, for mob-level storage interactions?

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -24,11 +24,13 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	var/datum/extension/tool/tool = get_extension(src, /datum/extension/tool)
 	return (tool?.handle_physical_manipulation(user)) || FALSE
 
+// If TRUE, prevent afterattack from running.
 /obj/item/proc/resolve_attackby(atom/A, mob/user, var/click_params)
 	if(!(item_flags & ITEM_FLAG_NO_PRINT))
 		add_fingerprint(user)
 	return A.attackby(src, user, click_params)
 
+// If TRUE, prevent afterattack from running.
 /atom/proc/attackby(obj/item/used_item, mob/user, var/click_params)
 	if(storage)
 		if(isrobot(user) && (used_item == user.get_active_held_item()))
@@ -44,6 +46,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	if(!.)
 		return bash(W,user)
 
+// Return TRUE if further actions (afterattack, etc) should be prevented, FALSE if they can proceed.
 /atom/movable/proc/bash(obj/item/weapon, mob/user)
 	if(isliving(user) && user.a_intent == I_HELP)
 		return FALSE

--- a/code/datums/extensions/assembly/assembly_interaction.dm
+++ b/code/datums/extensions/assembly/assembly_interaction.dm
@@ -103,3 +103,4 @@
 
 	if(istype(W, /obj/item/stock_parts))
 		return try_install_component(user, W)
+	return FALSE

--- a/code/game/atoms_movable_overlay.dm
+++ b/code/game/atoms_movable_overlay.dm
@@ -42,6 +42,7 @@
 /atom/movable/overlay/attackby(obj/item/I, mob/user)
 	if (master)
 		return master.attackby(I, user)
+	return TRUE
 
 /atom/movable/overlay/attack_hand(mob/user)
 	SHOULD_CALL_PARENT(FALSE)

--- a/code/game/machinery/CableLayer.dm
+++ b/code/game/machinery/CableLayer.dm
@@ -34,7 +34,7 @@
 			to_chat(user, "<span class='warning'>\The [src]'s cable reel is full.</span>")
 		else
 			to_chat(user, "You load [result] lengths of cable into [src].")
-		return
+		return TRUE
 
 	if(IS_WIRECUTTER(O))
 		if(cable && cable.amount)
@@ -48,6 +48,8 @@
 				CC.amount = m
 		else
 			to_chat(usr, "<span class='warning'>There's no more cable on the reel.</span>")
+		return TRUE
+	return ..()
 
 /obj/machinery/cablelayer/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -48,7 +48,7 @@
 
 	if(stat & (NOPOWER|BROKEN))
 		to_chat(user, "<span class='warning'>You try to switch on the suppressor, yet nothing happens.</span>")
-		return
+		return TRUE
 
 	if(user != victim && !suppressing) // Skip checks if you're doing it to yourself or turning it off, this is an anti-griefing mechanic more than anything.
 		user.visible_message("<span class='warning'>\The [user] begins switching on \the [src]'s neural suppressor.</span>")

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -308,7 +308,7 @@
 		add_fingerprint(user)
 		if(!beaker)
 			if(!user.try_unequip(I, src))
-				return
+				return TRUE
 			beaker = I
 			user.visible_message(SPAN_NOTICE("\The [user] adds \a [I] to \the [src]."), SPAN_NOTICE("You add \a [I] to \the [src]."))
 		else

--- a/code/game/machinery/_machines_base/stock_parts/access_lock.dm
+++ b/code/game/machinery/_machines_base/stock_parts/access_lock.dm
@@ -61,8 +61,7 @@
 		if(I && check_access(I))
 			locked = !locked
 			visible_message(SPAN_NOTICE("\The [src] beeps and flashes green twice: it is now [locked ? "" : "un"]locked."))
-			return TRUE
-		return
+		return TRUE
 	return ..()
 
 /obj/item/stock_parts/access_lock/attack_self(mob/user)

--- a/code/game/machinery/_machines_base/stock_parts/power/battery.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/battery.dm
@@ -163,7 +163,7 @@
 			return TRUE
 
 		if(!user.try_unequip(I, src))
-			return
+			return TRUE
 		add_cell(machine, I)
 		user.visible_message(\
 			SPAN_WARNING("\The [user] has inserted the power cell to \the [src]!"),\
@@ -173,6 +173,7 @@
 	// Interactions without machine
 	if(!istype(machine))
 		return ..()
+	return FALSE
 
 /obj/item/stock_parts/power/battery/attack_self(mob/user)
 	if(cell)

--- a/code/game/machinery/_machines_base/stock_parts/power/terminal.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/terminal.dm
@@ -151,6 +151,7 @@
 					"You add cables to the \the [machine].")
 				make_terminal(machine)
 		return TRUE
+	return FALSE
 
 /obj/item/stock_parts/power/terminal/get_source_info()
 	. =  "The machine can receive power by direct connection to the powernet. "

--- a/code/game/machinery/ai_slipper.dm
+++ b/code/game/machinery/ai_slipper.dm
@@ -25,7 +25,7 @@
 
 /obj/machinery/ai_slipper/attackby(obj/item/W, mob/user)
 	if(stat & (NOPOWER|BROKEN))
-		return
+		return FALSE
 	if (issilicon(user))
 		return attack_ai(user)
 	else // trying to unlock the interface
@@ -41,6 +41,7 @@
 					interact(user)
 		else
 			to_chat(user, "<span class='warning'>Access denied.</span>")
+		return TRUE
 
 /obj/machinery/ai_slipper/interface_interact(mob/user)
 	interact(user)

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -185,16 +185,16 @@
 	if(IS_WRENCH(I))
 		if(use_power == POWER_USE_ACTIVE)
 			to_chat(user, "<span class='warning'>Turn \the [src] off first!</span>")
-			return
+			return TRUE
 
 		anchored = !anchored
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 		to_chat(user, "<span class='notice'>You [anchored ? "wrench" : "unwrench"] \the [src].</span>")
 
-		return
+		return TRUE
 	//doesn't hold tanks
 	if(istype(I, /obj/item/tank))
-		return
+		return FALSE
 
 	return ..()
 
@@ -206,6 +206,6 @@
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/attackby(var/obj/item/I, var/mob/user)
 	if(IS_WRENCH(I))
 		to_chat(user, "<span class='warning'>The bolts are too tight for you to unscrew!</span>")
-		return
+		return TRUE
 
 	return ..()

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -186,7 +186,7 @@
 
 /obj/machinery/camera/physical_attack_hand(mob/living/human/user)
 	if(!istype(user))
-		return
+		return TRUE
 	if(user.species.can_shred(user))
 		user.do_attack_animation(src)
 		visible_message(SPAN_WARNING("\The [user] slashes at [src]!"))
@@ -194,6 +194,7 @@
 		add_hiddenprint(user)
 		take_damage(25)
 		return TRUE
+	return FALSE
 
 /obj/machinery/camera/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/paper))

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -225,9 +225,7 @@ var/global/list/deactivated_ai_cores = list()
 	qdel(src)
 
 /obj/structure/aicore/deactivated/attackby(var/obj/item/W, var/mob/user)
-	if(IS_WRENCH(W) || IS_WELDER(W))
-		. = ..()
-	else if(istype(W, /obj/item/aicard))
+	if(istype(W, /obj/item/aicard))
 		var/obj/item/aicard/card = W
 		var/mob/living/silicon/ai/transfer = locate() in card
 		if(transfer)
@@ -235,6 +233,7 @@ var/global/list/deactivated_ai_cores = list()
 		else
 			to_chat(user, SPAN_DANGER("ERROR: Unable to locate artificial intelligence."))
 		return TRUE
+	return ..()
 
 /client/proc/empty_ai_core_toggle_latejoin()
 	set name = "Toggle AI Core Latejoin"

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -74,8 +74,8 @@
 			updateUsrDialog()
 		else if(giver)
 			to_chat(user, SPAN_WARNING("There is already ID card inside."))
-		return
-	..()
+		return TRUE
+	return ..()
 
 /obj/machinery/computer/guestpass/interface_interact(var/mob/user)
 	ui_interact(user)

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -8,8 +8,9 @@
 	if(istype(O, /obj/item/aiModule))
 		var/obj/item/aiModule/M = O
 		M.install(src, user)
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/machinery/computer/upload/ai
 	name = "\improper AI upload console"

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -40,16 +40,14 @@
 
 /obj/machinery/computer/message_monitor/attackby(obj/item/O, mob/user)
 	if(stat & (NOPOWER|BROKEN))
-		..()
-		return
+		return ..()
 	if(!istype(user))
-		return
+		return TRUE
 	if(IS_SCREWDRIVER(O) && emag)
 		//Stops people from just unscrewing the monitor and putting it back to get the console working again.
 		to_chat(user, "<span class='warning'>It is too hot to mess with!</span>")
-		return
-	..()
-	return
+		return TRUE
+	return ..()
 
 /obj/machinery/computer/message_monitor/emag_act(var/remaining_charges, var/mob/user)
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -523,22 +523,23 @@
 /obj/structure/broken_cryo/attackby(obj/item/W, mob/user)
 	if (busy)
 		to_chat(user, SPAN_NOTICE("Someone else is attempting to open this."))
-		return
-	if (closed)
-		if (IS_CROWBAR(W))
-			busy = 1
-			visible_message("[user] starts to pry the glass cover off of \the [src].")
-			if (!do_after(user, 50, src))
-				visible_message("[user] stops trying to pry the glass off of \the [src].")
-				busy = 0
-				return
-			closed = 0
-			busy = 0
-			icon_state = "broken_cryo_open"
-			var/obj/dead = new remains_type(loc)
-			dead.set_dir(dir) //skeleton is oriented as cryo
-	else
+		return TRUE
+	if (!closed)
 		to_chat(user, SPAN_NOTICE("The glass cover is already open."))
+		return TRUE
+	if (IS_CROWBAR(W))
+		busy = 1
+		visible_message("[user] starts to pry the glass cover off of \the [src].")
+		if (!do_after(user, 50, src))
+			visible_message("[user] stops trying to pry the glass off of \the [src].")
+			busy = 0
+			return TRUE
+		closed = 0
+		busy = 0
+		icon_state = "broken_cryo_open"
+		var/obj/dead = new remains_type(loc)
+		dead.set_dir(dir) //skeleton is oriented as cryo
+	return TRUE
 
 /obj/machinery/cryopod/proc/on_mob_spawn()
 	playsound(src, 'sound/machines/ding.ogg', 30, 1)

--- a/code/game/machinery/dehumidifier.dm
+++ b/code/game/machinery/dehumidifier.dm
@@ -62,6 +62,7 @@
 			SPAN_NOTICE("[user] switches [active ? "on" : "off"] \the [src]."),
 			SPAN_NOTICE("You switch [active ? "on" : "off"] \the [src]."))
 		return TRUE
+	return FALSE
 
 /obj/machinery/dehumidifier/Process()
 	if(!active)

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -28,15 +28,14 @@
 				src.icon_state = "barrier[src.locked]"
 				if ((src.locked == 1.0) && (src.emagged < 2.0))
 					to_chat(user, "Barrier lock toggled on.")
-					return
+					return TRUE
 				else if ((src.locked == 0.0) && (src.emagged < 2.0))
 					to_chat(user, "Barrier lock toggled off.")
-					return
+					return TRUE
 			else
 				spark_at(src, amount=2, cardinal_only = TRUE)
 				visible_message("<span class='warning'>BZZzZZzZZzZT</span>")
-				return
-		return
+				return TRUE
 	else if(IS_WRENCH(W))
 		var/current_max_health = get_max_health()
 		if (current_health < current_max_health)
@@ -44,13 +43,12 @@
 			emagged = 0
 			req_access = list(access_security)
 			visible_message("<span class='warning'>[user] repairs \the [src]!</span>")
-			return
+			return TRUE
 		else if (src.emagged > 0)
 			src.emagged = 0
 			src.req_access = list(access_security)
 			visible_message("<span class='warning'>[user] repairs \the [src]!</span>")
-			return
-		return
+			return TRUE
 	else
 		switch(W.atom_damage_type)
 			if(BURN)
@@ -59,7 +57,8 @@
 				current_health -= W.get_attack_force(user) * 0.5
 		if (current_health <= 0)
 			explode()
-		..()
+		return TRUE
+	return ..()
 
 /obj/machinery/deployable/barrier/explosion_act(severity)
 	. = ..()

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -157,16 +157,16 @@
 					to_chat(user, "<span class='warning'>You must remain still while working on \the [src].</span>")
 			else
 				to_chat(user, "<span class='notice'>[src]'s motors resist your effort.</span>")
-			return
+			return TRUE
 	if(istype(C, /obj/item/stack/material) && C.get_material_type() == /decl/material/solid/metal/plasteel)
 		var/amt = ceil((get_max_health() - current_health)/150)
 		if(!amt)
 			to_chat(user, "<span class='notice'>\The [src] is already fully functional.</span>")
-			return
+			return TRUE
 		var/obj/item/stack/P = C
 		if(!P.can_use(amt))
 			to_chat(user, "<span class='warning'>You don't have enough sheets to repair this! You need at least [amt] sheets.</span>")
-			return
+			return TRUE
 		to_chat(user, "<span class='notice'>You begin repairing \the [src]...</span>")
 		if(do_after(user, 5 SECONDS, src))
 			if(P.use(amt))
@@ -176,6 +176,7 @@
 				to_chat(user, "<span class='warning'>You don't have enough sheets to repair this! You need at least [amt] sheets.</span>")
 		else
 			to_chat(user, "<span class='warning'>You must remain still while working on \the [src].</span>")
+		return TRUE
 	return ..()
 
 // Proc: open()

--- a/code/game/machinery/doors/braces.dm
+++ b/code/game/machinery/doors/braces.dm
@@ -69,11 +69,9 @@
 	electronics.attack_self(user)
 
 /obj/item/airlock_brace/attackby(obj/item/W, mob/user)
-	..()
 	if (istype(W.GetIdCard(), /obj/item/card/id))
 		if(!airlock)
-			attack_self(user)
-			return
+			return attack_self(user)
 		else
 			var/obj/item/card/id/C = W.GetIdCard()
 			if(check_access(C))
@@ -83,23 +81,23 @@
 					unlock_brace(usr)
 			else
 				to_chat(user, "You swipe \the [C] through \the [src], but it does not react.")
-		return
+		return TRUE
 
 	if (istype(W, /obj/item/crowbar/brace_jack))
 		if(!airlock)
-			return
+			return FALSE
 		var/obj/item/crowbar/brace_jack/C = W
 		to_chat(user, "You begin forcibly removing \the [src] with \the [C].")
 		if(do_after(user, rand(150,300), airlock))
 			to_chat(user, "You finish removing \the [src].")
 			unlock_brace(user)
-		return
+		return TRUE
 
 	if(IS_WELDER(W))
 		var/obj/item/weldingtool/C = W
 		if(!is_damaged())
 			to_chat(user, "\The [src] does not require repairs.")
-			return
+			return TRUE
 		if(C.weld(0,user))
 			playsound(src, 'sound/items/Welder.ogg', 100, 1)
 			current_health = min(current_health + rand(20,30), get_max_health())
@@ -107,6 +105,8 @@
 				to_chat(user, "You repair some dents on \the [src]. It is in perfect condition now.")
 			else
 				to_chat(user, "You repair some dents on \the [src].")
+		return TRUE
+	return ..()
 
 
 /obj/item/airlock_brace/physically_destroyed(skip_qdel)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -219,23 +219,22 @@
 /obj/machinery/door/firedoor/attackby(obj/item/C, mob/user)
 	add_fingerprint(user, 0, C)
 	if(operating)
-		return//Already doing something.
+		return TRUE //Already doing something.
 	if(IS_WELDER(C) && !repairing)
 		var/obj/item/weldingtool/W = C
 		if(W.weld(0, user))
 			playsound(src, 'sound/items/Welder.ogg', 100, 1)
 			if(do_after(user, 2 SECONDS, src))
-				if(!W.isOn()) return
+				if(!W.isOn()) return TRUE
 				blocked = !blocked
 				user.visible_message("<span class='danger'>\The [user] [blocked ? "welds" : "unwelds"] \the [src] with \a [W].</span>",\
 				"You [blocked ? "weld" : "unweld"] \the [src] with \the [W].",\
 				"You hear something being welded.")
 				playsound(src, 'sound/items/Welder.ogg', 100, 1)
 				update_icon()
-				return TRUE
 			else
 				to_chat(user, SPAN_WARNING("You must remain still to complete this task."))
-				return TRUE
+		return TRUE
 
 	if(blocked && IS_CROWBAR(C))
 		user.visible_message("<span class='danger'>\The [user] pries at \the [src] with \a [C], but \the [src] is welded in place!</span>",\
@@ -255,7 +254,7 @@
 		user.visible_message("<span class='danger'>\The [user] starts to force \the [src] [density ? "open" : "closed"] with \a [C]!</span>",\
 				"You start forcing \the [src] [density ? "open" : "closed"] with \the [C]!",\
 				"You hear metal strain.")
-		if(do_after(user,30,src))
+		if(do_after(user, 3 SECONDS, src))
 			if(IS_CROWBAR(C))
 				if(stat & (BROKEN|NOPOWER) || !density)
 					user.visible_message("<span class='danger'>\The [user] forces \the [src] [density ? "open" : "closed"] with \a [C]!</span>",\

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -176,7 +176,7 @@
 /obj/machinery/door/window/attackby(obj/item/I, mob/user)
 	//If it's in the process of opening/closing, ignore the click
 	if(operating)
-		return
+		return TRUE
 
 	if(bash(I, user))
 		return TRUE
@@ -191,11 +191,13 @@
 		else
 			if (emagged)
 				to_chat(user, SPAN_WARNING("\The [src] seems to be stuck and refuses to close!"))
-				return
+				return TRUE
 			close()
+		return TRUE
 
 	else if (density)
 		flick("[base_state]deny", src)
+		return TRUE
 
 /obj/machinery/door/window/bash(obj/item/weapon, mob/user)
 	//Emags and energy swords? You may pass.

--- a/code/game/machinery/embedded_controller/airlock_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/airlock_docking_controller.dm
@@ -21,8 +21,9 @@
 		else
 			code = stars(code)
 		to_chat(user,"[W]'s screen displays '[code]'")
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/machinery/embedded_controller/radio/airlock/docking_port/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/nanoui/master_ui = null, var/datum/topic_state/state = global.default_topic_state)
 	var/data[0]

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -43,8 +43,9 @@
 			user.visible_message("<span class='warning'>[user] has disconnected \the [src]'s flashbulb!</span>", "<span class='warning'>You disconnect \the [src]'s flashbulb!</span>")
 		if (!src.disable)
 			user.visible_message("<span class='warning'>[user] has connected \the [src]'s flashbulb!</span>", "<span class='warning'>You connect \the [src]'s flashbulb!</span>")
+		return TRUE
 	else
-		..()
+		return ..()
 
 //Let the AI trigger them directly.
 /obj/machinery/flasher/attack_ai()
@@ -134,6 +135,8 @@
 		else if (src.anchored)
 			user.show_message(text("<span class='warning'>[src] is now secured.</span>"))
 			src.overlays += "[base_state]-s"
+		return TRUE
+	return ..()
 
 /obj/machinery/button/flasher
 	name = "flasher button"

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -75,6 +75,7 @@ var/global/list/floor_light_cache = list()
 			if(isnull(damaged))
 				damaged = 0
 		return TRUE
+	return FALSE
 
 /obj/machinery/floor_light/interface_interact(var/mob/user)
 	if(!CanInteract(user, DefaultTopicState()))

--- a/code/game/machinery/floorlayer.dm
+++ b/code/game/machinery/floorlayer.dm
@@ -42,14 +42,14 @@
 		mode[m] = !mode[m]
 		var/O = mode[m]
 		user.visible_message("<span class='notice'>[usr] has set \the [src] [m] mode [!O?"off":"on"].</span>", "<span class='notice'>You set \the [src] [m] mode [!O?"off":"on"].</span>")
-		return
+		return TRUE
 
 	if(istype(W, /obj/item/stack/tile))
 		if(!user.try_unequip(W, T))
-			return
+			return TRUE
 		to_chat(user, "<span class='notice'>\The [W] successfully loaded.</span>")
 		TakeTile(T)
-		return
+		return TRUE
 
 	if(IS_CROWBAR(W))
 		if(!length(contents))
@@ -60,12 +60,12 @@
 				to_chat(user, "<span class='notice'>You remove \the [E] from \the [src].</span>")
 				E.dropInto(loc)
 				T = null
-		return
+		return TRUE
 
 	if(IS_SCREWDRIVER(W))
 		T = input("Choose tile type.", "Tiles") as null|anything in contents
-		return
-	..()
+		return TRUE
+	return ..()
 
 /obj/machinery/floorlayer/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -128,8 +128,9 @@
 		else if(!disable)
 			user.visible_message("<span class='warning'>[user] has reconnected \the [src]!</span>", "<span class='warning'>You fix the connection to \the [src].</span>")
 		update_icon()
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/machinery/sparker/attack_ai()
 	if (anchored)

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -157,7 +157,7 @@
 		add_fingerprint(user)
 		wrench_floor_bolts(user, 0, W)
 		power_change()
-		return
+		return TRUE
 	return ..()
 
 /obj/machinery/media/jukebox/emag_act(var/remaining_charges, var/mob/user)

--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -70,29 +70,29 @@
 
 	if(cooking)
 		to_chat(user, "<span class='warning'>\The [src] is running!</span>")
-		return
+		return TRUE
 
 	if((. = component_attackby(I, user)))
 		return
 
 	if(!cook_type || (stat & (NOPOWER|BROKEN)))
 		to_chat(user, "<span class='warning'>\The [src] is not working.</span>")
-		return
+		return TRUE
 
 	// We're trying to cook something else. Check if it's valid.
 	var/obj/item/food/check = I
 	if(istype(check) && islist(check.cooked) && (cook_type in check.cooked))
 		to_chat(user, "<span class='warning'>\The [check] has already been [cook_type].</span>")
-		return 0
+		return TRUE
 	else if(istype(check, /obj/item/chems/glass))
 		to_chat(user, "<span class='warning'>That would probably break [src].</span>")
-		return 0
+		return TRUE
 	else if(istype(check, /obj/item/disk/nuclear))
 		to_chat(user, "Central Command would kill you if you [cook_type] that.")
-		return 0
+		return TRUE
 	else if(!istype(check) && !istype(check, /obj/item/holder))
 		to_chat(user, "<span class='warning'>That's not edible.</span>")
-		return 0
+		return TRUE
 
 	// Gotta hurt.
 	if(istype(cooking_obj, /obj/item/holder))
@@ -101,7 +101,7 @@
 
 	// Not sure why a food item that passed the previous checks would fail to drop, but safety first.
 	if(!user.try_unequip(I))
-		return
+		return TRUE
 
 	// We can actually start cooking now.
 	user.visible_message("<span class='notice'>\The [user] puts \the [I] into \the [src].</span>")
@@ -115,7 +115,7 @@
 
 	// Sanity checks.
 	if(check_cooking_obj())
-		return // Cooking failed/was terminated.
+		return TRUE // Cooking failed/was terminated.
 
 	// RIP slow-moving held mobs.
 	if(istype(cooking_obj, /obj/item/holder))
@@ -183,6 +183,7 @@
 				cooking = 0
 				icon_state = off_icon
 				break
+	return TRUE
 
 /obj/machinery/cooker/proc/check_cooking_obj()
 	if(!cooking_obj || cooking_obj.loc != src)

--- a/code/game/machinery/kitchen/icecream.dm
+++ b/code/game/machinery/kitchen/icecream.dm
@@ -132,11 +132,11 @@
 				to_chat(user, "<span class='warning'>There is not enough icecream left!</span>")
 		else
 			to_chat(user, "<span class='notice'>[O] already has icecream in it.</span>")
-		return 1
+		return TRUE
 	else if(ATOM_IS_OPEN_CONTAINER(O))
-		return
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/machinery/icecream_vat/proc/make(var/mob/user, var/make_type, var/amount)
 	for(var/R in get_ingredient_list(make_type))

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -187,7 +187,7 @@
 /obj/machinery/smartfridge/attackby(var/obj/item/O, var/mob/user)
 	if(accept_check(O))
 		if(!user.try_unequip(O))
-			return
+			return TRUE
 		stock_item(O)
 		user.visible_message("<span class='notice'>\The [user] has added \the [O] to \the [src].</span>", "<span class='notice'>You add \the [O] to \the [src].</span>")
 		update_icon()

--- a/code/game/machinery/message_server.dm
+++ b/code/game/machinery/message_server.dm
@@ -140,7 +140,8 @@ var/global/list/message_servers = list()
 		istype(O,/obj/item/stock_parts/circuitboard/message_monitor))
 		spamfilter_limit += round(MESSAGE_SERVER_DEFAULT_SPAM_LIMIT / 2)
 		qdel(O)
-		to_chat(user, "You install additional memory and processors into message server. Its filtering capabilities been enhanced.")
+		to_chat(user, "You install additional memory and processors into \the [src]. Its filtering capabilities been enhanced.")
+		return TRUE
 	else
 		return ..()
 

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -44,14 +44,13 @@ var/global/list/navbeacons = list()
 /obj/machinery/navbeacon/attackby(var/obj/item/I, var/mob/user)
 	var/turf/T = loc
 	if(!T.is_plating())
-		return		// prevent intraction when T-scanner revealed
+		return TRUE // prevent intraction when T-scanner revealed
 
 	if(IS_SCREWDRIVER(I))
 		open = !open
-
 		user.visible_message("\The [user] [open ? "opens" : "closes"] cover of \the [src].", "You [open ? "open" : "close"] cover of \the [src].")
-
 		update_icon()
+		return TRUE
 
 	else if(I.GetIdCard())
 		if(open)
@@ -63,7 +62,8 @@ var/global/list/navbeacons = list()
 			updateDialog()
 		else
 			to_chat(user, "You must open the cover first!")
-	return
+		return TRUE
+	return FALSE
 
 /obj/machinery/navbeacon/interface_interact(var/mob/user)
 	interact(user)

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -874,21 +874,19 @@ var/global/list/allCasters = list() //Global list that will contain reference to
 		if(src.scribble_page == src.curr_page)
 			to_chat(user, SPAN_WARNING("There's already a scribble in this page... You wouldn't want to make things too cluttered, would you?"))
 			return TRUE
-		else
-			var/s = input(user, "Write something", "Newspaper") as null | message
-			if(!length(s))
-				return
-			if(!CanPhysicallyInteractWith(user, src))
-				to_chat(user, SPAN_WARNING("You must stay close to \the [src]!"))
-				return
-			if(W.do_tool_interaction(TOOL_PEN, user, src, 0, fuel_expenditure = 1) && !QDELETED(src)) //Make it instant, since handle_writing_literacy does the waiting
-				s = sanitize(s)
-				s = user.handle_writing_literacy(user, s)
-				src.scribble_page = src.curr_page
-				src.scribble = s
-				src.attack_self(user)
-				return TRUE
-			return
+		var/s = input(user, "Write something", "Newspaper") as null | message
+		if(!length(s))
+			return TRUE
+		if(!CanPhysicallyInteractWith(user, src))
+			to_chat(user, SPAN_WARNING("You must stay close to \the [src]!"))
+			return TRUE
+		if(W.do_tool_interaction(TOOL_PEN, user, src, 0, fuel_expenditure = 1) && !QDELETED(src)) //Make it instant, since handle_writing_literacy does the waiting
+			s = sanitize(s)
+			s = user.handle_writing_literacy(user, s)
+			src.scribble_page = src.curr_page
+			src.scribble = s
+			src.attack_self(user)
+		return TRUE
 	return ..()
 
 ////////////////////////////////////helper procs

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -67,7 +67,7 @@ var/global/bomb_set
 				to_chat(user, "You screw the control panel of \the [src] back on.")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 			flick("lock", src)
-		return
+		return TRUE
 
 	if(panel_open && (IS_MULTITOOL(O) || IS_WIRECUTTER(O)))
 		return attack_hand_with_interaction_checks(user)
@@ -75,7 +75,7 @@ var/global/bomb_set
 	if(extended)
 		if(istype(O, /obj/item/disk/nuclear))
 			if(!user.try_unequip(O, src))
-				return
+				return TRUE
 			auth = O
 			add_fingerprint(user)
 			return attack_hand_with_interaction_checks(user)
@@ -85,66 +85,67 @@ var/global/bomb_set
 			if(0)
 				if(IS_WELDER(O))
 					var/obj/item/weldingtool/WT = O
-					if(!WT.isOn()) return
+					if(!WT.isOn()) return TRUE
 					if(WT.get_fuel() < 5) // uses up 5 fuel.
 						to_chat(user, "<span class='warning'>You need more fuel to complete this task.</span>")
-						return
+						return TRUE
 
 					user.visible_message("[user] starts cutting loose the anchoring bolt covers on [src].", "You start cutting loose the anchoring bolt covers with [O]...")
 
-					if(do_after(user,40, src))
-						if(!src || !user || !WT.weld(5, user)) return
+					if(do_after(user, 4 SECONDS, src))
+						if(QDELETED(src) || QDELETED(user) || !WT.weld(5, user)) return TRUE
 						user.visible_message("\The [user] cuts through the bolt covers on \the [src].", "You cut through the bolt cover.")
 						removal_stage = 1
-				return
+				return TRUE
 
 			if(1)
 				if(IS_CROWBAR(O))
 					user.visible_message("[user] starts forcing open the bolt covers on [src].", "You start forcing open the anchoring bolt covers with [O]...")
 
-					if(do_after(user, 15, src))
-						if(!src || !user) return
+					if(do_after(user, 1.5 SECONDS, src))
+						if(QDELETED(src) || QDELETED(user)) return TRUE
 						user.visible_message("\The [user] forces open the bolt covers on \the [src].", "You force open the bolt covers.")
 						removal_stage = 2
-				return
+				return TRUE
 
 			if(2)
 				if(IS_WELDER(O))
 					var/obj/item/weldingtool/WT = O
-					if(!WT.isOn()) return
+					if(!WT.isOn()) return TRUE
 					if (WT.get_fuel() < 5) // uses up 5 fuel.
 						to_chat(user, "<span class='warning'>You need more fuel to complete this task.</span>")
-						return
+						return TRUE
 
 					user.visible_message("[user] starts cutting apart the anchoring system sealant on [src].", "You start cutting apart the anchoring system's sealant with [O]...")
 
-					if(do_after(user, 40, src))
-						if(!src || !user || !WT.weld(5, user)) return
+					if(do_after(user, 4 SECONDS, src))
+						if(QDELETED(src) || QDELETED(user) || !WT.weld(5, user)) return TRUE
 						user.visible_message("\The [user] cuts apart the anchoring system sealant on \the [src].", "You cut apart the anchoring system's sealant.")
 						removal_stage = 3
-				return
+				return TRUE
 
 			if(3)
 				if(IS_WRENCH(O))
 					user.visible_message("[user] begins unwrenching the anchoring bolts on [src].", "You begin unwrenching the anchoring bolts...")
-					if(do_after(user, 50, src))
-						if(!src || !user) return
+					if(do_after(user, 5 SECONDS, src))
+						if(QDELETED(src) || QDELETED(user)) return TRUE
 						user.visible_message("[user] unwrenches the anchoring bolts on [src].", "You unwrench the anchoring bolts.")
 						removal_stage = 4
-				return
+				return TRUE
 
 			if(4)
 				if(IS_CROWBAR(O))
 					user.visible_message("[user] begins lifting [src] off of the anchors.", "You begin lifting the device off the anchors...")
-					if(do_after(user, 80, src))
-						if(!src || !user) return
+					if(do_after(user, 8 SECONDS, src))
+						if(QDELETED(src) || QDELETED(user)) return TRUE
 						user.visible_message("\The [user] crowbars \the [src] off of the anchors. It can now be moved.", "You jam the crowbar under the nuclear device and lift it off its anchors. You can now move it!")
 						anchored = FALSE
 						removal_stage = 5
-				return
-	..()
+				return TRUE
+	return ..()
 
 /obj/machinery/nuclearbomb/physical_attack_hand(mob/user)
+	. = FALSE
 	if(!extended && deployable)
 		. = TRUE
 		if(removal_stage < 5)
@@ -469,8 +470,7 @@ var/global/bomb_set
 		inserters += ch
 
 /obj/machinery/nuclearbomb/station/attackby(obj/item/O, mob/user)
-	if(IS_WRENCH(O))
-		return
+	return TRUE // cannot be moved
 
 /obj/machinery/nuclearbomb/station/Topic(href, href_list)
 	if((. = ..()))

--- a/code/game/machinery/oxygen_pump.dm
+++ b/code/game/machinery/oxygen_pump.dm
@@ -62,6 +62,7 @@
 	if(breather)
 		detach_mask(user)
 		return TRUE
+	return FALSE
 
 /obj/machinery/oxygen_pump/interface_interact(mob/user)
 	ui_interact(user)
@@ -143,18 +144,21 @@
 			icon_state = icon_state_open
 		if(!stat)
 			icon_state = icon_state_closed
-		//TO-DO: Open icon
+		return TRUE
 	if(istype(W, /obj/item/tank) && (stat & MAINT))
 		if(tank)
 			to_chat(user, SPAN_WARNING("\The [src] already has a tank installed!"))
-		else
-			if(!user.try_unequip(W, src))
-				return
-			tank = W
-			user.visible_message(SPAN_NOTICE("\The [user] installs \the [tank] into \the [src]."), SPAN_NOTICE("You install \the [tank] into \the [src]."))
-			src.add_fingerprint(user)
+			return TRUE
+		if(!user.try_unequip(W, src))
+			return TRUE
+		tank = W
+		user.visible_message(SPAN_NOTICE("\The [user] installs \the [tank] into \the [src]."), SPAN_NOTICE("You install \the [tank] into \the [src]."))
+		src.add_fingerprint(user)
+		return TRUE
 	if(istype(W, /obj/item/tank) && !stat)
 		to_chat(user, SPAN_WARNING("Please open the maintenance hatch first."))
+		return TRUE
+	return FALSE // TODO: should this be a parent call? do we want this to be (de)constructable?
 
 /obj/machinery/oxygen_pump/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -134,6 +134,7 @@ Buildable meters
 	playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
 	to_chat(user, "<span class='notice'>You have fastened \the [src].</span>")
 	qdel(src)
+	return TRUE
 
 /obj/item/machine_chassis/air_sensor
 	name = "gas sensor"

--- a/code/game/machinery/pipe/pipelayer.dm
+++ b/code/game/machinery/pipe/pipelayer.dm
@@ -45,12 +45,12 @@
 		P_type_t = input("Choose pipe type", "Pipe type") as null|anything in Pipes
 		P_type = Pipes[P_type_t]
 		user.visible_message("<span class='notice'>[user] has set \the [src] to manufacture [P_type_t].</span>", "<span class='notice'>You set \the [src] to manufacture [P_type_t].</span>")
-		return
+		return TRUE
 
 	if(IS_CROWBAR(W))
 		a_dis=!a_dis
 		user.visible_message("<span class='notice'>[user] has [!a_dis?"de":""]activated auto-dismantling.</span>", "<span class='notice'>You [!a_dis?"de":""]activate auto-dismantling.</span>")
-		return
+		return TRUE
 
 	if(istype(W, /obj/item/stack/material) && W.get_material_type() == /decl/material/solid/metal/steel)
 
@@ -62,7 +62,7 @@
 		else
 			user.visible_message("<span class='notice'>[user] has loaded metal into \the [src].</span>", "<span class='notice'>You load metal into \the [src]</span>")
 
-		return
+		return TRUE
 
 	if(IS_SCREWDRIVER(W))
 		if(metal)
@@ -76,8 +76,8 @@
 				user.visible_message("<span class='notice'>[user] removes [m] sheet\s of metal from the \the [src].</span>", "<span class='notice'>You remove [m] sheet\s of metal from \the [src]</span>")
 		else
 			to_chat(user, "\The [src] is empty.")
-		return
-	..()
+		return TRUE
+	return ..()
 
 /obj/machinery/pipelayer/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -71,6 +71,7 @@
 		charging = null
 		update_icon()
 		return TRUE
+	return FALSE
 
 /obj/machinery/recharger/Process()
 	if(stat & (NOPOWER|BROKEN) || !anchored)

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -208,26 +208,29 @@ var/global/req_console_information = list()
 
 /obj/machinery/network/requests_console/attackby(var/obj/item/O, var/mob/user)
 	if (istype(O, /obj/item/card/id))
-		if(inoperable(MAINT)) return
-		if(screen == RCS_MESSAUTH)
-			var/obj/item/card/id/T = O
-			msgVerified = text("<font color='green'><b>Verified by [T.registered_name] ([T.assignment])</b></font>")
-			SSnano.update_uis(src)
-		if(screen == RCS_ANNOUNCE)
-			var/obj/item/card/id/ID = O
-			if (access_RC_announce in ID.GetAccess())
-				announceAuth = 1
-				announcement.announcer = ID.assignment ? "[ID.assignment] [ID.registered_name]" : ID.registered_name
-			else
-				reset_message()
-				to_chat(user, "<span class='warning'>You are not authorized to send announcements.</span>")
-			SSnano.update_uis(src)
+		if(inoperable(MAINT)) return TRUE
+		switch(screen)
+			if(RCS_MESSAUTH)
+				var/obj/item/card/id/T = O
+				msgVerified = text("<font color='green'><b>Verified by [T.registered_name] ([T.assignment])</b></font>")
+				SSnano.update_uis(src)
+			if(RCS_ANNOUNCE)
+				var/obj/item/card/id/ID = O
+				if (access_RC_announce in ID.GetAccess())
+					announceAuth = 1
+					announcement.announcer = ID.assignment ? "[ID.assignment] [ID.registered_name]" : ID.registered_name
+				else
+					reset_message()
+					to_chat(user, "<span class='warning'>You are not authorized to send announcements.</span>")
+				SSnano.update_uis(src)
+		return TRUE
 	if (istype(O, /obj/item/stamp))
-		if(inoperable(MAINT)) return
+		if(inoperable(MAINT)) return TRUE
 		if(screen == RCS_MESSAUTH)
 			var/obj/item/stamp/T = O
 			msgStamped = "<font color='blue'><b>Stamped with the [T.name]</b></font>"
 			SSnano.update_uis(src)
+		return TRUE
 	return ..()
 
 /obj/machinery/network/requests_console/proc/reset_message(var/mainmenu = 0)

--- a/code/game/machinery/self_destruct.dm
+++ b/code/game/machinery/self_destruct.dm
@@ -11,33 +11,35 @@
 
 /obj/machinery/self_destruct/attackby(obj/item/W, mob/user)
 	if(IS_WELDER(W))
-		if(damaged)
-			user.visible_message("[user] begins to repair [src].", "You begin repairing [src].")
-			if(do_after(usr, 100, src))
-				var/obj/item/weldingtool/w = W
-				if(w.weld(10))
-					damaged = 0
-					user.visible_message("[user] repairs [src].", "You repair [src].")
-				else
-					to_chat(user, "<span class='warning'>There is not enough fuel to repair [src].</span>")
-				return
+		if(!damaged)
+			return FALSE
+		user.visible_message("[user] begins to repair [src].", "You begin repairing [src].")
+		if(do_after(usr, 100, src))
+			var/obj/item/weldingtool/w = W
+			if(w.weld(10))
+				damaged = 0
+				user.visible_message("[user] repairs [src].", "You repair [src].")
+			else
+				to_chat(user, "<span class='warning'>There is not enough fuel to repair [src].</span>")
+		return TRUE
 	if(istype(W, /obj/item/nuclear_cylinder))
 		if(damaged)
 			to_chat(user, "<span class='warning'>[src] is damaged, you cannot place the cylinder.</span>")
-			return
+			return TRUE
 		if(cylinder)
 			to_chat(user, "There is already a cylinder here.")
-			return
-		user.visible_message("[user] begins to carefully place [W] onto the Inserter.", "You begin to carefully place [W] onto the Inserter.")
+			return TRUE
+		user.visible_message("[user] begins to carefully place [W] onto [src].", "You begin to carefully place [W] onto [src].")
 		if(do_after(user, 80, src) && user.try_unequip(W, src))
 			cylinder = W
 			density = TRUE
-			user.visible_message("[user] places [W] onto the Inserter.", "You place [W] onto the Inserter.")
+			user.visible_message("[user] places [W] onto [src].", "You place [W] onto [src].")
 			update_icon()
-			return
-	..()
+		return TRUE
+	return ..()
 
 /obj/machinery/self_destruct/physical_attack_hand(mob/user)
+	. = FALSE
 	if(cylinder)
 		. = TRUE
 		if(armed)

--- a/code/game/machinery/self_destruct_storage.dm
+++ b/code/game/machinery/self_destruct_storage.dm
@@ -65,15 +65,6 @@
 
 /obj/machinery/nuclear_cylinder_storage/physical_attack_hand(mob/user)
 	if(!panel_open)
-		if(operable() && locked && check_access(user))
-			locked = FALSE
-			user.visible_message(
-				"\The [user] unlocks \the [src].",
-				"You unlock \the [src]."
-			)
-			update_icon()
-			return TRUE
-
 		if(!locked)
 			open = !open
 			user.visible_message(
@@ -82,14 +73,24 @@
 			)
 			update_icon()
 			return TRUE
+		if(operable() && check_access(user))
+			locked = FALSE
+			user.visible_message(
+				"\The [user] unlocks \the [src].",
+				"You unlock \the [src]."
+			)
+			update_icon()
+			return TRUE
 	else
 		to_chat(user, SPAN_WARNING("\The [src] is currently in maintenance mode!"))
+		return TRUE
+	return FALSE
 
 /obj/machinery/nuclear_cylinder_storage/attackby(obj/item/O, mob/user)
 	if(!open && operable() && istype(O, /obj/item/card/id))
 		if(panel_open)
 			to_chat(user, SPAN_WARNING("\The [src] is currently in maintenance mode!"))
-			return
+			return TRUE
 
 		var/obj/item/card/id/id = O
 		if(check_access(id))
@@ -99,12 +100,12 @@
 				"You [locked ? "lock" : "unlock"] \the [src]."
 			)
 			update_icon()
-		return
+		return TRUE
 
 	if(open && istype(O, /obj/item/nuclear_cylinder) && (length(cylinders) < max_cylinders))
 		if(panel_open)
 			to_chat(user, SPAN_WARNING("\The [src] is currently in maintenance mode!"))
-			return
+			return TRUE
 
 		user.visible_message(
 			"\The [user] begins inserting \the [O] into storage.",
@@ -117,8 +118,9 @@
 			)
 			cylinders.Add(O)
 			update_icon()
+		return TRUE
 
-	..()
+	return ..()
 
 /obj/machinery/nuclear_cylinder_storage/handle_mouse_drop(atom/over, mob/user, params)
 	if(over == user && open && !panel_open && length(cylinders))

--- a/code/game/machinery/singularitybeacon.dm
+++ b/code/game/machinery/singularitybeacon.dm
@@ -58,18 +58,15 @@ var/global/list/singularity_beacons = list()
 	if(IS_SCREWDRIVER(W))
 		if(use_power)
 			to_chat(user, SPAN_DANGER("You need to deactivate the beacon first!"))
-			return
+			return TRUE
 
+		anchored = !anchored
 		if(anchored)
-			anchored = FALSE
-			to_chat(user, SPAN_NOTICE("You unscrew the beacon from the floor."))
-			return
-		else
-			anchored = TRUE
 			to_chat(user, SPAN_NOTICE("You screw the beacon to the floor."))
-			return
-	..()
-	return
+		else
+			to_chat(user, SPAN_NOTICE("You unscrew the beacon from the floor."))
+		return TRUE
+	return ..()
 
 // Ensure the terminal is always accessible to be plugged in.
 /obj/machinery/singularity_beacon/components_are_accessible(var/path)

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -91,6 +91,7 @@
 		user.visible_message("<span class='notice'>[user] switches [on ? "on" : "off"] \the [src].</span>","<span class='notice'>You switch [on ? "on" : "off"] \the [src].</span>")
 		update_icon()
 		return TRUE
+	return FALSE
 
 /obj/machinery/space_heater/Topic(href, href_list, state = global.physical_topic_state)
 	if (..())

--- a/code/game/machinery/suit_cycler.dm
+++ b/code/game/machinery/suit_cycler.dm
@@ -209,12 +209,12 @@
 	if(istype(I, /obj/item/clothing/shoes/magboots))
 		if(locked)
 			to_chat(user, SPAN_WARNING("The suit cycler is locked."))
-			return
+			return TRUE
 		if(boots)
 			to_chat(user, SPAN_WARNING("The cycler already contains some boots."))
-			return
+			return TRUE
 		if(!user.try_unequip(I, src))
-			return
+			return TRUE
 		to_chat(user, "You fit \the [I] into the suit cycler.")
 		set_boots(I)
 		update_icon()

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -86,7 +86,7 @@
 
 /obj/machinery/turretid/attackby(obj/item/W, mob/user)
 	if(stat & BROKEN)
-		return
+		return FALSE
 
 	if(istype(W, /obj/item/card/id)||istype(W, /obj/item/modular_computer))
 		if(src.allowed(usr))
@@ -95,7 +95,7 @@
 			else
 				locked = !locked
 				to_chat(user, "<span class='notice'>You [ locked ? "lock" : "unlock"] the panel.</span>")
-		return
+		return TRUE
 	return ..()
 
 /obj/machinery/turretid/emag_act(var/remaining_charges, var/mob/user)

--- a/code/game/machinery/turrets/_turrets.dm
+++ b/code/game/machinery/turrets/_turrets.dm
@@ -133,20 +133,18 @@
 	update_use_power(POWER_USE_IDLE)
 
 /obj/machinery/turret/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/gun))
-		if(!installed_gun)
-			if(!user.try_unequip(I, src))
-				return
-			to_chat(user, SPAN_NOTICE("You install \the [I] into \the [src]!"))
-			installed_gun = I
-			setup_gun()
-			return
+	if(istype(I, /obj/item/gun) && !installed_gun)
+		if(!user.try_unequip(I, src))
+			return TRUE
+		to_chat(user, SPAN_NOTICE("You install \the [I] into \the [src]!"))
+		installed_gun = I
+		setup_gun()
+		return TRUE
 
 	if(istype(I, /obj/item/ammo_magazine) || istype(I, /obj/item/ammo_casing))
 		var/obj/item/stock_parts/ammo_box/ammo_box = get_component_of_type(/obj/item/stock_parts/ammo_box)
 		if(istype(ammo_box))
-			ammo_box.attackby(I, user)
-			return
+			return ammo_box.attackby(I, user)
 	. = ..()
 
 // This is called after the gun gets instantiated or slotted in.

--- a/code/game/machinery/vending/_vending.dm
+++ b/code/game/machinery/vending/_vending.dm
@@ -251,6 +251,7 @@
 	if(seconds_electrified != 0)
 		if(shock(user, 100))
 			return TRUE
+	return FALSE
 
 /obj/machinery/vending/interface_interact(mob/user)
 	ui_interact(user)

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -292,7 +292,8 @@
 	if(.)
 		M = build_machine_type
 		to_chat(user, SPAN_NOTICE("You setup \the [src]'s software to work as a '[initial(M.name)]', using \the [W]."))
-		return .
+		return TRUE
+	return FALSE
 
 /obj/item/frame/button/airlock_controller/kit
 	fully_construct = TRUE
@@ -321,7 +322,7 @@
 	var/choice = input(user, "Chose the type of controller to build:", "Select Controller Type") as null|anything in possible_kit_type_names
 	if(!choice || !CanPhysicallyInteract(user))
 		build_machine_type = initial(build_machine_type)
-		return
+		return TRUE
 	build_machine_type = possible_kit_type_names[choice]
 	M = build_machine_type
 	to_chat(user, SPAN_NOTICE("You set the kit type to '[initial(M.name)]'!"))

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -97,12 +97,12 @@
 	if(istype(W, /obj/item/chems/pill/detergent))
 		if(!(atom_flags & ATOM_FLAG_OPEN_CONTAINER))
 			to_chat(user, SPAN_WARNING("Open the detergent port first!"))
-			return
+			return TRUE
 		if(reagents.total_volume >= reagents.maximum_volume)
 			to_chat(user, SPAN_WARNING("The detergent port is full!"))
-			return
+			return TRUE
 		if(!user.try_unequip(W))
-			return
+			return TRUE
 		// Directly transfer to the holder to avoid touch reactions.
 		W.reagents?.trans_to_holder(reagents, W.reagents.total_volume)
 		to_chat(user, SPAN_NOTICE("You dissolve \the [W] in the detergent port."))
@@ -131,14 +131,14 @@
 			else if((!length(wash_whitelist) || is_type_in_list(W, wash_whitelist)) && !is_type_in_list(W, wash_blacklist))
 				if(W.w_class > max_item_size)
 					to_chat(user, SPAN_WARNING("\The [W] is too large for \the [src]!"))
-					return
+					return TRUE
 				if(!user.try_unequip(W, src))
-					return
+					return TRUE
 				state |= WASHER_STATE_LOADED
 				update_icon()
 			else
 				to_chat(user, SPAN_WARNING("You can't put \the [W] in \the [src]."))
-				return
+				return TRUE
 		else
 			to_chat(user, SPAN_NOTICE("\The [src] is full."))
 			return TRUE

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -55,6 +55,7 @@
 
 	current_health -= damage
 	healthcheck()
+	return TRUE
 
 /obj/effect/spider/bullet_act(var/obj/item/projectile/Proj)
 	..()
@@ -194,7 +195,7 @@
 	. = ..()
 
 /obj/effect/spider/spiderling/attackby(var/obj/item/W, var/mob/user)
-	..()
+	. = ..()
 	if(current_health > 0)
 		disturbed()
 

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -1035,7 +1035,7 @@ modules/mob/living/human/life.dm if you die, you will be zoomed out.
 		LAZYADD(., slot_belt_str)
 
 // Updates the icons of the mob wearing the clothing item, if any.
-/obj/item/proc/update_clothing_icon()
+/obj/item/proc/update_clothing_icon(do_update_icon = TRUE)
 	var/mob/wearer = loc
 	if(!istype(wearer))
 		return FALSE
@@ -1044,7 +1044,8 @@ modules/mob/living/human/life.dm if you die, you will be zoomed out.
 		return FALSE
 	for(var/slot in equip_slots)
 		wearer.update_equipment_overlay(slot, FALSE)
-	wearer.update_icon()
+	if(do_update_icon)
+		wearer.update_icon()
 	return TRUE
 
 /obj/item/proc/reconsider_client_screen_presence(var/client/client, var/slot)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -58,7 +58,7 @@
 
 /obj/structure/closet/body_bag/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/hand_labeler))
-		return //Prevent the labeler from opening the bag when trying to apply a label
+		return FALSE //Prevent the labeler from opening the bag when trying to apply a label
 	. = ..()
 
 /obj/structure/closet/body_bag/store_mobs(var/stored_units)

--- a/code/game/objects/items/devices/hacktool.dm
+++ b/code/game/objects/items/devices/hacktool.dm
@@ -27,8 +27,9 @@
 	if(IS_SCREWDRIVER(W))
 		in_hack_mode = !in_hack_mode
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/item/multitool/hacktool/resolve_attackby(atom/A, mob/user)
 	sanity_check()

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -82,20 +82,20 @@
 		return TOPIC_HANDLED
 
 /obj/item/holowarrant/attackby(obj/item/W, mob/user)
-	if(active)
-		var/obj/item/card/id/I = W.GetIdCard()
-		if(I && check_access_list(I.GetAccess()))
-			var/choice = alert(user, "Would you like to authorize this warrant?","Warrant authorization","Yes","No")
-			var/datum/report_field/signature/auth = active.field_from_name("Authorized by")
-			if(choice == "Yes")
-				auth.ask_value(user)
-			user.visible_message(SPAN_NOTICE("You swipe \the [I] through \the [src]."),
-								 SPAN_NOTICE("[user] swipes \the [I] through \the [src]."))
-			broadcast_security_hud_message("[active.get_broadcast_summary()] has been authorized by [auth.get_value()].", src)
-		else
-			to_chat(user, "<span class='notice'>A red \"Access Denied\" light blinks on \the [src]</span>")
-		return 1
-	..()
+	if(!active)
+		return ..()
+	var/obj/item/card/id/I = W.GetIdCard()
+	if(I && check_access_list(I.GetAccess()))
+		var/choice = alert(user, "Would you like to authorize this warrant?","Warrant authorization","Yes","No")
+		var/datum/report_field/signature/auth = active.field_from_name("Authorized by")
+		if(choice == "Yes")
+			auth.ask_value(user)
+		user.visible_message(SPAN_NOTICE("You swipe \the [I] through \the [src]."),
+								SPAN_NOTICE("[user] swipes \the [I] through \the [src]."))
+		broadcast_security_hud_message("[active.get_broadcast_summary()] has been authorized by [auth.get_value()].", src)
+	else
+		to_chat(user, "<span class='notice'>A red \"Access Denied\" light blinks on \the [src]</span>")
+	return TRUE
 
 //hit other people with it
 /obj/item/holowarrant/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -90,32 +90,33 @@
 			return
 	. = ..()
 
+// TODO: Refactor this to check matter or maybe even just use the fabricator recipe for lights directly
 /obj/item/lightreplacer/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/stack/material) && W.get_material_type() == /decl/material/solid/glass)
 		var/obj/item/stack/G = W
 		if(uses >= max_uses)
-			to_chat(user, "<span class='warning'>[src.name] is full.</span>")
-			return
+			to_chat(user, "<span class='warning'>\The [src] is full.</span>")
 		else if(G.use(1))
-			AddUses(16) //Autolathe converts 1 sheet into 16 lights.
+			AddUses(16) //Autolathe converts 1 sheet into 16 lights. // TODO: Make this use matter instead
 			to_chat(user, "<span class='notice'>You insert a piece of glass into \the [src]. You have [uses] light\s remaining.</span>")
-			return
 		else
 			to_chat(user, "<span class='warning'>You need one sheet of glass to replace lights.</span>")
+		return TRUE
 
 	if(istype(W, /obj/item/light))
 		var/obj/item/light/L = W
 		if(L.status == 0) // LIGHT OKAY
 			if(uses < max_uses)
 				if(!user.try_unequip(L))
-					return
+					return TRUE
 				AddUses(1)
 				to_chat(user, "You insert \the [L.name] into \the [src]. You have [uses] light\s remaining.")
 				qdel(L)
-				return
+				return TRUE
 		else
 			to_chat(user, "You need a working light.")
-			return
+			return TRUE
+	return ..()
 
 /obj/item/lightreplacer/attack_self(mob/user)
 	/* // This would probably be a bit OP. If you want it though, uncomment the code.

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -89,6 +89,7 @@
 				"[user] detaches \the [src] from the cable.", \
 				"<span class='notice'>You detach \the [src] from the cable.</span>",
 				"<span class='italics'>You hear some wires being disconnected from something.</span>")
+		return TRUE
 	else
 		return ..()
 

--- a/code/game/objects/items/devices/spy_bug.dm
+++ b/code/game/objects/items/devices/spy_bug.dm
@@ -42,8 +42,9 @@
 	if(istype(W, /obj/item/spy_monitor))
 		var/obj/item/spy_monitor/SM = W
 		SM.pair(src, user)
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/item/spy_bug/hear_talk(mob/M, var/msg, verb, decl/language/speaking)
 	radio.hear_talk(M, msg, speaking)
@@ -90,6 +91,7 @@
 /obj/item/spy_monitor/attackby(obj/W, mob/user)
 	if(istype(W, /obj/item/spy_bug))
 		pair(W, user)
+		return TRUE
 	else
 		return ..()
 

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -115,7 +115,7 @@
 			cover_open = 1
 			to_chat(user, "You unscrew the panel.")
 		update_icon()
-		return
+		return TRUE
 
 	if (istype(W, /obj/item/cell))
 		if(cover_open)
@@ -123,11 +123,11 @@
 				to_chat(user, "There is a [cell] already installed here.")
 			else
 				if(!user.try_unequip(W, src))
-					return
+					return TRUE
 				cell = W
 				to_chat(user, "You insert \the [cell].")
 		update_icon()
-		return
+		return TRUE
 
 	return ..()
 

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -42,19 +42,19 @@
 	if(IS_SCREWDRIVER(I))
 		maintenance = !maintenance
 		to_chat(user, "<span class='notice'>You [maintenance ? "open" : "secure"] the lid.</span>")
-		return
+		return TRUE
 	if(istype(I, /obj/item/magnetic_tape))
 		if(mytape)
 			to_chat(user, "<span class='notice'>There's already a tape inside.</span>")
-			return
+			return TRUE
 		if(!user.try_unequip(I))
-			return
+			return TRUE
 		I.forceMove(src)
 		mytape = I
 		to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
 		update_icon()
-		return
-	..()
+		return TRUE
+	return ..()
 
 
 /obj/item/taperecorder/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
@@ -422,21 +422,21 @@
 
 
 /obj/item/magnetic_tape/attackby(obj/item/I, mob/user, params)
-	if(user.incapacitated())
-		return
+	if(user.incapacitated()) // TODO: this may not be necessary since OnClick checks before starting the attack chain
+		return TRUE
 	if(ruined && IS_SCREWDRIVER(I))
 		if(!max_capacity)
 			to_chat(user, "<span class='notice'>There is no tape left inside.</span>")
-			return
+			return TRUE
 		to_chat(user, "<span class='notice'>You start winding the tape back in...</span>")
 		if(do_after(user, 120, target = src))
 			to_chat(user, "<span class='notice'>You wound the tape back in.</span>")
 			fix()
-		return
+		return TRUE
 	else if(IS_PEN(I))
 		if(loc == user)
 			var/new_name = input(user, "What would you like to label the tape?", "Tape labeling") as null|text
-			if(isnull(new_name)) return
+			if(isnull(new_name)) return TRUE
 			new_name = sanitize_safe(new_name)
 			if(new_name)
 				SetName("tape - '[new_name]'")
@@ -444,12 +444,14 @@
 			else
 				SetName("tape")
 				to_chat(user, "<span class='notice'>You scratch off the label.</span>")
-		return
+		return TRUE
 	else if(IS_WIRECUTTER(I))
 		cut(user)
+		return TRUE
 	else if(istype(I, /obj/item/magnetic_tape/loose))
 		join(user, I)
-	..()
+		return TRUE
+	return ..()
 
 /obj/item/magnetic_tape/proc/cut(mob/user)
 	if(!LAZYLEN(timestamp))

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -15,15 +15,14 @@
 /obj/item/transfer_valve/attackby(obj/item/item, mob/user)
 	var/turf/location = get_turf(src) // For admin logs
 	if(istype(item, /obj/item/tank))
-
 		var/T1_weight = 0
 		var/T2_weight = 0
 		if(tank_one && tank_two)
 			to_chat(user, "<span class='warning'>There are already two tanks attached, remove one first.</span>")
-			return
+			return TRUE
 
 		if(!user.try_unequip(item, src))
-			return
+			return TRUE
 		if(!tank_one)
 			tank_one = item
 		else
@@ -37,21 +36,18 @@
 			T2_weight = tank_two.w_class
 
 		src.w_class = max(initial(src.w_class),T1_weight,T2_weight) //gets w_class of biggest object, because you shouldn't be able to just shove tanks in and have them be tiny.
-
-		update_icon()
-
-		SSnano.update_uis(src) // update all UIs attached to src
+		. = TRUE
 //TODO: Have this take an assemblyholder
 	else if(isassembly(item))
 		var/obj/item/assembly/A = item
 		if(A.secured)
 			to_chat(user, "<span class='notice'>The device is secured.</span>")
-			return
+			return TRUE
 		if(attached_device)
 			to_chat(user, "<span class='warning'>There is already an device attached to the valve, remove it first.</span>")
-			return
+			return TRUE
 		if(!user.try_unequip(item, src))
-			return
+			return TRUE
 		attached_device = A
 		to_chat(user, "<span class='notice'>You attach \the [item] to the valve controls and secure it.</span>")
 		A.holder = src
@@ -61,8 +57,12 @@
 		message_admins("[key_name_admin(user)] attached a [item] to a transfer valve. (<A HREF='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[location.x];Y=[location.y];Z=[location.z]'>JMP</a>)")
 		log_game("[key_name_admin(user)] attached a [item] to a transfer valve.")
 		attacher = user
+		. = TRUE
+	if(.)
+		update_icon()
 		SSnano.update_uis(src) // update all UIs attached to src
-	return
+		return TRUE
+	return ..()
 
 
 /obj/item/transfer_valve/HasProximity(atom/movable/AM)

--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -97,20 +97,20 @@
 
 /* Assembly by a roboticist */
 /obj/item/robot_parts/head/attackby(var/obj/item/assembly/S, mob/user)
-	if ((!istype(S, /obj/item/assembly/infra)))
-		..()
-		return
+	if (!istype(S, /obj/item/assembly/infra))
+		return ..()
 	var/obj/item/TVAssembly/A = new(user)
 	qdel(S)
 	user.put_in_hands(A)
 	to_chat(user, "<span class='notice'>You add the infrared sensor to the robot head.</span>")
 	qdel(src)
+	return TRUE
 
 /* Using camcorder icon as I can't sprite.
 Using robohead because of restricting to roboticist */
 /obj/item/TVAssembly
 	name = "TV Camera assembly"
-	desc = "A robotic head with an infrared sensor inside"
+	desc = "A robotic head with an infrared sensor inside."
 	icon = 'icons/obj/robot_parts.dmi'
 	icon_state = "head"
 	item_state = "head"
@@ -118,6 +118,7 @@ Using robohead because of restricting to roboticist */
 	w_class = ITEM_SIZE_LARGE
 	material = /decl/material/solid/metal/steel
 
+// TODO: refactor this to use slapcrafting? remove entirely?
 /obj/item/TVAssembly/attackby(var/obj/item/W, var/mob/user)
 	switch(buildstep)
 		if(0)
@@ -126,30 +127,30 @@ Using robohead because of restricting to roboticist */
 				qdel(W)
 				desc = "This TV camera assembly has a camera module."
 				buildstep++
+				return TRUE
 		if(1)
 			if(istype(W, /obj/item/taperecorder))
 				qdel(W)
 				buildstep++
 				to_chat(user, "<span class='notice'>You add the tape recorder to [src]</span>")
 				desc = "This TV camera assembly has a camera and audio module."
-				return
+				return TRUE
 		if(2)
 			if(IS_COIL(W))
 				var/obj/item/stack/cable_coil/C = W
 				if(!C.use(3))
 					to_chat(user, "<span class='notice'>You need three cable coils to wire the devices.</span>")
-					..()
-					return
+					return TRUE
 				buildstep++
 				to_chat(user, SPAN_NOTICE("You wire the assembly."))
 				desc = "This TV camera assembly has wires sticking out."
-				return
+				return TRUE
 		if(3)
 			if(IS_WIRECUTTER(W))
 				to_chat(user, "<span class='notice'> You trim the wires.</span>")
 				buildstep++
 				desc = "This TV camera assembly needs casing."
-				return
+				return TRUE
 		if(4)
 			if(istype(W, /obj/item/stack/material))
 				var/obj/item/stack/material/S = W
@@ -159,8 +160,8 @@ Using robohead because of restricting to roboticist */
 					var/turf/T = get_turf(src)
 					new /obj/item/camera/tvcamera(T)
 					qdel(src)
-					return
-	..()
+					return TRUE
+	return ..()
 
 /datum/extension/network_device/camera/television
 	expected_type = /obj/item/camera/tvcamera

--- a/code/game/objects/items/glassjar.dm
+++ b/code/game/objects/items/glassjar.dm
@@ -76,12 +76,14 @@
 		if(contains == 0)
 			contains = 1
 		if(contains != 1)
-			return
+			return TRUE
 		if(!user.try_unequip(W, src))
-			return
+			return TRUE
 		var/obj/item/cash/S = W
 		user.visible_message("<span class='notice'>[user] puts \the [S] into \the [src].</span>")
 		update_icon()
+		return TRUE
+	return ..()
 
 /obj/item/glass_jar/on_update_icon() // Also updates name and desc
 	. = ..()

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -1,3 +1,4 @@
+// TODO: This is literally only available from abandoned mining crates. Remove?
 /obj/item/latexballon
 	name = "latex glove"
 	desc = "A latex glove, usually used as a balloon."
@@ -45,3 +46,5 @@
 /obj/item/latexballon/attackby(obj/item/W, mob/user)
 	if (W.can_puncture())
 		burst()
+		return TRUE
+	return FALSE

--- a/code/game/objects/items/rescuebag.dm
+++ b/code/game/objects/items/rescuebag.dm
@@ -35,18 +35,19 @@
 	if(istype(W,/obj/item/tank))
 		if(airtank)
 			to_chat(user, "\The [src] already has an air tank installed.")
-			return 1
-		else if(user.try_unequip(W))
+			return TRUE
+		if(user.try_unequip(W))
 			W.forceMove(src)
 			airtank = W
 			to_chat(user, "You install \the [W] in \the [src].")
-			return 1
+		return TRUE
 	else if(airtank && IS_SCREWDRIVER(W))
 		to_chat(user, "You remove \the [airtank] from \the [src].")
 		airtank.dropInto(loc)
 		airtank = null
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/item/bodybag/rescue/examine(mob/user)
 	. = ..()
@@ -88,21 +89,21 @@
 		add_overlay("tank")
 
 /obj/structure/closet/body_bag/rescue/attackby(obj/item/W, mob/user, var/click_params)
-	if(istype(W,/obj/item/tank/))
+	if(istype(W,/obj/item/tank))
 		if(airtank)
 			to_chat(user, "\The [src] already has an air tank installed.")
-			return 1
 		else if(user.try_unequip(W, src))
 			set_tank(W)
 			to_chat(user, "You install \the [W] in \the [src].")
-			return 1
+		return TRUE
 	else if(airtank && IS_SCREWDRIVER(W))
 		to_chat(user, "You remove \the [airtank] from \the [src].")
 		airtank.dropInto(loc)
 		airtank = null
 		update_icon()
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/structure/closet/body_bag/rescue/fold(var/user)
 	var/obj/item/tank/my_tank = airtank

--- a/code/game/objects/items/robot/robot_frame.dm
+++ b/code/game/objects/items/robot/robot_frame.dm
@@ -38,7 +38,7 @@
 	if(IS_CROWBAR(W))
 		if(!parts.len)
 			to_chat(user, SPAN_WARNING("\The [src] has no parts to remove."))
-			return
+			return TRUE
 		var/removing = pick(parts)
 		var/obj/item/robot_parts/part = parts[removing]
 		part.forceMove(get_turf(src))
@@ -46,44 +46,44 @@
 		parts -= removing
 		to_chat(user, SPAN_WARNING("You lever \the [part] off \the [src]."))
 		update_icon()
+		return TRUE
 
 	// Install a robotic part.
 	else if (istype(W, /obj/item/robot_parts))
 		var/obj/item/robot_parts/part = W
 		if(!required_parts[part.bp_tag] || !istype(W, required_parts[part.bp_tag]))
 			to_chat(user, SPAN_WARNING("\The [src] is not compatible with \the [W]."))
-			return
-		if(parts[part.bp_tag])
+		else if(parts[part.bp_tag])
 			to_chat(user, SPAN_WARNING("\The [src] already has \a [W] installed."))
-			return
-		if(part.can_install(user) && user.try_unequip(W, src))
+		else if(part.can_install(user) && user.try_unequip(W, src))
 			parts[part.bp_tag] = part
 			update_icon()
+		return TRUE
 
 	// Install a brain.
 	else if(istype(W, /obj/item/organ/internal/brain_interface))
 
 		if(!isturf(loc))
 			to_chat(user, SPAN_WARNING("You can't put \the [W] in without the frame being on the ground."))
-			return
+			return TRUE
 
 		if(!check_completion())
 			to_chat(user, SPAN_WARNING("The frame is not ready for the central processor to be installed."))
-			return
+			return TRUE
 
 		var/obj/item/organ/internal/brain_interface/M = W
 		var/mob/living/brainmob = M?.get_brainmob()
 		if(!brainmob)
 			to_chat(user, SPAN_WARNING("Sticking an empty [W.name] into the frame would sort of defeat the purpose."))
-			return
+			return TRUE
 
 		if(jobban_isbanned(brainmob, ASSIGNMENT_ROBOT))
 			to_chat(user, SPAN_WARNING("\The [W] does not seem to fit."))
-			return
+			return TRUE
 
 		if(brainmob.stat == DEAD)
 			to_chat(user, SPAN_WARNING("Sticking a dead [W.name] into the frame would sort of defeat the purpose."))
-			return
+			return TRUE
 
 		var/ghost_can_reenter = 0
 		if(brainmob.mind)
@@ -96,15 +96,15 @@
 				ghost_can_reenter = 1
 		if(!ghost_can_reenter)
 			to_chat(user, SPAN_WARNING("\The [W] is completely unresponsive; there's no point."))
-			return
+			return TRUE
 
 		if(!user.try_unequip(W))
-			return
+			return TRUE
 
 		SSstatistics.add_field("cyborg_frames_built",1)
 		var/mob/living/silicon/robot/O = new product(get_turf(loc))
 		if(!O)
-			return
+			return TRUE
 
 		O.central_processor = W
 		O.set_invisibility(INVISIBILITY_NONE)
@@ -131,13 +131,15 @@
 		RAISE_EVENT(/decl/observ/cyborg_created, O)
 		O.Namepick()
 		qdel(src)
+		return TRUE
 
 	else if(IS_PEN(W))
 		var/t = sanitize_safe(input(user, "Enter new robot name", src.name, src.created_name), MAX_NAME_LEN)
 		if(t && (in_range(src, user) || loc == user))
 			created_name = t
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/item/robot_parts/robot_suit/Destroy()
 	parts.Cut()

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -107,38 +107,39 @@
 	return success && ..()
 
 /obj/item/robot_parts/chest/attackby(obj/item/W, mob/user)
-	..()
 	if(istype(W, /obj/item/cell))
 		if(src.cell)
 			to_chat(user, "<span class='warning'>You have already inserted a cell!</span>")
-			return
 		else
 			if(!user.try_unequip(W, src))
-				return
+				return TRUE
 			src.cell = W
 			to_chat(user, "<span class='notice'>You insert the cell!</span>")
+		return TRUE
 	if(IS_COIL(W))
 		if(src.wires)
 			to_chat(user, "<span class='warning'>You have already inserted wire!</span>")
-			return
 		else
 			var/obj/item/stack/cable_coil/coil = W
 			if(coil.use(1))
 				src.wires = 1.0
 				to_chat(user, "<span class='notice'>You insert the wire!</span>")
+		return TRUE
+	return ..()
 
 /obj/item/robot_parts/head/attackby(obj/item/W, mob/user)
-	..()
 	if(istype(W, /obj/item/flash))
 		if(isrobot(user))
 			var/current_module = user.get_active_held_item()
 			if(current_module == W)
 				to_chat(user, "<span class='warning'>How do you propose to do that?</span>")
-				return
+				return TRUE
 			else
 				add_flashes(W,user)
 		else
 			add_flashes(W,user)
+		return TRUE
+	return ..()
 
 /obj/item/robot_parts/head/proc/add_flashes(obj/item/W, mob/user) //Made into a seperate proc to avoid copypasta
 	if(src.flash1 && src.flash2)

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -23,8 +23,9 @@
 			overlays.Cut()
 			bulletholes.Cut()
 			hp = initial(hp)
-			to_chat(usr, "<span class='notice'>You slice off [src]'s uneven chunks of aluminium and scorch marks.</span>")
-			return
+			to_chat(user, "<span class='notice'>You slice off [src]'s uneven chunks of aluminium and scorch marks.</span>")
+		return TRUE
+	return ..()
 
 /obj/item/target/attack_hand(var/mob/user)
 	// taking pinned targets off!

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -60,7 +60,7 @@
 
 		if(!can_use(2))
 			to_chat(user, "<span class='warning'>You need at least two rods to do this.</span>")
-			return
+			return TRUE
 
 		if(WT.weld(0,user))
 			visible_message(SPAN_NOTICE("\The [src] is fused together by \the [user] with \the [WT]."), 3, SPAN_NOTICE("You hear welding."), 2)
@@ -69,13 +69,13 @@
 				if(user.is_holding_offhand(src))
 					user.put_in_hands(new_item)
 			use(2)
-		return
+		return TRUE
 
 	if (istype(W, /obj/item/stack/tape_roll/duct_tape))
 		var/obj/item/stack/tape_roll/duct_tape/T = W
 		if(!T.can_use(4))
 			to_chat(user, SPAN_WARNING("You need 4 [T.plural_name] to make a splint!"))
-			return
+			return TRUE
 		T.use(4)
 
 		var/obj/item/stack/medical/splint/improvised/new_splint = new(user.loc)
@@ -85,10 +85,8 @@
 		user.visible_message(SPAN_NOTICE("\The [user] constructs \a [new_splint] out of a [singular_name]."), \
 				SPAN_NOTICE("You use make \a [new_splint] out of a [singular_name]."))
 		src.use(1)
-
-		return
-
-	..()
+		return TRUE
+	return ..()
 
 /obj/item/stack/material/rods/attack_self(mob/user)
 	add_fingerprint(user)

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -50,19 +50,17 @@
 	update_icon()	//Initializes the ammo counter
 
 /obj/item/rcd/attackby(obj/item/W, mob/user)
-
 	if(istype(W, /obj/item/rcd_ammo))
 		var/obj/item/rcd_ammo/cartridge = W
 		if((stored_matter + cartridge.remaining) > max_stored_matter)
 			to_chat(user, "<span class='notice'>The RCD can't hold that many additional matter-units.</span>")
-			return
+			return TRUE
 		stored_matter += cartridge.remaining
 		qdel(W)
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 		to_chat(user, "<span class='notice'>The RCD now holds [stored_matter]/[max_stored_matter] matter-units.</span>")
 		update_icon()
-		return
-
+		return TRUE
 	if(IS_SCREWDRIVER(W))
 		crafting = !crafting
 		if(!crafting)
@@ -70,9 +68,8 @@
 		else
 			to_chat(user, "<span class='notice'>The RCD can now be modified.</span>")
 		src.add_fingerprint(user)
-		return
-
-	..()
+		return TRUE
+	return ..()
 
 /obj/item/rcd/attack_self(mob/user)
 	//Change the mode
@@ -165,7 +162,7 @@
 	return 0
 
 /obj/item/rcd/borg/attackby()
-	return
+	return FALSE
 
 /obj/item/rcd/borg/can_use(var/mob/user,var/turf/T)
 	return (user.Adjacent(T) && !user.incapacitated())
@@ -185,7 +182,7 @@
 	return 0
 
 /obj/item/rcd/mounted/attackby()
-	return
+	return FALSE
 
 /obj/item/rcd/mounted/can_use(var/mob/user,var/turf/T)
 	return (user.Adjacent(T) && !user.incapacitated())

--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -165,10 +165,10 @@ var/global/list/rpd_pipe_selection_skilled = list()
 /obj/item/rpd/attackby(var/obj/item/W, var/mob/user)
 	if(istype(W, /obj/item/pipe))
 		if(!user.try_unequip(W))
-			return
+			return TRUE
 		recycle(W,user)
-		return
-	..()
+		return TRUE
+	return ..()
 
 /obj/item/rpd/proc/recycle(var/obj/item/W,var/mob/user)
 	if(!user.skill_check(SKILL_ATMOS,SKILL_BASIC))

--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -28,19 +28,16 @@ RSF
 		to_chat(user, "It currently holds [stored_matter]/30 fabrication-units.")
 
 /obj/item/rsf/attackby(obj/item/W, mob/user)
-	..()
 	if (istype(W, /obj/item/rcd_ammo))
-
 		if ((stored_matter + 10) > 30)
 			to_chat(user, "The RSF can't hold any more matter.")
-			return
-
+			return TRUE
 		qdel(W)
-
 		stored_matter += 10
 		playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
 		to_chat(user, "The RSF now holds [stored_matter]/30 fabrication-units.")
-		return
+		return TRUE
+	return ..()
 
 /obj/item/rsf/attack_self(mob/user)
 	playsound(src.loc, 'sound/effects/pop.ogg', 50, 0)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -44,8 +44,8 @@
 			if(signature && !signed_by && !user.incapacitated() && Adjacent(user))
 				signed_by = signature
 				user.visible_message(SPAN_NOTICE("\The [user] signs \the [src] with a flourish."))
-		return
-	..()
+		return TRUE
+	return ..()
 
 /obj/item/card/data
 	name = "data card"

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -68,19 +68,22 @@
 	toggle_paddles()
 	return TRUE
 
+// TODO: This should really use the cell extension
 /obj/item/defibrillator/attackby(obj/item/W, mob/user, params)
 	if(W == paddles)
 		reattach_paddles(user)
+		return TRUE
 	else if(istype(W, /obj/item/cell))
 		if(bcell)
-			to_chat(user, "<span class='notice'>\the [src] already has a cell.</span>")
+			to_chat(user, "<span class='notice'>\The [src] already has a cell.</span>")
 		else
 			if(!user.try_unequip(W))
-				return
+				return TRUE
 			W.forceMove(src)
 			bcell = W
 			to_chat(user, "<span class='notice'>You install a cell in \the [src].</span>")
 			update_icon()
+		return TRUE
 
 	else if(IS_SCREWDRIVER(W))
 		if(bcell)
@@ -89,6 +92,8 @@
 			bcell = null
 			to_chat(user, "<span class='notice'>You remove the cell from \the [src].</span>")
 			update_icon()
+			return TRUE
+		return FALSE
 	else
 		return ..()
 

--- a/code/game/objects/items/weapons/electric_welder.dm
+++ b/code/game/objects/items/weapons/electric_welder.dm
@@ -44,7 +44,7 @@
 
 /obj/item/weldingtool/electric/attackby(var/obj/item/W, var/mob/user)
 	if(istype(W,/obj/item/stack/material/rods) || istype(W, /obj/item/chems/welder_tank))
-		return
+		return FALSE // NO ELECTRIC FLAMETHROWER
 	return ..()
 
 /obj/item/weldingtool/electric/use_fuel(var/amount)

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -32,10 +32,11 @@
 	if(IS_SCREWDRIVER(I))
 		open_panel = !open_panel
 		to_chat(user, "<span class='notice'>You [open_panel ? "open" : "close"] the wire panel.</span>")
+		return TRUE
 	else if(IS_WIRECUTTER(I) || IS_MULTITOOL(I) || istype(I, /obj/item/assembly/signaler ))
-		wires.Interact(user)
+		return wires.Interact(user)
 	else
-		..()
+		return ..()
 
 /obj/item/plastique/attack_self(mob/user)
 	var/newtime = input(usr, "Please set the timer.", "Timer", 10) as num

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -28,17 +28,17 @@
 	if(!QDELETED(src))
 		qdel(src)
 
+// this can't be made, should it just be removed?
+// should it be made into a subtype of closet? of living statue?
 /obj/effect/spresent/relaymove(mob/user)
 	if (user.stat)
 		return
 	to_chat(user, "<span class='warning'>You can't move.</span>")
 
 /obj/effect/spresent/attackby(obj/item/W, mob/user)
-	..()
-
 	if(!IS_WIRECUTTER(W))
 		to_chat(user, "<span class='warning'>I need wirecutters for that.</span>")
-		return
+		return TRUE
 
 	to_chat(user, "<span class='notice'>You cut open the present.</span>")
 
@@ -49,6 +49,7 @@
 			M.client.perspective = MOB_PERSPECTIVE
 
 	qdel(src)
+	return TRUE
 
 /obj/item/a_gift/attack_self(mob/M)
 	var/gift_type = pick(

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -116,7 +116,7 @@
 				return TRUE
 	if(.)
 		update_icon()
-		return
+		return TRUE
 	return ..()
 
 /obj/item/grenade/chem_grenade/activate(mob/user)

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -53,12 +53,12 @@
 		var/obj/item/assembly_holder/det = W
 		if(istype(det.a_left,det.a_right.type) || (!isigniter(det.a_left) && !isigniter(det.a_right)))
 			to_chat(user, "<span class='warning'>Assembly must contain one igniter.</span>")
-			return
+			return TRUE
 		if(!det.secured)
 			to_chat(user, "<span class='warning'>Assembly must be secured with screwdriver.</span>")
-			return
+			return TRUE
 		if(!user.try_unequip(det, src))
-			return
+			return TRUE
 		path = 1
 		log_and_message_admins("has attached \a [W] to \the [src].")
 		to_chat(user, "<span class='notice'>You add [W] to the metal casing.</span>")
@@ -72,6 +72,7 @@
 			det_time = 10*T.time
 		SetName("unsecured grenade with [beakers.len] containers[detonator?" and detonator":""]")
 		stage = 1
+		. = TRUE
 	else if(IS_SCREWDRIVER(W) && path != 2)
 		if(stage == 1)
 			path = 1
@@ -83,33 +84,40 @@
 				SetName("fake grenade")
 			playsound(src.loc, 'sound/items/Screwdriver.ogg', 25, -3)
 			stage = 2
+			. = TRUE
 		else if(stage == 2)
 			if(active && prob(95))
 				to_chat(user, "<span class='warning'>You trigger the assembly!</span>")
 				detonate()
-				return
+				return TRUE
 			else
 				to_chat(user, "<span class='notice'>You unlock the assembly.</span>")
 				playsound(src.loc, 'sound/items/Screwdriver.ogg', 25, -3)
 				SetName("unsecured grenade with [beakers.len] containers[detonator?" and detonator":""]")
 				stage = 1
 				active = FALSE
+				. = TRUE
 	else if(is_type_in_list(W, allowed_containers) && (!stage || stage==1) && path != 2)
 		path = 1
 		if(beakers.len == 2)
 			to_chat(user, "<span class='warning'>The grenade can not hold more containers.</span>")
-			return
+			return TRUE
 		else
 			if(W.reagents.total_volume)
 				if(!user.try_unequip(W, src))
-					return
+					return TRUE
 				to_chat(user, "<span class='notice'>You add \the [W] to the assembly.</span>")
 				beakers += W
 				stage = 1
 				SetName("unsecured grenade with [beakers.len] containers[detonator?" and detonator":""]")
+				. = TRUE
 			else
 				to_chat(user, "<span class='warning'>\The [W] is empty.</span>")
-	update_icon()
+				return TRUE
+	if(.)
+		update_icon()
+		return
+	return ..()
 
 /obj/item/grenade/chem_grenade/activate(mob/user)
 	if(active)

--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -39,13 +39,14 @@
 	else
 		icon_state = "implantcase-0"
 
+// TODO: the name stuff here probably doesn't work, this needs an update_name override
 /obj/item/implantcase/attackby(obj/item/I, mob/user)
 	if (IS_PEN(I))
 		var/t = input(user, "What would you like the label to be?", src.name, null)
 		if (user.get_active_held_item() != I)
-			return
+			return TRUE
 		if((!in_range(src, usr) && loc != user))
-			return
+			return TRUE
 		t = sanitize_safe(t, MAX_NAME_LEN)
 		if(t)
 			SetName("glass case - '[t]'")
@@ -53,9 +54,9 @@
 		else
 			SetName(initial(name))
 			desc = "A case containing an implant."
-	else if(istype(I, /obj/item/chems/syringe))
-		if(istype(imp,/obj/item/implant/chem))
-			imp.attackby(I,user)
+		return TRUE
+	else if(istype(I, /obj/item/chems/syringe) && istype(imp,/obj/item/implant/chem))
+		return imp.attackby(I,user)
 	else if (istype(I, /obj/item/implanter))
 		var/obj/item/implanter/M = I
 		if (M.imp && !imp && !M.imp.implanted)
@@ -69,10 +70,11 @@
 		update_description()
 		update_icon()
 		M.update_icon()
+		return TRUE
 	else if (istype(I, /obj/item/implant) && user.try_unequip(I, src))
 		to_chat(usr, "<span class='notice'>You slide \the [I] into \the [src].</span>")
 		imp = I
 		update_description()
 		update_icon()
-	else
-		return ..()
+		return TRUE
+	return ..()

--- a/code/game/objects/items/weapons/implants/implantpad.dm
+++ b/code/game/objects/items/weapons/implants/implantpad.dm
@@ -52,7 +52,7 @@
 		. = TRUE
 	if(.)
 		update_icon()
-		return
+		return TRUE
 	return ..()
 
 /obj/item/implantpad/attack_self(mob/user)

--- a/code/game/objects/items/weapons/implants/implantpad.dm
+++ b/code/game/objects/items/weapons/implants/implantpad.dm
@@ -23,7 +23,6 @@
 	return TRUE
 
 /obj/item/implantpad/attackby(obj/item/I, mob/user)
-	..()
 	if(istype(I, /obj/item/implantcase))
 		var/obj/item/implantcase/C = I
 		if(!imp && C.imp)
@@ -35,6 +34,7 @@
 			C.imp = imp
 			imp = null
 		C.update_icon()
+		. = TRUE
 	else if(istype(I, /obj/item/implanter))
 		var/obj/item/implanter/C = I
 		if(!imp && C.imp)
@@ -46,9 +46,14 @@
 			C.imp = imp
 			imp = null
 		C.update_icon()
+		. = TRUE
 	else if(istype(I, /obj/item/implant) && user.try_unequip(I, src))
 		imp = I
-	update_icon()
+		. = TRUE
+	if(.)
+		update_icon()
+		return
+	return ..()
 
 /obj/item/implantpad/attack_self(mob/user)
 	if (imp)

--- a/code/game/objects/items/weapons/implants/implants/chem.dm
+++ b/code/game/objects/items/weapons/implants/implants/chem.dm
@@ -48,8 +48,9 @@ var/global/list/chem_implants = list()
 			if(do_after(user,5,src))
 				I.reagents.trans_to_obj(src, 5)
 				to_chat(user, "<span class='notice'>You inject 5 units of the solution. The syringe now contains [I.reagents.total_volume] units.</span>")
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/item/implantcase/chem
 	name = "glass case - 'chem'"

--- a/code/game/objects/items/weapons/material/ashtray.dm
+++ b/code/game/objects/items/weapons/material/ashtray.dm
@@ -28,7 +28,7 @@
 	if (istype(W,/obj/item/trash/cigbutt) || istype(W,/obj/item/clothing/mask/smokable/cigarette) || istype(W, /obj/item/flame/match))
 		if (contents.len >= max_butts)
 			to_chat(user, "\The [src] is full.")
-			return
+			return TRUE
 
 		if (istype(W,/obj/item/clothing/mask/smokable/cigarette))
 			var/obj/item/clothing/mask/smokable/cigarette/cig = W
@@ -43,6 +43,7 @@
 		if(user.try_unequip(W, src))
 			set_extension(src, /datum/extension/scent/ashtray)
 			update_icon()
+		return TRUE
 	return ..()
 
 /obj/item/ashtray/throw_impact(atom/hit_atom)

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -64,24 +64,24 @@
 		if(WT.weld(0, user))
 			material.create_object(get_turf(src))
 			qdel(src)
-			return
+			return TRUE
 	if(istype(W, /obj/item/stack/cable_coil))
 
 		if(!material || (material.shard_type in list(SHARD_SPLINTER, SHARD_SHRAPNEL)))
 			to_chat(user, SPAN_WARNING("\The [src] is not suitable for using as a shank."))
-			return
+			return TRUE
 		if(has_handle)
 			to_chat(user, SPAN_WARNING("\The [src] already has a handle."))
-			return
+			return TRUE
 		var/obj/item/stack/cable_coil/cable = W
 		if(cable.use(3))
 			to_chat(user, SPAN_NOTICE("You wind some cable around the thick end of \the [src]."))
 			has_handle = cable.color
 			SetName("[material.solid_name] shank")
 			update_icon()
-			return
+			return TRUE
 		to_chat(user, SPAN_WARNING("You need 3 or more units of cable to give \the [src] a handle."))
-		return
+		return TRUE
 	return ..()
 
 /obj/item/shard/on_update_icon()

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -69,8 +69,8 @@
 
 /obj/effect/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/mop) || istype(I, /obj/item/soap))
-		return
-	..()
+		return FALSE
+	return ..()
 
 /obj/item/mop/advanced
 	desc = "The most advanced tool in a custodian's arsenal, with a cleaner synthesizer to boot! Just think of all the viscera you will clean up with this!"

--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -89,7 +89,8 @@ var/global/list/image/hazard_overlays //Cached hazard floor overlays for the bar
 	return ..()
 
 /obj/item/stack/tape_roll/barricade_tape/attack_hand()
-	if((. = ..()) && !QDELETED(src))
+	. = ..()
+	if(. && !QDELETED(src))
 		update_icon()
 
 /**Callback used when whoever holds us moved to a new turf. */

--- a/code/game/objects/items/weapons/secrets_disk.dm
+++ b/code/game/objects/items/weapons/secrets_disk.dm
@@ -48,7 +48,7 @@
 			to_chat(user, "<span class='notice'>You swipe your card and [locked ? "lock":"unlock"] the disk.</span>")
 		else
 			to_chat(user, "<span class='warning'>The disk's screen flashes 'Access Denied'.</span>")
-		return
+		return TRUE
 	. = ..()
 
 /obj/item/disk/secret_project/verb/change_codename()

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -91,8 +91,9 @@
 			user.visible_message("<span class='warning'>[user] bashes [src] with [W]!</span>")
 			playsound(user.loc, 'sound/effects/shieldbash.ogg', 50, 1)
 			cooldown = world.time
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/item/shield/riot/metal
 	name = "plasteel combat shield"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -64,7 +64,7 @@
 /obj/item/belt/holster/attackby(obj/item/W, mob/user)
 	var/datum/extension/holster/H = get_extension(src, /datum/extension/holster)
 	if(H.holster(W, user))
-		return
+		return TRUE
 	else
 		. = ..(W, user)
 

--- a/code/game/objects/items/weapons/storage/fancy/cigarettes.dm
+++ b/code/game/objects/items/weapons/storage/fancy/cigarettes.dm
@@ -25,10 +25,6 @@
 	. = ..()
 
 /obj/item/box/fancy/cigarettes/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
-
-	if(!ismob(target))
-		return
-
 	if(target == user && user.get_target_zone() == BP_MOUTH && contents.len > 0 && !user.get_equipped_item(slot_wear_mask_str))
 		// Find ourselves a cig. Note that we could be full of lighters.
 		var/obj/item/clothing/mask/smokable/cigarette/cig = null

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -22,30 +22,30 @@
 	if (istype(W, /obj/item/card/id))
 		if(src.broken)
 			to_chat(user, "<span class='warning'>It appears to be broken.</span>")
-			return
+			return TRUE
 		if(src.allowed(user))
 			src.locked = !( src.locked )
 			if(src.locked)
 				src.icon_state = src.icon_locked
 				to_chat(user, "<span class='notice'>You lock \the [src]!</span>")
 				storage?.close_all()
-				return
 			else
 				src.icon_state = src.icon_closed
 				to_chat(user, "<span class='notice'>You unlock \the [src]!</span>")
-				return
 		else
 			to_chat(user, "<span class='warning'>Access Denied</span>")
+		return TRUE
 	else if(istype(W, /obj/item/energy_blade))
 		var/obj/item/energy_blade/blade = W
 		if(blade.is_special_cutting_tool() && emag_act(INFINITY, user, W, "The locker has been sliced open by [user] with an energy blade!", "You hear metal being sliced and sparks flying."))
 			spark_at(src.loc, amount=5)
 			playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
+		return TRUE
 	if(!locked)
-		..()
+		return ..()
 	else
 		to_chat(user, "<span class='warning'>It's locked!</span>")
-	return
+		return TRUE
 
 /obj/item/lockbox/emag_act(var/remaining_charges, var/mob/user, var/emag_source, var/visual_feedback = "", var/audible_feedback = "")
 	if(!broken)

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -49,11 +49,12 @@
 /obj/item/secure_storage/attackby(obj/item/W, mob/user)
 	var/datum/extension/lockable/lock = get_extension(src, /datum/extension/lockable)
 	if(lock.attackby(W, user))
-		return
+		return TRUE
 
 	// -> storage/attackby() what with handle insertion, etc
 	if(!lock.locked)
 		. = ..()
+	return FALSE
 
 /obj/item/secure_storage/handle_mouse_drop(atom/over, mob/user, params)
 	var/datum/extension/lockable/lock = get_extension(src, /datum/extension/lockable)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -172,7 +172,7 @@
 	return 0
 
 /obj/item/baton/robot/attackby(obj/item/W, mob/user)
-	return
+	return FALSE
 
 /obj/item/baton/robot/setup_power_supply(loaded_cell_type, accepted_cell_type, power_supply_extension_type, charge_value)
 	SHOULD_CALL_PARENT(FALSE)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -117,17 +117,17 @@ var/global/list/global/tank_gauge_cache = list()
 
 
 /obj/item/tank/attackby(var/obj/item/W, var/mob/user)
-	..()
 	if (istype(loc, /obj/item/assembly))
 		icon = loc
 
 	if (istype(W, /obj/item/scanner/gas))
-		return
+		return TRUE
 
 	if (istype(W,/obj/item/latexballon))
 		var/obj/item/latexballon/LB = W
 		LB.blow(src)
 		add_fingerprint(user)
+		return TRUE
 
 	if(IS_COIL(W))
 		var/obj/item/stack/cable_coil/C = W
@@ -135,6 +135,7 @@ var/global/list/global/tank_gauge_cache = list()
 			wired = 1
 			to_chat(user, "<span class='notice'>You attach the wires to the tank.</span>")
 			update_icon(TRUE)
+		return TRUE
 
 	if(IS_WIRECUTTER(W))
 		if(wired && proxyassembly.assembly)
@@ -162,6 +163,7 @@ var/global/list/global/tank_gauge_cache = list()
 				to_chat(user, "<span class='danger'>You slip and bump the igniter!</span>")
 				if(prob(85))
 					proxyassembly.receive_signal()
+			return TRUE
 
 		else if(wired)
 			if(do_after(user, 10, src))
@@ -171,6 +173,7 @@ var/global/list/global/tank_gauge_cache = list()
 
 		else
 			to_chat(user, "<span class='notice'>There are no wires to cut!</span>")
+		return TRUE
 
 	if(istype(W, /obj/item/assembly_holder))
 		if(wired)
@@ -184,6 +187,7 @@ var/global/list/global/tank_gauge_cache = list()
 				to_chat(user, "<span class='notice'>You stop attaching the assembly.</span>")
 		else
 			to_chat(user, "<span class='notice'>You need to wire the device up first.</span>")
+		return TRUE
 
 	if(IS_WELDER(W))
 		var/obj/item/weldingtool/WT = W
@@ -205,14 +209,17 @@ var/global/list/global/tank_gauge_cache = list()
 			else
 				to_chat(user, "<span class='notice'>The emergency pressure relief valve has already been welded.</span>")
 		add_fingerprint(user)
+		return TRUE
 
 	if(istype(W, /obj/item/flamethrower))
 		var/obj/item/flamethrower/F = W
 		if(!F.secured || F.tank || !user.try_unequip(src, F))
-			return
+			return TRUE
 
 		master = F
 		F.tank = src
+		return TRUE
+	return ..()
 
 /obj/item/tank/attack_self(mob/user)
 	add_fingerprint(user)

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -149,9 +149,9 @@
 
 /obj/item/stack/tape_roll/duct_tape/proc/stick(var/obj/item/W, mob/user)
 	if(!(W.item_flags & ITEM_FLAG_CAN_TAPE) || !user.try_unequip(W))
-		return
+		return FALSE
 	if(!can_use(1))
-		return
+		return FALSE
 	use(1)
 	var/obj/item/duct_tape/tape = new(get_turf(src))
 	tape.attach(W)

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -213,11 +213,11 @@
 //Removes fuel from the welding tool. If a mob is passed, it will perform an eyecheck on the mob.
 /obj/item/weldingtool/proc/weld(var/fuel_usage = 1, var/mob/user = null)
 	if(!welding)
-		return
+		return FALSE
 	if(get_fuel() < fuel_usage)
 		if(user)
 			to_chat(user, SPAN_NOTICE("You need more [welding_resource] to complete this task."))
-		return
+		return FALSE
 
 	use_fuel(fuel_usage)
 	if(user)

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -147,7 +147,7 @@
 /obj/item/weldingtool/attackby(obj/item/W, mob/user)
 	if(welding)
 		to_chat(user, SPAN_WARNING("Stop welding first!"))
-		return
+		return TRUE
 
 	if (istype(W, /obj/item/chems/welder_tank))
 		return insert_tank(W, user)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -210,7 +210,7 @@
 /obj/effect/energy_net/attackby(obj/item/W, mob/user)
 	current_health -= W.get_attack_force(user)
 	healthcheck()
-	..()
+	return TRUE
 
 /obj/effect/energy_net/user_unbuckle_mob(mob/user)
 	return escape_net(user)

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -42,11 +42,11 @@
 		if(access_bar in card.GetAccess())
 			var/sign_type = input(user, "What would you like to change the barsign to?") as null|anything in get_valid_states(0)
 			if(!sign_type)
-				return
+				return TRUE
 			icon_state = sign_type
 			to_chat(user, "<span class='notice'>You change the barsign.</span>")
 		else
 			to_chat(user, "<span class='warning'>Access denied.</span>")
-		return
+		return TRUE
 
 	return ..()

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -26,8 +26,8 @@ LINEN BINS
 			for(var/i in 1 to rand(2,5))
 				new /obj/item/chems/glass/rag(get_turf(src))
 			qdel(src)
-		return
-	..()
+		return TRUE
+	return ..()
 
 /obj/item/bedsheet/yellowed
 	desc = "A surprisingly soft bedsheet. This one is old and yellowed."
@@ -142,9 +142,9 @@ LINEN BINS
 	if(istype(I, /obj/item/bedsheet))
 		if(curamount >= max_stored)
 			to_chat(user, SPAN_WARNING("\The [src] is full!"))
-			return
+			return TRUE
 		if(!user.try_unequip(I, src))
-			return
+			return TRUE
 		LAZYDISTINCTADD(sheets, I)
 		update_icon()
 		to_chat(user, SPAN_NOTICE("You put [I] in [src]."))
@@ -156,7 +156,7 @@ LINEN BINS
 	if(!.)
 		if(curamount && !hidden && I.w_class < w_class)	//make sure there's sheets to hide it among, make sure nothing else is hidden in there.
 			if(!user.try_unequip(I, src))
-				return
+				return TRUE
 			hidden = I
 			to_chat(user, SPAN_NOTICE("You hide [I] among the sheets."))
 			return TRUE

--- a/code/game/objects/structures/charge_pylon.dm
+++ b/code/game/objects/structures/charge_pylon.dm
@@ -45,12 +45,15 @@
 		visible_message("<span class='danger'>\The [user] has been shocked by \the [src]!</span>")
 		user.throw_at(get_step(user,get_dir(src,user)), 5, 10)
 
-/obj/structure/charge_pylon/attackby(var/obj/item/grab/grab, mob/user)
-	if(!istype(grab))
-		return
+/obj/structure/charge_pylon/attackby(var/obj/item/item, mob/user)
+	if(!istype(item, /obj/item/grab))
+		return FALSE
+	var/obj/item/grab/grab = item
 	var/mob/M = grab.get_affecting_mob()
 	if(M)
 		charge_user(M)
+		return TRUE
+	return FALSE
 
 /obj/structure/charge_pylon/Bumped(atom/AM)
 	if(ishuman(AM))

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -319,7 +319,7 @@ var/global/list/closets = list()
 		if(!WT.weld(0,user))
 			if(WT.isOn())
 				to_chat(user, SPAN_NOTICE("You need more welding fuel to complete this task."))
-			return
+			return TRUE
 		welded = !welded
 		update_icon()
 		user.visible_message(SPAN_WARNING("\The [src] has been [welded?"welded shut":"unwelded"] by \the [user]."), blind_message = "You hear welding.", range = 3)

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -103,6 +103,7 @@
 	user.do_attack_animation(src)
 	visible_message("<span class='danger'>[user] strikes [src] with [I].</span>")
 	check_health()
+	return TRUE
 
 /obj/structure/closet/statue/receive_mouse_drop(atom/dropping, mob/user, params)
 	return TRUE

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -47,12 +47,11 @@
 			rigged = 1
 			return TRUE
 		return FALSE
-	else if(istype(W, /obj/item/assembly_holder) || istype(W, /obj/item/assembly))
-		if(rigged)
-			if(!user.try_unequip(W, src))
-				return TRUE
-			to_chat(user, "<span class='notice'>You attach [W] to [src].</span>")
+	else if((istype(W, /obj/item/assembly_holder) || istype(W, /obj/item/assembly)) && rigged)
+		if(!user.try_unequip(W, src))
 			return TRUE
+		to_chat(user, "<span class='notice'>You attach [W] to [src].</span>")
+		return TRUE
 	else if(IS_WIRECUTTER(W))
 		if(rigged)
 			to_chat(user, "<span class='notice'>You cut away the wiring.</span>")

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -36,28 +36,30 @@
 	if(opened)
 		return ..()
 	else if(istype(W, /obj/item/stack/package_wrap))
-		return
+		return FALSE // let afterattack run
 	else if(istype(W, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/C = W
 		if(rigged)
 			to_chat(user, "<span class='notice'>[src] is already rigged!</span>")
-			return
+			return TRUE
 		if (C.use(1))
 			to_chat(user, "<span class='notice'>You rig [src].</span>")
 			rigged = 1
-			return
+			return TRUE
+		return FALSE
 	else if(istype(W, /obj/item/assembly_holder) || istype(W, /obj/item/assembly))
 		if(rigged)
 			if(!user.try_unequip(W, src))
-				return
+				return TRUE
 			to_chat(user, "<span class='notice'>You attach [W] to [src].</span>")
-			return
+			return TRUE
 	else if(IS_WIRECUTTER(W))
 		if(rigged)
 			to_chat(user, "<span class='notice'>You cut away the wiring.</span>")
 			playsound(loc, 'sound/items/Wirecutter.ogg', 100, 1)
 			rigged = 0
-			return
+			return TRUE
+		return FALSE
 	else
 		return ..()
 

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -110,27 +110,25 @@
 	return ..()
 
 /obj/structure/curtain/attackby(obj/item/W, mob/user)
-	if(IS_SCREWDRIVER(W))
-		if(!curtain_kind_path)
-			return
-
+	if(IS_SCREWDRIVER(W) && curtain_kind_path)
 		user.visible_message(
 			SPAN_NOTICE("\The [user] begins uninstalling \the [src]."),
 			SPAN_NOTICE("You begin uninstalling \the [src]."))
 		playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 
 		if(!do_after(user, 4 SECONDS, src))
-			return
+			return TRUE
 
 		if(QDELETED(src))
-			return
+			return TRUE
 
 		var/decl/curtain_kind/kind = GET_DECL(curtain_kind_path)
 		var/obj/item/curtain/C = kind.make_item(loc)
 		transfer_fingerprints_to(C)
 		qdel(src)
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/structure/curtain/proc/toggle()
 	playsound(src, 'sound/effects/curtain.ogg', 15, 1, -5)

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -26,15 +26,15 @@
 /obj/item/curtain/attackby(obj/item/W, mob/user)
 	if(IS_SCREWDRIVER(W))
 		if(!curtain_kind_path)
-			return
+			return TRUE
 
 		if(!isturf(loc))
 			to_chat(user, SPAN_DANGER("You cannot install \the [src] from your hands."))
-			return
+			return TRUE
 
 		if(isspaceturf(loc))
 			to_chat(user, SPAN_DANGER("You cannot install \the [src] in space."))
-			return
+			return TRUE
 
 		user.visible_message(
 			SPAN_NOTICE("\The [user] begins installing \the [src]."),
@@ -42,17 +42,18 @@
 		playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 
 		if(!do_after(user, 4 SECONDS, src))
-			return
+			return TRUE
 
 		if(QDELETED(src))
-			return
+			return TRUE
 
 		var/decl/curtain_kind/kind = GET_DECL(curtain_kind_path)
 		var/obj/structure/curtain/C = kind.make_structure(loc, dir)
 		transfer_fingerprints_to(C)
 		qdel(src)
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/item/curtain/on_update_icon()
 	. = ..()

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -96,22 +96,22 @@
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	var/obj/item/card/id/id = W.GetIdCard()
 	if(istype(id))
-		if(allowed(usr))
+		if(allowed(user))
 			locked = !locked
 			to_chat(user, "\The [src] was [locked ? "locked" : "unlocked"].")
 		else
 			to_chat(user, "\The [src]'s card reader denies you access.")
-		return
+		return TRUE
 
 	if(isitem(W) && (!locked || destroyed))
 		if(!W.simulated || W.anchored)
-			return
+			return FALSE
 
 		if(user.try_unequip(W, src))
 			W.pixel_x = 0
 			W.pixel_y = -7
 			update_icon()
-		return
+		return TRUE
 	. = ..()
 
 /obj/structure/displaycase/attack_hand(mob/user)
@@ -137,3 +137,4 @@
 		visible_message(SPAN_WARNING("[user] kicks \the [src]."), SPAN_WARNING("You kick \the [src]."))
 		take_damage(2)
 		return TRUE
+	return FALSE

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -126,7 +126,7 @@
 		var/obj/item/selected_item
 		selected_item = show_radial_menu(user, src, make_item_radial_menu_choices(src), radius = 42, require_near = TRUE, use_labels = RADIAL_LABELS_OFFSET)
 		if(QDELETED(selected_item) || !contents.Find(selected_item) || !Adjacent(user) || user.incapacitated())
-			return
+			return TRUE
 
 		to_chat(user, SPAN_NOTICE("You remove \the [selected_item] from \the [src]."))
 		selected_item.dropInto(loc)

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -128,10 +128,10 @@
 	if(IS_PEN(W))
 		var/t = sanitize_safe(input(user, "Enter the name for the door.", src.name, src.created_name), MAX_NAME_LEN)
 		if(!length(t))
-			return
+			return TRUE
 		if(!CanPhysicallyInteractWith(user, src))
 			to_chat(user, SPAN_WARNING("You must stay close to \the [src]!"))
-			return
+			return TRUE
 		created_name = t
 		return TRUE
 
@@ -144,7 +144,7 @@
 				if(glass_material_datum)
 					var/mat_name = glass_material_datum.solid_name || glass_material_datum.name
 					user.visible_message("[user] welds the [mat_name] plating off the airlock assembly.", "You start to weld the [mat_name] plating off the airlock assembly.")
-					if(do_after(user, 40,src))
+					if(do_after(user, 4 SECONDS, src))
 						if(!WT.isOn())
 							return TRUE
 						to_chat(user, "<span class='notice'>You welded the [mat_name] plating off!</span>")
@@ -154,12 +154,12 @@
 					return TRUE
 			if(!anchored)
 				user.visible_message("[user] dissassembles the airlock assembly.", "You start to dissassemble the airlock assembly.")
-				if(do_after(user, 40,src))
+				if(do_after(user, 4 SECONDS, src))
 					if(!WT.isOn())
-						return
+						return TRUE
 					to_chat(user, "<span class='notice'>You dissasembled the airlock assembly!</span>")
 					dismantle_structure(user)
-					return TRUE
+				return TRUE
 		else
 			to_chat(user, "<span class='notice'>You need more welding fuel.</span>")
 			return TRUE
@@ -171,52 +171,56 @@
 		else
 			user.visible_message("[user] begins securing the airlock assembly to the floor.", "You begin securing the airlock assembly to the floor.")
 
-		if(do_after(user, 40,src))
-			if(!src) return
+		if(do_after(user, 4 SECONDS, src))
+			if(QDELETED(src)) return TRUE
 			to_chat(user, "<span class='notice'>You [anchored? "un" : ""]secured the airlock assembly!</span>")
 			anchored = !anchored
 			update_icon()
+		return TRUE
 
 
 	else if(IS_COIL(W) && state == 0 && anchored)
 		var/obj/item/stack/cable_coil/C = W
 		if (C.get_amount() < 1)
 			to_chat(user, "<span class='warning'>You need one length of coil to wire the airlock assembly.</span>")
-			return
+			return TRUE
 		user.visible_message("[user] wires the airlock assembly.", "You start to wire the airlock assembly.")
-		if(do_after(user, 40,src) && state == 0 && anchored)
+		if(do_after(user, 4 SECONDS, src) && state == 0 && anchored)
 			if (C.use(1))
 				src.state = 1
 				to_chat(user, "<span class='notice'>You wire the airlock.</span>")
 				update_icon()
+		return TRUE
 
 	else if(IS_WIRECUTTER(W) && state == 1 )
 		playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
 		user.visible_message("[user] cuts the wires from the airlock assembly.", "You start to cut the wires from airlock assembly.")
 
 		if(do_after(user, 40,src))
-			if(!src) return
+			if(QDELETED(src)) return TRUE
 			to_chat(user, "<span class='notice'>You cut the airlock wires.!</span>")
 			new/obj/item/stack/cable_coil(src.loc, 1)
 			src.state = 0
 			update_icon()
+		return TRUE
 
 	else if(istype(W, /obj/item/stock_parts/circuitboard/airlock_electronics) && state == 1)
 		var/obj/item/stock_parts/circuitboard/airlock_electronics/E = W
 		if(!ispath(airlock_type, E.build_path))
-			return
+			return FALSE
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
 		user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
 
 		if(do_after(user, 40,src))
-			if(!src) return
+			if(QDELETED(src)) return TRUE
 			if(!user.try_unequip(W, src))
-				return
+				return TRUE
 			to_chat(user, "<span class='notice'>You installed the airlock electronics!</span>")
 			src.state = 2
 			src.SetName("Near finished Airlock Assembly")
 			src.electronics = W
 			update_icon()
+		return TRUE
 
 	else if(IS_CROWBAR(W) && state == 2 )
 		//This should never happen, but just in case I guess
@@ -224,19 +228,20 @@
 			to_chat(user, "<span class='notice'>There was nothing to remove.</span>")
 			src.state = 1
 			update_icon()
-			return
+			return TRUE
 
 		playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
 		user.visible_message("\The [user] starts removing the electronics from the airlock assembly.", "You start removing the electronics from the airlock assembly.")
 
-		if(do_after(user, 40,src))
-			if(!src) return
+		if(do_after(user, 4 SECONDS, src))
+			if(QDELETED(src)) return TRUE
 			to_chat(user, "<span class='notice'>You removed the airlock electronics!</span>")
 			src.state = 1
 			src.SetName("Wired Airlock Assembly")
 			electronics.dropInto(loc)
 			electronics = null
 			update_icon()
+		return TRUE
 
 	else if(istype(W, /obj/item/stack/material) && !glass)
 		var/obj/item/stack/material/S = W
@@ -244,26 +249,28 @@
 		if (S.get_amount() >= 2)
 			playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
 			user.visible_message("[user] adds [S.name] to the airlock assembly.", "You start to install [S.name] into the airlock assembly.")
-			if(do_after(user, 40,src) && !glass)
+			if(do_after(user, 4 SECONDS, src) && !glass)
 				if (S.use(2))
 					to_chat(user, "<span class='notice'>You installed reinforced glass windows into the airlock assembly.</span>")
 					glass = 1
 					glass_material = material_name
 					update_icon()
 			return TRUE
+		return FALSE
 
 	else if(IS_SCREWDRIVER(W) && state == 2 )
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
 		to_chat(user, "<span class='notice'>Now finishing the airlock.</span>")
 
-		if(do_after(user, 40,src))
-			if(!src) return
+		if(do_after(user, 4 SECONDS, src))
+			if(QDELETED(src)) return TRUE
 			to_chat(user, "<span class='notice'>You finish the airlock!</span>")
 			var/obj/machinery/door/door = new airlock_type(get_turf(src), dir, FALSE, src)
 			door.construct_state.post_construct(door) // it eats the circuit inside Initialize
 			qdel(src)
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/structure/door_assembly/on_update_icon()
 	..()

--- a/code/game/objects/structures/drain.dm
+++ b/code/game/objects/structures/drain.dm
@@ -17,7 +17,6 @@
 		to_chat(user, "It is welded shut.")
 
 /obj/structure/hygiene/drain/attackby(var/obj/item/thing, var/mob/user)
-	..()
 	if(IS_WELDER(thing))
 		var/obj/item/weldingtool/WT = thing
 		if(WT.isOn())
@@ -26,13 +25,13 @@
 		else
 			to_chat(user, "<span class='warning'>Turn \the [thing] on, first.</span>")
 		update_icon()
-		return
+		return TRUE
 	if(IS_WRENCH(thing))
 		new /obj/item/drain(src.loc)
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 		to_chat(user, "<span class='warning'>[user] unwrenches \the [src].</span>")
 		qdel(src)
-		return
+		return TRUE
 	return ..()
 
 /obj/structure/hygiene/drain/on_update_icon()
@@ -59,7 +58,7 @@
 		playsound(src, 'sound/items/Ratchet.ogg', 50, 1)
 		to_chat(user, SPAN_NOTICE("\The [user] wrenches \the [src] down."))
 		qdel(src)
-		return
+		return TRUE
 	return ..()
 
 /obj/structure/hygiene/drain/bath

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -14,9 +14,11 @@
 	. = ..()
 	has_extinguisher = new/obj/item/chems/spray/extinguisher(src)
 
+// TODO: I wanted to make it so you had to actually use your hand to open it if it's closed, but
+// that'd be out of scope for just an attackby audit. Someone fix this so it can call parent please.
 /obj/structure/extinguisher_cabinet/attackby(obj/item/O, mob/user)
 	if(isrobot(user))
-		return
+		return FALSE
 	if(istype(O, /obj/item/chems/spray/extinguisher))
 		if(!has_extinguisher && opened && user.try_unequip(O, src))
 			has_extinguisher = O
@@ -27,6 +29,7 @@
 	else
 		opened = !opened
 	update_icon()
+	return TRUE
 
 
 /obj/structure/extinguisher_cabinet/attack_hand(mob/user)

--- a/code/game/objects/structures/fences.dm
+++ b/code/game/objects/structures/fences.dm
@@ -91,11 +91,11 @@
 	if(IS_WIRECUTTER(tool))
 		if(!cuttable)
 			to_chat(user, SPAN_WARNING("This section of the fence can't be cut."))
-			return
+			return TRUE
 		var/current_stage = hole_size
 		if(current_stage >= MAX_HOLE_SIZE)
 			to_chat(user, SPAN_NOTICE("This fence has too much cut out of it already."))
-			return
+			return TRUE
 
 		if(tool.do_tool_interaction(TOOL_WIRECUTTERS, user, src, CUT_TIME, "cutting through", "cutting through", check_skill = FALSE) && current_stage == hole_size) // do_tool_interaction sleeps, so make sure it hasn't been cut more while we waited
 			switch(++hole_size)

--- a/code/game/objects/structures/fireaxe_cabinet.dm
+++ b/code/game/objects/structures/fireaxe_cabinet.dm
@@ -68,7 +68,7 @@
 
 	if(IS_MULTITOOL(O))
 		toggle_lock(user)
-		return
+		return TRUE
 
 	if(istype(O, /obj/item/bladed/axe/fire))
 		if(open)
@@ -79,7 +79,7 @@
 				fireaxe = O
 				to_chat(user, "<span class='notice'>You place \the [fireaxe] into \the [src].</span>")
 				update_icon()
-			return
+			return TRUE
 
 	var/force = O.get_attack_force(user)
 	if(force)
@@ -89,15 +89,15 @@
 		visible_message("<span class='danger'>[user] [pick(O.attack_verb)] \the [src]!</span>")
 		if(damage_threshold > force)
 			to_chat(user, "<span class='danger'>Your strike is deflected by the reinforced glass!</span>")
-			return
+			return TRUE
 		if(shattered)
-			return
+			return TRUE
 		shattered = 1
 		unlocked = 1
 		open = 1
 		playsound(user, 'sound/effects/Glassbr3.ogg', 100, 1)
 		update_icon()
-		return
+		return TRUE
 
 	return ..()
 

--- a/code/game/objects/structures/fitness.dm
+++ b/code/game/objects/structures/fitness.dm
@@ -47,6 +47,8 @@
 		playsound(src.loc, 'sound/items/Deconstruct.ogg', 75, 1)
 		weight = (weight % max_weight) + 1
 		to_chat(user, "You set the machine's weight level to [weight].")
+		return TRUE
+	return ..()
 
 /obj/structure/fitness/weightlifter/attack_hand(mob/user)
 	if(!ishuman(user))

--- a/code/game/objects/structures/flaps.dm
+++ b/code/game/objects/structures/flaps.dm
@@ -47,11 +47,14 @@
 		if(user.do_skilled(3 SECONDS, SKILL_CONSTRUCTION, src))
 			user.visible_message("<span class='warning'>\The [user] deconstructs \the [src].</span>", "<span class='warning'>You deconstruct \the [src].</span>")
 			qdel(src)
+		return TRUE
 	if(IS_SCREWDRIVER(W) && anchored)
 		airtight = !airtight
 		airtight ? become_airtight() : clear_airtight()
 		user.visible_message("<span class='warning'>\The [user] adjusts \the [src], [airtight ? "preventing" : "allowing"] air flow.</span>")
-	else ..()
+		return TRUE
+	else
+		return ..()
 
 /obj/structure/flaps/explosion_act(severity)
 	..()

--- a/code/game/objects/structures/fountain.dm
+++ b/code/game/objects/structures/fountain.dm
@@ -33,7 +33,7 @@
 	var/datum/appearance_descriptor/age/age = my_bodytype && LAZYACCESS(my_bodytype.appearance_descriptors, "age")
 	if(H.isSynthetic() || !my_bodytype || !age)
 		to_chat(H, SPAN_WARNING("A feeling of foreboding stills your hand. The fountain is not for your kind."))
-		return
+		return TRUE
 
 	if(alert("As you reach out to touch the fountain, a feeling of doubt overcomes you. Steel yourself and proceed?",,"Yes", "No") == "Yes")
 		visible_message("\The [H] touches \the [src].")

--- a/code/game/objects/structures/fuel_port.dm
+++ b/code/game/objects/structures/fuel_port.dm
@@ -52,6 +52,7 @@
 		add_overlay("[icon_state]_closed")
 
 /obj/structure/fuel_port/attackby(obj/item/W, mob/user)
+	. = FALSE
 	if(W.do_tool_interaction(TOOL_CROWBAR, user, src, 1 SECOND))
 		if(open)
 			playsound(src, sound_open, 25, 0, -3)

--- a/code/game/objects/structures/fuel_port.dm
+++ b/code/game/objects/structures/fuel_port.dm
@@ -59,19 +59,22 @@
 		else
 			playsound(src, sound_close, 15, 1, -3)
 			open = TRUE
+		. = TRUE
 
 	else if(istype(W, /obj/item/tank))
 		if(!open)
 			to_chat(user, SPAN_WARNING("\The [src] door is still closed!"))
-			return
+			return TRUE
 
 		if(locate_tank())
 			to_chat(user, SPAN_WARNING("\The [src] already has a tank inside!"))
-			return
+			return TRUE
 		else
 			user.try_unequip(W, src)
+			. = TRUE
 
-	update_icon()
+	if(.)
+		update_icon()
 
 // Walls hide stuff inside them, but we want to be visible.
 /obj/structure/fuel_port/hide()

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -101,7 +101,7 @@
 		if(istype(W, /obj/item/gun/energy/plasmacutter))
 			var/obj/item/gun/energy/plasmacutter/cutter = W
 			if(!cutter.slice(user))
-				return
+				return TRUE
 		playsound(src.loc, 'sound/items/Welder.ogg', 100, 1)
 		visible_message(SPAN_NOTICE("\The [user] begins slicing apart \the [src] with \the [W]."))
 		if(do_after(user,reinf_material ? 40: 20,src))

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -191,7 +191,7 @@
 	if(istype(W,/obj/item/stack/material))
 		var/obj/item/stack/material/ST = W
 		if(ST.material.opacity > 0.7)
-			return 0
+			return FALSE
 
 		var/dir_to_set = 5
 		if(!is_on_frame())
@@ -201,7 +201,7 @@
 				dir_to_set = get_dir(loc, user)
 				if(dir_to_set & (dir_to_set - 1)) //Only works for cardinal direcitons, diagonals aren't supposed to work like this.
 					to_chat(user, "<span class='notice'>You can't reach.</span>")
-					return
+					return TRUE
 		place_window(user, loc, dir_to_set, ST)
 		return TRUE
 

--- a/code/game/objects/structures/holosigns.dm
+++ b/code/game/objects/structures/holosigns.dm
@@ -28,6 +28,7 @@
 /obj/structure/holosign/attackby(obj/W, mob/user)
 	visible_message(SPAN_NOTICE("\The [user] waves \a [W] through \the [src], causing it to dissipate."))
 	deactivate(user)
+	return TRUE
 
 /obj/structure/holosign/proc/deactivate(mob/living/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)

--- a/code/game/objects/structures/ironing_board.dm
+++ b/code/game/objects/structures/ironing_board.dm
@@ -63,22 +63,22 @@
 	if(!density)
 		if(istype(I,/obj/item/clothing) || istype(I,/obj/item/ironingiron))
 			to_chat(user, "<span class='notice'>[src] isn't deployed!</span>")
-			return
+			return TRUE
 		return ..()
 
 	if(istype(I,/obj/item/clothing))
 		if(cloth)
 			to_chat(user, "<span class='notice'>[cloth] is already on the ironing table!</span>")
-			return
+			return TRUE
 		if(buckled_mob)
 			to_chat(user, "<span class='notice'>[buckled_mob] is already on the ironing table!</span>")
-			return
+			return TRUE
 
 		if(user.try_unequip(I, src))
 			cloth = I
 			events_repository.register(/decl/observ/destroyed, I, src, TYPE_PROC_REF(/obj/structure/bed/roller/ironingboard, remove_item))
 			update_icon()
-		return
+		return TRUE
 	else if(istype(I,/obj/item/ironingiron))
 		var/obj/item/ironingiron/R = I
 
@@ -90,32 +90,32 @@
 
 			visible_message("<span class='danger'>[user] begins ironing [src.buckled_mob]'s [parsed]!</span>", "<span class='danger'>You begin ironing [buckled_mob]'s [parsed]!</span>")
 			if(!do_after(user, 40, src))
-				return
+				return TRUE
 			visible_message("<span class='danger'>[user] irons [src.buckled_mob]'s [parsed]!</span>", "<span class='danger'>You iron [buckled_mob]'s [parsed]!</span>")
 
 			var/obj/item/organ/external/affecting = GET_EXTERNAL_ORGAN(H, zone)
 			affecting.take_external_damage(0, 15, used_weapon = "Hot metal")
 
-			return
+			return TRUE
 
 		if(!cloth)
 			if(!holding && !R.enabled && user.try_unequip(I, src))
 				holding = R
 				events_repository.register(/decl/observ/destroyed, I, src, TYPE_PROC_REF(/obj/structure/bed/roller/ironingboard, remove_item))
 				update_icon()
-				return
+				return TRUE
 			to_chat(user, "<span class='notice'>There isn't anything on the ironing board.</span>")
-			return
+			return TRUE
 
 		visible_message("[user] begins ironing [cloth].")
-		if(!do_after(user, 40, src))
-			return
+		if(!do_after(user, 4 SECONDS, src))
+			return TRUE
 
 		visible_message("[user] finishes ironing [cloth].")
 		cloth.ironed_state = WRINKLES_NONE
-		return
+		return TRUE
 
-	..()
+	return ..()
 
 /obj/structure/bed/roller/ironingboard/attack_hand(var/mob/user)
 	if(!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE) || buckled_mob)

--- a/code/game/objects/structures/iv_drip.dm
+++ b/code/game/objects/structures/iv_drip.dm
@@ -88,12 +88,13 @@
 	if (istype(W, /obj/item/chems))
 		if(!isnull(src.beaker))
 			to_chat(user, "There is already a reagent container loaded!")
-			return
+			return TRUE
 		if(!user.try_unequip(W, src))
-			return
+			return TRUE
 		beaker = W
 		to_chat(user, "You attach \the [W] to \the [src].")
 		queue_icon_update()
+		return TRUE
 	else
 		return ..()
 

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -27,11 +27,12 @@
 /obj/structure/janitorialcart/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/bag/trash) && !mybag)
 		if(!user.try_unequip(I, src))
-			return
+			return TRUE
 		mybag = I
 		update_icon()
 		updateUsrDialog()
 		to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
+		return TRUE
 
 	else if(istype(I, /obj/item/mop))
 		if(I.reagents.total_volume < I.reagents.maximum_volume)	//if it's not completely soaked we assume they want to wet it, otherwise store it
@@ -41,47 +42,52 @@
 				reagents.trans_to_obj(I, I.reagents.maximum_volume)
 				to_chat(user, "<span class='notice'>You wet [I] in [src].</span>")
 				playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
-				return
+			return TRUE
 		if(!mymop)
 			if(!user.try_unequip(I, src))
-				return
+				return TRUE
 			mymop = I
 			update_icon()
 			updateUsrDialog()
 			to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
+			return TRUE
 
 	else if(istype(I, /obj/item/chems/spray) && !myspray)
 		if(!user.try_unequip(I, src))
-			return
+			return TRUE
 		myspray = I
 		update_icon()
 		updateUsrDialog()
 		to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
+		return TRUE
 
 	else if(istype(I, /obj/item/lightreplacer) && !myreplacer)
 		if(!user.try_unequip(I, src))
-			return
+			return TRUE
 		myreplacer = I
 		update_icon()
 		updateUsrDialog()
 		to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
+		return TRUE
 
 	else if(istype(I, /obj/item/caution))
 		if(signs < 4)
 			if(!user.try_unequip(I, src))
-				return
+				return TRUE
 			signs++
 			update_icon()
 			updateUsrDialog()
 			to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
 		else
 			to_chat(user, "<span class='notice'>[src] can't hold any more signs.</span>")
+		return TRUE
 
 	else if(istype(I, /obj/item/chems/glass))
-		return // So we do not put them in the trash bag as we mean to fill the mop bucket
+		return FALSE // So we do not put them in the trash bag as we mean to fill the mop bucket; FALSE means run afterattack
 
 	else if(mybag)
-		mybag.attackby(I, user)
+		return mybag.attackby(I, user)
+	return ..()
 
 
 /obj/structure/janitorialcart/attack_hand(mob/user)
@@ -225,7 +231,7 @@
 
 	if(istype(I, /obj/item/bag/trash))
 		if(!user.try_unequip(I, src))
-			return
+			return TRUE
 		to_chat(user, SPAN_NOTICE("You hook \the [I] onto the [callme]."))
 		mybag = I
 		return TRUE

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -65,22 +65,21 @@
 	physically_destroyed()
 
 /obj/structure/lattice/attackby(obj/item/C, mob/user)
-
 	if (istype(C, /obj/item/stack/tile))
 		var/turf/T = get_turf(src)
 		T.attackby(C, user) //BubbleWrap - hand this off to the underlying turf instead
-		return
+		return TRUE
 	if(IS_WELDER(C))
 		var/obj/item/weldingtool/WT = C
 		if(WT.weld(0, user))
 			deconstruct(user)
-		return
+		return TRUE
 	if(istype(C, /obj/item/gun/energy/plasmacutter))
 		var/obj/item/gun/energy/plasmacutter/cutter = C
 		if(!cutter.slice(user))
-			return
+			return TRUE
 		deconstruct(user)
-		return
+		return TRUE
 	if (istype(C, /obj/item/stack/material/rods))
 
 		var/ladder = (locate(/obj/structure/ladder) in loc)
@@ -91,13 +90,15 @@
 		var/obj/item/stack/material/rods/R = C
 		if(locate(/obj/structure/catwalk) in get_turf(src))
 			to_chat(user, SPAN_WARNING("There is already a catwalk here."))
-			return
+			return TRUE
 		else if(R.use(2))
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 			new /obj/structure/catwalk(src.loc, R.material.type)
-			return
+			return TRUE
 		else
 			to_chat(user, SPAN_WARNING("You require at least two rods to complete the catwalk."))
+			return TRUE
+	return ..()
 
 /obj/structure/lattice/on_update_icon()
 	..()

--- a/code/game/objects/structures/memorial.dm
+++ b/code/game/objects/structures/memorial.dm
@@ -18,6 +18,8 @@
 		to_chat(user, "<span class='warning'>You add \the [T.owner_name]'s \the [T] to \the [src].</span>")
 		fallen += "[T.owner_rank] [T.owner_name] | [T.owner_branch]"
 		qdel(T)
+		return TRUE
+	return ..()
 
 /obj/structure/memorial/examine(mob/user, distance)
 	. = ..()

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -27,3 +27,5 @@
 			playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 		else
 			to_chat(user, SPAN_WARNING("\The [I] is saturated."))
+		return TRUE
+	return ..()

--- a/code/game/objects/structures/pit.dm
+++ b/code/game/objects/structures/pit.dm
@@ -314,7 +314,7 @@
 		var/msg = sanitize(input(user, "What should it say?", "Grave marker", html_decode(message)) as text|null)
 		if(!CanPhysicallyInteract(user))
 			to_chat(user, SPAN_WARNING("You must stay close to \the [src]!"))
-			return
+			return TRUE
 		if(msg && used_item.do_tool_interaction(TOOL_PEN, user, src, 1 SECOND, fuel_expenditure = 1))
 			message = msg
 		return TRUE

--- a/code/game/objects/structures/pit.dm
+++ b/code/game/objects/structures/pit.dm
@@ -180,7 +180,7 @@
 		var/msg = sanitize(input(user, "What should it say?", "Grave marker", html_decode(message)) as text|null)
 		if(!CanPhysicallyInteract(user))
 			to_chat(user, SPAN_WARNING("You must stay close to \the [src]!"))
-			return
+			return TRUE
 		if(msg && used_item.do_tool_interaction(TOOL_PEN, user, src, 1 SECOND, fuel_expenditure = 1))
 			message = msg
 		return TRUE

--- a/code/game/objects/structures/quicksand.dm
+++ b/code/game/objects/structures/quicksand.dm
@@ -82,8 +82,9 @@
 /obj/effect/quicksand/attackby(obj/item/W, mob/user)
 	if(!exposed && W.get_attack_force(user))
 		expose()
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/effect/quicksand/Crossed(atom/movable/AM)
 	if(!isliving(AM))

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -235,19 +235,19 @@ WOOD_RAILING_SUBTYPE(yew)
 	visible_message(SPAN_DANGER("\The [user] throws \the [victim] over \the [src]!"))
 	return TRUE
 
+// TODO: rewrite to use handle_default_wrench_attackby, bash, etc
 /obj/structure/railing/attackby(var/obj/item/W, var/mob/user)
-
 	// Dismantle
 	if(IS_WRENCH(W))
 		if(!anchored)
 			playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
-			if(do_after(user, 20, src))
+			if(do_after(user, 2 SECONDS, src))
 				if(anchored)
-					return
+					return TRUE
 				user.visible_message("<span class='notice'>\The [user] dismantles \the [src].</span>", "<span class='notice'>You dismantle \the [src].</span>")
 				material.create_object(loc, 2)
 				qdel(src)
-			return
+			return TRUE
 	// Wrench Open
 		else
 			playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
@@ -258,7 +258,7 @@ WOOD_RAILING_SUBTYPE(yew)
 				user.visible_message("<span class='notice'>\The [user] wrenches \the [src] closed.</span>", "<span class='notice'>You wrench \the [src] closed.</span>")
 				density = TRUE
 			update_icon()
-			return
+			return TRUE
 	// Repair
 	if(IS_WELDER(W))
 		var/obj/item/weldingtool/F = W
@@ -266,34 +266,34 @@ WOOD_RAILING_SUBTYPE(yew)
 			var/current_max_health = get_max_health()
 			if(current_health >= current_max_health)
 				to_chat(user, "<span class='warning'>\The [src] does not need repairs.</span>")
-				return
+				return TRUE
 			playsound(loc, 'sound/items/Welder.ogg', 50, 1)
 			if(do_after(user, 20, src))
 				if(current_health >= current_max_health)
-					return
+					return TRUE
 				user.visible_message("<span class='notice'>\The [user] repairs some damage to \the [src].</span>", "<span class='notice'>You repair some damage to \the [src].</span>")
 				current_health = min(current_health+(current_max_health/5), current_max_health)
-			return
+			return TRUE
 
 	// Install
 	if(IS_SCREWDRIVER(W))
 		if(!density)
 			to_chat(user, "<span class='notice'>You need to wrench \the [src] from back into place first.</span>")
-			return
+			return TRUE
 		user.visible_message(anchored ? "<span class='notice'>\The [user] begins unscrew \the [src].</span>" : "<span class='notice'>\The [user] begins fasten \the [src].</span>" )
 		playsound(loc, 'sound/items/Screwdriver.ogg', 75, 1)
 		if(do_after(user, 10, src) && density)
 			to_chat(user, (anchored ? "<span class='notice'>You have unfastened \the [src] from the floor.</span>" : "<span class='notice'>You have fastened \the [src] to the floor.</span>"))
 			anchored = !anchored
 			update_icon()
-		return
+		return TRUE
 
 	var/force = W.get_attack_force(user)
 	if(force && (W.atom_damage_type == BURN || W.atom_damage_type == BRUTE))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		visible_message("<span class='danger'>\The [src] has been [LAZYLEN(W.attack_verb) ? pick(W.attack_verb) : "attacked"] with \the [W] by \the [user]!</span>")
 		take_damage(force, W.atom_damage_type)
-		return
+		return TRUE
 	. = ..()
 
 /obj/structure/railing/explosion_act(severity)

--- a/code/game/objects/structures/rubble.dm
+++ b/code/game/objects/structures/rubble.dm
@@ -51,7 +51,7 @@
 	if(!is_rummaging)
 		if(!lootleft)
 			to_chat(user, SPAN_NOTICE("There's nothing left in this one but unusable garbage..."))
-			return
+			return TRUE
 		visible_message(SPAN_NOTICE("\The [user] starts rummaging through \the [src]."))
 		is_rummaging = TRUE
 		if(do_after(user, 30))

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -21,10 +21,11 @@ FLOOR SAFES
 	var/space = 0		//the combined w_class of everything in the safe
 	var/maxspace = 24	//the maximum combined w_class of stuff in the safe
 
+// TODO: make this use a storage datum?
 /obj/structure/safe/Initialize()
 	for(var/obj/item/I in loc)
 		if(space >= maxspace)
-			return
+			break
 		if(I.w_class + space <= maxspace) //todo replace with internal storage or something
 			space += I.w_class
 			I.forceMove(src)
@@ -142,18 +143,19 @@ FLOOR SAFES
 	if(open)
 		if(I.w_class + space <= maxspace)
 			if(!user.try_unequip(I, src))
-				return
+				return TRUE
 			space += I.w_class
 			to_chat(user, "<span class='notice'>You put [I] in [src].</span>")
 			updateUsrDialog()
-			return
+			return TRUE
 		else
 			to_chat(user, "<span class='notice'>[I] won't fit in [src].</span>")
-			return
+			return TRUE
 	else
 		if(istype(I, /obj/item/clothing/neck/stethoscope))
 			to_chat(user, "Hold [I] in one of your hands while you manipulate the dial.")
-			return
+			return TRUE
+		return FALSE
 
 
 /obj/structure/safe/explosion_act(severity)

--- a/code/game/objects/structures/skele_stand.dm
+++ b/code/game/objects/structures/skele_stand.dm
@@ -61,18 +61,21 @@
 		var/nuname = sanitize(input(user,"What do you want to name this skeleton as?","Skeleton Christening",name) as text|null)
 		if(nuname && CanPhysicallyInteract(user))
 			SetName(nuname)
-			return 1
+			return TRUE
 	if(istype(W,/obj/item/clothing))
 		var/obj/item/clothing/clothes = W
-		if(clothes.fallback_slot)
-			if(swag[clothes.fallback_slot])
-				to_chat(user,SPAN_NOTICE("There is already that kind of clothing on \the [src]."))
-			else if(user.try_unequip(W, src))
-				swag[clothes.fallback_slot] = W
-				update_icon()
-				return 1
-	else
+		if(!clothes.fallback_slot)
+			return FALSE
+		if(swag[clothes.fallback_slot])
+			to_chat(user,SPAN_NOTICE("There is already that kind of clothing on \the [src]."))
+		else if(user.try_unequip(W, src))
+			swag[clothes.fallback_slot] = W
+			update_icon()
+		return TRUE
+	. = ..()
+	if(!.)
 		rattle_bones(user, W)
+		return TRUE
 
 /obj/structure/skele_stand/Destroy()
 	for(var/slot in swag)

--- a/code/game/objects/structures/stool_bed_chair_nest_sofa/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest_sofa/bed.dm
@@ -191,6 +191,7 @@
 	anchored = FALSE
 	buckle_pixel_shift = list("x" = 0, "y" = 0, "z" = 6)
 	movable_flags = MOVABLE_FLAG_WHEELED
+	tool_interaction_flags = 0
 	var/item_form_type = /obj/item/roller	//The folded-up object path.
 	var/obj/item/chems/beaker
 	var/iv_attached = 0
@@ -214,17 +215,18 @@
 			iv.pixel_y = 6
 		add_overlay(iv)
 
+/obj/structure/bed/roller/can_apply_padding()
+	return FALSE
+
 /obj/structure/bed/roller/attackby(obj/item/I, mob/user)
-	if(IS_WRENCH(I) || istype(I, /obj/item/stack) || IS_WIRECUTTER(I))
-		return 1
 	if(iv_stand && !beaker && istype(I, /obj/item/chems))
 		if(!user.try_unequip(I, src))
-			return
+			return TRUE
 		to_chat(user, "You attach \the [I] to \the [src].")
 		beaker = I
 		queue_icon_update()
-		return 1
-	..()
+		return TRUE
+	return ..()
 
 /obj/structure/bed/roller/attack_hand(mob/user)
 	if(!beaker || buckled_mob || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))

--- a/code/game/objects/structures/stool_bed_chair_nest_sofa/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest_sofa/chairs.dm
@@ -304,10 +304,8 @@
 	color = WOOD_COLOR_GENERIC
 	material = /decl/material/solid/organic/wood
 
-/obj/structure/bed/chair/wood/attackby(obj/item/W, mob/user)
-	if(istype(W,/obj/item/stack) || IS_WIRECUTTER(W))
-		return
-	..()
+/obj/structure/bed/chair/wood/can_apply_padding()
+	return FALSE
 
 /obj/structure/bed/chair/wood/mahogany
 	color = WOOD_COLOR_RICH

--- a/code/game/objects/structures/stool_bed_chair_nest_sofa/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest_sofa/stools.dm
@@ -101,15 +101,15 @@
 	if(IS_WRENCH(W))
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 		dismantle()
-		qdel(src)
+		return TRUE
 	else if(istype(W,/obj/item/stack))
 		if(padding_material)
 			to_chat(user, "\The [src] is already padded.")
-			return
+			return TRUE
 		var/obj/item/stack/C = W
 		if(C.get_amount() < 1) // How??
 			qdel(C)
-			return
+			return TRUE
 
 		var/padding_type
 		var/new_padding_color
@@ -124,7 +124,7 @@
 
 		if(!padding_type)
 			to_chat(user, "You cannot pad \the [src] with that.")
-			return
+			return TRUE
 
 		C.use(1)
 		if(!isturf(src.loc))
@@ -132,17 +132,18 @@
 			src.dropInto(loc)
 		to_chat(user, "You add padding to \the [src].")
 		add_padding(padding_type, new_padding_color)
-		return
+		return TRUE
 
 	else if(IS_WIRECUTTER(W))
 		if(!padding_material)
 			to_chat(user, "\The [src] has no padding to remove.")
-			return
+			return TRUE
 		to_chat(user, "You remove the padding from \the [src].")
 		playsound(src, 'sound/items/Wirecutter.ogg', 100, 1)
 		remove_padding()
+		return TRUE
 	else
-		..()
+		return ..()
 
 //Generated subtypes for mapping porpoises
 /obj/item/stool/wood

--- a/code/game/objects/structures/stool_bed_chair_nest_sofa/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest_sofa/wheelchair.dm
@@ -9,6 +9,7 @@
 		/datum/movement_handler/delay = list(5),
 		/datum/movement_handler/move_relay_self
 	)
+	tool_interaction_flags = 0
 
 	var/item_form_type = /obj/item/wheelchair_kit
 	var/bloodiness
@@ -22,10 +23,8 @@
 /obj/structure/bed/chair/wheelchair/on_update_icon()
 	set_overlays(image(icon = 'icons/obj/furniture.dmi', icon_state = "w_overlay", layer = ABOVE_HUMAN_LAYER))
 
-/obj/structure/bed/chair/wheelchair/attackby(obj/item/W, mob/user)
-	if(IS_WRENCH(W) || istype(W,/obj/item/stack) || IS_WIRECUTTER(W))
-		return
-	..()
+/obj/structure/bed/chair/wheelchair/can_apply_padding()
+	return FALSE
 
 /obj/structure/bed/chair/wheelchair/attack_hand(mob/user)
 	if(!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))

--- a/code/game/objects/structures/target_stake.dm
+++ b/code/game/objects/structures/target_stake.dm
@@ -12,6 +12,8 @@
 	if (!pinned_target && istype(W, /obj/item/target) && user.try_unequip(W, get_turf(src)))
 		to_chat(user, "<span class='notice'>You slide [W] into the stake.</span>")
 		set_target(W)
+		return TRUE
+	return ..()
 
 /obj/structure/target_stake/attack_hand(var/mob/user)
 	if (!pinned_target || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))

--- a/code/game/objects/structures/under_wardrobe.dm
+++ b/code/game/objects/structures/under_wardrobe.dm
@@ -8,12 +8,14 @@
 	density = TRUE
 	var/static/list/amount_of_underwear_by_id_card
 
-/obj/structure/undies_wardrobe/attackby(var/obj/item/underwear/underwear, var/mob/user)
-	if(istype(underwear))
+/obj/structure/undies_wardrobe/attackby(var/obj/item/item, var/mob/user)
+	if(istype(item, /obj/item/underwear))
+		var/obj/item/underwear/underwear = item
 		if(!user.try_unequip(underwear))
-			return
+			return TRUE
 		qdel(underwear)
-		user.visible_message("<span class='notice'>\The [user] inserts \their [underwear.name] into \the [src].</span>", "<span class='notice'>You insert your [underwear.name] into \the [src].</span>")
+		var/decl/pronouns/user_pronouns = user.get_pronouns()
+		user.visible_message("<span class='notice'>\The [user] inserts [user_pronouns.his] [underwear.name] into \the [src].</span>", "<span class='notice'>You insert your [underwear.name] into \the [src].</span>")
 
 		var/id = user.GetIdCard()
 		var/message
@@ -30,9 +32,9 @@
 			events_repository.register(/decl/observ/destroyed, id, src, TYPE_PROC_REF(/obj/structure/undies_wardrobe, remove_id_card))
 		else
 			remove_id_card(id)
-
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/structure/undies_wardrobe/proc/remove_id_card(var/id_card)
 	LAZYREMOVE(amount_of_underwear_by_id_card, id_card)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -48,7 +48,7 @@ var/global/list/hygiene_props = list()
 			clogged--
 			if(clogged <= 0)
 				unclog()
-		return
+		return TRUE
 	. = ..()
 
 /obj/structure/hygiene/examine(mob/user)
@@ -182,20 +182,20 @@ var/global/list/hygiene_props = list()
 				"You hear grinding porcelain.")
 			cistern = !cistern
 			update_icon()
-		return
+		return TRUE
 
 	if(cistern && !isrobot(user)) //STOP PUTTING YOUR MODULES IN THE TOILET.
 		if(I.w_class > ITEM_SIZE_NORMAL)
 			to_chat(user, SPAN_WARNING("\The [I] does not fit."))
-			return
+			return TRUE
 		if(w_items + I.w_class > ITEM_SIZE_HUGE)
 			to_chat(user, SPAN_WARNING("The cistern is full."))
-			return
+			return TRUE
 		if(!user.try_unequip(I, src))
-			return
+			return TRUE
 		w_items += I.w_class
 		to_chat(user, SPAN_NOTICE("You carefully place \the [I] into the cistern."))
-		return
+		return TRUE
 
 	. = ..()
 
@@ -286,7 +286,7 @@ var/global/list/hygiene_props = list()
 /obj/structure/hygiene/shower/attackby(obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/scanner/gas))
 		to_chat(user, SPAN_NOTICE("The water temperature seems to be [watertemp]."))
-		return
+		return TRUE
 
 	if(IS_WRENCH(I))
 		var/newtemp = input(user, "What setting would you like to set the temperature valve to?", "Water Temperature Valve") in temperature_settings
@@ -394,7 +394,7 @@ var/global/list/hygiene_props = list()
 
 	if(busy)
 		to_chat(user, SPAN_WARNING("Someone's already washing here."))
-		return
+		return TRUE
 
 	var/obj/item/chems/chem_container = hit_with
 	if (istype(chem_container) && ATOM_IS_OPEN_CONTAINER(chem_container) && chem_container.reagents)
@@ -426,14 +426,14 @@ var/global/list/hygiene_props = list()
 			playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 		else
 			to_chat(user, SPAN_WARNING("\The [hit_with] is saturated."))
-		return
+		return TRUE
 
 	var/turf/location = user.loc
 	if(!isturf(location))
-		return
+		return FALSE
 
 	if(!istype(hit_with))
-		return
+		return FALSE
 
 	to_chat(usr, SPAN_NOTICE("You start washing \the [hit_with]."))
 	playsound(loc, 'sound/effects/sink_long.ogg', 75, 1)
@@ -451,6 +451,7 @@ var/global/list/hygiene_props = list()
 	user.visible_message( \
 		SPAN_NOTICE("\The [user] washes \a [hit_with] using \the [src]."),
 		SPAN_NOTICE("You wash \a [hit_with] using \the [src]."))
+	return TRUE
 
 
 /obj/structure/hygiene/sink/kitchen
@@ -470,7 +471,7 @@ var/global/list/hygiene_props = list()
 
 /obj/structure/hygiene/sink/puddle/attackby(obj/item/O, var/mob/user)
 	icon_state = "puddle-splash"
-	..()
+	. = ..()
 	icon_state = "puddle"
 
 //toilet paper interaction for clogging toilets and other facilities
@@ -480,18 +481,19 @@ var/global/list/hygiene_props = list()
 		return ..()
 	if (clogged == -1)
 		to_chat(user, SPAN_WARNING("Try as you might, you can not clog \the [src] with \the [I]."))
-		return
+		return TRUE
 	if (clogged)
 		to_chat(user, SPAN_WARNING("\The [src] is already clogged."))
-		return
+		return TRUE
 	if (!do_after(user, 3 SECONDS, src))
 		to_chat(user, SPAN_WARNING("You must stay still to clog \the [src]."))
-		return
+		return TRUE
 	if (clogged || QDELETED(I) || !user.try_unequip(I))
-		return
+		return TRUE
 	to_chat(user, SPAN_NOTICE("You unceremoniously jam \the [src] with \the [I]. What a rebel."))
 	clog(1)
 	qdel(I)
+	return TRUE
 
 ////////////////////////////////////////////////////
 // Toilet Paper Roll

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -150,8 +150,7 @@
 		if (ishuman(user))
 			var/mob/living/human/H = user
 			if(H.species.can_shred(H))
-				attack_generic(H,25)
-				return
+				return attack_generic(H,25)
 
 		playsound(src.loc, 'sound/effects/glassknock.ogg', 80, 1)
 		user.do_attack_animation(src)
@@ -596,7 +595,7 @@
 	return TRUE
 
 /obj/structure/window/reinforced/crescent/attackby()
-	return
+	return TRUE
 
 /obj/structure/window/reinforced/crescent/explosion_act()
 	SHOULD_CALL_PARENT(FALSE)

--- a/code/game/turfs/floors/subtypes/floor_static.dm
+++ b/code/game/turfs/floors/subtypes/floor_static.dm
@@ -11,7 +11,7 @@
 
 /turf/floor/fixed/attackby(var/obj/item/C, var/mob/user)
 	if(istype(C, /obj/item/stack) && !IS_COIL(C))
-		return
+		return TRUE
 	return ..()
 
 /turf/floor/fixed/on_update_icon()

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -110,13 +110,14 @@
 		if(L)
 			var/obj/item/stack/tile/floor/S = C
 			if (!S.use(1))
-				return
+				return TRUE
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 			ChangeTurf(/turf/floor/airless)
 			qdel(L)
 		else
 			to_chat(user, "<span class='warning'>The plating is going to need some support.</span>")
 		return TRUE
+	return FALSE
 
 
 // Ported from unstable r355

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -3,7 +3,7 @@
 
 //Overwrite because we dont want people building rods in space.
 /turf/space/transit/attackby(obj/O, mob/user)
-	return
+	return TRUE
 
 /turf/space/transit/Initialize()
 	. = ..()

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -82,7 +82,7 @@
 	material = /decl/material/solid/metal/alienalloy
 
 /turf/wall/raidershuttle/attackby()
-	return
+	return TRUE
 
 //Alien metal walls
 /turf/wall/alium

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -120,15 +120,14 @@
 		var/obj/item/assembly/assembly = component
 		if(!assembly.secured && !secured)
 			attach_assembly(assembly, user)
-			return
+			return TRUE
 	if(IS_SCREWDRIVER(component))
 		if(toggle_secure())
 			to_chat(user, SPAN_NOTICE("\The [src] is ready!"))
 		else
 			to_chat(user, SPAN_NOTICE("\The [src] can now be attached!"))
-		return
-	..()
-	return
+		return TRUE
+	return ..()
 
 
 /obj/item/assembly/Process()

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -113,7 +113,7 @@
 	if(IS_SCREWDRIVER(W))
 		if(!a_left || !a_right)
 			to_chat(user, "<span class='warning'>BUG:Assembly part missing, please report this!</span>")
-			return
+			return TRUE
 		a_left.toggle_secure()
 		a_right.toggle_secure()
 		secured = !secured
@@ -122,11 +122,8 @@
 		else
 			to_chat(user, "<span class='notice'>\The [src] can now be taken apart!</span>")
 		update_icon()
-		return
-	else
-		..()
-	return
-
+		return TRUE
+	return ..()
 
 /obj/item/assembly_holder/attack_self(mob/user as mob)
 	src.add_fingerprint(user)

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -132,7 +132,7 @@
 		var/datum/browser/written_digital/popup = new (user, "Vent Configuration Utility", "[src] Configuration Panel", 600, 200)
 		popup.set_content(jointext(get_console_data(),"<br>"))
 		popup.open()
-		return
+		return TRUE
 	return ..()
 
 /decl/public_access/public_variable/volume_rate

--- a/code/modules/augment/active/circuit.dm
+++ b/code/modules/augment/active/circuit.dm
@@ -20,7 +20,7 @@
 			holding = null
 			playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
 		else to_chat(user, SPAN_WARNING("The augment is empty!"))
-		return
+		return TRUE
 	if(istype(W, /obj/item/electronic_assembly/augment))
 		if(holding)
 			to_chat(user, SPAN_WARNING("There's already an assembly in there."))
@@ -28,6 +28,5 @@
 			holding = W
 			holding.canremove = 0
 			playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
-		return
-
-	..()
+		return TRUE
+	return ..()

--- a/code/modules/augment/active/cyberbrain.dm
+++ b/code/modules/augment/active/cyberbrain.dm
@@ -56,7 +56,8 @@
 
 /obj/item/organ/internal/augment/active/cyberbrain/attackby(var/obj/item/W, var/mob/user)
 	var/datum/extension/assembly/assembly = get_extension(src, /datum/extension/assembly)
-	if(assembly.attackby(W, user))
+	. = assembly.attackby(W, user)
+	if(.)
 		return
 	return ..()
 

--- a/code/modules/augment/augment.dm
+++ b/code/modules/augment/augment.dm
@@ -24,8 +24,8 @@
 		organ_tag = input(user, "Adjust installation parameters") as null|anything in allowed_organs
 		update_parent_organ()
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-		return
-	..()
+		return TRUE
+	return ..()
 
 /obj/item/organ/internal/augment/do_install(var/mob/living/human/target, var/obj/item/organ/external/affected, var/in_place = FALSE, var/update_icon = TRUE, var/detached = FALSE)
 	. = ..()

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -130,7 +130,8 @@
 /obj/machinery/gateway/centerstation/attackby(obj/item/W, mob/user)
 	if(IS_MULTITOOL(W))
 		to_chat(user, "The gate is already calibrated, there is no work for you to do here.")
-		return
+		return TRUE
+	return FALSE
 
 /////////////////////////////////////Away////////////////////////
 
@@ -226,8 +227,9 @@
 	if(IS_MULTITOOL(W))
 		if(calibrated)
 			to_chat(user, "The gate is already calibrated, there is no work for you to do here.")
-			return
+			return TRUE
 		else
 			to_chat(user, "<span class='notice'><b>Recalibration successful!</b></span>: This gate's systems have been fine tuned.  Travel to this gate will now be on target.")
 			calibrated = 1
-			return
+			return TRUE
+	return FALSE

--- a/code/modules/awaymissions/loot.dm
+++ b/code/modules/awaymissions/loot.dm
@@ -12,7 +12,7 @@
 	if(things && things.len)
 		for(var/i = lootcount, i > 0, i--)
 			if(!things.len)
-				return
+				break
 
 			var/loot_spawn = pick(things)
 			var/loot_path = text2path(loot_spawn)

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -168,16 +168,16 @@
 	if(IS_WIRECUTTER(W))
 		if(prob(user.skill_fail_chance(SKILL_SCIENCE, 90, SKILL_EXPERT)))
 			to_chat(user, SPAN_WARNING("You fail to collect a sample from \the [src]."))
-			return
+			return TRUE
 		else
 			if(!pruned)
 				to_chat(user, SPAN_NOTICE("You collect a sample from \the [src]."))
 				new product(user.loc)
 				pruned = TRUE
-				return
+				return TRUE
 			else
 				to_chat(user, SPAN_WARNING("\The [src] has already been pruned."))
-				return
+				return TRUE
 
 	var/damage = 0
 	switch(W.atom_damage_type)
@@ -189,7 +189,7 @@
 			damage = (W.get_attack_force(user) / brute_resist)
 
 	take_damage(damage, W.atom_damage_type)
-	return
+	return TRUE
 
 /obj/effect/blob/core
 	name = "master nucleus"

--- a/code/modules/clothing/_clothing_accessories.dm
+++ b/code/modules/clothing/_clothing_accessories.dm
@@ -65,7 +65,7 @@
 	if(length(accessories))
 		for(var/obj/item/clothing/accessory in accessories)
 			accessory.attackby(I, user)
-		return
+		return TRUE
 
 	. = ..()
 

--- a/code/modules/clothing/badges/holobadge.dm
+++ b/code/modules/clothing/badges/holobadge.dm
@@ -46,7 +46,7 @@
 		var/obj/item/card/id/id_card = O.GetIdCard()
 
 		if(!id_card)
-			return
+			return TRUE
 
 		if((badge_access in id_card.access) || emagged)
 			to_chat(user, "You imprint your ID details onto the badge.")
@@ -54,8 +54,8 @@
 			set_desc(user)
 		else
 			to_chat(user, "[src] rejects your ID, and flashes 'Insufficient access!'")
-		return
-	..()
+		return TRUE
+	return ..()
 
 /obj/item/box/holobadge
 	name = "holobadge box"

--- a/code/modules/clothing/gloves/jewelry/rings/material.dm
+++ b/code/modules/clothing/gloves/jewelry/rings/material.dm
@@ -12,12 +12,15 @@
 /obj/item/clothing/gloves/ring/material/attackby(var/obj/item/S, var/mob/user)
 	if(S.sharp)
 		var/inscription = sanitize(input("Enter an inscription to engrave.", "Inscription") as null|text)
-		if(!user.stat && !user.incapacitated() && user.Adjacent(src) && S.loc == user)
-			if(!inscription)
-				return
-			desc = "A ring made from [material.solid_name]."
-			to_chat(user, "<span class='warning'>You carve \"[inscription]\" into \the [src].</span>")
-			desc += "<br>Written on \the [src] is the inscription \"[inscription]\""
+		if(user.stat || !user.incapacitated() || !user.Adjacent(src) || S.loc != user)
+			return TRUE
+		if(!inscription)
+			return TRUE
+		desc = "A ring made from [material.solid_name]."
+		to_chat(user, "<span class='warning'>You carve \"[inscription]\" into \the [src].</span>")
+		desc += "<br>Written on \the [src] is the inscription \"[inscription]\""
+		return TRUE
+	return ..()
 
 /obj/item/clothing/gloves/ring/material/OnTopic(var/mob/user, var/list/href_list)
 	if(href_list["examine"])

--- a/code/modules/clothing/masks/cig_crafting.dm
+++ b/code/modules/clothing/masks/cig_crafting.dm
@@ -59,19 +59,20 @@
 	seed = "finetobacco"
 
 /obj/item/clothing/mask/smokable/cigarette/rolled/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/cigarette_filter))
-		if(filter)
-			to_chat(user, "<span class='warning'>[src] already has a filter!</span>")
-			return
-		if(lit)
-			to_chat(user, "<span class='warning'>[src] is lit already!</span>")
-			return
-		if(user.try_unequip(I))
-			to_chat(user, "<span class='notice'>You stick [I] into \the [src]</span>")
-			filter = 1
-			SetName("filtered [name]")
-			brand = "[brand] with a filter"
-			update_icon()
-			qdel(I)
-			return
-	..()
+	if(!istype(I, /obj/item/cigarette_filter))
+		return ..()
+	if(filter)
+		to_chat(user, "<span class='warning'>[src] already has a filter!</span>")
+		return TRUE
+	if(lit)
+		to_chat(user, "<span class='warning'>[src] is lit already!</span>")
+		return TRUE
+	if(!user.try_unequip(I))
+		return TRUE
+	to_chat(user, "<span class='notice'>You stick [I] into \the [src]</span>")
+	filter = 1
+	SetName("filtered [name]")
+	brand = "[brand] with a filter"
+	update_icon()
+	qdel(I)
+	return TRUE

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -110,7 +110,7 @@
 
 	if(ismob(loc))
 		var/mob/living/M = loc
-		M.update_equipment_overlay(slot_wear_mask_str, FALSE)
+		update_clothing_icon(do_update_icon = FALSE)
 		M.update_inhand_overlays()
 
 /obj/item/clothing/mask/smokable/adjust_mob_overlay(mob/living/user_mob, bodytype, image/overlay, slot, bodypart, use_fallback_if_icon_missing = TRUE)
@@ -160,7 +160,6 @@
 	update_icon()
 
 /obj/item/clothing/mask/smokable/attackby(var/obj/item/W, var/mob/user)
-	..()
 	if(W.isflamesource() || W.get_heat() >= T100C)
 		var/text = matchmes
 		if(istype(W, /obj/item/flame/match))
@@ -179,6 +178,8 @@
 		text = replacetext(text, "NAME", "[name]")
 		text = replacetext(text, "FLAME", "[W.name]")
 		light(text)
+		return TRUE
+	return ..()
 
 /obj/item/clothing/mask/smokable/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	if(target.on_fire)
@@ -471,11 +472,6 @@
 	desc = "A manky old cigar butt."
 	icon = 'icons/clothing/mask/smokables/cigar_butt.dmi'
 
-/obj/item/clothing/mask/smokable/cigarette/cigar/attackby(var/obj/item/W, var/mob/user)
-	..()
-	user.update_equipment_overlay(slot_wear_mask_str, FALSE)
-	user.update_inhand_overlays()
-
 //Bizarre
 /obj/item/clothing/mask/smokable/cigarette/rolled/sausage
 	name = "sausage"
@@ -559,40 +555,27 @@
 		SetName("empty [initial(name)]")
 
 /obj/item/clothing/mask/smokable/pipe/attackby(var/obj/item/W, var/mob/user)
-	if(istype(W, /obj/item/energy_blade/sword))
-		return
-
-	..()
-
-	if (istype(W, /obj/item/food))
+	if(istype(W, /obj/item/energy_blade/sword)) // Can't light a pipe with an esword
+		return TRUE
+	if (istype(W, /obj/item/food/grown))
 		var/obj/item/food/grown/grown = W
 		if (!grown.dry)
 			to_chat(user, SPAN_NOTICE("\The [grown] must be dried before you stuff it into \the [src]."))
-			return
+			return TRUE
 		if (smoketime)
 			to_chat(user, SPAN_NOTICE("\The [src] is already packed."))
-			return
+			return TRUE
 		smoketime = 1000
 		if(grown.reagents)
 			grown.reagents.trans_to_obj(src, grown.reagents.total_volume)
 		SetName("[grown.name]-packed [initial(name)]")
 		qdel(grown)
-
-	else if(istype(W, /obj/item/flame/fuelled/lighter))
-		var/obj/item/flame/fuelled/lighter/L = W
-		if(L.lit)
-			light(SPAN_NOTICE("[user] manages to light their [name] with [W]."))
-
-	else if(istype(W, /obj/item/flame/match))
-		var/obj/item/flame/match/M = W
-		if(M.lit)
-			light(SPAN_NOTICE("[user] lights their [name] with their [W]."))
-
-	else if(istype(W, /obj/item/assembly/igniter))
-		light(SPAN_NOTICE("[user] fiddles with [W], and manages to light their [name] with the power of science."))
-
-	user.update_equipment_overlay(slot_wear_mask_str, FALSE)
-	user.update_inhand_overlays()
+		update_icon()
+		return TRUE
+	. = ..()
+	if(.)
+		return
+	return TRUE
 
 /obj/item/clothing/mask/smokable/pipe/cobpipe
 	name = "corn cob pipe"

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -190,23 +190,23 @@
 				repair_power = 1
 
 		if(!repair_power)
-			return
+			return FALSE
 
 		if(ishuman(loc))
 			var/mob/living/human/H = loc
 			if(H.get_equipped_item(slot_wear_suit_str) == src)
 				to_chat(user, SPAN_WARNING("You cannot repair \the [src] while it is being worn."))
-				return
+				return TRUE
 
 		if(burn_damage <= 0)
 			to_chat(user, "There is no surface damage on \the [src] to repair.") //maybe change the descriptor to more obvious? idk what
-			return
+			return TRUE
 
 		var/obj/item/stack/P = W
 		var/use_amt = min(P.get_amount(), 3)
 		if(use_amt && P.use(use_amt))
 			repair_breaches(BURN, use_amt * repair_power, user)
-		return
+		return TRUE
 
 	else if(IS_WELDER(W))
 
@@ -214,19 +214,19 @@
 			var/mob/living/human/H = loc
 			if(H.get_equipped_item(slot_wear_suit_str) == src)
 				to_chat(user, SPAN_WARNING("You cannot repair \the [src] while it is being worn."))
-				return
+				return TRUE
 
 		if (brute_damage <= 0)
 			to_chat(user, "There is no structural damage on \the [src] to repair.")
-			return
+			return TRUE
 
 		var/obj/item/weldingtool/WT = W
 		if(!WT.weld(5))
 			to_chat(user, SPAN_WARNING("You need more welding fuel to repair this suit."))
-			return
+			return TRUE
 
 		repair_breaches(BRUTE, 3, user)
-		return
+		return TRUE
 
 	else if(istype(W, /obj/item/stack/tape_roll/duct_tape))
 		var/datum/breach/target_breach		//Target the largest unpatched breach.
@@ -239,17 +239,13 @@
 		if(!target_breach)
 			to_chat(user, "There are no open breaches to seal with \the [W].")
 		else
-			var/mob/living/human/H = user
-			if(!istype(H))
-				return
-
 			var/obj/item/stack/tape_roll/duct_tape/D = W
 			var/amount_needed = ceil(target_breach.class * 2)
 			if(!D.can_use(amount_needed))
 				to_chat(user, SPAN_WARNING("There's not enough [D.plural_name] in your [src] to seal \the [target_breach.descriptor] on \the [src]! You need at least [amount_needed] [D.plural_name]."))
-				return
+				return TRUE
 
-			if(do_after(user, H.get_equipped_item(slot_wear_suit_str) == src? 60 : 30, isliving(loc)? loc : null)) //Sealing a breach on your own suit is awkward and time consuming
+			if(do_after(user, user.get_equipped_item(slot_wear_suit_str) == src? 6 SECONDS : 3 SECONDS, isliving(loc)? loc : null)) //Sealing a breach on your own suit is awkward and time consuming
 				D.use(amount_needed)
 				playsound(src, 'sound/effects/tape.ogg',25)
 				user.visible_message(
@@ -259,9 +255,8 @@
 				target_breach.patched = TRUE
 				target_breach.update_descriptor()
 				calc_breach_damage()
-		return
-
-	..()
+		return TRUE
+	return ..()
 
 /obj/item/clothing/suit/space/examine(mob/user)
 	. = ..()

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -75,43 +75,43 @@
 
 		if(damage == 0)
 			to_chat(user, "There is no damage to mend.")
-			return
+			return TRUE
 
 		to_chat(user, "You start mending the damaged portions of \the [src]...")
 
 		if(!do_after(user,30,src) || !W || !src)
-			return
+			return TRUE
 
 		var/obj/item/stack/nanopaste/paste = W
 		damage = 0
 		to_chat(user, "You mend the damage to [src] with [W].")
 		paste.use(1)
-		return
+		return TRUE
 
 	else if(IS_COIL(W))
 
 		switch(damage)
 			if(0)
 				to_chat(user, "There is no damage to mend.")
-				return
+				return TRUE
 			if(2)
 				to_chat(user, "There is no damage that you are capable of mending with such crude tools.")
-				return
+				return TRUE
 
 		var/obj/item/stack/cable_coil/cable = W
 		if(!cable.can_use(5))
 			to_chat(user, "You need five units of cable to repair \the [src].")
-			return
+			return TRUE
 
 		to_chat(user, "You start mending the damaged portions of \the [src]...")
 		if(!do_after(user,30,src) || !W || !src)
-			return
+			return TRUE
 
 		damage = 1
-		to_chat(user, "You mend some of damage to [src] with [W], but you will need more advanced tools to fix it completely.")
+		to_chat(user, "You mend some of the damage to [src] with [W], but you will need more advanced tools to fix it completely.")
 		cable.use(5)
-		return
-	..()
+		return TRUE
+	return ..()
 
 /obj/item/rig_module/Initialize()
 	. =..()

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -387,7 +387,7 @@
 	if(istype(W, /obj/item/tank/jetpack/rig))
 		if(jets)
 			to_chat(user, SPAN_WARNING("There's already a propellant tank inside of \the [src]!"))
-			return
+			return TRUE
 		if(user.try_unequip(W))
 			to_chat(user, SPAN_NOTICE("You insert \the [W] into [src]."))
 			W.forceMove(src)

--- a/code/modules/clothing/webbing/holster.dm
+++ b/code/modules/clothing/webbing/holster.dm
@@ -15,7 +15,7 @@
 /obj/item/clothing/webbing/holster/attackby(obj/item/W, mob/user)
 	var/datum/extension/holster/H = get_extension(src, /datum/extension/holster)
 	if(H.holster(W, user))
-		return
+		return TRUE
 	else
 		. = ..(W, user)
 

--- a/code/modules/detectivework/microscope/_forensic_machine.dm
+++ b/code/modules/detectivework/microscope/_forensic_machine.dm
@@ -42,28 +42,30 @@
 	return res + ..()
 
 /obj/machinery/forensic/attackby(obj/item/W, mob/user)
+	if(component_attackby(W, user))
+		return TRUE
+
 	if(user?.a_intent == I_HURT)
-		return ..()
+		return ..() // bash, bash!
 
 	if(sample)
-		to_chat(user, SPAN_WARNING("There is already a slide in \the [src]."))
-		return
+		to_chat(user, SPAN_WARNING("There is already a sample in \the [src]."))
+		return TRUE
 
-	if(istype(W))
-		if(istype(W, /obj/item/evidencebag))
-			var/obj/item/evidencebag/B = W
-			if(B.stored_item)
-				to_chat(user, SPAN_NOTICE("You insert \the [B.stored_item] from \the [B]."))
-				B.stored_item.forceMove(src)
-				set_sample(B.stored_item)
-				B.empty()
-				return
-		if(!user.try_unequip(W, src))
-			return
-		to_chat(user, SPAN_NOTICE("You insert \the [W] into  \the [src]."))
-		set_sample(W)
-		update_icon()
-		return
+	if(istype(W, /obj/item/evidencebag))
+		var/obj/item/evidencebag/B = W
+		if(B.stored_item)
+			to_chat(user, SPAN_NOTICE("You insert \the [B.stored_item] from \the [B]."))
+			B.stored_item.forceMove(src)
+			set_sample(B.stored_item)
+			B.empty()
+			return TRUE
+	if(!user.try_unequip(W, src))
+		return TRUE
+	to_chat(user, SPAN_NOTICE("You insert \the [W] into  \the [src]."))
+	set_sample(W)
+	update_icon()
+	return TRUE
 
 /obj/machinery/forensic/proc/get_report()
 	if(!sample)

--- a/code/modules/detectivework/tools/sample_kits/swabs.dm
+++ b/code/modules/detectivework/tools/sample_kits/swabs.dm
@@ -26,22 +26,22 @@
 	user.visible_message(SPAN_NOTICE("\The [user] starts swabbing a sample from \the [H]."))
 	if(!do_mob(user, H, time_to_take))
 		user.visible_message(SPAN_WARNING("\The [user] tried to take a swab sample from \the [H], but they moved away."))
-		return
+		return TRUE
 
 	if(user.get_target_zone() == BP_MOUTH)
 		var/cover = H.get_covering_equipped_item(SLOT_FACE)
 		if(cover)
 			to_chat(user, SPAN_WARNING("\The [H]'s [cover] is in the way."))
-			return
+			return TRUE
 
 		var/unique_enzymes = H.get_unique_enzymes()
 		if(!unique_enzymes)
 			to_chat(user, SPAN_WARNING("They don't seem to have DNA!"))
-			return
+			return TRUE
 
 		if(!H.check_has_mouth())
 			to_chat(user, SPAN_WARNING("They don't have a mouth."))
-			return
+			return TRUE
 
 		user.visible_message(SPAN_NOTICE("[user] swabs \the [H]'s mouth for a saliva sample."))
 		var/datum/forensics/trace_dna/trace = new()
@@ -54,7 +54,7 @@
 		var/zone = user.get_target_zone()
 		if(!H.has_organ(zone))
 			to_chat(user, SPAN_WARNING("They don't have that part!"))
-			return
+			return TRUE
 		var/obj/object_to_swab = GET_EXTERNAL_ORGAN(H, zone)
 		var/cover = H.get_covering_equipped_item_by_zone(zone)
 		if(cover)
@@ -68,12 +68,12 @@
 					has_evidence = TRUE
 		if(!has_evidence)
 			to_chat(user, SPAN_WARNING("You can't find anything useful on \the [object_to_swab]."))
-			return
+			return TRUE
 		user.visible_message(SPAN_NOTICE("[user] swabs [H]'s [object_to_swab.name] for a sample."))
 		var/obj/item/forensics/sample/swab/S = new /obj/item/forensics/sample/swab/(get_turf(user), object_to_swab)
 		user.put_in_hands(S)
 	update_icon()
-	return 1
+	return TRUE
 
 
 /obj/item/forensics/sample/swab

--- a/code/modules/economy/cael/ATM.dm
+++ b/code/modules/economy/cael/ATM.dm
@@ -80,19 +80,20 @@
 		if(emagged > 0)
 			//prevent inserting id into an emagged ATM
 			to_chat(user, "[html_icon(src)] <span class='warning'>CARD READER ERROR. This system has been compromised!</span>")
-			return
+			return TRUE
 		if(stat & NOPOWER)
 			to_chat(user, "You try to insert your card into [src], but nothing happens.")
-			return
+			return TRUE
 
 		var/obj/item/card/id/idcard = I
 		if(!held_card)
 			if(!user.try_unequip(idcard, src))
-				return
+				return TRUE
 			held_card = idcard
 			if(authenticated_account && held_card.associated_account_number != authenticated_account.account_number)
 				authenticated_account = null
 			attack_hand_with_interaction_checks(user)
+			return TRUE
 
 	else if(authenticated_account)
 		if(istype(I,/obj/item/cash))
@@ -105,6 +106,7 @@
 				to_chat(user, "<span class='info'>You insert [I] into [src].</span>")
 				attack_hand_with_interaction_checks(user)
 				qdel(I)
+			return TRUE
 
 		if(istype(I,/obj/item/charge_stick))
 			var/obj/item/charge_stick/stick = I
@@ -118,8 +120,8 @@
 					to_chat(user, "<span class='info'>You insert [I] into [src].</span>")
 					attack_hand_with_interaction_checks(user)
 					qdel(I)
-	else
-		..()
+			return TRUE
+	return ..()
 
 /obj/machinery/atm/interface_interact(mob/user)
 	interact(user)

--- a/code/modules/economy/cael/EFTPOS.dm
+++ b/code/modules/economy/cael/EFTPOS.dm
@@ -87,7 +87,8 @@
 		if(linked_account)
 			scan_card(I, O)
 		else
-			to_chat(usr, "[html_icon(src)]<span class='warning'>Unable to connect to linked account.</span>")
+			to_chat(user, "[html_icon(src)]<span class='warning'>Unable to connect to linked account.</span>")
+		return TRUE
 	else if (istype(O, /obj/item/charge_stick))
 		var/obj/item/charge_stick/E = O
 		if (linked_account)
@@ -102,14 +103,14 @@
 						visible_message("[html_icon(src)] \The [src] chimes.")
 						transaction_paid = 1
 					else
-						to_chat(usr, "[html_icon(src)]<span class='warning'>Transaction failed! Please try again.</span>")
+						to_chat(user, "[html_icon(src)]<span class='warning'>Transaction failed! Please try again.</span>")
 				else
-					to_chat(usr, "[html_icon(src)]<span class='warning'>\The [O] doesn't have that much money!</span>")
+					to_chat(user, "[html_icon(src)]<span class='warning'>\The [O] doesn't have that much money!</span>")
 		else
-			to_chat(usr, "[html_icon(src)]<span class='warning'>EFTPOS is not connected to an account.</span>")
-
+			to_chat(user, "[html_icon(src)]<span class='warning'>EFTPOS is not connected to an account.</span>")
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/item/eftpos/Topic(var/href, var/href_list)
 	if(href_list["choice"])

--- a/code/modules/economy/worth_cash.dm
+++ b/code/modules/economy/worth_cash.dm
@@ -60,7 +60,7 @@
 		var/obj/item/cash/cash = W
 		if(cash.currency != currency)
 			to_chat(user, SPAN_WARNING("You can't mix two different currencies, it would be uncivilized."))
-			return
+			return TRUE
 		if(user.try_unequip(W))
 			adjust_worth(cash.absolute_worth)
 			var/decl/currency/cur = GET_DECL(currency)
@@ -71,6 +71,8 @@
 	else if(istype(W, /obj/item/gun/launcher/money))
 		var/obj/item/gun/launcher/money/L = W
 		L.absorb_cash(src, user)
+		return TRUE
+	return ..()
 
 /obj/item/cash/on_update_icon()
 	. = ..()

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -299,8 +299,8 @@ var/global/list/meteors_major = list(
 /obj/effect/meteor/attackby(obj/item/W, mob/user, params)
 	if(IS_PICK(W))
 		qdel(src)
-		return
-	..()
+		return TRUE
+	return ..()
 
 /obj/effect/meteor/proc/make_debris()
 	if(meteordrop && dropamt)

--- a/code/modules/fabrication/fabricator_intake.dm
+++ b/code/modules/fabrication/fabricator_intake.dm
@@ -100,7 +100,7 @@
 	if((obj_flags & OBJ_FLAG_ANCHORABLE) && (IS_WRENCH(O) || IS_HAMMER(O)))
 		return ..()
 	if(stat & (NOPOWER | BROKEN))
-		return
+		return TRUE
 
 	// Gate some simple interactions beind intent so people can still feed lathes disks.
 	if(user.a_intent != I_HURT)
@@ -109,27 +109,27 @@
 		if(IS_MULTITOOL(O))
 			var/datum/extension/local_network_member/fabnet = get_extension(src, /datum/extension/local_network_member)
 			fabnet.get_new_tag(user)
-			return
+			return TRUE
 
 		// Install new designs.
 		if(istype(O, /obj/item/disk/design_disk))
 			var/obj/item/disk/design_disk/disk = O
 			if(!disk.blueprint)
 				to_chat(usr, SPAN_WARNING("\The [O] is blank."))
-				return
+				return TRUE
 			if(disk.blueprint in installed_designs)
 				to_chat(usr, SPAN_WARNING("\The [src] is already loaded with the blueprint stored on \the [O]."))
-				return
+				return TRUE
 			installed_designs += disk.blueprint
 			design_cache |= disk.blueprint
 			visible_message(SPAN_NOTICE("\The [user] inserts \the [O] into \the [src], and after a second or so of loud clicking, the fabricator beeps and spits it out again."))
-			return
+			return TRUE
 
 	// TEMP HACK FIX:
 	// Autolathes currently do not process atom contents. As a workaround, refuse all atoms with contents.
 	if(length(O.contents) && !ignore_input_contents_length)
 		to_chat(user, SPAN_WARNING("\The [src] cannot process an object containing other objects. Empty it out first."))
-		return
+		return TRUE
 	// REMOVE FIX WHEN LATHES TAKE CONTENTS PLS.
 
 	// Take reagents, if any are applicable.
@@ -160,6 +160,7 @@
 	if(fab_status_flags & FAB_SHOCKED)
 		shock(user, 50)
 		return TRUE
+	return FALSE
 
 /obj/machinery/fabricator/interface_interact(mob/user)
 	if((fab_status_flags & FAB_DISABLED) && !panel_open)

--- a/code/modules/games/boardgame.dm
+++ b/code/modules/games/boardgame.dm
@@ -24,8 +24,9 @@
 	return TRUE
 
 /obj/item/board/attackby(obj/item/I, mob/user)
-	if(!addPiece(I,user))
-		..()
+	if(addPiece(I,user))
+		return TRUE
+	return ..()
 
 /obj/item/board/proc/addPiece(obj/item/I, mob/user, var/tile = 0)
 	if(I.w_class != ITEM_SIZE_TINY) //only small stuff

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -156,8 +156,8 @@ var/global/list/card_decks = list()
 
 		qdel(O)
 		to_chat(user, "You place your cards on the bottom of \the [src].")
-		return
-	..()
+		return TRUE
+	return ..()
 
 /obj/item/deck/verb/draw_card()
 

--- a/code/modules/goals/definitions/department_clerical.dm
+++ b/code/modules/goals/definitions/department_clerical.dm
@@ -132,10 +132,10 @@
 	if(IS_PEN(W))
 		if(user.real_name in has_signed)
 			to_chat(user, SPAN_WARNING("You have already signed \the [src]."))
-			return
+			return TRUE
 		if(!(user.real_name in needs_signed))
 			to_chat(user, SPAN_WARNING("You can't see anywhere on \the [src] for you to sign; it doesn't need your signature."))
-			return
+			return TRUE
 		LAZYADD(has_signed, user.real_name)
 		LAZYREMOVE(needs_signed, user.real_name)
 		user.visible_message(SPAN_NOTICE("\The [user] signs \the [src] with \the [W]."))

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -10,7 +10,7 @@
 	return 0.8
 
 /turf/floor/holofloor/attackby(obj/item/W, mob/user)
-	return
+	return TRUE
 	// HOLOFLOOR DOES NOT GIVE A FUCK
 
 /turf/floor/holofloor/carpet
@@ -151,27 +151,27 @@
 /obj/machinery/door/window/holowindoor/attackby(obj/item/I, mob/user)
 
 	if (src.operating == 1)
-		return
+		return TRUE
 
 	if(src.density && istype(I, /obj/item) && !istype(I, /obj/item/card))
 		playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
 		visible_message("<span class='danger'>\The [src] was hit by \the [I].</span>")
 		if(I.atom_damage_type == BRUTE || I.atom_damage_type == BURN)
 			take_damage(I.get_attack_force(user))
-		return
+		return TRUE
 
 	src.add_fingerprint(user)
-	if (!src.requiresID())
-		user = null
-
 	if (src.allowed(user))
 		if (src.density)
 			open()
 		else
 			close()
+		return TRUE
 
 	else if (src.density)
 		flick("[base_state]deny", src)
+		return TRUE
+	return FALSE
 
 /obj/machinery/door/window/holowindoor/shatter(var/display_message = TRUE)
 	set_density(FALSE)
@@ -322,6 +322,7 @@
 
 /obj/machinery/readybutton/attackby(obj/item/W, mob/user)
 	to_chat(user, "The device is a solid button, there's nothing you can do with it!")
+	return TRUE
 
 /obj/machinery/readybutton/physical_attack_hand(mob/user)
 	currentarea = get_area(src)

--- a/code/modules/holomap/holomap.dm
+++ b/code/modules/holomap/holomap.dm
@@ -66,10 +66,10 @@
 		return ..()
 	if(watching_mob && (watching_mob != user))
 		to_chat(user, SPAN_WARNING("Someone else is currently watching the holomap."))
-		return
+		return TRUE
 	if(user.loc != loc)
 		to_chat(user, SPAN_WARNING("You need to stand in front of \the [src]."))
-		return
+		return TRUE
 	startWatching(user)
 	return TRUE
 

--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -50,49 +50,49 @@
 		closed = !closed
 		user.visible_message("<span class='notice'>\The [user] [closed ? "closes" : "opens"] \the [src].</span>", "<span class='notice'>You [closed ? "close" : "open"] \the [src].</span>")
 		update_icon()
-		return
+		return TRUE
 	else if(IS_WRENCH(I))
 		anchored = !anchored
 		user.visible_message("<span class='notice'>\The [user] [anchored ? "wrenches" : "unwrenches"] \the [src].</span>", "<span class='notice'>You [anchored ? "wrench" : "unwrench"] \the [src].</span>")
-		return
+		return TRUE
 	else if(istype(I, /obj/item/bee_smoker))
 		if(closed)
 			to_chat(user, "<span class='notice'>You need to open \the [src] with a crowbar before smoking the bees.</span>")
-			return
+			return TRUE
 		user.visible_message("<span class='notice'>\The [user] smokes the bees in \the [src].</span>", "<span class='notice'>You smoke the bees in \the [src].</span>")
 		smoked = 30
 		update_icon()
-		return
+		return TRUE
 	else if(istype(I, /obj/item/honey_frame))
 		if(closed)
 			to_chat(user, "<span class='notice'>You need to open \the [src] with a crowbar before inserting \the [I].</span>")
-			return
+			return TRUE
 		if(frames >= maxFrames)
 			to_chat(user, "<span class='notice'>There is no place for an another frame.</span>")
-			return
+			return TRUE
 		var/obj/item/honey_frame/H = I
 		if(H.honey)
 			to_chat(user, "<span class='notice'>\The [I] is full with beeswax and honey, empty it in the extractor first.</span>")
-			return
+			return TRUE
 		++frames
 		user.visible_message("<span class='notice'>\The [user] loads \the [I] into \the [src].</span>", "<span class='notice'>You load \the [I] into \the [src].</span>")
 		update_icon()
 		qdel(I)
-		return
+		return TRUE
 	else if(istype(I, /obj/item/bee_pack))
 		var/obj/item/bee_pack/B = I
 		if(B.full && bee_count)
 			to_chat(user, "<span class='notice'>\The [src] already has bees inside.</span>")
-			return
+			return TRUE
 		if(!B.full && bee_count < 90)
 			to_chat(user, "<span class='notice'>\The [src] is not ready to split.</span>")
-			return
+			return TRUE
 		if(!B.full && !smoked)
 			to_chat(user, "<span class='notice'>Smoke \the [src] first!</span>")
-			return
+			return TRUE
 		if(closed)
 			to_chat(user, "<span class='notice'>You need to open \the [src] with a crowbar before moving the bees.</span>")
-			return
+			return TRUE
 		if(B.full)
 			user.visible_message("<span class='notice'>\The [user] puts the queen and the bees from \the [I] into \the [src].</span>", "<span class='notice'>You put the queen and the bees from \the [I] into \the [src].</span>")
 			bee_count = 20
@@ -102,7 +102,7 @@
 			bee_count /= 2
 			B.fill()
 		update_icon()
-		return
+		return TRUE
 	else if(istype(I, /obj/item/scanner/plant))
 		to_chat(user, "<span class='notice'>Scan result of \the [src]...</span>")
 		to_chat(user, "Beehive is [bee_count ? "[round(bee_count)]% full" : "empty"].[bee_count > 90 ? " Colony is ready to split." : ""]")
@@ -114,36 +114,38 @@
 			to_chat(user, "No frames installed.")
 		if(smoked)
 			to_chat(user, "The hive is smoked.")
-		return 1
+		return TRUE
 	else if(IS_SCREWDRIVER(I))
 		if(bee_count)
 			to_chat(user, "<span class='notice'>You can't dismantle \the [src] with these bees inside.</span>")
-			return
+			return TRUE
 		to_chat(user, "<span class='notice'>You start dismantling \the [src]...</span>")
 		playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
 		if(do_after(user, 30, src))
 			user.visible_message("<span class='notice'>\The [user] dismantles \the [src].</span>", "<span class='notice'>You dismantle \the [src].</span>")
 			new /obj/item/beehive_assembly(loc)
 			qdel(src)
-		return
+		return TRUE
+	return FALSE // this should probably not be a machine, so don't do any component interactions
 
 /obj/machinery/beehive/physical_attack_hand(var/mob/user)
-	if(!closed)
-		. = TRUE
-		if(honeycombs < 100)
-			to_chat(user, "<span class='notice'>There are no filled honeycombs.</span>")
-			return
-		if(!smoked && bee_count)
-			to_chat(user, "<span class='notice'>The bees won't let you take the honeycombs out like this, smoke them first.</span>")
-			return
-		user.visible_message("<span class='notice'>\The [user] starts taking the honeycombs out of \the [src].</span>", "<span class='notice'>You start taking the honeycombs out of \the [src]...</span>")
-		while(honeycombs >= 100 && do_after(user, 30, src))
-			new /obj/item/honey_frame/filled(loc)
-			honeycombs -= 100
-			--frames
-		update_icon()
-		if(honeycombs < 100)
-			to_chat(user, "<span class='notice'>You take all filled honeycombs out.</span>")
+	if(closed)
+		return FALSE
+	. = TRUE
+	if(honeycombs < 100)
+		to_chat(user, "<span class='notice'>There are no filled honeycombs.</span>")
+		return
+	if(!smoked && bee_count)
+		to_chat(user, "<span class='notice'>The bees won't let you take the honeycombs out like this, smoke them first.</span>")
+		return
+	user.visible_message("<span class='notice'>\The [user] starts taking the honeycombs out of \the [src].</span>", "<span class='notice'>You start taking the honeycombs out of \the [src]...</span>")
+	while(honeycombs >= 100 && do_after(user, 30, src))
+		new /obj/item/honey_frame/filled(loc)
+		honeycombs -= 100
+		--frames
+	update_icon()
+	if(honeycombs < 100)
+		to_chat(user, "<span class='notice'>You take all filled honeycombs out.</span>")
 
 /obj/machinery/beehive/Process()
 	if(closed && !smoked && bee_count)
@@ -188,14 +190,12 @@
 /obj/machinery/honey_extractor/attackby(var/obj/item/I, var/mob/user)
 	if(processing)
 		to_chat(user, "<span class='notice'>\The [src] is currently spinning, wait until it's finished.</span>")
-		return
-	if((. = component_attackby(I, user)))
-		return
+		return TRUE
 	if(istype(I, /obj/item/honey_frame))
 		var/obj/item/honey_frame/H = I
 		if(!H.honey)
 			to_chat(user, "<span class='notice'>\The [H] is empty, put it into a beehive.</span>")
-			return
+			return TRUE
 		user.visible_message("<span class='notice'>\The [user] loads \the [H] into \the [src] and turns it on.</span>", "<span class='notice'>You load \the [H] into \the [src] and turn it on.</span>")
 		processing = H.honey
 		icon_state = "centrifuge_moving"
@@ -206,16 +206,18 @@
 			honey += processing
 			processing = 0
 			icon_state = "centrifuge"
+		return TRUE
 	else if(istype(I, /obj/item/chems/glass))
 		if(!honey)
 			to_chat(user, "<span class='notice'>There is no honey in \the [src].</span>")
-			return
+			return TRUE
 		var/obj/item/chems/glass/G = I
 		var/transferred = min(G.reagents.maximum_volume - G.reagents.total_volume, honey)
 		G.add_to_reagents(/decl/material/liquid/nutriment/honey, transferred)
 		honey -= transferred
 		user.visible_message("<span class='notice'>\The [user] collects honey from \the [src] into \the [G].</span>", "<span class='notice'>You collect [transferred] units of honey from \the [src] into \the [G].</span>")
-		return 1
+		return TRUE
+	return ..() // smack it, interact with components, etc.
 
 /obj/item/bee_smoker
 	name = "bee smoker"

--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -10,12 +10,12 @@
 	material = /decl/material/solid/organic/plantmatter
 
 /obj/item/corncob/attackby(obj/item/W, mob/user)
-	..()
 	if(istype(W, /obj/item/circular_saw) || IS_HATCHET(W) || istype(W, /obj/item/knife))
 		to_chat(user, "<span class='notice'>You use [W] to fashion a pipe out of the corn cob!</span>")
 		new /obj/item/clothing/mask/smokable/pipe/cobpipe (user.loc)
 		qdel(src)
-		return
+		return TRUE
+	return ..()
 
 /obj/item/bananapeel
 	name = "banana peel"

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -70,47 +70,43 @@
 	if(istype(W,/obj/item/seeds))
 		if(seed)
 			to_chat(user, "There is already a seed loaded.")
-			return
-		var/obj/item/seeds/S =W
+			return TRUE
+		var/obj/item/seeds/S = W
 		if(S.seed && S.seed.get_trait(TRAIT_IMMUTABLE) > 0)
 			to_chat(user, "That seed is not compatible with our genetics technology.")
 		else if(user.try_unequip(W, src))
 			seed = W
 			to_chat(user, "You load [W] into [src].")
-		return
+		return TRUE
 
 	if(IS_SCREWDRIVER(W))
 		open = !open
 		to_chat(user, "<span class='notice'>You [open ? "open" : "close"] the maintenance panel.</span>")
-		return
+		return TRUE
 
-	if(open)
-		if(IS_CROWBAR(W))
-			dismantle()
-			return
+	if(open && IS_CROWBAR(W))
+		dismantle()
+		return TRUE
 
 	if(istype(W,/obj/item/disk/botany))
 		if(loaded_disk)
 			to_chat(user, "There is already a data disk loaded.")
-			return
+			return TRUE
+		var/obj/item/disk/botany/B = W
+		if(B.genes && B.genes.len)
+			if(!disk_needs_genes)
+				to_chat(user, "That disk already has gene data loaded.")
+				return TRUE
 		else
-			var/obj/item/disk/botany/B = W
-
-			if(B.genes && B.genes.len)
-				if(!disk_needs_genes)
-					to_chat(user, "That disk already has gene data loaded.")
-					return
-			else
-				if(disk_needs_genes)
-					to_chat(user, "That disk does not have any gene data loaded.")
-					return
-			if(!user.try_unequip(W, src))
-				return
-			loaded_disk = W
-			to_chat(user, "You load [W] into [src].")
-
-		return
-	..()
+			if(disk_needs_genes)
+				to_chat(user, "That disk does not have any gene data loaded.")
+				return TRUE
+		if(!user.try_unequip(W, src))
+			return TRUE
+		loaded_disk = W
+		to_chat(user, "You load [W] into [src].")
+		return TRUE
+	return ..()
 
 // Allows for a trait to be extracted from a seed packet, destroying that seed.
 /obj/machinery/botany/extractor

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -36,6 +36,7 @@
 /obj/effect/dead_plant/attackby()
 	..()
 	qdel(src)
+	return TRUE // if we're deleted we can't do any further interactions
 
 /obj/effect/vine
 	name = "vine"
@@ -202,18 +203,19 @@
 	if(W.edge && W.w_class < ITEM_SIZE_NORMAL && user.a_intent != I_HURT)
 		if(!is_mature())
 			to_chat(user, SPAN_WARNING("\The [src] is not mature enough to yield a sample yet."))
-			return
+			return TRUE
 		if(!seed)
 			to_chat(user, SPAN_WARNING("There is nothing to take a sample from."))
-			return
+			return TRUE
 		var/needed_skill = seed.mysterious ? SKILL_ADEPT : SKILL_BASIC
 		if(prob(user.skill_fail_chance(SKILL_BOTANY, 90, needed_skill)))
 			to_chat(user, SPAN_WARNING("You failed to get a usable sample."))
 		else
 			seed.harvest(user,0,1)
 		current_health -= (rand(3,5)*5)
+		return TRUE
 	else
-		..()
+		. = ..()
 		var/damage = W.get_attack_force(user)
 		if(W.edge)
 			damage *= 2

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -568,6 +568,7 @@
 	if(dead)
 		remove_dead(user)
 		return TRUE
+	return FALSE
 
 /obj/machinery/portable_atmospherics/hydroponics/examine(mob/user)
 	. = ..(user)

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -70,11 +70,13 @@
 		var/amt = M.amount
 		if(amt * SHEET_MATERIAL_AMOUNT + materials[M.material.type] > metal_max)
 			amt = ceil((metal_max - materials[M.material.type]) / SHEET_MATERIAL_AMOUNT)
-		if(M.use(amt))
-			materials[M.material.type] = min(metal_max, materials[M.material.type] + amt * SHEET_MATERIAL_AMOUNT)
-			to_chat(user, "<span class='warning'>You insert [M.material.solid_name] into \the [src].</span>")
-			if(user)
-				attack_self(user) // We're really bad at refreshing the UI, so this is the best we've got.
+		if(!M.use(amt))
+			return FALSE
+		materials[M.material.type] = min(metal_max, materials[M.material.type] + amt * SHEET_MATERIAL_AMOUNT)
+		to_chat(user, "<span class='warning'>You insert [M.material.solid_name] into \the [src].</span>")
+		if(user)
+			attack_self(user) // We're really bad at refreshing the UI, so this is the best we've got.
+		return TRUE
 	if(istype(O, /obj/item/disk/integrated_circuit/upgrade/advanced))
 		if(upgraded)
 			to_chat(user, "<span class='warning'>[src] already has this upgrade. </span>")
@@ -99,22 +101,22 @@
 		var/obj/item/electronic_assembly/EA = O //microtransactions not included
 		if(EA.battery)
 			to_chat(user, "<span class='warning'>Remove [EA]'s power cell first!</span>")
-			return
+			return TRUE
 		if(EA.assembly_components.len)
 			if(recycling)
-				return
+				return TRUE
 			if(!EA.opened)
 				to_chat(user, "<span class='warning'>You can't reach [EA]'s components to remove them!</span>")
-				return
+				return TRUE
 			for(var/V in EA.assembly_components)
 				var/obj/item/integrated_circuit/IC = V
 				if(!IC.removable)
 					to_chat(user, "<span class='warning'>[EA] has irremovable components in the casing, preventing you from emptying it.</span>")
-					return
+					return TRUE
 			to_chat(user, "<span class='notice'>You begin recycling [EA]'s components...</span>")
 			playsound(src, 'sound/items/electronic_assembly_emptying.ogg', 50, TRUE)
 			if(!do_after(user, 30, target = src) || recycling) //short channel so you don't accidentally start emptying out a complex assembly
-				return
+				return TRUE
 			recycling = TRUE
 			for(var/V in EA.assembly_components)
 				recycle(V, null, EA)

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -39,9 +39,9 @@
 		var/obj/item/gun/energy/gun = O
 		if(installed_gun)
 			to_chat(user, "<span class='warning'>There's already a weapon installed.</span>")
-			return
+			return TRUE
 		if(!user.try_unequip(gun,src))
-			return
+			return TRUE
 		installed_gun = gun
 		to_chat(user, "<span class='notice'>You slide \the [gun] into the firing mechanism.</span>")
 		playsound(src, 'sound/items/Crowbar.ogg', 50, 1)
@@ -56,8 +56,9 @@
 			var/datum/firemode/fm = installed_gun.firemodes[installed_gun.sel_mode]
 			set_pin_data(IC_OUTPUT, 2, fm.name)
 		push_data()
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/item/integrated_circuit/manipulation/weapon_firing/attack_self(var/mob/user)
 	if(installed_gun)
@@ -184,10 +185,12 @@
 	if(istype(G))
 		if(attached_grenade)
 			to_chat(user, "<span class='warning'>There is already a grenade attached!</span>")
-		else if(user.try_unequip(G,src))
+			return TRUE
+		if(user.try_unequip(G,src))
 			user.visible_message("<span class='warning'>\The [user] attaches \a [G] to \the [src]!</span>", "<span class='notice'>You attach \the [G] to \the [src].</span>")
 			attach_grenade(G)
 			G.forceMove(src)
+		return TRUE
 	else
 		return ..()
 
@@ -650,6 +653,7 @@
 /obj/item/integrated_circuit/manipulation/ai/attackby(var/obj/item/I, var/mob/user)
 	if(is_type_in_list(I, list(/obj/item/aicard, /obj/item/paicard, /obj/item/organ/internal/brain_interface)))
 		load_ai(user, I)
+		return TRUE
 	else return ..()
 
 /obj/item/integrated_circuit/manipulation/ai/attack_self(user)

--- a/code/modules/locks/lock_construct.dm
+++ b/code/modules/locks/lock_construct.dm
@@ -27,13 +27,13 @@
 			K.key_data = lock_data
 		else
 			to_chat(user, SPAN_WARNING("\The [I] already unlocks something..."))
-		return
+		return TRUE
 	if(istype(I,/obj/item/lock_construct))
 		var/obj/item/lock_construct/L = I
 		src.lock_data = L.lock_data
 		to_chat(user, SPAN_NOTICE("You copy the lock from \the [L] to \the [src], making them identical."))
-		return
-	..()
+		return TRUE
+	return ..()
 
 /obj/item/lock_construct/proc/create_lock(var/atom/target, var/mob/user)
 	. = new /datum/lock(target, lock_data, material?.type)

--- a/code/modules/mechs/components/_components.dm
+++ b/code/modules/mechs/components/_components.dm
@@ -49,7 +49,8 @@
 /obj/item/mech_component/proc/install_component(var/obj/item/thing, var/mob/user)
 	if(user.try_unequip(thing, src))
 		user.visible_message(SPAN_NOTICE("\The [user] installs \the [thing] in \the [src]."))
-		return 1
+		return TRUE
+	return FALSE
 
 /obj/item/mech_component/proc/update_component_health()
 	total_damage = brute_damage + burn_damage

--- a/code/modules/mechs/components/arms.dm
+++ b/code/modules/mechs/components/arms.dm
@@ -28,8 +28,11 @@
 	if(istype(thing,/obj/item/robot_parts/robot_component/actuator))
 		if(motivator)
 			to_chat(user, SPAN_WARNING("\The [src] already has an actuator installed."))
-			return
-		if(install_component(thing, user)) motivator = thing
+			return TRUE
+		if(install_component(thing, user))
+			motivator = thing
+			return TRUE
+		return FALSE
 	else
 		return ..()
 

--- a/code/modules/mechs/components/body.dm
+++ b/code/modules/mechs/components/body.dm
@@ -144,19 +144,27 @@
 	if(istype(thing,/obj/item/robot_parts/robot_component/diagnosis_unit))
 		if(diagnostics)
 			to_chat(user, SPAN_WARNING("\The [src] already has a diagnostic system installed."))
-			return
-		if(install_component(thing, user)) diagnostics = thing
+			return TRUE
+		if(install_component(thing, user))
+			diagnostics = thing
+			return TRUE
+		return FALSE
 	else if(istype(thing, /obj/item/cell))
 		if(cell)
 			to_chat(user, SPAN_WARNING("\The [src] already has a cell installed."))
-			return
-		if(install_component(thing,user)) cell = thing
+			return TRUE
+		if(install_component(thing,user))
+			cell = thing
+			return TRUE
+		return FALSE
 	else if(istype(thing, /obj/item/robot_parts/robot_component/armour/exosuit))
 		if(m_armour)
 			to_chat(user, SPAN_WARNING("\The [src] already has armour installed."))
-			return
+			return TRUE
 		if(install_component(thing, user))
 			m_armour = thing
+			return TRUE
+		return FALSE
 	else
 		return ..()
 

--- a/code/modules/mechs/components/frame.dm
+++ b/code/modules/mechs/components/frame.dm
@@ -72,23 +72,22 @@
 	return ..(SOUTH)
 
 /obj/structure/heavy_vehicle_frame/attackby(var/obj/item/thing, var/mob/user)
-
 	// Removing components.
 	if(IS_CROWBAR(thing))
 		if(is_reinforced == FRAME_REINFORCED)
 			if(!do_after(user, 5 * user.skill_delay_mult(SKILL_DEVICES)) || !material)
-				return
+				return TRUE
 			user.visible_message(SPAN_NOTICE("\The [user] crowbars the reinforcement off \the [src]."))
 			material.create_object(src.loc, 10)
 			material = null
 			is_reinforced = 0
-			return
+			return TRUE
 
 		var/to_remove = input("Which component would you like to remove") as null|anything in list(arms, body, legs, head)
 
 		if(!to_remove)
 			to_chat(user, SPAN_WARNING("There are no components to remove."))
-			return
+			return TRUE
 
 		if(uninstall_component(to_remove, user))
 			if(to_remove == arms)
@@ -101,7 +100,7 @@
 				head = null
 
 		update_icon()
-		return
+		return TRUE
 
 	// Final construction step.
 	else if(IS_SCREWDRIVER(thing))
@@ -109,7 +108,7 @@
 		// Check for basic components.
 		if(!(arms && legs && head && body))
 			to_chat(user,  SPAN_WARNING("There are still parts missing from \the [src]."))
-			return
+			return TRUE
 
 		// Check for wiring.
 		if(is_wired < FRAME_WIRED_ADJUSTED)
@@ -117,7 +116,7 @@
 				to_chat(user, SPAN_WARNING("\The [src]'s wiring has not been adjusted!"))
 			else
 				to_chat(user, SPAN_WARNING("\The [src] is not wired!"))
-			return
+			return TRUE
 
 		// Check for basing metal internal plating.
 		if(is_reinforced < FRAME_REINFORCED_WELDED)
@@ -127,14 +126,14 @@
 				to_chat(user, SPAN_WARNING("\The [src]'s internal reinforcement has not been welded down!"))
 			else
 				to_chat(user, SPAN_WARNING("\The [src] has no internal reinforcement!"))
-			return
+			return TRUE
 
 		visible_message(SPAN_NOTICE("\The [user] begins tightening screws, flipping connectors and finishing off \the [src]."))
 		if(!user.do_skilled(50, SKILL_DEVICES, src))
-			return
+			return TRUE
 
 		if(is_reinforced < FRAME_REINFORCED_WELDED || is_wired < FRAME_WIRED_ADJUSTED || !(arms && legs && head && body) || QDELETED(src) || QDELETED(user))
-			return
+			return TRUE
 
 		// We're all done. Finalize the exosuit and pass the frame to the new system.
 		var/mob/living/exosuit/M = new(get_turf(src), src)
@@ -147,27 +146,27 @@
 		body = null
 		qdel(src)
 
-		return
+		return TRUE
 
 	// Installing wiring.
 	else if(IS_COIL(thing))
 
 		if(is_wired)
 			to_chat(user, SPAN_WARNING("\The [src] has already been wired."))
-			return
+			return TRUE
 
 		var/obj/item/stack/cable_coil/CC = thing
 		if(CC.get_amount() < 10)
 			to_chat(user, SPAN_WARNING("You need at least ten units of cable to complete the exosuit."))
-			return
+			return TRUE
 
 		user.visible_message("\The [user] begins wiring \the [src]...")
 
 		if(!do_after(user, 30 * user.skill_delay_mult(SKILL_ELECTRICAL)))
-			return
+			return TRUE
 
 		if(!CC || !user || !src || CC.get_amount() < 10 || is_wired)
-			return
+			return TRUE
 
 		CC.use(10)
 		user.visible_message("\The [user] installs wiring in \the [src].")
@@ -177,12 +176,12 @@
 	else if(IS_WIRECUTTER(thing))
 		if(!is_wired)
 			to_chat(user, "There is no wiring in \the [src] to neaten.")
-			return
+			return TRUE
 
 		user.visible_message("\The [user] begins adjusting the wiring inside \the [src]...")
 		var/last_wiring_state = is_wired
 		if(!do_after(user, 30 * user.skill_delay_mult(SKILL_ELECTRICAL)) || last_wiring_state != is_wired)
-			return
+			return TRUE
 
 		visible_message("\The [user] [(is_wired == FRAME_WIRED_ADJUSTED) ? "snips some of" : "neatens"] the wiring in \the [src].")
 		playsound(user.loc, 'sound/items/Wirecutter.ogg', 100, 1)
@@ -193,15 +192,15 @@
 		if(M.material)
 			if(is_reinforced)
 				to_chat(user, SPAN_WARNING("There is already a material reinforcement installed in \the [src]."))
-				return
+				return TRUE
 			if(M.get_amount() < 10)
 				to_chat(user, SPAN_WARNING("You need at least ten sheets to reinforce \the [src]."))
-				return
+				return TRUE
 
 			visible_message("\The [user] begins layering the interior of the \the [src] with \the [M].")
 
 			if(!do_after(user, 30 * user.skill_delay_mult(SKILL_DEVICES)) || is_reinforced)
-				return
+				return TRUE
 
 			visible_message("\The [user] reinforces \the [src] with \the [M].")
 			playsound(user.loc, 'sound/items/Deconstruct.ogg', 50, 1)
@@ -214,16 +213,16 @@
 	else if(IS_WRENCH(thing))
 		if(!is_reinforced)
 			to_chat(user, SPAN_WARNING("There is no metal to secure inside \the [src]."))
-			return
+			return TRUE
 		if(is_reinforced == FRAME_REINFORCED_WELDED)
 			to_chat(user, SPAN_WARNING("\The [src]'s internal reinforcment has been welded in."))
-			return
+			return TRUE
 
 		var/last_reinforced_state = is_reinforced
 		visible_message("\The [user] begins adjusting the metal reinforcement inside \the [src].")
 
 		if(!user.do_skilled(4 SECONDS, SKILL_DEVICES,src) || last_reinforced_state != is_reinforced)
-			return
+			return TRUE
 
 		visible_message("\The [user] [(is_reinforced == 2) ? "unsecures" : "secures"] the metal reinforcement inside \the [src].")
 		playsound(user.loc, 'sound/items/Ratchet.ogg', 100, 1)
@@ -233,13 +232,13 @@
 		var/obj/item/weldingtool/WT = thing
 		if(!is_reinforced)
 			to_chat(user, SPAN_WARNING("There is no metal to secure inside \the [src]."))
-			return
+			return TRUE
 		if(is_reinforced == FRAME_REINFORCED)
 			to_chat(user, SPAN_WARNING("The reinforcement inside \the [src] has not been secured."))
-			return
+			return TRUE
 		if(!WT.isOn())
 			to_chat(user, SPAN_WARNING("Turn \the [WT] on, first."))
-			return
+			return TRUE
 		if(WT.weld(1, user))
 
 			var/last_reinforced_state = is_reinforced
@@ -252,47 +251,48 @@
 			playsound(user.loc, 'sound/items/Welder.ogg', 50, 1)
 		else
 			to_chat(user, SPAN_WARNING("Not enough fuel!"))
-			return
+			return TRUE
 	// Installing basic components.
 	else if(istype(thing,/obj/item/mech_component/manipulators))
 		if(arms)
 			to_chat(user, SPAN_WARNING("\The [src] already has manipulators installed."))
-			return
+			return TRUE
 		if(install_component(thing, user))
 			if(arms)
 				thing.dropInto(loc)
-				return
+				return TRUE
 			arms = thing
 	else if(istype(thing,/obj/item/mech_component/propulsion))
 		if(legs)
 			to_chat(user, SPAN_WARNING("\The [src] already has a propulsion system installed."))
-			return
+			return TRUE
 		if(install_component(thing, user))
 			if(legs)
 				thing.dropInto(loc)
-				return
+				return TRUE
 			legs = thing
 	else if(istype(thing,/obj/item/mech_component/sensors))
 		if(head)
 			to_chat(user, SPAN_WARNING("\The [src] already has a sensor array installed."))
-			return
+			return TRUE
 		if(install_component(thing, user))
 			if(head)
 				thing.dropInto(loc)
-				return
+				return TRUE
 			head = thing
 	else if(istype(thing,/obj/item/mech_component/chassis))
 		if(body)
 			to_chat(user, SPAN_WARNING("\The [src] already has an outer chassis installed."))
-			return
+			return TRUE
 		if(install_component(thing, user))
 			if(body)
 				thing.dropInto(loc)
-				return
+				return TRUE
 			body = thing
 	else
 		return ..()
 	update_icon()
+	return TRUE
 
 /obj/structure/heavy_vehicle_frame/proc/install_component(var/obj/item/thing, var/mob/user)
 	var/obj/item/mech_component/MC = thing

--- a/code/modules/mechs/components/frame.dm
+++ b/code/modules/mechs/components/frame.dm
@@ -244,7 +244,7 @@
 			var/last_reinforced_state = is_reinforced
 			visible_message("\The [user] begins welding the metal reinforcement inside \the [src].")
 			if(!do_after(user, 20 * user.skill_delay_mult(SKILL_DEVICES)) || last_reinforced_state != is_reinforced)
-				return
+				return TRUE
 
 			visible_message("\The [user] [(is_reinforced == FRAME_REINFORCED_WELDED) ? "unwelds the reinforcement from" : "welds the reinforcement into"] \the [src].")
 			is_reinforced = (is_reinforced == FRAME_REINFORCED_WELDED) ? FRAME_REINFORCED_SECURE : FRAME_REINFORCED_WELDED

--- a/code/modules/mechs/components/head.dm
+++ b/code/modules/mechs/components/head.dm
@@ -59,18 +59,27 @@
 	if(istype(thing, /obj/item/mech_component/control_module))
 		if(software)
 			to_chat(user, SPAN_WARNING("\The [src] already has a control modules installed."))
-			return
-		if(install_component(thing, user)) software = thing
+			return TRUE
+		if(install_component(thing, user))
+			software = thing
+			return TRUE
+		return FALSE
 	else if(istype(thing,/obj/item/robot_parts/robot_component/radio))
 		if(radio)
 			to_chat(user, SPAN_WARNING("\The [src] already has a radio installed."))
-			return
-		if(install_component(thing, user)) radio = thing
+			return TRUE
+		if(install_component(thing, user))
+			radio = thing
+			return TRUE
+		return FALSE
 	else if(istype(thing,/obj/item/robot_parts/robot_component/camera))
 		if(camera)
 			to_chat(user, SPAN_WARNING("\The [src] already has a camera installed."))
-			return
-		if(install_component(thing, user)) camera = thing
+			return TRUE
+		if(install_component(thing, user))
+			camera = thing
+			return TRUE
+		return FALSE
 	else
 		return ..()
 
@@ -107,15 +116,14 @@
 	to_chat(user, SPAN_NOTICE("It has [max_installed_software - LAZYLEN(installed_software)] empty slot\s remaining out of [max_installed_software]."))
 
 /obj/item/mech_component/control_module/attackby(var/obj/item/thing, var/mob/user)
-
 	if(istype(thing, /obj/item/stock_parts/circuitboard/exosystem))
 		install_software(thing, user)
-		return
+		return TRUE
 
 	if(IS_SCREWDRIVER(thing))
-		var/result = ..()
+		. = ..()
 		update_software()
-		return result
+		return
 	else
 		return ..()
 

--- a/code/modules/mechs/components/legs.dm
+++ b/code/modules/mechs/components/legs.dm
@@ -26,8 +26,11 @@
 	if(istype(thing,/obj/item/robot_parts/robot_component/actuator))
 		if(motivator)
 			to_chat(user, SPAN_WARNING("\The [src] already has an actuator installed."))
-			return
-		if(install_component(thing, user)) motivator = thing
+			return TRUE
+		if(install_component(thing, user))
+			motivator = thing
+			return TRUE
+		return FALSE
 	else
 		return ..()
 

--- a/code/modules/mechs/equipment/combat_projectile.dm
+++ b/code/modules/mechs/equipment/combat_projectile.dm
@@ -1,13 +1,14 @@
 /obj/item/mech_equipment/mounted_system/projectile/attackby(var/obj/item/O, var/mob/user)
 	var/obj/item/gun/projectile/automatic/A = holding
 	if(!istype(A))
-		return
+		return FALSE
 	if(istype(O, /obj/item/crowbar))
 		A.unload_ammo(user)
 		to_chat(user, SPAN_NOTICE("You remove the ammo magazine from \the [src]."))
 	else if(istype(O, A.magazine_type))
 		A.load_ammo(O, user)
 		to_chat(user, SPAN_NOTICE("You load the ammo magazine into \the [src]."))
+	return TRUE
 
 /obj/item/mech_equipment/mounted_system/projectile/attack_self(var/mob/user)
 	. = ..()

--- a/code/modules/mechs/equipment/medical.dm
+++ b/code/modules/mechs/equipment/medical.dm
@@ -31,8 +31,9 @@
 
 /obj/item/mech_equipment/sleeper/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/chems/glass))
-		sleeper.attackby(I, user)
-	else return ..()
+		return sleeper.attackby(I, user)
+	else
+		return ..()
 
 /obj/item/mech_equipment/sleeper/afterattack(var/atom/target, var/mob/living/user, var/inrange, var/params)
 	. = ..()
@@ -77,11 +78,11 @@
 /obj/machinery/sleeper/mounted/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/chems/glass))
 		if(!user.try_unequip(I, src))
-			return
-
+			return TRUE
 		if(beaker)
-			beaker.forceMove(get_turf(src))
+			user.put_in_hands(beaker)
 			user.visible_message("<span class='notice'>\The [user] removes \the [beaker] from \the [src].</span>", "<span class='notice'>You remove \the [beaker] from \the [src].</span>")
 		beaker = I
 		user.visible_message("<span class='notice'>\The [user] adds \a [I] to \the [src].</span>", "<span class='notice'>You add \a [I] to \the [src].</span>")
-
+		return TRUE
+	return FALSE

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -173,24 +173,24 @@
 			. = 0
 
 /obj/structure/closet/crate/secure/loot/attackby(obj/item/W, mob/user)
-	if(locked)
-		if (IS_MULTITOOL(W)) // Greetings Urist McProfessor, how about a nice game of cows and bulls?
-			to_chat(user, "<span class='notice'>DECA-CODE LOCK ANALYSIS:</span>")
-			if (attempts == 1)
-				to_chat(user, "<span class='warning'>* Anti-Tamper system will activate on the next failed access attempt.</span>")
-			else
-				to_chat(user, "<span class='notice'>* Anti-Tamper system will activate after [src.attempts] failed access attempts.</span>")
-			if(lastattempt.len)
-				var/bulls = 0
-				var/cows = 0
+	if(!locked || !IS_MULTITOOL(W))
+		return ..()
+	// Greetings Urist McProfessor, how about a nice game of cows and bulls?
+	to_chat(user, "<span class='notice'>DECA-CODE LOCK ANALYSIS:</span>")
+	if (attempts == 1)
+		to_chat(user, "<span class='warning'>* Anti-Tamper system will activate on the next failed access attempt.</span>")
+	else
+		to_chat(user, "<span class='notice'>* Anti-Tamper system will activate after [src.attempts] failed access attempts.</span>")
+	if(lastattempt.len)
+		var/bulls = 0
+		var/cows = 0
 
-				var/list/code_contents = code.Copy()
-				for(var/i in 1 to codelen)
-					if(lastattempt[i] == code[i])
-						++bulls
-					else if(lastattempt[i] in code_contents)
-						++cows
-					code_contents -= lastattempt[i]
-				to_chat(user, "<span class='notice'>Last code attempt had [bulls] correct digits at correct positions and [cows] correct digits at incorrect positions.</span>")
-			return
-	..()
+		var/list/code_contents = code.Copy()
+		for(var/i in 1 to codelen)
+			if(lastattempt[i] == code[i])
+				++bulls
+			else if(lastattempt[i] in code_contents)
+				++cows
+			code_contents -= lastattempt[i]
+		to_chat(user, "<span class='notice'>Last code attempt had [bulls] correct digits at correct positions and [cows] correct digits at incorrect positions.</span>")
+	return TRUE

--- a/code/modules/mining/machinery/material_extractor.dm
+++ b/code/modules/mining/machinery/material_extractor.dm
@@ -156,28 +156,28 @@
 		var/datum/extension/atmospherics_connection/connection = get_extension(src, /datum/extension/atmospherics_connection)
 		if(connection.disconnect())
 			to_chat(user, SPAN_NOTICE("You disconnect \the [src] from the port."))
-			return
+			return TRUE
 		else
 			var/obj/machinery/atmospherics/portables_connector/possible_port = locate(/obj/machinery/atmospherics/portables_connector) in loc
 			if(possible_port)
 				if(connection.connect(possible_port))
 					to_chat(user, SPAN_NOTICE("You connect \the [src] to the port."))
-					return
+					return TRUE
 				else
 					to_chat(user, SPAN_WARNING("\The [src] failed to connect to the port."))
-					return
+					return TRUE
 
 	if(istype(I, /obj/item/chems/glass))
 		if(isnull(output_container))
 			if(!user.try_unequip(I, src))
-				return
+				return TRUE
 			output_container = I
 			events_repository.register(/decl/observ/destroyed, output_container, src, TYPE_PROC_REF(/obj/machinery/material_processing/extractor, remove_container))
 			user.visible_message(SPAN_NOTICE("\The [user] places \a [I] in \the [src]."), SPAN_NOTICE("You place \a [I] in \the [src]."))
-			return
+			return TRUE
 
 		to_chat(user, SPAN_WARNING("\The [src] already has an output container!"))
-		return
+		return TRUE
 	. = ..()
 
 /obj/machinery/material_processing/extractor/proc/remove_container()

--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -217,10 +217,10 @@
 // Used when you want an effect to happen when the grab enters this state as an upgrade
 /decl/grab/proc/enter_as_up(var/obj/item/grab/grab)
 
-/decl/grab/proc/item_attack(var/obj/item/grab/grab, var/obj/item)
+	return FALSE
 
 /decl/grab/proc/resolve_item_attack(var/obj/item/grab/grab, var/mob/living/human/user, var/obj/item/I, var/target_zone)
-	return 0
+	return FALSE
 
 /decl/grab/proc/handle_resist(var/obj/item/grab/grab)
 	var/mob/living/affecting = grab.get_affecting_mob()

--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -217,6 +217,7 @@
 // Used when you want an effect to happen when the grab enters this state as an upgrade
 /decl/grab/proc/enter_as_up(var/obj/item/grab/grab)
 
+/decl/grab/proc/item_attack(var/obj/item/grab/grab, var/obj/item)
 	return FALSE
 
 /decl/grab/proc/resolve_item_attack(var/obj/item/grab/grab, var/mob/living/human/user, var/obj/item/I, var/target_zone)

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -279,7 +279,8 @@
 
 /obj/item/grab/attackby(obj/W, mob/user)
 	if(user == assailant)
-		current_grab.item_attack(src, W)
+		return current_grab.item_attack(src, W)
+	return FALSE
 
 /obj/item/grab/proc/assailant_reverse_facing()
 	return current_grab.reverse_facing

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -94,7 +94,7 @@
 			to_chat(user, "<span class='warning'>Please close the access panel before locking it.</span>")
 		else
 			to_chat(user, "<span class='warning'>Access denied.</span>")
-		return
+		return TRUE
 	else if(IS_SCREWDRIVER(O))
 		if(!locked)
 			open = !open
@@ -102,7 +102,7 @@
 			Interact(usr)
 		else
 			to_chat(user, "<span class='notice'>You need to unlock the controls first.</span>")
-		return
+		return TRUE
 	else if(IS_WELDER(O))
 		if(current_health < get_max_health())
 			if(open)
@@ -112,9 +112,9 @@
 				to_chat(user, "<span class='notice'>Unable to repair with the maintenance panel closed.</span>")
 		else
 			to_chat(user, "<span class='notice'>\The [src] does not need a repair.</span>")
-		return
+		return TRUE
 	else
-		..()
+		return ..()
 
 /mob/living/bot/attack_ai(var/mob/living/user)
 	Interact(user)

--- a/code/modules/mob/living/bot/medibot.dm
+++ b/code/modules/mob/living/bot/medibot.dm
@@ -159,18 +159,18 @@
 	if(istype(O, /obj/item/chems/glass))
 		if(locked)
 			to_chat(user, "<span class='notice'>You cannot insert a beaker because the panel is locked.</span>")
-			return
+			return TRUE
 		if(!isnull(reagent_glass))
 			to_chat(user, "<span class='notice'>There is already a beaker loaded.</span>")
-			return
+			return TRUE
 
 		if(!user.try_unequip(O, src))
-			return
+			return TRUE
 		reagent_glass = O
 		to_chat(user, "<span class='notice'>You insert [O].</span>")
-		return
+		return TRUE
 	else
-		..()
+		return ..()
 
 /mob/living/bot/medbot/default_disarm_interaction(mob/user)
 	if(!is_tipped)

--- a/code/modules/mob/living/bot/mulebot.dm
+++ b/code/modules/mob/living/bot/mulebot.dm
@@ -116,7 +116,7 @@
 				safety = !safety
 
 /mob/living/bot/mulebot/attackby(var/obj/item/O, var/mob/user)
-	..()
+	. = ..()
 	update_icon()
 
 /mob/living/bot/mulebot/proc/obeyCommand(var/command)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -559,7 +559,6 @@ var/global/list/custom_ai_icons_by_ckey_and_name = list()
 
 /mob/living/silicon/ai/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/aicard))
-
 		var/obj/item/aicard/card = W
 		card.grab_ai(src, user)
 
@@ -568,24 +567,23 @@ var/global/list/custom_ai_icons_by_ckey_and_name = list()
 			user.visible_message("<span class='notice'>\The [user] starts to unbolt \the [src] from the plating...</span>")
 			if(!do_after(user,40, src))
 				user.visible_message("<span class='notice'>\The [user] decides not to unbolt \the [src].</span>")
-				return
+				return TRUE
 			user.visible_message("<span class='notice'>\The [user] finishes unfastening \the [src]!</span>")
 			anchored = FALSE
-			return
+			return TRUE
 		else
 			user.visible_message("<span class='notice'>\The [user] starts to bolt \the [src] to the plating...</span>")
 			if(!do_after(user,40,src))
 				user.visible_message("<span class='notice'>\The [user] decides not to bolt \the [src].</span>")
-				return
+				return TRUE
 			user.visible_message("<span class='notice'>\The [user] finishes fastening down \the [src]!</span>")
 			anchored = TRUE
-			return
+			return TRUE
 	if(try_stock_parts_install(W, user))
-		return
+		return TRUE
 	if(try_stock_parts_removal(W, user))
-		return
-	else
-		return ..()
+		return TRUE
+	return ..()
 
 /mob/living/silicon/ai/proc/control_integrated_radio()
 	set name = "Radio Settings"

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -284,9 +284,9 @@ var/global/list/possible_say_verbs = list(
 		to_chat(src, SPAN_NOTICE("Your access has been updated!"))
 		return FALSE // don't continue processing click callstack.
 	if(try_stock_parts_install(W, user))
-		return
+		return TRUE
 	if(try_stock_parts_removal(W, user))
-		return
+		return TRUE
 	var/force = W.get_attack_force(user)
 	if(force)
 		visible_message(SPAN_DANGER("[user] attacks [src] with [W]!"))
@@ -296,7 +296,7 @@ var/global/list/possible_say_verbs = list(
 
 	spawn(1)
 		if(stat != DEAD) fold()
-	return
+	return TRUE
 
 /mob/living/silicon/pai/default_interaction(mob/user)
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -167,33 +167,26 @@
 
 //Drones cannot be upgraded with borg modules so we need to catch some items before they get used in ..().
 /mob/living/silicon/robot/drone/attackby(var/obj/item/W, var/mob/user)
-
 	if(istype(W, /obj/item/borg/upgrade))
 		to_chat(user, "<span class='danger'>\The [src] is not compatible with \the [W].</span>")
 		return TRUE
-
 	else if(IS_CROWBAR(W) && user.a_intent != I_HURT)
 		to_chat(user, "<span class='danger'>\The [src] is hermetically sealed. You can't open the case.</span>")
-		return
-
+		return TRUE
 	else if (istype(W, /obj/item/card/id)||istype(W, /obj/item/modular_computer))
-
 		if(stat == DEAD)
-
 			if(!get_config_value(/decl/config/toggle/on/allow_drone_spawn) || emagged || should_be_dead()) //It's dead, Dave.
 				to_chat(user, "<span class='danger'>The interface is fried, and a distressing burned smell wafts from the robot's interior. You're not rebooting this one.</span>")
-				return
-
+				return TRUE
 			if(!allowed(usr))
 				to_chat(user, "<span class='danger'>Access denied.</span>")
-				return
-
+				return TRUE
 			var/decl/pronouns/pronouns = user.get_pronouns()
 			user.visible_message( \
 				SPAN_NOTICE("\The [user] swipes [pronouns.his] ID card through \the [src], attempting to reboot it."), \
 				SPAN_NOTICE("You swipe your ID card through \the [src], attempting to reboot it."))
 			request_player()
-			return
+			return TRUE
 
 		var/decl/pronouns/pronouns = user.get_pronouns()
 		user.visible_message( \
@@ -204,9 +197,8 @@
 				shut_down()
 			else
 				to_chat(user, SPAN_DANGER("Access denied."))
-		return
-
-	..()
+		return TRUE
+	return ..()
 
 /mob/living/silicon/robot/drone/emag_act(var/remaining_charges, var/mob/user)
 	if(!client || stat == DEAD)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -443,7 +443,6 @@
 	return 2
 
 /mob/living/silicon/robot/attackby(obj/item/W, mob/user)
-
 	if(istype(W, /obj/item/inducer) || istype(W, /obj/item/handcuffs))
 		return TRUE
 
@@ -452,7 +451,7 @@
 			var/datum/robot_component/C = components[V]
 			if(!C.installed && C.accepts_component(W))
 				if(!user.try_unequip(W))
-					return
+					return TRUE
 				C.installed = 1
 				C.wrapped = W
 				C.install()
@@ -463,20 +462,19 @@
 					C.brute_damage = WC.brute_damage
 					C.electronics_damage = WC.burn_damage
 
-				to_chat(usr, "<span class='notice'>You install the [W.name].</span>")
-				return
+				to_chat(user, "<span class='notice'>You install the [W.name].</span>")
+				return TRUE
 		// If the robot is having something inserted which will remain inside it, self-inserting must be handled before exiting to avoid logic errors. Use the handle_selfinsert proc.
 		if(try_stock_parts_install(W, user))
-			return
+			return TRUE
 
 	if(IS_WELDER(W) && user.a_intent != I_HURT)
 		if (src == user)
 			to_chat(user, "<span class='warning'>You lack the reach to be able to repair yourself.</span>")
-			return
-
+			return TRUE
 		if (!get_damage(BRUTE))
 			to_chat(user, "Nothing to fix here!")
-			return
+			return TRUE
 		var/obj/item/weldingtool/WT = W
 		if (WT.weld(0))
 			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
@@ -485,22 +483,22 @@
 			user.visible_message(SPAN_NOTICE("\The [user] has fixed some of the dents on \the [src]!"))
 		else
 			to_chat(user, "Need more welding fuel!")
-			return
+		return TRUE
 
 	else if(istype(W, /obj/item/stack/cable_coil) && (wiresexposed || isdrone(src)))
 		if (!get_damage(BURN))
 			to_chat(user, "Nothing to fix here!")
-			return
+			return TRUE
 		var/obj/item/stack/cable_coil/coil = W
 		if (coil.use(1))
 			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 			heal_damage(BURN, 30)
 			user.visible_message(SPAN_NOTICE("\The [user] has fixed some of the burnt wires on \the [src]!"))
+		return TRUE
 
 	else if(IS_CROWBAR(W) && user.a_intent != I_HURT)	// crowbar means open or close the cover - we all know what a crowbar is by now
 		if(opened)
 			if(cell)
-
 				user.visible_message(
 					SPAN_NOTICE("\The [user] begins clasping shut \the [src]'s maintenance hatch."),
 					SPAN_NOTICE("You begin closing up \the [src]."))
@@ -514,7 +512,7 @@
 				//Cell is out, wires are exposed, remove CPU, produce damaged chassis, baleet original mob.
 				if(!central_processor)
 					to_chat(user, "\The [src] has no central processor to remove.")
-					return
+					return TRUE
 
 				user.visible_message(
 					SPAN_NOTICE("\The [user] begins ripping \the [central_processor] out of \the [src]."),
@@ -522,7 +520,6 @@
 
 				if(do_after(user, 50, src))
 					dismantle(user)
-
 			else
 				// Okay we're not removing the cell or a CPU, but maybe something else?
 				var/list/removable_components = list()
@@ -534,7 +531,7 @@
 				removable_components |= stock_parts
 				var/remove = input(user, "Which component do you want to pry out?", "Remove Component") as null|anything in removable_components
 				if(!remove || !opened || !(remove in (stock_parts|components)) || !Adjacent(user))
-					return
+					return TRUE
 				var/obj/item/removed_item
 				if(istype(components[remove], /datum/robot_component))
 					var/datum/robot_component/C = components[remove]
@@ -562,7 +559,7 @@
 					to_chat(user, "<span class='notice'>You open \the [src]'s maintenance hatch.</span>")
 					opened = 1
 					update_icon()
-
+		return TRUE
 	else if (istype(W, /obj/item/cell) && opened)	// trying to put a cell inside
 		var/datum/robot_component/C = components["power cell"]
 		if(wiresexposed)
@@ -581,62 +578,64 @@
 			// This means that removing and replacing a power cell will repair the mount.
 			C.brute_damage = 0
 			C.electronics_damage = 0
-
+		return TRUE
 	else if(IS_WIRECUTTER(W) || IS_MULTITOOL(W))
 		if (wiresexposed)
 			wires.Interact(user)
 		else
 			to_chat(user, "You can't reach the wiring.")
+		return TRUE
 	else if(IS_SCREWDRIVER(W) && opened && !cell)	// haxing
 		wiresexposed = !wiresexposed
 		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
 		update_icon()
-
+		return TRUE
 	else if(IS_SCREWDRIVER(W) && opened && cell)	// radio
 		if(silicon_radio)
 			silicon_radio.attackby(W,user)//Push it to the radio to let it handle everything
 		else
 			to_chat(user, "Unable to locate a radio.")
 		update_icon()
-
+		return TRUE
 	else if(istype(W, /obj/item/encryptionkey/) && opened)
 		if(silicon_radio)//sanityyyyyy
 			silicon_radio.attackby(W,user)//GTFO, you have your own procs
 		else
 			to_chat(user, "Unable to locate a radio.")
+		return TRUE
 	else if (istype(W, /obj/item/card/id)||istype(W, /obj/item/modular_computer)||istype(W, /obj/item/card/robot))			// trying to unlock the interface with an ID card
 		if(emagged)//still allow them to open the cover
 			to_chat(user, "The interface seems slightly damaged.")
 		if(opened)
 			to_chat(user, "You must close the cover to swipe an ID card.")
 		else
-			if(allowed(usr))
+			if(allowed(user))
 				locked = !locked
 				to_chat(user, "You [ locked ? "lock" : "unlock"] [src]'s interface.")
 				update_icon()
 			else
 				to_chat(user, "<span class='warning'>Access denied.</span>")
+		return TRUE
 	else if(istype(W, /obj/item/borg/upgrade))
 		var/obj/item/borg/upgrade/U = W
 		if(!opened)
-			to_chat(usr, "You must access the borgs internals!")
+			to_chat(user, "You must access [src]'s internals!")
 		else if(!src.module && U.require_module)
-			to_chat(usr, "The borg must choose a module before he can be upgraded!")
+			to_chat(user, "[src] must choose a module before they can be upgraded!")
 		else if(U.locked)
-			to_chat(usr, "The upgrade is locked and cannot be used yet!")
+			to_chat(user, "The upgrade is locked and cannot be used yet!")
 		else
 			if(U.action(src))
 				if(!user.try_unequip(U, src))
-					return
-				to_chat(usr, "You apply the upgrade to [src]!")
+					return TRUE
+				to_chat(user, "You apply the upgrade to [src]!")
 				handle_selfinsert(W, user)
 			else
-				to_chat(usr, "Upgrade error!")
-
-	else
-		if(!(istype(W, /obj/item/robotanalyzer) || istype(W, /obj/item/scanner/health)) && W.get_attack_force(user) && user.a_intent != I_HELP)
-			spark_at(src, 5, holder=src)
-		return ..()
+				to_chat(user, "Upgrade error!")
+		return TRUE
+	if(!(istype(W, /obj/item/robotanalyzer) || istype(W, /obj/item/scanner/health)) && W.get_attack_force(user) && user.a_intent != I_HELP)
+		spark_at(src, 5, holder=src)
+	return ..()
 
 /mob/living/silicon/robot/proc/handle_selfinsert(obj/item/W, mob/user)
 	if ((user == src) && istype(get_active_held_item(),/obj/item/gripper))

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -127,15 +127,14 @@
 		dance()
 
 /mob/living/simple_animal/corgi/attackby(var/obj/item/O, var/mob/user)  //Marker -Agouri
-	if(istype(O, /obj/item/newspaper))
-		if(!stat)
-			visible_message(SPAN_NOTICE("\The [user] baps \the [src] on the nose with the rolled-up [O.name]!"))
-			spawn(0)
-				for(var/i in list(1,2,4,8,4,2,1,2))
-					set_dir(i)
-					sleep(1)
+	if(istype(O, /obj/item/newspaper) && !stat)
+		visible_message(SPAN_NOTICE("\The [user] baps \the [src] on the nose with the rolled-up [O.name]!"))
+		var/datum/mob_controller/corgi/corgi_ai = ai
+		if(istype(corgi_ai))
+			corgi_ai.dance()
+		return TRUE
 	else
-		..()
+		return ..()
 
 /mob/living/simple_animal/corgi/puppy
 	name = "\improper corgi puppy"

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -245,19 +245,19 @@ var/global/chicken_count = 0
 		global.chicken_count -= 1
 
 /mob/living/simple_animal/fowl/chicken/attackby(var/obj/item/O, var/mob/user)
-	if(istype(O, /obj/item/food)) //feedin' dem chickens
-		var/obj/item/food/G = O
-		if(findtext(G.get_grown_tag(), "wheat")) // includes chopped, crushed, dried etc.
-			if(!stat && eggsleft < 4)
-				user.visible_message(SPAN_NOTICE("[user] feeds \the [O] to \the [src]! It clucks happily."), SPAN_NOTICE("You feed \the [O] to \the [src]! It clucks happily."), SPAN_NOTICE("You hear clucking."))
-				qdel(O)
-				eggsleft += rand(1, 2)
-			else
-				to_chat(user, SPAN_NOTICE("\The [src] doesn't seem hungry!"))
+	if(istype(O, /obj/item/food))
+		return ..()
+	var/obj/item/food/G = O //feedin' dem chickens
+	if(findtext(G.get_grown_tag(), "wheat")) // includes chopped, crushed, dried etc.
+		if(!stat && eggsleft < 4)
+			user.visible_message(SPAN_NOTICE("[user] feeds \the [O] to \the [src]! It clucks happily."), SPAN_NOTICE("You feed \the [O] to \the [src]! It clucks happily."), SPAN_NOTICE("You hear clucking."))
+			qdel(O)
+			eggsleft += rand(1, 2)
 		else
-			to_chat(user, "\The [src] doesn't seem interested in that.")
+			to_chat(user, SPAN_NOTICE("\The [src] doesn't seem hungry!"))
 	else
-		..()
+		to_chat(user, "\The [src] doesn't seem interested in that.")
+	return TRUE
 
 /mob/living/simple_animal/fowl/chicken/handle_living_non_stasis_processes()
 	if((. = ..()) && prob(1) && eggsleft > 0)

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -108,7 +108,7 @@
 				var/datum/mob_controller/aggressive/bear/bearbrain = ai
 				bearbrain.stance_step = 12
 			ai.set_target(user)
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/bear/attack_hand(mob/user)
 	if(istype(ai))

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
@@ -332,15 +332,14 @@
 
 //Mobs with objects
 /mob/living/simple_animal/hostile/parrot/attackby(var/obj/item/O, var/mob/user)
-	..()
-	if(!stat && !client && !istype(O, /obj/item/stack/medical))
-		if(O.get_attack_force(user))
-			if(parrot_state == PARROT_PERCH)
-				parrot_sleep_dur = parrot_sleep_max //Reset it's sleep timer if it was perched
-			parrot_interest = user
-			parrot_state = PARROT_SWOOP | PARROT_FLEE
-			drop_held_item(0)
-			update_icon()
+	. = ..()
+	if(!stat && !client && !istype(O, /obj/item/stack/medical) && O.get_attack_force(user))
+		if(parrot_state == PARROT_PERCH)
+			parrot_sleep_dur = parrot_sleep_max //Reset it's sleep timer if it was perched
+		parrot_interest = user
+		parrot_state = PARROT_SWOOP | PARROT_FLEE
+		drop_held_item(0)
+		update_icon()
 
 //Bullets
 /mob/living/simple_animal/hostile/parrot/bullet_act(var/obj/item/projectile/Proj)

--- a/code/modules/mob_holder/_holder.dm
+++ b/code/modules/mob_holder/_holder.dm
@@ -143,4 +143,7 @@
 
 /obj/item/holder/attackby(obj/item/W, mob/user)
 	for(var/mob/M in src.contents)
-		M.attackby(W,user)
+		. = M.attackby(W,user)
+		if(.)
+			return
+	return FALSE

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -87,20 +87,21 @@
 
 /obj/item/modular_computer/attackby(var/obj/item/W, var/mob/user)
 	var/datum/extension/assembly/assembly = get_extension(src, /datum/extension/assembly)
-	if(assembly.attackby(W, user))
+	. = assembly.attackby(W, user)
+	if(.)
 		update_verbs()
-		return
+		return TRUE
 
 	if(IS_PEN(W) && (W.w_class <= ITEM_SIZE_TINY) && stores_pen)
 		if(istype(stored_pen))
 			to_chat(user, "<span class='notice'>There is already a pen in [src].</span>")
-			return
+			return TRUE
 		if(!user.try_unequip(W, src))
-			return
+			return TRUE
 		stored_pen = W
 		update_verbs()
 		to_chat(user, "<span class='notice'>You insert [W] into [src].</span>")
-		return
+		return TRUE
 	return ..()
 
 /obj/item/modular_computer/examine(mob/user)

--- a/code/modules/modular_computers/hardware/ai_slot.dm
+++ b/code/modules/modular_computers/hardware/ai_slot.dm
@@ -22,19 +22,19 @@
 	..()
 
 /obj/item/stock_parts/computer/ai_slot/attackby(var/obj/item/W, var/mob/user)
-	if(..())
-		return 1
 	if(istype(W, /obj/item/aicard))
 		if(stored_card)
 			to_chat(user, "\The [src] is already occupied.")
-			return
+			return TRUE
 		if(!user.try_unequip(W, src))
-			return
+			return TRUE
 		do_insert_ai(user, W)
 		return TRUE
 	if(IS_SCREWDRIVER(W))
 		to_chat(user, "You manually remove \the [stored_card] from \the [src].")
 		do_eject_ai(user)
+		return TRUE
+	return ..()
 
 /obj/item/stock_parts/computer/ai_slot/Destroy()
 	if(stored_card)

--- a/code/modules/modular_computers/hardware/charge_stick_slot.dm
+++ b/code/modules/modular_computers/hardware/charge_stick_slot.dm
@@ -82,9 +82,9 @@
 		loc.verbs |= /obj/item/stock_parts/computer/charge_stick_slot/proc/verb_eject_stick
 	return TRUE
 
-/obj/item/stock_parts/computer/charge_stick_slot/attackby(obj/item/card/id/I, mob/user)
+/obj/item/stock_parts/computer/charge_stick_slot/attackby(obj/item/charge_stick/I, mob/user)
 	if(!istype(I))
-		return
+		return ..()
 	insert_stick(I, user)
 	return TRUE
 

--- a/code/modules/modular_computers/hardware/disk_slot.dm
+++ b/code/modules/modular_computers/hardware/disk_slot.dm
@@ -99,7 +99,7 @@
 
 /obj/item/stock_parts/computer/data_disk_drive/attackby(obj/item/disk/new_disk, mob/user)
 	if(!istype(new_disk))
-		return
+		return ..()
 	insert_disk(new_disk, user)
 	return TRUE
 

--- a/code/modules/modular_computers/hardware/drive_slot.dm
+++ b/code/modules/modular_computers/hardware/drive_slot.dm
@@ -96,7 +96,7 @@
 
 /obj/item/stock_parts/computer/drive_slot/attackby(obj/item/stock_parts/computer/hard_drive/portable/I, mob/user)
 	if(!istype(I))
-		return
+		return ..()
 	insert_drive(I, user)
 	return TRUE
 

--- a/code/modules/modular_computers/hardware/lan_port.dm
+++ b/code/modules/modular_computers/hardware/lan_port.dm
@@ -95,3 +95,4 @@
 				to_chat(user, SPAN_NOTICE("You cut the cables and dismantle the network terminal."))
 				qdel(terminal)
 		return TRUE
+	return FALSE

--- a/code/modules/modular_computers/hardware/nano_printer.dm
+++ b/code/modules/modular_computers/hardware/nano_printer.dm
@@ -37,11 +37,12 @@
 		return 0
 	return 1
 
+// TODO: unify with /obj/item/stock_parts/printer somehow?
 /obj/item/stock_parts/computer/nano_printer/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/paper))
 		if(stored_paper >= max_paper)
 			to_chat(user, "You try to add \the [W] into \the [src], but its paper bin is full.")
-			return
+			return TRUE
 
 		to_chat(user, "You insert \the [W] into [src].")
 		qdel(W)
@@ -51,13 +52,16 @@
 		var/num_of_pages_added = 0
 		if(stored_paper >= max_paper)
 			to_chat(user, "You try to add \the [W] into \the [src], but its paper bin is full.")
-			return
-		for(var/obj/item/bundleitem in B) //loop through items in bundle
-			if(istype(bundleitem, /obj/item/paper)) //if item is paper (and not photo), add into the bin
-				B.pages.Remove(bundleitem)
-				qdel(bundleitem)
-				num_of_pages_added++
-				stored_paper++
+			return TRUE
+		if(!B.is_blank())
+			if(user)
+				to_chat(user, SPAN_WARNING("\The [B] contains some non-blank pages, or something else than paper sheets!"))
+			return TRUE
+		for(var/obj/item/paper/bundleitem in B) //loop through papers in bundle
+			B.pages.Remove(bundleitem)
+			qdel(bundleitem)
+			num_of_pages_added++
+			stored_paper++
 			if(stored_paper >= max_paper) //check if the printer is full yet
 				to_chat(user, "The printer has been filled to full capacity.")
 				break
@@ -71,4 +75,5 @@
 			else //if at least two items remain, just update the bundle icon
 				B.update_icon()
 		to_chat(user, "You add [num_of_pages_added] papers from \the [W] into \the [src].")
-	return
+		return TRUE
+	return ..()

--- a/code/modules/modular_computers/hardware/scanners/scanner.dm
+++ b/code/modules/modular_computers/hardware/scanners/scanner.dm
@@ -54,8 +54,10 @@
 
 /obj/item/stock_parts/computer/scanner/proc/do_on_afterattack(mob/user, atom/target, proximity)
 
+// TODO: Revisit to see if we can make do_on_attackby return a bool so that normal afterattack can run.
 /obj/item/stock_parts/computer/scanner/attackby(obj/W, mob/user)
 	do_on_attackby(user, W)
+	return TRUE
 
 /obj/item/stock_parts/computer/scanner/proc/do_on_attackby(mob/user, atom/target)
 

--- a/code/modules/multiz/map_data.dm
+++ b/code/modules/multiz/map_data.dm
@@ -7,11 +7,11 @@
 	var/turf/edge_type ///< What the map edge should be formed with. (null = world.turf)
 
 // If the height is more than 1, we mark all contained levels as connected.
-// This is in New because it is an auxiliary effect specifically needed pre-init.
+// This initializes immediately because it is an auxiliary effect specifically needed pre-SSatoms init.
 INITIALIZE_IMMEDIATE(/obj/abstract/map_data)
 /obj/abstract/map_data/Initialize(mapload, _height)
 	if(!istype(loc)) // Using loc.z is safer when using the maploader and New.
-		return
+		return INITIALIZE_HINT_QDEL
 	if(_height)
 		height = _height
 	for(var/i = (loc.z - height + 1) to (loc.z-1))

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -148,6 +148,7 @@
 
 /atom/movable/openspace/mimic/attackby(obj/item/W, mob/user)
 	to_chat(user, SPAN_NOTICE("\The [src] is too far away."))
+	return TRUE
 
 /atom/movable/openspace/mimic/attack_hand(mob/user)
 	SHOULD_CALL_PARENT(FALSE)
@@ -195,7 +196,7 @@
 	z_flags = ZMM_IGNORE  // Only one of these should ever be visible at a time, the mimic logic will handle that.
 
 /atom/movable/openspace/turf_proxy/attackby(obj/item/W, mob/user)
-	loc.attackby(W, user)
+	return loc.attackby(W, user)
 
 /atom/movable/openspace/turf_proxy/attack_hand(mob/user as mob)
 	SHOULD_CALL_PARENT(FALSE)
@@ -223,7 +224,7 @@
 	delegate = loc:below
 
 /atom/movable/openspace/turf_mimic/attackby(obj/item/W, mob/user)
-	loc.attackby(W, user)
+	return loc.attackby(W, user)
 
 /atom/movable/openspace/turf_mimic/attack_hand(mob/user as mob)
 	SHOULD_CALL_PARENT(FALSE)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -260,7 +260,7 @@
 
 			if(length(connecting_limb.children))
 				to_chat(usr, SPAN_WARNING("You cannot connect additional limbs to \the [connecting_limb]."))
-				return
+				return TRUE
 
 			var/mob/holder = loc
 			if(istype(holder))
@@ -270,7 +270,7 @@
 				forceMove(connecting_limb)
 
 			if(loc != connecting_limb)
-				return
+				return TRUE
 
 			if(istype(connecting_limb.owner))
 				connecting_limb.owner.add_organ(src, connecting_limb)
@@ -283,10 +283,10 @@
 
 			if(LAZYLEN(children))
 				to_chat(usr, SPAN_WARNING("You cannot connect additional limbs to \the [src]."))
-				return
+				return TRUE
 
 			if(!user.try_unequip(connecting_limb, src))
-				return
+				return TRUE
 
 			if(istype(connecting_limb.owner))
 				connecting_limb.owner.add_organ(connecting_limb, src)
@@ -297,7 +297,7 @@
 
 		else
 			to_chat(user, SPAN_WARNING("\The [connecting_limb] cannot be connected to \the [src]."))
-			return
+			return TRUE
 
 		if(combined)
 			to_chat(user, SPAN_NOTICE("You connect \the [connecting_limb] to \the [src]."))
@@ -305,15 +305,15 @@
 			update_icon()
 			connecting_limb.compile_icon()
 			connecting_limb.update_icon()
-			return
+			return TRUE
 
 	//Remove sub-limbs
 	if(used_item.get_tool_quality(TOOL_SAW) && LAZYLEN(children) && try_saw_off_child(used_item, user))
-		return
+		return TRUE
 	//Remove internal items/organs/implants
 	if(try_remove_internal_item(used_item, user))
-		return
-	..()
+		return TRUE
+	return ..()
 
 //Handles removing internal organs/implants/items still in the detached limb.
 /obj/item/organ/external/proc/try_remove_internal_item(var/obj/item/used_item, var/mob/user)

--- a/code/modules/organs/internal/cell.dm
+++ b/code/modules/organs/internal/cell.dm
@@ -60,29 +60,32 @@
 	if(cell)
 		cell.emp_act(severity)
 
+// TODO: Make this use the cell extension instead?
+// Or have it grant a subtype of cell extension to the mob, maybe?
 /obj/item/organ/internal/cell/attackby(obj/item/W, mob/user)
 	if(IS_SCREWDRIVER(W))
 		if(open)
-			open = 0
+			open = FALSE
 			to_chat(user, SPAN_NOTICE("You screw the battery panel in place."))
 		else
-			open = 1
+			open = TRUE
 			to_chat(user, SPAN_NOTICE("You unscrew the battery panel."))
-
-	if(IS_CROWBAR(W))
-		if(open)
+		return TRUE
+	else if(open)
+		if(IS_CROWBAR(W))
 			if(cell)
 				user.put_in_hands(cell)
 				to_chat(user, SPAN_NOTICE("You remove \the [cell] from \the [src]."))
 				cell = null
-
-	if (istype(W, /obj/item/cell))
-		if(open)
+			return TRUE
+		else if (istype(W, /obj/item/cell))
 			if(cell)
 				to_chat(user, SPAN_WARNING("There is a power cell already installed."))
 			else if(user.try_unequip(W, src))
 				cell = W
 				to_chat(user, SPAN_NOTICE("You insert \the [cell]."))
+			return TRUE
+	return ..()
 
 /obj/item/organ/internal/cell/on_add_effects()
 	. = ..()

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -379,21 +379,21 @@
 			owner.update_health()
 
 /obj/item/organ/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
-
 	if(BP_IS_PROSTHETIC(src) || !istype(target) || !istype(user) || (user != target && user.a_intent == I_HELP))
 		return ..()
 
 	if(alert("Do you really want to use this organ as food? It will be useless for anything else afterwards.",,"Ew, no.","Bon appetit!") == "Ew, no.")
 		to_chat(user, SPAN_NOTICE("You successfully repress your cannibalistic tendencies."))
-		return
+		return TRUE
 
 	if(QDELETED(src))
-		return
+		return TRUE
 
 	if(!user.try_unequip(src))
-		return
+		return TRUE
 
 	target.attackby(convert_to_food(user), user)
+	return TRUE
 
 /obj/item/organ/proc/convert_to_food(mob/user)
 	var/obj/item/food/organ/yum = new(get_turf(src))

--- a/code/modules/overmap/disperser/disperser.dm
+++ b/code/modules/overmap/disperser/disperser.dm
@@ -20,6 +20,7 @@
 			playsound(src, 'sound/items/jaws_pry.ogg', 50, 1)
 		else
 			to_chat(user,"<span class='notice'>The maintenance panel must be screwed open for this!</span>")
+		return TRUE
 	else
 		return ..()
 

--- a/code/modules/overmap/ftl_shunt/core.dm
+++ b/code/modules/overmap/ftl_shunt/core.dm
@@ -585,16 +585,15 @@
 	QDEL_NULL(fuel)
 
 /obj/machinery/ftl_shunt/fuel_port/attackby(var/obj/item/O, var/mob/user)
-	if(istype(O, /obj/item/fuel_assembly))
-		if(!fuel)
-			if(!do_after(user, 2 SECONDS, src) || fuel)
-				return
-			if(!user || !user.try_unequip(O, src))
-				return
-			fuel = O
-			max_fuel = get_fuel_joules(TRUE)
-			update_icon()
+	if(istype(O, /obj/item/fuel_assembly) && !fuel)
+		if(!do_after(user, 2 SECONDS, src) || fuel)
 			return TRUE
+		if(!user || !user.try_unequip(O, src))
+			return TRUE
+		fuel = O
+		max_fuel = get_fuel_joules(TRUE)
+		update_icon()
+		return TRUE
 
 	. = ..()
 

--- a/code/modules/overmap/ships/machines/fusion_thruster.dm
+++ b/code/modules/overmap/ships/machines/fusion_thruster.dm
@@ -29,7 +29,7 @@
 	var/datum/extension/local_network_member/lanm = get_extension(src, /datum/extension/local_network_member)
 	var/datum/local_network/lan = lanm.get_local_network()
 
-	if(lan)	
+	if(lan)
 		var/list/fusion_cores = lan.get_devices(/obj/machinery/fusion_core)
 		if(fusion_cores && fusion_cores.len)
 			harvest_from = fusion_cores[1]
@@ -40,5 +40,5 @@
 		var/datum/extension/local_network_member/lanm = get_extension(src, /datum/extension/local_network_member)
 		if(lanm.get_new_tag(user))
 			find_core()
-		return
+		return TRUE
 	return ..()

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -70,7 +70,7 @@
 	var/obj/item/top_paper = top_paper()
 	if(istype(W, /obj/item/paper) || istype(W, /obj/item/photo))
 		if(!user.try_unequip(W, src))
-			return
+			return TRUE
 		push_paper(W)
 		to_chat(user, SPAN_NOTICE("You clip the [W] onto \the [src]."))
 		return TRUE

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -138,7 +138,8 @@ var/global/list/adminfaxes     = list()	//cache for faxes that have been sent to
 /obj/machinery/faxmachine/attackby(obj/item/I, mob/user)
 	if(istype(construct_state, /decl/machine_construction/default/panel_closed))
 		if(istype(I, /obj/item/paper) || istype(I, /obj/item/photo) || istype(I, /obj/item/paper_bundle))
-			return insert_scanner_item(I, user)
+			insert_scanner_item(I, user)
+			return TRUE
 	. = ..()
 
 /obj/machinery/faxmachine/ui_data(mob/user, ui_key)

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -28,16 +28,16 @@
 	. = ..()
 
 /obj/structure/filing_cabinet/attackby(obj/item/P, mob/user)
-	if(is_type_in_list(P, can_hold))
-		if(!user.try_unequip(P, src))
-			return
-		add_fingerprint(user)
-		to_chat(user, SPAN_NOTICE("You put [P] in [src]."))
-		flick("[initial(icon_state)]-open",src)
-		updateUsrDialog()
+	if(!is_type_in_list(P, can_hold))
+		return ..()
+	if(!user.try_unequip(P, src))
 		return TRUE
+	add_fingerprint(user)
+	to_chat(user, SPAN_NOTICE("You put [P] in [src]."))
+	flick("[initial(icon_state)]-open",src)
+	updateUsrDialog()
+	return TRUE
 
-	return ..()
 /obj/structure/filing_cabinet/interact(mob/user)
 	user.set_machine(src)
 	var/dat = "<HR><TABLE>"

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -36,7 +36,7 @@
 /obj/item/folder/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/paper) || istype(W, /obj/item/photo) || istype(W, /obj/item/paper_bundle))
 		if(!user.try_unequip(W, src))
-			return
+			return TRUE
 		to_chat(user, SPAN_NOTICE("You put the [W] into \the [src]."))
 		updateUsrDialog()
 		update_icon()
@@ -47,10 +47,10 @@
 		var/n_name = sanitize_safe(input(usr, "What would you like to label the folder?", "Folder Labelling", null)  as text, MAX_NAME_LEN)
 		if(!CanPhysicallyInteractWith(user, src))
 			to_chat(user, SPAN_WARNING("You must stay close to \the [src]."))
-			return
+			return TRUE
 		SetName("folder[(n_name ? text("- '[n_name]'") : null)]")
 		return TRUE
-	return
+	return ..()
 
 /obj/item/folder/attack_self(mob/user)
 	return interact(user)
@@ -119,6 +119,6 @@
 /obj/item/folder/envelope/attackby(obj/item/W, mob/user)
 	if(sealed)
 		sealcheck(user)
-		return
+		return TRUE
 	else
-		..()
+		return ..()

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -154,7 +154,7 @@
 		var/obj/item/paper/P = W
 		if(!P.is_blank())
 			to_chat(user, SPAN_WARNING("\The [P] is not blank. You can't use that for refilling \the [src]."))
-			return
+			return TRUE
 
 		var/incoming_amt = LAZYACCESS(P.matter, /decl/material/solid/organic/paper)
 		var/current_amt = LAZYACCESS(matter, /decl/material/solid/organic/paper)
@@ -162,12 +162,12 @@
 
 		if(incoming_amt < LABEL_MATERIAL_COST)
 			to_chat(user, SPAN_WARNING("\The [P] does not contains enough paper."))
-			return
+			return TRUE
 		if(((incoming_amt + current_amt) / LABEL_MATERIAL_COST) > max_labels)
 			to_chat(user, SPAN_WARNING("There's not enough room in \the [src] for the [label_added] label(s) \the [P] is worth."))
-			return
+			return TRUE
 		if(!user.do_skilled(2 SECONDS, SKILL_LITERACY, src) || (QDELETED(W) || QDELETED(src)))
-			return
+			return TRUE
 
 		to_chat(user, SPAN_NOTICE("You slice \the [P] into [label_added] small strips and insert them into \the [src]'s paper feed."))
 		add_paper_labels(label_added)
@@ -206,7 +206,6 @@
 		else
 			//Abort because not enough materials for even a single label
 			to_chat(user, SPAN_WARNING("There's not enough [ST.plural_name] in \the [ST] to refil \the [src]!"))
-			return
 
 		update_icon()
 		return TRUE

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -377,7 +377,7 @@
 	else if(istype(P, /obj/item/paper) || istype(P, /obj/item/photo))
 		var/obj/item/paper_bundle/B = try_bundle_with(P, user)
 		if(!B)
-			return
+			return TRUE
 		user.put_in_hands(B)
 		to_chat(user, SPAN_NOTICE("You clip \the [P] and \the [name] together."))
 		return TRUE
@@ -385,7 +385,7 @@
 	else if(IS_PEN(P))
 		if(is_crumpled)
 			to_chat(user, SPAN_WARNING("\The [src] is too crumpled to write on."))
-			return
+			return TRUE
 
 		var/obj/item/pen/robopen/RP = P
 		if ( istype(RP) && RP.mode == 2 )

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -34,7 +34,7 @@
 	if(istype(W, /obj/item/paper) || istype(W, /obj/item/photo))
 		var/obj/item/paper/paper = W
 		if(istype(paper) && !paper.can_bundle())
-			return //non-paper or bundlable paper only
+			return TRUE //non-paper or bundlable paper only
 		merge(W, user, cur_page)
 		return TRUE
 
@@ -54,7 +54,8 @@
 			. = P.attackby(W, user)
 			update_icon()
 			updateUsrDialog()
-		return
+			return
+		// How did we not have a page? Dunno, fall through to parent call anyway, I guess
 
 	else if(IS_PEN(W) || istype(W, /obj/item/stamp))
 		close_browser(user, "window=[name]")
@@ -63,7 +64,8 @@
 			. = P.attackby(W, user)
 			update_icon()
 			updateUsrDialog()
-		return
+			return
+		// How did we not have a page? Dunno, fall through to parent call anyway, I guess
 
 	return ..()
 

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -59,7 +59,7 @@
 			if("Carbon-Copy")
 				P = new /obj/item/paper/carbon
 			else
-				return
+				return TRUE
 
 		if(!istype(P, /obj/item/paper/carbon) && global.current_holiday?.name == "April Fool's Day" && prob(30))
 			P.rigged = TRUE
@@ -76,17 +76,16 @@
 	if(istype(I, /obj/item/paper))
 		if(amount >= max_amount)
 			to_chat(user, SPAN_WARNING("\The [src] is full!"))
-			return
+			return TRUE
 		if(!user.try_unequip(I, src))
-			return
+			return TRUE
 		add_paper(I)
 		to_chat(user, SPAN_NOTICE("You put [I] in [src]."))
 		return TRUE
-
 	else if(istype(I, /obj/item/paper_bundle))
 		if(amount >= max_amount)
 			to_chat(user, SPAN_WARNING("\The [src] is full!"))
-			return
+			return TRUE
 		var/obj/item/paper_bundle/B = I
 		var/was_there_a_photo = FALSE
 		for(var/obj/item/bundleitem in I) //loop through items in bundle
@@ -102,7 +101,6 @@
 		if(was_there_a_photo)
 			to_chat(user, SPAN_NOTICE("The photo cannot go into \the [src]."))
 		return TRUE
-
 	return ..()
 
 /obj/item/paper_bin/examine(mob/user, distance)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -112,7 +112,7 @@
 	if(IS_PEN(P))
 		if(!CanPhysicallyInteractWith(user, src))
 			to_chat(user, SPAN_WARNING("You can't interact with this!"))
-			return
+			return TRUE
 		scribble = sanitize(input(user, "What would you like to write on the back? (Leave empty to erase)", "Photo Writing", scribble), MAX_DESC_LEN)
 		return TRUE
 	return ..()
@@ -269,10 +269,10 @@
 					user.put_in_active_hand(film)
 					film = I
 					return TRUE
-				return
+				return TRUE
 			//Unskilled losers have to remove it first
 			to_chat(user, SPAN_NOTICE("[src] already has some film in it! Remove it first!"))
-			return
+			return TRUE
 		else
 			if(user.do_skilled(1 SECONDS, SKILL_DEVICES, src))
 				if(user.get_skill_value(SKILL_DEVICES) >= SKILL_EXPERT)
@@ -286,7 +286,7 @@
 				user.try_unequip(I, src)
 				film = I
 				return TRUE
-			return
+			return TRUE
 	return ..()
 
 /obj/item/camera/proc/get_mobs(turf/the_turf)

--- a/code/modules/paperwork/printer.dm
+++ b/code/modules/paperwork/printer.dm
@@ -62,12 +62,14 @@
 	if(istype(W, /obj/item/chems/toner_cartridge))
 		if(toner)
 			to_chat(user, SPAN_WARNING("There is already \a [W] in \the [src]!"))
+			return TRUE
 		else
 			return insert_toner(W, user)
 
-	else if((istype(W, /obj/item/paper) || istype(W, /obj/item/paper_bundle)))
+	else if(istype(W, /obj/item/paper) || istype(W, /obj/item/paper_bundle))
 		if(paper_left >= paper_max)
 			to_chat(user, SPAN_WARNING("There is no more room for paper in \the [src]!"))
+			return TRUE
 		else
 			return insert_paper(W, user)
 	. = ..()
@@ -144,10 +146,10 @@
 	if(toner)
 		if(user)
 			to_chat(user, SPAN_WARNING("There's already a cartridge in \the [src]."))
-		return
+		return TRUE
 
 	if(!user.try_unequip(T, src))
-		return
+		return TRUE
 	toner = T
 	if(user)
 		to_chat(user, SPAN_NOTICE("You install \a [T] in \the [src]."))
@@ -160,7 +162,7 @@
 	if(!toner)
 		if(user)
 			to_chat(user, SPAN_WARNING("There is no toner cartridge in \the [src]."))
-		return
+		return TRUE
 
 	if(user)
 		user.put_in_hands(toner)
@@ -177,16 +179,16 @@
 	if(paper_left >= paper_max)
 		if(user)
 			to_chat(user, SPAN_WARNING("There is no room for more paper in \the [src]."))
-		return
+		return TRUE
 
 	if(istype(paper_refill, /obj/item/paper))
 		var/obj/item/paper/P = paper_refill
 		if(!P.is_blank())
 			if(user)
 				to_chat(user, SPAN_WARNING("\The [P] isn't blank!"))
-			return
+			return TRUE
 		if(!user?.try_unequip(paper_refill))
-			return
+			return TRUE
 		if(user)
 			to_chat(user, SPAN_NOTICE("You insert \a [paper_refill] in \the [src]."))
 		qdel(paper_refill)
@@ -197,17 +199,16 @@
 		if(!B.is_blank())
 			if(user)
 				to_chat(user, SPAN_WARNING("\The [B] contains some non-blank pages, or something else than paper sheets!"))
-			return
+			return TRUE
 
 		var/amt_papers = B.get_amount_papers()
 		var/to_insert = min((paper_max - paper_left), amt_papers)
-		if(user)
-			to_chat(user, SPAN_NOTICE("You insert \a [paper_refill] in \the [src]."))
 		if(to_insert >= amt_papers)
-			if(user.try_unequip(B))
-				qdel(B)
-			else
-				return
+			if(!user.try_unequip(B))
+				return TRUE
+			if(user)
+				to_chat(user, SPAN_NOTICE("You insert \a [paper_refill] in \the [src]."))
+			qdel(B)
 		else
 			B.remove_sheets(to_insert, user)
 		paper_left += to_insert

--- a/code/modules/persistence/graffiti.dm
+++ b/code/modules/persistence/graffiti.dm
@@ -38,27 +38,17 @@
 		to_chat(user,  "It reads \"[processed_message]\".")
 
 /obj/effect/decal/writing/attackby(var/obj/item/thing, var/mob/user)
-	if(IS_WELDER(thing))
-		if(thing.do_tool_interaction(TOOL_WELDER, user, src, 3 SECONDS))
-			playsound(src, 'sound/items/Welder2.ogg', 50, TRUE)
-			user.visible_message(SPAN_NOTICE("\The [user] clears away some graffiti."))
-			qdel(src)
-			return TRUE
-
+	if(IS_WELDER(thing) && thing.do_tool_interaction(TOOL_WELDER, user, src, 3 SECONDS))
+		playsound(src, 'sound/items/Welder2.ogg', 50, TRUE)
+		user.visible_message(SPAN_NOTICE("\The [user] clears away some graffiti."))
+		qdel(src)
+		return TRUE
 	else if(thing.sharp && user.a_intent != I_HELP) //Check intent so you don't go insane trying to unscrew a light fixture over a graffiti
-
 		if(jobban_isbanned(user, "Graffiti"))
 			to_chat(user, SPAN_WARNING("You are banned from leaving persistent information across rounds."))
-			return
-
-		var/_message = sanitize(input("Enter an additional message to engrave.", "Graffiti") as null|text, trim = TRUE)
-		if(_message && loc && user && !user.incapacitated() && user.Adjacent(loc) && thing.loc == user)
-			user.visible_message(SPAN_WARNING("\The [user] begins carving something into \the [loc]."))
-			if(do_after(user, max(20, length(_message)), src) && loc)
-				user.visible_message(SPAN_DANGER("\The [user] carves some graffiti into \the [loc]."))
-				message = "[message] [_message]"
-				author = user.ckey
-				if(lowertext(message) == "elbereth")
-					to_chat(user, SPAN_NOTICE("You feel much safer."))
-	else
-		. = ..()
+			return TRUE
+		var/turf/T = get_turf(src)
+		if(T)
+			T.try_graffiti(user, thing)
+			return TRUE
+	return ..()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -440,7 +440,8 @@ var/global/list/all_apcs = list()
 
 /obj/machinery/power/apc/attackby(obj/item/W, mob/user)
 	if (istype(construct_state, /decl/machine_construction/wall_frame/panel_closed/hackable/hacking) && (IS_MULTITOOL(W) || IS_WIRECUTTER(W) || istype(W, /obj/item/assembly/signaler)))
-		return wires.Interact(user)
+		wires.Interact(user)
+		return TRUE
 	return ..()
 
 /obj/machinery/power/apc/bash(obj/item/used_item, mob/user)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -445,7 +445,7 @@ var/global/list/all_apcs = list()
 
 /obj/machinery/power/apc/bash(obj/item/used_item, mob/user)
 	if (!(user.a_intent == I_HURT) || (used_item.item_flags & ITEM_FLAG_NO_BLUDGEON))
-		return
+		return FALSE
 
 	if(!used_item.user_can_attack_with(user))
 		return FALSE
@@ -505,6 +505,7 @@ var/global/list/all_apcs = list()
 			else
 				beenhit += 1
 			return TRUE
+	return FALSE
 
 /obj/machinery/power/apc/interface_interact(mob/user)
 	ui_interact(user)

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -229,13 +229,15 @@
 	return ..()
 
 /obj/machinery/power/smes/batteryrack/attackby(var/obj/item/W, var/mob/user)
-	if(..())
-		return TRUE
+	. = ..()
+	if(.)
+		return
 	if(istype(W, /obj/item/cell)) // ID Card, try to insert it.
 		if(insert_cell(W, user))
 			to_chat(user, "You insert \the [W] into \the [src].")
 		else
 			to_chat(user, "\The [src] has no empty slot for \the [W].")
+		return TRUE
 
 /obj/machinery/power/smes/batteryrack/interface_interact(var/mob/user)
 	ui_interact(user)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -157,6 +157,7 @@ By design, d1 is the smallest direction and d2 is the highest
 //   - Multitool : get the power currently passing through the cable
 //
 
+// TODO: take a closer look at cable attackby, make it call parent?
 /obj/structure/cable/attackby(obj/item/W, mob/user)
 	if(IS_WIRECUTTER(W))
 		cut_wire(W, user)
@@ -165,7 +166,7 @@ By design, d1 is the smallest direction and d2 is the highest
 		var/obj/item/stack/cable_coil/coil = W
 		if (coil.get_amount() < 1)
 			to_chat(user, "You don't have enough cable to lay down.")
-			return
+			return TRUE
 		coil.cable_join(src, user)
 
 	else if(IS_MULTITOOL(W))
@@ -198,6 +199,7 @@ By design, d1 is the smallest direction and d2 is the highest
 			visible_message(SPAN_WARNING("[user] stops cutting before any damage is done."))
 
 	src.add_fingerprint(user)
+	return TRUE
 
 /obj/structure/cable/proc/cut_wire(obj/item/W, mob/user)
 	var/turf/T = get_turf(src)

--- a/code/modules/power/fission/core.dm
+++ b/code/modules/power/fission/core.dm
@@ -202,22 +202,22 @@
 	if(IS_MULTITOOL(W))
 		var/datum/extension/local_network_member/fission = get_extension(src, /datum/extension/local_network_member)
 		fission.get_new_tag(user)
-		return
+		return TRUE
 
 	// Cannot deconstruct etc. the core while it is active.
 	if(check_active())
 		to_chat(user, SPAN_WARNING("You cannot do that while \the [src] is active!"))
-		return
+		return TRUE
 
 	if(istype(W, /obj/item/fuel_assembly))
 		if(length(fuel_rods) >= MAX_RODS)
 			to_chat(user, SPAN_WARNING("\The [src] is full!"))
-			return
+			return TRUE
 		if(!user.try_unequip(W, src))
-			return
+			return TRUE
 		fuel_rods[W] = FALSE // Rod is not exposed to begin with.
 		user.visible_message(SPAN_NOTICE("\The [user] inserts \a [W] into \the [src]."), SPAN_NOTICE("You insert \a [W] into \the [src]."))
-		return
+		return TRUE
 	. = ..()
 
 /obj/machinery/atmospherics/unary/fission_core/proc/jump_start()

--- a/code/modules/power/fusion/consoles/_consoles.dm
+++ b/code/modules/power/fusion/consoles/_consoles.dm
@@ -26,7 +26,7 @@
 	if(IS_MULTITOOL(thing))
 		var/datum/extension/local_network_member/fusion = get_extension(src, /datum/extension/local_network_member)
 		fusion.get_new_tag(user)
-		return
+		return TRUE
 	else
 		return ..()
 

--- a/code/modules/power/fusion/core/_core.dm
+++ b/code/modules/power/fusion/core/_core.dm
@@ -102,12 +102,12 @@
 
 	if(owned_field)
 		to_chat(user,"<span class='warning'>Shut \the [src] off first!</span>")
-		return
+		return TRUE
 
 	if(IS_MULTITOOL(W))
 		var/datum/extension/local_network_member/fusion = get_extension(src, /datum/extension/local_network_member)
 		fusion.get_new_tag(user)
-		return
+		return TRUE
 
 	else if(IS_WRENCH(W))
 		anchored = !anchored
@@ -120,7 +120,7 @@
 			user.visible_message("[user.name] unsecures [src.name] from the floor.", \
 				"You unsecure \the [src] from the floor.", \
 				"You hear a ratchet.")
-		return
+		return TRUE
 
 	return ..()
 

--- a/code/modules/power/fusion/fuel_injector/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_injector/fuel_injector.dm
@@ -50,15 +50,15 @@
 	if(IS_MULTITOOL(W))
 		var/datum/extension/local_network_member/fusion = get_extension(src, /datum/extension/local_network_member)
 		fusion.get_new_tag(user)
-		return
+		return TRUE
 
 	if(istype(W, /obj/item/fuel_assembly))
 
 		if(injecting)
 			to_chat(user, "<span class='warning'>Shut \the [src] off before playing with the fuel rod!</span>")
-			return
+			return TRUE
 		if(!user.try_unequip(W, src))
-			return
+			return TRUE
 		if(cur_assembly)
 			visible_message("<span class='notice'>\The [user] swaps \the [src]'s [cur_assembly] for \a [W].</span>")
 		else
@@ -67,19 +67,19 @@
 			cur_assembly.dropInto(loc)
 			user.put_in_hands(cur_assembly)
 		cur_assembly = W
-		return
+		return TRUE
 
 	if(IS_WRENCH(W))
 		if(injecting)
 			to_chat(user, "<span class='warning'>Shut \the [src] off first!</span>")
-			return
+			return TRUE
 		anchored = !anchored
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
 		if(anchored)
 			user.visible_message("\The [user] secures \the [src] to the floor.")
 		else
 			user.visible_message("\The [user] unsecures \the [src] from the floor.")
-		return
+		return TRUE
 
 	return ..()
 

--- a/code/modules/power/fusion/gyrotron/gyrotron.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron.dm
@@ -60,7 +60,7 @@
 	if(IS_MULTITOOL(W))
 		var/datum/extension/local_network_member/fusion = get_extension(src, /datum/extension/local_network_member)
 		fusion.get_new_tag(user)
-		return
+		return TRUE
 	return ..()
 
 #undef GYRO_POWER

--- a/code/modules/power/fusion/kinetic_harvester.dm
+++ b/code/modules/power/fusion/kinetic_harvester.dm
@@ -37,7 +37,7 @@
 		var/datum/extension/local_network_member/lanm = get_extension(src, /datum/extension/local_network_member)
 		if(lanm.get_new_tag(user))
 			find_core()
-		return
+		return TRUE
 	return ..()
 
 /obj/machinery/kinetic_harvester/proc/find_core()

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -154,16 +154,16 @@
 	generate_power(effective_gen)
 
 /obj/machinery/generator/attackby(obj/item/W, mob/user)
-	if(IS_WRENCH(W))
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-		anchored = !anchored
-		user.visible_message("[user.name] [anchored ? "secures" : "unsecures"] the bolts holding [src.name] to the floor.", \
-					"You [anchored ? "secure" : "unsecure"] the bolts holding [src] to the floor.", \
-					"You hear a ratchet.")
-		update_use_power(anchored)
-		reconnect()
-	else
-		..()
+	if(!IS_WRENCH(W))
+		return ..()
+	playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
+	anchored = !anchored
+	user.visible_message("[user.name] [anchored ? "secures" : "unsecures"] the bolts holding [src.name] to the floor.", \
+				"You [anchored ? "secure" : "unsecure"] the bolts holding [src] to the floor.", \
+				"You hear a ratchet.")
+	update_use_power(anchored)
+	reconnect()
+	return TRUE
 
 /obj/machinery/generator/CanUseTopic(mob/user)
 	if(!anchored)

--- a/code/modules/power/heavycable.dm
+++ b/code/modules/power/heavycable.dm
@@ -27,7 +27,7 @@
 	if(istype(item, /obj/item/stack/cable_coil) && !istype(item, /obj/item/stack/cable_coil/heavyduty))
 		to_chat(user, SPAN_WARNING("\The [item] isn't heavy enough to connect to \the [src]."))
 		return TRUE
-	..()
+	return ..()
 
 #undef IS_TOOL_WITH_QUALITY
 

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -306,12 +306,12 @@
 		var/amount = min((max_sheets - sheets), addstack.amount)
 		if(amount < 1)
 			to_chat(user, "<span class='notice'>\The [src] is full!</span>")
-			return
+			return TRUE
 		to_chat(user, "<span class='notice'>You add [amount] sheet\s to \the [src].</span>")
 		sheets += amount
 		addstack.use(amount)
 		updateUsrDialog()
-		return
+		return TRUE
 	if(IS_WRENCH(O) && !active)
 		if(!anchored)
 			to_chat(user, "<span class='notice'>You secure \the [src] to the floor.</span>")
@@ -320,6 +320,7 @@
 
 		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		anchored = !anchored
+		return TRUE
 	return component_attackby(O, user)
 
 /obj/machinery/port_gen/pacman/dismantle()

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -93,33 +93,33 @@ var/global/list/rad_collectors = list()
 	if(istype(W, /obj/item/tank/hydrogen))
 		if(!src.anchored)
 			to_chat(user, "<span class='warning'>\The [src] needs to be secured to the floor first.</span>")
-			return 1
+			return TRUE
 		if(src.loaded_tank)
 			to_chat(user, "<span class='warning'>There's already a tank loaded.</span>")
-			return 1
+			return TRUE
 		if(!user.try_unequip(W, src))
-			return
+			return TRUE
 		src.loaded_tank = W
 		update_icon()
-		return 1
+		return TRUE
 	else if(IS_CROWBAR(W))
 		if(loaded_tank && !src.locked)
 			eject()
-			return 1
+			return TRUE
 	else if(IS_WRENCH(W))
 		if(loaded_tank)
 			to_chat(user, "<span class='notice'>Remove the tank first.</span>")
-			return 1
+			return TRUE
 		for(var/obj/machinery/rad_collector/R in get_turf(src))
 			if(R != src)
 				to_chat(user, "<span class='warning'>You cannot install more than one collector on the same spot.</span>")
-				return 1
+				return TRUE
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
 		src.anchored = !src.anchored
 		user.visible_message("[user.name] [anchored? "secures":"unsecures"] \the [src].", \
 			"You [anchored? "secure":"undo"] the external bolts.", \
 			"You hear a ratchet.")
-		return 1
+		return TRUE
 	else if(istype(W, /obj/item/card/id)||istype(W, /obj/item/modular_computer))
 		if (src.allowed(user))
 			if(active)
@@ -130,7 +130,7 @@ var/global/list/rad_collectors = list()
 				to_chat(user, SPAN_WARNING("The controls can only be locked when \the [src] is active."))
 		else
 			to_chat(user, "<span class='warning'>Access denied!</span>")
-		return 1
+		return TRUE
 	return ..()
 
 /obj/machinery/rad_collector/examine(mob/user, distance)

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -11,7 +11,7 @@
 	movable_flags = MOVABLE_FLAG_PROXMOVE
 	var/obj/machinery/field_generator/FG1 = null
 	var/obj/machinery/field_generator/FG2 = null
-	var/hasShocked = 0 //Used to add a delay between shocks. In some cases this used to crash servers by spawning hundreds of sparks every second.
+	var/next_shock_time = 0 SECONDS //Used to add a delay between shocks. In some cases this used to crash servers by spawning hundreds of sparks every second.
 
 /obj/effect/containment_field/Destroy()
 	if(FG1 && !FG1.clean_up)
@@ -22,7 +22,8 @@
 
 /obj/effect/containment_field/attack_hand(mob/user)
 	SHOULD_CALL_PARENT(FALSE)
-	return shock(user)
+	shock(user)
+	return TRUE
 
 /obj/effect/containment_field/explosion_act(severity)
 	SHOULD_CALL_PARENT(FALSE)
@@ -34,23 +35,19 @@
 		shock(AM)
 
 /obj/effect/containment_field/proc/shock(mob/living/user)
-	if(hasShocked)
-		return 0
+	if(next_shock_time > world.time)
+		return FALSE
 	if(!FG1 || !FG2)
 		qdel(src)
-		return 0
+		return FALSE
 	if(isliving(user))
-		hasShocked = 1
+		next_shock_time = world.time + 2 SECONDS
 		var/shock_damage = min(rand(30,40),rand(30,40))
 		user.electrocute_act(shock_damage, src)
-
 		var/atom/target = get_edge_target_turf(user, get_dir(src, get_step_away(user, src)))
 		user.throw_at(target, 200, 4)
-
-		sleep(20)
-
-		hasShocked = 0
 		return TRUE
+	return FALSE
 
 /obj/effect/containment_field/proc/set_master(var/master1,var/master2)
 	if(!master1 || !master2)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -138,7 +138,7 @@
 	if(IS_WRENCH(W))
 		if(active)
 			to_chat(user, "Turn off [src] first.")
-			return
+			return TRUE
 		switch(state)
 			if(0)
 				state = 1
@@ -156,54 +156,55 @@
 				anchored = FALSE
 			if(2)
 				to_chat(user, "<span class='warning'>\The [src] needs to be unwelded from the floor.</span>")
-		return
+		return TRUE
 
 	if(IS_WELDER(W))
 		var/obj/item/weldingtool/WT = W
 		if(active)
 			to_chat(user, "Turn off [src] first.")
-			return
+			return TRUE
 		switch(state)
 			if(0)
 				to_chat(user, "<span class='warning'>\The [src] needs to be wrenched to the floor.</span>")
 			if(1)
-				if (WT.weld(0,user))
-					playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
-					user.visible_message("[user.name] starts to weld [src] to the floor.", \
-						"You start to weld [src] to the floor.", \
-						"You hear welding.")
-					if (do_after(user,20,src))
-						if(!src || !WT.isOn()) return
-						state = 2
-						to_chat(user, "You weld [src] to the floor.")
-				else
+				if (!WT.weld(0,user))
 					to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
+					return TRUE
+				playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
+				user.visible_message("[user.name] starts to weld [src] to the floor.", \
+					"You start to weld [src] to the floor.", \
+					"You hear welding.")
+				if (!do_after(user, 2 SECONDS, src))
+					return TRUE
+				if(!src || !WT.isOn()) return TRUE
+				state = 2
+				to_chat(user, "You weld [src] to the floor.")
 			if(2)
 				if (WT.weld(0,user))
 					playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
 					user.visible_message("[user.name] starts to cut [src] free from the floor.", \
 						"You start to cut [src] free from the floor.", \
 						"You hear welding.")
-					if (do_after(user,20,src))
-						if(!src || !WT.isOn()) return
-						state = 1
-						to_chat(user, "You cut [src] free from the floor.")
+					if (!do_after(user, 2 SECONDS, src))
+						return TRUE
+					if(!src || !WT.isOn()) return TRUE
+					state = 1
+					to_chat(user, "You cut [src] free from the floor.")
 				else
 					to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
-		return
+		return TRUE
 
 	if(istype(W, /obj/item/card/id) || istype(W, /obj/item/modular_computer))
 		if(emagged)
 			to_chat(user, "<span class='warning'>The lock seems to be broken.</span>")
-			return
+			return TRUE
 		if(allowed(user))
 			locked = !locked
 			to_chat(user, "The controls are now [locked ? "locked." : "unlocked."]")
 		else
 			to_chat(user, "<span class='warning'>Access denied.</span>")
-		return
-	..()
-	return
+		return TRUE
+	return ..()
 
 /obj/machinery/emitter/emag_act(var/remaining_charges, var/mob/user)
 	if(!emagged)

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -92,6 +92,7 @@ field_generator power level display
 
 				src.add_fingerprint(user)
 				return TRUE
+		return FALSE
 	else
 		to_chat(user, "\The [src] needs to be firmly secured to the floor first.")
 		return TRUE
@@ -99,7 +100,7 @@ field_generator power level display
 /obj/machinery/field_generator/attackby(obj/item/W, mob/user)
 	if(active)
 		to_chat(user, "\The [src] needs to be off.")
-		return
+		return TRUE
 	else if(IS_WRENCH(W))
 		switch(state)
 			if(0)
@@ -109,6 +110,7 @@ field_generator power level display
 					"You secure the external reinforcing bolts to the floor.", \
 					"You hear ratchet.")
 				src.anchored = TRUE
+				return TRUE
 			if(1)
 				state = 0
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
@@ -116,42 +118,43 @@ field_generator power level display
 					"You undo the external reinforcing bolts.", \
 					"You hear ratchet.")
 				src.anchored = FALSE
+				return TRUE
 			if(2)
 				to_chat(user, "<span class='warning'> \The [src] needs to be unwelded from the floor.</span>")
-				return
+				return TRUE
 	else if(IS_WELDER(W))
 		var/obj/item/weldingtool/WT = W
 		switch(state)
 			if(0)
 				to_chat(user, "<span class='warning'>\The [src] needs to be wrenched to the floor.</span>")
-				return
+				return TRUE
 			if(1)
-				if (WT.weld(0,user))
-					playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
-					user.visible_message("[user.name] starts to weld \the [src] to the floor.", \
-						"You start to weld \the [src] to the floor.", \
-						"You hear welding.")
-					if (do_after(user,20,src))
-						if(!src || !WT.isOn()) return
-						state = 2
-						to_chat(user, "You weld the field generator to the floor.")
-				else
-					return
+				if (!WT.weld(0,user))
+					return TRUE
+				playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
+				user.visible_message("[user.name] starts to weld \the [src] to the floor.", \
+					"You start to weld \the [src] to the floor.", \
+					"You hear welding.")
+				if (!do_after(user, 2 SECONDS, src))
+					return TRUE
+				if(!src || !WT.isOn()) return TRUE
+				state = 2
+				to_chat(user, "You weld the field generator to the floor.")
+				return TRUE
 			if(2)
-				if (WT.weld(0,user))
-					playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
-					user.visible_message("[user.name] starts to cut \the [src] free from the floor.", \
-						"You start to cut \the [src] free from the floor.", \
-						"You hear welding.")
-					if (do_after(user,20,src))
-						if(!src || !WT.isOn()) return
-						state = 1
-						to_chat(user, "You cut \the [src] free from the floor.")
-				else
-					return
-	else
-		..()
-		return
+				if (!WT.weld(0,user))
+					return TRUE
+				playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
+				user.visible_message("[user.name] starts to cut \the [src] free from the floor.", \
+					"You start to cut \the [src] free from the floor.", \
+					"You hear welding.")
+				if (!do_after(user, 2 SECONDS, src))
+					return TRUE
+				if(!src || !WT.isOn()) return TRUE
+				state = 1
+				to_chat(user, "You cut \the [src] free from the floor.")
+				return TRUE
+	return ..()
 
 
 /obj/machinery/field_generator/emp_act()

--- a/code/modules/power/singularity/generator.dm
+++ b/code/modules/power/singularity/generator.dm
@@ -40,16 +40,16 @@
 		qdel(src)
 
 /obj/machinery/singularity_generator/attackby(obj/item/W, mob/user)
-	if(IS_WRENCH(W))
-		anchored = !anchored
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-		if(anchored)
-			user.visible_message("[user.name] secures \the [src] to the floor.", \
-				"You secure \the [src] to the floor.", \
-				"You hear a ratchet.")
-		else
-			user.visible_message("[user.name] unsecures \the [src] from the floor.", \
-				"You unsecure \the [src] from the floor.", \
-				"You hear a ratchet.")
-		return
-	return ..()
+	if(!IS_WRENCH(W))
+		return ..()
+	anchored = !anchored
+	playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
+	if(anchored)
+		user.visible_message("[user.name] secures \the [src] to the floor.", \
+			"You secure \the [src] to the floor.", \
+			"You hear a ratchet.")
+	else
+		user.visible_message("[user.name] unsecures \the [src] from the floor.", \
+			"You unsecure \the [src] from the floor.", \
+			"You hear a ratchet.")
+	return TRUE

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -103,8 +103,10 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 
 
 /obj/structure/particle_accelerator/attackby(obj/item/W, mob/user)
-	if(!has_extension(W, /datum/extension/tool) || !process_tool_hit(W,user))
-		return ..()
+	if(has_extension(W, /datum/extension/tool))
+		if(process_tool_hit(W,user))
+			return TRUE
+	return ..()
 
 /obj/structure/particle_accelerator/Move()
 	..()
@@ -242,8 +244,10 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 
 
 /obj/machinery/particle_accelerator/attackby(obj/item/W, mob/user)
-	if(!has_extension(W, /datum/extension/tool) || !process_tool_hit(W,user))
-		return ..()
+	if(has_extension(W, /datum/extension/tool))
+		if(process_tool_hit(W,user))
+			return TRUE
+	return ..()
 
 /obj/machinery/particle_accelerator/explosion_act(severity)
 	. = ..()

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -223,10 +223,7 @@
 /obj/machinery/power/smes/attackby(var/obj/item/W, var/mob/user)
 	if(component_attackby(W, user))
 		return TRUE
-
-	if (!panel_open)
-		to_chat(user, "<span class='warning'>You need to open the access hatch on \the [src] first!</span>")
-		return TRUE
+	return bash(W, user)
 
 /obj/machinery/power/smes/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	// this is the data which will be sent to the ui

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -334,16 +334,18 @@
 	// No more disassembling of overloaded SMESs. You broke it, now enjoy the consequences.
 	if (failing)
 		to_chat(user, "<span class='warning'>\The [src]'s screen is flashing with alerts. It seems to be overloaded! Touching it now is probably not a good idea.</span>")
+		return TRUE
+	. = ..()
+	if(.)
 		return
-
-	if (!..())
-
-		// Multitool - change RCON tag
-		if(IS_MULTITOOL(W))
-			var/newtag = input(user, "Enter new RCON tag. Use \"NO_TAG\" to disable RCON or leave empty to cancel.", "SMES RCON system") as text
-			if(newtag)
-				RCon_tag = newtag
-				to_chat(user, "<span class='notice'>You changed the RCON tag to: [newtag]</span>")
+	// Multitool - change RCON tag
+	if(IS_MULTITOOL(W))
+		var/newtag = input(user, "Enter new RCON tag. Use \"NO_TAG\" to disable RCON or leave empty to cancel.", "SMES RCON system") as text
+		if(newtag)
+			RCon_tag = newtag
+			to_chat(user, "<span class='notice'>You changed the RCON tag to: [newtag]</span>")
+		return TRUE
+	return FALSE
 
 // Proc: toggle_input()
 // Parameters: None

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -74,7 +74,6 @@ var/global/list/solars_list = list()
 
 
 /obj/machinery/power/solar/attackby(obj/item/W, mob/user)
-
 	if(IS_CROWBAR(W))
 		playsound(loc, 'sound/machines/click.ogg', 50, 1)
 		user.visible_message("<span class='notice'>[user] begins to take the glass off the solar panel.</span>")
@@ -86,12 +85,12 @@ var/global/list/solars_list = list()
 			playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
 			user.visible_message("<span class='notice'>[user] takes the glass off the solar panel.</span>")
 			qdel(src)
-		return
+		return TRUE
 	else if (W)
 		add_fingerprint(user)
 		current_health -= W.get_attack_force(user)
 		healthcheck()
-	..()
+	return ..()
 
 /obj/machinery/power/solar/proc/healthcheck()
 	if (current_health <= 0)
@@ -242,9 +241,8 @@ var/global/list/solars_list = list()
 		glass_reinforced = null
 
 /obj/item/solar_assembly/attackby(var/obj/item/W, var/mob/user)
-
-	if(!anchored && isturf(loc))
-		if(IS_WRENCH(W))
+	if(IS_WRENCH(W))
+		if(!anchored && isturf(loc))
 			anchored = TRUE
 			default_pixel_x = 0
 			default_pixel_y = 0
@@ -252,43 +250,37 @@ var/global/list/solars_list = list()
 			reset_offsets(0)
 			user.visible_message("<span class='notice'>[user] wrenches the solar assembly into place.</span>")
 			playsound(loc, 'sound/items/Ratchet.ogg', 75, 1)
-			return 1
-	else
-		if(IS_WRENCH(W))
+			return TRUE
+		else
 			anchored = FALSE
-			user.visible_message("<span class='notice'>[user] unwrenches the solar assembly from it's place.</span>")
+			user.visible_message("<span class='notice'>[user] unwrenches the solar assembly from its place.</span>")
 			playsound(loc, 'sound/items/Ratchet.ogg', 75, 1)
-			return 1
-
-		if(istype(W, /obj/item/stack/material) && W.get_material_type() == /decl/material/solid/glass)
-			var/obj/item/stack/material/S = W
-			if(S.use(2))
-				glass_type =       S.material.type
-				glass_reinforced = S.reinf_material?.type
-				playsound(loc, 'sound/machines/click.ogg', 50, 1)
-				user.visible_message("<span class='notice'>[user] places the glass on the solar assembly.</span>")
-				if(tracker)
-					new /obj/machinery/power/tracker(get_turf(src), src)
-				else
-					new /obj/machinery/power/solar(get_turf(src), src)
-			else
-				to_chat(user, "<span class='warning'>You need two sheets of glass to put them into a solar panel.</span>")
-				return
-			return 1
-
-	if(!tracker)
-		if(istype(W, /obj/item/tracker_electronics))
-			tracker = 1
-			qdel(W)
-			user.visible_message("<span class='notice'>[user] inserts the electronics into the solar assembly.</span>")
-			return 1
-	else
-		if(IS_CROWBAR(W))
-			new /obj/item/tracker_electronics(loc)
-			tracker = 0
-			user.visible_message("<span class='notice'>[user] takes out the electronics from the solar assembly.</span>")
-			return 1
-	..()
+			return TRUE
+	else if(istype(W, /obj/item/stack/material) && W.get_material_type() == /decl/material/solid/glass)
+		var/obj/item/stack/material/S = W
+		if(!S.use(2))
+			to_chat(user, "<span class='warning'>You need two sheets of glass to put them into a solar panel.</span>")
+			return TRUE
+		glass_type =       S.material.type
+		glass_reinforced = S.reinf_material?.type
+		playsound(loc, 'sound/machines/click.ogg', 50, 1)
+		user.visible_message("<span class='notice'>[user] places the glass on the solar assembly.</span>")
+		if(tracker)
+			new /obj/machinery/power/tracker(get_turf(src), src)
+		else
+			new /obj/machinery/power/solar(get_turf(src), src)
+		return TRUE
+	if(!tracker && istype(W, /obj/item/tracker_electronics))
+		tracker = TRUE
+		qdel(W)
+		user.visible_message("<span class='notice'>[user] inserts the electronics into the solar assembly.</span>")
+		return TRUE
+	else if(IS_CROWBAR(W))
+		new /obj/item/tracker_electronics(loc)
+		tracker = 0
+		user.visible_message("<span class='notice'>[user] takes out the electronics from the solar assembly.</span>")
+		return TRUE
+	return ..()
 
 //
 // Solar Control Computer

--- a/code/modules/power/stirling.dm
+++ b/code/modules/power/stirling.dm
@@ -145,9 +145,9 @@
 /obj/machinery/atmospherics/binary/stirling/attackby(var/obj/item/W, var/mob/user)
 	if((istype(W, /obj/item/tank/stirling)))
 		if(inserted_cylinder)
-			return
+			return TRUE
 		if(!user.try_unequip(W, src))
-			return
+			return TRUE
 		to_chat(user, SPAN_NOTICE("You insert \the [W] into \the [src]."))
 		inserted_cylinder = W
 		update_icon()
@@ -164,9 +164,9 @@
 		if(IS_WRENCH(W))
 			var/target_frequency = input(user, "Enter the cycle frequency you would like \the [src] to operate at ([MAX_FREQUENCY/4] - [MAX_FREQUENCY] Hz)", "Stirling Frequency", cycle_frequency) as num | null
 			if(!CanPhysicallyInteract(user) || !target_frequency)
-				return
+				return TRUE
 			cycle_frequency = round(clamp(target_frequency, MAX_FREQUENCY/4, MAX_FREQUENCY))
-			to_chat(usr, SPAN_NOTICE("You adjust \the [src] to operate at a frequency of [cycle_frequency] Hz."))
+			to_chat(user, SPAN_NOTICE("You adjust \the [src] to operate at a frequency of [cycle_frequency] Hz."))
 			return TRUE
 
 	. = ..()
@@ -178,12 +178,13 @@
 
 	if(!inserted_cylinder)
 		to_chat(user, SPAN_WARNING("You must insert a stirling piston cylinder into \the [src] before you can start it!"))
-		return
+		return TRUE
 	to_chat(user, "You start trying to manually rev up \the [src].")
 	if(do_after(user, 2 SECONDS, src) && !active && inserted_cylinder && !(stat & BROKEN))
 		visible_message("[user] pulls on the starting cord of \the [src], revving it up!", "You pull on the starting cord of \the [src], revving it up!")
 		playsound(src.loc, 'sound/machines/engine.ogg', 35, 1)
 		active = TRUE
+	return TRUE
 
 /obj/machinery/atmospherics/binary/stirling/on_update_icon()
 	cut_overlays()

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -34,12 +34,12 @@
 
 		if(istype(T) && !T.is_plating())
 			to_chat(user, SPAN_WARNING("You must remove the floor plating in front of \the [machine] first!"))
-			return
+			return TRUE
 
 		 // If this is a terminal that's somehow been left behind, let it be removed freely.
 		if(machine && !machine.components_are_accessible(/obj/item/stock_parts/power/terminal))
 			to_chat(user, SPAN_WARNING("You must open the panel on \the [machine] first!"))
-			return
+			return TRUE
 
 		user.visible_message(SPAN_WARNING("\The [user] dismantles the power terminal from \the [machine]."), \
 										  "You begin to cut the cables...")
@@ -53,6 +53,7 @@
 				new /obj/item/stack/cable_coil(T, 10)
 				to_chat(user, SPAN_NOTICE("You cut the cables and dismantle the power terminal."))
 				qdel_self()
+		return TRUE
 	. = ..()
 
 /obj/machinery/power/terminal/examine(mob/user)

--- a/code/modules/power/tracker.dm
+++ b/code/modules/power/tracker.dm
@@ -60,16 +60,17 @@
 	if(IS_CROWBAR(W))
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 		user.visible_message("<span class='notice'>[user] begins to take the glass off the solar tracker.</span>")
-		if(do_after(user, 50,src))
-			var/obj/item/solar_assembly/S = locate() in src
-			if(S)
-				S.dropInto(loc)
-				S.give_glass()
-			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-			user.visible_message("<span class='notice'>[user] takes the glass off the tracker.</span>")
-			qdel(src)
-		return
-	..()
+		if(!do_after(user, 5 SECONDS, src))
+			return TRUE
+		var/obj/item/solar_assembly/S = locate() in src
+		if(S)
+			S.dropInto(loc)
+			S.give_glass()
+		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
+		user.visible_message("<span class='notice'>[user] takes the glass off the tracker.</span>")
+		qdel(src)
+		return TRUE
+	return ..()
 
 // Tracker Electronic
 

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -87,22 +87,23 @@
 		forensics.add_from_atom(/datum/forensics/gunshot_residue, src)
 
 /obj/item/ammo_casing/attackby(obj/item/W, mob/user)
-	if(IS_SCREWDRIVER(W))
-		if(!BB)
-			to_chat(user, "<span class='notice'>There is no bullet in the casing to inscribe anything into.</span>")
-			return
+	if(!IS_SCREWDRIVER(W))
+		return ..()
+	if(!BB)
+		to_chat(user, "<span class='notice'>There is no bullet in the casing to inscribe anything into.</span>")
+		return TRUE
 
-		var/tmp_label = ""
-		var/label_text = sanitize_safe(input(user, "Inscribe some text into \the [initial(BB.name)]","Inscription",tmp_label), MAX_NAME_LEN)
-		if(length(label_text) > 20)
-			to_chat(user, "<span class='warning'>The inscription can be at most 20 characters long.</span>")
-		else if(!label_text)
-			to_chat(user, "<span class='notice'>You scratch the inscription off of [initial(BB)].</span>")
-			BB.SetName(initial(BB.name))
-		else
-			to_chat(user, "<span class='notice'>You inscribe \"[label_text]\" into \the [initial(BB.name)].</span>")
-			BB.SetName("[initial(BB.name)] (\"[label_text]\")")
-	else ..()
+	var/tmp_label = ""
+	var/label_text = sanitize_safe(input(user, "Inscribe some text into \the [initial(BB.name)]","Inscription",tmp_label), MAX_NAME_LEN)
+	if(length(label_text) > 20)
+		to_chat(user, "<span class='warning'>The inscription can be at most 20 characters long.</span>")
+	else if(!label_text)
+		to_chat(user, "<span class='notice'>You scratch the inscription off of [initial(BB)].</span>")
+		BB.SetName(initial(BB.name))
+	else
+		to_chat(user, "<span class='notice'>You inscribe \"[label_text]\" into \the [initial(BB.name)].</span>")
+		BB.SetName("[initial(BB.name)] (\"[label_text]\")")
+	return TRUE
 
 /obj/item/ammo_casing/on_update_icon()
 	. = ..()
@@ -189,20 +190,21 @@
 	update_icon()
 
 /obj/item/ammo_magazine/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/ammo_casing))
-		var/obj/item/ammo_casing/C = W
-		if(C.caliber != caliber)
-			to_chat(user, "<span class='warning'>[C] does not fit into [src].</span>")
-			return
-		if(get_stored_ammo_count() >= max_ammo)
-			to_chat(user, "<span class='warning'>[src] is full!</span>")
-			return
-		if(!user.try_unequip(C, src))
-			return
-		stored_ammo.Add(C)
-		playsound(user, 'sound/weapons/guns/interaction/bullet_insert.ogg', 50, 1)
-		update_icon()
-	else ..()
+	if(!istype(W, /obj/item/ammo_casing))
+		return ..()
+	var/obj/item/ammo_casing/C = W
+	if(C.caliber != caliber)
+		to_chat(user, "<span class='warning'>[C] does not fit into [src].</span>")
+		return TRUE
+	if(get_stored_ammo_count() >= max_ammo)
+		to_chat(user, "<span class='warning'>[src] is full!</span>")
+		return TRUE
+	if(!user.try_unequip(C, src))
+		return TRUE
+	stored_ammo.Add(C)
+	playsound(user, 'sound/weapons/guns/interaction/bullet_insert.ogg', 50, 1)
+	update_icon()
+	return TRUE
 
 /obj/item/ammo_magazine/attack_self(mob/user)
 	create_initial_contents()

--- a/code/modules/projectiles/guns/launcher/bows/crossbow_powered.dm
+++ b/code/modules/projectiles/guns/launcher/bows/crossbow_powered.dm
@@ -121,23 +121,25 @@
 		var/obj/item/rcd_ammo/cartridge = W
 		if((stored_matter + cartridge.remaining) > max_stored_matter)
 			to_chat(user, SPAN_NOTICE("The RCD can't hold that many additional matter-units."))
-			return
+			return TRUE
 		stored_matter += cartridge.remaining
 		qdel(W)
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 		to_chat(user, SPAN_NOTICE("The RCD now holds [stored_matter]/[max_stored_matter] matter-units."))
 		update_icon()
-
+		return TRUE
 	if(istype(W, /obj/item/stack/material/bow_ammo/bolt/rcd))
 		var/obj/item/stack/material/bow_ammo/bolt/rcd/A = W
 		if((stored_matter + 10) > max_stored_matter)
 			to_chat(user, SPAN_NOTICE("Unable to reclaim flashforged bolt. The RCD can't hold that many additional matter-units."))
-			return
+			return TRUE
 		stored_matter += 10
 		qdel(A)
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 		to_chat(user, SPAN_NOTICE("Flashforged bolt reclaimed. The RCD now holds [stored_matter]/[max_stored_matter] matter-units."))
 		update_icon()
+		return TRUE
+	return ..()
 
 /obj/item/gun/launcher/bow/crossbow/powered/rapidcrossbowdevice/on_update_icon()
 	. = ..()

--- a/code/modules/projectiles/guns/launcher/foam_gun.dm
+++ b/code/modules/projectiles/guns/launcher/foam_gun.dm
@@ -19,14 +19,17 @@
 	var/list/darts = new/list()
 
 /obj/item/gun/launcher/foam/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/foam_dart))
-		if(darts.len < max_darts)
-			if(!user.try_unequip(I, src))
-				return
-			darts += I
-			to_chat(user, SPAN_NOTICE("You slot \the [I] into \the [src]."))
-		else
-			to_chat(user, SPAN_WARNING("\The [src] can hold no more darts."))
+	if(!istype(I, /obj/item/foam_dart))
+		return ..()
+	if(darts.len < max_darts)
+		if(!user.try_unequip(I, src))
+			return TRUE
+		darts += I
+		to_chat(user, SPAN_NOTICE("You slot \the [I] into \the [src]."))
+		return TRUE
+	else
+		to_chat(user, SPAN_WARNING("\The [src] can hold no more darts."))
+		return TRUE
 
 /obj/item/gun/launcher/foam/consume_next_projectile()
 	if(darts.len)

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -79,10 +79,11 @@
 	pump(user)
 
 /obj/item/gun/launcher/grenade/attackby(obj/item/I, mob/user)
-	if((istype(I, /obj/item/grenade)))
+	if(istype(I, /obj/item/grenade))
 		load(I, user)
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/item/gun/launcher/grenade/attack_hand(mob/user)
 	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))

--- a/code/modules/projectiles/guns/launcher/money_cannon.dm
+++ b/code/modules/projectiles/guns/launcher/money_cannon.dm
@@ -112,23 +112,23 @@
 	return TRUE
 
 /obj/item/gun/launcher/money/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/cash/))
+	if(istype(W, /obj/item/cash))
 		var/obj/item/cash/bling = W
 		if(bling.absolute_worth < 1)
 			to_chat(user, "<span class='warning'>You can't seem to get \the [bling] to slide into the receptacle.</span>")
-			return
+			return TRUE
 
 		var/decl/currency/cur = GET_DECL(bling.currency)
 		if(bling.currency != global.using_map.default_currency)
 			to_chat(user, SPAN_WARNING("Due to local legislation and budget cuts, \the [src] will only accept [cur.name]."))
-			return
+			return TRUE
 
 		receptacle_value += bling.absolute_worth
 		to_chat(user, "<span class='notice'>You slide [bling.get_worth()] [cur.name_singular] into [src]'s receptacle.</span>")
 		qdel(bling)
-
+		return TRUE
 	else
-		to_chat(user, "<span class='warning'>That's not going to fit in there.</span>")
+		return ..()
 
 /obj/item/gun/launcher/money/examine(mob/user)
 	. = ..(user)

--- a/code/modules/projectiles/guns/launcher/rocket.dm
+++ b/code/modules/projectiles/guns/launcher/rocket.dm
@@ -26,12 +26,15 @@
 	if(istype(I, /obj/item/ammo_casing/rocket))
 		if(rockets.len < max_rockets)
 			if(!user.try_unequip(I, src))
-				return
+				return TRUE
 			rockets += I
 			to_chat(user, "<span class='notice'>You put the rocket in [src].</span>")
 			to_chat(user, "<span class='notice'>[rockets.len] / [max_rockets] rockets.</span>")
+			return TRUE
 		else
 			to_chat(usr, "<span class='warning'>\The [src] cannot hold more rockets.</span>")
+			return TRUE
+	return ..()
 
 /obj/item/gun/launcher/rocket/consume_next_projectile()
 	if(rockets.len)

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -25,12 +25,16 @@
 		underlays += MA
 
 /obj/item/syringe_cartridge/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/chems/syringe) && user.try_unequip(I, src))
+	if(istype(I, /obj/item/chems/syringe))
+		if(!user.try_unequip(I, src))
+			return TRUE
 		syringe = I
 		to_chat(user, "<span class='notice'>You carefully insert [syringe] into [src].</span>")
-		sharp = 1
+		sharp = TRUE
 		name = "syringe dart"
 		update_icon()
+		return TRUE
+	return ..()
 
 /obj/item/syringe_cartridge/attack_self(mob/user)
 	if(syringe)
@@ -129,13 +133,14 @@
 		var/obj/item/syringe_cartridge/C = A
 		if(darts.len >= max_darts)
 			to_chat(user, "<span class='warning'>[src] is full!</span>")
-			return
+			return TRUE
 		if(!user.try_unequip(C, src))
-			return
+			return TRUE
 		darts += C //add to the end
 		user.visible_message("[user] inserts \a [C] into [src].", "<span class='notice'>You insert \a [C] into [src].</span>")
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/item/gun/launcher/syringe/rapid
 	name = "syringe gun revolver"

--- a/code/modules/projectiles/guns/magnetic/magnetic.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic.dm
@@ -104,71 +104,71 @@
 		if(IS_SCREWDRIVER(thing))
 			if(!capacitor)
 				to_chat(user, "<span class='warning'>\The [src] has no capacitor installed.</span>")
-				return
+				return TRUE
 			user.put_in_hands(capacitor)
 			user.visible_message("<span class='notice'>\The [user] unscrews \the [capacitor] from \the [src].</span>")
 			playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
 			capacitor = null
 			update_icon()
-			return
+			return TRUE
 		if(istype(thing, /obj/item/stock_parts/capacitor))
 			if(capacitor)
 				to_chat(user, "<span class='warning'>\The [src] already has \a [capacitor] installed.</span>")
-				return
+				return TRUE
 			if(!user.try_unequip(thing, src))
-				return
+				return TRUE
 			capacitor = thing
 			playsound(loc, 'sound/machines/click.ogg', 10, 1)
 			power_per_tick = (power_cost*0.15) * capacitor.rating
 			user.visible_message("<span class='notice'>\The [user] slots \the [capacitor] into \the [src].</span>")
 			update_icon()
-			return
+			return TRUE
 
-	if(istype(thing, load_type))
+	if(!istype(thing, load_type))
+		return ..()
 
-		// This is not strictly necessary for the magnetic gun but something using
-		// specific ammo types may exist down the track.
-		var/obj/item/stack/ammo = thing
-		if(!istype(ammo))
-			if(loaded)
-				to_chat(user, "<span class='warning'>\The [src] already has \a [loaded] loaded.</span>")
-				return
-			var/obj/item/magnetic_ammo/mag = thing
-			if(istype(mag))
-				if(!(load_type == mag.basetype))
-					to_chat(user, "<span class='warning'>\The [src] doesn't seem to accept \a [mag].</span>")
-					return
-				projectile_type = mag.projectile_type
-			if(!user.try_unequip(thing, src))
-				return
+	// This is not strictly necessary for the magnetic gun but something using
+	// specific ammo types may exist down the track.
+	var/obj/item/stack/ammo = thing
+	if(!istype(ammo))
+		if(loaded)
+			to_chat(user, "<span class='warning'>\The [src] already has \a [loaded] loaded.</span>")
+			return TRUE
+		var/obj/item/magnetic_ammo/mag = thing
+		if(istype(mag))
+			if(!(load_type == mag.basetype))
+				to_chat(user, "<span class='warning'>\The [src] doesn't seem to accept \a [mag].</span>")
+				return TRUE
+			projectile_type = mag.projectile_type
+		if(!user.try_unequip(thing, src))
+			return TRUE
 
-			loaded = thing
-		else if(load_sheet_max > 1)
-			var ammo_count = 0
-			var/obj/item/stack/loaded_ammo = loaded
-			if(!istype(loaded_ammo))
-				ammo_count = min(load_sheet_max,ammo.amount)
-				loaded = new load_type(src, ammo_count)
-			else
-				ammo_count = min(load_sheet_max-loaded_ammo.amount,ammo.amount)
-				loaded_ammo.amount += ammo_count
-			if(ammo_count <= 0)
-				// This will also display when someone tries to insert a stack of 0, but that shouldn't ever happen anyway.
-				to_chat(user, "<span class='warning'>\The [src] is already fully loaded.</span>")
-				return
-			ammo.use(ammo_count)
+		loaded = thing
+	else if(load_sheet_max > 1)
+		var ammo_count = 0
+		var/obj/item/stack/loaded_ammo = loaded
+		if(!istype(loaded_ammo))
+			ammo_count = min(load_sheet_max,ammo.amount)
+			loaded = new load_type(src, ammo_count)
 		else
-			if(loaded)
-				to_chat(user, "<span class='warning'>\The [src] already has \a [loaded] loaded.</span>")
-				return
-			loaded = new load_type(src, 1)
-			ammo.use(1)
+			ammo_count = min(load_sheet_max-loaded_ammo.amount,ammo.amount)
+			loaded_ammo.amount += ammo_count
+		if(ammo_count <= 0)
+			// This will also display when someone tries to insert a stack of 0, but that shouldn't ever happen anyway.
+			to_chat(user, "<span class='warning'>\The [src] is already fully loaded.</span>")
+			return TRUE
+		ammo.use(ammo_count)
+	else
+		if(loaded)
+			to_chat(user, "<span class='warning'>\The [src] already has \a [loaded] loaded.</span>")
+			return TRUE
+		loaded = new load_type(src, 1)
+		ammo.use(1)
 
-		user.visible_message("<span class='notice'>\The [user] loads \the [src] with \the [loaded].</span>")
-		playsound(loc, 'sound/weapons/flipblade.ogg', 50, 1)
-		update_icon()
-		return
-	. = ..()
+	user.visible_message("<span class='notice'>\The [user] loads \the [src] with \the [loaded].</span>")
+	playsound(loc, 'sound/weapons/flipblade.ogg', 50, 1)
+	update_icon()
+	return TRUE
 
 /obj/item/gun/magnetic/attack_hand(var/mob/user)
 	if(!user.is_holding_offhand(src) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -97,10 +97,10 @@
 	launcher = new(src)
 
 /obj/item/gun/projectile/automatic/assault_rifle/grenade/attackby(obj/item/I, mob/user)
-	if((istype(I, /obj/item/grenade)))
-		launcher.load(I, user)
-	else
-		..()
+	if(!istype(I, /obj/item/grenade))
+		return ..()
+	launcher.load(I, user)
+	return TRUE
 
 /obj/item/gun/projectile/automatic/assault_rifle/grenade/attack_hand(mob/user)
 	if(!user.is_holding_offhand(src) || !use_launcher || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -70,8 +70,8 @@
 /obj/item/gun/projectile/dartgun/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/chems/glass))
 		add_beaker(I, user)
-		return 1
-	..()
+		return TRUE
+	return ..()
 
 /obj/item/gun/projectile/dartgun/proc/add_beaker(var/obj/item/chems/glass/B, mob/user)
 	if(!istype(B, container_type))

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -91,15 +91,17 @@
 			for(var/i in 1 to max_shells)
 				Fire(user, user)	//will this work? //it will. we call it twice, for twice the FUN
 			user.visible_message("<span class='danger'>The shotgun goes off!</span>", "<span class='danger'>The shotgun goes off in your face!</span>")
-			return
-		if(do_after(user, 30, src))	//SHIT IS STEALTHY EYYYYY
-			user.try_unequip(src)
-			var/obj/item/gun/projectile/shotgun/doublebarrel/sawn/empty/buddy = new(loc)
-			transfer_fingerprints_to(buddy)
-			qdel(src)
-			to_chat(user, "<span class='warning'>You shorten the barrel of \the [src]!</span>")
+			return TRUE
+		if(!do_after(user, 3 SECONDS, src))	//SHIT IS STEALTHY EYYYYY
+			return TRUE
+		user.try_unequip(src)
+		var/obj/item/gun/projectile/shotgun/doublebarrel/sawn/empty/buddy = new(loc)
+		transfer_fingerprints_to(buddy)
+		qdel(src)
+		to_chat(user, "<span class='warning'>You shorten the barrel of \the [src]!</span>")
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/item/gun/projectile/shotgun/doublebarrel/sawn
 	name = "sawn-off shotgun"

--- a/code/modules/projectiles/secure.dm
+++ b/code/modules/projectiles/secure.dm
@@ -35,10 +35,12 @@
 			verbs += /obj/item/gun/proc/reset_registration
 			registered_owner = id.registered_name
 			to_chat(user, SPAN_NOTICE("\The [src] chimes quietly as it registers to \"[registered_owner]\"."))
+			return TRUE
 		else
 			to_chat(user, SPAN_NOTICE("\The [src] buzzes quietly, refusing to register without first being reset."))
+			return TRUE
 	else
-		..()
+		return ..()
 
 /obj/item/gun/emag_act(var/charges, var/mob/user)
 	if(!charges)

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -44,9 +44,9 @@
 
 		if(beaker)
 			to_chat(user, SPAN_WARNING("A beaker is already loaded into the machine."))
-			return
+			return TRUE
 		if(!user.try_unequip(B, src))
-			return
+			return TRUE
 		beaker = B
 		to_chat(user, SPAN_NOTICE("You add the beaker to the machine!"))
 		updateUsrDialog()
@@ -61,9 +61,9 @@
 
 		if(loaded_pill_bottle)
 			to_chat(user, SPAN_WARNING("A pill bottle is already loaded into the machine."))
-			return
+			return TRUE
 		if(!user.try_unequip(B, src))
-			return
+			return TRUE
 		loaded_pill_bottle = B
 		to_chat(user, SPAN_NOTICE("You add the pill bottle into the dispenser slot!"))
 		updateUsrDialog()

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -93,7 +93,7 @@
 
 	if(IS_CROWBAR(hit_with) && !panel_open && length(cartridges))
 		var/label = input(user, "Which cartridge would you like to remove?", "Chemical Dispenser") as null|anything in cartridges
-		if(!label) return
+		if(!label) return TRUE
 		var/obj/item/chems/chem_disp_cartridge/C = remove_cartridge(label)
 		if(C)
 			to_chat(user, SPAN_NOTICE("You remove \the [C] from \the [src]."))

--- a/code/modules/reagents/reagent_containers/condiments/__condiment.dm
+++ b/code/modules/reagents/reagent_containers/condiments/__condiment.dm
@@ -23,20 +23,21 @@
 	if(IS_PEN(W))
 		var/tmp_label = sanitize_safe(input(user, "Enter a label for [name]", "Label", label_text), MAX_NAME_LEN)
 		if(tmp_label == label_text)
-			return
+			return TRUE
 		if(length(tmp_label) > 10)
 			to_chat(user, SPAN_NOTICE("The label can be at most 10 characters long."))
+			return TRUE
+		if(length(tmp_label))
+			to_chat(user, SPAN_NOTICE("You set the label to \"[tmp_label]\"."))
+			label_text = tmp_label
 		else
-			if(length(tmp_label))
-				to_chat(user, SPAN_NOTICE("You set the label to \"[tmp_label]\"."))
-				label_text = tmp_label
-			else
-				to_chat(user, SPAN_NOTICE("You remove the label."))
-				label_text = null
-			update_name()
-			update_container_desc()
-			update_icon()
-		return
+			to_chat(user, SPAN_NOTICE("You remove the label."))
+			label_text = null
+		update_name()
+		update_container_desc()
+		update_icon()
+		return TRUE
+	return ..()
 
 /obj/item/chems/condiment/afterattack(var/obj/target, var/mob/user, var/proximity)
 	if(!proximity)

--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -214,10 +214,12 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 				user.visible_message("<span class='notice'>The contents of \the [src] splash all over [user]!</span>")
 				reagents.splash(user, reagents.total_volume)
 			qdel(src)
-			return
+			return TRUE
 		user.visible_message("<span class='notice'>[user] gently strikes \the [src] with a spoon, calling the room to attention.</span>")
 		playsound(src, "sound/items/wineglass.ogg", 65, 1)
-	else return ..()
+		return TRUE
+	else
+		return ..()
 
 /obj/item/chems/drinks/glass2/ProcessAtomTemperature()
 	var/old_temp = temperature

--- a/code/modules/reagents/reagent_containers/drinkingglass/extras.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/extras.dm
@@ -3,25 +3,27 @@
 
 	if(istype(I, /obj/item/glass_extra))
 		var/obj/item/glass_extra/GE = I
-		if(can_add_extra(GE))
-			extras += GE
-			if(!user.try_unequip(GE, src))
-				return
-			to_chat(user, "<span class=notice>You add \the [GE] to \the [src].</span>")
-			update_icon()
-		else
+		if(!can_add_extra(GE))
 			to_chat(user, "<span class=warning>There's no space to put \the [GE] on \the [src]!</span>")
+			return TRUE
+		extras += GE
+		if(!user.try_unequip(GE, src))
+			return TRUE
+		to_chat(user, "<span class=notice>You add \the [GE] to \the [src].</span>")
+		update_icon()
+		return TRUE
 	else if(istype(I, /obj/item/food/processed_grown/slice))
 		if(!rim_pos)
 			to_chat(user, "<span class=warning>There's no space to put \the [I] on \the [src]!</span>")
-			return
+			return TRUE
 		var/obj/item/food/processed_grown/slice/FS = I
 		extras += FS
 		if(!user.try_unequip(FS, src))
-			return
+			return TRUE
 		reset_offsets(0) // Reset its pixel offsets so the icons work!
 		to_chat(user, "<span class=notice>You add \the [FS] to \the [src].</span>")
 		update_icon()
+		return TRUE
 	else
 		return ..()
 

--- a/code/modules/reagents/reagent_containers/food/baking/leavened_dough.dm
+++ b/code/modules/reagents/reagent_containers/food/baking/leavened_dough.dm
@@ -13,11 +13,13 @@
 
 // Dough + rolling pin = flat dough
 /obj/item/food/dough/attackby(obj/item/W, mob/user)
-	if(istype(W,/obj/item/kitchen/rollingpin))
-		var/obj/item/food/sliceable/flatdough/result = new()
-		result.dropInto(loc)
-		to_chat(user, "You flatten the dough.")
-		qdel(src)
+	if(!istype(W,/obj/item/kitchen/rollingpin))
+		return ..()
+	var/obj/item/food/sliceable/flatdough/result = new()
+	result.dropInto(loc)
+	to_chat(user, "You flatten the dough.")
+	qdel(src)
+	return TRUE
 
 // slicable into 3x doughslices
 /obj/item/food/sliceable/flatdough

--- a/code/modules/reagents/reagent_containers/food/canned/_canned.dm
+++ b/code/modules/reagents/reagent_containers/food/canned/_canned.dm
@@ -35,22 +35,23 @@
 		unseal()
 
 /obj/item/food/can/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/knife) && !ATOM_IS_OPEN_CONTAINER(src))
-		user.visible_message(
-			SPAN_NOTICE("\The [user] is trying to open \the [src] with \the [W]."),
-			SPAN_NOTICE("You start to open \the [src].")
-		)
-		var/open_timer = istype(W, /obj/item/knife/opener) ? 5 SECONDS : 15 SECONDS
-		if(do_after(user, open_timer, src))
+	if(!ATOM_IS_OPEN_CONTAINER(src))
+		if(istype(W, /obj/item/knife))
+			user.visible_message(
+				SPAN_NOTICE("\The [user] starts trying to open \the [src] with \the [W]."),
+				SPAN_NOTICE("You start to open \the [src].")
+			)
+			var/open_timer = istype(W, /obj/item/knife/opener) ? 5 SECONDS : 15 SECONDS
+			if(!do_after(user, open_timer, src))
+				to_chat(user, SPAN_WARNING("You must remain uninterrupted to open \the [src]."))
+				return TRUE
 			to_chat(user, SPAN_NOTICE("You unseal \the [src] with a crack of metal."))
 			unseal()
-			return
-
-	else if(istype(W,/obj/item/utensil))
-		if(ATOM_IS_OPEN_CONTAINER(src))
-			..()
-		else
-			to_chat(user, SPAN_WARNING("You need a can-opener to open this!"))
+			return TRUE
+		else if(istype(W,/obj/item/utensil))
+			to_chat(user, SPAN_WARNING("You need a can opener to open this!"))
+			return TRUE
+	return ..()
 
 /obj/item/food/can/on_update_icon()
 	. = ..()

--- a/code/modules/reagents/reagent_containers/food/eggs.dm
+++ b/code/modules/reagents/reagent_containers/food/eggs.dm
@@ -40,7 +40,7 @@
 
 		if(!(clr in list("blue","green","mime","orange","purple","rainbow","red","yellow")))
 			to_chat(usr, SPAN_WARNING("The egg refuses to take on this color!"))
-			return
+			return TRUE
 
 		to_chat(usr, SPAN_NOTICE("You color \the [src] [clr]"))
 		icon_state = "egg-[clr]"

--- a/code/modules/reagents/reagent_containers/food/fish.dm
+++ b/code/modules/reagents/reagent_containers/food/fish.dm
@@ -73,5 +73,5 @@
 	if(thing.sharp || thing.edge)
 		user.visible_message(SPAN_NOTICE("\The [user] cracks open \the [src] with \the [thing]."))
 		crack_shell(user)
-		return
+		return TRUE
 	. = ..()

--- a/code/modules/reagents/reagent_containers/food/sandwich.dm
+++ b/code/modules/reagents/reagent_containers/food/sandwich.dm
@@ -5,7 +5,8 @@
 		S.dropInto(loc)
 		S.attackby(W,user)
 		qdel(src)
-	..()
+		return TRUE
+	return ..()
 
 /obj/item/food/csandwich
 	name = "sandwich"
@@ -17,6 +18,8 @@
 	var/list/ingredients = list()
 
 /obj/item/food/csandwich/attackby(obj/item/W, mob/user)
+	if(!istype(W, /obj/item/food) && !istype(W, /obj/item/shard))
+		return ..()
 
 	var/sandwich_limit = 4
 	for(var/obj/item/O in ingredients)
@@ -24,24 +27,24 @@
 			sandwich_limit += 4
 
 	if(src.contents.len > sandwich_limit)
-		to_chat(user, "<span class='wwarning'>If you put anything else on \the [src] it's going to collapse.</span>")
-		return
-	else if(istype(W,/obj/item/shard))
+		to_chat(user, "<span class='warning'>If you put anything else on \the [src] it's going to collapse.</span>")
+		return TRUE
+	if(istype(W,/obj/item/shard))
 		if(!user.try_unequip(W, src))
-			return
+			return TRUE
 		to_chat(user, "<span class='warning'>You hide [W] in \the [src].</span>")
 		update_icon()
-		return
+		return TRUE
 	else if(istype(W,/obj/item/food))
 		if(!user.try_unequip(W, src))
-			return
+			return TRUE
 		to_chat(user, "<span class='warning'>You layer [W] over \the [src].</span>")
 		var/obj/item/chems/F = W
 		F.reagents.trans_to_obj(src, F.reagents.total_volume)
 		ingredients += W
 		update_icon()
-		return
-	..()
+		return TRUE
+	return FALSE // This shouldn't ever happen but okay.
 
 /obj/item/food/csandwich/on_update_icon()
 	. = ..()

--- a/code/modules/reagents/reagent_containers/food/sushi.dm
+++ b/code/modules/reagents/reagent_containers/food/sushi.dm
@@ -91,16 +91,16 @@
 		var/obj/item/food/sashimi/other_sashimi = I
 		if(slices + other_sashimi.slices > 5)
 			to_chat(user, "<span class='warning'>Show some restraint, would you?</span>")
-			return
+			return TRUE
 		if(!user.try_unequip(I))
-			return
+			return TRUE
 		slices += other_sashimi.slices
 		bitesize = slices
 		update_icon()
 		if(I.reagents)
 			I.reagents.trans_to(src, I.reagents.total_volume)
 		qdel(I)
-		return
+		return TRUE
 
 	// Make sushi.
 	if(istype(I, /obj/item/food/boiledrice))
@@ -108,9 +108,9 @@
 			to_chat(user, "<span class='warning'>Putting more than one slice of fish on your sushi is just greedy.</span>")
 		else
 			if(!user.try_unequip(I))
-				return
+				return TRUE
 			new /obj/item/food/sushi(get_turf(src), null, TRUE, I, src)
-		return
+		return TRUE
 	. = ..()
 
 /obj/item/food/sashimi/handle_utensil_cutting(obj/item/tool, mob/user)
@@ -133,7 +133,7 @@
 				to_chat(user, "<span class='warning'>Putting more than one slice of fish on your sushi is just greedy.</span>")
 			else
 				new /obj/item/food/sushi(get_turf(src), null, TRUE, src, I)
-			return
+			return TRUE
 		var/static/list/sushi_types = list(
 			/obj/item/food/friedegg,
 			/obj/item/food/tofu,
@@ -144,27 +144,28 @@
 		)
 		if(is_type_in_list(I, sushi_types))
 			new /obj/item/food/sushi(get_turf(src), null, TRUE, src, I)
-			return
+			return TRUE
 	. = ..()
 // Used for turning other food into sushi.
+// TODO: maybe make these resolve_attackby overrides on boiledrice instead?
 /obj/item/food/friedegg/attackby(var/obj/item/I, var/mob/user)
 	if((locate(/obj/structure/table) in loc) && istype(I, /obj/item/food/boiledrice))
 		new /obj/item/food/sushi(get_turf(src), null, TRUE, I, src)
-		return
+		return TRUE
 	. = ..()
 /obj/item/food/tofu/attackby(var/obj/item/I, var/mob/user)
 	if((locate(/obj/structure/table) in loc) && istype(I, /obj/item/food/boiledrice))
 		new /obj/item/food/sushi(get_turf(src), null, TRUE, I, src)
-		return
+		return TRUE
 	. = ..()
 /obj/item/food/butchery/cutlet/raw/attackby(var/obj/item/I, var/mob/user)
 	if((locate(/obj/structure/table) in loc) && istype(I, /obj/item/food/boiledrice))
 		new /obj/item/food/sushi(get_turf(src), null, TRUE, I, src)
-		return
+		return TRUE
 	. = ..()
 /obj/item/food/butchery/cutlet/attackby(var/obj/item/I, var/mob/user)
 	if((locate(/obj/structure/table) in loc) && istype(I, /obj/item/food/boiledrice))
 		new /obj/item/food/sushi(get_turf(src), null, TRUE, I, src)
-		return
+		return TRUE
 	. = ..()
 // End non-fish sushi.

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -132,7 +132,7 @@
 			playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 		else
 			to_chat(user, SPAN_WARNING("\The [D] is saturated."))
-		return
+		return TRUE
 	else
 		return ..()
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -152,12 +152,12 @@
 	return TRUE
 
 /obj/item/chems/hypospray/vial/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/chems/glass/beaker/vial))
-		if(!do_after(user,10) || !(W in user))
-			return
-		insert_vial(W, user)
+	if(!istype(W, /obj/item/chems/glass/beaker/vial))
+		return ..()
+	if(!do_after(user, 1 SECOND, src))
 		return TRUE
-	. = ..()
+	insert_vial(W, user)
+	return TRUE
 
 /obj/item/chems/hypospray/vial/afterattack(obj/target, mob/user, proximity) // hyposprays can be dumped into, why not out? uses standard_pour_into helper checks.
 	if(!proximity)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -65,7 +65,7 @@
 	update_icon()
 
 /obj/item/chems/syringe/attackby(obj/item/I, mob/user)
-	return
+	return FALSE // allow afterattack to proceed
 
 /obj/item/chems/syringe/afterattack(obj/target, mob/user, proximity)
 	if(!proximity)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -208,12 +208,14 @@ var/global/list/all_conveyor_switches = list()
 		position = 0
 
 /obj/machinery/conveyor_switch/attackby(obj/item/I, mob/user, params)
-	if(IS_CROWBAR(I))
-		var/obj/item/conveyor_switch_construct/C = new/obj/item/conveyor_switch_construct(src.loc)
-		C.id_tag = id_tag
-		transfer_fingerprints_to(C)
-		to_chat(user, "<span class='notice'>You deattach the conveyor switch.</span>")
-		qdel(src)
+	if(!IS_CROWBAR(I))
+		return ..()
+	var/obj/item/conveyor_switch_construct/C = new/obj/item/conveyor_switch_construct(src.loc)
+	C.id_tag = id_tag
+	transfer_fingerprints_to(C)
+	to_chat(user, "<span class='notice'>You detach the conveyor switch.</span>")
+	qdel(src)
+	return TRUE
 
 /obj/machinery/conveyor_switch/oneway
 	var/convdir = 1 //Set to 1 or -1 depending on which way you want the convayor to go. (In other words keep at 1 and set the proper dir on the belts.)
@@ -240,11 +242,12 @@ var/global/list/all_conveyor_switches = list()
 	var/id_tag
 
 /obj/item/conveyor_construct/attackby(obj/item/I, mob/user, params)
-	..()
-	if(istype(I, /obj/item/conveyor_switch_construct))
-		to_chat(user, "<span class='notice'>You link the switch to the conveyor belt assembly.</span>")
-		var/obj/item/conveyor_switch_construct/C = I
-		id_tag = C.id_tag
+	if(!istype(I, /obj/item/conveyor_switch_construct))
+		return ..()
+	to_chat(user, "<span class='notice'>You link the switch to the conveyor belt assembly.</span>")
+	var/obj/item/conveyor_switch_construct/C = I
+	id_tag = C.id_tag
+	return TRUE
 
 /obj/item/conveyor_construct/afterattack(atom/A, mob/user, proximity)
 	if(!proximity || !istype(A, /turf/floor) || user.incapacitated())

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -80,35 +80,33 @@
 	return
 
 /obj/machinery/disposal/deliveryChute/attackby(var/obj/item/I, var/mob/user)
-	if(!I || !user)
-		return
-
 	if(IS_SCREWDRIVER(I))
 		if(c_mode==0)
 			c_mode=1
-			playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
+			playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, TRUE)
 			to_chat(user, "You remove the screws around the power connection.")
-			return
+			return TRUE
 		else if(c_mode==1)
 			c_mode=0
-			playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
+			playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, TRUE)
 			to_chat(user, "You attach the screws around the power connection.")
-			return
+			return TRUE
 	else if(IS_WELDER(I) && c_mode==1)
 		var/obj/item/weldingtool/W = I
-		if(W.weld(1,user))
-			to_chat(user, "You start slicing the floorweld off the delivery chute.")
-			if(do_after(user,20, src))
-				playsound(src.loc, 'sound/items/Welder2.ogg', 100, 1)
-				if(!src || !W.isOn()) return
-				to_chat(user, "You sliced the floorweld off the delivery chute.")
-				var/obj/structure/disposalconstruct/C = new (loc, src)
-				C.update()
-				qdel(src)
-			return
-		else
-			to_chat(user, "You need more welding fuel to complete this task.")
-			return
+		if(!W.weld(1,user)) // 'you need more welding fuel' messages are already handled
+			return TRUE
+		to_chat(user, "You start slicing the floorweld off the delivery chute.")
+		if(!do_after(user, 2 SECONDS, src))
+			to_chat(user, "You stop slicing the floorweld off the delivery chute.")
+			return TRUE
+		playsound(src.loc, 'sound/items/Welder2.ogg', 100, TRUE)
+		if(!src || !W.isOn()) return TRUE
+		to_chat(user, "You slice the floorweld off the delivery chute.")
+		var/obj/structure/disposalconstruct/C = new (loc, src)
+		C.update()
+		qdel(src)
+		return TRUE
+	return ..()
 
 /obj/machinery/disposal/deliveryChute/Destroy()
 	if(trunk)

--- a/code/modules/research/design_console.dm
+++ b/code/modules/research/design_console.dm
@@ -25,11 +25,11 @@
 	if(istype(I, /obj/item/disk/design_disk))
 		if(disk)
 			to_chat(user, SPAN_WARNING("\The [src] already has a disk inserted."))
-			return
+			return TRUE
 		if(user.try_unequip(I, src))
 			visible_message("\The [user] slots \the [I] into \the [src].")
 			disk = I
-			return
+			return TRUE
 	. = ..()
 
 /obj/machinery/computer/design_console/proc/eject_disk(var/mob/user)

--- a/code/modules/research/design_database.dm
+++ b/code/modules/research/design_database.dm
@@ -155,13 +155,13 @@ var/global/list/default_initial_tech_levels
 	if(istype(I, /obj/item/disk/tech_disk))
 		if(disk)
 			to_chat(user, SPAN_WARNING("\The [src] already has a disk inserted."))
-			return
+			return TRUE
 		if(user.try_unequip(I, src))
 			visible_message("\The [user] slots \the [I] into \the [src].")
 			visible_message(SPAN_NOTICE("\The [src]'s I/O light begins to blink."))
 			disk = I
 			need_disk_operation = TRUE
-			return
+			return TRUE
 
 	. = ..()
 

--- a/code/modules/research/design_database_analyzer.dm
+++ b/code/modules/research/design_database_analyzer.dm
@@ -86,12 +86,12 @@
 		fabnet.get_new_tag(user)
 		return TRUE
 
-	if(isrobot(user))
-		return
 	if(busy)
 		to_chat(user, SPAN_WARNING("\The [src] is busy right now."))
 		return TRUE
 	if(component_attackby(O, user))
+		return TRUE
+	if(isrobot(user))
 		return TRUE
 	if(loaded_item)
 		to_chat(user, SPAN_WARNING("There is something already loaded into \the [src]."))
@@ -109,13 +109,14 @@
 		to_chat(user, SPAN_WARNING("You cannot deconstruct this item."))
 		return TRUE
 
-	if(user.try_unequip(O, src))
-		busy = TRUE
-		loaded_item = O
-		to_chat(user, SPAN_NOTICE("You add \the [O] to \the [src]."))
-		flick("d_analyzer_la", src)
-		addtimer(CALLBACK(src, PROC_REF(refresh_busy)), 1 SECOND)
+	if(!user.try_unequip(O, src))
 		return TRUE
+	busy = TRUE
+	loaded_item = O
+	to_chat(user, SPAN_NOTICE("You add \the [O] to \the [src]."))
+	flick("d_analyzer_la", src)
+	addtimer(CALLBACK(src, PROC_REF(refresh_busy)), 1 SECOND)
+	return TRUE
 
 /obj/machinery/destructive_analyzer/proc/refresh_busy()
 	if(busy)

--- a/code/modules/security levels/keycard_authentication.dm
+++ b/code/modules/security levels/keycard_authentication.dm
@@ -26,26 +26,32 @@
 
 /obj/machinery/keycard_auth/attack_ai(mob/living/silicon/ai/user)
 	to_chat(user, "<span class='warning'>A firewall prevents you from interfacing with this device!</span>")
-	return
+	return TRUE
 
 /obj/machinery/keycard_auth/attackby(obj/item/W, mob/user)
+	if(!istype(W,/obj/item/card/id))
+		return ..()
 	if(stat & (NOPOWER|BROKEN))
 		to_chat(user, "This device is not powered.")
-		return
-	if(istype(W,/obj/item/card/id))
-		visible_message(SPAN_NOTICE("[user] swipes \the [W] through \the [src]."))
-		var/obj/item/card/id/ID = W
-		if(access_keycard_auth in ID.access)
-			if(active)
-				if(event_source && initial_card?.resolve() != ID)
-					event_source.confirmed = 1
-					event_source.event_confirmed_by = user
-				else
-					visible_message(SPAN_WARNING("\The [src] blinks and displays a message: Unable to confirm the event with the same card."), range=2)
-			else if(screen == 2)
-				event_triggered_by = user
-				initial_card = weakref(ID)
-				broadcast_request() //This is the device making the initial event request. It needs to broadcast to other devices
+		return TRUE
+	visible_message(SPAN_NOTICE("[user] swipes \the [W] through \the [src]."))
+	var/obj/item/card/id/ID = W
+	if(!(access_keycard_auth in ID.access)) // you get nothing!
+		return TRUE
+	if(active)
+		if(!event_source) // Is this even possible? Should active just be !isnull(event_source)?
+			return TRUE
+		if(initial_card?.resolve() == ID)
+			visible_message(SPAN_WARNING("\The [src] blinks and displays a message: Unable to confirm the event with the same card."), range=2)
+			return TRUE
+		event_source.confirmed = 1
+		event_source.event_confirmed_by = user
+		return TRUE
+	if(screen == 2)
+		event_triggered_by = user
+		initial_card = weakref(ID)
+		broadcast_request() //This is the device making the initial event request. It needs to broadcast to other devices
+	return TRUE
 
 //icon_state gets set everwhere besides here, that needs to be fixed sometime
 /obj/machinery/keycard_auth/on_update_icon()

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -208,22 +208,27 @@
 
 // Attacks with hand tools. Blocked by Hyperkinetic flag.
 /obj/effect/shield/attackby(var/obj/item/I, var/mob/user)
+	return bash(I, user)
+
+/obj/effect/shield/bash(obj/item/weapon, mob/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(src)
 
-	if(gen.check_flag(MODEFLAG_HYPERKINETIC))
-		var/force = I.get_attack_force(user)
-		user.visible_message("<span class='danger'>\The [user] [pick(I.attack_verb)] \the [src] with \the [I]!</span>")
-		if(I.atom_damage_type == BURN)
+	if(!gen.check_flag(MODEFLAG_HYPERKINETIC))
+		user.visible_message("<span class='danger'>\The [user] tries to attack \the [src] with \the [weapon], but it passes through!</span>")
+		return TRUE
+	var/force = weapon.get_attack_force(user)
+	user.visible_message("<span class='danger'>\The [user] [pick(weapon.attack_verb)] \the [src] with \the [weapon]!</span>")
+	switch(weapon.atom_damage_type)
+		if(BURN)
 			take_damage(force, SHIELD_DAMTYPE_HEAT)
-		else if (I.atom_damage_type == BRUTE)
+		if (BRUTE)
 			take_damage(force, SHIELD_DAMTYPE_PHYSICAL)
 		else
 			take_damage(force, SHIELD_DAMTYPE_EM)
-		if(gen.check_flag(MODEFLAG_OVERCHARGE) && (I.obj_flags & OBJ_FLAG_CONDUCTIBLE))
-			overcharge_shock(user)
-	else
-		user.visible_message("<span class='danger'>\The [user] tries to attack \the [src] with \the [I], but it passes through!</span>")
+	if(gen.check_flag(MODEFLAG_OVERCHARGE) && (weapon.obj_flags & OBJ_FLAG_CONDUCTIBLE))
+		overcharge_shock(user)
+	return TRUE
 
 
 // Special treatment for meteors because they would otherwise penetrate right through the shield.

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -40,22 +40,33 @@
 	if(!height || air_group) return 0
 	else return ..()
 
-/obj/machinery/shield/attackby(obj/item/W, mob/user)
-	if(!istype(W)) return
+// Circumvent base machinery attackby
+// TODO: MAKE SHIELDS NOT MACHINERY???
+/obj/machinery/shield/attackby(obj/item/I, mob/user)
+	return bash(I, user)
 
+/obj/machinery/shield/bash(obj/item/W, mob/user)
+	if(isliving(user) && user.a_intent == I_HELP)
+		return FALSE
+	if(!W.user_can_attack_with(user))
+		return FALSE
+	if(W.item_flags & ITEM_FLAG_NO_BLUDGEON)
+		return FALSE
 	//Calculate damage
-	if(W.atom_damage_type == BRUTE || W.atom_damage_type == BURN)
-		current_health -= W.get_attack_force(user)
+	switch(W.atom_damage_type)
+		if(BRUTE, BURN)
+			current_health -= W.get_attack_force(user)
+		else
+			return FALSE
 
 	//Play a fitting sound
 	playsound(src.loc, 'sound/effects/EMPulse.ogg', 75, 1)
 
 	check_failure()
-	set_opacity(1)
-	spawn(20) if(!QDELETED(src)) set_opacity(0)
+	set_opacity(TRUE)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, set_opacity), FALSE), 2 SECONDS)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-
-	..()
+	return TRUE
 
 /obj/machinery/shield/bullet_act(var/obj/item/projectile/Proj)
 	current_health -= Proj.get_structure_damage()
@@ -264,21 +275,23 @@
 		else
 			to_chat(user, "<span class='notice'>You open the panel and expose the wiring.</span>")
 			is_open = 1
-
+		return TRUE
 	else if(IS_COIL(W) && malfunction && is_open)
 		var/obj/item/stack/cable_coil/coil = W
 		to_chat(user, "<span class='notice'>You begin to replace the wires.</span>")
-		if(do_after(user, 30,src))
-			if (coil.use(1))
-				current_health = get_max_health()
-				malfunction = 0
-				to_chat(user, "<span class='notice'>You repair \the [src]!</span>")
-				update_icon()
-
+		if(!do_after(user, 3 SECONDS, src))
+			to_chat(user, SPAN_NOTICE("You stop repairing \the [src]."))
+			return TRUE
+		if (coil.use(1))
+			current_health = get_max_health()
+			malfunction = 0
+			to_chat(user, "<span class='notice'>You repair \the [src]!</span>")
+			update_icon()
+		return TRUE
 	else if(IS_WRENCH(W))
 		if(locked)
 			to_chat(user, "The bolts are covered, unlocking this would retract the covers.")
-			return
+			return TRUE
 		if(anchored)
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 			to_chat(user, "<span class='notice'>'You unsecure \the [src] from the floor!</span>")
@@ -286,21 +299,19 @@
 				to_chat(user, "<span class='notice'>\The [src] shuts off!</span>")
 				src.shields_down()
 			anchored = FALSE
-		else
-			if(isspaceturf(get_turf(src))) return //No wrenching these in space!
+		else if(!isspaceturf(get_turf(src))) //No wrenching these in space!
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 			to_chat(user, "<span class='notice'>You secure \the [src] to the floor!</span>")
 			anchored = TRUE
-
-
+		return TRUE
 	else if(istype(W, /obj/item/card/id) || istype(W, /obj/item/modular_computer/pda))
 		if(src.allowed(user))
 			src.locked = !src.locked
 			to_chat(user, "The controls are now [src.locked ? "locked." : "unlocked."]")
 		else
 			to_chat(user, "<span class='warning'>Access denied.</span>")
-	else
-		..()
+		return TRUE
+	return ..()
 
 
 /obj/machinery/shieldgen/on_update_icon()

--- a/code/modules/shieldgen/shieldwallgen.dm
+++ b/code/modules/shieldgen/shieldwallgen.dm
@@ -207,19 +207,16 @@
 	if(IS_WRENCH(W))
 		if(active)
 			to_chat(user, "Turn off the field generator first.")
-			return
-
-		else if(anchored == 0)
+			return TRUE
+		if(!anchored)
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
 			to_chat(user, "You secure the external reinforcing bolts to the floor.")
 			src.anchored = TRUE
-			return
-
-		else if(anchored == 1)
-			playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-			to_chat(user, "You undo the external reinforcing bolts.")
-			src.anchored = FALSE
-			return
+			return TRUE
+		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
+		to_chat(user, "You undo the external reinforcing bolts.")
+		src.anchored = FALSE
+		return TRUE
 
 	if(istype(W, /obj/item/card/id)||istype(W, /obj/item/modular_computer))
 		if (src.allowed(user))
@@ -227,11 +224,8 @@
 			to_chat(user, "Controls are now [src.locked ? "locked." : "unlocked."]")
 		else
 			to_chat(user, "<span class='warning'>Access denied.</span>")
-		return
-
-	else
-		src.add_fingerprint(user)
-		..()
+		return TRUE
+	return ..()
 
 
 /obj/machinery/shieldwallgen/proc/cleanup(var/NSEW)
@@ -300,14 +294,11 @@
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(src)
 	playsound(loc, 'sound/weapons/smash.ogg', 75, 1)
+	return TRUE
 
 /obj/machinery/shieldwall/Process()
 	if(needs_power)
-		if(isnull(gen_primary)||isnull(gen_secondary))
-			qdel(src)
-			return
-
-		if(!(gen_primary.active)||!(gen_secondary.active))
+		if(!gen_primary?.active || !gen_secondary?.active)
 			qdel(src)
 			return
 

--- a/code/modules/shuttles/docking_beacon.dm
+++ b/code/modules/shuttles/docking_beacon.dm
@@ -49,11 +49,11 @@
 	if(IS_WRENCH(I))
 		if(!allowed(user))
 			to_chat(user, SPAN_WARNING("The bolts on \the [src] are locked!"))
-			return
+			return TRUE
 		playsound(loc, 'sound/items/Ratchet.ogg', 100, 1)
 		to_chat(user, SPAN_NOTICE("You [anchored ? "unanchor" : "anchor"] \the [src]."))
 		anchored = !anchored
-		return
+		return TRUE
 
 	. = ..()
 

--- a/code/modules/shuttles/shuttle_emergency.dm
+++ b/code/modules/shuttles/shuttle_emergency.dm
@@ -175,8 +175,9 @@
 		return 1
 
 /obj/machinery/computer/shuttle_control/emergency/attackby(obj/item/W, mob/user)
-	read_authorization(W)
-	..()
+	if(read_authorization(W))
+		return TRUE
+	return ..()
 
 /obj/machinery/computer/shuttle_control/emergency/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	var/data[0]

--- a/code/modules/spells/general/mark_recall.dm
+++ b/code/modules/spells/general/mark_recall.dm
@@ -64,7 +64,7 @@
 /obj/effect/cleanable/wizard_mark/Destroy()
 	spell.mark = null //dereference pls.
 	spell = null
-	..()
+	return ..()
 
 /obj/effect/cleanable/wizard_mark/attack_hand(var/mob/user)
 	if(user != spell.holder)

--- a/code/modules/spells/spellbook.dm
+++ b/code/modules/spells/spellbook.dm
@@ -103,7 +103,7 @@ var/global/list/artefact_feedback = list(
 				if(I.reagents.has_reagent(id, 5))
 					make_sacrifice(I, user, id)
 					return TRUE
-	..()
+	return ..()
 
 /obj/item/book/spell/interact(mob/user)
 	var/dat = null

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -629,11 +629,12 @@ var/global/list/supermatter_delam_accent_sounds = list(
 		var/obj/item/stack/tape_roll/duct_tape/T = W
 		if(!T.can_use(20))
 			to_chat(user, SPAN_WARNING("You need at least 20 [T.plural_name] to repair \the [src]."))
-			return
+			return TRUE
 		T.use(20)
 		playsound(src, 'sound/effects/tape.ogg', 100, TRUE)
 		to_chat(user, SPAN_NOTICE("You begin to repair some of the damage to \the [src] with \the [W]."))
 		damage = max(damage -10, 0)
+		return TRUE // be nice, the extra duct tape if you have 21 or more doesn't turn to ash and irradiate you.
 
 	if(!QDELETED(W))
 		user.visible_message(SPAN_WARNING("\The [user] touches \the [src] with \a [W] as silence fills the room..."),\
@@ -644,6 +645,7 @@ var/global/list/supermatter_delam_accent_sounds = list(
 		user.drop_from_inventory(W)
 		Consume(user, W, TRUE)
 	user.apply_damage(150, IRRADIATE, damage_flags = DAM_DISPERSED)
+	return TRUE
 
 /obj/machinery/power/supermatter/Bumped(atom/AM)
 	if(!Consume(null, AM))

--- a/code/modules/synthesized_instruments/real_instruments/Synthesizer/synthesizer.dm
+++ b/code/modules/synthesized_instruments/real_instruments/Synthesizer/synthesizer.dm
@@ -16,26 +16,27 @@
 	if (IS_WRENCH(O))
 		if (!anchored && !isspaceturf(get_turf(src)))
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-			to_chat(usr, "<span class='notice'> You begin to tighten \the [src] to the floor...</span>")
-			if (do_after(user, 20))
+			to_chat(user, "<span class='notice'>You begin to tighten \the [src] to the floor...</span>")
+			if (do_after(user, 2 SECONDS))
 				if(!anchored && !isspaceturf(get_turf(src)))
 					user.visible_message( \
 						"[user] tightens \the [src]'s casters.", \
-						"<span class='notice'> You tighten \the [src]'s casters. Now it can be played again.</span>", \
-						"<span class='italics'>You hear ratchet.</span>")
+						"<span class='notice'>You tighten \the [src]'s casters. Now it can be played again.</span>", \
+						"<span class='italics'>You hear a ratchet.</span>")
 					src.anchored = TRUE
 		else if(anchored)
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-			to_chat(usr, "<span class='notice'> You begin to loosen \the [src]'s casters...</span>")
-			if (do_after(user, 40))
+			to_chat(user, "<span class='notice'>You begin to loosen \the [src]'s casters...</span>")
+			if (do_after(user, 4 SECONDS))
 				if(anchored)
 					user.visible_message( \
 						"[user] loosens \the [src]'s casters.", \
-						"<span class='notice'> You loosen \the [src]. Now it can be pulled somewhere else.</span>", \
-						"<span class='italics'>You hear ratchet.</span>")
+						"<span class='notice'>You loosen \the [src]. Now it can be pulled somewhere else.</span>", \
+						"<span class='italics'>You hear a ratchet.</span>")
 					src.anchored = FALSE
-	else
-		..()
+			return TRUE
+		// we failed to do anything because we were unanchored in space, fall through to parent and smack it?
+	return ..()
 
 /obj/structure/synthesized_instrument/synthesizer/shouldStopPlaying(mob/user)
 	return !((src && in_range(src, user) && src.anchored) || src.real_instrument.player.song.autorepeat)

--- a/code/modules/vehicles/bike.dm
+++ b/code/modules/vehicles/bike.dm
@@ -112,16 +112,16 @@
 		if(istype(W, /obj/item/engine))
 			if(engine)
 				to_chat(user, "<span class='warning'>There is already an engine block in \the [src].</span>")
-				return 1
+				return TRUE
 			user.visible_message("<span class='warning'>\The [user] installs \the [W] into \the [src].</span>")
 			load_engine(W)
-			return
+			return TRUE
 		else if(engine && engine.attackby(W,user))
-			return 1
+			return TRUE
 		else if(IS_CROWBAR(W) && engine)
 			to_chat(user, "You pop out \the [engine] from \the [src].")
 			unload_engine()
-			return 1
+			return TRUE
 	return ..()
 
 /obj/vehicle/bike/receive_mouse_drop(atom/dropping, mob/user, params)

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -71,18 +71,16 @@
 	if(open && IS_WIRECUTTER(W))
 		passenger_allowed = !passenger_allowed
 		user.visible_message("<span class='notice'>[user] [passenger_allowed ? "cuts" : "mends"] a cable in [src].</span>","<span class='notice'>You [passenger_allowed ? "cut" : "mend"] the load limiter cable.</span>")
-	else
-		..()
+		return TRUE
+	return ..()
 
 /obj/vehicle/train/cargo/engine/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/key/cargo_train))
-		if(!key)
-			if(!user.try_unequip(W, src))
-				return
+		if(!key && user.try_unequip(W, src))
 			key = W
 			verbs += /obj/vehicle/train/cargo/engine/verb/remove_key
-		return
-	..()
+		return TRUE
+	return ..()
 
 //cargo trains are open topped, so there is a chance the projectile will hit the mob ridding the train instead
 /obj/vehicle/train/cargo/bullet_act(var/obj/item/projectile/Proj)

--- a/code/modules/vehicles/engine.dm
+++ b/code/modules/vehicles/engine.dm
@@ -41,14 +41,17 @@
 			cell = I
 			user.drop_from_inventory(I)
 			I.forceMove(src)
-		return 1
+		return TRUE
 	else if(IS_CROWBAR(I))
 		if(cell)
-			to_chat(user, "You pry out \the [cell].")
+			to_chat(user, "You pry out \the [cell] with \the [I].")
 			cell.dropInto(loc)
 			cell = null
-			return 1
-	..()
+			return TRUE
+		if(user.a_intent != I_HURT)
+			to_chat(user, SPAN_WARNING("There is no cell in \the [src] to remove with \the [I]!"))
+			return TRUE
+	return ..()
 
 /obj/item/engine/electric/prefill()
 	cell = new /obj/item/cell/high(src.loc)

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -70,40 +70,59 @@
 
 /obj/vehicle/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/hand_labeler))
-		return
+		return FALSE // allow afterattack to run
 	if(IS_SCREWDRIVER(W))
 		if(!locked)
 			open = !open
 			update_icon()
 			to_chat(user, "<span class='notice'>Maintenance panel is now [open ? "opened" : "closed"].</span>")
+			return TRUE
+		to_chat(user, SPAN_WARNING("You can't [open ? "close" : "open"] the maintenance panel while \the [src] is locked!"))
+		return TRUE
 	else if(IS_CROWBAR(W) && cell && open)
 		remove_cell(user)
-
+		return TRUE
 	else if(istype(W, /obj/item/cell) && !cell && open)
 		insert_cell(W, user)
+		return TRUE
 	else if(IS_WELDER(W))
-		var/obj/item/weldingtool/T = W
-		if(T.welding)
-			var/current_max_health = get_max_health()
-			if(current_health < current_max_health)
-				if(open)
-					current_health = min(current_max_health, current_health+10)
-					user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-					user.visible_message("<span class='warning'>\The [user] repairs \the [src]!</span>","<span class='notice'>You repair \the [src]!</span>")
-				else
-					to_chat(user, "<span class='notice'>Unable to repair with the maintenance panel closed.</span>")
-			else
-				to_chat(user, "<span class='notice'>[src] does not need a repair.</span>")
+		var/current_max_health = get_max_health()
+		if(current_health >= current_max_health)
+			to_chat(user, "<span class='notice'>[src] does not need repairs.</span>")
+			return TRUE
+		if(!open)
+			to_chat(user, "<span class='notice'>Unable to repair with the maintenance panel closed.</span>")
+			return TRUE
+		var/obj/item/weldingtool/welder = W
+		if(!welder.welding)
+			to_chat(user, "<span class='notice'>Unable to repair while [W] is off.</span>")
+			return TRUE
+		if(welder.weld(5, user))
+			current_health = min(current_max_health, current_health+10)
+			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+			user.visible_message("<span class='warning'>\The [user] repairs \the [src] with \the [welder]!</span>","<span class='notice'>You repair \the [src] with \the [welder]!</span>")
+			return TRUE
+		return TRUE // welder.weld already includes on-fail feedback
+	return ..() // handles bash()
+
+/obj/vehicle/bash(obj/item/weapon, mob/user)
+	if(isliving(user) && user.a_intent == I_HELP)
+		return FALSE
+	if(!weapon.user_can_attack_with(user))
+		return FALSE
+	if(weapon.item_flags & ITEM_FLAG_NO_BLUDGEON)
+		return FALSE
+	// physical damage types that can impart force; swinging a bat or energy sword
+	switch(weapon.atom_damage_type)
+		if(BURN)
+			current_health -= weapon.get_attack_force(user) * fire_dam_coeff
+			. = TRUE
+		if(BRUTE)
+			current_health -= weapon.get_attack_force(user) * brute_dam_coeff
+			. = TRUE
 		else
-			to_chat(user, "<span class='notice'>Unable to repair while [src] is off.</span>")
-	else
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		switch(W.atom_damage_type)
-			if(BURN)
-				current_health -= W.get_attack_force(user) * fire_dam_coeff
-			if(BRUTE)
-				current_health -= W.get_attack_force(user) * brute_dam_coeff
-		..()
+			. = FALSE
+	if(.)
 		healthcheck()
 
 /obj/vehicle/bullet_act(var/obj/item/projectile/Proj)

--- a/code/modules/xenoarcheaology/artifacts/standalone/replicator.dm
+++ b/code/modules/xenoarcheaology/artifacts/standalone/replicator.dm
@@ -127,9 +127,10 @@
 
 /obj/machinery/replicator/attackby(obj/item/W, mob/user)
 	if(!user.try_unequip(W, src))
-		return
+		return FALSE
 	stored_materials.Add(W)
-	src.visible_message("<span class='notice'>\The [user] inserts \the [W] into \the [src].</span>")
+	user.visible_message(SPAN_NOTICE("\The [user] inserts \the [W] into \the [src]."), SPAN_NOTICE("You insert \the [W] into \the [src]."))
+	return TRUE
 
 /obj/machinery/replicator/OnTopic(user, href_list)
 	if(href_list["activate"])

--- a/code/modules/xenoarcheaology/finds/find_types/fossils.dm
+++ b/code/modules/xenoarcheaology/finds/find_types/fossils.dm
@@ -53,15 +53,14 @@
 	icon_state = "hskull"
 
 /obj/item/fossil/skull/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/fossil/animal))
-		if(!user.canUnEquip(W))
-			return
-		var/mob/M = get_recursive_loc_of_type(/mob)
-		if(M && !M.try_unequip(src))
-			return
-		var/obj/o = new /obj/structure/skeleton(get_turf(src))
-		user.try_unequip(W, o)
-		forceMove(o)
+	if(!istype(W, /obj/item/fossil/animal))
+		return ..()
+	if(!user.try_unequip(src))
+		return FALSE
+	var/obj/structure/skeleton/skellybones = new (get_turf(src))
+	user.try_unequip(W, skellybones)
+	forceMove(skellybones)
+	return TRUE
 
 /obj/structure/skeleton
 	name = "alien skeleton display"
@@ -85,16 +84,18 @@
 
 /obj/structure/skeleton/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/fossil/animal))
-		if(bone_count < required_bones)
-			if(user.try_unequip(W, src))
-				bone_count++
-				if(bone_count == required_bones)
-					icon_state = "skel"
-					set_density(1)
-		else
+		if(bone_count >= required_bones)
 			to_chat(user, SPAN_NOTICE("\The [src] is already complete."))
+			return TRUE
+		if(!user.try_unequip(W, src))
+			return TRUE
+		bone_count++
+		if(bone_count == required_bones)
+			icon_state = "skel"
+			set_density(1)
+		return TRUE
 	else if(IS_PEN(W))
 		plaque_contents = sanitize(input("What would you like to write on the plaque:","Skeleton plaque",""))
 		user.visible_message("[user] writes something on the base of [src].","You relabel the plaque on the base of [src].")
-	else
-		..()
+		return TRUE
+	return ..()

--- a/code/modules/xenoarcheaology/finds/strange_rock.dm
+++ b/code/modules/xenoarcheaology/finds/strange_rock.dm
@@ -55,3 +55,5 @@
 	if(prob(33))
 		visible_message(SPAN_WARNING("[src] crumbles away, leaving some dust and gravel behind."))
 		physically_destroyed()
+		return TRUE
+	return FALSE

--- a/code/modules/xenoarcheaology/machinery/artifact_harvester.dm
+++ b/code/modules/xenoarcheaology/machinery/artifact_harvester.dm
@@ -57,17 +57,17 @@
 	cur_artifact = new_artifact
 
 /obj/machinery/artifact_harvester/attackby(var/obj/I, var/mob/user)
-	if(istype(I,/obj/item/anobattery))
-		if(!inserted_battery)
-			if(!user.try_unequip(I, src))
-				return
-			to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
-			inserted_battery = I
-			updateDialog()
-		else
-			to_chat(user, "<span class='warning'>There is already a battery in [src].</span>")
-	else
-		return..()
+	if(!istype(I, /obj/item/anobattery))
+		return ..()
+	if(inserted_battery)
+		to_chat(user, SPAN_WARNING("There is already a battery in [src]."))
+		return TRUE
+	if(!user.try_unequip(I, src))
+		return TRUE
+	to_chat(user, SPAN_NOTICE("You insert [I] into [src]."))
+	inserted_battery = I
+	updateDialog()
+	return TRUE
 
 /obj/machinery/artifact_harvester/interface_interact(user)
 	ui_interact(user)

--- a/code/modules/xenoarcheaology/machinery/geosample_scanner.dm
+++ b/code/modules/xenoarcheaology/machinery/geosample_scanner.dm
@@ -64,7 +64,7 @@
 	if(istype(I, /obj/item/stack/nanopaste))
 		if(scanning)
 			to_chat(user, SPAN_WARNING("You can't do that while [src] is scanning!"))
-			return
+			return TRUE
 		var/choice = alert("What do you want to do with the nanopaste?","Radiometric Scanner","Scan nanopaste","Fix seal integrity")
 		if(CanPhysicallyInteract(user) && !QDELETED(I) && I.loc == user && choice == "Fix seal integrity")
 			var/obj/item/stack/nanopaste/N = I
@@ -75,7 +75,7 @@
 	if(istype(I, /obj/item/chems/glass))
 		if(scanning)
 			to_chat(user, SPAN_WARNING("You can't do that while [src] is scanning!"))
-			return
+			return TRUE
 		var/choice = alert("What do you want to do with the container?","Radiometric Scanner","Add coolant","Empty coolant","Scan container")
 		if(CanPhysicallyInteract(user) && !QDELETED(I) && I.loc == user)
 			//#TODO: The add coolant stuff could probably be handled by the default reagent handling code. And the emptying could be done with an alt interaction.
@@ -102,12 +102,13 @@
 	if(istype(I))
 		if(scanned_item)
 			to_chat(user, SPAN_WARNING("\The [src] already has \a [scanned_item] inside!"))
-			return
+			return TRUE
 		if(!user.try_unequip(I, src))
-			return
+			return TRUE
 		scanned_item = I
 		to_chat(user, SPAN_NOTICE("You put \the [I] into \the [src]."))
 		return TRUE
+	return FALSE
 
 /obj/machinery/radiocarbon_spectrometer/proc/update_coolant()
 	var/total_purity = 0

--- a/code/modules/xenoarcheaology/tools/ano_device_battery.dm
+++ b/code/modules/xenoarcheaology/tools/ano_device_battery.dm
@@ -60,15 +60,16 @@
 	. = ..()
 
 /obj/item/anodevice/attackby(var/obj/I, var/mob/user)
-	if(istype(I, /obj/item/anobattery))
-		if(!inserted_battery)
-			if(!user.try_unequip(I, src))
-				return
-			to_chat(user, "<span class='notice'>You insert \the [I] into \the [src].</span>")
-			inserted_battery = I
-			update_icon()
-	else
+	if(!istype(I, /obj/item/anobattery))
 		return ..()
+	if(inserted_battery)
+		return TRUE
+	if(!user.try_unequip(I, src))
+		return TRUE
+	to_chat(user, SPAN_NOTICE("You insert \the [I] into \the [src]."))
+	inserted_battery = I
+	update_icon()
+	return TRUE
 
 /obj/item/anodevice/attack_self(var/mob/user)
 	ui_interact(user)

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -505,6 +505,7 @@
 	return 1
 
 /datum/gas_mixture/proc/get_mass()
+	. = 0
 	for(var/g in gas)
 		var/decl/material/mat = GET_DECL(g)
 		. += gas[g] * mat.molar_mass * group_multiplier
@@ -513,6 +514,7 @@
 	var/M = get_total_moles()
 	if(M)
 		return get_mass()/M
+	return 0
 
 ///Returns a color blended from all materials the gas mixture contains
 /datum/gas_mixture/proc/get_overall_color()

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -116,12 +116,12 @@
 		var/force = W.get_attack_force(user)
 		if (!(W.sharp) || (W.sharp && force < 10))//is not sharp enough or at all
 			to_chat(user,"<span class='warning'>You can't cut through \the [src] with \the [W], it's too dull.</span>")
-			return
+			return TRUE
 		visible_message("<span class='warning'>[user] starts to cut through \the [src] with \the [W]!</span>")
 		while(current_health > 0 && !QDELETED(src) && !QDELETED(user))
 			if (!do_after(user, 20, src))
 				visible_message("<span class='warning'>[user] stops cutting through \the [src] with \the [W]!</span>")
-				return
+				return TRUE
 			take_damage(20 * (1 + (force-10)/10), W.atom_damage_type) //the sharper the faster, every point of force above 10 adds 10 % to damage
 		new /obj/item/stack/net(src.loc)
 		qdel(src)

--- a/mods/gamemodes/cult/mobs/constructs/soulstone.dm
+++ b/mods/gamemodes/cult/mobs/constructs/soulstone.dm
@@ -47,12 +47,11 @@
 		to_chat(user, "This one is cracked and useless.")
 
 /obj/item/soulstone/attackby(var/obj/item/I, var/mob/user)
-	..()
 	if(is_evil && istype(I, /obj/item/nullrod))
 		to_chat(user, SPAN_NOTICE("You cleanse \the [src] of taint, purging its shackles to its creator."))
-		is_evil = 0
-		return
-	if(I.get_attack_force(user) >= 5)
+		is_evil = FALSE
+		return TRUE
+	else if(I.get_attack_force(user) >= 5)
 		if(full != SOULSTONE_CRACKED)
 			user.visible_message(
 				SPAN_WARNING("\The [user] hits \the [src] with \the [I], and it breaks.[shade.client ? " You hear a terrible scream!" : ""]"),
@@ -63,6 +62,8 @@
 		else
 			user.visible_message(SPAN_DANGER("\The [user] shatters \the [src] with \the [I]!"))
 			shatter()
+		return TRUE
+	return ..()
 
 /obj/item/soulstone/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	if(target == shade)
@@ -117,31 +118,33 @@
 	desc = "This eerie contraption looks like it would come alive if supplied with a missing ingredient."
 
 /obj/structure/constructshell/attackby(var/obj/item/I, var/mob/user)
-	if(istype(I, /obj/item/soulstone))
-		var/obj/item/soulstone/S = I
-		if(!S.shade.client)
-			to_chat(user, SPAN_NOTICE("\The [I] has essence, but no soul. Activate it in your hand to find a soul for it first."))
-			return
-		if(S.shade.loc != S)
-			to_chat(user, SPAN_NOTICE("Recapture the shade back into \the [I] first."))
-			return
-		var/construct = alert(user, "Please choose which type of construct you wish to create.",,"Artificer", "Wraith", "Juggernaut")
-		var/ctype
-		switch(construct)
-			if("Artificer")
-				ctype = /mob/living/simple_animal/construct/builder
-			if("Wraith")
-				ctype = /mob/living/simple_animal/construct/wraith
-			if("Juggernaut")
-				ctype = /mob/living/simple_animal/construct/armoured
-		var/mob/living/simple_animal/construct/C = new ctype(get_turf(src))
-		C.key = S.shade.key
-		//C.cancel_camera()
-		if(S.is_evil)
-			var/decl/special_role/cult = GET_DECL(/decl/special_role/cultist)
-			cult.add_antagonist(C.mind)
-		qdel(S)
-		qdel(src)
+	if(!istype(I, /obj/item/soulstone))
+		return ..()
+	var/obj/item/soulstone/S = I
+	if(!S.shade.client)
+		to_chat(user, SPAN_NOTICE("\The [I] has essence, but no soul. Activate it in your hand to find a soul for it first."))
+		return TRUE
+	if(S.shade.loc != S)
+		to_chat(user, SPAN_NOTICE("Recapture the shade back into \the [I] first."))
+		return TRUE
+	var/construct = alert(user, "Please choose which type of construct you wish to create.",,"Artificer", "Wraith", "Juggernaut")
+	var/ctype
+	switch(construct)
+		if("Artificer")
+			ctype = /mob/living/simple_animal/construct/builder
+		if("Wraith")
+			ctype = /mob/living/simple_animal/construct/wraith
+		if("Juggernaut")
+			ctype = /mob/living/simple_animal/construct/armoured
+	var/mob/living/simple_animal/construct/C = new ctype(get_turf(src))
+	C.key = S.shade.key
+	//C.cancel_camera()
+	if(S.is_evil)
+		var/decl/special_role/cult = GET_DECL(/decl/special_role/cultist)
+		cult.add_antagonist(C.mind)
+	qdel(S)
+	qdel(src)
+	return TRUE
 
 /obj/structure/constructshell/get_artifact_scan_data()
 	return "Tribal idol - subject resembles statues/emblems built by superstitious pre-warp civilisations to honour their gods. Material appears to be a rock/plastcrete composite."

--- a/mods/gamemodes/cult/runes.dm
+++ b/mods/gamemodes/cult/runes.dm
@@ -48,11 +48,12 @@
 	if(istype(I, /obj/item/book/tome) && iscultist(user))
 		user.visible_message(SPAN_NOTICE("[user] rubs \the [src] with \the [I], and \the [src] is absorbed by it."), "You retrace your steps, carefully undoing the lines of \the [src].")
 		qdel(src)
-		return
+		return TRUE
 	else if(istype(I, /obj/item/nullrod))
 		user.visible_message(SPAN_NOTICE("[user] hits \the [src] with \the [I], and it disappears, fizzling."), SPAN_NOTICE("You disrupt the vile magic with the deadening field of \the [I]."), "You hear a fizzle.")
 		qdel(src)
-		return
+		return TRUE
+	return ..()
 
 /obj/effect/rune/attack_hand(var/mob/user)
 	SHOULD_CALL_PARENT(FALSE)
@@ -320,13 +321,14 @@
 	if(istype(I, /obj/item/nullrod))
 		user.visible_message(SPAN_NOTICE("\The [user] touches \the [src] with \the [I], and it disappears."), SPAN_NOTICE("You disrupt the vile magic with the deadening field of \the [I]."))
 		qdel(src)
-	else
-		var/force = I.get_attack_force(user)
-		if(force)
-			user.visible_message(SPAN_NOTICE("\The [user] hits \the [src] with \the [I]."), SPAN_NOTICE("You hit \the [src] with \the [I]."))
-			take_damage(force, I.atom_damage_type)
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-			user.do_attack_animation(src)
+		return TRUE
+	var/force = I.get_attack_force(user)
+	if(force)
+		user.visible_message(SPAN_NOTICE("\The [user] hits \the [src] with \the [I]."), SPAN_NOTICE("You hit \the [src] with \the [I]."))
+		take_damage(force, I.atom_damage_type)
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.do_attack_animation(src)
+	return TRUE
 
 /obj/effect/cultwall/bullet_act(var/obj/item/projectile/Proj)
 	if(!(Proj.atom_damage_type == BRUTE || Proj.atom_damage_type == BURN))
@@ -811,11 +813,11 @@
 	speak_incantation(user, "Uhrast ka'hfa heldsagen ver[pick("'","`")]lot!")
 	to_chat(user, SPAN_WARNING("In the last moment of your humble life, you feel an immense pain as fabric of reality mends... with your blood."))
 	for(var/mob/M in global.living_mob_list_)
+		var/decl/pronouns/pronouns = user.get_pronouns()
 		if(iscultist(M))
-			var/decl/pronouns/pronouns = user.get_pronouns()
-			to_chat(M, "You see a vision of \the [user] keeling over dead, his blood glowing blue as it escapes [pronouns.his] body and dissipates into thin air; you hear an otherwordly scream and feel that a great disaster has just been averted.")
+			to_chat(M, "You see a vision of \the [user] keeling over dead, [pronouns.his] blood glowing blue as it escapes [pronouns.his] body and dissipates into thin air; you hear an otherwordly scream and feel that a great disaster has just been averted.")
 		else
-			to_chat(M, "You see a vision of [name] keeling over dead, his blood glowing blue as it escapes his body and dissipates into thin air; you hear an otherwordly scream and feel very weak for a moment.")
+			to_chat(M, "You see a vision of [name] keeling over dead, [pronouns.his] blood glowing blue as it escapes [pronouns.his] body and dissipates into thin air; you hear an otherwordly scream and feel very weak for a moment.")
 	log_and_message_admins("mended reality with the greatest sacrifice", user)
 	user.dust()
 	var/decl/special_role/cultist/cult = GET_DECL(/decl/special_role/cultist)
@@ -826,8 +828,8 @@
 
 /obj/effect/rune/tearreality/attackby()
 	if(the_end_comes)
-		return
-	..()
+		return TRUE
+	return ..()
 
 /* Imbue runes */
 

--- a/mods/gamemodes/cult/structures.dm
+++ b/mods/gamemodes/cult/structures.dm
@@ -25,9 +25,11 @@
 
 /obj/structure/cult/pylon/attack_generic(var/mob/user, var/damage)
 	attackpylon(user, damage)
+	return TRUE
 
 /obj/structure/cult/pylon/attackby(obj/item/W, mob/user)
 	attackpylon(user, W.get_attack_force(user))
+	return TRUE
 
 /obj/structure/cult/pylon/proc/attackpylon(mob/user, var/damage)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)

--- a/mods/species/ascent/effects/razorweb.dm
+++ b/mods/species/ascent/effects/razorweb.dm
@@ -91,6 +91,8 @@
 
 	if(destroy_self)
 		qdel(src)
+		return TRUE
+	return FALSE
 
 /obj/effect/razorweb/on_update_icon()
 	overlays.Cut()

--- a/mods/species/vox/datum/heist_compatibility.dm
+++ b/mods/species/vox/datum/heist_compatibility.dm
@@ -21,7 +21,7 @@
 
 	var/choice = input("Do you wish to become a vox of the Shoal? This is not reversible.") as null|anything in list("No","Yes")
 	if(choice != "Yes")
-		return ..()
+		return TRUE
 
 	var/decl/outfit/outfit = GET_DECL(/decl/outfit/vox_raider)
 	var/mob/living/human/vox/vox = new(get_turf(src), SPECIES_VOX)
@@ -30,6 +30,7 @@
 		user.mind.transfer_to(vox)
 	qdel(user)
 	addtimer(CALLBACK(src, PROC_REF(do_post_voxifying), vox), 1)
+	return TRUE
 
 /obj/structure/mirror/raider/proc/do_post_voxifying(var/mob/living/human/vox)
 	var/newname = sanitize_safe(input(vox,"Enter a name, or leave blank for the default name.", "Name change","") as text, MAX_NAME_LEN)


### PR DESCRIPTION
## Description of changes
Fixes all the incorrect return values for attackby/attack_hand, Initialize(), and Destroy() procs.

I am so sorry, pre-emptively, to whoever reviews this

## Why and what will this PR improve
Everything should return `TRUE` or `FALSE` now, barring a few edge-cases where things return the value of a proc and I didn't want to go and audit all of THOSE too.

## Authorship
Me me me, including the OpenDream stuff needed to find these