### PR TITLE
Fix humans and unathi having the wrong brightness

### DIFF
--- a/code/modules/species/station/human_bodytypes.dm
+++ b/code/modules/species/station/human_bodytypes.dm
@@ -6,7 +6,6 @@
 	icon_deformed         = 'icons/mob/human_races/species/human/deformed_body_female.dmi'
 	blood_overlays        = 'icons/mob/human_races/species/human/blood_overlays.dmi'
 	bandages_icon         = 'icons/mob/bandage.dmi'
-	limb_icon_intensity   = 0.7
 	associated_gender     = FEMALE
 	onmob_state_modifiers = list((slot_w_uniform_str) = "f")
 	appearance_flags      = HAS_SKIN_TONE_NORMAL | HAS_UNDERWEAR | HAS_EYE_COLOR

--- a/mods/species/unathi/datum/species_bodytypes.dm
+++ b/mods/species/unathi/datum/species_bodytypes.dm
@@ -7,7 +7,6 @@
 	cosmetics_icon          = 'mods/species/unathi/icons/cosmetics.dmi'
 	blood_overlays          = 'icons/mob/human_races/species/human/blood_overlays.dmi'
 	bandages_icon           = 'icons/mob/bandage.dmi'
-	limb_icon_intensity     = 0.7
 	health_hud_intensity    = 2
 	associated_gender       = FEMALE
 	onmob_state_modifiers   = list((slot_w_uniform_str) = "f")


### PR DESCRIPTION
## Description of changes
This var was only ever applied for shapeshifter bodytypes for some reason. It was generalized and the default value for `/decl/bodytype` was removed, but humans and unathi still had a value of `0.7`.

## Why and what will this PR improve
Fixes #4874.

## Changelog
:cl:
tweak: Human and unathi sprites should be slightly brighter now.
/:cl: