### PR TITLE
Moving unarmed attacks onto limbs.

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -187,7 +187,7 @@
 /obj/machinery/camera/physical_attack_hand(mob/living/human/user)
 	if(!istype(user))
 		return TRUE
-	if(user.species.can_shred(user))
+	if(user.can_shred())
 		user.do_attack_animation(src)
 		visible_message(SPAN_WARNING("\The [user] slashes at [src]!"))
 		playsound(src.loc, 'sound/weapons/slash.ogg', 100, 1)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -139,13 +139,11 @@
 		return
 
 /obj/machinery/door/window/physical_attack_hand(mob/user)
-	if(ishuman(user))
-		var/mob/living/human/H = user
-		if(H.species.can_shred(H))
-			playsound(loc, 'sound/effects/Glasshit.ogg', 75, 1)
-			visible_message("<span class='danger'>\The [user] smashes against \the [src].</span>", 1)
-			take_damage(25)
-			return TRUE
+	if(user.can_shred())
+		playsound(loc, 'sound/effects/Glasshit.ogg', 75, 1)
+		visible_message(SPAN_DANGER("\The [user] smashes against \the [src]."))
+		take_damage(25)
+		return TRUE
 	return ..()
 
 /obj/machinery/door/window/emag_act(var/remaining_charges, var/mob/user)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -193,13 +193,9 @@
 /obj/effect/energy_net/attack_hand(var/mob/user)
 	if(!user.check_intent(I_FLAG_HARM))
 		return ..()
-	var/decl/species/my_species = user.get_species()
-	if(my_species)
-		if(my_species.can_shred(user))
-			playsound(src.loc, 'sound/weapons/slash.ogg', 80, 1)
-			current_health -= rand(10, 20)
-		else
-			current_health -= rand(1,3)
+	if(user.can_shred())
+		playsound(src.loc, 'sound/weapons/slash.ogg', 80, 1)
+		current_health -= rand(10, 20)
 	else
 		current_health -= rand(5,8)
 	to_chat(user, SPAN_DANGER("You claw at the energy net."))

--- a/code/game/objects/structures/defensive_barrier.dm
+++ b/code/game/objects/structures/defensive_barrier.dm
@@ -105,8 +105,7 @@
 	if(!user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 
-	var/decl/species/species = user.get_species()
-	if(ishuman(user) && species?.can_shred(user) && user.check_intent(I_FLAG_HARM))
+	if(user.can_shred() && user.check_intent(I_FLAG_HARM))
 		take_damage(20)
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		return TRUE

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -101,12 +101,10 @@
 
 	var/damage_dealt = 1
 	var/attack_message = "kicks"
-	if(ishuman(user))
-		var/mob/living/human/H = user
-		if(H.species.can_shred(H))
-			attack_message = "mangles"
-			damage_dealt = 5
-	attack_generic(user,damage_dealt,attack_message)
+	if(user.can_shred())
+		attack_message = "mangles"
+		damage_dealt = 5
+	attack_generic(user, damage_dealt, attack_message)
 	return TRUE
 
 /obj/structure/grille/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -147,21 +147,23 @@
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if (user.check_intent(I_FLAG_HARM))
 
-		if (ishuman(user))
-			var/mob/living/human/H = user
-			if(H.species.can_shred(H))
-				return attack_generic(H,25)
+		if(user.can_shred())
+			return attack_generic(user, 25)
 
 		playsound(src.loc, 'sound/effects/glassknock.ogg', 80, 1)
 		user.do_attack_animation(src)
-		user.visible_message(SPAN_DANGER("\The [user] bangs against \the [src]!"),
-							SPAN_DANGER("You bang against \the [src]!"),
-							"You hear a banging sound.")
+		user.visible_message(
+			SPAN_DANGER("\The [user] bangs against \the [src]!"),
+			SPAN_DANGER("You bang against \the [src]!"),
+			"You hear a banging sound."
+		)
 	else
 		playsound(src.loc, 'sound/effects/glassknock.ogg', 80, 1)
-		user.visible_message("[user.name] knocks on \the [src].",
-							"You knock on \the [src].",
-							"You hear a knocking sound.")
+		user.visible_message(
+			SPAN_NOTICE("\The [user] knocks on \the [src]."),
+			SPAN_NOTICE("You knock on \the [src]."),
+			"You hear a knocking sound."
+		)
 	return TRUE
 
 /obj/structure/window/do_simple_ranged_interaction(var/mob/user)

--- a/code/modules/mob/living/human/human_attackhand.dm
+++ b/code/modules/mob/living/human/human_attackhand.dm
@@ -1,13 +1,12 @@
 /mob/living/human/proc/get_unarmed_attack(var/mob/target, var/hit_zone = null)
 	if(!hit_zone)
 		hit_zone = get_target_zone()
-	var/list/available_attacks = get_natural_attacks()
+	var/list/available_attacks = get_mob_natural_attacks()
 	var/decl/natural_attack/use_attack = default_attack
 	if(!use_attack || !use_attack.is_usable(src, target, hit_zone) || !(use_attack.type in available_attacks))
 		use_attack = null
 		var/list/other_attacks = list()
-		for(var/u_attack_type in available_attacks)
-			var/decl/natural_attack/u_attack = GET_DECL(u_attack_type)
+		for(var/decl/natural_attack/u_attack as anything in available_attacks)
 			if(!u_attack.is_usable(src, target, hit_zone))
 				continue
 			if(u_attack.is_starting_default)
@@ -18,11 +17,8 @@
 			use_attack = pick(other_attacks)
 	. = use_attack?.resolve_to_soft_variant(src)
 
-/mob/living/human/proc/get_natural_attacks()
-	. = list()
-	for(var/obj/item/organ/external/limb in get_external_organs())
-		if(length(limb.unarmed_attacks) && limb.is_usable())
-			. |= limb.unarmed_attacks
+/obj/item/organ/external/proc/get_natural_attacks()
+	return null
 
 /obj/item/organ/external/proc/get_injury_status(include_pain = TRUE, include_visible = TRUE)
 	. = list()
@@ -409,14 +405,12 @@
 	set src = usr
 
 	var/list/choices
-	for(var/thing in get_natural_attacks())
-		var/decl/natural_attack/u_attack = GET_DECL(thing)
-		if(istype(u_attack))
-			var/image/radial_button = new
-			radial_button.name = capitalize(u_attack.name)
-			LAZYSET(choices, u_attack, radial_button)
+	for(var/decl/natural_attack/u_attack as anything in get_mob_natural_attacks())
+		var/image/radial_button = new
+		radial_button.name = capitalize(u_attack.name)
+		LAZYSET(choices, u_attack, radial_button)
 	var/decl/natural_attack/new_attack = show_radial_menu(src, (attack_selector || src), choices, radius = 42, use_labels = RADIAL_LABELS_OFFSET)
-	if(QDELETED(src) || !istype(new_attack) || !(new_attack.type in get_natural_attacks()))
+	if(QDELETED(src) || !istype(new_attack) || !(new_attack in get_mob_natural_attacks()))
 		return
 	default_attack = new_attack
 	to_chat(src, SPAN_NOTICE("Your default unarmed attack is now <b>[default_attack?.name || "cleared"]</b>."))

--- a/code/modules/mob/living/human/human_defines.dm
+++ b/code/modules/mob/living/human/human_defines.dm
@@ -23,8 +23,6 @@
 	var/mob/remoteview_target = null
 	var/hand_blood_color
 	var/list/flavor_texts = list()
-	/// Are you trying not to hurt your opponent?
-	var/pulling_punches
 	/// We are a robutt.
 	var/full_prosthetic
 	/// Number of robot limbs.

--- a/code/modules/mob/living/human/human_verbs.dm
+++ b/code/modules/mob/living/human/human_verbs.dm
@@ -319,9 +319,3 @@
 		"<span class='danger'>[self ? "You pop" : "[U] pops"] your [current_limb.joint] back in!</span>" \
 		)
 		current_limb.undislocate()
-
-/mob/living/human/verb/pull_punches()
-	set name = "Switch Stance"
-	set desc = "Try not to hurt them."
-	set category = "IC"
-	species.toggle_stance(src)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2023,3 +2023,11 @@ default behaviour is:
 	// or things should just update their worn slot when coating is added
 	update_equipment_overlay(slot_shoes_str)
 	return TRUE
+
+/mob/living/verb/pull_punches()
+	set name = "Switch Stance"
+	set desc = "Try not to hurt them."
+	set category = "IC"
+	if(!incapacitated())
+		pulling_punches = !pulling_punches
+		to_chat(src, SPAN_NOTICE("You are now [pulling_punches ? "pulling your punches" : "not pulling your punches"]."))

--- a/code/modules/mob/living/living_resist.dm
+++ b/code/modules/mob/living/living_resist.dm
@@ -63,8 +63,7 @@
 	return 1
 
 /mob/living/proc/can_break_restraints()
-	var/decl/species/my_species = get_species()
-	return my_species?.can_shred(src, 1)
+	return can_shred(ignore_intent = TRUE)
 
 /mob/living/proc/get_special_resist_time()
 	return 0

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -643,8 +643,7 @@
 	return user?.attempt_hug(src)
 
 /mob/living/silicon/robot/default_hurt_interaction(mob/user)
-	var/decl/species/user_species = user.get_species()
-	if(user_species?.can_shred(user))
+	if(user.can_shred())
 		attack_generic(user, rand(30,50), "slashed")
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		return TRUE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1392,3 +1392,24 @@
 		paw = GET_EXTERNAL_ORGAN(src, BP_R_HAND)
 	if(istype(paw) && paw.is_usable())
 		return paw
+
+// Called when using the shredding behavior.
+/mob/proc/can_shred(var/mob/living/human/H, var/ignore_intent, var/ignore_antag)
+	if((!ignore_intent && !check_intent(I_FLAG_HARM)) || pulling_punches)
+		return FALSE
+	if(!ignore_antag && mind && !player_is_antag(mind))
+		return FALSE
+	if(get_equipped_item(slot_handcuffed_str) || buckled)
+		return FALSE
+	for(var/decl/natural_attack/attack as anything in get_mob_natural_attacks())
+		if(attack.is_usable(src) && attack.shredding)
+			return TRUE
+	return FALSE
+
+/mob/proc/get_mob_natural_attacks()
+	for(var/obj/item/organ/external/limb in get_external_organs())
+		if(!limb.is_usable())
+			continue
+		var/list/limb_unarmed_attacks = limb.get_natural_attacks()
+		if(istype(limb_unarmed_attacks, /decl/natural_attack) || (islist(limb_unarmed_attacks) && length(limb_unarmed_attacks)))
+			LAZYDISTINCTADD(., limb_unarmed_attacks)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -156,3 +156,6 @@
 	// Offset the overhead text if necessary.
 	var/offset_overhead_text_x = 0
 	var/offset_overhead_text_y = 0
+
+	/// Are you trying not to hurt your opponent?
+	var/pulling_punches

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -70,8 +70,6 @@
 	var/stage = 0
 	var/cavity = 0
 
-	var/list/unarmed_attacks
-
 	var/atom/movable/applied_pressure
 	var/atom/movable/splinted
 
@@ -141,10 +139,6 @@
 	_icon_cache_key = null
 	. = ..()
 	skin_blend = bodytype.limb_blend
-	for(var/attack_type in species.unarmed_attacks)
-		var/decl/natural_attack/attack = GET_DECL(attack_type)
-		if(istype(attack) && (organ_tag in attack.usable_with_limbs))
-			LAZYADD(unarmed_attacks, attack_type)
 	update_icon()
 
 /obj/item/organ/external/set_bodytype(decl/bodytype/new_bodytype, override_material = null, apply_to_internal_organs = TRUE)

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -20,6 +20,24 @@
 	var/forehead_graffiti
 	var/graffiti_style
 
+/obj/item/organ/external/head/get_natural_attacks()
+	if(!can_intake_reagents)
+		return null
+	var/static/unarmed_attack = GET_DECL(/decl/natural_attack/bite)
+	return unarmed_attack
+
+/obj/item/organ/external/head/sharp_bite/get_natural_attacks()
+	if(!can_intake_reagents)
+		return null
+	var/static/unarmed_attack = GET_DECL(/decl/natural_attack/bite/sharp)
+	return unarmed_attack
+
+/obj/item/organ/external/head/strong_bite/get_natural_attacks()
+	if(!can_intake_reagents)
+		return null
+	var/static/unarmed_attack = GET_DECL(/decl/natural_attack/bite/strong)
+	return unarmed_attack
+
 /obj/item/organ/external/head/proc/get_organ_eyes_overlay()
 	if(!glowing_eyes && !owner?.has_chemical_effect(CE_GLOWINGEYES, 1))
 		return

--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -113,6 +113,13 @@
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK | ORGAN_FLAG_CAN_DISLOCATE
 	organ_category = ORGAN_CATEGORY_STANCE
 
+/obj/item/organ/external/foot/get_natural_attacks()
+	var/static/list/unarmed_attacks = list(
+		GET_DECL(/decl/natural_attack/stomp),
+		GET_DECL(/decl/natural_attack/kick)
+	)
+	return unarmed_attacks
+
 /obj/item/organ/external/foot/right
 	organ_tag = BP_R_FOOT
 	name = "right foot"
@@ -139,6 +146,10 @@
 	is_washable = TRUE
 	var/gripper_type = /datum/inventory_slot/gripper/left_hand
 
+/obj/item/organ/external/hand/get_natural_attacks()
+	var/static/unarmed_attack = GET_DECL(/decl/natural_attack/punch)
+	return unarmed_attack
+
 /obj/item/organ/external/hand/do_install(mob/living/human/target, affected, in_place, update_icon, detached)
 	. = ..()
 	if(. && owner && gripper_type)
@@ -158,3 +169,11 @@
 	joint = "right wrist"
 	amputation_point = "right wrist"
 	gripper_type = /datum/inventory_slot/gripper/right_hand
+
+/obj/item/organ/external/hand/clawed/get_natural_attacks()
+	var/static/unarmed_attack = GET_DECL(/decl/natural_attack/claws)
+	return unarmed_attack
+
+/obj/item/organ/external/hand/right/clawed/get_natural_attacks()
+	var/static/unarmed_attack = GET_DECL(/decl/natural_attack/claws)
+	return unarmed_attack

--- a/code/modules/paperwork/papershredder.dm
+++ b/code/modules/paperwork/papershredder.dm
@@ -89,7 +89,7 @@
 /obj/machinery/papershredder/proc/is_bin_empty()
 	return !(length(shredder_bin) > 0 && cached_total_matter)
 
-/obj/machinery/papershredder/proc/can_shred(var/obj/item/I, var/mob/user = null)
+/obj/machinery/papershredder/proc/can_shred_document(var/obj/item/I, var/mob/user = null)
 	if(!istype(I))
 		if(user)
 			to_chat(user, SPAN_WARNING("\The [I] cannot be shredded by \the [src]!"))
@@ -120,7 +120,7 @@
 			empty_bin(user, used_item)
 			return TRUE
 
-		else if(!trying_to_smack && can_shred(used_item))
+		else if(!trying_to_smack && can_shred_document(used_item))
 			shred(used_item, user)
 			return TRUE
 	return ..()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -491,21 +491,20 @@ var/global/list/all_apcs = list()
 
 /obj/machinery/power/apc/physical_attack_hand(mob/user)
 	//Human mob special interaction goes here.
-	if(ishuman(user))
-		var/mob/living/human/H = user
-
-		if(H.species.can_shred(H))
-			user.visible_message("<span class='warning'>\The [user] slashes at \the [src]!</span>", "<span class='notice'>You slash at \the [src]!</span>")
-			playsound(src.loc, 'sound/weapons/slash.ogg', 100, 1)
-
-			var/allcut = wires.IsAllCut()
-			if(beenhit >= pick(3, 4) && allcut == 0)
-				wires.CutAll()
-				src.update_icon()
-				src.visible_message("<span class='warning'>\The [src]'s wires are shredded!</span>")
-			else
-				beenhit += 1
-			return TRUE
+	if(user.can_shred())
+		user.visible_message(
+			SPAN_DANGER("\The [user] slashes at \the [src]!"),
+			SPAN_DANGER("You slash at \the [src]!")
+		)
+		playsound(src.loc, 'sound/weapons/slash.ogg', 100, 1)
+		var/allcut = wires.IsAllCut()
+		if(beenhit >= pick(3, 4) && allcut == 0)
+			wires.CutAll()
+			update_icon()
+			visible_message(SPAN_DANGER("\The [src]'s wires are shredded!"))
+		else
+			beenhit += 1
+		return TRUE
 	return FALSE
 
 /obj/machinery/power/apc/interface_interact(mob/user)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -316,12 +316,13 @@
 		to_chat(user, "There is no [get_fitting_name()] in this light.")
 		return TRUE
 
-	if(ishuman(user))
-		var/mob/living/human/H = user
-		if(H.species.can_shred(H))
-			visible_message("<span class='warning'>[user.name] smashed the light!</span>", 3, "You hear a tinkle of breaking glass.")
-			broken()
-			return TRUE
+	if(user.can_shred())
+		visible_message(
+			SPAN_DANGER("\The [user] smashes the light!"),
+			blind_message = "You hear a tinkle of breaking glass."
+		)
+		broken()
+		return TRUE
 
 	// make it burn hands if not wearing fire-insulated gloves
 	if(on)

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -79,12 +79,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 
 	// Combat vars.
 	var/total_health = DEFAULT_SPECIES_HEALTH  // Point at which the mob will enter crit.
-	var/list/unarmed_attacks = list(           // Possible unarmed attacks that the mob will use in combat,
-		/decl/natural_attack/stomp,
-		/decl/natural_attack/kick,
-		/decl/natural_attack/punch,
-		/decl/natural_attack/bite
-	)
 
 	var/brute_mod =      1                    // Physical damage multiplier.
 	var/burn_mod =       1                    // Burn damage multiplier.
@@ -493,23 +487,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	if(!H.is_physically_disabled())
 		return TRUE //We could tie it to stamina
 	return FALSE
-
-// Called when using the shredding behavior.
-/decl/species/proc/can_shred(var/mob/living/human/H, var/ignore_intent, var/ignore_antag)
-
-	if((!ignore_intent && !H.check_intent(I_FLAG_HARM)) || H.pulling_punches)
-		return 0
-
-	if(!ignore_antag && H.mind && !player_is_antag(H.mind))
-		return 0
-
-	for(var/attack_type in unarmed_attacks)
-		var/decl/natural_attack/attack = GET_DECL(attack_type)
-		if(!istype(attack) || !attack.is_usable(H))
-			continue
-		if(attack.shredding)
-			return 1
-	return 0
 
 /decl/species/proc/handle_vision(var/mob/living/human/H)
 	var/list/vision = H.get_accumulated_vision_handlers()

--- a/code/modules/species/species_helpers.dm
+++ b/code/modules/species/species_helpers.dm
@@ -5,11 +5,6 @@ var/global/list/stored_shock_by_ref = list()
 		target.electrocute_act(stored_shock_by_ref["\ref[src]"]*0.9, src)
 		stored_shock_by_ref["\ref[src]"] = 0
 
-/decl/species/proc/toggle_stance(var/mob/living/human/H)
-	if(!H.incapacitated())
-		H.pulling_punches = !H.pulling_punches
-		to_chat(H, "<span class='notice'>You are now [H.pulling_punches ? "pulling your punches" : "not pulling your punches"].</span>")
-
 /decl/species/proc/fluid_act(var/mob/living/human/H, var/datum/reagents/fluids)
 	SHOULD_CALL_PARENT(TRUE)
 	var/water = REAGENT_VOLUME(fluids, /decl/material/liquid/water)

--- a/code/modules/species/station/golem.dm
+++ b/code/modules/species/station/golem.dm
@@ -16,7 +16,6 @@
 
 	available_bodytypes = list(/decl/bodytype/crystalline/golem)
 
-	unarmed_attacks = list(/decl/natural_attack/stomp, /decl/natural_attack/kick, /decl/natural_attack/punch)
 	species_flags = SPECIES_FLAG_NO_POISON
 	spawn_flags = SPECIES_IS_RESTRICTED
 	shock_vulnerability = 0

--- a/code/modules/species/station/monkey.dm
+++ b/code/modules/species/station/monkey.dm
@@ -15,7 +15,6 @@
 	dusted_anim = "dust-m"
 	death_message = "lets out a faint chimper as it collapses and stops moving..."
 
-	unarmed_attacks = list(/decl/natural_attack/bite, /decl/natural_attack/claws, /decl/natural_attack/punch)
 	inherent_verbs = list(/mob/living/proc/ventcrawl)
 	species_hud = /datum/hud_data/monkey
 	butchery_data = /decl/butchery_data/humanoid/monkey

--- a/mods/content/fantasy/datum/hnoll/species.dm
+++ b/mods/content/fantasy/datum/hnoll/species.dm
@@ -30,13 +30,6 @@
 	move_trail          = /obj/effect/decal/cleanable/blood/tracks/paw
 	base_external_prosthetics_model = null
 
-	unarmed_attacks = list(
-		/decl/natural_attack/stomp,
-		/decl/natural_attack/kick,
-		/decl/natural_attack/punch,
-		/decl/natural_attack/bite/sharp
-	)
-
 	available_background_info = list(
 		/decl/background_category/homeworld = list(
 			/decl/background_detail/location/fantasy,

--- a/mods/species/ascent/datum/species.dm
+++ b/mods/species/ascent/datum/species.dm
@@ -71,11 +71,6 @@
 	species_flags =           SPECIES_FLAG_NO_SLIP | SPECIES_FLAG_NO_MINOR_CUT
 	spawn_flags =             SPECIES_IS_RESTRICTED
 
-	unarmed_attacks = list(
-		/decl/natural_attack/claws/strong/gloves,
-		/decl/natural_attack/bite/sharp
-	)
-
 	force_background_info = list(
 		/decl/background_category/heritage =   /decl/background_detail/heritage/ascent,
 		/decl/background_category/homeworld = /decl/background_detail/location/kharmaani,

--- a/mods/species/bayliens/tajaran/datum/species.dm
+++ b/mods/species/bayliens/tajaran/datum/species.dm
@@ -45,13 +45,6 @@
 	thirst_factor = DEFAULT_THIRST_FACTOR * 1.2
 	gluttonous = GLUT_TINY
 
-	unarmed_attacks = list(
-		/decl/natural_attack/stomp,
-		/decl/natural_attack/kick,
-		/decl/natural_attack/punch,
-		/decl/natural_attack/bite/sharp
-	)
-
 	move_trail = /obj/effect/decal/cleanable/blood/tracks/paw
 
 	available_background_info = list(

--- a/mods/species/bayliens/tajaran/datum/species_bodytypes.dm
+++ b/mods/species/bayliens/tajaran/datum/species_bodytypes.dm
@@ -28,7 +28,10 @@
 	eye_low_light_vision_adjustment_speed = 0.3
 
 	override_limb_types = list(
-		BP_TAIL = /obj/item/organ/external/tail/cat
+		BP_TAIL   = /obj/item/organ/external/tail/cat,
+		BP_HEAD   = /obj/item/organ/external/head/sharp_bite,
+		BP_L_HAND = /obj/item/organ/external/hand/clawed,
+		BP_R_HAND = /obj/item/organ/external/hand/right/clawed
 	)
 
 	default_sprite_accessories = list(

--- a/mods/species/bayliens/tritonian/datum/species.dm
+++ b/mods/species/bayliens/tritonian/datum/species.dm
@@ -13,10 +13,3 @@
 
 	body_temperature =    302
 	water_soothe_amount = 5
-
-	unarmed_attacks = list(
-		/decl/natural_attack/stomp,
-		/decl/natural_attack/kick,
-		/decl/natural_attack/punch,
-		/decl/natural_attack/bite/sharp
-	)

--- a/mods/species/bayliens/tritonian/datum/species_bodytypes.dm
+++ b/mods/species/bayliens/tritonian/datum/species_bodytypes.dm
@@ -6,6 +6,9 @@
 	override_organ_types  = list(
 		BP_LUNGS = /obj/item/organ/internal/lungs/gills
 	)
+	override_limb_types = list(
+		BP_HEAD   = /obj/item/organ/external/head/sharp_bite
+	)
 
 /decl/bodytype/human/tritonian/masculine
 	name                  = "masculine"

--- a/mods/species/bayliens/unathi/datum/species.dm
+++ b/mods/species/bayliens/unathi/datum/species.dm
@@ -24,13 +24,6 @@
 		/decl/bodytype/lizard,
 		/decl/bodytype/lizard/masculine
 	)
-	unarmed_attacks = list(
-		/decl/natural_attack/stomp,
-		/decl/natural_attack/tail,
-		/decl/natural_attack/claws,
-		/decl/natural_attack/punch,
-		/decl/natural_attack/bite/sharp
-	)
 
 	available_accessory_categories = list(
 		SAC_HORNS,

--- a/mods/species/bayliens/unathi/datum/species_bodytypes.dm
+++ b/mods/species/bayliens/unathi/datum/species_bodytypes.dm
@@ -34,19 +34,24 @@
 	)
 
 	override_organ_types = list(
-		BP_EYES = /obj/item/organ/internal/eyes/lizard,
-		BP_BRAIN = /obj/item/organ/internal/brain/lizard
+		BP_EYES   = /obj/item/organ/internal/eyes/lizard,
+		BP_BRAIN  = /obj/item/organ/internal/brain/lizard
 	)
 
-	override_limb_types = list(BP_TAIL = /obj/item/organ/external/tail/lizard)
+	override_limb_types = list(
+		BP_TAIL   = /obj/item/organ/external/tail/lizard,
+		BP_HEAD   = /obj/item/organ/external/head/strong_bite,
+		BP_L_HAND = /obj/item/organ/external/hand/clawed,
+		BP_R_HAND = /obj/item/organ/external/hand/right/clawed
+	)
 
-	cold_level_1 = 280 //Default 260 - Lower is better
-	cold_level_2 = 220 //Default 200
-	cold_level_3 = 130 //Default 120
+	cold_level_1  = 280 //Default 260 - Lower is better
+	cold_level_2  = 220 //Default 200
+	cold_level_3  = 130 //Default 120
 
-	heat_level_1 = 420 //Default 360 - Higher is better
-	heat_level_2 = 480 //Default 400
-	heat_level_3 = 1100 //Default 1000
+	heat_level_1  = 420 //Default 360 - Higher is better
+	heat_level_2  = 480 //Default 400
+	heat_level_3  = 1100 //Default 1000
 
 	heat_discomfort_level = 320
 	heat_discomfort_strings = list(
@@ -81,3 +86,7 @@
 /obj/item/organ/external/tail/lizard
 	tail_icon             = 'mods/species/bayliens/unathi/icons/tail.dmi'
 	tail_animation_states = 9
+
+/obj/item/organ/external/tail/lizard/get_natural_attacks()
+	var/static/unarmed_attack = GET_DECL(/decl/natural_attack/tail)
+	return unarmed_attack

--- a/mods/species/drakes/species.dm
+++ b/mods/species/drakes/species.dm
@@ -20,10 +20,7 @@
 		/decl/pronouns/male,
 		/decl/pronouns/female
 	)
-	unarmed_attacks = list(
-		/decl/natural_attack/bite/sharp/drake,
-		/decl/natural_attack/claws/strong/drake
-	)
+
 	available_background_info = list(
 		/decl/background_category/heritage   = list(/decl/background_detail/heritage/grafadreka),
 		/decl/background_category/homeworld = list(/decl/background_detail/location/grafadreka),

--- a/mods/species/drakes/species_bodytypes.dm
+++ b/mods/species/drakes/species_bodytypes.dm
@@ -38,7 +38,8 @@
 	override_limb_types  = list(
 		BP_TAIL   = /obj/item/organ/external/tail/grafadreka,
 		BP_L_HAND = /obj/item/organ/external/hand/quadruped/grafadreka,
-		BP_R_HAND = /obj/item/organ/external/hand/right/quadruped/grafadreka
+		BP_R_HAND = /obj/item/organ/external/hand/right/quadruped/grafadreka,
+		BP_HEAD   = /obj/item/organ/external/head/grafadreka
 	)
 	base_color           = "#608894"
 	base_eye_color       = COLOR_SILVER
@@ -307,6 +308,10 @@
 	_base_attack_force = 8
 	needs_attack_dexterity = DEXTERITY_NONE
 
+/obj/item/organ/external/hand/quadruped/grafadreka/get_natural_attacks()
+	var/static/unarmed_attack = GET_DECL(/decl/natural_attack/claws/strong/drake)
+	return unarmed_attack
+
 /obj/item/organ/external/hand/quadruped/grafadreka/Initialize(mapload, material_key, datum/mob_snapshot/supplied_appearance, decl/bodytype/new_bodytype)
 	. = ..()
 	item_flags |= ITEM_FLAG_NO_BLUDGEON
@@ -323,6 +328,10 @@
 	_base_attack_force = 8
 	needs_attack_dexterity = DEXTERITY_NONE
 
+/obj/item/organ/external/hand/right/quadruped/grafadreka/get_natural_attacks()
+	var/static/unarmed_attack = GET_DECL(/decl/natural_attack/claws/strong/drake)
+	return unarmed_attack
+
 /obj/item/organ/external/hand/right/quadruped/grafadreka/Initialize(mapload, material_key, datum/mob_snapshot/supplied_appearance, decl/bodytype/new_bodytype)
 	. = ..()
 	item_flags |= ITEM_FLAG_NO_BLUDGEON
@@ -334,3 +343,7 @@
 /obj/item/organ/external/hand/right/quadruped/grafadreka/set_bodytype(decl/bodytype/new_bodytype, override_material, apply_to_internal_organs)
 	override_material = /decl/material/solid/organic/bone
 	. = ..()
+
+/obj/item/organ/external/head/grafadreka/get_natural_attacks()
+	var/static/unarmed_attack = GET_DECL(/decl/natural_attack/bite/sharp/drake)
+	return unarmed_attack

--- a/mods/species/drakes/species_bodytypes.dm
+++ b/mods/species/drakes/species_bodytypes.dm
@@ -39,7 +39,7 @@
 		BP_TAIL   = /obj/item/organ/external/tail/grafadreka,
 		BP_L_HAND = /obj/item/organ/external/hand/quadruped/grafadreka,
 		BP_R_HAND = /obj/item/organ/external/hand/right/quadruped/grafadreka,
-		BP_HEAD   = /obj/item/organ/external/head/grafadreka
+		BP_HEAD   = /obj/item/organ/external/head/gripper/grafadreka
 	)
 	base_color           = "#608894"
 	base_eye_color       = COLOR_SILVER
@@ -203,9 +203,14 @@
 		/datum/ability_handler/predator/grafadreka/hatchling
 	)
 	z_flags             = 0
+	// TODO: weaker attack subtypes for the baby
 	override_limb_types = list(
-		BP_TAIL = /obj/item/organ/external/tail/grafadreka/hatchling
+		BP_TAIL   = /obj/item/organ/external/tail/grafadreka/hatchling,
+		BP_L_HAND = /obj/item/organ/external/hand/quadruped/grafadreka,
+		BP_R_HAND = /obj/item/organ/external/hand/right/quadruped/grafadreka,
+		BP_HEAD   = /obj/item/organ/external/head/gripper/grafadreka
 	)
+
 	default_emotes      = list(
 		/decl/emote/audible/drake_hatchling_growl,
 		/decl/emote/audible/drake_hatchling_whine,
@@ -344,6 +349,6 @@
 	override_material = /decl/material/solid/organic/bone
 	. = ..()
 
-/obj/item/organ/external/head/grafadreka/get_natural_attacks()
+/obj/item/organ/external/head/gripper/grafadreka/get_natural_attacks()
 	var/static/unarmed_attack = GET_DECL(/decl/natural_attack/bite/sharp/drake)
 	return unarmed_attack

--- a/mods/species/neoavians/datum/species.dm
+++ b/mods/species/neoavians/datum/species.dm
@@ -52,12 +52,6 @@
 	swap_flags = MONKEY|SIMPLE_ANIMAL
 	push_flags = MONKEY|SIMPLE_ANIMAL
 
-	unarmed_attacks = list(
-		/decl/natural_attack/bite/sharp,
-		/decl/natural_attack/claws,
-		/decl/natural_attack/stomp/weak
-	)
-
 	available_background_info = list(
 		/decl/background_category/heritage = list(
 			/decl/background_detail/heritage/neoavian,

--- a/mods/species/neoavians/datum/species_bodytypes.dm
+++ b/mods/species/neoavians/datum/species_bodytypes.dm
@@ -39,6 +39,13 @@
 	base_eye_color       = "#f5c842"
 	mob_size             = MOB_SIZE_SMALL
 	nail_noun            = "talons"
+	override_limb_types  = list(
+		BP_L_FOOT = /obj/item/organ/external/foot/avian,
+		BP_R_FOOT = /obj/item/organ/external/foot/right/avian,
+		BP_L_HAND = /obj/item/organ/external/hand/clawed,
+		BP_R_HAND = /obj/item/organ/external/hand/right/clawed,
+		BP_HEAD   = /obj/item/organ/external/head/sharp_bite
+	)
 	has_organ            = list(
 		BP_STOMACH = /obj/item/organ/internal/stomach,
 		BP_HEART   = /obj/item/organ/internal/heart,
@@ -169,6 +176,14 @@
 		)
 	)
 	. = ..()
+
+/obj/item/organ/external/foot/avian/get_natural_attacks()
+	var/static/unarmed_attack = GET_DECL(/decl/natural_attack/stomp/weak)
+	return unarmed_attack
+
+/obj/item/organ/external/foot/right/avian/get_natural_attacks()
+	var/static/unarmed_attack = GET_DECL(/decl/natural_attack/stomp/weak)
+	return unarmed_attack
 
 /obj/item/organ/external/tail/avian/get_tail()
 	if(istype(bodytype, /decl/bodytype/avian))

--- a/mods/species/serpentid/datum/species.dm
+++ b/mods/species/serpentid/datum/species.dm
@@ -60,8 +60,6 @@
 	swap_flags = ALLMOBS
 	move_trail = /obj/effect/decal/cleanable/blood/tracks/snake
 
-	unarmed_attacks = list(/decl/natural_attack/forelimb_slash)
-
 	pain_emotes_with_pain_level = list(
 			list(/decl/emote/audible/bug_hiss) = 40
 	)
@@ -100,12 +98,6 @@
 			return TRUE
 
 	return FALSE
-
-/decl/species/serpentid/can_shred(var/mob/living/human/H, var/ignore_intent, var/ignore_antag)
-	if(!H.get_equipped_item(slot_handcuffed_str) || H.buckled)
-		return ..(H, ignore_intent, TRUE)
-	else
-		return 0
 
 /decl/species/serpentid/handle_movement_delay_special(var/mob/living/human/victim)
 	var/tally = 0

--- a/mods/species/serpentid/datum/species_bodytypes.dm
+++ b/mods/species/serpentid/datum/species_bodytypes.dm
@@ -34,15 +34,16 @@
 		BP_HEAD         = list("path" = /obj/item/organ/external/head/insectoid/serpentid),
 		BP_L_ARM        = list("path" = /obj/item/organ/external/arm/insectoid),
 		BP_L_HAND       = list("path" = /obj/item/organ/external/hand/insectoid),
-		BP_L_HAND_UPPER = list("path" = /obj/item/organ/external/hand/insectoid/upper),
+		BP_L_HAND_UPPER = list("path" = /obj/item/organ/external/hand/insectoid/upper/serpentid),
 		BP_R_ARM        = list("path" = /obj/item/organ/external/arm/right/insectoid),
 		BP_R_HAND       = list("path" = /obj/item/organ/external/hand/right/insectoid),
-		BP_R_HAND_UPPER = list("path" = /obj/item/organ/external/hand/right/insectoid/upper),
+		BP_R_HAND_UPPER = list("path" = /obj/item/organ/external/hand/right/insectoid/upper/serpentid),
 		BP_R_LEG        = list("path" = /obj/item/organ/external/leg/right/insectoid/serpentid),
 		BP_L_LEG        = list("path" = /obj/item/organ/external/leg/insectoid/serpentid),
 		BP_L_FOOT       = list("path" = /obj/item/organ/external/foot/insectoid/serpentid),
 		BP_R_FOOT       = list("path" = /obj/item/organ/external/foot/right/insectoid/serpentid)
 	)
+
 	appearance_descriptors = list(
 		/datum/appearance_descriptor/height =      1.75,
 		/datum/appearance_descriptor/body_length = 1
@@ -122,3 +123,11 @@
 	name = "green"
 	icon_base = 'mods/species/serpentid/icons/body_green.dmi'
 	uid = "bodytype_serpentid_green"
+
+/obj/item/organ/external/hand/insectoid/upper/serpentid/get_natural_attacks()
+	var/static/unarmed_attack = GET_DECL(/decl/natural_attack/forelimb_slash)
+	return unarmed_attack
+
+/obj/item/organ/external/hand/right/insectoid/upper/serpentid/get_natural_attacks()
+	var/static/unarmed_attack = GET_DECL(/decl/natural_attack/forelimb_slash)
+	return unarmed_attack

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -30,11 +30,6 @@
 
 	preview_outfit = null
 
-	unarmed_attacks = list(
-		/decl/natural_attack/stomp,
-		/decl/natural_attack/kick,
-		/decl/natural_attack/punch
-	)
 	available_pronouns = list(
 		/decl/pronouns,
 		/decl/pronouns/neuter

--- a/mods/species/vox/datum/species.dm
+++ b/mods/species/vox/datum/species.dm
@@ -32,14 +32,6 @@
 		/mob/living/human/proc/toggle_vox_pressure_seal
 	)
 
-	unarmed_attacks = list(
-		/decl/natural_attack/stomp,
-		/decl/natural_attack/kick,
-		/decl/natural_attack/claws/strong/gloves,
-		/decl/natural_attack/punch,
-		/decl/natural_attack/bite/strong
-	)
-
 	rarity_value = 4
 
 	description = {"The Vox are the broken remnants of a once-proud race, now reduced to little more

--- a/mods/species/vox/datum/species_bodytypes.dm
+++ b/mods/species/vox/datum/species_bodytypes.dm
@@ -30,9 +30,13 @@
 		BP_BRAIN
 	)
 	override_limb_types = list(
-		BP_GROIN = /obj/item/organ/external/groin/vox,
-		BP_TAIL = /obj/item/organ/external/tail/vox
+		BP_GROIN  = /obj/item/organ/external/groin/vox,
+		BP_TAIL   = /obj/item/organ/external/tail/vox,
+		BP_L_HAND = /obj/item/organ/external/hand/vox,
+		BP_R_HAND = /obj/item/organ/external/hand/right/vox,
+		BP_HEAD   = /obj/item/organ/external/head/strong_bite
 	)
+
 	has_organ = list(
 		BP_STOMACH    = /obj/item/organ/internal/stomach/vox,
 		BP_HEART      = /obj/item/organ/internal/heart/vox,
@@ -172,3 +176,11 @@
 
 /obj/item/organ/external/tail/vox/stanchion
 	tail_icon  = 'mods/species/vox/icons/body/stanchion/body.dmi'
+
+/obj/item/organ/external/hand/vox/get_natural_attacks()
+	var/static/unarmed_attack = GET_DECL(/decl/natural_attack/claws/strong/gloves)
+	return unarmed_attack
+
+/obj/item/organ/external/hand/right/vox/get_natural_attacks()
+	var/static/unarmed_attack = GET_DECL(/decl/natural_attack/claws/strong/gloves)
+	return unarmed_attack


### PR DESCRIPTION
## Description of changes
- Removes species and limb unarmed_attacks list.
- Adds a proc on limbs that retrieves static lists of unarmed attacks.
- Changes bodytypes to refer to the new organ types.

## Why and what will this PR improve
Simplifies unarmed attack grabbing, cleans it up a bit.

## Authorship
Myself.

## Changelog
Nothing player-facing.