### PR TITLE
Fix lighting overlays being created multiple times per turf

### DIFF
--- a/code/controllers/subsystems/ambience.dm
+++ b/code/controllers/subsystems/ambience.dm
@@ -33,6 +33,14 @@ SUBSYSTEM_DEF(ambience)
 	/// Whether this turf has been queued for an ambient lighting update.
 	var/ambience_queued = FALSE
 
+/turf/proc/shows_outdoor_ambience()
+	return is_outside()
+
+// Starlight can't be blocked by stuff above a space turf.
+// TODO: decide if open sky deserves the same treatment
+/turf/space/shows_outdoor_ambience()
+	return TRUE
+
 /turf/proc/update_ambient_light_from_z_or_area()
 
 	// If we're not outside, we don't show ambient light.
@@ -40,7 +48,7 @@ SUBSYSTEM_DEF(ambience)
 
 	var/ambient_light_modifier
 	// If we're indoors because of our area, OR we're outdoors and not exposed to the weather, get interior ambience.
-	var/outsideness = is_outside()
+	var/outsideness = shows_outdoor_ambience()
 	if((!outsideness && is_outside == OUTSIDE_AREA) || (outsideness && get_weather_exposure() != WEATHER_EXPOSED))
 		var/area/A = get_area(src)
 		if(isnull(A?.interior_ambient_light_modifier))

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -140,7 +140,7 @@
 	if ((old_opacity != opacity) || (tidlu != old_dynamic_lighting) || force_lighting_update)
 		reconsider_lights()
 
-	if (tidlu != old_dynamic_lighting)
+	if (tidlu != old_dynamic_lighting && SSlighting.initialized) // don't fuck with lighting before lighting flush
 		if (tidlu)
 			lighting_build_overlay()
 		else

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -126,8 +126,7 @@
 // Builds a lighting overlay for us, but only if our area is dynamic.
 /turf/proc/lighting_build_overlay(now = FALSE)
 	if (lighting_overlay)
-		return	// shrug
-		// CRASH("Attempted to create lighting_overlay on tile that already had one.")
+		CRASH("Attempted to create lighting_overlay on tile that already had one.")
 
 	if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(src))
 		if (!lighting_corners_initialised || !corners)

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -65,27 +65,17 @@
 		return
 
 	// Unlit turfs will have corners if they have a lit neighbor -- don't generate corners for them, but do update them if they're there.
-	// if (!corners)
-	// 	var/force_build_corners = FALSE
-	// 	for (var/turf/T as anything in RANGE_TURFS(src, 1))
-	// 		if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
-	// 			force_build_corners = TRUE
-	// 			break
+	if (!corners)
+		var/force_build_corners = FALSE
+		for (var/turf/T as anything in RANGE_TURFS(src, 1))
+			if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+				force_build_corners = TRUE
+				break
 
-	// 	if (force_build_corners || TURF_IS_DYNAMICALLY_LIT_UNSAFE(src))
-	// 		generate_missing_corners()
-	// 	else
-	// 		return
-
-	// still inefficient :(
-	if(!corners || !lighting_corners_initialised)
-		/* Commented out pending working out why this doesn't work properly on Neb.
-		if(TURF_IS_DYNAMICALLY_LIT_UNSAFE(src))
+		if (force_build_corners || TURF_IS_DYNAMICALLY_LIT_UNSAFE(src))
 			generate_missing_corners()
 		else
 			return
-		*/
-		generate_missing_corners()
 
 	// This list can contain nulls on things like space turfs -- they only have their neighbors' corners.
 	for (var/datum/lighting_corner/C in corners)

--- a/code/modules/maps/_map_template.dm
+++ b/code/modules/maps/_map_template.dm
@@ -185,8 +185,6 @@
 	for(var/z_index = bounds[MAP_MINZ] to bounds[MAP_MAXZ])
 		var/datum/level_data/level = SSmapping.levels_by_z[z_index]
 		level.after_template_load(src)
-		if(SSlighting.initialized)
-			SSlighting.InitializeZlev(z_index)
 	Master.StopLoadingMap()
 	log_game("Z-level [name] loaded at [x],[y],[world.maxz]")
 	loaded++
@@ -225,8 +223,6 @@
 	init_atoms(atoms_to_initialise)
 	init_shuttles(shuttle_state, map_hash, initialized_areas_by_type)
 	after_load()
-	if (SSlighting.initialized)
-		SSlighting.InitializeTurfs(atoms_to_initialise)	// Hopefully no turfs get placed on new coords by SSatoms.
 	Master.StopLoadingMap()
 
 	log_game("[name] loaded at at [T.x],[T.y],[T.z]")

--- a/code/modules/maps/reader.dm
+++ b/code/modules/maps/reader.dm
@@ -185,8 +185,6 @@ var/global/dmm_suite/preloader/_preloader = new
 							maxx = max(maxx, xcrd)
 							++xcrd
 					--ycrd
-				if (zexpansion && SSlighting.initialized)
-					SSlighting.InitializeZlev(zcrd)
 
 			bounds[MAP_MAXX] = clamp(max(bounds[MAP_MAXX], cropMap ? min(maxx, world.maxx) : maxx), x_lower, x_upper)
 

--- a/code/modules/maps/template_types/random_exoplanet/random_planet.dm
+++ b/code/modules/maps/template_types/random_exoplanet/random_planet.dm
@@ -203,9 +203,9 @@
 
 	//Run the finishing touch on all loaded levels
 	for(var/datum/level_data/LD in new_level_data)
-		LD.after_template_load(src)
-		if(SSlighting.initialized)
-			SSlighting.InitializeZlev(LD.level_z)
+		//This is done in parent if we have mappaths, so skip it unless we don't have any
+		if(!length(mappaths))
+			LD.after_template_load(src)
 		log_game("Z-level '[LD.name]'(planetoid:'[name]') loaded at [LD.level_z]")
 	loaded++
 	return WORLD_CENTER_TURF(world.maxz)


### PR DESCRIPTION
## Description of changes
Fixes unnecessary/redundant z-level initialization and inlines a method that shouldn't ever be reused elsewhere.
Also re-enables some guard code to prevent this from being reintroduced.
Finally, we *always* go through lighting_build_overlay to make overlays, rather than just using a bare `new()` in SSlighting init.

## Why and what will this PR improve
Restores some assumptions that O7L uses, potentially optimizes some parts of lighting