### PR TITLE
Remove a lot of unnecessary uses of initial(name)

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -9,9 +9,6 @@ var/global/list/mannequins_
 // Uplinks
 var/global/list/obj/item/uplink/world_uplinks = list()
 
-//Preferences stuff
-var/global/datum/category_collection/underwear/underwear = new()
-
 // Visual nets
 var/global/list/datum/visualnet/visual_nets = list()
 var/global/datum/visualnet/camera/cameranet = new()

--- a/code/controllers/subsystems/initialization/materials.dm
+++ b/code/controllers/subsystems/initialization/materials.dm
@@ -6,8 +6,6 @@ SUBSYSTEM_DEF(materials)
 	priority = SS_PRIORITY_MATERIALS
 
 	// Material vars.
-	var/list/materials
-	var/list/strata
 	var/list/fusion_reactions
 	var/list/weighted_minerals_sparse =       list()
 	var/list/weighted_minerals_rich =         list()
@@ -54,9 +52,8 @@ SUBSYSTEM_DEF(materials)
 		sortTim(cocktails_by_primary_ingredient[reagent], /proc/cmp_cocktail_des)
 
 	// Various other material functions.
-	build_material_lists()       // Build core material lists.
+	build_mineral_weight_lists()
 	build_fusion_reaction_list() // Build fusion reaction tree.
-	materials = sortTim(SSmaterials.materials, /proc/cmp_name_asc)
 
 	var/alpha_inc = 256 / DAMAGE_OVERLAY_COUNT
 	for(var/i = 1; i <= DAMAGE_OVERLAY_COUNT; i++)
@@ -65,18 +62,11 @@ SUBSYSTEM_DEF(materials)
 		img.alpha = (i * alpha_inc) - 1
 		LAZYADD(wall_damage_overlays, img)
 
-	strata = decls_repository.get_decls_of_subtype(/decl/strata) // for debug VV purposes
-
 	. = ..()
 
-/datum/controller/subsystem/materials/proc/build_material_lists()
-	if(LAZYLEN(materials))
-		return
-	materials =         list()
-	var/list/material_decls = decls_repository.get_decls_of_subtype(/decl/material)
-	for(var/mtype in material_decls)
-		var/decl/material/new_mineral = material_decls[mtype]
-		materials += new_mineral
+/datum/controller/subsystem/materials/proc/build_mineral_weight_lists()
+	var/list/material_decls = decls_repository.get_decls_of_subtype_unassociated(/decl/material)
+	for(var/decl/material/new_mineral as anything in material_decls)
 		if(new_mineral.sparse_material_weight)
 			weighted_minerals_sparse[new_mineral.type] = new_mineral.sparse_material_weight
 		if(new_mineral.rich_material_weight)

--- a/code/datums/category.dm
+++ b/code/datums/category.dm
@@ -12,16 +12,16 @@
 	categories_by_name = new()
 	for(var/category_type in typesof(category_group_type))
 		var/datum/category_group/category = category_type
-		if(initial(category.name))
-			category = new category(src)
-			categories += category
-			categories_by_name[category.name] = category
+		if(TYPE_IS_ABSTRACT(category))
+			continue
+		category = new category(src)
+		categories += category
+		ASSERT(category.name)
+		categories_by_name[category.name] = category
 	categories = sortTim(categories, /proc/cmp_category_groups)
 
 /datum/category_collection/Destroy()
-	for(var/category in categories)
-		qdel(category)
-	categories.Cut()
+	QDEL_LIST(categories)
 	return ..()
 
 /******************
@@ -43,10 +43,12 @@
 
 	for(var/item_type in typesof(category_item_type))
 		var/datum/category_item/item = item_type
-		if(initial(item.name))
-			item = new item(src)
-			items += item
-			items_by_name[item.name] = item
+		if(TYPE_IS_ABSTRACT(item))
+			continue
+		item = new item(src)
+		items += item
+		ASSERT(item.name)
+		items_by_name[item.name] = item
 
 	// For whatever reason dd_insertObjectList(items, item) doesn't insert in the correct order
 	// If you change this, confirm that character setup doesn't become completely unordered.
@@ -67,6 +69,7 @@
 * Category Items *
 *****************/
 /datum/category_item
+	abstract_type = /datum/category_item
 	var/name = ""
 	var/datum/category_group/category		// The group this item belongs to
 

--- a/code/datums/repositories/atom_info.dm
+++ b/code/datums/repositories/atom_info.dm
@@ -5,6 +5,7 @@ var/global/repository/atom_info/atom_info_repository = new()
 	var/list/combined_worth_cache = list()
 	var/list/single_worth_cache =   list()
 	var/list/name_cache =           list()
+	var/list/description_cache =    list()
 	var/list/matter_mult_cache =    list()
 	var/list/origin_tech_cache =    list()
 
@@ -37,6 +38,9 @@ var/global/repository/atom_info/atom_info_repository = new()
 	if(!name_cache[key])
 		instance = instance || get_instance_of(path, material, amount)
 		name_cache[key] = instance.name
+	if(!description_cache[key])
+		instance = instance || get_instance_of(path, material, amount)
+		description_cache[key] = instance.desc
 	if(!matter_mult_cache[key] && ispath(path, /obj))
 		var/obj/obj_instance = instance || get_instance_of(path, material, amount)
 		matter_mult_cache[key] = obj_instance.get_matter_amount_modifier()
@@ -66,6 +70,11 @@ var/global/repository/atom_info/atom_info_repository = new()
 	var/key = create_key_for(path, material, amount)
 	update_cached_info_for(path, material, amount, key)
 	. = name_cache[key]
+
+/repository/atom_info/proc/get_description_for(var/path, var/material, var/amount)
+	var/key = create_key_for(path, material, amount)
+	update_cached_info_for(path, material, amount, key)
+	. = description_cache[key]
 
 /repository/atom_info/proc/get_matter_multiplier_for(var/path, var/material, var/amount)
 	var/key = create_key_for(path, material, amount)

--- a/code/datums/underwear/bottom.dm
+++ b/code/datums/underwear/bottom.dm
@@ -1,4 +1,5 @@
 /datum/category_item/underwear/bottom
+	abstract_type = /datum/category_item/underwear/bottom
 	underwear_gender = PLURAL
 	underwear_name = "underwear"
 	underwear_type = /obj/item/underwear/bottom

--- a/code/datums/underwear/socks.dm
+++ b/code/datums/underwear/socks.dm
@@ -1,4 +1,5 @@
 /datum/category_item/underwear/socks
+	abstract_type = /datum/category_item/underwear/socks
 	underwear_name = "socks"
 	underwear_gender = PLURAL
 	underwear_type = /obj/item/underwear/socks

--- a/code/datums/underwear/top.dm
+++ b/code/datums/underwear/top.dm
@@ -1,4 +1,5 @@
 /datum/category_item/underwear/top
+	abstract_type = /datum/category_item/underwear/top
 	underwear_name = "bra"
 	underwear_type = /obj/item/underwear/top
 

--- a/code/datums/underwear/undershirt.dm
+++ b/code/datums/underwear/undershirt.dm
@@ -1,4 +1,5 @@
 /datum/category_item/underwear/undershirt
+	abstract_type = /datum/category_item/underwear/undershirt
 	underwear_name = "undershirt"
 	underwear_type = /obj/item/underwear/undershirt
 

--- a/code/datums/underwear/underwear.dm
+++ b/code/datums/underwear/underwear.dm
@@ -1,6 +1,7 @@
 /****************************
 * Category Collection Setup *
 ****************************/
+var/global/datum/category_collection/underwear/underwear = new()
 /datum/category_collection/underwear
 	category_group_type = /datum/category_group/underwear
 
@@ -8,6 +9,9 @@
 * Categories *
 *************/
 // Lower sort order is applied as icons first
+/datum/category_group/underwear
+	abstract_type = /datum/category_group/underwear
+
 /datum/category_group/underwear/top
 	name = "Underwear, top"
 	sort_order = 1

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -35,8 +35,8 @@
 			return
 
 		add_autopsy_data(S)
-		for(var/decl/material/dose as anything in M.chem_doses)
-			chemtraces |= initial(dose.name)
+		for(var/decl/material/dose in decls_repository.get_decls_unassociated(M.chem_doses))
+			chemtraces |= dose.use_name
 
 	else if(istype(A, /obj/item/organ/external))
 		set_target(A, user)
@@ -65,11 +65,11 @@
 	if(timeofdeath)
 		scan_data += "<b>Time of death:</b> [worldtime2stationtime(timeofdeath)]<br>"
 
-	var/n = 1
+	var/weapon_count = 1
 	for(var/weapon in weapon_data)
 		var/list/organs = weapon_data[weapon]["organs"]
 		var/datum/autopsy_data/data = weapon_data[weapon]["data"]
-		scan_data += "<b>Weapon #[n++]:</b> [data.weapon]"
+		scan_data += "<b>Weapon #[weapon_count++]:</b> [data.weapon]"
 		if(data.hits)
 			var/damage_desc
 			switch(data.damage)

--- a/code/game/objects/items/weapons/material/stick.dm
+++ b/code/game/objects/items/weapons/material/stick.dm
@@ -43,7 +43,7 @@
 			return TRUE
 
 		if(cloth.get_amount() < cloth_cost)
-			to_chat(user, SPAN_WARNING("You need at least [cloth_cost] unit\s of material to create \a [initial(product_type.name)]."))
+			to_chat(user, SPAN_WARNING("You need at least [cloth_cost] unit\s of material to create \a [atom_info_repository.get_name_for(product_type)]."))
 			return TRUE
 
 		// Ugly way to check for dried grass vs regular grass.

--- a/code/game/objects/items/weapons/storage/fancy/_fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy/_fancy.dm
@@ -49,4 +49,4 @@
 	if(distance > 1 || !key_type)
 		return
 	var/key_count = count_by_type(contents, key_type)
-	. += "There [key_count == 1? "is" : "are"] [key_count] [initial(key_type.name)]\s in the box."
+	. += "There [key_count == 1? "is" : "are"] [key_count] [atom_info_repository.get_name_for(key_type)]\s in the box."

--- a/code/modules/client/preference_setup/antagonism/01_candidacy.dm
+++ b/code/modules/client/preference_setup/antagonism/01_candidacy.dm
@@ -2,6 +2,9 @@
 	var/list/may_be_special_role
 	var/list/be_special_role
 
+/datum/category_item/player_setup_item/antagonism
+	abstract_type = /datum/category_item/player_setup_item/antagonism
+
 /datum/category_item/player_setup_item/antagonism/candidacy
 	name = "Candidacy"
 	sort_order = 1

--- a/code/modules/client/preference_setup/background/01_species.dm
+++ b/code/modules/client/preference_setup/background/01_species.dm
@@ -1,3 +1,6 @@
+/datum/category_item/player_setup_item/background
+	abstract_type = /datum/category_item/player_setup_item/background
+
 /datum/category_item/player_setup_item/background/species
 	name = "Species"
 	sort_order = 1

--- a/code/modules/client/preference_setup/controls/01_keybindings.dm
+++ b/code/modules/client/preference_setup/controls/01_keybindings.dm
@@ -47,6 +47,9 @@
 		to_chat(client, SPAN_DANGER("[conflicted.category]: [conflicted.full_name] needs updating."))
 		LAZYADD(key_bindings["Unbound"], conflicted.name) // set it to unbound to prevent this from opening up again in the future
 
+/datum/category_item/player_setup_item/controls
+	abstract_type = /datum/category_item/player_setup_item/controls
+
 /datum/category_item/player_setup_item/controls/keybindings
 	name = "Keybindings"
 	sort_order = 1

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -15,6 +15,9 @@
 	var/decl/species/species_decl = get_species_decl()
 	return species_decl.get_bodytype_by_name(bodytype) || species_decl.default_bodytype
 
+/datum/category_item/player_setup_item/physical
+	abstract_type = /datum/category_item/player_setup_item/physical
+
 /datum/category_item/player_setup_item/physical/basic
 	name = "Basic"
 	sort_order = 1

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -13,6 +13,9 @@ var/global/list/valid_icon_sizes = list(32, 48, 64, 96, 128)
 	//Style for popup tooltips
 	var/tooltip_style            = "Midnight"
 
+/datum/category_item/player_setup_item/player_global
+	abstract_type = /datum/category_item/player_setup_item/player_global
+
 /datum/category_item/player_setup_item/player_global/ui
 	name = "UI"
 	sort_order = 1

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -263,14 +263,13 @@
 
 			entry += "<br><i>"
 			var/list/skill_checks = list()
-			for(var/R in skills_required)
-				var/decl/skill/S = R
+			for(var/decl/skill/required_skill in skills_required)
 				var/skill_entry
-				skill_entry += "[S.levels[skills_required[R]]]"
+				skill_entry += "[required_skill.levels[skills_required[required_skill]]]"
 				if(allowed)
-					skill_entry = "<font color=55cc55>[skill_entry] [R]</font>"
+					skill_entry = "<font color=55cc55>[skill_entry] [required_skill]</font>"
 				else
-					skill_entry = "<font color=cc5555>[skill_entry] [R]</font>"
+					skill_entry = "<font color=cc5555>[skill_entry] [required_skill]</font>"
 				skill_checks += skill_entry
 
 			entry += "[english_list(skill_checks)]</i>"

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -1,5 +1,8 @@
 var/global/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 
+/datum/category_group/player_setup_category
+	abstract_type = /datum/category_group/player_setup_category
+
 /datum/category_group/player_setup_category/background_preferences
 	name = "Background"
 	sort_order = 1 // must go first because species
@@ -181,6 +184,7 @@ var/global/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 * Category Item Setup *
 **********************/
 /datum/category_item/player_setup_item
+	abstract_type = /datum/category_item/player_setup_item
 	var/sort_order = 0
 	var/datum/preferences/pref
 

--- a/code/modules/client/preference_setup/records/00_records.dm
+++ b/code/modules/client/preference_setup/records/00_records.dm
@@ -2,6 +2,7 @@
 	var/list/records = list()
 
 /datum/category_item/player_setup_item/records
+	abstract_type = /datum/category_item/player_setup_item/records
 	var/record_key
 
 /datum/category_item/player_setup_item/records/content(var/mob/user)

--- a/code/modules/codex/categories/category_recipes.dm
+++ b/code/modules/codex/categories/category_recipes.dm
@@ -33,8 +33,12 @@
 			if(!product)
 				continue
 			category_name = "mix recipe"
-			lore_text = initial(product.desc)
-			var/product_name = (ispath(product, /atom/movable) && TYPE_IS_SPAWNABLE(product)) ? atom_info_repository.get_name_for(product) : initial(product.name)
+			var/product_name = initial(product.name)
+			if(ispath(product, /atom/movable) && TYPE_IS_SPAWNABLE(product))
+				product_name = atom_info_repository.get_name_for(product)
+				lore_text = atom_info_repository.get_description_for(product)
+			else
+				lore_text = initial(product.desc)
 			mechanics_text = "This recipe produces \a [product_name].<br>It should be performed in a mixing bowl or beaker, and requires the following ingredients:"
 		else
 			var/decl/material/product = GET_DECL(food.result)
@@ -111,6 +115,7 @@
 		var/lore_text = recipe.lore_text
 		if(ispath(recipe_product, /atom/movable) && TYPE_IS_SPAWNABLE(recipe_product))
 			product_name = atom_info_repository.get_name_for(recipe_product)
+			lore_text ||= atom_info_repository.get_description_for(recipe_product)
 		else if(ispath(recipe.result, /decl/material))
 			var/decl/material/result_reagent = GET_DECL(recipe.result)
 			product_name = result_reagent.use_name
@@ -118,10 +123,9 @@
 			lore_text ||= result_reagent.lore_text
 		else // some things can't be spawned by the atom info repository because they need extra args we can't pass
 			product_name = initial(recipe_product.name)
+			lore_text ||= initial(recipe_product.desc)
 		product_link ||= "\a [product_name]"
 		mechanics_text += "<br>This recipe takes [ceil(recipe.cooking_time/(1 SECOND))] second\s to cook in [english_list(cooking_methods, and_text = " or ")] and creates [product_link]."
-		if(!lore_text)
-			lore_text = initial(recipe_product.desc)
 
 		var/recipe_name = recipe.display_name || sanitize(product_name)
 		guide_html += "<h3>[capitalize(recipe_name)]</h3>Cook [english_list(ingredients)] for [ceil(recipe.cooking_time/(1 SECOND))] second\s."

--- a/code/modules/codex/categories/category_substances.dm
+++ b/code/modules/codex/categories/category_substances.dm
@@ -67,7 +67,10 @@
 			var/chems = list()
 			for(var/chemical in mat.dissolves_into)
 				var/decl/material/material = GET_DECL(chemical)
-				chems += "<span codexlink='[material.codex_name || material.name] (substance)'>[material.name]</span> ([mat.dissolves_into[chemical]*100]%)"
+				var/material_link = "<span codexlink='[material.codex_name || material.name] (substance)'>[material.name]</span>"
+				if(material.hidden_from_codex)
+					material_link = material.name
+				chems += "[material_link] ([mat.dissolves_into[chemical]*100]%)"
 			var/solvent_needed
 			if(mat.dissolves_in <= MAT_SOLVENT_NONE)
 				solvent_needed = "any liquid"

--- a/code/modules/codex/categories/category_substances.dm
+++ b/code/modules/codex/categories/category_substances.dm
@@ -9,7 +9,7 @@
 		if(mat.hidden_from_codex)
 			continue
 
-		var/new_lore_text = initial(mat.lore_text)
+		var/new_lore_text = mat.lore_text
 		if(mat.taste_description)
 			if(new_lore_text)
 				new_lore_text = "[new_lore_text]<br><br>"

--- a/code/modules/codex/categories/category_substances.dm
+++ b/code/modules/codex/categories/category_substances.dm
@@ -3,8 +3,8 @@
 	desc = "Various natural and artificial substances."
 
 /decl/codex_category/substances/Populate()
-
-	for(var/decl/material/mat as anything in SSmaterials.materials)
+	var/list/decl/material/alphabetized_materials = sortTim(decls_repository.get_decls_of_subtype_unassociated(/decl/material), /proc/cmp_name_asc)
+	for(var/decl/material/mat as anything in alphabetized_materials)
 
 		if(mat.hidden_from_codex)
 			continue
@@ -67,8 +67,8 @@
 		if(mat.dissolves_in != MAT_SOLVENT_IMMUNE && LAZYLEN(mat.dissolves_into))
 			var/chems = list()
 			for(var/chemical in mat.dissolves_into)
-				var/decl/material/R = chemical
-				chems += "[initial(R.name)] ([mat.dissolves_into[chemical]*100]%)"
+				var/decl/material/material = GET_DECL(chemical)
+				chems += "<span codexlink='[material.codex_name || material.name] (substance)'>[material.name]</span> ([mat.dissolves_into[chemical]*100]%)"
 			var/solvent_needed
 			if(mat.dissolves_in <= MAT_SOLVENT_NONE)
 				solvent_needed = "any liquid"

--- a/code/modules/codex/categories/category_substances.dm
+++ b/code/modules/codex/categories/category_substances.dm
@@ -35,16 +35,15 @@
 				var/decl/material/catalyst = GET_DECL(catalyst_id)
 				catalysts += "[reaction.catalysts[catalyst_id]]u <span codexlink='[catalyst.codex_name || catalyst.name] (substance)'>[catalyst.name]</span>"
 
-			var/decl/material/result = reaction.result
 			var/mix_link = "Mixing"
 			if(istype(reaction, /decl/chemical_reaction/alloy))
 				mix_link = "Alloying"
 
 			mix_link = "<span codexlink='[reaction.name] (chemical reaction)'>[mix_link]</span>"
 			if(catalysts.len)
-				production_strings += "[mix_link] [english_list(reactant_values)], catalyzed by [english_list(catalysts)], producing [reaction.result_amount]u [lowertext(initial(result.name))]."
+				production_strings += "[mix_link] [english_list(reactant_values)], catalyzed by [english_list(catalysts)], producing [reaction.result_amount]u [mat.name]."
 			else
-				production_strings += "[mix_link] [english_list(reactant_values)], producing [reaction.result_amount]u [lowertext(initial(result.name))]."
+				production_strings += "[mix_link] [english_list(reactant_values)], producing [reaction.result_amount]u [mat.name]."
 			// Todo: smelting and compressing
 
 		if(length(production_strings))

--- a/code/modules/codex/entries/_codex_entry.dm
+++ b/code/modules/codex/entries/_codex_entry.dm
@@ -46,9 +46,11 @@
 	if(_antag_text)         antag_text =         _antag_text
 
 	if(store_codex_entry && length(associated_paths))
-		for(var/tpath in associated_paths)
-			var/atom/thing = tpath
-			var/thing_name = codex_sanitize(initial(thing.name))
+		for(var/atom/thing as anything in associated_paths)
+			var/thing_name = initial(thing.name)
+			if(ispath(thing, /atom/movable) && TYPE_IS_SPAWNABLE(thing))
+				thing_name = atom_info_repository.get_name_for(thing)
+			thing_name = codex_sanitize(thing_name)
 			if(disambiguator)
 				thing_name = "[thing_name] ([disambiguator])"
 			LAZYDISTINCTADD(associated_strings, thing_name)

--- a/code/modules/goals/definitions/department_clerical.dm
+++ b/code/modules/goals/definitions/department_clerical.dm
@@ -20,8 +20,7 @@
 		SSgoals.pending_goals -= src
 		return
 	paperwork_type = pick(paperwork_types)
-	var/obj/item/paperwork/paperwork_type_obj = paperwork_type
-	waiting_for_signatories_description = replacetext(waiting_for_signatories_description, "%PAPERWORK%", "\the [initial(paperwork_type_obj.name)]")
+	waiting_for_signatories_description = replacetext(waiting_for_signatories_description, "%PAPERWORK%", "\the [atom_info_repository.get_name_for(paperwork_type)]")
 
 	..()
 
@@ -74,8 +73,7 @@
 	if(!generated_paperwork)
 		description = waiting_for_signatories_description
 	else if(QDELETED(paperwork_instance))
-		var/obj/item/paperwork/paperwork_type_obj = paperwork_type
-		description = "\The [initial(paperwork_type_obj.name)] has been destroyed."
+		description = "\The [atom_info_repository.get_name_for(paperwork_type)] has been destroyed."
 	else if(length(paperwork_instance.needs_signed))
 		description = "Have \the [paperwork_instance] signed by [english_list(paperwork_instance.all_signatories)]."
 	else

--- a/code/modules/goals/definitions/personal_achievement_specific_object.dm
+++ b/code/modules/goals/definitions/personal_achievement_specific_object.dm
@@ -65,4 +65,4 @@
 /datum/goal/achievement/specific_object/pet/update_strings()
 	..()
 	var/mob/animal = object_path
-	description = "Pet \a [initial(animal.name)]."
+	description = "Pet \a [initial(animal.name)]." // probably best not to use the atom info repository for this, lest we get 'Pet a monkey (666).'

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -292,16 +292,15 @@
 
 /obj/item/integrated_circuit/input/gene_scanner/do_work()
 	var/list/greagents = list()
-	var/obj/machinery/portable_atmospherics/hydroponics/H = get_pin_data_as_type(IC_INPUT, 1, /obj/machinery/portable_atmospherics/hydroponics)
-	if(!istype(H)) //Invalid input
+	var/obj/machinery/portable_atmospherics/hydroponics/plant = get_pin_data_as_type(IC_INPUT, 1, /obj/machinery/portable_atmospherics/hydroponics)
+	if(!istype(plant)) //Invalid input
 		return
 	for(var/i=1, i<=outputs.len, i++)
 		set_pin_data(IC_OUTPUT, i, null)
-	if(H in view(get_turf(src))) // Like the medbot's analyzer it can be used at range.
-		if(H.seed)
-			for(var/chem_path in H.seed.chems)
-				var/decl/material/R = chem_path
-				greagents.Add(initial(R.name))
+	if(plant.seed && (plant in view(get_turf(src)))) // Like the medbot's analyzer it can be used at range.
+		for(var/chem_path in plant.seed.chems)
+			var/decl/material/material = GET_DECL(chem_path)
+			greagents.Add(material.use_name)
 
 	set_pin_data(IC_OUTPUT, 1, greagents)
 	push_data()

--- a/code/modules/materials/definitions/solids/materials_solid_mundane.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_mundane.dm
@@ -5,7 +5,6 @@
 	ore_name = "slag"
 	ore_desc = "Someone messed up..."
 	ore_icon_overlay = "lump"
-	hidden_from_codex = TRUE
 	reflectiveness = MAT_VALUE_DULL
 	wall_support_value = MAT_VALUE_LIGHT
 	value = 0.1

--- a/code/modules/reagents/chems/random/random_effects.dm
+++ b/code/modules/reagents/chems/random/random_effects.dm
@@ -45,7 +45,7 @@
 	mode = RANDOM_CHEM_EFFECT_INT
 
 /decl/random_chem_effect/general_properties/name/on_property_recompute(var/decl/material/liquid/random/reagent, var/value)
-	reagent.name = "[initial(reagent.name)]-[value]"
+	reagent.name = "[initial(reagent.name)]-[value]" // this is a valid use of initial(reagent.name) since we're resetting it to the base value
 
 /decl/random_chem_effect/general_properties/color/get_random_value()
 	return color_matrix_rotate_hue(round(rand(0,360),20))

--- a/code/modules/reagents/dispenser/cartridge_spawn.dm
+++ b/code/modules/reagents/dispenser/cartridge_spawn.dm
@@ -1,13 +1,14 @@
-/client/proc/spawn_chemdisp_cartridge(size in list("small", "medium", "large"), reagent in decls_repository.get_decl_paths_of_subtype(/decl/material))
+/client/proc/spawn_chemdisp_cartridge(size in list("small", "medium", "large"), reagent_type in decls_repository.get_decl_paths_of_subtype(/decl/material))
 	set name = "Spawn Chemical Dispenser Cartridge"
 	set category = "Admin"
 
-	var/obj/item/chems/chem_disp_cartridge/C
+	var/cartridge_type
 	switch(size)
-		if("small") C = new /obj/item/chems/chem_disp_cartridge/small(usr.loc)
-		if("medium") C = new /obj/item/chems/chem_disp_cartridge/medium(usr.loc)
-		if("large") C = new /obj/item/chems/chem_disp_cartridge(usr.loc)
-	C.add_to_reagents(reagent, C.volume)
-	var/decl/material/R = reagent
-	C.setLabel(initial(R.name))
-	log_and_message_admins("spawned a [size] reagent container containing [reagent]")
+		if("small") cartridge_type = /obj/item/chems/chem_disp_cartridge/small
+		if("medium") cartridge_type = /obj/item/chems/chem_disp_cartridge/medium
+		if("large") cartridge_type = /obj/item/chems/chem_disp_cartridge
+	var/obj/item/chems/chem_disp_cartridge/cartridge = new cartridge_type(usr.loc)
+	cartridge.add_to_reagents(reagent_type, cartridge.volume)
+	var/reagent_name = cartridge.reagents.get_primary_reagent_name()
+	cartridge.setLabel(reagent_name)
+	log_and_message_admins("spawned a [size] reagent container containing [reagent_name] ([reagent_type])")

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -32,9 +32,9 @@
 
 /obj/item/chems/borghypo/Initialize()
 	. = ..()
-	for(var/decl/material/reagent as anything in reagent_ids)
-		reagent_volumes[reagent] = volume
-		reagent_names += initial(reagent.name)
+	for(var/decl/material/reagent in decls_repository.get_decls_unassociated(reagent_ids))
+		reagent_volumes[reagent.type] = volume
+		reagent_names += reagent.use_name // TODO: should we even bother precaching this? all of this code sucks anyway
 	START_PROCESSING(SSobj, src)
 
 /obj/item/chems/borghypo/Destroy()
@@ -101,16 +101,16 @@
 		if(index > 0 && index <= reagent_ids.len)
 			playsound(loc, 'sound/effects/pop.ogg', 50, 0)
 			mode = index
-			var/decl/material/reagent = reagent_ids[mode]
-			to_chat(user, "<span class='notice'>Synthesizer is now producing '[initial(reagent.name)]'.</span>")
+			var/decl/material/reagent = GET_DECL(reagent_ids[mode])
+			to_chat(user, SPAN_NOTICE("Synthesizer is now producing '[reagent.use_name]'."))
 		return TOPIC_REFRESH
 
 /obj/item/chems/borghypo/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
 	if(distance > 2)
 		return
-	var/decl/material/reagent = reagent_ids[mode]
-	. += SPAN_NOTICE("It is currently producing [initial(reagent.name)] and has [reagent_volumes[reagent_ids[mode]]] out of [volume] units left.")
+	var/decl/material/reagent = GET_DECL(reagent_ids[mode])
+	. += SPAN_NOTICE("It is currently producing [reagent.use_name] and has [reagent_volumes[reagent_ids[mode]]] out of [volume] units left.")
 
 /obj/item/chems/borghypo/service
 	name = "cyborg drink synthesizer"

--- a/code/modules/reagents/reagent_containers/food/lunch.dm
+++ b/code/modules/reagents/reagent_containers/food/lunch.dm
@@ -103,8 +103,8 @@ var/global/list/lunchables_ethanol_reagents_ = list(
 /proc/init_lunchable_list(var/list/lunches)
 	. = list()
 	for(var/lunch in lunches)
-		var/obj/O = lunch
-		.[initial(O.name)] = lunch
+		var/object_name = atom_info_repository.get_name_for(lunch)
+		.[object_name] = lunch
 	return sortTim(., /proc/cmp_text_asc)
 
 /proc/init_lunchable_reagent_list(var/list/banned_reagents, var/reagent_type)
@@ -112,6 +112,6 @@ var/global/list/lunchables_ethanol_reagents_ = list(
 	for(var/reagent_subtype in decls_repository.get_decls_of_type(reagent_type))
 		if(reagent_subtype in banned_reagents)
 			continue
-		var/decl/material/reagent = reagent_subtype
-		.[initial(reagent.name)] = reagent_subtype
+		var/decl/material/reagent = GET_DECL(reagent_subtype)
+		.[reagent.liquid_name] = reagent_subtype
 	return sortTim(., /proc/cmp_text_asc)

--- a/code/modules/scanners/health.dm
+++ b/code/modules/scanners/health.dm
@@ -244,11 +244,11 @@
 	if(H.reagents.total_volume)
 		var/unknown = 0
 		var/reagentdata[0]
-		for(var/A in H.reagents.reagent_volumes)
-			var/decl/material/R = GET_DECL(A)
-			if(R.scannable)
+		for(var/rtype in H.reagents.reagent_volumes)
+			var/decl/material/injected_reagent = GET_DECL(rtype)
+			if(injected_reagent.scannable)
 				print_reagent_default_message = FALSE
-				reagentdata[A] = "<span class='scan_notice'>[round(REAGENT_VOLUME(H.reagents, A), 1)]u [R.use_name]</span>"
+				reagentdata[rtype] = "<span class='scan_notice'>[round(REAGENT_VOLUME(H.reagents, rtype), 1)]u [injected_reagent.use_name]</span>"
 			else
 				unknown++
 		if(reagentdata.len)
@@ -264,11 +264,11 @@
 	if(touching_reagents && touching_reagents.total_volume)
 		var/unknown = 0
 		var/reagentdata[0]
-		for(var/A in touching_reagents.reagent_volumes)
-			var/decl/material/R = GET_DECL(A)
-			if(R.scannable)
+		for(var/rtype in touching_reagents.reagent_volumes)
+			var/decl/material/touched_reagent = GET_DECL(rtype)
+			if(touched_reagent.scannable)
 				print_reagent_default_message = FALSE
-				reagentdata[R.type] = "<span class='scan_notice'>[round(REAGENT_VOLUME(H.reagents, R.type), 1)]u [R.name]</span>"
+				reagentdata[rtype] = "<span class='scan_notice'>[round(REAGENT_VOLUME(H.reagents, rtype), 1)]u [touched_reagent.use_name]</span>"
 			else
 				unknown++
 		if(reagentdata.len)
@@ -284,10 +284,10 @@
 	if(ingested && ingested.total_volume)
 		var/unknown = 0
 		for(var/rtype in ingested.reagent_volumes)
-			var/decl/material/R = GET_DECL(rtype)
-			if(R.scannable)
+			var/decl/material/ingested_reagent = GET_DECL(rtype)
+			if(ingested_reagent.scannable)
 				print_reagent_default_message = FALSE
-				. += "<span class='scan_notice'>[capitalize(R.use_name)] found in subject's stomach.</span>"
+				. += "<span class='scan_notice'>[capitalize(ingested_reagent.use_name)] found in subject's stomach.</span>"
 			else
 				++unknown
 		if(unknown)
@@ -298,10 +298,10 @@
 	if(inhaled && inhaled.total_volume)
 		var/unknown = 0
 		for(var/rtype in inhaled.reagent_volumes)
-			var/decl/material/R = GET_DECL(rtype)
-			if(R.scannable)
+			var/decl/material/inhaled_reagent = GET_DECL(rtype)
+			if(inhaled_reagent.scannable)
 				print_reagent_default_message = FALSE
-				. += "<span class='scan_notice'>[capitalize(R.use_name)] found in subject's lungs.</span>"
+				. += "<span class='scan_notice'>[capitalize(inhaled_reagent.use_name)] found in subject's lungs.</span>"
 			else
 				++unknown
 		if(unknown)
@@ -310,10 +310,10 @@
 
 	if(length(H.chem_doses))
 		var/list/chemtraces = list()
-		for(var/T in H.chem_doses)
-			var/decl/material/R = T
-			if(initial(R.scannable))
-				chemtraces += "[initial(R.name)] ([LAZYACCESS(H.chem_doses, T)])"
+		for(var/dose_type in H.chem_doses)
+			var/decl/material/dose_material = GET_DECL(dose_type)
+			if(dose_material.scannable)
+				chemtraces += "[dose_material.use_name] ([LAZYACCESS(H.chem_doses, dose_type)])"
 		if(chemtraces.len)
 			. += "<span class='scan_notice'>Metabolism products of [english_list(chemtraces)] found in subject's system.</span>"
 

--- a/code/modules/scanners/mass_spectrometer.dm
+++ b/code/modules/scanners/mass_spectrometer.dm
@@ -47,8 +47,8 @@
 		..()
 
 /proc/mass_spectrometer_scan(var/datum/reagents/reagents, mob/user, var/details)
-	if(!reagents || !reagents.total_volume)
-		return "<span class='warning'>No sample to scan.</span>"
+	if(!reagents?.total_volume)
+		return SPAN_WARNING("No sample to scan.")
 	var/list/blood_traces = list()
 	var/list/blood_doses = list()
 
@@ -57,27 +57,27 @@
 		if(istype(random))
 			return random.get_scan_data(user)
 
-	for(var/R in reagents.reagent_volumes)
-		if(!ispath(R, /decl/material/liquid/blood))
-			return "<span class='warning'>The sample was contaminated! Please insert another sample</span>"
-		var/data = REAGENT_DATA(reagents, R)
+	for(var/reagent_type in reagents.reagent_volumes)
+		if(!ispath(reagent_type, /decl/material/liquid/blood))
+			return SPAN_WARNING("The sample was contaminated! Please insert another sample.")
+		var/data = REAGENT_DATA(reagents, reagent_type)
 		if(islist(data))
 			blood_traces = data[DATA_BLOOD_TRACE_CHEM]
 			blood_doses = data[DATA_BLOOD_DOSE_CHEM]
 		break
 
 	var/list/dat = list("Trace Chemicals Found: ")
-	for(var/T in blood_traces)
-		var/decl/material/R = T
+	for(var/trace_type in blood_traces)
+		var/decl/material/trace_material = GET_DECL(trace_type)
 		if(details)
-			dat += "[initial(R.name)] ([blood_traces[T]] units) "
+			dat += "[trace_material.use_name] ([blood_traces[trace_type]] units) "
 		else
-			dat += "[initial(R.name)] "
+			dat += "[trace_material.use_name] "
 	if(details)
 		dat += "Metabolism Products of Chemicals Found:"
-		for(var/T in blood_doses)
-			var/decl/material/R = T
-			dat += "[initial(R.name)] ([blood_doses[T]] units) "
+		for(var/dose_type in blood_doses)
+			var/decl/material/dose_material = GET_DECL(dose_type)
+			dat += "[dose_material.use_name] ([blood_doses[dose_type]] units) "
 
 	return jointext(dat, "<br>")
 

--- a/code/unit_tests/unit_test.dm
+++ b/code/unit_tests/unit_test.dm
@@ -211,8 +211,8 @@ var/global/ascii_reset = "[ascii_esc]\[0m"
 	if(!check_rights(R_DEBUG))
 		return
 
-	log_and_message_admins("has started the unit test '[initial(unit_test_type.name)]'")
 	var/datum/unit_test/test = new unit_test_type
+	log_and_message_admins("has started the unit test '[test.name]'")
 	var/end_unit_tests = world.time + MAX_UNIT_TEST_RUN_TIME
 	do_unit_test(test, end_unit_tests, FALSE)
 	if(test.async)


### PR DESCRIPTION
## Description of changes
Replaces a bunch of `initial(foo.name)` uses with `atom_info_repository.get_name_for(foo)`.
Replaces a bunch of `initial(reagent.name)` uses with `reagent.use_name`.
Makes category datums use abstract types rather than checking if name is non-null.
Removes the (now-)unused `SSmaterials.all_materials` var, since it's entirely redundant now.

## Why and what will this PR improve
Generally, I think `initial()` should be avoided where unnecessary, and these weren't necessary.