### PR TITLE
Adds a quick interaction proc for ctrl-click while holding an atom.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -282,10 +282,17 @@
 	return A.CtrlClick(src)
 
 /atom/proc/CtrlClick(var/mob/user)
+	if(loc == user)
+		var/decl/interaction_handler/handler = get_quick_interaction_handler(user)
+		if(handler)
+			var/using_item = user.get_active_held_item() || user.get_usable_hand_slot_organ()
+			if(handler.is_possible(src, user, using_item))
+				return handler.invoked(src, user, using_item)
 	return FALSE
 
 /atom/movable/CtrlClick(var/mob/living/user)
-	return try_make_grab(user, defer_hand = TRUE) || ..()
+	if(!(. = ..()) && loc != user)
+		return try_make_grab(user, defer_hand = TRUE) || ..()
 
 /*
 	Alt click

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -893,6 +893,15 @@
 		check_loc = check_loc.loc
 
 /**
+	Get a default interaction for a user from this atom.
+
+	- `user`: The mob that this interaction is for
+	- Return: A default interaction decl, or null.
+*/
+/atom/proc/get_quick_interaction_handler(mob/user)
+	return
+
+/**
 	Get a list of alt interactions for a user from this atom.
 
 	- `user`: The mob that these alt interactions are for

--- a/code/modules/codex/codex_atom.dm
+++ b/code/modules/codex/codex_atom.dm
@@ -36,5 +36,8 @@
 
 /atom/examine(mob/user, distance, infix = "", suffix = "")
 	. = ..()
+	var/decl/interaction_handler/handler = get_quick_interaction_handler(user)
+	if(handler)
+		to_chat(user, SPAN_NOTICE("<b>Ctrl-click</b> \the [src] while in your inventory to [lowertext(handler.name)]."))
 	if(user?.get_preference_value(/datum/client_preference/inquisitive_examine) == PREF_ON && user.can_use_codex() && SScodex.get_codex_entry(get_codex_value(user)))
 		to_chat(user, SPAN_NOTICE("The codex has <b><a href='byond://?src=\ref[SScodex];show_examined_info=\ref[src];show_to=\ref[user]'>relevant information</a></b> available."))

--- a/code/modules/codex/entries/guns.dm
+++ b/code/modules/codex/entries/guns.dm
@@ -35,7 +35,7 @@
 		traits += "It's best fired with a two-handed grip."
 
 	if(has_safety)
-		traits += "It has a safety switch. Control-Click it to toggle safety."
+		traits += "It has a safety switch, which can be toggled via <b>ctrl-click</b> or selecting Toggle Safety from the <b>alt-click</b> radial."
 
 	if(is_secure_gun())
 		traits += "It's fitted with a secure registration chip. Swipe ID on it to register."

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -747,6 +747,9 @@
 		return FALSE
 	return TRUE
 
+/obj/item/gun/get_quick_interaction_handler(mob/user)
+	return GET_DECL(/decl/interaction_handler/gun/toggle_safety)
+
 /obj/item/gun/get_alt_interactions(mob/user)
 	. = ..()
 	LAZYADD(., /decl/interaction_handler/gun/toggle_safety)


### PR DESCRIPTION
Aiming at staging so Scav gets it ahead of next staging period. Small footprint, arguable 'fix'.

## Description of changes
- Ctrl-click on an atom in your inventory will try to check for a quick interaction handler before trying to grab.
- Guns have toggle safety set as their quick interaction.
- Fixes #4727

## Why and what will this PR improve
Quick toggling of safety during firefights.

## Authorship
Myself.

## Changelog
:cl:
add: Ctrl-click in inventory will toggle safety on firearms.
/:cl: