### PR TITLE
Adding floor hazard checks to slipping, lava and bear traps.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -997,3 +997,6 @@
 
 /atom/proc/can_drink_from(mob/user)
 	return ATOM_IS_OPEN_CONTAINER(src) && reagents?.total_volume && user.check_has_mouth()
+
+/atom/proc/immune_to_floor_hazards()
+	return !simulated || throwing

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -999,4 +999,4 @@
 	return ATOM_IS_OPEN_CONTAINER(src) && reagents?.total_volume && user.check_has_mouth()
 
 /atom/proc/immune_to_floor_hazards()
-	return !simulated || throwing
+	return !simulated

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -585,3 +585,6 @@
 	if(ATOM_IS_OPEN_CONTAINER(src))
 		return loc?.take_vaporized_reagent(reagent, amount)
 	return null
+
+/atom/movable/immune_to_floor_hazards()
+	return ..() || throwing

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -90,31 +90,33 @@
 	if(!isliving(AM))
 		return
 
-	var/mob/living/M = AM
-	if(M.buckled) //wheelchairs, office chairs, rollerbeds
+	var/mob/living/victim = AM
+	if(victim.buckled) //wheelchairs, office chairs, rollerbeds
+		return
+	if(victim.immune_to_floor_hazards())
 		return
 
 	playsound(src.loc, 'sound/effects/glass_step.ogg', 50, 1) // not sure how to handle metal shards with sounds
 
-	var/decl/species/walker_species = M.get_species()
-	if(walker_species && (walker_species.get_shock_vulnerability(M) < 0.5 || (walker_species.species_flags & (SPECIES_FLAG_NO_EMBED|SPECIES_FLAG_NO_MINOR_CUT)))) //Thick skin.
+	var/decl/species/walker_species = victim.get_species()
+	if(walker_species && (walker_species.get_shock_vulnerability(victim) < 0.5 || (walker_species.species_flags & (SPECIES_FLAG_NO_EMBED|SPECIES_FLAG_NO_MINOR_CUT)))) //Thick skin.
 		return
 
-	var/obj/item/shoes = M.get_equipped_item(slot_shoes_str)
-	var/obj/item/suit = M.get_equipped_item(slot_wear_suit_str)
+	var/obj/item/shoes = victim.get_equipped_item(slot_shoes_str)
+	var/obj/item/suit = victim.get_equipped_item(slot_wear_suit_str)
 	if(shoes || (suit && (suit.body_parts_covered & SLOT_FEET)))
 		return
 
 	var/list/check = list(BP_L_FOOT, BP_R_FOOT)
 	while(check.len)
 		var/picked = pick_n_take(check)
-		var/obj/item/organ/external/affecting = GET_EXTERNAL_ORGAN(M, picked)
+		var/obj/item/organ/external/affecting = GET_EXTERNAL_ORGAN(victim, picked)
 		if(!affecting || BP_IS_PROSTHETIC(affecting))
 			continue
-		to_chat(M, SPAN_DANGER("You step on \the [src]!"))
+		to_chat(victim, SPAN_DANGER("You step on \the [src]!"))
 		affecting.take_external_damage(5, 0)
 		if(affecting.can_feel_pain())
-			SET_STATUS_MAX(M, STAT_WEAK, 3)
+			SET_STATUS_MAX(victim, STAT_WEAK, 3)
 		return
 
 //Prevent the shard from being allowed to shatter

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -57,10 +57,10 @@
 	add_to_reagents(/decl/material/liquid/cleaner/soap, SOAP_CLEANER_ON_WET)
 
 /obj/item/soap/Crossed(atom/movable/AM)
-	if(!isliving(AM))
-		return
-	var/mob/living/M = AM
-	M.slip("\the [src]", 3)
+	var/mob/living/victim = AM
+	if(istype(victim))
+		victim.slip("\the [src]", 3)
+	return ..()
 
 /obj/item/soap/afterattack(atom/target, mob/user, proximity)
 	if(!proximity) return

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -1,17 +1,17 @@
 /obj/item/beartrap
-	name = "mechanical trap"
-	throw_speed = 2
-	throw_range = 1
-	gender = PLURAL
-	icon = 'icons/obj/items/beartrap.dmi'
-	icon_state = "beartrap0"
-	randpixel = 0
-	desc = "A mechanically activated leg trap. Low-tech, but reliable. Looks like it could really hurt if you set it off."
-	w_class = ITEM_SIZE_NORMAL
-	origin_tech = @'{"materials":1}'
-	material = /decl/material/solid/metal/steel
-	can_buckle = 0 //disallow manual un/buckling
-	var/deployed = 0
+	name         = "mechanical trap"
+	desc         = "A mechanically activated leg trap. Low-tech, but reliable. Looks like it could really hurt if you set it off."
+	throw_speed  = 2
+	throw_range  = 1
+	gender       = PLURAL
+	icon         = 'icons/obj/items/beartrap.dmi'
+	icon_state   = "beartrap0"
+	randpixel    = 0
+	w_class      = ITEM_SIZE_NORMAL
+	origin_tech  = @'{"materials":1}'
+	material     = /decl/material/solid/metal/steel
+	can_buckle   = FALSE //disallow manual un/buckling
+	var/deployed = FALSE
 
 /obj/item/beartrap/proc/can_use(mob/user)
 	. = (user.check_dexterity(DEXTERITY_SIMPLE_MACHINES) && !issilicon(user) && !user.stat && !user.restrained())
@@ -19,12 +19,12 @@
 /obj/item/beartrap/user_unbuckle_mob(mob/user)
 	if(buckled_mob && can_use(user))
 		user.visible_message(
-			"<span class='notice'>\The [user] begins freeing \the [buckled_mob] from \the [src].</span>",
-			"<span class='notice'>You carefully begin to free \the [buckled_mob] from \the [src].</span>",
-			"<span class='notice'>You hear metal creaking.</span>"
+			SPAN_NOTICE("\The [user] begins freeing \the [buckled_mob] from \the [src]."),
+			SPAN_NOTICE("You carefully begin to free \the [buckled_mob] from \the [src]."),
+			SPAN_NOTICE("You hear metal creaking.")
 			)
 		if(do_after(user, 60, src))
-			user.visible_message("<span class='notice'>\The [buckled_mob] has been freed from \the [src] by \the [user].</span>")
+			user.visible_message(SPAN_NOTICE("\The [buckled_mob] has been freed from \the [src] by \the [user]."))
 			unbuckle_mob()
 			anchored = FALSE
 
@@ -32,19 +32,18 @@
 	..()
 	if(!deployed && can_use(user))
 		user.visible_message(
-			"<span class='danger'>[user] starts to deploy \the [src].</span>",
-			"<span class='danger'>You begin deploying \the [src]!</span>",
+			SPAN_DANGER("\The [user] starts to deploy \the [src]."),
+			SPAN_DANGER("You begin deploying \the [src]!"),
 			"You hear the slow creaking of a spring."
-			)
+		)
 
-		if (do_after(user, 60, src) && user.try_unequip(src))
+		if (do_after(user, 6 SECONDS, src) && user.try_unequip(src))
 			user.visible_message(
-				"<span class='danger'>\The [user] has deployed \the [src].</span>",
-				"<span class='danger'>You have deployed \the [src]!</span>",
+				SPAN_DANGER("\The [user] has deployed \the [src]."),
+				SPAN_DANGER("You have deployed \the [src]!"),
 				"You hear a latch click loudly."
-				)
-
-			deployed = 1
+			)
+			deployed = TRUE
 			update_icon()
 			anchored = TRUE
 
@@ -55,7 +54,7 @@
 		user_unbuckle_mob(user)
 		return TRUE
 	if(!deployed || !can_use(user))
-		return FALSE
+		return ..()
 	user.visible_message(
 		SPAN_DANGER("\The [user] starts to disarm \the [src]."),
 		SPAN_NOTICE("You begin disarming \the [src]!"),
@@ -71,40 +70,45 @@
 		update_icon()
 	return TRUE
 
-/obj/item/beartrap/proc/attack_mob(mob/L)
+/obj/item/beartrap/proc/attack_mob(mob/victim)
+
+	if(victim.immune_to_floor_hazards())
+		return FALSE
 
 	var/target_zone
-	if(L.current_posture.prone)
+	if(victim.current_posture.prone)
 		target_zone = ran_zone()
 	else
 		target_zone = pick(BP_L_FOOT, BP_R_FOOT, BP_L_LEG, BP_R_LEG)
 
-	if(!L.apply_damage(30, BRUTE, target_zone, used_weapon=src))
-		return 0
+	if(!victim.apply_damage(30, BRUTE, target_zone, used_weapon=src))
+		return FALSE
 
 	//trap the victim in place
-	set_dir(L.dir)
-	buckle_mob(L)
-	to_chat(L, "<span class='danger'>The steel jaws of \the [src] bite into you, trapping you in place!</span>")
-	deployed = 0
+	set_dir(victim.dir)
+	buckle_mob(victim)
+	to_chat(victim, SPAN_DANGER("The steel jaws of \the [src] bite into you, trapping you in place!"))
+	deployed = FALSE
+	return TRUE
 
 /obj/item/beartrap/Crossed(atom/movable/AM)
 	..()
 	if(!deployed || !isliving(AM))
 		return
-	var/mob/living/L = AM
-	if(MOVING_DELIBERATELY(L))
+	var/mob/living/victim = AM
+	if(MOVING_DELIBERATELY(victim) || victim.immune_to_floor_hazards())
 		return
-	L.visible_message(
-		SPAN_DANGER("\The [L] steps on \the [src]."),
+	victim.visible_message(
+		SPAN_DANGER("\The [victim] steps on \the [src]."),
 		SPAN_DANGER("You step on \the [src]!"),
-		"<b>You hear a loud metallic snap!</b>")
-	attack_mob(L)
+		"<b>You hear a loud metallic snap!</b>"
+	)
+	attack_mob(victim)
 	if(!buckled_mob)
 		anchored = FALSE
-	deployed = 0
+	deployed = FALSE
 	update_icon()
 
 /obj/item/beartrap/on_update_icon()
 	. = ..()
-	icon_state = "beartrap[deployed == TRUE]"
+	icon_state = "beartrap[deployed]"

--- a/code/game/turfs/flooring/flooring_lava.dm
+++ b/code/game/turfs/flooring/flooring_lava.dm
@@ -18,7 +18,7 @@
 	var/datum/gas_mixture/environment = target.return_air()
 	var/pressure = environment?.return_pressure()
 	for(var/atom/movable/AM as anything in target.get_contained_external_atoms())
-		if(!AM.is_burnable())
+		if(!AM.is_burnable() || AM.immune_to_floor_hazards())
 			continue
 		. = null
 		if(isliving(AM))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -694,7 +694,14 @@ default behaviour is:
 /mob/living/proc/has_brain()
 	return TRUE
 
-/mob/living/proc/slip(var/slipped_on, stun_duration = 8)
+// We are jumping, levitating or being thrown.
+/mob/living/immune_to_floor_hazards()
+	. = ..() || is_floating
+
+/mob/living/proc/slip(slipped_on, stun_duration = 8)
+
+	if(immune_to_floor_hazards())
+		return FALSE
 
 	var/decl/species/my_species = get_species()
 	if(my_species?.check_no_slip(src))

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -91,9 +91,6 @@
 	if(!has_gravity())
 		return
 
-	if(throwing)
-		return
-
 	if(can_fall())
 		begin_falling(lastloc, below)
 
@@ -115,7 +112,7 @@
 
 //For children to override
 /atom/movable/proc/can_fall(var/anchor_bypass = FALSE, var/turf/location_override = loc)
-	if(!simulated)
+	if(immune_to_floor_hazards())
 		return FALSE
 
 	if(anchored && !anchor_bypass)


### PR DESCRIPTION
## Description of changes
- You can jump/levitate over lava, soap, wet floors, and bear traps.
- Bear traps can be picked up.
- Fixes https://github.com/ScavStation/ScavStation/issues/1196

## Why and what will this PR improve
Soap and wet floors are no longer inescapable facts of life.

## Authorship
Myself.

## Changelog
:cl:
tweak: Leaping will now bypass lava, wet floors, soap, and bear traps.
/:cl: