### PR TITLE
Fix duplicate `name_prefix` var

### DIFF
--- a/code/modules/banners/__banner.dm
+++ b/code/modules/banners/__banner.dm
@@ -12,7 +12,6 @@
 	var/hung_desc        = "The banner is rather unremarkable."
 	var/banner_type      = /obj/item/banner
 	var/embroiderable    = TRUE
-	var/name_prefix
 	var/list/decals
 	var/trim_color
 


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
`var/name_prefix` was declared on both `/obj/item` and `/obj/item/banner`

This is due to https://github.com/NebulaSS13/Nebula/pull/4582 and https://github.com/NebulaSS13/Nebula/pull/4603 adding the same var to each type.

This errors in BYOND and is also breaking OpenDream CI.


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->