### PR TITLE
[MDB IGNORE] Make chairs not a subtype of bed

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -503,7 +503,7 @@ SUBSYSTEM_DEF(jobs)
 			spawnpoint.after_join(H)
 
 		// Moving wheelchair if they have one
-		if(H.buckled && istype(H.buckled, /obj/structure/bed/chair/wheelchair))
+		if(H.buckled && istype(H.buckled, /obj/structure/chair/wheelchair))
 			H.buckled.forceMove(H.loc)
 			H.buckled.set_dir(H.dir)
 

--- a/code/datums/supplypacks/medical.dm
+++ b/code/datums/supplypacks/medical.dm
@@ -80,7 +80,7 @@
 
 /decl/hierarchy/supply_pack/medical/wheelchair
 	name = "Equipment - Wheelchair crate"
-	contains = list(/obj/structure/bed/chair/wheelchair)
+	contains = list(/obj/structure/chair/wheelchair)
 	containertype = /obj/structure/closet/crate/large
 	containername = "\improper Wheelchair crate"
 

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -113,8 +113,8 @@
 	if(!isliving(AM) || amount < 1)
 		return
 	var/mob/living/walker = AM
-	if(istype(walker.buckled, /obj/structure/bed/chair/wheelchair))
-		var/obj/structure/bed/chair/wheelchair/wheelchair = walker.buckled
+	if(istype(walker.buckled, /obj/structure/chair/wheelchair))
+		var/obj/structure/chair/wheelchair/wheelchair = walker.buckled
 		wheelchair.bloodiness = 4
 	else
 		walker.add_walking_contaminant(chemical, amount, (blood_data ? blood_data[pick(blood_data)] : null))

--- a/code/game/objects/effects/footprints.dm
+++ b/code/game/objects/effects/footprints.dm
@@ -48,7 +48,7 @@
 		return null
 	if(buckled || current_posture?.prone)
 		return 'icons/mob/footprints/footprints_trail.dmi'
-	if(istype(buckled, /obj/structure/bed/chair))
+	if(istype(buckled, /obj/structure/chair))
 		return 'icons/mob/footprints/footprints_wheelchair.dmi'
 	var/obj/item/clothing/shoes/shoes = get_equipped_item(slot_shoes_str)
 	if(istype(shoes) && shoes.footprint_icon)

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -69,7 +69,7 @@
 	if(O.anchored || !(O.movable_flags & MOVABLE_FLAG_WHEELED))
 		return
 
-	var/obj/structure/bed/chair/C = istype(O, /obj/structure/bed/chair)? O : null
+	var/obj/structure/chair/C = istype(O, /obj/structure/chair)? O : null
 	//#TODO: That could definitely be improved. Would suggest to use process_momentum but its only for thrownthing
 	var/list/move_speed = list(1, 1, 1, 2, 2, 3)
 	for(var/i in 1 to 6)

--- a/code/game/objects/structures/beds/rollerbed.dm
+++ b/code/game/objects/structures/beds/rollerbed.dm
@@ -15,6 +15,7 @@
 	var/iv_attached = 0
 	var/iv_stand = TRUE
 
+// this completely circumvents normal bed icon updating, does this really even need to be a bed subtype?
 /obj/structure/bed/roller/on_update_icon()
 	cut_overlays()
 	if(density)

--- a/code/game/objects/structures/benches/bench.dm
+++ b/code/game/objects/structures/benches/bench.dm
@@ -1,5 +1,5 @@
 // These are benches with backs. For backless benches that can't be buckled to, check for /obj/structure/table/bench.
-/obj/structure/bed/chair/bench
+/obj/structure/chair/bench
 	name = "bench"
 	desc = "A simple slatted bench."
 	icon = 'icons/obj/structures/furniture/bench.dmi'
@@ -12,73 +12,73 @@
 	/// A bitfield of connected neighbors.
 	var/neighbors = 0
 
-/obj/structure/bed/chair/bench/should_have_alpha_mask()
+/obj/structure/chair/bench/should_have_alpha_mask()
 	if(!simulated || !isturf(loc))
 		return FALSE
-	var/obj/structure/bed/chair/bench/south_neighbor = locate() in get_step(loc, SOUTH)
+	var/obj/structure/chair/bench/south_neighbor = locate() in get_step(loc, SOUTH)
 	if(can_visually_connect_to(south_neighbor)) // if we're connected to a south neighbor don't add an alpha mask
 		return TRUE
 	return TRUE
 
 // TODO: make this use the generic structure smoothing system?
-/obj/structure/bed/chair/bench/can_visually_connect_to(var/obj/structure/bed/chair/bench/other)
+/obj/structure/chair/bench/can_visually_connect_to(var/obj/structure/chair/bench/other)
 	return istype(other) && other.dir == dir && other.icon == icon && other.material == material
 
-/obj/structure/bed/chair/bench/Initialize(mapload)
+/obj/structure/chair/bench/Initialize(mapload)
 	..()
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/structure/bed/chair/bench/LateInitialize(mapload)
+/obj/structure/chair/bench/LateInitialize(mapload)
 	..()
 	if(mapload)
 		recalculate_connections()
 	else
 		update_neighbors()
 
-/obj/structure/bed/chair/bench/Destroy()
+/obj/structure/chair/bench/Destroy()
 	var/oldloc = loc
 	. = ..()
 	update_neighbors(oldloc)
 
-/obj/structure/bed/chair/bench/set_dir()
+/obj/structure/chair/bench/set_dir()
 	var/olddir = dir
 	. = ..()
 	if(.)
 		update_neighbors(update_dir = olddir, skip_icon_update = TRUE)
 		update_neighbors(update_dir = dir)
 
-/obj/structure/bed/chair/bench/Move()
+/obj/structure/chair/bench/Move()
 	var/oldloc = loc
 	. = ..()
 	if(.)
 		update_neighbors(oldloc, skip_icon_update = TRUE)
 		update_neighbors(loc)
 
-/obj/structure/bed/chair/bench/proc/update_neighbors(update_loc = loc, update_dir = dir, skip_icon_update)
+/obj/structure/chair/bench/proc/update_neighbors(update_loc = loc, update_dir = dir, skip_icon_update)
 	if(!skip_icon_update)
 		recalculate_connections()
 	if(!isturf(update_loc))
 		return
 	for(var/stepdir in list(turn(update_dir, -90), turn(update_dir, 90)))
-		for(var/obj/structure/bed/chair/bench/other in get_step(update_loc, stepdir))
+		for(var/obj/structure/chair/bench/other in get_step(update_loc, stepdir))
 			other.recalculate_connections()
 
 // TODO: Make this use base structure smoothing eventually? Somehow?
-/obj/structure/bed/chair/bench/proc/recalculate_connections()
+/obj/structure/chair/bench/proc/recalculate_connections()
 	neighbors = 0
 	if(!isturf(loc))
 		neighbors = 0
 	else
 		for(var/checkdir in list(turn(dir, -90), turn(dir,  90)))
 			var/turf/check_turf = get_step(loc, checkdir)
-			for(var/obj/structure/bed/chair/bench/other in check_turf)
+			for(var/obj/structure/chair/bench/other in check_turf)
 				// TODO: Make this use normal structure smoothing helpers.
 				if(other.dir == dir && other.icon == icon && other.material == material)
 					neighbors |= checkdir
 					break
 	update_icon()
 
-/obj/structure/bed/chair/bench/get_base_icon()
+/obj/structure/chair/bench/get_base_icon()
 	. = ..()
 	var/left_dir  = turn(dir, -90)
 	var/right_dir = turn(dir,  90)
@@ -92,13 +92,13 @@
 	else
 		. += "_standing"
 
-/obj/structure/bed/chair/bench/get_material_icon()
+/obj/structure/chair/bench/get_material_icon()
 	return material?.bench_icon || initial(icon)
 
-/obj/structure/bed/chair/bench/mahogany
+/obj/structure/chair/bench/mahogany
 	color = WOOD_COLOR_RICH
 	material = /decl/material/solid/organic/wood/mahogany
 
-/obj/structure/bed/chair/bench/ebony
+/obj/structure/chair/bench/ebony
 	color = WOOD_COLOR_BLACK
 	material = /decl/material/solid/organic/wood/ebony

--- a/code/game/objects/structures/benches/lounge.dm
+++ b/code/game/objects/structures/benches/lounge.dm
@@ -1,13 +1,13 @@
-/obj/structure/bed/chair/bench/lounge
+/obj/structure/chair/bench/lounge
 	name       = "lounge"
 	desc       = "An elegant lounge, perfect for reclining on."
 	icon       = 'icons/obj/structures/furniture/lounge.dmi'
 
 // Just use the existing icon.
-/obj/structure/bed/chair/bench/lounge/get_material_icon()
+/obj/structure/chair/bench/lounge/get_material_icon()
 	return icon || initial(icon)
 
-/obj/structure/bed/chair/bench/lounge/mapped
+/obj/structure/chair/bench/lounge/mapped
 	color          = /decl/material/solid/organic/wood/mahogany::color
 	material       = /decl/material/solid/organic/wood/mahogany
 	initial_padding_material = /decl/material/solid/organic/cloth

--- a/code/game/objects/structures/benches/pew.dm
+++ b/code/game/objects/structures/benches/pew.dm
@@ -1,15 +1,15 @@
-/obj/structure/bed/chair/bench/pew
+/obj/structure/chair/bench/pew
 	name = "pew"
 	desc = "A long bench with a backboard, commonly found in places of worship, courtrooms and so on. Not known for being particularly comfortable."
 	icon = 'icons/obj/structures/furniture/pew.dmi'
 
-/obj/structure/bed/chair/bench/pew/get_material_icon()
+/obj/structure/chair/bench/pew/get_material_icon()
 	return material?.pew_icon || initial(icon)
 
-/obj/structure/bed/chair/bench/pew/mahogany
+/obj/structure/chair/bench/pew/mahogany
 	color    = /decl/material/solid/organic/wood/mahogany::color
 	material = /decl/material/solid/organic/wood/mahogany
 
-/obj/structure/bed/chair/bench/pew/ebony
+/obj/structure/chair/bench/pew/ebony
 	color    = /decl/material/solid/organic/wood/ebony::color
 	material = /decl/material/solid/organic/wood/ebony

--- a/code/game/objects/structures/chairs/chairs.dm
+++ b/code/game/objects/structures/chairs/chairs.dm
@@ -1,41 +1,68 @@
-//YES, chairs are a type of bed. Hopefully this will be fixed by the end of Q2 2025.
-/obj/structure/bed/chair
+/obj/structure/chair
 	name = "chair"
 	desc = "You sit in this, either by will or force."
 	icon = 'icons/obj/structures/furniture/chair.dmi'
-	icon_state = "world_preview"
+	icon_state = ICON_STATE_WORLD + "_preview"
+	anchored = TRUE
+	can_buckle = TRUE
+	buckle_lying = FALSE // force people to sit up in chairs when buckled
+	buckle_sound = 'sound/effects/buckle.ogg'
+	material = DEFAULT_FURNITURE_MATERIAL
+	material_alteration = MAT_FLAG_ALTERATION_ALL
+	tool_interaction_flags = TOOL_INTERACTION_DECONSTRUCT
+	parts_amount = 2
+	parts_type = /obj/item/stack/material/rods
 	color = "#666666"
-	buckle_dir = 0
-	buckle_lying = 0 //force people to sit up in chairs when buckled
 	obj_flags = OBJ_FLAG_ROTATABLE | OBJ_FLAG_SUPPORT_MOB
 	user_comfort = 0.5
+	monetary_worth_multiplier = 2.5 // Utility structures should be worth more than their matter (wheelchairs, rollers, etc).
 
 	var/propelled = 0 // Check for fire-extinguisher-driven chairs
 	var/has_special_overlay = FALSE
+	/// The padding extension type for this chair. If null, no extension is created and this chair cannot be padded.
+	var/padding_extension_type = /datum/extension/padding
+	var/decl/material/initial_padding_material
+	var/initial_padding_color
 
-/obj/structure/bed/chair/do_simple_ranged_interaction(var/mob/user)
+/obj/structure/chair/Initialize(ml, _mat, _reinf_mat)
+	. = ..()
+	if(padding_extension_type && initial_padding_material)
+		get_or_create_extension(src, padding_extension_type, initial_padding_material, initial_padding_color)
+
+/obj/structure/chair/do_simple_ranged_interaction(var/mob/user)
 	if(!buckled_mob && user)
 		rotate(user)
 	return TRUE
 
-/obj/structure/bed/chair/post_buckle_mob()
+/obj/structure/chair/post_buckle_mob()
 	update_icon()
+	return ..()
+
+// Allow self-buckling even without dexterity.
+// Copied from beds; do we actually want this?
+/obj/structure/chair/user_can_mousedrop_onto(mob/user, atom/being_dropped, incapacitation_flags, params)
+	if(user == being_dropped)
+		return user.Adjacent(src) && !user.incapacitated(INCAPACITATION_STUNNED|INCAPACITATION_KNOCKOUT)
 	return ..()
 
 /// Returns an alternate icon based on our material.
 /// Mostly used by benches.
 /// TODO: Refactor to eliminate?
-/obj/structure/bed/chair/proc/get_material_icon()
+/obj/structure/chair/proc/get_material_icon()
 	return icon
 
-/obj/structure/bed/chair/update_materials()
+/obj/structure/chair/update_materials()
 	. = ..()
 	var/icon/material_icon = get_material_icon()
 	if(material_icon)
 		icon = material_icon
 
-/obj/structure/bed/chair/on_update_icon()
-	..() // handles setting icon_state to get_base_icon(), and adds padding
+/obj/structure/chair/proc/get_base_icon()
+	return ICON_STATE_WORLD
+
+/obj/structure/chair/on_update_icon()
+	..()
+	icon_state = get_base_icon()
 	var/base_color = get_color()
 	var/datum/extension/padding/padding_extension = get_extension(src, __IMPLIED_TYPE__)
 	var/use_padding_color = padding_extension?.get_padding_color(material_alteration & MAT_FLAG_ALTERATION_COLOR)
@@ -48,6 +75,7 @@
 	I.layer = use_layer
 	add_overlay(I)
 	if(padding_extension?.get_padding_material())
+		add_overlay(overlay_image(icon, "[icon_state]_padding", padding_extension.get_padding_color(material_alteration & MAT_FLAG_ALTERATION_COLOR), RESET_COLOR|RESET_ALPHA))
 		I = overlay_image(icon, "[icon_state]_padding_over", use_padding_color, RESET_COLOR)
 		I.layer = use_layer
 		add_overlay(I)
@@ -59,7 +87,18 @@
 		I.layer = use_layer
 		add_overlay(I)
 
-/obj/structure/bed/chair/rotate(mob/user)
+// No name override, a cotton-padded metal chair shouldn't be a cotton chair, it should be a metal chair.
+
+/obj/structure/chair/update_material_desc(override_desc)
+	var/base_desc = override_desc || initial(desc)
+	var/datum/extension/padding/padding_extension = get_extension(src, __IMPLIED_TYPE__)
+	var/decl/material/padding_material = padding_extension?.get_padding_material()
+	if(padding_material)
+		desc = "[base_desc] It's made of [material.use_name] and padded with [padding_material.use_name]."
+	else
+		desc = "[base_desc] It's made of [material.use_name]."
+
+/obj/structure/chair/rotate(mob/user)
 	if(!CanPhysicallyInteract(user))
 		to_chat(user, SPAN_NOTICE("You can't interact with \the [src] right now!"))
 		return
@@ -67,60 +106,60 @@
 	set_dir(turn(dir, 90))
 	update_icon()
 
-/obj/structure/bed/chair/padded
+/obj/structure/chair/padded
 	initial_padding_material = /decl/material/solid/organic/cloth
-/obj/structure/bed/chair/padded/red
+/obj/structure/chair/padded/red
 	initial_padding_color = "#9d2300"
-/obj/structure/bed/chair/padded/brown
+/obj/structure/chair/padded/brown
 	initial_padding_material = /decl/material/solid/organic/leather
-/obj/structure/bed/chair/padded/teal
+/obj/structure/chair/padded/teal
 	initial_padding_color = "#00e1ff"
-/obj/structure/bed/chair/padded/black
+/obj/structure/chair/padded/black
 	initial_padding_color = "#505050"
-/obj/structure/bed/chair/padded/green
+/obj/structure/chair/padded/green
 	initial_padding_color = "#b7f27d"
-/obj/structure/bed/chair/padded/purple
+/obj/structure/chair/padded/purple
 	initial_padding_color = "#9933ff"
-/obj/structure/bed/chair/padded/blue
+/obj/structure/chair/padded/blue
 	initial_padding_color = "#46698c"
-/obj/structure/bed/chair/padded/beige
+/obj/structure/chair/padded/beige
 	initial_padding_color = "#ceb689"
-/obj/structure/bed/chair/padded/lime
+/obj/structure/chair/padded/lime
 	initial_padding_color = "#62e36c"
-/obj/structure/bed/chair/padded/yellow
+/obj/structure/chair/padded/yellow
 	initial_padding_color = "#ffbf00"
 
 // Leaving this in for the sake of compilation.
-/obj/structure/bed/chair/comfy
+/obj/structure/chair/comfy
 	name = "comfy chair"
 	desc = "It's a chair. It looks comfy."
 	icon = 'icons/obj/structures/furniture/chair_comfy.dmi'
 	initial_padding_material = /decl/material/solid/organic/cloth
 
-/obj/structure/bed/chair/comfy/unpadded
+/obj/structure/chair/comfy/unpadded
 	initial_padding_material = null
-/obj/structure/bed/chair/comfy/brown
+/obj/structure/chair/comfy/brown
 	initial_padding_material = /decl/material/solid/organic/leather
-/obj/structure/bed/chair/comfy/red
+/obj/structure/chair/comfy/red
 	initial_padding_color = "#9d2300"
-/obj/structure/bed/chair/comfy/teal
+/obj/structure/chair/comfy/teal
 	initial_padding_color = "#00e1ff"
-/obj/structure/bed/chair/comfy/black
+/obj/structure/chair/comfy/black
 	initial_padding_color = "#505050"
-/obj/structure/bed/chair/comfy/green
+/obj/structure/chair/comfy/green
 	initial_padding_color = "#b7f27d"
-/obj/structure/bed/chair/comfy/purple
+/obj/structure/chair/comfy/purple
 	initial_padding_color = "#9933ff"
-/obj/structure/bed/chair/comfy/blue
+/obj/structure/chair/comfy/blue
 	initial_padding_color = "#46698c"
-/obj/structure/bed/chair/comfy/beige
+/obj/structure/chair/comfy/beige
 	initial_padding_color = "#ceb689"
-/obj/structure/bed/chair/comfy/lime
+/obj/structure/chair/comfy/lime
 	initial_padding_color = "#62e36c"
-/obj/structure/bed/chair/comfy/yellow
+/obj/structure/chair/comfy/yellow
 	initial_padding_color = "#ffbf00"
 
-/obj/structure/bed/chair/comfy/captain
+/obj/structure/chair/comfy/captain
 	name = "captain chair"
 	desc = "It's a chair. Only for the highest ranked asses."
 	icon = 'icons/obj/structures/furniture/chair_captain.dmi'
@@ -130,36 +169,36 @@
 	initial_padding_color = "#46698c"
 	has_special_overlay = TRUE
 
-/obj/structure/bed/chair/armchair
+/obj/structure/chair/armchair
 	name = "armchair"
 	desc = "It's an armchair. It looks comfy."
 	icon = 'icons/obj/structures/furniture/armchair.dmi'
 	initial_padding_material = /decl/material/solid/organic/cloth
 
-/obj/structure/bed/chair/armchair/unpadded
+/obj/structure/chair/armchair/unpadded
 	initial_padding_material = null
-/obj/structure/bed/chair/armchair/brown
+/obj/structure/chair/armchair/brown
 	initial_padding_material = /decl/material/solid/organic/leather
-/obj/structure/bed/chair/armchair/red
+/obj/structure/chair/armchair/red
 	initial_padding_color = "#9d2300"
-/obj/structure/bed/chair/armchair/teal
+/obj/structure/chair/armchair/teal
 	initial_padding_color = "#00e1ff"
-/obj/structure/bed/chair/armchair/black
+/obj/structure/chair/armchair/black
 	initial_padding_color = "#505050"
-/obj/structure/bed/chair/armchair/green
+/obj/structure/chair/armchair/green
 	initial_padding_color = "#b7f27d"
-/obj/structure/bed/chair/armchair/purple
+/obj/structure/chair/armchair/purple
 	initial_padding_color = "#9933ff"
-/obj/structure/bed/chair/armchair/blue
+/obj/structure/chair/armchair/blue
 	initial_padding_color = "#46698c"
-/obj/structure/bed/chair/armchair/beige
+/obj/structure/chair/armchair/beige
 	initial_padding_color = "#ceb689"
-/obj/structure/bed/chair/armchair/lime
+/obj/structure/chair/armchair/lime
 	initial_padding_color = "#62e36c"
-/obj/structure/bed/chair/armchair/yellow
+/obj/structure/chair/armchair/yellow
 	initial_padding_color = "#ffbf00"
 
-/obj/structure/bed/chair/office
+/obj/structure/chair/office
 	name = "office chair"
 	icon = 'icons/obj/structures/furniture/chair_office.dmi'
 	anchored = FALSE
@@ -167,7 +206,7 @@
 	movable_flags = MOVABLE_FLAG_WHEELED
 	initial_padding_material = /decl/material/solid/organic/cloth
 
-/obj/structure/bed/chair/office/Move()
+/obj/structure/chair/office/Move()
 	. = ..()
 	if(buckled_mob)
 		var/mob/living/occupant = buckled_mob
@@ -179,7 +218,7 @@
 			else
 				unbuckle_mob()
 
-/obj/structure/bed/chair/office/Bump(atom/A)
+/obj/structure/chair/office/Bump(atom/A)
 	..()
 	if(!buckled_mob)
 		return
@@ -205,66 +244,66 @@
 			victim.apply_damage(10, BRUTE, def_zone)
 		occupant.visible_message("<span class='danger'>[occupant] crashed into \the [A]!</span>")
 
-/obj/structure/bed/chair/office/light
+/obj/structure/chair/office/light
 	initial_padding_color = "#f0f0f0"
-/obj/structure/bed/chair/office/dark
+/obj/structure/chair/office/dark
 	initial_padding_color = "#505050"
 
-/obj/structure/bed/chair/office/comfy
+/obj/structure/chair/office/comfy
 	name = "comfy office chair"
 	desc = "It's an office chair. It looks comfy."
 	icon = 'icons/obj/structures/furniture/chair_comfy_office.dmi'
 
-/obj/structure/bed/chair/office/comfy/unpadded
+/obj/structure/chair/office/comfy/unpadded
 	initial_padding_material = null
-/obj/structure/bed/chair/office/comfy/brown
+/obj/structure/chair/office/comfy/brown
 	initial_padding_material = /decl/material/solid/organic/leather
-/obj/structure/bed/chair/office/comfy/red
+/obj/structure/chair/office/comfy/red
 	initial_padding_color = "#9d2300"
-/obj/structure/bed/chair/office/comfy/teal
+/obj/structure/chair/office/comfy/teal
 	initial_padding_color = "#00e1ff"
-/obj/structure/bed/chair/office/comfy/black
+/obj/structure/chair/office/comfy/black
 	initial_padding_color = "#505050"
-/obj/structure/bed/chair/office/comfy/green
+/obj/structure/chair/office/comfy/green
 	initial_padding_color = "#b7f27d"
-/obj/structure/bed/chair/office/comfy/purple
+/obj/structure/chair/office/comfy/purple
 	initial_padding_color = "#9933ff"
-/obj/structure/bed/chair/office/comfy/blue
+/obj/structure/chair/office/comfy/blue
 	initial_padding_color = "#46698c"
-/obj/structure/bed/chair/office/comfy/beige
+/obj/structure/chair/office/comfy/beige
 	initial_padding_color = "#ceb689"
-/obj/structure/bed/chair/office/comfy/lime
+/obj/structure/chair/office/comfy/lime
 	initial_padding_color = "#62e36c"
-/obj/structure/bed/chair/office/comfy/yellow
+/obj/structure/chair/office/comfy/yellow
 	initial_padding_color = "#ffbf00"
 
-/obj/structure/bed/chair/rounded
+/obj/structure/chair/rounded
 	name = "rounded chair"
 	desc = "It's a rounded chair. It looks comfy."
 	icon = 'icons/obj/structures/furniture/chair_rounded.dmi'
 
-/obj/structure/bed/chair/rounded/brown
+/obj/structure/chair/rounded/brown
 	initial_padding_material = /decl/material/solid/organic/leather
-/obj/structure/bed/chair/rounded/red
+/obj/structure/chair/rounded/red
 	initial_padding_color = "#9d2300"
-/obj/structure/bed/chair/rounded/teal
+/obj/structure/chair/rounded/teal
 	initial_padding_color = "#00e1ff"
-/obj/structure/bed/chair/rounded/black
+/obj/structure/chair/rounded/black
 	initial_padding_color = "#505050"
-/obj/structure/bed/chair/rounded/green
+/obj/structure/chair/rounded/green
 	initial_padding_color = "#b7f27d"
-/obj/structure/bed/chair/rounded/purple
+/obj/structure/chair/rounded/purple
 	initial_padding_color = "#9933ff"
-/obj/structure/bed/chair/rounded/blue
+/obj/structure/chair/rounded/blue
 	initial_padding_color = "#46698c"
-/obj/structure/bed/chair/rounded/beige
+/obj/structure/chair/rounded/beige
 	initial_padding_color = "#ceb689"
-/obj/structure/bed/chair/rounded/lime
+/obj/structure/chair/rounded/lime
 	initial_padding_color = "#62e36c"
-/obj/structure/bed/chair/rounded/yellow
+/obj/structure/chair/rounded/yellow
 	initial_padding_color = "#ffbf00"
 
-/obj/structure/bed/chair/shuttle
+/obj/structure/chair/shuttle
 	name = "shuttle seat"
 	desc = "A comfortable, secure seat. It has a sturdy-looking buckling system for smoother flights."
 	icon = 'icons/obj/structures/furniture/chair_shuttle.dmi'
@@ -273,19 +312,19 @@
 	initial_padding_material = /decl/material/solid/organic/cloth
 	has_special_overlay = TRUE
 
-/obj/structure/bed/chair/shuttle/get_base_icon()
+/obj/structure/chair/shuttle/get_base_icon()
 	. = ..()
 	if (buckled_mob)
 		. += "_buckled"
 
-/obj/structure/bed/chair/shuttle/blue
+/obj/structure/chair/shuttle/blue
 	initial_padding_color = "#46698c"
-/obj/structure/bed/chair/shuttle/black
+/obj/structure/chair/shuttle/black
 	initial_padding_color = "#505050"
-/obj/structure/bed/chair/shuttle/white
+/obj/structure/chair/shuttle/white
 	initial_padding_color = "#f0f0f0"
 
-/obj/structure/bed/chair/wood
+/obj/structure/chair/wood
 	name_prefix = "classic"
 	desc = "Old is never too old to not be in fashion."
 	icon = 'icons/obj/structures/furniture/chair_wooden.dmi'
@@ -293,37 +332,37 @@
 	material = /decl/material/solid/organic/wood/oak
 	padding_extension_type = null // Cannot be padded.
 
-/obj/structure/bed/chair/wood/mahogany
+/obj/structure/chair/wood/mahogany
 	color = WOOD_COLOR_RICH
 	material = /decl/material/solid/organic/wood/mahogany
-/obj/structure/bed/chair/wood/maple
+/obj/structure/chair/wood/maple
 	color = WOOD_COLOR_PALE
 	material = /decl/material/solid/organic/wood/maple
-/obj/structure/bed/chair/wood/ebony
+/obj/structure/chair/wood/ebony
 	color = WOOD_COLOR_BLACK
 	material = /decl/material/solid/organic/wood/ebony
-/obj/structure/bed/chair/wood/walnut
+/obj/structure/chair/wood/walnut
 	color = WOOD_COLOR_CHOCOLATE
 	material = /decl/material/solid/organic/wood/walnut
 
-/obj/structure/bed/chair/wood/wings
+/obj/structure/chair/wood/wings
 	name = "winged chair"
 	icon = 'icons/obj/structures/furniture/chair_wooden_wings.dmi'
 
-/obj/structure/bed/chair/wood/wings/mahogany
+/obj/structure/chair/wood/wings/mahogany
 	color = WOOD_COLOR_RICH
 	material = /decl/material/solid/organic/wood/mahogany
-/obj/structure/bed/chair/wood/wings/maple
+/obj/structure/chair/wood/wings/maple
 	color = WOOD_COLOR_PALE
 	material = /decl/material/solid/organic/wood/maple
-/obj/structure/bed/chair/wood/wings/ebony
+/obj/structure/chair/wood/wings/ebony
 	color = WOOD_COLOR_BLACK
 	material = /decl/material/solid/organic/wood/ebony
-/obj/structure/bed/chair/wood/wings/walnut
+/obj/structure/chair/wood/wings/walnut
 	color = WOOD_COLOR_CHOCOLATE
 	material = /decl/material/solid/organic/wood/walnut
 
-/obj/structure/bed/chair/backed
+/obj/structure/chair/backed
 	name_prefix = "backed"
 	desc = "A tall chair with a sturdy back. Not very comfortable."
 	icon = 'icons/obj/structures/furniture/chair_backed.dmi'
@@ -331,10 +370,10 @@
 	material = /decl/material/solid/organic/wood/oak
 	color = /decl/material/solid/organic/wood/oak::color
 
-/obj/structure/bed/chair/backed/get_material_icon()
+/obj/structure/chair/backed/get_material_icon()
 	return material?.backed_chair_icon || initial(icon)
 
-/obj/structure/bed/chair/slatted
+/obj/structure/chair/slatted
 	name = "seat"
 	name_prefix = "slatted" // slatted wooden seat vs wooden slatted seat
 	icon = 'icons/obj/structures/furniture/chair_slatted.dmi'
@@ -342,5 +381,5 @@
 	material = /decl/material/solid/organic/wood/oak
 	color = /decl/material/solid/organic/wood/oak::color
 
-/obj/structure/bed/chair/slatted/get_material_icon()
+/obj/structure/chair/slatted/get_material_icon()
 	return material?.slatted_seat_icon || initial(icon)

--- a/code/game/objects/structures/chairs/rustic_chairs.dm
+++ b/code/game/objects/structures/chairs/rustic_chairs.dm
@@ -1,4 +1,4 @@
-/obj/structure/bed/chair/rustic
+/obj/structure/chair/rustic
 	name_prefix = "rustic"
 	desc = "A simple, rustic-looking chair. Looks like it'd hurt to sit on for too long..."
 	icon = 'icons/obj/structures/furniture/chair_rustic.dmi'
@@ -6,7 +6,7 @@
 	color = /decl/material/solid/organic/wood/walnut::color
 	user_comfort = -0.5
 
-/obj/structure/bed/chair/rustic_fancy
+/obj/structure/chair/rustic_fancy
 	name_prefix = "fancy"
 	desc = "An ornate, detailed chair made from wood. It has armrests!"
 	icon = 'icons/obj/structures/furniture/chair_rustic_fancy.dmi'
@@ -16,5 +16,5 @@
 	initial_padding_color = COLOR_CHERRY_RED
 	user_comfort = 1.25
 
-/obj/structure/bed/chair/rustic_fancy/ebony
+/obj/structure/chair/rustic_fancy/ebony
 	material = /decl/material/solid/organic/wood/ebony

--- a/code/game/objects/structures/chairs/wheelchair.dm
+++ b/code/game/objects/structures/chairs/wheelchair.dm
@@ -1,4 +1,4 @@
-/obj/structure/bed/chair/wheelchair
+/obj/structure/chair/wheelchair
 	name = "wheelchair"
 	desc = "Now we're getting somewhere."
 	icon = 'icons/obj/structures/furniture/wheelchair.dmi'
@@ -17,19 +17,19 @@
 	// TODO: Replace with reagent holder? This doesn't even properly handle non-human bloodstains.
 	var/bloodiness
 
-/obj/structure/bed/chair/wheelchair/Initialize()
+/obj/structure/chair/wheelchair/Initialize()
 	. = ..()
 
 	if(!item_form_type)
 		verbs -= .verb/collapse
 
-/obj/structure/bed/chair/wheelchair/attack_hand(mob/user)
+/obj/structure/chair/wheelchair/attack_hand(mob/user)
 	if(!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
 		return ..()
 	user_unbuckle_mob(user)
 	return TRUE
 
-/obj/structure/bed/chair/wheelchair/Bump(atom/A)
+/obj/structure/chair/wheelchair/Bump(atom/A)
 	..()
 	if(!buckled_mob)
 		return
@@ -58,7 +58,7 @@
 		victim.apply_damage(10, BRUTE, def_zone)
 	occupant.visible_message(SPAN_DANGER("\The [occupant] crashed into \the [A]!"))
 
-/obj/structure/bed/chair/wheelchair/proc/create_track()
+/obj/structure/chair/wheelchair/proc/create_track()
 	var/obj/effect/decal/cleanable/blood/tracks/B = new(loc)
 	var/newdir = get_dir(get_step(loc, dir), loc)
 	if(newdir == dir)
@@ -73,11 +73,11 @@
 	bloodiness--
 
 /proc/equip_wheelchair(mob/living/human/H) //Proc for spawning in a wheelchair if a new character has no legs. Used in new_player.dm
-	var/obj/structure/bed/chair/wheelchair/W = new(get_turf(H))
+	var/obj/structure/chair/wheelchair/W = new(get_turf(H))
 	if(isturf(H.loc))
 		W.buckle_mob(H)
 
-/obj/structure/bed/chair/wheelchair/verb/collapse()
+/obj/structure/chair/wheelchair/verb/collapse()
 	set name = "Collapse Wheelchair"
 	set category = "Object"
 	set src in oview(1)
@@ -105,7 +105,7 @@
 		K.add_fingerprint(usr)
 		qdel(src)
 
-/obj/structure/bed/chair/wheelchair/handle_buckled_relaymove(var/datum/movement_handler/mh, var/mob/mob, var/direction, var/mover)
+/obj/structure/chair/wheelchair/handle_buckled_relaymove(var/datum/movement_handler/mh, var/mob/mob, var/direction, var/mover)
 	if(isspaceturf(loc))
 		return // No wheelchair driving in space
 	. = MOVEMENT_HANDLED
@@ -115,7 +115,7 @@
 	direction = mob.AdjustMovementDirection(direction, mover)
 	DoMove(direction, mob)
 
-/obj/structure/bed/chair/wheelchair/relaymove(mob/user, direction)
+/obj/structure/chair/wheelchair/relaymove(mob/user, direction)
 	if(user)
 		user.glide_size = glide_size
 	step(src, direction)
@@ -128,7 +128,7 @@
 	icon_state = ICON_STATE_WORLD
 	w_class = ITEM_SIZE_LARGE
 	max_health = 50
-	var/structure_form_type = /obj/structure/bed/chair/wheelchair
+	var/structure_form_type = /obj/structure/chair/wheelchair
 
 /obj/item/wheelchair_kit/attack_self(mob/user)
 	if(!structure_form_type)
@@ -136,7 +136,7 @@
 
 	user.visible_message("<b>[user]</b> starts to lay out \the [src].")
 	if(do_after(user, 4 SECONDS, src))
-		var/obj/structure/bed/chair/wheelchair/W = new structure_form_type(get_turf(user))
+		var/obj/structure/chair/wheelchair/W = new structure_form_type(get_turf(user))
 		user.visible_message("<b>[user]</b> lays out \the [W].")
 		W.add_fingerprint(user)
 		qdel(src)

--- a/code/game/objects/structures/flaps.dm
+++ b/code/game/objects/structures/flaps.dm
@@ -23,8 +23,8 @@
 	if(istype(A) && A.checkpass(PASS_FLAG_GLASS))
 		return prob(60)
 
-	var/obj/structure/bed/B = A
-	if (istype(A, /obj/structure/bed) && B.buckled_mob)//if it's a bed/chair and someone is buckled, it will not pass
+	var/atom/movable/moving_movable = A
+	if (ismovable(A) && moving_movable.buckled_mob)//if someone is buckled, it will not pass
 		return 0
 
 	if(istype(A, /obj/vehicle))	//no vehicles
@@ -32,7 +32,7 @@
 
 	var/mob/living/M = A
 	if(istype(M))
-		if(M.current_posture.prone)
+		if(M.current_posture.prone && !M.buckled)
 			return ..()
 		for(var/mob_type in mobs_can_pass)
 			if(istype(A, mob_type))

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -172,36 +172,34 @@
 /datum/movement_handler/move_relay_self/janicart/MayMove(mob/mover, is_external)
 	. = ..()
 	if(. == MOVEMENT_PROCEED && !is_external && !(locate(/obj/item/janicart_key) in mover.get_held_items()))
-		var/obj/structure/bed/chair/janicart/janicart = host
+		var/obj/structure/janicart/janicart = host
 		to_chat(mover, SPAN_WARNING("You'll need the keys in one of your hands to drive this [istype(janicart) ? janicart.callme : host.name]."))
 		return MOVEMENT_STOP
 
 //old style cart
-/obj/structure/bed/chair/janicart
+/obj/structure/janicart
 	name = "janicart"
 	icon = 'icons/obj/vehicles.dmi'
 	icon_state = "pussywagon"
+	can_buckle = TRUE
+	buckle_lying = FALSE // force people to sit up when buckled to it
+	buckle_sound = 'sound/effects/buckle.ogg'
+	buckle_layer_above = TRUE
+	buckle_movable = TRUE
 	color = null
 	anchored = FALSE
 	density =  TRUE
 	material_alteration = MAT_FLAG_ALTERATION_NONE
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	buckle_layer_above = TRUE
-	buckle_movable = TRUE
 	movement_handlers = list(
 		/datum/movement_handler/deny_multiz,
 		/datum/movement_handler/delay = list(1),
 		/datum/movement_handler/move_relay_self/janicart
 	)
-	padding_extension_type = null
-
 	var/obj/item/bag/trash/mybag = null
 	var/callme = "pimpin' ride"	//how do people refer to it?
 
-/obj/structure/bed/chair/janicart/get_base_icon()
-	return initial(icon_state)
-
-/obj/structure/bed/chair/janicart/Initialize()
+/obj/structure/janicart/Initialize()
 	// Handled in init due to dirs needing to be stringified
 	buckle_pixel_shift = list(
 		"[NORTH]" = list("x" =   0, "y" = 4, "z" = 0),
@@ -212,14 +210,14 @@
 	. = ..()
 	create_reagents(100)
 
-/obj/structure/bed/chair/janicart/examine(mob/user, distance)
+/obj/structure/janicart/examine(mob/user, distance)
 	. = ..()
 	if(distance <= 1)
 		to_chat(user, "[html_icon(src)] This [callme] contains [reagents.total_volume] unit\s of water!")
 		if(mybag)
 			to_chat(user, "\A [mybag] is hanging on the [callme].")
 
-/obj/structure/bed/chair/janicart/attackby(obj/item/I, mob/user)
+/obj/structure/janicart/attackby(obj/item/I, mob/user)
 
 	if(istype(I, /obj/item/mop))
 		if(reagents.total_volume > 1)
@@ -243,27 +241,27 @@
 
 	. = ..()
 
-/obj/structure/bed/chair/janicart/attack_hand(mob/user)
+/obj/structure/janicart/attack_hand(mob/user)
 	if(!mybag || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	user.put_in_hands(mybag)
 	mybag = null
 	return TRUE
 
-/obj/structure/bed/chair/janicart/handle_buckled_relaymove(var/datum/movement_handler/mh, var/mob/mob, var/direction, var/mover)
+/obj/structure/janicart/handle_buckled_relaymove(var/datum/movement_handler/mh, var/mob/mob, var/direction, var/mover)
 	if(isspaceturf(loc))
 		return
 	. = MOVEMENT_HANDLED
 	DoMove(mob.AdjustMovementDirection(direction, mover), mob)
 
-/obj/structure/bed/chair/janicart/relaymove(mob/user, direction)
+/obj/structure/janicart/relaymove(mob/user, direction)
 	if(user.incapacitated(INCAPACITATION_DISRUPTED))
 		unbuckle_mob()
 	user.glide_size = glide_size
 	step(src, direction)
 	set_dir(direction)
 
-/obj/structure/bed/chair/janicart/bullet_act(var/obj/item/projectile/Proj)
+/obj/structure/janicart/bullet_act(var/obj/item/projectile/Proj)
 	if(buckled_mob)
 		if(prob(85))
 			return buckled_mob.bullet_act(Proj)

--- a/code/modules/crafting/stack_recipes/recipes_hardness_integrity.dm
+++ b/code/modules/crafting/stack_recipes/recipes_hardness_integrity.dm
@@ -49,14 +49,14 @@
 	category           = "seating"
 
 /decl/stack_recipe/hardness/integrity/furniture/bench
-	result_type        = /obj/structure/bed/chair/bench
+	result_type        = /obj/structure/chair/bench
 	category           = "seating"
 
 /decl/stack_recipe/hardness/integrity/furniture/bench/pew
-	result_type        = /obj/structure/bed/chair/bench/pew
+	result_type        = /obj/structure/chair/bench/pew
 
 /decl/stack_recipe/hardness/integrity/furniture/bench/lounge
-	result_type        = /obj/structure/bed/chair/bench/lounge
+	result_type        = /obj/structure/chair/bench/lounge
 	difficulty         = MAT_VALUE_VERY_HARD_DIY
 
 /decl/stack_recipe/hardness/integrity/furniture/closet
@@ -70,27 +70,27 @@
 	result_type        = /obj/structure/closet/coffin
 
 /decl/stack_recipe/hardness/integrity/furniture/chair
-	result_type        = /obj/structure/bed/chair
+	result_type        = /obj/structure/chair
 	category           = "seating"
 
 /decl/stack_recipe/hardness/integrity/furniture/chair/office
-	result_type        = /obj/structure/bed/chair/office/comfy/unpadded
+	result_type        = /obj/structure/chair/office/comfy/unpadded
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /decl/stack_recipe/hardness/integrity/furniture/chair/comfy
-	result_type        = /obj/structure/bed/chair/comfy/unpadded
+	result_type        = /obj/structure/chair/comfy/unpadded
 
 /decl/stack_recipe/hardness/integrity/furniture/chair/arm
-	result_type        = /obj/structure/bed/chair/armchair/unpadded
+	result_type        = /obj/structure/chair/armchair/unpadded
 
 /decl/stack_recipe/hardness/integrity/furniture/chair/roundedchair
-	result_type        = /obj/structure/bed/chair/rounded
+	result_type        = /obj/structure/chair/rounded
 
 /decl/stack_recipe/hardness/integrity/furniture/chair/backed
-	result_type        = /obj/structure/bed/chair/backed
+	result_type        = /obj/structure/chair/backed
 
 /decl/stack_recipe/hardness/integrity/furniture/chair/slatted
-	result_type        = /obj/structure/bed/chair/slatted
+	result_type        = /obj/structure/chair/slatted
 
 /decl/stack_recipe/hardness/integrity/furniture/drying_rack
 	result_type        = /obj/structure/drying_rack

--- a/code/modules/crafting/stack_recipes/recipes_planks.dm
+++ b/code/modules/crafting/stack_recipes/recipes_planks.dm
@@ -187,11 +187,11 @@
 	result_type            = /obj/structure/bookcase/cart
 
 /decl/stack_recipe/planks/furniture/chair
-	result_type            = /obj/structure/bed/chair/wood
+	result_type            = /obj/structure/chair/wood
 	category               = "seating"
 
 /decl/stack_recipe/planks/furniture/chair/fancy
-	result_type            = /obj/structure/bed/chair/wood/wings
+	result_type            = /obj/structure/chair/wood/wings
 
 /decl/stack_recipe/planks/furniture/chest
 	result_type            = /obj/structure/closet/crate/chest

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -186,7 +186,7 @@
 	holographic = TRUE
 	material = /decl/material/solid/metal/aluminium/holographic
 
-/obj/structure/bed/chair/holochair
+/obj/structure/chair/holochair
 	tool_interaction_flags = 0
 	holographic = TRUE
 	material = /decl/material/solid/metal/aluminium/holographic

--- a/code/modules/mob/living/human/human_movement.dm
+++ b/code/modules/mob/living/human/human_movement.dm
@@ -25,7 +25,7 @@
 	if(can_feel_pain() && get_shock() >= 10)
 		tally += (get_shock() / 10) //pain shouldn't slow you down if you can't even feel it
 
-	if(istype(buckled, /obj/structure/bed/chair/wheelchair))
+	if(istype(buckled, /obj/structure/chair/wheelchair))
 		for(var/organ_name in list(BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM))
 			var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(src, organ_name)
 			tally += E ? E.get_movement_delay(4) : 4

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
@@ -49,7 +49,7 @@
 	//These vars store their preffered perch and if they dont have one, what they can use as a perch
 	var/obj/parrot_perch = null
 	var/static/list/desired_perches = list(
-		/obj/structure/bed/chair,
+		/obj/structure/chair,
 		/obj/structure/table,
 		/obj/machinery/constructable_frame/computerframe,
 		/obj/structure/displaycase,

--- a/code/modules/random_map/drop/droppod.dm
+++ b/code/modules/random_map/drop/droppod.dm
@@ -124,7 +124,7 @@
 		get_spawned_drop(T)
 
 /datum/random_map/droppod/proc/get_spawned_drop(var/turf/T)
-	var/obj/structure/bed/chair/C = new(T)
+	var/obj/structure/chair/C = new(T)
 	C.set_light(3, 1, l_color = "#cc0000")
 	var/mob/living/drop
 	// This proc expects a list of mobs to be passed to the spawner.

--- a/maps/antag_spawn/ert/ert_base.dmm
+++ b/maps/antag_spawn/ert/ert_base.dmm
@@ -91,7 +91,7 @@
 /turf/unsimulated/floor/dark,
 /area/map_template/rescue_base/base)
 "ay" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/unsimulated/floor/dark,
 /area/map_template/rescue_base/base)
 "az" = (
@@ -405,7 +405,7 @@
 /turf/unsimulated/floor/vault,
 /area/map_template/rescue_base/base)
 "bq" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /turf/unsimulated/floor/dark,
@@ -1036,7 +1036,7 @@
 /turf/unsimulated/floor/vault,
 /area/map_template/rescue_base/base)
 "cP" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/unsimulated/floor/dark,
@@ -1386,7 +1386,7 @@
 /turf/unsimulated/floor/rescue_base,
 /area/map_template/rescue_base/base)
 "dO" = (
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /turf/unsimulated/floor/vault,
 /area/map_template/rescue_base/base)
 "dQ" = (
@@ -1469,7 +1469,7 @@
 /turf/unsimulated/floor/vault,
 /area/map_template/rescue_base/base)
 "eg" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /turf/unsimulated/floor/vault,
@@ -1741,7 +1741,7 @@
 /turf/unsimulated/floor/cult,
 /area/map_template/rescue_base/base)
 "eI" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /turf/unsimulated/floor/cult,
@@ -1913,13 +1913,13 @@
 /turf/floor/tiled/dark,
 /area/map_template/rescue_base/start)
 "fg" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /turf/floor/tiled/dark,
 /area/map_template/rescue_base/start)
 "fh" = (
-/obj/structure/bed/chair/shuttle,
+/obj/structure/chair/shuttle,
 /turf/floor/tiled/dark,
 /area/map_template/rescue_base/start)
 "fi" = (
@@ -2192,7 +2192,7 @@
 /turf/floor/tiled/dark,
 /area/map_template/rescue_base/start)
 "fT" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/machinery/light{
@@ -2206,7 +2206,7 @@
 /turf/floor/tiled/dark,
 /area/map_template/rescue_base/start)
 "fV" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -2251,7 +2251,7 @@
 /turf/floor/tiled/dark,
 /area/map_template/rescue_base/start)
 "gb" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/tiled/dark,
@@ -2468,7 +2468,7 @@
 	pixel_x = 27;
 	dir = 8
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -2527,7 +2527,7 @@
 /turf/floor/plating,
 /area/map_template/rescue_base/start)
 "gV" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/tiled/dark,
@@ -2581,7 +2581,7 @@
 /turf/unsimulated/floor/asteroid,
 /area/map_template/rescue_base/base)
 "hd" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/machinery/light{

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -149,7 +149,7 @@
 /turf/floor/shuttle/darkred,
 /area/map_template/merc_shuttle)
 "aq" = (
-/obj/structure/bed/chair/shuttle/blue{
+/obj/structure/chair/shuttle/blue{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -269,7 +269,7 @@
 /turf/floor/reinforced,
 /area/map_template/merc_shuttle)
 "aC" = (
-/obj/structure/bed/chair/shuttle/blue{
+/obj/structure/chair/shuttle/blue{
 	dir = 1
 	},
 /turf/floor/shuttle/darkred,
@@ -383,7 +383,7 @@
 	pixel_x = -21;
 	req_access = list("ACCESS_MERCENARY")
 	},
-/obj/structure/bed/chair/shuttle/blue{
+/obj/structure/chair/shuttle/blue{
 	dir = 4
 	},
 /turf/floor/shuttle/darkred,
@@ -421,7 +421,7 @@
 /turf/floor/shuttle/darkred,
 /area/map_template/merc_shuttle)
 "aP" = (
-/obj/structure/bed/chair/shuttle/blue{
+/obj/structure/chair/shuttle/blue{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -487,7 +487,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/structure/bed/chair/shuttle/blue{
+/obj/structure/chair/shuttle/blue{
 	dir = 4
 	},
 /turf/floor/shuttle/darkred,
@@ -1639,11 +1639,11 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/structure/bed/chair/office,
+/obj/structure/chair/office,
 /turf/floor/tiled,
 /area/map_template/merc_spawn)
 "ec" = (
-/obj/structure/bed/chair/office{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/floor/tiled,
@@ -1849,7 +1849,7 @@
 /turf/floor/plating,
 /area/map_template/merc_spawn)
 "jE" = (
-/obj/structure/bed/chair/shuttle/blue{
+/obj/structure/chair/shuttle/blue{
 	dir = 8
 	},
 /obj/machinery/recharger/wallcharger{
@@ -1907,7 +1907,7 @@
 	dir = 8;
 	icon_state = "warningcorner"
 	},
-/obj/structure/bed/chair/office{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/floor/tiled,
@@ -2632,7 +2632,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning"
 	},
-/obj/structure/bed/chair/office{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/floor/tiled,
@@ -2695,7 +2695,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/obj/structure/bed/chair/office,
+/obj/structure/chair/office,
 /turf/floor/tiled,
 /area/map_template/merc_spawn)
 "Vw" = (

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -63,7 +63,7 @@
 /area/ship/scrap/command/bridge)
 "aj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /obj/abstract/landmark/corpse/deadcap,
@@ -126,7 +126,7 @@
 /turf/wall/r_wall,
 /area/ship/scrap/command/bridge)
 "au" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/machinery/power/apc/derelict{
@@ -152,7 +152,7 @@
 	dir = 4;
 	
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/tiled/dark/usedup,
@@ -407,7 +407,7 @@
 /turf/floor/laminate,
 /area/ship/scrap/command/captain)
 "aV" = (
-/obj/structure/bed/chair/comfy/brown,
+/obj/structure/chair/comfy/brown,
 /turf/floor/laminate,
 /area/ship/scrap/command/captain)
 "aW" = (
@@ -1090,7 +1090,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/tiled/usedup,
 /area/ship/scrap/crew/saloon)
 "cn" = (
@@ -1106,7 +1106,7 @@
 /area/ship/scrap/crew/saloon)
 "co" = (
 /obj/structure/emergency_dispenser/north,
-/obj/structure/bed/chair/wood,
+/obj/structure/chair/wood,
 /obj/item/deck/tarot,
 /turf/floor/tiled/usedup,
 /area/ship/scrap/crew/saloon)
@@ -1585,7 +1585,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /turf/floor/tiled/usedup,
@@ -2216,7 +2216,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/structure/bed/chair/office/light,
+/obj/structure/chair/office/light,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -3775,7 +3775,7 @@
 /turf/floor/tiled/usedup,
 /area/ship/scrap/maintenance/engineering)
 "hr" = (
-/obj/structure/bed/chair/comfy/brown,
+/obj/structure/chair/comfy/brown,
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},

--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -113,7 +113,7 @@
 	if(!istype(corpse))
 		return
 	corpse.SetName("Captain")
-	var/obj/structure/bed/chair/C = locate() in loc
+	var/obj/structure/chair/C = locate() in loc
 	if(C)
 		C.buckle_mob(corpse)
 	qdel(src)

--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -139,7 +139,7 @@
 /turf/floor/plating,
 /area/casino/casino_bridge)
 "au" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/splatter,
@@ -188,13 +188,13 @@
 /turf/floor/plating,
 /area/casino/casino_maintenance)
 "aE" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/tiled,
 /area/casino/casino_bridge)
 "aF" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/splatter,
@@ -688,7 +688,7 @@
 /turf/floor/plating,
 /area/casino/casino_security)
 "bQ" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/plating,
 /area/casino/casino_security)
 "bR" = (
@@ -999,7 +999,7 @@
 /turf/floor/tiled,
 /area/casino/casino_security)
 "cS" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
@@ -1229,7 +1229,7 @@
 /turf/floor/tiled,
 /area/casino/casino_cutter)
 "dG" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/door/window,
@@ -1273,7 +1273,7 @@
 /turf/floor/plating/airless,
 /area/space)
 "dM" = (
-/obj/structure/bed/chair/comfy/red{
+/obj/structure/chair/comfy/red{
 	dir = 8
 	},
 /turf/floor/plating,
@@ -1313,7 +1313,7 @@
 /turf/floor/plating,
 /area/casino/casino_storage)
 "dR" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/plating,
 /area/casino/casino_storage)
 "dS" = (
@@ -1323,7 +1323,7 @@
 /turf/floor/plating,
 /area/casino/casino_storage)
 "dT" = (
-/obj/structure/bed/chair/office/light,
+/obj/structure/chair/office/light,
 /turf/floor/plating,
 /area/casino/casino_storage)
 "dU" = (
@@ -1344,20 +1344,20 @@
 /obj/random/cash,
 /obj/random/cash,
 /obj/random/cash,
-/obj/structure/bed/chair/comfy/captain{
+/obj/structure/chair/comfy/captain{
 	dir = 1
 	},
 /turf/floor/shuttle/yellow,
 /area/casino/casino_cutter)
 "dY" = (
-/obj/structure/bed/chair/comfy/captain{
+/obj/structure/chair/comfy/captain{
 	dir = 1
 	},
 /obj/item/bag/cash,
 /turf/floor/shuttle/yellow,
 /area/casino/casino_cutter)
 "dZ" = (
-/obj/structure/bed/chair/comfy/captain{
+/obj/structure/chair/comfy/captain{
 	dir = 1
 	},
 /turf/floor/shuttle/yellow,
@@ -1366,7 +1366,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/bed/chair/comfy/captain{
+/obj/structure/chair/comfy/captain{
 	dir = 1
 	},
 /turf/floor/shuttle/yellow,
@@ -1531,7 +1531,7 @@
 /turf/floor/plating,
 /area/casino/casino_storage)
 "ey" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/floor/plating,
 /area/casino/casino_storage)
@@ -1999,7 +1999,7 @@
 /turf/floor/carpet,
 /area/casino/casino_mainfloor)
 "fL" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 1
 	},
 /turf/floor/carpet,
@@ -2165,27 +2165,27 @@
 /turf/floor/tiled,
 /area/casino/casino_crew_cantina)
 "gk" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/floor/tiled,
 /area/casino/casino_crew_cantina)
 "gl" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/tiled,
 /area/casino/casino_crew_cantina)
 "gm" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/item/chems/drinks/flask/shiny,
 /turf/floor/tiled,
 /area/casino/casino_crew_cantina)
 "gn" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/random/snack,
@@ -2357,7 +2357,7 @@
 /turf/floor/tiled,
 /area/casino/casino_mainfloor)
 "gI" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/tiled,
@@ -2393,7 +2393,7 @@
 /turf/wall,
 /area/casino/casino_solar_control)
 "gX" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/tiled,
 /area/casino/casino_mainfloor)
 "gY" = (
@@ -2720,7 +2720,7 @@
 /turf/floor/carpet,
 /area/casino/casino_mainfloor)
 "hZ" = (
-/obj/structure/bed/chair/comfy/red{
+/obj/structure/chair/comfy/red{
 	dir = 4
 	},
 /turf/floor/carpet,
@@ -2736,7 +2736,7 @@
 /turf/floor/carpet,
 /area/casino/casino_mainfloor)
 "ic" = (
-/obj/structure/bed/chair/comfy/red{
+/obj/structure/chair/comfy/red{
 	dir = 8
 	},
 /turf/floor/carpet,
@@ -2848,7 +2848,7 @@
 /turf/floor/tiled,
 /area/casino/casino_kitchen)
 "ip" = (
-/obj/structure/bed/chair/comfy/red{
+/obj/structure/chair/comfy/red{
 	dir = 4
 	},
 /obj/item/knife/combat,
@@ -3123,7 +3123,7 @@
 /turf/floor/carpet,
 /area/casino/casino_mainfloor)
 "jc" = (
-/obj/structure/bed/chair/comfy/beige{
+/obj/structure/chair/comfy/beige{
 	dir = 8
 	},
 /turf/floor/carpet,
@@ -3576,7 +3576,7 @@
 /turf/floor/carpet,
 /area/casino/casino_mainfloor)
 "kl" = (
-/obj/structure/bed/chair/comfy/black{
+/obj/structure/chair/comfy/black{
 	dir = 1
 	},
 /turf/floor/carpet,
@@ -4196,7 +4196,7 @@
 /turf/floor/carpet,
 /area/casino/casino_mainfloor)
 "lV" = (
-/obj/structure/bed/chair/comfy/black,
+/obj/structure/chair/comfy/black,
 /turf/floor/carpet,
 /area/casino/casino_mainfloor)
 "lX" = (
@@ -4212,7 +4212,7 @@
 /turf/floor/plating,
 /area/casino/casino_bow)
 "lY" = (
-/obj/structure/bed/chair/comfy/red{
+/obj/structure/chair/comfy/red{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4232,7 +4232,7 @@
 /turf/floor/laminate,
 /area/casino/casino_private_vip)
 "mb" = (
-/obj/structure/bed/chair/comfy/red{
+/obj/structure/chair/comfy/red{
 	dir = 8
 	},
 /turf/floor/laminate,
@@ -4245,7 +4245,7 @@
 /turf/floor/laminate,
 /area/casino/casino_private_vip)
 "md" = (
-/obj/structure/bed/chair/comfy/red,
+/obj/structure/chair/comfy/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/floor/laminate,
 /area/casino/casino_private1)
@@ -4257,7 +4257,7 @@
 /turf/floor/laminate,
 /area/casino/casino_private1)
 "mf" = (
-/obj/structure/bed/chair/comfy/red,
+/obj/structure/chair/comfy/red,
 /obj/item/flame/fuelled/lighter/zippo/random,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/floor/laminate,
@@ -4295,7 +4295,7 @@
 /turf/floor/plating,
 /area/casino/casino_bow)
 "ml" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/splatter,
@@ -4319,7 +4319,7 @@
 /turf/floor/plating,
 /area/casino/casino_bow)
 "mp" = (
-/obj/structure/bed/chair/comfy/red{
+/obj/structure/chair/comfy/red{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -4337,7 +4337,7 @@
 /turf/floor/laminate,
 /area/casino/casino_private_vip)
 "ms" = (
-/obj/structure/bed/chair/comfy/red{
+/obj/structure/chair/comfy/red{
 	dir = 8
 	},
 /obj/item/bag/cash,
@@ -4358,7 +4358,7 @@
 /turf/floor/laminate,
 /area/casino/casino_private1)
 "mv" = (
-/obj/structure/bed/chair/comfy/red{
+/obj/structure/chair/comfy/red{
 	dir = 8
 	},
 /turf/floor/laminate,
@@ -4376,7 +4376,7 @@
 /turf/floor/laminate,
 /area/casino/casino_private2)
 "my" = (
-/obj/structure/bed/chair/comfy/red{
+/obj/structure/chair/comfy/red{
 	dir = 8
 	},
 /turf/floor/laminate,
@@ -4603,7 +4603,7 @@
 /turf/floor/plating/airless,
 /area/casino/casino_bow)
 "nj" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/item/radio/intercom{
 	dir = 4;
 	pixel_x = -22
@@ -4624,7 +4624,7 @@
 /turf/wall/r_wall,
 /area/casino/casino_bow)
 "nm" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/machinery/status_display{
 	pixel_x = -32;
 	dir = 8
@@ -4639,7 +4639,7 @@
 /turf/floor/plating,
 /area/casino/casino_bow)
 "nn" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/machinery/status_display{
 	pixel_x = -32;
 	dir = 8
@@ -4654,7 +4654,7 @@
 /turf/floor/plating,
 /area/casino/casino_bow)
 "no" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/machinery/status_display{
 	pixel_x = -32;
 	dir = 8
@@ -5000,7 +5000,7 @@
 /turf/floor/carpet,
 /area/casino/casino_mainfloor)
 "Fb" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -177,7 +177,7 @@
 /turf/floor/plating,
 /area/derelict/ship)
 "aA" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/tiled,
@@ -408,7 +408,7 @@
 /turf/floor/tiled,
 /area/derelict/ship)
 "bk" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/tiled,
@@ -578,7 +578,7 @@
 /turf/floor/tiled/dark/airless,
 /area/constructionsite/bridge)
 "bT" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/tiled,
 /area/derelict/ship)
 "bU" = (
@@ -1244,7 +1244,7 @@
 /turf/floor/plating/airless/broken,
 /area/constructionsite/storage)
 "et" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 1
 	},
 /turf/floor/tiled/dark/airless,

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -578,7 +578,7 @@
 /turf/floor/plating,
 /area/errant_pisces/enginering)
 "bM" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /turf/floor/plating,
@@ -947,7 +947,7 @@
 /turf/floor/plating,
 /area/errant_pisces/enginering)
 "cT" = (
-/obj/structure/bed/chair/janicart,
+/obj/structure/janicart,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -2542,7 +2542,7 @@
 /turf/floor/laminate,
 /area/errant_pisces/rooms)
 "gt" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /turf/floor/laminate,
@@ -2556,7 +2556,7 @@
 /turf/floor/laminate,
 /area/errant_pisces/rooms)
 "gv" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /turf/floor/laminate,
@@ -2659,7 +2659,7 @@
 /turf/floor/plating/airless,
 /area/space)
 "gL" = (
-/obj/structure/bed/chair/comfy/green,
+/obj/structure/chair/comfy/green,
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
@@ -2677,7 +2677,7 @@
 /turf/floor/laminate,
 /area/errant_pisces/rooms)
 "gO" = (
-/obj/structure/bed/chair/comfy/teal,
+/obj/structure/chair/comfy/teal,
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
@@ -2694,7 +2694,7 @@
 /turf/floor/laminate,
 /area/errant_pisces/rooms)
 "gR" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2892,7 +2892,7 @@
 /turf/floor/laminate,
 /area/errant_pisces/rooms)
 "ht" = (
-/obj/structure/bed/chair/comfy/brown,
+/obj/structure/chair/comfy/brown,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
@@ -2931,7 +2931,7 @@
 	pixel_y = -25;
 	req_access = newlist()
 	},
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /turf/floor/laminate,
@@ -3071,7 +3071,7 @@
 /turf/floor/tiled,
 /area/errant_pisces/infirmary)
 "hY" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/tiled,
 /area/errant_pisces/infirmary)
 "hZ" = (
@@ -3792,7 +3792,7 @@
 /turf/floor/tiled,
 /area/errant_pisces/science_wing)
 "kg" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /turf/floor/tiled,
@@ -3984,7 +3984,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/floor/tiled,
@@ -5658,7 +5658,7 @@
 /turf/floor/tiled,
 /area/errant_pisces/bridge)
 "oT" = (
-/obj/structure/bed/chair/comfy/captain,
+/obj/structure/chair/comfy/captain,
 /turf/floor/tiled,
 /area/errant_pisces/bridge)
 "oU" = (
@@ -5778,7 +5778,7 @@
 /turf/floor/laminate,
 /area/errant_pisces/bridge)
 "pm" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 4
 	},
 /turf/floor/laminate,
@@ -5919,7 +5919,7 @@
 /turf/floor/tiled,
 /area/errant_pisces/bridge)
 "pL" = (
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /turf/floor/tiled,
 /area/errant_pisces/bridge)
 "pM" = (
@@ -6051,7 +6051,7 @@
 /turf/floor/tiled,
 /area/errant_pisces/bridge)
 "qb" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/floor/tiled,
@@ -6279,7 +6279,7 @@
 /turf/wall/r_wall,
 /area/space)
 "qN" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/plating,
 /area/errant_pisces/fishing_wing)
 "qO" = (
@@ -6356,7 +6356,7 @@
 /turf/space,
 /area/space)
 "qU" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/plating,
@@ -6373,7 +6373,7 @@
 /turf/floor/plating,
 /area/errant_pisces/fishing_wing)
 "qX" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/item/flame/match,

--- a/maps/away/liberia/liberia.dmm
+++ b/maps/away/liberia/liberia.dmm
@@ -23,7 +23,7 @@
 /turf/floor/tiled/techfloor/grid,
 /area/liberia/dockinghall)
 "ad" = (
-/obj/structure/bed/chair/comfy/captain{
+/obj/structure/chair/comfy/captain{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/blue/mono,
@@ -326,7 +326,7 @@
 /turf/floor/tiled/techfloor/grid,
 /area/liberia/engineeringengines)
 "aO" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/floor/tiled/steel_grid,
@@ -624,7 +624,7 @@
 /turf/floor/plating,
 /area/liberia/bridge)
 "bn" = (
-/obj/structure/bed/chair/wood/walnut,
+/obj/structure/chair/wood/walnut,
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
@@ -838,7 +838,7 @@
 /turf/floor/carpet/blue2,
 /area/liberia/mule)
 "bE" = (
-/obj/structure/bed/chair/shuttle/blue{
+/obj/structure/chair/shuttle/blue{
 	dir = 8
 	},
 /turf/floor/carpet/blue2,
@@ -1114,7 +1114,7 @@
 	req_access = list("ACCESS_MERCHANT");
 	dir = 1
 	},
-/obj/structure/bed/chair/shuttle/blue{
+/obj/structure/chair/shuttle/blue{
 	dir = 8
 	},
 /turf/floor/carpet/blue2,
@@ -1460,7 +1460,7 @@
 /turf/floor/tiled/techfloor/grid,
 /area/liberia/engineeringengines)
 "cG" = (
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 9
 	},
@@ -1546,7 +1546,7 @@
 /turf/floor/tiled/dark,
 /area/liberia/mule)
 "cQ" = (
-/obj/structure/bed/chair/office/comfy/brown{
+/obj/structure/chair/office/comfy/brown{
 	dir = 4
 	},
 /obj/structure/cable/blue{
@@ -3301,7 +3301,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 9
 	},
-/obj/structure/bed/chair/wood/walnut{
+/obj/structure/chair/wood/walnut{
 	dir = 4
 	},
 /turf/floor/carpet,
@@ -3321,13 +3321,13 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
 	},
-/obj/structure/bed/chair/wood/walnut{
+/obj/structure/chair/wood/walnut{
 	dir = 8
 	},
 /turf/floor/carpet,
 /area/liberia/bar)
 "fR" = (
-/obj/structure/bed/chair/wood/walnut{
+/obj/structure/chair/wood/walnut{
 	dir = 4
 	},
 /obj/machinery/alarm/liberia{
@@ -3345,7 +3345,7 @@
 /turf/floor/laminate/ebony,
 /area/liberia/bar)
 "fT" = (
-/obj/structure/bed/chair/wood/walnut{
+/obj/structure/chair/wood/walnut{
 	dir = 8
 	},
 /obj/machinery/power/apc/liberia{
@@ -3473,7 +3473,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /turf/floor/tiled,
@@ -3492,7 +3492,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/obj/structure/bed/chair/wood/walnut{
+/obj/structure/chair/wood/walnut{
 	dir = 4
 	},
 /turf/floor/carpet,
@@ -3507,7 +3507,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
-/obj/structure/bed/chair/wood/walnut{
+/obj/structure/chair/wood/walnut{
 	dir = 8
 	},
 /turf/floor/carpet,
@@ -3516,7 +3516,7 @@
 /turf/floor/laminate/ebony,
 /area/liberia/bar)
 "gj" = (
-/obj/structure/bed/chair/wood/walnut,
+/obj/structure/chair/wood/walnut,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/abstract/submap_landmark/spawnpoint/liberia,
 /turf/floor/laminate/ebony,
@@ -3576,7 +3576,7 @@
 /turf/floor/tiled/monotile,
 /area/liberia/officeroom)
 "gp" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4176,7 +4176,7 @@
 /turf/floor/carpet/red,
 /area/liberia/captain)
 "hq" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/floor/carpet/red,
@@ -4776,7 +4776,7 @@
 /turf/floor/tiled/dark/monotile,
 /area/liberia/bridge)
 "iN" = (
-/obj/structure/bed/chair/comfy/blue{
+/obj/structure/chair/comfy/blue{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/blue/mono,
@@ -5160,7 +5160,7 @@
 /obj/machinery/alarm/liberia{
 	pixel_y = 24
 	},
-/obj/structure/bed/chair/office/comfy/beige,
+/obj/structure/chair/office/comfy/beige,
 /turf/floor/carpet,
 /area/liberia/library)
 "jM" = (
@@ -5188,7 +5188,7 @@
 /turf/floor/tiled/monotile,
 /area/liberia/officeroom)
 "jR" = (
-/obj/structure/bed/chair/wood/walnut,
+/obj/structure/chair/wood/walnut,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
@@ -5214,7 +5214,7 @@
 /turf/floor/tiled/dark,
 /area/liberia/bridge)
 "jU" = (
-/obj/structure/bed/chair/wood/walnut,
+/obj/structure/chair/wood/walnut,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
@@ -5239,7 +5239,7 @@
 /turf/floor/tiled/techfloor/grid,
 /area/liberia/merchantstorage)
 "jW" = (
-/obj/structure/bed/chair/office/comfy/beige{
+/obj/structure/chair/office/comfy/beige{
 	dir = 4
 	},
 /turf/floor/carpet,
@@ -5307,7 +5307,7 @@
 /area/liberia/guestroom2)
 "kb" = (
 /obj/effect/floor_decal/spline/fancy/wood,
-/obj/structure/bed/chair/office/comfy/beige{
+/obj/structure/chair/office/comfy/beige{
 	dir = 4
 	},
 /turf/floor/carpet,
@@ -5475,7 +5475,7 @@
 /turf/floor/carpet,
 /area/liberia/library)
 "kq" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -6288,7 +6288,7 @@
 /turf/floor/tiled/steel_grid,
 /area/liberia/atmos)
 "nH" = (
-/obj/structure/bed/chair/wood/walnut,
+/obj/structure/chair/wood/walnut,
 /obj/abstract/submap_landmark/spawnpoint/liberia,
 /turf/floor/tiled,
 /area/liberia/hallway)
@@ -7734,7 +7734,7 @@
 /turf/wall/prepainted,
 /area/liberia/bar)
 "Ja" = (
-/obj/structure/bed/chair/wood/walnut,
+/obj/structure/chair/wood/walnut,
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},

--- a/maps/away/lost_supply_base/lost_supply_base.dmm
+++ b/maps/away/lost_supply_base/lost_supply_base.dmm
@@ -353,7 +353,7 @@
 /turf/floor/tiled/airless,
 /area/lost_supply_base/office)
 "aT" = (
-/obj/structure/bed/chair/comfy/captain,
+/obj/structure/chair/comfy/captain,
 /turf/floor/tiled/airless,
 /area/lost_supply_base/office)
 "aU" = (
@@ -1170,7 +1170,7 @@
 /turf/floor/tiled/airless,
 /area/lost_supply_base/common)
 "dy" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/tiled/airless,
@@ -1190,7 +1190,7 @@
 /area/lost_supply_base/common)
 "dB" = (
 /obj/item/utensil/fork,
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/tiled/airless,
@@ -1249,16 +1249,16 @@
 /turf/floor/shuttle/blue,
 /area/space)
 "dT" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/random/handgun,
 /turf/floor/shuttle/blue,
 /area/space)
 "dU" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/shuttle/blue,
 /area/space)
 "dV" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/random/smokes,
 /turf/floor/shuttle/blue,
 /area/space)
@@ -1306,7 +1306,7 @@
 /turf/floor/tiled/airless,
 /area/lost_supply_base/common)
 "ef" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/tiled/airless,
@@ -1405,7 +1405,7 @@
 /turf/floor/shuttle/blue,
 /area/space)
 "ex" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/item/key,
@@ -1473,13 +1473,13 @@
 /turf/floor/shuttle/blue,
 /area/space)
 "eM" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/shuttle/blue,
 /area/space)
 "eN" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/random/voidhelmet,

--- a/maps/away/magshield/magshield.dmm
+++ b/maps/away/magshield/magshield.dmm
@@ -641,7 +641,7 @@
 /turf/floor/plating/airless,
 /area/magshield/smes_storage)
 "bY" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/light/small{
@@ -711,7 +711,7 @@
 /turf/floor/plating,
 /area/magshield/smes_storage)
 "ci" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
@@ -1318,7 +1318,7 @@
 /turf/floor/plating/airless,
 /area/magshield/north)
 "dP" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/plating/airless,
@@ -2079,7 +2079,7 @@
 /turf/floor/tiled,
 /area/magshield/west)
 "fZ" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /turf/floor/tiled,
@@ -2492,7 +2492,7 @@
 /turf/floor/tiled/white,
 /area/magshield/west)
 "hp" = (
-/obj/structure/bed/chair/comfy/captain,
+/obj/structure/chair/comfy/captain,
 /turf/floor/tiled/white,
 /area/magshield/west)
 "hq" = (
@@ -2655,7 +2655,7 @@
 /turf/floor/carpet/blue,
 /area/magshield/west)
 "hS" = (
-/obj/structure/bed/chair/comfy/red,
+/obj/structure/chair/comfy/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -3057,7 +3057,7 @@
 /turf/floor/tiled,
 /area/magshield/south)
 "je" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/tiled,
 /area/magshield/south)
 "jf" = (
@@ -3148,7 +3148,7 @@
 /turf/floor/tiled,
 /area/magshield/south)
 "js" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/tiled,
@@ -3160,7 +3160,7 @@
 /turf/floor/tiled,
 /area/magshield/south)
 "ju" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -3177,7 +3177,7 @@
 /turf/floor/tiled,
 /area/magshield/south)
 "jw" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/tiled,
@@ -3424,7 +3424,7 @@
 /turf/floor/tiled,
 /area/magshield/south)
 "kh" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/tiled,

--- a/maps/away/mining/mining-signal.dmm
+++ b/maps/away/mining/mining-signal.dmm
@@ -150,7 +150,7 @@
 /turf/floor/tiled,
 /area/outpost/abandoned)
 "aK" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8;
 	icon_state = "officechair_dark"
 	},
@@ -158,7 +158,7 @@
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
 "aL" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4;
 	icon_state = "officechair_dark"
 	},
@@ -332,7 +332,7 @@
 /turf/floor/tiled/white,
 /area/outpost/abandoned)
 "bs" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/effect/floor_decal/corner/purple{
 	dir = 5
 	},
@@ -778,7 +778,7 @@
 /turf/floor/carpet/blue,
 /area/outpost/abandoned)
 "cP" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -1061,12 +1061,12 @@
 /area/outpost/abandoned)
 "dK" = (
 /obj/abstract/landmark/mapped_fluid/fuel,
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "dL" = (
 /obj/abstract/landmark/mapped_fluid/fuel,
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/machinery/light/small/emergency{
 	dir = 1;
 	icon_state = "bulb1"
@@ -1074,7 +1074,7 @@
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "dM" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "dN" = (
@@ -1746,7 +1746,7 @@
 /turf/floor/tiled/dark,
 /area/outpost/abandoned)
 "fV" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
 /turf/floor/tiled/dark,
@@ -1780,7 +1780,7 @@
 /turf/wall/titanium,
 /area/outpost/abandoned)
 "ga" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/visible,
@@ -2126,7 +2126,7 @@
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "hb" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
 	icon_state = "warning"
@@ -2176,7 +2176,7 @@
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "hk" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -2190,7 +2190,7 @@
 /turf/floor/tiled/airless,
 /area/outpost/abandoned)
 "hm" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/tiled/airless,

--- a/maps/away/smugglers/smugglers.dmm
+++ b/maps/away/smugglers/smugglers.dmm
@@ -682,7 +682,7 @@
 /turf/floor/tiled,
 /area/smugglers/office)
 "bL" = (
-/obj/structure/bed/chair/comfy/red{
+/obj/structure/chair/comfy/red{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -865,7 +865,7 @@
 /turf/floor/plating/airless,
 /area/smugglers/dorms)
 "cr" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/machinery/light,
@@ -889,7 +889,7 @@
 /turf/floor/tiled,
 /area/smugglers/dorms)
 "cu" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/light,

--- a/maps/away/unishi/unishi-2.dmm
+++ b/maps/away/unishi/unishi-2.dmm
@@ -19,13 +19,13 @@
 /turf/floor/carpet/red,
 /area/unishi/library)
 "af" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /turf/floor/carpet/red,
 /area/unishi/library)
 "ah" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -289,7 +289,7 @@
 /turf/floor/tiled/white,
 /area/unishi/chem)
 "aU" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/tiled/white,
@@ -334,7 +334,7 @@
 /turf/floor,
 /area/unishi/common)
 "bb" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -430,7 +430,7 @@
 /turf/floor,
 /area/unishi/common)
 "bt" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/tiled/dark,
 /area/unishi/classroom)
 "bu" = (
@@ -446,7 +446,7 @@
 /turf/floor/tiled/dark,
 /area/unishi/classroom)
 "bv" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -844,7 +844,7 @@
 /turf/floor/tiled,
 /area/unishi/meeting)
 "cA" = (
-/obj/structure/bed/chair/office/comfy/black,
+/obj/structure/chair/office/comfy/black,
 /turf/floor/tiled,
 /area/unishi/meeting)
 "cB" = (
@@ -954,7 +954,7 @@
 /turf/floor/reinforced,
 /area/space)
 "cM" = (
-/obj/structure/bed/chair/office/comfy/black{
+/obj/structure/chair/office/comfy/black{
 	dir = 4
 	},
 /turf/floor/tiled,
@@ -1014,7 +1014,7 @@
 /turf/floor/reinforced,
 /area/unishi/toxins)
 "cW" = (
-/obj/structure/bed/chair/office/comfy/black{
+/obj/structure/chair/office/comfy/black{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -1084,13 +1084,13 @@
 /turf/floor/reinforced,
 /area/unishi/toxins)
 "df" = (
-/obj/structure/bed/chair/office/comfy/black{
+/obj/structure/chair/office/comfy/black{
 	dir = 1
 	},
 /turf/floor/tiled,
 /area/unishi/meeting)
 "dg" = (
-/obj/structure/bed/chair/office/comfy/black{
+/obj/structure/chair/office/comfy/black{
 	dir = 1
 	},
 /obj/machinery/alarm{
@@ -1286,13 +1286,13 @@
 /turf/wall/titanium,
 /area/unishi/hydro)
 "dK" = (
-/obj/structure/bed/chair/office{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/floor/tiled,
 /area/unishi/rnd)
 "dL" = (
-/obj/structure/bed/chair/office{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1310,7 +1310,7 @@
 /turf/floor/tiled,
 /area/unishi/rnd)
 "dN" = (
-/obj/structure/bed/chair/office{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2001,7 +2001,7 @@
 /turf/floor/tiled/dark,
 /area/unishi/common)
 "fB" = (
-/obj/structure/bed/chair/office/comfy/black{
+/obj/structure/chair/office/comfy/black{
 	dir = 4
 	},
 /obj/machinery/light,
@@ -2020,7 +2020,7 @@
 /turf/floor/tiled/dark,
 /area/unishi/common)
 "fE" = (
-/obj/structure/bed/chair/office/comfy/black{
+/obj/structure/chair/office/comfy/black{
 	dir = 1
 	},
 /turf/floor/tiled/dark,
@@ -2042,7 +2042,7 @@
 /turf/floor/tiled/white/monotile,
 /area/unishi/common)
 "fH" = (
-/obj/structure/bed/chair/office/comfy/black{
+/obj/structure/chair/office/comfy/black{
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{

--- a/maps/away/unishi/unishi-3.dmm
+++ b/maps/away/unishi/unishi-3.dmm
@@ -58,7 +58,7 @@
 /turf/floor/tiled,
 /area/unishi/bridge)
 "an" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/tiled,
@@ -70,7 +70,7 @@
 /turf/floor/tiled/white/monotile,
 /area/unishi/bridge)
 "ap" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/machinery/light,
@@ -449,7 +449,7 @@
 /turf/floor/tiled,
 /area/unishi/living)
 "bD" = (
-/obj/structure/bed/chair/office{
+/obj/structure/chair/office{
 	dir = 1
 	},
 /turf/floor/tiled,
@@ -526,7 +526,7 @@
 /turf/floor,
 /area/unishi/living)
 "bL" = (
-/obj/structure/bed/chair/janicart,
+/obj/structure/janicart,
 /obj/item/key,
 /obj/structure/hygiene/sink/kitchen{
 	dir = 8;
@@ -626,7 +626,7 @@
 /turf/floor/tiled/white,
 /area/unishi/med)
 "cb" = (
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /turf/floor/tiled/white,
 /area/unishi/med)
 "cc" = (
@@ -637,7 +637,7 @@
 /turf/floor/tiled/white,
 /area/unishi/med)
 "cd" = (
-/obj/structure/bed/chair/armchair/black,
+/obj/structure/chair/armchair/black,
 /turf/floor/laminate,
 /area/unishi/lounge)
 "ce" = (
@@ -862,7 +862,7 @@
 /turf/floor,
 /area/unishi/living)
 "cC" = (
-/obj/structure/bed/chair/padded/brown,
+/obj/structure/chair/padded/brown,
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube1"
@@ -873,23 +873,23 @@
 /turf/floor/tiled,
 /area/unishi/living)
 "cD" = (
-/obj/structure/bed/chair/padded/black,
+/obj/structure/chair/padded/black,
 /obj/machinery/computer/modular/telescreen/preset/generic,
 /turf/floor/tiled,
 /area/unishi/living)
 "cE" = (
-/obj/structure/bed/chair/padded/black,
+/obj/structure/chair/padded/black,
 /turf/floor/tiled,
 /area/unishi/living)
 "cF" = (
 /obj/structure/noticeboard{
 	default_pixel_y = 25
 	},
-/obj/structure/bed/chair/padded/black,
+/obj/structure/chair/padded/black,
 /turf/floor/tiled,
 /area/unishi/living)
 "cG" = (
-/obj/structure/bed/chair/armchair/beige{
+/obj/structure/chair/armchair/beige{
 	dir = 4
 	},
 /turf/floor/laminate,
@@ -966,13 +966,13 @@
 /turf/floor/tiled,
 /area/unishi/living)
 "cP" = (
-/obj/structure/bed/chair/armchair/black{
+/obj/structure/chair/armchair/black{
 	dir = 1
 	},
 /turf/floor/laminate,
 /area/unishi/lounge)
 "cQ" = (
-/obj/structure/bed/chair/padded/brown{
+/obj/structure/chair/padded/brown{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/brown{
@@ -981,7 +981,7 @@
 /turf/floor/tiled,
 /area/unishi/living)
 "cR" = (
-/obj/structure/bed/chair/padded/black{
+/obj/structure/chair/padded/black{
 	dir = 1
 	},
 /turf/floor/tiled,
@@ -1014,7 +1014,7 @@
 /turf/floor/tiled,
 /area/unishi/kitchen)
 "cX" = (
-/obj/structure/bed/chair/padded/brown{
+/obj/structure/chair/padded/brown{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/brown{
@@ -1029,7 +1029,7 @@
 /turf/floor/tiled,
 /area/unishi/living)
 "cZ" = (
-/obj/structure/bed/chair/padded/black{
+/obj/structure/chair/padded/black{
 	dir = 8
 	},
 /obj/machinery/light,
@@ -1728,7 +1728,7 @@
 /turf/floor/laminate,
 /area/unishi/living)
 "eK" = (
-/obj/structure/bed/chair/office,
+/obj/structure/chair/office,
 /obj/machinery/light/small{
 	dir = 4;
 	icon_state = "bulb1"
@@ -1776,7 +1776,7 @@
 /turf/floor/tiled,
 /area/unishi/living)
 "eR" = (
-/obj/structure/bed/chair/office/comfy/black{
+/obj/structure/chair/office/comfy/black{
 	dir = 4
 	},
 /turf/floor/laminate,
@@ -1866,7 +1866,7 @@
 /turf/floor,
 /area/unishi/living)
 "fc" = (
-/obj/structure/bed/chair/armchair/black,
+/obj/structure/chair/armchair/black,
 /turf/floor/laminate,
 /area/unishi/living)
 "fd" = (

--- a/maps/away/yacht/yacht.dmm
+++ b/maps/away/yacht/yacht.dmm
@@ -42,7 +42,7 @@
 /area/yacht/bridge)
 "ak" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/bed/chair/comfy/captain,
+/obj/structure/chair/comfy/captain,
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/laminate/walnut,
@@ -192,7 +192,7 @@
 /turf/floor/laminate/yew,
 /area/yacht/living)
 "aF" = (
-/obj/structure/bed/chair/wood/wings{
+/obj/structure/chair/wood/wings{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/visible,
@@ -465,7 +465,7 @@
 /turf/floor/carpet/purple,
 /area/yacht/living)
 "bw" = (
-/obj/structure/bed/chair/comfy/red{
+/obj/structure/chair/comfy/red{
 	dir = 4
 	},
 /turf/floor/carpet/purple,

--- a/maps/exodus/exodus-1.dmm
+++ b/maps/exodus/exodus-1.dmm
@@ -405,7 +405,7 @@
 /turf/floor/carpet,
 /area/exodus/maintenance/sub/port)
 "bi" = (
-/obj/structure/bed/chair/wood/wings,
+/obj/structure/chair/wood/wings,
 /turf/floor/plating,
 /area/exodus/maintenance/sub/port)
 "bj" = (
@@ -414,7 +414,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/sub/port)
 "bk" = (
-/obj/structure/bed/chair/wood/wings{
+/obj/structure/chair/wood/wings{
 	dir = 4
 	},
 /turf/floor/plating,
@@ -461,13 +461,13 @@
 /turf/floor/plating,
 /area/exodus/maintenance/sub/port)
 "bs" = (
-/obj/structure/bed/chair/wood/wings{
+/obj/structure/chair/wood/wings{
 	dir = 1
 	},
 /turf/floor/laminate,
 /area/exodus/maintenance/sub/port)
 "bt" = (
-/obj/structure/bed/chair/wood/wings{
+/obj/structure/chair/wood/wings{
 	dir = 1
 	},
 /turf/floor/plating,
@@ -1044,13 +1044,13 @@
 /turf/floor/plating,
 /area/exodus/maintenance/sub/starboard)
 "dw" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/floor/plating,
 /area/exodus/maintenance/sub/starboard)
 "dx" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /turf/floor/plating,
@@ -1105,7 +1105,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/sub/starboard)
 "dE" = (
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /turf/floor/plating,
 /area/exodus/maintenance/sub/starboard)
 "dF" = (
@@ -1278,7 +1278,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/sub/port)
 "dZ" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /turf/floor/plating,
@@ -1683,7 +1683,7 @@
 /turf/floor/bluegrid,
 /area/exodus/maintenance/sub/command)
 "fc" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3674,7 +3674,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/plating,
@@ -3716,7 +3716,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/atmos)
 "jM" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/abstract/landmark/start{
@@ -5714,7 +5714,7 @@
 /turf/floor/tiled/dark/monotile,
 /area/exodus/maintenance/telecomms)
 "Bc" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/floor/lino,

--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -1034,7 +1034,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/foresolar)
 "acn" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -1386,7 +1386,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/meeting)
 "acZ" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -1523,7 +1523,7 @@
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/plating,
@@ -1775,7 +1775,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/main)
 "adV" = (
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /obj/abstract/landmark/start{
 	name = "Security Officer"
 	},
@@ -1962,7 +1962,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/main)
 "aep" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /obj/abstract/landmark/start{
@@ -2049,7 +2049,7 @@
 /turf/floor/plating,
 /area/exodus/crew_quarters/heads/hos)
 "aex" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -2119,7 +2119,7 @@
 /turf/wall/prepainted,
 /area/exodus/security/warden)
 "aeG" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -2306,7 +2306,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/meeting)
 "afb" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -2342,7 +2342,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/meeting)
 "afe" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -2506,7 +2506,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/meeting)
 "afx" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /obj/structure/cable/green{
@@ -2556,7 +2556,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/security_starboard)
 "afB" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/machinery/light/small/emergency{
@@ -2689,7 +2689,7 @@
 /area/shuttle/escape_pod_3)
 "afQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/tiled/steel_grid,
@@ -2822,7 +2822,7 @@
 /turf/floor/plating,
 /area/exodus/security/meeting)
 "agh" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/machinery/status_display{
@@ -3560,7 +3560,7 @@
 /turf/floor/carpet,
 /area/exodus/crew_quarters/heads/hos)
 "ahM" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/machinery/light/small/emergency{
@@ -3583,7 +3583,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/carpet,
 /area/exodus/crew_quarters/heads/hos)
 "ahO" = (
@@ -3743,7 +3743,7 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/security/brig/processing)
 "aik" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /turf/floor/tiled/dark,
@@ -3829,7 +3829,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/dormitory)
 "aiv" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/brig/processing)
 "aiw" = (
@@ -3875,7 +3875,7 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/security/brig)
 "aiC" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /turf/floor/plating,
@@ -3885,7 +3885,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/security_port)
 "aiE" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -3911,7 +3911,7 @@
 /turf/floor/plating,
 /area/exodus/security/brig/interrogation)
 "aiG" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -3946,7 +3946,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/substation/security)
 "aiK" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /obj/abstract/landmark/start{
@@ -4039,7 +4039,7 @@
 /turf/floor/tiled/dark,
 /area/exodus/security/warden)
 "aiV" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -4056,7 +4056,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/brig/processing)
 "aiX" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4133,7 +4133,7 @@
 /turf/floor/tiled/dark,
 /area/exodus/security/brig/processing)
 "ajf" = (
-/obj/structure/bed/chair/comfy/black{
+/obj/structure/chair/comfy/black{
 	dir = 1
 	},
 /obj/abstract/landmark/start{
@@ -4207,7 +4207,7 @@
 /turf/floor/tiled/dark,
 /area/exodus/security/warden)
 "ajk" = (
-/obj/structure/bed/chair/wood/walnut{
+/obj/structure/chair/wood/walnut{
 	dir = 8
 	},
 /obj/machinery/status_display{
@@ -5480,7 +5480,7 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/security/brig/processing)
 "alC" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /obj/abstract/landmark/start{
@@ -5765,7 +5765,7 @@
 /turf/wall/prepainted,
 /area/exodus/lawoffice)
 "amj" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /obj/machinery/button/alternate/door{
@@ -5800,7 +5800,7 @@
 /turf/wall/prepainted,
 /area/exodus/security/main)
 "amm" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /obj/machinery/button/alternate/door{
@@ -6074,7 +6074,7 @@
 /turf/floor/plating,
 /area/exodus/security/prison)
 "amP" = (
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /obj/abstract/landmark/start{
 	name = "Internal Affairs Agent"
 	},
@@ -6723,7 +6723,7 @@
 /turf/floor/lino,
 /area/exodus/security/detectives_office)
 "aoe" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /obj/abstract/landmark/start{
@@ -6753,7 +6753,7 @@
 /area/exodus/security/detectives_office)
 "aoh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/tiled/dark,
@@ -7340,7 +7340,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/dormitory)
 "apw" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -7394,7 +7394,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/dormitory)
 "apC" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/machinery/status_display{
@@ -7416,7 +7416,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red{
@@ -7428,7 +7428,7 @@
 /turf/floor/laminate,
 /area/exodus/maintenance/dormitory)
 "apG" = (
-/obj/structure/bed/chair/wood/wings,
+/obj/structure/chair/wood/wings,
 /turf/floor/laminate,
 /area/exodus/maintenance/dormitory)
 "apH" = (
@@ -7539,7 +7539,7 @@
 /turf/floor/tiled/dark,
 /area/exodus/lawoffice)
 "apS" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
 /turf/floor/tiled/white,
@@ -7630,7 +7630,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/prison)
 "aqb" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
@@ -7646,7 +7646,7 @@
 	id_tag = "air_in";
 	use_power = 1
 	},
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
@@ -7668,7 +7668,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/prison)
 "aqe" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
@@ -7729,7 +7729,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/dormitory)
 "aqj" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -7856,7 +7856,7 @@
 /turf/floor/laminate,
 /area/exodus/maintenance/dormitory)
 "aqv" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -7879,7 +7879,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/brig/solitaryB)
 "aqy" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /obj/abstract/landmark/start{
@@ -8107,7 +8107,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/prison)
 "aqY" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -8668,13 +8668,13 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/security/brig/solitaryB)
 "asa" = (
-/obj/structure/bed/chair/wood/wings{
+/obj/structure/chair/wood/wings{
 	dir = 1
 	},
 /turf/floor/laminate,
 /area/exodus/maintenance/dormitory)
 "asb" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/plating,
@@ -8752,7 +8752,7 @@
 /turf/floor/plating/airless,
 /area/exodus/solar/auxstarboard)
 "asi" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/tiled/steel_grid,
@@ -8766,7 +8766,7 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/maintenance/dormitory)
 "ask" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8883,7 +8883,7 @@
 /turf/wall/r_wall/prepainted,
 /area/exodus/security/brig/solitaryA)
 "asx" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/machinery/status_display{
@@ -9151,7 +9151,7 @@
 /turf/wall/prepainted,
 /area/exodus/security/prison/dorm)
 "asX" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /mob/living/simple_animal/passive/mouse,
@@ -9893,7 +9893,7 @@
 /turf/wall/prepainted,
 /area/exodus/maintenance/arrivals)
 "auR" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/structure/cable/green{
@@ -10145,7 +10145,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/security/prison)
 "avt" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/machinery/alarm{
@@ -10557,7 +10557,7 @@
 /turf/floor/laminate/walnut,
 /area/exodus/crew_quarters/sleep/bedrooms)
 "awk" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/alarm{
@@ -11512,7 +11512,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/pods)
 "ays" = (
-/obj/structure/bed/chair/comfy/beige{
+/obj/structure/chair/comfy/beige{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning,
@@ -13171,7 +13171,7 @@
 /turf/floor/tiled/dark,
 /area/exodus/ai_monitored/storage/eva)
 "aBR" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -13398,7 +13398,7 @@
 /turf/floor/plating,
 /area/exodus/storage/emergency2)
 "aCr" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -13541,7 +13541,7 @@
 /turf/floor/plating,
 /area/exodus/bridge)
 "aCI" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -14549,7 +14549,7 @@
 /turf/floor/tiled/dark,
 /area/exodus/security/checkpoint2)
 "aEO" = (
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -16405,7 +16405,7 @@
 /obj/effect/floor_decal/corner/white{
 	dir = 10
 	},
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 8
 	},
 /obj/abstract/landmark/latejoin,
@@ -16526,7 +16526,7 @@
 /obj/effect/floor_decal/corner/white{
 	dir = 5
 	},
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 8
 	},
 /obj/abstract/landmark/latejoin,
@@ -16567,7 +16567,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 8
 	},
 /turf/floor/tiled/dark/monotile,
@@ -16814,7 +16814,7 @@
 /turf/floor/lino,
 /area/exodus/chapel/office)
 "aJk" = (
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -16828,7 +16828,7 @@
 /obj/abstract/landmark/start{
 	name = "Chaplain"
 	},
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/floor/lino,
 /area/exodus/chapel/office)
@@ -17152,7 +17152,7 @@
 /turf/floor/tiled/monotile,
 /area/exodus/storage/primary)
 "aJW" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -17205,7 +17205,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/substation/civilian_west)
 "aKb" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -17732,7 +17732,7 @@
 /turf/wall/prepainted,
 /area/exodus/hydroponics)
 "aLi" = (
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -17761,7 +17761,7 @@
 /turf/floor/laminate/walnut,
 /area/exodus/library)
 "aLm" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/tiled/dark,
@@ -17829,7 +17829,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -18144,7 +18144,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/library)
 "aMg" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /turf/floor/laminate/walnut,
@@ -18187,7 +18187,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -18218,7 +18218,7 @@
 /turf/floor/lino,
 /area/exodus/crew_quarters/bar)
 "aMq" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/floor/laminate/walnut,
@@ -18431,7 +18431,7 @@
 /turf/wall/r_wall/prepainted,
 /area/exodus/research/docking)
 "aMN" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -18525,14 +18525,14 @@
 /turf/floor/plating,
 /area/exodus/maintenance/arrivals)
 "aMX" = (
-/obj/structure/bed/chair/comfy/beige,
+/obj/structure/chair/comfy/beige,
 /turf/floor/lino,
 /area/exodus/hallway/secondary/entry/starboard)
 "aMY" = (
 /turf/floor/lino,
 /area/exodus/hallway/secondary/entry/starboard)
 "aMZ" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -18566,7 +18566,7 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/hydroponics)
 "aNd" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -18630,7 +18630,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/port)
 "aNj" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /turf/floor/laminate/walnut,
@@ -19123,7 +19123,7 @@
 /turf/floor/lino,
 /area/exodus/crew_quarters/bar)
 "aOf" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -19425,7 +19425,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
@@ -20546,7 +20546,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/library)
 "aRn" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
 /obj/machinery/button/windowtint{
@@ -20762,7 +20762,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/port)
 "aRJ" = (
-/obj/structure/bed/chair/comfy/beige{
+/obj/structure/chair/comfy/beige{
 	dir = 1
 	},
 /turf/floor/lino,
@@ -20997,7 +20997,7 @@
 /area/exodus/medical/medbay)
 "aSl" = (
 /obj/machinery/light/small,
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/machinery/alarm{
@@ -21287,7 +21287,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/locker)
 "aSP" = (
-/obj/structure/bed/chair/wood/walnut{
+/obj/structure/chair/wood/walnut{
 	dir = 4
 	},
 /turf/floor/laminate/walnut,
@@ -21458,7 +21458,7 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/hallway/secondary/entry/aft)
 "aTk" = (
-/obj/structure/bed/chair/wood/walnut{
+/obj/structure/chair/wood/walnut{
 	dir = 8
 	},
 /turf/floor/laminate/walnut,
@@ -21784,7 +21784,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_one)
 "aTW" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/full,
@@ -22522,7 +22522,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/storage/tools)
 "aVN" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/tiled/steel_grid,
@@ -22555,7 +22555,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/bridge)
 "aVS" = (
-/obj/structure/bed/chair/wood/walnut,
+/obj/structure/chair/wood/walnut,
 /turf/floor/laminate/walnut,
 /area/exodus/crew_quarters/bar)
 "aVT" = (
@@ -22581,11 +22581,11 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/obj/structure/bed/chair/wood/walnut,
+/obj/structure/chair/wood/walnut,
 /turf/floor/laminate/walnut,
 /area/exodus/crew_quarters/bar)
 "aVX" = (
-/obj/structure/bed/chair/wood/walnut,
+/obj/structure/chair/wood/walnut,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/floor/laminate/walnut,
 /area/exodus/crew_quarters/bar)
@@ -22619,7 +22619,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/bed/chair/wood/walnut,
+/obj/structure/chair/wood/walnut,
 /obj/structure/disposalpipe/segment,
 /turf/floor/laminate/walnut,
 /area/exodus/crew_quarters/bar)
@@ -22734,7 +22734,7 @@
 /turf/floor/tiled/white,
 /area/exodus/crew_quarters/kitchen)
 "aWl" = (
-/obj/structure/bed/chair/comfy/black,
+/obj/structure/chair/comfy/black,
 /turf/floor/laminate/walnut,
 /area/exodus/library)
 "aWm" = (
@@ -22835,7 +22835,7 @@
 /obj/abstract/landmark/start{
 	name = "Librarian"
 	},
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /turf/floor/laminate/walnut,
 /area/exodus/library)
 "aWA" = (
@@ -23622,7 +23622,7 @@
 /turf/floor/lino,
 /area/exodus/security/vacantoffice)
 "aYt" = (
-/obj/structure/bed/chair/comfy/black{
+/obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /turf/floor/laminate/walnut,
@@ -23834,7 +23834,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/locker)
 "aYS" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -24057,7 +24057,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/bridge)
 "aZg" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -24164,7 +24164,7 @@
 /turf/floor/plating,
 /area/exodus/research/xenobiology/xenoflora)
 "aZr" = (
-/obj/structure/bed/chair/wood/walnut{
+/obj/structure/chair/wood/walnut{
 	dir = 1
 	},
 /turf/floor/laminate/walnut,
@@ -24239,7 +24239,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/bed/chair/wood/walnut{
+/obj/structure/chair/wood/walnut{
 	dir = 1
 	},
 /turf/floor/laminate/walnut,
@@ -24272,7 +24272,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/bed/chair/wood/walnut{
+/obj/structure/chair/wood/walnut{
 	dir = 1
 	},
 /turf/floor/laminate/walnut,
@@ -24312,13 +24312,13 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/bed/chair/wood/walnut{
+/obj/structure/chair/wood/walnut{
 	dir = 1
 	},
 /turf/floor/laminate/walnut,
 /area/exodus/crew_quarters/bar)
 "aZL" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/structure/window/reinforced{
@@ -24388,13 +24388,13 @@
 /turf/wall/prepainted,
 /area/exodus/engineering/engine_eva)
 "aZV" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
 /turf/floor/lino,
 /area/exodus/security/vacantoffice)
 "aZW" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /turf/floor/lino,
@@ -25085,7 +25085,7 @@
 /turf/floor/tiled/white,
 /area/exodus/crew_quarters/kitchen)
 "bbs" = (
-/obj/structure/bed/chair/comfy/black{
+/obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -25184,7 +25184,7 @@
 /turf/floor/tiled/dark,
 /area/exodus/security/vacantoffice)
 "bbE" = (
-/obj/structure/bed/chair/comfy/black{
+/obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /turf/floor/laminate/walnut,
@@ -25502,7 +25502,7 @@
 /turf/floor/plating/airless,
 /area/exodus/turret_protected/ai)
 "bcm" = (
-/obj/structure/bed/chair/comfy/black{
+/obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -25979,7 +25979,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/aft)
 "bdk" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/floor/lino,
@@ -26282,7 +26282,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/starboard)
 "bdR" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/lime{
@@ -26389,7 +26389,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/structure/bed/chair/wood/walnut{
+/obj/structure/chair/wood/walnut{
 	dir = 4
 	},
 /turf/floor/laminate/walnut,
@@ -26505,7 +26505,7 @@
 /turf/floor/tiled/dark,
 /area/exodus/security/vacantoffice)
 "bex" = (
-/obj/structure/bed/chair/comfy/black,
+/obj/structure/chair/comfy/black,
 /turf/floor/carpet,
 /area/exodus/bridge/meeting_room)
 "bey" = (
@@ -26543,7 +26543,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/locker)
 "beC" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -26564,7 +26564,7 @@
 /turf/floor/laminate/walnut,
 /area/exodus/library)
 "beE" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -26869,7 +26869,7 @@
 /turf/floor/plating,
 /area/exodus/quartermaster/office)
 "bfj" = (
-/obj/structure/bed/chair/comfy/black{
+/obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -26882,7 +26882,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/starboard)
 "bfl" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -27015,7 +27015,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/exit)
 "bfB" = (
-/obj/structure/bed/chair/comfy/black{
+/obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -27570,7 +27570,7 @@
 /turf/floor/carpet,
 /area/exodus/bridge/meeting_room)
 "bgQ" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /turf/floor/carpet,
@@ -27653,7 +27653,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/aft)
 "bgZ" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /turf/floor/carpet,
@@ -27682,7 +27682,7 @@
 /turf/floor/laminate/walnut,
 /area/exodus/crew_quarters/captain)
 "bhd" = (
-/obj/structure/bed/chair/comfy/black{
+/obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /turf/floor/carpet,
@@ -27698,7 +27698,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/starboard)
 "bhf" = (
-/obj/structure/bed/chair/comfy/black{
+/obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /turf/floor/carpet,
@@ -29966,7 +29966,7 @@
 /turf/floor/bluegrid,
 /area/exodus/turret_protected/ai)
 "blE" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/abstract/landmark/start{
@@ -30464,7 +30464,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/bed/chair/wheelchair,
+/obj/structure/chair/wheelchair,
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
@@ -30861,7 +30861,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/carpet,
 /area/exodus/crew_quarters/captain)
 "bns" = (
@@ -31088,7 +31088,7 @@
 /turf/floor/tiled/dark,
 /area/exodus/turret_protected/ai)
 "bnK" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/floor/tiled/white,
@@ -31121,7 +31121,7 @@
 /turf/floor/tiled/freezer,
 /area/exodus/medical/patient_wing/washroom)
 "bnQ" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /obj/abstract/landmark/start{
@@ -31337,7 +31337,7 @@
 /turf/floor/tiled/dark,
 /area/exodus/turret_protected/ai_upload)
 "bou" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /obj/abstract/landmark/start{
@@ -31482,7 +31482,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/workshop)
 "boK" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 1
 	},
 /obj/abstract/landmark/start{
@@ -31560,7 +31560,7 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 5
 	},
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -31569,7 +31569,7 @@
 /turf/floor/tiled/white,
 /area/exodus/research/lab)
 "boT" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 4
 	},
 /turf/floor/tiled/white,
@@ -33845,7 +33845,7 @@
 	pixel_x = -16;
 	pixel_y = 28
 	},
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /obj/abstract/landmark/start{
@@ -33979,7 +33979,7 @@
 	pixel_x = 6;
 	pixel_y = 28
 	},
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /obj/abstract/landmark/start{
@@ -34038,7 +34038,7 @@
 /turf/floor/carpet,
 /area/exodus/crew_quarters/captain)
 "btT" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -34583,7 +34583,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/office)
 "buT" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/firealarm{
@@ -35239,7 +35239,7 @@
 /obj/abstract/landmark/start{
 	name = "Cargo Technician"
 	},
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /turf/floor/tiled/steel_grid,
@@ -35303,7 +35303,7 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/quartermaster/office)
 "bws" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -35416,7 +35416,7 @@
 /turf/floor/plating,
 /area/exodus/storage/emergency)
 "bwG" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -35457,7 +35457,7 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/tiled/white,
@@ -35518,7 +35518,7 @@
 /turf/floor/tiled/dark,
 /area/exodus/turret_protected/ai_upload)
 "bwR" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -35995,7 +35995,7 @@
 /turf/floor/tiled/dark,
 /area/exodus/research)
 "bxQ" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -37848,7 +37848,7 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/quartermaster/office)
 "bBw" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/tiled/steel_grid,
@@ -38128,7 +38128,7 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/medbay3)
 "bCb" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/light,
@@ -38496,7 +38496,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_three)
 "bCR" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /obj/abstract/landmark/start{
@@ -38532,7 +38532,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/crew_quarters/heads/hop)
 "bCT" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/tiled/steel_grid,
@@ -41003,7 +41003,7 @@
 /turf/floor/reinforced,
 /area/exodus/research/misc_lab)
 "bHH" = (
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /obj/abstract/landmark/start{
 	name = "Quartermaster"
 	},
@@ -41170,7 +41170,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_three)
 "bHV" = (
-/obj/structure/bed/chair/office/light,
+/obj/structure/chair/office/light,
 /turf/floor/tiled/dark,
 /area/exodus/research/server)
 "bHW" = (
@@ -41540,7 +41540,7 @@
 /turf/floor/plating,
 /area/exodus/medical/genetics/cloning)
 "bIH" = (
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /obj/abstract/landmark/start{
 	name = "Geneticist"
 	},
@@ -42632,7 +42632,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/qm)
 "bKO" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/tiled/steel_grid,
@@ -43149,7 +43149,7 @@
 /turf/floor/plating/airless,
 /area/exodus/research/test_area)
 "bLU" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/tiled/steel_grid,
@@ -43267,7 +43267,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /obj/abstract/landmark/start{
@@ -43837,7 +43837,7 @@
 /turf/floor,
 /area/exodus/quartermaster/miningdock)
 "bNh" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/purple/diagonal{
@@ -44233,7 +44233,7 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/crew_quarters/heads/cmo)
 "bOe" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -44243,7 +44243,7 @@
 /turf/floor/tiled/white,
 /area/exodus/crew_quarters/heads/cmo)
 "bOf" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/tiled/white,
 /area/exodus/crew_quarters/heads/cmo)
 "bOg" = (
@@ -45722,7 +45722,7 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/medical/medbay)
 "bRc" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /obj/abstract/landmark/start{
@@ -46444,7 +46444,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /obj/abstract/landmark/start{
@@ -46503,7 +46503,7 @@
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medbay Examination Room"
 	},
-/obj/structure/bed/chair/wheelchair,
+/obj/structure/chair/wheelchair,
 /turf/floor/tiled/white,
 /area/exodus/medical/exam_room)
 "bSz" = (
@@ -46511,7 +46511,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /obj/effect/floor_decal/corner/pink{
 	dir = 9
 	},
@@ -46522,7 +46522,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /obj/effect/floor_decal/corner/pink{
 	dir = 9
 	},
@@ -46607,7 +46607,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/research/storage)
 "bSJ" = (
-/obj/structure/bed/chair/comfy/teal{
+/obj/structure/chair/comfy/teal{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue{
@@ -46763,7 +46763,7 @@
 /turf/floor/plating,
 /area/exodus/storage/tech)
 "bTc" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -47563,7 +47563,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/bed/chair/comfy/teal{
+/obj/structure/chair/comfy/teal{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue{
@@ -47659,7 +47659,7 @@
 /turf/floor/laminate/walnut,
 /area/exodus/engineering/break_room)
 "bUY" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/status_display{
@@ -48034,7 +48034,7 @@
 /turf/floor/tiled/airless,
 /area/exodus/research/test_area)
 "bVM" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -48366,7 +48366,7 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/patient_wing)
 "bWx" = (
-/obj/structure/bed/chair/comfy/teal,
+/obj/structure/chair/comfy/teal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -48451,7 +48451,7 @@
 /turf/floor/tiled/white,
 /area/exodus/research/misc_lab)
 "bWH" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 1
 	},
 /obj/abstract/landmark/start{
@@ -48815,7 +48815,7 @@
 /obj/abstract/landmark/start{
 	name = "Station Engineer"
 	},
-/obj/structure/bed/chair/comfy/brown,
+/obj/structure/chair/comfy/brown,
 /turf/floor/carpet,
 /area/exodus/engineering/break_room)
 "bXv" = (
@@ -49517,7 +49517,7 @@
 /turf/floor/plating,
 /area/exodus/engineering/storage)
 "bYH" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -49600,7 +49600,7 @@
 /obj/abstract/landmark/start{
 	name = "Station Engineer"
 	},
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /turf/floor/carpet,
@@ -49951,7 +49951,7 @@
 /turf/floor/tiled/freezer,
 /area/exodus/medical/patient_wing/washroom)
 "bZH" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/plating,
@@ -50168,7 +50168,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/crew_quarters/heads/chief)
 "cae" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 4
 	},
 /obj/abstract/landmark/start{
@@ -50207,7 +50207,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/crew_quarters/heads/chief)
 "cag" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -50377,7 +50377,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/structure/bed/chair/comfy/teal{
+/obj/structure/chair/comfy/teal{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/pink/three_quarters{
@@ -50439,7 +50439,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/pink{
@@ -50714,7 +50714,7 @@
 /obj/abstract/landmark/start{
 	name = "Atmospheric Technician"
 	},
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /turf/floor/carpet,
@@ -52167,7 +52167,7 @@
 /obj/abstract/landmark/start{
 	name = "Station Engineer"
 	},
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /turf/floor/carpet,
@@ -52176,7 +52176,7 @@
 /obj/abstract/landmark/start{
 	name = "Atmospheric Technician"
 	},
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /turf/floor/carpet,
@@ -52282,7 +52282,7 @@
 /turf/floor/laminate/walnut,
 /area/exodus/engineering/break_room)
 "cel" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /obj/machinery/firealarm{
@@ -52447,7 +52447,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/foyer)
 "ceB" = (
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/break_room)
@@ -52554,7 +52554,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/medical/surgeryobs)
 "ceP" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/tiled/steel_grid,
 /area/exodus/medical/surgeryobs)
 "ceQ" = (
@@ -53075,7 +53075,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /turf/floor/carpet/blue,
@@ -53225,7 +53225,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/foyer)
 "cgp" = (
-/obj/structure/bed/chair/comfy/brown,
+/obj/structure/chair/comfy/brown,
 /obj/abstract/landmark/start{
 	name = "Psychiatrist"
 	},
@@ -53312,7 +53312,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
 /obj/abstract/landmark/start{
@@ -54138,7 +54138,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /obj/abstract/landmark/start{
@@ -54801,7 +54801,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
 /obj/abstract/landmark/start{
@@ -54844,7 +54844,7 @@
 /area/exodus/research/xenobiology/xenoflora)
 "cjG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /obj/abstract/landmark/start{
@@ -55493,7 +55493,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/engi_engine)
 "cle" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
@@ -56425,7 +56425,7 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/surgery)
 "cmY" = (
-/obj/structure/bed/chair/comfy/black{
+/obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/blue{
@@ -56657,7 +56657,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/engineering_monitoring)
 "cnA" = (
@@ -57703,7 +57703,7 @@
 /turf/floor/plating/airless,
 /area/space)
 "cqa" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /obj/abstract/landmark/start{
@@ -58055,7 +58055,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/engi_shuttle)
 "cre" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /obj/abstract/landmark/start{
@@ -59039,7 +59039,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/camera/network/medbay{
 	c_tag = "Virology Monkey Pen"
@@ -59471,7 +59471,7 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/virology)
 "cuN" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -59494,7 +59494,7 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/virology)
 "cuR" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /turf/floor/tiled/white,
@@ -60054,7 +60054,7 @@
 /obj/effect/floor_decal/corner/white{
 	dir = 5
 	},
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 8
 	},
 /obj/abstract/landmark/latejoin,
@@ -60360,7 +60360,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/workshop)
 "cyz" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/abstract/landmark/start{
 	name = "Station Engineer"
 	},
@@ -60405,7 +60405,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/secondary/entry/port)
 "cyI" = (
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -60658,13 +60658,13 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/plating,
 /area/exodus/maintenance/engi_shuttle)
 "czE" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -60697,7 +60697,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/engi_shuttle)
 "czO" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -61202,7 +61202,7 @@
 /turf/wall/r_wall/prepainted,
 /area/exodus/engineering/engine_airlock)
 "cDt" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -61241,7 +61241,7 @@
 /turf/floor/tiled/techfloor/grid,
 /area/exodus/engineering/engine_airlock)
 "cDy" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/plating,
@@ -61544,7 +61544,7 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/virology)
 "cEV" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/plating,
@@ -61755,7 +61755,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/engine_monitoring)
 "cGn" = (
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /obj/abstract/landmark/start{
 	name = "Station Engineer"
 	},
@@ -61949,7 +61949,7 @@
 /turf/floor/plating,
 /area/exodus/engineering/drone_fabrication)
 "cHg" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning,
@@ -62923,7 +62923,7 @@
 	pixel_y = 25;
 	tag_door = "engineering_shuttle_hatch"
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/machinery/light{
@@ -62980,7 +62980,7 @@
 /turf/floor/tiled/dark,
 /area/ship/exodus_pod_engineering)
 "cLk" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/tiled/dark,
@@ -63031,7 +63031,7 @@
 /turf/floor/plating,
 /area/ship/exodus_pod_engineering)
 "cLu" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/machinery/light,
@@ -63708,7 +63708,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/central_two)
 "gOE" = (
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 8
 	},
 /obj/abstract/landmark/latejoin,
@@ -63824,7 +63824,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/hallway/primary/starboard)
 "hWZ" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -63844,7 +63844,7 @@
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/tiled/steel_grid,
@@ -63878,7 +63878,7 @@
 /obj/effect/floor_decal/corner/white{
 	dir = 10
 	},
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 8
 	},
 /obj/abstract/landmark/latejoin,
@@ -63924,13 +63924,13 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 8
 	},
 /turf/floor/tiled/dark/monotile,
 /area/shuttle/arrival/station)
 "iTt" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/structure/cable/green{
@@ -64031,7 +64031,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/tiled/white,
@@ -64096,7 +64096,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -64198,7 +64198,7 @@
 /turf/floor/plating,
 /area/ship/exodus_pod_research)
 "mYp" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
@@ -64305,7 +64305,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/tiled/steel_grid,
@@ -64354,7 +64354,7 @@
 /turf/floor/tiled/dark,
 /area/exodus/chapel/main)
 "pqS" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -64516,7 +64516,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -64740,7 +64740,7 @@
 /turf/floor/plating,
 /area/ship/exodus_pod_mining)
 "tQY" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/light,
@@ -65065,7 +65065,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/quartermaster/office)
 "xVx" = (
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 8
 	},
 /obj/abstract/landmark/latejoin,

--- a/maps/exodus/exodus-admin.dmm
+++ b/maps/exodus/exodus-admin.dmm
@@ -207,7 +207,7 @@
 /turf/unsimulated/floor/steel,
 /area/centcom)
 "auW" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/unsimulated/floor/steel,
@@ -254,7 +254,7 @@
 /turf/space,
 /area/space)
 "ayg" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/unsimulated/floor/steel,
@@ -330,7 +330,7 @@
 /turf/space,
 /area/shuttle/supply_shuttle)
 "aBA" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
@@ -343,7 +343,7 @@
 /turf/unsimulated/floor/steel,
 /area/centcom)
 "aBC" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
@@ -408,7 +408,7 @@
 /turf/unsimulated/floor/steel,
 /area/centcom)
 "aCv" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/unsimulated/floor/steel,
 /area/centcom)
 "aCx" = (
@@ -520,7 +520,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/half{
@@ -558,7 +558,7 @@
 /turf/floor/tiled/dark,
 /area/shuttle/escape_shuttle)
 "aGE" = (
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
@@ -756,7 +756,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 8
 	},
 /turf/floor/tiled/monotile,
@@ -785,7 +785,7 @@
 /turf/floor/plating,
 /area/shuttle/escape_shuttle)
 "aIS" = (
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 8
 	},
 /turf/floor/tiled/monotile,
@@ -937,7 +937,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/half{
@@ -982,7 +982,7 @@
 /turf/unsimulated/floor/white,
 /area/space)
 "aLc" = (
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/half{
@@ -997,7 +997,7 @@
 /turf/floor/tiled/dark/monotile,
 /area/shuttle/escape_shuttle)
 "aLe" = (
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/half{
@@ -1006,7 +1006,7 @@
 /turf/floor/tiled/dark/monotile,
 /area/shuttle/escape_shuttle)
 "aLf" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/green{
@@ -1024,7 +1024,7 @@
 /turf/floor/tiled/white,
 /area/shuttle/escape_shuttle)
 "aLm" = (
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /obj/machinery/button/blast_door{
 	desc = "A remote control switch for port-side blast doors.";
 	id_tag = "CentComPort";
@@ -1297,7 +1297,7 @@
 /turf/unsimulated/floor/grass,
 /area/centcom/holding)
 "aMp" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/green{
@@ -1339,19 +1339,19 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 4
 	},
 /turf/floor/tiled/monotile,
 /area/shuttle/escape_shuttle)
 "aMz" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/unsimulated/floor/steel,
 /area/centcom/holding)
 "aMA" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/unsimulated/floor/steel,
@@ -1400,7 +1400,7 @@
 /turf/unsimulated/floor/steel,
 /area/centcom/holding)
 "aMR" = (
-/obj/structure/bed/chair/wood/wings{
+/obj/structure/chair/wood/wings{
 	dir = 4
 	},
 /turf/unsimulated/floor/laminate,
@@ -1422,7 +1422,7 @@
 	c_tag = "Shuttle East";
 	dir = 4
 	},
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 4
 	},
 /turf/floor/tiled/monotile,
@@ -1457,7 +1457,7 @@
 /turf/unsimulated/floor/laminate,
 /area/centcom/holding)
 "aNa" = (
-/obj/structure/bed/chair/wood/wings{
+/obj/structure/chair/wood/wings{
 	dir = 8
 	},
 /turf/unsimulated/floor/laminate,
@@ -1508,7 +1508,7 @@
 /turf/unsimulated/floor/lino,
 /area/centcom/holding)
 "aNo" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/green{
@@ -1530,7 +1530,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 4
 	},
 /turf/floor/tiled/monotile,
@@ -1683,7 +1683,7 @@
 /turf/unsimulated/floor/lino,
 /area/centcom/holding)
 "aPK" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/green,
@@ -1737,7 +1737,7 @@
 /turf/unsimulated/floor/laminate,
 /area/centcom/holding)
 "aZb" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /obj/structure/table/laminate{
@@ -1751,7 +1751,7 @@
 /turf/unsimulated/floor/lino,
 /area/centcom/holding)
 "bgb" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /obj/structure/table/laminate{
@@ -1766,7 +1766,7 @@
 /turf/unsimulated/floor/lino,
 /area/centcom/holding)
 "bjb" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/green{
@@ -1883,7 +1883,7 @@
 /turf/floor/tiled,
 /area/shuttle/escape_shuttle)
 "cEu" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/machinery/camera/network/crescent{
@@ -1905,7 +1905,7 @@
 /turf/floor/tiled/dark/monotile,
 /area/shuttle/escape_shuttle)
 "cIe" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/unsimulated/floor/lino,
 /area/tdome/tdomeadmin)
 "cIv" = (
@@ -1921,7 +1921,7 @@
 /turf/floor/tiled/dark,
 /area/shuttle/escape_shuttle)
 "cQH" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/abstract/landmark{
@@ -1944,7 +1944,7 @@
 	name = "Emergency NanoMed";
 	pixel_x = 28
 	},
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/blue/border{
@@ -1979,7 +1979,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 9
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/unsimulated/floor/steel,
@@ -2085,7 +2085,7 @@
 /turf/unsimulated/floor/vault,
 /area/tdome)
 "fRC" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/unsimulated/floor/vault,
@@ -2116,7 +2116,7 @@
 /turf/floor/tiled,
 /area/shuttle/escape_shuttle)
 "ghj" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/unsimulated/floor/vault,
@@ -2163,7 +2163,7 @@
 /turf/floor/tiled/dark,
 /area/shuttle/escape_shuttle)
 "hlP" = (
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 4
 	},
 /turf/floor/tiled/dark/monotile,
@@ -2202,7 +2202,7 @@
 /turf/floor/tiled/dark,
 /area/shuttle/escape_shuttle)
 "hMN" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -2252,7 +2252,7 @@
 /turf/floor/tiled/monotile,
 /area/shuttle/escape_shuttle)
 "jlk" = (
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 8
 	},
 /turf/floor/tiled/dark/monotile,
@@ -2289,7 +2289,7 @@
 /turf/unsimulated/floor/lino,
 /area/tdome/tdomeadmin)
 "jSH" = (
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue{
@@ -2302,7 +2302,7 @@
 /turf/unsimulated/floor/white,
 /area/tdome)
 "kfk" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/abstract/landmark{
 	name = "tdomeobserve"
 	},
@@ -2314,7 +2314,7 @@
 /turf/unsimulated/floor/lino,
 /area/tdome/tdomeobserve)
 "kjk" = (
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue/diagonal{
@@ -2403,7 +2403,7 @@
 /turf/unsimulated/floor/lino,
 /area/tdome/tdomeadmin)
 "lQy" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/structure/disposalpipe/segment,
 /obj/abstract/landmark{
 	name = "tdomeobserve"
@@ -2505,7 +2505,7 @@
 /turf/unsimulated/floor/vault,
 /area/tdome/tdome2)
 "nPB" = (
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 4
 	},
 /turf/floor/tiled/monotile,

--- a/maps/ministation/ministation-0.dmm
+++ b/maps/ministation/ministation-0.dmm
@@ -436,7 +436,7 @@
 /turf/floor/tiled,
 /area/ministation/cargo)
 "cg" = (
-/obj/structure/bed/chair/comfy,
+/obj/structure/chair/comfy,
 /turf/floor/carpet/blue2,
 /area/ministation/hall/s1)
 "cj" = (
@@ -1655,7 +1655,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 6
 	},
-/obj/structure/bed/chair/office,
+/obj/structure/chair/office,
 /turf/floor/tiled,
 /area/ministation/cargo)
 "gt" = (
@@ -2599,7 +2599,7 @@
 	dir = 1;
 	pixel_y = -23
 	},
-/obj/structure/bed/chair/janicart{
+/obj/structure/janicart{
 	dir = 4
 	},
 /turf/floor/tiled,
@@ -2811,7 +2811,7 @@
 /turf/floor/plating,
 /area/ministation/smcontrol)
 "lA" = (
-/obj/structure/bed/chair/comfy/black{
+/obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /turf/floor/laminate/walnut,
@@ -3386,7 +3386,7 @@
 /turf/floor/pool,
 /area/ministation/dorms)
 "od" = (
-/obj/structure/bed/chair/comfy/black{
+/obj/structure/chair/comfy/black{
 	dir = 1
 	},
 /turf/floor/laminate/walnut,
@@ -4579,7 +4579,7 @@
 /turf/floor/tiled,
 /area/ministation/hall/s1)
 "uj" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/beige{
@@ -4678,7 +4678,7 @@
 /area/ministation/smcontrol)
 "uH" = (
 /obj/machinery/light,
-/obj/structure/bed/chair/comfy/black{
+/obj/structure/chair/comfy/black{
 	dir = 1
 	},
 /turf/floor/laminate/walnut,
@@ -4927,7 +4927,7 @@
 "vK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt/visible,
-/obj/structure/bed/chair/wood{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -4964,7 +4964,7 @@
 /area/ministation/hall/s1)
 "vY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/tiled/steel_grid,
@@ -5021,7 +5021,7 @@
 /turf/floor/tiled/monotile,
 /area/ministation/atmospherics)
 "wk" = (
-/obj/structure/bed/chair/comfy/black{
+/obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /obj/machinery/alarm{
@@ -6115,7 +6115,7 @@
 /area/ministation/mining)
 "Bq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/bed/chair/wood{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/floor/tiled,
@@ -10572,7 +10572,7 @@
 /obj/abstract/landmark/start{
 	name = "Head Engineer"
 	},
-/obj/structure/bed/chair/office{
+/obj/structure/chair/office{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -12176,7 +12176,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/bed/chair/office,
+/obj/structure/chair/office,
 /turf/floor/tiled,
 /area/ministation/smcontrol)
 "SO" = (

--- a/maps/ministation/ministation-1.dmm
+++ b/maps/ministation/ministation-1.dmm
@@ -167,7 +167,7 @@
 /turf/floor/plating,
 /area/ministation/maint/l2centraln)
 "aH" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/tiled,
 /area/ministation/hall/w2)
 "aL" = (
@@ -540,7 +540,7 @@
 /turf/floor/tiled/white,
 /area/ministation/medical)
 "cR" = (
-/obj/structure/bed/chair/office/comfy/brown,
+/obj/structure/chair/office/comfy/brown,
 /obj/abstract/landmark/start{
 	name = "Detective"
 	},
@@ -1268,7 +1268,7 @@
 /area/ministation/detective)
 "gL" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/bed/chair/armchair/black{
+/obj/structure/chair/armchair/black{
 	dir = 4
 	},
 /turf/floor/tiled/dark,
@@ -1359,7 +1359,7 @@
 /turf/floor/tiled,
 /area/ministation/security)
 "hh" = (
-/obj/structure/bed/chair/office/light,
+/obj/structure/chair/office/light,
 /obj/abstract/landmark/start{
 	name = "Medical Doctor"
 	},
@@ -1384,7 +1384,7 @@
 /turf/floor/tiled,
 /area/ministation/hall/w2)
 "hm" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
@@ -1488,7 +1488,7 @@
 /obj/abstract/landmark/start{
 	name = "Medical Doctor"
 	},
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue{
@@ -1817,7 +1817,7 @@
 /turf/floor/tiled/white,
 /area/ministation/medical)
 "iG" = (
-/obj/structure/bed/chair/office/comfy/brown{
+/obj/structure/chair/office/comfy/brown{
 	dir = 1
 	},
 /turf/floor/carpet/red,
@@ -2423,7 +2423,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/machinery/status_display{
 	pixel_x = -32;
 	dir = 8
@@ -2496,7 +2496,7 @@
 /turf/floor/tiled,
 /area/ministation/hydro)
 "lR" = (
-/obj/structure/bed/chair/comfy/beige{
+/obj/structure/chair/comfy/beige{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3218,7 +3218,7 @@
 /turf/floor/tiled/white,
 /area/ministation/medical)
 "pQ" = (
-/obj/structure/bed/chair/armchair/black{
+/obj/structure/chair/armchair/black{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue{
@@ -3382,10 +3382,10 @@
 /turf/floor/tiled/white,
 /area/ministation/medical)
 "qz" = (
-/obj/structure/bed/chair/armchair/black{
+/obj/structure/chair/armchair/black{
 	dir = 4
 	},
-/obj/structure/bed/chair/armchair/black{
+/obj/structure/chair/armchair/black{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue{
@@ -3408,7 +3408,7 @@
 /turf/floor/tiled/dark,
 /area/ministation/cafe)
 "qF" = (
-/obj/structure/bed/chair/comfy/beige{
+/obj/structure/chair/comfy/beige{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -4426,7 +4426,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/bed/chair/armchair/red{
+/obj/structure/chair/armchair/red{
 	dir = 1
 	},
 /turf/floor/tiled,
@@ -4636,7 +4636,7 @@
 /turf/floor/tiled,
 /area/ministation/hall/w2)
 "uG" = (
-/obj/structure/bed/chair/office/comfy/brown{
+/obj/structure/chair/office/comfy/brown{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -5384,7 +5384,7 @@
 /turf/floor/tiled/white,
 /area/ministation/medical)
 "xd" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
 /obj/machinery/alarm{
@@ -6034,7 +6034,7 @@
 /turf/floor/tiled/dark,
 /area/ministation/cafe)
 "zi" = (
-/obj/structure/bed/chair/office/light,
+/obj/structure/chair/office/light,
 /turf/floor/carpet/red,
 /area/ministation/security)
 "zj" = (
@@ -6051,7 +6051,7 @@
 /area/ministation/maint/l2centrals)
 "zn" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/bed/chair/armchair/black{
+/obj/structure/chair/armchair/black{
 	dir = 1
 	},
 /turf/floor/tiled/dark,
@@ -6244,7 +6244,7 @@
 /turf/floor/laminate,
 /area/ministation/detective)
 "zZ" = (
-/obj/structure/bed/chair/comfy/beige{
+/obj/structure/chair/comfy/beige{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6546,7 +6546,7 @@
 /turf/floor/lino,
 /area/ministation/cafe)
 "Bs" = (
-/obj/structure/bed/chair/office/light,
+/obj/structure/chair/office/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -7080,7 +7080,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/structure/bed/chair/comfy/beige,
+/obj/structure/chair/comfy/beige,
 /turf/floor/carpet,
 /area/ministation/hall/w2)
 "Es" = (
@@ -7315,7 +7315,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 32
 	},
-/obj/structure/bed/chair/comfy/beige,
+/obj/structure/chair/comfy/beige,
 /turf/floor/carpet,
 /area/ministation/hall/w2)
 "Ga" = (
@@ -8169,7 +8169,7 @@
 /turf/floor/tiled,
 /area/ministation/security)
 "KW" = (
-/obj/structure/bed/chair/office/comfy/brown{
+/obj/structure/chair/office/comfy/brown{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -8266,7 +8266,7 @@
 /turf/floor/tiled,
 /area/ministation/hall/w2)
 "LK" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 4
 	},
 /obj/structure/railing/mapped{
@@ -9148,7 +9148,7 @@
 /turf/floor/tiled/white,
 /area/ministation/medical)
 "Qj" = (
-/obj/structure/bed/chair/comfy/beige{
+/obj/structure/chair/comfy/beige{
 	dir = 1
 	},
 /turf/floor/tiled,
@@ -9284,7 +9284,7 @@
 /turf/floor/tiled,
 /area/ministation/security)
 "Rd" = (
-/obj/structure/bed/chair/armchair/black{
+/obj/structure/chair/armchair/black{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -9596,7 +9596,7 @@
 /turf/floor/plating,
 /area/ministation/maint/l2centraln)
 "Te" = (
-/obj/structure/bed/chair/office/light,
+/obj/structure/chair/office/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -9775,7 +9775,7 @@
 /area/ministation/cafe)
 "Ue" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/bed/chair/armchair/black{
+/obj/structure/chair/armchair/black{
 	dir = 8
 	},
 /turf/floor/tiled/dark,
@@ -9895,7 +9895,7 @@
 /turf/floor/plating,
 /area/ministation/maint/l2centraln)
 "UN" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/plating,
@@ -9907,7 +9907,7 @@
 /turf/space,
 /area/space)
 "UW" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/tiled,
 /area/ministation/hall/e2)
 "UY" = (
@@ -9930,7 +9930,7 @@
 /turf/wall/r_wall/hull,
 /area/ministation/arrival)
 "Va" = (
-/obj/structure/bed/chair/wheelchair,
+/obj/structure/chair/wheelchair,
 /obj/machinery/camera/network/medbay{
 	req_access = list("ACCESS_CAMERAS")
 	},
@@ -10478,7 +10478,7 @@
 /turf/floor/plating,
 /area/ministation/security)
 "Yj" = (
-/obj/structure/bed/chair/office/light,
+/obj/structure/chair/office/light,
 /obj/abstract/landmark/start{
 	name = "Security Officer"
 	},

--- a/maps/ministation/ministation-2.dmm
+++ b/maps/ministation/ministation-2.dmm
@@ -421,7 +421,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/bed/chair/comfy/captain,
+/obj/structure/chair/comfy/captain,
 /turf/floor/tiled,
 /area/ministation/bridge)
 "bA" = (
@@ -486,7 +486,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/bed/chair/comfy/captain{
+/obj/structure/chair/comfy/captain{
 	dir = 4
 	},
 /obj/machinery/camera/network/command{
@@ -1594,7 +1594,7 @@
 /turf/floor/tiled/white,
 /area/ministation/science)
 "gN" = (
-/obj/structure/bed/chair/shuttle/blue{
+/obj/structure/chair/shuttle/blue{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -2053,7 +2053,7 @@
 /obj/abstract/landmark/start{
 	name = "Scientist"
 	},
-/obj/structure/bed/chair/office/light,
+/obj/structure/chair/office/light,
 /obj/item/radio/intercom{
 	dir = 8;
 	pixel_x = 22
@@ -2752,7 +2752,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
-/obj/structure/bed/chair/padded/blue{
+/obj/structure/chair/padded/blue{
 	dir = 1
 	},
 /turf/floor/tiled,
@@ -2771,7 +2771,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/bed/chair/shuttle/blue{
+/obj/structure/chair/shuttle/blue{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -2927,7 +2927,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/bed/chair/shuttle/blue{
+/obj/structure/chair/shuttle/blue{
 	dir = 1
 	},
 /turf/floor/tiled,
@@ -3322,7 +3322,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
-/obj/structure/bed/chair/padded/blue{
+/obj/structure/chair/padded/blue{
 	dir = 1
 	},
 /turf/floor/tiled,
@@ -4619,7 +4619,7 @@
 /turf/floor/tiled/white,
 /area/ministation/science)
 "Bb" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -4756,7 +4756,7 @@
 /turf/floor/lino,
 /area/ministation/telecomms)
 "BE" = (
-/obj/structure/bed/chair/padded/blue{
+/obj/structure/chair/padded/blue{
 	dir = 1
 	},
 /turf/floor/lino,
@@ -5304,7 +5304,7 @@
 /turf/floor/carpet/green,
 /area/ministation/library)
 "DS" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -5370,7 +5370,7 @@
 /turf/floor/carpet/magenta,
 /area/ministation/science)
 "Ex" = (
-/obj/structure/bed/chair/armchair/black{
+/obj/structure/chair/armchair/black{
 	dir = 4
 	},
 /turf/floor/carpet/green,
@@ -5795,7 +5795,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/bed/chair/wood/maple{
+/obj/structure/chair/wood/maple{
 	dir = 8
 	},
 /obj/abstract/landmark/start{
@@ -6180,7 +6180,7 @@
 /turf/floor/plating,
 /area/ministation/maint/l3central)
 "LT" = (
-/obj/structure/bed/chair/armchair/black{
+/obj/structure/chair/armchair/black{
 	dir = 4
 	},
 /turf/floor/laminate/mahogany,
@@ -6319,7 +6319,7 @@
 /turf/floor/tiled/white,
 /area/ministation/science)
 "MJ" = (
-/obj/structure/bed/chair/armchair/black,
+/obj/structure/chair/armchair/black,
 /turf/floor/carpet/green,
 /area/ministation/library)
 "MP" = (
@@ -6560,7 +6560,7 @@
 /turf/floor/tiled,
 /area/ministation/bridge)
 "Od" = (
-/obj/structure/bed/chair/wood/walnut{
+/obj/structure/chair/wood/walnut{
 	dir = 4
 	},
 /turf/floor/laminate/yew,
@@ -6573,7 +6573,7 @@
 /turf/wall/titanium,
 /area/ministation/shuttle/outgoing)
 "Om" = (
-/obj/structure/bed/chair/armchair/black{
+/obj/structure/chair/armchair/black{
 	dir = 8
 	},
 /turf/floor/carpet/green,
@@ -6630,7 +6630,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
 /turf/floor/tiled/white,
@@ -6810,7 +6810,7 @@
 /turf/floor/laminate/mahogany,
 /area/ministation/library)
 "PE" = (
-/obj/structure/bed/chair/armchair/black{
+/obj/structure/chair/armchair/black{
 	dir = 8
 	},
 /turf/floor/laminate/mahogany,
@@ -6883,7 +6883,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6904,7 +6904,7 @@
 /turf/floor/tiled/white,
 /area/ministation/science)
 "Qh" = (
-/obj/structure/bed/chair/wood/walnut{
+/obj/structure/chair/wood/walnut{
 	dir = 4
 	},
 /obj/machinery/light{
@@ -7480,7 +7480,7 @@
 	dir = 5
 	},
 /obj/effect/overmap/visitable/ship/ministation,
-/obj/structure/bed/chair/padded/blue,
+/obj/structure/chair/padded/blue,
 /turf/floor/tiled,
 /area/ministation/bridge)
 "TF" = (
@@ -7783,7 +7783,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/bed/chair/comfy/captain{
+/obj/structure/chair/comfy/captain{
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -8077,7 +8077,7 @@
 /turf/floor/tiled,
 /area/ministation/hall/n3)
 "Xe" = (
-/obj/structure/bed/chair/wood/walnut{
+/obj/structure/chair/wood/walnut{
 	dir = 4
 	},
 /obj/machinery/light,
@@ -8483,7 +8483,7 @@
 /turf/floor/plating,
 /area/ministation/maint/l3ne)
 "Zt" = (
-/obj/structure/bed/chair/wood/walnut{
+/obj/structure/chair/wood/walnut{
 	dir = 4
 	},
 /obj/machinery/firealarm{
@@ -8550,7 +8550,7 @@
 /turf/floor/tiled,
 /area/ministation/hall/s3)
 "ZS" = (
-/obj/structure/bed/chair/shuttle/blue{
+/obj/structure/chair/shuttle/blue{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{

--- a/maps/ministation/space.dmm
+++ b/maps/ministation/space.dmm
@@ -56,7 +56,7 @@
 /turf/floor/shuttle/blue,
 /area/shuttle/escape_shuttle)
 "ao" = (
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	icon_state = "shuttle_chair";
 	dir = 1
 	},
@@ -67,7 +67,7 @@
 /turf/floor/shuttle/blue,
 /area/shuttle/escape_shuttle)
 "aq" = (
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	icon_state = "shuttle_chair";
 	dir = 1
 	},
@@ -120,7 +120,7 @@
 	icon_state = "stripe";
 	dir = 1
 	},
-/obj/structure/bed/chair/shuttle{
+/obj/structure/chair/shuttle{
 	icon_state = "shuttle_chair";
 	dir = 1
 	},
@@ -135,7 +135,7 @@
 	icon_state = "stripe";
 	dir = 1
 	},
-/obj/structure/bed/chair/shuttle{
+/obj/structure/chair/shuttle{
 	icon_state = "shuttle_chair";
 	dir = 1
 	},
@@ -146,7 +146,7 @@
 	icon_state = "stripe";
 	dir = 5
 	},
-/obj/structure/bed/chair/shuttle{
+/obj/structure/chair/shuttle{
 	icon_state = "shuttle_chair";
 	dir = 1
 	},
@@ -176,7 +176,7 @@
 /turf/floor/shuttle/blue,
 /area/shuttle/escape_shuttle)
 "aC" = (
-/obj/structure/bed/chair/shuttle{
+/obj/structure/chair/shuttle{
 	icon_state = "shuttle_chair";
 	dir = 1
 	},
@@ -187,7 +187,7 @@
 	icon_state = "stripe";
 	dir = 4
 	},
-/obj/structure/bed/chair/shuttle{
+/obj/structure/chair/shuttle{
 	icon_state = "shuttle_chair";
 	dir = 1
 	},
@@ -207,7 +207,7 @@
 /area/shuttle/escape_shuttle)
 "aG" = (
 /obj/effect/floor_decal/industrial/traffic,
-/obj/structure/bed/chair/shuttle{
+/obj/structure/chair/shuttle{
 	icon_state = "shuttle_chair";
 	dir = 1
 	},
@@ -219,7 +219,7 @@
 /area/shuttle/escape_shuttle)
 "aH" = (
 /obj/effect/floor_decal/industrial/traffic,
-/obj/structure/bed/chair/shuttle{
+/obj/structure/chair/shuttle{
 	icon_state = "shuttle_chair";
 	dir = 1
 	},
@@ -230,7 +230,7 @@
 	icon_state = "stripe";
 	dir = 6
 	},
-/obj/structure/bed/chair/shuttle{
+/obj/structure/chair/shuttle{
 	icon_state = "shuttle_chair";
 	dir = 1
 	},

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -688,7 +688,7 @@
 	pixel_x = -24;
 	locked = 0
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/visible,
@@ -955,7 +955,7 @@
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "bC" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/visible,
@@ -992,13 +992,13 @@
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "bH" = (
-/obj/structure/bed/chair/shuttle/black,
+/obj/structure/chair/shuttle/black,
 /obj/abstract/submap_landmark/spawnpoint/crashed_pod_survivor,
 /obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "bI" = (
-/obj/structure/bed/chair/shuttle/black,
+/obj/structure/chair/shuttle/black,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -1143,7 +1143,7 @@
 /turf/floor/tiled/white,
 /area/map_template/crashed_pod)
 "bW" = (
-/obj/structure/bed/chair/shuttle/black,
+/obj/structure/chair/shuttle/black,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -1200,7 +1200,7 @@
 /turf/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "ca" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
 /area/map_template/crashed_pod)

--- a/maps/random_ruins/exoplanet_ruins/deserted_lab/deserted_lab.dmm
+++ b/maps/random_ruins/exoplanet_ruins/deserted_lab/deserted_lab.dmm
@@ -109,7 +109,7 @@
 /turf/floor/tiled/steel_ridged,
 /area/template_noop)
 "ax" = (
-/obj/structure/bed/chair/office/light,
+/obj/structure/chair/office/light,
 /obj/structure/emergency_dispenser/east,
 /turf/floor/tiled/white,
 /area/template_noop)
@@ -231,7 +231,7 @@
 /area/template_noop)
 "aU" = (
 /obj/random/junk,
-/obj/structure/bed/chair/office/light,
+/obj/structure/chair/office/light,
 /turf/floor/carpet/blue2,
 /area/template_noop)
 "aV" = (

--- a/maps/random_ruins/exoplanet_ruins/hut/hut.dmm
+++ b/maps/random_ruins/exoplanet_ruins/hut/hut.dmm
@@ -36,7 +36,7 @@
 /turf/floor/tiled/dark,
 /area/template_noop)
 "k" = (
-/obj/structure/bed/chair/wheelchair,
+/obj/structure/chair/wheelchair,
 /turf/floor/tiled/dark,
 /area/template_noop)
 "l" = (

--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
@@ -1389,7 +1389,7 @@
 /obj/structure/sign/warning/smoking{
 	pixel_y = 32
 	},
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 4
 	},
 /turf/floor/tiled,
@@ -1524,7 +1524,7 @@
 /turf/floor/fixed/alium,
 /area/map_template/hydrobase/station/processing)
 "ei" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 1
 	},
 /turf/floor/tiled,

--- a/maps/random_ruins/exoplanet_ruins/lodge/lodge.dmm
+++ b/maps/random_ruins/exoplanet_ruins/lodge/lodge.dmm
@@ -86,7 +86,7 @@
 /turf/floor/wood,
 /area/template_noop)
 "p" = (
-/obj/structure/bed/chair/wood{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /obj/effect/floor_decal/spline/fancy/wood/corner,
@@ -162,7 +162,7 @@
 /turf/floor/tiled/monotile,
 /area/template_noop)
 "D" = (
-/obj/structure/bed/chair/wood{
+/obj/structure/chair/wood{
 	dir = 8
 	},
 /obj/effect/floor_decal/spline/fancy/wood{

--- a/maps/random_ruins/exoplanet_ruins/marooned/marooned.dmm
+++ b/maps/random_ruins/exoplanet_ruins/marooned/marooned.dmm
@@ -51,7 +51,7 @@
 /area/map_template/marooned)
 "am" = (
 /obj/abstract/landmark/corpse/marooned_officer,
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood,
@@ -183,7 +183,7 @@
 /obj/structure/handrail{
 	dir = 4
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/item/trash/liquidfood,
@@ -207,7 +207,7 @@
 /obj/structure/handrail{
 	dir = 4
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline,

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -317,7 +317,7 @@
 /turf/floor/tiled/techfloor,
 /area/map_template/colony/command)
 "aW" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor{
@@ -849,7 +849,7 @@
 /turf/floor/reinforced/oxygen,
 /area/map_template/colony/atmospherics)
 "bX" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red{
@@ -2468,7 +2468,7 @@
 /turf/floor/tiled/techfloor,
 /area/map_template/colony/atmospherics)
 "fn" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -2477,7 +2477,7 @@
 /turf/floor/laminate/walnut,
 /area/map_template/colony/messhall)
 "fo" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /obj/structure/sign/double/maltesefalcon/right{
@@ -2548,7 +2548,7 @@
 /turf/floor/tiled/techfloor,
 /area/map_template/colony/atmospherics)
 "fu" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /obj/structure/sign/double/maltesefalcon/left{
@@ -2725,7 +2725,7 @@
 /area/map_template/colony/messhall)
 "fK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -3790,7 +3790,7 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/red,
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/tiled/techfloor,
@@ -4158,7 +4158,7 @@
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 36
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/tiled/techfloor,
@@ -4865,7 +4865,7 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 6
 	},
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red{
@@ -5636,7 +5636,7 @@
 /turf/floor/lino,
 /area/map_template/colony)
 "kQ" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /turf/floor/lino,
@@ -6338,7 +6338,7 @@
 /turf/floor/tiled/techfloor,
 /area/map_template/colony/airlock)
 "mi" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /turf/floor/tiled/techfloor/grid,
@@ -6709,7 +6709,7 @@
 /turf/floor/concrete,
 /area/map_template/colony/mineralprocessing)
 "mR" = (
-/obj/structure/bed/chair/comfy/beige{
+/obj/structure/chair/comfy/beige{
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor,
@@ -6950,7 +6950,7 @@
 /turf/floor/tiled/dark/monotile,
 /area/map_template/colony/jail)
 "np" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
@@ -7075,7 +7075,7 @@
 /turf/floor/tiled/dark/monotile,
 /area/map_template/colony/jail)
 "nD" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red{

--- a/maps/random_ruins/exoplanet_ruins/radshrine/radshrine.dmm
+++ b/maps/random_ruins/exoplanet_ruins/radshrine/radshrine.dmm
@@ -10,7 +10,7 @@
 /turf/wall/uranium,
 /area/template_noop)
 "e" = (
-/obj/structure/bed/chair/wood,
+/obj/structure/chair/wood,
 /obj/effect/decal/cleanable/cobweb,
 /turf/floor/carpet/red,
 /area/template_noop)
@@ -30,7 +30,7 @@
 /turf/floor/reinforced,
 /area/template_noop)
 "I" = (
-/obj/structure/bed/chair/wood,
+/obj/structure/chair/wood,
 /turf/floor/carpet/red,
 /area/template_noop)
 

--- a/maps/random_ruins/exoplanet_ruins/spider_nest/spider_nest.dmm
+++ b/maps/random_ruins/exoplanet_ruins/spider_nest/spider_nest.dmm
@@ -53,7 +53,7 @@
 /turf/floor/lino,
 /area/template_noop)
 "l" = (
-/obj/structure/bed/chair/office/comfy/blue,
+/obj/structure/chair/office/comfy/blue,
 /obj/item/pen,
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/blood/drip,
@@ -174,7 +174,7 @@
 /turf/floor/reinforced,
 /area/template_noop)
 "F" = (
-/obj/structure/bed/chair/office/comfy/purple,
+/obj/structure/chair/office/comfy/purple,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/filth,
 /turf/floor/lino,

--- a/maps/shaded_hills/shaded_hills-dungeon.dmm
+++ b/maps/shaded_hills/shaded_hills-dungeon.dmm
@@ -34,7 +34,7 @@
 /turf/floor/path/running_bond/basalt,
 /area/shaded_hills/caves/dungeon/poi)
 "dA" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 4
 	},
 /obj/item/remains/human,
@@ -66,7 +66,7 @@
 /turf/floor/rock/basalt,
 /area/shaded_hills/caves/dungeon/poi)
 "fW" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 8
 	},
 /obj/item/stack/medical/bandage/crafted/five,
@@ -86,7 +86,7 @@
 /turf/floor/path/running_bond/basalt,
 /area/shaded_hills/caves/dungeon/poi)
 "hz" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 8
 	},
 /turf/floor/path/running_bond/basalt,
@@ -115,7 +115,7 @@
 /turf/floor/mud,
 /area/shaded_hills/caves/dungeon)
 "jU" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 8
 	},
 /obj/item/food/grown/dried_tobacco/bad,
@@ -147,7 +147,7 @@
 /turf/floor/path/running_bond/basalt,
 /area/shaded_hills/caves/dungeon/poi)
 "kN" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 4
 	},
 /obj/item/stack/material/bolt/mapped/cloth/five,
@@ -176,13 +176,13 @@
 /turf/floor/path/running_bond/basalt,
 /area/shaded_hills/caves/dungeon/poi)
 "nD" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 4
 	},
 /turf/floor/path/herringbone/basalt,
 /area/shaded_hills/caves/dungeon/poi)
 "nE" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 8
 	},
 /obj/item/bladed/folding,
@@ -243,7 +243,7 @@
 /turf/floor/path/basalt,
 /area/shaded_hills/caves/dungeon/inn)
 "oW" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 8
 	},
 /turf/floor/path/herringbone/basalt,
@@ -336,13 +336,13 @@
 /turf/floor/path/running_bond/basalt,
 /area/shaded_hills/caves/dungeon/poi)
 "wa" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 4
 	},
 /turf/floor/path/running_bond/basalt,
 /area/shaded_hills/caves/dungeon/poi)
 "wg" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 4
 	},
 /obj/random/hostile/dungeon,
@@ -397,7 +397,7 @@
 /turf/floor/path/basalt,
 /area/shaded_hills/caves/dungeon/poi)
 "Bk" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 4
 	},
 /obj/item/food/grown/dried_tobacco/bad,
@@ -443,7 +443,7 @@
 /turf/floor/path/basalt,
 /area/shaded_hills/caves/dungeon/poi)
 "Eq" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 8
 	},
 /obj/item/stack/material/bolt/mapped/cloth/five,
@@ -554,7 +554,7 @@
 /turf/floor/path/running_bond/basalt,
 /area/shaded_hills/caves/dungeon/poi)
 "ME" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 4
 	},
 /obj/item/stack/medical/bandage/crafted/five,
@@ -609,7 +609,7 @@
 /turf/floor/path/herringbone/basalt,
 /area/shaded_hills/caves/dungeon/poi)
 "Rt" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 8
 	},
 /obj/random/hostile/dungeon,
@@ -624,7 +624,7 @@
 /turf/floor/path/running_bond/basalt,
 /area/shaded_hills/caves/dungeon/poi)
 "SN" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 8
 	},
 /obj/item/remains/human,

--- a/maps/shaded_hills/shaded_hills-grassland.dmm
+++ b/maps/shaded_hills/shaded_hills-grassland.dmm
@@ -8,7 +8,7 @@
 /turf/floor/grass,
 /area/shaded_hills/outside)
 "cy" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 8
 	},
 /obj/abstract/landmark/start/shaded_hills/miner,
@@ -92,7 +92,7 @@
 /turf/floor/mud,
 /area/shaded_hills/caves)
 "mG" = (
-/obj/structure/bed/chair/bench/ebony,
+/obj/structure/chair/bench/ebony,
 /obj/item/bladed/folding,
 /obj/abstract/landmark/start/shaded_hills/miner,
 /turf/floor/barren,
@@ -364,7 +364,7 @@
 /turf/wall/natural/basalt/shaded_hills,
 /area/shaded_hills/caves/river)
 "YB" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 8
 	},
 /obj/abstract/landmark/start/shaded_hills/miner,

--- a/maps/shaded_hills/shaded_hills-inn.dmm
+++ b/maps/shaded_hills/shaded_hills-inn.dmm
@@ -27,7 +27,7 @@
 /turf/floor/wood/rough/walnut,
 /area/shaded_hills/stable)
 "bv" = (
-/obj/structure/bed/chair/rustic{
+/obj/structure/chair/rustic{
 	dir = 4
 	},
 /turf/floor/wood/walnut,
@@ -249,13 +249,13 @@
 	dir = 4;
 	start_lit = 1
 	},
-/obj/structure/bed/chair/rustic_fancy/ebony{
+/obj/structure/chair/rustic_fancy/ebony{
 	dir = 1
 	},
 /turf/floor/carpet,
 /area/shaded_hills/inn)
 "hc" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 1
 	},
 /turf/floor/wood/rough/walnut,
@@ -305,7 +305,7 @@
 /turf/floor/path/herringbone/basalt,
 /area/shaded_hills/inn)
 "ij" = (
-/obj/structure/bed/chair/rustic{
+/obj/structure/chair/rustic{
 	dir = 4
 	},
 /turf/floor/wood/walnut,
@@ -350,7 +350,7 @@
 /turf/floor/wood/rough/walnut,
 /area/shaded_hills/stable)
 "jk" = (
-/obj/structure/bed/chair/bench/pew/mahogany{
+/obj/structure/chair/bench/pew/mahogany{
 	dir = 1
 	},
 /obj/abstract/landmark/start/shaded_hills/cleric,
@@ -406,7 +406,7 @@
 /turf/floor/wood/rough/walnut,
 /area/shaded_hills/stable)
 "kI" = (
-/obj/structure/bed/chair/bench/pew/ebony{
+/obj/structure/chair/bench/pew/ebony{
 	dir = 4
 	},
 /turf/floor/wood/walnut,
@@ -433,7 +433,7 @@
 /turf/floor/path/herringbone/basalt,
 /area/shaded_hills/inn)
 "lL" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 1
 	},
 /obj/abstract/landmark/start/shaded_hills/farmer,
@@ -459,7 +459,7 @@
 /turf/floor/wood/rough/walnut,
 /area/shaded_hills/farmhouse)
 "mD" = (
-/obj/structure/bed/chair/rustic,
+/obj/structure/chair/rustic,
 /turf/floor/wood/rough/walnut,
 /area/shaded_hills/stable)
 "mG" = (
@@ -488,7 +488,7 @@
 /turf/wall/log/walnut,
 /area/shaded_hills/stable)
 "nx" = (
-/obj/structure/bed/chair/bench/pew/ebony{
+/obj/structure/chair/bench/pew/ebony{
 	dir = 8
 	},
 /obj/structure/railing/mapped/wooden/ebony{
@@ -532,7 +532,7 @@
 /turf/floor/grass,
 /area/shaded_hills/outside/downlands)
 "pd" = (
-/obj/structure/bed/chair/bench/pew/mahogany{
+/obj/structure/chair/bench/pew/mahogany{
 	dir = 1
 	},
 /turf/floor/wood/mahogany,
@@ -705,13 +705,13 @@
 /turf/floor/grass,
 /area/shaded_hills/outside/downlands)
 "tZ" = (
-/obj/structure/bed/chair/rustic{
+/obj/structure/chair/rustic{
 	dir = 4
 	},
 /turf/floor/wood/rough/walnut,
 /area/shaded_hills/inn/porch)
 "uk" = (
-/obj/structure/bed/chair/bench/pew/ebony{
+/obj/structure/chair/bench/pew/ebony{
 	dir = 8
 	},
 /obj/effect/floor_decal/spline/fancy/wood/walnut{
@@ -795,7 +795,7 @@
 /obj/structure/wall_sconce/lantern{
 	dir = 4
 	},
-/obj/structure/bed/chair/rustic{
+/obj/structure/chair/rustic{
 	dir = 1
 	},
 /turf/floor/wood/rough/walnut,
@@ -869,7 +869,7 @@
 /turf/wall/brick/basalt,
 /area/shaded_hills/general_store)
 "yJ" = (
-/obj/structure/bed/chair/rustic{
+/obj/structure/chair/rustic{
 	dir = 1
 	},
 /obj/abstract/landmark/start/shaded_hills/farmer,
@@ -995,7 +995,7 @@
 /turf/floor/grass,
 /area/shaded_hills/outside/shrine)
 "BG" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 1
 	},
 /turf/floor/wood/walnut,
@@ -1065,7 +1065,7 @@
 /turf/floor/wood/walnut,
 /area/shaded_hills/general_store)
 "Er" = (
-/obj/structure/bed/chair/bench/pew/ebony{
+/obj/structure/chair/bench/pew/ebony{
 	dir = 4
 	},
 /obj/structure/railing/mapped/wooden/ebony{
@@ -1311,7 +1311,7 @@
 /turf/floor/wood/rough/walnut,
 /area/shaded_hills/shrine)
 "Jw" = (
-/obj/structure/bed/chair/rustic,
+/obj/structure/chair/rustic,
 /turf/floor/wood/rough/walnut,
 /area/shaded_hills/inn/porch)
 "Jz" = (
@@ -1334,7 +1334,7 @@
 /turf/floor/path/herringbone/basalt,
 /area/shaded_hills/shrine)
 "JS" = (
-/obj/structure/bed/chair/rustic{
+/obj/structure/chair/rustic{
 	dir = 1
 	},
 /turf/floor/wood/rough/walnut,
@@ -1355,7 +1355,7 @@
 /turf/wall/log/walnut/shutter/open,
 /area/shaded_hills/shrine)
 "KD" = (
-/obj/structure/bed/chair/rustic{
+/obj/structure/chair/rustic{
 	dir = 1
 	},
 /turf/floor/wood/walnut,
@@ -1493,7 +1493,7 @@
 /obj/structure/wall_sconce/lantern{
 	dir = 8
 	},
-/obj/structure/bed/chair/bench/pew/ebony{
+/obj/structure/chair/bench/pew/ebony{
 	dir = 4
 	},
 /turf/floor/wood/walnut,
@@ -1540,7 +1540,7 @@
 /turf/wall/log/walnut,
 /area/shaded_hills/shrine)
 "QL" = (
-/obj/structure/bed/chair/rustic{
+/obj/structure/chair/rustic{
 	dir = 1
 	},
 /obj/structure/wall_sconce/lantern{
@@ -1621,7 +1621,7 @@
 /turf/floor/mud,
 /area/shaded_hills/outside/shrine)
 "Sw" = (
-/obj/structure/bed/chair/rustic{
+/obj/structure/chair/rustic{
 	dir = 8
 	},
 /turf/floor/wood/rough/walnut,
@@ -1669,7 +1669,7 @@
 /turf/floor/path/herringbone/basalt,
 /area/shaded_hills/inn/kitchen)
 "Td" = (
-/obj/structure/bed/chair/rustic{
+/obj/structure/chair/rustic{
 	dir = 8
 	},
 /turf/floor/wood/walnut,
@@ -1723,7 +1723,7 @@
 /turf/floor/wood/rough/walnut,
 /area/shaded_hills/shrine)
 "US" = (
-/obj/structure/bed/chair/rustic{
+/obj/structure/chair/rustic{
 	dir = 4
 	},
 /turf/floor/wood/walnut,

--- a/maps/shaded_hills/shaded_hills-swamp.dmm
+++ b/maps/shaded_hills/shaded_hills-swamp.dmm
@@ -9,7 +9,7 @@
 /turf/floor/mud/water,
 /area/shaded_hills/outside/river/swamp)
 "cS" = (
-/obj/structure/bed/chair/wood/ebony{
+/obj/structure/chair/wood/ebony{
 	dir = 8
 	},
 /turf/floor/wood/rough/walnut,

--- a/maps/tradeship/tradeship-0.dmm
+++ b/maps/tradeship/tradeship-0.dmm
@@ -1334,7 +1334,7 @@
 /turf/floor/tiled,
 /area/ship/trade/disused)
 "rt" = (
-/obj/structure/bed/chair/padded/beige,
+/obj/structure/chair/padded/beige,
 /turf/floor/carpet/red,
 /area/ship/trade/disused)
 "rv" = (
@@ -1767,7 +1767,7 @@
 /turf/floor/carpet/green,
 /area/ship/trade/disused)
 "IG" = (
-/obj/structure/bed/chair/comfy/green{
+/obj/structure/chair/comfy/green{
 	dir = 1
 	},
 /obj/machinery/power/apc{
@@ -2107,7 +2107,7 @@
 /turf/floor/tiled/techfloor/grid,
 /area/ship/trade/livestock)
 "Ua" = (
-/obj/structure/bed/chair/wood/walnut,
+/obj/structure/chair/wood/walnut,
 /turf/floor/carpet/red,
 /area/ship/trade/disused)
 "Ug" = (

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -3,7 +3,7 @@
 /turf/space,
 /area/space)
 "ab" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/beige{
@@ -467,7 +467,7 @@
 /turf/floor/carpet/blue,
 /area/ship/trade/command/captain)
 "aW" = (
-/obj/structure/bed/chair/comfy/brown,
+/obj/structure/chair/comfy/brown,
 /turf/floor/carpet/blue,
 /area/ship/trade/command/captain)
 "aX" = (
@@ -575,7 +575,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 6
 	},
-/obj/structure/bed/chair/shuttle/black{
+/obj/structure/chair/shuttle/black{
 	dir = 8
 	},
 /obj/machinery/firealarm{
@@ -593,7 +593,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 6
 	},
-/obj/structure/bed/chair/shuttle/blue{
+/obj/structure/chair/shuttle/blue{
 	dir = 8
 	},
 /turf/floor/tiled/steel_ridged,
@@ -1121,7 +1121,7 @@
 /turf/floor/tiled/steel_ridged,
 /area/ship/trade/dock)
 "cw" = (
-/obj/structure/bed/chair/comfy/teal{
+/obj/structure/chair/comfy/teal{
 	dir = 1
 	},
 /obj/abstract/landmark/start{
@@ -1265,7 +1265,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/bed/chair/wood,
+/obj/structure/chair/wood,
 /turf/floor/tiled,
 /area/ship/trade/crew/saloon)
 "da" = (
@@ -2414,7 +2414,7 @@
 /turf/floor/tiled/freezer,
 /area/ship/trade/crew/wash)
 "fV" = (
-/obj/structure/bed/chair/office/light,
+/obj/structure/chair/office/light,
 /obj/abstract/landmark/start{
 	name = "Head Doctor"
 	},
@@ -3216,7 +3216,7 @@
 /turf/floor/tiled/techfloor,
 /area/ship/trade/maintenance/engineering)
 "hW" = (
-/obj/structure/bed/chair/comfy/brown,
+/obj/structure/chair/comfy/brown,
 /obj/abstract/landmark/start{
 	name = "Head Engineer"
 	},
@@ -3690,7 +3690,7 @@
 /obj/effect/floor_decal/corner/white{
 	dir = 6
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/tiled,
@@ -3779,7 +3779,7 @@
 /turf/floor/reinforced/airmix,
 /area/ship/trade/maintenance/atmos)
 "jb" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /obj/machinery/media/jukebox/old,
@@ -4670,7 +4670,7 @@
 /obj/effect/floor_decal/corner/white{
 	dir = 6
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/tiled,
@@ -5047,7 +5047,7 @@
 /turf/wall/r_wall/hull,
 /area/ship/trade/maintenance/atmos)
 "rH" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/tiled/dark,
@@ -5074,7 +5074,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 9
 	},
-/obj/structure/bed/chair/shuttle/white{
+/obj/structure/chair/shuttle/white{
 	dir = 4
 	},
 /turf/floor/tiled/steel_ridged,
@@ -6641,7 +6641,7 @@
 /turf/floor/tiled/monotile,
 /area/ship/trade/command/hallway)
 "Jk" = (
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /obj/abstract/landmark/start{
 	name = "First Mate"
 	},
@@ -7090,7 +7090,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 9
 	},
-/obj/structure/bed/chair/shuttle/blue{
+/obj/structure/chair/shuttle/blue{
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -7234,7 +7234,7 @@
 	dir = 4;
 	id_tag = "tradeship_rescue_shuttle_pump"
 	},
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/white{
@@ -7995,7 +7995,7 @@
 /obj/effect/floor_decal/corner/white{
 	dir = 6
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/tiled,

--- a/maps/tradeship/tradeship-3.dmm
+++ b/maps/tradeship/tradeship-3.dmm
@@ -47,7 +47,7 @@
 /turf/floor/plating,
 /area/ship/trade/maintenance/solars)
 "ai" = (
-/obj/structure/bed/chair/wood,
+/obj/structure/chair/wood,
 /turf/floor/reinforced/airless,
 /area/space)
 "aj" = (

--- a/mods/content/corporate/away_sites/lar_maria/lar_maria-1.dmm
+++ b/mods/content/corporate/away_sites/lar_maria/lar_maria-1.dmm
@@ -560,7 +560,7 @@
 /turf/floor/tiled/white,
 /area/lar_maria/vir_main)
 "bL" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/floor/tiled/white,
@@ -571,7 +571,7 @@
 /turf/floor/tiled/white,
 /area/lar_maria/vir_main)
 "bN" = (
-/obj/structure/bed/chair/office/dark{
+/obj/structure/chair/office/dark{
 	dir = 1
 	},
 /turf/floor/tiled/white,
@@ -585,7 +585,7 @@
 /turf/floor/tiled,
 /area/lar_maria/cells)
 "bR" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/tiled,
@@ -597,7 +597,7 @@
 /area/lar_maria/cells)
 "bT" = (
 /obj/machinery/light,
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/tiled,
@@ -969,7 +969,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/tiled,
@@ -1527,13 +1527,13 @@
 /turf/floor/tiled,
 /area/lar_maria/sec_wing)
 "ev" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/tiled,
 /area/lar_maria/sec_wing)
 "ew" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/abstract/landmark/corpse/lar_maria/zhp_guard,
@@ -1652,7 +1652,7 @@
 /turf/floor/tiled,
 /area/lar_maria/sec_wing)
 "eK" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/tiled,
@@ -1762,7 +1762,7 @@
 /turf/floor/tiled/white,
 /area/lar_maria/vir_aux)
 "eZ" = (
-/obj/structure/bed/chair/office/dark,
+/obj/structure/chair/office/dark,
 /turf/floor/tiled/white,
 /area/lar_maria/vir_aux)
 "fa" = (
@@ -1782,7 +1782,7 @@
 /area/lar_maria/cells)
 "fd" = (
 /obj/machinery/light,
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /mob/living/simple_animal/hostile/lar_maria/test_subject,
@@ -2376,7 +2376,7 @@
 /turf/floor/plating,
 /area/lar_maria/sec_wing)
 "gj" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/abstract/landmark/corpse/lar_maria/test_subject,
@@ -2680,7 +2680,7 @@
 /turf/floor/plating,
 /area/lar_maria/cells)
 "hb" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/alarm{
@@ -2789,7 +2789,7 @@
 /turf/floor/plating,
 /area/lar_maria/cells)
 "ht" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/tiled,
 /area/lar_maria/vir_access)
 "hu" = (
@@ -2861,7 +2861,7 @@
 /turf/floor/tiled,
 /area/lar_maria/vir_access)
 "hF" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3050,7 +3050,7 @@
 /turf/floor/tiled,
 /area/lar_maria/vir_access)
 "hZ" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3373,7 +3373,7 @@
 /turf/floor/tiled,
 /area/lar_maria/vir_access)
 "iK" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/item/gun/energy/taser,
@@ -3384,7 +3384,7 @@
 /turf/floor/tiled,
 /area/lar_maria/sec_wing)
 "iM" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /mob/living/simple_animal/hostile/lar_maria/guard,

--- a/mods/content/corporate/away_sites/lar_maria/lar_maria-2.dmm
+++ b/mods/content/corporate/away_sites/lar_maria/lar_maria-2.dmm
@@ -899,7 +899,7 @@
 /obj/structure/window/basic{
 	dir = 1
 	},
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
 /turf/floor/tiled,
@@ -920,7 +920,7 @@
 /obj/structure/window/basic{
 	dir = 4
 	},
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
 /turf/floor/tiled,
@@ -1006,7 +1006,7 @@
 /turf/floor/plating,
 /area/lar_maria/atmos)
 "cY" = (
-/obj/structure/bed/chair/comfy/purple{
+/obj/structure/chair/comfy/purple{
 	dir = 1
 	},
 /turf/floor/laminate,
@@ -1021,7 +1021,7 @@
 /turf/floor/laminate,
 /area/lar_maria/dorms)
 "db" = (
-/obj/structure/bed/chair/comfy/black{
+/obj/structure/chair/comfy/black{
 	dir = 1
 	},
 /turf/floor/laminate,
@@ -1031,7 +1031,7 @@
 /turf/floor/laminate,
 /area/lar_maria/dorms)
 "de" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /turf/floor/laminate,
@@ -1062,7 +1062,7 @@
 /turf/floor/tiled,
 /area/lar_maria/library)
 "dj" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 4
 	},
 /turf/floor/tiled,
@@ -1338,7 +1338,7 @@
 /obj/structure/window/basic{
 	dir = 4
 	},
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
 /turf/floor/tiled,
@@ -1358,7 +1358,7 @@
 /obj/structure/window/basic{
 	dir = 4
 	},
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
 /obj/machinery/light,
@@ -1386,7 +1386,7 @@
 /turf/floor/tiled,
 /area/lar_maria/library)
 "ei" = (
-/obj/structure/bed/chair/comfy/beige,
+/obj/structure/chair/comfy/beige,
 /turf/floor/laminate,
 /area/lar_maria/dorms)
 "ej" = (
@@ -1394,7 +1394,7 @@
 /turf/floor/laminate,
 /area/lar_maria/dorms)
 "ek" = (
-/obj/structure/bed/chair/comfy/brown,
+/obj/structure/chair/comfy/brown,
 /turf/floor/laminate,
 /area/lar_maria/dorms)
 "el" = (
@@ -1414,7 +1414,7 @@
 /turf/floor/laminate,
 /area/lar_maria/dorms)
 "eo" = (
-/obj/structure/bed/chair/comfy/green,
+/obj/structure/chair/comfy/green,
 /turf/floor/laminate,
 /area/lar_maria/dorms)
 "ep" = (
@@ -1488,7 +1488,7 @@
 /turf/floor/tiled,
 /area/lar_maria/office)
 "eD" = (
-/obj/structure/bed/chair/office/light,
+/obj/structure/chair/office/light,
 /obj/abstract/landmark/corpse/lar_maria/virologist_female,
 /obj/effect/decal/cleanable/blood,
 /turf/floor/tiled,
@@ -1696,7 +1696,7 @@
 /turf/floor/tiled,
 /area/lar_maria/office)
 "fo" = (
-/obj/structure/bed/chair/office/light,
+/obj/structure/chair/office/light,
 /turf/floor/tiled,
 /area/lar_maria/office)
 "fp" = (
@@ -1783,7 +1783,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/tiled,
@@ -1794,7 +1794,7 @@
 /turf/floor/tiled,
 /area/lar_maria/office)
 "fB" = (
-/obj/structure/bed/chair/office/light,
+/obj/structure/chair/office/light,
 /obj/effect/decal/cleanable/blood,
 /turf/floor/tiled,
 /area/lar_maria/office)
@@ -2001,7 +2001,7 @@
 /turf/floor/tiled,
 /area/lar_maria/office)
 "gl" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 1
 	},
 /turf/floor/tiled,
@@ -2188,7 +2188,7 @@
 /turf/floor/tiled,
 /area/lar_maria/mess_hall)
 "gQ" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/tiled,
@@ -2200,7 +2200,7 @@
 /turf/floor/tiled,
 /area/lar_maria/mess_hall)
 "gS" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/tiled,
@@ -2255,7 +2255,7 @@
 /turf/floor/plating,
 /area/lar_maria/hallway)
 "hd" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/machinery/light/small{
@@ -2303,7 +2303,7 @@
 /turf/floor/tiled,
 /area/lar_maria/mess_hall)
 "hj" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/tiled,
@@ -2765,7 +2765,7 @@
 /turf/floor/tiled,
 /area/lar_maria/mess_hall)
 "iz" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/abstract/landmark/corpse/lar_maria/virologist,
@@ -3052,7 +3052,7 @@
 /turf/floor/plating,
 /area/space)
 "kb" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/light/small{
@@ -3061,7 +3061,7 @@
 /turf/floor/plating,
 /area/lar_maria/solar_control)
 "lb" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/machinery/light/small{

--- a/mods/content/corporate/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
+++ b/mods/content/corporate/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
@@ -87,7 +87,7 @@
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "ao" = (
-/obj/structure/bed/chair/shuttle{
+/obj/structure/chair/shuttle{
 	dir = 8
 	},
 /obj/structure/window/reinforced{
@@ -97,7 +97,7 @@
 /turf/floor/tiled/monotile,
 /area/map_template/oldpod)
 "ap" = (
-/obj/structure/bed/chair/shuttle{
+/obj/structure/chair/shuttle{
 	dir = 4
 	},
 /obj/structure/window/reinforced{

--- a/mods/content/fantasy/submaps/woods/suspicious_cabin/suspicious_cabin.dmm
+++ b/mods/content/fantasy/submaps/woods/suspicious_cabin/suspicious_cabin.dmm
@@ -3,7 +3,7 @@
 /turf/template_noop,
 /area/template_noop)
 "d" = (
-/obj/structure/bed/chair/wood/ebony{
+/obj/structure/chair/wood/ebony{
 	dir = 1
 	},
 /turf/floor/wood/walnut,
@@ -33,7 +33,7 @@
 /turf/floor/wood/walnut,
 /area/template_noop)
 "r" = (
-/obj/structure/bed/chair/bench/ebony{
+/obj/structure/chair/bench/ebony{
 	dir = 4
 	},
 /turf/floor/wood/walnut,
@@ -50,7 +50,7 @@
 /turf/wall/log/walnut/shutter,
 /area/template_noop)
 "w" = (
-/obj/structure/bed/chair/wood/ebony,
+/obj/structure/chair/wood/ebony,
 /turf/floor/wood/walnut,
 /area/template_noop)
 "x" = (
@@ -96,7 +96,7 @@
 /turf/floor/path/basalt,
 /area/template_noop)
 "P" = (
-/obj/structure/bed/chair/bench/ebony,
+/obj/structure/chair/bench/ebony,
 /turf/floor/wood/walnut,
 /area/template_noop)
 "Q" = (

--- a/mods/content/generic_shuttles/tanker/tanker.dmm
+++ b/mods/content/generic_shuttles/tanker/tanker.dmm
@@ -257,7 +257,7 @@
 /turf/floor/tiled/steel_grid,
 /area/tanker)
 "yG" = (
-/obj/structure/bed/chair/office,
+/obj/structure/chair/office,
 /turf/floor/tiled/steel_grid,
 /area/tanker)
 "An" = (
@@ -315,7 +315,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/bed/chair/shuttle{
+/obj/structure/chair/shuttle{
 	dir = 8
 	},
 /turf/floor/tiled/steel_grid,
@@ -475,7 +475,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/bed/chair/shuttle{
+/obj/structure/chair/shuttle{
 	dir = 8
 	},
 /turf/floor/tiled/steel_grid,

--- a/mods/content/government/away_sites/icarus/icarus-1.dmm
+++ b/mods/content/government/away_sites/icarus/icarus-1.dmm
@@ -37,15 +37,15 @@
 /turf/floor/grass/wild,
 /area/icarus/open)
 "am" = (
-/obj/structure/bed/chair/comfy/black,
+/obj/structure/chair/comfy/black,
 /turf/floor/laminate,
 /area/icarus/vessel)
 "an" = (
-/obj/structure/bed/chair/comfy/captain,
+/obj/structure/chair/comfy/captain,
 /turf/floor/laminate,
 /area/icarus/vessel)
 "ao" = (
-/obj/structure/bed/chair/comfy/black,
+/obj/structure/chair/comfy/black,
 /obj/item/secure_storage/briefcase,
 /turf/floor/laminate,
 /area/icarus/vessel)
@@ -99,7 +99,7 @@
 /turf/floor/laminate,
 /area/icarus/vessel)
 "aB" = (
-/obj/structure/bed/chair/comfy/black{
+/obj/structure/chair/comfy/black{
 	dir = 1
 	},
 /turf/floor/laminate,
@@ -467,7 +467,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "bP" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/tiled,
@@ -928,13 +928,13 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "dk" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/tiled,
 /area/icarus/vessel)
 "dl" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/visible,
@@ -980,7 +980,7 @@
 /turf/floor/tiled,
 /area/icarus/open)
 "dt" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/visible,
@@ -1095,7 +1095,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "dN" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/visible,
@@ -1185,7 +1185,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "eb" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1201,7 +1201,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "ed" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/visible,
@@ -1424,7 +1424,7 @@
 "eO" = (
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/unsimulated/floor/sand,

--- a/mods/content/government/away_sites/icarus/icarus-2.dmm
+++ b/mods/content/government/away_sites/icarus/icarus-2.dmm
@@ -38,7 +38,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "al" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/tiled,
@@ -115,7 +115,7 @@
 /turf/floor/tiled,
 /area/icarus/open)
 "aA" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/abstract/landmark/corpse/bridgeofficer,
@@ -127,7 +127,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "aD" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/tiled,
@@ -180,7 +180,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "aO" = (
-/obj/structure/bed/chair/comfy/captain{
+/obj/structure/chair/comfy/captain{
 	dir = 8
 	},
 /turf/floor/tiled,
@@ -199,7 +199,7 @@
 /turf/floor/tiled/dark,
 /area/icarus/vessel)
 "aR" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/tiled,
@@ -478,7 +478,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "bH" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /turf/floor/tiled,
@@ -493,7 +493,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "bK" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /turf/floor/tiled,
@@ -572,7 +572,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "ca" = (
-/obj/structure/bed/chair/comfy/brown,
+/obj/structure/chair/comfy/brown,
 /turf/floor/tiled,
 /area/icarus/vessel)
 "cb" = (
@@ -604,7 +604,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "cf" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/abstract/landmark/corpse/engineer,
@@ -1006,7 +1006,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "dl" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /obj/abstract/landmark/corpse/scientist,
@@ -1101,7 +1101,7 @@
 /turf/floor/tiled,
 /area/icarus/vessel)
 "dz" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/tiled,
 /area/icarus/vessel)
 "dA" = (
@@ -1429,7 +1429,7 @@
 	},
 /area/icarus/vessel)
 "eB" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /turf/floor/shuttle/white,
 /area/icarus/vessel)
 "eC" = (
@@ -1475,7 +1475,7 @@
 /turf/floor/shuttle/white,
 /area/icarus/open)
 "eK" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/shuttle/white,
@@ -1521,7 +1521,7 @@
 /turf/floor/plating,
 /area/icarus/vessel)
 "eS" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/shuttle/white,
@@ -1532,7 +1532,7 @@
 	},
 /area/icarus/vessel)
 "eU" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 1
 	},
 /turf/floor/shuttle/white,

--- a/mods/content/government/ruins/ec_old_crash/ec_old_crash.dmm
+++ b/mods/content/government/ruins/ec_old_crash/ec_old_crash.dmm
@@ -1529,7 +1529,7 @@
 /turf/floor,
 /area/map_template/ecship/engineering)
 "dr" = (
-/obj/structure/bed/chair,
+/obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},

--- a/mods/gamemodes/heist/heist_base.dmm
+++ b/mods/gamemodes/heist/heist_base.dmm
@@ -830,7 +830,7 @@
 /turf/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
 "cL" = (
-/obj/structure/bed/chair/shuttle{
+/obj/structure/chair/shuttle{
 	dir = 8
 	},
 /turf/floor/shuttle/red,
@@ -856,7 +856,7 @@
 /turf/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
 "cN" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/chair/office/light{
 	dir = 4
 	},
 /turf/floor/shuttle/red,
@@ -1229,7 +1229,7 @@
 /turf/floor/plating,
 /area/map_template/skipjack_station/start)
 "dM" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /obj/machinery/light/small{
@@ -1243,7 +1243,7 @@
 /turf/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
 "dO" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/light/small{
@@ -1298,7 +1298,7 @@
 /turf/floor/plating,
 /area/map_template/skipjack_station/start)
 "dX" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/floor/shuttle/red,
@@ -1310,7 +1310,7 @@
 /turf/floor/shuttle/red,
 /area/map_template/skipjack_station/start)
 "dZ" = (
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/floor/shuttle/red,

--- a/mods/gamemodes/ninja/maps/ninja_base.dmm
+++ b/mods/gamemodes/ninja/maps/ninja_base.dmm
@@ -896,7 +896,7 @@
 /area/map_template/ninja_dojo/start)
 "cS" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/bed/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/unsimulated/floor/dark,
@@ -976,7 +976,7 @@
 /turf/unsimulated/floor/dark,
 /area/map_template/ninja_dojo/start)
 "da" = (
-/obj/structure/bed/chair/shuttle,
+/obj/structure/chair/shuttle,
 /turf/unsimulated/floor/dark,
 /area/map_template/ninja_dojo/start)
 "db" = (

--- a/mods/species/ascent/structures/ship_furniture.dm
+++ b/mods/species/ascent/structures/ship_furniture.dm
@@ -1,9 +1,9 @@
-MANTIDIFY(/obj/structure/bed/chair/padded/purple, "mantid nest", "resting place") // sets up name, description and color
+MANTIDIFY(/obj/structure/chair/padded/purple, "mantid nest", "resting place") // sets up name, description and color
 
-/obj/structure/bed/chair/padded/purple/ascent // sets up icon and offsets
+/obj/structure/chair/padded/purple/ascent // sets up icon and offsets
 	icon = 'mods/species/ascent/icons/furniture/chair_nest.dmi'
 
-/obj/structure/bed/chair/padded/purple/ascent/gyne
+/obj/structure/chair/padded/purple/ascent/gyne
 	name = "mantid throne"
 	icon = 'mods/species/ascent/icons/furniture/chair_nest_large.dmi'
 

--- a/tools/map_migrations/4838_chairs.txt
+++ b/tools/map_migrations/4838_chairs.txt
@@ -1,0 +1,2 @@
+/obj/structure/bed/chair/janicart/@SUBTYPES : /obj/structure/janicart/@SUBTYPES{@OLD}
+/obj/structure/bed/chair/@SUBTYPES : /obj/structure/chair/@SUBTYPES{@OLD}


### PR DESCRIPTION
## Description of changes
Depends on #4837 and #4835.

Makes chairs no longer a subtype of bed.
Makes the janicart not a subtype of chair.
Passes New() arguments to extension `post_creation` to make some ordering things less of a huge pain. If I need to revert it I have a hackier workaround but it'd be sort of a pain.

## Why and what will this PR improve
I don't like that chairs are beds. This makes them not beds. It also makes the janicart not a chair, so it's neither a bed nor a chair.
It also will let us potentially repath other things later, like `/obj/structure/bed/roller` to `/obj/structure/rollerbed` (since it circumvents most of the logic unique to `/obj/structure/bed` aside from the surgery stuff).

## Authorship
Me.