### PR TITLE
Cleaning up some submap archetype code

### DIFF
--- a/code/controllers/subsystems/initialization/modpacks.dm
+++ b/code/controllers/subsystems/initialization/modpacks.dm
@@ -40,7 +40,7 @@ SUBSYSTEM_DEF(modpacks)
 
 	// Update compiled infolists and apply.
 	default_submap_whitelisted_species |= global.using_map.default_species
-	for(var/decl/submap_archetype/submap in decls_repository.get_decls_of_type_unassociated(/decl/submap_archetype))
+	for(var/decl/submap_archetype/submap in global.using_map.get_available_submap_archetypes())
 		if(islist(submap.whitelisted_species) && !length(submap.whitelisted_species))
 			submap.whitelisted_species |= SSmodpacks.default_submap_whitelisted_species
 		if(islist(submap.blacklisted_species) && !length(submap.blacklisted_species))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -323,7 +323,7 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 		ordered_submaps = sortTim(SSmapping.submaps.Copy(), /proc/cmp_submap_asc)
 	for(var/datum/submap/submap as anything in ordered_submaps)
 		if(submap?.available())
-			dat += "<tr><td colspan = 3><b>[submap.name] ([submap.archetype.descriptor]):</b></td></tr>"
+			dat += "<tr><td colspan = 3><b>[submap.name] ([submap.archetype.name]):</b></td></tr>"
 			job_summaries = list()
 			for(var/otherthing in submap.jobs)
 				var/datum/job/job = submap.jobs[otherthing]

--- a/code/modules/submaps/_submap.dm
+++ b/code/modules/submaps/_submap.dm
@@ -26,7 +26,7 @@
 
 	archetype = _archetype
 	if(!pref_name)
-		pref_name = archetype.descriptor
+		pref_name = archetype.name
 
 	testing("Starting submap setup - '[name]', [archetype], [associated_z]z.")
 
@@ -41,7 +41,7 @@
 		jobs[job.title] = job
 
 	if(!associated_z)
-		testing( "Submap error - [name]/[archetype ? archetype.descriptor : "NO ARCHETYPE"] could not find an associated z-level for spawnpoint registration.")
+		testing( "Submap error - [name]/[archetype ? archetype.name : "NO ARCHETYPE"] could not find an associated z-level for spawnpoint registration.")
 		qdel(src)
 		return
 
@@ -59,7 +59,7 @@
 				registered_spawnpoint = TRUE
 
 	if(!registered_spawnpoint)
-		testing( "Submap error - [name]/[archetype ? archetype.descriptor : "NO ARCHETYPE"] has no job spawn points.")
+		testing( "Submap error - [name]/[archetype ? archetype.name : "NO ARCHETYPE"] has no job spawn points.")
 		qdel(src)
 		return
 

--- a/code/modules/submaps/submap_archetype.dm
+++ b/code/modules/submaps/submap_archetype.dm
@@ -1,5 +1,6 @@
 /decl/submap_archetype
-	var/descriptor = "generic ship archetype"
+	// TODO: use UID instead of name for pref saving.
+	var/name = "generic ship archetype"
 	var/list/whitelisted_species = list()
 	var/list/blacklisted_species = list()
 	var/call_webhook
@@ -13,12 +14,18 @@
 
 /decl/submap_archetype/validate()
 	. = ..()
-	if(!descriptor)
-		. += "no descriptor set"
+	if(name)
+		var/static/list/submaps_by_name = list( (global.using_map.name) = global.using_map.type)
+		if(submaps_by_name[name])
+			. += "name '[name]' ([type]) collides with submap type '[submaps_by_name[name]]'"
+		else
+			submaps_by_name[name] = type
+	else
+		. += "no name set"
 
 // Generic ships to populate the list.
 /decl/submap_archetype/derelict
-	descriptor = "drifting wreck"
+	name = "drifting wreck"
 
 /decl/submap_archetype/abandoned_ship
-	descriptor = "abandoned ship"
+	name = "abandoned ship"

--- a/code/modules/submaps/submap_job.dm
+++ b/code/modules/submaps/submap_job.dm
@@ -78,17 +78,17 @@
 		to_chat(feedback, "<span class='boldannounce'>Not old enough. Minimum character age is [minimum_character_age[S.get_root_species_name()]].</span>")
 		return TRUE
 	if(LAZYLEN(whitelisted_species) && !(prefs.species in whitelisted_species))
-		to_chat(feedback, "<span class='boldannounce'>Your current species, [prefs.species], is not permitted as [title] on \a [owner.archetype.descriptor].</span>")
+		to_chat(feedback, "<span class='boldannounce'>Your current species, [prefs.species], is not permitted as [title] on \a [owner.archetype.name].</span>")
 		return TRUE
 	if(prefs.species in blacklisted_species)
-		to_chat(feedback, "<span class='boldannounce'>Your current species, [prefs.species], is not permitted as [title] on \a [owner.archetype.descriptor].</span>")
+		to_chat(feedback, "<span class='boldannounce'>Your current species, [prefs.species], is not permitted as [title] on \a [owner.archetype.name].</span>")
 		return TRUE
 	if(owner && owner.archetype)
 		if(LAZYLEN(owner.archetype.whitelisted_species) && !(prefs.species in owner.archetype.whitelisted_species))
-			to_chat(feedback, "<span class='boldannounce'>Your current species, [prefs.species], is not permitted on \a [owner.archetype.descriptor].</span>")
+			to_chat(feedback, "<span class='boldannounce'>Your current species, [prefs.species], is not permitted on \a [owner.archetype.name].</span>")
 			return TRUE
 		if(prefs.species in owner.archetype.blacklisted_species)
-			to_chat(feedback, "<span class='boldannounce'>Your current species, [prefs.species], is not permitted on \a [owner.archetype.descriptor].</span>")
+			to_chat(feedback, "<span class='boldannounce'>Your current species, [prefs.species], is not permitted on \a [owner.archetype.name].</span>")
 			return TRUE
 	return FALSE
 

--- a/code/unit_tests/unique_tests.dm
+++ b/code/unit_tests/unique_tests.dm
@@ -207,26 +207,6 @@
 		pass("All gas symbols are unique.")
 	return TRUE
 
-/datum/unit_test/submaps_shall_have_a_unique_descriptor
-	name = "UNIQUENESS: Archetypes shall have a valid, unique descriptor."
-
-/datum/unit_test/submaps_shall_have_a_unique_descriptor/start_test()
-	var/list/submaps_by_name = list()
-
-	var/list/all_submaps = decls_repository.get_decls_of_subtype(/decl/submap_archetype)
-	for(var/submap_type in all_submaps)
-		var/decl/submap_archetype/submap = all_submaps[submap_type]
-		if(submap.descriptor)
-			group_by(submaps_by_name, submap.descriptor, submap_type)
-
-	var/number_of_issues = number_of_issues(submaps_by_name, "Submap Archetype Descriptors")
-	if(length(number_of_issues))
-		fail("Found [number_of_issues] submap archetype\s with duplicate descriptors.")
-	else
-		pass("All submap archetypes have unique descriptors.")
-	return 1
-
-
 /datum/unit_test/proc/number_of_issues(var/list/entries, var/type, var/feedback = /decl/noi_feedback)
 	var/issues = 0
 	for(var/key in entries)

--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -3,11 +3,11 @@
 #include "bearcat_access.dm"
 
 /obj/abstract/submap_landmark/joinable_submap/bearcat
-	name = "FTV Bearcat"
+	name      = "FTV Bearcat"
 	archetype = /decl/submap_archetype/derelict/bearcat
 
 /decl/submap_archetype/derelict/bearcat
-	descriptor = "derelict cargo vessel"
+	name      = "derelict cargo vessel"
 	crew_jobs = list(
 		/datum/job/submap/bearcat_captain,
 		/datum/job/submap/bearcat_crewman

--- a/maps/away/liberia/liberia_jobs.dm
+++ b/maps/away/liberia/liberia_jobs.dm
@@ -1,6 +1,6 @@
 // Submap datum and archetype.
 /decl/submap_archetype/liberia
-	descriptor = "merchant ship"
+	name      = "merchant ship"
 	crew_jobs = list(
 		/datum/job/submap/merchant
 	)

--- a/maps/away/unishi/unishi.dm
+++ b/maps/away/unishi/unishi.dm
@@ -3,11 +3,11 @@
 #include "../../../mods/content/xenobiology/_xenobiology.dme"
 
 /obj/abstract/submap_landmark/joinable_submap/unishi
-	name = "SRV Verne"
+	name      = "SRV Verne"
 	archetype = /decl/submap_archetype/derelict/unishi
 
 /decl/submap_archetype/derelict/unishi
-	descriptor = "derelict research vessel"
+	name      = "derelict research vessel"
 	crew_jobs = list(
 		/datum/job/submap/unishi_crew,
 		/datum/job/submap/unishi_researcher

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
@@ -1,17 +1,17 @@
 /datum/map_template/ruin/exoplanet/crashed_pod
-	name = "crashed survival pod"
-	description = "A crashed survival pod from a destroyed ship."
-	suffixes = list("crashed_pod/crashed_pod.dmm")
-	cost = 2
+	name           = "crashed survival pod"
+	description    = "A crashed survival pod from a destroyed ship."
+	suffixes       = list("crashed_pod/crashed_pod.dmm")
+	cost           = 2
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
-	template_tags = TEMPLATE_TAG_HUMAN|TEMPLATE_TAG_WRECK
+	template_tags  = TEMPLATE_TAG_HUMAN|TEMPLATE_TAG_WRECK
 
 /area/map_template/crashed_pod
-	name = "\improper Crashed Survival Pod"
+	name       = "\improper Crashed Survival Pod"
 	icon_state = "blue"
 
 /decl/submap_archetype/crashed_pod
-	descriptor = "crashed survival pod"
+	name      = "crashed survival pod"
 	crew_jobs = list(/datum/job/submap/pod)
 
 /datum/submap/crashed_pod/sync_cell(var/obj/effect/overmap/visitable/cell)

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
@@ -1,18 +1,18 @@
 #include "../../../../mods/mobs/dionaea/_dionaea.dme"
 
 /datum/map_template/ruin/exoplanet/playablecolony
-	name = "established colony"
-	description = "a fully functional colony on the frontier of settled space"
-	suffixes = list("playablecolony/colony.dmm")
-	cost = 2
+	name           = "established colony"
+	description    = "a fully functional colony on the frontier of settled space"
+	suffixes       = list("playablecolony/colony.dmm")
+	cost           = 2
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
-	template_tags = TEMPLATE_TAG_HUMAN|TEMPLATE_TAG_HABITAT
+	template_tags  = TEMPLATE_TAG_HUMAN|TEMPLATE_TAG_HABITAT
 	apc_test_exempt_areas = list(
 		/area/map_template/colony/mineralprocessing = NO_SCRUBBER|NO_VENT
 	)
 
 /decl/submap_archetype/playablecolony
-	descriptor = "established colony"
+	name      = "established colony"
 	crew_jobs = list(/datum/job/submap/colonist)
 
 /datum/job/submap/colonist

--- a/maps/shaded_hills/shaded_hills_define.dm
+++ b/maps/shaded_hills/shaded_hills_define.dm
@@ -47,3 +47,6 @@
 /datum/map/shaded_hills/get_map_info()
 	return "You're in the <b>[station_name]</b> of the [system_name], nestled between the mountains and the river and bisected by the decaying Queens' Road. On all sides, you are surrounded by untamed wilds, with only a small ruined fort, rebuilt into an inn, to the east as a sign of civilisation. \
 	Far from the control of [boss_name], you are free to carve forward a path to survival for yourself and your comrades however you wish. Strike the earth!"
+
+/datum/map/shaded_hills/get_available_submap_archetypes()
+	return null // Return list of decl instances when relevant submaps exist.

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -527,3 +527,6 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 
 /datum/map/proc/finalize_map_generation()
 	return
+
+/datum/map/proc/get_available_submap_archetypes()
+	return decls_repository.get_decls_of_subtype_unassociated(/decl/submap_archetype)


### PR DESCRIPTION
## Description of changes
- Submap archetype code uses get_decls_of_type_unassociated().
- Maps can supply distinct submap archetype lists instead of always using the full set.
- Submap `descriptor` is now `name` so that they'll behave nicely in input() in the future.
- Submap name uniqueness validation is now in submap archetype validate()

## Why and what will this PR improve
No crashed pods on Shaded Hills.

## Authorship
Myself.

## Changelog
Nothing player-facing.