### PR TITLE
Refactor injury self-examination, readd wound pressure via agrab

### DIFF
--- a/code/_onclick/hud/screen/screen_warnings.dm
+++ b/code/_onclick/hud/screen/screen_warnings.dm
@@ -8,6 +8,12 @@
 	icon_state = "health0"
 	screen_loc = ui_health
 
+/obj/screen/health_warning/handle_click(mob/user, params)
+	if(ishuman(user))
+		var/mob/living/human/human_user = user
+		human_user.check_self_injuries()
+	return TRUE
+
 /obj/screen/warning_cells
 	name = "cell"
 	icon_state = "charge-empty"

--- a/code/modules/mob/grab/normal/norm_aggressive.dm
+++ b/code/modules/mob/grab/normal/norm_aggressive.dm
@@ -14,6 +14,13 @@
 	breakability       = 3
 	grab_icon_state    = "reinforce1"
 	break_chance_table = list(5, 20, 40, 80, 100)
+	help_action        = "wound pressure" // A bit clunky, but this is only used for admin logs presently!
+
+/decl/grab/normal/aggressive/on_hit_help(obj/item/grab/grab, atom/target, proximity)
+	var/mob/living/human/grab_victim = grab.get_affecting_mob()
+	if(!istype(grab_victim) || !proximity || (target && target != grab_victim))
+		return FALSE
+	return grab_victim.apply_pressure(grab.assailant, grab.target_zone)
 
 /decl/grab/normal/aggressive/process_effect(var/obj/item/grab/grab)
 	var/mob/living/affecting_mob = grab.get_affecting_mob()


### PR DESCRIPTION
## Description of changes
Fixes applying wound pressure to yourself.
Fixes applying wound pressure to others (using the prior functionality of help intent with an aggressive grab).
Clicking your health doll now gives you the same status info as clicking your mob on help intent, which is good for cases like drakes where the default help-intent self-interaction is disabled.

## Why and what will this PR improve
The injury self-examination rewrite is used in my Caves of Qud inspired mutations modpack I'm working on.

## Authorship
Me.

## Changelog
:cl:
add: You can apply pressure to another's wounds by aggressively grabbing them and then clicking them with the grab on help intent, with the affected zone targeted.
add: Clicking the health doll now checks yourself for injuries, the same as clicking yourself on help intent if no other action is available.
bugfix: You can once again apply pressure to your own wounds, by clicking yourself on help intent with the affected zone targeted.
/:cl: