### PR TITLE
Remove unnecessary uses of usr

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -60,7 +60,7 @@
 
 	if(silicon_camera.in_camera_mode)
 		silicon_camera.camera_mode_off()
-		silicon_camera.captureimage(A, usr)
+		silicon_camera.captureimage(A, src)
 		return
 
 	A.add_hiddenprint(src)
@@ -118,10 +118,10 @@
 	I have no idea why it was in atoms.dm instead of respective files.
 */
 
-/atom/proc/AICtrlAltClick()
+/atom/proc/AICtrlAltClick(mob/living/silicon/user)
 
-/obj/machinery/door/airlock/AICtrlAltClick() // Electrifies doors.
-	if(usr.incapacitated())
+/obj/machinery/door/airlock/AICtrlAltClick(mob/living/silicon/user) // Electrifies doors.
+	if(user.incapacitated())
 		return
 	if(!electrified_until)
 		// permanent shock
@@ -131,14 +131,14 @@
 		Topic(src, list("command"="electrify_permanently", "activate" = "0"))
 	return 1
 
-/atom/proc/AICtrlShiftClick()
+/atom/proc/AICtrlShiftClick(mob/living/silicon/user)
 	return
 
-/atom/proc/AIShiftClick()
+/atom/proc/AIShiftClick(mob/living/silicon/user)
 	return
 
-/obj/machinery/door/airlock/AIShiftClick()  // Opens and closes doors!
-	if(usr.incapacitated())
+/obj/machinery/door/airlock/AIShiftClick(mob/living/silicon/user)  // Opens and closes doors!
+	if(user.incapacitated())
 		return
 	if(density)
 		Topic(src, list("command"="open", "activate" = "1"))
@@ -146,11 +146,11 @@
 		Topic(src, list("command"="open", "activate" = "0"))
 	return 1
 
-/atom/proc/AICtrlClick()
+/atom/proc/AICtrlClick(mob/living/silicon/user)
 	return FALSE
 
-/obj/machinery/door/airlock/AICtrlClick() // Bolts doors
-	if(usr.incapacitated())
+/obj/machinery/door/airlock/AICtrlClick(mob/living/silicon/user) // Bolts doors
+	if(user.incapacitated())
 		return FALSE
 	if(locked)
 		Topic(src, list("command"="bolts", "activate" = "0"))
@@ -158,35 +158,35 @@
 		Topic(src, list("command"="bolts", "activate" = "1"))
 	return TRUE
 
-/obj/machinery/power/apc/AICtrlClick() // turns off/on APCs.
-	if(usr.incapacitated())
+/obj/machinery/power/apc/AICtrlClick(mob/living/silicon/user) // turns off/on APCs.
+	if(user.incapacitated())
 		return FALSE
 	Topic(src, list("breaker"="1"))
 	return TRUE
 
-/obj/machinery/turretid/AICtrlClick() //turns off/on Turrets
-	if(usr.incapacitated())
+/obj/machinery/turretid/AICtrlClick(mob/living/silicon/user) //turns off/on Turrets
+	if(user.incapacitated())
 		return FALSE
 	Topic(src, list("command"="enable", "value"="[!enabled]"))
 	return TRUE
 
-/atom/proc/AIAltClick(var/atom/A)
-	return AltClick(A)
+/atom/proc/AIAltClick(mob/living/silicon/user)
+	return AltClick(user)
 
-/obj/machinery/turretid/AIAltClick() //toggles lethal on turrets
-	if(usr.incapacitated())
+/obj/machinery/turretid/AIAltClick(mob/living/silicon/user) //toggles lethal on turrets
+	if(user.incapacitated())
 		return
 	Topic(src, list("command"="lethal", "value"="[!lethal]"))
 	return 1
 
-/obj/machinery/atmospherics/binary/pump/AIAltClick()
-	return AltClick()
+/obj/machinery/atmospherics/binary/pump/AIAltClick(mob/living/silicon/user)
+	return AltClick(user)
 
 /atom/proc/AIMiddleClick(var/mob/living/silicon/user)
 	return 0
 
-/obj/machinery/door/airlock/AIMiddleClick() // Toggles door bolt lights.
-	if(usr.incapacitated())
+/obj/machinery/door/airlock/AIMiddleClick(mob/living/silicon/user) // Toggles door bolt lights.
+	if(user.incapacitated())
 		return
 	if(..())
 		return

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -108,7 +108,7 @@
 	if(holding == A) // Handle attack_self
 		holding.attack_self(src)
 		trigger_aiming(TARGET_CAN_CLICK)
-		usr.update_inhand_overlays(FALSE)
+		update_inhand_overlays(FALSE)
 		return 1
 
 	//Atoms on your person

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -42,9 +42,9 @@
 	if(silicon_camera.in_camera_mode)
 		silicon_camera.camera_mode_off()
 		if(is_component_functioning("camera"))
-			silicon_camera.captureimage(A, usr)
+			silicon_camera.captureimage(A, src)
 		else
-			to_chat(src, "<span class='danger'>Your camera isn't functional.</span>")
+			to_chat(src, SPAN_DANGER("Your camera isn't functional."))
 		return
 
 	var/obj/item/holding = get_active_held_item()
@@ -111,42 +111,39 @@
 /atom/proc/BorgCtrlShiftClick(var/mob/living/silicon/robot/user) //forward to human click if not overriden
 	CtrlShiftClick(user)
 
-/obj/machinery/door/airlock/BorgCtrlShiftClick()
-	AICtrlShiftClick()
+/obj/machinery/door/airlock/BorgCtrlShiftClick(mob/living/silicon/robot/user)
+	AICtrlShiftClick(user)
 
 /atom/proc/BorgShiftClick(var/mob/living/silicon/robot/user) //forward to human click if not overriden
 	ShiftClick(user)
 
-/obj/machinery/door/airlock/BorgShiftClick()  // Opens and closes doors! Forwards to AI code.
-	AIShiftClick()
+/obj/machinery/door/airlock/BorgShiftClick(mob/living/silicon/robot/user)  // Opens and closes doors! Forwards to AI code.
+	AIShiftClick(user)
 
 /atom/proc/BorgCtrlClick(var/mob/living/silicon/robot/user) //forward to human click if not overriden
 	return CtrlClick(user)
 
-/obj/machinery/door/airlock/BorgCtrlClick() // Bolts doors. Forwards to AI code.
-	return AICtrlClick()
+/obj/machinery/door/airlock/BorgCtrlClick(mob/living/silicon/robot/user) // Bolts doors. Forwards to AI code.
+	return AICtrlClick(user)
 
-/obj/machinery/power/apc/BorgCtrlClick() // turns off/on APCs. Forwards to AI code.
-	return AICtrlClick()
+/obj/machinery/power/apc/BorgCtrlClick(mob/living/silicon/robot/user) // turns off/on APCs. Forwards to AI code.
+	return AICtrlClick(user)
 
-/obj/machinery/turretid/BorgCtrlClick() //turret control on/off. Forwards to AI code.
-	return AICtrlClick()
+/obj/machinery/turretid/BorgCtrlClick(mob/living/silicon/robot/user) //turret control on/off. Forwards to AI code.
+	return AICtrlClick(user)
 
 /atom/proc/BorgAltClick(var/mob/living/silicon/robot/user)
 	AltClick(user)
 	return
 
-/obj/machinery/door/airlock/BorgAltClick() // Eletrifies doors. Forwards to AI code.
-	if (!usr.check_intent(I_FLAG_HELP))
-		AICtrlAltClick()
+/obj/machinery/door/airlock/BorgAltClick(mob/living/silicon/robot/user) // Eletrifies doors. Forwards to AI code.
+	if (!user.check_intent(I_FLAG_HELP))
+		AICtrlAltClick(user)
 	else
 		..()
 
-/obj/machinery/turretid/BorgAltClick() //turret lethal on/off. Forwards to AI code.
-	AIAltClick()
-
-/obj/machinery/atmospherics/binary/pump/BorgAltClick()
-	return AltClick()
+/obj/machinery/turretid/BorgAltClick(mob/living/silicon/robot/user) //turret lethal on/off. Forwards to AI code.
+	AIAltClick(user)
 
 /atom/proc/BorgCtrlAltClick(var/mob/living/silicon/robot/user)
 	CtrlAltClick(user)

--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -78,7 +78,7 @@
 				Deactivate()
 		if(AB_GENERIC)
 			if(target && procname)
-				call(target,procname)(usr)
+				call(target,procname)(owner)
 	return
 
 /datum/action/proc/Activate()

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -96,11 +96,11 @@ var/global/obj/screen/robot_inventory
 			R.active_storage.close(R) //Closes the inventory ui.
 
 		if(!R.module)
-			to_chat(usr, SPAN_WARNING("No module selected."))
+			to_chat(R, SPAN_WARNING("No module selected."))
 			return
 
 		if(!R.module.equipment)
-			to_chat(usr, SPAN_WARNING("Selected module has no equipment available."))
+			to_chat(R, SPAN_WARNING("Selected module has no equipment available."))
 			return
 
 		if(!R.robot_modules_background)

--- a/code/_onclick/hud/screen/screen_ai_button.dm
+++ b/code/_onclick/hud/screen/screen_ai_button.dm
@@ -8,9 +8,9 @@
 	var/image/template_undelay
 
 /obj/screen/ai_button/handle_click(mob/user, params)
-	if(!isAI(usr))
+	if(!isAI(user))
 		return TRUE
-	var/mob/living/silicon/ai/A = usr
+	var/mob/living/silicon/ai/A = user
 	if(!(ai_verb in A.verbs))
 		return TRUE
 

--- a/code/_onclick/hud/screen/screen_equip.dm
+++ b/code/_onclick/hud/screen/screen_equip.dm
@@ -3,6 +3,6 @@
 	icon_state = "act_equip"
 
 /obj/screen/equip/handle_click(mob/user, params)
-	if(ishuman(usr))
-		var/mob/living/human/H = usr
+	if(ishuman(user))
+		var/mob/living/human/H = user
 		H.quick_equip()

--- a/code/_onclick/hud/screen/screen_exosuit.dm
+++ b/code/_onclick/hud/screen/screen_exosuit.dm
@@ -340,19 +340,19 @@
 		toggled = owner.head.active_sensors
 	. = ..()
 
-/obj/screen/exosuit/toggle/camera/toggled()
+/obj/screen/exosuit/toggle/camera/toggled(mob/user)
 	var/mob/living/exosuit/owner = get_owning_exosuit()
 	if(!istype(owner) || !owner.head)
-		to_chat(usr, SPAN_WARNING("I/O Error: Camera systems not found."))
+		to_chat(user, SPAN_WARNING("I/O Error: Camera systems not found."))
 		return
 	if(!owner.head.vision_flags)
-		to_chat(usr,  SPAN_WARNING("Alternative sensor configurations not found. Contact manufacturer for more details."))
+		to_chat(user,  SPAN_WARNING("Alternative sensor configurations not found. Contact manufacturer for more details."))
 		return
 	if(!owner.get_cell())
-		to_chat(usr,  SPAN_WARNING("The augmented vision systems are offline."))
+		to_chat(user,  SPAN_WARNING("The augmented vision systems are offline."))
 		return
 	owner.head.active_sensors = ..()
-	to_chat(usr, SPAN_NOTICE("[owner.head.name] advanced sensor mode is [owner.head.active_sensors ? "now" : "no longer" ] active."))
+	to_chat(user, SPAN_NOTICE("[owner.head.name] advanced sensor mode is [owner.head.active_sensors ? "now" : "no longer" ] active."))
 
 /obj/screen/exosuit/needle
 	vis_flags = VIS_INHERIT_ID

--- a/code/_onclick/hud/screen/screen_inventory.dm
+++ b/code/_onclick/hud/screen/screen_inventory.dm
@@ -55,7 +55,7 @@
 
 	// Mark anything we're potentially trying to equip.
 	var/obj/item/mouse_over_atom = mouse_over_atom_ref?.resolve()
-	if(istype(mouse_over_atom) && !QDELETED(mouse_over_atom) && !usr.get_equipped_item(slot_id))
+	if(istype(mouse_over_atom) && !QDELETED(mouse_over_atom) && !owner.get_equipped_item(slot_id))
 		var/mutable_appearance/MA = new /mutable_appearance(mouse_over_atom)
 		MA.layer   = HUD_ABOVE_ITEM_LAYER
 		MA.plane   = HUD_PLANE

--- a/code/_onclick/hud/screen/screen_needs.dm
+++ b/code/_onclick/hud/screen/screen_needs.dm
@@ -12,15 +12,15 @@
 	if(user.nutrition_icon == src)
 		switch(icon_state)
 			if("nutrition0")
-				to_chat(usr, SPAN_WARNING("You are completely stuffed."))
+				to_chat(user, SPAN_WARNING("You are completely stuffed."))
 			if("nutrition1")
-				to_chat(usr, SPAN_NOTICE("You are not hungry."))
+				to_chat(user, SPAN_NOTICE("You are not hungry."))
 			if("nutrition2")
-				to_chat(usr, SPAN_NOTICE("You are a bit peckish."))
+				to_chat(user, SPAN_NOTICE("You are a bit peckish."))
 			if("nutrition3")
-				to_chat(usr, SPAN_WARNING("You are quite hungry."))
+				to_chat(user, SPAN_WARNING("You are quite hungry."))
 			if("nutrition4")
-				to_chat(usr, SPAN_DANGER("You are starving!"))
+				to_chat(user, SPAN_DANGER("You are starving!"))
 
 /obj/screen/drink
 	name = "hydration"
@@ -32,15 +32,15 @@
 	if(user.hydration_icon == src)
 		switch(icon_state)
 			if("hydration0")
-				to_chat(usr, SPAN_WARNING("You are overhydrated."))
+				to_chat(user, SPAN_WARNING("You are overhydrated."))
 			if("hydration1")
-				to_chat(usr, SPAN_NOTICE("You are not thirsty."))
+				to_chat(user, SPAN_NOTICE("You are not thirsty."))
 			if("hydration2")
-				to_chat(usr, SPAN_NOTICE("You are a bit thirsty."))
+				to_chat(user, SPAN_NOTICE("You are a bit thirsty."))
 			if("hydration3")
-				to_chat(usr, SPAN_WARNING("You are quite thirsty."))
+				to_chat(user, SPAN_WARNING("You are quite thirsty."))
 			if("hydration4")
-				to_chat(usr, SPAN_DANGER("You are dying of thirst!"))
+				to_chat(user, SPAN_DANGER("You are dying of thirst!"))
 
 /obj/screen/bodytemp
 	name = "body temperature"
@@ -52,23 +52,23 @@
 	if(user.bodytemp == src)
 		switch(icon_state)
 			if("temp4")
-				to_chat(usr, SPAN_DANGER("You are being cooked alive!"))
+				to_chat(user, SPAN_DANGER("You are being cooked alive!"))
 			if("temp3")
-				to_chat(usr, SPAN_DANGER("Your body is burning up!"))
+				to_chat(user, SPAN_DANGER("Your body is burning up!"))
 			if("temp2")
-				to_chat(usr, SPAN_DANGER("You are overheating."))
+				to_chat(user, SPAN_DANGER("You are overheating."))
 			if("temp1")
-				to_chat(usr, SPAN_WARNING("You are uncomfortably hot."))
+				to_chat(user, SPAN_WARNING("You are uncomfortably hot."))
 			if("temp-4")
-				to_chat(usr, SPAN_DANGER("You are being frozen solid!"))
+				to_chat(user, SPAN_DANGER("You are being frozen solid!"))
 			if("temp-3")
-				to_chat(usr, SPAN_DANGER("You are freezing cold!"))
+				to_chat(user, SPAN_DANGER("You are freezing cold!"))
 			if("temp-2")
-				to_chat(usr, SPAN_WARNING("You are dangerously chilled!"))
+				to_chat(user, SPAN_WARNING("You are dangerously chilled!"))
 			if("temp-1")
-				to_chat(usr, SPAN_NOTICE("You are uncomfortably cold."))
+				to_chat(user, SPAN_NOTICE("You are uncomfortably cold."))
 			else
-				to_chat(usr, SPAN_NOTICE("Your body is at a comfortable temperature."))
+				to_chat(user, SPAN_NOTICE("Your body is at a comfortable temperature."))
 
 /obj/screen/pressure
 	name = "pressure"
@@ -80,15 +80,15 @@
 	if(user.pressure == src)
 		switch(icon_state)
 			if("pressure2")
-				to_chat(usr, SPAN_DANGER("The air pressure here is crushing!"))
+				to_chat(user, SPAN_DANGER("The air pressure here is crushing!"))
 			if("pressure1")
-				to_chat(usr, SPAN_WARNING("The air pressure here is dangerously high."))
+				to_chat(user, SPAN_WARNING("The air pressure here is dangerously high."))
 			if("pressure-1")
-				to_chat(usr, SPAN_WARNING("The air pressure here is dangerously low."))
+				to_chat(user, SPAN_WARNING("The air pressure here is dangerously low."))
 			if("pressure-2")
-				to_chat(usr, SPAN_DANGER("There is nearly no air pressure here!"))
+				to_chat(user, SPAN_DANGER("There is nearly no air pressure here!"))
 			else
-				to_chat(usr, SPAN_NOTICE("The local air pressure is comfortable."))
+				to_chat(user, SPAN_NOTICE("The local air pressure is comfortable."))
 
 /obj/screen/toxins
 	name = "toxin"
@@ -99,9 +99,9 @@
 /obj/screen/toxins/handle_click(mob/user, params)
 	if(user.toxin == src)
 		if(icon_state == "tox0")
-			to_chat(usr, SPAN_NOTICE("The air is clear of toxins."))
+			to_chat(user, SPAN_NOTICE("The air is clear of toxins."))
 		else
-			to_chat(usr, SPAN_DANGER("The air is eating away at your skin!"))
+			to_chat(user, SPAN_DANGER("The air is eating away at your skin!"))
 
 /obj/screen/oxygen
 	name = "oxygen"
@@ -112,6 +112,6 @@
 /obj/screen/oxygen/handle_click(mob/user, params)
 	if(user.oxygen == src)
 		if(icon_state == "oxy0")
-			to_chat(usr, SPAN_NOTICE("You are breathing easy."))
+			to_chat(user, SPAN_NOTICE("You are breathing easy."))
 		else
-			to_chat(usr, SPAN_DANGER("You cannot breathe!"))
+			to_chat(user, SPAN_DANGER("You cannot breathe!"))

--- a/code/_onclick/hud/screen/screen_pai.dm
+++ b/code/_onclick/hud/screen/screen_pai.dm
@@ -68,7 +68,7 @@
 /obj/screen/pai/subsystems/handle_click(mob/user, params)
 	var/mob/living/silicon/pai/pai = user
 	if(istype(pai))
-		var/ss_name = input(usr, "Activates the given subsystem", "Subsystems", "") in pai.silicon_subsystems_by_name
+		var/ss_name = input(user, "Activates the given subsystem", "Subsystems", "") in pai.silicon_subsystems_by_name
 		if (!ss_name)
 			return
 		var/stat_silicon_subsystem/SSS = pai.silicon_subsystems_by_name[ss_name]

--- a/code/datums/communication/aooc.dm
+++ b/code/datums/communication/aooc.dm
@@ -30,7 +30,7 @@
 			receive_communication(C, target, SPAN_AOOC("<EM>[get_options_bar(C, 0, 1, 1)]:</EM> <span class='message'>[message]</span>"))
 		else if(target.mob?.mind?.assigned_special_role)
 			var/display_name = C.key
-			var/player_display = holder ? "[display_name]([usr.client.holder.rank])" : display_name
+			var/player_display = holder ? "[display_name]([C.holder.rank])" : display_name
 			receive_communication(C, target, SPAN_AOOC("<EM>[player_display]:</EM> <span class='message'>[message]</span>"))
 
 /decl/communication_channel/aooc/do_broadcast(message)

--- a/code/datums/extensions/assembly/assembly_interaction.dm
+++ b/code/datums/extensions/assembly/assembly_interaction.dm
@@ -20,7 +20,7 @@
 			return TRUE
 
 		to_chat(user, "You begin repairing damage to \the [holder]...")
-		if(WT.weld(round(damage/75)) && do_after(usr, damage/10))
+		if(WT.weld(round(damage/75)) && do_after(user, damage/10))
 			damage = 0
 			to_chat(user, "You repair \the [holder].")
 		return TRUE
@@ -33,11 +33,11 @@
 		for(var/obj/item/stock_parts/computer/H in parts)
 			component_names.Add(H.name)
 
-		var/choice = input(usr, "Which component do you want to uninstall?", "[assembly_name] maintenance", null) as null|anything in component_names
+		var/choice = input(user, "Which component do you want to uninstall?", "[assembly_name] maintenance", null) as null|anything in component_names
 		if(!choice)
 			return TRUE
 		var/atom/movable/HA = holder
-		if(!HA.Adjacent(usr))
+		if(!HA.Adjacent(user))
 			return TRUE
 
 		var/obj/item/stock_parts/H = find_component_by_name(choice)

--- a/code/datums/extensions/eye/landing.dm
+++ b/code/datums/extensions/eye/landing.dm
@@ -27,12 +27,12 @@
 
 /datum/action/eye/landing/rotate_cw
 	name = "Rotate clockwise"
-	procname ="turn_shuttle_cw"
+	procname = TYPE_PROC_REF(/mob/observer/eye/landing, turn_shuttle_cw)
 	button_icon_state = "shuttle_rotate_cw"
 	target_type = EYE_TARGET
 
 /datum/action/eye/landing/rotate_ccw
 	name = "Rotate counterclockwise"
-	procname ="turn_shuttle_ccw"
+	procname = TYPE_PROC_REF(/mob/observer/eye/landing, turn_shuttle_ccw)
 	button_icon_state = "shuttle_rotate_ccw"
 	target_type = EYE_TARGET

--- a/code/datums/extensions/holster/holster.dm
+++ b/code/datums/extensions/holster/holster.dm
@@ -82,7 +82,7 @@
 				G.check_accidents(user)
 				if(G.safety() && !user.skill_fail_prob(SKILL_WEAPONS, 100, SKILL_EXPERT, 0.5)) //Experienced shooter will disable safety before shooting.
 					G.toggle_safety(user)
-			usr.visible_message(
+			user.visible_message(
 				"<span class='danger'>\The [user] draws \the [holstered], ready to go!</span>",
 				"<span class='warning'>You draw \the [holstered], ready to go!</span>"
 				)

--- a/code/datums/extensions/multitool/multitool.dm
+++ b/code/datums/extensions/multitool/multitool.dm
@@ -13,7 +13,7 @@
 		popup.set_content(html)
 		popup.open()
 	else
-		close_window(usr)
+		close_window(user)
 
 /datum/extension/interactive/multitool/proc/get_interact_window(var/obj/item/multitool/M, var/mob/user)
 	return
@@ -36,7 +36,7 @@
 
 /datum/extension/interactive/multitool/extension_act(href, href_list, var/mob/user)
 	if(..())
-		close_window(usr)
+		close_window(user)
 		return TRUE
 
 	var/obj/item/multitool/M = user.get_multitool()

--- a/code/datums/extensions/storage/subtypes_sheets.dm
+++ b/code/datums/extensions/storage/subtypes_sheets.dm
@@ -44,10 +44,10 @@
 			inserted = 1
 			break
 	if(!inserted || !S.amount)
-		usr.drop_from_inventory(S, holder)
+		user.drop_from_inventory(S, holder)
 		if(!S.amount)
 			qdel(S)
-	prepare_ui(usr)
+	prepare_ui(user)
 	if(isatom(holder))
 		var/atom/atom_holder = holder
 		atom_holder.update_icon()
@@ -64,8 +64,8 @@
 		if(!S.amount)
 			qdel(S) // todo: there's probably something missing here
 	prepare_ui()
-	if(usr.active_storage)
-		usr.active_storage.show_to(usr)
+	if(user.active_storage)
+		user.active_storage.show_to(user)
 	if(isatom(holder))
 		var/atom/atom_holder = holder
 		atom_holder.update_icon()

--- a/code/datums/traits/_traits.dm
+++ b/code/datums/traits/_traits.dm
@@ -236,6 +236,8 @@
 			result += trait.get_trait_selection_data(caller, ticked_traits, (recurse_level+1), ignore_children_if_unticked)
 	return result
 
+/// Shows `show_to` a browser window describing the character setup traits taken by `src`.
+/// `show_to` must be non-null.
 /mob/proc/get_trait_data(var/mob/show_to)
 
 	var/list/traits = get_traits()
@@ -262,7 +264,7 @@
 		if(printed_cat)
 			dat += "<hr>"
 
-	var/datum/browser/popup = new((show_to || usr), "trait_summary_\ref[src]", "Aspect Summary")
+	var/datum/browser/popup = new(show_to, "trait_summary_\ref[src]", "Aspect Summary")
 	popup.set_content(jointext(dat, null))
 	popup.open()
 

--- a/code/game/machinery/CableLayer.dm
+++ b/code/game/machinery/CableLayer.dm
@@ -38,7 +38,7 @@
 
 	if(IS_WIRECUTTER(O))
 		if(cable && cable.amount)
-			var/m = round(input(usr,"Please specify the length of cable to cut","Cut cable",min(cable.amount,30)) as num, 1)
+			var/m = round(input(user,"Please specify the length of cable to cut","Cut cable",min(cable.amount,30)) as num, 1)
 			m = min(m, cable.amount)
 			m = min(m, 30)
 			if(m)
@@ -47,7 +47,7 @@
 				var/obj/item/stack/cable_coil/CC = new (get_turf(src))
 				CC.amount = m
 		else
-			to_chat(usr, "<span class='warning'>There's no more cable on the reel.</span>")
+			to_chat(user, "<span class='warning'>There's no more cable on the reel.</span>")
 		return TRUE
 	return ..()
 

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -248,7 +248,7 @@
 
 /obj/machinery/sleeper/CanUseTopic(user)
 	if(user == occupant)
-		to_chat(usr, SPAN_WARNING("You can't reach the controls from the inside."))
+		to_chat(user, SPAN_WARNING("You can't reach the controls from the inside."))
 		return STATUS_CLOSE
 	. = ..()
 

--- a/code/game/machinery/_machines_base/stock_parts/network_lock.dm
+++ b/code/game/machinery/_machines_base/stock_parts/network_lock.dm
@@ -183,7 +183,7 @@
 
 	if(href_list["add_pattern"])
 		if(length(groups) >= MAX_PATTERNS)
-			to_chat(usr, SPAN_WARNING("You cannot add more than [MAX_PATTERNS] patterns to \the [src]!"))
+			to_chat(user, SPAN_WARNING("You cannot add more than [MAX_PATTERNS] patterns to \the [src]!"))
 			return TOPIC_HANDLED
 		LAZYADD(groups, list(list()))
 		return TOPIC_REFRESH

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -221,7 +221,7 @@
 		return TOPIC_REFRESH
 
 	if(href_list["set_input_tag"])
-		var/t = sanitize_safe(input(usr, "Enter the input ID tag.", src.name, src.input_tag), MAX_NAME_LEN)
+		var/t = sanitize_safe(input(user, "Enter the input ID tag.", src.name, src.input_tag), MAX_NAME_LEN)
 		t = sanitize_safe(t, MAX_NAME_LEN)
 		if (t)
 			src.input_tag = t
@@ -229,7 +229,7 @@
 		return TOPIC_REFRESH
 
 	if(href_list["set_output_tag"])
-		var/t = sanitize_safe(input(usr, "Enter the output ID tag.", src.name, src.output_tag), MAX_NAME_LEN)
+		var/t = sanitize_safe(input(user, "Enter the output ID tag.", src.name, src.output_tag), MAX_NAME_LEN)
 		t = sanitize_safe(t, MAX_NAME_LEN)
 		if (t)
 			src.output_tag = t
@@ -237,7 +237,7 @@
 		return TOPIC_REFRESH
 
 	if(href_list["set_sensor_tag"])
-		var/t = sanitize_safe(input(usr, "Enter the sensor ID tag.", src.name, src.sensor_tag))
+		var/t = sanitize_safe(input(user, "Enter the sensor ID tag.", src.name, src.sensor_tag))
 		t = sanitize_safe(t, MAX_NAME_LEN)
 		if(t)
 			src.sensor_tag = t
@@ -245,7 +245,7 @@
 		return TOPIC_REFRESH
 
 	if(href_list["set_sensor_name"])
-		var/t = sanitize_safe(input(usr, "Enter the sensor name.", src.name, src.sensor_name))
+		var/t = sanitize_safe(input(user, "Enter the sensor name.", src.name, src.sensor_name))
 		t = sanitize_safe(t, MAX_NAME_LEN)
 		if(t)
 			src.sensor_name = t

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -160,7 +160,7 @@
 /obj/machinery/biogenerator/OnTopic(user, href_list)
 	switch (href_list["action"])
 		if("activate")
-			activate()
+			activate(user)
 		if("detach")
 			if(beaker)
 				beaker.dropInto(src.loc)
@@ -186,8 +186,8 @@
 	ui_interact(user)
 	return TRUE
 
-/obj/machinery/biogenerator/proc/activate()
-	if (usr.stat)
+/obj/machinery/biogenerator/proc/activate(mob/user)
+	if (user.incapacitated())
 		return
 	if (stat) //NOPOWER etc
 		return

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -149,33 +149,32 @@
 
 /mob/living/silicon/ai/proc/ai_actual_track(mob/living/target)
 	if(!istype(target))	return
-	var/mob/living/silicon/ai/U = usr
 
-	if(target == U.cameraFollow)
+	if(target == cameraFollow)
 		return
 
-	if(U.cameraFollow)
-		U.ai_cancel_tracking()
-	U.cameraFollow = target
-	to_chat(U, "Tracking target...")
+	if(cameraFollow)
+		ai_cancel_tracking()
+	cameraFollow = target
+	to_chat(src, "Tracking target...")
 	target.tracking_initiated()
 
 	spawn (0)
-		while (U.cameraFollow == target)
-			if (U.cameraFollow == null)
+		while (cameraFollow == target)
+			if (cameraFollow == null)
 				return
 
 			switch(target.tracking_status())
 				if(TRACKING_NO_COVERAGE)
-					to_chat(U, "Target is not near any active cameras.")
+					to_chat(src, "Target is not near any active cameras.")
 					sleep(100)
 					continue
 				if(TRACKING_TERMINATE)
-					U.ai_cancel_tracking(1)
+					ai_cancel_tracking(1)
 					return
 
-			if(U.eyeobj)
-				U.eyeobj.setLoc(get_turf(target), 0)
+			if(eyeobj)
+				eyeobj.setLoc(get_turf(target), 0)
 			else
 				view_core()
 				return

--- a/code/game/machinery/floorlayer.dm
+++ b/code/game/machinery/floorlayer.dm
@@ -41,7 +41,7 @@
 		var/m = input("Choose work mode", "Mode") as null|anything in mode
 		mode[m] = !mode[m]
 		var/O = mode[m]
-		user.visible_message("<span class='notice'>[usr] has set \the [src] [m] mode [!O?"off":"on"].</span>", "<span class='notice'>You set \the [src] [m] mode [!O?"off":"on"].</span>")
+		user.visible_message("<span class='notice'>[user] has set \the [src] [m] mode [!O?"off":"on"].</span>", "<span class='notice'>You set \the [src] [m] mode [!O?"off":"on"].</span>")
 		return TRUE
 
 	if(istype(W, /obj/item/stack/tile))

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -110,7 +110,7 @@
 		if(emagged)
 			emag_play()
 		else if(!current_track)
-			to_chat(usr, "No track selected.")
+			to_chat(user, "No track selected.")
 		else
 			StartPlaying()
 		return TOPIC_REFRESH

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -415,20 +415,20 @@
 	ffuu.add_to_reagents(/decl/material/liquid/acrylamide, amount/10)
 	return ffuu
 
-/obj/machinery/microwave/OnTopic(href, href_list)
+/obj/machinery/microwave/OnTopic(mob/user, href_list)
 	switch(href_list["action"])
 		if ("cook")
 			cook()
 			return TOPIC_REFRESH
 
 		if ("dispose")
-			dispose(usr)
+			dispose(user)
 			return TOPIC_REFRESH
 
 		if ("ejectitem")
 			for(var/obj/O in get_contained_external_atoms())
 				if(strip_improper(O.name) == href_list["target"])
-					eject_item(usr, O)
+					eject_item(user, O)
 					break
 			return TOPIC_REFRESH
 
@@ -437,7 +437,7 @@
 			for(var/material_type in reagents.reagent_volumes)
 				mat = GET_DECL(material_type)
 				if(mat.name == href_list["target"])
-					eject_reagent(usr, material_type)
+					eject_reagent(user, material_type)
 					break
 			return TOPIC_REFRESH
 

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -253,7 +253,7 @@ var/global/list/allCasters = list() //Global list that will contain reference to
 				dat+="<B><A href='byond://?src=\ref[src];set_new_message=1'>Message Body</A>:</B> [src.msg] <BR>"
 				dat+="<B>Photo</B>: "
 				if(photo_data && photo_data.photo)
-					send_rsc(usr, photo_data.photo.img, "tmp_photo.png")
+					send_rsc(user, photo_data.photo.img, "tmp_photo.png")
 					dat+="<BR><img src='tmp_photo.png' width = '180'>"
 					dat+="<BR><B><A href='byond://?src=\ref[src];set_attachment=1'>Delete Photo</A></B></BR>"
 				else
@@ -325,7 +325,7 @@ var/global/list/allCasters = list() //Global list that will contain reference to
 							dat+="-[MESSAGE.body] <BR>"
 							if(MESSAGE.img)
 								var/resourc_name = "newscaster_photo_[sanitize(viewing_channel.channel_name)]_[i].png"
-								send_asset(usr.client, resourc_name)
+								send_asset(user.client, resourc_name)
 								dat+="<img src='[resourc_name]' width = '180'><BR>"
 								if(MESSAGE.caption)
 									dat+="<FONT SIZE=1><B>[MESSAGE.caption]</B></FONT><BR>"
@@ -397,7 +397,7 @@ var/global/list/allCasters = list() //Global list that will contain reference to
 				dat+="<A href='byond://?src=\ref[src];set_wanted_desc=1'>Description</A>: [src.msg] <BR>"
 				dat+="<B>Photo</B>: "
 				if(photo_data && photo_data.photo)
-					send_rsc(usr, photo_data.photo.img, "tmp_photo.png")
+					send_rsc(user, photo_data.photo.img, "tmp_photo.png")
 					dat+="<BR><img src='tmp_photo.png' width = '180'>"
 					dat+="<BR><B><A href='byond://?src=\ref[src];set_attachment=1'>Delete Photo</A></B></BR>"
 				else
@@ -431,7 +431,7 @@ var/global/list/allCasters = list() //Global list that will contain reference to
 				dat+="<B>Description</B>: [news_network.wanted_issue.body]<BR>"
 				dat+="<B>Photo</B>: "
 				if(news_network.wanted_issue.img)
-					send_rsc(usr, news_network.wanted_issue.img, "tmp_photow.png")
+					send_rsc(user, news_network.wanted_issue.img, "tmp_photow.png")
 					dat+="<BR><img src='tmp_photow.png' width = '180'>"
 				else
 					dat+="None"

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -278,7 +278,7 @@ var/global/bomb_set
 					to_chat(usr, "<span class='warning'>Nothing happens, something might be wrong with the wiring.</span>")
 					return 1
 				if(!timing && !safety)
-					start_bomb()
+					start_bomb(usr)
 				else
 					check_cutoff()
 			if(href_list["safety"])
@@ -306,9 +306,9 @@ var/global/bomb_set
 					to_chat(usr, "<span class='warning'>There is nothing to anchor to!</span>")
 	return 1
 
-/obj/machinery/nuclearbomb/proc/start_bomb()
+/obj/machinery/nuclearbomb/proc/start_bomb(user)
 	timing = 1
-	log_and_message_admins("activated the detonation countdown of \the [src]")
+	log_and_message_admins("activated the detonation countdown of \the [src]", user)
 	bomb_set++ //There can still be issues with this resetting when there are multiple bombs. Not a big deal though for Nuke/N
 	var/decl/security_state/security_state = GET_DECL(global.using_map.security_state)
 	original_level = security_state.current_security_level
@@ -479,11 +479,11 @@ var/global/bomb_set
 	if(href_list["anchor"])
 		return
 
-/obj/machinery/nuclearbomb/station/start_bomb()
+/obj/machinery/nuclearbomb/station/start_bomb(mob/user)
 	for(var/inserter in inserters)
 		var/obj/machinery/self_destruct/sd = inserter
 		if(!istype(sd) || !sd.armed)
-			to_chat(usr, "<span class='warning'>An inserter has not been armed or is damaged.</span>")
+			to_chat(user, "<span class='warning'>An inserter has not been armed or is damaged.</span>")
 			return
 	visible_message("<span class='warning'>Warning. The self-destruct sequence override will be disabled [self_destruct_cutoff] seconds before detonation.</span>")
 	..()

--- a/code/game/machinery/oxygen_pump.dm
+++ b/code/game/machinery/oxygen_pump.dm
@@ -185,7 +185,7 @@
 /obj/machinery/oxygen_pump/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	var/data[0]
 	if(!tank)
-		to_chat(usr, SPAN_WARNING("It is missing a tank!"))
+		to_chat(user, SPAN_WARNING("It is missing a tank!"))
 		data["tankPressure"] = 0
 		data["releasePressure"] = 0
 		data["defaultReleasePressure"] = 0

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -193,7 +193,7 @@ var/global/list/turret_icons
 		return STATUS_CLOSE
 
 	if(!anchored)
-		to_chat(usr, "<span class='notice'>\The [src] has to be secured first!</span>")
+		to_chat(user, "<span class='notice'>\The [src] has to be secured first!</span>")
 		return STATUS_CLOSE
 
 	return ..()

--- a/code/game/machinery/self_destruct.dm
+++ b/code/game/machinery/self_destruct.dm
@@ -14,7 +14,7 @@
 		if(!damaged)
 			return FALSE
 		user.visible_message("[user] begins to repair [src].", "You begin repairing [src].")
-		if(do_after(usr, 100, src))
+		if(do_after(user, 100, src))
 			var/obj/item/weldingtool/w = W
 			if(w.weld(10))
 				damaged = 0

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -81,7 +81,7 @@
 		dat += " [set_temperature]K ([set_temperature-T0C]&deg;C)"
 		dat += "<A href='byond://?src=\ref[src];op=temp;val=5'>+</A><BR>"
 
-		var/datum/browser/popup = new(usr, "spaceheater", "Space Heater Control Panel")
+		var/datum/browser/popup = new(user, "spaceheater", "Space Heater Control Panel")
 		popup.set_content(jointext(dat, null))
 		popup.open()
 

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -66,13 +66,13 @@
 		L = locate("landmark*[C.data]") // use old stype
 
 	if(istype(L, /obj/abstract/landmark) && isturf(L.loc) && user.try_unequip(I))
-		to_chat(usr, "You insert the coordinates into the machine.")
-		to_chat(usr, "A message flashes across the screen reminding the traveller that the nuclear authentication disk is to remain on the [station_name()] at all times.")
+		to_chat(user, "You insert the coordinates into the machine.")
+		to_chat(user, "A message flashes across the screen reminding the traveller that the nuclear authentication disk is to remain on the [station_name()] at all times.")
 		qdel(I)
 		audible_message(SPAN_NOTICE("Locked in."))
 		src.locked = L
 		one_time_use = 1
-		add_fingerprint(usr)
+		add_fingerprint(user)
 	return TRUE
 
 /obj/machinery/computer/teleporter/interface_interact(var/mob/user)

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -89,7 +89,7 @@
 		return FALSE
 
 	if(istype(W, /obj/item/card/id)||istype(W, /obj/item/modular_computer))
-		if(src.allowed(usr))
+		if(src.allowed(user))
 			if(emagged)
 				to_chat(user, "<span class='notice'>The turret control is unresponsive.</span>")
 			else

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -227,11 +227,11 @@
 		return STATUS_CLOSE
 	return ..()
 
-/obj/item/radio/OnTopic(href, href_list)
+/obj/item/radio/OnTopic(mob/user, href_list)
 	if((. = ..()))
 		return
 
-	usr.set_machine(src)
+	user.set_machine(src)
 	if(href_list["analog"])
 		if(can_use_analog)
 			analog = text2num(href_list["analog"])
@@ -258,8 +258,8 @@
 		var/new_frequency = sanitize_frequency(frequency + text2num(href_list["freq"]))
 		set_frequency(new_frequency)
 		if(hidden_uplink)
-			if(hidden_uplink.check_trigger(usr, frequency, traitor_frequency))
-				close_browser(usr, "window=radio")
+			if(hidden_uplink.check_trigger(user, frequency, traitor_frequency))
+				close_browser(user, "window=radio")
 		. = TOPIC_REFRESH
 	else if (href_list["talk"])
 		toggle_broadcast()
@@ -278,14 +278,14 @@
 		. = TOPIC_REFRESH
 	else if(href_list["spec_freq"])
 		var freq = href_list["spec_freq"]
-		if(has_channel_access(usr, freq))
+		if(has_channel_access(user, freq))
 			set_frequency(text2num(freq))
 		. = TOPIC_REFRESH
 	if(href_list["nowindow"]) // here for pAIs, maybe others will want it, idk
 		return TOPIC_HANDLED
 	if(href_list["network_settings"])
 		var/datum/extension/network_device/D = get_extension(src, /datum/extension/network_device)
-		D.ui_interact(usr)
+		D.ui_interact(user)
 		. = TOPIC_HANDLED
 	if(. & TOPIC_REFRESH)
 		SSnano.update_uis(src)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -147,12 +147,12 @@ var/global/list/global/tank_gauge_cache = list()
 
 				var/obj/item/assembly_holder/assy = proxyassembly.assembly
 				if(assy.a_left && assy.a_right)
-					assy.dropInto(usr.loc)
+					assy.dropInto(user.loc)
 					assy.master = null
 					proxyassembly.assembly = null
 				else
 					if(!proxyassembly.assembly.a_left)
-						assy.a_right.dropInto(usr.loc)
+						assy.a_right.dropInto(user.loc)
 						assy.a_right.holder = null
 						assy.a_right = null
 						proxyassembly.assembly = null
@@ -299,7 +299,7 @@ var/global/list/global/tank_gauge_cache = list()
 		return TOPIC_REFRESH
 
 	if (href_list["stat"])
-		toggle_valve(usr)
+		toggle_valve(user)
 		return TOPIC_REFRESH
 
 /obj/item/tank/proc/toggle_valve(var/mob/user)

--- a/code/game/objects/items/weapons/tools/wirecutter.dm
+++ b/code/game/objects/items/weapons/tools/wirecutter.dm
@@ -46,7 +46,7 @@
 	var/obj/item/handcuffs/cable/cuffs = target.get_equipped_item(slot_handcuffed_str)
 	if(user.check_intent(I_FLAG_HELP) && istype(cuffs) && target.try_unequip(cuffs))
 		user.visible_message(
-			"\The [usr] cuts \the [target]'s restraints with \the [src]!",
+			"\The [user] cuts \the [target]'s restraints with \the [src]!",
 			"You cut \the [target]'s restraints with \the [src]!",
 			"You hear cable being cut."
 		)

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -344,7 +344,7 @@ var/global/list/closets = list()
 	if(!. && istype(AM) && opened && !istype(AM, /obj/structure/closet) && AM.simulated && !AM.anchored && (large || !ismob(AM)))
 		step_towards(AM, loc)
 		if(user != AM)
-			user.show_viewers(SPAN_DANGER("\The [user] stuffs \the [AM] into \the [src]!"))
+			user.visible_message(SPAN_DANGER("\The [user] stuffs \the [AM] into \the [src]!"), SPAN_DANGER("You stuff \the [AM] into \the [src]!"))
 		return TRUE
 
 /obj/structure/closet/attack_ai(mob/living/silicon/ai/user)

--- a/code/game/objects/structures/crematorium.dm
+++ b/code/game/objects/structures/crematorium.dm
@@ -82,7 +82,7 @@
 	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	if(locked)
-		to_chat(usr, SPAN_WARNING("It's currently locked."))
+		to_chat(user, SPAN_WARNING("It's currently locked."))
 		return TRUE
 	if(open)
 		close()

--- a/code/game/objects/structures/fishtanks.dm
+++ b/code/game/objects/structures/fishtanks.dm
@@ -191,13 +191,13 @@ var/global/list/global/aquarium_states_and_layers = list(
 		return
 	if(!Adjacent(target))
 		return
-	usr.visible_message(SPAN_WARNING("\The [user] starts climbing out of \the [src]!"))
+	user.visible_message(SPAN_WARNING("\The [user] starts climbing out of \the [src]!"))
 	if(!do_after(user,50))
 		return
 	if (!Adjacent(target))
 		return
-	usr.forceMove(target)
-	usr.visible_message(SPAN_WARNING("\The [user] climbs out of \the [src]!"))
+	user.forceMove(target)
+	user.visible_message(SPAN_WARNING("\The [user] climbs out of \the [src]!"))
 
 /obj/structure/glass_tank/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	. = locate(/obj/structure/glass_tank) in (target == loc) ? (mover && mover.loc) : target

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -145,7 +145,7 @@
 		to_chat(user, SPAN_WARNING("You will need a support made of sturdier material to hold up [S.material.solid_name] cladding."))
 		return FALSE
 
-	add_hiddenprint(usr)
+	add_hiddenprint(user)
 	if(S.material.integrity < 50)
 		to_chat(user, SPAN_WARNING("This material is too soft for use in wall construction."))
 		return 0
@@ -165,7 +165,7 @@
 	var/turf/wall/T = get_turf(src)
 	T.set_turf_materials(S.material, reinf_material, null, material)
 	T.can_open = prepped_for_fakewall
-	T.add_hiddenprint(usr)
+	T.add_hiddenprint(user)
 	material = null
 	reinf_material = null
 	qdel(src)

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -100,7 +100,7 @@ FLOOR SAFES
 			to_chat(user, "<span class='notice'>You can't [open ? "close" : "open"] [src], the lock is engaged!</span>")
 			return
 
-	var/canhear = locate(/obj/item/clothing/neck/stethoscope) in usr.get_held_items()
+	var/canhear = locate(/obj/item/clothing/neck/stethoscope) in user.get_held_items()
 	if(href_list["decrement"])
 		dial = decrement(dial)
 		if(dial == tumbler_1_pos + 1 || dial == tumbler_1_pos - 71)

--- a/code/game/objects/structures/stool_bed_chair_nest_sofa/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest_sofa/bed.dm
@@ -234,8 +234,8 @@
 	remove_beaker(user)
 	return TRUE
 
-/obj/structure/bed/roller/proc/collapse()
-	visible_message("[usr] collapses [src].")
+/obj/structure/bed/roller/proc/collapse(mob/user)
+	visible_message("[user] collapses [src].")
 	new item_form_type(get_turf(src))
 	qdel(src)
 
@@ -300,7 +300,7 @@
 		remove_beaker(user)
 		return TRUE
 	if(!buckled_mob)
-		collapse()
+		collapse(user)
 		return TRUE
 	. = ..()
 

--- a/code/modules/client/preference_setup/general/05_flavor.dm
+++ b/code/modules/client/preference_setup/general/05_flavor.dm
@@ -54,11 +54,11 @@
 			if("open")
 				pass()
 			if("general")
-				var/msg = sanitize(input(usr,"Give a general description of your character. This will be shown regardless of clothing. Do not include OOC information here.","Flavor Text",html_decode(pref.flavor_texts[href_list["flavor_text"]])) as message, extra = 0)
+				var/msg = sanitize(input(user,"Give a general description of your character. This will be shown regardless of clothing. Do not include OOC information here.","Flavor Text",html_decode(pref.flavor_texts[href_list["flavor_text"]])) as message, extra = 0)
 				if(CanUseTopic(user))
 					pref.flavor_texts[href_list["flavor_text"]] = msg
 			else
-				var/msg = sanitize(input(usr,"Set the flavor text for your [href_list["flavor_text"]].","Flavor Text",html_decode(pref.flavor_texts[href_list["flavor_text"]])) as message, extra = 0)
+				var/msg = sanitize(input(user,"Set the flavor text for your [href_list["flavor_text"]].","Flavor Text",html_decode(pref.flavor_texts[href_list["flavor_text"]])) as message, extra = 0)
 				if(CanUseTopic(user))
 					pref.flavor_texts[href_list["flavor_text"]] = msg
 		SetFlavorText(user)
@@ -69,11 +69,11 @@
 			if("open")
 				pass()
 			if("Default")
-				var/msg = sanitize(input(usr,"Set the default flavour text for your robot. It will be used for any module without individual setting.","Flavour Text",html_decode(pref.flavour_texts_robot["Default"])) as message, extra = 0)
+				var/msg = sanitize(input(user,"Set the default flavour text for your robot. It will be used for any module without individual setting.","Flavour Text",html_decode(pref.flavour_texts_robot["Default"])) as message, extra = 0)
 				if(CanUseTopic(user))
 					pref.flavour_texts_robot[href_list["flavour_text_robot"]] = msg
 			else
-				var/msg = sanitize(input(usr,"Set the flavour text for your robot with [href_list["flavour_text_robot"]] module. If you leave this empty, default flavour text will be used for this module.","Flavour Text",html_decode(pref.flavour_texts_robot[href_list["flavour_text_robot"]])) as message, extra = 0)
+				var/msg = sanitize(input(user,"Set the flavour text for your robot with [href_list["flavour_text_robot"]] module. If you leave this empty, default flavour text will be used for this module.","Flavour Text",html_decode(pref.flavour_texts_robot[href_list["flavour_text_robot"]])) as message, extra = 0)
 				if(CanUseTopic(user))
 					pref.flavour_texts_robot[href_list["flavour_text_robot"]] = msg
 		SetFlavourTextRobot(user)

--- a/code/modules/client/preference_setup/global/03_pai.dm
+++ b/code/modules/client/preference_setup/global/03_pai.dm
@@ -67,13 +67,13 @@
 				if(!isnull(t) && CanUseTopic(user))
 					candidate.comments = sanitize(t)
 			if("chassis")
-				t = input(usr,"What would you like to use for your mobile chassis icon?") as null|anything in global.possible_chassis
+				t = input(user,"What would you like to use for your mobile chassis icon?") as null|anything in global.possible_chassis
 				if(!isnull(t) && CanUseTopic(user))
 					candidate.chassis = t
 				update_pai_preview(user)
 				. = TOPIC_HARD_REFRESH
 			if("say")
-				t = input(usr,"What theme would you like to use for your speech verbs?") as null|anything in global.possible_say_verbs
+				t = input(user,"What theme would you like to use for your speech verbs?") as null|anything in global.possible_say_verbs
 				if(!isnull(t) && CanUseTopic(user))
 					candidate.say_verb = t
 			if("cyclebg")

--- a/code/modules/clothing/neck/necklace/pendant_locket.dm
+++ b/code/modules/clothing/neck/necklace/pendant_locket.dm
@@ -42,9 +42,9 @@
 		return TRUE
 	if(istype(used_item, /obj/item/paper) || istype(used_item, /obj/item/photo))
 		if(held)
-			to_chat(usr, SPAN_WARNING("\The [src] already has something inside it."))
+			to_chat(user, SPAN_WARNING("\The [src] already has something inside it."))
 		else if(user.try_unequip(used_item, src))
-			to_chat(usr, SPAN_NOTICE("You slip \the [used_item] into \the [src]."))
+			to_chat(user, SPAN_NOTICE("You slip \the [used_item] into \the [src]."))
 			held = used_item
 		return TRUE
 	return ..()

--- a/code/modules/codex/codex_implant.dm
+++ b/code/modules/codex/codex_implant.dm
@@ -8,4 +8,4 @@
 
 /obj/item/implant/codex/implanted(var/mob/source)
 	. = ..(source)
-	to_chat(usr, "<span class='notice'>You feel the brief sensation of having an entire encyclopedia at the tip of your tongue as the codex implant meshes with your nervous system.</span>")
+	to_chat(imp_in, SPAN_NOTICE("You feel the brief sensation of having an entire encyclopedia at the tip of your tongue as the codex implant meshes with your nervous system."))

--- a/code/modules/crafting/pottery/pottery_structures.dm
+++ b/code/modules/crafting/pottery/pottery_structures.dm
@@ -63,5 +63,5 @@
 /decl/interaction_handler/open_firebox/invoked(atom/target, mob/user, obj/item/prop)
 	var/obj/structure/fire_source/kiln/kiln = target
 	kiln.firebox_open = !kiln.firebox_open
-	to_chat(usr, SPAN_NOTICE("You [kiln.firebox_open ? "open" : "close"] \the [kiln]'s firebox."))
+	to_chat(user, SPAN_NOTICE("You [kiln.firebox_open ? "open" : "close"] \the [kiln]'s firebox."))
 	kiln.update_icon()

--- a/code/modules/detectivework/microscope/_forensic_machine.dm
+++ b/code/modules/detectivework/microscope/_forensic_machine.dm
@@ -111,7 +111,7 @@
 
 /obj/machinery/forensic/handle_mouse_drop(atom/over, mob/user, params)
 	if(user == over)
-		remove_sample(usr)
+		remove_sample(user)
 		return TRUE
 	. = ..()
 
@@ -125,4 +125,4 @@
 
 /decl/interaction_handler/forensics_remove_sample/invoked(atom/target, mob/user, obj/item/prop)
 	var/obj/machinery/forensic/F = target
-	F.remove_sample(usr)
+	F.remove_sample(user)

--- a/code/modules/economy/worth_cash.dm
+++ b/code/modules/economy/worth_cash.dm
@@ -137,7 +137,7 @@
 	if(QDELETED(src) || get_worth() <= 1 || user.incapacitated() || loc != user)
 		return TRUE
 
-	var/amount = input(usr, "How many [cur.name] do you want to take? (0 to [get_worth() - 1])", "Take Money", 20) as num
+	var/amount = input(user, "How many [cur.name] do you want to take? (0 to [get_worth() - 1])", "Take Money", 20) as num
 	amount = round(clamp(amount, 0, floor(get_worth() - 1)))
 
 	if(!amount || QDELETED(src) || get_worth() <= 1 || user.incapacitated() || loc != user)

--- a/code/modules/fabrication/fabricator_intake.dm
+++ b/code/modules/fabrication/fabricator_intake.dm
@@ -115,10 +115,10 @@
 		if(istype(O, /obj/item/disk/design_disk))
 			var/obj/item/disk/design_disk/disk = O
 			if(!disk.blueprint)
-				to_chat(usr, SPAN_WARNING("\The [O] is blank."))
+				to_chat(user, SPAN_WARNING("\The [O] is blank."))
 				return TRUE
 			if(disk.blueprint in installed_designs)
-				to_chat(usr, SPAN_WARNING("\The [src] is already loaded with the blueprint stored on \the [O]."))
+				to_chat(user, SPAN_WARNING("\The [src] is already loaded with the blueprint stored on \the [O]."))
 				return TRUE
 			installed_designs += disk.blueprint
 			design_cache |= disk.blueprint

--- a/code/modules/games/boardgame.dm
+++ b/code/modules/games/boardgame.dm
@@ -101,7 +101,7 @@
 	if(selected >= 0 && !isobserver(user))
 		dat += "<br><A href='byond://?src=\ref[src];remove=0'>Remove Selected Piece</A>"
 	show_browser(user, jointext(dat, null), "window=boardgame;size=430x500") // 50px * 8 squares + 30 margin
-	onclose(usr, "boardgame")
+	onclose(user, "boardgame")
 
 /obj/item/board/Topic(href, href_list)
 	if(!usr.Adjacent(src))

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -208,7 +208,6 @@ var/global/list/card_decks = list()
 	for(var/mob/living/player in viewers(3))
 		if(!player.stat)
 			players += player
-	//players -= usr
 
 	var/mob/living/M = input("Who do you wish to deal a card?") as null|anything in players
 	if(!usr || !src || !M) return

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -144,7 +144,7 @@
 		update_projections()
 		to_chat(user, "<span class='notice'>You vastly increase projector power and override the safety and security protocols.</span>")
 		to_chat(user, "Warning.  Automatic shutoff and derezing protocols have been corrupted.  Please call [global.using_map.company_name] maintenance and do not use the simulator.")
-		log_game("[key_name(usr)] emagged the Holodeck Control Computer")
+		log_game("[key_name(user)] emagged the Holodeck Control Computer")
 		src.updateUsrDialog()
 		return 1
 	else

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -314,7 +314,7 @@
 			if(!silent)
 				to_chat(user, SPAN_WARNING("The [body.hatch_descriptor] is locked."))
 			return
-		hud_open.toggled()
+		hud_open.toggled(user)
 		if(!silent)
 			to_chat(user, SPAN_NOTICE("You open the hatch and climb out of \the [src]."))
 	else
@@ -506,7 +506,7 @@
 			to_chat(user, SPAN_WARNING("The [body.hatch_descriptor] is locked."))
 			return TRUE
 		if(hud_open)
-			hud_open.toggled()
+			hud_open.toggled(user)
 			return TRUE
 
 /mob/living/exosuit/default_hurt_interaction(var/mob/user)

--- a/code/modules/mining/ore_box.dm
+++ b/code/modules/mining/ore_box.dm
@@ -31,7 +31,7 @@
 		return insert_ore(W, user)
 	if(W.storage)
 		var/added_ore = FALSE
-		W.storage.hide_from(usr)
+		W.storage.hide_from(user)
 		for(var/obj/item/stack/material/ore/O in W.storage.get_contents())
 			if(total_ores >= maximum_ores)
 				break

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -95,7 +95,7 @@
 		if(access_scanner.allowed(user) && !open)
 			locked = !locked
 			to_chat(user, "<span class='notice'>Controls are now [locked ? "locked." : "unlocked."]</span>")
-			Interact(usr)
+			Interact(user)
 		else if(open)
 			to_chat(user, "<span class='warning'>Please close the access panel before locking it.</span>")
 		else
@@ -105,7 +105,7 @@
 		if(!locked)
 			open = !open
 			to_chat(user, "<span class='notice'>Maintenance panel is now [open ? "opened" : "closed"].</span>")
-			Interact(usr)
+			Interact(user)
 		else
 			to_chat(user, "<span class='notice'>You need to unlock the controls first.</span>")
 		return TRUE

--- a/code/modules/mob/living/human/human.dm
+++ b/code/modules/mob/living/human/human.dm
@@ -182,7 +182,7 @@
 			var/datum/computer_file/report/crew_record/R = network.get_crew_record_by_name(perpname)
 			if(R)
 				var/setcriminal = input(user, "Specify a new criminal status for this person.", "Security HUD", R.get_criminalStatus()) as null|anything in global.security_statuses
-				if(hasHUD(usr, HUD_SECURITY) && setcriminal)
+				if(hasHUD(user, HUD_SECURITY) && setcriminal)
 					R.set_criminalStatus(setcriminal)
 					modified = 1
 
@@ -196,11 +196,11 @@
 							U.handle_regular_hud_updates()
 
 			if(!modified)
-				to_chat(usr, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
+				to_chat(user, "<span class='warning'>Unable to locate a data core entry for this person.</span>")
 			return TOPIC_HANDLED
 
 	if (href_list["secrecord"])
-		if(hasHUD(usr, HUD_SECURITY))
+		if(hasHUD(user, HUD_SECURITY))
 			var/perpname = "wot"
 			var/read = 0
 
@@ -274,11 +274,11 @@
 			var/datum/computer_file/report/crew_record/E = network.get_crew_record_by_name(perpname)
 			if(E)
 				if(hasHUD(user, HUD_MEDICAL))
-					to_chat(usr, "<b>Name:</b> [E.get_name()]")
-					to_chat(usr, "<b>Gender:</b> [E.get_gender()]")
-					to_chat(usr, "<b>Species:</b> [E.get_species_name()]")
-					to_chat(usr, "<b>Blood Type:</b> [E.get_bloodtype()]")
-					to_chat(usr, "<b>Details:</b> [E.get_medical_record()]")
+					to_chat(user, "<b>Name:</b> [E.get_name()]")
+					to_chat(user, "<b>Gender:</b> [E.get_gender()]")
+					to_chat(user, "<b>Species:</b> [E.get_species_name()]")
+					to_chat(user, "<b>Blood Type:</b> [E.get_bloodtype()]")
+					to_chat(user, "<b>Details:</b> [E.get_medical_record()]")
 					read = 1
 			if(!read)
 				to_chat(user, "<span class='warning'>Unable to locate a data core entry for this person.</span>")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -36,7 +36,7 @@
 	if(!..())
 		return 0
 
-	usr.visible_message("<b>[src]</b> points to <a href='byond://?src=\ref[A];look_at_me=1'>[A]</a>")
+	visible_message("<b>[src]</b> points to <a href='byond://?src=\ref[A];look_at_me=1'>[A]</a>")
 	return 1
 
 /*one proc, four uses
@@ -657,7 +657,7 @@ default behaviour is:
 	if(length(selectable_postures) == 1)
 		selected_posture = selectable_postures[1]
 	else
-		selected_posture = input(usr, "Which posture do you wish to adopt?", "Change Posture", current_posture) as null|anything in selectable_postures
+		selected_posture = input(src, "Which posture do you wish to adopt?", "Change Posture", current_posture) as null|anything in selectable_postures
 		if(!selected_posture || length(get_available_postures()) <= 1 || incapacitated(INCAPACITATION_KNOCKOUT) || !canClick())
 			return
 		if(current_posture == selected_posture || !(selected_posture in get_selectable_postures()))
@@ -1063,7 +1063,7 @@ default behaviour is:
 				if(user.mob_size >= exosuit.body.min_pilot_size && user.mob_size <= exosuit.body.max_pilot_size)
 					exosuit.enter(src)
 				else
-					to_chat(usr, SPAN_WARNING("You cannot pilot a exosuit of this size."))
+					to_chat(user, SPAN_WARNING("You cannot pilot a exosuit of this size."))
 				return TRUE
 	. = ..()
 

--- a/code/modules/mob/living/living_resist.dm
+++ b/code/modules/mob/living/living_resist.dm
@@ -13,37 +13,39 @@
 		if(buckled.can_buckle)
 			buckled.user_unbuckle_mob(src)
 		else
-			to_chat(usr, "<span class='warning'>You can't seem to escape from \the [buckled]!</span>")
+			to_chat(src, "<span class='warning'>You can't seem to escape from \the [buckled]!</span>")
 		return
 
 	setClickCooldown(100)
 	unbuckle_time = max(0, (2 MINUTES) - get_special_resist_time())
 
+	var/decl/pronouns/pronouns = get_pronouns()
+
 	visible_message(
-		"<span class='danger'>[src] attempts to unbuckle themself!</span>",
+		"<span class='danger'>[src] attempts to unbuckle [pronouns.self]!</span>",
 		"<span class='warning'>You attempt to unbuckle yourself. (This will take around [unbuckle_time / (1 SECOND)] second\s and you need to stand still)</span>", range = 2
 	)
 
 	if(unbuckle_time && buckled)
 		var/stages = 2
 		for(var/i = 1 to stages)
-			if(!unbuckle_time || do_after(usr, unbuckle_time*0.5, incapacitation_flags = INCAPACITATION_DEFAULT & ~(INCAPACITATION_RESTRAINED | INCAPACITATION_BUCKLED_FULLY)))
+			if(!unbuckle_time || do_after(src, unbuckle_time*0.5, incapacitation_flags = INCAPACITATION_DEFAULT & ~(INCAPACITATION_RESTRAINED | INCAPACITATION_BUCKLED_FULLY)))
 				if(!buckled)
 					return
 				visible_message(
-					SPAN_WARNING("\The [src] tries to unbuckle themself."),
+					SPAN_WARNING("\The [src] tries to unbuckle [pronouns.self]."),
 					SPAN_WARNING("You try to unbuckle yourself ([i*100/stages]% done)."), range = 2
 					)
 			else
 				if(!buckled)
 					return
 				visible_message(
-					SPAN_WARNING("\The [src] stops trying to unbuckle themself."),
+					SPAN_WARNING("\The [src] stops trying to unbuckle [pronouns.self]."),
 					SPAN_WARNING("You stop trying to unbuckle yourself."), range = 2
 					)
 				return
 		visible_message(
-			SPAN_DANGER("\The [src] manages to unbuckle themself!"),
+			SPAN_DANGER("\The [src] manages to unbuckle [pronouns.self]!"),
 			SPAN_NOTICE("You successfully unbuckle yourself."), range = 2
 			)
 		buckled.user_unbuckle_mob(src)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -178,7 +178,7 @@
 			if(!get_config_value(/decl/config/toggle/on/allow_drone_spawn) || emagged || should_be_dead()) //It's dead, Dave.
 				to_chat(user, "<span class='danger'>The interface is fried, and a distressing burned smell wafts from the robot's interior. You're not rebooting this one.</span>")
 				return TRUE
-			if(!allowed(usr))
+			if(!allowed(user))
 				to_chat(user, "<span class='danger'>Access denied.</span>")
 				return TRUE
 			var/decl/pronouns/pronouns = user.get_pronouns()
@@ -193,7 +193,7 @@
 			SPAN_DANGER("\The [user] swipes [pronouns.his] ID card through \the [src], attempting to shut it down."), \
 			SPAN_DANGER("You swipe your ID card through \the [src], attempting to shut it down."))
 		if(!emagged)
-			if(allowed(usr))
+			if(allowed(user))
 				shut_down()
 			else
 				to_chat(user, SPAN_DANGER("Access denied."))

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -243,9 +243,9 @@
 	to_chat(user, "It has [stored_walls] wall segment\s and [stored_doors] door segment\s stored.")
 	to_chat(user, "It is set to deploy [mode ? "doors" : "walls"]")
 
-/obj/item/inflatable_dispenser/attack_self()
+/obj/item/inflatable_dispenser/attack_self(mob/user)
 	mode = !mode
-	to_chat(usr, "You set \the [src] to deploy [mode ? "doors" : "walls"].")
+	to_chat(user, "You set \the [src] to deploy [mode ? "doors" : "walls"].")
 
 /obj/item/inflatable_dispenser/afterattack(var/atom/A, var/mob/user)
 	..(A, user)
@@ -301,7 +301,7 @@
 	if(istype(A, /obj/item/inflatable))
 		if(istype(A, /obj/item/inflatable/door))
 			if(stored_doors >= max_doors)
-				to_chat(usr, "\The [src] is full!")
+				to_chat(user, "\The [src] is full!")
 				return
 			stored_doors++
 			qdel(A)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -368,7 +368,7 @@
 	if(istype(W) && user.try_unequip(W))
 		W.forceMove(src)
 		stock_parts += W
-		to_chat(usr, "<span class='notice'>You install the [W.name].</span>")
+		to_chat(user, "<span class='notice'>You install the [W.name].</span>")
 		return TRUE
 
 /mob/living/silicon/proc/try_stock_parts_removal(obj/item/W, mob/user)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -561,10 +561,10 @@
 		update_flavor_text(href_list["flavor_change"])
 		return TOPIC_HANDLED
 
-// If usr != src, or if usr == src but the Topic call was not resolved, this is called next.
 /mob/proc/get_comments_record()
 	return
 
+// If usr != src, or if usr == src but the Topic call was not resolved, this is called next.
 /mob/OnTopic(mob/user, href_list, datum/topic_state/state)
 
 	if(href_list["refresh"])
@@ -626,9 +626,6 @@
 		return TRUE
 	. = ..()
 
-/mob/proc/is_active()
-	return (0 >= usr.stat)
-
 /mob/proc/can_touch(var/atom/touching)
 	if(!touching.Adjacent(src) || incapacitated())
 		return FALSE
@@ -638,16 +635,6 @@
 	if (buckled)
 		to_chat(src, SPAN_WARNING("You are buckled down."))
 	return TRUE
-
-/mob/proc/see(message)
-	if(!is_active())
-		return 0
-	to_chat(src, message)
-	return 1
-
-/mob/proc/show_viewers(message)
-	for(var/mob/M in viewers())
-		M.see(message)
 
 /mob/Stat()
 	..()
@@ -806,12 +793,10 @@
 		to_chat(usr, "You are restrained and cannot do that!")
 		return
 
-	var/mob/S = src
-	var/mob/U = usr
 	var/list/valid_objects = list()
 	var/self = null
 
-	if(S == U)
+	if(src == usr)
 		self = 1 // Removing object from yourself.
 
 	valid_objects = get_visible_implants(0)
@@ -819,16 +804,16 @@
 		if(self)
 			to_chat(src, "You have nothing stuck in your body that is large enough to remove.")
 		else
-			to_chat(U, "[src] has nothing stuck in their wounds that is large enough to remove.")
+			to_chat(usr, "[src] has nothing stuck in their wounds that is large enough to remove.")
 		return
 	var/obj/item/selection = input("What do you want to yank out?", "Embedded objects") in valid_objects
 	if(self)
 		to_chat(src, "<span class='warning'>You attempt to get a good grip on [selection] in your body.</span>")
 	else
-		to_chat(U, "<span class='warning'>You attempt to get a good grip on [selection] in [S]'s body.</span>")
-	if(!do_mob(U, S, 30, incapacitation_flags = INCAPACITATION_DEFAULT & (~INCAPACITATION_FORCELYING))) //let people pinned to stuff yank it out, otherwise they're stuck... forever!!!
+		to_chat(usr, "<span class='warning'>You attempt to get a good grip on [selection] in [src]'s body.</span>")
+	if(!do_mob(usr, src, 30, incapacitation_flags = INCAPACITATION_DEFAULT & (~INCAPACITATION_FORCELYING))) //let people pinned to stuff yank it out, otherwise they're stuck... forever!!!
 		return
-	if(!selection || !S || !U)
+	if(QDELETED(selection) || QDELETED(src) || QDELETED(usr))
 		return
 
 	if(self)
@@ -837,10 +822,10 @@
 		visible_message("<span class='warning'><b>[usr] rips [selection] out of [src]'s body.</b></span>","<span class='warning'><b>[usr] rips [selection] out of your body.</b></span>")
 	remove_implant(selection)
 	selection.forceMove(get_turf(src))
-	if(U.get_empty_hand_slot())
-		U.put_in_hands(selection)
-	if(ishuman(U))
-		var/mob/living/human/human_user = U
+	if(usr.get_empty_hand_slot())
+		usr.put_in_hands(selection)
+	if(ishuman(usr))
+		var/mob/living/human/human_user = usr
 		human_user.bloody_hands(src)
 	return 1
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -39,11 +39,10 @@
 			attack_self()
 			return
 		if(SOUTHWEST)
-			if(isliving(usr))
-				var/mob/living/M = usr
-				M.toggle_throw_mode()
+			if(isliving(mob))
+				mob.toggle_throw_mode()
 			else
-				to_chat(usr, "<span class='warning'>This mob type cannot throw items.</span>")
+				to_chat(src, "<span class='warning'>This mob type cannot throw items.</span>")
 			return
 		if(NORTHWEST)
 			mob.hotkey_drop()

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -185,9 +185,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		ghost.timeofdeath = world.time // Because the living mob won't have a time of death and we want the respawn timer to work properly.
 		announce_ghost_joinleave(ghost)
 
-/mob/observer/ghost/is_active()
-	return FALSE
-
 /mob/observer/ghost/Stat()
 	. = ..()
 	if(statpanel("Status") && SSevac.evacuation_controller)

--- a/code/modules/mob/stripping.dm
+++ b/code/modules/mob/stripping.dm
@@ -47,7 +47,7 @@
 				visible_message(SPAN_NOTICE("\The [user] [sensor.get_sensors_locked() ? "" : "un"]locks \the [src]'s vitals sensor controls."), range = 2)
 			return
 		if("internals")
-			visible_message("<span class='danger'>\The [usr] is trying to set \the [src]'s internals!</span>")
+			visible_message("<span class='danger'>\The [user] is trying to set \the [src]'s internals!</span>")
 			if(do_after(user, HUMAN_STRIP_DELAY, src, progress = 0))
 				toggle_internals(user)
 			return

--- a/code/modules/mob_holder/_holder.dm
+++ b/code/modules/mob_holder/_holder.dm
@@ -115,9 +115,9 @@
 		if(length(cards))
 			LAZYDISTINCTADD(., cards)
 
-/obj/item/holder/attack_self()
+/obj/item/holder/attack_self(mob/user)
 	for(var/mob/M in contents)
-		M.show_stripping_window(usr)
+		M.show_stripping_window(user)
 
 /obj/item/holder/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -151,7 +151,7 @@
 				module.show_assignments = 1
 		if("print")
 			if(!(get_file_perms(module.get_access(user), user) & OS_WRITE_ACCESS))
-				to_chat(usr, SPAN_WARNING("Access denied."))
+				to_chat(user, SPAN_WARNING("Access denied."))
 				return
 			if(computer.has_component(PART_PRINTER)) //This option should never be called if there is no printer
 				if(module.mod_mode)
@@ -175,7 +175,7 @@
 							contents += "  [get_access_desc(A)]"
 
 					if(!computer.print_paper(contents,"access report"))
-						to_chat(usr, "<span class='notice'>Hardware error: Printer was unable to print the file. It may be out of paper.</span>")
+						to_chat(user, "<span class='notice'>Hardware error: Printer was unable to print the file. It may be out of paper.</span>")
 						return
 				else
 					var/contents = {"<h4>Crew Manifest</h4>
@@ -183,7 +183,7 @@
 									[html_crew_manifest()]
 									"}
 					if(!computer.print_paper(contents, "crew manifest ([stationtime2text()])"))
-						to_chat(usr, "<span class='notice'>Hardware error: Printer was unable to print the file. It may be out of paper.</span>")
+						to_chat(user, "<span class='notice'>Hardware error: Printer was unable to print the file. It may be out of paper.</span>")
 						return
 		if("eject")
 			var/obj/item/stock_parts/computer/card_slot/card_slot = computer.get_component(PART_CARD)
@@ -193,7 +193,7 @@
 				card_slot.insert_id(user.get_active_held_item(), user)
 		if("terminate")
 			if(!(get_file_perms(module.get_access(user), user) & OS_WRITE_ACCESS))
-				to_chat(usr, SPAN_WARNING("Access denied."))
+				to_chat(user, SPAN_WARNING("Access denied."))
 				return
 			if(computer)
 				id_card.assignment = "Terminated"
@@ -201,7 +201,7 @@
 				RAISE_EVENT(/decl/observ/employee_id_terminated, id_card)
 		if("edit")
 			if(!(get_file_perms(module.get_access(user), user) & OS_WRITE_ACCESS))
-				to_chat(usr, SPAN_WARNING("Access denied."))
+				to_chat(user, SPAN_WARNING("Access denied."))
 				return
 			if(computer)
 				var/static/regex/hash_check = regex(@"^[0-9a-fA-F]{32}$")
@@ -212,7 +212,7 @@
 						id_card.formal_name_suffix = initial(id_card.formal_name_suffix)
 						id_card.formal_name_prefix = initial(id_card.formal_name_prefix)
 					else
-						computer.show_error(usr, "Invalid name entered!")
+						computer.show_error(user, "Invalid name entered!")
 				else if(href_list["account"])
 					var/account_num = text2num(input("Enter account number.", "Account", id_card.associated_account_number))
 					id_card.associated_account_number = account_num
@@ -243,11 +243,11 @@
 					if(!isnull(sug_blood_type) && CanUseTopic(user))
 						id_card.blood_type = sug_blood_type
 				else if(href_list["front_photo"])
-					var/photo = get_photo(usr)
+					var/photo = get_photo(user)
 					if(photo && CanUseTopic(user))
 						id_card.front = photo
 				else if(href_list["side_photo"])
-					var/photo = get_photo(usr)
+					var/photo = get_photo(user)
 					if(photo && CanUseTopic(user))
 						id_card.side = photo
 				else if(href_list["load_data"])
@@ -275,7 +275,7 @@
 						apply_access(id_card, access)
 		if("assign")
 			if(!(get_file_perms(module.get_access(user), user) & OS_WRITE_ACCESS))
-				to_chat(usr, SPAN_WARNING("Access denied."))
+				to_chat(user, SPAN_WARNING("Access denied."))
 				return
 			if(computer && id_card)
 				var/t1 = href_list["assign_target"]

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -62,7 +62,7 @@
 	data["message_line1"] = msg_line1
 	data["message_line2"] = msg_line2
 	data["state"] = current_status
-	data["isAI"] = issilicon(usr)
+	data["isAI"] = issilicon(user)
 	data["authenticated"] = is_authenticated(user)
 	data["boss_short"] = global.using_map.boss_short
 
@@ -153,17 +153,17 @@
 			current_status = text2num(href_list["target"])
 		if("announce")
 			. = 1
-			if(is_authenticated(user) && !issilicon(usr) && ntn_comm)
+			if(is_authenticated(user) && !issilicon(user) && ntn_comm)
 				if(user)
 					var/obj/item/card/id/id_card = user.GetIdCard()
 					crew_announcement.announcer = GetNameAndAssignmentFromId(id_card)
 				else
 					crew_announcement.announcer = "Unknown"
 				if(announcment_cooldown)
-					to_chat(usr, "Please allow at least one minute to pass between announcements.")
+					to_chat(user, "Please allow at least one minute to pass between announcements.")
 					return TRUE
-				var/input = input(usr, "Please write a message to announce to the [station_name()].", "Priority Announcement") as null|message
-				if(!input || !can_still_topic() || filter_block_message(usr, input))
+				var/input = input(user, "Please write a message to announce to the [station_name()].", "Priority Announcement") as null|message
+				if(!input || !can_still_topic() || filter_block_message(user, input))
 					return 1
 				var/affected_zlevels = SSmapping.get_connected_levels(get_host_z())
 				crew_announcement.Announce(input, zlevels = affected_zlevels)
@@ -174,35 +174,35 @@
 			. = 1
 			if(href_list["target"] == "emagged")
 				if(program)
-					if(is_authenticated(user) && program.computer.emagged() && !issilicon(usr) && ntn_comm)
+					if(is_authenticated(user) && program.computer.emagged() && !issilicon(user) && ntn_comm)
 						if(centcomm_message_cooldown)
-							to_chat(usr, "<span class='warning'>Arrays recycling. Please stand by.</span>")
+							to_chat(user, "<span class='warning'>Arrays recycling. Please stand by.</span>")
 							SSnano.update_uis(src)
 							return
-						var/input = sanitize(input(usr, "Please choose a message to transmit to \[ABNORMAL ROUTING CORDINATES\] via quantum entanglement.  Please be aware that this process is very expensive, and abuse will lead to... termination. Transmission does not guarantee a response. There is a 30 second delay before you may send another message, be clear, full and concise.", "To abort, send an empty message.", "") as null|text)
-						if(!input || !can_still_topic() || filter_block_message(usr, input))
+						var/input = sanitize(input(user, "Please choose a message to transmit to \[ABNORMAL ROUTING CORDINATES\] via quantum entanglement.  Please be aware that this process is very expensive, and abuse will lead to... termination. Transmission does not guarantee a response. There is a 30 second delay before you may send another message, be clear, full and concise.", "To abort, send an empty message.", "") as null|text)
+						if(!input || !can_still_topic() || filter_block_message(user, input))
 							return 1
-						Syndicate_announce(input, usr)
-						to_chat(usr, "<span class='notice'>Message transmitted.</span>")
-						log_say("[key_name(usr)] has made an illegal announcement: [input]")
+						Syndicate_announce(input, user)
+						to_chat(user, "<span class='notice'>Message transmitted.</span>")
+						log_say("[key_name(user)] has made an illegal announcement: [input]")
 						centcomm_message_cooldown = 1
 						spawn(300)//30 second cooldown
 							centcomm_message_cooldown = 0
 			else if(href_list["target"] == "regular")
-				if(is_authenticated(user) && !issilicon(usr) && ntn_comm)
+				if(is_authenticated(user) && !issilicon(user) && ntn_comm)
 					if(centcomm_message_cooldown)
-						to_chat(usr, "<span class='warning'>Arrays recycling. Please stand by.</span>")
+						to_chat(user, "<span class='warning'>Arrays recycling. Please stand by.</span>")
 						SSnano.update_uis(src)
 						return
 					if(!is_relay_online())//Contact Centcom has a check, Syndie doesn't to allow for Traitor funs.
-						to_chat(usr, "<span class='warning'>No emergency communication relay detected. Unable to transmit message.</span>")
+						to_chat(user, "<span class='warning'>No emergency communication relay detected. Unable to transmit message.</span>")
 						return 1
 					var/input = sanitize(input("Please choose a message to transmit to [global.using_map.boss_short] via quantum entanglement.  Please be aware that this process is very expensive, and abuse will lead to... termination.  Transmission does not guarantee a response. There is a 30 second delay before you may send another message, be clear, full and concise.", "To abort, send an empty message.", "") as null|text)
-					if(!input || !can_still_topic() || filter_block_message(usr, input))
+					if(!input || !can_still_topic() || filter_block_message(user, input))
 						return 1
-					Centcomm_announce(input, usr)
-					to_chat(usr, "<span class='notice'>Message transmitted.</span>")
-					log_say("[key_name(usr)] has made an IA [global.using_map.boss_short] announcement: [input]")
+					Centcomm_announce(input, user)
+					to_chat(user, "<span class='notice'>Message transmitted.</span>")
+					log_say("[key_name(user)] has made an IA [global.using_map.boss_short] announcement: [input]")
 					centcomm_message_cooldown = 1
 					spawn(300) //30 second cooldown
 						centcomm_message_cooldown = 0
@@ -241,7 +241,7 @@
 						post_status(href_list["target"])
 		if("setalert")
 			. = 1
-			if(is_authenticated(user) && !issilicon(usr) && ntn_cont && ntn_comm)
+			if(is_authenticated(user) && !issilicon(user) && ntn_cont && ntn_comm)
 				var/decl/security_state/security_state = GET_DECL(global.using_map.security_state)
 				var/decl/security_level/target_level = locate(href_list["target"]) in security_state.comm_console_security_levels
 				if(target_level && security_state.can_switch_to(target_level))
@@ -250,7 +250,7 @@
 						if(security_state.set_security_level(target_level))
 							SSstatistics.add_field(target_level.type,1)
 			else
-				to_chat(usr, "You press the button, but a red light flashes and nothing happens.") //This should never happen
+				to_chat(user, "You press the button, but a red light flashes and nothing happens.") //This should never happen
 
 			current_status = STATE_DEFAULT
 		if("viewmessage")
@@ -270,13 +270,13 @@
 			. = 1
 			if(is_authenticated(user) && ntn_comm)
 				if(!program.computer.print_paper(current_viewing_message["contents"],current_viewing_message["title"]))
-					to_chat(usr, "<span class='notice'>Hardware Error: Printer was unable to print the selected file.</span>")
+					to_chat(user, "<span class='notice'>Hardware Error: Printer was unable to print the selected file.</span>")
 		if("unbolt_doors")
 			global.using_map.unbolt_saferooms()
-			to_chat(usr, "<span class='notice'>The console beeps, confirming the signal was sent to have the saferooms unbolted.</span>")
+			to_chat(user, "<span class='notice'>The console beeps, confirming the signal was sent to have the saferooms unbolted.</span>")
 		if("bolt_doors")
 			global.using_map.bolt_saferooms()
-			to_chat(usr, "<span class='notice'>The console beeps, confirming the signal was sent to have the saferooms bolted.</span>")
+			to_chat(user, "<span class='notice'>The console beeps, confirming the signal was sent to have the saferooms bolted.</span>")
 
 #undef STATE_DEFAULT
 #undef STATE_MESSAGELIST
@@ -365,7 +365,7 @@ var/global/last_message_id = 0
 	if(isnull(emergency))
 		emergency = 1
 
-	if(!global.universe.OnShuttleCall(usr))
+	if(!global.universe.OnShuttleCall(user))
 		to_chat(user, "<span class='notice'>Cannot establish a connection.</span>")
 		return
 

--- a/code/modules/modular_computers/file_system/programs/engineering/network_monitoring.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/network_monitoring.dm
@@ -119,7 +119,7 @@
 			return TOPIC_HANDLED
 		var/new_roles = global.all_mainframe_roles - M.roles
 		if(!length(new_roles))
-			to_chat(usr, SPAN_WARNING("This server already has all possible roles enabled."))
+			to_chat(user, SPAN_WARNING("This server already has all possible roles enabled."))
 			return TOPIC_HANDLED
 		var/role = input(user,"What role to enable on this server?") as null|anything in new_roles
 		if(role && CanUseTopic(user, state))
@@ -132,7 +132,7 @@
 		if(!istype(M))
 			return TOPIC_HANDLED
 		if(!length(M.roles))
-			to_chat(usr, SPAN_WARNING("This server has no enabled roles to remove."))
+			to_chat(user, SPAN_WARNING("This server has no enabled roles to remove."))
 			return TOPIC_HANDLED
 		var/role = input(user,"What role to disable on this server?") as null|anything in M.roles
 		if(role && CanUseTopic(user, state))

--- a/code/modules/modular_computers/file_system/programs/generic/records.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/records.dm
@@ -163,7 +163,7 @@
 		var/obj/item/photo/photo = user.get_active_held_item()
 		return photo.img
 	if(issilicon(user))
-		var/mob/living/silicon/tempAI = usr
+		var/mob/living/silicon/tempAI = user
 		var/obj/item/photo/selection = tempAI.GetPicture()
 		if (selection)
 			return selection.img

--- a/code/modules/modular_computers/file_system/programs/generic/reports.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/reports.dm
@@ -141,7 +141,7 @@
 			return 1
 		var/field_ID = text2num(href_list["ID"])
 		var/datum/report_field/field = selected_report.field_from_ID(field_ID)
-		if(!field || !(field.get_perms(get_access(usr), usr) & OS_WRITE_ACCESS))
+		if(!field || !(field.get_perms(get_access(user), user) & OS_WRITE_ACCESS))
 			return 1
 		field.ask_value(user) //Handles the remaining IO.
 		return 1

--- a/code/modules/modular_computers/networking/machinery/acl.dm
+++ b/code/modules/modular_computers/networking/machinery/acl.dm
@@ -32,14 +32,14 @@
 	if(href_list["back"])
 		current_group = null
 		return TOPIC_REFRESH
-	
+
 	if(href_list["create_group"])
-		var/group_name = sanitize_for_group(input(usr, "Enter the name of the new group. Maximum 15 characters, only alphanumeric characters, _ and - are allowed:", "Create Group"))
+		var/group_name = sanitize_for_group(input(user, "Enter the name of the new group. Maximum 15 characters, only alphanumeric characters, _ and - are allowed:", "Create Group"))
 		if(!length(group_name))
 			return TOPIC_HANDLED
 		if(!CanInteract(user, global.default_topic_state))
 			return TOPIC_REFRESH
-		
+
 		var/output = D.add_group(group_name, current_group)
 		if(group_name in D.all_groups)
 			to_chat(user, SPAN_NOTICE(output))
@@ -59,15 +59,15 @@
 			else
 				to_chat(user, SPAN_NOTICE(output))
 			return TOPIC_REFRESH
-	
+
 	if(href_list["toggle_submanagement"])
 		D.toggle_submanagement()
 		return TOPIC_REFRESH
-	
+
 	if(href_list["toggle_parent_account_creation"])
 		D.toggle_parent_account_creation()
 		return TOPIC_REFRESH
-	
+
 	if(href_list["view_child_groups"])
 		var/parent_group = href_list["view_child_groups"]
 		if(parent_group && (parent_group in D.group_dict))
@@ -75,7 +75,7 @@
 		else
 			current_group = null
 		return TOPIC_REFRESH
-	
+
 	if(href_list["info"])
 		switch(href_list["info"])
 			if("submanagement")

--- a/code/modules/modular_computers/os/ui.dm
+++ b/code/modules/modular_computers/os/ui.dm
@@ -61,7 +61,7 @@
 	. = min(., extension_status(user))
 
 // Handles user's GUI input
-/datum/extension/interactive/os/extension_act(href, href_list, user)
+/datum/extension/interactive/os/extension_act(href, href_list, mob/user)
 	if( href_list["PC_exit"] )
 		kill_program(active_program)
 		return TOPIC_HANDLED
@@ -94,7 +94,7 @@
 		system_shutdown()
 		return TOPIC_HANDLED
 	if( href_list["PC_minimize"] )
-		minimize_program(usr)
+		minimize_program(user)
 		return TOPIC_HANDLED
 
 	if( href_list["PC_killprogram"] )
@@ -105,7 +105,7 @@
 
 		kill_program(P)
 		update_uis()
-		to_chat(usr, "<span class='notice'>Program [P.filename].[P.filetype] with PID [rand(100,999)] has been killed.</span>")
+		to_chat(user, "<span class='notice'>Program [P.filename].[P.filetype] with PID [rand(100,999)] has been killed.</span>")
 		return TOPIC_HANDLED
 
 	if( href_list["PC_runprogram"] )
@@ -117,15 +117,15 @@
 		return TOPIC_REFRESH
 
 	if( href_list["PC_terminal"] )
-		open_terminal(usr)
+		open_terminal(user)
 		return TOPIC_HANDLED
 
 	if( href_list["PC_login"])
-		login_prompt(usr)
+		login_prompt(user)
 		return TOPIC_REFRESH
 
 	if( href_list["PC_logout"])
-		logout_account(usr)
+		logout_account(user)
 		return TOPIC_REFRESH
 
 /datum/extension/interactive/os/proc/regular_ui_update()

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -259,7 +259,7 @@
 		if(connecting_limb.organ_tag == parent_organ)
 
 			if(length(connecting_limb.children))
-				to_chat(usr, SPAN_WARNING("You cannot connect additional limbs to \the [connecting_limb]."))
+				to_chat(user, SPAN_WARNING("You cannot connect additional limbs to \the [connecting_limb]."))
 				return TRUE
 
 			var/mob/holder = loc
@@ -282,7 +282,7 @@
 		else if(connecting_limb.parent_organ == organ_tag)
 
 			if(LAZYLEN(children))
-				to_chat(usr, SPAN_WARNING("You cannot connect additional limbs to \the [src]."))
+				to_chat(user, SPAN_WARNING("You cannot connect additional limbs to \the [src]."))
 				return TRUE
 
 			if(!user.try_unequip(connecting_limb, src))

--- a/code/modules/overmap/internet/internet_uplink.dm
+++ b/code/modules/overmap/internet/internet_uplink.dm
@@ -181,7 +181,7 @@ var/global/list/internet_uplinks = list()
 
 	return ..()
 
-/obj/machinery/computer/internet_uplink/interface_interact(user)
+/obj/machinery/computer/internet_uplink/interface_interact(mob/user)
 	var/datum/extension/local_network_member/uplink_comp = get_extension(src, /datum/extension/local_network_member)
 	var/datum/local_network/lan = uplink_comp.get_local_network()
 
@@ -193,5 +193,5 @@ var/global/list/internet_uplinks = list()
 		return FALSE
 
 	var/datum/topic_state/remote/R = new(src, linked)
-	linked.ui_interact(usr, state = R)
+	linked.ui_interact(user, state = R)
 	return TRUE

--- a/code/modules/overmap/ships/computers/shuttle.dm
+++ b/code/modules/overmap/ships/computers/shuttle.dm
@@ -42,8 +42,8 @@
 		if(length(port_choices))
 			port = input("Choose shuttle docking port:", "Shuttle Docking Port") as null|anything in port_choices
 		else
-			to_chat(usr, SPAN_WARNING("No functional docking ports, defaulting to center-of-mass landing."))
-		if(CanInteract(usr, global.default_topic_state) && (port in port_choices))
+			to_chat(user, SPAN_WARNING("No functional docking ports, defaulting to center-of-mass landing."))
+		if(CanInteract(user, global.default_topic_state) && (port in port_choices))
 			shuttle.set_port(port_choices[port])
 	if(href_list["pick"])
 		var/list/possible_d = shuttle.get_possible_destinations()
@@ -51,9 +51,9 @@
 		if(possible_d.len)
 			D = input("Choose shuttle destination", "Shuttle Destination") as null|anything in possible_d
 		else
-			to_chat(usr, SPAN_WARNING("No valid landing sites in range."))
+			to_chat(user, SPAN_WARNING("No valid landing sites in range."))
 		possible_d = shuttle.get_possible_destinations()
-		if(CanInteract(usr, global.default_topic_state) && (D in possible_d))
+		if(CanInteract(user, global.default_topic_state) && (D in possible_d))
 			shuttle.set_destination(possible_d[D])
 		return TOPIC_REFRESH
 	if(href_list["manual_landing"])
@@ -68,7 +68,7 @@
 			else
 				start_landing(user, shuttle)
 			return TOPIC_REFRESH
-		to_chat(usr, SPAN_WARNING("The manual controls look hopelessly complex to you!"))
+		to_chat(user, SPAN_WARNING("The manual controls look hopelessly complex to you!"))
 
 /obj/machinery/computer/shuttle_control/explore/proc/start_landing(var/mob/user, var/datum/shuttle/autodock/overmap/shuttle)
 	var/obj/effect/overmap/visitable/current_sector = global.overmap_sectors[num2text(z)]

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -111,7 +111,7 @@
 	user.set_machine(src)
 	show_browser(user, dat, "window=[initial(name)]")
 	onclose(user, initial(name))
-	add_fingerprint(usr)
+	add_fingerprint(user)
 	return
 
 /obj/item/clipboard/proc/add_pen(var/obj/item/I, var/mob/user)

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -44,7 +44,7 @@
 
 	else if(IS_PEN(W))
 		updateUsrDialog()
-		var/n_name = sanitize_safe(input(usr, "What would you like to label the folder?", "Folder Labelling", null)  as text, MAX_NAME_LEN)
+		var/n_name = sanitize_safe(input(user, "What would you like to label the folder?", "Folder Labelling", null)  as text, MAX_NAME_LEN)
 		if(!CanPhysicallyInteractWith(user, src))
 			to_chat(user, SPAN_WARNING("You must stay close to \the [src]."))
 			return TRUE

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -332,7 +332,7 @@
 		var/pen_flags = I.get_tool_property(TOOL_PEN, TOOL_PROP_PEN_FLAG)
 		var/decl/tool_archetype/pen/parch = GET_DECL(TOOL_PEN)
 		if(!(pen_flags & PEN_FLAG_ACTIVE))
-			parch.toggle_active(usr, I)
+			parch.toggle_active(user, I)
 		var/iscrayon = pen_flags & PEN_FLAG_CRAYON
 		var/isfancy  = pen_flags & PEN_FLAG_FANCY
 

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -129,7 +129,7 @@
 	//Dump all stored papers too
 	for(var/i=1 to amount)
 		var/obj/item/paper/P = new /obj/item/paper(forced_loc)
-		P.merge_with_existing(forced_loc, usr)
+		P.merge_with_existing(forced_loc, user)
 	LAZYCLEARLIST(papers)
 
 /obj/item/paper_bin/proc/add_paper(var/obj/item/paper/P)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -235,7 +235,7 @@ By design, d1 is the smallest direction and d2 is the highest
 				if(c.d1 == UP || c.d2 == UP)
 					qdel(c)
 
-	investigate_log("was cut by [key_name(usr, usr.client)] in [get_area_name(user)]","wires")
+	investigate_log("was cut by [key_name(user, user.client)] in [get_area_name(user)]","wires")
 
 	qdel(src)
 
@@ -245,7 +245,7 @@ By design, d1 is the smallest direction and d2 is the highest
 		return 0
 	if (electrocute_mob(user, powernet, src, siemens_coeff))
 		spark_at(src, amount=5, cardinal_only = TRUE)
-		if(HAS_STATUS(usr, STAT_STUN))
+		if(HAS_STATUS(user, STAT_STUN))
 			return 1
 	return 0
 

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -76,9 +76,9 @@
 	if(distance > 1)
 		return
 	if(active)
-		to_chat(usr, "<span class='notice'>The generator is on.</span>")
+		to_chat(user, "<span class='notice'>The generator is on.</span>")
 	else
-		to_chat(usr, "<span class='notice'>The generator is off.</span>")
+		to_chat(user, "<span class='notice'>The generator is off.</span>")
 /obj/machinery/port_gen/emp_act(severity)
 	if(!active)
 		return

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -67,8 +67,8 @@
 			if(active==1)
 				active = 0
 				to_chat(user, "You turn off \the [src].")
-				log_and_message_admins("turned off \the [src]")
-				investigate_log("turned <font color='red'>off</font> by [key_name_admin(user || usr)]","singulo")
+				log_and_message_admins("turned off \the [src]", user)
+				investigate_log("turned <font color='red'>off</font> by [key_name_admin(user)]","singulo")
 			else
 				active = 1
 				if(user)
@@ -77,8 +77,8 @@
 				to_chat(user, "You turn on \the [src].")
 				shot_number = 0
 				fire_delay = get_initial_fire_delay()
-				log_and_message_admins("turned on \the [src]")
-				investigate_log("turned <font color='green'>on</font> by [key_name_admin(user || usr)]","singulo")
+				log_and_message_admins("turned on \the [src]", user)
+				investigate_log("turned <font color='green'>on</font> by [key_name_admin(user)]","singulo")
 			update_icon()
 		else
 			to_chat(user, "<span class='warning'>The controls are locked!</span>")

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -155,7 +155,7 @@
 	var/obj/item/clothing/gloves/G = h_user.get_equipped_item(slot_gloves_str)
 	if(istype(G) && G.siemens_coefficient == 0)
 		user_protected = 1
-	log_and_message_admins("SMES FAILURE: <b>[src.x]X [src.y]Y [src.z]Z</b> User: [usr.ckey], Intensity: [intensity]/100 - <A HREF='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>")
+	log_and_message_admins("SMES FAILURE: <b>[src.x]X [src.y]Y [src.z]Z</b> User: [user.ckey], Intensity: [intensity]/100 - <A HREF='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>")
 
 	switch (intensity)
 		if (0 to 15)

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -185,7 +185,7 @@
 
 /obj/machinery/turbine/OnTopic(user, href_list)
 	if(href_list["close"])
-		close_browser(usr, "window=turbine")
+		close_browser(user, "window=turbine")
 		return TOPIC_HANDLED
 
 	if(href_list["str"])
@@ -244,9 +244,9 @@
 
 
 
-/obj/machinery/computer/turbine_computer/OnTopic(user, href_list)
+/obj/machinery/computer/turbine_computer/OnTopic(mob/user, href_list)
 	if( href_list["view"] )
-		usr.client.eye = src.compressor
+		user.client.eye = src.compressor
 		. = TOPIC_HANDLED
 	else if( href_list["str"] )
 		src.compressor.starter = !src.compressor.starter

--- a/code/modules/projectiles/guns/launcher/rocket.dm
+++ b/code/modules/projectiles/guns/launcher/rocket.dm
@@ -32,7 +32,7 @@
 			to_chat(user, "<span class='notice'>[rockets.len] / [max_rockets] rockets.</span>")
 			return TRUE
 		else
-			to_chat(usr, "<span class='warning'>\The [src] cannot hold more rockets.</span>")
+			to_chat(user, "<span class='warning'>\The [src] cannot hold more rockets.</span>")
 			return TRUE
 	return ..()
 

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -151,13 +151,13 @@
 	else if (href_list["eject"])
 		var/index = text2num(href_list["eject"])
 		if(beakers[index])
-			remove_beaker(beakers[index], usr)
+			remove_beaker(beakers[index], user)
 		. = TOPIC_REFRESH
 	else if (href_list["eject_cart"])
-		unload_ammo(usr)
+		unload_ammo(user)
 		. = TOPIC_REFRESH
 
-	Interact(usr)
+	Interact(user)
 
 /obj/item/gun/projectile/dartgun/medical
 	starting_chems = list(/decl/material/liquid/burn_meds,/decl/material/liquid/brute_meds,/decl/material/liquid/antitoxins)

--- a/code/modules/projectiles/targeting/targeting_client.dm
+++ b/code/modules/projectiles/targeting/targeting_client.dm
@@ -1,12 +1,11 @@
 //These are called by the on-screen buttons, adjusting what the victim can and cannot do.
 /client/proc/add_gun_icons()
-	if(!usr || !usr.item_use_icon) return 1 // This can runtime if someone manages to throw a gun out of their hand before the proc is called.
-	screen |= usr.item_use_icon
-	screen |= usr.gun_move_icon
-	screen |= usr.radio_use_icon
+	if(!mob.item_use_icon) return 1 // This can runtime if someone manages to throw a gun out of their hand before the proc is called.
+	screen |= mob.item_use_icon
+	screen |= mob.gun_move_icon
+	screen |= mob.radio_use_icon
 
 /client/proc/remove_gun_icons()
-	if(!usr) return 1 // Runtime prevention on N00k agents spawning with SMG
-	screen -= usr.item_use_icon
-	screen -= usr.gun_move_icon
-	screen -= usr.radio_use_icon
+	screen -= mob.item_use_icon
+	screen -= mob.gun_move_icon
+	screen -= mob.radio_use_icon

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -254,7 +254,7 @@
 		spawn()
 			has_sprites += user.client
 			for(var/i = 1 to MAX_PILL_SPRITE)
-				send_rsc(usr, icon('icons/obj/items/chem/pill.dmi', "pill" + num2text(i)), "pill[i].png")
+				send_rsc(user, icon('icons/obj/items/chem/pill.dmi', "pill" + num2text(i)), "pill[i].png")
 	var/dat = list()
 	dat += "<TITLE>[name]</TITLE>"
 	dat += "[name] Menu:"

--- a/code/modules/reagents/dispenser/cartridge.dm
+++ b/code/modules/reagents/dispenser/cartridge.dm
@@ -48,13 +48,14 @@
 		else if(user)
 			to_chat(user, SPAN_NOTICE("You clear the label on \the [src]."))
 
-/obj/item/chems/chem_disp_cartridge/attack_self()
-	..()
+/obj/item/chems/chem_disp_cartridge/attack_self(mob/user)
+	if((. = ..()))
+		return
 	if (ATOM_IS_OPEN_CONTAINER(src))
-		to_chat(usr, SPAN_NOTICE("You put the cap on \the [src]."))
+		to_chat(user, SPAN_NOTICE("You put the cap on \the [src]."))
 		atom_flags ^= ATOM_FLAG_OPEN_CONTAINER
 	else
-		to_chat(usr, SPAN_NOTICE("You take the cap off \the [src]."))
+		to_chat(user, SPAN_NOTICE("You take the cap off \the [src]."))
 		atom_flags |= ATOM_FLAG_OPEN_CONTAINER
 
 /obj/item/chems/chem_disp_cartridge/afterattack(obj/target, mob/user, proximity_flag, click_parameters)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -43,10 +43,10 @@
 
 /obj/item/chems/proc/cannot_interact(mob/user)
 	if(!CanPhysicallyInteract(user))
-		to_chat(usr, SPAN_WARNING("You're in no condition to do that!"))
+		to_chat(user, SPAN_WARNING("You're in no condition to do that!"))
 		return TRUE
 	if(ismob(loc) && loc != user)
-		to_chat(usr, SPAN_WARNING("You can't set transfer amounts while \the [src] is being held by someone else."))
+		to_chat(user, SPAN_WARNING("You can't set transfer amounts while \the [src] is being held by someone else."))
 		return TRUE
 	return FALSE
 

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -100,14 +100,14 @@
 
 	return
 
-/obj/item/chems/borghypo/OnTopic(var/href, var/list/href_list)
+/obj/item/chems/borghypo/OnTopic(mob/user, href_list, datum/topic_state/state)
 	if(href_list["reagent_index"])
 		var/index = text2num(href_list["reagent_index"])
 		if(index > 0 && index <= reagent_ids.len)
 			playsound(loc, 'sound/effects/pop.ogg', 50, 0)
 			mode = index
 			var/decl/material/R = reagent_ids[mode]
-			to_chat(usr, "<span class='notice'>Synthesizer is now producing '[initial(R.name)]'.</span>")
+			to_chat(user, "<span class='notice'>Synthesizer is now producing '[initial(R.name)]'.</span>")
 		return TOPIC_REFRESH
 
 /obj/item/chems/borghypo/examine(mob/user, distance)

--- a/code/modules/reagents/reagent_containers/food/eggs.dm
+++ b/code/modules/reagents/reagent_containers/food/eggs.dm
@@ -39,10 +39,10 @@
 		var/clr = W.get_tool_property(TOOL_PEN, TOOL_PROP_COLOR_NAME)
 
 		if(!(clr in list("blue","green","mime","orange","purple","rainbow","red","yellow")))
-			to_chat(usr, SPAN_WARNING("The egg refuses to take on this color!"))
+			to_chat(user, SPAN_WARNING("The egg refuses to take on this color!"))
 			return TRUE
 
-		to_chat(usr, SPAN_NOTICE("You color \the [src] [clr]"))
+		to_chat(user, SPAN_NOTICE("You color \the [src] [clr]"))
 		icon_state = "egg-[clr]"
 		return TRUE
 	return ..()

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -56,14 +56,14 @@
 /obj/item/chems/glass/proc/can_lid()
 	return TRUE
 
-/obj/item/chems/glass/attack_self()
+/obj/item/chems/glass/attack_self(mob/user)
 	. = ..()
 	if(!. && can_lid())
 		if(ATOM_IS_OPEN_CONTAINER(src))
-			to_chat(usr, SPAN_NOTICE("You put the lid on \the [src]."))
+			to_chat(user, SPAN_NOTICE("You put the lid on \the [src]."))
 			atom_flags ^= ATOM_FLAG_OPEN_CONTAINER
 		else
-			to_chat(usr, SPAN_NOTICE("You take the lid off \the [src]."))
+			to_chat(user, SPAN_NOTICE("You take the lid off \the [src]."))
 			atom_flags |= ATOM_FLAG_OPEN_CONTAINER
 		update_icon()
 

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -85,7 +85,7 @@
 
 /obj/item/chems/spray/attack_self(var/mob/user)
 	if(has_safety())
-		toggle_safety()
+		toggle_safety(user)
 		return TRUE
 	else
 		//If no safety, we just toggle the nozzle
@@ -98,9 +98,9 @@
 /obj/item/chems/spray/proc/has_safety()
 	return FALSE
 
-/obj/item/chems/spray/proc/toggle_safety()
+/obj/item/chems/spray/proc/toggle_safety(mob/user)
 	safety = !safety
-	to_chat(usr, SPAN_NOTICE("You switch the safety [safety ? "on" : "off"]."))
+	to_chat(user, SPAN_NOTICE("You switch the safety [safety ? "on" : "off"]."))
 
 /obj/item/chems/spray/examine(mob/user, distance)
 	. = ..()

--- a/code/modules/shield_generators/handheld_diffuser.dm
+++ b/code/modules/shield_generators/handheld_diffuser.dm
@@ -41,14 +41,14 @@
 				if(istype(S) && !S.diffused_for && !S.disabled_for && cell.checked_use(10 KILOWATTS * CELLRATE))
 					S.diffuse(20)
 
-/obj/item/shield_diffuser/attack_self()
+/obj/item/shield_diffuser/attack_self(mob/user)
 	enabled = !enabled
 	update_icon()
 	if(enabled)
 		START_PROCESSING(SSobj, src)
 	else
 		STOP_PROCESSING(SSobj, src)
-	to_chat(usr, "You turn \the [src] [enabled ? "on" : "off"].")
+	to_chat(user, "You turn \the [src] [enabled ? "on" : "off"].")
 
 /obj/item/shield_diffuser/examine(mob/user)
 	. = ..()

--- a/code/modules/shuttles/docking_beacon.dm
+++ b/code/modules/shuttles/docking_beacon.dm
@@ -94,7 +94,7 @@
 
 	if(href_list["edit_codes"])
 		var/newcode = sanitize(input("Input new docking codes:", "Docking codes", docking_codes) as text|null)
-		if(!CanInteract(usr,state))
+		if(!CanInteract(user,state))
 			return TOPIC_NOACTION
 		if(newcode)
 			docking_codes = uppertext(newcode)
@@ -103,7 +103,7 @@
 
 	if(href_list["edit_display_name"])
 		var/newname = sanitize(input("Input new display name:", "Display name", display_name) as text|null)
-		if(!CanInteract(usr,state))
+		if(!CanInteract(user,state))
 			return TOPIC_NOACTION
 		if(newname)
 			display_name = newname
@@ -114,7 +114,7 @@
 	if(href_list["edit_size"])
 		var/newwidth = input("Input new docking width for beacon:", "Docking size", docking_width) as num|null
 		var/newheight = input("Input new docking height for beacon:", "Docking size", docking_height) as num|null
-		if(!CanInteract(usr,state))
+		if(!CanInteract(user,state))
 			return TOPIC_NOACTION
 		if(newwidth && newheight)
 			docking_width = clamp(newwidth, 0, MAX_DOCKING_SIZE)
@@ -134,7 +134,7 @@
 		return TOPIC_REFRESH
 
 	if(href_list["edit_permitted_shuttles"])
-		var/shuttle = sanitize(input(usr,"Enter the ID of the shuttle you wish to permit/unpermit for this beacon:", "Enter ID") as text|null)
+		var/shuttle = sanitize(input(user,"Enter the ID of the shuttle you wish to permit/unpermit for this beacon:", "Enter ID") as text|null)
 		if(shuttle)
 			if(shuttle in permitted_shuttles)
 				permitted_shuttles -= shuttle
@@ -166,7 +166,7 @@
 
 	if(href_list["change_color"])
 		var/new_color = input(user, "Choose a color.", "\the [src]", ship_color) as color|null
-		if(!CanInteract(usr,state))
+		if(!CanInteract(user,state))
 			return TOPIC_NOACTION
 		if(new_color && new_color != ship_color)
 			ship_color = new_color
@@ -175,7 +175,7 @@
 
 	if(href_list["change_ship_name"])
 		var/new_ship_name = sanitize(input(user, "Enter a new name for the ship:", "Change ship name.") as null|text)
-		if(!CanInteract(usr,state))
+		if(!CanInteract(user,state))
 			return TOPIC_NOACTION
 		if(!new_ship_name)
 			return TOPIC_HANDLED
@@ -195,7 +195,7 @@
 		if(!construction_mode)
 			return TOPIC_HANDLED
 		var/confirm = alert(user, "This will permanently finalize the ship, are you sure?", "Ship finalization", "No", "Yes")
-		if(!CanInteract(usr,state))
+		if(!CanInteract(user,state))
 			return TOPIC_NOACTION
 		if(confirm == "Yes")
 			if(create_ship())
@@ -203,7 +203,7 @@
 				ship_name = ""
 				LAZYCLEARLIST(errors)
 			else
-				to_chat(usr, SPAN_WARNING("Could not finalize the construction of the ship!"))
+				to_chat(user, SPAN_WARNING("Could not finalize the construction of the ship!"))
 		return TOPIC_REFRESH
 
 /obj/machinery/docking_beacon/proc/allow_projection()

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -89,7 +89,7 @@
 
 	if(href_list["set_codes"])
 		var/newcode = input("Input new docking codes", "Docking codes", shuttle.docking_codes) as text|null
-		if (newcode && CanInteract(usr, global.default_topic_state))
+		if (newcode && CanInteract(user, global.default_topic_state))
 			shuttle.set_docking_codes(uppertext(newcode))
 		return TOPIC_REFRESH
 

--- a/code/modules/shuttles/shuttle_console_multi.dm
+++ b/code/modules/shuttles/shuttle_console_multi.dm
@@ -9,14 +9,14 @@
 			"can_pick" = shuttle.moving_status == SHUTTLE_IDLE,
 		)
 
-/obj/machinery/computer/shuttle_control/multi/handle_topic_href(var/datum/shuttle/autodock/multi/shuttle, var/list/href_list)
+/obj/machinery/computer/shuttle_control/multi/handle_topic_href(var/datum/shuttle/autodock/multi/shuttle, var/list/href_list, var/user)
 	if((. = ..()) != null)
 		return
 
 	if(href_list["pick"])
 		var/dest_key = input("Choose shuttle destination", "Shuttle Destination") as null|anything in shuttle.get_destinations()
-		if(dest_key && CanInteract(usr, global.default_topic_state))
-			shuttle.set_destination(dest_key, usr)
+		if(dest_key && CanInteract(user, global.default_topic_state))
+			shuttle.set_destination(dest_key, user)
 		return TOPIC_REFRESH
 
 

--- a/code/modules/vehicles/bike.dm
+++ b/code/modules/vehicles/bike.dm
@@ -63,7 +63,7 @@
 		usr.visible_message("\The [usr] puts up \the [src]'s kickstand.")
 	else
 		if(isspaceturf(src.loc))
-			to_chat(usr, "<span class='warning'> You don't think kickstands work in space...</span>")
+			to_chat(usr, "<span class='warning'>You don't think kickstands work in space...</span>")
 			return
 		usr.visible_message("\The [usr] puts down \the [src]'s kickstand.")
 

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -193,7 +193,7 @@
 	if(distance > 1)
 		return
 
-	if(!ishuman(usr))
+	if(!ishuman(user))
 		return
 
 	to_chat(user, "The power light is [on ? "on" : "off"].\nThere are[key ? "" : " no"] keys in the ignition.")

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -240,23 +240,23 @@
 		turn_on()
 		return
 
-/obj/vehicle/proc/insert_cell(var/obj/item/cell/C, var/mob/living/human/H)
+/obj/vehicle/proc/insert_cell(var/obj/item/cell/C, var/mob/living/user)
 	if(cell)
 		return
 	if(!istype(C))
 		return
-	if(!H.try_unequip(C, src))
+	if(!user.try_unequip(C, src))
 		return
 	cell = C
 	powercheck()
-	to_chat(usr, "<span class='notice'>You install [C] in [src].</span>")
+	to_chat(user, "<span class='notice'>You install [C] in [src].</span>")
 
-/obj/vehicle/proc/remove_cell(var/mob/living/human/H)
+/obj/vehicle/proc/remove_cell(var/mob/living/user)
 	if(!cell)
 		return
 
-	to_chat(usr, "<span class='notice'>You remove [cell] from [src].</span>")
-	H.put_in_hands(cell)
+	to_chat(user, "<span class='notice'>You remove [cell] from [src].</span>")
+	user.put_in_hands(cell)
 	cell = null
 	powercheck()
 

--- a/mods/content/matchmaking/matchmaker.dm
+++ b/mods/content/matchmaking/matchmaker.dm
@@ -271,8 +271,8 @@ var/global/datum/matchmaker/matchmaker = new()
 			var/list/relations = matchmaker.get_relationships(mind)
 			for(var/datum/relation/R in relations)
 				R.finalize()
-			show_browser(usr,null, "window=relations")
+			show_browser(src,null, "window=relations")
 		else
-			show_browser(usr,null, "window=relations")
+			show_browser(src,null, "window=relations")
 		return TOPIC_HANDLED
 	return ..()

--- a/mods/gamemodes/cult/spells/construct.dm
+++ b/mods/gamemodes/cult/spells/construct.dm
@@ -89,12 +89,12 @@
 
 	hud_state = "const_pylon"
 
-/spell/aoe_turf/conjure/pylon/cast(list/targets)
+/spell/aoe_turf/conjure/pylon/cast(list/targets, mob/user)
 	..()
 	var/turf/spawn_place = pick(targets)
 	for(var/obj/structure/cult/pylon/P in spawn_place.contents)
 		if(P.isbroken)
-			P.repair(usr)
+			P.repair(user)
 		continue
 	return
 

--- a/mods/mobs/borers/mob/borer/borer_hud.dm
+++ b/mods/mobs/borers/mob/borer/borer_hud.dm
@@ -54,7 +54,7 @@
 /obj/screen/borer/handle_click(mob/user, params)
 	if(!isborer(user))
 		return FALSE
-	var/mob/living/simple_animal/borer/worm = usr
+	var/mob/living/simple_animal/borer/worm = user
 	if(!worm.host)
 		return FALSE
 	return TRUE

--- a/mods/species/ascent/effects/razorweb.dm
+++ b/mods/species/ascent/effects/razorweb.dm
@@ -13,7 +13,7 @@
 		web.buckle_mob(hit_atom)
 		web.visible_message(SPAN_DANGER("\The [hit_atom] is tangled in \the [web]!"))
 	web.entangle(hit_atom, TRUE)
-	playsound(usr, 'mods/species/ascent/sounds/razorweb_twang.ogg', 50)
+	playsound(src, 'mods/species/ascent/sounds/razorweb_twang.ogg', 50)
 	qdel(src)
 
 // Hey, did you ever see The Cube (1997) directed by Vincenzo Natali?
@@ -68,7 +68,7 @@
 	START_PROCESSING(SSobj, src)
 
 /obj/effect/razorweb/proc/decay()
-	playsound(usr, 'mods/species/ascent/sounds/razorweb_break.ogg', 50)
+	playsound(src, 'mods/species/ascent/sounds/razorweb_break.ogg', 50)
 	qdel_self()
 
 /obj/effect/razorweb/attack_hand(mob/user)
@@ -163,8 +163,8 @@
 
 	if(prob(break_chance))
 		visible_message(SPAN_DANGER("\The [src] breaks apart!"))
-		playsound(usr, 'mods/species/ascent/sounds/razorweb_break.ogg', 50)
+		playsound(src, 'mods/species/ascent/sounds/razorweb_break.ogg', 50)
 		qdel(src)
 	else
-		playsound(usr, 'mods/species/ascent/sounds/razorweb_twang.ogg', 50)
+		playsound(src, 'mods/species/ascent/sounds/razorweb_twang.ogg', 50)
 		break_chance = min(break_chance+10, 100)

--- a/mods/species/ascent/mobs/nymph/nymph_life.dm
+++ b/mods/species/ascent/mobs/nymph/nymph_life.dm
@@ -61,23 +61,22 @@
 		return
 
 	molt = min(molt + 1, 5)
-	var/mob/living/simple_animal/alien/kharmaan/nymph = usr
-	nymph.visible_message("\icon[nymph] [nymph] begins to shimmy and shake out of its old skin.")
+	visible_message("\icon[src] [src] begins to shimmy and shake out of its old skin.")
 	if(molt == 5)
-		if(do_after(nymph, 10 SECONDS, nymph, FALSE))
-			var/mob/living/human/H = new(get_turf(usr), SPECIES_MANTID_ALATE)
-			H.set_gyne_lineage(nymph.get_gyne_lineage())
+		if(do_after(src, 10 SECONDS, src, FALSE))
+			var/mob/living/human/H = new(get_turf(src), SPECIES_MANTID_ALATE)
+			H.set_gyne_lineage(get_gyne_lineage())
 			H.real_name = "[random_id(/decl/species/mantid, 10000, 99999)] [H.get_gyne_name()]"
-			H.nutrition = nymph.nutrition * 0.25 // Homgry after molt.
-			nymph.mind.transfer_to(H)
-			qdel(nymph)
+			H.nutrition = nutrition * 0.25 // Homgry after molt.
+			mind.transfer_to(H)
+			qdel(src)
 			H.visible_message("\icon[H] [H] emerges from its molt as a new alate.")
 			new/obj/item/ascent_molt(get_turf(src))
 		else
-			nymph.visible_message("\icon[nymph] [nymph] abruptly stops molting.")
+			visible_message("\icon[src] [src] abruptly stops molting.")
 		return
 
-	if(do_after(nymph, 5 SECONDS, nymph, FALSE))
+	if(do_after(src, 5 SECONDS, src, FALSE))
 		var/matrix/M = matrix()
 		M.Scale(1 + (molt / 10))
 		animate(src, transform = M, time = 2, easing = QUAD_EASING)
@@ -88,4 +87,4 @@
 		new /obj/item/ascent_molt(get_turf(src))
 
 	else
-		nymph.visible_message("\icon[nymph] [nymph] abruptly stops molting.")
+		visible_message("\icon[src] [src] abruptly stops molting.")


### PR DESCRIPTION
Removes a lot of unnecessary uses of `usr` (around 500, by my count). Using `usr` when `user` exists can result in funny bugs like "an admin's character is inexplicably electrocuted to death because they triggered the random camera damage event", and more mundane bugs like stuff just plain not working right. Mostly this is a code quality thing rather than bugfixes, though, so to dev it goes.

Completely untested as of writing this.