### PR TITLE
Reagent heaters can now heat skillets/pots.

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/chemistry.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/chemistry.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/reagent_heater
-	name = "circuitboard (chemical heater)"
+	name = "circuitboard (hotplate)"
 	build_path = /obj/machinery/reagent_temperature
 	board_type = "machine"
 	origin_tech = @'{"powerstorage":2,"engineering":1}'

--- a/code/modules/food/cooking/cooking_vessels/_cooking_vessel.dm
+++ b/code/modules/food/cooking/cooking_vessels/_cooking_vessel.dm
@@ -40,6 +40,8 @@
 	return FALSE
 
 /obj/item/chems/cooking_vessel/afterattack(var/obj/target, var/mob/user, var/proximity)
+	if(!proximity || istype(target, /obj/machinery/reagent_temperature))
+		return FALSE
 	if(!ATOM_IS_OPEN_CONTAINER(src) || !proximity) //Is the container open & are they next to whatever they're clicking?
 		return FALSE //If not, do nothing.
 	if(target?.storage)

--- a/code/modules/food/cooking/cooking_vessels/pot.dm
+++ b/code/modules/food/cooking/cooking_vessels/pot.dm
@@ -15,10 +15,15 @@
 
 /obj/item/chems/cooking_vessel/pot/get_reagents_overlay(state_prefix)
 	var/image/our_overlay = ..()
-	if(our_overlay && last_boil_status && check_state_in_icon("[our_overlay.icon_state]_boiling", icon))
+	if(our_overlay && last_boil_status && check_state_in_icon("[our_overlay.icon_state]_boiling", our_overlay.icon))
 		// change the base state but keep the overlays
 		our_overlay.icon_state = "[our_overlay.icon_state]_boiling"
 	return our_overlay
+
+/obj/item/chems/cooking_vessel/pot/on_reagent_change()
+	. = ..()
+	last_boil_temp   = null
+	last_boil_status = null
 
 /obj/item/chems/cooking_vessel/pot/ProcessAtomTemperature()
 	. = ..()
@@ -34,9 +39,10 @@
 				next_boil_status = TRUE
 				break
 
-		if(next_boil_status != last_boil_status)
+		if(isnull(last_boil_status) || next_boil_status != last_boil_status)
 			last_boil_status = next_boil_status
 			update_icon()
 
 	if(. == PROCESS_KILL)
-		last_boil_temp = null
+		last_boil_temp   = null
+		last_boil_status = null

--- a/code/modules/food/cooking/cooking_vessels/pot.dm
+++ b/code/modules/food/cooking/cooking_vessels/pot.dm
@@ -16,20 +16,19 @@
 /obj/item/chems/cooking_vessel/pot/get_reagents_overlay(state_prefix)
 	var/image/our_overlay = ..()
 	if(our_overlay && last_boil_status && check_state_in_icon("[our_overlay.icon_state]_boiling", our_overlay.icon))
-		// change the base state but keep the overlays
 		our_overlay.icon_state = "[our_overlay.icon_state]_boiling"
 	return our_overlay
 
 /obj/item/chems/cooking_vessel/pot/on_reagent_change()
-	. = ..()
 	last_boil_temp   = null
 	last_boil_status = null
+	. = ..()
 
 /obj/item/chems/cooking_vessel/pot/ProcessAtomTemperature()
 	. = ..()
 
 	// Largely ignore return value so we don't skip this update on the final time we temperature process.
-	if(isnull(last_boil_temp) || temperature != last_boil_temp)
+	if(temperature != last_boil_temp)
 
 		last_boil_temp = temperature
 		var/next_boil_status = FALSE
@@ -39,7 +38,7 @@
 				next_boil_status = TRUE
 				break
 
-		if(isnull(last_boil_status) || next_boil_status != last_boil_status)
+		if(next_boil_status != last_boil_status)
 			last_boil_status = next_boil_status
 			update_icon()
 

--- a/code/modules/reagents/heat_sources/_heat_source.dm
+++ b/code/modules/reagents/heat_sources/_heat_source.dm
@@ -97,6 +97,7 @@
 			return TRUE
 		thing.reset_offsets(anim_time = 0)
 		user.visible_message(SPAN_NOTICE("\The [user] places \the [thing] onto \the [src]."))
+		return TRUE
 
 	if(IS_WRENCH(thing))
 		if(use_power == POWER_USE_ACTIVE)

--- a/code/modules/reagents/heat_sources/_heat_source.dm
+++ b/code/modules/reagents/heat_sources/_heat_source.dm
@@ -5,8 +5,8 @@
 #define HEATER_MODE_COOL         "cool"
 
 /obj/machinery/reagent_temperature
-	name = "chemical heater"
-	desc = "A small electric Bunsen, used to heat beakers and vials of chemicals."
+	name = "hotplate"
+	desc = "A small electric hotplate, used to heat cookware, beakers, or vials of chemicals."
 	icon = 'icons/obj/machines/heat_sources.dmi'
 	icon_state = "hotplate"
 	atom_flags = ATOM_FLAG_CLIMBABLE
@@ -70,6 +70,7 @@
 
 /obj/machinery/reagent_temperature/ProcessAtomTemperature()
 	if(use_power >= POWER_USE_ACTIVE)
+
 		var/last_temperature = temperature
 		if(heater_mode == HEATER_MODE_HEAT && temperature < target_temperature)
 			temperature = min(target_temperature, temperature + heating_power)
@@ -79,10 +80,24 @@
 			if(container)
 				queue_temperature_atoms(container)
 			queue_icon_update()
+
+		// Hackery to heat pots placed onto a hotplate without also grilling/baking stuff.
+		if(isturf(loc))
+			var/datum/gas_mixture/environment = loc.return_air()
+			for(var/obj/item/chems/cooking_vessel/pot in loc.get_contained_external_atoms())
+				pot.fire_act(environment, temperature, 500)
+
 		return TRUE // Don't kill this processing loop unless we're not powered.
 	. = ..()
 
 /obj/machinery/reagent_temperature/attackby(var/obj/item/thing, var/mob/user)
+
+	if(istype(thing, /obj/item/chems/cooking_vessel))
+		if(!user.try_unequip(thing, get_turf(src)))
+			return TRUE
+		thing.reset_offsets(anim_time = 0)
+		user.visible_message(SPAN_NOTICE("\The [user] places \the [thing] onto \the [src]."))
+
 	if(IS_WRENCH(thing))
 		if(use_power == POWER_USE_ACTIVE)
 			to_chat(user, SPAN_WARNING("Turn \the [src] off first!"))

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -27,6 +27,8 @@
 
 /obj/item/chems/on_update_icon()
 	. = ..()
+	if(detail_state)
+		add_overlay(overlay_image(icon, "[initial(icon_state)][detail_state]", detail_color || COLOR_WHITE, RESET_COLOR))
 	var/image/contents_overlay = get_reagents_overlay(use_single_icon ? icon_state : null)
 	if(contents_overlay)
 		add_overlay(contents_overlay)
@@ -49,11 +51,6 @@
 		to_chat(usr, SPAN_WARNING("You can't set transfer amounts while \the [src] is being held by someone else."))
 		return TRUE
 	return FALSE
-
-/obj/item/chems/on_update_icon()
-	. = ..()
-	if(detail_state)
-		add_overlay(overlay_image(icon, "[initial(icon_state)][detail_state]", detail_color || COLOR_WHITE, RESET_COLOR))
 
 /obj/item/chems/update_name()
 	. = ..() // handles material, etc

--- a/maps/ministation/ministation-1.dmm
+++ b/maps/ministation/ministation-1.dmm
@@ -6710,6 +6710,8 @@
 	},
 /obj/structure/table/woodentable,
 /obj/machinery/reagent_temperature,
+/obj/item/chems/cooking_vessel/pot,
+/obj/item/chems/cooking_vessel/skillet,
 /turf/floor/lino,
 /area/ministation/cafe)
 "Ct" = (

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -2002,6 +2002,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/item/chems/glass/beaker{
+	pixel_x = 5
+	},
+/obj/item/chems/condiment/small/peppermill{
+	pixel_x = 3
+	},
+/obj/item/chems/condiment/enzyme,
+/obj/item/chems/glass/rag,
+/obj/item/chems/cooking_vessel/pot,
 /turf/floor/tiled,
 /area/ship/trade/crew/kitchen)
 "eQ" = (
@@ -4684,14 +4693,8 @@
 "nH" = (
 /obj/structure/table,
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/item/chems/glass/beaker{
-	pixel_x = 5
-	},
-/obj/item/chems/condiment/small/peppermill{
-	pixel_x = 3
-	},
-/obj/item/chems/condiment/enzyme,
-/obj/item/chems/glass/rag,
+/obj/machinery/reagent_temperature,
+/obj/item/chems/cooking_vessel/skillet,
 /turf/floor/tiled,
 /area/ship/trade/crew/kitchen)
 "nR" = (


### PR DESCRIPTION
## Description of changes
- Reagent heaters are renamed to hotplates.
- Reagent heaters will heat cooking vessels on their turf.
- Tradeship and Ministation kitchens have pots/skillets/hotplates.

Does not fix pots not showing their boiling overlay, cannot work out the cause of that.

## Why and what will this PR improve
Space maps can now make soup.

## Authorship
Myself.

## Changelog
:cl:
tweak: Reagent heaters/hotplates can be used to heat pots and skillets to make soup.
/:cl:
