### PR TITLE
Remove mind.original

### DIFF
--- a/code/datums/communication/dsay.dm
+++ b/code/datums/communication/dsay.dm
@@ -61,12 +61,8 @@
 
 	keyname = C.key
 	if(C.mob) //Most of the time this is the dead/observer mob; we can totally use him if there is no better name
-		var/mindname
+		var/mindname = C.mob.mind?.name // the mind's "original name"
 		var/realname = C.mob.real_name
-		if(C.mob.mind)
-			mindname = C.mob.mind.name
-			if(C.mob.mind.original && C.mob.mind.original.real_name)
-				realname = C.mob.mind.original.real_name
 		if(mindname && mindname != realname)
 			name = "[realname] died as [mindname]"
 		else

--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -33,7 +33,6 @@
 	var/key
 	var/name				//replaces mob/var/original_name
 	var/mob/living/current
-	var/mob/living/original	//TODO: remove.not used in any meaningful way ~Carn. First I'll need to tweak the way silicon-mobs handle minds.
 	var/active = 0
 
 	var/gen_relations_info
@@ -71,17 +70,11 @@
 	if(current?.mind == src)
 		current.mind = null
 	current = null
-	if(original?.mind == src)
-		original.mind = null
-	original = null
 	. = ..()
 
 /datum/mind/proc/handle_mob_deletion(mob/living/deleted_mob)
 	if (current == deleted_mob)
 		current = null
-
-	if (original == deleted_mob)
-		original = null
 
 /datum/mind/proc/transfer_to(mob/living/new_character)
 	if(!istype(new_character))
@@ -505,7 +498,6 @@
 		mind.key = key
 	else
 		mind = new /datum/mind(key)
-		mind.original = src
 		SSticker.minds += mind
 	if(!mind.name)	mind.name = real_name
 	mind.current = src

--- a/code/game/antagonist/antagonist_update.dm
+++ b/code/game/antagonist/antagonist_update.dm
@@ -13,7 +13,6 @@
 		player.current = new mob_path(get_turf(player.current))
 		player.transfer_to(player.current)
 		if(holder) qdel(holder)
-	player.original = player.current
 	if(!preserve_appearance && (flags & ANTAG_SET_APPEARANCE))
 		spawn(3)
 			var/mob/living/human/H = player.current

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -550,7 +550,7 @@ var/global/list/additional_antag_types = list()
 
 			continue //Happy connected client
 		for(var/mob/observer/ghost/D in SSmobs.mob_list)
-			if(D.mind && (D.mind.original == L || D.mind.current == L))
+			if(D.mind && D.mind.current == L)
 				if(L.stat == DEAD)
 					msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] (Dead)\n"
 					continue //Dead mob, ghost abandoned

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -120,7 +120,7 @@
 					dat += "<dd><A href='byond://?src=\ref[src];pass=1'>&#09;[++i]. Set Custom Key</a><br></dd>"
 			else
 				dat += "<br><hr><dd><span class='notice'>Please authenticate with the server in order to show additional options.</span>"
-			if((isAI(user) || isrobot(user)) && (user.mind.assigned_special_role && user.mind.original == user))
+			if((isAI(user) || isrobot(user)) && player_is_antag(user.mind))
 				//Malf/Traitor AIs can bruteforce into the system to gain the Key.
 				dat += "<dd><A href='byond://?src=\ref[src];hack=1'><i><font color='Red'>*&@#. Bruteforce Key</font></i></font></a></dd>"
 
@@ -283,7 +283,7 @@
 
 	//Hack the Console to get the password
 	if (href_list["hack"])
-		if((isAI(usr) || isrobot(usr)) && usr.mind.assigned_special_role && usr.mind.original == usr)
+		if((isAI(usr) || isrobot(usr)) && player_is_antag(usr.mind))
 			src.hacking = 1
 			src.screen = 2
 			update_icon()

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -68,7 +68,7 @@
 			return TOPIC_HANDLED
 
 		// Antag AI checks
-		if(!isAI(user) || !(user.mind.assigned_special_role && user.mind.original == user))
+		if(!isAI(user) || !player_is_antag(user.mind))
 			to_chat(user, "<span class='warning'>Access Denied</span>")
 			return TOPIC_HANDLED
 
@@ -103,9 +103,9 @@
 		. = TOPIC_REFRESH
 
 // Proc: get_cyborgs()
-// Parameters: 1 (operator - mob which is operating the console.)
+// Parameters: 1 (user - mob which is operating the console.)
 // Description: Returns NanoUI-friendly list of accessible cyborgs.
-/obj/machinery/computer/robotics/proc/get_cyborgs(var/mob/operator)
+/obj/machinery/computer/robotics/proc/get_cyborgs(var/mob/user)
 	var/list/robots = list()
 
 	for(var/mob/living/silicon/robot/R in global.silicon_mob_list)
@@ -145,7 +145,7 @@
 		robot["master_ai"] = R.connected_ai ? R.connected_ai.name : "None"
 		robot["hackable"] = 0
 		// Antag AIs know whether linked cyborgs are hacked or not.
-		if(operator && isAI(operator) && (R.connected_ai == operator) && (operator.mind.assigned_special_role && operator.mind.original == operator))
+		if(user && isAI(user) && (R.connected_ai == user) && player_is_antag(user.mind))
 			robot["hacked"] = R.emagged ? 1 : 0
 			robot["hackable"] = R.emagged? 0 : 1
 		robots.Add(list(robot))

--- a/code/game/objects/items/robot/robot_frame.dm
+++ b/code/game/objects/items/robot/robot_frame.dm
@@ -111,6 +111,7 @@
 		O.custom_name = created_name
 		O.updatename("Default")
 
+		clear_antag_roles(brainmob.mind, implanted = TRUE) // some antag roles persist
 		brainmob.mind.transfer_to(O)
 		if(O.mind && O.mind.assigned_role)
 			O.job = O.mind.assigned_role

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -42,8 +42,11 @@
 	var/datum/ai_laws/master = connected_ai && lawupdate ? connected_ai.laws : null
 	if (master)
 		master.sync(src)
-	..()
-	return
+	. = ..()
+	// if we aren't malfunctioning and we have a law 0, it's presumably shared
+	// if we are malfunctioning and we don't have a law 0, we don't need to worry about this
+	if(connected_ai && is_malfunctioning() && has_zeroth_law())
+		to_chat(src, SPAN_BOLD("Remember, your AI does NOT share or know about your law 0."))
 
 /mob/living/silicon/robot/proc/robot_checklaws()
 	set category = "Silicon Commands"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -294,8 +294,6 @@ var/global/list/global/organ_rel_size = list(
 		var/datum/mind/M = O
 		if(M.current && M.current.client)
 			C = M.current.client
-		else if(M.original && M.original.client)
-			C = M.original.client
 
 	if(C)
 		if(C.get_preference_value(/datum/client_preference/anon_say) == PREF_YES)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -392,7 +392,6 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 
 	if(mind)
 		mind.active = 0 //we wish to transfer the key manually
-		mind.original = new_character
 		var/memory = client.prefs.records[PREF_MEM_RECORD]
 		if(memory)
 			mind.StoreMemory(memory)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -70,7 +70,6 @@
 	O.aiRestorePowerRoutine = 0
 	if(mind)
 		mind.transfer_to(O)
-		O.mind.original = O
 	else
 		O.key = key
 
@@ -128,7 +127,6 @@
 	mind.active = TRUE
 	mind.transfer_to(O)
 	if(O.mind && O.mind.assigned_role == ASSIGNMENT_ROBOT)
-		O.mind.original = O
 		var/mmi_type = SSrobots.get_brain_type_by_title(O.mind.role_alt_title ? O.mind.role_alt_title : O.mind.assigned_role)
 		if(mmi_type)
 			O.central_processor = new mmi_type(O)

--- a/mods/gamemodes/traitor/overrides.dm
+++ b/mods/gamemodes/traitor/overrides.dm
@@ -3,17 +3,11 @@
 	return mind && traitors.is_antagonist(mind)
 
 /mob/living/silicon/robot/show_master(mob/who)
-	// TODO: Update to new antagonist system.
-	if (mind?.assigned_special_role == /decl/special_role/traitor && mind.original == src && connected_ai)
+	var/decl/special_role/traitor/traitor_role = IMPLIED_DECL
+	if(traitor_role.is_antagonist(mind) && connected_ai)
 		to_chat(who, "<b>Remember, [connected_ai.name] is technically your master, but your objective comes first.</b>")
 		return
 	return ..()
-
-/mob/living/silicon/robot/lawsync()
-	. = ..()
-	// TODO: Update to new antagonist system.
-	if(mind?.assigned_special_role == /decl/special_role/traitor && mind.original == src)
-		to_chat(src, SPAN_BOLD("Remember, your AI does NOT share or know about your law 0."))
 
 /mob/living/silicon/robot/handle_regular_hud_updates()
 	. = ..()

--- a/mods/species/vox/datum/heist_compatibility.dm
+++ b/mods/species/vox/datum/heist_compatibility.dm
@@ -16,7 +16,7 @@
 
 	var/decl/species/my_species = user?.get_species()
 	var/decl/special_role/raider/raiders = GET_DECL(/decl/special_role/raider)
-	if(!istype(user) || !user.mind || !user.mind.assigned_special_role != raiders || !my_species || my_species.name == SPECIES_VOX || !is_alien_whitelisted(user, SPECIES_VOX))
+	if(!istype(user) || !user.mind || !raiders.is_antagonist(user.mind) || !my_species || my_species.name == SPECIES_VOX || !is_alien_whitelisted(user, SPECIES_VOX))
 		return ..()
 
 	var/choice = input("Do you wish to become a vox of the Shoal? This is not reversible.") as null|anything in list("No","Yes")


### PR DESCRIPTION
There is a ~12 year old TODO about removing this. 

Also updates the Vox raider mirror to use the special role system properly. Same with some traitor borg stuff. Certain Law 0 handling was moved out of the traitor modpack as well.