### PR TITLE
Tweaking flooring procs to allow for multiple flooring layers.

### DIFF
--- a/code/game/machinery/CableLayer.dm
+++ b/code/game/machinery/CableLayer.dm
@@ -87,7 +87,7 @@
 	if(istype(new_turf, /turf/floor))
 		var/turf/floor/T = new_turf
 		if(!T.is_plating())
-			T.set_flooring(null, place_product = !T.is_floor_damaged())
+			T.clear_flooring(place_product = !T.is_floor_damaged())
 	return new_turf.is_plating()
 
 /obj/machinery/cablelayer/proc/layCable(var/turf/new_turf,var/M_Dir)

--- a/code/game/machinery/floorlayer.dm
+++ b/code/game/machinery/floorlayer.dm
@@ -82,7 +82,7 @@
 	if(istype(new_turf, /turf/floor))
 		var/turf/floor/T = new_turf
 		if(!T.is_plating())
-			T.set_flooring(null, place_product = !T.is_floor_damaged())
+			T.clear_flooring(place_product = !T.is_floor_damaged())
 	return new_turf.is_plating()
 
 /obj/machinery/floorlayer/proc/TakeNewStack()

--- a/code/game/machinery/pipe/pipelayer.dm
+++ b/code/game/machinery/pipe/pipelayer.dm
@@ -111,7 +111,7 @@
 	if(istype(new_turf, /turf/floor))
 		var/turf/floor/T = new_turf
 		if(!T.is_plating())
-			T.set_flooring(null, place_product = !T.is_floor_damaged())
+			T.clear_flooring(place_product = !T.is_floor_damaged())
 	return new_turf.is_plating()
 
 /obj/machinery/pipelayer/proc/layPipe(var/turf/w_turf,var/M_Dir,var/old_dir)

--- a/code/game/turfs/flooring/_flooring.dm
+++ b/code/game/turfs/flooring/_flooring.dm
@@ -300,7 +300,7 @@ var/global/list/flooring_cache = list()
 		if(!user.do_skilled(remove_timer, SKILL_CONSTRUCTION, floor) || floor.get_topmost_flooring() != src)
 			return TRUE
 		to_chat(user, SPAN_NOTICE("You remove the [get_surface_descriptor()] with \the [item]."))
-		floor.set_flooring(null, place_product = TRUE)
+		floor.remove_flooring(floor.get_topmost_flooring(), place_product = TRUE)
 		playsound(floor, 'sound/items/Deconstruct.ogg', 80, 1)
 		return TRUE
 
@@ -313,21 +313,21 @@ var/global/list/flooring_cache = list()
 				if(floor.get_topmost_flooring() != src)
 					return
 				to_chat(user, SPAN_NOTICE("You remove the broken [get_surface_descriptor()]."))
-				floor.set_flooring(null)
+				floor.remove_flooring(floor.get_topmost_flooring())
 			else if(flooring_flags & TURF_IS_FRAGILE)
 				if(!user.do_skilled(remove_timer, SKILL_CONSTRUCTION, floor, 0.15))
 					return TRUE
 				if(floor.get_topmost_flooring() != src)
 					return
 				to_chat(user, SPAN_DANGER("You forcefully pry off the [get_surface_descriptor()], destroying them in the process."))
-				floor.set_flooring(null)
+				floor.remove_flooring(floor.get_topmost_flooring())
 			else if(flooring_flags & TURF_REMOVE_CROWBAR)
 				if(!user.do_skilled(remove_timer, SKILL_CONSTRUCTION, floor))
 					return TRUE
 				if(floor.get_topmost_flooring() != src)
 					return
 				to_chat(user, SPAN_NOTICE("You lever off the [get_surface_descriptor()]."))
-				floor.set_flooring(null, place_product = TRUE)
+				floor.remove_flooring(floor.get_topmost_flooring(), place_product = TRUE)
 			else
 				return
 			playsound(floor, 'sound/items/Crowbar.ogg', 80, 1)
@@ -339,7 +339,7 @@ var/global/list/flooring_cache = list()
 			if(!user.do_skilled(remove_timer, SKILL_CONSTRUCTION, floor) || floor.get_topmost_flooring() != src)
 				return TRUE
 			to_chat(user, SPAN_NOTICE("You unscrew and remove the [get_surface_descriptor()]."))
-			floor.set_flooring(null, place_product = TRUE)
+			floor.remove_flooring(floor.get_topmost_flooring(), place_product = TRUE)
 			playsound(floor, 'sound/items/Screwdriver.ogg', 80, 1)
 			return TRUE
 
@@ -347,7 +347,7 @@ var/global/list/flooring_cache = list()
 			if(!user.do_skilled(remove_timer, SKILL_CONSTRUCTION, floor) || floor.get_topmost_flooring() != src)
 				return TRUE
 			to_chat(user, SPAN_NOTICE("You unwrench and remove the [get_surface_descriptor()]."))
-			floor.set_flooring(null, place_product = TRUE)
+			floor.remove_flooring(floor.get_topmost_flooring(), place_product = TRUE)
 			playsound(floor, 'sound/items/Ratchet.ogg', 80, 1)
 			return TRUE
 

--- a/code/game/turfs/flooring/flooring_grass.dm
+++ b/code/game/turfs/flooring/flooring_grass.dm
@@ -17,12 +17,12 @@
 
 /decl/flooring/grass/fire_act(turf/floor/target, datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(target.get_topmost_flooring() == src && (exposed_temperature > T0C + 200 && prob(5)) || exposed_temperature > T0C + 1000)
-		target.set_flooring(null)
+		target.remove_flooring(target.get_topmost_flooring())
 		return TRUE
 	return ..()
 
 /decl/flooring/grass/handle_turf_digging(turf/floor/target)
-	target.set_flooring(null)
+	target.remove_flooring(target.get_topmost_flooring())
 	return FALSE
 
 /decl/flooring/grass/wild
@@ -42,7 +42,7 @@
 	if(IS_KNIFE(item) && harvestable && istype(floor_material) && floor_material.dug_drop_type)
 		if(item.do_tool_interaction(TOOL_KNIFE, user, floor, 3 SECONDS, start_message = "harvesting", success_message = "harvesting") && !QDELETED(floor) && floor.get_topmost_flooring() == src)
 			new floor_material.dug_drop_type(floor, rand(2,5))
-			floor.set_flooring(/decl/flooring/grass)
+			floor.remove_flooring(src)
 		return TRUE
 	return ..()
 

--- a/code/game/turfs/flooring/flooring_snow.dm
+++ b/code/game/turfs/flooring/flooring_snow.dm
@@ -26,7 +26,7 @@
 /decl/flooring/snow/fire_act(turf/floor/target, datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(!target.reagents?.total_volume)
 		if(target.get_topmost_flooring() == src)
-			target.set_flooring(/decl/flooring/permafrost)
+			target.remove_flooring(src)
 		else if(target.get_base_flooring() == src)
 			target.set_base_flooring(/decl/flooring/permafrost)
 		return

--- a/code/game/turfs/floors/floor_acts.dm
+++ b/code/game/turfs/floors/floor_acts.dm
@@ -42,7 +42,7 @@
 	if(!is_floor_burned() && prob(5))
 		burn_tile(exposed_temperature)
 	else if(temp_destroy && exposed_temperature >= (temp_destroy + 100) && prob(1) && has_flooring())
-		set_flooring(null) //destroy the tile, exposing plating
+		remove_flooring(get_topmost_flooring()) //destroy the tile, exposing plating
 		burn_tile(exposed_temperature)
 	return ..()
 

--- a/code/game/turfs/floors/floor_damage.dm
+++ b/code/game/turfs/floors/floor_damage.dm
@@ -1,6 +1,6 @@
 /turf/floor/proc/break_tile_to_plating()
 	if(has_flooring())
-		set_flooring(null)
+		clear_flooring()
 	break_tile()
 
 /turf/floor/proc/break_tile()

--- a/code/game/turfs/floors/floor_layers.dm
+++ b/code/game/turfs/floors/floor_layers.dm
@@ -1,0 +1,258 @@
+/turf/floor
+	VAR_PROTECTED/decl/flooring/_base_flooring = /decl/flooring/plating
+	VAR_PROTECTED/list/decl/flooring/_flooring
+	VAR_PRIVATE/decl/flooring/_topmost_flooring
+
+/turf/floor/proc/get_all_flooring()
+	. = list()
+	if(istype(_flooring))
+		. += _flooring
+	else if(ispath(_flooring))
+		. += GET_DECL(_flooring)
+	else if(islist(_flooring))
+		for(var/floor in _flooring)
+			if(ispath(floor))
+				_flooring += GET_DECL(floor)
+			else if(istype(floor, /decl/flooring))
+				_flooring += floor
+	if(_base_flooring)
+		. += get_base_flooring()
+
+/turf/floor/proc/has_flooring()
+	return !isnull(_flooring)
+
+/turf/floor/proc/set_base_flooring(new_base_flooring, skip_update)
+	if(ispath(new_base_flooring, /decl/flooring))
+		new_base_flooring = GET_DECL(new_base_flooring)
+	else if(!istype(new_base_flooring, /decl/flooring))
+		new_base_flooring = null
+	if(_base_flooring == new_base_flooring)
+		return
+	_base_flooring = new_base_flooring
+	if(!_base_flooring) // We can never have a null base flooring.
+		_base_flooring = GET_DECL(initial(_base_flooring)) || GET_DECL(/decl/flooring/plating)
+	update_from_flooring(skip_update)
+
+/turf/floor/proc/get_base_flooring()
+	RETURN_TYPE(/decl/flooring)
+	if(ispath(_base_flooring))
+		_base_flooring = GET_DECL(_base_flooring)
+	return _base_flooring
+
+/turf/floor/proc/get_topmost_flooring()
+	RETURN_TYPE(/decl/flooring)
+
+	if(isnull(_topmost_flooring))
+		var/flooring_length = length(_flooring)
+		if(isnull(_flooring))
+			_topmost_flooring = FALSE
+		else if(islist(_flooring) && flooring_length)
+			_topmost_flooring = _flooring[flooring_length]
+		else if(istype(_flooring, /decl/flooring))
+			_topmost_flooring = _flooring
+
+	if(istype(_topmost_flooring))
+		return _topmost_flooring
+	return get_base_flooring()
+
+/turf/floor/proc/clear_flooring(skip_update = FALSE, place_product)
+	if(isnull(_flooring))
+		return FALSE
+	if(islist(_flooring))
+		for(var/floor in _flooring)
+			remove_flooring(floor, TRUE, place_product)
+	else if(_flooring)
+		remove_flooring(_flooring, TRUE, place_product)
+	if(!skip_update)
+		update_from_flooring()
+	return TRUE
+
+/turf/floor/proc/remove_flooring(var/decl/flooring/flooring, skip_update, place_product)
+
+	// Remove floor layers one by one.
+	_topmost_flooring  = null
+	if(islist(flooring))
+		for(var/floor in UNLINT(flooring))
+			if(remove_flooring(floor, TRUE, place_product))
+				. = TRUE
+		if(. && !skip_update)
+			set_floor_broken(skip_update = TRUE)
+			set_floor_burned(skip_update = TRUE)
+			update_from_flooring()
+		return
+
+	// Validate our input.
+	if(ispath(flooring))
+		flooring = GET_DECL(flooring)
+	if(!istype(flooring))
+		return
+
+	// Remove this turf from the layer stack.
+	var/was_topmost = (flooring == get_topmost_flooring())
+	if(islist(_flooring))
+		LAZYREMOVE(_flooring, flooring)
+		if(LAZYLEN(_flooring) == 1)
+			_flooring = _flooring[1]
+	else if(_flooring == flooring)
+		_flooring = null
+
+	// If the turf was not the topmost turf, then we don't really need to care about it.
+	if(!was_topmost)
+		return
+
+	LAZYCLEARLIST(decals)
+	for(var/obj/effect/decal/writing/W in src)
+		qdel(W)
+
+	flooring.on_flooring_remove(src)
+
+	if(flooring.build_type && place_product)
+		// If build_type uses material stack, check for it
+		// Because material stack uses different arguments
+		// And we need to use build material to spawn stack
+		if(ispath(flooring.build_type, /obj/item/stack/material))
+			var/decl/material/M = GET_DECL(flooring.build_material)
+			if(!M)
+				CRASH("[src] at ([x], [y], [z]) cannot create stack because it has a bad build_material path: '[flooring.build_material]'")
+			M.create_object(src, flooring.build_cost, flooring.build_type)
+		else
+			var/obj/item/stack/tile/new_tile = new flooring.build_type(src)
+			if(flooring.can_paint && paint_color)
+				new_tile.paint_color = paint_color
+
+	if(flooring.has_environment_proc && is_processing)
+		STOP_PROCESSING(SSobj, src)
+
+	floor_icon_state_override = null
+
+	if(!skip_update)
+		set_floor_broken(skip_update = TRUE)
+		set_floor_burned(skip_update = TRUE)
+		update_from_flooring()
+
+/turf/floor/proc/set_flooring(var/decl/flooring/newflooring, skip_update, place_product)
+
+	_topmost_flooring = null
+
+	// Clear this here to get it out of the way.
+	floor_icon_state_override = null
+
+	// If _flooring is unset, we can shortcut a lot of these steps.
+	if(isnull(_flooring))
+
+		if(isnull(newflooring))
+			return FALSE
+
+		if(islist(newflooring))
+			_flooring = list()
+			for(var/floor in UNLINT(newflooring))
+				if(ispath(floor))
+					floor = GET_DECL(floor)
+				if(istype(floor, /decl/flooring))
+					_flooring += floor
+		else if(ispath(newflooring))
+			_flooring = GET_DECL(newflooring)
+		else if(istype(newflooring))
+			_flooring = newflooring
+		else
+			return FALSE
+
+		if(!skip_update)
+			update_from_flooring()
+		return TRUE
+
+
+	// If we already have a flooring state, we need to do some cleanup and housekeeping.
+	clear_flooring(skip_update = TRUE, place_product = place_product)
+	if(!isnull(newflooring))
+		add_flooring(newflooring, skip_update, place_product)
+	if(!skip_update)
+		update_from_flooring(skip_update)
+
+/turf/floor/proc/add_flooring(decl/flooring/newflooring, skip_update)
+
+	_topmost_flooring = null
+
+	// Add floor layers one by one.
+	if(islist(newflooring))
+		for(var/floor in UNLINT(newflooring))
+			if(add_flooring(floor, skip_update = FALSE))
+				. = TRUE
+		if(!skip_update)
+			set_floor_broken(skip_update = TRUE)
+			set_floor_burned(skip_update = TRUE)
+			update_from_flooring()
+		return
+
+	// We only want to work with references.
+	if(ispath(newflooring, /decl/flooring))
+		newflooring = GET_DECL(newflooring)
+	else if(!istype(newflooring, /decl/flooring))
+		return FALSE
+
+	// Check if the layer is already present.
+	if(_flooring)
+		if(islist(_flooring))
+			if(newflooring in _flooring)
+				return FALSE
+		else if(newflooring == _flooring)
+			return FALSE
+
+	// Add our layer to the top of layers.
+	if(isnull(_flooring))
+		_flooring = newflooring
+	else
+		if(!islist(_flooring))
+			_flooring = list(_flooring)
+		_flooring |= newflooring
+
+	// Update for the new top layer.
+	if(!skip_update)
+		set_floor_broken(skip_update = TRUE)
+		set_floor_burned(skip_update = TRUE)
+		update_from_flooring()
+
+	return TRUE
+
+/turf/floor/proc/update_from_flooring(skip_update)
+
+	_topmost_flooring = null
+
+	var/decl/flooring/copy_from = get_topmost_flooring()
+	if(!istype(copy_from))
+		return // this should never be the case
+
+	update_floor_strings()
+
+	gender     = copy_from.gender
+	layer      = copy_from.floor_layer
+	turf_flags = copy_from.turf_flags
+	z_flags    = copy_from.z_flags
+
+	if(copy_from.turf_light_range || copy_from.turf_light_power || copy_from.turf_light_color)
+		set_light(copy_from.turf_light_range, copy_from.turf_light_power, copy_from.turf_light_color)
+	else
+		set_light(0)
+
+	if(z_flags & ZM_MIMIC_BELOW)
+		enable_zmimic(z_flags)
+	else
+		disable_zmimic()
+
+	if(copy_from.has_environment_proc)
+		if(!is_processing)
+			START_PROCESSING(SSobj, src)
+	else if(is_processing)
+		STOP_PROCESSING(SSobj, src)
+
+	levelupdate()
+
+	for(var/obj/effect/footprints/print in src)
+		qdel(print)
+
+	if(!skip_update)
+		update_icon()
+		for(var/dir in global.alldirs)
+			var/turf/neighbor = get_step_resolving_mimic(src, dir)
+			if(istype(neighbor))
+				neighbor.update_icon()

--- a/code/game/turfs/floors/subtypes/floor_carpet.dm
+++ b/code/game/turfs/floors/subtypes/floor_carpet.dm
@@ -1,9 +1,8 @@
-
 /turf/floor/carpet
-	name = "brown carpet"
-	icon = 'icons/turf/flooring/carpet.dmi'
-	icon_state = "brown"
-	_flooring = /decl/flooring/carpet
+	name        = "brown carpet"
+	icon        = 'icons/turf/flooring/carpet.dmi'
+	icon_state  = "brown"
+	_flooring   = /decl/flooring/carpet
 
 /turf/floor/carpet/broken
 	_floor_broken = TRUE
@@ -15,49 +14,49 @@
 	set_floor_broken(setting_broken)
 
 /turf/floor/carpet/blue
-	name = "blue carpet"
-	icon_state = "blue1"
-	_flooring = /decl/flooring/carpet/blue
+	name        = "blue carpet"
+	icon_state  = "blue1"
+	_flooring   = /decl/flooring/carpet/blue
 
 /turf/floor/carpet/blue2
-	name = "pale blue carpet"
-	icon_state = "blue2"
-	_flooring = /decl/flooring/carpet/blue2
+	name        = "pale blue carpet"
+	icon_state  = "blue2"
+	_flooring   = /decl/flooring/carpet/blue2
 
 /turf/floor/carpet/blue3
-	name = "sea blue carpet"
-	icon_state = "blue3"
-	_flooring = /decl/flooring/carpet/blue3
+	name        = "sea blue carpet"
+	icon_state  = "blue3"
+	_flooring   = /decl/flooring/carpet/blue3
 
 /turf/floor/carpet/magenta
-	name = "magenta carpet"
-	icon_state = "magenta"
-	_flooring = /decl/flooring/carpet/magenta
+	name        = "magenta carpet"
+	icon_state  = "magenta"
+	_flooring   = /decl/flooring/carpet/magenta
 
 /turf/floor/carpet/purple
-	name = "purple carpet"
-	icon_state = "purple"
-	_flooring = /decl/flooring/carpet/purple
+	name        = "purple carpet"
+	icon_state  = "purple"
+	_flooring   = /decl/flooring/carpet/purple
 
 /turf/floor/carpet/orange
-	name = "orange carpet"
-	icon_state = "orange"
-	_flooring = /decl/flooring/carpet/orange
+	name        = "orange carpet"
+	icon_state  = "orange"
+	_flooring   = /decl/flooring/carpet/orange
 
 /turf/floor/carpet/green
-	name = "green carpet"
-	icon_state = "green"
-	_flooring = /decl/flooring/carpet/green
+	name        = "green carpet"
+	icon_state  = "green"
+	_flooring   = /decl/flooring/carpet/green
 
 /turf/floor/carpet/red
-	name = "red carpet"
-	icon_state = "red"
-	_flooring = /decl/flooring/carpet/red
+	name        = "red carpet"
+	icon_state  = "red"
+	_flooring   = /decl/flooring/carpet/red
 
 /turf/floor/carpet/rustic
-	name = "rustic carpet"
-	icon = 'icons/turf/flooring/simple_carpet.dmi'
-	icon_state = "carpet"
-	_flooring = /decl/flooring/carpet/rustic
+	name        = "rustic carpet"
+	icon        = 'icons/turf/flooring/simple_carpet.dmi'
+	icon_state  = "carpet"
+	_flooring   = /decl/flooring/carpet/rustic
 	paint_color = COLOR_CHESTNUT
-	color = COLOR_CHESTNUT
+	color       = COLOR_CHESTNUT

--- a/code/game/turfs/floors/subtypes/floor_circuit.dm
+++ b/code/game/turfs/floors/subtypes/floor_circuit.dm
@@ -1,26 +1,26 @@
 /turf/floor/bluegrid
-	name = "mainframe floor"
-	icon = 'icons/turf/flooring/circuit.dmi'
-	icon_state = "bcircuit"
-	_flooring = /decl/flooring/reinforced/circuit
+	name        = "mainframe floor"
+	icon        = 'icons/turf/flooring/circuit.dmi'
+	icon_state  = "bcircuit"
+	_flooring   = /decl/flooring/reinforced/circuit
 
 /turf/floor/bluegrid/airless
-	name = "airless floor"
+	name        = "airless floor"
 	initial_gas = null
 	temperature = TCMB
 
 /turf/floor/bluegrid/mainframe
-	name = "mainframe base" // TODO: force name overriding flooring?
+	name        = "mainframe base" // TODO: force name overriding flooring?
 	temperature = 263
 
 /turf/floor/greengrid
-	name = "mainframe floor"
-	icon = 'icons/turf/flooring/circuit.dmi'
-	icon_state = "gcircuit"
-	_flooring = /decl/flooring/reinforced/circuit/green
+	name        = "mainframe floor"
+	icon        = 'icons/turf/flooring/circuit.dmi'
+	icon_state  = "gcircuit"
+	_flooring   = /decl/flooring/reinforced/circuit/green
 
 /turf/floor/greengrid/airless
-	name = "airless floor"
+	name        = "airless floor"
 	initial_gas = null
 	temperature = TCMB
 
@@ -28,7 +28,7 @@
 	initial_gas = list(/decl/material/gas/nitrogen = MOLES_N2STANDARD)
 
 /turf/floor/blackgrid
-	name = "mainframe floor"
-	icon = 'icons/turf/flooring/circuit.dmi'
-	icon_state = "rcircuit"
-	_flooring = /decl/flooring/reinforced/circuit/red
+	name        = "mainframe floor"
+	icon        = 'icons/turf/flooring/circuit.dmi'
+	icon_state  = "rcircuit"
+	_flooring   = /decl/flooring/reinforced/circuit/red

--- a/code/game/turfs/floors/subtypes/floor_concrete.dm
+++ b/code/game/turfs/floors/subtypes/floor_concrete.dm
@@ -7,23 +7,23 @@
 	floor_material = /decl/material/solid/stone/concrete
 
 /turf/floor/concrete/smooth
-	icon_state = "concrete"
+	icon_state     = "concrete"
 
 /turf/floor/concrete/flooded
-	flooded = /decl/material/liquid/water
-	color = COLOR_LIQUID_WATER
+	flooded        = /decl/material/liquid/water
+	color          = COLOR_LIQUID_WATER
 
 /turf/floor/concrete/reinforced
-	name = "reinforced concrete"
-	icon_state = "hexacrete"
-	_flooring = /decl/flooring/concrete/reinforced
+	name           = "reinforced concrete"
+	icon_state     = "hexacrete"
+	_flooring      = /decl/flooring/concrete/reinforced
 
 /turf/floor/concrete/reinforced/damaged/LateInitialize()
 	. = ..()
 	set_floor_broken(TRUE)
 
 /turf/floor/concrete/reinforced/road
-	name = "asphalt"
-	color = COLOR_GRAY40
-	icon_state = "concrete"
-	_flooring = /decl/flooring/concrete/asphalt
+	name           = "asphalt"
+	color          = COLOR_GRAY40
+	icon_state     = "concrete"
+	_flooring      = /decl/flooring/concrete/asphalt

--- a/code/game/turfs/floors/subtypes/floor_misc.dm
+++ b/code/game/turfs/floors/subtypes/floor_misc.dm
@@ -1,54 +1,54 @@
 /turf/floor/lino
-	name = "lino"
-	icon = 'icons/turf/flooring/linoleum.dmi'
-	icon_state = "lino"
-	_flooring = /decl/flooring/linoleum
+	name           = "lino"
+	icon           = 'icons/turf/flooring/linoleum.dmi'
+	icon_state     = "lino"
+	_flooring      = /decl/flooring/linoleum
 
 
 /turf/floor/crystal
-	name = "crystal floor"
-	icon = 'icons/turf/flooring/crystal.dmi'
-	icon_state = "crystal"
-	_flooring = /decl/flooring/crystal
+	name           = "crystal floor"
+	icon           = 'icons/turf/flooring/crystal.dmi'
+	icon_state     = "crystal"
+	_flooring      = /decl/flooring/crystal
 
 /turf/floor/glass
-	name = "glass floor"
-	icon = 'icons/turf/flooring/glass.dmi'
-	icon_state = "glass"
-	_flooring = /decl/flooring/glass
+	name           = "glass floor"
+	icon           = 'icons/turf/flooring/glass.dmi'
+	icon_state     = "glass"
+	_flooring      = /decl/flooring/glass
 
 /turf/floor/glass/boro
-	_flooring = /decl/flooring/glass/boro
+	_flooring      = /decl/flooring/glass/boro
 
 /turf/floor/pool
-	name = "pool floor"
-	icon = 'icons/turf/flooring/pool.dmi'
-	icon_state = "pool"
-	height = -(FLUID_OVER_MOB_HEAD) - 50
-	_flooring = /decl/flooring/pool
+	name           = "pool floor"
+	icon           = 'icons/turf/flooring/pool.dmi'
+	icon_state     = "pool"
+	height         = -(FLUID_OVER_MOB_HEAD) - 50
+	_flooring      = /decl/flooring/pool
 
 /turf/floor/pool/deep
-	height = -FLUID_DEEP - 50
+	height         = -FLUID_DEEP - 50
 
 /turf/floor/fake_grass
-	name = "grass patch"
-	icon = 'icons/turf/flooring/fakegrass.dmi'
-	icon_state = "grass0"
-	_flooring = /decl/flooring/grass/fake
+	name           = "grass patch"
+	icon           = 'icons/turf/flooring/fakegrass.dmi'
+	icon_state     = "grass0"
+	_flooring      = /decl/flooring/grass/fake
 
 /turf/floor/woven
-	name = "floor"
-	icon = 'icons/turf/flooring/woven.dmi'
-	icon_state = "woven"
-	color = COLOR_BEIGE
-	_flooring = /decl/flooring/woven
+	name           = "floor"
+	icon           = 'icons/turf/flooring/woven.dmi'
+	icon_state     = "woven"
+	color          = COLOR_BEIGE
+	_flooring      = /decl/flooring/woven
 
 /turf/floor/straw
-	name = "loose straw"
-	icon = 'icons/turf/flooring/straw.dmi'
-	icon_state = "straw"
-	color = COLOR_WHEAT
-	_flooring = /decl/flooring/straw
+	name           = "loose straw"
+	icon           = 'icons/turf/flooring/straw.dmi'
+	icon_state     = "straw"
+	color          = COLOR_WHEAT
+	_flooring      = /decl/flooring/straw
 
 // Defining this here as a dummy mapping shorthand so mappers can search for 'plating'.
 /turf/floor/plating
@@ -63,7 +63,7 @@
 	_flooring = /decl/flooring/dirt
 
 /turf/floor/plating/broken
-	_floor_broken = TRUE
+	_floor_broken  = TRUE
 
 /turf/floor/plating/broken/Initialize(ml, floortype)
 	. = ..()
@@ -72,12 +72,12 @@
 	set_floor_broken(setting_broken)
 
 /turf/floor/plating/airless
-	name = "airless plating"
-	initial_gas = null
-	temperature = TCMB
+	name           = "airless plating"
+	initial_gas    = null
+	temperature    = TCMB
 
 /turf/floor/plating/airless/broken
-	_floor_broken = TRUE
+	_floor_broken  = TRUE
 
 /turf/floor/plating/airless/broken/Initialize(ml, floortype)
 	. = ..()
@@ -86,13 +86,13 @@
 	set_floor_broken(setting_broken)
 
 /turf/floor/plating/broken/one
-	_floor_broken = "broken1"
+	_floor_broken  = "broken1"
 
 /turf/floor/plating/broken/two
-	_floor_broken = "broken2"
+	_floor_broken  = "broken2"
 
 /turf/floor/plating/broken/three
-	_floor_broken = "broken3"
+	_floor_broken  = "broken3"
 
 /turf/floor/plating/broken/four
-	_floor_broken = "broken4"
+	_floor_broken  = "broken4"

--- a/code/game/turfs/floors/subtypes/floor_natural.dm
+++ b/code/game/turfs/floors/subtypes/floor_natural.dm
@@ -1,104 +1,116 @@
 /turf/floor/barren
-	name = "ground"
-	icon = 'icons/turf/flooring/barren.dmi'
-	icon_state = "barren"
-	_base_flooring = /decl/flooring/barren
+	name              = "ground"
+	icon              = 'icons/turf/flooring/barren.dmi'
+	icon_state        = "barren"
+	_base_flooring    = /decl/flooring/barren
 
 /turf/floor/dirt
-	name = "dirt"
-	icon = 'icons/turf/flooring/dirt.dmi'
-	icon_state = "dirt"
-	color = /decl/material/solid/soil::color // preview color
-	_base_flooring = /decl/flooring/dirt
+	name              = "dirt"
+	icon              = 'icons/turf/flooring/dirt.dmi'
+	icon_state        = "dirt"
+	color             = /decl/material/solid/soil::color // preview color
+	_base_flooring    = /decl/flooring/dirt
 
 /turf/floor/chlorine_sand
-	name = "chlorinated sand"
-	icon = 'icons/turf/flooring/chlorine_sand.dmi'
-	icon_state = "chlorine0"
-	_base_flooring = /decl/flooring/sand/chlorine
+	name              = "chlorinated sand"
+	icon              = 'icons/turf/flooring/chlorine_sand.dmi'
+	icon_state        = "chlorine0"
+	_base_flooring    = /decl/flooring/sand/chlorine
 
 /turf/floor/chlorine_sand/marsh
-	name = "chlorine marsh"
+	name              = "chlorine marsh"
+	_base_flooring    = /decl/flooring/sand/chlorine/marsh
+	height            = -(FLUID_SHALLOW)
 	fill_reagent_type = /decl/material/gas/chlorine
-	_base_flooring = /decl/flooring/sand/chlorine/marsh
-	height = -(FLUID_SHALLOW)
 
 /turf/floor/lava
-	name = "lava"
-	icon = 'icons/turf/flooring/lava.dmi'
-	icon_state = "lava"
-	_base_flooring = /decl/flooring/lava
+	name              = "lava"
+	icon              = 'icons/turf/flooring/lava.dmi'
+	icon_state        = "lava"
+	_base_flooring    = /decl/flooring/lava
 
 /turf/floor/grass
-	name = "grass"
-	icon = 'icons/turf/flooring/grass.dmi'
-	icon_state = "grass0"
-	color = "#5e7a3b"
-	_flooring = /decl/flooring/grass
-	_base_flooring = /decl/flooring/dirt
+	name              = "grass"
+	icon              = 'icons/turf/flooring/grass.dmi'
+	icon_state        = "grass0"
+	color             = "#5e7a3b"
+	_flooring         = /decl/flooring/grass
+	_base_flooring    = /decl/flooring/dirt
+
+/turf/floor/grass/snow
+	name              = "snow"
+	icon              = 'icons/turf/flooring/snow.dmi'
+	icon_state        = "snow0"
+	_flooring         = list(
+		/decl/flooring/grass,
+		/decl/flooring/snow
+	)
 
 /turf/floor/grass/wild
-	name = "wild grass"
-	icon = 'icons/turf/flooring/wildgrass.dmi'
-	icon_state = "wildgrass"
-	_flooring = /decl/flooring/grass/wild
-	_base_flooring = /decl/flooring/dirt
+	name              = "wild grass"
+	icon              = 'icons/turf/flooring/wildgrass.dmi'
+	icon_state        = "wildgrass"
+	_flooring         = list(
+		/decl/flooring/grass,
+		/decl/flooring/grass/wild
+	)
+	_base_flooring    = /decl/flooring/dirt
 
 /turf/floor/ice
-	name = "ice"
-	icon = 'icons/turf/flooring/ice.dmi'
-	icon_state = "ice"
-	color = COLOR_LIQUID_WATER
-	_flooring = /decl/flooring/ice
-	_base_flooring = /decl/flooring/dirt
+	name              = "ice"
+	icon              = 'icons/turf/flooring/ice.dmi'
+	icon_state        = "ice"
+	color             = COLOR_LIQUID_WATER
+	_flooring         = /decl/flooring/ice
+	_base_flooring    = /decl/flooring/dirt
 
 /turf/floor/snow
-	name = "snow"
-	icon = 'icons/turf/flooring/snow.dmi'
-	icon_state = "snow0"
-	_flooring = /decl/flooring/snow
-	_base_flooring = /decl/flooring/dirt
+	name              = "snow"
+	icon              = 'icons/turf/flooring/snow.dmi'
+	icon_state        = "snow0"
+	_flooring         = /decl/flooring/snow
+	_base_flooring    = /decl/flooring/dirt
 
 /turf/floor/clay
-	name = "clay"
-	icon = 'icons/turf/flooring/clay.dmi'
-	icon_state = "clay"
-	_base_flooring = /decl/flooring/clay
+	name              = "clay"
+	icon              = 'icons/turf/flooring/clay.dmi'
+	icon_state        = "clay"
+	_base_flooring    = /decl/flooring/clay
 
 /turf/floor/clay/flooded
-	flooded = /decl/material/liquid/water
+	flooded           = /decl/material/liquid/water
 
 /turf/floor/mud
-	name = "mud"
-	icon = 'icons/turf/flooring/mud.dmi'
-	icon_state = "mud"
-	color = /decl/material/solid/soil::color // preview color
-	_base_flooring = /decl/flooring/mud
+	name              = "mud"
+	icon              = 'icons/turf/flooring/mud.dmi'
+	icon_state        = "mud"
+	color             = /decl/material/solid/soil::color // preview color
+	_base_flooring    = /decl/flooring/mud
 
 /turf/floor/mud/water
-	color = COLOR_SKY_BLUE
+	color             = COLOR_SKY_BLUE
+	height            = -(FLUID_SHALLOW)
 	fill_reagent_type = /decl/material/liquid/water
-	height = -(FLUID_SHALLOW)
 
 /turf/floor/mud/water/deep
-	color = COLOR_BLUE
-	height = -(FLUID_DEEP)
+	color             = COLOR_BLUE
+	height            = -(FLUID_DEEP)
 
 /turf/floor/mud/flooded
-	flooded = /decl/material/liquid/water
+	flooded           = /decl/material/liquid/water
 
 /turf/floor/dry
-	name = "dry mud"
-	icon = 'icons/turf/flooring/seafloor.dmi'
-	icon_state = "seafloor"
-	_base_flooring = /decl/flooring/dry_mud
+	name              = "dry mud"
+	icon              = 'icons/turf/flooring/seafloor.dmi'
+	icon_state        = "seafloor"
+	_base_flooring    = /decl/flooring/dry_mud
 
 /turf/floor/rock/sand
-	name = "sand"
-	icon = 'icons/turf/flooring/sand.dmi'
-	icon_state = "sand0"
-	color = "#ae9e66"
-	_flooring = /decl/flooring/sand
+	name              = "sand"
+	icon              = 'icons/turf/flooring/sand.dmi'
+	icon_state        = "sand0"
+	color             = "#ae9e66"
+	_flooring         = /decl/flooring/sand
 
 /turf/floor/rock/basalt/sand
 	name = "sand"
@@ -108,30 +120,30 @@
 	_flooring = /decl/flooring/sand
 
 /turf/floor/rock/sand/water
-	color = COLOR_SKY_BLUE
+	color             = COLOR_SKY_BLUE
+	height            = -(FLUID_SHALLOW)
 	fill_reagent_type = /decl/material/liquid/water
-	height = -(FLUID_SHALLOW)
 
 /turf/floor/rock/sand/water/deep
-	color = COLOR_BLUE
-	height = -(FLUID_DEEP)
+	color             = COLOR_BLUE
+	height            = -(FLUID_DEEP)
 
 /turf/floor/seafloor
-	name = "sea floor"
-	icon = 'icons/turf/flooring/seafloor.dmi'
-	icon_state = "seafloor"
-	_base_flooring = /decl/flooring/seafloor
+	name              = "sea floor"
+	icon              = 'icons/turf/flooring/seafloor.dmi'
+	icon_state        = "seafloor"
+	_base_flooring    = /decl/flooring/seafloor
 
 /turf/floor/seafloor/flooded
-	flooded = /decl/material/liquid/water
-	color = COLOR_LIQUID_WATER
+	flooded           = /decl/material/liquid/water
+	color             = COLOR_LIQUID_WATER
 
 /turf/floor/shrouded
-	name = "packed sand"
-	icon = 'icons/turf/flooring/shrouded.dmi'
-	icon_state = "shrouded0"
-	_base_flooring = /decl/flooring/shrouded
+	name              = "packed sand"
+	icon              = 'icons/turf/flooring/shrouded.dmi'
+	icon_state        = "shrouded0"
+	_base_flooring    = /decl/flooring/shrouded
 
 /turf/floor/shrouded/tar
-	height = -(FLUID_SHALLOW)
+	height            = -(FLUID_SHALLOW)
 	fill_reagent_type = /decl/material/liquid/tar

--- a/code/game/turfs/floors/subtypes/floor_path.dm
+++ b/code/game/turfs/floors/subtypes/floor_path.dm
@@ -1,14 +1,14 @@
 
 /turf/floor/path
-	name           = "path"
-	gender         = NEUTER
-	desc           = "A cobbled path made of loose stones."
-	color          = COLOR_GRAY
-	icon           = 'icons/turf/flooring/path.dmi'
-	icon_state     = "cobble"
-	_flooring      = /decl/flooring/path/cobblestone
-	floor_material = /decl/material/solid/stone/sandstone
-	_base_flooring = /decl/flooring/dirt
+	name            = "path"
+	gender          = NEUTER
+	desc            = "A cobbled path made of loose stones."
+	color           = COLOR_GRAY
+	icon            = 'icons/turf/flooring/path.dmi'
+	icon_state      = "cobble"
+	_flooring       = /decl/flooring/path/cobblestone
+	floor_material  = /decl/material/solid/stone/sandstone
+	_base_flooring  = /decl/flooring/dirt
 
 /turf/floor/path/Initialize(mapload, no_update_icon)
 	. = ..()
@@ -28,12 +28,12 @@
 		LAZYADD(decals, moss)
 
 /turf/floor/path/running_bond
-	icon_state = "runningbond"
-	_flooring = /decl/flooring/path/running_bond
+	icon_state      = "runningbond"
+	_flooring       = /decl/flooring/path/running_bond
 
 /turf/floor/path/herringbone
-	icon_state = "herringbone"
-	_flooring = /decl/flooring/path/herringbone
+	icon_state      = "herringbone"
+	_flooring       = /decl/flooring/path/herringbone
 
 // Material subtypes.
 #define PATH_MATERIAL_SUBTYPES(material_name) \

--- a/code/game/turfs/floors/subtypes/floor_reinforced.dm
+++ b/code/game/turfs/floors/subtypes/floor_reinforced.dm
@@ -1,14 +1,17 @@
 /turf/floor/reinforced
-	name = "reinforced floor"
-	icon = 'icons/turf/flooring/tiles.dmi'
-	icon_state = "reinforced"
-	_flooring = /decl/flooring/reinforced
+	name        = "reinforced floor"
+	icon        = 'icons/turf/flooring/tiles.dmi'
+	icon_state  = "reinforced"
+	_flooring   = /decl/flooring/reinforced
 
 /turf/floor/reinforced/airless
 	initial_gas = null
 
 /turf/floor/reinforced/airmix
-	initial_gas = list(/decl/material/gas/oxygen = MOLES_O2ATMOS, /decl/material/gas/nitrogen = MOLES_N2ATMOS)
+	initial_gas = list(
+		/decl/material/gas/oxygen = MOLES_O2ATMOS,
+		/decl/material/gas/nitrogen = MOLES_N2ATMOS
+	)
 
 /turf/floor/reinforced/nitrogen
 	initial_gas = list(/decl/material/gas/nitrogen = ATMOSTANK_NITROGEN)
@@ -20,7 +23,7 @@
 	initial_gas = list(/decl/material/gas/oxygen = ATMOSTANK_OXYGEN)
 
 /turf/floor/reinforced/nitrogen/engine
-	name = "engine floor"
+	name        = "engine floor"
 	initial_gas = list(/decl/material/gas/nitrogen = MOLES_N2STANDARD)
 
 /turf/floor/reinforced/hydrogen/fuel
@@ -33,6 +36,6 @@
 	initial_gas = list(/decl/material/gas/nitrous_oxide = ATMOSTANK_NITROUSOXIDE)
 
 /turf/floor/reinforced/airless
-	name = "vacuum floor"
+	name        = "vacuum floor"
 	initial_gas = null
 	temperature = TCMB

--- a/code/game/turfs/floors/subtypes/floor_shuttle.dm
+++ b/code/game/turfs/floors/subtypes/floor_shuttle.dm
@@ -1,33 +1,33 @@
 /turf/floor/shuttle
-	name = "shuttle floor"
-	icon = 'icons/turf/flooring/shuttle.dmi'
-	desc = "A synthetic floor plate commonly seen in shuttles and other vehicles."
-	_flooring = /decl/flooring/reinforced/shuttle
+	name       = "shuttle floor"
+	icon       = 'icons/turf/flooring/shuttle.dmi'
+	desc       = "A synthetic floor plate commonly seen in shuttles and other vehicles."
+	_flooring  = /decl/flooring/reinforced/shuttle
 
 /turf/floor/shuttle/blue
 	icon_state = "floor"
-	_flooring = /decl/flooring/reinforced/shuttle/blue
+	_flooring  = /decl/flooring/reinforced/shuttle/blue
 
 /turf/floor/shuttle/yellow
 	icon_state = "floor2"
-	_flooring = /decl/flooring/reinforced/shuttle/yellow
+	_flooring  = /decl/flooring/reinforced/shuttle/yellow
 
 /turf/floor/shuttle/white
 	icon_state = "floor3"
-	_flooring = /decl/flooring/reinforced/shuttle/white
+	_flooring  = /decl/flooring/reinforced/shuttle/white
 
 /turf/floor/shuttle/red
 	icon_state = "floor4"
-	_flooring = /decl/flooring/reinforced/shuttle/red
+	_flooring  = /decl/flooring/reinforced/shuttle/red
 
 /turf/floor/shuttle/purple
 	icon_state = "floor5"
-	_flooring = /decl/flooring/reinforced/shuttle/purple
+	_flooring  = /decl/flooring/reinforced/shuttle/purple
 
 /turf/floor/shuttle/darkred
 	icon_state = "floor6"
-	_flooring = /decl/flooring/reinforced/shuttle/darkred
+	_flooring  = /decl/flooring/reinforced/shuttle/darkred
 
 /turf/floor/shuttle/black
 	icon_state = "floor7"
-	_flooring = /decl/flooring/reinforced/shuttle/black
+	_flooring  = /decl/flooring/reinforced/shuttle/black

--- a/code/game/turfs/floors/subtypes/floor_static.dm
+++ b/code/game/turfs/floors/subtypes/floor_static.dm
@@ -2,12 +2,12 @@
 // Use this to bypass the flooring system entirely ie. event areas, holodeck, etc.
 
 /turf/floor/fixed
-	name = "floor"
-	icon = 'icons/turf/flooring/tiles.dmi'
-	icon_state = "steel"
-	_flooring = null
+	name          = "floor"
+	icon          = 'icons/turf/flooring/tiles.dmi'
+	icon_state    = "steel"
+	_flooring     = null
 	footstep_type = /decl/footsteps/plating
-	is_outside = OUTSIDE_AREA
+	is_outside    = OUTSIDE_AREA
 
 /turf/floor/fixed/attackby(var/obj/item/C, var/mob/user)
 	if(istype(C, /obj/item/stack) && !IS_COIL(C))
@@ -24,10 +24,10 @@
 	return
 
 /turf/floor/fixed/alium
-	name = "alien plating"
-	desc = "This obviously wasn't made for your feet."
-	icon = 'icons/turf/flooring/alium.dmi'
-	icon_state = "jaggy"
+	name          = "alien plating"
+	desc          = "This obviously wasn't made for your feet."
+	icon          = 'icons/turf/flooring/alium.dmi'
+	icon_state    = "jaggy"
 
 /turf/floor/fixed/alium/attackby(var/obj/item/C, var/mob/user)
 	if(IS_CROWBAR(C))
@@ -45,8 +45,8 @@
 	icon_state = "[style][(x*y) % 7]"
 
 /turf/floor/fixed/alium/airless
-	initial_gas = null
-	temperature = TCMB
+	initial_gas   = null
+	temperature   = TCMB
 
 /turf/floor/fixed/alium/explosion_act(severity)
 	SHOULD_CALL_PARENT(FALSE)

--- a/code/game/turfs/floors/subtypes/floor_tiled.dm
+++ b/code/game/turfs/floors/subtypes/floor_tiled.dm
@@ -1,117 +1,117 @@
 //Tiled floor + sub-types
 /turf/floor/tiled
-	name = "floor"
-	icon = 'icons/turf/flooring/tiles.dmi'
-	icon_state = "tiled"
-	_flooring = /decl/flooring/tiling
+	name          = "floor"
+	icon          = 'icons/turf/flooring/tiles.dmi'
+	icon_state    = "tiled"
+	_flooring     = /decl/flooring/tiling
 
 /turf/floor/tiled/dark
-	name = "dark floor"
-	icon_state = "dark"
-	_flooring = /decl/flooring/tiling/dark
+	name          = "dark floor"
+	icon_state    = "dark"
+	_flooring     = /decl/flooring/tiling/dark
 
 /turf/floor/tiled/dark/monotile
-	name = "floor"
-	icon_state = "monotiledark"
-	_flooring = /decl/flooring/tiling/mono/dark
+	name          = "floor"
+	icon_state    = "monotiledark"
+	_flooring     = /decl/flooring/tiling/mono/dark
 
 /turf/floor/tiled/dark/monotile/telecomms
-	name = "telecomms dark floor" // TODO: force name overriding flooring?
-	temperature = 263
+	name          = "telecomms dark floor" // TODO: force name overriding flooring?
+	temperature   = 263
 
 /turf/floor/tiled/dark/airless
-	initial_gas = null
+	initial_gas   = null
 
 /turf/floor/tiled/white
-	name = "white floor"
-	icon_state = "white"
-	_flooring = /decl/flooring/tiling/white
+	name          = "white floor"
+	icon_state    = "white"
+	_flooring     = /decl/flooring/tiling/white
 
 /turf/floor/tiled/white/monotile
-	name = "floor"
-	icon_state = "monotile"
-	_flooring = /decl/flooring/tiling/mono/white
+	name          = "floor"
+	icon_state    = "monotile"
+	_flooring     = /decl/flooring/tiling/mono/white
 
 /turf/floor/tiled/monofloor
-	name = "floor"
-	icon_state = "steel_monofloor"
-	_flooring = /decl/flooring/tiling/mono
+	name          = "floor"
+	icon_state    = "steel_monofloor"
+	_flooring     = /decl/flooring/tiling/mono
 
 /turf/floor/tiled/white/airless
-	name = "airless floor"
-	initial_gas = null
-	temperature = TCMB
+	name          = "airless floor"
+	initial_gas   = null
+	temperature   = TCMB
 
 /turf/floor/tiled/freezer
-	name = "tiles"
-	icon_state = "freezer"
-	_flooring = /decl/flooring/tiling/freezer
+	name          = "tiles"
+	icon_state    = "freezer"
+	_flooring     = /decl/flooring/tiling/freezer
 
 /turf/floor/tiled/freezer/kitchen
-	name = "kitchen freezer floor" // TODO: force override of flooring name
-	temperature = 263
+	name          = "kitchen freezer floor" // TODO: force override of flooring name
+	temperature   = 263
 
 /turf/floor/tiled/techmaint
-	name = "floor"
-	icon = 'icons/turf/flooring/tiles.dmi'
-	icon_state = "techmaint"
-	_flooring = /decl/flooring/tiling/new_tile/techmaint
+	name          = "floor"
+	icon          = 'icons/turf/flooring/tiles.dmi'
+	icon_state    = "techmaint"
+	_flooring     = /decl/flooring/tiling/new_tile/techmaint
 
 /turf/floor/tiled/monofloor
-	name = "floor"
-	icon_state = "steel_monofloor"
-	_flooring = /decl/flooring/tiling/new_tile/monofloor
+	name          = "floor"
+	icon_state    = "steel_monofloor"
+	_flooring     = /decl/flooring/tiling/new_tile/monofloor
 
 /turf/floor/tiled/techfloor
-	name = "floor"
-	icon = 'icons/turf/flooring/techfloor.dmi'
-	icon_state = "techfloor_gray"
-	_flooring = /decl/flooring/tiling/tech
+	name          = "floor"
+	icon          = 'icons/turf/flooring/techfloor.dmi'
+	icon_state    = "techfloor_gray"
+	_flooring     = /decl/flooring/tiling/tech
 
 /turf/floor/tiled/monotile
-	name = "floor"
-	icon_state = "steel_monotile"
-	_flooring = /decl/flooring/tiling/mono
+	name          = "floor"
+	icon_state    = "steel_monotile"
+	_flooring     = /decl/flooring/tiling/mono
 
 /turf/floor/tiled/steel_grid
-	name = "floor"
-	icon_state = "steel_grid"
-	_flooring = /decl/flooring/tiling/new_tile/steel_grid
+	name          = "floor"
+	icon_state    = "steel_grid"
+	_flooring     = /decl/flooring/tiling/new_tile/steel_grid
 
 /turf/floor/tiled/steel_ridged
-	name = "floor"
-	icon_state = "steel_ridged"
-	_flooring = /decl/flooring/tiling/new_tile/steel_ridged
+	name          = "floor"
+	icon_state    = "steel_ridged"
+	_flooring     = /decl/flooring/tiling/new_tile/steel_ridged
 
 /turf/floor/tiled/old_tile
-	name = "floor"
-	icon_state = "tile_full"
-	_flooring = /decl/flooring/tiling/new_tile
+	name          = "floor"
+	icon_state    = "tile_full"
+	_flooring     = /decl/flooring/tiling/new_tile
 
 /turf/floor/tiled/old_cargo
-	name = "floor"
-	icon_state = "cargo_one_full"
-	_flooring = /decl/flooring/tiling/new_tile/cargo_one
+	name          = "floor"
+	icon_state    = "cargo_one_full"
+	_flooring     = /decl/flooring/tiling/new_tile/cargo_one
 
 /turf/floor/tiled/kafel_full
-	name = "floor"
-	icon_state = "kafel_full"
-	_flooring = /decl/flooring/tiling/new_tile/kafel
+	name          = "floor"
+	icon_state    = "kafel_full"
+	_flooring     = /decl/flooring/tiling/new_tile/kafel
 
 /turf/floor/tiled/stone
-	name = "stone slab floor"
-	icon_state = "stone"
-	_flooring = /decl/flooring/tiling/stone
+	name          = "stone slab floor"
+	icon_state    = "stone"
+	_flooring     = /decl/flooring/tiling/stone
 
 /turf/floor/tiled/techfloor/grid
-	name = "floor"
-	icon_state = "techfloor_grid"
-	_flooring = /decl/flooring/tiling/tech/grid
+	name          = "floor"
+	icon_state    = "techfloor_grid"
+	_flooring     = /decl/flooring/tiling/tech/grid
 
 /turf/floor/tiled/airless
-	name = "airless floor"
-	initial_gas = null
-	temperature = TCMB
+	name          = "airless floor"
+	initial_gas   = null
+	temperature   = TCMB
 
 /turf/floor/tiled/airless/broken
 	_floor_broken = TRUE

--- a/code/game/turfs/floors/subtypes/floor_wood.dm
+++ b/code/game/turfs/floors/subtypes/floor_wood.dm
@@ -1,18 +1,18 @@
 /turf/floor/wood
-	name = "wooden floor"
-	icon = 'icons/turf/flooring/wood.dmi'
-	icon_state = "wood0"
-	color = /decl/material/solid/organic/wood/oak::color
-	_flooring = /decl/flooring/wood
+	name          = "wooden floor"
+	icon          = 'icons/turf/flooring/wood.dmi'
+	icon_state    = "wood0"
+	color         = /decl/material/solid/organic/wood/oak::color
+	_flooring     = /decl/flooring/wood
 
 #define WOOD_FLOOR_SUBTYPE(BASE, WOOD) \
 /turf/floor/##BASE/##WOOD { \
-	color = /decl/material/solid/organic/wood/##WOOD::color; \
-	_flooring = /decl/flooring/##BASE/##WOOD; \
+	color         = /decl/material/solid/organic/wood/##WOOD::color; \
+	_flooring     = /decl/flooring/##BASE/##WOOD; \
 }
 
 /turf/floor/wood/broken
-	icon_state = "wood_broken0"
+	icon_state    = "wood_broken0"
 	_floor_broken = TRUE
 
 /turf/floor/wood/broken/Initialize()
@@ -22,19 +22,19 @@
 	set_floor_broken(setting_broken)
 
 /turf/floor/wood/broken/one
-	icon_state = "wood_broken1"
+	icon_state    = "wood_broken1"
 	_floor_broken = "broken1"
 
 /turf/floor/wood/broken/two
-	icon_state = "wood_broken2"
+	icon_state    = "wood_broken2"
 	_floor_broken = "broken2"
 
 /turf/floor/wood/broken/three
-	icon_state = "wood_broken3"
+	icon_state    = "wood_broken3"
 	_floor_broken = "broken3"
 
 /turf/floor/wood/broken/four
-	icon_state = "wood_broken4"
+	icon_state    = "wood_broken4"
 	_floor_broken = "broken4"
 
 WOOD_FLOOR_SUBTYPE(wood, mahogany)
@@ -46,11 +46,11 @@ WOOD_FLOOR_SUBTYPE(wood, yew)
 
 // Rough wood floors; lower skill requirement, more wasteful to craft.
 /turf/floor/wood/rough
-	name = "rough-hewn wooden floor"
-	icon = 'icons/turf/flooring/wood_alt.dmi'
-	icon_state = "wood_peasant0"
-	color = /decl/material/solid/organic/wood/oak::color
-	_flooring = /decl/flooring/wood
+	name          = "rough-hewn wooden floor"
+	icon          = 'icons/turf/flooring/wood_alt.dmi'
+	icon_state    = "wood_peasant0"
+	color         = /decl/material/solid/organic/wood/oak::color
+	_flooring     = /decl/flooring/wood
 
 WOOD_FLOOR_SUBTYPE(wood/rough, mahogany)
 WOOD_FLOOR_SUBTYPE(wood/rough, maple)
@@ -61,14 +61,14 @@ WOOD_FLOOR_SUBTYPE(wood/rough, yew)
 
 // Laminate floor; basically identical to wood, but uses older smoother icons.
 /turf/floor/laminate
-	name = "wooden laminate floor"
-	icon = 'icons/turf/flooring/laminate.dmi'
-	icon_state = "wood"
-	color = /decl/material/solid/organic/wood/chipboard::color
-	_flooring = /decl/flooring/laminate
+	name          = "wooden laminate floor"
+	icon          = 'icons/turf/flooring/laminate.dmi'
+	icon_state    = "wood"
+	color         = /decl/material/solid/organic/wood/chipboard::color
+	_flooring     = /decl/flooring/laminate
 
 /turf/floor/laminate/broken
-	icon_state = "wood_broken0"
+	icon_state    = "wood_broken0"
 	_floor_broken = TRUE
 
 /turf/floor/laminate/broken/Initialize()
@@ -78,37 +78,37 @@ WOOD_FLOOR_SUBTYPE(wood/rough, yew)
 	set_floor_broken(setting_broken)
 
 /turf/floor/laminate/broken/one
-	icon_state = "wood_broken1"
+	icon_state    = "wood_broken1"
 	_floor_broken = "broken1"
 
 /turf/floor/laminate/broken/two
-	icon_state = "wood_broken2"
+	icon_state    = "wood_broken2"
 	_floor_broken = "broken2"
 
 /turf/floor/laminate/broken/three
-	icon_state = "wood_broken3"
+	icon_state    = "wood_broken3"
 	_floor_broken = "broken3"
 
 /turf/floor/laminate/broken/four
-	icon_state = "wood_broken4"
+	icon_state    = "wood_broken4"
 	_floor_broken = "broken4"
 
 /turf/floor/laminate/mahogany
-	color = /decl/material/solid/organic/wood/chipboard/mahogany::color
-	_flooring = /decl/flooring/laminate/mahogany
+	color         = /decl/material/solid/organic/wood/chipboard/mahogany::color
+	_flooring     = /decl/flooring/laminate/mahogany
 
 /turf/floor/laminate/maple
-	color = /decl/material/solid/organic/wood/chipboard/maple::color
-	_flooring = /decl/flooring/laminate/maple
+	color         = /decl/material/solid/organic/wood/chipboard/maple::color
+	_flooring     = /decl/flooring/laminate/maple
 
 /turf/floor/laminate/ebony
-	color = /decl/material/solid/organic/wood/chipboard/ebony::color
-	_flooring = /decl/flooring/laminate/ebony
+	color         = /decl/material/solid/organic/wood/chipboard/ebony::color
+	_flooring     = /decl/flooring/laminate/ebony
 
 /turf/floor/laminate/walnut
-	color = /decl/material/solid/organic/wood/chipboard/walnut::color
-	_flooring = /decl/flooring/laminate/walnut
+	color         = /decl/material/solid/organic/wood/chipboard/walnut::color
+	_flooring     = /decl/flooring/laminate/walnut
 
 /turf/floor/laminate/yew
-	color = /decl/material/solid/organic/wood/chipboard/yew::color
-	_flooring = /decl/flooring/laminate/yew
+	color         = /decl/material/solid/organic/wood/chipboard/yew::color
+	_flooring     = /decl/flooring/laminate/yew

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -207,6 +207,8 @@
 
 	// Unlint this to copy the actual raw vars.
 	UNLINT(_flooring = other._flooring)
+	if(islist(_flooring))
+		_flooring = _flooring.Copy()
 	UNLINT(_base_flooring = other._base_flooring)
 	set_floor_broken(other._floor_broken, TRUE)
 	set_floor_burned(other._floor_burned)

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -14,103 +14,103 @@
 	// HOLOFLOOR DOES NOT GIVE A FUCK
 
 /turf/floor/holofloor/carpet
-	name = "brown carpet"
-	icon = 'icons/turf/flooring/carpet.dmi'
-	icon_state = "brown"
-	_flooring = /decl/flooring/carpet
+	name          = "brown carpet"
+	icon          = 'icons/turf/flooring/carpet.dmi'
+	icon_state    = "brown"
+	_flooring     = /decl/flooring/carpet
 
 /turf/floor/holofloor/concrete
-	name = "brown carpet"
-	icon = 'icons/turf/flooring/carpet.dmi'
-	icon_state = "brown"
-	_flooring = /decl/flooring/carpet
+	name          = "brown carpet"
+	icon          = 'icons/turf/flooring/carpet.dmi'
+	icon_state    = "brown"
+	_flooring     = /decl/flooring/carpet
 
 /turf/floor/holofloor/concrete
-	name = "floor"
-	icon = 'icons/turf/flooring/misc.dmi'
-	icon_state = "concrete"
-	_flooring = null
+	name          = "floor"
+	icon          = 'icons/turf/flooring/misc.dmi'
+	icon_state    = "concrete"
+	_flooring     = null
 
 /turf/floor/holofloor/tiled
-	name = "floor"
-	icon = 'icons/turf/flooring/tiles.dmi'
-	icon_state = "steel"
-	_flooring = /decl/flooring/tiling
+	name          = "floor"
+	icon          = 'icons/turf/flooring/tiles.dmi'
+	icon_state    = "steel"
+	_flooring     = /decl/flooring/tiling
 
 /turf/floor/holofloor/tiled/dark
-	name = "dark floor"
-	icon_state = "dark"
-	_flooring = /decl/flooring/tiling/dark
+	name          = "dark floor"
+	icon_state    = "dark"
+	_flooring     = /decl/flooring/tiling/dark
 
 /turf/floor/holofloor/tiled/stone
-	name = "stone floor"
-	icon_state = "stone"
-	_flooring = /decl/flooring/tiling/stone
+	name          = "stone floor"
+	icon_state    = "stone"
+	_flooring     = /decl/flooring/tiling/stone
 
 /turf/floor/holofloor/lino
-	name = "lino"
-	icon = 'icons/turf/flooring/linoleum.dmi'
-	icon_state = "lino"
-	_flooring = /decl/flooring/linoleum
+	name          = "lino"
+	icon          = 'icons/turf/flooring/linoleum.dmi'
+	icon_state    = "lino"
+	_flooring     = /decl/flooring/linoleum
 
 /turf/floor/holofloor/wood
-	name = "wooden floor"
-	icon = 'icons/turf/flooring/wood.dmi'
-	icon_state = "wood0"
-	color = WOOD_COLOR_CHOCOLATE
-	_flooring = /decl/flooring/wood
+	name          = "wooden floor"
+	icon          = 'icons/turf/flooring/wood.dmi'
+	icon_state    = "wood0"
+	color         = WOOD_COLOR_CHOCOLATE
+	_flooring     = /decl/flooring/wood
 
 /turf/floor/holofloor/grass
-	name = "lush grass"
-	icon = 'icons/turf/flooring/fakegrass.dmi'
-	icon_state = "grass0"
-	_flooring = /decl/flooring/grass/fake
+	name          = "lush grass"
+	icon          = 'icons/turf/flooring/fakegrass.dmi'
+	icon_state    = "grass0"
+	_flooring     = /decl/flooring/grass/fake
 
 /turf/floor/holofloor/snow
-	name = "snow"
-	icon = 'icons/turf/flooring/snow.dmi'
-	icon_state = "snow0"
-	_flooring = /decl/flooring/snow/fake
+	name          = "snow"
+	icon          = 'icons/turf/flooring/snow.dmi'
+	icon_state    = "snow0"
+	_flooring     = /decl/flooring/snow/fake
 
 /turf/floor/holofloor/space
-	name = "\proper space"
-	icon = 'icons/turf/flooring/fake_space.dmi'
-	icon_state = "space0"
-	_flooring = /decl/flooring/fake_space
+	name          = "\proper space"
+	icon          = 'icons/turf/flooring/fake_space.dmi'
+	icon_state    = "space0"
+	_flooring     = /decl/flooring/fake_space
 
 /turf/floor/holofloor/reinforced
-	icon = 'icons/turf/flooring/tiles.dmi'
-	_flooring = /decl/flooring/reinforced
-	name = "reinforced holofloor"
-	icon_state = "reinforced"
+	name          = "reinforced holofloor"
+	icon          = 'icons/turf/flooring/tiles.dmi'
+	_flooring     = /decl/flooring/reinforced
+	icon_state    = "reinforced"
 
 /turf/floor/holofloor/beach
-	desc = "Uncomfortably gritty for a hologram."
-	icon = 'icons/misc/beach.dmi'
-	_flooring = /decl/flooring/sand/fake
+	desc          = "Uncomfortably gritty for a hologram."
+	icon          = 'icons/misc/beach.dmi'
+	_flooring     = /decl/flooring/sand/fake
 	abstract_type = /turf/floor/holofloor/beach
 
 /turf/floor/holofloor/beach/sand
-	name = "sand"
-	icon_state = "desert0"
+	name          = "sand"
+	icon_state    = "desert0"
 
 /turf/floor/holofloor/beach/coastline
-	name = "coastline"
-	icon = 'icons/misc/beach2.dmi'
-	icon_state = "sandwater"
-	_flooring = /decl/flooring/sand/fake
+	name          = "coastline"
+	icon          = 'icons/misc/beach2.dmi'
+	icon_state    = "sandwater"
+	_flooring     = /decl/flooring/sand/fake
 
 /turf/floor/holofloor/beach/water
-	name = "water"
-	icon_state = "seashallow"
-	_flooring = /decl/flooring/fake_water
+	name          = "water"
+	icon_state    = "seashallow"
+	_flooring     = /decl/flooring/fake_water
 
 /turf/floor/holofloor/desert
-	name = "desert sand"
-	desc = "Uncomfortably gritty for a hologram."
-	icon_state = "barren"
-	icon = 'icons/turf/flooring/barren.dmi'
-	_flooring = /decl/flooring/sand/fake
+	name          = "desert sand"
+	desc          = "Uncomfortably gritty for a hologram."
+	icon          = 'icons/turf/flooring/barren.dmi'
+	icon_state    = "barren"
+	_flooring     = /decl/flooring/sand/fake
 
 /turf/floor/holofloor/desert/Initialize(var/ml)
 	. = ..()
@@ -118,19 +118,19 @@
 		LAZYADD(decals, image('icons/turf/flooring/decals.dmi', "asteroid[rand(0,9)]"))
 
 /obj/structure/holostool
-	name = "stool"
-	desc = "Apply butt."
-	icon = 'icons/obj/furniture.dmi'
-	icon_state = "stool_padded_preview"
-	anchored = TRUE
+	name          = "stool"
+	desc          = "Apply butt."
+	icon          = 'icons/obj/furniture.dmi'
+	icon_state    = "stool_padded_preview"
+	anchored      = TRUE
 
 /obj/item/clothing/gloves/boxing/hologlove
-	name = "boxing gloves"
-	desc = "Because you really needed another excuse to punch your crewmates."
+	name          = "boxing gloves"
+	desc          = "Because you really needed another excuse to punch your crewmates."
 
 /obj/structure/window/reinforced/holowindow/full
-	dir = NORTHEAST
-	icon_state = "rwindow_full"
+	dir           = NORTHEAST
+	icon_state    = "rwindow_full"
 
 /obj/structure/window/reinforced/holowindow/attackby(obj/item/weapon, mob/user)
 	if(IS_SCREWDRIVER(weapon) || IS_CROWBAR(weapon) || IS_WRENCH(weapon))

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -165,7 +165,7 @@
 			anchored = TRUE
 			if(do_after(src, 50, F))
 				if(F.is_floor_damaged())
-					F.set_flooring(null)
+					F.remove_flooring(F.get_topmost_flooring())
 			anchored = FALSE
 			target = null
 			busy = 0

--- a/code/unit_tests/turf_icons.dm
+++ b/code/unit_tests/turf_icons.dm
@@ -188,9 +188,10 @@
 // Procs used for validation below.
 /turf/floor/validate_turf()
 	. = ..()
+
 	if(!istype(_base_flooring))
 		. += "null or invalid _base_flooring ([_base_flooring || "NULL"])"
-	if(_flooring && !istype(_flooring))
+	if(_flooring && !islist(_flooring) && !istype(_flooring, /decl/flooring))
 		. += "invalid post-init type for _flooring ([_flooring || "NULL"])"
 
 	var/decl/flooring/check_flooring = get_topmost_flooring()

--- a/mods/content/fantasy/submaps/woods/fairy_rings/fairy_ring.dmm
+++ b/mods/content/fantasy/submaps/woods/fairy_rings/fairy_ring.dmm
@@ -1,10 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/floor/fake_grass,
+/turf/floor/grass,
 /area/fantasy/outside/point_of_interest/fairy_ring)
 "w" = (
 /obj/structure/flora/plant/random_mushroom,
-/turf/floor/fake_grass,
+/turf/floor/grass,
 /area/fantasy/outside/point_of_interest/fairy_ring)
 "D" = (
 /turf/floor/grass/wild,

--- a/mods/content/psionics/system/psionics/null/turf_floor.dm
+++ b/mods/content/psionics/system/psionics/null/turf_floor.dm
@@ -3,6 +3,6 @@
 	return (flooring && flooring.is_psi_null()) ? src : ..()
 
 /turf/floor/tiled/nullglass
-	name = "nullglass floor"
+	name       = "nullglass floor"
 	icon_state = "nullglass"
-	_flooring = /decl/flooring/tiling/nullglass
+	_flooring  = /decl/flooring/tiling/nullglass

--- a/mods/gamemodes/cult/cultify/turf.dm
+++ b/mods/gamemodes/cult/cultify/turf.dm
@@ -17,10 +17,10 @@
 	return ..()
 
 /turf/floor/cult
-	name = "engraved floor"
-	icon = 'icons/turf/flooring/cult.dmi'
-	icon_state = "cult"
-	_flooring = /decl/flooring/reinforced/cult
+	name           = "engraved floor"
+	icon           = 'icons/turf/flooring/cult.dmi'
+	icon_state     = "cult"
+	_flooring      = /decl/flooring/reinforced/cult
 
 /turf/wall/on_defilement()
 	var/new_material
@@ -38,12 +38,12 @@
 
 //Cult wall
 /turf/wall/cult
-	icon_state = "cult"
-	color = COLOR_RED_GRAY
-	material = /decl/material/solid/stone/cult
+	icon_state     = "cult"
+	color          = COLOR_RED_GRAY
+	material       = /decl/material/solid/stone/cult
 
 /turf/wall/cult/reinf
-	icon_state = "reinforced_cult"
+	icon_state     = "reinforced_cult"
 	reinf_material = /decl/material/solid/stone/cult/reinforced
 
 /turf/wall/cult/dismantle_turf(devastated, explode, no_product, keep_air = TRUE)

--- a/mods/species/ascent/turfs/ship.dm
+++ b/mods/species/ascent/turfs/ship.dm
@@ -17,40 +17,46 @@
 	broken_states  = null
 
 /turf/wall/ascent
-	color = COLOR_PURPLE
+	color          = COLOR_PURPLE
 
 /turf/wall/ascent/on_update_icon()
 	. = ..()
-	color = COLOR_PURPLE
+	color          = COLOR_PURPLE
 
 /turf/wall/r_wall/ascent
-	color = COLOR_PURPLE
+	color          = COLOR_PURPLE
 
 /turf/wall/r_wall/ascent/on_update_icon()
 	. = ..()
-	color = COLOR_PURPLE
+	color          = COLOR_PURPLE
 
 /turf/floor/shuttle_ceiling/ascent
-	color = COLOR_PURPLE
-	icon_state = "jaggy"
-	icon = 'icons/turf/flooring/alium.dmi'
+	color          = COLOR_PURPLE
+	icon_state     = "jaggy"
+	icon           = 'icons/turf/flooring/alium.dmi'
 
 /turf/floor/ascent
-	name = "mantid plating"
-	color = COLOR_GRAY20
-	initial_gas = list(/decl/material/gas/methyl_bromide = MOLES_CELLSTANDARD * 0.5, /decl/material/gas/oxygen = MOLES_CELLSTANDARD * 0.5)
+	name           = "mantid plating"
+	color          = COLOR_GRAY20
 	_base_flooring = /decl/flooring/plating/ascent
-	icon_state = "curvy"
-	icon = 'icons/turf/flooring/alium.dmi'
+	icon_state     = "curvy"
+	icon           = 'icons/turf/flooring/alium.dmi'
+	initial_gas    = list(
+		/decl/material/gas/methyl_bromide = MOLES_CELLSTANDARD * 0.5,
+		/decl/material/gas/oxygen         = MOLES_CELLSTANDARD * 0.5
+	)
 
 /turf/floor/ascent/Initialize()
 	. = ..()
-	icon_state = "curvy[rand(0,6)]"
+	icon_state     = "curvy[rand(0,6)]"
 
 /turf/floor/tiled/ascent
-	name = "mantid tiling"
-	icon_state = "jaggy"
-	icon = 'icons/turf/flooring/alium.dmi'
-	color = COLOR_GRAY40
-	initial_gas = list(/decl/material/gas/methyl_bromide = MOLES_CELLSTANDARD * 0.5, /decl/material/gas/oxygen = MOLES_CELLSTANDARD * 0.5)
-	_flooring = /decl/flooring/tiling_ascent
+	name           = "mantid tiling"
+	icon           = 'icons/turf/flooring/alium.dmi'
+	icon_state     = "jaggy"
+	color          = COLOR_GRAY40
+	_flooring      = /decl/flooring/tiling_ascent
+	initial_gas    = list(
+		/decl/material/gas/methyl_bromide = MOLES_CELLSTANDARD * 0.5,
+		/decl/material/gas/oxygen         = MOLES_CELLSTANDARD * 0.5
+	)

--- a/mods/species/skrell/turfs/flooring.dm
+++ b/mods/species/skrell/turfs/flooring.dm
@@ -1,33 +1,33 @@
 /turf/floor/tiled/skrell
-	icon = 'mods/species/skrell/icons/turf/skrellturf.dmi'
+	icon       = 'mods/species/skrell/icons/turf/skrellturf.dmi'
 	icon_state = "skrellblack"
-	_flooring = /decl/flooring/reinforced/shuttle/skrell
+	_flooring  = /decl/flooring/reinforced/shuttle/skrell
 
 /turf/floor/tiled/skrell/white
 	icon_state = "skrellwhite"
-	_flooring = /decl/flooring/reinforced/shuttle/skrell/white
+	_flooring  = /decl/flooring/reinforced/shuttle/skrell/white
 
 /turf/floor/tiled/skrell/red
 	icon_state = "skrellred"
-	_flooring = /decl/flooring/reinforced/shuttle/skrell/red
+	_flooring  = /decl/flooring/reinforced/shuttle/skrell/red
 
 /turf/floor/tiled/skrell/blue
 	icon_state = "skrellblue"
-	_flooring = /decl/flooring/reinforced/shuttle/skrell/blue
+	_flooring  = /decl/flooring/reinforced/shuttle/skrell/blue
 
 /turf/floor/tiled/skrell/orange
 	icon_state = "skrellorange"
-	_flooring = /decl/flooring/reinforced/shuttle/skrell/orange
+	_flooring  = /decl/flooring/reinforced/shuttle/skrell/orange
 
 /turf/floor/tiled/skrell/green
 	icon_state = "skrellgreen"
-	_flooring = /decl/flooring/reinforced/shuttle/skrell/green
+	_flooring  = /decl/flooring/reinforced/shuttle/skrell/green
 
 /////////////////////////////////////////////////////////////////////////
 
 /decl/flooring/reinforced/shuttle/skrell
-	icon = 'mods/species/skrell/icons/turf/skrellturf.dmi'
-	icon_base = "skrellblack"
+	icon       = 'mods/species/skrell/icons/turf/skrellturf.dmi'
+	icon_base  = "skrellblack"
 
 /decl/flooring/reinforced/shuttle/skrell/white
 	icon_base = "skrellwhite"

--- a/nebula.dme
+++ b/nebula.dme
@@ -1590,6 +1590,7 @@
 #include "code\game\turfs\floors\floor_digging.dm"
 #include "code\game\turfs\floors\floor_height.dm"
 #include "code\game\turfs\floors\floor_icon.dm"
+#include "code\game\turfs\floors\floor_layers.dm"
 #include "code\game\turfs\floors\floor_materials.dm"
 #include "code\game\turfs\floors\subtypes\floor_carpet.dm"
 #include "code\game\turfs\floors\subtypes\floor_circuit.dm"


### PR DESCRIPTION
## Description of changes
- Adds handling to `_flooring` for multiple floor types on the same turf.
- Changes wild grass to be `dirt, grass, wild grass` and adds a snowy grass type (`dirt, grass, snow`).

I would like some input on this one as it is blowing out init time on Shaded Hills 250% (almost a full minute) and there are some odd instances of completely black turfs. 

## Why and what will this PR improve
Allows for things like snow accumulation without ChangeTurf() or overriding the lower turf types.

## Authorship
Myself.

## Changelog
Nothing player-facing currently.