### PR TITLE
Fix ammo magazine lazyloaded matter values

### DIFF
--- a/code/datums/repositories/atom_info.dm
+++ b/code/datums/repositories/atom_info.dm
@@ -10,9 +10,9 @@ var/global/repository/atom_info/atom_info_repository = new()
 
 /repository/atom_info/proc/create_key_for(var/path, var/material, var/amount)
 	. = "[path]"
-	if(material)
+	if(ispath(path, /obj) && material) // only objects take material as an arg
 		. = "[.]-[material]"
-	if(!isnull(amount))
+	if(ispath(path, /obj/item/stack) && !isnull(amount)) // similarly for stacks and amount
 		. = "[.]-[amount]"
 
 /repository/atom_info/proc/get_instance_of(var/path, var/material, var/amount)

--- a/code/datums/supplypacks/galley.dm
+++ b/code/datums/supplypacks/galley.dm
@@ -143,7 +143,7 @@
 /decl/hierarchy/supply_pack/galley/beer_dispenser
 	name = "Equipment - Booze dispenser"
 	contains = list(
-			/obj/machinery/chemical_dispenser/bar_alc{anchored = FALSE}
+			/obj/machinery/chemical_dispenser/bar_alc/unanchored
 		)
 	containertype = /obj/structure/largecrate
 	containername = "booze dispenser crate"
@@ -151,7 +151,7 @@
 /decl/hierarchy/supply_pack/galley/soda_dispenser
 	name = "Equipment - Soda dispenser"
 	contains = list(
-			/obj/machinery/chemical_dispenser/bar_soft{anchored = FALSE}
+			/obj/machinery/chemical_dispenser/bar_soft/unanchored
 		)
 	containertype = /obj/structure/largecrate
 	containername = "soda dispenser crate"

--- a/code/datums/supplypacks/science.dm
+++ b/code/datums/supplypacks/science.dm
@@ -4,7 +4,7 @@
 /decl/hierarchy/supply_pack/science/chemistry_dispenser
 	name = "Equipment - Chemical Reagent dispenser"
 	contains = list(
-			/obj/machinery/chemical_dispenser{anchored = FALSE}
+			/obj/machinery/chemical_dispenser/unanchored
 		)
 	containertype = /obj/structure/largecrate
 	containername = "reagent dispenser crate"

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -177,6 +177,16 @@
 		stored_ammo += new ammo_type(src)
 	contents_initialized = TRUE
 
+/obj/item/ammo_magazine/get_contained_matter()
+	. = ..()
+	if(!lazyload_contents || contents_initialized || !ammo_type || !initial_ammo)
+		return
+	// Add our expected matter from lazyloaded stuff.
+	var/list/ammo_matter = atom_info_repository.get_matter_for(ammo_type).Copy()
+	for(var/matter_entry in ammo_matter)
+		ammo_matter[matter_entry] *= initial_ammo
+	. = MERGE_ASSOCS_WITH_NUM_VALUES(., ammo_matter)
+
 /obj/item/ammo_magazine/proc/get_stored_ammo_count()
 	. = length(stored_ammo)
 	if(!contents_initialized)

--- a/code/modules/reagents/dispenser/dispenser_presets.dm
+++ b/code/modules/reagents/dispenser/dispenser_presets.dm
@@ -1,3 +1,6 @@
+/obj/machinery/chemical_dispenser/unanchored
+	anchored = FALSE
+
 /obj/machinery/chemical_dispenser/full
 	spawn_cartridges = list(
 			/obj/item/chems/chem_disp_cartridge/hydrazine,
@@ -60,6 +63,9 @@
 	beaker_offset = -2
 	beaker_positions = list(-1,3,7,11,15)
 
+/obj/machinery/chemical_dispenser/bar_soft/unanchored
+	anchored = FALSE
+
 /obj/machinery/chemical_dispenser/bar_soft/full
 	spawn_cartridges = list(
 			/obj/item/chems/chem_disp_cartridge/water,
@@ -98,6 +104,8 @@
 	beaker_offset = -2
 	beaker_positions = list(-3,2,7,12,17)
 
+/obj/machinery/chemical_dispenser/bar_alc/unanchored
+	anchored = FALSE
 
 /obj/machinery/chemical_dispenser/bar_alc/full
 	spawn_cartridges = list(


### PR DESCRIPTION
## Description of changes
Fixes magazines not including lazyloaded ammo in their matter.
Improves the atom info repository by stripping unnecessary info out of the key.
Removes the two modified types still in code, which caused the atom info repository to freak out because their string representation is just `""`.

## Why and what will this PR improve
Fixes a bug that wasn't put on the tracker.