### PR TITLE
Fix alien whitelist not filtering displayed species

### DIFF
--- a/code/modules/client/preference_setup/background/01_species.dm
+++ b/code/modules/client/preference_setup/background/01_species.dm
@@ -89,6 +89,14 @@
 
 		var/choice = href_list["set_species"]
 		if(choice != pref.species)
+			if(!check_rights(R_ADMIN, 0) && get_config_value(/decl/config/toggle/use_alien_whitelist))
+				var/decl/species/new_species = get_species_by_key(choice)
+				if(!new_species)
+					return TOPIC_REFRESH
+				if(!(new_species.spawn_flags & SPECIES_CAN_JOIN))
+					return TOPIC_REFRESH
+				else if((new_species.spawn_flags & SPECIES_IS_WHITELISTED) && !is_alien_whitelisted(preference_mob(), new_species))
+					return TOPIC_REFRESH
 
 			pref.species = choice
 			pref.sanitize_preferences()

--- a/code/modules/client/preference_setup/background/01_species.dm
+++ b/code/modules/client/preference_setup/background/01_species.dm
@@ -47,7 +47,7 @@
 	. += "<table width = '100%'>"
 	. += "<tr><td colspan=3><center><h3>Species</h3></center></td></tr>"
 	. += "<tr><td colspan=3><center>"
-	for(var/s in get_playable_species())
+	for(var/s in playables)
 		var/decl/species/list_species = get_species_by_key(s)
 		if(pref.species == list_species.name)
 			. += "<span class='linkOn'>[list_species.name]</span> "


### PR DESCRIPTION
## Description of changes
Fix the `playables` list being generated but not used.
Fixes being able to select species you can't see via href hacking.
Untested please remind me to test it before you hit approve I'm making this in a rush

## Why and what will this PR improve
Fixes issues with the alien whitelist config option

## Changelog
:cl:
bugfix: Players can no longer view or select species in character creation that they are not whitelisted for, if species whitelists are enabled.
/:cl: