### PR TITLE
Make sharp weapons apply coating as reagents on hit

### DIFF
--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -967,10 +967,11 @@ modules/mob/living/human/life.dm if you die, you will be zoomed out.
 /obj/item/proc/on_active_hand()
 	return
 
-/obj/item/proc/has_embedded(mob/living/victim)
+/obj/item/proc/has_embedded(mob/living/victim, def_zone)
 	if(istype(victim))
 		LAZYDISTINCTADD(victim.embedded, src)
 		victim.verbs |= /mob/proc/yank_out_object
+		apply_coating_on_hit(null, victim, def_zone, embedded = TRUE)
 		return TRUE
 	return FALSE
 
@@ -1044,9 +1045,40 @@ modules/mob/living/human/life.dm if you die, you will be zoomed out.
 /obj/item/proc/attack_message_name()
 	return "\a [src]"
 
+/// Returns the fraction of coating applied on a successful hit.
+/obj/item/proc/get_coating_apply_fraction()
+	return is_sharp(src) ? 0.7 ** (w_class - 1) : 0
+
+/// Returns the fraction of applied coating that enters the bloodstream on a successful hit.
+/// This is applied to the result of get_coating_apply_fraction().
+/obj/item/proc/get_coating_inject_fraction()
+	// I put no thought into this implementation.
+	return is_sharp(src) ? 0.8 : 0.2
+
+/obj/item/proc/get_coating_volume()
+	return round(10 * sqrt(w_class))
+
+/// Returns the number of units applied.
+/// User is allowed to be null, target must not be.
+/obj/item/proc/apply_coating_on_hit(mob/user, mob/target, def_zone, embedded = FALSE)
+	if(coating?.total_liquid_volume <= 0)
+		return 0
+	var/transferred_coating_amount = min(get_coating_apply_fraction(), coating.total_liquid_volume)
+	if(embedded)
+		transferred_coating_amount = coating.total_liquid_volume
+	else // user is allowed to be null
+		transferred_coating_amount *= (1 - target.get_blocked_ratio(def_zone, BRUTE, damage_flags(), armor_penetration, get_attack_force(user)))
+	if(transferred_coating_amount <= 0)
+		return 0
+	// first apply the injected reagents
+	. = coating.trans_to_mob(target, transferred_coating_amount * get_coating_inject_fraction(), CHEM_INJECT, transferred_phases = MAT_PHASE_LIQUID)
+	transferred_coating_amount -= .
+	if(transferred_coating_amount > 0)
+		. += coating.trans_to_mob(target, transferred_coating_amount, CHEM_TOUCH, transferred_phases = MAT_PHASE_LIQUID)
+
 /obj/item/proc/add_coating(reagent_type, amount, data)
 	if(!coating)
-		coating = new /datum/reagents(10, src)
+		coating = new /datum/reagents(get_coating_volume(), src)
 	if(ispath(reagent_type))
 		coating.add_reagent(reagent_type, amount, data)
 	else if(istype(reagent_type, /datum/reagents))

--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -54,6 +54,7 @@
 	for(var/T in forensics.evidence)
 		var/datum/forensics/F = forensics.evidence[T]
 		other_forensics.add_data(T, F.data)
+		forensics.remove_data(T)
 
 /obj/item/proc/add_trace_DNA(mob/living/M)
 	if(istype(M) && M.has_genetic_information())

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -252,8 +252,8 @@
 		//Sharp objects will always embed if they do enough damage.
 		//Thrown sharp objects have some momentum already and have a small chance to embed even if the damage is below the threshold
 		if((sharp && prob(sharp_embed_chance)) || (embed_damage > embed_threshold && prob(embed_chance)))
-			affecting.embed_in_organ(I, supplied_wound = (istype(supplied_wound) ? supplied_wound : null))
-			I.has_embedded(src)
+			affecting.embed_in_organ(I, supplied_wound = supplied_wound)
+			I.has_embedded(src, def_zone)
 			. = TRUE
 
 	// Simple embed for mobs with no limbs.
@@ -261,8 +261,15 @@
 		O.forceMove(src)
 		if(isitem(O))
 			var/obj/item/I = O
-			I.has_embedded(src)
+			I.has_embedded(src, def_zone)
 		. = TRUE
+
+	// we want coated items to inject their coating if sharp and not embedded
+	// if it's embedded it's transferred separately in has_embedded
+	// todo: maybe check if the created wound is bleeding instead of checking if it's sharp
+	if(isitem(O) && !. && O.is_sharp())
+		var/obj/item/poisoned_weapon = O
+		poisoned_weapon.apply_coating_on_hit(user, src, def_zone)
 
 	// Allow a tick for throwing/striking to resolve.
 	if(. && direction)

--- a/code/modules/projectiles/guns/launcher/bows/bow_firing.dm
+++ b/code/modules/projectiles/guns/launcher/bows/bow_firing.dm
@@ -8,7 +8,8 @@
 		return FALSE
 	if(istype(ammo, /obj/item/stack))
 		var/obj/item/stack/stack = ammo
-		ammo = stack.split(1)
+		if(stack.get_amount() > 1)
+			ammo = stack.split(1)
 		if(QDELETED(ammo))
 			return FALSE
 		ammo.forceMove(src)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -651,8 +651,12 @@ var/global/datum/reagents/sink/infinite_reagent_sink = new
 		return trans_to_turf(target, amount, multiplier, copy, defer_update = defer_update, transferred_phases = transferred_phases)
 	if(isobj(target))
 		touch_obj(target)
-		if(!QDELETED(target) && target.can_be_poured_into(my_atom))
-			return trans_to_obj(target, amount, multiplier, copy, defer_update = defer_update, transferred_phases = transferred_phases)
+		if(!QDELETED(target))
+			if(target.can_be_poured_into(my_atom))
+				return trans_to_obj(target, amount, multiplier, copy, defer_update = defer_update, transferred_phases = transferred_phases)
+			else if(isitem(target)) // even if you can't pour into it, you can still coat it
+				var/obj/item/target_item = target
+				return target_item.add_coating(src, amount)
 		return 0
 	return 0
 


### PR DESCRIPTION
sharp weapons now apply a fraction of their coating on-hit, split between injected and contact reagents.
weapons also now apply their entire coating as reagents on embed, still split between the two.
i am not married to any of this implementation i just wanted it done as a proof of concept, literally anything about it can change and i'd still be happy

the purpose of this is so that you can dip arrows in poison and have it poison people, or dip a knife in poison and have it poison them when you embed it in their spine. hooray! this should also work on simplemobs theoretically but i forget if they even metabolize reagents.

- [ ] Made sure the coating doesn't just immediately drip off
- [ ] Tested attacking carbons
- [ ] Tested attacking simplemobs
- [ ] Tested embedding in carbons
- [ ] Tested embedding in simplemobs

## Changelog
:cl: ophelia
add: sharp items now apply a fraction of their coating on-hit, split between injected and contact reagents.
add: items apply their entire coating on embed, split between injected and contact reagents.
/:cl: