### PR TITLE
Vomit and mud can now be tracked around the floor.

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -108,3 +108,12 @@ var/global/list/bodytype_species_pairs = list() // A list of bodytypes -> specie
 /proc/get_bodytype_species_pairs()
 	build_species_lists()
 	. = global.bodytype_species_pairs
+
+// Used to avoid constantly generating new lists during movement.
+var/global/list/all_stance_limbs   = list(
+	ORGAN_CATEGORY_STANCE,
+	ORGAN_CATEGORY_STANCE_ROOT
+)
+var/global/list/child_stance_limbs = list(
+	ORGAN_CATEGORY_STANCE
+)

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -91,26 +91,12 @@
 /obj/effect/decal/cleanable/blood/Crossed(atom/movable/AM)
 	if(!isliving(AM) || amount < 1)
 		return
-
-	var/mob/living/M = AM
-	var/obj/item/organ/external/l_foot = GET_EXTERNAL_ORGAN(M, BP_L_FOOT)
-	var/obj/item/organ/external/r_foot = GET_EXTERNAL_ORGAN(M, BP_R_FOOT)
-	var/hasfeet = l_foot && r_foot
-
-	var/transferred_data = blood_data ? blood_data[pick(blood_data)] : null
-	var/obj/item/clothing/shoes/shoes = M.get_equipped_item(slot_shoes_str)
-	if(istype(shoes) && !M.buckled)//Adding blood to shoes
-		shoes.add_coating(chemical, amount, transferred_data)
-	else if (hasfeet)//Or feet
-		if(l_foot)
-			l_foot.add_coating(chemical, amount, transferred_data)
-		if(r_foot)
-			r_foot.add_coating(chemical, amount, transferred_data)
-	else if (M.buckled && istype(M.buckled, /obj/structure/bed/chair/wheelchair))
-		var/obj/structure/bed/chair/wheelchair/W = M.buckled
-		W.bloodiness = 4
-
-	M.update_equipment_overlay(slot_shoes_str)
+	var/mob/living/walker = AM
+	if(istype(walker.buckled, /obj/structure/bed/chair/wheelchair))
+		var/obj/structure/bed/chair/wheelchair/wheelchair = walker.buckled
+		wheelchair.bloodiness = 4
+	else
+		walker.add_walking_contaminant(chemical, amount, (blood_data ? blood_data[pick(blood_data)] : null))
 	amount--
 
 /obj/effect/decal/cleanable/blood/proc/dry()

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -90,9 +90,20 @@
 	if(prob(75))
 		set_rotation(pick(90, 180, 270))
 
+/obj/effect/decal/cleanable/vomit/mapped/Initialize(ml, _age)
+	. = ..()
+	add_to_reagents(/decl/material/liquid/acid/stomach, rand(3,5))
+	add_to_reagents(/decl/material/liquid/nutriment, rand(5,8))
+
 /obj/effect/decal/cleanable/vomit/on_update_icon()
 	. = ..()
-	color = reagents.get_color()
+	color = reagents?.get_color()
+
+/obj/effect/decal/cleanable/vomit/Crossed(atom/movable/AM)
+	. = ..()
+	if(!QDELETED(src) && reagents?.total_volume >= 1 && isliving(AM))
+		var/mob/living/walker = AM
+		walker.add_walking_contaminant(reagents, rand(2, 3))
 
 /obj/effect/decal/cleanable/tomato_smudge
 	name               = "tomato smudge"

--- a/code/game/objects/items/_item_materials.dm
+++ b/code/game/objects/items/_item_materials.dm
@@ -5,8 +5,8 @@
 	if((material_alteration & MAT_FLAG_ALTERATION_COLOR) && material)
 		alpha = 100 + material.opacity * 255
 	color = get_color() // avoiding set_color() here as that will set it on paint_color
-	if(blood_overlay)
-		add_overlay(blood_overlay)
+	if(coating_overlay)
+		add_overlay(coating_overlay)
 	if(global.contamination_overlay && contaminated)
 		add_overlay(global.contamination_overlay)
 

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -66,8 +66,8 @@
 	update_held_icon()
 
 /obj/item/telebaton/on_update_icon()
-	if(length(blood_DNA))
-		generate_blood_overlay(TRUE) // Force recheck.
+	if(coating?.total_volume || blood_DNA)
+		generate_coating_overlay(TRUE) // Force recheck.
 	. = ..()
 	if(on)
 		icon = 'icons/obj/items/weapon/telebaton_extended.dmi'

--- a/code/game/turfs/flooring/_flooring.dm
+++ b/code/game/turfs/flooring/_flooring.dm
@@ -350,3 +350,9 @@ var/global/list/flooring_cache = list()
 
 /decl/flooring/proc/handle_turf_digging(turf/floor/target)
 	return TRUE
+
+/decl/flooring/proc/turf_crossed(atom/movable/crosser)
+	return
+
+/decl/flooring/proc/can_show_footsteps(turf/target)
+	return TRUE

--- a/code/game/turfs/flooring/flooring_mud.dm
+++ b/code/game/turfs/flooring/flooring_mud.dm
@@ -19,6 +19,15 @@
 		return
 	return ..()
 
+/decl/flooring/mud/turf_crossed(atom/movable/crosser)
+	if(!isliving(crosser))
+		return
+	var/mob/living/walker = crosser
+	walker.add_walking_contaminant(/decl/material/solid/soil, rand(2,3))
+
+/decl/flooring/mud/can_show_footsteps(turf/target)
+	return FALSE // So we don't end up covered in a million footsteps that we provided.
+
 /decl/flooring/dry_mud
 	name            = "dry mud"
 	desc            = "This was once mud, but forgot to keep hydrated."

--- a/code/game/turfs/floors/_floor.dm
+++ b/code/game/turfs/floors/_floor.dm
@@ -297,3 +297,11 @@
 /turf/floor/get_plant_growth_rate()
 	var/decl/flooring/flooring = get_topmost_flooring()
 	return flooring ? flooring.growth_value : ..()
+
+/turf/floor/Crossed(atom/movable/AM)
+	var/decl/flooring/flooring = get_topmost_flooring()
+	flooring?.turf_crossed(AM)
+	return ..()
+
+/turf/floor/can_show_footsteps()
+	return ..() && get_topmost_flooring()?.can_show_footsteps(src)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -822,6 +822,9 @@
 			if(IS_HOE(held) && can_dig_farm(held.material?.hardness))
 				LAZYDISTINCTADD(., /decl/interaction_handler/dig/farm)
 
+/turf/proc/can_show_footsteps()
+	return simulated
+
 /decl/interaction_handler/show_turf_contents
 	name = "Show Turf Contents"
 	expected_user_type = /mob

--- a/code/modules/detectivework/tools/uvlight.dm
+++ b/code/modules/detectivework/tools/uvlight.dm
@@ -47,6 +47,7 @@
 			add_overlay(emissive_overlay(icon, "[icon_state]-on"))
 			z_flags |= ZMM_MANGLE_PLANES
 
+// TODO: does this even work with SSoverlays?
 /obj/item/uv_light/proc/clear_last_scan()
 	if(scanned.len)
 		for(var/atom/O in scanned)
@@ -62,7 +63,7 @@
 		stored_alpha.Cut()
 	if(reset_objects.len)
 		for(var/obj/item/I in reset_objects)
-			I.overlays -= I.blood_overlay
+			I.overlays -= I.coating_overlay
 			if(I.fluorescent == FLUORESCENT_GLOWING)
 				I.fluorescent = FLUORESCENT_GLOWS
 		reset_objects.Cut()
@@ -86,6 +87,6 @@
 						A.alpha = use_alpha
 					if(istype(A, /obj/item))
 						var/obj/item/O = A
-						if(O.was_bloodied && !(O.blood_overlay in O.overlays))
-							O.overlays |= O.blood_overlay
+						if(O.was_bloodied && !(O.coating_overlay in O.overlays))
+							O.overlays |= O.coating_overlay
 							reset_objects |= O

--- a/code/modules/mob/living/human/human.dm
+++ b/code/modules/mob/living/human/human.dm
@@ -1071,40 +1071,6 @@
 	var/datum/appearance_descriptor/age = LAZYACCESS(bodytype.appearance_descriptors, "age")
 	LAZYSET(appearance_descriptors, "age", (age ? age.sanitize_value(val) : 30))
 
-/mob/living/human/HandleBloodTrail(turf/T, old_loc)
-	// Tracking blood
-	var/obj/item/source
-	var/obj/item/clothing/shoes/shoes = get_equipped_item(slot_shoes_str)
-	if(istype(shoes))
-		shoes.handle_movement(src, MOVING_QUICKLY(src))
-		if(shoes.coating && shoes.coating.total_volume > 1)
-			source = shoes
-	else
-		for(var/foot_tag in list(BP_L_FOOT, BP_R_FOOT))
-			var/obj/item/organ/external/stomper = GET_EXTERNAL_ORGAN(src, foot_tag)
-			if(stomper && stomper.coating && stomper.coating.total_volume > 1)
-				source = stomper
-	if(!source)
-		species.handle_trail(src, T, old_loc)
-		return
-
-	var/list/bloodDNA
-	var/bloodcolor
-	var/list/blood_data = REAGENT_DATA(source.coating, /decl/material/liquid/blood)
-	if(blood_data)
-		bloodDNA = list(blood_data[DATA_BLOOD_DNA] = blood_data[DATA_BLOOD_TYPE])
-	else
-		bloodDNA = list()
-	bloodcolor = source.coating.get_color()
-	source.remove_coating(1)
-	update_equipment_overlay(slot_shoes_str)
-
-	if(species.get_move_trail(src))
-		T.AddTracks(species.get_move_trail(src),bloodDNA, dir, 0, bloodcolor) // Coming
-		if(isturf(old_loc))
-			var/turf/old_turf = old_loc
-			old_turf.AddTracks(species.get_move_trail(src), bloodDNA, 0, dir, bloodcolor) // Going
-
 /mob/living/human/remove_implant(obj/item/implant, surgical_removal = FALSE, obj/item/organ/external/affected)
 	if((. = ..()) && !surgical_removal)
 		shock_stage += 20

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -585,8 +585,7 @@
 	if(!root_bodytype)
 		return
 
-	var/static/list/all_stance_limbs = list(ORGAN_CATEGORY_STANCE, ORGAN_CATEGORY_STANCE_ROOT)
-	var/expected_limbs_for_bodytype = root_bodytype.get_expected_organ_count_for_categories(all_stance_limbs)
+	var/expected_limbs_for_bodytype = root_bodytype.get_expected_organ_count_for_categories(global.all_stance_limbs)
 	if(expected_limbs_for_bodytype <= 0)
 		return // we don't care about stance for whatever reason.
 
@@ -598,7 +597,7 @@
 
 	var/found_limbs = 0
 	var/had_limb_pain = FALSE
-	for(var/obj/item/organ/external/limb in get_organs_by_categories(all_stance_limbs))
+	for(var/obj/item/organ/external/limb in get_organs_by_categories(global.all_stance_limbs))
 		found_limbs++
 		var/add_stance_damage = 0
 		if(limb.is_malfunctioning())

--- a/maps/away/mining/mining-signal.dmm
+++ b/maps/away/mining/mining-signal.dmm
@@ -1561,7 +1561,7 @@
 /area/outpost/abandoned)
 "fs" = (
 /obj/effect/decal/cleanable/dirt/visible,
-/obj/effect/decal/cleanable/vomit,
+/obj/effect/decal/cleanable/vomit/mapped,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "ft" = (
@@ -2428,7 +2428,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/vomit,
+/obj/effect/decal/cleanable/vomit/mapped,
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,

--- a/maps/away/smugglers/smugglers.dmm
+++ b/maps/away/smugglers/smugglers.dmm
@@ -854,7 +854,7 @@
 /turf/floor,
 /area/smugglers/dorms)
 "cp" = (
-/obj/effect/decal/cleanable/vomit,
+/obj/effect/decal/cleanable/vomit/mapped,
 /obj/random/medical/lite,
 /turf/floor/plating/airless,
 /area/smugglers/dorms)

--- a/maps/away/unishi/unishi-2.dmm
+++ b/maps/away/unishi/unishi-2.dmm
@@ -2283,7 +2283,7 @@
 /turf/space,
 /area/unishi/smresearch)
 "go" = (
-/obj/effect/decal/cleanable/vomit,
+/obj/effect/decal/cleanable/vomit/mapped,
 /obj/item/defibrillator,
 /turf/floor/tiled/techfloor,
 /area/unishi/smresearch)
@@ -2397,7 +2397,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/vomit,
+/obj/effect/decal/cleanable/vomit/mapped,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -119,7 +119,7 @@
 "ap" = (
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
-/obj/effect/decal/cleanable/vomit,
+/obj/effect/decal/cleanable/vomit/mapped,
 /obj/effect/decal/cleanable/filth,
 /obj/structure/curtain/open/shower/engineering,
 /obj/structure/hygiene/toilet{

--- a/maps/random_ruins/exoplanet_ruins/deserted_lab/deserted_lab.dmm
+++ b/maps/random_ruins/exoplanet_ruins/deserted_lab/deserted_lab.dmm
@@ -184,7 +184,7 @@
 /turf/floor/tiled/white,
 /area/template_noop)
 "aM" = (
-/obj/effect/decal/cleanable/vomit,
+/obj/effect/decal/cleanable/vomit/mapped,
 /obj/item/chems/glass/paint/random,
 /obj/structure/closet/medical_wall/filled{
 	pixel_y = 32

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -4708,7 +4708,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/vomit,
+/obj/effect/decal/cleanable/vomit/mapped,
 /turf/floor/tiled/white/monotile,
 /area/map_template/colony/bathroom)
 "jl" = (

--- a/maps/random_ruins/exoplanet_ruins/spider_nest/spider_nest.dmm
+++ b/maps/random_ruins/exoplanet_ruins/spider_nest/spider_nest.dmm
@@ -83,7 +83,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/shard,
 /obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/vomit,
+/obj/effect/decal/cleanable/vomit/mapped,
 /turf/floor/tiled/techfloor,
 /area/template_noop)
 "q" = (
@@ -242,7 +242,7 @@
 /obj/effect/spider/stickyweb,
 /obj/random/voidsuit,
 /obj/random/loot,
-/obj/effect/decal/cleanable/vomit,
+/obj/effect/decal/cleanable/vomit/mapped,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -29;
 	dir = 4

--- a/maps/tradeship/tradeship-1.dmm
+++ b/maps/tradeship/tradeship-1.dmm
@@ -3161,7 +3161,7 @@
 	dir = 1;
 	pixel_y = -21
 	},
-/obj/effect/decal/cleanable/vomit,
+/obj/effect/decal/cleanable/vomit/mapped,
 /obj/structure/hygiene/toilet{
 	dir = 1
 	},


### PR DESCRIPTION
## Description of changes
- Added mob-level general coating proc for shoes/feet coatings.
- Vomit and mud can coat shoes/feet and get tracked around like blood.
- Quadrupeds will get coatings on all four feet, not just back feet.

![image](https://github.com/user-attachments/assets/d820bbf3-54a2-46e7-a900-a610a4343425)
![image](https://github.com/user-attachments/assets/65cba844-8c8e-4b1d-b73c-e2e9f72f5119)

## Why and what will this PR improve
Janitor can yell at people for tracking mud/sick around.

## Authorship
Myself.

## Changelog
:cl:
tweak: Mud and blood can now leave footprints.
/:cl:
