### PR TITLE
Add fluid heights to slots, fix overzealous dousing

### DIFF
--- a/code/datums/inventory_slots/_inventory_slot.dm
+++ b/code/datums/inventory_slots/_inventory_slot.dm
@@ -20,7 +20,7 @@
 	var/requires_organ_tag
 	var/quick_equip_priority = 0 // Higher priority means it will be checked first. If null, will not be considered for quick equip.
 	/// What depth of fluid is necessary for an item in this slot to be considered submerged?
-	var/fluid_height = FLUID_SHALLOW
+	var/fluid_height = FLUID_SHALLOW // we're treating FLUID_SHALLOW as waist level, basically
 
 	var/mob_overlay_layer
 	var/alt_mob_overlay_layer

--- a/code/datums/inventory_slots/_inventory_slot.dm
+++ b/code/datums/inventory_slots/_inventory_slot.dm
@@ -19,6 +19,8 @@
 	var/requires_slot_flags
 	var/requires_organ_tag
 	var/quick_equip_priority = 0 // Higher priority means it will be checked first. If null, will not be considered for quick equip.
+	/// What depth of fluid is necessary for an item in this slot to be considered submerged?
+	var/fluid_height = FLUID_SHALLOW
 
 	var/mob_overlay_layer
 	var/alt_mob_overlay_layer

--- a/code/datums/inventory_slots/inventory_gripper.dm
+++ b/code/datums/inventory_slots/inventory_gripper.dm
@@ -5,6 +5,7 @@
 	/// If set, use this icon_state for the hand slot overlay; otherwise, use slot_id.
 	var/hand_overlay
 	quick_equip_priority = null // you quick-equip stuff by holding it in a gripper, so this ought to be skipped
+	fluid_height = (FLUID_SHALLOW + FLUID_OVER_MOB_HEAD) / 2 // halfway between waist and top of head, so roughly chest level, reasoning that you can just hold it up out of the water
 
 	// For reference, grippers do not use ui_loc, they have it set dynamically during /datum/hud/proc/rebuild_hands()
 

--- a/code/datums/inventory_slots/slots/slot_back.dm
+++ b/code/datums/inventory_slots/slots/slot_back.dm
@@ -7,6 +7,7 @@
 	requires_slot_flags = SLOT_BACK
 	mob_overlay_layer = HO_BACK_LAYER
 	quick_equip_priority = 14
+	fluid_height = (FLUID_SHALLOW + FLUID_OVER_MOB_HEAD) / 2 // halfway between waist and top of head, so roughly chest level
 
 /datum/inventory_slot/back/simple
 	requires_organ_tag = null

--- a/code/datums/inventory_slots/slots/slot_ears.dm
+++ b/code/datums/inventory_slots/slots/slot_ears.dm
@@ -10,6 +10,7 @@
 	requires_slot_flags = SLOT_EARS
 	mob_overlay_layer = HO_L_EAR_LAYER
 	quick_equip_priority = 7
+	fluid_height = (FLUID_SHALLOW * 0.25 + FLUID_OVER_MOB_HEAD * 0.75) // 3/4 of the way between waist-level and the top of your head
 
 /datum/inventory_slot/ear/update_mob_equipment_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
 	for(var/slot in global.airtight_slots)

--- a/code/datums/inventory_slots/slots/slot_glasses.dm
+++ b/code/datums/inventory_slots/slots/slot_glasses.dm
@@ -11,6 +11,7 @@
 	mob_overlay_layer = HO_GLASSES_LAYER
 	alt_mob_overlay_layer = HO_GOGGLES_LAYER
 	quick_equip_priority = 5
+	fluid_height = (FLUID_SHALLOW * 0.25 + FLUID_OVER_MOB_HEAD * 0.75) // 3/4 of the way between waist-level and the top of your head
 
 /datum/inventory_slot/glasses/get_examined_string(mob/owner, mob/user, distance, hideflags, decl/pronouns/pronouns)
 	if(_holding && !(hideflags & HIDEEYES))

--- a/code/datums/inventory_slots/slots/slot_head.dm
+++ b/code/datums/inventory_slots/slots/slot_head.dm
@@ -9,6 +9,7 @@
 	requires_slot_flags = SLOT_HEAD
 	mob_overlay_layer = HO_HEAD_LAYER
 	quick_equip_priority = 9
+	fluid_height = FLUID_OVER_MOB_HEAD
 
 /datum/inventory_slot/head/simple
 	requires_organ_tag = null

--- a/code/datums/inventory_slots/slots/slot_id.dm
+++ b/code/datums/inventory_slots/slots/slot_id.dm
@@ -6,6 +6,7 @@
 	requires_slot_flags = SLOT_ID
 	mob_overlay_layer = HO_ID_LAYER
 	quick_equip_priority = 13
+	fluid_height = (FLUID_SHALLOW + FLUID_OVER_MOB_HEAD) / 2 // halfway between waist and top of head, so roughly chest level
 
 /datum/inventory_slot/id/update_mob_equipment_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
 	var/obj/item/clothing/clothes = user.get_equipped_item(slot_w_uniform_str)

--- a/code/datums/inventory_slots/slots/slot_mask.dm
+++ b/code/datums/inventory_slots/slots/slot_mask.dm
@@ -10,6 +10,7 @@
 	can_be_hidden = TRUE
 	mob_overlay_layer = HO_FACEMASK_LAYER
 	quick_equip_priority = 10
+	fluid_height = (FLUID_SHALLOW * 0.25 + FLUID_OVER_MOB_HEAD * 0.75) // 3/4 of the way between waist-level and the top of your head
 
 /datum/inventory_slot/mask/update_mob_equipment_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
 	if(prop?.flags_inv & BLOCK_ALL_HAIR)

--- a/code/datums/inventory_slots/slots/slot_shoes.dm
+++ b/code/datums/inventory_slots/slots/slot_shoes.dm
@@ -10,6 +10,7 @@
 	)
 	requires_slot_flags = SLOT_FEET
 	quick_equip_priority = 3
+	fluid_height = 3
 
 /datum/inventory_slot/shoes/update_mob_equipment_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
 	var/obj/item/suit =    user.get_equipped_item(slot_wear_suit_str)

--- a/code/datums/inventory_slots/slots/slot_suit_storage.dm
+++ b/code/datums/inventory_slots/slots/slot_suit_storage.dm
@@ -5,6 +5,7 @@
 	slot_id = slot_s_store_str
 	requires_organ_tag = BP_CHEST
 	mob_overlay_layer = HO_SUIT_STORE_LAYER
+	fluid_height = (FLUID_SHALLOW + FLUID_OVER_MOB_HEAD) / 2 // halfway between waist and top of head, so roughly chest level
 
 /datum/inventory_slot/suit_storage/can_equip_to_slot(var/mob/user, var/obj/item/prop, var/disable_warning, var/ignore_equipped)
 	. = ..()

--- a/code/game/atoms_fluids.dm
+++ b/code/game/atoms_fluids.dm
@@ -24,11 +24,12 @@
 	return T?.is_flooded(lying_mob, absolute)
 
 /atom/proc/submerged(depth, above_turf)
+	var/turf/T = get_turf(src)
 	if(isnull(depth))
-		var/turf/T = get_turf(src)
 		if(!istype(T))
 			return FALSE
 		depth = T.get_fluid_depth()
+	if(istype(T))
 		var/turf_height = T.get_physical_height()
 		// If we're not on the surface of the turf (floating, leaping, or other sources)
 		// then we add the turf height to the depth, so you can jump over a water-filled pit
@@ -50,7 +51,7 @@
 	return ..()
 
 /obj/item/submerged(depth, above_turf)
-	var/datum/inventory_slot/slot = get_any_equipped_slot()
+	var/datum/inventory_slot/slot = get_any_equipped_slot_datum()
 	// we're in a mob and have a slot, so we bail early
 	if(istype(slot))
 		var/mob/owner = loc // get_any_equipped_slot checks istype already

--- a/code/game/atoms_fluids.dm
+++ b/code/game/atoms_fluids.dm
@@ -23,19 +23,63 @@
 	var/turf/T = get_turf(src)
 	return T?.is_flooded(lying_mob, absolute)
 
-/atom/proc/submerged(depth)
+/atom/proc/submerged(depth, above_turf)
 	if(isnull(depth))
 		var/turf/T = get_turf(src)
 		if(!istype(T))
 			return FALSE
 		depth = T.get_fluid_depth()
+		var/turf_height = T.get_physical_height()
+		// If we're not on the surface of the turf (floating, leaping, or other sources)
+		// then we add the turf height to the depth, so you can jump over a water-filled pit
+		// or throw something over it
+		if(turf_height < 0 && above_turf)
+			depth += turf_height
 	if(ismob(loc))
 		return depth >= FLUID_SHALLOW
 	if(isturf(loc))
+		if(locate(/obj/structure/table))
+			return depth >= FLUID_SHALLOW
 		return depth >= 3
 	return depth >= FLUID_OVER_MOB_HEAD
 
-/turf/submerged(depth)
+// This override exists purely because throwing is movable-level and not atom-level,
+// for obvious reasons (that being that non-movable atoms cannot move).
+/atom/movable/submerged(depth, above_turf)
+	above_turf ||= !!throwing
+	return ..()
+
+/obj/item/submerged(depth, above_turf)
+	var/datum/inventory_slot/slot = get_any_equipped_slot()
+	// we're in a mob and have a slot, so we bail early
+	if(istype(slot))
+		var/mob/owner = loc // get_any_equipped_slot checks istype already
+		if(owner.current_posture.prone)
+			return ..() // treat us like an atom sitting on the ground (or table), really
+		if(isnull(depth)) // copied from base proc, since we aren't calling parent in this block
+			var/turf/T = get_turf(src)
+			if(!istype(T))
+				return FALSE
+			depth = T.get_fluid_depth()
+		return depth >= slot.fluid_height
+	return ..()
+
+/mob/submerged(depth, above_turf)
+	above_turf ||= is_floating || !!throwing // check throwing here because of the table check coming before parent call
+	var/obj/structure/table/standing_on = locate(/obj/structure/table) in loc
+	// can't stand on a table if we're floating
+	if(!above_turf && standing_on && standing_on.mob_offset > 0) // standing atop a table that is a meaningful amount above the ground (not a bench)
+		if(isnull(depth)) // duplicated from atom because we don't call parent in this block
+			var/turf/T = get_turf(src)
+			if(!istype(T))
+				return FALSE
+			depth = T.get_fluid_depth()
+		// assuming default tables are at waist height, this is a simple adjustment to scale it for taller/shorter ones
+		return depth >= floor(FLUID_SHALLOW * (standing_on.mob_offset / /obj/structure/table::mob_offset))
+	return ..()
+
+// above_turf is nonsensical for turfs but I don't want the linter to complain
+/turf/submerged(depth, above_turf)
 	if(isnull(depth))
 		depth = get_fluid_depth()
 	return depth >= FLUID_OVER_MOB_HEAD

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -272,7 +272,7 @@
 
 		if(isturf(loc))
 			var/turf/T = loc
-			if(T.reagents)
+			if(T.reagents?.total_volume && submerged())
 				fluid_act(T.reagents)
 
 		for(var/mob/viewer in storage?.storage_ui?.is_seeing)

--- a/code/game/objects/items/flame/_flame.dm
+++ b/code/game/objects/items/flame/_flame.dm
@@ -167,14 +167,7 @@
 	if(waterproof)
 		return
 
-	var/check_depth = FLUID_PUDDLE
-	if(ismob(loc))
-		var/mob/holder = loc
-		if(!holder.current_posture?.prone)
-			check_depth = FLUID_OVER_MOB_HEAD
-		else
-			check_depth = FLUID_SHALLOW
-	if(fluids.total_volume >= check_depth)
+	if(fluids.total_volume >= FLUID_PUDDLE)
 		snuff_out(no_message = TRUE)
 
 /obj/item/flame/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -117,11 +117,8 @@
 	..()
 	if(!QDELETED(src) && fluids?.total_volume)
 		fluids.touch_turf(src)
-		// technically, fluids might not be our own reagent holder
-		// so we factor in height ourselves
-		var/fluid_height = fluids.total_volume + get_physical_height()
 		for(var/atom/movable/AM as anything in get_contained_external_atoms())
-			if(!AM.submerged(fluid_height))
+			if(!AM.submerged())
 				continue
 			AM.fluid_act(fluids)
 

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -117,7 +117,12 @@
 	..()
 	if(!QDELETED(src) && fluids?.total_volume)
 		fluids.touch_turf(src)
+		// technically, fluids might not be our own reagent holder
+		// so we factor in height ourselves
+		var/fluid_height = fluids.total_volume + get_physical_height()
 		for(var/atom/movable/AM as anything in get_contained_external_atoms())
+			if(!AM.submerged(fluid_height))
+				continue
 			AM.fluid_act(fluids)
 
 /turf/proc/remove_fluids(var/amount, var/defer_update)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -271,15 +271,49 @@
 		return 1 //already unequipped, so success
 	return I.mob_can_unequip(src, slot)
 
+/// Gets the inventory slot string ID for the mob whose contents we're in, if any.
+/// Checks both equipped and held item slots.
 /obj/item/proc/get_any_equipped_slot()
-	return get_equipped_slot() || get_held_slot()
+	if(!ismob(loc))
+		return null
+	var/mob/mob = loc
+	return mob.get_any_equipped_slot_for_item(src)
 
+/// Gets the inventory slot string ID for an item that may be in our inventory.
+/// Checks both equipped and held item slots.
+/mob/proc/get_any_equipped_slot_for_item(obj/item/I)
+	var/list/slots = get_inventory_slots() + get_held_item_slots()
+	if(!length(slots))
+		return
+	for(var/slot_str in slots)
+		if(get_equipped_item(slot_str) == I) // slots[slot]._holding == I
+			return slot_str
+
+/// A counterpart to get_any_equipped_slot_for_item that returns the slot datum rather than the slot name.
+/// Checks both equipped and held item slots.
+/obj/item/proc/get_any_equipped_slot_datum()
+	if(!ismob(loc))
+		return null
+	var/mob/mob = loc
+	return mob.get_inventory_slot_datum(mob.get_any_equipped_slot_for_item(src))
+
+/// Gets the equipment (worn) slot string ID for the mob whose contents we're in, if any. Does not include held slots.
 /obj/item/proc/get_equipped_slot()
 	if(!ismob(loc))
 		return null
 	var/mob/mob = loc
 	return mob.get_equipped_slot_for_item(src)
 
+/// A helper that returns the slot datum rather than the slot name.
+/// Does not include held slots.
+/// Saves unnecessary duplicate ismob checks and loc casts.
+/obj/item/proc/get_equipped_slot_datum()
+	if(!ismob(loc))
+		return null
+	var/mob/mob = loc
+	return mob.get_inventory_slot_datum(mob.get_equipped_slot_for_item(src))
+
+/// Gets the equipment (worn) slot string ID for an item we may be wearing. Does not include held slots.
 /mob/proc/get_equipped_slot_for_item(obj/item/I)
 	var/list/slots = get_inventory_slots()
 	if(!length(slots))
@@ -288,12 +322,14 @@
 		if(get_equipped_item(slot_str) == I) // slots[slot]._holding == I
 			return slot_str
 
+/// Gets the held item slot string ID for the mob whose contents we're in, if any. Does not include worn slots.
 /obj/item/proc/get_held_slot()
 	if(!ismob(loc))
 		return null
 	var/mob/mob = loc
 	return mob.get_held_slot_for_item(src)
 
+/// Gets the held item slot string ID for an item we may be holding. Does not include worn slots.
 /mob/proc/get_held_slot_for_item(obj/item/I)
 	var/list/slots = get_held_item_slots()
 	if(!length(slots))

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -271,6 +271,9 @@
 		return 1 //already unequipped, so success
 	return I.mob_can_unequip(src, slot)
 
+/obj/item/proc/get_any_equipped_slot()
+	return get_equipped_slot() || get_held_slot()
+
 /obj/item/proc/get_equipped_slot()
 	if(!ismob(loc))
 		return null
@@ -284,6 +287,12 @@
 	for(var/slot_str in slots)
 		if(get_equipped_item(slot_str) == I) // slots[slot]._holding == I
 			return slot_str
+
+/obj/item/proc/get_held_slot()
+	if(!ismob(loc))
+		return null
+	var/mob/mob = loc
+	return mob.get_held_slot_for_item(src)
 
 /mob/proc/get_held_slot_for_item(obj/item/I)
 	var/list/slots = get_held_item_slots()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -853,8 +853,13 @@ default behaviour is:
 	fluids.touch_mob(src)
 	if(QDELETED(src) || !fluids.total_volume)
 		return
+	var/on_turf = fluids.my_atom == get_turf(src)
 	for(var/atom/movable/A as anything in get_equipped_items(TRUE))
 		if(!A.simulated)
+			continue
+		// if we're being affected by reagent fluids, items check if they're submerged
+		// todo: i don't like how this works, it feels hacky. maybe separate coating and submersion somehow and make this only checked for submersion
+		if(on_turf && !A.submerged())
 			continue
 		A.fluid_act(fluids)
 		if(QDELETED(src) || !fluids.total_volume)


### PR DESCRIPTION
added heights to slots, currently unscaled but could easily be affected by mob height and size modifiers. unfortunately it'd need a rewrite to properly handle like... a head below your hands, or whatever. would probably want to make that organ-driven somehow.
expands submerged checks to add negative turf height when floating or being thrown. this means you can leap over deep water or throw a lantern across water.
makes all fluid act sources from movement check submersion
basically you might get your shoes wet in a puddle but you won't have your lantern immediately doused.

this is moderately tested but should be pulled into volatile tbh