### PR TITLE
Cask rack fixes and tweaks

### DIFF
--- a/code/game/objects/structures/barrels/cask_rack.dm
+++ b/code/game/objects/structures/barrels/cask_rack.dm
@@ -150,7 +150,7 @@
 	color = /decl/material/solid/organic/wood/ebony::color
 
 /obj/structure/cask_rack/large/mapped/Initialize(ml, _mat, _reinf_mat)
-	new /obj/structure/reagent_dispensers/barrel/cask/ebony/water(src)
-	new /obj/structure/reagent_dispensers/barrel/cask/ebony/beer(src)
-	new /obj/structure/reagent_dispensers/barrel/cask/ebony/wine(src)
 	. = ..()
+	try_stack_barrel(new /obj/structure/reagent_dispensers/barrel/cask/ebony/water)
+	try_stack_barrel(new /obj/structure/reagent_dispensers/barrel/cask/ebony/beer)
+	try_stack_barrel(new /obj/structure/reagent_dispensers/barrel/cask/ebony/wine)


### PR DESCRIPTION
- Premapped cask racks no longer have invisible barrels.
- Players have a delay when moving casks on or off of the rack, modified by hauling skill.
I might also make it so that it has a stamina cost but I'm not sure.