### PR TITLE
Fantasy modpack: Crutch in loadout

### DIFF
--- a/mods/content/fantasy/items/clothing/_loadout.dm
+++ b/mods/content/fantasy/items/clothing/_loadout.dm
@@ -288,6 +288,18 @@
 		"white wine" =  /decl/material/liquid/ethanol/wine/premium,
 	))
 
+/decl/loadout_option/fantasy/utility/crutch
+	name = "crutch"
+	path = /obj/item/crutch/wooden/padded
+	available_materials = list(
+		/decl/material/solid/organic/wood/oak,
+		/decl/material/solid/organic/wood/mahogany,
+		/decl/material/solid/organic/wood/maple,
+		/decl/material/solid/organic/wood/ebony,
+		/decl/material/solid/organic/wood/walnut
+	)
+	uid = "gear_fantasy_crutch"
+
 /decl/loadout_option/fantasy/eyes
 	abstract_type = /decl/loadout_option/fantasy/eyes
 	slot = slot_glasses_str


### PR DESCRIPTION

## Description of changes
Adds a wooden crutch to the loadout on fantasy maps.

## Why and what will this PR improve
Good to have for roleplay, something a character might have when arriving

## Authorship
Myself

## Changelog
:cl:
add: Adds a wooden crutch to the fantasy loadout
/:cl:
