### PR TITLE
Improve code quality grep checks

### DIFF
--- a/code/_helpers/files.dm
+++ b/code/_helpers/files.dm
@@ -1,7 +1,7 @@
 //Sends resource files to client cache
 /client/proc/getFiles()
 	for(var/file in args)
-		direct_output(src, browse_rsc(file))
+		send_rsc(src, file, null)
 
 /client/proc/browse_files(root="data/logs/", max_iterations=10, list/valid_extensions=list(".txt",".log",".htm"))
 	var/path = root

--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -163,7 +163,7 @@ mob
 			// Send the icon to src's local cache
 			send_rsc(src, getFlatIcon(src), iconName)
 			// Display the icon in their browser
-			direct_output(src, browse("<body bgcolor='#000000'><p><img src='[iconName]'></p></body>"))
+			show_browser(src, "<body bgcolor='#000000'><p><img src='[iconName]'></p></body>")
 
 		Output_Icon()
 			set name = "2. Output Icon"

--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -26,7 +26,7 @@ var/global/log_end= world.system_type == UNIX ? ascii2text(13) : ""
 	to_world_log("## TESTING: [msg][log_end]")
 
 /proc/game_log(category, text)
-	direct_output(diary, "\[[time_stamp()]] [game_id] [category]: [text][log_end]")
+	to_file(diary, "\[[time_stamp()]] [game_id] [category]: [text][log_end]")
 
 /proc/log_admin(text)
 	global.admin_log.Add(text)

--- a/code/_helpers/profiling.dm
+++ b/code/_helpers/profiling.dm
@@ -71,7 +71,7 @@
 		lines += "[entry] => [num2text(data[STAT_ENTRY_TIME], 10)]ms ([data[STAT_ENTRY_COUNT]]) (avg:[num2text(data[STAT_ENTRY_TIME]/(data[STAT_ENTRY_COUNT] || 1), 99)])"
 
 	if (user)
-		direct_output(user, browse("<ol><li>[lines.Join("</li><li>")]</li></ol>", "window=[url_encode("stats:[ref(stats)]")]"))
+		show_browser(user, "<ol><li>[lines.Join("</li><li>")]</li></ol>", "window=[url_encode("stats:[ref(stats)]")]")
 
 	. = lines.Join("\n")
 

--- a/code/_helpers/sorts/__main.dm
+++ b/code/_helpers/sorts/__main.dm
@@ -169,7 +169,7 @@ reverse a descending sequence without violating stability.
 	var/r = 0	//becomes 1 if any bits are shifted off
 	while(n >= MIN_MERGE)
 		r |= (n & 1)
-		n >>= 1
+		n = BITSHIFT_RIGHT(n, 1)
 	return n + r
 
 //Examines the stack of runs waiting to be merged and merges adjacent runs until the stack invariants are reestablished:

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -106,9 +106,12 @@
 #define show_image(target, image)                           target << (image)
 #define send_rsc(target, rsc_content, rsc_name)             target << browse_rsc(rsc_content, rsc_name)
 #define open_link(target, url)                              target << link(url)
+#define ftp_to(target, file_entry, suggested_name)          target << ftp(file_entry, suggested_name)
+#define open_file_for(target, file)                         target << run(file)
 #define to_savefile(target, key, value)                     target[(key)] << (value)
 #define from_savefile(target, key, value)                   target[(key)] >> (value)
 #define to_output(target, output_content, output_args)      target << output((output_content), (output_args))
+// Avoid using this where possible, prefer the other helpers instead.
 #define direct_output(target, value)                        target << (value)
 
 /proc/html_icon(var/thing) // Proc instead of macro to avoid precompiler problems.

--- a/code/controllers/subsystems/initialization/character_info.dm
+++ b/code/controllers/subsystems/initialization/character_info.dm
@@ -136,7 +136,7 @@ SUBSYSTEM_DEF(character_info)
 				fdel(dump_file_name)
 			text2file(JOINTEXT(SScharacter_info.get_character_manifest_html(apply_striping = FALSE)), dump_file_name)
 			if(fexists(dump_file_name))
-				direct_output(usr, ftp(dump_file_name, "dump_manifest.html"))
+				ftp_to(usr, dump_file_name, "dump_manifest.html")
 				return TOPIC_HANDLED
 		catch(var/exception/E)
 			log_debug("Exception when dumping character relationship manifest: [E]")

--- a/code/datums/supplypacks/supplypack.dm
+++ b/code/datums/supplypacks/supplypack.dm
@@ -24,9 +24,7 @@ var/global/list/cargoprices = list()
 		cost = 0
 		for(var/entry in contains)
 			cost += atom_info_repository.get_combined_worth_for(entry) * max(1, contains[entry])
-		var/container_value = containertype ? atom_info_repository.get_single_worth_for(containertype) : 0
-		if(container_value)
-			cost += atom_info_repository.get_single_worth_for(containertype)
+		cost += containertype ? atom_info_repository.get_single_worth_for(containertype) : 0
 		cost = max(1, NONUNIT_CEILING((cost * WORTH_TO_SUPPLY_POINTS_CONSTANT * SSsupply.price_markup), WORTH_TO_SUPPLY_POINTS_ROUND_CONSTANT))
 	global.cargoprices[name] = cost
 

--- a/code/game/objects/items/_item_force.dm
+++ b/code/game/objects/items/_item_force.dm
@@ -162,6 +162,6 @@
 
 	text2file(jointext(rows, "\n"), "weapon_stats_dump.csv")
 	if(fexists("weapon_stats_dump.csv"))
-		direct_output(usr, ftp("weapon_stats_dump.csv", "weapon_stats_dump.csv"))
+		ftp_to(usr, "weapon_stats_dump.csv", "weapon_stats_dump.csv")
 	to_chat(usr, "Done.")
 */

--- a/code/game/objects/structures/flora/tree.dm
+++ b/code/game/objects/structures/flora/tree.dm
@@ -102,12 +102,21 @@
 /obj/structure/flora/tree/pine/init_appearance()
 	icon_state = "pine_[rand(1, 3)]"
 
+var/global/list/christmas_trees = list()
 /obj/structure/flora/tree/pine/xmas
 	name         = "\improper Christmas tree"
 	desc         = "O Christmas tree, O Christmas tree..."
 	icon         = 'icons/obj/flora/pinetrees.dmi'
 	icon_state   = "pine_c"
 	stump_type   = /obj/structure/flora/stump/tree/pine/xmas
+
+/obj/structure/flora/tree/pine/xmas/Initialize(ml, _mat, _reinf_mat)
+	. = ..()
+	global.christmas_trees += src
+
+/obj/structure/flora/tree/pine/xmas/Destroy()
+	global.christmas_trees -= src
+	return ..()
 
 /obj/structure/flora/tree/pine/xmas/init_appearance()
 	return //Only one possible icon

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -126,7 +126,7 @@ var/global/world_topic_last = world.timeofday
 	throttle[2] = reason
 
 /world/Topic(T, addr, master, key)
-	direct_output(diary, "TOPIC: \"[T]\", from:[addr], master:[master], key:[key][log_end]")
+	to_file(diary, "TOPIC: \"[T]\", from:[addr], master:[master], key:[key][log_end]")
 
 	if (global.world_topic_last > world.timeofday)
 		global.world_topic_throttle = list() //probably passed midnight
@@ -201,7 +201,7 @@ var/global/_reboot_announced = FALSE
 /world/proc/save_mode(var/the_mode)
 	var/F = file("data/mode.txt")
 	fdel(F)
-	direct_output(F, the_mode)
+	to_file(F, the_mode)
 
 /world/proc/load_motd()
 	join_motd = safe_file2text("config/motd.txt", FALSE)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -321,7 +321,7 @@ var/global/BSACooldown = 0
 				dat += "<A href='byond://?src=\ref[src];remove_player_info=[key];remove_index=[i]'>Remove</A>"
 			dat += "<hr></li>"
 		if(update_file)
-			direct_output(info, infos)
+			to_file(info, infos)
 
 	dat += "</ul><br><A href='byond://?src=\ref[src];add_player_info=[key]'>Add Comment</A><br>"
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -174,7 +174,7 @@
 		else if(task == "permissions")
 			if(!D)	return
 			var/list/permissionlist = list()
-			for(var/i=1, i<=R_MAXPERMISSION, i<<=1)		//that <<= is shorthand for i = i << 1. Which is a left BITSHIFT_LEFT
+			for(var/i=1, i<=R_MAXPERMISSION, i = BITSHIFT_LEFT(i, 1))
 				permissionlist[rights2text(i)] = i
 			var/new_permission = input("Select a permission to turn on/off", "Permission toggle", null, null) as null|anything in permissionlist
 			if(!new_permission)	return

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -10,7 +10,7 @@
 	var/inactive_groups = SSair.zones.len - active_groups
 
 	var/hotspots = 0
-	for(var/obj/fire/hotspot in world)
+	for(var/obj/fire/hotspot in SSair.active_hotspots)
 		hotspots++
 
 	var/active_on_main_station = 0

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -51,7 +51,7 @@
 		return
 
 	message_admins("[key_name_admin(src)] accessed file: [path]")
-	direct_output(src, run(file(path)))
+	open_file_for(src, file(path))
 	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
 	return
 
@@ -64,6 +64,6 @@
 	set name = "Show Server Log"
 	set desc = "Shows today's server log."
 
-	direct_output(usr, run(diary))
+	open_file_for(usr, diary)
 	SSstatistics.add_field_details("admin_verb","VTL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -24,6 +24,7 @@
 var/global/camera_range_display_status = 0
 var/global/intercom_range_display_status = 0
 
+var/global/list/debug_camera_range_markers = list()
 /obj/effect/debugging/camera_range
 	icon = 'icons/480x480.dmi'
 	icon_state = "25percent"
@@ -33,10 +34,24 @@ var/global/intercom_range_display_status = 0
 	default_pixel_x = -224
 	default_pixel_y = -224
 	reset_offsets(0)
+	global.debug_camera_range_markers += src
 
+/obj/effect/debugging/camera_range/Destroy()
+	global.debug_camera_range_markers -= src
+	return ..()
+
+var/global/list/mapping_debugging_markers = list()
 /obj/effect/debugging/marker
 	icon = 'icons/turf/areas.dmi'
 	icon_state = "yellow"
+
+/obj/effect/debugging/marker/Initialize(mapload)
+	. = ..()
+	global.mapping_debugging_markers += src
+
+/obj/effect/debugging/marker/Destroy()
+	global.mapping_debugging_markers -= src
+	return ..()
 
 /obj/effect/debugging/marker/Move()
 	return 0
@@ -56,7 +71,7 @@ var/global/intercom_range_display_status = 0
 
 
 
-	for(var/obj/effect/debugging/camera_range/C in world)
+	for(var/obj/effect/debugging/camera_range/C as anything in debug_camera_range_markers)
 		qdel(C)
 
 	if(camera_range_display_status)
@@ -113,7 +128,7 @@ var/global/intercom_range_display_status = 0
 	else
 		intercom_range_display_status = 1
 
-	for(var/obj/effect/debugging/marker/M in world)
+	for(var/obj/effect/debugging/marker/M in global.mapping_debugging_markers)
 		qdel(M)
 
 	if(intercom_range_display_status)

--- a/code/modules/admin/view_variables/helpers.dm
+++ b/code/modules/admin/view_variables/helpers.dm
@@ -6,16 +6,16 @@
 	return {"
 		<a href='byond://?_src_=vars;datumedit=\ref[src];varnameedit=name'><b>[src]</b></a>
 		<br><font size='1'>
-		<a href='byond://?_src_=vars;rotatedatum=\ref[src];rotatedir=left'><<</a>
+		<a href='byond://?_src_=vars;rotatedatum=\ref[src];rotatedir=left'>\<\<</a>
 		<a href='byond://?_src_=vars;datumedit=\ref[src];varnameedit=dir'>[dir2text(dir)]</a>
-		<a href='byond://?_src_=vars;rotatedatum=\ref[src];rotatedir=right'>>></a>
+		<a href='byond://?_src_=vars;rotatedatum=\ref[src];rotatedir=right'>\>\></a>
 		</font>
 		"}
 
 /mob/living/get_view_variables_header()
 	return {"
 		<a href='byond://?_src_=vars;rename=\ref[src]'><b>[src]</b></a><font size='1'>
-		<br><a href='byond://?_src_=vars;rotatedatum=\ref[src];rotatedir=left'><<</a> <a href='byond://?_src_=vars;datumedit=\ref[src];varnameedit=dir'>[dir2text(dir)]</a> <a href='byond://?_src_=vars;rotatedatum=\ref[src];rotatedir=right'>>></a>
+		<br><a href='byond://?_src_=vars;rotatedatum=\ref[src];rotatedir=left'>\<\<</a> <a href='byond://?_src_=vars;datumedit=\ref[src];varnameedit=dir'>[dir2text(dir)]</a> <a href='byond://?_src_=vars;rotatedatum=\ref[src];rotatedir=right'>\>\></a>
 		<br><a href='byond://?_src_=vars;datumedit=\ref[src];varnameedit=ckey'>[ckey ? ckey : "No ckey"]</a> / <a href='byond://?_src_=vars;datumedit=\ref[src];varnameedit=real_name'>[real_name ? real_name : "No real name"]</a>
 		<br>
 		BRUTE:<a href='byond://?_src_=vars;mobToDamage=\ref[src];adjustDamage=[BRUTE]'>[get_damage(BRUTE)]</a>

--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -45,7 +45,7 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 	client.sending |= asset_name
 	var/job = ++client.last_asset_job
 
-	direct_output(client, browse("<script>window.location.href='byond://?asset_cache_confirm_arrival=[job]'</script>", "window=asset_cache_browser"))
+	show_browser(client, "<script>window.location.href='byond://?asset_cache_confirm_arrival=[job]'</script>", "window=asset_cache_browser")
 
 	var/t = 0
 	var/timeout_time = (ASSET_CACHE_SEND_TIMEOUT * client.sending.len) + ASSET_CACHE_SEND_TIMEOUT
@@ -85,7 +85,7 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 	client.sending |= unreceived
 	var/job = ++client.last_asset_job
 
-	direct_output(client, browse("<script>window.location.href='byond://?asset_cache_confirm_arrival=[job]'</script>", "window=asset_cache_browser"))
+	show_browser(client, "<script>window.location.href='byond://?asset_cache_confirm_arrival=[job]'</script>", "window=asset_cache_browser")
 
 	var/t = 0
 	var/timeout_time = ASSET_CACHE_SEND_TIMEOUT * client.sending.len

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -295,7 +295,7 @@ var/global/list/time_prefs_fixed = list()
 		return
 	if(href_list["preference"] == "open_whitelist_forum")
 		if(get_config_value(/decl/config/text/forumurl))
-			direct_output(user, link(get_config_value(/decl/config/text/forumurl)))
+			open_link(user, get_config_value(/decl/config/text/forumurl))
 		else
 			to_chat(user, "<span class='danger'>The forum URL is not set in the server configuration.</span>")
 			return

--- a/code/modules/holidays/holiday_special.dm
+++ b/code/modules/holidays/holiday_special.dm
@@ -1,12 +1,12 @@
-/datum/holiday/christmas/New()
-	..()
+/datum/holiday/christmas
 	announcement = "Merry Christmas, everyone!"
 
 /datum/holiday/christmas/set_up_holiday()
-	for(var/obj/structure/flora/tree/pine/xmas in world)
-		if(isNotStationLevel(xmas.z))
+	for(var/obj/structure/flora/tree/pine/xmas/crimmas_tree in global.christmas_trees)
+		if(isNotStationLevel(crimmas_tree.z))
 			continue
-		for(var/turf/T in orange(1,xmas))
-			if(T.is_floor() && T.simulated)
-				for(var/i = 1 to rand(1,5))
-					new /obj/item/a_gift(T)
+		for(var/turf/T in orange(1, crimmas_tree))
+			if(!T.is_floor() || !T.simulated)
+				continue
+			for(var/i = 1 to rand(1,5))
+				new /obj/item/a_gift(T)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1013,7 +1013,7 @@
 					sleep(5)
 					to_chat(src, "<span class='danger'>Would you like to send a report to the vendor? Y/N</span>")
 					sleep(10)
-					to_chat(src, "<span class='danger'>> N</span>")
+					to_chat(src, "<span class='danger'>\> N</span>")
 					sleep(20)
 					to_chat(src, "<span class='danger'>ERRORERRORERROR</span>")
 					to_chat(src, "<b>Obey these laws:</b>")

--- a/code/modules/modular_computers/file_system/programs/generic/folding.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/folding.dm
@@ -23,7 +23,7 @@
 
 	var/started_on 			= 0 	// When the program started some science.
 	var/current_interval 	= 0		// How long the current interval will be.
-	var/next_event 			= 0 	// in world timeofday, when the next event is scheduled to pop.
+	var/next_event 			= 0 	// based on world.timeofday, when the next event is scheduled to pop.
 	var/program_status		= PROGRAM_STATUS_RUNNING		// Program periodically needs a restart, increases crash chance slightly over time.
 	var/crashed_at			= 0		// When the program crashed.
 

--- a/code/modules/modular_computers/terminal/terminal.dm
+++ b/code/modules/modular_computers/terminal/terminal.dm
@@ -98,7 +98,7 @@
 			account_name = "LOCAL"
 	else
 		account_name = "GUEST"
-	content += "<form action='byond://'><input type='hidden' name='src' value='\ref[src]'>>[account_name]:/[current_disk?.get_dir_path(current_directory, TRUE)]<input type='text' size='40' name='input' autofocus><input type='submit' value='Enter'></form>"
+	content += "<form action='byond://'><input type='hidden' name='src' value='\ref[src]'\>\>[account_name]:/[current_disk?.get_dir_path(current_directory, TRUE)]<input type='text' size='40' name='input' autofocus><input type='submit' value='Enter'></form>"
 	content += "<i>type `man` for a list of available commands.</i>"
 	panel.set_content("<tt>[jointext(content, "<br>")]</tt>")
 
@@ -159,7 +159,7 @@
 /datum/terminal/proc/parse_directory(directory_path, create_directories = FALSE)
 	var/datum/file_storage/target_disk = current_disk
 	var/datum/computer_file/directory/root_dir = current_directory
-	
+
 	if(!length(directory_path))
 		return list(target_disk, root_dir)
 
@@ -168,8 +168,8 @@
 
 	// Otherwise, we append the working directory path to the passed path.
 	var/list/directories = splittext(directory_path, "/")
-	
-	// When splitting the text, there could be blank strings at either end, so remove them. If there's any in the body of the path, there was a 
+
+	// When splitting the text, there could be blank strings at either end, so remove them. If there's any in the body of the path, there was a
 	// missed input, so leave them.
 	if(!length(directories[1]))
 		directories.Cut(1, 2)
@@ -194,7 +194,7 @@
 			if(!target_disk) // Invalid disk entered.
 				return OS_DIR_NOT_FOUND
 			directories.Cut(1, 2)
-			
+
 		break // Any further use of ../ is handled by the hard drive.
 
 	// If we were only pathing to the parent of a directory or to a disk, we can return early.
@@ -208,7 +208,7 @@
 	var/datum/computer_file/directory/target_directory = target_disk.parse_directory(final_path, create_directories)
 	if(!istype(target_directory))
 		return OS_DIR_NOT_FOUND
-	
+
 	return list(target_disk, target_directory)
 
 // Returns list(/datum/file_storage, /datum/computer_file/directory, /datum/computer_file) on success. Returns error code on failure.
@@ -221,7 +221,7 @@
 	var/list/dirs_and_file = splittext(file_path, "/")
 	if(!length(dirs_and_file))
 		return OS_DIR_NOT_FOUND
-	
+
 	// Join together everything but the filename into a path.
 	var/list/file_loc = parse_directory(jointext(dirs_and_file, "/", 1, dirs_and_file.len))
 	if(!islist(file_loc)) // Errored!
@@ -231,7 +231,7 @@
 	var/datum/computer_file/directory/target_dir = file_loc[2]
 	if(!istype(target_disk))
 		return OS_DIR_NOT_FOUND
-	
+
 	var/filename = dirs_and_file[dirs_and_file.len]
 	var/datum/computer_file/target_file = target_disk.get_file(filename, target_dir)
 	if(!istype(target_file))
@@ -265,5 +265,5 @@
 			return "I/O error, Harddrive may be non-functional"
 		if(OS_NETWORK_ERROR)
 			return "Unable to connect to the network"
-	
+
 	return "An unspecified error occured."

--- a/code/modules/overmap/contacts/_contacts.dm
+++ b/code/modules/overmap/contacts/_contacts.dm
@@ -29,7 +29,6 @@
 
 	radar = image(loc = effect, icon = 'icons/obj/overmap.dmi', icon_state = "sensor_range")
 	radar.color = source.color
-	radar.tag = "radar"
 	radar.add_filter("blur", 1, list(type = "blur", size = 1))
 	radar.appearance_flags |= RESET_TRANSFORM | KEEP_APART
 	radar.appearance_flags &= ~PIXEL_SCALE

--- a/code/modules/random_map/drop/droppod.dm
+++ b/code/modules/random_map/drop/droppod.dm
@@ -136,7 +136,6 @@
 			drop = pick(supplied_drop_types)
 			supplied_drop_types -= drop
 			if(istype(drop))
-				drop.tag = null
 				if(drop.buckled)
 					drop.buckled = null
 				drop.forceMove(T)
@@ -168,7 +167,6 @@
 			return
 		for(var/i=0;i<spawn_count;i++)
 			var/mob/living/M = new spawn_path()
-			M.tag = "awaiting drop"
 			spawned_mobs |= M
 	else
 		var/list/candidates = list()
@@ -187,7 +185,6 @@
 
 		// Spawn the mob in nullspace for now.
 		spawned_mob = new spawn_path()
-		spawned_mob.tag = "awaiting drop"
 
 		// Equip them, if they are human and it is desirable.
 		if(ishuman(spawned_mob))
@@ -203,7 +200,6 @@
 		if(spawned_mobs.len)
 			for(var/mob/living/M in spawned_mobs)
 				spawned_mobs -= M
-				M.tag = null
 				qdel(M)
 			spawned_mobs.Cut()
 		return

--- a/code/modules/recycling/disposalpipe.dm
+++ b/code/modules/recycling/disposalpipe.dm
@@ -234,11 +234,6 @@
 /obj/structure/disposalpipe/hides_under_flooring()
 	return 1
 
-// *** TEST verb
-//client/verb/dispstop()
-//	for(var/obj/structure/disposalholder/H in world)
-//		H.active = 0
-
 // a straight or bent segment
 /obj/structure/disposalpipe/segment
 	icon_state = "pipe-s" // Sadly this var stores state. "pipe-c" is corner. Should be changed, but requires huge map diff.

--- a/code/unit_tests/equipment_tests.dm
+++ b/code/unit_tests/equipment_tests.dm
@@ -1,41 +1,36 @@
 /datum/unit_test/vision_glasses
 	name = "EQUIPMENT: Vision Template"
 	abstract_type = /datum/unit_test/vision_glasses
-	var/mob/living/human/H = null
+	var/mob/living/human/subject = null
 	var/expectation = SEE_INVISIBLE_NOLIGHTING
 	var/glasses_type = null
 	async = 1
 
 /datum/unit_test/vision_glasses/start_test()
-	var/list/test = create_test_mob_with_mind(get_safe_turf(), /mob/living/human)
-	if(isnull(test))
-		fail("Check Runtimed in Mob creation")
-
-	if(test["result"] == FAILURE)
-		fail(test["msg"])
-		async = 0
-		return 0
-
-	H = locate(test["mobref"])
-	H.equip_to_slot(new glasses_type(H), slot_glasses_str)
+	subject = new(get_safe_turf(), SPECIES_HUMAN) // force human so default map species doesn't mess with anything
+	subject.equip_to_slot(new glasses_type(subject), slot_glasses_str)
 	return 1
 
 /datum/unit_test/vision_glasses/check_result()
 
-	if(isnull(H) || H.life_tick < 2)
+	if(isnull(subject) || subject.life_tick < 2)
 		return 0
 
-	if(isnull(H.get_equipped_item(slot_glasses_str)))
+	if(isnull(subject.get_equipped_item(slot_glasses_str)))
 		fail("Mob doesn't have glasses on")
 
-	H.handle_vision()	// Because Life has a client check that bypasses updating vision
+	subject.handle_vision()	// Because Life has a client check that bypasses updating vision
 
-	if(H.see_invisible == expectation)
-		pass("Mob See invisible is [H.see_invisible]")
+	if(subject.see_invisible == expectation)
+		pass("Mob See invisible is [subject.see_invisible]")
 	else
-		fail("Mob See invisible is [H.see_invisible] / expected [expectation]")
+		fail("Mob See invisible is [subject.see_invisible] / expected [expectation]")
 
 	return 1
+
+/datum/unit_test/vision_glasses/teardown_test()
+	QDEL_NULL(subject)
+	. = ..()
 
 /datum/unit_test/vision_glasses/NVG
 	name = "EQUIPMENT: NVG see_invis"

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -503,6 +503,28 @@
 
 //=======================================================================================
 
+// These vars are used to avoid in-world loops in the following unit test.
+var/global/_unit_test_disposal_segments = list()
+var/global/_unit_test_sort_junctions = list()
+
+#ifdef UNIT_TEST
+/obj/structure/disposalpipe/segment/Initialize(mapload)
+	. = ..()
+	_unit_test_disposal_segments += src
+
+/obj/structure/disposalpipe/segment/Destroy()
+	_unit_test_disposal_segments -= src
+	return ..()
+
+/obj/structure/disposalpipe/sortjunction/Initialize(mapload)
+	. = ..()
+	_unit_test_sort_junctions += src
+
+/obj/structure/disposalpipe/sortjunction/Destroy()
+	_unit_test_sort_junctions -= src
+	return ..()
+#endif
+
 /datum/unit_test/disposal_segments_shall_connect_with_other_disposal_pipes
 	name = "MAP: Disposal segments shall connect with other disposal pipes"
 
@@ -522,7 +544,7 @@
 		num2text(SOUTH) = list(list(SOUTH, list(NORTH, WEST)), list(EAST,  list(NORTH, EAST))),
 		num2text(WEST)  = list(list(EAST,  list(NORTH, EAST)), list(SOUTH, list(SOUTH, EAST))))
 
-	for(var/obj/structure/disposalpipe/segment/D in world)
+	for(var/obj/structure/disposalpipe/segment/D in _unit_test_disposal_segments)
 		if(!D.loc)
 			continue
 		if(D.icon_state == "pipe-s")
@@ -760,7 +782,7 @@
 /datum/unit_test/networked_disposals_shall_deliver_tagged_packages/start_test()
 	. = 1
 	var/fail = FALSE
-	for(var/obj/structure/disposalpipe/sortjunction/sort in world)
+	for(var/obj/structure/disposalpipe/sortjunction/sort in _unit_test_sort_junctions)
 		if(!sort.loc)
 			continue
 		if(is_type_in_list(sort, exempt_junctions))

--- a/code/unit_tests/mob_tests.dm
+++ b/code/unit_tests/mob_tests.dm
@@ -60,19 +60,9 @@
 
 var/global/default_mobloc = null
 
-/proc/create_test_mob_with_mind(var/turf/mobloc = null, var/mobtype = /mob/living/human)
+/proc/create_test_mob_with_mind(var/turf/mobloc, var/mobtype = /mob/living/human)
 	var/list/test_result = list("result" = FAILURE, "msg"    = "", "mobref" = null)
 
-	if(isnull(mobloc))
-		if(!default_mobloc)
-			for(var/turf/floor/tiled/T in world)
-				if(!T.zone?.air)
-					continue
-				var/pressure = T.zone.air.return_pressure()
-				if(90 < pressure && pressure < 120) // Find a turf between 90 and 120
-					default_mobloc = T
-					break
-		mobloc = default_mobloc
 	if(!mobloc)
 		test_result["msg"] = "Unable to find a location to create test mob"
 		return test_result

--- a/code/unit_tests/mob_tests.dm
+++ b/code/unit_tests/mob_tests.dm
@@ -58,9 +58,7 @@
 
 // ============================================================================
 
-var/global/default_mobloc = null
-
-/proc/create_test_mob_with_mind(var/turf/mobloc, var/mobtype = /mob/living/human)
+/datum/unit_test/mob_damage/proc/create_test_mob_with_mind(var/turf/mobloc, var/mobtype = /mob/living/human)
 	var/list/test_result = list("result" = FAILURE, "msg"    = "", "mobref" = null)
 
 	if(!mobloc)

--- a/mods/content/supermatter/endgame_cascade/universe.dm
+++ b/mods/content/supermatter/endgame_cascade/universe.dm
@@ -67,9 +67,10 @@
 		if(!invalid_area)
 			A.update_icon()
 
+// TODO: Should this be changed to use the actual ambient lights system...?
 /datum/universal_state/supermatter_cascade/OverlayAndAmbientSet()
 	spawn(0)
-		for(var/datum/lighting_corner/L in world)
+		for(var/datum/lighting_corner/L in SSlighting.lighting_corners)
 			if(isAdminLevel(L.z))
 				L.update_lumcount(1,1,1)
 			else

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -23,34 +23,35 @@ exactly() { # exactly N name search [mode] [filter]
 
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 # Additional exception August 2020: \b is a regex symbol as well as a BYOND macro.
-exactly 1 "escapes" '\\\\(red|blue|green|black|b|i[^mc])'
-exactly 8 "Del()s" '\WDel\('
+exactly 3 "escapes" '\\(red|blue|green|black|b|i[^mc])'
+exactly 3 "Del()s" '(?<!world/)\bDel\('  -P
 exactly 2 "/atom text paths" '"/atom'
 exactly 2 "/area text paths" '"/area'
 exactly 2 "/datum text paths" '"/datum'
 exactly 2 "/mob text paths" '"/mob'
 exactly 6 "/obj text paths" '"/obj'
 exactly 10 "/turf text paths" '"/turf'
-exactly 1 "world<< uses" 'world<<|world[[:space:]]<<'
-exactly 89 "'in world' uses" 'in world'
-exactly 1 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
-exactly 18 "<< uses" '(?<!<)<<(?!<)' -P
-exactly 9 ">> uses" '>>(?!>)' -P
+exactly 1 "world<< uses" 'world\s*<<'
+exactly 74 "'in world' uses" '\s+\bin world\b(?=\s*$|\s*//|\s*\))' -P
+exactly 1 "world.log<< uses" 'world.log\s*<<'
+exactly 18 "<< uses" '(?<![<\\])<<(?!<)' -P
+exactly 1 "direct_output uses" '\bdirect_output\('
+exactly 3 ">> uses" '(?<![>\\])>>(?!>)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 23 "text2path uses" 'text2path'
-exactly 4 "update_icon() override" '/update_icon\((.*)\)'  -P
-exactly 0 "goto uses" 'goto '
+exactly 4 "update_icon() overrides" '\/update_icon\(' -P
+exactly 0 "goto uses" '\bgoto\b'
 exactly 9 "atom/New uses" '^/(obj|atom|area|mob|turf).*/New\('
 exactly 1 "decl/New uses" '^/decl.*/New\('
-exactly 0 "tag uses" '\stag = ' -P '*.dmm'
-exactly 3 "unmarked globally scoped variables" '^(/|)var/(?!global)' -P
-exactly 0 "global-marked member variables" '\t(/|)var.*/global/.+' -P
-exactly 0 "static-marked globally scoped variables" '^(/|)var.*/static/.+' -P
+exactly 3 "tag uses" '(?<!/)\btag\s*=(?!=)' -P '*.dm *.dmm'
+exactly 3 "unmarked globally scoped variables" '^/?var/(?!global)' -P
+exactly 0 "global-marked member variables" '\t+/?var.*/global/' -P
+exactly 0 "static-marked globally scoped variables" '^/?var.*/static/.+' -P
 exactly 1 "direct usage of decls_repository.get_decl()" 'decls_repository\.get_decl\(' -P
-exactly 19 "direct loc set" '(\t|;|\.)loc\s*=(?!=)' -P
+exactly 19 "direct loc set" '[^ ,(/]\bloc\s*=(?!=)' -P
 exactly 0 "magic number mouse opacity set" 'mouse_opacity\s*=\s*[0-2]' -P
-exactly 1 "magic number density set" '\bdensity\s*=\s*[01]' -P
-exactly 0 "magic number anchored set" '\banchored\s*=\s*[01]' -P
+exactly 0 "magic number density set" '\bdensity\s*=\s*[01]\b' -P
+exactly 0 "magic number anchored set" '\banchored\s*=\s*[01]\b' -P
 exactly 0 "magic number opacity set" '\bopacity\s*=\s*[01](?!\.)' -P
 
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong


### PR DESCRIPTION
## Description of changes
- Adds a check for the `tag` var in code, expanding it from just checking in maps.
- Removes unnecessary usage of the `tag` var.
- Replaces all current uses of `direct_output` with specialized helpers, in preparation for allowing drop-in optional replacement for downstreams that want to opt into things like rust-g to improve performance.
- Improves a lot of our grep checks to reduce false positives.
- Removes 15 `in world` loops, either deleting them entirely because they're dead code, or replacing them with other lists.
- Fixes redundant code in supply pack setup. This just got thrown in because eh, why not.

## Why and what will this PR improve
Improves code quality across the board.