### PR TITLE
Repath rags to not be subtypes of /obj/item/chems/glass

### DIFF
--- a/code/datums/supplypacks/custodial.dm
+++ b/code/datums/supplypacks/custodial.dm
@@ -10,7 +10,7 @@
 					/obj/item/lightreplacer,
 					/obj/item/chems/spray/cleaner,
 					/obj/item/box/lights/mixed,
-					/obj/item/chems/glass/rag,
+					/obj/item/chems/rag,
 					/obj/item/grenade/chem_grenade/cleaner = 3,
 					/obj/structure/mopbucket)
 	containertype = /obj/structure/closet/crate/large
@@ -33,7 +33,7 @@
 					/obj/item/grenade/chem_grenade/cleaner = 3,
 					/obj/item/box/detergent = 3,
 					/obj/item/chems/glass/bucket,
-					/obj/item/chems/glass/rag,
+					/obj/item/chems/rag,
 					/obj/item/chems/spray/cleaner = 2,
 					/obj/item/soap)
 	containertype = /obj/structure/closet/crate/large

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -87,7 +87,7 @@
 		dispose()
 		return
 	else if(dirty==100) // The microwave is all dirty so can't be used!
-		if(istype(O, /obj/item/chems/spray/cleaner) || istype(O, /obj/item/chems/glass/rag)) // If they're trying to clean it then let them
+		if(istype(O, /obj/item/chems/spray/cleaner) || istype(O, /obj/item/chems/rag)) // If they're trying to clean it then let them
 			user.visible_message(
 				SPAN_NOTICE("\The [user] starts to clean [src]."),
 				SPAN_NOTICE("You start to clean [src].")

--- a/code/game/objects/random/subtypes/misc.dm
+++ b/code/game/objects/random/subtypes/misc.dm
@@ -225,7 +225,7 @@
 /obj/random/soap/spawn_choices()
 	var/static/list/spawnable_choices = list(
 		/obj/item/soap                         = 12,
-		/obj/item/chems/glass/rag              =  2,
+		/obj/item/chems/rag              =  2,
 		/obj/item/chems/spray/cleaner          =  2,
 		/obj/item/grenade/chem_grenade/cleaner =  1
 	)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -24,7 +24,7 @@ LINEN BINS
 		if(do_after(user, 50, src))
 			to_chat(user, "<span class='notice'>You cut \the [src] into pieces!</span>")
 			for(var/i in 1 to rand(2,5))
-				new /obj/item/chems/glass/rag(get_turf(src))
+				new /obj/item/chems/rag(get_turf(src))
 			qdel(src)
 		return TRUE
 	return ..()

--- a/code/modules/crafting/stack_recipes/recipes_textiles.dm
+++ b/code/modules/crafting/stack_recipes/recipes_textiles.dm
@@ -157,6 +157,6 @@
 	available_to_map_tech_level = MAP_TECH_LEVEL_MEDIEVAL
 
 /decl/stack_recipe/textiles/rag
-	result_type = /obj/item/chems/glass/rag
+	result_type = /obj/item/chems/rag
 	crafting_extra_cost_factor = 1 // whatever you produce is going to be a rag, there's no wastage
 	difficulty = MAT_VALUE_TRIVIAL_DIY

--- a/code/modules/reagents/reagent_containers/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/drinks/bottle.dm
@@ -13,7 +13,7 @@
 	abstract_type = /obj/item/chems/drinks/bottle
 
 	var/smash_duration = 5 //Directly relates to the 'weaken' duration. Lowered by armor (i.e. helmets)
-	var/obj/item/chems/glass/rag/rag = null
+	var/obj/item/chems/rag/rag = null
 	var/rag_underlay = "rag"
 	var/stop_spin_bottle = FALSE //Gotta stop the rotation.
 
@@ -95,7 +95,7 @@
 
 /obj/item/chems/drinks/bottle/attackby(obj/item/W, mob/user)
 	if(!rag)
-		if(istype(W, /obj/item/chems/glass/rag))
+		if(istype(W, /obj/item/chems/rag))
 			insert_rag(W, user)
 			return TRUE
 	else if(W.isflamesource())
@@ -105,7 +105,7 @@
 /obj/item/chems/drinks/bottle/attack_self(mob/user)
 	return rag ? remove_rag(user) : ..()
 
-/obj/item/chems/drinks/bottle/proc/insert_rag(obj/item/chems/glass/rag/R, mob/user)
+/obj/item/chems/drinks/bottle/proc/insert_rag(obj/item/chems/rag/R, mob/user)
 	if(material?.type != /decl/material/solid/glass)
 		to_chat(user, SPAN_WARNING("\The [src] isn't made of glass, you can't make a good Molotov with it."))
 		return TRUE

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -150,6 +150,7 @@
 	pixel_x = 32;
 	initial_network_id = "freightnet_0451";
 	dir = 4;
+	
 	},
 /obj/structure/bed/chair{
 	dir = 1
@@ -1860,7 +1861,7 @@
 	pixel_x = 3
 	},
 /obj/item/chems/condiment/enzyme,
-/obj/item/chems/glass/rag,
+/obj/item/chems/rag,
 /turf/floor/tiled/usedup,
 /area/ship/scrap/crew/kitchen)
 "dU" = (
@@ -2428,7 +2429,7 @@
 /obj/machinery/light,
 /obj/machinery/optable,
 /obj/item/chems/drinks/glass2/coffeecup/britcup,
-/obj/item/chems/glass/rag,
+/obj/item/chems/rag,
 /turf/floor/tiled/white,
 /area/ship/scrap/crew/medbay)
 "eQ" = (
@@ -3000,7 +3001,7 @@
 /obj/random/clothing,
 /obj/random/clothing,
 /obj/random/clothing,
-/obj/item/chems/glass/rag,
+/obj/item/chems/rag,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/floor/tiled/usedup,
 /area/ship/scrap/crew/wash)
@@ -5161,12 +5162,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/floor/reinforced/airless,
 /area/ship/scrap/maintenance/atmos)
-"Ix" = (
-/obj/machinery/network/router{
-	initial_network_id = "freightnet_0451"
-	},
-/turf/floor/bluegrid/airless,
-/area/ship/scrap/comms)
 "IG" = (
 /obj/item/shard,
 /obj/machinery/atmospherics/unary/outlet_injector{

--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -3543,7 +3543,7 @@
 "kf" = (
 /obj/structure/table/marble,
 /obj/item/chems/drinks/bottle/rum,
-/obj/item/chems/glass/rag,
+/obj/item/chems/rag,
 /obj/random/drinkbottle,
 /obj/random/drinkbottle,
 /obj/random/drinkbottle,

--- a/maps/away/liberia/liberia.dmm
+++ b/maps/away/liberia/liberia.dmm
@@ -3696,7 +3696,7 @@
 /area/liberia/bar)
 "gz" = (
 /obj/structure/table/laminate,
-/obj/item/chems/glass/rag,
+/obj/item/chems/rag,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},

--- a/maps/away/yacht/yacht.dmm
+++ b/maps/away/yacht/yacht.dmm
@@ -249,7 +249,7 @@
 "aM" = (
 /obj/structure/table/marble,
 /obj/item/pizzabox/vegetable,
-/obj/item/chems/glass/rag,
+/obj/item/chems/rag,
 /obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/laminate/yew,
 /area/yacht/living)

--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -16348,7 +16348,7 @@
 /area/exodus/hallway/secondary/entry/starboard)
 "aIe" = (
 /obj/structure/table/reinforced,
-/obj/item/chems/glass/rag,
+/obj/item/chems/rag,
 /obj/structure/noticeboard{
 	default_pixel_x = -30
 	},
@@ -26783,7 +26783,7 @@
 	},
 /obj/structure/table/marble,
 /obj/item/stack/package_wrap,
-/obj/item/chems/glass/rag,
+/obj/item/chems/rag,
 /obj/item/chems/spray/cleaner,
 /turf/floor/tiled/white,
 /area/exodus/crew_quarters/kitchen)

--- a/maps/exodus/exodus-admin.dmm
+++ b/maps/exodus/exodus-admin.dmm
@@ -1487,7 +1487,7 @@
 	dir = 5
 	},
 /obj/item/book/manual/barman_recipes,
-/obj/item/chems/glass/rag,
+/obj/item/chems/rag,
 /turf/unsimulated/floor/lino,
 /area/centcom/holding)
 "aNl" = (

--- a/maps/ministation/ministation-1.dmm
+++ b/maps/ministation/ministation-1.dmm
@@ -2259,7 +2259,7 @@
 /area/ministation/hall/e2)
 "kR" = (
 /obj/structure/table,
-/obj/item/chems/glass/rag,
+/obj/item/chems/rag,
 /obj/item/trash/stick,
 /obj/item/utensil/spoon,
 /turf/floor/tiled/white,

--- a/maps/tradeship/tradeship-0.dmm
+++ b/maps/tradeship/tradeship-0.dmm
@@ -1325,7 +1325,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/item/backpack/dufflebag,
-/obj/item/chems/glass/rag,
+/obj/item/chems/rag,
 /obj/item/chems/glass/bucket,
 /obj/machinery/firealarm{
 	pixel_y = 21
@@ -1518,7 +1518,7 @@
 /obj/item/assembly/mousetrap,
 /obj/item/radio,
 /obj/item/bag/trash,
-/obj/item/chems/glass/rag,
+/obj/item/chems/rag,
 /obj/item/caution,
 /obj/item/caution,
 /obj/item/caution,

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -2009,7 +2009,7 @@
 	pixel_x = 3
 	},
 /obj/item/chems/condiment/enzyme,
-/obj/item/chems/glass/rag,
+/obj/item/chems/rag,
 /obj/item/chems/cooking_vessel/pot,
 /turf/floor/tiled,
 /area/ship/trade/crew/kitchen)
@@ -4759,7 +4759,7 @@
 /obj/machinery/light,
 /obj/machinery/optable,
 /obj/item/chems/drinks/glass2/coffeecup/britcup,
-/obj/item/chems/glass/rag,
+/obj/item/chems/rag,
 /turf/floor/tiled/white,
 /area/ship/trade/crew/medbay)
 "op" = (
@@ -5672,7 +5672,7 @@
 /obj/random/clothing,
 /obj/random/clothing,
 /obj/random/clothing,
-/obj/item/chems/glass/rag,
+/obj/item/chems/rag,
 /obj/item/firstaid/regular,
 /turf/floor/tiled/freezer,
 /area/ship/trade/crew/wash)

--- a/mods/content/dungeon_loot/subtypes/maint.dm
+++ b/mods/content/dungeon_loot/subtypes/maint.dm
@@ -30,7 +30,7 @@
 		/obj/item/clothing/mask/gas,
 		/obj/item/clothing/mask/gas/half,
 		/obj/item/clothing/mask/breath,
-		/obj/item/chems/glass/rag,
+		/obj/item/chems/rag,
 		/obj/item/food/junk/liquidfood,
 		/obj/item/secure_storage/briefcase,
 		/obj/item/briefcase,

--- a/mods/gamemodes/heist/heist_base.dmm
+++ b/mods/gamemodes/heist/heist_base.dmm
@@ -604,7 +604,7 @@
 /area/map_template/syndicate_mothership/raider_base)
 "cc" = (
 /obj/structure/table/laminate,
-/obj/item/chems/glass/rag,
+/obj/item/chems/rag,
 /obj/random/loot,
 /turf/unsimulated/floor/laminate,
 /area/map_template/syndicate_mothership/raider_base)
@@ -737,7 +737,7 @@
 /obj/machinery/door/blast/regular/open{
 	id_tag = "SkipjackShuttersNorth";
 	name = "Blast Doors";
-
+	
 	},
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/effect/paint/brown,
@@ -1104,7 +1104,7 @@
 	dir = 4;
 	id_tag = "SkipjackShuttersWest";
 	name = "Skipjack Shutters";
-
+	
 	},
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/effect/paint/brown,
@@ -1131,7 +1131,7 @@
 	dir = 8;
 	id_tag = "SkipjackShuttersEast";
 	name = "Skipjack Shutters";
-
+	
 	},
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/effect/paint/brown,
@@ -1203,7 +1203,7 @@
 	dir = 4;
 	id_tag = "SkipjackShuttersWest";
 	name = "Skipjack Shutters";
-
+	
 	},
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/floor/plating,

--- a/tools/map_migrations/4829_rags.txt
+++ b/tools/map_migrations/4829_rags.txt
@@ -1,0 +1,1 @@
+/obj/item/chems/glass/rag/@SUBTYPES : /obj/item/chems/rag/@SUBTYPES{@OLD}


### PR DESCRIPTION
See title. Untested but I made sure to copy the useful overrides over.