### PR TITLE
Fix muddy footprints being made of blood, adds snowy footprints

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -1,4 +1,3 @@
-#define DRYING_TIME 5 MINUTES //for 1 unit of depth in puddle (amount var)
 #define BLOOD_SIZE_SMALL     1
 #define BLOOD_SIZE_MEDIUM    2
 #define BLOOD_SIZE_BIG       3
@@ -21,6 +20,8 @@
 	var/base_icon = 'icons/effects/blood.dmi'
 	var/basecolor=COLOR_BLOOD_HUMAN // Color when wet.
 	var/amount = 5
+	//for 1 unit of depth in puddle (amount var)
+	var/time_to_dry = 5 MINUTES
 	var/drytime
 	var/dryname = "dried blood"
 	var/drydesc = "It's dry and crusty. Someone isn't doing their job."
@@ -29,19 +30,21 @@
 	var/chemical = /decl/material/liquid/blood
 
 /obj/effect/decal/cleanable/blood/reveal_blood()
-	if(!fluorescent)
+	if(ispath(chemical, /decl/material/liquid/blood) && !fluorescent)
 		fluorescent = FLUORESCENT_GLOWS
 		basecolor = COLOR_LUMINOL
 		update_icon()
 
 /obj/effect/decal/cleanable/blood/clean(clean_forensics = TRUE)
-	fluorescent = FALSE
-	if(invisibility != INVISIBILITY_ABSTRACT)
-		set_invisibility(INVISIBILITY_ABSTRACT)
-		amount = 0
-		STOP_PROCESSING(SSobj, src)
-		remove_extension(src, /datum/extension/scent)
-	. = ..(clean_forensics = FALSE)
+	if(ispath(chemical, /decl/material/liquid/blood))
+		clean_forensics = FALSE
+		fluorescent = FALSE
+		if(invisibility != INVISIBILITY_ABSTRACT)
+			set_invisibility(INVISIBILITY_ABSTRACT)
+			amount = 0
+			STOP_PROCESSING(SSobj, src)
+			remove_extension(src, /datum/extension/scent)
+	. = ..(clean_forensics)
 
 /obj/effect/decal/cleanable/blood/hide()
 	return
@@ -50,8 +53,11 @@
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 
-/obj/effect/decal/cleanable/blood/Initialize(mapload)
+// new_chemical is a material typepath, or null
+/obj/effect/decal/cleanable/blood/Initialize(ml, _age, new_chemical)
 	. = ..()
+	if(!isnull(new_chemical))
+		chemical = new_chemical
 	if(merge_with_blood())
 		return INITIALIZE_HINT_QDEL
 	start_drying()
@@ -61,16 +67,31 @@
 	if(!isturf(loc) || blood_size == BLOOD_SIZE_NO_MERGE)
 		return FALSE
 	for(var/obj/effect/decal/cleanable/blood/B in loc)
-		if(B != src && B.blood_size != BLOOD_SIZE_NO_MERGE)
-			if(B.blood_DNA)
-				blood_size = BLOOD_SIZE_NO_MERGE
-				B.blood_DNA |= blood_DNA.Copy()
-			B.alpha = initial(B.alpha) // reset rain-based fading due to more drips
-			return TRUE
+		if(B == src)
+			continue
+		if(B.blood_size == BLOOD_SIZE_NO_MERGE)
+			continue
+		if(B.invisibility >= INVISIBILITY_ABSTRACT) // has been cleaned
+			continue
+		if(B.chemical != chemical) // don't mix blood and oil or oil and mud etc
+			continue // todo: refactor to make bloody steps use reagents and track data/size/amount on there?
+		if(B.blood_DNA)
+			blood_size = BLOOD_SIZE_NO_MERGE
+			B.blood_DNA |= blood_DNA.Copy()
+		B.alpha = initial(B.alpha) // reset rain-based fading due to more drips
+		return TRUE
 	return FALSE
 
 /obj/effect/decal/cleanable/blood/proc/start_drying()
-	drytime = world.time + DRYING_TIME * (amount+1)
+	var/decl/material/our_chemical = GET_DECL(chemical)
+	time_to_dry = our_chemical.get_time_to_dry_stain(src)
+	switch(time_to_dry)
+		if(0) // dry instantly
+			dry()
+			return
+		if(-INFINITY to 0) // don't even bother trying to dry this
+			return
+	drytime = world.time + time_to_dry * (amount+1)
 	update_icon()
 	START_PROCESSING(SSobj, src)
 
@@ -100,6 +121,9 @@
 	amount--
 
 /obj/effect/decal/cleanable/blood/proc/dry()
+	var/decl/material/our_chemical = GET_DECL(chemical)
+	if(our_chemical.handle_stain_dry(src))
+		return TRUE // prevent additional drying handling; this includes preventing processing, so be careful
 	name = dryname
 	desc = drydesc
 	color = adjust_brightness(color, -50)
@@ -107,6 +131,7 @@
 	blood_data = null
 	remove_extension(src, /datum/extension/scent)
 	STOP_PROCESSING(SSobj, src)
+	return FALSE
 
 /obj/effect/decal/cleanable/blood/attack_hand(mob/user)
 	if(!amount || !length(blood_data) || !ishuman(user))
@@ -233,7 +258,7 @@
 		for (var/i = 0, i < pick(1, 200; 2, 150; 3, 50; 4), i++)
 			sleep(3)
 			if (i > 0)
-				var/obj/effect/decal/cleanable/blood/b = new /obj/effect/decal/cleanable/blood/splatter(loc)
+				var/obj/effect/decal/cleanable/blood/b = new /obj/effect/decal/cleanable/blood/splatter(loc, null, chemical)
 				b.basecolor = src.basecolor
 				b.update_icon()
 			if (step_to(src, get_step(src, direction), 0))

--- a/code/game/objects/effects/decals/Cleanable/robots.dm
+++ b/code/game/objects/effects/decals/Cleanable/robots.dm
@@ -13,9 +13,6 @@
 /obj/effect/decal/cleanable/blood/gibs/robot/on_update_icon()
 	color = "#ffffff"
 
-/obj/effect/decal/cleanable/blood/gibs/robot/dry()	//pieces of robots do not dry up like
-	return
-
 /obj/effect/decal/cleanable/blood/gibs/robot/streak(var/list/directions)
 	spawn (0)
 		var/direction = pick(directions)
@@ -43,9 +40,6 @@
 	basecolor = SYNTH_BLOOD_COLOR
 	chemical = /decl/material/liquid/lube
 	cleanable_scent = "industrial lubricant"
-
-/obj/effect/decal/cleanable/blood/oil/dry()
-	return
 
 /obj/effect/decal/cleanable/blood/oil/streak
 	random_icon_states = list("mgibbl1", "mgibbl2", "mgibbl3", "mgibbl4", "mgibbl5")

--- a/code/game/objects/effects/decals/Cleanable/tracks.dm
+++ b/code/game/objects/effects/decals/Cleanable/tracks.dm
@@ -10,8 +10,7 @@
 #define TRACKS_GOING_EAST   64
 #define TRACKS_GOING_WEST   128
 
-// 5 seconds
-#define TRACKS_CRUSTIFY_TIME   50
+#define TRACKS_CRUSTIFY_TIME   5 SECONDS
 
 /datum/fluidtrack
 	var/direction=0
@@ -26,7 +25,8 @@
 	src.wet=_wet
 
 /obj/effect/decal/cleanable/blood/tracks/reveal_blood()
-	if(!fluorescent)
+	// don't reveal non-blood tracks
+	if(ispath(chemical, /decl/material/liquid/blood) && !fluorescent)
 		if(stack && stack.len)
 			for(var/datum/fluidtrack/track in stack)
 				track.basecolor = COLOR_LUMINOL

--- a/code/game/objects/effects/footprints.dm
+++ b/code/game/objects/effects/footprints.dm
@@ -7,7 +7,7 @@
 	is_spawnable_type = FALSE
 	blend_mode        = BLEND_SUBTRACT
 	alpha             = 128
-	var/list/footprints
+	var/list/image/footprints
 
 /obj/effect/footprints/Initialize(mapload)
 	. = ..()
@@ -15,7 +15,7 @@
 	name = null
 
 /obj/effect/footprints/Destroy()
-	QDEL_NULL(footprints)
+	footprints.Cut() // don't qdel images
 	. = ..()
 
 /obj/effect/footprints/on_update_icon()

--- a/code/game/objects/structures/stool_bed_chair_nest_sofa/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest_sofa/wheelchair.dm
@@ -12,6 +12,7 @@
 	tool_interaction_flags = 0
 
 	var/item_form_type = /obj/item/wheelchair_kit
+	// TODO: Replace with reagent holder? This doesn't even properly handle non-human bloodstains.
 	var/bloodiness
 
 /obj/structure/bed/chair/wheelchair/Initialize()

--- a/code/game/turfs/flooring/_flooring.dm
+++ b/code/game/turfs/flooring/_flooring.dm
@@ -391,5 +391,7 @@ var/global/list/flooring_cache = list()
 /decl/flooring/proc/turf_crossed(atom/movable/crosser)
 	return
 
-/decl/flooring/proc/can_show_coating_footprints(turf/target)
+/// target is the turf that wants to know if it supports footprints
+/// contaminant is, optionally, the material of the coating that wants to be added.
+/decl/flooring/proc/can_show_coating_footprints(turf/target, decl/material/contaminant)
 	return TRUE

--- a/code/game/turfs/flooring/flooring_mud.dm
+++ b/code/game/turfs/flooring/flooring_mud.dm
@@ -25,10 +25,12 @@
 	if(!isliving(crosser))
 		return
 	var/mob/living/walker = crosser
-	walker.add_walking_contaminant(/decl/material/solid/soil, rand(2,3))
+	walker.add_walking_contaminant(force_material.type, rand(2,3))
 
-/decl/flooring/mud/can_show_coating_footprints(turf/target)
-	return FALSE // So we don't end up covered in a million footsteps that we provided.
+/decl/flooring/mud/can_show_coating_footprints(turf/target, decl/material/contaminant)
+	if(force_material.type == contaminant) // So we don't end up covered in a million footsteps that we provided.
+		return FALSE
+	return ..()
 
 /decl/flooring/dry_mud
 	name            = "dry mud"

--- a/code/game/turfs/flooring/flooring_snow.dm
+++ b/code/game/turfs/flooring/flooring_snow.dm
@@ -31,6 +31,19 @@
 		return
 	return ..()
 
+/decl/flooring/snow/turf_crossed(atom/movable/crosser)
+	if(!isliving(crosser))
+		return
+	var/mob/living/walker = crosser
+	// at some point this might even be able to use the height
+	// of the snow flooring layer, so deep snow gives you more coating
+	walker.add_walking_contaminant(force_material.type, rand(1, 2))
+
+/decl/flooring/snow/can_show_coating_footprints(turf/target, decl/material/contaminant)
+	if(force_material.type == contaminant) // So we don't end up covered in a million footsteps that we provided.
+		return FALSE
+	return ..()
+
 /decl/flooring/permafrost
 	name            = "permafrost"
 	desc            = "A stretch of frozen soil that hasn't seen a thaw for many seasons."

--- a/code/game/turfs/floors/_floor.dm
+++ b/code/game/turfs/floors/_floor.dm
@@ -309,5 +309,5 @@
 	flooring?.turf_crossed(AM)
 	return ..()
 
-/turf/floor/can_show_coating_footprints()
-	return ..() && get_topmost_flooring()?.can_show_coating_footprints(src)
+/turf/floor/can_show_coating_footprints(decl/material/contaminant = null)
+	return ..() && get_topmost_flooring()?.can_show_coating_footprints(src, contaminant)

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -1203,3 +1203,15 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 // TODO: expand this to more than just Actual Poison.
 /decl/material/proc/is_unsafe_to_drink(mob/user)
 	return toxicity > 0
+
+/// Used for material-dependent effects on stain dry.
+/// Return TRUE to skip default drying handling.
+/decl/material/proc/handle_stain_dry(obj/effect/decal/cleanable/blood/stain)
+	return FALSE
+
+/// Returns (in deciseconds) how long until dry() will be called on this stain,
+/// or null to use the stain's default.
+/// If 0 is returned, it dries instantly.
+/// If any value below 0 is returned, it doesn't start processing.
+/decl/material/proc/get_time_to_dry_stain(obj/effect/decal/cleanable/blood/stain)
+	return initial(stain.time_to_dry)

--- a/code/modules/materials/definitions/liquids/materials_liquid_chemistry.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_chemistry.dm
@@ -25,3 +25,7 @@
 	value = 0.1
 	slipperiness = 80
 	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
+
+// Prevent oil stains from drying.
+/decl/material/liquid/lube/get_time_to_dry_stain(obj/effect/decal/cleanable/blood/stain)
+	return -1

--- a/code/modules/materials/definitions/liquids/materials_liquid_mundane.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_mundane.dm
@@ -1,0 +1,12 @@
+/decl/material/liquid/mucus
+	name = "mucus"
+	uid = "chem_mucus"
+	lore_text = "A gooey semi-liquid produced by a wide variety of organisms. In some, it's associated with disease and illness."
+	taste_description = "slime"
+	color = COLOR_LIQUID_WATER
+	opacity = 0.5
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
+
+/decl/material/liquid/mucus/handle_stain_dry(obj/effect/decal/cleanable/blood/stain)
+	qdel(stain)
+	return TRUE // skip blood handling

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -223,7 +223,7 @@
 	. += "<BR><BR>Description:<BR>"
 	if(detailed_blood && istype(reagent, /decl/material/liquid/blood))
 		var/blood_data = REAGENT_DATA(beaker?.reagents, /decl/material/liquid/blood)
-		. += "Blood Type: [LAZYACCESS(blood_data, DATA_BLOOD_TYPE)]<br>DNA: [LAZYACCESS(blood_data, "blood.DNA")]"
+		. += "Blood Type: [LAZYACCESS(blood_data, DATA_BLOOD_TYPE)]<br>DNA: [LAZYACCESS(blood_data, DATA_BLOOD_DNA)]"
 	else
 		. += "[reagent.lore_text]"
 	. += "<BR><BR><BR><A href='byond://?src=\ref[src];main=1'>(Back)</A>"

--- a/code/modules/reagents/chems/chems_blood.dm
+++ b/code/modules/reagents/chems/chems_blood.dm
@@ -72,7 +72,7 @@
 
 /decl/material/liquid/blood/get_reagent_color(datum/reagents/holder)
 	var/list/blood_data = REAGENT_DATA(holder, type)
-	return blood_data?["blood_color"] || ..()
+	return blood_data?[DATA_BLOOD_COLOR] || ..()
 
 /decl/material/liquid/coagulated_blood
 	name = "coagulated blood"

--- a/mods/species/bayliens/skrell/datum/species.dm
+++ b/mods/species/bayliens/skrell/datum/species.dm
@@ -117,27 +117,36 @@
 	var/obj/item/shoes = H.get_equipped_item(slot_shoes_str)
 	if(!shoes)
 		var/list/bloodDNA
-		var/list/blood_data = REAGENT_DATA(H.vessel, /decl/material/liquid/blood)
+		var/list/blood_data = REAGENT_DATA(H.vessel, blood_reagent)
 		if(blood_data)
 			bloodDNA = list(blood_data[DATA_BLOOD_DNA] = blood_data[DATA_BLOOD_TYPE])
 		else
 			bloodDNA = list()
-		if(T.simulated)
-			T.AddTracks(/obj/effect/decal/cleanable/blood/tracks/footprints/skrellprints, bloodDNA, H.dir, 0, H.get_skin_colour() + "25") // Coming (8c is the alpha value)
+		T.AddTracks(/obj/effect/decal/cleanable/blood/tracks/footprints/skrellprints, bloodDNA, H.dir, 0, H.get_skin_colour() + "25") // Coming (25 is the alpha value)
 		if(isturf(old_loc))
 			var/turf/old_turf = old_loc
-			if(old_turf.simulated)
-				old_turf.AddTracks(/obj/effect/decal/cleanable/blood/tracks/footprints/skrellprints, bloodDNA, 0, H.dir, H.get_skin_colour() + "25") // Going (8c is the alpha value)
+			old_turf.AddTracks(/obj/effect/decal/cleanable/blood/tracks/footprints/skrellprints, bloodDNA, 0, H.dir, H.get_skin_colour() + "25") // Going (25 is the alpha value)
 
 /decl/species/skrell/check_background()
 	return TRUE
 
+/decl/material/liquid/mucus/skrell
+	name = "slime"
+	uid = "chem_mucus_skrell"
+	lore_text = "A gooey semi-liquid secreted by skrellian skin."
+
+// Copied from blood.
+// TODO: There's not currently a way to check this, which might be a little annoying for forensics.
+// But this is just a stopgap to stop Skrell from literally leaking blood everywhere they go.
+/decl/material/liquid/mucus/skrell/get_reagent_color(datum/reagents/holder)
+	var/list/goo_data = REAGENT_DATA(holder, type)
+	return goo_data?[DATA_BLOOD_COLOR] || ..()
+
 /obj/effect/decal/cleanable/blood/tracks/footprints/skrellprints
 	name = "wet footprints"
 	desc = "They look like still wet tracks left by skrellian feet."
+	chemical = /decl/material/liquid/mucus/skrell
 
-/obj/effect/decal/cleanable/blood/tracks/footprints/skrellprints/dry()
-	qdel(src)
 /obj/item/organ/internal/eyes/skrell
 	name = "amphibian eyes"
 	desc = "Large black orbs, belonging to some sort of giant frog by looks of it."

--- a/nebula.dme
+++ b/nebula.dme
@@ -2744,6 +2744,7 @@
 #include "code\modules\materials\definitions\gasses\material_gas_mundane.dm"
 #include "code\modules\materials\definitions\liquids\_mat_liquid.dm"
 #include "code\modules\materials\definitions\liquids\materials_liquid_chemistry.dm"
+#include "code\modules\materials\definitions\liquids\materials_liquid_mundane.dm"
 #include "code\modules\materials\definitions\liquids\materials_liquid_solvents.dm"
 #include "code\modules\materials\definitions\liquids\materials_liquid_soup.dm"
 #include "code\modules\materials\definitions\liquids\materials_liquid_toxins.dm"


### PR DESCRIPTION
## Description of changes
Makes coating actually set the `chemical` var on bloody/oily/muddy/etc tracks, meaning it will no longer always be considered blood.
Fixes some issues with coating footprints merging into bloody footprints.
Fixes bloodstains merging into cleaned (invisible) bloodstains.
Fixes non-bloody footprints not being fully cleaned (because of blood forensics things).
Only stuff with `coating == /decl/material/liquid/blood` is affected by luminol and various other bloodstain-specific things.
Moves oil stain drying overrides onto the chemical oil uses, `/decl/material/liquid/lube`, which will also apply to, e.g., a robot that 'bleeds' oil.
Adds snowy footprints that melt after a while.

## Why and what will this PR improve
Makes non-bloody footsteps make more sense, prevents some issues with them.

## Changelog
:cl:
tweak: Mud can now receive footprints with any reagent other than mud. No more conspicuously missing bloody footprints!
add: Added snowy footsteps. They melt after a certain amount of time based on their local temperature.
/:cl:
