### PR TITLE
Fix lighting on maps loaded after SSlighting init

### DIFF
--- a/code/controllers/subsystems/lighting.dm
+++ b/code/controllers/subsystems/lighting.dm
@@ -57,7 +57,10 @@ SUBSYSTEM_DEF(lighting)
 		var/datum/level_data/level = SSmapping.levels_by_z[zlevel]
 		for (var/turf/tile as anything in block(1, 1, zlevel, level.level_max_width, level.level_max_height)) // include TRANSITIONEDGE turfs
 			if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(tile))
-				tile.lighting_build_overlay()
+				if(!isnull(tile.lighting_overlay))
+					log_warning("Attempted to create lighting_overlay on [tile.get_log_info_line()] when it already had one.")
+					continue
+				new /atom/movable/lighting_overlay(tile)
 				overlaycount++
 			CHECK_TICK
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -118,6 +118,10 @@
 	else if (permit_ao)
 		queue_ao()
 
+	// we're being loaded in a new z-level, we need to build lighting
+	if(mapload && !changing_turf && SSlighting.initialized)
+		lighting_build_overlay()
+
 	if(simulated)
 		updateVisibility(src, FALSE)
 

--- a/code/game/turfs/unsimulated.dm
+++ b/code/game/turfs/unsimulated.dm
@@ -3,6 +3,7 @@
 	initial_gas = GAS_STANDARD_AIRMIX
 	abstract_type = /turf/unsimulated
 	simulated = FALSE
+	dynamic_lighting = FALSE
 
 // Shortcut a bunch of simulation stuff since this turf just needs to sit there.
 // We don't even call Initialize(), how cool is that???


### PR DESCRIPTION
Fixes a regression caused by #4756.

Maploading only goes through new() and not changeturf. If we're loading a turf during mapload, *and* it's not in changeturf, *and* SSlighting init has already run, then we need to build the lighting overlay for that turf in Initialize().

I decided to do this rather than making it do a pass after expanding the world bounds (runs before the actual map loading is done, will do basically nothing because unsim filler turfs fail TIDLU) or after finishing loading a map (multiple relevant points, complicated for planets/etc., can result in missing some turfs or processing others twice.

Definitely needs proper review by @Lohikar to make sure I don't do an oopsie again and that I'm not overlooking a better solution.