### PR TITLE
Makes Airlock Helpers for buttons actually work

### DIFF
--- a/code/modules/abstract/airlock_helper.dm
+++ b/code/modules/abstract/airlock_helper.dm
@@ -145,4 +145,7 @@ You still need to set the controller's "id_tag" to something unique.
 /obj/abstract/airlock_helper/button
 	my_device = /obj/machinery/button/access
 	icon_state = "button"
-	tag_addon = "_airlock"
+
+/obj/abstract/airlock_helper/button/configure_associated_device()
+	var/obj/machinery/button/access/my_button = my_device
+	my_button.set_id_tag(my_controller.id_tag)


### PR DESCRIPTION
Makes `/obj/abstract/airlock_helper/button` actually set buttons' id_tags instead of doing nothing.
Presumably when I tested the helpers the first time around I had forgotten to wipe `id_tag` off of the buttons on the airlock I was testing it on and assumed the buttons were being set.
