### PR TITLE
Remove arguments from update_icon overrides

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -375,13 +375,18 @@
 
 /**
 	Update this atom's icon.
+	If prior to the first SSicon_update flush (i.e. it's during init), icon updates are forced to queue instead.
+	This saves a lot of init time.
 
 	- Events: `updated_icon`
 */
 /atom/proc/update_icon()
 	SHOULD_CALL_PARENT(TRUE)
-	on_update_icon()
-	RAISE_EVENT(/decl/observ/updated_icon, src)
+	if(SSicon_update.init_state == SS_INITSTATE_NONE)
+		queue_icon_update()
+	else
+		on_update_icon()
+		RAISE_EVENT(/decl/observ/updated_icon, src)
 
 /**
 	Update this atom's icon.

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -380,7 +380,7 @@
 */
 /atom/proc/update_icon()
 	SHOULD_CALL_PARENT(TRUE)
-	on_update_icon(arglist(args))
+	on_update_icon()
 	RAISE_EVENT(/decl/observ/updated_icon, src)
 
 /**

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -23,7 +23,8 @@
 	var/active = 0
 	var/heating_power = 40 KILOWATTS
 
-/obj/machinery/space_heater/on_update_icon(var/rebuild_overlay = 0)
+/obj/machinery/space_heater/on_update_icon()
+	. = ..()
 	if(!on)
 		icon_state = "sheater-off"
 		set_light(0)
@@ -36,11 +37,8 @@
 	else
 		icon_state = "sheater-standby"
 		set_light(0)
-
-	if(rebuild_overlay)
-		overlays.Cut()
-		if(panel_open)
-			overlays  += "sheater-open"
+	if(panel_open)
+		add_overlay("sheater-open")
 
 /obj/machinery/space_heater/examine(mob/user)
 	. = ..()

--- a/code/game/objects/item_mob_overlay.dm
+++ b/code/game/objects/item_mob_overlay.dm
@@ -43,7 +43,7 @@ var/global/list/icon_state_cache = list()
 	return out.Copy()
 
 /proc/_fetch_icon_state_cache_entry(checkicon)
-	if(isnull(checkicon) || !(isfile(checkicon) || isicon(checkicon)))
+	if(!checkicon)
 		return null
 	// if we want to let people del icons (WHY???) then we can use weakreF()
 	// but right now it's cheaper to just use checkicon directly

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -380,13 +380,13 @@
 	var/list/timestamp = new/list()
 	var/ruined = 0
 	var/doctored = 0
+	/// Whether we draw the ruined ribbon overlay when ruined.
+	var/draw_ribbon_if_ruined = TRUE
 
-//draw_ribbon: Whether we draw the ruined ribbon overlay. Only used by quantum tape.
-//#FIXME: Probably should be handled better.
-/obj/item/magnetic_tape/on_update_icon(var/draw_ribbon = TRUE)
+/obj/item/magnetic_tape/on_update_icon()
 	. = ..()
 	icon_state = get_world_inventory_state()
-	if(draw_ribbon && ruined && max_capacity)
+	if(draw_ribbon_if_ruined && ruined && max_capacity)
 		add_overlay(overlay_image(icon, "[icon_state]_ribbonoverlay", flags = RESET_COLOR))
 
 /obj/item/magnetic_tape/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
@@ -524,12 +524,10 @@
 	desc = "Quantum-enriched self-repairing nanotape, used for magnetic storage of information."
 	icon = 'icons/obj/items/device/tape_recorder/tape_casette_loose.dmi'
 	ruined = TRUE
+	draw_ribbon_if_ruined = FALSE
 
 /obj/item/magnetic_tape/loose/fix()
 	return
-
-/obj/item/magnetic_tape/loose/on_update_icon()
-	. = ..(FALSE)
 
 /obj/item/magnetic_tape/loose/get_loose_tape()
 	return

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -36,7 +36,7 @@
 	src.stabilization_on = !( src.stabilization_on )
 	to_chat(usr, "You toggle the stabilization [stabilization_on? "on":"off"].")
 
-/obj/item/tank/jetpack/on_update_icon(override)
+/obj/item/tank/jetpack/on_update_icon()
 	. = ..()
 	if(on)
 		add_overlay("[icon_state]-on")

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -35,7 +35,6 @@ var/global/list/global/tank_gauge_cache = list()
 
 	var/gauge_icon = "indicator_tank"
 	var/gauge_cap = 6
-	var/previous_gauge_pressure = null
 
 	var/datum/gas_mixture/air_contents = null
 	var/distribute_pressure = ONE_ATMOSPHERE
@@ -63,7 +62,7 @@ var/global/list/global/tank_gauge_cache = list()
 	air_contents.update_values()
 
 	START_PROCESSING(SSobj, src)
-	update_icon(TRUE)
+	update_icon()
 
 /obj/item/tank/Destroy()
 	QDEL_NULL(air_contents)
@@ -134,7 +133,7 @@ var/global/list/global/tank_gauge_cache = list()
 		if(C.use(1))
 			wired = 1
 			to_chat(user, "<span class='notice'>You attach the wires to the tank.</span>")
-			update_icon(TRUE)
+			update_icon()
 		return TRUE
 
 	if(IS_WIRECUTTER(W))
@@ -157,7 +156,7 @@ var/global/list/global/tank_gauge_cache = list()
 						assy.a_right = null
 						proxyassembly.assembly = null
 						qdel(assy)
-				update_icon(TRUE)
+				update_icon()
 
 			else
 				to_chat(user, "<span class='danger'>You slip and bump the igniter!</span>")
@@ -169,7 +168,7 @@ var/global/list/global/tank_gauge_cache = list()
 			if(do_after(user, 10, src))
 				to_chat(user, "<span class='notice'>You quickly clip the wire from the tank.</span>")
 				wired = 0
-				update_icon(TRUE)
+				update_icon()
 
 		else
 			to_chat(user, "<span class='notice'>There are no wires to cut!</span>")
@@ -378,17 +377,17 @@ var/global/list/global/tank_gauge_cache = list()
 	air_contents.react()
 	check_status()
 
-/obj/item/tank/on_update_icon(var/override)
+// TODO: Check if this works without the override argument. Everything in tank code seems to call it, so...
+/obj/item/tank/on_update_icon()
 	. = ..()
-	var/list/overlays_to_add
-	if(override && (proxyassembly.assembly || wired))
-		LAZYADD(overlays_to_add, overlay_image('icons/obj/items/tanks/tank_components.dmi', "bomb_assembly"))
+	if(proxyassembly?.assembly || wired)
+		add_overlay(overlay_image('icons/obj/items/tanks/tank_components.dmi', "bomb_assembly"))
 		if(proxyassembly.assembly)
 			var/mutable_appearance/bombthing = new(proxyassembly.assembly)
 			bombthing.appearance_flags = RESET_COLOR
 			bombthing.pixel_y = -1
 			bombthing.pixel_x = -3
-			LAZYADD(overlays_to_add, bombthing)
+			add_overlay(bombthing)
 
 	if(gauge_icon)
 		var/gauge_pressure = 0
@@ -398,13 +397,10 @@ var/global/list/global/tank_gauge_cache = list()
 				gauge_pressure = -1
 			else
 				gauge_pressure = round((gauge_pressure/TANK_IDEAL_PRESSURE)*gauge_cap)
-		if(override || (previous_gauge_pressure != gauge_pressure))
-			var/indicator = "[gauge_icon][(gauge_pressure == -1) ? "overload" : gauge_pressure]"
-			if(!tank_gauge_cache[indicator])
-				tank_gauge_cache[indicator] = image('icons/obj/items/tanks/tank_indicators.dmi', indicator)
-			LAZYADD(overlays_to_add, tank_gauge_cache[indicator])
-		previous_gauge_pressure = gauge_pressure
-	add_overlay(overlays_to_add)
+		var/indicator = "[gauge_icon][(gauge_pressure == -1) ? "overload" : gauge_pressure]"
+		if(!tank_gauge_cache[indicator])
+			tank_gauge_cache[indicator] = image('icons/obj/items/tanks/tank_indicators.dmi', indicator)
+		add_overlay(tank_gauge_cache[indicator])
 
 //Handle exploding, leaking, and rupturing of the tank
 /obj/item/tank/proc/check_status()
@@ -534,7 +530,7 @@ var/global/list/global/tank_gauge_cache = list()
 	proxyassembly.assembly = new /obj/item/assembly_holder(src)
 	proxyassembly.assembly.master = proxyassembly
 	proxyassembly.assembly.update_icon()
-	update_icon(TRUE)
+	update_icon()
 
 /////////////////////////////////
 ///Pulled from rewritten bomb.dm
@@ -571,7 +567,7 @@ var/global/list/global/tank_gauge_cache = list()
 	S.master = proxyassembly	//Tell the assembly about its new owner
 	S.forceMove(src)			//Move the assembly
 
-	update_icon(TRUE)
+	update_icon()
 
 /obj/item/tank/proc/cause_explosion()	//This happens when a bomb is told to explode
 	var/obj/item/assembly_holder/assy = proxyassembly.assembly
@@ -588,7 +584,7 @@ var/global/list/global/tank_gauge_cache = list()
 	assy.master = null
 	proxyassembly.assembly = null
 	qdel(assy)
-	update_icon(TRUE)
+	update_icon()
 
 	air_contents.add_thermal_energy(15000)
 

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -70,7 +70,8 @@ WOOD_RAILING_SUBTYPE(yew)
 	else
 		obj_flags &= (~OBJ_FLAG_CONDUCTIBLE)
 
-	update_icon(FALSE)
+	update_connections()
+	update_icon()
 
 /obj/structure/railing/get_material_health_modifier()
 	. = 0.2
@@ -98,7 +99,8 @@ WOOD_RAILING_SUBTYPE(yew)
 		return !density
 	return TRUE
 
-/obj/structure/railing/proc/NeighborsCheck(var/UpdateNeighbors = 1)
+// TODO: Make railings use the normal structure smoothing system! This sucks!
+/obj/structure/railing/update_connections(propagate = FALSE)
 	neighbor_status = 0
 	var/Rturn = turn(dir, -90)
 	var/Lturn = turn(dir, 90)
@@ -106,35 +108,40 @@ WOOD_RAILING_SUBTYPE(yew)
 	for(var/obj/structure/railing/R in loc)
 		if ((R.dir == Lturn) && R.anchored)
 			neighbor_status |= 32
-			if (UpdateNeighbors)
-				R.update_icon(0)
+			if (propagate)
+				R.update_connections()
+				R.update_icon()
 		if ((R.dir == Rturn) && R.anchored)
 			neighbor_status |= 2
-			if (UpdateNeighbors)
-				R.update_icon(0)
+			if (propagate)
+				R.update_connections()
+				R.update_icon()
 	for (var/obj/structure/railing/R in get_step(src, Lturn))
 		if ((R.dir == dir) && R.anchored)
 			neighbor_status |= 16
-			if (UpdateNeighbors)
-				R.update_icon(0)
+			if (propagate)
+				R.update_connections()
+				R.update_icon()
 	for (var/obj/structure/railing/R in get_step(src, Rturn))
 		if ((R.dir == dir) && R.anchored)
 			neighbor_status |= 1
-			if (UpdateNeighbors)
-				R.update_icon(0)
+			if (propagate)
+				R.update_connections()
+				R.update_icon()
 	for (var/obj/structure/railing/R in get_step(src, (Lturn + dir)))
 		if ((R.dir == Rturn) && R.anchored)
 			neighbor_status |= 64
-			if (UpdateNeighbors)
-				R.update_icon(0)
+			if (propagate)
+				R.update_connections()
+				R.update_icon()
 	for (var/obj/structure/railing/R in get_step(src, (Rturn + dir)))
 		if ((R.dir == Lturn) && R.anchored)
 			neighbor_status |= 4
-			if (UpdateNeighbors)
-				R.update_icon(0)
+			if (propagate)
+				R.update_connections()
+				R.update_icon()
 
-/obj/structure/railing/on_update_icon(var/update_neighbors = TRUE)
-	NeighborsCheck(update_neighbors)
+/obj/structure/railing/on_update_icon()
 	..()
 	if (!neighbor_status || !anchored)
 		icon_state = "railing0-[density]"
@@ -188,6 +195,7 @@ WOOD_RAILING_SUBTYPE(yew)
 
 	forceMove(get_step(src, dir))
 	set_dir(turn(dir, 180))
+	update_connections(TRUE)
 	update_icon()
 
 /obj/structure/railing/CheckExit(var/atom/movable/O, var/turf/target)
@@ -260,6 +268,7 @@ WOOD_RAILING_SUBTYPE(yew)
 			else
 				user.visible_message("<span class='notice'>\The [user] wrenches \the [src] closed.</span>", "<span class='notice'>You wrench \the [src] closed.</span>")
 				density = TRUE
+			update_connections(TRUE)
 			update_icon()
 			return TRUE
 	// Repair
@@ -288,6 +297,7 @@ WOOD_RAILING_SUBTYPE(yew)
 		if(do_after(user, 10, src) && density)
 			to_chat(user, (anchored ? "<span class='notice'>You have unfastened \the [src] from the floor.</span>" : "<span class='notice'>You have fastened \the [src] to the floor.</span>"))
 			anchored = !anchored
+			update_connections(TRUE)
 			update_icon()
 		return TRUE
 

--- a/code/game/turfs/floors/floor_icon.dm
+++ b/code/game/turfs/floors/floor_icon.dm
@@ -102,24 +102,19 @@
 			add_overlay(I)
 	pixel_z = default_pixel_z
 
-/turf/floor/on_update_icon(var/update_neighbors)
+/turf/floor/on_update_icon()
 	. = ..()
 
 	color = get_color()
 
 	cut_overlays()
 	update_height_appearance() // Also refreshes out base layer.
-	update_floor_icon(update_neighbors)
+	update_floor_icon()
 
 	for(var/image/I in decals)
 		if(I.layer < layer)
 			continue
 		add_overlay(I)
-
-	if(update_neighbors)
-		for(var/turf/floor/F in orange(src, 1))
-			F.queue_ao()
-			F.queue_icon_update()
 
 	compile_overlays()
 
@@ -132,7 +127,7 @@
 		SetName(initial(name))
 		desc = initial(desc)
 
-/turf/floor/proc/update_floor_icon(update_neighbors)
+/turf/floor/proc/update_floor_icon()
 	var/decl/flooring/use_flooring = get_topmost_flooring()
 	if(istype(use_flooring))
 		use_flooring.update_turf_icon(src)

--- a/code/modules/atmospherics/components/tvalve.dm
+++ b/code/modules/atmospherics/components/tvalve.dm
@@ -30,12 +30,12 @@
 /obj/machinery/atmospherics/tvalve/buildable
 	uncreated_component_parts = null
 
-/obj/machinery/atmospherics/tvalve/on_update_icon(animation)
-	if(animation)
-		flick("[base_icon_state][src.state][!src.state]",src)
-	else
-		icon_state = "[base_icon_state][state]"
+/obj/machinery/atmospherics/tvalve/proc/do_turn_animation()
+	update_icon()
+	flick("[base_icon_state][src.state][!src.state]",src)
 
+/obj/machinery/atmospherics/tvalve/on_update_icon()
+	icon_state = "[base_icon_state][state]"
 	build_device_underlays(FALSE)
 
 /obj/machinery/atmospherics/tvalve/hide(var/i)
@@ -105,8 +105,8 @@
 	return TRUE
 
 /obj/machinery/atmospherics/tvalve/proc/user_toggle()
-	update_icon(1)
-	sleep(10)
+	do_turn_animation()
+	sleep(1 SECOND)
 	toggle()
 
 /obj/machinery/atmospherics/tvalve/Process()

--- a/code/modules/atmospherics/components/valve.dm
+++ b/code/modules/atmospherics/components/valve.dm
@@ -33,12 +33,12 @@
 	open = 1
 	icon_state = "map_valve1"
 
-/obj/machinery/atmospherics/valve/on_update_icon(animation)
-	if(animation)
-		flick("valve[src.open][!src.open]",src)
-	else
-		icon_state = "valve[open]"
+/obj/machinery/atmospherics/valve/proc/do_turn_animation()
+	update_icon()
+	flick("valve[src.open][!src.open]",src)
 
+/obj/machinery/atmospherics/valve/on_update_icon()
+	icon_state = "valve[open]"
 	build_device_underlays(FALSE)
 
 /obj/machinery/atmospherics/valve/hide(var/i)
@@ -94,8 +94,8 @@
 	return TRUE
 
 /obj/machinery/atmospherics/valve/proc/user_toggle()
-	update_icon(1)
-	sleep(10)
+	do_turn_animation()
+	sleep(1 SECOND)
 	toggle()
 
 /obj/machinery/atmospherics/valve/Process()

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -265,7 +265,7 @@
 	smoke.start()
 	qdel(src)
 
-/obj/machinery/atmospherics/pipe/simple/on_update_icon(var/safety = 0)
+/obj/machinery/atmospherics/pipe/simple/on_update_icon()
 	if(!atmos_initalized)
 		return
 
@@ -391,7 +391,7 @@
 	pipe_class = PIPE_CLASS_TRINARY
 	connect_dir_type = NORTH | EAST | WEST
 
-/obj/machinery/atmospherics/pipe/manifold/on_update_icon(var/safety = 0)
+/obj/machinery/atmospherics/pipe/manifold/on_update_icon()
 	if(!atmos_initalized)
 		return
 
@@ -521,7 +521,7 @@
 	rotate_class = PIPE_ROTATE_ONEDIR
 	connect_dir_type = NORTH | SOUTH | EAST | WEST
 
-/obj/machinery/atmospherics/pipe/manifold4w/on_update_icon(var/safety = 0)
+/obj/machinery/atmospherics/pipe/manifold4w/on_update_icon()
 	if(!atmos_initalized)
 		return
 
@@ -641,7 +641,7 @@
 	initialize_directions = SOUTH
 	build_icon_state = "cap"
 
-/obj/machinery/atmospherics/pipe/cap/on_update_icon(var/safety = 0)
+/obj/machinery/atmospherics/pipe/cap/on_update_icon()
 	icon_state = "cap[icon_connect_type]"
 	color = get_color()
 
@@ -705,7 +705,7 @@
 	icon_state = "map_universal"
 	build_icon_state = "universal"
 
-/obj/machinery/atmospherics/pipe/simple/visible/universal/on_update_icon(var/safety = 0)
+/obj/machinery/atmospherics/pipe/simple/visible/universal/on_update_icon()
 	if(!atmos_initalized)
 		return
 
@@ -723,7 +723,7 @@
 	icon_state = "map_universal"
 	build_icon_state = "universal"
 
-/obj/machinery/atmospherics/pipe/simple/hidden/universal/on_update_icon(var/safety = 0)
+/obj/machinery/atmospherics/pipe/simple/hidden/universal/on_update_icon()
 	if(!atmos_initalized)
 		return
 

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -35,10 +35,10 @@
 	else if(!on && light_applied)
 		set_light(0)
 		light_applied = 0
-	update_icon(user)
+	update_icon()
 	user.update_action_buttons()
 
-/obj/item/clothing/head/on_update_icon(var/mob/user)
+/obj/item/clothing/head/on_update_icon()
 	. = ..()
 	update_clothing_icon()
 	if(on)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -82,7 +82,7 @@
 		to_chat(user, "You lower the visor on \the [src].")
 	update_icon()
 
-/obj/item/clothing/head/helmet/riot/on_update_icon(mob/user)
+/obj/item/clothing/head/helmet/riot/on_update_icon()
 	. = ..()
 	icon_state = get_world_inventory_state()
 	if(up && check_state_in_icon("[icon_state]_up", icon))

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -214,7 +214,7 @@
 	. = ..()
 	update_icon()
 
-/obj/item/clothing/head/cakehat/on_update_icon(mob/user)
+/obj/item/clothing/head/cakehat/on_update_icon()
 	. = ..()
 	z_flags &= ~ZMM_MANGLE_PLANES
 	if(is_on_fire() && check_state_in_icon("[icon_state]-flame", icon))

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -183,7 +183,7 @@
 			set_extension(piece, armor_type, armor, armor_degradation_speed)
 
 	set_slowdown_and_vision(!offline)
-	update_icon(1)
+	update_icon()
 
 /obj/item/rig/Destroy()
 	QDEL_NULL(gloves)
@@ -232,7 +232,7 @@
 			piece.max_pressure_protection = initial(piece.max_pressure_protection)
 			piece.min_pressure_protection = initial(piece.min_pressure_protection)
 			piece.item_flags &= ~ITEM_FLAG_AIRTIGHT
-	update_icon(1)
+	update_icon()
 
 /obj/item/rig/proc/toggle_seals(var/mob/initiator,var/instant)
 
@@ -346,7 +346,7 @@
 		canremove = !seal_target
 		if(airtight)
 			update_component_sealed()
-		update_icon(1)
+		update_icon()
 		return 0
 
 	// Success!
@@ -363,7 +363,7 @@
 			module.deactivate()
 	if(airtight)
 		update_component_sealed()
-	update_icon(1)
+	update_icon()
 
 
 /obj/item/rig/proc/update_component_sealed()
@@ -386,7 +386,7 @@
 			helmet.flags_inv &= ~(HIDEMASK)
 		else
 			helmet.flags_inv |= HIDEMASK
-	update_icon(1)
+	update_icon()
 
 /obj/item/rig/Process()
 

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -23,10 +23,11 @@
 	light_wedge = LIGHT_WIDE
 	bodytype_equip_flags = null
 
-/obj/item/clothing/head/helmet/space/rig/on_update_icon(mob/user)
+/obj/item/clothing/head/helmet/space/rig/on_update_icon()
 	. = ..()
 	icon_state = get_world_inventory_state()
-	if(user?.check_rig_status() && check_state_in_icon("[icon_state]-sealed", icon))
+	var/mob/mob_loc = loc
+	if(istype(mob_loc) && mob_loc.check_rig_status() && check_state_in_icon("[icon_state]-sealed", icon))
 		icon_state = "[icon_state]-sealed"
 
 /obj/item/clothing/head/helmet/space/rig/adjust_mob_overlay(mob/living/user_mob, bodytype, image/overlay, slot, bodypart, use_fallback_if_icon_missing = TRUE)
@@ -43,10 +44,11 @@
 	bodytype_equip_flags = null
 	gender = PLURAL
 
-/obj/item/clothing/gloves/rig/on_update_icon(mob/user)
+/obj/item/clothing/gloves/rig/on_update_icon()
 	. = ..()
 	icon_state = get_world_inventory_state()
-	if(user?.check_rig_status() && check_state_in_icon("[icon_state]-sealed", icon))
+	var/mob/mob_loc = loc
+	if(istype(mob_loc) && mob_loc.check_rig_status() && check_state_in_icon("[icon_state]-sealed", icon))
 		icon_state = "[icon_state]-sealed"
 
 /obj/item/clothing/gloves/rig/adjust_mob_overlay(mob/living/user_mob, bodytype, image/overlay, slot, bodypart, use_fallback_if_icon_missing = TRUE)
@@ -63,10 +65,11 @@
 	bodytype_equip_flags = null
 	gender = PLURAL
 
-/obj/item/clothing/shoes/magboots/rig/on_update_icon(mob/user)
+/obj/item/clothing/shoes/magboots/rig/on_update_icon()
 	. = ..()
 	icon_state = get_world_inventory_state()
-	if(user?.check_rig_status() && check_state_in_icon("[icon_state]-sealed", icon))
+	var/mob/mob_loc = loc
+	if(istype(mob_loc) && mob_loc.check_rig_status() && check_state_in_icon("[icon_state]-sealed", icon))
 		icon_state = "[icon_state]-sealed"
 
 /obj/item/clothing/shoes/magboots/rig/adjust_mob_overlay(mob/living/user_mob, bodytype, image/overlay, slot, bodypart, use_fallback_if_icon_missing = TRUE)
@@ -89,10 +92,11 @@
 	can_breach = 1
 	var/list/supporting_limbs = list() //If not-null, automatically splints breaks. Checked when removing the suit.
 
-/obj/item/clothing/suit/space/rig/on_update_icon(mob/user)
+/obj/item/clothing/suit/space/rig/on_update_icon()
 	. = ..()
 	icon_state = get_world_inventory_state()
-	if(user?.check_rig_status() && check_state_in_icon("[icon_state]-sealed", icon))
+	var/mob/mob_loc = loc
+	if(istype(mob_loc) && mob_loc.check_rig_status() && check_state_in_icon("[icon_state]-sealed", icon))
 		icon_state = "[icon_state]-sealed"
 
 /obj/item/clothing/suit/space/rig/adjust_mob_overlay(mob/living/user_mob, bodytype, image/overlay, slot, bodypart, use_fallback_if_icon_missing = TRUE)

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -103,7 +103,7 @@
 		overlay.icon_state = "[overlay.icon_state]_dark"
 	. = ..()
 
-/obj/item/clothing/head/helmet/space/on_update_icon(mob/user)
+/obj/item/clothing/head/helmet/space/on_update_icon()
 	. = ..()
 	var/base_icon_state = get_world_inventory_state()
 	if(!base_icon_state)

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -292,7 +292,10 @@ var/global/list/card_decks = list()
 	icon_state = "empty"
 	w_class = ITEM_SIZE_TINY
 	material = /decl/material/solid/organic/cardboard
+	dir = NORTH // our default dir is expected to be north, e.g. we've been placed by someone facing north
 	var/concealed = 0
+	/// Whether or not we should shift our icons according to our dir or not.
+	var/is_on_table = FALSE
 	var/list/datum/playingcard/cards = list()
 
 /obj/item/hand/attack_self(var/mob/user)
@@ -337,43 +340,42 @@ var/global/list/card_decks = list()
 		for(var/datum/playingcard/P in cards)
 			to_chat(user, "\The [APPEND_FULLSTOP_IF_NEEDED(P.name)]")
 
-/obj/item/hand/on_update_icon(var/direction = 0)
+/obj/item/hand/on_update_icon()
 	. = ..()
-	if(!cards.len)
-		qdel(src)
-		return
-	else if(cards.len > 1)
-		name = "hand of cards"
-		desc = "Some playing cards."
-	else if(concealed)
-		name = "single playing card"
-		desc = "An unknown playing card, concealed."
-	else
-		var/datum/playingcard/P = cards[1]
-		name = "[P.name]"
-		desc = "[P.desc]"
+	var/card_count = length(cards)
+	switch(card_count)
+		if(0)
+			qdel(src)
+			return
+		if(1)
+			var/datum/playingcard/top_card = cards[1]
+			if(concealed)
+				name = "single playing card"
+				desc = "An unknown playing card, concealed."
+			else
+				name = top_card.name
+				desc = top_card.desc
+			var/image/I = top_card.card_image(concealed, src.icon)
+			I.pixel_x += (-5+rand(10))
+			I.pixel_y += (-5+rand(10))
+			add_overlay(I)
+			compile_overlays()
+			return
+		else
+			name = "hand of cards"
+			desc = "Some playing cards."
 
-	overlays.Cut()
-
-	if(cards.len == 1)
-		var/datum/playingcard/P = cards[1]
-		var/image/I = P.card_image(concealed, src.icon)
-		I.pixel_x += (-5+rand(10))
-		I.pixel_y += (-5+rand(10))
-		overlays += I
-		return
-
-	var/offset = floor(20/cards.len)
+	var/offset = floor(20/card_count)
 
 	var/matrix/M = matrix()
-	if(direction)
-		switch(direction)
+	if(is_on_table)
+		switch(dir)
 			if(NORTH)
-				M.Translate( 0,  0)
+				M.Translate( 0,  0) // Technically redundant but it makes the logic clearer.
 			if(SOUTH)
 				M.Translate( 0,  4)
 			if(WEST)
-				M.Turn(90)
+				M.Turn(-90)
 				M.Translate( 3,  0)
 			if(EAST)
 				M.Turn(90)
@@ -381,29 +383,36 @@ var/global/list/card_decks = list()
 	var/i = 0
 	for(var/datum/playingcard/P in cards)
 		var/image/I = P.card_image(concealed, src.icon)
-		//I.pixel_x = origin+(offset*i)
-		switch(direction)
+		switch(dir)
 			if(SOUTH)
 				I.pixel_x = 8-(offset*i)
 			if(WEST)
 				I.pixel_y = -6+(offset*i)
 			if(EAST)
 				I.pixel_y = 8-(offset*i)
-			else
+			if(NORTH)
 				I.pixel_x = -7+(offset*i)
+			// other dirs are explicitly unsupported!
 		I.transform = M
-		overlays += I
+		add_overlay(I)
 		i++
+	compile_overlays() // these should be as responsive as possible
 
 /obj/item/hand/dropped(mob/user)
 	..()
-	if(locate(/obj/structure/table, loc))
-		src.update_icon(user.dir)
+	if(locate(/obj/structure/table) in loc)
+		is_on_table = TRUE
+		set_dir(user.dir)
 	else
-		update_icon()
+		is_on_table = FALSE
+		set_dir(initial(dir))
+	update_icon()
 
 /obj/item/hand/on_picked_up(mob/user)
-	src.update_icon()
+	..()
+	is_on_table = FALSE
+	set_dir(initial(dir))
+	update_icon()
 
 /*** A special thing that steals a card from a deck, probably lost in maint somewhere. ***/
 /obj/item/hand/missing_card

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -148,7 +148,7 @@
 	if(bodytype != old_bodytype && apply_to_internal_organs)
 		bodytype.rebuild_internal_organs(src, override_material)
 	if(.)
-		update_icon(TRUE)
+		update_icon()
 
 /obj/item/organ/external/copy_from_mob_snapshot(datum/mob_snapshot/supplied_appearance)
 	_icon_cache_key = null

--- a/code/modules/organs/external/_external_icons.dm
+++ b/code/modules/organs/external/_external_icons.dm
@@ -43,7 +43,7 @@ var/global/list/limb_icon_cache = list()
 	if(eyes) eyes.update_colour()
 
 /obj/item/organ/external/head/on_remove_effects(mob/living/last_owner)
-	update_icon(1)
+	update_icon()
 	if(last_owner)
 		SetName("[last_owner.real_name]'s head")
 		addtimer(CALLBACK(last_owner, TYPE_PROC_REF(/mob, update_hair)), 1, TIMER_UNIQUE)

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -11,6 +11,8 @@
 	pickup_sound = 'sound/foley/paperpickup2.ogg'
 	material     = /decl/material/solid/organic/cardboard
 	item_flags   = ITEM_FLAG_CAN_TAPE
+	/// If true, add a cosmetic overlay when we have contents.
+	var/has_paper_overlay = TRUE
 
 /obj/item/folder/blue
 	desc       = "A blue folder."
@@ -28,9 +30,9 @@
 	desc       = "A cyan folder."
 	icon_state = "folder_cyan"
 
-/obj/item/folder/on_update_icon(var/paper_overlay = TRUE)
+/obj/item/folder/on_update_icon()
 	. = ..()
-	if(paper_overlay && length(contents))
+	if(has_paper_overlay && length(contents))
 		add_overlay("folder_paper")
 
 /obj/item/folder/attackby(obj/item/W, mob/user)
@@ -88,10 +90,11 @@
 	name = "envelope"
 	desc = "A thick envelope. You can't see what's inside."
 	icon_state = "envelope_sealed"
+	has_paper_overlay = FALSE
 	var/sealed = 1
 
 /obj/item/folder/envelope/on_update_icon()
-	. = ..(paper_overlay = FALSE)
+	. = ..()
 	if(sealed)
 		icon_state = "envelope_sealed"
 	else

--- a/code/modules/power/floorlamp.dm
+++ b/code/modules/power/floorlamp.dm
@@ -23,12 +23,14 @@
 		if(istype(held_item, /obj/item/lampshade))
 			lampshade = held_item
 			user.drop_from_inventory(held_item, src)
-			update_icon(0)
+			update_light_status(FALSE)
+			update_icon()
 			return TRUE
 	else if(held_item.do_tool_interaction(TOOL_SCREWDRIVER, user, src, 1 SECOND, "unscrewing", "unscrewing"))
 		lampshade.dropInto(loc)
 		lampshade = null
-		update_icon(0)
+		update_light_status(FALSE)
+		update_icon()
 		return TRUE
 	return ..()
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -123,12 +123,11 @@
 		on = FALSE
 	if(on)
 		update_use_power(POWER_USE_ACTIVE)
-		var/changed = FALSE
 		if(current_mode && (current_mode in lightbulb.lighting_modes))
-			changed = set_light(arglist(lightbulb.lighting_modes[current_mode]))
+			set_light(arglist(lightbulb.lighting_modes[current_mode]))
 		else
-			changed = set_light(lightbulb.b_range, lightbulb.b_power, lightbulb.b_color)
-		if(trigger && changed && get_status() == LIGHT_OK)
+			set_light(lightbulb.b_range, lightbulb.b_power, lightbulb.b_color)
+		if(trigger && get_status() == LIGHT_OK)
 			switch_check()
 	else
 		update_use_power(POWER_USE_OFF)


### PR DESCRIPTION
## Description of changes
Saves almost two seconds on tradeship init by:
- removing `arglist()` arguments passing to `on_update_icon()`
- removing an assoc list insertion when using `queue_icon_update()`
- optimizing icon update queue processing on `SSicon_update` to be faster
- making all icon updates prior to the first `SSicon_update` flush queue (I tested this, it is in fact much faster)
- removing an oversafe check in `_fetch_icon_state_cache_entry()` that should honestly just runtime in the icon_states check. It should never be passed a non-icon tbh.

I've yet to test railings, valves, and shield effects but they should work. The other stuff was unused args, or I tested them (lights were definitely tested, and I made sure normal updates for things like walls, floors, and machines worked by uh. Well, I fucked it up on accident and compared it to that to make sure everything had properly updated, lol.)

## Why and what will this PR improve
Prevents a ton of duplicate update_icon() calls in init. Everything is buttery smooth.
Also fixes an issue with rigged lights.

## Authorship
Me.