### PR TITLE
Optimize atom init significantly (init time halved)

### DIFF
--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -1,7 +1,6 @@
 #define INITIALIZATION_INSSATOMS      0	//New should not call Initialize
-#define INITIALIZATION_INSSATOMS_LATE 1	//New should not call Initialize; after the first pass is complete (handled differently)
-#define INITIALIZATION_INNEW_MAPLOAD  2	//New should call Initialize(TRUE)
-#define INITIALIZATION_INNEW_REGULAR  3	//New should call Initialize(FALSE)
+#define INITIALIZATION_INNEW_MAPLOAD  1	//New should call Initialize(TRUE)
+#define INITIALIZATION_INNEW_REGULAR  2	//New should call Initialize(FALSE)
 
 #define INITIALIZE_HINT_NORMAL   0  //Nothing happens
 #define INITIALIZE_HINT_LATELOAD 1  //Call LateInitialize

--- a/code/controllers/subsystems/atoms.dm
+++ b/code/controllers/subsystems/atoms.dm
@@ -11,8 +11,10 @@ SUBSYSTEM_DEF(atoms)
 	var/atom_init_stage = INITIALIZATION_INSSATOMS
 	var/old_init_stage
 
-	var/list/late_loaders
+	/// A non-associative list of lists, with the format list(list(atom, list(Initialize arguments))).
 	var/list/created_atoms = list()
+	/// A non-associative list of lists, with the format list(list(atom, list(LateInitialize arguments))).
+	var/list/late_loaders = list()
 
 	var/list/BadInitializeCalls = list()
 
@@ -22,21 +24,25 @@ SUBSYSTEM_DEF(atoms)
 	return ..()
 
 /datum/controller/subsystem/atoms/proc/InitializeAtoms()
-	if(atom_init_stage <= INITIALIZATION_INSSATOMS_LATE)
+	if(atom_init_stage <= INITIALIZATION_INSSATOMS)
 		return
 
 	atom_init_stage = INITIALIZATION_INNEW_MAPLOAD
 
-	LAZYINITLIST(late_loaders)
-
 	var/list/mapload_arg = list(TRUE)
 
-	var/count = created_atoms.len
-	while(created_atoms.len)
-		var/atom/A = created_atoms[created_atoms.len]
-		var/list/atom_args = created_atoms[A]
-		created_atoms.len--
-		if(!QDELETED(A) && !(A.atom_flags & ATOM_FLAG_INITIALIZED))
+	var/index = 1
+	// Things can add to the end of this list while we iterate, so we can't use a for loop.
+	while(index <= length(created_atoms))
+		// Don't remove from this list while we run, that's expensive.
+		// That would also make it harder to handle things added while we iterate.
+		var/list/creation_packet = created_atoms[index++]
+		var/atom/A = creation_packet[1]
+		var/list/atom_args = creation_packet[2]
+		// I sure hope nothing in this list is ever hard-deleted, or else QDELING will runtime.
+		// If you get a null reference runtime error, just change it back to QDELETED.
+		// The ATOM_FLAG_INITIALIZED check is because of INITIALIZE_IMMEDIATE().
+		if(!QDELING(A) && !(A.atom_flags & ATOM_FLAG_INITIALIZED))
 			if(atom_args)
 				atom_args.Insert(1, TRUE)
 				InitAtom(A, atom_args)
@@ -44,26 +50,19 @@ SUBSYSTEM_DEF(atoms)
 				InitAtom(A, mapload_arg)
 			CHECK_TICK
 
-	// If wondering why not just store all atoms in created_atoms and use the block above: that turns out unbearably expensive.
-	// Instead, atoms without extra arguments in New created on server start are fished out of world directly.
-	// We do this exactly once.
-	if(!initialized)
-		for(var/atom/A in world)
-			if(!QDELETED(A) && !(A.atom_flags & ATOM_FLAG_INITIALIZED))
-				InitAtom(A, mapload_arg)
-				++count
-				CHECK_TICK
-
-	report_progress("Initialized [count] atom\s")
+	report_progress("Initialized [index] atom\s")
+	created_atoms.Cut()
 
 	atom_init_stage = INITIALIZATION_INNEW_REGULAR
 
-	if(late_loaders.len)
-		for(var/I in late_loaders)
-			var/atom/A = I
-			A.LateInitialize(arglist(late_loaders[A]))
+	if(length(late_loaders))
+		index = 1
+		while(index <= length(late_loaders))
+			var/list/creation_packet = late_loaders[index++]
+			var/atom/A = creation_packet[1]
+			A.LateInitialize(arglist(creation_packet[2]))
 			CHECK_TICK
-		report_progress("Late initialized [late_loaders.len] atom\s")
+		report_progress("Late initialized [index] atom\s")
 		late_loaders.Cut()
 
 /datum/controller/subsystem/atoms/proc/InitAtom(atom/A, list/arguments)
@@ -91,7 +90,7 @@ SUBSYSTEM_DEF(atoms)
 			EMPTY_BLOCK_GUARD
 		if(INITIALIZE_HINT_LATELOAD)
 			if(arguments[1])	//mapload
-				late_loaders[A] = arguments
+				late_loaders[++late_loaders.len] = list(A, arguments)
 			else
 				A.LateInitialize(arglist(arguments))
 		if(INITIALIZE_HINT_QDEL)
@@ -113,7 +112,7 @@ SUBSYSTEM_DEF(atoms)
 
 /datum/controller/subsystem/atoms/proc/map_loader_begin()
 	old_init_stage = atom_init_stage
-	atom_init_stage = INITIALIZATION_INSSATOMS_LATE
+	atom_init_stage = INITIALIZATION_INSSATOMS
 
 /datum/controller/subsystem/atoms/proc/map_loader_stop()
 	atom_init_stage = old_init_stage

--- a/code/controllers/subsystems/machines.dm
+++ b/code/controllers/subsystems/machines.dm
@@ -82,6 +82,12 @@ if(current_step == this_step || (check_resumed && !resumed)) {\
 
 #undef INTERNAL_PROCESS_STEP
 
+/datum/controller/subsystem/machines/StartLoadingMap()
+	suspend()
+
+/datum/controller/subsystem/machines/StopLoadingMap()
+	wake()
+
 // rebuild all power networks from scratch - only called at world creation or by the admin verb
 // The above is a lie. Turbolifts also call this proc.
 /datum/controller/subsystem/machines/proc/makepowernets()

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -119,15 +119,9 @@ SUBSYSTEM_DEF(mapping)
 	// This needs to be non-null even if the overmap isn't created for this map.
 	overmap_event_handler = GET_DECL(/decl/overmap_event_handler)
 
-	var/old_maxz
-	for(var/z = 1 to world.maxz)
-		var/datum/level_data/level = levels_by_z[z]
-		if(!istype(level))
-			level = new /datum/level_data/space(z)
-			PRINT_STACK_TRACE("Missing z-level data object for z[num2text(z)]!")
-		level.setup_level_data()
+	setup_data_for_levels()
 
-	old_maxz = world.maxz
+	var/old_maxz = world.maxz
 	// Build away sites.
 	global.using_map.build_away_sites()
 	global.using_map.build_planets()
@@ -150,13 +144,7 @@ SUBSYSTEM_DEF(mapping)
 	test_load_map_templates()
 #endif
 
-	// Check/associated/setup our level data objects.
-	for(var/z = old_maxz + 1 to world.maxz)
-		var/datum/level_data/level = levels_by_z[z]
-		if(!istype(level))
-			level = new /datum/level_data/space(z)
-			PRINT_STACK_TRACE("Missing z-level data object for z[num2text(z)]!")
-		level.setup_level_data()
+	setup_data_for_levels(min_z = old_maxz + 1)
 
 	// Generate turbolifts last, since away sites may have elevators to generate too.
 	for(var/obj/abstract/turbolift_spawner/turbolift as anything in turbolifts_to_initialize)
@@ -165,6 +153,14 @@ SUBSYSTEM_DEF(mapping)
 	global.using_map.finalize_map_generation()
 
 	. = ..()
+
+/datum/controller/subsystem/mapping/proc/setup_data_for_levels(min_z = 1, max_z = world.maxz)
+	for(var/z = min_z to max_z)
+		var/datum/level_data/level = levels_by_z[z]
+		if(!istype(level))
+			level = new /datum/level_data/space(z)
+			PRINT_STACK_TRACE("Missing z-level data object for z[num2text(z)]!")
+		level.setup_level_data()
 
 /datum/controller/subsystem/mapping/Recover()
 	flags |= SS_NO_INIT

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -109,6 +109,8 @@ SUBSYSTEM_DEF(mapping)
 	// Load any queued map template markers.
 	for(var/obj/abstract/landmark/map_load_mark/queued_mark in queued_markers)
 		queued_mark.load_subtemplate()
+		if(!QDELETED(queued_mark)) // for if the tile that lands on the landmark is a no-op tile
+			qdel(queued_mark)
 	queued_markers.Cut()
 
 	// Populate overmap.

--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -16,18 +16,15 @@
 
 	var/do_initialize = SSatoms.atom_init_stage
 	var/list/created = SSatoms.created_atoms
-	if(do_initialize > INITIALIZATION_INSSATOMS_LATE)
+	if(do_initialize > INITIALIZATION_INSSATOMS)
 		args[1] = do_initialize == INITIALIZATION_INNEW_MAPLOAD
 		if(SSatoms.InitAtom(src, args))
 			//we were deleted
 			return
-	else if(created)
-		var/list/argument_list
-		if(length(args) > 1)
-			argument_list = args.Copy(2)
-		if(argument_list || do_initialize == INITIALIZATION_INSSATOMS_LATE)
-			created[src] = argument_list
-
+	else if(length(args) > 1)
+		created[++created.len] = list(src, args.Copy(2))
+	else
+		created[++created.len] = list(src, null)
 	if(atom_flags & ATOM_FLAG_CLIMBABLE)
 		verbs += /atom/proc/climb_on
 

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -32,7 +32,7 @@ exactly 2 "/mob text paths" '"/mob'
 exactly 6 "/obj text paths" '"/obj'
 exactly 10 "/turf text paths" '"/turf'
 exactly 1 "world<< uses" 'world<<|world[[:space:]]<<'
-exactly 90 "'in world' uses" 'in world'
+exactly 89 "'in world' uses" 'in world'
 exactly 1 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
 exactly 18 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 9 ">> uses" '>>(?!>)' -P


### PR DESCRIPTION
## Description of changes
Makes /atom/New during mapload take half as long to complete, bringing away sites testing init from 130 to 85 seconds on my machine—that means init is twice as fast. This was done by making the created_atoms list non-associative, since we don't rely on it for deduplication or membership checking, just to associate atoms to their arguments.

## Why and what will this PR improve
Init time drops drastically on maps with lots of atoms.