### PR TITLE
Add NOSCREEN and NOINPUT immunity to various machines

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -10,7 +10,6 @@
 	active_power_usage = 5
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
-	stat_immune = 0
 
 	var/suppressing = FALSE
 	var/mob/living/victim

--- a/code/game/machinery/bodyscanner.dm
+++ b/code/game/machinery/bodyscanner.dm
@@ -2,7 +2,7 @@
 /obj/machinery/bodyscanner
 	var/mob/living/carbon/human/occupant
 	var/locked
-	name = "Body Scanner"
+	name = "body scanner"
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "body_scanner_0"
 	density = TRUE
@@ -11,7 +11,6 @@
 	active_power_usage = 10000	//10 kW. It's a big all-body scanner.
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
-	stat_immune = 0
 	var/open_sound = 'sound/machines/podopen.ogg'
 	var/close_sound = 'sound/machines/podclose.ogg'
 

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -9,7 +9,7 @@
 	initial_access = list(list(access_kitchen, access_morgue))
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
-	stat_immune = 0
+	stat_immune = NOSCREEN
 
 	var/operating = 0        //Is it on?
 	var/dirty = 0            // Does it need cleaning?

--- a/code/game/machinery/mech_recharger.dm
+++ b/code/game/machinery/mech_recharger.dm
@@ -11,7 +11,6 @@
 	base_type = /obj/machinery/mech_recharger
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
-	stat_immune = 0
 
 	var/mob/living/exosuit/charging
 	var/base_charge_rate = 60 KILOWATTS

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -15,7 +15,6 @@
 	var/icon_state_idle = "recharger0" //also when unpowered
 	var/portable = 1
 
-	stat_immune = 0
 	uncreated_component_parts = null
 	construct_state = /decl/machine_construction/default/panel_closed
 

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -8,7 +8,6 @@
 	idle_power_usage = 50
 	base_type = /obj/machinery/recharge_station
 	uncreated_component_parts = null
-	stat_immune = 0
 	construct_state = /decl/machine_construction/default/panel_closed
 
 	var/overlay_icon = 'icons/obj/objects.dmi'

--- a/code/game/machinery/seed_extractor.dm
+++ b/code/game/machinery/seed_extractor.dm
@@ -10,7 +10,6 @@
 	active_power_usage = 2000
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
-	stat_immune = 0
 
 /obj/machinery/seed_extractor/attackby(var/obj/item/O, var/mob/user)
 	if((. = component_attackby(O, user)))

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -16,7 +16,6 @@
 	anchored = TRUE
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
-	stat_immune = NOSCREEN
 	var/state = 0
 	var/gibs_ready = FALSE
 	obj_flags = OBJ_FLAG_ANCHORABLE

--- a/code/game/objects/items/weapons/circuitboards/machinery/medical.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/medical.dm
@@ -18,8 +18,7 @@
 	origin_tech = @'{"engineering":2,"biotech":4,"programming":4}'
 	req_components = list(
 		/obj/item/stock_parts/scanning_module = 2,
-		/obj/item/stock_parts/manipulator = 2,
-		/obj/item/stock_parts/console_screen = 1)
+		/obj/item/stock_parts/manipulator = 2)
 	additional_spawn_components = list(
 		/obj/item/stock_parts/power/apc/buildable = 1
 	)

--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -172,7 +172,6 @@
 	density = TRUE
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
-	stat_immune = 0
 
 	var/processing = 0
 	var/honey = 0

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -6,7 +6,6 @@
 	layer = ABOVE_HUMAN_LAYER //So it draws over mobs in the tile north of it.
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
-	stat_immune = 0
 
 /obj/machinery/mining/drill
 	name = "mining drill head"
@@ -183,7 +182,7 @@
 	. = (length(supports) <= 0)
 
 /obj/machinery/mining/drill/proc/system_error(var/error)
-
+	// TODO: suppress the message if no screen is installed?
 	if(error)
 		src.visible_message("<span class='notice'>\The [src] flashes a '[error]' warning.</span>")
 	need_player_check = 1
@@ -232,6 +231,7 @@
 	icon_state = "mining_brace"
 	obj_flags = OBJ_FLAG_ROTATABLE
 	interact_offline = 1
+	stat_immune = NOSCREEN | NOINPUT
 
 	var/obj/machinery/mining/drill/connected
 

--- a/code/modules/power/fusion/core/_core.dm
+++ b/code/modules/power/fusion/core/_core.dm
@@ -14,7 +14,7 @@
 	anchored = FALSE
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
-	stat_immune = 0
+	stat_immune = NOINPUT
 	base_type = /obj/machinery/fusion_core
 	stock_part_presets = list(/decl/stock_part_preset/terminal_setup)
 
@@ -42,16 +42,6 @@
 			update_use_power(POWER_USE_IDLE)
 		else
 			owned_field.handle_tick()
-
-/obj/machinery/fusion_core/Topic(href, href_list)
-	if(..())
-		return 1
-	if(href_list["str"])
-		var/dif = text2num(href_list["str"])
-		field_strength = min(max(field_strength + dif, MIN_FIELD_STR), MAX_FIELD_STR)
-		change_power_consumption(500 * field_strength, POWER_USE_ACTIVE)
-		if(owned_field)
-			owned_field.ChangeFieldStrength(field_strength)
 
 /obj/machinery/fusion_core/update_use_power(new_use_power)
 	. = ..()
@@ -101,7 +91,7 @@
 /obj/machinery/fusion_core/attackby(var/obj/item/W, var/mob/user)
 
 	if(owned_field)
-		to_chat(user,"<span class='warning'>Shut \the [src] off first!</span>")
+		to_chat(user, SPAN_WARNING("Shut \the [src] off first!"))
 		return
 
 	if(IS_MULTITOOL(W))
@@ -113,12 +103,12 @@
 		anchored = !anchored
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
 		if(anchored)
-			user.visible_message("[user.name] secures [src.name] to the floor.", \
-				"You secure the [src.name] to the floor.", \
+			user.visible_message("\The [user] secures \the [src] to the floor.", \
+				"You secure \the [src] to the floor.", \
 				"You hear a ratchet.")
 		else
-			user.visible_message("[user.name] unsecures [src.name] from the floor.", \
-				"You unsecure the [src.name] from the floor.", \
+			user.visible_message("\The [user] unsecures \the [src] from the floor.", \
+				"You unsecure \the [src] from the floor.", \
 				"You hear a ratchet.")
 		return
 

--- a/code/modules/power/fusion/fuel_injector/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_injector/fuel_injector.dm
@@ -9,7 +9,6 @@
 	active_power_usage = 500
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
-	stat_immune = 0
 	base_type = /obj/machinery/fusion_fuel_injector
 
 	var/fuel_usage = 0.001

--- a/code/unit_tests/machine_tests.dm
+++ b/code/unit_tests/machine_tests.dm
@@ -86,3 +86,36 @@
 	else
 		pass("All machines had valid basetypes.")
 	return  1
+
+/datum/unit_test/machines_shall_have_sane_stat_immune
+	name = "MACHINE: All machines that do not require screens/keyboards must have NOSCREEN/NOINPUT stat immunity."
+
+/datum/unit_test/machines_shall_have_sane_stat_immune/start_test()
+	var/failed = list()
+	var/passed = list()
+	for(var/obj/machinery/machine as anything in SSmachines.machinery)
+		var/candidate_type = machine.base_type || machine.type
+		if(isnull(machine.construct_state))
+			continue
+		if(passed[candidate_type] || failed[candidate_type])
+			continue
+		var/obj/item/stock_parts/circuitboard/board = machine.get_component_of_type(/obj/item/stock_parts/circuitboard)
+		var/has_screen = machine.get_component_of_type(/obj/item/stock_parts/console_screen)
+		var/has_keyboard = machine.get_component_of_type(/obj/item/stock_parts/keyboard)
+		if(board)
+			has_screen ||= (/obj/item/stock_parts/console_screen in board.req_components) || (/obj/item/stock_parts/console_screen in board.additional_spawn_components)
+			has_keyboard ||= (/obj/item/stock_parts/keyboard in board.req_components) || (/obj/item/stock_parts/keyboard in board.additional_spawn_components)
+		if(!has_screen && !(machine.stat_immune & NOSCREEN))
+			failed[candidate_type] = TRUE
+			log_bad("[log_info_line(machine)] doesn't start with or require a screen, but did not have NOSCREEN in stat_immune.")
+		if(!has_keyboard && !(machine.stat_immune & NOINPUT))
+			failed[candidate_type] = TRUE
+			log_bad("[log_info_line(machine)] doesn't start with or require a keyboard, but did not have NOINPUT in stat_immune.")
+		if(!failed[candidate_type])
+			passed[candidate_type] = TRUE
+
+	if(length(failed))
+		fail("One or more machines had incorrect stat_immune settings.")
+	else
+		pass("All machines had correct stat_immune settings.")
+	return TRUE


### PR DESCRIPTION
## Description of changes
Adds a test to catch machines without immunity to NOSCREEN/NOINPUT that also don't require or spawn with screens/keyboards.
Also fixes various cases of that.

## Why and what will this PR improve
Fixes #4873.