### PR TITLE
Fix arguments to change_appearance

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -50,6 +50,7 @@
 	var/decl/language/required_language
 
 	// Used for setting appearance.
+	/// Species that are valid when changing appearance while spawning as this role. Null allows all species.
 	var/list/valid_species
 	var/min_player_age = 14
 

--- a/code/game/antagonist/antagonist_update.dm
+++ b/code/game/antagonist/antagonist_update.dm
@@ -3,10 +3,6 @@
 		leader = current_antagonists[1]
 
 /decl/special_role/proc/update_antag_mob(var/datum/mind/player, var/preserve_appearance)
-
-	if(!valid_species)
-		valid_species = list(global.using_map.default_species)
-
 	// Get the mob.
 	if((flags & ANTAG_OVERRIDE_MOB) && (!player.current || (mob_path && !istype(player.current, mob_path))))
 		var/mob/holder = player.current
@@ -17,7 +13,7 @@
 	if(!preserve_appearance && (flags & ANTAG_SET_APPEARANCE))
 		spawn(3)
 			var/mob/living/carbon/human/H = player.current
-			if(istype(H)) H.change_appearance(APPEARANCE_ALL, H.loc, H, valid_species, state = global.z_topic_state)
+			if(istype(H)) H.change_appearance(APPEARANCE_ALL, H.loc, H, species_whitelist = valid_species, state = global.z_topic_state)
 	return player.current
 
 /decl/special_role/proc/update_access(var/mob/living/player)

--- a/code/modules/acting/acting_items.dm
+++ b/code/modules/acting/acting_items.dm
@@ -33,7 +33,7 @@
 	if(!ishuman(user))
 		return ..()
 	var/mob/living/carbon/human/H = user
-	H.change_appearance(APPEARANCE_ALL, H.loc, H, H.generate_valid_species(), state = global.z_topic_state)
+	H.change_appearance(APPEARANCE_ALL, H.loc, H, state = global.z_topic_state)
 	var/getName = sanitize(input(H, "Would you like to change your name to something else?", "Name change") as null|text, MAX_NAME_LEN)
 	if(getName)
 		H.real_name = getName


### PR DESCRIPTION
## Description of changes
Fixes a 10 year old mistake where the args for these calls weren't updated when the proc itself was.
As a result, I made it so that special roles allow all species by default (the behavior it's had for the last 10 years) while still supporting restricting special roles to certain species if anyone ever uses it.

## Why and what will this PR improve
Fixes a 10 year old bug.