### PR TITLE
Adding a silhouette that flashes when hit by an attack.

### DIFF
--- a/code/controllers/subsystems/processing/fast_process.dm
+++ b/code/controllers/subsystems/processing/fast_process.dm
@@ -2,4 +2,4 @@
 
 PROCESSING_SUBSYSTEM_DEF(fastprocess)
 	name = "Fast Processing"
-	wait = 2
+	wait = 1

--- a/code/modules/mechs/mech_damage.dm
+++ b/code/modules/mechs/mech_damage.dm
@@ -90,12 +90,16 @@
 /mob/living/exosuit/adjustFireLoss(var/amount, var/obj/item/mech_component/MC = pick(list(arms, legs, body, head)), var/do_update_health = TRUE)
 	if(MC)
 		MC.take_burn_damage(amount)
+		if(amount > 3)
+			flash_silhouette(flash_color = COLOR_ORANGE)
 		if(do_update_health)
 			update_health() // TODO: unify these procs somehow instead of having weird brute-wrapping behavior as the default.
 
 /mob/living/exosuit/adjustBruteLoss(var/amount, var/obj/item/mech_component/MC = pick(list(arms, legs, body, head)), var/do_update_health = TRUE)
 	if(MC)
 		MC.take_brute_damage(amount)
+		if(amount > 3)
+			flash_silhouette(flash_color = COLOR_RED)
 	..()
 
 /mob/living/exosuit/proc/zoneToComponent(var/zone)

--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -96,6 +96,7 @@
 	// Reset plane and layer so that it doesn't inherit the UI settings from equipped items.
 	var/image/I = new(loc = A)
 	I.appearance = weapon
+	I.appearance_flags |= KEEP_APART
 	I.plane = DEFAULT_PLANE
 	I.layer = A.layer + 0.1
 	I.pixel_x = -(A.pixel_x)

--- a/code/modules/mob/living/human/human_damage.dm
+++ b/code/modules/mob/living/human/human_damage.dm
@@ -91,20 +91,24 @@
 	SHOULD_CALL_PARENT(FALSE) // take/heal overall call update_health regardless of arg
 	if(amount > 0)
 		take_overall_damage(amount, 0)
+		if(istype(ai))
+			ai.retaliate()
+		if(amount >= 3)
+			flash_silhouette(flash_color = COLOR_RED)
 	else
 		heal_overall_damage(-amount, 0)
 	BITSET(hud_updateflag, HEALTH_HUD)
-	if(amount > 0 && istype(ai))
-		ai.retaliate()
 
 /mob/living/human/adjustFireLoss(var/amount, var/do_update_health = TRUE)
 	if(amount > 0)
 		take_overall_damage(0, amount)
+		if(istype(ai))
+			ai.retaliate()
+		if(amount >= 3)
+			flash_silhouette(flash_color = COLOR_RED)
 	else
 		heal_overall_damage(0, -amount)
 	BITSET(hud_updateflag, HEALTH_HUD)
-	if(amount > 0 && istype(ai))
-		ai.retaliate()
 
 /mob/living/human/getCloneLoss()
 	var/amount = 0
@@ -273,6 +277,10 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 		return
 	var/obj/item/organ/external/picked = pick(parts)
 	if(picked.take_external_damage(brute, burn, override_droplimb = override_droplimb))
+		if(brute > 3)
+			flash_silhouette(flash_color = COLOR_RED)
+		else if(burn > 3)
+			flash_silhouette(flash_color = COLOR_ORANGE)
 		BITSET(hud_updateflag, HEALTH_HUD)
 	update_health()
 
@@ -317,6 +325,11 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 			apply_damage(damage = brute_avg, damagetype = BRUTE, damage_flags = dam_flags, used_weapon = used_weapon, silent = TRUE, given_organ = E)
 		if(burn_avg)
 			apply_damage(damage = burn_avg, damagetype = BURN, damage_flags = dam_flags, used_weapon = used_weapon, silent = TRUE, given_organ = E)
+
+	if(brute > 3)
+		flash_silhouette(flash_color = COLOR_RED)
+	else if(burn > 3)
+		flash_silhouette(flash_color = COLOR_ORANGE)
 
 	update_health()
 	BITSET(hud_updateflag, HEALTH_HUD)

--- a/code/modules/mob/living/living_damage.dm
+++ b/code/modules/mob/living/living_damage.dm
@@ -1,3 +1,68 @@
+/obj/effect/silhouette
+	icon              = 'icons/effects/32x32.dmi'
+	icon_state        = "FFF"
+	mouse_opacity     = MOUSE_OPACITY_UNCLICKABLE
+	layer             = ABOVE_LIGHTING_LAYER
+	plane             = ABOVE_LIGHTING_PLANE
+	appearance_flags  = RESET_ALPHA|RESET_COLOR|KEEP_APART
+	is_spawnable_type = FALSE
+	alpha             = 0
+	var/mob/living/owner
+
+/obj/effect/silhouette/Initialize(mapload)
+	. = ..()
+	START_PROCESSING(SSfastprocess, src)
+	owner = loc
+	if(!istype(owner))
+		return INITIALIZE_HINT_QDEL
+	global.events_repository.register(/decl/observ/moved, owner, src, TYPE_PROC_REF(/obj/effect/silhouette, follow_owner))
+	add_filter("owner_mask", 1, list(type = "alpha", render_source = "render_\ref[owner]"))
+	name = null
+	verbs.Cut()
+
+/obj/effect/silhouette/Destroy()
+	STOP_PROCESSING(SSfastprocess, src)
+	if(owner)
+		global.events_repository.unregister(/decl/observ/moved, owner, src)
+		if(owner.silhouette == src)
+			owner.silhouette = null
+		owner = null
+	return ..()
+
+/obj/effect/silhouette/Process()
+	..()
+	if(owner)
+		pixel_x = owner.pixel_x
+		pixel_y = owner.pixel_y
+		pixel_z = owner.pixel_z
+		pixel_w = owner.pixel_w
+
+/obj/effect/silhouette/proc/follow_owner()
+	glide_size = owner.glide_size
+	forceMove(owner.loc)
+
+/mob/living/proc/flash_silhouette(flash_time = 2, flash_color = COLOR_WHITE)
+	update_appearance_flags(add_flags = KEEP_TOGETHER)
+	silhouette.alpha = 255
+	silhouette.color = flash_color
+	addtimer(CALLBACK(src, PROC_REF(hide_silhouette)), flash_time, (TIMER_OVERRIDE | TIMER_UNIQUE | TIMER_NO_HASH_WAIT))
+
+/mob/living/proc/hide_silhouette()
+	update_appearance_flags(remove_flags = KEEP_TOGETHER)
+	silhouette.alpha = 0
+
+/mob/living
+	var/obj/effect/silhouette/silhouette
+
+/mob/living/Initialize()
+	silhouette    = new(src)
+	render_target = "render_\ref[src]"
+	. = ..()
+
+/mob/living/Destroy()
+	. = ..()
+	QDEL_NULL(silhouette)
+
 /mob/living/setBruteLoss(var/amount)
 	take_damage((amount * 0.5)-get_damage(BRUTE))
 

--- a/code/modules/mob/living/silicon/ai/ai_damage.dm
+++ b/code/modules/mob/living/silicon/ai/ai_damage.dm
@@ -13,15 +13,20 @@
 	return oxyloss
 
 /mob/living/silicon/ai/adjustFireLoss(var/amount, var/do_update_health = TRUE)
-	if(status_flags & GODMODE) return
+	if(status_flags & GODMODE)
+		return
 	fireloss = max(0, fireloss + min(amount, current_health))
 	if(do_update_health)
 		update_health()
+	if(amount >= 3)
+		flash_silhouette(flash_color = COLOR_ORANGE)
 
 /mob/living/silicon/ai/adjustBruteLoss(var/amount, var/do_update_health = TRUE)
 	if(!(status_flags & GODMODE))
 		bruteloss = max(0, bruteloss + min(amount, current_health))
 	..()
+	if(amount >= 3)
+		flash_silhouette(flash_color = COLOR_RED)
 
 /mob/living/silicon/ai/adjustOxyLoss(var/damage, var/do_update_health = TRUE)
 	if(!(status_flags & GODMODE))

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -15,13 +15,19 @@
 /mob/living/silicon/robot/adjustBruteLoss(var/amount, var/do_update_health = TRUE)
 	SHOULD_CALL_PARENT(FALSE) // take/heal overall call update_health regardless of arg
 	if(amount > 0)
+		var/old_health = current_health
 		take_overall_damage(amount, 0)
+		if(current_health - old_health <= -3)
+			flash_silhouette(flash_color = COLOR_RED)
 	else
 		heal_overall_damage(-amount, 0)
 
 /mob/living/silicon/robot/adjustFireLoss(var/amount, var/do_update_health = TRUE)
 	if(amount > 0)
+		var/old_health = current_health
 		take_overall_damage(0, amount)
+		if(current_health - old_health <= -3)
+			flash_silhouette(flash_color = COLOR_ORANGE)
 	else
 		heal_overall_damage(0, -amount)
 

--- a/code/modules/mob/living/simple_animal/simple_animal_damage.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_damage.dm
@@ -37,13 +37,21 @@
 /mob/living/simple_animal/adjustBruteLoss(var/amount, var/do_update_health = TRUE)
 	brute_damage = clamp(brute_damage + amount, 0, get_max_health())
 	. = ..()
+	if(amount > 0)
+		if(istype(ai))
+			ai.retaliate()
+		if(amount >= 3)
+			flash_silhouette(flash_color = COLOR_RED)
 
 /mob/living/simple_animal/adjustFireLoss(var/amount, var/do_update_health = TRUE)
 	burn_damage = clamp(burn_damage + amount, 0, get_max_health())
 	if(do_update_health)
 		update_health()
-	if(amount > 0 && istype(ai))
-		ai.retaliate()
+	if(amount > 0 )
+		if(istype(ai))
+			ai.retaliate()
+		if(amount >= 3)
+			flash_silhouette(flash_color = COLOR_ORANGE)
 
 /mob/living/simple_animal/hit_with_weapon(obj/item/O, mob/living/user, var/effective_force, var/hit_zone)
 


### PR DESCRIPTION
Trying to add a full silhouette solid colour flash when hit by an attack - having some issues, so opening a draft for review/input:
- Silhouette does not respect animated transforms (giant spider attack windup for example)
- Silhouette includes attack animation overlays (wrench etc).
- Humans don't proc the flash despite the stuff I've added to their code.