### PR TITLE
Update Create & Destroy unit test

### DIFF
--- a/code/___compile_options.dm
+++ b/code/___compile_options.dm
@@ -1,7 +1,3 @@
-// The default value for all uses of set background. Set background can cause gradual lag and is recommended you only turn this on if necessary.
-// 1 will enable set background. 0 will disable set background.
-#define BACKGROUND_ENABLED 0
-
 // If REFTRACK_IN_CI is defined, the reftracker will run in CI.
 #define REFTRACK_IN_CI
 #if defined(REFTRACK_IN_CI) && defined(UNIT_TEST) && !defined(SPACEMAN_DMM)

--- a/code/__defines/qdel.dm
+++ b/code/__defines/qdel.dm
@@ -33,13 +33,13 @@
 #define QDESTROYING(X) (isnull(X) || X.gc_destroyed == GC_CURRENTLY_BEING_QDELETED)
 
 //Qdel helper macros.
-#define QDEL_IN(item, time) if(!isnull(item)) {addtimer(CALLBACK(item, TYPE_PROC_REF(/datum, qdel_self)), time, TIMER_STOPPABLE)}
-#define QDEL_IN_CLIENT_TIME(item, time) if(!isnull(item)) {addtimer(CALLBACK(item, TYPE_PROC_REF(/datum, qdel_self)), time, TIMER_STOPPABLE | TIMER_CLIENT_TIME)}
+#define QDEL_IN(item, time) if(!isnull(item)) {addtimer(CALLBACK(item, TYPE_PROC_REF(/datum, qdel_self)), time)}
+#define QDEL_IN_CLIENT_TIME(item, time) if(!isnull(item)) {addtimer(CALLBACK(item, TYPE_PROC_REF(/datum, qdel_self)), time, TIMER_CLIENT_TIME)}
 #define QDEL_NULL(item) if(item) {qdel(item); item = null}
 #define QDEL_NULL_SCREEN(item) if(client) { client.screen -= item; }; QDEL_NULL(item)
 #define QDEL_NULL_LIST(x) if(x) { for(var/y in x) { qdel(y) }}; if(x) {x.Cut(); x = null } // Second x check to handle items that LAZYREMOVE on qdel.
 #define QDEL_LIST(L) if(L) { for(var/I in L) qdel(I); L.Cut(); }
-#define QDEL_LIST_IN(L, time) addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(______qdel_list_wrapper), L), time, TIMER_STOPPABLE)
+#define QDEL_LIST_IN(L, time) addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(______qdel_list_wrapper), L), time)
 #define QDEL_LIST_ASSOC(L) if(L) { for(var/I in L) { qdel(L[I]); qdel(I); } L.Cut(); }
 #define QDEL_LIST_ASSOC_VAL(L) if(L) { for(var/I in L) qdel(L[I]); L.Cut(); }
 

--- a/code/__defines/qdel.dm
+++ b/code/__defines/qdel.dm
@@ -21,8 +21,12 @@
 #define GC_QUEUE_ITEM_GCD_DESTROYED 3 //! Item's gc_destroyed var value. Used to detect ref reuse.
 #define GC_QUEUE_ITEM_INDEX_COUNT 3 //! Number of item indexes, used for allocating the nested lists. Don't forget to increase this if you add a new queue item index
 
-#define GC_QUEUED_FOR_HARD_DEL -1
-#define GC_CURRENTLY_BEING_QDELETED -2
+// Defines for the time an item has to get its reference cleaned before it fails the queue and moves to the next.
+#define GC_FILTER_QUEUE (1 SECONDS)
+#define GC_CHECK_QUEUE (5 MINUTES)
+#define GC_DEL_QUEUE (10 SECONDS)
+
+#define GC_CURRENTLY_BEING_QDELETED -1
 
 #define QDELING(X) (X.gc_destroyed)
 #define QDELETED(X) (isnull(X) || QDELING(X))

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -195,3 +195,7 @@
 #define FONT_GIANT(X) "<font size='5'>[X]</font>"
 
 #define PRINT_STACK_TRACE(X) get_stack_trace(X, __FILE__, __LINE__)
+
+/// Checks if potential_weakref is a weakref of thing.
+/// NOTE: These argments are the opposite order of TG's, because I think TG's are counterintuitive.
+#define IS_WEAKREF_OF(potential_weakref, thing) (istype(thing, /datum) && !isnull(potential_weakref) && thing.weakref == potential_weakref)

--- a/code/game/images.dm
+++ b/code/game/images.dm
@@ -1,3 +1,0 @@
-/image/Destroy()
-	..()
-	return QDEL_HINT_HARDDEL

--- a/code/modules/mob/living/human/human.dm
+++ b/code/modules/mob/living/human/human.dm
@@ -346,7 +346,7 @@
 			return
 		var/decl/pronouns/pronouns = get_pronouns()
 		visible_message(SPAN_DANGER("\The [src] starts sticking a finger down [pronouns.his] own throat. It looks like [pronouns.he] [pronouns.is] trying to throw up!"))
-		if(!do_after(src, 30))
+		if(!do_after(src, 3 SECONDS))
 			return
 		timevomit = max(timevomit, 5)
 
@@ -355,13 +355,22 @@
 
 	lastpuke = TRUE
 	to_chat(src, SPAN_WARNING("You feel nauseous..."))
+	var/finish_time = 35 SECONDS
 	if(level > 1)
-		sleep(150 / timevomit)	//15 seconds until second warning
-		to_chat(src, SPAN_WARNING("You feel like you are about to throw up!"))
+		// 15 seconds until second warning
+		addtimer(CALLBACK(src, PROC_REF(vomit_second_warning_message)), 15 SECONDS / timevomit)
+		finish_time += 15 SECONDS / timevomit
 		if(level > 2)
-			sleep(100 / timevomit)	//and you have 10 more for mad dash to the bucket
-			empty_stomach()
-	sleep(350)	//wait 35 seconds before next volley
+			// and you have 10 more for mad dash to the bucket
+			// timer delay must include the time from the prior one also
+			addtimer(CALLBACK(src, PROC_REF(empty_stomach)), 25 SECONDS / timevomit)
+			finish_time += 10 SECONDS / timevomit
+	addtimer(CALLBACK(src, PROC_REF(reset_vomit_cooldown)), finish_time)
+
+/mob/living/human/proc/vomit_second_warning_message()
+	to_chat(src, SPAN_WARNING("You feel like you are about to throw up!"))
+
+/mob/living/human/proc/reset_vomit_cooldown()
 	lastpuke = FALSE
 
 /mob/living/human/proc/increase_germ_level(n)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -1,6 +1,5 @@
 /mob/living/Life()
 	set invisibility = FALSE
-	set background = BACKGROUND_ENABLED
 
 	..()
 

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -142,7 +142,7 @@
 /obj/item/food/Destroy()
 	QDEL_NULL(plate)
 	trash = null
-	if(contents)
+	if(length(contents))
 		for(var/atom/movable/something in contents)
 			something.dropInto(loc)
 	. = ..()

--- a/code/world.dm
+++ b/code/world.dm
@@ -12,6 +12,9 @@
 	hub = "Exadv1.spacestation13"
 	icon_size = WORLD_ICON_SIZE
 	fps = 20
-#ifdef GC_FAILURE_HARD_LOOKUP
+#ifdef FIND_REF_NO_CHECK_TICK
+#pragma push
+#pragma ignore loop_checks
 	loop_checks = FALSE
+#pragma pop
 #endif

--- a/mods/content/xenobiology/slime/_slime.dm
+++ b/mods/content/xenobiology/slime/_slime.dm
@@ -33,7 +33,6 @@
 	var/slime_type = /decl/slime_colour/grey
 	var/cores = 1 // the number of /obj/item/slime_extract's the slime has left inside
 	var/core_removal_stage = 0 //For removing cores.
-	var/datum/reagents/metabolism/ingested
 
 /mob/living/slime/Destroy()
 	set_feeding_on()
@@ -65,8 +64,7 @@
 
 	. = ..(mapload)
 
-	ingested = new /datum/reagents/metabolism(240, src, CHEM_TOUCH)
-	reagents = ingested
+	reagents = new /datum/reagents/metabolism(240, src, CHEM_TOUCH)
 	render_target = "slime_\ref[src]"
 
 	verbs += /mob/living/proc/ventcrawl

--- a/mods/content/xenobiology/slime/life.dm
+++ b/mods/content/xenobiology/slime/life.dm
@@ -46,6 +46,7 @@
 	. = ..()
 	if(feeding_on)
 		slime_feed()
+	var/datum/reagents/metabolism/ingested = reagents
 	ingested.metabolize()
 
 /mob/living/slime/fluid_act(datum/reagents/fluids)
@@ -86,6 +87,7 @@
 	. = ..()
 	if(feeding_on)
 		slime_feed()
+	var/datum/reagents/metabolism/ingested = reagents
 	ingested.metabolize()
 
 	// Digest whatever we've got floating around in our goop.

--- a/mods/content/xenobiology/slime/slime_commands.dm
+++ b/mods/content/xenobiology/slime/slime_commands.dm
@@ -20,15 +20,16 @@
 	triggers = list("follow")
 
 /decl/slime_command/follow/get_response(var/speaker, var/spoken, var/datum/mob_controller/slime/holder)
-	if(holder.leader)
-		if(holder.leader == speaker)
+	var/mob/leader_mob = holder.leader?.resolve()
+	if(leader_mob)
+		if(leader_mob == speaker)
 			return pick("Yes...", "Lead...", "Following...")
-		if(LAZYACCESS(holder.observed_friends, weakref(speaker)) > LAZYACCESS(holder.observed_friends, weakref(holder.leader)))
-			holder.leader = speaker
+		if(LAZYACCESS(holder.observed_friends, weakref(speaker)) > LAZYACCESS(holder.observed_friends, holder.leader))
+			holder.leader = weakref(speaker)
 			return "Yes... I follow [speaker]..."
-		return "No... I follow [holder.leader]..."
+		return "No... I follow [leader_mob]..."
 	if(LAZYACCESS(holder.observed_friends, weakref(speaker)) > 2)
-		holder.leader = speaker
+		holder.leader = weakref(speaker)
 		return "I follow..."
 	return pick("No...", "I won't follow...")
 
@@ -45,18 +46,20 @@
 				holder.adjust_friendship(speaker, -1)
 				return "Grrr..."
 			return "Fine..."
-	if(holder.current_target)
+	var/mob/actual_target = holder.current_target?.resolve()
+	if(actual_target)
 		if(friendship > 3)
 			holder.current_target = null
 			if(friendship < 6)
 				holder.adjust_friendship(speaker, -1)
 				return "Grrr..."
 			return "Fine..."
-	if(holder.leader)
-		if(holder.leader == speaker)
+	var/mob/leader_mob = holder.leader?.resolve()
+	if(leader_mob)
+		if(leader_mob == speaker)
 			holder.leader = null
 			return "Yes... I'll stop..."
-		if(friendship > LAZYACCESS(holder.observed_friends, weakref(holder.leader)))
+		if(friendship > LAZYACCESS(holder.observed_friends, holder.leader))
 			holder.leader = null
 			return "Yes... I'll stop..."
 		return "No... I'll keep following..."
@@ -66,11 +69,12 @@
 
 /decl/slime_command/stay/get_response(var/speaker, var/spoken, var/datum/mob_controller/slime/holder)
 	var/friendship = LAZYACCESS(holder.observed_friends, weakref(speaker))
-	if(holder.leader)
-		if(holder.leader == speaker)
+	var/mob/leader_mob = holder.leader?.resolve()
+	if(leader_mob)
+		if(leader_mob == speaker)
 			holder.holding_still = friendship * 10
 			return "Yes... Staying..."
-		var/leader_friendship = LAZYACCESS(holder.observed_friends, weakref(holder.leader))
+		var/leader_friendship = LAZYACCESS(holder.observed_friends, holder.leader)
 		if(friendship > leader_friendship)
 			holder.holding_still = (friendship - leader_friendship) * 10
 			return "Yes... Staying..."

--- a/mods/content/xenobiology/slime/slime_comments.dm
+++ b/mods/content/xenobiology/slime/slime_comments.dm
@@ -29,8 +29,9 @@
 		if(holder.slime.nutrition < holder.slime.get_starve_nutrition())
 			. += list("So... hungry...", "Very... hungry...", "Need... food...", "Must... eat...")
 			tension += 10
-		if(holder.current_target)
-			. += "\The [holder.current_target]... looks tasty..."
+		var/mob/actual_target = holder.current_target?.resolve()
+		if(actual_target)
+			. += "\The [actual_target]... looks tasty..."
 		if(length(.) && prob(tension))
 			return pick(.)
 

--- a/mods/content/xenobiology/slime/slime_reagents.dm
+++ b/mods/content/xenobiology/slime/slime_reagents.dm
@@ -14,22 +14,23 @@
 	metabolism = REM * 0.25
 	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 
-/decl/material/liquid/water/affect_touch(var/mob/living/M, var/removed, var/datum/reagents/holder)
+/decl/material/liquid/water/affect_touch(var/mob/living/victim, var/removed, var/datum/reagents/holder)
 	. = ..()
-	if(isslime(M))
-		M.take_damage(10 * removed, TOX)
-		var/mob/living/slime/S = M
-		if(istype(S) && istype(S.ai, /datum/mob_controller/slime))
-			var/datum/mob_controller/slime/slime_ai = S.ai
-			if(slime_ai.current_target)
+	if(isslime(victim))
+		victim.take_damage(10 * removed, TOX)
+		var/mob/living/slime/slime_victim = victim
+		if(istype(slime_victim) && istype(slime_victim.ai, /datum/mob_controller/slime))
+			var/datum/mob_controller/slime/slime_ai = slime_victim.ai
+			if(slime_ai.current_target) // don't bother resolving it, we're just clearing it
 				slime_ai.current_target = null
-			S.set_feeding_on()
-		if(LAZYACCESS(M.chem_doses, type) == removed)
-			M.visible_message( \
-				SPAN_DANGER("\The [S]'s flesh sizzles where \the [name] touches it!"), \
-				SPAN_DANGER("Your flesh is burned by \the [name]!"))
-			SET_STATUS_MAX(M, STAT_CONFUSE, 2)
-			var/datum/mob_controller/slime/slime_ai = M.ai
+			slime_victim.set_feeding_on()
+		if(LAZYACCESS(victim.chem_doses, type) == removed)
+			var/reagent_name = get_reagent_name(holder) // mostly to check masked name, but handles phase too
+			victim.visible_message( \
+				SPAN_DANGER("\The [slime_victim]'s flesh sizzles where \the [reagent_name] touches it!"), \
+				SPAN_DANGER("Your flesh is burned by \the [reagent_name]!"))
+			SET_STATUS_MAX(victim, STAT_CONFUSE, 2)
+			var/datum/mob_controller/slime/slime_ai = victim.ai
 			if(istype(slime_ai))
 				slime_ai.attacked = max(slime_ai.attacked, rand(7,10)) // angery
 

--- a/nebula.dme
+++ b/nebula.dme
@@ -10,6 +10,7 @@
 #define DEBUG
 // END_PREFERENCES
 // BEGIN_INCLUDE
+#include "code\___compile_options.dm"
 #include "code\___opendream_linting.dm"
 #include "code\__globals.dm"
 #include "code\_macros.dm"
@@ -20,7 +21,6 @@
 #include "code\__datastructures\stack.dm"
 #include "code\__defines\_byond_version_compat.dm"
 #include "code\__defines\_compile_helpers.dm"
-#include "code\__defines\_compile_options.dm"
 #include "code\__defines\_planes+layers.dm"
 #include "code\__defines\_tick.dm"
 #include "code\__defines\admin.dm"

--- a/nebula.dme
+++ b/nebula.dme
@@ -753,7 +753,6 @@
 #include "code\game\atoms_movable_overlay.dm"
 #include "code\game\atoms_temperature.dm"
 #include "code\game\base_turf.dm"
-#include "code\game\images.dm"
 #include "code\game\movietitles.dm"
 #include "code\game\response_team.dm"
 #include "code\game\sound.dm"

--- a/~code/global_init.dm
+++ b/~code/global_init.dm
@@ -11,15 +11,14 @@
 	Pre-map initialization stuff should go here.
 */
 
-var/global_init = new /datum/global_init()
+var/global/global_init = new /datum/global_init()
 
 /datum/global_init/New()
 	SSconfiguration.load_all_configuration()
 	generate_game_id()
 	makeDatumRefLists()
-	qdel(src) //we're done
+	QDEL_IN(src, 0) //we're done. give it some time to finish setting up though
 
 /datum/global_init/Destroy()
-	global_init = null
-	..()
-	return QDEL_HINT_HARDDEL
+	global.global_init = null
+	return ..()


### PR DESCRIPTION
## Description of changes
Fixes the inconsistency with false positives (and false negatives) in the Create & Destroy test by checking based on gc_destroyed rather than queue time.
Also checks all queues and removes code duplication that handled the queues separately.
Also removes some unnecessary harddel hints by making them harddel normally.
Increases the filter queue time to 1 second rather than 0 seconds.

## Why and what will this PR improve
should make gc tests more consistent?

## Authorship
Taken from latest TG. Lots of PRs included, I'm not going to link them all unless someone specifically asks :(