### PR TITLE
Fix drake salve aura never expiring

### DIFF
--- a/code/modules/paperwork/papershredder.dm
+++ b/code/modules/paperwork/papershredder.dm
@@ -245,7 +245,7 @@
 	user.visible_message( \
 		SPAN_DANGER("\The [user] burns right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap."), \
 		SPAN_DANGER("You burn right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap."))
-	fire_act()
+	fire_act(return_air(), P.get_heat(), 500)
 
 /obj/item/shreddedp/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	SHOULD_CALL_PARENT(FALSE)

--- a/mods/species/drakes/drake_abilities_friendly.dm
+++ b/mods/species/drakes/drake_abilities_friendly.dm
@@ -86,7 +86,7 @@ var/global/list/_wounds_being_tended_by_drakes = list()
 	// Sivian animals get a heal buff from the modifier, others just
 	// get it to stop friendly drakes constantly licking their wounds.
 	// Organ wounds are closed, but the owners get sifsap injected via open wounds.
-	friend.add_aura(new /obj/aura/sifsap_salve(null, 60 SECONDS))
+	friend.add_aura(new /obj/aura/sifsap_salve(friend, 60 SECONDS))
 	var/list/friend_organs = friend.get_external_organs()
 	if(length(friend_organs))
 		for (var/obj/item/organ/external/E in friend_organs)


### PR DESCRIPTION
- Fixes the drake salve aura never expiring (did not have an owner set).
- Fixes shredded paper fire_act not passing air, heat, or volume.