### PR TITLE
Fix misc. issues with fluid appearances

### DIFF
--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -89,7 +89,7 @@ var/global/round_start_time = 0
 		out += "[seconds] second\s"
 	if(length(out))
 		return english_list(out)
-	return null
+	return "less than a second"
 
 /proc/roundduration2text()
 	if(!round_start_time)

--- a/code/_helpers/visual_filters.dm
+++ b/code/_helpers/visual_filters.dm
@@ -55,8 +55,8 @@
 		LAZYREMOVE(filter_data, filter_name)
 		filters -= thing
 		update_filters()
-		return FALSE
-	return TRUE
+		return TRUE
+	return FALSE
 
 /// Animate a given filter on this atom. All params after the first are passed to animate().
 /atom/movable/proc/animate_filter(filter_name, list/params)

--- a/code/game/objects/items/flame/_flame.dm
+++ b/code/game/objects/items/flame/_flame.dm
@@ -125,6 +125,9 @@
 	update_attack_force()
 
 	update_icon()
+	if(ismob(loc)) // not very robust for things like accessories...
+		update_held_icon()
+		update_clothing_icon()
 	if(istype(loc, /obj/structure/wall_sconce))
 		loc.update_icon()
 

--- a/code/game/objects/items/flame/flame_torch.dm
+++ b/code/game/objects/items/flame/flame_torch.dm
@@ -76,11 +76,11 @@
 	if(head_material)
 		var/decl/material/head_mat = GET_DECL(head_material)
 		if(burnt)
-			add_overlay(overlay_image(icon, "[icon_state]-burnt", head_mat.color, flags = RESET_COLOR))
+			add_overlay(overlay_image(icon, "[icon_state]-burnt", head_mat.color, flags = RESET_COLOR|KEEP_APART))
 		else
-			add_overlay(overlay_image(icon, "[icon_state]-head", head_mat.color, flags = RESET_COLOR))
+			add_overlay(overlay_image(icon, "[icon_state]-head", head_mat.color, flags = RESET_COLOR|KEEP_APART))
 	if(lit)
-		add_overlay(overlay_image(icon, "[icon_state]-lit", flags = RESET_COLOR))
+		add_overlay(overlay_image(icon, "[icon_state]-lit", flags = RESET_COLOR|KEEP_APART))
 
 /obj/item/flame/torch/get_sconce_overlay()
 	. = list(overlay_image(icon, "[icon_state]-sconce", color = color, flags = RESET_COLOR))

--- a/code/modules/fluids/_fluid.dm
+++ b/code/modules/fluids/_fluid.dm
@@ -22,8 +22,7 @@
 	// Update layer.
 	var/new_layer
 	var/turf/T = get_turf(src)
-	var/effective_depth = T?.get_physical_height() + reagent_volume
-	if(effective_depth < 0)
+	if(T.pixel_z < 0)
 		new_layer = T.layer + 0.2
 	else if(reagent_volume > FLUID_DEEP)
 		new_layer = DEEP_FLUID_LAYER


### PR DESCRIPTION
- Fixes an issue with fluids on recessed natural turfs flickering above/below mobs.
- Fixes torch head colors breaking when an alpha mask is applied.
- Fixes KEEP_TOGETHER never being unapplied when an alpha mask is removed, because remove_filter returned the wrong value.
- Adds held and worn icon update calls to torches when they're extinguished.
- Fixes ticks2readable giving a blank output for values under 10 ticks (relevant for ability cooldown etc).