### PR TITLE
Optimize event registration and firing

### DIFF
--- a/code/__defines/observ.dm
+++ b/code/__defines/observ.dm
@@ -1,4 +1,1 @@
-// This also works, and removes the need for the _REPEAT variant, but the linter hates it:
-//   #define RAISE_EVENT(OBS, args...) (GET_DECL(OBS))?.raise_event(args);
-#define RAISE_EVENT(OBS, args...) var/decl/observ/__event = GET_DECL(OBS); __event?.raise_event(args);
-#define RAISE_EVENT_REPEAT(OBS, args...) __event = GET_DECL(OBS); __event?.raise_event(args);
+#define RAISE_EVENT(OBS, args...) UNLINT((GET_DECL(OBS))?.raise_event(args));

--- a/code/_global_vars/misc.dm
+++ b/code/_global_vars/misc.dm
@@ -1,1 +1,0 @@
-var/global/list/all_observable_events = list()

--- a/code/_helpers/cmp.dm
+++ b/code/_helpers/cmp.dm
@@ -57,6 +57,8 @@
 
 /proc/cmp_qdel_item_time(datum/qdel_item/A, datum/qdel_item/B)
 	. = B.hard_delete_time - A.hard_delete_time
+	if (!. && B.qdels && A.qdels) // sort by time per call
+		. = (B.destroy_time / B.qdels) - (A.destroy_time / A.qdels)
 	if (!.)
 		. = B.destroy_time - A.destroy_time
 	if (!.)

--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -214,4 +214,4 @@ var/global/log_end= world.system_type == UNIX ? ascii2text(13) : ""
 
 /proc/report_progress(var/progress_message)
 	admin_notice("<span class='boldannounce'>[progress_message]</span>", R_DEBUG)
-	to_world_log(progress_message)
+	log_world(progress_message)

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -34,7 +34,7 @@
 /proc/get_exposed_defense_zone(var/atom/movable/target)
 	return pick(BP_HEAD, BP_L_HAND, BP_R_HAND, BP_L_FOOT, BP_R_FOOT, BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG, BP_CHEST, BP_GROIN)
 
-/proc/do_mob(mob/user , mob/target, time = 30, target_zone = 0, uninterruptible = 0, progress = 1, incapacitation_flags = INCAPACITATION_DEFAULT, check_holding = TRUE)
+/proc/do_mob(mob/user, mob/target, time = 30, target_zone = 0, uninterruptible = 0, progress = 1, incapacitation_flags = INCAPACITATION_DEFAULT, check_holding = TRUE)
 	if(!user || !target)
 		return 0
 	var/user_loc = user.loc

--- a/code/_helpers/profiling.dm
+++ b/code/_helpers/profiling.dm
@@ -110,7 +110,8 @@
 	var/init = call_ext(lib, "init")()
 	if("0" != init) CRASH("[lib] init error: [init]")
 
-/world/New()
+var/global/datum/profiler/_profiler = new
+/datum/profiler/New()
 	prof_init()
-	. = ..()
+	..()
 #endif

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -187,7 +187,6 @@ var/global/datum/controller/master/Master = new
 
 	var/msg = "Initializations complete within [time] second\s!"
 	report_progress(msg)
-	log_world(msg)
 
 	initializing = FALSE
 

--- a/code/controllers/subsystems/holomap.dm
+++ b/code/controllers/subsystems/holomap.dm
@@ -104,4 +104,5 @@ SUBSYSTEM_DEF(minimap)
 				if(!areas[areaToPaint])
 					areas[areaToPaint] = icon(HOLOMAP_ICON, "blank")
 				areas[areaToPaint].DrawBox(HOLOMAP_AREACOLOR_BASE, x + offset_x, y + offset_y) //We draw white because we want a generic version to use later. However if there is no colour we ignore it
+		CHECK_TICK
 	return areas

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -50,10 +50,8 @@
 				qdel(extension)
 		extensions = null
 
-	var/decl/observ/destroyed/destroyed_event = GET_DECL(/decl/observ/destroyed)
-	// Typecheck is needed (rather than nullchecking) due to oddness with new() ordering during world creation.
-	if(istype(events_repository) && destroyed_event.event_sources[src])
-		RAISE_EVENT(/decl/observ/destroyed, src)
+	if(event_listeners?[/decl/observ/destroyed])
+		raise_event_non_global(/decl/observ/destroyed)
 
 	if (!isturf(src))	// Not great, but the 'correct' way to do it would add overhead for little benefit.
 		cleanup_events(src)

--- a/code/datums/observation/density_set.dm
+++ b/code/datums/observation/density_set.dm
@@ -11,3 +11,4 @@
 /decl/observ/density_set
 	name = "Density Set"
 	expected_type = /atom
+	flags = OBSERVATION_NO_GLOBAL_REGISTRATIONS

--- a/code/datums/observation/entered.dm
+++ b/code/datums/observation/entered.dm
@@ -12,6 +12,7 @@
 /decl/observ/entered
 	name = "Entered"
 	expected_type = /atom
+	flags = OBSERVATION_NO_GLOBAL_REGISTRATIONS
 
 /*******************
 * Entered Handling *
@@ -19,4 +20,5 @@
 
 /atom/Entered(atom/movable/enterer, atom/old_loc)
 	..()
-	RAISE_EVENT(/decl/observ/entered, src, enterer, old_loc)
+	if(event_listeners?[/decl/observ/entered])
+		raise_event_non_global(/decl/observ/entered, enterer, old_loc)

--- a/code/datums/observation/exited.dm
+++ b/code/datums/observation/exited.dm
@@ -12,6 +12,7 @@
 /decl/observ/exited
 	name = "Exited"
 	expected_type = /atom
+	flags = OBSERVATION_NO_GLOBAL_REGISTRATIONS
 
 /******************
 * Exited Handling *
@@ -19,4 +20,5 @@
 
 /atom/Exited(atom/movable/exitee, atom/new_loc)
 	. = ..()
-	RAISE_EVENT(/decl/observ/exited, src, exitee, new_loc)
+	if(event_listeners?[/decl/observ/exited])
+		raise_event_non_global(/decl/observ/exited, exitee, new_loc)

--- a/code/datums/observation/helpers.dm
+++ b/code/datums/observation/helpers.dm
@@ -1,5 +1,6 @@
 /atom/movable/proc/recursive_move(var/atom/movable/am, var/old_loc, var/new_loc)
-	RAISE_EVENT(/decl/observ/moved, src, old_loc, new_loc)
+	if(event_listeners?[/decl/observ/moved])
+		raise_event_non_global(/decl/observ/moved, old_loc, new_loc)
 
 /atom/movable/proc/move_to_turf(var/atom/movable/am, var/old_loc, var/new_loc)
 	var/turf/T = get_turf(new_loc)

--- a/code/datums/observation/moved.dm
+++ b/code/datums/observation/moved.dm
@@ -33,12 +33,13 @@
 
 /atom/Entered(var/atom/movable/am, var/atom/old_loc)
 	. = ..()
-	RAISE_EVENT(/decl/observ/moved, am, old_loc, am.loc)
+	if(am.event_listeners?[/decl/observ/moved])
+		am.raise_event_non_global(/decl/observ/moved, old_loc, am.loc)
 
 /atom/movable/Entered(var/atom/movable/am, atom/old_loc)
 	. = ..()
-	var/decl/observ/moved/moved_event = GET_DECL(/decl/observ/moved)
-	if(moved_event.has_listeners(am))
+	// We inline and simplify has_listeners here since we know this event can never have global registrations.
+	if(am.event_listeners?[/decl/observ/moved])
 		events_repository.register(/decl/observ/moved, src, am, TYPE_PROC_REF(/atom/movable, recursive_move))
 
 /atom/movable/Exited(var/atom/movable/am, atom/new_loc)

--- a/code/datums/observation/name_set.dm
+++ b/code/datums/observation/name_set.dm
@@ -11,6 +11,7 @@
 /decl/observ/name_set
 	name = "Name Set"
 	expected_type = /atom
+	flags = OBSERVATION_NO_GLOBAL_REGISTRATIONS
 
 /*********************
 * Name Set Handling *
@@ -23,5 +24,6 @@
 		if(has_extension(src, /datum/extension/labels))
 			var/datum/extension/labels/L = get_extension(src, /datum/extension/labels)
 			name = L.AppendLabelsToName(name)
-		RAISE_EVENT(/decl/observ/name_set, src, old_name, new_name)
+		if(event_listeners?[/decl/observ/name_set])
+			raise_event_non_global(/decl/observ/name_set, old_name, new_name)
 		update_above()

--- a/code/datums/observation/observation.dm
+++ b/code/datums/observation/observation.dm
@@ -62,10 +62,6 @@
 	var/list/global_listeners = list()        // Associative list of instances that listen to all events of this type (as opposed to events belonging to a specific source) and the proc to call.
 	VAR_PROTECTED/flags                       // See _defines.dm for available flags and what they do
 
-/decl/observ/Initialize()
-	. = ..()
-	global.all_observable_events += src
-
 /datum
 	/// Associative list of observ type -> associative list of listeners -> an instance/list of procs to call on the listener when the event is raised.
 	var/list/list/list/event_listeners

--- a/code/datums/observation/updated_icon.dm
+++ b/code/datums/observation/updated_icon.dm
@@ -11,3 +11,4 @@
 /decl/observ/updated_icon
 	name = "Updated Icon"
 	expected_type = /atom
+	flags = OBSERVATION_NO_GLOBAL_REGISTRATIONS

--- a/code/datums/observation/~cleanup.dm
+++ b/code/datums/observation/~cleanup.dm
@@ -10,11 +10,11 @@ var/global/list/_all_global_event_listeners = list()
 
 /proc/cleanup_events(var/datum/source)
 	if(source?.global_listen_count > 0)
-		cleanup_global_listener(source, source.global_listen_count)
+		cleanup_global_listener(source)
 	if(source?.event_source_count > 0)
-		cleanup_source_listeners(source, source.event_source_count)
+		cleanup_source_listeners(source)
 	if(source?.event_listen_count > 0)
-		cleanup_event_listener(source, source.event_listen_count)
+		cleanup_event_listener(source)
 
 /decl/observ/register(var/datum/event_source, var/datum/listener, var/proc_call)
 	. = ..()
@@ -46,48 +46,40 @@ var/global/list/_all_global_event_listeners = list()
 			global._all_global_event_listeners -= listener
 #endif
 
-/proc/cleanup_global_listener(listener, listen_count)
-	var/events_removed
+/proc/cleanup_global_listener(datum/listener)
 	for(var/decl/observ/event in decls_repository.get_decls_of_subtype_unassociated(/decl/observ))
-		if((events_removed = event.unregister_global(listener)))
+		if(event.unregister_global(listener))
 			log_debug("[event] ([event.type]) - [log_info_line(listener)] was deleted while still globally registered to an event.")
-			listen_count -= events_removed
-			if(!listen_count)
+			if(!listener.global_listen_count)
 				return
-	if(listen_count > 0)
+	if(listener.global_listen_count > 0)
 		CRASH("Failed to clean up all global listener entries!")
 
 // This might actually be fast enough now that there's no point in logging it?
-/proc/cleanup_source_listeners(datum/event_source, source_listener_count)
-	event_source.event_source_count = 0
-	var/events_removed
+/proc/cleanup_source_listeners(datum/event_source)
 	for(var/event_type in event_source.event_listeners)
 		var/list/list/proc_owners = event_source.event_listeners[event_type]
 		if(proc_owners)
 			var/decl/observ/event = GET_DECL(event_type)
 			for(var/proc_owner in proc_owners)
 				var/list/callbacks_cached = proc_owners[proc_owner]?.Copy()
-				if((events_removed = event.unregister(event_source, proc_owner)))
+				if(event.unregister(event_source, proc_owner))
 					log_debug("[event] ([event.type]) - [log_info_line(event_source)] was deleted while still being listened to by [log_info_line(proc_owner)]. Callbacks: [json_encode(callbacks_cached)]")
-					source_listener_count -= events_removed
-					if(!source_listener_count)
+					if(!event_source.event_source_count)
 						return
-	if(source_listener_count > 0)
+	if(event_source.event_source_count > 0)
 		CRASH("Failed to clean up all event source entries!")
 
-/proc/cleanup_event_listener(datum/listener, listener_count)
-	listener.event_listen_count = 0
-	var/events_removed
+/proc/cleanup_event_listener(datum/listener)
 	for(var/event_type in listener._listening_to)
 		var/list/listened_sources = listener._listening_to[event_type]
 		if(listened_sources)
 			for(var/datum/event_source in listened_sources)
 				var/list/callbacks_cached = event_source.event_listeners[event_type]?[listener]?.Copy()
 				var/decl/observ/event = GET_DECL(event_type)
-				if((events_removed = event.unregister(event_source, listener)))
+				if(event.unregister(event_source, listener))
 					log_debug("[event] ([event.type]) - [log_info_line(listener)] was deleted while still listening to [log_info_line(event_source)]. Callbacks: [json_encode(callbacks_cached)]")
-					listener_count -= events_removed
-					if(!listener_count)
+					if(!listener.event_listen_count)
 						return
-	if(listener_count > 0)
+	if(listener.event_listen_count > 0)
 		CRASH("Failed to clean up all listener entries!")

--- a/code/datums/observation/~cleanup.dm
+++ b/code/datums/observation/~cleanup.dm
@@ -1,3 +1,5 @@
+/// This variable is used only for sanity checks during unit tests. It contains a list of all datums with global event registrations.
+var/global/list/_all_global_event_listeners = list()
 /datum
 	/// Tracks how many event registrations are listening to us. Used in cleanup to prevent dangling references.
 	var/event_source_count = 0
@@ -30,11 +32,19 @@
 	. = ..()
 	if(.)
 		listener.global_listen_count += 1
+// This variable is used only for sanity checks during unit tests.
+#ifdef UNIT_TEST
+		global._all_global_event_listeners += listener
+#endif
 
 /decl/observ/unregister_global(var/datum/listener, var/proc_call)
 	. = ..()
 	if(.)
 		listener.global_listen_count -= .
+#ifdef UNIT_TEST
+		if(!listener.global_listen_count)
+			global._all_global_event_listeners -= listener
+#endif
 
 /proc/cleanup_global_listener(listener, listen_count)
 	var/events_removed

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -216,7 +216,8 @@
 	SHOULD_CALL_PARENT(TRUE)
 	if(density != new_density)
 		density = !!new_density
-		RAISE_EVENT(/decl/observ/density_set, src, !density, density)
+		if(event_listeners?[/decl/observ/density_set])
+			raise_event_non_global(/decl/observ/density_set, !density, density)
 
 /**
 	Handle a projectile `P` hitting this atom
@@ -376,7 +377,8 @@
 			if(L.light_angle)
 				L.source_atom.update_light()
 
-	RAISE_EVENT(/decl/observ/dir_set, src, old_dir, new_dir)
+	if(event_listeners?[/decl/observ/dir_set])
+		raise_event_non_global(/decl/observ/dir_set, old_dir, new_dir)
 
 
 /// Set the icon to `new_icon`
@@ -404,7 +406,8 @@
 /atom/proc/update_icon()
 	SHOULD_CALL_PARENT(TRUE)
 	on_update_icon()
-	RAISE_EVENT(/decl/observ/updated_icon, src)
+	if(event_listeners?[/decl/observ/updated_icon])
+		raise_event_non_global(/decl/observ/updated_icon)
 
 /**
 	Update this atom's icon.

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -185,8 +185,8 @@
 	. = TRUE
 
 	// observ
-	if(!loc)
-		RAISE_EVENT(/decl/observ/moved, src, origin, null)
+	if(!loc && event_listeners?[/decl/observ/moved])
+		raise_event_non_global(/decl/observ/moved, origin, null)
 
 	// freelook
 	if(simulated && opacity)
@@ -237,8 +237,8 @@
 			else
 				unbuckle_mob()
 
-		if(!loc)
-			RAISE_EVENT(/decl/observ/moved, src, old_loc, null)
+		if(!loc && event_listeners?[/decl/observ/moved])
+			raise_event_non_global(/decl/observ/moved, old_loc, null)
 
 		// freelook
 		if(simulated && opacity)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -248,7 +248,7 @@
 /obj/machinery/cryopod/lifepod/Process()
 	if(SSevac.evacuation_controller && SSevac.evacuation_controller.state >= EVAC_LAUNCHING)
 		if(occupant && !launched)
-			launch()
+			INVOKE_ASYNC(src, PROC_REF(launch))
 	..()
 
 /obj/machinery/cryopod/Destroy()

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -649,7 +649,7 @@
 		addtimer(CALLBACK(user, TYPE_PROC_REF(/mob, check_emissive_equipment)), 0, TIMER_UNIQUE)
 
 	RAISE_EVENT(/decl/observ/mob_unequipped, user, src)
-	RAISE_EVENT_REPEAT(/decl/observ/item_unequipped, src, user)
+	RAISE_EVENT(/decl/observ/item_unequipped, src, user)
 
 // called just after an item is picked up, after it has been equipped to the mob.
 /obj/item/proc/on_picked_up(mob/user)
@@ -709,7 +709,7 @@
 			addtimer(CALLBACK(user, TYPE_PROC_REF(/mob, check_emissive_equipment)), 0, TIMER_UNIQUE)
 
 	RAISE_EVENT(/decl/observ/mob_equipped, user, src, slot)
-	RAISE_EVENT_REPEAT(/decl/observ/item_equipped, src, user, slot)
+	RAISE_EVENT(/decl/observ/item_equipped, src, user, slot)
 
 // As above but for items being equipped to an active module on a robot.
 /obj/item/proc/equipped_robot(var/mob/user)

--- a/code/game/objects/items/books/_book.dm
+++ b/code/game/objects/items/books/_book.dm
@@ -41,6 +41,13 @@
 	if(SSpersistence.is_tracking(src, /decl/persistence_handler/book))
 		. = QDEL_HINT_LETMELIVE
 
+/// Clears the text written in the book. Used for acetone removing ink. Returns TRUE if successful, FALSE if it can't be dissolved.
+/obj/item/book/proc/clear_text()
+	if(can_dissolve_text)
+		dat = null
+		return TRUE
+	return FALSE
+
 /obj/item/book/on_update_icon()
 	. = ..()
 	icon_state = get_world_inventory_state()
@@ -77,12 +84,16 @@
 
 	if(dat)
 		user.visible_message("\The [user] opens a book titled \"[title]\" and begins reading intently.")
-		var/processed_dat = user.handle_reading_literacy(user, dat)
-		if(processed_dat)
-			show_browser(user, processed_dat, "window=book;size=1000x550")
-			onclose(user, "book")
+		show_text_to(user)
 	else
 		to_chat(user, SPAN_WARNING("This book is completely blank!"))
+
+/// Reader is the mob doing the reading, whose skill will be used for skillchecks. User is the mob who is holding the book, and do_afters will use them.
+/obj/item/book/proc/show_text_to(mob/reader, mob/user)
+	var/processed_dat = reader.handle_reading_literacy(reader, dat)
+	if(processed_dat)
+		show_browser(reader, processed_dat, "window=book;size=1000x550")
+		onclose(reader, "book")
 
 /obj/item/book/attackby(obj/item/used_item, mob/user)
 
@@ -148,9 +159,7 @@
 			SPAN_NOTICE("\The [user] opens up a book and shows it to \the [target].")
 		)
 		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN) //to prevent spam
-		var/processed_dat = target.handle_reading_literacy(user, "<i>Author: [author].</i><br><br>" + "[dat]")
-		if(processed_dat)
-			show_browser(target, processed_dat, "window=book;size=1000x550")
+		show_text_to(target)
 		return TRUE
 	return ..()
 

--- a/code/game/objects/items/books/manuals/_manual.dm
+++ b/code/game/objects/items/books/manuals/_manual.dm
@@ -2,13 +2,38 @@
 	unique = TRUE // Unable to be copied, unable to be modified
 	abstract_type = /obj/item/book/manual
 	var/guide_decl
+	var/tmp/has_initialized = FALSE
 
 /obj/item/book/manual/Initialize()
 	. = ..()
+	// try to initialize the text! if it's prior to sscodex init it'll initialize on being read
+	// if the guide is invalid the manual will need to be deleted
+	if(initialize_data(in_init = TRUE) == INITIALIZE_HINT_QDEL)
+		return INITIALIZE_HINT_QDEL
+
+/obj/item/book/manual/try_to_read()
+	initialize_data()
+	. = ..()
+
+/obj/item/book/manual/show_text_to()
+	initialize_data()
+	. = ..()
+
+/obj/item/book/manual/clear_text()
+	if((. = ..()))
+		has_initialized = TRUE // prevent data from being added later if it hasn't already been
+
+/obj/item/book/manual/proc/initialize_data(in_init = FALSE)
+	if(has_initialized || !SScodex.initialized)
+		return
+	// Has yet to initialize.
 	var/guide_text = guide_decl && SScodex.get_manual_text(guide_decl)
 	if(!guide_text)
 		log_debug("Manual [type] spawned with invalid guide decl type ([guide_decl || null]).")
-		return INITIALIZE_HINT_QDEL
+		if(in_init)
+			return INITIALIZE_HINT_QDEL
+		qdel(src)
+		return
 	dat = {"
 		<html>
 			<head>
@@ -19,3 +44,4 @@
 			</body>
 		</html>
 	"}
+	has_initialized = TRUE

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -71,6 +71,8 @@
 	var/old_affecting_heat_sources = affecting_heat_sources
 	var/old_height =           get_physical_height()
 	var/old_alpha_mask_state = get_movable_alpha_mask_state(null)
+	var/old_event_listeners =  event_listeners
+	var/old_listening_to =     _listening_to
 
 	var/old_ambience =         ambient_light
 	var/old_ambience_mult =    ambient_light_multiplier
@@ -98,6 +100,9 @@
 	var/turf/changed_turf = .
 	changed_turf.above =            old_above     // Multiz ref tracking.
 	changed_turf.prev_type =        old_prev_type // Shuttle transition turf tracking.
+	// Set our observation bookkeeping lists back.
+	changed_turf.event_listeners =  old_event_listeners
+	changed_turf._listening_to =    old_listening_to
 
 	changed_turf.affecting_heat_sources = old_affecting_heat_sources
 

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -121,8 +121,8 @@
 	if(tell_universe)
 		global.universe.OnTurfChange(changed_turf)
 
-	if(changed_turf.density != old_density)
-		RAISE_EVENT(/decl/observ/density_set, changed_turf, old_density, changed_turf.density)
+	if(changed_turf.density != old_density && changed_turf.event_listeners?[/decl/observ/density_set])
+		changed_turf.raise_event_non_global(/decl/observ/density_set, old_density, changed_turf.density)
 
 	// lighting stuff
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -511,6 +511,8 @@
 		. += "<li>qdel() Count: [I.qdels]</li>"
 		if(I.early_destroy)
 			. += "<li>Early destroy count: [I.early_destroy]</li>"
+		if(I.qdels)
+			. += "<li>Average Destroy() Cost: [I.destroy_time / I.qdels]ms/call</li>"
 		. += "<li>Destroy() Cost: [I.destroy_time]ms</li>"
 		if(I.hard_deletes)
 			. += "<li>Total Hard Deletes [I.hard_deletes]</li>"

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -743,8 +743,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 			O.visible_message(SPAN_NOTICE("The solution dissolves the ink on the paper."), range = 1)
 		else if(istype(O, /obj/item/book) && amount >= FLUID_PUDDLE)
 			var/obj/item/book/affectedbook = O
-			if(affectedbook.can_dissolve_text)
-				affectedbook.dat = null
+			if(affectedbook.clear_text())
 				O.visible_message(SPAN_NOTICE("The solution dissolves the ink on the book."), range = 1)
 			else
 				O.visible_message(SPAN_WARNING("The solution does nothing. Whatever this is, it isn't normal ink."), range = 1)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -947,9 +947,9 @@ default behaviour is:
 			if(user != src)
 				to_chat(user, SPAN_NOTICE("\The [src] scans the writing..."))
 		if(skill_check(SKILL_LITERACY, SKILL_BASIC))
-			if(skip_delays || do_after(src, 1 SECOND, user))
+			if(skip_delays || do_mob(user, src, 1 SECOND))
 				. = stars(text_content, 85)
-		else if(skip_delays || do_after(src, 3 SECONDS, user))
+		else if(skip_delays || do_mob(user, src, 3 SECONDS))
 			. = ..()
 
 /mob/living/handle_writing_literacy(var/mob/user, var/text_content, var/skip_delays)

--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -223,7 +223,8 @@
 	if(!change_turf && !change_area)
 		return
 	var/area/A = change_area ? get_base_area_instance() : null
-	for(var/turf/T as anything in Z_ALL_TURFS(level_z))
+	// We don't have to worry about the edge turfs because those are handled in build_border().
+	for(var/turf/T as anything in block(level_inner_min_x, level_inner_min_y, level_z, level_inner_max_x, level_inner_max_y, level_z))
 		if(change_turf)
 			T = T.ChangeTurf(picked_turf)
 		if(change_area)

--- a/code/modules/random_map/noise/noise.dm
+++ b/code/modules/random_map/noise/noise.dm
@@ -152,6 +152,7 @@
 				total += map[TRANSLATE_COORD(x, y+1)]
 				next_map[TRANSLATE_COORD(x, y)] = round(total / 3)
 		map = next_map
+		CHECK_TICK
 
 	if(smooth_single_tiles)
 		for(var/x in 1 to limit_x - 1)

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -184,7 +184,7 @@
 	var/obj/effect/shuttle_landmark/old_location = current_location
 	RAISE_EVENT(/decl/observ/shuttle_pre_move, src, old_location, destination)
 	shuttle_moved(destination, translation, angle_offset)
-	RAISE_EVENT_REPEAT(/decl/observ/shuttle_moved, src, old_location, destination)
+	RAISE_EVENT(/decl/observ/shuttle_moved, src, old_location, destination)
 	if(istype(old_location))
 		old_location.shuttle_departed(src)
 	destination.shuttle_arrived(src)
@@ -208,7 +208,7 @@
 	var/obj/effect/shuttle_landmark/old_location = current_location
 	RAISE_EVENT(/decl/observ/shuttle_pre_move, src, old_location, destination)
 	shuttle_moved(destination, translation, angle_offset)
-	RAISE_EVENT_REPEAT(/decl/observ/shuttle_moved, src, old_location, destination)
+	RAISE_EVENT(/decl/observ/shuttle_moved, src, old_location, destination)
 	if(istype(old_location))
 		old_location.shuttle_departed(src)
 	destination.shuttle_arrived(src)

--- a/code/unit_tests/observation_tests.dm
+++ b/code/unit_tests/observation_tests.dm
@@ -7,29 +7,26 @@
 	abstract_type = /datum/unit_test/observation
 	async = 0
 	var/list/received_moves
-	var/list/received_name_set_events
-
-	var/list/stored_global_listen_count
+	var/list/received_opacity_events
+	/// A list of datums to check for event sanity pre- and post-test.
+	var/list/datums_of_interest
+	var/list/stored_global_registrations
 
 /datum/unit_test/observation/start_test()
 	received_moves = received_moves || list()
-	received_name_set_events = received_name_set_events || list()
+	received_opacity_events = received_opacity_events || list()
 	received_moves.Cut()
-	received_name_set_events.Cut()
+	received_opacity_events.Cut()
 
-	var/decl/observ/moved/moved_event = GET_DECL(/decl/observ/moved)
-	for(var/global_listener in moved_event.global_listeners)
-		events_repository.unregister_global(/decl/observ/moved, global_listener)
-
-	stored_global_listen_count = global.global_listen_count.Copy()
+	stored_global_registrations = global._all_global_event_listeners.Copy()
 
 	sanity_check_events("Pre-Test")
 	. = conduct_test()
 	sanity_check_events("Post-Test")
+	LAZYCLEARLIST(datums_of_interest)
 
 /datum/unit_test/observation/proc/sanity_check_events(var/phase)
-	for(var/entry in global.all_observable_events)
-		var/decl/observ/event = entry
+	for(var/decl/observ/event in decls_repository.get_decls_of_subtype_unassociated(/decl/observ))
 		var/null_count = 0
 		for(var/null_candidate in event.global_listeners)
 			if(isnull(event.global_listeners[null_candidate]))
@@ -37,27 +34,21 @@
 		if(null_count > 0)
 			fail("[phase]: [event] - The global listeners list contains a null entry.")
 
-		for(var/event_source in event.event_sources)
-			for(var/list/list_of_listeners in event.event_sources[event_source])
-				if(isnull(list_of_listeners))
-					fail("[phase]: [event] - The event source list contains a null entry.")
-				else if(!istype(list_of_listeners))
-					fail("[phase]: [event] - The list of listeners was not of the expected type. Was [list_of_listeners.type].")
-				else
-					for(var/listener in list_of_listeners)
-						if(isnull(listener))
-							fail("[phase]: [event] - The event source listener list contains a null entry.")
-						else
-							var/proc_calls = list_of_listeners[listener]
-							if(isnull(proc_calls))
-								fail("[phase]: [event] - [listener] - The proc call list was null.")
-							else
-								for(var/proc_call in proc_calls)
-									if(isnull(proc_call))
-										fail("[phase]: [event] - [listener]- The proc call list contains a null entry.")
+	for(var/datum/datum_of_interest in datums_of_interest)
+		for(var/registered_event_type in datum_of_interest.event_listeners)
+			if(datum_of_interest.event_listeners[registered_event_type] && (null in datum_of_interest.event_listeners[registered_event_type]))
+				fail("[phase]: [registered_event_type] - [datum_of_interest]'s event_listeners list contains a null key.")
+			for(var/datum/listener in datum_of_interest.event_listeners[registered_event_type])
+				var/proc_calls = datum_of_interest.event_listeners[registered_event_type][listener]
+				if(isnull(proc_calls))
+					fail("[phase]: [registered_event_type] - [listener] - The proc call list was null.")
+				else if(null in proc_calls)
+					fail("[phase]: [registered_event_type] - [listener]- The proc call list contains a null entry.")
+			if(datum_of_interest._listening_to?[registered_event_type] && (null in datum_of_interest._listening_to[registered_event_type]))
+				fail("[phase]: [registered_event_type] - [datum_of_interest]'s _listening_to list contains a null value.")
 
-	for(var/entry in (global.global_listen_count - stored_global_listen_count))
-		fail("[phase]: global_listen_count - Contained [log_info_line(entry)].")
+	for(var/entry in (global._all_global_event_listeners - stored_global_registrations))
+		fail("[phase]: _all_global_event_listeners - Contained [log_info_line(entry)].")
 
 /datum/unit_test/observation/proc/conduct_test()
 	return 0
@@ -70,40 +61,39 @@
 		var/list/l = entry
 		log_unit_test("[l[1]] - [l[2]] - [l[3]]")
 
-/datum/unit_test/observation/proc/receive_name_change(source, old_name, new_name)
-	received_name_set_events[++received_name_set_events.len] = list(source, old_name, new_name)
+/datum/unit_test/observation/proc/receive_opacity_change(source, old_opacity, new_opacity)
+	received_opacity_events[++received_opacity_events.len] = list(source, old_opacity, new_opacity)
 
-/datum/unit_test/observation/proc/dump_received_names()
-	for(var/entry in received_name_set_events)
+/datum/unit_test/observation/proc/dump_received_opacities()
+	for(var/entry in received_opacity_events)
 		var/list/l = entry
 		log_unit_test("[l[1]] - [l[2]] - [l[3]]")
 
 /datum/unit_test/observation/global_listeners_shall_receive_events
 	name = "OBSERVATION: Global listeners shall receive events"
-	var/old_name
-	var/new_name
+	var/old_opacity
+	var/new_opacity
 
 /datum/unit_test/observation/global_listeners_shall_receive_events/conduct_test()
 	var/turf/start = get_safe_turf()
 	var/obj/O = get_named_instance(/obj, start)
-	old_name = O.name
-	new_name = O.name + " (New)"
+	old_opacity = O.opacity
+	new_opacity = !old_opacity
 
-	events_repository.register_global(/decl/observ/name_set, src, TYPE_PROC_REF(/datum/unit_test/observation, receive_name_change))
-	O.SetName(new_name)
-
-	if(received_name_set_events.len != 1)
-		fail("Expected 1 raised name set event, were [received_name_set_events.len].")
-		dump_received_names()
+	events_repository.register_global(/decl/observ/opacity_set, src, TYPE_PROC_REF(/datum/unit_test/observation, receive_opacity_change))
+	O.set_opacity(new_opacity)
+	if(length(received_opacity_events) != 1)
+		fail("Expected 1 raised opacity set event, were [received_opacity_events].")
+		dump_received_opacities()
 		return 1
 
-	var/list/event = received_name_set_events[1]
-	if(event[1] != O || event[2] != old_name || event[3] != new_name)
-		fail("Unepected name set event received. Expected [O], was [event[1]]. Expected [old_name], was [event[2]]. Expected [new_name], was [event[3]]")
+	var/list/event = received_opacity_events[1]
+	if(event[1] != O || event[2] != old_opacity || event[3] != new_opacity)
+		fail("Unexpected opacity set event received. Expected [O], was [event[1]]. Expected [old_opacity], was [event[2]]. Expected [new_opacity], was [event[3]]")
 	else
-		pass("Received the expected name set event.")
+		pass("Received the expected opacity set event.")
 
-	events_repository.unregister_global(/decl/observ/name_set, src)
+	events_repository.unregister_global(/decl/observ/opacity_set, src)
 	qdel(O)
 	return 1
 
@@ -114,6 +104,8 @@
 	var/turf/T = get_safe_turf()
 	var/mob/living/human/H = get_named_instance(/mob/living/human, T, global.using_map.default_species)
 	var/mob/observer/ghost/O = get_named_instance(/mob/observer/ghost, T, "Ghost")
+
+	datums_of_interest = list(T, H, O)
 
 	O.ManualFollow(H)
 	if(is_listening_to_movement(H, O))
@@ -132,6 +124,7 @@
 	var/turf/T = get_safe_turf()
 	var/mob/living/human/H = get_named_instance(/mob/living/human, T, global.using_map.default_species)
 	var/mob/observer/ghost/O = get_named_instance(/mob/observer/ghost, T, "Ghost")
+	datums_of_interest = list(T, H, O)
 
 	O.ManualFollow(H)
 	O.stop_following()
@@ -150,6 +143,7 @@
 /datum/unit_test/observation/moved_shall_not_register_on_enter_without_listeners/conduct_test()
 	var/turf/T = get_safe_turf()
 	var/mob/living/human/H = get_named_instance(/mob/living/human, T, global.using_map.default_species)
+	datums_of_interest = list(T, H)
 	qdel(H.virtual_mob)
 	H.virtual_mob = null
 
@@ -173,6 +167,7 @@
 	var/mob/living/human/H = get_named_instance(/mob/living/human, T, global.using_map.default_species)
 	var/obj/structure/closet/C = get_named_instance(/obj/structure/closet, T, "Closet")
 	var/mob/observer/ghost/O = get_named_instance(/mob/observer/ghost, T, "Ghost")
+	datums_of_interest = list(T, H, C, O)
 
 	H.forceMove(C)
 	O.ManualFollow(H)
@@ -196,6 +191,7 @@
 	var/mob/living/human/H = get_named_instance(/mob/living/human, T, global.using_map.default_species)
 	var/obj/structure/closet/C = get_named_instance(/obj/structure/closet, T, "Closet")
 	var/mob/observer/ghost/O = get_named_instance(/mob/observer/ghost, T, "Ghost")
+	datums_of_interest = list(T, H, C, O)
 
 	O.ManualFollow(H)
 	H.forceMove(C)
@@ -220,6 +216,7 @@
 	var/mob/observer/ghost/one = get_named_instance(/mob/observer/ghost, T, "Ghost One")
 	var/mob/observer/ghost/two = get_named_instance(/mob/observer/ghost, T, "Ghost Two")
 	var/mob/observer/ghost/three = get_named_instance(/mob/observer/ghost, T, "Ghost Three")
+	datums_of_interest = list(T, one, two, three)
 
 	two.ManualFollow(one)
 	three.ManualFollow(two)
@@ -244,6 +241,7 @@
 	var/mob/observer/ghost/one = get_named_instance(/mob/observer/ghost, T, "Ghost One")
 	var/mob/observer/ghost/two = get_named_instance(/mob/observer/ghost, T, "Ghost Two")
 	var/mob/observer/ghost/three = get_named_instance(/mob/observer/ghost, T, "Ghost Three")
+	datums_of_interest = list(T, one, two, three)
 
 	two.ManualFollow(one)
 	three.ManualFollow(two)
@@ -266,20 +264,21 @@
 /datum/unit_test/observation/sanity_global_listeners_shall_not_leave_null_entries_when_destroyed/conduct_test()
 	var/turf/T = get_safe_turf()
 	var/obj/O = get_named_instance(/obj, T)
+	datums_of_interest = list(T, O)
 
-	events_repository.register_global(/decl/observ/name_set, O, TYPE_PROC_REF(/atom/movable, move_to_turf))
+	events_repository.register_global(/decl/observ/atom_examined, O, TYPE_PROC_REF(/atom/movable, move_to_turf))
 	qdel(O)
 
-	var/decl/observ/name_set/name_set_event = GET_DECL(/decl/observ/name_set)
+	var/decl/observ/atom_examined/examined_event = IMPLIED_DECL
 	var/null_count = 0
-	for(var/null_candidate in name_set_event.global_listeners)
-		if (isnull(name_set_event.event_sources[null_candidate]))
+	for(var/datum/null_candidate in examined_event.global_listeners) // skip null keys
+		if (isnull(examined_event.global_listeners[null_candidate]))
 			null_count++
-	if(null_count > 0)
+	if(null_count)
 		fail("The global listener list contains a null value.")
 	else
 		pass("The global listener list does not contain a null value.")
-	if(name_set_event.global_listeners && (null in name_set_event.global_listeners))
+	if(examined_event.global_listeners && (null in examined_event.global_listeners))
 		fail("The global listener list contains a null key.")
 	else
 		pass("The global listener list does not contain a null key.")
@@ -296,21 +295,7 @@
 
 	events_repository.register(/decl/observ/moved, event_source, listener, TYPE_PROC_REF(/atom/movable, recursive_move))
 	qdel(event_source)
-
-	var/decl/observ/moved/moved_event = GET_DECL(/decl/observ/moved)
-	var/null_count = 0
-	for(var/null_candidate in moved_event.event_sources)
-		if (isnull(moved_event.event_sources[null_candidate]))
-			null_count++
-	if(null_count > 0)
-		fail("The event source list contains a null value.")
-	else
-		pass("The event source list does not contain a null value.")
-	if(moved_event.event_sources && (null in moved_event.event_sources))
-		fail("The event source list contains a null key.")
-	else
-		pass("The event source list does not contain a null key.")
-
+	sanity_check_events("Post-Event Source Deletion")
 	qdel(listener)
 	return 1
 
@@ -321,24 +306,11 @@
 	var/turf/T = get_safe_turf()
 	var/mob/event_source = get_named_instance(/mob, T, "Event Source")
 	var/mob/listener = get_named_instance(/mob, T, "Event Listener")
+	datums_of_interest = list(T, event_source, listener)
 
 	events_repository.register(/decl/observ/moved, event_source, listener, TYPE_PROC_REF(/atom/movable, recursive_move))
 	qdel(listener)
-
-	var/decl/observ/moved/moved_event = GET_DECL(/decl/observ/moved)
-	var/listeners = moved_event.event_sources[event_source]
-	var/null_count = 0
-	for(var/null_candidate in listeners)
-		if (isnull(listeners[null_candidate]))
-			null_count++
-	if(null_count > 0)
-		fail("The event source listener list contains a null value.")
-	else
-		pass("The event source listener list does not contain a null value.")
-	if(listeners && (null in listeners))
-		fail("The event source listener list contains a null key.")
-	else
-		pass("The event source listener list does not contain a null key.")
+	sanity_check_events("Post-Listener Deletion")
 	qdel(event_source)
 	return 1
 
@@ -349,6 +321,7 @@
 	var/turf/T = get_safe_turf()
 	var/mob/event_source = get_named_instance(/mob, T, "Event Source")
 	var/mob/listener = get_named_instance(/mob, T, "Event Listener")
+	datums_of_interest = list(T, event_source, listener)
 
 	var/initial_event_source_count = event_source.event_source_count
 	var/initial_event_listen_count = listener.event_listen_count
@@ -373,6 +346,7 @@
 	var/turf/T = get_safe_turf()
 	var/mob/event_source = get_named_instance(/mob, T, "Event Source")
 	var/mob/listener = get_named_instance(/mob, T, "Event Listener")
+	datums_of_interest = list(T, event_source, listener)
 
 	var/initial_event_source_count = event_source.event_source_count
 	var/initial_event_listen_count = listener.event_listen_count
@@ -399,6 +373,7 @@
 	var/mob/event_source_A = get_named_instance(/mob, T, "Event Source A")
 	var/mob/event_source_B = get_named_instance(/mob, T, "Event Source B")
 	var/mob/listener = get_named_instance(/mob, T, "Event Listener")
+	datums_of_interest = list(T, event_source_A, event_source_B, listener)
 
 	var/initial_event_listen_count = listener.event_listen_count
 	events_repository.register(/decl/observ/moved, event_source_A, listener, TYPE_PROC_REF(/atom/movable, recursive_move))
@@ -424,6 +399,7 @@
 	var/mob/event_source = get_named_instance(/mob, T, "Event Source")
 	var/mob/listener_A = get_named_instance(/mob, T, "Event Listener A")
 	var/mob/listener_B = get_named_instance(/mob, T, "Event Listener B")
+	datums_of_interest = list(T, event_source, listener_A, listener_B)
 
 	var/initial_event_source_count = event_source.event_source_count
 	var/initial_event_listen_count = listener_B.event_listen_count

--- a/nebula.dme
+++ b/nebula.dme
@@ -115,7 +115,6 @@
 #include "code\_global_vars\client.dm"
 #include "code\_global_vars\configuration.dm"
 #include "code\_global_vars\logging.dm"
-#include "code\_global_vars\misc.dm"
 #include "code\_global_vars\mobs.dm"
 #include "code\_global_vars\sensitive.dm"
 #include "code\_global_vars\sound.dm"


### PR DESCRIPTION
## Description of changes
Optimizes the cleanup of global events.
Dramatically optimizes some of the most expensive events by leveraging the no-global-registration flag, using a separate helper to avoid firing events if no one is listening.

Uh. We may need to manually carry over event_listeners in changeturf, I'm not 100% sure, do tell me one way or the other

## Why and what will this PR improve
Makes events faster... probably. Also removes the three-deep list on events and makes bookkeeping/cleanup a good bit faster.