### PR TITLE
Cleaning up affect_overdose() procs.

### DIFF
--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -1002,9 +1002,9 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 		holder.remove_reagent(type, REAGENT_VOLUME(holder, type))
 		. = TRUE
 
-/decl/material/proc/affect_overdose(mob/living/M, total_dose) // Overdose effect. Doesn't happen instantly.
-	M.add_chemical_effect(CE_TOXIN, 1)
-	M.take_damage(REM, TOX)
+/decl/material/proc/affect_overdose(mob/living/victim, total_dose) // Overdose effect. Doesn't happen instantly.
+	victim.add_chemical_effect(CE_TOXIN, 1)
+	victim.take_damage(REM, TOX)
 
 /decl/material/proc/initialize_data(list/newdata) // Called when the reagent is first added to a reagents datum.
 	. = newdata

--- a/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
@@ -128,16 +128,14 @@
 	..()
 	ADJ_STATUS(M, STAT_CONFUSE, 1.5)
 
-/decl/material/liquid/heartstopper/affect_overdose(mob/living/M, total_dose)
+/decl/material/liquid/heartstopper/affect_overdose(mob/living/victim, total_dose)
 	..()
-	if(ishuman(M))
-		var/mob/living/human/H = M
-		if(H.stat != UNCONSCIOUS)
-			if(H.ticks_since_last_successful_breath >= 10)
-				H.ticks_since_last_successful_breath = max(10, H.ticks_since_last_successful_breath-10)
-			H.take_damage(2, OXY)
-			SET_STATUS_MAX(H, STAT_WEAK, 10)
-		M.add_chemical_effect(CE_NOPULSE, 1)
+	if(victim.stat != UNCONSCIOUS)
+		if(victim.ticks_since_last_successful_breath >= 10)
+			victim.ticks_since_last_successful_breath = max(10, victim.ticks_since_last_successful_breath-10)
+		victim.take_damage(2, OXY)
+		SET_STATUS_MAX(victim, STAT_WEAK, 10)
+	victim.add_chemical_effect(CE_NOPULSE, 1)
 
 /decl/material/liquid/zombiepowder
 	name = "zombie powder"

--- a/code/modules/reagents/Chemistry-Metabolism.dm
+++ b/code/modules/reagents/Chemistry-Metabolism.dm
@@ -20,7 +20,7 @@
 	parent = null
 	return ..()
 
-/datum/reagents/metabolism/proc/metabolize(var/list/dosage_tracker)
+/datum/reagents/metabolism/proc/metabolize(list/dosage_tracker)
 	if(!parent || total_volume < MINIMUM_CHEMICAL_VOLUME || !length(reagent_volumes))
 		return
 	for(var/rtype in reagent_volumes)

--- a/code/modules/reagents/chems/chems_alcohol.dm
+++ b/code/modules/reagents/chems/chems_alcohol.dm
@@ -226,8 +226,8 @@
 	if(M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 
-/decl/material/liquid/alcohol/coffee/affect_overdose(mob/living/M, total_dose)
-	ADJ_STATUS(M, STAT_JITTER, 5)
+/decl/material/liquid/alcohol/coffee/affect_overdose(mob/living/victim, total_dose)
+	ADJ_STATUS(victim, STAT_JITTER, 5)
 
 /decl/material/liquid/alcohol/melonliquor
 	name = "melon liqueur"

--- a/code/modules/reagents/chems/chems_compounds.dm
+++ b/code/modules/reagents/chems/chems_compounds.dm
@@ -35,11 +35,11 @@
 		addtimer(CALLBACK(H, TYPE_PROC_REF(/mob/living/human, update_eyes)), 5 SECONDS)
 	. = ..()
 
-/decl/material/liquid/glowsap/affect_overdose(mob/living/M, total_dose)
+/decl/material/liquid/glowsap/affect_overdose(mob/living/victim, total_dose)
 	. = ..()
-	M.add_chemical_effect(CE_TOXIN, 1)
-	M.set_hallucination(60, 20)
-	SET_STATUS_MAX(M, STAT_DRUGGY, 10)
+	victim.add_chemical_effect(CE_TOXIN, 1)
+	victim.set_hallucination(60, 20)
+	SET_STATUS_MAX(victim, STAT_DRUGGY, 10)
 
 /decl/material/solid/blackpepper
 	name = "black pepper"

--- a/code/modules/reagents/chems/chems_drinks.dm
+++ b/code/modules/reagents/chems/chems_drinks.dm
@@ -378,9 +378,9 @@
 	..()
 	M.add_chemical_effect(CE_PULSE, 2)
 
-/decl/material/liquid/drink/coffee/affect_overdose(mob/living/M, total_dose)
-	ADJ_STATUS(M, STAT_JITTER, 5)
-	M.add_chemical_effect(CE_PULSE, 1)
+/decl/material/liquid/drink/coffee/affect_overdose(mob/living/victim, total_dose)
+	ADJ_STATUS(victim, STAT_JITTER, 5)
+	victim.add_chemical_effect(CE_PULSE, 1)
 
 /decl/material/liquid/drink/coffee/build_presentation_name_from_reagents(var/obj/item/prop, var/supplied)
 

--- a/code/modules/reagents/chems/chems_drugs.dm
+++ b/code/modules/reagents/chems/chems_drugs.dm
@@ -61,9 +61,9 @@
 		LAZYSET(holder.reagent_data, type, world.time)
 		to_chat(M, "<span class='notice'>You feel invigorated and calm.</span>")
 
-/decl/material/liquid/nicotine/affect_overdose(mob/living/M, total_dose)
+/decl/material/liquid/nicotine/affect_overdose(mob/living/victim, total_dose)
 	..()
-	M.add_chemical_effect(CE_PULSE, 2)
+	victim.add_chemical_effect(CE_PULSE, 2)
 
 /decl/material/liquid/sedatives
 	name = "sedatives"
@@ -253,10 +253,9 @@
 	if(istype(M))
 		M.remove_client_color(/datum/client_color/noir/thirdeye)
 
-/decl/material/liquid/glowsap/gleam/affect_overdose(mob/living/M, total_dose)
-	M.take_damage(rand(1, 5), BRAIN)
-	if(ishuman(M) && prob(10))
-		var/mob/living/human/H = M
-		H.seizure()
+/decl/material/liquid/glowsap/gleam/affect_overdose(mob/living/victim, total_dose)
+	victim.take_damage(rand(1, 5), BRAIN)
 	if(prob(10))
-		to_chat(M, SPAN_DANGER("<font size = [rand(2,4)]>[pick(overdose_messages)]</font>"))
+		victim.seizure()
+	if(prob(10))
+		to_chat(victim, SPAN_DANGER("<font size = [rand(2,4)]>[pick(overdose_messages)]</font>"))

--- a/code/modules/reagents/chems/chems_medicines.dm
+++ b/code/modules/reagents/chems/chems_medicines.dm
@@ -52,14 +52,12 @@
 	uid = "chem_styptic"
 	var/effectiveness = 1
 
-/decl/material/liquid/brute_meds/affect_overdose(mob/living/M, var/datum/reagents/holder)
+/decl/material/liquid/brute_meds/affect_overdose(mob/living/victim, total_dose)
 	..()
-	if(ishuman(M))
-		M.add_chemical_effect(CE_BLOCKAGE, (15 + REAGENT_VOLUME(holder, type))/100)
-		var/mob/living/human/H = M
-		for(var/obj/item/organ/external/E in H.get_external_organs())
-			if(E.status & ORGAN_ARTERY_CUT && prob(2 + REAGENT_VOLUME(holder, type) / overdose))
-				E.status &= ~ORGAN_ARTERY_CUT
+	victim.add_chemical_effect(CE_BLOCKAGE, (15 + total_dose) / 100)
+	for(var/obj/item/organ/external/limb in victim.get_external_organs())
+		if((limb.status & ORGAN_ARTERY_CUT) && prob(2 + total_dose / overdose))
+			limb.status &= ~ORGAN_ARTERY_CUT
 
 //This is a logistic function that effectively doubles the healing rate as brute amounts get to around 200. Any injury below 60 is essentially unaffected and there's a scaling inbetween.
 #define ADJUSTED_REGEN_VAL(X) (6+(6/(1+200*2.71828**(-0.05*(X)))))
@@ -169,12 +167,10 @@
 	if(immunity_to_add > 0)
 		M.adjust_immunity(immunity_to_add) // Rapidly brings someone up to half immunity.
 
-/decl/material/liquid/immunobooster/affect_overdose(mob/living/M, total_dose)
+/decl/material/liquid/immunobooster/affect_overdose(mob/living/victim, total_dose)
 	..()
-	M.add_chemical_effect(CE_TOXIN, 1)
-	var/mob/living/human/H = M
-	if(istype(H))
-		M.adjust_immunity(-0.5)
+	victim.add_chemical_effect(CE_TOXIN, 1)
+	victim.adjust_immunity(-0.5)
 
 /decl/material/liquid/stimulants
 	name = "stimulants"
@@ -240,12 +236,12 @@
 	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_antibiotics"
 
-/decl/material/liquid/antibiotics/affect_overdose(mob/living/M, total_dose)
+/decl/material/liquid/antibiotics/affect_overdose(mob/living/victim, total_dose)
 	..()
-	M.adjust_immunity(-0.5)
-	M.immunity = max(M.immunity - 0.25, 0)
+	victim.adjust_immunity(-0.5)
+	victim.immunity = max(victim.immunity - 0.25, 0)
 	if(prob(2))
-		M.immunity_norm = max(M.immunity_norm - 1, 0)
+		victim.immunity_norm = max(victim.immunity_norm - 1, 0)
 
 /decl/material/liquid/retrovirals
 	name = "retrovirals"
@@ -258,14 +254,12 @@
 	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 	uid = "chem_retrovirals"
 
-/decl/material/liquid/retrovirals/affect_overdose(mob/living/M, total_dose)
+/decl/material/liquid/retrovirals/affect_overdose(mob/living/victim, total_dose)
 	. = ..()
-	if(ishuman(M))
-		var/mob/living/human/H = M
-		for(var/obj/item/organ/external/E in H.get_external_organs())
-			if(!BP_IS_PROSTHETIC(E) && prob(25) && !(E.status & ORGAN_MUTATED))
-				E.mutate()
-				E.limb_flags |= ORGAN_FLAG_DEFORMED
+	for(var/obj/item/organ/external/limb in victim.get_external_organs())
+		if(!BP_IS_PROSTHETIC(limb) && prob(25) && !(limb.status & ORGAN_MUTATED))
+			limb.mutate()
+			limb.limb_flags |= ORGAN_FLAG_DEFORMED
 
 /decl/material/liquid/retrovirals/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	. = ..()
@@ -404,8 +398,8 @@
 				break
 	..()
 
-/decl/material/liquid/clotting_agent/affect_overdose(mob/living/M, total_dose)
-	var/obj/item/organ/internal/heart = GET_INTERNAL_ORGAN(M, BP_HEART)
+/decl/material/liquid/clotting_agent/affect_overdose(mob/living/victim, total_dose)
+	var/obj/item/organ/internal/heart = GET_INTERNAL_ORGAN(victim, BP_HEART)
 	if(heart && prob(25))
 		heart.take_general_damage(rand(1,3))
 	return ..()

--- a/code/modules/reagents/chems/chems_painkillers.dm
+++ b/code/modules/reagents/chems/chems_painkillers.dm
@@ -112,17 +112,17 @@
 		M.add_chemical_effect(CE_ALCOHOL_TOXIC, 1)
 		M.add_chemical_effect(CE_BREATHLOSS, 1 * boozed) //drinking and opiating suppresses breathing.
 
-/decl/material/liquid/painkillers/affect_overdose(mob/living/M, total_dose)
+/decl/material/liquid/painkillers/affect_overdose(mob/living/victim, total_dose)
 	..()
-	M.add_chemical_effect(CE_PAINKILLER, pain_power*0.5) //extra painkilling for extra trouble
+	victim.add_chemical_effect(CE_PAINKILLER, pain_power*0.5) //extra painkilling for extra trouble
 	if(narcotic)
-		SET_STATUS_MAX(M, STAT_DRUGGY, 10)
-		M.set_hallucination(120, 30)
-		M.add_chemical_effect(CE_BREATHLOSS, breathloss_severity*2) //ODing on opiates can be deadly.
-		if(isboozed(M))
-			M.add_chemical_effect(CE_BREATHLOSS, breathloss_severity*4) //Don't drink and OD on opiates folks
+		SET_STATUS_MAX(victim, STAT_DRUGGY, 10)
+		victim.set_hallucination(120, 30)
+		victim.add_chemical_effect(CE_BREATHLOSS, breathloss_severity*2) //ODing on opiates can be deadly.
+		if(isboozed(victim))
+			victim.add_chemical_effect(CE_BREATHLOSS, breathloss_severity*4) //Don't drink and OD on opiates folks
 	else
-		M.add_chemical_effect(CE_TOXIN, 1)
+		victim.add_chemical_effect(CE_TOXIN, 1)
 
 /decl/material/liquid/painkillers/proc/isboozed(var/mob/living/M)
 	. = 0

--- a/mods/content/psionics/datum/chems.dm
+++ b/mods/content/psionics/datum/chems.dm
@@ -2,9 +2,9 @@
 	var/decl/special_role/wizard/wizards = GET_DECL(/decl/special_role/wizard)
 	. = (M.get_ability_handler(/datum/ability_handler/psionics) || (M.mind && wizards.is_antagonist(M.mind))) ? /decl/material/nullglass : ..()
 
-/decl/material/liquid/glowsap/gleam/affect_overdose(mob/living/M, total_dose)
+/decl/material/liquid/glowsap/gleam/affect_overdose(mob/living/victim, total_dose)
 	..()
-	var/datum/ability_handler/psionics/psi = M.get_ability_handler(/datum/ability_handler/psionics)
+	var/datum/ability_handler/psionics/psi = victim.get_ability_handler(/datum/ability_handler/psionics)
 	psi?.check_latency_trigger(30, "a [name] overdose")
 
 /decl/chemical_reaction/synthesis/nullglass

--- a/mods/species/drakes/sifsap.dm
+++ b/mods/species/drakes/sifsap.dm
@@ -44,9 +44,9 @@
 	M.add_chemical_effect(CE_PULSE, -1)
 	return ..()
 
-/decl/material/liquid/sifsap/affect_overdose(mob/living/M, total_dose)
-	if(M.has_trait(/decl/trait/sivian_biochemistry))
+/decl/material/liquid/sifsap/affect_overdose(mob/living/victim, total_dose)
+	if(victim.has_trait(/decl/trait/sivian_biochemistry))
 		return
-	M.apply_damage(1, IRRADIATE)
-	SET_STATUS_MAX(M, 5, STAT_DROWSY)
+	victim.apply_damage(1, IRRADIATE)
+	SET_STATUS_MAX(victim, 5, STAT_DROWSY)
 	return ..()


### PR DESCRIPTION
- Cleans up single-letter vars and use of human casts in affect_overdose().
- Fixes erroneous use of reagent holder in brute meds affect_overdose().