### PR TITLE
Adding item-based intent.

### DIFF
--- a/code/_onclick/hud/screen/screen_intent.dm
+++ b/code/_onclick/hud/screen/screen_intent.dm
@@ -98,20 +98,21 @@
 
 	var/decl/intent/owner_intent = owner.get_intent()
 	var/i = 1
-	var/list/all_intents = owner.get_available_intents()
+	var/list/unused_selectors = intent_selectors?.Copy()
+	var/list/all_intents = owner.get_available_intents(skip_update = TRUE)
 	for(var/decl/intent/intent as anything in all_intents)
 		var/obj/screen/intent_button/intent_button = get_intent_button(i)
 		if(intent == owner_intent)
 			intent_button.set_selected(intent)
 		else
 			intent_button.set_deselected(intent)
+		LAZYREMOVE(unused_selectors, intent_button)
 		i++
 		apply_intent_button_offset(intent_button, i, length(all_intents))
 		add_vis_contents(intent_button)
 
-	if(i < length(intent_selectors))
-		for(var/index = i+1 to length(intent_selectors))
-			remove_vis_contents(intent_selectors[index])
+	if(length(unused_selectors))
+		remove_vis_contents(unused_selectors)
 
 /obj/screen/intent/binary
 	intent_width     = 32

--- a/code/_onclick/hud/screen/screen_intent.dm
+++ b/code/_onclick/hud/screen/screen_intent.dm
@@ -48,6 +48,19 @@
 		icon = intent.icon
 		icon_state = selected ? intent.icon_state : "[intent.icon_state]_off"
 
+/obj/screen/intent_button/MouseEntered(location, control, params)
+	if(intent && (intent.name || intent.desc))
+		openToolTip(user = usr, tip_src = src, params = params, content = intent.desc)
+	return ..()
+
+/obj/screen/intent_button/MouseDown()
+	closeToolTip(usr)
+	return ..()
+
+/obj/screen/intent_button/MouseExited()
+	closeToolTip(usr)
+	return ..()
+
 /obj/screen/intent
 	name                 = "intent"
 	icon                 = 'icons/screen/intents.dmi'

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -1153,8 +1153,13 @@ modules/mob/living/human/life.dm if you die, you will be zoomed out.
 /obj/item/proc/loadout_should_keep(obj/item/new_item, mob/wearer)
 	return type != new_item.type && !replaced_in_loadout
 
+/obj/item/dropped(mob/user, slot)
+	. = ..()
+	user?.clear_available_intents()
+
 /obj/item/equipped(mob/user, slot)
 	. = ..()
+	user?.clear_available_intents()
 	// delay for 1ds to allow the rest of the call stack to resolve
 	if(!QDELETED(src) && !QDELETED(user) && user.get_equipped_slot_for_item(src) == slot)
 		try_burn_wearer(user, slot, 1)
@@ -1285,3 +1290,6 @@ modules/mob/living/human/life.dm if you die, you will be zoomed out.
 		squash_item()
 		if(!QDELETED(src))
 			physically_destroyed()
+
+/obj/item/proc/get_provided_intents(mob/wielder)
+	return null

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -466,7 +466,8 @@
 	return
 
 /mob/proc/select_held_item_slot(var/slot)
-	return
+	SHOULD_CALL_PARENT(TRUE)
+	clear_available_intents()
 
 /mob/proc/get_inventory_slots()
 	return

--- a/code/modules/mob/living/inventory.dm
+++ b/code/modules/mob/living/inventory.dm
@@ -58,6 +58,7 @@
 		queue_hand_rebuild()
 
 /mob/living/select_held_item_slot(var/slot)
+	. = ..()
 	var/last_slot = get_active_held_item_slot()
 	if(slot != last_slot && (slot in get_held_item_slots()))
 		_held_item_slot_selected = slot

--- a/mods/mobs/dionaea/mob/_nymph.dm
+++ b/mods/mobs/dionaea/mob/_nymph.dm
@@ -76,18 +76,6 @@
 		heal_damage(OXY, rads, do_update_health = FALSE)
 		heal_damage(TOX, rads)
 
-/*
-/mob/living/simple_animal/alien/diona/get_default_intent()
-	return GET_DECL(/decl/intent/help/binary/diona)
-
-/mob/living/simple_animal/alien/diona/get_available_intents()
-	var/static/list/available_intents = list(
-		GET_DECL(/decl/intent/harm/binary/diona),
-		GET_DECL(/decl/intent/help/binary/diona)
-	)
-	return available_intents
-*/
-
 /decl/bodytype/diona
 	name = "nymph"
 	bodytype_flag = 0

--- a/mods/mobs/dionaea/mob/nymph_ui.dm
+++ b/mods/mobs/dionaea/mob/nymph_ui.dm
@@ -1,17 +1,3 @@
-/* Commented out due to issues with interactions and combined intent flags.
-/obj/screen/intent/binary/diona
-	icon = 'mods/mobs/dionaea/icons/ui_intents.dmi'
-	screen_loc = DIONA_SCREEN_LOC_INTENT
-
-/decl/intent/harm/binary/diona
-	icon = 'mods/mobs/dionaea/icons/ui_intent_overlay.dmi'
-	uid = "intent_harm_binary_diona"
-
-/decl/intent/help/binary/diona
-	icon = 'mods/mobs/dionaea/icons/ui_intent_overlay.dmi'
-	uid = "intent_help_binary_diona"
-*/
-
 /decl/ui_style/diona
 	name = "Diona"
 	restricted = TRUE

--- a/mods/species/ascent/mobs/nymph/_nymph.dm
+++ b/mods/species/ascent/mobs/nymph/_nymph.dm
@@ -51,15 +51,3 @@
 
 /mob/living/simple_animal/alien/kharmaan/get_dexterity(var/silent)
 	return (DEXTERITY_EQUIP_ITEM)
-
-/*
-/mob/living/simple_animal/alien/kharmaan/get_default_intent()
-	return GET_DECL(/decl/intent/help/binary/ascent)
-
-/mob/living/simple_animal/alien/kharmaan/get_available_intents()
-	var/static/list/available_intents = list(
-		GET_DECL(/decl/intent/harm/binary/ascent),
-		GET_DECL(/decl/intent/help/binary/ascent)
-	)
-	return available_intents
-*/

--- a/mods/species/ascent/mobs/nymph/nymph_ui.dm
+++ b/mods/species/ascent/mobs/nymph/nymph_ui.dm
@@ -1,16 +1,3 @@
-/* Commented out due to issues with interactions and combined intent flags.
-/obj/screen/intent/binary/ascent
-	icon = 'mods/species/ascent/icons/ui_intents.dmi'
-	screen_loc = ANYMPH_SCREEN_LOC_INTENT
-
-/decl/intent/harm/binary/ascent
-	icon = 'mods/species/ascent/icons/ui_intent_overlay.dmi'
-	uid = "intent_harm_binary_ascent"
-
-/decl/intent/help/binary/ascent
-	icon = 'mods/species/ascent/icons/ui_intent_overlay.dmi'
-	uid = "intent_help_binary_ascent"
-*/
 /obj/screen/ascent_nymph_molt
 	name = "molt"
 	icon = 'mods/species/ascent/icons/ui_molt.dmi'


### PR DESCRIPTION
## Description of changes
- Intent list is dynamically generated based on inhand items.
- Intents can prune other intents off the available intent list.
- Intent display can show less than four intents without exploding.

## Why and what will this PR improve
Finishes putting stuff in place for full dynamic intents.

## Authorship
Myself.

## Changelog
Nothing player-facing.