### PR TITLE
Attack dexterity is bypassed for items in rigs.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -26,6 +26,8 @@ avoid code duplication. This includes items that may sometimes act as a standard
 
 // If TRUE, prevent afterattack from running.
 /obj/item/proc/resolve_attackby(atom/A, mob/user, var/click_params)
+	if(!user.check_dexterity(get_required_attack_dexterity()))
+		return TRUE
 	if(!(item_flags & ITEM_FLAG_NO_PRINT))
 		add_fingerprint(user)
 	return A.attackby(src, user, click_params)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -26,7 +26,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 
 // If TRUE, prevent afterattack from running.
 /obj/item/proc/resolve_attackby(atom/A, mob/user, var/click_params)
-	if(!user.check_dexterity(get_required_attack_dexterity()))
+	if(!user.check_dexterity(get_required_attack_dexterity(user, A)))
 		return TRUE
 	if(!(item_flags & ITEM_FLAG_NO_PRINT))
 		add_fingerprint(user)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -997,5 +997,11 @@
 /atom/proc/can_drink_from(mob/user)
 	return ATOM_IS_OPEN_CONTAINER(src) && reagents?.total_volume && user.check_has_mouth()
 
+/atom/proc/adjust_required_attack_dexterity(mob/user, required_dexterity)
+	if(storage) // TODO: possibly check can_be_inserted() to avoid being able to shoot mirrors as a drake.
+		return DEXTERITY_HOLD_ITEM
+	return required_dexterity
+
 /atom/proc/immune_to_floor_hazards()
 	return !simulated
+

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -121,12 +121,14 @@
 	var/weapon_can_knock_prone = TRUE
 
 /// Returns a dexterity value required to use this item as a weapon.
-/obj/item/proc/get_required_attack_dexterity()
+/obj/item/proc/get_required_attack_dexterity(mob/user, atom/target)
 	// We can likely assume that if we're located inside a rig, then the wearer
 	// has the appropriate dexterity to wear and use the rig, even if they aren't
 	// manually dexterous; specifically useful for things like baxxid and drakes.
 	var/obj/item/rig/rig = get_recursive_loc_of_type(/obj/item/rig)
-	return istype(rig) ? DEXTERITY_NONE : needs_attack_dexterity
+	. = istype(rig) ? DEXTERITY_NONE : needs_attack_dexterity
+	if(istype(target))
+		. = target.adjust_required_attack_dexterity(user, .)
 
 // Returns a dexterity value required to interact with this item at all, such as picking it up.
 /obj/item/get_required_interaction_dexterity()
@@ -582,8 +584,8 @@
 		return TRUE
 	return FALSE
 
-/obj/item/proc/user_can_attack_with(mob/user, silent = FALSE)
-	return user.check_dexterity(get_required_attack_dexterity(), silent = silent)
+/obj/item/proc/user_can_attack_with(mob/user, atom/target, silent = FALSE)
+	return user.check_dexterity(get_required_attack_dexterity(user, target), silent = silent)
 
 /obj/item/attackby(obj/item/used_item, mob/user)
 	// if can_wield is false we still need to call parent for storage objects to work properly

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -120,6 +120,18 @@
 	/// Can this item knock someone out if used as a weapon? Overridden for natural weapons as a nerf to simplemobs.
 	var/weapon_can_knock_prone = TRUE
 
+/// Returns a dexterity value required to use this item as a weapon.
+/obj/item/proc/get_required_attack_dexterity()
+	// We can likely assume that if we're located inside a rig, then the wearer
+	// has the appropriate dexterity to wear and use the rig, even if they aren't
+	// manually dexterous; specifically useful for things like baxxid and drakes.
+	var/obj/item/rig/rig = get_recursive_loc_of_type(/obj/item/rig)
+	return istype(rig) ? DEXTERITY_NONE : needs_attack_dexterity
+
+// Returns a dexterity value required to interact with this item at all, such as picking it up.
+/obj/item/get_required_interaction_dexterity()
+	return needs_interaction_dexterity
+
 /obj/item/get_color()
 	if(paint_color)
 		return paint_color
@@ -571,11 +583,11 @@
 	return FALSE
 
 /obj/item/proc/user_can_attack_with(mob/user, silent = FALSE)
-	return !needs_attack_dexterity || user.check_dexterity(needs_attack_dexterity, silent = silent)
+	return user.check_dexterity(get_required_attack_dexterity(), silent = silent)
 
 /obj/item/attackby(obj/item/used_item, mob/user)
 	// if can_wield is false we still need to call parent for storage objects to work properly
-	var/can_wield = user_can_attack_with(user, silent = TRUE)
+	var/can_wield = used_item.user_can_attack_with(user, silent = TRUE)
 
 	if(can_wield && try_slapcrafting(used_item, user))
 		return TRUE

--- a/code/game/objects/structures/racks.dm
+++ b/code/game/objects/structures/racks.dm
@@ -29,6 +29,12 @@
 			I.pixel_y = max(3-i*3, -3) + 1
 			I.pixel_z = 0
 
+/obj/structure/rack/adjust_required_attack_dexterity(mob/user, required_dexterity)
+	// Let people put stuff on tables without necessarily being able to use a gun or such.
+	if(user?.check_intent(I_FLAG_HELP))
+		return DEXTERITY_HOLD_ITEM
+	return ..()
+
 /obj/structure/rack/attackby(obj/item/O, mob/user, click_params)
 	. = ..()
 	if(!. && !isrobot(user) && O.loc == user && user.try_unequip(O, loc))

--- a/code/game/objects/structures/tables.dm
+++ b/code/game/objects/structures/tables.dm
@@ -41,12 +41,6 @@
 /obj/structure/table/should_have_alpha_mask()
 	return simulated && isturf(loc) && !(locate(/obj/structure/table) in get_step(loc, SOUTH))
 
-/obj/structure/table/clear_connections()
-	connections = null
-
-/obj/structure/table/set_connections(dirs, other_dirs)
-	connections = dirs_to_corner_states(dirs)
-
 /obj/structure/table/Initialize()
 	if(ispath(additional_reinf_material, /decl/material))
 		additional_reinf_material = GET_DECL(additional_reinf_material)
@@ -68,6 +62,29 @@
 	else
 		update_connections(TRUE)
 		update_icon()
+
+/obj/structure/table/Destroy()
+	var/turf/oldloc = loc
+	additional_reinf_material = null
+	. = ..()
+	if(istype(oldloc))
+		for(var/obj/structure/table/table in range(oldloc, 1))
+			if(QDELETED(table))
+				continue
+			table.update_connections(FALSE)
+			table.update_icon()
+
+/obj/structure/table/adjust_required_attack_dexterity(mob/user, required_dexterity)
+	// Let people put stuff on tables without necessarily being able to use a gun or such.
+	if(user?.check_intent(I_FLAG_HELP))
+		return DEXTERITY_HOLD_ITEM
+	return ..()
+
+/obj/structure/table/clear_connections()
+	connections = null
+
+/obj/structure/table/set_connections(dirs, other_dirs)
+	connections = dirs_to_corner_states(dirs)
 
 /obj/structure/table/get_material_health_modifier()
 	. = additional_reinf_material ? 0.75 : 0.5
@@ -105,17 +122,6 @@
 	..()
 	felted = FALSE
 	additional_reinf_material = null
-
-/obj/structure/table/Destroy()
-	var/turf/oldloc = loc
-	additional_reinf_material = null
-	. = ..()
-	if(istype(oldloc))
-		for(var/obj/structure/table/table in range(oldloc, 1))
-			if(QDELETED(table))
-				continue
-			table.update_connections(FALSE)
-			table.update_icon()
 
 /obj/structure/table/can_dismantle(mob/user)
 	. = ..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1945,11 +1945,12 @@ default behaviour is:
 		var/datum/inventory_slot/gripper/slot = get_inventory_slot_datum(empty_hand)
 		if(!istype(slot))
 			continue
+		var/req_item_dex = item.get_required_attack_dexterity()
 		if(slot.requires_organ_tag)
 			var/obj/item/organ/external/hand = GET_EXTERNAL_ORGAN(src, slot.requires_organ_tag)
-			if(istype(hand) && hand.is_usable() && (!item.needs_attack_dexterity || hand.get_manual_dexterity() >= item.needs_attack_dexterity))
+			if(istype(hand) && hand.is_usable() && (!req_item_dex || hand.get_manual_dexterity() >= req_item_dex))
 				return TRUE
-		else if(!item.needs_attack_dexterity || slot.dexterity >= item.needs_attack_dexterity)
+		else if(!req_item_dex || slot.dexterity >= req_item_dex)
 			return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1945,7 +1945,7 @@ default behaviour is:
 		var/datum/inventory_slot/gripper/slot = get_inventory_slot_datum(empty_hand)
 		if(!istype(slot))
 			continue
-		var/req_item_dex = item.get_required_attack_dexterity()
+		var/req_item_dex = item.get_required_attack_dexterity(src)
 		if(slot.requires_organ_tag)
 			var/obj/item/organ/external/hand = GET_EXTERNAL_ORGAN(src, slot.requires_organ_tag)
 			if(istype(hand) && hand.is_usable() && (!req_item_dex || hand.get_manual_dexterity() >= req_item_dex))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -196,7 +196,7 @@
 	if(!isliving(user))
 		return FALSE
 
-	if(!user.check_dexterity(get_required_attack_dexterity()))
+	if(!user.check_dexterity(get_required_attack_dexterity(user)))
 		return FALSE
 
 	if(is_secure_gun() && !free_fire() && (!authorized_modes[sel_mode] || !registered_owner))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -45,6 +45,7 @@
 	drop_sound = 'sound/foley/drop1.ogg'
 	pickup_sound = 'sound/foley/pickup2.ogg'
 	can_be_twohanded = TRUE // also checks one_hand_penalty
+	needs_attack_dexterity = DEXTERITY_WEAPONS
 
 	var/fire_verb = "fire"
 	var/waterproof = FALSE
@@ -193,15 +194,20 @@
 /obj/item/gun/proc/special_check(var/mob/user)
 
 	if(!isliving(user))
-		return 0
-	if(!user.check_dexterity(DEXTERITY_WEAPONS))
-		return 0
+		return FALSE
+
+	if(!user.check_dexterity(get_required_attack_dexterity()))
+		return FALSE
+
+	if(is_secure_gun() && !free_fire() && (!authorized_modes[sel_mode] || !registered_owner))
+		audible_message(SPAN_WARNING("\The [src] buzzes, refusing to fire."), hearing_distance = 3)
+		playsound(loc, 'sound/machines/buzz-sigh.ogg', 10, 0)
+		return FALSE
 
 	var/mob/living/M = user
 	if(!safety() && world.time > last_safety_check + 5 MINUTES && !user.skill_check(SKILL_WEAPONS, SKILL_BASIC))
 		if(prob(30))
 			toggle_safety()
-			return 1
 
 	if(M.has_genetic_condition(GENE_COND_CLUMSY) && prob(40)) //Clumsy handling
 		var/obj/P = consume_next_projectile()
@@ -218,8 +224,9 @@
 				M.try_unequip(src)
 		else
 			handle_click_empty(user)
-		return 0
-	return 1
+		return FALSE
+
+	return TRUE
 
 /obj/item/gun/emp_act(severity)
 	for(var/obj/O in contents)

--- a/code/modules/projectiles/secure.dm
+++ b/code/modules/projectiles/secure.dm
@@ -99,14 +99,6 @@
 	var/decl/security_state/security_state = GET_DECL(global.using_map.security_state)
 	return security_state.current_security_level_is_same_or_higher_than(security_state.high_security_level)
 
-/obj/item/gun/special_check()
-	if(is_secure_gun() && !free_fire() && (!authorized_modes[sel_mode] || !registered_owner))
-		audible_message(SPAN_WARNING("\The [src] buzzes, refusing to fire."), hearing_distance = 3)
-		playsound(loc, 'sound/machines/buzz-sigh.ogg', 10, 0)
-		return 0
-
-	. = ..()
-
 /obj/item/gun/get_next_firemode()
 	if(!is_secure_gun())
 		return ..()


### PR DESCRIPTION
## Description of changes
- Adds a getter for required attack dexterity.
- Provides required interaction dexterity to get_required_interaction_dexterity() for items.
- Bypasses required attack dexterity checks for items in rigs.
- Removes hardcoded gun dex check from special_check() in favour of attack dexterity check.

## Why and what will this PR improve
Dex system less wonky.
Drakes can use back-mounted machine guns in the future.

## Authorship
@Ofpelh found the issue, I just authored an alternative fix. 

## Changelog
:cl:
tweak: Guns can now be fired from rigs regardless of dexterity.
/:cl: