### PR TITLE
Removes unnecessary pronouns

### DIFF
--- a/code/_onclick/ghost.dm
+++ b/code/_onclick/ghost.dm
@@ -45,6 +45,9 @@
 		return
 	if(user.client && user.client.inquisitive_ghost)
 		user.examinate(src)
+		return
+	if(user.client?.holder || user.antagHUD)
+		storage?.show_to(user)
 	return
 
 // ---------------------------------------

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -66,9 +66,9 @@
 	var/obj/item/organ/external/hand/O = GET_EXTERNAL_ORGAN(src, get_active_held_item_slot())
 	if(!istype(O))
 		return FALSE
-	var/decl/pronouns/G = get_pronouns()
+	var/decl/pronouns/pronouns = get_pronouns()
 	visible_message(
-		SPAN_DANGER("\The [src] chews on [G.his] [O.name]"),
+		SPAN_DANGER("\The [src] chews on [pronouns.his] [O.name]"),
 		SPAN_DANGER("You chew on your [O.name]!")
 	)
 	admin_attacker_log(src, "chewed on their [O.name]!")

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -581,11 +581,6 @@
 
 	return ..()
 
-/obj/item/attack_ghost(mob/user)
-	var/mob/observer/ghost/pronouns = user
-	if(pronouns.client?.holder || pronouns.antagHUD)
-		storage?.show_to(user)
-
 /obj/item/proc/talk_into(mob/living/M, message, message_mode, var/verb = "says", var/decl/language/speaking = null)
 	return
 

--- a/code/modules/mob/living/human/examine.dm
+++ b/code/modules/mob/living/human/examine.dm
@@ -268,13 +268,13 @@
 	return
 
 /mob/living/human/getHUDsource(hudtype)
-	var/obj/item/clothing/glasses/pronouns = get_equipped_item(slot_glasses_str)
-	if(!istype(pronouns))
+	var/obj/item/clothing/glasses/glasses = get_equipped_item(slot_glasses_str)
+	if(!istype(glasses))
 		return ..()
-	if(pronouns.glasses_hud_type & hudtype)
-		return pronouns
-	if(pronouns.hud && (pronouns.hud.glasses_hud_type & hudtype))
-		return pronouns.hud
+	if(glasses.glasses_hud_type & hudtype)
+		return glasses
+	if(glasses.hud && (glasses.hud.glasses_hud_type & hudtype))
+		return glasses.hud
 
 /mob/living/silicon/robot/getHUDsource(hudtype)
 	for(var/obj/item/borg/sight/sight in list(module_state_1, module_state_2, module_state_3))

--- a/code/modules/mob/living/human/human.dm
+++ b/code/modules/mob/living/human/human.dm
@@ -84,9 +84,9 @@
 	. = ..()
 	if(statpanel("Status"))
 
-		var/obj/item/gps/pronouns = get_active_held_item()
-		if(istype(pronouns))
-			stat("Coordinates:", "[pronouns.get_coordinates()]")
+		var/obj/item/gps/gps = get_active_held_item()
+		if(istype(gps))
+			stat("Coordinates:", "[gps.get_coordinates()]")
 
 		stat("Intent:", "[a_intent]")
 		stat("Move Mode:", "[move_intent.name]")

--- a/code/modules/mob/living/human/human_verbs.dm
+++ b/code/modules/mob/living/human/human_verbs.dm
@@ -97,8 +97,8 @@
 		target.show_message("<span class='notice'>You hear a voice that seems to echo around the room: [say]</span>")
 	usr.show_message("<span class='notice'>You project your mind into [target.real_name]: [say]</span>")
 	log_say("[key_name(usr)] sent a telepathic message to [key_name(target)]: [say]")
-	for(var/mob/observer/ghost/pronouns in global.player_list)
-		pronouns.show_message("<i>Telepathic message from <b>[src]</b> to <b>[target]</b>: [say]</i>")
+	for(var/mob/observer/ghost/ghost in global.player_list)
+		ghost.show_message("<i>Telepathic message from <b>[src]</b> to <b>[target]</b>: [say]</i>")
 
 /mob/living/human/proc/remoteobserve()
 	set name = "Remote View"

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -286,8 +286,8 @@
 /mob/living/silicon/robot/drone/proc/request_player()
 	if(too_many_active_drones())
 		return
-	var/decl/ghosttrap/pronouns = GET_DECL(/decl/ghosttrap/maintenance_drone)
-	pronouns.request_player(src, "Someone is attempting to reboot a maintenance drone.", 30 SECONDS)
+	var/decl/ghosttrap/ghosttrap = GET_DECL(/decl/ghosttrap/maintenance_drone)
+	ghosttrap.request_player(src, "Someone is attempting to reboot a maintenance drone.", 30 SECONDS)
 
 /mob/living/silicon/robot/drone/proc/transfer_personality(var/client/player)
 	if(!player) return

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -329,8 +329,8 @@
 		var/prot = FALSE
 		var/mob/living/human/H = user
 		if(istype(H))
-			var/obj/item/clothing/gloves/pronouns = H.get_equipped_item(slot_gloves_str)
-			if(istype(pronouns) && pronouns.max_heat_protection_temperature > LIGHT_BULB_TEMPERATURE)
+			var/obj/item/clothing/gloves/gloves = H.get_equipped_item(slot_gloves_str)
+			if(istype(gloves) && gloves.max_heat_protection_temperature > LIGHT_BULB_TEMPERATURE)
 				prot = TRUE
 
 		if(prot > 0 || user.has_genetic_condition(GENE_COND_COLD_RESISTANCE))


### PR DESCRIPTION
Fixes cases where variables were accidentally renamed to `pronouns` incorrectly (because `var/decl/pronouns/G` was really common). Also moves ghosts opening storage on an atom to atom-level.