### PR TITLE
Augments now keep their intended material costs and don't end up full of meat.

### DIFF
--- a/code/modules/augment/active/armblades.dm
+++ b/code/modules/augment/active/armblades.dm
@@ -24,6 +24,8 @@
 	//Limited to robolimbs
 	augment_flags = AUGMENTATION_MECHANIC
 	material = /decl/material/solid/metal/steel
+
+/obj/item/organ/internal/augment/active/simple/armblade/reset_matter()
 	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
 
 /obj/item/armblade/claws
@@ -44,4 +46,6 @@
 	//Limited to robolimbs
 	augment_flags = AUGMENTATION_MECHANIC
 	material = /decl/material/solid/metal/steel
+
+/obj/item/organ/internal/augment/active/simple/wolverine/reset_matter()
 	matter = list(/decl/material/solid/gemstone/diamond = MATTER_AMOUNT_REINFORCEMENT)

--- a/code/modules/augment/active/tool/engineering.dm
+++ b/code/modules/augment/active/tool/engineering.dm
@@ -3,7 +3,6 @@
 	action_button_name = "Deploy Engineering Tool"
 	desc = "A lightweight augmentation for the engineer on-the-go. This one comes with a series of common tools."
 	material = /decl/material/solid/metal/steel
-	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
 	paths = list(
 		/obj/item/screwdriver/finger,
 		/obj/item/wrench/finger,
@@ -13,6 +12,9 @@
 		/obj/item/multitool/finger
 	)
 	origin_tech = @'{"materials":4,"magnets":3,"engineering":3}'
+
+/obj/item/organ/internal/augment/active/polytool/engineer/reset_matter()
+	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
 
 /obj/item/weldingtool/finger
 	name = "digital welder"

--- a/code/modules/augment/active/tool/surgical.dm
+++ b/code/modules/augment/active/tool/surgical.dm
@@ -3,10 +3,6 @@
 	action_button_name = "Deploy Surgical Tool"
 	desc = "Part of a line of biomedical augmentations, this device contains the full set of tools any surgeon would ever need."
 	material = /decl/material/solid/metal/steel
-	matter = list(
-		/decl/material/solid/fiberglass = MATTER_AMOUNT_SECONDARY,
-		/decl/material/solid/metal/silver = MATTER_AMOUNT_REINFORCEMENT
-	)
 	paths = list(
 		/obj/item/bonesetter,
 		/obj/item/cautery,
@@ -17,3 +13,9 @@
 		/obj/item/surgicaldrill
 	)
 	origin_tech = @'{"materials":4,"magnets":3,"engineering":3}'
+
+/obj/item/organ/internal/augment/active/polytool/surgical/reset_matter()
+	matter = list(
+		/decl/material/solid/fiberglass = MATTER_AMOUNT_SECONDARY,
+		/decl/material/solid/metal/silver = MATTER_AMOUNT_REINFORCEMENT
+	)

--- a/code/modules/augment/augment.dm
+++ b/code/modules/augment/augment.dm
@@ -16,7 +16,9 @@
 /obj/item/organ/internal/augment/Initialize()
 	. = ..()
 	organ_tag = pick(allowed_organs)
+	set_bodytype(/decl/bodytype/prosthetic/augment)
 	update_parent_organ()
+	reagents?.clear_reagents() // Removing meat from the reagents list.
 
 /obj/item/organ/internal/augment/attackby(obj/item/W, mob/user)
 	if(IS_SCREWDRIVER(W) && allowed_organs.len > 1)

--- a/code/modules/augment/passive/armor.dm
+++ b/code/modules/augment/passive/armor.dm
@@ -4,7 +4,9 @@
 	icon_state = "armor-chest"
 	desc = "A flexible composite mesh designed to prevent tearing and puncturing of underlying tissue."
 	material = /decl/material/solid/metal/steel
-	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
 	origin_tech = @'{"materials":4,"engineering":2,"biotech":3}'
 	var/brute_mult = 0.8
 	var/burn_mult = 1
+
+/obj/item/organ/internal/augment/armor/reset_matter()
+	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)

--- a/code/modules/augment/passive/boost/muscle.dm
+++ b/code/modules/augment/passive/boost/muscle.dm
@@ -9,9 +9,11 @@
 	icon_state = "muscule"
 	desc = "Nanofiber tendons powered by an array of actuators to help the wearer mantain speed even while encumbered. You may want to install these in pairs to see a result."
 	material = /decl/material/solid/metal/steel
-	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
 	origin_tech = @'{"materials":4,"magnets":3,"biotech":3}'
 	var/obj/item/organ/internal/augment/boost/muscle/other //we need two for these
+
+/obj/item/organ/internal/augment/boost/muscle/reset_matter()
+	matter = list(/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT)
 
 /obj/item/organ/internal/augment/boost/muscle/on_add_effects()
 	. = ..()

--- a/code/modules/augment/passive/boost/reflex.dm
+++ b/code/modules/augment/passive/boost/reflex.dm
@@ -4,11 +4,13 @@
 	buffs = list(SKILL_COMBAT = 1)
 	injury_debuffs = list(SKILL_COMBAT = -1)
 	material = /decl/material/solid/metal/steel
+	origin_tech = @'{"materials":2,"magnets":3,"programming":5,"biotech":2}'
+
+/obj/item/organ/internal/augment/boost/reflex/reset_matter()
 	matter = list(
 		/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/metal/silver = MATTER_AMOUNT_TRACE
 	)
-	origin_tech = @'{"materials":2,"magnets":3,"programming":5,"biotech":2}'
 
 /obj/item/organ/internal/augment/boost/reflex/buff()
 	if((. = ..()))

--- a/code/modules/augment/passive/boost/shooting.dm
+++ b/code/modules/augment/passive/boost/shooting.dm
@@ -4,11 +4,13 @@
 	buffs = list(SKILL_WEAPONS = 1)
 	injury_debuffs = list(SKILL_WEAPONS = -1)
 	material = /decl/material/solid/metal/steel
+	origin_tech = @'{"materials":4,"magnets":3,"biotech":3}'
+
+/obj/item/organ/internal/augment/boost/reflex/reset_matter()
 	matter = list(
 		/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/metal/silver = MATTER_AMOUNT_TRACE
 	)
-	origin_tech = @'{"materials":4,"magnets":3,"biotech":3}'
 
 /obj/item/organ/internal/augment/boost/reflex/buff()
 	if((. = ..()))

--- a/code/modules/augment/passive/nanoaura.dm
+++ b/code/modules/augment/passive/nanoaura.dm
@@ -15,15 +15,16 @@
 	desc = "Nanomachines, son."
 	action_button_name = "Toggle Nanomachines"
 	material = /decl/material/solid/metal/steel
+	origin_tech = @'{"materials":4,"magnets":4,"engineering":5,"biotech":3}'
+	var/obj/aura/nanoaura/aura = null
+	var/charges = 4
+
+/obj/item/organ/internal/augment/active/nanounit/reset_matter()
 	matter = list(
 		/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/metal/gold = MATTER_AMOUNT_TRACE,
 		/decl/material/solid/metal/uranium = MATTER_AMOUNT_TRACE
 	)
-	origin_tech = @'{"materials":4,"magnets":4,"engineering":5,"biotech":3}'
-
-	var/obj/aura/nanoaura/aura = null
-	var/charges = 4
 
 /obj/item/organ/internal/augment/active/nanounit/on_add_effects()
 	. = ..()

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -37,6 +37,9 @@
 	/// Set to true if this organ should return info to Stat(). See get_stat_info().
 	var/has_stat_info
 
+/obj/item/organ/proc/reset_matter()
+	matter = null
+
 /obj/item/organ/Destroy()
 	if(owner)
 		owner.remove_organ(src, FALSE, FALSE, TRUE, TRUE, FALSE) //Tell our parent we're unisntalling in place
@@ -141,9 +144,16 @@
 	max_damage *= bodytype.hardiness
 	min_broken_damage *= bodytype.hardiness
 	bodytype.resize_organ(src)
-	set_material(override_material || bodytype.material)
-	matter = bodytype.matter?.Copy()
+
+	reset_matter()
+	set_material(override_material || bodytype.organ_material)
+	for(var/mat in bodytype.matter)
+		if(mat in matter)
+			matter[mat] += bodytype.matter[mat]
+		else
+			LAZYSET(matter, mat, bodytype.matter[mat])
 	create_matter()
+
 	// maybe this should be a generalized repopulate_reagents helper??
 	if(reagents)
 		reagents.clear_reagents()

--- a/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
+++ b/code/modules/organs/prosthetics/prosthetics_manufacturer.dm
@@ -6,11 +6,12 @@
 	modifier_string = "robotic"
 	is_robotic = TRUE
 	body_flags = BODY_FLAG_NO_DNA | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS | BODY_FLAG_NO_PAIN | BODY_FLAG_NO_EAT
-	material = /decl/material/solid/metal/steel
+	organ_material = /decl/material/solid/metal/steel
 	appearance_flags = HAS_EYE_COLOR
 	eye_flash_mod = 1
 	eye_darksight_range = 2
 	associated_gender = null
+	edible_reagent = null
 	emote_sounds = list(
 		"whistle" = list('sound/voice/emotes/longwhistle_robot.ogg'),
 		"qwhistle" = list('sound/voice/emotes/shortwhistle_robot.ogg'),

--- a/code/modules/organs/prosthetics/prosthetics_manufacturer_models.dm
+++ b/code/modules/organs/prosthetics/prosthetics_manufacturer_models.dm
@@ -15,8 +15,13 @@
 	is_robotic = FALSE
 	modular_limb_tier = MODULAR_BODYPART_ANYWHERE
 	bodytype_category = BODYTYPE_HUMANOID
-	material = /decl/material/solid/organic/wood
+	organ_material = /decl/material/solid/organic/wood
 	required_map_tech = MAP_TECH_LEVEL_MEDIEVAL
 	uid = "bodytype_prosthetic_wooden"
 
 DEFINE_ROBOLIMB_MODEL_TRAITS(/decl/bodytype/prosthetic/wooden, pirate, 0, "wooden")
+
+// Dummy/stub prosthetic type for augment implants.
+/decl/bodytype/prosthetic/augment
+	name = "Augment"
+	uid = "bodytype_prosthetic_augment"

--- a/code/modules/species/species_bodytype.dm
+++ b/code/modules/species/species_bodytype.dm
@@ -116,7 +116,7 @@ var/global/list/bodytypes_by_category = list()
 	var/base_eye_color =  COLOR_BLACK
 
 	/// Used to initialize organ material
-	var/material =        /decl/material/solid/organic/meat
+	var/organ_material = /decl/material/solid/organic/meat
 	/// Used to initialize organ matter
 	var/list/matter =     null
 	/// The reagent organs are filled with, which currently affects what mobs that eat the organ will receive.
@@ -717,7 +717,7 @@ var/global/list/bodytypes_by_category = list()
 	for(var/obj/item/organ/internal/innard in limb.internal_organs)
 		var/obj/item/organ/internal/organ_prototype = replacing_organs[innard.organ_tag]
 		if(organ_prototype && istype(innard, organ_prototype))
-			innard.set_bodytype(type, override_material || material)
+			innard.set_bodytype(type, override_material || organ_material)
 			replacing_organs -= innard.organ_tag
 		else
 			limb.owner.remove_organ(innard, FALSE, FALSE, TRUE, TRUE, FALSE)

--- a/code/modules/species/species_crystalline_bodytypes.dm
+++ b/code/modules/species/species_crystalline_bodytypes.dm
@@ -7,7 +7,7 @@
 	abstract_type = /decl/bodytype/crystalline
 	limb_tech = @'{"materials":4}'
 	is_robotic = FALSE
-	material = /decl/material/solid/gemstone/crystal
+	organ_material = /decl/material/solid/gemstone/crystal
 	body_flags = BODY_FLAG_CRYSTAL_REFORM | BODY_FLAG_NO_DNA | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 	cold_level_1 = SYNTH_COLD_LEVEL_1
 	cold_level_2 = SYNTH_COLD_LEVEL_2

--- a/mods/content/corporate/datum/robolimbs.dm
+++ b/mods/content/corporate/datum/robolimbs.dm
@@ -3,7 +3,7 @@
 	desc = "This limb has a white polymer casing with blue holo-displays."
 	icon_base = 'mods/content/corporate/icons/cyberlimbs/bishop/bishop_main.dmi'
 	bodytype_category = BODYTYPE_HUMANOID
-	material = /decl/material/solid/metal/aluminium
+	organ_material = /decl/material/solid/metal/aluminium
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_SECONDARY
 	)
@@ -15,7 +15,7 @@
 	icon_base = 'mods/content/corporate/icons/cyberlimbs/bishop/bishop_rook.dmi'
 	has_eyes = FALSE
 	bodytype_category = BODYTYPE_HUMANOID
-	material = /decl/material/solid/metal/steel
+	organ_material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/metal/stainlesssteel = MATTER_AMOUNT_SECONDARY
 	)
@@ -41,7 +41,7 @@
 	desc = "This limb has a sleek black and white polymer finish."
 	icon_base = 'mods/content/corporate/icons/cyberlimbs/zenghu/zenghu_spirit.dmi'
 	bodytype_category = BODYTYPE_HUMANOID
-	material = /decl/material/solid/metal/aluminium
+	organ_material = /decl/material/solid/metal/aluminium
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_SECONDARY
 	)
@@ -52,7 +52,7 @@
 	desc = "This skeletal mechanical limb has a minimalist black and red casing."
 	icon_base = 'mods/content/corporate/icons/cyberlimbs/xion/xion_econo.dmi'
 	bodytype_category = BODYTYPE_HUMANOID
-	material = /decl/material/solid/metal/aluminium
+	organ_material = /decl/material/solid/metal/aluminium
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_SECONDARY
 	)
@@ -64,7 +64,7 @@
 	icon_base = 'mods/content/corporate/icons/cyberlimbs/wardtakahashi/wardtakahashi_main.dmi'
 	body_flags = BODY_FLAG_NO_DNA | BODY_FLAG_NO_PAIN | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 	bodytype_category = BODYTYPE_HUMANOID
-	material = /decl/material/solid/metal/aluminium
+	organ_material = /decl/material/solid/metal/aluminium
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_SECONDARY
 	)
@@ -81,7 +81,7 @@
 	desc = "This limb is simple and functional; no effort has been made to make it look human."
 	icon_base = 'mods/content/corporate/icons/cyberlimbs/morpheus/morpheus_main.dmi'
 	bodytype_category = BODYTYPE_HUMANOID
-	material = /decl/material/solid/metal/steel
+	organ_material = /decl/material/solid/metal/steel
 	uid = "bodytype_prosthetic_morpheus"
 
 /decl/bodytype/prosthetic/morpheus/mantis
@@ -99,7 +99,7 @@
 	body_flags = BODY_FLAG_NO_DNA | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 	bodytype_category = BODYTYPE_HUMANOID
 	// todo: add synthflesh material?
-	material = /decl/material/solid/metal/aluminium
+	organ_material = /decl/material/solid/metal/aluminium
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_SECONDARY
 	)
@@ -123,7 +123,7 @@
 	desc = "This limb has a minimalist black and red casing."
 	icon_base = 'mods/content/corporate/icons/cyberlimbs/xion/xion_main.dmi'
 	bodytype_category = BODYTYPE_HUMANOID
-	material = /decl/material/solid/metal/aluminium
+	organ_material = /decl/material/solid/metal/aluminium
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_SECONDARY
 	)
@@ -134,7 +134,7 @@
 	desc = "This limb is made from a cheap polymer."
 	icon_base = 'mods/content/corporate/icons/cyberlimbs/nanotrasen/nanotrasen_main.dmi'
 	bodytype_category = BODYTYPE_HUMANOID
-	material = /decl/material/solid/organic/plastic
+	organ_material = /decl/material/solid/organic/plastic
 	uid = "bodytype_prosthetic_nanotrasen"
 
 DEFINE_ROBOLIMB_DESIGNS(/decl/bodytype/prosthetic/shellguard,                 shellguard)

--- a/mods/species/utility_frames/species_bodytypes.dm
+++ b/mods/species/utility_frames/species_bodytypes.dm
@@ -10,7 +10,7 @@
 	body_flags =        BODY_FLAG_NO_PAIN | BODY_FLAG_NO_DNA | BODY_FLAG_NO_DEFIB | BODY_FLAG_NO_STASIS
 	base_color = "#333355"
 	base_eye_color = "#00ccff"
-	material = /decl/material/solid/metal/steel
+	organ_material = /decl/material/solid/metal/steel
 	vital_organs = list(
 		BP_BRAIN,
 		BP_CELL


### PR DESCRIPTION
- Fixes #4622.
- Fixes #4588.
- Sets prosthetic edible reagent to null.
- Reworks organ matter to preserve augment material costs/matter lists.