### PR TITLE
Fix AI unarmed attacks

### DIFF
--- a/code/game/objects/effects/dirty_floor.dm
+++ b/code/game/objects/effects/dirty_floor.dm
@@ -11,7 +11,6 @@
 
 /obj/effect/decal/cleanable/dirt/Initialize()
 	. = ..()
-	name = ""
 	verbs.Cut()
 
 /obj/effect/decal/cleanable/dirt/on_update_icon()

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -87,6 +87,9 @@
 /mob/living/bot/ssd_check()
 	return FALSE
 
+/mob/living/bot/try_awaken(mob/user)
+	return FALSE
+
 /mob/living/bot/attackby(var/obj/item/O, var/mob/user)
 	if(O.GetIdCard())
 		if(access_scanner.allowed(user) && !open)

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -84,6 +84,9 @@
 	if(. && !gibbed)
 		gib()
 
+/mob/living/bot/ssd_check()
+	return FALSE
+
 /mob/living/bot/attackby(var/obj/item/O, var/mob/user)
 	if(O.GetIdCard())
 		if(access_scanner.allowed(user) && !open)

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -51,7 +51,7 @@
 
 /mob/living/bot/cleanbot/handleAdjacentTarget()
 	if(get_turf(target) == src.loc)
-		UnarmedAttack(target)
+		UnarmedAttack(target, TRUE)
 
 /mob/living/bot/cleanbot/UnarmedAttack(var/obj/effect/decal/cleanable/D, var/proximity)
 

--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -106,7 +106,7 @@
 		flick("farmbot_broke", src)
 
 /mob/living/bot/farmbot/handleAdjacentTarget()
-	UnarmedAttack(target)
+	UnarmedAttack(target, TRUE)
 
 /mob/living/bot/farmbot/lookForTargets()
 	if(emagged)

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -95,7 +95,7 @@
 
 /mob/living/bot/floorbot/handleAdjacentTarget()
 	if(get_turf(target) == src.loc)
-		UnarmedAttack(target)
+		UnarmedAttack(target, TRUE)
 
 /mob/living/bot/floorbot/lookForTargets()
 	for(var/turf/floor/T in view(src))

--- a/code/modules/mob/living/bot/medibot.dm
+++ b/code/modules/mob/living/bot/medibot.dm
@@ -73,7 +73,7 @@
 /mob/living/bot/medbot/handleAdjacentTarget()
 	if(is_tipped) // Don't handle targets if we're incapacitated!
 		return
-	UnarmedAttack(target)
+	UnarmedAttack(target, TRUE)
 
 /mob/living/bot/medbot/lookForTargets()
 	if(is_tipped) // Don't look for targets if we're incapacitated!

--- a/code/modules/mob/living/bot/mulebot.dm
+++ b/code/modules/mob/living/bot/mulebot.dm
@@ -172,7 +172,7 @@
 	if(target == src.loc)
 		custom_emote(2, "makes a chiming sound.")
 		playsound(loc, 'sound/machines/chime.ogg', 50, 0)
-		UnarmedAttack(target)
+		UnarmedAttack(target, TRUE)
 		resetTarget()
 		if(auto_return && home && (loc != home))
 			target = home

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -182,7 +182,7 @@
 			begin_arrest(target, threat)
 		++awaiting_surrender
 	else
-		UnarmedAttack(target)
+		UnarmedAttack(target, TRUE)
 
 /mob/living/bot/secbot/proc/cuff_target(var/mob/living/target)
 	if(istype(target) && !target.get_equipped_item(slot_handcuffed_str))

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -96,7 +96,7 @@
 	else
 		body.set_dir(SOUTH)
 	if(isturf(movement_target.loc) && body.Adjacent(movement_target))
-		body.UnarmedAttack(movement_target)
+		body.UnarmedAttack(movement_target, TRUE)
 	else if(ishuman(movement_target.loc) && prob(20))
 		body.custom_emote(VISIBLE_MESSAGE, "stares at the [movement_target] that [movement_target.loc] has with sad puppy eyes.")
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
@@ -258,7 +258,7 @@
 				return
 
 			//Time for the hurt to begin!
-			parrot.UnarmedAttack(L)
+			parrot.UnarmedAttack(L, parrot.Adjacent(L))
 			return
 
 		//Otherwise, fly towards the mob!

--- a/mods/content/xenobiology/slime/_slime.dm
+++ b/mods/content/xenobiology/slime/_slime.dm
@@ -127,7 +127,7 @@
 			if(istype(AM, /obj/structure/window) || istype(AM, /obj/structure/grille))
 				if(nutrition <= get_hunger_nutrition())
 					if (is_adult || prob(5))
-						UnarmedAttack(AM)
+						UnarmedAttack(AM, Adjacent(AM))
 
 	if(ismob(AM))
 		var/mob/tmob = AM

--- a/mods/content/xenobiology/slime/slime_AI.dm
+++ b/mods/content/xenobiology/slime/slime_AI.dm
@@ -147,7 +147,7 @@
 				for(var/mob/living/slime/frenemy in range(1, body))
 					if(frenemy != body && body.Adjacent(frenemy))
 						body.a_intent_change((frenemy.slime_type == slime.slime_type) ? I_HELP : I_HURT)
-						body.UnarmedAttack(frenemy)
+						body.UnarmedAttack(frenemy, TRUE)
 						added_delay = 10
 		else if(slime.Adjacent(current_target))
 			var/do_attack = FALSE
@@ -161,7 +161,7 @@
 				body.a_intent_change(I_GRAB)
 				do_attack = TRUE
 			if(do_attack)
-				body.UnarmedAttack(current_target)
+				body.UnarmedAttack(current_target, TRUE)
 				added_delay = 10
 			else
 				current_target = null


### PR DESCRIPTION
fixes AI unarmed attacks by passing the proximity flag.
fixes dirt being nameless when bots clean it
fix bots being treated as ssd when you click them, which stops you from opening their interact menu.
\- ophelia