### PR TITLE
Fix shields becoming frames when damaged

### DIFF
--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -7,8 +7,28 @@
 	opacity = FALSE
 	anchored = TRUE
 	max_health = 200
+	frame_type = null
+	construct_state = /decl/machine_construction/noninteractive
 	var/shield_generate_power = 7500	//how much power we use when regenerating
 	var/shield_idle_power = 1500		//how much power we use when just being sustained.
+
+/obj/machinery/shield/take_damage(amount, damtype, silent)
+	if(amount <= 0)
+		return
+	if(damtype != BRUTE && damtype != BURN && damtype != ELECTROCUTE)
+		return
+	if(!silent)
+		playsound(src.loc, 'sound/effects/EMPulse.ogg', 75, TRUE)
+	current_health -= amount
+	set_opacity(TRUE)
+	check_failure()
+	if(!QDELETED(src))
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, set_opacity), FALSE), 2 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
+
+// This should never be damaged via anything but the shield's health dropping.
+/obj/machinery/shield/dismantle()
+	check_failure()
+	return QDELING(src) // return true if deleted, false otherwise
 
 /obj/machinery/shield/malfai
 	name = "emergency forcefield"
@@ -21,7 +41,7 @@
 
 /obj/machinery/shield/proc/check_failure()
 	if (current_health <= 0)
-		visible_message("<span class='notice'>\The [src] dissipates!</span>")
+		visible_message(SPAN_NOTICE("\The [src] dissipates!"))
 		qdel(src)
 		return
 
@@ -31,39 +51,15 @@
 	update_nearby_tiles(need_rebuild=1)
 
 /obj/machinery/shield/Destroy()
-	set_opacity(0)
-	set_density(0)
+	set_opacity(FALSE)
+	set_density(FALSE)
 	update_nearby_tiles()
 	. = ..()
 
 /obj/machinery/shield/CanPass(atom/movable/mover, turf/target, height, air_group)
+	// blocks air, normal behavior for everything else
 	if(!height || air_group) return 0
 	else return ..()
-
-/obj/machinery/shield/attackby(obj/item/W, mob/user)
-	if(!istype(W)) return
-
-	//Calculate damage
-	var/aforce = W.force
-	if(W.damtype == BRUTE || W.damtype == BURN)
-		current_health -= aforce
-
-	//Play a fitting sound
-	playsound(src.loc, 'sound/effects/EMPulse.ogg', 75, 1)
-
-	check_failure()
-	set_opacity(1)
-	spawn(20) if(!QDELETED(src)) set_opacity(0)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-
-	..()
-
-/obj/machinery/shield/bullet_act(var/obj/item/projectile/Proj)
-	current_health -= Proj.get_structure_damage()
-	..()
-	check_failure()
-	set_opacity(1)
-	spawn(20) if(!QDELETED(src)) set_opacity(0)
 
 /obj/machinery/shield/explosion_act(severity)
 	. = ..()
@@ -78,28 +74,21 @@
 			if(prob(50))
 				qdel(src)
 
-/obj/machinery/shield/hitby(AM, var/datum/thrownthing/TT)
+/obj/machinery/shield/hitby(atom/movable/hitter, var/datum/thrownthing/thrownthing)
 	. = ..()
 	if(.)
 		//Let everyone know we've been hit!
-		visible_message(SPAN_DANGER("\The [src] was hit by \the [AM]."))
+		visible_message(SPAN_DANGER("\The [src] was hit by \the [hitter]."))
 		//Super realistic, resource-intensive, real-time damage calculations.
 		var/tforce = 0
-		if(ismob(AM)) // All mobs have a multiplier and a size according to mob_defines.dm
-			var/mob/I = AM
-			tforce = I.mob_size * (TT.speed/THROWFORCE_SPEED_DIVISOR)
+		if(ismob(hitter)) // All mobs have a multiplier and a size according to mob_defines.dm
+			var/mob/mob_hitter = hitter
+			tforce = mob_hitter.mob_size * (thrownthing.speed/THROWFORCE_SPEED_DIVISOR)
 		else
-			var/obj/O = AM
-			tforce = O.throwforce * (TT.speed/THROWFORCE_SPEED_DIVISOR)
-		current_health -= tforce
-		//This seemed to be the best sound for hitting a force field.
-		playsound(src.loc, 'sound/effects/EMPulse.ogg', 100, 1)
-		check_failure()
-		//The shield becomes dense to absorb the blow. Purely asthetic.
-		set_opacity(1)
-		spawn(20)
-			if(!QDELETED(src))
-				set_opacity(0)
+			var/obj/obj_hitter = hitter
+			tforce = obj_hitter.throwforce * (thrownthing.speed/THROWFORCE_SPEED_DIVISOR)
+		if(tforce > 0)
+			take_damage(tforce, BRUTE)
 
 /obj/machinery/shieldgen
 	name = "Emergency shield projector"
@@ -196,12 +185,12 @@
 		else
 			check_delay--
 
+// todo: roll this into normal machinery damage stuff? maybe it only blows up if active when it's destroyed?
 /obj/machinery/shieldgen/proc/checkhp()
 	if(current_health <= 30)
 		src.malfunction = 1
 	if(current_health <= 0)
-		spawn(0)
-			explosion(get_turf(src.loc), 0, 0, 1, 0, 0, 0)
+		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(explosion), get_turf(src), 0, 0, 1, 0, 0, 0), 0)
 		qdel(src)
 	update_icon()
 	return

--- a/code/modules/shieldgen/shieldwallgen.dm
+++ b/code/modules/shieldgen/shieldwallgen.dm
@@ -265,86 +265,78 @@
 	anchored = TRUE
 	density = TRUE
 	light_range = 3
-	var/needs_power = 0
+	frame_type = null
+	construct_state = /decl/machine_construction/noninteractive
+	var/needs_power = FALSE
 	var/obj/machinery/shieldwallgen/gen_primary
 	var/obj/machinery/shieldwallgen/gen_secondary
 	var/power_usage = 800	//how much power it takes to sustain the shield
 	var/generate_power_usage = 5000	//how much power it takes to start up the shield
+
+/obj/machinery/shieldwall/proc/use_generator_power(amount)
+	if(!needs_power)
+		return
+	var/obj/machinery/shieldwallgen/G = pick(gen_primary, gen_secondary) // if we use power and still exist, we assume we have both generators
+	G.storedpower -= amount
+
+/obj/machinery/shieldwall/take_damage(amount, damtype, silent)
+	if(amount <= 0)
+		return
+	if(damtype != BRUTE && damtype != BURN && damtype != ELECTROCUTE)
+		return
+	. = ..() // mostly just plays sound effects on damage
+	use_generator_power(500 * amount)
+
+// This should never be deleted via anything but the generator running out of power.
+/obj/machinery/shieldwall/dismantle()
+	return FALSE // nope!
 
 /obj/machinery/shieldwall/Initialize(mapload, obj/machinery/shieldwallgen/A, obj/machinery/shieldwallgen/B)
 	. = ..(mapload)
 	update_nearby_tiles()
 	gen_primary = A
 	gen_secondary = B
-	if(A && B && A.active && B.active)
-		needs_power = 1
-		if(prob(50))
-			A.storedpower -= generate_power_usage
-		else
-			B.storedpower -= generate_power_usage
+	if(gen_primary?.active && gen_secondary?.active)
+		needs_power = TRUE
+		use_generator_power(generate_power_usage)
 	else
 		return INITIALIZE_HINT_QDEL
 
 /obj/machinery/shieldwall/Destroy()
+	gen_primary = null
+	gen_secondary = null
 	update_nearby_tiles()
 	. = ..()
 
-/obj/machinery/shieldwall/attackby(var/obj/item/I, var/mob/user)
-	var/obj/machinery/shieldwallgen/G = prob(50) ? gen_primary : gen_secondary
-	G.storedpower -= I.force*2500
-	user.visible_message("<span class='danger'>\The [user] hits \the [src] with \the [I]!</span>")
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	user.do_attack_animation(src)
-	playsound(loc, 'sound/weapons/smash.ogg', 75, 1)
-
 /obj/machinery/shieldwall/Process()
-	if(needs_power)
-		if(isnull(gen_primary)||isnull(gen_secondary))
-			qdel(src)
-			return
-
-		if(!(gen_primary.active)||!(gen_secondary.active))
-			qdel(src)
-			return
-
-		var/obj/machinery/shieldwallgen/G = prob(50) ? gen_primary : gen_secondary
-		G.storedpower -= power_usage
-
-
-/obj/machinery/shieldwall/bullet_act(var/obj/item/projectile/Proj)
-	if(needs_power)
-		var/obj/machinery/shieldwallgen/G = prob(50) ? gen_primary : gen_secondary
-		G.storedpower -= 400 * Proj.get_structure_damage()
-	..()
-	return
+	if(!needs_power)
+		return
+	if(QDELETED(gen_primary) || QDELETED(gen_secondary))
+		qdel(src)
+		return
+	if(!gen_primary.active || !gen_secondary.active)
+		qdel(src)
+		return
+	use_generator_power(power_usage)
 
 /obj/machinery/shieldwall/explosion_act(severity)
 	SHOULD_CALL_PARENT(FALSE)
 	if(!needs_power)
 		return
-	var/obj/machinery/shieldwallgen/G = prob(50) ? gen_primary : gen_secondary
-	switch(severity)
-		if(1)
-			G.storedpower -= rand(30000, min(G.storedpower, 60000))
-		if(2)
-			G.storedpower -= rand(15000, min(G.storedpower, 30000))
-		if(3)
-			G.storedpower -= rand(5000, min(G.storedpower, 15000))
+	take_damage(100/severity, BRUTE, TRUE) // will drain power according to damage
 
 /obj/machinery/shieldwall/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group || (height==0)) return 1
-
+	if(!height || air_group || !density)
+		return TRUE
 	if(istype(mover) && mover.checkpass(PASS_FLAG_GLASS))
 		return prob(20)
-	else
-		if (istype(mover, /obj/item/projectile))
-			return prob(10)
-		else
-			return !src.density
+	if (istype(mover, /obj/item/projectile))
+		return prob(10)
+	return FALSE
 
 /obj/machinery/shieldwallgen/online
 	anchored = TRUE
-	active = 1
+	active = TRUE
 
 /obj/machinery/shieldwallgen/online/Initialize()
 	storedpower = max_stored_power


### PR DESCRIPTION
## Description of changes
Overrides dismantle(), frame_type, and construct_state for both types of shields made by shield generators.
Cleans up related shield code overall, which will make it substantially easier to make them not machines at some point.

## Why and what will this PR improve
Fixes #4865.