### PR TITLE
Clean up single- and double-letter decl variable names

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -438,14 +438,14 @@ SUBSYSTEM_DEF(jobs)
 	var/list/spawn_in_storage = list()
 	if(H.client.prefs.Gear() && job.loadout_allowed)
 		for(var/thing in H.client.prefs.Gear())
-			var/decl/loadout_option/G = decls_repository.get_decl_by_id_or_var(thing, /decl/loadout_option)
-			if(!istype(G))
+			var/decl/loadout_option/gear = decls_repository.get_decl_by_id_or_var(thing, /decl/loadout_option)
+			if(!istype(gear))
 				continue
-			if(!G.is_permitted(H, job))
+			if(!gear.is_permitted(H, job))
 				to_chat(H, SPAN_WARNING("Your current species, job, branch, skills or whitelist status does not permit you to spawn with [thing]!"))
 				continue
-			if(!G.slot || !G.spawn_on_mob(H, H.client.prefs.Gear()[G.uid]))
-				spawn_in_storage.Add(G)
+			if(!gear.slot || !gear.spawn_on_mob(H, H.client.prefs.Gear()[gear.uid]))
+				spawn_in_storage.Add(gear)
 
 	// do accessories last so they don't attach to a suit that will be replaced
 	if(H.char_rank && H.char_rank.accessory)
@@ -537,8 +537,8 @@ SUBSYSTEM_DEF(jobs)
 		return other_mob
 
 	if(spawn_in_storage)
-		for(var/decl/loadout_option/G in spawn_in_storage)
-			G.spawn_in_storage_or_drop(H, H.client.prefs.Gear()[G.uid])
+		for(var/decl/loadout_option/gear in spawn_in_storage)
+			gear.spawn_in_storage_or_drop(H, H.client.prefs.Gear()[gear.uid])
 
 	var/article = job.total_positions == 1 ? "the" : "a"
 	to_chat(H, "<font size = 3><B>You are [article] [alt_title || job_title].</B></font>")

--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -41,10 +41,9 @@ SUBSYSTEM_DEF(supply)
 
 	//Build master supply list
 	var/decl/hierarchy/supply_pack/root = IMPLIED_DECL
-	for(var/decl/hierarchy/supply_pack/sp in root.get_descendants())
-		if(!sp.is_category())
-			master_supply_list += sp
-			CHECK_TICK
+	for(var/decl/hierarchy/supply_pack/pack in root.get_descendants())
+		if(!pack.is_category())
+			master_supply_list += pack
 
 // Just add points over time.
 /datum/controller/subsystem/supply/fire()

--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -40,13 +40,11 @@ SUBSYSTEM_DEF(supply)
 	ordernum = rand(1,9000)
 
 	//Build master supply list
-	var/decl/hierarchy/supply_pack/root = GET_DECL(/decl/hierarchy/supply_pack)
-	for(var/decl/hierarchy/supply_pack/sp in root.children)
-		if(sp.is_category())
-			for(var/decl/hierarchy/supply_pack/spc in sp.get_descendants())
-				spc.setup()
-				master_supply_list += spc
-				CHECK_TICK
+	var/decl/hierarchy/supply_pack/root = IMPLIED_DECL
+	for(var/decl/hierarchy/supply_pack/sp in root.get_descendants())
+		if(!sp.is_category())
+			master_supply_list += sp
+			CHECK_TICK
 
 // Just add points over time.
 /datum/controller/subsystem/supply/fire()
@@ -62,68 +60,63 @@ SUBSYSTEM_DEF(supply)
 	point_sources[source] += amount
 	point_sources["total"] += amount
 
-	//To stop things being sent to centcomm which should not be sent to centcomm. Recursively checks for these types.
-/datum/controller/subsystem/supply/proc/forbidden_atoms_check(atom/A)
-	if(isliving(A))
-		return 1
-	if(istype(A,/obj/item/disk/nuclear))
-		return 1
-	if(istype(A,/obj/machinery/nuclearbomb))
-		return 1
-	if(istype(A,/obj/item/radio/beacon))
-		return 1
+/// To stop things being sent to centcomm which should not be sent to centcomm. Recursively checks for these types.
+/datum/controller/subsystem/supply/proc/forbidden_atoms_check(atom/checking)
+	if(isliving(checking)) // You can't send a mob to the admin level.
+		return TRUE
+	if(istype(checking, /obj/item/disk/nuclear)) // Keep it somewhere nuclear operatives can reach it.
+		return TRUE
+	if(istype(checking, /obj/machinery/nuclearbomb)) // Don't nuke the admin level.
+		return TRUE
+	if(istype(checking, /obj/item/radio/beacon)) // Because these can be used for teleportation, I guess?
+		return TRUE
 
-	for(var/i=1, i<=A.contents.len, i++)
-		var/atom/B = A.contents[i]
-		if(.(B))
-			return 1
+	for(var/atom/child in checking.contents)
+		if(forbidden_atoms_check(child))
+			return TRUE
+	return FALSE
 
 /datum/controller/subsystem/supply/proc/sell()
-
 	for(var/area/subarea in shuttle.shuttle_area)
-		for(var/atom/movable/AM in subarea)
-			if(AM.anchored)
+		for(var/obj/structure/closet/crate/sold_crate in subarea)
+			if(sold_crate.anchored)
 				continue
-			if(istype(AM, /obj/structure/closet/crate))
-				var/obj/structure/closet/crate/CR = AM
-				RAISE_EVENT(/decl/observ/crate_sold, subarea, CR)
-				add_points_from_source(CR.get_single_monetary_worth() * crate_return_rebate * 0.1, "crate")
-				var/find_slip = 1
+			RAISE_EVENT(/decl/observ/crate_sold, subarea, sold_crate)
+			add_points_from_source(sold_crate.get_single_monetary_worth() * crate_return_rebate * 0.1, "crate")
+			var/find_slip = TRUE
 
-				for(var/atom/atom as anything in CR)
-					// Sell manifests
-					if(find_slip && istype(atom, /obj/item/paper/manifest))
-						var/obj/item/paper/manifest/slip = atom
-						if(!LAZYACCESS(slip.metadata, "is_copy") && LAZYLEN(slip.applied_stamps))
-							add_points_from_source(LAZYACCESS(slip.metadata, "order_total") * slip_return_rebate, "manifest")
-							find_slip = 0
-						continue
+			for(var/atom/movable/subcontent as anything in sold_crate)
+				// Sell manifests
+				if(find_slip && istype(subcontent, /obj/item/paper/manifest))
+					var/obj/item/paper/manifest/slip = subcontent
+					if(!LAZYACCESS(slip.metadata, "is_copy") && LAZYLEN(slip.applied_stamps))
+						add_points_from_source(LAZYACCESS(slip.metadata, "order_total") * slip_return_rebate, "manifest")
+						find_slip = FALSE
+					continue
 
-					// Sell materials
-					if(is_type_in_list(atom, saleable_materials))
-						add_points_from_source(atom.get_combined_monetary_worth() * goods_sale_modifier * 0.1, "goods")
-					// Must sell ore detector disks in crates
-					else if(istype(atom, /obj/item/disk/survey))
-						add_points_from_source(atom.get_combined_monetary_worth() * 0.005, "data")
+				// Sell materials
+				if(is_type_in_list(subcontent, saleable_materials))
+					add_points_from_source(subcontent.get_combined_monetary_worth() * goods_sale_modifier * 0.1, "goods")
+				// Must sell ore detector disks in crates
+				else if(istype(subcontent, /obj/item/disk/survey))
+					add_points_from_source(subcontent.get_combined_monetary_worth() * 0.005, "data")
 
-			qdel(AM)
+			qdel(sold_crate)
 
 /datum/controller/subsystem/supply/proc/get_clear_turfs()
 	var/list/clear_turfs = list()
-
 	for(var/area/subarea in shuttle.shuttle_area)
-		for(var/turf/T in subarea)
-			if(T.density)
+		for(var/turf/candidate_turf in subarea)
+			if(candidate_turf.density)
 				continue
-			var/occupied = 0
-			for(var/atom/A in T.contents)
-				if(!A.simulated || !A.density)
+			var/occupied = FALSE
+			for(var/atom/movable/child as anything in candidate_turf.contents)
+				if(!child.simulated || !child.density)
 					continue
-				occupied = 1
+				occupied = TRUE
 				break
 			if(!occupied)
-				clear_turfs += T
-
+				clear_turfs += candidate_turf
 	return clear_turfs
 
 //Buyin
@@ -133,56 +126,55 @@ SUBSYSTEM_DEF(supply)
 
 	var/list/clear_turfs = get_clear_turfs()
 
-	for(var/S in shoppinglist)
+	for(var/datum/supply_order/order in shoppinglist)
 		if(!clear_turfs.len)
 			break
 		var/turf/pickedloc = pick_n_take(clear_turfs)
-		shoppinglist -= S
-		donelist += S
+		shoppinglist -= order
+		donelist += order
 
-		var/datum/supply_order/SO = S
-		var/decl/hierarchy/supply_pack/SP = SO.object
+		var/decl/hierarchy/supply_pack/supplypack = order.object
 
-		var/obj/A = new SP.containertype(pickedloc)
-		A.SetName("[SP.containername][SO.comment ? " ([SO.comment])":"" ]")
+		var/obj/result = new supplypack.containertype(pickedloc)
+		result.SetName("[supplypack.containername][order.comment ? " ([order.comment])":"" ]")
 		//supply manifest generation begin
 
 		var/obj/item/paper/manifest/slip
-		if(!SP.contraband)
+		if(!supplypack.contraband)
 			var/info = list()
 			info +="<h3>[global.using_map.boss_name] Shipping Manifest</h3><hr><br>"
-			info +="Order #[SO.ordernum]<br>"
+			info +="Order #[order.ordernum]<br>"
 			info +="Destination: [global.using_map.station_name]<br>"
 			info +="[shoppinglist.len] PACKAGES IN THIS SHIPMENT<br>"
 			info +="CONTENTS:<br><ul>"
 
-			slip = new /obj/item/paper/manifest(A, null, JOINTEXT(info))
-			LAZYSET(slip.metadata, "order_total", SP.cost)
+			slip = new /obj/item/paper/manifest(result, null, JOINTEXT(info))
+			LAZYSET(slip.metadata, "order_total", supplypack.cost)
 			LAZYSET(slip.metadata, "is_copy",     FALSE)
 
 		//spawn the stuff, finish generating the manifest while you're at it
-		if(SP.access)
-			if(!islist(SP.access))
-				A.req_access = list(SP.access)
-			else if(islist(SP.access))
-				var/list/L = SP.access // access var is a plain var, we need a list
-				A.req_access = L.Copy()
+		if(supplypack.access)
+			if(!islist(supplypack.access))
+				result.req_access = list(supplypack.access)
+			else if(islist(supplypack.access))
+				var/list/supplypack_access = supplypack.access // access var is a plain var, we need a list
+				result.req_access = supplypack_access.Copy()
 
-		var/list/spawned = SP.spawn_contents(A)
+		var/list/spawned = supplypack.spawn_contents(result)
 		if(slip)
 			for(var/atom/content in spawned)
 				slip.info += "<li>[content.name]</li>" //add the item to the manifest
 			slip.info += "</ul><br>CHECK CONTENTS AND STAMP BELOW THE LINE TO CONFIRM RECEIPT OF GOODS<hr>"
 
 // Adds any given item to the supply shuttle
-/datum/controller/subsystem/supply/proc/addAtom(var/atom/movable/A)
+/datum/controller/subsystem/supply/proc/addAtom(var/atom/movable/added)
 	var/list/clear_turfs = get_clear_turfs()
 	if(!clear_turfs.len)
 		return FALSE
 
 	var/turf/pickedloc = pick(clear_turfs)
 
-	A.forceMove(pickedloc)
+	added.forceMove(pickedloc)
 
 	return TRUE
 

--- a/code/datums/appearances/automatic/cardborg.dm
+++ b/code/datums/appearances/automatic/cardborg.dm
@@ -34,19 +34,19 @@
 	var/obj/item/back = H.get_equipped_item(slot_back_str)
 	if(!istype(back))
 		return
-	var/decl/cardborg_appearance/ca = appearances[back.type]
-	if(!ca) ca = appearances[/obj/item/backpack]
+	var/decl/cardborg_appearance/disguise = appearances[back.type]
+	if(!disguise) disguise = appearances[/obj/item/backpack]
 
-	var/image/I = image(icon = ca.icon, icon_state = ca.icon_state, loc = H)
+	var/image/I = image(icon = disguise.icon, icon_state = disguise.icon_state, loc = H)
 	I.override = 1
-	I.overlays += image(icon = ca.icon, icon_state = "[ca.icon_state]-eyes") //gotta look realistic
+	I.overlays += image(icon = disguise.icon, icon_state = "[disguise.icon_state]-eyes") //gotta look realistic
 	return I
 
 /decl/appearance_handler/cardborg/proc/init_appearances()
 	if(!appearances)
 		appearances = list()
-		for(var/decl/cardborg_appearance/ca in init_subtypes(/decl/cardborg_appearance))
-			appearances[ca.backpack_type] = ca
+		for(var/decl/cardborg_appearance/disguise in init_subtypes(/decl/cardborg_appearance))
+			appearances[disguise.backpack_type] = disguise
 
 /decl/cardborg_appearance
 	var/backpack_type

--- a/code/datums/hierarchy.dm
+++ b/code/datums/hierarchy.dm
@@ -4,6 +4,8 @@
 	var/name = "Hierarchy"
 	var/decl/hierarchy/parent
 	var/list/decl/hierarchy/children
+	/// The cached result of get_descendants(). Should not be mutated.
+	VAR_PRIVATE/list/decl/hierarchy/_descendants
 	var/expected_type
 
 /decl/hierarchy/Initialize()
@@ -22,10 +24,13 @@
 /decl/hierarchy/proc/get_descendants()
 	if(!children)
 		return
-	. = children.Copy()
+	if(_descendants)
+		return _descendants
+	_descendants = children.Copy()
 	for(var/decl/hierarchy/child in children)
 		if(child.children)
-			. |= child.get_descendants()
+			_descendants |= child.get_descendants()
+	return _descendants
 
 /decl/hierarchy/dd_SortValue()
 	return name

--- a/code/datums/mind/memory.dm
+++ b/code/datums/mind/memory.dm
@@ -7,8 +7,8 @@
 	. = mind.StoreMemory(memory, options)
 
 /datum/mind/proc/StoreMemory(var/memory, var/options)
-	var/decl/memory_options/MO = GET_DECL(options || /decl/memory_options/default)
-	return MO.Create(src, memory)
+	var/decl/memory_options/memory_option = GET_DECL(options || /decl/memory_options/default)
+	return memory_option.Create(src, memory)
 
 /datum/mind/proc/RemoveMemory(var/datum/memory/memory, var/mob/remover)
 	if(!memory)
@@ -20,20 +20,18 @@
 	ShowMemory(remover)
 
 /datum/mind/proc/ClearMemories(var/list/tags)
-	for(var/mem in memories)
-		var/datum/memory/M = mem
+	for(var/datum/memory/mem as anything in memories)
 		// If no tags were supplied OR if there is any union between the given tags and memory tags
 		//  then remove the memory
-		if(!length(tags) || length(tags & M.tags))
-			LAZYREMOVE(memories, M)
+		if(!length(tags) || length(tags & mem.tags))
+			LAZYREMOVE(memories, mem)
 
 /datum/mind/proc/CopyMemories(var/datum/mind/target)
 	if(!istype(target))
 		return
 
-	for(var/mem in memories)
-		var/datum/memory/M = mem
-		M.Copy(target)
+	for(var/datum/memory/mem in memories)
+		mem.Copy(target)
 
 /datum/mind/proc/MemoryTags()
 	. = list()
@@ -50,13 +48,12 @@
 	var/list/output = list()
 	var/last_owner_name
 	// We pretend that memories are stored in some semblance of an order
-	for(var/mem in memories)
-		var/datum/memory/M = mem
-		var/owner_name = M.OwnerName()
+	for(var/datum/memory/mem in memories)
+		var/owner_name = mem.OwnerName()
 		if(owner_name != last_owner_name)
 			output += "<B>[current.real_name]'s Memories</B><HR>"
 			last_owner_name = owner_name
-		output += "[M.memory] <a href='byond://?src=\ref[src];remove_memory=\ref[M]'>\[Remove\]</a>"
+		output += "[mem.memory] <a href='byond://?src=\ref[src];remove_memory=\ref[mem]'>\[Remove\]</a>"
 
 	if(objectives.len > 0)
 		output += "<HR><B>Objectives:</B>"
@@ -161,9 +158,8 @@
 		return
 
 	var/relevant_memories = 0
-	for(var/mem in target.memories)
-		var/datum/memory/M = mem
-		if(M.type == memory_type)
+	for(var/datum/memory/mem in target.memories)
+		if(mem.type == memory_type)
 			relevant_memories++
 
 	if(relevant_memories > memory_limit)

--- a/code/datums/outfits/equipment/backpacks.dm
+++ b/code/datums/outfits/equipment/backpacks.dm
@@ -190,9 +190,9 @@
 /proc/get_default_outfit_backpack()
 	var backpacks = global.using_map.get_available_backpacks()
 	for(var/backpack in backpacks)
-		var/decl/backpack_outfit/bo = backpacks[backpack]
-		if(bo.is_default)
-			return bo
+		var/decl/backpack_outfit/backpack_option = backpacks[backpack]
+		if(backpack_option.is_default)
+			return backpack_option
 
 #undef BACKPACK_HAS_TYPE_SELECTION
 #undef BACKPACK_HAS_SUBTYPE_SELECTION

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -205,17 +205,17 @@
 		wearer.put_in_hands(new hand(wearer))
 
 	if((outfit_flags & OUTFIT_HAS_BACKPACK) && !(OUTFIT_ADJUSTMENT_SKIP_BACKPACK & equip_adjustments))
-		var/decl/backpack_outfit/bo
+		var/decl/backpack_outfit/backpack_option
 		var/metadata
 
 		if(wearer.backpack_setup)
-			bo = wearer.backpack_setup.backpack
+			backpack_option = wearer.backpack_setup.backpack
 			metadata = wearer.backpack_setup.metadata
 		else
-			bo = get_default_outfit_backpack()
+			backpack_option = get_default_outfit_backpack()
 
-		var/override_type = backpack_overrides[bo.type]
-		var/backpack = bo.spawn_backpack(wearer, metadata, override_type)
+		var/override_type = backpack_overrides[backpack_option.type]
+		var/backpack = backpack_option.spawn_backpack(wearer, metadata, override_type)
 
 		if(backpack)
 			if(back)

--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -87,7 +87,7 @@
 	containername = "collector crate"
 	access = access_engine_equip
 
-/decl/hierarchy/supply_pack/engineering/PA
+/decl/hierarchy/supply_pack/engineering/particle_accelerator
 	name = "Equipment - Particle accelerator"
 	contains = list(/obj/structure/particle_accelerator/fuel_chamber,
 					/obj/machinery/particle_accelerator/control_box,

--- a/code/datums/supplypacks/supplypack.dm
+++ b/code/datums/supplypacks/supplypack.dm
@@ -14,8 +14,13 @@
 	var/supply_method = /decl/supply_method
 	var/decl/security_level/security_level
 
-//Is run once on init for non-base-category supplypacks.
 var/global/list/cargoprices = list()
+/decl/hierarchy/supply_pack/Initialize()
+	. = ..()
+	if(!is_category())
+		setup()
+
+//Is run once on init for non-category supplypacks.
 /decl/hierarchy/supply_pack/proc/setup()
 	if(!num_contained)
 		for(var/entry in contains)

--- a/code/datums/supplypacks/supplypack.dm
+++ b/code/datums/supplypacks/supplypack.dm
@@ -16,12 +16,9 @@
 
 var/global/list/cargoprices = list()
 /decl/hierarchy/supply_pack/Initialize()
-	. = ..()
-	if(!is_category())
-		setup()
-
-//Is run once on init for non-category supplypacks.
-/decl/hierarchy/supply_pack/proc/setup()
+	. = ..() // make sure children are set up
+	if(is_category())
+		return // don't do any of this for categories
 	if(!num_contained)
 		for(var/entry in contains)
 			num_contained += max(1, contains[entry])
@@ -33,8 +30,8 @@ var/global/list/cargoprices = list()
 		cost = max(1, NONUNIT_CEILING((cost * WORTH_TO_SUPPLY_POINTS_CONSTANT * SSsupply.price_markup), WORTH_TO_SUPPLY_POINTS_ROUND_CONSTANT))
 	global.cargoprices[name] = cost
 
-	var/decl/supply_method/sm = GET_DECL(supply_method)
-	manifest = sm.setup_manifest(src)
+	var/decl/supply_method/method = GET_DECL(supply_method)
+	manifest = method.setup_manifest(src)
 
 /client/proc/print_cargo_prices()
 	set name = "Print Cargo Prices"
@@ -64,8 +61,8 @@ var/global/list/cargoprices = list()
 	return security_state.current_security_level_is_same_or_higher_than(security_level)
 
 /decl/hierarchy/supply_pack/proc/spawn_contents(var/location)
-	var/decl/supply_method/sm = GET_DECL(supply_method)
-	. = sm.spawn_contents(src, location)
+	var/decl/supply_method/method = GET_DECL(supply_method)
+	. = method.spawn_contents(src, location)
 	for(var/obj/O in .)
 		O.anchored = FALSE
 
@@ -78,18 +75,18 @@ var/global/list/cargoprices = list()
 //NEW NOTE: Do NOT set the price of any crates below 7 points. Doing so allows infinite points.
 */
 
-/decl/supply_method/proc/spawn_contents(var/decl/hierarchy/supply_pack/sp, var/location)
-	if(!sp || !location)
+/decl/supply_method/proc/spawn_contents(var/decl/hierarchy/supply_pack/pack, var/location)
+	if(!pack || !location)
 		return
 	. = list()
-	for(var/entry in sp.contains)
-		for(var/i = 1 to max(1, sp.contains[entry]))
+	for(var/entry in pack.contains)
+		for(var/i = 1 to max(1, pack.contains[entry]))
 			dd_insertObjectList(.,new entry(location))
 
-/decl/supply_method/proc/setup_manifest(var/decl/hierarchy/supply_pack/sp)
+/decl/supply_method/proc/setup_manifest(var/decl/hierarchy/supply_pack/pack)
 	. = list()
 	. += "<ul>"
-	for(var/path in sp.contains)
+	for(var/path in pack.contains)
 		var/atom/A = path
 		if(!ispath(A))
 			continue
@@ -97,13 +94,13 @@ var/global/list/cargoprices = list()
 	. += "</ul>"
 	. = jointext(.,null)
 
-/decl/supply_method/randomized/spawn_contents(var/decl/hierarchy/supply_pack/sp, var/location)
-	if(!sp || !location)
+/decl/supply_method/randomized/spawn_contents(var/decl/hierarchy/supply_pack/pack, var/location)
+	if(!pack || !location)
 		return
 	. = list()
-	for(var/j = 1 to sp.num_contained)
-		var/picked = pick(sp.contains)
+	for(var/j = 1 to pack.num_contained)
+		var/picked = pick(pack.contains)
 		. += new picked(location)
 
-/decl/supply_method/randomized/setup_manifest(var/decl/hierarchy/supply_pack/sp)
-	return "Contains any [sp.num_contained] of:" + ..()
+/decl/supply_method/randomized/setup_manifest(var/decl/hierarchy/supply_pack/pack)
+	return "Contains any [pack.num_contained] of:" + ..()

--- a/code/datums/uplink/uplink_sources.dm
+++ b/code/datums/uplink/uplink_sources.dm
@@ -133,8 +133,8 @@ var/global/list/default_uplink_source_priority = list(
 			priority_order |= GET_DECL(entry)
 
 	for(var/entry in priority_order)
-		var/decl/uplink_source/US = entry
-		if(US.setup_uplink_source(M, amount) != SETUP_FAILED)
+		var/decl/uplink_source/uplink = entry
+		if(uplink.setup_uplink_source(M, amount) != SETUP_FAILED)
 			return TRUE
 
 	to_chat(M, "<span class='warning'>Either by choice or circumstance you will be without an uplink.</span>")

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -884,18 +884,18 @@ FIRE ALARM
 			set_light(2, 0.25, COLOR_RED)
 		else if(isContactLevel(z))
 			var/decl/security_state/security_state = GET_DECL(global.using_map.security_state)
-			var/decl/security_level/sl = security_state.current_security_level
+			var/decl/security_level/sec_level = security_state.current_security_level
 
-			set_light(sl.light_power, sl.light_range, sl.light_color_alarm)
+			set_light(sec_level.light_power, sec_level.light_range, sec_level.light_color_alarm)
 
-			if(sl.alarm_appearance.alarm_icon)
-				var/image/alert1 = image(sl.icon, sl.alarm_appearance.alarm_icon)
-				alert1.color = sl.alarm_appearance.alarm_icon_color
+			if(sec_level.alarm_appearance.alarm_icon)
+				var/image/alert1 = image(sec_level.icon, sec_level.alarm_appearance.alarm_icon)
+				alert1.color = sec_level.alarm_appearance.alarm_icon_color
 				add_overlay(alert1)
 
-			if(sl.alarm_appearance.alarm_icon_twotone)
-				var/image/alert2 = image(sl.icon, sl.alarm_appearance.alarm_icon_twotone)
-				alert2.color = sl.alarm_appearance.alarm_icon_twotone_color
+			if(sec_level.alarm_appearance.alarm_icon_twotone)
+				var/image/alert2 = image(sec_level.icon, sec_level.alarm_appearance.alarm_icon_twotone)
+				alert2.color = sec_level.alarm_appearance.alarm_icon_twotone_color
 				add_overlay(alert2)
 		else
 			add_overlay("fire0")

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -168,23 +168,23 @@
 	remove_display()
 
 	var/decl/security_state/security_state = GET_DECL(global.using_map.security_state)
-	var/decl/security_level/sl = security_state.current_security_level
+	var/decl/security_level/sec_level = security_state.current_security_level
 
-	set_light(sl.light_range, sl.light_power, sl.light_color_status_display)
+	set_light(sec_level.light_range, sec_level.light_power, sec_level.light_color_status_display)
 
-	if(sl.alarm_appearance.display_icon)
-		var/image/alert1 = image(sl.icon, sl.alarm_appearance.display_icon)
-		alert1.color = sl.alarm_appearance.display_icon_color
+	if(sec_level.alarm_appearance.display_icon)
+		var/image/alert1 = image(sec_level.icon, sec_level.alarm_appearance.display_icon)
+		alert1.color = sec_level.alarm_appearance.display_icon_color
 		overlays |= alert1
 
-	if(sl.alarm_appearance.display_icon_twotone)
-		var/image/alert2 = image(sl.icon, sl.alarm_appearance.display_icon_twotone)
-		alert2.color = sl.alarm_appearance.display_icon_twotone_color
+	if(sec_level.alarm_appearance.display_icon_twotone)
+		var/image/alert2 = image(sec_level.icon, sec_level.alarm_appearance.display_icon_twotone)
+		alert2.color = sec_level.alarm_appearance.display_icon_twotone_color
 		overlays |= alert2
 
-	if(sl.alarm_appearance.display_emblem)
-		var/image/alert3 = image(sl.icon, sl.alarm_appearance.display_emblem)
-		alert3.color = sl.alarm_appearance.display_emblem_color
+	if(sec_level.alarm_appearance.display_emblem)
+		var/image/alert3 = image(sec_level.icon, sec_level.alarm_appearance.display_emblem)
+		alert3.color = sec_level.alarm_appearance.display_emblem_color
 		overlays |= alert3
 
 /obj/machinery/status_display/proc/set_picture(state)

--- a/code/game/turfs/initialization/init.dm
+++ b/code/game/turfs/initialization/init.dm
@@ -7,6 +7,7 @@
 /area/Initialize(mapload)
 	. = ..()
 	if(ispath(turf_initializer))
-		var/decl/turf_initializer/ti = GET_DECL(turf_initializer)
-		for(var/turf/T in src)
-			ti.InitializeTurf(T)
+		var/decl/turf_initializer/initializer = GET_DECL(turf_initializer)
+		// TODO: It may be worth doing a post-mapload loop over turfs instead, to limit the number of in-area (in-world) loops?
+		for(var/turf/initialized_turf in src)
+			initializer.InitializeTurf(initialized_turf)

--- a/code/game/turfs/turf_footsteps.dm
+++ b/code/game/turfs/turf_footsteps.dm
@@ -1,8 +1,8 @@
 /proc/get_footstep_for_mob(var/footstep_type, var/mob/living/caller)
 	. = istype(caller) && caller.get_mob_footstep(footstep_type)
 	if(!.)
-		var/decl/footsteps/FS = GET_DECL(footstep_type)
-		. = pick(FS.footstep_sounds)
+		var/decl/footsteps/footsteps = GET_DECL(footstep_type)
+		. = pick(footsteps.footstep_sounds)
 
 /turf/proc/get_footstep_sound(var/mob/caller)
 	for(var/obj/structure/S in contents)

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -526,8 +526,8 @@
 /client/proc/special_set_vv_var(var/datum/O, variable, var_value, client)
 	var/list/vv_set_handlers = decls_repository.get_decls_of_subtype(/decl/vv_set_handler)
 	for(var/vv_handler in vv_set_handlers)
-		var/decl/vv_set_handler/sh = vv_set_handlers[vv_handler]
-		if(sh.can_handle_set_var(O, variable, var_value, client))
-			sh.handle_set_var(O, variable, var_value, client)
+		var/decl/vv_set_handler/set_handler = vv_set_handlers[vv_handler]
+		if(set_handler.can_handle_set_var(O, variable, var_value, client))
+			set_handler.handle_set_var(O, variable, var_value, client)
 			return TRUE
 	return FALSE

--- a/code/modules/bodytype/bodytype_random.dm
+++ b/code/modules/bodytype/bodytype_random.dm
@@ -4,8 +4,8 @@
 	if((Z && !(appearance_flags & Z)) || !random_##Y.len){\
 		return;\
 	}\
-	var/decl/color_generator/CG = GET_DECL(pickweight(random_##Y));\
-	return CG && CG.generate_random_colour();\
+	var/decl/color_generator/color_gen = GET_DECL(pickweight(random_##Y));\
+	return color_gen?.generate_random_colour();\
 }
 
 #define SETUP_RANDOM_COLOR_SETTER(X, Y)\

--- a/code/modules/client/preference_setup/antagonism/02_setup.dm
+++ b/code/modules/client/preference_setup/antagonism/02_setup.dm
@@ -27,8 +27,8 @@
 /datum/category_item/player_setup_item/antagonism/basic/save_character(datum/pref_record_writer/writer)
 	var/uplink_order = list()
 	for(var/entry in pref.uplink_sources)
-		var/decl/uplink_source/UL = entry
-		uplink_order += UL.name
+		var/decl/uplink_source/uplink = entry
+		uplink_order += uplink.name
 
 	writer.write("uplink_sources", uplink_order)
 	writer.write("exploit_record", pref.exploit_record)
@@ -43,10 +43,10 @@
 	. +="<b>Antag Setup:</b><br>"
 	. +="Uplink Source Priority: <a href='byond://?src=\ref[src];add_source=1'>Add</a><br>"
 	for(var/entry in pref.uplink_sources)
-		var/decl/uplink_source/US = entry
-		. +="[US.name] <a href='byond://?src=\ref[src];move_source_up=\ref[US]'>Move Up</a> <a href='byond://?src=\ref[src];move_source_down=\ref[US]'>Move Down</a> <a href='byond://?src=\ref[src];remove_source=\ref[US]'>Remove</a><br>"
-		if(US.desc)
-			. += "<font size=1>[US.desc]</font><br>"
+		var/decl/uplink_source/uplink = entry
+		. +="[uplink.name] <a href='byond://?src=\ref[src];move_source_up=\ref[uplink]'>Move Up</a> <a href='byond://?src=\ref[src];move_source_down=\ref[uplink]'>Move Down</a> <a href='byond://?src=\ref[src];remove_source=\ref[uplink]'>Remove</a><br>"
+		if(uplink.desc)
+			. += "<font size=1>[uplink.desc]</font><br>"
 	if(!pref.uplink_sources.len)
 		. += "<span class='warning'>You will not receive an uplink unless you add an uplink source!</span>"
 	. +="<br>"
@@ -64,25 +64,25 @@
 			return TOPIC_REFRESH
 
 	if(href_list["remove_source"])
-		var/decl/uplink_source/US = locate(href_list["remove_source"]) in pref.uplink_sources
-		if(US && pref.uplink_sources.Remove(US))
+		var/decl/uplink_source/uplink = locate(href_list["remove_source"]) in pref.uplink_sources
+		if(uplink && pref.uplink_sources.Remove(uplink))
 			return TOPIC_REFRESH
 
 	if(href_list["move_source_up"])
-		var/decl/uplink_source/US = locate(href_list["move_source_up"]) in pref.uplink_sources
-		if(!US)
+		var/decl/uplink_source/uplink = locate(href_list["move_source_up"]) in pref.uplink_sources
+		if(!uplink)
 			return TOPIC_NOACTION
-		var/index = pref.uplink_sources.Find(US)
+		var/index = pref.uplink_sources.Find(uplink)
 		if(index <= 1)
 			return TOPIC_NOACTION
 		pref.uplink_sources.Swap(index, index - 1)
 		return TOPIC_REFRESH
 
 	if(href_list["move_source_down"])
-		var/decl/uplink_source/US = locate(href_list["move_source_down"]) in pref.uplink_sources
-		if(!US)
+		var/decl/uplink_source/uplink = locate(href_list["move_source_down"]) in pref.uplink_sources
+		if(!uplink)
 			return TOPIC_NOACTION
-		var/index = pref.uplink_sources.Find(US)
+		var/index = pref.uplink_sources.Find(uplink)
 		if(index >= pref.uplink_sources.len)
 			return TOPIC_NOACTION
 		pref.uplink_sources.Swap(index, index + 1)

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -261,8 +261,8 @@
 				var/list/accessory_metadata = length(current_accessories) ? current_accessories[current_accessory] : accessory_decl.get_default_accessory_metadata()
 				var/list/metadata_strings = list()
 				for(var/metadata_type in accessory_decl.accessory_metadata_types)
-					var/decl/sprite_accessory_metadata/sam = GET_DECL(metadata_type)
-					metadata_strings += sam.get_metadata_options_string(src, accessory_cat_decl, accessory_decl, LAZYACCESS(accessory_metadata, metadata_type))
+					var/decl/sprite_accessory_metadata/metadata = GET_DECL(metadata_type)
+					metadata_strings += metadata.get_metadata_options_string(src, accessory_cat_decl, accessory_decl, LAZYACCESS(accessory_metadata, metadata_type))
 				var/acc_decl_ref = "\ref[accessory_decl]"
 				. += "<tr>"
 				. += "<td width = '100px'><b>[accessory_cat_decl.name]</b></td>"
@@ -284,8 +284,8 @@
 				var/list/accessory_metadata = current_accessories[accessory]
 				var/list/metadata_strings = list()
 				for(var/metadata_type in accessory_decl.accessory_metadata_types)
-					var/decl/sprite_accessory_metadata/sam = GET_DECL(metadata_type)
-					metadata_strings += sam.get_metadata_options_string(src, accessory_cat_decl, accessory_decl, LAZYACCESS(accessory_metadata, metadata_type))
+					var/decl/sprite_accessory_metadata/metadata = GET_DECL(metadata_type)
+					metadata_strings += metadata.get_metadata_options_string(src, accessory_cat_decl, accessory_decl, LAZYACCESS(accessory_metadata, metadata_type))
 				var/acc_decl_ref = "\ref[accessory_decl]"
 				. += "<tr>"
 				. += "<td width = '100px'><a href='byond://?src=\ref[src];acc_cat_decl=[cat_decl_ref];acc_decl=[acc_decl_ref];acc_remove=1'>Remove</a></td>"

--- a/code/modules/client/preference_setup/general/04_equipment.dm
+++ b/code/modules/client/preference_setup/general/04_equipment.dm
@@ -18,8 +18,8 @@
 	if(!backpacks_by_name)
 		backpacks_by_name = list()
 		var/bos = global.using_map.get_available_backpacks()
-		for(var/bo in bos)
-			var/decl/backpack_outfit/backpack_outfit = bos[bo]
+		for(var/backpack_option in bos)
+			var/decl/backpack_outfit/backpack_outfit = bos[backpack_option]
 			backpacks_by_name[backpack_outfit.name] = backpack_outfit
 
 /datum/category_item/player_setup_item/physical/equipment/load_character(datum/pref_record_reader/R)
@@ -210,13 +210,13 @@
 		var/backpack_name = href_list["backpack"]
 		if(!(backpack_name in backpacks_by_name))
 			return TOPIC_NOACTION
-		var/decl/backpack_outfit/bo = backpacks_by_name[backpack_name]
-		var/datum/backpack_tweak/bt = locate(href_list["tweak"]) in bo.tweaks
+		var/decl/backpack_outfit/backpack_option = backpacks_by_name[backpack_name]
+		var/datum/backpack_tweak/bt = locate(href_list["tweak"]) in backpack_option.tweaks
 		if(!bt)
 			return TOPIC_NOACTION
-		var/new_metadata = bt.get_metadata(user, get_backpack_metadata(bo, bt))
+		var/new_metadata = bt.get_metadata(user, get_backpack_metadata(backpack_option, bt))
 		if(new_metadata)
-			set_backpack_metadata(bo, bt, new_metadata)
+			set_backpack_metadata(backpack_option, bt, new_metadata)
 			return TOPIC_REFRESH_UPDATE_PREVIEW
 	else if(href_list["change_cash_choice"])
 		var/list/display_choices = list()

--- a/code/modules/client/preference_setup/global/02_prefixes.dm
+++ b/code/modules/client/preference_setup/global/02_prefixes.dm
@@ -100,8 +100,8 @@
 						continue
 					var/prefix_key = pref.prefix_keys_by_type[prefix_type]
 					if(prefix_key == new_key)
-						var/decl/prefix/pi = GET_DECL(prefix_type)
-						pref.prefix_keys_by_type[pi.type] = pi.default_key
+						var/decl/prefix/prefix = GET_DECL(prefix_type)
+						pref.prefix_keys_by_type[prefix.type] = prefix.default_key
 				// Then we reset any and all duplicates
 				reset_duplicate_keys()
 				// Then, if the new key was reset it means it matched a default key.

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -38,8 +38,8 @@
 /decl/loadout_option/proc/can_afford(var/mob/user, var/datum/preferences/pref)
 	if(cost > 0 && (pref.total_loadout_cost + cost) > get_config_value(/decl/config/num/max_gear_cost))
 		return FALSE
-	var/decl/loadout_category/LC = GET_DECL(category)
-	if(!LC || pref.total_loadout_selections[category] >= LC.max_selections)
+	var/decl/loadout_category/loadout_cat = GET_DECL(category)
+	if(!loadout_cat || pref.total_loadout_selections[category] >= loadout_cat.max_selections)
 		return FALSE
 	return TRUE
 
@@ -145,7 +145,7 @@
 	var/firstcat = 1
 	current_tab = current_tab || global.using_map.loadout_categories[1].type
 	var/decl/loadout_category/current_category_decl = GET_DECL(current_tab)
-	for(var/decl/loadout_category/LC as anything in global.using_map.loadout_categories)
+	for(var/decl/loadout_category/loadout_cat as anything in global.using_map.loadout_categories)
 
 		if(firstcat)
 			firstcat = FALSE
@@ -153,21 +153,21 @@
 			. += " |"
 
 		var/category_cost = 0
-		for(var/gear_id in LC.gear)
+		for(var/gear_id in loadout_cat.gear)
 			if(gear_id in pref.gear_list[pref.gear_slot])
-				var/decl/loadout_option/gear = LC.gear[gear_id]
+				var/decl/loadout_option/gear = loadout_cat.gear[gear_id]
 				category_cost += gear.cost
 
 		if(category == current_category_decl.type)
-			. += " <span class='linkOn'>[LC.name] - [category_cost]</span> "
+			. += " <span class='linkOn'>[loadout_cat.name] - [category_cost]</span> "
 		else
 			var/category_selections
-			if(LC.max_selections < INFINITY)
-				category_selections = " - [LC.max_selections - pref.total_loadout_selections[category]] remaining"
+			if(loadout_cat.max_selections < INFINITY)
+				category_selections = " - [loadout_cat.max_selections - pref.total_loadout_selections[category]] remaining"
 			if(category_cost)
-				. += " <a href='byond://?src=\ref[src];select_category=\ref[LC]'><font color = '#e67300'>[LC.name] - [category_cost][category_selections]</font></a> "
+				. += " <a href='byond://?src=\ref[src];select_category=\ref[loadout_cat]'><font color = '#e67300'>[loadout_cat.name] - [category_cost][category_selections]</font></a> "
 			else
-				. += " <a href='byond://?src=\ref[src];select_category=\ref[LC]'>[LC.name] - 0[category_selections]</a> "
+				. += " <a href='byond://?src=\ref[src];select_category=\ref[loadout_cat]'>[loadout_cat.name] - 0[category_selections]</a> "
 
 	. += "</b></center></td></tr>"
 	. += "<tr><td colspan=3><hr></td></tr>"
@@ -366,9 +366,9 @@
 		recalculate_loadout_cost()
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 	if(href_list["select_category"])
-		var/decl/loadout_category/LC = locate(href_list["select_category"])
-		if(istype(LC) && (LC in global.using_map.loadout_categories))
-			current_tab = LC.type
+		var/decl/loadout_category/loadout_cat = locate(href_list["select_category"])
+		if(istype(loadout_cat) && (loadout_cat in global.using_map.loadout_categories))
+			current_tab = loadout_cat.type
 		else
 			current_tab = global.using_map.loadout_categories[1].type
 		return TOPIC_REFRESH
@@ -435,9 +435,9 @@
 	. = ..()
 
 	if(!global.using_map.loadout_blacklist || !(type in global.using_map.loadout_blacklist))
-		var/decl/loadout_category/LC = GET_DECL(category)
-		ADD_SORTED(LC.gear, uid, /proc/cmp_text_asc)
-		LC.gear[uid] = src
+		var/decl/loadout_category/loadout_cat = GET_DECL(category)
+		ADD_SORTED(loadout_cat.gear, uid, /proc/cmp_text_asc)
+		loadout_cat.gear[uid] = src
 
 	if(FLAGS_EQUALS(loadout_flags, GEAR_HAS_TYPE_SELECTION|GEAR_HAS_SUBTYPE_SELECTION))
 		CRASH("May not have both type and subtype selection tweaks")

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -89,25 +89,25 @@
 
 		pref.total_loadout_cost = 0
 		pref.total_loadout_selections = list()
-		var/list/gears = pref.gear_list[index]
-		if(istype(gears))
-			for(var/gear_id in gears)
+		var/list/loadout = pref.gear_list[index]
+		if(istype(loadout))
+			for(var/gear_id in loadout)
 				var/mob/user = preference_mob()
-				var/decl/loadout_option/LO = decls_repository.get_decl_by_id_or_var(gear_id, /decl/loadout_option)
+				var/decl/loadout_option/gear = decls_repository.get_decl_by_id_or_var(gear_id, /decl/loadout_option)
 
-				if(!istype(LO))
-					gears -= gear_id
+				if(!istype(gear))
+					loadout -= gear_id
 					continue
 
 				// Swap names for UIDs to grandfather in old saves.
-				if(LO.uid != gear_id)
-					gears[LO.uid] = gears[gear_id]
-					gears -= gear_id
-					gear_id = LO.uid
+				if(gear.uid != gear_id)
+					loadout[gear.uid] = loadout[gear_id]
+					loadout -= gear_id
+					gear_id = gear.uid
 
-				if(LO && (GET_DECL(LO.category) in global.using_map.loadout_categories) && LO.can_be_taken_by(user, pref) && LO.can_afford(user, pref))
-					pref.total_loadout_cost += LO.cost
-					pref.total_loadout_selections[LO.category] = (pref.total_loadout_selections[LO.category] + 1)
+				if(gear && (GET_DECL(gear.category) in global.using_map.loadout_categories) && gear.can_be_taken_by(user, pref) && gear.can_afford(user, pref))
+					pref.total_loadout_cost += gear.cost
+					pref.total_loadout_selections[gear.category] = (pref.total_loadout_selections[gear.category] + 1)
 		else
 			pref.gear_list[index] = list()
 
@@ -116,12 +116,12 @@
 	pref.total_loadout_cost = 0
 	pref.total_loadout_selections = list()
 
-	var/list/gears = pref.gear_list[pref.gear_slot]
-	for(var/i = 1; i <= gears.len; i++)
-		var/decl/loadout_option/G = decls_repository.get_decl_by_id_or_var(gears[i], /decl/loadout_option)
-		if(G)
-			pref.total_loadout_cost += G.cost
-			pref.total_loadout_selections[G.category] = (pref.total_loadout_selections[G.category] + 1)
+	var/list/loadout = pref.gear_list[pref.gear_slot]
+	for(var/i = 1; i <= loadout.len; i++)
+		var/decl/loadout_option/gear = decls_repository.get_decl_by_id_or_var(loadout[i], /decl/loadout_option)
+		if(gear)
+			pref.total_loadout_cost += gear.cost
+			pref.total_loadout_selections[gear.category] = (pref.total_loadout_selections[gear.category] + 1)
 
 /datum/category_item/player_setup_item/loadout/content()
 	. = list()
@@ -154,9 +154,9 @@
 
 		var/category_cost = 0
 		for(var/gear in LC.gear)
-			var/decl/loadout_option/G = LC.gear[gear]
+			var/decl/loadout_option/gear = LC.gear[gear]
 			if(gear in pref.gear_list[pref.gear_slot])
-				category_cost += G.cost
+				category_cost += gear.cost
 
 		if(category == current_category_decl.type)
 			. += " <span class='linkOn'>[LC.name] - [category_cost]</span> "
@@ -180,13 +180,13 @@
 		var/list/other_gear = list()
 		var/i = 0
 		for(var/gear in current_loadout)
-			var/decl/loadout_option/G = decls_repository.get_decl_by_id(gear, validate_decl_type = FALSE)
-			if(istype(G))
-				if(G.slot)
+			var/decl/loadout_option/gear = decls_repository.get_decl_by_id(gear, validate_decl_type = FALSE)
+			if(istype(gear))
+				if(gear.slot)
 					i++
-					. += "<tr><td colspan=2><center>Layer [i]: [G.name]</center></td><td><a href='byond://?src=\ref[src];gear=\ref[G];layer_lower=1'>Layer under</a><a href='byond://?src=\ref[src];gear=\ref[G];layer_higher=1'>Layer over</a><a href='byond://?src=\ref[src];toggle_gear=\ref[G]'>Remove</a></td></tr>"
+					. += "<tr><td colspan=2><center>Layer [i]: [gear.name]</center></td><td><a href='byond://?src=\ref[src];gear=\ref[gear];layer_lower=1'>Layer under</a><a href='byond://?src=\ref[src];gear=\ref[gear];layer_higher=1'>Layer over</a><a href='byond://?src=\ref[src];toggle_gear=\ref[gear]'>Remove</a></td></tr>"
 				else
-					other_gear += "<tr><td colspan=2><center>[G.name]</center></td><td><a href='byond://?src=\ref[src];toggle_gear=\ref[G]'>Remove</a></td></tr>"
+					other_gear += "<tr><td colspan=2><center>[gear.name]</center></td><td><a href='byond://?src=\ref[src];toggle_gear=\ref[gear]'>Remove</a></td></tr>"
 
 		if(length(other_gear))
 			. += "<tr><td colspan=3><b><hr><center>Other gear</b><hr></center></td></tr>"
@@ -207,24 +207,24 @@
 	var/mob/user = preference_mob()
 	for(var/gear_id in current_category_decl.gear)
 
-		var/decl/loadout_option/G = current_category_decl.gear[gear_id]
-		if(!G.can_be_taken_by(user, pref))
+		var/decl/loadout_option/gear = current_category_decl.gear[gear_id]
+		if(!gear.can_be_taken_by(user, pref))
 			continue
 
-		var/ticked = (G.uid in pref.gear_list[pref.gear_slot])
+		var/ticked = (gear.uid in pref.gear_list[pref.gear_slot])
 		var/list/entry = list()
-		entry += "<tr style='vertical-align:top;'><td width=25%><a style='white-space:normal;' [ticked ? "class='linkOn' " : ""]href='byond://?src=\ref[src];toggle_gear=\ref[G]'>[G.name]</a></td>"
-		entry += "<td width = 10% style='vertical-align:top'>[G.cost]</td>"
-		entry += "<td><font size=2>[G.get_description(get_gear_metadata(G, TRUE))]</font>"
+		entry += "<tr style='vertical-align:top;'><td width=25%><a style='white-space:normal;' [ticked ? "class='linkOn' " : ""]href='byond://?src=\ref[src];toggle_gear=\ref[gear]'>[gear.name]</a></td>"
+		entry += "<td width = 10% style='vertical-align:top'>[gear.cost]</td>"
+		entry += "<td><font size=2>[gear.get_description(get_gear_metadata(gear, TRUE))]</font>"
 
 		var/allowed = 1
-		if(allowed && G.allowed_roles)
+		if(allowed && gear.allowed_roles)
 			var/good_job = 0
 			var/bad_job = 0
 			entry += "<br><i>"
 			var/list/jobchecks = list()
 			for(var/datum/job/J in jobs)
-				if(J.type in G.allowed_roles)
+				if(J.type in gear.allowed_roles)
 					jobchecks += "<font color=55cc55>[J.title]</font>"
 					good_job = 1
 				else
@@ -233,7 +233,7 @@
 			allowed = good_job || !bad_job
 			entry += "[english_list(jobchecks)]</i>"
 
-		if(allowed && G.allowed_branches)
+		if(allowed && gear.allowed_branches)
 			var/list/branches = list()
 			for(var/datum/job/J in jobs)
 				if(pref.branches[J.title])
@@ -244,7 +244,7 @@
 				entry += "<br><i>"
 				for(var/branch in branches)
 					var/datum/mil_branch/player_branch = mil_branches.get_branch(branch)
-					if(player_branch.type in G.allowed_branches)
+					if(player_branch.type in gear.allowed_branches)
 						branch_checks += "<font color=55cc55>[player_branch.name]</font>"
 						good_branch = 1
 					else
@@ -253,11 +253,11 @@
 
 				entry += "[english_list(branch_checks)]</i>"
 
-		if(allowed && G.allowed_skills)
+		if(allowed && gear.allowed_skills)
 			var/list/skills_required = list()//make it into instances? instead of path
-			for(var/skill in G.allowed_skills)
+			for(var/skill in gear.allowed_skills)
 				var/decl/skill/instance = GET_DECL(skill)
-				skills_required[instance] = G.allowed_skills[skill]
+				skills_required[instance] = gear.allowed_skills[skill]
 
 			allowed = skill_check(jobs, skills_required)//Checks if a single job has all the skills required
 
@@ -277,44 +277,44 @@
 		entry += "</tr>"
 		if(ticked)
 			entry += "<tr><td colspan=3>"
-			for(var/datum/gear_tweak/tweak in G.gear_tweaks)
-				var/contents = tweak.get_contents(get_tweak_metadata(G, tweak))
+			for(var/datum/gear_tweak/tweak in gear.gear_tweaks)
+				var/contents = tweak.get_contents(get_tweak_metadata(gear, tweak))
 				if(contents)
-					entry += " <a href='byond://?src=\ref[src];gear=\ref[G];tweak=\ref[tweak]'>[contents]</a>"
+					entry += " <a href='byond://?src=\ref[src];gear=\ref[gear];tweak=\ref[tweak]'>[contents]</a>"
 			entry += "</td></tr>"
 		if(!hide_unavailable_gear || allowed || ticked)
 			. += entry
 	. += "</table>"
 	. = jointext(.,null)
 
-/datum/category_item/player_setup_item/loadout/proc/get_gear_metadata(var/decl/loadout_option/G, var/readonly)
-	var/list/gear = pref.gear_list[pref.gear_slot]
-	. = gear[G.uid]
+/datum/category_item/player_setup_item/loadout/proc/get_gear_metadata(var/decl/loadout_option/gear, var/readonly)
+	var/list/gears = pref.gear_list[pref.gear_slot]
+	. = gears[gear.uid]
 	if(!.)
 		. = list()
 		if(!readonly)
-			gear[G.uid] = .
+			gears[gear.uid] = .
 
-/datum/category_item/player_setup_item/loadout/proc/get_tweak_metadata(var/decl/loadout_option/G, var/datum/gear_tweak/tweak)
-	var/list/metadata = get_gear_metadata(G)
+/datum/category_item/player_setup_item/loadout/proc/get_tweak_metadata(var/decl/loadout_option/gear, var/datum/gear_tweak/tweak)
+	var/list/metadata = get_gear_metadata(gear)
 	. = metadata["[tweak]"]
 	if(!.)
 		. = tweak.get_default()
 		metadata["[tweak]"] = .
 
-/datum/category_item/player_setup_item/loadout/proc/set_tweak_metadata(var/decl/loadout_option/G, var/datum/gear_tweak/tweak, var/new_metadata)
-	var/list/metadata = get_gear_metadata(G)
+/datum/category_item/player_setup_item/loadout/proc/set_tweak_metadata(var/decl/loadout_option/gear, var/datum/gear_tweak/tweak, var/new_metadata)
+	var/list/metadata = get_gear_metadata(gear)
 	metadata["[tweak]"] = new_metadata
 
 /datum/category_item/player_setup_item/loadout/OnTopic(href, href_list, user)
 	if(href_list["toggle_gear"])
-		var/decl/loadout_option/TG = locate(href_list["toggle_gear"])
-		if(!istype(TG))
+		var/decl/loadout_option/gear_to_toggle = locate(href_list["toggle_gear"])
+		if(!istype(gear_to_toggle))
 			return TOPIC_REFRESH
-		if(TG.uid in pref.gear_list[pref.gear_slot])
-			pref.gear_list[pref.gear_slot] -= TG.uid
-		else if(TG.can_afford(preference_mob(), pref))
-			pref.gear_list[pref.gear_slot] += TG.uid
+		if(gear_to_toggle.uid in pref.gear_list[pref.gear_slot])
+			pref.gear_list[pref.gear_slot] -= gear_to_toggle.uid
+		else if(gear_to_toggle.can_afford(preference_mob(), pref))
+			pref.gear_list[pref.gear_slot] += gear_to_toggle.uid
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 
 	if(href_list["gear"])
@@ -373,8 +373,8 @@
 			current_tab = global.using_map.loadout_categories[1].type
 		return TOPIC_REFRESH
 	if(href_list["clear_loadout"])
-		var/list/gear = pref.gear_list[pref.gear_slot]
-		gear.Cut()
+		var/list/current_gear = pref.gear_list[pref.gear_slot]
+		current_gear.Cut()
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 	if(href_list["toggle_hiding"])
 		hide_unavailable_gear = !hide_unavailable_gear

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -153,9 +153,9 @@
 			. += " |"
 
 		var/category_cost = 0
-		for(var/gear in LC.gear)
-			var/decl/loadout_option/gear = LC.gear[gear]
-			if(gear in pref.gear_list[pref.gear_slot])
+		for(var/gear_id in LC.gear)
+			if(gear_id in pref.gear_list[pref.gear_slot])
+				var/decl/loadout_option/gear = LC.gear[gear_id]
 				category_cost += gear.cost
 
 		if(category == current_category_decl.type)
@@ -179,8 +179,8 @@
 
 		var/list/other_gear = list()
 		var/i = 0
-		for(var/gear in current_loadout)
-			var/decl/loadout_option/gear = decls_repository.get_decl_by_id(gear, validate_decl_type = FALSE)
+		for(var/gear_id in current_loadout)
+			var/decl/loadout_option/gear = decls_repository.get_decl_by_id(gear_id, validate_decl_type = FALSE)
 			if(istype(gear))
 				if(gear.slot)
 					i++

--- a/code/modules/client/ui_styles/_helpers.dm
+++ b/code/modules/client/ui_styles/_helpers.dm
@@ -1,9 +1,9 @@
 /proc/get_ui_styles(var/filter_available = TRUE)
 	var/list/all_ui_styles = decls_repository.get_decls_of_subtype(/decl/ui_style)
 	for(var/ui_type in all_ui_styles)
-		var/decl/ui_style/ui = all_ui_styles[ui_type]
-		if(!ui.restricted || !filter_available)
-			LAZYADD(., ui)
+		var/decl/ui_style/style = all_ui_styles[ui_type]
+		if(!style.restricted || !filter_available)
+			LAZYADD(., style)
 
 /proc/get_ui_icon(decl/ui_style/ui_style, ui_key)
 

--- a/code/modules/economy/_worth.dm
+++ b/code/modules/economy/_worth.dm
@@ -10,9 +10,9 @@
 /atom/proc/get_single_monetary_worth()
 	. = get_base_value() * get_value_multiplier()
 	if(reagents)
-		for(var/a in reagents.reagent_volumes)
-			var/decl/material/reg = GET_DECL(a)
-			. += reg.get_value() * REAGENT_VOLUME(reagents, a) * REAGENT_WORTH_MULTIPLIER
+		for(var/reagent_type in reagents.reagent_volumes)
+			var/decl/material/reagent = GET_DECL(reagent_type)
+			. += reagent.get_value() * REAGENT_VOLUME(reagents, reagent_type) * REAGENT_WORTH_MULTIPLIER
 	. = max(0, round(.))
 
 /atom/proc/get_contents_monetary_worth()

--- a/code/modules/events/shipping_error.dm
+++ b/code/modules/events/shipping_error.dm
@@ -1,6 +1,6 @@
 /datum/event/shipping_error/start()
-	var/datum/supply_order/O = new /datum/supply_order()
-	O.ordernum = SSsupply.ordernum
-	O.object = pick(SSsupply.master_supply_list)
-	O.orderedby = random_name(pick(MALE,FEMALE), species = global.using_map.default_species)
-	SSsupply.shoppinglist += O
+	var/datum/supply_order/order = new /datum/supply_order()
+	order.ordernum = SSsupply.ordernum
+	order.object = pick(SSsupply.master_supply_list)
+	order.orderedby = random_name(pick(MALE,FEMALE), species = global.using_map.default_species)
+	SSsupply.shoppinglist += order

--- a/code/modules/genetics/plants/gene_special.dm
+++ b/code/modules/genetics/plants/gene_special.dm
@@ -4,6 +4,6 @@
 		TRAIT_TELEPORTING
 	)
 
-/decl/plant_gene/special/mutate(datum/seed/seed, turf/location)
+/decl/plant_gene/special/mutate(datum/seed/seed, atom/location)
 	if(prob(65))
 		seed.set_trait(TRAIT_TELEPORTING, !seed.get_trait(TRAIT_TELEPORTING))

--- a/code/modules/genetics/plants/gene_vigour.dm
+++ b/code/modules/genetics/plants/gene_vigour.dm
@@ -7,7 +7,7 @@
 		TRAIT_SPREAD
 	)
 
-/decl/plant_gene/vigour/mutate(datum/seed/seed, turf/location)
+/decl/plant_gene/vigour/mutate(datum/seed/seed, atom/location)
 	if(prob(65))
 		seed.set_trait(TRAIT_PRODUCTION, seed.get_trait(TRAIT_PRODUCTION)+rand(-1,1),10,0)
 	if(prob(65))

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -511,11 +511,11 @@
 	return pick(mutants)
 
 //Mutates the plant overall (randomly).
-/datum/seed/proc/mutate(var/degree,var/turf/source_turf)
+/datum/seed/proc/mutate(var/degree, var/atom/location)
 
 	if(!degree || get_trait(TRAIT_IMMUTABLE) > 0) return
 
-	source_turf.visible_message("<span class='notice'>\The [display_name] quivers!</span>")
+	location.visible_message("<span class='notice'>\The [display_name] quivers!</span>")
 
 	//This looks like shit, but it's a lot easier to read/change this way.
 	var/total_mutations = rand(1,1+degree)
@@ -523,7 +523,7 @@
 		switch(rand(0,11))
 			if(0) //Plant cancer!
 				set_trait(TRAIT_ENDURANCE,get_trait(TRAIT_ENDURANCE)-rand(10,20),null,0)
-				source_turf.visible_message("<span class='danger'>\The [display_name] withers rapidly!</span>")
+				location.visible_message("<span class='danger'>\The [display_name] withers rapidly!</span>")
 			if(1)
 				set_trait(TRAIT_NUTRIENT_CONSUMPTION,get_trait(TRAIT_NUTRIENT_CONSUMPTION)+rand(-(degree*0.1),(degree*0.1)),5,0)
 				set_trait(TRAIT_WATER_CONSUMPTION,   get_trait(TRAIT_WATER_CONSUMPTION)   +rand(-degree,degree),50,0)
@@ -545,7 +545,7 @@
 				if(prob(degree*5))
 					set_trait(TRAIT_CARNIVOROUS,     get_trait(TRAIT_CARNIVOROUS)+rand(-degree,degree),2, 0)
 					if(get_trait(TRAIT_CARNIVOROUS))
-						source_turf.visible_message("<span class='notice'>\The [display_name] shudders hungrily.</span>")
+						location.visible_message("<span class='notice'>\The [display_name] shudders hungrily.</span>")
 			if(6)
 				set_trait(TRAIT_WEED_TOLERANCE,      get_trait(TRAIT_WEED_TOLERANCE)+(rand(-2,2)*degree),10, 0)
 				if(prob(degree*5))
@@ -559,7 +559,7 @@
 				set_trait(TRAIT_POTENCY,             get_trait(TRAIT_POTENCY)+(rand(-20,20)*degree),200, 0)
 				if(prob(degree*5))
 					set_trait(TRAIT_SPREAD,          get_trait(TRAIT_SPREAD)+rand(-1,1),2, 0)
-					source_turf.visible_message("<span class='notice'>\The [display_name] spasms visibly, shifting in the tray.</span>")
+					location.visible_message("<span class='notice'>\The [display_name] spasms visibly, shifting in the tray.</span>")
 			if(9)
 				set_trait(TRAIT_MATURATION,          get_trait(TRAIT_MATURATION)+(rand(-1,1)*degree),30, 0)
 				if(prob(degree*5))
@@ -568,12 +568,12 @@
 				if(prob(degree*2))
 					set_trait(TRAIT_BIOLUM,         !get_trait(TRAIT_BIOLUM))
 					if(get_trait(TRAIT_BIOLUM))
-						source_turf.visible_message("<span class='notice'>\The [display_name] begins to glow!</span>")
+						location.visible_message("<span class='notice'>\The [display_name] begins to glow!</span>")
 						if(prob(degree*2))
 							set_trait(TRAIT_BIOLUM_COLOUR,get_random_colour(0,75,190))
-							source_turf.visible_message("<span class='notice'>\The [display_name]'s glow </span><font color='[get_trait(TRAIT_BIOLUM_COLOUR)]'>changes colour</font>!")
+							location.visible_message("<span class='notice'>\The [display_name]'s glow </span><font color='[get_trait(TRAIT_BIOLUM_COLOUR)]'>changes colour</font>!")
 					else
-						source_turf.visible_message("<span class='notice'>\The [display_name]'s glow dims...</span>")
+						location.visible_message("<span class='notice'>\The [display_name]'s glow dims...</span>")
 			if(11)
 				set_trait(TRAIT_TELEPORTING,1)
 

--- a/code/modules/hydroponics/seed_gene_mut.dm
+++ b/code/modules/hydroponics/seed_gene_mut.dm
@@ -1,11 +1,11 @@
-/datum/seed/proc/diverge_mutate_gene(var/decl/plant_gene/G, var/turf/T)
-	if(!istype(G))
+/datum/seed/proc/diverge_mutate_gene(var/decl/plant_gene/gene, var/atom/location)
+	if(!istype(gene))
 		log_debug("Attempted to mutate [src] with a non-plantgene var.")
 		return src
 
-	var/datum/seed/S = diverge()	//Let's not modify all of the seeds.
-	T.visible_message("<span class='notice'>\The [S.display_name] quivers!</span>")	//Mimicks the normal mutation.
-	G.mutate(S, T)
+	var/datum/seed/seed = diverge()	//Let's not modify all of the seeds.
+	location.visible_message("<span class='notice'>\The [seed.display_name] quivers!</span>")	//Mimicks the normal mutation.
+	gene.mutate(seed, location)
 
-	return S
+	return seed
 

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -194,7 +194,7 @@
 		if(istype(Proj, /obj/item/projectile/energy/floramut/gene))
 			var/obj/item/projectile/energy/floramut/gene/G = Proj
 			if(seed)
-				set_seed(seed.diverge_mutate_gene(G.gene, get_turf(loc)), reset_values = FALSE)	//get_turf just in case it's not in a turf.
+				set_seed(seed.diverge_mutate_gene(G.gene, src), reset_values = FALSE)
 		else
 			mutate(1)
 			return
@@ -354,7 +354,7 @@
 	// harvested yet and it's safe to assume it's restricted to this tray.
 	if(!isnull(SSplants.seeds[seed.name]))
 		set_seed(seed.diverge(), reset_values = FALSE)
-	seed.mutate(severity,get_turf(src))
+	seed.mutate(severity, src)
 
 	return
 

--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -418,8 +418,8 @@
 		if(1)
 			var/cont[0]
 			for(var/rtype in reagents.reagent_volumes)
-				var/decl/material/RE = GET_DECL(rtype)
-				cont += RE.name
+				var/decl/material/reagent = GET_DECL(rtype)
+				cont += reagent.name
 			set_pin_data(IC_OUTPUT, 3, cont)
 			push_data()
 		if(2)

--- a/code/modules/mob/living/human/examine.dm
+++ b/code/modules/mob/living/human/examine.dm
@@ -249,8 +249,8 @@
 
 	var/list/human_examines = decls_repository.get_decls_of_subtype(/decl/human_examination)
 	for(var/exam in human_examines)
-		var/decl/human_examination/HE = human_examines[exam]
-		var/adding_text = HE.do_examine(user, distance, src)
+		var/decl/human_examination/examiner = human_examines[exam]
+		var/adding_text = examiner.do_examine(user, distance, src)
 		if(adding_text)
 			. += adding_text
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/giant_parrot/giant_parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/giant_parrot/giant_parrot.dm
@@ -32,12 +32,12 @@
 
 /mob/living/simple_animal/hostile/parrot/space/Initialize()
 	. = ..()
-	var/decl/parrot_subspecies/ps = get_parrot_species()
-	if(ps)
-		icon_set = ps.icon_set
-		butchery_data = ps.butchery_data
+	var/decl/parrot_subspecies/parrot_species = get_parrot_species()
+	if(parrot_species)
+		icon_set = parrot_species.icon_set
+		butchery_data = parrot_species.butchery_data
 		if(get_subspecies_name)
-			SetName(ps.name)
+			SetName(parrot_species.name)
 	set_scale(2)
 	update_icon()
 

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -37,10 +37,10 @@
 
 	var/decl/security_state/security_state = GET_DECL(global.using_map.security_state)
 	if(security_state?.show_on_login)
-		var/decl/security_level/SL = security_state.current_security_level
-		// todo: allow maps to oevrride this string for things like the fantasy map being on high alert?
+		var/decl/security_level/sec_level = security_state.current_security_level
+		// todo: allow maps to override this string for things like the fantasy map being on high alert?
 		// eg "The alert level *in* Karzerfeste Keep is currently high alert." or "Karzerfeste Keep is currently on high alert."
-		to_chat(src, SPAN_NOTICE("The alert level on the [station_name()] is currently: <span class='[SL.light_color_class]'><B>[SL.name]</B></span>. [SL?.up_description]"))
+		to_chat(src, SPAN_NOTICE("The alert level on the [station_name()] is currently: <span class='[sec_level.light_color_class]'><B>[sec_level.name]</B></span>. [sec_level?.up_description]"))
 
 	// bolds the changelog button on the interface so we know there are updates.
 	if(client.prefs?.lastchangelog != global.changelog_hash)

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -85,24 +85,24 @@
 	if((equip_preview_mob & EQUIP_PREVIEW_LOADOUT) && !(previewJob && (equip_preview_mob & EQUIP_PREVIEW_JOB) && previewJob.skip_loadout_preview))
 		// Equip custom gear loadout, replacing any job items
 		for(var/thing in Gear())
-			var/decl/loadout_option/G = decls_repository.get_decl_by_id_or_var(thing, /decl/loadout_option)
-			if(G)
+			var/decl/loadout_option/gear = decls_repository.get_decl_by_id_or_var(thing, /decl/loadout_option)
+			if(gear)
 				var/permitted = FALSE
-				if(G.allowed_roles && G.allowed_roles.len)
+				if(LAZYLEN(gear.allowed_roles))
 					if(previewJob)
-						for(var/job_type in G.allowed_roles)
+						for(var/job_type in gear.allowed_roles)
 							if(previewJob.type == job_type)
 								permitted = TRUE
 				else
 					permitted = TRUE
 
-				if(G.whitelisted && !(mannequin.species.name in G.whitelisted))
+				if(gear.whitelisted && !(mannequin.species.name in gear.whitelisted))
 					permitted = FALSE
 
 				if(!permitted)
 					continue
 
-				if(G.slot && G.spawn_on_mob(mannequin, gear_list[gear_slot][G.uid]))
+				if(gear.slot && gear.spawn_on_mob(mannequin, gear_list[gear_slot][gear.uid]))
 					update_icon = TRUE
 
 	if(update_icon)

--- a/code/modules/modular_computers/file_system/programs/generic/supply.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/supply.dm
@@ -166,11 +166,11 @@
 
 	if(href_list["order"])
 		clear_order_contents()
-		var/decl/hierarchy/supply_pack/P = locate(href_list["order"]) in SSsupply.master_supply_list
-		if(!istype(P))
+		var/decl/hierarchy/supply_pack/pack = locate(href_list["order"]) in SSsupply.master_supply_list
+		if(!istype(pack))
 			return 1
 
-		if(P.hidden && !emagged)
+		if(pack.hidden && !emagged)
 			return 1
 
 		var/reason = sanitize(input(user,"Reason:","Why do you require this item?","") as null|text,,0)
@@ -190,7 +190,7 @@
 
 		var/datum/supply_order/O = new /datum/supply_order()
 		O.ordernum = SSsupply.ordernum
-		O.object = P
+		O.object = pack
 		O.orderedby = idname
 		O.reason = reason
 		O.orderedrank = idrank
@@ -315,31 +315,32 @@
 	category_contents.Cut()
 	var/decl/hierarchy/supply_pack/root = GET_DECL(/decl/hierarchy/supply_pack)
 	var/decl/currency/cur = GET_DECL(global.using_map.default_currency)
-	for(var/decl/hierarchy/supply_pack/sp in root.children)
-		if(!sp.is_category())
+	// FIXME: This probably doesn't even work properly? It assumes there aren't any nested categories...
+	for(var/decl/hierarchy/supply_pack/pack in root.children)
+		if(!pack.is_category())
 			continue // No children
-		category_names.Add(sp.name)
+		category_names.Add(pack.name)
 		var/list/category[0]
-		for(var/decl/hierarchy/supply_pack/spc in sp.get_descendants())
-			if((spc.hidden || spc.contraband || !spc.sec_available()) && !emagged)
+		for(var/decl/hierarchy/supply_pack/child_pack in pack.get_descendants())
+			if((child_pack.hidden || child_pack.contraband || !child_pack.sec_available()) && !emagged)
 				continue
 			category.Add(list(list(
-				"name" = spc.name,
-				"cost" = cur.format_value(spc.cost),
-				"ref" = "\ref[spc]"
+				"name" = child_pack.name,
+				"cost" = cur.format_value(child_pack.cost),
+				"ref" = "\ref[child_pack]"
 			)))
-		category_contents[sp.name] = category
+		category_contents[pack.name] = category
 
 /datum/nano_module/supply/proc/generate_order_contents(var/order_ref)
-	var/decl/hierarchy/supply_pack/sp = locate(order_ref) in SSsupply.master_supply_list
-	if(!istype(sp))
+	var/decl/hierarchy/supply_pack/pack = locate(order_ref) in SSsupply.master_supply_list
+	if(!istype(pack))
 		return FALSE
 	contents_of_order.Cut()
 	showing_contents_of_ref = order_ref
-	for(var/item_path in sp.contains) // Thanks to Lohikar for helping me with type paths - CarlenWhite
+	for(var/item_path in pack.contains) // Thanks to Lohikar for helping me with type paths - CarlenWhite
 		var/obj/item/stack/OB = item_path // Not always a stack, but will always have a name we can fetch.
 		var/name = initial(OB.name)
-		var/amount = sp.contains[item_path] || 1 // If it's just one item (has no number associated), fallback to 1.
+		var/amount = pack.contains[item_path] || 1 // If it's just one item (has no number associated), fallback to 1.
 		if(ispath(item_path, /obj/item/stack)) // And if it is a stack, consider the amount
 			amount *= initial(OB.amount)
 
@@ -349,9 +350,9 @@
 			"amount" = amount
 		)))
 
-	if(sp.contains.len == 0) // Handles the case where sp.contains is empty, e.g. for livecargo
+	if(!length(pack.contains)) // Handles the case where pack.contains is empty, e.g. for livecargo
 		contents_of_order.Add(list(list(
-			"name" = sp.containername,
+			"name" = pack.containername,
 			"amount" = 1
 		)))
 

--- a/code/modules/modular_computers/networking/device_types/_network_device.dm
+++ b/code/modules/modular_computers/networking/device_types/_network_device.dm
@@ -447,16 +447,16 @@
 	var/list/pub_vars = get_public_variables()
 
 	for(var/path in pub_methods)
-		var/decl/public_access/pub = pub_methods[path]
-		var/alias = pub.name
+		var/decl/public_access/pub_method = pub_methods[path]
+		var/alias = pub_method.name
 		alias = replacetext(alias, " ", "_")
-		LAZYSET(command_and_call, alias, pub)
+		LAZYSET(command_and_call, alias, pub_method)
 
 	for(var/path in pub_vars)
-		var/decl/public_access/pub = pub_vars[path]
-		var/alias = pub.name
+		var/decl/public_access/pub_var = pub_vars[path]
+		var/alias = pub_var.name
 		alias = replacetext(alias, " ", "_")
-		LAZYSET(command_and_write, alias, pub)
+		LAZYSET(command_and_write, alias, pub_var)
 
 /**Returns the outward facing URI for this network device.*/
 /datum/extension/network_device/proc/get_network_URI()

--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -56,13 +56,13 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 
 /obj/item/chems/drinks/glass2/proc/has_fizz()
 	if(LAZYLEN(reagents.reagent_volumes))
-		var/decl/material/R = reagents.get_primary_reagent_decl()
-		if(("fizz" in R.glass_special))
+		var/decl/material/primary = reagents.get_primary_reagent_decl()
+		if(("fizz" in primary.glass_special))
 			return 1
 		var/totalfizzy = 0
 		for(var/rtype in reagents.reagent_volumes)
-			var/decl/material/re = GET_DECL(rtype)
-			if("fizz" in re.glass_special)
+			var/decl/material/reagent = GET_DECL(rtype)
+			if("fizz" in reagent.glass_special)
 				totalfizzy += REAGENT_VOLUME(reagents, rtype)
 		if(totalfizzy >= reagents.total_volume / 5) // 20% fizzy by volume
 			return 1
@@ -72,12 +72,12 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 	if(LAZYLEN(reagents.reagent_volumes) > 0)
 		if(temperature > T0C + 40)
 			return 1
-		var/decl/material/R = reagents.get_primary_reagent_decl()
-		if(!("vapor" in R.glass_special))
+		var/decl/material/primary = reagents.get_primary_reagent_decl()
+		if(!("vapor" in primary.glass_special))
 			var/totalvape = 0
 			for(var/rtype in reagents.reagent_volumes)
-				var/decl/material/re = GET_DECL(rtype)
-				if("vapor" in re.glass_special)
+				var/decl/material/reagent = GET_DECL(rtype)
+				if("vapor" in reagent.glass_special)
 					totalvape += REAGENT_VOLUME(reagents, type)
 			if(totalvape >= volume * 0.6) // 60% vapor by container volume
 				return 1

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -86,9 +86,9 @@
 		return TRUE
 	else
 		//If no safety, we just toggle the nozzle
-		var/decl/interaction_handler/IH = GET_DECL(/decl/interaction_handler/next_spray_amount)
-		if(IH.is_possible(src, user))
-			IH.invoked(src, user, user.get_active_held_item())
+		var/decl/interaction_handler/handler = GET_DECL(/decl/interaction_handler/next_spray_amount)
+		if(handler.is_possible(src, user))
+			handler.invoked(src, user, user.get_active_held_item())
 			return TRUE
 
 ///Whether the spray has a safety toggle

--- a/code/modules/scent/_scent.dm
+++ b/code/modules/scent/_scent.dm
@@ -132,13 +132,13 @@ To add a scent extension to an atom using a reagent's info, where R. is the reag
 	if(!holder || !holder.total_volume)
 		return
 	for(var/reagent_type in holder.reagent_volumes)
-		var/decl/material/R = GET_DECL(reagent_type)
-		if(!R.scent)
+		var/decl/material/scented_reagent = GET_DECL(reagent_type)
+		if(!scented_reagent.scent)
 			continue
-		var/decl/scent_intensity/SI = GET_DECL(R.scent_intensity)
-		var/r_scent_intensity = REAGENT_VOLUME(holder, reagent_type) * SI.intensity
+		var/decl/scent_intensity/scent = GET_DECL(scented_reagent.scent_intensity)
+		var/r_scent_intensity = REAGENT_VOLUME(holder, reagent_type) * scent.intensity
 		if(r_scent_intensity > scent_intensity)
-			smelliest = R
+			smelliest = scented_reagent
 			scent_intensity = r_scent_intensity
 
 	return smelliest

--- a/code/modules/submaps/submap_join.dm
+++ b/code/modules/submaps/submap_join.dm
@@ -78,8 +78,8 @@
 			job.apply_fingerprints(character)
 			var/list/spawn_in_storage = SSjobs.equip_custom_loadout(character, job)
 			if(spawn_in_storage)
-				for(var/decl/loadout_option/G in spawn_in_storage)
-					G.spawn_in_storage_or_drop(user_human, user_human.client.prefs.Gear()[G.uid])
+				for(var/decl/loadout_option/gear in spawn_in_storage)
+					gear.spawn_in_storage_or_drop(user_human, user_human.client.prefs.Gear()[gear.uid])
 			SScustomitems.equip_custom_items(user_human)
 
 		character.job = job.title
@@ -97,12 +97,12 @@
 		if(istype(ojob) && ojob.info)
 			to_chat(character, ojob.info)
 
-		if(user_human && user_human.has_genetic_condition(GENE_COND_NEARSIGHTED))
+		if(user_human && user_human.has_genetic_condition(GENE_COND_NEARSIGHTED)) // is this even necessary with the new aspects system?
 			var/equipped = user_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/prescription(user_human), slot_glasses_str)
 			if(equipped)
-				var/obj/item/clothing/glasses/G = user_human.get_equipped_item(slot_glasses_str)
-				if(istype(G))
-					G.prescription = 7
+				var/obj/item/clothing/glasses/glasses = user_human.get_equipped_item(slot_glasses_str)
+				if(istype(glasses))
+					glasses.prescription = 7
 
 		BITSET(character.hud_updateflag, ID_HUD)
 		BITSET(character.hud_updateflag, IMPLOYAL_HUD)

--- a/code/unit_tests/alt_appearances_test.dm
+++ b/code/unit_tests/alt_appearances_test.dm
@@ -2,9 +2,8 @@
 	name = "ALT APPEARANCE: Cardborg shall have base backpack variant"
 
 /datum/unit_test/alt_appearance_cardborg_shall_have_base_backpack_variant/start_test()
-	for(var/ca_type in decls_repository.get_decl_paths_of_subtype(/decl/cardborg_appearance))
-		var/decl/cardborg_appearance/ca = ca_type
-		var/obj/item/backpack/backpack_type = initial(ca.backpack_type)
+	for(var/decl/cardborg_appearance/disguise in decls_repository.get_decls_of_subtype_unassociated(/decl/cardborg_appearance))
+		var/obj/item/backpack/backpack_type = disguise.backpack_type
 		if(backpack_type == /obj/item/backpack)
 			pass("Found a cardborg appearance using the base /obj/item/backpack backpack.")
 			return 1
@@ -18,10 +17,9 @@
 /datum/unit_test/alt_appearance_cardborg_all_icon_states_shall_exist/start_test()
 	var/failed = FALSE
 
-	for(var/ca_type in decls_repository.get_decl_paths_of_subtype(/decl/cardborg_appearance))
-		var/decl/cardborg_appearance/ca = ca_type
-		var/icon_state = initial(ca.icon_state)
-		if(!check_state_in_icon(icon_state, initial(ca.icon)))
+	for(var/decl/cardborg_appearance/disguise in decls_repository.get_decls_of_subtype_unassociated(/decl/cardborg_appearance))
+		var/icon_state = disguise.icon_state
+		if(!check_state_in_icon(icon_state, disguise.icon))
 			log_unit_test("Icon state [icon_state] is missing.")
 			failed = TRUE
 	if(failed)
@@ -36,8 +34,8 @@
 /datum/unit_test/alt_appearance_cardborg_shall_have_unique_backpack_types/start_test()
 	var/list/backpack_types = list()
 	for(var/ca_type in decls_repository.get_decl_paths_of_subtype(/decl/cardborg_appearance))
-		var/decl/cardborg_appearance/ca = ca_type
-		group_by(backpack_types, initial(ca.backpack_type), ca)
+		var/decl/cardborg_appearance/disguise = ca_type
+		group_by(backpack_types, initial(disguise.backpack_type), disguise)
 
 	var/number_of_issues = number_of_issues(backpack_types, "Backpack Types")
 	if(number_of_issues)

--- a/code/unit_tests/loadout_tests.dm
+++ b/code/unit_tests/loadout_tests.dm
@@ -4,9 +4,9 @@
 /datum/unit_test/loadout_test_shall_have_valid_icon_states/start_test()
 
 	var/list/failed = list()
-	for(var/decl/loadout_option/G in decls_repository.get_decls_unassociated(/decl/loadout_option))
+	for(var/decl/loadout_option/gear in decls_repository.get_decls_unassociated(/decl/loadout_option))
 		var/list/path_tweaks = list()
-		for(var/datum/gear_tweak/path/p in G.gear_tweaks)
+		for(var/datum/gear_tweak/path/p in gear.gear_tweaks)
 			path_tweaks += p
 
 		if(path_tweaks.len)
@@ -15,17 +15,17 @@
 					var/path_type = p.valid_paths[path_name]
 					if(!type_has_valid_icon_state(path_type))
 						var/atom/A = path_type
-						failed += "[G] - [path_type] ('[path_name]'): Did not find a gear_tweak's icon_state '[initial(A.icon_state)]' in the icon '[initial(A.icon)]'."
+						failed += "[gear] - [path_type] ('[path_name]'): Did not find a gear_tweak's icon_state '[initial(A.icon_state)]' in the icon '[initial(A.icon)]'."
 		else
-			if(!type_has_valid_icon_state(G.path))
-				var/obj/O = G.path
-				if(ispath(G.path, /obj))
-					O = new G.path()
+			if(!type_has_valid_icon_state(gear.path))
+				var/obj/O = gear.path
+				if(ispath(gear.path, /obj))
+					O = new gear.path()
 					if(!is_string_in_list(O.icon_state, icon_states(O.icon)))
-						failed += "[G] - [G.path]: Did not find the icon state '[O.icon_state]' in the icon '[O.icon]'."
+						failed += "[gear] - [gear.path]: Did not find the icon state '[O.icon_state]' in the icon '[O.icon]'."
 					qdel(O)
 				else
-					failed += "[G] - [G.path]: Did not find the icon state '[initial(O.icon_state)]' in the icon '[initial(O.icon)]'."
+					failed += "[gear] - [gear.path]: Did not find the icon state '[initial(O.icon_state)]' in the icon '[initial(O.icon)]'."
 
 	if(length(failed))
 		fail("[length(failed)] /decl/loadout definition\s had paths with invalid icon states:\n[jointext(failed, "\n")]")
@@ -38,12 +38,12 @@
 
 /datum/unit_test/loadout_test_gear_path_tweaks_shall_be_of_gear_path/start_test()
 	var/list/failed = list()
-	for(var/decl/loadout_option/G in decls_repository.get_decls_unassociated(/decl/loadout_option))
-		for(var/datum/gear_tweak/path/p in G.gear_tweaks)
+	for(var/decl/loadout_option/gear in decls_repository.get_decls_unassociated(/decl/loadout_option))
+		for(var/datum/gear_tweak/path/p in gear.gear_tweaks)
 			for(var/path_name in p.valid_paths)
 				var/path_type = p.valid_paths[path_name]
-				if(!ispath(path_type, G.path))
-					failed += "[G] - [path_type] ('[path_name]'): Was not a path of [G.path]."
+				if(!ispath(path_type, gear.path))
+					failed += "[gear] - [path_type] ('[path_name]'): Was not a path of [gear.path]."
 
 	if(length(failed))
 		fail("[length(failed)] /datum/gear_tweak/path definition\s had invalid paths:\n[jointext(failed, "\n")]")
@@ -56,10 +56,10 @@
 
 /datum/unit_test/loadout_test_gear_path_tweaks_shall_have_unique_keys/start_test()
 	var/path_entries_by_gear_path_and_name = list()
-	for(var/decl/loadout_option/G in decls_repository.get_decls_unassociated(/decl/loadout_option))
-		for(var/datum/gear_tweak/path/p in G.gear_tweaks)
+	for(var/decl/loadout_option/gear in decls_repository.get_decls_unassociated(/decl/loadout_option))
+		for(var/datum/gear_tweak/path/p in gear.gear_tweaks)
 			for(var/path_name in p.valid_paths)
-				group_by(path_entries_by_gear_path_and_name, "[G] - [p] - [path_name]", path_name)
+				group_by(path_entries_by_gear_path_and_name, "[gear] - [p] - [path_name]", path_name)
 
 	var/number_of_issues = number_of_issues(path_entries_by_gear_path_and_name, "Path Tweak Names")
 	if(number_of_issues)
@@ -79,15 +79,15 @@
 /datum/unit_test/loadout_custom_setup_tweaks_shall_have_valid_procs/start_test()
 
 	var/list/failures = list()
-	for(var/decl/loadout_option/G in decls_repository.get_decls_unassociated(/decl/loadout_option))
+	for(var/decl/loadout_option/gear in decls_repository.get_decls_unassociated(/decl/loadout_option))
 		var/datum/instance
 		var/mob/user
-		for(var/datum/gear_tweak/custom_setup/cs in G.gear_tweaks)
-			instance = instance || new G.path()
+		for(var/datum/gear_tweak/custom_setup/custom_tweak in gear.gear_tweaks)
+			instance = instance || new gear.path()
 			user = user || new()
-			var/res = cs.tweak_item(user, instance)
-			if(res != GEAR_TWEAK_SUCCESS && res != GEAR_TWEAK_SKIPPED)
-				failures += "[G.type] - [cs.type]"
+			var/result = custom_tweak.tweak_item(user, instance)
+			if(result != GEAR_TWEAK_SUCCESS && result != GEAR_TWEAK_SKIPPED)
+				failures += "[gear.type] - [custom_tweak.type]"
 
 		QDEL_NULL(instance)
 		QDEL_NULL(user)
@@ -102,13 +102,13 @@
 	name = "LOADOUT: Custom setup tweak shall be applied as expected"
 
 /datum/unit_test/loadout_custom_setup_tweak_shall_be_applied_as_expected/start_test()
-	var/decl/loadout_option/G = GET_DECL(/decl/loadout_option/loadout_test)
-	var/obj/unit_test/loadout/instance = new G.path()
+	var/decl/loadout_option/gear = GET_DECL(/decl/loadout_option/loadout_test)
+	var/obj/unit_test/loadout/instance = new gear.path()
 	var/mob/user = new()
-	for(var/datum/gear_tweak/custom_setup/cs in G.gear_tweaks)
-		cs.tweak_item(user, instance)
+	for(var/datum/gear_tweak/custom_setup/custom_tweak in gear.gear_tweaks)
+		custom_tweak.tweak_item(user, instance)
 
-	if(instance.loadout_mob == user && instance.loadout_var == G.custom_setup_proc_arguments[1])
+	if(instance.loadout_mob == user && instance.loadout_var == gear.custom_setup_proc_arguments[1])
 		pass("Succesfully applied custom tweak")
 	else
 		fail("Failed to apply custom tweak")

--- a/code/unit_tests/view_variables_test.dm
+++ b/code/unit_tests/view_variables_test.dm
@@ -5,20 +5,20 @@
 	var/list/faulty_handlers = list()
 	var/list/vv_set_handlers = decls_repository.get_decls_of_subtype(/decl/vv_set_handler)
 	for(var/vv_handler in vv_set_handlers)
-		var/decl/vv_set_handler/sh = vv_set_handlers[vv_handler]
-		if(!ispath(sh.handled_type))
-			log_bad("[sh] does not have a valid handled type. Expected a path, was [log_info_line(sh.handled_type)]")
-			faulty_handlers |= sh
-		if(!islist(sh.handled_vars))
-			log_bad("[sh] does not have a handled variables list. Expected a list, was [log_info_line(sh.handled_vars)]")
-			faulty_handlers |= sh
-		else if(!sh.handled_vars.len)
-			log_bad("[sh] as an empty handled variables list.")
-			faulty_handlers |= sh
+		var/decl/vv_set_handler/set_handler = vv_set_handlers[vv_handler]
+		if(!ispath(set_handler.handled_type))
+			log_bad("[set_handler] does not have a valid handled type. Expected a path, was [log_info_line(set_handler.handled_type)]")
+			faulty_handlers |= set_handler
+		if(!islist(set_handler.handled_vars))
+			log_bad("[set_handler] does not have a handled variables list. Expected a list, was [log_info_line(set_handler.handled_vars)]")
+			faulty_handlers |= set_handler
+		else if(!set_handler.handled_vars.len)
+			log_bad("[set_handler] as an empty handled variables list.")
+			faulty_handlers |= set_handler
 		else
 			continue
 			// Somehow check for missing vars here without creating instances.
-			// I.e.:  for(var/handled_var in sh.handled_vars) check handled_var in handled_type.vars
+			// I.e.:  for(var/handled_var in set_handler.handled_vars) check handled_var in handled_type.vars
 
 	if(faulty_handlers.len)
 		fail("The following special VV handlers are invalid: [english_list(faulty_handlers)]")

--- a/mods/content/byond_membership/_byond_membership.dm
+++ b/mods/content/byond_membership/_byond_membership.dm
@@ -7,8 +7,8 @@
 
 /decl/communication_channel/ooc/get_emblem(client/C)
 	if(C && C.get_byond_membership() && C.get_preference_value(/datum/client_preference/byond_membership/emblem) == PREF_SHOW)
-		var/decl/modpack/byond_membership/bm = GET_DECL(/decl/modpack/byond_membership)
-		return "[html_icon(bm.emblem)] "
+		var/decl/modpack/byond_membership/membership = GET_DECL(/decl/modpack/byond_membership)
+		return "[html_icon(membership.emblem)] "
 
 /datum/client_preference/byond_membership/emblem
 	description = "BYOND Membership Emblem"


### PR DESCRIPTION
## Description of changes
Replaces single- and double-letter decl variable names with more descriptive equivalents.
Also modernizes some of the code I had to touch to do so, including replacing unnecessary uses of `initial()`, replacing bespoke `name` checks with TYPE_IS_ABSTRACT, 
I got carried away and also did some stuff with global vars which I'm probably going to pull into another PR.

## Why and what will this PR improve
code quality cleanup yay