### PR TITLE
Optimize flooring and small parts of init/destroy

### DIFF
--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -29,7 +29,7 @@
 	tag = null
 	weakref = null // Clear this reference to ensure it's kept for as brief duration as possible.
 
-	if(istype(SSnano))
+	if(length(open_uis)) // inline the open ui check to avoid unnecessary proc call overhead
 		SSnano.close_uis(src)
 
 	if(active_timers)

--- a/code/datums/extensions/extensions.dm
+++ b/code/datums/extensions/extensions.dm
@@ -104,14 +104,14 @@
 
 //Fast way to check if it has an extension, also doesn't trigger instantiation of lazy loaded extensions
 /proc/has_extension(var/datum/source, var/base_type)
-	return !!(source.extensions && source.extensions[base_type])
+	return !!source.extensions?[base_type]
 
 /proc/construct_extension_instance(var/extension_type, var/datum/source, var/list/arguments)
 	arguments = list(source) + arguments
 	return new extension_type(arglist(arguments))
 
 /proc/remove_extension(var/datum/source, var/base_type)
-	if(!source.extensions || !source.extensions[base_type])
+	if(!source.extensions?[base_type])
 		return
 	if(!islist(source.extensions[base_type]))
 		qdel(source.extensions[base_type])

--- a/code/game/turfs/flooring/_flooring.dm
+++ b/code/game/turfs/flooring/_flooring.dm
@@ -200,40 +200,39 @@ var/global/list/flooring_cache = list()
 		var/decl/material/use_material = target.get_material()
 		target.color = use_material?.color
 
-	var/edge_layer = (icon_edge_layer != FLOOR_EDGE_NONE) ? target.layer + icon_edge_layer : target.layer
-	var/list/edge_overlays = list()
-	var/has_border = 0
-	for(var/step_dir in global.cardinal)
-		var/turf/T = get_step_resolving_mimic(target, step_dir)
-		if(!istype(T) || symmetric_test_link(target, T))
-			continue
-		has_border |= step_dir
-		if(icon_edge_layer != FLOOR_EDGE_NONE)
-			if(has_internal_edges)
-				edge_overlays += get_flooring_overlay("[icon]_[icon_base]-edge-[step_dir]", edge_state, step_dir, edge_layer = edge_layer)
-			if(has_external_edges && target.can_draw_edge_over(T))
-				edge_overlays += get_flooring_overlay("[icon]_[icon_base]-outer-edge-[step_dir]", outer_edge_state, step_dir, TRUE, edge_layer = edge_layer)
+	if (icon_edge_layer != FLOOR_EDGE_NONE && (has_internal_edges || has_external_edges))
+		var/edge_layer = target.layer + icon_edge_layer
+		var/list/edge_overlays = list()
+		var/has_border = 0
+		for(var/step_dir in global.cardinal)
+			var/turf/T = get_step_resolving_mimic(target, step_dir)
+			if(!istype(T) || symmetric_test_link(target, T))
+				continue
+			has_border |= step_dir
+			if(icon_edge_layer != FLOOR_EDGE_NONE)
+				if(has_internal_edges)
+					edge_overlays += get_flooring_overlay("[icon]_[icon_base]-edge-[step_dir]", edge_state, step_dir, edge_layer = edge_layer)
+				if(has_external_edges && target.can_draw_edge_over(T))
+					edge_overlays += get_flooring_overlay("[icon]_[icon_base]-outer-edge-[step_dir]", outer_edge_state, step_dir, TRUE, edge_layer = edge_layer)
 
-	if (has_internal_edges || has_external_edges)
 		var/has_smooth = ~(has_border & (NORTH | SOUTH | EAST | WEST))
 		for(var/step_dir in global.cornerdirs)
 			var/turf/T = get_step_resolving_mimic(target, step_dir)
 			if(!istype(T) || symmetric_test_link(target, T))
 				continue
-			if(icon_edge_layer != FLOOR_EDGE_NONE)
-				if(has_internal_edges)
-					if((has_smooth & step_dir) == step_dir)
-						edge_overlays += get_flooring_overlay("[icon]_[icon_base]-corner-[step_dir]", corner_state, step_dir, edge_layer = edge_layer)
-					else if((has_border & step_dir) == step_dir)
-						edge_overlays += get_flooring_overlay("[icon]_[icon_base]-edge-[step_dir]", edge_state, step_dir, edge_layer = edge_layer)
-				if(has_external_edges && target.can_draw_edge_over(T))
-					if((has_smooth & step_dir) == step_dir)
-						edge_overlays += get_flooring_overlay("[icon]_[icon_base]-outer-corner-[step_dir]", outer_corner_state, step_dir, TRUE, edge_layer = edge_layer)
-					else if((has_border & step_dir) == step_dir)
-						edge_overlays += get_flooring_overlay("[icon]_[icon_base]-outer-edge-[step_dir]", outer_edge_state, step_dir, TRUE, edge_layer = edge_layer)
+			if(has_internal_edges)
+				if((has_smooth & step_dir) == step_dir)
+					edge_overlays += get_flooring_overlay("[icon]_[icon_base]-corner-[step_dir]", corner_state, step_dir, edge_layer = edge_layer)
+				else if((has_border & step_dir) == step_dir)
+					edge_overlays += get_flooring_overlay("[icon]_[icon_base]-edge-[step_dir]", edge_state, step_dir, edge_layer = edge_layer)
+			if(has_external_edges && target.can_draw_edge_over(T))
+				if((has_smooth & step_dir) == step_dir)
+					edge_overlays += get_flooring_overlay("[icon]_[icon_base]-outer-corner-[step_dir]", outer_corner_state, step_dir, TRUE, edge_layer = edge_layer)
+				else if((has_border & step_dir) == step_dir)
+					edge_overlays += get_flooring_overlay("[icon]_[icon_base]-outer-edge-[step_dir]", outer_edge_state, step_dir, TRUE, edge_layer = edge_layer)
 
-	if(length(edge_overlays))
-		target.add_overlay(edge_overlays)
+		if(length(edge_overlays))
+			target.add_overlay(edge_overlays)
 
 	if(target.is_floor_broken())
 		target.add_overlay(get_damage_overlay(target._floor_broken))

--- a/code/game/turfs/floors/floor_icon.dm
+++ b/code/game/turfs/floors/floor_icon.dm
@@ -172,20 +172,17 @@
 	return FALSE
 
 /decl/flooring/proc/test_link(var/turf/origin, var/turf/opponent)
-	if(!istype(origin) || !istype(opponent))
-		return FALSE
-
 	// Just a normal floor
 	if (istype(opponent, /turf/floor))
-		var/turf/floor/floor_opponent = opponent
-		var/decl/flooring/opponent_flooring = floor_opponent.get_topmost_flooring()
 		if (floor_smooth == SMOOTH_ALL)
 			return TRUE
+		var/turf/floor/floor_opponent = opponent
+		var/decl/flooring/opponent_flooring = floor_opponent.get_topmost_flooring()
 		//If the floor is the same as us,then we're linked,
-		else if (istype(opponent_flooring, neighbour_type))
+		if (istype(opponent_flooring, neighbour_type))
 			return TRUE
 		//If we get here it must be using a whitelist or blacklist
-		else if (floor_smooth == SMOOTH_WHITELIST)
+		if (floor_smooth == SMOOTH_WHITELIST)
 			if (flooring_whitelist[opponent_flooring.type])
 				//Found a match on the typecache
 				return TRUE
@@ -194,9 +191,8 @@
 				//No match on the typecache
 				return TRUE
 		//Check for window frames.
-		if (wall_smooth == SMOOTH_ALL)
-			if(locate(/obj/structure/wall_frame) in opponent)
-				return TRUE
+		if (wall_smooth == SMOOTH_ALL && locate(/obj/structure/wall_frame) in opponent)
+			return TRUE
 	// Wall turf
 	else if(opponent.is_wall())
 		if(wall_smooth == SMOOTH_ALL)

--- a/code/game/turfs/floors/floor_layers.dm
+++ b/code/game/turfs/floors/floor_layers.dm
@@ -1,7 +1,7 @@
 /turf/floor
 	VAR_PROTECTED/decl/flooring/_base_flooring = /decl/flooring/plating
 	VAR_PROTECTED/list/decl/flooring/_flooring
-	VAR_PRIVATE/decl/flooring/_topmost_flooring
+	VAR_PRIVATE/tmp/decl/flooring/_topmost_flooring
 
 /turf/floor/proc/get_all_flooring()
 	. = list()
@@ -44,16 +44,15 @@
 
 	if(isnull(_topmost_flooring))
 		var/flooring_length = length(_flooring)
-		if(isnull(_flooring))
-			_topmost_flooring = FALSE
-		else if(islist(_flooring) && flooring_length)
+		if(flooring_length) // no need to check islist, length is only nonzero for lists and strings, and strings are invalid here
 			_topmost_flooring = _flooring[flooring_length]
 		else if(istype(_flooring, /decl/flooring))
 			_topmost_flooring = _flooring
-
-	if(istype(_topmost_flooring))
-		return _topmost_flooring
-	return get_base_flooring()
+		else if(ispath(_flooring, /decl/flooring))
+			_topmost_flooring = GET_DECL(_flooring)
+		else
+			_topmost_flooring = FALSE
+	return _topmost_flooring || get_base_flooring()
 
 /turf/floor/proc/clear_flooring(skip_update = FALSE, place_product)
 	if(isnull(_flooring))

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -141,3 +141,7 @@
 
 /turf/space/black
 	icon_state = "black"
+
+// not how space works
+/turf/space/get_movable_alpha_mask_state(atom/movable/mover)
+	return null

--- a/code/modules/nano/nanoexternal.dm
+++ b/code/modules/nano/nanoexternal.dm
@@ -11,7 +11,7 @@
 	set name = "Reset NanoUI"
 	set category = "OOC"
 
-	var/ui_amt = length(mob.open_uis)
+	var/ui_amt = length(mob.opened_uis)
 	SSnano.close_user_uis(mob)
 	to_chat(src, "[ui_amt] UI windows reset.")
 
@@ -67,5 +67,7 @@
 	return list() // Not implemented.
 
 
-// Used by SSnano (/datum/controller/subsystem/processing/nano) to track UIs opened by this mob
-/mob/var/list/open_uis
+/// Lazy associative list of /nanoui UIs opened on this object, according to ui_key. Not to be confused with opened_uis on mob.
+/datum/var/tmp/list/open_uis
+/// Used by SSnano (/datum/controller/subsystem/processing/nano) to track UIs opened by this mob.
+/mob/var/list/opened_uis


### PR DESCRIPTION
## Description of changes
Moves `open_uis` from `SSnano` and onto `/datum`.
Stubs out `get_movable_alpha_mask_state` for space turfs since they should never have an alpha mask.
Simplifies the logic in `has_extension` and `remove_extension`. Might be an optimization but I'm not sure.
Optimizes floor icons and smoothing.
Optimizes `get_topmost_flooring()`.

## Why and what will this PR improve
Saves ~7 seconds on Exodus and about a second or two on Shaded Hills.

## Authorship
Me