### PR TITLE
Misc Scav feedback fixes.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -124,10 +124,10 @@
 			var/resolved = holding.resolve_attackby(A, src, params)
 			if(!resolved && A && holding)
 				holding.afterattack(A, src, 1, params) // 1 indicates adjacency
-			setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+			setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 		else
 			if(ismob(A)) // No instant mob attacking
-				setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+				setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 			UnarmedAttack(A, TRUE)
 
 		trigger_aiming(TARGET_CAN_CLICK)
@@ -151,10 +151,10 @@
 				var/resolved = holding.resolve_attackby(A, src, params)
 				if(!resolved && A && holding)
 					holding.afterattack(A, src, 1, params) // 1: clicking something Adjacent
-				setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+				setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 			else
 				if(ismob(A)) // No instant mob attacking
-					setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+					setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 				UnarmedAttack(A, TRUE)
 
 			trigger_aiming(TARGET_CAN_CLICK)

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -69,7 +69,7 @@
 		var/resolved = holding.resolve_attackby(A, src, params)
 		if(!resolved && A && holding)
 			holding.afterattack(A, src, 1, params) // 1 indicates adjacency
-		setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 		return
 
 	if(!isturf(loc))
@@ -81,7 +81,7 @@
 			var/resolved = holding.resolve_attackby(A, src, params)
 			if(!resolved && A && holding)
 				holding.afterattack(A, src, 1, params) // 1 indicates adjacency
-			setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+			setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 		else
 			holding.afterattack(A, src, 0, params)
 		return

--- a/code/_onclick/rig.dm
+++ b/code/_onclick/rig.dm
@@ -46,6 +46,6 @@
 				return 0
 		rig.selected_module.engage(A, alert_ai)
 		if(ismob(A)) // No instant mob attacking - though modules have their own cooldowns
-			setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+			setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 		return 1
 	return 0

--- a/code/game/objects/effects/dirty_floor.dm
+++ b/code/game/objects/effects/dirty_floor.dm
@@ -11,6 +11,7 @@
 
 /obj/effect/decal/cleanable/dirt/visible
 	dirt_amount = 60
+	persistent = FALSE // This is a subtype for mapping.
 
 /obj/effect/decal/cleanable/dirt/Initialize()
 	. = ..()

--- a/code/game/objects/effects/dirty_floor.dm
+++ b/code/game/objects/effects/dirty_floor.dm
@@ -9,9 +9,13 @@
 	alpha = 0
 	var/dirt_amount = 0
 
+/obj/effect/decal/cleanable/dirt/visible
+	dirt_amount = 60
+
 /obj/effect/decal/cleanable/dirt/Initialize()
 	. = ..()
 	verbs.Cut()
+	update_icon()
 
 /obj/effect/decal/cleanable/dirt/on_update_icon()
 	. = ..()

--- a/code/game/objects/random/subtypes/misc.dm
+++ b/code/game/objects/random/subtypes/misc.dm
@@ -164,7 +164,7 @@
 		/obj/effect/decal/cleanable/ash,
 		/obj/effect/decal/cleanable/generic,
 		/obj/effect/decal/cleanable/flour,
-		/obj/effect/decal/cleanable/dirt,
+		/obj/effect/decal/cleanable/dirt/visible,
 		/obj/item/remains/robot
 	)
 	return spawnable_choices

--- a/code/game/objects/structures/_structure_icon.dm
+++ b/code/game/objects/structures/_structure_icon.dm
@@ -7,7 +7,7 @@ var/global/list/default_noblend_objects = list(/obj/machinery/door/window, /obj/
 /obj/structure/on_update_icon()
 	..()
 	if(material_alteration & MAT_FLAG_ALTERATION_COLOR)
-		update_material_colour()
+		update_material_color()
 	cut_overlays()
 	if(istype(lock))
 		update_lock_overlay()

--- a/code/game/objects/structures/_structure_materials.dm
+++ b/code/game/objects/structures/_structure_materials.dm
@@ -17,7 +17,7 @@
 	if(material_alteration & MAT_FLAG_ALTERATION_DESC)
 		update_material_desc()
 	if(material_alteration & MAT_FLAG_ALTERATION_COLOR)
-		update_material_colour()
+		update_material_color()
 	if((alpha / 255) < 0.5)
 		set_opacity(FALSE)
 	else
@@ -49,7 +49,7 @@
 	else
 		desc = base_desc
 
-/obj/structure/proc/update_material_colour()
+/obj/structure/proc/update_material_color()
 	color = get_color()
 	if(istype(material))
 		alpha = clamp((50 + material.opacity * 255), 0, 255)

--- a/code/game/objects/structures/bookcase.dm
+++ b/code/game/objects/structures/bookcase.dm
@@ -213,7 +213,7 @@ var/global/list/station_bookcases = list()
 /obj/structure/bookcase/cart/on_update_icon()
 	// We don't (can't) call parent, so we have to do this here
 	if(material_alteration & MAT_FLAG_ALTERATION_COLOR)
-		update_material_colour()
+		update_material_color()
 	cut_overlays()
 	if(istype(lock))
 		update_lock_overlay()

--- a/code/game/objects/structures/flora/potted.dm
+++ b/code/game/objects/structures/flora/potted.dm
@@ -9,7 +9,7 @@
 	anchored     = FALSE
 	layer        = ABOVE_HUMAN_LAYER
 	w_class      = ITEM_SIZE_LARGE
-	remains_type = /obj/effect/decal/cleanable/dirt
+	remains_type = /obj/effect/decal/cleanable/dirt/visible
 	hitsound     = 'sound/effects/glass_crack2.ogg'
 	snd_cut      = 'sound/effects/break_ceramic.ogg'
 	material     = /decl/material/solid/stone/pottery

--- a/code/game/objects/structures/tables.dm
+++ b/code/game/objects/structures/tables.dm
@@ -293,14 +293,9 @@
 	if(additional_reinf_material)
 		desc = "[desc] It has been reinforced with [additional_reinf_material.solid_name]."
 
-/obj/structure/table/update_material_colour()
-	if(is_flipped)
-		return ..()
-	alpha = 255
-	reset_color()
-
 /obj/structure/table/proc/handle_normal_icon()
 	color = null // Don't double-apply our color, clear the map preview.
+	alpha = 255
 	icon_state = "blank"
 	var/image/I
 	// Base frame shape.

--- a/code/game/turfs/turf_effects.dm
+++ b/code/game/turfs/turf_effects.dm
@@ -37,6 +37,7 @@
 	if(!dirt)
 		dirt = new(src)
 	dirt.dirt_amount = min(dirt.dirt_amount + amount, MAX_DIRT)
+	dirt.update_icon()
 	return TRUE
 #undef MAX_DIRT
 

--- a/code/modules/crafting/stack_recipes/recipes_hardness_integrity.dm
+++ b/code/modules/crafting/stack_recipes/recipes_hardness_integrity.dm
@@ -76,6 +76,9 @@
 /decl/stack_recipe/hardness/integrity/lock
 	result_type        = /obj/item/lock_construct
 
+/decl/stack_recipe/hardness/integrity/lockpick
+	result_type        = /obj/item/lockpick
+
 /decl/stack_recipe/hardness/integrity/key
 	result_type        = /obj/item/key
 

--- a/code/modules/fabrication/fabricator_bioprinter.dm
+++ b/code/modules/fabrication/fabricator_bioprinter.dm
@@ -12,7 +12,7 @@
 	var/datum/mob_snapshot/loaded_dna //DNA for biological organs
 
 /obj/machinery/fabricator/bioprinter/can_ingest(var/obj/item/thing)
-	. = istype(thing, /obj/item/organ) || istype(thing, /obj/item/food/butchery) || ..()
+	. = istype(thing, /obj/item/organ) || istype(thing, /obj/item/food/butchery) || istype(thing?.material, /decl/material/solid/organic/meat) || ..()
 
 /obj/machinery/fabricator/bioprinter/get_nano_template()
 	return "fabricator_bioprinter.tmpl"
@@ -22,9 +22,6 @@
 	//Keep these in the order so changing settings while queueing things up won't screw up older orders in the queue
 	order.set_data("dna", loaded_dna)
 	return order
-
-/obj/machinery/fabricator/bioprinter/can_ingest(var/obj/item/thing)
-	return istype(thing?.material, /decl/material/solid/organic/meat) || ..()
 
 /obj/machinery/fabricator/bioprinter/do_build(datum/fabricator_build_order/order)
 	. = ..()

--- a/code/modules/fabrication/fabricator_books.dm
+++ b/code/modules/fabrication/fabricator_books.dm
@@ -10,6 +10,13 @@
 	fabricator_class = FABRICATOR_CLASS_BOOKS
 	color_selectable = TRUE
 
+/obj/machinery/fabricator/book/can_ingest(obj/item/thing)
+	var/static/list/paper_types = list(
+		/obj/item/paper,
+		/obj/item/shreddedp
+	)
+	. = is_type_in_list(thing, paper_types) || ..()
+
 /obj/machinery/fabricator/book/make_order(datum/fabricator_recipe/recipe, multiplier)
 	var/datum/fabricator_build_order/order = ..()
 	LAZYSET(order.data, "selected_color", selected_color)

--- a/code/modules/fabrication/fabricator_food.dm
+++ b/code/modules/fabrication/fabricator_food.dm
@@ -33,7 +33,7 @@
 				break
 	..()
 
-/obj/machinery/fabricator/bioprinter/can_ingest(var/obj/item/thing)
+/obj/machinery/fabricator/replicator/can_ingest(var/obj/item/thing)
 	return istype(thing, /obj/item/food) || ..()
 
 /obj/machinery/fabricator/replicator/proc/state_status()

--- a/code/modules/locks/lock.dm
+++ b/code/modules/locks/lock.dm
@@ -20,6 +20,7 @@
 	var/lock_data = "" //basically a randomized string. The longer the string the more complex the lock.
 	var/atom/holder
 	var/material
+	var/lockpicking_skill = SKILL_DEVICES
 
 /datum/lock/New(var/atom/h, var/complexity = 1, var/mat)
 	holder = h
@@ -77,9 +78,9 @@
 	if(!unlock_power)
 		return FALSE
 	user.visible_message("<b>\The [user]</b> begins to pick \the [holder]'s lock with \the [I].", SPAN_NOTICE("You begin picking \the [holder]'s lock."))
-	if(!do_after(user, 2 SECONDS, holder))
+	if(!user.do_skilled(2 SECONDS, lockpicking_skill, holder, check_holding = TRUE, set_cooldown = TRUE))
 		return FALSE
-	if(prob(20*(unlock_power/getComplexity())))
+	if(!user.skill_fail_prob(lockpicking_skill, 100 - (20*(unlock_power/getComplexity())), SKILL_EXPERT))
 		to_chat(user, SPAN_NOTICE("You pick open \the [holder]'s lock!"))
 		unlock(lock_data)
 		return TRUE

--- a/code/modules/persistence/persistence_datum.dm
+++ b/code/modules/persistence/persistence_datum.dm
@@ -63,9 +63,8 @@
 		else
 			return
 
-	. = GetValidTurf(locate(tokens["x"], tokens["y"], tokens["z"]), tokens)
-	if(.)
-		CreateEntryInstance(., tokens)
+	if(GetValidTurf(locate(tokens["x"], tokens["y"], tokens["z"]), tokens))
+		return CreateEntryInstance(., tokens)
 
 /decl/persistence_handler/proc/IsValidEntry(var/atom/entry)
 	if(!istype(entry))
@@ -92,7 +91,7 @@
 	.["age"] = GetEntryAge(entry)
 
 /decl/persistence_handler/proc/FinalizeTokens(var/list/tokens)
-	. = tokens
+	. = tokens || list()
 
 /decl/persistence_handler/Initialize()
 

--- a/code/modules/persistence/persistence_datum_book.dm
+++ b/code/modules/persistence/persistence_datum_book.dm
@@ -17,7 +17,7 @@
 	if(case)
 		book.forceMove(case)
 		case.update_icon()
-	. = book
+	return book
 
 /decl/persistence_handler/book/IsValidEntry(var/atom/entry)
 	. = ..()

--- a/code/modules/persistence/persistence_datum_filth.dm
+++ b/code/modules/persistence/persistence_datum_filth.dm
@@ -15,11 +15,16 @@
 	. = ..()
 	if(.["path"] && !ispath(.["path"]))
 		.["path"] = text2path(.["path"])
-	. = tokens
+	if(isnull(.["filthiness"]))
+		.["filthiness"] = 0
 
 /decl/persistence_handler/filth/CreateEntryInstance(var/turf/creating, var/list/tokens)
 	var/_path = tokens["path"]
-	new _path(creating, tokens["age"]+1)
+	var/obj/effect/decal/cleanable/dirt/dirt = new _path(creating, tokens["age"]+1)
+	if(istype(dirt))
+		dirt.dirt_amount = tokens["filthiness"]
+		dirt.update_icon()
+	return dirt
 
 /decl/persistence_handler/filth/GetEntryAge(var/atom/entry)
 	var/obj/effect/decal/cleanable/filth = entry
@@ -32,3 +37,8 @@
 /decl/persistence_handler/filth/CompileEntry(var/atom/entry)
 	. = ..()
 	.["path"] = "[GetEntryPath(entry)]"
+	if(istype(entry, /obj/effect/decal/cleanable/dirt))
+		var/obj/effect/decal/cleanable/dirt/dirt = entry
+		.["filthiness"] = dirt.dirt_amount
+	else
+		.["filthiness"] = 0

--- a/code/modules/persistence/persistence_datum_graffiti.dm
+++ b/code/modules/persistence/persistence_datum_graffiti.dm
@@ -17,7 +17,7 @@
 	return TRUE
 
 /decl/persistence_handler/graffiti/CreateEntryInstance(var/turf/creating, var/list/tokens)
-	new /obj/effect/decal/writing(creating, tokens["age"]+1, tokens["message"], tokens["author"])
+	return new /obj/effect/decal/writing(creating, tokens["age"]+1, tokens["message"], tokens["author"])
 
 /decl/persistence_handler/graffiti/IsValidEntry(var/atom/entry)
 	. = ..()

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -815,12 +815,7 @@ var/global/datum/reagents/sink/infinite_reagent_sink = new
 		target.remove_cleanables()
 	if(dirtiness != DIRTINESS_NEUTRAL)
 		if(dirtiness > DIRTINESS_NEUTRAL)
-			var/obj/effect/decal/cleanable/dirt/dirtoverlay = locate() in target
-			if (!dirtoverlay)
-				dirtoverlay = new /obj/effect/decal/cleanable/dirt(target)
-				dirtoverlay.alpha = total_volume * dirtiness
-			else
-				dirtoverlay.alpha = min(dirtoverlay.alpha + total_volume * dirtiness, 255)
+			target.add_dirt(ceil(total_volume * dirtiness))
 		else
 			if(dirtiness <= DIRTINESS_STERILE)
 				target.germ_level -= min(total_volume*20, target.germ_level)

--- a/code/procs/hud.dm
+++ b/code/procs/hud.dm
@@ -13,73 +13,71 @@ the HUD updates properly! */
 	if(!can_process_hud(M))
 		return
 	var/datum/arranged_hud_process/P = arrange_hud_process(M, Alt, global.med_hud_users)
-	for(var/mob/living/human/patient in P.Mob.in_view(P.Turf))
+	for(var/mob/living/human/patient in P.hud_mob.in_view(P.hud_turf))
 
-		if(patient.is_invisible_to(P.Mob))
+		if(patient.is_invisible_to(P.hud_mob))
 			continue
 
 		if(local_scanner)
-			P.Client.images += patient.hud_list[HEALTH_HUD]
+			P.hud_client.images += patient.hud_list[HEALTH_HUD]
 
 			if(network)
 				var/record = network.get_crew_record_by_name(patient.get_visible_name())
 				if(!record)
 					return
-				P.Client.images += patient.hud_list[STATUS_HUD]
+				P.hud_client.images += patient.hud_list[STATUS_HUD]
 		else
 			var/sensor_level = getsensorlevel(patient)
 			if(sensor_level >= VITALS_SENSOR_VITAL)
-				P.Client.images += patient.hud_list[HEALTH_HUD]
+				P.hud_client.images += patient.hud_list[HEALTH_HUD]
 			if(sensor_level >= VITALS_SENSOR_BINARY)
-				P.Client.images += patient.hud_list[LIFE_HUD]
+				P.hud_client.images += patient.hud_list[LIFE_HUD]
 
 //Security HUDs. Pass a value for the second argument to enable implant viewing or other special features.
 /proc/process_sec_hud(var/mob/M, var/advanced_mode, var/mob/Alt, datum/computer_network/network)
 	if(!can_process_hud(M))
 		return
 	var/datum/arranged_hud_process/P = arrange_hud_process(M, Alt, global.sec_hud_users)
-	for(var/mob/living/human/perp in P.Mob.in_view(P.Turf))
+	for(var/mob/living/human/perp in P.hud_mob.in_view(P.hud_turf))
 
-		if(perp.is_invisible_to(P.Mob))
+		if(perp.is_invisible_to(P.hud_mob))
 			continue
 
 		if(network)
 			var/record = network.get_crew_record_by_name(perp.get_visible_name())
 			if(!record)
 				return
-			P.Client.images += perp.hud_list[ID_HUD]
+			P.hud_client.images += perp.hud_list[ID_HUD]
 			if(advanced_mode)
-				P.Client.images += perp.hud_list[WANTED_HUD]
-				P.Client.images += perp.hud_list[IMPTRACK_HUD]
-				P.Client.images += perp.hud_list[IMPLOYAL_HUD]
-				P.Client.images += perp.hud_list[IMPCHEM_HUD]
+				P.hud_client.images += perp.hud_list[WANTED_HUD]
+				P.hud_client.images += perp.hud_list[IMPTRACK_HUD]
+				P.hud_client.images += perp.hud_list[IMPLOYAL_HUD]
+				P.hud_client.images += perp.hud_list[IMPCHEM_HUD]
 
 /proc/process_jani_hud(var/mob/M, var/mob/Alt)
 	var/datum/arranged_hud_process/P = arrange_hud_process(M, Alt, global.jani_hud_users)
-	for (var/obj/effect/decal/cleanable/dirtyfloor in view(P.Mob))
-		P.Client.images += dirtyfloor.hud_overlay
+	for (var/obj/effect/decal/cleanable/dirtyfloor in view(P.hud_mob))
+		if(istype(dirtyfloor, /obj/effect/decal/cleanable/dirt))
+			var/obj/effect/decal/cleanable/dirt/dirt = dirtyfloor
+			if(dirt.alpha <= 0)
+				continue
+		P.hud_client.images += dirtyfloor.hud_overlay
 
 /datum/arranged_hud_process
-	var/client/Client
-	var/mob/Mob
-	var/turf/Turf
+	var/client/hud_client
+	var/mob/hud_mob
+	var/turf/hud_turf
 
 /proc/arrange_hud_process(var/mob/M, var/mob/Alt, var/list/hud_list)
 	hud_list |= M
 	var/datum/arranged_hud_process/P = new
-	P.Client = M.client
-	P.Mob = Alt ? Alt : M
-	P.Turf = get_turf(P.Mob)
+	P.hud_client = M.client
+	P.hud_mob = Alt ? Alt : M
+	P.hud_turf = get_turf(P.hud_mob)
 	return P
 
 /proc/can_process_hud(var/mob/M)
-	if(!M)
-		return 0
-	if(!M.client)
-		return 0
-	if(M.stat != CONSCIOUS)
-		return 0
-	return 1
+	return M?.client && M.stat == CONSCIOUS
 
 //Deletes the current HUD images so they can be refreshed with new ones.
 /mob/proc/handle_hud_glasses() //Used in the life.dm of mobs that can use HUDs.

--- a/maps/away/bearcat/bearcat-1.dmm
+++ b/maps/away/bearcat/bearcat-1.dmm
@@ -145,7 +145,7 @@
 	dir = 8;
 	icon_state = "bulb1"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo/lower)
 "aw" = (
@@ -253,11 +253,11 @@
 	pixel_x = -24;
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo/lower)
 "aG" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stool/padded,
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo/lower)
@@ -335,7 +335,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo/lower)
 "aP" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -724,7 +724,7 @@
 /turf/floor/usedup,
 /area/ship/scrap/maintenance/lower)
 "bF" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -24;
@@ -830,7 +830,7 @@
 /area/ship/scrap/cargo/lower)
 "bQ" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/computer/shuttle_control/lift,
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo/lower)
@@ -1111,7 +1111,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo/lower)
 "ct" = (
@@ -1283,7 +1283,7 @@
 	dir = 8;
 	icon_state = "bulb1"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo/lower)
 "cQ" = (
@@ -1540,16 +1540,16 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo/lower)
 "dp" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo/lower)
 "dq" = (
 /obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo/lower)
 "dr" = (
@@ -1561,7 +1561,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo/lower)
 "ds" = (
@@ -1957,7 +1957,7 @@
 	icon_state = "bulb1"
 	},
 /obj/structure/ladder,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/sign/deck/second{
 	pixel_y = 32
 	},
@@ -1973,7 +1973,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/usedup,
 /area/ship/scrap/maintenance/storage)
 "ej" = (
@@ -1983,7 +1983,7 @@
 /turf/floor/usedup,
 /area/ship/scrap/maintenance/eva)
 "ek" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/light/small{
 	dir = 1;
 	icon_state = "bulb1"
@@ -2060,7 +2060,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -2073,7 +2073,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/maintenance/storage)
 "es" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -2090,7 +2090,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/maintenance/storage)
 "eu" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -2130,7 +2130,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/usedup,
 /area/ship/scrap/maintenance/eva)
 "ey" = (
@@ -2306,7 +2306,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/maintenance/storage)
 "eK" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -2319,7 +2319,7 @@
 /obj/structure/cable{
 	icon_state = "5-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/usedup,
 /area/ship/scrap/maintenance/storage)
 "eM" = (
@@ -2330,14 +2330,14 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/usedup,
 /area/ship/scrap/maintenance/eva)
 "eN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/usedup,
 /area/ship/scrap/maintenance/eva)
 "eO" = (

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -587,7 +587,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/dock)
 "bo" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -654,7 +654,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/dock)
 "bt" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -773,7 +773,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -912,7 +912,7 @@
 /turf/floor/usedup,
 /area/ship/scrap/dock)
 "bM" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
@@ -1234,7 +1234,7 @@
 	dir = 8;
 	icon_state = "twindow"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/floor/tiled/usedup,
 /area/ship/scrap/crew/toilets)
@@ -1554,7 +1554,7 @@
 	dir = 8;
 	icon_state = "twindow"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/floor/tiled/usedup,
 /area/ship/scrap/crew/toilets)
@@ -1571,7 +1571,7 @@
 	icon_state = "twindow"
 	},
 /obj/structure/window/reinforced/tinted,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable,
 /obj/machinery/power/apc/derelict{
 	dir = 4;
@@ -1592,7 +1592,7 @@
 	dir = 8;
 	icon_state = "bulb1"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "conpipe-c"
@@ -1608,7 +1608,7 @@
 /turf/wall,
 /area/ship/scrap/crew/saloon)
 "dn" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -1668,7 +1668,7 @@
 	dir = 4;
 	icon_state = "bulb1"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/floor/tiled/usedup,
@@ -1824,13 +1824,13 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo)
 "dL" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo)
 "dM" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/corner/beige{
 	dir = 6
@@ -1940,7 +1940,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/crew/hallway/port)
 "dX" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -24;
@@ -1954,7 +1954,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo)
 "dZ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1973,7 +1973,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo)
 "eb" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/light/small{
 	dir = 4;
 	icon_state = "bulb1"
@@ -2055,7 +2055,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/crew/kitchen)
 "ek" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -2173,7 +2173,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo)
 "es" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -2386,7 +2386,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo)
 "eJ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
@@ -2418,7 +2418,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo)
 "eM" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable,
 /obj/machinery/power/apc/derelict{
 	dir = 4;
@@ -2568,7 +2568,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo)
 "fb" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/computer/shuttle_control/lift,
@@ -2585,7 +2585,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/cargo)
 "fd" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2972,7 +2972,7 @@
 /area/ship/scrap/cargo)
 "fO" = (
 /obj/structure/emergency_dispenser/west,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -3090,7 +3090,7 @@
 	dir = 4;
 	icon_state = "bulb1"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -3348,7 +3348,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/fire)
 "gD" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -3486,7 +3486,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/maintenance/hallway)
 "gO" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -3756,8 +3756,8 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/maintenance/engineering)
 "ho" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
@@ -3792,7 +3792,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/maintenance/engineering)
 "hq" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/light_switch{
 	pixel_y = 25
 	},
@@ -3962,7 +3962,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stool/padded,
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -3981,7 +3981,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -4140,7 +4140,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/maintenance/engineering)
 "hU" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
 	},

--- a/maps/away/liberia/liberia.dmm
+++ b/maps/away/liberia/liberia.dmm
@@ -1095,7 +1095,7 @@
 	pixel_x = -6;
 	pixel_y = 28
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "merchant_ship_vent"
 	},
@@ -5774,7 +5774,7 @@
 	pixel_x = -28;
 	pixel_y = -10
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/catwalk,
 /obj/structure/cable/blue{
 	icon_state = "1-4"

--- a/maps/away/mining/mining-signal.dmm
+++ b/maps/away/mining/mining-signal.dmm
@@ -339,22 +339,22 @@
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
 "bt" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/corner/purple{
 	dir = 5
 	},
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
 "bu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/corner/purple{
 	dir = 5
 	},
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
 "bv" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -377,7 +377,7 @@
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
 "by" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor,
 /area/outpost/abandoned)
 "bz" = (
@@ -407,7 +407,7 @@
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
 "bB" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/noticeboard/anomaly{
 	default_pixel_y = 32
 	},
@@ -420,22 +420,22 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
 "bD" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor,
 /area/outpost/abandoned)
 "bE" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
 "bF" = (
@@ -459,13 +459,13 @@
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
 "bI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/trash/cigbutt/cigarbutt,
 /turf/floor,
 /area/outpost/abandoned)
 "bJ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
 "bK" = (
@@ -473,8 +473,8 @@
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
 "bL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
 "bM" = (
@@ -482,7 +482,7 @@
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
 "bN" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/blood,
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
@@ -497,14 +497,14 @@
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
 "bQ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/corner/purple{
 	dir = 10
 	},
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
 "bR" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/light/small,
 /turf/floor,
 /area/outpost/abandoned)
@@ -525,7 +525,7 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
 "bV" = (
@@ -570,7 +570,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "cc" = (
@@ -582,7 +582,7 @@
 	dir = 1;
 	icon_state = "bulb1"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "cd" = (
@@ -590,8 +590,8 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "ce" = (
@@ -604,7 +604,7 @@
 /obj/effect/floor_decal/corner/red/three_quarters{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/ammo_casing/pistol/magnum,
 /turf/floor/tiled/dark,
 /area/outpost/abandoned)
@@ -612,7 +612,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/ammo_casing/pistol/magnum,
 /turf/floor/tiled/dark,
 /area/outpost/abandoned)
@@ -632,8 +632,8 @@
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
 "ck" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor,
 /area/outpost/abandoned)
 "cl" = (
@@ -663,12 +663,12 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/broken/three,
 /area/outpost/abandoned)
 "co" = (
 /obj/structure/table/woodentable,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/trash,
 /turf/floor/wood,
 /area/outpost/abandoned)
@@ -692,7 +692,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood,
 /area/outpost/abandoned)
 "ct" = (
@@ -710,13 +710,13 @@
 /area/outpost/abandoned)
 "cv" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "cw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "cx" = (
@@ -730,35 +730,35 @@
 /turf/wall/titanium,
 /area/outpost/abandoned)
 "cG" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/wall/titanium,
 /area/outpost/abandoned)
 "cH" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood,
 /area/outpost/abandoned)
 "cI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood,
 /area/outpost/abandoned)
 "cJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/broken/four,
 /area/outpost/abandoned)
 "cK" = (
 /obj/effect/floor_decal/plaque,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood,
 /area/outpost/abandoned)
 "cL" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/trash,
 /turf/floor/wood/broken,
 /area/outpost/abandoned)
@@ -801,19 +801,19 @@
 /area/outpost/abandoned)
 "cU" = (
 /obj/effect/floor_decal/corner/paleblue/three_quarters,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "cV" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "cW" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "cX" = (
@@ -821,7 +821,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/loot,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
@@ -829,12 +829,12 @@
 /obj/effect/floor_decal/corner/paleblue/three_quarters{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "cZ" = (
 /obj/effect/floor_decal/corner/red/three_quarters,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/outpost/abandoned)
 "da" = (
@@ -844,7 +844,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/outpost/abandoned)
 "db" = (
@@ -866,7 +866,7 @@
 /area/outpost/abandoned)
 "dd" = (
 /obj/structure/barricade,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor,
 /area/outpost/abandoned)
 "de" = (
@@ -889,7 +889,7 @@
 /area/outpost/abandoned)
 "df" = (
 /obj/effect/wallframe_spawn/reinforced,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/door/blast/regular{
 	id_tag = "mars_blast"
 	},
@@ -899,31 +899,31 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/carpet,
 /area/outpost/abandoned)
 "dh" = (
 /turf/floor/carpet/broken,
 /area/outpost/abandoned)
 "di" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/carpet/broken,
 /area/outpost/abandoned)
 "dj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/carpet,
 /area/outpost/abandoned)
 "dk" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/carpet/broken,
 /area/outpost/abandoned)
 "dl" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/carpet,
 /area/outpost/abandoned)
 "dm" = (
@@ -1021,7 +1021,7 @@
 /obj/item/shard{
 	icon_state = "shardlarge"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "dF" = (
@@ -1032,7 +1032,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "dG" = (
@@ -1121,16 +1121,16 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "dV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating/broken,
 /area/outpost/abandoned)
 "dW" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "dY" = (
@@ -1143,7 +1143,7 @@
 	dir = 4;
 	icon_state = "bulb1"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "dZ" = (
@@ -1154,18 +1154,18 @@
 /turf/wall/titanium,
 /area/outpost/abandoned)
 "ea" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/abstract/landmark/mapped_fluid/fuel,
 /obj/abstract/landmark/mapped_fluid/fuel,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "eb" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/mop,
 /turf/floor/plating/broken/two,
 /area/outpost/abandoned)
 "ec" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/abstract/landmark/mapped_fluid/fuel,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
@@ -1199,7 +1199,7 @@
 /turf/floor/barren,
 /area/mine/explored)
 "ej" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/barren,
 /area/mine/explored)
 "ek" = (
@@ -1244,13 +1244,13 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "es" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "et" = (
@@ -1260,15 +1260,15 @@
 	dir = 1
 	},
 /obj/item/shard,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "eu" = (
 /obj/abstract/landmark/mapped_fluid/fuel,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /mob/living/bot/medbot,
 /turf/floor/tiled/white/airless,
 /area/outpost/abandoned)
@@ -1289,13 +1289,13 @@
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "ez" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating/broken/one,
 /area/outpost/abandoned)
 "eA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/gibspawner/human,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
@@ -1322,7 +1322,7 @@
 /area/outpost/abandoned)
 "eF" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 4
 	},
@@ -1340,7 +1340,7 @@
 /turf/floor/plating,
 /area/outpost/abandoned)
 "eI" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/door/airlock/external,
 /turf/floor/plating,
 /area/outpost/abandoned)
@@ -1348,27 +1348,27 @@
 /obj/item/shard{
 	icon_state = "shardsmall"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/outpost/abandoned)
 "eK" = (
 /obj/item/shard{
 	icon_state = "piecesmall"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/outpost/abandoned)
 "eL" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/outpost/abandoned)
 "eM" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "eO" = (
@@ -1381,7 +1381,7 @@
 /turf/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "eP" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating/broken/four,
 /area/outpost/abandoned)
 "eQ" = (
@@ -1423,15 +1423,15 @@
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "eV" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
 	},
 /turf/floor/plating/broken/one,
 /area/outpost/abandoned)
 "eW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/abstract/landmark/mapped_fluid/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
@@ -1439,9 +1439,9 @@
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "eX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/generic,
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
@@ -1449,8 +1449,8 @@
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "eY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/wrench,
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
@@ -1458,7 +1458,7 @@
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "eZ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
 	},
@@ -1472,7 +1472,7 @@
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "fb" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
 	},
@@ -1481,7 +1481,7 @@
 /turf/floor/plating/broken/one,
 /area/outpost/abandoned)
 "fc" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_magazine/pistol/small,
 /turf/floor/tiled/airless,
@@ -1495,25 +1495,25 @@
 /turf/floor/tiled/airless,
 /area/mine/explored)
 "ff" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 4
 	},
 /turf/floor/barren,
 /area/mine/explored)
 "fg" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/warning/cee,
 /turf/floor/plating,
 /area/outpost/abandoned)
 "fh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/outpost/abandoned)
 "fi" = (
 /obj/item/pen,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/outpost/abandoned)
 "fj" = (
@@ -1539,8 +1539,8 @@
 /area/outpost/abandoned)
 "fo" = (
 /obj/random/medical,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "fq" = (
@@ -1560,33 +1560,33 @@
 /turf/floor/fake_grass,
 /area/outpost/abandoned)
 "fs" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/vomit,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "ft" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/medical,
 /turf/floor/plating/broken/four,
 /area/outpost/abandoned)
 "fu" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/mopbucket,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "fv" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/remains,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "fw" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/trash,
 /turf/floor/plating/broken/one,
 /area/outpost/abandoned)
 "fx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/ammo_magazine/pistol/small,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
@@ -1638,8 +1638,8 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "fG" = (
@@ -1647,8 +1647,8 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "fH" = (
@@ -1659,7 +1659,7 @@
 /turf/floor/fake_grass,
 /area/outpost/abandoned)
 "fJ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/window/basic{
 	dir = 4
 	},
@@ -1695,7 +1695,7 @@
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "fO" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	dir = 4;
 	icon_state = "0-2"
@@ -1707,7 +1707,7 @@
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "fP" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/light/small/emergency,
 /obj/structure/cable{
 	dir = 4;
@@ -1720,7 +1720,7 @@
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "fR" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/mine/explored)
 "fS" = (
@@ -1729,7 +1729,7 @@
 /turf/floor/tiled/dark,
 /area/outpost/abandoned)
 "fT" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/firealarm{
 	dir = 1;
 	icon_state = "firex";
@@ -1783,7 +1783,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "gb" = (
@@ -1791,7 +1791,7 @@
 /area/mine/explored)
 "gc" = (
 /obj/item/solar_assembly,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/barren,
 /area/mine/explored)
 "gd" = (
@@ -1822,17 +1822,17 @@
 /turf/floor/plating,
 /area/outpost/abandoned)
 "gi" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/abstract/landmark/proc_caller/floor_breaker,
 /turf/floor/tiled/airless/broken,
 /area/mine/explored)
 "gj" = (
 /obj/machinery/door/airlock/hatch,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/outpost/abandoned)
 "gk" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/power/terminal{
 	dir = 1
 	},
@@ -1849,7 +1849,7 @@
 /turf/floor/plating/broken/two,
 /area/outpost/abandoned)
 "gn" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
 	icon_state = "warning"
@@ -1891,16 +1891,16 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/barren,
 /area/mine/explored)
 "gt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/barren,
 /area/mine/explored)
 "gu" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/outpost/abandoned)
 "gv" = (
@@ -1927,7 +1927,7 @@
 /turf/floor/plating,
 /area/outpost/abandoned)
 "gy" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/light/small/emergency{
 	dir = 8;
 	icon_state = "bulb1"
@@ -1966,7 +1966,7 @@
 /area/outpost/abandoned)
 "gE" = (
 /obj/effect/decal/cleanable/blood/tracks/footprints,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "gF" = (
@@ -1996,8 +1996,8 @@
 /turf/floor/plating,
 /area/outpost/abandoned)
 "gK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable/orange{
 	icon_state = "2-8"
 	},
@@ -2012,7 +2012,7 @@
 /turf/floor/barren,
 /area/mine/explored)
 "gN" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/door/firedoor,
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -2021,7 +2021,7 @@
 /area/outpost/abandoned)
 "gO" = (
 /obj/effect/decal/cleanable/blood/tracks/footprints,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/firedoor_assembly{
 	anchored = 1
 	},
@@ -2040,7 +2040,7 @@
 /turf/floor/barren,
 /area/outpost/abandoned)
 "gR" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
@@ -2210,7 +2210,7 @@
 /turf/floor/plating,
 /area/outpost/abandoned)
 "hp" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/abstract/landmark/mapped_fluid/fuel,
 /turf/floor/plating,
 /area/outpost/abandoned)
@@ -2311,7 +2311,7 @@
 /area/outpost/abandoned)
 "hD" = (
 /obj/random/junk,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/abstract/landmark/mapped_fluid/fuel,
 /turf/floor/plating,
 /area/outpost/abandoned)
@@ -2339,7 +2339,7 @@
 /turf/floor/plating,
 /area/outpost/abandoned)
 "hL" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/overmap/visitable/sector/away,
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
@@ -2382,7 +2382,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/ammo_casing/pistol/magnum,
 /obj/abstract/landmark/allowed_leak,
 /turf/floor/tiled/dark,
@@ -2392,9 +2392,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/ammo_casing/pistol/magnum,
 /turf/floor/tiled/dark,
 /area/outpost/abandoned)
@@ -2429,10 +2429,10 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/vomit,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor,
 /area/outpost/abandoned)
 "wb" = (
@@ -2454,7 +2454,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/light/small/emergency{
 	dir = 4;
 	icon_state = "bulb1"
@@ -2462,8 +2462,8 @@
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
 "HD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "IX" = (

--- a/maps/away/slavers/slavers_base.dmm
+++ b/maps/away/slavers/slavers_base.dmm
@@ -220,7 +220,7 @@
 /turf/floor/plating/airless,
 /area/slavers_base/cells)
 "aT" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/blood,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -230,7 +230,7 @@
 /turf/floor/tiled/airless,
 /area/slavers_base/cells)
 "aU" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/cells)
 "aV" = (
@@ -262,7 +262,7 @@
 /turf/floor/plating/airless,
 /area/slavers_base/cells)
 "bb" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -332,7 +332,7 @@
 /turf/floor/plating/airless,
 /area/slavers_base/cells)
 "bm" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -345,7 +345,7 @@
 /turf/floor/tiled/airless,
 /area/slavers_base/cells)
 "bn" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -361,7 +361,7 @@
 /obj/machinery/door/airlock{
 	name = "Cell block B"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -377,7 +377,7 @@
 /turf/floor/tiled/airless,
 /area/slavers_base/cells)
 "bp" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -396,14 +396,14 @@
 /turf/floor/tiled/airless,
 /area/slavers_base/cells)
 "bq" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
 /turf/floor/tiled/airless,
 /area/slavers_base/cells)
 "br" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
@@ -420,14 +420,14 @@
 	id_tag = "permentryflash";
 	name = "Floor mounted flash"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
 /turf/floor/tiled/airless,
 /area/slavers_base/cells)
 "bt" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
@@ -453,7 +453,7 @@
 /turf/floor/plating/airless,
 /area/slavers_base/cells)
 "bx" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
@@ -466,7 +466,7 @@
 /area/slavers_base/powatm)
 "bz" = (
 /obj/structure/closet/crate/plastic/rations,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -477,14 +477,14 @@
 /area/slavers_base/cells)
 "bA" = (
 /obj/random/trash,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/floor/tiled/airless,
 /area/slavers_base/cells)
 "bB" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/remains/human,
 /turf/floor/tiled/airless,
 /area/slavers_base/cells)
@@ -492,7 +492,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
@@ -507,7 +507,7 @@
 /turf/floor/plating/airless,
 /area/slavers_base/cells)
 "bF" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -589,11 +589,11 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/cells)
 "bS" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable/cyan{
 	icon_state = "1-4"
 	},
@@ -603,7 +603,7 @@
 /turf/floor/tiled/airless,
 /area/slavers_base/cells)
 "bT" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
@@ -623,7 +623,7 @@
 /area/slavers_base/cells)
 "bV" = (
 /obj/random/trash,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
@@ -640,7 +640,7 @@
 	id_tag = "permentryflash";
 	name = "Floor mounted flash"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/ammo_casing/shotgun/beanbag{
 	pixel_x = -8;
 	pixel_y = -4
@@ -666,7 +666,7 @@
 /obj/machinery/door/airlock{
 	name = "Dens block"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -679,7 +679,7 @@
 /turf/floor/tiled/airless,
 /area/slavers_base/cells)
 "bY" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/blood,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -697,7 +697,7 @@
 /turf/floor/tiled/airless,
 /area/slavers_base/cells)
 "bZ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/blood,
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -729,7 +729,7 @@
 /turf/floor/plating/airless,
 /area/slavers_base/cells)
 "cc" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -787,7 +787,7 @@
 /turf/floor/plating/airless,
 /area/slavers_base/cells)
 "cl" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -800,7 +800,7 @@
 /turf/wall,
 /area/slavers_base/hangar)
 "cn" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/ammo_casing/shotgun/beanbag,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -820,7 +820,7 @@
 /obj/machinery/door/airlock{
 	name = "Cell block A"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -836,7 +836,7 @@
 /turf/floor/tiled/airless,
 /area/slavers_base/cells)
 "cp" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -855,7 +855,7 @@
 /turf/floor/tiled/airless,
 /area/slavers_base/cells)
 "cq" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
@@ -868,7 +868,7 @@
 /turf/floor/tiled/airless,
 /area/slavers_base/cells)
 "cr" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable/cyan{
 	icon_state = "1-8"
 	},
@@ -897,7 +897,7 @@
 /turf/floor/plating/airless,
 /area/slavers_base/cells)
 "cw" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/ammo_casing/shotgun/beanbag,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -916,7 +916,7 @@
 /turf/floor/plating/airless,
 /area/slavers_base/cells)
 "cz" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -929,7 +929,7 @@
 /turf/floor/tiled/airless,
 /area/slavers_base/cells)
 "cA" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -1044,7 +1044,7 @@
 /turf/wall,
 /area/slavers_base/secwing)
 "cT" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1056,7 +1056,7 @@
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "cU" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/door/airlock{
 	name = "Slave hold hallway"
 	},
@@ -1193,7 +1193,7 @@
 /turf/floor/tiled/airless,
 /area/slavers_base/secwing)
 "ds" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -1209,7 +1209,7 @@
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "dt" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -1256,7 +1256,7 @@
 /turf/floor/tiled/airless,
 /area/slavers_base/med)
 "dw" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -1268,18 +1268,18 @@
 /turf/floor/tiled/airless,
 /area/slavers_base/med)
 "dx" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/med)
 "dy" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/floor/tiled/airless,
 /area/slavers_base/med)
 "dz" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/hygiene/shower{
 	pixel_y = 30
 	},
@@ -1401,41 +1401,41 @@
 /turf/floor/tiled/airless,
 /area/slavers_base/secwing)
 "dT" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/ammo_casing/shotgun/beanbag,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "dU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "dV" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/floor/tiled/airless,
 /area/slavers_base/med)
 "dW" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/junk,
 /turf/floor/tiled/airless,
 /area/slavers_base/med)
 "dX" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/medical/lite,
 /turf/floor/tiled/airless,
 /area/slavers_base/med)
@@ -1545,12 +1545,12 @@
 "er" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "es" = (
 /obj/item/ammo_casing/shotgun/beanbag,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "et" = (
@@ -1564,7 +1564,7 @@
 /obj/structure/window/basic{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/abstract/landmark/corpse/slavers_base/slaver5,
 /obj/effect/decal/cleanable/blood,
 /turf/floor/tiled/airless,
@@ -1579,11 +1579,11 @@
 /obj/structure/window/basic{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/med)
 "ex" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/ammo_casing/shotgun/beanbag,
 /turf/floor/tiled/airless,
 /area/slavers_base/med)
@@ -1738,7 +1738,7 @@
 /area/slavers_base/secwing)
 "eT" = (
 /obj/item/gun/projectile/shotgun/pump,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "eU" = (
@@ -1882,7 +1882,7 @@
 /turf/floor/tiled/airless,
 /area/slavers_base/secwing)
 "fo" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "fp" = (
@@ -1932,7 +1932,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating/airless,
 /area/slavers_base/hallway)
 "fu" = (
@@ -1948,7 +1948,7 @@
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "fv" = (
@@ -1961,7 +1961,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "fw" = (
@@ -1977,7 +1977,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "fx" = (
@@ -1986,8 +1986,8 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "fy" = (
@@ -2000,7 +2000,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "fz" = (
@@ -2138,7 +2138,7 @@
 /obj/machinery/door/airlock{
 	name = "Power/atmos"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating/airless,
 /area/slavers_base/hallway)
 "fS" = (
@@ -2147,31 +2147,31 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "fT" = (
 /obj/item/wrench,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "fU" = (
 /obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "fV" = (
 /obj/machinery/door/airlock{
 	name = "West hallway"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "fW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "fX" = (
@@ -2408,11 +2408,11 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "gG" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
@@ -2588,7 +2588,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "hc" = (
@@ -2947,7 +2947,7 @@
 /turf/floor/tiled,
 /area/slavers_base/dorms)
 "id" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/generic,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
@@ -3106,7 +3106,7 @@
 /area/slavers_base/dorms)
 "iG" = (
 /obj/random/junk,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "iH" = (
@@ -3121,19 +3121,19 @@
 /turf/floor/plating/airless,
 /area/slavers_base/maint)
 "iI" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/demo)
 "iJ" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/demo)
 "iK" = (
 /obj/item/clothing/suit/nun,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/demo)
 "iL" = (
@@ -3141,7 +3141,7 @@
 	dir = 1
 	},
 /obj/item/clothing/suit/robe/yellowed,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/demo)
 "iM" = (
@@ -3281,7 +3281,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
@@ -3289,13 +3289,13 @@
 /area/slavers_base/demo)
 "ja" = (
 /obj/item/clothing/shoes/color/brown,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/demo)
 "jb" = (
 /obj/item/clothing/pants/pj/blue,
 /obj/item/clothing/shirt/pj/blue,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/demo)
 "jc" = (
@@ -3405,7 +3405,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -3417,7 +3417,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "jv" = (
@@ -3487,11 +3487,11 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/airless,
 /area/slavers_base/hallway)
 "jH" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -3892,7 +3892,7 @@
 /turf/floor/tiled/white,
 /area/slavers_base/dorms)
 "nm" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/floor/tiled/airless,
 /area/slavers_base/demo)

--- a/maps/away/smugglers/smugglers.dmm
+++ b/maps/away/smugglers/smugglers.dmm
@@ -204,7 +204,7 @@
 /turf/floor,
 /area/smugglers/base)
 "aF" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
@@ -367,7 +367,7 @@
 /turf/floor,
 /area/smugglers/base)
 "aW" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor,
 /area/smugglers/base)
 "aX" = (
@@ -607,7 +607,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/smugglers/office)
 "bD" = (
@@ -661,7 +661,7 @@
 /turf/floor,
 /area/smugglers/base)
 "bJ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/smugglers/office)
 "bK" = (
@@ -777,8 +777,8 @@
 /turf/wall,
 /area/smugglers/dorms)
 "cd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -788,7 +788,7 @@
 /obj/structure/noticeboard{
 	default_pixel_y = 30
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/table,
 /obj/machinery/microwave{
 	pixel_y = 10
@@ -796,7 +796,7 @@
 /turf/floor/tiled,
 /area/smugglers/dorms)
 "cf" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/closet/crate,
 /obj/random/snack,
 /obj/random/snack,
@@ -806,21 +806,21 @@
 /turf/floor/tiled,
 /area/smugglers/dorms)
 "cg" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/closet/crate,
 /obj/random/drinkbottle,
 /obj/random/drinkbottle,
 /turf/floor/tiled,
 /area/smugglers/dorms)
 "ch" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/computer/arcade,
 /turf/floor/tiled,
 /area/smugglers/dorms)
 "ci" = (
 /obj/structure/closet/crate/plastic/rations,
 /obj/effect/decal/cleanable/cobweb2,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/smugglers/dorms)
 "cj" = (
@@ -828,8 +828,8 @@
 /turf/floor/plating/airless,
 /area/smugglers/dorms)
 "cl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable,
 /obj/machinery/power/apc{
 	dir = 8;
@@ -839,12 +839,12 @@
 /turf/floor/tiled,
 /area/smugglers/dorms)
 "cm" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/smugglers/dorms)
 "cn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/smugglers/dorms)
 "co" = (
@@ -874,7 +874,7 @@
 /area/smugglers/dorms)
 "cs" = (
 /obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/paper/smug_3,
 /obj/item/flame/fuelled/lighter,
 /obj/random/coin,
@@ -882,7 +882,7 @@
 /area/smugglers/dorms)
 "ct" = (
 /obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/cash/c10,
 /obj/random/smokes,
 /obj/random/snack,
@@ -897,7 +897,7 @@
 /area/smugglers/dorms)
 "cv" = (
 /obj/structure/closet,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/medical,
 /obj/random/medical,
 /obj/random/tech_supply,
@@ -910,29 +910,29 @@
 /area/smugglers/dorms)
 "cx" = (
 /obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/smugglers/dorms)
 "cy" = (
 /obj/structure/closet/smuggler,
 /obj/random/suit,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/smugglers/dorms)
 "cz" = (
 /obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /mob/living/simple_animal/hostile/malf_drone,
 /turf/floor/tiled,
 /area/smugglers/dorms)
 "cA" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/trash,
 /turf/floor/tiled,
 /area/smugglers/dorms)
 "cB" = (
 /obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/smugglers/dorms)
 "cC" = (

--- a/maps/away/yacht/yacht.dmm
+++ b/maps/away/yacht/yacht.dmm
@@ -15,7 +15,7 @@
 /turf/floor/tiled/airless/broken,
 /area/yacht/bridge)
 "ae" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/walnut,
 /area/yacht/bridge)
 "af" = (
@@ -30,7 +30,7 @@
 /turf/wall/titanium,
 /area/yacht/bridge)
 "ai" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/computer/ship/helm,
 /turf/floor/wood/walnut,
 /area/yacht/bridge)
@@ -43,8 +43,8 @@
 "ak" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/bed/chair/comfy/captain,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/walnut,
 /area/yacht/bridge)
 "al" = (
@@ -60,7 +60,7 @@
 /obj/item/chems/drinks/glass2/coffeecup,
 /obj/item/newspaper,
 /obj/effect/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/energy,
 /obj/item/paper{
 	info = "I used up all of my energy. I am hopelessly lost. This ship has become my grave. They did it. The intelligence agency that no one ever talks about. Sol Gov wanted their revenge, and they got it. They easily could have killed me on my ship, or tortured me, but they knew that floating here through space would be the worst possible torture. "
@@ -70,19 +70,19 @@
 "an" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /mob/living/simple_animal/hostile/giant_spider/hunter,
 /turf/floor/wood/walnut,
 /area/yacht/bridge)
 "ao" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/maintenance/clean,
 /turf/floor/wood/walnut,
 /area/yacht/bridge)
 "ap" = (
 /obj/structure/filing_cabinet/chestdrawer,
 /obj/effect/decal/cleanable/cobweb2,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/walnut,
 /area/yacht/bridge)
 "aq" = (
@@ -94,7 +94,7 @@
 /obj/item/rig/medical/equipped,
 /obj/item/gun/energy/captain,
 /obj/effect/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/walnut,
 /area/yacht/bridge)
 "ar" = (
@@ -102,7 +102,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/walnut,
 /area/yacht/bridge)
 "as" = (
@@ -111,7 +111,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/walnut,
 /area/yacht/bridge)
 "at" = (
@@ -122,7 +122,7 @@
 	name = "Yacht bridge";
 	pixel_y = -24
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/walnut,
 /area/yacht/bridge)
 "au" = (
@@ -131,7 +131,7 @@
 	icon_state = "tube1"
 	},
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/walnut,
 /area/yacht/bridge)
 "av" = (
@@ -179,7 +179,7 @@
 /obj/structure/hygiene/shower{
 	pixel_y = 20
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/freezer,
 /area/yacht/living)
 "aE" = (
@@ -188,14 +188,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "aF" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "aG" = (
@@ -205,7 +205,7 @@
 /obj/structure/table/marble,
 /obj/item/trash/snack_bowl,
 /obj/machinery/reagentgrinder/juicer,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/paper{
 	info = "Tonight I woke up to a sound I hoped to have never heard, a small explosion. I rushed to the bridge to diagnose the damage and saw the worst possible news. My solar tracker is gone, and so is the fucking computer. No way to override the settings now, because the assholes EMPd  the computer. No way to charge my SMES reliably, and no way to heat the fuel. I am stuck in the water! Unheated, this gas will not be enough to get absolutely anywhere near a port. This is bad. Real bad. The current charge on SMES is 20 percent, so I'll just try and orient the ship to hit the current star at maximum efficiency so we will charge at 100, and maybe make it to the next solar system. The next port is in the orbit of a Gas giant named Duma. Maybe I can dock there and repair my array. I freaking knew I needed to get a generator. I spent all of the money the Terrans gave me, and this piece of shit is all I could get.  "
 	},
@@ -220,14 +220,14 @@
 /area/yacht/living)
 "aI" = (
 /obj/item/towel/random,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/freezer,
 /area/yacht/living)
 "aJ" = (
 /obj/structure/hygiene/toilet{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/freezer,
 /area/yacht/living)
 "aK" = (
@@ -239,22 +239,22 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "aL" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "aM" = (
 /obj/structure/table/marble,
 /obj/item/pizzabox/vegetable,
 /obj/item/chems/glass/rag,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "aN" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/junk,
 /turf/floor/wood/yew,
 /area/yacht/living)
@@ -270,18 +270,18 @@
 /obj/structure/table/marble,
 /obj/item/deck/cards,
 /obj/item/dice,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "aR" = (
 /obj/effect/decal/cleanable/blood/gibs/robot/up,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "aS" = (
 /obj/structure/table/marble,
 /obj/machinery/microwave,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "aT" = (
@@ -327,7 +327,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "aY" = (
@@ -337,7 +337,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "aZ" = (
@@ -350,7 +350,7 @@
 /obj/structure/table/marble,
 /obj/item/book/manual/chef_recipes,
 /obj/item/chems/drinks/pitcher,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/drinkbottle,
 /turf/floor/wood/yew,
 /area/yacht/living)
@@ -360,7 +360,7 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs/robot/down,
 /obj/effect/decal/cleanable/blood/gibs/robot/up,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "bb" = (
@@ -369,7 +369,7 @@
 	icon_state = "tube1"
 	},
 /obj/machinery/vending/dinnerware,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "bc" = (
@@ -384,12 +384,12 @@
 /area/yacht/living)
 "bf" = (
 /obj/effect/decal/cleanable/blood/gibs/robot/limb,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "bg" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "bh" = (
@@ -399,7 +399,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "bk" = (
@@ -419,7 +419,7 @@
 /area/yacht/living)
 "bn" = (
 /obj/effect/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/freezer,
 /area/yacht/living)
 "bo" = (
@@ -427,7 +427,7 @@
 /turf/floor/tiled/freezer,
 /area/yacht/living)
 "bp" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/paper{
 	info = "I have accepted my fate. I will go into EVA with one of the cyanide pills in my mouth, and I will float off. I want a military funeral, and I will arrange it myself. Good bye all. I have earned and sealed my fate. "
 	},
@@ -454,7 +454,7 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "bu" = (
@@ -478,7 +478,7 @@
 /turf/floor/rock/sand/water,
 /area/yacht/living)
 "bz" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/freezer,
 /area/yacht/living)
 "bA" = (
@@ -492,7 +492,7 @@
 	dir = 8
 	},
 /obj/effect/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "bB" = (
@@ -503,7 +503,7 @@
 	dir = 4
 	},
 /obj/effect/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "bC" = (
@@ -556,7 +556,7 @@
 "bI" = (
 /obj/machinery/light,
 /obj/item/clothing/shoes/swimmingfins,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/freezer,
 /area/yacht/living)
 "bJ" = (
@@ -566,12 +566,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/blood/gibs/robot/limb,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "bK" = (
 /obj/effect/decal/cleanable/blood/gibs/robot/down,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/floodlight,
 /turf/floor/wood/yew,
 /area/yacht/living)
@@ -609,24 +609,24 @@
 /area/yacht/engine)
 "bR" = (
 /obj/machinery/atmospherics/unary/tank/air,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "bS" = (
 /obj/structure/tank_rack/oxygen,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "bT" = (
 /obj/item/cell/hyper,
 /obj/item/book/manual/engineering_guide,
 /obj/item/rcd,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/computer/ship/engines,
 /turf/floor/plating,
 /area/yacht/engine)
 "bU" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/power/smes/buildable,
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -645,40 +645,40 @@
 	name = "Yacht engine";
 	pixel_y = 24
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "bW" = (
 /obj/item/chems/spray/extinguisher,
 /obj/machinery/portable_atmospherics/hydroponics,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "bX" = (
 /obj/machinery/vending/hydronutrients,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "bY" = (
 /obj/machinery/seed_storage/garden,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "bZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
 /turf/floor/plating,
 /area/yacht/engine)
 "ca" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "cb" = (
 /obj/machinery/atmospherics/binary/pump,
 /obj/machinery/space_heater,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "cc" = (
@@ -691,14 +691,14 @@
 /area/yacht/engine)
 "cd" = (
 /obj/structure/closet/crate/hydroponics,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "ce" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stock_parts/circuitboard/broken,
 /turf/floor/plating,
 /area/yacht/engine)
@@ -728,7 +728,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "cj" = (
@@ -739,19 +739,19 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "ck" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "cl" = (
 /obj/structure/janitorialcart,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "cm" = (
@@ -762,21 +762,21 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "cn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "co" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/portable_atmospherics/powered/pump,
 /turf/floor/plating,
 /area/yacht/engine)
@@ -843,7 +843,7 @@
 /turf/floor/plating/airless,
 /area/yacht/engine)
 "cu" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -857,22 +857,22 @@
 	pixel_x = -24
 	},
 /obj/machinery/portable_atmospherics/hydroponics,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "cD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "cE" = (
 /obj/effect/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "cF" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "cG" = (
@@ -880,7 +880,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "cJ" = (
@@ -904,12 +904,12 @@
 /area/yacht/engine)
 "cN" = (
 /obj/structure/closet/toolcloset,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "cO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "cQ" = (
@@ -921,7 +921,7 @@
 	pixel_x = -23
 	},
 /obj/machinery/portable_atmospherics/hydroponics,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "cR" = (
@@ -931,32 +931,32 @@
 	},
 /obj/item/tool/spade,
 /obj/item/chems/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "cS" = (
 /obj/machinery/light,
 /obj/structure/reagent_dispensers/beerkeg,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "cT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "cW" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "cY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "cZ" = (
@@ -966,7 +966,7 @@
 "da" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/caution/cone,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "db" = (
@@ -975,12 +975,12 @@
 /area/yacht/engine)
 "dc" = (
 /obj/structure/closet/wardrobe/pjs,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "dd" = (
 /obj/structure/closet/wardrobe/suit,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 "df" = (
@@ -989,7 +989,7 @@
 /area/yacht/engine)
 "dg" = (
 /obj/structure/closet/crate/plastic/rations,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "dh" = (
@@ -997,7 +997,7 @@
 	dir = 1;
 	level = 2
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "di" = (
@@ -1010,11 +1010,11 @@
 /area/yacht/engine)
 "dk" = (
 /obj/machinery/atmospherics/unary/heater,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "dm" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
 	level = 2
@@ -1025,7 +1025,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "do" = (
@@ -1034,7 +1034,7 @@
 	dir = 4;
 	pixel_y = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/meter,
 /turf/floor/plating,
 /area/yacht/engine)
@@ -1080,7 +1080,7 @@
 /area/yacht/engine)
 "dt" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/black,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/meter,
 /obj/machinery/light/small{
 	dir = 8
@@ -1088,7 +1088,7 @@
 /turf/floor/plating,
 /area/yacht/engine)
 "du" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 10
 	},
@@ -1096,21 +1096,21 @@
 /area/yacht/engine)
 "dv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "dw" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "dx" = (
 /turf/floor/reinforced/carbon_dioxide,
 /area/yacht/engine)
 "dy" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /turf/floor/plating,
 /area/yacht/engine)
@@ -1119,7 +1119,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "dA" = (
@@ -1127,7 +1127,7 @@
 	dir = 10
 	},
 /obj/structure/window/reinforced,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/recharge_station,
 /turf/floor/plating,
 /area/yacht/engine)
@@ -1188,7 +1188,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/constructable_frame/computerframe,
 /obj/machinery/button/access/interior{
 	id_tag = "yacht_airlock";
@@ -1205,7 +1205,7 @@
 	icon_state = "0-2"
 	},
 /obj/item/toolbox/electrical,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -1218,7 +1218,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -1228,7 +1228,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/door/airlock/external/bolted{
 	id_tag = "yacht_outer"
 	},
@@ -1238,7 +1238,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	id_tag = "yacht_airlock";
 	pixel_y = 24;
@@ -1262,7 +1262,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -1278,7 +1278,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
@@ -1288,7 +1288,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
@@ -1298,8 +1298,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
@@ -1311,7 +1311,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -1324,7 +1324,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "rb" = (
@@ -1334,7 +1334,7 @@
 /turf/floor/plating,
 /area/yacht/engine)
 "sb" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -1342,7 +1342,7 @@
 /area/yacht/engine)
 "tb" = (
 /obj/structure/closet/firecloset,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -1350,14 +1350,14 @@
 /area/yacht/engine)
 "ub" = (
 /obj/structure/closet/secure_closet/freezer/meat,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
 "vb" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/floor/plating,
 /area/yacht/engine)
@@ -1369,7 +1369,7 @@
 	pixel_y = 20
 	},
 /obj/item/bikehorn/rubberducky,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/soap,
 /turf/floor/tiled/freezer,
 /area/yacht/living)
@@ -1378,7 +1378,7 @@
 /area/yacht/living)
 "Hj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -1386,8 +1386,8 @@
 /area/yacht/engine)
 "Ty" = (
 /obj/structure/closet/secure_closet/freezer/meat,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/yew,
 /area/yacht/living)
 

--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -63651,7 +63651,7 @@
 /obj/machinery/conveyor_switch{
 	id_tag = "cargo_mining_conveyor"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/miningdock)
@@ -64224,7 +64224,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/starboard)
 "nIv" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -65001,7 +65001,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_two)
 "xpO" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/fabricator/industrial,
 /obj/item/stack/material/ingot/mapped/osmium/ten,
 /obj/effect/floor_decal/industrial/outline/yellow,

--- a/maps/ministation/ministation-0.dmm
+++ b/maps/ministation/ministation-0.dmm
@@ -455,7 +455,7 @@
 /turf/floor/plating/airless,
 /area/space)
 "cl" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/loading{
 	dir = 8
 	},
@@ -469,7 +469,7 @@
 /turf/floor/plating/airless,
 /area/space)
 "cp" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -815,7 +815,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/cargo)
 "dF" = (
@@ -944,7 +944,7 @@
 /turf/floor/tiled,
 /area/ministation/janitor)
 "ej" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/cargo)
 "ek" = (
@@ -1103,7 +1103,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/junction,
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -1267,7 +1267,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/floor/tiled,
 /area/ministation/cargo)
@@ -1319,7 +1319,7 @@
 /turf/floor/plating,
 /area/ministation/engine)
 "ft" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/hologram/holopad,
 /obj/item/radio/intercom/locked{
 	dir = 4;
@@ -1506,7 +1506,7 @@
 /turf/floor/plating,
 /area/ministation/ai_sat)
 "fW" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/floor/tiled,
 /area/ministation/engine)
@@ -1592,7 +1592,7 @@
 /turf/floor/tiled,
 /area/ministation/cargo)
 "gk" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -1601,7 +1601,7 @@
 /area/ministation/cargo)
 "gl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -1903,7 +1903,7 @@
 /turf/floor/tiled,
 /area/ministation/cargo)
 "hq" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -1936,7 +1936,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -2059,7 +2059,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -2229,7 +2229,7 @@
 /area/ministation/dorms)
 "iU" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/binary/pump/on{
 	target_pressure = 200;
 	dir = 8
@@ -2569,7 +2569,7 @@
 /turf/floor/tiled/techfloor,
 /area/ministation/atmospherics)
 "kw" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -2634,7 +2634,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/abstract/landmark/start{
 	name = "Deck Hand"
 	},
@@ -2747,7 +2747,7 @@
 /turf/floor/tiled,
 /area/ministation/hall/n)
 "ln" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/floor/tiled,
 /area/ministation/engine)
@@ -2767,7 +2767,7 @@
 /turf/floor/tiled,
 /area/ministation/cargo)
 "lr" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -3183,7 +3183,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/tinted,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random_multi/single_item/captains_spare_id,
 /obj/structure/window/reinforced/tinted{
 	dir = 8
@@ -3718,7 +3718,7 @@
 /turf/floor/wood/walnut,
 /area/ministation/dorms)
 "qo" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -4861,7 +4861,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/ministation/maint/eastatmos)
 "vz" = (
@@ -4926,7 +4926,7 @@
 /area/ministation/engine)
 "vK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/bed/chair/wood{
 	dir = 8
 	},
@@ -5060,7 +5060,7 @@
 /turf/floor/plating,
 /area/ministation/maint/l1ne)
 "wt" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood,
 /area/ministation/engine)
 "wu" = (
@@ -5252,7 +5252,7 @@
 /turf/floor/plating,
 /area/ministation/maint/l1central)
 "xr" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/sign/department/eva{
 	pixel_y = 30
 	},
@@ -5275,7 +5275,7 @@
 /turf/floor/plating,
 /area/ministation/maint/westatmos)
 "xE" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -6722,7 +6722,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -7037,7 +7037,7 @@
 /turf/floor/tiled,
 /area/ministation/hall/s1)
 "Eg" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -7095,7 +7095,7 @@
 /turf/floor/tiled,
 /area/ministation/engine)
 "En" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/engine)
 "Eo" = (
@@ -7243,7 +7243,7 @@
 /area/ministation/engine)
 "EK" = (
 /obj/effect/decal/cleanable/blood/oil,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -7343,7 +7343,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -7432,7 +7432,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /mob/living/simple_animal/opossum/poppy,
 /obj/item/stool/padded,
 /obj/abstract/landmark/start{
@@ -7491,7 +7491,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood,
 /area/ministation/engine)
 "Fn" = (
@@ -7935,7 +7935,7 @@
 /area/ministation/trash)
 "Ge" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/floor/tiled,
 /area/ministation/engine)
@@ -8088,7 +8088,7 @@
 /area/ministation/engine)
 "Gy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/engine)
 "Gz" = (
@@ -8339,7 +8339,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/engine)
 "Hd" = (
@@ -8383,7 +8383,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/engine)
 "Hj" = (
@@ -8511,7 +8511,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -8526,7 +8526,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -8567,7 +8567,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/engine)
 "HD" = (
@@ -8848,7 +8848,7 @@
 /turf/floor/plating,
 /area/ministation/ai_sat)
 "Iq" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -10506,7 +10506,7 @@
 	pixel_x = -32;
 	pixel_y = -32
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -11145,7 +11145,7 @@
 /turf/floor,
 /area/ministation/maint/eastatmos)
 "OY" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment,
 /turf/floor/tiled,
 /area/ministation/hall/n)
@@ -11185,7 +11185,7 @@
 /turf/floor/plating,
 /area/ministation/ai_upload)
 "Pe" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/floor/tiled,
 /area/ministation/cargo)
@@ -11246,7 +11246,7 @@
 /turf/space,
 /area/ministation/supply_dock)
 "Pq" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/table,
 /obj/item/megaphone,
 /obj/item/box,
@@ -11561,7 +11561,7 @@
 /area/ministation/smcontrol)
 "QG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/hall/s1)
 "QH" = (
@@ -11776,7 +11776,7 @@
 /turf/floor/plating/airless,
 /area/ministation/mining)
 "Rr" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/hall/s1)
 "Rs" = (
@@ -11790,7 +11790,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/hall/s1)
 "Ru" = (
@@ -12020,7 +12020,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -12039,7 +12039,7 @@
 /area/ministation/atmospherics)
 "So" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/hall/n)
 "Sp" = (
@@ -12062,7 +12062,7 @@
 /turf/floor,
 /area/ministation/maint/eastatmos)
 "Ss" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -12106,7 +12106,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 10
 	},
@@ -12197,7 +12197,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -12497,7 +12497,7 @@
 /turf/floor/tiled,
 /area/ministation/engine)
 "TP" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
@@ -12609,7 +12609,7 @@
 /turf/floor/tiled,
 /area/ministation/engine)
 "Ul" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -12745,7 +12745,7 @@
 /turf/floor/tiled,
 /area/ministation/engine)
 "UT" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/binary/pump/on{
 	target_pressure = 200;
 	dir = 1
@@ -12927,7 +12927,7 @@
 /turf/floor/plating,
 /area/ministation/supermatter)
 "VF" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment,
 /turf/floor/tiled,
 /area/ministation/hall/s1)
@@ -13117,7 +13117,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/ministation/maint/eastatmos)
 "Wn" = (
@@ -13261,7 +13261,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -13274,7 +13274,7 @@
 /turf/space,
 /area/space)
 "Xb" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
 	},
@@ -13344,7 +13344,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/tinted,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -13384,7 +13384,7 @@
 /turf/floor/plating,
 /area/ministation/mining)
 "Xx" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/hall/n)
 "Xz" = (
@@ -13581,7 +13581,7 @@
 /turf/floor/plating,
 /area/ministation/engine)
 "Yu" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -14017,7 +14017,7 @@
 /area/ministation/engine)
 "ZR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment,
 /turf/floor/tiled,
 /area/ministation/hall/s1)

--- a/maps/ministation/ministation-1.dmm
+++ b/maps/ministation/ministation-1.dmm
@@ -242,7 +242,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /mob/living/simple_animal/passive/mouse/brown/Tom,
 /turf/floor/lino,
 /area/ministation/cafe)
@@ -329,7 +329,7 @@
 /turf/floor/tiled,
 /area/ministation/hall/w2)
 "bJ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/railing/mapped{
 	dir = 1
 	},
@@ -434,7 +434,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/ministation/maint/l2centrals)
 "cq" = (
@@ -611,7 +611,7 @@
 /area/ministation/hall/w2)
 "dn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/hygiene/drain,
 /turf/floor/tiled/stone,
 /area/ministation/hall/e2)
@@ -895,7 +895,7 @@
 /turf/floor/plating,
 /area/ministation/maint/l2centrals)
 "ey" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -999,7 +999,7 @@
 /turf/floor/tiled/dark,
 /area/ministation/security)
 "fm" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -1673,7 +1673,7 @@
 /turf/floor/tiled/white,
 /area/ministation/medical)
 "in" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -1715,7 +1715,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -2453,7 +2453,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/hall/w2)
 "lN" = (
@@ -3052,7 +3052,7 @@
 /turf/floor/plating/airless,
 /area/space)
 "ps" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/wall,
 /area/ministation/hall/w2)
 "pu" = (
@@ -3678,7 +3678,7 @@
 /turf/floor/tiled,
 /area/ministation/hop)
 "rE" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
@@ -3910,7 +3910,7 @@
 /area/ministation/medical)
 "ss" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/hall/w2)
 "st" = (
@@ -4291,7 +4291,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/hall/e2)
 "tE" = (
@@ -4383,7 +4383,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/cooker/fryer,
 /turf/floor/lino,
 /area/ministation/cafe)
@@ -4473,7 +4473,7 @@
 /turf/floor/tiled,
 /area/ministation/hall/w2)
 "ub" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -4497,7 +4497,7 @@
 /area/ministation/hall/w2)
 "ud" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/ss13/l6,
 /turf/floor/tiled,
 /area/ministation/hall/w2)
@@ -4562,7 +4562,7 @@
 /area/ministation/hall/e2)
 "uq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/stone,
 /area/ministation/hall/e2)
 "us" = (
@@ -4628,7 +4628,7 @@
 /area/ministation/hall/w2)
 "uD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/hall/w2)
 "uG" = (
@@ -4900,7 +4900,7 @@
 /area/ministation/cafe)
 "vw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/floor/tiled/dark,
@@ -5006,7 +5006,7 @@
 /turf/floor/tiled/dark,
 /area/ministation/medical)
 "vO" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/light{
 	dir = 8
@@ -5093,7 +5093,7 @@
 /turf/space,
 /area/space)
 "wk" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/floor/tiled/dark,
 /area/ministation/cafe)
@@ -5234,7 +5234,7 @@
 /turf/floor/tiled/white,
 /area/ministation/medical)
 "wD" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/hall/e2)
 "wE" = (
@@ -5488,7 +5488,7 @@
 /turf/floor/tiled,
 /area/ministation/hydro)
 "xy" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/corner/green/half{
 	dir = 1
 	},
@@ -5597,7 +5597,7 @@
 /area/ministation/security)
 "xQ" = (
 /obj/item/stool/padded,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/floor/tiled/dark,
 /area/ministation/cafe)
@@ -5793,7 +5793,7 @@
 /turf/floor/tiled/dark,
 /area/ministation/cafe)
 "yw" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -5807,7 +5807,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -6132,7 +6132,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/lino,
 /area/ministation/cafe)
 "zF" = (
@@ -6173,7 +6173,7 @@
 /turf/floor/lino,
 /area/ministation/cafe)
 "zK" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/floor/lino,
@@ -6244,7 +6244,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/hall/w2)
 "Ae" = (
@@ -6446,7 +6446,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/stone,
 /area/ministation/hall/e2)
 "AJ" = (
@@ -6473,7 +6473,7 @@
 /turf/floor/tiled/white,
 /area/ministation/medical)
 "AK" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
@@ -6776,7 +6776,7 @@
 /turf/floor/tiled/white,
 /area/ministation/medical)
 "CL" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -7274,7 +7274,7 @@
 /turf/floor/tiled,
 /area/ministation/hydro)
 "FJ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -7411,7 +7411,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -7476,7 +7476,7 @@
 /turf/floor/tiled,
 /area/ministation/hall/w2)
 "GZ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/hall/w2)
 "Hd" = (
@@ -7489,7 +7489,7 @@
 /obj/effect/floor_decal/industrial/firstaid{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white,
 /area/ministation/hall/e2)
 "Hn" = (
@@ -7800,7 +7800,7 @@
 /turf/floor/tiled/white,
 /area/ministation/medical)
 "IX" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -7903,7 +7903,7 @@
 /area/ministation/hall/e2)
 "Jz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 4
@@ -7929,7 +7929,7 @@
 /turf/floor/tiled,
 /area/ministation/hall/e2)
 "JJ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
@@ -8530,7 +8530,7 @@
 /turf/floor/fake_grass,
 /area/ministation/hall/e2)
 "Nh" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4;
@@ -8961,7 +8961,7 @@
 "Ps" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/ministation/cafe)
 "Pw" = (
@@ -9259,7 +9259,7 @@
 /area/ministation/hall/w2)
 "QO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/lino,
 /area/ministation/cafe)
 "QP" = (
@@ -9329,7 +9329,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/lino,
 /area/ministation/cafe)
 "Rx" = (
@@ -9471,7 +9471,7 @@
 /turf/floor/plating,
 /area/ministation/arrival)
 "Sy" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -9520,7 +9520,7 @@
 /turf/floor/plating,
 /area/ministation/arrival)
 "SF" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/ss13/l4,
 /turf/floor/tiled,
@@ -9623,7 +9623,7 @@
 /turf/floor/tiled/dark,
 /area/ministation/security)
 "To" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -9775,7 +9775,7 @@
 /turf/floor/tiled/dark,
 /area/ministation/cafe)
 "Ug" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/railing/mapped,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10239,7 +10239,7 @@
 /turf/floor/plating,
 /area/ministation/arrival)
 "WC" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
@@ -10446,7 +10446,7 @@
 /turf/floor/tiled/white,
 /area/ministation/detective)
 "XK" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/ss13/l14,
 /turf/floor/tiled,
 /area/ministation/hall/w2)
@@ -10515,7 +10515,7 @@
 	pixel_x = 32;
 	pixel_y = 32
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},

--- a/maps/ministation/ministation-2.dmm
+++ b/maps/ministation/ministation-2.dmm
@@ -791,7 +791,7 @@
 /area/ministation/science)
 "cJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment,
 /turf/floor/tiled,
 /area/ministation/hall/n3)
@@ -1123,7 +1123,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/hall/n3)
 "et" = (
@@ -1363,7 +1363,7 @@
 /turf/floor/tiled/white,
 /area/ministation/science)
 "fi" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -1628,7 +1628,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment,
 /turf/floor/tiled,
 /area/ministation/hall/n3)
@@ -3062,7 +3062,7 @@
 /turf/floor/plating,
 /area/ministation/hall/s3)
 "nL" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/network/relay{
 	initial_network_id = "molluscnet"
 	},
@@ -3207,7 +3207,7 @@
 /turf/floor/tiled/white,
 /area/ministation/science)
 "oN" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/hall/s3)
 "oP" = (
@@ -3226,7 +3226,7 @@
 /turf/floor/wood/mahogany,
 /area/ministation/library)
 "oR" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -3263,7 +3263,7 @@
 /turf/floor/tiled,
 /area/ministation/bridge)
 "pi" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -3509,7 +3509,7 @@
 /turf/space,
 /area/space)
 "sh" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -3998,7 +3998,7 @@
 /turf/floor/tiled/white,
 /area/ministation/science)
 "vJ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "_North APC";
@@ -4151,7 +4151,7 @@
 /turf/floor/lino,
 /area/ministation/telecomms)
 "xr" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -4168,7 +4168,7 @@
 /area/ministation/library)
 "xH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -4374,7 +4374,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -4539,7 +4539,7 @@
 /turf/floor/wood/mahogany,
 /area/ministation/library)
 "AH" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/wall,
 /area/ministation/hall/n3)
 "AK" = (
@@ -4651,7 +4651,7 @@
 /turf/floor/plating,
 /area/ministation/maint/l3central)
 "Bk" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -4972,7 +4972,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/floor/plating,
 /area/ministation/maint/l3sw)
@@ -5328,7 +5328,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/ministation/maint/l3sw)
 "Ee" = (
@@ -5554,7 +5554,7 @@
 /turf/floor/wood/mahogany,
 /area/ministation/library)
 "Gh" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -5687,7 +5687,7 @@
 /turf/wall/r_wall/prepainted,
 /area/space)
 "HB" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/ministation/maint/l3sw)
 "HK" = (
@@ -6472,7 +6472,7 @@
 /turf/floor/wood/yew,
 /area/ministation/court)
 "NF" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -6491,7 +6491,7 @@
 /turf/floor/tiled,
 /area/ministation/bridge)
 "NJ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/flora/pottedplant/aquatic,
 /turf/floor/lino,
@@ -6758,7 +6758,7 @@
 /area/space)
 "Pw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/techfloor/orange,
 /turf/floor/tiled,
 /area/ministation/hall/n3)
@@ -6839,7 +6839,7 @@
 /turf/floor/plating,
 /area/ministation/maint/l3sw)
 "PR" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/hall/n3)
 "PT" = (
@@ -6985,7 +6985,7 @@
 /area/space)
 "QG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment,
 /turf/floor/tiled,
 /area/ministation/hall/s3)
@@ -7098,7 +7098,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/hall/s3)
 "Rv" = (
@@ -7299,7 +7299,7 @@
 /area/ministation/science)
 "So" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/hall/n3)
 "Sq" = (
@@ -7682,7 +7682,7 @@
 /turf/floor/tiled/white,
 /area/ministation/science)
 "UK" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/portables_connector{
 	pixel_x = -3
 	},
@@ -8114,7 +8114,7 @@
 /turf/floor/tiled/white,
 /area/ministation/science)
 "XA" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/railing/mapped,
@@ -8223,7 +8223,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/ministation/maint/l3sw)
 "Yj" = (
@@ -8439,7 +8439,7 @@
 /turf/floor/plating,
 /area/ministation/maint/l3sw)
 "Zj" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/floor/plating,
 /area/ministation/maint/l3sw)
@@ -8542,7 +8542,7 @@
 /area/ministation/court)
 "ZR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ministation/hall/s3)
 "ZS" = (

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -55,18 +55,18 @@
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "ai" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/trash/raisins,
 /obj/item/chems/drinks/glass2/fitnessflask,
 /turf/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "aj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "ak" = (
@@ -77,8 +77,8 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "al" = (
@@ -88,21 +88,21 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "am" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/abstract/landmark/allowed_leak,
 /turf/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "an" = (
 /obj/machinery/atmospherics/omni/filter,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/abstract/landmark/allowed_leak,
 /turf/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
@@ -110,15 +110,15 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/trash/tastybread,
 /obj/item/chems/drinks/cans/speer,
 /obj/abstract/landmark/allowed_leak,
 /turf/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "ap" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/decal/cleanable/filth,
 /obj/structure/curtain/open/shower/engineering,
@@ -134,7 +134,7 @@
 "aq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/closet/hydrant{
 	pixel_x = -27;
 	dir = 4
@@ -147,7 +147,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/space_heater,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "as" = (
@@ -160,7 +160,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/filth,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/floor/tiled/techfloor,
@@ -169,7 +169,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/power/smes/buildable{
 	charge = 50000;
 	inputting = 1;
@@ -182,13 +182,13 @@
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/abstract/landmark/allowed_leak,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "av" = (
 /obj/machinery/atmospherics/omni/filter,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/abstract/landmark/allowed_leak,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
@@ -196,7 +196,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/abstract/landmark/allowed_leak,
 /turf/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
@@ -217,7 +217,7 @@
 /obj/machinery/door/airlock/engineering,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "aB" = (
@@ -233,7 +233,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "aD" = (
@@ -261,7 +261,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "aG" = (
@@ -285,7 +285,7 @@
 /obj/item/clothing/costume/savage_hunter,
 /obj/item/clothing/costume/savage_hunter/female,
 /obj/item/clothing/jumpsuit/wetsuit,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/trash/candy/proteinbar,
 /obj/item/trash/liquidfood,
 /obj/item/stock_parts/matter_bin/super,
@@ -303,7 +303,7 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "aI" = (
@@ -313,8 +313,8 @@
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "aJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/filth,
 /obj/structure/curtain/open/shower/engineering,
 /obj/structure/hygiene/shower{
@@ -334,7 +334,7 @@
 	dir = 1
 	},
 /obj/item/mop,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/trash/candy/proteinbar,
 /obj/item/trash/liquidfood,
 /obj/item/box/detergent,
@@ -348,7 +348,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "aM" = (
@@ -366,19 +366,19 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "aO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "aP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/filth,
 /obj/item/solar_assembly,
 /obj/item/solar_assembly,
@@ -388,7 +388,7 @@
 /area/map_template/crashed_pod)
 "aQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "aR" = (
@@ -407,7 +407,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/trash/tastybread,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
@@ -418,16 +418,16 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "aV" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "aW" = (
@@ -435,7 +435,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "aX" = (
@@ -443,14 +443,14 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "aY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/civilian,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "aZ" = (
@@ -462,13 +462,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark/monotile,
 /area/map_template/crashed_pod)
 "ba" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "bb" = (
@@ -479,7 +479,7 @@
 "bc" = (
 /obj/abstract/submap_landmark/spawnpoint/crashed_pod_survivor,
 /obj/structure/bed/chair/shuttle/black,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark/monotile,
 /area/map_template/crashed_pod)
 "bd" = (
@@ -490,7 +490,7 @@
 /obj/item/radio,
 /obj/item/radio,
 /obj/random/plushie,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark/monotile,
 /area/map_template/crashed_pod)
 "be" = (
@@ -502,7 +502,7 @@
 	pixel_x = -27;
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "bf" = (
@@ -514,14 +514,14 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark/monotile,
 /area/map_template/crashed_pod)
 "bg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "bh" = (
@@ -529,37 +529,37 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "bi" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "bj" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/recharger,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/chems/drinks/glass2/coffeecup/metal,
 /turf/floor/tiled/dark/monotile,
 /area/map_template/crashed_pod)
 "bk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/industrial/warning,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "bl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/industrial/warning,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "bm" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/trash/candy/proteinbar,
 /obj/item/trash/liquidfood,
 /turf/floor/tiled/dark,
@@ -569,12 +569,12 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "bo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "bp" = (
@@ -603,7 +603,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "bu" = (
@@ -627,7 +627,7 @@
 /area/map_template/crashed_pod)
 "bw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "bx" = (
@@ -639,14 +639,14 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "by" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "bz" = (
@@ -662,7 +662,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "bB" = (
@@ -679,9 +679,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "bD" = (
@@ -695,8 +695,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "bF" = (
@@ -713,7 +713,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/filth,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
@@ -745,13 +745,13 @@
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/ash,
 /obj/item/trash/cigbutt/cigarbutt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "bL" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "bM" = (
@@ -782,7 +782,7 @@
 /obj/item/clothing/jumpsuit/orange,
 /obj/item/clothing/jumpsuit/blackjumpshorts,
 /obj/item/clothing/jumpsuit/black,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "bN" = (
@@ -793,10 +793,10 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/table/steel_reinforced,
 /obj/item/binoculars,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/trash/candy/proteinbar,
 /obj/item/chems/drinks/cans/speer,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "bP" = (
@@ -830,16 +830,16 @@
 /obj/item/clothing/jumpsuit/orange,
 /obj/item/clothing/jumpsuit/blackjumpshorts,
 /obj/item/clothing/jumpsuit/black,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "bR" = (
 /obj/structure/table/steel_reinforced,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/trash/tastybread,
 /obj/item/geiger,
 /obj/item/geiger,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "bS" = (
@@ -884,7 +884,7 @@
 /obj/item/clothing/jumpsuit/orange,
 /obj/item/clothing/jumpsuit/blackjumpshorts,
 /obj/item/clothing/jumpsuit/black,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "bV" = (
@@ -979,7 +979,7 @@
 /obj/item/ashtray,
 /obj/item/paper_bin,
 /obj/item/chems/drinks/cans/speer,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/pen,
 /turf/floor/tiled/dark,
 /area/map_template/crashed_pod)

--- a/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
@@ -40,13 +40,13 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/abstract/landmark/allowed_leak,
 /turf/floor/plating,
 /area/map_template/oldpod)
 "ai" = (
 /obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aj" = (
@@ -65,25 +65,25 @@
 /obj/structure/bed,
 /obj/abstract/landmark/corpse/doctor,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "al" = (
 /obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "am" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "an" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "ao" = (
@@ -93,7 +93,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "ap" = (
@@ -103,7 +103,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aq" = (
@@ -112,8 +112,8 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/filth,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
@@ -121,30 +121,30 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "as" = (
 /obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "at" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "au" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/abstract/landmark/allowed_leak,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
@@ -152,8 +152,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/abstract/landmark/allowed_leak,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
@@ -162,52 +162,52 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "ax" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced/hull,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/map_template/oldpod)
 "ay" = (
 /obj/item/frame/air_alarm,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stock_parts/circuitboard/air_alarm,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "az" = (
 /obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aA" = (
 /obj/random/firstaid,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aB" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aC" = (
 /obj/item/clothing/head/helmet/space/emergency,
 /obj/item/clothing/suit/space/emergency,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aD" = (
@@ -223,26 +223,26 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/item/tool/pickaxe,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aE" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/table,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aG" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aH" = (
@@ -250,7 +250,7 @@
 	icon_state = "0-4"
 	},
 /obj/item/frame/apc,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/cell/crap/empty,
 /obj/item/stock_parts/circuitboard/apc,
 /turf/floor/tiled/monotile,
@@ -260,29 +260,29 @@
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aJ" = (
 /obj/abstract/landmark/corpse/pirate,
 /obj/item/gun/energy/captain,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aK" = (
 /obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aL" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aM" = (
@@ -290,7 +290,7 @@
 /obj/item/baton/cattleprod,
 /obj/item/shard,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aN" = (
@@ -327,7 +327,7 @@
 /turf/floor/plating,
 /area/map_template/oldpod)
 "aQ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aR" = (
@@ -345,16 +345,16 @@
 	name = "plastic table frame"
 	},
 /obj/item/firstaid/surgery,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/monotile,
 /area/map_template/oldpod)
 "aS" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/monotile,
 /area/map_template/oldpod)
 "aT" = (
@@ -366,7 +366,7 @@
 	dir = 1
 	},
 /obj/structure/closet/crate/plastic/rations,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/gun/projectile/zipgun,
 /obj/item/gun/projectile/zipgun,
 /obj/item/gun/projectile/zipgun,
@@ -411,16 +411,16 @@
 	dir = 8
 	},
 /obj/machinery/optable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/blood,
 /turf/floor/tiled/white/monotile,
 /area/map_template/oldpod)
 "aY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/monotile,
 /area/map_template/oldpod)
 "aZ" = (
@@ -433,7 +433,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/monotile,
 /area/map_template/oldpod)
 "ba" = (
@@ -475,14 +475,14 @@
 	},
 /obj/random/firstaid,
 /obj/random/firstaid,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/monotile,
 /area/map_template/oldpod)
 "bf" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/monotile,
 /area/map_template/oldpod)
 "bg" = (
@@ -493,9 +493,9 @@
 	dir = 6;
 	icon_state = "warning"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white/monotile,
 /area/map_template/oldpod)
 

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -922,7 +922,7 @@
 /area/map_template/colony/atmospherics)
 "cf" = (
 /obj/structure/catwalk,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/emitter/gyrotron,
 /turf/floor/concrete,
 /area/template_noop)
@@ -1415,7 +1415,7 @@
 "dn" = (
 /obj/structure/catwalk,
 /obj/machinery/rad_collector,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/template_noop)
 "do" = (
@@ -1576,7 +1576,7 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/surgery)
 "dG" = (
@@ -1853,7 +1853,7 @@
 "eh" = (
 /obj/structure/catwalk,
 /obj/structure/closet/crate/solar_assembly,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/template_noop)
 "ei" = (
@@ -2075,8 +2075,8 @@
 /area/map_template/colony/messhall)
 "eD" = (
 /obj/structure/catwalk,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/command)
 "eE" = (
@@ -2342,8 +2342,8 @@
 /area/map_template/colony/medbay)
 "eZ" = (
 /obj/structure/catwalk,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/template_noop)
 "fa" = (
@@ -2361,7 +2361,7 @@
 /area/map_template/colony)
 "fc" = (
 /obj/structure/catwalk,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/template_noop)
 "fd" = (
@@ -3204,7 +3204,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/carpet/green,
 /area/map_template/colony/messhall)
 "gt" = (
@@ -3411,7 +3411,7 @@
 /turf/floor/tiled/techfloor,
 /area/map_template/colony/atmospherics)
 "gP" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/carpet/green,
 /area/map_template/colony/messhall)
 "gQ" = (
@@ -3429,7 +3429,7 @@
 /turf/floor/tiled/steel_ridged,
 /area/map_template/colony/airlock)
 "gR" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "playablecolonymain_pump_out_external"
 	},
@@ -4724,7 +4724,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/walnut,
 /area/map_template/colony/commons)
 "jm" = (
@@ -4796,7 +4796,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/wood/walnut,
 /area/map_template/colony/commons)
 "jt" = (
@@ -4981,7 +4981,7 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/messhall)
 "jL" = (
@@ -5586,11 +5586,11 @@
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "kL" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "kM" = (
@@ -5598,7 +5598,7 @@
 	id_tag = "playablecolony_crematorium"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "kN" = (
@@ -5607,7 +5607,7 @@
 	pixel_y = 25;
 	req_access = list()
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/recharger,
@@ -5713,15 +5713,15 @@
 /area/map_template/colony/airlock)
 "kZ" = (
 /obj/structure/table/steel_reinforced,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "la" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "lb" = (
@@ -5771,7 +5771,7 @@
 /area/map_template/colony)
 "lg" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "lh" = (
@@ -5792,7 +5792,7 @@
 	id_tag = "colonymine"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/steel_ridged,
 /area/map_template/colony/mineralprocessing)
 "lj" = (
@@ -5839,7 +5839,7 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "lo" = (
@@ -5879,7 +5879,7 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "lu" = (
@@ -5890,12 +5890,12 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "lv" = (
 /obj/effect/floor_decal/industrial/warning/dust,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "lw" = (
@@ -5934,8 +5934,8 @@
 	dir = 8
 	},
 /obj/structure/table/steel_reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "lA" = (
@@ -5946,7 +5946,7 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "lB" = (
@@ -5976,7 +5976,7 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "lD" = (
@@ -5984,7 +5984,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "lG" = (
@@ -6026,8 +6026,8 @@
 /turf/floor/tiled/white,
 /area/map_template/colony/bathroom)
 "lJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	cycle_to_external_air = 1;
 	id_tag = "playablecolonymain";
@@ -6070,7 +6070,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "playablecolonymain_pump";
 	power_rating = 25000
@@ -6127,7 +6127,7 @@
 	dir = 8;
 	icon_state = "warning"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor/grid,
 /area/map_template/colony/airlock)
 "lR" = (
@@ -6142,7 +6142,7 @@
 	name = "Colonial suit cycler";
 	req_access = list()
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor/grid,
 /area/map_template/colony/airlock)
 "lS" = (
@@ -6150,13 +6150,13 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "lT" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning/dust,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "lU" = (
@@ -6164,15 +6164,15 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "lV" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "lW" = (
@@ -6205,7 +6205,7 @@
 /area/map_template/colony)
 "lX" = (
 /obj/effect/floor_decal/industrial/warning/dust,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/item/radio/intercom{
 	dir = 8;
@@ -6232,8 +6232,8 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "ma" = (
@@ -6256,8 +6256,8 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -6268,8 +6268,8 @@
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "mb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/floor/tiled/techfloor,
 /area/map_template/colony/airlock)
@@ -6319,7 +6319,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/colony/airlock)
 "mh" = (
@@ -6329,7 +6329,7 @@
 /obj/machinery/door/airlock/external{
 	id_tag = "playablecolonymain_interior_door"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/colony/airlock)
 "mi" = (
@@ -6353,7 +6353,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/template_noop)
 "ml" = (
@@ -6385,8 +6385,8 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "mo" = (
@@ -6422,14 +6422,14 @@
 	dir = 8;
 	icon_state = "warning"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor/grid,
 /area/map_template/colony/airlock)
 "ms" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/binary/pump/high_power/on{
 	dir = 8;
 	target_pressure = 500
@@ -6521,8 +6521,8 @@
 	name = "Hard Equipment Storage";
 	pixel_y = 28
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/command)
 "mD" = (
@@ -6683,19 +6683,19 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/colony/airlock)
 "mP" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/cell_charger,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/flashlight/lamp/floodlamp,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "mQ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
 	dir = 8
@@ -6789,7 +6789,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
@@ -7208,9 +7208,9 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 8;
 	id_tag = "playablecolonymain_pump_out_internal";
@@ -7262,8 +7262,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 1;
 	id_tag = "playablecolonymain_pump";
@@ -7283,7 +7283,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 1;
 	id_tag = "playablecolonymain_pump";
@@ -7306,7 +7306,7 @@
 	dir = 8;
 	icon_state = "warning"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/floor/tiled/techfloor/grid,
 /area/map_template/colony/airlock)
@@ -7348,7 +7348,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/colony/airlock)
 "ob" = (
@@ -7361,7 +7361,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/map_template/colony/airlock)
 "oc" = (
@@ -7374,7 +7374,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/radio/intercom{
 	dir = 8;
 	pixel_x = 22
@@ -7388,33 +7388,33 @@
 /obj/effect/floor_decal/industrial/loading{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "oe" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/warning/dust,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "of" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/warning/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "og" = (
 /obj/effect/floor_decal/industrial/warning/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "oh" = (
 /obj/effect/floor_decal/industrial/warning/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "oi" = (
@@ -7506,9 +7506,9 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/catwalk,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
@@ -7520,9 +7520,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/catwalk,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
@@ -7539,9 +7539,9 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/catwalk,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
@@ -7560,7 +7560,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/template_noop)
 "oq" = (
@@ -7568,7 +7568,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/template_noop)
 "or" = (
@@ -7579,7 +7579,7 @@
 /obj/structure/sign/warning/high_voltage{
 	pixel_y = 28
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/template_noop)
 "os" = (
@@ -7587,7 +7587,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/template_noop)
 "ot" = (
@@ -7595,16 +7595,16 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/map_template/colony/hydroponics)
 "ou" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -7621,8 +7621,8 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -7646,9 +7646,9 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 8;
 	id_tag = "playablecolonymain_pump_out_internal";
@@ -7661,38 +7661,38 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "oz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 5
 	},
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "oA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/catwalk,
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "oB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 4
 	},
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "oC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
@@ -7814,8 +7814,8 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/template_noop)
 "vt" = (
@@ -7936,9 +7936,9 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete,
 /area/template_noop)
 "Kn" = (
@@ -7954,7 +7954,7 @@
 /area/map_template/colony/hydroponics)
 "Kz" = (
 /obj/structure/catwalk,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/light/spot{
 	dir = 1
 	},

--- a/maps/shaded_hills/shaded_hills_currency.dm
+++ b/maps/shaded_hills/shaded_hills_currency.dm
@@ -1,7 +1,7 @@
 /datum/map/shaded_hills
 	starting_cash_choices = list(
-		/decl/starting_cash_choice/none,
-		/decl/starting_cash_choice/cash
+		/decl/starting_cash_choice/cash,
+		/decl/starting_cash_choice/none
 	)
 	default_currency = /decl/currency/imperial
 	salary_modifier = 0.05 // turn the 300-400 base into 15-20 base

--- a/maps/tradeship/tradeship-0.dmm
+++ b/maps/tradeship/tradeship-0.dmm
@@ -108,7 +108,7 @@
 /turf/floor/tiled/steel_grid,
 /area/ship/trade/loading_bay)
 "ap" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -188,7 +188,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/button/access/interior{
 	dir = 1;
 	id_tag = "lower_cargo";
@@ -198,7 +198,7 @@
 /area/ship/trade/loading_bay)
 "ax" = (
 /obj/item/stool/padded,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -322,7 +322,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/steel_grid,
 /area/ship/trade/loading_bay)
 "aI" = (
@@ -598,7 +598,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ship/trade/loading_bay)
 "bj" = (
@@ -609,7 +609,7 @@
 /area/ship/trade/fore_port_underside_maint)
 "bk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/table,
 /obj/item/paicard,
 /turf/floor,
@@ -618,7 +618,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	level = 2
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/trash/mollusc_shell/clam,
 /turf/floor,
 /area/ship/trade/disused)
@@ -741,7 +741,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ship/trade/loading_bay)
 "bG" = (
@@ -752,7 +752,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/vending/cola{
 	dir = 4
 	},
@@ -886,7 +886,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ship/trade/loading_bay)
 "bW" = (
@@ -1000,7 +1000,7 @@
 	dir = 8;
 	flickering = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1061,7 +1061,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/hygiene/drain,
 /turf/floor/tiled,
 /area/ship/trade/loading_bay)
@@ -1101,7 +1101,7 @@
 /turf/floor,
 /area/ship/trade/loading_bay)
 "iy" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -1156,7 +1156,7 @@
 /area/ship/trade/loading_bay)
 "lg" = (
 /obj/item/stool/bar/padded,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -1182,7 +1182,7 @@
 /turf/floor,
 /area/ship/trade/aft_port_underside_maint)
 "lv" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/bluegrid,
 /area/ship/trade/undercomms)
 "lA" = (
@@ -1248,7 +1248,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ship/trade/disused)
 "oO" = (
@@ -1280,7 +1280,7 @@
 /turf/floor,
 /area/ship/trade/loading_bay)
 "pi" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ship/trade/loading_bay)
 "pG" = (
@@ -1301,7 +1301,7 @@
 /turf/floor/plating,
 /area/ship/trade/loading_bay)
 "qt" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ship/trade/disused)
 "qK" = (
@@ -1319,7 +1319,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/backpack/dufflebag,
 /obj/item/chems/glass/rag,
 /obj/item/chems/glass/bucket,
@@ -1530,7 +1530,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -1637,7 +1637,7 @@
 /turf/floor/tiled/steel_grid,
 /area/ship/trade/loading_bay)
 "DT" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -1651,7 +1651,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ship/trade/disused)
 "Ff" = (
@@ -1659,7 +1659,7 @@
 /turf/floor/carpet/red,
 /area/ship/trade/disused)
 "Ft" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -1669,7 +1669,7 @@
 /turf/floor,
 /area/ship/trade/undercomms)
 "Fy" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/loot_pile/maint/trash,
 /turf/floor/tiled,
 /area/ship/trade/disused)
@@ -1751,7 +1751,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ship/trade/disused)
 "Iv" = (
@@ -2030,7 +2030,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -2054,7 +2054,7 @@
 "QW" = (
 /obj/item/stack/tile/floor/five,
 /obj/item/crowbar/red,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stool/padded,
 /turf/floor,
 /area/ship/trade/disused)
@@ -2094,7 +2094,7 @@
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/loot_pile/maint/junk,
 /turf/floor,
 /area/ship/trade/disused)

--- a/maps/tradeship/tradeship-1.dmm
+++ b/maps/tradeship/tradeship-1.dmm
@@ -292,7 +292,7 @@
 /turf/floor/plating,
 /area/ship/trade/cargo/lower)
 "aH" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
@@ -486,7 +486,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/ship/trade/maintenance/lower)
 "bd" = (
@@ -655,7 +655,7 @@
 /obj/structure/cable{
 	icon_state = "6-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ship/trade/cargo/lower)
 "bw" = (
@@ -739,7 +739,7 @@
 /turf/floor/tiled,
 /area/ship/trade/maintenance/lower)
 "bJ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -24
@@ -828,7 +828,7 @@
 /area/ship/trade/cargo/lower)
 "bV" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
@@ -1024,7 +1024,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
 "cC" = (
@@ -1144,7 +1144,7 @@
 	dir = 8;
 	icon_state = "bulb1"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/railing/mapped{
 	dir = 4
 	},
@@ -1337,11 +1337,11 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
 "du" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ship/trade/cargo/lower)
 "dv" = (
@@ -1357,7 +1357,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1;
 	icon_state = "warningcorner"
@@ -1400,14 +1400,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/ship/trade/drunk_tank)
 "dB" = (
 /obj/structure/table,
 /obj/random/plushie,
 /obj/item/synthesized_instrument/violin,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/ship/trade/drunk_tank)
 "dD" = (
@@ -1608,7 +1608,7 @@
 	icon_state = "bulb1"
 	},
 /obj/structure/ladder,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/sign/deck/second{
 	pixel_y = 32
 	},
@@ -1619,7 +1619,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -1638,7 +1638,7 @@
 /turf/floor/plating,
 /area/ship/trade/maintenance/eva)
 "ep" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "bulb1"
@@ -1687,7 +1687,7 @@
 /turf/floor/tiled/techfloor,
 /area/ship/trade/maintenance/techstorage)
 "ew" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -1714,7 +1714,7 @@
 /turf/floor/tiled/techfloor,
 /area/ship/trade/maintenance/techstorage)
 "ez" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -1751,7 +1751,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/ship/trade/maintenance/eva)
 "eD" = (
@@ -1776,7 +1776,7 @@
 /turf/floor/tiled/techfloor,
 /area/ship/trade/maintenance/techstorage)
 "eQ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light_switch{
 	pixel_x = 24;
@@ -1795,14 +1795,14 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/ship/trade/maintenance/eva)
 "eS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techfloor,
 /area/ship/trade/maintenance/eva)
 "eV" = (
@@ -1849,7 +1849,7 @@
 /turf/floor/plating,
 /area/ship/trade/maintenance/storage)
 "fa" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/ship/trade/drunk_tank)
 "fb" = (
@@ -1981,7 +1981,7 @@
 /turf/floor,
 /area/ship/trade/science/fabricaton)
 "hI" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
 	icon_state = "warning"
@@ -2151,7 +2151,7 @@
 /obj/machinery/conveyor_switch{
 	id_tag = "con"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/floor/tiled,
 /area/ship/trade/cargo/lower)
@@ -2340,7 +2340,7 @@
 /turf/wall/r_wall/hull,
 /area/ship/trade/maintenance/techstorage)
 "rB" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stack/material/ore/iron,
 /obj/item/stack/material/ore/coal{
 	pixel_x = 3;
@@ -2443,7 +2443,7 @@
 /turf/floor/tiled/techfloor,
 /area/ship/trade/maintenance/techstorage)
 "un" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/fabricator/industrial,
 /obj/item/stack/material/ingot/mapped/osmium/ten,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -2562,7 +2562,7 @@
 	},
 /obj/item/bedsheet/mime,
 /obj/effect/decal/cleanable/cobweb2,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/ship/trade/drunk_tank)
 "xa" = (
@@ -2672,7 +2672,7 @@
 /turf/floor/tiled/dark,
 /area/ship/trade/crew/dorms1)
 "Bq" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
 	},
@@ -2737,7 +2737,7 @@
 	dir = 4;
 	level = 2
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ship/trade/cargo/lower)
 "DQ" = (
@@ -2864,7 +2864,7 @@
 /area/ship/trade/science/fabricaton)
 "IU" = (
 /obj/structure/window/reinforced,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
 	},
@@ -2948,7 +2948,7 @@
 /turf/floor/lino,
 /area/ship/trade/crew/dorms2)
 "Lx" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stool/padded,
 /turf/floor/tiled,
 /area/ship/trade/cargo/lower)
@@ -2968,7 +2968,7 @@
 /turf/floor/tiled/techfloor,
 /area/ship/trade/maintenance/techstorage)
 "LN" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
 	},
@@ -2991,7 +2991,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ship/trade/maintenance/lower)
 "Mx" = (
@@ -2999,7 +2999,7 @@
 /turf/wall,
 /area/ship/trade/escape_port)
 "Nb" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
@@ -3376,7 +3376,7 @@
 /turf/floor/tiled/white,
 /area/ship/trade/science/fabricaton)
 "Zv" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm{
 	dir = 4;

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -275,7 +275,7 @@
 /turf/floor/tiled/white,
 /area/ship/trade/crew/medbay/chemistry)
 "aB" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/closet/emcloset,
 /obj/random/voidsuit,
 /obj/random/voidhelmet,
@@ -528,7 +528,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -645,7 +645,7 @@
 /turf/wall/r_wall,
 /area/ship/trade/dock)
 "bn" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -21
@@ -676,7 +676,7 @@
 /turf/floor/plating,
 /area/ship/trade/shuttle/outgoing/general)
 "br" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/emergency_dispenser/north,
 /turf/floor/tiled/monotile,
 /area/ship/trade/dock)
@@ -733,7 +733,7 @@
 "bv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -820,7 +820,7 @@
 /turf/floor/plating,
 /area/ship/trade/dock)
 "bB" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/sign/warning/vacuum{
 	dir = 4;
 	pixel_x = -34
@@ -828,7 +828,7 @@
 /turf/floor/tiled/monotile,
 /area/ship/trade/dock)
 "bC" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -990,7 +990,7 @@
 /turf/floor/tiled/monotile,
 /area/ship/trade/dock)
 "bO" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/steeldecal/steel_decals6,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8;
@@ -1340,7 +1340,7 @@
 	dir = 8;
 	icon_state = "twindow"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/abstract/landmark/start{
 	name = "Deck Hand"
 	},
@@ -1647,7 +1647,7 @@
 	dir = 8;
 	icon_state = "twindow"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random_multi/single_item/captains_spare_id,
 /turf/floor/tiled/freezer,
 /area/ship/trade/crew/toilets)
@@ -1664,7 +1664,7 @@
 	icon_state = "twindow"
 	},
 /obj/structure/window/reinforced/tinted,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable,
 /obj/machinery/power/apc{
 	dir = 4;
@@ -1681,7 +1681,7 @@
 /turf/floor/tiled/freezer,
 /area/ship/trade/crew/toilets)
 "dO" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "conpipe-c"
@@ -1700,7 +1700,7 @@
 /turf/wall,
 /area/ship/trade/crew/saloon)
 "dQ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/corner/beige{
 	dir = 9
 	},
@@ -1730,7 +1730,7 @@
 /turf/floor/tiled,
 /area/ship/trade/crew/saloon)
 "dV" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -1869,7 +1869,7 @@
 /area/ship/trade/crew/kitchen)
 "ez" = (
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ship/trade/crew/kitchen)
 "eA" = (
@@ -1920,7 +1920,7 @@
 /turf/floor/tiled/techfloor,
 /area/ship/trade/cargo)
 "eF" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -1933,7 +1933,7 @@
 /turf/floor/tiled/techfloor,
 /area/ship/trade/cargo)
 "eH" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "bulb1"
@@ -2005,7 +2005,7 @@
 /turf/floor/tiled,
 /area/ship/trade/crew/kitchen)
 "eQ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -2223,7 +2223,7 @@
 /turf/floor/tiled/white,
 /area/ship/trade/crew/medbay)
 "fp" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/catwalk,
 /turf/open,
 /area/ship/trade/cargo)
@@ -2624,7 +2624,7 @@
 /area/ship/trade/cargo)
 "gt" = (
 /obj/structure/emergency_dispenser/west,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -2817,7 +2817,7 @@
 /turf/floor/tiled,
 /area/ship/trade/garden)
 "hi" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -2904,7 +2904,7 @@
 /turf/floor/plating,
 /area/ship/trade/crew/hallway/starboard)
 "ht" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -3187,7 +3187,7 @@
 /turf/floor/tiled/techfloor,
 /area/ship/trade/maintenance/engineering)
 "hV" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/light_switch{
 	pixel_y = 25
 	},
@@ -3345,7 +3345,7 @@
 /turf/floor/tiled/techfloor,
 /area/ship/trade/maintenance/engineering)
 "ij" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -3365,7 +3365,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stool/padded,
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -3387,7 +3387,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -3532,7 +3532,7 @@
 /turf/floor/tiled/techfloor,
 /area/ship/trade/maintenance/engineering)
 "iz" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
 	},
@@ -3654,7 +3654,7 @@
 /area/ship/trade/maintenance/atmos)
 "iN" = (
 /obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "iQ" = (
@@ -4863,8 +4863,8 @@
 /turf/floor/plating,
 /area/ship/trade/shieldbay)
 "pT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
@@ -4973,7 +4973,7 @@
 /turf/floor/plating,
 /area/ship/trade/shuttle/rescue)
 "qO" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/computer/modular/preset/merchant/tradeship,
 /obj/machinery/light_switch{
@@ -6414,7 +6414,7 @@
 	pixel_x = 30;
 	pixel_y = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "GO" = (
@@ -6659,7 +6659,7 @@
 /area/ship/trade/crew/saloon)
 "Jp" = (
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/meat_hook,
 /obj/machinery/newscaster{
 	pixel_y = -32;
@@ -7277,7 +7277,7 @@
 /turf/floor/bluegrid,
 /area/ship/trade/command/bridge)
 "Qc" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -7359,7 +7359,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "Rb" = (
@@ -7420,7 +7420,7 @@
 /turf/floor/carpet/blue,
 /area/ship/trade/command/captain)
 "Rv" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/abstract/landmark/start{
 	name = "Cargo Technician"
 	},
@@ -7699,7 +7699,7 @@
 /turf/wall/titanium,
 /area/ship/trade/shuttle/outgoing/general)
 "UV" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/ship/trade/dock)
 "UY" = (
@@ -7918,7 +7918,7 @@
 /turf/floor/tiled,
 /area/ship/trade/shuttle/outgoing/general)
 "Xz" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "XG" = (
@@ -7951,7 +7951,7 @@
 /turf/floor/plating,
 /area/ship/trade/maintenance/engine/aft)
 "Ya" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/catwalk,
 /obj/structure/railing/mapped,

--- a/mods/content/fantasy/datum/skills.dm
+++ b/mods/content/fantasy/datum/skills.dm
@@ -306,3 +306,6 @@
 		"Experienced" = "You work as an pharmacist, or else you are a doctor with training in chemistry. If you are a pharmacist, you can make most medications. At this stage, you're working mostly by-the-book. <br>- You can examine held containers for some reagents.",
 		"Master"      = "You specialized in chemistry or pharmaceuticals; you are either a medical researcher or professional chemist. You can create custom mixes and make even the trickiest of medications easily. You understand how your pharmaceuticals interact with the bodies of your patients. You are probably the originator of at least one new chemical innovation.<br>- You can examine held containers for all reagents."
 	)
+
+/datum/lock
+	lockpicking_skill = SKILL_ARTIFICE

--- a/mods/content/government/away_sites/icarus/icarus-1.dmm
+++ b/mods/content/government/away_sites/icarus/icarus-1.dmm
@@ -221,23 +221,23 @@
 /turf/wall,
 /area/icarus/vessel)
 "aY" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/vessel)
 "aZ" = (
 /obj/random/obstruction,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/vessel)
 "ba" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/floor/tiled,
 /area/icarus/vessel)
 "bb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/vessel)
 "bc" = (
@@ -395,7 +395,7 @@
 /area/icarus/vessel)
 "bE" = (
 /obj/random/trash,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white,
 /area/icarus/vessel)
 "bF" = (
@@ -405,21 +405,21 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white,
 /area/icarus/vessel)
 "bH" = (
 /obj/structure/hygiene/shower{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white,
 /area/icarus/vessel)
 "bI" = (
 /obj/structure/hygiene/shower{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white,
 /area/icarus/vessel)
 "bJ" = (
@@ -514,7 +514,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "bX" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white,
 /area/icarus/vessel)
 "bY" = (
@@ -528,14 +528,14 @@
 	dir = 4
 	},
 /obj/random/trash,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white,
 /area/icarus/vessel)
 "ca" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/floor/tiled/white,
 /area/icarus/vessel)
@@ -625,7 +625,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white,
 /area/icarus/vessel)
 "cq" = (
@@ -633,7 +633,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white,
 /area/icarus/vessel)
 "cr" = (
@@ -652,7 +652,7 @@
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white,
 /area/icarus/vessel)
 "ct" = (
@@ -699,7 +699,7 @@
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/abstract/landmark/corpse/chef,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/floor/tiled/white,
@@ -784,7 +784,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "cN" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "cO" = (
@@ -878,14 +878,14 @@
 /obj/structure/broken_cryo/icarus{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/vessel)
 "dd" = (
 /obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/floor/tiled,
@@ -921,8 +921,8 @@
 "dj" = (
 /obj/structure/table,
 /obj/item/towel,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/floor/tiled,
@@ -937,7 +937,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/vessel)
 "dm" = (
@@ -971,7 +971,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "dr" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/wall,
 /area/icarus/vessel)
 "ds" = (
@@ -983,13 +983,13 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/vessel)
 "du" = (
 /obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/vessel)
 "dv" = (
@@ -1030,13 +1030,13 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/vessel)
 "dC" = (
 /obj/structure/table,
 /obj/random/accessory,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/floor/tiled,
@@ -1098,7 +1098,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -1125,7 +1125,7 @@
 /area/icarus/open)
 "dR" = (
 /obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white,
 /area/icarus/open)
 "dS" = (
@@ -1136,7 +1136,7 @@
 /turf/floor/tiled,
 /area/icarus/open)
 "dU" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/open)
 "dV" = (
@@ -1145,7 +1145,7 @@
 /turf/floor/tiled,
 /area/icarus/open)
 "dW" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/abstract/landmark/allowed_leak,
@@ -1204,41 +1204,41 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/open)
 "ee" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "ef" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/icarus/open)
 "eg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/icarus/open)
 "eh" = (
 /obj/random/tank,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white,
 /area/icarus/open)
 "ei" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "ej" = (
 /obj/random/trash,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/open)
 "ek" = (
@@ -1246,38 +1246,38 @@
 /turf/floor/tiled,
 /area/icarus/open)
 "el" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/open)
 "em" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/icarus/open)
 "en" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eo" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white,
 /area/icarus/open)
 "ep" = (
 /obj/structure/filing_cabinet/tall,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/open)
 "eq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating/airless/broken,
 /area/icarus/open)
 "er" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/floor/tiled,
 /area/icarus/open)
@@ -1290,7 +1290,7 @@
 /area/icarus/open)
 "eu" = (
 /obj/item/clothing/mask/smokable/cigarette/killthroat,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/open)
 "ev" = (
@@ -1298,9 +1298,9 @@
 /turf/floor/tiled,
 /area/icarus/open)
 "ew" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/clothing/mask/breath/emergency,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
@@ -1314,394 +1314,394 @@
 /turf/floor/tiled,
 /area/icarus/open)
 "ez" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating/airless/broken,
 /area/icarus/open)
 "eA" = (
 /turf/floor/plating/airless/broken,
 /area/icarus/open)
 "eB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/scalpel,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/bedsheet/orange,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/icarus/open)
 "eF" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/grass/wild,
 /area/icarus/open)
 "eG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/clothing/mask/surgical,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/plate,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/utensil/knife,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/bed/padded,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/snack,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/plate,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/ash,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stack/material/rods,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stack/material/ore/slag,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/ash,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stack/material/ore/slag,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stack/material/rods,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/snack,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/trash,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/ash,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "eZ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stack/material/rods,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "fa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/pill_bottle/antibiotics,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "fb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/trash,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "fc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/bag/trash,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "fd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/trash,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "fe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "ff" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "fg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stack/material/rods,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "fh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/chems/drinks/cans/waterbottle,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "fi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stack/material/rods,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "fj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stack/material/rods,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "fk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/ash,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "fl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "fm" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/trash,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "fn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/ash,
 /obj/random/trash,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "fo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/material,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "fp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stack/material/rods,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "fq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/ash,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "fr" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/material,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "fs" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stack/material/ore/slag,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "ft" = (
 /obj/effect/icarus/irradiate,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "fv" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/icarus/open)
 "fw" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating/airless/broken,
 /area/icarus/open)
 "fx" = (
@@ -1714,13 +1714,13 @@
 /turf/floor/tiled,
 /area/icarus/open)
 "fz" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/vessel)
 "fA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/vessel)
 "fB" = (
@@ -1736,10 +1736,10 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "fE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/vessel)
 "fF" = (
@@ -1747,12 +1747,12 @@
 /turf/floor/plating,
 /area/icarus/vessel)
 "fG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/vessel)
 "fH" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/trash,
 /turf/unsimulated/floor/sand,
 /area/icarus/vessel)
@@ -1904,10 +1904,10 @@
 /turf/floor/plating,
 /area/icarus/vessel)
 "gj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/trash,
 /turf/unsimulated/floor/sand,
 /area/icarus/vessel)
@@ -2478,7 +2478,7 @@
 /area/icarus/vessel)
 "hW" = (
 /obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "hX" = (
@@ -2487,8 +2487,8 @@
 /area/icarus/open)
 "hY" = (
 /obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "hZ" = (
@@ -2505,17 +2505,17 @@
 /area/icarus/vessel)
 "ib" = (
 /obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "ic" = (
 /obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "id" = (
@@ -2525,52 +2525,52 @@
 /turf/wall/r_wall,
 /area/icarus/open)
 "ie" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stack/material/ore/slag,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "if" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stack/material/ore/slag,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "ig" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/trash,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "ih" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/vehicle/train/cargo/trolley,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "ii" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stack/material/ore/slag,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "ij" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/engine{
 	anchored = 0
 	},
@@ -2578,28 +2578,28 @@
 /area/icarus/open)
 "ik" = (
 /obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "il" = (
 /obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
 "im" = (
 /obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/item/stack/material/ore/slag,
 /turf/unsimulated/floor/sand,
 /area/icarus/open)
@@ -2608,8 +2608,8 @@
 /turf/floor/grass/wild,
 /area/icarus/open)
 "ip" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/grass/wild,
 /area/icarus/open)
 "jb" = (
@@ -2654,7 +2654,7 @@
 	pixel_y = 2
 	},
 /obj/random/soap,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/white,
 /area/icarus/vessel)
 "rK" = (

--- a/mods/content/government/away_sites/icarus/icarus-2.dmm
+++ b/mods/content/government/away_sites/icarus/icarus-2.dmm
@@ -27,7 +27,7 @@
 /turf/floor/plating,
 /area/icarus/vessel)
 "ai" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/vessel)
 "aj" = (
@@ -45,7 +45,7 @@
 /area/icarus/vessel)
 "am" = (
 /obj/item/stack/material/ore/slag,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/vessel)
 "an" = (
@@ -86,13 +86,13 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "au" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/blood,
 /turf/floor/tiled,
 /area/icarus/vessel)
 "av" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/vessel)
 "aw" = (
@@ -122,7 +122,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "aB" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/overmap/visitable/sector/icarus,
 /turf/floor/tiled,
 /area/icarus/vessel)
@@ -143,7 +143,7 @@
 /area/icarus/vessel)
 "aG" = (
 /obj/random/loot,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/vessel)
 "aH" = (
@@ -462,7 +462,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "bF" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/floor/tiled,
@@ -585,7 +585,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "cc" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -635,7 +635,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "cj" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
@@ -678,7 +678,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "cp" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -781,8 +781,8 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "cF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/floor/tiled,
@@ -1054,7 +1054,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "dr" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/floor/tiled,
@@ -1114,7 +1114,7 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/vessel)
 "dC" = (
@@ -1176,7 +1176,7 @@
 /turf/wall,
 /area/icarus/open)
 "dL" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/random/trash,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1209,7 +1209,7 @@
 /turf/floor/tiled,
 /area/icarus/open)
 "dP" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/open)
 "dQ" = (
@@ -1249,7 +1249,7 @@
 /turf/floor/tiled,
 /area/icarus/open)
 "dX" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -1285,9 +1285,9 @@
 /turf/floor/plating,
 /area/icarus/open)
 "ed" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/open)
 "ee" = (
@@ -1296,8 +1296,8 @@
 /turf/floor/tiled,
 /area/icarus/open)
 "ef" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/icarus/open)
 "eg" = (

--- a/mods/gamemodes/heist/heist_base.dmm
+++ b/mods/gamemodes/heist/heist_base.dmm
@@ -160,7 +160,7 @@
 /area/map_template/syndicate_mothership/raider_base)
 "aK" = (
 /obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/sign/painting/monkey_painting{
 	pixel_x = -28;
 	pixel_y = 4
@@ -317,7 +317,7 @@
 /turf/unsimulated/floor/plating,
 /area/map_template/syndicate_mothership/raider_base)
 "bf" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/plating,
 /area/map_template/syndicate_mothership/raider_base)
 "bg" = (
@@ -421,7 +421,7 @@
 /turf/unsimulated/floor/plating,
 /area/map_template/syndicate_mothership/raider_base)
 "bv" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/structure/window/reinforced{
@@ -435,7 +435,7 @@
 /turf/unsimulated/floor/plating,
 /area/map_template/syndicate_mothership/raider_base)
 "bx" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/unsimulated/floor/plating,
@@ -529,12 +529,12 @@
 /turf/unsimulated/floor/wood/broken6,
 /area/map_template/syndicate_mothership/raider_base)
 "bO" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/washing_machine,
 /turf/unsimulated/floor/plating,
 /area/map_template/syndicate_mothership/raider_base)
 "bP" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
@@ -558,14 +558,14 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /turf/unsimulated/floor/plating,
 /area/map_template/syndicate_mothership/raider_base)
 "bS" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/unsimulated/floor/plating,

--- a/tools/map_migrations/4647_dirt.txt
+++ b/tools/map_migrations/4647_dirt.txt
@@ -1,0 +1,2 @@
+/obj/effect/decal/cleanable/dirt/@SUBTYPES : /obj/effect/decal/cleanable/dirt/visible/@SUBTYPES{@OLD}
+


### PR DESCRIPTION
- Lowers default click cooldown (items/attacks already set their own, so this largely impacts non-harm-intent interactions).
- Fixes autobinders not taking paper along with several other fab intake issues.
- Fixes https://github.com/ScavStation/ScavStation/issues/1148