### PR TITLE
Optimize parts of atmos code, plus some misc. optimizations

### DIFF
--- a/code/__defines/ZAS.dm
+++ b/code/__defines/ZAS.dm
@@ -57,29 +57,25 @@
 	}
 
 #ifdef MULTIZAS
-
-var/global/list/csrfz_check = list(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST, NORTHUP, EASTUP, WESTUP, SOUTHUP, NORTHDOWN, EASTDOWN, WESTDOWN, SOUTHDOWN)
-var/global/list/gzn_check = list(NORTH, SOUTH, EAST, WEST, UP, DOWN)
+#define ZAS_CSRFZ_CHECK global.cornerdirsz
+#define ZAS_GZN_CHECK global.cardinalz
 
 #define ATMOS_CANPASS_TURF(ret, A, B) \
 	if (A.blocks_air & AIR_BLOCKED || B.blocks_air & AIR_BLOCKED) { \
 		ret = BLOCKED; \
 	} \
-	else if (B.z != A.z) { \
-		if (B.z < A.z) { \
-			ret = (A.z_flags & ZM_ALLOW_ATMOS) ? ZONE_BLOCKED : BLOCKED; \
-		} \
-		else { \
-			ret = (B.z_flags & ZM_ALLOW_ATMOS) ? ZONE_BLOCKED : BLOCKED; \
-		} \
+	else if (B.z < A.z) { \
+		ret = (A.z_flags & ZM_ALLOW_ATMOS) ? ZONE_BLOCKED : BLOCKED; \
 	} \
-	else if (A.blocks_air & ZONE_BLOCKED || B.blocks_air & ZONE_BLOCKED) { \
-		ret = (A.z == B.z) ? ZONE_BLOCKED : AIR_BLOCKED; \
+	else if(B.z > A.z) { \
+		ret = (B.z_flags & ZM_ALLOW_ATMOS) ? ZONE_BLOCKED : BLOCKED; \
 	} \
-	else if (A.contents.len) { \
+	else if ((A.blocks_air & ZONE_BLOCKED) || (B.blocks_air & ZONE_BLOCKED)) { \
+		ret = ZONE_BLOCKED; \
+	} \
+	else if (length(A.contents)) { \
 		ret = 0;\
-		for (var/thing in A) { \
-			var/atom/movable/AM = thing; \
+		for (var/atom/movable/AM as anything in A) { \
 			ATMOS_CANPASS_MOVABLE(ret, AM, B); \
 			if (ret == BLOCKED) { \
 				break;\
@@ -88,8 +84,8 @@ var/global/list/gzn_check = list(NORTH, SOUTH, EAST, WEST, UP, DOWN)
 	}
 #else
 
-var/global/list/csrfz_check = list(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)
-var/global/list/gzn_check = list(NORTH, SOUTH, EAST, WEST)
+#define ZAS_CSRFZ_CHECK global.cornerdirs
+#define ZAS_GZN_CHECK global.cardinal
 
 #define ATMOS_CANPASS_TURF(ret, A, B) \
 	if (A.blocks_air & AIR_BLOCKED || B.blocks_air & AIR_BLOCKED) { \
@@ -98,7 +94,7 @@ var/global/list/gzn_check = list(NORTH, SOUTH, EAST, WEST)
 	else if (A.blocks_air & ZONE_BLOCKED || B.blocks_air & ZONE_BLOCKED) { \
 		ret = ZONE_BLOCKED; \
 	} \
-	else if (A.contents.len) { \
+	else if (length(A.contents)) { \
 		ret = 0;\
 		for (var/thing in A) { \
 			var/atom/movable/AM = thing; \

--- a/code/game/objects/item_mob_overlay.dm
+++ b/code/game/objects/item_mob_overlay.dm
@@ -45,13 +45,15 @@ var/global/list/icon_state_cache = list()
 /proc/_fetch_icon_state_cache_entry(checkicon)
 	if(isnull(checkicon) || !(isfile(checkicon) || isicon(checkicon)))
 		return null
-	var/checkkey = "\ref[checkicon]"
-	var/list/check = global.icon_state_cache[checkkey]
+	// if we want to let people del icons (WHY???) then we can use weakreF()
+	// but right now it's cheaper to just use checkicon directly
+	// ref doesn't even do any deduplication
+	var/list/check = global.icon_state_cache[checkicon]
 	if(!check)
 		check = list()
 		for(var/istate in icon_states(checkicon))
 			check[istate] = TRUE
-		global.icon_state_cache[checkkey] = check
+		global.icon_state_cache[checkicon] = check
 	return check
 
 /obj/item/proc/update_world_inventory_state()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -517,7 +517,7 @@
 		if(below)
 			below.update_weather(new_weather)
 
-// Updates turf participation in ZAS according to outside status. Must be called whenever the outside status of a turf may change.
+/// Updates turf participation in ZAS according to outside status and atmosphere participation bools. Must be called whenever any of those values may change.
 /turf/proc/update_external_atmos_participation()
 	var/old_outside = last_outside_check
 	last_outside_check = OUTSIDE_UNCERTAIN

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -148,24 +148,24 @@
 
 	// end of lighting stuff
 
-	// In case the turf isn't marked for update in Initialize (e.g. space), we call this to create any unsimulated edges necessary.
-	if(W.zone_membership_candidate != old_zone_membership_candidate)
-		SSair.mark_for_update(src)
-
 	// we check the var rather than the proc, because area outside values usually shouldn't be set on turfs
 	W.last_outside_check = OUTSIDE_UNCERTAIN
 	if(W.is_outside != old_outside)
 		// This will check the exterior atmos participation of this turf and all turfs connected by open space below.
 		W.set_outside(old_outside, skip_weather_update = TRUE)
-	else if(HasBelow(z) && (W.is_open() != old_is_open)) // Otherwise, we do it here if the open status of the turf has changed.
-		var/turf/checking = src
-		while(HasBelow(checking.z))
-			checking = GetBelow(checking)
-			if(!isturf(checking))
-				break
-			checking.update_external_atmos_participation()
-			if(!checking.is_open())
-				break
+	else // We didn't already update our external atmos participation in set_outside.
+		if(HasBelow(z) && (W.is_open() != old_is_open)) // Otherwise, we do it here if the open status of the turf has changed.
+			var/turf/checking = src
+			while(HasBelow(checking.z))
+				checking = GetBelow(checking)
+				if(!isturf(checking))
+					break
+				checking.update_external_atmos_participation()
+				if(!checking.is_open())
+					break
+		// In case the turf isn't marked for update in Initialize (e.g. space), we call this to create any unsimulated edges necessary.
+		if(W.zone_membership_candidate != old_zone_membership_candidate)
+			update_external_atmos_participation()
 
 	W.update_weather(force_update_below = W.is_open() != old_is_open)
 

--- a/code/game/turfs/unsimulated.dm
+++ b/code/game/turfs/unsimulated.dm
@@ -25,3 +25,6 @@
 
 /turf/unsimulated/get_lumcount(var/minlum = 0, var/maxlum = 1)
 	return 0.8
+
+/turf/unsimulated/get_movable_alpha_mask_state(atom/movable/mover)
+	return null

--- a/code/modules/ZAS/Turf.dm
+++ b/code/modules/ZAS/Turf.dm
@@ -35,9 +35,9 @@
 
 	var/list/postponed
 	#ifdef MULTIZAS
-	for(var/d = 1, d < 64, d *= 2)
+	for(var/d in global.cardinalz)
 	#else
-	for(var/d = 1, d < 16, d *= 2)
+	for(var/d in global.cardinal)
 	#endif
 
 		var/turf/unsim = get_step(src, d)

--- a/code/modules/ZAS/Turf.dm
+++ b/code/modules/ZAS/Turf.dm
@@ -167,7 +167,7 @@
 #define GET_ZONE_NEIGHBOURS(T, ret) \
 	ret = 0; \
 	if (T.zone) { \
-		for (var/_gzn_dir in gzn_check) { \
+		for (var/_gzn_dir in ZAS_GZN_CHECK) { \
 			var/turf/other = get_step(T, _gzn_dir); \
 			if (istype(other) && other.simulated && other.zone == T.zone) { \
 				var/block; \
@@ -198,7 +198,7 @@
 	if (!(check_dirs & (check_dirs - 1))) //Equivalent to: if(IsInteger(log(2, .)))
 		return TRUE
 
-	for(var/dir in global.csrfz_check)
+	for(var/dir in ZAS_CSRFZ_CHECK)
 		//for each pair of "adjacent" cardinals (e.g. NORTH and WEST, but not NORTH and SOUTH)
 		if((dir & check_dirs) == dir)
 			//check that they are connected by the corner turf


### PR DESCRIPTION
## Description of changes
Optimizes and modernizes certain parts of atmos code.

Optimizes `_fetch_icon_state_cache_entry()` by using the icon as a key rather than the icon's ref, because there's a 1:1 correspondence. Using a ref is just slower for no benefit. (As far as I can tell it works fine for files, but I guess it might cause issues if you `qdel()` a file object? But I don't think that's even valid, and goes against the idea of wanting to cache this anyway. I think we only softdel them, and I'm pretty sure file() objects are reused under the hood.)

Makes unsim turfs not have alpha masks. I *might* need to adjust this in the future to just be the specific unsim turf subtypes that have no functionality, but I mostly don't want to waste time on alpha masks for these turfs during maploading, and we don't have any unsim turfs that mask their contents anyway.

## Why and what will this PR improve
Performance improvements, mostly relevant for init and any sort of heavy atmos load.