### PR TITLE
Fix miscellaneous code quality and consistency issues

### DIFF
--- a/code/_onclick/hud/screen/screen_credits.dm
+++ b/code/_onclick/hud/screen/screen_credits.dm
@@ -18,14 +18,16 @@
 	animate(src, transform = M, time = CREDIT_ROLL_SPEED)
 	target = M
 	animate(src, alpha = 255, time = CREDIT_EASE_DURATION, flags = ANIMATION_PARALLEL)
-	spawn(CREDIT_ROLL_SPEED - CREDIT_EASE_DURATION)
-		if(!QDELETED(src))
-			animate(src, alpha = 0, transform = target, time = CREDIT_EASE_DURATION)
-			sleep(CREDIT_EASE_DURATION)
-			qdel(src)
+	addtimer(CALLBACK(src, PROC_REF(ease_out)), CREDIT_ROLL_SPEED - CREDIT_EASE_DURATION)
 	var/mob/owner = owner_ref?.resolve()
 	if(istype(owner) && owner.client)
 		owner.client.screen += src
+
+/obj/screen/credit/proc/ease_out()
+	if(QDELETED(src))
+		return
+	animate(src, alpha = 0, transform = target, time = CREDIT_EASE_DURATION)
+	QDEL_IN_CLIENT_TIME(src, CREDIT_EASE_DURATION)
 
 /obj/screen/credit/Destroy()
 	var/client/P = parent

--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -279,13 +279,13 @@ SUBSYSTEM_DEF(garbage)
 	qdel(D, force)
 #endif
 
-// Should be treated as a replacement for the 'del' keyword.
-// Datums passed to this will be given a chance to clean up references to allow the GC to collect them.
+/// Should be treated as a replacement for the 'del' keyword.
+/// Datums passed to this will be given a chance to clean up references to allow the GC to collect them.
+/// Non-datums passed to this will be hard-deleted.
 /proc/qdel(datum/D, force=FALSE)
 	if(isnull(D))
 		return
 	if(!istype(D))
-		PRINT_STACK_TRACE("qdel() can only handle /datum (sub)types, was passed: [log_info_line(D)]")
 		del(D)
 		return
 	var/datum/qdel_item/I = SSgarbage.items[D.type]

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -198,7 +198,7 @@ SUBSYSTEM_DEF(mapping)
 	. = list()
 	for(var/template_type in subtypesof(/datum/map_template))
 		var/datum/map_template/template = template_type
-		if(!TYPE_IS_ABSTRACT(template) && initial(template.template_parent_type) != template_type && initial(template.name))
+		if(!TYPE_IS_ABSTRACT(template))
 			. += new template_type(type) // send name as a param to catch people doing illegal ad hoc creation
 
 /datum/controller/subsystem/mapping/proc/get_template(var/template_name)

--- a/code/controllers/subsystems/shuttle.dm
+++ b/code/controllers/subsystems/shuttle.dm
@@ -125,13 +125,14 @@ SUBSYSTEM_DEF(shuttle)
 
 /datum/controller/subsystem/shuttle/proc/initialize_shuttle(var/shuttle_type, var/map_hash, var/list/add_args)
 	var/datum/shuttle/shuttle = shuttle_type
-	if(initial(shuttle.category) != shuttle_type)
-		var/list/shuttle_args = list(map_hash)
-		if(length(add_args))
-			shuttle_args += add_args
-		shuttle = new shuttle(arglist(shuttle_args))
-		shuttle_areas |= shuttle.shuttle_area
-		return shuttle
+	if(TYPE_IS_ABSTRACT(shuttle))
+		return null
+	var/list/shuttle_args = list(map_hash)
+	if(length(add_args))
+		shuttle_args += add_args
+	shuttle = new shuttle(arglist(shuttle_args))
+	shuttle_areas |= shuttle.shuttle_area
+	return shuttle
 
 /datum/controller/subsystem/shuttle/proc/hook_up_motherships(shuttles_list)
 	for(var/datum/shuttle/S in shuttles_list)

--- a/code/datums/traits/maluses/amputations.dm
+++ b/code/datums/traits/maluses/amputations.dm
@@ -15,8 +15,6 @@
 			if(trait_type == type)
 				continue
 			var/decl/trait/malus/amputation/trait = check_traits[trait_type]
-			if(!trait.name)
-				continue // remove when abstract decl handling from dev is merged
 			for(var/limb in trait.apply_to_limbs)
 				if(limb in ban_traits_relating_to_limbs)
 					LAZYDISTINCTADD(incompatible_with, trait_type)

--- a/code/game/objects/effects/chem/water.dm
+++ b/code/game/objects/effects/chem/water.dm
@@ -45,8 +45,7 @@
 				break
 
 		sleep(delay)
-	sleep(10)
-	qdel(src)
+	QDEL_IN(src, 1 SECOND)
 
 /obj/effect/effect/water/Move(turf/newloc)
 	if(newloc.density)

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -34,16 +34,14 @@
 	if(ismob(obj))
 		var/mob/mob = obj
 		mob.add_genetic_condition(pick(decls_repository.get_decls_of_type(/decl/genetic_condition/disability)))
-	spawn(0)
-		qdel(src)
+	qdel(src)
 
 /obj/effect/mine/proc/triggerstun(obj)
 	if(ismob(obj))
 		var/mob/M = obj
 		SET_STATUS_MAX(M, STAT_STUN, 30)
 	spark_at(src, cardinal_only = TRUE)
-	spawn(0)
-		qdel(src)
+	qdel(src)
 
 /obj/effect/mine/proc/triggern2o(obj)
 	//example: n2o triggerproc
@@ -53,8 +51,7 @@
 		if(target.simulated && !target.blocks_air)
 			target.assume_gas(/decl/material/gas/nitrous_oxide, 30)
 
-	spawn(0)
-		qdel(src)
+	qdel(src)
 
 /obj/effect/mine/proc/triggerflame(obj)
 	for (var/turf/target in range(1,src))
@@ -62,21 +59,18 @@
 			target.assume_gas(/decl/material/gas/hydrogen, 30)
 			target.hotspot_expose(1000, CELL_VOLUME)
 
-	spawn(0)
-		qdel(src)
+	qdel(src)
 
 /obj/effect/mine/proc/triggerkick(obj)
 	spark_at(src, cardinal_only = TRUE)
 	if(ismob(obj))
 		var/mob/victim = obj
 		qdel(victim.client)
-	spawn(0)
-		qdel(src)
+	qdel(src)
 
 /obj/effect/mine/proc/explode(obj)
 	explosion(loc, 0, 1, 2, 3)
-	spawn(0)
-		qdel(src)
+	qdel(src)
 
 /obj/effect/mine/dnascramble
 	name = "Radiation Mine"

--- a/code/game/objects/effects/temporary.dm
+++ b/code/game/objects/effects/temporary.dm
@@ -5,7 +5,7 @@
 	layer = ABOVE_HUMAN_LAYER
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
 	simulated = FALSE
-	var/duration = 10 //in deciseconds
+	var/duration = 1 SECOND //in deciseconds
 
 /obj/effect/temp_visual/Initialize(mapload, set_dir)
 	if(set_dir)
@@ -17,9 +17,15 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "empdisable"
 
+/obj/effect/temp_visual/emppulse
+	name = "electromagnetic pulse"
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "emppulse"
+	duration = 2 SECONDS
+
 /obj/effect/temp_visual/bloodsplatter
 	icon = 'icons/effects/bloodspatter.dmi'
-	duration = 5
+	duration = 0.5 SECONDS
 	layer = LYING_HUMAN_LAYER
 	var/splatter_type = "splatter"
 

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -14,13 +14,7 @@
 		log_and_message_admins("EMP with size ([heavy_range], [light_range]) in area [epicenter.loc.name] ")
 
 	if(heavy_range > 1)
-		var/obj/effect/overlay/pulse = new/obj/effect/overlay(epicenter)
-		pulse.icon = 'icons/effects/effects.dmi'
-		pulse.icon_state = "emppulse"
-		pulse.SetName("electromagnetic pulse")
-		pulse.anchored = TRUE
-		spawn(20)
-			qdel(pulse)
+		new /obj/effect/temp_visual/emppulse(epicenter)
 
 	if(heavy_range > light_range)
 		light_range = heavy_range

--- a/code/game/objects/items/weapons/grenades/anti_photon_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/anti_photon_grenade.dm
@@ -18,5 +18,4 @@
 /obj/item/grenade/anti_photon/proc/finish()
 	set_light(10, 10, rgb(rand(64,255), rand(64,255), rand(64,255)))
 	playsound(loc, 'sound/effects/bang.ogg', 50, 1, 5)
-	sleep(1 SECOND)
-	qdel(src)
+	QDEL_IN(src, 1 SECOND)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -64,8 +64,7 @@
 
 /obj/item/energy_net/dropped()
 	..()
-	spawn(10)
-		if(src) qdel(src)
+	QDEL_IN(src, 1 SECOND)
 
 /obj/item/energy_net/throw_impact(atom/hit_atom)
 	..()
@@ -85,8 +84,7 @@
 		qdel(src)
 
 	// If we miss or hit an obstacle, we still want to delete the net.
-	spawn(10)
-		if(src) qdel(src)
+	QDEL_IN(src, 1 SECOND)
 
 /obj/effect/energy_net
 	name = "energy net"

--- a/code/game/world_topic_commands.dm
+++ b/code/game/world_topic_commands.dm
@@ -356,6 +356,5 @@
 	uid = "topic_command_prometheus_metrics"
 
 /decl/topic_command/secure/prometheus_metrics/use()
-	if(!global.prometheus_metrics)
-		return "Metrics not ready"
-	return global.prometheus_metrics.collect()
+	var/static/decl/prometheus_metrics/prometheus_metrics = IMPLIED_DECL
+	return prometheus_metrics.collect()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -979,8 +979,7 @@
 		var/obj/effect/stop/S
 		S = new /obj/effect/stop(M.loc)
 		S.victim = M
-		spawn(20)
-			qdel(S)
+		QDEL_IN(S, 2 SECONDS)
 
 		var/turf/floor/T = get_turf(M)
 		if(istype(T))

--- a/code/modules/admin/view_variables/helpers.dm
+++ b/code/modules/admin/view_variables/helpers.dm
@@ -1,6 +1,4 @@
-
-// Keep these two together, they *must* be defined on both
-// If /client ever becomes /datum/client or similar, they can be merged
+// If /client/var/parent_type ever stops being /datum, this proc will need to be redefined on client.
 /datum/proc/get_view_variables_header()
 	return "<b>[src]</b>"
 

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -290,8 +290,8 @@
 			return
 		var/list/possible_ailments = list()
 		for(var/atype in subtypesof(/datum/ailment))
-			var/datum/ailment/ailment = get_ailment_reference(atype)
-			if(ailment && ailment.category != ailment.type && ailment.can_apply_to(limb))
+			var/datum/ailment/ailment = get_ailment_reference(atype) // will not get abstract ailments
+			if(ailment && ailment.can_apply_to(limb))
 				possible_ailments |= ailment
 
 		var/datum/ailment/ailment = input("Select an ailment type to add.", "Add Ailment") as null|anything in possible_ailments

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -159,8 +159,7 @@
 		if(a_right)
 			a_right.holder = null
 			a_right.forceMove(T)
-		spawn(0)
-			qdel(src)
+		qdel(src)
 	return
 
 /obj/item/assembly_holder/hear_talk(mob/living/M, msg, verb, decl/language/speaking)

--- a/code/modules/clothing/head/fated_key.dm
+++ b/code/modules/clothing/head/fated_key.dm
@@ -113,5 +113,5 @@
 	animate(src, alpha = 255, time = 3)
 	sleep(13)
 	animate(src, alpha = 0, time = 40)
-	sleep(40)
-	qdel(src)
+	if(!QDELING(src))
+		QDEL_IN(src, 4 SECONDS)

--- a/code/modules/maps/_map_template.dm
+++ b/code/modules/maps/_map_template.dm
@@ -1,4 +1,5 @@
 /datum/map_template
+	abstract_type = /datum/map_template
 	///Name for differentiating templates
 	var/name = "Default Template Name"
 	///The width of the template's levels. Size is preloaded from template during template registration.
@@ -23,8 +24,6 @@
 	var/modify_tag_vars = TRUE
 	///List of strings to store the templates under for mass retrieval.
 	var/list/template_categories
-	///If this is equal to current type, the datum is abstract and should not be created.
-	var/template_parent_type = /datum/map_template
 	///The initial type of level_data to instantiate new z-level with initially. (Is replaced by whatever is in the map file.) If null, will use default.
 	var/level_data_type
 	/// Various tags used for selecting templates for placement on a map.

--- a/code/modules/maps/template_types/antag_spawn.dm
+++ b/code/modules/maps/template_types/antag_spawn.dm
@@ -1,3 +1,3 @@
 /datum/map_template/ruin/antag_spawn
 	prefix = "maps/antag_spawn/"
-	template_parent_type = /datum/map_template/ruin/antag_spawn
+	abstract_type = /datum/map_template/ruin/antag_spawn

--- a/code/modules/maps/template_types/away_site.dm
+++ b/code/modules/maps/template_types/away_site.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site
 	prefix = "maps/away/"
 	template_categories = list(MAP_TEMPLATE_CATEGORY_AWAYSITE)
-	template_parent_type = /datum/map_template/ruin/away_site
+	abstract_type = /datum/map_template/ruin/away_site
 	var/spawn_weight = 1
 
 /datum/map_template/ruin/away_site/get_spawn_weight()

--- a/code/modules/maps/template_types/mapped_planet/mapped_planet_template.dm
+++ b/code/modules/maps/template_types/mapped_planet/mapped_planet_template.dm
@@ -6,7 +6,6 @@
 /datum/map_template/planetoid
 	name                 = "planetoid"
 	abstract_type        = /datum/map_template/planetoid
-	template_parent_type = /datum/map_template/planetoid
 	template_categories  = list(MAP_TEMPLATE_CATEGORY_PLANET)
 	level_data_type      = /datum/level_data/planetoid
 	modify_tag_vars      = TRUE

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/barren.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/barren.dm
@@ -76,7 +76,6 @@
 	overmap_marker_type        = /obj/effect/overmap/visitable/sector/planetoid/exoplanet/barren
 	template_tags_blacklist    = TEMPLATE_TAG_HABITAT|TEMPLATE_TAG_WATER
 	subtemplate_budget         = 6
-	template_parent_type       = /datum/map_template/planetoid/random/exoplanet
 	level_data_type            = /datum/level_data/planetoid/exoplanet/barren
 	prefered_level_data_per_z  = list(
 		/datum/level_data/planetoid/exoplanet/barren,     //surface level

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/chlorine.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/chlorine.dm
@@ -87,7 +87,6 @@
 	planetoid_data_type        = /datum/planetoid_data/random/chlorine
 	overmap_marker_type        = /obj/effect/overmap/visitable/sector/planetoid/exoplanet/chlorine
 	template_tags_blacklist    = TEMPLATE_TAG_HABITAT|TEMPLATE_TAG_WATER
-	template_parent_type       = /datum/map_template/planetoid/random/exoplanet
 	level_data_type            = /datum/level_data/planetoid/exoplanet/chlorine
 	prefered_level_data_per_z  = list(
 		/datum/level_data/planetoid/exoplanet/chlorine,

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/desert.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/desert.dm
@@ -95,7 +95,6 @@
 	name                       = "desert exoplanet"
 	planetoid_data_type        = /datum/planetoid_data/random/desert
 	overmap_marker_type        = /obj/effect/overmap/visitable/sector/planetoid/exoplanet/desert
-	template_parent_type       = /datum/map_template/planetoid/random/exoplanet
 	level_data_type            = /datum/level_data/planetoid/exoplanet/desert
 	prefered_level_data_per_z  = list(
 		/datum/level_data/planetoid/exoplanet/desert,

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/grass.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/grass.dm
@@ -119,7 +119,6 @@
 	name                       = "lush exoplanet"
 	planetoid_data_type        = /datum/planetoid_data/random/grass
 	overmap_marker_type        = /obj/effect/overmap/visitable/sector/planetoid/exoplanet/grass
-	template_parent_type       = /datum/map_template/planetoid/random/exoplanet
 	level_data_type            = /datum/level_data/planetoid/exoplanet/grass
 	prefered_level_data_per_z  = list(
 		/datum/level_data/planetoid/exoplanet/grass,

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/meat.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/meat.dm
@@ -91,7 +91,6 @@
 	planetoid_data_type        = /datum/planetoid_data/random/meat
 	overmap_marker_type        = /obj/effect/overmap/visitable/sector/planetoid/exoplanet/meat
 	template_tags_blacklist    = TEMPLATE_TAG_HABITAT|TEMPLATE_TAG_HUMAN|TEMPLATE_TAG_WATER
-	template_parent_type       = /datum/map_template/planetoid/random/exoplanet
 	level_data_type            = /datum/level_data/planetoid/exoplanet/meat
 	prefered_level_data_per_z  = null
 

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/shrouded.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/shrouded.dm
@@ -86,7 +86,6 @@
 	planetoid_data_type        = /datum/planetoid_data/random/shrouded
 	overmap_marker_type        = /obj/effect/overmap/visitable/sector/planetoid/exoplanet/shrouded
 	template_tags_blacklist    = TEMPLATE_TAG_HABITAT
-	template_parent_type       = /datum/map_template/planetoid/random/exoplanet
 	level_data_type            = /datum/level_data/planetoid/exoplanet/shrouded
 	prefered_level_data_per_z  = list(
 		/datum/level_data/planetoid/exoplanet/shrouded,

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/snow.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/snow.dm
@@ -77,7 +77,6 @@
 	name                       = "snow exoplanet"
 	planetoid_data_type        = /datum/planetoid_data/random/snow
 	overmap_marker_type        = /obj/effect/overmap/visitable/sector/planetoid/exoplanet/snow
-	template_parent_type       = /datum/map_template/planetoid/random/exoplanet
 	level_data_type            = /datum/level_data/planetoid/exoplanet/snow
 	prefered_level_data_per_z  = list(
 		/datum/level_data/planetoid/exoplanet/snow,

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/volcanic.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/volcanic.dm
@@ -92,7 +92,6 @@
 	overmap_marker_type        = /obj/effect/overmap/visitable/sector/planetoid/exoplanet/volcanic
 	max_themes                 = 1
 	template_tags_blacklist    = TEMPLATE_TAG_HABITAT|TEMPLATE_TAG_WATER
-	template_parent_type       = /datum/map_template/planetoid/random/exoplanet
 	level_data_type            = /datum/level_data/planetoid/exoplanet/volcanic
 	prefered_level_data_per_z  = list(
 		/datum/level_data/planetoid/exoplanet/volcanic,

--- a/code/modules/maps/template_types/random_exoplanet/random_exoplanet.dm
+++ b/code/modules/maps/template_types/random_exoplanet/random_exoplanet.dm
@@ -2,7 +2,6 @@
 /datum/map_template/planetoid/random/exoplanet
 	name                  = "random exoplanet"
 	abstract_type         = /datum/map_template/planetoid/random/exoplanet
-	template_parent_type  = /datum/map_template/planetoid/random/exoplanet
 	template_categories   = list(MAP_TEMPLATE_CATEGORY_EXOPLANET)
 	template_category         = MAP_TEMPLATE_CATEGORY_EXOPLANET_SITE
 	tallness              = 1

--- a/code/modules/maps/template_types/random_exoplanet/random_planet.dm
+++ b/code/modules/maps/template_types/random_exoplanet/random_planet.dm
@@ -7,7 +7,6 @@
 /datum/map_template/planetoid/random
 	name                 = "random planetoid"
 	abstract_type        = /datum/map_template/planetoid/random
-	template_parent_type = /datum/map_template/planetoid/random
 	modify_tag_vars      = TRUE //Would set it to false, since we're generating everything on the fly, but unit test doesn't like it
 	tallness             = 1 //Amount of vertical z-levels to generate for this planet.
 

--- a/code/modules/maps/template_types/ruins.dm
+++ b/code/modules/maps/template_types/ruins.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin
 	name = null
 	template_flags = 0 // No duplicates by default
-	template_parent_type = /datum/map_template/ruin
+	abstract_type = /datum/map_template/ruin
 	var/description
 	var/cost = 0
 	var/prefix

--- a/code/modules/maps/template_types/ruins_exoplanet.dm
+++ b/code/modules/maps/template_types/ruins_exoplanet.dm
@@ -1,4 +1,4 @@
 /datum/map_template/ruin/exoplanet
 	prefix = "maps/random_ruins/exoplanet_ruins/"
 	template_categories = list(MAP_TEMPLATE_CATEGORY_EXOPLANET_SITE)
-	template_parent_type = /datum/map_template/ruin/exoplanet
+	abstract_type = /datum/map_template/ruin/exoplanet

--- a/code/modules/mob/living/human/human_helpers.dm
+++ b/code/modules/mob/living/human/human_helpers.dm
@@ -116,9 +116,8 @@
 		ping_image.layer = BEAM_PROJECTILE_LAYER
 		ping_image.pixel_x = (T.x - src.x) * WORLD_ICON_SIZE
 		ping_image.pixel_y = (T.y - src.y) * WORLD_ICON_SIZE
-		show_image(src, ping_image)
-		spawn(8)
-			qdel(ping_image)
+		show_image(src, ping_image) // todo: should this use screen stuff instead?
+		QDEL_IN(ping_image, 0.8 SECONDS) // qdeling an image is gross but oh well
 		var/feedback = list("<span class='notice'>There are noises of movement ")
 		var/direction = get_dir(src, L)
 		if(direction)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1065,8 +1065,7 @@
 	animation.icon_state = "blank"
 	animation.icon = 'icons/mob/mob.dmi'
 	flick("blspell", animation)
-	sleep(5)
-	qdel(animation)
+	QDEL_IN(animation, 0.5 SECONDS)
 
 /mob/living/silicon/robot/proc/handle_radio_transmission()
 	if(!is_component_functioning("radio"))

--- a/code/modules/mob/living/simple_animal/passive/horse.dm
+++ b/code/modules/mob/living/simple_animal/passive/horse.dm
@@ -1,21 +1,22 @@
 /mob/living/simple_animal/passive/horse
-	name                 = "horse"
-	real_name            = "horse"
-	desc                 = "A hefty four-legged animal traditionally used for hauling goods, recreational riding, and stomping enemy soldiers to death."
-	icon                 = 'icons/mob/simple_animal/horse.dmi'
-	speak_emote          = list("neighs", "whinnies")
-	possession_candidate = TRUE
-	mob_size             = MOB_SIZE_LARGE
-	pixel_x              = -6
-	default_pixel_x      = -6
-	base_animal_type     = /mob/living/simple_animal/passive/horse
-	faction              = null
-	buckle_pixel_shift   = @"{'x':0,'y':0,'z':16}"
-	can_have_rider       = TRUE
-	max_rider_size       = MOB_SIZE_MEDIUM
-	ai                   = /datum/mob_controller/passive/horse
-
-	var/honse_color // Replace this with "base" state when simple animal stuff is merged.
+	name                  = "horse"
+	real_name             = "horse"
+	desc                  = "A hefty four-legged animal traditionally used for hauling goods, recreational riding, and stomping enemy soldiers to death."
+	icon                  = 'icons/mob/simple_animal/horse.dmi'
+	speak_emote           = list("neighs", "whinnies")
+	possession_candidate  = TRUE
+	mob_size              = MOB_SIZE_LARGE
+	pixel_x               = -6
+	default_pixel_x       = -6
+	base_animal_type      = /mob/living/simple_animal/passive/horse
+	faction               = null
+	buckle_pixel_shift    = @"{'x':0,'y':0,'z':16}"
+	can_have_rider        = TRUE
+	max_rider_size        = MOB_SIZE_MEDIUM
+	ai                    = /datum/mob_controller/passive/horse
+	draw_visible_overlays = list(
+		"base"            = "#ccc496"
+	)
 
 /datum/mob_controller/passive/horse
 	emote_speech = list("Neigh!","NEIGH!","Neigh?")
@@ -31,18 +32,15 @@
 	. = ..()
 	add_inventory_slot(new /datum/inventory_slot/back/horse)
 	equip_to_slot_or_del(new /obj/item/saddle(src), slot_back_str)
-	if(!honse_color)
-		honse_color = pick(get_possible_horse_colors())
+	if(!LAZYACCESS(draw_visible_overlays, "base"))
+		LAZYSET(draw_visible_overlays, "base", pick(get_possible_horse_colors()))
 	update_icon()
 
-/mob/living/simple_animal/passive/horse/refresh_visible_overlays()
-	var/list/current_overlays = list(overlay_image(icon, icon_state, honse_color, RESET_COLOR))
+/mob/living/simple_animal/passive/horse/add_additional_visible_overlays(list/accumulator)
 	if(buckled_mob)
-		var/image/horse_front = overlay_image(icon, "[icon_state]-buckled", honse_color, RESET_COLOR)
+		var/image/horse_front = overlay_image(icon, "[icon_state]-buckled", draw_visible_overlays["base"], RESET_COLOR)
 		horse_front.layer = ABOVE_HUMAN_LAYER
-		current_overlays += horse_front
-	set_current_mob_overlay(HO_SKIN_LAYER, current_overlays, redraw_mob = FALSE) // We're almost certainly redrawing in ..() anyway
-	. = ..()
+		accumulator += horse_front
 
 /mob/living/simple_animal/passive/horse/get_bodytype()
 	return GET_DECL(/decl/bodytype/quadruped/animal/horse)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -98,8 +98,7 @@
 	O.add_ai_verbs()
 
 	O.rename_self("ai",1)
-	spawn(0)	// Mobs still instantly del themselves, thus we need to spawn or O will never be returned
-		qdel(src)
+	qdel(src)
 	return O
 
 //human -> robot
@@ -136,7 +135,7 @@
 	RAISE_EVENT(/decl/observ/cyborg_created, O)
 	O.Namepick()
 
-	qdel(src) // Queues us for a hard delete
+	qdel(src)
 	return O
 
 /mob/living/human/proc/corgize()
@@ -188,8 +187,7 @@
 
 
 	to_chat(new_mob, "You suddenly feel more... animalistic.")
-	spawn()
-		qdel(src)
+	qdel(src)
 	return
 
 /mob/proc/Animalize()

--- a/code/modules/organs/ailments/_ailment.dm
+++ b/code/modules/organs/ailments/_ailment.dm
@@ -1,10 +1,9 @@
 /datum/ailment
+	abstract_type = /datum/ailment
 	var/name                      // Descriptive name, primarily used for adminbus.
 	var/timer_id                  // Current timer waiting to proc next symptom message.
 	var/min_time = 2 MINUTES      // Minimum time between symptom messages.
 	var/max_time = 5 MINUTES      // Maximum time between symptom messages.
-	var/category = /datum/ailment // Used similar to hierarchies, if category == type then the
-	                              // ailment is a category and won't be applied to organs.
 	var/obj/item/organ/organ      // Organ associated with the ailment (ailment is in organ.ailments list).
 
 	// Requirements before applying to a target.

--- a/code/modules/organs/ailments/ailment_codex.dm
+++ b/code/modules/organs/ailments/ailment_codex.dm
@@ -40,7 +40,7 @@
 	ailment_table += "<tr><td><b>[name_column]</b></td><td><b>[treatment_column]</b></td></tr>"
 	for(var/atype in subtypesof(/datum/ailment))
 		var/datum/ailment/ailment = get_ailment_reference(atype)
-		if(!ailment.name || show_robotics_recipes != ailment.applies_to_prosthetics || ailment.hidden_from_codex)
+		if(!ailment || show_robotics_recipes != ailment.applies_to_prosthetics || ailment.hidden_from_codex)
 			continue
 		ailment_table += "<tr><td>[ailment.name]</td><td>"
 		var/list/ailment_cures = list()

--- a/code/modules/organs/ailments/ailments_medical.dm
+++ b/code/modules/organs/ailments/ailments_medical.dm
@@ -1,5 +1,5 @@
 /datum/ailment/head
-	category = /datum/ailment/head
+	abstract_type = /datum/ailment/head
 	applies_to_organ = list(BP_HEAD)
 
 /datum/ailment/head/headache

--- a/code/modules/organs/ailments/faults/_fault.dm
+++ b/code/modules/organs/ailments/faults/_fault.dm
@@ -1,7 +1,7 @@
 /datum/ailment/fault
 	applies_to_robotics    = TRUE
 	applies_to_prosthetics = TRUE
-	category = /datum/ailment/fault
+	abstract_type = /datum/ailment/fault
 	treated_by_item_type = list(
 		/obj/item/stack/nanopaste,
 		/obj/item/stack/tape_roll/duct_tape

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -482,8 +482,10 @@
 	return
 
 var/global/list/ailment_reference_cache = list()
-/proc/get_ailment_reference(var/ailment_type)
+/proc/get_ailment_reference(var/datum/ailment/ailment_type)
 	if(!ispath(ailment_type, /datum/ailment))
+		return
+	if(TYPE_IS_ABSTRACT(ailment_type))
 		return
 	if(!global.ailment_reference_cache[ailment_type])
 		global.ailment_reference_cache[ailment_type] = new ailment_type
@@ -495,7 +497,7 @@ var/global/list/ailment_reference_cache = list()
 		return .
 	for(var/ailment_type in subtypesof(/datum/ailment))
 		var/datum/ailment/ailment = ailment_type
-		if(initial(ailment.category) == ailment_type)
+		if(TYPE_IS_ABSTRACT(ailment))
 			continue
 		ailment = get_ailment_reference(ailment_type)
 		if(ailment.can_apply_to(src))

--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -7,7 +7,7 @@
 	var/fuel_consumption = 0 //Amount of moles of gas consumed per trip; If zero, then shuttle is magic and does not need fuel
 	var/list/obj/structure/fuel_port/fuel_ports //the fuel ports of the shuttle (but usually just one)
 
-	category = /datum/shuttle/autodock/overmap
+	abstract_type = /datum/shuttle/autodock/overmap
 	var/skill_needed = SKILL_BASIC
 	var/landing_skill_needed = SKILL_EXPERT
 	var/operator_skill = SKILL_MIN

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -85,7 +85,8 @@
 	to_chat(user, "The charge meter reads [round(src.percent(), 0.1)]%.")
 
 /obj/item/cell/emp_act(severity)
-	//remove this once emp changes on dev are merged in
+	// remove this if EMPs are ever rebalanced so that they don't instantly drain borg cells
+	// todo: containers (partially) shielding contents?
 	if(isrobot(loc))
 		var/mob/living/silicon/robot/R = loc
 		severity *= R.cell_emp_mult

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -612,19 +612,22 @@
 /obj/item/light/proc/switch_on()
 	switchcount++
 	if(rigged)
-		log_and_message_admins("Rigged light explosion, last touched by [fingerprintslast]")
-		var/turf/T = get_turf(src.loc)
-		spawn(0)
-			sleep(2)
-			explosion(T, 0, 0, 3, 5)
-			sleep(1)
-			qdel(src)
+		addtimer(CALLBACK(src, PROC_REF(do_rigged_explosion)), 0.2 SECONDS)
 		status = LIGHT_BROKEN
 	else if(prob(min(60, switchcount*switchcount*0.01)))
 		status = LIGHT_BURNED
 	else if(sound_on)
 		playsound(src, sound_on, 75)
 	return status
+
+/obj/item/light/proc/do_rigged_explosion()
+	if(!rigged)
+		return
+	log_and_message_admins("Rigged light explosion, last touched by [fingerprintslast]")
+	var/turf/T = get_turf(src)
+	explosion(T, 0, 0, 3, 5)
+	if(!QDELETED(src))
+		QDEL_IN(src, 1)
 
 /obj/machinery/light/do_simple_ranged_interaction(var/mob/user)
 	if(lightbulb)

--- a/code/modules/prometheus_metrics/metric_family.dm
+++ b/code/modules/prometheus_metrics/metric_family.dm
@@ -1,11 +1,11 @@
 // Datum used for gathering a set of prometheus metrics.
-/datum/metric_family
+/decl/metric_family
 	var/name = null
 	var/metric_type = null
 	var/help = null
 
 // Collect should return a list of lists with two entries, one being a list and the other being a number.
-/datum/metric_family/proc/collect()
+/decl/metric_family/proc/collect()
 	var/list/out = list()
 
 	out[++out.len] = list(list("foo" = "bar"), 3.14)
@@ -15,9 +15,9 @@
 
 // _to_proto will call the collect() method and format its result in a list
 // suitable for encoding as a JSON protobuf mapping.
-/datum/metric_family/proc/_to_proto()
+/decl/metric_family/proc/_to_proto()
 	var/list/collected = collect()
-	
+
 	var/list/out = list(
 		"name" = name,
 		"type" = metric_type,
@@ -36,7 +36,7 @@
 			label_pairs[++label_pairs.len] = list("name" = k, "value" = m[1][k])
 
 		metrics[++metrics.len] = list("label" = label_pairs, PROMETHEUS_METRIC_NAME(metric_type) = list("value" = m[2]))
-	
+
 	if(metrics.len == 0)
 		return null
 	out["metric"] = metrics

--- a/code/modules/prometheus_metrics/metrics.dm
+++ b/code/modules/prometheus_metrics/metrics.dm
@@ -1,24 +1,15 @@
-var/global/datum/prometheus_metrics/prometheus_metrics = new
-
 // prometheus_metrics holds a list of metric_family datums and uses them to
 // create a json protobuf.
-/datum/prometheus_metrics
+/decl/prometheus_metrics
 	var/list/metric_families
 
-/datum/prometheus_metrics/New()
-	metric_families = list()
-	for(var/T in subtypesof(/datum/metric_family))
-		var/datum/metric_family/mf = T
-		if(initial(mf.name) == null || initial(mf.metric_type) == null)
-			continue
-		metric_families += new T
-
-/datum/prometheus_metrics/proc/collect()
+/decl/prometheus_metrics/proc/collect()
 	var/list/out = list()
 
-	for(var/datum/metric_family/MF in metric_families)
-		var/proto = MF._to_proto()
+	for(var/decl/metric_family/metric_family in decls_repository.get_decls_of_type_unassociated(/decl/metric_family))
+		var/proto = metric_family._to_proto()
 		if(proto != null)
-			out[++out.len] = MF._to_proto()
-	
+			// out += proto will try to merge the lists, we have to insert it at the end instead
+			out[++out.len] = proto
+
 	return json_encode(out)

--- a/code/modules/prometheus_metrics/metrics/byond.dm
+++ b/code/modules/prometheus_metrics/metrics/byond.dm
@@ -1,29 +1,29 @@
 // byond-specific metrics
 
-/datum/metric_family/byond_time
+/decl/metric_family/byond_time
 	name = "byond_world_time_seconds"
 	metric_type = PROMETHEUS_METRIC_COUNTER
 	help = "Counter of 'game-time' seconds since server startup"
 
-/datum/metric_family/byond_time/collect()
+/decl/metric_family/byond_time/collect()
 	return list(list(null, world.time / 10))
 
 
-/datum/metric_family/byond_tick_lag
+/decl/metric_family/byond_tick_lag
 	name = "byond_tick_lag"
 	metric_type = PROMETHEUS_METRIC_GAUGE
 	help = "Current value of world.tick_lag"
 
-/datum/metric_family/byond_tick_lag/collect()
+/decl/metric_family/byond_tick_lag/collect()
 	return list(list(null, world.tick_lag))
 
 
-/datum/metric_family/byond_players
+/decl/metric_family/byond_players
 	name = "byond_players"
 	metric_type = PROMETHEUS_METRIC_GAUGE
 	help = "Number of players currently connected to the server"
 
-/datum/metric_family/byond_players/collect()
+/decl/metric_family/byond_players/collect()
 	var/c = 0
 	for(var/client/C)
 		if(C.connection == "seeker" || C.connection == "web")
@@ -31,10 +31,10 @@
 	return list(list(null, c))
 
 
-/datum/metric_family/byond_cpu
+/decl/metric_family/byond_cpu
 	name = "byond_cpu"
 	metric_type = PROMETHEUS_METRIC_GAUGE
 	help = "Current value of world.cpu"
 
-/datum/metric_family/byond_cpu/collect()
+/decl/metric_family/byond_cpu/collect()
 	return list(list(null, world.cpu))

--- a/code/modules/prometheus_metrics/metrics/ss13.dm
+++ b/code/modules/prometheus_metrics/metrics/ss13.dm
@@ -1,11 +1,11 @@
 // ss13-specific metrics
 
-/datum/metric_family/ss13_controller_time_seconds
+/decl/metric_family/ss13_controller_time_seconds
 	name = "ss13_controller_time_seconds"
 	metric_type = PROMETHEUS_METRIC_COUNTER
 	help = "Counter of time spent in a controller in seconds"
 
-/datum/metric_family/ss13_controller_time_seconds/collect()
+/decl/metric_family/ss13_controller_time_seconds/collect()
 	var/list/out = list()
 	if(Master)
 		for(var/name in Master.total_run_times)
@@ -14,23 +14,23 @@
 	return out
 
 
-/datum/metric_family/ss13_master_runlevel
+/decl/metric_family/ss13_master_runlevel
 	name = "ss13_master_runlevel"
 	metric_type = PROMETHEUS_METRIC_GAUGE
 	help = "Current MC runlevel"
 
-/datum/metric_family/ss13_master_runlevel/collect()
+/decl/metric_family/ss13_master_runlevel/collect()
 	if(Master)
 		return list(list(null, Master.current_runlevel))
 	return list()
 
 
-/datum/metric_family/ss13_garbage_queue_length
+/decl/metric_family/ss13_garbage_queue_length
 	name = "ss13_garbage_queue_length"
 	metric_type = PROMETHEUS_METRIC_GAUGE
 	help = "Length of SSgarbage queues"
 
-/datum/metric_family/ss13_garbage_queue_length/collect()
+/decl/metric_family/ss13_garbage_queue_length/collect()
 	var/list/out = list()
 
 	if(SSgarbage)
@@ -40,12 +40,12 @@
 	return out
 
 
-/datum/metric_family/ss13_garbage_queue_results
+/decl/metric_family/ss13_garbage_queue_results
 	name = "ss13_garbage_queue_results"
 	metric_type = PROMETHEUS_METRIC_COUNTER
 	help = "Counter of pass/fail results for SSgarbage queues"
 
-/datum/metric_family/ss13_garbage_queue_results/collect()
+/decl/metric_family/ss13_garbage_queue_results/collect()
 	var/list/out = list()
 
 	if(SSgarbage)
@@ -56,12 +56,12 @@
 	return out
 
 
-/datum/metric_family/ss13_garbage_total_cleaned
+/decl/metric_family/ss13_garbage_total_cleaned
 	name = "ss13_garbage_total_cleaned"
 	metric_type = PROMETHEUS_METRIC_COUNTER
 	help = "Counter for number of objects deleted/GCed by SSgarbage"
 
-/datum/metric_family/ss13_garbage_total_cleaned/collect()
+/decl/metric_family/ss13_garbage_total_cleaned/collect()
 	var/list/out = list()
 
 	if(SSgarbage)

--- a/code/modules/recycling/disposalpipe.dm
+++ b/code/modules/recycling/disposalpipe.dm
@@ -184,8 +184,7 @@
 		if(H)
 			expel(H, T, 0)
 
-	spawn(2)	// delete pipe after 2 ticks to ensure expel proc finished
-		qdel(src)
+	QDEL_IN(src, 2) // delete pipe after 2 ticks to ensure expel proc finished
 
 
 // pipe affected by explosion

--- a/code/modules/shuttles/escape_pods.dm
+++ b/code/modules/shuttles/escape_pods.dm
@@ -3,7 +3,7 @@ var/global/list/escape_pods_by_name = list()
 
 /datum/shuttle/autodock/ferry/escape_pod
 	var/datum/computer/file/embedded_program/docking/simple/escape_pod_berth/arming_controller
-	category = /datum/shuttle/autodock/ferry/escape_pod
+	abstract_type = /datum/shuttle/autodock/ferry/escape_pod
 	move_time = 100
 
 /datum/shuttle/autodock/ferry/escape_pod/New(map_hash)

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -12,7 +12,7 @@
 	var/arrive_time = 0	//the time at which the shuttle arrives when long jumping
 	var/flags = 0
 	var/process_state = IDLE_STATE //Used with SHUTTLE_FLAGS_PROCESS, as well as to store current state.
-	var/category = /datum/shuttle
+	abstract_type = /datum/shuttle
 	var/multiz = 0	//how many multiz levels, starts at 0
 
 	var/ceiling_type = /turf/unsimulated/floor/shuttle_ceiling

--- a/code/modules/shuttles/shuttle_autodock.dm
+++ b/code/modules/shuttles/shuttle_autodock.dm
@@ -16,7 +16,7 @@
 	var/obj/effect/shuttle_landmark/landmark_transition  //This variable is type-abused initially: specify the landmark_tag, not the actual landmark.
 	var/move_time = 240		//the time spent in the transition area
 
-	category = /datum/shuttle/autodock
+	abstract_type = /datum/shuttle/autodock
 	flags = SHUTTLE_FLAGS_PROCESS | SHUTTLE_FLAGS_ZERO_G
 
 /datum/shuttle/autodock/New(var/map_hash, var/obj/effect/shuttle_landmark/start_waypoint)

--- a/code/modules/shuttles/shuttle_emergency.dm
+++ b/code/modules/shuttles/shuttle_emergency.dm
@@ -1,5 +1,5 @@
 /datum/shuttle/autodock/ferry/emergency
-	category = /datum/shuttle/autodock/ferry/emergency
+	abstract_type = /datum/shuttle/autodock/ferry/emergency
 	move_time = 10 MINUTES
 	flags = SHUTTLE_FLAGS_PROCESS | SHUTTLE_FLAGS_ZERO_G | SHUTTLE_FLAGS_NO_CODE
 	var/datum/evacuation_controller/shuttle/emergency_controller

--- a/code/modules/shuttles/shuttle_ferry.dm
+++ b/code/modules/shuttles/shuttle_ferry.dm
@@ -7,7 +7,7 @@
 	var/obj/effect/shuttle_landmark/waypoint_station  //This variable is type-abused initially: specify the landmark_tag, not the actual landmark.
 	var/obj/effect/shuttle_landmark/waypoint_offsite  //This variable is type-abused initially: specify the landmark_tag, not the actual landmark.
 
-	category = /datum/shuttle/autodock/ferry
+	abstract_type = /datum/shuttle/autodock/ferry
 
 /datum/shuttle/autodock/ferry/New(map_hash)
 	if(map_hash)

--- a/code/modules/shuttles/shuttle_specops.dm
+++ b/code/modules/shuttles/shuttle_specops.dm
@@ -14,10 +14,7 @@
 	var/reset_time = 0	//the world.time at which the shuttle will be ready to move again.
 	var/launch_prep = 0
 	var/cancel_countdown = 0
-	category = /datum/shuttle/autodock/ferry/specops
-
-/datum/shuttle/autodock/ferry/specops/New()
-	..()
+	abstract_type = /datum/shuttle/autodock/ferry/specops
 
 /datum/shuttle/autodock/ferry/specops/launch(var/user)
 	if (!can_launch())

--- a/code/modules/shuttles/shuttle_supply.dm
+++ b/code/modules/shuttles/shuttle_supply.dm
@@ -3,7 +3,7 @@
 	var/late_chance = 80
 	var/max_late_time = (30 SECONDS)
 	flags = SHUTTLE_FLAGS_PROCESS|SHUTTLE_FLAGS_SUPPLY|SHUTTLE_FLAGS_NO_CODE
-	category = /datum/shuttle/autodock/ferry/supply
+	abstract_type = /datum/shuttle/autodock/ferry/supply
 	ceiling_type = /turf/floor/shuttle_ceiling
 
 /datum/shuttle/autodock/ferry/supply/short_jump(var/area/destination)

--- a/code/modules/shuttles/shuttles_multi.dm
+++ b/code/modules/shuttles/shuttles_multi.dm
@@ -2,7 +2,7 @@
 	var/list/destination_tags
 	var/list/destinations_cache = list()
 	var/last_cache_rebuild_time = 0
-	category = /datum/shuttle/autodock/multi
+	abstract_type = /datum/shuttle/autodock/multi
 
 /datum/shuttle/autodock/multi/New(map_hash)
 	..()
@@ -42,7 +42,7 @@
 	var/arrival_message
 	var/departure_message
 
-	category = /datum/shuttle/autodock/multi/antag
+	abstract_type = /datum/shuttle/autodock/multi/antag
 
 /datum/shuttle/autodock/multi/antag/New(map_hash)
 	..()

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -144,23 +144,17 @@
 		healthcheck()
 
 /obj/vehicle/emp_act(severity)
-	var/was_on = on
+	addtimer(CALLBACK(src, PROC_REF(end_emp), on), severity * 30 SECONDS)
 	stat |= EMPED
-	var/obj/effect/overlay/pulse2 = new /obj/effect/overlay(loc)
-	pulse2.icon = 'icons/effects/effects.dmi'
-	pulse2.icon_state = "empdisable"
-	pulse2.SetName("emp sparks")
-	pulse2.anchored = TRUE
-	pulse2.set_dir(pick(global.cardinal))
-
-	spawn(10)
-		qdel(pulse2)
+	var/obj/effect/temp_visual/emp_burst/burst = new /obj/effect/temp_visual/emp_burst(loc)
+	burst.set_dir(pick(global.cardinal))
 	if(on)
 		turn_off()
-	spawn(severity*300)
-		stat &= ~EMPED
-		if(was_on)
-			turn_on()
+
+/obj/vehicle/proc/end_emp(was_on)
+	stat &= ~EMPED
+	if(was_on)
+		turn_on()
 
 /obj/vehicle/attack_ai(mob/living/silicon/ai/user)
 	return

--- a/code/unit_tests/_template.dm
+++ b/code/unit_tests/_template.dm
@@ -7,8 +7,8 @@
 
 /datum/unit_test/template
 	name = "Test Template - Change My name"
-	template = /datum/unit_test/template    // Set this var equal to the test path to treat it as a template, i.e. it should not be run
-	async = 1                               // Set if we should continue testing elsewhere and come back and check on the results.
+	abstract_type = /datum/unit_test/template // Set this var equal to the test path to treat it as a template, i.e. it should not be run
+	async = 1                                 // Set if we should continue testing elsewhere and come back and check on the results.
 
 
 /datum/unit_test/template/start_test()

--- a/code/unit_tests/atmospherics_tests.dm
+++ b/code/unit_tests/atmospherics_tests.dm
@@ -2,7 +2,7 @@
 	Unit tests for ATMOSPHERICS primitives
 */
 /datum/unit_test/atmos_machinery
-	template = /datum/unit_test/atmos_machinery
+	abstract_type = /datum/unit_test/atmos_machinery
 	var/list/test_cases = list()
 
 /datum/unit_test/atmos_machinery/proc/create_gas_mixes(gas_mix_data)
@@ -60,7 +60,7 @@
 		pass("[case_name]: conserved moles of each gas ID.")
 
 /datum/unit_test/atmos_machinery/conserve_moles
-	template = /datum/unit_test/atmos_machinery/conserve_moles
+	abstract_type = /datum/unit_test/atmos_machinery/conserve_moles
 	test_cases = list(
 		uphill = list(
 			source = list(

--- a/code/unit_tests/chemistry_tests.dm
+++ b/code/unit_tests/chemistry_tests.dm
@@ -1,6 +1,6 @@
 /datum/unit_test/chemistry
 	name = "CHEMISTRY: Reagent Template"
-	template = /datum/unit_test/chemistry
+	abstract_type = /datum/unit_test/chemistry
 
 	var/container_volume = 45
 	var/donor_type = /obj/item

--- a/code/unit_tests/equipment_tests.dm
+++ b/code/unit_tests/equipment_tests.dm
@@ -1,6 +1,6 @@
 /datum/unit_test/vision_glasses
 	name = "EQUIPMENT: Vision Template"
-	template = /datum/unit_test/vision_glasses
+	abstract_type = /datum/unit_test/vision_glasses
 	var/mob/living/human/H = null
 	var/expectation = SEE_INVISIBLE_NOLIGHTING
 	var/glasses_type = null

--- a/code/unit_tests/extension_tests.dm
+++ b/code/unit_tests/extension_tests.dm
@@ -1,6 +1,6 @@
 /datum/unit_test/extensions
 	name = "EXTENSIONS template"
-	template = /datum/unit_test/extensions
+	abstract_type = /datum/unit_test/extensions
 	async = 0
 
 /datum/unit_test/extensions/basic_extension_shall_lazy_initalize_as_expected

--- a/code/unit_tests/foundation_tests.dm
+++ b/code/unit_tests/foundation_tests.dm
@@ -3,7 +3,7 @@
 */
 /datum/unit_test/foundation
 	name = "FOUNDATION template"
-	template = /datum/unit_test/foundation
+	abstract_type = /datum/unit_test/foundation
 	async = 0
 
 /datum/unit_test/foundation/step_shall_return_true_on_success

--- a/code/unit_tests/graph_tests.dm
+++ b/code/unit_tests/graph_tests.dm
@@ -430,7 +430,7 @@
 * Base Test Setup *
 ******************/
 /datum/unit_test/graph_test
-	template = /datum/unit_test/graph_test
+	abstract_type = /datum/unit_test/graph_test
 	async = TRUE
 	var/list/graphs
 

--- a/code/unit_tests/icon_tests.dm
+++ b/code/unit_tests/icon_tests.dm
@@ -1,6 +1,6 @@
 /datum/unit_test/icon_test
 	name = "ICON STATE template"
-	template = /datum/unit_test/icon_test
+	abstract_type = /datum/unit_test/icon_test
 
 /datum/unit_test/icon_test/food_shall_have_icon_states
 	name = "ICON STATE: Food And Drink Subtypes Shall Have Icon States"

--- a/code/unit_tests/integrated_circuits.dm
+++ b/code/unit_tests/integrated_circuits.dm
@@ -1,5 +1,5 @@
 /datum/unit_test/integrated_circuits
-	template = /datum/unit_test/integrated_circuits
+	abstract_type = /datum/unit_test/integrated_circuits
 
 /datum/unit_test/integrated_circuits/unique_names
 	name = "INTEGRATED CIRCUITS: Circuits must have unique names"
@@ -64,7 +64,7 @@
 
 /datum/unit_test/integrated_circuits/input_output
 	name = "INTEGRATED CIRCUITS: INPUT/OUTPUT - TEMPLATE"
-	template = /datum/unit_test/integrated_circuits/input_output
+	abstract_type = /datum/unit_test/integrated_circuits/input_output
 	var/list/all_inputs = list()
 	var/list/all_expected_outputs = list()
 	var/activation_pin = 1

--- a/code/unit_tests/mob_tests.dm
+++ b/code/unit_tests/mob_tests.dm
@@ -129,7 +129,7 @@ var/global/default_mobloc = null
 
 /datum/unit_test/mob_damage
 	name = "MOB: Template for mob damage"
-	template = /datum/unit_test/mob_damage
+	abstract_type = /datum/unit_test/mob_damage
 	var/damagetype = BRUTE
 	var/mob_type = /mob/living/human
 	var/expected_vulnerability = STANDARD

--- a/code/unit_tests/movement_tests.dm
+++ b/code/unit_tests/movement_tests.dm
@@ -1,6 +1,6 @@
 /datum/unit_test/movement
 	name = "MOVEMENT template"
-	template = /datum/unit_test/movement
+	abstract_type = /datum/unit_test/movement
 	async = 0
 
 /datum/unit_test/movement/force_move_shall_trigger_crossed_when_entering_turf

--- a/code/unit_tests/observation_tests.dm
+++ b/code/unit_tests/observation_tests.dm
@@ -4,7 +4,7 @@
 
 /datum/unit_test/observation
 	name = "OBSERVATION template"
-	template = /datum/unit_test/observation
+	abstract_type = /datum/unit_test/observation
 	async = 0
 	var/list/received_moves
 	var/list/received_name_set_events

--- a/code/unit_tests/override_tests.dm
+++ b/code/unit_tests/override_tests.dm
@@ -2,7 +2,7 @@
 
 /datum/unit_test/override
 	name = "OVERRIDE template"
-	template = /datum/unit_test/override
+	abstract_type = /datum/unit_test/override
 
 /datum/unit_test/override/obj_random_shall_spawn_heaviest_item
 	name = "OVERRIDE: obj/random shall spawn heaviest item"

--- a/code/unit_tests/proximity_tests.dm
+++ b/code/unit_tests/proximity_tests.dm
@@ -2,7 +2,7 @@
 * Template Setup *
 *****************/
 /datum/unit_test/proximity
-	template = /datum/unit_test/proximity
+	abstract_type = /datum/unit_test/proximity
 	var/turf/wall/wall
 	var/obj/proximity_listener/proximity_listener
 
@@ -24,7 +24,7 @@
 		wall.set_opacity(opacity)
 
 /datum/unit_test/proximity/visibility
-	template = /datum/unit_test/proximity/visibility
+	abstract_type = /datum/unit_test/proximity/visibility
 	var/list/expected_number_of_turfs_by_trigger_type
 
 /datum/unit_test/proximity/visibility/start_test()

--- a/code/unit_tests/time_tests.dm
+++ b/code/unit_tests/time_tests.dm
@@ -1,6 +1,6 @@
 /datum/unit_test/time
 	name = "TIME: Template"
-	template = /datum/unit_test/time
+	abstract_type = /datum/unit_test/time
 
 /datum/unit_test/time/shall_validate_sixth_of_june
 	name = "TIME: Shall validate 6th of June"

--- a/code/unit_tests/unit_test.dm
+++ b/code/unit_tests/unit_test.dm
@@ -4,7 +4,7 @@
  *   For the most part I think any test can be created that doesn't require a client in a mob or require a game mode other then extended
  *
  *   The easiest way to make effective tests is to create a "template" if you intend to run the same test over and over and make your actual
- *   tests be a "child object" of those templates.  Be sure and name your templates with the word "template" somewhere in var/name.
+ *   tests be a "child object" of those templates.  Be sure to set abstract_type on your template type.
  *
  *   The goal is to have all sorts of tests that run and to run them as quickly as possible.
  *
@@ -51,8 +51,8 @@ var/global/ascii_reset = "[ascii_esc]\[0m"
 // Templates aren't intended to be ran but just serve as a way to create child objects of it with inheritable tests for quick test creation.
 
 /datum/unit_test
+	abstract_type = /datum/unit_test
 	var/name = "template - should not be ran."
-	var/template        // Treat the unit test as a template if its type is the same as the value of this var
 	var/disabled = 0    // If we want to keep a unit test in the codebase but not run it for some reason.
 	var/async = 0       // If the check can be left to do it's own thing, you must define a check_result() proc if you use this.
 	var/reported = 0	// If it's reported a success or failure.  Any tests that have not are assumed to be failures.
@@ -157,11 +157,10 @@ var/global/ascii_reset = "[ascii_esc]\[0m"
 
 /proc/get_test_datums()
 	. = list()
-	for(var/test in subtypesof(/datum/unit_test))
-		var/datum/unit_test/d = test
-		if(test == initial(d.template))
+	for(var/datum/unit_test/test as anything in subtypesof(/datum/unit_test))
+		if(TYPE_IS_ABSTRACT(test))
 			continue
-		. += d
+		. += test
 
 /proc/do_unit_test(datum/unit_test/test, end_time, skip_disabled_tests = TRUE)
 	if(test.disabled && skip_disabled_tests)

--- a/code/unit_tests/virtual_mob_tests.dm
+++ b/code/unit_tests/virtual_mob_tests.dm
@@ -1,10 +1,10 @@
 /datum/unit_test/virtual
 	name = "VIRTUAL: Template"
-	template = /datum/unit_test/virtual
+	abstract_type = /datum/unit_test/virtual
 
 /datum/unit_test/virtual/helper
 	name = "VIRTUAL: Template Helper"
-	template = /datum/unit_test/virtual/helper
+	abstract_type = /datum/unit_test/virtual/helper
 
 	var/helper_proc
 	var/list/expected_mobs

--- a/code/unit_tests/zas_tests.dm
+++ b/code/unit_tests/zas_tests.dm
@@ -12,7 +12,7 @@
 
 /datum/unit_test/zas_area_test
 	name = "ZAS: Area Test Template"
-	template = /datum/unit_test/zas_area_test
+	abstract_type = /datum/unit_test/zas_area_test
 	var/area_path = null                    // Put the area you are testing here.
 	var/expectation = UT_NORMAL             // See defines above.
 

--- a/maps/random_ruins/space_ruins/space_ruins.dm
+++ b/maps/random_ruins/space_ruins/space_ruins.dm
@@ -5,6 +5,7 @@
 	material = /decl/material/solid/gemstone/diamond
 
 /datum/map_template/ruin/space
+	abstract_type = /datum/map_template/ruin/space
 	template_categories = list(MAP_TEMPLATE_CATEGORY_SPACE)
 	prefix = "maps/random_ruins/space_ruins/"
 	cost = 1

--- a/mods/content/fantasy/submaps/_submaps.dm
+++ b/mods/content/fantasy/submaps/_submaps.dm
@@ -7,7 +7,6 @@
 
 /datum/map_template/fantasy
 	abstract_type = /datum/map_template/fantasy
-	template_parent_type = /datum/map_template/fantasy
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	area_usage_test_exempted_root_areas = list(
 		/area/fantasy/outside/point_of_interest

--- a/mods/content/fantasy/submaps/downlands/_downlands.dm
+++ b/mods/content/fantasy/submaps/downlands/_downlands.dm
@@ -1,9 +1,7 @@
 /datum/map_template/fantasy/downlands
 	abstract_type = /datum/map_template/fantasy/downlands
 	template_categories = list(MAP_TEMPLATE_CATEGORY_FANTASY_DOWNLANDS)
-	template_parent_type = /datum/map_template/fantasy/downlands
 
 /datum/map_template/fantasy/dungeon
 	abstract_type = /datum/map_template/fantasy/dungeon
 	template_categories = list(MAP_TEMPLATE_CATEGORY_FANTASY_DUNGEON)
-	template_parent_type = /datum/map_template/fantasy/dungeon

--- a/mods/content/fantasy/submaps/grassland/_grassland.dm
+++ b/mods/content/fantasy/submaps/grassland/_grassland.dm
@@ -1,9 +1,7 @@
 /datum/map_template/fantasy/grassland
 	abstract_type = /datum/map_template/fantasy/grassland
 	template_categories = list(MAP_TEMPLATE_CATEGORY_FANTASY_GRASSLAND)
-	template_parent_type = /datum/map_template/fantasy/grassland
 
 /datum/map_template/fantasy/cavern
 	abstract_type = /datum/map_template/fantasy/cavern
 	template_categories = list(MAP_TEMPLATE_CATEGORY_FANTASY_CAVERNS)
-	template_parent_type = /datum/map_template/fantasy/cavern

--- a/mods/content/fantasy/submaps/swamp/_swamp.dm
+++ b/mods/content/fantasy/submaps/swamp/_swamp.dm
@@ -1,4 +1,3 @@
 /datum/map_template/fantasy/swamp
 	abstract_type = /datum/map_template/fantasy/swamp
 	template_categories = list(MAP_TEMPLATE_CATEGORY_FANTASY_SWAMP)
-	template_parent_type = /datum/map_template/fantasy/swamp

--- a/mods/content/fantasy/submaps/woods/_woods.dm
+++ b/mods/content/fantasy/submaps/woods/_woods.dm
@@ -1,4 +1,3 @@
 /datum/map_template/fantasy/woods
 	abstract_type = /datum/map_template/fantasy/woods
 	template_categories = list(MAP_TEMPLATE_CATEGORY_FANTASY_WOODS)
-	template_parent_type = /datum/map_template/fantasy/woods

--- a/mods/content/psionics/system/psionics/equipment/psipower_tk.dm
+++ b/mods/content/psionics/system/psionics/equipment/psipower_tk.dm
@@ -106,5 +106,4 @@
 		O.icon = 'icons/effects/effects.dmi'
 		O.icon_state = "nothing"
 		flick("empdisable",O)
-		sleep(5)
-		qdel(O)
+		QDEL_IN(src, 0.5 SECONDS)

--- a/mods/mobs/borers/mob/organ.dm
+++ b/mods/mobs/borers/mob/organ.dm
@@ -38,5 +38,4 @@
 		B.leave_host()
 		B.ckey = last_owner.ckey
 
-	spawn(0)
-		qdel(src)
+	qdel(src)

--- a/mods/species/vox/datum/unit_testing.dm
+++ b/mods/species/vox/datum/unit_testing.dm
@@ -4,7 +4,7 @@
 
 /datum/unit_test/mob_damage/vox
 	name = "MOB: Vox damage check template"
-	template = /datum/unit_test/mob_damage/vox
+	abstract_type = /datum/unit_test/mob_damage/vox
 	mob_type = /mob/living/human/vox
 
 /datum/unit_test/mob_damage/vox/brute


### PR DESCRIPTION
## Description of changes
Removes a lot of spawn() and sleep() abuse in favor of QDEL_IN and timers.
Makes a bunch of things use abstract_type instead of bespoke vars that do the same thing.
Makes attack filters a datum subtype.
Makes the prometheus metrics system use decls.
Fixes some old outdated code comments.
Fixes horse coloration.

## Why and what will this PR improve
Improves code quality and consistency.