### PR TITLE
Fix double words in strings and comments

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -81,8 +81,8 @@ The latter will result in a linter warning and will not work correctly.
 #define ITEM_FLAG_NOCUFFS                   BITFLAG(11) // Gloves that have this flag prevent cuffs being applied
 #define ITEM_FLAG_CAN_HIDE_IN_SHOES         BITFLAG(12) // Items that can be hidden in shoes that permit it
 #define ITEM_FLAG_PADDED                    BITFLAG(13) // When set on gloves, will act like pulling punches in unarmed combat.
-#define ITEM_FLAG_CAN_TAPE                  BITFLAG(14) // Whether the item can be be taped onto something using tape
-#define ITEM_FLAG_IS_WEAPON               BITFLAG(15) // Item is considered a weapon. Currently only used for force-based worth calculation.
+#define ITEM_FLAG_CAN_TAPE                  BITFLAG(14) // Whether the item can be taped onto something using tape
+#define ITEM_FLAG_IS_WEAPON                 BITFLAG(15) // Item is considered a weapon. Currently only used for force-based worth calculation.
 
 // Flags for pass_flags (/atom/var/pass_flags)
 #define PASS_FLAG_TABLE                     BITFLAG(0)

--- a/code/__defines/gamemode.dm
+++ b/code/__defines/gamemode.dm
@@ -3,7 +3,7 @@
 #define CHOOSE_GAMEMODE_RETRY       2 // The gamemode could not be chosen; we will use the next most popular option voted in, or the default.
 #define CHOOSE_GAMEMODE_REVOTE      3 // The gamemode could not be chosen; we need to have a revote.
 #define CHOOSE_GAMEMODE_RESTART     4 // The gamemode could not be chosen; we will restart the server.
-#define CHOOSE_GAMEMODE_SILENT_REDO 5 // The gamemode could not be chosen; we request to have the the proc rerun on the next tick.
+#define CHOOSE_GAMEMODE_SILENT_REDO 5 // The gamemode could not be chosen; we request to have the proc rerun on the next tick.
 
 //End game state, to manage round end.
 #define END_GAME_NOT_OVER         1

--- a/code/datums/wires/nuclearbomb.dm
+++ b/code/datums/wires/nuclearbomb.dm
@@ -20,7 +20,7 @@ var/global/const/NUCLEARBOMB_WIRE_SAFETY		= 4
 	var/obj/machinery/nuclearbomb/N = holder
 	. += ..()
 	. += "<BR>The device is [N.timing ? "shaking!" : "still."]<BR>"
-	. += "The device is is [N.safety ? "quiet" : "whirring"].<BR>"
+	. += "The device is [N.safety ? "quiet" : "whirring"].<BR>"
 	. += "The lights are [N.lighthack ? "static" : "functional"].<BR>"
 
 /datum/wires/nuclearbomb/proc/toggle_hacked()

--- a/code/game/machinery/_machines_base/stock_parts/power/terminal.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/terminal.dm
@@ -135,7 +135,7 @@
 		if(!C.can_use(10))
 			to_chat(user, "<span class='warning'>You need ten lengths of cable for \the [machine].</span>")
 			return TRUE
-		user.visible_message("<span class='warning'>\The [user] adds cables to the \the [machine].</span>", \
+		user.visible_message("<span class='warning'>\The [user] adds cables to \the [machine].</span>", \
 							"You start adding cables to \the [machine] frame...")
 		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		if(do_after(user, 20, machine))
@@ -147,8 +147,8 @@
 						return TRUE
 				C.use(10)
 				user.visible_message(\
-					"<span class='warning'>\The [user] has added cables to the \the [machine]!</span>",\
-					"You add cables to the \the [machine].")
+					"<span class='warning'>\The [user] has added cables to \the [machine]!</span>",\
+					"You add cables to \the [machine].")
 				make_terminal(machine)
 		return TRUE
 

--- a/code/game/machinery/pipe/pipelayer.dm
+++ b/code/game/machinery/pipe/pipelayer.dm
@@ -73,7 +73,7 @@
 			if(m)
 				use_metal(m)
 				SSmaterials.create_object(/decl/material/solid/metal/steel, get_turf(src), m)
-				user.visible_message("<span class='notice'>[user] removes [m] sheet\s of metal from the \the [src].</span>", "<span class='notice'>You remove [m] sheet\s of metal from \the [src]</span>")
+				user.visible_message(SPAN_NOTICE("[user] removes [m] sheet\s of metal from \the [src]."), SPAN_NOTICE("You remove [m] sheet\s of metal from \the [src]"))
 		else
 			to_chat(user, "\The [src] is empty.")
 		return

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -246,7 +246,7 @@
 	icon = 'icons/obj/airlock_machines.dmi'
 	icon_state = "airlock_control_off"
 	name = "airlock controller frame"
-	desc = "Used to build airlock controllers. Use a multitool on the circuit to determine which type you want, and then hit this with the the circuit."
+	desc = "Used to build airlock controllers. Use a multitool on the circuit to determine which type you want, and then hit this with the circuit."
 	build_machine_type = null
 	///Used when configuring a dummy controller
 	var/master_controller_id_tag

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -69,7 +69,7 @@
 		do
 			var/datum/uplink_random_selection/uplink_selection = get_uplink_random_selection_by_type(/datum/uplink_random_selection/blacklist)
 			new_discount_item = uplink_selection.get_random_item(INFINITY, src)
-		// Ensures we only only get items for which we get an actual discount and that this particular uplink can actually view (can buy would risk near-infinite loops).
+		// Ensures we only get items for which we get an actual discount and that this particular uplink can actually view (can buy would risk near-infinite loops).
 		while(is_improper_item(new_discount_item, discount_amount))
 		if(!new_discount_item)
 			return

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -89,16 +89,16 @@
 		switch(det_time)
 			if (1)
 				det_time = 10
-				to_chat(user, SPAN_NOTICE("You set the \the [src] for 1 second detonation time."))
+				to_chat(user, SPAN_NOTICE("You set \the [src] for 1 second detonation time."))
 			if (10)
 				det_time = 30
-				to_chat(user, SPAN_NOTICE("You set the \the [src] for 3 second detonation time."))
+				to_chat(user, SPAN_NOTICE("You set \the [src] for 3 second detonation time."))
 			if (30)
 				det_time = 50
-				to_chat(user, SPAN_NOTICE("You set the \the [src] for 5 second detonation time."))
+				to_chat(user, SPAN_NOTICE("You set \the [src] for 5 second detonation time."))
 			if (50)
 				det_time = 1
-				to_chat(user, SPAN_NOTICE("You set the \the [src] for instant detonation."))
+				to_chat(user, SPAN_NOTICE("You set \the [src] for instant detonation."))
 		add_fingerprint(user)
 		return TRUE
 	return ..()

--- a/code/game/objects/items/weapons/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/weapons/grenades/spawnergrenade.dm
@@ -1,5 +1,5 @@
 /obj/item/grenade/spawnergrenade
-	desc = "It is set to detonate in 5 seconds. It will unleash unleash an unspecified anomaly into the vicinity."
+	desc = "It is set to detonate in 5 seconds. It will unleash an unspecified anomaly into the vicinity."
 	name = "delivery grenade"
 	icon = 'icons/obj/items/grenades/delivery.dmi'
 	origin_tech = @'{"materials":3,"magnets":4}'

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -193,7 +193,7 @@ var/global/list/global/tank_gauge_cache = list()
 		var/obj/item/weldingtool/WT = W
 		if(WT.weld(1,user))
 			if(!valve_welded)
-				to_chat(user, "<span class='notice'>You begin welding the \the [src] emergency pressure relief valve.</span>")
+				to_chat(user, "<span class='notice'>You begin welding \the [src] emergency pressure relief valve.</span>")
 				if(do_after(user, 40,src))
 					to_chat(user, "<span class='notice'>You carefully weld \the [src] emergency pressure relief valve shut.</span><span class='warning'> \The [src] may now rupture under pressure!</span>")
 					valve_welded = 1

--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -41,7 +41,7 @@
 	var/obj/item/removing = contents[contents.len]
 	user.visible_message( \
 		SPAN_NOTICE("\The [user] takes \the [removing] off \the [src]."),
-		SPAN_NOTICE("You take \the [removing] off the \the [src].")
+		SPAN_NOTICE("You take \the [removing] off \the [src].")
 	)
 	removing.dropInto(loc)
 	user.put_in_active_hand(removing)
@@ -74,7 +74,7 @@
 	if(user.try_unequip(W, src))
 		user.visible_message( \
 			SPAN_NOTICE("\The [user] hangs \the [W] on \the [src]."), \
-			SPAN_NOTICE("You hang \the [W] on the \the [src].") \
+			SPAN_NOTICE("You hang \the [W] on \the [src].") \
 		)
 		update_icon()
 	return TRUE

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -67,7 +67,7 @@
 		holder.update_icon()
 	update_beams()
 
-/obj/item/assembly/infra/interact(mob/user)//TODO: change this this to the wire control panel
+/obj/item/assembly/infra/interact(mob/user)//TODO: change this to the wire control panel
 	if(!secured)
 		return
 	if(!CanInteract(user, global.physical_topic_state))

--- a/code/modules/atmospherics/datum_pipeline.dm
+++ b/code/modules/atmospherics/datum_pipeline.dm
@@ -45,7 +45,7 @@
 
 	. = ..()
 
-/datum/pipeline/Process()//This use to be called called from the pipe networks
+/datum/pipeline/Process()//This use to be called from the pipe networks
 	//Check to see if pressure is within acceptable limits
 	var/pressure = air.return_pressure()
 	if(pressure > maximum_pressure)

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -183,7 +183,7 @@
 /obj/item/clothing/mask/smokable/attack(var/mob/living/M, var/mob/living/user, def_zone)
 	if(istype(M) && M.on_fire)
 		user.do_attack_animation(M)
-		light(SPAN_NOTICE("\The [user] coldly lights the \the [src] with the burning body of \the [M]."))
+		light(SPAN_NOTICE("\The [user] coldly lights \the [src] with the burning body of \the [M]."))
 		return 1
 	else
 		return ..()

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -1,6 +1,6 @@
 //Spacesuit
 //Note: Everything in modules/clothing/spacesuits should have the entire suit grouped together.
-//      Meaning the the suit is defined directly after the corrisponding helmet. Just like below!
+//      Meaning the suit is defined directly after the corresponding helmet. Just like below!
 
 /obj/item/clothing/head/helmet/space
 	name = "space helmet"

--- a/code/modules/clothing/suits/armor/merc.dm
+++ b/code/modules/clothing/suits/armor/merc.dm
@@ -4,7 +4,7 @@
 
 /obj/item/clothing/accessory/armor/plate/merc
 	name = "heavy armor plate"
-	desc = "A diamond-reinforced titanium armor plate, providing state of of the art protection. Attaches to a plate carrier."
+	desc = "A diamond-reinforced titanium armor plate, providing state of the art protection. Attaches to a plate carrier."
 	icon = 'icons/clothing/accessories/armor/armor_merc.dmi'
 	armor = list(
 		ARMOR_MELEE = ARMOR_MELEE_RESISTANT,

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -82,7 +82,7 @@
 								"When asked a question, respond with the least-obvious and least-rational answer.",
 								"[pick("Everyone", random_player)] is wearing a pretty pink dress! Compliment it!",
 								"You are the [location_name()]'s psychologist. Give advice to [pick("the crew", random_player)].",
-								"[random_player] is the monarch of of England. Ensure all crewmembers pay due respect.",
+								"[random_player] is the monarch of England. Ensure all crewmembers pay due respect.",
 								"[pick("The crew", random_player)] is [pick("ugly","beautiful")]. Ensure all are aware.",
 								"Reminding the crew of their mortality is good for the morale. Keep the crew's morale up.",
 								"[pick("Monkeys","Doors")] are part of the crew, too. Make sure they are treated humanely.",

--- a/code/modules/integrated_electronics/subtypes/memory.dm
+++ b/code/modules/integrated_electronics/subtypes/memory.dm
@@ -63,7 +63,7 @@
 
 /obj/item/integrated_circuit/memory/huge
 	name = "large memory stick"
-	desc = "This stick of memory can store up up to sixteen pieces of data."
+	desc = "This stick of memory can store up to sixteen pieces of data."
 	icon_state = "memory16"
 	w_class = ITEM_SIZE_SMALL
 	spawn_flags = IC_SPAWN_RESEARCH

--- a/code/modules/maps/_map_template.dm
+++ b/code/modules/maps/_map_template.dm
@@ -225,7 +225,7 @@
 	if (SSlighting.initialized)
 		SSlighting.InitializeTurfs(atoms_to_initialise)	// Hopefully no turfs get placed on new coords by SSatoms.
 
-	log_game("[name] loaded at at [T.x],[T.y],[T.z]")
+	log_game("[name] loaded at [T.x],[T.y],[T.z]")
 	loaded++
 
 	return TRUE

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -289,7 +289,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 // Placeholders for light tiles and rglass.
 /decl/material/proc/reinforce(var/mob/user, var/obj/item/stack/material/used_stack, var/obj/item/stack/material/target_stack, var/use_sheets = 1)
 	if(!used_stack.can_use(use_sheets))
-		to_chat(user, SPAN_WARNING("You need need at least one [used_stack.singular_name] to reinforce [target_stack]."))
+		to_chat(user, SPAN_WARNING("You need at least one [used_stack.singular_name] to reinforce [target_stack]."))
 		return
 
 	var/decl/material/reinf_mat = used_stack.material
@@ -298,7 +298,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 		return
 
 	if(!target_stack.can_use(use_sheets))
-		to_chat(user, SPAN_WARNING("You need need at least [use_sheets] [use_sheets == 1 ? target_stack.singular_name : target_stack.plural_name] for reinforcement with [used_stack]."))
+		to_chat(user, SPAN_WARNING("You need at least [use_sheets] [use_sheets == 1 ? target_stack.singular_name : target_stack.plural_name] for reinforcement with [used_stack]."))
 		return
 
 	to_chat(user, SPAN_NOTICE("You reinforce the [target_stack] with [reinf_mat.solid_name]."))

--- a/code/modules/mechs/components/frame.dm
+++ b/code/modules/mechs/components/frame.dm
@@ -198,7 +198,7 @@
 				to_chat(user, SPAN_WARNING("You need at least ten sheets to reinforce \the [src]."))
 				return
 
-			visible_message("\The [user] begins layering the interior of the \the [src] with \the [M].")
+			visible_message("\The [user] begins layering the interior of \the [src] with \the [M].")
 
 			if(!do_after(user, 30 * user.skill_delay_mult(SKILL_DEVICES)) || is_reinforced)
 				return

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -461,9 +461,9 @@
 			if(!body) //Error
 				return TRUE
 			var/delay = min(50 * user.skill_delay_mult(SKILL_DEVICES), 50 * user.skill_delay_mult(SKILL_EVA))
-			visible_message(SPAN_NOTICE("\The [user] starts forcing the \the [src]'s emergency [body.hatch_descriptor] release using \the [thing]."))
+			visible_message(SPAN_NOTICE("\The [user] starts forcing \the [src]'s emergency [body.hatch_descriptor] release using \the [thing]."))
 			if(do_after(user, delay, src))
-				visible_message(SPAN_NOTICE("\The [user] forces \the [src]'s [body.hatch_descriptor] open using the \the [thing]."))
+				visible_message(SPAN_NOTICE("\The [user] forces \the [src]'s [body.hatch_descriptor] open using \the [thing]."))
 				playsound(user.loc, 'sound/machines/bolts_up.ogg', 25, 1)
 				hatch_locked = FALSE
 				hatch_closed = FALSE

--- a/code/modules/modular_computers/hardware/lan_port.dm
+++ b/code/modules/modular_computers/hardware/lan_port.dm
@@ -77,10 +77,10 @@
 			to_chat(user, SPAN_WARNING("You need five lengths of network cable for \the [parent]."))
 			return TRUE
 
-		user.visible_message(SPAN_NOTICE("\The [user] adds cables to the \the [parent]."), "You start adding cables to \the [parent] frame...")
+		user.visible_message(SPAN_NOTICE("\The [user] adds cables to \the [parent]."), "You start adding cables to \the [parent] frame...")
 		if(do_after(user, 20, parent))
 			if(!terminal && (loc == parent) && parent.components_are_accessible(type) && !check_terminal_block(T) && C.use(5))
-				user.visible_message(SPAN_NOTICE("\The [user] has added cables to the \the [parent]!"), "You add cables to the \the [parent].")
+				user.visible_message(SPAN_NOTICE("\The [user] has added cables to \the [parent]!"), "You add cables to \the [parent].")
 				set_terminal()
 		return TRUE
 	if(IS_WIRECUTTER(I) && terminal)

--- a/code/modules/modular_computers/networking/machinery/telecomms.dm
+++ b/code/modules/modular_computers/networking/machinery/telecomms.dm
@@ -127,7 +127,7 @@ var/global/list/telecomms_hubs = list()
 	if(overloaded_for > 0)
 		overloaded_for--
 
-/// Accepts either a raw frequency (numeric), or or a frequency/key string, and returns the associated channel data.
+/// Accepts either a raw frequency (numeric), or a frequency/key string, and returns the associated channel data.
 /obj/machinery/network/telecomms_hub/proc/get_channel_from_freq_or_key(var/cid)
 	cid = "[cid]"
 	. = LAZYACCESS(channels_by_frequency, cid) || LAZYACCESS(channels_by_key, cid)

--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -682,7 +682,7 @@ INITIALIZE_IMMEDIATE(/obj/abstract/level_data_spawner)
 		load_subtemplate(T, template)
 		return template
 
-///Actually handles loading a template template at the given turf.
+///Actually handles loading a template at the given turf.
 /datum/level_data/proc/load_subtemplate(turf/central_turf, datum/map_template/template)
 	if(!template)
 		return FALSE

--- a/code/modules/organs/external/wounds/wound.dm
+++ b/code/modules/organs/external/wounds/wound.dm
@@ -79,7 +79,7 @@
 		return 0
 	return (wound_damage() <= autoheal_cutoff) ? 1 : is_treated()
 
-// checks whether the wound has been appropriately treated
+/// checks whether the wound has been appropriately treated
 /datum/wound/proc/is_treated()
 	if(!LAZYLEN(embedded_objects))
 		switch(damage_type)
@@ -88,7 +88,7 @@
 			if(BURN)
 				return salved
 
-	// Checks whether other other can be merged into src.
+/// Checks whether other can be merged into src.
 /datum/wound/proc/can_merge_wounds(var/datum/wound/other)
 	if (other.type != src.type) return 0
 	if (other.current_stage != src.current_stage) return 0

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -11,7 +11,7 @@
 	active_power_usage = 100 KILOWATTS
 
 	var/efficiency = 0.3	// Energy efficiency. 30% at this time, so 100kW load means 30kW laser pulses.
-	var/minimum_power = 10 KILOWATTS // The minimum power the emitter will still fire at it it doesn't have enough power available.
+	var/minimum_power = 10 KILOWATTS // The minimum power below which the emitter will turn off; different than the power needed to fire.
 	var/active = 0
 	var/fire_delay = 100
 	var/max_burst_delay = 100

--- a/code/modules/reagents/reagent_containers/inhaler.dm
+++ b/code/modules/reagents/reagent_containers/inhaler.dm
@@ -63,7 +63,7 @@
 	user.do_attack_animation(target)
 
 	if(user == target)
-		user.visible_message(SPAN_NOTICE("\The [user] inhales from \the [src]."), SPAN_NOTICE("You stick the \the [src] in your mouth and press the injection button."))
+		user.visible_message(SPAN_NOTICE("\The [user] inhales from \the [src]."), SPAN_NOTICE("You stick \the [src] in your mouth and press the injection button."))
 	else
 		user.visible_message(SPAN_WARNING("\The [user] attempts to administer \the [src] to \the [target]..."), SPAN_NOTICE("You attempt to administer \the [src] to \the [target]..."))
 		if (!do_after(user, 1 SECONDS, target))

--- a/code/modules/recycling/disposalholder.dm
+++ b/code/modules/recycling/disposalholder.dm
@@ -82,11 +82,11 @@
 		if(!curr)
 			last.expel(src, loc, dir)
 
-	// find the turf which should contain the next pipe
+/// find the turf which should contain the next pipe
 /obj/structure/disposalholder/proc/nextloc()
 	return get_step(loc,dir)
 
-// find a matching pipe on a turf
+/// find a matching pipe on a turf
 /obj/structure/disposalholder/proc/findpipe(var/turf/T)
 	if(!T)
 		return null
@@ -98,8 +98,8 @@
 	// if no matching pipe, return null
 	return null
 
-// merge two holder objects
-// used when a a holder meets a stuck holder
+/// merge two holder objects
+/// used when a holder meets a stuck holder
 /obj/structure/disposalholder/proc/merge(var/obj/structure/disposalholder/other)
 	for(var/atom/movable/AM in other)
 		AM.forceMove(src)		// move everything in other holder to this one
@@ -119,7 +119,7 @@
 	else
 		partialTag = new_tag
 
-// called when player tries to move while in a pipe
+/// called when player tries to move while in a pipe
 /obj/structure/disposalholder/relaymove(mob/user)
 	if(!isliving(user))
 		return

--- a/code/modules/shuttles/shuttle_specops.dm
+++ b/code/modules/shuttles/shuttle_specops.dm
@@ -98,7 +98,7 @@
 	return ..()
 
 /datum/shuttle/autodock/ferry/specops/proc/sleep_until_launch()
-	var/message_tracker[] = list(0,1,2,3,5,10,30,45)//Create a a list with potential time values.
+	var/message_tracker[] = list(0,1,2,3,5,10,30,45)//Create a list with potential time values.
 
 	var/launch_time = world.time + specops_countdown_time
 	var/time_until_launch

--- a/mods/content/psionics/system/psionics/faculties/coercion.dm
+++ b/mods/content/psionics/system/psionics/faculties/coercion.dm
@@ -181,7 +181,7 @@
 			return TRUE
 
 		if(accepted_glamour == "Yes")
-			to_chat(user,   SPAN_DANGER("You layer a glamour across the \the [target]'s senses, beguiling them to unwittingly follow your commands."))
+			to_chat(user,   SPAN_DANGER("You layer a glamour across \the [target]'s senses, beguiling them to unwittingly follow your commands."))
 			to_chat(target, SPAN_DANGER("You have been ensnared by \the [user]'s glamour!"))
 			beguiled.add_antagonist(target.mind, new_controller = user)
 		else


### PR DESCRIPTION
Fixes (nonsensical) doubled-up words in strings and comments.

Because I just had to one-up https://github.com/tgstation/tgstation/pull/89127.