### PR TITLE
Cleaning up a lot of sprite_sheets setting.

### DIFF
--- a/mods/content/fantasy/_fantasy.dme
+++ b/mods/content/fantasy/_fantasy.dme
@@ -28,12 +28,12 @@
 #include "datum\kobaloi\species.dm"
 #include "items\material_overrides.dm"
 #include "items\clothing\_loadout.dm"
+#include "items\clothing\_overrides.dm"
 #include "items\clothing\_recipes.dm"
 #include "items\clothing\armor.dm"
 #include "items\clothing\glasses.dm"
 #include "items\clothing\jerkin.dm"
 #include "items\clothing\loincloth.dm"
-#include "items\clothing\overrides.dm"
 #include "items\clothing\trousers.dm"
 #include "props\signpost.dm"
 // END_INCLUDE

--- a/mods/content/fantasy/datum/kobaloi/clothing.dm
+++ b/mods/content/fantasy/datum/kobaloi/clothing.dm
@@ -1,4 +1,2 @@
-/obj/item/bag/sack/Initialize()
-	. = ..()
-	if(!(BODYTYPE_KOBALOI in sprite_sheets))
-		LAZYSET(sprite_sheets, BODYTYPE_KOBALOI, 'mods/content/fantasy/icons/clothing/sack_kobaloi.dmi')
+/obj/item/bag/sack
+	_kobaloi_onmob_icon = 'mods/content/fantasy/icons/clothing/sack_kobaloi.dmi'

--- a/mods/content/fantasy/items/clothing/_overrides.dm
+++ b/mods/content/fantasy/items/clothing/_overrides.dm
@@ -1,0 +1,15 @@
+/obj/item
+	var/_kobaloi_onmob_icon
+	var/_hnoll_onmob_icon
+
+/obj/item/setup_sprite_sheets()
+	. = ..()
+	if(_kobaloi_onmob_icon)
+		LAZYSET(sprite_sheets, BODYTYPE_KOBALOI, _kobaloi_onmob_icon)
+	if(_hnoll_onmob_icon)
+		LAZYSET(sprite_sheets, BODYTYPE_HNOLL, _hnoll_onmob_icon)
+
+/obj/item/clothing/gloves/setup_equip_flags()
+	. = ..()
+	if(!isnull(bodytype_equip_flags) && !(bodytype_equip_flags & BODY_EQUIP_FLAG_EXCLUDE))
+		bodytype_equip_flags |= BODY_EQUIP_FLAG_HNOLL

--- a/mods/content/fantasy/items/clothing/jerkin.dm
+++ b/mods/content/fantasy/items/clothing/jerkin.dm
@@ -2,6 +2,6 @@
 	name = "jerkin"
 	desc = "A sturdy jerkin, worn on the upper body."
 	icon = 'mods/content/fantasy/icons/clothing/jerkin.dmi'
-	sprite_sheets = list(BODYTYPE_HNOLL = 'mods/content/fantasy/icons/clothing/jerkin_hnoll.dmi')
+	_hnoll_onmob_icon = 'mods/content/fantasy/icons/clothing/jerkin_hnoll.dmi'
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME | MAT_FLAG_ALTERATION_DESC
 	material = /decl/material/solid/organic/leather

--- a/mods/content/fantasy/items/clothing/loincloth.dm
+++ b/mods/content/fantasy/items/clothing/loincloth.dm
@@ -3,7 +3,7 @@
 	gender = NEUTER
 	desc = "A simple garment that is worn around the legs and lower body."
 	icon = 'mods/content/fantasy/icons/clothing/loincloth.dmi'
-	sprite_sheets = list(BODYTYPE_HNOLL = 'mods/content/fantasy/icons/clothing/loincloth_hnoll.dmi')
+	_hnoll_onmob_icon = 'mods/content/fantasy/icons/clothing/loincloth_hnoll.dmi'
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME | MAT_FLAG_ALTERATION_DESC
 	material = /decl/material/solid/organic/skin/fur
 

--- a/mods/content/fantasy/items/clothing/overrides.dm
+++ b/mods/content/fantasy/items/clothing/overrides.dm
@@ -1,4 +1,0 @@
-/obj/item/clothing/gloves/setup_equip_flags()
-	. = ..()
-	if(!isnull(bodytype_equip_flags) && !(bodytype_equip_flags & BODY_EQUIP_FLAG_EXCLUDE))
-		bodytype_equip_flags |= BODY_EQUIP_FLAG_HNOLL

--- a/mods/content/fantasy/items/clothing/trousers.dm
+++ b/mods/content/fantasy/items/clothing/trousers.dm
@@ -5,9 +5,7 @@
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME | MAT_FLAG_ALTERATION_DESC
 	material            = /decl/material/solid/organic/leather
 	color               = /decl/material/solid/organic/leather::color
-	sprite_sheets       = list(
-		BODYTYPE_HNOLL  = 'mods/content/fantasy/icons/clothing/trousers_hnoll.dmi'
-	)
+	_hnoll_onmob_icon   = 'mods/content/fantasy/icons/clothing/trousers_hnoll.dmi'
 
 /obj/item/clothing/pants/trousers/jerkin/Initialize()
 	. = ..()
@@ -20,6 +18,4 @@
 	name                = "braies"
 	desc                = "Some short trousers. Comfortable and easy to wear."
 	icon                = 'mods/content/fantasy/icons/clothing/braies.dmi'
-	sprite_sheets       = list(
-		BODYTYPE_HNOLL  = 'mods/content/fantasy/icons/clothing/braies_hnoll.dmi'
-	)
+	_hnoll_onmob_icon   = 'mods/content/fantasy/icons/clothing/braies_hnoll.dmi'

--- a/mods/species/ascent/_ascent.dme
+++ b/mods/species/ascent/_ascent.dme
@@ -14,6 +14,7 @@
 #include "datum\species_bodytypes.dm"
 #include "datum\traits.dm"
 #include "effects\razorweb.dm"
+#include "items\_overrides.dm"
 #include "items\cell.dm"
 #include "items\clothing.dm"
 #include "items\clustertool.dm"

--- a/mods/species/ascent/items/_overrides.dm
+++ b/mods/species/ascent/items/_overrides.dm
@@ -1,0 +1,10 @@
+/obj/item
+	var/_alate_onmob_icon
+	var/_gyne_onmob_icon
+
+/obj/item/setup_sprite_sheets()
+	. = ..()
+	if(_alate_onmob_icon)
+		LAZYSET(sprite_sheets, BODYTYPE_MANTID_SMALL, _alate_onmob_icon)
+	if(_gyne_onmob_icon)
+		LAZYSET(sprite_sheets, BODYTYPE_MANTID_LARGE, _gyne_onmob_icon)

--- a/mods/species/ascent/items/clothing.dm
+++ b/mods/species/ascent/items/clothing.dm
@@ -22,7 +22,7 @@
 	desc = "An alien facemask with chunky gas filters and a breathing valve."
 	filter_water = TRUE
 	icon = 'mods/species/ascent/icons/clothing/mask.dmi'
-	sprite_sheets = list(BODYTYPE_MANTID_LARGE = 'mods/species/ascent/icons/clothing/mask_gyne.dmi')
+	_gyne_onmob_icon = 'mods/species/ascent/icons/clothing/mask_gyne.dmi'
 	bodytype_equip_flags = BODY_EQUIP_FLAG_GYNE | BODY_EQUIP_FLAG_ALATE
 	filtered_gases = list(
 		/decl/material/gas/nitrous_oxide,
@@ -38,9 +38,7 @@
 	desc = "A set of powerful gripping claws."
 	icon = 'mods/species/ascent/icons/magboots/boots.dmi'
 	bodytype_equip_flags = BODY_EQUIP_FLAG_GYNE | BODY_EQUIP_FLAG_ALATE
-	sprite_sheets = list(
-		BODYTYPE_MANTID_LARGE = 'mods/species/ascent/icons/magboots/boots_gyne.dmi'
-	)
+	_gyne_onmob_icon = 'mods/species/ascent/icons/magboots/boots_gyne.dmi'
 
 /obj/item/clothing/jumpsuit/ascent
 	name = "mantid undersuit"
@@ -48,9 +46,7 @@
 	bodytype_equip_flags = BODY_EQUIP_FLAG_GYNE | BODY_EQUIP_FLAG_ALATE
 	icon = 'mods/species/ascent/icons/clothing/under.dmi'
 	color = COLOR_DARK_GUNMETAL
-	sprite_sheets = list(
-		BODYTYPE_MANTID_LARGE = 'mods/species/ascent/icons/clothing/under_gyne.dmi'
-	)
+	_gyne_onmob_icon = 'mods/species/ascent/icons/clothing/under_gyne.dmi'
 
 /obj/item/clothing/suit/ascent
 	name = "mantid gear harness"
@@ -58,7 +54,7 @@
 	bodytype_equip_flags = BODY_EQUIP_FLAG_GYNE | BODY_EQUIP_FLAG_ALATE
 	icon_state = ICON_STATE_WORLD
 	icon = 'mods/species/ascent/icons/clothing/under_harness.dmi'
-	sprite_sheets = list(BODYTYPE_MANTID_LARGE = 'mods/species/ascent/icons/clothing/under_harness_gyne.dmi')
+	_gyne_onmob_icon = 'mods/species/ascent/icons/clothing/under_harness_gyne.dmi'
 	body_parts_covered = 0
 	slot_flags = SLOT_OVER_BODY | SLOT_LOWER_BODY
 	storage = /datum/storage/pockets/suit

--- a/mods/species/ascent/items/guns.dm
+++ b/mods/species/ascent/items/guns.dm
@@ -20,7 +20,7 @@
 		list(mode_name="shock",  projectile_type = /obj/item/projectile/beam/stun/shock),
 		list(mode_name="lethal", projectile_type = /obj/item/projectile/beam/particle)
 		)
-	sprite_sheets = list(BODYTYPE_MANTID_LARGE = 'mods/species/ascent/icons/particle_rifle/inhands_gyne.dmi')
+	_gyne_onmob_icon = 'mods/species/ascent/icons/particle_rifle/inhands_gyne.dmi'
 
 /obj/item/gun/energy/particle/small
 	name = "particle projector"

--- a/mods/species/ascent/items/rig.dm
+++ b/mods/species/ascent/items/rig.dm
@@ -3,7 +3,6 @@
 	name = "alate support exosuit"
 	desc = "A powerful support exosuit with integrated power supply, weapon and atmosphere. It's closer to a mech than a rig."
 	icon = 'mods/species/ascent/icons/rig/rig.dmi'
-
 	suit_type = "support exosuit"
 	armor = list(
 		ARMOR_MELEE = ARMOR_MELEE_MAJOR,
@@ -28,7 +27,7 @@
 	gloves =     /obj/item/clothing/gloves/rig/mantid
 
 	update_visible_name = TRUE
-	sprite_sheets = list(BODYTYPE_MANTID_LARGE = 'mods/species/ascent/icons/rig/rig_gyne.dmi')
+	_gyne_onmob_icon = 'mods/species/ascent/icons/rig/rig_gyne.dmi'
 	initial_modules = list(
 		/obj/item/rig_module/vision/thermal,
 		/obj/item/rig_module/ai_container,
@@ -241,7 +240,7 @@
 	desc = "More like a torpedo casing than a helmet."
 	bodytype_equip_flags = BODY_EQUIP_FLAG_GYNE | BODY_EQUIP_FLAG_ALATE
 	icon = 'mods/species/ascent/icons/rig/rig_helmet.dmi'
-	sprite_sheets = list(BODYTYPE_MANTID_LARGE = 'mods/species/ascent/icons/rig/rig_helmet_gyne.dmi')
+	_gyne_onmob_icon = 'mods/species/ascent/icons/rig/rig_helmet_gyne.dmi'
 
 /obj/item/clothing/suit/space/rig/mantid
 	desc = "It's closer to a mech than a suit."
@@ -255,16 +254,16 @@
 		/obj/item/stack/medical/resin,
 		/obj/item/chems/drinks/cans/waterbottle/ascent
 	)
-	sprite_sheets = list(BODYTYPE_MANTID_LARGE = 'mods/species/ascent/icons/rig/rig_chest_gyne.dmi')
+	_gyne_onmob_icon = 'mods/species/ascent/icons/rig/rig_chest_gyne.dmi'
 
 /obj/item/clothing/shoes/magboots/rig/mantid
 	icon = 'mods/species/ascent/icons/rig/rig_boots.dmi'
 	desc = "It's like a highly advanced forklift."
 	bodytype_equip_flags = BODY_EQUIP_FLAG_GYNE | BODY_EQUIP_FLAG_ALATE
-	sprite_sheets = list(BODYTYPE_MANTID_LARGE = 'mods/species/ascent/icons/rig/rig_boots_gyne.dmi')
+	_gyne_onmob_icon = 'mods/species/ascent/icons/rig/rig_boots_gyne.dmi'
 
 /obj/item/clothing/gloves/rig/mantid
 	icon = 'mods/species/ascent/icons/rig/rig_gloves.dmi'
 	desc = "They look like a cross between a can opener and a Swiss army knife the size of a shoebox."
 	bodytype_equip_flags = BODY_EQUIP_FLAG_GYNE | BODY_EQUIP_FLAG_ALATE
-	sprite_sheets = list(BODYTYPE_MANTID_LARGE = 'mods/species/ascent/icons/rig/rig_gloves_gyne.dmi')
+	_gyne_onmob_icon = 'mods/species/ascent/icons/rig/rig_gloves_gyne.dmi'

--- a/mods/species/bayliens/_bayliens.dm
+++ b/mods/species/bayliens/_bayliens.dm
@@ -1,7 +1,12 @@
-#define SPECIES_SKRELL   "Skrell"
-#define SPECIES_TAJARA   "Tajara"
-#define SPECIES_LIZARD   "Unathi"
-#define SPECIES_ADHERENT "Adherent"
+#define SPECIES_SKRELL    "Skrell"
+#define SPECIES_TAJARA    "Tajara"
+#define SPECIES_LIZARD    "Unathi"
+#define SPECIES_ADHERENT  "Adherent"
+
+#define BODYTYPE_FELINE   "feline body"
+#define BODYTYPE_ADHERENT "adherent body"
+
+#define BODY_EQUIP_FLAG_FELINE BITFLAG(7)
 
 /decl/modpack/bayliens
 	name = "Baystation 12 Aliens"

--- a/mods/species/bayliens/_bayliens.dme
+++ b/mods/species/bayliens/_bayliens.dme
@@ -1,7 +1,8 @@
 #ifndef MODPACK_BAYLIENS
 #define MODPACK_BAYLIENS
 // BEGIN_INCLUDE
-#include "bayliens.dm"
+#include "_bayliens.dm"
+#include "_overrides.dm"
 #include "adherent\_adherent.dm"
 #include "adherent\datum\culture.dm"
 #include "adherent\datum\emotes.dm"

--- a/mods/species/bayliens/_overrides.dm
+++ b/mods/species/bayliens/_overrides.dm
@@ -1,0 +1,7 @@
+/obj/item
+	var/_feline_onmob_icon
+
+/obj/item/setup_sprite_sheets()
+	. = ..()
+	if(_feline_onmob_icon)
+		LAZYSET(sprite_sheets, BODYTYPE_FELINE, _feline_onmob_icon)

--- a/mods/species/bayliens/adherent/_adherent.dm
+++ b/mods/species/bayliens/adherent/_adherent.dm
@@ -1,6 +1,4 @@
-#define BODYTYPE_ADHERENT "adherent body"
 #define LANGUAGE_ADHERENT "Protocol"
-
 #define BP_FLOAT        "floatation disc"
 #define BP_JETS         "maneuvering jets"
 #define BP_COOLING_FINS "cooling fins"

--- a/mods/species/bayliens/tajaran/_tajaran.dm
+++ b/mods/species/bayliens/tajaran/_tajaran.dm
@@ -1,6 +1,4 @@
 #define LANGUAGE_TAJARA "Siik'maas"
-#define BODYTYPE_FELINE "feline body"
-#define BODY_EQUIP_FLAG_FELINE BITFLAG(7)
 
 /obj/item/clothing/setup_equip_flags()
 	. = ..()

--- a/mods/species/bayliens/tajaran/machinery/suit_cycler.dm
+++ b/mods/species/bayliens/tajaran/machinery/suit_cycler.dm
@@ -2,70 +2,53 @@
 	LAZYDISTINCTADD(available_bodytypes, BODYTYPE_FELINE)
 	. = ..()
 
-/obj/item/clothing/suit/space/void/merc/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_FELINE, 'mods/species/bayliens/tajaran/icons/clothing/merc/suit.dmi')
+/obj/item/clothing/suit/space/void/merc
+	_feline_onmob_icon = 'mods/species/bayliens/tajaran/icons/clothing/merc/suit.dmi'
 
-/obj/item/clothing/suit/space/void/swat/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_FELINE, 'mods/species/bayliens/tajaran/icons/clothing/deathsquad/suit.dmi')
+/obj/item/clothing/suit/space/void/swat
+	_feline_onmob_icon = 'mods/species/bayliens/tajaran/icons/clothing/deathsquad/suit.dmi'
 
-/obj/item/clothing/suit/space/void/engineering/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_FELINE, 'mods/species/bayliens/tajaran/icons/clothing/engineering/suit.dmi')
+/obj/item/clothing/suit/space/void/engineering
+	_feline_onmob_icon = 'mods/species/bayliens/tajaran/icons/clothing/engineering/suit.dmi'
 
-/obj/item/clothing/suit/space/void/mining/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_FELINE, 'mods/species/bayliens/tajaran/icons/clothing/mining/suit.dmi')
+/obj/item/clothing/suit/space/void/mining
+	_feline_onmob_icon = 'mods/species/bayliens/tajaran/icons/clothing/mining/suit.dmi'
 
-/obj/item/clothing/suit/space/void/medical/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_FELINE, 'mods/species/bayliens/tajaran/icons/clothing/medical/suit.dmi')
+/obj/item/clothing/suit/space/void/medical
+	_feline_onmob_icon = 'mods/species/bayliens/tajaran/icons/clothing/medical/suit.dmi'
 
-/obj/item/clothing/suit/space/void/security/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_FELINE, 'mods/species/bayliens/tajaran/icons/clothing/sec/suit.dmi')
+/obj/item/clothing/suit/space/void/security
+	_feline_onmob_icon = 'mods/species/bayliens/tajaran/icons/clothing/sec/suit.dmi'
 
-/obj/item/clothing/suit/space/void/atmos/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_FELINE, 'mods/species/bayliens/tajaran/icons/clothing/atmos/suit.dmi')
+/obj/item/clothing/suit/space/void/atmos
+	_feline_onmob_icon = 'mods/species/bayliens/tajaran/icons/clothing/atmos/suit.dmi'
 
-/obj/item/clothing/suit/space/void/engineering/alt/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_FELINE, 'mods/species/bayliens/tajaran/icons/clothing/engineering_alt/suit.dmi')
+/obj/item/clothing/suit/space/void/engineering/alt
+	_feline_onmob_icon = 'mods/species/bayliens/tajaran/icons/clothing/engineering_alt/suit.dmi'
 
-/obj/item/clothing/suit/space/void/mining/alt/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_FELINE, 'mods/species/bayliens/tajaran/icons/clothing/mining_alt/suit.dmi')
+/obj/item/clothing/suit/space/void/mining/alt
+	_feline_onmob_icon = 'mods/species/bayliens/tajaran/icons/clothing/mining_alt/suit.dmi'
 
-/obj/item/clothing/suit/space/void/medical/alt/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_FELINE, 'mods/species/bayliens/tajaran/icons/clothing/medical_alt/suit.dmi')
+/obj/item/clothing/suit/space/void/medical/alt
+	_feline_onmob_icon = 'mods/species/bayliens/tajaran/icons/clothing/medical_alt/suit.dmi'
 
-/obj/item/clothing/suit/space/void/security/alt/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_FELINE, 'mods/species/bayliens/tajaran/icons/clothing/sec_alt/suit.dmi')
+/obj/item/clothing/suit/space/void/security/alt
+	_feline_onmob_icon = 'mods/species/bayliens/tajaran/icons/clothing/sec_alt/suit.dmi'
 
-/obj/item/clothing/suit/space/void/atmos/alt/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_FELINE, 'mods/species/bayliens/tajaran/icons/clothing/atmos_alt/suit.dmi')
+/obj/item/clothing/suit/space/void/atmos/alt
+	_feline_onmob_icon = 'mods/species/bayliens/tajaran/icons/clothing/atmos_alt/suit.dmi'
 
-/obj/item/clothing/suit/space/void/engineering/salvage/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_FELINE, 'mods/species/bayliens/tajaran/icons/clothing/salvage/suit.dmi')
+/obj/item/clothing/suit/space/void/engineering/salvage
+	_feline_onmob_icon = 'mods/species/bayliens/tajaran/icons/clothing/salvage/suit.dmi'
 
-/obj/item/clothing/suit/space/void/expedition/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_FELINE, 'mods/species/bayliens/tajaran/icons/clothing/pilot/suit.dmi')
+/obj/item/clothing/suit/space/void/expedition
+	_feline_onmob_icon = 'mods/species/bayliens/tajaran/icons/clothing/pilot/suit.dmi'
 
-/obj/item/clothing/suit/space/void/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_FELINE, 'mods/species/bayliens/tajaran/icons/clothing/nasa/suit.dmi')
+/obj/item/clothing/suit/space/void
+	_feline_onmob_icon = 'mods/species/bayliens/tajaran/icons/clothing/nasa/suit.dmi'
 
-/obj/item/clothing/suit/space/void/wizard/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_FELINE, 'mods/species/bayliens/tajaran/icons/clothing/wizard/suit.dmi')
+/obj/item/clothing/suit/space/void/wizard
+	_feline_onmob_icon = 'mods/species/bayliens/tajaran/icons/clothing/wizard/suit.dmi'
 
-/obj/item/clothing/suit/space/void/excavation/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_FELINE, 'mods/species/bayliens/tajaran/icons/clothing/excavation/suit.dmi')
+/obj/item/clothing/suit/space/void/excavation
+	_feline_onmob_icon = 'mods/species/bayliens/tajaran/icons/clothing/excavation/suit.dmi'

--- a/mods/species/drakes/_drakes.dme
+++ b/mods/species/drakes/_drakes.dme
@@ -7,6 +7,7 @@
 
 // BEGIN_INCLUDE
 #include "_drakes.dm"
+#include "_overrides.dm"
 #include "clothing.dm"
 #include "culture.dm"
 #include "drake_abilities.dm"

--- a/mods/species/drakes/_overrides.dm
+++ b/mods/species/drakes/_overrides.dm
@@ -1,0 +1,10 @@
+/obj/item
+	var/_drake_onmob_icon
+	var/_drake_hatchling_onmob_icon
+
+/obj/item/backpack/setup_sprite_sheets()
+	. = ..()
+	if(_drake_onmob_icon)
+		LAZYSET(sprite_sheets, BODYTYPE_GRAFADREKA, _drake_onmob_icon)
+	if(_drake_hatchling_onmob_icon)
+		LAZYSET(sprite_sheets, BODYTYPE_GRAFADREKA_HATCHLING, _drake_hatchling_onmob_icon)

--- a/mods/species/drakes/clothing.dm
+++ b/mods/species/drakes/clothing.dm
@@ -1,21 +1,11 @@
+/obj/item/backpack
+	_drake_onmob_icon = 'mods/species/drakes/icons/clothing/backpack.dmi'
+	_drake_hatchling_onmob_icon = 'mods/species/drakes/icons/clothing/hatchling_backpack.dmi'
 
-/obj/item/backpack/setup_sprite_sheets()
-	. = ..()
-	if(!(BODYTYPE_GRAFADREKA in sprite_sheets))
-		LAZYSET(sprite_sheets, BODYTYPE_GRAFADREKA, 'mods/species/drakes/icons/clothing/backpack.dmi')
-	if(!(BODYTYPE_GRAFADREKA_HATCHLING in sprite_sheets))
-		LAZYSET(sprite_sheets, BODYTYPE_GRAFADREKA_HATCHLING, 'mods/species/drakes/icons/clothing/hatchling_backpack.dmi')
+/obj/item/card/id
+	_drake_onmob_icon = 'mods/species/drakes/icons/clothing/id.dmi'
+	_drake_hatchling_onmob_icon = 'mods/species/drakes/icons/clothing/hatchling_id.dmi'
 
-/obj/item/card/id/setup_sprite_sheets()
-	. = ..()
-	if(!(BODYTYPE_GRAFADREKA in sprite_sheets))
-		LAZYSET(sprite_sheets, BODYTYPE_GRAFADREKA, 'mods/species/drakes/icons/clothing/id.dmi')
-	if(!(BODYTYPE_GRAFADREKA_HATCHLING in sprite_sheets))
-		LAZYSET(sprite_sheets, BODYTYPE_GRAFADREKA_HATCHLING, 'mods/species/drakes/icons/clothing/hatchling_id.dmi')
-
-/obj/item/bag/setup_sprite_sheets()
-	. = ..()
-	if(!(BODYTYPE_GRAFADREKA in sprite_sheets))
-		LAZYSET(sprite_sheets, BODYTYPE_GRAFADREKA, 'mods/species/drakes/icons/clothing/sack.dmi')
-	if(!(BODYTYPE_GRAFADREKA_HATCHLING in sprite_sheets))
-		LAZYSET(sprite_sheets, BODYTYPE_GRAFADREKA_HATCHLING, 'mods/species/drakes/icons/clothing/hatchling_backpack.dmi')
+/obj/item/bag
+	_drake_onmob_icon = 'mods/species/drakes/icons/clothing/sack.dmi'
+	_drake_hatchling_onmob_icon = 'mods/species/drakes/icons/clothing/hatchling_backpack.dmi'

--- a/mods/species/neoavians/_neoavians.dme
+++ b/mods/species/neoavians/_neoavians.dme
@@ -2,6 +2,7 @@
 #define CONTENT_PACK_NEOAVIANS
 // BEGIN_INCLUDE
 #include "_neoavians.dm"
+#include "_overrides.dm"
 #include "clothing.dm"
 #include "datum\accessory.dm"
 #include "datum\language.dm"

--- a/mods/species/neoavians/_overrides.dm
+++ b/mods/species/neoavians/_overrides.dm
@@ -1,0 +1,7 @@
+/obj/item
+	var/_avian_onmob_icon
+
+/obj/item/setup_sprite_sheets()
+	. = ..()
+	if(_avian_onmob_icon)
+		LAZYSET(sprite_sheets, BODYTYPE_AVIAN, _avian_onmob_icon)

--- a/mods/species/neoavians/clothing.dm
+++ b/mods/species/neoavians/clothing.dm
@@ -1,11 +1,9 @@
 //Shoes
-/obj/item/clothing/shoes/magboots/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/feet/magboots.dmi')
+/obj/item/clothing/shoes/magboots
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/feet/magboots.dmi'
 
-/obj/item/clothing/shoes/galoshes/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/feet/galoshes.dmi')
+/obj/item/clothing/shoes/galoshes
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/feet/galoshes.dmi'
 
 //Gloves
 /obj/item/clothing/gloves/setup_equip_flags()
@@ -13,34 +11,31 @@
 	if(!isnull(bodytype_equip_flags) && !(bodytype_equip_flags & BODY_EQUIP_FLAG_EXCLUDE))
 		bodytype_equip_flags |= BODY_EQUIP_FLAG_AVIAN
 
-/obj/item/clothing/gloves/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/gloves.dmi')
+/obj/item/clothing/gloves
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/gloves.dmi'
+
+/obj/item/clothing/gloves/ring
+	_avian_onmob_icon = null
 
 //Backpacks & tanks
 
-/obj/item/backpack/satchel/Initialize()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/satchel.dmi')
+/obj/item/backpack/satchel
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/satchel.dmi'
 
 //Radsuits (theyre essential?)
 
-/obj/item/clothing/head/radiation/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/head/rad_helm.dmi')
+/obj/item/clothing/head/radiation
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/head/rad_helm.dmi'
 
-/obj/item/clothing/suit/radiation/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/suit/rad_suit.dmi')
+/obj/item/clothing/suit/radiation
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/suit/rad_suit.dmi'
 
 //cloaks
-/obj/item/clothing/suit/cloak/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/accessory/cloak.dmi')
+/obj/item/clothing/suit/cloak
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/accessory/cloak.dmi'
 
-/obj/item/clothing/suit/cloak/hide/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/accessory/cloak_hide.dmi')
+/obj/item/clothing/suit/cloak/hide
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/accessory/cloak_hide.dmi'
 
 //clothing
 /obj/item/clothing/dress/avian_smock
@@ -49,6 +44,7 @@
 	icon = 'mods/species/neoavians/icons/clothing/under/smock.dmi'
 	icon_state = ICON_STATE_WORLD
 	bodytype_equip_flags = BODY_EQUIP_FLAG_AVIAN
+	_avian_onmob_icon = null
 
 /obj/item/clothing/dress/avian_smock/worker
 	name = "worker's smock"
@@ -86,6 +82,7 @@
 	icon = 'mods/species/neoavians/icons/clothing/feet/shoes.dmi'
 	color = COLOR_GRAY
 	bodytype_equip_flags = BODY_EQUIP_FLAG_AVIAN
+	_avian_onmob_icon = null
 
 /obj/item/clothing/shoes/avian/footwraps
 	name = "cloth footwraps"

--- a/mods/species/neoavians/machinery/suit_cycler.dm
+++ b/mods/species/neoavians/machinery/suit_cycler.dm
@@ -4,86 +4,68 @@
 
 //mining
 
-/obj/item/clothing/suit/space/void/mining/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/spacesuit/void/mining/suit.dmi')
+/obj/item/clothing/suit/space/void/mining
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/spacesuit/void/mining/suit.dmi'
 
-/obj/item/clothing/head/helmet/space/void/mining/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/spacesuit/void/mining/helmet.dmi')
+/obj/item/clothing/head/helmet/space/void/mining
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/spacesuit/void/mining/helmet.dmi'
 
 //excavation
 
-/obj/item/clothing/suit/space/void/excavation/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/spacesuit/void/mining/suit.dmi')
+/obj/item/clothing/suit/space/void/excavation
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/spacesuit/void/mining/suit.dmi'
 
-/obj/item/clothing/head/helmet/space/void/excavation/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/spacesuit/void/mining/helmet.dmi')
+/obj/item/clothing/head/helmet/space/void/excavation
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/spacesuit/void/mining/helmet.dmi'
 
 //engineering
 
-/obj/item/clothing/head/helmet/space/void/engineering/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/spacesuit/void/engineering/helmet.dmi')
+/obj/item/clothing/head/helmet/space/void/engineering
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/spacesuit/void/engineering/helmet.dmi'
 
-/obj/item/clothing/suit/space/void/engineering/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/spacesuit/void/engineering/suit.dmi')
+/obj/item/clothing/suit/space/void/engineering
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/spacesuit/void/engineering/suit.dmi'
 
-/obj/item/clothing/head/helmet/space/void/atmos/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/spacesuit/void/atmos/helmet.dmi')
+/obj/item/clothing/head/helmet/space/void/atmos
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/spacesuit/void/atmos/helmet.dmi'
 
-/obj/item/clothing/suit/space/void/atmos/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/spacesuit/void/atmos/suit.dmi')
+/obj/item/clothing/suit/space/void/atmos
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/spacesuit/void/atmos/suit.dmi'
 
 //medical
 
-/obj/item/clothing/suit/space/void/medical/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/spacesuit/void/medical/suit.dmi')
+/obj/item/clothing/suit/space/void/medical
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/spacesuit/void/medical/suit.dmi'
 
-/obj/item/clothing/head/helmet/space/void/medical/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/spacesuit/void/medical/helmet.dmi')
+/obj/item/clothing/head/helmet/space/void/medical
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/spacesuit/void/medical/helmet.dmi'
 
 //security
 
-/obj/item/clothing/head/helmet/space/void/security/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/spacesuit/void/sec/helmet.dmi')
+/obj/item/clothing/head/helmet/space/void/security
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/spacesuit/void/sec/helmet.dmi'
 
-/obj/item/clothing/suit/space/void/security/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/spacesuit/void/sec/suit.dmi')
+/obj/item/clothing/suit/space/void/security
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/spacesuit/void/sec/suit.dmi'
 
 //salvage
 
-/obj/item/clothing/head/helmet/space/void/engineering/salvage/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/spacesuit/void/salvage/helmet.dmi')
+/obj/item/clothing/head/helmet/space/void/engineering/salvage
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/spacesuit/void/salvage/helmet.dmi'
 
-/obj/item/clothing/suit/space/void/engineering/salvage/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/spacesuit/void/salvage/suit.dmi')
+/obj/item/clothing/suit/space/void/engineering/salvage
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/spacesuit/void/salvage/suit.dmi'
 
 //pilot
-/obj/item/clothing/head/helmet/space/void/expedition/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/spacesuit/void/pilot/helmet.dmi')
+/obj/item/clothing/head/helmet/space/void/expedition
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/spacesuit/void/pilot/helmet.dmi'
 
-/obj/item/clothing/suit/space/void/expedition/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/spacesuit/void/pilot/suit.dmi')
+/obj/item/clothing/suit/space/void/expedition
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/spacesuit/void/pilot/suit.dmi'
 
 //merc
-/obj/item/clothing/head/helmet/space/void/merc/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/spacesuit/void/merc/helmet.dmi')
+/obj/item/clothing/head/helmet/space/void/merc
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/spacesuit/void/merc/helmet.dmi'
 
-/obj/item/clothing/suit/space/void/merc/setup_sprite_sheets()
-	. = ..()
-	LAZYSET(sprite_sheets, BODYTYPE_AVIAN, 'mods/species/neoavians/icons/clothing/spacesuit/void/merc/suit.dmi')
+/obj/item/clothing/suit/space/void/merc
+	_avian_onmob_icon = 'mods/species/neoavians/icons/clothing/spacesuit/void/merc/suit.dmi'


### PR DESCRIPTION
## Description of changes
All sprite_sheets setting in modpacks now uses item vars to track relevant icons.

## Why and what will this PR improve
Allows overriding sprite_sheets on subtypes.

## Authorship
Myself.

## Changelog
Nothing player-facing.