### PR TITLE
Fixing issues with robot brainmobs.

### DIFF
--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -44,7 +44,7 @@
 		container.queue_icon_update()
 
 /mob/living/brain/proc/get_container()
-	. = loc?.loc
+	return get_recursive_loc_of_type(/obj/item/organ/internal)
 
 /mob/living/brain/Login()
 	. = ..()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -11,3 +11,9 @@
 		stop_aiming(no_message=1)
 		if(istype(ai))
 			ai.handle_death(gibbed)
+
+		var/decl/species/my_species = get_species()
+		if(my_species)
+			if(!gibbed && my_species.death_sound)
+				playsound(loc, my_species.death_sound, 80, 1, 1)
+			my_species.handle_death(src)

--- a/code/modules/mob/living/human/death.dm
+++ b/code/modules/mob/living/human/death.dm
@@ -33,11 +33,8 @@
 	if(!gibbed)
 		set_tail_animation_state(null, TRUE)
 		handle_organs()
-		if(species.death_sound)
-			playsound(loc, species.death_sound, 80, 1, 1)
 	if(SSticker.mode)
 		SSticker.mode.check_win()
-	species.handle_death(src)
 
 /mob/living/human/physically_destroyed(var/skip_qdel, var/droplimb_type = DISMEMBER_METHOD_BLUNT)
 	for(var/obj/item/organ/external/limb in get_external_organs())


### PR DESCRIPTION
- Fixes #4749
- Fixes MMIs/posibrains being deaf/blind due to crap container retrieval proc.
- Gibbing a robot will always try to leave the brain.