### PR TITLE
Fix misc. issues on staging found via optimization PR

### DIFF
--- a/code/game/turfs/walls/wall_natural.dm
+++ b/code/game/turfs/walls/wall_natural.dm
@@ -167,7 +167,7 @@
 		if(!prob(reinf_material.ore_spread_chance))
 			continue
 		var/turf/wall/natural/target_turf = get_step_resolving_mimic(src, trydir)
-		if(!istype(target_turf) || !isnull(target_turf.reinf_material))
+		if(!istype(target_turf) || !isnull(target_turf.reinf_material) || target_turf.ramp_slope_direction)
 			continue
 		target_turf.set_turf_materials(target_turf.material, reinf_material)
 		target_turf.spread_deposit()

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/barren.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/barren.dm
@@ -13,7 +13,7 @@
 
 /datum/level_data/planetoid/exoplanet/barren
 	base_area           = /area/exoplanet/barren
-	base_turf           = /turf/floor
+	base_turf           = /turf/floor/barren
 	exterior_atmosphere = null //Generate me
 	exterior_atmos_temp = null //Generate me
 	level_generators    = list(
@@ -99,7 +99,7 @@
 ///Generator for fauna and flora spawners for the surface of the barren exoplanet
 /datum/random_map/noise/exoplanet/barren
 	descriptor           = "barren exoplanet"
-	land_type            = /turf/floor
+	land_type            = /turf/floor/barren
 	flora_prob           = 0.1
 	large_flora_prob     = 0
 	fauna_prob           = 0
@@ -111,7 +111,7 @@
 
 /area/exoplanet/barren
 	name       = "\improper Planetary surface"
-	base_turf  = /turf/floor
+	base_turf  = /turf/floor/barren
 	is_outside = OUTSIDE_YES
 	ambience   = list(
 		'sound/effects/wind/wind_2_1.ogg',

--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -736,7 +736,8 @@ INITIALIZE_IMMEDIATE(/obj/abstract/level_data_spawner)
 	return ..()
 
 /datum/level_data/mining_level/asteroid
-	base_turf = /turf/floor
+	base_turf = /turf/floor/barren
+	filler_turf = /turf/space
 	level_generators = list(
 		/datum/random_map/automata/cave_system,
 		/datum/random_map/noise/ore

--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -181,7 +181,6 @@
 
 	initialize_level_id()
 	SSmapping.register_level_data(src)
-	setup_ambient()
 	setup_exterior_atmosphere()
 	if(SSmapping.initialized && !defer_level_setup)
 		setup_level_data()
@@ -233,6 +232,7 @@
 	if(!skip_gen)
 		generate_level()
 	after_generate_level()
+	setup_ambient()
 
 	// Determine our relative positioning.
 	// First find an appropriate origin point.
@@ -720,6 +720,12 @@ INITIALIZE_IMMEDIATE(/obj/abstract/level_data_spawner)
 	level_flags = (ZLEVEL_CONTACT|ZLEVEL_PLAYER|ZLEVEL_SEALED)
 	filler_turf = /turf/unsimulated/dark_filler
 
+// Used in order to avoid making the level too large. Only works if loaded prior to SSmapping init... it's unclear if this really does much.
+/datum/level_data/unit_test/after_template_load(var/datum/map_template/template)
+	. = ..()
+	level_max_width ||= template.width
+	level_max_height ||= template.height
+
 /datum/level_data/overmap
 	name = "Sensor Display"
 	level_flags = ZLEVEL_SEALED
@@ -833,9 +839,6 @@ INITIALIZE_IMMEDIATE(/obj/abstract/level_data_spawner)
 /datum/level_data/proc/load_subtemplate(turf/central_turf, datum/map_template/template)
 	if(!template)
 		return FALSE
-	for(var/turf/T in template.get_affected_turfs(central_turf, TRUE))
-		for(var/mob/living/simple_animal/monster in T)
-			qdel(monster)
 	template.load(central_turf, centered = TRUE)
 	return TRUE
 

--- a/code/modules/random_map/automata/caves.dm
+++ b/code/modules/random_map/automata/caves.dm
@@ -2,7 +2,7 @@
 	iterations = 5
 	descriptor = "moon caves"
 	wall_type =  /turf/wall/natural
-	floor_type = /turf/floor
+	floor_type = /turf/floor/barren
 	target_turf_type = /turf/unsimulated/mask
 
 	var/sparse_mineral_turf = /turf/wall/natural/random

--- a/maps/away/lost_supply_base/lost_supply_base.dmm
+++ b/maps/away/lost_supply_base/lost_supply_base.dmm
@@ -1982,7 +1982,7 @@
 /turf/unsimulated/mask,
 /area/mine/unexplored)
 "gu" = (
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "ib" = (
 /obj/structure/hygiene/sink{

--- a/maps/away/mining/mining-asteroid.dmm
+++ b/maps/away/mining/mining-asteroid.dmm
@@ -6,14 +6,14 @@
 /turf/unsimulated/mask,
 /area/mine/unexplored)
 "af" = (
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "aj" = (
 /turf/wall/r_wall,
 /area/djstation)
 "ak" = (
 /obj/random/junk,
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "al" = (
 /obj/random/trash,
@@ -204,15 +204,15 @@
 /area/djstation)
 "be" = (
 /obj/random/maintenance,
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "bf" = (
 /obj/effect/overmap/visitable/sector/cluster,
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "cb" = (
 /obj/effect/shuttle_landmark/cluster/nav5,
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "db" = (
 /obj/effect/shuttle_landmark/cluster/nav6,
@@ -236,7 +236,7 @@
 /area/space)
 "ib" = (
 /obj/effect/shuttle_landmark/cluster/nav7,
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "jb" = (
 /obj/machinery/button/access/exterior{
@@ -245,7 +245,7 @@
 	pixel_y = -24;
 	dir = 1
 	},
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "kb" = (
 /obj/machinery/door/airlock/external{
@@ -345,7 +345,7 @@
 	req_access = null;
 	dir = 4
 	},
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "wb" = (
 /obj/machinery/door/airlock/external{

--- a/maps/away/mining/mining-orb.dmm
+++ b/maps/away/mining/mining-orb.dmm
@@ -14,10 +14,10 @@
 /turf/unsimulated/mask,
 /area/mine/unexplored)
 "ae" = (
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "af" = (
-/turf/floor,
+/turf/floor/barren,
 /area/mine/unexplored)
 "ag" = (
 /turf/wall/natural/random/high_chance,
@@ -250,7 +250,7 @@
 /area/mine/explored)
 "st" = (
 /obj/effect/shuttle_landmark/orb/nav7,
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "vc" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -277,7 +277,7 @@
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 4
 	},
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "Aj" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner,

--- a/maps/away/mining/mining_areas.dm
+++ b/maps/away/mining/mining_areas.dm
@@ -3,7 +3,7 @@
 	icon_state = "mining"
 	ambience = list('sound/ambience/ambimine.ogg', 'sound/ambience/song_game.ogg')
 	sound_env = ASTEROID
-	base_turf = /turf/floor
+	base_turf = /turf/floor/barren
 	area_flags = AREA_FLAG_IS_BACKGROUND | AREA_FLAG_HIDE_FROM_HOLOMAP
 
 /area/mine/explored

--- a/maps/away/smugglers/smugglers.dmm
+++ b/maps/away/smugglers/smugglers.dmm
@@ -3,7 +3,7 @@
 /turf/space,
 /area/space)
 "ab" = (
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "ac" = (
 /turf/unsimulated/mask,
@@ -24,7 +24,7 @@
 /turf/floor,
 /area/smugglers/base)
 "ah" = (
-/turf/floor,
+/turf/floor/barren,
 /area/space)
 "aj" = (
 /obj/item/ammo_casing/pistol/magnum{
@@ -37,11 +37,11 @@
 	pixel_y = -5
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "ak" = (
 /obj/effect/decal/cleanable/blood,
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "al" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -98,7 +98,7 @@
 	pixel_y = 7
 	},
 /obj/item/flashlight/flare/glowstick/yellow,
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "av" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -281,11 +281,11 @@
 	pixel_x = -25;
 	pixel_y = 25
 	},
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "aM" = (
 /obj/random/trash,
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "aN" = (
 /obj/machinery/light/small{
@@ -432,7 +432,7 @@
 /obj/item/tool/xeno/hand{
 	pixel_x = -15
 	},
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "bh" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -476,7 +476,7 @@
 /area/smugglers/base)
 "bn" = (
 /obj/structure/boulder,
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "bo" = (
 /obj/item/stack/material/ore/silver,
@@ -484,7 +484,7 @@
 	pixel_x = 10;
 	pixel_y = -5
 	},
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "bp" = (
 /obj/structure/cable{
@@ -946,7 +946,7 @@
 "db" = (
 /obj/effect/decal/cleanable/blood,
 /obj/abstract/landmark/corpse/doctor,
-/turf/floor,
+/turf/floor/barren,
 /area/mine/explored)
 "eb" = (
 /obj/machinery/light/small{

--- a/maps/away_sites_testing/away_sites_testing_define.dm
+++ b/maps/away_sites_testing/away_sites_testing_define.dm
@@ -20,10 +20,10 @@
 	var/list/unsorted_sites = list_values(SSmapping.get_templates_by_category(MAP_TEMPLATE_CATEGORY_AWAYSITE))
 	var/list/sorted_sites = sortTim(unsorted_sites, /proc/cmp_sort_templates_tallest_to_shortest)
 	for (var/datum/map_template/A in sorted_sites)
-		A.load_new_z(centered = FALSE)
+		A.load_new_z()
 		testing("Spawning [A] in [english_list(SSmapping.get_connected_levels(world.maxz))]")
 		if(A.template_flags & TEMPLATE_FLAG_TEST_DUPLICATES)
-			A.load_new_z(centered = FALSE)
+			A.load_new_z()
 			testing("Spawning [A] in [english_list(SSmapping.get_connected_levels(world.maxz))]")
 
 /proc/cmp_sort_templates_tallest_to_shortest(var/datum/map_template/a, var/datum/map_template/b)

--- a/maps/planets/test_planet/neutralia-2.dmm
+++ b/maps/planets/test_planet/neutralia-2.dmm
@@ -3,11 +3,11 @@
 /turf/unsimulated/mineral,
 /area/exoplanet/underground/neutralia)
 "b" = (
-/turf/floor,
+/turf/floor/barren,
 /area/exoplanet/underground/neutralia)
 "c" = (
 /obj/abstract/level_data_spawner/neutralia/underground,
-/turf/floor,
+/turf/floor/barren,
 /area/exoplanet/underground/neutralia)
 
 (1,1,1) = {"

--- a/maps/planets/test_planet/neutralia-3.dmm
+++ b/maps/planets/test_planet/neutralia-3.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/floor,
+/turf/floor/barren,
 /area/exoplanet/neutralia)
 "b" = (
 /turf/unsimulated/mineral,
@@ -17,15 +17,15 @@
 /area/exoplanet/neutralia)
 "j" = (
 /obj/abstract/landmark/exoplanet_spawn/large_plant,
-/turf/floor,
+/turf/floor/barren,
 /area/exoplanet/neutralia)
 "o" = (
 /obj/abstract/landmark/exoplanet_spawn/animal,
-/turf/floor,
+/turf/floor/barren,
 /area/exoplanet/neutralia)
 "x" = (
 /obj/abstract/landmark/exoplanet_spawn/plant,
-/turf/floor,
+/turf/floor/barren,
 /area/exoplanet/neutralia)
 
 (1,1,1) = {"

--- a/maps/planets/test_planet/test_planet.dm
+++ b/maps/planets/test_planet/test_planet.dm
@@ -131,14 +131,14 @@
 	name             = "neutralia surface"
 	level_id         = NEUTRALIA_SURFACE_LEVEL_ID
 	base_area        = /area/exoplanet/neutralia
-	base_turf        = /turf/floor
+	base_turf        = /turf/floor/barren
 	border_filler    = /turf/unsimulated/dark_filler
 
 /datum/level_data/planetoid/neutralia/underground
 	name             = "neutralia underground"
 	level_id         = "neutralia_underground"
 	base_area        = /area/exoplanet/underground/neutralia
-	base_turf        = /turf/floor
+	base_turf        = /turf/floor/barren
 	border_filler    = /turf/unsimulated/mineral
 
 /datum/level_data/planetoid/neutralia/underground/bottom

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -222,8 +222,8 @@ function run_byond_tests {
     then exit 1
     else msg "configured map is '$MAP_PATH'"
     fi
-    cp config/example/* config/
-    cp data/secrets/example/* data/secrets/
+    cp -r config/example/* config/
+    cp -r data/secrets/example/* data/secrets/
     if [[ "$CI" == "true" ]]; then
         msg "installing BYOND"
         ./install-byond.sh || exit 1


### PR DESCRIPTION
## Description of changes
Fixes some mapping errors that replaced barren turfs with plating.
Fixes starlight not working on compiled-in maps due to ordering.
Fixes ore deposits spreading into ramps.
Fixes the gamemode example config not being copied during CI. (Also copies subdirectories in the secrets folder just in case.

## Why and what will this PR improve
Fixes misc. issues that can go in early while optimization is still being testing.